### PR TITLE
fix(agent): open commerce actions in external browser

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.test.ts
@@ -178,6 +178,32 @@ test("desktop agent gui link actions open urls through the workspace browser", a
   ]);
 });
 
+test("desktop agent gui commerce actions open urls in the external browser", async () => {
+  const openedUrls: string[] = [];
+
+  const handled = await runDesktopAgentGUILinkAction(
+    {
+      source: "agent-external-action",
+      type: "open-url",
+      url: "https://example.com/plans"
+    },
+    {
+      getAgentSession: failGetAgentSession,
+      launchAgentGui: failLaunchAgentGui,
+      launchWorkspaceIssueManager: failLaunchWorkspaceIssueManager,
+      launchWorkspaceFiles: failLaunchWorkspaceFiles,
+      openBrowserUrl: failOpenBrowserUrl,
+      openExternalUrl(url) {
+        openedUrls.push(url);
+      },
+      workspaceId: "workspace-1"
+    }
+  );
+
+  assert.equal(handled, true);
+  assert.deepEqual(openedUrls, ["https://example.com/plans"]);
+});
+
 test("desktop agent gui link actions launch agent sessions in the same workspace", async () => {
   const launchedSessions: unknown[] = [];
 

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.ts
@@ -2,6 +2,11 @@ import { parseRichTextMentionHref } from "@tutti-os/ui-rich-text/core";
 import type { WorkspaceLinkAction } from "@contexts/workspace/presentation/renderer/actions/workspaceLinkActions";
 import type { DesktopAgentGUIProvider } from "../desktopAgentGUINodeState.ts";
 
+// Value mirror of AGENT_EXTERNAL_LINK_ACTION_SOURCE from @tutti-os/agent-gui.
+// See the note below: runtime imports from the Agent GUI barrel break the
+// desktop node --test runner.
+const AGENT_EXTERNAL_LINK_ACTION_SOURCE = "agent-external-action";
+
 // Value mirror of AGENT_PASTED_TEXT_MENTION_KIND from @tutti-os/agent-gui.
 // Kept as a local literal so this module (loaded by the node --test runner)
 // does not pull the whole agent-gui barrel, whose extensionless internal
@@ -56,6 +61,7 @@ export interface DesktopAgentGUILinkActionDependencies {
     url: string;
     workspaceId: string;
   }): Promise<boolean> | boolean;
+  openExternalUrl?(url: string): Promise<void> | void;
   workspaceId: string;
 }
 
@@ -85,6 +91,13 @@ export async function runDesktopAgentGUILinkAction(
         workspaceId: dependencies.workspaceId
       });
     case "open-url":
+      if (
+        action.source === AGENT_EXTERNAL_LINK_ACTION_SOURCE &&
+        dependencies.openExternalUrl
+      ) {
+        await dependencies.openExternalUrl(action.url);
+        return true;
+      }
       return dependencies.openBrowserUrl({
         reuseIfOpen: false,
         source: "agent_command",

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
@@ -152,6 +152,7 @@ export function createWorkspaceAgentGuiContribution(input: {
       },
       launchGroupChat: requestGroupChatLaunch,
       openBrowserUrl: requestWorkspaceBrowserLaunch,
+      openExternalUrl: (url) => input.hostFilesApi.openExternal(url),
       workspaceId: input.workspaceId
     });
   };

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAgentMessageCenterAction.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAgentMessageCenterAction.tsx
@@ -306,6 +306,7 @@ export function WorkspaceAgentMessageCenterAction({
         launchWorkspaceFiles: requestWorkspaceFilesLaunch,
         launchGroupChat: requestGroupChatLaunch,
         openBrowserUrl: requestWorkspaceBrowserLaunch,
+        openExternalUrl: (url) => workbenchHostService.openExternal(url),
         workspaceId: workspace.id
       });
     },

--- a/packages/agent/gui/actions/portableWorkspaceNavigationActions.ts
+++ b/packages/agent/gui/actions/portableWorkspaceNavigationActions.ts
@@ -6,6 +6,8 @@ export type WorkspaceLinkActionSource =
   | "agent-file-change"
   | string;
 
