### PR TITLE
refactor(agent): align mobile and desktop AgentGUI flows

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -52,11 +52,17 @@ export function agentActivitySessionFromTuttidSession(
 
 export function agentActivitySessionDetailFromTuttid(
   workspaceId: string,
+  expectedAgentSessionId: string,
   detail: WorkspaceAgentSessionDetailResponse
 ): AgentActivitySessionDetailSnapshot {
-  return mapAgentActivitySessionDetailFromTuttid(workspaceId, detail, {
-    currentUserId: DESKTOP_AGENT_GUI_CURRENT_USER_ID
-  });
+  return mapAgentActivitySessionDetailFromTuttid(
+    workspaceId,
+    expectedAgentSessionId,
+    detail,
+    {
+      currentUserId: DESKTOP_AGENT_GUI_CURRENT_USER_ID
+    }
+  );
 }
 
 export function createDesktopAgentActivityAdapter({

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -6,8 +6,10 @@ import {
 } from "@tutti-os/agent-activity-core";
 import {
   agentActivityMessageFromTuttidMessage,
+  agentActivitySessionDetailFromTuttid as mapAgentActivitySessionDetailFromTuttid,
   agentActivitySessionFromTuttidSession as mapAgentActivitySessionFromTuttidSession,
-  agentActivityTuttiModeActivationFromTuttid
+  agentActivityTuttiModeActivationFromTuttid,
+  type AgentActivitySessionDetailSnapshot
 } from "@tutti-os/agent-activity-tuttid-adapter";
 export {
   agentActivityMessageFromTuttidMessage,
@@ -20,6 +22,7 @@ import type {
   CreateWorkspaceAgentSessionRequest,
   SendWorkspaceAgentSessionInputRequest,
   WorkspaceAgentSession,
+  WorkspaceAgentSessionDetailResponse,
   WorkspaceAgentProvider
 } from "@tutti-os/client-tuttid-ts";
 import type { DesktopRuntimeApi } from "@preload/types";
@@ -43,6 +46,15 @@ export function agentActivitySessionFromTuttidSession(
   session: WorkspaceAgentSession
 ): AgentActivitySession {
   return mapAgentActivitySessionFromTuttidSession(workspaceId, session, {
+    currentUserId: DESKTOP_AGENT_GUI_CURRENT_USER_ID
+  });
+}
+
+export function agentActivitySessionDetailFromTuttid(
+  workspaceId: string,
+  detail: WorkspaceAgentSessionDetailResponse
+): AgentActivitySessionDetailSnapshot {
+  return mapAgentActivitySessionDetailFromTuttid(workspaceId, detail, {
     currentUserId: DESKTOP_AGENT_GUI_CURRENT_USER_ID
   });
 }

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts
@@ -234,6 +234,7 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
       );
     const mapped = agentActivitySessionDetailFromTuttid(
       normalizedWorkspaceId,
+      agentSessionId,
       detail
     );
     this.reportReconcileTrace({

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts
@@ -5,10 +5,10 @@ import {
   type SessionDetailSnapshotReceivedIntent
 } from "@tutti-os/agent-activity-core";
 import {
+  analyzeAgentActivityEventObservation,
   agentActivitySessionMessageWindowFromDescendingPage,
   createAgentActivitySnapshotProjector,
   parseAgentActivityMessageDeltaEvent,
-  parseInlineActivityMessages,
   selectEngineSession
 } from "@tutti-os/agent-activity-core";
 import type { WorkspaceAgentActivityEnsureSessionSynchronizedInput } from "../workspaceAgentActivityService.interface.ts";
@@ -21,19 +21,13 @@ import {
   reconcileAfterVersion,
   stringifyError
 } from "./workspaceAgentActivityDiagnostics.ts";
-import {
-  agentActivitySessionFromTuttidSession,
-  agentActivityTurnFromTuttidTurn
-} from "../desktopAgentActivityAdapter.ts";
-import {
-  analyzeInlineMessageVersionContinuity,
-  reconcileAgentSessionMessagePages
-} from "./workspaceAgentActivityReconcileMessages.ts";
+import { agentActivitySessionDetailFromTuttid } from "../desktopAgentActivityAdapter.ts";
+import { reconcileAgentSessionMessagePages } from "./workspaceAgentActivityReconcileMessages.ts";
 import type {
-  AgentActivitySessionDetail,
   WorkspaceAgentActivityBridgeEvent,
   WorkspaceAgentActivityReconcileDependencies
 } from "./workspaceAgentActivityReconcileTypes.ts";
+import type { AgentActivitySessionDetailSnapshot } from "@tutti-os/agent-activity-tuttid-adapter";
 import { WorkspaceAgentComposerOptionsInvalidationCoordinator } from "./workspaceAgentComposerOptionsInvalidationCoordinator.ts";
 import { WorkspaceAgentActivityOptimisticProjection } from "./workspaceAgentActivityOptimisticProjection.ts";
 
@@ -226,7 +220,7 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
     workspaceId: string,
     agentSessionId: string,
     source: string
-  ): Promise<AgentActivitySessionDetail> {
+  ): Promise<AgentActivitySessionDetailSnapshot> {
     const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
     this.reportReconcileTrace({
       agentSessionId,
@@ -238,25 +232,24 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
         normalizedWorkspaceId,
         agentSessionId
       );
-    const activitySession = agentActivitySessionFromTuttidSession(
+    const mapped = agentActivitySessionDetailFromTuttid(
       normalizedWorkspaceId,
-      detail.session
+      detail
     );
-    const childSessions = detail.childSessions.map((session) =>
-      agentActivitySessionFromTuttidSession(normalizedWorkspaceId, session)
-    );
-    const turns = detail.turns.map(agentActivityTurnFromTuttidTurn);
     this.reportReconcileTrace({
       agentSessionId,
       traceEvent: `${source}.resolved`,
       workspaceId: normalizedWorkspaceId,
       fields: {
-        incomingSession:
-          agentActivitySessionReconcileDiagnosticDetails(activitySession),
-        childSessionIds: childSessions.map((session) => session.agentSessionId)
+        incomingSession: agentActivitySessionReconcileDiagnosticDetails(
+          mapped.session
+        ),
+        childSessionIds: mapped.childSessions.map(
+          (session) => session.agentSessionId
+        )
       }
     });
-    return { session: activitySession, childSessions, turns };
+    return mapped;
   }
 
   protected upsertAuthoritativeSession(
@@ -272,7 +265,7 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
   }
 
   protected upsertAuthoritativeSessionDetail(
-    detail: AgentActivitySessionDetail,
+    detail: AgentActivitySessionDetailSnapshot,
     source: string,
     options: Pick<
       SessionDetailSnapshotReceivedIntent,
@@ -600,15 +593,15 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
     }
     if (this.isSessionTombstoned(workspaceId, agentSessionId)) return;
     if (input.eventType === "session_reconcile_required") {
-      this.entry(workspaceId).engine.dispatch({
-        agentSessionId,
-        eventType: input.eventType,
-        hasCachedSession: this.hasCachedSession(workspaceId, agentSessionId),
-        hasInlineMessages: false,
-        inlineApplied: false,
-        type: "session/activityObserved",
-        workspaceId
+      const observation = analyzeAgentActivityEventObservation({
+        cachedMessages:
+          this.activitySnapshot(workspaceId).sessionMessagesById[
+            agentSessionId
+          ] ?? [],
+        event: input,
+        hasCachedSession: this.hasCachedSession(workspaceId, agentSessionId)
       });
+      this.entry(workspaceId).engine.dispatch(observation.intent);
       return;
     }
     if (input.eventType === "state_patch") {
@@ -656,35 +649,33 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
       return;
     }
     const hasCachedSession = this.hasCachedSession(workspaceId, agentSessionId);
-    const messages = parseInlineActivityMessages(input);
     const cachedMessages =
       this.activitySnapshot(workspaceId).sessionMessagesById[agentSessionId] ??
       [];
-    const inlineContinuity = analyzeInlineMessageVersionContinuity(
+    const observation = analyzeAgentActivityEventObservation({
       cachedMessages,
-      messages
-    );
-    const canApplyInlineMessages =
-      messages.length > 0 && inlineContinuity.continuous;
-    if (canApplyInlineMessages) {
+      event: input,
+      hasCachedSession
+    });
+    if (observation.canApplyInlineMessages) {
       this.entry(workspaceId).engine.dispatch(
         {
-          messages,
+          messages: observation.inlineMessages,
           type: "message/snapshotReceived",
           workspaceId
         },
         { batch: true }
       );
-      for (const message of messages) {
+      for (const message of observation.inlineMessages) {
         this.emitSessionEvent(workspaceId, hostMessageEventFromCore(message));
       }
       this.reconcileOptimisticMessages(workspaceId, agentSessionId);
-    } else if (messages.length > 0) {
+    } else if (observation.inlineMessages.length > 0) {
       this.reportReconcileTrace({
         agentSessionId,
         traceEvent: "realtime.message_version_gap_detected",
         workspaceId,
-        fields: { ...inlineContinuity }
+        fields: { ...observation.inlineContinuity }
       });
     }
     if (
@@ -693,16 +684,7 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
     ) {
       this.markNextReconcileLive(workspaceId, agentSessionId);
     }
-    const inlineApplied = hasCachedSession && canApplyInlineMessages;
-    this.entry(workspaceId).engine.dispatch({
-      agentSessionId,
-      eventType: input.eventType,
-      hasCachedSession,
-      hasInlineMessages: messages.length > 0,
-      inlineApplied,
-      type: "session/activityObserved",
-      workspaceId
-    });
+    this.entry(workspaceId).engine.dispatch(observation.intent);
     if (input.eventType === "turn_update") {
       this.emitSessionEvent(workspaceId, {
         data: input.data,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileMessages.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileMessages.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { AgentActivityMessage } from "@tutti-os/agent-activity-core";
-import { analyzeInlineMessageVersionContinuity } from "./workspaceAgentActivityReconcileMessages.ts";
+import {
+  analyzeInlineMessageVersionContinuity,
+  type AgentActivityMessage
+} from "@tutti-os/agent-activity-core";
 
 test("inline message continuity accepts snapshot cursor gaps already present in the cache", () => {
   const result = analyzeInlineMessageVersionContinuity(

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileMessages.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileMessages.ts
@@ -15,47 +15,6 @@ interface ReconcileAgentSessionMessagePagesInput {
   workspaceId: string;
 }
 
-export interface InlineMessageVersionContinuity {
-  cachedVersion: number;
-  continuous: boolean;
-  firstUnseenVersion: number | null;
-  latestIncomingVersion: number;
-}
-
-/**
- * Realtime messages may be folded directly only when they extend the cached
- * per-session change cursor without a hole. Advancing the cache past a missed
- * mutable snapshot would make every later `afterVersion` pull skip that
- * snapshot forever, because message rows retain only their latest version.
- */
-export function analyzeInlineMessageVersionContinuity(
-  cached: readonly AgentActivityMessage[],
-  incoming: readonly AgentActivityMessage[]
-): InlineMessageVersionContinuity {
-  const cachedVersion = latestMessageVersion(cached);
-  const incomingVersions = [
-    ...new Set(incoming.map((message) => message.version))
-  ].sort((left, right) => left - right);
-  const latestIncomingVersion = incomingVersions.at(-1) ?? 0;
-  const unseenVersions = incomingVersions.filter(
-    (version) => version > cachedVersion
-  );
-  const versionsAreValid = incomingVersions.every(
-    (version) => Number.isSafeInteger(version) && version > 0
-  );
-  const continuous =
-    versionsAreValid &&
-    unseenVersions.every(
-      (version, index) => version === cachedVersion + index + 1
-    );
-  return {
-    cachedVersion,
-    continuous,
-    firstUnseenVersion: unseenVersions[0] ?? null,
-    latestIncomingVersion
-  };
-}
-
 export async function reconcileAgentSessionMessagePages(
   input: ReconcileAgentSessionMessagePagesInput
 ): Promise<AgentActivityMessagePage> {
@@ -88,13 +47,4 @@ export async function reconcileAgentSessionMessagePages(
     ),
     messages: result.messages
   };
-}
-
-function latestMessageVersion(
-  messages: readonly AgentActivityMessage[]
-): number {
-  return messages.reduce(
-    (latest, message) => Math.max(latest, message.version),
-    0
-  );
 }

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileTypes.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileTypes.ts
@@ -1,8 +1,4 @@
-import type {
-  AgentActivitySession,
-  AgentActivityTurn,
-  AgentActivityUpdatedEvent
-} from "@tutti-os/agent-activity-core";
+import type { AgentActivityUpdatedEvent } from "@tutti-os/agent-activity-core";
 import type {
   TuttidClient,
   TuttidEventStreamClient
@@ -13,12 +9,6 @@ export interface WorkspaceAgentActivityReconcileDependencies {
   eventStreamClient?: TuttidEventStreamClient;
   runtimeApi: Pick<DesktopRuntimeApi, "logTerminalDiagnostic">;
   tuttidClient: TuttidClient;
-}
-
-export interface AgentActivitySessionDetail {
-  session: AgentActivitySession;
-  childSessions: AgentActivitySession[];
-  turns: AgentActivityTurn[];
 }
 
 export type WorkspaceAgentActivityBridgeEvent =

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -46,8 +46,8 @@ test("WorkspaceAgentActivityService applies authoritative Session detail in one 
     ...workspaceAgentSession({ status: "ready" }),
     id: "session-child",
     kind: "child",
-    parentSessionId: "session-1",
-    rootSessionId: "session-1"
+    parentAgentSessionId: "session-1",
+    rootAgentSessionId: "session-1"
   };
   const service = new WorkspaceAgentActivityService({
     tuttidClient: {
@@ -2798,13 +2798,25 @@ test("WorkspaceAgentActivityService does not tombstone a missing reconcile witho
     service as unknown as {
       reconcileAgentActivityUpdate(input: {
         agentSessionId: string;
-        eventType: string;
+        data: {
+          agentSessionId: string;
+          eventType: "session_reconcile_required";
+          lastEventUnixMs: number;
+          workspaceId: string;
+        };
+        eventType: "session_reconcile_required";
         workspaceId: string;
       }): Promise<void>;
     }
   ).reconcileAgentActivityUpdate({
     agentSessionId: "ghost-session",
-    eventType: "session_update",
+    data: {
+      agentSessionId: "ghost-session",
+      eventType: "session_reconcile_required",
+      lastEventUnixMs: 1,
+      workspaceId: "ws-1"
+    },
+    eventType: "session_reconcile_required",
     workspaceId: "ws-1"
   });
   await new Promise((resolve) => setImmediate(resolve));
@@ -3066,8 +3078,14 @@ function workspaceAgentSession(overrides: {
     goal: null,
     id: "session-1",
     imported: false,
+    kind: "root",
+    parentAgentSessionId: null,
+    parentToolCallId: null,
+    parentTurnId: null,
     provider: overrides.provider ?? "codex",
     providerSessionId: null,
+    rootAgentSessionId: null,
+    rootTurnId: null,
     cwd: "/workspace",
     latestTurn,
     latestTurnInteractions: [],

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentSessionEngineHost.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentSessionEngineHost.test.ts
@@ -1,61 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type {
-  PromptQueueSendCommand,
-  TuttiModeActivationUpdateCommand
-} from "@tutti-os/agent-activity-core";
-import {
-  executeWorkspaceAgentPromptSendCommand,
-  executeWorkspaceAgentTuttiModeUpdateCommand
-} from "./workspaceAgentSessionEngineHost.ts";
-
-test("prompt command applies required settings before sending input", async () => {
-  const calls: string[] = [];
-  const command = promptCommand({ computerUse: true });
-
-  await executeWorkspaceAgentPromptSendCommand(
-    {
-      updateSessionSettings: async (input) => {
-        calls.push("settings");
-        assert.deepEqual(input, {
-          agentSessionId: "session-1",
-          settings: { computerUse: true },
-          workspaceId: "workspace-1"
-        });
-        return {} as never;
-      },
-      sendInput: async (input) => {
-        calls.push("prompt");
-        assert.equal(input.clientSubmitId, "submit-1");
-        assert.deepEqual(input.capabilityRefs, [
-          { capability: "tutti", source: "slash_command" }
-        ]);
-      }
-    },
-    command
-  );
-
-  assert.deepEqual(calls, ["settings", "prompt"]);
-});
-
-test("prompt command does not send when its required settings fail", async () => {
-  let sent = false;
-  await assert.rejects(
-    executeWorkspaceAgentPromptSendCommand(
-      {
-        updateSessionSettings: async () => {
-          throw new Error("settings failed");
-        },
-        sendInput: async () => {
-          sent = true;
-        }
-      },
-      promptCommand({ browserUse: true })
-    ),
-    /settings failed/
-  );
-  assert.equal(sent, false);
-});
+import type { TuttiModeActivationUpdateCommand } from "@tutti-os/agent-activity-core";
+import { executeWorkspaceAgentTuttiModeUpdateCommand } from "./workspaceAgentSessionEngineHost.ts";
 
 test("Tutti mode update command preserves CAS revision and zero intensity", async () => {
   const controller = new AbortController();
@@ -90,22 +36,3 @@ test("Tutti mode update command preserves CAS revision and zero intensity", asyn
     workspaceId: "workspace-1"
   });
 });
-
-function promptCommand(
-  requiredSettingsPatch: NonNullable<
-    PromptQueueSendCommand["requiredSettingsPatch"]
-  >
-): PromptQueueSendCommand {
-  return {
-    type: "queue/sendPrompt",
-    agentSessionId: "session-1",
-    capabilityRefs: [{ capability: "tutti", source: "slash_command" }],
-    clientSubmitId: "submit-1",
-    commandId: "command-1",
-    content: [{ type: "text", text: "runtime prompt" }],
-    displayPrompt: "/computer test",
-    promptId: "prompt-1",
-    requiredSettingsPatch,
-    workspaceId: "workspace-1"
-  };
-}

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentSessionEngineHost.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentSessionEngineHost.ts
@@ -1,11 +1,11 @@
 import {
   AGENT_SESSION_ENGINE_LOCAL_ORIGIN,
   createAgentSessionEngine,
+  executeAgentActivityPromptCommand,
   type AgentActivityAdapter,
   type AgentActivitySendInput,
   type AgentSessionEngine,
   type PlanSubmitDecisionResult,
-  type PromptQueueSendCommand,
   type SessionActivateCommand,
   type SessionReconcileCommand,
   type TuttiModeActivationUpdateCommand
@@ -55,38 +55,6 @@ interface CreateWorkspaceAgentSessionEngineHostInput {
   updateTuttiModeActivation: AgentActivityRuntime["updateTuttiModeActivation"];
   tuttidClient: TuttidClient;
   workspaceId: string;
-}
-
-type WorkspaceAgentPromptCommandPort = Pick<
-  CreateWorkspaceAgentSessionEngineHostInput,
-  "sendInput" | "updateSessionSettings"
->;
-
-export async function executeWorkspaceAgentPromptSendCommand(
-  input: WorkspaceAgentPromptCommandPort,
-  command: PromptQueueSendCommand
-): Promise<unknown> {
-  if (command.requiredSettingsPatch) {
-    await input.updateSessionSettings({
-      agentSessionId: command.agentSessionId,
-      settings: { ...command.requiredSettingsPatch },
-      workspaceId: command.workspaceId
-    });
-  }
-  return input.sendInput({
-    agentSessionId: command.agentSessionId,
-    ...(command.capabilityRefs?.length
-      ? { capabilityRefs: command.capabilityRefs }
-      : {}),
-    clientSubmitId: command.clientSubmitId,
-    content: [...command.content],
-    displayPrompt: command.displayPrompt ?? null,
-    ...(command.guidance === true ? { guidance: true } : {}),
-    ...(command.submitDiagnostics
-      ? { submitDiagnostics: { ...command.submitDiagnostics } }
-      : {}),
-    workspaceId: command.workspaceId
-  });
 }
 
 export function executeWorkspaceAgentTuttiModeUpdateCommand(
@@ -174,7 +142,13 @@ export function createWorkspaceAgentSessionEngineHost(
               workspaceId: command.workspaceId
             });
           case "queue/sendPrompt":
-            return executeWorkspaceAgentPromptSendCommand(input, command);
+            return executeAgentActivityPromptCommand(
+              {
+                sendInput: input.sendInput,
+                updateSessionSettings: input.updateSessionSettings
+              },
+              command
+            );
           case "interaction/respond":
             return input.submitInteractive({
               ...(command.action ? { action: command.action } : {}),

--- a/apps/mobile/src/components/MobileComposerDock.test.tsx
+++ b/apps/mobile/src/components/MobileComposerDock.test.tsx
@@ -1,6 +1,6 @@
 import { NativeSheet } from "@tutti-os/ui-system/native";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
-import { Modal } from "react-native";
+import { Modal, TextInput } from "react-native";
 import type { WorkspaceActivitySnapshot } from "../services/workspaceActivityService";
 import { MobileComposerDock } from "./MobileComposerDock";
 
@@ -39,6 +39,38 @@ test("keeps settings and tools overlays mutually exclusive during rapid taps", (
 
   act(() => renderer!.root.findAllByType(Modal)[1]?.props.onRequestClose());
   expect(visibleModals(renderer!)).toEqual([true, false]);
+});
+
+test("keeps the draft visible but disables editing and actions while unavailable", () => {
+  let renderer: ReactTestRenderer;
+  act(() => {
+    renderer = create(
+      <MobileComposerDock
+        model={{
+          ...createModel(),
+          commandsAvailable: false,
+          draft: "keep this draft"
+        }}
+        onDraftChange={() => undefined}
+        onRefreshQuickPrompts={() => Promise.resolve()}
+        onSend={() => undefined}
+        onStop={() => undefined}
+        onUpdate={() => undefined}
+        quickPromptLibrary={{
+          enabled: false,
+          errorCode: null,
+          prompts: [],
+          status: "ready"
+        }}
+      />
+    );
+  });
+
+  expect(renderer!.root.findByType(TextInput).props.editable).toBe(false);
+  expect(
+    renderer!.root.find((node) => node.props.testID === "mobile-composer-tools")
+      .props.disabled
+  ).toBe(true);
 });
 
 function press(renderer: ReactTestRenderer, testID: string): void {
@@ -96,11 +128,14 @@ function createModel(): WorkspaceActivitySnapshot {
       reasoning: false,
       speed: false
     },
+    commandsAvailable: true,
     conversation: null,
     creating: false,
     draft: "",
     errorCode: null,
+    interactionStates: {},
     loading: false,
+    pendingInteractions: [],
     pinningSessionIds: [],
     railErrorCode: null,
     railSections: [],

--- a/apps/mobile/src/components/MobileComposerDock.test.tsx
+++ b/apps/mobile/src/components/MobileComposerDock.test.tsx
@@ -1,76 +1,89 @@
-import { NativeSheet } from "@tutti-os/ui-system/native";
+import { NativeListRow, NativeSheet } from "@tutti-os/ui-system/native";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { Modal, TextInput } from "react-native";
+import type { AgentActivitySessionSettings } from "@tutti-os/agent-activity-core";
 import type { WorkspaceActivitySnapshot } from "../services/workspaceActivityService";
 import { MobileComposerDock } from "./MobileComposerDock";
 
-test("keeps settings and tools overlays mutually exclusive during rapid taps", () => {
+test("rejects stale overlay close callbacks across ABA activations", () => {
   let renderer: ReactTestRenderer;
   act(() => {
-    renderer = create(
-      <MobileComposerDock
-        model={createModel()}
-        onDraftChange={() => undefined}
-        onRefreshQuickPrompts={() => Promise.resolve()}
-        onSend={() => undefined}
-        onStop={() => undefined}
-        onUpdate={() => undefined}
-        quickPromptLibrary={{
-          enabled: false,
-          errorCode: null,
-          prompts: [],
-          status: "ready"
-        }}
-      />
-    );
+    renderer = create(composerDock(createModel()));
   });
 
   press(renderer!, "mobile-composer-model-settings");
+  expect(visibleModals(renderer!)).toEqual([true, false]);
+  const closeSettingsA =
+    renderer!.root.findByType(NativeSheet).props.onOpenChange;
+
+  press(renderer!, "mobile-composer-tools");
+  expect(visibleModals(renderer!)).toEqual([false, true]);
+  const closeToolsA =
+    renderer!.root.findAllByType(Modal)[1]?.props.onRequestClose;
+
+  press(renderer!, "mobile-composer-model-settings");
+  expect(visibleModals(renderer!)).toEqual([true, false]);
+
+  act(() => closeSettingsA(false));
   expect(visibleModals(renderer!)).toEqual([true, false]);
 
   press(renderer!, "mobile-composer-tools");
   expect(visibleModals(renderer!)).toEqual([false, true]);
 
-  act(() => renderer!.root.findByType(NativeSheet).props.onOpenChange(false));
+  act(() => closeToolsA());
   expect(visibleModals(renderer!)).toEqual([false, true]);
 
-  press(renderer!, "mobile-composer-model-settings");
-  expect(visibleModals(renderer!)).toEqual([true, false]);
-
   act(() => renderer!.root.findAllByType(Modal)[1]?.props.onRequestClose());
-  expect(visibleModals(renderer!)).toEqual([true, false]);
+  expect(visibleModals(renderer!)).toEqual([false, false]);
 });
 
 test("keeps the draft visible but disables editing and actions while unavailable", () => {
   let renderer: ReactTestRenderer;
   act(() => {
     renderer = create(
-      <MobileComposerDock
-        model={{
-          ...createModel(),
-          commandsAvailable: false,
-          draft: "keep this draft"
-        }}
-        onDraftChange={() => undefined}
-        onRefreshQuickPrompts={() => Promise.resolve()}
-        onSend={() => undefined}
-        onStop={() => undefined}
-        onUpdate={() => undefined}
-        quickPromptLibrary={{
-          enabled: false,
-          errorCode: null,
-          prompts: [],
-          status: "ready"
-        }}
-      />
+      composerDock({
+        ...createModel(),
+        commandsAvailable: false,
+        draft: "keep this draft"
+      })
     );
   });
 
   expect(renderer!.root.findByType(TextInput).props.editable).toBe(false);
+  expect(testTargetIsDisabled(renderer!, "mobile-composer-tools")).toBe(true);
   expect(
-    renderer!.root.find((node) => node.props.testID === "mobile-composer-tools")
-      .props.disabled
+    testTargetIsDisabled(renderer!, "mobile-composer-model-settings")
   ).toBe(true);
+});
+
+test("closes settings and rejects a queued selection when commands become unavailable", () => {
+  const updates: AgentActivitySessionSettings[] = [];
+  let renderer: ReactTestRenderer;
+  act(() => {
+    renderer = create(
+      composerDock(createModel(), (settings) => updates.push(settings))
+    );
+  });
+
+  press(renderer!, "mobile-composer-model-settings");
+  const queuedSelection = renderer!.root.find(
+    (node) =>
+      node.type === NativeListRow &&
+      node.props.title === "Test model" &&
+      typeof node.props.onPress === "function"
+  ).props.onPress;
+
+  act(() => {
+    renderer!.update(
+      composerDock({ ...createModel(), commandsAvailable: false }, (settings) =>
+        updates.push(settings)
+      )
+    );
+  });
+  expect(visibleModals(renderer!)).toEqual([false, false]);
+
+  act(() => queuedSelection());
+  expect(updates).toEqual([]);
 });
 
 function press(renderer: ReactTestRenderer, testID: string): void {
@@ -85,6 +98,36 @@ function visibleModals(renderer: ReactTestRenderer): boolean[] {
   return renderer.root
     .findAllByType(Modal)
     .map((modal) => modal.props.visible === true);
+}
+
+function testTargetIsDisabled(
+  renderer: ReactTestRenderer,
+  testID: string
+): boolean {
+  const targets = renderer.root.findAll((node) => node.props.testID === testID);
+  return targets.some((target) => target.props.disabled === true);
+}
+
+function composerDock(
+  model: WorkspaceActivitySnapshot,
+  onUpdate: (settings: AgentActivitySessionSettings) => void = () => undefined
+) {
+  return (
+    <MobileComposerDock
+      model={model}
+      onDraftChange={() => undefined}
+      onRefreshQuickPrompts={() => Promise.resolve()}
+      onSend={() => undefined}
+      onStop={() => undefined}
+      onUpdate={onUpdate}
+      quickPromptLibrary={{
+        enabled: false,
+        errorCode: null,
+        prompts: [],
+        status: "ready"
+      }}
+    />
+  );
 }
 
 function createModel(): WorkspaceActivitySnapshot {

--- a/apps/mobile/src/components/MobileComposerDock.test.tsx
+++ b/apps/mobile/src/components/MobileComposerDock.test.tsx
@@ -1,0 +1,114 @@
+import { NativeSheet } from "@tutti-os/ui-system/native";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { Modal } from "react-native";
+import type { WorkspaceActivitySnapshot } from "../services/workspaceActivityService";
+import { MobileComposerDock } from "./MobileComposerDock";
+
+test("keeps settings and tools overlays mutually exclusive during rapid taps", () => {
+  let renderer: ReactTestRenderer;
+  act(() => {
+    renderer = create(
+      <MobileComposerDock
+        model={createModel()}
+        onDraftChange={() => undefined}
+        onRefreshQuickPrompts={() => Promise.resolve()}
+        onSend={() => undefined}
+        onStop={() => undefined}
+        onUpdate={() => undefined}
+        quickPromptLibrary={{
+          enabled: false,
+          errorCode: null,
+          prompts: [],
+          status: "ready"
+        }}
+      />
+    );
+  });
+
+  press(renderer!, "mobile-composer-model-settings");
+  expect(visibleModals(renderer!)).toEqual([true, false]);
+
+  press(renderer!, "mobile-composer-tools");
+  expect(visibleModals(renderer!)).toEqual([false, true]);
+
+  act(() => renderer!.root.findByType(NativeSheet).props.onOpenChange(false));
+  expect(visibleModals(renderer!)).toEqual([false, true]);
+
+  press(renderer!, "mobile-composer-model-settings");
+  expect(visibleModals(renderer!)).toEqual([true, false]);
+
+  act(() => renderer!.root.findAllByType(Modal)[1]?.props.onRequestClose());
+  expect(visibleModals(renderer!)).toEqual([true, false]);
+});
+
+function press(renderer: ReactTestRenderer, testID: string): void {
+  const target = renderer.root.find(
+    (node) =>
+      node.props.testID === testID && typeof node.props.onPress === "function"
+  );
+  act(() => target.props.onPress());
+}
+
+function visibleModals(renderer: ReactTestRenderer): boolean[] {
+  return renderer.root
+    .findAllByType(Modal)
+    .map((modal) => modal.props.visible === true);
+}
+
+function createModel(): WorkspaceActivitySnapshot {
+  return {
+    activity: {
+      presences: [],
+      sessionMessagesById: {},
+      sessions: [],
+      workspaceId: "workspace"
+    },
+    ambiguousSubmission: false,
+    composerOptions: {
+      behavior: {
+        collapseModelOptionsToLatest: false,
+        modelOptionsAuthoritative: true,
+        planModeExclusiveWithPermissionMode: false,
+        prewarmDraftSession: false,
+        refreshModelOptionsAfterSettings: false
+      },
+      capabilities: null,
+      loadedAtUnixMs: 0,
+      models: [{ label: "Test model", value: "test-model" }],
+      modelConfigurable: true,
+      provider: "test",
+      reasoningEfforts: [],
+      skills: [],
+      speeds: []
+    },
+    composerOptionsLoadStatus: "ready",
+    composerSettings: { model: "test-model" },
+    composerSettingsSupport: {
+      browser: false,
+      computer: false,
+      model: true,
+      modelSwitch: true,
+      permission: false,
+      permissionModeChangeDeferred: false,
+      permissionModeChangeDuringTurn: false,
+      plan: false,
+      planImplementation: false,
+      reasoning: false,
+      speed: false
+    },
+    conversation: null,
+    creating: false,
+    draft: "",
+    errorCode: null,
+    loading: false,
+    pinningSessionIds: [],
+    railErrorCode: null,
+    railSections: [],
+    railStatus: "ready",
+    selectedAgentSessionId: null,
+    selectedAgentTargetId: null,
+    selectedSession: null,
+    sending: false,
+    targets: []
+  };
+}

--- a/apps/mobile/src/components/MobileComposerDock.tsx
+++ b/apps/mobile/src/components/MobileComposerDock.tsx
@@ -35,8 +35,12 @@ import {
 type ComposerToolsMenu = "tools" | "model" | "permission" | "quickPrompts";
 
 type ComposerOverlay =
-  | { kind: "settings"; menu: ComposerSettingMenu }
-  | { kind: "tools"; menu: ComposerToolsMenu }
+  | {
+      activationId: number;
+      kind: "settings";
+      menu: ComposerSettingMenu;
+    }
+  | { activationId: number; kind: "tools"; menu: ComposerToolsMenu }
   | null;
 
 export function MobileComposerDock({
@@ -61,6 +65,7 @@ export function MobileComposerDock({
   const [overlay, setOverlay] = useState<ComposerOverlay>(null);
   const [quickPromptQuery, setQuickPromptQuery] = useState("");
   const inputRef = useRef<TextInput>(null);
+  const nextOverlayActivationIdRef = useRef(1);
   const selectionRef = useRef<MobileTextSelection | null>(null);
   const hasActiveTurn = Boolean(
     model.selectedSession?.activeTurnId && !model.creating
@@ -94,24 +99,46 @@ export function MobileComposerDock({
     )?.label ?? t("defaultPermissions");
   const settingsMenu = overlay?.kind === "settings" ? overlay.menu : null;
   const toolsMenu = overlay?.kind === "tools" ? overlay.menu : null;
+  const settingsActivationId =
+    overlay?.kind === "settings" ? overlay.activationId : null;
+  const toolsActivationId =
+    overlay?.kind === "tools" ? overlay.activationId : null;
   const setSettingsMenu = (menu: ComposerSettingMenu | null): void => {
+    if (menu !== null) {
+      const activationId = nextOverlayActivationIdRef.current++;
+      setOverlay((current) =>
+        current?.kind === "settings"
+          ? { ...current, menu }
+          : { activationId, kind: "settings", menu }
+      );
+      return;
+    }
     setOverlay((current) =>
-      menu !== null
-        ? { kind: "settings", menu }
-        : current?.kind === "settings"
-          ? null
-          : current
+      current?.kind === "settings" &&
+      current.activationId === settingsActivationId
+        ? null
+        : current
     );
   };
   const setToolsMenu = (menu: ComposerToolsMenu | null): void => {
+    if (menu !== null) {
+      const activationId = nextOverlayActivationIdRef.current++;
+      setOverlay((current) =>
+        current?.kind === "tools"
+          ? { ...current, menu }
+          : { activationId, kind: "tools", menu }
+      );
+      return;
+    }
     setOverlay((current) =>
-      menu !== null
-        ? { kind: "tools", menu }
-        : current?.kind === "tools"
-          ? null
-          : current
+      current?.kind === "tools" && current.activationId === toolsActivationId
+        ? null
+        : current
     );
   };
+  useEffect(() => {
+    if (!model.commandsAvailable) setOverlay(null);
+  }, [model.commandsAvailable]);
   useEffect(() => {
     if (
       toolsMenu === "quickPrompts" &&
@@ -150,6 +177,8 @@ export function MobileComposerDock({
   return (
     <View style={styles.dock}>
       <MobileComposerSettingsSheet
+        activationId={settingsActivationId}
+        disabled={!model.commandsAvailable}
         menu={settingsMenu}
         model={model}
         onMenuChange={setSettingsMenu}
@@ -212,7 +241,7 @@ export function MobileComposerDock({
         presentationStyle="overFullScreen"
         statusBarTranslucent
         transparent
-        visible={toolsMenu !== null}
+        visible={model.commandsAvailable && toolsMenu !== null}
       >
         <Pressable onPress={() => setToolsMenu(null)} style={styles.backdrop}>
           <Pressable

--- a/apps/mobile/src/components/MobileComposerDock.tsx
+++ b/apps/mobile/src/components/MobileComposerDock.tsx
@@ -68,6 +68,7 @@ export function MobileComposerDock({
   const canSend = Boolean(
     model.draft.trim() &&
     (!model.creating || model.selectedAgentTargetId) &&
+    model.commandsAvailable &&
     !model.sending
   );
   const modelOptions = model.composerOptions?.models ?? [];
@@ -157,6 +158,7 @@ export function MobileComposerDock({
       <View style={styles.inputRow}>
         <NativeIconButton
           accessibilityLabel={t("moreActions")}
+          disabled={!model.commandsAvailable}
           icon={<Text style={styles.plus}>＋</Text>}
           onPress={openToolsMenu}
           style={styles.addButton}
@@ -166,7 +168,7 @@ export function MobileComposerDock({
         <View style={styles.inputPill}>
           <TextInput
             ref={inputRef}
-            editable={!model.sending}
+            editable={!model.sending && model.commandsAvailable}
             multiline
             onChangeText={onDraftChange}
             onSelectionChange={(
@@ -182,6 +184,7 @@ export function MobileComposerDock({
           {hasActiveTurn ? (
             <NativeIconButton
               accessibilityLabel={t("stop")}
+              disabled={!model.commandsAvailable}
               icon={<Text style={styles.actionIcon}>■</Text>}
               onPress={onStop}
               style={styles.actionButton}

--- a/apps/mobile/src/components/MobileComposerDock.tsx
+++ b/apps/mobile/src/components/MobileComposerDock.tsx
@@ -21,7 +21,10 @@ import {
 import { t } from "../i18n";
 import type { MobileQuickPromptLibrarySnapshot } from "../services/mobileQuickPromptLibraryService";
 import type { WorkspaceActivitySnapshot } from "../services/workspaceActivityService";
-import { MobileComposerSettingsSheet } from "./MobileComposerSettingsSheet";
+import {
+  MobileComposerSettingsSheet,
+  type ComposerSettingMenu
+} from "./MobileComposerSettingsSheet";
 import {
   addMobileQuickPrompt,
   filterMobileQuickPrompts,
@@ -29,11 +32,11 @@ import {
   type MobileTextSelection
 } from "./mobileQuickPromptPresentation";
 
-type ComposerToolsMenu =
-  | "tools"
-  | "model"
-  | "permission"
-  | "quickPrompts"
+type ComposerToolsMenu = "tools" | "model" | "permission" | "quickPrompts";
+
+type ComposerOverlay =
+  | { kind: "settings"; menu: ComposerSettingMenu }
+  | { kind: "tools"; menu: ComposerToolsMenu }
   | null;
 
 export function MobileComposerDock({
@@ -55,7 +58,7 @@ export function MobileComposerDock({
 }) {
   const theme = useNativeTheme();
   const styles = createStyles(theme);
-  const [menu, setMenu] = useState<ComposerToolsMenu>(null);
+  const [overlay, setOverlay] = useState<ComposerOverlay>(null);
   const [quickPromptQuery, setQuickPromptQuery] = useState("");
   const inputRef = useRef<TextInput>(null);
   const selectionRef = useRef<MobileTextSelection | null>(null);
@@ -88,18 +91,38 @@ export function MobileComposerDock({
     permissionOptions.find(
       (option) => option.id === model.composerSettings.permissionModeId
     )?.label ?? t("defaultPermissions");
+  const settingsMenu = overlay?.kind === "settings" ? overlay.menu : null;
+  const toolsMenu = overlay?.kind === "tools" ? overlay.menu : null;
+  const setSettingsMenu = (menu: ComposerSettingMenu | null): void => {
+    setOverlay((current) =>
+      menu !== null
+        ? { kind: "settings", menu }
+        : current?.kind === "settings"
+          ? null
+          : current
+    );
+  };
+  const setToolsMenu = (menu: ComposerToolsMenu | null): void => {
+    setOverlay((current) =>
+      menu !== null
+        ? { kind: "tools", menu }
+        : current?.kind === "tools"
+          ? null
+          : current
+    );
+  };
   useEffect(() => {
     if (
-      menu === "quickPrompts" &&
+      toolsMenu === "quickPrompts" &&
       quickPromptLibrary.status !== "loading" &&
       !quickPromptLibrary.enabled
     ) {
       setQuickPromptQuery("");
-      setMenu("tools");
+      setToolsMenu("tools");
     }
-  }, [menu, quickPromptLibrary.enabled, quickPromptLibrary.status]);
+  }, [toolsMenu, quickPromptLibrary.enabled, quickPromptLibrary.status]);
   const openToolsMenu = (): void => {
-    setMenu("tools");
+    setToolsMenu("tools");
     void onRefreshQuickPrompts();
   };
   const selectQuickPrompt = (content: string): void => {
@@ -114,7 +137,7 @@ export function MobileComposerDock({
       start: added.caret
     };
     setQuickPromptQuery("");
-    setMenu(null);
+    setToolsMenu(null);
     requestAnimationFrame(() => {
       inputRef.current?.focus();
       inputRef.current?.setNativeProps({
@@ -125,13 +148,19 @@ export function MobileComposerDock({
 
   return (
     <View style={styles.dock}>
-      <MobileComposerSettingsSheet model={model} onUpdate={onUpdate} />
+      <MobileComposerSettingsSheet
+        menu={settingsMenu}
+        model={model}
+        onMenuChange={setSettingsMenu}
+        onUpdate={onUpdate}
+      />
       <View style={styles.inputRow}>
         <NativeIconButton
           accessibilityLabel={t("moreActions")}
           icon={<Text style={styles.plus}>＋</Text>}
           onPress={openToolsMenu}
           style={styles.addButton}
+          testID="mobile-composer-tools"
           variant="secondary"
         />
         <View style={styles.inputPill}>
@@ -176,24 +205,24 @@ export function MobileComposerDock({
 
       <Modal
         animationType="fade"
-        onRequestClose={() => setMenu(null)}
+        onRequestClose={() => setToolsMenu(null)}
         presentationStyle="overFullScreen"
         statusBarTranslucent
         transparent
-        visible={menu !== null}
+        visible={toolsMenu !== null}
       >
-        <Pressable onPress={() => setMenu(null)} style={styles.backdrop}>
+        <Pressable onPress={() => setToolsMenu(null)} style={styles.backdrop}>
           <Pressable
             onPress={(event) => event.stopPropagation()}
             style={styles.menu}
           >
-            {menu === "tools" ? (
+            {toolsMenu === "tools" ? (
               <>
                 {model.composerSettingsSupport.model &&
                 modelOptions.length > 0 ? (
                   <NativeListRow
                     description={selectedModelLabel}
-                    onPress={() => setMenu("model")}
+                    onPress={() => setToolsMenu("model")}
                     title={t("model")}
                     trailing={<Text style={styles.chevron}>›</Text>}
                   />
@@ -202,7 +231,7 @@ export function MobileComposerDock({
                 permissionOptions.length > 0 ? (
                   <NativeListRow
                     description={selectedPermissionLabel}
-                    onPress={() => setMenu("permission")}
+                    onPress={() => setToolsMenu("permission")}
                     title={t("permissions")}
                     trailing={<Text style={styles.chevron}>›</Text>}
                   />
@@ -218,7 +247,7 @@ export function MobileComposerDock({
                       onUpdate({
                         planMode: !model.composerSettings.planMode
                       });
-                      setMenu(null);
+                      setToolsMenu(null);
                     }}
                     selected={model.composerSettings.planMode === true}
                     title={t("planMode")}
@@ -233,7 +262,7 @@ export function MobileComposerDock({
                             count: quickPromptLibrary.prompts.length
                           })
                     }
-                    onPress={() => setMenu("quickPrompts")}
+                    onPress={() => setToolsMenu("quickPrompts")}
                     title={t("quickPrompts")}
                     trailing={<Text style={styles.chevron}>›</Text>}
                   />
@@ -264,18 +293,18 @@ export function MobileComposerDock({
                   <NativeIconButton
                     accessibilityLabel={t("cancel")}
                     icon={<Text style={styles.menuBackIcon}>←</Text>}
-                    onPress={() => setMenu("tools")}
+                    onPress={() => setToolsMenu("tools")}
                     style={styles.menuBackButton}
                   />
                   <Text style={styles.menuTitle}>
-                    {menu === "model"
+                    {toolsMenu === "model"
                       ? t("model")
-                      : menu === "permission"
+                      : toolsMenu === "permission"
                         ? t("permissions")
                         : t("quickPrompts")}
                   </Text>
                 </View>
-                {menu === "quickPrompts" ? (
+                {toolsMenu === "quickPrompts" ? (
                   <TextInput
                     accessibilityLabel={t("searchQuickPrompts")}
                     autoCapitalize="none"
@@ -292,13 +321,13 @@ export function MobileComposerDock({
                   showsVerticalScrollIndicator
                   style={styles.menuOptions}
                 >
-                  {menu === "model"
+                  {toolsMenu === "model"
                     ? modelOptions.map((option) => (
                         <NativeListRow
                           key={option.value}
                           onPress={() => {
                             onUpdate({ model: option.value });
-                            setMenu(null);
+                            setToolsMenu(null);
                           }}
                           selected={
                             option.value === model.composerSettings.model
@@ -307,14 +336,14 @@ export function MobileComposerDock({
                         />
                       ))
                     : null}
-                  {menu === "permission"
+                  {toolsMenu === "permission"
                     ? permissionOptions.map((option) => (
                         <NativeListRow
                           description={option.description}
                           key={option.id}
                           onPress={() => {
                             onUpdate({ permissionModeId: option.id });
-                            setMenu(null);
+                            setToolsMenu(null);
                           }}
                           selected={
                             option.id ===
@@ -324,7 +353,7 @@ export function MobileComposerDock({
                         />
                       ))
                     : null}
-                  {menu === "quickPrompts"
+                  {toolsMenu === "quickPrompts"
                     ? filteredQuickPrompts.map((prompt) => (
                         <NativeListRow
                           description={previewMobileQuickPromptContent(
@@ -336,7 +365,7 @@ export function MobileComposerDock({
                         />
                       ))
                     : null}
-                  {menu === "quickPrompts" &&
+                  {toolsMenu === "quickPrompts" &&
                   quickPromptLibrary.status === "error" ? (
                     <View style={styles.quickPromptStatus}>
                       <Text style={styles.errorText}>
@@ -348,7 +377,7 @@ export function MobileComposerDock({
                       />
                     </View>
                   ) : null}
-                  {menu === "quickPrompts" &&
+                  {toolsMenu === "quickPrompts" &&
                   quickPromptLibrary.status === "loading" ? (
                     <ActivityIndicator
                       color={theme.color.accent}
@@ -356,14 +385,14 @@ export function MobileComposerDock({
                       style={styles.loading}
                     />
                   ) : null}
-                  {menu === "quickPrompts" &&
+                  {toolsMenu === "quickPrompts" &&
                   quickPromptLibrary.status === "ready" &&
                   quickPromptLibrary.prompts.length === 0 ? (
                     <Text style={styles.emptyMenu}>
                       {t("emptyQuickPrompts")}
                     </Text>
                   ) : null}
-                  {menu === "quickPrompts" &&
+                  {toolsMenu === "quickPrompts" &&
                   quickPromptLibrary.status === "ready" &&
                   quickPromptLibrary.prompts.length > 0 &&
                   filteredQuickPrompts.length === 0 ? (
@@ -371,7 +400,7 @@ export function MobileComposerDock({
                       {t("noQuickPromptResults")}
                     </Text>
                   ) : null}
-                  {menu !== "quickPrompts" &&
+                  {toolsMenu !== "quickPrompts" &&
                   model.composerOptionsLoadStatus === "loading" ? (
                     <ActivityIndicator
                       color={theme.color.accent}

--- a/apps/mobile/src/components/MobileComposerSettingsSheet.tsx
+++ b/apps/mobile/src/components/MobileComposerSettingsSheet.tsx
@@ -6,6 +6,7 @@ import {
   type NativeTheme,
   useNativeTheme
 } from "@tutti-os/ui-system/native";
+import { useRef } from "react";
 import { ScrollView, StyleSheet, Text, View } from "react-native";
 import { t } from "../i18n";
 import type { WorkspaceActivitySnapshot } from "../services/workspaceActivityService";
@@ -17,11 +18,15 @@ export type ComposerSettingMenu =
   | "permission";
 
 export function MobileComposerSettingsSheet({
+  activationId,
+  disabled,
   menu,
   model,
   onMenuChange,
   onUpdate
 }: {
+  activationId: number | null;
+  disabled: boolean;
   menu: ComposerSettingMenu | null;
   model: WorkspaceActivitySnapshot;
   onMenuChange(menu: ComposerSettingMenu | null): void;
@@ -29,6 +34,10 @@ export function MobileComposerSettingsSheet({
 }) {
   const theme = useNativeTheme();
   const styles = createStyles(theme);
+  const activeActivationIdRef = useRef(activationId);
+  const disabledRef = useRef(disabled);
+  activeActivationIdRef.current = activationId;
+  disabledRef.current = disabled;
   const options = model.composerOptions;
   const selectedModel = model.composerSettings.model ?? null;
   const reasoningOptions = selectedModel
@@ -41,6 +50,13 @@ export function MobileComposerSettingsSheet({
   );
 
   const closeWith = (settings: AgentActivitySessionSettings): void => {
+    if (
+      activationId === null ||
+      activeActivationIdRef.current !== activationId ||
+      disabledRef.current
+    ) {
+      return;
+    }
     onUpdate(settings);
     onMenuChange(null);
   };
@@ -50,6 +66,7 @@ export function MobileComposerSettingsSheet({
       <View style={styles.chips}>
         {showsModelChip ? (
           <ComposerChip
+            disabled={disabled}
             label={[
               selectedOptionLabel(options?.models ?? [], selectedModel) ??
                 t("model"),
@@ -70,6 +87,7 @@ export function MobileComposerSettingsSheet({
         model.composerSettingsSupport.reasoning &&
         reasoningOptions.length ? (
           <ComposerChip
+            disabled={disabled}
             label={
               selectedOptionLabel(
                 reasoningOptions,
@@ -82,6 +100,7 @@ export function MobileComposerSettingsSheet({
         ) : null}
         {model.composerSettingsSupport.speed && options?.speeds.length ? (
           <ComposerChip
+            disabled={disabled}
             label={
               selectedOptionLabel(
                 options?.speeds ?? [],
@@ -95,6 +114,7 @@ export function MobileComposerSettingsSheet({
         {model.composerSettingsSupport.permission &&
         options?.permissionConfig?.modes.length ? (
           <ComposerChip
+            disabled={disabled}
             label={
               selectedOptionLabel(
                 options?.permissionConfig?.modes ?? [],
@@ -110,7 +130,7 @@ export function MobileComposerSettingsSheet({
       <NativeSheet
         closeAccessibilityLabel={t("closeSheet")}
         onOpenChange={(open) => !open && onMenuChange(null)}
-        open={menu !== null}
+        open={!disabled && menu !== null}
       >
         <View style={styles.sheet}>
           <Text style={styles.sheetTitle}>{titleForMenu(menu)}</Text>
@@ -119,6 +139,7 @@ export function MobileComposerSettingsSheet({
               ? [
                   ...(options?.models.map((option) => (
                     <NativeListRow
+                      disabled={disabled}
                       key={`model:${option.value}`}
                       onPress={() => closeWith({ model: option.value })}
                       selected={option.value === selectedModel}
@@ -133,6 +154,7 @@ export function MobileComposerSettingsSheet({
                         </Text>,
                         ...reasoningOptions.map((option) => (
                           <NativeListRow
+                            disabled={disabled}
                             key={`reasoning:${option.value}`}
                             onPress={() =>
                               closeWith({ reasoningEffort: option.value })
@@ -151,6 +173,7 @@ export function MobileComposerSettingsSheet({
             {menu === "reasoning"
               ? reasoningOptions.map((option) => (
                   <NativeListRow
+                    disabled={disabled}
                     key={option.value}
                     onPress={() => closeWith({ reasoningEffort: option.value })}
                     selected={
@@ -163,6 +186,7 @@ export function MobileComposerSettingsSheet({
             {menu === "speed"
               ? options?.speeds.map((option) => (
                   <NativeListRow
+                    disabled={disabled}
                     key={option.value}
                     onPress={() => closeWith({ speed: option.value })}
                     selected={option.value === model.composerSettings.speed}
@@ -174,6 +198,7 @@ export function MobileComposerSettingsSheet({
               ? options?.permissionConfig?.modes.map((option) => (
                   <NativeListRow
                     description={option.description}
+                    disabled={disabled}
                     key={option.id}
                     onPress={() => closeWith({ permissionModeId: option.id })}
                     selected={
@@ -194,10 +219,12 @@ export function MobileComposerSettingsSheet({
 }
 
 function ComposerChip({
+  disabled,
   label,
   onPress,
   testID
 }: {
+  disabled: boolean;
   label: string;
   onPress(): void;
   testID: string;
@@ -206,6 +233,7 @@ function ComposerChip({
   const styles = createStyles(theme);
   return (
     <NativeButton
+      disabled={disabled}
       label={label}
       onPress={onPress}
       size="compact"

--- a/apps/mobile/src/components/MobileComposerSettingsSheet.tsx
+++ b/apps/mobile/src/components/MobileComposerSettingsSheet.tsx
@@ -6,28 +6,29 @@ import {
   type NativeTheme,
   useNativeTheme
 } from "@tutti-os/ui-system/native";
-import { useState } from "react";
 import { ScrollView, StyleSheet, Text, View } from "react-native";
 import { t } from "../i18n";
 import type { WorkspaceActivitySnapshot } from "../services/workspaceActivityService";
 
-type ComposerSettingMenu =
+export type ComposerSettingMenu =
   | "model"
   | "reasoning"
   | "speed"
-  | "permission"
-  | null;
+  | "permission";
 
 export function MobileComposerSettingsSheet({
+  menu,
   model,
+  onMenuChange,
   onUpdate
 }: {
+  menu: ComposerSettingMenu | null;
   model: WorkspaceActivitySnapshot;
+  onMenuChange(menu: ComposerSettingMenu | null): void;
   onUpdate(settings: AgentActivitySessionSettings): void;
 }) {
   const theme = useNativeTheme();
   const styles = createStyles(theme);
-  const [menu, setMenu] = useState<ComposerSettingMenu>(null);
   const options = model.composerOptions;
   const selectedModel = model.composerSettings.model ?? null;
   const reasoningOptions = selectedModel
@@ -41,7 +42,7 @@ export function MobileComposerSettingsSheet({
 
   const closeWith = (settings: AgentActivitySessionSettings): void => {
     onUpdate(settings);
-    setMenu(null);
+    onMenuChange(null);
   };
 
   return (
@@ -61,7 +62,8 @@ export function MobileComposerSettingsSheet({
             ]
               .filter(Boolean)
               .join(" ")}
-            onPress={() => setMenu("model")}
+            onPress={() => onMenuChange("model")}
+            testID="mobile-composer-model-settings"
           />
         ) : null}
         {!showsModelChip &&
@@ -74,7 +76,8 @@ export function MobileComposerSettingsSheet({
                 model.composerSettings.reasoningEffort ?? null
               ) ?? t("reasoning")
             }
-            onPress={() => setMenu("reasoning")}
+            onPress={() => onMenuChange("reasoning")}
+            testID="mobile-composer-reasoning-settings"
           />
         ) : null}
         {model.composerSettingsSupport.speed && options?.speeds.length ? (
@@ -85,7 +88,8 @@ export function MobileComposerSettingsSheet({
                 model.composerSettings.speed ?? null
               ) ?? t("speed")
             }
-            onPress={() => setMenu("speed")}
+            onPress={() => onMenuChange("speed")}
+            testID="mobile-composer-speed-settings"
           />
         ) : null}
         {model.composerSettingsSupport.permission &&
@@ -97,14 +101,15 @@ export function MobileComposerSettingsSheet({
                 model.composerSettings.permissionModeId ?? null
               ) ?? t("defaultPermissions")
             }
-            onPress={() => setMenu("permission")}
+            onPress={() => onMenuChange("permission")}
+            testID="mobile-composer-permission-settings"
           />
         ) : null}
       </View>
 
       <NativeSheet
         closeAccessibilityLabel={t("closeSheet")}
-        onOpenChange={(open) => !open && setMenu(null)}
+        onOpenChange={(open) => !open && onMenuChange(null)}
         open={menu !== null}
       >
         <View style={styles.sheet}>
@@ -188,7 +193,15 @@ export function MobileComposerSettingsSheet({
   );
 }
 
-function ComposerChip({ label, onPress }: { label: string; onPress(): void }) {
+function ComposerChip({
+  label,
+  onPress,
+  testID
+}: {
+  label: string;
+  onPress(): void;
+  testID: string;
+}) {
   const theme = useNativeTheme();
   const styles = createStyles(theme);
   return (
@@ -197,6 +210,7 @@ function ComposerChip({ label, onPress }: { label: string; onPress(): void }) {
       onPress={onPress}
       size="compact"
       style={styles.chip}
+      testID={testID}
       variant="secondary"
     />
   );
@@ -213,7 +227,7 @@ function selectedOptionLabel(
   return option?.label ?? value;
 }
 
-function titleForMenu(menu: ComposerSettingMenu): string {
+function titleForMenu(menu: ComposerSettingMenu | null): string {
   switch (menu) {
     case "model":
       return t("model");

--- a/apps/mobile/src/components/MobileConversationRows.test.tsx
+++ b/apps/mobile/src/components/MobileConversationRows.test.tsx
@@ -5,20 +5,28 @@ import { PrimaryButton } from "./PrimaryButton";
 import { MobileInteractionCard } from "./MobileConversationRows";
 
 test("renders Engine-owned submitting and failure state", () => {
+  let retries = 0;
   let renderer: ReactTestRenderer;
   act(() => {
     renderer = create(
       <MobileInteractionCard
         failed
         interaction={approvalInteraction()}
+        onRetry={() => {
+          retries += 1;
+        }}
         onSubmit={() => undefined}
         runtimeAvailable
-        submitting
+        submitting={false}
       />
     );
   });
 
-  expect(renderer!.root.findByType(PrimaryButton).props.disabled).toBe(true);
+  const retry = renderer!.root.findByType(PrimaryButton);
+  expect(retry.props.disabled).toBe(false);
+  expect(retry.props.label).toBe("Retry");
+  act(() => retry.props.onPress());
+  expect(retries).toBe(1);
   expect(
     renderer!.root
       .findAllByType(Text)
@@ -42,6 +50,7 @@ test("fails closed when an exit-plan Interaction has no runtime-authored options
         onSubmit={() => {
           submissions += 1;
         }}
+        onRetry={() => undefined}
         runtimeAvailable
         submitting={false}
       />

--- a/apps/mobile/src/components/MobileConversationRows.test.tsx
+++ b/apps/mobile/src/components/MobileConversationRows.test.tsx
@@ -1,0 +1,72 @@
+import type { AgentActivityInteraction } from "@tutti-os/agent-activity-core";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { Text } from "react-native";
+import { PrimaryButton } from "./PrimaryButton";
+import { MobileInteractionCard } from "./MobileConversationRows";
+
+test("renders Engine-owned submitting and failure state", () => {
+  let renderer: ReactTestRenderer;
+  act(() => {
+    renderer = create(
+      <MobileInteractionCard
+        failed
+        interaction={approvalInteraction()}
+        onSubmit={() => undefined}
+        runtimeAvailable
+        submitting
+      />
+    );
+  });
+
+  expect(renderer!.root.findByType(PrimaryButton).props.disabled).toBe(true);
+  expect(
+    renderer!.root
+      .findAllByType(Text)
+      .some((node) => String(node.props.children).includes("Something went"))
+  ).toBe(true);
+});
+
+test("fails closed when an exit-plan Interaction has no runtime-authored options", () => {
+  let submissions = 0;
+  let renderer: ReactTestRenderer;
+  act(() => {
+    renderer = create(
+      <MobileInteractionCard
+        failed={false}
+        interaction={{
+          ...approvalInteraction(),
+          input: {},
+          kind: "plan",
+          toolName: "ExitPlanMode"
+        }}
+        onSubmit={() => {
+          submissions += 1;
+        }}
+        runtimeAvailable
+        submitting={false}
+      />
+    );
+  });
+
+  expect(renderer!.root.findAllByType(PrimaryButton)).toHaveLength(0);
+  expect(submissions).toBe(0);
+});
+
+function approvalInteraction(): AgentActivityInteraction {
+  return {
+    agentSessionId: "session-1",
+    createdAtUnixMs: 1,
+    input: {
+      callId: "call-1",
+      options: [{ label: "Allow", optionId: "allow-once" }]
+    },
+    kind: "approval",
+    metadata: {},
+    output: null,
+    requestId: "request-1",
+    status: "pending",
+    toolName: "Approval",
+    turnId: "turn-1",
+    updatedAtUnixMs: 1
+  };
+}

--- a/apps/mobile/src/components/MobileConversationRows.tsx
+++ b/apps/mobile/src/components/MobileConversationRows.tsx
@@ -15,24 +15,28 @@ import { t } from "../i18n";
 import { PrimaryButton } from "./PrimaryButton";
 
 interface MobileInteractionCardProps {
+  failed: boolean;
   interaction: AgentActivityInteraction;
   onSubmit(input: {
     action?: string;
     optionId?: string;
     payload?: Record<string, unknown>;
-  }): Promise<void>;
+  }): void;
+  runtimeAvailable: boolean;
+  submitting: boolean;
 }
 
 export function MobileInteractionCard({
+  failed,
   interaction,
-  onSubmit
+  onSubmit,
+  runtimeAvailable,
+  submitting
 }: MobileInteractionCardProps) {
   const theme = useNativeTheme();
   const styles = createStyles(theme);
   const [answers, setAnswers] = useState<Record<string, string[]>>({});
-  const [failed, setFailed] = useState(false);
   const [planFeedback, setPlanFeedback] = useState("");
-  const [submitting, setSubmitting] = useState(false);
   const interactionIdentity = `${interaction.agentSessionId}:${interaction.turnId}:${interaction.requestId}`;
   const prompt = useMemo(
     () => projectAgentConversationPromptFromInteraction(interaction),
@@ -40,23 +44,14 @@ export function MobileInteractionCard({
   );
   const questions = prompt?.kind === "ask-user" ? prompt.questions : [];
   const options = prompt?.kind === "approval" ? prompt.options : [];
-  const submit = async (value: Parameters<typeof onSubmit>[0]) => {
-    setSubmitting(true);
-    setFailed(false);
-    try {
-      await onSubmit(value);
-    } catch {
-      setFailed(true);
-    } finally {
-      setSubmitting(false);
-    }
+  const submit = (value: Parameters<typeof onSubmit>[0]) => {
+    if (submitting || !runtimeAvailable) return;
+    onSubmit(value);
   };
 
   useEffect(() => {
     setAnswers({});
-    setFailed(false);
     setPlanFeedback("");
-    setSubmitting(false);
   }, [interactionIdentity]);
 
   return (
@@ -90,7 +85,7 @@ export function MobileInteractionCard({
                         <Pressable
                           accessibilityRole="button"
                           accessibilityState={{ selected: active }}
-                          disabled={submitting}
+                          disabled={submitting || !runtimeAvailable}
                           key={`${question.id}:${option.label}`}
                           onPress={() => {
                             setAnswers((current) => {
@@ -126,7 +121,7 @@ export function MobileInteractionCard({
                   </View>
                 ) : (
                   <TextInput
-                    editable={!submitting}
+                    editable={!submitting && runtimeAvailable}
                     multiline
                     onChangeText={(value) => {
                       setAnswers((current) => {
@@ -151,6 +146,7 @@ export function MobileInteractionCard({
           <PrimaryButton
             disabled={
               submitting ||
+              !runtimeAvailable ||
               questions.some(
                 (question) =>
                   readOwnAnswer(answers, question.id, []).length === 0
@@ -168,7 +164,7 @@ export function MobileInteractionCard({
                   question.multiSelect ? values : (values[0] ?? "")
                 );
               }
-              void submit({
+              submit({
                 action: "submit",
                 payload: {
                   ...buildAskUserAnswerPayload(answersByQuestionId)
@@ -181,20 +177,21 @@ export function MobileInteractionCard({
         <View style={styles.actionList}>
           {options.map((option) => (
             <PrimaryButton
-              disabled={submitting}
+              disabled={submitting || !runtimeAvailable}
               key={option.id}
               label={option.label}
-              onPress={() => void submit({ optionId: option.id })}
+              onPress={() => submit({ optionId: option.id })}
               secondary
             />
           ))}
         </View>
-      ) : prompt?.kind === "exit-plan" ? (
+      ) : prompt?.kind === "exit-plan" && prompt.options.length > 0 ? (
         <MobileExitPlanActions
           feedback={planFeedback}
           onFeedbackChange={setPlanFeedback}
           onSubmit={submit}
           prompt={prompt}
+          runtimeAvailable={runtimeAvailable}
           submitting={submitting}
         />
       ) : (
@@ -211,6 +208,7 @@ function MobileExitPlanActions({
   onFeedbackChange,
   onSubmit,
   prompt,
+  runtimeAvailable,
   submitting
 }: {
   feedback: string;
@@ -219,24 +217,24 @@ function MobileExitPlanActions({
     action?: string;
     optionId?: string;
     payload?: Record<string, unknown>;
-  }): Promise<void>;
+  }): void;
   prompt: Extract<AgentConversationPromptVM, { kind: "exit-plan" }>;
+  runtimeAvailable: boolean;
   submitting: boolean;
 }) {
   const theme = useNativeTheme();
   const styles = createStyles(theme);
-  const modes = prompt.options.length > 0 ? prompt.options : defaultPlanModes();
   const trimmedFeedback = feedback.trim();
 
   return (
     <View style={styles.actionList}>
       <Text style={styles.questionText}>{t("planPermissionQuestion")}</Text>
-      {modes.map((mode) => (
+      {prompt.options.map((mode) => (
         <Pressable
           accessibilityRole="button"
-          disabled={submitting}
+          disabled={submitting || !runtimeAvailable}
           key={mode.id}
-          onPress={() => void onSubmit({ action: "allow", optionId: mode.id })}
+          onPress={() => onSubmit({ action: "allow", optionId: mode.id })}
           style={styles.option}
         >
           <Text style={styles.optionText}>{mode.label}</Text>
@@ -246,7 +244,7 @@ function MobileExitPlanActions({
         </Pressable>
       ))}
       <TextInput
-        editable={!submitting}
+        editable={!submitting && runtimeAvailable}
         multiline
         onChangeText={onFeedbackChange}
         placeholder={t("planFeedbackHint")}
@@ -255,10 +253,10 @@ function MobileExitPlanActions({
         value={feedback}
       />
       <PrimaryButton
-        disabled={submitting}
+        disabled={submitting || !runtimeAvailable}
         label={trimmedFeedback ? t("sendPlanFeedback") : t("keepPlanning")}
         onPress={() =>
-          void onSubmit({
+          onSubmit({
             action: "deny",
             ...(prompt.keepPlanningOptionId
               ? { optionId: prompt.keepPlanningOptionId }
@@ -272,35 +270,6 @@ function MobileExitPlanActions({
       />
     </View>
   );
-}
-
-function defaultPlanModes() {
-  return [
-    {
-      description: t("planAcceptEditsDescription"),
-      id: "acceptEdits",
-      kind: "acceptEdits",
-      label: t("planAcceptEdits")
-    },
-    {
-      description: t("planAskFirstDescription"),
-      id: "default",
-      kind: "default",
-      label: t("planAskFirst")
-    },
-    {
-      description: t("planAllowAllDescription"),
-      id: "bypassPermissions",
-      kind: "bypassPermissions",
-      label: t("planAllowAll")
-    },
-    {
-      description: t("planAutoDescription"),
-      id: "auto",
-      kind: "auto",
-      label: t("planAuto")
-    }
-  ];
 }
 
 function interactionSummary(interaction: AgentActivityInteraction): string {

--- a/apps/mobile/src/components/MobileConversationRows.tsx
+++ b/apps/mobile/src/components/MobileConversationRows.tsx
@@ -17,6 +17,7 @@ import { PrimaryButton } from "./PrimaryButton";
 interface MobileInteractionCardProps {
   failed: boolean;
   interaction: AgentActivityInteraction;
+  onRetry(): void;
   onSubmit(input: {
     action?: string;
     optionId?: string;
@@ -29,6 +30,7 @@ interface MobileInteractionCardProps {
 export function MobileInteractionCard({
   failed,
   interaction,
+  onRetry,
   onSubmit,
   runtimeAvailable,
   submitting
@@ -54,6 +56,29 @@ export function MobileInteractionCard({
     setPlanFeedback("");
   }, [interactionIdentity]);
 
+  if (failed) {
+    return (
+      <View style={styles.interactionCard}>
+        <Text style={styles.interactionKind}>
+          {prompt?.kind === "ask-user"
+            ? t("question")
+            : prompt?.kind === "exit-plan"
+              ? t("plan")
+              : t("approval")}
+        </Text>
+        <Text style={styles.interactionTitle}>
+          {prompt?.title || interactionSummary(interaction)}
+        </Text>
+        <Text style={styles.error}>{t("genericError")}</Text>
+        <PrimaryButton
+          disabled={!runtimeAvailable}
+          label={t("retry")}
+          onPress={onRetry}
+        />
+      </View>
+    );
+  }
+
   return (
     <View style={styles.interactionCard}>
       <Text style={styles.interactionKind}>
@@ -66,8 +91,6 @@ export function MobileInteractionCard({
       <Text style={styles.interactionTitle}>
         {prompt?.title || interactionSummary(interaction)}
       </Text>
-      {failed ? <Text style={styles.error}>{t("genericError")}</Text> : null}
-
       {prompt?.kind === "ask-user" ? (
         <>
           {questions.map((question) => {

--- a/apps/mobile/src/screens/WorkspaceScreenView.tsx
+++ b/apps/mobile/src/screens/WorkspaceScreenView.tsx
@@ -1,6 +1,7 @@
-import type {
-  AgentActivityInteraction,
-  AgentActivitySessionSettings
+import {
+  canonicalInteractionKey,
+  type AgentActivityInteraction,
+  type AgentActivitySessionSettings
 } from "@tutti-os/agent-activity-core";
 import { resolveAgentConversationNavigationAction } from "@tutti-os/agent-gui/conversation-projection";
 import { createAgentConversationFollowEndController } from "@tutti-os/agent-gui/agent-conversation/follow-end";
@@ -322,13 +323,28 @@ export function ConversationWorkspaceView({
                 onLinkPress={openConversationLink}
               />
             )}
-            {model.selectedSession.pendingInteractions.map((interaction) => (
-              <MobileInteractionCard
-                interaction={interaction}
-                key={`${interaction.agentSessionId}:${interaction.turnId}:${interaction.requestId}`}
-                onSubmit={async (input) => onRespond(interaction, input)}
-              />
-            ))}
+            {model.pendingInteractions.map((interaction) => {
+              const interactionKey = canonicalInteractionKey(
+                interaction.agentSessionId,
+                interaction.turnId,
+                interaction.requestId
+              );
+              const state = model.interactionStates[interactionKey] ?? {
+                failed: false,
+                runtimeAvailable: false,
+                submitting: false
+              };
+              return (
+                <MobileInteractionCard
+                  failed={state.failed}
+                  interaction={interaction}
+                  key={interactionKey}
+                  onSubmit={(input) => onRespond(interaction, input)}
+                  runtimeAvailable={state.runtimeAvailable}
+                  submitting={state.submitting}
+                />
+              );
+            })}
           </ScrollView>
           {showScrollToBottom ? (
             <NativeButton

--- a/apps/mobile/src/screens/WorkspaceScreenView.tsx
+++ b/apps/mobile/src/screens/WorkspaceScreenView.tsx
@@ -139,7 +139,7 @@ export function ConversationWorkspaceView({
   onRefreshQuickPrompts(): Promise<void>;
   onRespond(
     interaction: AgentActivityInteraction,
-    input: {
+    input?: {
       action?: string;
       optionId?: string;
       payload?: Readonly<Record<string, unknown>>;
@@ -339,6 +339,7 @@ export function ConversationWorkspaceView({
                   failed={state.failed}
                   interaction={interaction}
                   key={interactionKey}
+                  onRetry={() => onRespond(interaction)}
                   onSubmit={(input) => onRespond(interaction, input)}
                   runtimeAvailable={state.runtimeAvailable}
                   submitting={state.submitting}

--- a/apps/mobile/src/services/mobileAgentActivityMapping.ts
+++ b/apps/mobile/src/services/mobileAgentActivityMapping.ts
@@ -1,0 +1,32 @@
+import type { AgentActivitySession } from "@tutti-os/agent-activity-core";
+import {
+  agentActivitySessionDetailFromTuttid,
+  agentActivitySessionFromTuttidSession,
+  type AgentActivitySessionDetailSnapshot
+} from "@tutti-os/agent-activity-tuttid-adapter";
+
+export interface MobileAgentActivityMapping {
+  mapSession(
+    session: Parameters<typeof agentActivitySessionFromTuttidSession>[1]
+  ): AgentActivitySession;
+  mapSessionDetail(
+    detail: Parameters<typeof agentActivitySessionDetailFromTuttid>[1]
+  ): AgentActivitySessionDetailSnapshot;
+}
+
+export function createMobileAgentActivityMapping(input: {
+  currentUserId: string;
+  workspaceId: string;
+}): MobileAgentActivityMapping {
+  const options = { currentUserId: input.currentUserId };
+  return {
+    mapSession: (session) =>
+      agentActivitySessionFromTuttidSession(
+        input.workspaceId,
+        session,
+        options
+      ),
+    mapSessionDetail: (detail) =>
+      agentActivitySessionDetailFromTuttid(input.workspaceId, detail, options)
+  };
+}

--- a/apps/mobile/src/services/mobileAgentActivityMapping.ts
+++ b/apps/mobile/src/services/mobileAgentActivityMapping.ts
@@ -10,7 +10,8 @@ export interface MobileAgentActivityMapping {
     session: Parameters<typeof agentActivitySessionFromTuttidSession>[1]
   ): AgentActivitySession;
   mapSessionDetail(
-    detail: Parameters<typeof agentActivitySessionDetailFromTuttid>[1]
+    expectedAgentSessionId: string,
+    detail: Parameters<typeof agentActivitySessionDetailFromTuttid>[2]
   ): AgentActivitySessionDetailSnapshot;
 }
 
@@ -26,7 +27,12 @@ export function createMobileAgentActivityMapping(input: {
         session,
         options
       ),
-    mapSessionDetail: (detail) =>
-      agentActivitySessionDetailFromTuttid(input.workspaceId, detail, options)
+    mapSessionDetail: (expectedAgentSessionId, detail) =>
+      agentActivitySessionDetailFromTuttid(
+        input.workspaceId,
+        expectedAgentSessionId,
+        detail,
+        options
+      )
   };
 }

--- a/apps/mobile/src/services/pendingSubmission.test.ts
+++ b/apps/mobile/src/services/pendingSubmission.test.ts
@@ -1,4 +1,9 @@
-import { resolvePendingSubmission } from "./pendingSubmission";
+import type { AgentSessionEngine } from "@tutti-os/agent-activity-core";
+import {
+  dismissPendingSubmission,
+  resolvePendingSubmission,
+  type PendingSubmission
+} from "./pendingSubmission";
 
 describe("resolvePendingSubmission", () => {
   it("reuses the exact identity when retrying an existing session submission", () => {
@@ -72,5 +77,42 @@ describe("resolvePendingSubmission", () => {
 
     expect(otherSession).not.toBe(first);
     expect(otherSession.agentSessionId).toBe("session-2");
+  });
+});
+
+describe("dismissPendingSubmission", () => {
+  it.each([
+    [
+      false,
+      {
+        clientSubmitId: "submit-1",
+        type: "submit/dismissed"
+      }
+    ],
+    [
+      true,
+      {
+        requestId: "submit-1",
+        type: "activation/dismissed"
+      }
+    ]
+  ])("dispatches the exact creating=%s dismissal", (creating, expected) => {
+    const intents: unknown[] = [];
+    const engine = {
+      dispatch(intent: unknown) {
+        intents.push(intent);
+      }
+    } as AgentSessionEngine;
+    const submission: PendingSubmission = {
+      agentSessionId: "session-1",
+      agentTargetId: creating ? "target-1" : null,
+      clientSubmitId: "submit-1",
+      creating,
+      text: "hello"
+    };
+
+    dismissPendingSubmission(engine, submission);
+
+    expect(intents).toEqual([expected]);
   });
 });

--- a/apps/mobile/src/services/pendingSubmission.ts
+++ b/apps/mobile/src/services/pendingSubmission.ts
@@ -35,6 +35,23 @@ export function resolvePendingSubmission(
   };
 }
 
+export function dismissPendingSubmission(
+  engine: AgentSessionEngine,
+  submission: PendingSubmission
+): void {
+  engine.dispatch(
+    submission.creating
+      ? {
+          requestId: submission.clientSubmitId,
+          type: "activation/dismissed"
+        }
+      : {
+          clientSubmitId: submission.clientSubmitId,
+          type: "submit/dismissed"
+        }
+  );
+}
+
 function createEntityId(): string {
   if (typeof globalThis.crypto?.randomUUID === "function") {
     return globalThis.crypto.randomUUID();
@@ -42,3 +59,4 @@ function createEntityId(): string {
   const fallbackHex = Math.random().toString(16).slice(2).padEnd(12, "0");
   return `00000000-0000-4000-8000-${fallbackHex.slice(0, 12)}`;
 }
+import type { AgentSessionEngine } from "@tutti-os/agent-activity-core";

--- a/apps/mobile/src/services/workspaceActivityCommandAdapter.test.ts
+++ b/apps/mobile/src/services/workspaceActivityCommandAdapter.test.ts
@@ -1,0 +1,145 @@
+import type {
+  AgentActivitySession,
+  AgentSessionEngine,
+  PromptQueueSendCommand,
+  SessionActivateCommand
+} from "@tutti-os/agent-activity-core";
+import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
+import { executeWorkspaceActivityCommand } from "./workspaceActivityCommandAdapter";
+
+describe("executeWorkspaceActivityCommand", () => {
+  test("applies required settings before sending every prompt semantic", async () => {
+    const operations: string[] = [];
+    const requests: Record<string, unknown>[] = [];
+    const sendFailure = new Error("stop after request capture");
+    const client = {
+      async updateWorkspaceAgentSessionSettings(
+        _workspaceId: string,
+        _agentSessionId: string,
+        settings: Record<string, unknown>
+      ) {
+        operations.push("settings");
+        requests.push(settings);
+        return {};
+      },
+      async sendWorkspaceAgentSessionInput(
+        _workspaceId: string,
+        _agentSessionId: string,
+        request: Record<string, unknown>
+      ) {
+        operations.push("send");
+        requests.push(request);
+        throw sendFailure;
+      }
+    } as unknown as TuttidClient;
+    const command: PromptQueueSendCommand = {
+      agentSessionId: "session-1",
+      capabilityRefs: [{ capability: "tutti", source: "slash_command" }],
+      clientSubmitId: "submit-1",
+      commandId: "command-1",
+      content: [{ text: "hello", type: "text" }],
+      displayPrompt: "/computer hello",
+      guidance: true,
+      promptId: "prompt-1",
+      requiredSettingsPatch: { computerUse: true },
+      submitDiagnostics: {
+        blockCount: 1,
+        source: "mobile-test",
+        submittedAtUnixMs: 10
+      },
+      type: "queue/sendPrompt",
+      workspaceId: "workspace-1"
+    };
+
+    await expect(
+      executeWorkspaceActivityCommand(
+        {
+          client,
+          engine: {} as AgentSessionEngine,
+          loadComposerOptions() {},
+          mapSession(): AgentActivitySession {
+            throw new Error("unexpected Session mapping");
+          },
+          mapSessionDetail() {
+            throw new Error("unexpected detail mapping");
+          },
+          async reconcileSession() {},
+          async reconcileWorkspace() {}
+        },
+        command
+      )
+    ).rejects.toBe(sendFailure);
+
+    expect(operations).toEqual(["settings", "send"]);
+    expect(requests).toEqual([
+      { computerUse: true },
+      {
+        capabilityRefs: [{ capability: "tutti", source: "slash_command" }],
+        clientSubmitId: "submit-1",
+        content: [{ text: "hello", type: "text" }],
+        displayPrompt: "/computer hello",
+        guidance: true,
+        submitDiagnostics: {
+          blockCount: 1,
+          source: "mobile-test",
+          submittedAtUnixMs: 10
+        }
+      }
+    ]);
+  });
+
+  test("does not invent computerUse on the generated create contract", async () => {
+    let createRequest: Record<string, unknown> | null = null;
+    const stopAfterCapture = new Error("stop after create request capture");
+    const client = {
+      async createWorkspaceAgentSession(
+        _workspaceId: string,
+        request: Record<string, unknown>
+      ) {
+        createRequest = request;
+        throw stopAfterCapture;
+      }
+    } as unknown as TuttidClient;
+    const command: SessionActivateCommand = {
+      agentSessionId: "session-1",
+      agentTargetId: "target-1",
+      clientSubmitId: "submit-1",
+      commandId: "command-1",
+      correlationId: "request-1",
+      initialContent: [{ text: "hello", type: "text" }],
+      mode: "new",
+      settings: { computerUse: false },
+      type: "session/activate",
+      visible: true,
+      workspaceId: "workspace-1"
+    };
+
+    await expect(
+      executeWorkspaceActivityCommand(
+        {
+          client,
+          engine: {} as AgentSessionEngine,
+          loadComposerOptions() {},
+          mapSession(): AgentActivitySession {
+            throw new Error("unexpected Session mapping");
+          },
+          mapSessionDetail() {
+            throw new Error("unexpected detail mapping");
+          },
+          async reconcileSession() {},
+          async reconcileWorkspace() {}
+        },
+        command
+      )
+    ).rejects.toBe(stopAfterCapture);
+
+    expect(createRequest).toEqual(
+      expect.objectContaining({
+        agentSessionId: "session-1",
+        agentTargetId: "target-1",
+        clientSubmitId: "submit-1"
+      })
+    );
+    expect(createRequest).not.toHaveProperty("computerUse");
+  });
+});

--- a/apps/mobile/src/services/workspaceActivityCommandAdapter.ts
+++ b/apps/mobile/src/services/workspaceActivityCommandAdapter.ts
@@ -1,14 +1,16 @@
 import type {
+  AgentActivitySendInput,
   AgentActivitySession,
   AgentSessionEngine,
   EngineExternalCommand,
-  PromptQueueSendCommand,
   SessionActivateCommand
 } from "@tutti-os/agent-activity-core";
+import { executeAgentActivityPromptCommand } from "@tutti-os/agent-activity-core";
 import {
   agentActivityComposerOptionsFromTuttidResult,
   agentActivitySessionFromTuttidSession,
-  agentActivityTurnFromTuttidTurn
+  agentActivityTurnFromTuttidTurn,
+  type AgentActivitySessionDetailSnapshot
 } from "@tutti-os/agent-activity-tuttid-adapter";
 import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
 import { mobileLocale } from "../i18n";
@@ -21,7 +23,16 @@ interface WorkspaceActivityCommandContext {
   mapSession(
     session: Parameters<typeof agentActivitySessionFromTuttidSession>[1]
   ): AgentActivitySession;
-  reconcileSession(agentSessionId: string): Promise<unknown>;
+  mapSessionDetail(
+    detail: Awaited<ReturnType<TuttidClient["getWorkspaceAgentSession"]>>
+  ): AgentActivitySessionDetailSnapshot;
+  reconcileSession(
+    agentSessionId: string,
+    scope: Extract<
+      EngineExternalCommand,
+      { type: "session/reconcile" }
+    >["scope"]
+  ): Promise<unknown>;
   reconcileWorkspace(): Promise<unknown>;
 }
 
@@ -38,7 +49,18 @@ export function executeWorkspaceActivityCommand(
     case "session/activate":
       return activateSession(context, command, signal);
     case "queue/sendPrompt":
-      return sendPrompt(context, command);
+      return executeAgentActivityPromptCommand(
+        {
+          sendInput: (input) => sendPrompt(context, input),
+          updateSessionSettings: (input) =>
+            context.client.updateWorkspaceAgentSessionSettings(
+              input.workspaceId,
+              input.agentSessionId,
+              input.settings
+            )
+        },
+        command
+      );
     case "turn/cancel":
       return context.client
         .cancelWorkspaceAgentTurn(
@@ -67,7 +89,7 @@ export function executeWorkspaceActivityCommand(
         )
         .then((session) => ({ session: context.mapSession(session) }));
     case "session/reconcile":
-      return context.reconcileSession(command.agentSessionId);
+      return context.reconcileSession(command.agentSessionId, command.scope);
     case "composerOptions/load":
       return context.client
         .getAgentProviderComposerOptions(
@@ -130,11 +152,23 @@ export function executeWorkspaceActivityCommand(
           removedSessionIds: response.removedSessionIds,
           removedSessions: response.removedSessions
         }));
-    default:
+    case "attention/readState/read":
+    case "attention/readState/write":
+    case "plan/submitDecision":
+    case "session/unactivate":
+    case "tuttiMode/update":
       return Promise.reject(
         new Error(`unsupported mobile agent command: ${command.type}`)
       );
+    default:
+      return assertNeverEngineCommand(command);
   }
+}
+
+function assertNeverEngineCommand(command: never): never {
+  throw new Error(
+    `unhandled mobile agent command: ${(command as { type?: unknown }).type}`
+  );
 }
 
 async function activateSession(
@@ -148,11 +182,15 @@ async function activateSession(
       command.workspaceId,
       command.agentSessionId
     );
-    const session = context.mapSession(detail.session);
-    context.engine.dispatch({ session, type: "session/upserted" });
+    const mapped = context.mapSessionDetail(detail);
+    context.engine.dispatch({
+      ...mapped,
+      type: "session/detailSnapshotReceived",
+      workspaceId: command.workspaceId
+    });
     return {
       activation: { mode: "existing", status: "already_attached" },
-      session
+      session: mapped.session
     };
   }
   const session = await context.client.createWorkspaceAgentSession(
@@ -178,9 +216,6 @@ async function activateSession(
       ...(typeof command.settings?.browserUse === "boolean"
         ? { browserUse: command.settings.browserUse }
         : {}),
-      ...(typeof command.settings?.computerUse === "boolean"
-        ? { computerUse: command.settings.computerUse }
-        : {}),
       submitDiagnostics: command.submitDiagnostics,
       title: command.title ?? null,
       visible: command.visible ?? true
@@ -200,17 +235,24 @@ async function activateSession(
 
 async function sendPrompt(
   context: WorkspaceActivityCommandContext,
-  command: PromptQueueSendCommand
+  input: AgentActivitySendInput
 ): Promise<unknown> {
   const result = await context.client.sendWorkspaceAgentSessionInput(
-    command.workspaceId,
-    command.agentSessionId,
+    input.workspaceId,
+    input.agentSessionId,
     {
-      clientSubmitId: command.clientSubmitId,
-      content: toTuttidPromptContent(command.content),
-      displayPrompt: command.displayPrompt ?? null,
-      guidance: command.guidance ?? false,
-      submitDiagnostics: command.submitDiagnostics
+      ...(input.capabilityRefs?.length
+        ? {
+            capabilityRefs: input.capabilityRefs.map((reference) => ({
+              ...reference
+            }))
+          }
+        : {}),
+      clientSubmitId: input.clientSubmitId,
+      content: toTuttidPromptContent(input.content),
+      displayPrompt: input.displayPrompt ?? null,
+      guidance: input.guidance ?? false,
+      submitDiagnostics: input.submitDiagnostics
     }
   );
   if (result.kind === "goalControl") {

--- a/apps/mobile/src/services/workspaceActivityCommandAdapter.ts
+++ b/apps/mobile/src/services/workspaceActivityCommandAdapter.ts
@@ -24,6 +24,7 @@ interface WorkspaceActivityCommandContext {
     session: Parameters<typeof agentActivitySessionFromTuttidSession>[1]
   ): AgentActivitySession;
   mapSessionDetail(
+    expectedAgentSessionId: string,
     detail: Awaited<ReturnType<TuttidClient["getWorkspaceAgentSession"]>>
   ): AgentActivitySessionDetailSnapshot;
   reconcileSession(
@@ -182,7 +183,7 @@ async function activateSession(
       command.workspaceId,
       command.agentSessionId
     );
-    const mapped = context.mapSessionDetail(detail);
+    const mapped = context.mapSessionDetail(command.agentSessionId, detail);
     context.engine.dispatch({
       ...mapped,
       type: "session/detailSnapshotReceived",

--- a/apps/mobile/src/services/workspaceActivityInteractionCommand.ts
+++ b/apps/mobile/src/services/workspaceActivityInteractionCommand.ts
@@ -1,0 +1,45 @@
+import {
+  canonicalInteractionKey,
+  type AgentActivityInteraction,
+  type AgentSessionEngine
+} from "@tutti-os/agent-activity-core";
+import type { WorkspaceActivitySnapshot } from "./workspaceActivityTypes";
+
+type InteractionResponseInput = {
+  action?: string;
+  optionId?: string;
+  payload?: Readonly<Record<string, unknown>>;
+};
+
+export function requestWorkspaceActivityInteractionResponse(input: {
+  commandId: string;
+  engine: AgentSessionEngine;
+  interaction: AgentActivityInteraction;
+  response: InteractionResponseInput;
+  states: WorkspaceActivitySnapshot["interactionStates"];
+  timeoutMs: number;
+  workspaceId: string;
+}): boolean {
+  const interaction = input.interaction;
+  const state =
+    input.states[
+      canonicalInteractionKey(
+        interaction.agentSessionId,
+        interaction.turnId,
+        interaction.requestId
+      )
+    ];
+  if (!state || state.submitting || !state.runtimeAvailable) return false;
+  input.engine.dispatch({
+    ...input.response,
+    agentSessionId: interaction.agentSessionId,
+    commandId: input.commandId,
+    requestId: interaction.requestId,
+    retry: false,
+    timeoutMs: input.timeoutMs,
+    turnId: interaction.turnId,
+    type: "interaction/responseRequested",
+    workspaceId: input.workspaceId
+  });
+  return true;
+}

--- a/apps/mobile/src/services/workspaceActivityInteractionCommand.ts
+++ b/apps/mobile/src/services/workspaceActivityInteractionCommand.ts
@@ -1,5 +1,6 @@
 import {
   canonicalInteractionKey,
+  selectEngineInteractionResponse,
   type AgentActivityInteraction,
   type AgentSessionEngine
 } from "@tutti-os/agent-activity-core";
@@ -15,7 +16,7 @@ export function requestWorkspaceActivityInteractionResponse(input: {
   commandId: string;
   engine: AgentSessionEngine;
   interaction: AgentActivityInteraction;
-  response: InteractionResponseInput;
+  response?: InteractionResponseInput;
   states: WorkspaceActivitySnapshot["interactionStates"];
   timeoutMs: number;
   workspaceId: string;
@@ -30,12 +31,34 @@ export function requestWorkspaceActivityInteractionResponse(input: {
       )
     ];
   if (!state || state.submitting || !state.runtimeAvailable) return false;
+  const previousResponse = selectEngineInteractionResponse(
+    input.engine.getSnapshot(),
+    interaction.agentSessionId,
+    interaction.turnId,
+    interaction.requestId
+  );
+  const response = state.failed
+    ? previousResponse?.status === "failed"
+      ? {
+          ...(previousResponse.action
+            ? { action: previousResponse.action }
+            : {}),
+          ...(previousResponse.optionId
+            ? { optionId: previousResponse.optionId }
+            : {}),
+          ...(previousResponse.payload
+            ? { payload: { ...previousResponse.payload } }
+            : {})
+        }
+      : null
+    : (input.response ?? null);
+  if (!response) return false;
   input.engine.dispatch({
-    ...input.response,
+    ...response,
     agentSessionId: interaction.agentSessionId,
     commandId: input.commandId,
     requestId: interaction.requestId,
-    retry: false,
+    retry: state.failed,
     timeoutMs: input.timeoutMs,
     turnId: interaction.turnId,
     type: "interaction/responseRequested",

--- a/apps/mobile/src/services/workspaceActivityMessagePageLoader.test.ts
+++ b/apps/mobile/src/services/workspaceActivityMessagePageLoader.test.ts
@@ -1,0 +1,210 @@
+import {
+  AGENT_SESSION_ENGINE_LOCAL_ORIGIN,
+  createAgentSessionEngine,
+  selectSessionMessages
+} from "@tutti-os/agent-activity-core";
+import type {
+  TuttidClient,
+  WorkspaceAgentSessionMessage,
+  WorkspaceAgentSessionMessagesResponse
+} from "@tutti-os/client-tuttid-ts";
+import { WorkspaceActivityMessagePageLoader } from "./workspaceActivityMessagePageLoader";
+
+describe("WorkspaceActivityMessagePageLoader", () => {
+  test("deduplicates only the exact query while allowing a different page to run", async () => {
+    const requests: Array<{
+      deferred: Deferred<WorkspaceAgentSessionMessagesResponse>;
+      query: Record<string, unknown>;
+    }> = [];
+    const harness = createHarness({
+      listMessages: async (_workspaceId, _agentSessionId, query) => {
+        const request = {
+          deferred: deferred<WorkspaceAgentSessionMessagesResponse>(),
+          query
+        };
+        requests.push(request);
+        return request.deferred.promise;
+      }
+    });
+
+    const newestA = harness.loader.loadPage("session-1", {
+      limit: 100,
+      order: "desc"
+    });
+    const newestB = harness.loader.loadPage("session-1", {
+      limit: 100,
+      order: "desc"
+    });
+    const older = harness.loader.loadPage("session-1", {
+      beforeVersion: 5,
+      limit: 100,
+      order: "desc"
+    });
+
+    expect(newestA).toBe(newestB);
+    expect(requests.map((request) => request.query)).toEqual([
+      { limit: 100, order: "desc" },
+      { beforeVersion: 5, limit: 100, order: "desc" }
+    ]);
+
+    requests[0]!.deferred.resolve(messagePage("message-5", 5));
+    requests[1]!.deferred.resolve(messagePage("message-2", 2));
+    await Promise.all([newestA, older]);
+
+    expect(
+      selectSessionMessages(harness.engine.getSnapshot(), "session-1").map(
+        (message) => message.version
+      )
+    ).toEqual([2, 5]);
+    expect(harness.appliedSessionIds).toEqual(["session-1", "session-1"]);
+    expect(harness.settledCount()).toBe(2);
+    harness.engine.dispose();
+  });
+
+  test("drops a late page when the host becomes unavailable", async () => {
+    const request = deferred<WorkspaceAgentSessionMessagesResponse>();
+    let available = true;
+    const harness = createHarness({
+      isAvailable: () => available,
+      listMessages: async () => request.promise
+    });
+
+    const load = harness.loader.loadPage("session-1", {
+      limit: 100,
+      order: "desc"
+    });
+    available = false;
+    request.resolve(messagePage("message-5", 5));
+    await load;
+
+    expect(
+      selectSessionMessages(harness.engine.getSnapshot(), "session-1")
+    ).toEqual([]);
+    expect(harness.appliedSessionIds).toEqual([]);
+    expect(harness.failedErrors).toEqual([]);
+    expect(harness.settledCount()).toBe(1);
+    harness.engine.dispose();
+  });
+
+  test("clears a failed request so the exact query can be retried", async () => {
+    const failure = new Error("message page unavailable");
+    let attempts = 0;
+    const harness = createHarness({
+      listMessages: async () => {
+        attempts += 1;
+        if (attempts === 1) throw failure;
+        return messagePage("message-7", 7);
+      }
+    });
+    const query = { afterVersion: 5, order: "asc" as const };
+
+    await expect(harness.loader.loadPage("session-1", query)).rejects.toBe(
+      failure
+    );
+    await harness.loader.loadPage("session-1", query);
+
+    expect(attempts).toBe(2);
+    expect(harness.failedErrors).toEqual([failure]);
+    expect(harness.settledCount()).toBe(2);
+    expect(
+      selectSessionMessages(harness.engine.getSnapshot(), "session-1").map(
+        (message) => message.version
+      )
+    ).toEqual([7]);
+    harness.engine.dispose();
+  });
+});
+
+function createHarness(input: {
+  isAvailable?: () => boolean;
+  listMessages(
+    workspaceId: string,
+    agentSessionId: string,
+    query: Record<string, unknown>
+  ): Promise<WorkspaceAgentSessionMessagesResponse>;
+}) {
+  const engine = createAgentSessionEngine({
+    clock: { nowUnixMs: () => 1 },
+    commandPort: { execute: async () => ({}) },
+    identity: {
+      origin: AGENT_SESSION_ENGINE_LOCAL_ORIGIN,
+      workspaceId: "workspace-1"
+    },
+    scheduler: {
+      schedule: () => ({ cancel: () => undefined })
+    }
+  });
+  const appliedSessionIds: string[] = [];
+  const failedErrors: unknown[] = [];
+  let settled = 0;
+  const client = {
+    listWorkspaceAgentSessionMessages: input.listMessages
+  } as Pick<TuttidClient, "listWorkspaceAgentSessionMessages">;
+  const loader = new WorkspaceActivityMessagePageLoader({
+    client,
+    engine,
+    isAvailable: input.isAvailable ?? (() => true),
+    onPageApplied: (agentSessionId) => {
+      appliedSessionIds.push(agentSessionId);
+    },
+    onRequestFailed: (error) => {
+      failedErrors.push(error);
+    },
+    onRequestSettled: () => {
+      settled += 1;
+    },
+    workspaceId: "workspace-1"
+  });
+  return {
+    appliedSessionIds,
+    engine,
+    failedErrors,
+    loader,
+    settledCount: () => settled
+  };
+}
+
+function messagePage(
+  messageId: string,
+  version: number
+): WorkspaceAgentSessionMessagesResponse {
+  return {
+    agentSessionId: "session-1",
+    hasMore: false,
+    latestVersion: version,
+    messages: [message(messageId, version)]
+  };
+}
+
+function message(
+  messageId: string,
+  version: number
+): WorkspaceAgentSessionMessage {
+  return {
+    agentSessionId: "session-1",
+    kind: "text",
+    messageId,
+    occurredAtUnixMs: version,
+    payload: { text: messageId },
+    role: "assistant",
+    sequence: version,
+    turnId: "turn-1",
+    version
+  };
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  reject(error: unknown): void;
+  resolve(value: T): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let reject!: (error: unknown) => void;
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}

--- a/apps/mobile/src/services/workspaceActivityMessagePageLoader.ts
+++ b/apps/mobile/src/services/workspaceActivityMessagePageLoader.ts
@@ -1,0 +1,106 @@
+import {
+  agentActivitySessionMessageWindowFromDescendingPage,
+  type AgentSessionEngine
+} from "@tutti-os/agent-activity-core";
+import { agentActivityMessageFromTuttidMessage } from "@tutti-os/agent-activity-tuttid-adapter";
+import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
+
+export interface WorkspaceActivityMessagePageQuery {
+  afterVersion?: number;
+  beforeVersion?: number;
+  limit?: number;
+  order: "asc" | "desc";
+}
+
+interface WorkspaceActivityMessagePageLoaderDependencies {
+  client: Pick<TuttidClient, "listWorkspaceAgentSessionMessages">;
+  engine: AgentSessionEngine;
+  isAvailable(): boolean;
+  onPageApplied(agentSessionId: string): void;
+  onRequestFailed(error: unknown): void;
+  onRequestSettled(): void;
+  workspaceId: string;
+}
+
+/**
+ * Owns transport-page concurrency and canonical Engine application for Mobile
+ * message reads. Polling cadence and authoritative-vs-incremental selection
+ * remain WorkspaceActivityService lifecycle decisions.
+ */
+export class WorkspaceActivityMessagePageLoader {
+  private readonly requestsInFlightByKey = new Map<string, Promise<void>>();
+
+  constructor(
+    private readonly dependencies: WorkspaceActivityMessagePageLoaderDependencies
+  ) {}
+
+  loadPage(
+    agentSessionId: string,
+    query: WorkspaceActivityMessagePageQuery
+  ): Promise<void> {
+    if (!this.dependencies.isAvailable()) return Promise.resolve();
+    const requestKey = messageRequestKey(agentSessionId, query);
+    const existing = this.requestsInFlightByKey.get(requestKey);
+    if (existing) return existing;
+
+    const request = this.dependencies.client
+      .listWorkspaceAgentSessionMessages(
+        this.dependencies.workspaceId,
+        agentSessionId,
+        query
+      )
+      .then((page) => {
+        if (!this.dependencies.isAvailable()) return;
+        const messages = page.messages.map((message) =>
+          agentActivityMessageFromTuttidMessage(
+            this.dependencies.workspaceId,
+            message
+          )
+        );
+        this.dependencies.engine.dispatch({
+          messages,
+          ...(query.order === "desc"
+            ? {
+                sessionMessageWindows: [
+                  {
+                    agentSessionId,
+                    ...agentActivitySessionMessageWindowFromDescendingPage({
+                      ...page,
+                      messages
+                    })
+                  }
+                ]
+              }
+            : {}),
+          type: "message/snapshotReceived",
+          workspaceId: this.dependencies.workspaceId
+        });
+        this.dependencies.onPageApplied(agentSessionId);
+      })
+      .catch((error: unknown) => {
+        this.dependencies.onRequestFailed(error);
+        throw error;
+      })
+      .finally(() => {
+        if (this.requestsInFlightByKey.get(requestKey) === request) {
+          this.requestsInFlightByKey.delete(requestKey);
+        }
+        this.dependencies.onRequestSettled();
+      });
+    this.requestsInFlightByKey.set(requestKey, request);
+    return request;
+  }
+}
+
+function messageRequestKey(
+  agentSessionId: string,
+  query: WorkspaceActivityMessagePageQuery
+): string {
+  return JSON.stringify([
+    agentSessionId,
+    query.order,
+    query.afterVersion ?? null,
+    query.beforeVersion ?? null,
+    query.limit ?? null
+  ]);
+}

--- a/apps/mobile/src/services/workspaceActivityProjection.ts
+++ b/apps/mobile/src/services/workspaceActivityProjection.ts
@@ -1,11 +1,15 @@
 import {
+  canonicalInteractionKey,
   selectRootAgentActivitySessions,
   selectRootAgentSessionIdsWithPendingInteractions,
   selectEngineTurnsForSession,
+  selectEngineInteractionResponse,
+  selectEngineSessionRuntimeAvailability,
   selectComposerOptions,
   selectComposerOptionsLoadStatus,
   type AgentActivitySessionSettings,
   selectSessionMutations,
+  selectWorkspaceAgentRootConversationSessions,
   type AgentActivitySnapshot,
   type AgentSessionEngine
 } from "@tutti-os/agent-activity-core";
@@ -109,6 +113,39 @@ export function projectWorkspaceActivitySnapshot({
     sessions.find(
       (session) => session.agentSessionId === navigation.selectedAgentSessionId
     ) ?? null;
+  const selectedConversation =
+    selectWorkspaceAgentRootConversationSessions(state).find(
+      (consumer) =>
+        consumer.session.agentSessionId === navigation.selectedAgentSessionId
+    ) ?? null;
+  const pendingInteractions = selectedConversation?.pendingInteractions ?? [];
+  const interactionStates = Object.fromEntries(
+    pendingInteractions.map((interaction) => {
+      const response = selectEngineInteractionResponse(
+        state,
+        interaction.agentSessionId,
+        interaction.turnId,
+        interaction.requestId
+      );
+      const runtimeAvailability = selectEngineSessionRuntimeAvailability(
+        state,
+        interaction.agentSessionId
+      );
+      return [
+        canonicalInteractionKey(
+          interaction.agentSessionId,
+          interaction.turnId,
+          interaction.requestId
+        ),
+        {
+          failed: response?.status === "failed",
+          runtimeAvailable: runtimeAvailability?.state !== "blocked",
+          submitting:
+            response?.status === "responding" || response?.status === "unknown"
+        }
+      ];
+    })
+  );
   const sending =
     Object.values(state.pendingIntents.submitsByClientSubmitId).some(
       (record) =>
@@ -182,6 +219,15 @@ export function projectWorkspaceActivitySnapshot({
       workspaceId
     }
   );
+  const selectedRuntimeAvailability = selectEngineSessionRuntimeAvailability(
+    state,
+    navigation.selectedAgentSessionId
+  );
+  const commandsAvailable = navigation.creating
+    ? state.engineRuntime.connection === "connected"
+    : Boolean(
+        selectedSession && selectedRuntimeAvailability?.state !== "blocked"
+      );
 
   return {
     activity,
@@ -190,11 +236,14 @@ export function projectWorkspaceActivitySnapshot({
     composerOptionsLoadStatus,
     composerSettings,
     composerSettingsSupport,
+    commandsAvailable,
     conversation,
     creating: navigation.creating,
     draft,
     errorCode: errorCode ?? rail.errorCode,
+    interactionStates,
     loading,
+    pendingInteractions,
     pinningSessionIds,
     railErrorCode: rail.errorCode,
     railSections: projectWorkspaceConversationRail({

--- a/apps/mobile/src/services/workspaceActivityService.test.ts
+++ b/apps/mobile/src/services/workspaceActivityService.test.ts
@@ -328,6 +328,69 @@ describe("WorkspaceActivityService", () => {
     service.dispose();
   });
 
+  test("retries a failed Interaction with the exact Engine-owned response", async () => {
+    const interaction = createInteraction();
+    const requests: Record<string, unknown>[] = [];
+    let attempt = 0;
+    const turn: WorkspaceAgentTurn = {
+      ...createTurn("session-1", interaction.turnId),
+      phase: "waiting",
+      settledAtUnixMs: null
+    };
+    const session = {
+      ...createSession(),
+      activeTurn: turn,
+      activeTurnId: turn.turnId,
+      latestTurn: turn,
+      latestTurnInteractions: [interaction],
+      pendingInteractions: [interaction]
+    };
+    const client = createClient({
+      interactive: async (_workspaceId, _agentSessionId, _requestId, input) => {
+        requests.push(input);
+        attempt += 1;
+        if (attempt === 1) throw new Error("temporary failure");
+        return session;
+      },
+      listMessages: emptyMessagePage,
+      session: () => session
+    });
+    const service = createService(client);
+
+    await service.start();
+    await flushAsyncWork();
+    service.respondToInteraction(interaction, { optionId: "allow-once" });
+    await flushAsyncWork();
+
+    const interactionKey = canonicalInteractionKey(
+      interaction.agentSessionId,
+      interaction.turnId,
+      interaction.requestId
+    );
+    expect(
+      service.getSnapshot().interactionStates[interactionKey]?.failed
+    ).toBe(true);
+
+    service.respondToInteraction(interaction);
+    await flushAsyncWork();
+
+    expect(requests).toEqual([
+      {
+        action: null,
+        optionId: "allow-once",
+        payload: null,
+        turnId: interaction.turnId
+      },
+      {
+        action: null,
+        optionId: "allow-once",
+        payload: null,
+        turnId: interaction.turnId
+      }
+    ]);
+    service.dispose();
+  });
+
   test("fails closed when a response does not match a canonical pending Interaction", async () => {
     let interactiveCalls = 0;
     const client = createClient({
@@ -573,6 +636,118 @@ describe("WorkspaceActivityService", () => {
     service.dispose();
   });
 
+  test("runs an authoritative live reconcile while an older page is in flight", async () => {
+    let liveListener: ((delivery: AgentLiveDelivery) => void) | null = null;
+    let resolveOlder: ((value: ReturnType<typeof messagePage>) => void) | null =
+      null;
+    const queries: Array<Record<string, unknown>> = [];
+    const client = createClient({
+      detail: async () => ({
+        childSessions: [],
+        session: createSession(),
+        turns: []
+      }),
+      listMessages: async (_workspaceId, agentSessionId, query) => {
+        queries.push(query);
+        if ("beforeVersion" in query) {
+          return new Promise((resolve) => {
+            resolveOlder = resolve;
+          });
+        }
+        const version = queries.length === 1 ? 5 : 6;
+        return {
+          ...messagePage(agentSessionId, `message-${version}`, version),
+          hasMore: version === 5
+        };
+      }
+    });
+    const service = createService(client, {
+      deviceLink: createLiveDeviceLink((listener) => {
+        liveListener = listener;
+      })
+    });
+
+    await service.start();
+    await flushAsyncWork();
+    const older = service.loadOlderMessages();
+    await flushAsyncWork();
+    liveListener!(sessionDiscontinuity());
+    await flushAsyncWork();
+
+    expect(queries).toEqual([
+      { limit: 100, order: "desc" },
+      { beforeVersion: 5, limit: 100, order: "desc" },
+      { limit: 100, order: "desc" }
+    ]);
+    expect(
+      service
+        .getSnapshot()
+        .activity.sessionMessagesById["session-1"]?.some(
+          (message) => message.version === 6
+        )
+    ).toBe(true);
+
+    resolveOlder!(messagePage("session-1", "message-1", 1));
+    await older;
+    service.dispose();
+  });
+
+  test("runs an authoritative live reconcile while incremental polling is in flight", async () => {
+    const clock = new RecordingClock();
+    let liveListener: ((delivery: AgentLiveDelivery) => void) | null = null;
+    let resolveIncremental:
+      | ((value: ReturnType<typeof messagePage>) => void)
+      | null = null;
+    const queries: Array<Record<string, unknown>> = [];
+    const client = createClient({
+      detail: async () => ({
+        childSessions: [],
+        session: createSession(),
+        turns: []
+      }),
+      listMessages: async (_workspaceId, agentSessionId, query) => {
+        queries.push(query);
+        if ("afterVersion" in query) {
+          return new Promise((resolve) => {
+            resolveIncremental = resolve;
+          });
+        }
+        const version = queries.length === 1 ? 5 : 7;
+        return messagePage(agentSessionId, `message-${version}`, version);
+      }
+    });
+    const service = createService(client, {
+      clock,
+      deviceLink: createLiveDeviceLink((listener) => {
+        liveListener = listener;
+      })
+    });
+
+    await service.start();
+    await flushAsyncWork();
+    clock.runNext(1_000);
+    await flushAsyncWork();
+    liveListener!(sessionDiscontinuity());
+    await flushAsyncWork();
+
+    expect(queries).toEqual([
+      { limit: 100, order: "desc" },
+      { afterVersion: 5, order: "asc" },
+      { limit: 100, order: "desc" }
+    ]);
+    expect(
+      service
+        .getSnapshot()
+        .activity.sessionMessagesById["session-1"]?.some(
+          (message) => message.version === 7
+        )
+    ).toBe(true);
+
+    resolveIncremental!(messagePage("session-1", "message-6", 6));
+    await flushAsyncWork();
+    service.dispose();
+  });
+
   test("loads a newly selected Session without waiting for the previous Session request", async () => {
     let resolveFirst: ((value: ReturnType<typeof messagePage>) => void) | null =
       null;
@@ -611,15 +786,30 @@ describe("WorkspaceActivityService", () => {
   test("reconciles one authoritative detail aggregate with child Sessions", async () => {
     let liveListener: ((delivery: AgentLiveDelivery) => void) | null = null;
     const root = createSession();
-    const child = createChildSession(root.id);
+    const childInteraction = {
+      ...createInteraction(),
+      agentSessionId: "child-1",
+      requestId: "child-request-1",
+      turnId: "child-turn-1"
+    };
+    const childTurn: WorkspaceAgentTurn = {
+      ...createTurn("child-1", childInteraction.turnId),
+      phase: "waiting",
+      settledAtUnixMs: null
+    };
+    const child = {
+      ...createChildSession(root.id),
+      activeTurn: childTurn,
+      activeTurnId: childTurn.turnId,
+      latestTurn: childTurn,
+      latestTurnInteractions: [childInteraction],
+      pendingInteractions: [childInteraction]
+    };
     const client = createClient({
       detail: async () => ({
         childSessions: [child],
         session: root,
-        turns: [
-          createTurn(root.id, "turn-root-1"),
-          createTurn(child.id, "turn-child-1")
-        ]
+        turns: [createTurn(root.id, "turn-root-1")]
       }),
       listMessages: emptyMessagePage
     });
@@ -676,6 +866,26 @@ describe("WorkspaceActivityService", () => {
         userId: "account-user-1"
       })
     );
+    const childInteractionKey = canonicalInteractionKey(
+      childInteraction.agentSessionId,
+      childInteraction.turnId,
+      childInteraction.requestId
+    );
+    expect(
+      service.getSnapshot().interactionStates[childInteractionKey]
+        ?.runtimeAvailable
+    ).toBe(true);
+
+    service.pause();
+    expect(
+      service.getSnapshot().interactionStates[childInteractionKey]
+        ?.runtimeAvailable
+    ).toBe(false);
+    service.resume();
+    expect(
+      service.getSnapshot().interactionStates[childInteractionKey]
+        ?.runtimeAvailable
+    ).toBe(true);
 
     service.dispose();
   });
@@ -1071,14 +1281,15 @@ class RecordingClock implements ClockPort {
   private readonly tasks: Array<{
     canceled: boolean;
     delayMs: number;
+    task: () => void;
   }> = [];
 
   now(): number {
     return 1_000;
   }
 
-  schedule(delayMs: number): { cancel(): void } {
-    const task = { canceled: false, delayMs };
+  schedule(delayMs: number, callback: () => void): { cancel(): void } {
+    const task = { canceled: false, delayMs, task: callback };
     this.tasks.push(task);
     return {
       cancel: () => {
@@ -1092,4 +1303,46 @@ class RecordingClock implements ClockPort {
       .filter((task) => !task.canceled)
       .map((task) => task.delayMs);
   }
+
+  runNext(delayMs: number): void {
+    const task = this.tasks.find(
+      (candidate) => !candidate.canceled && candidate.delayMs === delayMs
+    );
+    if (!task) throw new Error(`no active ${delayMs}ms task`);
+    task.canceled = true;
+    task.task();
+  }
+}
+
+function createLiveDeviceLink(
+  onSubscribe: (listener: (delivery: AgentLiveDelivery) => void) => void
+): DeviceLinkPort {
+  return {
+    closeLink: async () => undefined,
+    requestAgentHTTP: async () => ({
+      body: "",
+      errorCode: "",
+      headers: {},
+      protocolEpoch: 1,
+      status: 204
+    }),
+    subscribeAgentLive: (_workspaceId, listener) => {
+      onSubscribe(listener);
+      return { close() {} };
+    }
+  };
+}
+
+function sessionDiscontinuity(): AgentLiveDelivery {
+  return {
+    kind: "discontinuity",
+    reason: "canonical_update",
+    reconcileKeys: [
+      {
+        agentSessionId: "session-1",
+        kind: "session",
+        workspaceId: workspace.id
+      }
+    ]
+  };
 }

--- a/apps/mobile/src/services/workspaceActivityService.test.ts
+++ b/apps/mobile/src/services/workspaceActivityService.test.ts
@@ -1,7 +1,11 @@
+import { canonicalInteractionKey } from "@tutti-os/agent-activity-core";
 import type {
   TuttidClient,
+  WorkspaceAgentInteraction,
   WorkspaceAgentSession,
+  WorkspaceAgentSessionDetailResponse,
   WorkspaceAgentSessionMessage,
+  WorkspaceAgentTurn,
   WorkspaceSummary
 } from "@tutti-os/client-tuttid-ts";
 import { AgentDirectoryService } from "./agentDirectoryService";
@@ -271,6 +275,81 @@ describe("WorkspaceActivityService", () => {
     service.dispose();
   });
 
+  test("keeps Interaction submission and availability in Engine-owned state", async () => {
+    let interactiveCalls = 0;
+    const interaction = createInteraction();
+    const turn: WorkspaceAgentTurn = {
+      ...createTurn("session-1", interaction.turnId),
+      phase: "waiting",
+      settledAtUnixMs: null
+    };
+    const session = {
+      ...createSession(),
+      activeTurn: turn,
+      activeTurnId: turn.turnId,
+      latestTurn: turn,
+      latestTurnInteractions: [interaction],
+      pendingInteractions: [interaction]
+    };
+    const client = createClient({
+      interactive: async () => {
+        interactiveCalls += 1;
+        return new Promise<never>(() => undefined);
+      },
+      listMessages: emptyMessagePage,
+      session: () => session
+    });
+    const service = createService(client);
+
+    await service.start();
+    await flushAsyncWork();
+    service.respondToInteraction(interaction, { optionId: "allow-once" });
+    service.respondToInteraction(interaction, { optionId: "allow-once" });
+    await flushAsyncWork();
+
+    const interactionKey = canonicalInteractionKey(
+      interaction.agentSessionId,
+      interaction.turnId,
+      interaction.requestId
+    );
+    expect(interactiveCalls).toBe(1);
+    expect(service.getSnapshot().interactionStates[interactionKey]).toEqual({
+      failed: false,
+      runtimeAvailable: true,
+      submitting: true
+    });
+
+    service.pause();
+    expect(service.getSnapshot().interactionStates[interactionKey]).toEqual({
+      failed: false,
+      runtimeAvailable: false,
+      submitting: true
+    });
+    service.dispose();
+  });
+
+  test("fails closed when a response does not match a canonical pending Interaction", async () => {
+    let interactiveCalls = 0;
+    const client = createClient({
+      interactive: async () => {
+        interactiveCalls += 1;
+        return createSession();
+      },
+      listMessages: emptyMessagePage
+    });
+    const service = createService(client);
+
+    await service.start();
+    await flushAsyncWork();
+    service.respondToInteraction(createInteraction(), {
+      optionId: "allow-once"
+    });
+    await flushAsyncWork();
+
+    expect(interactiveCalls).toBe(0);
+    service.dispose();
+  });
+
   test("routes pin changes through the canonical session mutation command", async () => {
     let session = createSession();
     const pinRequests: boolean[] = [];
@@ -420,6 +499,187 @@ describe("WorkspaceActivityService", () => {
     service.dispose();
   });
 
+  test("applies a continuous live Session audit without a redundant detail read", async () => {
+    let liveListener: ((delivery: AgentLiveDelivery) => void) | null = null;
+    let detailReads = 0;
+    const client = createClient({
+      detail: async () => {
+        detailReads += 1;
+        return {
+          childSessions: [],
+          session: createSession(),
+          turns: []
+        };
+      },
+      listMessages: async (_workspaceId, agentSessionId) => ({
+        agentSessionId,
+        hasMore: false,
+        latestVersion: 1,
+        messages: [createMessage("message-1", 1)]
+      })
+    });
+    const deviceLink = {
+      closeLink: async () => undefined,
+      requestAgentHTTP: async () => ({
+        body: "",
+        errorCode: "",
+        headers: {},
+        protocolEpoch: 1,
+        status: 204
+      }),
+      subscribeAgentLive: (
+        _workspaceId: string,
+        listener: (delivery: AgentLiveDelivery) => void
+      ) => {
+        liveListener = listener;
+        return { close() {} };
+      }
+    } satisfies DeviceLinkPort;
+    const service = createService(client, { deviceLink });
+
+    await service.start();
+    await flushAsyncWork();
+    liveListener!({
+      event: {
+        agentSessionId: "session-1",
+        data: {
+          agentSessionId: "session-1",
+          audit: {
+            auditId: "audit-1",
+            occurredAtUnixMs: 2,
+            payload: { text: "/goal clear" },
+            role: "user",
+            version: 2
+          },
+          eventType: "session_audit",
+          workspaceId: workspace.id
+        },
+        eventType: "session_audit",
+        workspaceId: workspace.id
+      },
+      kind: "event"
+    });
+    await flushAsyncWork();
+
+    expect(
+      service
+        .getSnapshot()
+        .activity.sessionMessagesById["session-1"]?.map(
+          (message) => message.messageId
+        )
+    ).toEqual(["message-1", "audit-1"]);
+    expect(detailReads).toBe(0);
+
+    service.dispose();
+  });
+
+  test("loads a newly selected Session without waiting for the previous Session request", async () => {
+    let resolveFirst: ((value: ReturnType<typeof messagePage>) => void) | null =
+      null;
+    const requestedSessionIds: string[] = [];
+    const second = { ...createSession(), id: "session-2", title: "Second" };
+    const client = createClient({
+      listMessages: async (_workspaceId, agentSessionId) => {
+        requestedSessionIds.push(agentSessionId);
+        if (agentSessionId === "session-1") {
+          return new Promise((resolve) => {
+            resolveFirst = resolve;
+          });
+        }
+        return messagePage(agentSessionId, "message-2", 2);
+      },
+      sessions: () => [createSession(), second]
+    });
+    const service = createService(client);
+
+    await service.start();
+    await flushAsyncWork();
+    service.selectSession("session-2");
+    await flushAsyncWork();
+
+    expect(requestedSessionIds).toEqual(["session-1", "session-2"]);
+    expect(
+      service.getSnapshot().activity.sessionMessagesById["session-2"]?.[0]
+        ?.messageId
+    ).toBe("message-2");
+
+    resolveFirst!(messagePage("session-1", "message-1", 1));
+    await flushAsyncWork();
+    service.dispose();
+  });
+
+  test("reconciles one authoritative detail aggregate with child Sessions", async () => {
+    let liveListener: ((delivery: AgentLiveDelivery) => void) | null = null;
+    const root = createSession();
+    const child = createChildSession(root.id);
+    const client = createClient({
+      detail: async () => ({
+        childSessions: [child],
+        session: root,
+        turns: [
+          createTurn(root.id, "turn-root-1"),
+          createTurn(child.id, "turn-child-1")
+        ]
+      }),
+      listMessages: emptyMessagePage
+    });
+    const deviceLink = {
+      closeLink: async () => undefined,
+      requestAgentHTTP: async () => ({
+        body: "",
+        errorCode: "",
+        headers: {},
+        protocolEpoch: 1,
+        status: 204
+      }),
+      subscribeAgentLive: (
+        _workspaceId: string,
+        listener: (delivery: AgentLiveDelivery) => void
+      ) => {
+        liveListener = listener;
+        return { close() {} };
+      }
+    } satisfies DeviceLinkPort;
+    const service = createService(client, { deviceLink });
+
+    await service.start();
+    await flushAsyncWork();
+    liveListener!({
+      kind: "discontinuity",
+      reason: "canonical_update",
+      reconcileKeys: [
+        {
+          agentSessionId: root.id,
+          kind: "session",
+          workspaceId: workspace.id
+        }
+      ]
+    });
+    await flushAsyncWork();
+
+    expect(
+      service
+        .getSnapshot()
+        .activity.sessions.map((session) => session.agentSessionId)
+    ).toEqual(expect.arrayContaining([root.id, child.id]));
+    expect(
+      service
+        .getSnapshot()
+        .activity.sessions.find(
+          (session) => session.agentSessionId === child.id
+        )
+    ).toEqual(
+      expect.objectContaining({
+        kind: "child",
+        parentAgentSessionId: root.id,
+        rootAgentSessionId: root.id,
+        userId: "account-user-1"
+      })
+    );
+
+    service.dispose();
+  });
+
   test("accepts only the matching attachment catch-up barrier", async () => {
     const clock = new RecordingClock();
     let closeCount = 0;
@@ -523,6 +783,16 @@ function createClient(options: {
     workspaceId: string,
     input: { agentSessionId: string }
   ): Promise<WorkspaceAgentSession>;
+  detail?(
+    workspaceId: string,
+    agentSessionId: string
+  ): Promise<WorkspaceAgentSessionDetailResponse>;
+  interactive?(
+    workspaceId: string,
+    agentSessionId: string,
+    requestId: string,
+    input: Record<string, unknown>
+  ): Promise<WorkspaceAgentSession>;
   deleteBatch?(
     workspaceId: string,
     input: { sessionIds: string[] }
@@ -558,6 +828,7 @@ function createClient(options: {
     input: { title: string }
   ): Promise<WorkspaceAgentSession>;
   session?(): WorkspaceAgentSession | null;
+  sessions?(): WorkspaceAgentSession[];
   settings?(
     workspaceId: string,
     agentSessionId: string,
@@ -573,38 +844,53 @@ function createClient(options: {
     createWorkspaceAgentSession: options.create,
     deleteWorkspaceAgentSessionsBatch: options.deleteBatch,
     getAgentProviderComposerOptions: options.composerOptions,
+    getWorkspaceAgentSession: options.detail,
     listAgentTargets: async () => ({ targets: options.targets ?? [] }),
     listWorkspaceAgentSessionMessages: options.listMessages,
     listWorkspaceAgentSessionSections: async () => {
-      const session =
-        options.session === undefined ? createSession() : options.session();
-      if (!session) {
+      const sessions =
+        options.sessions?.() ??
+        (() => {
+          const session =
+            options.session === undefined ? createSession() : options.session();
+          return session ? [session] : [];
+        })();
+      if (sessions.length === 0) {
         return {
           pinned: { hasMore: false, sessions: [], totalCount: 0 },
           sections: [],
           workspaceId: workspace.id
         };
       }
-      const pinned = session.pinnedAtUnixMs
-        ? { hasMore: false, sessions: [session], totalCount: 1 }
-        : { hasMore: false, sessions: [], totalCount: 0 };
+      const pinnedSessions = sessions.filter(
+        (session) => session.pinnedAtUnixMs != null
+      );
+      const conversationSessions = sessions.filter(
+        (session) => session.pinnedAtUnixMs == null
+      );
       return {
-        pinned,
-        sections: session.pinnedAtUnixMs
-          ? []
-          : [
-              {
-                hasMore: false,
-                kind: "conversations" as const,
-                sectionKey: "conversations",
-                sessions: [session],
-                totalCount: 1
-              }
-            ],
+        pinned: {
+          hasMore: false,
+          sessions: pinnedSessions,
+          totalCount: pinnedSessions.length
+        },
+        sections:
+          conversationSessions.length === 0
+            ? []
+            : [
+                {
+                  hasMore: false,
+                  kind: "conversations" as const,
+                  sectionKey: "conversations",
+                  sessions: conversationSessions,
+                  totalCount: conversationSessions.length
+                }
+              ],
         workspaceId: workspace.id
       };
     },
     sendWorkspaceAgentSessionInput: options.send,
+    submitWorkspaceAgentInteractive: options.interactive,
     updateWorkspaceAgentSessionPin: options.pin,
     updateWorkspaceAgentSessionSettings: options.settings,
     updateWorkspaceAgentSessionTitle: options.rename
@@ -679,6 +965,57 @@ function createSession(): WorkspaceAgentSession {
   };
 }
 
+function createChildSession(rootAgentSessionId: string): WorkspaceAgentSession {
+  return {
+    ...createSession(),
+    id: "child-1",
+    kind: "child",
+    parentAgentSessionId: rootAgentSessionId,
+    parentToolCallId: "tool-call-1",
+    parentTurnId: "turn-root-1",
+    rootAgentSessionId,
+    rootTurnId: "turn-root-1",
+    title: "Child"
+  };
+}
+
+function createTurn(
+  agentSessionId: string,
+  turnId: string
+): WorkspaceAgentTurn {
+  return {
+    agentSessionId,
+    completedCommand: null,
+    error: null,
+    fileChanges: null,
+    origin: "user_prompt",
+    outcome: null,
+    phase: "settled",
+    settledAtUnixMs: 3,
+    startedAtUnixMs: 2,
+    turnId,
+    updatedAtUnixMs: 3
+  };
+}
+
+function createInteraction(): WorkspaceAgentInteraction {
+  return {
+    agentSessionId: "session-1",
+    createdAtUnixMs: 3,
+    input: {
+      options: [{ label: "Allow", optionId: "allow-once" }]
+    },
+    kind: "approval",
+    metadata: {},
+    output: null,
+    requestId: "request-1",
+    status: "pending",
+    toolName: "Approval",
+    turnId: "turn-1",
+    updatedAtUnixMs: 3
+  };
+}
+
 function createMessage(
   messageId: string,
   version: number
@@ -693,6 +1030,24 @@ function createMessage(
     sequence: version,
     turnId: "turn-1",
     version
+  };
+}
+
+function messagePage(
+  agentSessionId: string,
+  messageId: string,
+  version: number
+) {
+  return {
+    agentSessionId,
+    hasMore: false,
+    latestVersion: version,
+    messages: [
+      {
+        ...createMessage(messageId, version),
+        agentSessionId
+      }
+    ]
   };
 }
 

--- a/apps/mobile/src/services/workspaceActivityService.ts
+++ b/apps/mobile/src/services/workspaceActivityService.ts
@@ -1,6 +1,5 @@
 import {
   AGENT_SESSION_ENGINE_LOCAL_ORIGIN,
-  agentActivitySessionMessageWindowFromDescendingPage,
   createAgentActivitySnapshotProjector,
   createAgentSessionEngine,
   dispatchSessionMutation,
@@ -10,10 +9,7 @@ import {
   type AgentSessionEngine,
   type EngineExternalCommand
 } from "@tutti-os/agent-activity-core";
-import {
-  agentActivityMessageFromTuttidMessage,
-  type AgentActivitySessionDetailSnapshot
-} from "@tutti-os/agent-activity-tuttid-adapter";
+import { type AgentActivitySessionDetailSnapshot } from "@tutti-os/agent-activity-tuttid-adapter";
 import type {
   TuttidClient,
   WorkspaceSummary
@@ -38,6 +34,7 @@ import { createMobileActivityCommandId } from "./workspaceActivityCommandSupport
 import { requestWorkspaceActivityInteractionResponse } from "./workspaceActivityInteractionCommand";
 import type { WorkspaceActivitySnapshot } from "./workspaceActivityTypes";
 import { WorkspaceAgentLiveLane } from "./workspaceAgentLiveLane";
+import { WorkspaceActivityMessagePageLoader } from "./workspaceActivityMessagePageLoader";
 import { selectWorkspaceConversationRailSessionIds } from "./workspaceConversationRailProjection";
 import type { WorkspaceNavigationService } from "./workspaceNavigationService";
 import { WorkspaceMediaService } from "./workspaceMediaService";
@@ -54,6 +51,7 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
   readonly media: WorkspaceMediaService;
   private readonly engine: AgentSessionEngine;
   private readonly liveLane: WorkspaceAgentLiveLane;
+  private readonly messagePages: WorkspaceActivityMessagePageLoader;
   private readonly mapping: ReturnType<typeof createMobileAgentActivityMapping>;
   private readonly projectActivity: (
     state: ReturnType<AgentSessionEngine["getSnapshot"]>
@@ -61,10 +59,6 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
   private disposed = false;
   private paused = false;
   private initializePromise: Promise<void> | null = null;
-  private readonly messageRequestsInFlightByKey = new Map<
-    string,
-    Promise<void>
-  >();
   private messagePollTask: { cancel(): void } | null = null;
   private errorCode: "request_failed" | null = null;
   private loading = true;
@@ -132,6 +126,23 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
       readCanonicalActivity: () =>
         this.projectActivity(this.engine.getSnapshot()),
       reconcileWorkspace: () => this.reconcileWorkspace(),
+      workspaceId: this.workspace.id
+    });
+    this.messagePages = new WorkspaceActivityMessagePageLoader({
+      client: this.client,
+      engine: this.engine,
+      isAvailable: () => !this.disposed && !this.paused,
+      onPageApplied: (agentSessionId) => {
+        this.liveLane.reconcileMessages(agentSessionId);
+        this.errorCode = null;
+      },
+      onRequestFailed: () => {
+        if (!this.disposed) this.errorCode = "request_failed";
+      },
+      onRequestSettled: () => {
+        this.onDependencyChanged();
+        this.scheduleMessagesPoll();
+      },
       workspaceId: this.workspace.id
     });
     this.disposables.push(
@@ -456,14 +467,14 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
     if (!window?.hasOlderMessages || window.oldestLoadedVersion === null)
       return;
     try {
-      await this.loadMessagePage(selected, {
+      await this.messagePages.loadPage(selected, {
         beforeVersion: window.oldestLoadedVersion,
         limit: MESSAGE_PAGE_SIZE,
         order: "desc"
       });
     } catch {
-      // loadMessagePage records the presentation error; paging remains
-      // explicitly retryable through the same action.
+      // The message page loader records the presentation error; paging
+      // remains explicitly retryable through the same action.
     }
   }
 
@@ -555,76 +566,16 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
       0
     );
     if (authoritative || latestVersion === 0) {
-      await this.loadMessagePage(agentSessionId, {
+      await this.messagePages.loadPage(agentSessionId, {
         limit: MESSAGE_PAGE_SIZE,
         order: "desc"
       });
       return;
     }
-    await this.loadMessagePage(agentSessionId, {
+    await this.messagePages.loadPage(agentSessionId, {
       afterVersion: latestVersion,
       order: "asc"
     });
-  }
-
-  private async loadMessagePage(
-    agentSessionId: string,
-    query: {
-      afterVersion?: number;
-      beforeVersion?: number;
-      limit?: number;
-      order: "asc" | "desc";
-    }
-  ): Promise<void> {
-    if (this.paused || this.disposed) return;
-    const requestKey = messageRequestKey(agentSessionId, query);
-    const existing = this.messageRequestsInFlightByKey.get(requestKey);
-    if (existing) return existing;
-    const request = this.client
-      .listWorkspaceAgentSessionMessages(
-        this.workspace.id,
-        agentSessionId,
-        query
-      )
-      .then((page) => {
-        if (this.disposed || this.paused) return;
-        const messages = page.messages.map((message) =>
-          agentActivityMessageFromTuttidMessage(this.workspace.id, message)
-        );
-        this.engine.dispatch({
-          messages,
-          ...(query.order === "desc"
-            ? {
-                sessionMessageWindows: [
-                  {
-                    agentSessionId,
-                    ...agentActivitySessionMessageWindowFromDescendingPage({
-                      ...page,
-                      messages
-                    })
-                  }
-                ]
-              }
-            : {}),
-          type: "message/snapshotReceived",
-          workspaceId: this.workspace.id
-        });
-        this.liveLane.reconcileMessages(agentSessionId);
-        this.errorCode = null;
-      })
-      .catch((error: unknown) => {
-        if (!this.disposed) this.errorCode = "request_failed";
-        throw error;
-      })
-      .finally(() => {
-        if (this.messageRequestsInFlightByKey.get(requestKey) === request) {
-          this.messageRequestsInFlightByKey.delete(requestKey);
-        }
-        this.onDependencyChanged();
-        this.scheduleMessagesPoll();
-      });
-    this.messageRequestsInFlightByKey.set(requestKey, request);
-    return request;
   }
 
   private executeCommand(
@@ -795,22 +746,4 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
       this.drafts.set(draftKey, text);
     }
   }
-}
-
-function messageRequestKey(
-  agentSessionId: string,
-  query: {
-    afterVersion?: number;
-    beforeVersion?: number;
-    limit?: number;
-    order: "asc" | "desc";
-  }
-): string {
-  return JSON.stringify([
-    agentSessionId,
-    query.order,
-    query.afterVersion ?? null,
-    query.beforeVersion ?? null,
-    query.limit ?? null
-  ]);
 }

--- a/apps/mobile/src/services/workspaceActivityService.ts
+++ b/apps/mobile/src/services/workspaceActivityService.ts
@@ -4,7 +4,6 @@ import {
   createAgentActivitySnapshotProjector,
   createAgentSessionEngine,
   dispatchSessionMutation,
-  selectRootAgentActivitySessions,
   type AgentActivitySessionSettings,
   type AgentActivityInteraction,
   type AgentActivitySession,
@@ -13,8 +12,7 @@ import {
 } from "@tutti-os/agent-activity-core";
 import {
   agentActivityMessageFromTuttidMessage,
-  agentActivitySessionFromTuttidSession,
-  agentActivityTurnFromTuttidTurn
+  type AgentActivitySessionDetailSnapshot
 } from "@tutti-os/agent-activity-tuttid-adapter";
 import type {
   TuttidClient,
@@ -22,8 +20,10 @@ import type {
 } from "@tutti-os/client-tuttid-ts";
 import type { AgentDirectoryService } from "./agentDirectoryService";
 import type { ComposerDraftService } from "./composerDraftService";
+import { createMobileAgentActivityMapping } from "./mobileAgentActivityMapping";
 import { ObservableService } from "./observableService";
 import {
+  dismissPendingSubmission,
   resolvePendingSubmission,
   type PendingSubmission
 } from "./pendingSubmission";
@@ -33,13 +33,12 @@ import {
   projectWorkspaceActivitySnapshot,
   resolveWorkspaceComposerTarget
 } from "./workspaceActivityProjection";
-import type {
-  WorkspaceConversationRailService,
-  WorkspaceConversationRailSnapshot
-} from "./workspaceConversationRailService";
+import type { WorkspaceConversationRailService } from "./workspaceConversationRailService";
 import { createMobileActivityCommandId } from "./workspaceActivityCommandSupport";
+import { requestWorkspaceActivityInteractionResponse } from "./workspaceActivityInteractionCommand";
 import type { WorkspaceActivitySnapshot } from "./workspaceActivityTypes";
 import { WorkspaceAgentLiveLane } from "./workspaceAgentLiveLane";
+import { selectWorkspaceConversationRailSessionIds } from "./workspaceConversationRailProjection";
 import type { WorkspaceNavigationService } from "./workspaceNavigationService";
 import { WorkspaceMediaService } from "./workspaceMediaService";
 
@@ -55,18 +54,21 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
   readonly media: WorkspaceMediaService;
   private readonly engine: AgentSessionEngine;
   private readonly liveLane: WorkspaceAgentLiveLane;
+  private readonly mapping: ReturnType<typeof createMobileAgentActivityMapping>;
   private readonly projectActivity: (
     state: ReturnType<AgentSessionEngine["getSnapshot"]>
   ) => WorkspaceActivitySnapshot["activity"];
   private disposed = false;
   private paused = false;
   private initializePromise: Promise<void> | null = null;
-  private messagesInFlight: Promise<void> | null = null;
+  private readonly messagesInFlightBySessionId = new Map<
+    string,
+    Promise<void>
+  >();
   private messagePollTask: { cancel(): void } | null = null;
   private errorCode: "request_failed" | null = null;
   private loading = true;
   private observedSelectedSessionId: string | null = null;
-  private lastRailSessions: WorkspaceConversationRailSnapshot["sessions"] = [];
   private previousConversation: WorkspaceActivitySnapshot["conversation"] =
     null;
   private snapshotCache: WorkspaceActivitySnapshot | null = null;
@@ -85,11 +87,15 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
     private readonly drafts: ComposerDraftService,
     private readonly rail: WorkspaceConversationRailService,
     private readonly clock: ClockPort,
-    private readonly currentUserId: string,
+    currentUserId: string,
     deviceLink?: DeviceLinkPort
   ) {
     super();
     this.media = new WorkspaceMediaService(workspace.id, client);
+    this.mapping = createMobileAgentActivityMapping({
+      currentUserId,
+      workspaceId: workspace.id
+    });
     this.projectActivity = createAgentActivitySnapshotProjector(workspace.id);
     this.engine = createAgentSessionEngine({
       clock: { nowUnixMs: () => this.clock.now() },
@@ -141,17 +147,15 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
         this.loadComposerOptions();
       }),
       this.drafts.subscribe(() => this.onDependencyChanged()),
+      this.rail.attachSessionConsumer((sessions) => {
+        if (this.disposed || this.paused) return;
+        this.applyRailSessionPage(sessions.map(this.mapping.mapSession));
+      }),
       this.rail.subscribe(() => {
         const rail = this.rail.getSnapshot();
-        if (
-          rail.status === "ready" &&
-          rail.sessions !== this.lastRailSessions &&
-          !this.disposed &&
-          !this.paused
-        ) {
-          this.lastRailSessions = rail.sessions;
-          this.applySessionSnapshot(
-            rail.sessions.map((session) => this.mapSession(session))
+        if (rail.status === "ready" && !this.disposed && !this.paused) {
+          this.navigation.reconcileSessionIds(
+            selectWorkspaceConversationRailSessionIds(rail.sections)
           );
         }
         this.onDependencyChanged();
@@ -245,6 +249,7 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
   }
 
   updateComposerSettings(settings: AgentActivitySessionSettings): void {
+    if (!this.getSnapshot().commandsAvailable) return;
     const target = this.currentComposerTarget();
     if (!target || Object.keys(settings).length === 0) return;
     const navigation = this.navigation.getSnapshot();
@@ -309,7 +314,7 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
         { title: normalizedTitle }
       );
       this.engine.dispatch({
-        session: this.mapSession(session),
+        session: this.mapping.mapSession(session),
         type: "session/upserted"
       });
       await this.rail.reconcile();
@@ -340,7 +345,7 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
   async send(): Promise<void> {
     const snapshot = this.getSnapshot();
     const text = snapshot.draft.trim();
-    if (!text || snapshot.sending) return;
+    if (!text || snapshot.sending || !snapshot.commandsAvailable) return;
     if (snapshot.creating && !snapshot.selectedAgentTargetId) return;
     const draftKey = snapshot.creating
       ? "new"
@@ -358,7 +363,7 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
       await this.reconcileWorkspace().catch(() => undefined);
       this.reconcilePendingSubmissions();
       if (!this.pendingSubmissionsByDraftKey.has(draftKey)) return;
-      this.dismissPendingSubmission(submission);
+      dismissPendingSubmission(this.engine, submission);
       this.ambiguousDraftKeys.delete(draftKey);
       this.errorCode = null;
     }
@@ -409,7 +414,9 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
   }
 
   stop(): void {
-    const selected = this.getSnapshot().selectedSession;
+    const snapshot = this.getSnapshot();
+    if (!snapshot.commandsAvailable) return;
+    const selected = snapshot.selectedSession;
     if (!selected) return;
     const now = this.clock.now();
     this.engine.dispatch({
@@ -430,32 +437,40 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
       payload?: Readonly<Record<string, unknown>>;
     }
   ): void {
-    this.engine.dispatch({
-      ...input,
-      agentSessionId: interaction.agentSessionId,
+    requestWorkspaceActivityInteractionResponse({
       commandId: createMobileActivityCommandId(),
-      requestId: interaction.requestId,
-      retry: false,
+      engine: this.engine,
+      interaction,
+      response: input,
+      states: this.getSnapshot().interactionStates,
       timeoutMs: COMMAND_TIMEOUT_MS,
-      turnId: interaction.turnId,
-      type: "interaction/responseRequested",
       workspaceId: this.workspace.id
     });
   }
 
   async loadOlderMessages(): Promise<void> {
     const selected = this.navigation.getSnapshot().selectedAgentSessionId;
-    if (!selected || this.messagesInFlight || this.paused || this.disposed)
+    if (
+      !selected ||
+      this.messagesInFlightBySessionId.has(selected) ||
+      this.paused ||
+      this.disposed
+    )
       return;
     const window = this.projectActivity(this.engine.getSnapshot())
       .sessionMessageWindowsById?.[selected];
     if (!window?.hasOlderMessages || window.oldestLoadedVersion === null)
       return;
-    await this.loadMessagePage(selected, {
-      beforeVersion: window.oldestLoadedVersion,
-      limit: MESSAGE_PAGE_SIZE,
-      order: "desc"
-    });
+    try {
+      await this.loadMessagePage(selected, {
+        beforeVersion: window.oldestLoadedVersion,
+        limit: MESSAGE_PAGE_SIZE,
+        order: "desc"
+      });
+    } catch {
+      // loadMessagePage records the presentation error; paging remains
+      // explicitly retryable through the same action.
+    }
   }
 
   pause(): void {
@@ -514,8 +529,20 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
 
   private async loadSelectedMessages(authoritative: boolean): Promise<void> {
     const agentSessionId = this.navigation.getSnapshot().selectedAgentSessionId;
-    if (this.messagesInFlight) return this.messagesInFlight;
     if (!agentSessionId || this.paused || this.disposed) return;
+    try {
+      await this.loadSessionMessages(agentSessionId, authoritative);
+    } catch {
+      // Background and presentation-driven loads surface the recorded error in
+      // the workspace snapshot. Engine-owned reconcile commands call the same
+      // primitive directly and retain the rejection for canonical retry state.
+    }
+  }
+
+  private async loadSessionMessages(
+    agentSessionId: string,
+    authoritative: boolean
+  ): Promise<void> {
     const activity = this.projectActivity(this.engine.getSnapshot());
     const messages = activity.sessionMessagesById[agentSessionId] ?? [];
     const latestVersion = messages.reduce(
@@ -544,21 +571,17 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
       order: "asc" | "desc";
     }
   ): Promise<void> {
-    if (this.messagesInFlight || this.paused || this.disposed) return;
-    this.messagesInFlight = this.client
+    if (this.paused || this.disposed) return;
+    const existing = this.messagesInFlightBySessionId.get(agentSessionId);
+    if (existing) return existing;
+    const request = this.client
       .listWorkspaceAgentSessionMessages(
         this.workspace.id,
         agentSessionId,
         query
       )
       .then((page) => {
-        if (
-          this.disposed ||
-          this.paused ||
-          this.navigation.getSnapshot().selectedAgentSessionId !==
-            agentSessionId
-        )
-          return;
+        if (this.disposed || this.paused) return;
         const messages = page.messages.map((message) =>
           agentActivityMessageFromTuttidMessage(this.workspace.id, message)
         );
@@ -583,15 +606,19 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
         this.liveLane.reconcileMessages(agentSessionId);
         this.errorCode = null;
       })
-      .catch(() => {
+      .catch((error: unknown) => {
         if (!this.disposed) this.errorCode = "request_failed";
+        throw error;
       })
       .finally(() => {
-        this.messagesInFlight = null;
+        if (this.messagesInFlightBySessionId.get(agentSessionId) === request) {
+          this.messagesInFlightBySessionId.delete(agentSessionId);
+        }
         this.onDependencyChanged();
         this.scheduleMessagesPoll();
       });
-    return this.messagesInFlight;
+    this.messagesInFlightBySessionId.set(agentSessionId, request);
+    return request;
   }
 
   private executeCommand(
@@ -603,9 +630,10 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
         client: this.client,
         engine: this.engine,
         loadComposerOptions: (options) => this.loadComposerOptions(options),
-        mapSession: (session) => this.mapSession(session),
-        reconcileSession: (agentSessionId) =>
-          this.reconcileSession(agentSessionId),
+        mapSession: this.mapping.mapSession,
+        mapSessionDetail: this.mapping.mapSessionDetail,
+        reconcileSession: (agentSessionId, scope) =>
+          this.reconcileSession(agentSessionId, scope),
         reconcileWorkspace: () => this.reconcileWorkspace()
       },
       command,
@@ -615,30 +643,36 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
 
   private async reconcileWorkspace(): Promise<unknown> {
     const rail = await this.rail.reconcile();
-    const sessions = rail.sessions.map((session) => this.mapSession(session));
     if (this.disposed || this.paused) {
       throw new Error("mobile workspace activity is unavailable");
     }
-    this.applySessionSnapshot(sessions);
     this.errorCode = null;
-    return { sessions };
+    return {
+      sessionIds: selectWorkspaceConversationRailSessionIds(rail.sections)
+    };
   }
 
-  private async reconcileSession(agentSessionId: string): Promise<unknown> {
-    const detail = await this.client.getWorkspaceAgentSession(
-      this.workspace.id,
-      agentSessionId
-    );
-    const session = this.mapSession(detail.session);
-    this.engine.dispatch({ session, type: "session/upserted" });
-    for (const turn of detail.turns) {
+  private async reconcileSession(
+    agentSessionId: string,
+    scope: "messages" | "state" | "state_and_messages"
+  ): Promise<unknown> {
+    let mapped: AgentActivitySessionDetailSnapshot | null = null;
+    if (scope !== "messages") {
+      const detail = await this.client.getWorkspaceAgentSession(
+        this.workspace.id,
+        agentSessionId
+      );
+      mapped = this.mapping.mapSessionDetail(detail);
       this.engine.dispatch({
-        turn: agentActivityTurnFromTuttidTurn(turn),
-        type: "turn/upserted"
+        ...mapped,
+        type: "session/detailSnapshotReceived",
+        workspaceId: this.workspace.id
       });
     }
-    await this.loadSelectedMessages(true);
-    return { session };
+    if (scope !== "state") {
+      await this.loadSessionMessages(agentSessionId, true);
+    }
+    return mapped ? { session: mapped.session } : {};
   }
 
   private loadComposerOptions(options?: { force?: boolean }): void {
@@ -681,26 +715,26 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
     this.messagePollTask = null;
   }
 
-  private applySessionSnapshot(sessions: AgentActivitySession[]): void {
+  private applyRailSessionPage(
+    sessions: readonly AgentActivitySession[]
+  ): void {
+    if (sessions.length === 0) return;
     this.engine.dispatch({
       sessions,
       type: "session/snapshotReceived"
     });
-    if (!this.paused) {
-      for (const session of sessions) {
-        this.engine.dispatch({
-          agentSessionId: session.agentSessionId,
-          availability: { state: "available" },
-          type: "session/runtimeAvailabilityChanged"
-        });
+    for (const session of sessions) {
+      if (!this.paused) {
+        this.engine.dispatch(
+          {
+            agentSessionId: session.agentSessionId,
+            availability: { state: "available" },
+            type: "session/runtimeAvailabilityChanged"
+          },
+          { batch: true }
+        );
       }
     }
-    const roots = selectRootAgentActivitySessions({ sessions }).filter(
-      (session) => session.visible
-    );
-    this.navigation.reconcileSessionIds(
-      roots.map((session) => session.agentSessionId)
-    );
   }
 
   private onDependencyChanged(): void {
@@ -754,27 +788,5 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
     if (!this.drafts.get(draftKey)) {
       this.drafts.set(draftKey, text);
     }
-  }
-
-  private dismissPendingSubmission(submission: PendingSubmission): void {
-    if (submission.creating) {
-      this.engine.dispatch({
-        requestId: submission.clientSubmitId,
-        type: "activation/dismissed"
-      });
-      return;
-    }
-    this.engine.dispatch({
-      clientSubmitId: submission.clientSubmitId,
-      type: "submit/dismissed"
-    });
-  }
-
-  private mapSession(
-    session: Parameters<typeof agentActivitySessionFromTuttidSession>[1]
-  ): AgentActivitySession {
-    return agentActivitySessionFromTuttidSession(this.workspace.id, session, {
-      currentUserId: this.currentUserId
-    });
   }
 }

--- a/apps/mobile/src/services/workspaceActivityService.ts
+++ b/apps/mobile/src/services/workspaceActivityService.ts
@@ -61,7 +61,7 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
   private disposed = false;
   private paused = false;
   private initializePromise: Promise<void> | null = null;
-  private readonly messagesInFlightBySessionId = new Map<
+  private readonly messageRequestsInFlightByKey = new Map<
     string,
     Promise<void>
   >();
@@ -431,7 +431,7 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
 
   respondToInteraction(
     interaction: AgentActivityInteraction,
-    input: {
+    input?: {
       action?: string;
       optionId?: string;
       payload?: Readonly<Record<string, unknown>>;
@@ -441,7 +441,7 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
       commandId: createMobileActivityCommandId(),
       engine: this.engine,
       interaction,
-      response: input,
+      ...(input ? { response: input } : {}),
       states: this.getSnapshot().interactionStates,
       timeoutMs: COMMAND_TIMEOUT_MS,
       workspaceId: this.workspace.id
@@ -450,13 +450,7 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
 
   async loadOlderMessages(): Promise<void> {
     const selected = this.navigation.getSnapshot().selectedAgentSessionId;
-    if (
-      !selected ||
-      this.messagesInFlightBySessionId.has(selected) ||
-      this.paused ||
-      this.disposed
-    )
-      return;
+    if (!selected || this.paused || this.disposed) return;
     const window = this.projectActivity(this.engine.getSnapshot())
       .sessionMessageWindowsById?.[selected];
     if (!window?.hasOlderMessages || window.oldestLoadedVersion === null)
@@ -506,6 +500,17 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
       type: "engine/connectionChanged",
       workspaceId: this.workspace.id
     });
+    for (const session of this.projectActivity(this.engine.getSnapshot())
+      .sessions) {
+      this.engine.dispatch(
+        {
+          agentSessionId: session.agentSessionId,
+          availability: { state: "available" },
+          type: "session/runtimeAvailabilityChanged"
+        },
+        { batch: true }
+      );
+    }
     this.engine.dispatch({
       type: "workspace/reconcileRequested",
       workspaceId: this.workspace.id
@@ -572,7 +577,8 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
     }
   ): Promise<void> {
     if (this.paused || this.disposed) return;
-    const existing = this.messagesInFlightBySessionId.get(agentSessionId);
+    const requestKey = messageRequestKey(agentSessionId, query);
+    const existing = this.messageRequestsInFlightByKey.get(requestKey);
     if (existing) return existing;
     const request = this.client
       .listWorkspaceAgentSessionMessages(
@@ -611,13 +617,13 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
         throw error;
       })
       .finally(() => {
-        if (this.messagesInFlightBySessionId.get(agentSessionId) === request) {
-          this.messagesInFlightBySessionId.delete(agentSessionId);
+        if (this.messageRequestsInFlightByKey.get(requestKey) === request) {
+          this.messageRequestsInFlightByKey.delete(requestKey);
         }
         this.onDependencyChanged();
         this.scheduleMessagesPoll();
       });
-    this.messagesInFlightBySessionId.set(agentSessionId, request);
+    this.messageRequestsInFlightByKey.set(requestKey, request);
     return request;
   }
 
@@ -662,7 +668,7 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
         this.workspace.id,
         agentSessionId
       );
-      mapped = this.mapping.mapSessionDetail(detail);
+      mapped = this.mapping.mapSessionDetail(agentSessionId, detail);
       this.engine.dispatch({
         ...mapped,
         type: "session/detailSnapshotReceived",
@@ -789,4 +795,22 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
       this.drafts.set(draftKey, text);
     }
   }
+}
+
+function messageRequestKey(
+  agentSessionId: string,
+  query: {
+    afterVersion?: number;
+    beforeVersion?: number;
+    limit?: number;
+    order: "asc" | "desc";
+  }
+): string {
+  return JSON.stringify([
+    agentSessionId,
+    query.order,
+    query.afterVersion ?? null,
+    query.beforeVersion ?? null,
+    query.limit ?? null
+  ]);
 }

--- a/apps/mobile/src/services/workspaceActivityTypes.ts
+++ b/apps/mobile/src/services/workspaceActivityTypes.ts
@@ -1,6 +1,7 @@
 import type {
   AgentActivityComposerOptions,
   AgentActivityComposerOptionsLoadStatus,
+  AgentActivityInteraction,
   AgentActivitySession,
   AgentActivitySessionSettings,
   AgentActivitySnapshot
@@ -17,11 +18,23 @@ export interface WorkspaceActivitySnapshot {
   composerOptionsLoadStatus: AgentActivityComposerOptionsLoadStatus | null;
   composerSettings: AgentActivitySessionSettings;
   composerSettingsSupport: AgentComposerSettingsSupport;
+  commandsAvailable: boolean;
   conversation: AgentConversationVM | null;
   creating: boolean;
   draft: string;
   errorCode: "request_failed" | null;
   loading: boolean;
+  interactionStates: Readonly<
+    Record<
+      string,
+      {
+        failed: boolean;
+        submitting: boolean;
+        runtimeAvailable: boolean;
+      }
+    >
+  >;
+  pendingInteractions: readonly AgentActivityInteraction[];
   pinningSessionIds: readonly string[];
   railErrorCode: "request_failed" | null;
   railSections: readonly WorkspaceConversationRailSection[];

--- a/apps/mobile/src/services/workspaceAgentLiveLane.ts
+++ b/apps/mobile/src/services/workspaceAgentLiveLane.ts
@@ -1,4 +1,5 @@
 import {
+  analyzeAgentActivityEventObservation,
   createAgentActivityOptimisticMessageOverlay,
   parseAgentActivityMessageDeltaEvent,
   type AgentActivityLiveEvent,
@@ -216,22 +217,56 @@ export class WorkspaceAgentLiveLane {
           turn: agentActivityTurnFromLiveEvent(event),
           type: "turn/upserted"
         });
+        this.observeAuthoritativeEvent(event);
         this.scheduleRailReconcile();
-        if (event.data.turn.phase === "settled") {
-          this.requestSessionReconcile(event.agentSessionId, true);
-        }
         return;
       case "interaction_update":
         this.options.engine.dispatch({
           interaction: event.data.interaction,
           type: "interaction/upserted"
         });
+        this.observeAuthoritativeEvent(event);
         this.scheduleRailReconcile();
         return;
-      case "session_audit":
-        this.requestSessionReconcile(event.agentSessionId, true);
+      case "session_audit": {
+        this.observeAuthoritativeEvent(event);
         this.scheduleRailReconcile();
+        return;
+      }
     }
+  }
+
+  private observeAuthoritativeEvent(
+    event: Exclude<AgentActivityLiveEvent, { eventType: "message_delta" }>
+  ): void {
+    const activity = this.options.readCanonicalActivity();
+    const cachedMessages =
+      activity.sessionMessagesById[event.agentSessionId] ?? [];
+    const observation = analyzeAgentActivityEventObservation({
+      cachedMessages,
+      event,
+      hasCachedSession: activity.sessions.some(
+        (session) => session.agentSessionId === event.agentSessionId
+      )
+    });
+    if (observation.canApplyInlineMessages) {
+      this.options.engine.dispatch(
+        {
+          messages: observation.inlineMessages,
+          type: "message/snapshotReceived",
+          workspaceId: this.options.workspaceId
+        },
+        { batch: true }
+      );
+      this.optimisticMessages.reconcile(
+        {
+          agentSessionId: event.agentSessionId,
+          workspaceId: this.options.workspaceId
+        },
+        [...cachedMessages, ...observation.inlineMessages]
+      );
+    }
+    this.options.engine.dispatch(observation.intent);
   }
 
   private reconcileDiscontinuity(

--- a/apps/mobile/src/services/workspaceConversationRailProjection.test.ts
+++ b/apps/mobile/src/services/workspaceConversationRailProjection.test.ts
@@ -1,5 +1,8 @@
 import type { AgentConversationRailSummary } from "@tutti-os/agent-gui/conversation-rail-projection";
-import { projectWorkspaceConversationRail } from "./workspaceConversationRailProjection";
+import {
+  projectWorkspaceConversationRail,
+  selectWorkspaceConversationRailSessionIds
+} from "./workspaceConversationRailProjection";
 import type { WorkspaceConversationRailMembership } from "./workspaceConversationRailService";
 
 describe("projectWorkspaceConversationRail", () => {
@@ -65,6 +68,15 @@ describe("projectWorkspaceConversationRail", () => {
     });
 
     expect(sections[0]?.items.map((item) => item.id)).toEqual(["new", "known"]);
+  });
+
+  test("deduplicates canonical navigation ids across Rail memberships", () => {
+    expect(
+      selectWorkspaceConversationRailSessionIds([
+        { sessionIds: ["session-1", "session-2"] },
+        { sessionIds: ["session-1", "session-3"] }
+      ])
+    ).toEqual(["session-1", "session-2", "session-3"]);
   });
 });
 

--- a/apps/mobile/src/services/workspaceConversationRailProjection.ts
+++ b/apps/mobile/src/services/workspaceConversationRailProjection.ts
@@ -12,6 +12,17 @@ export interface WorkspaceConversationRailSection {
   totalCount: number;
 }
 
+export function selectWorkspaceConversationRailSessionIds(
+  memberships: readonly Pick<
+    WorkspaceConversationRailMembership,
+    "sessionIds"
+  >[]
+): string[] {
+  return [
+    ...new Set(memberships.flatMap((membership) => membership.sessionIds))
+  ];
+}
+
 export function projectWorkspaceConversationRail(input: {
   conversations: readonly AgentConversationRailSummary[];
   loadingMoreSectionId: string | null;

--- a/apps/mobile/src/services/workspaceConversationRailService.test.ts
+++ b/apps/mobile/src/services/workspaceConversationRailService.test.ts
@@ -40,6 +40,7 @@ describe("WorkspaceConversationRailService", () => {
 
   test("keeps server section identity and loads the next exact page", async () => {
     const sectionQueries: Array<Record<string, unknown>> = [];
+    const receivedSessionPages: string[][] = [];
     const client = {
       listWorkspaceAgentPinnedSessionPage: async () => ({
         page: { hasMore: false, sessions: [], totalCount: 0 },
@@ -91,6 +92,9 @@ describe("WorkspaceConversationRailService", () => {
       client,
       new ManualClock()
     );
+    service.attachSessionConsumer((sessions) => {
+      receivedSessionPages.push(sessions.map((session) => session.id));
+    });
 
     await service.start();
     await service.loadMore("section:project:/repo");
@@ -108,9 +112,8 @@ describe("WorkspaceConversationRailService", () => {
       sessionIds: ["session-1", "session-2"],
       totalCount: 2
     });
-    expect(service.getSnapshot().sessions.map((session) => session.id)).toEqual(
-      ["session-1", "session-2"]
-    );
+    expect(receivedSessionPages).toEqual([["session-1"], ["session-2"]]);
+    expect(service.getSnapshot()).not.toHaveProperty("sessions");
 
     service.dispose();
   });
@@ -203,6 +206,48 @@ describe("WorkspaceConversationRailService", () => {
 
     service.setLiveConnected(false);
     expect(clock.activeDelays()).toEqual([2_000]);
+    service.dispose();
+  });
+
+  test("keeps canonical session entities out of rail state", async () => {
+    const session = createSession("session-1", 1);
+    const received: WorkspaceAgentSession[][] = [];
+    const client = {
+      listWorkspaceAgentSessionSections: async () => ({
+        pinned: { hasMore: false, sessions: [], totalCount: 0 },
+        sections: [
+          {
+            hasMore: false,
+            kind: "conversations" as const,
+            sectionKey: "conversations",
+            sessions: [session],
+            totalCount: 1
+          }
+        ],
+        workspaceId: workspace.id
+      })
+    } as unknown as TuttidClient;
+    const service = new WorkspaceConversationRailService(
+      workspace,
+      client,
+      new ManualClock()
+    );
+    service.attachSessionConsumer((sessions) => received.push([...sessions]));
+
+    await service.start();
+
+    expect(received).toEqual([[session]]);
+    expect(service.getSnapshot()).toEqual({
+      errorCode: null,
+      loadingMoreSectionId: null,
+      sections: [
+        expect.objectContaining({
+          sessionIds: ["session-1"],
+          totalCount: 1
+        })
+      ],
+      status: "ready"
+    });
     service.dispose();
   });
 });

--- a/apps/mobile/src/services/workspaceConversationRailService.ts
+++ b/apps/mobile/src/services/workspaceConversationRailService.ts
@@ -32,9 +32,12 @@ export interface WorkspaceConversationRailSnapshot {
   errorCode: "request_failed" | null;
   loadingMoreSectionId: string | null;
   sections: readonly WorkspaceConversationRailMembership[];
-  sessions: readonly WorkspaceAgentSession[];
   status: "idle" | "loading" | "ready";
 }
+
+type WorkspaceConversationRailSessionConsumer = (
+  sessions: readonly WorkspaceAgentSession[]
+) => void;
 
 export class WorkspaceConversationRailService extends ObservableService<WorkspaceConversationRailSnapshot> {
   readonly _serviceBrand: undefined;
@@ -43,11 +46,12 @@ export class WorkspaceConversationRailService extends ObservableService<Workspac
   private paused = false;
   private loadPromise: Promise<void> | null = null;
   private pollTask: { cancel(): void } | null = null;
+  private sessionConsumer: WorkspaceConversationRailSessionConsumer | null =
+    null;
   private snapshot: WorkspaceConversationRailSnapshot = {
     errorCode: null,
     loadingMoreSectionId: null,
     sections: [],
-    sessions: [],
     status: "idle"
   };
 
@@ -60,6 +64,20 @@ export class WorkspaceConversationRailService extends ObservableService<Workspac
   }
 
   getSnapshot = (): WorkspaceConversationRailSnapshot => this.snapshot;
+
+  attachSessionConsumer(
+    consumer: WorkspaceConversationRailSessionConsumer
+  ): () => void {
+    if (this.sessionConsumer && this.sessionConsumer !== consumer) {
+      throw new Error(
+        "mobile conversation rail already has a session consumer"
+      );
+    }
+    this.sessionConsumer = consumer;
+    return () => {
+      if (this.sessionConsumer === consumer) this.sessionConsumer = null;
+    };
+  }
 
   start(): Promise<void> {
     return this.refresh();
@@ -112,17 +130,14 @@ export class WorkspaceConversationRailService extends ObservableService<Workspac
           freshSections,
           this.snapshot.sections
         );
-        const freshSessions = uniqueSessions(freshSections, response);
+        const freshSessions = uniqueSessions(response);
         this.snapshot = {
           errorCode: null,
           loadingMoreSectionId: null,
           sections,
-          sessions: sessionsForMemberships(
-            sections,
-            mergeSessions(this.snapshot.sessions, freshSessions)
-          ),
           status: "ready"
         };
+        this.sessionConsumer?.(freshSessions);
         this.emitChange();
       })
       .catch(() => {
@@ -199,7 +214,6 @@ export class WorkspaceConversationRailService extends ObservableService<Workspac
               )
             ).section;
       if (this.disposed || this.paused) return;
-      const sessions = mergeSessions(this.snapshot.sessions, page.sessions);
       const sections = this.snapshot.sections.map((candidate) =>
         candidate.id === sectionId
           ? {
@@ -218,9 +232,9 @@ export class WorkspaceConversationRailService extends ObservableService<Workspac
         errorCode: null,
         loadingMoreSectionId: null,
         sections,
-        sessions,
         status: "ready"
       };
+      this.sessionConsumer?.(page.sessions);
     } catch {
       if (this.disposed) return;
       this.snapshot = {
@@ -267,6 +281,7 @@ export class WorkspaceConversationRailService extends ObservableService<Workspac
     this.pollTask?.cancel();
     this.pollTask = null;
     this.loadPromise = null;
+    this.sessionConsumer = null;
     this.clearListeners();
   }
 
@@ -315,13 +330,10 @@ function membershipFromPage(input: {
   };
 }
 
-function uniqueSessions(
-  sections: readonly WorkspaceConversationRailMembership[],
-  response: {
-    pinned: { sessions: readonly WorkspaceAgentSession[] };
-    sections: readonly WorkspaceAgentSessionSection[];
-  }
-): WorkspaceAgentSession[] {
+function uniqueSessions(response: {
+  pinned: { sessions: readonly WorkspaceAgentSession[] };
+  sections: readonly WorkspaceAgentSessionSection[];
+}): WorkspaceAgentSession[] {
   const sessionsById = new Map<string, WorkspaceAgentSession>();
   for (const session of response.pinned.sessions) {
     sessionsById.set(session.id, session);
@@ -331,11 +343,7 @@ function uniqueSessions(
       sessionsById.set(session.id, session);
     }
   }
-  const orderedIds = sections.flatMap((section) => section.sessionIds);
-  return orderedIds.flatMap((id) => {
-    const session = sessionsById.get(id);
-    return session ? [session] : [];
-  });
+  return [...sessionsById.values()];
 }
 
 function reconcileRefreshedMemberships(
@@ -370,30 +378,6 @@ function reconcileRefreshedMemberships(
       sessionIds
     };
   });
-}
-
-function sessionsForMemberships(
-  sections: readonly WorkspaceConversationRailMembership[],
-  sessions: readonly WorkspaceAgentSession[]
-): WorkspaceAgentSession[] {
-  const sessionsById = new Map(
-    sessions.map((session) => [session.id, session])
-  );
-  return sections.flatMap((section) =>
-    section.sessionIds.flatMap((sessionId) => {
-      const session = sessionsById.get(sessionId);
-      return session ? [session] : [];
-    })
-  );
-}
-
-function mergeSessions(
-  current: readonly WorkspaceAgentSession[],
-  next: readonly WorkspaceAgentSession[]
-): WorkspaceAgentSession[] {
-  const byId = new Map(current.map((session) => [session.id, session]));
-  for (const session of next) byId.set(session.id, session);
-  return [...byId.values()];
 }
 
 function uniqueIds(ids: readonly string[]): string[] {

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -930,9 +930,12 @@ disconnected-transport fallback only.
 
 After either transport is normalized, Desktop and Mobile call the same
 `analyzeAgentActivityEventObservation` helper. The helper derives inline
-messages, validates version continuity, and emits one
-`session/activityObserved` intent with the required reconcile scope. Mobile
-does not widen its four-variant framed live protocol to mirror Desktop:
+messages, validates envelope/data/message identity, requires every advertised
+message to parse, checks the advertised count and latest-version cursor, and
+then validates version continuity. Any disagreement fails closed to
+authoritative reconciliation. The helper emits one `session/activityObserved`
+intent with the required reconcile scope. Mobile does not widen its four-variant
+framed live protocol to mirror Desktop:
 canonical `message_update`, `session_deleted`, and
 `session_reconcile_required` events are converted server-side to scoped
 discontinuities and converge through authoritative reads.
@@ -1086,8 +1089,9 @@ For runtime boundary enforcement:
   retries, event wiring, and orchestration remain in each application adapter.
 - Root detail DTOs use the adapter's aggregate mapper so root Session, child
   Sessions, and Turns enter the Engine through one
-  `session/detailSnapshotReceived` intent. A malformed nested entity rejects
-  the aggregate instead of publishing a partial hierarchy.
+  `session/detailSnapshotReceived` intent. The mapper verifies the requested
+  Session identity, child hierarchy, and Turn ownership; a malformed nested
+  entity rejects the aggregate instead of publishing a partial hierarchy.
 - Engine prompt commands use the activity-core prompt executor. Required
   settings are persisted before send, and a failed settings write prevents
   delivery; transport request mapping remains host-owned.

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -287,6 +287,12 @@ errors. In particular, `listSessionSectionDeletionCandidates` and
 the action and reports
 `agent.gui.conversation_batch_delete.capability_incomplete` when a host exposes
 only one half, instead of accepting a click that cannot complete.
+Native Mobile currently owns a narrower Rail controller, but it obeys the same
+entity boundary: the controller retains only section membership, ordered
+Session ids, cursors, totals, and request state. Generated Session DTOs from
+first-page and pagination responses are transient adapter input and are
+immediately upserted into the workspace Engine; they are never retained in a
+second Mobile Rail entity store.
 Every daemon `WorkspaceAgentSession` response carries the persisted membership
 as required `railSectionKey`. The desktop adapter rejects a missing or blank
 value as a protocol contract error; it must not manufacture `conversations` or
@@ -922,6 +928,15 @@ AAR; the transport package's AAR and Java namespace remain Agent-free. Mobile
 disables its message and Rail pollers after `stream_ready`; those pollers are
 disconnected-transport fallback only.
 
+After either transport is normalized, Desktop and Mobile call the same
+`analyzeAgentActivityEventObservation` helper. The helper derives inline
+messages, validates version continuity, and emits one
+`session/activityObserved` intent with the required reconcile scope. Mobile
+does not widen its four-variant framed live protocol to mirror Desktop:
+canonical `message_update`, `session_deleted`, and
+`session_reconcile_required` events are converted server-side to scoped
+discontinuities and converge through authoritative reads.
+
 Hosts may accept older provider/runtime reports with missing transcript
 ownership or ordering fields, but those gaps must be filled before events enter
 `agent-activity-core` or `@tutti-os/agent-gui`. Session-level notices and
@@ -1069,5 +1084,12 @@ For runtime boundary enforcement:
 - A pure generated-`tuttid` DTO projection shared by Desktop and Mobile belongs
   in `agent-activity-tuttid-adapter`. Host identity injection, transport,
   retries, event wiring, and orchestration remain in each application adapter.
+- Root detail DTOs use the adapter's aggregate mapper so root Session, child
+  Sessions, and Turns enter the Engine through one
+  `session/detailSnapshotReceived` intent. A malformed nested entity rejects
+  the aggregate instead of publishing a partial hierarchy.
+- Engine prompt commands use the activity-core prompt executor. Required
+  settings are persisted before send, and a failed settings write prevents
+  delivery; transport request mapping remains host-owned.
 - External repository adoption should require implementing the adapter, not
   copying session merge or needs-attention logic.

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -395,7 +395,8 @@ notice does not offer a manual retry because transport recovery is host-owned.
   dispatch each entity independently
 - Desktop and Mobile use the same host-neutral event-observation helper to
   decide whether normalized entities can apply inline and whether the exact
-  Session needs an authoritative state or message reconcile
+  Session needs an authoritative state or message reconcile; partial parsing,
+  identity mismatch, count mismatch, or cursor disagreement always reconciles
 - message updates fold inline only when unseen versions are continuous
 - version gaps and reconnects trigger incremental message reconciliation for hydrated Sessions
 - Turn, Interaction, and legacy state invalidation trigger authoritative Session reconciliation
@@ -404,6 +405,11 @@ notice does not offer a manual retry because transport recovery is host-owned.
 ### 4.3 Root and child hydration
 
 Workspace lists show root Sessions only. A root detail read also returns nested child Sessions; the engine stores every entity, Rail selects roots, and timeline/Message Center selectors aggregate descendants.
+
+Child Session discovery does not require every host to prefetch child transcript
+pages. A surface that does not render child conversations keeps the hierarchy
+and pending Interaction state canonical without paying for unused child message
+history.
 
 A `waiting` Turn does not imply user action. Only a pending Interaction produces approval/question attention.
 

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -13,6 +13,8 @@ Scope:
 - `packages/agent/activity-core`: frontend workspace engine
 - `packages/agent/gui`: Agent GUI, Message Center, and conversation presentation
 - `apps/desktop`: Electron, Workbench, transport, and concrete host capabilities
+- `apps/mobile`: React Native presentation, DeviceLink transport adapter, and
+  mobile lifecycle integration
 
 Implementation progress belongs in Git history or an active spec. Debugging procedures belong in [Agent Runtime Troubleshooting](../conventions/troubleshooting/agent-runtime.md).
 
@@ -116,7 +118,7 @@ AgentGUI / Message Center / host surface
   -> typed intent or AgentActivityRuntime command
   -> workspace AgentSessionEngine
   -> injected command port
-  -> Desktop WorkspaceAgentActivityService / adapter
+  -> Desktop or Mobile workspace activity adapter
   -> tuttid HTTP and product adapter
   -> packages/agent/host
   -> canonical store transaction + provider runtime port
@@ -129,7 +131,7 @@ provider runtime observation
   -> packages/agent/host + store-sqlite canonical transaction
   -> CommittedDelta / CommitObserver
   -> tuttid ActivityProjection and event publication
-  -> Desktop event/reconcile bridge
+  -> Desktop business-event bridge or Mobile DeviceLink live lane
   -> workspace AgentSessionEngine reducer
   -> memoized AgentActivitySnapshot
   -> selectors / pure projections
@@ -138,17 +140,18 @@ provider runtime observation
 
 ### 2.3 Ownership map
 
-| Layer                           | Owns                                                                                       | Must not own                                |
-| ------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------- |
-| `store-sqlite/canonical`        | canonical phase, outcome, origin, Interaction, capability vocabulary, and pure projections | HTTP, provider processes, React             |
-| `store-sqlite`                  | canonical transactions, SQLite repositories, durable tombstones/outbox participation       | product UI, transport policy                |
-| `packages/agent/host`           | create/resume/send/cancel, Interaction, Goal, operation, and recovery lifecycle            | HTTP DTOs, Electron, concrete provider wire |
-| `packages/agent/daemon`         | provider registry, runtime mechanics, wire normalization                                   | AgentGUI policy, cross-provider UI branches |
-| `services/tuttid/service/agent` | Host adapters, HTTP/query/composer/product policy, provider preparation                    | reimplementation of Host lifecycle          |
-| tuttid `ActivityProjection`     | canonical read projection, commit observation, event publication/repair                    | lifecycle decisions, React state            |
-| `agent-activity-core`           | workspace engine, canonical frontend entities, pending intents, queue, selectors           | HTTP, Electron, React                       |
-| `agent-gui`                     | runtime contract, projections, controllers, views, UI-local state                          | daemon truth, a second session store        |
-| `apps/desktop`                  | tuttid client, business-event WebSocket, preload, Workbench, windows, file/OS capabilities | a second Agent business core                |
+| Layer                           | Owns                                                                                       | Must not own                                      |
+| ------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------- |
+| `store-sqlite/canonical`        | canonical phase, outcome, origin, Interaction, capability vocabulary, and pure projections | HTTP, provider processes, React                   |
+| `store-sqlite`                  | canonical transactions, SQLite repositories, durable tombstones/outbox participation       | product UI, transport policy                      |
+| `packages/agent/host`           | create/resume/send/cancel, Interaction, Goal, operation, and recovery lifecycle            | HTTP DTOs, Electron, concrete provider wire       |
+| `packages/agent/daemon`         | provider registry, runtime mechanics, wire normalization                                   | AgentGUI policy, cross-provider UI branches       |
+| `services/tuttid/service/agent` | Host adapters, HTTP/query/composer/product policy, provider preparation                    | reimplementation of Host lifecycle                |
+| tuttid `ActivityProjection`     | canonical read projection, commit observation, event publication/repair                    | lifecycle decisions, React state                  |
+| `agent-activity-core`           | workspace engine, canonical frontend entities, pending intents, queue, selectors           | HTTP, Electron, React                             |
+| `agent-gui`                     | runtime contract, projections, controllers, views, UI-local state                          | daemon truth, a second session store              |
+| `apps/desktop`                  | tuttid client, business-event WebSocket, preload, Workbench, windows, file/OS capabilities | a second Agent business core                      |
+| `apps/mobile`                   | DeviceLink adapter, Native renderer, app lifecycle, navigation and drafts                  | a second Agent business core or Session DTO cache |
 
 `services/tuttid/api/openapi/tuttid.v1.yaml` is authoritative for HTTP request/response contracts. It projects the canonical domain; it does not replace `store-sqlite/canonical`.
 
@@ -341,6 +344,13 @@ but disabled until the transport recovers. It must not reuse the engine-wide
 connection state for this case, because one remote Session losing its owner must
 not disable Local Agent or another remote Session.
 
+Mobile projects pending Interactions from the root conversation plus its child
+Sessions and reads each exact Engine response record for submitting/failure
+state. Native cards dispatch semantic response intents only; they do not keep a
+parallel Promise lifecycle. Missing provider-authored Plan options fail closed,
+and runtime unavailability disables the exact response without discarding
+composer drafts or Interaction identity.
+
 Device connection presentation is target-scoped rather than Session-scoped.
 The host exposes a target connection source keyed by `agentTargetId` with the
 current status and retry attempt, and AgentGUI reads the active conversation
@@ -380,8 +390,12 @@ notice does not offer a manual retry because transport recovery is host-owned.
 - an authoritative Session detail result enters through
   `session/detailSnapshotReceived`; `agent-activity-core` expands the root
   Session, Turns, child Sessions, and optional message coverage in one engine
-  drain and one subscriber notification. Desktop maps transport data into that
-  intent and must not dispatch each entity independently
+  drain and one subscriber notification. Desktop and Mobile use the same
+  `@tutti-os/agent-activity-tuttid-adapter` aggregate mapper and must not
+  dispatch each entity independently
+- Desktop and Mobile use the same host-neutral event-observation helper to
+  decide whether normalized entities can apply inline and whether the exact
+  Session needs an authoritative state or message reconcile
 - message updates fold inline only when unseen versions are continuous
 - version gaps and reconnects trigger incremental message reconciliation for hydrated Sessions
 - Turn, Interaction, and legacy state invalidation trigger authoritative Session reconciliation
@@ -411,6 +425,13 @@ The busy-session prompt queue is ephemeral durable-intent coordination in the wo
 ### 4.5 Rail query and presentation state
 
 The Rail query cache stores section metadata, ordered Session IDs, cursors, and totals only. Session entities always come from the engine.
+
+Mobile follows the same ownership rule even though its Native Rail controller is
+host-owned: each first-page or pagination response passes Session DTOs
+transiently through the shared mapper into Engine upserts, while the Rail
+snapshot retains only memberships, ordered IDs, cursors, totals, and loading
+state. Refreshing a bounded Rail page is not deletion evidence and must not
+replace or prune canonical Engine entities.
 
 Cross-platform hosts may reuse the DOM-free canonical Rail summary projection
 from `@tutti-os/agent-gui/conversation-rail-projection`. They must still obtain
@@ -452,6 +473,14 @@ state local. Existing-session setting changes enter the engine as
 `session/settingsUpdateRequested`; new-session draft settings travel on the
 activation intent. A renderer must not call the settings endpoint from a
 component or invent a provider-specific settings schema.
+
+An activation intent's shared Session settings are not an HTTP create-field
+allowlist. Each host must construct a typed
+`CreateWorkspaceAgentSessionRequest` and forward only fields present in the
+generated contract. In particular, `computerUse` is a default-on runtime
+setting but is not currently a create-request field; Mobile must not add it as
+an extra property. Supporting an explicit first-Turn opt-out requires changing
+OpenAPI and the create adapter first.
 
 Hosts install the complete query/mutation cohort from
 `@tutti-os/agent-gui/conversation-rail-runtime`; the shared factory owns the
@@ -700,6 +729,9 @@ observe the portaled menu DOM, or infer target identity from provider or
 visible text. The current conversation's composer input availability is
 independent from this launch surface: a target connection may disable input
 while Handoff remains available when the host supplies the launch callback.
+Handoff preserves canonical Rail placement: a source in the Chats section
+omits its runtime `cwd` from the destination project selection, while a source
+in a project section carries that project's path.
 AgentGUI DOM surfaces render the target's owner badge through the shared UI
 System Avatar primitive. A failed owner image falls back to the supplied owner
 label initial instead of exposing a browser broken-image glyph.

--- a/docs/conventions/troubleshooting/mobile.md
+++ b/docs/conventions/troubleshooting/mobile.md
@@ -83,33 +83,44 @@
   `apps/mobile/src/services/workspaceActivityCommandAdapter.ts`,
   `apps/mobile/src/components/MobileComposerSettingsSheet.tsx`
 
-## Mobile composer option chips do not open
+## Mobile composer option sheets do not respond
 
 - **Symptom:** Model, reasoning, speed, and permission chips are visible and
   accessible above the composer, but tapping them does not show their option
-  sheet. The same model or permission options remain reachable through the `+`
-  menu.
+  sheet; or rapidly alternating between a chip and the `+` button leaves two
+  overlapping menus, with the lower menu visible but unable to receive taps.
 - **Quick checks:** Tap a chip on a real Android or iOS renderer and inspect the
   JavaScript log. Repeated `BottomSheetModal::handlePortalRender` entries,
-  followed by a maximum-update-depth error, identify the overlay path; a
-  missing composer-options response is a different problem covered above.
-- **Root cause:** `@gorhom/bottom-sheet` delegates `BottomSheetModal` rendering
-  through `@gorhom/portal`. Its portal update path is incompatible with the
+  followed by a maximum-update-depth error, identify the legacy overlay path.
+  Without that error, inspect the native window hierarchy: two simultaneous
+  composer `Modal` windows identify competing local overlay state rather than
+  a slow or missing press handler. A missing composer-options response is a
+  different problem covered above.
+- **Root causes:** `@gorhom/bottom-sheet` delegates `BottomSheetModal` rendering
+  through `@gorhom/portal`; its portal update path is incompatible with the
   current React 19 Native renderer and recursively republishes the modal node
-  instead of presenting it.
+  instead of presenting it. Separately, sibling composer controls must not own
+  independent window-level overlay state: queued taps can open both windows,
+  and the top window then intercepts input intended for the visible lower one.
 - **Fix:** Keep the shared compact `NativeSheet` on React Native's window-level
   `Modal`, with UI System scrim and panel tokens. Require a caller-localized
   close label, expose backdrop dismissal as an accessibility button, handle the
   iOS accessibility escape gesture, and represent an optional fixed height as
   one value rather than silently accepting multiple snap points. Reserve
   `@gorhom/bottom-sheet` for app-owned complex sheets that genuinely need its
-  gesture, keyboard, or multi-snap-point behavior.
+  gesture, keyboard, or multi-snap-point behavior. At composition boundaries
+  that offer multiple overlay entry points, keep one discriminated overlay
+  state in their nearest common owner and make child controls submit typed menu
+  intents.
 - **Validation:** Open and dismiss the model, speed, and permission sheets more
   than once, select the already active option without changing Session state,
-  and confirm there is no maximum-update-depth error. Also verify touch
-  backdrop, Android system-back, VoiceOver escape, and screen-reader close
-  button dismissal without hiding the sheet's interactive descendants.
+  and rapidly alternate between a settings chip and `+`; assert that no more
+  than one native modal is visible. Confirm there is no maximum-update-depth
+  error. Also verify touch backdrop, Android system-back, VoiceOver escape, and
+  screen-reader close button dismissal without hiding the sheet's interactive
+  descendants.
 - **References:** `packages/ui/system/src/native/sheet.tsx`,
+  `apps/mobile/src/components/MobileComposerDock.tsx`,
   `apps/mobile/src/components/MobileComposerSettingsSheet.tsx`
 
 ## Browser login returns to the App but remains signed out

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -412,7 +412,8 @@ Google Play 账号。以下事项等正式分发前再处理：
   Mobile 将 `message_delta` 投影到 activity-core optimistic overlay，直接应用
   Turn/Interaction 更新，并在 discontinuity、序列断点和重连时读取 canonical 数据；
 - workspace 前台已有 live stream 时不再运行一秒消息轮询和两秒会话轮询；长流断开或
-  协议不可用时才恢复单飞轮询，并以一秒退避自动重建 live stream；
+  协议不可用时才恢复轮询。消息读取按 Session 分别 single-flight，不让旧会话的慢请求
+  阻塞用户刚切换到的会话，并以一秒退避自动重建 live stream；
 - Android caller 已接入 create/get/update attempt、STUN 二次 gathering、真实
   DeviceLink request stream、端到端请求 deadline、prepare/connect generation
   fencing 和 Native 15 秒后台 grace period；
@@ -426,6 +427,10 @@ Google Play 账号。以下事项等正式分发前再处理：
   切换会话会定位最新内容，流式更新只在 `following` 时跟随；主动上滑会在首个滚动帧前
   进入 `detached` 并提供回到底部入口，内容增长和近底部几何不能自行恢复跟随；加载历史
   消息时保持当前阅读锚点；
+- Rail service 只保存 section membership、Session id、cursor、total 和请求状态；
+  首屏与分页返回的 Session DTO 瞬时通过共享 mapper upsert 到 workspace Engine，
+  不在 Mobile 再维护一份实体缓存。root detail 的 Session、child Session 和 Turn
+  也通过一个原子 `session/detailSnapshotReceived` 进入 Engine；
 - Agent 消息正文已接入 Fabric 原生 Markdown renderer，支持 GFM 标题、列表、代码块、
   表格、任务列表、流式尾部动画和系统文本选择；样式全部映射到 Native UI System
   token，Mobile 不再维护 Markdown AST 或另一份消息类型；
@@ -436,6 +441,9 @@ Google Play 账号。以下事项等正式分发前再处理：
   AgentGUI 的纯 support/settings projection 和 activity-tuttid DTO mapper。Native
   sheet 只负责模型、推理、速度、权限和计划模式的本地展示；已有会话设置走 Engine
   command，新建会话的目标设置作为 activation intent 一并提交；
+- Mobile 与 Desktop 复用 activity-core 的 realtime observation 和 prompt command
+  executor。Interaction 的 submitting/failure、child 聚合和 per-Session runtime
+  availability 全部从 Engine 投影，Native card 不维护独立 Promise 状态；
 - Go authenticated link、owner host、application frame、allowlist、race，以及
   TypeScript/Jest、Metro bundle、Kotlin/Java/CMake、四 ABI APK 均已有自动验证。
 - `apps/mobile/ios` 已建立 React Native 0.86/Fabric Simulator shell，并提供与

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -412,8 +412,9 @@ Google Play 账号。以下事项等正式分发前再处理：
   Mobile 将 `message_delta` 投影到 activity-core optimistic overlay，直接应用
   Turn/Interaction 更新，并在 discontinuity、序列断点和重连时读取 canonical 数据；
 - workspace 前台已有 live stream 时不再运行一秒消息轮询和两秒会话轮询；长流断开或
-  协议不可用时才恢复轮询。消息读取按 Session 分别 single-flight，不让旧会话的慢请求
-  阻塞用户刚切换到的会话，并以一秒退避自动重建 live stream；
+  协议不可用时才恢复轮询。消息读取按 Session 和查询覆盖范围分别 single-flight，
+  older/incremental 请求不会吞掉 live gap 所需的 authoritative newest-page 读取；
+  旧会话的慢请求也不会阻塞用户刚切换到的会话，并以一秒退避自动重建 live stream；
 - Android caller 已接入 create/get/update attempt、STUN 二次 gathering、真实
   DeviceLink request stream、端到端请求 deadline、prepare/connect generation
   fencing 和 Native 15 秒后台 grace period；
@@ -430,7 +431,9 @@ Google Play 账号。以下事项等正式分发前再处理：
 - Rail service 只保存 section membership、Session id、cursor、total 和请求状态；
   首屏与分页返回的 Session DTO 瞬时通过共享 mapper upsert 到 workspace Engine，
   不在 Mobile 再维护一份实体缓存。root detail 的 Session、child Session 和 Turn
-  也通过一个原子 `session/detailSnapshotReceived` 进入 Engine；
+  也通过一个原子 `session/detailSnapshotReceived` 进入 Engine；当前 Native
+  会话流不展示 child 对话，因此只分页读取选中 root Session 的消息，不预取没有消费方的
+  child transcript；
 - Agent 消息正文已接入 Fabric 原生 Markdown renderer，支持 GFM 标题、列表、代码块、
   表格、任务列表、流式尾部动画和系统文本选择；样式全部映射到 Native UI System
   token，Mobile 不再维护 Markdown AST 或另一份消息类型；
@@ -443,7 +446,9 @@ Google Play 账号。以下事项等正式分发前再处理：
   command，新建会话的目标设置作为 activation intent 一并提交；
 - Mobile 与 Desktop 复用 activity-core 的 realtime observation 和 prompt command
   executor。Interaction 的 submitting/failure、child 聚合和 per-Session runtime
-  availability 全部从 Engine 投影，Native card 不维护独立 Promise 状态；
+  availability 全部从 Engine 投影；前后台恢复会解锁 Engine 中全部已知 Session，
+  不依赖有界 Rail 页重新发现。Native card 不维护独立 Promise 状态，失败重试复用
+  Engine 保存的原始 response，不能修改后伪装成同一请求；
 - Go authenticated link、owner host、application frame、allowlist、race，以及
   TypeScript/Jest、Metro bundle、Kotlin/Java/CMake、四 ABI APK 均已有自动验证。
 - `apps/mobile/ios` 已建立 React Native 0.86/Fabric Simulator shell，并提供与

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -412,7 +412,9 @@ Google Play 账号。以下事项等正式分发前再处理：
   Mobile 将 `message_delta` 投影到 activity-core optimistic overlay，直接应用
   Turn/Interaction 更新，并在 discontinuity、序列断点和重连时读取 canonical 数据；
 - workspace 前台已有 live stream 时不再运行一秒消息轮询和两秒会话轮询；长流断开或
-  协议不可用时才恢复轮询。消息读取按 Session 和查询覆盖范围分别 single-flight，
+  协议不可用时才恢复轮询。`WorkspaceActivityMessagePageLoader` 单独负责 transport
+  page 请求、DTO 映射、Engine 应用和按 Session + 查询覆盖范围的 single-flight；
+  `WorkspaceActivityService` 只决定轮询时机和 authoritative/incremental 读取语义。
   older/incremental 请求不会吞掉 live gap 所需的 authoritative newest-page 读取；
   旧会话的慢请求也不会阻塞用户刚切换到的会话，并以一秒退避自动重建 live stream；
 - Android caller 已接入 create/get/update attempt、STUN 二次 gathering、真实

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -443,7 +443,11 @@ Google Play 账号。以下事项等正式分发前再处理：
 - Composer options 以 Agent Target 为 key 通过同一个 `AgentSessionEngine` 加载，复用
   AgentGUI 的纯 support/settings projection 和 activity-tuttid DTO mapper。Native
   sheet 只负责模型、推理、速度、权限和计划模式的本地展示；已有会话设置走 Engine
-  command，新建会话的目标设置作为 activation intent 一并提交；
+  command，新建会话的目标设置作为 activation intent 一并提交。settings sheet 与
+  tools modal 共享一个带 activation identity 的 overlay 状态，Native 延迟关闭回调
+  只能关闭自己所属的 activation，不能在 ABA 切换后关闭同类型的新 overlay；
+  `commandsAvailable` 为 false 时关闭现有 overlay，并统一禁用输入、工具入口、设置
+  chips 和 sheet 选项，避免展示可操作但会被 command adapter 拒绝的控件；
 - Mobile 与 Desktop 复用 activity-core 的 realtime observation 和 prompt command
   executor。Interaction 的 submitting/failure、child 聚合和 per-Session runtime
   availability 全部从 Engine 投影；前后台恢复会解锁 Engine 中全部已知 Session，

--- a/docs/plans/2026-07-25-mobile-agent-di-data-layer.md
+++ b/docs/plans/2026-07-25-mobile-agent-di-data-layer.md
@@ -70,7 +70,9 @@ React bindings or decorator syntax in service modules.
   cursors, totals, and project labels. It uses the server's exact
   `railSectionKey` membership and never infers projects from `cwd`.
 - Rail Session DTOs and message pages are mapped into canonical activity
-  entities and dispatched into one workspace `AgentSessionEngine`.
+  entities and dispatched into one workspace `AgentSessionEngine`. The Rail
+  snapshot retains only membership, ordered ids, cursors, totals, and request
+  state; Session DTOs are transient input rather than a second entity cache.
 - Mobile consumes the DOM-free
   `@tutti-os/agent-gui/conversation-rail-projection` entry for the same title,
   provider, status, attention, pin, and sort semantics as Agent GUI, then

--- a/docs/specs/2026-07-23-mobile-agentgui-device-link-design.md
+++ b/docs/specs/2026-07-23-mobile-agentgui-device-link-design.md
@@ -26,8 +26,11 @@ workspace catalog, Agent Target directory, navigation identity, drafts,
 polling, and command execution live in pure TypeScript services rather than
 screen effects. Workspace state is projected from one
 `AgentSessionEngine`; Desktop and Mobile share generated-tuttid DTO mapping
-through `@tutti-os/agent-activity-tuttid-adapter`. Conversation-list visual
-alignment remains the next UI milestone.
+through `@tutti-os/agent-activity-tuttid-adapter`, shared realtime-observation
+rules through `@tutti-os/agent-activity-core`, and DOM-free conversation and
+Rail projections through `@tutti-os/agent-gui`. Mobile Rail state contains only
+membership and pagination metadata; canonical Session entities remain in the
+Engine. Conversation-list visual alignment remains the next UI milestone.
 
 ## 1. 背景
 
@@ -544,8 +547,11 @@ allowlist 和 Android fetch adapter，并直接复用生成的
 `@tutti-os/client-tuttid-ts`；workspace、Agent Target catalog、Session
 list/get/create/send/cancel/Interaction 均沿用现有 HTTP contract。owner host 会在
 caller 获得 response-only STUN endpoints 并二次发布 ICE 后再认领 attempt，避免
-连接旧 fingerprint。Relay 和 event stream 尚未实现，当前消息更新使用前台增量
-snapshot polling。
+连接旧 fingerprint。Relay 尚未实现。direct lane 的 `agent_live` event stream
+已经接入：delta、Turn、Interaction 和 session audit 通过 framed live protocol
+进入 Mobile；canonical-only 更新由 Personal 的 `mobileremote` adapter 转为
+scoped discontinuity，再触发权威 snapshot reconcile。Session/Message poller
+仅在 event stream 未就绪或断开时作为降级路径。
 
 ### M4 — Mobile App shell（Android 首发）
 
@@ -594,13 +600,18 @@ Simulator 的相机路径明确使用现有手动配对码降级。真机与分�
 Interaction 提交已接入。Mobile 已接入 workspace `AgentSessionEngine`；create、
 send、stop 和 Interaction response 统一通过 Engine intent/command port，Session
 和 Message 快照映射后进入同一 canonical state。Desktop 与 Mobile 的生成契约
-映射由 `@tutti-os/agent-activity-tuttid-adapter` 复用。当前 Native renderer 是
+映射、Session detail 聚合和事件 reconcile 判定分别由
+`@tutti-os/agent-activity-tuttid-adapter` 与
+`@tutti-os/agent-activity-core` 复用；Mobile Rail 只保存分组、Session id、游标
+和总数，实体页瞬时映射后直接 upsert 到 Engine。Interaction 提交中、失败状态和
+per-Session runtime availability 也由 Engine 投影，Native card 不维护第二套
+Promise 状态。当前 Native renderer 是
 `apps/mobile` 内的 MVP presentation adapter；它不定义 Session/Message DTO。
 Interaction answer payload 与原型安全的 question-id 读写已从
 `@tutti-os/agent-gui` 的无 DOM 子路径复用；轮询为 single-flight，超时重试保留
 原始 session/submit identity；不明确的写入会先做 workspace 权威校准，再使用同一
-identity 进入显式 Retry。事件流 reconcile、Markdown/code、unsupported fallback
-的完整视觉语义和会话列表视觉对齐仍是剩余项。
+identity 进入显式 Retry。Markdown/code、unsupported fallback 的完整视觉语义和
+会话列表视觉对齐仍是剩余项。
 
 ### M6 — 稳定性和第二阶段准备
 

--- a/packages/agent/activity-core/README.md
+++ b/packages/agent/activity-core/README.md
@@ -1,12 +1,12 @@
 # @tutti-os/agent-activity-core
 
-Shared agent activity state, merge rules, and selectors for Tutti agent UIs.
+Shared agent activity state, orchestration rules, merge rules, and selectors for
+Tutti agent UIs.
 
-This package owns the frontend-side session snapshot model used by surfaces such
-as `@tutti-os/agent-gui` and the future message center. It does not know about
-Electron, HTTP, SSE, or daemon DTOs. Product-specific code provides an
-`AgentActivityAdapter`; the controller turns that adapter into a stable in-memory
-snapshot.
+This package owns the frontend-side workspace engine and activity snapshot model
+used by Desktop and Mobile surfaces. It does not know about Electron, React
+Native, HTTP, SSE, DeviceLink, or daemon DTOs. Product-specific adapters execute
+transport commands and normalize observations before they enter the engine.
 
 ## Package Boundary
 
@@ -17,13 +17,17 @@ snapshot.
 - can retain live session event streams with reference-counted subscription
   lifecycle when a host adapter exposes that optional capability
 - merges persisted and live messages with version-aware conflict handling
+- analyzes normalized activity events into one inline-observation intent plus
+  an explicit authoritative-reconcile requirement
+- executes the shared prompt command sequence, including required settings
+  persistence before send
 - exposes selectors such as `selectNeedsAttentionCount`
 
 It intentionally does not render UI, open network connections directly, persist
 state, or translate daemon/backend contracts. Those responsibilities belong to a
 host adapter such as the desktop renderer adapter.
 
-## Session Engine (skeleton)
+## Session Engine
 
 `createAgentSessionEngine` is the workspace-level orchestration loop described
 in `docs/architecture/agent-gui-refactor-plan.md` (section 3.3). It is
@@ -60,9 +64,10 @@ Engine rules:
   surfaces subscribe through the single `useEngineSelector` binding in
   `@tutti-os/agent-gui`.
 
-The current state tree carries only the skeleton `engineRuntime` domain;
-business domains (turn lifecycle, queue send, optimistic intents) land as
-sibling reducers in later refactor slices.
+The state tree includes lifecycle entities, message windows, prompt queue,
+pending intents, composer options, runtime availability, reconciliation, and
+attention/read state. Hosts must consume selectors or stable snapshot
+projections instead of reading reducer maps from UI components.
 
 ## Adapter Contract
 
@@ -227,6 +232,24 @@ additionally accepts:
 
 Events with a different `workspaceId` are ignored. Unknown event types are
 ignored.
+
+Hosts use `analyzeAgentActivityEventObservation` after transport normalization.
+It returns inline messages, their version continuity, and the single
+`session/activityObserved` intent that drives Engine reconciliation. Desktop
+receives the full canonical event union. The paired-device live protocol carries
+only delta, Turn, Interaction, and audit variants; tuttid converts canonical-only
+message, deletion, and reconcile-required events into scoped discontinuities so
+Mobile performs an authoritative read instead of inventing a second event model.
+
+## Prompt Command Execution
+
+`executeAgentActivityPromptCommand` is the shared command-port helper for an
+Engine `queue/sendPrompt` command. When the command includes a required settings
+patch, the helper waits for that exact settings write before sending the prompt.
+If the write fails, it does not send. It preserves capability references,
+structured content, display prompt, guidance mode, and submit diagnostics
+without interpreting provider policy. Activation, transport DTO mapping, retry,
+and command-result dispatch remain host responsibilities.
 
 ## Message Merge Rules
 

--- a/packages/agent/activity-core/src/activityEventObservation.test.ts
+++ b/packages/agent/activity-core/src/activityEventObservation.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type {
+  AgentActivityMessage,
+  AgentActivityUpdatedEvent
+} from "./types.ts";
+import {
+  analyzeAgentActivityEventObservation,
+  analyzeInlineMessageVersionContinuity
+} from "./activityEventObservation.ts";
+
+test("inline continuity accepts an extension after the latest cached cursor", () => {
+  assert.deepEqual(
+    analyzeInlineMessageVersionContinuity(
+      [message(1), message(5)],
+      [message(6), message(7)]
+    ),
+    {
+      cachedVersion: 5,
+      continuous: true,
+      firstUnseenVersion: 6,
+      latestIncomingVersion: 7
+    }
+  );
+});
+
+test("inline continuity rejects an unseen mutable version hole", () => {
+  assert.equal(
+    analyzeInlineMessageVersionContinuity([message(1)], [message(3)])
+      .continuous,
+    false
+  );
+});
+
+test("message updates apply inline only for a cached Session with continuity", () => {
+  const event = messageUpdateEvent([eventMessage(2)]);
+  const cached = analyzeAgentActivityEventObservation({
+    cachedMessages: [message(1)],
+    event,
+    hasCachedSession: true
+  });
+  const uncached = analyzeAgentActivityEventObservation({
+    cachedMessages: [],
+    event: messageUpdateEvent([eventMessage(1)]),
+    hasCachedSession: false
+  });
+
+  assert.equal(cached.canApplyInlineMessages, true);
+  assert.equal(cached.intent.inlineApplied, true);
+  assert.equal(cached.intent.hasInlineMessages, true);
+  assert.equal(uncached.canApplyInlineMessages, true);
+  assert.equal(uncached.intent.inlineApplied, false);
+});
+
+test("turn and interaction observations require canonical state reconciliation", () => {
+  const event: Extract<
+    AgentActivityUpdatedEvent,
+    { eventType: "session_reconcile_required" }
+  > = {
+    agentSessionId: "session-1",
+    data: {
+      agentSessionId: "session-1",
+      agentTargetId: "target-1",
+      eventType: "session_reconcile_required",
+      lastEventUnixMs: 10,
+      workspaceId: "workspace-1"
+    },
+    eventType: "session_reconcile_required",
+    workspaceId: "workspace-1"
+  };
+
+  const observation = analyzeAgentActivityEventObservation({
+    cachedMessages: [],
+    event,
+    hasCachedSession: true
+  });
+
+  assert.deepEqual(observation.inlineMessages, []);
+  assert.deepEqual(observation.intent, {
+    agentSessionId: "session-1",
+    eventType: "session_reconcile_required",
+    hasCachedSession: true,
+    hasInlineMessages: false,
+    inlineApplied: false,
+    type: "session/activityObserved",
+    workspaceId: "workspace-1"
+  });
+});
+
+function message(version: number): AgentActivityMessage {
+  return {
+    workspaceId: "workspace-1",
+    agentSessionId: "session-1",
+    kind: "text",
+    messageId: `message-${version}`,
+    occurredAtUnixMs: version,
+    payload: { text: String(version) },
+    role: "assistant",
+    turnId: "turn-1",
+    version
+  };
+}
+
+function eventMessage(version: number) {
+  return {
+    agentSessionId: "session-1",
+    kind: "text",
+    messageId: `message-${version}`,
+    occurredAtUnixMs: version,
+    payload: { text: String(version) },
+    role: "assistant",
+    sequence: version,
+    turnId: "turn-1",
+    version
+  };
+}
+
+function messageUpdateEvent(
+  messages: ReturnType<typeof eventMessage>[]
+): Extract<AgentActivityUpdatedEvent, { eventType: "message_update" }> {
+  return {
+    agentSessionId: "session-1",
+    data: {
+      acceptedCount: messages.length,
+      agentSessionId: "session-1",
+      eventType: "message_update",
+      latestVersion: messages.at(-1)?.version ?? 0,
+      messages,
+      workspaceId: "workspace-1"
+    },
+    eventType: "message_update",
+    workspaceId: "workspace-1"
+  };
+}

--- a/packages/agent/activity-core/src/activityEventObservation.test.ts
+++ b/packages/agent/activity-core/src/activityEventObservation.test.ts
@@ -52,6 +52,59 @@ test("message updates apply inline only for a cached Session with continuity", (
   assert.equal(uncached.intent.inlineApplied, false);
 });
 
+test("message updates fail closed when any advertised message is malformed", () => {
+  const malformed = {
+    ...eventMessage(3),
+    occurredAtUnixMs: 0
+  };
+  const observation = analyzeAgentActivityEventObservation({
+    cachedMessages: [message(1)],
+    event: messageUpdateEvent([eventMessage(2), malformed]),
+    hasCachedSession: true
+  });
+
+  assert.deepEqual(
+    observation.inlineMessages.map((item) => item.version),
+    [2]
+  );
+  assert.equal(observation.canApplyInlineMessages, false);
+  assert.equal(observation.intent.inlineApplied, false);
+});
+
+test("message updates fail closed on envelope, message, or cursor disagreement", () => {
+  const mismatchedData = messageUpdateEvent([eventMessage(2)]);
+  mismatchedData.data.agentSessionId = "session-2";
+  const mismatchedMessage = messageUpdateEvent([
+    { ...eventMessage(2), agentSessionId: "session-2" }
+  ]);
+  const mismatchedCursor = messageUpdateEvent([eventMessage(2)]);
+  mismatchedCursor.data.latestVersion = 3;
+
+  for (const event of [mismatchedData, mismatchedMessage, mismatchedCursor]) {
+    const observation = analyzeAgentActivityEventObservation({
+      cachedMessages: [message(1)],
+      event,
+      hasCachedSession: true
+    });
+    assert.equal(observation.canApplyInlineMessages, false);
+    assert.equal(observation.intent.inlineApplied, false);
+  }
+});
+
+test("message updates fail closed when acceptedCount disagrees with the payload", () => {
+  const event = messageUpdateEvent([eventMessage(2)]);
+  event.data.acceptedCount = 2;
+
+  const observation = analyzeAgentActivityEventObservation({
+    cachedMessages: [message(1)],
+    event,
+    hasCachedSession: true
+  });
+
+  assert.equal(observation.canApplyInlineMessages, false);
+  assert.equal(observation.intent.inlineApplied, false);
+});
+
 test("turn and interaction observations require canonical state reconciliation", () => {
   const event: Extract<
     AgentActivityUpdatedEvent,

--- a/packages/agent/activity-core/src/activityEventObservation.ts
+++ b/packages/agent/activity-core/src/activityEventObservation.ts
@@ -1,0 +1,102 @@
+import { parseInlineActivityMessages } from "./inlineActivityMessages.ts";
+import type {
+  AgentActivityMessage,
+  AgentActivityUpdatedEvent
+} from "./types.ts";
+import type { SessionActivityObservedIntent } from "./engine/sessionReconcile.types.ts";
+
+type ObservableAgentActivityUpdatedEvent = Exclude<
+  AgentActivityUpdatedEvent,
+  { eventType: "message_delta" | "session_deleted" }
+>;
+
+export interface InlineMessageVersionContinuity {
+  cachedVersion: number;
+  continuous: boolean;
+  firstUnseenVersion: number | null;
+  latestIncomingVersion: number;
+}
+
+export interface AgentActivityEventObservation {
+  canApplyInlineMessages: boolean;
+  inlineContinuity: InlineMessageVersionContinuity;
+  inlineMessages: readonly AgentActivityMessage[];
+  intent: SessionActivityObservedIntent;
+}
+
+/**
+ * Derives the one engine observation for an authoritative activity event.
+ *
+ * Hosts may apply continuous inline messages before dispatching `intent`.
+ * The engine remains responsible for choosing the authoritative reconcile
+ * scope. Message deltas and deletion tombstones have separate stateful host
+ * handling and are deliberately excluded from this helper.
+ */
+export function analyzeAgentActivityEventObservation(input: {
+  cachedMessages: readonly AgentActivityMessage[];
+  event: ObservableAgentActivityUpdatedEvent;
+  hasCachedSession: boolean;
+}): AgentActivityEventObservation {
+  const inlineMessages = parseInlineActivityMessages(input.event);
+  const inlineContinuity = analyzeInlineMessageVersionContinuity(
+    input.cachedMessages,
+    inlineMessages
+  );
+  const canApplyInlineMessages =
+    inlineMessages.length > 0 && inlineContinuity.continuous;
+  return {
+    canApplyInlineMessages,
+    inlineContinuity,
+    inlineMessages,
+    intent: {
+      agentSessionId: input.event.agentSessionId,
+      eventType: input.event.eventType,
+      hasCachedSession: input.hasCachedSession,
+      hasInlineMessages: inlineMessages.length > 0,
+      inlineApplied: input.hasCachedSession && canApplyInlineMessages,
+      type: "session/activityObserved",
+      workspaceId: input.event.workspaceId
+    }
+  };
+}
+
+/**
+ * Realtime messages may be folded directly only when they extend the cached
+ * per-session change cursor without a hole. Otherwise a later incremental read
+ * could skip a missed mutable snapshot permanently.
+ */
+export function analyzeInlineMessageVersionContinuity(
+  cached: readonly AgentActivityMessage[],
+  incoming: readonly AgentActivityMessage[]
+): InlineMessageVersionContinuity {
+  const cachedVersion = latestMessageVersion(cached);
+  const incomingVersions = [
+    ...new Set(incoming.map((message) => message.version))
+  ].sort((left, right) => left - right);
+  const latestIncomingVersion = incomingVersions.at(-1) ?? 0;
+  const unseenVersions = incomingVersions.filter(
+    (version) => version > cachedVersion
+  );
+  const versionsAreValid = incomingVersions.every(
+    (version) => Number.isSafeInteger(version) && version > 0
+  );
+  return {
+    cachedVersion,
+    continuous:
+      versionsAreValid &&
+      unseenVersions.every(
+        (version, index) => version === cachedVersion + index + 1
+      ),
+    firstUnseenVersion: unseenVersions[0] ?? null,
+    latestIncomingVersion
+  };
+}
+
+function latestMessageVersion(
+  messages: readonly AgentActivityMessage[]
+): number {
+  return messages.reduce(
+    (latest, message) => Math.max(latest, message.version),
+    0
+  );
+}

--- a/packages/agent/activity-core/src/activityEventObservation.ts
+++ b/packages/agent/activity-core/src/activityEventObservation.ts
@@ -38,12 +38,18 @@ export function analyzeAgentActivityEventObservation(input: {
   hasCachedSession: boolean;
 }): AgentActivityEventObservation {
   const inlineMessages = parseInlineActivityMessages(input.event);
+  const inlinePayloadConsistent = isInlinePayloadConsistent(
+    input.event,
+    inlineMessages
+  );
   const inlineContinuity = analyzeInlineMessageVersionContinuity(
     input.cachedMessages,
     inlineMessages
   );
   const canApplyInlineMessages =
-    inlineMessages.length > 0 && inlineContinuity.continuous;
+    inlineMessages.length > 0 &&
+    inlinePayloadConsistent &&
+    inlineContinuity.continuous;
   return {
     canApplyInlineMessages,
     inlineContinuity,
@@ -58,6 +64,51 @@ export function analyzeAgentActivityEventObservation(input: {
       workspaceId: input.event.workspaceId
     }
   };
+}
+
+function isInlinePayloadConsistent(
+  event: ObservableAgentActivityUpdatedEvent,
+  inlineMessages: readonly AgentActivityMessage[]
+): boolean {
+  const workspaceId = event.workspaceId.trim();
+  const agentSessionId = event.agentSessionId.trim();
+  if (
+    !workspaceId ||
+    !agentSessionId ||
+    event.data.workspaceId.trim() !== workspaceId ||
+    event.data.agentSessionId.trim() !== agentSessionId ||
+    event.data.eventType !== event.eventType ||
+    inlineMessages.some(
+      (message) =>
+        message.workspaceId !== workspaceId ||
+        message.agentSessionId !== agentSessionId
+    )
+  ) {
+    return false;
+  }
+
+  if (event.eventType === "session_audit") {
+    return inlineMessages.length === 1;
+  }
+  if (event.eventType !== "message_update") {
+    return false;
+  }
+
+  if (
+    inlineMessages.length !== event.data.messages.length ||
+    event.data.acceptedCount !== event.data.messages.length
+  ) {
+    return false;
+  }
+  const latestInlineVersion = inlineMessages.reduce(
+    (latest, message) => Math.max(latest, message.version),
+    0
+  );
+  return (
+    Number.isSafeInteger(event.data.latestVersion) &&
+    event.data.latestVersion >= 0 &&
+    latestInlineVersion === event.data.latestVersion
+  );
 }
 
 /**

--- a/packages/agent/activity-core/src/engine/promptCommandExecution.test.ts
+++ b/packages/agent/activity-core/src/engine/promptCommandExecution.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { PromptQueueSendCommand } from "./promptQueue.types.ts";
+import {
+  executeAgentActivityPromptCommand,
+  type AgentActivityPromptCommandPort
+} from "./promptCommandExecution.ts";
+
+test("applies required settings before preserving every send semantic", async () => {
+  const operations: string[] = [];
+  const port: AgentActivityPromptCommandPort<{ accepted: true }> = {
+    async updateSessionSettings(input) {
+      operations.push(`settings:${input.settings.browserUse}`);
+    },
+    async sendInput(input) {
+      operations.push(`send:${input.clientSubmitId}`);
+      assert.deepEqual(input, {
+        agentSessionId: "session-1",
+        capabilityRefs: [{ capability: "tutti", source: "slash_command" }],
+        clientSubmitId: "submit-1",
+        content: [{ text: "hello", type: "text" }],
+        displayPrompt: "Hello",
+        guidance: true,
+        submitDiagnostics: {
+          blockCount: 1,
+          source: "test",
+          submittedAtUnixMs: 10
+        },
+        workspaceId: "workspace-1"
+      });
+      return { accepted: true };
+    }
+  };
+
+  const result = await executeAgentActivityPromptCommand(port, createCommand());
+
+  assert.deepEqual(operations, ["settings:true", "send:submit-1"]);
+  assert.deepEqual(result, { accepted: true });
+});
+
+test("does not send when the required settings patch fails", async () => {
+  let sendCalls = 0;
+  const expected = new Error("settings rejected");
+  const port: AgentActivityPromptCommandPort = {
+    async updateSessionSettings() {
+      throw expected;
+    },
+    async sendInput() {
+      sendCalls += 1;
+    }
+  };
+
+  await assert.rejects(
+    executeAgentActivityPromptCommand(port, createCommand()),
+    expected
+  );
+  assert.equal(sendCalls, 0);
+});
+
+test("sends immediately when the command has no settings precondition", async () => {
+  let settingsCalls = 0;
+  let sendCalls = 0;
+  const port: AgentActivityPromptCommandPort = {
+    async updateSessionSettings() {
+      settingsCalls += 1;
+    },
+    async sendInput() {
+      sendCalls += 1;
+    }
+  };
+
+  await executeAgentActivityPromptCommand(port, {
+    ...createCommand(),
+    requiredSettingsPatch: undefined
+  });
+
+  assert.equal(settingsCalls, 0);
+  assert.equal(sendCalls, 1);
+});
+
+function createCommand(): PromptQueueSendCommand {
+  return {
+    agentSessionId: "session-1",
+    capabilityRefs: [{ capability: "tutti", source: "slash_command" }],
+    clientSubmitId: "submit-1",
+    commandId: "command-1",
+    content: [{ text: "hello", type: "text" }],
+    displayPrompt: "Hello",
+    guidance: true,
+    promptId: "prompt-1",
+    requiredSettingsPatch: { browserUse: true },
+    submitDiagnostics: {
+      blockCount: 1,
+      source: "test",
+      submittedAtUnixMs: 10
+    },
+    type: "queue/sendPrompt",
+    workspaceId: "workspace-1"
+  };
+}

--- a/packages/agent/activity-core/src/engine/promptCommandExecution.ts
+++ b/packages/agent/activity-core/src/engine/promptCommandExecution.ts
@@ -1,0 +1,48 @@
+import type {
+  AgentActivitySendInput,
+  AgentActivitySessionSettings
+} from "../types.ts";
+import type { PromptQueueSendCommand } from "./promptQueue.types.ts";
+
+export interface AgentActivityPromptCommandPort<TResult = unknown> {
+  sendInput(input: AgentActivitySendInput): Promise<TResult>;
+  updateSessionSettings(input: {
+    agentSessionId: string;
+    settings: AgentActivitySessionSettings;
+    workspaceId: string;
+  }): Promise<unknown>;
+}
+
+/**
+ * Executes the host-neutral ordering contract for one Engine prompt command.
+ *
+ * A required settings patch is part of the submission precondition: the send
+ * must not begin until the exact Session accepts that patch. Hosts retain
+ * transport, diagnostics, authentication, and result mapping.
+ */
+export async function executeAgentActivityPromptCommand<TResult>(
+  port: AgentActivityPromptCommandPort<TResult>,
+  command: PromptQueueSendCommand
+): Promise<TResult> {
+  if (command.requiredSettingsPatch) {
+    await port.updateSessionSettings({
+      agentSessionId: command.agentSessionId,
+      settings: { ...command.requiredSettingsPatch },
+      workspaceId: command.workspaceId
+    });
+  }
+  return port.sendInput({
+    agentSessionId: command.agentSessionId,
+    ...(command.capabilityRefs?.length
+      ? { capabilityRefs: command.capabilityRefs }
+      : {}),
+    clientSubmitId: command.clientSubmitId,
+    content: [...command.content],
+    displayPrompt: command.displayPrompt ?? null,
+    ...(command.guidance === true ? { guidance: true } : {}),
+    ...(command.submitDiagnostics
+      ? { submitDiagnostics: { ...command.submitDiagnostics } }
+      : {}),
+    workspaceId: command.workspaceId
+  });
+}

--- a/packages/agent/activity-core/src/index.ts
+++ b/packages/agent/activity-core/src/index.ts
@@ -1,4 +1,10 @@
 export type { AgentActivityAdapter } from "./adapter.ts";
+export {
+  analyzeAgentActivityEventObservation,
+  analyzeInlineMessageVersionContinuity,
+  type AgentActivityEventObservation,
+  type InlineMessageVersionContinuity
+} from "./activityEventObservation.ts";
 export { AGENT_ACTIVITY_LIVE_PROTOCOL_REVISION } from "./liveProtocolRevision.gen.ts";
 export type { AgentActivityLiveEvent } from "./liveEvent.types.ts";
 export { parseAgentActivityMessageDeltaEvent } from "./liveEventParsing.ts";
@@ -64,6 +70,10 @@ export type {
   EngineDiagnosticEvent,
   EngineDiagnosticSink
 } from "./engine/diagnostics.ts";
+export {
+  executeAgentActivityPromptCommand,
+  type AgentActivityPromptCommandPort
+} from "./engine/promptCommandExecution.ts";
 export type {
   AgentSessionEngine,
   AgentSessionEngineIdentity,

--- a/packages/agent/activity-tuttid-adapter/README.md
+++ b/packages/agent/activity-tuttid-adapter/README.md
@@ -15,3 +15,10 @@ back to the engine; they do not duplicate provider capability parsing. The
 public mapper accepts the generated `AgentProviderComposerOptionsResponse`
 contract. Only its documented `runtimeContext` remains opaque; typed Skill and
 capability catalogs do not grow compatibility fields in this adapter.
+
+`agentActivitySessionDetailFromTuttid` is the single detail aggregate mapper for
+Desktop and Mobile. It validates and maps the root Session, nested child
+Sessions, and Turns as one value. A host dispatches the result through one
+`session/detailSnapshotReceived` intent; it must not partially publish a root
+when a child or Turn violates the generated protocol contract. Transport reads,
+message paging, retries, and Engine dispatch remain in the host adapter.

--- a/packages/agent/activity-tuttid-adapter/README.md
+++ b/packages/agent/activity-tuttid-adapter/README.md
@@ -18,7 +18,10 @@ capability catalogs do not grow compatibility fields in this adapter.
 
 `agentActivitySessionDetailFromTuttid` is the single detail aggregate mapper for
 Desktop and Mobile. It validates and maps the root Session, nested child
-Sessions, and Turns as one value. A host dispatches the result through one
-`session/detailSnapshotReceived` intent; it must not partially publish a root
-when a child or Turn violates the generated protocol contract. Transport reads,
-message paging, retries, and Engine dispatch remain in the host adapter.
+Sessions, and Turns as one value. The caller supplies the requested Session id;
+the mapper rejects a mismatched response root, a child outside that hierarchy,
+or a Turn not owned by the requested Session. A host dispatches the result
+through one `session/detailSnapshotReceived` intent; it must not partially
+publish a root when a child or Turn violates the generated protocol contract.
+Transport reads, message paging, retries, and Engine dispatch remain in the host
+adapter.

--- a/packages/agent/activity-tuttid-adapter/src/index.ts
+++ b/packages/agent/activity-tuttid-adapter/src/index.ts
@@ -2,6 +2,11 @@ export {
   agentActivityMessageFromTuttidMessage,
   agentActivitySessionFromTuttidSession,
   agentActivityTuttiModeActivationFromTuttid,
-  agentActivityTurnFromTuttidTurn
+  agentActivityTurnFromTuttidTurn,
+  type AgentActivitySessionMappingOptions
 } from "./mappers.ts";
 export { agentActivityComposerOptionsFromTuttidResult } from "./composerOptions.ts";
+export {
+  agentActivitySessionDetailFromTuttid,
+  type AgentActivitySessionDetailSnapshot
+} from "./sessionDetail.ts";

--- a/packages/agent/activity-tuttid-adapter/src/sessionDetail.test.ts
+++ b/packages/agent/activity-tuttid-adapter/src/sessionDetail.test.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type {
+  WorkspaceAgentSession,
+  WorkspaceAgentSessionDetailResponse,
+  WorkspaceAgentTurn
+} from "@tutti-os/client-tuttid-ts";
+import { agentActivitySessionDetailFromTuttid } from "./index.ts";
+
+test("detail mapping preserves the authoritative root, children, and Turns", () => {
+  const detail = agentActivitySessionDetailFromTuttid(
+    "workspace-1",
+    {
+      session: createSession({
+        id: "root-1",
+        kind: "root"
+      }),
+      childSessions: [
+        createSession({
+          id: "child-1",
+          kind: "child",
+          parentAgentSessionId: "root-1",
+          parentTurnId: "turn-root-1",
+          rootAgentSessionId: "root-1",
+          rootTurnId: "turn-root-1"
+        })
+      ],
+      turns: [
+        createTurn({
+          agentSessionId: "root-1",
+          turnId: "turn-root-1"
+        }),
+        createTurn({
+          agentSessionId: "child-1",
+          turnId: "turn-child-1"
+        })
+      ]
+    } satisfies WorkspaceAgentSessionDetailResponse,
+    { currentUserId: "account-user-1" }
+  );
+
+  assert.equal(detail.session.agentSessionId, "root-1");
+  assert.equal(detail.session.userId, "account-user-1");
+  assert.deepEqual(
+    detail.childSessions.map((session) => ({
+      agentSessionId: session.agentSessionId,
+      parentAgentSessionId: session.parentAgentSessionId,
+      rootAgentSessionId: session.rootAgentSessionId,
+      userId: session.userId
+    })),
+    [
+      {
+        agentSessionId: "child-1",
+        parentAgentSessionId: "root-1",
+        rootAgentSessionId: "root-1",
+        userId: "account-user-1"
+      }
+    ]
+  );
+  assert.deepEqual(
+    detail.turns.map((turn) => [turn.agentSessionId, turn.turnId]),
+    [
+      ["root-1", "turn-root-1"],
+      ["child-1", "turn-child-1"]
+    ]
+  );
+});
+
+test("detail mapping fails the entire aggregate when a child violates protocol v2", () => {
+  const child = createSession({
+    id: "child-1",
+    kind: "child",
+    parentAgentSessionId: "root-1",
+    rootAgentSessionId: "root-1"
+  });
+  const malformedChild = { ...child } as Record<string, unknown>;
+  delete malformedChild.railSectionKey;
+
+  assert.throws(
+    () =>
+      agentActivitySessionDetailFromTuttid(
+        "workspace-1",
+        {
+          session: createSession({ id: "root-1", kind: "root" }),
+          childSessions: [malformedChild as WorkspaceAgentSession],
+          turns: []
+        },
+        { currentUserId: "account-user-1" }
+      ),
+    /Protocol v2 contract error:.*railSectionKey/
+  );
+});
+
+function createSession(
+  overrides: Partial<WorkspaceAgentSession>
+): WorkspaceAgentSession {
+  return {
+    activeTurn: null,
+    activeTurnId: null,
+    agentTargetId: "target-1",
+    capabilities: null,
+    createdAtUnixMs: 1,
+    cwd: "/workspace",
+    endedAtUnixMs: null,
+    goal: null,
+    id: "session-1",
+    imported: false,
+    kind: "root",
+    latestTurn: null,
+    latestTurnInteractions: [],
+    parentAgentSessionId: null,
+    parentToolCallId: null,
+    parentTurnId: null,
+    pendingInteractions: [],
+    permissionConfig: { configurable: false, modes: [] },
+    pinnedAtUnixMs: null,
+    provider: "codex",
+    providerSessionId: null,
+    railSectionKey: "conversations",
+    resumable: true,
+    rootAgentSessionId: null,
+    rootTurnId: null,
+    settings: {},
+    title: "Session",
+    tuttiModeActivation: null,
+    updatedAtUnixMs: 2,
+    usage: null,
+    visible: true,
+    ...overrides
+  };
+}
+
+function createTurn(
+  overrides: Pick<WorkspaceAgentTurn, "agentSessionId" | "turnId">
+): WorkspaceAgentTurn {
+  return {
+    agentSessionId: overrides.agentSessionId,
+    completedCommand: null,
+    error: null,
+    fileChanges: null,
+    origin: "user_prompt",
+    outcome: null,
+    phase: "settled",
+    settledAtUnixMs: 3,
+    startedAtUnixMs: 1,
+    turnId: overrides.turnId,
+    updatedAtUnixMs: 3
+  };
+}

--- a/packages/agent/activity-tuttid-adapter/src/sessionDetail.test.ts
+++ b/packages/agent/activity-tuttid-adapter/src/sessionDetail.test.ts
@@ -10,6 +10,7 @@ import { agentActivitySessionDetailFromTuttid } from "./index.ts";
 test("detail mapping preserves the authoritative root, children, and Turns", () => {
   const detail = agentActivitySessionDetailFromTuttid(
     "workspace-1",
+    "root-1",
     {
       session: createSession({
         id: "root-1",
@@ -29,10 +30,6 @@ test("detail mapping preserves the authoritative root, children, and Turns", () 
         createTurn({
           agentSessionId: "root-1",
           turnId: "turn-root-1"
-        }),
-        createTurn({
-          agentSessionId: "child-1",
-          turnId: "turn-child-1"
         })
       ]
     } satisfies WorkspaceAgentSessionDetailResponse,
@@ -59,10 +56,7 @@ test("detail mapping preserves the authoritative root, children, and Turns", () 
   );
   assert.deepEqual(
     detail.turns.map((turn) => [turn.agentSessionId, turn.turnId]),
-    [
-      ["root-1", "turn-root-1"],
-      ["child-1", "turn-child-1"]
-    ]
+    [["root-1", "turn-root-1"]]
   );
 });
 
@@ -80,6 +74,7 @@ test("detail mapping fails the entire aggregate when a child violates protocol v
     () =>
       agentActivitySessionDetailFromTuttid(
         "workspace-1",
+        "root-1",
         {
           session: createSession({ id: "root-1", kind: "root" }),
           childSessions: [malformedChild as WorkspaceAgentSession],
@@ -89,6 +84,97 @@ test("detail mapping fails the entire aggregate when a child violates protocol v
       ),
     /Protocol v2 contract error:.*railSectionKey/
   );
+});
+
+test("detail mapping rejects a response for a different requested Session", () => {
+  assert.throws(
+    () =>
+      agentActivitySessionDetailFromTuttid(
+        "workspace-1",
+        "requested-1",
+        {
+          session: createSession({ id: "other-1", kind: "root" }),
+          childSessions: [],
+          turns: []
+        },
+        { currentUserId: "account-user-1" }
+      ),
+    /root Session id.*does not match requested id/
+  );
+});
+
+test("detail mapping rejects children outside the requested hierarchy", () => {
+  assert.throws(
+    () =>
+      agentActivitySessionDetailFromTuttid(
+        "workspace-1",
+        "root-1",
+        {
+          session: createSession({ id: "root-1", kind: "root" }),
+          childSessions: [
+            createSession({
+              id: "foreign-child",
+              kind: "child",
+              parentAgentSessionId: "foreign-root",
+              rootAgentSessionId: "root-1"
+            })
+          ],
+          turns: []
+        },
+        { currentUserId: "account-user-1" }
+      ),
+    /outside the requested Session hierarchy/
+  );
+});
+
+test("detail mapping accepts descendants below a requested child Session", () => {
+  const detail = agentActivitySessionDetailFromTuttid(
+    "workspace-1",
+    "child-1",
+    {
+      session: createSession({
+        id: "child-1",
+        kind: "child",
+        parentAgentSessionId: "root-1",
+        rootAgentSessionId: "root-1"
+      }),
+      childSessions: [
+        createSession({
+          id: "nested-child-1",
+          kind: "child",
+          parentAgentSessionId: "child-1",
+          rootAgentSessionId: "root-1"
+        })
+      ],
+      turns: [createTurn({ agentSessionId: "child-1", turnId: "child-turn-1" })]
+    },
+    { currentUserId: "account-user-1" }
+  );
+
+  assert.equal(detail.session.agentSessionId, "child-1");
+  assert.equal(detail.childSessions[0]?.agentSessionId, "nested-child-1");
+});
+
+test("detail mapping rejects malformed or foreign Turns atomically", () => {
+  for (const turn of [
+    createTurn({ agentSessionId: "child-1", turnId: "turn-child-1" }),
+    createTurn({ agentSessionId: "root-1", turnId: " " })
+  ]) {
+    assert.throws(
+      () =>
+        agentActivitySessionDetailFromTuttid(
+          "workspace-1",
+          "root-1",
+          {
+            session: createSession({ id: "root-1", kind: "root" }),
+            childSessions: [],
+            turns: [turn]
+          },
+          { currentUserId: "account-user-1" }
+        ),
+      /Turn.*must be owned by requested Session/
+    );
+  }
 });
 
 function createSession(

--- a/packages/agent/activity-tuttid-adapter/src/sessionDetail.ts
+++ b/packages/agent/activity-tuttid-adapter/src/sessionDetail.ts
@@ -1,0 +1,40 @@
+import type {
+  AgentActivitySession,
+  AgentActivityTurn
+} from "@tutti-os/agent-activity-core";
+import type { WorkspaceAgentSessionDetailResponse } from "@tutti-os/client-tuttid-ts";
+import {
+  agentActivitySessionFromTuttidSession,
+  agentActivityTurnFromTuttidTurn,
+  type AgentActivitySessionMappingOptions
+} from "./mappers.ts";
+
+export interface AgentActivitySessionDetailSnapshot {
+  session: AgentActivitySession;
+  childSessions: readonly AgentActivitySession[];
+  turns: readonly AgentActivityTurn[];
+}
+
+/**
+ * Maps one authoritative tuttid detail response without performing transport
+ * or dispatch work. Hosts feed the returned aggregate to the engine through a
+ * single `session/detailSnapshotReceived` intent so root, child, and Turn
+ * state cannot become observably half-applied.
+ */
+export function agentActivitySessionDetailFromTuttid(
+  workspaceId: string,
+  detail: WorkspaceAgentSessionDetailResponse,
+  options: AgentActivitySessionMappingOptions
+): AgentActivitySessionDetailSnapshot {
+  return {
+    session: agentActivitySessionFromTuttidSession(
+      workspaceId,
+      detail.session,
+      options
+    ),
+    childSessions: detail.childSessions.map((session) =>
+      agentActivitySessionFromTuttidSession(workspaceId, session, options)
+    ),
+    turns: detail.turns.map(agentActivityTurnFromTuttidTurn)
+  };
+}

--- a/packages/agent/activity-tuttid-adapter/src/sessionDetail.ts
+++ b/packages/agent/activity-tuttid-adapter/src/sessionDetail.ts
@@ -23,9 +23,11 @@ export interface AgentActivitySessionDetailSnapshot {
  */
 export function agentActivitySessionDetailFromTuttid(
   workspaceId: string,
+  expectedAgentSessionId: string,
   detail: WorkspaceAgentSessionDetailResponse,
   options: AgentActivitySessionMappingOptions
 ): AgentActivitySessionDetailSnapshot {
+  assertTuttidSessionDetailContract(expectedAgentSessionId, detail);
   return {
     session: agentActivitySessionFromTuttidSession(
       workspaceId,
@@ -37,4 +39,102 @@ export function agentActivitySessionDetailFromTuttid(
     ),
     turns: detail.turns.map(agentActivityTurnFromTuttidTurn)
   };
+}
+
+function assertTuttidSessionDetailContract(
+  expectedAgentSessionId: string,
+  detail: WorkspaceAgentSessionDetailResponse
+): void {
+  const expectedId = trimmedString(expectedAgentSessionId);
+  const rootId = trimmedString(detail.session?.id);
+  if (!expectedId || rootId !== expectedId) {
+    throw detailContractError(
+      `root Session id ${JSON.stringify(rootId)} does not match requested id ${JSON.stringify(expectedId)}`
+    );
+  }
+  if (!Array.isArray(detail.childSessions) || !Array.isArray(detail.turns)) {
+    throw detailContractError(
+      "childSessions and turns must be authoritative arrays"
+    );
+  }
+  const hierarchyRootId =
+    detail.session.kind === "root"
+      ? rootId
+      : trimmedString(detail.session.rootAgentSessionId);
+  if (
+    (detail.session.kind !== "root" && detail.session.kind !== "child") ||
+    !hierarchyRootId
+  ) {
+    throw detailContractError(
+      "requested Session hierarchy identity is invalid"
+    );
+  }
+
+  const childrenById = new Map<
+    string,
+    WorkspaceAgentSessionDetailResponse["childSessions"][number]
+  >();
+  for (const child of detail.childSessions) {
+    const childId = trimmedString(child.id);
+    if (
+      !childId ||
+      childId === rootId ||
+      child.kind !== "child" ||
+      trimmedString(child.rootAgentSessionId) !== hierarchyRootId ||
+      childrenById.has(childId)
+    ) {
+      throw detailContractError(
+        `child Session identity ${JSON.stringify(childId)} is invalid`
+      );
+    }
+    childrenById.set(childId, child);
+  }
+
+  for (const child of detail.childSessions) {
+    assertDescendsFromRequestedSession(child, rootId, childrenById);
+  }
+  for (const turn of detail.turns) {
+    const turnId = trimmedString(turn.turnId);
+    const ownerId = trimmedString(turn.agentSessionId);
+    if (!turnId || ownerId !== rootId) {
+      throw detailContractError(
+        `Turn ${JSON.stringify(turnId)} must be owned by requested Session ${JSON.stringify(rootId)}`
+      );
+    }
+  }
+}
+
+function assertDescendsFromRequestedSession(
+  child: WorkspaceAgentSessionDetailResponse["childSessions"][number],
+  requestedSessionId: string,
+  childrenById: ReadonlyMap<
+    string,
+    WorkspaceAgentSessionDetailResponse["childSessions"][number]
+  >
+): void {
+  const childId = trimmedString(child.id);
+  const visited = new Set<string>([childId]);
+  let parentId = trimmedString(child.parentAgentSessionId);
+  while (parentId && parentId !== requestedSessionId) {
+    if (visited.has(parentId)) {
+      throw detailContractError(
+        `child Session ${JSON.stringify(childId)} contains a parent cycle`
+      );
+    }
+    visited.add(parentId);
+    parentId = trimmedString(childrenById.get(parentId)?.parentAgentSessionId);
+  }
+  if (parentId !== requestedSessionId) {
+    throw detailContractError(
+      `child Session ${JSON.stringify(childId)} is outside the requested Session hierarchy`
+    );
+  }
+}
+
+function detailContractError(reason: string): Error {
+  return new Error(`Protocol v2 contract error: ${reason}`);
+}
+
+function trimmedString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.spec.ts
@@ -222,7 +222,8 @@ describe("handoffProjectPathForConversation", () => {
     expect(
       handoffProjectPathForConversation({
         cwd: "/workspace/fallback",
-        project: { path: " /workspace/project-a " }
+        project: { path: " /workspace/project-a " },
+        railSectionKey: "project:/workspace/project-a"
       } as never)
     ).toBe("/workspace/project-a");
   });
@@ -231,8 +232,19 @@ describe("handoffProjectPathForConversation", () => {
     expect(
       handoffProjectPathForConversation({
         cwd: " /workspace/project-b ",
-        project: null
+        project: null,
+        railSectionKey: "project:/workspace/project-b"
       } as never)
     ).toBe("/workspace/project-b");
+  });
+
+  it("omits the cwd when the source belongs to conversations", () => {
+    expect(
+      handoffProjectPathForConversation({
+        cwd: " /workspace/conversation ",
+        project: { path: " /workspace/stale-project " },
+        railSectionKey: " conversations "
+      } as never)
+    ).toBeNull();
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.ts
@@ -347,6 +347,9 @@ export function buildAgentConversationHandoffPrompt(input: {
 export function handoffProjectPathForConversation(
   conversation: AgentGUINodeViewModel["rail"]["activeConversation"]
 ): string | null {
+  if (conversation?.railSectionKey?.trim() === "conversations") {
+    return null;
+  }
   return (
     conversation?.project?.path?.trim() || conversation?.cwd?.trim() || null
   );


### PR DESCRIPTION
## Summary

- keep Mobile composer overlays mutually exclusive and reject stale native close callbacks
- move normalized activity-event observation and prompt command execution into agent-activity-core for both Desktop and Mobile
- move root Session detail mapping into agent-activity-tuttid-adapter so one atomic Engine intent owns root, child Session, and Turn updates
- make the Mobile Rail retain membership and ordered Session IDs only; canonical Session entities stay in the workspace Engine
- project Mobile Interaction response state from the Engine instead of component-local Promise state
- construct the typed Mobile create request from the generated contract and stop forwarding the unsupported computerUse field
- update architecture, package, Mobile, plan, specification, and troubleshooting documentation to match the implemented ownership

## Why

Desktop and Mobile had converged on the same Agent activity domain but still duplicated event reconciliation, prompt sequencing, detail mapping, and Session storage decisions in host code. That reduced locality and allowed equivalent bugs to require separate fixes.

The Mobile create adapter also treated the shared activation settings bag as an HTTP create-field allowlist. This could add computerUse even though the generated create contract does not expose it.

The composer overlay bug had a related ownership problem: sibling native modals owned competing lifecycles, so delayed dismissals could close a newer surface or leave an invisible window intercepting touches.

## Impact

Both hosts now share the host-neutral Agent activity mechanics while retaining transport-specific adapters. Mobile has one canonical Session entity owner, atomic detail hydration, exact Interaction submission state, and a create request constrained by the generated API contract. Existing runtime computer-use settings remain available for established Sessions; only the invalid create-request passthrough is removed.

## Validation

- pnpm check:changed: 21 lanes passed
- pre-push pnpm check:changed -- --push-ready: 22 lanes passed
- focused tests cover event continuity and reconcile scopes, settings-before-send ordering, atomic detail mapping and malformed nested DTO rejection, Mobile Rail identity ownership, Interaction submission/failure state, live-lane fallback, and create-request field filtering
- commit hooks passed formatting, lint, Electron/UI/renderer boundaries, AgentGUI degradation, and runtime image budgets
- Android physical-device verification for the composer overlay behavior on V2507A remained clean: one active modal window, model selection worked through both entry points, and no JavaScript or Android runtime errors occurred

## Documentation

Updated the durable AgentGUI and Agent activity ownership documents, Mobile implementation guide, active design/plan documents, package READMEs, and the Mobile troubleshooting note.