### PR TITLE
fix(desktop): render Tutti Agent Commerce account

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentsService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentsService.test.ts
@@ -186,6 +186,7 @@ test("desktop agents service maps enabled daemon targets into the AgentGUI agent
       maskIconUrl: "data:image/svg+xml;base64,mask",
       heroImageUrl: "data:image/jpeg;base64,hero",
       name: "Codex",
+      ownership: "self",
       provider: "codex"
     }
   ]);

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentsService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentsService.ts
@@ -350,6 +350,7 @@ export function mapAgentTargetPresentationsToAgents(
       ...(target.maskIconUrl ? { maskIconUrl: target.maskIconUrl } : {}),
       ...(target.heroImageUrl ? { heroImageUrl: target.heroImageUrl } : {}),
       availability: target.availability,
+      ownership: "self" as const,
       provider: target.provider as AgentGUIProvider,
       ...(target.launchRefType === "agent_extension"
         ? { setupKind: "target_runtime" as const }

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -25,7 +25,6 @@ import {
 } from "@tutti-os/workbench-surface";
 import { useTranslation } from "@renderer/i18n";
 import { useDesktopPreferencesService } from "@renderer/features/desktop-preferences/ui/useDesktopPreferencesService";
-import { useWorkspaceSettingsService } from "../../workspace-workbench/ui/useWorkspaceSettingsService";
 import { buildDesktopCommerceErrorPresentation } from "./desktopCommerceErrorPresentation";
 import { Toast } from "@renderer/lib/toast";
 import { isDesktopAgentProvider } from "@shared/preferences";
@@ -76,6 +75,7 @@ import { useStableDesktopAgentGUIHostProps } from "./useStableDesktopAgentGUIHos
 import { resolveDesktopAgentGUIEmbeddedDesktopSize } from "./desktopAgentGUIEmbeddedFrame.ts";
 import { scheduleDesktopAgentGUIWorkbenchHydration } from "./desktopAgentGUIWorkbenchHydration.ts";
 import { useDesktopAgentConfigCommerce } from "./useDesktopAgentConfigCommerce.tsx";
+import { hasDesktopLocalTuttiAgent } from "./desktopAgentConfigCommerceContext.ts";
 import { useDesktopAgentGUIComposerFooterAccessory } from "./useDesktopAgentGUIComposerFooterAccessory.tsx";
 import { useDesktopAgentGUIOpenSessionComposerRequest } from "./useDesktopAgentGUIOpenSessionComposerRequest.ts";
 import { useDesktopAgentGUIProviderAuthAccountLabels } from "./useDesktopAgentGUIProviderAuthAccountLabels.ts";
@@ -132,9 +132,7 @@ function DesktopAgentGUISurfaceImpl({
 }: DesktopAgentGUISurfaceProps): JSX.Element {
   const agents = agentDirectory.agents;
   const { i18n, locale } = useTranslation();
-  const { state: workspaceSettingsState } = useWorkspaceSettingsService();
-  const commerceEnabled =
-    workspaceSettingsState.tuttiAgentSwitchEnabled === true;
+  const commerceEnabled = hasDesktopLocalTuttiAgent(agents);
   const { accountState, handleAgentConfigMenuOpen, renderAgentConfigAccount } =
     useDesktopAgentConfigCommerce(commerceEnabled);
   const { service: desktopPreferencesService, state: desktopPreferencesState } =

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/desktopAgentConfigCommerceContext.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/desktopAgentConfigCommerceContext.ts
@@ -1,4 +1,15 @@
-import type { AgentGUIAgentConfigMenuContext } from "@tutti-os/agent-gui";
+import type {
+  AgentGUIAgent,
+  AgentGUIAgentConfigMenuContext
+} from "@tutti-os/agent-gui";
+
+export function hasDesktopLocalTuttiAgent(
+  agents: readonly Pick<AgentGUIAgent, "agentTargetId">[]
+): boolean {
+  return agents.some(
+    (agent) => agent.agentTargetId.trim() === "local:tutti-agent"
+  );
+}
 
 export function isDesktopLocalTuttiAgentConfigContext(
   context: AgentGUIAgentConfigMenuContext

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/useDesktopAgentConfigCommerce.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/useDesktopAgentConfigCommerce.test.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { AgentTarget } from "@tutti-os/client-tuttid-ts";
 import type { AgentGUIAgentConfigMenuContext } from "@tutti-os/agent-gui";
 import {
+  mapAgentTargetsToPresentations,
+  mapAgentTargetPresentationsToAgents
+} from "../services/internal/desktopAgentsService.ts";
+import {
+  hasDesktopLocalTuttiAgent,
   isDesktopLocalTuttiAgentConfigContext,
   shouldRenderDesktopAgentConfigCommerce
 } from "./desktopAgentConfigCommerceContext.ts";
@@ -56,5 +62,46 @@ test("agent config Commerce falls back while disabled or signed out", () => {
       hasAccount: false
     }),
     false
+  );
+});
+
+test("daemon Tutti Agent mapping supplies the self-owned Commerce context", () => {
+  const target: AgentTarget = {
+    createdAtUnixMs: 1780272000000,
+    enabled: true,
+    iconKey: "tutti-agent",
+    iconUrl: "tutti-asset://agent/tutti-agent.png",
+    heroImageUrl: null,
+    maskIconUrl: null,
+    id: "local:tutti-agent",
+    launchRef: {
+      provider: "tutti-agent",
+      type: "builtin_local"
+    },
+    name: "Tutti Agent",
+    provider: "tutti-agent",
+    sortOrder: 50,
+    source: "system",
+    updatedAtUnixMs: 1780272000000
+  };
+  const agent = mapAgentTargetPresentationsToAgents(
+    mapAgentTargetsToPresentations([target])
+  )[0];
+
+  assert.ok(agent);
+  assert.equal(hasDesktopLocalTuttiAgent([]), false);
+  assert.equal(hasDesktopLocalTuttiAgent([agent]), true);
+  assert.equal(
+    shouldRenderDesktopAgentConfigCommerce({
+      context: {
+        agentTargetId: agent.agentTargetId,
+        label: agent.name,
+        ownership: agent.ownership ?? undefined,
+        provider: agent.provider
+      },
+      enabled: true,
+      hasAccount: true
+    }),
+    true
   );
 });


### PR DESCRIPTION
## Summary

- mark daemon-backed local Agent targets as self-owned when mapping them into AgentGUI
- derive Tutti Agent Commerce availability from the authoritative enabled Agent directory instead of startup-sensitive Settings state
- add a regression test covering the daemon target mapping through the Commerce render predicate

## Verification

- `node --import ./apps/desktop/test/register-asset-stub.mjs --test --experimental-strip-types apps/desktop/src/renderer/src/features/workspace-agent/ui/useDesktopAgentConfigCommerce.test.ts apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentsService.test.ts`
- `pnpm --filter @tutti-os/desktop typecheck`
- `git diff --check`
- `make dev-gui`: selected the exact Tutti Agent rail target and verified the Commerce menu renders the signed-in account, Free plan, and credit balance 200; refresh completed successfully
- push-ready `check:changed` passed all 12 lanes

## Checklist

- [x] This change does not alter agent lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] Documentation changes are not required.
- [x] README/CONTRIBUTING changes are not required.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] DCO sign-off is not required for this repository change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->