### PR TITLE
fix(agent): restore Codex subagent session projection

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -242,6 +242,12 @@ Provider-native subagents use child Sessions:
 - `parentToolCallId`: delegation card correlation
 - child messages, Turns, and Interactions retain the child owner
 
+A provider adapter must normalize explicit spawn evidence into both the parent
+delegation call and the canonical child Session/Turn. AgentGUI attaches the
+child lane only through the immutable `parentToolCallId`; it must not parse
+provider-native spawn events, invent a missing parent card, or create a
+presentation-only child lane.
+
 ### 3.2 Turn
 
 One user submission or provider continuation belongs to one canonical Turn.

--- a/docs/conventions/troubleshooting/agent-approvals-subagents.md
+++ b/docs/conventions/troubleshooting/agent-approvals-subagents.md
@@ -113,6 +113,25 @@ session-level child summaries.
 - Validate: inject root, known-child, and unknown-thread notifications in one
   run; assert three distinct routing outcomes.
 
+### Codex subagents ran but AgentGUI shows no child lanes
+
+- Symptom: Codex rollout data contains child threads, but the canonical store
+  has no child sessions and AgentGUI shows only the root conversation.
+- Check: compare `thread/read(includeTurns=true)` spawn items with
+  `workspace_agent_sessions`. A current Codex app-server may report a spawn as
+  `subAgentActivity(kind=started, id, agentThreadId)` instead of
+  `collabAgentToolCall(tool=spawnAgent, receiverThreadIds)`.
+- Cause: the adapter recognized only one provider-native spawn representation,
+  so it persisted neither the parent delegation card nor the child
+  Session/Turn. This is an adapter normalization gap, not an AgentGUI lane
+  projection bug.
+- Fix: normalize both explicit representations into the same parent call and
+  canonical child relation. Keep duplicate notifications idempotent and retain
+  the existing post-cancel interrupt boundary.
+- Validate: replay the exact observed item shape; assert parent call plus child
+  Session/Turn creation, duplicate suppression, and late-child interruption
+  after root cancellation.
+
 ### Claude SDK child events overwrite or complete the root turn
 
 - Symptom: a child result replaces the root answer, the root completes while a

--- a/docs/specs/2026-07-15-provider-native-subagents.md
+++ b/docs/specs/2026-07-15-provider-native-subagents.md
@@ -440,14 +440,20 @@ Native concepts:
 - Root conversation: app-server `threadId` equal to
   `workspace_agent_sessions.provider_session_id`.
 - Child agent: child app-server `threadId`.
-- Spawn edge: `collabAgentToolCall` with `tool=spawnAgent` and
-  `receiverThreadIds`.
+- Spawn edge: either `collabAgentToolCall` with `tool=spawnAgent` and
+  `receiverThreadIds`, or `subAgentActivity` with `kind=started`,
+  `id=<parent tool call id>`, and `agentThreadId=<child thread id>`.
 - Control tools: `Wait` / `CloseAgent` style `collabAgentToolCall` entries.
 
 Mapping:
 
