### PR TITLE
feat(ui): add MinusLinedIcon and refine browser zoom controls

### DIFF
--- a/packages/browser/workbench-node/src/react/BrowserNodeActionsMenu.tsx
+++ b/packages/browser/workbench-node/src/react/BrowserNodeActionsMenu.tsx
@@ -1,4 +1,5 @@
 import {
+  AddLinedIcon,
   ArrowRightIcon,
   Button,
   ChevronDownIcon,
@@ -11,6 +12,7 @@ import {
   LaunchIcon,
   LocateFolderIcon,
   MenuSurface,
+  MinusLinedIcon,
   MoreHorizontalIcon,
   PauseIcon,
   PlayIcon,
@@ -306,12 +308,10 @@ export function BrowserNodeActionsMenu({
                           setZoom(runtime.zoomFactor - browserZoomStep)
                         }
                       >
-                        <span
+                        <MinusLinedIcon
                           aria-hidden="true"
-                          className="text-base leading-none"
-                        >
-                          −
-                        </span>
+                          className="size-3.5"
+                        />
                       </Button>
                       <Button
                         className="min-w-14 px-1 text-[12px]"
@@ -334,12 +334,7 @@ export function BrowserNodeActionsMenu({
                           setZoom(runtime.zoomFactor + browserZoomStep)
                         }
                       >
-                        <span
-                          aria-hidden="true"
-                          className="text-base leading-none"
-                        >
-                          +
-                        </span>
+                        <AddLinedIcon aria-hidden="true" className="size-3.5" />
                       </Button>
                     </div>
                   </div>

--- a/packages/browser/workbench-node/src/react/BrowserNodeChrome.tsx
+++ b/packages/browser/workbench-node/src/react/BrowserNodeChrome.tsx
@@ -1,5 +1,5 @@
 import {
-  AddIcon,
+  AddLinedIcon,
   ArrowLeftIcon,
   ArrowRightIcon,
   Button,
@@ -209,7 +209,7 @@ export function BrowserNodeChrome({
           variant="chrome"
           onClick={() => feature.tabsStore.addTab(surfaceNodeId)}
         >
-          <AddIcon className="size-4" />
+          <AddLinedIcon className="size-3.5" />
         </Button>
         <div className="min-w-8 flex-1 self-stretch" aria-hidden="true" />
       </div>
@@ -355,7 +355,7 @@ function BrowserNodeTabButton({
   return (
     <div
       className={cn(
-        "group flex h-7 min-w-[104px] max-w-[220px] items-center gap-1.5 rounded-md border px-2 text-xs transition-colors",
+        "group flex h-7 min-w-[104px] max-w-[220px] items-center gap-1.5 rounded-md border pl-2 pr-1 text-xs transition-colors",
         active
           ? "border-[var(--line-2)] bg-[var(--background-fronted)] text-[var(--text-primary)]"
           : "border-transparent text-[var(--text-secondary)] hover:bg-[var(--transparency-hover)] hover:text-[var(--text-primary)]"

--- a/packages/browser/workbench-node/src/react/BrowserNodeMenuPrimitives.tsx
+++ b/packages/browser/workbench-node/src/react/BrowserNodeMenuPrimitives.tsx
@@ -26,7 +26,7 @@ export function BrowserNodeMenuItem({
     >
       <span className="min-w-0 flex-1 text-left">{children}</span>
       {endAdornment ? (
-        <span className="ml-auto text-[var(--text-tertiary)]">
+        <span className="ml-auto flex-none! text-[var(--text-tertiary)]">
           {endAdornment}
         </span>
       ) : null}

--- a/packages/ui/system/src/icons/system-icons.tsx
+++ b/packages/ui/system/src/icons/system-icons.tsx
@@ -594,6 +594,17 @@ export function AddLinedIcon(props: IconProps) {
   );
 }
 
+export function MinusLinedIcon(props: IconProps) {
+  return (
+    <FilledPathIcon {...props}>
+      <path
+        d="M3 11C2.44772 11 2 11.4477 2 12C2 12.5523 2.44772 13 3 13H21C21.5523 13 22 12.5523 22 12C22 11.4477 21.5523 11 21 11H3Z"
+        fill="currentColor"
+      />
+    </FilledPathIcon>
+  );
+}
+
 export function ImportLinedIcon(props: IconProps) {
   return (
     <FilledPathIcon {...props}>

--- a/packages/ui/system/src/metadata/components.json
+++ b/packages/ui/system/src/metadata/components.json
@@ -2364,6 +2364,20 @@
       "iconVariant": "lined"
     },
     {
+      "id": "minus-lined-icon",
+      "layer": "base",
+      "name": "MinusLinedIcon",
+      "export": "MinusLinedIcon",
+      "from": "@tutti-os/ui-system/icons",
+      "category": "icon",
+      "status": "stable",
+      "source": "src/icons/system-icons.tsx",
+      "description": "Slim system icon for minus or decrease actions.",
+      "useCases": ["Zoom controls", "Dense decrease controls"],
+      "migrationHints": [],
+      "iconVariant": "lined"
+    },
+    {
       "id": "import-lined-icon",
       "layer": "base",
       "name": "ImportLinedIcon",

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManager.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManager.tsx
@@ -501,7 +501,7 @@ export function WorkspaceFileManager({
           aria-valuemax={sidebarMaxWidth}
           aria-valuemin={workspaceFileManagerSidebarMinWidth}
           aria-valuenow={sidebarWidth}
-          className="nodrag @max-[600px]/workspace-file-manager:hidden relative z-[1] -ml-1 -mr-1 h-full w-2 shrink-0 cursor-col-resize touch-none outline-none before:absolute before:left-1/2 before:h-full before:w-px before:-translate-x-1/2 before:bg-transparent hover:before:bg-[var(--border-focus)] focus-visible:before:bg-[var(--border-focus)]"
+          className="nodrag @max-[600px]/workspace-file-manager:hidden relative z-[1] -ml-1 -mr-1 h-full w-2 shrink-0 cursor-col-resize touch-none outline-none before:absolute before:left-1/2 before:h-full before:w-px before:-translate-x-1/2 before:bg-[var(--border-1)] hover:before:bg-[var(--border-focus)] focus-visible:before:bg-[var(--border-focus)]"
           role="separator"
           tabIndex={0}
           onKeyDown={handleSidebarResizeKeyDown}


### PR DESCRIPTION
## Motivation

Browser workbench zoom controls rendered `+` / `−` as raw text spans, which looked inconsistent with the rest of the iconography and scaled poorly. The shared UI System had an `AddLinedIcon` but no matching minus variant.

## Changes

- `@tutti-os/ui-system`: add `MinusLinedIcon` (lined variant, matching `AddLinedIcon`) and register it in `components.json` metadata
- `BrowserNodeActionsMenu`: replace text-based `+` / `−` zoom buttons with `AddLinedIcon` / `MinusLinedIcon`
- `BrowserNodeChrome`: use `AddLinedIcon` for the new-tab button; adjust tab button padding (`pl-2 pr-1`)
- `BrowserNodeMenuPrimitives`: keep menu end adornments from shrinking (`flex-none!`)
- `WorkspaceFileManager`: show the sidebar resize separator line by default (`border-1`) instead of only on hover

## Validation

- pre-commit lint-staged + staged boundary checks passed
- `pnpm check:changed -- --push-ready` passed (14 lanes)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1746" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->