### PR TITLE
fix(tutti-mode): validate Cursor task models

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopWorkspaceWorkflowRuntime.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopWorkspaceWorkflowRuntime.test.ts
@@ -325,10 +325,11 @@ test("desktop workflow runtime builds agent-scoped assignment option catalogs", 
       },
       async getAgentProviderComposerOptions(
         provider: string,
-        request?: { agentTargetId?: string }
+        request?: { agentTargetId?: string; workspaceId?: string }
       ) {
         assert.equal(provider, "codex");
         assert.equal(request?.agentTargetId, "workspace-agent:openrouter");
+        assert.equal(request?.workspaceId, "workspace-1");
         return {
           modelConfig: {
             configurable: true,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopWorkspaceWorkflowRuntime.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopWorkspaceWorkflowRuntime.ts
@@ -242,7 +242,7 @@ function createAssignmentOptionsSource(
       const [composerOptions, plans] = await Promise.all([
         tuttidClient.getAgentProviderComposerOptions(
           entry.provider as AgentTarget["provider"],
-          { agentTargetId }
+          { agentTargetId, workspaceId }
         ),
         tuttidClient.listModelPlans(workspaceId).catch(() => null)
       ]);

--- a/docs/architecture/workspace-workflows.md
+++ b/docs/architecture/workspace-workflows.md
@@ -421,6 +421,21 @@ on the checkpoint. Accept, reject, and cancel post the decision to the daemon;
 rejection feedback is mandatory. Closing the app does not discard the review:
 the next mount reconstructs it from the daemon snapshot.
 
+Task-assignment catalog requests carry both the workspace and exact Agent
+target so account-scoped provider discovery can populate the picker. Cursor
+catalog evidence uses the normal live-model TTL instead of being preserved
+indefinitely. On every pending accept, the workflow service applies any
+user-owned overrides in memory and validates every effective explicit task
+model from the complete plan before the checkpoint is committed; only the
+overrides remain persisted on the checkpoint. Cursor validation invalidates
+prior evidence and requires a new hidden account-scoped probe instead of
+reusing running-session or persisted catalogs. Each invalidation advances a
+monotonic provider generation carried through discovery singleflight; a probe
+may publish or satisfy validation only while its generation remains current.
+An unavailable model, failed refresh, or superseded probe rejects the decision
+before issue materialization. Idempotent replays of an already-decided
+checkpoint do not repeat discovery.
+
 The Tutti activation additionally carries a session-scoped orchestration
 intensity (0-100, default 50). The composer's Tutti Budget popup persists it
 as a new activation revision; each turn's frozen snapshot copies it, and the

--- a/packages/agent/daemon/providerregistry/providers.go
+++ b/packages/agent/daemon/providerregistry/providers.go
@@ -50,7 +50,10 @@ func cursorDescriptor() ProviderDescriptor {
 					{Command: "plan", Effect: SlashCommandEffectTogglePlanMode},
 				},
 			},
-			Behavior:                ComposerBehaviorDescriptor{CollapseModelOptionsToLatest: true, PreserveLiveModelCache: true},
+			Behavior: ComposerBehaviorDescriptor{
+				CollapseModelOptionsToLatest:          true,
+				RefreshTaskAssignmentModelsOnDecision: true,
+			},
 			ModelCapabilityRuleKind: ModelCapabilityRuleKindCursorComposerImage,
 			Skills:                  SkillDescriptor{Kind: SkillKindCursor, Invocation: SkillInvocationTextTrigger},
 		},

--- a/packages/agent/daemon/providerregistry/registry.go
+++ b/packages/agent/daemon/providerregistry/registry.go
@@ -470,6 +470,10 @@ func Validate(descriptor ProviderDescriptor) error {
 		(descriptor.ComposerProfile.LiveModelDiscovery.HiddenProbe || descriptor.ComposerProfile.LiveModelDiscovery.AccountScoped) {
 		return fmt.Errorf("provider %q live model discovery behavior requires a discovery kind", providerID)
 	}
+	if descriptor.ComposerProfile.Behavior.RefreshTaskAssignmentModelsOnDecision &&
+		(!descriptor.ComposerProfile.LiveModelDiscovery.HiddenProbe || !descriptor.ComposerProfile.LiveModelDiscovery.AccountScoped) {
+		return fmt.Errorf("provider %q task assignment model refresh requires hidden, account-scoped live model discovery", providerID)
+	}
 	if descriptor.ComposerProfile.LiveModelDiscovery.Kind != "" && descriptor.ComposerProfile.ModelCatalog != "" {
 		return fmt.Errorf("provider %q cannot declare both live model discovery and a model catalog", providerID)
 	}

--- a/packages/agent/daemon/providerregistry/types.go
+++ b/packages/agent/daemon/providerregistry/types.go
@@ -443,12 +443,13 @@ type LiveModelDiscoveryDescriptor struct {
 }
 
 type ComposerBehaviorDescriptor struct {
-	CollapseModelOptionsToLatest        bool
-	ModelOptionsAuthoritative           bool
-	RefreshModelOptionsAfterSettings    bool
-	PrewarmDraftSession                 bool
-	PlanModeExclusiveWithPermissionMode bool
-	PreserveLiveModelCache              bool
+	CollapseModelOptionsToLatest          bool
+	ModelOptionsAuthoritative             bool
+	RefreshModelOptionsAfterSettings      bool
+	PrewarmDraftSession                   bool
+	PlanModeExclusiveWithPermissionMode   bool
+	PreserveLiveModelCache                bool
+	RefreshTaskAssignmentModelsOnDecision bool
 }
 
 type ModelCapabilityRuleKind string

--- a/services/tuttid/service/agent/composer_live_model_cache.go
+++ b/services/tuttid/service/agent/composer_live_model_cache.go
@@ -166,21 +166,34 @@ func (c *composerLiveModelCache) invalidateProvider(provider string) int {
 // options can re-discover models after the provider's auth or config files
 // changed on disk.
 func (s *Service) InvalidateLiveComposerModels(provider string) {
+	s.invalidateLiveComposerModels(provider)
+}
+
+func (s *Service) invalidateLiveComposerModels(provider string) uint64 {
 	if s == nil {
-		return
+		return 0
 	}
 	normalized := agentprovider.NormalizeOpen(provider)
 	if normalized == "" {
-		return
+		return 0
 	}
 	nowUnixMS := time.Now().UnixMilli()
-	deletedCacheEntries := s.liveComposerModelCache().invalidateProvider(normalized)
 	prefix := "live-model:" + normalized + ":"
 	s.liveModelDiscoveryMu.Lock()
+	defer s.liveModelDiscoveryMu.Unlock()
 	if s.liveModelInvalidatedAtUnixMS == nil {
 		s.liveModelInvalidatedAtUnixMS = make(map[string]int64)
 	}
+	if s.liveModelInvalidationGen == nil {
+		s.liveModelInvalidationGen = make(map[string]uint64)
+	}
+	generation := s.liveModelInvalidationGen[normalized] + 1
+	if generation == 0 {
+		generation = 1
+	}
+	s.liveModelInvalidationGen[normalized] = generation
 	s.liveModelInvalidatedAtUnixMS[normalized] = nowUnixMS
+	deletedCacheEntries := s.liveComposerModelCache().invalidateProvider(normalized)
 	deletedAttemptMarkers := 0
 	for key := range s.liveModelDiscoveryAttempted {
 		if strings.HasPrefix(key, prefix) {
@@ -197,9 +210,10 @@ func (s *Service) InvalidateLiveComposerModels(provider string) {
 		"provider":              normalized,
 		"deletedCacheEntries":   deletedCacheEntries,
 		"deletedAttemptMarkers": deletedAttemptMarkers,
+		"generation":            generation,
 		"occurredAtUnixMs":      nowUnixMS,
 	})
-	s.liveModelDiscoveryMu.Unlock()
+	return generation
 }
 
 func (s *Service) liveModelCacheTTL(provider string) time.Duration {

--- a/services/tuttid/service/agent/composer_live_model_cache_test.go
+++ b/services/tuttid/service/agent/composer_live_model_cache_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -23,11 +24,7 @@ func TestGetLiveComposerModelOptionsClaudeExpiresForRediscovery(t *testing.T) {
 	}
 }
 
-// Cursor keeps its live model cache for the daemon's lifetime too: it has no
-// probe session at all, so an expired entry could only be re-discovered by a
-// running conversation — until then the picker would collapse to the single
-// selected model. Running sessions still override a stale entry.
-func TestGetLiveComposerModelOptionsCursorNeverExpires(t *testing.T) {
+func TestGetLiveComposerModelOptionsCursorExpiresForAccountRediscovery(t *testing.T) {
 	service := &Service{}
 	cachedAt := time.Now().UTC()
 	service.setLiveComposerModelOptions("cursor", "ws-1", "/repo", cachedAt, []ComposerConfigOptionValue{
@@ -35,13 +32,246 @@ func TestGetLiveComposerModelOptionsCursorNeverExpires(t *testing.T) {
 		{Value: "gpt-5.2[reasoning=medium,fast=false]", Label: "gpt-5.2"},
 	})
 
-	got, ok := service.getLiveComposerModelOptions("cursor", "ws-1", "/repo", cachedAt.Add(24*time.Hour))
-	if !ok {
-		t.Fatal("cursor live model cache expired, want last-known-good retained")
+	if _, ok := service.getLiveComposerModelOptions("cursor", "ws-1", "/repo", cachedAt.Add(24*time.Hour)); ok {
+		t.Fatal("cursor live model cache did not expire")
 	}
-	if len(got) != 2 {
-		t.Fatalf("cached options = %d, want 2", len(got))
+}
+
+func TestAvailableTaskAssignmentModelsRefreshesCursorCatalog(t *testing.T) {
+	t.Setenv("TUTTI_STATE_DIR", t.TempDir())
+	runtime := newFakeRuntime()
+	runtime.startHook = func(_ RuntimeStartInput, session ProviderRuntimeSession) ProviderRuntimeSession {
+		session.RuntimeContext = cursorModelRuntimeContext()
+		return session
 	}
+	service := newIsolatedAgentService(runtime)
+	service.AgentTargetStore = fakeAgentTargetStore{targets: defaultTestAgentTargets()}
+	service.LiveModelDiscoveryDeleteDelay = time.Hour
+	scope := newComposerLiveModelScope(agentprovider.Cursor, "ws-1", "", "local:cursor")
+	service.setLiveComposerModelOptionsForScope(scope, time.Now().UTC(), []ComposerConfigOptionValue{
+		{ID: "cursor-opus", Label: "Opus", Value: "cursor-opus"},
+	})
+
+	models, err := service.AvailableTaskAssignmentModels(
+		context.Background(),
+		"ws-1",
+		"local:cursor",
+		"",
+	)
+	if err != nil {
+		t.Fatalf("AvailableTaskAssignmentModels() error = %v", err)
+	}
+	want := []string{"default[]", "composer-2.5[fast=true]", "gpt-5.2[reasoning=medium,fast=false]"}
+	if !slices.Equal(models, want) {
+		t.Fatalf("AvailableTaskAssignmentModels() = %v, want refreshed catalog %v", models, want)
+	}
+	if len(runtime.startCalls) != 1 {
+		t.Fatalf("hidden discovery starts = %d, want 1", len(runtime.startCalls))
+	}
+}
+
+func TestAvailableTaskAssignmentModelsRequiresFreshCursorProbe(t *testing.T) {
+	staleContext := map[string]any{
+		"configOptions": []any{map[string]any{
+			"id":      "model",
+			"options": []any{map[string]any{"name": "Opus", "value": "cursor-opus"}},
+		}},
+	}
+	for _, test := range []struct {
+		name  string
+		setup func(*Service, *fakeRuntime)
+	}{
+		{
+			name: "running session",
+			setup: func(_ *Service, runtime *fakeRuntime) {
+				futureUnixMS := time.Now().Add(time.Hour).UnixMilli()
+				runtime.sessions["ws-1:stale-running"] = ProviderRuntimeSession{
+					ID:              "stale-running",
+					WorkspaceID:     "ws-1",
+					AgentTargetID:   "local:cursor",
+					Provider:        agentprovider.Cursor,
+					RuntimeContext:  staleContext,
+					CreatedAtUnixMS: futureUnixMS,
+					UpdatedAtUnixMS: futureUnixMS,
+				}
+			},
+		},
+		{
+			name: "persisted session",
+			setup: func(service *Service, _ *fakeRuntime) {
+				service.SessionReader = fakeSessionReader{sessions: map[string]PersistedSession{
+					"ws-1:stale-persisted": {
+						ID:                     "stale-persisted",
+						WorkspaceID:            "ws-1",
+						AgentTargetID:          "local:cursor",
+						Provider:               agentprovider.Cursor,
+						InternalRuntimeContext: staleContext,
+						UpdatedAtUnixMS:        time.Now().Add(time.Hour).UnixMilli(),
+					},
+				}}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("TUTTI_STATE_DIR", t.TempDir())
+			runtime := newFakeRuntime()
+			runtime.startHook = func(_ RuntimeStartInput, session ProviderRuntimeSession) ProviderRuntimeSession {
+				session.RuntimeContext = cursorModelRuntimeContext()
+				return session
+			}
+			service := newIsolatedAgentService(runtime)
+			service.AgentTargetStore = fakeAgentTargetStore{targets: defaultTestAgentTargets()}
+			service.LiveModelDiscoveryDeleteDelay = time.Hour
+			test.setup(service, runtime)
+
+			models, err := service.AvailableTaskAssignmentModels(
+				context.Background(),
+				"ws-1",
+				"local:cursor",
+				"",
+			)
+			if err != nil {
+				t.Fatalf("AvailableTaskAssignmentModels() error = %v", err)
+			}
+			want := []string{"default[]", "composer-2.5[fast=true]", "gpt-5.2[reasoning=medium,fast=false]"}
+			if !slices.Equal(models, want) {
+				t.Fatalf("AvailableTaskAssignmentModels() = %v, want fresh probe catalog %v", models, want)
+			}
+			if len(runtime.startCalls) != 1 {
+				t.Fatalf("hidden discovery starts = %d, want 1 fresh probe", len(runtime.startCalls))
+			}
+		})
+	}
+}
+
+func TestAvailableTaskAssignmentModelsDoesNotAcceptSupersededProbe(t *testing.T) {
+	t.Setenv("TUTTI_STATE_DIR", t.TempDir())
+	runtime := newTaskAssignmentProbeRaceRuntime()
+	service := newIsolatedAgentService(runtime)
+	service.AgentTargetStore = fakeAgentTargetStore{targets: defaultTestAgentTargets()}
+	service.LiveModelDiscoveryDeleteDelay = time.Hour
+
+	type result struct {
+		models []string
+		err    error
+	}
+	firstResult := make(chan result, 1)
+	go func() {
+		models, err := service.AvailableTaskAssignmentModels(context.Background(), "ws-1", "local:cursor", "")
+		firstResult <- result{models: models, err: err}
+	}()
+	<-runtime.firstProbeStarted
+
+	initialInvalidatedAt := service.liveModelInvalidatedAtUnixMSForProvider(agentprovider.Cursor)
+	time.Sleep(2 * time.Millisecond)
+	secondResult := make(chan result, 1)
+	go func() {
+		models, err := service.AvailableTaskAssignmentModels(context.Background(), "ws-1", "local:cursor", "")
+		secondResult <- result{models: models, err: err}
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for service.liveModelInvalidatedAtUnixMSForProvider(agentprovider.Cursor) <= initialInvalidatedAt {
+		if time.Now().After(deadline) {
+			t.Fatal("second validation did not invalidate the provider")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	// Reproduce two invalidations sharing the same millisecond token. The
+	// generation under test must still distinguish the later validation.
+	service.liveModelDiscoveryMu.Lock()
+	service.liveModelInvalidatedAtUnixMS[agentprovider.Cursor] = initialInvalidatedAt
+	service.liveModelDiscoveryMu.Unlock()
+	close(runtime.releaseFirstProbe)
+
+	second := <-secondResult
+	want := []string{"default[]", "composer-2.5[fast=true]", "gpt-5.2[reasoning=medium,fast=false]"}
+	if second.err != nil {
+		t.Fatalf("second AvailableTaskAssignmentModels() error = %v", second.err)
+	}
+	if !slices.Equal(second.models, want) {
+		t.Fatalf("second AvailableTaskAssignmentModels() = %v, want post-invalidation catalog %v", second.models, want)
+	}
+	first := <-firstResult
+	if first.err == nil && !slices.Equal(first.models, want) {
+		t.Fatalf("superseded first validation accepted stale catalog %v", first.models)
+	}
+	if starts := runtime.startCount(); starts != 2 {
+		t.Fatalf("hidden discovery starts = %d, want independent probes for both invalidation generations", starts)
+	}
+	scope := newComposerLiveModelScope(agentprovider.Cursor, "ws-1", "", "local:cursor")
+	cached, ok := service.getLiveComposerModelOptionsForScope(scope, time.Now().UTC())
+	if !ok || !slices.Equal(composerConfigOptionModelValues(cached), want) {
+		t.Fatalf("cache after superseded probe = %v ok = %v, want current generation %v", cached, ok, want)
+	}
+}
+
+type taskAssignmentProbeRaceRuntime struct {
+	*fakeRuntime
+	mu                sync.Mutex
+	starts            int
+	firstProbeStarted chan struct{}
+	releaseFirstProbe chan struct{}
+}
+
+func newTaskAssignmentProbeRaceRuntime() *taskAssignmentProbeRaceRuntime {
+	return &taskAssignmentProbeRaceRuntime{
+		fakeRuntime:       newFakeRuntime(),
+		firstProbeStarted: make(chan struct{}),
+		releaseFirstProbe: make(chan struct{}),
+	}
+}
+
+func (runtime *taskAssignmentProbeRaceRuntime) Start(
+	ctx context.Context,
+	input RuntimeStartInput,
+) (ProviderRuntimeSession, error) {
+	runtime.mu.Lock()
+	runtime.starts++
+	ordinal := runtime.starts
+	runtime.mu.Unlock()
+	if ordinal == 1 {
+		close(runtime.firstProbeStarted)
+		select {
+		case <-ctx.Done():
+			return ProviderRuntimeSession{}, ctx.Err()
+		case <-runtime.releaseFirstProbe:
+		}
+	}
+	runtimeContext := cursorModelRuntimeContext()
+	if ordinal == 1 {
+		runtimeContext = map[string]any{
+			"configOptions": []any{map[string]any{
+				"id":      "model",
+				"options": []any{map[string]any{"name": "Opus", "value": "cursor-opus"}},
+			}},
+		}
+	}
+	nowUnixMS := time.Now().UnixMilli()
+	return ProviderRuntimeSession{
+		ID:              input.AgentSessionID,
+		AgentTargetID:   input.AgentTargetID,
+		Provider:        input.Provider,
+		WorkspaceID:     input.WorkspaceID,
+		RuntimeContext:  runtimeContext,
+		CreatedAtUnixMS: nowUnixMS,
+		UpdatedAtUnixMS: nowUnixMS,
+		Status:          "ready",
+	}, nil
+}
+
+func (*taskAssignmentProbeRaceRuntime) Sessions(string) []ProviderRuntimeSession {
+	return nil
+}
+
+func (*taskAssignmentProbeRaceRuntime) Session(string, string) (ProviderRuntimeSession, bool) {
+	return ProviderRuntimeSession{}, false
+}
+
+func (runtime *taskAssignmentProbeRaceRuntime) startCount() int {
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	return runtime.starts
 }
 
 // Switching Claude auth context (e.g. OAuth subscription -> ANTHROPIC_API_KEY

--- a/services/tuttid/service/agent/composer_live_model_coordinator.go
+++ b/services/tuttid/service/agent/composer_live_model_coordinator.go
@@ -3,8 +3,11 @@ package agent
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
+
+	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 )
 
 var errLiveModelDiscoveryPending = errors.New("live model discovery continues in background")
@@ -22,30 +25,59 @@ func (s *Service) discoverLiveComposerModels(
 	input ComposerOptionsInput,
 	settings ComposerSettings,
 ) ([]ComposerConfigOptionValue, error) {
+	generation := s.liveModelInvalidationGenerationForProvider(input.Provider)
+	return s.discoverLiveComposerModelsAtGeneration(ctx, input, settings, generation, false)
+}
+
+func (s *Service) discoverFreshLiveComposerModels(
+	ctx context.Context,
+	input ComposerOptionsInput,
+	settings ComposerSettings,
+	generation uint64,
+) ([]ComposerConfigOptionValue, error) {
+	return s.discoverLiveComposerModelsAtGeneration(ctx, input, settings, generation, true)
+}
+
+func (s *Service) discoverLiveComposerModelsAtGeneration(
+	ctx context.Context,
+	input ComposerOptionsInput,
+	settings ComposerSettings,
+	generation uint64,
+	requireFreshProbe bool,
+) ([]ComposerConfigOptionValue, error) {
 	scope := newComposerLiveModelScopeForInput(input, settings)
 	if scope.workspaceID == "" {
 		return nil, ErrInvalidArgument
 	}
+	if s.liveModelInvalidationGenerationForProvider(scope.provider) != generation {
+		return nil, errLiveModelDiscoverySuperseded
+	}
 	cacheKey := scope.key()
-	resultCh := s.liveModelDiscoveryGroup.DoChan(cacheKey, func() (any, error) {
+	singleflightKey := fmt.Sprintf("%s:generation:%d:fresh:%t", cacheKey, generation, requireFreshProbe)
+	resultCh := s.liveModelDiscoveryGroup.DoChan(singleflightKey, func() (any, error) {
 		lifecycleCtx, cancelLifecycle := context.WithTimeout(ctx, liveModelDiscoveryLifecycleTimeout)
 		defer cancelLifecycle()
 		if newComposerLiveModelScopeForInput(input, settings).key() != cacheKey {
 			return nil, errLiveModelDiscoverySuperseded
 		}
-		invalidatedAtStart := s.liveModelInvalidatedAtUnixMSForProvider(scope.provider)
+		if s.liveModelInvalidationGenerationForProvider(scope.provider) != generation {
+			return nil, errLiveModelDiscoverySuperseded
+		}
 		now := time.Now().UTC()
-		if cached, ok := s.getLiveComposerModelOptionsForScope(scope, now); ok && len(cached) > 0 {
-			return cached, nil
+		if !requireFreshProbe {
+			if cached, ok := s.getLiveComposerModelOptionsForScope(scope, now); ok && len(cached) > 0 {
+				return cached, nil
+			}
+			if s.liveModelDiscoveryWasAttempted(cacheKey) {
+				return nil, errLiveModelDiscoveryAlreadyAttempted
+			}
 		}
-		if s.liveModelDiscoveryWasAttempted(cacheKey) {
-			return nil, errLiveModelDiscoveryAlreadyAttempted
-		}
-		discovered, err := s.discoverLiveComposerModelsUncachedForScope(
+		discovered, err := s.discoverLiveComposerModelsUncachedForScopeWithPolicy(
 			lifecycleCtx,
 			scope,
 			input.providerTargetRef,
 			settings,
+			!requireFreshProbe,
 		)
 		if err != nil {
 			if providerTargetRefKind(input.providerTargetRef) == "agent_extension" {
@@ -67,10 +99,14 @@ func (s *Service) discoverLiveComposerModels(
 			}
 			return nil, err
 		}
-		if s.liveModelInvalidatedAtUnixMSForProvider(scope.provider) > invalidatedAtStart {
+		if !s.setLiveComposerModelOptionsForScopeIfGeneration(
+			scope,
+			time.Now().UTC(),
+			discovered,
+			generation,
+		) {
 			return nil, errLiveModelDiscoverySuperseded
 		}
-		s.setLiveComposerModelOptionsForScope(scope, time.Now().UTC(), discovered)
 		return discovered, nil
 	})
 	waitTimer := time.NewTimer(liveModelDiscoveryTimeout)
@@ -84,9 +120,39 @@ func (s *Service) discoverLiveComposerModels(
 		if result.Err != nil {
 			return nil, result.Err
 		}
+		if s.liveModelInvalidationGenerationForProvider(scope.provider) != generation {
+			return nil, errLiveModelDiscoverySuperseded
+		}
 		models, _ := result.Val.([]ComposerConfigOptionValue)
 		return cloneComposerConfigOptionValues(models), nil
 	}
+}
+
+func (s *Service) liveModelInvalidationGenerationForProvider(provider string) uint64 {
+	normalized := agentprovider.NormalizeOpen(provider)
+	if normalized == "" {
+		return 0
+	}
+	s.liveModelDiscoveryMu.Lock()
+	defer s.liveModelDiscoveryMu.Unlock()
+	return s.liveModelInvalidationGen[normalized]
+}
+
+func (s *Service) setLiveComposerModelOptionsForScopeIfGeneration(
+	scope composerLiveModelScope,
+	now time.Time,
+	options []ComposerConfigOptionValue,
+	generation uint64,
+) bool {
+	s.liveModelDiscoveryMu.Lock()
+	defer s.liveModelDiscoveryMu.Unlock()
+	if s.liveModelInvalidationGen[scope.provider] != generation {
+		return false
+	}
+	if len(options) > 0 {
+		s.liveComposerModelCache().set(scope, now, options)
+	}
+	return true
 }
 
 func (s *Service) liveModelDiscoveryWasAttempted(cacheKey string) bool {

--- a/services/tuttid/service/agent/composer_live_model_discovery.go
+++ b/services/tuttid/service/agent/composer_live_model_discovery.go
@@ -153,6 +153,22 @@ func (s *Service) discoverLiveComposerModelsUncachedForScope(
 	providerTargetRef map[string]any,
 	settings ComposerSettings,
 ) ([]ComposerConfigOptionValue, error) {
+	return s.discoverLiveComposerModelsUncachedForScopeWithPolicy(
+		ctx,
+		scope,
+		providerTargetRef,
+		settings,
+		true,
+	)
+}
+
+func (s *Service) discoverLiveComposerModelsUncachedForScopeWithPolicy(
+	ctx context.Context,
+	scope composerLiveModelScope,
+	providerTargetRef map[string]any,
+	settings ComposerSettings,
+	allowRunningSessionReuse bool,
+) ([]ComposerConfigOptionValue, error) {
 	isExtension := providerTargetRefKind(providerTargetRef) == "agent_extension"
 	if isExtension {
 		logAgentExtensionComposerDebug("discovery_started", map[string]any{
@@ -175,11 +191,13 @@ func (s *Service) discoverLiveComposerModelsUncachedForScope(
 			return nil, err
 		}
 	}
-	if reused, hasProviderSession := s.liveModelOptionsFromRunningSessionForScope(scope); hasProviderSession {
-		if len(reused) > 0 {
-			return reused, nil
+	if allowRunningSessionReuse {
+		if reused, hasProviderSession := s.liveModelOptionsFromRunningSessionForScope(scope); hasProviderSession {
+			if len(reused) > 0 {
+				return reused, nil
+			}
+			return nil, errLiveModelDiscoveryAlreadyAttempted
 		}
-		return nil, errLiveModelDiscoveryAlreadyAttempted
 	}
 	// Spawning a hidden probe session is opt-in per provider: it creates a
 	// real provider session (and, for account-backed CLIs, server-side
@@ -195,12 +213,14 @@ func (s *Service) discoverLiveComposerModelsUncachedForScope(
 	}
 	// Recheck after waiting: another key may have started a reusable session
 	// while this request waited for the credential-sensitive startup slot.
-	if reused, hasProviderSession := s.liveModelOptionsFromRunningSessionForScope(scope); hasProviderSession {
-		releaseStartup()
-		if len(reused) > 0 {
-			return reused, nil
+	if allowRunningSessionReuse {
+		if reused, hasProviderSession := s.liveModelOptionsFromRunningSessionForScope(scope); hasProviderSession {
+			releaseStartup()
+			if len(reused) > 0 {
+				return reused, nil
+			}
+			return nil, errLiveModelDiscoveryAlreadyAttempted
 		}
-		return nil, errLiveModelDiscoveryAlreadyAttempted
 	}
 	var session ProviderRuntimeSession
 	visible := false
@@ -447,6 +467,25 @@ func (s *Service) mergeLiveComposerModelsForComposerOptions(
 	scope := newComposerLiveModelScopeForInput(input, effectiveSettings)
 	var liveModels []ComposerConfigOptionValue
 	modelSource := "claude-static"
+	if input.requireFreshLiveModelCatalog {
+		if strings.TrimSpace(input.WorkspaceID) == "" {
+			return ComposerOptions{}, ErrInvalidArgument
+		}
+		discovered, err := s.discoverFreshLiveComposerModels(
+			ctx,
+			input,
+			effectiveSettings,
+			input.liveModelCatalogInvalidationGeneration,
+		)
+		if err != nil {
+			return ComposerOptions{}, err
+		}
+		if len(discovered) == 0 {
+			return ComposerOptions{}, errLiveModelDiscoverySessionFailed
+		}
+		discovered = s.enrichModelCapabilityOptions(ctx, provider, discovered)
+		return mergeComposerModelsIntoComposerOptions(options, discovered, runtimeLiveModelCatalogSource), nil
+	}
 	if strings.TrimSpace(input.WorkspaceID) != "" {
 		now := time.Now().UTC()
 		reused, hasProviderSession := s.liveModelOptionsFromRunningSessionForScope(scope)

--- a/services/tuttid/service/agent/composer_options.go
+++ b/services/tuttid/service/agent/composer_options.go
@@ -8,7 +8,6 @@ import (
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
-	modelplanbiz "github.com/tutti-os/tutti/services/tuttid/biz/modelplan"
 	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
 )
 
@@ -62,27 +61,6 @@ type ComposerConfigOptionValue struct {
 }
 
 type ComposerSettings = agenthost.ComposerSettings
-
-type ComposerOptionsInput struct {
-	AgentTargetID            string
-	Cwd                      string
-	Locale                   string
-	Provider                 string
-	WorkspaceID              string
-	Settings                 ComposerSettings
-	IncludeCapabilityCatalog *bool
-	// ResolvedModelPlan is a daemon-only exact plan override supplied by a
-	// WorkspaceAgent resolver. It may contain a credential and must never be
-	// serialized into runtime context or transport responses.
-	ResolvedModelPlan *modelplanbiz.Plan
-	// IgnoreModelPlanBinding forces provider-native credentials and model
-	// discovery for internal probes and subscription checks that must not
-	// inherit the workspace target binding. It is daemon-only and must not be
-	// exposed as a user-facing session setting.
-	IgnoreModelPlanBinding   bool
-	providerTargetRef        map[string]any
-	extensionComposerProfile ExtensionComposerProfile
-}
 
 type ComposerSkillOption struct {
 	Name        string

--- a/services/tuttid/service/agent/composer_options_input.go
+++ b/services/tuttid/service/agent/composer_options_input.go
@@ -1,0 +1,26 @@
+package agent
+
+import modelplanbiz "github.com/tutti-os/tutti/services/tuttid/biz/modelplan"
+
+type ComposerOptionsInput struct {
+	AgentTargetID            string
+	Cwd                      string
+	Locale                   string
+	Provider                 string
+	WorkspaceID              string
+	Settings                 ComposerSettings
+	IncludeCapabilityCatalog *bool
+	// ResolvedModelPlan is a daemon-only exact plan override supplied by a
+	// WorkspaceAgent resolver. It may contain a credential and must never be
+	// serialized into runtime context or transport responses.
+	ResolvedModelPlan *modelplanbiz.Plan
+	// IgnoreModelPlanBinding forces provider-native credentials and model
+	// discovery for internal probes and subscription checks that must not
+	// inherit the workspace target binding. It is daemon-only and must not be
+	// exposed as a user-facing session setting.
+	IgnoreModelPlanBinding                 bool
+	requireFreshLiveModelCatalog           bool
+	liveModelCatalogInvalidationGeneration uint64
+	providerTargetRef                      map[string]any
+	extensionComposerProfile               ExtensionComposerProfile
+}

--- a/services/tuttid/service/agent/model_validation.go
+++ b/services/tuttid/service/agent/model_validation.go
@@ -64,6 +64,83 @@ func (s *Service) validateComposerModelForCreate(
 	}
 }
 
+// AvailableTaskAssignmentModels returns a freshly discovered, authoritative
+// provider-native catalog for task-assignment validation when the provider
+// requires that stronger check. Other providers and explicit Model Plans keep
+// their existing validation path and return no catalog.
+func (s *Service) AvailableTaskAssignmentModels(
+	ctx context.Context,
+	workspaceID string,
+	agentTargetID string,
+	modelPlanID string,
+) ([]string, error) {
+	workspaceID = strings.TrimSpace(workspaceID)
+	agentTargetID = strings.TrimSpace(agentTargetID)
+	if strings.TrimSpace(modelPlanID) != "" {
+		return nil, nil
+	}
+	if workspaceID == "" {
+		return nil, fmt.Errorf("%w: workspace is required for task model validation", ErrInvalidArgument)
+	}
+	if agentTargetID == "" {
+		return nil, nil
+	}
+	launchInput := CreateSessionInput{AgentTargetID: agentTargetID}
+	launch, err := s.resolveCreateSessionLaunch(ctx, workspaceID, &launchInput)
+	if err != nil {
+		return nil, err
+	}
+	provider := agentprovider.NormalizeOpen(launch.Provider)
+	if !composerProfileFor(provider).Behavior.RefreshTaskAssignmentModelsOnDecision {
+		return nil, nil
+	}
+
+	// A task decision is the last boundary before the selected model becomes
+	// durable. Drop cached and persisted evidence so an account change cannot
+	// validate against a catalog advertised by an older provider session.
+	invalidationGeneration := s.invalidateLiveComposerModels(provider)
+	options, err := s.GetComposerOptions(ctx, ComposerOptionsInput{
+		AgentTargetID:                          agentTargetID,
+		Provider:                               provider,
+		WorkspaceID:                            workspaceID,
+		IgnoreModelPlanBinding:                 true,
+		requireFreshLiveModelCatalog:           true,
+		liveModelCatalogInvalidationGeneration: invalidationGeneration,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("refresh %s task assignment models: %w", provider, err)
+	}
+	if s.liveModelInvalidationGenerationForProvider(provider) != invalidationGeneration {
+		return nil, fmt.Errorf("%w: current %s model catalog was superseded", ErrInvalidArgument, provider)
+	}
+	if strings.TrimSpace(stringFromAny(options.RuntimeContext["modelCatalogSource"])) != runtimeLiveModelCatalogSource {
+		return nil, fmt.Errorf("%w: current %s model catalog is unavailable", ErrInvalidArgument, provider)
+	}
+	models := make([]string, 0, len(options.ModelConfig.Options))
+	seen := make(map[string]struct{}, len(options.ModelConfig.Options))
+	for _, option := range options.ModelConfig.Options {
+		if option.Requested {
+			continue
+		}
+		model := strings.TrimSpace(option.Value)
+		if model == "" {
+			model = strings.TrimSpace(option.ID)
+		}
+		if model == "" {
+			continue
+		}
+		if _, ok := seen[model]; ok {
+			continue
+		}
+		seen[model] = struct{}{}
+		models = append(models, model)
+	}
+	if len(models) == 0 {
+		return nil, fmt.Errorf("%w: current %s model catalog is empty", ErrInvalidArgument, provider)
+	}
+	return models, nil
+}
+
 func (s *Service) availableComposerModelsForValidation(
 	ctx context.Context,
 	provider string,

--- a/services/tuttid/service/agent/provider_descriptor_test.go
+++ b/services/tuttid/service/agent/provider_descriptor_test.go
@@ -53,6 +53,12 @@ func TestCursorComposerProfileComesFromProviderDescriptor(t *testing.T) {
 		!profile.LiveModelProbeSession || !profile.LiveModelAccountScoped {
 		t.Fatalf("cursor live model discovery profile = %#v", profile)
 	}
+	if profile.Behavior.PreserveLiveModelCache {
+		t.Fatalf("cursor live model cache must expire: %#v", profile.Behavior)
+	}
+	if !profile.Behavior.RefreshTaskAssignmentModelsOnDecision {
+		t.Fatalf("cursor task assignment models must refresh on decision: %#v", profile.Behavior)
+	}
 	if profile.SkillKind != string(providerregistry.SkillKindCursor) || profile.SkillInvocation != string(providerregistry.SkillInvocationTextTrigger) {
 		t.Fatalf("cursor skill profile = %#v", profile)
 	}

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -82,6 +82,7 @@ type Service struct {
 	liveModelDiscoveryMu           sync.Mutex
 	liveModelDiscoveryAttempted    map[string]struct{}
 	liveModelInvalidatedAtUnixMS   map[string]int64
+	liveModelInvalidationGen       map[string]uint64
 	liveModelDiscoverySessions     map[string]liveModelDiscoverySessionRef
 	liveModelDiscoveryGroup        singleflight.Group
 	sessionSettingsMu              sync.Mutex

--- a/services/tuttid/service/tuttimodeplan/service.go
+++ b/services/tuttid/service/tuttimodeplan/service.go
@@ -105,12 +105,13 @@ type PlanRevisionFeedbackInput struct {
 }
 
 type Service struct {
-	Store                  Store
-	SourceSessionDeletions SourceSessionDeletionStore
-	Revisions              RevisionContentStore
-	Publisher              Publisher
-	IssueMaterializer      IssueMaterializer
-	FeedbackDispatcher     FeedbackDispatcher
+	Store                      Store
+	SourceSessionDeletions     SourceSessionDeletionStore
+	Revisions                  RevisionContentStore
+	Publisher                  Publisher
+	IssueMaterializer          IssueMaterializer
+	FeedbackDispatcher         FeedbackDispatcher
+	TaskAssignmentModelCatalog TaskAssignmentModelCatalog
 	// FeatureFlags reads the desktop preferences feature-flag map. Nil keeps
 	// every write allowed; when set, Propose/Revise/Decide are rejected with
 	// ErrTuttiModeDisabled unless lab.tuttiMode is true.
@@ -540,7 +541,7 @@ func (s *Service) Decide(ctx context.Context, input DecideInput) (DecisionResult
 	if err != nil {
 		return DecisionResult{}, err
 	}
-	assignments, err := s.validatedDecisionTaskAssignments(input, snapshot, checkpoint)
+	assignments, err := s.validatedDecisionTaskAssignments(ctx, input, snapshot, checkpoint)
 	if err != nil {
 		return DecisionResult{}, err
 	}
@@ -629,48 +630,6 @@ func (s *Service) Decide(ctx context.Context, input DecideInput) (DecisionResult
 		NextAction: nextActionAfterOperation(nextAction, operation),
 		Operation:  operation,
 	}, nil
-}
-
-// validatedDecisionTaskAssignments enforces the accept-only, task-review-only
-// scope of per-task overrides and verifies every override targets a task in
-// the current revision document.
-func (s *Service) validatedDecisionTaskAssignments(
-	input DecideInput,
-	snapshot workflowbiz.Snapshot,
-	checkpoint workflowbiz.WorkflowCheckpoint,
-) ([]workflowbiz.TaskAssignment, error) {
-	assignments, err := workflowbiz.NormalizeTaskAssignments(input.TaskAssignments)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrInvalidDecision, err)
-	}
-	if len(assignments) == 0 {
-		return nil, nil
-	}
-	if input.Decision != workflowbiz.CheckpointStatusAccepted || checkpoint.Kind != workflowbiz.CheckpointKindTaskReview {
-		return nil, fmt.Errorf("%w: task assignments are only valid when accepting a task review", ErrInvalidDecision)
-	}
-	revision, found := revisionByID(snapshot.Revisions, checkpoint.RevisionID)
-	if !found {
-		return nil, ErrCheckpointMissing
-	}
-	raw, err := s.Revisions.Read(snapshot.Workflow.ID, revision.DocumentPath, revision.SHA256)
-	if err != nil {
-		return nil, err
-	}
-	document, err := ParsePlanMarkdown(raw)
-	if err != nil {
-		return nil, err
-	}
-	knownTasks := make(map[string]struct{}, len(document.Tasks))
-	for _, task := range document.Tasks {
-		knownTasks[task.ID] = struct{}{}
-	}
-	for _, assignment := range assignments {
-		if _, ok := knownTasks[assignment.TaskID]; !ok {
-			return nil, fmt.Errorf("%w: task assignment references unknown task %q", ErrInvalidDecision, assignment.TaskID)
-		}
-	}
-	return assignments, nil
 }
 
 func (s *Service) Wait(ctx context.Context, input WaitInput) (WaitResult, error) {

--- a/services/tuttid/service/tuttimodeplan/service_test.go
+++ b/services/tuttid/service/tuttimodeplan/service_test.go
@@ -2152,6 +2152,104 @@ func TestServiceDecideRejectsInvalidTaskAssignments(t *testing.T) {
 	}
 }
 
+func TestServiceDecideRejectsUnavailableAssignedModel(t *testing.T) {
+	t.Parallel()
+
+	now := time.UnixMilli(1_700_000_000_000).UTC()
+	store := newMemoryWorkflowStore()
+	service := newTestService(t, store, now.Add(time.Minute), "operation-1")
+	documentPath, digest, err := service.Revisions.Write("workflow-1", taskGraphMarkdown("Guarded model"))
+	if err != nil {
+		t.Fatalf("write plan: %v", err)
+	}
+	snapshot := workflowSnapshotFixture(
+		workflowbiz.CheckpointKindTaskReview,
+		workflowbiz.CheckpointStatusPending,
+		workflowbiz.WorkflowStatusPendingReview,
+		now,
+	)
+	snapshot.Revisions[0].DocumentPath = documentPath
+	snapshot.Revisions[0].SHA256 = digest
+	store.snapshots[workflowStoreKey("workspace-1", "workflow-1")] = snapshot
+	service.TaskAssignmentModelCatalog = staticTaskAssignmentModelCatalog{
+		models: []string{"cursor-auto", "cursor-sonnet"},
+	}
+
+	if _, err := service.Decide(context.Background(), DecideInput{
+		WorkspaceID:  "workspace-1",
+		WorkflowID:   "workflow-1",
+		CheckpointID: "checkpoint-1",
+		Decision:     workflowbiz.CheckpointStatusAccepted,
+		DecidedBy:    "user-1",
+		TaskAssignments: []workflowbiz.TaskAssignment{{
+			TaskID:        "task-1",
+			AgentTargetID: stringPointer("local:cursor"),
+			Model:         stringPointer("cursor-opus"),
+		}},
+	}); !errors.Is(err, ErrInvalidDecision) {
+		t.Fatalf("Decide(unavailable model) error = %v, want ErrInvalidDecision", err)
+	}
+	if checkpoint := store.snapshots[workflowStoreKey("workspace-1", "workflow-1")].Checkpoints[0]; checkpoint.Status != workflowbiz.CheckpointStatusPending {
+		t.Fatalf("unavailable model mutated checkpoint: %#v", checkpoint)
+	}
+}
+
+func TestServiceDecideRejectsUnavailableDocumentModelWithoutOverrides(t *testing.T) {
+	t.Parallel()
+
+	now := time.UnixMilli(1_700_000_000_000).UTC()
+	store := newMemoryWorkflowStore()
+	service := newTestService(t, store, now.Add(time.Minute), "operation-1")
+	markdown := strings.Replace(
+		string(taskGraphMarkdown("Guarded document model")),
+		"    priority: medium\n",
+		"    priority: medium\n    agentTargetId: local:cursor\n    model: cursor-opus\n",
+		1,
+	)
+	documentPath, digest, err := service.Revisions.Write("workflow-1", []byte(markdown))
+	if err != nil {
+		t.Fatalf("write plan: %v", err)
+	}
+	snapshot := workflowSnapshotFixture(
+		workflowbiz.CheckpointKindTaskReview,
+		workflowbiz.CheckpointStatusPending,
+		workflowbiz.WorkflowStatusPendingReview,
+		now,
+	)
+	snapshot.Revisions[0].DocumentPath = documentPath
+	snapshot.Revisions[0].SHA256 = digest
+	store.snapshots[workflowStoreKey("workspace-1", "workflow-1")] = snapshot
+	service.TaskAssignmentModelCatalog = staticTaskAssignmentModelCatalog{
+		models: []string{"cursor-auto", "cursor-sonnet"},
+	}
+
+	if _, err := service.Decide(context.Background(), DecideInput{
+		WorkspaceID:  "workspace-1",
+		WorkflowID:   "workflow-1",
+		CheckpointID: "checkpoint-1",
+		Decision:     workflowbiz.CheckpointStatusAccepted,
+		DecidedBy:    "user-1",
+	}); !errors.Is(err, ErrInvalidDecision) {
+		t.Fatalf("Decide(stale document model) error = %v, want ErrInvalidDecision", err)
+	}
+	if checkpoint := store.snapshots[workflowStoreKey("workspace-1", "workflow-1")].Checkpoints[0]; checkpoint.Status != workflowbiz.CheckpointStatusPending {
+		t.Fatalf("stale document model mutated checkpoint: %#v", checkpoint)
+	}
+}
+
+type staticTaskAssignmentModelCatalog struct {
+	models []string
+}
+
+func (catalog staticTaskAssignmentModelCatalog) AvailableTaskAssignmentModels(
+	context.Context,
+	string,
+	string,
+	string,
+) ([]string, error) {
+	return append([]string(nil), catalog.models...), nil
+}
+
 func TestServiceRetireConfigurationReviewWorkflowsCancelsLegacyPending(t *testing.T) {
 	t.Parallel()
 

--- a/services/tuttid/service/tuttimodeplan/task_assignment_validation.go
+++ b/services/tuttid/service/tuttimodeplan/task_assignment_validation.go
@@ -1,0 +1,110 @@
+package tuttimodeplan
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	workflowbiz "github.com/tutti-os/tutti/services/tuttid/biz/workspaceworkflow"
+)
+
+// TaskAssignmentModelCatalog supplies an authoritative model catalog at the
+// user decision boundary. An empty result means the selected assignment keeps
+// its provider's existing validation path.
+type TaskAssignmentModelCatalog interface {
+	AvailableTaskAssignmentModels(
+		context.Context,
+		string,
+		string,
+		string,
+	) ([]string, error)
+}
+
+// validatedDecisionTaskAssignments enforces the accept-only, task-review-only
+// scope of per-task overrides and verifies every override targets a task in
+// the current revision document.
+func (s *Service) validatedDecisionTaskAssignments(
+	ctx context.Context,
+	input DecideInput,
+	snapshot workflowbiz.Snapshot,
+	checkpoint workflowbiz.WorkflowCheckpoint,
+) ([]workflowbiz.TaskAssignment, error) {
+	assignments, err := workflowbiz.NormalizeTaskAssignments(input.TaskAssignments)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidDecision, err)
+	}
+	if len(assignments) > 0 &&
+		(input.Decision != workflowbiz.CheckpointStatusAccepted || checkpoint.Kind != workflowbiz.CheckpointKindTaskReview) {
+		return nil, fmt.Errorf("%w: task assignments are only valid when accepting a task review", ErrInvalidDecision)
+	}
+	if input.Decision != workflowbiz.CheckpointStatusAccepted || checkpoint.Kind != workflowbiz.CheckpointKindTaskReview {
+		return assignments, nil
+	}
+	if len(assignments) == 0 &&
+		(s.TaskAssignmentModelCatalog == nil || checkpoint.Status != workflowbiz.CheckpointStatusPending) {
+		return assignments, nil
+	}
+	revision, found := revisionByID(snapshot.Revisions, checkpoint.RevisionID)
+	if !found {
+		return nil, ErrCheckpointMissing
+	}
+	raw, err := s.Revisions.Read(snapshot.Workflow.ID, revision.DocumentPath, revision.SHA256)
+	if err != nil {
+		return nil, err
+	}
+	document, err := ParsePlanMarkdown(raw)
+	if err != nil {
+		return nil, err
+	}
+	knownTasks := make(map[string]PlanTask, len(document.Tasks))
+	for _, task := range document.Tasks {
+		knownTasks[task.ID] = task
+	}
+	for _, assignment := range assignments {
+		task, ok := knownTasks[assignment.TaskID]
+		if !ok {
+			return nil, fmt.Errorf("%w: task assignment references unknown task %q", ErrInvalidDecision, assignment.TaskID)
+		}
+		applyTaskAssignmentOverride(&task, assignment)
+		knownTasks[assignment.TaskID] = task
+	}
+	if s.TaskAssignmentModelCatalog == nil || checkpoint.Status != workflowbiz.CheckpointStatusPending {
+		return assignments, nil
+	}
+	modelCatalogs := make(map[string][]string)
+	for _, documentTask := range document.Tasks {
+		task := knownTasks[documentTask.ID]
+		model := strings.TrimSpace(task.Model)
+		if model == "" {
+			continue
+		}
+		catalogKey := strings.TrimSpace(task.AgentTargetID) + "\x00" + strings.TrimSpace(task.ModelPlanID)
+		availableModels, cached := modelCatalogs[catalogKey]
+		if !cached {
+			availableModels, err = s.TaskAssignmentModelCatalog.AvailableTaskAssignmentModels(
+				ctx,
+				input.WorkspaceID,
+				task.AgentTargetID,
+				task.ModelPlanID,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("%w: validate model for task %q: %v", ErrInvalidDecision, task.ID, err)
+			}
+			modelCatalogs[catalogKey] = availableModels
+		}
+		if len(availableModels) == 0 {
+			continue
+		}
+		available := false
+		for _, candidate := range availableModels {
+			if strings.TrimSpace(candidate) == model {
+				available = true
+				break
+			}
+		}
+		if !available {
+			return nil, fmt.Errorf("%w: model %q is unavailable for task %q", ErrInvalidDecision, model, task.ID)
+		}
+	}
+	return assignments, nil
+}

--- a/services/tuttid/wiring_daemon_api.go
+++ b/services/tuttid/wiring_daemon_api.go
@@ -446,12 +446,13 @@ func buildDaemonAPI(ctx context.Context, store workspacedata.CatalogStore, analy
 		MutationLocks: workspaceservice.NewIssueMutationLocks(),
 	}
 	tuttiModePlans := &tuttimodeplanservice.Service{
-		Store:                  workflowStore,
-		SourceSessionDeletions: sourceSessionDeletionStore,
-		Revisions:              workspacedata.WorkflowRevisionFiles{StateDir: tuttitypes.DefaultStateDir()},
-		Publisher:              eventstreamservice.WorkspaceWorkflowPublisher{Service: events},
-		IssueMaterializer:      tuttimodeplanservice.WorkspaceIssueMaterializer{Issues: &issueService},
-		FeatureFlags:           tuttiModeFeatureFlags,
+		Store:                      workflowStore,
+		SourceSessionDeletions:     sourceSessionDeletionStore,
+		Revisions:                  workspacedata.WorkflowRevisionFiles{StateDir: tuttitypes.DefaultStateDir()},
+		Publisher:                  eventstreamservice.WorkspaceWorkflowPublisher{Service: events},
+		IssueMaterializer:          tuttimodeplanservice.WorkspaceIssueMaterializer{Issues: &issueService},
+		FeatureFlags:               tuttiModeFeatureFlags,
+		TaskAssignmentModelCatalog: agentSessionService,
 		FeedbackDispatcher: &tuttiModePlanFeedbackDispatcher{
 			Agents:    agentSessionService,
 			TurnLinks: workflowStore,


### PR DESCRIPTION
## Summary
- Scope task-assignment composer-option requests to the workspace so Cursor resolves an account-scoped catalog
- Stop preserving Cursor model catalogs indefinitely
- At pending Tutti Mode acceptance, require a **new Cursor probe** that bypasses cache, running-session reuse, and persisted fallback catalogs
- Bind probes to a monotonic invalidation generation so concurrent accepts cannot consume a superseded catalog
- Validate every effective task model, including unchanged stale models already stored in the plan document, before durable acceptance/materialization

## Root cause
Tutti Mode could display stale Cursor models and only validated explicit UI overrides. A task whose document already named an unavailable Cursor Opus model could therefore be accepted and launched. Ordinary cache invalidation was also insufficient because a running or concurrent stale probe could still be reused.

## Test plan
- [x] Fresh-probe regression tests (running-session and persisted-catalog stale cases)
- [x] Superseded concurrent-probe regression test
- [x] `go test -race ./service/agent -run '^TestAvailableTaskAssignmentModels(RequiresFreshCursorProbe|DoesNotAcceptSupersededProbe)$' -count=1`
- [x] `go test ./service/tuttimodeplan -count=1`
- [x] Desktop workflow runtime test (7 passing)
- [x] Independent Codex review approved the final change

## Notes
`pnpm check:changed -- --push-ready` was attempted earlier. Its changed code lanes passed, but the environment-specific `service/computer` integration test failed because no eligible visible desktop window was available, and a nested `build:go` invocation resolved pnpm 10.33.1 instead of the required 10.11.0. Focused affected-surface tests above passed.
