### PR TITLE
fix(agent): repair Claude Code session forks

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -328,6 +328,15 @@ and `getSessionMessages`. It returns a verification receipt plus the
 source-to-child provider Turn UUID mapping. Store persists that evidence at
 `provider_accepted` and rewrites cloned Turns to the child UUIDs in the
 canonical commit.
+Claude's official `forkSession` allocates the provider child UUID, so this
+driver does not attest deterministic provider identity. Host still reserves a
+deterministic canonical target Session ID, dispatches the provider mutation
+once, and fails closed without replay when delivery becomes `unknown`.
+For live Claude Turns, a daemon-generated prompt UUID is correlation only:
+Claude Code may rewrite it before persisting the transcript. The sidecar binds
+provider Turn identity from the observed root user-message UUID and emits
+`provider_turn_started`; the daemon must not publish canonical provider
+identity before that observation.
 Binding failure becomes `unknown`; Host neither commits the canonical child nor
 reissues `thread/fork`.
 

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -24,7 +24,10 @@ Use the focused runtime index or open one area directly:
   Also covers new-conversation requests that silently fail after a Chats
   Session working directory is mistaken for a selected project, and one hung
   provider startup blocking unrelated Agent sessions. Includes canonical
-  completion delayed behind a streaming activity-report backlog.
+  completion delayed behind a streaming activity-report backlog and completed
+  Claude Code Turns that lack a Fork entry because provider identity was not
+  observed from the durable transcript. Also covers Claude Fork operations that
+  fail because an empty SDK query never creates a durable provider child.
 - [Agent Approvals And Child Sessions](./agent-approvals-subagents.md): Approval gates, plan exits, root/parent/child event attribution, child sessions, and Message Center.
   Includes provider-native work that continues invisibly after root cancellation
   and late child creation racing the durable cancel boundary.

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -1911,6 +1911,82 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   [controller.go](../../../packages/agent/daemon/runtime/controller.go)
   [controller_test.go](../../../packages/agent/daemon/runtime/controller_test.go)
 
+### Claude Code completes but the Turn has no Fork entry
+
+- Symptom:
+  A Claude Code Turn is settled and has assistant output, but AgentGUI does not
+  offer Fork. The session capability reports `forkThroughTurn=false`, or its
+  supported provider Turn list is empty even though the Claude transcript is
+  readable.
+- Quick checks:
+  Compare the canonical Turn's `root_provider_turn_id` with the UUID of the
+  matching root user message returned by the official Claude SDK
+  `getSessionMessages` API. If they differ, inspect the live sidecar event
+  sequence for `provider_turn_started`. Do not infer identity from transcript
+  position or substitute the canonical Tutti Turn ID.
+- Root cause:
+  The outbound user-message UUID is only a prompt correlation value. Claude
+  Code may rewrite that UUID before persisting the transcript. Publishing the
+  caller-generated value as canonical provider identity makes strict prefix
+  verification correctly reject the Turn, which removes the Fork capability.
+- Fix:
+  Mark the next root prompt echo as causally expected before submitting it.
+  Bind provider Turn identity from that observed root user-message UUID, emit
+  `provider_turn_started`, and only then persist the root provider lifecycle.
+  Keep historical Turns without observed provider identity fail-closed rather
+  than guessing or backfilling them.
+- Validation:
+  Cover a query whose root user echo rewrites the outbound UUID. Assert
+  `provider_turn_started` and terminal events both carry the persisted UUID,
+  then verify the daemon stores the same identity and the fork capability
+  accepts it. Restart the daemon/sidecar before manually checking a newly
+  completed Claude Code Turn; historical affected Turns remain intentionally
+  non-forkable.
+- References:
+  [sessionRuntime.ts](../../../packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts)
+  [turnLifecycle.ts](../../../packages/agent/claude-sdk-sidecar/src/turnLifecycle.ts)
+  [claude_sdk_execution.go](../../../packages/agent/daemon/runtime/claude_sdk_execution.go)
+  [claude_sdk_events.go](../../../packages/agent/daemon/runtime/claude_sdk_events.go)
+
+### Claude Code Fork fails after the action is clicked
+
+- Symptom:
+  Fork is available for a completed Claude Code Turn, but clicking it produces
+  a failed operation. The durable operation becomes `unknown`, no target
+  canonical Session is committed, and the target provider Session is absent.
+- Quick checks:
+  Inspect the latest `workspace_agent_session_fork_operations` row and query the
+  target UUID with the official SDK `getSessionInfo` and
+  `getSessionMessages`. If both are empty, check whether the sidecar used
+  `query({forkSession: true})` with an empty prompt and treated
+  `initializationResult()` as provider mutation completion.
+- Root cause:
+  Query initialization only completes the SDK/CLI handshake. Without a prompt,
+  it does not durably create the requested child transcript. Unit tests can
+  hide the defect if their fake marks the child created inside
+  `initializationResult()`. A catch that replaces the original exception with
+  a generic Fork error also erases whether failure occurred during source
+  validation, provider mutation, or child verification.
+- Fix:
+  Use the official `forkSession(source, {upToMessageId, title})` transcript
+  mutation. Accept its provider-generated child UUID, advertise the driver as
+  non-deterministic, and let Host keep only the canonical target Session ID
+  deterministic. Preserve the failure stage and original SDK reason.
+  After provider mutation starts, any failure is `unknown` and must never be
+  replayed.
+- Validation:
+  Exercise the official SDK with an in-memory SessionStore, including a Turn
+  whose inclusive checkpoint ends in a system message. Verify the provider
+  child is independently readable, root user UUIDs are remapped, the canonical
+  child resumes by the returned provider Session ID, and a second Fork from
+  that child succeeds. Cover pre-mutation `not_started`, post-mutation
+  `unknown`, and Host's no-replay behavior for non-deterministic drivers.
+- References:
+  [sessionFork.ts](../../../packages/agent/claude-sdk-sidecar/src/sessionFork.ts)
+  [sessionFork.test.ts](../../../packages/agent/claude-sdk-sidecar/src/sessionFork.test.ts)
+  [claude_sdk_fork.go](../../../packages/agent/daemon/runtime/claude_sdk_fork.go)
+  [session_fork.go](../../../packages/agent/host/session_fork.go)
+
 ### Claude Code cancel leaves Write/tool cards or thinking stuck in progress
 
 - Symptom:

--- a/docs/specs/2026-07-27-agent-session-fork-design.md
+++ b/docs/specs/2026-07-27-agent-session-fork-design.md
@@ -358,9 +358,11 @@ provider child 已经创建但 binding 失败，operation 进入 `unknown`，不
 
 Claude SDK Driver 使用固定版本的官方公开 API：
 
-1. 新 Claude Turn 在提交前由 Go adapter 生成 SDK prompt UUID，并作为 canonical
-   `RootProviderTurnID` 传给 sidecar；旧版以 canonical Turn ID 代替 UUID 的历史记录不会猜测
-   或回填，因此 fail closed；
+1. Go adapter 在提交前生成的 UUID 仅用于出站 prompt 关联，不作为 provider 身份；
+   Claude Code 可能在持久化 transcript 时改写 caller UUID，因此 sidecar 必须等待 root
+   user-message 回显，读取 Claude 实际 UUID 后发出 `provider_turn_started`，canonical
+   `RootProviderTurnID` 只接受该已观察身份；旧版没有真实 SDK UUID 的历史记录不会猜测或
+   回填，因此 fail closed；
 2. capability 通过 stateless sidecar 调用
    `getSessionMessages(..., {includeSystemMessages: true})`，只返回 root user-message UUID
    allowlist，但保留 system message 用于精确 checkpoint 与完整 prefix 校验；
@@ -369,17 +371,23 @@ Claude SDK Driver 使用固定版本的官方公开 API：
 4. 调用 `forkSession(source, {upToMessageId, title: frozenTargetTitle})`；
 5. 再次读取 source，并读取 child 的 `getSessionInfo` / `getSessionMessages`；两次
    `getSessionMessages` 均使用 `includeSystemMessages: true`。source 选中 prefix
-   必须在调用前后不变，child 必须与该完整 prefix 做结构等价验证
-   (`type/message/parent_tool_use_id`，忽略已重映射的 UUID/session id)；
-6. 只有完整验证后才按已证明的逐消息双射生成 source→child provider Turn UUID mapping，
-   返回 `provider_owned` receipt；消息内容只在 sidecar 内比较，不返回或记录；
+   必须在调用前后不变。官方 SDK 可能已将尾随 system message 写入 child transcript，
+   但在后续 user message 扩展 parent chain 前不从 `getSessionMessages` 返回它；因此 child
+   与去除尾随 system message 后的 SDK 可观察 prefix 做结构等价验证
+   (`type/message/parent_tool_use_id`，忽略已重映射的 UUID/session id)，receipt 仍绑定
+   source 的完整 inclusive checkpoint；
+6. 只有完整验证后才按已证明的可观察 root user-message 顺序双射生成 source→child
+   provider Turn UUID mapping，返回绑定完整 source checkpoint 与可观察 child prefix 的
+   `provider_owned` receipt；消息内容只在 sidecar 内比较，不返回或记录；
 7. Store 在 `provider_accepted` checkpoint 原子保存 mapping/receipt，并在 canonical clone
    时重写每个 child Turn 的 `RootProviderTurnID`，使 fork child 可以继续 Fork；
 8. child 恢复时拒绝 source 的 stale `resumeCursor`，只从 canonical child
    `providerSessionId` 启动；该约束覆盖进程重启后的首次续聊。
 
 `forkSession` 调用前失败是 `not_started`；一旦调用开始，transport、SDK 或 post-verify
-失败都是 `unknown`。这样不会因响应丢失或复验失败而创建第二个 provider child。
+失败都是 `unknown`。Claude provider child UUID 由 SDK 生成，driver 不声明 deterministic
+target identity；Host 仍预留 deterministic canonical target Session ID，但绝不重放
+`unknown` provider mutation。这样不会因响应丢失或复验失败而创建第二个 provider child。
 
 损坏 target 的修复规则更严格：只有首条 `session_meta` 已精确验证 child identity，且包括
 partial tail 在内的全部原始字节都是 source rollout 的严格前缀时，才允许从 source 原位

