### PR TITLE
fix(agent): bound streamed tool output memory

### DIFF
--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -27,11 +27,12 @@ Use the focused runtime index or open one area directly:
   startup that fails when concurrent provider input and output are treated as a
   strict scheduling order, false final-state mismatches caused by replay-generated
   child identities, and canonical completion delayed behind a streaming activity-report
-  backlog. It also covers provider-completed submissions reported as delivery
-  unknown after canonical message provenance conflicts, completed Claude Code
-  Turns that lack a Fork entry because provider identity was not observed from
-  the durable transcript, and Claude Fork operations that fail because an empty
-  SDK query never creates a durable provider child.
+  backlog, plus daemon memory growth while a tool streams a large output. It
+  also covers provider-completed submissions reported as delivery unknown after
+  canonical message provenance conflicts, completed Claude Code Turns that lack
+  a Fork entry because provider identity was not observed from the durable
+  transcript, and Claude Fork operations that fail because an empty SDK query
+  never creates a durable provider child.
 - [Agent Approvals And Child Sessions](./agent-approvals-subagents.md): Approval gates, plan exits, root/parent/child event attribution, child sessions, and Message Center.
   Includes provider-native work that continues invisibly after root cancellation
   and late child creation racing the durable cancel boundary.

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -80,6 +80,7 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 - [AgentGUI freezes when session history is large](./agent-session-lifecycle.md#agentgui-freezes-when-session-history-is-large)
 - [AgentGUI @ Sessions tab is empty](./agent-session-lifecycle.md#agentgui--sessions-tab-is-empty)
 - [Agent diagnostics flood while a turn is streaming](./agent-session-lifecycle.md#agent-diagnostics-flood-while-a-turn-is-streaming)
+- [Daemon memory grows rapidly while a tool streams output](./agent-session-lifecycle.md#daemon-memory-grows-rapidly-while-a-tool-streams-output)
 - [Codex turn stays working before any reply or tool activity](./agent-session-lifecycle.md#codex-turn-stays-working-before-any-reply-or-tool-activity)
 - [Codex WebSocket reconnect rejects a long prompt metadata header](./agent-session-lifecycle.md#codex-websocket-reconnect-rejects-a-long-prompt-metadata-header)
 - [Imported sessions trigger fresh-completion indicators](./agent-session-lifecycle.md#imported-sessions-trigger-fresh-completion-indicators)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -263,6 +263,36 @@
   [report_coalescer.go](../../../packages/agent/daemon/runtime/report_coalescer.go),
   [controller_report_queue_test.go](../../../packages/agent/daemon/runtime/controller_report_queue_test.go)
 
+### Daemon memory grows rapidly while a tool streams output
+
+- **Symptom:** `tuttid` memory and compressor usage climb rapidly during a
+  command with a large output. The final tool output can be modest compared
+  with peak memory, and canonical message queries or SQLite writes become slow
+  only after memory pressure is already high.
+- **Quick checks:** Correlate tool `outputDelta` notifications with
+  `agent_session.activity_report.queue_backlog`. Confirm the queued updates are
+  running `tool_call` messages whose `output.text` is a cumulative snapshot.
+  Distinguish the runtime report queue from the live EventHub: the live path
+  carries append operations, while durable reporting carries snapshots.
+- **Root cause:** Rebuilding cumulative output with `current + delta` allocates
+  and copies the full prefix for every chunk. If running tool snapshots are not
+  eligible for streaming report coalescing, the single reporter persists each
+  snapshot separately while the unbounded, re-entry-safe FIFO retains the
+  later snapshots. The combination turns linear provider output into
+  quadratic copying and a large live backlog.
+- **Fix:** Accumulate normalized tool output with an incremental builder, and
+  coalesce running `tool_call` reports by stable message ID so only the latest
+  snapshot in each reporting window reaches durable persistence. Keep live
+  append operations unchanged, and force the pending running snapshot to flush
+  before a completed or failed update.
+- **Validation:** Stream multiple chunks for one tool and verify live offsets
+  remain byte-based, the durable coalescer retains the highest-sequence output
+  snapshot, and a terminal update flushes after that snapshot rather than
+  being merged or reordered.
+- **References:**
+  [acp_turn_normalizer_tool_output.go](../../../packages/agent/daemon/runtime/acp_turn_normalizer_tool_output.go),
+  [report_coalescer.go](../../../packages/agent/daemon/runtime/report_coalescer.go)
+
 ### Tutti mode is active in the composer but disappears after the first submit
 
 - **Symptom:** The home composer shows Tutti enabled and the submit trace records

--- a/packages/agent/daemon/runtime/acp_turn_normalizer.go
+++ b/packages/agent/daemon/runtime/acp_turn_normalizer.go
@@ -26,7 +26,7 @@ type acpTurnNormalizer struct {
 	toolItemIDs               map[string]string
 	toolCallsSeen             map[string]bool
 	pendingToolCalls          map[string]pendingToolCallSnapshot
-	toolOutputText            map[string]string
+	toolOutputContent         map[string]*strings.Builder
 	earlyToolOutput           map[string]earlyToolOutputSnapshot
 	earlyToolOutputBytes      int
 	fileChanges               map[string]any
@@ -114,11 +114,11 @@ func (n *acpTurnNormalizer) SuppressAssistantOutput() {
 
 func newACPTurnNormalizer() *acpTurnNormalizer {
 	return &acpTurnNormalizer{
-		toolItemIDs:      make(map[string]string),
-		toolCallsSeen:    make(map[string]bool),
-		pendingToolCalls: make(map[string]pendingToolCallSnapshot),
-		toolOutputText:   make(map[string]string),
-		earlyToolOutput:  make(map[string]earlyToolOutputSnapshot),
+		toolItemIDs:       make(map[string]string),
+		toolCallsSeen:     make(map[string]bool),
+		pendingToolCalls:  make(map[string]pendingToolCallSnapshot),
+		toolOutputContent: make(map[string]*strings.Builder),
+		earlyToolOutput:   make(map[string]earlyToolOutputSnapshot),
 	}
 }
 
@@ -609,7 +609,7 @@ func (n *acpTurnNormalizer) trackToolCallEvent(event activityshared.Event) {
 		}
 	case activityshared.EventCallCompleted, activityshared.EventCallFailed:
 		delete(n.pendingToolCalls, event.EventID)
-		delete(n.toolOutputText, event.EventID)
+		delete(n.toolOutputContent, event.EventID)
 	}
 }
 

--- a/packages/agent/daemon/runtime/acp_turn_normalizer_tool_output.go
+++ b/packages/agent/daemon/runtime/acp_turn_normalizer_tool_output.go
@@ -39,8 +39,14 @@ func (n *acpTurnNormalizer) AppendToolOutputDelta(
 		n.bufferEarlyToolOutput(turnID, rawToolCallID, delta)
 		return nil
 	}
-	current := n.toolOutputText[eventID]
-	next := current + delta
+	content := n.toolOutputContent[eventID]
+	if content == nil {
+		content = &strings.Builder{}
+		n.toolOutputContent[eventID] = content
+	}
+	offset := content.Len()
+	_, _ = content.WriteString(delta)
+	next := content.String()
 	payload := clonePayload(pending.payload)
 	if payload == nil {
 		payload = map[string]any{}
@@ -58,12 +64,12 @@ func (n *acpTurnNormalizer) AppendToolOutputDelta(
 		Operation: "set",
 		Text:      next,
 	}
-	if current != "" {
-		offset := int64(len(current))
+	if offset > 0 {
+		offsetBytes := int64(offset)
 		operation = &liveprotocol.MessageToolOutputOperation{
 			Operation:   "append_text",
 			Text:        delta,
-			OffsetBytes: &offset,
+			OffsetBytes: &offsetBytes,
 		}
 	}
 	event := newTurnActivityEventWithID(
@@ -77,7 +83,6 @@ func (n *acpTurnNormalizer) AppendToolOutputDelta(
 		payload,
 	)
 	attachToolOutputLiveOperation(&event, operation)
-	n.toolOutputText[eventID] = next
 	n.trackToolCallEvent(event)
 	return []activityshared.Event{event}
 }

--- a/packages/agent/daemon/runtime/report_coalescer_test.go
+++ b/packages/agent/daemon/runtime/report_coalescer_test.go
@@ -41,6 +41,41 @@ func TestStreamingReportCoalescerKeepsLatestMessageSnapshot(t *testing.T) {
 	}
 }
 
+func TestStreamingReportCoalescerFlushesToolOutputBeforeTerminalReport(t *testing.T) {
+	t.Parallel()
+
+	coalescer := newStreamingReportCoalescer(time.Hour)
+	defer coalescer.stop()
+
+	running := toolCallStreamingReport(1, map[string]any{
+		"output": map[string]any{"text": "hello"},
+	})
+	if flushed := coalescer.add(reportRequest{
+		ctx:    context.Background(),
+		report: running,
+	}); len(flushed) != 0 {
+		t.Fatalf("streaming add flushed %#v, want pending", flushed)
+	}
+
+	terminal := toolCallStreamingReport(2, map[string]any{
+		"output": map[string]any{"text": "hello world"},
+	})
+	terminal.MessageUpdates[0].Status = messageStreamStateCompleted
+	flushed := coalescer.add(reportRequest{
+		ctx:    context.Background(),
+		report: terminal,
+	})
+	if len(flushed) != 2 {
+		t.Fatalf("flushed reports = %d, want pending streaming plus terminal", len(flushed))
+	}
+	if flushed[0].report.MessageUpdates[0].Status != "running" {
+		t.Fatalf("first flushed report = %#v, want running", flushed[0].report)
+	}
+	if flushed[1].report.MessageUpdates[0].Status != messageStreamStateCompleted {
+		t.Fatalf("second flushed report = %#v, want completed", flushed[1].report)
+	}
+}
+
 func TestStreamingReportCoalescerFlushesBeforeTerminalReport(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- accumulate provider tool output deltas with a per-call `strings.Builder` instead of `current + delta`, eliminating full-prefix copying for every output chunk
- retain cumulative durable snapshots and byte-offset live append operations without changing the live EventHub protocol
- add explicit coverage that the `tool_call` coalescer now on `main` flushes a running snapshot before its terminal update, and document the complete memory/backlog failure pattern

A large streamed command currently rebuilds the full cumulative `output.text` for every provider delta. Even with the queue-level `tool_call` coalescing added by #1703, that source path remains quadratic in bytes copied and can create substantial allocation and compressor pressure. This PR makes source accumulation incremental; #1703 remains the owner of queue coalescing and terminal scheduling.

## Verification

- `pnpm check:changed` after rebasing onto current `origin/main` (7 lanes passed)
- pre-push `pnpm check:changed -- --push-ready` after rebase (8 lanes passed)
- focused iteration: `go test ./runtime -run TestStreamingReportCoalescer\|TestExplicitToolOutputDelta -count=1`

## Checklist

- [x] This does not change session/turn/goal/runtime-operation lifecycle semantics; it changes runtime output accumulation only.
- [x] I kept the change focused on one concern.
- [x] I updated troubleshooting documentation for the affected data flow.
- [x] README/CONTRIBUTING translations are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] The commit is signed off with DCO.