### PR TITLE
feat(agent-gui): add Claude through-turn session fork

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -268,7 +268,7 @@ conjunction:
 provider registry declares native Session Fork
   AND the exact adapter/version attests throughTurn support
   AND product-owned Session context can be transferred safely
-  AND that provider explicitly registers target runtime state binding
+  AND provider state has an explicit host-copy or provider-owned binding mode
 ```
 
 Only that conjunction projects `lifecycleCapabilities.forkThroughTurn=true`.
@@ -276,8 +276,10 @@ The Codex adapter reads the initialized version from an exact live process when
 one exists. For a historical, detached, or newly forked Session it performs one
 cached short-lived initialize probe against the same resolved adapter/runtime;
 that probe neither resumes the provider thread nor creates a canonical Turn.
-AgentGUI renders one action in each settled root Turn footer and hides it
-otherwise. Boundary availability is deliberately separate: execution
+AgentGUI renders an action only when the capability response contains a known
+canonical Turn-id allowlist and the settled root Turn is in that list; an
+unknown or absent list is fail-closed. Boundary availability is deliberately
+separate: execution
 transactionally rejects an unverified prefix, descendant lane, or
 session-scoped local attachment. This prevents a later unavailable Turn from
 hiding an earlier valid Turn while preserving a fail-closed commit.
@@ -308,15 +310,24 @@ and canonical state are being matched. The provider call begins only after the
 checkpoints and the local clone use a detached bounded context so an HTTP
 disconnect cannot lose the child identity.
 
-Before `provider_accepted`, Host delegates provider-local persistence binding
-to a product adapter. Codex validates every JSONL record plus the accepted
+Before `provider_accepted`, Host requires typed binding evidence. `host_copy`
+requires a configured binder that explicitly supports the source provider;
+otherwise capability is unavailable and a direct request is rejected before
+provider dispatch. A binder failure after provider acceptance is `unknown`,
+never an implicit success. Codex validates every JSONL record plus the accepted
 child `session_meta.id`, verifies source/target size and SHA-256, and atomically
 copies only that rollout from the source run-scoped `CODEX_HOME` into the
 target run-scoped `CODEX_HOME`. File and directory fsync make the rename
 crash-durable before the Host checkpoint where directory fsync is supported;
 Windows retains file fsync plus atomic rename because its portable filesystem
 API does not expose directory fsync. The target therefore owns resumable
-provider state independently of source cleanup.
+provider state independently of source cleanup. Claude uses `provider_owned`:
+the official SDK writes the child into its shared session store, and the
+short-lived sidecar proves it is independently readable with `getSessionInfo`
+and `getSessionMessages`. It returns a verification receipt plus the
+source-to-child provider Turn UUID mapping. Store persists that evidence at
+`provider_accepted` and rewrites cloned Turns to the child UUIDs in the
+canonical commit.
 Binding failure becomes `unknown`; Host neither commits the canonical child nor
 reissues `thread/fork`.
 

--- a/docs/specs/2026-07-27-agent-session-fork-design.md
+++ b/docs/specs/2026-07-27-agent-session-fork-design.md
@@ -185,6 +185,10 @@ child 继承 prepare 时冻结的：
 
 历史 Session 先经过一次 `RuntimePreparation`，同一份 prepared runtime identity 同时用于
 driver attestation、provider dispatch 和 canonical child 的 cwd/settings/runtime context。
+runtime context 中引用 provider Session identity 的恢复游标不能越过 Fork 边界直接复用。
+Claude adapter 只接受 `resumeCursor.resume == canonical providerSessionId` 的游标；child
+继承到 source 游标时丢弃该游标，并以 `forkSession` 返回的 child identity 恢复，防止首次
+续聊重新进入 source namespace。
 env 与 provider target reference 只用于本次 provider dispatch，不作为凭据或临时运行事实写入
 canonical snapshot；后续恢复 child 时仍通过正常 `RuntimePreparation` 从 agent target 和已冻结的
 canonical settings/context 重新解析。由于进程重启会把未 dispatch 的 `prepared` operation 标记为
@@ -368,7 +372,9 @@ Claude SDK Driver 使用固定版本的官方公开 API：
 6. 只有完整验证后才按已证明的逐消息双射生成 source→child provider Turn UUID mapping，
    返回 `provider_owned` receipt；消息内容只在 sidecar 内比较，不返回或记录；
 7. Store 在 `provider_accepted` checkpoint 原子保存 mapping/receipt，并在 canonical clone
-   时重写每个 child Turn 的 `RootProviderTurnID`，使 fork child 可以继续 Fork。
+   时重写每个 child Turn 的 `RootProviderTurnID`，使 fork child 可以继续 Fork；
+8. child 恢复时拒绝 source 的 stale `resumeCursor`，只从 canonical child
+   `providerSessionId` 启动；该约束覆盖进程重启后的首次续聊。
 
 `forkSession` 调用前失败是 `not_started`；一旦调用开始，transport、SDK 或 post-verify
 失败都是 `unknown`。这样不会因响应丢失或复验失败而创建第二个 provider child。

--- a/docs/specs/2026-07-27-agent-session-fork-design.md
+++ b/docs/specs/2026-07-27-agent-session-fork-design.md
@@ -361,13 +361,15 @@ Claude SDK Driver 使用固定版本的官方公开 API：
 1. 新 Claude Turn 在提交前由 Go adapter 生成 SDK prompt UUID，并作为 canonical
    `RootProviderTurnID` 传给 sidecar；旧版以 canonical Turn ID 代替 UUID 的历史记录不会猜测
    或回填，因此 fail closed；
-2. capability 通过 stateless sidecar 调用 `getSessionMessages`，只返回 root user-message
-   UUID allowlist；
+2. capability 通过 stateless sidecar 调用
+   `getSessionMessages(..., {includeSystemMessages: true})`，只返回 root user-message UUID
+   allowlist，但保留 system message 用于精确 checkpoint 与完整 prefix 校验；
 3. dispatch 前再次读取 source transcript，验证 canonical ordered UUID prefix，并把所选
    root user message 到下一个 root user message之前的最后消息作为 inclusive checkpoint；
 4. 调用 `forkSession(source, {upToMessageId, title: frozenTargetTitle})`；
-5. 再次读取 source，并读取 child 的 `getSessionInfo` / `getSessionMessages`；source
-   选中 prefix 必须在调用前后不变，child 必须与该完整 prefix 做结构等价验证
+5. 再次读取 source，并读取 child 的 `getSessionInfo` / `getSessionMessages`；两次
+   `getSessionMessages` 均使用 `includeSystemMessages: true`。source 选中 prefix
+   必须在调用前后不变，child 必须与该完整 prefix 做结构等价验证
    (`type/message/parent_tool_use_id`，忽略已重映射的 UUID/session id)；
 6. 只有完整验证后才按已证明的逐消息双射生成 source→child provider Turn UUID mapping，
    返回 `provider_owned` receipt；消息内容只在 sidecar 内比较，不返回或记录；
@@ -571,7 +573,7 @@ fail closed。
 当前明确不支持：
 
 - 完整会话 Fork 产品入口；
-- 非 Codex Agent 的 Driver；
+- 除 Codex 与 Claude Code 外的其他 Agent Driver；
 - 没有原生历史边界能力时的消息 replay 模拟；
 - 从 Message 中间位置 Fork；
 - 包含 session-local attachment 的 boundary；

--- a/docs/specs/2026-07-27-agent-session-fork-design.md
+++ b/docs/specs/2026-07-27-agent-session-fork-design.md
@@ -51,7 +51,8 @@ AgentGUI Turn action
   -> Agent Host durable Fork saga
   -> store-sqlite snapshot/operation/commit
   -> provider-neutral runtime Fork
-  -> Codex app-server thread/fork(lastTurnId)
+       - Codex app-server thread/fork(lastTurnId)
+       - Claude Agent SDK forkSession(upToMessageId, title)
 ```
 
 各层职责：
@@ -66,6 +67,7 @@ AgentGUI Turn action
 | store-sqlite       | source fence、snapshot、operation、ID remap、canonical atomic commit |
 | daemon runtime     | 按确切 provider runtime 解析能力并调用 provider Driver               |
 | Codex Driver       | `thread/fork`、版本门槛、完整 provider Turn prefix 验证              |
+| Claude SDK Driver  | stateless inspect/fork、消息 checkpoint、child UUID 映射与复验       |
 
 这符合 AgentGUI 的既有约束：canonical lifecycle 和 mutation 状态属于 Activity Engine；
 React 不保存第二份 Fork request、pending 或结果状态。
