### PR TITLE
refactor(agent-gui): tighten conversation package exports

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.test.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { AGENT_CONVERSATION_RAIL_RUNTIME_METHODS } from "@tutti-os/agent-gui/conversation-rail-runtime";
 import { createDesktopAgentActivityRuntime } from "./createDesktopAgentActivityRuntime.ts";
 import type { IWorkspaceAgentActivityService } from "./workspaceAgentActivityService.interface.ts";
 
@@ -9,7 +8,14 @@ test("desktop agent activity runtime installs the complete conversation rail cap
     createWorkspaceAgentActivityService()
   );
 
-  for (const method of AGENT_CONVERSATION_RAIL_RUNTIME_METHODS) {
+  for (const method of [
+    "deleteSessionsBatch",
+    "listPinnedSessionsPage",
+    "listSessionSectionDeletionCandidates",
+    "listSessionSectionPage",
+    "listSessionSections",
+    "listSessionsPage"
+  ] as const) {
     assert.equal(typeof runtime[method], "function", method);
   }
 });

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -279,7 +279,11 @@ sections come from current user projects and session membership comes from
 persisted `rail_section_key`, not frontend cwd grouping or project-root
 filters.
 The published `@tutti-os/agent-gui/conversation-rail-runtime` entrypoint owns
-the host-neutral Rail query/mutation cohort. The sibling
+the host-neutral Rail query/mutation cohort. Its stable host surface is the
+typed `createAgentConversationRailRuntime` factory plus the runtime/source
+types; method-name manifests and UI capability inspection are package-internal.
+Downstream hosts such as tsh compose the typed factory and do not import those
+test or presentation helpers. The sibling
 `@tutti-os/agent-gui/conversation-rail-controller` entrypoint owns the
 controller interface, workspace-Engine-scoped query caches, and
 `createAgentGUIConversationRailQueryController` factory. Product hosts provide
@@ -306,9 +310,10 @@ controller snapshot exposes memberships, ordered ids, pagination, search, and
 request state only; Desktop joins it with Engine state for localized
 conversation summaries outside the headless entrypoint. Resolved cache entries
 are shared by controllers created for the same workspace Engine; the factory,
-not `AgentActivityRuntime` or a host adapter, owns that registry. In-flight
-first-page entity payloads stay scoped to one attached controller generation so
-an obsolete mount cannot ingest or cache them.
+not `AgentActivityRuntime` or a host adapter, owns that registry. The cache
+implementation has no published AgentGUI subpath. In-flight first-page entity
+payloads stay scoped to one attached controller generation so an obsolete mount
+cannot ingest or cache them.
 Every daemon `WorkspaceAgentSession` response carries the persisted membership
 as required `railSectionKey`. The desktop adapter rejects a missing or blank
 value as a protocol contract error; it must not manufacture `conversations` or

--- a/packages/agent/gui/README.md
+++ b/packages/agent/gui/README.md
@@ -243,7 +243,10 @@ verifies its `(workspaceId, origin)` identity. Module-global runtime slots and
 hidden origin registries are forbidden.
 
 The `@tutti-os/agent-gui/conversation-rail-runtime` subpath exposes the
-host-neutral Rail query/mutation cohort. The sibling
+host-neutral Rail query/mutation cohort through
+`createAgentConversationRailRuntime` and its runtime/source types. Method-name
+manifests and UI capability inspection remain package-internal; hosts use the
+typed factory instead of importing test helpers. The sibling
 `@tutti-os/agent-gui/conversation-rail-controller` subpath exposes the canonical
 `createAgentGUIConversationRailQueryController` factory and controller
 interface used by Desktop and Native Mobile. The headless implementation owns
@@ -256,9 +259,9 @@ its internal query helpers as public API.
 Its public snapshot is presentation-free; Desktop derives localized
 conversation summaries from that snapshot plus Engine state in its adapter.
 The factory owns resolved-query cache reuse per workspace Engine; cache access
