### PR TITLE
fix(desktop): align sidecar release smoke protocol

### DIFF
--- a/apps/desktop/scripts/smoke-claude-sdk-sidecar.mjs
+++ b/apps/desktop/scripts/smoke-claude-sdk-sidecar.mjs
@@ -36,7 +36,7 @@ export async function smokeClaudeSDKSidecar({
   });
 
   const send = (request) => {
-    child.stdin.write(`${JSON.stringify({ version: 2, ...request })}\n`);
+    child.stdin.write(`${JSON.stringify({ version: 5, ...request })}\n`);
   };
   const waitForEvent = async (predicate, label) => {
     while (true) {

--- a/tools/scripts/claude-sdk-sidecar-protocol.test.mjs
+++ b/tools/scripts/claude-sdk-sidecar-protocol.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const sidecarProtocolPath = new URL(
+  "../../packages/agent/claude-sdk-sidecar/src/protocol.ts",
+  import.meta.url
+);
+const daemonProtocolPath = new URL(
+  "../../packages/agent/daemon/runtime/claude_sdk_protocol.go",
+  import.meta.url
+);
+const releaseSmokePath = new URL(
+  "../../apps/desktop/scripts/smoke-claude-sdk-sidecar.mjs",
+  import.meta.url
+);
+
+test("Claude SDK sidecar protocol versions stay aligned across runtimes", async () => {
+  const [sidecarProtocol, daemonProtocol, releaseSmoke] = await Promise.all([
+    readFile(sidecarProtocolPath, "utf8"),
+    readFile(daemonProtocolPath, "utf8"),
+    readFile(releaseSmokePath, "utf8")
+  ]);
+
+  const versions = {
+    sidecar: extractProtocolVersion(
+      sidecarProtocol,
+      /CLAUDE_SDK_SIDECAR_PROTOCOL_VERSION\s*=\s*(\d+)\s+as const/u,
+      "TypeScript sidecar"
+    ),
+    daemon: extractProtocolVersion(
+      daemonProtocol,
+      /claudeSDKSidecarProtocolVersion\s*=\s*(\d+)/u,
+      "Go daemon"
+    ),
+    releaseSmoke: extractProtocolVersion(
+      releaseSmoke,
+      /JSON\.stringify\(\{\s*version:\s*(\d+),\s*\.\.\.request\s*\}\)/u,
+      "desktop release smoke test"
+    )
+  };
+
+  assert.equal(
+    versions.daemon,
+    versions.sidecar,
+    `Go daemon protocol v${versions.daemon} must match TypeScript sidecar protocol v${versions.sidecar}`
+  );
+  assert.equal(
+    versions.releaseSmoke,
+    versions.sidecar,
+    `desktop release smoke protocol v${versions.releaseSmoke} must match TypeScript sidecar protocol v${versions.sidecar}`
+  );
+});
+
+function extractProtocolVersion(source, pattern, label) {
+  const match = pattern.exec(source);
+  assert.ok(match, `${label} must declare an explicit protocol version`);
+  return Number(match[1]);
+}


### PR DESCRIPTION
## Summary

- update the desktop release sidecar smoke client from protocol v2 to v5
- add a tools test that keeps the Go daemon, TypeScript sidecar, and release smoke protocol versions aligned

## Root cause

The Claude SDK sidecar and Go daemon had moved to protocol v5, while `smoke-claude-sdk-sidecar.mjs` still emitted protocol v2 requests. All macOS release architectures therefore failed during `prepare_claude_sdk_sidecar` with `unsupported sidecar protocol version 2`.

## Impact

Desktop release packaging can complete the vendored Claude SDK sidecar smoke check again. Future protocol bumps that update only one runtime will fail the fast tools test before reaching the release workflow.

## Validation

- `node apps/desktop/scripts/vendor-claude-sdk-sidecar.mjs`
- `node --test tools/scripts/claude-sdk-sidecar-protocol.test.mjs`
- `pnpm --filter @tutti-os/claude-sdk-sidecar test` — 103 passed
- `go test ./runtime -run '^TestClaudeSDKSidecarProtocol' -count=1`
- `pnpm test:tools`
- `pnpm check:changed -- --push-ready` — 9 lanes passed
- `pnpm exec oxfmt --check apps/desktop/scripts/smoke-claude-sdk-sidecar.mjs tools/scripts/claude-sdk-sidecar-protocol.test.mjs`
- `pnpm exec oxlint apps/desktop/scripts/smoke-claude-sdk-sidecar.mjs tools/scripts/claude-sdk-sidecar-protocol.test.mjs`
