### PR TITLE
fix(agent-gui): isolate concurrent session renders

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -474,6 +474,14 @@ disable submission, but must not change editor editability.
 ### 4.1 Read/write rules
 
 - reads use exported selectors or memoized `AgentActivitySnapshot`
+- an engine subscriber notification is an invalidation signal, not a render
+  command. Concurrent AgentGUI surfaces subscribe through exact
+  Session-family or target selectors; a selector preserves its selected
+  reference when another root Session changes
+- whole-workspace `AgentActivitySnapshot` projections remain valid for bounded
+  aggregate reads, but do not belong in high-frequency AgentGUI render paths.
+  Event callbacks that need current canonical data read the engine snapshot at
+  event time instead of retaining a whole-workspace render snapshot
 - lifecycle writes use typed intents/commands
 - consumers do not read reducer maps directly
 - consumers do not create canonical session/message mirrors

--- a/docs/conventions/testing.md
+++ b/docs/conventions/testing.md
@@ -114,6 +114,7 @@ ownership, not a runtime call stack or proof of causation.
 
 The capture runner ships `provider-switch`, `session-switch`,
 `provider-session-cycle`, `virtualized-streaming`,
+`concurrent-agent-streaming`,
 `virtualized-scroll-locator`, `virtualized-session-cycle`,
 `virtualized-oversized-active-turn`, `browser-behind-agent-gui-pixels`,
 `rail-scope-reveal`, `composer-input`, `composer-overflow-resize`, `workbench-window-lifecycle`,
@@ -124,6 +125,14 @@ The capture runner ships `provider-switch`, `session-switch`,
 `--scenario <id>`. Scenario modules own preparation, completion conditions,
 semantic assertions, milestones, and metadata; runtime startup, trace capture,
 renderer analysis, and report rendering stay scenario-neutral.
+
+`concurrent-agent-streaming` selects two settled root Sessions, restores them
+into two non-overlapping visible AgentGUI windows, and routes each through an
+isolated fake Cursor ACP Session. Both Composer forms submit in one renderer
+task. The scenario requires both windows to enter working state, produce
+repeated transcript mutations, and settle before the trace tail. It reports
+the sampled conversation-projection and streaming-text functions without
+setting a cross-device timing threshold.
 
 `virtualized-streaming` and `virtualized-scroll-locator` require one root
 Session with at least thirty settled Turns. They change only the isolated copy

