### PR TITLE
feat(ui-system): add quote icon

### DIFF
--- a/packages/ui/system/NOTICE
+++ b/packages/ui/system/NOTICE
@@ -61,7 +61,7 @@ SOFTWARE.
 
 ----------------------------------------------------------------------
 
-The MessageSquareTextIcon and GripVerticalIcon paths in
+The MessageSquareTextIcon, QuoteIcon, and GripVerticalIcon paths in
 src/icons/system-icons.tsx are source-derived from Lucide
 (https://github.com/lucide-icons/lucide), revision
 658573b0171e693bc965c167592cc0b92d002a3e, used under the ISC License.

--- a/packages/ui/system/src/icons/system-icons.tsx
+++ b/packages/ui/system/src/icons/system-icons.tsx
@@ -143,6 +143,26 @@ export function MessageSquareTextIcon(props: IconProps) {
   );
 }
 
+/** Source-derived from Lucide `quote` (ISC). */
+export function QuoteIcon(props: IconProps) {
+  return (
+    <SvgIcon stroke="currentColor" {...props}>
+      <path
+        d="M16 3a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2 1 1 0 0 1 1 1v1a2 2 0 0 1-2 2 1 1 0 0 0-1 1v2a1 1 0 0 0 1 1 6 6 0 0 0 6-6V5a2 2 0 0 0-2-2z"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+      />
+      <path
+        d="M5 3a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2 1 1 0 0 1 1 1v1a2 2 0 0 1-2 2 1 1 0 0 0-1 1v2a1 1 0 0 0 1 1 6 6 0 0 0 6-6V5a2 2 0 0 0-2-2z"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+      />
+    </SvgIcon>
+  );
+}
+
 /** Source-derived from Lucide `grip-vertical` (ISC). */
 export function GripVerticalIcon(props: IconProps) {
   return (

--- a/packages/ui/system/src/metadata/components.json
+++ b/packages/ui/system/src/metadata/components.json
@@ -82,6 +82,20 @@
       "migrationHints": []
     },
     {
+      "id": "quote-lined-icon",
+      "layer": "base",
+      "name": "QuoteIcon",
+      "export": "QuoteIcon",
+      "from": "@tutti-os/ui-system/icons",
+      "category": "icon",
+      "status": "stable",
+      "source": "src/icons/system-icons.tsx",
+      "description": "Source-derived Lucide quote icon.",
+      "useCases": ["Quote actions", "Quoted content affordances"],
+      "migrationHints": [],
+      "iconVariant": "lined"
+    },
+    {
       "id": "grip-vertical-icon",
       "layer": "base",
       "name": "GripVerticalIcon",


### PR DESCRIPTION
## What changed

- add a public `QuoteIcon` derived from Lucide's `quote` icon
- register the icon in UI System metadata so it appears in the Storyboard icon inventory
- extend the existing Lucide ISC attribution in `NOTICE`

## Why

TSH room chat needs a dedicated quotation-mark icon for the quote action. Reusing a message-bubble icon conflicts visually with the separate topic-reply action.

## Impact

Consumers can import `QuoteIcon` from `@tutti-os/ui-system/icons`. The icon follows the existing 24×24, `currentColor`, configurable-size icon contract.

## Validation

- `node tools/scripts/check-ui-metadata.mjs`
- `pnpm check:ui-boundaries`
- `pnpm --filter @tutti-os/ui-system typecheck`
- `pnpm --filter @tutti-os/ui-storyboard typecheck`
- `pnpm --filter @tutti-os/ui-system build`
- repository staged-file and push-ready checks
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1726" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->