### PR TITLE
fix(agent-gui): omit chats cwd from handoff

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -700,6 +700,9 @@ observe the portaled menu DOM, or infer target identity from provider or
 visible text. The current conversation's composer input availability is
 independent from this launch surface: a target connection may disable input
 while Handoff remains available when the host supplies the launch callback.
+Handoff preserves canonical Rail placement: a source in the Chats section
+omits its runtime `cwd` from the destination project selection, while a source
+in a project section carries that project's path.
 AgentGUI DOM surfaces render the target's owner badge through the shared UI
 System Avatar primitive. A failed owner image falls back to the supplied owner
 label initial instead of exposing a browser broken-image glyph.

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.spec.ts
@@ -222,7 +222,8 @@ describe("handoffProjectPathForConversation", () => {
     expect(
       handoffProjectPathForConversation({
         cwd: "/workspace/fallback",
-        project: { path: " /workspace/project-a " }
+        project: { path: " /workspace/project-a " },
+        railSectionKey: "project:/workspace/project-a"
       } as never)
     ).toBe("/workspace/project-a");
   });
@@ -231,8 +232,19 @@ describe("handoffProjectPathForConversation", () => {
     expect(
       handoffProjectPathForConversation({
         cwd: " /workspace/project-b ",
-        project: null
+        project: null,
+        railSectionKey: "project:/workspace/project-b"
       } as never)
     ).toBe("/workspace/project-b");
+  });
+
+  it("omits the cwd when the source belongs to conversations", () => {
+    expect(
+      handoffProjectPathForConversation({
+        cwd: " /workspace/conversation ",
+        project: { path: " /workspace/stale-project " },
+        railSectionKey: " conversations "
+      } as never)
+    ).toBeNull();
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.ts
@@ -347,6 +347,9 @@ export function buildAgentConversationHandoffPrompt(input: {
 export function handoffProjectPathForConversation(
   conversation: AgentGUINodeViewModel["rail"]["activeConversation"]
 ): string | null {
+  if (conversation?.railSectionKey?.trim() === "conversations") {
+    return null;
+  }
   return (
     conversation?.project?.path?.trim() || conversation?.cwd?.trim() || null
   );


### PR DESCRIPTION
## Summary

- omit `userProjectPath` when the handoff source belongs to the `conversations` Rail section
- preserve canonical project paths and the existing project-section cwd fallback
- add regression coverage and document the handoff placement contract

This prevents a Chats-scoped runtime cwd from being interpreted as a destination project selection, which could make new-conversation activation fail closed when no matching user project exists.

## Verification

- `pnpm check:changed` (11/11 lanes passed)
- pre-push `pnpm check:changed -- --push-ready` (12/12 lanes passed)

## Checklist

- [x] This change does not alter Host-owned session/turn/goal/runtime-operation lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] I updated documentation for the handoff placement behavior.
- [x] README/CONTRIBUTING translations are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] The commit is signed off with DCO.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->