### PR TITLE
fix(workspace-files): restore agent sidebar context menu

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebarPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebarPanel.tsx
@@ -122,7 +122,7 @@ export function StandaloneAgentToolSidebarPanel({
         <LazyWorkspaceFileManagerPane
           className="h-full"
           revealIntent={fileOpenRequest}
-          showInternalOpenWithActions={false}
+          showInternalOpenWithActions
           showPreviewPanel={false}
           workspaceID={workspaceId}
         />

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentToolWorkbench.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentToolWorkbench.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 import type {
   WorkbenchContribution,
@@ -11,6 +12,22 @@ import {
   createStandaloneAgentToolSnapshotRepository,
   resolveStandaloneAgentToolContribution
 } from "./standaloneAgentToolWorkbench.ts";
+
+const standaloneAgentToolSidebarPanelSource = readFileSync(
+  new URL("./StandaloneAgentToolSidebarPanel.tsx", import.meta.url),
+  "utf8"
+);
+
+test("standalone Agent Files keeps the complete Open With menu", () => {
+  assert.match(
+    standaloneAgentToolSidebarPanelSource,
+    /<LazyWorkspaceFileManagerPane[\s\S]*?showInternalOpenWithActions(?:=\{true\})?/
+  );
+  assert.doesNotMatch(
+    standaloneAgentToolSidebarPanelSource,
+    /showInternalOpenWithActions=\{false\}/
+  );
+});
 
 test("standalone Agent terminal contribution keeps the real renderer and opens fullscreen without a dock", async () => {
   const renderBody = () => null;

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1112,6 +1112,12 @@ host.
 That layout carries the actions, open state, and reserved width into the one
 authoritative `AgentGuiWorkbenchHeader`.
 
+The standalone Files tool reuses the Desktop file-manager pane and its complete
+context menu. Its Open With submenu keeps Tutti's file viewer and in-app browser
+alongside system applications, default-browser handling, and the system
+application picker. Double-clicking a file still delegates to the desktop
+host's system-default opener; directories continue to navigate inside Files.
+
 Header ownership is explicit. A native standalone window selects the
 window-owned contract, so the shared sidebar composes the Workbench Header and
 body frame. An embedded Workbench selects the host-owned contract and projects

--- a/docs/conventions/desktop-visual-language.md
+++ b/docs/conventions/desktop-visual-language.md
@@ -257,6 +257,9 @@ windows instead of assuming that the preferred side is always available.
 - recompute placement when the viewport or scroll position changes
 - preserve keyboard hierarchy: forward arrow enters the submenu, while back
   arrow and Escape return focus to its trigger
+- when a menu is portaled out of a side panel, stack it on the shared
+  `--z-panel-popover` layer; a raw numeric fallback below `--z-panel` leaves the
+  menu rendered but hidden behind the panel
 
 ### Settings Dialogs
 

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManagerContextMenu.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManagerContextMenu.tsx
@@ -114,12 +114,11 @@ export function WorkspaceFileManagerContextMenu({
       style={{
         left: `${position.x}px`,
         top: `${position.y}px`,
-        // Prefer the host CSS var when present; fall back to a stable stacking
-        // value so an unset var cannot invalidate the entire z-index declaration.
-        // Viewport menus need to clear typical workbench chrome (≈ z-10..50).
+        // A portaled viewport menu no longer inherits the file-manager-local
+        // overlay variable, so use the shared layer above `--z-panel`.
         zIndex:
           positionMode === "viewport"
-            ? "var(--workspace-file-manager-dialog-overlay-z-index, 10050)"
+            ? "var(--z-panel-popover)"
             : "var(--workspace-file-manager-dialog-overlay-z-index, 20)"
       }}
       onContextMenu={(event) => {
@@ -496,7 +495,7 @@ function ContextMenuSubmenu({
         role="menu"
         style={{
           width: submenuPosition.width,
-          zIndex: "calc(var(--z-panel-popover) + 200)"
+          zIndex: "calc(var(--z-panel-popover) + 1)"
         }}
         onPointerEnter={openSubmenu}
         onPointerLeave={scheduleClose}

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManagerContextMenuContainer.render.test.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManagerContextMenuContainer.render.test.tsx
@@ -1,0 +1,109 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { WorkspaceFileManagerSession } from "../services/workspaceFileManagerService.interface.ts";
+
+const probes = vi.hoisted(() => ({
+  contextMenu: {
+    entry: {
+      hasChildren: false,
+      kind: "file" as const,
+      mtimeMs: null,
+      name: "alpha.txt",
+      path: "/workspace/alpha.txt",
+      sizeBytes: 1024
+    },
+    x: 120,
+    y: 80
+  }
+}));
+
+vi.mock("./useWorkspaceFileManagerService.ts", () => ({
+  useWorkspaceFileManagerContextMenuView: () => ({
+    view: {
+      contextMenu: probes.contextMenu,
+      currentDirectoryPath: "/workspace",
+      isBusy: false,
+      isLoading: false,
+      isMutating: false
+    }
+  })
+}));
+
+import { WorkspaceFileManagerContextMenuContainer } from "./WorkspaceFileManagerContextMenuContainer.tsx";
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe("WorkspaceFileManagerContextMenuContainer", () => {
+  it("portals an actionable menu outside a contained Agent sidebar", async () => {
+    const closeContextMenu = vi.fn();
+    const onSelect = vi.fn();
+    const resolveContextMenu = vi.fn(() => [
+      {
+        id: "open",
+        label: "Open",
+        onSelect,
+        type: "item" as const
+      }
+    ]);
+    const session = {
+      closeContextMenu,
+      store: {
+        locationSections: [],
+        searchQuery: "",
+        selectedLocationId: null
+      }
+    } as unknown as WorkspaceFileManagerSession;
+    const sidebar = document.createElement("aside");
+    sidebar.style.contain = "layout paint";
+    sidebar.style.overflow = "hidden";
+    document.body.append(sidebar);
+    const root = createRoot(sidebar);
+    const previousActEnvironment = (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT;
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+
+    try {
+      await act(async () => {
+        root.render(
+          <WorkspaceFileManagerContextMenuContainer
+            resolveContextMenu={resolveContextMenu}
+            session={session}
+          />
+        );
+      });
+
+      const menu = document.querySelector<HTMLElement>(
+        "[data-workspace-file-manager-context-menu]"
+      );
+      expect(menu).not.toBeNull();
+      expect(sidebar.contains(menu)).toBe(false);
+      expect(menu?.classList.contains("fixed")).toBe(true);
+      expect(menu?.style.zIndex).toBe("var(--z-panel-popover)");
+
+      const openButton =
+        menu?.querySelector<HTMLButtonElement>('[role="menuitem"]');
+      expect(openButton?.textContent).toContain("Open");
+
+      await act(async () => {
+        openButton?.click();
+      });
+      expect(closeContextMenu).toHaveBeenCalledOnce();
+      expect(onSelect).toHaveBeenCalledOnce();
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      sidebar.remove();
+      (
+        globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+      ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- render the portaled Files context menu on the shared panel-popover layer so it stays above the Agent tool sidebar
- restore Tutti file viewer and app browser entries in the standalone Agent Files Open With submenu
- add a contained-sidebar portal/action regression test and document the durable stacking rule

The regression was caused by the context menu fallback layer (10050) sitting below the Agent sidebar layer (--z-panel, 100500), so the menu existed in the DOM but was painted behind the sidebar.

## Verification

- pnpm --filter @tutti-os/workspace-file-manager test
- pnpm check:changed
- pnpm check:changed -- --push-ready
- architecture review planner plus Desktop/package boundary reviewers: no findings

## Checklist

- [x] This change does not alter agent lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] I updated documentation for the behavior and reusable stacking rule.
- [x] README/CONTRIBUTING language variants are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] The commit is signed off with DCO.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1748" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->