### PR TITLE
fix(agent): 解决handoff时，并行处理导致的子Agent工作目录丢失

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1589,10 +1589,14 @@ The controller's new-conversation command must distinguish rail placement from
 the active Session's runtime working directory before entering the home
 composer. A Session in the Chats section may have a generated `cwd`, but that
 path is not a selected user project and must be cleared. A Session in a
-canonical project section keeps its working directory, while a command already
-on the home composer preserves the user's explicit project selection. Views
-only forward new-conversation intent; unresolved active rail membership fails
-closed rather than guessing from composer presentation fields.
+canonical project section resolves that section key back to the registered
+project root; its runtime `cwd` may instead be a nested directory or isolated
+worktree and is never reused as project identity. “Continue in new
+conversation” uses the same resolution before moving the mention draft to
+Home. A command already on the home composer preserves the user's explicit
+project selection. Views only forward new-conversation intent; unresolved
+active rail membership fails closed rather than guessing from composer
+presentation fields.
 For delegated/shared execution, the initiating caller remains the placement
 authority: the adapter forwards that caller-selected `RailPlacement` through
 the binding to the owner Host. The owner persists the same section key and does

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1597,6 +1597,11 @@ For delegated/shared execution, the initiating caller remains the placement
 authority: the adapter forwards that caller-selected `RailPlacement` through
 the binding to the owner Host. The owner persists the same section key and does
 not recompute it from the owner's user-project list.
+The Agent CLI handoff adapter also inherits the caller Session's runtime `cwd`
+so the delegate starts inside the same checkout or linked worktree. If a
+project-backed caller has no runtime `cwd`, its canonical project path is the
+fallback. A supplied caller Session ID that cannot be resolved fails the start
+instead of creating a detached Session in an allocator directory.
 
 ### 7.2 Existing conversation submit
 

--- a/docs/architecture/issue-execution.md
+++ b/docs/architecture/issue-execution.md
@@ -47,6 +47,13 @@ Generic Issue dispatch is split into two phases:
    creates the Agent Session. A launch failure settles the claimed Run through
    the normal idempotent completion command.
 
+The source planning Session supplies two independent launch facts: its working
+directory is the fallback execution base, while its canonical rail placement
+is the delegate Session's logical project/conversation ownership. Preparing an
+isolated task worktree changes only the execution directory. Issue dispatch
+must carry the source `RailPlacement` unchanged into the Agent Host create
+contract and must never infer placement from the temporary worktree path.
+
 Stopping is also split:
 
 1. Under the Issue lock, set `dispatchPaused=true` and snapshot the Issue's

--- a/docs/architecture/issue-execution.md
+++ b/docs/architecture/issue-execution.md
@@ -53,6 +53,12 @@ is the delegate Session's logical project/conversation ownership. Preparing an
 isolated task worktree changes only the execution directory. Issue dispatch
 must carry the source `RailPlacement` unchanged into the Agent Host create
 contract and must never infer placement from the temporary worktree path.
+When an Issue names a source Session, that projection is a launch
+precondition: an unavailable/deleted source leaves the Task unclaimed for a
+later reconcile instead of creating a detached Run and Session. Each dispatch
+pass resolves the source once, so worktree planning and Agent creation consume
+the same immutable source snapshot. A project placement with an empty runtime
+cwd falls back to its canonical project path.
 
 Stopping is also split:
 

--- a/docs/architecture/workspace-agents-and-automation.md
+++ b/docs/architecture/workspace-agents-and-automation.md
@@ -229,6 +229,13 @@ Agent's tool configuration. The first message is composed as rule prompt +
 completed/failed event note; the target Agent reads source context through
 the mention instead of an inline transcript copy. Built-in Harness targets
 are always selectable, so automation works before any WorkspaceAgent exists.
+The target inherits the source Session's runtime working directory and
+canonical rail placement as separate values. A source running in an isolated
+worktree therefore keeps that worktree as its execution cwd while the
+follow-up remains grouped under the source project. For a project-backed
+source with an empty cwd, the canonical project path is the execution fallback;
+source lookup failure stops the launch rather than allocating a detached
+Session directory.
 
 Automation-origin sessions carry the originating rule id, source session id,
 and bounded depth in runtime context. Failure-triggered rescue may evaluate

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -21,9 +21,10 @@ Use the focused runtime index or open one area directly:
   probes, extension release refresh delaying daemon startup, and CPU spikes.
 - [Agent Sessions And Lifecycle](./agent-session-lifecycle.md): Turn state, activation, planning-mode classification, Tutti workflow response contracts, loading, cancel, goal controls, restore, file-change undo, rail projection, realtime completion provenance, event updates, imports, and performance.
   Includes shared-device recovery that looks terminal while the host is still retrying.
-  Also covers new-conversation requests that silently fail after a Chats
-  Session working directory is mistaken for a selected project, and one hung
-  provider startup blocking unrelated Agent sessions. Extension snapshot
+  Also covers new or derived conversations that silently fail or lose
+  project/Git ownership when a runtime worktree is mistaken for a canonical
+  project (or the source Session is unavailable), and one hung provider startup
+  blocking unrelated Agent sessions. Extension snapshot
   failures that erase the Agent's Tutti CLI command catalog or block restart
   resume are covered here as well. Includes cassette replay
   startup that fails when concurrent provider input and output are treated as a

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -1640,6 +1640,11 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   while its explicitly selected child-project section says `No chats yet`.
   Switching provider filters may briefly retain the previous scope's row before
   the exact persisted membership makes the child section empty again.
+  Delegated Issue tasks, Agent CLI handoffs, Automation follow-ups, or
+  AgentGUI “New conversation” / “Continue in new conversation” can show a
+  related variant: the new Session appears in Chats or under a temporary
+  worktree instead of the source project, and Git commands no longer operate
+  on the intended checkout.
 - Quick checks:
   Inspect the session `cwd` from the activity snapshot. Generated no-project
   sessions should carry `runtimeContext.noProject: true` in the daemon report
@@ -1657,6 +1662,12 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   `rail_section_key` in `workspace_agent_sessions`. If the cwd is inside a
   registered child project but the persisted key names an ancestor, check
   whether that child was registered only after the original import completed.
+  For a newly derived Session, compare those three fields with the source
+  Session and inspect whether the create adapter supplied both `cwd` and
+  `RailPlacement`. If an Issue has `source_session_id` but no Run was created,
+  verify that the source Session still resolves; dispatch intentionally waits
+  instead of guessing. For project Sessions with an empty cwd, verify that the
+  adapter used `rail_project_path` as the runtime fallback.
 - Root cause:
   Rail membership is classified once by the daemon when the session is first
   persisted, using `cwd`, runtime no-project markers, and current user projects.
@@ -1673,6 +1684,12 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   writes creates another ordering trap: the store may see an existing parent
   project but not the selected child while assigning the session's first,
   normally immutable rail key.
+  Derived-Session entry points add the inverse trap: copying only runtime cwd
+  loses logical ownership when the cwd is an isolated worktree, while copying
+  only rail placement can leave the Agent without the source checkout. Looking
+  up the source twice during one dispatch can also mix two different snapshots,
+  and silently accepting a missing source turns an invalid handoff into a
+  detached allocator-backed Session.
 - Fix:
   Build runtime state from a clone of the session launch `RuntimeContext`, overlay
   canonical session fields, and merge provider `StateAdapter` context as a patch
@@ -1696,6 +1713,11 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   key rather than racing the runtime's asynchronous activity reporter. AgentGUI
   must project sessions only by exact key equality and must not retain a cwd-based
   grouping fallback.
+  For handoff, Issue, Automation, and AgentGUI new-conversation flows, carry
+  runtime cwd and canonical rail placement independently. Resolve project
+  identity by exact section key, use the canonical project path when a
+  project-backed source cwd is empty, take one source snapshot per dispatch,
+  and fail closed when a required source Session cannot be resolved.
 - Validation:
   Run
   `pnpm --filter @tutti-os/agent-gui test -- agent-gui/agentGuiNode/model/agentGuiConversationModel.spec.ts`,
@@ -1704,6 +1726,9 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   `go test ./packages/agent/store-sqlite -run 'ImportedRail|ClassifiesRail'`,
   `node --import ./test/register-asset-stub.mjs --test --experimental-strip-types ./src/renderer/src/features/workspace-user-project/services/internal/desktopWorkspaceUserProjectService.test.ts`
   from `apps/desktop`, then run `pnpm check:changed`.
+  For derived-Session regressions, also run the focused AgentGUI
+  new-conversation tests plus
+  `go test ./service/workspace ./service/automationrule`.
 - References:
   [controller_state.go](../../../packages/agent/daemon/runtime/controller_state.go)
   [controller_state_test.go](../../../packages/agent/daemon/runtime/controller_state_test.go)
@@ -1715,6 +1740,8 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   [desktopWorkspaceUserProjectService.ts](../../../apps/desktop/src/renderer/src/features/workspace-user-project/services/internal/desktopWorkspaceUserProjectService.ts)
   [agentGuiConversationProjectResolver.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationProjectResolver.ts)
   [useAgentGuiConversationList.ts](../../../packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/useAgentGuiConversationList.ts)
+  [issue_sequential_dispatch.go](../../../services/tuttid/service/workspace/issue_sequential_dispatch.go)
+  [daemon_executor.go](../../../services/tuttid/service/automationrule/daemon_executor.go)
 
 ### AgentGUI new conversation does nothing after leaving a Chats session
 
@@ -1742,13 +1769,16 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   Normalize default project selection at the AgentGUI controller's
   new-conversation command. Explicit section actions remain authoritative; an
   active Chats Session replaces the home selection with no project, an active
-  project Session keeps its working directory, and an action already on Home
-  preserves the user's explicit selection. Views forward the intent without
+  project Session resolves its immutable section key back to the canonical
+  registered project path, and an action already on Home preserves the user's
+  explicit selection. The continuation action shares this resolver before it
+  moves the source mention draft to Home. Views forward the intent without
   interpreting composer presentation fields.
 - Validation:
   Cover the command through final `session/activate` for three P0 scenarios:
-  active Chats clears a generated cwd, active Project preserves its cwd and
-  canonical placement, and Home preserves an explicit project selection.
+  active Chats clears a generated cwd, active Project with a nested/worktree
+  cwd preserves its canonical placement, Continue uses that same project, and
+  Home preserves an explicit project selection.
 - References:
   [agentGuiNewConversationRequest.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiNewConversationRequest.ts)
   [useAgentGUIOperationActions.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIOperationActions.ts)

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiNewConversationRequest.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiNewConversationRequest.spec.tsx
@@ -102,6 +102,42 @@ describe("P0 new-conversation placement scenarios", () => {
     });
   });
 
