### PR TITLE
fix(agent-gui): make composer readiness atomic

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -372,6 +372,18 @@ the existing recovery, approval, or prompt chrome visible until the connection
 notice replaces it. Recovery removes the notice without a success banner. The
 notice does not offer a manual retry because transport recovery is host-owned.
 
+Session presentation derives one canonical Composer gate from target
+connection, Session runtime availability, provider readiness, ownership,
+activation, Interaction, and busy/queue facts. The gate is one atomic
+projection with separate editor, submission, and runtime-command decisions;
+AgentGUI must not place `canSubmit`, target-connection blocking, or
+Session-runtime blocking in independent memoized view slices and recombine them
+later. The editor, send action, keyboard submit paths, Stop availability, and
+Interaction submission consume that same gate snapshot. Busy work may project
+queue submission while keeping the editor editable. Draft emptiness, upload
+progress/failure, project existence, and other draft-local conditions may
+disable submission, but must not change editor editability.
+
 ### 4.1 Read/write rules
 
 - reads use exported selectors or memoized `AgentActivitySnapshot`
@@ -776,6 +788,12 @@ Code uses stable horizontal layers and behavior-oriented vertical modules:
 A controller may compose flows but cannot become a second lifecycle state machine. Extract complete behavior first; do not scatter it into a pile of domainless helpers.
 
 Activation and existing-Session submit share a canonical prompt envelope. Submit eligibility includes text and renderable structured content; an individual composer does not redefine it.