-- The spawn tool call creates one subordinate `WorkspaceAgentSession` per
-  receiver thread id and a submitted child turn owned by that session.
+- Either spawn representation creates the normalized parent delegation call,
+  one subordinate `WorkspaceAgentSession` per child thread id, and a submitted
+  child turn owned by that session. If app-server reports the same edge more
+  than once, registration and normalized events remain idempotent.
+- A `subAgentActivity` `started` item means the provider accepted the spawn, so
+  its normalized parent delegation call is completed. The child thread's own
+  events remain authoritative for the child turn lifecycle.
 - `threadId != root provider_session_id` events are child events only after
   the child thread has been registered from a spawn edge.
 - App-server server requests use the same `threadId` ownership rule as

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -2683,38 +2683,62 @@ func TestCodexAppServerAdapterCancelInterruptsLateUnownedRootTurn(t *testing.T) 
 }
 
 func TestCodexAppServerAdapterCancelInterruptsLateChildWithoutCreatingSession(t *testing.T) {
-	adapter, transport, session := startedAppServerAdapter(t)
-	adapter.markRootTurnCanceled(session.AgentSessionID, "root-turn-1")
-	appSession := adapter.getSession(session.AgentSessionID)
-
-	reduction := newCodexAppServerReducer(adapter).ReduceNotification(appSession.client, session, "root-turn-1", acpMessage{
-		Method: appServerNotifyItemCompleted,
-		Params: mustJSONRawMessage(t, map[string]any{
-			"threadId": session.ProviderSessionID,
-			"turnId":   "provider-turn-1",
-			"item": map[string]any{
+	items := []struct {
+		name string
+		item map[string]any
+	}{
+		{
+			name: "collaboration tool call",
+			item: map[string]any{
 				"type":              "collabAgentToolCall",
 				"id":                "spawn-after-cancel",
 				"tool":              "spawnAgent",
 				"status":            "completed",
 				"receiverThreadIds": []any{"child-after-cancel"},
 			},
-		}),
-	}, newACPTurnNormalizer(), nil)
-	if len(reduction.Events) != 0 {
-		t.Fatalf("late child events = %#v, want none", reduction.Events)
+		},
+		{
+			name: "sub-agent activity",
+			item: map[string]any{
+				"type":          "subAgentActivity",
+				"id":            "spawn-after-cancel",
+				"agentThreadId": "child-after-cancel",
+				"agentPath":     "/root/reviewer",
+				"kind":          "started",
+			},
+		},
 	}
-	if _, ok := adapter.appServerChildThread(session.AgentSessionID, "child-after-cancel"); ok {
-		t.Fatal("late child received a canonical child session context")
-	}
-	waitForCondition(t, func() bool {
-		for _, request := range appServerRequestParamsList(t, transport.conn, appServerMethodTurnInterrupt) {
-			if asString(request["threadId"]) == "child-after-cancel" {
-				return true
+
+	for _, test := range items {
+		t.Run(test.name, func(t *testing.T) {
+			adapter, transport, session := startedAppServerAdapter(t)
+			adapter.markRootTurnCanceled(session.AgentSessionID, "root-turn-1")
+			appSession := adapter.getSession(session.AgentSessionID)
+
+			reduction := newCodexAppServerReducer(adapter).ReduceNotification(appSession.client, session, "root-turn-1", acpMessage{
+				Method: appServerNotifyItemCompleted,
+				Params: mustJSONRawMessage(t, map[string]any{
+					"threadId": session.ProviderSessionID,
+					"turnId":   "provider-turn-1",
+					"item":     test.item,
+				}),
+			}, newACPTurnNormalizer(), nil)
+			if len(reduction.Events) != 0 {
+				t.Fatalf("late child events = %#v, want none", reduction.Events)
 			}
-		}
-		return false
-	})
+			if _, ok := adapter.appServerChildThread(session.AgentSessionID, "child-after-cancel"); ok {
+				t.Fatal("late child received a canonical child session context")
+			}
+			waitForCondition(t, func() bool {
+				for _, request := range appServerRequestParamsList(t, transport.conn, appServerMethodTurnInterrupt) {
+					if asString(request["threadId"]) == "child-after-cancel" {
+						return true
+					}
+				}
+				return false
+			})
+		})
+	}
 }
 
 func TestCodexAppServerAdapterNewCanonicalTurnClearsCancelBoundary(t *testing.T) {

--- a/packages/agent/daemon/runtime/codex_appserver_event_items.go
+++ b/packages/agent/daemon/runtime/codex_appserver_event_items.go
@@ -305,6 +305,22 @@ func appServerItemToolCallUpdate(item map[string]any, completed bool) (map[strin
 				)
 			}
 		}
+	case "subAgentActivity":
+		if asString(item["kind"]) != "started" {
+			return nil, false
+		}
+		childThreadID := strings.TrimSpace(asString(item["agentThreadId"]))
+		if childThreadID == "" {
+			return nil, false
+		}
+		update["sessionUpdate"] = "tool_call_update"
+		update["status"] = messageStreamStateCompleted
+		update["title"] = "spawnAgent"
+		update["kind"] = "execute"
+		update["rawInput"] = map[string]any{
+			"agentName":         "spawnAgent",
+			"receiverThreadIds": []any{childThreadID},
+		}
 	case "imageGeneration":
 		update["title"] = "Generate image"
 		update["kind"] = "other"
@@ -412,10 +428,11 @@ func appServerOutputText(value any) string {
 }
 
 type appServerNotificationRoute struct {
-	session    Session
-	child      *codexAppServerThreadContext
-	turnID     string
-	normalizer *acpTurnNormalizer
-	events     []activityshared.Event
-	drop       bool
+	session              Session
+	child                *codexAppServerThreadContext
+	turnID               string
+	normalizer           *acpTurnNormalizer
+	events               []activityshared.Event
+	registeredChildCount int
+	drop                 bool
 }

--- a/packages/agent/daemon/runtime/codex_appserver_event_routing.go
+++ b/packages/agent/daemon/runtime/codex_appserver_event_routing.go
@@ -29,7 +29,10 @@ func (a *CodexAppServerAdapter) appServerNotificationRoute(
 		if len(added) > 0 {
 			a.scheduleChildNicknameFetches(session, added)
 		}
-		return appServerNotificationRoute{events: events}
+		return appServerNotificationRoute{
+			events:               events,
+			registeredChildCount: len(added),
+		}
 	}
 
 	child, ok := a.appServerChildThread(session.AgentSessionID, eventThreadID)
@@ -72,11 +75,12 @@ func (a *CodexAppServerAdapter) appServerNotificationRoute(
 		a.storeAppServerChildThread(session.AgentSessionID, eventThreadID, child)
 	}
 	return appServerNotificationRoute{
-		session:    eventSession,
-		child:      child,
-		turnID:     child.turnID,
-		normalizer: child.normalizer,
-		events:     prefixEvents,
+		session:              eventSession,
+		child:                child,
+		turnID:               child.turnID,
+		normalizer:           child.normalizer,
+		events:               prefixEvents,
+		registeredChildCount: len(added),
 	}
 }
 
@@ -131,21 +135,13 @@ func (a *CodexAppServerAdapter) rememberAppServerChildThreads(
 	parentTurnID string,
 	item map[string]any,
 ) ([]string, []activityshared.Event) {
-	if asString(item["type"]) != "collabAgentToolCall" {
+	spawn, ok := appServerChildSpawnEvidenceFromItem(item)
+	if !ok {
 		return nil, nil
 	}
-	childThreadIDs := appServerReceiverThreadIDs(item["receiverThreadIds"])
-	if len(childThreadIDs) == 0 {
-		return nil, nil
-	}
+	childThreadIDs := spawn.childThreadIDs
 	parentThreadID = strings.TrimSpace(parentThreadID)
-	parentItemID := strings.TrimSpace(asString(item["id"]))
-	// Wait/close cards reference existing children but are not delegation
-	// edges. A durable child is created only from the spawn card that supplies
-	// its immutable parent tool-call id.
-	if appServerAgentControlToolName(asString(item["tool"])) != "" {
-		return nil, nil
-	}
+	parentItemID := spawn.parentItemID
 	rootAgentSessionID = strings.TrimSpace(rootAgentSessionID)
 	rootTurnID = strings.TrimSpace(rootTurnID)
 	parentAgentSessionID = strings.TrimSpace(parentAgentSessionID)
@@ -238,6 +234,49 @@ func (a *CodexAppServerAdapter) rememberAppServerChildThreads(
 		}
 	}
 	return added, events
+}
+
+type appServerChildSpawnEvidence struct {
+	parentItemID   string
+	childThreadIDs []string
+}
+
+func appServerChildSpawnEvidenceFromItem(item map[string]any) (appServerChildSpawnEvidence, bool) {
+	parentItemID := strings.TrimSpace(asString(item["id"]))
+	if parentItemID == "" {
+		return appServerChildSpawnEvidence{}, false
+	}
+	switch asString(item["type"]) {
+	case "collabAgentToolCall":
+		// Wait/close cards reference existing children but are not delegation
+		// edges. A durable child is created only from a spawn-shaped card that
+		// supplies its immutable parent tool-call id.
+		if appServerAgentControlToolName(asString(item["tool"])) != "" {
+			return appServerChildSpawnEvidence{}, false
+		}
+		childThreadIDs := appServerReceiverThreadIDs(item["receiverThreadIds"])
+		if len(childThreadIDs) == 0 {
+			return appServerChildSpawnEvidence{}, false
+		}
+		return appServerChildSpawnEvidence{
+			parentItemID:   parentItemID,
+			childThreadIDs: childThreadIDs,
+		}, true
+	case "subAgentActivity":
+		if asString(item["kind"]) != "started" {
+			return appServerChildSpawnEvidence{}, false
+		}
+		childThreadID := strings.TrimSpace(asString(item["agentThreadId"]))
+		if childThreadID == "" {
+			return appServerChildSpawnEvidence{}, false
+		}
+		return appServerChildSpawnEvidence{
+			parentItemID:   parentItemID,
+			childThreadIDs: []string{childThreadID},
+		}, true
+	default:
+		return appServerChildSpawnEvidence{}, false
+	}
 }
 
 func (a *CodexAppServerAdapter) appServerChildThread(agentSessionID string, childThreadID string) (*codexAppServerThreadContext, bool) {

--- a/packages/agent/daemon/runtime/codex_appserver_events_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_events_test.go
@@ -441,6 +441,79 @@ func TestCodexAppServerAdapterRoutesLinkedChildThreadEvents(t *testing.T) {
 	}
 }
 
+func TestCodexAppServerAdapterRegistersSubAgentActivityChild(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewCodexAppServerAdapter(nil)
+	session := Session{
+		AgentSessionID:    "agent-session-1",
+		Provider:          ProviderCodex,
+		ProviderSessionID: "parent-thread-1",
+		CWD:               "/workspace",
+	}
+	adapter.storeSession(session.AgentSessionID, &codexAppServerSession{threadID: session.ProviderSessionID})
+	reducer := newCodexAppServerReducer(adapter)
+	normalizer := newACPTurnNormalizer()
+	notification := acpMessage{
+		Method: appServerNotifyItemCompleted,
+		Params: mustJSONRawMessage(t, map[string]any{
+			"threadId": session.ProviderSessionID,
+			"turnId":   "parent-turn-1",
+			"item": map[string]any{
+				"type":          "subAgentActivity",
+				"id":            "spawn-child-1",
+				"agentThreadId": "child-thread-1",
+				"agentPath":     "/root/reviewer",
+				"kind":          "started",
+			},
+		}),
+	}
+
+	events := reducer.ReduceNotification(
+		nil,
+		session,
+		"parent-turn-1",
+		notification,
+		normalizer,
+		nil,
+	).Events
+	if len(events) != 2 {
+		t.Fatalf("subAgentActivity events = %#v, want child creation and completed parent tool call", events)
+	}
+	childStarted := events[0]
+	if childStarted.Type != activityshared.EventSessionStarted ||
+		childStarted.SessionKind != "child" ||
+		childStarted.ProviderSessionID != "child-thread-1" ||
+		childStarted.ParentToolCallID != "spawn-child-1" {
+		t.Fatalf("child start = %#v", childStarted)
+	}
+	parentCall := events[1]
+	parentCallInput := payloadMap(parentCall.Payload.Metadata, "input")
+	if parentCall.Type != activityshared.EventCallCompleted ||
+		parentCall.AgentSessionID != session.AgentSessionID ||
+		parentCall.Payload.CallID != "spawn-child-1" ||
+		parentCall.Payload.Name != "spawnAgent" ||
+		parentCallInput["agentName"] != "spawnAgent" {
+		t.Fatalf("parent spawn call = %#v", parentCall)
+	}
+	child, ok := adapter.appServerChildThread(session.AgentSessionID, "child-thread-1")
+	if !ok || child.parentItemID != "spawn-child-1" || child.parentAgentSessionID != session.AgentSessionID {
+		t.Fatalf("registered child = %#v (ok=%v)", child, ok)
+	}
+
+	duplicate := reducer.ReduceNotification(
+		nil,
+		session,
+		"parent-turn-1",
+		notification,
+		normalizer,
+		nil,
+	).Events
+	if len(duplicate) != 0 {
+		t.Fatalf("duplicate subAgentActivity events = %#v, want none", duplicate)
+	}
+}
+
 func TestCodexAppServerAdapterRoutesChildFileChangeApprovalWithChildInput(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/codex_appserver_reducer.go
+++ b/packages/agent/daemon/runtime/codex_appserver_reducer.go
@@ -194,9 +194,17 @@ func (r codexAppServerReducer) reduceNotification(
 		}
 		return emit(normalizer.AppendThinkingChunk(session, turnID, appServerReasoningDeltaText(params)))
 	case appServerNotifyItemStarted:
-		return emit(a.appServerItemEvents(session, turnID, payloadObject(params["item"]), false, normalizer))
+		item := payloadObject(params["item"])
+		if asString(item["type"]) == "subAgentActivity" && route.registeredChildCount == 0 {
+			return emit(nil)
+		}
+		return emit(a.appServerItemEvents(session, turnID, item, false, normalizer))
 	case appServerNotifyItemCompleted:
-		return emit(a.appServerItemEvents(session, turnID, payloadObject(params["item"]), true, normalizer))
+		item := payloadObject(params["item"])
+		if asString(item["type"]) == "subAgentActivity" && route.registeredChildCount == 0 {
+			return emit(nil)
+		}
+		return emit(a.appServerItemEvents(session, turnID, item, true, normalizer))
 	case appServerNotifyPlanUpdated:
 		if normalizer == nil {
 			return codexAppServerReduction{}


### PR DESCRIPTION
## Summary
- normalize Codex `subAgentActivity(kind=started)` as provider-native child spawn evidence
- emit the parent delegation call and canonical child session/turn without adding AgentGUI fallbacks
- keep duplicate spawn notifications idempotent and preserve the post-cancel child interrupt boundary
- document the adapter/AgentGUI ownership rule and the recurring troubleshooting path

## Tests
- `go test ./runtime -count=1`
- `pnpm check:changed`
- `pnpm check:changed -- --push-ready`

## Notes
- the first push-ready run hit an unrelated timeout in `TestLocalProcessTransportFindsKnownNodeGlobalBin`; the repository-prescribed failed-only retry passed, followed by a clean final push-ready run
- existing sessions created before this fix are not backfilled

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->