--- a/packages/agent/activity-core/src/engine/agentActivitySnapshot.projector.ts
+++ b/packages/agent/activity-core/src/engine/agentActivitySnapshot.projector.ts
@@ -30,7 +30,7 @@ export function createAgentActivitySnapshotProjector(
       state.sessionLifecycle === previousState.sessionLifecycle
         ? previousSnapshot.sessions
         : selectAllWorkspaceAgentConsumerSessions(state).map((item) =>
-            projectSession(
+            projectAgentActivitySession(
               item.session,
               item.activeTurn,
               item.latestTurn,
@@ -108,7 +108,7 @@ export function createEmptyAgentActivitySnapshot(
   };
 }
 
-function projectSession(
+export function projectAgentActivitySession(
   session: Omit<
     AgentActivitySession,
     | "activeTurn"

--- a/packages/agent/activity-core/src/engine/sessionFamily.selectors.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionFamily.selectors.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { AgentActivityMessage } from "../types.ts";
+import {
+  createInitialAgentSessionEngineState,
+  rootEngineReducer
+} from "./rootReducer.ts";
+import { createAgentSessionFamilySnapshotSelector } from "./sessionFamily.selectors.ts";
+
+test("session family selector preserves unrelated root projection identity", () => {
+  let state = rootEngineReducer(createInitialAgentSessionEngineState(), {
+    sessions: [
+      session("session-a"),
+      session("session-a-child", {
+        kind: "child",
+        parentAgentSessionId: "session-a",
+        rootAgentSessionId: "session-a"
+      }),
+      session("session-b")
+    ],
+    type: "session/snapshotReceived"
+  }).state;
+  state = rootEngineReducer(state, {
+    messages: [
+      message("message-a-1", "session-a", 1),
+      message("message-a-child-1", "session-a-child", 1),
+      message("message-b-1", "session-b", 1)
+    ],
+    type: "message/snapshotReceived"
+  }).state;
+
+  const selectA = createAgentSessionFamilySnapshotSelector("session-a");
+  const selectB = createAgentSessionFamilySnapshotSelector("session-b");
+  const initialA = selectA(state);
+  const initialB = selectB(state);
+
+  state = rootEngineReducer(state, {
+    messages: [message("message-a-2", "session-a", 2)],
+    type: "message/snapshotReceived"
+  }).state;
+
+  const updatedA = selectA(state);
+  const updatedB = selectB(state);
+  assert.notEqual(updatedA, initialA);
+  assert.notEqual(updatedA.messagesBySessionId, initialA.messagesBySessionId);
+  assert.equal(updatedB, initialB);
+  assert.equal(updatedB.messagesBySessionId, initialB.messagesBySessionId);
+});
+
+test("session family selector preserves an empty unrelated message bucket", () => {
+  let state = rootEngineReducer(createInitialAgentSessionEngineState(), {
+    sessions: [session("session-a"), session("session-b")],
+    type: "session/snapshotReceived"
+  }).state;
+  const selectB = createAgentSessionFamilySnapshotSelector("session-b");
+  const initialB = selectB(state);
+
+  state = rootEngineReducer(state, {
+    messages: [message("message-a-1", "session-a", 1)],
+    type: "message/snapshotReceived"
+  }).state;
+
+  assert.equal(selectB(state), initialB);
+});
+
+function session(
+  agentSessionId: string,
+  overrides: Record<string, unknown> = {}
+) {
+  return {
+    activeTurnId: null,
+    agentSessionId,
+    cwd: "/workspace",
+    latestTurnInteractions: [],
+    pendingInteractions: [],
+    provider: "codex",
+    title: agentSessionId,
+    workspaceId: "workspace-1",
+    ...overrides
+  };
+}
+
+function message(
+  messageId: string,
+  agentSessionId: string,
+  version: number
+): AgentActivityMessage {
+  return {
+    agentSessionId,
+    kind: "text",
+    messageId,
+    occurredAtUnixMs: version,
+    payload: { text: messageId },
+    role: "assistant",
+    sequence: version,
+    status: null,
+    turnId: "turn-1",
+    version,
+    workspaceId: "workspace-1"
+  };
+}

--- a/packages/agent/activity-core/src/engine/sessionFamily.selectors.ts
+++ b/packages/agent/activity-core/src/engine/sessionFamily.selectors.ts
@@ -1,0 +1,197 @@
+import type {
+  AgentActivityInteraction,
+  AgentActivityMessage,
+  AgentActivitySession
+} from "../types.ts";
+import { projectAgentActivitySession } from "./agentActivitySnapshot.projector.ts";
+import {
+  selectEngineActiveTurn,
+  selectEngineInteractionsForSession,
+  selectEngineLatestTurn,
+  selectEnginePendingInteractions
+} from "./sessionLifecycle.selectors.ts";
+import type { CanonicalAgentSession } from "./sessionLifecycle.types.ts";
+import type { AgentSessionEngineState } from "./types.ts";
+
+const EMPTY_MESSAGES: readonly AgentActivityMessage[] = [];
+
+export interface AgentSessionFamilySnapshot {
+  childSessions: readonly AgentActivitySession[];
+  messagesBySessionId: Readonly<
+    Record<string, readonly AgentActivityMessage[]>
+  >;
+  pendingInteractions: readonly AgentActivityInteraction[];
+  rootSession: AgentActivitySession | null;
+}
+
+interface ProjectedSessionRecord {
+  activeTurn: AgentActivitySession["activeTurn"];
+  interactions: readonly AgentActivityInteraction[];
+  latestTurn: AgentActivitySession["latestTurn"];
+  pendingInteractions: readonly AgentActivityInteraction[];
+  projected: AgentActivitySession;
+  session: CanonicalAgentSession;
+}
+
+/**
+ * Creates a Session-family projection for one mounted consumer.
+ *
+ * Workspace engines notify every subscriber after a drain. This selector keeps
+ * the previous result when only another root Session changed, so one streaming
+ * conversation cannot force unrelated AgentGUI surfaces to render.
+ */
+export function createAgentSessionFamilySnapshotSelector(
+  rootAgentSessionId: string | null | undefined
+): (state: AgentSessionEngineState) => AgentSessionFamilySnapshot {
+  const rootId = rootAgentSessionId?.trim() ?? "";
+  let previousRecordsById = new Map<string, ProjectedSessionRecord>();
+  let previousSnapshot: AgentSessionFamilySnapshot = {
+    childSessions: [],
+    messagesBySessionId: {},
+    pendingInteractions: [],
+    rootSession: null
+  };
+
+  return (state) => {
+    if (!rootId) return previousSnapshot;
+
+    const familySessions = Object.values(
+      state.sessionLifecycle.sessionsById
+    ).filter(
+      (session) =>
+        session.agentSessionId === rootId ||
+        (session.kind === "child" &&
+          session.rootAgentSessionId?.trim() === rootId)
+    );
+    const nextRecordsById = new Map<string, ProjectedSessionRecord>();
+    const projectedSessions: AgentActivitySession[] = [];
+
+    for (const session of familySessions) {
+      const activeTurn = selectEngineActiveTurn(state, session.agentSessionId);
+      const latestTurn = selectEngineLatestTurn(state, session.agentSessionId);
+      const interactions = selectEngineInteractionsForSession(
+        state,
+        session.agentSessionId
+      );
+      const pendingInteractions = selectEnginePendingInteractions(
+        state,
+        session.agentSessionId
+      );
+      const previousRecord = previousRecordsById.get(session.agentSessionId);
+      const reusable =
+        previousRecord?.session === session &&
+        previousRecord.activeTurn === activeTurn &&
+        previousRecord.latestTurn === latestTurn &&
+        referenceArrayEqual(previousRecord.interactions, interactions) &&
+        referenceArrayEqual(
+          previousRecord.pendingInteractions,
+          pendingInteractions
+        );
+      const record: ProjectedSessionRecord = reusable
+        ? previousRecord
+        : {
+            activeTurn,
+            interactions,
+            latestTurn,
+            pendingInteractions,
+            projected: projectAgentActivitySession(
+              session,
+              activeTurn,
+              latestTurn,
+              interactions,
+              pendingInteractions
+            ),
+            session
+          };
+      nextRecordsById.set(session.agentSessionId, record);
+      projectedSessions.push(record.projected);
+    }
+
+    const nextChildSessions = projectedSessions.filter(
+      (session) => session.kind === "child"
+    );
+    const rootSession =
+      projectedSessions.find(
+        (session) => session.agentSessionId === rootId
+      ) ?? null;
+    const childSessions = referenceArrayEqual(
+      previousSnapshot.childSessions,
+      nextChildSessions
+    )
+      ? previousSnapshot.childSessions
+      : nextChildSessions;
+    const nextMessagesBySessionId = Object.fromEntries(
+      familySessions.map((session) => [
+        session.agentSessionId,
+        state.sessionMessages.messagesBySessionId[session.agentSessionId] ??
+          EMPTY_MESSAGES
+      ])
+    );
+    const messagesBySessionId = messageRecordsEqual(
+      previousSnapshot.messagesBySessionId,
+      nextMessagesBySessionId
+    )
+      ? previousSnapshot.messagesBySessionId
+      : nextMessagesBySessionId;
+    const nextPendingInteractions = projectedSessions
+      .flatMap((session) => session.pendingInteractions)
+      .sort(compareInteractions);
+    const pendingInteractions = referenceArrayEqual(
+      previousSnapshot.pendingInteractions,
+      nextPendingInteractions
+    )
+      ? previousSnapshot.pendingInteractions
+      : nextPendingInteractions;
+
+    previousRecordsById = nextRecordsById;
+    if (
+      childSessions === previousSnapshot.childSessions &&
+      messagesBySessionId === previousSnapshot.messagesBySessionId &&
+      pendingInteractions === previousSnapshot.pendingInteractions &&
+      rootSession === previousSnapshot.rootSession
+    ) {
+      return previousSnapshot;
+    }
+    previousSnapshot = {
+      childSessions,
+      messagesBySessionId,
+      pendingInteractions,
+      rootSession
+    };
+    return previousSnapshot;
+  };
+}
+
+function referenceArrayEqual<T>(
+  left: readonly T[],
+  right: readonly T[]
+): boolean {
+  return (
+    left === right ||
+    (left.length === right.length &&
+      left.every((item, index) => item === right[index]))
+  );
+}
+
+function messageRecordsEqual(
+  left: AgentSessionFamilySnapshot["messagesBySessionId"],
+  right: AgentSessionFamilySnapshot["messagesBySessionId"]
+): boolean {
+  const leftIds = Object.keys(left);
+  const rightIds = Object.keys(right);
+  return (
+    leftIds.length === rightIds.length &&
+    rightIds.every((id) => left[id] === right[id])
+  );
+}
+
+function compareInteractions(
+  left: AgentActivityInteraction,
+  right: AgentActivityInteraction
+): number {
+  return (
+    left.createdAtUnixMs - right.createdAtUnixMs ||
+    left.agentSessionId.localeCompare(right.agentSessionId) ||
+    left.requestId.localeCompare(right.requestId)
+  );
+}

--- a/packages/agent/activity-core/src/engine/sessionMessages.selectors.ts
+++ b/packages/agent/activity-core/src/engine/sessionMessages.selectors.ts
@@ -1,4 +1,5 @@
 import type { AgentActivityMessage } from "../types.ts";
+import type { AgentActivitySessionMessageWindow } from "../messageWindow.types.ts";
 import type { AgentSessionEngineState } from "./types.ts";
 
 const EMPTY_MESSAGES: readonly AgentActivityMessage[] = [];
@@ -16,4 +17,13 @@ export function selectSessionMessages(
   const id = agentSessionId?.trim() ?? "";
   if (!id) return EMPTY_MESSAGES;
   return state.sessionMessages.messagesBySessionId[id] ?? EMPTY_MESSAGES;
+}
+
+export function selectSessionMessageWindow(
+  state: AgentSessionEngineState,
+  agentSessionId: string | null | undefined
+): Readonly<AgentActivitySessionMessageWindow> | null {
+  const id = agentSessionId?.trim() ?? "";
+  if (!id) return null;
+  return state.sessionMessages.windowsBySessionId[id] ?? null;
 }

--- a/packages/agent/activity-core/src/index.ts
+++ b/packages/agent/activity-core/src/index.ts
@@ -145,9 +145,14 @@ export {
   selectSessionAttention
 } from "./engine/attentionReadState.selectors.ts";
 export {
+  selectSessionMessageWindow,
   selectSessionMessages,
   selectSessionMessagesById
 } from "./engine/sessionMessages.selectors.ts";
+export {
+  createAgentSessionFamilySnapshotSelector,
+  type AgentSessionFamilySnapshot
+} from "./engine/sessionFamily.selectors.ts";
 export type { SessionMessagesState } from "./engine/sessionMessages.types.ts";
 export {
   selectComposerOptions,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerCapabilities.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerCapabilities.spec.tsx
@@ -1,11 +1,11 @@
 import { renderHook } from "@testing-library/react";
 import {
-  createEmptyAgentActivitySnapshot,
   normalizeAgentActivitySession,
   type CanonicalAgentSession
 } from "@tutti-os/agent-activity-core";
 import { describe, expect, it } from "vitest";
 import { useAgentGUIComposerCapabilities } from "./useAgentGUIComposerCapabilities";
+import { createTestAgentSessionEngine } from "../../../shared/testing/createTestAgentSessionEngine";
 
 describe("useAgentGUIComposerCapabilities", () => {
   function engineSession(input: {
@@ -54,7 +54,6 @@ describe("useAgentGUIComposerCapabilities", () => {
         activeConversationId: "session-1",
         activeEngineSession,
         activeSessionState: null,
-        agentActivitySnapshot: createEmptyAgentActivitySnapshot("workspace-1"),
         data,
         draftSettingsBySessionId: {},
         selectedComposerTargetData: {
@@ -62,7 +61,8 @@ describe("useAgentGUIComposerCapabilities", () => {
           data,
           provider: "opencode",
           targetId: "local:opencode"
-        }
+        },
+        sessionEngine: createTestAgentSessionEngine("workspace-1")
       })
     );
 
@@ -96,7 +96,6 @@ describe("useAgentGUIComposerCapabilities", () => {
         activeConversationId: activeEngineSession.agentSessionId,
         activeEngineSession,
         activeSessionState: null,
-        agentActivitySnapshot: createEmptyAgentActivitySnapshot("workspace-1"),
         data,
         draftSettingsBySessionId: {},
         selectedComposerTargetData: {
@@ -104,7 +103,8 @@ describe("useAgentGUIComposerCapabilities", () => {
           data,
           provider: "opencode",
           targetId: "local:opencode"
-        }
+        },
+        sessionEngine: createTestAgentSessionEngine("workspace-1")
       })
     );
 
@@ -147,7 +147,6 @@ describe("useAgentGUIComposerCapabilities", () => {
         activeConversationId: activeEngineSession.agentSessionId,
         activeEngineSession,
         activeSessionState: null,
-        agentActivitySnapshot: createEmptyAgentActivitySnapshot("workspace-1"),
         data,
         draftSettingsBySessionId: {},
         selectedComposerTargetData: {
@@ -155,7 +154,8 @@ describe("useAgentGUIComposerCapabilities", () => {
           data,
           provider: "opencode",
           targetId: "local:opencode"
-        }
+        },
+        sessionEngine: createTestAgentSessionEngine("workspace-1")
       })
     );
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerCapabilities.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerCapabilities.ts
@@ -1,9 +1,11 @@
 import {
   resolveAgentActivityCapability,
   resolveAgentActivityUsage,
+  selectComposerOptions,
+  selectComposerOptionsLoadStatus,
   type AgentActivityUsage,
-  type AgentActivitySnapshot,
-  type CanonicalAgentSession
+  type CanonicalAgentSession,
+  type AgentSessionEngine
 } from "@tutti-os/agent-activity-core";
 import { useMemo, useRef } from "react";
 import type {
@@ -15,23 +17,20 @@ import type { AgentGUINodeData } from "../../../types";
 import { composerSettingsSupportFromOptions } from "../model/composerSettingsSupport";
 import { normalizeOptionalText } from "./agentGuiController.promptHelpers";
 import {
-  composerOptionsForTarget,
-  composerOptionsLoadingForTarget
-} from "./agentGuiController.providerHelpers";
-import {
   composerTargetDataForConversation,
   type AgentGUIComposerTargetData
 } from "./agentGuiController.composerPresentation";
 import { resolvePromptImageSelectedModel } from "./agentGuiController.draftMessageHelpers";
+import { useEngineSelector } from "../../../shared/engine/useEngineSelector";
 
 interface UseAgentGUIComposerCapabilitiesInput {
   activeConversationId: string | null;
   activeEngineSession: CanonicalAgentSession | null;
   activeSessionState: AgentSessionState | null;
-  agentActivitySnapshot: AgentActivitySnapshot;
   data: AgentGUINodeData;
   draftSettingsBySessionId: Record<string, AgentSessionComposerSettings>;
   selectedComposerTargetData: AgentGUIComposerTargetData;
+  sessionEngine: AgentSessionEngine;
 }
 
 export function useAgentGUIComposerCapabilities(
@@ -46,14 +45,20 @@ export function useAgentGUIComposerCapabilities(
     optimisticTarget: null,
     selectedTarget: input.selectedComposerTargetData
   });
-  const providerComposerOptions = composerOptionsForTarget({
-    snapshot: input.agentActivitySnapshot,
-    target: composerTargetData
-  });
-  const composerOptionsLoading = composerOptionsLoadingForTarget({
-    snapshot: input.agentActivitySnapshot,
-    target: composerTargetData
-  });
+  const composerTargetKey = composerTargetData.agentTargetId?.trim() ?? "";
+  const providerComposerOptions = useEngineSelector(
+    input.sessionEngine,
+    (state) => selectComposerOptions(state, composerTargetKey)
+  );
+  const composerOptionsLoadStatus = useEngineSelector(
+    input.sessionEngine,
+    (state) => selectComposerOptionsLoadStatus(state, composerTargetKey)
+  );
+  const composerOptionsLoading = Boolean(
+    composerTargetKey &&
+    !providerComposerOptions &&
+    composerOptionsLoadStatus === "loading"
+  );
   const defaultReasoningEffort: AgentSessionReasoningEffort | null = "high";
   const sessionCapabilities = input.activeEngineSession?.capabilities ?? null;
   const resolvedPromptImagesSupported =

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIControllerRefs.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIControllerRefs.ts
@@ -1,4 +1,3 @@
-import type { AgentActivitySnapshot } from "@tutti-os/agent-activity-core";
 import { useRef } from "react";
 import type { AgentHostUserProject } from "../../../host/agentHostApi";
 import type { AgentSessionComposerSettings } from "../../../shared/agentSessionTypes";
@@ -17,7 +16,6 @@ import type { AgentGUIComposerDefaultsAuthorityReconciler } from "./agentGuiComp
 
 interface UseAgentGUIControllerRefsInput {
   activeConversationId: string | null;
-  agentActivitySnapshot: AgentActivitySnapshot;
   conversations: AgentGUIConversationSummary[];
   data: AgentGUINodeData;
   draftByScopeKey: Record<string, AgentComposerDraft>;
@@ -55,7 +53,6 @@ export function useAgentGUIControllerRefs(
   const userProjectsLoadSeqRef = useRef(0);
   const conversationsRef = useRef(input.conversations);
   const isMountedRef = useRef(true);
-  const agentActivitySnapshotRef = useRef(input.agentActivitySnapshot);
   const dataRef = useRef(input.data);
   const selectedAgentTargetRef = useRef(input.effectiveSelectedProviderTarget);
   const selectedAgentTargetIsExplicitRef = useRef(
@@ -132,7 +129,6 @@ export function useAgentGUIControllerRefs(
   userProjectsRef.current = input.userProjects;
   isNoProjectPathRef.current = input.isNoProjectPath;
   conversationsRef.current = input.conversations;
-  agentActivitySnapshotRef.current = input.agentActivitySnapshot;
   dataRef.current = input.data;
   selectedAgentTargetRef.current = input.effectiveSelectedProviderTarget;
   selectedAgentTargetIsExplicitRef.current = input.homeComposerTargetOverride
@@ -153,7 +149,6 @@ export function useAgentGUIControllerRefs(
 
   return {
     activeConversationIdRef,
-    agentActivitySnapshotRef,
     conversationIdsRef,
     conversationsRef,
     dataRef,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationDetail.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationDetail.spec.tsx
@@ -1,9 +1,6 @@
 import { renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import {
-  createEmptyAgentActivitySnapshot,
-  normalizeAgentActivitySession
-} from "@tutti-os/agent-activity-core";
+import { normalizeAgentActivitySession } from "@tutti-os/agent-activity-core";
 import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
 import { createTestAgentSessionEngine } from "../../../shared/testing/createTestAgentSessionEngine";
 import type { AgentGUIConversationSummary } from "../model/agentGuiConversationModel";
@@ -28,7 +25,12 @@ function conversationDetailInput(
     activeQueuedPromptInFlight: null,
     activeQueuedPrompts: [],
     activeQueueStatus: "active",
-    agentActivitySnapshot: createEmptyAgentActivitySnapshot("workspace-1"),
+    activeSessionFamily: {
+      childSessions: [],
+      messagesBySessionId: {},
+      pendingInteractions: [],
+      rootSession: null
+    },
     activeSessionReconcileError: null,
     activeSessionView: null,
     activeTimelineItems: [],
@@ -150,9 +152,11 @@ describe("useAgentGUIConversationDetail", () => {
       useAgentGUIConversationDetail(
         conversationDetailInput({
           activeConversation: conversationSummary(),
-          agentActivitySnapshot: {
-            ...createEmptyAgentActivitySnapshot("workspace-1"),
-            sessions: [session]
+          activeSessionFamily: {
+            childSessions: [],
+            messagesBySessionId: {},
+            pendingInteractions: [],
+            rootSession: session
           }
         })
       )
@@ -190,17 +194,17 @@ describe("useAgentGUIConversationDetail", () => {
         useAgentGUIConversationDetail(
           conversationDetailInput({
             activeConversation: conversationSummary(),
-            agentActivitySnapshot: {
-              ...createEmptyAgentActivitySnapshot("workspace-1"),
-              sessions: [
-                normalizeAgentActivitySession({
-                  ...baseSession,
-                  lifecycleCapabilities: {
-                    fork: false,
-                    forkThroughTurn
-                  }
-                })
-              ]
+            activeSessionFamily: {
+              childSessions: [],
+              messagesBySessionId: {},
+              pendingInteractions: [],
+              rootSession: normalizeAgentActivitySession({
+                ...baseSession,
+                lifecycleCapabilities: {
+                  fork: false,
+                  forkThroughTurn
+                }
+              })
             }
           })
         ),

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationDetail.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationDetail.ts
@@ -3,7 +3,7 @@ import {
   selectEngineTurnsForSession,
   type AgentActivityInteraction,
   type AgentActivityMessage,
-  type AgentActivitySnapshot,
+  type AgentSessionFamilySnapshot,
   type AgentActivityTurn,
   type AgentSessionEngine,
   type EngineQueuedPrompt,
@@ -59,7 +59,7 @@ interface UseAgentGUIConversationDetailInput {
   activeQueuedPromptInFlight: PromptQueueInFlightCommand | null;
   activeQueuedPrompts: readonly EngineQueuedPrompt[];
   activeQueueStatus: AgentGUIQueueStatus;
-  agentActivitySnapshot: AgentActivitySnapshot;
+  activeSessionFamily: AgentSessionFamilySnapshot;
   activeSessionReconcileError: string | null;
   activeSessionView: {
     hasOlderMessages: boolean;
@@ -99,14 +99,6 @@ export function useAgentGUIConversationDetail(
     input.sessionEngine,
     (state) => selectEngineTurnsForSession(state, input.activeConversationId),
     referenceArrayEqual
-  );
-  const activitySession = useMemo(
-    () =>
-      input.agentActivitySnapshot.sessions.find(
-        (session) =>
-          session.agentSessionId === input.activeConversationId?.trim()
-      ) ?? null,
-    [input.activeConversationId, input.agentActivitySnapshot.sessions]
   );
   const projectionConversation =
     useMemo<AgentGUIConversationProjectionSource | null>(() => {
@@ -177,26 +169,21 @@ export function useAgentGUIConversationDetail(
     if (!projectionConversation) {
       return { conversation: null, detail: null };
     }
-    const rootSessionId = projectionConversation.id.trim();
-    const childSessions = input.agentActivitySnapshot.sessions.filter(
-      (session) =>
-        session.kind === "child" && session.rootAgentSessionId === rootSessionId
-    );
     return buildAgentGUIConversationModels({
       timelineItems: input.activeTimelineItems,
       conversation: projectionConversation,
-      canonicalSession: activitySession,
-      childSessions,
-      childMessagesBySessionId: input.agentActivitySnapshot.sessionMessagesById,
+      canonicalSession: input.activeSessionFamily.rootSession,
+      childSessions: input.activeSessionFamily.childSessions,
+      childMessagesBySessionId: input.activeSessionFamily.messagesBySessionId,
       workspaceRoot: input.workspacePath,
       avoidGroupingEdits: input.avoidGroupingEdits
     });
   }, [
     input.activeTimelineItems,
-    input.agentActivitySnapshot.sessionMessagesById,
-    input.agentActivitySnapshot.sessions,
+    input.activeSessionFamily.childSessions,
+    input.activeSessionFamily.messagesBySessionId,
+    input.activeSessionFamily.rootSession,
     input.avoidGroupingEdits,
-    activitySession,
     input.workspacePath,
     projectionConversation
   ]);

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -1,13 +1,11 @@
 import {
+  createAgentSessionFamilySnapshotSelector,
   selectEngineSessionIsRespondingToInteraction,
   selectWorkspaceAgentConsumerSessions
 } from "@tutti-os/agent-activity-core";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useAgentHostApi } from "../../../agentActivityHost";
-import {
-  useAgentActivityRuntime,
-  useAgentActivitySnapshot
-} from "../../../agentActivityRuntime";
+import { useAgentActivityRuntime } from "../../../agentActivityRuntime";
 import { useAccountStore } from "../../../host/agentHostAccountStore";
 import type { AgentHostUserProject } from "../../../host/agentHostApi";
 import type { AgentSessionComposerSettings } from "../../../shared/agentSessionTypes";
@@ -148,7 +146,6 @@ export function useAgentGUINodeController({
   }, [agentActivityRuntime, agentActivityRuntimeOrigin, workspaceId]);
   // Stable runtime identity isolates conversation queries and session-view refs.
   const agentHostApi = useAgentHostApi();
-  const agentActivitySnapshot = useAgentActivitySnapshot(workspaceId);
   const providerCatalogSelection = useAgentGUIProviderCatalogSelection({
     comingSoonProviders,
     data,
@@ -245,23 +242,16 @@ export function useAgentGUINodeController({
     activeSessionState,
     isCreatingConversation
   } = sessionEngineState;
-  const activeRelatedPendingInteractions = useMemo(() => {
-    if (!activeConversationId) return [];
-    return agentActivitySnapshot.sessions
-      .filter(
-        (session) =>
-          session.agentSessionId === activeConversationId ||
-          (session.kind === "child" &&
-            session.rootAgentSessionId === activeConversationId)
-      )
-      .flatMap((session) => session.pendingInteractions)
-      .sort(
-        (left, right) =>
-          left.createdAtUnixMs - right.createdAtUnixMs ||
-          left.agentSessionId.localeCompare(right.agentSessionId) ||
-          left.requestId.localeCompare(right.requestId)
-      );
-  }, [activeConversationId, agentActivitySnapshot.sessions]);
+  const selectActiveSessionFamily = useMemo(
+    () => createAgentSessionFamilySnapshotSelector(activeConversationId),
+    [activeConversationId]
+  );
+  const activeSessionFamily = useEngineSelector(
+    sessionEngine,
+    selectActiveSessionFamily
+  );
+  const activeRelatedPendingInteractions =
+    activeSessionFamily.pendingInteractions;
   const activeRelatedIsRespondingToInteraction = useEngineSelector(
     sessionEngine,
     (state) =>
@@ -289,10 +279,10 @@ export function useAgentGUINodeController({
     activeConversationId,
     activeEngineSession,
     activeSessionState,
-    agentActivitySnapshot,
     data,
     draftSettingsBySessionId,
-    selectedComposerTargetData
+    selectedComposerTargetData,
+    sessionEngine
   });
   const {
     composerSupport,
@@ -306,7 +296,6 @@ export function useAgentGUINodeController({
   );
   const controllerRefs = useAgentGUIControllerRefs({
     activeConversationId,
-    agentActivitySnapshot,
     conversations,
     data,
     draftByScopeKey,
@@ -327,7 +316,6 @@ export function useAgentGUINodeController({
   });
   const {
     activeConversationIdRef,
-    agentActivitySnapshotRef,
     conversationIdsRef,
     conversationsRef,
     dataRef,
@@ -351,8 +339,6 @@ export function useAgentGUINodeController({
     activeConversationIdRef,
     agentActivityRuntime,
     agentActivityRuntimeOrigin,
-    agentActivitySnapshot,
-    agentActivitySnapshotRef,
     dataRef,
     isMountedRef,
     reloadSelectedConversationRef,
@@ -691,8 +677,8 @@ export function useAgentGUINodeController({
     activeLatestPendingSubmitTurnId:
       sessionEngineState.activeLatestPendingSubmit?.turnId ?? null,
     activeMessages,
+    activeSessionFamily,
     activeTimelineItems,
-    agentActivitySnapshot,
     activeEngineHasPendingInteractions:
       activeRelatedPendingInteractions.length > 0,
     isRespondingToInteraction: activeRelatedIsRespondingToInteraction,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionDetailTransport.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionDetailTransport.ts
@@ -1,7 +1,8 @@
 import {
   selectLatestActivationForSession,
+  selectSessionMessages,
+  selectSessionMessageWindow,
   type SessionReconcileScope,
-  type AgentActivitySnapshot,
   type AgentSessionEngine
 } from "@tutti-os/agent-activity-core";
 import type { RefObject } from "react";
@@ -21,14 +22,13 @@ import {
   useAgentConversationMessagePaging,
   windowHasTurnMissingUserPrompt
 } from "./useAgentConversationMessagePaging";
+import { useEngineSelector } from "../../../shared/engine/useEngineSelector";
 
 export function useAgentGUISessionDetailTransport(input: {
   activeConversationId: string | null;
   activeConversationIdRef: RefObject<string | null>;
   agentActivityRuntime: AgentActivityRuntime;
   agentActivityRuntimeOrigin: string;
-  agentActivitySnapshot: AgentActivitySnapshot;
-  agentActivitySnapshotRef: RefObject<AgentActivitySnapshot>;
   dataRef: RefObject<AgentGUINodeData>;
   isMountedRef: RefObject<boolean>;
   reloadSelectedConversationRef: RefObject<
@@ -48,8 +48,6 @@ export function useAgentGUISessionDetailTransport(input: {
     activeConversationIdRef,
     agentActivityRuntime,
     agentActivityRuntimeOrigin,
-    agentActivitySnapshot,
-    agentActivitySnapshotRef,
     dataRef,
     isMountedRef,
     reloadSelectedConversationRef,
@@ -65,31 +63,35 @@ export function useAgentGUISessionDetailTransport(input: {
     }),
     [agentActivityRuntimeOrigin, workspaceId]
   );
+  const activeCanonicalMessages = useEngineSelector(
+    sessionEngine,
+    (engineState) => selectSessionMessages(engineState, activeConversationId)
+  );
+  const activeCanonicalWindow = useEngineSelector(
+    sessionEngine,
+    (engineState) =>
+      selectSessionMessageWindow(engineState, activeConversationId)
+  );
   const state = useAgentSessionControllerState(
     sessionViewRef(activeConversationId),
-    activeConversationId
-      ? (agentActivitySnapshot.sessionMessagesById[activeConversationId] ?? [])
-      : [],
-    activeConversationId
-      ? (agentActivitySnapshot.sessionMessageWindowsById?.[
-          activeConversationId
-        ] ?? null)
-      : null
+    activeCanonicalMessages,
+    activeCanonicalWindow
   );
   const resolveSessionMessages = useCallback(
     (agentSessionId: string | null | undefined) => {
       const normalized = agentSessionId?.trim() ?? "";
       if (!normalized) return EMPTY_AGENT_GUI_MESSAGES;
       const sessionView = state.getAgentSessionView(sessionViewRef(normalized));
-      const canonical =
-        agentActivitySnapshot.sessionMessagesById[normalized] ??
-        EMPTY_AGENT_GUI_MESSAGES;
+      const canonical = selectSessionMessages(
+        sessionEngine.getSnapshot(),
+        normalized
+      );
       const older = sessionView?.olderMessages ?? EMPTY_AGENT_GUI_MESSAGES;
       return older.length > 0
         ? mergeWorkspaceAgentMessages(older, canonical)
         : canonical;
     },
-    [agentActivitySnapshot.sessionMessagesById, sessionViewRef, state]
+    [sessionEngine, sessionViewRef, state]
   );
   const {
     loadSessionState,
@@ -144,8 +146,7 @@ export function useAgentGUISessionDetailTransport(input: {
     },
     getActiveSessionId: () => activeConversationIdRef.current,
     getCanonicalMessages: (agentSessionId) =>
-      agentActivitySnapshotRef.current.sessionMessagesById[agentSessionId] ??
-      EMPTY_AGENT_GUI_MESSAGES,
+      selectSessionMessages(sessionEngine.getSnapshot(), agentSessionId),
     isMounted: () => isMountedRef.current,
     projection: {
       maxVersion: maxFiniteMessageVersion,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionFamilySubscription.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionFamilySubscription.spec.tsx
@@ -1,0 +1,79 @@
+import { act, renderHook } from "@testing-library/react";
+import {
+  createAgentSessionFamilySnapshotSelector,
+  normalizeAgentActivitySession,
+  type AgentActivityMessage
+} from "@tutti-os/agent-activity-core";
+import { describe, expect, it } from "vitest";
+import { useEngineSelector } from "../../../shared/engine/useEngineSelector";
+import { createTestAgentSessionEngine } from "../../../shared/testing/createTestAgentSessionEngine";
+
+describe("AgentGUI Session-family subscription", () => {
+  it("does not render an unrelated AgentGUI when another Session streams", () => {
+    const engine = createTestAgentSessionEngine("workspace-1");
+    engine.dispatch({
+      sessions: [
+        normalizeAgentActivitySession(session("session-a")),
+        normalizeAgentActivitySession(session("session-b"))
+      ],
+      type: "session/snapshotReceived"
+    });
+    const selectA = createAgentSessionFamilySnapshotSelector("session-a");
+    const selectB = createAgentSessionFamilySnapshotSelector("session-b");
+    let rendersA = 0;
+    let rendersB = 0;
+
+    renderHook(() => {
+      rendersA += 1;
+      return useEngineSelector(engine, selectA);
+    });
+    renderHook(() => {
+      rendersB += 1;
+      return useEngineSelector(engine, selectB);
+    });
+    const initialRendersA = rendersA;
+    const initialRendersB = rendersB;
+
+    act(() => {
+      engine.dispatch({
+        messages: [message("message-a", "session-a")],
+        type: "message/snapshotReceived"
+      });
+    });
+
+    expect(rendersA).toBeGreaterThan(initialRendersA);
+    expect(rendersB).toBe(initialRendersB);
+  });
+});
+
+function session(agentSessionId: string) {
+  return {
+    activeTurnId: null,
+    agentSessionId,
+    cwd: "/workspace",
+    latestTurnInteractions: [],
+    pendingInteractions: [],
+    provider: "codex",
+    title: agentSessionId,
+    workspaceId: "workspace-1"
+  };
+}
+
+function message(
+  messageId: string,
+  agentSessionId: string
+): AgentActivityMessage {
+  return {
+    agentSessionId,
+    kind: "text",
+    messageId,
+    occurredAtUnixMs: 1,
+    payload: { text: messageId },
+    role: "assistant",
+    sequence: 1,
+    status: null,
+    turnId: "turn-1",
+    version: 1,
+    workspaceId: "workspace-1"
+  };
+}

--- a/tools/scripts/agent-gui-concurrent-streaming-performance-scenario.mjs
+++ b/tools/scripts/agent-gui-concurrent-streaming-performance-scenario.mjs
@@ -1,0 +1,497 @@
+import {
+  evaluate,
+  finishRendererScenario,
+  markRenderer,
+  startRendererScenario,
+  waitForEvaluation
+} from "./agent-gui-performance-helpers.mjs";
+import { installCursorPerformanceFixture } from "./agent-gui-layout-performance-scenarios.mjs";
+import {
+  requiredScenarioData,
+  scenarioSummary as summary,
+  sqlString,
+  startupWorkspaceID
+} from "./agent-gui-performance-snapshot-helpers.mjs";
+
+const scenarioID = "concurrent-agent-streaming";
+const markers = {
+  start: `tutti-perf:${scenarioID}:start`,
+  submitted: `tutti-perf:${scenarioID}:submitted-observed`,
+  bothMutated: `tutti-perf:${scenarioID}:both-transcripts-mutated`,
+  settled: `tutti-perf:${scenarioID}:settled-observed`,
+  end: `tutti-perf:${scenarioID}:end`
+};
+
+export const concurrentAgentStreamingScenario = {
+  id: scenarioID,
+  markers,
+  milestones: [
+    {
+      key: "submitted",
+      label: "both Agent prompts submitted",
+      marker: markers.submitted
+    },
+    {
+      key: "bothMutated",
+      label: "both transcripts first mutated",
+      marker: markers.bothMutated
+    },
+    {
+      key: "settled",
+      label: "both Agent streams settled",
+      marker: markers.settled
+    }
+  ],
+  prepareSnapshot: prepareConcurrentAgentStreamingSnapshot,
+  prepare: prepareConcurrentAgentStreaming,
+  execute: executeConcurrentAgentStreaming,
+  profileFunctionNames: [
+    "buildAgentGUIConversationModels",
+    "buildCanonicalWorkspaceAgentDetailView",
+    "advanceStreamingVisibleText"
+  ],
+  describe(prepared) {
+    return `${prepared.nodeIDs.length} visible AgentGUI windows; ${prepared.sessionIDs.length} simultaneous deterministic ACP streams`;
+  },
+  summarize(prepared, result) {
+    return summary(
+      [
+        {
+          name: "two AgentGUI windows visible",
+          passed: prepared.visibleWindowCount === 2
+        },
+        {
+          name: "windows show different sessions",
+          passed: new Set(prepared.activeSessionIDs).size === 2
+        },
+        {
+          name: "submits entered working state together",
+          passed: result.startedCount === 2 && result.submitDeltaMs <= 5
+        },
+        {
+          name: "both transcripts mutated repeatedly",
+          passed: result.mutationBatches.every((count) => count >= 8)
+        },
+        {
+          name: "both streams settled",
+          passed: result.settledCount === 2
+        }
+      ],
+      [
+        { label: "Sessions", value: prepared.sessionIDs.join(", ") },
+        {
+          label: "Persisted turns",
+          value: prepared.turnCounts.join(" + ")
+        },
+        {
+          label: "Submit delta",
+          value: `${result.submitDeltaMs.toFixed(3)} ms`
+        },
+        {
+          label: "Mutation batches",
+          value: result.mutationBatches.join(" + ")
+        },
+        {
+          label: "DOM mutations",
+          value: result.mutations.join(" + ")
+        },
+        { label: "Provider", value: "two isolated fake Cursor ACP sessions" }
+      ],
+      "two non-overlapping AgentGUI bodies show different restored sessions; both forms submit in one renderer task; each local ACP stream produces at least eight MutationObserver batches and settles"
+    );
+  }
+};
+
+async function prepareConcurrentAgentStreamingSnapshot(context) {
+  const environment = await installCursorPerformanceFixture(context);
+  const workspaceID = await startupWorkspaceID(context);
+  const candidates = await context.sqliteJSON(
+    context.databasePath,
+    `
+SELECT s.agent_session_id AS sessionID, COUNT(t.turn_id) AS turnCount
+FROM workspace_agent_sessions s
+LEFT JOIN workspace_agent_turns t
+  ON t.workspace_id = s.workspace_id
+ AND t.agent_session_id = s.agent_session_id
+WHERE s.workspace_id = '${sqlString(workspaceID)}'
+  AND s.deleted_at_unix_ms = 0
+  AND s.origin = 'WORKSPACE_AGENT_SESSION_ORIGIN_RUNTIME'
+  AND s.session_kind = 'root'
+  AND s.active_turn_id IS NULL
+GROUP BY s.agent_session_id
+ORDER BY COUNT(t.turn_id) DESC, s.agent_session_id ASC
+LIMIT 2;
+`
+  );
+  if (candidates.length !== 2) {
+    throw new Error(
+      "concurrent-agent-streaming requires two settled root sessions in the startup workspace"
+    );
+  }
+  const snapshotRows = await context.sqliteJSON(
+    context.databasePath,
+    `
+SELECT snapshot_json AS snapshotJSON
+FROM workspace_workbench_snapshots
+WHERE workspace_id = '${sqlString(workspaceID)}'
+LIMIT 1;
+`
+  );
+  const snapshot = JSON.parse(snapshotRows[0]?.snapshotJSON ?? "null");
+  const preparedSnapshot = prepareConcurrentAgentStreamingWorkbenchSnapshot(
+    snapshot,
+    candidates.map((candidate) => candidate.sessionID)
+  );
+  const now = Date.now();
+  const sessionUpdates = candidates
+    .map(
+      (candidate, index) => `
+UPDATE workspace_agent_sessions
+SET agent_target_id = 'local:cursor',
+    provider = 'cursor',
+    provider_session_id = 'tutti-perf-cursor-session-${index + 1}',
+    model = '',
+    settings_json = '{}',
+    cwd = '${sqlString(context.workspaceRoot)}',
+    rail_section_kind = 'conversations',
+    rail_project_path = '',
+    rail_section_key = 'conversations',
+    session_metadata_json = json_set(
+      session_metadata_json,
+      '$.visible', json('true'),
+      '$.imported', json('false')
+    ),
+    internal_runtime_context_json = '{}',
+    updated_at_unix_ms = ${now + index}
+WHERE workspace_id = '${sqlString(workspaceID)}'
+  AND agent_session_id = '${sqlString(candidate.sessionID)}';`
+    )
+    .join("\n");
+  await context.sqliteExec(
+    context.databasePath,
+    `
+PRAGMA foreign_keys = ON;
+UPDATE agent_targets
+SET enabled = 1, updated_at_ms = ${now}
+WHERE id = 'local:cursor';
+${sessionUpdates}
+UPDATE workspace_workbench_snapshots
+SET snapshot_json = '${sqlString(JSON.stringify(preparedSnapshot))}'
+WHERE workspace_id = '${sqlString(workspaceID)}';
+`
+  );
+  return {
+    data: {
+      nodeIDs: preparedSnapshot.nodeStack.slice(-2),
+      sessionIDs: candidates.map((candidate) => candidate.sessionID),
+      turnCounts: candidates.map((candidate) => Number(candidate.turnCount)),
+      workspaceID
+    },
+    environment
+  };
+}
+
+export function prepareConcurrentAgentStreamingWorkbenchSnapshot(
+  snapshot,
+  sessionIDs
+) {
+  if (
+    !snapshot ||
+    typeof snapshot !== "object" ||
+    !Array.isArray(snapshot.nodes) ||
+    !Array.isArray(sessionIDs) ||
+    sessionIDs.length !== 2 ||
+    sessionIDs.some((sessionID) => !String(sessionID).trim())
+  ) {
+    throw new Error("invalid concurrent Agent streaming snapshot input");
+  }
+  const template =
+    snapshot.nodes.find(
+      (node) =>
+        node?.id === snapshot.activeNodeId && node?.data?.typeId === "agent-gui"
+    ) ?? snapshot.nodes.find((node) => node?.data?.typeId === "agent-gui");
+  if (!template) {
+    throw new Error("concurrent Agent streaming snapshot has no AgentGUI node");
+  }
+  const retainedNodes = snapshot.nodes.filter(
+    (node) => node?.data?.typeId !== "agent-gui"
+  );
+  const gap = 16;
+  const windowWidth = Math.max(560, (template.frame.width - gap) / 2);
+  const agentNodes = sessionIDs.map((sessionID, index) => {
+    const instanceID = `agent-gui:instance:perf-concurrent-${index + 1}`;
+    const node = structuredClone(template);
+    node.id = `agent-gui:${instanceID}`;
+    node.data = {
+      ...node.data,
+      instanceId: instanceID,
+      instanceKey: null,
+      snapshotNodeState: {
+        ...(node.data?.snapshotNodeState ?? {}),
+        agentTargetId: "local:cursor",
+        conversationRailCollapsed: true,
+        lastActiveAgentSessionId: sessionID,
+        lastActiveAgentSessionIdByAgentTargetId: {
+          "local:cursor": sessionID
+        }
+      }
+    };
+    node.frame = {
+      ...template.frame,
+      x: template.frame.x + index * (windowWidth + gap),
+      width: windowWidth
+    };
+    node.isMinimized = false;
+    return node;
+  });
+  return {
+    ...snapshot,
+    activeNodeId: agentNodes[1].id,
+    nodeStack: [
+      ...retainedNodes.map((node) => node.id),
+      ...agentNodes.map((node) => node.id)
+    ],
+    nodes: [...retainedNodes, ...agentNodes]
+  };
+}
+
+async function prepareConcurrentAgentStreaming(context, options) {
+  const fixture = requiredScenarioData(context, scenarioID);
+  const ready = await waitForEvaluation(
+    context.pageClient,
+    `(() => {
+      const expected = ${JSON.stringify(fixture.nodeIDs)};
+      const windows = expected.map((nodeID) => {
+        const shell = document.querySelector(
+          '[data-workbench-window-id="' + CSS.escape(nodeID) + '"]'
+        );
+        const body = shell?.querySelector('[data-agent-gui-visible="true"]');
+        const activeRow = shell?.querySelector(
+          '[data-testid^="agent-gui-conversation-item-"][data-active="true"]'
+        );
+        const editor = shell?.querySelector(
+          '#agent-gui-detail [contenteditable="true"][role="textbox"]'
+        );
+        return {
+          activeSessionID:
+            activeRow?.getAttribute('data-testid')
+              ?.slice('agent-gui-conversation-item-'.length) ?? null,
+          editorReady:
+            editor instanceof HTMLElement &&
+            editor.getAttribute('aria-disabled') !== 'true',
+          visible:
+            body instanceof HTMLElement &&
+            getComputedStyle(body).contentVisibility !== 'hidden'
+        };
+      });
+      return {
+        ready:
+          windows.length === 2 &&
+          windows.every((windowState) =>
+            windowState.visible &&
+            windowState.editorReady &&
+            windowState.activeSessionID
+          ),
+        windows
+      };
+    })()`,
+    options.timeoutMs,
+    "two visible AgentGUI sessions with enabled composers",
+    100
+  );
+  return {
+    ...fixture,
+    activeSessionIDs: ready.windows.map(
+      (windowState) => windowState.activeSessionID
+    ),
+    visibleWindowCount: ready.windows.filter(
+      (windowState) => windowState.visible
+    ).length
+  };
+}
+
+async function executeConcurrentAgentStreaming(context, prepared, options) {
+  const { pageClient } = context;
+  await evaluate(
+    pageClient,
+    `(() => {
+      const nodeIDs = ${JSON.stringify(prepared.nodeIDs)};
+      const windows = nodeIDs.map((nodeID, index) => {
+        const shell = document.querySelector(
+          '[data-workbench-window-id="' + CSS.escape(nodeID) + '"]'
+        );
+        const timeline = shell?.querySelector('[data-testid="agent-gui-timeline"]');
+        const editor = shell?.querySelector(
+          '#agent-gui-detail [contenteditable="true"][role="textbox"]'
+        );
+        if (!(timeline instanceof HTMLElement) || !(editor instanceof HTMLElement)) {
+          throw new Error('concurrent Agent streaming surface is unavailable');
+        }
+        editor.focus();
+        document.execCommand('selectAll', false);
+        if (
+          !document.execCommand(
+            'insertText',
+            false,
+            'Concurrent Agent streaming fixture ' + (index + 1)
+          )
+        ) {
+          throw new Error('could not enter concurrent Agent prompt');
+        }
+        return { editor, timeline };
+      });
+      window.__tuttiPerfConcurrentAgentStreaming = {
+        bothMutated: false,
+        observers: [],
+        windows
+      };
+      return true;
+    })()`
+  );
+  await waitForEvaluation(
+    pageClient,
+    `(() => {
+      const state = window.__tuttiPerfConcurrentAgentStreaming;
+      return {
+        ready: Boolean(
+          state?.windows?.length === 2 &&
+          state.windows.every(({ editor }) => {
+            const submit = editor.closest('form')?.querySelector(
+              'button[type="submit"]'
+            );
+            return submit instanceof HTMLButtonElement && !submit.disabled;
+          })
+        )
+      };
+    })()`,
+    options.timeoutMs,
+    "two enabled Agent composer submit buttons",
+    25
+  );
+  await startRendererScenario(pageClient, markers.start);
+  await evaluate(
+    pageClient,
+    `(() => {
+      const runtime = window.__tuttiPerfConcurrentAgentStreaming;
+      runtime.windows.forEach((windowState) => {
+        windowState.state = {
+          firstMutation: false,
+          mutationBatches: 0,
+          mutations: 0
+        };
+        const observer = new MutationObserver((records) => {
+          windowState.state.mutationBatches += 1;
+          windowState.state.mutations += records.length;
+          windowState.state.firstMutation = true;
+          if (
+            runtime.windows.every(
+              (candidate) => candidate.state.firstMutation
+            ) &&
+            !runtime.bothMutated
+          ) {
+            runtime.bothMutated = true;
+            console.timeStamp(${JSON.stringify(markers.bothMutated)});
+          }
+        });
+        observer.observe(windowState.timeline, {
+          attributes: true,
+          characterData: true,
+          childList: true,
+          subtree: true
+        });
+        runtime.observers.push(observer);
+      });
+      return true;
+    })()`
+  );
+  const submit = await evaluate(
+    pageClient,
+    `(() => {
+      const state = window.__tuttiPerfConcurrentAgentStreaming;
+      const submittedAt = [];
+      for (const { editor } of state.windows) {
+        const form = editor.closest('form');
+        if (!(form instanceof HTMLFormElement)) {
+          throw new Error('concurrent Agent composer form is unavailable');
+        }
+        submittedAt.push(performance.now());
+        form.requestSubmit();
+      }
+      return {
+        submitDeltaMs: submittedAt[1] - submittedAt[0]
+      };
+    })()`
+  );
+  await markRenderer(pageClient, markers.submitted);
+  const started = await waitForEvaluation(
+    pageClient,
+    `(() => {
+      const nodeIDs = ${JSON.stringify(prepared.nodeIDs)};
+      const startedCount = nodeIDs.filter((nodeID) => {
+        const shell = document.querySelector(
+          '[data-workbench-window-id="' + CSS.escape(nodeID) + '"]'
+        );
+        return shell?.querySelector(
+          '[data-testid="agent-gui-composer-stop-symbol"]'
+        );
+      }).length;
+      return { ready: startedCount === 2, startedCount };
+    })()`,
+    options.timeoutMs,
+    "both Agent streams working",
+    25
+  );
+  const settled = await waitForEvaluation(
+    pageClient,
+    `(() => {
+      const state = window.__tuttiPerfConcurrentAgentStreaming;
+      const nodeIDs = ${JSON.stringify(prepared.nodeIDs)};
+      const settledCount = nodeIDs.filter((nodeID) => {
+        const shell = document.querySelector(
+          '[data-workbench-window-id="' + CSS.escape(nodeID) + '"]'
+        );
+        return !shell?.querySelector(
+          '[data-testid="agent-gui-composer-stop-symbol"]'
+        );
+      }).length;
+      const mutationBatches =
+        state?.windows?.map(({ state: windowState }) =>
+          windowState.mutationBatches
+        ) ?? [];
+      const mutations =
+        state?.windows?.map(({ state: windowState }) =>
+          windowState.mutations
+        ) ?? [];
+      return {
+        ready:
+          settledCount === 2 &&
+          mutationBatches.length === 2 &&
+          mutationBatches.every((count) => count >= 8),
+        mutationBatches,
+        mutations,
+        settledCount
+      };
+    })()`,
+    options.timeoutMs,
+    "both concurrent Agent streams settled",
+    50
+  );
+  await markRenderer(pageClient, markers.settled);
+  await evaluate(
+    pageClient,
+    `(() => {
+      window.__tuttiPerfConcurrentAgentStreaming?.observers?.forEach(
+        (observer) => observer.disconnect()
+      );
+      return true;
+    })()`
+  );
+  await finishRendererScenario(pageClient, markers.end);
+  return {
+    mutationBatches: settled.mutationBatches,
+    mutations: settled.mutations,
+    settledCount: settled.settledCount,
+    startedCount: started.startedCount,
+    submitDeltaMs: submit.submitDeltaMs
+  };
+}

--- a/tools/scripts/agent-gui-layout-performance-scenarios.mjs
+++ b/tools/scripts/agent-gui-layout-performance-scenarios.mjs
@@ -106,14 +106,7 @@ export async function prepareVirtualizedTranscriptSnapshot(
   context,
   options = {}
 ) {
-  const fixtureBinDirectory = join(context.runtimeDirectory, "state", "bin");
-  await mkdir(fixtureBinDirectory, { recursive: true });
-  const fixtureBinaryPath = join(fixtureBinDirectory, "cursor-agent");
-  await copyFile(
-    join(cursorFixtureDirectory, "cursor-agent"),
-    fixtureBinaryPath
-  );
-  await chmod(fixtureBinaryPath, 0o755);
+  const fixtureEnvironment = await installCursorPerformanceFixture(context);
   const workspaceID = await startupWorkspaceID(context);
   const richTextCandidateRequirement = options.richTextFixture
     ? "AND userTextMessageCount >= 4"
@@ -220,10 +213,22 @@ ${richTextFixtureUpdate}
       richTextParagraphsPerMessage: options.richTextFixture ? 8 : 0,
       workspaceID
     },
-    environment: {
-      PATH: `${fixtureBinDirectory}:${process.env.PATH ?? ""}`,
-      SHELL: fixtureBinaryPath
-    }
+    environment: fixtureEnvironment
+  };
+}
+
+export async function installCursorPerformanceFixture(context) {
+  const fixtureBinDirectory = join(context.runtimeDirectory, "state", "bin");
+  await mkdir(fixtureBinDirectory, { recursive: true });
+  const fixtureBinaryPath = join(fixtureBinDirectory, "cursor-agent");
+  await copyFile(
+    join(cursorFixtureDirectory, "cursor-agent"),
+    fixtureBinaryPath
+  );
+  await chmod(fixtureBinaryPath, 0o755);
+  return {
+    PATH: `${fixtureBinDirectory}:${process.env.PATH ?? ""}`,
+    SHELL: fixtureBinaryPath
   };
 }
 

--- a/tools/scripts/agent-gui-performance-scenarios.mjs
+++ b/tools/scripts/agent-gui-performance-scenarios.mjs
@@ -22,12 +22,14 @@ import {
   virtualizedSessionCycleScenario
 } from "./agent-gui-virtualization-performance-scenarios.mjs";
 import { providerStatusFocusRefreshScenario } from "./agent-provider-status-performance-scenario.mjs";
+import { concurrentAgentStreamingScenario } from "./agent-gui-concurrent-streaming-performance-scenario.mjs";
 
 export const agentGuiPerformanceScenarios = [
   providerSwitchScenario,
   sessionSwitchScenario,
   providerSessionCycleScenario,
   virtualizedStreamingScenario,
+  concurrentAgentStreamingScenario,
   virtualizedScrollLocatorScenario,
   virtualizedSessionCycleScenario,
   virtualizedOversizedActiveTurnScenario,

--- a/tools/scripts/fixtures/agent-gui-performance/cursor-agent
+++ b/tools/scripts/fixtures/agent-gui-performance/cursor-agent
@@ -23,6 +23,7 @@ if (args.includes("about")) {
 function runACPFixture() {
   const input = readline.createInterface({ input: process.stdin });
   let canceled = false;
+  let activeSessionId = "tutti-perf-cursor-session";
   input.on("line", (line) => {
     void handleMessage(line).catch((error) => {
       process.stderr.write(`${error.stack ?? error.message}\n`);
@@ -41,13 +42,19 @@ function runACPFixture() {
         });
         return;
       case "session/new":
+        activeSessionId =
+          message.params?.sessionId?.trim?.() || activeSessionId;
         respond(message.id, {
           configOptions: [],
-          sessionId: "tutti-perf-cursor-session"
+          sessionId: activeSessionId
         });
         return;
       case "session/load":
       case "session/resume":
+        activeSessionId =
+          message.params?.sessionId?.trim?.() || activeSessionId;
+        respond(message.id, { configOptions: [] });
+        return;
       case "session/set_mode":
       case "session/set_config_option":
         respond(message.id, { configOptions: [] });
@@ -56,6 +63,8 @@ function runACPFixture() {
         canceled = true;
         return;
       case "session/prompt":
+        activeSessionId =
+          message.params?.sessionId?.trim?.() || activeSessionId;
         canceled = false;
         await streamPrompt(message.id);
         return;
@@ -84,7 +93,7 @@ function runACPFixture() {
     }
     for (let index = 0; index < 48 && !canceled; index += 1) {
       notify("session/update", {
-        sessionId: "tutti-perf-cursor-session",
+        sessionId: activeSessionId,
         update: {
           sessionUpdate: "agent_message_chunk",
           content: {
@@ -103,7 +112,7 @@ function runACPFixture() {
       const toolCallId = `tutti-perf-oversized-tool-${index}`;
       const title = `Inspect fixture path ${index + 1}`;
       notify("session/update", {
-        sessionId: "tutti-perf-cursor-session",
+        sessionId: activeSessionId,
         update: {
           sessionUpdate: "tool_call",
           toolCallId,
@@ -116,7 +125,7 @@ function runACPFixture() {
         }
       });
       notify("session/update", {
-        sessionId: "tutti-perf-cursor-session",
+        sessionId: activeSessionId,
         update: {
           sessionUpdate: "tool_call_update",
           toolCallId,

--- a/tools/scripts/run-agent-gui-performance.test.mjs
+++ b/tools/scripts/run-agent-gui-performance.test.mjs
@@ -17,6 +17,7 @@ import {
 } from "./agent-gui-window-performance-scenarios.mjs";
 import { summarizeProviderStatusFocusRefresh } from "./agent-provider-status-performance-scenario.mjs";
 import { buildAllProcessTimeProfileArgs } from "./all-process-time-profile.mjs";
+import { prepareConcurrentAgentStreamingWorkbenchSnapshot } from "./agent-gui-concurrent-streaming-performance-scenario.mjs";
 import {
   applyScenarioAssessment,
   findUnknownAgentTargetMigrationIDs,
@@ -194,6 +195,7 @@ test("performance scenario registry exposes renderer and window scenarios", () =
       "session-switch",
       "provider-session-cycle",
       "virtualized-streaming",
+      "concurrent-agent-streaming",
       "virtualized-scroll-locator",
       "virtualized-session-cycle",
       "virtualized-oversized-active-turn",
@@ -216,6 +218,51 @@ test("performance scenario registry exposes renderer and window scenarios", () =
     () => resolveAgentGuiPerformanceScenario("missing"),
     /unknown scenario: missing/
   );
+});
+
+test("concurrent streaming snapshot creates two visible session-scoped AgentGUI windows", () => {
+  const prepared = prepareConcurrentAgentStreamingWorkbenchSnapshot(
+    {
+      activeNodeId: "agent-source",
+      nodeStack: ["terminal-1", "agent-source"],
+      nodes: [
+        {
+          id: "terminal-1",
+          data: { typeId: "terminal" },
+          frame: { x: 0, y: 0, width: 800, height: 600 }
+        },
+        {
+          id: "agent-source",
+          data: {
+            instanceId: "source",
+            typeId: "agent-gui",
+            snapshotNodeState: { agentTargetId: "local:codex" }
+          },
+          frame: { x: 20, y: 30, width: 1400, height: 720 },
+          isMinimized: true
+        }
+      ]
+    },
+    ["session-1", "session-2"]
+  );
+  const agents = prepared.nodes.filter(
+    (node) => node.data.typeId === "agent-gui"
+  );
+
+  assert.equal(agents.length, 2);
+  assert.deepEqual(
+    agents.map((node) => node.data.snapshotNodeState.lastActiveAgentSessionId),
+    ["session-1", "session-2"]
+  );
+  assert.equal(
+    agents.every((node) => node.isMinimized === false),
+    true
+  );
+  assert.equal(
+    agents[0].frame.x + agents[0].frame.width < agents[1].frame.x,
+    true
+  );
+  assert.equal(prepared.activeNodeId, agents[1].id);
 });
 
 test("AgentGUI window stress snapshot creates exact unique mounted windows", () => {


### PR DESCRIPTION
## Summary
- add a headless two-Agent concurrent streaming performance scenario
- replace AgentGUI's whole-workspace activity snapshot subscription with stable Session-family and exact target selectors
- keep Rail updates independent while preventing unrelated AgentGUI surfaces from rendering
- document the high-frequency selector ownership rule

## Tests
- `pnpm check:changed -- --push-ready`
- `pnpm --filter @tutti-os/agent-activity-core test`
- `pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom --maxWorkers=3 agent-gui/agentGuiNode/controller/useAgentGUISessionFamilySubscription.spec.tsx agent-gui/agentGuiNode/controller/useAgentGUIComposerCapabilities.spec.tsx agent-gui/agentGuiNode/controller/useAgentGUIConversationDetail.spec.tsx`
- `pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom --maxWorkers=1 contexts/workspace/presentation/renderer/agentGuiConversationList/useAgentGuiConversationList.spec.tsx`
- `pnpm perf:agent-gui -- --scenario concurrent-agent-streaming --output .tmp/perf/agent-gui/concurrent-agent-streaming/after-selector-fix`
- repeated the same headless performance scenario at `after-selector-fix-repeat`

## Notes
- headless traces reduced `AgentGUINode` markers from 469 to 120/136 and `buildAgentGUIConversationModels` samples from 1202 to 158/167
- no event throttling, debounce, copied engine state, or Rail delay was introduced

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1739" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->