### PR TITLE
fix(agent): recover interrupted managed npm installs

### DIFF
--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -402,6 +402,12 @@ file or directory`. If the CLI path exists but `codex app-server` cannot
   platform optional dependency versions. The daemon default chain intentionally
   excludes mirrors that only sync the aggregate package. Preserve
   `TUTTI_AGENT_NPM_REGISTRY` as an explicit single-registry pin with no fallback.
+  Before a managed global npm retry, remove only the selected package's sibling
+  staging directories (for example, `@tutti-os/.tutti-agent-<hash>`), and repeat
+  that cleanup after a failed or canceled attempt. Do not remove the global
+  `node_modules` tree because the selected prefix can contain unrelated
+  user-installed packages. This lets a later daemon restart recover from a
+  desktop-close cancellation instead of repeatedly failing with `ENOTEMPTY`.
 - Validation:
   Install into a temporary prefix/cache and verify the provider probe, not only
   npm's exit code. Confirm `tutti-agent app-server` can start far enough to pass

--- a/services/tuttid/service/agentstatus/installer_codex_cli.go
+++ b/services/tuttid/service/agentstatus/installer_codex_cli.go
@@ -129,6 +129,13 @@ func (s Service) runManagedNPMPackageAction(
 	registries := s.rankedManagedNPMRegistries(ctx, spec)
 	var result InstallCommandResult
 	binConflictRepaired := false
+	// npm can leave a sibling .<package>-<hash> staging directory when an
+	// install is interrupted (for example, when the desktop window that started
+	// the action closes). The next npm install then fails before doing any useful
+	// work with ENOTEMPTY while trying to rename the current package into that
+	// stale destination. Clean only this package's staging directories; the
+	// global prefix may contain unrelated user-installed packages.
+	cleanupManagedNPMStagingDirs(installPrefix, packageName)
 	for i, registry := range registries {
 		registryDisplay := displayNPMRegistry(registry)
 		setActiveAction(ctx, provider, ActiveAction{
@@ -189,6 +196,10 @@ func (s Service) runManagedNPMPackageAction(
 				return result, nil
 			}
 		}
+		cleanupManagedNPMStagingDirs(installPrefix, packageName)
+		if ctx.Err() != nil {
+			return result, err
+		}
 		if i < len(registries)-1 {
 			slog.Warn(
 				"agent provider managed npm install failed on registry, trying next",
@@ -201,6 +212,77 @@ func (s Service) runManagedNPMPackageAction(
 		}
 	}
 	return result, err
+}
+
+func cleanupManagedNPMStagingDirs(installPrefix, packageName string) {
+	packageDir, ok := managedNPMGlobalPackageDir(installPrefix, packageName)
+	if !ok {
+		return
+	}
+	parentDir := filepath.Dir(packageDir)
+	stagingPrefix := "." + filepath.Base(packageDir) + "-"
+	entries, err := os.ReadDir(parentDir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			slog.Warn(
+				"agent provider managed npm staging directory scan failed",
+				"path", parentDir,
+				"package", packageName,
+				"error", err,
+			)
+		}
+		return
+	}
+	for _, entry := range entries {
+		if !strings.HasPrefix(entry.Name(), stagingPrefix) {
+			continue
+		}
+		path := filepath.Join(parentDir, entry.Name())
+		if err := os.RemoveAll(path); err != nil {
+			slog.Warn(
+				"agent provider managed npm staging directory cleanup failed",
+				"path", path,
+				"package", packageName,
+				"error", err,
+			)
+			continue
+		}
+		slog.Info(
+			"agent provider managed npm staging directory cleaned",
+			"path", path,
+			"package", packageName,
+		)
+	}
+}
+
+func managedNPMGlobalPackageDir(installPrefix, packageName string) (string, bool) {
+	installPrefix = strings.TrimSpace(installPrefix)
+	packageName = strings.TrimSpace(packageName)
+	if installPrefix == "" || packageName == "" {
+		return "", false
+	}
+	parts := strings.Split(packageName, "/")
+	switch {
+	case strings.HasPrefix(packageName, "@"):
+		if len(parts) != 2 || !validManagedNPMPackagePathPart(parts[0]) || !validManagedNPMPackagePathPart(parts[1]) {
+			return "", false
+		}
+	case len(parts) != 1 || !validManagedNPMPackagePathPart(parts[0]):
+		return "", false
+	}
+	nodeModulesDir := filepath.Join(installPrefix, "lib", "node_modules")
+	if runtime.GOOS == "windows" {
+		nodeModulesDir = filepath.Join(installPrefix, "node_modules")
+	}
+	return filepath.Join(append([]string{nodeModulesDir}, parts...)...), true
+}
+
+func validManagedNPMPackagePathPart(part string) bool {
+	part = strings.TrimSpace(part)
+	return part != "" &&
+		part != "." &&
+		part != ".." &&
+		!strings.ContainsAny(part, `\/`)
 }
 
 func (s Service) repairManagedNPMBinEEXIST(

--- a/services/tuttid/service/agentstatus/installer_codex_cli_test.go
+++ b/services/tuttid/service/agentstatus/installer_codex_cli_test.go
@@ -2,6 +2,7 @@ package agentstatus
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"slices"
@@ -47,6 +48,25 @@ func TestCodexNPMPrefixFromPackageDir(t *testing.T) {
 	for in, want := range cases {
 		if got := npmGlobalPrefixFromPackageDir(in); got != want {
 			t.Errorf("npmGlobalPrefixFromPackageDir(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestManagedNPMGlobalPackageDirRejectsUnsafePackageNames(t *testing.T) {
+	t.Parallel()
+
+	for _, packageName := range []string{
+		"",
+		".",
+		"..",
+		"../tutti-agent",
+		"@tutti-os",
+		"@tutti-os/../tutti-agent",
+		"@tutti-os/tutti-agent/extra",
+		`@tutti-os\tutti-agent`,
+	} {
+		if path, ok := managedNPMGlobalPackageDir("/safe/prefix", packageName); ok {
+			t.Errorf("managedNPMGlobalPackageDir(%q) = %q, want rejected", packageName, path)
 		}
 	}
 }
@@ -269,6 +289,118 @@ func TestRunManagedNPMPackageInstallerInstallsTuttiAgentWithManagedRuntime(t *te
 	}
 	if !slices.Contains(command.Env, "npm_config_registry=https://registry.example.test") {
 		t.Fatalf("Env = %#v, want selected npm registry", command.Env)
+	}
+}
+
+func TestRunManagedNPMPackageInstallerCleansOnlyOwnStaleStagingDirectories(t *testing.T) {
+	home := t.TempDir()
+	runtimeRoot := fakeManagedRuntimeRoot(t)
+	managedNPM := filepath.Join(runtimeRoot, "node", "bin", npmBinaryNameForTest())
+	managedNode := filepath.Join(runtimeRoot, "node", "bin", nodeBinaryNameForTest())
+	managedNodeBinDir := filepath.Dir(managedNode)
+	installPrefix := filepath.Join(home, ".local")
+	packageDir, ok := managedNPMGlobalPackageDir(installPrefix, "@tutti-os/tutti-agent")
+	if !ok {
+		t.Fatal("managed npm package directory was not resolved")
+	}
+	staleDir := filepath.Join(filepath.Dir(packageDir), ".tutti-agent-8IDARXyS")
+	unrelatedStagingDir := filepath.Join(filepath.Dir(packageDir), ".other-package-12345678")
+	for _, dir := range []string{packageDir, staleDir, unrelatedStagingDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	service := probeTestService(home)
+	service.HTTPClient = agentNPMRegistryProbeHTTPClient(nil)
+	service.Environ = func() []string {
+		return []string{"PATH=/usr/bin:/bin", agentNPMRegistryEnv + "=https://registry.example.test"}
+	}
+	service.ManagedRuntime = staticManagedRuntimeResolver{
+		runtime: managedruntime.ResolvedRuntime{
+			Root:    runtimeRoot,
+			Node:    managedNode,
+			NPM:     managedNPM,
+			BinDirs: []string{managedNodeBinDir},
+			EnvOverrides: []string{
+				"TUTTI_APP_RUNTIME_ROOT=" + runtimeRoot,
+				"TUTTI_APP_NODE=" + managedNode,
+				"TUTTI_APP_NPM=" + managedNPM,
+				"PATH=" + managedNodeBinDir + string(os.PathListSeparator) + "/usr/bin" + string(os.PathListSeparator) + "/bin",
+			},
+		},
+	}
+	service.IsExecutableFile = isTestExecutableUnderHome(home)
+	service.InstallCommand = func(_ context.Context, _ InstallCommandInput) (InstallCommandResult, error) {
+		if _, err := os.Stat(staleDir); !os.IsNotExist(err) {
+			t.Fatalf("stale package staging directory still exists before install: %v", err)
+		}
+		for _, path := range []string{packageDir, unrelatedStagingDir} {
+			if _, err := os.Stat(path); err != nil {
+				t.Fatalf("unrelated path %s was removed: %v", path, err)
+			}
+		}
+		return InstallCommandResult{ExitCode: 0, Stdout: "installed"}, nil
+	}
+
+	if _, err := service.runManagedNPMPackageInstaller(context.Background(), "tutti-agent", ManagedNPMPackageInstallerSpec{
+		PackageName:     "@tutti-os/tutti-agent",
+		BinaryName:      "tutti-agent",
+		IncludeOptional: true,
+	}, ""); err != nil {
+		t.Fatalf("runManagedNPMPackageInstaller() error = %v", err)
+	}
+}
+
+func TestRunManagedNPMPackageInstallerCleansStagingAfterInterruptedAttempt(t *testing.T) {
+	home := t.TempDir()
+	runtimeRoot := fakeManagedRuntimeRoot(t)
+	managedNPM := filepath.Join(runtimeRoot, "node", "bin", npmBinaryNameForTest())
+	managedNode := filepath.Join(runtimeRoot, "node", "bin", nodeBinaryNameForTest())
+	managedNodeBinDir := filepath.Dir(managedNode)
+	installPrefix := filepath.Join(home, ".local")
+	packageDir, ok := managedNPMGlobalPackageDir(installPrefix, "@tutti-os/tutti-agent")
+	if !ok {
+		t.Fatal("managed npm package directory was not resolved")
+	}
+	staleDir := filepath.Join(filepath.Dir(packageDir), ".tutti-agent-canceled")
+
+	service := probeTestService(home)
+	service.HTTPClient = agentNPMRegistryProbeHTTPClient(nil)
+	service.Environ = func() []string {
+		return []string{"PATH=/usr/bin:/bin", agentNPMRegistryEnv + "=https://registry.example.test"}
+	}
+	service.ManagedRuntime = staticManagedRuntimeResolver{
+		runtime: managedruntime.ResolvedRuntime{
+			Root:    runtimeRoot,
+			Node:    managedNode,
+			NPM:     managedNPM,
+			BinDirs: []string{managedNodeBinDir},
+			EnvOverrides: []string{
+				"TUTTI_APP_RUNTIME_ROOT=" + runtimeRoot,
+				"TUTTI_APP_NODE=" + managedNode,
+				"TUTTI_APP_NPM=" + managedNPM,
+				"PATH=" + managedNodeBinDir + string(os.PathListSeparator) + "/usr/bin" + string(os.PathListSeparator) + "/bin",
+			},
+		},
+	}
+	service.IsExecutableFile = isTestExecutableUnderHome(home)
+	service.InstallCommand = func(_ context.Context, _ InstallCommandInput) (InstallCommandResult, error) {
+		if err := os.MkdirAll(staleDir, 0o755); err != nil {
+			t.Fatalf("mkdir stale staging directory: %v", err)
+		}
+		return InstallCommandResult{ExitCode: -1}, context.Canceled
+	}
+
+	if _, err := service.runManagedNPMPackageInstaller(context.Background(), "tutti-agent", ManagedNPMPackageInstallerSpec{
+		PackageName:     "@tutti-os/tutti-agent",
+		BinaryName:      "tutti-agent",
+		IncludeOptional: true,
+	}, ""); !errors.Is(err, context.Canceled) {
+		t.Fatalf("runManagedNPMPackageInstaller() error = %v, want context canceled", err)
+	}
+	if _, err := os.Stat(staleDir); !os.IsNotExist(err) {
+		t.Fatalf("stale staging directory remains after interrupted install: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- clean stale package-scoped npm staging directories before managed global installs
- clean newly-created staging directories after failed or canceled attempts
- preserve unrelated global packages and reject unsafe package paths
- document restart recovery for interrupted Tutti Agent installs

This fixes the repeated `ENOTEMPTY` loop seen when closing the desktop interrupts npm while it renames `@tutti-os/tutti-agent` to a temporary `.tutti-agent-<hash>` directory.

## Verification

- `go test ./service/agentstatus`
- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready` (6 lanes passed)

## Fallback Three Questions

- Source: desktop shutdown can cancel the managed npm child process while npm is midway through its package-directory rename, leaving a `.tutti-agent-<hash>` staging directory.
- Why can it not be fixed at that source? npm is an external process and cancellation or process termination can occur at any point; recovery must tolerate filesystem state left by an interrupted npm transaction.
- Removal condition: this cleanup can be removed if managed agent CLIs no longer use npm global package replacement, or npm guarantees cleanup of staging directories across cancellation on every supported platform.

## Checklist

- [x] This does not change session/turn/goal/runtime-operation lifecycle semantics; it is provider installation recovery in `tuttid`.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] README/CONTRIBUTING language variants are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commit is signed off with DCO.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1734" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->