@@ -117,7 +119,10 @@ interface AgentActivitySessionLifecycleCapabilities {
 
 - Codex app-server 版本满足门槛且协议支持 `lastTurnId`：
   `forkThroughTurn=true`；
-- 其他 Agent 或不满足门槛的 Codex runtime：`forkThroughTurn=false`；
+- Claude Agent SDK 能读取 exact transcript、且 canonical provider Turn UUID
+  与其 root user-message prefix 匹配：`forkThroughTurn=true`；
+- 其他 Agent、不满足门槛的 Codex runtime、以及没有真实 SDK UUID 的旧 Claude
+  Turn：`forkThroughTurn=false`；
 - 当前所有接入：`fork=false`，完整会话按钮不展示。
 
 结构 capability 与瞬时 availability 分开：
@@ -230,7 +235,8 @@ dispatching          -> unknown
 - 相同 request hash replay 返回原 operation；
 - 相同 request ID、不同 hash 返回 conflict；
 - provider 已可能接受时绝不自动再次 dispatch；
-- provider child 状态必须先绑定到 target Session 独立 runtime namespace，随后才能写入
+- provider child 状态必须通过 `host_copy` 或 `provider_owned` 的 typed binding
+  evidence 证明独立可恢复，随后才能写入
   `provider_accepted` 并提交 canonical child；
 - `provider_accepted` 之后只重试本地 canonical commit。
 - source + point 的 durable boundary barrier 覆盖 active、unknown 和
@@ -244,6 +250,7 @@ operation 持久化：
 - operation/request/hash；
 - source/target canonical identity；
 - source/target provider identity；
+- ordered target provider Turn IDs、binding mode 和 verification receipt；
 - `point_kind`、source canonical/provider Turn；
 - commit 后的 target canonical boundary Turn；
 - Driver kind/version；
@@ -305,7 +312,7 @@ cwd、env 以及已解析 executable 的 size/mtime/verified identity 都必须�
 executable identity 的 shell/package-manager wrapper 不缓存。CLI 升降级或不同 Session
 runtime identity 会重新 initialize probe，避免跨 Session 误展示按钮。
 
-## 7. Provider Driver 与 Codex 接入
+## 7. Provider Driver、Codex 与 Claude SDK 接入
 
 provider-neutral输入：
 
@@ -313,6 +320,7 @@ provider-neutral输入：
 source provider Session id
 source canonical Turn id
 ordered source provider Turn ID prefix
+frozen target title
 driver kind/version
 frozen runtime preparation
 ```
@@ -331,9 +339,10 @@ Codex Driver：
    size/SHA-256，只将该 rollout crash-durable 地原子复制到 target `CODEX_HOME`，不复制
    整个 provider home，也不建立依赖 source 生命周期的软链接。
 
-provider-state binding 也是 provider 接入能力的一部分。每个 Agent 必须显式声明自己是否
-能将 native child 状态绑定到 target runtime namespace；没有声明时 Session capability
-fail closed，GUI 不展示 Fork。
+provider-state binding 也是 provider 接入能力的一部分。每个 Agent 必须显式选择
+`host_copy` 或 `provider_owned` 并提交相应 evidence；`host_copy` binder 缺失或不支持当前
+provider 时必须在 provider dispatch 前 fail closed，provider 调用后的 binder 失败进入
+`unknown`；缺少 mapping 或 receipt 时不能进入 `provider_accepted`。
 
 这比只验证最后一个 Turn 更严格：最后一个 ID 相同不能证明中间历史没有丢失或重排。
 provider-state binding 幂等，但不能只凭同 ID rollout 信任 target：source/target fingerprint
@@ -342,6 +351,27 @@ provider-state binding 幂等，但不能只凭同 ID rollout 信任 target：so
 非前缀的分叉 fail closed。source rollout 已被清理时，只接受完整验证通过的 target。若
 provider child 已经创建但 binding 失败，operation 进入 `unknown`，不提交 canonical child，
 也绝不重发 provider Fork。
+
+Claude SDK Driver 使用固定版本的官方公开 API：
+
+1. 新 Claude Turn 在提交前由 Go adapter 生成 SDK prompt UUID，并作为 canonical
+   `RootProviderTurnID` 传给 sidecar；旧版以 canonical Turn ID 代替 UUID 的历史记录不会猜测
+   或回填，因此 fail closed；
+2. capability 通过 stateless sidecar 调用 `getSessionMessages`，只返回 root user-message
+   UUID allowlist；
+3. dispatch 前再次读取 source transcript，验证 canonical ordered UUID prefix，并把所选
+   root user message 到下一个 root user message之前的最后消息作为 inclusive checkpoint；
+4. 调用 `forkSession(source, {upToMessageId, title: frozenTargetTitle})`；
+5. 再次读取 source，并读取 child 的 `getSessionInfo` / `getSessionMessages`；source
+   选中 prefix 必须在调用前后不变，child 必须与该完整 prefix 做结构等价验证
+   (`type/message/parent_tool_use_id`，忽略已重映射的 UUID/session id)；
+6. 只有完整验证后才按已证明的逐消息双射生成 source→child provider Turn UUID mapping，
+   返回 `provider_owned` receipt；消息内容只在 sidecar 内比较，不返回或记录；
+7. Store 在 `provider_accepted` checkpoint 原子保存 mapping/receipt，并在 canonical clone
+   时重写每个 child Turn 的 `RootProviderTurnID`，使 fork child 可以继续 Fork。
+
+`forkSession` 调用前失败是 `not_started`；一旦调用开始，transport、SDK 或 post-verify
+失败都是 `unknown`。这样不会因响应丢失或复验失败而创建第二个 provider child。
 
 损坏 target 的修复规则更严格：只有首条 `session_meta` 已精确验证 child identity，且包括
 partial tail 在内的全部原始字节都是 source rollout 的严格前缀时，才允许从 source 原位

--- a/packages/agent/claude-sdk-sidecar/README.md
+++ b/packages/agent/claude-sdk-sidecar/README.md
@@ -19,9 +19,15 @@ build step and no bundled entry point beyond the source files.
 ## Sidecar protocol
 
 The daemon and sidecar exchange newline-delimited JSON envelopes over standard
-input and output. Every request and event carries `"version": 2`; either side
+input and output. Every request and event carries `"version": 3`; either side
 rejects unsupported or missing versions instead of guessing compatibility.
 Protocol types and validation live in `src/protocol.ts`.
+
+`inspect_fork_checkpoints` and `fork_session` are stateless requests: they do
+not create a `SessionRuntime` or resume a query. They use the official SDK
+session APIs, verify the selected source prefix and the independently readable
+child transcript, and return identities plus a provider-owned binding receipt;
+prompt and tool content never cross this protocol boundary.
 
 Interactive responses use `(turnId, requestId)` identity. The sidecar keeps a
 bounded terminal disposition registry so `submit_interactive` is idempotent:

--- a/packages/agent/claude-sdk-sidecar/package.json
+++ b/packages/agent/claude-sdk-sidecar/package.json
@@ -27,6 +27,7 @@
     "src/sessionSettings.ts",
     "src/sessionRuntime.ts",
     "src/sessionConfiguration.ts",
+    "src/sessionFork.ts",
     "src/settingsEnv.ts",
     "src/taskNotification.ts",
     "src/taskPlan.ts",

--- a/packages/agent/claude-sdk-sidecar/src/goalExecQueue.ts
+++ b/packages/agent/claude-sdk-sidecar/src/goalExecQueue.ts
@@ -9,6 +9,7 @@ export type GoalCommandDispatch = {
 
 export type GoalExecInput = {
   turnId: string;
+  providerTurnId?: string;
   prompt: string;
   content?: unknown;
   turnOrigin?: string;

--- a/packages/agent/claude-sdk-sidecar/src/main.ts
+++ b/packages/agent/claude-sdk-sidecar/src/main.ts
@@ -12,6 +12,10 @@ import {
 import { booleanValue, envObject, stringValue } from "./runtimeValues.ts";
 import { sidecarSessionSettings } from "./sessionSettings.ts";
 import { SessionRuntime } from "./sessionRuntime.ts";
+import {
+  forkClaudeSession,
+  inspectClaudeForkCheckpoints
+} from "./sessionFork.ts";
 
 const sessions = new Map<string, SessionRuntime>();
 
@@ -65,9 +69,33 @@ export async function handleRequest(
                 action: stringValue(payload.goalAction) as "set" | "clear"
               }
             : undefined,
-          stringValue(payload.hostContext)
+          stringValue(payload.hostContext),
+          stringValue(payload.providerTurnId)
         );
         emit({ id, type: "ok" });
+        return;
+      }
+      case "inspect_fork_checkpoints": {
+        const payload = request.payload ?? {};
+        const result = await inspectClaudeForkCheckpoints({
+          sessionId: stringValue(payload.providerSessionId),
+          cwd: stringValue(payload.cwd)
+        });
+        emit({ id, type: "ok", payload: result });
+        return;
+      }
+      case "fork_session": {
+        const payload = request.payload ?? {};
+        const result = await forkClaudeSession({
+          sessionId: stringValue(payload.providerSessionId),
+          providerTurnId: stringValue(payload.providerTurnId),
+          providerTurnIds: Array.isArray(payload.providerTurnIds)
+            ? payload.providerTurnIds.map(stringValue)
+            : [],
+          cwd: stringValue(payload.cwd),
+          title: stringValue(payload.title)
+        });
+        emit({ id, type: "ok", payload: result });
         return;
       }
       case "guide": {
@@ -149,7 +177,13 @@ export async function handleRequest(
       id,
       type: "error",
       payload: {
-        error: errorMessage(error)
+        error: errorMessage(error),
+        ...(error &&
+        typeof error === "object" &&
+        "deliveryDisposition" in error &&
+        typeof error.deliveryDisposition === "string"
+          ? { deliveryDisposition: error.deliveryDisposition }
+          : {})
       }
     });
   }

--- a/packages/agent/claude-sdk-sidecar/src/main.ts
+++ b/packages/agent/claude-sdk-sidecar/src/main.ts
@@ -92,6 +92,7 @@ export async function handleRequest(
           providerTurnIds: Array.isArray(payload.providerTurnIds)
             ? payload.providerTurnIds.map(stringValue)
             : [],
+          targetSessionId: stringValue(payload.targetProviderSessionId),
           cwd: stringValue(payload.cwd),
           title: stringValue(payload.title)
         });

--- a/packages/agent/claude-sdk-sidecar/src/protocol.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/protocol.test.ts
@@ -34,6 +34,19 @@ test("sidecar protocol accepts stop_task requests", () => {
   );
 });
 
+test("sidecar protocol accepts stateless session fork requests", () => {
+  for (const type of ["inspect_fork_checkpoints", "fork_session"] as const) {
+    assert.equal(
+      parseClaudeSDKSidecarRequest({
+        version: CLAUDE_SDK_SIDECAR_PROTOCOL_VERSION,
+        type,
+        payload: { providerSessionId: "provider-session-1" }
+      }).type,
+      type
+    );
+  }
+});
+
 test("sidecar protocol rejects missing and unknown versions", () => {
   assert.throws(
     () => parseClaudeSDKSidecarRequest({ type: "exec" }),

--- a/packages/agent/claude-sdk-sidecar/src/protocol.ts
+++ b/packages/agent/claude-sdk-sidecar/src/protocol.ts
@@ -1,4 +1,4 @@
-export const CLAUDE_SDK_SIDECAR_PROTOCOL_VERSION = 2 as const;
+export const CLAUDE_SDK_SIDECAR_PROTOCOL_VERSION = 3 as const;
 
 export type ClaudeSDKSidecarRequestType =
   | "start"
@@ -9,6 +9,8 @@ export type ClaudeSDKSidecarRequestType =
   | "submit_interactive"
   | "interactive_disposition"
   | "apply_settings"
+  | "inspect_fork_checkpoints"
+  | "fork_session"
   | "close";
 
 export type ClaudeSDKSidecarRequest = {
@@ -76,6 +78,8 @@ const REQUEST_TYPES = new Set<ClaudeSDKSidecarRequestType>([
   "submit_interactive",
   "interactive_disposition",
   "apply_settings",
+  "inspect_fork_checkpoints",
+  "fork_session",
   "close"
 ]);
 

--- a/packages/agent/claude-sdk-sidecar/src/sessionFork.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionFork.test.ts
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  forkClaudeSession,
+  inspectClaudeForkCheckpoints
+} from "./sessionFork.ts";
+
+const source = [
+  message("user", "prompt-1", { role: "user", content: "one" }),
+  message("assistant", "answer-1", { role: "assistant", content: "first" }),
+  message("user", "prompt-2", { role: "user", content: "two" }),
+  message("assistant", "answer-2", { role: "assistant", content: "second" })
+];
+const child = [
+  message("user", "child-prompt-1", { role: "user", content: "one" }, "child"),
+  message(
+    "assistant",
+    "child-answer-1",
+    { role: "assistant", content: "first" },
+    "child"
+  )
+];
+
+test("Claude fork inspection exposes only root user message UUIDs", async () => {
+  const result = await inspectClaudeForkCheckpoints(
+    { sessionId: "source", cwd: "/workspace" },
+    fakeSDK()
+  );
+  assert.deepEqual(result, { providerTurnIds: ["prompt-1", "prompt-2"] });
+});
+
+test("Claude fork verifies the inclusive prefix and maps remapped UUIDs", async () => {
+  const calls: Array<Record<string, unknown>> = [];
+  const result = await forkClaudeSession(
+    {
+      sessionId: "source",
+      providerTurnId: "prompt-1",
+      providerTurnIds: ["prompt-1"],
+      cwd: "/workspace",
+      title: "Source (2)"
+    },
+    fakeSDK(calls)
+  );
+  assert.equal(result.providerSessionId, "child");
+  assert.deepEqual(result.targetProviderTurnIds, ["child-prompt-1"]);
+  assert.equal(result.stateBindingMode, "provider_owned");
+  assert.match(String(result.stateBindingReceipt), /^claude-sdk-fork-v1:/);
+  assert.deepEqual(calls, [
+    {
+      sessionId: "source",
+      options: {
+        dir: "/workspace",
+        upToMessageId: "answer-1",
+        title: "Source (2)"
+      }
+    }
+  ]);
+});
+
+test("Claude fork reports unknown once the SDK mutation was invoked", async () => {
+  const sdk = fakeSDK();
+  sdk.forkSession = async () => {
+    throw new Error("connection lost");
+  };
+  await assert.rejects(
+    forkClaudeSession(
+      {
+        sessionId: "source",
+        providerTurnId: "prompt-1",
+        providerTurnIds: ["prompt-1"],
+        cwd: "/workspace",
+        title: "Source (2)"
+      },
+      sdk
+    ),
+    (error: unknown) =>
+      error instanceof Error &&
+      "deliveryDisposition" in error &&
+      error.deliveryDisposition === "unknown"
+  );
+});
+
+test("Claude fork validates the checkpoint identity before SDK mutation", async () => {
+  const calls: Array<Record<string, unknown>> = [];
+  const sdk = fakeSDK(calls);
+  sdk.getSessionMessages = async () => [
+    message("user", "prompt-1", { role: "user", content: "one" }),
+    message("assistant", "", { role: "assistant", content: "first" })
+  ];
+  await assert.rejects(
+    forkClaudeSession(
+      {
+        sessionId: "source",
+        providerTurnId: "prompt-1",
+        providerTurnIds: ["prompt-1"],
+        cwd: "/workspace",
+        title: ""
+      },
+      sdk
+    ),
+    (error: unknown) =>
+      error instanceof Error &&
+      "deliveryDisposition" in error &&
+      error.deliveryDisposition === "not_started"
+  );
+  assert.deepEqual(calls, []);
+});
+
+test("Claude fork supports an untitled canonical session", async () => {
+  const calls: Array<Record<string, unknown>> = [];
+  const result = await forkClaudeSession(
+    {
+      sessionId: "source",
+      providerTurnId: "prompt-1",
+      providerTurnIds: ["prompt-1"],
+      cwd: "/workspace",
+      title: " "
+    },
+    fakeSDK(calls)
+  );
+  assert.equal(result.providerSessionId, "child");
+  assert.deepEqual(calls, [
+    {
+      sessionId: "source",
+      options: {
+        dir: "/workspace",
+        upToMessageId: "answer-1"
+      }
+    }
+  ]);
+});
+
+function fakeSDK(calls: Array<Record<string, unknown>> = []) {
+  return {
+    getSessionMessages: async (sessionId: string) =>
+      sessionId === "child" ? child : source,
+    getSessionInfo: async () => ({
+      sessionId: "child",
+      summary: "child",
+      lastModified: 1
+    }),
+    forkSession: async (
+      sessionId: string,
+      options?: {
+        dir?: string;
+        upToMessageId?: string;
+        title?: string;
+      }
+    ) => {
+      calls.push({ sessionId, options });
+      return { sessionId: "child" };
+    }
+  };
+}
+
+function message(
+  type: "user" | "assistant",
+  uuid: string,
+  content: unknown,
+  sessionId = "source"
+) {
+  return {
+    type,
+    uuid,
+    session_id: sessionId,
+    message: content,
+    parent_tool_use_id: null
+  };
+}

--- a/packages/agent/claude-sdk-sidecar/src/sessionFork.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionFork.test.ts
@@ -130,6 +130,140 @@ test("Claude fork supports an untitled canonical session", async () => {
   ]);
 });
 
+test("Claude fork includes trailing system messages in its exact checkpoint", async () => {
+  const calls: Array<Record<string, unknown>> = [];
+  const sourceWithSystem = [
+    message("user", "prompt-1", { role: "user", content: "one" }),
+    message("assistant", "answer-1", {
+      role: "assistant",
+      content: "first"
+    }),
+    message("system", "compact-1", {
+      subtype: "compact_boundary",
+      compact_metadata: { trigger: "auto" }
+    })
+  ];
+  const childWithSystem = [
+    message(
+      "user",
+      "child-prompt-1",
+      { role: "user", content: "one" },
+      "child"
+    ),
+    message(
+      "assistant",
+      "child-answer-1",
+      { role: "assistant", content: "first" },
+      "child"
+    ),
+    message(
+      "system",
+      "child-compact-1",
+      {
+        subtype: "compact_boundary",
+        compact_metadata: { trigger: "auto" }
+      },
+      "child"
+    )
+  ];
+  const transcriptReads: Array<Record<string, unknown>> = [];
+  const sdk = {
+    getSessionMessages: async (
+      sessionId: string,
+      options?: Record<string, unknown>
+    ) => {
+      transcriptReads.push({ sessionId, options });
+      return sessionId === "child" ? childWithSystem : sourceWithSystem;
+    },
+    getSessionInfo: async () => ({
+      sessionId: "child",
+      summary: "child",
+      lastModified: 1
+    }),
+    forkSession: async (
+      sessionId: string,
+      options?: {
+        dir?: string;
+        upToMessageId?: string;
+        title?: string;
+      }
+    ) => {
+      calls.push({ sessionId, options });
+      return { sessionId: "child" };
+    }
+  };
+
+  const result = await forkClaudeSession(
+    {
+      sessionId: "source",
+      providerTurnId: "prompt-1",
+      providerTurnIds: ["prompt-1"],
+      cwd: "/workspace",
+      title: "Source (2)"
+    },
+    sdk
+  );
+
+  assert.deepEqual(result.targetProviderTurnIds, ["child-prompt-1"]);
+  assert.deepEqual(calls, [
+    {
+      sessionId: "source",
+      options: {
+        dir: "/workspace",
+        upToMessageId: "compact-1",
+        title: "Source (2)"
+      }
+    }
+  ]);
+  assert.equal(transcriptReads.length, 3);
+  for (const read of transcriptReads) {
+    assert.deepEqual(read.options, {
+      dir: "/workspace",
+      includeSystemMessages: true
+    });
+  }
+});
+
+test("Claude fork reports unknown when child omits a trailing system message", async () => {
+  const sourceWithSystem = [
+    message("user", "prompt-1", { role: "user", content: "one" }),
+    message("assistant", "answer-1", {
+      role: "assistant",
+      content: "first"
+    }),
+    message("system", "compact-1", {
+      subtype: "compact_boundary"
+    })
+  ];
+  const sdk = {
+    getSessionMessages: async (sessionId: string) =>
+      sessionId === "child" ? child : sourceWithSystem,
+    getSessionInfo: async () => ({
+      sessionId: "child",
+      summary: "child",
+      lastModified: 1
+    }),
+    forkSession: async () => ({ sessionId: "child" })
+  };
+
+  await assert.rejects(
+    forkClaudeSession(
+      {
+        sessionId: "source",
+        providerTurnId: "prompt-1",
+        providerTurnIds: ["prompt-1"],
+        cwd: "/workspace",
+        title: "Source (2)"
+      },
+      sdk
+    ),
+    (error: unknown) =>
+      error instanceof Error &&
+      "deliveryDisposition" in error &&
+      error.deliveryDisposition === "unknown"
+  );
+});
+
 test("Claude fork can branch again from a provider-owned child", async () => {
   const calls: Array<Record<string, unknown>> = [];
   const grandchild = [
@@ -223,7 +357,7 @@ function fakeSDK(calls: Array<Record<string, unknown>> = []) {
 }
 
 function message(
-  type: "user" | "assistant",
+  type: "user" | "assistant" | "system",
   uuid: string,
   content: unknown,
   sessionId = "source"

--- a/packages/agent/claude-sdk-sidecar/src/sessionFork.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionFork.test.ts
@@ -5,6 +5,8 @@ import {
   inspectClaudeForkCheckpoints
 } from "./sessionFork.ts";
 
+const childSessionId = "11111111-1111-4111-8111-111111111111";
+const grandchildSessionId = "22222222-2222-4222-8222-222222222222";
 const source = [
   message("user", "prompt-1", { role: "user", content: "one" }),
   message("assistant", "answer-1", { role: "assistant", content: "first" }),
@@ -12,12 +14,17 @@ const source = [
   message("assistant", "answer-2", { role: "assistant", content: "second" })
 ];
 const child = [
-  message("user", "child-prompt-1", { role: "user", content: "one" }, "child"),
+  message(
+    "user",
+    "child-prompt-1",
+    { role: "user", content: "one" },
+    childSessionId
+  ),
   message(
     "assistant",
     "child-answer-1",
     { role: "assistant", content: "first" },
-    "child"
+    childSessionId
   )
 ];
 
@@ -36,38 +43,116 @@ test("Claude fork verifies the inclusive prefix and maps remapped UUIDs", async 
       sessionId: "source",
       providerTurnId: "prompt-1",
       providerTurnIds: ["prompt-1"],
+      targetSessionId: childSessionId,
       cwd: "/workspace",
       title: "Source (2)"
     },
     fakeSDK(calls)
   );
-  assert.equal(result.providerSessionId, "child");
+  assert.equal(result.providerSessionId, childSessionId);
   assert.deepEqual(result.targetProviderTurnIds, ["child-prompt-1"]);
   assert.equal(result.stateBindingMode, "provider_owned");
   assert.match(String(result.stateBindingReceipt), /^claude-sdk-fork-v1:/);
   assert.deepEqual(calls, [
     {
-      sessionId: "source",
       options: {
-        dir: "/workspace",
-        upToMessageId: "answer-1",
+        cwd: "/workspace",
+        resume: "source",
+        forkSession: true,
+        sessionId: childSessionId,
+        resumeSessionAt: "answer-1",
         title: "Source (2)"
       }
     }
   ]);
 });
 
+test("Claude fork reconciles an existing deterministic child without another mutation", async () => {
+  let queryCalls = 0;
+  const result = await forkClaudeSession(
+    {
+      sessionId: "source",
+      providerTurnId: "prompt-1",
+      providerTurnIds: ["prompt-1"],
+      targetSessionId: childSessionId,
+      cwd: "/workspace",
+      title: "Source (2)"
+    },
+    {
+      getSessionMessages: async (sessionId: string) =>
+        sessionId === childSessionId ? child : source,
+      getSessionInfo: async (sessionId: string) => ({
+        sessionId,
+        summary: "child",
+        lastModified: 1
+      }),
+      query: (() => {
+        queryCalls++;
+        return makeQuery(async () => {});
+      }) as never
+    }
+  );
+
+  assert.equal(result.providerSessionId, childSessionId);
+  assert.deepEqual(result.targetProviderTurnIds, ["child-prompt-1"]);
+  assert.equal(queryCalls, 0);
+});
+
+test("Claude fork initializes with an empty prompt stream", async () => {
+  let created = false;
+  let promptResult: Promise<IteratorResult<unknown>> | undefined;
+  const sdk = {
+    getSessionMessages: async (sessionId: string) => {
+      if (sessionId === childSessionId) {
+        return created ? child : [];
+      }
+      return source;
+    },
+    getSessionInfo: async () =>
+      created
+        ? { sessionId: childSessionId, summary: "child", lastModified: 1 }
+        : undefined,
+    query: ((params: { prompt: AsyncIterable<unknown> }) => {
+      const iterator = params.prompt[Symbol.asyncIterator]();
+      return makeQuery(
+        async () => {
+          created = true;
+        },
+        () => {
+          promptResult = iterator.next();
+        }
+      );
+    }) as never
+  };
+
+  await forkClaudeSession(
+    {
+      sessionId: "source",
+      providerTurnId: "prompt-1",
+      providerTurnIds: ["prompt-1"],
+      targetSessionId: childSessionId,
+      cwd: "/workspace",
+      title: "Source (2)"
+    },
+    sdk
+  );
+
+  assert.deepEqual(await promptResult, { done: true, value: undefined });
+});
+
 test("Claude fork reports unknown once the SDK mutation was invoked", async () => {
   const sdk = fakeSDK();
-  sdk.forkSession = async () => {
-    throw new Error("connection lost");
-  };
+  sdk.query = (() =>
+    makeQuery(async () => {
+      throw new Error("connection lost");
+    })) as never;
   await assert.rejects(
     forkClaudeSession(
       {
         sessionId: "source",
         providerTurnId: "prompt-1",
         providerTurnIds: ["prompt-1"],
+        targetSessionId: childSessionId,
         cwd: "/workspace",
         title: "Source (2)"
       },
@@ -93,6 +178,7 @@ test("Claude fork validates the checkpoint identity before SDK mutation", async 
         sessionId: "source",
         providerTurnId: "prompt-1",
         providerTurnIds: ["prompt-1"],
+        targetSessionId: childSessionId,
         cwd: "/workspace",
         title: ""
       },
@@ -113,18 +199,21 @@ test("Claude fork supports an untitled canonical session", async () => {
       sessionId: "source",
       providerTurnId: "prompt-1",
       providerTurnIds: ["prompt-1"],
+      targetSessionId: childSessionId,
       cwd: "/workspace",
       title: " "
     },
     fakeSDK(calls)
   );
-  assert.equal(result.providerSessionId, "child");
+  assert.equal(result.providerSessionId, childSessionId);
   assert.deepEqual(calls, [
     {
-      sessionId: "source",
       options: {
-        dir: "/workspace",
-        upToMessageId: "answer-1"
+        cwd: "/workspace",
+        resume: "source",
+        forkSession: true,
+        sessionId: childSessionId,
+        resumeSessionAt: "answer-1"
       }
     }
   ]);
@@ -148,13 +237,13 @@ test("Claude fork includes trailing system messages in its exact checkpoint", as
       "user",
       "child-prompt-1",
       { role: "user", content: "one" },
-      "child"
+      childSessionId
     ),
     message(
       "assistant",
       "child-answer-1",
       { role: "assistant", content: "first" },
-      "child"
+      childSessionId
     ),
     message(
       "system",
@@ -163,34 +252,36 @@ test("Claude fork includes trailing system messages in its exact checkpoint", as
         subtype: "compact_boundary",
         compact_metadata: { trigger: "auto" }
       },
-      "child"
+      childSessionId
     )
   ];
   const transcriptReads: Array<Record<string, unknown>> = [];
+  let created = false;
   const sdk = {
     getSessionMessages: async (
       sessionId: string,
       options?: Record<string, unknown>
     ) => {
       transcriptReads.push({ sessionId, options });
-      return sessionId === "child" ? childWithSystem : sourceWithSystem;
-    },
-    getSessionInfo: async () => ({
-      sessionId: "child",
-      summary: "child",
-      lastModified: 1
-    }),
-    forkSession: async (
-      sessionId: string,
-      options?: {
-        dir?: string;
-        upToMessageId?: string;
-        title?: string;
+      if (sessionId === childSessionId) {
+        return created ? childWithSystem : [];
       }
-    ) => {
-      calls.push({ sessionId, options });
-      return { sessionId: "child" };
-    }
+      return sourceWithSystem;
+    },
+    getSessionInfo: async () =>
+      created
+        ? {
+            sessionId: childSessionId,
+            summary: "child",
+            lastModified: 1
+          }
+        : undefined,
+    query: ((params: { options?: Record<string, unknown> }) => {
+      calls.push({ options: selectedForkOptions(params.options) });
+      return makeQuery(async () => {
+        created = true;
+      });
+    }) as never
   };
 
   const result = await forkClaudeSession(
@@ -198,6 +289,7 @@ test("Claude fork includes trailing system messages in its exact checkpoint", as
       sessionId: "source",
       providerTurnId: "prompt-1",
       providerTurnIds: ["prompt-1"],
+      targetSessionId: childSessionId,
       cwd: "/workspace",
       title: "Source (2)"
     },
@@ -207,15 +299,17 @@ test("Claude fork includes trailing system messages in its exact checkpoint", as
   assert.deepEqual(result.targetProviderTurnIds, ["child-prompt-1"]);
   assert.deepEqual(calls, [
     {
-      sessionId: "source",
       options: {
-        dir: "/workspace",
-        upToMessageId: "compact-1",
+        cwd: "/workspace",
+        resume: "source",
+        forkSession: true,
+        sessionId: childSessionId,
+        resumeSessionAt: "compact-1",
         title: "Source (2)"
       }
     }
   ]);
-  assert.equal(transcriptReads.length, 3);
+  assert.equal(transcriptReads.length, 4);
   for (const read of transcriptReads) {
     assert.deepEqual(read.options, {
       dir: "/workspace",
@@ -235,15 +329,26 @@ test("Claude fork reports unknown when child omits a trailing system message", a
       subtype: "compact_boundary"
     })
   ];
+  let created = false;
   const sdk = {
-    getSessionMessages: async (sessionId: string) =>
-      sessionId === "child" ? child : sourceWithSystem,
-    getSessionInfo: async () => ({
-      sessionId: "child",
-      summary: "child",
-      lastModified: 1
-    }),
-    forkSession: async () => ({ sessionId: "child" })
+    getSessionMessages: async (sessionId: string) => {
+      if (sessionId === childSessionId) {
+        return created ? child : [];
+      }
+      return sourceWithSystem;
+    },
+    getSessionInfo: async () =>
+      created
+        ? {
+            sessionId: childSessionId,
+            summary: "child",
+            lastModified: 1
+          }
+        : undefined,
+    query: (() =>
+      makeQuery(async () => {
+        created = true;
+      })) as never
   };
 
   await assert.rejects(
@@ -252,6 +357,7 @@ test("Claude fork reports unknown when child omits a trailing system message", a
         sessionId: "source",
         providerTurnId: "prompt-1",
         providerTurnIds: ["prompt-1"],
+        targetSessionId: childSessionId,
         cwd: "/workspace",
         title: "Source (2)"
       },
@@ -271,62 +377,64 @@ test("Claude fork can branch again from a provider-owned child", async () => {
       "user",
       "grandchild-prompt-1",
       { role: "user", content: "one" },
-      "grandchild"
+      grandchildSessionId
     ),
     message(
       "assistant",
       "grandchild-answer-1",
       { role: "assistant", content: "first" },
-      "grandchild"
+      grandchildSessionId
     )
   ];
+  let created = false;
   const sdk = {
     getSessionMessages: async (sessionId: string) => {
-      if (sessionId === "child") {
+      if (sessionId === childSessionId) {
         return child;
       }
-      if (sessionId === "grandchild") {
-        return grandchild;
+      if (sessionId === grandchildSessionId) {
+        return created ? grandchild : [];
       }
       return source;
     },
-    getSessionInfo: async (sessionId: string) => ({
-      sessionId,
-      summary: "grandchild",
-      lastModified: 1
-    }),
-    forkSession: async (
-      sessionId: string,
-      options?: {
-        dir?: string;
-        upToMessageId?: string;
-        title?: string;
-      }
-    ) => {
-      calls.push({ sessionId, options });
-      return { sessionId: "grandchild" };
-    }
+    getSessionInfo: async (sessionId: string) =>
+      sessionId === grandchildSessionId && created
+        ? {
+            sessionId,
+            summary: "grandchild",
+            lastModified: 1
+          }
+        : undefined,
+    query: ((params: { options?: Record<string, unknown> }) => {
+      calls.push({ options: selectedForkOptions(params.options) });
+      return makeQuery(async () => {
+        created = true;
+      });
+    }) as never
   };
 
   const result = await forkClaudeSession(
     {
-      sessionId: "child",
+      sessionId: childSessionId,
       providerTurnId: "child-prompt-1",
       providerTurnIds: ["child-prompt-1"],
+      targetSessionId: grandchildSessionId,
       cwd: "/workspace",
       title: "Grandchild"
     },
     sdk
   );
 
-  assert.equal(result.providerSessionId, "grandchild");
+  assert.equal(result.providerSessionId, grandchildSessionId);
   assert.deepEqual(result.targetProviderTurnIds, ["grandchild-prompt-1"]);
   assert.deepEqual(calls, [
     {
-      sessionId: "child",
       options: {
-        dir: "/workspace",
-        upToMessageId: "child-answer-1",
+        cwd: "/workspace",
+        resume: childSessionId,
+        forkSession: true,
+        sessionId: grandchildSessionId,
+        resumeSessionAt: "child-answer-1",
         title: "Grandchild"
       }
     }
@@ -334,26 +442,62 @@ test("Claude fork can branch again from a provider-owned child", async () => {
 });
 
 function fakeSDK(calls: Array<Record<string, unknown>> = []) {
+  let created = false;
   return {
-    getSessionMessages: async (sessionId: string) =>
-      sessionId === "child" ? child : source,
-    getSessionInfo: async () => ({
-      sessionId: "child",
-      summary: "child",
-      lastModified: 1
-    }),
-    forkSession: async (
-      sessionId: string,
-      options?: {
-        dir?: string;
-        upToMessageId?: string;
-        title?: string;
+    getSessionMessages: async (sessionId: string) => {
+      if (sessionId === childSessionId) {
+        return created ? child : [];
       }
-    ) => {
-      calls.push({ sessionId, options });
-      return { sessionId: "child" };
-    }
+      return source;
+    },
+    getSessionInfo: async () =>
+      created
+        ? {
+            sessionId: childSessionId,
+            summary: "child",
+            lastModified: 1
+          }
+        : undefined,
+    query: ((params: { options?: Record<string, unknown> }) => {
+      calls.push({ options: selectedForkOptions(params.options) });
+      return makeQuery(async () => {
+        created = true;
+      });
+    }) as never
   };
+}
+
+function makeQuery(
+  onInitialize: () => Promise<void>,
+  onClose: () => void = () => {}
+) {
+  const iterator = (async function* () {})();
+  return Object.assign(iterator, {
+    initializationResult: async () => {
+      await onInitialize();
+      return {};
+    },
+    close: onClose
+  });
+}
+
+function selectedForkOptions(
+  options: Record<string, unknown> | undefined
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const key of [
+    "cwd",
+    "resume",
+    "forkSession",
+    "sessionId",
+    "resumeSessionAt",
+    "title"
+  ]) {
+    if (options && key in options) {
+      result[key] = options[key];
+    }
+  }
+  return result;
 }
 
 function message(

--- a/packages/agent/claude-sdk-sidecar/src/sessionFork.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionFork.test.ts
@@ -130,6 +130,75 @@ test("Claude fork supports an untitled canonical session", async () => {
   ]);
 });
 
+test("Claude fork can branch again from a provider-owned child", async () => {
+  const calls: Array<Record<string, unknown>> = [];
+  const grandchild = [
+    message(
+      "user",
+      "grandchild-prompt-1",
+      { role: "user", content: "one" },
+      "grandchild"
+    ),
+    message(
+      "assistant",
+      "grandchild-answer-1",
+      { role: "assistant", content: "first" },
+      "grandchild"
+    )
+  ];
+  const sdk = {
+    getSessionMessages: async (sessionId: string) => {
+      if (sessionId === "child") {
+        return child;
+      }
+      if (sessionId === "grandchild") {
+        return grandchild;
+      }
+      return source;
+    },
+    getSessionInfo: async (sessionId: string) => ({
+      sessionId,
+      summary: "grandchild",
+      lastModified: 1
+    }),
+    forkSession: async (
+      sessionId: string,
+      options?: {
+        dir?: string;
+        upToMessageId?: string;
+        title?: string;
+      }
+    ) => {
+      calls.push({ sessionId, options });
+      return { sessionId: "grandchild" };
+    }
+  };
+
+  const result = await forkClaudeSession(
+    {
+      sessionId: "child",
+      providerTurnId: "child-prompt-1",
+      providerTurnIds: ["child-prompt-1"],
+      cwd: "/workspace",
+      title: "Grandchild"
+    },
+    sdk
+  );
+
+  assert.equal(result.providerSessionId, "grandchild");
+  assert.deepEqual(result.targetProviderTurnIds, ["grandchild-prompt-1"]);
+  assert.deepEqual(calls, [
+    {
+      sessionId: "child",
+      options: {
+        dir: "/workspace",
+        upToMessageId: "child-answer-1",
+        title: "Grandchild"
+      }
+    }
+  ]);
+});
+
 function fakeSDK(calls: Array<Record<string, unknown>> = []) {
   return {
     getSessionMessages: async (sessionId: string) =>

--- a/packages/agent/claude-sdk-sidecar/src/sessionFork.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionFork.ts
@@ -186,6 +186,22 @@ async function readExistingChild(
   };
 }
 
+// LIMITATION / SDK upgrade checkpoint:
+//
+// The pinned official SDK's direct forkSession() API chooses a random child
+// UUID and has no idempotency key, so it cannot implement Host's deterministic
+// replay contract. query() is used only to initialize
+// resume + forkSession + sessionId + resumeSessionAt with an empty prompt.
+//
+// A provider interruption can still leave the requested UUID present but with
+// a partial or unverifiable transcript. We deliberately return delivery
+// "unknown" in that case: deleting provider-owned state or creating a second
+// UUID would violate exactly-once safety.
+//
+// When upgrading @anthropic-ai/claude-agent-sdk, re-check whether
+// forkSession() supports a caller-supplied child UUID/idempotency key and an
+// atomic or reliably reconcilable durable result. If it does, replace this
+// query() workaround and revisit the fail-closed partial-child path above.
 async function initializeDeterministicFork(
   input: ForkInput,
   checkpointId: string,

--- a/packages/agent/claude-sdk-sidecar/src/sessionFork.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionFork.ts
@@ -1,9 +1,14 @@
 import { createHash } from "node:crypto";
 import {
-  forkSession,
   getSessionInfo,
-  getSessionMessages
+  getSessionMessages,
+  query,
+  type Options,
+  type Query
 } from "@anthropic-ai/claude-agent-sdk";
+import { resolveClaudeCodeExecutablePath } from "./executablePath.ts";
+import { AsyncPromptQueue } from "./promptQueue.ts";
+import { claudeSettingsEnv } from "./settingsEnv.ts";
 
 type SDKMessage = {
   type?: unknown;
@@ -21,19 +26,20 @@ type ForkInspectInput = {
 type ForkInput = ForkInspectInput & {
   providerTurnId: string;
   providerTurnIds: string[];
+  targetSessionId: string;
   title: string;
 };
 
 type ClaudeForkSDK = {
   getSessionMessages: typeof getSessionMessages;
   getSessionInfo: typeof getSessionInfo;
-  forkSession: typeof forkSession;
+  query: typeof query;
 };
 
 const defaultClaudeForkSDK: ClaudeForkSDK = {
   getSessionMessages,
   getSessionInfo,
-  forkSession
+  query
 };
 
 export async function inspectClaudeForkCheckpoints(
@@ -71,6 +77,10 @@ async function forkClaudeSessionVerified(
 ): Promise<Record<string, unknown>> {
   requireIdentity(input.sessionId, "provider session id");
   requireIdentity(input.providerTurnId, "provider turn id");
+  requireUUID(input.targetSessionId, "target provider session id");
+  if (input.targetSessionId === input.sessionId) {
+    throw new Error("target provider session id equals source session id");
+  }
   const expectedTurnIds = normalizedIdentities(input.providerTurnIds);
   if (
     expectedTurnIds.length === 0 ||
@@ -93,17 +103,28 @@ async function forkClaudeSessionVerified(
   const checkpointId = sourceMessageIds.at(-1) ?? "";
   requireIdentity(checkpointId, "checkpoint message id");
 
-  onForkStarted();
-  const title = input.title.trim();
-  const child = await sdk.forkSession(input.sessionId, {
-    ...options,
-    upToMessageId: checkpointId,
-    ...(title ? { title } : {})
-  });
-  const childSessionId = messageIdentity(child?.sessionId);
-  if (!childSessionId || childSessionId === input.sessionId) {
-    throw new Error("Claude SDK returned an invalid fork session id");
+  const existingChild = await readExistingChild(
+    input.targetSessionId,
+    options,
+    transcriptReadOptions,
+    sdk
+  );
+  if (existingChild.exists) {
+    onForkStarted();
+    return verifiedForkResult({
+      input,
+      checkpointId,
+      sourcePrefix,
+      sourceMessageIds,
+      childSessionId: input.targetSessionId,
+      childMessages: existingChild.messages,
+      expectedTurnIds
+    });
   }
+
+  onForkStarted();
+  await initializeDeterministicFork(input, checkpointId, sdk);
+  const childSessionId = input.targetSessionId;
 
   const [sourceB, childInfo, childMessages] = await Promise.all([
     sdk.getSessionMessages(input.sessionId, transcriptReadOptions) as Promise<
@@ -132,6 +153,94 @@ async function forkClaudeSessionVerified(
   if (messageIdentity(childInfo?.sessionId) !== childSessionId) {
     throw new Error("forked Claude session is not independently discoverable");
   }
+  return verifiedForkResult({
+    input,
+    checkpointId,
+    sourcePrefix,
+    sourceMessageIds,
+    childSessionId,
+    childMessages,
+    expectedTurnIds
+  });
+}
+
+async function readExistingChild(
+  childSessionId: string,
+  infoOptions: { dir?: string },
+  transcriptReadOptions: { dir?: string; includeSystemMessages: true },
+  sdk: ClaudeForkSDK
+): Promise<{ exists: boolean; messages: SDKMessage[] }> {
+  const [info, messages] = await Promise.all([
+    sdk.getSessionInfo(childSessionId, infoOptions),
+    sdk.getSessionMessages(childSessionId, transcriptReadOptions) as Promise<
+      SDKMessage[]
+    >
+  ]);
+  const infoSessionId = messageIdentity(info?.sessionId);
+  if (infoSessionId && infoSessionId !== childSessionId) {
+    throw new Error("deterministic Claude child resolved to another session");
+  }
+  return {
+    exists: infoSessionId === childSessionId || messages.length !== 0,
+    messages
+  };
+}
+
+async function initializeDeterministicFork(
+  input: ForkInput,
+  checkpointId: string,
+  sdk: ClaudeForkSDK
+): Promise<void> {
+  const promptQueue = new AsyncPromptQueue();
+  const cwd = input.cwd.trim() || process.cwd();
+  const settingsEnv = claudeSettingsEnv(cwd);
+  const env = {
+    ...process.env,
+    ...settingsEnv
+  };
+  const executablePath = resolveClaudeCodeExecutablePath(env);
+  const title = input.title.trim();
+  const options: Options = {
+    cwd,
+    env,
+    resume: input.sessionId,
+    forkSession: true,
+    sessionId: input.targetSessionId,
+    resumeSessionAt: checkpointId,
+    ...(title ? { title } : {}),
+    ...(executablePath ? { pathToClaudeCodeExecutable: executablePath } : {})
+  };
+  const forkQuery = sdk.query({
+    // Initialization performs the provider fork. Deliberately never enqueue a
+    // user message: the child must end exactly at the selected checkpoint.
+    prompt: promptQueue.iterate(),
+    options
+  }) as Query;
+  try {
+    await forkQuery.initializationResult();
+  } finally {
+    promptQueue.close();
+    forkQuery.close();
+  }
+}
+
+function verifiedForkResult(input: {
+  input: ForkInput;
+  checkpointId: string;
+  sourcePrefix: SDKMessage[];
+  sourceMessageIds: string[];
+  childSessionId: string;
+  childMessages: SDKMessage[];
+  expectedTurnIds: string[];
+}): Record<string, unknown> {
+  const {
+    checkpointId,
+    sourcePrefix,
+    sourceMessageIds,
+    childSessionId,
+    childMessages,
+    expectedTurnIds
+  } = input;
   const childMessageIds = messageIdentities(
     childMessages,
     "forked transcript prefix"
@@ -156,10 +265,11 @@ async function forkClaudeSessionVerified(
   const receipt = createHash("sha256")
     .update(
       JSON.stringify({
-        sourceSessionId: input.sessionId,
+        sourceSessionId: input.input.sessionId,
         childSessionId,
         checkpointId,
         targetCheckpointId,
+        sourceMessageIds,
         expectedTurnIds,
         targetProviderTurnIds
       })
@@ -334,5 +444,16 @@ function messageIdentity(value: unknown): string {
 function requireIdentity(value: string, label: string): void {
   if (!value.trim()) {
     throw new Error(`${label} is required`);
+  }
+}
+
+function requireUUID(value: string, label: string): void {
+  requireIdentity(value, label);
+  if (
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      value.trim()
+    )
+  ) {
+    throw new Error(`${label} must be a UUID`);
   }
 }

--- a/packages/agent/claude-sdk-sidecar/src/sessionFork.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionFork.ts
@@ -43,7 +43,7 @@ export async function inspectClaudeForkCheckpoints(
   requireIdentity(input.sessionId, "provider session id");
   const messages = (await sdk.getSessionMessages(
     input.sessionId,
-    sdkOptions(input.cwd)
+    transcriptOptions(input.cwd)
   )) as SDKMessage[];
   return {
     providerTurnIds: rootProviderTurnIds(messages)
@@ -80,9 +80,10 @@ async function forkClaudeSessionVerified(
   }
 
   const options = sdkOptions(input.cwd);
+  const transcriptReadOptions = transcriptOptions(input.cwd);
   const sourceA = (await sdk.getSessionMessages(
     input.sessionId,
-    options
+    transcriptReadOptions
   )) as SDKMessage[];
   const sourcePrefix = exactSourcePrefix(sourceA, expectedTurnIds);
   const sourceMessageIds = messageIdentities(
@@ -105,9 +106,13 @@ async function forkClaudeSessionVerified(
   }
 
   const [sourceB, childInfo, childMessages] = await Promise.all([
-    sdk.getSessionMessages(input.sessionId, options) as Promise<SDKMessage[]>,
+    sdk.getSessionMessages(input.sessionId, transcriptReadOptions) as Promise<
+      SDKMessage[]
+    >,
     sdk.getSessionInfo(childSessionId, options),
-    sdk.getSessionMessages(childSessionId, options) as Promise<SDKMessage[]>
+    sdk.getSessionMessages(childSessionId, transcriptReadOptions) as Promise<
+      SDKMessage[]
+    >
   ]);
   const sourcePrefixB = exactSourcePrefix(sourceB, expectedTurnIds);
   const sourceMessageIdsB = messageIdentities(
@@ -290,6 +295,16 @@ function assertIdentityEquality(
 function sdkOptions(cwd: string): { dir?: string } {
   const dir = cwd.trim();
   return dir ? { dir } : {};
+}
+
+function transcriptOptions(cwd: string): {
+  dir?: string;
+  includeSystemMessages: true;
+} {
+  return {
+    ...sdkOptions(cwd),
+    includeSystemMessages: true
+  };
 }
 
 function normalizedIdentities(values: string[]): string[] {

--- a/packages/agent/claude-sdk-sidecar/src/sessionFork.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionFork.ts
@@ -1,0 +1,323 @@
+import { createHash } from "node:crypto";
+import {
+  forkSession,
+  getSessionInfo,
+  getSessionMessages
+} from "@anthropic-ai/claude-agent-sdk";
+
+type SDKMessage = {
+  type?: unknown;
+  uuid?: unknown;
+  session_id?: unknown;
+  message?: unknown;
+  parent_tool_use_id?: unknown;
+};
+
+type ForkInspectInput = {
+  sessionId: string;
+  cwd: string;
+};
+
+type ForkInput = ForkInspectInput & {
+  providerTurnId: string;
+  providerTurnIds: string[];
+  title: string;
+};
+
+type ClaudeForkSDK = {
+  getSessionMessages: typeof getSessionMessages;
+  getSessionInfo: typeof getSessionInfo;
+  forkSession: typeof forkSession;
+};
+
+const defaultClaudeForkSDK: ClaudeForkSDK = {
+  getSessionMessages,
+  getSessionInfo,
+  forkSession
+};
+
+export async function inspectClaudeForkCheckpoints(
+  input: ForkInspectInput,
+  sdk: ClaudeForkSDK = defaultClaudeForkSDK
+): Promise<Record<string, unknown>> {
+  requireIdentity(input.sessionId, "provider session id");
+  const messages = (await sdk.getSessionMessages(
+    input.sessionId,
+    sdkOptions(input.cwd)
+  )) as SDKMessage[];
+  return {
+    providerTurnIds: rootProviderTurnIds(messages)
+  };
+}
+
+export async function forkClaudeSession(
+  input: ForkInput,
+  sdk: ClaudeForkSDK = defaultClaudeForkSDK
+): Promise<Record<string, unknown>> {
+  let forkStarted = false;
+  try {
+    return await forkClaudeSessionVerified(input, sdk, () => {
+      forkStarted = true;
+    });
+  } catch {
+    throw new ClaudeForkError(forkStarted ? "unknown" : "not_started");
+  }
+}
+
+async function forkClaudeSessionVerified(
+  input: ForkInput,
+  sdk: ClaudeForkSDK,
+  onForkStarted: () => void
+): Promise<Record<string, unknown>> {
+  requireIdentity(input.sessionId, "provider session id");
+  requireIdentity(input.providerTurnId, "provider turn id");
+  const expectedTurnIds = normalizedIdentities(input.providerTurnIds);
+  if (
+    expectedTurnIds.length === 0 ||
+    expectedTurnIds.at(-1) !== input.providerTurnId
+  ) {
+    throw new Error("provider turn prefix does not end at the selected turn");
+  }
+
+  const options = sdkOptions(input.cwd);
+  const sourceA = (await sdk.getSessionMessages(
+    input.sessionId,
+    options
+  )) as SDKMessage[];
+  const sourcePrefix = exactSourcePrefix(sourceA, expectedTurnIds);
+  const sourceMessageIds = messageIdentities(
+    sourcePrefix,
+    "source transcript prefix"
+  );
+  const checkpointId = sourceMessageIds.at(-1) ?? "";
+  requireIdentity(checkpointId, "checkpoint message id");
+
+  onForkStarted();
+  const title = input.title.trim();
+  const child = await sdk.forkSession(input.sessionId, {
+    ...options,
+    upToMessageId: checkpointId,
+    ...(title ? { title } : {})
+  });
+  const childSessionId = messageIdentity(child?.sessionId);
+  if (!childSessionId || childSessionId === input.sessionId) {
+    throw new Error("Claude SDK returned an invalid fork session id");
+  }
+
+  const [sourceB, childInfo, childMessages] = await Promise.all([
+    sdk.getSessionMessages(input.sessionId, options) as Promise<SDKMessage[]>,
+    sdk.getSessionInfo(childSessionId, options),
+    sdk.getSessionMessages(childSessionId, options) as Promise<SDKMessage[]>
+  ]);
+  const sourcePrefixB = exactSourcePrefix(sourceB, expectedTurnIds);
+  const sourceMessageIdsB = messageIdentities(
+    sourcePrefixB,
+    "re-read source transcript prefix"
+  );
+  assertStructuralEquality(
+    sourcePrefix,
+    sourcePrefixB,
+    "source transcript changed during fork"
+  );
+  assertIdentityEquality(
+    sourceMessageIds,
+    sourceMessageIdsB,
+    "source transcript identities changed during fork"
+  );
+  if (messageIdentity(childInfo?.sessionId) !== childSessionId) {
+    throw new Error("forked Claude session is not independently discoverable");
+  }
+  const childMessageIds = messageIdentities(
+    childMessages,
+    "forked transcript prefix"
+  );
+  assertStructuralEquality(
+    sourcePrefix,
+    childMessages,
+    "forked Claude transcript does not equal the selected source prefix"
+  );
+
+  const sourceIndexById = new Map(
+    sourcePrefix.map((message, index) => [messageIdentity(message), index])
+  );
+  const targetProviderTurnIds = expectedTurnIds.map((sourceId) => {
+    const index = sourceIndexById.get(sourceId);
+    if (index === undefined) {
+      throw new Error("source provider turn is absent from verified prefix");
+    }
+    return childMessageIds[index];
+  });
+  const targetCheckpointId = childMessageIds.at(-1) ?? "";
+  const receipt = createHash("sha256")
+    .update(
+      JSON.stringify({
+        sourceSessionId: input.sessionId,
+        childSessionId,
+        checkpointId,
+        targetCheckpointId,
+        expectedTurnIds,
+        targetProviderTurnIds
+      })
+    )
+    .digest("hex");
+  return {
+    providerSessionId: childSessionId,
+    targetProviderTurnIds,
+    stateBindingMode: "provider_owned",
+    stateBindingReceipt: `claude-sdk-fork-v1:${receipt}`,
+    deliveryDisposition: "accepted"
+  };
+}
+
+class ClaudeForkError extends Error {
+  readonly deliveryDisposition: "not_started" | "unknown";
+
+  constructor(deliveryDisposition: "not_started" | "unknown") {
+    super("Claude SDK session fork failed");
+    this.deliveryDisposition = deliveryDisposition;
+  }
+}
+
+function exactSourcePrefix(
+  messages: SDKMessage[],
+  expectedTurnIds: string[]
+): SDKMessage[] {
+  const actualRootIds = rootProviderTurnIds(messages);
+  if (
+    expectedTurnIds.some((turnId, index) => actualRootIds[index] !== turnId)
+  ) {
+    throw new Error(
+      "canonical provider turn prefix does not match Claude transcript"
+    );
+  }
+  const selectedIndex = messages.findIndex(
+    (message) =>
+      isRootUserMessage(message) &&
+      messageIdentity(message) === expectedTurnIds.at(-1)
+  );
+  if (selectedIndex < 0) {
+    throw new Error("selected provider turn is absent from Claude transcript");
+  }
+  const nextRootIndex = messages.findIndex(
+    (message, index) => index > selectedIndex && isRootUserMessage(message)
+  );
+  const end = nextRootIndex < 0 ? messages.length : nextRootIndex;
+  if (end <= selectedIndex) {
+    throw new Error(
+      "selected provider turn has no exact transcript checkpoint"
+    );
+  }
+  return messages.slice(0, end);
+}
+
+function rootProviderTurnIds(messages: SDKMessage[]): string[] {
+  const result: string[] = [];
+  const seen = new Set<string>();
+  for (const message of messages) {
+    if (!isRootUserMessage(message)) {
+      continue;
+    }
+    const identity = messageIdentity(message);
+    if (!identity || seen.has(identity)) {
+      throw new Error(
+        "Claude transcript contains an invalid root user identity"
+      );
+    }
+    seen.add(identity);
+    result.push(identity);
+  }
+  return result;
+}
+
+function isRootUserMessage(message: SDKMessage): boolean {
+  return message?.type === "user" && !message?.parent_tool_use_id;
+}
+
+function assertStructuralEquality(
+  source: SDKMessage[],
+  target: SDKMessage[],
+  error: string
+): void {
+  if (
+    source.length !== target.length ||
+    source.some(
+      (message, index) =>
+        JSON.stringify(normalizedMessage(message)) !==
+        JSON.stringify(normalizedMessage(target[index]))
+    )
+  ) {
+    throw new Error(error);
+  }
+}
+
+function normalizedMessage(
+  message: SDKMessage | undefined
+): Record<string, unknown> {
+  return {
+    type: message?.type,
+    message: message?.message,
+    parent_tool_use_id: message?.parent_tool_use_id ?? null
+  };
+}
+
+function messageIdentities(messages: SDKMessage[], label: string): string[] {
+  const result: string[] = [];
+  const seen = new Set<string>();
+  for (const message of messages) {
+    const identity = messageIdentity(message);
+    if (!identity || seen.has(identity)) {
+      throw new Error(`${label} does not have a complete identity bijection`);
+    }
+    seen.add(identity);
+    result.push(identity);
+  }
+  return result;
+}
+
+function assertIdentityEquality(
+  source: string[],
+  target: string[],
+  error: string
+): void {
+  if (
+    source.length !== target.length ||
+    source.some((identity, index) => identity !== target[index])
+  ) {
+    throw new Error(error);
+  }
+}
+
+function sdkOptions(cwd: string): { dir?: string } {
+  const dir = cwd.trim();
+  return dir ? { dir } : {};
+}
+
+function normalizedIdentities(values: string[]): string[] {
+  const result: string[] = [];
+  const seen = new Set<string>();
+  for (const value of values) {
+    const identity = value.trim();
+    if (!identity || seen.has(identity)) {
+      throw new Error("provider turn prefix contains an invalid identity");
+    }
+    seen.add(identity);
+    result.push(identity);
+  }
+  return result;
+}
+
+function messageIdentity(value: unknown): string {
+  if (typeof value === "string") {
+    return value.trim();
+  }
+  if (value && typeof value === "object" && "uuid" in value) {
+    return messageIdentity((value as { uuid?: unknown }).uuid);
+  }
+  return "";
+}
+
+function requireIdentity(value: string, label: string): void {
+  if (!value.trim()) {
+    throw new Error(`${label} is required`);
+  }
+}

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts
@@ -179,6 +179,7 @@ export class SessionRuntime {
     this.goalExecQueue = new GoalExecQueue((input) =>
       this.dispatchExec(
         input.turnId,
+        input.providerTurnId,
         input.prompt,
         input.content,
         input.turnOrigin,
@@ -246,10 +247,11 @@ export class SessionRuntime {
     content?: unknown,
     turnOrigin?: string,
     goal?: GoalCommandDispatch,
-    hostContext = ""
+    hostContext = "",
+    providerTurnId = ""
   ): void {
     if (this.driver) {
-      this.driver.exec(turnId, prompt);
+      this.driver.exec(turnId, prompt, providerTurnId);
       return;
     }
     if (this.sessionClosed) {
@@ -265,6 +267,7 @@ export class SessionRuntime {
     if (goal?.operationId && goal.revision > 0) {
       this.goalExecQueue.accept({
         turnId,
+        providerTurnId,
         prompt,
         content,
         turnOrigin,
@@ -275,6 +278,7 @@ export class SessionRuntime {
     }
     this.dispatchExec(
       turnId,
+      providerTurnId,
       prompt,
       content,
       turnOrigin,
@@ -285,6 +289,7 @@ export class SessionRuntime {
 
   private dispatchExec(
     turnId: string,
+    providerTurnId: string | undefined,
     prompt: string,
     content?: unknown,
     turnOrigin?: string,
@@ -294,7 +299,7 @@ export class SessionRuntime {
     this.turns.closeSyntheticBeforeUserTurn();
     const turn: RuntimeTurn = {
       turnId,
-      promptUuid: crypto.randomUUID(),
+      promptUuid: providerTurnId?.trim() || crypto.randomUUID(),
       ...(turnOrigin ? { origin: turnOrigin } : {}),
       ...(goal
         ? {
@@ -327,11 +332,17 @@ export class SessionRuntime {
         ) as unknown as SDKUserMessage["message"]["content"];
         let outboundContent = sdkContent;
         if (hostContext.trim()) {
-          const hostContextBlock = { type: "text" as const, text: hostContext.trim() };
+          const hostContextBlock = {
+            type: "text" as const,
+            text: hostContext.trim()
+          };
           if (Array.isArray(sdkContent)) {
             sdkContent.unshift(hostContextBlock);
           } else {
-            outboundContent = [hostContextBlock, { type: "text" as const, text: sdkContent }];
+            outboundContent = [
+              hostContextBlock,
+              { type: "text" as const, text: sdkContent }
+            ];
           }
         }
         generation.expectPromptEcho(turn.promptUuid);

--- a/packages/agent/claude-sdk-sidecar/src/testDriver.ts
+++ b/packages/agent/claude-sdk-sidecar/src/testDriver.ts
@@ -12,7 +12,7 @@ export class SidecarTestDriver {
     this.interactions = interactions;
   }
 
-  exec(turnId: string, prompt: string): void {
+  exec(turnId: string, prompt: string, providerTurnId = ""): void {
     this.turns.activateTransient(turnId);
     if (prompt.includes("approval")) {
       void this.interactions
@@ -25,8 +25,10 @@ export class SidecarTestDriver {
             toolUseID: "test-approval-tool"
           }
         )
-        .then(() => this.completeTurn(turnId, "Approval accepted."))
-        .catch((error) => this.failTurn(turnId, error));
+        .then(() =>
+          this.completeTurn(turnId, providerTurnId, "Approval accepted.")
+        )
+        .catch((error) => this.failTurn(turnId, providerTurnId, error));
       return;
     }
     if (prompt.includes("ask-user")) {
@@ -47,8 +49,10 @@ export class SidecarTestDriver {
             toolUseID: "test-ask-user-tool"
           }
         )
-        .then(() => this.completeTurn(turnId, "Question answered."))
-        .catch((error) => this.failTurn(turnId, error));
+        .then(() =>
+          this.completeTurn(turnId, providerTurnId, "Question answered.")
+        )
+        .catch((error) => this.failTurn(turnId, providerTurnId, error));
       return;
     }
     if (prompt.includes("exit-plan")) {
@@ -61,19 +65,20 @@ export class SidecarTestDriver {
             toolUseID: "test-exit-plan-tool"
           }
         )
-        .then(() => this.completeTurn(turnId, "Plan captured."))
-        .catch((error) => this.failTurn(turnId, error));
+        .then(() => this.completeTurn(turnId, providerTurnId, "Plan captured."))
+        .catch((error) => this.failTurn(turnId, providerTurnId, error));
       return;
     }
     emit({
       type: "assistant_delta",
       payload: {
         turnId,
+        ...(providerTurnId ? { providerTurnId } : {}),
         content: `Echo: ${prompt}`,
         snapshot: `Echo: ${prompt}`
       }
     });
-    this.completeTurn(turnId, `Echo: ${prompt}`);
+    this.completeTurn(turnId, providerTurnId, `Echo: ${prompt}`);
   }
 
   guide(prompt: string): void {
@@ -87,25 +92,39 @@ export class SidecarTestDriver {
     });
   }
 
-  private completeTurn(turnId: string, content: string): void {
+  private completeTurn(
+    turnId: string,
+    providerTurnId: string,
+    content: string
+  ): void {
     emit({
       type: "assistant_completed",
-      payload: { turnId, content }
+      payload: {
+        turnId,
+        ...(providerTurnId ? { providerTurnId } : {}),
+        content
+      }
     });
     emit({
       type: "turn_completed",
       payload: {
         turnId,
+        ...(providerTurnId ? { providerTurnId } : {}),
         stopReason: "end_turn"
       }
     });
   }
 
-  private failTurn(turnId: string, error: unknown): void {
+  private failTurn(
+    turnId: string,
+    providerTurnId: string,
+    error: unknown
+  ): void {
     emit({
       type: "turn_failed",
       payload: {
         turnId,
+        ...(providerTurnId ? { providerTurnId } : {}),
         error: errorMessage(error)
       }
     });

--- a/packages/agent/claude-sdk-sidecar/src/turnLifecycle.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/turnLifecycle.test.ts
@@ -20,7 +20,11 @@ test("turn lifecycle activates and settles a queued turn", () => {
   assert.equal(settlements.count, 1);
   assert.deepEqual(events[0], {
     type: "turn_completed",
-    payload: { stopReason: "end_turn", turnId: "turn-1" }
+    payload: {
+      stopReason: "end_turn",
+      turnId: "turn-1",
+      providerTurnId: "prompt-1"
+    }
   });
 });
 

--- a/packages/agent/claude-sdk-sidecar/src/turnLifecycle.ts
+++ b/packages/agent/claude-sdk-sidecar/src/turnLifecycle.ts
@@ -206,7 +206,14 @@ export class TurnLifecycle {
     }
     turn.settled = true;
     this.completedTurnCount += 1;
-    this.emit({ type, payload: { ...payload, turnId: turn.turnId } });
+    this.emit({
+      type,
+      payload: {
+        ...payload,
+        turnId: turn.turnId,
+        ...(turn.promptUuid ? { providerTurnId: turn.promptUuid } : {})
+      }
+    });
     this.clearContinuationStartTimer();
     this.active = undefined;
     this.activeIdValue = "";
@@ -299,6 +306,7 @@ export class TurnLifecycle {
         type: "goal_command_started",
         payload: {
           turnId: turn.turnId,
+          ...(turn.promptUuid ? { providerTurnId: turn.promptUuid } : {}),
           operationId: turn.goalOperationId,
           revision: turn.goalRevision,
           repairEpoch: turn.goalRepairEpoch ?? 0,
@@ -352,7 +360,14 @@ export class TurnLifecycle {
       return;
     }
     turn.settled = true;
-    this.emit({ type, payload: { ...payload, turnId: turn.turnId } });
+    this.emit({
+      type,
+      payload: {
+        ...payload,
+        turnId: turn.turnId,
+        ...(turn.promptUuid ? { providerTurnId: turn.promptUuid } : {})
+      }
+    });
   }
 
   private compactQueue(): void {

--- a/packages/agent/daemon/hostadapter/runtime.go
+++ b/packages/agent/daemon/hostadapter/runtime.go
@@ -270,13 +270,14 @@ func (a *RuntimeController) ResolveSessionFork(
 		return host.SessionForkDriverDescriptor{}, nil
 	}
 	return host.SessionForkDriverDescriptor{
-		Kind:                        firstNonEmptyString(capabilities.DriverKind, "daemon-runtime-native"),
-		Version:                     firstNonEmptyString(capabilities.DriverVersion, "v1"),
-		StateBindingMode:            host.SessionForkStateBindingMode(firstNonEmptyString(capabilities.StateBindingMode, string(host.SessionForkStateBindingHostCopy))),
-		FullSession:                 capabilities.FullSession,
-		ThroughTurn:                 capabilities.ThroughTurn,
-		ThroughProviderTurnIDs:      append([]string(nil), capabilities.ThroughProviderTurnIDs...),
-		ThroughProviderTurnIDsKnown: capabilities.ThroughProviderTurnIDsKnown,
+		Kind:                         firstNonEmptyString(capabilities.DriverKind, "daemon-runtime-native"),
+		Version:                      firstNonEmptyString(capabilities.DriverVersion, "v1"),
+		StateBindingMode:             host.SessionForkStateBindingMode(firstNonEmptyString(capabilities.StateBindingMode, string(host.SessionForkStateBindingHostCopy))),
+		DeterministicTargetSessionID: capabilities.DeterministicTargetSessionID,
+		FullSession:                  capabilities.FullSession,
+		ThroughTurn:                  capabilities.ThroughTurn,
+		ThroughProviderTurnIDs:       append([]string(nil), capabilities.ThroughProviderTurnIDs...),
+		ThroughProviderTurnIDsKnown:  capabilities.ThroughProviderTurnIDsKnown,
 	}, nil
 }
 
@@ -295,14 +296,12 @@ func (a *RuntimeController) ForkSession(
 			DeliveryDisposition: host.SessionForkDeliveryNotStarted,
 		}, host.ErrSessionForkUnsupported
 	}
-	// RequestID remains the Host's durable replay key. The daemon/provider fork
-	// transport has no provider-side idempotency key and intentionally does not
-	// receive it.
 	result, err := backend.Fork(ctx, agentruntime.SessionForkInput{
-		Source:          runtimeSession(input.Source),
-		ProviderTurnID:  input.SourceProviderTurnID,
-		ProviderTurnIDs: append([]string(nil), input.SourceProviderTurnIDs...),
-		TargetTitle:     input.TargetTitle,
+		Source:                  runtimeSession(input.Source),
+		ProviderTurnID:          input.SourceProviderTurnID,
+		ProviderTurnIDs:         append([]string(nil), input.SourceProviderTurnIDs...),
+		TargetProviderSessionID: strings.TrimSpace(input.TargetProviderSessionID),
+		TargetTitle:             input.TargetTitle,
 	})
 	mapped := host.RuntimeSessionForkResult{
 		ProviderSessionID:     strings.TrimSpace(result.ProviderSessionID),

--- a/packages/agent/daemon/hostadapter/runtime.go
+++ b/packages/agent/daemon/hostadapter/runtime.go
@@ -270,8 +270,9 @@ func (a *RuntimeController) ResolveSessionFork(
 		return host.SessionForkDriverDescriptor{}, nil
 	}
 	return host.SessionForkDriverDescriptor{
-		Kind:                        "daemon-runtime-native",
-		Version:                     "v1",
+		Kind:                        firstNonEmptyString(capabilities.DriverKind, "daemon-runtime-native"),
+		Version:                     firstNonEmptyString(capabilities.DriverVersion, "v1"),
+		StateBindingMode:            host.SessionForkStateBindingMode(firstNonEmptyString(capabilities.StateBindingMode, string(host.SessionForkStateBindingHostCopy))),
 		FullSession:                 capabilities.FullSession,
 		ThroughTurn:                 capabilities.ThroughTurn,
 		ThroughProviderTurnIDs:      append([]string(nil), capabilities.ThroughProviderTurnIDs...),
@@ -301,12 +302,19 @@ func (a *RuntimeController) ForkSession(
 		Source:          runtimeSession(input.Source),
 		ProviderTurnID:  input.SourceProviderTurnID,
 		ProviderTurnIDs: append([]string(nil), input.SourceProviderTurnIDs...),
+		TargetTitle:     input.TargetTitle,
 	})
 	mapped := host.RuntimeSessionForkResult{
-		ProviderSessionID: strings.TrimSpace(result.ProviderSessionID),
+		ProviderSessionID:     strings.TrimSpace(result.ProviderSessionID),
+		TargetProviderTurnIDs: append([]string(nil), result.TargetProviderTurnIDs...),
+		StateBindingMode:      host.SessionForkStateBindingMode(strings.TrimSpace(result.StateBindingMode)),
+		StateBindingReceipt:   strings.TrimSpace(result.StateBindingReceipt),
 		DeliveryDisposition: host.SessionForkDeliveryDisposition(
 			result.DeliveryDisposition,
 		),
+	}
+	if mapped.StateBindingMode == "" {
+		mapped.StateBindingMode = host.SessionForkStateBindingHostCopy
 	}
 	if err != nil {
 		if errors.Is(err, agentruntime.ErrSessionForkUnsupported) {
@@ -315,6 +323,15 @@ func (a *RuntimeController) ForkSession(
 		return mapped, mapRuntimeError(err)
 	}
 	return mapped, nil
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func (a *RuntimeController) GoalControl(ctx context.Context, input host.RuntimeGoalControlInput) (host.RuntimeGoalControlResult, error) {

--- a/packages/agent/daemon/providerregistry/claude_code.go
+++ b/packages/agent/daemon/providerregistry/claude_code.go
@@ -11,8 +11,9 @@ func claudeCodeDescriptor() ProviderDescriptor {
 	return ProviderDescriptor{
 		Identity: canonicalProviderIdentity(ClaudeCodeProviderID),
 		Runtime: RuntimeDescriptor{
-			Kind: RuntimeKindClaudeSDK,
-			Name: "claude-agent-sdk",
+			Kind:              RuntimeKindClaudeSDK,
+			Name:              "claude-agent-sdk",
+			NativeSessionFork: true,
 			Endpoint: RuntimeEndpointDescriptor{
 				BaseURLEnvVars: []string{
 					"ANTHROPIC_BASE_URL",

--- a/packages/agent/daemon/runtime/claude_sdk_event_projection_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_event_projection_test.go
@@ -38,6 +38,55 @@ func TestClaudeCodeSDKAdapterMapsSyntheticTurnStarted(t *testing.T) {
 	}
 }
 
+func TestClaudeCodeSDKAdapterCompletesCanonicalTurnByProviderIdentity(t *testing.T) {
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session := standardTestSession(ProviderClaudeCode)
+	adapterSession := &claudeSDKAdapterSession{
+		session:   session,
+		liveState: newClaudeSDKLiveState(),
+	}
+	adapter.beginClaudeSDKRootTurn(
+		adapterSession,
+		"canonical-turn-1",
+		"provider-prompt-1",
+	)
+
+	var published []activityshared.Event
+	adapter.SetSessionEventSink(func(agentSessionID string, events []activityshared.Event) {
+		if agentSessionID == session.AgentSessionID {
+			published = append(published, events...)
+		}
+	})
+	adapter.dispatchClaudeSDKEvent(
+		session.AgentSessionID,
+		adapterSession,
+		claudeSDKSidecarEvent{
+			Type: "turn_completed",
+			Payload: map[string]any{
+				"turnId":         "canonical-turn-1",
+				"providerTurnId": "provider-prompt-1",
+				"stopReason":     "end_turn",
+			},
+		},
+	)
+
+	var completion *activityshared.Event
+	for index := range published {
+		if published[index].Type == activityshared.EventRootProviderTurnCompleted {
+			completion = &published[index]
+			break
+		}
+	}
+	if completion == nil ||
+		completion.Payload.TurnID != "canonical-turn-1" ||
+		completion.Payload.ProviderTurnID != "provider-prompt-1" {
+		t.Fatalf("published=%#v, want canonical/provider completion identities", published)
+	}
+	if adapter.consumeClaudeSDKRootProviderTurn(adapterSession, "provider-prompt-1") {
+		t.Fatal("provider turn identity remained live after terminal dispatch")
+	}
+}
+
 func TestClaudeCodeSDKAdapterUsesSidecarAssistantMessageID(t *testing.T) {
 	adapter := NewClaudeCodeSDKAdapter(nil)
 	session := standardTestSession(ProviderClaudeCode)

--- a/packages/agent/daemon/runtime/claude_sdk_events.go
+++ b/packages/agent/daemon/runtime/claude_sdk_events.go
@@ -43,14 +43,15 @@ func (*ClaudeCodeSDKAdapter) applySidecarSessionEvent(adapterSession *claudeSDKA
 
 func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapterSession, session Session, turnID string, event claudeSDKSidecarEvent) ([]activityshared.Event, bool, error) {
 	adapterSession.applySessionPayload(&session, event.Payload)
-	providerTurnID := strings.TrimSpace(turnID)
 	eventTurnID := firstNonEmptyString(payloadString(event.Payload, "turnId"), payloadString(event.Payload, "turnID"))
-	if eventTurnID != "" && providerTurnID != "" && eventTurnID != providerTurnID {
+	if eventTurnID != "" && strings.TrimSpace(turnID) != "" && eventTurnID != strings.TrimSpace(turnID) {
 		return nil, false, nil
 	}
-	if providerTurnID == "" {
-		providerTurnID = eventTurnID
-	}
+	providerTurnID := firstNonEmptyString(
+		payloadString(event.Payload, "providerTurnId"),
+		strings.TrimSpace(turnID),
+		eventTurnID,
+	)
 	a.mu.Lock()
 	_, fencedGoalTurn := adapterSession.fencedGoalTurns[providerTurnID]
 	if fencedGoalTurn && isClaudeSDKTerminalEvent(event.Type) {
@@ -525,7 +526,11 @@ func (a *ClaudeCodeSDKAdapter) dispatchClaudeSDKEvent(agentSessionID string, ada
 	}
 	waiter := a.claudeSDKTurnWaiter(adapterSession, turnID)
 	if claudeSDKSidecarTurnTerminal(event.Type) {
-		known := a.consumeClaudeSDKRootProviderTurn(adapterSession, turnID)
+		providerTurnID := firstNonEmptyString(
+			payloadString(event.Payload, "providerTurnId"),
+			turnID,
+		)
+		known := a.consumeClaudeSDKRootProviderTurn(adapterSession, providerTurnID)
 		goalClearControlTurn := a.isGoalClearControlTurn(adapterSession, turnID)
 		if waiter == nil && !known && !goalClearControlTurn {
 			return

--- a/packages/agent/daemon/runtime/claude_sdk_execution.go
+++ b/packages/agent/daemon/runtime/claude_sdk_execution.go
@@ -25,7 +25,8 @@ func (a *ClaudeCodeSDKAdapter) Exec(
 		return nil, ErrSessionDisconnected
 	}
 	session.ProviderSessionID = adapterSession.providerSessionID
-	a.beginClaudeSDKRootTurn(adapterSession, turnID, turnID)
+	providerTurnID := newID()
+	a.beginClaudeSDKRootTurn(adapterSession, turnID, providerTurnID)
 	explicitDisplayPrompt, visibleText := explicitAndVisiblePromptText(content, displayPrompt)
 	events := make([]activityshared.Event, 0, 4)
 	emitEvents := func(next []activityshared.Event) {
@@ -44,7 +45,7 @@ func (a *ClaudeCodeSDKAdapter) Exec(
 		newTurnActivityEvent(session, EventTurnStarted, turnID, SessionStatusWorking, "", "", map[string]any{
 			"adapter": claudeSDKSidecarAdapterName,
 		}),
-		claudeSDKRootProviderTurnStartedEvent(session, turnID, turnID, map[string]any{
+		claudeSDKRootProviderTurnStartedEvent(session, turnID, providerTurnID, map[string]any{
 			"adapter": claudeSDKSidecarAdapterName,
 		}),
 	}
@@ -56,17 +57,17 @@ func (a *ClaudeCodeSDKAdapter) Exec(
 	waiter := a.registerClaudeSDKTurn(adapterSession, turnID, emit)
 	if err := a.startClaudeSDKReader(session.AgentSessionID, adapterSession); err != nil {
 		a.unregisterClaudeSDKTurn(adapterSession, turnID, waiter)
-		events = append(events, a.claudeSDKRootProviderFailureEvents(adapterSession, session, turnID, err)...)
+		events = append(events, a.claudeSDKRootProviderFailureEvents(adapterSession, session, turnID, providerTurnID, err)...)
 		return events, err
 	}
-	payload := claudeSDKExecPayload(ctx, session, turnID, content, visibleText)
+	payload := claudeSDKExecPayload(ctx, session, turnID, providerTurnID, content, visibleText)
 	if err := adapterSession.send(claudeSDKSidecarRequest{
 		ID:      newID(),
 		Type:    "exec",
 		Payload: payload,
 	}); err != nil {
 		a.unregisterClaudeSDKTurn(adapterSession, turnID, waiter)
-		events = append(events, a.claudeSDKRootProviderFailureEvents(adapterSession, session, turnID, err)...)
+		events = append(events, a.claudeSDKRootProviderFailureEvents(adapterSession, session, turnID, providerTurnID, err)...)
 		return events, err
 	}
 
@@ -76,7 +77,7 @@ func (a *ClaudeCodeSDKAdapter) Exec(
 			events = append(events, result.events...)
 		}
 		if result.err != nil {
-			events = append(events, a.claudeSDKRootProviderFailureEvents(adapterSession, session, turnID, result.err)...)
+			events = append(events, a.claudeSDKRootProviderFailureEvents(adapterSession, session, turnID, providerTurnID, result.err)...)
 		}
 		return events, result.err
 	case <-ctx.Done():
@@ -99,12 +100,14 @@ func claudeSDKExecPayload(
 	ctx context.Context,
 	session Session,
 	turnID string,
+	providerTurnID string,
 	content []PromptContentBlock,
 	visibleText string,
 ) map[string]any {
 	payload := map[string]any{
 		"agentSessionId": session.AgentSessionID,
 		"turnId":         turnID,
+		"providerTurnId": providerTurnID,
 		"prompt":         promptTextForClaudeSDK(content, visibleText),
 		"content":        promptContentForClaudeSDK(content, visibleText),
 	}
@@ -114,7 +117,7 @@ func claudeSDKExecPayload(
 	return payload
 }
 
-func (a *ClaudeCodeSDKAdapter) claudeSDKRootProviderFailureEvents(adapterSession *claudeSDKAdapterSession, session Session, turnID string, err error) []activityshared.Event {
+func (a *ClaudeCodeSDKAdapter) claudeSDKRootProviderFailureEvents(adapterSession *claudeSDKAdapterSession, session Session, turnID string, providerTurnID string, err error) []activityshared.Event {
 	events := a.finishClaudeSDKTurnLifecycle(adapterSession, session, turnID, claudeSDKTurnFinishFailed, "provider_transport_failed")
 	metadata := map[string]any{"adapter": claudeSDKSidecarAdapterName}
 	if err != nil {
@@ -123,11 +126,11 @@ func (a *ClaudeCodeSDKAdapter) claudeSDKRootProviderFailureEvents(adapterSession
 	events = append(events, claudeSDKRootProviderTurnCompletedEvent(
 		session,
 		turnID,
-		turnID,
+		providerTurnID,
 		activityshared.TurnOutcomeFailed,
 		metadata,
 	))
-	a.consumeClaudeSDKRootProviderTurn(adapterSession, turnID)
+	a.consumeClaudeSDKRootProviderTurn(adapterSession, providerTurnID)
 	return events
 }
 

--- a/packages/agent/daemon/runtime/claude_sdk_fork.go
+++ b/packages/agent/daemon/runtime/claude_sdk_fork.go
@@ -36,7 +36,7 @@ func (a *ClaudeCodeSDKAdapter) ForkCapabilities(
 	turnIDs, ok := claudeSDKPayloadStringList(event.Payload, "providerTurnIds")
 	if !ok {
 		return SessionForkCapabilities{}, errors.New(
-			"Claude SDK fork inspection returned invalid provider turn identities",
+			"claude SDK fork inspection returned invalid provider turn identities",
 		)
 	}
 	return SessionForkCapabilities{
@@ -95,7 +95,7 @@ func (a *ClaudeCodeSDKAdapter) Fork(
 	if !ok {
 		result.DeliveryDisposition = SessionForkDeliveryUnknown
 		return result, errors.New(
-			"Claude SDK fork returned invalid target provider turn identities",
+			"claude SDK fork returned invalid target provider turn identities",
 		)
 	}
 	result.ProviderSessionID = payloadString(event.Payload, "providerSessionId")
@@ -110,7 +110,7 @@ func (a *ClaudeCodeSDKAdapter) Fork(
 		result.StateBindingReceipt == "" ||
 		result.DeliveryDisposition != SessionForkDeliveryAccepted {
 		result.DeliveryDisposition = SessionForkDeliveryUnknown
-		return result, errors.New("Claude SDK fork returned incomplete verification evidence")
+		return result, errors.New("claude SDK fork returned incomplete verification evidence")
 	}
 	return result, nil
 }

--- a/packages/agent/daemon/runtime/claude_sdk_fork.go
+++ b/packages/agent/daemon/runtime/claude_sdk_fork.go
@@ -7,7 +7,11 @@ import (
 )
 
 const (
-	claudeSDKForkDriverKind    = "claude-agent-sdk-session-fork"
+	claudeSDKForkDriverKind = "claude-agent-sdk-session-fork"
+	// sidecar-v4 uses the official SDK query resume/fork options because the
+	// pinned direct forkSession API cannot accept Host's deterministic child
+	// UUID. On an SDK upgrade, check for caller-selected child identity,
+	// idempotency, and atomic/reconcilable persistence before replacing it.
 	claudeSDKForkDriverVersion = "0.3.201/sidecar-v4-deterministic"
 )
 

--- a/packages/agent/daemon/runtime/claude_sdk_fork.go
+++ b/packages/agent/daemon/runtime/claude_sdk_fork.go
@@ -1,0 +1,192 @@
+package agentruntime
+
+import (
+	"context"
+	"errors"
+	"strings"
+)
+
+const (
+	claudeSDKForkDriverKind    = "claude-agent-sdk-session-fork"
+	claudeSDKForkDriverVersion = "0.3.201/sidecar-v3"
+)
+
+func (a *ClaudeCodeSDKAdapter) ForkCapabilities(
+	ctx context.Context,
+	source Session,
+) (SessionForkCapabilities, error) {
+	if a == nil || a.transport == nil {
+		return SessionForkCapabilities{}, nil
+	}
+	event, _, err := a.statelessClaudeSDKForkRequest(
+		ctx,
+		source,
+		claudeSDKSidecarRequest{
+			ID:   newID(),
+			Type: "inspect_fork_checkpoints",
+			Payload: map[string]any{
+				"providerSessionId": strings.TrimSpace(source.ProviderSessionID),
+				"cwd":               strings.TrimSpace(source.CWD),
+			},
+		},
+	)
+	if err != nil {
+		return SessionForkCapabilities{}, err
+	}
+	turnIDs, ok := claudeSDKPayloadStringList(event.Payload, "providerTurnIds")
+	if !ok {
+		return SessionForkCapabilities{}, errors.New(
+			"Claude SDK fork inspection returned invalid provider turn identities",
+		)
+	}
+	return SessionForkCapabilities{
+		DriverKind:                  claudeSDKForkDriverKind,
+		DriverVersion:               claudeSDKForkDriverVersion,
+		StateBindingMode:            "provider_owned",
+		ThroughTurn:                 len(turnIDs) != 0,
+		ThroughProviderTurnIDs:      turnIDs,
+		ThroughProviderTurnIDsKnown: true,
+	}, nil
+}
+
+func (a *ClaudeCodeSDKAdapter) Fork(
+	ctx context.Context,
+	input SessionForkInput,
+) (SessionForkResult, error) {
+	result := SessionForkResult{
+		ForkedFromProviderSessionID: strings.TrimSpace(input.Source.ProviderSessionID),
+		ThroughProviderTurnID:       strings.TrimSpace(input.ProviderTurnID),
+		DeliveryDisposition:         SessionForkDeliveryNotStarted,
+	}
+	if a == nil || a.transport == nil {
+		return result, ErrSessionForkUnsupported
+	}
+	event, sent, err := a.statelessClaudeSDKForkRequest(
+		ctx,
+		input.Source,
+		claudeSDKSidecarRequest{
+			ID:   newID(),
+			Type: "fork_session",
+			Payload: map[string]any{
+				"providerSessionId": strings.TrimSpace(input.Source.ProviderSessionID),
+				"providerTurnId":    strings.TrimSpace(input.ProviderTurnID),
+				"providerTurnIds":   append([]string(nil), input.ProviderTurnIDs...),
+				"cwd":               strings.TrimSpace(input.Source.CWD),
+				"title":             strings.TrimSpace(input.TargetTitle),
+			},
+		},
+	)
+	if err != nil {
+		if sent {
+			result.DeliveryDisposition = SessionForkDeliveryUnknown
+		}
+		if eventDisposition := SessionForkDeliveryDisposition(
+			payloadString(event.Payload, "deliveryDisposition"),
+		); eventDisposition == SessionForkDeliveryNotStarted ||
+			eventDisposition == SessionForkDeliveryUnknown {
+			result.DeliveryDisposition = eventDisposition
+		}
+		return result, err
+	}
+	targetTurnIDs, ok := claudeSDKPayloadStringList(
+		event.Payload,
+		"targetProviderTurnIds",
+	)
+	if !ok {
+		result.DeliveryDisposition = SessionForkDeliveryUnknown
+		return result, errors.New(
+			"Claude SDK fork returned invalid target provider turn identities",
+		)
+	}
+	result.ProviderSessionID = payloadString(event.Payload, "providerSessionId")
+	result.TargetProviderTurnIDs = targetTurnIDs
+	result.StateBindingMode = payloadString(event.Payload, "stateBindingMode")
+	result.StateBindingReceipt = payloadString(event.Payload, "stateBindingReceipt")
+	result.DeliveryDisposition = SessionForkDeliveryDisposition(
+		payloadString(event.Payload, "deliveryDisposition"),
+	)
+	if result.ProviderSessionID == "" ||
+		result.StateBindingMode != "provider_owned" ||
+		result.StateBindingReceipt == "" ||
+		result.DeliveryDisposition != SessionForkDeliveryAccepted {
+		result.DeliveryDisposition = SessionForkDeliveryUnknown
+		return result, errors.New("Claude SDK fork returned incomplete verification evidence")
+	}
+	return result, nil
+}
+
+func (a *ClaudeCodeSDKAdapter) statelessClaudeSDKForkRequest(
+	ctx context.Context,
+	session Session,
+	request claudeSDKSidecarRequest,
+) (claudeSDKSidecarEvent, bool, error) {
+	spec, cleanup, err := prepareProviderLaunch(ctx, a.preparer, session, ProcessSpec{
+		Provider:       strings.TrimSpace(session.Provider),
+		AgentSessionID: session.AgentSessionID,
+		RoomID:         session.RoomID,
+		CWD:            session.CWD,
+		Command:        claudeSDKSidecarCommand(session.Env),
+		Env:            claudeSDKSidecarEnv(session),
+		DirectStart:    true,
+	})
+	if err != nil {
+		return claudeSDKSidecarEvent{}, false, err
+	}
+	conn, err := a.transport.Start(ctx, spec)
+	if err != nil {
+		cleanupPreparedLaunch(cleanup)
+		return claudeSDKSidecarEvent{}, false, err
+	}
+	conn = wrapProviderLaunchCleanup(conn, cleanup)
+	defer conn.Close()
+	adapterSession := &claudeSDKAdapterSession{
+		conn:   conn,
+		reader: &claudeSDKLineReader{conn: conn},
+	}
+	if err := adapterSession.send(request); err != nil {
+		return claudeSDKSidecarEvent{}, false, err
+	}
+	event, err := adapterSession.roundTripDirectResponse(ctx, request)
+	if err != nil {
+		return event, true, err
+	}
+	return event, true, nil
+}
+
+func claudeSDKPayloadStringList(
+	payload map[string]any,
+	key string,
+) ([]string, bool) {
+	raw, exists := payload[key]
+	if !exists {
+		return nil, false
+	}
+	values, ok := raw.([]any)
+	if !ok {
+		if typed, typedOK := raw.([]string); typedOK {
+			values = make([]any, len(typed))
+			for index := range typed {
+				values[index] = typed[index]
+			}
+		} else {
+			return nil, false
+		}
+	}
+	result := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, rawValue := range values {
+		value, ok := rawValue.(string)
+		value = strings.TrimSpace(value)
+		if !ok || value == "" {
+			return nil, false
+		}
+		if _, duplicate := seen[value]; duplicate {
+			return nil, false
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result, true
+}
+
+var _ SessionForkAdapter = (*ClaudeCodeSDKAdapter)(nil)

--- a/packages/agent/daemon/runtime/claude_sdk_fork.go
+++ b/packages/agent/daemon/runtime/claude_sdk_fork.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	claudeSDKForkDriverKind    = "claude-agent-sdk-session-fork"
-	claudeSDKForkDriverVersion = "0.3.201/sidecar-v3"
+	claudeSDKForkDriverVersion = "0.3.201/sidecar-v4-deterministic"
 )
 
 func (a *ClaudeCodeSDKAdapter) ForkCapabilities(
@@ -40,12 +40,13 @@ func (a *ClaudeCodeSDKAdapter) ForkCapabilities(
 		)
 	}
 	return SessionForkCapabilities{
-		DriverKind:                  claudeSDKForkDriverKind,
-		DriverVersion:               claudeSDKForkDriverVersion,
-		StateBindingMode:            "provider_owned",
-		ThroughTurn:                 len(turnIDs) != 0,
-		ThroughProviderTurnIDs:      turnIDs,
-		ThroughProviderTurnIDsKnown: true,
+		DriverKind:                   claudeSDKForkDriverKind,
+		DriverVersion:                claudeSDKForkDriverVersion,
+		StateBindingMode:             "provider_owned",
+		DeterministicTargetSessionID: true,
+		ThroughTurn:                  len(turnIDs) != 0,
+		ThroughProviderTurnIDs:       turnIDs,
+		ThroughProviderTurnIDsKnown:  true,
 	}, nil
 }
 
@@ -61,6 +62,11 @@ func (a *ClaudeCodeSDKAdapter) Fork(
 	if a == nil || a.transport == nil {
 		return result, ErrSessionForkUnsupported
 	}
+	targetProviderSessionID := strings.TrimSpace(input.TargetProviderSessionID)
+	if targetProviderSessionID == "" ||
+		targetProviderSessionID == result.ForkedFromProviderSessionID {
+		return result, errors.New("deterministic Claude fork target session id is required")
+	}
 	event, sent, err := a.statelessClaudeSDKForkRequest(
 		ctx,
 		input.Source,
@@ -68,11 +74,12 @@ func (a *ClaudeCodeSDKAdapter) Fork(
 			ID:   newID(),
 			Type: "fork_session",
 			Payload: map[string]any{
-				"providerSessionId": strings.TrimSpace(input.Source.ProviderSessionID),
-				"providerTurnId":    strings.TrimSpace(input.ProviderTurnID),
-				"providerTurnIds":   append([]string(nil), input.ProviderTurnIDs...),
-				"cwd":               strings.TrimSpace(input.Source.CWD),
-				"title":             strings.TrimSpace(input.TargetTitle),
+				"providerSessionId":       strings.TrimSpace(input.Source.ProviderSessionID),
+				"providerTurnId":          strings.TrimSpace(input.ProviderTurnID),
+				"providerTurnIds":         append([]string(nil), input.ProviderTurnIDs...),
+				"targetProviderSessionId": targetProviderSessionID,
+				"cwd":                     strings.TrimSpace(input.Source.CWD),
+				"title":                   strings.TrimSpace(input.TargetTitle),
 			},
 		},
 	)
@@ -106,6 +113,7 @@ func (a *ClaudeCodeSDKAdapter) Fork(
 		payloadString(event.Payload, "deliveryDisposition"),
 	)
 	if result.ProviderSessionID == "" ||
+		result.ProviderSessionID != targetProviderSessionID ||
 		result.StateBindingMode != "provider_owned" ||
 		result.StateBindingReceipt == "" ||
 		result.DeliveryDisposition != SessionForkDeliveryAccepted {

--- a/packages/agent/daemon/runtime/claude_sdk_fork_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_fork_test.go
@@ -27,6 +27,7 @@ func TestClaudeSDKForkCapabilitiesUsesStatelessTranscriptInspection(t *testing.T
 	}
 	if capabilities.DriverKind != claudeSDKForkDriverKind ||
 		capabilities.DriverVersion != claudeSDKForkDriverVersion ||
+		!capabilities.DeterministicTargetSessionID ||
 		!capabilities.ThroughTurn ||
 		!capabilities.ThroughProviderTurnIDsKnown ||
 		!reflect.DeepEqual(
@@ -60,8 +61,9 @@ func TestClaudeSDKForkReturnsProviderOwnedIdentityEvidence(t *testing.T) {
 
 	result, err := adapter.Fork(t.Context(), SessionForkInput{
 		Source: source, ProviderTurnID: "prompt-2",
-		ProviderTurnIDs: []string{"prompt-1", "prompt-2"},
-		TargetTitle:     "Claude session (2)",
+		ProviderTurnIDs:         []string{"prompt-1", "prompt-2"},
+		TargetProviderSessionID: "claude-child",
+		TargetTitle:             "Claude session (2)",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -78,7 +80,8 @@ func TestClaudeSDKForkReturnsProviderOwnedIdentityEvidence(t *testing.T) {
 	}
 	requests := conn.requests()
 	if len(requests) != 1 || requests[0].Type != "fork_session" ||
-		payloadString(requests[0].Payload, "title") != "Claude session (2)" {
+		payloadString(requests[0].Payload, "title") != "Claude session (2)" ||
+		payloadString(requests[0].Payload, "targetProviderSessionId") != "claude-child" {
 		t.Fatalf("requests=%#v", requests)
 	}
 }
@@ -96,7 +99,8 @@ func TestClaudeSDKForkPreservesUnknownDispositionAfterDispatch(t *testing.T) {
 	source.ProviderSessionID = "claude-source"
 	result, err := adapter.Fork(t.Context(), SessionForkInput{
 		Source: source, ProviderTurnID: "prompt-1",
-		ProviderTurnIDs: []string{"prompt-1"}, TargetTitle: "Child",
+		ProviderTurnIDs:         []string{"prompt-1"},
+		TargetProviderSessionID: "claude-child", TargetTitle: "Child",
 	})
 	if err == nil || result.DeliveryDisposition != SessionForkDeliveryUnknown {
 		t.Fatalf("result=%#v error=%v", result, err)
@@ -137,7 +141,8 @@ func TestClaudeSDKForkedChildCanResumeAndStartTurn(t *testing.T) {
 
 	result, err := adapter.Fork(t.Context(), SessionForkInput{
 		Source: source, ProviderTurnID: "prompt-1",
-		ProviderTurnIDs: []string{"prompt-1"}, TargetTitle: "Child",
+		ProviderTurnIDs:         []string{"prompt-1"},
+		TargetProviderSessionID: "claude-child", TargetTitle: "Child",
 	})
 	if err != nil {
 		t.Fatalf("Fork: %v", err)

--- a/packages/agent/daemon/runtime/claude_sdk_fork_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_fork_test.go
@@ -1,0 +1,166 @@
+package agentruntime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"reflect"
+	"sync"
+	"testing"
+)
+
+func TestClaudeSDKForkCapabilitiesUsesStatelessTranscriptInspection(t *testing.T) {
+	conn := &claudeSDKForkTestConnection{
+		responseType: "ok",
+		responsePayload: map[string]any{
+			"providerTurnIds": []string{"prompt-1", "prompt-2"},
+		},
+	}
+	adapter := NewClaudeCodeSDKAdapter(claudeSDKForkTestTransport{conn: conn})
+	source := standardTestSession(ProviderClaudeCode)
+	source.ProviderSessionID = "claude-source"
+
+	capabilities, err := adapter.ForkCapabilities(t.Context(), source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if capabilities.DriverKind != claudeSDKForkDriverKind ||
+		capabilities.DriverVersion != claudeSDKForkDriverVersion ||
+		!capabilities.ThroughTurn ||
+		!capabilities.ThroughProviderTurnIDsKnown ||
+		!reflect.DeepEqual(
+			capabilities.ThroughProviderTurnIDs,
+			[]string{"prompt-1", "prompt-2"},
+		) {
+		t.Fatalf("capabilities=%#v", capabilities)
+	}
+	requests := conn.requests()
+	if len(requests) != 1 ||
+		requests[0].Type != "inspect_fork_checkpoints" ||
+		payloadString(requests[0].Payload, "providerSessionId") != "claude-source" {
+		t.Fatalf("requests=%#v", requests)
+	}
+}
+
+func TestClaudeSDKForkReturnsProviderOwnedIdentityEvidence(t *testing.T) {
+	conn := &claudeSDKForkTestConnection{
+		responseType: "ok",
+		responsePayload: map[string]any{
+			"providerSessionId":     "claude-child",
+			"targetProviderTurnIds": []string{"child-prompt-1", "child-prompt-2"},
+			"stateBindingMode":      "provider_owned",
+			"stateBindingReceipt":   "claude-sdk-fork-v1:receipt",
+			"deliveryDisposition":   "accepted",
+		},
+	}
+	adapter := NewClaudeCodeSDKAdapter(claudeSDKForkTestTransport{conn: conn})
+	source := standardTestSession(ProviderClaudeCode)
+	source.ProviderSessionID = "claude-source"
+
+	result, err := adapter.Fork(t.Context(), SessionForkInput{
+		Source: source, ProviderTurnID: "prompt-2",
+		ProviderTurnIDs: []string{"prompt-1", "prompt-2"},
+		TargetTitle:     "Claude session (2)",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ProviderSessionID != "claude-child" ||
+		result.DeliveryDisposition != SessionForkDeliveryAccepted ||
+		result.StateBindingMode != "provider_owned" ||
+		result.StateBindingReceipt == "" ||
+		!reflect.DeepEqual(
+			result.TargetProviderTurnIDs,
+			[]string{"child-prompt-1", "child-prompt-2"},
+		) {
+		t.Fatalf("result=%#v", result)
+	}
+	requests := conn.requests()
+	if len(requests) != 1 || requests[0].Type != "fork_session" ||
+		payloadString(requests[0].Payload, "title") != "Claude session (2)" {
+		t.Fatalf("requests=%#v", requests)
+	}
+}
+
+func TestClaudeSDKForkPreservesUnknownDispositionAfterDispatch(t *testing.T) {
+	conn := &claudeSDKForkTestConnection{
+		responseType: "error",
+		responsePayload: map[string]any{
+			"error":               "Claude SDK session fork failed",
+			"deliveryDisposition": "unknown",
+		},
+	}
+	adapter := NewClaudeCodeSDKAdapter(claudeSDKForkTestTransport{conn: conn})
+	source := standardTestSession(ProviderClaudeCode)
+	source.ProviderSessionID = "claude-source"
+	result, err := adapter.Fork(t.Context(), SessionForkInput{
+		Source: source, ProviderTurnID: "prompt-1",
+		ProviderTurnIDs: []string{"prompt-1"}, TargetTitle: "Child",
+	})
+	if err == nil || result.DeliveryDisposition != SessionForkDeliveryUnknown {
+		t.Fatalf("result=%#v error=%v", result, err)
+	}
+}
+
+type claudeSDKForkTestTransport struct {
+	conn ProcessConnection
+}
+
+func (t claudeSDKForkTestTransport) Start(
+	context.Context,
+	ProcessSpec,
+) (ProcessConnection, error) {
+	if t.conn == nil {
+		return nil, errors.New("test connection is unavailable")
+	}
+	return t.conn, nil
+}
+
+type claudeSDKForkTestConnection struct {
+	mu              sync.Mutex
+	sent            []claudeSDKSidecarRequest
+	frames          []ProcessFrame
+	responseType    string
+	responsePayload map[string]any
+}
+
+func (c *claudeSDKForkTestConnection) Send(data []byte) error {
+	var request claudeSDKSidecarRequest
+	if err := json.Unmarshal(data, &request); err != nil {
+		return err
+	}
+	response, err := json.Marshal(claudeSDKSidecarEvent{
+		Version: claudeSDKSidecarProtocolVersion,
+		ID:      request.ID,
+		Type:    c.responseType,
+		Payload: clonePayload(c.responsePayload),
+	})
+	if err != nil {
+		return err
+	}
+	c.mu.Lock()
+	c.sent = append(c.sent, request)
+	c.frames = append(c.frames, ProcessFrame{Stdout: append(response, '\n')})
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *claudeSDKForkTestConnection) Recv() (ProcessFrame, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.frames) == 0 {
+		return ProcessFrame{}, io.EOF
+	}
+	frame := c.frames[0]
+	c.frames = c.frames[1:]
+	return frame, nil
+}
+
+func (*claudeSDKForkTestConnection) Close() error { return nil }
+
+func (c *claudeSDKForkTestConnection) requests() []claudeSDKSidecarRequest {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]claudeSDKSidecarRequest(nil), c.sent...)
+}

--- a/packages/agent/daemon/runtime/claude_sdk_fork_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_fork_test.go
@@ -103,6 +103,98 @@ func TestClaudeSDKForkPreservesUnknownDispositionAfterDispatch(t *testing.T) {
 	}
 }
 
+func TestClaudeSDKForkedChildCanResumeAndStartTurn(t *testing.T) {
+	forkConn := &claudeSDKForkTestConnection{
+		responseType: "ok",
+		responsePayload: map[string]any{
+			"providerSessionId":     "claude-child",
+			"targetProviderTurnIds": []string{"child-prompt-1"},
+			"stateBindingMode":      "provider_owned",
+			"stateBindingReceipt":   "claude-sdk-fork-v1:receipt",
+			"deliveryDisposition":   "accepted",
+		},
+	}
+	childConn := &scriptedClaudeSDKConnection{
+		frames: []ProcessFrame{
+			{
+				Stdout: []byte(
+					`{"type":"session_started","payload":{"providerSessionId":"claude-child"}}` + "\n",
+				),
+			},
+			{
+				Stdout: []byte(
+					`{"type":"turn_completed","payload":{"turnId":"canonical-child-turn","stopReason":"end_turn"}}` + "\n",
+				),
+			},
+		},
+	}
+	transport := &claudeSDKForkSequenceTransport{
+		connections: []ProcessConnection{forkConn, childConn},
+	}
+	adapter := NewClaudeCodeSDKAdapter(transport)
+	source := standardTestSession(ProviderClaudeCode)
+	source.ProviderSessionID = "claude-source"
+
+	result, err := adapter.Fork(t.Context(), SessionForkInput{
+		Source: source, ProviderTurnID: "prompt-1",
+		ProviderTurnIDs: []string{"prompt-1"}, TargetTitle: "Child",
+	})
+	if err != nil {
+		t.Fatalf("Fork: %v", err)
+	}
+	target := source
+	target.AgentSessionID = "agent-session-child"
+	target.ProviderSessionID = result.ProviderSessionID
+	target.RuntimeContext = map[string]any{
+		"resumeCursor": map[string]any{
+			"kind":            "claude-agent-sdk",
+			"version":         int64(1),
+			"resume":          "claude-source",
+			"resumeSessionAt": "source-answer-1",
+			"turnCount":       int64(1),
+		},
+	}
+	if err := adapter.Resume(t.Context(), target); err != nil {
+		t.Fatalf("Resume forked child: %v", err)
+	}
+	if !adapter.HasLiveSession(target) {
+		t.Fatal("forked child did not retain a live resumed session")
+	}
+
+	if _, err := adapter.Exec(
+		t.Context(),
+		target,
+		[]PromptContentBlock{{Type: "text", Text: "continue from fork"}},
+		"",
+		"canonical-child-turn",
+		nil,
+		nil,
+	); err != nil {
+		t.Fatalf("Exec forked child: %v", err)
+	}
+	requests := childConn.sentRequests()
+	if len(requests) != 2 ||
+		requests[0].Type != "start" ||
+		requests[1].Type != "exec" {
+		t.Fatalf("child requests=%#v, want start then exec", requests)
+	}
+	if requests[0].Payload["providerSessionId"] != "claude-child" {
+		t.Fatalf(
+			"child start providerSessionId=%#v",
+			requests[0].Payload["providerSessionId"],
+		)
+	}
+	if cursor := payloadMap(requests[0].Payload, "resumeCursor"); len(cursor) != 0 {
+		t.Fatalf("child start reused source resume cursor: %#v", cursor)
+	}
+	if requests[1].Payload["agentSessionId"] != "agent-session-child" {
+		t.Fatalf("child exec payload=%#v", requests[1].Payload)
+	}
+	if transport.starts() != 2 {
+		t.Fatalf("process starts=%d, want fork sidecar and child runtime", transport.starts())
+	}
+}
+
 type claudeSDKForkTestTransport struct {
 	conn ProcessConnection
 }
@@ -163,4 +255,31 @@ func (c *claudeSDKForkTestConnection) requests() []claudeSDKSidecarRequest {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return append([]claudeSDKSidecarRequest(nil), c.sent...)
+}
+
+type claudeSDKForkSequenceTransport struct {
+	mu          sync.Mutex
+	connections []ProcessConnection
+	startCount  int
+}
+
+func (t *claudeSDKForkSequenceTransport) Start(
+	_ context.Context,
+	_ ProcessSpec,
+) (ProcessConnection, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.startCount++
+	if len(t.connections) == 0 {
+		return nil, errors.New("test connection sequence is exhausted")
+	}
+	conn := t.connections[0]
+	t.connections = t.connections[1:]
+	return conn, nil
+}
+
+func (t *claudeSDKForkSequenceTransport) starts() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.startCount
 }

--- a/packages/agent/daemon/runtime/claude_sdk_goal.go
+++ b/packages/agent/daemon/runtime/claude_sdk_goal.go
@@ -427,6 +427,7 @@ func (a *ClaudeCodeSDKAdapter) sendGoalCommandExec(
 	payload := map[string]any{
 		"agentSessionId": session.AgentSessionID,
 		"turnId":         turnID,
+		"providerTurnId": turnID,
 		"prompt":         command,
 		"content":        promptContentForClaudeSDK(nil, command),
 	}

--- a/packages/agent/daemon/runtime/claude_sdk_goal_lifecycle_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_goal_lifecycle_test.go
@@ -646,6 +646,9 @@ func TestClaudeSDKGoalArmTurnCarriesDurableGoalIdentity(t *testing.T) {
 		t.Fatalf("ApplyGoal set: %v", err)
 	}
 	turnID := payloadString(setRequest.Payload, "turnId")
+	if payloadString(setRequest.Payload, "providerTurnId") != turnID {
+		t.Fatalf("goal provider turn id != SDK prompt UUID: %#v", setRequest.Payload)
+	}
 	if payloadString(setRequest.Payload, "goalOperationId") != "goal-op-7" || payloadInt64(setRequest.Payload, "goalRevision") != 7 {
 		t.Fatalf("goal exec payload = %#v", setRequest.Payload)
 	}

--- a/packages/agent/daemon/runtime/claude_sdk_protocol.go
+++ b/packages/agent/daemon/runtime/claude_sdk_protocol.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-const claudeSDKSidecarProtocolVersion = 2
+const claudeSDKSidecarProtocolVersion = 3
 
 type claudeSDKSidecarRequest struct {
 	Version int            `json:"version"`

--- a/packages/agent/daemon/runtime/claude_sdk_session.go
+++ b/packages/agent/daemon/runtime/claude_sdk_session.go
@@ -291,7 +291,8 @@ func claudeSDKResumeCursorFromSession(session Session) map[string]any {
 		return nil
 	}
 	resume := strings.TrimSpace(asString(cursor["resume"]))
-	if resume == "" {
+	providerSessionID := strings.TrimSpace(session.ProviderSessionID)
+	if resume == "" || providerSessionID == "" || resume != providerSessionID {
 		return nil
 	}
 	return clonePayload(cursor)

--- a/packages/agent/daemon/runtime/claude_sdk_session_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_session_test.go
@@ -414,6 +414,43 @@ func TestClaudeCodeSDKAdapterStartSendsResumeCursor(t *testing.T) {
 	}
 }
 
+func TestClaudeCodeSDKAdapterStartDropsResumeCursorFromForkSource(t *testing.T) {
+	conn := &scriptedClaudeSDKConnection{
+		frames: []ProcessFrame{{
+			Stdout: []byte(`{"type":"session_started","payload":{"providerSessionId":"provider-session-child"}}` + "\n"),
+		}},
+	}
+	adapter := NewClaudeCodeSDKAdapter(&recordingClaudeSDKTransport{conn: conn})
+	session := standardTestSession(ProviderClaudeCode)
+	session.ProviderSessionID = "provider-session-child"
+	session.RuntimeContext = map[string]any{
+		"resumeCursor": map[string]any{
+			"kind":            "claude-agent-sdk",
+			"version":         int64(1),
+			"resume":          "provider-session-source",
+			"resumeSessionAt": "source-assistant-1",
+			"turnCount":       int64(7),
+		},
+	}
+
+	if _, err := adapter.Start(t.Context(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	sent := conn.sentRequests()
+	if len(sent) != 1 || sent[0].Type != "start" {
+		t.Fatalf("sent requests = %#v, want start", sent)
+	}
+	if cursor := payloadMap(sent[0].Payload, "resumeCursor"); len(cursor) != 0 {
+		t.Fatalf("resume cursor payload = %#v, want stale source cursor removed", cursor)
+	}
+	if sent[0].Payload["providerSessionId"] != "provider-session-child" {
+		t.Fatalf(
+			"provider session id = %#v, want forked child",
+			sent[0].Payload["providerSessionId"],
+		)
+	}
+}
+
 func TestClaudeCodeSDKAdapterSessionStateUpdatesResumeCursor(t *testing.T) {
 	adapter := NewClaudeCodeSDKAdapter(nil)
 	session := standardTestSession(ProviderClaudeCode)

--- a/packages/agent/daemon/runtime/claude_sdk_session_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_session_test.go
@@ -566,6 +566,13 @@ func TestClaudeCodeSDKAdapterExecSendsStructuredPromptContent(t *testing.T) {
 	if sent[0].Payload["prompt"] != "what is in this image?" {
 		t.Fatalf("exec prompt = %#v, want legacy text prompt", sent[0].Payload["prompt"])
 	}
+	providerTurnID := payloadString(sent[0].Payload, "providerTurnId")
+	if providerTurnID == "" || providerTurnID == "turn-image" {
+		t.Fatalf(
+			"exec provider turn id = %q, want a distinct SDK prompt UUID",
+			providerTurnID,
+		)
+	}
 	content, ok := sent[0].Payload["content"].([]any)
 	if !ok || len(content) != 2 {
 		t.Fatalf("exec content = %#v, want text and image blocks", sent[0].Payload["content"])

--- a/packages/agent/daemon/runtime/claude_sdk_transport_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_transport_test.go
@@ -64,6 +64,7 @@ func TestClaudeCodeSDKAdapterExecWithSidecarTestDriver(t *testing.T) {
 	var sawUser bool
 	var assistantText string
 	var completed bool
+	var startedProviderTurnID, completedProviderTurnID string
 	for _, event := range events {
 		if event.Type == activityshared.EventMessageAppended &&
 			event.Payload.Role == activityshared.MessageRoleUser &&
@@ -77,6 +78,10 @@ func TestClaudeCodeSDKAdapterExecWithSidecarTestDriver(t *testing.T) {
 		if event.Type == activityshared.EventRootProviderTurnCompleted &&
 			event.Payload.TurnOutcome == string(activityshared.TurnOutcomeCompleted) {
 			completed = true
+			completedProviderTurnID = event.Payload.ProviderTurnID
+		}
+		if event.Type == activityshared.EventRootProviderTurnStarted {
+			startedProviderTurnID = event.Payload.ProviderTurnID
 		}
 	}
 	if !sawUser {
@@ -87,6 +92,15 @@ func TestClaudeCodeSDKAdapterExecWithSidecarTestDriver(t *testing.T) {
 	}
 	if !completed {
 		t.Fatalf("events missing root provider completion: %#v", events)
+	}
+	if startedProviderTurnID == "" ||
+		startedProviderTurnID == "turn-sdk-1" ||
+		completedProviderTurnID != startedProviderTurnID {
+		t.Fatalf(
+			"provider turn lifecycle start=%q complete=%q, want one real SDK prompt UUID",
+			startedProviderTurnID,
+			completedProviderTurnID,
+		)
 	}
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_fork.go
+++ b/packages/agent/daemon/runtime/codex_appserver_fork.go
@@ -77,6 +77,7 @@ func (a *CodexAppServerAdapter) ForkCapabilities(
 
 func codexForkCapabilitiesForVersion(version [3]int) SessionForkCapabilities {
 	return SessionForkCapabilities{
+		StateBindingMode: "host_copy",
 		// The provider protocol can fork a whole thread, but Tutti must not
 		// advertise that structural capability until the Host/API/Engine/UI
 		// full-session Point is end-to-end. Capabilities describe the product

--- a/packages/agent/daemon/runtime/tutti_mode_host_context_test.go
+++ b/packages/agent/daemon/runtime/tutti_mode_host_context_test.go
@@ -253,6 +253,7 @@ func TestClaudeSDKExecPayloadKeepsTuttiContextSeparateFromUserInput(t *testing.T
 		ctx,
 		Session{AgentSessionID: "session-1"},
 		"turn-1",
+		"provider-turn-1",
 		content,
 		"what mode is active?",
 	)

--- a/packages/agent/daemon/runtime/types.go
+++ b/packages/agent/daemon/runtime/types.go
@@ -109,23 +109,25 @@ type CloseInput struct {
 // SessionForkCapabilities reports provider-native fork boundaries supported by
 // the exact runtime currently attached to a session.
 type SessionForkCapabilities struct {
-	DriverKind                  string   `json:"driverKind,omitempty"`
-	DriverVersion               string   `json:"driverVersion,omitempty"`
-	StateBindingMode            string   `json:"stateBindingMode,omitempty"`
-	FullSession                 bool     `json:"fullSession"`
-	ThroughTurn                 bool     `json:"throughTurn"`
-	ThroughProviderTurnIDs      []string `json:"throughProviderTurnIds,omitempty"`
-	ThroughProviderTurnIDsKnown bool     `json:"throughProviderTurnIdsKnown,omitempty"`
+	DriverKind                   string   `json:"driverKind,omitempty"`
+	DriverVersion                string   `json:"driverVersion,omitempty"`
+	StateBindingMode             string   `json:"stateBindingMode,omitempty"`
+	DeterministicTargetSessionID bool     `json:"deterministicTargetSessionId,omitempty"`
+	FullSession                  bool     `json:"fullSession"`
+	ThroughTurn                  bool     `json:"throughTurn"`
+	ThroughProviderTurnIDs       []string `json:"throughProviderTurnIds,omitempty"`
+	ThroughProviderTurnIDsKnown  bool     `json:"throughProviderTurnIdsKnown,omitempty"`
 }
 
 // SessionForkInput identifies a provider source and optional inclusive
 // provider-turn boundary. ProviderTurnID is deliberately distinct from the
 // canonical WorkspaceAgentTurn id.
 type SessionForkInput struct {
-	Source          Session  `json:"-"`
-	ProviderTurnID  string   `json:"providerTurnId,omitempty"`
-	ProviderTurnIDs []string `json:"providerTurnIds,omitempty"`
-	TargetTitle     string   `json:"targetTitle,omitempty"`
+	Source                  Session  `json:"-"`
+	ProviderTurnID          string   `json:"providerTurnId,omitempty"`
+	ProviderTurnIDs         []string `json:"providerTurnIds,omitempty"`
+	TargetProviderSessionID string   `json:"targetProviderSessionId,omitempty"`
+	TargetTitle             string   `json:"targetTitle,omitempty"`
 }
 
 type SessionForkDeliveryDisposition string

--- a/packages/agent/daemon/runtime/types.go
+++ b/packages/agent/daemon/runtime/types.go
@@ -109,6 +109,9 @@ type CloseInput struct {
 // SessionForkCapabilities reports provider-native fork boundaries supported by
 // the exact runtime currently attached to a session.
 type SessionForkCapabilities struct {
+	DriverKind                  string   `json:"driverKind,omitempty"`
+	DriverVersion               string   `json:"driverVersion,omitempty"`
+	StateBindingMode            string   `json:"stateBindingMode,omitempty"`
 	FullSession                 bool     `json:"fullSession"`
 	ThroughTurn                 bool     `json:"throughTurn"`
 	ThroughProviderTurnIDs      []string `json:"throughProviderTurnIds,omitempty"`
@@ -122,6 +125,7 @@ type SessionForkInput struct {
 	Source          Session  `json:"-"`
 	ProviderTurnID  string   `json:"providerTurnId,omitempty"`
 	ProviderTurnIDs []string `json:"providerTurnIds,omitempty"`
+	TargetTitle     string   `json:"targetTitle,omitempty"`
 }
 
 type SessionForkDeliveryDisposition string
@@ -139,6 +143,9 @@ type SessionForkResult struct {
 	ProviderSessionID           string                         `json:"providerSessionId"`
 	ForkedFromProviderSessionID string                         `json:"forkedFromProviderSessionId"`
 	ThroughProviderTurnID       string                         `json:"throughProviderTurnId,omitempty"`
+	TargetProviderTurnIDs       []string                       `json:"targetProviderTurnIds,omitempty"`
+	StateBindingMode            string                         `json:"stateBindingMode,omitempty"`
+	StateBindingReceipt         string                         `json:"stateBindingReceipt,omitempty"`
 	DeliveryDisposition         SessionForkDeliveryDisposition `json:"deliveryDisposition"`
 }
 

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
@@ -41,7 +41,12 @@ describe("AgentTranscriptView", () => {
       detailViewModel({
         session: normalizeAgentActivitySession({
           ...detail.session,
-          lifecycleCapabilities: { fork: false, forkThroughTurn: true }
+          lifecycleCapabilities: {
+            fork: false,
+            forkThroughTurn: true,
+            forkThroughTurnIds: ["turn-1"],
+            forkThroughTurnIdsKnown: true
+          }
         }),
         sessionTurns: [settledTurn]
       })
@@ -100,7 +105,12 @@ describe("AgentTranscriptView", () => {
       detailViewModel({
         session: normalizeAgentActivitySession({
           ...detail.session,
-          lifecycleCapabilities: { fork: false, forkThroughTurn: true }
+          lifecycleCapabilities: {
+            fork: false,
+            forkThroughTurn: true,
+            forkThroughTurnIds: ["turn-1"],
+            forkThroughTurnIdsKnown: true
+          }
         }),
         sessionTurns: [
           canonicalTurn({
@@ -172,7 +182,12 @@ describe("AgentTranscriptView", () => {
       detailViewModel({
         session: normalizeAgentActivitySession({
           ...detail.session,
-          lifecycleCapabilities: { fork: false, forkThroughTurn: true }
+          lifecycleCapabilities: {
+            fork: false,
+            forkThroughTurn: true,
+            forkThroughTurnIds: ["turn-1", "turn-2"],
+            forkThroughTurnIdsKnown: true
+          }
         }),
         sessionTurns: [
           canonicalTurn({
@@ -281,6 +296,42 @@ describe("AgentTranscriptView", () => {
     ).toHaveLength(1);
   });
 
+  it("fails closed when provider Turn boundary identities are unknown", () => {
+    const detail = detailViewModel();
+    const conversation = projectAgentConversationVM(
+      detailViewModel({
+        session: normalizeAgentActivitySession({
+          ...detail.session,
+          lifecycleCapabilities: { fork: false, forkThroughTurn: true }
+        }),
+        sessionTurns: [
+          canonicalTurn({
+            outcome: "completed",
+            phase: "settled",
+            settledAtUnixMs: 7_000
+          })
+        ]
+      })
+    );
+    render(
+      <AgentTranscriptView
+        conversation={conversation}
+        labels={{
+          thinkingLabel: "Thought process",
+          toolCallsLabel: (count: number) => `Tool calls (${count})`,
+          processing: "Planning next moves",
+          turnSummary: "Changed files"
+        }}
+        onForkThroughTurn={vi.fn()}
+      />
+    );
+    expect(
+      screen.queryByRole("button", {
+        name: "agentHost.agentGui.forkThroughTurn"
+      })
+    ).toBeNull();
+  });
+
   it("does not expose Fork for a canonical Turn that is still running", () => {
     const detail = detailViewModel();
     const conversation = projectAgentConversationVM(
@@ -288,7 +339,12 @@ describe("AgentTranscriptView", () => {
         session: normalizeAgentActivitySession({
           ...detail.session,
           activeTurnId: "turn-1",
-          lifecycleCapabilities: { fork: false, forkThroughTurn: true }
+          lifecycleCapabilities: {
+            fork: false,
+            forkThroughTurn: true,
+            forkThroughTurnIds: ["turn-1"],
+            forkThroughTurnIdsKnown: true
+          }
         }),
         sessionTurns: [canonicalTurn()]
       })
@@ -321,7 +377,12 @@ describe("AgentTranscriptView", () => {
         session: normalizeAgentActivitySession({
           ...detail.session,
           activeTurnId: "turn-active",
-          lifecycleCapabilities: { fork: false, forkThroughTurn: true }
+          lifecycleCapabilities: {
+            fork: false,
+            forkThroughTurn: true,
+            forkThroughTurnIds: ["turn-1"],
+            forkThroughTurnIdsKnown: true
+          }
         }),
         sessionTurns: [
           canonicalTurn({
@@ -357,7 +418,12 @@ describe("AgentTranscriptView", () => {
       detailViewModel({
         session: normalizeAgentActivitySession({
           ...detail.session,
-          lifecycleCapabilities: { fork: false, forkThroughTurn: true }
+          lifecycleCapabilities: {
+            fork: false,
+            forkThroughTurn: true,
+            forkThroughTurnIds: ["turn-1"],
+            forkThroughTurnIdsKnown: true
+          }
         }),
         sessionTurns: [
           canonicalTurn({
@@ -475,7 +541,12 @@ describe("AgentTranscriptView", () => {
       detailViewModel({
         session: normalizeAgentActivitySession({
           ...detail.session,
-          lifecycleCapabilities: { fork: false, forkThroughTurn: true }
+          lifecycleCapabilities: {
+            fork: false,
+            forkThroughTurn: true,
+            forkThroughTurnIds: ["turn-1"],
+            forkThroughTurnIdsKnown: true
+          }
         }),
         sessionTurns: [
           canonicalTurn({

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx
@@ -591,8 +591,8 @@ export const AgentTranscriptView = memo(function AgentTranscriptView({
       canonicalTurnById.get(turnId)?.phase !== "settled" ||
       conversation.sourceDetail.session.kind !== "root" ||
       lifecycleCapabilities.forkThroughTurn !== true ||
-      (lifecycleCapabilities.forkThroughTurnIdsKnown === true &&
-        !lifecycleCapabilities.forkThroughTurnIds?.includes(turnId))
+      lifecycleCapabilities.forkThroughTurnIdsKnown !== true ||
+      !lifecycleCapabilities.forkThroughTurnIds?.includes(turnId)
     ) {
       return null;
     }

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.virtual.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.virtual.spec.tsx
@@ -190,7 +190,12 @@ describe("AgentTranscriptView virtual rendering", () => {
         ...baseConversation.sourceDetail,
         session: normalizeAgentActivitySession({
           ...baseConversation.sourceDetail.session,
-          lifecycleCapabilities: { fork: false, forkThroughTurn: true }
+          lifecycleCapabilities: {
+            fork: false,
+            forkThroughTurn: true,
+            forkThroughTurnIds: ["turn-10"],
+            forkThroughTurnIdsKnown: true
+          }
         })
       }
     };

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -166,23 +166,27 @@ with report, Goal/runtime mutation, deletion, and competing Fork writes.
 An accepted provider child is not checkpointed as `provider_accepted` until a
 provider-state binder has made the exact child state independently discoverable
 from the target Session runtime namespace. Binding failure is delivery-unknown,
-because the provider mutation may already exist and must not be dispatched
-again.
+because the provider mutation may already exist.
 Provider dispatch starts only after its marker commits. Provider acceptance is
 checkpointed with a detached bounded context and recovery retries only the
 atomic canonical prefix clone; a crash with an indeterminate provider result
-becomes `unknown` and is never automatically redispatched. A later request for
-the same source boundary recovers that durable unknown operation. A committed
-operation also retains the boundary barrier until the Engine explicitly
-acknowledges that its authoritative child Session has entered canonical UI
-state. Thus, losing a committed HTTP response and restarting with fresh
-request/target ids returns the original operation and child instead of invoking
-the provider again. The ACK is committed-only and idempotent; it releases the
-barrier so a later explicit action may create another branch from the same
-Turn. `unknown` cannot be acknowledged and remains fail-closed. Startup marks
-abandoned `prepared` work failed—its marker proves provider dispatch never
-began—and releases its source fence and target reservation without requiring a
-live runtime.
+becomes `unknown`. Drivers are never blindly redispatched. A driver may
+explicitly attest deterministic target identity: Host then derives the provider
+child UUID from the durable operation id, requires the returned identity to
+match, and may reconcile `dispatching` or `unknown` by repeating the same
+request. The provider adapter must first verify an existing child at that UUID
+and create it only when absent. Drivers without that attestation keep the
+fail-closed `unknown` behavior. A later request for the same source boundary
+recovers the durable operation. A committed operation also retains the boundary
+barrier until the Engine explicitly acknowledges that its authoritative child
+Session has entered canonical UI state. Thus, losing a committed HTTP response
+and restarting with fresh request/target ids returns the original operation and
+child instead of creating another provider identity. The ACK is committed-only
+and idempotent; it releases the barrier so a later explicit action may create
+another branch from the same Turn. `unknown` cannot be acknowledged. Startup
+marks abandoned `prepared` work failed—its marker proves provider dispatch
+never began—and releases its source fence and target reservation without
+requiring a live runtime.
 Public adapters keep the operation as the response once its durable row
 exists: internal `prepared`, `dispatching`, and `provider_accepted` phases
 collapse to `accepted`, while `committed`, `failed`, and `unknown` remain

--- a/packages/agent/host/ports.go
+++ b/packages/agent/host/ports.go
@@ -101,6 +101,7 @@ type SessionForkContextPolicy interface {
 // state needed by the target runtime namespace. A failure is delivery-unknown:
 // the provider mutation may already exist and must never be dispatched again.
 type SessionForkProviderStateBinder interface {
+	SupportsSessionForkProviderStateBinding(provider string) bool
 	BindSessionForkProviderState(context.Context, SessionForkProviderStateBinding) error
 }
 

--- a/packages/agent/host/ports.go
+++ b/packages/agent/host/ports.go
@@ -52,6 +52,7 @@ type SessionForkStore interface {
 	GetUnknownSessionForkOperation(context.Context, string, string, string, string) (storesqlite.SessionForkOperation, bool, error)
 	GetBlockingSessionForkOperation(context.Context, string, string, string, string) (storesqlite.SessionForkOperation, bool, error)
 	MarkSessionForkDispatching(context.Context, string, string, int64) (storesqlite.SessionForkOperation, bool, error)
+	RetryUnknownSessionFork(context.Context, string, string, int64) (storesqlite.SessionForkOperation, bool, error)
 	FailPreparedSessionFork(context.Context, string, string, string, int64) (storesqlite.SessionForkOperation, bool, error)
 	RecordSessionForkProviderResult(context.Context, storesqlite.SessionForkProviderResult) (storesqlite.SessionForkOperation, bool, error)
 	CommitSessionFork(context.Context, string, string, int64) (storesqlite.SessionForkCommitResult, error)
@@ -99,7 +100,8 @@ type SessionForkContextPolicy interface {
 
 // SessionForkProviderStateBinder transfers only the accepted provider child
 // state needed by the target runtime namespace. A failure is delivery-unknown:
-// the provider mutation may already exist and must never be dispatched again.
+// the provider mutation may already exist. Only a driver with an attested
+// deterministic target identity may reconcile it by replaying the same UUID.
 type SessionForkProviderStateBinder interface {
 	SupportsSessionForkProviderStateBinding(provider string) bool
 	BindSessionForkProviderState(context.Context, SessionForkProviderStateBinding) error

--- a/packages/agent/host/session_fork.go
+++ b/packages/agent/host/session_fork.go
@@ -15,7 +15,6 @@ import (
 )
 
 const sessionForkCheckpointTimeout = 10 * time.Second
-const sessionForkRecoveryPageSize = 100
 
 // ForkSession forks provider state through an inclusive canonical Turn and
 // then atomically installs the corresponding canonical child root session.
@@ -296,59 +295,6 @@ func (h *Host) AcknowledgeSessionForkOperation(
 	return result, found, err
 }
 
-func (h *Host) RecoverSessionForks(ctx context.Context) error {
-	if h == nil || h.sessionForks == nil || h.sessionForkRecovery == nil {
-		return nil
-	}
-	var recoveryErrors []error
-	handleOperation := func(operation storesqlite.SessionForkOperation) {
-		switch operation.Status {
-		case storesqlite.SessionForkStatusPrepared:
-			// No dispatch marker proves the provider call never started. Mark
-			// the abandoned request failed so its durable source fence cannot
-			// freeze the session after the caller/UI process has restarted.
-			_, _, err := h.sessionForks.FailPreparedSessionFork(
-				ctx,
-				operation.WorkspaceID,
-				operation.OperationID,
-				"prepared session fork was abandoned during restart",
-				h.now().UnixMilli(),
-			)
-			if err != nil {
-				recoveryErrors = append(recoveryErrors, err)
-			}
-			return
-		}
-		if _, err := h.processSessionForkOperation(ctx, operation); err != nil &&
-			!errors.Is(err, ErrSessionForkDeliveryUnknown) &&
-			!errors.Is(err, ErrSessionForkFailed) {
-			recoveryErrors = append(recoveryErrors,
-				fmt.Errorf("recover session fork %s: %w", operation.OperationID, err))
-		}
-	}
-	cursor := storesqlite.SessionForkRecoveryCursor{}
-	for {
-		operations, err := h.sessionForkRecovery.ListRecoverableSessionForkOperationsPage(
-			ctx, cursor, sessionForkRecoveryPageSize,
-		)
-		if err != nil {
-			return errors.Join(append(recoveryErrors, err)...)
-		}
-		for _, operation := range operations {
-			handleOperation(operation)
-		}
-		if len(operations) < sessionForkRecoveryPageSize {
-			break
-		}
-		last := operations[len(operations)-1]
-		cursor = storesqlite.SessionForkRecoveryCursor{
-			CreatedAtUnixMS: last.CreatedAtUnixMS,
-			OperationID:     last.OperationID,
-		}
-	}
-	return errors.Join(recoveryErrors...)
-}
-
 func (h *Host) processSessionForkOperation(
 	ctx context.Context,
 	operation storesqlite.SessionForkOperation,
@@ -491,7 +437,8 @@ func (h *Host) processSessionForkOperationWithSource(
 			ErrSessionForkUnsupported,
 		)
 	}
-	if operation.Status == storesqlite.SessionForkStatusUnknown {
+	switch operation.Status {
+	case storesqlite.SessionForkStatusUnknown:
 		operation, _, err = h.sessionForks.RetryUnknownSessionFork(
 			ctx,
 			operation.WorkspaceID,
@@ -504,7 +451,7 @@ func (h *Host) processSessionForkOperationWithSource(
 				err,
 			)
 		}
-	} else if operation.Status == storesqlite.SessionForkStatusPrepared {
+	case storesqlite.SessionForkStatusPrepared:
 		var dispatchChanged bool
 		operation, dispatchChanged, err = h.sessionForks.MarkSessionForkDispatching(
 			ctx, operation.WorkspaceID, operation.OperationID, h.now().UnixMilli(),

--- a/packages/agent/host/session_fork.go
+++ b/packages/agent/host/session_fork.go
@@ -160,7 +160,12 @@ func (h *Host) forkSessionSerialized(
 	if err != nil {
 		return ForkSessionResult{}, err
 	}
-	return h.processSessionForkOperationWithSource(ctx, operation, &runtimeSource)
+	return h.processSessionForkOperationWithSource(
+		ctx,
+		operation,
+		&runtimeSource,
+		false,
+	)
 }
 
 func (h *Host) GetSessionForkOperation(
@@ -178,6 +183,7 @@ func (h *Host) GetSessionForkOperation(
 	}
 	if op.Status == storesqlite.SessionForkStatusPrepared ||
 		op.Status == storesqlite.SessionForkStatusDispatching ||
+		op.Status == storesqlite.SessionForkStatusUnknown ||
 		op.Status == storesqlite.SessionForkStatusProviderAccepted {
 		var result ForkSessionResult
 		err = h.withSessionMutationActor(
@@ -208,22 +214,9 @@ func (h *Host) GetSessionForkOperation(
 					result = ForkSessionResult{Operation: failed}
 					return failErr
 				}
-				if current.Status == storesqlite.SessionForkStatusDispatching {
-					unknown, _, recordErr := h.sessionForks.RecordSessionForkProviderResult(
-						actorCtx,
-						storesqlite.SessionForkProviderResult{
-							WorkspaceID: current.WorkspaceID,
-							OperationID: current.OperationID,
-							Status:      storesqlite.SessionForkStatusUnknown,
-							LastError: "provider result was not durably recorded " +
-								"after dispatch began",
-							OccurredAtUnixMS: h.now().UnixMilli(),
-						},
-					)
-					result = ForkSessionResult{Operation: unknown}
-					return recordErr
-				}
-				if current.Status != storesqlite.SessionForkStatusProviderAccepted {
+				if current.Status != storesqlite.SessionForkStatusDispatching &&
+					current.Status != storesqlite.SessionForkStatusUnknown &&
+					current.Status != storesqlite.SessionForkStatusProviderAccepted {
 					var resultErr error
 					result, resultErr = h.sessionForkResult(actorCtx, current)
 					return resultErr
@@ -325,20 +318,6 @@ func (h *Host) RecoverSessionForks(ctx context.Context) error {
 				recoveryErrors = append(recoveryErrors, err)
 			}
 			return
-		case storesqlite.SessionForkStatusDispatching:
-			_, _, err := h.sessionForks.RecordSessionForkProviderResult(
-				ctx, storesqlite.SessionForkProviderResult{
-					WorkspaceID:      operation.WorkspaceID,
-					OperationID:      operation.OperationID,
-					Status:           storesqlite.SessionForkStatusUnknown,
-					LastError:        "provider result was not durably recorded before restart",
-					OccurredAtUnixMS: h.now().UnixMilli(),
-				},
-			)
-			if err != nil {
-				recoveryErrors = append(recoveryErrors, err)
-			}
-			return
 		}
 		if _, err := h.processSessionForkOperation(ctx, operation); err != nil &&
 			!errors.Is(err, ErrSessionForkDeliveryUnknown) &&
@@ -374,7 +353,13 @@ func (h *Host) processSessionForkOperation(
 	ctx context.Context,
 	operation storesqlite.SessionForkOperation,
 ) (ForkSessionResult, error) {
-	return h.processSessionForkOperationWithSource(ctx, operation, nil)
+	return h.processSessionForkOperationWithSource(
+		ctx,
+		operation,
+		nil,
+		operation.Status == storesqlite.SessionForkStatusDispatching ||
+			operation.Status == storesqlite.SessionForkStatusUnknown,
+	)
 }
 
 // processSessionForkOperationWithSource reuses one prepared historical runtime
@@ -385,7 +370,10 @@ func (h *Host) processSessionForkOperationWithSource(
 	ctx context.Context,
 	operation storesqlite.SessionForkOperation,
 	preparedSource *ProviderRuntimeSession,
+	allowDeterministicReplay bool,
 ) (ForkSessionResult, error) {
+	replaying := operation.Status == storesqlite.SessionForkStatusDispatching ||
+		operation.Status == storesqlite.SessionForkStatusUnknown
 	switch operation.Status {
 	case storesqlite.SessionForkStatusCommitted:
 		return h.sessionForkResult(ctx, operation)
@@ -401,31 +389,55 @@ func (h *Host) processSessionForkOperationWithSource(
 			Operation: commit.Operation, Session: commit.Session, Lineage: &lineage,
 		}, nil
 	case storesqlite.SessionForkStatusDispatching:
-		return ForkSessionResult{Operation: operation}, ErrSessionForkInProgress
+		if !allowDeterministicReplay {
+			return ForkSessionResult{Operation: operation}, ErrSessionForkInProgress
+		}
 	case storesqlite.SessionForkStatusFailed:
 		return ForkSessionResult{Operation: operation}, ErrSessionForkFailed
 	case storesqlite.SessionForkStatusUnknown:
-		return ForkSessionResult{Operation: operation}, ErrSessionForkDeliveryUnknown
+		if !allowDeterministicReplay {
+			return ForkSessionResult{Operation: operation}, ErrSessionForkDeliveryUnknown
+		}
 	case storesqlite.SessionForkStatusPrepared:
 	default:
 		return ForkSessionResult{Operation: operation}, storesqlite.ErrSessionForkTransition
+	}
+	failBeforeDispatch := func(
+		message string,
+		cause error,
+	) (ForkSessionResult, error) {
+		if !replaying {
+			return h.failPreparedSessionFork(ctx, operation, message, cause)
+		}
+		if operation.Status == storesqlite.SessionForkStatusUnknown {
+			return ForkSessionResult{Operation: operation},
+				errors.Join(ErrSessionForkDeliveryUnknown, cause)
+		}
+		recorded, _, recordErr := h.sessionForks.RecordSessionForkProviderResult(
+			ctx,
+			storesqlite.SessionForkProviderResult{
+				WorkspaceID:      operation.WorkspaceID,
+				OperationID:      operation.OperationID,
+				Status:           storesqlite.SessionForkStatusUnknown,
+				LastError:        message,
+				OccurredAtUnixMS: h.now().UnixMilli(),
+			},
+		)
+		return ForkSessionResult{Operation: recorded},
+			errors.Join(ErrSessionForkDeliveryUnknown, cause, recordErr)
 	}
 
 	boundary, supported, err := h.sessionForks.CheckSessionForkThroughTurn(
 		ctx, operation.WorkspaceID, operation.SourceAgentSessionID, operation.SourceTurnID,
 	)
 	if err != nil {
-		return h.failPreparedSessionFork(
-			ctx,
-			operation,
+		return failBeforeDispatch(
 			"canonical through-turn boundary could not be verified before dispatch",
 			err,
 		)
 	}
 	if !supported {
-		return h.failPreparedSessionFork(
-			ctx,
-			operation,
+		return failBeforeDispatch(
 			"canonical through-turn boundary is no longer forkable",
 			storesqlite.ErrSessionForkTurnState,
 		)
@@ -436,9 +448,7 @@ func (h *Host) processSessionForkOperationWithSource(
 	} else {
 		source, err = h.sessionForkRuntimeSource(ctx, boundary.Session)
 		if err != nil {
-			return h.failPreparedSessionFork(
-				ctx,
-				operation,
+			return failBeforeDispatch(
 				"source runtime could not be prepared before dispatch",
 				err,
 			)
@@ -446,9 +456,7 @@ func (h *Host) processSessionForkOperationWithSource(
 	}
 	if strings.TrimSpace(source.ProviderSessionID) !=
 		strings.TrimSpace(operation.SourceProviderSessionID) {
-		return h.failPreparedSessionFork(
-			ctx,
-			operation,
+		return failBeforeDispatch(
 			"source provider session identity changed before dispatch",
 			ErrSessionForkFailed,
 		)
@@ -459,16 +467,12 @@ func (h *Host) processSessionForkOperationWithSource(
 	)
 	if err != nil {
 		if errors.Is(err, ErrSessionForkUnsupported) {
-			return h.failPreparedSessionFork(
-				ctx,
-				operation,
+			return failBeforeDispatch(
 				"provider no longer supports the prepared session fork",
 				ErrSessionForkUnsupported,
 			)
 		}
-		return h.failPreparedSessionFork(
-			ctx,
-			operation,
+		return failBeforeDispatch(
 			"provider fork capability could not be verified before dispatch",
 			err,
 		)
@@ -476,41 +480,58 @@ func (h *Host) processSessionForkOperationWithSource(
 	normalizeSessionForkDriverDescriptor(&descriptor)
 	if !descriptor.ThroughTurn || descriptor.Kind != operation.DriverKind ||
 		descriptor.Version != operation.DriverVersion ||
+		(replaying && !descriptor.DeterministicTargetSessionID) ||
 		!validSessionForkStateBindingMode(
 			descriptor.StateBindingMode,
 			h.sessionForkState,
 			source.Provider,
 		) {
-		return h.failPreparedSessionFork(
-			ctx,
-			operation,
+		return failBeforeDispatch(
 			"provider session fork driver changed before dispatch",
 			ErrSessionForkUnsupported,
 		)
 	}
-	var dispatchChanged bool
-	operation, dispatchChanged, err = h.sessionForks.MarkSessionForkDispatching(
-		ctx, operation.WorkspaceID, operation.OperationID, h.now().UnixMilli(),
-	)
-	if err != nil {
-		return h.failPreparedSessionFork(
+	if operation.Status == storesqlite.SessionForkStatusUnknown {
+		operation, _, err = h.sessionForks.RetryUnknownSessionFork(
 			ctx,
-			operation,
-			"provider dispatch marker could not be persisted",
-			err,
+			operation.WorkspaceID,
+			operation.OperationID,
+			h.now().UnixMilli(),
 		)
+		if err != nil {
+			return failBeforeDispatch(
+				"provider replay marker could not be persisted",
+				err,
+			)
+		}
+	} else if operation.Status == storesqlite.SessionForkStatusPrepared {
+		var dispatchChanged bool
+		operation, dispatchChanged, err = h.sessionForks.MarkSessionForkDispatching(
+			ctx, operation.WorkspaceID, operation.OperationID, h.now().UnixMilli(),
+		)
+		if err != nil {
+			return failBeforeDispatch(
+				"provider dispatch marker could not be persisted",
+				err,
+			)
+		}
+		if !dispatchChanged {
+			return h.processSessionForkOperation(ctx, operation)
+		}
 	}
-	if !dispatchChanged {
-		return h.processSessionForkOperation(ctx, operation)
+	targetProviderSessionIDRequest := ""
+	if descriptor.DeterministicTargetSessionID {
+		targetProviderSessionIDRequest = operation.OperationID
 	}
 	providerResult, dispatchErr := h.sessionForkRuntime.ForkSession(
 		ctx, RuntimeSessionForkInput{
-			Source:                cloneSessionForkRuntimeSource(source),
-			SourceProviderTurnID:  operation.SourceProviderTurnID,
-			SourceProviderTurnIDs: append([]string(nil), boundary.RootProviderTurnIDs...),
-			TargetTitle:           operation.TargetTitle,
-			RequestID:             operation.RequestID,
-			Driver:                descriptor,
+			Source:                  cloneSessionForkRuntimeSource(source),
+			SourceProviderTurnID:    operation.SourceProviderTurnID,
+			SourceProviderTurnIDs:   append([]string(nil), boundary.RootProviderTurnIDs...),
+			TargetProviderSessionID: targetProviderSessionIDRequest,
+			TargetTitle:             operation.TargetTitle,
+			RequestID:               operation.RequestID,
+			Driver:                  descriptor,
 		},
 	)
 	targetProviderSessionID := strings.TrimSpace(providerResult.ProviderSessionID)
@@ -527,19 +548,22 @@ func (h *Host) processSessionForkOperationWithSource(
 		providerResult.DeliveryDisposition != SessionForkDeliveryAccepted ||
 		targetProviderSessionID == "" ||
 		targetProviderSessionID == operation.SourceProviderSessionID ||
+		(targetProviderSessionIDRequest != "" &&
+			targetProviderSessionID != targetProviderSessionIDRequest) ||
 		providerResult.StateBindingMode != descriptor.StateBindingMode ||
 		!validSessionForkProviderResult(providerResult, boundary.RootProviderTurnIDs) {
 		message := "provider fork result was invalid"
 		status := storesqlite.SessionForkStatusUnknown
 		if dispatchErr != nil {
 			message = dispatchErr.Error()
-			if errors.Is(dispatchErr, ErrSessionForkUnsupported) ||
+			if !replaying && (errors.Is(dispatchErr, ErrSessionForkUnsupported) ||
 				providerResult.DeliveryDisposition == SessionForkDeliveryNotStarted ||
-				providerResult.DeliveryDisposition == SessionForkDeliveryRejected {
+				providerResult.DeliveryDisposition == SessionForkDeliveryRejected) {
 				status = storesqlite.SessionForkStatusFailed
 			}
-		} else if providerResult.DeliveryDisposition == SessionForkDeliveryNotStarted ||
-			providerResult.DeliveryDisposition == SessionForkDeliveryRejected {
+		} else if !replaying &&
+			(providerResult.DeliveryDisposition == SessionForkDeliveryNotStarted ||
+				providerResult.DeliveryDisposition == SessionForkDeliveryRejected) {
 			status = storesqlite.SessionForkStatusFailed
 		}
 		recorded, _, recordErr := h.sessionForks.RecordSessionForkProviderResult(

--- a/packages/agent/host/session_fork.go
+++ b/packages/agent/host/session_fork.go
@@ -119,7 +119,12 @@ func (h *Host) forkSessionSerialized(
 		return ForkSessionResult{}, err
 	}
 	normalizeSessionForkDriverDescriptor(&descriptor)
-	if !descriptor.ThroughTurn || descriptor.Kind == "" || descriptor.Version == "" {
+	if !descriptor.ThroughTurn || descriptor.Kind == "" || descriptor.Version == "" ||
+		!validSessionForkStateBindingMode(
+			descriptor.StateBindingMode,
+			h.sessionForkState,
+			runtimeSource.Provider,
+		) {
 		return ForkSessionResult{}, ErrSessionForkUnsupported
 	}
 	targetContext, err := h.prepareSessionForkTargetContext(
@@ -470,7 +475,12 @@ func (h *Host) processSessionForkOperationWithSource(
 	}
 	normalizeSessionForkDriverDescriptor(&descriptor)
 	if !descriptor.ThroughTurn || descriptor.Kind != operation.DriverKind ||
-		descriptor.Version != operation.DriverVersion {
+		descriptor.Version != operation.DriverVersion ||
+		!validSessionForkStateBindingMode(
+			descriptor.StateBindingMode,
+			h.sessionForkState,
+			source.Provider,
+		) {
 		return h.failPreparedSessionFork(
 			ctx,
 			operation,
@@ -498,11 +508,16 @@ func (h *Host) processSessionForkOperationWithSource(
 			Source:                cloneSessionForkRuntimeSource(source),
 			SourceProviderTurnID:  operation.SourceProviderTurnID,
 			SourceProviderTurnIDs: append([]string(nil), boundary.RootProviderTurnIDs...),
+			TargetTitle:           operation.TargetTitle,
 			RequestID:             operation.RequestID,
 			Driver:                descriptor,
 		},
 	)
 	targetProviderSessionID := strings.TrimSpace(providerResult.ProviderSessionID)
+	if providerResult.StateBindingMode == "" {
+		providerResult.StateBindingMode = SessionForkStateBindingHostCopy
+	}
+	providerResult.StateBindingReceipt = strings.TrimSpace(providerResult.StateBindingReceipt)
 	checkpointCtx, checkpointCancel := context.WithTimeout(
 		context.WithoutCancel(ctx),
 		sessionForkCheckpointTimeout,
@@ -511,7 +526,9 @@ func (h *Host) processSessionForkOperationWithSource(
 	if dispatchErr != nil ||
 		providerResult.DeliveryDisposition != SessionForkDeliveryAccepted ||
 		targetProviderSessionID == "" ||
-		targetProviderSessionID == operation.SourceProviderSessionID {
+		targetProviderSessionID == operation.SourceProviderSessionID ||
+		providerResult.StateBindingMode != descriptor.StateBindingMode ||
+		!validSessionForkProviderResult(providerResult, boundary.RootProviderTurnIDs) {
 		message := "provider fork result was invalid"
 		status := storesqlite.SessionForkStatusUnknown
 		if dispatchErr != nil {
@@ -543,7 +560,28 @@ func (h *Host) processSessionForkOperationWithSource(
 		return ForkSessionResult{Operation: recorded},
 			errors.Join(ErrSessionForkDeliveryUnknown, dispatchErr)
 	}
-	if h.sessionForkState != nil {
+	if providerResult.StateBindingMode == SessionForkStateBindingHostCopy &&
+		h.sessionForkState == nil {
+		bindErr := errors.New("provider child state binding is unavailable")
+		recorded, _, recordErr := h.sessionForks.RecordSessionForkProviderResult(
+			checkpointCtx,
+			storesqlite.SessionForkProviderResult{
+				WorkspaceID:             operation.WorkspaceID,
+				OperationID:             operation.OperationID,
+				Status:                  storesqlite.SessionForkStatusUnknown,
+				TargetProviderSessionID: targetProviderSessionID,
+				LastError:               bindErr.Error(),
+				OccurredAtUnixMS:        h.now().UnixMilli(),
+			},
+		)
+		if recordErr != nil {
+			return ForkSessionResult{Operation: operation},
+				errors.Join(ErrSessionForkDeliveryUnknown, bindErr, recordErr)
+		}
+		return ForkSessionResult{Operation: recorded},
+			errors.Join(ErrSessionForkDeliveryUnknown, bindErr)
+	}
+	if providerResult.StateBindingMode == SessionForkStateBindingHostCopy {
 		bindErr := h.sessionForkState.BindSessionForkProviderState(
 			checkpointCtx,
 			SessionForkProviderStateBinding{
@@ -580,6 +618,9 @@ func (h *Host) processSessionForkOperationWithSource(
 			WorkspaceID: operation.WorkspaceID, OperationID: operation.OperationID,
 			Status:                  storesqlite.SessionForkStatusProviderAccepted,
 			TargetProviderSessionID: targetProviderSessionID,
+			TargetProviderTurnIDs:   append([]string(nil), providerResult.TargetProviderTurnIDs...),
+			StateBindingMode:        string(providerResult.StateBindingMode),
+			StateBindingReceipt:     providerResult.StateBindingReceipt,
 			OccurredAtUnixMS:        h.now().UnixMilli(),
 		},
 	)
@@ -588,6 +629,36 @@ func (h *Host) processSessionForkOperationWithSource(
 			errors.Join(ErrSessionForkDeliveryUnknown, err)
 	}
 	return h.processSessionForkOperation(checkpointCtx, operation)
+}
+
+func validSessionForkProviderResult(
+	result RuntimeSessionForkResult,
+	sourceProviderTurnIDs []string,
+) bool {
+	switch result.StateBindingMode {
+	case SessionForkStateBindingHostCopy:
+		return len(result.TargetProviderTurnIDs) == 0 &&
+			result.StateBindingReceipt == ""
+	case SessionForkStateBindingProviderOwned:
+		if result.StateBindingReceipt == "" ||
+			len(result.TargetProviderTurnIDs) != len(sourceProviderTurnIDs) {
+			return false
+		}
+		seen := make(map[string]struct{}, len(result.TargetProviderTurnIDs))
+		for _, rawID := range result.TargetProviderTurnIDs {
+			id := strings.TrimSpace(rawID)
+			if id == "" {
+				return false
+			}
+			if _, duplicate := seen[id]; duplicate {
+				return false
+			}
+			seen[id] = struct{}{}
+		}
+		return true
+	default:
+		return false
+	}
 }
 
 func (h *Host) prepareSessionForkTargetContext(

--- a/packages/agent/host/session_fork.go
+++ b/packages/agent/host/session_fork.go
@@ -631,36 +631,6 @@ func (h *Host) processSessionForkOperationWithSource(
 	return h.processSessionForkOperation(checkpointCtx, operation)
 }
 
-func validSessionForkProviderResult(
-	result RuntimeSessionForkResult,
-	sourceProviderTurnIDs []string,
-) bool {
-	switch result.StateBindingMode {
-	case SessionForkStateBindingHostCopy:
-		return len(result.TargetProviderTurnIDs) == 0 &&
-			result.StateBindingReceipt == ""
-	case SessionForkStateBindingProviderOwned:
-		if result.StateBindingReceipt == "" ||
-			len(result.TargetProviderTurnIDs) != len(sourceProviderTurnIDs) {
-			return false
-		}
-		seen := make(map[string]struct{}, len(result.TargetProviderTurnIDs))
-		for _, rawID := range result.TargetProviderTurnIDs {
-			id := strings.TrimSpace(rawID)
-			if id == "" {
-				return false
-			}
-			if _, duplicate := seen[id]; duplicate {
-				return false
-			}
-			seen[id] = struct{}{}
-		}
-		return true
-	default:
-		return false
-	}
-}
-
 func (h *Host) prepareSessionForkTargetContext(
 	ctx context.Context,
 	source storesqlite.Session,

--- a/packages/agent/host/session_fork_capabilities.go
+++ b/packages/agent/host/session_fork_capabilities.go
@@ -50,10 +50,20 @@ func (h *Host) GetSessionForkCapabilities(
 	capabilities := SessionForkCapabilities{
 		FullSession: descriptor.FullSession &&
 			descriptor.Kind != "" &&
-			descriptor.Version != "",
+			descriptor.Version != "" &&
+			validSessionForkStateBindingMode(
+				descriptor.StateBindingMode,
+				h.sessionForkState,
+				runtimeSource.Provider,
+			),
 		ThroughTurn: descriptor.ThroughTurn &&
 			descriptor.Kind != "" &&
-			descriptor.Version != "",
+			descriptor.Version != "" &&
+			validSessionForkStateBindingMode(
+				descriptor.StateBindingMode,
+				h.sessionForkState,
+				runtimeSource.Provider,
+			),
 	}
 	if !capabilities.ThroughTurn ||
 		!descriptor.ThroughProviderTurnIDsKnown {
@@ -97,6 +107,9 @@ func matchingSessionForkTurnPrefix(
 func normalizeSessionForkDriverDescriptor(input *SessionForkDriverDescriptor) {
 	input.Kind = strings.TrimSpace(input.Kind)
 	input.Version = strings.TrimSpace(input.Version)
+	if input.StateBindingMode == "" {
+		input.StateBindingMode = SessionForkStateBindingHostCopy
+	}
 	if !input.ThroughProviderTurnIDsKnown {
 		input.ThroughProviderTurnIDs = nil
 		return
@@ -117,4 +130,20 @@ func normalizeSessionForkDriverDescriptor(input *SessionForkDriverDescriptor) {
 		normalized = append(normalized, turnID)
 	}
 	input.ThroughProviderTurnIDs = normalized
+}
+
+func validSessionForkStateBindingMode(
+	mode SessionForkStateBindingMode,
+	hostBinder SessionForkProviderStateBinder,
+	provider string,
+) bool {
+	switch mode {
+	case SessionForkStateBindingHostCopy:
+		return hostBinder != nil &&
+			hostBinder.SupportsSessionForkProviderStateBinding(provider)
+	case SessionForkStateBindingProviderOwned:
+		return true
+	default:
+		return false
+	}
 }

--- a/packages/agent/host/session_fork_conformance_test.go
+++ b/packages/agent/host/session_fork_conformance_test.go
@@ -329,16 +329,24 @@ func (*sessionForkConformanceRuntime) ResolveSessionFork(
 ) (agenthost.SessionForkDriverDescriptor, error) {
 	return agenthost.SessionForkDriverDescriptor{
 		Kind: "codex-app-server", Version: "1", ThroughTurn: true,
+		StateBindingMode: agenthost.SessionForkStateBindingProviderOwned,
 	}, nil
 }
 
 func (r *sessionForkConformanceRuntime) ForkSession(
-	context.Context,
-	agenthost.RuntimeSessionForkInput,
+	_ context.Context,
+	input agenthost.RuntimeSessionForkInput,
 ) (agenthost.RuntimeSessionForkResult, error) {
 	r.forkCalls++
+	targetTurnIDs := make([]string, 0, len(input.SourceProviderTurnIDs))
+	for _, sourceID := range input.SourceProviderTurnIDs {
+		targetTurnIDs = append(targetTurnIDs, "forked-"+sourceID)
+	}
 	return agenthost.RuntimeSessionForkResult{
-		ProviderSessionID:   "provider-target",
-		DeliveryDisposition: agenthost.SessionForkDeliveryAccepted,
+		ProviderSessionID:     "provider-target",
+		TargetProviderTurnIDs: targetTurnIDs,
+		StateBindingMode:      agenthost.SessionForkStateBindingProviderOwned,
+		StateBindingReceipt:   "conformance-provider-owned-receipt",
+		DeliveryDisposition:   agenthost.SessionForkDeliveryAccepted,
 	}, nil
 }

--- a/packages/agent/host/session_fork_provider_result.go
+++ b/packages/agent/host/session_fork_provider_result.go
@@ -1,0 +1,33 @@
+package agenthost
+
+import "strings"
+
+func validSessionForkProviderResult(
+	result RuntimeSessionForkResult,
+	sourceProviderTurnIDs []string,
+) bool {
+	switch result.StateBindingMode {
+	case SessionForkStateBindingHostCopy:
+		return len(result.TargetProviderTurnIDs) == 0 &&
+			result.StateBindingReceipt == ""
+	case SessionForkStateBindingProviderOwned:
+		if result.StateBindingReceipt == "" ||
+			len(result.TargetProviderTurnIDs) != len(sourceProviderTurnIDs) {
+			return false
+		}
+		seen := make(map[string]struct{}, len(result.TargetProviderTurnIDs))
+		for _, rawID := range result.TargetProviderTurnIDs {
+			id := strings.TrimSpace(rawID)
+			if id == "" {
+				return false
+			}
+			if _, duplicate := seen[id]; duplicate {
+				return false
+			}
+			seen[id] = struct{}{}
+		}
+		return true
+	default:
+		return false
+	}
+}

--- a/packages/agent/host/session_fork_recovery.go
+++ b/packages/agent/host/session_fork_recovery.go
@@ -1,0 +1,63 @@
+package agenthost
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+const sessionForkRecoveryPageSize = 100
+
+func (h *Host) RecoverSessionForks(ctx context.Context) error {
+	if h == nil || h.sessionForks == nil || h.sessionForkRecovery == nil {
+		return nil
+	}
+	var recoveryErrors []error
+	handleOperation := func(operation storesqlite.SessionForkOperation) {
+		if operation.Status == storesqlite.SessionForkStatusPrepared {
+			// No dispatch marker proves the provider call never started. Mark
+			// the abandoned request failed so its durable source fence cannot
+			// freeze the session after the caller/UI process has restarted.
+			_, _, err := h.sessionForks.FailPreparedSessionFork(
+				ctx,
+				operation.WorkspaceID,
+				operation.OperationID,
+				"prepared session fork was abandoned during restart",
+				h.now().UnixMilli(),
+			)
+			if err != nil {
+				recoveryErrors = append(recoveryErrors, err)
+			}
+			return
+		}
+		if _, err := h.processSessionForkOperation(ctx, operation); err != nil &&
+			!errors.Is(err, ErrSessionForkDeliveryUnknown) &&
+			!errors.Is(err, ErrSessionForkFailed) {
+			recoveryErrors = append(recoveryErrors,
+				fmt.Errorf("recover session fork %s: %w", operation.OperationID, err))
+		}
+	}
+	cursor := storesqlite.SessionForkRecoveryCursor{}
+	for {
+		operations, err := h.sessionForkRecovery.ListRecoverableSessionForkOperationsPage(
+			ctx, cursor, sessionForkRecoveryPageSize,
+		)
+		if err != nil {
+			return errors.Join(append(recoveryErrors, err)...)
+		}
+		for _, operation := range operations {
+			handleOperation(operation)
+		}
+		if len(operations) < sessionForkRecoveryPageSize {
+			break
+		}
+		last := operations[len(operations)-1]
+		cursor = storesqlite.SessionForkRecoveryCursor{
+			CreatedAtUnixMS: last.CreatedAtUnixMS,
+			OperationID:     last.OperationID,
+		}
+	}
+	return errors.Join(recoveryErrors...)
+}

--- a/packages/agent/host/session_fork_test.go
+++ b/packages/agent/host/session_fork_test.go
@@ -84,7 +84,10 @@ func TestForkSessionTransportFailureBecomesUnknownAndNeverRedispatches(t *testin
 
 func TestForkSessionBindsAcceptedProviderStateBeforeCanonicalCommit(t *testing.T) {
 	store := newFakeSessionForkStore()
-	runtime := &fakeSessionForkRuntime{providerSessionID: "provider-child"}
+	runtime := &fakeSessionForkRuntime{
+		providerSessionID: "provider-child",
+		stateBindingMode:  SessionForkStateBindingHostCopy,
+	}
 	binder := &fakeSessionForkStateBinder{}
 	host := New(Config{
 		SessionForks: store, SessionForkRuntime: runtime, SessionForkState: binder,
@@ -115,7 +118,10 @@ func TestForkSessionBindsAcceptedProviderStateBeforeCanonicalCommit(t *testing.T
 
 func TestForkSessionProviderStateBindingFailureBecomesUnknownAndNeverRedispatches(t *testing.T) {
 	store := newFakeSessionForkStore()
-	runtime := &fakeSessionForkRuntime{providerSessionID: "provider-child"}
+	runtime := &fakeSessionForkRuntime{
+		providerSessionID: "provider-child",
+		stateBindingMode:  SessionForkStateBindingHostCopy,
+	}
 	binder := &fakeSessionForkStateBinder{err: errors.New("rollout copy failed")}
 	host := New(Config{
 		SessionForks: store, SessionForkRuntime: runtime, SessionForkState: binder,
@@ -150,6 +156,49 @@ func TestForkSessionProviderStateBindingFailureBecomesUnknownAndNeverRedispatche
 			runtime.forkCalls,
 			len(binder.inputs),
 		)
+	}
+}
+
+func TestForkSessionHostCopyWithoutBinderFailsClosed(t *testing.T) {
+	store := newFakeSessionForkStore()
+	runtime := &fakeSessionForkRuntime{
+		providerSessionID: "provider-child",
+		stateBindingMode:  SessionForkStateBindingHostCopy,
+	}
+	result, err := New(Config{
+		SessionForks: store, SessionForkRuntime: runtime,
+	}).ForkSession(t.Context(), ForkSessionInput{
+		WorkspaceID: "ws", SourceAgentSessionID: "source",
+		TargetAgentSessionID: "target", RequestID: "request",
+		ThroughTurnID: "turn",
+	})
+	if !errors.Is(err, ErrSessionForkUnsupported) ||
+		result.Operation.OperationID != "" ||
+		result.Session.ID != "" ||
+		runtime.forkCalls != 0 {
+		t.Fatalf("ForkSession() result=%#v error=%v", result, err)
+	}
+}
+
+func TestForkSessionHostCopyWithUnsupportedBinderFailsBeforeDispatch(t *testing.T) {
+	store := newFakeSessionForkStore()
+	runtime := &fakeSessionForkRuntime{
+		providerSessionID: "provider-child",
+		stateBindingMode:  SessionForkStateBindingHostCopy,
+	}
+	result, err := New(Config{
+		SessionForks:       store,
+		SessionForkRuntime: runtime,
+		SessionForkState:   &fakeSessionForkStateBinder{unsupported: true},
+	}).ForkSession(t.Context(), ForkSessionInput{
+		WorkspaceID: "ws", SourceAgentSessionID: "source",
+		TargetAgentSessionID: "target", RequestID: "request",
+		ThroughTurnID: "turn",
+	})
+	if !errors.Is(err, ErrSessionForkUnsupported) ||
+		result.Operation.OperationID != "" ||
+		runtime.forkCalls != 0 {
+		t.Fatalf("ForkSession() result=%#v error=%v", result, err)
 	}
 }
 
@@ -709,11 +758,17 @@ type fakeSessionForkRuntime struct {
 	resolvedSources     []ProviderRuntimeSession
 	forkInputs          []RuntimeSessionForkInput
 	mutateFirstResolve  bool
+	stateBindingMode    SessionForkStateBindingMode
 }
 
 type fakeSessionForkStateBinder struct {
-	inputs []SessionForkProviderStateBinding
-	err    error
+	inputs      []SessionForkProviderStateBinding
+	err         error
+	unsupported bool
+}
+
+func (f *fakeSessionForkStateBinder) SupportsSessionForkProviderStateBinding(string) bool {
+	return f != nil && !f.unsupported
 }
 
 func (f *fakeSessionForkStateBinder) BindSessionForkProviderState(
@@ -749,9 +804,23 @@ func (f *fakeSessionForkRuntime) ResolveSessionFork(
 		if index >= len(f.descriptors) {
 			index = len(f.descriptors) - 1
 		}
-		return f.descriptors[index], f.resolveErr
+		descriptor := f.descriptors[index]
+		if descriptor.StateBindingMode == "" {
+			descriptor.StateBindingMode = f.effectiveStateBindingMode()
+		}
+		return descriptor, f.resolveErr
 	}
-	return SessionForkDriverDescriptor{Kind: "codex", Version: "1", ThroughTurn: true}, f.resolveErr
+	return SessionForkDriverDescriptor{
+		Kind: "codex", Version: "1", ThroughTurn: true,
+		StateBindingMode: f.effectiveStateBindingMode(),
+	}, f.resolveErr
+}
+
+func (f *fakeSessionForkRuntime) effectiveStateBindingMode() SessionForkStateBindingMode {
+	if f.stateBindingMode != "" {
+		return f.stateBindingMode
+	}
+	return SessionForkStateBindingProviderOwned
 }
 
 func (f *fakeSessionForkRuntime) ForkSession(
@@ -768,9 +837,21 @@ func (f *fakeSessionForkRuntime) ForkSession(
 		f.forkErr == nil && strings.TrimSpace(f.providerSessionID) != "" {
 		disposition = SessionForkDeliveryAccepted
 	}
+	mode := f.effectiveStateBindingMode()
+	var targetProviderTurnIDs []string
+	receipt := ""
+	if mode == SessionForkStateBindingProviderOwned {
+		receipt = "fake-provider-owned-receipt"
+		for _, sourceID := range input.SourceProviderTurnIDs {
+			targetProviderTurnIDs = append(targetProviderTurnIDs, "forked-"+sourceID)
+		}
+	}
 	return RuntimeSessionForkResult{
-		ProviderSessionID:   f.providerSessionID,
-		DeliveryDisposition: disposition,
+		ProviderSessionID:     f.providerSessionID,
+		TargetProviderTurnIDs: targetProviderTurnIDs,
+		StateBindingMode:      mode,
+		StateBindingReceipt:   receipt,
+		DeliveryDisposition:   disposition,
 	}, f.forkErr
 }
 

--- a/packages/agent/host/session_fork_test.go
+++ b/packages/agent/host/session_fork_test.go
@@ -420,6 +420,50 @@ func TestRecoverSessionForksMarksDispatchingUnknownWithoutProviderCall(t *testin
 	}
 }
 
+func TestRecoverSessionForksReplaysDeterministicProviderChildIdentity(t *testing.T) {
+	for _, status := range []string{
+		storesqlite.SessionForkStatusDispatching,
+		storesqlite.SessionForkStatusUnknown,
+	} {
+		t.Run(status, func(t *testing.T) {
+			store := newFakeSessionForkStore()
+			store.operation = storesqlite.SessionForkOperation{
+				OperationID: "11111111-1111-4111-8111-111111111111",
+				WorkspaceID: "ws", RequestID: "request", RequestHash: "hash",
+				SourceAgentSessionID: "source", TargetAgentSessionID: "target",
+				SourceTurnID: "turn", SourceProviderSessionID: "provider-source",
+				SourceProviderTurnID: "provider-turn",
+				DriverKind:           "claude", DriverVersion: "deterministic-v1",
+				Status: status,
+			}
+			runtime := &fakeSessionForkRuntime{
+				providerSessionID: store.operation.OperationID,
+				descriptors: []SessionForkDriverDescriptor{{
+					Kind: "claude", Version: "deterministic-v1",
+					StateBindingMode: SessionForkStateBindingProviderOwned,
+					ThroughTurn:      true, DeterministicTargetSessionID: true,
+				}},
+			}
+			host := New(Config{
+				SessionForks: store, SessionForkRecovery: store,
+				SessionForkRuntime: runtime,
+			})
+			if err := host.RecoverSessionForks(context.Background()); err != nil {
+				t.Fatalf("RecoverSessionForks() error=%v", err)
+			}
+			if store.operation.Status != storesqlite.SessionForkStatusCommitted {
+				t.Fatalf("recovered status=%q, want committed", store.operation.Status)
+			}
+			if runtime.forkCalls != 1 || len(runtime.forkInputs) != 1 {
+				t.Fatalf("provider fork calls=%d inputs=%#v", runtime.forkCalls, runtime.forkInputs)
+			}
+			if got := runtime.forkInputs[0].TargetProviderSessionID; got != store.operation.OperationID {
+				t.Fatalf("target provider session id=%q", got)
+			}
+		})
+	}
+}
+
 func TestRecoverSessionForksFailsAbandonedPreparedWithoutLiveRuntime(t *testing.T) {
 	store := newFakeSessionForkStore()
 	store.operation = storesqlite.SessionForkOperation{
@@ -1086,6 +1130,17 @@ func (f *fakeSessionForkStore) MarkSessionForkDispatching(
 	_ context.Context, _, _ string, _ int64,
 ) (storesqlite.SessionForkOperation, bool, error) {
 	f.operation.Status = storesqlite.SessionForkStatusDispatching
+	return f.operation, true, nil
+}
+
+func (f *fakeSessionForkStore) RetryUnknownSessionFork(
+	_ context.Context, _, _ string, _ int64,
+) (storesqlite.SessionForkOperation, bool, error) {
+	if f.operation.Status != storesqlite.SessionForkStatusUnknown {
+		return f.operation, false, storesqlite.ErrSessionForkTransition
+	}
+	f.operation.Status = storesqlite.SessionForkStatusDispatching
+	f.operation.LastError = ""
 	return f.operation, true, nil
 }
 

--- a/packages/agent/host/sqlite_workspace_store.go
+++ b/packages/agent/host/sqlite_workspace_store.go
@@ -175,6 +175,27 @@ func (s *SQLiteWorkspaceStore) MarkSessionForkDispatching(
 	return operation, changed, err
 }
 
+func (s *SQLiteWorkspaceStore) RetryUnknownSessionFork(
+	ctx context.Context,
+	workspaceID, operationID string,
+	now int64,
+) (storesqlite.SessionForkOperation, bool, error) {
+	store, err := s.store(workspaceID)
+	if err != nil {
+		return storesqlite.SessionForkOperation{}, false, err
+	}
+	operation, changed, err := store.RetryUnknownSessionFork(
+		ctx,
+		workspaceID,
+		operationID,
+		now,
+	)
+	if err == nil && changed {
+		NotifyCommitted(ctx, s.Observer, CanonicalDelta(operation.CommitDelta))
+	}
+	return operation, changed, err
+}
+
 func (s *SQLiteWorkspaceStore) FailPreparedSessionFork(
 	ctx context.Context,
 	workspaceID, operationID, lastError string,

--- a/packages/agent/host/sqlite_workspace_store_test.go
+++ b/packages/agent/host/sqlite_workspace_store_test.go
@@ -43,6 +43,7 @@ func (workspaceStoreForkRuntime) ResolveSessionFork(
 		ThroughTurn:                 true,
 		ThroughProviderTurnIDsKnown: true,
 		ThroughProviderTurnIDs:      []string{"provider-turn-1"},
+		StateBindingMode:            agenthost.SessionForkStateBindingProviderOwned,
 	}, nil
 }
 

--- a/packages/agent/host/types.go
+++ b/packages/agent/host/types.go
@@ -162,6 +162,7 @@ type SessionForkTargetContext struct {
 type SessionForkDriverDescriptor struct {
 	Kind                        string
 	Version                     string
+	StateBindingMode            SessionForkStateBindingMode
 	FullSession                 bool
 	ThroughTurn                 bool
 	ThroughProviderTurnIDs      []string
@@ -172,6 +173,7 @@ type RuntimeSessionForkInput struct {
 	Source                ProviderRuntimeSession
 	SourceProviderTurnID  string
 	SourceProviderTurnIDs []string
+	TargetTitle           string
 	RequestID             string
 	Driver                SessionForkDriverDescriptor
 }
@@ -186,9 +188,19 @@ const (
 )
 
 type RuntimeSessionForkResult struct {
-	ProviderSessionID   string
-	DeliveryDisposition SessionForkDeliveryDisposition
+	ProviderSessionID     string
+	TargetProviderTurnIDs []string
+	StateBindingMode      SessionForkStateBindingMode
+	StateBindingReceipt   string
+	DeliveryDisposition   SessionForkDeliveryDisposition
 }
+
+type SessionForkStateBindingMode string
+
+const (
+	SessionForkStateBindingHostCopy      SessionForkStateBindingMode = "host_copy"
+	SessionForkStateBindingProviderOwned SessionForkStateBindingMode = "provider_owned"
+)
 
 // SessionForkProviderStateBinding describes the provider-local durable state
 // that must become independently discoverable from the target Tutti session's

--- a/packages/agent/host/types.go
+++ b/packages/agent/host/types.go
@@ -160,22 +160,27 @@ type SessionForkTargetContext struct {
 }
 
 type SessionForkDriverDescriptor struct {
-	Kind                        string
-	Version                     string
-	StateBindingMode            SessionForkStateBindingMode
-	FullSession                 bool
-	ThroughTurn                 bool
-	ThroughProviderTurnIDs      []string
-	ThroughProviderTurnIDsKnown bool
+	Kind             string
+	Version          string
+	StateBindingMode SessionForkStateBindingMode
+	// DeterministicTargetSessionID guarantees that ForkSession honors
+	// TargetProviderSessionID and that repeating the same input reconciles or
+	// creates that one provider child instead of allocating another identity.
+	DeterministicTargetSessionID bool
+	FullSession                  bool
+	ThroughTurn                  bool
+	ThroughProviderTurnIDs       []string
+	ThroughProviderTurnIDsKnown  bool
 }
 
 type RuntimeSessionForkInput struct {
-	Source                ProviderRuntimeSession
-	SourceProviderTurnID  string
-	SourceProviderTurnIDs []string
-	TargetTitle           string
-	RequestID             string
-	Driver                SessionForkDriverDescriptor
+	Source                  ProviderRuntimeSession
+	SourceProviderTurnID    string
+	SourceProviderTurnIDs   []string
+	TargetProviderSessionID string
+	TargetTitle             string
+	RequestID               string
+	Driver                  SessionForkDriverDescriptor
 }
 
 type SessionForkDeliveryDisposition string

--- a/packages/agent/store-sqlite/migrations.go
+++ b/packages/agent/store-sqlite/migrations.go
@@ -75,6 +75,7 @@ const schemaMigrationWorkspaceAgentSessionForkV1 = "workspace_agent_session_fork
 const schemaMigrationWorkspaceAgentSessionForkV2 = "workspace_agent_session_fork_v2"
 const schemaMigrationWorkspaceAgentSessionForkV3 = "workspace_agent_session_fork_v3"
 const schemaMigrationWorkspaceAgentSessionForkV4 = "workspace_agent_session_fork_v4"
+const schemaMigrationWorkspaceAgentSessionForkV5 = "workspace_agent_session_fork_v5"
 
 // claimableMigrationIDs are the migration IDs that may already be recorded
 // in the legacy tuttid ledger; the claim copies exactly these.
@@ -272,7 +273,10 @@ CREATE TABLE IF NOT EXISTS `+schemaMigrationsTable+` (
 	if err := s.applyWorkspaceAgentSessionForkV3(ctx); err != nil {
 		return err
 	}
-	return s.applyWorkspaceAgentSessionForkV4(ctx)
+	if err := s.applyWorkspaceAgentSessionForkV4(ctx); err != nil {
+		return err
+	}
+	return s.applyWorkspaceAgentSessionForkV5(ctx)
 }
 
 // claimLegacyMigrations copies agent-store migration records that were

--- a/packages/agent/store-sqlite/migrations_session_fork.go
+++ b/packages/agent/store-sqlite/migrations_session_fork.go
@@ -375,3 +375,48 @@ WHERE workspace_id = ? AND operation_id = ? AND status = 'committed'
 	}
 	return nil
 }
+
+// applyWorkspaceAgentSessionForkV5 persists the provider identities created by
+// a native fork. Claude's official SDK remaps every transcript UUID, so the
+// canonical child must not retain source provider-turn identities.
+func (s *Store) applyWorkspaceAgentSessionForkV5(ctx context.Context) error {
+	applied, err := s.hasMigration(ctx, schemaMigrationWorkspaceAgentSessionForkV5)
+	if err != nil || applied {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin workspace agent session fork v5: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `
+ALTER TABLE workspace_agent_session_fork_operations
+ADD COLUMN target_title TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE workspace_agent_session_fork_operations
+ADD COLUMN target_provider_turn_ids_json TEXT NOT NULL DEFAULT '[]'
+CHECK (
+  json_valid(target_provider_turn_ids_json)
+  AND json_type(target_provider_turn_ids_json) = 'array'
+);
+
+ALTER TABLE workspace_agent_session_fork_operations
+ADD COLUMN provider_state_binding_mode TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE workspace_agent_session_fork_operations
+ADD COLUMN provider_state_binding_receipt TEXT NOT NULL DEFAULT '';
+
+UPDATE workspace_agent_session_fork_operations
+SET provider_state_binding_mode = 'host_copy'
+WHERE TRIM(COALESCE(target_provider_session_id, '')) <> '';
+`); err != nil {
+		return fmt.Errorf("add workspace agent session fork provider mapping: %w", err)
+	}
+	if err := recordMigrationTx(ctx, tx, schemaMigrationWorkspaceAgentSessionForkV5); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit workspace agent session fork v5: %w", err)
+	}
+	return nil
+}

--- a/packages/agent/store-sqlite/migrations_session_fork_test.go
+++ b/packages/agent/store-sqlite/migrations_session_fork_test.go
@@ -293,10 +293,11 @@ func assertSessionForkMigrationCounts(t *testing.T, db *sql.DB, operationCount i
 	}
 	if err := db.QueryRow(`
 SELECT COUNT(*) FROM agent_store_schema_migrations
-WHERE id IN (?, ?, ?, ?)
+WHERE id IN (?, ?, ?, ?, ?)
 `, schemaMigrationWorkspaceAgentSessionForkV1, schemaMigrationWorkspaceAgentSessionForkV2,
 		schemaMigrationWorkspaceAgentSessionForkV3,
-		schemaMigrationWorkspaceAgentSessionForkV4).Scan(&migrationRows); err != nil {
+		schemaMigrationWorkspaceAgentSessionForkV4,
+		schemaMigrationWorkspaceAgentSessionForkV5).Scan(&migrationRows); err != nil {
 		t.Fatal(err)
 	}
 	if err := db.QueryRow(`
@@ -306,9 +307,9 @@ WHERE point_kind = 'through_turn'
 		t.Fatal(err)
 	}
 	if operations != operationCount || reservations != operationCount ||
