### PR TITLE
feat(workspace-app-center): configure visible tabs

### DIFF
--- a/.changeset/app-center-visible-tabs.md
+++ b/.changeset/app-center-visible-tabs.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/workspace-app-center": patch
+---
+
+Allow App Center hosts to select which application tabs are visible.

--- a/packages/workspace/app-center/README.md
+++ b/packages/workspace/app-center/README.md
@@ -63,3 +63,16 @@ Desktop owns the `showAppDeveloperSources` preference, persists it through the
 desktop-preferences service, and passes the resulting value into the App Center
 pane. Keep preference UI, daemon storage, and host-specific source links out of
 this package.
+
+## Visible App Tabs
+
+`AppCenterPanel` shows the recommended, community, and my-apps tabs by default.
+Hosts can restrict or reorder them with `visibleAppTabs`. For example, a host
+that only exposes the official catalog can render:
+
+```tsx
+<AppCenterPanel visibleAppTabs={["recommended"]} {...props} />
+```
+
+If the controlled active tab is not visible, the panel renders the first
+visible tab. An empty configuration falls back to the recommended tab.

--- a/packages/workspace/app-center/src/ui/AppCenterPanel.tsx
+++ b/packages/workspace/app-center/src/ui/AppCenterPanel.tsx
@@ -64,6 +64,11 @@ import {
   type AppCenterFactoryPermissionOption,
   type AppCenterHostActions
 } from "./AppCard.tsx";
+import {
+  resolveActiveAppCenterTab,
+  resolveVisibleAppCenterTabs,
+  type AppCenterAppTab
+} from "./appCenterTabs.ts";
 
 type FactoryTemplateID =
   | "lovart"
@@ -72,7 +77,7 @@ type FactoryTemplateID =
   | "system"
   | "news"
   | "gomoku";
-export type AppCenterAppTab = "recommended" | "community" | "my";
+export type { AppCenterAppTab } from "./appCenterTabs.ts";
 type RecommendedCategoryTabID =
   | "all"
   | "product-design"
@@ -162,6 +167,7 @@ export interface AppCenterPanelProps {
   readonly providerLoading?: boolean;
   readonly providerOptions?: readonly AppCenterFactoryProviderOption[];
   readonly showDeveloperSources?: boolean;
+  readonly visibleAppTabs?: readonly AppCenterAppTab[];
   readonly viewModel: AppCenterViewModel;
 }
 
@@ -181,6 +187,7 @@ export function AppCenterPanel({
   providerLoading = false,
   providerOptions = [],
   showDeveloperSources = false,
+  visibleAppTabs: configuredVisibleAppTabs,
   viewModel
 }: AppCenterPanelProps): ReactElement {
   const promptTextareaId = useId();
@@ -253,7 +260,14 @@ export function AppCenterPanel({
     useState<AppCenterAppTab>("recommended");
   const [activeRecommendedCategoryTab, setActiveRecommendedCategoryTab] =
     useState<RecommendedCategoryTabID>("all");
-  const activeAppTab = controlledActiveAppTab ?? uncontrolledActiveAppTab;
+  const visibleAppTabs = useMemo(
+    () => resolveVisibleAppCenterTabs(configuredVisibleAppTabs),
+    [configuredVisibleAppTabs]
+  );
+  const activeAppTab = resolveActiveAppCenterTab(
+    controlledActiveAppTab ?? uncontrolledActiveAppTab,
+    visibleAppTabs
+  );
   useEffect(() => {
     setSelectedProvider((current) =>
       resolveSelectedAppFactoryProvider(
@@ -602,20 +616,15 @@ export function AppCenterPanel({
             <SectionTabs
               ariaLabel={copy.t("labels.appList")}
               className="h-8"
-              tabs={[
-                {
-                  label: copy.t("labels.recommendedApps"),
-                  value: "recommended"
-                },
-                {
-                  label: copy.t("labels.communityApps"),
-                  value: "community"
-                },
-                {
-                  label: copy.t("labels.myApps"),
-                  value: "my"
-                }
-              ]}
+              tabs={visibleAppTabs.map((tab) => ({
+                label:
+                  tab === "recommended"
+                    ? copy.t("labels.recommendedApps")
+                    : tab === "community"
+                      ? copy.t("labels.communityApps")
+                      : copy.t("labels.myApps"),
+                value: tab
+              }))}
               value={activeAppTab}
               onValueChange={setActiveAppTab}
             />

--- a/packages/workspace/app-center/src/ui/appCenterTabs.test.ts
+++ b/packages/workspace/app-center/src/ui/appCenterTabs.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  resolveActiveAppCenterTab,
+  resolveVisibleAppCenterTabs
+} from "./appCenterTabs.ts";
+
+test("all app tabs are visible by default", () => {
+  assert.deepEqual(resolveVisibleAppCenterTabs(undefined), [
+    "recommended",
+    "community",
+    "my"
+  ]);
+});
+
+test("hosts can select and order the visible app tabs", () => {
+  assert.deepEqual(resolveVisibleAppCenterTabs(["my", "recommended", "my"]), [
+    "my",
+    "recommended"
+  ]);
+});
+
+test("an empty visible tab configuration keeps the panel usable", () => {
+  assert.deepEqual(resolveVisibleAppCenterTabs([]), ["recommended"]);
+});
+
+test("a hidden active tab falls back to the first visible tab", () => {
+  assert.equal(
+    resolveActiveAppCenterTab("community", ["recommended"]),
+    "recommended"
+  );
+});

--- a/packages/workspace/app-center/src/ui/appCenterTabs.ts
+++ b/packages/workspace/app-center/src/ui/appCenterTabs.ts
@@ -1,0 +1,31 @@
+export type AppCenterAppTab = "recommended" | "community" | "my";
+
+const defaultVisibleAppTabs: readonly AppCenterAppTab[] = [
+  "recommended",
+  "community",
+  "my"
+];
+
+export function resolveVisibleAppCenterTabs(
+  configuredTabs: readonly AppCenterAppTab[] | undefined
+): readonly AppCenterAppTab[] {
+  if (configuredTabs === undefined) {
+    return defaultVisibleAppTabs;
+  }
+
+  const visibleTabs = configuredTabs.filter(
+    (tab, index) =>
+      defaultVisibleAppTabs.includes(tab) &&
+      configuredTabs.indexOf(tab) === index
+  );
+  return visibleTabs.length > 0 ? visibleTabs : ["recommended"];
+}
+
+export function resolveActiveAppCenterTab(
+  requestedTab: AppCenterAppTab,
+  visibleTabs: readonly AppCenterAppTab[]
+): AppCenterAppTab {
+  return visibleTabs.includes(requestedTab)
+    ? requestedTab
+    : (visibleTabs[0] ?? "recommended");
+}


### PR DESCRIPTION
## Summary

- add an optional `visibleAppTabs` prop to `AppCenterPanel` so hosts can select and order application tabs
- preserve all existing tabs by default and fall back to the first visible tab when the controlled tab is hidden
- document the TSH official-catalog-only usage and add a patch changeset

TSH can hide Community apps and My apps with:

```tsx
<AppCenterPanel visibleAppTabs={["recommended"]} {...props} />
```

## Verification

- `pnpm check:changed`
- `pnpm check:changed -- --push-ready`
- `pnpm --filter @tutti-os/workspace-app-center build`

## Checklist

- [x] Agent lifecycle semantics are not changed.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior changed.
- [x] No translated README variants exist for this package.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] The commit is signed off with DCO.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1725" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->