### PR TITLE
feat(agent-gui): add agent target info render slot

### DIFF
--- a/.changeset/agent-target-info-renderer.md
+++ b/.changeset/agent-target-info-renderer.md
@@ -1,0 +1,6 @@
+---
+"@tutti-os/agent-gui": minor
+---
+
+Expose a lazy, product-neutral Agent target information renderer for provider
+Rail, Conversation Rail, and Workbench Header icon tooltips.

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -997,6 +997,17 @@ chrome seam for the exact selected Agent Target. Its paired
 state without hiding workflow in the render slot. Returning no content keeps
 the provider account and quota block unchanged. AgentGUI never derives billing
 ownership from provider identity.
+The optional `renderSlots.agentTargetInfo` seam enriches the exact target icon
+in the provider Rail and Conversation Rail. The same
+`AgentGUIAgentTargetInfoRenderer` may be passed to
+`AgentGuiWorkbenchHeader.renderAgentTargetInfo` with its exact
+`conversationAgentTarget`. AgentGUI owns Tooltip disclosure, positioning,
+focus behavior, and the built-in label fallback; the Host renderer receives
+only `{ target, surface }`, remains presentation-only, and is invoked lazily
+while the Tooltip content is mounted. Conversation rows resolve the target by
+canonical `agentTargetId` from the current Host directory and fail closed when
+it is absent. They do not copy owner, device, availability, or other target
+metadata into Session state.
 Host chrome that aligns to AgentGUI's internal layout must consume explicit
 package signals such as `hostActions.onConversationRailLayoutChange`; it must
 not observe package DOM, CSS variables, or class names with
@@ -1117,7 +1128,10 @@ WebGL scene readiness remains local presentation state; it must not enter
 
 The shared Workbench Header owns conversation-identity visibility. When no
 Conversation exists, it ignores conversation titles, Agent titles, primary
-icons, and fallback icons even if a host supplies them.
+icons, exact Agent targets, target-information renderers, and fallback icons
+even if a host supplies them. When target information is enabled, only the
+session icon becomes a no-drag Tooltip trigger; the surrounding title remains
+owned by the Header's existing drag and menu behavior.
 
 The reusable tool-sidebar contract lives in
 `packages/agent/gui/workbench/tool-sidebar`. Hosts provide the supported panel

--- a/packages/agent/gui/README.md
+++ b/packages/agent/gui/README.md
@@ -236,6 +236,15 @@ pnpm check:agent-activity-runtime-boundaries
 `hostCapabilities`, `hostActions`, and `renderSlots`. Extend the owning object;
 do not restore flat compatibility props.
 
+Hosts may provide `renderSlots.agentTargetInfo` to enrich the exact Agent icon
+in the provider Rail and Conversation Rail. The renderer receives
+`{ target, surface }`; AgentGUI owns Tooltip mechanics and calls the renderer
+only while the content is mounted. Pass the same renderer plus an exact
+`conversationAgentTarget` to `AgentGuiWorkbenchHeader` for the Header icon.
+Conversation history resolves the current Host directory by canonical
+`agentTargetId`; missing targets show no enriched Tooltip and target metadata
+is never copied into Session state.
+
 Workbench hosts capture Dock and minimize previews from the mounted AgentGUI
 node. AgentGUI does not expose a second-tree preview renderer or preview-mode
 contract.

--- a/packages/agent/gui/README.md
+++ b/packages/agent/gui/README.md
@@ -238,8 +238,9 @@ do not restore flat compatibility props.
 
 Hosts may provide `renderSlots.agentTargetInfo` to enrich the exact Agent icon
 in the provider Rail and Conversation Rail. The renderer receives