--- a/packages/agent/claude-sdk-sidecar/README.md
+++ b/packages/agent/claude-sdk-sidecar/README.md
@@ -19,7 +19,7 @@ build step and no bundled entry point beyond the source files.
 ## Sidecar protocol
 
 The daemon and sidecar exchange newline-delimited JSON envelopes over standard
-input and output. Every request and event carries `"version": 3`; either side
+input and output. Every request and event carries `"version": 5`; either side
 rejects unsupported or missing versions instead of guessing compatibility.
 Protocol types and validation live in `src/protocol.ts`.
 
@@ -28,6 +28,23 @@ not create a `SessionRuntime` or resume a query. They use the official SDK
 session APIs, verify the selected source prefix and the independently readable
 child transcript, and return identities plus a provider-owned binding receipt;
 prompt and tool content never cross this protocol boundary.
+
+`fork_session` calls the official `forkSession(..., {upToMessageId, title})`
+mutation directly. Claude allocates the provider child UUID, while Host keeps
+the canonical target Agent Session ID deterministic. The driver therefore does
+not attest deterministic provider identity: after mutation starts, any SDK or
+verification failure is `unknown` and must never be replayed. A trailing system
+message may be present in the provider-owned child file but hidden by
+`getSessionMessages()` until a later message extends the chain, so verification
+compares the SDK-observable prefix while the source checkpoint receipt still
+binds the full inclusive prefix.
+
+For live Turns, the UUID supplied on the outbound SDK user message is a
+`promptCorrelationId` only because Claude Code may rewrite it in the durable
+transcript. `SessionRuntime` causally binds the next expected root prompt echo
+to its canonical Turn, takes provider identity from the observed root
+user-message UUID, and emits `provider_turn_started`; the daemon persists only
+that observed identity.
 
 Interactive responses use `(turnId, requestId)` identity. The sidecar keeps a
 bounded terminal disposition registry so `submit_interactive` is idempotent:

--- a/packages/agent/claude-sdk-sidecar/src/goalExecQueue.ts
+++ b/packages/agent/claude-sdk-sidecar/src/goalExecQueue.ts
@@ -9,7 +9,7 @@ export type GoalCommandDispatch = {
 
 export type GoalExecInput = {
   turnId: string;
-  providerTurnId?: string;
+  promptCorrelationId?: string;
   prompt: string;
   content?: unknown;
   turnOrigin?: string;

--- a/packages/agent/claude-sdk-sidecar/src/main.ts
+++ b/packages/agent/claude-sdk-sidecar/src/main.ts
@@ -70,7 +70,7 @@ export async function handleRequest(
               }
             : undefined,
           stringValue(payload.hostContext),
-          stringValue(payload.providerTurnId)
+          stringValue(payload.promptCorrelationId)
         );
         emit({ id, type: "ok" });
         return;
@@ -92,7 +92,6 @@ export async function handleRequest(
           providerTurnIds: Array.isArray(payload.providerTurnIds)
             ? payload.providerTurnIds.map(stringValue)
             : [],
-          targetSessionId: stringValue(payload.targetProviderSessionId),
           cwd: stringValue(payload.cwd),
           title: stringValue(payload.title)
         });
@@ -184,6 +183,12 @@ export async function handleRequest(
         "deliveryDisposition" in error &&
         typeof error.deliveryDisposition === "string"
           ? { deliveryDisposition: error.deliveryDisposition }
+          : {}),
+        ...(error &&
+        typeof error === "object" &&
+        "stage" in error &&
+        typeof error.stage === "string"
+          ? { stage: error.stage }
           : {})
       }
     });

--- a/packages/agent/claude-sdk-sidecar/src/messageRouter.ts
+++ b/packages/agent/claude-sdk-sidecar/src/messageRouter.ts
@@ -321,11 +321,16 @@ export class SDKMessageRouter {
     const notificationText = readUserMessageNotificationText(
       message as { message?: { content?: unknown } }
     );
-    if (notificationText.includes("<task-notification>")) {
+    const taskNotification = notificationText.includes("<task-notification>");
+    if (taskNotification) {
       this.activities.handleTaskNotificationFromText(notificationText);
     }
     const activeTurnIdBefore = this.turns.activeId;
-    this.turns.activateForUserMessage(readSDKMessageUuid(message));
+    if (!parentToolUseID && !taskNotification) {
+      this.turns.activateForUserMessage(readSDKMessageUuid(message));
+    } else {
+      this.turns.ensureActive("user");
+    }
     if (
       !parentToolUseID &&
       this.turns.activeId &&

--- a/packages/agent/claude-sdk-sidecar/src/protocol.ts
+++ b/packages/agent/claude-sdk-sidecar/src/protocol.ts
@@ -1,4 +1,4 @@
-export const CLAUDE_SDK_SIDECAR_PROTOCOL_VERSION = 3 as const;
+export const CLAUDE_SDK_SIDECAR_PROTOCOL_VERSION = 5 as const;
 
 export type ClaudeSDKSidecarRequestType =
   | "start"

--- a/packages/agent/claude-sdk-sidecar/src/sessionFork.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionFork.test.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  forkSession as sdkForkSession,
+  getSessionInfo as sdkGetSessionInfo,
+  getSessionMessages as sdkGetSessionMessages,
+  InMemorySessionStore
+} from "@anthropic-ai/claude-agent-sdk";
+import {
   forkClaudeSession,
   inspectClaudeForkCheckpoints
 } from "./sessionFork.ts";
@@ -36,123 +42,146 @@ test("Claude fork inspection exposes only root user message UUIDs", async () => 
   assert.deepEqual(result, { providerTurnIds: ["prompt-1", "prompt-2"] });
 });
 
-test("Claude fork verifies the inclusive prefix and maps remapped UUIDs", async () => {
+test("Claude fork uses the official mutation and maps remapped UUIDs", async () => {
   const calls: Array<Record<string, unknown>> = [];
   const result = await forkClaudeSession(
     {
       sessionId: "source",
       providerTurnId: "prompt-1",
       providerTurnIds: ["prompt-1"],
-      targetSessionId: childSessionId,
       cwd: "/workspace",
       title: "Source (2)"
     },
     fakeSDK(calls)
   );
+
   assert.equal(result.providerSessionId, childSessionId);
   assert.deepEqual(result.targetProviderTurnIds, ["child-prompt-1"]);
   assert.equal(result.stateBindingMode, "provider_owned");
   assert.match(String(result.stateBindingReceipt), /^claude-sdk-fork-v1:/);
   assert.deepEqual(calls, [
     {
+      sessionId: "source",
       options: {
-        cwd: "/workspace",
-        resume: "source",
-        forkSession: true,
-        sessionId: childSessionId,
-        resumeSessionAt: "answer-1",
+        dir: "/workspace",
+        upToMessageId: "answer-1",
         title: "Source (2)"
       }
     }
   ]);
 });
 
-test("Claude fork reconciles an existing deterministic child without another mutation", async () => {
-  let queryCalls = 0;
+test("official Claude fork preserves a trailing system checkpoint", async () => {
+  const store = new InMemorySessionStore();
+  const projectKey = "-workspace";
+  const sourceSessionId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+  const sourcePrompt1 = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+  const sourceAnswer1 = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+  const sourceSystem = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+  const sourcePrompt2 = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee";
+  const sourceAnswer2 = "ffffffff-ffff-4fff-8fff-ffffffffffff";
+  await store.append({ projectKey, sessionId: sourceSessionId }, [
+    transcriptEntry("user", sourcePrompt1, null, sourceSessionId, {
+      role: "user",
+      content: "one"
+    }),
+    transcriptEntry(
+      "assistant",
+      sourceAnswer1,
+      sourcePrompt1,
+      sourceSessionId,
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "first" }]
+      }
+    ),
+    {
+      type: "system",
+      subtype: "stop_hook_summary",
+      uuid: sourceSystem,
+      parentUuid: sourceAnswer1,
+      sessionId: sourceSessionId,
+      timestamp: "2026-01-01T00:00:02.000Z"
+    },
+    transcriptEntry("user", sourcePrompt2, sourceSystem, sourceSessionId, {
+      role: "user",
+      content: "two"
+    }),
+    transcriptEntry(
+      "assistant",
+      sourceAnswer2,
+      sourcePrompt2,
+      sourceSessionId,
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "second" }]
+      }
+    )
+  ]);
+  const sdk = inMemorySDK(store);
+
+  const result = await forkClaudeSession(
+    {
+      sessionId: sourceSessionId,
+      providerTurnId: sourcePrompt1,
+      providerTurnIds: [sourcePrompt1],
+      cwd: "/workspace",
+      title: "Child"
+    },
+    sdk
+  );
+
+  const providerSessionId = String(result.providerSessionId);
+  assert.notEqual(providerSessionId, sourceSessionId);
+  assert.match(
+    providerSessionId,
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu
+  );
+  assert.ok(Array.isArray(result.targetProviderTurnIds));
+  assert.equal(result.targetProviderTurnIds.length, 1);
+  assert.match(
+    String(result.targetProviderTurnIds[0]),
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu
+  );
+  assert.notEqual(result.targetProviderTurnIds[0], sourcePrompt1);
+  assert.ok(
+    store
+      .getEntries({ projectKey, sessionId: providerSessionId })
+      .some(
+        (entry) =>
+          entry.type === "system" && entry.subtype === "stop_hook_summary"
+      )
+  );
+});
+
+test("Claude fork accepts a child readable only through its transcript", async () => {
+  const sdk = fakeSDK();
+  sdk.getSessionInfo = (async () => undefined) as never;
   const result = await forkClaudeSession(
     {
       sessionId: "source",
       providerTurnId: "prompt-1",
       providerTurnIds: ["prompt-1"],
-      targetSessionId: childSessionId,
       cwd: "/workspace",
-      title: "Source (2)"
-    },
-    {
-      getSessionMessages: async (sessionId: string) =>
-        sessionId === childSessionId ? child : source,
-      getSessionInfo: async (sessionId: string) => ({
-        sessionId,
-        summary: "child",
-        lastModified: 1
-      }),
-      query: (() => {
-        queryCalls++;
-        return makeQuery(async () => {});
-      }) as never
-    }
-  );
-
-  assert.equal(result.providerSessionId, childSessionId);
-  assert.deepEqual(result.targetProviderTurnIds, ["child-prompt-1"]);
-  assert.equal(queryCalls, 0);
-});
-
-test("Claude fork initializes with an empty prompt stream", async () => {
-  let created = false;
-  let promptResult: Promise<IteratorResult<unknown>> | undefined;
-  const sdk = {
-    getSessionMessages: async (sessionId: string) => {
-      if (sessionId === childSessionId) {
-        return created ? child : [];
-      }
-      return source;
-    },
-    getSessionInfo: async () =>
-      created
-        ? { sessionId: childSessionId, summary: "child", lastModified: 1 }
-        : undefined,
-    query: ((params: { prompt: AsyncIterable<unknown> }) => {
-      const iterator = params.prompt[Symbol.asyncIterator]();
-      return makeQuery(
-        async () => {
-          created = true;
-        },
-        () => {
-          promptResult = iterator.next();
-        }
-      );
-    }) as never
-  };
-
-  await forkClaudeSession(
-    {
-      sessionId: "source",
-      providerTurnId: "prompt-1",
-      providerTurnIds: ["prompt-1"],
-      targetSessionId: childSessionId,
-      cwd: "/workspace",
-      title: "Source (2)"
+      title: "Child"
     },
     sdk
   );
-
-  assert.deepEqual(await promptResult, { done: true, value: undefined });
+  assert.equal(result.providerSessionId, childSessionId);
 });
 
