### PR TITLE
fix(agent-gui): retry transient owner avatar loads

### DIFF
--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -53,6 +53,7 @@ React rendering, Workbench state, external stores, input composition, and UI per
 
 - [Renderer body requests fail with `ERR_H2_OR_QUIC_REQUIRED`](./workbench-renderer.md#renderer-body-requests-fail-with-err_h2_or_quic_required)
 - [Renderer `fetch()` rejects an Electron image protocol that `<img>` can load](./workbench-renderer.md#renderer-fetch-rejects-an-electron-image-protocol-that-img-can-load)
+- [AgentGUI carousel owner avatar stays a solid badge](./workbench-renderer.md#agentgui-carousel-owner-avatar-stays-a-solid-badge)
 - [Renderer tile memory warnings from hidden autoplay animation](./workbench-renderer.md#renderer-tile-memory-warnings-from-hidden-autoplay-animation)
 - [Standalone Agent dev window stays black during cold startup](./workbench-renderer.md#standalone-agent-dev-window-stays-black-during-cold-startup)
 - [IME composition breaks fuzzy search or controlled search inputs](./workbench-renderer.md#ime-composition-breaks-fuzzy-search-or-controlled-search-inputs)

--- a/docs/conventions/troubleshooting/workbench-renderer.md
+++ b/docs/conventions/troubleshooting/workbench-renderer.md
@@ -246,6 +246,33 @@
   [tuttiAssetProtocol.ts](../../../apps/desktop/src/main/host/tuttiAssetProtocol.ts)
   [workspaceFileIconProtocol.ts](../../../apps/desktop/src/main/host/workspaceFileIconProtocol.ts)
 
+### AgentGUI carousel owner avatar stays a solid badge
+
+- Symptom:
+  The DOM owner avatar and other identity surfaces show the expected image, but
+  the WebGL empty-home carousel keeps its solid programmatic owner marker until
+  the component remounts.
+- Quick checks:
+  Confirm the host projects a non-empty `owner.avatarUrl`, the same URL renders
+  in a normal anonymous `<img>`, and the asset response permits anonymous CORS.
+  If a restart or remount makes the carousel image appear without changing the
+  directory projection, inspect the carousel image loader rather than adding
+  another profile or daemon request.
+- Root cause:
+  A transient first network failure can be latched as a decoded `null` image.
+  Because the authoritative URL did not change, the carousel has no reason to
+  create a new image generation and the solid fallback remains.
+- Fix:
+  Keep one carousel image-load owner and retry anonymous owner badges a small,
+  bounded number of times. Cancellation must clear both the active image source
+  and any pending retry timer. Continue using the host's authoritative owner
+  projection; renderer code must not fetch a second avatar source.
+- Validation:
+  Inject one failed owner-image attempt, advance through the first retry delay,
+  and assert that the next anonymous image resolves while icon and cover loading
+  remain unchanged. Also assert that canceling a generation resolves it empty
+  and clears every active source.
+
 ### Renderer tile memory warnings from hidden autoplay animation
 
 - Symptom:

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselImageLoad.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselImageLoad.spec.ts
@@ -1,9 +1,10 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { AgentGuiHeroCarouselImageLoad } from "./agentGuiHeroCarouselImageLoad";
 
 class FakeImage {
   static instances: FakeImage[] = [];
   static autoLoad = true;
+  static failuresByUrl = new Map<string, number>();
 
   complete = false;
   crossOrigin: string | null = null;
@@ -30,7 +31,14 @@ class FakeImage {
     this.value = value;
     if (value && FakeImage.autoLoad) {
       this.complete = true;
-      this.onload?.();
+      const failuresRemaining = FakeImage.failuresByUrl.get(value) ?? 0;
+      if (failuresRemaining > 0) {
+        FakeImage.failuresByUrl.set(value, failuresRemaining - 1);
+        this.naturalWidth = 0;
+        this.onerror?.();
+      } else {
+        this.onload?.();
+      }
     }
   }
 
@@ -44,6 +52,8 @@ describe("AgentGuiHeroCarouselImageLoad", () => {
     globalThis.Image = originalImage;
     FakeImage.instances.length = 0;
     FakeImage.autoLoad = true;
+    FakeImage.failuresByUrl.clear();
+    vi.useRealTimers();
   });
 
   it("loads every canvas-bound image anonymously before decoding", async () => {
@@ -93,5 +103,31 @@ describe("AgentGuiHeroCarouselImageLoad", () => {
 
     expect(FakeImage.instances.every((image) => image.src === "")).toBe(true);
     expect(result).toEqual({ badges: [null], covers: [null], icons: [null] });
+  });
+
+  it("retries a transient owner badge failure", async () => {
+    vi.useFakeTimers();
+    globalThis.Image = FakeImage as unknown as typeof Image;
+    const badgeUrl = "https://cdn.example.com/owner.png";
+    FakeImage.failuresByUrl.set(badgeUrl, 1);
+    const load = new AgentGuiHeroCarouselImageLoad([
+      {
+        agentTargetId: "local:codex",
+        badge: { iconUrl: badgeUrl },
+        iconUrl: "app://codex.png",
+        label: "Codex",
+        provider: "codex",
+        targetId: "local:codex"
+      }
+    ]);
+
+    await vi.advanceTimersByTimeAsync(150);
+    const result = await load.result;
+
+    expect(FakeImage.instances).toHaveLength(4);
+    expect(FakeImage.instances[2]?.src).toBe("");
+    expect(FakeImage.instances[3]?.crossOrigin).toBe("anonymous");
+    expect(FakeImage.instances[3]?.src).toBe(badgeUrl);
+    expect(result.badges[0]).toBe(FakeImage.instances[3]);
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselImageLoad.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselImageLoad.ts
@@ -4,6 +4,10 @@ import cursorVinylAssetUrl from "../../app/renderer/assets/icons/agent-vinyls/cu
 import openclawVinylAssetUrl from "../../app/renderer/assets/icons/agent-vinyls/openclaw-vinyl.png";
 import opencodeVinylAssetUrl from "../../app/renderer/assets/icons/agent-vinyls/opencode-vinyl.png";
 import tuttiVinylAssetUrl from "../../app/renderer/assets/icons/agent-vinyls/tutti-vinyl.png";
+import {
+  agentGuiScheduler,
+  type AgentGuiScheduledTask
+} from "./agentGuiScheduler";
 import type { AgentGUIAgentAvatarPresentation } from "./model/agentGuiAgentAvatarPresentation";
 
 const AGENT_VINYL_COVER_BY_PROVIDER: Readonly<Record<string, string>> = {
@@ -14,6 +18,8 @@ const AGENT_VINYL_COVER_BY_PROVIDER: Readonly<Record<string, string>> = {
   opencode: opencodeVinylAssetUrl,
   "tutti-agent": tuttiVinylAssetUrl
 };
+
+const BADGE_IMAGE_RETRY_DELAYS_MS = [150, 500] as const;
 
 export interface AgentGuiHeroCarouselDecodedImages {
   badges: readonly (HTMLImageElement | null)[];
@@ -41,7 +47,7 @@ export class AgentGuiHeroCarouselImageLoad {
               AGENT_VINYL_COVER_BY_PROVIDER[item.provider] ||
               null
           ),
-          this.loadImage(item.badge?.iconUrl ?? null)
+          this.loadImage(item.badge?.iconUrl ?? null, true)
         ]);
         return { badge, cover, icon };
       })
@@ -63,16 +69,17 @@ export class AgentGuiHeroCarouselImageLoad {
     this.pendingLoads.clear();
   }
 
-  private loadImage(url: string | null): Promise<HTMLImageElement | null> {
+  private loadImage(
+    url: string | null,
+    retryTransientFailure = false
+  ): Promise<HTMLImageElement | null> {
     if (!url || this.canceled || typeof Image !== "function") {
       return Promise.resolve(null);
     }
-    const image = new Image();
-    image.crossOrigin = "anonymous";
-    image.decoding = "async";
-    image.loading = "eager";
-    image.setAttribute("fetchpriority", "high");
     let settled = false;
+    let image: HTMLImageElement | null = null;
+    let retryIndex = 0;
+    let retryTask: AgentGuiScheduledTask | null = null;
     let resolvePromise = (_value: HTMLImageElement | null): void => undefined;
     const pending: PendingImageLoad = {
       cancel: () => settle(null, true),
@@ -88,39 +95,94 @@ export class AgentGuiHeroCarouselImageLoad {
         return;
       }
       settled = true;
-      image.onload = null;
-      image.onerror = null;
+      if (retryTask !== null) {
+        retryTask.cancel();
+        retryTask = null;
+      }
+      if (image) {
+        image.onload = null;
+        image.onerror = null;
+      }
       this.pendingLoads.delete(pending);
-      if (clearSource) {
+      if (clearSource && image) {
         image.src = "";
       }
       resolvePromise(value);
     };
-    const settleDecoded = (): void => {
+    const settleDecoded = (loadedImage: HTMLImageElement): void => {
       let decode: Promise<void> | undefined;
       try {
-        decode = image.decode?.();
+        decode = loadedImage.decode?.();
       } catch {
-        settle(image);
+        settle(loadedImage);
         return;
       }
       if (decode) {
-        void decode.then(() => settle(image)).catch(() => settle(image));
+        void decode
+          .then(() => settle(loadedImage))
+          .catch(() => settle(loadedImage));
         return;
       }
-      settle(image);
+      settle(loadedImage);
     };
-    image.onload = settleDecoded;
-    image.onerror = () => settle(null);
-    this.pendingLoads.add(pending);
-    image.src = url;
-    if (image.complete) {
-      if (image.naturalWidth > 0) {
-        settleDecoded();
-      } else {
-        settle(null);
+    const retryOrSettle = (failedImage: HTMLImageElement): void => {
+      failedImage.onload = null;
+      failedImage.onerror = null;
+      if (
+        retryTransientFailure &&
+        retryIndex < BADGE_IMAGE_RETRY_DELAYS_MS.length &&
+        !this.canceled
+      ) {
+        failedImage.src = "";
+        const delay = BADGE_IMAGE_RETRY_DELAYS_MS[retryIndex]!;
+        retryIndex += 1;
+        retryTask = agentGuiScheduler.schedule(delay, () => {
+          retryTask = null;
+          startAttempt();
+        });
+        return;
       }
-    }
+      settle(null);
+    };
+    const startAttempt = (): void => {
+      if (settled || this.canceled) {
+        settle(null, true);
+        return;
+      }
+      const nextImage = new Image();
+      image = nextImage;
+      nextImage.crossOrigin = "anonymous";
+      nextImage.decoding = "async";
+      nextImage.loading = "eager";
+      nextImage.setAttribute("fetchpriority", "high");
+      let attemptFinished = false;
+      const handleLoaded = (): void => {
+        if (attemptFinished) {
+          return;
+        }
+        attemptFinished = true;
+        settleDecoded(nextImage);
+      };
+      const handleFailed = (): void => {
+        if (attemptFinished) {
+          return;
+        }
+        attemptFinished = true;
+        retryOrSettle(nextImage);
+      };
+      nextImage.onload = handleLoaded;
+      nextImage.onerror = handleFailed;
+      nextImage.src = url;
+      if (nextImage.complete) {
+        if (nextImage.naturalWidth > 0) {
+          handleLoaded();
+        } else {
+          handleFailed();
+        }
+      }
+    };
+    this.pendingLoads.add(pending);
+    startAttempt();
     return pending.promise;
   }
 }


### PR DESCRIPTION
## Summary

- retry transient owner-badge image failures in the AgentGUI WebGL carousel after 150 ms and 500 ms
- keep icon and cover retry behavior unchanged while preserving anonymous CORS loading for every canvas-bound image
- cancel pending retry work and clear the active image source when the image generation is disposed
- document the solid owner-badge troubleshooting pattern

The carousel previously latched a single transient owner-avatar failure as a decoded `null` image. Because the authoritative avatar URL did not change, the white programmatic fallback remained until the component remounted.

## Verification

- `pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom --maxWorkers=3 agent-gui/agentGuiNode/agentGuiHeroCarouselImageLoad.spec.ts --reporter=verbose`
- `pnpm check:changed`
- push hook: `pnpm check:changed -- --push-ready` (12 lanes passed)
- TSH local-cohort smoke test with the first CORS owner-avatar request aborted; the retry loaded the avatar without a remount

## Fallback Three Questions

- Source: a transient browser/network failure on the first anonymous owner-avatar image request.
- Why can it not be fixed at that source? The host projection, URL, and CORS response are valid; the failure is transient transport state, while the carousel owns the decoded image generation that previously latched the failure.
- Removal condition: remove this retry when a shared image-loading owner provides equivalent bounded retry/revalidation for both DOM and WebGL consumers, or when the carousel no longer retains a decoded generation after a failed request.

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): not applicable; image loading only.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. (Not applicable.)
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.