### PR TITLE
fix(agent): avoid redundant child message reads

### DIFF
--- a/apps/desktop/src/main/agentPowerSaveBlocker.test.ts
+++ b/apps/desktop/src/main/agentPowerSaveBlocker.test.ts
@@ -222,6 +222,7 @@ function createSession(id: string, status: string): WorkspaceAgentSession {
     activeTurnId: active ? "turn-1" : null,
     latestTurn: null,
     latestTurnInteractions: [],
+    messageVersion: 0,
     pendingInteractions: [],
     permissionConfig: { configurable: false, modes: [] },
     pinnedAtUnixMs: null,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -1873,6 +1873,7 @@ function createSession(
     usage: null,
     visible: true,
     ...canonicalOverrides,
+    messageVersion: canonicalOverrides.messageVersion ?? 0,
     tuttiModeActivation: canonicalOverrides.tuttiModeActivation ?? null,
     kind: canonicalOverrides.kind ?? "root",
     rootAgentSessionId: canonicalOverrides.rootAgentSessionId ?? null,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityDiagnostics.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityDiagnostics.ts
@@ -54,6 +54,22 @@ export function reconcileAfterVersion(
     : latest;
 }
 
+export function latestDurableMessageVersion(
+  messages: readonly AgentActivityMessage[]
+): number {
+  return messages.reduce((latest, message) => {
+    if (
+      !Number.isSafeInteger(message.sequence) ||
+      (message.sequence ?? 0) <= 0 ||
+      !Number.isSafeInteger(message.version) ||
+      message.version <= 0
+    ) {
+      return latest;
+    }
+    return Math.max(latest, message.version);
+  }, 0);
+}
+
 export function hasInlineMessagesData(data: unknown): boolean {
   return (
     typeof data === "object" &&

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts
@@ -851,16 +851,23 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
     const discoveredSessionIds = new Set(
       discoveredSessions.map((session) => session.agentSessionId)
     );
-    const childSessionsNeedingFinalRead = detail.childSessions.filter(
-      (session) => {
-        if (!discoveredSessionIds.has(session.agentSessionId)) return true;
-        return (
-          latestDurableMessageVersion(
-            cachedMessagesBySessionId.get(session.agentSessionId) ?? []
-          ) < session.messageVersion
-        );
-      }
-    );
+    const finalChildSessionsById = new Map<string, AgentActivitySession>();
+    if (detail.session.kind === "child") {
+      finalChildSessionsById.set(detail.session.agentSessionId, detail.session);
+    }
+    for (const session of detail.childSessions) {
+      finalChildSessionsById.set(session.agentSessionId, session);
+    }
+    const childSessionsNeedingFinalRead = [
+      ...finalChildSessionsById.values()
+    ].filter((session) => {
+      if (!discoveredSessionIds.has(session.agentSessionId)) return true;
+      return (
+        latestDurableMessageVersion(
+          cachedMessagesBySessionId.get(session.agentSessionId) ?? []
+        ) < session.messageVersion
+      );
+    });
     pages.push(...(await reconcileMessages(childSessionsNeedingFinalRead)));
     if (this.isSessionTombstoned(workspaceId, agentSessionId)) {
       return;

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts
@@ -8,6 +8,7 @@ import {
   analyzeAgentActivityEventObservation,
   agentActivitySessionMessageWindowFromDescendingPage,
   createAgentActivitySnapshotProjector,
+  mergeAgentActivityMessages,
   parseAgentActivityMessageDeltaEvent,
   selectEngineSession
 } from "@tutti-os/agent-activity-core";
@@ -17,6 +18,7 @@ import {
   agentActivitySessionReconcileDiagnosticDetails,
   hostMessageEventFromCore,
   isWorkspaceAgentSessionNotFoundError,
+  latestDurableMessageVersion,
   normalizeWorkspaceId,
   reconcileAfterVersion,
   stringifyError
@@ -729,6 +731,22 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
     if (this.isSessionTombstoned(workspaceId, agentSessionId)) {
       return;
     }
+    const cachedMessagesBySessionId = new Map<
+      string,
+      AgentActivitySnapshot["sessionMessagesById"][string]
+    >();
+    const knownMessageWindows = new Set<string>();
+    const initialSnapshot = this.activitySnapshot(workspaceId);
+    for (const [sessionId, messages] of Object.entries(
+      initialSnapshot.sessionMessagesById
+    )) {
+      cachedMessagesBySessionId.set(sessionId, messages);
+    }
+    for (const sessionId of Object.keys(
+      initialSnapshot.sessionMessageWindowsById ?? {}
+    )) {
+      knownMessageWindows.add(sessionId);
+    }
     const reconcileMessages = async (
       sessions: AgentActivitySession[]
     ): Promise<
@@ -741,11 +759,29 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
       Promise.all(
         sessions.map(async (session) => {
           const sessionId = session.agentSessionId;
-          const snapshot = this.activitySnapshot(workspaceId);
-          const cached = snapshot.sessionMessagesById[sessionId];
-          const startsAtNewestBoundary =
-            snapshot.sessionMessageWindowsById?.[sessionId] === undefined;
-          const afterVersion = reconcileAfterVersion(cached ?? []);
+          const cached = cachedMessagesBySessionId.get(sessionId) ?? [];
+          const startsAtNewestBoundary = !knownMessageWindows.has(sessionId);
+          const childSession = session.kind === "child";
+          const afterVersion = childSession
+            ? latestDurableMessageVersion(cached)
+            : reconcileAfterVersion(cached);
+          if (
+            childSession &&
+            !startsAtNewestBoundary &&
+            afterVersion >= session.messageVersion
+          ) {
+            this.reportReconcileTrace({
+              agentSessionId: sessionId,
+              traceEvent: "reconcile.combined.messages_skipped",
+              workspaceId,
+              fields: {
+                afterVersion,
+                messageVersion: session.messageVersion,
+                requestedSessionId: agentSessionId
+              }
+            });
+            return null;
+          }
           this.reportReconcileTrace({
             agentSessionId: sessionId,
             traceEvent: "reconcile.combined.messages_requested",
@@ -755,7 +791,8 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
           const page = await reconcileAgentSessionMessagePages({
             adapter: entry.adapter,
             agentSessionId: sessionId,
-            cached: cached ?? [],
+            cached,
+            cursorPolicy: childSession ? "durable" : "conversation",
             messageWindowKnown: !startsAtNewestBoundary,
             shouldAbort: () => this.isSessionTombstoned(workspaceId, sessionId),
             workspaceId
@@ -771,12 +808,29 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
               requestedSessionId: agentSessionId
             }
           });
+          cachedMessagesBySessionId.set(
+            sessionId,
+            mergeAgentActivityMessages(cached, page.messages)
+          );
+          if (startsAtNewestBoundary) {
+            knownMessageWindows.add(sessionId);
+          }
           return {
             agentSessionId: sessionId,
             page,
             startsAtNewestBoundary
           };
         })
+      ).then((results) =>
+        results.filter(
+          (
+            result
+          ): result is {
+            agentSessionId: string;
+            page: AgentActivityMessagePage;
+            startsAtNewestBoundary: boolean;
+          } => result !== null
+        )
       );
     const discoveredSessions = [
       discoveryDetail.session,
@@ -797,10 +851,17 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
     const discoveredSessionIds = new Set(
       discoveredSessions.map((session) => session.agentSessionId)
     );
-    const newlyDiscoveredSessions = detail.childSessions.filter(
-      (session) => !discoveredSessionIds.has(session.agentSessionId)
+    const childSessionsNeedingFinalRead = detail.childSessions.filter(
+      (session) => {
+        if (!discoveredSessionIds.has(session.agentSessionId)) return true;
+        return (
+          latestDurableMessageVersion(
+            cachedMessagesBySessionId.get(session.agentSessionId) ?? []
+          ) < session.messageVersion
+        );
+      }
     );
-    pages.push(...(await reconcileMessages(newlyDiscoveredSessions)));
+    pages.push(...(await reconcileMessages(childSessionsNeedingFinalRead)));
     if (this.isSessionTombstoned(workspaceId, agentSessionId)) {
       return;
     }
@@ -893,7 +954,15 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
     const messages = snapshot.sessionMessagesById[agentSessionId];
     const startsAtNewestBoundary =
       snapshot.sessionMessageWindowsById?.[agentSessionId] === undefined;
-    const afterVersion = reconcileAfterVersion(messages ?? []);
+    const cursorPolicy =
+      selectEngineSession(entry.engine.getSnapshot(), agentSessionId)?.kind ===
+      "child"
+        ? "durable"
+        : "conversation";
+    const afterVersion =
+      cursorPolicy === "durable"
+        ? latestDurableMessageVersion(messages ?? [])
+        : reconcileAfterVersion(messages ?? []);
     this.reportReconcileTrace({
       agentSessionId,
       traceEvent: "reconcile.messages.requested",
@@ -904,6 +973,7 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
       adapter: entry.adapter,
       agentSessionId,
       cached: messages ?? [],
+      cursorPolicy,
       messageWindowKnown: !startsAtNewestBoundary,
       shouldAbort: () => this.isSessionTombstoned(workspaceId, agentSessionId),
       workspaceId

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileMessages.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileMessages.test.ts
@@ -1,58 +1,238 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import {
-  analyzeInlineMessageVersionContinuity,
-  type AgentActivityMessage
+import type {
+  AgentActivityAdapter,
+  AgentActivityDurableMessage,
+  AgentActivityMessage,
+  AgentActivityMessagePage
 } from "@tutti-os/agent-activity-core";
+import { reconcileAgentSessionMessagePages } from "./workspaceAgentActivityReconcileMessages.ts";
 
-test("inline message continuity accepts snapshot cursor gaps already present in the cache", () => {
-  const result = analyzeInlineMessageVersionContinuity(
-    [message(1), message(5)],
-    [message(6), message(7)]
-  );
-
-  assert.deepEqual(result, {
-    cachedVersion: 5,
-    continuous: true,
-    firstUnseenVersion: 6,
-    latestIncomingVersion: 7
+test("child cursor advances from assistant-only durable messages", async () => {
+  const requests: MessageRequest[] = [];
+  await reconcileAgentSessionMessagePages({
+    adapter: adapterRecording(requests),
+    agentSessionId: "child-1",
+    cached: [message({ role: "assistant", sequence: 1, version: 7 })],
+    cursorPolicy: "durable",
+    messageWindowKnown: true,
+    shouldAbort: () => false,
+    workspaceId: "workspace-1"
   });
+
+  assert.deepEqual(requests, [
+    {
+      afterVersion: 7,
+      agentSessionId: "child-1",
+      order: "asc",
+      workspaceId: "workspace-1"
+    }
+  ]);
 });
 
-test("inline message continuity rejects an unseen version hole", () => {
-  const result = analyzeInlineMessageVersionContinuity(
-    [message(1)],
-    [message(3)]
-  );
-
-  assert.deepEqual(result, {
-    cachedVersion: 1,
-    continuous: false,
-    firstUnseenVersion: 3,
-    latestIncomingVersion: 3
+test("child cursor advances from tool-only durable messages", async () => {
+  const requests: MessageRequest[] = [];
+  await reconcileAgentSessionMessagePages({
+    adapter: adapterRecording(requests),
+    agentSessionId: "child-1",
+    cached: [
+      message({
+        kind: "tool_call",
+        role: "assistant",
+        sequence: 4,
+        version: 12
+      })
+    ],
+    cursorPolicy: "durable",
+    messageWindowKnown: true,
+    shouldAbort: () => false,
+    workspaceId: "workspace-1"
   });
+
+  assert.equal(requests[0]?.afterVersion, 12);
+  assert.equal(requests[0]?.order, "asc");
 });
 
-test("inline message continuity accepts duplicate or stale delivery", () => {
-  assert.equal(
-    analyzeInlineMessageVersionContinuity(
-      [message(3)],
-      [message(2), message(3)]
-    ).continuous,
-    true
+test("child cursor ignores transient overlays even when their version is higher", async () => {
+  const requests: MessageRequest[] = [];
+  await reconcileAgentSessionMessagePages({
+    adapter: adapterRecording(requests),
+    agentSessionId: "child-1",
+    cached: [
+      message({ sequence: 1, version: 5 }),
+      message({ messageId: "transient", sequence: undefined, version: 99 })
+    ],
+    cursorPolicy: "durable",
+    messageWindowKnown: true,
+    shouldAbort: () => false,
+    workspaceId: "workspace-1"
+  });
+
+  assert.equal(requests[0]?.afterVersion, 5);
+});
+
+test("root conversation keeps its missing-user history repair policy", async () => {
+  const requests: MessageRequest[] = [];
+  await reconcileAgentSessionMessagePages({
+    adapter: adapterRecording(requests),
+    agentSessionId: "root-1",
+    cached: [message({ role: "assistant", sequence: 1, version: 7 })],
+    cursorPolicy: "conversation",
+    messageWindowKnown: true,
+    shouldAbort: () => false,
+    workspaceId: "workspace-1"
+  });
+
+  assert.deepEqual(requests, [
+    {
+      afterVersion: 0,
+      agentSessionId: "root-1",
+      order: "asc",
+      workspaceId: "workspace-1"
+    }
+  ]);
+});
+
+test("first child read preserves the bounded newest-page contract", async () => {
+  const requests: MessageRequest[] = [];
+  await reconcileAgentSessionMessagePages({
+    adapter: adapterRecording(requests),
+    agentSessionId: "child-1",
+    cached: [],
+    cursorPolicy: "durable",
+    messageWindowKnown: false,
+    shouldAbort: () => false,
+    workspaceId: "workspace-1"
+  });
+
+  assert.deepEqual(requests, [
+    {
+      agentSessionId: "child-1",
+      limit: 100,
+      order: "desc",
+      workspaceId: "workspace-1"
+    }
+  ]);
+});
+
+test("known-empty child drains every message from authoritative cursor zero", async () => {
+  const requests: MessageRequest[] = [];
+  const adapter = {
+    async listSessionMessages(
+      input: MessageRequest
+    ): Promise<AgentActivityMessagePage> {
+      requests.push({ ...input });
+      if (input.afterVersion === 0) {
+        return {
+          hasMore: true,
+          latestVersion: 100,
+          messages: Array.from({ length: 100 }, (_, index) =>
+            durableMessage({
+              messageId: `message-${index + 1}`,
+              sequence: index + 1,
+              version: index + 1
+            })
+          )
+        };
+      }
+      assert.equal(input.afterVersion, 100);
+      return {
+        hasMore: false,
+        latestVersion: 200,
+        messages: Array.from({ length: 100 }, (_, index) =>
+          durableMessage({
+            messageId: `message-${index + 101}`,
+            sequence: index + 101,
+            version: index + 101
+          })
+        )
+      };
+    }
+  } as AgentActivityAdapter;
+
+  const page = await reconcileAgentSessionMessagePages({
+    adapter,
+    agentSessionId: "child-1",
+    cached: [],
+    cursorPolicy: "durable",
+    messageWindowKnown: true,
+    shouldAbort: () => false,
+    workspaceId: "workspace-1"
+  });
+
+  assert.deepEqual(
+    requests.map(({ afterVersion, order }) => ({ afterVersion, order })),
+    [
+      { afterVersion: 0, order: "asc" },
+      { afterVersion: 100, order: "asc" }
+    ]
   );
+  assert.equal(page.messages.length, 200);
+  assert.equal(page.latestVersion, 200);
 });
 
-function message(version: number): AgentActivityMessage {
+test("known-empty root preserves the newest-page repair policy", async () => {
+  const requests: MessageRequest[] = [];
+  await reconcileAgentSessionMessagePages({
+    adapter: adapterRecording(requests),
+    agentSessionId: "root-1",
+    cached: [],
+    cursorPolicy: "conversation",
+    messageWindowKnown: true,
+    shouldAbort: () => false,
+    workspaceId: "workspace-1"
+  });
+
+  assert.deepEqual(requests, [
+    {
+      agentSessionId: "root-1",
+      limit: 100,
+      order: "desc",
+      workspaceId: "workspace-1"
+    }
+  ]);
+});
+
+type MessageRequest = Parameters<
+  AgentActivityAdapter["listSessionMessages"]
+>[0];
+
+function adapterRecording(requests: MessageRequest[]): AgentActivityAdapter {
   return {
-    workspaceId: "ws-1",
-    agentSessionId: "session-1",
-    messageId: `message-${version}`,
-    version,
-    turnId: "turn-1",
+    async listSessionMessages(input): Promise<AgentActivityMessagePage> {
+      requests.push({ ...input });
+      return {
+        hasMore: false,
+        latestVersion: input.afterVersion ?? 0,
+        messages: []
+      };
+    }
+  } as AgentActivityAdapter;
+}
+
+function message(
+  overrides: Partial<AgentActivityMessage>
+): AgentActivityMessage {
+  return {
+    ...durableMessage(),
+    ...overrides
+  } as AgentActivityMessage;
+}
+
+function durableMessage(
+  overrides: Partial<AgentActivityDurableMessage> = {}
+): AgentActivityDurableMessage {
+  return {
+    agentSessionId: "child-1",
+    kind: "message.assistant",
+    messageId: "message-1",
+    occurredAtUnixMs: 1,
+    payload: {},
     role: "assistant",
-    kind: "text",
-    payload: { text: String(version) },
-    occurredAtUnixMs: version
+    sequence: 1,
+    turnId: "turn-1",
+    version: 1,
+    workspaceId: "workspace-1",
+    ...overrides
   };
 }

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileMessages.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileMessages.ts
@@ -4,12 +4,16 @@ import {
   type AgentActivityMessage,
   type AgentActivityMessagePage
 } from "@tutti-os/agent-activity-core";
-import { reconcileAfterVersion } from "./workspaceAgentActivityDiagnostics.ts";
+import {
+  latestDurableMessageVersion,
+  reconcileAfterVersion
+} from "./workspaceAgentActivityDiagnostics.ts";
 
 interface ReconcileAgentSessionMessagePagesInput {
   adapter: AgentActivityAdapter;
   agentSessionId: string;
   cached: AgentActivityMessage[];
+  cursorPolicy: "conversation" | "durable";
   messageWindowKnown: boolean;
   shouldAbort: () => boolean;
   workspaceId: string;
@@ -18,7 +22,14 @@ interface ReconcileAgentSessionMessagePagesInput {
 export async function reconcileAgentSessionMessagePages(
   input: ReconcileAgentSessionMessagePagesInput
 ): Promise<AgentActivityMessagePage> {
-  if (input.cached.length === 0 || !input.messageWindowKnown) {
+  const afterVersion =
+    input.cursorPolicy === "durable"
+      ? latestDurableMessageVersion(input.cached)
+      : reconcileAfterVersion(input.cached);
+  const shouldLoadNewestPage =
+    !input.messageWindowKnown ||
+    (input.cursorPolicy === "conversation" && input.cached.length === 0);
+  if (shouldLoadNewestPage) {
     return input.adapter.listSessionMessages({
       workspaceId: input.workspaceId,
       agentSessionId: input.agentSessionId,
@@ -27,7 +38,6 @@ export async function reconcileAgentSessionMessagePages(
     });
   }
 
-  const afterVersion = reconcileAfterVersion(input.cached);
   const result = await loadAllAgentSessionMessages({
     afterVersion,
     listPage: (cursor) =>

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -1980,6 +1980,7 @@ test("WorkspaceAgentActivityService reconciles child sessions and their messages
     ...workspaceAgentSession({ status: "working" }),
     id: "child-1",
     kind: "child",
+    messageVersion: 1,
     rootAgentSessionId: "session-1",
     rootTurnId: "turn-1",
     parentAgentSessionId: "session-1",
@@ -1988,6 +1989,10 @@ test("WorkspaceAgentActivityService reconciles child sessions and their messages
     title: "Child 1"
   };
   const messageRequests: string[] = [];
+  const messageRequestInputs: Array<{
+    agentSessionId: string;
+    request: Record<string, unknown>;
+  }> = [];
   const service = new WorkspaceAgentActivityService({
     tuttidClient: {
       getWorkspaceAgentSession: async () => ({
@@ -2017,9 +2022,11 @@ test("WorkspaceAgentActivityService reconciles child sessions and their messages
       }),
       listWorkspaceAgentSessionMessages: async (
         _workspaceId: string,
-        agentSessionId: string
+        agentSessionId: string,
+        request: Record<string, unknown>
       ) => {
         messageRequests.push(agentSessionId);
+        messageRequestInputs.push({ agentSessionId, request });
         return {
           hasMore: false,
           latestVersion: 1,
@@ -2031,6 +2038,7 @@ test("WorkspaceAgentActivityService reconciles child sessions and their messages
               occurredAtUnixMs: 1,
               payload: { text: agentSessionId },
               role: "assistant",
+              sequence: 1,
               turnId: agentSessionId === "child-1" ? "child-turn-1" : "turn-1",
               version: 1
             }
@@ -2072,6 +2080,17 @@ test("WorkspaceAgentActivityService reconciles child sessions and their messages
     snapshot.sessionMessagesById["child-1"]?.[0]?.turnId,
     "child-turn-1"
   );
+  messageRequests.length = 0;
+  service.ensureSessionSynchronized({
+    agentSessionId: "session-1",
+    workspaceId: "ws-1"
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(
+    messageRequests,
+    ["session-1"],
+    "an unchanged child cursor should skip its message request"
+  );
   assert.deepEqual(
     selectEngineTurnsForSession(
       service.getSessionEngine("ws-1").getSnapshot(),
@@ -2092,6 +2111,108 @@ test("WorkspaceAgentActivityService reconciles child sessions and their messages
         }
       }
     ]
+  );
+});
+
+test("WorkspaceAgentActivityService catches up a child that advances between detail reads", async () => {
+  const root = workspaceAgentSession({ status: "ready" });
+  const child = {
+    ...workspaceAgentSession({ status: "working" }),
+    id: "child-1",
+    kind: "child",
+    messageVersion: 1,
+    parentAgentSessionId: "session-1",
+    parentToolCallId: "spawn-1",
+    parentTurnId: "turn-1",
+    rootAgentSessionId: "session-1",
+    rootTurnId: "turn-1"
+  };
+  let detailReads = 0;
+  let advanceBetweenDetailReads = false;
+  const childRequests: Array<Record<string, unknown>> = [];
+  const service = new WorkspaceAgentActivityService({
+    tuttidClient: {
+      getWorkspaceAgentSession: async () => {
+        detailReads += 1;
+        return {
+          session: root,
+          childSessions: [
+            {
+              ...child,
+              messageVersion:
+                advanceBetweenDetailReads && detailReads === 2 ? 2 : 1
+            }
+          ],
+          turns: []
+        };
+      },
+      listWorkspaceAgentSessions: async () => ({
+        hasMore: false,
+        sessions: [root],
+        workspaceId: "ws-1"
+      }),
+      listWorkspaceAgentSessionMessages: async (
+        _workspaceId: string,
+        agentSessionId: string,
+        request: Record<string, unknown>
+      ) => {
+        if (agentSessionId !== "child-1") {
+          return { hasMore: false, latestVersion: 0, messages: [] };
+        }
+        childRequests.push(request);
+        const version = request.afterVersion === 1 ? 2 : 1;
+        return {
+          hasMore: false,
+          latestVersion: version,
+          messages: [
+            {
+              agentSessionId,
+              kind: "text",
+              messageId: "child-progress",
+              occurredAtUnixMs: version,
+              payload: { text: `v${version}` },
+              role: "assistant",
+              sequence: 1,
+              turnId: "child-turn-1",
+              version
+            }
+          ]
+        };
+      }
+    } as unknown as TuttidClient,
+    runtimeApi: { logTerminalDiagnostic: async () => {} }
+  });
+
+  await service.load("ws-1");
+  service.ensureSessionSynchronized({
+    agentSessionId: "session-1",
+    workspaceId: "ws-1"
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(childRequests, [
+    { afterVersion: 0, beforeVersion: undefined, limit: 100, order: "desc" }
+  ]);
+  childRequests.length = 0;
+  detailReads = 0;
+  advanceBetweenDetailReads = true;
+  service.ensureSessionSynchronized({
+    agentSessionId: "session-1",
+    workspaceId: "ws-1"
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(childRequests, [
+    {
+      afterVersion: 1,
+      beforeVersion: undefined,
+      limit: undefined,
+      order: "asc"
+    }
+  ]);
+  assert.equal(
+    service.getSnapshot("ws-1").sessionMessagesById["child-1"]?.[0]?.version,
+    2
   );
 });
 
@@ -2156,9 +2277,14 @@ test("WorkspaceAgentActivityService loads the newest history page first", async 
   );
 });
 
-test("WorkspaceAgentActivityService drains every incremental history page", async () => {
+test("WorkspaceAgentActivityService drains child incremental pages from its durable cursor", async () => {
   const requests: Array<Record<string, unknown>> = [];
-  const session = workspaceAgentSession({ status: "ready" });
+  const session = {
+    ...workspaceAgentSession({ status: "ready" }),
+    kind: "child",
+    parentAgentSessionId: "root-1",
+    rootAgentSessionId: "root-1"
+  };
   let mode: "idle" | "incremental" | "seed" = "idle";
   const message = (version: number) => ({
     agentSessionId: "session-1",
@@ -2166,7 +2292,8 @@ test("WorkspaceAgentActivityService drains every incremental history page", asyn
     messageId: `message-${version}`,
     occurredAtUnixMs: version,
     payload: { text: String(version) },
-    role: "user",
+    role: "assistant",
+    sequence: version,
     turnId: `turn-${version}`,
     version
   });
@@ -3036,6 +3163,7 @@ function workspaceAgentSession(overrides: {
   runtimeContext?: Record<string, unknown>;
   settings?: Record<string, unknown>;
   latestTurn?: Record<string, unknown> | null;
+  messageVersion?: number;
   status: string;
   submitAvailability?: Record<string, unknown>;
   turnLifecycle?: Record<string, unknown>;
@@ -3089,6 +3217,7 @@ function workspaceAgentSession(overrides: {
     cwd: "/workspace",
     latestTurn,
     latestTurnInteractions: [],
+    messageVersion: overrides.messageVersion ?? 0,
     pendingInteractions: [],
     permissionConfig: { configurable: false, modes: [] },
     pinnedAtUnixMs: null,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -2114,7 +2114,7 @@ test("WorkspaceAgentActivityService reconciles child sessions and their messages
   );
 });
 
-test("WorkspaceAgentActivityService catches up a child that advances between detail reads", async () => {
+test("WorkspaceAgentActivityService catches up children that advance between detail reads", async () => {
   const root = workspaceAgentSession({ status: "ready" });
   const child = {
     ...workspaceAgentSession({ status: "working" }),
@@ -2132,8 +2132,21 @@ test("WorkspaceAgentActivityService catches up a child that advances between det
   const childRequests: Array<Record<string, unknown>> = [];
   const service = new WorkspaceAgentActivityService({
     tuttidClient: {
-      getWorkspaceAgentSession: async () => {
+      getWorkspaceAgentSession: async (
+        _workspaceId: string,
+        requestedSessionId: string
+      ) => {
         detailReads += 1;
+        if (requestedSessionId === "child-1") {
+          return {
+            session: {
+              ...child,
+              messageVersion: detailReads === 2 ? 3 : 2
+            },
+            childSessions: [],
+            turns: []
+          };
+        }
         return {
           session: root,
           childSessions: [
@@ -2160,7 +2173,8 @@ test("WorkspaceAgentActivityService catches up a child that advances between det
           return { hasMore: false, latestVersion: 0, messages: [] };
         }
         childRequests.push(request);
-        const version = request.afterVersion === 1 ? 2 : 1;
+        const version =
+          request.afterVersion === 2 ? 3 : request.afterVersion === 1 ? 2 : 1;
         return {
           hasMore: false,
           latestVersion: version,
@@ -2213,6 +2227,27 @@ test("WorkspaceAgentActivityService catches up a child that advances between det
   assert.equal(
     service.getSnapshot("ws-1").sessionMessagesById["child-1"]?.[0]?.version,
     2
+  );
+
+  childRequests.length = 0;
+  detailReads = 0;
+  service.ensureSessionSynchronized({
+    agentSessionId: "child-1",
+    workspaceId: "ws-1"
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(childRequests, [
+    {
+      afterVersion: 2,
+      beforeVersion: undefined,
+      limit: undefined,
+      order: "asc"
+    }
+  ]);
+  assert.equal(
+    service.getSnapshot("ws-1").sessionMessagesById["child-1"]?.[0]?.version,
+    3
   );
 });
 

--- a/apps/mobile/src/services/workspaceActivityService.test.ts
+++ b/apps/mobile/src/services/workspaceActivityService.test.ts
@@ -1154,6 +1154,7 @@ function createSession(): WorkspaceAgentSession {
     kind: "root",
     latestTurn: null,
     latestTurnInteractions: [],
+    messageVersion: 0,
     parentAgentSessionId: null,
     parentToolCallId: null,
     parentTurnId: null,

--- a/apps/mobile/src/services/workspaceConversationRailService.test.ts
+++ b/apps/mobile/src/services/workspaceConversationRailService.test.ts
@@ -270,6 +270,7 @@ function createSession(
     kind: "root",
     latestTurn: null,
     latestTurnInteractions: [],
+    messageVersion: 0,
     parentAgentSessionId: null,
     parentToolCallId: null,
     parentTurnId: null,

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -697,6 +697,16 @@ Durable daemon message pages and `message_update` payloads use
 `AgentActivityDurableMessage`, whose immutable `sequence` is required. Local
 optimistic and session-audit projections may use the separate transient
 message shape; this must not weaken the durable page or realtime contract.
+The generated daemon Session DTO also requires `messageVersion`. The shared
+`@tutti-os/agent-activity-tuttid-adapter` validates and preserves that high-water
+cursor for Desktop and Mobile; consumers must not replace a missing value with
+zero or add an old-daemon fallback because both binaries upgrade together.
+Every HTTP field in this cursor domain (`messageVersion`, message `version`,
+page `latestVersion`, and `afterVersion`/`beforeVersion`) is bounded by
+JavaScript's maximum safe integer. Durable message `sequence` has the same
+transport bound. Store and service layers retain `uint64`; the daemon API owns
+checked conversion and must fail response projection instead of emitting an
+inexact JSON number.
 
 The adapter exposes the HTTP operations used by that command port and by the
 desktop reconcile bridge:

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -393,6 +393,10 @@ notice does not offer a manual retry because transport recovery is host-owned.
   drain and one subscriber notification. Desktop and Mobile use the same
   `@tutti-os/agent-activity-tuttid-adapter` aggregate mapper and must not
   dispatch each entity independently
+- every daemon Session response carries the required `messageVersion`
+  high-water cursor. Daemon and renderer ship as one protocol unit, so the
+  shared adapter rejects a missing or invalid cursor instead of fabricating
+  zero or entering a compatibility read path
 - Desktop and Mobile use the same host-neutral event-observation helper to
   decide whether normalized entities can apply inline and whether the exact
   Session needs an authoritative state or message reconcile; partial parsing,
@@ -410,6 +414,20 @@ Child Session discovery does not require every host to prefetch child transcript
 pages. A surface that does not render child conversations keeps the hierarchy
 and pending Interaction state canonical without paying for unused child message
 history.
+
+Desktop hydrates child messages only when its aggregate projections need them.
+The first read remains a bounded newest-first page. Later root-detail
+reconciliation compares each child's required Session `messageVersion` with the
+largest locally cached durable message version; an unchanged child performs no
+message request. Newly discovered children use the bounded newest-first read,
+while already hydrated children that advanced use incremental reads. A known
+empty child window is an authoritative durable cursor at zero, so its first
+later messages are drained incrementally from `afterVersion=0`; it is not
+treated as an unknown window. The second detail read catches a child that
+advances while the first message pass is in flight. Transient optimistic rows
+never advance this cursor. This child policy is separate from the root
+conversation's user-boundary repair policy, which may intentionally restart an
+incremental read at zero.
 
 A `waiting` Turn does not imply user action. Only a pending Interaction produces approval/question attention.
 

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -2691,6 +2691,45 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   [workspaceAgentActivityReconcileMessages.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileMessages.ts)
   [agent-gui-node.md](../../architecture/agent-gui-node.md)
 
+### Root detail reconciliation repeatedly reloads unchanged child transcripts
+
+- Symptom:
+  Opening or reconciling one root conversation repeatedly issues message-list
+  requests for every known child Session, including assistant-only and
+  tool-only children whose durable messages have not changed.
+- Quick checks:
+  Compare each child Session's required `messageVersion` from both root-detail
+  reads with the largest cached message version that also has a durable
+  `sequence`. If the cache is current but the request still starts at zero,
+  inspect whether child reconciliation reused the root conversation's
+  user-message boundary heuristic.
+- Root cause:
+  The root heuristic intentionally returns zero when cached history has no user
+  message, so it can repair an incomplete root conversation. Applying that
+  heuristic to provider-native child Sessions makes ordinary assistant/tool
+  histories look permanently unhydrated and forces the same reads forever.
+- Fix:
+  Keep root and child cursor policies separate. For a child, derive the cursor
+  only from durable sequenced messages and skip its message request when that
+  cursor has reached the Session `messageVersion`. Preserve the bounded
+  newest-first initial read, but treat an existing empty child window as the
+  authoritative zero cursor and drain later messages from `afterVersion=0`.
+  After the first message pass, read root detail again and incrementally fetch
+  newly discovered children plus existing children whose `messageVersion`
+  advanced during the pass. Do not let optimistic/transient rows advance the
+  durable cursor, and do not add polling; later changes arrive through the
+  existing push-and-reconcile path.
+- Validation:
+  Cover assistant-only and tool-only child caches, a transient row with a higher
+  synthetic version, an unchanged child that performs no request, initial
+  newest-first hydration, an empty known child that gains more than one page,
+  and a child advancing between the two detail reads. Keep a root assistant-only
+  case proving its existing repair still reads from zero.
+- References:
+  [workspaceAgentActivityReconcileBridge.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts)
+  [workspaceAgentActivityReconcileMessages.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileMessages.ts)
+  [agent-gui-node.md](../../architecture/agent-gui-node.md)
+
 ### AgentActivity replication repeatedly rejects message batches as invalid
 
 - Symptom:

--- a/packages/agent/activity-core/src/types.ts
+++ b/packages/agent/activity-core/src/types.ts
@@ -71,6 +71,7 @@ export interface AgentActivitySession {
   imported: boolean;
   visible: boolean;
   resumable: boolean;
+  /** Latest accepted durable message change cursor. */
   messageVersion: number;
   lastEventUnixMs: number;
   startedAtUnixMs: number;

--- a/packages/agent/activity-tuttid-adapter/src/mappers.test.ts
+++ b/packages/agent/activity-tuttid-adapter/src/mappers.test.ts
@@ -16,6 +16,19 @@ test("session mapping requires and preserves the host-owned user identity", () =
     { currentUserId: "account-user-1" }
   );
   assert.equal(session.userId, "account-user-1");
+  assert.equal(session.messageVersion, 7);
+});
+
+test("session mapping rejects an invalid message cursor", () => {
+  assert.throws(
+    () =>
+      agentActivitySessionFromTuttidSession(
+        "workspace-1",
+        { ...createSession(), messageVersion: -1 },
+        { currentUserId: "account-user-1" }
+      ),
+    /messageVersion must be a non-negative safe integer/
+  );
 });
 
 test("session mapping rejects missing protocol-v2 fields", () => {
@@ -23,6 +36,7 @@ test("session mapping rejects missing protocol-v2 fields", () => {
     "activeTurnId",
     "latestTurnInteractions",
     "pendingInteractions",
+    "messageVersion",
     "railSectionKey",
     "tuttiModeActivation"
   ] as const) {
@@ -98,6 +112,7 @@ function createSession(): WorkspaceAgentSession {
     kind: "root",
     latestTurn: null,
     latestTurnInteractions: [],
+    messageVersion: 7,
     parentAgentSessionId: null,
     parentToolCallId: null,
     parentTurnId: null,

--- a/packages/agent/activity-tuttid-adapter/src/mappers.ts
+++ b/packages/agent/activity-tuttid-adapter/src/mappers.ts
@@ -56,7 +56,7 @@ export function agentActivitySessionFromTuttidSession(
     imported: session.imported ?? false,
     visible: session.visible ?? true,
     resumable: session.resumable ?? false,
-    messageVersion: 0,
+    messageVersion: session.messageVersion,
     lastEventUnixMs: updatedAtUnixMs,
     pinnedAtUnixMs: session.pinnedAtUnixMs ?? null,
     startedAtUnixMs: createdAtUnixMs,
@@ -123,6 +123,15 @@ export function assertTuttidProtocolV2SessionContract(
   ) {
     throw new Error(
       "Protocol v2 contract error: workspace agent railSectionKey must be a non-empty string"
+    );
+  }
+  if (
+    typeof value.messageVersion !== "number" ||
+    !Number.isSafeInteger(value.messageVersion) ||
+    value.messageVersion < 0
+  ) {
+    throw new Error(
+      "Protocol v2 contract error: workspace agent messageVersion must be a non-negative safe integer"
     );
   }
 }

--- a/packages/agent/activity-tuttid-adapter/src/sessionDetail.test.ts
+++ b/packages/agent/activity-tuttid-adapter/src/sessionDetail.test.ts
@@ -194,6 +194,7 @@ function createSession(
     kind: "root",
     latestTurn: null,
     latestTurnInteractions: [],
+    messageVersion: 0,
     parentAgentSessionId: null,
     parentToolCallId: null,
     parentTurnId: null,

--- a/packages/clients/tuttid-ts/src/generated/index.ts
+++ b/packages/clients/tuttid-ts/src/generated/index.ts
@@ -1624,6 +1624,7 @@ export type {
   WorkspaceAgentInteraction,
   WorkspaceAgentInteractionKind,
   WorkspaceAgentInteractionStatus,
+  WorkspaceAgentMessageCursor,
   WorkspaceAgentModelRef,
   WorkspaceAgentPlanDecisionOperation,
   WorkspaceAgentPlanDecisionResponse,

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -2085,6 +2085,11 @@ export type UpdateTuttiModeActivationResponse = {
  */
 export type WorkspaceAgentSessionKind = "root" | "child";
 
+/**
+ * Per-session durable message change cursor. The upper bound preserves exact integer representation in JavaScript clients.
+ */
+export type WorkspaceAgentMessageCursor = number;
+
 export type WorkspaceAgentSession = {
   id: string;
   kind: WorkspaceAgentSessionKind;
@@ -2114,6 +2119,10 @@ export type WorkspaceAgentSession = {
   agentTargetId: string | null;
   provider: WorkspaceAgentProvider;
   providerSessionId: string | null;
+  /**
+   * Latest accepted per-session message change cursor. This is a high-water mark, not a count of materialized message rows.
+   */
+  messageVersion: WorkspaceAgentMessageCursor;
   cwd: string | null;
   /**
    * Persisted conversation-rail membership key. Clients must use this exact key for section placement and must not infer membership from cwd or project paths.
@@ -2439,13 +2448,13 @@ export type WorkspaceAgentSessionMessage = {
   completedAtUnixMs?: number;
   createdAtUnixMs?: number;
   updatedAtUnixMs?: number;
-  version: number;
+  version: WorkspaceAgentMessageCursor;
 };
 
 export type WorkspaceAgentSessionMessagesResponse = {
   agentSessionId: string;
   messages: Array<WorkspaceAgentSessionMessage>;
-  latestVersion: number;
+  latestVersion: WorkspaceAgentMessageCursor;
   hasMore: boolean;
 };
 
@@ -9754,8 +9763,8 @@ export type ListWorkspaceAgentSessionMessagesData = {
     agentSessionID: string;
   };
   query?: {
-    afterVersion?: number;
-    beforeVersion?: number;
+    afterVersion?: WorkspaceAgentMessageCursor;
+    beforeVersion?: WorkspaceAgentMessageCursor;
     order?: "asc" | "desc";
     limit?: number;
   };

--- a/services/tuttid/api/daemon_agent_session_messages.go
+++ b/services/tuttid/api/daemon_agent_session_messages.go
@@ -1,11 +1,14 @@
 package api
 
 import (
+	"fmt"
 	"strings"
 
 	tuttigenerated "github.com/tutti-os/tutti/services/tuttid/api/generated"
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
 )
+
+const maxWorkspaceAgentJSONSafeInteger = uint64(1<<53 - 1)
 
 func generatedAgentSessionMessages(messages []agentservice.SessionMessage) ([]tuttigenerated.WorkspaceAgentSessionMessage, error) {
 	result := make([]tuttigenerated.WorkspaceAgentSessionMessage, 0, len(messages))
@@ -17,21 +20,29 @@ func generatedAgentSessionMessages(messages []agentservice.SessionMessage) ([]tu
 		if trimmed := strings.TrimSpace(message.TurnID); trimmed != "" {
 			turnID = &trimmed
 		}
+		sequence, err := generatedWorkspaceAgentSafeInteger("message sequence", message.ID)
+		if err != nil {
+			return nil, fmt.Errorf("project workspace agent message %q: %w", message.MessageID, err)
+		}
+		version, err := generatedWorkspaceAgentSafeInteger("message version", message.Version)
+		if err != nil {
+			return nil, fmt.Errorf("project workspace agent message %q: %w", message.MessageID, err)
+		}
 		generated := tuttigenerated.WorkspaceAgentSessionMessage{
 			AgentSessionId:    strings.TrimSpace(message.AgentSessionID),
 			CompletedAtUnixMs: int64Pointer(message.CompletedAtUnixMS),
 			CreatedAtUnixMs:   int64Pointer(message.CreatedAtUnixMS),
 			Kind:              strings.TrimSpace(message.Kind),
 			MessageId:         strings.TrimSpace(message.MessageID),
-			OccurredAtUnixMs:  normalizedGeneratedMessageOccurredAtUnixMS(message),
+			OccurredAtUnixMs:  normalizedGeneratedMessageOccurredAtUnixMS(message, version),
 			Payload:           clonePayloadPointer(message.Payload),
 			Role:              strings.TrimSpace(message.Role),
-			Sequence:          int64(message.ID),
+			Sequence:          sequence,
 			StartedAtUnixMs:   int64Pointer(message.StartedAtUnixMS),
 			Status:            stringPointer(strings.TrimSpace(message.Status)),
 			TurnId:            turnID,
 			UpdatedAtUnixMs:   int64Pointer(message.UpdatedAtUnixMS),
-			Version:           int64(message.Version),
+			Version:           version,
 		}
 		if message.Semantics != nil {
 			userVisible := message.Semantics.UserVisibleAssistantResponse
@@ -46,6 +57,25 @@ func generatedAgentSessionMessages(messages []agentservice.SessionMessage) ([]tu
 		result = append(result, generated)
 	}
 	return result, nil
+}
+
+func generatedWorkspaceAgentSafeInteger(field string, value uint64) (int64, error) {
+	if value > maxWorkspaceAgentJSONSafeInteger {
+		return 0, fmt.Errorf(
+			"%s %d exceeds JavaScript safe integer maximum %d",
+			field,
+			value,
+			maxWorkspaceAgentJSONSafeInteger,
+		)
+	}
+	return int64(value), nil
+}
+
+func workspaceAgentMessageCursorFromRequest(value int64) (uint64, error) {
+	if value < 0 || uint64(value) > maxWorkspaceAgentJSONSafeInteger {
+		return 0, agentservice.ErrInvalidArgument
+	}
+	return uint64(value), nil
 }
 
 func agentSessionMessageVersionRange(messages []agentservice.SessionMessage) (uint64, uint64) {
@@ -76,14 +106,14 @@ func generatedAgentSessionMessageVersionRange(messages []tuttigenerated.Workspac
 	return first, last
 }
 
-func normalizedGeneratedMessageOccurredAtUnixMS(message agentservice.SessionMessage) int64 {
+func normalizedGeneratedMessageOccurredAtUnixMS(message agentservice.SessionMessage, version int64) int64 {
 	return firstPositiveInt64(
 		message.OccurredAtUnixMS,
 		message.StartedAtUnixMS,
 		message.CompletedAtUnixMS,
 		message.CreatedAtUnixMS,
 		message.UpdatedAtUnixMS,
-		int64(message.Version),
+		version,
 		1,
 	)
 }

--- a/services/tuttid/api/daemon_agent_sessions.go
+++ b/services/tuttid/api/daemon_agent_sessions.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"strings"
 	"time"
@@ -159,16 +160,18 @@ func (api DaemonAPI) ListWorkspaceAgentSessionMessages(ctx context.Context, requ
 	agentSessionID := string(request.AgentSessionID)
 	input := agentservice.ListMessagesInput{}
 	if request.Params.AfterVersion != nil {
-		if *request.Params.AfterVersion < 0 {
+		afterVersion, err := workspaceAgentMessageCursorFromRequest(*request.Params.AfterVersion)
+		if err != nil {
 			return writeListWorkspaceAgentSessionMessagesError(agentservice.ErrInvalidArgument), nil
 		}
-		input.AfterVersion = uint64(*request.Params.AfterVersion)
+		input.AfterVersion = afterVersion
 	}
 	if request.Params.BeforeVersion != nil {
-		if *request.Params.BeforeVersion < 0 {
+		beforeVersion, err := workspaceAgentMessageCursorFromRequest(*request.Params.BeforeVersion)
+		if err != nil {
 			return writeListWorkspaceAgentSessionMessagesError(agentservice.ErrInvalidArgument), nil
 		}
-		input.BeforeVersion = uint64(*request.Params.BeforeVersion)
+		input.BeforeVersion = beforeVersion
 	}
 	if request.Params.Order != nil {
 		switch *request.Params.Order {
@@ -216,6 +219,10 @@ func (api DaemonAPI) ListWorkspaceAgentSessionMessages(ctx context.Context, requ
 		return writeListWorkspaceAgentSessionMessagesError(err), nil
 	}
 	messages, err := generatedAgentSessionMessages(page.Messages)
+	var latestVersion int64
+	if err == nil {
+		latestVersion, err = generatedWorkspaceAgentSafeInteger("latest message version", page.LatestVersion)
+	}
 	if err != nil {
 		firstVersion, lastVersion := agentSessionMessageVersionRange(page.Messages)
 		slog.Warn("workspace agent session messages response transform failed",
@@ -255,7 +262,7 @@ func (api DaemonAPI) ListWorkspaceAgentSessionMessages(ctx context.Context, requ
 	return tuttigenerated.ListWorkspaceAgentSessionMessages200JSONResponse{
 		AgentSessionId: page.AgentSessionID,
 		HasMore:        page.HasMore,
-		LatestVersion:  int64(page.LatestVersion),
+		LatestVersion:  latestVersion,
 		Messages:       messages,
 	}, nil
 }
@@ -717,6 +724,10 @@ func generatedAgentSession(session agentservice.Session) (tuttigenerated.Workspa
 	if err != nil {
 		return tuttigenerated.WorkspaceAgentSession{}, err
 	}
+	messageVersion, err := generatedWorkspaceAgentSafeInteger("session message version", session.MessageVersion)
+	if err != nil {
+		return tuttigenerated.WorkspaceAgentSession{}, fmt.Errorf("project workspace agent session %q: %w", session.ID, err)
+	}
 	return tuttigenerated.WorkspaceAgentSession{
 		ActiveTurn:             activeTurn,
 		ActiveTurnId:           optionalStringPointer(strings.TrimSpace(session.ActiveTurnID)),
@@ -731,6 +742,7 @@ func generatedAgentSession(session agentservice.Session) (tuttigenerated.Workspa
 		Kind:                   tuttigenerated.WorkspaceAgentSessionKind(session.Kind),
 		LatestTurn:             latestTurn,
 		LatestTurnInteractions: latestTurnInteractions,
+		MessageVersion:         messageVersion,
 		ParentAgentSessionId:   optionalStringPointer(strings.TrimSpace(session.ParentAgentSessionID)),
 		ParentToolCallId:       optionalStringPointer(strings.TrimSpace(session.ParentToolCallID)),
 		ParentTurnId:           optionalStringPointer(strings.TrimSpace(session.ParentTurnID)),

--- a/services/tuttid/api/daemon_agent_sessions_latest_turn_test.go
+++ b/services/tuttid/api/daemon_agent_sessions_latest_turn_test.go
@@ -37,6 +37,7 @@ func TestGeneratedAgentSessionIncludesIndependentLatestTurnProjection(t *testing
 		Provider:               "codex",
 		RailSectionKey:         "project:repo-1",
 		CreatedAt:              time.UnixMilli(10),
+		MessageVersion:         11,
 		LatestTurn:             &latest,
 		LatestTurnInteractions: latestInteractions,
 		Metadata: agentactivitybiz.SessionMetadata{
@@ -51,6 +52,9 @@ func TestGeneratedAgentSessionIncludesIndependentLatestTurnProjection(t *testing
 	})
 	if err != nil {
 		t.Fatalf("generatedAgentSession() error = %v", err)
+	}
+	if generated.MessageVersion != 11 {
+		t.Fatalf("messageVersion = %#v, want 11", generated.MessageVersion)
 	}
 	if generated.ActiveTurn != nil || generated.ActiveTurnId != nil {
 		t.Fatalf("active turn = %#v id=%#v, want none", generated.ActiveTurn, generated.ActiveTurnId)

--- a/services/tuttid/api/daemon_test.go
+++ b/services/tuttid/api/daemon_test.go
@@ -94,6 +94,7 @@ type stubAgentSessionService struct {
 	clearFn                         func(context.Context, string) (agentservice.ClearSessionsResult, error)
 	composerOptionsFn               func(context.Context, agentservice.ComposerOptionsInput) (agentservice.ComposerOptions, error)
 	createFn                        func(context.Context, string, agentservice.CreateSessionInput) (agentservice.Session, error)
+	getDetailFn                     func(context.Context, string, string) (agentservice.SessionDetail, error)
 	getFn                           func(context.Context, string, string) (agentservice.Session, error)
 	deleteFn                        func(context.Context, string, string) (agentservice.DeleteSessionResult, error)
 	listSectionDeletionCandidatesFn func(context.Context, string, agentservice.ListSessionSectionDeletionCandidatesInput) (agentservice.SessionSectionDeletionCandidates, error)
@@ -354,7 +355,10 @@ func (s stubAgentSessionService) Get(ctx context.Context, workspaceID, agentSess
 	return s.getFn(ctx, workspaceID, agentSessionID)
 }
 
-func (stubAgentSessionService) GetDetail(context.Context, string, string) (agentservice.SessionDetail, error) {
+func (s stubAgentSessionService) GetDetail(ctx context.Context, workspaceID, agentSessionID string) (agentservice.SessionDetail, error) {
+	if s.getDetailFn != nil {
+		return s.getDetailFn(ctx, workspaceID, agentSessionID)
+	}
 	return agentservice.SessionDetail{ChildSessions: []agentservice.Session{}}, nil
 }
 
@@ -2284,6 +2288,196 @@ func TestDaemonAPIGeneratedRoutesProjectTurnlessAgentSessionMessagesAsSessionLev
 	}
 	if response.Messages[0].TurnId != nil {
 		t.Fatalf("turnId = %v, want null", *response.Messages[0].TurnId)
+	}
+}
+
+func TestGeneratedWorkspaceAgentSafeIntegerBounds(t *testing.T) {
+	t.Parallel()
+
+	value, err := generatedWorkspaceAgentSafeInteger(
+		"message version",
+		maxWorkspaceAgentJSONSafeInteger,
+	)
+	if err != nil {
+		t.Fatalf("maximum safe integer rejected: %v", err)
+	}
+	if value != int64(maxWorkspaceAgentJSONSafeInteger) {
+		t.Fatalf("value = %d, want %d", value, maxWorkspaceAgentJSONSafeInteger)
+	}
+	if _, err := generatedWorkspaceAgentSafeInteger(
+		"message version",
+		maxWorkspaceAgentJSONSafeInteger+1,
+	); err == nil {
+		t.Fatal("maximum safe integer plus one accepted")
+	}
+}
+
+func TestDaemonAPIGeneratedRoutesAcceptSafeAgentMessageCursorQueries(t *testing.T) {
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, NewRoutes(DaemonAPI{
+		AgentSessionService: stubAgentSessionService{
+			listMessagesFn: func(_ context.Context, _ string, _ string, input agentservice.ListMessagesInput) (agentservice.SessionMessagesPage, error) {
+				if input.AfterVersion != maxWorkspaceAgentJSONSafeInteger {
+					t.Fatalf("afterVersion = %d, want %d", input.AfterVersion, maxWorkspaceAgentJSONSafeInteger)
+				}
+				if input.BeforeVersion != maxWorkspaceAgentJSONSafeInteger {
+					t.Fatalf("beforeVersion = %d, want %d", input.BeforeVersion, maxWorkspaceAgentJSONSafeInteger)
+				}
+				return agentservice.SessionMessagesPage{
+					AgentSessionID: "agent-session-1",
+					Messages:       []agentservice.SessionMessage{},
+					LatestVersion:  maxWorkspaceAgentJSONSafeInteger,
+				}, nil
+			},
+		},
+	}))
+
+	recorder := performGeneratedRouteRequest(
+		t,
+		mux,
+		http.MethodGet,
+		fmt.Sprintf(
+			"/v1/workspaces/ws-1/agent-sessions/agent-session-1/messages?afterVersion=%d&beforeVersion=%d",
+			maxWorkspaceAgentJSONSafeInteger,
+			maxWorkspaceAgentJSONSafeInteger,
+		),
+		nil,
+	)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+}
+
+func TestDaemonAPIGeneratedRoutesRejectUnsafeAgentMessageCursorQueries(t *testing.T) {
+	for _, parameter := range []string{"afterVersion", "beforeVersion"} {
+		t.Run(parameter, func(t *testing.T) {
+			mux := http.NewServeMux()
+			RegisterRoutes(mux, NewRoutes(DaemonAPI{
+				AgentSessionService: stubAgentSessionService{
+					listMessagesFn: func(context.Context, string, string, agentservice.ListMessagesInput) (agentservice.SessionMessagesPage, error) {
+						t.Fatal("unsafe cursor reached the service")
+						return agentservice.SessionMessagesPage{}, nil
+					},
+				},
+			}))
+
+			recorder := performGeneratedRouteRequest(
+				t,
+				mux,
+				http.MethodGet,
+				fmt.Sprintf(
+					"/v1/workspaces/ws-1/agent-sessions/agent-session-1/messages?%s=%d",
+					parameter,
+					maxWorkspaceAgentJSONSafeInteger+1,
+				),
+				nil,
+			)
+			if recorder.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d; body: %s", recorder.Code, http.StatusBadRequest, recorder.Body.String())
+			}
+		})
+	}
+}
+
+func TestDaemonAPIGeneratedRoutesRejectUnsafeAgentMessageResponseIntegers(t *testing.T) {
+	tests := []struct {
+		name string
+		page agentservice.SessionMessagesPage
+	}{
+		{
+			name: "sequence",
+			page: agentservice.SessionMessagesPage{
+				AgentSessionID: "agent-session-1",
+				LatestVersion:  1,
+				Messages: []agentservice.SessionMessage{{
+					ID:             maxWorkspaceAgentJSONSafeInteger + 1,
+					AgentSessionID: "agent-session-1",
+					MessageID:      "message-1",
+					Kind:           "text",
+					Role:           "assistant",
+					Version:        1,
+				}},
+			},
+		},
+		{
+			name: "message version",
+			page: agentservice.SessionMessagesPage{
+				AgentSessionID: "agent-session-1",
+				LatestVersion:  maxWorkspaceAgentJSONSafeInteger + 1,
+				Messages: []agentservice.SessionMessage{{
+					ID:             1,
+					AgentSessionID: "agent-session-1",
+					MessageID:      "message-1",
+					Kind:           "text",
+					Role:           "assistant",
+					Version:        maxWorkspaceAgentJSONSafeInteger + 1,
+				}},
+			},
+		},
+		{
+			name: "latest version",
+			page: agentservice.SessionMessagesPage{
+				AgentSessionID: "agent-session-1",
+				LatestVersion:  maxWorkspaceAgentJSONSafeInteger + 1,
+				Messages:       []agentservice.SessionMessage{},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			RegisterRoutes(mux, NewRoutes(DaemonAPI{
+				AgentSessionService: stubAgentSessionService{
+					listMessagesFn: func(context.Context, string, string, agentservice.ListMessagesInput) (agentservice.SessionMessagesPage, error) {
+						return test.page, nil
+					},
+				},
+			}))
+
+			recorder := performGeneratedRouteRequest(
+				t,
+				mux,
+				http.MethodGet,
+				"/v1/workspaces/ws-1/agent-sessions/agent-session-1/messages",
+				nil,
+			)
+			if recorder.Code != http.StatusBadGateway {
+				t.Fatalf("status = %d, want %d; body: %s", recorder.Code, http.StatusBadGateway, recorder.Body.String())
+			}
+		})
+	}
+}
+
+func TestDaemonAPIGeneratedRoutesRejectUnsafeSessionMessageVersion(t *testing.T) {
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, NewRoutes(DaemonAPI{
+		AgentSessionService: stubAgentSessionService{
+			getDetailFn: func(context.Context, string, string) (agentservice.SessionDetail, error) {
+				return agentservice.SessionDetail{
+					Session: agentservice.Session{
+						ID:             "agent-session-1",
+						Kind:           agentactivitybiz.SessionKindRoot,
+						MessageVersion: maxWorkspaceAgentJSONSafeInteger + 1,
+						Provider:       "codex",
+						RailSectionKey: "conversations",
+						CreatedAt:      time.UnixMilli(1),
+					},
+					ChildSessions: []agentservice.Session{},
+					Turns:         []agentactivitybiz.Turn{},
+				}, nil
+			},
+		},
+	}))
+
+	recorder := performGeneratedRouteRequest(
+		t,
+		mux,
+		http.MethodGet,
+		"/v1/workspaces/ws-1/agent-sessions/agent-session-1",
+		nil,
+	)
+	if recorder.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d; body: %s", recorder.Code, http.StatusBadGateway, recorder.Body.String())
 	}
 }
 

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -6225,6 +6225,9 @@ type WorkspaceAgentInteractionKind string
 // WorkspaceAgentInteractionStatus defines model for WorkspaceAgentInteractionStatus.
 type WorkspaceAgentInteractionStatus string
 
+// WorkspaceAgentMessageCursor Per-session durable message change cursor. The upper bound preserves exact integer representation in JavaScript clients.
+type WorkspaceAgentMessageCursor = int64
+
 // WorkspaceAgentModelRef defines model for WorkspaceAgentModelRef.
 type WorkspaceAgentModelRef struct {
 	Model       *string `json:"model,omitempty"`
@@ -6305,6 +6308,9 @@ type WorkspaceAgentSession struct {
 
 	// LatestTurnInteractions Protocol v2. Read-only independent Interaction entity projections for latestTurn, including pending, answered, and superseded terminal states. These entities are not session-owned persistent state.
 	LatestTurnInteractions []WorkspaceAgentInteraction `json:"latestTurnInteractions"`
+
+	// MessageVersion Latest accepted per-session message change cursor. This is a high-water mark, not a count of materialized message rows.
+	MessageVersion WorkspaceAgentMessageCursor `json:"messageVersion"`
 
 	// ParentAgentSessionId Direct parent session that created this child session. Null when kind is root.
 	ParentAgentSessionId *string `json:"parentAgentSessionId"`
@@ -6472,15 +6478,19 @@ type WorkspaceAgentSessionMessage struct {
 	// TurnId A non-empty turnId attaches a Turn-scoped message to a real persisted Turn. Null is valid only when kind is session_audit; empty strings are forbidden. Legacy stored turnless rows are read as compatibility data and are never assigned a guessed Turn.
 	TurnId          *string `json:"turnId"`
 	UpdatedAtUnixMs *int64  `json:"updatedAtUnixMs,omitempty"`
-	Version         int64   `json:"version"`
+
+	// Version Per-session durable message change cursor. The upper bound preserves exact integer representation in JavaScript clients.
+	Version WorkspaceAgentMessageCursor `json:"version"`
 }
 
 // WorkspaceAgentSessionMessagesResponse defines model for WorkspaceAgentSessionMessagesResponse.
 type WorkspaceAgentSessionMessagesResponse struct {
-	AgentSessionId string                         `json:"agentSessionId"`
-	HasMore        bool                           `json:"hasMore"`
-	LatestVersion  int64                          `json:"latestVersion"`
-	Messages       []WorkspaceAgentSessionMessage `json:"messages"`
+	AgentSessionId string `json:"agentSessionId"`
+	HasMore        bool   `json:"hasMore"`
+
+	// LatestVersion Per-session durable message change cursor. The upper bound preserves exact integer representation in JavaScript clients.
+	LatestVersion WorkspaceAgentMessageCursor    `json:"latestVersion"`
+	Messages      []WorkspaceAgentSessionMessage `json:"messages"`
 }
 
 // WorkspaceAgentSessionPage defines model for WorkspaceAgentSessionPage.
@@ -7497,8 +7507,8 @@ type ListWorkspaceAgentSessionsParams struct {
 
 // ListWorkspaceAgentSessionMessagesParams defines parameters for ListWorkspaceAgentSessionMessages.
 type ListWorkspaceAgentSessionMessagesParams struct {
-	AfterVersion  *int64                                        `form:"afterVersion,omitempty" json:"afterVersion,omitempty"`
-	BeforeVersion *int64                                        `form:"beforeVersion,omitempty" json:"beforeVersion,omitempty"`
+	AfterVersion  *WorkspaceAgentMessageCursor                  `form:"afterVersion,omitempty" json:"afterVersion,omitempty"`
+	BeforeVersion *WorkspaceAgentMessageCursor                  `form:"beforeVersion,omitempty" json:"beforeVersion,omitempty"`
 	Order         *ListWorkspaceAgentSessionMessagesParamsOrder `form:"order,omitempty" json:"order,omitempty"`
 	Limit         *int                                          `form:"limit,omitempty" json:"limit,omitempty"`
 }

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -3842,16 +3842,12 @@ paths:
           name: afterVersion
           required: false
           schema:
-            type: integer
-            format: int64
-            minimum: 0
+            $ref: "#/components/schemas/WorkspaceAgentMessageCursor"
         - in: query
           name: beforeVersion
           required: false
           schema:
-            type: integer
-            format: int64
-            minimum: 0
+            $ref: "#/components/schemas/WorkspaceAgentMessageCursor"
         - in: query
           name: order
           required: false
@@ -10570,6 +10566,14 @@ components:
       enum:
         - root
         - child
+    WorkspaceAgentMessageCursor:
+      type: integer
+      format: int64
+      minimum: 0
+      maximum: 9007199254740991
+      description: >-
+        Per-session durable message change cursor. The upper bound preserves
+        exact integer representation in JavaScript clients.
     WorkspaceAgentSession:
       type: object
       additionalProperties: false
@@ -10584,6 +10588,7 @@ components:
         - agentTargetId
         - provider
         - providerSessionId
+        - messageVersion
         - cwd
         - railSectionKey
         - visible
@@ -10654,6 +10659,12 @@ components:
         providerSessionId:
           type: string
           nullable: true
+        messageVersion:
+          allOf:
+            - $ref: "#/components/schemas/WorkspaceAgentMessageCursor"
+          description: >-
+            Latest accepted per-session message change cursor. This is a
+            high-water mark, not a count of materialized message rows.
         cwd:
           type: string
           nullable: true
@@ -11315,6 +11326,7 @@ components:
           type: integer
           format: int64
           minimum: 1
+          maximum: 9007199254740991
           description: >-
             Stable message presentation order assigned when the durable message
             row is first created. Updating the same message does not change this
@@ -11360,9 +11372,7 @@ components:
           type: integer
           format: int64
         version:
-          type: integer
-          format: int64
-          minimum: 0
+          $ref: "#/components/schemas/WorkspaceAgentMessageCursor"
     WorkspaceAgentSessionMessagesResponse:
       type: object
       additionalProperties: false
@@ -11380,9 +11390,7 @@ components:
           items:
             $ref: "#/components/schemas/WorkspaceAgentSessionMessage"
         latestVersion:
-          type: integer
-          format: int64
-          minimum: 0
+          $ref: "#/components/schemas/WorkspaceAgentMessageCursor"
         hasMore:
           type: boolean
     WorkspaceAgentGeneratedFileEntry:

--- a/services/tuttid/service/agent/activity_projection_session.go
+++ b/services/tuttid/service/agent/activity_projection_session.go
@@ -27,6 +27,7 @@ func persistedSessionFromActivity(session agentactivitybiz.Session) PersistedSes
 		Metadata:               session.Metadata,
 		InternalRuntimeContext: clonePayload(session.InternalRuntimeContext),
 		Title:                  strings.TrimSpace(session.Title),
+		MessageVersion:         session.MessageVersion,
 		PinnedAtUnixMS:         session.PinnedAtUnixMS,
 		LastEventUnixMS:        session.LastEventUnixMS,
 		StartedAtUnixMS:        session.StartedAtUnixMS,

--- a/services/tuttid/service/agent/host_test_adapters_test.go
+++ b/services/tuttid/service/agent/host_test_adapters_test.go
@@ -381,7 +381,7 @@ func activitySessionFromPersisted(session PersistedSession) storesqlite.Session 
 		RailSectionKind: session.RailSectionKind, RailProjectPath: session.RailProjectPath,
 		RailSectionKey: session.RailSectionKey, Settings: ComposerSettingsToMap(session.Settings),
 		Metadata: session.Metadata, InternalRuntimeContext: clonePayload(session.InternalRuntimeContext), Title: session.Title,
-		PinnedAtUnixMS: session.PinnedAtUnixMS, LastEventUnixMS: session.LastEventUnixMS,
+		MessageVersion: session.MessageVersion, PinnedAtUnixMS: session.PinnedAtUnixMS, LastEventUnixMS: session.LastEventUnixMS,
 		StartedAtUnixMS: session.StartedAtUnixMS, EndedAtUnixMS: session.EndedAtUnixMS,
 		CreatedAtUnixMS: session.CreatedAtUnixMS, UpdatedAtUnixMS: session.UpdatedAtUnixMS, ActiveTurnID: session.ActiveTurnID,
 	}

--- a/services/tuttid/service/agent/service_session.go
+++ b/services/tuttid/service/agent/service_session.go
@@ -201,6 +201,7 @@ func sessionFromPersisted(session PersistedSession, resumable bool) Session {
 	result.ParentAgentSessionID = strings.TrimSpace(session.ParentAgentSessionID)
 	result.ParentTurnID = strings.TrimSpace(session.ParentTurnID)
 	result.ParentToolCallID = strings.TrimSpace(session.ParentToolCallID)
+	result.MessageVersion = session.MessageVersion
 	result.Metadata = session.Metadata
 	result.Isolation = sessionIsolationFromRuntimeContext(session.InternalRuntimeContext)
 	return result
@@ -247,6 +248,7 @@ func mergePersistedSessionState(session Session, persisted PersistedSession) Ses
 		session.Settings = &settings
 	}
 	session.PermissionConfig = composerPermissionConfig(session.Provider, permissionModeIDFromSettings(session.Settings), preferencesbiz.DefaultDesktopLocale)
+	session.MessageVersion = persisted.MessageVersion
 	session.PinnedAtUnixMS = persisted.PinnedAtUnixMS
 	if persisted.UpdatedAtUnixMS > 0 &&
 		(session.UpdatedAt == nil || persisted.UpdatedAtUnixMS > session.UpdatedAt.UnixMilli()) {

--- a/services/tuttid/service/agent/service_session_child_test.go
+++ b/services/tuttid/service/agent/service_session_child_test.go
@@ -32,12 +32,28 @@ func TestSessionFromPersistedPreservesRailSectionKey(t *testing.T) {
 	session := sessionFromPersisted(PersistedSession{
 		ID:             "session-1",
 		Kind:           agentactivitybiz.SessionKindRoot,
+		MessageVersion: 17,
 		Provider:       "codex",
 		RailSectionKey: " project:repo-1 ",
 	}, false)
 
 	if session.RailSectionKey != "project:repo-1" {
 		t.Fatalf("rail section key = %q, want project:repo-1", session.RailSectionKey)
+	}
+	if session.MessageVersion != 17 {
+		t.Fatalf("message version = %d, want 17", session.MessageVersion)
+	}
+}
+
+func TestPersistedSessionFromActivityPreservesMessageVersion(t *testing.T) {
+	t.Parallel()
+
+	session := persistedSessionFromActivity(agentactivitybiz.Session{
+		ID: "session-1", WorkspaceID: "workspace-1", MessageVersion: 23,
+	})
+
+	if session.MessageVersion != 23 {
+		t.Fatalf("message version = %d, want 23", session.MessageVersion)
 	}
 }
 
@@ -49,6 +65,7 @@ func TestServiceSessionResponseMergesPersistedRailSectionKey(t *testing.T) {
 		PersistedSession{
 			ID:             "session-1",
 			WorkspaceID:    "workspace-1",
+			MessageVersion: 19,
 			Provider:       "codex",
 			RailSectionKey: "project:repo-1",
 		},
@@ -57,5 +74,8 @@ func TestServiceSessionResponseMergesPersistedRailSectionKey(t *testing.T) {
 
 	if session.RailSectionKey != "project:repo-1" {
 		t.Fatalf("rail section key = %q, want project:repo-1", session.RailSectionKey)
+	}
+	if session.MessageVersion != 19 {
+		t.Fatalf("message version = %d, want 19", session.MessageVersion)
 	}
 }

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -236,6 +236,7 @@ type Session struct {
 	Settings             *ComposerSettings
 	PermissionConfig     PermissionConfig
 	Title                *string
+	MessageVersion       uint64
 	PinnedAtUnixMS       int64
 	CreatedAt            time.Time
 	UpdatedAt            *time.Time
@@ -371,6 +372,7 @@ type PersistedSession struct {
 	Metadata               agentactivitybiz.SessionMetadata
 	InternalRuntimeContext map[string]any
 	Title                  string
+	MessageVersion         uint64
 	PinnedAtUnixMS         int64
 	LastEventUnixMS        int64
 	StartedAtUnixMS        int64


### PR DESCRIPTION
## Summary

- expose the persisted per-Session `messageVersion` as a required daemon/renderer protocol field instead of fabricating `0` in the shared adapter
- let Desktop skip child message reads when its durable cursor already matches the authoritative Session cursor
- keep first child hydration bounded to the newest 100 messages, while hydrated children use incremental paging and known-empty children drain from `afterVersion=0`
- preserve the root conversation repair policy and the second detail read that catches either the requested child or descendants advancing during message reconciliation
- bound message cursors and durable message sequence to JavaScript's maximum safe integer at the OpenAPI and daemon projection seams

## Why

Desktop applied the root conversation's “no user message” repair heuristic to provider-native child Sessions. Assistant-only and tool-only children therefore reset their cursor to zero and repeatedly re-read unchanged transcript history.

Independent review also exposed three boundary cases that are fixed in this PR:

- an already-known empty child could later gain more than 100 messages and be truncated by a newest-page reload
- the daemon stored cursors as `uint64`, while the HTTP/TypeScript contract used JavaScript `number` without an explicit exact-integer ceiling
- direct reconciliation of a child could miss a message committed between its first message read and second detail read because the final catch-up only examined descendants

## Impact

Unchanged child Sessions now issue no message request during root detail reconciliation. Changed children use existing incremental reads and push/reconcile behavior; no polling was added. Root transcript behavior and current child-card interaction remain unchanged.

Daemon and renderer are released together, so `messageVersion` is a strict required contract rather than an old-daemon compatibility branch. Store and service layers retain `uint64`; only the HTTP/JavaScript transport seam enforces the safe integer range.

This is a query/DTO projection change. It does not define Session, Turn, Goal, or runtime-operation lifecycle semantics and does not change the Agent Host contract.

## Validation

- `pnpm check:changed`: 26 lanes passed on the final branch
- pre-push `pnpm check:changed -- --push-ready`: 28 lanes passed after each push
- focused Desktop tests cover assistant-only and tool-only cursors, transient overlays, root policy preservation, newest-page hydration, known-empty zero-cursor multi-page draining, unchanged-child skipping, direct child reconciliation, and both descendant/direct-child two-detail advancement races
- daemon route tests cover the maximum safe integer, unsafe request cursors returning 400, and unsafe Session/message/page projections returning 502
- `pnpm check:api-generated` passes with matching Go and TypeScript generated contracts
- independent Desktop, daemon/contract, package/docs, cursor-contract, and final PR reviews were completed; every actionable finding was addressed

## Documentation

Updated the AgentGUI architecture, Agent activity package contract, and Agent Session troubleshooting guide with the required cursor contract, child hydration rules, zero-cursor behavior, and transport range ownership.