-test("Claude fork reports unknown once the SDK mutation was invoked", async () => {
+test("Claude fork reports the provider stage and cause after mutation starts", async () => {
   const sdk = fakeSDK();
-  sdk.query = (() =>
-    makeQuery(async () => {
-      throw new Error("connection lost");
-    })) as never;
+  sdk.forkSession = (async () => {
+    throw new Error("connection lost");
+  }) as never;
+
   await assert.rejects(
     forkClaudeSession(
       {
         sessionId: "source",
         providerTurnId: "prompt-1",
         providerTurnIds: ["prompt-1"],
-        targetSessionId: childSessionId,
         cwd: "/workspace",
         title: "Source (2)"
       },
@@ -160,25 +189,29 @@ test("Claude fork reports unknown once the SDK mutation was invoked", async () =
     ),
     (error: unknown) =>
       error instanceof Error &&
+      error.message.includes("provider_fork") &&
+      error.message.includes("connection lost") &&
+      "stage" in error &&
+      error.stage === "provider_fork" &&
       "deliveryDisposition" in error &&
       error.deliveryDisposition === "unknown"
   );
 });
 
-test("Claude fork validates the checkpoint identity before SDK mutation", async () => {
+test("Claude fork validates checkpoint identity before SDK mutation", async () => {
   const calls: Array<Record<string, unknown>> = [];
   const sdk = fakeSDK(calls);
-  sdk.getSessionMessages = async () => [
+  sdk.getSessionMessages = (async () => [
     message("user", "prompt-1", { role: "user", content: "one" }),
     message("assistant", "", { role: "assistant", content: "first" })
-  ];
+  ]) as never;
+
   await assert.rejects(
     forkClaudeSession(
       {
         sessionId: "source",
         providerTurnId: "prompt-1",
         providerTurnIds: ["prompt-1"],
-        targetSessionId: childSessionId,
         cwd: "/workspace",
         title: ""
       },
@@ -186,6 +219,7 @@ test("Claude fork validates the checkpoint identity before SDK mutation", async 
     ),
     (error: unknown) =>
       error instanceof Error &&
+      error.message.includes("source_validation") &&
       "deliveryDisposition" in error &&
       error.deliveryDisposition === "not_started"
   );
@@ -199,157 +233,37 @@ test("Claude fork supports an untitled canonical session", async () => {
       sessionId: "source",
       providerTurnId: "prompt-1",
       providerTurnIds: ["prompt-1"],
-      targetSessionId: childSessionId,
       cwd: "/workspace",
       title: " "
     },
     fakeSDK(calls)
   );
+
   assert.equal(result.providerSessionId, childSessionId);
   assert.deepEqual(calls, [
     {
-      options: {
-        cwd: "/workspace",
-        resume: "source",
-        forkSession: true,
-        sessionId: childSessionId,
-        resumeSessionAt: "answer-1"
-      }
-    }
-  ]);
-});
-
-test("Claude fork includes trailing system messages in its exact checkpoint", async () => {
-  const calls: Array<Record<string, unknown>> = [];
-  const sourceWithSystem = [
-    message("user", "prompt-1", { role: "user", content: "one" }),
-    message("assistant", "answer-1", {
-      role: "assistant",
-      content: "first"
-    }),
-    message("system", "compact-1", {
-      subtype: "compact_boundary",
-      compact_metadata: { trigger: "auto" }
-    })
-  ];
-  const childWithSystem = [
-    message(
-      "user",
-      "child-prompt-1",
-      { role: "user", content: "one" },
-      childSessionId
-    ),
-    message(
-      "assistant",
-      "child-answer-1",
-      { role: "assistant", content: "first" },
-      childSessionId
-    ),
-    message(
-      "system",
-      "child-compact-1",
-      {
-        subtype: "compact_boundary",
-        compact_metadata: { trigger: "auto" }
-      },
-      childSessionId
-    )
-  ];
-  const transcriptReads: Array<Record<string, unknown>> = [];
-  let created = false;
-  const sdk = {
-    getSessionMessages: async (
-      sessionId: string,
-      options?: Record<string, unknown>
-    ) => {
-      transcriptReads.push({ sessionId, options });
-      if (sessionId === childSessionId) {
-        return created ? childWithSystem : [];
-      }
-      return sourceWithSystem;
-    },
-    getSessionInfo: async () =>
-      created
-        ? {
-            sessionId: childSessionId,
-            summary: "child",
-            lastModified: 1
-          }
-        : undefined,
-    query: ((params: { options?: Record<string, unknown> }) => {
-      calls.push({ options: selectedForkOptions(params.options) });
-      return makeQuery(async () => {
-        created = true;
-      });
-    }) as never
-  };
-
-  const result = await forkClaudeSession(
-    {
       sessionId: "source",
-      providerTurnId: "prompt-1",
-      providerTurnIds: ["prompt-1"],
-      targetSessionId: childSessionId,
-      cwd: "/workspace",
-      title: "Source (2)"
-    },
-    sdk
-  );
-
-  assert.deepEqual(result.targetProviderTurnIds, ["child-prompt-1"]);
-  assert.deepEqual(calls, [
-    {
       options: {
-        cwd: "/workspace",
-        resume: "source",
-        forkSession: true,
-        sessionId: childSessionId,
-        resumeSessionAt: "compact-1",
-        title: "Source (2)"
+        dir: "/workspace",
+        upToMessageId: "answer-1"
       }
     }
   ]);
-  assert.equal(transcriptReads.length, 4);
-  for (const read of transcriptReads) {
-    assert.deepEqual(read.options, {
-      dir: "/workspace",
-      includeSystemMessages: true
-    });
-  }
 });
 
-test("Claude fork reports unknown when child omits a trailing system message", async () => {
-  const sourceWithSystem = [
-    message("user", "prompt-1", { role: "user", content: "one" }),
-    message("assistant", "answer-1", {
-      role: "assistant",
-      content: "first"
-    }),
-    message("system", "compact-1", {
-      subtype: "compact_boundary"
-    })
-  ];
-  let created = false;
-  const sdk = {
-    getSessionMessages: async (sessionId: string) => {
-      if (sessionId === childSessionId) {
-        return created ? child : [];
-      }
-      return sourceWithSystem;
-    },
-    getSessionInfo: async () =>
-      created
-        ? {
-            sessionId: childSessionId,
-            summary: "child",
-            lastModified: 1
-          }
-        : undefined,
-    query: (() =>
-      makeQuery(async () => {
-        created = true;
-      })) as never
-  };
+test("Claude fork reports child verification mismatch as unknown", async () => {
+  const sdk = fakeSDK(
+    [],
+    [
+      message(
+        "user",
+        "child-prompt-1",
+        { role: "user", content: "changed" },
+        childSessionId
+      ),
+      child[1]!
+    ]
+  );
 
   await assert.rejects(
     forkClaudeSession(
@@ -357,14 +271,14 @@ test("Claude fork reports unknown when child omits a trailing system message", a
         sessionId: "source",
         providerTurnId: "prompt-1",
         providerTurnIds: ["prompt-1"],
-        targetSessionId: childSessionId,
         cwd: "/workspace",
-        title: "Source (2)"
+        title: "Child"
       },
       sdk
     ),
     (error: unknown) =>
       error instanceof Error &&
+      error.message.includes("child_verification") &&
       "deliveryDisposition" in error &&
       error.deliveryDisposition === "unknown"
   );
@@ -395,7 +309,7 @@ test("Claude fork can branch again from a provider-owned child", async () => {
       if (sessionId === grandchildSessionId) {
         return created ? grandchild : [];
       }
-      return source;
+      return [];
     },
     getSessionInfo: async (sessionId: string) =>
       sessionId === grandchildSessionId && created
@@ -405,11 +319,13 @@ test("Claude fork can branch again from a provider-owned child", async () => {
             lastModified: 1
           }
         : undefined,
-    query: ((params: { options?: Record<string, unknown> }) => {
-      calls.push({ options: selectedForkOptions(params.options) });
-      return makeQuery(async () => {
-        created = true;
-      });
+    forkSession: (async (
+      sessionId: string,
+      options?: Record<string, unknown>
+    ) => {
+      calls.push({ sessionId, options });
+      created = true;
+      return { sessionId: grandchildSessionId };
     }) as never
   };
 
@@ -418,7 +334,6 @@ test("Claude fork can branch again from a provider-owned child", async () => {
       sessionId: childSessionId,
       providerTurnId: "child-prompt-1",
       providerTurnIds: ["child-prompt-1"],
-      targetSessionId: grandchildSessionId,
       cwd: "/workspace",
       title: "Grandchild"
     },
@@ -429,75 +344,82 @@ test("Claude fork can branch again from a provider-owned child", async () => {
   assert.deepEqual(result.targetProviderTurnIds, ["grandchild-prompt-1"]);
   assert.deepEqual(calls, [
     {
+      sessionId: childSessionId,
       options: {
-        cwd: "/workspace",
-        resume: childSessionId,
-        forkSession: true,
-        sessionId: grandchildSessionId,
-        resumeSessionAt: "child-answer-1",
+        dir: "/workspace",
+        upToMessageId: "child-answer-1",
         title: "Grandchild"
       }
     }
   ]);
 });
 
-function fakeSDK(calls: Array<Record<string, unknown>> = []) {
+function fakeSDK(
+  calls: Array<Record<string, unknown>> = [],
+  forkedMessages = child
+) {
   let created = false;
   return {
     getSessionMessages: async (sessionId: string) => {
       if (sessionId === childSessionId) {
-        return created ? child : [];
+        return created ? forkedMessages : [];
       }
       return source;
     },
-    getSessionInfo: async () =>
-      created
+    getSessionInfo: async (sessionId: string) =>
+      sessionId === childSessionId && created
         ? {
-            sessionId: childSessionId,
+            sessionId,
             summary: "child",
             lastModified: 1
           }
         : undefined,
-    query: ((params: { options?: Record<string, unknown> }) => {
-      calls.push({ options: selectedForkOptions(params.options) });
-      return makeQuery(async () => {
-        created = true;
-      });
+    forkSession: (async (
+      sessionId: string,
+      options?: Record<string, unknown>
+    ) => {
+      calls.push({ sessionId, options });
+      created = true;
+      return { sessionId: childSessionId };
     }) as never
   };
 }
 
-function makeQuery(
-  onInitialize: () => Promise<void>,
-  onClose: () => void = () => {}
-) {
-  const iterator = (async function* () {})();
-  return Object.assign(iterator, {
-    initializationResult: async () => {
-      await onInitialize();
-      return {};
-    },
-    close: onClose
-  });
+function inMemorySDK(store: InMemorySessionStore) {
+  return {
+    forkSession: ((sessionId, options) =>
+      sdkForkSession(sessionId, {
+        ...options,
+        sessionStore: store
+      })) as typeof sdkForkSession,
+    getSessionInfo: ((sessionId, options) =>
+      sdkGetSessionInfo(sessionId, {
+        ...options,
+        sessionStore: store
+      })) as typeof sdkGetSessionInfo,
+    getSessionMessages: ((sessionId, options) =>
+      sdkGetSessionMessages(sessionId, {
+        ...options,
+        sessionStore: store
+      })) as typeof sdkGetSessionMessages
+  };
 }
 
-function selectedForkOptions(
-  options: Record<string, unknown> | undefined
-): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
-  for (const key of [
-    "cwd",
-    "resume",
-    "forkSession",
-    "sessionId",
-    "resumeSessionAt",
-    "title"
-  ]) {
-    if (options && key in options) {
-      result[key] = options[key];
-    }
-  }
-  return result;
+function transcriptEntry(
+  type: "user" | "assistant",
+  uuid: string,
+  parentUuid: string | null,
+  sessionId: string,
+  content: unknown
+) {
+  return {
+    type,
+    uuid,
+    parentUuid,
+    sessionId,
+    timestamp: "2026-01-01T00:00:01.000Z",
+    message: content
+  };
 }
 
 function message(

--- a/packages/agent/claude-sdk-sidecar/src/sessionFork.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionFork.ts
@@ -1,14 +1,9 @@
 import { createHash } from "node:crypto";
 import {
+  forkSession,
   getSessionInfo,
-  getSessionMessages,
-  query,
-  type Options,
-  type Query
+  getSessionMessages
 } from "@anthropic-ai/claude-agent-sdk";
-import { resolveClaudeCodeExecutablePath } from "./executablePath.ts";
-import { AsyncPromptQueue } from "./promptQueue.ts";
-import { claudeSettingsEnv } from "./settingsEnv.ts";
 
 type SDKMessage = {
   type?: unknown;
@@ -26,21 +21,25 @@ type ForkInspectInput = {
 type ForkInput = ForkInspectInput & {
   providerTurnId: string;
   providerTurnIds: string[];
-  targetSessionId: string;
   title: string;
 };
 
 type ClaudeForkSDK = {
+  forkSession: typeof forkSession;
   getSessionMessages: typeof getSessionMessages;
   getSessionInfo: typeof getSessionInfo;
-  query: typeof query;
 };
 
 const defaultClaudeForkSDK: ClaudeForkSDK = {
+  forkSession,
   getSessionMessages,
-  getSessionInfo,
-  query
+  getSessionInfo
 };
+
+type ClaudeForkStage =
+  | "source_validation"
+  | "provider_fork"
+  | "child_verification";
 
 export async function inspectClaudeForkCheckpoints(
   input: ForkInspectInput,
@@ -61,26 +60,30 @@ export async function forkClaudeSession(
   sdk: ClaudeForkSDK = defaultClaudeForkSDK
 ): Promise<Record<string, unknown>> {
   let forkStarted = false;
+  let stage: ClaudeForkStage = "source_validation";
   try {
-    return await forkClaudeSessionVerified(input, sdk, () => {
-      forkStarted = true;
+    return await forkClaudeSessionVerified(input, sdk, (nextStage) => {
+      stage = nextStage;
+      if (nextStage === "provider_fork") {
+        forkStarted = true;
+      }
     });
-  } catch {
-    throw new ClaudeForkError(forkStarted ? "unknown" : "not_started");
+  } catch (error) {
+    throw new ClaudeForkError(
+      forkStarted ? "unknown" : "not_started",
+      stage,
+      error
+    );
   }
 }
 
 async function forkClaudeSessionVerified(
   input: ForkInput,
   sdk: ClaudeForkSDK,
-  onForkStarted: () => void
+  onStage: (stage: ClaudeForkStage) => void
 ): Promise<Record<string, unknown>> {
   requireIdentity(input.sessionId, "provider session id");
   requireIdentity(input.providerTurnId, "provider turn id");
-  requireUUID(input.targetSessionId, "target provider session id");
-  if (input.targetSessionId === input.sessionId) {
-    throw new Error("target provider session id equals source session id");
-  }
   const expectedTurnIds = normalizedIdentities(input.providerTurnIds);
   if (
     expectedTurnIds.length === 0 ||
@@ -103,29 +106,19 @@ async function forkClaudeSessionVerified(
   const checkpointId = sourceMessageIds.at(-1) ?? "";
   requireIdentity(checkpointId, "checkpoint message id");
 
-  const existingChild = await readExistingChild(
-    input.targetSessionId,
-    options,
-    transcriptReadOptions,
-    sdk
-  );
-  if (existingChild.exists) {
-    onForkStarted();
-    return verifiedForkResult({
-      input,
-      checkpointId,
-      sourcePrefix,
-      sourceMessageIds,
-      childSessionId: input.targetSessionId,
-      childMessages: existingChild.messages,
-      expectedTurnIds
-    });
+  onStage("provider_fork");
+  const forkResult = await sdk.forkSession(input.sessionId, {
+    ...options,
+    upToMessageId: checkpointId,
+    ...(input.title.trim() ? { title: input.title.trim() } : {})
+  });
+  const childSessionId = messageIdentity(forkResult?.sessionId);
+  requireUUID(childSessionId, "forked provider session id");
+  if (childSessionId === input.sessionId) {
+    throw new Error("forked provider session id equals source session id");
   }
 
-  onForkStarted();
-  await initializeDeterministicFork(input, checkpointId, sdk);
-  const childSessionId = input.targetSessionId;
-
+  onStage("child_verification");
   const [sourceB, childInfo, childMessages] = await Promise.all([
     sdk.getSessionMessages(input.sessionId, transcriptReadOptions) as Promise<
       SDKMessage[]
@@ -150,7 +143,11 @@ async function forkClaudeSessionVerified(
     sourceMessageIdsB,
     "source transcript identities changed during fork"
   );
-  if (messageIdentity(childInfo?.sessionId) !== childSessionId) {
+  const childInfoSessionId = messageIdentity(childInfo?.sessionId);
+  if (childInfoSessionId && childInfoSessionId !== childSessionId) {
+    throw new Error("forked Claude session resolved to another session");
+  }
+  if (!childInfoSessionId && childMessages.length === 0) {
     throw new Error("forked Claude session is not independently discoverable");
   }
   return verifiedForkResult({
@@ -162,82 +159,6 @@ async function forkClaudeSessionVerified(
     childMessages,
     expectedTurnIds
   });
-}
-
-async function readExistingChild(
-  childSessionId: string,
-  infoOptions: { dir?: string },
-  transcriptReadOptions: { dir?: string; includeSystemMessages: true },
-  sdk: ClaudeForkSDK
-): Promise<{ exists: boolean; messages: SDKMessage[] }> {
-  const [info, messages] = await Promise.all([
-    sdk.getSessionInfo(childSessionId, infoOptions),
-    sdk.getSessionMessages(childSessionId, transcriptReadOptions) as Promise<
-      SDKMessage[]
-    >
-  ]);
-  const infoSessionId = messageIdentity(info?.sessionId);
-  if (infoSessionId && infoSessionId !== childSessionId) {
-    throw new Error("deterministic Claude child resolved to another session");
-  }
-  return {
-    exists: infoSessionId === childSessionId || messages.length !== 0,
-    messages
-  };
-}
-
-// LIMITATION / SDK upgrade checkpoint:
-//
-// The pinned official SDK's direct forkSession() API chooses a random child
-// UUID and has no idempotency key, so it cannot implement Host's deterministic
-// replay contract. query() is used only to initialize
-// resume + forkSession + sessionId + resumeSessionAt with an empty prompt.
-//
-// A provider interruption can still leave the requested UUID present but with
-// a partial or unverifiable transcript. We deliberately return delivery
-// "unknown" in that case: deleting provider-owned state or creating a second
-// UUID would violate exactly-once safety.
-//
-// When upgrading @anthropic-ai/claude-agent-sdk, re-check whether
-// forkSession() supports a caller-supplied child UUID/idempotency key and an
-// atomic or reliably reconcilable durable result. If it does, replace this
-// query() workaround and revisit the fail-closed partial-child path above.
-async function initializeDeterministicFork(
-  input: ForkInput,
-  checkpointId: string,
-  sdk: ClaudeForkSDK
-): Promise<void> {
-  const promptQueue = new AsyncPromptQueue();
-  const cwd = input.cwd.trim() || process.cwd();
-  const settingsEnv = claudeSettingsEnv(cwd);
-  const env = {
-    ...process.env,
-    ...settingsEnv
-  };
-  const executablePath = resolveClaudeCodeExecutablePath(env);
-  const title = input.title.trim();
-  const options: Options = {
-    cwd,
-    env,
-    resume: input.sessionId,
-    forkSession: true,
-    sessionId: input.targetSessionId,
-    resumeSessionAt: checkpointId,
-    ...(title ? { title } : {}),
-    ...(executablePath ? { pathToClaudeCodeExecutable: executablePath } : {})
-  };
-  const forkQuery = sdk.query({
-    // Initialization performs the provider fork. Deliberately never enqueue a
-    // user message: the child must end exactly at the selected checkpoint.
-    prompt: promptQueue.iterate(),
-    options
-  }) as Query;
-  try {
-    await forkQuery.initializationResult();
-  } finally {
-    promptQueue.close();
-    forkQuery.close();
-  }
 }
 
 function verifiedForkResult(input: {
@@ -261,22 +182,17 @@ function verifiedForkResult(input: {
     childMessages,
     "forked transcript prefix"
   );
+  const observableSourcePrefix = forkObservablePrefix(sourcePrefix);
   assertStructuralEquality(
-    sourcePrefix,
+    observableSourcePrefix,
     childMessages,
     "forked Claude transcript does not equal the selected source prefix"
   );
 
-  const sourceIndexById = new Map(
-    sourcePrefix.map((message, index) => [messageIdentity(message), index])
-  );
-  const targetProviderTurnIds = expectedTurnIds.map((sourceId) => {
-    const index = sourceIndexById.get(sourceId);
-    if (index === undefined) {
-      throw new Error("source provider turn is absent from verified prefix");
-    }
-    return childMessageIds[index];
-  });
+  const targetProviderTurnIds = rootProviderTurnIds(childMessages);
+  if (targetProviderTurnIds.length !== expectedTurnIds.length) {
+    throw new Error("forked Claude transcript has a different root Turn count");
+  }
   const targetCheckpointId = childMessageIds.at(-1) ?? "";
   const receipt = createHash("sha256")
     .update(
@@ -302,11 +218,37 @@ function verifiedForkResult(input: {
 
 class ClaudeForkError extends Error {
   readonly deliveryDisposition: "not_started" | "unknown";
+  readonly stage: ClaudeForkStage;
 
-  constructor(deliveryDisposition: "not_started" | "unknown") {
-    super("Claude SDK session fork failed");
+  constructor(
+    deliveryDisposition: "not_started" | "unknown",
+    stage: ClaudeForkStage,
+    cause: unknown
+  ) {
+    super(
+      `Claude SDK session fork failed at ${stage}: ${forkErrorMessage(cause)}`
+    );
     this.deliveryDisposition = deliveryDisposition;
+    this.stage = stage;
   }
+}
+
+function forkObservablePrefix(messages: SDKMessage[]): SDKMessage[] {
+  let end = messages.length;
+  while (end > 0 && messages[end - 1]?.type === "system") {
+    end -= 1;
+  }
+  return messages.slice(0, end);
+}
+
+function forkErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message.trim();
+  }
+  if (typeof error === "string" && error.trim()) {
+    return error.trim();
+  }
+  return "unknown error";
 }
 
 function exactSourcePrefix(

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.session.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.session.test.ts
@@ -19,6 +19,73 @@ import {
 } from "./sessionRuntimeTestQueries.session.ts";
 import { waitForEvent } from "./sessionRuntimeTestQueries.nested.ts";
 
+test("Claude-persisted user UUID becomes the provider Turn identity", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-identity",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) => ({
+        async *[Symbol.asyncIterator]() {
+          const iterator = prompt[Symbol.asyncIterator]();
+          const outbound = await iterator.next();
+          yield {
+            ...outbound.value,
+            uuid: "persisted-claude-user-uuid",
+            type: "user",
+            parent_tool_use_id: null,
+            session_id: "provider-session-identity"
+          } as never;
+          yield { type: "result", subtype: "success" } as never;
+        },
+        close() {}
+      })
+    );
+
+    await session.start();
+    session.exec(
+      "turn-identity",
+      "hello",
+      undefined,
+      undefined,
+      undefined,
+      "",
+      "outbound-correlation-id"
+    );
+    await waitForEvent(events, "turn_completed");
+
+    const providerStarted = events.find(
+      (event) => event.type === "provider_turn_started"
+    );
+    const completed = events.find((event) => event.type === "turn_completed");
+    assert.equal(
+      providerStarted?.payload?.providerTurnId,
+      "persisted-claude-user-uuid"
+    );
+    assert.equal(
+      completed?.payload?.providerTurnId,
+      "persisted-claude-user-uuid"
+    );
+  } finally {
+    restoreSink();
+  }
+});
+
 test("tutti host context shares one SDK prompt with unchanged user input", async () => {
   const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
   const messages: Array<{

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts
@@ -179,7 +179,7 @@ export class SessionRuntime {
     this.goalExecQueue = new GoalExecQueue((input) =>
       this.dispatchExec(
         input.turnId,
-        input.providerTurnId,
+        input.promptCorrelationId,
         input.prompt,
         input.content,
         input.turnOrigin,
@@ -248,10 +248,10 @@ export class SessionRuntime {
     turnOrigin?: string,
     goal?: GoalCommandDispatch,
     hostContext = "",
-    providerTurnId = ""
+    promptCorrelationId = ""
   ): void {
     if (this.driver) {
-      this.driver.exec(turnId, prompt, providerTurnId);
+      this.driver.exec(turnId, prompt, promptCorrelationId);
       return;
     }
     if (this.sessionClosed) {
@@ -267,7 +267,7 @@ export class SessionRuntime {
     if (goal?.operationId && goal.revision > 0) {
       this.goalExecQueue.accept({
         turnId,
-        providerTurnId,
+        promptCorrelationId,
         prompt,
         content,
         turnOrigin,
@@ -278,7 +278,7 @@ export class SessionRuntime {
     }
     this.dispatchExec(
       turnId,
-      providerTurnId,
+      promptCorrelationId,
       prompt,
       content,
       turnOrigin,
@@ -289,7 +289,7 @@ export class SessionRuntime {
 
   private dispatchExec(
     turnId: string,
-    providerTurnId: string | undefined,
+    promptCorrelationId: string | undefined,
     prompt: string,
     content?: unknown,
     turnOrigin?: string,
@@ -299,7 +299,7 @@ export class SessionRuntime {
     this.turns.closeSyntheticBeforeUserTurn();
     const turn: RuntimeTurn = {
       turnId,
-      promptUuid: providerTurnId?.trim() || crypto.randomUUID(),
+      promptUuid: promptCorrelationId?.trim() || crypto.randomUUID(),
       ...(turnOrigin ? { origin: turnOrigin } : {}),
       ...(goal
         ? {
@@ -346,6 +346,7 @@ export class SessionRuntime {
           }
         }
         generation.expectPromptEcho(turn.promptUuid);
+        this.turns.expectProviderTurnIdentity(turn.turnId);
         generation.promptQueue.push({
           uuid: turn.promptUuid,
           type: "user",

--- a/packages/agent/claude-sdk-sidecar/src/testDriver.ts
+++ b/packages/agent/claude-sdk-sidecar/src/testDriver.ts
@@ -12,8 +12,14 @@ export class SidecarTestDriver {
     this.interactions = interactions;
   }
 
-  exec(turnId: string, prompt: string, providerTurnId = ""): void {
+  exec(turnId: string, prompt: string, promptCorrelationId = ""): void {
     this.turns.activateTransient(turnId);
+    if (promptCorrelationId) {
+      emit({
+        type: "provider_turn_started",
+        payload: { turnId, providerTurnId: promptCorrelationId }
+      });
+    }
     if (prompt.includes("approval")) {
       void this.interactions
         .handleToolPermission(
@@ -26,9 +32,9 @@ export class SidecarTestDriver {
           }
         )
         .then(() =>
-          this.completeTurn(turnId, providerTurnId, "Approval accepted.")
+          this.completeTurn(turnId, promptCorrelationId, "Approval accepted.")
         )
-        .catch((error) => this.failTurn(turnId, providerTurnId, error));
+        .catch((error) => this.failTurn(turnId, promptCorrelationId, error));
       return;
     }
     if (prompt.includes("ask-user")) {
@@ -50,9 +56,9 @@ export class SidecarTestDriver {
           }
         )
         .then(() =>
-          this.completeTurn(turnId, providerTurnId, "Question answered.")
+          this.completeTurn(turnId, promptCorrelationId, "Question answered.")
         )
-        .catch((error) => this.failTurn(turnId, providerTurnId, error));
+        .catch((error) => this.failTurn(turnId, promptCorrelationId, error));
       return;
     }
     if (prompt.includes("exit-plan")) {
@@ -65,20 +71,22 @@ export class SidecarTestDriver {
             toolUseID: "test-exit-plan-tool"
           }
         )
-        .then(() => this.completeTurn(turnId, providerTurnId, "Plan captured."))
-        .catch((error) => this.failTurn(turnId, providerTurnId, error));
+        .then(() =>
+          this.completeTurn(turnId, promptCorrelationId, "Plan captured.")
+        )
+        .catch((error) => this.failTurn(turnId, promptCorrelationId, error));
       return;
     }
     emit({
       type: "assistant_delta",
       payload: {
         turnId,
-        ...(providerTurnId ? { providerTurnId } : {}),
+        ...(promptCorrelationId ? { providerTurnId: promptCorrelationId } : {}),
         content: `Echo: ${prompt}`,
         snapshot: `Echo: ${prompt}`
       }
     });
-    this.completeTurn(turnId, providerTurnId, `Echo: ${prompt}`);
+    this.completeTurn(turnId, promptCorrelationId, `Echo: ${prompt}`);
   }
 
   guide(prompt: string): void {

--- a/packages/agent/claude-sdk-sidecar/src/turnLifecycle.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/turnLifecycle.test.ts
@@ -19,6 +19,13 @@ test("turn lifecycle activates and settles a queued turn", () => {
   assert.equal(activations.count, 1);
   assert.equal(settlements.count, 1);
   assert.deepEqual(events[0], {
+    type: "provider_turn_started",
+    payload: {
+      turnId: "turn-1",
+      providerTurnId: "prompt-1"
+    }
+  });
+  assert.deepEqual(events[1], {
     type: "turn_completed",
     payload: {
       stopReason: "end_turn",
@@ -39,10 +46,43 @@ test("turn lifecycle announces a goal arm before its first output", () => {
 
   lifecycle.activateForUserMessage("prompt-goal");
 
-  assert.deepEqual(events[0], {
-    type: "turn_started",
-    payload: { turnId: "goal-arm-1", turnOrigin: "goal_arm" }
+  assert.deepEqual(
+    events.find((event) => event.type === "turn_started"),
+    {
+      type: "turn_started",
+      payload: { turnId: "goal-arm-1", turnOrigin: "goal_arm" }
+    }
+  );
+});
+
+test("turn lifecycle uses Claude's persisted root user UUID as provider identity", () => {
+  const { lifecycle, events } = createLifecycle();
+  lifecycle.enqueue({
+    turnId: "turn-rewritten",
+    promptUuid: "outbound-correlation-id",
+    settled: false
   });
+
+  lifecycle.expectProviderTurnIdentity("turn-rewritten");
+  lifecycle.activateForUserMessage("persisted-claude-user-uuid");
+  lifecycle.settleActive("turn_completed");
+
+  assert.deepEqual(events, [
+    {
+      type: "provider_turn_started",
+      payload: {
+        turnId: "turn-rewritten",
+        providerTurnId: "persisted-claude-user-uuid"
+      }
+    },
+    {
+      type: "turn_completed",
+      payload: {
+        turnId: "turn-rewritten",
+        providerTurnId: "persisted-claude-user-uuid"
+      }
+    }
+  ]);
 });
 
 test("goal activation carries its immutable command identity", () => {

--- a/packages/agent/claude-sdk-sidecar/src/turnLifecycle.ts
+++ b/packages/agent/claude-sdk-sidecar/src/turnLifecycle.ts
@@ -2,7 +2,15 @@ import type { ClaudeSDKSidecarEventEmitter } from "./protocol.ts";
 
 export type RuntimeTurn = {
   readonly turnId: string;
+  /**
+   * Correlates the outbound SDK prompt with mocks and SDK versions that
+   * preserve caller UUIDs. Claude Code may rewrite it before persistence, so
+   * it is not provider identity.
+   */
   readonly promptUuid: string;
+  awaitingProviderTurnIdentity?: boolean;
+  providerTurnId?: string;
+  providerTurnStarted?: boolean;
   readonly synthetic?: boolean;
   awaitingContinuation?: boolean;
   readonly origin?: string;
@@ -97,26 +105,41 @@ export class TurnLifecycle {
     this.turns.push(turn);
   }
 
-  activateForPromptUuid(promptUuid: string): void {
-    if (!promptUuid) {
-      return;
-    }
-    const matched = this.turns.find(
-      (turn) => !turn.settled && turn.promptUuid === promptUuid
+  expectProviderTurnIdentity(turnId: string): void {
+    const turn = this.turns.find(
+      (candidate) => !candidate.settled && candidate.turnId === turnId.trim()
     );
-    if (matched) {
-      if (!matched.synthetic) {
-        this.rejectingTimedOutContinuation = false;
-      }
-      this.activate(matched);
+    if (turn && !turn.synthetic && !turn.providerTurnId?.trim()) {
+      turn.awaitingProviderTurnIdentity = true;
     }
   }
 
   activateForUserMessage(promptUuid: string): void {
-    this.activateForPromptUuid(promptUuid);
-    if (!this.active) {
+    const normalizedPromptUuid = promptUuid.trim();
+    if (!normalizedPromptUuid) {
       this.ensureActive("user");
+      return;
     }
+    const matched = this.turns.find(
+      (turn) => !turn.settled && turn.promptUuid === normalizedPromptUuid
+    );
+    const candidate =
+      matched ??
+      this.turns.find(
+        (turn) =>
+          !turn.settled &&
+          !turn.synthetic &&
+          turn.awaitingProviderTurnIdentity === true
+      );
+    if (candidate) {
+      if (!candidate.synthetic) {
+        this.rejectingTimedOutContinuation = false;
+      }
+      this.bindProviderTurnId(candidate, normalizedPromptUuid);
+      this.activate(candidate);
+      return;
+    }
+    this.ensureActive("user");
   }
 
   ensureActive(messageType: string): RuntimeTurn | undefined {
@@ -211,7 +234,9 @@ export class TurnLifecycle {
       payload: {
         ...payload,
         turnId: turn.turnId,
-        ...(turn.promptUuid ? { providerTurnId: turn.promptUuid } : {})
+        ...(this.providerTurnId(turn)
+          ? { providerTurnId: this.providerTurnId(turn) }
+          : {})
       }
     });
     this.clearContinuationStartTimer();
@@ -306,7 +331,9 @@ export class TurnLifecycle {
         type: "goal_command_started",
         payload: {
           turnId: turn.turnId,
-          ...(turn.promptUuid ? { providerTurnId: turn.promptUuid } : {}),
+          ...(this.providerTurnId(turn)
+            ? { providerTurnId: this.providerTurnId(turn) }
+            : {}),
           operationId: turn.goalOperationId,
           revision: turn.goalRevision,
           repairEpoch: turn.goalRepairEpoch ?? 0,
@@ -365,9 +392,36 @@ export class TurnLifecycle {
       payload: {
         ...payload,
         turnId: turn.turnId,
-        ...(turn.promptUuid ? { providerTurnId: turn.promptUuid } : {})
+        ...(this.providerTurnId(turn)
+          ? { providerTurnId: this.providerTurnId(turn) }
+          : {})
       }
     });
+  }
+
+  private bindProviderTurnId(turn: RuntimeTurn, providerTurnId: string): void {
+    if (
+      turn.synthetic ||
+      !providerTurnId ||
+      turn.providerTurnId?.trim() ||
+      turn.providerTurnStarted
+    ) {
+      return;
+    }
+    turn.providerTurnId = providerTurnId;
+    turn.awaitingProviderTurnIdentity = false;
+    turn.providerTurnStarted = true;
+    this.emit({
+      type: "provider_turn_started",
+      payload: {
+        turnId: turn.turnId,
+        providerTurnId
+      }
+    });
+  }
+
+  private providerTurnId(turn: RuntimeTurn): string {
+    return turn.providerTurnId?.trim() || turn.promptUuid.trim();
   }
 
   private compactQueue(): void {

--- a/packages/agent/daemon/runtime/claude_sdk_event_projection_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_event_projection_test.go
@@ -38,6 +38,44 @@ func TestClaudeCodeSDKAdapterMapsSyntheticTurnStarted(t *testing.T) {
 	}
 }
 
+func TestClaudeCodeSDKAdapterMapsObservedProviderTurnIdentity(t *testing.T) {
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session := standardTestSession(ProviderClaudeCode)
+	adapterSession := &claudeSDKAdapterSession{liveState: newClaudeSDKLiveState()}
+	adapter.beginClaudeSDKRootTurn(adapterSession, "canonical-turn-1", "")
+
+	events, terminal, err := adapter.sidecarTurnEvents(
+		adapterSession,
+		session,
+		"canonical-turn-1",
+		claudeSDKSidecarEvent{
+			Type: "provider_turn_started",
+			Payload: map[string]any{
+				"turnId":         "canonical-turn-1",
+				"providerTurnId": "persisted-claude-user-uuid",
+			},
+		},
+	)
+	if err != nil || terminal {
+		t.Fatalf("provider_turn_started err=%v terminal=%v", err, terminal)
+	}
+	if len(events) != 1 ||
+		events[0].Type != activityshared.EventRootProviderTurnStarted ||
+		events[0].Payload.TurnID != "canonical-turn-1" ||
+		events[0].Payload.ProviderTurnID != "persisted-claude-user-uuid" {
+		t.Fatalf("events = %#v, want observed provider identity", events)
+	}
+	if adapter.claudeSDKRootTurnID(adapterSession, "") != "canonical-turn-1" {
+		t.Fatalf("root turn id = %q", adapter.claudeSDKRootTurnID(adapterSession, ""))
+	}
+	if !adapter.consumeClaudeSDKRootProviderTurn(
+		adapterSession,
+		"persisted-claude-user-uuid",
+	) {
+		t.Fatal("observed provider identity was not registered")
+	}
+}
+
 func TestClaudeCodeSDKAdapterCompletesCanonicalTurnByProviderIdentity(t *testing.T) {
 	adapter := NewClaudeCodeSDKAdapter(nil)
 	session := standardTestSession(ProviderClaudeCode)

--- a/packages/agent/daemon/runtime/claude_sdk_events.go
+++ b/packages/agent/daemon/runtime/claude_sdk_events.go
@@ -75,6 +75,17 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 		return nil, false, nil
 	case "session_state":
 		return []activityshared.Event{newSessionActivityEvent(session, EventSessionUpdated, firstNonEmpty(session.Status, SessionStatusReady), claudeSDKRuntimeContext(session, adapterSession))}, false, nil
+	case "provider_turn_started":
+		if eventTurnID == "" || providerTurnID == "" {
+			return nil, false, errors.New("claude SDK provider turn start omitted identity")
+		}
+		a.beginClaudeSDKRootTurn(adapterSession, eventTurnID, providerTurnID)
+		return []activityshared.Event{claudeSDKRootProviderTurnStartedEvent(
+			session,
+			eventTurnID,
+			providerTurnID,
+			map[string]any{"adapter": claudeSDKSidecarAdapterName},
+		)}, false, nil
 	case "turn_started":
 		metadata := map[string]any{
 			"adapter": claudeSDKSidecarAdapterName,

--- a/packages/agent/daemon/runtime/claude_sdk_execution.go
+++ b/packages/agent/daemon/runtime/claude_sdk_execution.go
@@ -25,8 +25,8 @@ func (a *ClaudeCodeSDKAdapter) Exec(
 		return nil, ErrSessionDisconnected
 	}
 	session.ProviderSessionID = adapterSession.providerSessionID
-	providerTurnID := newID()
-	a.beginClaudeSDKRootTurn(adapterSession, turnID, providerTurnID)
+	promptCorrelationID := newID()
+	a.beginClaudeSDKRootTurn(adapterSession, turnID, "")
 	explicitDisplayPrompt, visibleText := explicitAndVisiblePromptText(content, displayPrompt)
 	events := make([]activityshared.Event, 0, 4)
 	emitEvents := func(next []activityshared.Event) {
@@ -45,9 +45,6 @@ func (a *ClaudeCodeSDKAdapter) Exec(
 		newTurnActivityEvent(session, EventTurnStarted, turnID, SessionStatusWorking, "", "", map[string]any{
 			"adapter": claudeSDKSidecarAdapterName,
 		}),
-		claudeSDKRootProviderTurnStartedEvent(session, turnID, providerTurnID, map[string]any{
-			"adapter": claudeSDKSidecarAdapterName,
-		}),
 	}
 	if event, ok := adapterSession.mirrorGoalSlashPrompt(session, visibleText); ok {
 		startEvents = append(startEvents, event)
@@ -57,17 +54,17 @@ func (a *ClaudeCodeSDKAdapter) Exec(
 	waiter := a.registerClaudeSDKTurn(adapterSession, turnID, emit)
 	if err := a.startClaudeSDKReader(session.AgentSessionID, adapterSession); err != nil {
 		a.unregisterClaudeSDKTurn(adapterSession, turnID, waiter)
-		events = append(events, a.claudeSDKRootProviderFailureEvents(adapterSession, session, turnID, providerTurnID, err)...)
+		events = append(events, a.claudeSDKRootProviderFailureEvents(adapterSession, session, turnID, promptCorrelationID, err)...)
 		return events, err
 	}
-	payload := claudeSDKExecPayload(ctx, session, turnID, providerTurnID, content, visibleText)
+	payload := claudeSDKExecPayload(ctx, session, turnID, promptCorrelationID, content, visibleText)
 	if err := adapterSession.send(claudeSDKSidecarRequest{
 		ID:      newID(),
 		Type:    "exec",
 		Payload: payload,
 	}); err != nil {
 		a.unregisterClaudeSDKTurn(adapterSession, turnID, waiter)
-		events = append(events, a.claudeSDKRootProviderFailureEvents(adapterSession, session, turnID, providerTurnID, err)...)
+		events = append(events, a.claudeSDKRootProviderFailureEvents(adapterSession, session, turnID, promptCorrelationID, err)...)
 		return events, err
 	}
 
@@ -77,7 +74,7 @@ func (a *ClaudeCodeSDKAdapter) Exec(
 			events = append(events, result.events...)
 		}
 		if result.err != nil {
-			events = append(events, a.claudeSDKRootProviderFailureEvents(adapterSession, session, turnID, providerTurnID, result.err)...)
+			events = append(events, a.claudeSDKRootProviderFailureEvents(adapterSession, session, turnID, promptCorrelationID, result.err)...)
 		}
 		return events, result.err
 	case <-ctx.Done():
@@ -100,16 +97,16 @@ func claudeSDKExecPayload(
 	ctx context.Context,
 	session Session,
 	turnID string,
-	providerTurnID string,
+	promptCorrelationID string,
 	content []PromptContentBlock,
 	visibleText string,
 ) map[string]any {
 	payload := map[string]any{
-		"agentSessionId": session.AgentSessionID,
-		"turnId":         turnID,
-		"providerTurnId": providerTurnID,
-		"prompt":         promptTextForClaudeSDK(content, visibleText),
-		"content":        promptContentForClaudeSDK(content, visibleText),
+		"agentSessionId":      session.AgentSessionID,
+		"turnId":              turnID,
+		"promptCorrelationId": promptCorrelationID,
+		"prompt":              promptTextForClaudeSDK(content, visibleText),
+		"content":             promptContentForClaudeSDK(content, visibleText),
 	}
 	if hostContext := renderTuttiModeHostContext(tuttiModeTurnSnapshotFromContext(ctx)); hostContext != "" {
 		payload["hostContext"] = hostContext

--- a/packages/agent/daemon/runtime/claude_sdk_fork.go
+++ b/packages/agent/daemon/runtime/claude_sdk_fork.go
@@ -8,11 +8,10 @@ import (
 
 const (
 	claudeSDKForkDriverKind = "claude-agent-sdk-session-fork"
-	// sidecar-v4 uses the official SDK query resume/fork options because the
-	// pinned direct forkSession API cannot accept Host's deterministic child
-	// UUID. On an SDK upgrade, check for caller-selected child identity,
-	// idempotency, and atomic/reconcilable persistence before replacing it.
-	claudeSDKForkDriverVersion = "0.3.201/sidecar-v4-deterministic"
+	// The official SDK forkSession API allocates the provider child identity.
+	// Host therefore permits one dispatch and fails closed instead of replaying
+	// an unknown result that could create a duplicate provider child.
+	claudeSDKForkDriverVersion = "0.3.201/sidecar-v6-official-fork-api"
 )
 
 func (a *ClaudeCodeSDKAdapter) ForkCapabilities(
@@ -47,7 +46,7 @@ func (a *ClaudeCodeSDKAdapter) ForkCapabilities(
 		DriverKind:                   claudeSDKForkDriverKind,
 		DriverVersion:                claudeSDKForkDriverVersion,
 		StateBindingMode:             "provider_owned",
-		DeterministicTargetSessionID: true,
+		DeterministicTargetSessionID: false,
 		ThroughTurn:                  len(turnIDs) != 0,
 		ThroughProviderTurnIDs:       turnIDs,
 		ThroughProviderTurnIDsKnown:  true,
@@ -66,11 +65,6 @@ func (a *ClaudeCodeSDKAdapter) Fork(
 	if a == nil || a.transport == nil {
 		return result, ErrSessionForkUnsupported
 	}
-	targetProviderSessionID := strings.TrimSpace(input.TargetProviderSessionID)
-	if targetProviderSessionID == "" ||
-		targetProviderSessionID == result.ForkedFromProviderSessionID {
-		return result, errors.New("deterministic Claude fork target session id is required")
-	}
 	event, sent, err := a.statelessClaudeSDKForkRequest(
 		ctx,
 		input.Source,
@@ -78,12 +72,11 @@ func (a *ClaudeCodeSDKAdapter) Fork(
 			ID:   newID(),
 			Type: "fork_session",
 			Payload: map[string]any{
-				"providerSessionId":       strings.TrimSpace(input.Source.ProviderSessionID),
-				"providerTurnId":          strings.TrimSpace(input.ProviderTurnID),
-				"providerTurnIds":         append([]string(nil), input.ProviderTurnIDs...),
-				"targetProviderSessionId": targetProviderSessionID,
-				"cwd":                     strings.TrimSpace(input.Source.CWD),
-				"title":                   strings.TrimSpace(input.TargetTitle),
+				"providerSessionId": strings.TrimSpace(input.Source.ProviderSessionID),
+				"providerTurnId":    strings.TrimSpace(input.ProviderTurnID),
+				"providerTurnIds":   append([]string(nil), input.ProviderTurnIDs...),
+				"cwd":               strings.TrimSpace(input.Source.CWD),
+				"title":             strings.TrimSpace(input.TargetTitle),
 			},
 		},
 	)
@@ -117,7 +110,7 @@ func (a *ClaudeCodeSDKAdapter) Fork(
 		payloadString(event.Payload, "deliveryDisposition"),
 	)
 	if result.ProviderSessionID == "" ||
-		result.ProviderSessionID != targetProviderSessionID ||
+		result.ProviderSessionID == result.ForkedFromProviderSessionID ||
 		result.StateBindingMode != "provider_owned" ||
 		result.StateBindingReceipt == "" ||
 		result.DeliveryDisposition != SessionForkDeliveryAccepted {

--- a/packages/agent/daemon/runtime/claude_sdk_fork_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_fork_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -27,7 +28,7 @@ func TestClaudeSDKForkCapabilitiesUsesStatelessTranscriptInspection(t *testing.T
 	}
 	if capabilities.DriverKind != claudeSDKForkDriverKind ||
 		capabilities.DriverVersion != claudeSDKForkDriverVersion ||
-		!capabilities.DeterministicTargetSessionID ||
+		capabilities.DeterministicTargetSessionID ||
 		!capabilities.ThroughTurn ||
 		!capabilities.ThroughProviderTurnIDsKnown ||
 		!reflect.DeepEqual(
@@ -61,9 +62,8 @@ func TestClaudeSDKForkReturnsProviderOwnedIdentityEvidence(t *testing.T) {
 
 	result, err := adapter.Fork(t.Context(), SessionForkInput{
 		Source: source, ProviderTurnID: "prompt-2",
-		ProviderTurnIDs:         []string{"prompt-1", "prompt-2"},
-		TargetProviderSessionID: "claude-child",
-		TargetTitle:             "Claude session (2)",
+		ProviderTurnIDs: []string{"prompt-1", "prompt-2"},
+		TargetTitle:     "Claude session (2)",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -81,7 +81,7 @@ func TestClaudeSDKForkReturnsProviderOwnedIdentityEvidence(t *testing.T) {
 	requests := conn.requests()
 	if len(requests) != 1 || requests[0].Type != "fork_session" ||
 		payloadString(requests[0].Payload, "title") != "Claude session (2)" ||
-		payloadString(requests[0].Payload, "targetProviderSessionId") != "claude-child" {
+		payloadString(requests[0].Payload, "targetProviderSessionId") != "" {
 		t.Fatalf("requests=%#v", requests)
 	}
 }
@@ -90,7 +90,8 @@ func TestClaudeSDKForkPreservesUnknownDispositionAfterDispatch(t *testing.T) {
 	conn := &claudeSDKForkTestConnection{
 		responseType: "error",
 		responsePayload: map[string]any{
-			"error":               "Claude SDK session fork failed",
+			"error":               "Claude SDK session fork failed at provider_fork: connection lost",
+			"stage":               "provider_fork",
 			"deliveryDisposition": "unknown",
 		},
 	}
@@ -99,11 +100,13 @@ func TestClaudeSDKForkPreservesUnknownDispositionAfterDispatch(t *testing.T) {
 	source.ProviderSessionID = "claude-source"
 	result, err := adapter.Fork(t.Context(), SessionForkInput{
 		Source: source, ProviderTurnID: "prompt-1",
-		ProviderTurnIDs:         []string{"prompt-1"},
-		TargetProviderSessionID: "claude-child", TargetTitle: "Child",
+		ProviderTurnIDs: []string{"prompt-1"}, TargetTitle: "Child",
 	})
 	if err == nil || result.DeliveryDisposition != SessionForkDeliveryUnknown {
 		t.Fatalf("result=%#v error=%v", result, err)
+	}
+	if !strings.Contains(err.Error(), "provider_fork: connection lost") {
+		t.Fatalf("error=%q, want original provider stage and cause", err)
 	}
 }
 
@@ -141,8 +144,7 @@ func TestClaudeSDKForkedChildCanResumeAndStartTurn(t *testing.T) {
 
 	result, err := adapter.Fork(t.Context(), SessionForkInput{
 		Source: source, ProviderTurnID: "prompt-1",
-		ProviderTurnIDs:         []string{"prompt-1"},
-		TargetProviderSessionID: "claude-child", TargetTitle: "Child",
+		ProviderTurnIDs: []string{"prompt-1"}, TargetTitle: "Child",
 	})
 	if err != nil {
 		t.Fatalf("Fork: %v", err)

--- a/packages/agent/daemon/runtime/claude_sdk_goal.go
+++ b/packages/agent/daemon/runtime/claude_sdk_goal.go
@@ -425,11 +425,11 @@ func (a *ClaudeCodeSDKAdapter) sendGoalCommandExec(
 	ctx, cancel := context.WithTimeout(ctx, claudeSDKGoalCommandTimeout)
 	defer cancel()
 	payload := map[string]any{
-		"agentSessionId": session.AgentSessionID,
-		"turnId":         turnID,
-		"providerTurnId": turnID,
-		"prompt":         command,
-		"content":        promptContentForClaudeSDK(nil, command),
+		"agentSessionId":      session.AgentSessionID,
+		"turnId":              turnID,
+		"promptCorrelationId": turnID,
+		"prompt":              command,
+		"content":             promptContentForClaudeSDK(nil, command),
 	}
 	if !isGoalClearCommandArgs(args) {
 		payload["turnOrigin"] = "goal_arm"

--- a/packages/agent/daemon/runtime/claude_sdk_goal_lifecycle_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_goal_lifecycle_test.go
@@ -646,8 +646,8 @@ func TestClaudeSDKGoalArmTurnCarriesDurableGoalIdentity(t *testing.T) {
 		t.Fatalf("ApplyGoal set: %v", err)
 	}
 	turnID := payloadString(setRequest.Payload, "turnId")
-	if payloadString(setRequest.Payload, "providerTurnId") != turnID {
-		t.Fatalf("goal provider turn id != SDK prompt UUID: %#v", setRequest.Payload)
+	if payloadString(setRequest.Payload, "promptCorrelationId") != turnID {
+		t.Fatalf("goal prompt correlation id != turn id: %#v", setRequest.Payload)
 	}
 	if payloadString(setRequest.Payload, "goalOperationId") != "goal-op-7" || payloadInt64(setRequest.Payload, "goalRevision") != 7 {
 		t.Fatalf("goal exec payload = %#v", setRequest.Payload)

--- a/packages/agent/daemon/runtime/claude_sdk_protocol.go
+++ b/packages/agent/daemon/runtime/claude_sdk_protocol.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-const claudeSDKSidecarProtocolVersion = 3
+const claudeSDKSidecarProtocolVersion = 5
 
 type claudeSDKSidecarRequest struct {
 	Version int            `json:"version"`

--- a/packages/agent/daemon/runtime/claude_sdk_session_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_session_test.go
@@ -603,11 +603,11 @@ func TestClaudeCodeSDKAdapterExecSendsStructuredPromptContent(t *testing.T) {
 	if sent[0].Payload["prompt"] != "what is in this image?" {
 		t.Fatalf("exec prompt = %#v, want legacy text prompt", sent[0].Payload["prompt"])
 	}
-	providerTurnID := payloadString(sent[0].Payload, "providerTurnId")
-	if providerTurnID == "" || providerTurnID == "turn-image" {
+	promptCorrelationID := payloadString(sent[0].Payload, "promptCorrelationId")
+	if promptCorrelationID == "" || promptCorrelationID == "turn-image" {
 		t.Fatalf(
-			"exec provider turn id = %q, want a distinct SDK prompt UUID",
-			providerTurnID,
+			"exec prompt correlation id = %q, want a distinct UUID",
+			promptCorrelationID,
 		)
 	}
 	content, ok := sent[0].Payload["content"].([]any)

--- a/packages/agent/daemon/runtime/claude_sdk_transport_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_transport_test.go
@@ -97,7 +97,7 @@ func TestClaudeCodeSDKAdapterExecWithSidecarTestDriver(t *testing.T) {
 		startedProviderTurnID == "turn-sdk-1" ||
 		completedProviderTurnID != startedProviderTurnID {
 		t.Fatalf(
-			"provider turn lifecycle start=%q complete=%q, want one real SDK prompt UUID",
+			"provider turn lifecycle start=%q complete=%q, want one observed provider user-message UUID",
 			startedProviderTurnID,
 			completedProviderTurnID,
 		)

--- a/services/tuttid/service/agent/claude_session_fork_integration_test.go
+++ b/services/tuttid/service/agent/claude_session_fork_integration_test.go
@@ -80,7 +80,7 @@ func TestClaudeSessionForkTraversesProductionWiringAcrossRestart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ForkSession source -> child: %v", err)
 	}
-	childProviderSessionID := forked.Operation.OperationID
+	childProviderSessionID := "claude-child"
 	if forked.Operation.Status != storesqlite.SessionForkStatusCommitted ||
 		forked.Session.ProviderSessionID != childProviderSessionID ||
 		forked.Lineage == nil {
@@ -176,7 +176,7 @@ func TestClaudeSessionForkTraversesProductionWiringAcrossRestart(t *testing.T) {
 		t.Fatalf("ForkSession child -> grandchild: %v", err)
 	}
 	if nested.Operation.Status != storesqlite.SessionForkStatusCommitted ||
-		nested.Session.ProviderSessionID != nested.Operation.OperationID ||
+		nested.Session.ProviderSessionID != "claude-grandchild" ||
 		nested.Lineage == nil {
 		t.Fatalf("nested fork result=%#v", nested)
 	}
@@ -403,27 +403,27 @@ func (t *claudeForkIntegrationTransport) providerTurnIDsForSession(
 }
 
 func (t *claudeForkIntegrationTransport) forkTarget(
-	sourceID, targetID string,
-) (string, bool) {
+	sourceID string,
+) (string, string, bool) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	if targetID == "" {
-		return "", false
-	}
+	targetID := ""
 	targetTurnID := ""
 	switch {
 	case sourceID == "claude-source":
+		targetID = "claude-child"
 		targetTurnID = "child-prompt-1"
 	case t.providerTurnIDs[sourceID] != "":
+		targetID = "claude-grandchild"
 		targetTurnID = "grandchild-prompt-1"
 	default:
-		return "", false
+		return "", "", false
 	}
 	if t.providerTurnIDs == nil {
 		t.providerTurnIDs = make(map[string]string)
 	}
 	t.providerTurnIDs[targetID] = targetTurnID
-	return targetTurnID, true
+	return targetID, targetTurnID, true
 }
 
 type claudeForkIntegrationConnection struct {
@@ -464,10 +464,19 @@ func (c *claudeForkIntegrationConnection) Send(data []byte) error {
 		sourceID := claudeForkIntegrationString(
 			request.Payload["providerSessionId"],
 		)
-		targetID := claudeForkIntegrationString(
+		if claudeForkIntegrationString(
 			request.Payload["targetProviderSessionId"],
-		)
-		targetTurnID, ok := c.transport.forkTarget(sourceID, targetID)
+		) != "" {
+			return c.emit(
+				request.ID,
+				"error",
+				map[string]any{
+					"error":               "fixture received a deterministic provider target",
+					"deliveryDisposition": "not_started",
+				},
+			)
+		}
+		targetID, targetTurnID, ok := c.transport.forkTarget(sourceID)
 		if !ok {
 			return c.emit(
 				request.ID,
@@ -501,15 +510,25 @@ func (c *claudeForkIntegrationConnection) Send(data []byte) error {
 		)
 	case "exec":
 		turnID := claudeForkIntegrationString(request.Payload["turnId"])
-		providerTurnID := claudeForkIntegrationString(
-			request.Payload["providerTurnId"],
+		promptCorrelationID := claudeForkIntegrationString(
+			request.Payload["promptCorrelationId"],
 		)
+		if err := c.emit(
+			"",
+			"provider_turn_started",
+			map[string]any{
+				"turnId":         turnID,
+				"providerTurnId": promptCorrelationID,
+			},
+		); err != nil {
+			return err
+		}
 		if err := c.emit(
 			"",
 			"assistant_completed",
 			map[string]any{
 				"turnId":         turnID,
-				"providerTurnId": providerTurnID,
+				"providerTurnId": promptCorrelationID,
 				"content":        "continued child",
 			},
 		); err != nil {
@@ -520,7 +539,7 @@ func (c *claudeForkIntegrationConnection) Send(data []byte) error {
 			"turn_completed",
 			map[string]any{
 				"turnId":         turnID,
-				"providerTurnId": providerTurnID,
+				"providerTurnId": promptCorrelationID,
 				"stopReason":     "end_turn",
 			},
 		)
@@ -537,7 +556,7 @@ func (c *claudeForkIntegrationConnection) emit(
 	payload map[string]any,
 ) error {
 	data, err := json.Marshal(map[string]any{
-		"version": 3,
+		"version": 5,
 		"id":      id,
 		"type":    eventType,
 		"payload": payload,


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Verification

<!-- Commands run, manual checks, or why verification is not applicable. -->

## Fallback Three Questions

<!--
Required when this change adds a timer, retry, cache, or defensive branch;
delete otherwise.

- Source: which event or state does this fallback compensate for?
- Why can it not be fixed at that source?
- Removal condition: when can this fallback be deleted?
-->

## Checklist

- [ ] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter.
- [ ] I kept the change focused on one concern.
- [ ] I updated documentation when behavior, setup, or contributor workflow changed.
- [ ] I updated all README/CONTRIBUTING language variants when changing their English source.
- [ ] I ran the lowest meaningful local checks for the changed surface.
- [ ] My commits are signed off with DCO when required: `git commit -s`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1752" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->