+
+The canonical Composer gate belongs to the Session-presentation projection and
+travels through the Composer view-model slice as one object. View-local
+transition or workflow locks may layer on top as explicit presentation locks;
+they do not copy or reinterpret runtime, connection, provider, ownership, or
+queue readiness.
 
 The conversation composer area is a stable `AgentComposerRegion` with explicit
 floating-control, lifted-interaction, accessory, and primary-composer slots.

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -85,6 +85,7 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 - [Imported sessions trigger fresh-completion indicators](./agent-session-lifecycle.md#imported-sessions-trigger-fresh-completion-indicators)
 - [Realtime agent completion does not show unread attention](./agent-session-lifecycle.md#realtime-agent-completion-does-not-show-unread-attention)
 - [Completed agent session stays activating and disables the composer](./agent-session-lifecycle.md#completed-agent-session-stays-activating-and-disables-the-composer)
+- [Shared Agent composer stays disabled after the target connects](./agent-session-lifecycle.md#shared-agent-composer-stays-disabled-after-the-target-connects)
 - [Goal clear stays planning and leaves the session running](./agent-session-lifecycle.md#goal-clear-stays-planning-and-leaves-the-session-running)
 - [Cursor session/new is canceled before its 30-second timeout](./agent-session-lifecycle.md#cursor-sessionnew-is-canceled-before-its-30-second-timeout)
 - [Cursor auto-continue invents interrupted work after a network drop](./agent-session-lifecycle.md#cursor-auto-continue-invents-interrupted-work-after-a-network-drop)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -2280,6 +2280,42 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   [workspaceAgentActivityReconcileBridge.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts)
   [workspaceAgentActivityService.test.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts)
 
+### Shared Agent composer stays disabled after the target connects
+
+- Symptom:
+  A shared Agent target reaches `connected`, and diagnostics show submission
+  readiness has recovered, but the entire composer remains disabled and cannot
+  receive focus or input. This differs from an empty draft disabling only the
+  send button.
+- Quick checks:
+  Inspect one rendered Composer gate snapshot. Its runtime, editor, and
+  submission branches must agree: a ready submission cannot coexist with a
+  target-connection runtime block. If logs instead compare fields from separate
+  Composer and readiness projections, inspect view-model memoization before
+  debugging P2P transport.
+- Root cause:
+  Connection and submission facts were projected into independent memoized
+  slices. A missing dependency could retain the old target-connection block
+  while publishing the new submission-ready value, and a downstream detail
+  model then recombined those two render-time generations into a torn
+  `composerDisabled` decision.
+- Fix:
+  Derive the canonical Composer gate once at the Session-presentation boundary.
+  Keep editor editability, submission readiness/queue/blocking, and
+  runtime-command availability in that one object, then pass it through one
+  view-model slice to the editor, send button, shortcuts, Stop control, and
+  Interaction paths. Keep draft-empty and upload conditions submission-local.
+- Validation:
+  Drive an exact shared target from `connecting` to `connected` and assert the
+  same resulting snapshot reports runtime ready, editor editable, and
+  submission ready. Also cover busy queue behavior, collaborator read-only
+  behavior, and the invariant that submission ready never retains a runtime
+  connection block.
+- References:
+  [agentGuiComposerGate.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiComposerGate.ts)
+  [useAgentGUISessionPresentation.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.ts)
+  [useAgentGUIViewModel.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/model/useAgentGUIViewModel.ts)
+
 ### AgentGUI submit clears the composer but creates no session or turn
 
 - Symptom:

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -47,6 +47,7 @@ import {
   agentComposerDraftPrompt
 } from "./model/agentComposerDraft";
 import type { AgentGUIComposerContentType } from "./engagement/agentGUIEngagement.types";
+import { projectAgentGUIComposerGateControls } from "./model/agentGuiComposerGate";
 import {
   groupAgentExternalPromptEntryInsertions,
   resolveAgentExternalPromptEntries
@@ -97,9 +98,10 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     hasCompactableContext = true,
     compactSupported = null,
     availableSkills = EMPTY_PROVIDER_SKILLS,
-    disabled,
+    gate,
+    presentationEditorDisabled,
     disabledReason,
-    submitDisabled,
+    presentationSubmitDisabled,
     tuttiModeActive = false,
     tuttiModeUpdating = false,
     tuttiModeOrchestrationIntensity = 50,
@@ -110,7 +112,6 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     handoffAgentTargets,
     providerSelectReadonly = false,
     onHandoffConversation,
-    canQueueWhileBusy,
     showStopButton,
     stopDisabled,
     activePrompt,
@@ -153,6 +154,15 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     onRequestGitBranches = null,
     referenceProvenanceFilters = null
   } = props;
+  const {
+    canQueueWhileBusy,
+    editorDisabled: disabled,
+    submissionDisabled: submitDisabled
+  } = projectAgentGUIComposerGateControls({
+    gate,
+    presentationEditorDisabled,
+    presentationSubmitDisabled
+  });
   const draftPrompt = agentComposerDraftPrompt(draftContent);
   const goalDraftObjective = canGoalControl
     ? goalDraftObjectiveFromPrompt(draftPrompt)
@@ -560,7 +570,6 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     composerControlsHardDisabled,
     isSelectedProjectMissing,
     disabled,
-    canQueueWhileBusy,
     onHandoffConversation,
     handoffLabel,
     handoffMenuLabel,

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.memo.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.memo.spec.tsx
@@ -504,8 +504,16 @@ function createViewModel(
     pendingInteractivePrompt: null,
     queuedPrompts: [],
     queueStatus: "active",
-    canSubmit: true,
-    canQueueWhileBusy: false,
+    gate: {
+      conversationBusy: false,
+      runtime: {
+        status: "ready",
+        reason: null,
+        sessionRuntimeReason: null
+      },
+      editor: { status: "editable", reason: null },
+      submission: { status: "ready", reason: null }
+    },
     isSubmitting: false,
     isInterrupting: false,
     promptImagesSupported: true,

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.status.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.status.spec.tsx
@@ -496,8 +496,16 @@ function createViewModel(
     pendingInteractivePrompt: null,
     queuedPrompts: [],
     queueStatus: "active",
-    canSubmit: true,
-    canQueueWhileBusy: false,
+    gate: {
+      conversationBusy: false,
+      runtime: {
+        status: "ready",
+        reason: null,
+        sessionRuntimeReason: null
+      },
+      editor: { status: "editable", reason: null },
+      submission: { status: "ready", reason: null }
+    },
     isSubmitting: false,
     isInterrupting: false,
     promptImagesSupported: true,

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
@@ -12,6 +12,7 @@ import type { AgentProjectPathChangeMetadata } from "../AgentComposerSettingsMen
 import type { AgentSlashCommandCapability } from "../model/agentSlashCommandProviderPolicy";
 import type {
   AgentComposerDraft,
+  AgentGUIComposerGate,
   AgentGUIComposerSettingsVM,
   AgentGUIProviderSkillOption,
   AgentGUIQueueStatus,
@@ -85,9 +86,12 @@ export interface AgentComposerProps {
   hasCompactableContext?: boolean;
   compactSupported?: boolean | null;
   availableSkills?: readonly AgentGUIProviderSkillOption[];
-  disabled: boolean;
+  gate: AgentGUIComposerGate;
+  /** View-local lock that does not redefine canonical Composer readiness. */
+  presentationEditorDisabled: boolean;
   disabledReason?: string | null;
-  submitDisabled: boolean;
+  /** Draft-independent view-local submission lock. */
+  presentationSubmitDisabled: boolean;
   /** Canonical engine projection of the independent TuttiModeActivation. */
   tuttiModeActive?: boolean;
   /** Blocks submission/removal while activation CAS or creation is unresolved. */
@@ -109,7 +113,6 @@ export interface AgentComposerProps {
     agentTargetId?: string | null;
   }) => void;
   onHandoffConversation?: (target: AgentGUIAgentTarget) => void;
-  canQueueWhileBusy: boolean;
   showStopButton: boolean;
   stopDisabled: boolean;
   activePrompt: AgentConversationPromptVM | null;

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerProviderTargets.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerProviderTargets.ts
@@ -13,7 +13,6 @@ interface Input {
   composerControlsHardDisabled: boolean;
   isSelectedProjectMissing: boolean;
   disabled: boolean;
-  canQueueWhileBusy: boolean;
   onHandoffConversation?: (target: AgentGUIAgentTarget) => void;
   handoffLabel?: string;
   handoffMenuLabel?: string;
@@ -32,7 +31,6 @@ export function useComposerProviderTargets(input: Input) {
     composerControlsHardDisabled,
     isSelectedProjectMissing,
     disabled,
-    canQueueWhileBusy,
     onHandoffConversation,
     handoffLabel,
     handoffMenuLabel
@@ -94,8 +92,7 @@ export function useComposerProviderTargets(input: Input) {
     styles.composerInputShell,
     isHeroLayout && styles.composerInputShellHero
   );
-  const inputDisabled =
-    isSelectedProjectMissing || (disabled && !canQueueWhileBusy);
+  const inputDisabled = isSelectedProjectMissing || disabled;
   const providerSelectDisabled =
     providerSelectReadonly || composerControlsHardDisabled || inputDisabled;
   const handoffDisabled = resolveComposerHandoffDisabled({

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerSlashActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerSlashActions.ts
@@ -53,9 +53,6 @@ type Props = Pick<
   AgentComposerProps,
   | "workspaceId"
   | "provider"
-  | "disabled"
-  | "submitDisabled"
-  | "canQueueWhileBusy"
   | "isSendingTurn"
   | "isSubmittingPrompt"
   | "showStopButton"
@@ -73,7 +70,11 @@ type Props = Pick<
   | "onSlashStatusClose"
   | "onPromptImagesUnsupported"
   | "onRequestGitBranches"
->;
+> & {
+  disabled: boolean;
+  submitDisabled: boolean;
+  canQueueWhileBusy: boolean;
+};
 
 interface UseComposerSlashActionsInput extends Props {
   onTuttiModeActivate?: () => void;

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.spec.tsx
@@ -85,7 +85,13 @@ describe("useAgentGUISessionPresentation", () => {
       targetConnectionSource,
       workspaceId: "workspace-1"
     } as unknown as Parameters<typeof useAgentGUISessionPresentation>[0];
-    const rendered = renderHook(() => useAgentGUISessionPresentation(input));
+    const rendered = renderHook(
+      ({ renderRevision }) => {
+        void renderRevision;
+        return useAgentGUISessionPresentation(input);
+      },
+      { initialProps: { renderRevision: 0 } }
+    );
 
     expect(rendered.result.current.composerGate).toMatchObject({
       runtime: { status: "blocked", reason: "target_connection" },
@@ -102,5 +108,10 @@ describe("useAgentGUISessionPresentation", () => {
       editor: { status: "editable", reason: null },
       submission: { status: "ready", reason: null }
     });
+    const readyGate = rendered.result.current.composerGate;
+
+    rendered.rerender({ renderRevision: 1 });
+
+    expect(rendered.result.current.composerGate).toBe(readyGate);
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.spec.tsx
@@ -1,0 +1,106 @@
+import { act, renderHook } from "@testing-library/react";
+import { createAgentSessionEngine } from "@tutti-os/agent-activity-core";
+import { describe, expect, it, vi } from "vitest";
+import type {
+  AgentGUITargetConnectionSource,
+  AgentGUITargetConnectionState
+} from "../../../types";
+import { useAgentGUISessionPresentation } from "./useAgentGUISessionPresentation";
+
+class FakeTargetConnectionSource implements AgentGUITargetConnectionSource {
+  private readonly listeners = new Set<() => void>();
+  private state: AgentGUITargetConnectionState = {
+    status: "connecting",
+    retryAttempt: 0
+  };
+
+  getConnectionState(): AgentGUITargetConnectionState {
+    return this.state;
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  set(state: AgentGUITargetConnectionState): void {
+    this.state = state;
+    for (const listener of this.listeners) listener();
+  }
+}
+
+describe("useAgentGUISessionPresentation", () => {
+  it("makes a shared Agent composer editable in the same snapshot that its target connects", () => {
+    const targetConnectionSource = new FakeTargetConnectionSource();
+    const sessionEngine = createAgentSessionEngine({
+      clock: { nowUnixMs: () => 1 },
+      commandPort: { execute: vi.fn(() => new Promise(() => undefined)) },
+      identity: { origin: "test", workspaceId: "workspace-1" },
+      scheduler: { schedule: () => ({ cancel() {} }) }
+    });
+    const input = {
+      activeConversation: null,
+      activeConversationId: null,
+      activeEngineActiveTurn: null,
+      activeEngineAvailability: "available",
+      activeEngineHasPendingInteractions: false,
+      activeEngineLatestTurn: null,
+      activeEngineRuntimeAvailability: null,
+      activeEngineSession: null,
+      activeLatestPendingSubmitTurnId: null,
+      activeLiveState: "inactive",
+      activeMessages: [],
+      activePendingActivation: null,
+      activeSessionState: null,
+      activeTimelineItems: [],
+      activationError: null,
+      activationErrorCode: null,
+      activationState: null,
+      activityDisplayStatus: null,
+      agentActivityRuntime: {},
+      agentTargetsLoading: false,
+      composerSupport: {
+        model: false,
+        reasoningEffort: false,
+        permissionMode: false,
+        planMode: false,
+        planImplementation: false,
+        plan: false
+      },
+      conversation: null,
+      currentUserId: "user-1",
+      isCreatingConversation: false,
+      isInterrupting: false,
+      isLoadingMessages: false,
+      isRespondingToInteraction: false,
+      isSubmitting: false,
+      lastRenderStateDiagnosticKeyRef: { current: null },
+      optimisticGoalControl: null,
+      pendingApproval: null,
+      planImplementationTurnIdRef: { current: null },
+      providerReadinessGate: null,
+      serverInteractivePrompt: null,
+      sessionEngine,
+      targetConnectionAgentTargetId: "shared-agent:shared-1",
+      targetConnectionSource,
+      workspaceId: "workspace-1"
+    } as unknown as Parameters<typeof useAgentGUISessionPresentation>[0];
+    const rendered = renderHook(() => useAgentGUISessionPresentation(input));
+
+    expect(rendered.result.current.composerGate).toMatchObject({
+      runtime: { status: "blocked", reason: "target_connection" },
+      editor: { status: "blocked", reason: "runtime_blocked" },
+      submission: { status: "blocked", reason: "runtime_blocked" }
+    });
+
+    act(() => {
+      targetConnectionSource.set({ status: "connected", retryAttempt: 0 });
+    });
+
+    expect(rendered.result.current.composerGate).toMatchObject({
+      runtime: { status: "ready", reason: null },
+      editor: { status: "editable", reason: null },
+      submission: { status: "ready", reason: null }
+    });
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.ts
@@ -26,6 +26,10 @@ import type {
   AgentGUIConversationSummary,
   AgentGUIInteractivePrompt
 } from "../model/agentGuiConversationModel";
+import {
+  isDifferentKnownConversationOwner,
+  resolveAgentGUIComposerGate
+} from "../model/agentGuiComposerGate";
 import type {
   AgentGUIOptimisticGoalControl,
   AgentGUISessionChrome
@@ -70,6 +74,7 @@ interface UseAgentGUISessionPresentationInput {
   agentActivityRuntime: AgentActivityRuntime;
   composerSupport: ReturnType<typeof composerSettingsSupportFromOptions>;
   conversation: AgentConversationVM | null;
+  currentUserId?: string | null;
   isCreatingConversation: boolean;
   isInterrupting: boolean;
   isLoadingMessages: boolean;
@@ -79,6 +84,9 @@ interface UseAgentGUISessionPresentationInput {
   pendingApproval: AgentApprovalItemVM | null;
   planImplementationTurnIdRef: CurrentValue<string | null>;
   optimisticGoalControl: AgentGUIOptimisticGoalControl | null;
+  providerReadinessGate:
+    | import("../../../types").AgentGUIProviderReadinessGate
+    | null;
   agentTargetsLoading: boolean;
   ownerDeviceLabel?: string | null;
   serverInteractivePrompt: AgentGUIInteractivePrompt | null;
@@ -142,7 +150,6 @@ export function useAgentGUISessionPresentation(
     input.activeEngineRuntimeAvailability?.state === "blocked"
       ? input.activeEngineRuntimeAvailability.reason
       : null;
-  const sessionRuntimeBlocked = sessionRuntimeBlockedReason !== null;
   const targetConnection = useAgentGUITargetConnectionState({
     agentTargetId: input.targetConnectionAgentTargetId,
     source: input.targetConnectionSource
@@ -286,26 +293,35 @@ export function useAgentGUISessionPresentation(
     targetConnection.visibleState,
     sessionChromeRawState
   ]);
-  const canSubmit =
-    !input.agentTargetsLoading &&
-    !targetConnection.blocked &&
-    input.activeLiveState !== "activating" &&
-    input.activeLiveState !== "failed" &&
-    !activeConversationResumeUnavailable &&
-    input.pendingApproval === null &&
-    pendingInteractivePrompt === null &&
-    sessionChrome.auth === null &&
-    !activeConversationBusy &&
-    !input.isCreatingConversation &&
-    !input.isSubmitting &&
-    !input.isInterrupting;
-  const canQueueWhileBusy =
-    input.activeConversationId !== null &&
-    !sessionRuntimeBlocked &&
-    !targetConnection.blocked &&
-    (activeConversationBusy ||
-      input.isSubmitting ||
-      input.activeEngineHasPendingInteractions);
+  const hasNonRetryableRecoveryFailure =
+    (sessionChrome.recovery?.kind === "failed" &&
+      sessionChrome.recovery.canRetry === false) ||
+    sessionChrome.recovery?.kind === "resume-unavailable";
+  const composerGate = resolveAgentGUIComposerGate({
+    activeConversationBusy,
+    activeConversationId: input.activeConversationId,
+    activeEngineHasPendingInteractions:
+      input.activeEngineHasPendingInteractions,
+    activeLiveState: input.activeLiveState,
+    activeConversationResumeUnavailable,
+    agentTargetsLoading: input.agentTargetsLoading,
+    authBlocked: sessionChrome.auth !== null,
+    hasNonRetryableRecoveryFailure,
+    isCollaboratorConversation: isDifferentKnownConversationOwner({
+      conversationUserId: input.activeConversation?.userId,
+      currentUserId: input.currentUserId
+    }),
+    isCreatingConversation: input.isCreatingConversation,
+    isInterrupting: input.isInterrupting,
+    isSubmitting: input.isSubmitting,
+    pendingApproval: input.pendingApproval !== null,
+    pendingInteractivePrompt: pendingInteractivePrompt !== null,
+    providerReadinessGate: input.providerReadinessGate,
+    sessionRuntimeBlockedReason,
+    targetConnectionBlocked: targetConnection.blocked
+  });
+  const canSubmit = composerGate.submission.status === "ready";
+  const canQueueWhileBusy = composerGate.submission.status === "queue";
   const hasSentUserMessage = input.activeTimelineItems.some(
     (item) => item.role === "user"
   );
@@ -334,7 +350,11 @@ export function useAgentGUISessionPresentation(
       input.isLoadingMessages ? "loading-messages" : "",
       input.isSubmitting ? "submitting" : "",
       canSubmit ? "can-submit" : "cannot-submit",
-      canQueueWhileBusy ? "can-queue" : "cannot-queue"
+      canQueueWhileBusy ? "can-queue" : "cannot-queue",
+      composerGate.editor.status,
+      composerGate.editor.reason ?? "",
+      composerGate.submission.reason ?? "",
+      composerGate.runtime.reason ?? ""
     ].join(":");
     if (input.lastRenderStateDiagnosticKeyRef.current === diagnosticKey) return;
     input.lastRenderStateDiagnosticKeyRef.current = diagnosticKey;
@@ -365,6 +385,7 @@ export function useAgentGUISessionPresentation(
     activeSubmitBlocked,
     canQueueWhileBusy,
     canSubmit,
+    composerGate,
     input.activeConversation,
     input.activeConversationId,
     input.activeEngineActiveTurn,
@@ -387,14 +408,10 @@ export function useAgentGUISessionPresentation(
 
   return {
     activeConversationBusy,
-    canQueueWhileBusy,
-    canSubmit,
+    composerGate,
     hasSentUserMessage,
     isRespondingApproval,
     pendingInteractivePrompt,
-    sessionRuntimeBlocked,
-    sessionRuntimeBlockedReason,
-    targetConnectionBlocked: targetConnection.blocked,
     sessionChrome
   };
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.ts
@@ -297,29 +297,55 @@ export function useAgentGUISessionPresentation(
     (sessionChrome.recovery?.kind === "failed" &&
       sessionChrome.recovery.canRetry === false) ||
     sessionChrome.recovery?.kind === "resume-unavailable";
-  const composerGate = resolveAgentGUIComposerGate({
-    activeConversationBusy,
-    activeConversationId: input.activeConversationId,
-    activeEngineHasPendingInteractions:
-      input.activeEngineHasPendingInteractions,
-    activeLiveState: input.activeLiveState,
-    activeConversationResumeUnavailable,
-    agentTargetsLoading: input.agentTargetsLoading,
-    authBlocked: sessionChrome.auth !== null,
-    hasNonRetryableRecoveryFailure,
-    isCollaboratorConversation: isDifferentKnownConversationOwner({
-      conversationUserId: input.activeConversation?.userId,
-      currentUserId: input.currentUserId
-    }),
-    isCreatingConversation: input.isCreatingConversation,
-    isInterrupting: input.isInterrupting,
-    isSubmitting: input.isSubmitting,
-    pendingApproval: input.pendingApproval !== null,
-    pendingInteractivePrompt: pendingInteractivePrompt !== null,
-    providerReadinessGate: input.providerReadinessGate,
-    sessionRuntimeBlockedReason,
-    targetConnectionBlocked: targetConnection.blocked
+  const authBlocked = sessionChrome.auth !== null;
+  const isCollaboratorConversation = isDifferentKnownConversationOwner({
+    conversationUserId: input.activeConversation?.userId,
+    currentUserId: input.currentUserId
   });
+  const pendingApproval = input.pendingApproval !== null;
+  const hasPendingInteractivePrompt = pendingInteractivePrompt !== null;
+  const composerGate = useMemo(
+    () =>
+      resolveAgentGUIComposerGate({
+        activeConversationBusy,
+        activeConversationId: input.activeConversationId,
+        activeEngineHasPendingInteractions:
+          input.activeEngineHasPendingInteractions,
+        activeLiveState: input.activeLiveState,
+        activeConversationResumeUnavailable,
+        agentTargetsLoading: input.agentTargetsLoading,
+        authBlocked,
+        hasNonRetryableRecoveryFailure,
+        isCollaboratorConversation,
+        isCreatingConversation: input.isCreatingConversation,
+        isInterrupting: input.isInterrupting,
+        isSubmitting: input.isSubmitting,
+        pendingApproval,
+        pendingInteractivePrompt: hasPendingInteractivePrompt,
+        providerReadinessGate: input.providerReadinessGate,
+        sessionRuntimeBlockedReason,
+        targetConnectionBlocked: targetConnection.blocked
+      }),
+    [
+      activeConversationBusy,
+      activeConversationResumeUnavailable,
+      authBlocked,
+      hasNonRetryableRecoveryFailure,
+      hasPendingInteractivePrompt,
+      input.activeConversationId,
+      input.activeEngineHasPendingInteractions,
+      input.activeLiveState,
+      input.agentTargetsLoading,
+      input.isCreatingConversation,
+      input.isInterrupting,
+      input.isSubmitting,
+      input.providerReadinessGate,
+      isCollaboratorConversation,
+      pendingApproval,
+      sessionRuntimeBlockedReason,
+      targetConnection.blocked
+    ]
+  );
   const canSubmit = composerGate.submission.status === "ready";
   const canQueueWhileBusy = composerGate.submission.status === "queue";
   const hasSentUserMessage = input.activeTimelineItems.some(

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIViewAssembly.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIViewAssembly.ts
@@ -16,6 +16,7 @@ import type { useAgentGUISessionDetailTransport } from "./useAgentGUISessionDeta
 import { resolveAgentGUIProviderReadinessGateForView } from "../model/agentGuiProviderReadiness";
 import type { useAgentGUITuttiModeActivation } from "./useAgentGUITuttiModeActivation";
 import { targetConnectionForAgentGUIView } from "./agentGuiController.providerHelpers";
+import { isAgentGUIAgentTargetComingSoon } from "../../../agentTargets";
 
 type ConversationPresentationInput = Parameters<
   typeof useAgentGUIConversationPresentation
@@ -40,6 +41,7 @@ type SessionPresentationInput = Omit<
   | "conversation"
   | "isInterrupting"
   | "pendingApproval"
+  | "providerReadinessGate"
   | "serverInteractivePrompt"
 >;
 type ProviderHomeInput = Parameters<typeof useAgentGUIProviderHome>[0];
@@ -118,10 +120,24 @@ export function useAgentGUIViewAssembly(input: UseAgentGUIViewAssemblyInput) {
     ...input,
     activeConversation
   });
+  const providerReadinessGate =
+    input.activeConversationId === null &&
+    isAgentGUIAgentTargetComingSoon(
+      input.effectiveSelectedProviderTarget,
+      input.normalizedComingSoonProviders
+    )
+      ? ({ status: "coming_soon" } as const)
+      : resolveAgentGUIProviderReadinessGateForView({
+          activeConversationId: input.activeConversationId,
+          providerReadinessGates: input.providerReadinessGates,
+          selectedProvider: input.effectiveSelectedProviderTarget.provider
+        });
   const session = useAgentGUISessionPresentation({
     ...input,
     activeConversation,
+    currentUserId: input.currentUserId,
     ownerDeviceLabel: targetConnection.ownerDeviceLabel,
+    providerReadinessGate,
     targetConnectionAgentTargetId: targetConnection.agentTargetId,
     activeLiveState: detail.activeLiveState,
     activationError: detail.activationError,
@@ -147,11 +163,6 @@ export function useAgentGUIViewAssembly(input: UseAgentGUIViewAssemblyInput) {
     input.activeConversationId === null
       ? input.selectedComposerTargetData.data
       : input.data;
-  const providerReadinessGate = resolveAgentGUIProviderReadinessGateForView({
-    activeConversationId: input.activeConversationId,
-    providerReadinessGates: input.providerReadinessGates,
-    selectedProvider: input.effectiveSelectedProviderTarget.provider
-  });
   const viewModel = useAgentGUIViewModel({
     shell: {
       nodeId: input.nodeId?.trim() || null,
@@ -200,7 +211,7 @@ export function useAgentGUIViewAssembly(input: UseAgentGUIViewAssemblyInput) {
       promptImagesSupported: input.promptImagesSupported,
       compactSupported: input.compactSupported,
       goalPauseSupported: input.goalPauseSupported,
-      canSubmit: session.canSubmit,
+      gate: session.composerGate,
       isTuttiModeActive: input.tuttiModeActivation.active,
       isTuttiModeUpdating: input.tuttiModeActivation.updatePending,
       tuttiModeOrchestrationIntensity:
@@ -209,12 +220,10 @@ export function useAgentGUIViewAssembly(input: UseAgentGUIViewAssemblyInput) {
       composerSettings: stableComposerSettings,
       queueStatus: detail.queueStatus,
       queuedPrompts: detail.queuedPrompts,
-      drainingQueuedPromptId: detail.drainingQueuedPromptId,
-      canQueueWhileBusy: session.canQueueWhileBusy
+      drainingQueuedPromptId: detail.drainingQueuedPromptId
     },
     interaction: {
       isRespondingApproval: session.isRespondingApproval,
-      isRuntimeBlocked: session.sessionRuntimeBlocked,
       pendingApproval: detail.pendingApproval,
       pendingInteractivePrompt: session.pendingInteractivePrompt,
       sessionChrome: session.sessionChrome,
@@ -230,10 +239,6 @@ export function useAgentGUIViewAssembly(input: UseAgentGUIViewAssemblyInput) {
     readiness: {
       activeLiveState: detail.activeLiveState,
       activationError: detail.activationError,
-      activeConversationBusy: session.activeConversationBusy,
-      sessionRuntimeBlocked: session.sessionRuntimeBlocked,
-      sessionRuntimeBlockedReason: session.sessionRuntimeBlockedReason,
-      targetConnectionBlocked: session.targetConnectionBlocked,
       providerReadinessGate
     },
     operations: {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIViewAssembly.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIViewAssembly.ts
@@ -120,18 +120,26 @@ export function useAgentGUIViewAssembly(input: UseAgentGUIViewAssemblyInput) {
     ...input,
     activeConversation
   });
-  const providerReadinessGate =
-    input.activeConversationId === null &&
-    isAgentGUIAgentTargetComingSoon(
+  const providerReadinessGate = useMemo(
+    () =>
+      input.activeConversationId === null &&
+      isAgentGUIAgentTargetComingSoon(
+        input.effectiveSelectedProviderTarget,
+        input.normalizedComingSoonProviders
+      )
+        ? ({ status: "coming_soon" } as const)
+        : resolveAgentGUIProviderReadinessGateForView({
+            activeConversationId: input.activeConversationId,
+            providerReadinessGates: input.providerReadinessGates,
+            selectedProvider: input.effectiveSelectedProviderTarget.provider
+          }),
+    [
+      input.activeConversationId,
       input.effectiveSelectedProviderTarget,
-      input.normalizedComingSoonProviders
-    )
-      ? ({ status: "coming_soon" } as const)
-      : resolveAgentGUIProviderReadinessGateForView({
-          activeConversationId: input.activeConversationId,
-          providerReadinessGates: input.providerReadinessGates,
-          selectedProvider: input.effectiveSelectedProviderTarget.provider
-        });
+      input.normalizedComingSoonProviders,
+      input.providerReadinessGates
+    ]
+  );
   const session = useAgentGUISessionPresentation({
     ...input,
     activeConversation,

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/AgentGUINodeViewModel.fixture.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/AgentGUINodeViewModel.fixture.ts
@@ -69,7 +69,7 @@ export function groupAgentGUINodeViewModelFixture(
       promptImagesSupported: flat.promptImagesSupported,
       compactSupported: flat.compactSupported,
       goalPauseSupported: flat.goalPauseSupported,
-      canSubmit: flat.canSubmit,
+      gate: flat.gate,
       isTuttiModeActive: flat.isTuttiModeActive ?? false,
       isTuttiModeUpdating: flat.isTuttiModeUpdating ?? false,
       tuttiModeOrchestrationIntensity:
@@ -78,12 +78,10 @@ export function groupAgentGUINodeViewModelFixture(
       composerSettings: flat.composerSettings,
       queueStatus: flat.queueStatus,
       queuedPrompts: flat.queuedPrompts,
-      drainingQueuedPromptId: flat.drainingQueuedPromptId,
-      canQueueWhileBusy: flat.canQueueWhileBusy
+      drainingQueuedPromptId: flat.drainingQueuedPromptId
     },
     interaction: {
       isRespondingApproval: flat.isRespondingApproval,
-      isRuntimeBlocked: flat.isRuntimeBlocked,
       pendingApproval: flat.pendingApproval,
       pendingInteractivePrompt: flat.pendingInteractivePrompt,
       sessionChrome: flat.sessionChrome,
@@ -92,10 +90,6 @@ export function groupAgentGUINodeViewModelFixture(
     readiness: {
       activeLiveState: flat.activeLiveState,
       activationError: flat.activationError,
-      activeConversationBusy: flat.activeConversationBusy,
-      sessionRuntimeBlocked: flat.sessionRuntimeBlocked,
-      sessionRuntimeBlockedReason: flat.sessionRuntimeBlockedReason ?? null,
-      targetConnectionBlocked: flat.targetConnectionBlocked,
       providerReadinessGate: flat.providerReadinessGate
     },
     operations: {

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/AgentGUINodeViewModel.renderBudget.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/AgentGUINodeViewModel.renderBudget.spec.tsx
@@ -16,6 +16,55 @@ describe("useAgentGUIViewModel render budgets", () => {
   it("keeps rail and detail references stable while typing in the composer", () => {
     assertIsolatedGroupUpdate("composer", ["detail", "rail"]);
   });
+
+  it("publishes the connecting-to-ready Composer gate as one snapshot", () => {
+    const initial = createViewModel();
+    const connectingGate: AgentGUINodeViewModel["composer"]["gate"] = {
+      conversationBusy: false,
+      runtime: {
+        status: "blocked",
+        reason: "target_connection",
+        sessionRuntimeReason: null
+      },
+      editor: { status: "blocked", reason: "runtime_blocked" },
+      submission: { status: "blocked", reason: "runtime_blocked" }
+    };
+    const readyGate: AgentGUINodeViewModel["composer"]["gate"] = {
+      conversationBusy: false,
+      runtime: {
+        status: "ready",
+        reason: null,
+        sessionRuntimeReason: null
+      },
+      editor: { status: "editable", reason: null },
+      submission: { status: "ready", reason: null }
+    };
+    const rendered = renderHook(
+      ({ candidate }) => useAgentGUIViewModel(candidate),
+      {
+        initialProps: {
+          candidate: {
+            ...initial,
+            composer: { ...initial.composer, gate: connectingGate }
+          }
+        }
+      }
+    );
+
+    rendered.rerender({
+      candidate: {
+        ...initial,
+        composer: { ...initial.composer, gate: readyGate }
+      }
+    });
+
+    expect(rendered.result.current.composer.gate).toBe(readyGate);
+    expect(rendered.result.current.composer.gate).toMatchObject({
+      runtime: { status: "ready" },
+      editor: { status: "editable" },
+      submission: { status: "ready" }
+    });
+  });
 });
 
 function assertIsolatedGroupUpdate(
@@ -114,7 +163,16 @@ function createViewModel(): AgentGUINodeViewModel {
       promptImagesSupported: false,
       compactSupported: false,
       goalPauseSupported: false,
-      canSubmit: false,
+      gate: {
+        conversationBusy: false,
+        runtime: {
+          status: "ready",
+          reason: null,
+          sessionRuntimeReason: null
+        },
+        editor: { status: "editable", reason: null },
+        submission: { status: "ready", reason: null }
+      },
       isTuttiModeActive: false,
       isTuttiModeUpdating: false,
       tuttiModeOrchestrationIntensity: 50,
@@ -123,8 +181,7 @@ function createViewModel(): AgentGUINodeViewModel {
         {} as AgentGUINodeViewModel["composer"]["composerSettings"],
       queuedPrompts: [],
       queueStatus: "active",
-      drainingQueuedPromptId: null,
-      canQueueWhileBusy: false
+      drainingQueuedPromptId: null
     },
     interaction: {} as AgentGUINodeViewModel["interaction"],
     readiness: {} as AgentGUINodeViewModel["readiness"],

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiComposerGate.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiComposerGate.spec.ts
@@ -97,6 +97,20 @@ describe("resolveAgentGUIComposerGate", () => {
     });
   });
 
+  it("keeps submitting in the same busy/queue gate snapshot", () => {
+    expect(
+      resolveAgentGUIComposerGate({
+        ...readyInput,
+        isSubmitting: true
+      })
+    ).toMatchObject({
+      conversationBusy: true,
+      runtime: { status: "ready" },
+      editor: { status: "editable", reason: null },
+      submission: { status: "queue", reason: "conversation_busy" }
+    });
+  });
+
   it("blocks both editing and submission for a collaborator-owned session", () => {
     expect(
       resolveAgentGUIComposerGate({

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiComposerGate.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiComposerGate.spec.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import {
+  projectAgentGUIComposerGateControls,
+  resolveAgentGUIComposerGate,
+  type ResolveAgentGUIComposerGateInput
+} from "./agentGuiComposerGate";
+
+const readyInput: ResolveAgentGUIComposerGateInput = {
+  activeConversationBusy: false,
+  activeConversationId: "session-1",
+  activeEngineHasPendingInteractions: false,
+  activeLiveState: "active",
+  activeConversationResumeUnavailable: false,
+  agentTargetsLoading: false,
+  authBlocked: false,
+  hasNonRetryableRecoveryFailure: false,
+  isCollaboratorConversation: false,
+  isCreatingConversation: false,
+  isInterrupting: false,
+  isSubmitting: false,
+  pendingApproval: false,
+  pendingInteractivePrompt: false,
+  providerReadinessGate: null,
+  sessionRuntimeBlockedReason: null,
+  targetConnectionBlocked: false
+};
+
+describe("resolveAgentGUIComposerGate", () => {
+  it("atomically unblocks a shared target when its connection becomes ready", () => {
+    const connecting = resolveAgentGUIComposerGate({
+      ...readyInput,
+      targetConnectionBlocked: true
+    });
+    expect(connecting).toEqual({
+      conversationBusy: false,
+      runtime: {
+        status: "blocked",
+        reason: "target_connection",
+        sessionRuntimeReason: null
+      },
+      editor: { status: "blocked", reason: "runtime_blocked" },
+      submission: { status: "blocked", reason: "runtime_blocked" }
+    });
+
+    const ready = resolveAgentGUIComposerGate(readyInput);
+    expect(ready).toEqual({
+      conversationBusy: false,
+      runtime: {
+        status: "ready",
+        reason: null,
+        sessionRuntimeReason: null
+      },
+      editor: { status: "editable", reason: null },
+      submission: { status: "ready", reason: null }
+    });
+    const controls = projectAgentGUIComposerGateControls({
+      gate: ready,
+      presentationEditorDisabled: false,
+      presentationSubmitDisabled: false
+    });
+    expect(controls.editorDisabled).toBe(false);
+
+    const editor = document.createElement("div");
+    editor.contentEditable = String(!controls.editorDisabled);
+    editor.tabIndex = 0;
+    document.body.append(editor);
+    editor.focus();
+    expect(editor.contentEditable).toBe("true");
+    expect(document.activeElement).toBe(editor);
+    editor.remove();
+  });
+
+  it("cannot expose ready submission with a stale runtime connection block", () => {
+    for (const targetConnectionBlocked of [false, true]) {
+      const gate = resolveAgentGUIComposerGate({
+        ...readyInput,
+        targetConnectionBlocked
+      });
+      if (gate.submission.status === "ready") {
+        expect(gate.runtime.status).toBe("ready");
+        expect(gate.editor.status).toBe("editable");
+      }
+    }
+  });
+
+  it("keeps the editor editable and projects queue submission while busy", () => {
+    expect(
+      resolveAgentGUIComposerGate({
+        ...readyInput,
+        activeConversationBusy: true
+      })
+    ).toMatchObject({
+      conversationBusy: true,
+      runtime: { status: "ready" },
+      editor: { status: "editable", reason: null },
+      submission: { status: "queue", reason: "conversation_busy" }
+    });
+  });
+
+  it("blocks both editing and submission for a collaborator-owned session", () => {
+    expect(
+      resolveAgentGUIComposerGate({
+        ...readyInput,
+        isCollaboratorConversation: true
+      })
+    ).toMatchObject({
+      runtime: { status: "ready" },
+      editor: { status: "blocked", reason: "collaborator_read_only" },
+      submission: { status: "blocked", reason: "collaborator_read_only" }
+    });
+  });
+
+  it("keeps approval queue semantics while runtime commands are available", () => {
+    expect(
+      resolveAgentGUIComposerGate({
+        ...readyInput,
+        activeEngineHasPendingInteractions: true,
+        pendingApproval: true
+      })
+    ).toMatchObject({
+      runtime: { status: "ready" },
+      editor: { status: "editable", reason: null },
+      submission: { status: "queue", reason: "conversation_busy" }
+    });
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiComposerGate.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiComposerGate.ts
@@ -29,6 +29,7 @@ export interface ResolveAgentGUIComposerGateInput {
 export function resolveAgentGUIComposerGate(
   input: ResolveAgentGUIComposerGateInput
 ): AgentGUIComposerGate {
+  const conversationBusy = input.activeConversationBusy || input.isSubmitting;
   const runtime: AgentGUIComposerGate["runtime"] = input.targetConnectionBlocked
     ? {
         status: "blocked",
@@ -49,9 +50,7 @@ export function resolveAgentGUIComposerGate(
   const canQueue =
     input.activeConversationId !== null &&
     runtime.status === "ready" &&
-    (input.activeConversationBusy ||
-      input.isSubmitting ||
-      input.activeEngineHasPendingInteractions);
+    (conversationBusy || input.activeEngineHasPendingInteractions);
   const canSubmit =
     !input.agentTargetsLoading &&
     input.providerReadinessGate === null &&
@@ -62,9 +61,8 @@ export function resolveAgentGUIComposerGate(
     !input.pendingApproval &&
     !input.pendingInteractivePrompt &&
     !input.authBlocked &&
-    !input.activeConversationBusy &&
+    !conversationBusy &&
     !input.isCreatingConversation &&
-    !input.isSubmitting &&
     !input.isInterrupting;
 
   const hardBlockReason = resolveHardBlockReason(input, runtime);
@@ -100,7 +98,7 @@ export function resolveAgentGUIComposerGate(
           };
 
   return {
-    conversationBusy: input.activeConversationBusy,
+    conversationBusy,
     runtime,
     editor,
     submission

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiComposerGate.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiComposerGate.ts
@@ -1,0 +1,201 @@
+import type { AgentGUIProviderReadinessGate } from "../../../types";
+import type {
+  AgentGUIComposerEditorBlockedReason,
+  AgentGUIComposerGate,
+  AgentGUIComposerSubmissionBlockedReason,
+  AgentGUIRuntimeBlockedReason
+} from "./agentGuiNodeTypes";
+
+export interface ResolveAgentGUIComposerGateInput {
+  activeConversationBusy: boolean;
+  activeConversationId: string | null;
+  activeEngineHasPendingInteractions: boolean;
+  activeLiveState: "inactive" | "activating" | "active" | "failed";
+  activeConversationResumeUnavailable: boolean;
+  agentTargetsLoading: boolean;
+  authBlocked: boolean;
+  hasNonRetryableRecoveryFailure: boolean;
+  isCollaboratorConversation: boolean;
+  isCreatingConversation: boolean;
+  isInterrupting: boolean;
+  isSubmitting: boolean;
+  pendingApproval: boolean;
+  pendingInteractivePrompt: boolean;
+  providerReadinessGate: AgentGUIProviderReadinessGate | null;
+  sessionRuntimeBlockedReason: AgentGUIRuntimeBlockedReason | null;
+  targetConnectionBlocked: boolean;
+}
+
+export function resolveAgentGUIComposerGate(
+  input: ResolveAgentGUIComposerGateInput
+): AgentGUIComposerGate {
+  const runtime: AgentGUIComposerGate["runtime"] = input.targetConnectionBlocked
+    ? {
+        status: "blocked",
+        reason: "target_connection",
+        sessionRuntimeReason: null
+      }
+    : input.sessionRuntimeBlockedReason !== null
+      ? {
+          status: "blocked",
+          reason: "session_runtime",
+          sessionRuntimeReason: input.sessionRuntimeBlockedReason
+        }
+      : {
+          status: "ready",
+          reason: null,
+          sessionRuntimeReason: null
+        };
+  const canQueue =
+    input.activeConversationId !== null &&
+    runtime.status === "ready" &&
+    (input.activeConversationBusy ||
+      input.isSubmitting ||
+      input.activeEngineHasPendingInteractions);
+  const canSubmit =
+    !input.agentTargetsLoading &&
+    input.providerReadinessGate === null &&
+    runtime.status === "ready" &&
+    input.activeLiveState !== "activating" &&
+    input.activeLiveState !== "failed" &&
+    !input.activeConversationResumeUnavailable &&
+    !input.pendingApproval &&
+    !input.pendingInteractivePrompt &&
+    !input.authBlocked &&
+    !input.activeConversationBusy &&
+    !input.isCreatingConversation &&
+    !input.isSubmitting &&
+    !input.isInterrupting;
+
+  const hardBlockReason = resolveHardBlockReason(input, runtime);
+  const editor = hardBlockReason
+    ? {
+        status: "blocked" as const,
+        reason: hardBlockReason
+      }
+    : canQueue
+      ? {
+          status: "editable" as const,
+          reason: null
+        }
+      : resolveEditorGate(input);
+  const submission = hardBlockReason
+    ? {
+        status: "blocked" as const,
+        reason: hardBlockReason
+      }
+    : canSubmit
+      ? {
+          status: "ready" as const,
+          reason: null
+        }
+      : canQueue
+        ? {
+            status: "queue" as const,
+            reason: "conversation_busy" as const
+          }
+        : {
+            status: "blocked" as const,
+            reason: resolveSubmissionBlockReason(input)
+          };
+
+  return {
+    conversationBusy: input.activeConversationBusy,
+    runtime,
+    editor,
+    submission
+  };
+}
+
+function resolveHardBlockReason(
+  input: ResolveAgentGUIComposerGateInput,
+  runtime: AgentGUIComposerGate["runtime"]
+): AgentGUIComposerEditorBlockedReason | null {
+  if (input.isCollaboratorConversation) {
+    return "collaborator_read_only";
+  }
+  if (runtime.status === "blocked") {
+    return "runtime_blocked";
+  }
+  if (input.hasNonRetryableRecoveryFailure) {
+    return "non_retryable_recovery";
+  }
+  return null;
+}
+
+function resolveEditorGate(
+  input: ResolveAgentGUIComposerGateInput
+): AgentGUIComposerGate["editor"] {
+  const reason: AgentGUIComposerEditorBlockedReason | null =
+    input.providerReadinessGate !== null
+      ? "provider_readiness"
+      : input.pendingApproval
+        ? "pending_approval"
+        : input.pendingInteractivePrompt
+          ? "pending_interactive_prompt"
+          : input.isSubmitting
+            ? "submitting"
+            : input.isInterrupting
+              ? "interrupting"
+              : input.isCreatingConversation
+                ? "creating_conversation"
+                : null;
+  return reason
+    ? { status: "blocked", reason }
+    : { status: "editable", reason: null };
+}
+
+function resolveSubmissionBlockReason(
+  input: ResolveAgentGUIComposerGateInput
+): AgentGUIComposerSubmissionBlockedReason {
+  if (input.agentTargetsLoading) return "agent_targets_loading";
+  if (input.providerReadinessGate !== null) return "provider_readiness";
+  if (input.activeLiveState === "activating") return "activation_pending";
+  if (input.activeLiveState === "failed") return "activation_failed";
+  if (input.activeConversationResumeUnavailable) return "resume_unavailable";
+  if (input.pendingApproval) return "pending_approval";
+  if (input.pendingInteractivePrompt) return "pending_interactive_prompt";
+  if (input.authBlocked) return "authentication_required";
+  if (input.activeConversationBusy) return "conversation_busy";
+  if (input.isCreatingConversation) return "creating_conversation";
+  if (input.isSubmitting) return "submitting";
+  if (input.isInterrupting) return "interrupting";
+  return "conversation_busy";
+}
+
+export function isDifferentKnownConversationOwner(input: {
+  conversationUserId?: string | null;
+  currentUserId?: string | null;
+}): boolean {
+  const conversationUserId = input.conversationUserId?.trim() ?? "";
+  const currentUserId = input.currentUserId?.trim() ?? "";
+  if (
+    !conversationUserId ||
+    !currentUserId ||
+    conversationUserId === "local" ||
+    currentUserId === "local"
+  ) {
+    return false;
+  }
+  return conversationUserId !== currentUserId;
+}
+
+export function projectAgentGUIComposerGateControls(input: {
+  gate: AgentGUIComposerGate;
+  presentationEditorDisabled: boolean;
+  presentationSubmitDisabled: boolean;
+}): {
+  canQueueWhileBusy: boolean;
+  editorDisabled: boolean;
+  submissionDisabled: boolean;
+} {
+  return {
+    canQueueWhileBusy: input.gate.submission.status === "queue",
+    editorDisabled:
+      input.gate.editor.status === "blocked" ||
+      input.presentationEditorDisabled,
+    submissionDisabled:
+      input.gate.submission.status === "blocked" ||
+      input.presentationSubmitDisabled
+  };
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
@@ -381,6 +381,80 @@ export interface AgentGUIDetailViewModel {
   conversationDetail: WorkspaceAgentSessionDetailViewModel | null;
 }
 
+export type AgentGUIRuntimeBlockedReason = Extract<
+  SessionRuntimeAvailability,
+  { state: "blocked" }
+>["reason"];
+
+export type AgentGUIComposerRuntimeGate =
+  | {
+      status: "ready";
+      reason: null;
+      sessionRuntimeReason: null;
+    }
+  | {
+      status: "blocked";
+      reason: "target_connection";
+      sessionRuntimeReason: null;
+    }
+  | {
+      status: "blocked";
+      reason: "session_runtime";
+      sessionRuntimeReason: AgentGUIRuntimeBlockedReason;
+    };
+
+export type AgentGUIComposerEditorBlockedReason =
+  | "collaborator_read_only"
+  | "creating_conversation"
+  | "interrupting"
+  | "non_retryable_recovery"
+  | "pending_approval"
+  | "pending_interactive_prompt"
+  | "provider_readiness"
+  | "runtime_blocked"
+  | "submitting";
+
+export type AgentGUIComposerSubmissionBlockedReason =
+  | AgentGUIComposerEditorBlockedReason
+  | "activation_failed"
+  | "activation_pending"
+  | "agent_targets_loading"
+  | "authentication_required"
+  | "conversation_busy"
+  | "resume_unavailable";
+
+export interface AgentGUIComposerGate {
+  /** Canonical busy projection captured with the same gate snapshot. */
+  conversationBusy: boolean;
+  /**
+   * Runtime-dependent command availability used by Composer-adjacent
+   * controls such as Stop and interactive responses.
+   */
+  runtime: AgentGUIComposerRuntimeGate;
+  editor:
+    | {
+        status: "editable";
+        reason: null;
+      }
+    | {
+        status: "blocked";
+        reason: AgentGUIComposerEditorBlockedReason;
+      };
+  submission:
+    | {
+        status: "ready";
+        reason: null;
+      }
+    | {
+        status: "queue";
+        reason: "conversation_busy";
+      }
+    | {
+        status: "blocked";
+        reason: AgentGUIComposerSubmissionBlockedReason;
+      };
+}
+
 export interface AgentGUIComposerViewModel {
   handoffAgentTargets: readonly AgentGUIAgentTarget[];
   availableCommands: AgentSessionCommand[];
@@ -395,7 +469,7 @@ export interface AgentGUIComposerViewModel {
   compactSupported: boolean | null;
   /** Provider goal exposes a real paused state and pause/resume controls. */
   goalPauseSupported: boolean;
-  canSubmit: boolean;
+  gate: AgentGUIComposerGate;
   isTuttiModeActive: boolean;
   isTuttiModeUpdating: boolean;
   /** Effective Tutti orchestration intensity (0-100) for the budget popup. */
@@ -410,30 +484,19 @@ export interface AgentGUIComposerViewModel {
   queuedPrompts: AgentGUIQueuedPromptVM[];
   queueStatus: AgentGUIQueueStatus;
   drainingQueuedPromptId: string | null;
-  canQueueWhileBusy: boolean;
 }
 
 export interface AgentGUIInteractionViewModel {
   isRespondingApproval: boolean;
-  isRuntimeBlocked: boolean;
   pendingApproval: AgentGUIApprovalRequest | null;
   pendingInteractivePrompt: AgentGUIInteractivePrompt | null;
   sessionChrome: AgentGUISessionChrome;
   inlineNotice: AgentGUIInlineNotice | null;
 }
 
-export type AgentGUIRuntimeBlockedReason = Extract<
-  SessionRuntimeAvailability,
-  { state: "blocked" }
->["reason"];
-
 export interface AgentGUIReadinessViewModel {
   activeLiveState: "inactive" | "activating" | "active" | "failed";
   activationError: string | null;
-  activeConversationBusy: boolean;
-  sessionRuntimeBlocked: boolean;
-  sessionRuntimeBlockedReason: AgentGUIRuntimeBlockedReason | null;
-  targetConnectionBlocked: boolean;
   providerReadinessGate: AgentGUIProviderReadinessGate | null;
 }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/useAgentGUIViewModel.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/useAgentGUIViewModel.ts
@@ -51,14 +51,13 @@ export function useAgentGUIViewModel(
     [
       candidate.composer.availableCommands,
       candidate.composer.availableSkills,
-      candidate.composer.canQueueWhileBusy,
-      candidate.composer.canSubmit,
       candidate.composer.compactSupported,
       candidate.composer.composerSettings,
       candidate.composer.draftContent,
       candidate.composer.draftPrompt,
       candidate.composer.drainingQueuedPromptId,
       candidate.composer.goalPauseSupported,
+      candidate.composer.gate,
       candidate.composer.handoffAgentTargets,
       candidate.composer.isCancelPending,
       candidate.composer.isCreatingConversation,
@@ -77,7 +76,6 @@ export function useAgentGUIViewModel(
     () => candidate.interaction,
     [
       candidate.interaction.inlineNotice,
-      candidate.interaction.isRuntimeBlocked,
       candidate.interaction.isRespondingApproval,
       candidate.interaction.pendingApproval,
       candidate.interaction.pendingInteractivePrompt,
@@ -88,11 +86,8 @@ export function useAgentGUIViewModel(
     () => candidate.readiness,
     [
       candidate.readiness.activationError,
-      candidate.readiness.activeConversationBusy,
       candidate.readiness.activeLiveState,
-      candidate.readiness.providerReadinessGate,
-      candidate.readiness.sessionRuntimeBlocked,
-      candidate.readiness.sessionRuntimeBlockedReason
+      candidate.readiness.providerReadinessGate
     ]
   );
   const operations = useMemo(

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
@@ -110,11 +110,10 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
     activePromptRequestId,
     bottomDockLiftedPrompt,
     bottomDockReplacementPrompt,
-    canQueueWhileBusy,
     chromeLabels,
     composerActivePrompt,
-    composerDisabled,
     composerDisabledReason,
+    composerGate,
     composerLabels,
     conversation,
     conversationFlowEmpty,
@@ -133,7 +132,6 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
     showTimelineSkeleton,
     showUnavailableChatEmpty,
     slashStatus: derivedSlashStatus,
-    submitDisabled,
     timelineConversationId,
     timelineInteractionLocked
   } = useAgentGUIDetailModel({
@@ -283,7 +281,7 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
   const canSwitchComposerProvider = true;
   const isInteractionPending =
     viewModel.interaction.isRespondingApproval ||
-    viewModel.interaction.isRuntimeBlocked;
+    composerGate.runtime.status === "blocked";
   const homeComposerProviderTargets = homeTargetProjection.agentTargets;
   const selectedHomeComposerTarget = homeTargetProjection.selectedAgentTarget;
   const composerProviderTargets =
@@ -372,10 +370,10 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
         viewModel.rail.activeConversationId === null
           ? selectHomeComposerAgentTargetAndFocus
           : undefined,
-      disabled: composerDisabled || timelineInteractionLocked,
+      gate: composerGate,
+      presentationEditorDisabled: timelineInteractionLocked,
       disabledReason: composerDisabledReason,
-      submitDisabled:
-        submitDisabled ||
+      presentationSubmitDisabled:
         timelineInteractionLocked ||
         tuttiWorkflowDock.phase?.kind === "materializing",
       tuttiModeActive: viewModel.composer.isTuttiModeActive,
@@ -387,7 +385,6 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       queuedPrompts: viewModel.composer.queuedPrompts,
       drainingQueuedPromptId: viewModel.composer.drainingQueuedPromptId,
       workspaceAppIcons,
-      canQueueWhileBusy,
       placeholder: viewModel.detail.hasSentUserMessage
         ? labels.followupPlaceholder
         : labels.initialPlaceholder,
@@ -464,12 +461,11 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       onRequestGitBranches: stableRequestGitBranches
     }),
     [
-      canQueueWhileBusy,
       capabilityMenuState,
       capabilityControlsReadOnly,
       canSwitchComposerProvider,
-      composerDisabled,
       composerDisabledReason,
+      composerGate,
       composerFocusRequestSequence,
       composerEngagement,
       composerInputHistoryProps,
@@ -507,7 +503,6 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       showStopButton,
       stopDisabled,
       slashStatus,
-      submitDisabled,
       setTuttiModeActive,
       setTuttiModeOrchestrationIntensity,
       submitInteractivePrompt,
@@ -545,7 +540,7 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       viewModel.composer.isTuttiModeUpdating,
       viewModel.composer.tuttiModeOrchestrationIntensity,
       viewModel.interaction.isRespondingApproval,
-      viewModel.interaction.isRuntimeBlocked,
+      composerGate.runtime.status,
       viewModel.composer.promptImagesSupported,
       viewModel.composer.queueStatus,
       viewModel.composer.queuedPrompts,

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.spec.ts
@@ -3,7 +3,6 @@ import {
   buildAgentConversationHandoffPrompt,
   handoffProjectPathForConversation,
   isAgentGUITransportNoticeVisible,
-  resolveAgentGUIComposerDisabled,
   resolveAgentGUIHomeNoticeChrome,
   resolveAgentGUIStopControl,
   shouldShowAgentGUIStopButton
@@ -80,43 +79,6 @@ describe("shouldShowAgentGUIStopButton", () => {
         ...idle,
         isAuthBlocked: true,
         isCreatingConversation: true
-      })
-    ).toBe(false);
-  });
-});
-
-describe("resolveAgentGUIComposerDisabled", () => {
-  const idle = {
-    canQueueWhileBusy: false,
-    hasNonRetryableRecoveryFailure: false,
-    isCollaboratorConversation: false,
-    isCreatingConversation: false,
-    isInterrupting: false,
-    isSubmitting: false,
-    pendingApproval: false,
-    pendingInteractivePrompt: false,
-    runtimeBlocked: false
-  };
-
-  it("disables editing when the Session runtime capability is blocked", () => {
-    expect(
-      resolveAgentGUIComposerDisabled({
-        ...idle,
-        runtimeBlocked: true
-      })
-    ).toBe(true);
-  });
-
-  it("keeps an available idle Session editable", () => {
-    expect(resolveAgentGUIComposerDisabled(idle)).toBe(false);
-  });
-
-  it("preserves queue-while-busy editing when the runtime is available", () => {
-    expect(
-      resolveAgentGUIComposerDisabled({
-        ...idle,
-        canQueueWhileBusy: true,
-        isSubmitting: true
       })
     ).toBe(false);
   });
@@ -211,7 +173,7 @@ describe("transport availability presentation", () => {
         isInterrupting: false,
         isSubmitting: false,
         isUnavailable: false,
-        sessionRuntimeBlocked: true
+        runtimeCommandsBlocked: true
       })
     ).toEqual({ disabled: true, visible: true });
   });

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.ts
@@ -15,6 +15,7 @@ import type {
 import type { AgentGUIAgentTarget } from "../../../types";
 import type { AgentGUIViewLabels } from "./AgentGUINodeView.types";
 import { conversationPlainTitle, stringValue } from "./agentGUIViewUtils";
+export { isDifferentKnownConversationOwner } from "../model/agentGuiComposerGate";
 
 export function commandAppSource(
   command: unknown
@@ -33,23 +34,6 @@ export function workspaceAppIconKey(
   workspaceId: string
 ): string {
   return `${workspaceId}\u0000${appId}`;
-}
-
-export function isDifferentKnownConversationOwner(input: {
-  conversationUserId?: string | null;
-  currentUserId?: string | null;
-}): boolean {
-  const conversationUserId = input.conversationUserId?.trim() ?? "";
-  const currentUserId = input.currentUserId?.trim() ?? "";
-  if (
-    !conversationUserId ||
-    !currentUserId ||
-    conversationUserId === "local" ||
-    currentUserId === "local"
-  ) {
-    return false;
-  }
-  return conversationUserId !== currentUserId;
 }
 
 export function isContextCanceledMessage(
@@ -284,36 +268,12 @@ export function resolveAgentGUIStopControl(input: {
   isInterrupting: boolean;
   isSubmitting: boolean;
   isUnavailable: boolean;
-  sessionRuntimeBlocked: boolean;
+  runtimeCommandsBlocked: boolean;
 }): { disabled: boolean; visible: boolean } {
   return {
-    disabled: input.sessionRuntimeBlocked,
+    disabled: input.runtimeCommandsBlocked,
     visible: shouldShowAgentGUIStopButton(input)
   };
-}
-
-export function resolveAgentGUIComposerDisabled(input: {
-  canQueueWhileBusy: boolean;
-  hasNonRetryableRecoveryFailure: boolean;
-  isCollaboratorConversation: boolean;
-  isCreatingConversation: boolean;
-  isInterrupting: boolean;
-  isSubmitting: boolean;
-  pendingApproval: boolean;
-  pendingInteractivePrompt: boolean;
-  runtimeBlocked: boolean;
-}): boolean {
-  return (
-    input.isCollaboratorConversation ||
-    input.runtimeBlocked ||
-    input.hasNonRetryableRecoveryFailure ||
-    (!input.canQueueWhileBusy &&
-      (input.pendingApproval ||
-        input.pendingInteractivePrompt ||
-        input.isSubmitting ||
-        input.isInterrupting ||
-        input.isCreatingConversation))
-  );
 }
 
 export function buildAgentConversationHandoffPrompt(input: {

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailModel.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailModel.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from "react";
-import type { AgentGUIProviderReadinessGate } from "../../../types";
 import { isAgentGUIAgentTargetComingSoon } from "../../../agentTargets";
 import { UnavailableChatIcon } from "../../../app/renderer/components/icons/UnavailableChatIcon";
 import { useProjectedAgentConversation } from "../../../shared/agentConversation/projection/useProjectedAgentConversation";
@@ -13,11 +12,9 @@ import type {
 import type { AgentGUIViewLabels } from "../AgentGUINodeView";
 import {
   isContextCanceledMessage,
-  isDifferentKnownConversationOwner,
   isAgentGUITransportNoticeVisible,
   resolveActiveConversationBusyStatus,
   resolveConversationDetailStatus,
-  resolveAgentGUIComposerDisabled,
   resolveAgentGUIHomeNoticeChrome,
   resolveAgentGUIStopControl,
   resolveSlashStatus,
@@ -85,9 +82,7 @@ export function useAgentGUIDetailModel(input: Input) {
     viewModel.rail.comingSoonProviders
   );
   const emptyProviderReadinessGate = !hasActiveConversation
-    ? selectedAgentTargetComingSoon
-      ? ({ status: "coming_soon" } satisfies AgentGUIProviderReadinessGate)
-      : viewModel.readiness.providerReadinessGate
+    ? viewModel.readiness.providerReadinessGate
     : null;
   const activePrompt =
     viewModel.interaction.pendingInteractivePrompt ??
@@ -231,45 +226,20 @@ export function useAgentGUIDetailModel(input: Input) {
   });
   const activeConversationTurnBusy =
     viewModel.composer.isSubmitting ||
-    viewModel.readiness.activeConversationBusy ||
+    viewModel.composer.gate.conversationBusy ||
     derivedBusyStatus !== null;
   const isComposerSending =
     viewModel.composer.isSubmitting ||
     activeConversationTurnBusy ||
     (!hasActiveConversation && viewModel.composer.isCreatingConversation);
-  const isCollaboratorConversation = isDifferentKnownConversationOwner({
-    conversationUserId: viewModel.rail.activeConversation?.userId,
-    currentUserId: viewModel.shell.currentUserId
-  });
-  const canQueueWhileBusy =
-    viewModel.composer.canQueueWhileBusy && !isCollaboratorConversation;
+  const isCollaboratorConversation =
+    viewModel.composer.gate.editor.status === "blocked" &&
+    viewModel.composer.gate.editor.reason === "collaborator_read_only";
   const composerDisabledReason = isCollaboratorConversation
     ? labels.collaboratorSessionReadOnlyPlaceholder
     : null;
-  const hasNonRetryableRecoveryFailure =
-    (sessionChrome.recovery?.kind === "failed" &&
-      sessionChrome.recovery.canRetry === false) ||
-    sessionChrome.recovery?.kind === "resume-unavailable";
-  const runtimeBlocked =
-    viewModel.readiness.sessionRuntimeBlocked ||
-    viewModel.readiness.targetConnectionBlocked;
-  const submitDisabled =
-    hasNonRetryableRecoveryFailure ||
-    isCollaboratorConversation ||
-    runtimeBlocked ||
-    (!viewModel.composer.canSubmit && !canQueueWhileBusy);
-  const composerDisabled = resolveAgentGUIComposerDisabled({
-    canQueueWhileBusy,
-    hasNonRetryableRecoveryFailure,
-    isCollaboratorConversation,
-    isCreatingConversation: viewModel.composer.isCreatingConversation,
-    isInterrupting: viewModel.composer.isInterrupting,
-    isSubmitting: viewModel.composer.isSubmitting,
-    pendingApproval: viewModel.interaction.pendingApproval !== null,
-    pendingInteractivePrompt:
-      viewModel.interaction.pendingInteractivePrompt !== null,
-    runtimeBlocked
-  });
+  const runtimeCommandsBlocked =
+    viewModel.composer.gate.runtime.status === "blocked";
   const stopControl = resolveAgentGUIStopControl({
     hasPendingApproval: viewModel.interaction.pendingApproval !== null,
     hasPendingInteractivePrompt:
@@ -281,7 +251,7 @@ export function useAgentGUIDetailModel(input: Input) {
     isInterrupting: viewModel.composer.isInterrupting,
     isSubmitting: viewModel.composer.isSubmitting,
     isUnavailable: viewModel.readiness.activeLiveState === "failed",
-    sessionRuntimeBlocked: runtimeBlocked
+    runtimeCommandsBlocked
   });
   const showStopButton = stopControl.visible;
   const stopDisabled = stopControl.disabled;
@@ -742,11 +712,10 @@ export function useAgentGUIDetailModel(input: Input) {
     activePromptRequestId,
     bottomDockLiftedPrompt,
     bottomDockReplacementPrompt,
-    canQueueWhileBusy,
     chromeLabels,
     composerActivePrompt,
-    composerDisabled,
     composerDisabledReason,
+    composerGate: viewModel.composer.gate,
     composerLabels,
     conversation,
     conversationFlowEmpty,
@@ -766,7 +735,6 @@ export function useAgentGUIDetailModel(input: Input) {
     showTimelineSkeleton,
     showUnavailableChatEmpty,
     slashStatus,
-    submitDisabled,
     timelineConversationId,
     timelineInteractionLocked: timelineTransitionPending
   };

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailModel.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailModel.tsx
@@ -13,8 +13,6 @@ import type { AgentGUIViewLabels } from "../AgentGUINodeView";
 import {
   isContextCanceledMessage,
   isAgentGUITransportNoticeVisible,
-  resolveActiveConversationBusyStatus,
-  resolveConversationDetailStatus,
   resolveAgentGUIHomeNoticeChrome,
   resolveAgentGUIStopControl,
   resolveSlashStatus,
@@ -216,22 +214,12 @@ export function useAgentGUIDetailModel(input: Input) {
       : activePrompt;
   const showUnavailableChatEmpty =
     hasActiveConversation && viewModel.detail.availability === "not_found";
-  const activeDetailStatus = resolveConversationDetailStatus(
-    viewModel.detail.conversationDetail
-  );
-  const derivedBusyStatus = resolveActiveConversationBusyStatus({
-    conversationStatus: viewModel.rail.activeConversation?.status,
-    detailStatus: activeDetailStatus,
-    conversation: targetConversation
-  });
-  const activeConversationTurnBusy =
-    viewModel.composer.isSubmitting ||
-    viewModel.composer.gate.conversationBusy ||
-    derivedBusyStatus !== null;
+  const activeConversationTurnBusy = viewModel.composer.gate.conversationBusy;
   const isComposerSending =
-    viewModel.composer.isSubmitting ||
     activeConversationTurnBusy ||
-    (!hasActiveConversation && viewModel.composer.isCreatingConversation);
+    (!hasActiveConversation &&
+      viewModel.composer.gate.submission.status === "blocked" &&
+      viewModel.composer.gate.submission.reason === "creating_conversation");
   const isCollaboratorConversation =
     viewModel.composer.gate.editor.status === "blocked" &&
     viewModel.composer.gate.editor.reason === "collaborator_read_only";


### PR DESCRIPTION
## Summary

- derive one canonical Composer gate at the AgentGUI Session-presentation seam
- keep editor editability, submission ready/queue/blocked state, and runtime-command availability in one atomic view-model snapshot
- remove downstream cross-slice readiness recombination and cover shared-target connecting-to-ready, queue, read-only, and focusability regressions

## Verification

- `pnpm --filter @tutti-os/agent-gui test` (290 files, 2437 tests passed)
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm check:changed` (11 lanes passed)
- pre-push `pnpm check:changed -- --push-ready` (12 lanes passed)

## Checklist

- [x] This does not change Agent Host lifecycle semantics; it changes AgentGUI presentation gating only.
- [x] I kept the change focused on one concern.
- [x] I updated architecture and troubleshooting documentation for the changed interaction data flow.
- [x] README/CONTRIBUTING language variants are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] The commit is signed off with DCO.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1723" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->