-		barriers != operationCount || migrationRows != 4 || pointKinds != operationCount {
+		barriers != operationCount || migrationRows != 5 || pointKinds != operationCount {
 		t.Fatalf(
-			"migration counts operations=%d reservations=%d barriers=%d ledger=%d pointKinds=%d, want %d/%d/%d/4/%d",
+			"migration counts operations=%d reservations=%d barriers=%d ledger=%d pointKinds=%d, want %d/%d/%d/5/%d",
 			operations, reservations, barriers, migrationRows, pointKinds,
 			operationCount, operationCount, operationCount, operationCount,
 		)
@@ -329,7 +330,8 @@ WHERE id IN (
   'workspace_agent_session_fork_v1',
   'workspace_agent_session_fork_v2',
   'workspace_agent_session_fork_v3',
-  'workspace_agent_session_fork_v4'
+  'workspace_agent_session_fork_v4',
+  'workspace_agent_session_fork_v5'
 );
 `); err != nil {
 		t.Fatalf("reset session fork migrations to pre-v1: %v", err)

--- a/packages/agent/store-sqlite/session_fork.go
+++ b/packages/agent/store-sqlite/session_fork.go
@@ -46,7 +46,10 @@ SELECT operation_id, workspace_id, request_id, request_hash,
        source_provider_session_id, source_turn_id, source_provider_turn_id,
        COALESCE(target_turn_id, ''),
        point_kind, driver_kind, driver_version, status,
-       COALESCE(target_provider_session_id, ''), snapshot_hash, last_error,
+       COALESCE(target_provider_session_id, ''),
+       target_title, target_provider_turn_ids_json,
+       provider_state_binding_mode, provider_state_binding_receipt,
+       snapshot_hash, last_error,
        created_at_unix_ms, updated_at_unix_ms,
        COALESCE(dispatched_at_unix_ms, 0), COALESCE(accepted_at_unix_ms, 0),
        COALESCE(completed_at_unix_ms, 0),
@@ -230,14 +233,16 @@ INSERT INTO workspace_agent_session_fork_operations (
   operation_id, workspace_id, request_id, request_hash,
   source_agent_session_id, target_agent_session_id,
   source_provider_session_id, source_turn_id, source_provider_turn_id,
-  point_kind, driver_kind, driver_version, status, snapshot_json, snapshot_hash,
+  point_kind, driver_kind, driver_version, status, target_title,
+  snapshot_json, snapshot_hash,
   created_at_unix_ms, updated_at_unix_ms
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `, input.OperationID, input.WorkspaceID, input.RequestID, input.RequestHash,
 		input.SourceAgentSessionID, input.TargetAgentSessionID,
 		source.ProviderSessionID, input.SourceTurnID, selected.RootProviderTurnID,
 		input.PointKind, input.DriverKind, input.DriverVersion, SessionForkStatusPrepared,
-		string(snapshotJSON), snapshotHash, input.OccurredAtUnixMS, input.OccurredAtUnixMS); err != nil {
+		snapshot.TargetTitle, string(snapshotJSON), snapshotHash,
+		input.OccurredAtUnixMS, input.OccurredAtUnixMS); err != nil {
 		return SessionForkOperation{}, false, fmt.Errorf("insert session fork operation: %w", err)
 	}
 	if _, err := tx.ExecContext(ctx, `

--- a/packages/agent/store-sqlite/session_fork_operations.go
+++ b/packages/agent/store-sqlite/session_fork_operations.go
@@ -51,7 +51,7 @@ LIMIT ?`, SessionForkStatusPrepared, SessionForkStatusDispatching,
 
 func (s *Store) MarkSessionForkDispatching(ctx context.Context, workspaceID, operationID string, now int64) (SessionForkOperation, bool, error) {
 	return s.transitionSessionFork(ctx, workspaceID, operationID, SessionForkStatusPrepared,
-		SessionForkStatusDispatching, "", "", now)
+		SessionForkStatusDispatching, "", nil, "", "", "", now)
 }
 
 func (s *Store) FailPreparedSessionFork(
@@ -66,6 +66,9 @@ func (s *Store) FailPreparedSessionFork(
 		SessionForkStatusPrepared,
 		SessionForkStatusFailed,
 		"",
+		nil,
+		"",
+		"",
 		lastError,
 		now,
 	)
@@ -75,10 +78,42 @@ func (s *Store) RecordSessionForkProviderResult(ctx context.Context, input Sessi
 	input.WorkspaceID, input.OperationID = strings.TrimSpace(input.WorkspaceID), strings.TrimSpace(input.OperationID)
 	input.TargetProviderSessionID = strings.TrimSpace(input.TargetProviderSessionID)
 	input.LastError = strings.TrimSpace(input.LastError)
+	input.StateBindingMode = strings.TrimSpace(input.StateBindingMode)
+	input.StateBindingReceipt = strings.TrimSpace(input.StateBindingReceipt)
+	rawTargetProviderTurnCount := len(input.TargetProviderTurnIDs)
+	input.TargetProviderTurnIDs = normalizedProviderIdentityList(input.TargetProviderTurnIDs)
+	if rawTargetProviderTurnCount != len(input.TargetProviderTurnIDs) {
+		return SessionForkOperation{}, false, errors.New(
+			"session fork target provider turn identities are invalid",
+		)
+	}
+	if input.StateBindingMode == "" && input.Status == SessionForkStatusProviderAccepted {
+		input.StateBindingMode = "host_copy"
+	}
 	switch input.Status {
 	case SessionForkStatusProviderAccepted:
-		if input.TargetProviderSessionID == "" {
+		if input.TargetProviderSessionID == "" || input.StateBindingMode == "" {
 			return SessionForkOperation{}, false, errors.New("accepted session fork requires target provider session id")
+		}
+		switch input.StateBindingMode {
+		case "host_copy":
+			if len(input.TargetProviderTurnIDs) != 0 ||
+				input.StateBindingReceipt != "" {
+				return SessionForkOperation{}, false, errors.New(
+					"host-copy session fork contains provider-owned evidence",
+				)
+			}
+		case "provider_owned":
+			if len(input.TargetProviderTurnIDs) == 0 ||
+				input.StateBindingReceipt == "" {
+				return SessionForkOperation{}, false, errors.New(
+					"provider-owned session fork requires mapping and receipt evidence",
+				)
+			}
+		default:
+			return SessionForkOperation{}, false, errors.New(
+				"accepted session fork has invalid provider state binding mode",
+			)
 		}
 	case SessionForkStatusFailed, SessionForkStatusUnknown:
 	default:
@@ -86,6 +121,7 @@ func (s *Store) RecordSessionForkProviderResult(ctx context.Context, input Sessi
 	}
 	return s.transitionSessionFork(ctx, input.WorkspaceID, input.OperationID,
 		SessionForkStatusDispatching, input.Status, input.TargetProviderSessionID,
+		input.TargetProviderTurnIDs, input.StateBindingMode, input.StateBindingReceipt,
 		input.LastError, input.OccurredAtUnixMS)
 }
 
@@ -120,6 +156,25 @@ func (s *Store) CommitSessionFork(ctx context.Context, workspaceID, operationID 
 	if snapshot.BoundaryMessageID <= 0 || len(snapshot.Turns) == 0 ||
 		snapshot.Turns[len(snapshot.Turns)-1].Turn.TurnID != op.SourceTurnID {
 		return SessionForkCommitResult{}, ErrSessionForkTurnState
+	}
+	switch op.StateBindingMode {
+	case "host_copy":
+		if len(op.TargetProviderTurnIDs) != 0 || op.StateBindingReceipt != "" {
+			return SessionForkCommitResult{}, errors.New(
+				"host-copy session fork contains provider-owned identity evidence",
+			)
+		}
+	case "provider_owned":
+		if op.StateBindingReceipt == "" ||
+			len(op.TargetProviderTurnIDs) != len(snapshot.Turns) {
+			return SessionForkCommitResult{}, errors.New(
+				"provider-owned session fork has incomplete provider identity mapping",
+			)
+		}
+	default:
+		return SessionForkCommitResult{}, errors.New(
+			"session fork provider state binding mode is invalid",
+		)
 	}
 	if op.Status == SessionForkStatusCommitted {
 		materialized := materializeSessionForkSnapshot(snapshot)
@@ -216,10 +271,13 @@ WHERE workspace_id = ? AND target_agent_session_id = ?
 	mutations := []TransactionMutation{
 		transactionMutation(workspaceID, op.TargetAgentSessionID, MutationEntitySession, op.TargetAgentSessionID, "insert", now),
 	}
-	for _, item := range snapshot.Turns {
+	for index, item := range snapshot.Turns {
 		turn, err := remapSessionForkTurn(item.Turn, identityMap)
 		if err != nil {
 			return SessionForkCommitResult{}, err
+		}
+		if len(op.TargetProviderTurnIDs) != 0 {
+			turn.RootProviderTurnID = op.TargetProviderTurnIDs[index]
 		}
 		if err := insertForkedTurnTx(ctx, tx, workspaceID, op.TargetAgentSessionID, turn); err != nil {
 			return SessionForkCommitResult{}, err
@@ -407,7 +465,8 @@ WHERE workspace_id = ? AND target_agent_session_id = ?
 
 func (s *Store) transitionSessionFork(
 	ctx context.Context,
-	workspaceID, operationID, fromStatus, toStatus, targetProviderSessionID, lastError string,
+	workspaceID, operationID, fromStatus, toStatus, targetProviderSessionID string,
+	targetProviderTurnIDs []string, stateBindingMode, stateBindingReceipt, lastError string,
 	now int64,
 ) (SessionForkOperation, bool, error) {
 	if s == nil || s.db == nil || strings.TrimSpace(workspaceID) == "" ||
@@ -420,15 +479,27 @@ func (s *Store) transitionSessionFork(
 		return SessionForkOperation{}, false, err
 	}
 	defer func() { _ = tx.Rollback() }()
+	if targetProviderTurnIDs == nil {
+		targetProviderTurnIDs = []string{}
+	}
+	targetProviderTurnIDsJSON, err := json.Marshal(targetProviderTurnIDs)
+	if err != nil {
+		return SessionForkOperation{}, false, err
+	}
 	result, err := tx.ExecContext(ctx, `
 UPDATE workspace_agent_session_fork_operations
 SET status = ?, target_provider_session_id = NULLIF(?, ''), last_error = ?,
+    target_provider_turn_ids_json = ?,
+    provider_state_binding_mode = ?,
+    provider_state_binding_receipt = ?,
     dispatched_at_unix_ms = CASE WHEN ? = 'dispatching' THEN ? ELSE dispatched_at_unix_ms END,
     accepted_at_unix_ms = CASE WHEN ? = 'provider_accepted' THEN ? ELSE accepted_at_unix_ms END,
     completed_at_unix_ms = CASE WHEN ? IN ('failed','unknown') THEN ? ELSE completed_at_unix_ms END,
     updated_at_unix_ms = ?
 WHERE workspace_id = ? AND operation_id = ? AND status = ?
 `, toStatus, strings.TrimSpace(targetProviderSessionID), strings.TrimSpace(lastError),
+		string(targetProviderTurnIDsJSON), strings.TrimSpace(stateBindingMode),
+		strings.TrimSpace(stateBindingReceipt),
 		toStatus, now, toStatus, now, toStatus, now, now, workspaceID, operationID, fromStatus)
 	if err != nil {
 		return SessionForkOperation{}, false, fmt.Errorf("transition session fork operation: %w", err)

--- a/packages/agent/store-sqlite/session_fork_operations.go
+++ b/packages/agent/store-sqlite/session_fork_operations.go
@@ -25,14 +25,14 @@ func (s *Store) ListRecoverableSessionForkOperationsPage(
 		limit = 100
 	}
 	rows, err := s.db.QueryContext(ctx, sessionForkOperationSelectSQL+`
-WHERE status IN (?, ?, ?)
+WHERE status IN (?, ?, ?, ?)
   AND (
     created_at_unix_ms > ?
     OR (created_at_unix_ms = ? AND operation_id > ?)
   )
 ORDER BY created_at_unix_ms, operation_id
 LIMIT ?`, SessionForkStatusPrepared, SessionForkStatusDispatching,
-		SessionForkStatusProviderAccepted, after.CreatedAtUnixMS,
+		SessionForkStatusProviderAccepted, SessionForkStatusUnknown, after.CreatedAtUnixMS,
 		after.CreatedAtUnixMS, strings.TrimSpace(after.OperationID), limit)
 	if err != nil {
 		return nil, fmt.Errorf("list recoverable session fork operations: %w", err)
@@ -52,6 +52,29 @@ LIMIT ?`, SessionForkStatusPrepared, SessionForkStatusDispatching,
 func (s *Store) MarkSessionForkDispatching(ctx context.Context, workspaceID, operationID string, now int64) (SessionForkOperation, bool, error) {
 	return s.transitionSessionFork(ctx, workspaceID, operationID, SessionForkStatusPrepared,
 		SessionForkStatusDispatching, "", nil, "", "", "", now)
+}
+
+// RetryUnknownSessionFork reopens only the durable dispatch marker. Callers
+// must first attest that the exact driver supports one deterministic target
+// provider identity across repeated dispatches.
+func (s *Store) RetryUnknownSessionFork(
+	ctx context.Context,
+	workspaceID, operationID string,
+	now int64,
+) (SessionForkOperation, bool, error) {
+	return s.transitionSessionFork(
+		ctx,
+		workspaceID,
+		operationID,
+		SessionForkStatusUnknown,
+		SessionForkStatusDispatching,
+		"",
+		nil,
+		"",
+		"",
+		"",
+		now,
+	)
 }
 
 func (s *Store) FailPreparedSessionFork(
@@ -494,13 +517,18 @@ SET status = ?, target_provider_session_id = NULLIF(?, ''), last_error = ?,
     provider_state_binding_receipt = ?,
     dispatched_at_unix_ms = CASE WHEN ? = 'dispatching' THEN ? ELSE dispatched_at_unix_ms END,
     accepted_at_unix_ms = CASE WHEN ? = 'provider_accepted' THEN ? ELSE accepted_at_unix_ms END,
-    completed_at_unix_ms = CASE WHEN ? IN ('failed','unknown') THEN ? ELSE completed_at_unix_ms END,
+    completed_at_unix_ms = CASE
+      WHEN ? = 'dispatching' THEN 0
+      WHEN ? IN ('failed','unknown') THEN ?
+      ELSE completed_at_unix_ms
+    END,
     updated_at_unix_ms = ?
 WHERE workspace_id = ? AND operation_id = ? AND status = ?
 `, toStatus, strings.TrimSpace(targetProviderSessionID), strings.TrimSpace(lastError),
 		string(targetProviderTurnIDsJSON), strings.TrimSpace(stateBindingMode),
 		strings.TrimSpace(stateBindingReceipt),
-		toStatus, now, toStatus, now, toStatus, now, now, workspaceID, operationID, fromStatus)
+		toStatus, now, toStatus, now, toStatus, toStatus, now, now,
+		workspaceID, operationID, fromStatus)
 	if err != nil {
 		return SessionForkOperation{}, false, fmt.Errorf("transition session fork operation: %w", err)
 	}

--- a/packages/agent/store-sqlite/session_fork_queries.go
+++ b/packages/agent/store-sqlite/session_fork_queries.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -44,7 +45,10 @@ SELECT operation_id, workspace_id, request_id, request_hash,
        source_provider_session_id, source_turn_id, source_provider_turn_id,
        COALESCE(target_turn_id, ''),
        point_kind, driver_kind, driver_version, status,
-       COALESCE(target_provider_session_id, ''), snapshot_hash, last_error,
+       COALESCE(target_provider_session_id, ''),
+       target_title, target_provider_turn_ids_json,
+       provider_state_binding_mode, provider_state_binding_receipt,
+       snapshot_hash, last_error,
        created_at_unix_ms, updated_at_unix_ms,
        COALESCE(dispatched_at_unix_ms, 0), COALESCE(accepted_at_unix_ms, 0),
        COALESCE(completed_at_unix_ms, 0),
@@ -91,12 +95,15 @@ func scanSessionForkOperation(scanner rowScanner) (SessionForkOperation, error) 
 
 func scanSessionForkOperationWithExtra(scanner rowScanner, extra ...any) (SessionForkOperation, error) {
 	var op SessionForkOperation
+	var targetProviderTurnIDsJSON string
 	destinations := []any{
 		&op.OperationID, &op.WorkspaceID, &op.RequestID, &op.RequestHash,
 		&op.SourceAgentSessionID, &op.TargetAgentSessionID,
 		&op.SourceProviderSessionID, &op.SourceTurnID, &op.SourceProviderTurnID,
 		&op.TargetTurnID,
 		&op.PointKind, &op.DriverKind, &op.DriverVersion, &op.Status, &op.TargetProviderSessionID,
+		&op.TargetTitle, &targetProviderTurnIDsJSON,
+		&op.StateBindingMode, &op.StateBindingReceipt,
 		&op.SnapshotHash, &op.LastError, &op.CreatedAtUnixMS, &op.UpdatedAtUnixMS,
 		&op.DispatchedAtUnixMS, &op.AcceptedAtUnixMS, &op.CompletedAtUnixMS,
 		&op.ClientObservedAtUnixMS,
@@ -105,6 +112,9 @@ func scanSessionForkOperationWithExtra(scanner rowScanner, extra ...any) (Sessio
 	if err := scanner.Scan(destinations...); err != nil {
 		return SessionForkOperation{}, err
 	}
+	if err := json.Unmarshal([]byte(targetProviderTurnIDsJSON), &op.TargetProviderTurnIDs); err != nil {
+		return SessionForkOperation{}, fmt.Errorf("decode target provider turn identities: %w", err)
+	}
 	if op.Status == SessionForkStatusCommitted &&
 		strings.TrimSpace(op.TargetTurnID) == "" {
 		return SessionForkOperation{}, errors.New(
@@ -112,6 +122,23 @@ func scanSessionForkOperationWithExtra(scanner rowScanner, extra ...any) (Sessio
 		)
 	}
 	return op, nil
+}
+
+func normalizedProviderIdentityList(values []string) []string {
+	result := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return nil
+		}
+		if _, duplicate := seen[value]; duplicate {
+			return nil
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
 }
 
 func scanSessionForkLineage(scanner rowScanner) (SessionForkLineage, bool, error) {

--- a/packages/agent/store-sqlite/session_fork_test.go
+++ b/packages/agent/store-sqlite/session_fork_test.go
@@ -1417,6 +1417,53 @@ func TestSessionForkFailedAndUnknownReleaseSourceFence(t *testing.T) {
 	}
 }
 
+func TestRetryUnknownSessionForkReopensDurableDispatchMarker(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	ctx := context.Background()
+	seedForkSession(t, store)
+	input := SessionForkPrepare{
+		OperationID: "fork-retry", WorkspaceID: "ws-1",
+		RequestID: "request-retry", RequestHash: "hash-retry",
+		SourceAgentSessionID: "source", TargetAgentSessionID: "target-retry",
+		SourceTurnID: "turn-1", DriverKind: "claude",
+		DriverVersion: "deterministic-v1", OccurredAtUnixMS: 100,
+	}
+	if _, _, err := prepareSessionForkForTest(t, store, ctx, input); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.MarkSessionForkDispatching(
+		ctx, input.WorkspaceID, input.OperationID, 101,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.RecordSessionForkProviderResult(
+		ctx,
+		SessionForkProviderResult{
+			WorkspaceID: input.WorkspaceID, OperationID: input.OperationID,
+			Status: SessionForkStatusUnknown, LastError: "response lost",
+			OccurredAtUnixMS: 102,
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+	operation, changed, err := store.RetryUnknownSessionFork(
+		ctx, input.WorkspaceID, input.OperationID, 103,
+	)
+	if err != nil || !changed ||
+		operation.Status != SessionForkStatusDispatching ||
+		operation.LastError != "" ||
+		operation.CompletedAtUnixMS != 0 ||
+		operation.DispatchedAtUnixMS != 103 {
+		t.Fatalf(
+			"RetryUnknownSessionFork() operation=%#v changed=%v error=%v",
+			operation,
+			changed,
+			err,
+		)
+	}
+}
+
 func TestSessionForkPrepareRequiresGoalAndRuntimeQuiescence(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/packages/agent/store-sqlite/session_fork_test.go
+++ b/packages/agent/store-sqlite/session_fork_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -241,6 +242,79 @@ WHERE workspace_id = 'ws-1' AND agent_session_id = 'target'
 			"CommitSessionFork(after child delete) result=%#v error=%v",
 			afterDelete,
 			err,
+		)
+	}
+}
+
+func TestSessionForkProviderOwnedResultRewritesChildProviderTurnIdentity(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	seedForkSession(t, store)
+	if _, updated, err := store.UpdateSessionTitle(
+		ctx, "ws-1", "source", "Claude session",
+	); err != nil || !updated {
+		t.Fatalf("UpdateSessionTitle() updated=%v error=%v", updated, err)
+	}
+	input := SessionForkPrepare{
+		OperationID: "fork-provider-owned", WorkspaceID: "ws-1",
+		RequestID: "request-provider-owned", RequestHash: "hash-provider-owned",
+		SourceAgentSessionID: "source", TargetAgentSessionID: "target-provider-owned",
+		SourceTurnID: "turn-1", DriverKind: "claude-agent-sdk-session-fork",
+		DriverVersion: "0.3.201/sidecar-v3", OccurredAtUnixMS: 500,
+	}
+	operation, _, err := prepareSessionForkForTest(t, store, ctx, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if operation.TargetTitle == "" {
+		t.Fatal("prepared operation omitted the frozen target title")
+	}
+	if _, _, err := store.MarkSessionForkDispatching(
+		ctx, input.WorkspaceID, input.OperationID, 501,
+	); err != nil {
+		t.Fatal(err)
+	}
+	operation, _, err = store.RecordSessionForkProviderResult(
+		ctx,
+		SessionForkProviderResult{
+			WorkspaceID: input.WorkspaceID, OperationID: input.OperationID,
+			Status:                  SessionForkStatusProviderAccepted,
+			TargetProviderSessionID: "claude-child",
+			TargetProviderTurnIDs:   []string{"claude-child-turn-1"},
+			StateBindingMode:        "provider_owned",
+			StateBindingReceipt:     "claude-sdk-fork-v1:receipt",
+			OccurredAtUnixMS:        502,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if operation.StateBindingMode != "provider_owned" ||
+		operation.StateBindingReceipt == "" ||
+		!reflect.DeepEqual(
+			operation.TargetProviderTurnIDs,
+			[]string{"claude-child-turn-1"},
+		) {
+		t.Fatalf("provider acceptance evidence=%#v", operation)
+	}
+	result, err := store.CommitSessionFork(ctx, input.WorkspaceID, input.OperationID, 503)
+	if err != nil {
+		t.Fatal(err)
+	}
+	turn, found, err := store.GetTurn(
+		ctx,
+		input.WorkspaceID,
+		input.TargetAgentSessionID,
+		result.Lineage.TargetTurnID,
+	)
+	if err != nil || !found {
+		t.Fatalf("GetTurn() found=%v error=%v", found, err)
+	}
+	if turn.RootProviderTurnID != "claude-child-turn-1" {
+		t.Fatalf(
+			"child root provider turn id=%q, want remapped Claude UUID",
+			turn.RootProviderTurnID,
 		)
 	}
 }

--- a/packages/agent/store-sqlite/session_fork_types.go
+++ b/packages/agent/store-sqlite/session_fork_types.go
@@ -49,6 +49,10 @@ type SessionForkOperation struct {
 	DriverVersion           string
 	Status                  string
 	TargetProviderSessionID string
+	TargetProviderTurnIDs   []string
+	TargetTitle             string
+	StateBindingMode        string
+	StateBindingReceipt     string
 	SnapshotHash            string
 	LastError               string
 	CreatedAtUnixMS         int64
@@ -82,6 +86,9 @@ type SessionForkProviderResult struct {
 	OperationID             string
 	Status                  string
 	TargetProviderSessionID string
+	TargetProviderTurnIDs   []string
+	StateBindingMode        string
+	StateBindingReceipt     string
 	LastError               string
 	OccurredAtUnixMS        int64
 }

--- a/services/tuttid/service/agent/claude_session_fork_integration_test.go
+++ b/services/tuttid/service/agent/claude_session_fork_integration_test.go
@@ -80,8 +80,9 @@ func TestClaudeSessionForkTraversesProductionWiringAcrossRestart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ForkSession source -> child: %v", err)
 	}
+	childProviderSessionID := forked.Operation.OperationID
 	if forked.Operation.Status != storesqlite.SessionForkStatusCommitted ||
-		forked.Session.ProviderSessionID != "claude-child" ||
+		forked.Session.ProviderSessionID != childProviderSessionID ||
 		forked.Lineage == nil {
 		t.Fatalf("source fork result=%#v", forked)
 	}
@@ -140,7 +141,7 @@ func TestClaudeSessionForkTraversesProductionWiringAcrossRestart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resume committed child after restart: %v", err)
 	}
-	if resumed.ProviderSessionID != "claude-child" ||
+	if resumed.ProviderSessionID != childProviderSessionID ||
 		!restartedBridge.RuntimeSessionLive(
 			"workspace-claude-fork",
 			"session-child",
@@ -154,7 +155,7 @@ func TestClaudeSessionForkTraversesProductionWiringAcrossRestart(t *testing.T) {
 	if cursor, exists := startPayload["resumeCursor"]; exists && cursor != nil {
 		t.Fatalf("child resume reused source cursor: %#v", cursor)
 	}
-	if startPayload["providerSessionId"] != "claude-child" {
+	if startPayload["providerSessionId"] != childProviderSessionID {
 		t.Fatalf("child start payload=%#v", startPayload)
 	}
 
@@ -175,7 +176,7 @@ func TestClaudeSessionForkTraversesProductionWiringAcrossRestart(t *testing.T) {
 		t.Fatalf("ForkSession child -> grandchild: %v", err)
 	}
 	if nested.Operation.Status != storesqlite.SessionForkStatusCommitted ||
-		nested.Session.ProviderSessionID != "claude-grandchild" ||
+		nested.Session.ProviderSessionID != nested.Operation.OperationID ||
 		nested.Lineage == nil {
 		t.Fatalf("nested fork result=%#v", nested)
 	}
@@ -343,9 +344,10 @@ func seedClaudeForkIntegrationSource(
 }
 
 type claudeForkIntegrationTransport struct {
-	mu            sync.Mutex
-	requestTypes  []string
-	startPayloads map[string]map[string]any
+	mu              sync.Mutex
+	requestTypes    []string
+	startPayloads   map[string]map[string]any
+	providerTurnIDs map[string]string
 }
 
 func (t *claudeForkIntegrationTransport) Start(
@@ -386,6 +388,44 @@ func (t *claudeForkIntegrationTransport) lastStartPayload(
 	return cloneClaudeForkIntegrationMap(payload), found
 }
 
+func (t *claudeForkIntegrationTransport) providerTurnIDsForSession(
+	providerSessionID string,
+) []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if providerSessionID == "claude-source" {
+		return []string{"source-prompt-1"}
+	}
+	if turnID := t.providerTurnIDs[providerSessionID]; turnID != "" {
+		return []string{turnID}
+	}
+	return []string{}
+}
+
+func (t *claudeForkIntegrationTransport) forkTarget(
+	sourceID, targetID string,
+) (string, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if targetID == "" {
+		return "", false
+	}
+	targetTurnID := ""
+	switch {
+	case sourceID == "claude-source":
+		targetTurnID = "child-prompt-1"
+	case t.providerTurnIDs[sourceID] != "":
+		targetTurnID = "grandchild-prompt-1"
+	default:
+		return "", false
+	}
+	if t.providerTurnIDs == nil {
+		t.providerTurnIDs = make(map[string]string)
+	}
+	t.providerTurnIDs[targetID] = targetTurnID
+	return targetTurnID, true
+}
+
 type claudeForkIntegrationConnection struct {
 	transport      *claudeForkIntegrationTransport
 	agentSessionID string
@@ -413,7 +453,7 @@ func (c *claudeForkIntegrationConnection) Send(data []byte) error {
 			request.ID,
 			"ok",
 			map[string]any{
-				"providerTurnIds": claudeForkIntegrationTurnIDs(
+				"providerTurnIds": c.transport.providerTurnIDsForSession(
 					claudeForkIntegrationString(
 						request.Payload["providerSessionId"],
 					),
@@ -424,8 +464,11 @@ func (c *claudeForkIntegrationConnection) Send(data []byte) error {
 		sourceID := claudeForkIntegrationString(
 			request.Payload["providerSessionId"],
 		)
-		targetID, targetTurnID := claudeForkIntegrationChild(sourceID)
-		if targetID == "" {
+		targetID := claudeForkIntegrationString(
+			request.Payload["targetProviderSessionId"],
+		)
+		targetTurnID, ok := c.transport.forkTarget(sourceID, targetID)
+		if !ok {
 			return c.emit(
 				request.ID,
 				"error",
@@ -529,30 +572,6 @@ func (c *claudeForkIntegrationConnection) Close() error {
 		close(c.closed)
 	})
 	return nil
-}
-
-func claudeForkIntegrationTurnIDs(providerSessionID string) []string {
-	switch providerSessionID {
-	case "claude-source":
-		return []string{"source-prompt-1"}
-	case "claude-child":
-		return []string{"child-prompt-1"}
-	case "claude-grandchild":
-		return []string{"grandchild-prompt-1"}
-	default:
-		return []string{}
-	}
-}
-
-func claudeForkIntegrationChild(sourceID string) (string, string) {
-	switch sourceID {
-	case "claude-source":
-		return "claude-child", "child-prompt-1"
-	case "claude-child":
-		return "claude-grandchild", "grandchild-prompt-1"
-	default:
-		return "", ""
-	}
 }
 
 func cloneClaudeForkIntegrationMap(source map[string]any) map[string]any {

--- a/services/tuttid/service/agent/claude_session_fork_integration_test.go
+++ b/services/tuttid/service/agent/claude_session_fork_integration_test.go
@@ -1,0 +1,579 @@
+package agent
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"io"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	hostadapter "github.com/tutti-os/tutti/packages/agent/daemon/hostadapter"
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+	_ "modernc.org/sqlite"
+)
+
+func TestClaudeSessionForkTraversesProductionWiringAcrossRestart(t *testing.T) {
+	ctx := t.Context()
+	db, err := sql.Open(
+		"sqlite",
+		filepath.Join(t.TempDir(), "claude-session-fork-integration.db"),
+	)
+	if err != nil {
+		t.Fatalf("open SQLite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+	canonical := storesqlite.New(db, storesqlite.Options{})
+	if err := canonical.Migrate(ctx); err != nil {
+		t.Fatalf("migrate SQLite: %v", err)
+	}
+	seedClaudeForkIntegrationSource(t, canonical)
+
+	store := &agenthost.SQLiteWorkspaceStore{
+		StoreForWorkspace: func(workspaceID string) *storesqlite.Store {
+			if workspaceID == "workspace-claude-fork" {
+				return canonical
+			}
+			return nil
+		},
+	}
+	transport := &claudeForkIntegrationTransport{}
+	_, bridge, applicationHost := newClaudeForkIntegrationRuntime(
+		transport,
+		store,
+	)
+
+	capabilities, err := applicationHost.GetSessionForkCapabilities(
+		ctx,
+		agenthost.SessionForkCapabilityInput{
+			WorkspaceID:          "workspace-claude-fork",
+			SourceAgentSessionID: "session-source",
+		},
+	)
+	if err != nil {
+		t.Fatalf("GetSessionForkCapabilities: %v", err)
+	}
+	if !capabilities.ThroughTurn ||
+		!capabilities.ThroughTurnIDsKnown ||
+		len(capabilities.ThroughTurnIDs) != 1 ||
+		capabilities.ThroughTurnIDs[0] != "turn-source" {
+		t.Fatalf("source capabilities=%#v", capabilities)
+	}
+
+	forked, err := applicationHost.ForkSession(
+		ctx,
+		agenthost.ForkSessionInput{
+			WorkspaceID:          "workspace-claude-fork",
+			SourceAgentSessionID: "session-source",
+			TargetAgentSessionID: "session-child",
+			RequestID:            "request-source-child",
+			Point: agenthost.SessionForkPoint{
+				Kind:   agenthost.SessionForkPointThroughTurn,
+				TurnID: "turn-source",
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("ForkSession source -> child: %v", err)
+	}
+	if forked.Operation.Status != storesqlite.SessionForkStatusCommitted ||
+		forked.Session.ProviderSessionID != "claude-child" ||
+		forked.Lineage == nil {
+		t.Fatalf("source fork result=%#v", forked)
+	}
+	childTurn, found, err := canonical.GetTurn(
+		ctx,
+		"workspace-claude-fork",
+		"session-child",
+		forked.Lineage.TargetTurnID,
+	)
+	if err != nil || !found {
+		t.Fatalf("get child turn found=%v error=%v", found, err)
+	}
+	if childTurn.RootProviderTurnID != "child-prompt-1" {
+		t.Fatalf(
+			"child provider turn id=%q, want remapped UUID",
+			childTurn.RootProviderTurnID,
+		)
+	}
+	if bridge.RuntimeSessionLive("workspace-claude-fork", "session-source") {
+		t.Fatal("historical source capability probe created a live runtime")
+	}
+
+	// Rebuild both daemon Controller and Host around the same production Store.
+	// The committed child still contains the frozen source resume cursor, so
+	// the Claude adapter must discard it and resume the canonical child ID.
+	_, restartedBridge, restartedHost := newClaudeForkIntegrationRuntime(
+		transport,
+		store,
+	)
+	child, found, err := canonical.GetSession(
+		ctx,
+		"workspace-claude-fork",
+		"session-child",
+	)
+	if err != nil || !found {
+		t.Fatalf("get committed child found=%v error=%v", found, err)
+	}
+	resumed, err := restartedBridge.Resume(
+		ctx,
+		agenthost.RuntimeResumeInput{
+			WorkspaceID:            child.WorkspaceID,
+			AgentSessionID:         child.ID,
+			AgentTargetID:          child.AgentTargetID,
+			Provider:               child.Provider,
+			ProviderSessionID:      child.ProviderSessionID,
+			Resumable:              true,
+			Cwd:                    child.Cwd,
+			Title:                  child.Title,
+			Status:                 "ready",
+			RuntimeContext:         child.InternalRuntimeContext,
+			InternalRuntimeContext: child.InternalRuntimeContext,
+			CreatedAtUnixMS:        child.CreatedAtUnixMS,
+			UpdatedAtUnixMS:        child.UpdatedAtUnixMS,
+		},
+	)
+	if err != nil {
+		t.Fatalf("resume committed child after restart: %v", err)
+	}
+	if resumed.ProviderSessionID != "claude-child" ||
+		!restartedBridge.RuntimeSessionLive(
+			"workspace-claude-fork",
+			"session-child",
+		) {
+		t.Fatalf("resumed child=%#v", resumed)
+	}
+	startPayload, found := transport.lastStartPayload("session-child")
+	if !found {
+		t.Fatal("child resume did not start Claude sidecar")
+	}
+	if cursor, exists := startPayload["resumeCursor"]; exists && cursor != nil {
+		t.Fatalf("child resume reused source cursor: %#v", cursor)
+	}
+	if startPayload["providerSessionId"] != "claude-child" {
+		t.Fatalf("child start payload=%#v", startPayload)
+	}
+
+	nested, err := restartedHost.ForkSession(
+		ctx,
+		agenthost.ForkSessionInput{
+			WorkspaceID:          "workspace-claude-fork",
+			SourceAgentSessionID: "session-child",
+			TargetAgentSessionID: "session-grandchild",
+			RequestID:            "request-child-grandchild",
+			Point: agenthost.SessionForkPoint{
+				Kind:   agenthost.SessionForkPointThroughTurn,
+				TurnID: forked.Lineage.TargetTurnID,
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("ForkSession child -> grandchild: %v", err)
+	}
+	if nested.Operation.Status != storesqlite.SessionForkStatusCommitted ||
+		nested.Session.ProviderSessionID != "claude-grandchild" ||
+		nested.Lineage == nil {
+		t.Fatalf("nested fork result=%#v", nested)
+	}
+	grandchildTurn, found, err := canonical.GetTurn(
+		ctx,
+		"workspace-claude-fork",
+		"session-grandchild",
+		nested.Lineage.TargetTurnID,
+	)
+	if err != nil || !found {
+		t.Fatalf("get grandchild turn found=%v error=%v", found, err)
+	}
+	if grandchildTurn.RootProviderTurnID != "grandchild-prompt-1" {
+		t.Fatalf(
+			"grandchild provider turn id=%q, want nested remapped UUID",
+			grandchildTurn.RootProviderTurnID,
+		)
+	}
+
+	execResult, err := restartedBridge.Exec(
+		ctx,
+		agenthost.RuntimeExecInput{
+			WorkspaceID:    "workspace-claude-fork",
+			AgentSessionID: "session-child",
+			TurnID:         "turn-child-continue",
+			Content: []agenthost.PromptContentBlock{{
+				Type: "text",
+				Text: "continue from the fork",
+			}},
+			DisplayPrompt: "continue from the fork",
+		},
+	)
+	if err != nil {
+		t.Fatalf("continue forked child: %v", err)
+	}
+	if !execResult.Accepted || execResult.TurnID != "turn-child-continue" {
+		t.Fatalf("child continuation result=%#v", execResult)
+	}
+	if err := restartedBridge.Close(
+		ctx,
+		agenthost.RuntimeCloseInput{
+			WorkspaceID:    "workspace-claude-fork",
+			AgentSessionID: "session-child",
+		},
+	); err != nil {
+		t.Fatalf("close resumed child: %v", err)
+	}
+}
+
+func newClaudeForkIntegrationRuntime(
+	transport agentruntime.ProcessTransport,
+	store *agenthost.SQLiteWorkspaceStore,
+) (
+	*agentruntime.Controller,
+	*hostadapter.RuntimeController,
+	*agenthost.Host,
+) {
+	adapter := agentruntime.NewClaudeCodeSDKAdapter(transport)
+	controller := agentruntime.NewController(
+		[]agentruntime.Adapter{adapter},
+		nil,
+	)
+	bridge := &hostadapter.RuntimeController{Backend: controller}
+	applicationHost := agenthost.New(agenthost.Config{
+		SessionForks:       store,
+		SessionForkRuntime: bridge,
+		Runtime:            bridge,
+	})
+	return controller, bridge, applicationHost
+}
+
+func seedClaudeForkIntegrationSource(
+	t *testing.T,
+	store *storesqlite.Store,
+) {
+	t.Helper()
+	ctx := t.Context()
+	session := storesqlite.SessionStateReport{
+		WorkspaceID:       "workspace-claude-fork",
+		AgentSessionID:    "session-source",
+		Kind:              storesqlite.SessionKindRoot,
+		Origin:            "runtime",
+		Provider:          agentruntime.ProviderClaudeCode,
+		ProviderSessionID: "claude-source",
+		RuntimeContext: map[string]any{
+			"resumeCursor": map[string]any{
+				"kind":            "claude-agent-sdk",
+				"version":         float64(1),
+				"resume":          "claude-source",
+				"resumeSessionAt": "source-answer-1",
+				"turnCount":       float64(1),
+			},
+		},
+		Cwd:              "/workspace",
+		Status:           "ready",
+		CurrentPhase:     "idle",
+		OccurredAtUnixMS: 1,
+	}
+	if _, err := store.ReportSessionState(ctx, session); err != nil {
+		t.Fatalf("seed Claude source session: %v", err)
+	}
+	session.Status = "active"
+	session.CurrentPhase = "working"
+	session.OccurredAtUnixMS = 10
+	if result, err := store.ReportActivityState(
+		ctx,
+		storesqlite.ActivityStateReport{
+			Session: session,
+			Turn: &storesqlite.TurnTransition{
+				WorkspaceID:      session.WorkspaceID,
+				AgentSessionID:   session.AgentSessionID,
+				TurnID:           "turn-source",
+				Phase:            storesqlite.TurnPhaseRunning,
+				OccurredAtUnixMS: 10,
+			},
+			RootProviderTurn: &storesqlite.RootProviderTurnTransition{
+				WorkspaceID:        session.WorkspaceID,
+				RootAgentSessionID: session.AgentSessionID,
+				RootTurnID:         "turn-source",
+				ProviderTurnID:     "source-prompt-1",
+				Phase:              storesqlite.RootProviderTurnPhaseRunning,
+				OccurredAtUnixMS:   10,
+			},
+		},
+	); err != nil || !result.TurnAccepted || !result.RootTurnAccepted {
+		t.Fatalf("seed Claude source turn result=%#v error=%v", result, err)
+	}
+	if _, err := store.ReportSessionMessages(
+		ctx,
+		storesqlite.SessionMessageReport{
+			WorkspaceID:    session.WorkspaceID,
+			AgentSessionID: session.AgentSessionID,
+			Origin:         "runtime",
+			Messages: []storesqlite.MessageUpdate{{
+				MessageID:        "message-source-answer",
+				TurnID:           "turn-source",
+				Role:             "assistant",
+				Kind:             "text",
+				Status:           "completed",
+				Payload:          map[string]any{"text": "source answer"},
+				OccurredAtUnixMS: 11,
+			}},
+		},
+	); err != nil {
+		t.Fatalf("seed Claude source message: %v", err)
+	}
+	session.OccurredAtUnixMS = 12
+	if result, err := store.ReportActivityState(
+		ctx,
+		storesqlite.ActivityStateReport{
+			Session: session,
+			RootProviderTurn: &storesqlite.RootProviderTurnTransition{
+				WorkspaceID:        session.WorkspaceID,
+				RootAgentSessionID: session.AgentSessionID,
+				RootTurnID:         "turn-source",
+				ProviderTurnID:     "source-prompt-1",
+				Phase:              storesqlite.RootProviderTurnPhaseCompleted,
+				Outcome:            storesqlite.TurnOutcomeCompleted,
+				OccurredAtUnixMS:   12,
+			},
+		},
+	); err != nil || !result.RootTurnAccepted {
+		t.Fatalf("settle Claude source turn result=%#v error=%v", result, err)
+	}
+}
+
+type claudeForkIntegrationTransport struct {
+	mu            sync.Mutex
+	requestTypes  []string
+	startPayloads map[string]map[string]any
+}
+
+func (t *claudeForkIntegrationTransport) Start(
+	_ context.Context,
+	spec agentruntime.ProcessSpec,
+) (agentruntime.ProcessConnection, error) {
+	return &claudeForkIntegrationConnection{
+		transport:      t,
+		agentSessionID: spec.AgentSessionID,
+		frames:         make(chan agentruntime.ProcessFrame, 8),
+		closed:         make(chan struct{}),
+	}, nil
+}
+
+func (t *claudeForkIntegrationTransport) record(
+	agentSessionID string,
+	request claudeForkIntegrationRequest,
+) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.requestTypes = append(t.requestTypes, request.Type)
+	if request.Type == "start" {
+		if t.startPayloads == nil {
+			t.startPayloads = make(map[string]map[string]any)
+		}
+		t.startPayloads[agentSessionID] = cloneClaudeForkIntegrationMap(
+			request.Payload,
+		)
+	}
+}
+
+func (t *claudeForkIntegrationTransport) lastStartPayload(
+	agentSessionID string,
+) (map[string]any, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	payload, found := t.startPayloads[agentSessionID]
+	return cloneClaudeForkIntegrationMap(payload), found
+}
+
+type claudeForkIntegrationConnection struct {
+	transport      *claudeForkIntegrationTransport
+	agentSessionID string
+	frames         chan agentruntime.ProcessFrame
+	closed         chan struct{}
+	closeOnce      sync.Once
+}
+
+type claudeForkIntegrationRequest struct {
+	Version int            `json:"version"`
+	ID      string         `json:"id"`
+	Type    string         `json:"type"`
+	Payload map[string]any `json:"payload"`
+}
+
+func (c *claudeForkIntegrationConnection) Send(data []byte) error {
+	var request claudeForkIntegrationRequest
+	if err := json.Unmarshal(data, &request); err != nil {
+		return err
+	}
+	c.transport.record(c.agentSessionID, request)
+	switch request.Type {
+	case "inspect_fork_checkpoints":
+		return c.emit(
+			request.ID,
+			"ok",
+			map[string]any{
+				"providerTurnIds": claudeForkIntegrationTurnIDs(
+					claudeForkIntegrationString(
+						request.Payload["providerSessionId"],
+					),
+				),
+			},
+		)
+	case "fork_session":
+		sourceID := claudeForkIntegrationString(
+			request.Payload["providerSessionId"],
+		)
+		targetID, targetTurnID := claudeForkIntegrationChild(sourceID)
+		if targetID == "" {
+			return c.emit(
+				request.ID,
+				"error",
+				map[string]any{
+					"error":               "unknown fixture source",
+					"deliveryDisposition": "not_started",
+				},
+			)
+		}
+		return c.emit(
+			request.ID,
+			"ok",
+			map[string]any{
+				"providerSessionId":     targetID,
+				"targetProviderTurnIds": []string{targetTurnID},
+				"stateBindingMode":      "provider_owned",
+				"stateBindingReceipt":   "claude-sdk-fork-v1:" + targetID,
+				"deliveryDisposition":   "accepted",
+			},
+		)
+	case "start":
+		return c.emit(
+			request.ID,
+			"session_started",
+			map[string]any{
+				"providerSessionId": claudeForkIntegrationString(
+					request.Payload["providerSessionId"],
+				),
+			},
+		)
+	case "exec":
+		turnID := claudeForkIntegrationString(request.Payload["turnId"])
+		providerTurnID := claudeForkIntegrationString(
+			request.Payload["providerTurnId"],
+		)
+		if err := c.emit(
+			"",
+			"assistant_completed",
+			map[string]any{
+				"turnId":         turnID,
+				"providerTurnId": providerTurnID,
+				"content":        "continued child",
+			},
+		); err != nil {
+			return err
+		}
+		return c.emit(
+			"",
+			"turn_completed",
+			map[string]any{
+				"turnId":         turnID,
+				"providerTurnId": providerTurnID,
+				"stopReason":     "end_turn",
+			},
+		)
+	case "close":
+		return c.emit(request.ID, "ok", nil)
+	default:
+		return c.emit(request.ID, "ok", nil)
+	}
+}
+
+func (c *claudeForkIntegrationConnection) emit(
+	id string,
+	eventType string,
+	payload map[string]any,
+) error {
+	data, err := json.Marshal(map[string]any{
+		"version": 3,
+		"id":      id,
+		"type":    eventType,
+		"payload": payload,
+	})
+	if err != nil {
+		return err
+	}
+	select {
+	case c.frames <- agentruntime.ProcessFrame{
+		Stdout: append(data, '\n'),
+	}:
+		return nil
+	case <-c.closed:
+		return io.EOF
+	}
+}
+
+func (c *claudeForkIntegrationConnection) Recv() (
+	agentruntime.ProcessFrame,
+	error,
+) {
+	select {
+	case frame := <-c.frames:
+		return frame, nil
+	case <-c.closed:
+		return agentruntime.ProcessFrame{}, io.EOF
+	}
+}
+
+func (c *claudeForkIntegrationConnection) Close() error {
+	c.closeOnce.Do(func() {
+		close(c.closed)
+	})
+	return nil
+}
+
+func claudeForkIntegrationTurnIDs(providerSessionID string) []string {
+	switch providerSessionID {
+	case "claude-source":
+		return []string{"source-prompt-1"}
+	case "claude-child":
+		return []string{"child-prompt-1"}
+	case "claude-grandchild":
+		return []string{"grandchild-prompt-1"}
+	default:
+		return []string{}
+	}
+}
+
+func claudeForkIntegrationChild(sourceID string) (string, string) {
+	switch sourceID {
+	case "claude-source":
+		return "claude-child", "child-prompt-1"
+	case "claude-child":
+		return "claude-grandchild", "grandchild-prompt-1"
+	default:
+		return "", ""
+	}
+}
+
+func cloneClaudeForkIntegrationMap(source map[string]any) map[string]any {
+	if source == nil {
+		return nil
+	}
+	data, err := json.Marshal(source)
+	if err != nil {
+		panic(err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal(data, &result); err != nil {
+		panic(err)
+	}
+	return result
+}
+
+func claudeForkIntegrationString(value any) string {
+	result, _ := value.(string)
+	return result
+}
+
+var _ agentruntime.ProcessTransport = (*claudeForkIntegrationTransport)(nil)
+var _ agentruntime.ProcessConnection = (*claudeForkIntegrationConnection)(nil)

--- a/services/tuttid/service/agent/host_adapters.go
+++ b/services/tuttid/service/agent/host_adapters.go
@@ -37,10 +37,6 @@ func (p serviceHostSessionForkContextPolicy) PrepareSessionForkTargetContext(
 	if p.service == nil || p.service.RuntimePreparer == nil {
 		return agenthost.SessionForkTargetContext{}, agenthost.ErrSessionForkUnsupported
 	}
-	binder, ok := p.service.RuntimePreparer.(runtimeprep.SessionForkProviderStateBinder)
-	if !ok || !binder.SupportsSessionForkProviderStateBinding(source.Provider) {
-		return agenthost.SessionForkTargetContext{}, agenthost.ErrSessionForkUnsupported
-	}
 	return agenthost.SessionForkTargetContext{
 		Cwd:            strings.TrimSpace(prepared.Cwd),
 		RuntimeContext: clonePayload(prepared.RuntimeContext),
@@ -48,6 +44,16 @@ func (p serviceHostSessionForkContextPolicy) PrepareSessionForkTargetContext(
 }
 
 type serviceHostSessionForkProviderStateBinder struct{ service *Service }
+
+func (b serviceHostSessionForkProviderStateBinder) SupportsSessionForkProviderStateBinding(
+	provider string,
+) bool {
+	if b.service == nil || b.service.RuntimePreparer == nil {
+		return false
+	}
+	binder, ok := b.service.RuntimePreparer.(runtimeprep.SessionForkProviderStateBinder)
+	return ok && binder.SupportsSessionForkProviderStateBinding(provider)
+}
 
 func (b serviceHostSessionForkProviderStateBinder) BindSessionForkProviderState(
 	ctx context.Context,

--- a/services/tuttid/service/agent/service_session_fork_test.go
+++ b/services/tuttid/service/agent/service_session_fork_test.go
@@ -69,6 +69,7 @@ func (r *sessionForkCapabilityRuntime) ResolveSessionFork(
 	return agenthost.SessionForkDriverDescriptor{
 		Kind:                        "native",
 		Version:                     "v1",
+		StateBindingMode:            agenthost.SessionForkStateBindingProviderOwned,
 		ThroughTurn:                 true,
 		ThroughProviderTurnIDs:      []string{"provider-turn-7"},
 		ThroughProviderTurnIDsKnown: true,
@@ -220,17 +221,17 @@ func TestSessionForkContextPolicyPreservesNonOwnedRuntimeFacts(t *testing.T) {
 	}
 }
 
-func TestSessionForkContextPolicyFailsClosedWithoutCodexStateBinder(t *testing.T) {
+func TestSessionForkContextPolicyLeavesBindingModeEnforcementToHost(t *testing.T) {
 	source := storesqlite.Session{Provider: "codex"}
 	prepared := agenthost.ProviderRuntimeSession{Cwd: "/prepared-project"}
-	_, err := (serviceHostSessionForkContextPolicy{
+	target, err := (serviceHostSessionForkContextPolicy{
 		service: &Service{RuntimePreparer: fakeRuntimePreparer{}},
 	}).PrepareSessionForkTargetContext(t.Context(), source, prepared)
-	if !errors.Is(err, agenthost.ErrSessionForkUnsupported) {
-		t.Fatalf("policy without provider state binder error=%v, want unsupported", err)
+	if err != nil || target.Cwd != "/prepared-project" {
+		t.Fatalf("policy without provider state binder target=%#v error=%v", target, err)
 	}
 
-	target, err := (serviceHostSessionForkContextPolicy{
+	target, err = (serviceHostSessionForkContextPolicy{
 		service: &Service{
 			RuntimePreparer: runtimeprep.NewDefaultPreparer(t.TempDir()),
 		},
@@ -604,6 +605,7 @@ func (*serviceSessionForkOperationRuntime) ResolveSessionFork(
 ) (agenthost.SessionForkDriverDescriptor, error) {
 	return agenthost.SessionForkDriverDescriptor{
 		Kind: "native", Version: "v1", ThroughTurn: true,
+		StateBindingMode: agenthost.SessionForkStateBindingProviderOwned,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

- add Claude Code through-Turn session fork using the official Claude Agent SDK
- derive the Claude child session UUID from the Host's durable fork operation id
- initialize the fork with SDK `query({ resume, forkSession, sessionId, resumeSessionAt })` and an empty prompt stream, so fork creation does not add a conversation turn
- reconcile an existing deterministic child by exact transcript and provider-Turn mapping verification before attempting another mutation
- allow Host recovery to replay `dispatching` and `unknown` only when the exact driver kind/version attests deterministic target identity
- preserve fail-closed behavior for Codex, older Claude fork drivers, and all providers without that explicit contract
- persist provider-owned UUID mapping and binding evidence, reject stale source cursors, and keep nested Claude forks resumable

This PR is rebased onto current `main` and builds on the shared Agent Host/Store/GUI fork foundation merged by #1728.

## Exactly-once / recovery behavior

The Host persists `operation_id` before provider dispatch and passes that UUID as `targetProviderSessionId`. The Claude sidecar first inspects that exact UUID:

- exact verified child exists: return the same child without another mutation
- child is absent: initialize one fork at that UUID
- partial or structurally different child exists: remain `unknown`; do not delete it and do not allocate another UUID

SQLite adds an atomic `unknown -> dispatching` retry transition. Host may use it only after re-resolving the same driver kind/version with `DeterministicTargetSessionID=true`. A returned provider identity must equal the requested operation UUID.

## Verification

- `pnpm check:changed -- --push-ready` — passed before and after rebasing latest `main`
- `pnpm --dir packages/agent/claude-sdk-sidecar test` — 102 tests passed
- `pnpm --dir packages/agent/claude-sdk-sidecar typecheck`
- `go test ./packages/agent/host ./packages/agent/store-sqlite ./packages/agent/daemon/runtime ./packages/agent/daemon/hostadapter`
- pre-commit staged checks and lint passed

Coverage includes:

- deterministic SDK option projection
- empty prompt stream
- existing-child reconciliation without a second query
- exact transcript including trailing system/compact messages
- provider UUID remapping and nested fork
- Host restart recovery from both `dispatching` and durable `unknown`
- generic/non-deterministic provider remains fail-closed without a provider call
- SQLite durable retry transition

## Fallback Three Questions

- Source: the target canonical snapshot is frozen before the provider mutation returns its child session ID, so it can temporarily inherit the source Claude `resumeCursor`.
- Why can it not be fixed at that source? The Host runtime context is provider-neutral; validating the opaque Claude cursor belongs at the Claude adapter resume boundary.
- Removal condition: remove the mismatch guard only when provider-specific target runtime context can be atomically projected after dispatch and guarantees the persisted cursor is already bound to the child provider session ID.

## Checklist

- [x] Shared lifecycle behavior lives in `packages/agent/host` and has Host/store tests.
- [x] Provider-specific mutation and transcript verification remain in the Claude sidecar/runtime adapter.
- [x] Documentation reflects deterministic replay and fail-closed boundaries.
- [x] The branch is rebased on current `main`.
- [x] Changed-aware push-ready checks pass.