+export const AGENT_EXTERNAL_LINK_ACTION_SOURCE = "agent-external-action";
+
 export interface OpenWorkspaceUrlLinkAction {
   type: "open-url";
   url: string;

--- a/packages/agent/gui/actions/workspaceLinkActions.ts
+++ b/packages/agent/gui/actions/workspaceLinkActions.ts
@@ -2,6 +2,7 @@ import type { WorkspaceIssueMentionMode } from "@tutti-os/workspace-issue-manage
 import { parseRichTextMentionHref } from "@tutti-os/ui-rich-text/core";
 import { getAgentCustomMentionKind } from "../shared/agentCustomMentionKinds";
 import {
+  AGENT_EXTERNAL_LINK_ACTION_SOURCE,
   resolveAgentSessionMentionLinkAction,
   resolveWorkspaceUrlLinkAction,
   type OpenAgentSessionLinkAction,
@@ -17,7 +18,7 @@ import {
   workspaceFilePathBasename
 } from "./workspaceFilePathCandidate";
 
-export { resolveWorkspaceUrlLinkAction };
+export { AGENT_EXTERNAL_LINK_ACTION_SOURCE, resolveWorkspaceUrlLinkAction };
 export {
   isDirectAgentGeneratedMediaPath,
   resolveWorkspaceFilePathCandidate

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
@@ -13,7 +13,10 @@ import { AgentPlanCard } from "./AgentPlanCard";
 import { AgentCollaborationRow } from "./AgentCollaborationRow";
 import { translate } from "../../../i18n/index";
 import { useOptionalAgentHostApi } from "../../../agentActivityHost";
-import type { WorkspaceLinkAction } from "../../../contexts/workspace/presentation/renderer/actions/workspaceLinkActions";
+import {
+  AGENT_EXTERNAL_LINK_ACTION_SOURCE,
+  type WorkspaceLinkAction
+} from "../../../contexts/workspace/presentation/renderer/actions/workspaceLinkActions";
 import {
   AgentMessageMarkdown,
   type AgentMessageMarkdownWorkspaceAppIcon
@@ -102,6 +105,20 @@ export function AgentMessageBlock({
         basePath,
         href,
         source: "agent-markdown"
+      });
+      if (action) {
+        onLinkAction?.(action);
+      }
+    },
+    [basePath, onLinkAction, workspaceRoot]
+  );
+  const handleExternalLinkClick = useCallback(
+    (href: string): void => {
+      const action = resolveAgentConversationLinkAction({
+        workspaceRoot,
+        basePath,
+        href,
+        source: AGENT_EXTERNAL_LINK_ACTION_SOURCE
       });
       if (action) {
         onLinkAction?.(action);
@@ -199,13 +216,13 @@ export function AgentMessageBlock({
         <AgentVisibleErrorMessage
           message={message}
           onAuthLogin={onAuthLogin}
-          onExternalLink={handleLinkClick}
+          onExternalLink={handleExternalLinkClick}
         />
       ) : recoveredError ? (
         <AgentVisibleErrorMessage
           message={recoveredError}
           onAuthLogin={onAuthLogin}
-          onExternalLink={handleLinkClick}
+          onExternalLink={handleExternalLinkClick}
         />
       ) : message.systemNotice ? (
         <AgentSystemNoticeMessage message={message} />

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.visibleError.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.visibleError.spec.tsx
@@ -272,6 +272,7 @@ describe("AgentVisibleErrorMessage", () => {
     fireEvent.click(getByText("Recharge credits"));
     expect(onLinkAction).toHaveBeenCalledWith(
       expect.objectContaining({
+        source: "agent-external-action",
         type: "open-url",
         url: "https://example.test/credits"
       })


### PR DESCRIPTION
## Summary

- mark Tutti Agent commerce CTAs as external-link actions
- open upgrade and recharge links in the system browser so the existing Tutti web login session is available
- keep normal Agent message URLs routed to the in-app workspace browser
- cover both Agent GUI action generation and desktop routing

## Testing

- Agent GUI visible-error tests (12 passed)
- Desktop Agent GUI link-action tests (11 passed)
- Agent GUI typecheck
- Desktop typecheck
- `pnpm check:changed -- --push-ready` (16 lanes passed)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1749" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->