-is not a runtime or host capability. In-flight first-page results are fenced to
-the attached controller generation so stale mounts cannot mutate the Engine or
-cache.
+is not a runtime or host capability and has no published package entrypoint.
+In-flight first-page results are fenced to the attached controller generation
+so stale mounts cannot mutate the Engine or cache.
 
 Run this boundary check after changing AgentGUI data flow:
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentConversationBatchDeletionCapability.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentConversationBatchDeletionCapability.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { inspectAgentConversationBatchDeletionCapability } from "./agentConversationBatchDeletionCapability";
+
+describe("inspectAgentConversationBatchDeletionCapability", () => {
+  it("enables batch deletion only when both runtime methods exist", () => {
+    expect(
+      inspectAgentConversationBatchDeletionCapability({
+        deleteSessionsBatch: vi.fn(),
+        listSessionSectionDeletionCandidates: vi.fn()
+      })
+    ).toEqual({
+      available: true,
+      missingMethods: [],
+      partial: false
+    });
+  });
+
+  it("fails closed when only one half of the batch deletion contract exists", () => {
+    expect(
+      inspectAgentConversationBatchDeletionCapability({
+        deleteSessionsBatch: vi.fn()
+      })
+    ).toEqual({
+      available: false,
+      missingMethods: ["listSessionSectionDeletionCandidates"],
+      partial: true
+    });
+  });
+
+  it("treats hosts without the optional capability as unavailable, not partial", () => {
+    expect(inspectAgentConversationBatchDeletionCapability({})).toEqual({
+      available: false,
+      missingMethods: [
+        "deleteSessionsBatch",
+        "listSessionSectionDeletionCandidates"
+      ],
+      partial: false
+    });
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentConversationBatchDeletionCapability.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentConversationBatchDeletionCapability.ts
@@ -1,0 +1,37 @@
+import type { AgentConversationRailRuntimePort } from "../../../agentConversationRailContracts.ts";
+
+const AGENT_CONVERSATION_BATCH_DELETION_RUNTIME_METHODS = [
+  "deleteSessionsBatch",
+  "listSessionSectionDeletionCandidates"
+] as const satisfies ReadonlyArray<keyof AgentConversationRailRuntimePort>;
+
+type AgentConversationBatchDeletionRuntimeMethod =
+  (typeof AGENT_CONVERSATION_BATCH_DELETION_RUNTIME_METHODS)[number];
+
+export interface AgentConversationBatchDeletionCapability {
+  available: boolean;
+  missingMethods: AgentConversationBatchDeletionRuntimeMethod[];
+  partial: boolean;
+}
+
+export function inspectAgentConversationBatchDeletionCapability(
+  runtime: Partial<
+    Pick<
+      AgentConversationRailRuntimePort,
+      AgentConversationBatchDeletionRuntimeMethod
+    >
+  >
+): AgentConversationBatchDeletionCapability {
+  const missingMethods =
+    AGENT_CONVERSATION_BATCH_DELETION_RUNTIME_METHODS.filter(
+      (method) => typeof runtime[method] !== "function"
+    );
+  return {
+    available: missingMethods.length === 0,
+    missingMethods: [...missingMethods],
+    partial:
+      missingMethods.length > 0 &&
+      missingMethods.length <
+        AGENT_CONVERSATION_BATCH_DELETION_RUNTIME_METHODS.length
+  };
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.reporting.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.reporting.ts
@@ -6,7 +6,6 @@ import type {
 } from "@tutti-os/agent-activity-core";
 import { toast } from "@tutti-os/ui-system";
 import { type AgentActivityRuntime } from "../../../agentActivityRuntime";
-import type { AgentConversationBatchDeletionCapability } from "../../../agentConversationRailRuntime";
 import type { AgentHostToastApi } from "../../../host/agentHostApi";
 import type { AgentConversationVM } from "../../../shared/agentConversation/contracts/agentConversationVM";
 import type { AgentSessionState } from "../../../shared/agentSessionTypes";
@@ -27,6 +26,7 @@ import {
   getAgentGUIErrorCode,
   normalizeAgentGUIDiagnosticError
 } from "./agentGuiController.errors";
+import type { AgentConversationBatchDeletionCapability } from "./agentConversationBatchDeletionCapability";
 export {
   normalizePermissionModeSemantic,
   permissionConfigFromComposerOptions,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts
@@ -8,7 +8,7 @@ import {
   type AgentGUIConversationRailQuerySnapshot,
   type ConversationRailQueryRuntime
 } from "../../../agentConversationRailController";
-import { inspectAgentConversationBatchDeletionCapability } from "../../../agentConversationRailRuntime";
+import { inspectAgentConversationBatchDeletionCapability } from "./agentConversationBatchDeletionCapability";
 import { useEngineSelector } from "../../../shared/engine/useEngineSelector";
 import type { AgentGUINodeViewModel } from "../model/agentGuiNodeTypes";
 import { createConversationRailConversationsSelector } from "./agentGuiConversationRailQuerySnapshot";

--- a/packages/agent/gui/agentConversationRailRuntime.spec.ts
+++ b/packages/agent/gui/agentConversationRailRuntime.spec.ts
@@ -1,18 +1,28 @@
 import { describe, expect, it, vi } from "vitest";
+import * as conversationRailRuntimeModule from "./agentConversationRailRuntime";
 import {
-  AGENT_CONVERSATION_RAIL_RUNTIME_METHODS,
   createAgentConversationRailRuntime,
-  inspectAgentConversationBatchDeletionCapability,
   type AgentConversationRailRuntimeSource
 } from "./agentConversationRailRuntime";
 
 describe("createAgentConversationRailRuntime", () => {
+  it("publishes only the host runtime factory as a JavaScript value", () => {
+    expect(Object.keys(conversationRailRuntimeModule)).toEqual([
+      "createAgentConversationRailRuntime"
+    ]);
+  });
+
   it("exposes one complete conversation rail capability cohort", () => {
     const runtime = createAgentConversationRailRuntime(createSource());
 
-    for (const method of AGENT_CONVERSATION_RAIL_RUNTIME_METHODS) {
-      expect(runtime[method], method).toBeTypeOf("function");
-    }
+    expect(Object.keys(runtime).sort()).toEqual([
+      "deleteSessionsBatch",
+      "listPinnedSessionsPage",
+      "listSessionSectionDeletionCandidates",
+      "listSessionSectionPage",
+      "listSessionSections",
+      "listSessionsPage"
+    ]);
   });
 
   it("forwards exact query and mutation inputs to the host source", async () => {
@@ -36,44 +46,6 @@ describe("createAgentConversationRailRuntime", () => {
       candidateInput
     );
     expect(source.deleteSessionsBatch).toHaveBeenCalledWith(deleteInput);
-  });
-});
-
-describe("inspectAgentConversationBatchDeletionCapability", () => {
-  it("enables batch deletion only when both runtime methods exist", () => {
-    expect(
-      inspectAgentConversationBatchDeletionCapability({
-        deleteSessionsBatch: vi.fn(),
-        listSessionSectionDeletionCandidates: vi.fn()
-      })
-    ).toEqual({
-      available: true,
-      missingMethods: [],
-      partial: false
-    });
-  });
-
-  it("fails closed when only one half of the batch deletion contract exists", () => {
-    expect(
-      inspectAgentConversationBatchDeletionCapability({
-        deleteSessionsBatch: vi.fn()
-      })
-    ).toEqual({
-      available: false,
-      missingMethods: ["listSessionSectionDeletionCandidates"],
-      partial: true
-    });
-  });
-
-  it("treats hosts without the optional capability as unavailable, not partial", () => {
-    expect(inspectAgentConversationBatchDeletionCapability({})).toEqual({
-      available: false,
-      missingMethods: [
-        "deleteSessionsBatch",
-        "listSessionSectionDeletionCandidates"
-      ],
-      partial: false
-    });
   });
 });
 

--- a/packages/agent/gui/agentConversationRailRuntime.ts
+++ b/packages/agent/gui/agentConversationRailRuntime.ts
@@ -1,43 +1,20 @@
 import type { AgentConversationRailRuntimePort } from "./agentConversationRailContracts.ts";
-const AGENT_CONVERSATION_BATCH_DELETION_RUNTIME_METHODS = [
-  "deleteSessionsBatch",
-  "listSessionSectionDeletionCandidates"
-] as const satisfies ReadonlyArray<keyof AgentConversationRailRuntimePort>;
 
-const AGENT_CONVERSATION_RAIL_SOURCE_METHODS = [
-  "deleteSessionsBatch",
-  "listPinnedSessionsPage",
-  "listSessionSectionDeletionCandidates",
-  "listSessionSectionPage",
-  "listSessionSections",
-  "listSessionsPage"
-] as const satisfies ReadonlyArray<keyof AgentConversationRailRuntimePort>;
-
-export const AGENT_CONVERSATION_RAIL_RUNTIME_METHODS = [
-  ...AGENT_CONVERSATION_RAIL_SOURCE_METHODS
-] as const satisfies ReadonlyArray<keyof AgentConversationRailRuntimePort>;
-
-type AgentConversationRailSourceMethod =
-  (typeof AGENT_CONVERSATION_RAIL_SOURCE_METHODS)[number];
-type AgentConversationBatchDeletionRuntimeMethod =
-  (typeof AGENT_CONVERSATION_BATCH_DELETION_RUNTIME_METHODS)[number];
+type AgentConversationRailRuntimeMethod =
+  | "deleteSessionsBatch"
+  | "listPinnedSessionsPage"
+  | "listSessionSectionDeletionCandidates"
+  | "listSessionSectionPage"
+  | "listSessionSections"
+  | "listSessionsPage";
 
 export type AgentConversationRailRuntime = Required<
-  Pick<
-    AgentConversationRailRuntimePort,
-    (typeof AGENT_CONVERSATION_RAIL_RUNTIME_METHODS)[number]
-  >
+  Pick<AgentConversationRailRuntimePort, AgentConversationRailRuntimeMethod>
 >;
 
 export type AgentConversationRailRuntimeSource = Required<
-  Pick<AgentConversationRailRuntimePort, AgentConversationRailSourceMethod>
+  Pick<AgentConversationRailRuntimePort, AgentConversationRailRuntimeMethod>
 >;
-
-export interface AgentConversationBatchDeletionCapability {
-  available: boolean;
-  missingMethods: AgentConversationBatchDeletionRuntimeMethod[];
-  partial: boolean;
-}
 
 export function createAgentConversationRailRuntime(
   source: AgentConversationRailRuntimeSource
@@ -50,27 +27,5 @@ export function createAgentConversationRailRuntime(
     listSessionSectionPage: (input) => source.listSessionSectionPage(input),
     listSessionSections: (input) => source.listSessionSections(input),
     listSessionsPage: (input) => source.listSessionsPage(input)
-  };
-}
-
-export function inspectAgentConversationBatchDeletionCapability(
-  runtime: Partial<
-    Pick<
-      AgentConversationRailRuntimePort,
-      AgentConversationBatchDeletionRuntimeMethod
-    >
-  >
-): AgentConversationBatchDeletionCapability {
-  const missingMethods =
-    AGENT_CONVERSATION_BATCH_DELETION_RUNTIME_METHODS.filter(
-      (method) => typeof runtime[method] !== "function"
-    );
-  return {
-    available: missingMethods.length === 0,
-    missingMethods: [...missingMethods],
-    partial:
-      missingMethods.length > 0 &&
-      missingMethods.length <
-        AGENT_CONVERSATION_BATCH_DELETION_RUNTIME_METHODS.length
   };
 }

--- a/packages/agent/gui/build/agentGuiBuildEntries.ts
+++ b/packages/agent/gui/build/agentGuiBuildEntries.ts
@@ -41,8 +41,7 @@ export const agentGUIBuildEntries = {
   "conversation-rail-runtime": "agentConversationRailRuntime.ts",
   "conversation-rail-projection": "conversationRailProjection.ts",
   "conversation-projection": "conversationProjection.ts",
-  "composer-projection": "composerProjection.ts",
-  "workspace-query-cache": "shared/query/workspaceQueryCache.ts"
+  "composer-projection": "composerProjection.ts"
 } as const;
 
 type AgentGUIBuildEntry = keyof typeof agentGUIBuildEntries;
@@ -77,8 +76,7 @@ export const agentGUIDtsEntryGroups = [
     "conversation-rail-runtime",
     "conversation-rail-projection",
     "conversation-projection",
-    "composer-projection",
-    "workspace-query-cache"
+    "composer-projection"
   ],
   [
     "dock-icons",

--- a/packages/agent/gui/package.json
+++ b/packages/agent/gui/package.json
@@ -35,7 +35,6 @@
     "./conversation-rail-projection": "./conversationRailProjection.ts",
     "./conversation-projection": "./conversationProjection.ts",
     "./composer-projection": "./composerProjection.ts",
-    "./workspace-query-cache": "./shared/query/workspaceQueryCache.ts",
     "./i18n": "./i18n/index.ts",
     "./workbench": "./workbench/index.ts",
     "./workbench/contribution": "./workbench/contribution.ts",
@@ -245,10 +244,6 @@
         "types": "./dist/composer-projection.d.ts",
         "import": "./dist/composer-projection.js"
       },
-      "./workspace-query-cache": {
-        "types": "./dist/workspace-query-cache.d.ts",
-        "import": "./dist/workspace-query-cache.js"
-      },
       "./i18n": {
         "types": "./dist/i18n/index.d.ts",
         "import": "./dist/i18n/index.js"
@@ -371,9 +366,6 @@
         ],
         "composer-projection": [
           "./dist/composer-projection.d.ts"
-        ],
-        "workspace-query-cache": [
-          "./dist/workspace-query-cache.d.ts"
         ],
         "i18n": [
           "./dist/i18n/index.d.ts"

--- a/packages/agent/gui/tsup.dts.config.test.ts
+++ b/packages/agent/gui/tsup.dts.config.test.ts
@@ -89,6 +89,13 @@ describe("Agent GUI declaration build groups", () => {
     );
   });
 
+  it("keeps the workspace query cache package-internal", () => {
+    expect(agentGUIBuildEntries).not.toHaveProperty("workspace-query-cache");
+    expect(
+      packageManifest.publishConfig.exports["./workspace-query-cache"]
+    ).toBeUndefined();
+  });
+
   it("builds and publishes the DOM-free conversation rail projection", () => {
     expect(agentGUIBuildEntries["conversation-rail-projection"]).toBe(
       "conversationRailProjection.ts"


### PR DESCRIPTION
## Summary

- narrow `@tutti-os/agent-gui/conversation-rail-runtime` to its stable host surface: `createAgentConversationRailRuntime` plus runtime/source types
- move batch-deletion capability inspection into the package-internal AgentGUI controller layer
- remove the unused published `workspace-query-cache` subpath while retaining cache ownership inside the Rail controller factory
- preserve Desktop host capability regression coverage without a public runtime method manifest
- document the stable Host facade and internal cache/capability boundaries

## Why

The shared Rail and Message controllers are proven multi-consumer state-machine boundaries and remain public. The problem was narrower: their package facade exposed a method-name manifest used only by tests, a UI capability inspector, and a cache implementation with no Tutti or tsh consumers. Those exports made implementation details look like supported cross-host contracts.

The production tsh integration continues to use the stable factory and `AgentConversationRailRuntimeSource` unchanged. Its only dependency on the removed method manifest was in two tests and is decoupled by [tutti-lab/tsh#2153](https://github.com/tutti-lab/tsh/pull/2153).

## Merge order

Merge [tutti-lab/tsh#2153](https://github.com/tutti-lab/tsh/pull/2153) before this PR or before publishing the resulting AgentGUI package cohort. This avoids a temporary compile failure in tsh tests during an exact-version upgrade.

## Impact

- no Desktop, Mobile, or tsh production data-flow changes
- no Rail/Message controller behavior changes
- smaller supported AgentGUI package surface
- generated `conversation-rail-runtime.d.ts` exports only the factory and two stable types
- clean builds no longer emit `workspace-query-cache.js` or `.d.ts`

## Validation

- `pnpm check:changed`
- `pnpm check:changed -- --push-ready`
- AgentGUI focused Vitest: 16 tests
- AgentGUI runtime and declaration build
- Desktop AgentGUI runtime tests: 11 tests
- clean artifact checks for the Rail runtime declaration and removed query-cache entrypoint
- coordinated tsh validation: Web typecheck and 19 focused runtime tests

## Documentation

Updated `packages/agent/gui/README.md` and `docs/architecture/agent-activity-packages.md` to record the stable host facade and package-internal cache/capability ownership.