### PR TITLE
fix(workspace-file-manager): support IME input in create name dialog

### DIFF
--- a/docs/conventions/troubleshooting/workbench-renderer.md
+++ b/docs/conventions/troubleshooting/workbench-renderer.md
@@ -327,33 +327,39 @@
 ### IME composition breaks fuzzy search or controlled search inputs
 
 - Symptom:
-  Chinese, Japanese, or Korean input cannot be committed in a fuzzy search or
-  mention picker. Pressing Enter to accept an IME candidate may select a
-  highlighted result, submit a search, or clear/replace the partially composed
-  text.
+  Chinese, Japanese, or Korean input cannot be committed in a fuzzy search,
+  mention picker, or a controlled name dialog (for example Files → New folder /
+  New file). Pressing Enter to accept an IME candidate may select a highlighted
+  result, submit a search or create dialog, or clear/replace the partially
+  composed text.
 - Quick checks:
   Inspect any `keydown` handler that consumes `Enter` or `Tab` while a menu is
-  open. Also inspect controlled `input[type="search"]` fields whose `value`
-  comes from async search/controller state.
+  open. Also inspect controlled text/`input[type="search"]` fields whose
+  `value` comes from async search/controller or dialog store state and whose
+  `onChange` commits on every keystroke without composition handlers.
 - Root cause:
   IME candidate confirmation is delivered through composition-aware keyboard
   events. If menu shortcuts do not check `isComposing` or the `keyCode/which`
   `229` fallback, the app treats candidate confirmation as a command. If a
-  controlled search input pushes every composition update through async search
-  state, stale parent values can overwrite the local composing buffer.
+  controlled search or name input pushes every composition update through async
+  search/controller/dialog state, stale parent values can overwrite the local
+  composing buffer.
 - Fix:
   In fuzzy/menu key handlers, return before command handling when
   `event.isComposing`, `event.nativeEvent.isComposing`, `keyCode === 229`, or
-  `which === 229`. For controlled search inputs, keep a local value during
-  `compositionstart`/`compositionend`, commit to the controller on
-  `compositionend`, and ignore stale parent values until the parent catches up.
+  `which === 229`. For controlled search or name inputs, keep a local value
+  during `compositionstart`/`compositionend` (prefer
+  `useComposedInputValue`), commit to the controller on `compositionend`, and
+  ignore stale parent values until the parent catches up. Guard form submit
+  while composition is active.
 - Validation:
   Add a unit test for the IME guard or input sync state, then manually type a
-  Chinese query and confirm Enter accepts the candidate instead of selecting a
-  result or submitting the field.
+  Chinese query/name and confirm Enter accepts the candidate instead of
+  selecting a result or submitting the field.
 - References:
   [richTextIme.ts](../../../packages/ui/rich-text/src/editor/richTextIme.ts)
   [useComposedInputValue.ts](../../../packages/ui/react-hooks/src/useComposedInputValue.ts)
+  [WorkspaceFileManagerMenus.tsx](../../../packages/workspace/file-manager/src/ui/WorkspaceFileManagerMenus.tsx)
   [WorkspaceFileReferencePickerTree.tsx](../../../packages/workspace/file-reference/src/ui/internal/reference/WorkspaceFileReferencePickerTree.tsx)
   [IssueManagerSidebarSections.tsx](../../../packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerSidebarSections.tsx)
 

--- a/packages/workspace/file-manager/package.json
+++ b/packages/workspace/file-manager/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@tutti-os/ui-i18n-runtime": "workspace:*",
+    "@tutti-os/ui-react-hooks": "workspace:*",
     "@tutti-os/ui-system": "workspace:*",
     "@tutti-os/workspace-file-preview": "workspace:*"
   },

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManagerIconGrid.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManagerIconGrid.tsx
@@ -321,6 +321,9 @@ function IconTileRenameInput({
           onClearInlineRenameValidation();
         }}
         onKeyDown={(event) => {
+          if (event.nativeEvent.isComposing || event.keyCode === 229) {
+            return;
+          }
           if (event.key === "Enter") {
             event.preventDefault();
             void onConfirmInlineRename(event.currentTarget.value);

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManagerMenus.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManagerMenus.tsx
@@ -1,3 +1,4 @@
+import { useComposedInputValue } from "@tutti-os/ui-react-hooks";
 import {
   Button,
   ConfirmationDialog,
@@ -33,6 +34,11 @@ export function WorkspaceFileManagerCreateDialog({
   onConfirm: () => void;
   onNameChange: (name: string) => void;
 }): ReactElement | null {
+  const nameInput = useComposedInputValue({
+    onCommit: onNameChange,
+    value: dialog?.name ?? ""
+  });
+
   if (!dialog) {
     return null;
   }
@@ -51,6 +57,9 @@ export function WorkspaceFileManagerCreateDialog({
           className="grid gap-3"
           onSubmit={(event) => {
             event.preventDefault();
+            if (busy || nameInput.isComposing) {
+              return;
+            }
             onConfirm();
           }}
         >
@@ -68,10 +77,11 @@ export function WorkspaceFileManagerCreateDialog({
                 ? copy.t("createDirectoryPlaceholder")
                 : copy.t("createFilePlaceholder")
             }
-            value={dialog.name}
-            onChange={(event) => {
-              onNameChange(event.currentTarget.value);
-            }}
+            value={nameInput.value}
+            onBlur={nameInput.onBlur}
+            onChange={nameInput.onChange}
+            onCompositionEnd={nameInput.onCompositionEnd}
+            onCompositionStart={nameInput.onCompositionStart}
           />
           {dialog.errorMessage ? (
             <p className="text-[13px] text-[var(--state-danger)]">

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManagerPanels.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManagerPanels.tsx
@@ -1457,6 +1457,9 @@ function EntryNameCell({
               }
             }}
             onKeyDown={(event) => {
+              if (event.nativeEvent.isComposing || event.keyCode === 229) {
+                return;
+              }
               if (event.key === "Enter") {
                 event.preventDefault();
                 void handleConfirm();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1124,6 +1124,9 @@ importers:
       "@tutti-os/ui-i18n-runtime":
         specifier: workspace:*
         version: link:../../ui/i18n-runtime
+      "@tutti-os/ui-react-hooks":
+        specifier: workspace:*
+        version: link:../../ui/react-hooks
       "@tutti-os/ui-system":
         specifier: workspace:*
         version: link:../../ui/system


### PR DESCRIPTION
## Summary
- Fix New folder / New file dialogs so CJK IME composition is not wiped by controlled dialog state (`useComposedInputValue`, same pattern as other workspace inputs).
- Ignore Enter / Escape during inline rename composition so confirming an IME candidate does not submit or cancel rename.
- Extend the workbench-renderer IME troubleshooting note to cover controlled name dialogs.

## Test plan
- [ ] Open Files → New folder, type a Chinese folder name with IME, confirm candidates, then create
- [ ] Open Files → New file and repeat with a Chinese file name
- [ ] Rename a file/folder with Chinese IME; Enter should accept the candidate, not submit rename mid-composition
- [ ] `pnpm --filter @tutti-os/workspace-file-manager test`


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1720" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->