+  it("keeps the logical project when the active session runs in an isolated worktree", async () => {
+    const projectPath = "/workspace/project-a";
+    const sectionKey = "project:workspace-1:/workspace/project-a";
+    const scenario = renderNewConversationScenario({
+      activeConversation: conversationSummary({
+        cwd: "/state/task-worktrees/issue/task-run",
+        railSectionKey: sectionKey
+      }),
+      initialHomeProjectPath: null,
+      userProjects: [
+        {
+          id: "project-a",
+          label: "Project A",
+          path: projectPath,
+          pinnedAtUnixMs: 0,
+          sectionKey
+        }
+      ]
+    });
+
+    act(() => scenario.requestNewConversation());
+    act(() =>
+      scenario.submitPrompt([{ type: "text", text: "continue from worktree" }])
+    );
+
+    expect(await scenario.waitForActivation()).toMatchObject({
+      cwd: projectPath,
+      railPlacement: {
+        version: 1,
+        kind: "project",
+        projectPath,
+        sectionKey
+      }
+    });
+  });
+
   it("preserves an explicit project selection already made on Home", async () => {
     const projectPath = "/workspace/project-a";
     const sectionKey = "project:workspace-1:/workspace/project-a";
@@ -327,7 +363,8 @@ function renderNewConversationScenario(input: {
         activeConversationId: activeConversationIdRef.current,
         conversations: conversationsRef.current,
         createConversation: result.current.createConversation,
-        transientConversation: null
+        transientConversation: null,
+        userProjects: input.userProjects
       });
     },
     persistActiveConversation,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiNewConversationRequest.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiNewConversationRequest.ts
@@ -1,4 +1,5 @@
 import type { AgentGUIConversationSummary } from "../model/agentGuiConversationModel";
+import type { AgentGUIConversationUserProject } from "../model/agentGuiConversationProjectResolver";
 import { resolveConversationSummaryById } from "./useAgentConversationSelection";
 
 export interface AgentGUINewConversationRequestOptions {
@@ -16,6 +17,7 @@ export function requestAgentGUINewConversation(input: {
   activeConversationId: string | null;
   conversations: readonly AgentGUIConversationSummary[];
   transientConversation: AgentGUIConversationSummary | null;
+  userProjects: readonly AgentGUIConversationUserProject[];
   options?: AgentGUINewConversationRequestOptions;
 }): boolean {
   if (input.options && "projectPath" in input.options) {
@@ -25,7 +27,8 @@ export function requestAgentGUINewConversation(input: {
   const selection = resolveAgentGUINewConversationProjectSelection({
     activeConversationId: input.activeConversationId,
     conversations: input.conversations,
-    transientConversation: input.transientConversation
+    transientConversation: input.transientConversation,
+    userProjects: input.userProjects
   });
   if (selection.kind === "unresolved") {
     return false;
@@ -45,6 +48,7 @@ export function resolveAgentGUINewConversationProjectSelection(input: {
   activeConversationId: string | null;
   conversations: readonly AgentGUIConversationSummary[];
   transientConversation: AgentGUIConversationSummary | null;
+  userProjects: readonly AgentGUIConversationUserProject[];
 }): AgentGUINewConversationProjectSelection {
   if (input.activeConversationId === null) {
     return { kind: "preserve_home" };
@@ -61,9 +65,14 @@ export function resolveAgentGUINewConversationProjectSelection(input: {
   if (sectionKey === "conversations") {
     return { kind: "replace", projectPath: null };
   }
-  const projectPath = activeConversation.cwd.trim();
-  if (!sectionKey || !projectPath) {
+  if (!sectionKey) {
     return { kind: "unresolved" };
   }
-  return { kind: "replace", projectPath };
+  const projectPath =
+    input.userProjects
+      .find((project) => project.sectionKey?.trim() === sectionKey)
+      ?.path.trim() ?? "";
+  return projectPath
+    ? { kind: "replace", projectPath }
+    : { kind: "unresolved" };
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIContinueConversation.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIContinueConversation.spec.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
 import {
   agentComposerDraftFiles,
   agentComposerDraftImages,
@@ -6,7 +8,10 @@ import {
   agentComposerDraftPrompt,
   buildAgentComposerDraft
 } from "../model/agentComposerDraft";
-import { buildContinueInNewConversationDraft } from "./useAgentGUIContinueConversation";
+import {
+  buildContinueInNewConversationDraft,
+  useAgentGUIContinueConversation
+} from "./useAgentGUIContinueConversation";
 
 describe("buildContinueInNewConversationDraft", () => {
   it("preserves every attachment block while replacing the continuation prompt", () => {
@@ -49,5 +54,64 @@ describe("buildContinueInNewConversationDraft", () => {
     expect(agentComposerDraftLargeTexts(continued)).toEqual(
       agentComposerDraftLargeTexts(sourceDraft)
     );
+  });
+
+  it("restores the canonical source project before moving the continuation draft to Home", () => {
+    const selectedProjectPathRef = { current: null as string | null };
+    const setSelectedProjectPath = vi.fn();
+    const activeConversationIdRef = { current: "session-1" as string | null };
+    const isComposerHomeRef = { current: false };
+    const activeConversation = {
+      id: "session-1",
+      provider: "codex" as const,
+      title: "Source",
+      status: "ready" as const,
+      cwd: "/state/task-worktrees/issue/task-run",
+      railSectionKey: "project:/workspace/project-a",
+      updatedAtUnixMs: 1
+    };
+    const { result } = renderHook(() =>
+      useAgentGUIContinueConversation({
+        accountProfilesByUserId: {},
+        activeConversationIdRef,
+        activePendingActivation: null,
+        agentActivityRuntime: {} as AgentActivityRuntime,
+        conversations: [activeConversation],
+        currentUserId: "user-1",
+        draftByScopeKey: {},
+        isComposerHomeRef,
+        loadDraftComposerOptions: vi.fn(),
+        persistActiveConversation: vi.fn(),
+        selectedProjectPathRef,
+        setActiveConversationId: vi.fn(),
+        setDetailError: vi.fn(),
+        setDraftByScopeKey: vi.fn(),
+        setIntent: vi.fn(),
+        setIsComposerHome: vi.fn(),
+        setIsLoadingMessages: vi.fn(),
+        setSelectedProjectPath,
+        transientConversation: null,
+        unactivate: vi.fn(async () => undefined),
+        userProjectsRef: {
+          current: [
+            {
+              id: "project-a",
+              label: "Project A",
+              path: "/workspace/project-a",
+              pinnedAtUnixMs: 0,
+              sectionKey: "project:/workspace/project-a"
+            }
+          ]
+        },
+        workspaceId: "workspace-1"
+      })
+    );
+
+    act(() => result.current());
+
+    expect(selectedProjectPathRef.current).toBe("/workspace/project-a");
+    expect(setSelectedProjectPath).toHaveBeenCalledWith("/workspace/project-a");
+    expect(activeConversationIdRef.current).toBeNull();
+    expect(isComposerHomeRef.current).toBe(true);
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIContinueConversation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIContinueConversation.ts
@@ -5,6 +5,7 @@ import { translate } from "../../../i18n/index";
 import type { AgentHostAccountUserProfile } from "../../../shared/contracts/dto";
 import type { AgentComposerDraft } from "../model/agentGuiNodeTypes";
 import type { AgentGUIConversationSummary } from "../model/agentGuiConversationModel";
+import type { AgentGUIConversationUserProject } from "../model/agentGuiConversationProjectResolver";
 import { resolveAgentGUIExplicitConversationTitle } from "../model/agentGuiProviderIdentity";
 import {
   agentComposerDraftPrompt,
@@ -13,6 +14,7 @@ import {
 } from "../model/agentComposerDraft";
 import { resolveAgentComposerDraftScopeKey } from "../model/agentComposerDraftScope";
 import { buildContinueInNewConversationPrompt } from "./agentGuiController.conversationHelpers";
+import { resolveAgentGUINewConversationProjectSelection } from "./agentGuiNewConversationRequest";
 import { reportAgentGUIActiveConversationCleared } from "./agentGuiController.reporting";
 import { isPendingNewConversationActivationForSession } from "./useAgentGUIActivation";
 import {
@@ -32,7 +34,6 @@ interface UseAgentGUIContinueConversationInput {
   activePendingActivation: PendingActivationIntentRecord | null;
   agentActivityRuntime: AgentActivityRuntime;
   conversations: readonly AgentGUIConversationSummary[];
-  createConversation(): void;
   currentUserId: string | null | undefined;
   draftByScopeKey: Record<string, AgentComposerDraft>;
   isComposerHomeRef: CurrentValue<boolean>;
@@ -46,8 +47,11 @@ interface UseAgentGUIContinueConversationInput {
   setIntent: Dispatch<SetStateAction<ConversationIntent>>;
   setIsComposerHome: Dispatch<SetStateAction<boolean>>;
   setIsLoadingMessages: Dispatch<SetStateAction<boolean>>;
+  selectedProjectPathRef: CurrentValue<string | null>;
+  setSelectedProjectPath: Dispatch<SetStateAction<string | null>>;
   transientConversation: AgentGUIConversationSummary | null;
   unactivate(agentSessionId: string): Promise<void>;
+  userProjectsRef: CurrentValue<readonly AgentGUIConversationUserProject[]>;
   workspaceId: string;
 }
 
@@ -67,15 +71,24 @@ export function useAgentGUIContinueConversation(
     const current = inputRef.current;
     const currentConversationId = current.activeConversationIdRef.current;
     if (!currentConversationId) return;
+    const projectSelection = resolveAgentGUINewConversationProjectSelection({
+      activeConversationId: currentConversationId,
+      conversations: current.conversations,
+      transientConversation: current.transientConversation,
+      userProjects: current.userProjectsRef.current
+    });
+    if (projectSelection.kind !== "replace") {
+      current.setDetailError(
+        translate("agentHost.agentGui.sessionActivationFailed")
+      );
+      return;
+    }
     const activeConversation = resolveConversationSummaryById(
       current.conversations,
       currentConversationId,
       current.transientConversation
     );
-    if (!activeConversation) {
-      current.createConversation();
-      return;
-    }
+    if (!activeConversation) return;
     const sourceDraftScopeKey = resolveAgentComposerDraftScopeKey({
       agentSessionId: currentConversationId
     });
@@ -110,6 +123,8 @@ export function useAgentGUIContinueConversation(
       void current.unactivate(currentConversationId);
     }
     current.setIntent({ tag: "home" });
+    current.selectedProjectPathRef.current = projectSelection.projectPath;
+    current.setSelectedProjectPath(projectSelection.projectPath);
     current.isComposerHomeRef.current = true;
     current.setIsComposerHome(true);
     current.activeConversationIdRef.current = null;

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.spec.ts
@@ -40,6 +40,28 @@ describe("resolveInitialRailPlacement", () => {
     });
   });
 
+  it("writes the canonical project root when the selected path is nested", () => {
+    expect(
+      resolveInitialRailPlacement({
+        selectedProjectPath: "/workspace/packages/agent",
+        userProjects: [
+          {
+            id: "project-1",
+            label: "Workspace",
+            path: "/workspace",
+            pinnedAtUnixMs: 0,
+            sectionKey: "project:/workspace"
+          }
+        ]
+      })
+    ).toEqual({
+      version: 1,
+      kind: "project",
+      projectPath: "/workspace",
+      sectionKey: "project:/workspace"
+    });
+  });
+
   it("fails closed when the selected project has no canonical section", () => {
     expect(
       resolveInitialRailPlacement({

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.ts
@@ -95,14 +95,17 @@ export function resolveInitialRailPlacement(input: {
     selectedProjectPath,
     input.userProjects
   );
-  const sectionKey = selectedProject?.sectionKey?.trim() ?? "";
+  if (!selectedProject) {
+    return null;
+  }
+  const sectionKey = selectedProject.sectionKey?.trim() ?? "";
   if (!sectionKey) {
     return null;
   }
   return {
     version: 1,
     kind: "project",
-    projectPath: selectedProjectPath,
+    projectPath: selectedProject.path.trim(),
     sectionKey
   };
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIOperationActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIOperationActions.ts
@@ -74,7 +74,8 @@ export function useAgentGUIOperationActions(
           conversations: input.conversationsRef.current,
           createConversation: enterConversationHome,
           options,
-          transientConversation: input.transientConversation
+          transientConversation: input.transientConversation,
+          userProjects: input.userProjectsRef.current
         })
       ) {
         return;
@@ -92,10 +93,7 @@ export function useAgentGUIOperationActions(
     ]
   );
 
-  const continueInNewConversation = useAgentGUIContinueConversation({
-    ...input,
-    createConversation: enterConversationHome
-  });
+  const continueInNewConversation = useAgentGUIContinueConversation(input);
 
   const isSessionMarkedNonResumable = useCallback(
     (agentSessionId: string): boolean => {

--- a/packages/agent/gui/vitest.config.ts
+++ b/packages/agent/gui/vitest.config.ts
@@ -7,6 +7,7 @@ const domTypeScriptTests = [
   "agent-gui/agentGuiNode/agentGuiNodeViewConversation.spec.ts",
   "agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.spec.ts",
   "agent-gui/agentGuiNode/composer/composerPortalTarget.spec.ts",
+  "agent-gui/agentGuiNode/controller/useAgentGUIContinueConversation.spec.ts",
   "agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.spec.ts",
   "agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.spec.ts",
   "agent-gui/agentGuiNode/model/agentGuiComposerGate.spec.ts",

--- a/services/tuttid/issue_run_agent_adapters.go
+++ b/services/tuttid/issue_run_agent_adapters.go
@@ -164,6 +164,7 @@ func (l issueRunAgentLauncher) Launch(ctx context.Context, launch workspaceservi
 		Model:                optionalString(launch.Model),
 		ModelPlanID:          optionalString(launch.ModelPlanID),
 		Visible:              boolPointer(true),
+		RailPlacement:        agentRailPlacementFromIssueRun(launch.RailPlacement),
 	})
 	if err == nil ||
 		strings.TrimSpace(result.TurnID) != "" ||
@@ -187,16 +188,50 @@ func (l issueRunAgentLauncher) Launch(ctx context.Context, launch workspaceservi
 	return workspaceservice.NewIssueRunLaunchNotStartedError(err)
 }
 
-type issueSourceSessionDirectoryResolver struct {
+func agentRailPlacementFromIssueRun(
+	placement *workspaceservice.IssueRunRailPlacement,
+) *agenthost.RailPlacement {
+	if placement == nil {
+		return nil
+	}
+	return &agenthost.RailPlacement{
+		Version:     1,
+		Kind:        agenthost.RailPlacementKind(strings.TrimSpace(placement.Kind)),
+		ProjectPath: strings.TrimSpace(placement.ProjectPath),
+		SectionKey:  strings.TrimSpace(placement.SectionKey),
+	}
+}
+
+type issueSourceSessionContextResolver struct {
 	Sessions agentservice.SessionReader
 }
 
-func (r issueSourceSessionDirectoryResolver) ResolveSourceSessionDirectory(workspaceID string, agentSessionID string) (string, bool) {
+func (r issueSourceSessionContextResolver) ResolveSourceSessionContext(
+	workspaceID string,
+	agentSessionID string,
+) (workspaceservice.IssueSourceSessionContext, bool) {
 	if r.Sessions == nil {
-		return "", false
+		return workspaceservice.IssueSourceSessionContext{}, false
 	}
 	session, ok := r.Sessions.GetSession(workspaceID, agentSessionID)
-	return session.Cwd, ok
+	if !ok {
+		return workspaceservice.IssueSourceSessionContext{}, false
+	}
+	context := workspaceservice.IssueSourceSessionContext{
+		WorkingDirectory: strings.TrimSpace(session.Cwd),
+	}
+	if strings.TrimSpace(session.RailSectionKey) != "" {
+		context.RailPlacement = &workspaceservice.IssueRunRailPlacement{
+			Kind:        strings.TrimSpace(session.RailSectionKind),
+			ProjectPath: strings.TrimSpace(session.RailProjectPath),
+			SectionKey:  strings.TrimSpace(session.RailSectionKey),
+		}
+		if context.WorkingDirectory == "" &&
+			context.RailPlacement.Kind == "project" {
+			context.WorkingDirectory = context.RailPlacement.ProjectPath
+		}
+	}
+	return context, true
 }
 
 func optionalString(value string) *string {

--- a/services/tuttid/service/agent/activity_projection_session.go
+++ b/services/tuttid/service/agent/activity_projection_session.go
@@ -22,6 +22,8 @@ func persistedSessionFromActivity(session agentactivitybiz.Session) PersistedSes
 		Provider:               strings.TrimSpace(session.Provider),
 		ProviderSessionID:      strings.TrimSpace(session.ProviderSessionID),
 		Cwd:                    strings.TrimSpace(session.Cwd),
+		RailSectionKind:        strings.TrimSpace(session.RailSectionKind),
+		RailProjectPath:        strings.TrimSpace(session.RailProjectPath),
 		RailSectionKey:         strings.TrimSpace(session.RailSectionKey),
 		Settings:               composerSettingsFromPayload(session.Settings),
 		Metadata:               session.Metadata,

--- a/services/tuttid/service/agent/service_session.go
+++ b/services/tuttid/service/agent/service_session.go
@@ -191,6 +191,8 @@ func sessionFromPersisted(session PersistedSession, resumable bool) Session {
 		RuntimeContext:    persistedSessionRuntimeContext(session),
 	}, resumable)
 	result.ActiveTurnID = strings.TrimSpace(session.ActiveTurnID)
+	result.RailSectionKind = strings.TrimSpace(session.RailSectionKind)
+	result.RailProjectPath = strings.TrimSpace(session.RailProjectPath)
 	result.RailSectionKey = strings.TrimSpace(session.RailSectionKey)
 	result.Kind = strings.TrimSpace(session.Kind)
 	if result.Kind == "" {
@@ -230,6 +232,8 @@ func mergePersistedSessionState(session Session, persisted PersistedSession) Ses
 	session.ParentAgentSessionID = strings.TrimSpace(persisted.ParentAgentSessionID)
 	session.ParentTurnID = strings.TrimSpace(persisted.ParentTurnID)
 	session.ParentToolCallID = strings.TrimSpace(persisted.ParentToolCallID)
+	session.RailSectionKind = strings.TrimSpace(persisted.RailSectionKind)
+	session.RailProjectPath = strings.TrimSpace(persisted.RailProjectPath)
 	session.RailSectionKey = strings.TrimSpace(persisted.RailSectionKey)
 	if strings.TrimSpace(session.UserID) == "" {
 		session.UserID = strings.TrimSpace(persisted.UserID)

--- a/services/tuttid/service/agent/service_session_child_test.go
+++ b/services/tuttid/service/agent/service_session_child_test.go
@@ -26,19 +26,23 @@ func TestPersistedChildSessionCannotResumeIndependently(t *testing.T) {
 	}
 }
 
-func TestSessionFromPersistedPreservesRailSectionKey(t *testing.T) {
+func TestSessionFromPersistedPreservesRailPlacement(t *testing.T) {
 	t.Parallel()
 
 	session := sessionFromPersisted(PersistedSession{
-		ID:             "session-1",
-		Kind:           agentactivitybiz.SessionKindRoot,
-		MessageVersion: 17,
-		Provider:       "codex",
-		RailSectionKey: " project:repo-1 ",
+		ID:              "session-1",
+		Kind:            agentactivitybiz.SessionKindRoot,
+		MessageVersion:  17,
+		Provider:        "codex",
+		RailSectionKind: " project ",
+		RailProjectPath: " /workspace/repo-1 ",
+		RailSectionKey:  " project:repo-1 ",
 	}, false)
 
-	if session.RailSectionKey != "project:repo-1" {
-		t.Fatalf("rail section key = %q, want project:repo-1", session.RailSectionKey)
+	if session.RailSectionKind != "project" ||
+		session.RailProjectPath != "/workspace/repo-1" ||
+		session.RailSectionKey != "project:repo-1" {
+		t.Fatalf("rail placement = %#v", session)
 	}
 	if session.MessageVersion != 17 {
 		t.Fatalf("message version = %d, want 17", session.MessageVersion)
@@ -50,30 +54,40 @@ func TestPersistedSessionFromActivityPreservesMessageVersion(t *testing.T) {
 
 	session := persistedSessionFromActivity(agentactivitybiz.Session{
 		ID: "session-1", WorkspaceID: "workspace-1", MessageVersion: 23,
+		RailSectionKind: "project", RailProjectPath: "/workspace/repo-1", RailSectionKey: "project:repo-1",
 	})
 
 	if session.MessageVersion != 23 {
 		t.Fatalf("message version = %d, want 23", session.MessageVersion)
 	}
+	if session.RailSectionKind != "project" ||
+		session.RailProjectPath != "/workspace/repo-1" ||
+		session.RailSectionKey != "project:repo-1" {
+		t.Fatalf("rail placement = %#v", session)
+	}
 }
 
-func TestServiceSessionResponseMergesPersistedRailSectionKey(t *testing.T) {
+func TestServiceSessionResponseMergesPersistedRailPlacement(t *testing.T) {
 	t.Parallel()
 
 	session := serviceSessionWithPersistedFreshness(
 		ProviderRuntimeSession{ID: "session-1", WorkspaceID: "workspace-1", Provider: "codex"},
 		PersistedSession{
-			ID:             "session-1",
-			WorkspaceID:    "workspace-1",
-			MessageVersion: 19,
-			Provider:       "codex",
-			RailSectionKey: "project:repo-1",
+			ID:              "session-1",
+			WorkspaceID:     "workspace-1",
+			MessageVersion:  19,
+			Provider:        "codex",
+			RailSectionKind: "project",
+			RailProjectPath: "/workspace/repo-1",
+			RailSectionKey:  "project:repo-1",
 		},
 		false,
 	)
 
-	if session.RailSectionKey != "project:repo-1" {
-		t.Fatalf("rail section key = %q, want project:repo-1", session.RailSectionKey)
+	if session.RailSectionKind != "project" ||
+		session.RailProjectPath != "/workspace/repo-1" ||
+		session.RailSectionKey != "project:repo-1" {
+		t.Fatalf("rail placement = %#v", session)
 	}
 	if session.MessageVersion != 19 {
 		t.Fatalf("message version = %d, want 19", session.MessageVersion)

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -242,6 +242,8 @@ type Session struct {
 	Provider             string
 	ProviderSessionID    string
 	Cwd                  string
+	RailSectionKind      string
+	RailProjectPath      string
 	RailSectionKey       string
 	Visible              bool
 	Resumable            bool

--- a/services/tuttid/service/automationrule/daemon_executor.go
+++ b/services/tuttid/service/automationrule/daemon_executor.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	automationrulebiz "github.com/tutti-os/tutti/services/tuttid/biz/automationrule"
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
 )
@@ -42,7 +43,7 @@ func (e *DaemonExecutor) ExecuteAutomationRule(ctx context.Context, input Execut
 	}
 	rule := input.Rule
 	prompt := automationLaunchPrompt(rule, input.WorkspaceID, input.SourceSessionID)
-	cwd := strings.TrimSpace(input.SourceCwd)
+	cwd := strings.TrimSpace(input.SourceContext.WorkingDirectory)
 	var cwdPointer *string
 	if cwd != "" {
 		cwdPointer = &cwd
@@ -88,6 +89,7 @@ func (e *DaemonExecutor) ExecuteAutomationRule(ctx context.Context, input Execut
 		InitialContent:         []agentservice.PromptContentBlock{{Type: "text", Text: prompt}},
 		InitialDisplayPrompt:   automationLaunchDisplayPrompt(rule, input.SourceSessionID),
 		Cwd:                    cwdPointer,
+		RailPlacement:          agentRailPlacementFromAutomationSource(input.SourceContext.RailPlacement),
 		PermissionModeID:       permissionModeID,
 		StrictPermissionMode:   permissionModeID != nil,
 		AgentTools:             append([]string(nil), rule.Permissions.AllowedTools...),
@@ -158,18 +160,54 @@ func (e *DaemonExecutor) failIssueRescue(
 	return cause
 }
 
-// AutomationSourceCwd implements SourceReader. Only the working directory is
-// copied from the source session; conversation context travels through the
-// session mention in the first message.
-func (e *DaemonExecutor) AutomationSourceCwd(ctx context.Context, workspaceID string, sessionID string) (string, error) {
+// AutomationSourceContext implements SourceReader. Runtime cwd and canonical
+// rail identity are copied independently; conversation content still travels
+// through the session mention in the first message.
+func (e *DaemonExecutor) AutomationSourceContext(
+	ctx context.Context,
+	workspaceID string,
+	sessionID string,
+) (AutomationSourceSessionContext, error) {
 	if e == nil || e.Agents == nil {
-		return "", fmt.Errorf("automation agent session service is unavailable")
+		return AutomationSourceSessionContext{}, fmt.Errorf("automation agent session service is unavailable")
 	}
 	session, err := e.Agents.Get(ctx, workspaceID, sessionID)
 	if err != nil {
-		return "", err
+		return AutomationSourceSessionContext{}, err
 	}
-	return strings.TrimSpace(session.Cwd), nil
+	return automationSourceContextFromSession(session), nil
+}
+
+func automationSourceContextFromSession(session agentservice.Session) AutomationSourceSessionContext {
+	sourceContext := AutomationSourceSessionContext{
+		WorkingDirectory: strings.TrimSpace(session.Cwd),
+	}
+	if strings.TrimSpace(session.RailSectionKey) != "" {
+		sourceContext.RailPlacement = &AutomationSourceRailPlacement{
+			Kind:        strings.TrimSpace(session.RailSectionKind),
+			ProjectPath: strings.TrimSpace(session.RailProjectPath),
+			SectionKey:  strings.TrimSpace(session.RailSectionKey),
+		}
+		if sourceContext.WorkingDirectory == "" &&
+			sourceContext.RailPlacement.Kind == string(agenthost.RailPlacementKindProject) {
+			sourceContext.WorkingDirectory = sourceContext.RailPlacement.ProjectPath
+		}
+	}
+	return sourceContext
+}
+
+func agentRailPlacementFromAutomationSource(
+	placement *AutomationSourceRailPlacement,
+) *agenthost.RailPlacement {
+	if placement == nil {
+		return nil
+	}
+	return &agenthost.RailPlacement{
+		Version:     1,
+		Kind:        agenthost.RailPlacementKind(strings.TrimSpace(placement.Kind)),
+		ProjectPath: strings.TrimSpace(placement.ProjectPath),
+		SectionKey:  strings.TrimSpace(placement.SectionKey),
+	}
 }
 
 // automationLaunchPrompt composes the fixed first-message contract: rule

--- a/services/tuttid/service/automationrule/daemon_executor_test.go
+++ b/services/tuttid/service/automationrule/daemon_executor_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	automationrulebiz "github.com/tutti-os/tutti/services/tuttid/biz/automationrule"
+	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
 )
 
 func TestAutomationLaunchPromptComposesInstructionMentionAndEventNote(t *testing.T) {
@@ -50,5 +51,35 @@ func TestAutomationOriginDepthDefaultsLegacyRowsAndReadsNestedDepth(t *testing.T
 	}
 	if depth, ok := automationOriginDepth(map[string]any{"automation": map[string]any{"ruleId": "rule", "depth": float64(2)}}); !ok || depth != 2 {
 		t.Fatalf("nested automation origin = %d, %v", depth, ok)
+	}
+}
+
+func TestAgentRailPlacementFromAutomationSourceKeepsLogicalProjectSeparateFromCwd(t *testing.T) {
+	got := agentRailPlacementFromAutomationSource(&AutomationSourceRailPlacement{
+		Kind:        " project ",
+		ProjectPath: " /workspace/project-a ",
+		SectionKey:  " project:/workspace/project-a ",
+	})
+	if got == nil ||
+		got.Version != 1 ||
+		got.Kind != "project" ||
+		got.ProjectPath != "/workspace/project-a" ||
+		got.SectionKey != "project:/workspace/project-a" {
+		t.Fatalf("rail placement = %#v", got)
+	}
+}
+
+func TestAutomationSourceContextFallsBackToProjectPathWhenCwdIsEmpty(t *testing.T) {
+	got := automationSourceContextFromSession(agentservice.Session{
+		RailSectionKind: "project",
+		RailProjectPath: "/workspace/project-a",
+		RailSectionKey:  "project:/workspace/project-a",
+	})
+	if got.WorkingDirectory != "/workspace/project-a" {
+		t.Fatalf("working directory = %q, want project path fallback", got.WorkingDirectory)
+	}
+	if got.RailPlacement == nil ||
+		got.RailPlacement.ProjectPath != "/workspace/project-a" {
+		t.Fatalf("rail placement = %#v", got.RailPlacement)
 	}
 }

--- a/services/tuttid/service/automationrule/service.go
+++ b/services/tuttid/service/automationrule/service.go
@@ -71,7 +71,21 @@ type ExecutionInput struct {
 	// every automatically launched Agent in a bounded rescue chain.
 	AutomationDepth int
 	TriggerID       string
-	SourceCwd       string
+	SourceContext   AutomationSourceSessionContext
+}
+
+// AutomationSourceSessionContext is the narrow source-session projection an
+// automation launch inherits. Runtime cwd and logical rail identity stay
+// separate because the source may itself be running in an isolated worktree.
+type AutomationSourceSessionContext struct {
+	WorkingDirectory string
+	RailPlacement    *AutomationSourceRailPlacement
+}
+
+type AutomationSourceRailPlacement struct {
+	Kind        string
+	ProjectPath string
+	SectionKey  string
 }
 
 type ExecutionResult struct {
@@ -84,12 +98,11 @@ type Executor interface {
 	ExecuteAutomationRule(context.Context, ExecutionInput) (ExecutionResult, error)
 }
 
-// SourceReader resolves the source session's working directory so the
-// launched follow-up session starts in the same project. Source conversation
-// content travels through the session mention, not through an inline
-// transcript copy.
+// SourceReader resolves both the source session's execution directory and its
+// immutable logical rail identity. Source conversation content travels through
+// the session mention, not through an inline transcript copy.
 type SourceReader interface {
-	AutomationSourceCwd(context.Context, string, string) (string, error)
+	AutomationSourceContext(context.Context, string, string) (AutomationSourceSessionContext, error)
 }
 
 type Service struct {
@@ -559,10 +572,10 @@ func (s *Service) runRule(key string, workspaceID string, sessionID string, sour
 			return
 		}
 	}
-	cwd := ""
+	sourceContext := AutomationSourceSessionContext{}
 	if s.Sources != nil {
 		var err error
-		cwd, err = s.Sources.AutomationSourceCwd(ctx, workspaceID, sessionID)
+		sourceContext, err = s.Sources.AutomationSourceContext(ctx, workspaceID, sessionID)
 		if err != nil {
 			slog.Warn("automation rule source lookup failed", "event", "automation_rule.source_failed", "rule_id", rule.ID, "error", err)
 			return
@@ -575,7 +588,7 @@ func (s *Service) runRule(key string, workspaceID string, sessionID string, sour
 		SourceAgentID:   sourceAgentID,
 		AutomationDepth: automationDepth,
 		TriggerID:       triggerID,
-		SourceCwd:       cwd,
+		SourceContext:   sourceContext,
 	}); err != nil {
 		slog.Warn("automation rule execution failed", "event", "automation_rule.execute_failed", "rule_id", rule.ID, "error", err)
 	}

--- a/services/tuttid/service/automationrule/service_test.go
+++ b/services/tuttid/service/automationrule/service_test.go
@@ -139,6 +139,18 @@ func (e recordingExecutor) ExecuteAutomationRule(_ context.Context, input Execut
 	return ExecutionResult{TargetSessionID: "target-1"}, nil
 }
 
+type staticAutomationSourceReader struct {
+	context AutomationSourceSessionContext
+}
+
+func (r staticAutomationSourceReader) AutomationSourceContext(
+	context.Context,
+	string,
+	string,
+) (AutomationSourceSessionContext, error) {
+	return r.context, nil
+}
+
 type staticUsage struct {
 	runs     int
 	tokens   int64
@@ -288,7 +300,20 @@ func TestObserveAgentSessionStateRunsOncePerRuleAndTurn(t *testing.T) {
 	rule.SourceWorkspaceAgentID = "workspace-agent:source"
 	_ = store.CreateAutomationRule(context.Background(), rule)
 	calls := make(chan ExecutionInput, 2)
-	service := &Service{Store: store, Executor: recordingExecutor{calls: calls}, Usage: staticUsage{}}
+	sourceContext := AutomationSourceSessionContext{
+		WorkingDirectory: "/state/task-worktrees/issue/task-run",
+		RailPlacement: &AutomationSourceRailPlacement{
+			Kind:        "project",
+			ProjectPath: "/workspace/project-a",
+			SectionKey:  "project:/workspace/project-a",
+		},
+	}
+	service := &Service{
+		Store:    store,
+		Executor: recordingExecutor{calls: calls},
+		Usage:    staticUsage{},
+		Sources:  staticAutomationSourceReader{context: sourceContext},
+	}
 	outcome := "completed"
 	turnID := "turn-1"
 	input := canonical.ReportSessionStateInput{
@@ -306,6 +331,11 @@ func TestObserveAgentSessionStateRunsOncePerRuleAndTurn(t *testing.T) {
 	case call := <-calls:
 		if call.Rule.ID != "rule-1" || call.SourceAgentID != "workspace-agent:source" || call.TriggerID != "turn-1" {
 			t.Fatalf("execution call = %#v", call)
+		}
+		if call.SourceContext.WorkingDirectory != sourceContext.WorkingDirectory ||
+			call.SourceContext.RailPlacement == nil ||
+			*call.SourceContext.RailPlacement != *sourceContext.RailPlacement {
+			t.Fatalf("source context = %#v, want %#v", call.SourceContext, sourceContext)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for automation execution")

--- a/services/tuttid/service/cli/providers/agentcontext/provider_test.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider_test.go
@@ -1553,7 +1553,13 @@ func TestStartCommandPreservesCommaInImagePath(t *testing.T) {
 
 func TestStartCommandInheritsCallerSessionCwd(t *testing.T) {
 	sessions := &fakeAgentSessions{
-		getSession: agentservice.Session{ID: "CALLER-1", Cwd: "/workspace/a"},
+		getSession: agentservice.Session{
+			ID:              "CALLER-1",
+			Cwd:             "/workspace/a-worktree",
+			RailSectionKind: "project",
+			RailProjectPath: "/workspace/a",
+			RailSectionKey:  "project:/workspace/a",
+		},
 	}
 	command := newTestClaudeStartCommand(newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions))
 
@@ -1569,8 +1575,43 @@ func TestStartCommandInheritsCallerSessionCwd(t *testing.T) {
 	if sessions.sessionID != "CALLER-1" {
 		t.Fatalf("sessionID = %q, want CALLER-1", sessions.sessionID)
 	}
+	if sessions.createInput.Cwd == nil || *sessions.createInput.Cwd != "/workspace/a-worktree" {
+		t.Fatalf("Cwd = %#v, want /workspace/a-worktree", sessions.createInput.Cwd)
+	}
+	placement := sessions.createInput.RailPlacement
+	if placement == nil ||
+		placement.Kind != "project" ||
+		placement.ProjectPath != "/workspace/a" ||
+		placement.SectionKey != "project:/workspace/a" {
+		t.Fatalf("RailPlacement = %#v, want caller project placement", placement)
+	}
+}
+
+func TestStartCommandFallsBackToCallerProjectPathWhenCwdIsEmpty(t *testing.T) {
+	sessions := &fakeAgentSessions{
+		getSession: agentservice.Session{
+			ID:              "CALLER-1",
+			RailSectionKind: "project",
+			RailProjectPath: "/workspace/a",
+			RailSectionKey:  "project:/workspace/a",
+		},
+	}
+	command := newTestCodexStartCommand(newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions))
+
+	_, err := command.Handler(context.Background(), cliservice.InvokeRequest{
+		Input: map[string]any{"agent-id": agenttargetbiz.IDLocalCodex, "prompt": "do work"},
+		Context: cliservice.InvokeContext{
+			AgentSessionID: "CALLER-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Handler: %v", err)
+	}
 	if sessions.createInput.Cwd == nil || *sessions.createInput.Cwd != "/workspace/a" {
-		t.Fatalf("Cwd = %#v, want /workspace/a", sessions.createInput.Cwd)
+		t.Fatalf("Cwd = %#v, want caller project path fallback", sessions.createInput.Cwd)
+	}
+	if sessions.createInput.RailPlacement == nil {
+		t.Fatal("RailPlacement = nil, want caller project placement")
 	}
 }
 
@@ -1627,6 +1668,9 @@ func TestStartCommandExplicitCwdOverridesCallerSessionCwd(t *testing.T) {
 	if sessions.createInput.Cwd == nil || *sessions.createInput.Cwd != "/workspace/other" {
 		t.Fatalf("Cwd = %#v, want /workspace/other", sessions.createInput.Cwd)
 	}
+	if sessions.createInput.RailPlacement != nil {
+		t.Fatalf("RailPlacement = %#v, want explicit cwd to retain its own placement policy", sessions.createInput.RailPlacement)
+	}
 }
 
 func TestStartCommandWithoutCallerSessionLeavesCwdForAllocator(t *testing.T) {
@@ -1644,7 +1688,7 @@ func TestStartCommandWithoutCallerSessionLeavesCwdForAllocator(t *testing.T) {
 	}
 }
 
-func TestStartCommandMissingCallerSessionLeavesCwdForAllocator(t *testing.T) {
+func TestStartCommandMissingCallerSessionFailsClosed(t *testing.T) {
 	sessions := &fakeAgentSessions{getErr: agentservice.ErrSessionNotFound}
 	command := newTestCodexStartCommand(newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions))
 
@@ -1654,11 +1698,11 @@ func TestStartCommandMissingCallerSessionLeavesCwdForAllocator(t *testing.T) {
 			AgentSessionID: "CALLER-1",
 		},
 	})
-	if err != nil {
-		t.Fatalf("Handler: %v", err)
+	if !errors.Is(err, agentservice.ErrSessionNotFound) {
+		t.Fatalf("Handler error = %v, want ErrSessionNotFound", err)
 	}
-	if sessions.createInput.Cwd != nil {
-		t.Fatalf("Cwd = %#v, want nil", sessions.createInput.Cwd)
+	if sessions.createCallCount != 0 {
+		t.Fatalf("createCallCount = %d, want no detached session", sessions.createCallCount)
 	}
 }
 

--- a/services/tuttid/service/cli/providers/agentcontext/session_commands.go
+++ b/services/tuttid/service/cli/providers/agentcontext/session_commands.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
 	"github.com/tutti-os/tutti/services/tuttid/biz/agentgui"
 	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
@@ -140,7 +141,7 @@ func (p Provider) runStart(ctx context.Context, invoke framework.InvokeContext, 
 		return nil, fmt.Errorf("%w: agent target id is required", cliservice.ErrInvalidInput)
 	}
 	provider := strings.TrimSpace(target.Provider)
-	cwd, err := p.resolveStartCwd(ctx, invoke.WorkspaceID, input.Cwd, invoke.Request.Context)
+	launchContext, err := p.resolveStartLaunchContext(ctx, invoke.WorkspaceID, input.Cwd, invoke.Request.Context)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +152,7 @@ func (p Provider) runStart(ctx context.Context, invoke framework.InvokeContext, 
 	created, err := p.sessions.CreateWithResult(ctx, invoke.WorkspaceID, agentservice.CreateSessionInput{
 		Provider:               provider,
 		AgentTargetID:          agentTargetID,
-		Cwd:                    optionalStringPointer(cwd),
+		Cwd:                    optionalStringPointer(launchContext.cwd),
 		InitialContent:         initialContent,
 		InitialDisplayPrompt:   input.DisplayPrompt,
 		Model:                  optionalStringPointer(input.Model),
@@ -162,6 +163,7 @@ func (p Provider) runStart(ctx context.Context, invoke framework.InvokeContext, 
 		Visible:                hiddenVisibleOverride(input.Hidden),
 		ConversationDetailMode: p.composerConversationDetailMode(ctx),
 		Isolation:              input.Isolation,
+		RailPlacement:          launchContext.railPlacement,
 	})
 	if err != nil {
 		return nil, err
@@ -203,30 +205,62 @@ func hiddenVisibleOverride(hidden bool) *bool {
 	return &visible
 }
 
-func (p Provider) resolveStartCwd(
+type startLaunchContext struct {
+	cwd           string
+	railPlacement *agenthost.RailPlacement
+}
+
+func (p Provider) resolveStartLaunchContext(
 	ctx context.Context,
 	workspaceID string,
 	explicit string,
 	invokeContext cliservice.InvokeContext,
-) (string, error) {
+) (startLaunchContext, error) {
 	if cwd := strings.TrimSpace(explicit); cwd != "" {
-		return cwd, nil
+		return startLaunchContext{cwd: cwd}, nil
 	}
 	callerID := strings.TrimSpace(invokeContext.AgentSessionID)
 	if callerID == "" {
-		return "", nil
+		return startLaunchContext{}, nil
 	}
 	session, err := p.sessions.Get(ctx, workspaceID, callerID)
 	if err != nil {
-		if errors.Is(err, agentservice.ErrSessionNotFound) {
-			return "", nil
+		return startLaunchContext{}, err
+	}
+	kind := agenthost.RailPlacementKind(strings.TrimSpace(session.RailSectionKind))
+	projectPath := strings.TrimSpace(session.RailProjectPath)
+	cwd := strings.TrimSpace(session.Cwd)
+	if cwd == "" && kind == agenthost.RailPlacementKindProject {
+		cwd = projectPath
+	}
+	return startLaunchContext{
+		cwd:           cwd,
+		railPlacement: railPlacementFromCallerSession(session),
+	}, nil
+}
+
+func railPlacementFromCallerSession(session agentservice.Session) *agenthost.RailPlacement {
+	kind := agenthost.RailPlacementKind(strings.TrimSpace(session.RailSectionKind))
+	projectPath := strings.TrimSpace(session.RailProjectPath)
+	sectionKey := strings.TrimSpace(session.RailSectionKey)
+	switch kind {
+	case agenthost.RailPlacementKindConversations:
+		if projectPath != "" || sectionKey != "conversations" {
+			return nil
 		}
-		return "", err
+	case agenthost.RailPlacementKindProject:
+		if projectPath == "" || sectionKey == "" || sectionKey == "conversations" {
+			return nil
+		}
+	default:
+		return nil
 	}
-	if cwd := strings.TrimSpace(session.Cwd); cwd != "" {
-		return cwd, nil
+	return &agenthost.RailPlacement{
+		Version:     1,
+		Kind:        kind,
+		ProjectPath: projectPath,
+		SectionKey:  sectionKey,
 	}
-	return "", nil
 }
 
 func (p Provider) newOpenCommand() cliservice.Command {

--- a/services/tuttid/service/tuttimodeexecution/conformance_test.go
+++ b/services/tuttid/service/tuttimodeexecution/conformance_test.go
@@ -44,6 +44,15 @@ type sqliteConformanceDriver struct {
 	cancelAuto         context.CancelFunc
 }
 
+type conformanceSourceSessionContextResolver struct{}
+
+func (conformanceSourceSessionContextResolver) ResolveSourceSessionContext(
+	_ string,
+	_ string,
+) (workspaceservice.IssueSourceSessionContext, bool) {
+	return workspaceservice.IssueSourceSessionContext{}, true
+}
+
 type controlledClock struct {
 	mu  sync.Mutex
 	now time.Time
@@ -320,6 +329,7 @@ func newSQLiteConformanceDriver(t *testing.T) *sqliteConformanceDriver {
 		dbPath: dbPath, store: store,
 		issues: workspaceservice.IssueManagerService{
 			Store: store, RunLauncher: launcher, TuttiModeExecutions: executions,
+			SourceSessionContextResolver:    conformanceSourceSessionContextResolver{},
 			MutationLocks:                   workspaceservice.NewIssueMutationLocks(),
 			TuttiModeRunLaunchLeaseDuration: time.Minute,
 			RunLaunchLeaseRenewalScheduler:  renewals,

--- a/services/tuttid/service/workspace/issue_execution_ports.go
+++ b/services/tuttid/service/workspace/issue_execution_ports.go
@@ -69,13 +69,28 @@ type IssueRunLaunch struct {
 	PermissionModeID   string
 	WorktreeBase       string
 	WorktreeBranch     string
+	RailPlacement      *IssueRunRailPlacement
 }
 
-// IssueSourceSessionDirectoryResolver is the narrow read needed to inherit
-// the planning session's working directory. Agent session lifecycle and
-// projection details stay outside Issue Manager.
-type IssueSourceSessionDirectoryResolver interface {
-	ResolveSourceSessionDirectory(workspaceID string, agentSessionID string) (string, bool)
+// IssueRunRailPlacement is the source conversation's logical rail identity.
+// It stays independent from ExecutionDirectory because a delegate may execute
+// inside an isolated worktree while remaining grouped with the source project.
+type IssueRunRailPlacement struct {
+	Kind        string
+	ProjectPath string
+	SectionKey  string
+}
+
+// IssueSourceSessionContext is the narrow source-session projection needed by
+// Issue dispatch. Agent lifecycle and persistence DTOs stay outside Issue
+// Manager.
+type IssueSourceSessionContext struct {
+	WorkingDirectory string
+	RailPlacement    *IssueRunRailPlacement
+}
+
+type IssueSourceSessionContextResolver interface {
+	ResolveSourceSessionContext(workspaceID string, agentSessionID string) (IssueSourceSessionContext, bool)
 }
 
 type IssueRunCancelState string

--- a/services/tuttid/service/workspace/issue_scheduled_dispatch.go
+++ b/services/tuttid/service/workspace/issue_scheduled_dispatch.go
@@ -76,11 +76,30 @@ func (s IssueManagerService) ScheduleTuttiModeIssue(
 	detail.Tasks = s.projectReviewedSettlementSubjectForSchedule(
 		ctx, workspaceID, input.IssueID, input.CheckpointID, detail.Tasks,
 	)
-	if err := s.validateTuttiModeScheduleIsolation(detail.Issue, detail.Tasks, input.TaskIDs); err != nil {
+	sourceContext, ok := s.resolveIssueSourceSessionContext(detail.Issue)
+	if !ok {
+		unlockIssue()
+		return ScheduleTuttiModeIssueResult{}, executionbiz.Reject(
+			executionbiz.ErrScheduleRejected,
+			executionbiz.RejectionWrongSourceSession,
+			"",
+		)
+	}
+	if err := s.validateTuttiModeScheduleIsolation(
+		detail.Issue,
+		detail.Tasks,
+		input.TaskIDs,
+		sourceContext,
+	); err != nil {
 		unlockIssue()
 		return ScheduleTuttiModeIssueResult{}, err
 	}
-	runs, err := s.prepareTuttiModeScheduleRuns(detail.Issue, detail.Tasks, input.TaskIDs)
+	runs, err := s.prepareTuttiModeScheduleRuns(
+		detail.Issue,
+		detail.Tasks,
+		input.TaskIDs,
+		sourceContext,
+	)
 	if err != nil {
 		unlockIssue()
 		return ScheduleTuttiModeIssueResult{}, err
@@ -114,7 +133,13 @@ func (s IssueManagerService) ScheduleTuttiModeIssue(
 		unlockIssue()
 		return ScheduleTuttiModeIssueResult{}, err
 	}
-	launches := s.tuttiModeLaunchesForRuns(ctx, detail.Issue, detail.Tasks, preparedRuns)
+	launches := s.tuttiModeLaunchesForRuns(
+		ctx,
+		detail.Issue,
+		detail.Tasks,
+		preparedRuns,
+		sourceContext,
+	)
 	unlockIssue()
 
 	s.launchScheduledTuttiModeRuns(ctx, launches)
@@ -169,6 +194,7 @@ func (IssueManagerService) validateTuttiModeScheduleIsolation(
 	issue workspaceissues.Issue,
 	tasks []workspaceissues.Task,
 	taskIDs []string,
+	sourceContext IssueSourceSessionContext,
 ) error {
 	byID := make(map[string]workspaceissues.Task, len(tasks))
 	activeOther := false
@@ -217,7 +243,7 @@ func (IssueManagerService) validateTuttiModeScheduleIsolation(
 			)
 		}
 		if issue.SequentialExecution {
-			if _, concurrent := s.sequentialTaskIsolation(issue, tasks, task); !concurrent {
+			if _, concurrent := sequentialTaskIsolation(tasks, task, sourceContext); !concurrent {
 				return executionbiz.Reject(
 					executionbiz.ErrScheduleRejected,
 					executionbiz.RejectionParallelismRejected,
@@ -233,6 +259,7 @@ func (IssueManagerService) prepareTuttiModeScheduleRuns(
 	issue workspaceissues.Issue,
 	tasks []workspaceissues.Task,
 	taskIDs []string,
+	sourceContext IssueSourceSessionContext,
 ) ([]workspaceissues.Run, error) {
 	if issue.PlanningSource != workspaceissues.PlanningSourceTuttiModePlan {
 		return nil, executionbiz.Reject(
@@ -267,7 +294,7 @@ func (IssueManagerService) prepareTuttiModeScheduleRuns(
 		}
 		seen[taskID] = struct{}{}
 		runID := uuid.NewString()
-		executionDirectory := s.resolveIssueTaskBaseDirectory(issue, task)
+		executionDirectory := resolveIssueTaskBaseDirectory(task, sourceContext)
 		runs = append(runs, workspaceissues.Run{
 			RunID:              runID,
 			TaskID:             task.TaskID,
@@ -296,6 +323,7 @@ func (s IssueManagerService) tuttiModeLaunchesForRuns(
 	issue workspaceissues.Issue,
 	tasks []workspaceissues.Task,
 	preparedRuns []executionbiz.PreparedRunLaunch,
+	sourceContext IssueSourceSessionContext,
 ) []IssueRunLaunch {
 	byID := make(map[string]workspaceissues.Task, len(tasks))
 	for _, task := range tasks {
@@ -310,7 +338,7 @@ func (s IssueManagerService) tuttiModeLaunchesForRuns(
 		}
 		isolation := issueTaskIsolation{}
 		if task.Parallelizable {
-			isolation, _ = s.sequentialTaskIsolation(issue, tasks, task)
+			isolation, _ = sequentialTaskIsolation(tasks, task, sourceContext)
 		}
 		executionDirectory := run.ExecutionDirectory
 		worktreeBase := ""
@@ -339,6 +367,7 @@ func (s IssueManagerService) tuttiModeLaunchesForRuns(
 			PermissionModeID:   task.PermissionModeID,
 			WorktreeBase:       worktreeBase,
 			WorktreeBranch:     worktreeBranch,
+			RailPlacement:      cloneIssueRunRailPlacement(sourceContext.RailPlacement),
 		})
 	}
 	return launches
@@ -542,7 +571,18 @@ func (s IssueManagerService) RecoverTuttiModeRunLaunchIntents(
 			unlockIssue()
 			return getErr
 		}
-		launches := s.tuttiModeLaunchesForRuns(ctx, detail.Issue, detail.Tasks, byIssue[issueID])
+		sourceContext, ok := s.resolveIssueSourceSessionContext(detail.Issue)
+		if !ok {
+			unlockIssue()
+			continue
+		}
+		launches := s.tuttiModeLaunchesForRuns(
+			ctx,
+			detail.Issue,
+			detail.Tasks,
+			byIssue[issueID],
+			sourceContext,
+		)
 		unlockIssue()
 		s.launchScheduledTuttiModeRuns(ctx, launches)
 	}

--- a/services/tuttid/service/workspace/issue_scheduled_dispatch.go
+++ b/services/tuttid/service/workspace/issue_scheduled_dispatch.go
@@ -165,7 +165,7 @@ func (s IssueManagerService) projectReviewedSettlementSubjectForSchedule(
 	return projected
 }
 
-func (s IssueManagerService) validateTuttiModeScheduleIsolation(
+func (IssueManagerService) validateTuttiModeScheduleIsolation(
 	issue workspaceissues.Issue,
 	tasks []workspaceissues.Task,
 	taskIDs []string,
@@ -229,7 +229,7 @@ func (s IssueManagerService) validateTuttiModeScheduleIsolation(
 	return nil
 }
 
-func (s IssueManagerService) prepareTuttiModeScheduleRuns(
+func (IssueManagerService) prepareTuttiModeScheduleRuns(
 	issue workspaceissues.Issue,
 	tasks []workspaceissues.Task,
 	taskIDs []string,

--- a/services/tuttid/service/workspace/issue_scheduled_dispatch_test.go
+++ b/services/tuttid/service/workspace/issue_scheduled_dispatch_test.go
@@ -199,6 +199,63 @@ func (launcher *scheduledLaunchRecorder) Launch(context.Context, IssueRunLaunch)
 	return nil
 }
 
+func TestTuttiModeLaunchPreservesSourceRailPlacement(t *testing.T) {
+	t.Parallel()
+
+	placement := &IssueRunRailPlacement{
+		Kind:        "project",
+		ProjectPath: "/repo",
+		SectionKey:  "project:/repo",
+	}
+	issue := workspaceissues.Issue{
+		WorkspaceID:     "workspace",
+		IssueID:         "issue",
+		SourceSessionID: "source",
+	}
+	task := workspaceissues.Task{
+		WorkspaceID:   issue.WorkspaceID,
+		IssueID:       issue.IssueID,
+		TaskID:        "task",
+		Title:         "Task",
+		AgentTargetID: "local:codex",
+	}
+	run := workspaceissues.Run{
+		WorkspaceID:        issue.WorkspaceID,
+		IssueID:            issue.IssueID,
+		TaskID:             task.TaskID,
+		RunID:              "run",
+		AgentSessionID:     "delegate",
+		AgentTargetID:      task.AgentTargetID,
+		ExecutionDirectory: "/repo",
+	}
+	launches := (IssueManagerService{}).tuttiModeLaunchesForRuns(
+		context.Background(),
+		issue,
+		[]workspaceissues.Task{task},
+		[]executionbiz.PreparedRunLaunch{{
+			Run:            run,
+			ClientSubmitID: "submit",
+		}},
+		IssueSourceSessionContext{
+			WorkingDirectory: "/repo",
+			RailPlacement:    placement,
+		},
+	)
+	if len(launches) != 1 {
+		t.Fatalf("launches = %d, want one", len(launches))
+	}
+	launch := launches[0]
+	if launch.ExecutionDirectory != "/repo" {
+		t.Fatalf("execution directory = %q, want source runtime directory", launch.ExecutionDirectory)
+	}
+	if launch.RailPlacement == nil || *launch.RailPlacement != *placement {
+		t.Fatalf("rail placement = %#v, want %#v", launch.RailPlacement, placement)
+	}
+	if launch.RailPlacement == placement {
+		t.Fatal("rail placement aliases the source snapshot")
+	}
+}
+
 func TestScheduledRunDeliveryUsesSharedSeamAndRenewsDurableLease(t *testing.T) {
 	t.Parallel()
 

--- a/services/tuttid/service/workspace/issue_sequential_dispatch.go
+++ b/services/tuttid/service/workspace/issue_sequential_dispatch.go
@@ -185,7 +185,11 @@ func (s IssueManagerService) claimIssueTaskRunLocked(
 ) (IssueRunLaunch, bool) {
 	agentSessionID := uuid.NewString()
 	runID := uuid.NewString()
-	executionDirectory := s.resolveIssueTaskBaseDirectory(issue, task)
+	sourceContext, _ := s.resolveIssueSourceSessionContext(issue)
+	executionDirectory := strings.TrimSpace(task.ExecutionDirectory)
+	if executionDirectory == "" {
+		executionDirectory = strings.TrimSpace(sourceContext.WorkingDirectory)
+	}
 	worktreeBranch := ""
 	worktreeBase := ""
 	if isolation.worktreeBase != "" {
@@ -223,7 +227,16 @@ func (s IssueManagerService) claimIssueTaskRunLocked(
 		PermissionModeID:   task.PermissionModeID,
 		WorktreeBase:       worktreeBase,
 		WorktreeBranch:     worktreeBranch,
+		RailPlacement:      cloneIssueRunRailPlacement(sourceContext.RailPlacement),
 	}, true
+}
+
+func cloneIssueRunRailPlacement(placement *IssueRunRailPlacement) *IssueRunRailPlacement {
+	if placement == nil {
+		return nil
+	}
+	cloned := *placement
+	return &cloned
 }
 
 func (s IssueManagerService) launchClaimedIssueRuns(ctx context.Context, launches []IssueRunLaunch) {

--- a/services/tuttid/service/workspace/issue_sequential_dispatch.go
+++ b/services/tuttid/service/workspace/issue_sequential_dispatch.go
@@ -39,6 +39,14 @@ func (s IssueManagerService) claimEligibleIssueRunsLocked(ctx context.Context, w
 	if detail.Issue.Budget.Status != workspaceissues.BudgetStatusActive {
 		return nil
 	}
+	sourceContext := IssueSourceSessionContext{}
+	if strings.TrimSpace(detail.Issue.SourceSessionID) != "" {
+		var ok bool
+		sourceContext, ok = s.resolveIssueSourceSessionContext(detail.Issue)
+		if !ok {
+			return nil
+		}
+	}
 	inflight := 0
 	for _, task := range detail.Tasks {
 		switch task.Status {
@@ -99,13 +107,13 @@ func (s IssueManagerService) claimEligibleIssueRunsLocked(ctx context.Context, w
 			if concurrent {
 				// A parallelizable task without a safe isolation story
 				// degrades to exclusive dispatch instead of trampling.
-				isolation, concurrent = s.sequentialTaskIsolation(detail.Issue, tasks, task)
+				isolation, concurrent = sequentialTaskIsolation(tasks, task, sourceContext)
 			}
 			if !concurrent {
 				// Exclusive task: launch only into an idle Issue, and bar
 				// everything behind it until it completes and is accepted.
 				if inflight == 0 && launchedConcurrent == 0 {
-					if launch, ok := s.claimIssueTaskRunLocked(ctx, detail.Issue, task, issueTaskIsolation{}, s.dependencyWorktreeOutputs(ctx, detail.Issue, task, byID)); ok {
+					if launch, ok := s.claimIssueTaskRunLocked(ctx, detail.Issue, task, issueTaskIsolation{}, sourceContext, s.dependencyWorktreeOutputs(ctx, detail.Issue, task, byID)); ok {
 						launches = append(launches, launch)
 					}
 				}
@@ -114,14 +122,14 @@ func (s IssueManagerService) claimEligibleIssueRunsLocked(ctx context.Context, w
 			if concurrentSlots <= 0 {
 				return launches
 			}
-			if launch, ok := s.claimIssueTaskRunLocked(ctx, detail.Issue, task, isolation, s.dependencyWorktreeOutputs(ctx, detail.Issue, task, byID)); ok {
+			if launch, ok := s.claimIssueTaskRunLocked(ctx, detail.Issue, task, isolation, sourceContext, s.dependencyWorktreeOutputs(ctx, detail.Issue, task, byID)); ok {
 				launches = append(launches, launch)
 			}
 			concurrentSlots--
 			launchedConcurrent++
 			continue
 		}
-		if launch, ok := s.claimIssueTaskRunLocked(ctx, detail.Issue, task, issueTaskIsolation{}, s.dependencyWorktreeOutputs(ctx, detail.Issue, task, byID)); ok {
+		if launch, ok := s.claimIssueTaskRunLocked(ctx, detail.Issue, task, issueTaskIsolation{}, sourceContext, s.dependencyWorktreeOutputs(ctx, detail.Issue, task, byID)); ok {
 			launches = append(launches, launch)
 		}
 		concurrentSlots--
@@ -181,11 +189,11 @@ func (s IssueManagerService) claimIssueTaskRunLocked(
 	issue workspaceissues.Issue,
 	task workspaceissues.Task,
 	isolation issueTaskIsolation,
+	sourceContext IssueSourceSessionContext,
 	dependencyOutputs []issueTaskDependencyOutput,
 ) (IssueRunLaunch, bool) {
 	agentSessionID := uuid.NewString()
 	runID := uuid.NewString()
-	sourceContext, _ := s.resolveIssueSourceSessionContext(issue)
 	executionDirectory := strings.TrimSpace(task.ExecutionDirectory)
 	if executionDirectory == "" {
 		executionDirectory = strings.TrimSpace(sourceContext.WorkingDirectory)

--- a/services/tuttid/service/workspace/issue_sequential_dispatch_test.go
+++ b/services/tuttid/service/workspace/issue_sequential_dispatch_test.go
@@ -21,13 +21,27 @@ import (
 )
 
 type sequentialSessionCreatorRecorder struct {
-	inputs []agentservice.CreateSessionInput
+	inputs   []agentservice.CreateSessionInput
+	launches []IssueRunLaunch
 }
 
 func (r *sequentialSessionCreatorRecorder) Launch(_ context.Context, launch IssueRunLaunch) error {
 	input := createSessionInputFromLaunch(launch)
+	r.launches = append(r.launches, launch)
 	r.inputs = append(r.inputs, input)
 	return nil
+}
+
+type staticIssueSourceSessionContextResolver struct {
+	context IssueSourceSessionContext
+	ok      bool
+}
+
+func (r staticIssueSourceSessionContextResolver) ResolveSourceSessionContext(
+	_ string,
+	_ string,
+) (IssueSourceSessionContext, bool) {
+	return r.context, r.ok
 }
 
 func createSessionInputFromLaunch(launch IssueRunLaunch) agentservice.CreateSessionInput {
@@ -840,6 +854,60 @@ func TestSequentialIssueRunsParallelizableTasksInIsolatedWorktrees(t *testing.T)
 	}
 	if len(cwds) != 2 {
 		t.Fatalf("worktree cwds = %v, want two distinct directories", cwds)
+	}
+}
+
+func TestSequentialIssueWorktreeDelegatesKeepSourceProjectRailPlacement(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := initIssueTaskGitRepo(t)
+	service, creator, worktreeRoot := newParallelizableDispatchService(t, "ws-par-source-placement")
+	sectionKey := "project:" + repo
+	sourcePlacement := &IssueRunRailPlacement{
+		Kind:        "project",
+		ProjectPath: repo,
+		SectionKey:  sectionKey,
+	}
+	service.SourceSessionContextResolver = staticIssueSourceSessionContextResolver{
+		context: IssueSourceSessionContext{
+			WorkingDirectory: repo,
+			RailPlacement:    sourcePlacement,
+		},
+		ok: true,
+	}
+	if _, err := service.CreateIssueFromPlan(ctx, "ws-par-source-placement", CreateIssueManagerIssueFromPlanInput{
+		Issue: CreateIssueManagerIssueInput{
+			IssueID:             "issue-source-placement",
+			TopicID:             workspaceissues.DefaultTopicID,
+			Title:               "Source placement issue",
+			PlanningSource:      string(workspaceissues.PlanningSourceTraditionalPlan),
+			SourceSessionID:     "planning-session",
+			SequentialExecution: true,
+		},
+		Tasks: []CreateIssueManagerTaskItemInput{
+			{TaskID: "p1", Title: "First parallel", AgentTargetID: agenttargetbiz.IDLocalCodex, Parallelizable: true},
+			{TaskID: "p2", Title: "Second parallel", AgentTargetID: agenttargetbiz.IDLocalCodex, Parallelizable: true},
+		},
+	}); err != nil {
+		t.Fatalf("CreateIssueFromPlan() error = %v", err)
+	}
+	if len(creator.launches) != 2 {
+		t.Fatalf("launches = %d, want both parallelizable tasks", len(creator.launches))
+	}
+	for _, launch := range creator.launches {
+		if launch.ExecutionDirectory == repo || !strings.HasPrefix(launch.ExecutionDirectory, worktreeRoot) {
+			t.Fatalf(
+				"launch execution directory = %q, want isolated worktree under %q",
+				launch.ExecutionDirectory,
+				worktreeRoot,
+			)
+		}
+		if launch.RailPlacement == nil {
+			t.Fatalf("launch rail placement is nil")
+		}
+		if *launch.RailPlacement != *sourcePlacement {
+			t.Fatalf("launch rail placement = %#v, want %#v", launch.RailPlacement, sourcePlacement)
+		}
 	}
 }
 

--- a/services/tuttid/service/workspace/issue_sequential_dispatch_test.go
+++ b/services/tuttid/service/workspace/issue_sequential_dispatch_test.go
@@ -44,6 +44,31 @@ func (r staticIssueSourceSessionContextResolver) ResolveSourceSessionContext(
 	return r.context, r.ok
 }
 
+type countingIssueSourceSessionContextResolver struct {
+	context IssueSourceSessionContext
+	calls   int
+}
+
+func (r *countingIssueSourceSessionContextResolver) ResolveSourceSessionContext(
+	_ string,
+	_ string,
+) (IssueSourceSessionContext, bool) {
+	r.calls++
+	return r.context, r.calls == 1
+}
+
+func availableIssueSourceSessionContextResolver() IssueSourceSessionContextResolver {
+	return staticIssueSourceSessionContextResolver{
+		context: IssueSourceSessionContext{
+			RailPlacement: &IssueRunRailPlacement{
+				Kind:       "conversations",
+				SectionKey: "conversations",
+			},
+		},
+		ok: true,
+	}
+}
+
 func createSessionInputFromLaunch(launch IssueRunLaunch) agentservice.CreateSessionInput {
 	reasoningIntensity := launch.ReasoningIntensity
 	return agentservice.CreateSessionInput{
@@ -84,9 +109,10 @@ func TestIssueSequentialExecutionDispatchesSuccessorOnlyAfterUserAcceptance(t *t
 	}
 	creator := &sequentialSessionCreatorRecorder{}
 	service := IssueManagerService{
-		RunLauncher:       creator,
-		Store:             store,
-		AgentTargetReader: store,
+		RunLauncher:                  creator,
+		Store:                        store,
+		AgentTargetReader:            store,
+		SourceSessionContextResolver: availableIssueSourceSessionContextResolver(),
 	}
 	detail, err := service.CreateIssueFromPlan(ctx, "workspace-sequential", CreateIssueManagerIssueFromPlanInput{
 		Issue: CreateIssueManagerIssueInput{
@@ -868,13 +894,13 @@ func TestSequentialIssueWorktreeDelegatesKeepSourceProjectRailPlacement(t *testi
 		ProjectPath: repo,
 		SectionKey:  sectionKey,
 	}
-	service.SourceSessionContextResolver = staticIssueSourceSessionContextResolver{
+	resolver := &countingIssueSourceSessionContextResolver{
 		context: IssueSourceSessionContext{
 			WorkingDirectory: repo,
 			RailPlacement:    sourcePlacement,
 		},
-		ok: true,
 	}
+	service.SourceSessionContextResolver = resolver
 	if _, err := service.CreateIssueFromPlan(ctx, "ws-par-source-placement", CreateIssueManagerIssueFromPlanInput{
 		Issue: CreateIssueManagerIssueInput{
 			IssueID:             "issue-source-placement",
@@ -908,6 +934,39 @@ func TestSequentialIssueWorktreeDelegatesKeepSourceProjectRailPlacement(t *testi
 		if *launch.RailPlacement != *sourcePlacement {
 			t.Fatalf("launch rail placement = %#v, want %#v", launch.RailPlacement, sourcePlacement)
 		}
+	}
+	if resolver.calls != 1 {
+		t.Fatalf("source context resolver calls = %d, want one immutable dispatch snapshot", resolver.calls)
+	}
+}
+
+func TestIssueWithMissingSourceSessionDoesNotClaimOrLaunchRun(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	service, creator, _ := newParallelizableDispatchService(t, "ws-missing-source")
+	service.SourceSessionContextResolver = staticIssueSourceSessionContextResolver{}
+
+	detail, err := service.CreateIssueFromPlan(ctx, "ws-missing-source", CreateIssueManagerIssueFromPlanInput{
+		Issue: CreateIssueManagerIssueInput{
+			IssueID:             "issue-missing-source",
+			TopicID:             workspaceissues.DefaultTopicID,
+			Title:               "Missing source",
+			PlanningSource:      string(workspaceissues.PlanningSourceTraditionalPlan),
+			SourceSessionID:     "deleted-planning-session",
+			SequentialExecution: true,
+		},
+		Tasks: []CreateIssueManagerTaskItemInput{{
+			TaskID: "task-1", Title: "Must wait", AgentTargetID: agenttargetbiz.IDLocalCodex,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateIssueFromPlan() error = %v", err)
+	}
+	if len(creator.launches) != 0 {
+		t.Fatalf("launches = %#v, want none while source Session is unavailable", creator.launches)
+	}
+	if detail.Tasks[0].Status != workspaceissues.StatusNotStarted || detail.Tasks[0].LatestRunID != "" {
+		t.Fatalf("task = %#v, want unclaimed not_started task", detail.Tasks[0])
 	}
 }
 
@@ -995,9 +1054,10 @@ func TestAutoAcceptTaskCompletionAdvancesDispatchWithoutHumanGate(t *testing.T) 
 	}
 	creator := &sequentialSessionCreatorRecorder{}
 	service := IssueManagerService{
-		RunLauncher:       creator,
-		Store:             store,
-		AgentTargetReader: store,
+		RunLauncher:                  creator,
+		Store:                        store,
+		AgentTargetReader:            store,
+		SourceSessionContextResolver: availableIssueSourceSessionContextResolver(),
 	}
 	detail, err := service.CreateIssueFromPlan(ctx, "workspace-auto-accept", CreateIssueManagerIssueFromPlanInput{
 		Issue: CreateIssueManagerIssueInput{
@@ -1052,9 +1112,10 @@ func TestReworkFromPendingAcceptanceRedispatchesSequentialHead(t *testing.T) {
 	}
 	creator := &sequentialSessionCreatorRecorder{}
 	service := IssueManagerService{
-		RunLauncher:       creator,
-		Store:             store,
-		AgentTargetReader: store,
+		RunLauncher:                  creator,
+		Store:                        store,
+		AgentTargetReader:            store,
+		SourceSessionContextResolver: availableIssueSourceSessionContextResolver(),
 	}
 	detail, err := service.CreateIssueFromPlan(ctx, "workspace-rework", CreateIssueManagerIssueFromPlanInput{
 		Issue: CreateIssueManagerIssueInput{
@@ -1119,10 +1180,11 @@ func TestTuttiModePlanInitialScheduleMaterializationIsInert(t *testing.T) {
 		Clock: func() time.Time { return now },
 	}
 	service := IssueManagerService{
-		RunLauncher:         creator,
-		Store:               store,
-		AgentTargetReader:   store,
-		TuttiModeExecutions: executions,
+		RunLauncher:                  creator,
+		Store:                        store,
+		AgentTargetReader:            store,
+		SourceSessionContextResolver: availableIssueSourceSessionContextResolver(),
+		TuttiModeExecutions:          executions,
 	}
 	detail, err := service.CreateIssueFromPlan(ctx, "ws-inert-tutti", CreateIssueManagerIssueFromPlanInput{
 		Issue: CreateIssueManagerIssueInput{
@@ -1223,10 +1285,11 @@ func TestCancelIssueExecutionCancelsAllRunningTraditionalPlanRuns(t *testing.T) 
 	creator := &sequentialSessionCreatorRecorder{}
 	canceller := &runSessionCancellerRecorder{}
 	service := IssueManagerService{
-		RunLauncher:       creator,
-		Store:             store,
-		AgentTargetReader: store,
-		MutationLocks:     NewIssueMutationLocks(),
+		RunLauncher:                  creator,
+		Store:                        store,
+		AgentTargetReader:            store,
+		MutationLocks:                NewIssueMutationLocks(),
+		SourceSessionContextResolver: availableIssueSourceSessionContextResolver(),
 	}
 	coordinator := IssueExecutionCoordinator{Issues: &service, RunSessionCanceller: canceller}
 	detail, err := service.CreateIssueFromPlan(ctx, "ws-stop-cascade", CreateIssueManagerIssueFromPlanInput{
@@ -1564,9 +1627,10 @@ func TestTraditionalPlanFailedRunCanBeReworkedAndRedispatched(t *testing.T) {
 	}
 	creator := &sequentialSessionCreatorRecorder{}
 	service := IssueManagerService{
-		RunLauncher:       creator,
-		Store:             store,
-		AgentTargetReader: store,
+		RunLauncher:                  creator,
+		Store:                        store,
+		AgentTargetReader:            store,
+		SourceSessionContextResolver: availableIssueSourceSessionContextResolver(),
 	}
 	detail, err := service.CreateIssueFromPlan(ctx, "workspace-fail-notify", CreateIssueManagerIssueFromPlanInput{
 		Issue: CreateIssueManagerIssueInput{

--- a/services/tuttid/service/workspace/issue_task_worktree.go
+++ b/services/tuttid/service/workspace/issue_task_worktree.go
@@ -39,12 +39,17 @@ func (s IssueManagerService) resolveIssueTaskBaseDirectory(issue workspaceissues
 	if explicit := strings.TrimSpace(task.ExecutionDirectory); explicit != "" {
 		return explicit
 	}
-	if s.SourceSessionDirectoryResolver != nil && strings.TrimSpace(issue.SourceSessionID) != "" {
-		if directory, ok := s.SourceSessionDirectoryResolver.ResolveSourceSessionDirectory(issue.WorkspaceID, issue.SourceSessionID); ok {
-			return strings.TrimSpace(directory)
-		}
+	if source, ok := s.resolveIssueSourceSessionContext(issue); ok {
+		return strings.TrimSpace(source.WorkingDirectory)
 	}
 	return ""
+}
+
+func (s IssueManagerService) resolveIssueSourceSessionContext(issue workspaceissues.Issue) (IssueSourceSessionContext, bool) {
+	if s.SourceSessionContextResolver == nil || strings.TrimSpace(issue.SourceSessionID) == "" {
+		return IssueSourceSessionContext{}, false
+	}
+	return s.SourceSessionContextResolver.ResolveSourceSessionContext(issue.WorkspaceID, issue.SourceSessionID)
 }
 
 // sequentialTaskIsolation decides whether a parallelizable task may actually

--- a/services/tuttid/service/workspace/issue_task_worktree.go
+++ b/services/tuttid/service/workspace/issue_task_worktree.go
@@ -35,14 +35,11 @@ func (s IssueManagerService) taskWorktreeRoot() string {
 // resolveIssueTaskBaseDirectory mirrors the launch-time execution directory
 // resolution: the task's explicit directory wins, otherwise the planning
 // session's working directory is inherited.
-func (s IssueManagerService) resolveIssueTaskBaseDirectory(issue workspaceissues.Issue, task workspaceissues.Task) string {
+func resolveIssueTaskBaseDirectory(task workspaceissues.Task, sourceContext IssueSourceSessionContext) string {
 	if explicit := strings.TrimSpace(task.ExecutionDirectory); explicit != "" {
 		return explicit
 	}
-	if source, ok := s.resolveIssueSourceSessionContext(issue); ok {
-		return strings.TrimSpace(source.WorkingDirectory)
-	}
-	return ""
+	return strings.TrimSpace(sourceContext.WorkingDirectory)
 }
 
 func (s IssueManagerService) resolveIssueSourceSessionContext(issue workspaceissues.Issue) (IssueSourceSessionContext, bool) {
@@ -58,10 +55,10 @@ func (s IssueManagerService) resolveIssueSourceSessionContext(issue workspaceiss
 // worktree; anything else (shared non-git directory, unresolvable base)
 // degrades to exclusive dispatch so concurrent sessions can never trample
 // each other.
-func (s IssueManagerService) sequentialTaskIsolation(
-	issue workspaceissues.Issue,
+func sequentialTaskIsolation(
 	tasks []workspaceissues.Task,
 	task workspaceissues.Task,
+	sourceContext IssueSourceSessionContext,
 ) (issueTaskIsolation, bool) {
 	explicit := strings.TrimSpace(task.ExecutionDirectory)
 	if explicit != "" && filepath.IsAbs(explicit) {
@@ -79,7 +76,7 @@ func (s IssueManagerService) sequentialTaskIsolation(
 			return issueTaskIsolation{}, true
 		}
 	}
-	base := s.resolveIssueTaskBaseDirectory(issue, task)
+	base := resolveIssueTaskBaseDirectory(task, sourceContext)
 	if base == "" || !directoryIsGitRepo(base) {
 		return issueTaskIsolation{}, false
 	}

--- a/services/tuttid/service/workspace/issues.go
+++ b/services/tuttid/service/workspace/issues.go
@@ -15,14 +15,14 @@ import (
 const issueManagerLocalActorUserID = "local"
 
 type IssueManagerService struct {
-	RunLauncher                    IssueRunLauncher
-	RunReconciler                  IssueRunReconciler
-	SourceSessionDirectoryResolver IssueSourceSessionDirectoryResolver
-	Publisher                      IssueManagerEventPublisher
-	ExecutionRecoveryQueue         *WorkspaceExecutionRecoveryQueue
-	Store                          workspaceissues.Store
-	AgentTargetReader              IssueAssignmentAgentTargetReader
-	PlanningTimeline               IssuePlanningTimelineReporter
+	RunLauncher                  IssueRunLauncher
+	RunReconciler                IssueRunReconciler
+	SourceSessionContextResolver IssueSourceSessionContextResolver
+	Publisher                    IssueManagerEventPublisher
+	ExecutionRecoveryQueue       *WorkspaceExecutionRecoveryQueue
+	Store                        workspaceissues.Store
+	AgentTargetReader            IssueAssignmentAgentTargetReader
+	PlanningTimeline             IssuePlanningTimelineReporter
 	// TuttiModeExecutions owns the product transaction that atomically adds
 	// the execution aggregate to a validated reusable Issue/task graph.
 	TuttiModeExecutions *tuttimodeexecutionservice.Service

--- a/services/tuttid/wiring_daemon_api.go
+++ b/services/tuttid/wiring_daemon_api.go
@@ -496,16 +496,16 @@ func buildDaemonAPI(
 		Delegate: tuttiModeExecutions,
 	}
 	issueService := workspaceservice.IssueManagerService{
-		RunLauncher:                    issueRunAgentLauncher{Sessions: agentSessionService, Host: agentHost},
-		RunLaunchGate:                  issueRunLaunchGate,
-		RunCancellationRequester:       issueRunCanceller,
-		SourceSessionDirectoryResolver: issueSourceSessionDirectoryResolver{Sessions: agentActivityProjection},
-		Publisher:                      eventstreamservice.WorkspaceIssuePublisher{Service: events},
-		Store:                          issueStore,
-		AgentTargetReader:              agentTargetStore,
-		PlanningTimeline:               agentservice.IssuePlanningTimelineReporter{Projection: agentActivityProjection},
-		TuttiModeExecutions:            tuttiModeExecutions,
-		MutationLocks:                  workspaceservice.NewIssueMutationLocks(),
+		RunLauncher:                  issueRunAgentLauncher{Sessions: agentSessionService, Host: agentHost},
+		RunLaunchGate:                issueRunLaunchGate,
+		RunCancellationRequester:     issueRunCanceller,
+		SourceSessionContextResolver: issueSourceSessionContextResolver{Sessions: agentActivityProjection},
+		Publisher:                    eventstreamservice.WorkspaceIssuePublisher{Service: events},
+		Store:                        issueStore,
+		AgentTargetReader:            agentTargetStore,
+		PlanningTimeline:             agentservice.IssuePlanningTimelineReporter{Projection: agentActivityProjection},
+		TuttiModeExecutions:          tuttiModeExecutions,
+		MutationLocks:                workspaceservice.NewIssueMutationLocks(),
 	}
 	tuttiModePlans := &tuttimodeplanservice.Service{
 		Store:             workflowStore,

--- a/services/tuttid/wiring_test.go
+++ b/services/tuttid/wiring_test.go
@@ -111,6 +111,25 @@ func TestIssueSourceSessionContextResolverReturnsExecutionAndRailIdentity(t *tes
 	}
 }
 
+func TestIssueSourceSessionContextResolverFallsBackToProjectPathWhenCwdIsEmpty(t *testing.T) {
+	resolver := issueSourceSessionContextResolver{Sessions: fakeIssueSourceSessionReader{
+		found: true,
+		session: agentservice.PersistedSession{
+			RailSectionKind: "project",
+			RailProjectPath: " /workspace/project ",
+			RailSectionKey:  "project:/workspace/project",
+		},
+	}}
+
+	got, ok := resolver.ResolveSourceSessionContext("workspace-1", "planning-session")
+	if !ok {
+		t.Fatal("ResolveSourceSessionContext() found = false")
+	}
+	if got.WorkingDirectory != "/workspace/project" {
+		t.Fatalf("working directory = %q, want project-path fallback", got.WorkingDirectory)
+	}
+}
+
 type fakeAnalyticsDebugEventStream struct{}
 
 func (fakeAnalyticsDebugEventStream) PublishFromServer(context.Context, string, []byte) error {

--- a/services/tuttid/wiring_test.go
+++ b/services/tuttid/wiring_test.go
@@ -15,6 +15,102 @@ import (
 	tuttitypes "github.com/tutti-os/tutti/services/tuttid/types"
 )
 
+type recordingIssueRunAgentSessionCreator struct {
+	workspaceID string
+	input       agentservice.CreateSessionInput
+}
+
+func (r *recordingIssueRunAgentSessionCreator) Create(
+	_ context.Context,
+	workspaceID string,
+	input agentservice.CreateSessionInput,
+) (agentservice.Session, error) {
+	r.workspaceID = workspaceID
+	r.input = input
+	return agentservice.Session{}, nil
+}
+
+func TestIssueRunAgentLauncherForwardsSourceRailPlacement(t *testing.T) {
+	creator := &recordingIssueRunAgentSessionCreator{}
+	launcher := issueRunAgentLauncher{Sessions: creator}
+
+	err := launcher.Launch(context.Background(), workspaceservice.IssueRunLaunch{
+		WorkspaceID:        "workspace-1",
+		AgentSessionID:     "delegate-1",
+		AgentTargetID:      "local-codex",
+		RunID:              "run-1",
+		Title:              "Delegated task",
+		Prompt:             "Implement the task",
+		ExecutionDirectory: "/tmp/task-worktree",
+		RailPlacement: &workspaceservice.IssueRunRailPlacement{
+			Kind:        " project ",
+			ProjectPath: " /workspace/project ",
+			SectionKey:  " project:/workspace/project ",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Launch() error = %v", err)
+	}
+	if creator.workspaceID != "workspace-1" {
+		t.Fatalf("Create() workspace = %q, want workspace-1", creator.workspaceID)
+	}
+	if creator.input.Cwd == nil || *creator.input.Cwd != "/tmp/task-worktree" {
+		t.Fatalf("Create() cwd = %#v, want isolated worktree", creator.input.Cwd)
+	}
+	if creator.input.RailPlacement == nil {
+		t.Fatal("Create() rail placement is nil")
+	}
+	if creator.input.RailPlacement.Version != 1 ||
+		creator.input.RailPlacement.Kind != "project" ||
+		creator.input.RailPlacement.ProjectPath != "/workspace/project" ||
+		creator.input.RailPlacement.SectionKey != "project:/workspace/project" {
+		t.Fatalf("Create() rail placement = %#v", creator.input.RailPlacement)
+	}
+}
+
+type fakeIssueSourceSessionReader struct {
+	session agentservice.PersistedSession
+	found   bool
+}
+
+func (r fakeIssueSourceSessionReader) GetSession(string, string) (agentservice.PersistedSession, bool) {
+	return r.session, r.found
+}
+
+func (fakeIssueSourceSessionReader) ListSessions(string) ([]agentservice.PersistedSession, bool) {
+	return nil, false
+}
+
+func (fakeIssueSourceSessionReader) SessionDeleted(context.Context, string, string) (bool, error) {
+	return false, nil
+}
+
+func TestIssueSourceSessionContextResolverReturnsExecutionAndRailIdentity(t *testing.T) {
+	resolver := issueSourceSessionContextResolver{Sessions: fakeIssueSourceSessionReader{
+		found: true,
+		session: agentservice.PersistedSession{
+			Cwd:             " /workspace/project ",
+			RailSectionKind: " project ",
+			RailProjectPath: " /workspace/project ",
+			RailSectionKey:  " project:/workspace/project ",
+		},
+	}}
+
+	got, ok := resolver.ResolveSourceSessionContext("workspace-1", "planning-session")
+	if !ok {
+		t.Fatal("ResolveSourceSessionContext() found = false")
+	}
+	if got.WorkingDirectory != "/workspace/project" {
+		t.Fatalf("working directory = %q, want /workspace/project", got.WorkingDirectory)
+	}
+	if got.RailPlacement == nil ||
+		got.RailPlacement.Kind != "project" ||
+		got.RailPlacement.ProjectPath != "/workspace/project" ||
+		got.RailPlacement.SectionKey != "project:/workspace/project" {
+		t.Fatalf("rail placement = %#v", got.RailPlacement)
+	}
+}
+
 type fakeAnalyticsDebugEventStream struct{}
 
 func (fakeAnalyticsDebugEventStream) PublishFromServer(context.Context, string, []byte) error {

--- a/services/tuttid/wiring_test.go
+++ b/services/tuttid/wiring_test.go
@@ -20,14 +20,14 @@ type recordingIssueRunAgentSessionCreator struct {
 	input       agentservice.CreateSessionInput
 }
 
-func (r *recordingIssueRunAgentSessionCreator) Create(
+func (r *recordingIssueRunAgentSessionCreator) CreateWithResult(
 	_ context.Context,
 	workspaceID string,
 	input agentservice.CreateSessionInput,
-) (agentservice.Session, error) {
+) (agentservice.CreateSessionResult, error) {
 	r.workspaceID = workspaceID
 	r.input = input
-	return agentservice.Session{}, nil
+	return agentservice.CreateSessionResult{}, nil
 }
 
 func TestIssueRunAgentLauncherForwardsSourceRailPlacement(t *testing.T) {
@@ -36,6 +36,7 @@ func TestIssueRunAgentLauncherForwardsSourceRailPlacement(t *testing.T) {
 
 	err := launcher.Launch(context.Background(), workspaceservice.IssueRunLaunch{
 		WorkspaceID:        "workspace-1",
+		ClientSubmitID:     "issue-run:run-1",
 		AgentSessionID:     "delegate-1",
 		AgentTargetID:      "local-codex",
 		RunID:              "run-1",


### PR DESCRIPTION
## Summary

- preserve the source Agent Session's canonical project/conversation placement when Issue execution delegates work to another Agent
- keep isolated child worktrees as runtime `cwd` values without reclassifying the child outside the source project
- make direct Agent mention/handoff inherit both the caller's runtime `cwd` and canonical rail placement
- make AgentGUI **New conversation** and **Continue in new conversation** resolve the active Session's immutable section key back to the canonical registered project root instead of treating a nested directory or worktree as project identity
- make Automation follow-up Sessions inherit source `cwd` and `RailPlacement` independently
- fall back to the canonical project path when a project-backed source has no runtime `cwd`
- fail closed when a required source Session cannot be resolved, and resolve the Issue source only once per dispatch pass
- preserve complete rail placement through activity and service Session projections

## Root cause

Runtime execution directory and logical project ownership were coupled at several derived-Session entry points. Issue dispatch inherited only the source Session's working directory; parallel execution then replaced it with a temporary worktree, while the launcher omitted `RailPlacement`. Direct handoff also inherited only `cwd`.

The same assumption remained in AgentGUI and Automation. AgentGUI reused the active Session's runtime `cwd` as a new project selection, and Automation copied only `SourceCwd`. A worktree or nested cwd could therefore become a false project identity, while a missing/empty source silently fell back to an allocator directory and detached the new Session from the intended Git repository.

## Fix

Runtime cwd and canonical rail placement now travel as separate values across direct handoff, Issue dispatch, AgentGUI new/continue flows, and Automation launches. Project identity is resolved by exact section key, while the runtime cwd remains execution-only. Project-backed sources with an empty cwd use the canonical project path as the runtime fallback.

Issue dispatch takes one immutable source-context snapshot per pass. If an Issue names a source Session and that Session is unavailable, the Task remains unclaimed for later reconciliation instead of creating a detached Run/Session.

## User impact

New or delegated Agent Sessions remain bound to the project selected by the initiating conversation and retain access to its Git checkout. Parallel children may still execute safely in isolated linked worktrees, but the UI continues grouping them under the source project. Invalid source context now stops launch instead of creating a conversation in a generic allocator directory.

## Documentation

- updated the AgentGUI, Issue execution, and Workspace Agent/Automation architecture guides
- expanded the durable Agent Session troubleshooting entry and index with the derived-Session cwd/rail diagnostic pattern

## Validation

- repository push-ready check: 17/17 lanes passed before the final upstream sync
- after syncing the latest `upstream/main`:
  - AgentGUI focused tests: 3 files, 14 tests passed
  - AgentGUI package typecheck passed
  - changed TypeScript Oxlint passed
  - Issue/Sequential focused Go tests passed
  - `service/automationrule` Go tests passed
  - Issue source resolver wiring tests passed
  - `git diff --check upstream/main...HEAD` passed

A second full push-ready attempt in the restricted sandbox could not verify the pnpm release signature because registry access was blocked; it did not report a code assertion or compilation failure. CI remains authoritative for the latest merged upstream base.