-`{ target, surface }`; AgentGUI owns Tooltip mechanics and calls the renderer
-only while the content is mounted. Pass the same renderer plus an exact
+`{ target, surface }` and returns one React element, or `null` to retain the
+built-in target-label fallback. AgentGUI owns Tooltip mechanics and calls the
+renderer only while the content is mounted. Pass the same renderer plus an exact
 `conversationAgentTarget` to `AgentGuiWorkbenchHeader` for the Header icon.
 Conversation history resolves the current Host directory by canonical
 `agentTargetId`; missing targets show no enriched Tooltip and target metadata

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -142,6 +142,7 @@ export const AgentGUINode = memo(function AgentGUINode({
   } = hostActions;
   const {
     agentConfigAccount: renderAgentConfigAccount,
+    agentTargetInfo: renderAgentTargetInfo,
     projectDirectoryPickerHeaderActions:
       renderProjectDirectoryPickerHeaderActions,
     providerRailEmpty: renderProviderRailEmpty,
@@ -448,6 +449,7 @@ export const AgentGUINode = memo(function AgentGUINode({
           return (
             <AgentGUINodeView
               viewModel={viewModel}
+              renderAgentTargetInfo={renderAgentTargetInfo}
               renderSidebarFooter={renderSidebarFooter}
               renderProviderRailEmpty={renderProviderRailEmpty}
               renderProviderUnavailableState={renderProviderUnavailableState}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.types.ts
@@ -19,6 +19,7 @@ import type {
   AgentGUITargetConnectionSource,
   AgentGUIHomeSuggestionId,
   AgentGUIAgentTarget,
+  AgentGUIAgentTargetInfoRenderer,
   AgentGUIAgentOwnership,
   NodeFrame,
   Point
@@ -210,6 +211,11 @@ export interface AgentGUIAgentConfigMenuContext {
 }
 
 export interface AgentGUINodeRenderSlots {
+  /**
+   * Optional Host-owned information for an exact Agent target. AgentGUI owns
+   * tooltip mechanics and invokes this renderer lazily for supported surfaces.
+   */
+  agentTargetInfo?: AgentGUIAgentTargetInfoRenderer;
   /**
    * Optional Host chrome for the exact target's account/Commerce presentation.
    * Returning null preserves AgentGUI's provider account and quota content.
@@ -434,6 +440,7 @@ export function areAgentGUINodePropsEqual(
     pa.onEngagementEvent === na.onEngagementEvent &&
     pa.onConversationRailLayoutChange === na.onConversationRailLayoutChange &&
     ps.agentConfigAccount === ns.agentConfigAccount &&
+    ps.agentTargetInfo === ns.agentTargetInfo &&
     ps.providerRailEmpty === ns.providerRailEmpty &&
     ps.providerUnavailableState === ns.providerUnavailableState &&
     ps.projectDirectoryPickerHeaderActions ===

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -14,6 +14,7 @@ import {
   AgentTargetPresentationProvider,
   type AgentMessageMarkdownAgentTarget
 } from "../../shared/AgentTargetPresentationContext";
+import { AgentTargetInfoRendererProvider } from "../../shared/AgentTargetInfoRendererContext";
 import { AgentConversationClockProvider } from "../../shared/agentConversation/components/AgentConversationClock";
 import type { AgentGUINodeViewModel } from "./model/agentGuiNodeTypes";
 import {
@@ -81,6 +82,7 @@ export function AgentGUINodeView({
   viewModel,
   referenceProvenanceFilters = null,
   sessionInputHistoryEnabled = false,
+  renderAgentTargetInfo,
   renderProjectDirectoryPickerHeaderActions,
   renderSidebarFooter,
   renderProviderRailEmpty,
@@ -769,5 +771,14 @@ export function AgentGUINodeView({
       </AgentTargetSetupRoot>
     </AgentTargetPresentationProvider>
   );
-  return <TooltipProvider>{content}</TooltipProvider>;
+  return (
+    <TooltipProvider>
+      <AgentTargetInfoRendererProvider
+        agentTargets={viewModel.rail.agentTargets}
+        renderer={renderAgentTargetInfo}
+      >
+        {content}
+      </AgentTargetInfoRendererProvider>
+    </TooltipProvider>
+  );
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailItem.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailItem.spec.tsx
@@ -1,10 +1,16 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { TooltipProvider } from "@tutti-os/ui-system";
 import { describe, expect, it, vi } from "vitest";
+import type {
+  AgentGUIAgentTarget,
+  AgentGUIAgentTargetInfoRenderer
+} from "../../../types";
 import type { AgentGUIConversationSummary } from "../model/agentGuiConversationModel";
 import {
   AgentTargetPresentationProvider,
   type AgentMessageMarkdownAgentTarget
 } from "../../../shared/AgentTargetPresentationContext";
+import { AgentTargetInfoRendererProvider } from "../../../shared/AgentTargetInfoRendererContext";
 import type { AgentGUIViewLabels } from "./AgentGUINodeView.types";
 import { AgentGUIConversationRailItem } from "./AgentGUIConversationRailItem";
 
@@ -169,6 +175,87 @@ describe("AgentGUIConversationRailItem interaction lock", () => {
     ).toBeNull();
   });
 
+  it("opens exact Host target information from icon hover and row keyboard focus", async () => {
+    const exactTarget: AgentGUIAgentTarget = {
+      agentTargetId: "agent:shared",
+      iconUrl: "data:image/png;base64,shared",
+      label: "Shared Codex",
+      ownerDeviceLabel: "Vector's MacBook Pro",
+      provider: "codex",
+      ref: { kind: "shared", provider: "codex" },
+      targetId: "shared:codex"
+    };
+    const siblingTarget: AgentGUIAgentTarget = {
+      ...exactTarget,
+      agentTargetId: "agent:sibling",
+      label: "Sibling Codex",
+      targetId: "shared:sibling"
+    };
+    const renderAgentTargetInfo = vi.fn(({ surface, target }) => (
+      <div>{`${surface}:${target.label}`}</div>
+    ));
+    const { container } = renderRailItem({
+      agentTargets: [
+        {
+          agentTargetId: exactTarget.agentTargetId!,
+          iconUrl: exactTarget.iconUrl,
+          provider: exactTarget.provider,
+          workspaceId: "workspace-1"
+        }
+      ],
+      isRailInteractionLocked: () => false,
+      item: { agentTargetId: exactTarget.agentTargetId },
+      renderAgentTargetInfo,
+      targetInfoTargets: [siblingTarget, exactTarget]
+    });
+
+    expect(renderAgentTargetInfo).not.toHaveBeenCalled();
+
+    fireEvent.pointerMove(
+      container.querySelector(".agent-gui-node__conversation-provider-image")!,
+      { pointerType: "mouse" }
+    );
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "conversation-rail:Shared Codex"
+    );
+    expect(renderAgentTargetInfo).toHaveBeenLastCalledWith({
+      surface: "conversation-rail",
+      target: exactTarget
+    });
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => expect(screen.queryByRole("tooltip")).toBeNull());
+
+    fireEvent.focus(screen.getByRole("button", { name: /Session 1/ }));
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "conversation-rail:Shared Codex"
+    );
+  });
+
+  it("fails closed when a session target is missing from the exact directory", () => {
+    const renderAgentTargetInfo = vi.fn(() => <div>Should not render</div>);
+    renderRailItem({
+      agentTargets: [
+        {
+          agentTargetId: "agent:missing",
+          iconUrl: "data:image/png;base64,missing",
+          provider: "codex",
+          workspaceId: "workspace-1"
+        }
+      ],
+      isRailInteractionLocked: () => false,
+      item: { agentTargetId: "agent:missing" },
+      renderAgentTargetInfo,
+      targetInfoTargets: []
+    });
+
+    fireEvent.focus(screen.getByRole("button", { name: /Session 1/ }));
+
+    expect(screen.queryByRole("tooltip")).toBeNull();
+    expect(renderAgentTargetInfo).not.toHaveBeenCalled();
+  });
+
   it("blocks the div context-menu trigger while rail reconciliation is pending", () => {
     const onSelectConversation = vi.fn();
     renderRailItem({
@@ -312,6 +399,8 @@ function renderRailItem(overrides: {
     conversation: AgentGUIConversationSummary
   ) => void;
   onSelectConversation?: (agentSessionId: string) => void;
+  renderAgentTargetInfo?: AgentGUIAgentTargetInfoRenderer;
+  targetInfoTargets?: readonly AgentGUIAgentTarget[];
 }) {
   const item = (
     <AgentGUIConversationRailItem
@@ -343,14 +432,22 @@ function renderRailItem(overrides: {
       onMarkConversationUnread={() => {}}
     />
   );
+  const withTargetPresentation = overrides.agentTargets ? (
+    <AgentTargetPresentationProvider agentTargets={overrides.agentTargets}>
+      {item}
+    </AgentTargetPresentationProvider>
+  ) : (
+    item
+  );
   return render(
-    overrides.agentTargets ? (
-      <AgentTargetPresentationProvider agentTargets={overrides.agentTargets}>
-        {item}
-      </AgentTargetPresentationProvider>
-    ) : (
-      item
-    )
+    <TooltipProvider>
+      <AgentTargetInfoRendererProvider
+        agentTargets={overrides.targetInfoTargets ?? []}
+        renderer={overrides.renderAgentTargetInfo}
+      >
+        {withTargetPresentation}
+      </AgentTargetInfoRendererProvider>
+    </TooltipProvider>
   );
 }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailItem.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailItem.spec.tsx
@@ -227,10 +227,19 @@ describe("AgentGUIConversationRailItem interaction lock", () => {
     fireEvent.keyDown(document, { key: "Escape" });
     await waitFor(() => expect(screen.queryByRole("tooltip")).toBeNull());
 
-    fireEvent.focus(screen.getByRole("button", { name: /Session 1/ }));
-    expect(await screen.findByRole("tooltip")).toHaveTextContent(
-      "conversation-rail:Shared Codex"
+    const conversationButton = screen.getByRole("button", {
+      name: /Session 1/
+    });
+    fireEvent.focus(conversationButton);
+    const focusTooltip = await screen.findByRole("tooltip");
+    expect(focusTooltip).toHaveTextContent("conversation-rail:Shared Codex");
+    expect(conversationButton).toHaveAttribute(
+      "aria-describedby",
+      focusTooltip.id
     );
+
+    fireEvent.blur(conversationButton);
+    await waitFor(() => expect(screen.queryByRole("tooltip")).toBeNull());
   });
 
   it("fails closed when a session target is missing from the exact directory", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailItem.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailItem.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo, useState } from "react";
+import { memo, useCallback, useMemo, useRef, useState } from "react";
 import { ExternalLink } from "lucide-react";
 import { NewWorkspaceLinedIcon, cn } from "@tutti-os/ui-system";
 import { WorkspaceUserProjectSelect } from "@tutti-os/workspace-user-project/ui";
@@ -116,6 +116,36 @@ export const AgentGUIConversationRailItem = memo(
     const agentTargets = useAgentTargetPresentations();
     const renderAgentTargetInfo = useAgentTargetInfoRenderer();
     const targetInfoTarget = useAgentTargetInfoTarget(item.agentTargetId);
+    const hasTargetInfo = Boolean(renderAgentTargetInfo && targetInfoTarget);
+    const targetInfoFocusedRef = useRef(false);
+    const targetInfoPointerOverIconRef = useRef(false);
+    const handleTargetInfoOpenChange = (open: boolean): void => {
+      if (
+        !open ||
+        targetInfoFocusedRef.current ||
+        targetInfoPointerOverIconRef.current
+      ) {
+        setTargetInfoOpen(open);
+      }
+    };
+    const handleTargetInfoIconPointerMove = (): void => {
+      targetInfoPointerOverIconRef.current = true;
+      setTargetInfoOpen(true);
+    };
+    const handleTargetInfoIconPointerLeave = (): void => {
+      targetInfoPointerOverIconRef.current = false;
+      if (!targetInfoFocusedRef.current) {
+        setTargetInfoOpen(false);
+      }
+    };
+    const handleTargetInfoFocus = (): void => {
+      targetInfoFocusedRef.current = true;
+      setTargetInfoOpen(true);
+    };
+    const handleTargetInfoBlur = (): void => {
+      targetInfoFocusedRef.current = false;
+      setTargetInfoOpen(false);
+    };
     const conversationIcon = agentGUIConversationIconPresentation(
       item.provider,
       item.agentTargetId,
@@ -134,6 +164,12 @@ export const AgentGUIConversationRailItem = memo(
             WebkitMaskImage: `url("${conversationIcon.url}")`,
             maskImage: `url("${conversationIcon.url}")`
           }}
+          onPointerLeave={
+            hasTargetInfo ? handleTargetInfoIconPointerLeave : undefined
+          }
+          onPointerMove={
+            hasTargetInfo ? handleTargetInfoIconPointerMove : undefined
+          }
         />
       ) : conversationIcon ? (
         <img
@@ -145,26 +181,14 @@ export const AgentGUIConversationRailItem = memo(
           )}
           draggable={false}
           src={conversationIcon.url}
+          onPointerLeave={
+            hasTargetInfo ? handleTargetInfoIconPointerLeave : undefined
+          }
+          onPointerMove={
+            hasTargetInfo ? handleTargetInfoIconPointerMove : undefined
+          }
         />
       ) : null;
-    const conversationIconWithTargetInfo =
-      conversationIconNode && renderAgentTargetInfo && targetInfoTarget ? (
-        <AgentTargetInfoTooltip
-          align="start"
-          fallbackLabel={targetInfoTarget.label}
-          onOpenChange={setTargetInfoOpen}
-          open={targetInfoOpen}
-          renderer={renderAgentTargetInfo}
-          side="bottom"
-          sideOffset={6}
-          surface="conversation-rail"
-          target={targetInfoTarget}
-        >
-          {conversationIconNode}
-        </AgentTargetInfoTooltip>
-      ) : (
-        conversationIconNode
-      );
     const setItemElement = useCallback(
       (element: HTMLDivElement | null) => {
         registerItemElement(item.id, element);
@@ -225,6 +249,45 @@ export const AgentGUIConversationRailItem = memo(
       onOpenConversationWindow,
       onRequestRenameConversation
     });
+    const conversationSelect = (
+      <button
+        type="button"
+        className={styles.conversationSelect}
+        onClick={handleSelect}
+        onBlur={hasTargetInfo ? handleTargetInfoBlur : undefined}
+        onDoubleClick={(event) => {
+          event.preventDefault();
+          handleRequestRename();
+        }}
+        onFocus={hasTargetInfo ? handleTargetInfoFocus : undefined}
+      >
+        <span className={styles.conversationTitleRow}>
+          {conversationIconNode}
+          <span className={styles.conversationTitle}>
+            {agentGUIConversationRailTitle(item, labels, uiLanguage)}
+          </span>
+        </span>
+        <AgentGUIConversationRailRelativeTime item={item} labels={labels} />
+      </button>
+    );
+    const conversationSelectWithTargetInfo =
+      renderAgentTargetInfo && targetInfoTarget ? (
+        <AgentTargetInfoTooltip
+          align="start"
+          fallbackLabel={targetInfoTarget.label}
+          onOpenChange={handleTargetInfoOpenChange}
+          open={targetInfoOpen}
+          renderer={renderAgentTargetInfo}
+          side="bottom"
+          sideOffset={6}
+          surface="conversation-rail"
+          target={targetInfoTarget}
+        >
+          {conversationSelect}
+        </AgentTargetInfoTooltip>
+      ) : (
+        conversationSelect
+      );
     const row = (
       <div
         ref={setItemElement}
@@ -245,33 +308,7 @@ export const AgentGUIConversationRailItem = memo(
         onMouseLeave={handleMouseLeave}
         onPointerEnter={() => setActionsActivated(true)}
       >
-        <button
-          type="button"
-          className={styles.conversationSelect}
-          onClick={handleSelect}
-          onBlur={
-            renderAgentTargetInfo && targetInfoTarget
-              ? () => setTargetInfoOpen(false)
-              : undefined
-          }
-          onDoubleClick={(event) => {
-            event.preventDefault();
-            handleRequestRename();
-          }}
-          onFocus={
-            renderAgentTargetInfo && targetInfoTarget
-              ? () => setTargetInfoOpen(true)
-              : undefined
-          }
-        >
-          <span className={styles.conversationTitleRow}>
-            {conversationIconWithTargetInfo}
-            <span className={styles.conversationTitle}>
-              {agentGUIConversationRailTitle(item, labels, uiLanguage)}
-            </span>
-          </span>
-          <AgentGUIConversationRailRelativeTime item={item} labels={labels} />
-        </button>
+        {conversationSelectWithTargetInfo}
         {actionsActivated || isPendingDeleteConversation ? (
           <div className={styles.conversationActions}>
             {isPendingDeleteConversation ? (

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailItem.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailItem.tsx
@@ -14,6 +14,11 @@ import {
   resolveAgentTargetPresentation,
   useAgentTargetPresentations
 } from "../../../shared/AgentTargetPresentationContext";
+import {
+  useAgentTargetInfoRenderer,
+  useAgentTargetInfoTarget
+} from "../../../shared/AgentTargetInfoRendererContext";
+import { AgentTargetInfoTooltip } from "../../../shared/AgentTargetInfoTooltip";
 import type { UiLanguage } from "../../../contexts/settings/domain/agentSettings";
 import type { AgentGUINodeViewModel } from "../model/agentGuiNodeTypes";
 import type { AgentGUIViewLabels } from "../AgentGUINodeView";
@@ -107,13 +112,59 @@ export const AgentGUIConversationRailItem = memo(
     "use memo";
     const pinned = (item.pinnedAtUnixMs ?? 0) > 0;
     const [actionsActivated, setActionsActivated] = useState(false);
+    const [targetInfoOpen, setTargetInfoOpen] = useState(false);
     const agentTargets = useAgentTargetPresentations();
+    const renderAgentTargetInfo = useAgentTargetInfoRenderer();
+    const targetInfoTarget = useAgentTargetInfoTarget(item.agentTargetId);
     const conversationIcon = agentGUIConversationIconPresentation(
       item.provider,
       item.agentTargetId,
       workspaceId,
       agentTargets
     );
+    const conversationIconNode =
+      conversationIcon?.kind === "mask" ? (
+        <span
+          aria-hidden="true"
+          className={cn(
+            styles.conversationProviderIcon,
+            styles.conversationProviderMaskIcon
+          )}
+          style={{
+            WebkitMaskImage: `url("${conversationIcon.url}")`,
+            maskImage: `url("${conversationIcon.url}")`
+          }}
+        />
+      ) : conversationIcon ? (
+        <img
+          alt=""
+          aria-hidden="true"
+          className={cn(
+            styles.conversationProviderIcon,
+            styles.conversationProviderImage
+          )}
+          draggable={false}
+          src={conversationIcon.url}
+        />
+      ) : null;
+    const conversationIconWithTargetInfo =
+      conversationIconNode && renderAgentTargetInfo && targetInfoTarget ? (
+        <AgentTargetInfoTooltip
+          align="start"
+          fallbackLabel={targetInfoTarget.label}
+          onOpenChange={setTargetInfoOpen}
+          open={targetInfoOpen}
+          renderer={renderAgentTargetInfo}
+          side="bottom"
+          sideOffset={6}
+          surface="conversation-rail"
+          target={targetInfoTarget}
+        >
+          {conversationIconNode}
+        </AgentTargetInfoTooltip>
+      ) : (
+        conversationIconNode
+      );
     const setItemElement = useCallback(
       (element: HTMLDivElement | null) => {
         registerItemElement(item.id, element);
@@ -198,36 +249,23 @@ export const AgentGUIConversationRailItem = memo(
           type="button"
           className={styles.conversationSelect}
           onClick={handleSelect}
+          onBlur={
+            renderAgentTargetInfo && targetInfoTarget
+              ? () => setTargetInfoOpen(false)
+              : undefined
+          }
           onDoubleClick={(event) => {
             event.preventDefault();
             handleRequestRename();
           }}
+          onFocus={
+            renderAgentTargetInfo && targetInfoTarget
+              ? () => setTargetInfoOpen(true)
+              : undefined
+          }
         >
           <span className={styles.conversationTitleRow}>
-            {conversationIcon?.kind === "mask" ? (
-              <span
-                aria-hidden="true"
-                className={cn(
-                  styles.conversationProviderIcon,
-                  styles.conversationProviderMaskIcon
-                )}
-                style={{
-                  WebkitMaskImage: `url("${conversationIcon.url}")`,
-                  maskImage: `url("${conversationIcon.url}")`
-                }}
-              />
-            ) : conversationIcon ? (
-              <img
-                alt=""
-                aria-hidden="true"
-                className={cn(
-                  styles.conversationProviderIcon,
-                  styles.conversationProviderImage
-                )}
-                draggable={false}
-                src={conversationIcon.url}
-              />
-            ) : null}
+            {conversationIconWithTargetInfo}
             <span className={styles.conversationTitle}>
               {agentGUIConversationRailTitle(item, labels, uiLanguage)}
             </span>

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
@@ -17,7 +17,8 @@ import type { WorkspaceLinkAction } from "../../../actions/workspaceLinkActions"
 import type {
   AgentGUIProvider,
   AgentGUIProviderRailAllPresentation,
-  AgentGUIAgentTarget
+  AgentGUIAgentTarget,
+  AgentGUIAgentTargetInfoRenderer
 } from "../../../types";
 import type { AgentMessageMarkdownWorkspaceAppIcon } from "../../../shared/AgentMessageMarkdown";
 import type { PlanIssueBudgetPreset } from "../../../shared/agentConversation/planImplementationPresentation";
@@ -522,6 +523,8 @@ export interface AgentGUINodeViewProps {
   viewModel: AgentGUINodeViewModel;
   referenceProvenanceFilters?: AgentComposerReferenceProvenanceFilters | null;
   sessionInputHistoryEnabled?: boolean;
+  /** Host-owned presentation for exact Agent targets; tooltip behavior stays AgentGUI-owned. */
+  renderAgentTargetInfo?: AgentGUIAgentTargetInfoRenderer;
   renderProjectDirectoryPickerHeaderActions?: ReferenceSourcePickerProps["renderHeaderActions"];
   renderSidebarFooter?: AgentGUISidebarFooterRenderer;
   /** Renders the provider rail empty state in "exact" mode. See the type doc. */

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIProviderRail.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIProviderRail.spec.tsx
@@ -2,6 +2,7 @@ import { createEvent, fireEvent, render, screen } from "@testing-library/react";
 import { TooltipProvider } from "@tutti-os/ui-system";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentGUIAgentTarget } from "../../../types";
+import { AgentTargetInfoRendererProvider } from "../../../shared/AgentTargetInfoRendererContext";
 import {
   AGENT_GUI_PROVIDER_RAIL_PREFERENCES_STORAGE_KEY,
   parseAgentGUIProviderRailPreferences
@@ -248,6 +249,45 @@ describe("AgentGUIProviderRail selection", () => {
 
     expect(badge).not.toBeNull();
     expect(badge?.querySelector('[data-slot="avatar"]')).not.toBeNull();
+  });
+
+  it("lazily renders exact Host target information for the hovered rail tile", async () => {
+    const sharedTarget = target({
+      agentTargetId: "agent:shared",
+      label: "Shared Codex",
+      ownerDeviceLabel: "Vector's MacBook Pro",
+      provider: "codex",
+      targetId: "shared:codex"
+    });
+    const renderAgentTargetInfo = vi.fn(({ surface, target }) => (
+      <div>{`${surface}:${target.agentTargetId}`}</div>
+    ));
+    render(
+      <TooltipProvider>
+        <AgentTargetInfoRendererProvider
+          agentTargets={[sharedTarget]}
+          renderer={renderAgentTargetInfo}
+        >
+          <AgentGUIProviderRail
+            {...providerRailProps({ agentTargets: [sharedTarget] })}
+          />
+        </AgentTargetInfoRendererProvider>
+      </TooltipProvider>
+    );
+
+    expect(renderAgentTargetInfo).not.toHaveBeenCalled();
+
+    fireEvent.pointerMove(screen.getByRole("tab", { name: "Shared Codex" }), {
+      pointerType: "mouse"
+    });
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "provider-rail:agent:shared"
+    );
+    expect(renderAgentTargetInfo).toHaveBeenLastCalledWith({
+      surface: "provider-rail",
+      target: sharedTarget
+    });
   });
 });
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIProviderRail.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIProviderRail.tsx
@@ -6,7 +6,6 @@ import {
   useState,
   type DragEvent
 } from "react";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@tutti-os/ui-system";
 import {
   createDisabledPlaceholderAgentGUIAgentTarget,
   createLocalAgentGUIAgentTarget
@@ -45,6 +44,8 @@ import styles from "../AgentGUINode.styles";
 import { AgentGUIProviderManagerDialog } from "./AgentGUIProviderManagerDialog";
 import { useAgentGUIProviderRailPreferences } from "./useAgentGUIProviderRailPreferences";
 import { AgentGUIOwnerAvatar } from "../AgentGUIOwnerAvatar";
+import { AgentTargetInfoTooltip } from "../../../shared/AgentTargetInfoTooltip";
+import { useAgentTargetInfoRenderer } from "../../../shared/AgentTargetInfoRendererContext";
 
 const agentGUIProviderRailCatalog = [
   ...migratedAgentGUIProviderIdentityCatalog
@@ -215,6 +216,7 @@ export const AgentGUIProviderRail = memo(function AgentGUIProviderRail({
   } = useAgentGUIProviderRailPreferences();
   const [dragState, setDragState] =
     useState<AgentGUIProviderRailDragState | null>(null);
+  const renderAgentTargetInfo = useAgentTargetInfoRenderer();
   const dragStateRef = useRef<AgentGUIProviderRailDragState | null>(null);
   const setProviderRailDragState = useCallback(
     (nextDragState: AgentGUIProviderRailDragState | null) => {
@@ -756,12 +758,17 @@ export const AgentGUIProviderRail = memo(function AgentGUIProviderRail({
           );
 
           return (
-            <Tooltip key={`${target.provider}:${target.targetId}:tooltip`}>
-              <TooltipTrigger asChild>{tile}</TooltipTrigger>
-              <TooltipContent side="right" sideOffset={-4}>
-                {label}
-              </TooltipContent>
-            </Tooltip>
+            <AgentTargetInfoTooltip
+              key={`${target.provider}:${target.targetId}:tooltip`}
+              fallbackLabel={label}
+              renderer={renderAgentTargetInfo}
+              side="right"
+              sideOffset={-4}
+              surface="provider-rail"
+              target={target}
+            >
+              {tile}
+            </AgentTargetInfoTooltip>
           );
         })}
       </div>

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -5468,6 +5468,19 @@ aside.workspace-agents-status-panel
   border-radius: 5px;
 }
 
+.agent-gui-workbench-header__session-icon-info-trigger {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  border-radius: 5px;
+  pointer-events: auto;
+  -webkit-app-region: no-drag;
+}
+
+.agent-gui-workbench-header__session-icon-info-trigger:focus-visible {
+  outline: auto;
+}
+
 .agent-gui-workbench-header__session-icon--pending {
   background: var(--transparency-block);
   animation: agent-gui-workbench-header-icon-pending 1.2s ease-in-out infinite;

--- a/packages/agent/gui/index.ts
+++ b/packages/agent/gui/index.ts
@@ -123,6 +123,9 @@ export type {
   AgentGUITargetConnectionStatus,
   AgentGUIAgentTarget,
   AgentGUIAgentTargetBadge,
+  AgentGUIAgentTargetInfoRenderContext,
+  AgentGUIAgentTargetInfoRenderer,
+  AgentGUIAgentTargetInfoSurface,
   AgentGUIAgentTargetRef
 } from "./types";
 export {

--- a/packages/agent/gui/shared/AgentTargetInfoRendererContext.tsx
+++ b/packages/agent/gui/shared/AgentTargetInfoRendererContext.tsx
@@ -1,0 +1,68 @@
+import {
+  createContext,
+  useContext,
+  useMemo,
+  type JSX,
+  type ReactNode
+} from "react";
+import type {
+  AgentGUIAgentTarget,
+  AgentGUIAgentTargetInfoRenderer
+} from "../types";
+
+interface AgentTargetInfoRendererContextValue {
+  renderer: AgentGUIAgentTargetInfoRenderer | null;
+  targetsByAgentTargetId: ReadonlyMap<string, AgentGUIAgentTarget>;
+}
+
+const EMPTY_TARGETS_BY_AGENT_TARGET_ID = new Map<string, AgentGUIAgentTarget>();
+
+const AgentTargetInfoRendererContext =
+  createContext<AgentTargetInfoRendererContextValue>({
+    renderer: null,
+    targetsByAgentTargetId: EMPTY_TARGETS_BY_AGENT_TARGET_ID
+  });
+
+export function AgentTargetInfoRendererProvider({
+  agentTargets,
+  children,
+  renderer
+}: {
+  agentTargets: readonly AgentGUIAgentTarget[];
+  children: ReactNode;
+  renderer?: AgentGUIAgentTargetInfoRenderer | null;
+}): JSX.Element {
+  const value = useMemo<AgentTargetInfoRendererContextValue>(() => {
+    const targetsByAgentTargetId = new Map<string, AgentGUIAgentTarget>();
+    for (const target of agentTargets) {
+      const agentTargetId = target.agentTargetId?.trim() ?? "";
+      if (agentTargetId && !targetsByAgentTargetId.has(agentTargetId)) {
+        targetsByAgentTargetId.set(agentTargetId, target);
+      }
+    }
+    return {
+      renderer: renderer ?? null,
+      targetsByAgentTargetId
+    };
+  }, [agentTargets, renderer]);
+
+  return (
+    <AgentTargetInfoRendererContext.Provider value={value}>
+      {children}
+    </AgentTargetInfoRendererContext.Provider>
+  );
+}
+
+export function useAgentTargetInfoRenderer(): AgentGUIAgentTargetInfoRenderer | null {
+  return useContext(AgentTargetInfoRendererContext).renderer;
+}
+
+export function useAgentTargetInfoTarget(
+  agentTargetId: string | null | undefined
+): AgentGUIAgentTarget | null {
+  const normalizedAgentTargetId = agentTargetId?.trim() ?? "";
+  const { targetsByAgentTargetId } = useContext(AgentTargetInfoRendererContext);
+  return normalizedAgentTargetId
+    ? (targetsByAgentTargetId.get(normalizedAgentTargetId) ?? null)
+    : null;
+}

--- a/packages/agent/gui/shared/AgentTargetInfoTooltip.spec.tsx
+++ b/packages/agent/gui/shared/AgentTargetInfoTooltip.spec.tsx
@@ -1,0 +1,47 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@tutti-os/ui-system";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentGUIAgentTargetInfoRenderer } from "../types";
+import { AgentTargetInfoTooltip } from "./AgentTargetInfoTooltip";
+
+afterEach(cleanup);
+
+describe("AgentTargetInfoTooltip", () => {
+  it("lazily uses the target label when the Host renderer returns null", async () => {
+    const renderer: AgentGUIAgentTargetInfoRenderer = vi.fn(() => null);
+
+    render(
+      <TooltipProvider delayDuration={0}>
+        <AgentTargetInfoTooltip
+          fallbackLabel="Shared Codex"
+          renderer={renderer}
+          surface="provider-rail"
+          target={{
+            agentTargetId: "agent:shared",
+            label: "Shared Codex",
+            provider: "codex",
+            ref: { kind: "shared", provider: "codex" },
+            targetId: "shared:codex"
+          }}
+        >
+          <button type="button">Agent information</button>
+        </AgentTargetInfoTooltip>
+      </TooltipProvider>
+    );
+
+    expect(renderer).not.toHaveBeenCalled();
+
+    fireEvent.pointerMove(
+      screen.getByRole("button", { name: "Agent information" }),
+      { pointerType: "mouse" }
+    );
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Shared Codex"
+    );
+    expect(renderer).toHaveBeenCalledWith({
+      surface: "provider-rail",
+      target: expect.objectContaining({ agentTargetId: "agent:shared" })
+    });
+  });
+});

--- a/packages/agent/gui/shared/AgentTargetInfoTooltip.tsx
+++ b/packages/agent/gui/shared/AgentTargetInfoTooltip.tsx
@@ -1,0 +1,80 @@
+import type { ReactElement } from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  cn
+} from "@tutti-os/ui-system";
+import type {
+  AgentGUIAgentTarget,
+  AgentGUIAgentTargetInfoRenderer,
+  AgentGUIAgentTargetInfoSurface
+} from "../types";
+
+interface AgentTargetInfoTooltipProps {
+  align?: "center" | "end" | "start";
+  children: ReactElement;
+  fallbackLabel: string;
+  onOpenChange?: (open: boolean) => void;
+  open?: boolean;
+  renderer?: AgentGUIAgentTargetInfoRenderer | null;
+  side?: "bottom" | "left" | "right" | "top";
+  sideOffset?: number;
+  surface: AgentGUIAgentTargetInfoSurface;
+  target: AgentGUIAgentTarget;
+}
+
+export function AgentTargetInfoTooltip({
+  align,
+  children,
+  fallbackLabel,
+  onOpenChange,
+  open,
+  renderer,
+  side,
+  sideOffset,
+  surface,
+  target
+}: AgentTargetInfoTooltipProps): React.JSX.Element {
+  return (
+    <Tooltip open={open} onOpenChange={onOpenChange}>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent
+        align={align}
+        className={cn(renderer && "items-stretch p-0")}
+        side={side}
+        sideOffset={sideOffset}
+      >
+        {renderer ? (
+          <AgentTargetInfoContent
+            fallbackLabel={fallbackLabel}
+            renderer={renderer}
+            surface={surface}
+            target={target}
+          />
+        ) : (
+          fallbackLabel
+        )}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function AgentTargetInfoContent({
+  fallbackLabel,
+  renderer,
+  surface,
+  target
+}: {
+  fallbackLabel: string;
+  renderer: AgentGUIAgentTargetInfoRenderer;
+  surface: AgentGUIAgentTargetInfoSurface;
+  target: AgentGUIAgentTarget;
+}): React.JSX.Element {
+  const content = renderer({ surface, target });
+  return content ? (
+    <>{content}</>
+  ) : (
+    <span className="px-2 py-1">{fallbackLabel}</span>
+  );
+}

--- a/packages/agent/gui/types.ts
+++ b/packages/agent/gui/types.ts
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { ReactElement } from "react";
 import type { AgentRuntimeStatus } from "./contexts/agent/domain/types";
 import type {
   AgentSettings,
@@ -252,7 +252,7 @@ export interface AgentGUIAgentTargetInfoRenderContext {
  */
 export type AgentGUIAgentTargetInfoRenderer = (
   context: AgentGUIAgentTargetInfoRenderContext
-) => ReactNode;
+) => ReactElement | null;
 
 export type AgentGUITargetConnectionStatus =
   | "connected"

--- a/packages/agent/gui/types.ts
+++ b/packages/agent/gui/types.ts
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import type { AgentRuntimeStatus } from "./contexts/agent/domain/types";
 import type {
   AgentSettings,
@@ -227,6 +228,31 @@ export interface AgentGUIAgentTarget {
   disabled?: boolean;
   unavailableReason?: string;
 }
+
+/**
+ * Product-neutral surfaces where a Host may enrich an exact Agent target.
+ * AgentGUI owns the trigger, positioning, and interaction behavior; the Host
+ * owns only the rendered information.
+ */
+export type AgentGUIAgentTargetInfoSurface =
+  | "provider-rail"
+  | "conversation-rail"
+  | "workbench-header";
+
+export interface AgentGUIAgentTargetInfoRenderContext {
+  surface: AgentGUIAgentTargetInfoSurface;
+  target: AgentGUIAgentTarget;
+}
+
+/**
+ * Renders Host-owned presentation for an exact Agent target.
+ *
+ * AgentGUI invokes this renderer lazily only while its tooltip content is
+ * mounted. Returning null preserves the built-in target-label fallback.
+ */
+export type AgentGUIAgentTargetInfoRenderer = (
+  context: AgentGUIAgentTargetInfoRenderContext
+) => ReactNode;
 
 export type AgentGUITargetConnectionStatus =
   | "connected"

--- a/packages/agent/gui/workbench/conversationIdentity.test.ts
+++ b/packages/agent/gui/workbench/conversationIdentity.test.ts
@@ -114,6 +114,59 @@ describe("resolveAgentGuiWorkbenchTitleDisplayPrompt", () => {
   });
 });
 
+describe("resolveAgentGuiWorkbenchConversationIdentity", () => {
+  it("preserves the exact Session Agent target for Host header presentation", () => {
+    const engine = createAgentSessionEngine({
+      clock: { nowUnixMs: () => 1 },
+      commandPort: { execute: async () => ({}) },
+      identity: { origin: "test", workspaceId: "workspace-1" },
+      scheduler: { schedule: () => ({ cancel() {} }) }
+    });
+    engine.dispatch({
+      type: "session/snapshotReceived",
+      sessions: [
+        {
+          activeTurnId: null,
+          agentSessionId: "session-1",
+          agentTargetId: "agent:shared",
+          createdAtUnixMs: 1,
+          cwd: "/workspace",
+          latestTurnInteractions: [],
+          pendingInteractions: [],
+          provider: "codex",
+          title: "Shared session",
+          updatedAtUnixMs: 1,
+          workspaceId: "workspace-1"
+        }
+      ]
+    });
+
+    expect(
+      resolveAgentGuiWorkbenchConversationIdentity({
+        agents: [
+          {
+            agentTargetId: "agent:shared",
+            availability: { status: "ready" },
+            iconUrl: "shared.png",
+            name: "Shared Codex",
+            provider: "codex"
+          }
+        ],
+        engineState: engine.getSnapshot(),
+        workbenchState: {
+          agentTargetId: "agent:sibling",
+          lastActiveAgentSessionId: "session-1"
+        }
+      })
+    ).toEqual(
+      expect.objectContaining({
+        agentTargetId: "agent:shared",
+        agentTitle: "Shared Codex"
+      })
+    );
+  });
+});
+
 function userMessage(prompt: string): AgentActivityMessage {
   return {
     agentSessionId: "session-1",

--- a/packages/agent/gui/workbench/conversationIdentity.ts
+++ b/packages/agent/gui/workbench/conversationIdentity.ts
@@ -24,6 +24,7 @@ import type {
 } from "./types.ts";
 
 export interface AgentGuiWorkbenchConversationIdentity {
+  agentTargetId?: string | null;
   agentTitle?: string | null;
   iconUrl?: string | null;
   title: string | null;
@@ -96,6 +97,7 @@ export function resolveAgentGuiWorkbenchConversationIdentity(input: {
       : null);
 
   return {
+    agentTargetId,
     agentTitle,
     iconUrl,
     title,
@@ -125,6 +127,7 @@ export function agentGuiWorkbenchConversationIdentitiesEqual(
     left === right ||
     (left !== null &&
       right !== null &&
+      left.agentTargetId === right.agentTargetId &&
       left.agentTitle === right.agentTitle &&
       left.iconUrl === right.iconUrl &&
       left.title === right.title &&

--- a/packages/agent/gui/workbench/header.spec.tsx
+++ b/packages/agent/gui/workbench/header.spec.tsx
@@ -89,6 +89,7 @@ describe("AgentGuiWorkbenchHeader conversation identity", () => {
   it.each([false, true])(
     "lazily renders exact Host target information for the session icon when collapsed is %s",
     async (isConversationRailCollapsed) => {
+      const onHeaderPointerDown = vi.fn();
       const conversationAgentTarget: AgentGUIAgentTarget = {
         agentTargetId: "agent:shared",
         iconUrl: "shared-agent.png",
@@ -118,15 +119,28 @@ describe("AgentGuiWorkbenchHeader conversation identity", () => {
           renderAgentTargetInfo={renderAgentTargetInfo}
           showConversationRailToggle={false}
           showWindowControls={false}
+          onPointerDown={onHeaderPointerDown}
           onToggleConversationRail={vi.fn()}
         />
       );
 
       expect(renderAgentTargetInfo).not.toHaveBeenCalled();
 
-      const trigger = screen.getByLabelText("Shared Codex");
-      fireEvent.pointerMove(trigger, { pointerType: "mouse" });
+      const trigger = screen.getByRole("img", { name: "Shared Codex" });
+      fireEvent.focus(trigger);
+      const focusTooltip = await screen.findByRole("tooltip");
+      expect(focusTooltip).toHaveTextContent("workbench-header:agent:shared");
+      expect(trigger).toHaveAttribute("aria-describedby", focusTooltip.id);
+      expect(trigger).toHaveAttribute("tabindex", "0");
 
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(screen.queryByRole("tooltip")).toBeNull();
+
+      fireEvent.blur(trigger);
+      fireEvent.pointerDown(trigger);
+      expect(onHeaderPointerDown).not.toHaveBeenCalled();
+      fireEvent.pointerUp(trigger);
+      fireEvent.pointerMove(trigger, { pointerType: "mouse" });
       expect(await screen.findByRole("tooltip")).toHaveTextContent(
         "workbench-header:agent:shared"
       );
@@ -134,7 +148,6 @@ describe("AgentGuiWorkbenchHeader conversation identity", () => {
         surface: "workbench-header",
         target: conversationAgentTarget
       });
-      expect(trigger).toHaveAttribute("tabindex", "0");
     }
   );
 

--- a/packages/agent/gui/workbench/header.spec.tsx
+++ b/packages/agent/gui/workbench/header.spec.tsx
@@ -1,5 +1,6 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentGUIAgentTarget } from "../types";
 import { AgentGuiWorkbenchHeader } from "./header";
 
 afterEach(cleanup);
@@ -83,5 +84,91 @@ describe("AgentGuiWorkbenchHeader conversation identity", () => {
       header?.style.getPropertyValue("--agent-gui-tool-sidebar-layout-width")
     ).toBe("432px");
     expect(screen.getByText("Host-owned tools")).toBeTruthy();
+  });
+
+  it.each([false, true])(
+    "lazily renders exact Host target information for the session icon when collapsed is %s",
+    async (isConversationRailCollapsed) => {
+      const conversationAgentTarget: AgentGUIAgentTarget = {
+        agentTargetId: "agent:shared",
+        iconUrl: "shared-agent.png",
+        label: "Shared Codex",
+        provider: "codex",
+        ref: { kind: "shared", provider: "codex" },
+        targetId: "shared:codex"
+      };
+      const renderAgentTargetInfo = vi.fn(({ surface, target }) => (
+        <div>{`${surface}:${target.agentTargetId}`}</div>
+      ));
+      render(
+        <AgentGuiWorkbenchHeader
+          conversationAgentTarget={conversationAgentTarget}
+          conversationIconUrl="shared-agent.png"
+          conversationTitle="Investigate skills"
+          copy={{
+            collapseConversationRail: "Collapse",
+            expandConversationRail: "Expand",
+            fallbackAgentLabel: "Agent",
+            newConversation: "New conversation"
+          }}
+          hasConversation
+          isConversationRailAutoCollapsed={false}
+          isConversationRailCollapsed={isConversationRailCollapsed}
+          nodeId="shared-agent-gui"
+          renderAgentTargetInfo={renderAgentTargetInfo}
+          showConversationRailToggle={false}
+          showWindowControls={false}
+          onToggleConversationRail={vi.fn()}
+        />
+      );
+
+      expect(renderAgentTargetInfo).not.toHaveBeenCalled();
+
+      const trigger = screen.getByLabelText("Shared Codex");
+      fireEvent.pointerMove(trigger, { pointerType: "mouse" });
+
+      expect(await screen.findByRole("tooltip")).toHaveTextContent(
+        "workbench-header:agent:shared"
+      );
+      expect(renderAgentTargetInfo).toHaveBeenLastCalledWith({
+        surface: "workbench-header",
+        target: conversationAgentTarget
+      });
+      expect(trigger).toHaveAttribute("tabindex", "0");
+    }
+  );
+
+  it("does not add interactive icon chrome without a Host renderer", () => {
+    render(
+      <AgentGuiWorkbenchHeader
+        conversationAgentTarget={{
+          agentTargetId: "agent:local",
+          label: "Local Codex",
+          provider: "codex",
+          ref: { kind: "local", provider: "codex" },
+          targetId: "local:codex"
+        }}
+        conversationIconUrl="local-agent.png"
+        conversationTitle="Local session"
+        copy={{
+          collapseConversationRail: "Collapse",
+          expandConversationRail: "Expand",
+          fallbackAgentLabel: "Agent",
+          newConversation: "New conversation"
+        }}
+        hasConversation
+        isConversationRailAutoCollapsed={false}
+        isConversationRailCollapsed={false}
+        nodeId="local-agent-gui"
+        showConversationRailToggle={false}
+        showWindowControls={false}
+        onToggleConversationRail={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByLabelText("Local Codex")).toBeNull();
+    expect(
+      screen.getByTestId("agent-gui-window-detail-title-icon")
+    ).toBeInTheDocument();
   });
 });

--- a/packages/agent/gui/workbench/header.ts
+++ b/packages/agent/gui/workbench/header.ts
@@ -23,6 +23,11 @@ import {
 import { CreateChatIcon } from "@tutti-os/ui-system/icons";
 import openLinkLinedIconUrl from "../app/renderer/assets/icons/open-link-lined.svg";
 import { useAgentGuiWorkbenchBodyRenderError } from "./bodyRenderErrorRegistry.ts";
+import { AgentTargetInfoTooltip } from "../shared/AgentTargetInfoTooltip.tsx";
+import type {
+  AgentGUIAgentTarget,
+  AgentGUIAgentTargetInfoRenderer
+} from "../types.ts";
 import { AgentGuiWorkbenchSessionMenu } from "./AgentGuiWorkbenchSessionMenu.tsx";
 import type {
   AgentGuiWorkbenchSessionAction,
@@ -72,6 +77,7 @@ export interface AgentGuiWorkbenchHeaderProps extends HTMLAttributes<HTMLElement
   conversationRailWidthPx?: number | null;
   conversationIconUrl?: string | null;
   conversationIconFallbackUrl?: string | null;
+  conversationAgentTarget?: AgentGUIAgentTarget | null;
   hasConversation?: boolean;
   providerRailWidthPx?: number | null;
   primaryAccessory?: ReactNode;
@@ -86,6 +92,7 @@ export interface AgentGuiWorkbenchHeaderProps extends HTMLAttributes<HTMLElement
   onOpenDetachedWindow?: () => void;
   onSessionAction?: (action: AgentGuiWorkbenchSessionAction) => void;
   onToggleConversationRail: (nextCollapsed: boolean) => void;
+  renderAgentTargetInfo?: AgentGUIAgentTargetInfoRenderer;
   showAppTitle?: boolean;
   showConversationRailToggle?: boolean;
   showWindowControls?: boolean;
@@ -107,6 +114,7 @@ export function AgentGuiWorkbenchHeader({
   conversationRailWidthPx,
   conversationIconUrl,
   conversationIconFallbackUrl,
+  conversationAgentTarget = null,
   hasConversation = false,
   providerRailWidthPx,
   primaryAccessory,
@@ -121,6 +129,7 @@ export function AgentGuiWorkbenchHeader({
   onOpenDetachedWindow,
   onSessionAction,
   onToggleConversationRail,
+  renderAgentTargetInfo,
   showAppTitle = true,
   showConversationRailToggle = true,
   showWindowControls = true,
@@ -306,7 +315,9 @@ export function AgentGuiWorkbenchHeader({
               className: "agent-gui-workbench-header__session-title"
             },
             createSessionHeaderIconSlot({
+              agentTarget: conversationAgentTarget,
               fallbackSrc: sessionIconFallbackUrl,
+              renderAgentTargetInfo,
               src: sessionIconUrl,
               testId: "agent-gui-window-session-icon"
             }),
@@ -345,7 +356,9 @@ export function AgentGuiWorkbenchHeader({
                   "data-testid": "agent-gui-window-detail-title"
                 },
                 createSessionHeaderIconSlot({
+                  agentTarget: conversationAgentTarget,
                   fallbackSrc: sessionIconFallbackUrl,
+                  renderAgentTargetInfo,
                   src: sessionIconUrl,
                   testId: "agent-gui-window-detail-title-icon"
                 }),
@@ -538,31 +551,63 @@ function createNewConversationButton({
 }
 
 function createSessionHeaderIconSlot({
+  agentTarget,
   src,
   fallbackSrc,
+  renderAgentTargetInfo,
   testId
 }: {
+  agentTarget: AgentGUIAgentTarget | null;
   src: string;
   fallbackSrc: string;
+  renderAgentTargetInfo?: AgentGUIAgentTargetInfoRenderer;
   testId: string;
 }): ReactNode {
   // While the session's provider is still resolving (e.g. a freshly created
   // session) there is no icon URL yet. Render a neutral skeleton block rather
   // than flashing a wrong/default provider icon; it is replaced once the real
   // icon arrives.
-  if (!src) {
-    return createElement("span", {
-      "aria-hidden": "true",
-      className:
-        "agent-gui-workbench-header__session-icon agent-gui-workbench-header__session-icon--pending",
-      "data-testid": `${testId}-pending`
-    });
+  const icon = !src
+    ? createElement("span", {
+        "aria-hidden": "true",
+        className:
+          "agent-gui-workbench-header__session-icon agent-gui-workbench-header__session-icon--pending",
+        "data-testid": `${testId}-pending`
+      })
+    : createElement(SessionHeaderIcon, {
+        key: `${src}::${fallbackSrc}`,
+        fallbackSrc,
+        src,
+        testId
+      });
+
+  if (!agentTarget || !renderAgentTargetInfo) {
+    return icon;
   }
-  return createElement(SessionHeaderIcon, {
-    key: `${src}::${fallbackSrc}`,
-    fallbackSrc,
-    src,
-    testId
+
+  const trigger = createElement(
+    "span",
+    {
+      "aria-label": agentTarget.label,
+      className: "agent-gui-workbench-header__session-icon-info-trigger",
+      tabIndex: 0
+    },
+    icon
+  );
+
+  return createElement(TooltipProvider, {
+    delayDuration: 0,
+    skipDelayDuration: 0,
+    children: createElement(AgentTargetInfoTooltip, {
+      align: "start",
+      fallbackLabel: agentTarget.label,
+      renderer: renderAgentTargetInfo,
+      side: "bottom",
+      sideOffset: 6,
+      surface: "workbench-header",
+      target: agentTarget,
+      children: trigger
+    })
   });
 }
 

--- a/packages/agent/gui/workbench/header.ts
+++ b/packages/agent/gui/workbench/header.ts
@@ -590,7 +590,10 @@ function createSessionHeaderIconSlot({
     {
       "aria-label": agentTarget.label,
       className: "agent-gui-workbench-header__session-icon-info-trigger",
-      tabIndex: 0
+      role: "img",
+      tabIndex: 0,
+      onDoubleClick: (event) => event.stopPropagation(),
+      onPointerDown: (event) => event.stopPropagation()
     },
     icon
   );


### PR DESCRIPTION
## What changed

- add an optional, product-neutral `agentTargetInfo` render slot that receives the exact `AgentGUIAgentTarget` and surface
- centralize tooltip mechanics for provider rail, conversation history icons, and Workbench Header session icons
- preserve the exact `agentTargetId` in Workbench conversation identity and resolve history targets through an indexed directory context
- render host content lazily only while the tooltip is mounted; hosts that do not provide the slot keep the existing label tooltip and DOM behavior
- associate keyboard focus with accessible tooltip content and prevent Header identity interactions from entering the window drag path
- define the host renderer contract as one React element or `null` for the built-in fallback
- document the public contract and add a minor changeset for `@tutti-os/agent-gui`

## Why

Host products need to enrich shared Agent identity with owner, device, and availability metadata without duplicating tooltip mechanics or inspecting AgentGUI DOM. The shared package should own interaction and exact-target routing, while each host remains responsible for product-specific card presentation.

This is presentation behavior, not Session/Turn/Goal/runtime-operation lifecycle semantics. TSH is the first external consumer, which is why the product-neutral contract lives in AgentGUI rather than in a host adapter.

## Impact and risks

- Public API: adds an optional render slot and surface/context types
- Affected surfaces: provider rail, conversation rail items, collapsed and expanded Workbench Header identity
- Existing hosts remain unchanged unless they explicitly provide the renderer
- Missing or stale `agentTargetId` fails closed to the existing presentation; provider names and titles are never used as identity fallbacks

## Verification

- full AgentGUI suite — 291 files / 2446 tests passed
- focused pointer, focus, blur, Escape, accessible-description, and Header drag-isolation suite — 3 files / 24 tests passed after review fixes
- `pnpm typecheck` — 32 packages passed
- `pnpm check:changed -- --push-ready` — 13 selected lanes passed twice, including the pre-push hook
- pre-commit formatting, Oxlint, UI/renderer boundary, AgentGUI degradation, and runtime image budget checks passed

## Documentation

- updated `docs/architecture/agent-gui-node.md`
- updated `packages/agent/gui/README.md`