### PR TITLE
fix(agent-gui): preserve Mermaid flowchart labels

### DIFF
--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -53,6 +53,7 @@ React rendering, Workbench state, external stores, input composition, and UI per
 
 - [Renderer body requests fail with `ERR_H2_OR_QUIC_REQUIRED`](./workbench-renderer.md#renderer-body-requests-fail-with-err_h2_or_quic_required)
 - [Renderer `fetch()` rejects an Electron image protocol that `<img>` can load](./workbench-renderer.md#renderer-fetch-rejects-an-electron-image-protocol-that-img-can-load)
+- [AgentGUI Mermaid flowcharts render shapes without labels](./workbench-renderer.md#agentgui-mermaid-flowcharts-render-shapes-without-labels)
 - [AgentGUI carousel owner avatar stays a solid badge](./workbench-renderer.md#agentgui-carousel-owner-avatar-stays-a-solid-badge)
 - [Renderer tile memory warnings from hidden autoplay animation](./workbench-renderer.md#renderer-tile-memory-warnings-from-hidden-autoplay-animation)
 - [Standalone Agent dev window stays black during cold startup](./workbench-renderer.md#standalone-agent-dev-window-stays-black-during-cold-startup)

--- a/docs/conventions/troubleshooting/workbench-renderer.md
+++ b/docs/conventions/troubleshooting/workbench-renderer.md
@@ -246,6 +246,34 @@
   [tuttiAssetProtocol.ts](../../../apps/desktop/src/main/host/tuttiAssetProtocol.ts)
   [workspaceFileIconProtocol.ts](../../../apps/desktop/src/main/host/workspaceFileIconProtocol.ts)
 
+### AgentGUI Mermaid flowcharts render shapes without labels
+
+- Symptom:
+  Mermaid flowcharts in AgentGUI show node borders and edges, but node and edge
+  labels are blank.
+- Quick checks:
+  Inspect Mermaid's raw SVG before the transcript sanitizer. If labels are
+  children of `<foreignObject>` while the sanitized SVG keeps shapes but has no
+  `<foreignObject>` or equivalent `<text>`, the missing content is an SVG/HTML
+  label-mode mismatch rather than a color or layout problem.
+- Root cause:
+  Mermaid enables HTML labels by default and renders them inside SVG
+  `<foreignObject>` elements. AgentGUI's defense-in-depth SVG sanitizer removes
+  those elements, including their text, while preserving native SVG shapes and
+  paths.
+- Fix:
+  Configure Mermaid to emit native SVG text with `htmlLabels: false`. Add
+  `htmlLabels` to Mermaid's secure configuration keys so diagram-level
+  directives cannot turn HTML labels back on. Keep the post-render SVG
+  sanitizer in place.
+- Validation:
+  Render a real flowchart containing multiline, CJK, decision, and edge labels,
+  including an `init` directive that requests HTML labels. Assert the sanitized
+  result contains every label as native SVG text and no `<foreignObject>`.
+- References:
+  [AgentMessageMermaid.tsx](../../../packages/agent/gui/shared/AgentMessageMermaid.tsx)
+  [AgentMessageMermaid.integration.spec.tsx](../../../packages/agent/gui/shared/AgentMessageMermaid.integration.spec.tsx)
+
 ### AgentGUI carousel owner avatar stays a solid badge
 
 - Symptom:

--- a/packages/agent/gui/shared/AgentMessageMermaid.integration.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMermaid.integration.spec.tsx
@@ -1,0 +1,77 @@
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { AgentMessageMermaid } from "./AgentMessageMermaid";
+
+describe("AgentMessageMermaid real renderer", () => {
+  const originalGetBBox = Object.getOwnPropertyDescriptor(
+    SVGElement.prototype,
+    "getBBox"
+  );
+  const originalGetComputedTextLength = Object.getOwnPropertyDescriptor(
+    SVGElement.prototype,
+    "getComputedTextLength"
+  );
+
+  beforeAll(() => {
+    Object.defineProperties(SVGElement.prototype, {
+      getBBox: {
+        configurable: true,
+        value: () => ({ height: 20, width: 120, x: 0, y: 0 })
+      },
+      getComputedTextLength: {
+        configurable: true,
+        value: () => 120
+      }
+    });
+  });
+
+  afterAll(() => {
+    restoreProperty(SVGElement.prototype, "getBBox", originalGetBBox);
+    restoreProperty(
+      SVGElement.prototype,
+      "getComputedTextLength",
+      originalGetComputedTextLength
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    document.documentElement.removeAttribute("data-theme");
+  });
+
+  it("keeps flowchart labels after the defense-in-depth sanitizer", async () => {
+    document.documentElement.dataset.theme = "light";
+    const view = render(
+      <AgentMessageMermaid
+        source={`%%{init: {"htmlLabels": true}}%%
+          flowchart TD
+            A["ACP Client<br/>启动 Agent"] --> B{"初始化成功？"}
+            B -->|"是"| C["创建会话"]`}
+        streaming={false}
+      />
+    );
+
+    await waitFor(() => {
+      expect(view.queryByTestId("agent-mermaid-svg")).not.toBeNull();
+    });
+    const container = view.getByTestId("agent-mermaid-svg");
+
+    expect(container.querySelector("foreignObject")).toBeNull();
+    expect(container.textContent).toContain("ACP Client");
+    expect(container.textContent).toContain("启动 Agent");
+    expect(container.textContent).toContain("初始化成功？");
+    expect(container.textContent).toContain("创建会话");
+  });
+});
+
+function restoreProperty(
+  target: object,
+  property: string,
+  descriptor: PropertyDescriptor | undefined
+): void {
+  if (descriptor) {
+    Object.defineProperty(target, property, descriptor);
+    return;
+  }
+  Reflect.deleteProperty(target, property);
+}

--- a/packages/agent/gui/shared/AgentMessageMermaid.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMermaid.spec.tsx
@@ -103,8 +103,10 @@ describe("AgentMessageMermaid", () => {
     });
     expect(mermaidMocks.initialize).toHaveBeenCalledWith(
       expect.objectContaining({
+        htmlLabels: false,
         maxEdges: 500,
         maxTextSize: 50_000,
+        secure: expect.arrayContaining(["htmlLabels", "securityLevel"]),
         securityLevel: "strict",
         startOnLoad: false,
         suppressErrorRendering: true,

--- a/packages/agent/gui/shared/AgentMessageMermaid.tsx
+++ b/packages/agent/gui/shared/AgentMessageMermaid.tsx
@@ -655,8 +655,18 @@ function resolveMermaidTheme(): MermaidTheme {
 function renderMermaid(source: string, theme: MermaidTheme): Promise<string> {
   mermaid.initialize({
     darkMode: theme === "dark",
+    htmlLabels: false,
     maxEdges: MERMAID_MAX_EDGES,
     maxTextSize: MERMAID_MAX_TEXT_SIZE,
+    secure: [
+      "secure",
+      "securityLevel",
+      "startOnLoad",
+      "maxTextSize",
+      "suppressErrorRendering",
+      "maxEdges",
+      "htmlLabels"
+    ],
     securityLevel: "strict",
     startOnLoad: false,
     suppressErrorRendering: true,


### PR DESCRIPTION
## Summary

- render Mermaid labels as native SVG text so AgentGUI's defense-in-depth sanitizer preserves them
- secure the `htmlLabels` setting against diagram-level directives
- add a real-renderer regression test covering multiline, CJK, decision, and edge labels
- document the recurring SVG/HTML label-mode troubleshooting pattern

## Verification

- `pnpm check:changed`
- `pnpm check:changed -- --push-ready`
- focused real Mermaid renderer and component tests (10 tests)

## Checklist

- [x] This change does not alter agent lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->