### PR TITLE
fix(tuttid): defer agent extension refresh during startup

### DIFF
--- a/docs/architecture/agent-extensions.md
+++ b/docs/architecture/agent-extensions.md
@@ -463,6 +463,14 @@ active installation remains available. If no verified installation exists,
 the source is not registered and `tuttid` logs one
 `agent_extension.reconcile_failed` record with a JSON payload.
 
+Daemon startup restores and verifies every enabled source's local active
+installation before serving Agent Target reads. When every enabled source has
+a usable local installation, release-index refresh runs in the background and
+does not delay the daemon listener. If any enabled source has no usable local
+installation, startup keeps the synchronous reconcile path so that a first
+installation is registered before the daemon serves its initial Target
+catalog. Preference-driven activation changes also remain synchronous.
+
 Agent Target catalog reads continue to verify the installed extension package
 and managed runtime integrity before reporting availability. Successful runtime
 version probes are reused only while the resolved executable fingerprint,

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -18,7 +18,7 @@ Use the focused runtime index or open one area directly:
   Includes Codex Model Plan Responses-to-Chat routing and extension
   command/Skill palette hydration failures.
   Also covers focus-driven provider CLI scans, repeated Extension Target version
-  probes, and CPU spikes.
+  probes, extension release refresh delaying daemon startup, and CPU spikes.
 - [Agent Sessions And Lifecycle](./agent-session-lifecycle.md): Turn state, activation, planning-mode classification, Tutti workflow response contracts, loading, cancel, goal controls, restore, file-change undo, rail projection, realtime completion provenance, event updates, imports, and performance.
   Includes shared-device recovery that looks terminal while the host is still retrying.
   Also covers new-conversation requests that silently fail after a Chats

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -1819,3 +1819,41 @@ invalid_grant`. Search `tuttid.log` for
   [gateway.go](../../../services/tuttid/service/modelgateway/gateway.go)
   [stream_converter.go](../../../services/tuttid/service/modelgateway/stream_converter.go)
   [model_endpoint.go](../../../packages/agent/runtimeprep/model_endpoint.go)
+
+### Enabled Agent Extensions delay every daemon startup
+
+- Symptom:
+  `tutti.parent_monitor.started` is followed by a multi-second silent gap before
+  `tutti.managed_runtime.profile_preload_started` and `tutti.listen`. The gap
+  grows as more Agent Extension feature flags are enabled.
+- Quick checks:
+  Compare the two timestamps and inspect `feature_flags_json` in the active
+  `desktop_preferences` row. Time each enabled source's signed
+  `versions.json`; the old startup path fetched the enabled indexes serially
+  before constructing the daemon API.
+- Root cause:
+  Agent Extension reconciliation combined two different jobs: restoring an
+  already verified local installation and checking its remote release index.
+  The daemon needed the first job before serving the Agent Target catalog, but
+  synchronously waited for the second job too. Multiple CloudFront TLS and
+  response waits therefore accumulated on every restart.
+- Fix:
+  Restore and verify cached active installations synchronously, register their
+  Targets, and move remote release refresh after successful daemon API
+  construction into the background. Keep synchronous reconciliation when an
+  enabled source has no usable local installation, and for explicit preference
+  activation changes, so the initial or newly enabled Target does not disappear
+  from the next catalog read. Release the reconciliation lock between background
+  source refreshes so a preference change does not wait for the complete remote
+  batch.
+- Validation:
+  Cover cached restore without any network request, missing-cache fallback to
+  synchronous reconciliation, disabled Target removal, offline fallback, and
+  preference-driven enable/disable. On a state root with cached enabled
+  extensions, verify `tutti.agent_extension.refresh_started` no longer delays
+  `tutti.listen` and later reaches
+  `tutti.agent_extension.refresh_completed`.
+- References:
+  [agent-extensions.md](../../architecture/agent-extensions.md)
+  [manager.go](../../../services/tuttid/service/agentextension/manager.go)
+  [wiring_daemon_api.go](../../../services/tuttid/wiring_daemon_api.go)

--- a/services/tuttid/service/agentextension/manager.go
+++ b/services/tuttid/service/agentextension/manager.go
@@ -86,6 +86,50 @@ func (m *Manager) Reconcile(ctx context.Context) []error {
 	return m.reconcile(ctx, featureFlags)
 }
 
+// RestoreActive registers verified local installations without contacting
+// extension release indexes. The boolean result reports whether an enabled
+// source has no usable local installation and therefore still needs a
+// synchronous reconcile before the daemon starts serving requests.
+func (m *Manager) RestoreActive(ctx context.Context) (bool, []error) {
+	m.reconcileMu.Lock()
+	defer m.reconcileMu.Unlock()
+
+	featureFlags := map[string]bool{}
+	if m.Preferences != nil {
+		preferences, err := m.Preferences.GetDesktopPreferences(ctx)
+		if err != nil {
+			return true, []error{fmt.Errorf("read agent extension feature flags: %w", err)}
+		}
+		featureFlags = preferences.FeatureFlags
+	}
+
+	requiresSynchronousReconcile := false
+	var errs []error
+	for _, source := range m.Sources {
+		if !sourceEnabled(source, featureFlags) {
+			if m.Store != nil {
+				if err := m.Store.DeleteAgentTarget(ctx, targetID(source.Key)); err != nil {
+					errs = append(errs, fmt.Errorf("disable extension %s target: %w", source.Key, err))
+				}
+			}
+			continue
+		}
+
+		installation, err := m.loadActive(source.Key)
+		if err != nil {
+			requiresSynchronousReconcile = true
+			if !errors.Is(err, os.ErrNotExist) {
+				errs = append(errs, fmt.Errorf("restore active agent extension %s: %w", source.Key, err))
+			}
+			continue
+		}
+		if err := m.registerTarget(ctx, installation); err != nil {
+			errs = append(errs, fmt.Errorf("register active agent extension %s: %w", source.Key, err))
+		}
+	}
+	return requiresSynchronousReconcile, errs
+}
+
 func (m *Manager) ReconcileDesktopPreferencesChange(ctx context.Context, previous, current preferencesbiz.DesktopPreferences) []error {
 	if !m.sourceActivationChanged(previous.FeatureFlags, current.FeatureFlags) {
 		return nil
@@ -101,30 +145,7 @@ func (m *Manager) ReconcileDesktopPreferencesChange(ctx context.Context, previou
 func (m *Manager) reconcile(ctx context.Context, featureFlags map[string]bool) []error {
 	var errs []error
 	for _, source := range m.Sources {
-		if !sourceEnabled(source, featureFlags) {
-			if m.Store != nil {
-				if err := m.Store.DeleteAgentTarget(ctx, targetID(source.Key)); err != nil {
-					errs = append(errs, fmt.Errorf("disable extension %s target: %w", source.Key, err))
-				}
-			}
-			continue
-		}
-		installation, reconcileErr := m.reconcileSource(ctx, source)
-		if reconcileErr != nil {
-			var fallbackErr error
-			installation, fallbackErr = m.loadActive(source.Key)
-			if fallbackErr != nil {
-				errs = append(errs, fmt.Errorf(
-					"reconcile agent extension %s: %w",
-					source.Key,
-					errors.Join(reconcileErr, fmt.Errorf("load active installation fallback: %w", fallbackErr)),
-				))
-				continue
-			}
-		}
-		if err := m.registerTarget(ctx, installation); err != nil {
-			errs = append(errs, fmt.Errorf("register agent extension %s: %w", source.Key, err))
-		}
+		errs = append(errs, m.reconcileConfiguredSource(ctx, source, featureFlags)...)
 	}
 	return errs
 }

--- a/services/tuttid/service/agentextension/manager_test.go
+++ b/services/tuttid/service/agentextension/manager_test.go
@@ -244,6 +244,76 @@ func TestManagerReconcileSnapshotsDevelopmentLocalPackage(t *testing.T) {
 	}
 }
 
+func TestManagerRestoreActiveRegistersCachedInstallationWithoutNetwork(t *testing.T) {
+	sourceDir := t.TempDir()
+	if err := extractPackage(testPackageZIP(t), sourceDir); err != nil {
+		t.Fatal(err)
+	}
+	stateDir := t.TempDir()
+	installationStore := agentextensiondata.NewFileInstallationStore(stateDir)
+	seedManager := Manager{
+		Installations: installationStore,
+		Store:         &targetStoreStub{targets: map[string]agenttargetbiz.Target{}},
+		Sources: []tuttitypes.AgentExtensionSource{{
+			Key: "gemini", LocalPackageDir: sourceDir, Enabled: true,
+		}},
+	}
+	if errs := seedManager.Reconcile(context.Background()); len(errs) != 0 {
+		t.Fatalf("seed Reconcile() errors = %v", errs)
+	}
+
+	requestCount := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requestCount++
+	}))
+	defer server.Close()
+	targets := &targetStoreStub{targets: map[string]agenttargetbiz.Target{}}
+	manager := Manager{
+		Installations: installationStore,
+		Store:         targets,
+		Client:        server.Client(),
+		Sources: []tuttitypes.AgentExtensionSource{{
+			Key: "gemini", ReleaseIndexURL: server.URL + "/versions.json", Enabled: true,
+		}},
+	}
+
+	requiresSynchronousReconcile, errs := manager.RestoreActive(context.Background())
+	if len(errs) != 0 {
+		t.Fatalf("RestoreActive() errors = %v", errs)
+	}
+	if requiresSynchronousReconcile {
+		t.Fatal("RestoreActive() unexpectedly requires a synchronous reconcile")
+	}
+	if requestCount != 0 {
+		t.Fatalf("RestoreActive() network requests = %d, want 0", requestCount)
+	}
+	if target := targets.targets["extension:gemini"]; target.Provider != "acp:gemini" {
+		t.Fatalf("restored target = %#v", target)
+	}
+}
+
+func TestManagerRestoreActiveRequiresSynchronousReconcileWithoutCachedInstallation(t *testing.T) {
+	targets := &targetStoreStub{targets: map[string]agenttargetbiz.Target{}}
+	manager := Manager{
+		Installations: agentextensiondata.NewFileInstallationStore(t.TempDir()),
+		Store:         targets,
+		Sources: []tuttitypes.AgentExtensionSource{{
+			Key: "gemini", Enabled: true,
+		}},
+	}
+
+	requiresSynchronousReconcile, errs := manager.RestoreActive(context.Background())
+	if len(errs) != 0 {
+		t.Fatalf("RestoreActive() errors = %v", errs)
+	}
+	if !requiresSynchronousReconcile {
+		t.Fatal("RestoreActive() did not require a synchronous reconcile")
+	}
+	if len(targets.targets) != 0 {
+		t.Fatalf("RestoreActive() targets = %#v, want none", targets.targets)
+	}
+}
+
 func TestManagerResolveRuntimeUsesSignedUserSearchPath(t *testing.T) {
 	homeDir := t.TempDir()
 	binDir := filepath.Join(homeDir, ".kimi-code", "bin")
@@ -436,7 +506,7 @@ func TestManagerInstallAtomicallyReplacesDifferentExistingVersionBytes(t *testin
 	}
 }
 
-func TestManagerReconcileUsesDesktopAgentExtensionFeatureFlag(t *testing.T) {
+func TestManagerStartupAndPreferenceReconcileUseDesktopAgentExtensionFeatureFlag(t *testing.T) {
 	sourceDir := t.TempDir()
 	if err := extractPackage(testPackageZIP(t), sourceDir); err != nil {
 		t.Fatal(err)
@@ -454,8 +524,12 @@ func TestManagerReconcileUsesDesktopAgentExtensionFeatureFlag(t *testing.T) {
 		}},
 	}
 
-	if errs := manager.Reconcile(context.Background()); len(errs) != 0 {
-		t.Fatalf("disabled Reconcile() errors = %v", errs)
+	requiresSynchronousReconcile, errs := manager.RestoreActive(context.Background())
+	if len(errs) != 0 {
+		t.Fatalf("disabled RestoreActive() errors = %v", errs)
+	}
+	if requiresSynchronousReconcile {
+		t.Fatal("disabled RestoreActive() unexpectedly requires a synchronous reconcile")
 	}
 	if _, ok := store.targets["extension:gemini"]; ok {
 		t.Fatal("disabled source target was not removed")

--- a/services/tuttid/service/agentextension/refresh.go
+++ b/services/tuttid/service/agentextension/refresh.go
@@ -1,0 +1,63 @@
+package agentextension
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	tuttitypes "github.com/tutti-os/tutti/services/tuttid/types"
+)
+
+// Refresh reconciles sources one at a time so preference-driven activation
+// changes do not wait behind the complete remote release-index batch.
+func (m *Manager) Refresh(ctx context.Context) []error {
+	var errs []error
+	for _, source := range m.Sources {
+		m.reconcileMu.Lock()
+		featureFlags := map[string]bool{}
+		if m.Preferences != nil {
+			preferences, err := m.Preferences.GetDesktopPreferences(ctx)
+			if err != nil {
+				m.reconcileMu.Unlock()
+				return append(errs, fmt.Errorf("read agent extension feature flags: %w", err))
+			}
+			featureFlags = preferences.FeatureFlags
+		}
+		errs = append(errs, m.reconcileConfiguredSource(ctx, source, featureFlags)...)
+		m.reconcileMu.Unlock()
+	}
+	return errs
+}
+
+func (m *Manager) reconcileConfiguredSource(
+	ctx context.Context,
+	source tuttitypes.AgentExtensionSource,
+	featureFlags map[string]bool,
+) []error {
+	if !sourceEnabled(source, featureFlags) {
+		if m.Store == nil {
+			return nil
+		}
+		if err := m.Store.DeleteAgentTarget(ctx, targetID(source.Key)); err != nil {
+			return []error{fmt.Errorf("disable extension %s target: %w", source.Key, err)}
+		}
+		return nil
+	}
+
+	installation, reconcileErr := m.reconcileSource(ctx, source)
+	if reconcileErr != nil {
+		var fallbackErr error
+		installation, fallbackErr = m.loadActive(source.Key)
+		if fallbackErr != nil {
+			return []error{fmt.Errorf(
+				"reconcile agent extension %s: %w",
+				source.Key,
+				errors.Join(reconcileErr, fmt.Errorf("load active installation fallback: %w", fallbackErr)),
+			)}
+		}
+	}
+	if err := m.registerTarget(ctx, installation); err != nil {
+		return []error{fmt.Errorf("register agent extension %s: %w", source.Key, err)}
+	}
+	return nil
+}

--- a/services/tuttid/wiring_agent_extension_startup.go
+++ b/services/tuttid/wiring_agent_extension_startup.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"time"
+
+	agentextensionservice "github.com/tutti-os/tutti/services/tuttid/service/agentextension"
+)
+
+func restoreAgentExtensionsForStartup(
+	ctx context.Context,
+	manager *agentextensionservice.Manager,
+) bool {
+	requiresSynchronousReconcile, restoreErrors := manager.RestoreActive(ctx)
+	for _, restoreErr := range restoreErrors {
+		payload, _ := json.Marshal(map[string]string{"error": restoreErr.Error()})
+		slog.Warn("agent_extension.restore_failed", "payload", string(payload))
+	}
+	if !requiresSynchronousReconcile {
+		return true
+	}
+	for _, reconcileErr := range manager.Reconcile(ctx) {
+		payload, _ := json.Marshal(map[string]string{"error": reconcileErr.Error()})
+		slog.Warn("agent_extension.reconcile_failed", "payload", string(payload))
+	}
+	return false
+}
+
+func startAgentExtensionBackgroundRefresh(manager *agentextensionservice.Manager) {
+	go func() {
+		startedAt := time.Now()
+		slog.Info("agent extension background refresh started",
+			"event", "tutti.agent_extension.refresh_started")
+		for _, reconcileErr := range manager.Refresh(context.Background()) {
+			payload, _ := json.Marshal(map[string]string{"error": reconcileErr.Error()})
+			slog.Warn("agent_extension.reconcile_failed", "payload", string(payload))
+		}
+		slog.Info("agent extension background refresh completed",
+			"event", "tutti.agent_extension.refresh_completed",
+			"durationMs", time.Since(startedAt).Milliseconds())
+	}()
+}

--- a/services/tuttid/wiring_daemon_api.go
+++ b/services/tuttid/wiring_daemon_api.go
@@ -148,10 +148,7 @@ func buildDaemonAPI(ctx context.Context, store workspacedata.CatalogStore, analy
 		Manager: agentExtensionManager, Workspaces: store, Targets: agentTargetStore,
 	}
 	agentTargets.AvailabilityResolver = agentExtensionManager
-	for _, reconcileErr := range agentExtensionManager.Reconcile(ctx) {
-		payload, _ := json.Marshal(map[string]string{"error": reconcileErr.Error()})
-		slog.Warn("agent_extension.reconcile_failed", "payload", string(payload))
-	}
+	refreshAgentExtensionsInBackground := restoreAgentExtensionsForStartup(ctx, agentExtensionManager)
 	managedCredentials := &managedcredentialsservice.Service{
 		Store: managedCredentialsStore,
 	}
@@ -649,6 +646,10 @@ func buildDaemonAPI(ctx context.Context, store workspacedata.CatalogStore, analy
 		},
 	}
 	providerAuthWatcher.Start()
+
+	if refreshAgentExtensionsInBackground {
+		startAgentExtensionBackgroundRefresh(agentExtensionManager)
+	}
 
 	return tuttiapi.DaemonAPI{
 		AccountService:            accountService,


### PR DESCRIPTION
## Summary
- restore verified local Agent Extension installations before daemon startup
- move remote release-index refresh off the listener critical path
- release the reconcile lock between background source refreshes
- document the startup lifecycle and troubleshooting evidence

## Tests
- `go test ./service/agentextension`
- `go test ./service/agentstatus`
- `pnpm check:changed -- --push-ready`
- `pnpm check:changed -- --failed-only`

## Notes
- isolated startup smoke test reached `tutti.listen` in 245 ms while the six-source background refresh completed in 19.97 s
- sources without a usable local installation still reconcile synchronously so the initial Agent Target catalog stays complete

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->