### PR TITLE
fix(tutti-mode): harden orchestration and execution recovery

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
@@ -1701,7 +1701,7 @@ function createWorkspaceAgentActivityService(
       return {
         effectiveSettings: input.settings ?? {},
         provider: input.provider ?? "codex"
-      };
+      } as never;
     },
     async updateSessionSettings(input) {
       calls.push(

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.ts
@@ -316,6 +316,7 @@ export function createDesktopAgentGUIWorkbenchHostInput({
     },
     agentSessionReplayService,
     tuttiModePlanReviewRuntime: createDesktopTuttiModePlanReviewRuntime({
+      composerOptionsRuntime: agentActivityRuntime,
       tuttidClient,
       eventStreamClient
     }),

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopTuttiModePlanAssignmentOptionsCache.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopTuttiModePlanAssignmentOptionsCache.test.ts
@@ -6,6 +6,7 @@ test("assignment option cache refreshes directory and detail after the fresh TTL
   let now = 0;
   let directoryLoadCount = 0;
   let detailLoadCount = 0;
+  const forceValues: Array<boolean | undefined> = [];
   const cache = createDesktopTuttiModePlanAssignmentOptionsCache(
     {
       async listAgentTargets() {
@@ -30,26 +31,29 @@ test("assignment option cache refreshes directory and detail after the fresh TTL
       async listWorkspaceAgents() {
         return { agents: [] } as never;
       },
-      async getAgentProviderComposerOptions() {
+      async listModelPlans() {
+        return { plans: [] } as never;
+      }
+    },
+    {
+      async getComposerOptions(input) {
         detailLoadCount += 1;
-        const model = `gpt-${detailLoadCount}`;
+        forceValues.push(input.force);
+        const model = `composer-2.${detailLoadCount + 4}[fast=true]`;
         return {
-          modelConfig: {
-            configurable: true,
-            options: [{ id: model, value: model, label: model }]
-          },
+          provider: "cursor",
+          models: [
+            {
+              value: model,
+              label: `composer-2.${detailLoadCount + 4}`
+            }
+          ],
           permissionConfig: {
             configurable: true,
             modes: [{ id: "auto", label: "Auto", semantic: "auto" }]
           },
-          reasoningConfig: {
-            configurable: true,
-            options: [{ id: "high", value: "high", label: "High" }]
-          }
+          reasoningEfforts: [{ value: "high", label: "High" }]
         } as never;
-      },
-      async listModelPlans() {
-        return { plans: [] } as never;
       }
     },
     () => now
@@ -65,18 +69,29 @@ test("assignment option cache refreshes directory and detail after the fresh TTL
     agentTargetId: "codex"
   };
   assert.deepEqual((await cache.source.loadAgentOptions(detailInput)).models, [
-    "gpt-1"
+    {
+      value: "composer-2.5[fast=true]",
+      label: "composer-2.5"
+    }
   ]);
   assert.deepEqual((await cache.source.loadAgentOptions(detailInput)).models, [
-    "gpt-1"
+    {
+      value: "composer-2.5[fast=true]",
+      label: "composer-2.5"
+    }
   ]);
   assert.equal(detailLoadCount, 1);
+  assert.deepEqual(forceValues, [undefined]);
 
   now = 5 * 60_000 + 1;
   await cache.source.listAgents(directoryInput);
   assert.equal(directoryLoadCount, 2);
   assert.deepEqual((await cache.source.loadAgentOptions(detailInput)).models, [
-    "gpt-2"
+    {
+      value: "composer-2.6[fast=true]",
+      label: "composer-2.6"
+    }
   ]);
   assert.equal(detailLoadCount, 2);
+  assert.deepEqual(forceValues, [undefined, true]);
 });

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopTuttiModePlanAssignmentOptionsCache.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopTuttiModePlanAssignmentOptionsCache.ts
@@ -1,9 +1,11 @@
 import type {
-  AgentTarget,
+  ModelPlan,
   TuttidClient,
   WorkspaceAgent
 } from "@tutti-os/client-tuttid-ts";
+import type { AgentActivityComposerOptions } from "@tutti-os/agent-activity-core";
 import type {
+  AgentActivityRuntime,
   TuttiModePlanAssignmentAgentDetail,
   TuttiModePlanAssignmentAgentOption,
   TuttiModePlanAssignmentOptionsSource
@@ -12,10 +14,12 @@ import { resolveAgentGUIProviderCatalogIdentity } from "@tutti-os/agent-gui/prov
 
 type AssignmentOptionsTuttidClient = Pick<
   TuttidClient,
-  | "listAgentTargets"
-  | "listWorkspaceAgents"
-  | "getAgentProviderComposerOptions"
-  | "listModelPlans"
+  "listAgentTargets" | "listWorkspaceAgents" | "listModelPlans"
+>;
+
+type AssignmentComposerOptionsRuntime = Pick<
+  AgentActivityRuntime,
+  "getComposerOptions"
 >;
 
 interface AssignmentAgentDirectoryEntry {
@@ -168,6 +172,32 @@ function cacheEntryIsFresh(
   );
 }
 
+function assignmentAgentDetailFromComposerOptions(
+  composerOptions: AgentActivityComposerOptions,
+  compatiblePlans: readonly ModelPlan[]
+): TuttiModePlanAssignmentAgentDetail {
+  return {
+    models: composerOptions.models.map((option) => ({ ...option })),
+    modelPlans: compatiblePlans.map((plan) => ({
+      modelPlanId: plan.id,
+      label: plan.name,
+      models: plan.models.map((model) => ({
+        label: model.name.trim() || model.id,
+        value: model.id
+      }))
+    })),
+    permissionModes: (composerOptions.permissionConfig?.modes ?? []).map(
+      (mode) => ({
+        id: mode.id,
+        label: mode.label?.trim() || mode.id
+      })
+    ),
+    reasoningEfforts: composerOptions.reasoningEfforts.map((option) => ({
+      ...option
+    }))
+  };
+}
+
 async function requestCachedValue<TValue>(input: {
   cache: AssignmentOptionsQueryCache<TValue>;
   cacheKey: string;
@@ -214,6 +244,7 @@ function invalidateCachedValue<TValue>(input: {
 
 export function createDesktopTuttiModePlanAssignmentOptionsCache(
   tuttidClient: AssignmentOptionsTuttidClient,
+  composerOptionsRuntime: AssignmentComposerOptionsRuntime,
   now: () => number = Date.now
 ): DesktopTuttiModePlanAssignmentOptionsCache {
   const directoryCache = createAssignmentOptionsQueryCache<
@@ -347,10 +378,16 @@ export function createDesktopTuttiModePlanAssignmentOptionsCache(
         now,
         load: async () => {
           const [composerOptions, plans] = await Promise.all([
-            tuttidClient.getAgentProviderComposerOptions(
-              entry.provider as AgentTarget["provider"],
-              { agentTargetId: normalizedAgentTargetId }
-            ),
+            composerOptionsRuntime.getComposerOptions({
+              agentTargetId: normalizedAgentTargetId,
+              force:
+                detailCache.read(cacheKey) !== null ||
+                (detailGenerations.get(cacheKey) ?? 0) > 0
+                  ? true
+                  : undefined,
+              provider: entry.provider,
+              workspaceId: normalizedWorkspaceId
+            }),
             tuttidClient.listModelPlans(normalizedWorkspaceId).catch(() => null)
           ]);
           const planProtocol =
@@ -363,25 +400,10 @@ export function createDesktopTuttiModePlanAssignmentOptionsCache(
               planProtocol !== null &&
               plan.protocol === planProtocol
           );
-          return {
-            models: composerOptions.modelConfig.options.map(
-              (option) => option.value
-            ),
-            modelPlans: compatiblePlans.map((plan) => ({
-              modelPlanId: plan.id,
-              label: plan.name,
-              models: plan.models.map((model) => model.id)
-            })),
-            permissionModes: composerOptions.permissionConfig.modes.map(
-              (mode) => ({
-                id: mode.id,
-                label: mode.label
-              })
-            ),
-            reasoningEfforts: composerOptions.reasoningConfig.options.map(
-              (option) => option.value
-            )
-          };
+          return assignmentAgentDetailFromComposerOptions(
+            composerOptions,
+            compatiblePlans
+          );
         }
       });
     }

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopWorkspaceWorkflowRuntime.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopWorkspaceWorkflowRuntime.test.ts
@@ -6,7 +6,30 @@ import type {
   WorkspaceWorkflowSnapshot,
   WorkspaceWorkflowUpdatedEventV1
 } from "@tutti-os/client-tuttid-ts";
-import { createDesktopTuttiModePlanReviewRuntime } from "./desktopWorkspaceWorkflowRuntime.ts";
+import {
+  createDesktopTuttiModePlanReviewRuntime as createRuntimeUnderTest,
+  type DesktopTuttiModePlanReviewRuntimeInput
+} from "./desktopWorkspaceWorkflowRuntime.ts";
+
+type TestRuntimeInput = Omit<
+  DesktopTuttiModePlanReviewRuntimeInput,
+  "composerOptionsRuntime"
+> & {
+  composerOptionsRuntime?: DesktopTuttiModePlanReviewRuntimeInput["composerOptionsRuntime"];
+};
+
+function createDesktopTuttiModePlanReviewRuntime(
+  input: TestRuntimeInput
+): ReturnType<typeof createRuntimeUnderTest> {
+  return createRuntimeUnderTest({
+    ...input,
+    composerOptionsRuntime: input.composerOptionsRuntime ?? {
+      async getComposerOptions() {
+        throw new Error("composer options are not used by this test");
+      }
+    }
+  });
+}
 
 interface AgentModelCatalogInvalidatedEvent {
   id: string;
@@ -237,6 +260,21 @@ test("desktop workflow runtime pulls pending state and forwards user decisions",
 
 test("desktop workflow runtime builds agent-scoped assignment option catalogs", async () => {
   const runtime = createDesktopTuttiModePlanReviewRuntime({
+    composerOptionsRuntime: {
+      async getComposerOptions(input) {
+        assert.equal(input.provider, "codex");
+        assert.equal(input.agentTargetId, "workspace-agent:openrouter");
+        return {
+          provider: "codex",
+          models: [{ value: "gpt-5.4", label: "GPT-5.4" }],
+          permissionConfig: {
+            configurable: true,
+            modes: [{ id: "auto", label: "Auto", semantic: "auto" }]
+          },
+          reasoningEfforts: [{ value: "high", label: "High" }]
+        } as never;
+      }
+    },
     tuttidClient: {
       async listPendingWorkspaceWorkflows() {
         return [];
@@ -349,27 +387,6 @@ test("desktop workflow runtime builds agent-scoped assignment option catalogs", 
           ]
         } as never;
       },
-      async getAgentProviderComposerOptions(
-        provider: string,
-        request?: { agentTargetId?: string }
-      ) {
-        assert.equal(provider, "codex");
-        assert.equal(request?.agentTargetId, "workspace-agent:openrouter");
-        return {
-          modelConfig: {
-            configurable: true,
-            options: [{ id: "gpt", value: "gpt-5.4", label: "GPT-5.4" }]
-          },
-          permissionConfig: {
-            configurable: true,
-            modes: [{ id: "auto", label: "Auto", semantic: "auto" }]
-          },
-          reasoningConfig: {
-            configurable: true,
-            options: [{ id: "high", value: "high", label: "High" }]
-          }
-        } as never;
-      },
       async listModelPlans(workspaceId: string) {
         assert.equal(workspaceId, "workspace-1");
         return {
@@ -419,12 +436,16 @@ test("desktop workflow runtime builds agent-scoped assignment option catalogs", 
     workspaceId: "workspace-1",
     agentTargetId: "workspace-agent:openrouter"
   });
-  assert.deepEqual(detail.models, ["gpt-5.4"]);
+  assert.deepEqual(detail.models, [{ value: "gpt-5.4", label: "GPT-5.4" }]);
   assert.deepEqual(detail.modelPlans, [
-    { modelPlanId: "plan-openai", label: "OpenAI plan", models: ["gpt-5.4"] }
+    {
+      modelPlanId: "plan-openai",
+      label: "OpenAI plan",
+      models: [{ value: "gpt-5.4", label: "GPT-5.4" }]
+    }
   ]);
   assert.deepEqual(detail.permissionModes, [{ id: "auto", label: "Auto" }]);
-  assert.deepEqual(detail.reasoningEfforts, ["high"]);
+  assert.deepEqual(detail.reasoningEfforts, [{ value: "high", label: "High" }]);
 
   const unknown = await runtime.assignmentOptions!.loadAgentOptions({
     workspaceId: "workspace-1",
@@ -509,57 +530,38 @@ function createRecordingEventStreamClient(): {
 test("assignment option cache deduplicates loads and fences invalidated results", async () => {
   const stream = createRecordingEventStreamClient();
   let composerLoadCount = 0;
+  const composerOptions = (model: string) => ({
+    provider: "codex",
+    models: [{ value: model, label: model.toUpperCase() }],
+    permissionConfig: {
+      configurable: true,
+      modes: [{ id: "auto", label: "Auto", semantic: "auto" }]
+    },
+    reasoningEfforts: [{ value: "high", label: "High" }]
+  });
   let resolveFirstComposerLoad:
-    | ((value: {
-        modelConfig: {
-          configurable: boolean;
-          options: { id: string; value: string; label: string }[];
-        };
-        permissionConfig: {
-          configurable: boolean;
-          modes: { id: string; label: string; semantic: string }[];
-        };
-        reasoningConfig: {
-          configurable: boolean;
-          options: { id: string; value: string; label: string }[];
-        };
-      }) => void)
+    | ((value: ReturnType<typeof composerOptions>) => void)
     | undefined;
   let markFirstComposerLoadStarted: (() => void) | undefined;
   const firstComposerLoadStarted = new Promise<void>((resolve) => {
     markFirstComposerLoadStarted = resolve;
   });
-  const firstComposerLoad = new Promise<{
-    modelConfig: {
-      configurable: boolean;
-      options: { id: string; value: string; label: string }[];
-    };
-    permissionConfig: {
-      configurable: boolean;
-      modes: { id: string; label: string; semantic: string }[];
-    };
-    reasoningConfig: {
-      configurable: boolean;
-      options: { id: string; value: string; label: string }[];
-    };
-  }>((resolve) => {
-    resolveFirstComposerLoad = resolve;
-  });
-  const composerOptions = (model: string) => ({
-    modelConfig: {
-      configurable: true,
-      options: [{ id: model, value: model, label: model }]
-    },
-    permissionConfig: {
-      configurable: true,
-      modes: [{ id: "auto", label: "Auto", semantic: "auto" }]
-    },
-    reasoningConfig: {
-      configurable: true,
-      options: [{ id: "high", value: "high", label: "High" }]
+  const firstComposerLoad = new Promise<ReturnType<typeof composerOptions>>(
+    (resolve) => {
+      resolveFirstComposerLoad = resolve;
     }
-  });
+  );
   const runtime = createDesktopTuttiModePlanReviewRuntime({
+    composerOptionsRuntime: {
+      async getComposerOptions() {
+        composerLoadCount += 1;
+        if (composerLoadCount === 1) {
+          markFirstComposerLoadStarted?.();
+          return firstComposerLoad as never;
+        }
+        return composerOptions(`gpt-${composerLoadCount}`) as never;
+      }
+    },
     tuttidClient: {
       async listAgentTargets() {
         return {
@@ -581,14 +583,6 @@ test("assignment option cache deduplicates loads and fences invalidated results"
       },
       async listWorkspaceAgents() {
         return { agents: [] } as never;
-      },
-      async getAgentProviderComposerOptions() {
-        composerLoadCount += 1;
-        if (composerLoadCount === 1) {
-          markFirstComposerLoadStarted?.();
-          return firstComposerLoad as never;
-        }
-        return composerOptions(`gpt-${composerLoadCount}`) as never;
       },
       async listModelPlans() {
         return { plans: [] } as never;
@@ -629,11 +623,11 @@ test("assignment option cache deduplicates loads and fences invalidated results"
   const results = await Promise.all([first, duplicate, afterInvalidation]);
   assert.equal(composerLoadCount, 2);
   for (const result of results) {
-    assert.deepEqual(result.models, ["gpt-2"]);
+    assert.deepEqual(result.models, [{ value: "gpt-2", label: "GPT-2" }]);
   }
   assert.deepEqual(
     runtime.assignmentOptions!.readAgentOptions?.(loadInput)?.models,
-    ["gpt-2"]
+    [{ value: "gpt-2", label: "GPT-2" }]
   );
   assert.deepEqual(invalidations, [
     {
@@ -658,12 +652,12 @@ test("assignment option cache deduplicates loads and fences invalidated results"
   });
   assert.deepEqual(
     runtime.assignmentOptions!.readAgentOptions?.(loadInput)?.models,
-    ["gpt-2"],
+    [{ value: "gpt-2", label: "GPT-2" }],
     "stale data remains readable while the refresh is pending"
   );
   assert.deepEqual(
     (await runtime.assignmentOptions!.loadAgentOptions(loadInput)).models,
-    ["gpt-3"]
+    [{ value: "gpt-3", label: "GPT-3" }]
   );
   assert.equal(composerLoadCount, 3);
 });

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopWorkspaceWorkflowRuntime.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopWorkspaceWorkflowRuntime.ts
@@ -5,6 +5,7 @@ import type {
   WorkspaceWorkflowTaskAssignment
 } from "@tutti-os/client-tuttid-ts";
 import type {
+  AgentActivityRuntime,
   TuttiModePlanReviewSnapshot,
   TuttiModePlanReviewRuntime,
   TuttiModePlanTaskAssignmentInput,
@@ -14,6 +15,7 @@ import type {
 import { createDesktopTuttiModePlanAssignmentOptionsCache } from "./desktopTuttiModePlanAssignmentOptionsCache.ts";
 
 export interface DesktopTuttiModePlanReviewRuntimeInput {
+  composerOptionsRuntime: Pick<AgentActivityRuntime, "getComposerOptions">;
   tuttidClient: Pick<
     TuttidClient,
     | "listPendingWorkspaceWorkflows"
@@ -21,7 +23,6 @@ export interface DesktopTuttiModePlanReviewRuntimeInput {
     | "decideWorkspaceWorkflowCheckpoint"
     | "listAgentTargets"
     | "listWorkspaceAgents"
-    | "getAgentProviderComposerOptions"
     | "listModelPlans"
     | "getWorkspaceIssueDetail"
     | "getWorkspaceIssueTaskDetail"
@@ -148,7 +149,10 @@ export function createDesktopTuttiModePlanReviewRuntime(
 ): TuttiModePlanReviewRuntime {
   let connectionStarted = false;
   const assignmentOptionsCache =
-    createDesktopTuttiModePlanAssignmentOptionsCache(input.tuttidClient);
+    createDesktopTuttiModePlanAssignmentOptionsCache(
+      input.tuttidClient,
+      input.composerOptionsRuntime
+    );
 
   return {
     async listPending({ workspaceId, sourceSessionId }) {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts
@@ -9,7 +9,9 @@ import {
 import {
   createAgentActivitySnapshotProjector,
   createAgentActivitySessionReconcileExecutor,
-  createAgentActivityWorkspaceEventCoordinator
+  createAgentActivityWorkspaceEventCoordinator,
+  selectEngineSession,
+  selectLatestActivationForSession
 } from "@tutti-os/agent-activity-core";
 import type { WorkspaceAgentActivityEnsureSessionSynchronizedInput } from "../workspaceAgentActivityService.interface.ts";
 import type { WorkspaceAgentSessionEngineHost } from "./workspaceAgentSessionEngineHost.ts";
@@ -467,7 +469,22 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
         (event) => {
           const agentSessionId = event.payload.agentSessionId.trim();
           if (!agentSessionId) return;
-          this.entries.get(workspaceId)?.engine.dispatch({
+          const entry = this.entries.get(workspaceId);
+          if (!entry) return;
+          const snapshot = entry.engine.getSnapshot();
+          const pendingActivation = selectLatestActivationForSession(
+            snapshot,
+            agentSessionId
+          );
+          if (
+            !selectEngineSession(snapshot, agentSessionId) &&
+            pendingActivation?.mode === "new" &&
+            (pendingActivation.status === "requested" ||
+              pendingActivation.status === "uncertain")
+          ) {
+            return;
+          }
+          entry.engine.dispatch({
             agentSessionId,
             needsMessages: false,
             needsState: true,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -2996,6 +2996,7 @@ test("WorkspaceAgentActivityService does not tombstone a missing reconcile witho
 test("WorkspaceAgentActivityService preserves a pending new session when the Tutti event races create visibility", async (t) => {
   const diagnostics: unknown[] = [];
   const listenersByTopic = new Map<string, (event: unknown) => void>();
+  let getSessionCalls = 0;
   let resolveCreate!: (value: Record<string, unknown>) => void;
   let resolveActivation!: () => void;
   const createResult = new Promise<Record<string, unknown>>((resolve) => {
@@ -3018,6 +3019,7 @@ test("WorkspaceAgentActivityService preserves a pending new session when the Tut
     tuttidClient: {
       createWorkspaceAgentSession: async () => createResult,
       getWorkspaceAgentSession: async () => {
+        getSessionCalls += 1;
         throw new TuttidProtocolError({
           code: "workspace_not_found",
           developerMessage: "workspace agent session not found",
@@ -3080,15 +3082,17 @@ test("WorkspaceAgentActivityService preserves a pending new session when the Tut
     engine.getSnapshot().sessionLifecycle.deletedSessionIds["session-1"],
     undefined
   );
-  assert.deepEqual(diagnostics.at(-1), {
-    details: {
-      agentSessionId: "session-1",
-      error: "workspace agent session not found"
-    },
-    event: "agent.activity.reconcile_session_absent",
-    level: "info",
-    workspaceId: "ws-1"
-  });
+  assert.equal(getSessionCalls, 0);
+  assert.equal(
+    diagnostics.some(
+      (entry) =>
+        entry &&
+        typeof entry === "object" &&
+        "event" in entry &&
+        entry.event === "agent.activity.reconcile_session_absent"
+    ),
+    false
+  );
 
   resolveCreate({
     ...workspaceAgentSession({ status: "working" }),
@@ -3109,6 +3113,71 @@ test("WorkspaceAgentActivityService preserves a pending new session when the Tut
       ?.status,
     "active"
   );
+});
+
+test("WorkspaceAgentActivityService still reconciles a Tutti update for an existing session", async (t) => {
+  const diagnostics: unknown[] = [];
+  const listenersByTopic = new Map<string, (event: unknown) => void>();
+  let getSessionCalls = 0;
+  const service = new WorkspaceAgentActivityService({
+    eventStreamClient: {
+      connect: async () => {},
+      dispose: () => {},
+      publishIntent: async () => {},
+      subscribe: (topic: string, listener: (event: unknown) => void) => {
+        listenersByTopic.set(topic, listener);
+        return () => {};
+      },
+      subscribeConnectionState: () => () => {}
+    } as never,
+    tuttidClient: {
+      getWorkspaceAgentSession: async () => {
+        getSessionCalls += 1;
+        throw new TuttidProtocolError({
+          code: "workspace_not_found",
+          developerMessage: "workspace agent session not found",
+          reason: "workspace_agent_session_not_found",
+          statusCode: 404
+        });
+      },
+      listWorkspaceAgentSessions: async () => ({
+        hasMore: false,
+        sessions: [workspaceAgentSession({ status: "ready" })],
+        workspaceId: "ws-1"
+      })
+    } as unknown as TuttidClient,
+    runtimeApi: {
+      logTerminalDiagnostic: async (payload) => {
+        diagnostics.push(payload);
+      }
+    }
+  });
+  t.after(() => service.dispose());
+  const engine = service.getSessionEngine("ws-1");
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.ok(selectEngineSession(engine.getSnapshot(), "session-1"));
+
+  const tuttiModeUpdated = listenersByTopic.get("workspace.tuttimode.updated");
+  assert.ok(tuttiModeUpdated);
+  tuttiModeUpdated({
+    payload: {
+      agentSessionId: "session-1",
+      workspaceId: "ws-1"
+    }
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(getSessionCalls, 1);
+  assert.deepEqual(diagnostics.at(-1), {
+    details: {
+      agentSessionId: "session-1",
+      error: "workspace agent session not found"
+    },
+    event: "agent.activity.reconcile_session_absent",
+    level: "info",
+    workspaceId: "ws-1"
+  });
 });
 
 test("WorkspaceAgentActivityService tombstones an explicit session deletion event", async () => {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -2,6 +2,7 @@ import {
   agentActivitySessionMessageWindowFromDescendingPage,
   dispatchSessionMutation,
   type AgentActivityAdapter,
+  type AgentActivityComposerOptions,
   type AgentActivityGoalControlResult,
   type AgentActivityMessagePage,
   type AgentActivitySession,
@@ -916,7 +917,7 @@ export class WorkspaceAgentActivityService
     signal?: AbortSignal;
     settings?: Parameters<typeof normalizeComposerSettings>[0] | null;
     workspaceId: string;
-  }): Promise<unknown> {
+  }): Promise<AgentActivityComposerOptions> {
     const provider = resolveDesktopAgentGUIProvider(input.provider);
     const workspaceId = normalizeWorkspaceId(input.workspaceId);
     const entry = this.entry(workspaceId);

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentComposerOptions.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentComposerOptions.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentActivityComposerOptions,
   AgentActivityComposerSettings,
   AgentSessionEngine
 } from "@tutti-os/agent-activity-core";
@@ -13,7 +14,7 @@ export function loadWorkspaceAgentComposerOptions(input: {
   settings: AgentActivityComposerSettings;
   signal?: AbortSignal;
   workspaceId: string;
-}): Promise<unknown> {
+}): Promise<AgentActivityComposerOptions> {
   input.engine.dispatch({
     commandId: input.commandId,
     type: "composerOptions/loadRequested",
@@ -32,7 +33,9 @@ export function loadWorkspaceAgentComposerOptions(input: {
     };
   };
   const current = readResult();
-  if (current.status === "ready") return Promise.resolve(current.options);
+  if (current.status === "ready" && current.options) {
+    return Promise.resolve(current.options);
+  }
   if (current.status === "error") {
     return Promise.reject(new Error("composer_options_load_failed"));
   }
@@ -46,11 +49,11 @@ export function loadWorkspaceAgentComposerOptions(input: {
     };
     const settle = () => {
       const result = readResult();
-      if (result.status === "ready") {
+      if (result.status === "ready" && result.options) {
         unsubscribe();
         input.signal?.removeEventListener("abort", onAbort);
         resolve(result.options);
-      } else if (result.status === "error") {
+      } else if (result.status === "ready" || result.status === "error") {
         unsubscribe();
         input.signal?.removeEventListener("abort", onAbort);
         reject(new Error("composer_options_load_failed"));

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/workspaceAgentActivityService.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/workspaceAgentActivityService.interface.ts
@@ -5,6 +5,7 @@ import type {
 } from "@tutti-os/agent-gui";
 import type {
   AgentActivityCancelTurnInput,
+  AgentActivityComposerOptions,
   AgentActivityGoalControlInput,
   AgentActivityGoalControlResult,
   AgentActivityCreateSessionInput,
@@ -188,7 +189,7 @@ export interface IWorkspaceAgentActivityService {
     signal?: AbortSignal;
     settings?: AgentHostAgentSessionComposerSettings | null;
     workspaceId: string;
-  }): Promise<unknown>;
+  }): Promise<AgentActivityComposerOptions>;
   updateSessionSettings(input: {
     agentSessionId: string;
     settings: AgentHostAgentSessionComposerSettings;

--- a/docs/architecture/issue-execution.md
+++ b/docs/architecture/issue-execution.md
@@ -18,8 +18,23 @@ Their materialization creates no Run and never enters the generic eligible-task
 dispatcher; later work requires an explicit Tutti execution schedule command.
 Every active Tutti checkpoint instead owns one durable main-conversation wake.
 The wake asks the source Agent to review canonical execution state and choose a
-fenced `schedule` or `acknowledge` command; settling a task never mechanically
-dispatches a successor.
+fenced `schedule`, `mutate`, `acknowledge`, `complete`, or `stop` command;
+settling a task never mechanically dispatches a successor.
+
+The source-facing `plan issue get` projection is a read-only composition of the
+Tutti execution aggregate and canonical Issue task detail. It exposes the
+active checkpoint and graph revision together with launch configuration,
+supersession, dependency readiness, allowed actions, and recovery guidance.
+The projection is scoped by trusted Agent Session context; callers cannot
+supply a source Session ID.
+
+Graph transition semantics belong to
+`services/tuttid/biz/tuttimodeexecution`. That business layer applies
+presence-aware updates, sparse rework inheritance, logical supersession,
+dependent-edge rebinding, and active-graph validation as one pure transition.
+The SQLite adapter only loads the graph, persists the returned inserts and
+updates inside the fenced transaction, and records idempotency history. Product
+mutation rules must not be reimplemented in the data adapter.
 
 ## Execution flow
 

--- a/docs/architecture/issue-execution.md
+++ b/docs/architecture/issue-execution.md
@@ -46,6 +46,23 @@ Because no Issue lock is held across the Agent call, that callback can safely
 settle the Run. A failed cancellation leaves the Run running, keeps dispatch
 paused, and returns an error; Issue intent must not fabricate Agent outcome.
 
+Stopping a Tutti source conversation uses a stronger, source-scoped boundary.
+The canceled canonical source Turn is committed with the Agent transaction's
+Tutti activity-inbox marker. The synchronous observer asks the execution
+service to archive every nonterminal execution for that workspace/source
+Session; it does not discover ownership by scanning a bounded page of running
+Runs. In one product transaction, archive fences each execution and Issue,
+cancels checkpoints, main wakes, Goal Reviews, prepared or leased Run launches,
+and pending workflow/checkpoint/operation recovery. It then cancels exact Run,
+main-wake, and reviewer Turns before sealing executions as `archived`.
+
+The same inbox marker is the crash boundary. A watchdog or reviewer sweep
+drains it before dispatch, creates any missing archive operations, and runs
+archive recovery before another automatic send. Startup create-Issue recovery
+also excludes workflows whose source has an undrained canceled-Turn marker.
+Only completed source Turns advance the inactivity clock; a canceled source
+Turn terminates orchestration instead of postponing the watchdog.
+
 The non-blocking Run launch gate closes the claim-to-launch race without
 holding a mutex across external work. Stop records cancel intent and returns
 without waiting for an in-flight Agent create call. Launch revalidates the
@@ -114,9 +131,10 @@ atomically acknowledge that wake and promote the next backlog checkpoint.
 Every nonterminal Tutti execution also carries a fixed inactivity deadline:
 `watchdogDueAt = lastOrchestratorActivityAt + 5m`. Valid schedule and
 acknowledge commands, Run settlement (including failed or canceled), exact
-source-session user input, and exact source root-Turn settlement reset that
-deadline. Delegate/child activity and activity from another workspace or
-Session do not. The Agent adapter only projects these facts after Host accepts
+source-session user input, and exact completed source root-Turn settlement
+reset that deadline. A canceled source Turn enters the terminal source-session
+stop boundary instead. Delegate/child activity and activity from another
+workspace or Session do not. The Agent adapter only projects these facts after Host accepts
 the user Turn or reports the canonical root Turn settled; it does not change
 Host lifecycle semantics. The projection carries the canonical Turn identity
 and user-message occurrence or root-Turn settlement time rather than callback

--- a/docs/architecture/workspace-workflows.md
+++ b/docs/architecture/workspace-workflows.md
@@ -469,6 +469,15 @@ on the checkpoint. Accept, reject, and cancel post the decision to the daemon;
 rejection feedback is mandatory. Closing the app does not discard the review:
 the next mount reconstructs it from the daemon snapshot.
 
+Desktop assignment catalogs load provider composer options through the same
+activity-core target-scoped cache used by the main Composer. The workflow
+adapter may join that canonical snapshot with the workspace Agent directory and
+compatible model-plan catalog, but it does not create a second provider-options
+transport path. Model and reasoning entries retain their canonical
+`value`/`label` metadata end to end: task overrides persist the opaque provider
+`value`, while editable and read-only review surfaces render the `label` and
+fall back to the value only for an unknown historical selection.
+
 The Tutti activation additionally carries a session-scoped orchestration
 intensity (0-100, default 50). The composer's Tutti Budget popup persists it
 as a new activation revision; each turn's frozen snapshot copies it, and the

--- a/docs/architecture/workspace-workflows.md
+++ b/docs/architecture/workspace-workflows.md
@@ -218,10 +218,14 @@ invented — plus explicit `execution.effect` / `execution.speed` preference
 snapshots. The existing v1 `reasoningIntensity` and
 `orchestrationIntensity` fields retain their provider-reasoning and
 Issue-orchestration meanings; speed is never encoded into
-`orchestrationIntensity`. It routes model
-assignment through the injected `$tutti-model-allocation` skill so C0-C3 task
-requirements, the effect floor, speed ranking, hard capabilities, and
-effect-scaled validation are applied consistently. Unless the user asks for
+`orchestrationIntensity`. It routes model assignment through the injected
+`$tutti-model-allocation` skill so C0-C3 task requirements, the effect floor,
+speed ranking, hard capabilities, and effect-scaled validation are applied
+consistently. The skill ranks joint Agent/model candidates across every
+plausible target: the planning Agent, current provider/model, and provider
+defaults receive no affinity bonus, while an equally qualified non-planning
+target wins the tie for safely independent work so the planner remains
+available for coordination and final integration. Unless the user asks for
 supervised execution, the guide directs agents to the permission mode whose
 semantic is `full-access` (codex `full-access`, claude-code
 `bypassPermissions`): the user's approval happens once at plan review, so

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -41,7 +41,10 @@ Use the focused runtime index or open one area directly:
 
 Issue dispatch, Run cancellation, Agent settlement, and stop coordination.
 
-- [Stopping a Tutti source Turn leaves task Sessions running](./issue-execution.md#stopping-a-tutti-source-turn-leaves-task-sessions-running)
+- [Managed task deletion is reported as a stale checkpoint](./issue-execution.md#managed-task-deletion-is-reported-as-a-stale-checkpoint)
+- [Settled checkpoint keeps reopening the source Session](./issue-execution.md#settled-checkpoint-keeps-reopening-the-source-session)
+- [Tutti composer stays busy after every task Turn settles](./issue-execution.md#tutti-composer-stays-busy-after-every-task-turn-settles)
+- [Stopping a Tutti source Turn leaves automation recoverable](./issue-execution.md#stopping-a-tutti-source-turn-leaves-automation-recoverable)
 - [Stop remains pending while the Agent Turn is already canceled](./issue-execution.md#stop-remains-pending-while-the-agent-turn-is-already-canceled)
 
 ## [Desktop And Release](./desktop-release.md)

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -42,6 +42,7 @@ Use the focused runtime index or open one area directly:
 Issue dispatch, Run cancellation, Agent settlement, and stop coordination.
 
 - [Managed task deletion is reported as a stale checkpoint](./issue-execution.md#managed-task-deletion-is-reported-as-a-stale-checkpoint)
+- [Reworked task scheduling is reported as a stale checkpoint](./issue-execution.md#reworked-task-scheduling-is-reported-as-a-stale-checkpoint)
 - [Settled checkpoint keeps reopening the source Session](./issue-execution.md#settled-checkpoint-keeps-reopening-the-source-session)
 - [Tutti composer stays busy after every task Turn settles](./issue-execution.md#tutti-composer-stays-busy-after-every-task-turn-settles)
 - [Stopping a Tutti source Turn leaves automation recoverable](./issue-execution.md#stopping-a-tutti-source-turn-leaves-automation-recoverable)

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -51,6 +51,7 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 - [AgentGUI turn actions return plain-text route 404s](./agent-session-lifecycle.md#agentgui-turn-actions-return-plain-text-route-404s)
 - [One hung provider startup blocks unrelated Agent sessions](./agent-session-lifecycle.md#one-hung-provider-startup-blocks-unrelated-agent-sessions)
 - [Many stopped Tutti Mode conversations start again when the app opens](./agent-session-lifecycle.md#many-stopped-tutti-mode-conversations-start-again-when-the-app-opens)
+- [A new Tutti conversation briefly reports session not found after submit](./agent-session-lifecycle.md#a-new-tutti-conversation-briefly-reports-session-not-found-after-submit)
 - [AgentGUI rail shows a failed Turn but the detail has no error](./agent-session-lifecycle.md#agentgui-rail-shows-a-failed-turn-but-the-detail-has-no-error)
 - [AgentGUI Stop reports no active turn after cancel succeeds](./agent-session-lifecycle.md#agentgui-stop-reports-no-active-turn-after-cancel-succeeds)
 - [AgentGUI send blocked by active_turn after settled snapshot](./agent-session-lifecycle.md#agentgui-send-blocked-by-activeturn-after-settled-snapshot)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -325,34 +325,35 @@
   verify the HTTP boundary sees the activation, the activation revision is
   `active`, and the first Turn snapshot retains its source and intensity.
 
-### A new Tutti conversation becomes unavailable immediately after submit
+### A new Tutti conversation briefly reports session not found after submit
 
-- **Symptom:** The optimistic conversation appears after the first submit, then
-  immediately changes to `Conversation unavailable` even though the provider
-  starts and the durable Session and Turn complete normally.
+- **Symptom:** The optimistic conversation appears after the first submit and
+  briefly shows `workspace agent session not found`, then recovers after the
+  provider starts and the durable Session and Turn complete normally.
 - **Quick checks:** Correlate the Session ID across desktop and daemon submit
   traces. The characteristic order is
   `renderer_adapter.create.http_requested`, then
-  `agent.activity.reconcile_session_missing`, then
+  `agent.activity.reconcile_session_absent`, then
   `renderer_adapter.create.resolved` and `api.create.completed`. Confirm the
   missing reconcile occurs while the engine still has a requested or uncertain
   new-session activation.
 - **Root cause:** Initial Tutti activation can publish
   `workspace.tuttimode.updated` before the create transaction is query-visible
   or its HTTP response returns. The renderer treats the event as a reconcile
-  hint, receives a transient 404, and mistakes it for authoritative deletion.
-  The resulting Session tombstone rejects the later successful create upsert.
-- **Fix:** Treat reconcile not-found as absence, not deletion evidence, and do
-  not create a tombstone from it. Let an authoritative create result or later
-  event upsert the Session. Tombstone only from explicit deletion evidence such
-  as `session_deleted` or a successful delete command, so real deletions remain
-  final.
+  hint and exposes its transient 404 as a detail failure even though the
+  independent create command is still in flight.
+- **Fix:** Ignore only this Tutti update hint when the exact Session has no
+  canonical record and its latest new-session activation is still requested or
+  uncertain. Let the authoritative create result confirm the Session. Do not
+  broadly swallow reconcile 404s: existing Sessions and other reconcile
+  sources still report their real failures. Tombstone only from explicit
+  deletion evidence such as `session_deleted` or a successful delete command.
 - **Validation:** Hold create in flight, publish
-  `workspace.tuttimode.updated`, return not-found from the Session read, and
-  verify the pending Session is not tombstoned. Then resolve create and verify
-  the canonical Session and active activation are present. Also prove an
-  ordinary reconcile 404 remains untombstoned while an explicit
-  `session_deleted` event does tombstone.
+  `workspace.tuttimode.updated`, and verify the Session read is not called and
+  no reconcile error is recorded. Then resolve create and verify the canonical
+  Session and active activation are present. Also prove the same event still
+  reconciles an existing Session and preserves its not-found diagnostic, while
+  an explicit `session_deleted` event tombstones it.
 - **References:**
   [workspaceAgentActivityReconcileBridge.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts)
   [workspaceEventCoordinator.ts](../../../packages/agent/activity-core/src/workspaceEventCoordinator.ts)

--- a/docs/conventions/troubleshooting/issue-execution.md
+++ b/docs/conventions/troubleshooting/issue-execution.md
@@ -23,6 +23,41 @@ Validate both aliases in the CLI provider tests and the task-canceled
 wake-prompt test. Do not weaken the generic Issue ownership guard or physically
 delete task/Run audit history; `supersede` and `rework` preserve that history.
 
+## Reworked task scheduling is reported as a stale checkpoint
+
+After a failed or canceled task is reworked, the mutation can succeed but
+scheduling its replacement may still be rejected. Run
+`tutti plan issue get --issue-id <id> --json` once to separate fence state from
+task eligibility. Compare its active checkpoint and graph revision with the
+successful mutation result, then use each task's `blockerReason`. Stable
+reasons such as `stale_graph_revision`, `missing_agent_target`, and
+`dependency_unsatisfied` identify which correction is required instead of
+collapsing every failure into a generic schedule rejection.
+
+A replacement submitted with only a new task ID, title, and content is a sparse
+rework, not a request to clear launch configuration. The mutation layer must
+inherit omitted Agent target, compatible model selection, permission mode,
+reasoning effort, execution directory, and dependencies from the superseded
+task. Explicit replacement values override those defaults. It must also
+redirect dependencies for active `not_started` tasks in the same transaction,
+preserve the old task and Run as superseded history, and reject the transaction
+if an affected dependent has already started.
+
+Do not query or modify the backing SQLite database to recover or bypass the
+rejected command. The daemon and CLI are the supported control plane, and
+guessing a production database path while the runtime is in development mode
+produces unrelated evidence. If the authoritative CLI snapshot and documented
+recovery commands still cannot resolve the failure, retain and report the exact
+CLI error.
+
+The checkpoint wake prompt must describe sparse rework inheritance, dependency
+redirects, and scheduling with the graph revision returned by the successful
+mutation. The injected CLI skill must also define the checkpoint/action matrix
+and bound fence or schema recovery to one refresh and one retry. Validate both
+failed and canceled terminal-run paths, sparse rework, inherited launch
+settings, dependency redirect, and replacement scheduling in the execution
+conformance suite.
+
 ## Tutti composer stays busy after every task Turn settles
 
 The Tutti composer deliberately shows Stop while its managed Issue still has

--- a/docs/conventions/troubleshooting/issue-execution.md
+++ b/docs/conventions/troubleshooting/issue-execution.md
@@ -1,5 +1,83 @@
 # Issue execution
 
+## Managed task deletion is reported as a stale checkpoint
+
+When a source Agent reports that a canceled task could not be removed because
+the current checkpoint rejects graph changes, inspect the two mutation attempts
+separately. `tutti issue task delete` must return `tutti_issue_managed` for a
+Tutti-owned graph; that is the expected ownership guard. The authorized path is
+`tutti plan issue mutate` with the active checkpoint and graph revision.
+
+If the mutate call reports that its caller, checkpoint, revision, or operation
+set is not current, first confirm the execution row, active checkpoint, graph
+revision, and source Session. When those fences still match, inspect
+`--operations-json`: operation objects use `kind`, not `op`, and a `rework`
+embeds its replacement under `task`, not `replacement`. Go's permissive JSON
+decoder otherwise ignores the alias, leaves the required field empty, and the
+service rejects the malformed operation before it evaluates the durable
+checkpoint.
+
+The CLI must reject that malformed shape with an actionable `kind` validation,
+and the durable wake prompt must include exact supersede and rework examples.
+Validate both aliases in the CLI provider tests and the task-canceled
+wake-prompt test. Do not weaken the generic Issue ownership guard or physically
+delete task/Run audit history; `supersede` and `rework` preserve that history.
+
+## Tutti composer stays busy after every task Turn settles
+
+The Tutti composer deliberately shows Stop while its managed Issue still has
+nonterminal tasks. When every Agent Turn is terminal but the composer remains
+busy, compare the execution graph revision with the active checkpoint revision
+and inspect the ordered checkpoint backlog. An `awaiting_main` execution whose
+active settlement checkpoint has an older revision cannot pass the source
+Agent's schedule or acknowledge fence.
+
+This mismatch can occur when parallel Runs append settlement checkpoints at one
+graph revision, the source Agent mutates the graph while reviewing the first
+checkpoint, and a later checkpoint is promoted without being rebound to the
+new revision. Promotion through both schedule and acknowledge must set the
+checkpoint's revision to the current execution revision in the same
+transaction. The watchdog repair path must also rebind already-active stale
+settlement or watchdog checkpoints, advance their retry deadline, and issue the
+next deterministic wake without rewriting task or Run history.
+
+Validate this class with a conformance scenario that mutates the graph before
+both schedule-driven and acknowledge-driven backlog promotion. Also validate
+watchdog recovery from a pre-existing active checkpoint whose revision trails
+the execution revision. Do not change the composer to ignore nonterminal Issue
+tasks; that would hide the durable orchestration deadlock while work remains
+unreviewed.
+
+When a rework succeeds but the current Issue board shows both the original and
+replacement tasks, compare the board with the Issue's active task projection.
+Rework deliberately retains the superseded task row and Run history for audit,
+but current-task lists, progress counts, and scheduling must exclude tasks whose
+`supersededAtUnix` is set. Do not delete the superseded history to make the
+counts agree.
+
+## Settled checkpoint keeps reopening the source Session
+
+A terminal Agent Turn does not resolve its Tutti execution checkpoint. When the
+checkpoint remains active after that Turn settles, the inactivity watchdog
+deliberately creates another deterministic wake after five minutes. Each wake
+is a new Agent Turn, so Desktop may show a new generic Turn-completion
+notification even though no task Run restarted.
+
+First group the wake records by Issue, checkpoint, and wake sequence. Multiple
+Issues may legitimately target the same source Session and therefore share the
+same conversation title. If an older Issue was replaced by a new plan but was
+never archived, both active checkpoints will continue to wake that Session.
+Do not suppress watchdog delivery or mark a Turn terminal as proof that the
+Issue is terminal; either action loses durable work.
+
+The source Agent must have an explicit terminal path when it decides an Issue
+should not continue. `tutti plan issue stop` derives source authority from the
+invoking Session, fences against the active checkpoint and graph revision, and
+reuses the recoverable archive flow to cancel Runs and close open wakes. The
+durable wake prompt must advertise that command. Validate the source,
+checkpoint, and revision fences, plus idempotent replay after the first stop
+has already canceled the active checkpoint.
+
 ## Stop remains pending while the Agent Turn is already canceled
 
 Check the durable Issue, Run, Agent Turn, runtime operation, and Agent outbox
@@ -27,27 +105,36 @@ repairing the callback cycle.
 For the ownership and data-flow contract, see
 [Issue Execution Coordination](../../architecture/issue-execution.md).
 
-## Stopping a Tutti source Turn leaves task Sessions running
+## Stopping a Tutti source Turn leaves automation recoverable
 
-First separate source-Turn cancellation from Issue execution cancellation. The
-source path is healthy when logs contain `agent_session.cancel.accepted` for the
-planning Session. If it is immediately followed by
-`workspace_issue.source_session_cancel_failed` with
-`tutti-owned issue is managed by its source conversation`, the Agent Turn
-stopped but the Issue cascade did not. Confirm that the Issue still has
-`dispatchPaused=false` and that its running Runs remain active.
+First compare the canonical source Turn, activity inbox, execution, archive
+operation, workflow operation, Run launch intent, wake, and Goal Review rows. A
+canceled source Turn followed by `awaiting_main`, `pending_goal_review`, or a
+new wake after restart means Stop affected the Agent runtime but did not cross a
+durable product boundary. A scan of running Runs is not sufficient: one source
+conversation may own several executions, including executions with no current
+Run, and bounded workspace scans can omit older Issues.
 
-This happens when the already-authorized source-session cascade calls the
-generic `CancelIssueExecution` entrypoint. That entrypoint must reject
-Tutti-managed graphs; weakening its ownership guard would expose managed Issues
-to unrelated mutations.
+The source-session Stop path must request archive for every nonterminal
+execution belonging to the exact workspace/source Session. The archive
+transaction pauses dispatch and cancels checkpoints, wakes, reviews, prepared
+or leased launch intents, and workflow recovery before external cancellation.
+Archive recovery then cancels exact Run, main-wake, and reviewer Turns. If Stop
+wins before a Run has a canonical Turn, settle that unlaunched Run as canceled;
+if delivery is already in flight, the launch gate performs exact-Turn
+compensation.
 
-Keep the generic guard intact. After proving the Issue has
-`PlanningSourceTuttiModePlan` and the exact `SourceSessionID`, route the cascade
-through `CancelTuttiModeIssueExecution`. That path durably pauses dispatch
-before it fans out exact Run Session cancellations. Validate with
-`TestCancelIssueExecutionForSourceSessionUsesManagedTuttiStopPath` plus the
-focused Issue execution cancellation tests. Desktop's embedded Tutti plan
-panel reaches the same managed path through
-`POST /v1/workspaces/{workspaceID}/tutti-executions/{issueID}/cancel-execution`;
-it must not call the generic Issue Manager cancel endpoint.
+The canonical canceled Turn and its `workspace_tutti_source_activity_inbox`
+marker are atomic. Draining the marker must create the same archive operations,
+must not count the canceled Turn as watchdog activity, and must happen before
+reviewer or main-wake dispatch. Create-Issue startup recovery must also reject
+an accepted workflow while that canceled-source marker remains undrained. This
+is why closing and reopening the app cannot legitimately resume the old
+automation.
+
+Validate this class with the source-session archive conformance scenarios,
+canceled-source inbox recovery, main-wake and reviewer dispatch-race
+compensation, a prepared Run with no canonical Turn, and workflow recovery
+fenced before inbox drain. Keep the generic Issue ownership guard intact;
+source Stop is a Tutti execution lifecycle operation, not a generic Issue
+mutation.

--- a/docs/conventions/tutti-cli-contract.md
+++ b/docs/conventions/tutti-cli-contract.md
@@ -44,6 +44,18 @@ An obsolete persisted default is ignored while reading Composer Options so the
 caller can recover by selecting a current advertised id. The same obsolete id,
 when explicitly supplied in the current invocation, remains invalid input.
 
+Tutti execution commands use stable rejection reasons such as
+`wrong_source_session`, `inactive_execution`, `inactive_checkpoint`,
+`stale_graph_revision`, `task_not_found`, `task_not_started`,
+`task_superseded`, `missing_agent_target`, `dependency_unsatisfied`,
+`dispatch_paused`, `budget_unavailable`, `capacity_exhausted`,
+`parallelism_rejected`, `duplicate_task`, `invalid_task_graph`, and
+`invalid_mutation_operation`. Their message must include one action-specific
+recovery hint. A fence rejection directs the caller to the source-scoped
+execution snapshot; a task rejection identifies the affected task. Callers
+must not infer a new revision, cycle through unrelated commands, or inspect the
+backing database.
+
 Exit codes stay intentionally small and stable: `0` means success, `2` means
 the command invocation or input was invalid, and `1` means authentication,
 transport, domain, or runtime failure. A daemon HTTP 400 response is invalid
@@ -412,6 +424,13 @@ The public command set is deliberately narrow:
   session instructing the Agent to revise, so the Agent does not have to poll;
 - `tutti plan get --workflow-id <id>` returns the caller-session-scoped
   authoritative snapshot;
+- `tutti plan issue get --issue-id <id>` returns the source-session-scoped
+  authoritative execution snapshot: execution status, active checkpoint,
+  graph revision, visible pending checkpoints, task launch settings,
+  supersession and dependency facts, per-task readiness blockers, ready task
+  IDs, allowed actions, and a checkpoint-specific recovery hint. It is the
+  only supported refresh operation after a fenced execution command is
+  rejected;
 - `tutti plan issue schedule --issue-id <id> --checkpoint-id <id>
 --expected-graph-revision <revision> --task-ids-json <json-array>
 --request-id <stable-id>` resolves the active execution checkpoint by
@@ -426,7 +445,18 @@ The public command set is deliberately narrow:
   graph revision and rebinds the checkpoint to that revision. Every operation
   object uses the `kind` key (`op` is invalid): `add` carries `task`, `update`
   carries `taskId` plus `task`, `rework` carries `taskId` plus its replacement
-  `task` (`replacement` is invalid), and `supersede` carries `taskId`;
+  `task` (`replacement` is invalid), and `supersede` carries `taskId`. A
+  new task must include `agentTargetId`. `update` and `rework` are
+  presence-aware: omitted fields are preserved, while explicit empty strings,
+  empty arrays, `false`, and zero values remain distinguishable and are applied
+  when the field is clearable. Required task invariants such as a nonempty
+  title and Agent target still fail closed. A sparse `rework` inherits omitted
+  launch settings, execution directory, and dependencies from the superseded
+  task; explicit replacement values override those defaults. A successful
+  `rework` also redirects every active, not-started task dependency from the
+  superseded task ID to the replacement task ID in the same transaction.
+  Rework is rejected if that redirect would require changing a task that has
+  already started;
 - `tutti plan issue acknowledge --issue-id <id> --checkpoint-id <id>
 --expected-graph-revision <revision> --request-id <stable-id>` resolves a
   reviewed `task_settled`, `task_failed`, or `task_canceled` checkpoint without
@@ -446,6 +476,22 @@ The public command set is deliberately narrow:
   fences the stop against the active checkpoint and graph revision, then uses
   the recoverable archive path to cancel open Runs and close pending
   checkpoints and wakes. The reason is retained as audit evidence.
+
+The active checkpoint defines the legal action set:
+
+| Checkpoint                     | Legal recovery                                                                                                                                                           |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `initial_schedule`             | schedule an exact ready set, mutate, or stop                                                                                                                             |
+| `task_settled`                 | schedule or mutate; acknowledge only when another Run is active or a later checkpoint is pending; or stop                                                                |
+| `task_failed`, `task_canceled` | rework the terminal task with a new task ID, then schedule the replacement with the mutation result revision; acknowledge only under the same backlog condition; or stop |
+| `all_tasks_terminal`           | complete Goal Review, or mutate and schedule exact follow-up work; or stop                                                                                               |
+
+The source Agent refreshes `plan issue get` at most once for an
+`inactive_checkpoint` or `stale_graph_revision` rejection and retries the
+intended command at most once with the returned fence. It reads mutation help
+at most once for `invalid_mutation_operation`. Repeating the same rejection
+after that bounded recovery is reported verbatim instead of triggering tool
+exploration or backing-store access.
 
 Tasks may carry optional `agentTargetId`, `modelPlanId`, `model`,
 `permissionModeId`, and `reasoningEffort` assignments. The user can override

--- a/docs/conventions/tutti-cli-contract.md
+++ b/docs/conventions/tutti-cli-contract.md
@@ -423,7 +423,10 @@ The public command set is deliberately narrow:
 --request-id <stable-id>` atomically applies one or more `add`, `update`,
   `rework`, or `supersede` operations to the active Issue graph. The checkpoint
   and graph revision fence the entire operation set; success increments the
-  graph revision and rebinds the checkpoint to that revision;
+  graph revision and rebinds the checkpoint to that revision. Every operation
+  object uses the `kind` key (`op` is invalid): `add` carries `task`, `update`
+  carries `taskId` plus `task`, `rework` carries `taskId` plus its replacement
+  `task` (`replacement` is invalid), and `supersede` carries `taskId`;
 - `tutti plan issue acknowledge --issue-id <id> --checkpoint-id <id>
 --expected-graph-revision <revision> --request-id <stable-id>` resolves a
   reviewed `task_settled`, `task_failed`, or `task_canceled` checkpoint without
@@ -435,7 +438,14 @@ The public command set is deliberately narrow:
 --decision goal_satisfied [--disagreement-reason <reason>]` completes the
   exact active Goal Review. The source Session comes from trusted invoke
   context. A disagreement reason is required when the source Agent overrides a
-  negative or inconclusive independent verdict.
+  negative or inconclusive independent verdict;
+- `tutti plan issue stop --issue-id <id> --checkpoint-id <id>
+--expected-graph-revision <revision> --reason <reason>
+--request-id <stable-id>` stops an Issue that was replaced or should no longer
+  continue. The daemon derives the source Session from trusted invoke context,
+  fences the stop against the active checkpoint and graph revision, then uses
+  the recoverable archive path to cancel open Runs and close pending
+  checkpoints and wakes. The reason is retained as audit evidence.
 
 Tasks may carry optional `agentTargetId`, `modelPlanId`, `model`,
 `permissionModeId`, and `reasoningEffort` assignments. The user can override

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/TuttiBudgetPopover.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/TuttiBudgetPopover.tsx
@@ -181,20 +181,9 @@ export function TuttiBudgetPopover({
               }}
             />
           </div>
-          <div className="mt-3 flex items-center justify-between gap-2 text-[11px] font-medium">
-            <span className="text-[var(--state-success)]">
-              {labels.previewCost}
-            </span>
-            <span className="text-[var(--accent-codex)]">
-              {labels.previewBalance}
-            </span>
-            <span className="text-[var(--tutti-purple)]">
-              {labels.previewPowerful}
-            </span>
-          </div>
           <div
             aria-live="polite"
-            className="mt-2 border-t border-[var(--line-2)] pt-2"
+            className="mt-3 border-t border-[var(--line-2)] pt-2"
           >
             <span className="text-[12px] font-medium text-[var(--text-secondary)]">
               {labels.previewTitle}

--- a/packages/agent/gui/agentActivityRuntime.tsx
+++ b/packages/agent/gui/agentActivityRuntime.tsx
@@ -8,6 +8,7 @@ import {
 import type {
   AgentActivityActivateSessionResult,
   AgentActivityCollaborationRun,
+  AgentActivityComposerOptions,
   AgentActivityGoalControlInput,
   AgentActivityGoalControlResult,
   AgentActivityCreateSessionInput,
@@ -317,7 +318,7 @@ export interface AgentActivityRuntime {
   ): Promise<AgentActivitySession>;
   getComposerOptions(
     input: AgentActivityRuntimeGetComposerOptionsInput
-  ): Promise<unknown>;
+  ): Promise<AgentActivityComposerOptions>;
   updateSessionSettings(
     input: AgentActivityRuntimeUpdateSessionSettingsInput
   ): Promise<AgentActivityRuntimeUpdateSessionSettingsResult>;

--- a/packages/agent/gui/workspaceWorkflow/tuttiModePlan/TuttiModePlanPanel.spec.tsx
+++ b/packages/agent/gui/workspaceWorkflow/tuttiModePlan/TuttiModePlanPanel.spec.tsx
@@ -95,16 +95,25 @@ function assignmentCatalog(
     ],
     optionsByAgentId: {
       "codex-agent": {
-        models: ["gpt-5.6-sol"],
+        models: [
+          { value: "gpt-5.6-sol", label: "GPT-5.6 Sol" },
+          {
+            value: "composer-2.5[fast=true]",
+            label: "composer-2.5"
+          }
+        ],
         modelPlans: [
           {
             modelPlanId: "model-plan-pro",
             label: "Pro plan",
-            models: ["gpt-5.6-sol"]
+            models: [{ value: "gpt-5.6-sol", label: "GPT-5.6 Sol" }]
           }
         ],
         permissionModes: [{ id: "acceptEdits", label: "Accept edits" }],
-        reasoningEfforts: ["low", "high"]
+        reasoningEfforts: [
+          { value: "low", label: "Low" },
+          { value: "high", label: "High" }
+        ]
       }
     },
     loadAgentOptions: vi.fn(),
@@ -186,6 +195,30 @@ describe("TuttiModePlanPanel", () => {
     expect(parallelSwitch).toHaveAttribute("aria-checked", "true");
   });
 
+  it("renders the canonical model label instead of the provider-native value", () => {
+    render(
+      <TuttiModePlanPanel
+        assignmentCatalog={assignmentCatalog()}
+        assignmentDrafts={{}}
+        labels={labels}
+        panel={{
+          ...panel,
+          tasks: [
+            {
+              ...panel.tasks[0]!,
+              model: "composer-2.5[fast=true]"
+            }
+          ]
+        }}
+        submitting={false}
+        onAssignmentDraftChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByLabelText("Model")).toHaveTextContent("composer-2.5");
+    expect(screen.getByLabelText("Model")).not.toHaveTextContent("[fast=true]");
+  });
+
   it("stays read-only without a host-owned draft store", () => {
     render(
       <TuttiModePlanPanel
@@ -216,5 +249,10 @@ describe("TuttiModePlanPanel", () => {
     expect(
       screen.queryByTestId("tutti-plan-task-assignment-implement")
     ).not.toBeInTheDocument();
+    expect(screen.getByTitle("Model")).toHaveTextContent("GPT-5.6 Sol");
+    expect(screen.getByTitle("Permission mode")).toHaveTextContent(
+      "Accept edits"
+    );
+    expect(screen.getByTitle("Reasoning effort")).toHaveTextContent("High");
   });
 });

--- a/packages/agent/gui/workspaceWorkflow/tuttiModePlan/TuttiModePlanPanel.tsx
+++ b/packages/agent/gui/workspaceWorkflow/tuttiModePlan/TuttiModePlanPanel.tsx
@@ -17,6 +17,7 @@ import type {
 } from "./tuttiModePlanPanelProjection";
 import type { TuttiModePlanAssignmentCatalog } from "./useTuttiModePlanPanels";
 import {
+  assignmentOptionLabel,
   TuttiModePlanTaskAssignmentEditor,
   permissionModeAssignmentTone
 } from "./TuttiModePlanTaskAssignmentEditor";
@@ -134,7 +135,11 @@ export function TuttiModePlanPanel({
                       }
                     />
                   ) : (
-                    <TaskAssignmentSummary labels={labels} task={task} />
+                    <TaskAssignmentSummary
+                      assignmentCatalog={assignmentCatalog}
+                      labels={labels}
+                      task={task}
+                    />
                   )}
                 </li>
               ))}
@@ -151,25 +156,56 @@ export function TuttiModePlanPanel({
  * single line, showing only the assignments the plan actually specifies.
  */
 function TaskAssignmentSummary({
+  assignmentCatalog,
   labels,
   task
 }: {
+  assignmentCatalog?: TuttiModePlanAssignmentCatalog | null;
   labels: TuttiModePlanPanelLabels;
   task: TuttiModePlanPanelTaskViewModel;
 }): React.JSX.Element | null {
+  const agentDetail = task.agentTargetId
+    ? assignmentCatalog?.optionsByAgentId[task.agentTargetId]
+    : null;
+  const modelOptions = [
+    ...(agentDetail?.models ?? []),
+    ...(agentDetail?.modelPlans.flatMap((plan) => plan.models) ?? [])
+  ];
   const chips: {
     label: string;
     tone?: "accent" | "success" | "warning" | undefined;
     value: string | null;
   }[] = [
-    { label: labels.agentTarget, value: task.agentTargetId },
-    { label: labels.model, value: task.model },
+    {
+      label: labels.agentTarget,
+      value: task.agentTargetId
+        ? (assignmentCatalog?.agents?.find(
+            (agent) => agent.agentTargetId === task.agentTargetId
+          )?.label ?? task.agentTargetId)
+        : null
+    },
+    {
+      label: labels.model,
+      value: assignmentOptionLabel(modelOptions, task.model)
+    },
     {
       label: labels.permissionMode,
       tone: permissionModeAssignmentTone(task.permissionModeId),
-      value: task.permissionModeId
+      value: assignmentOptionLabel(
+        (agentDetail?.permissionModes ?? []).map((mode) => ({
+          label: mode.label,
+          value: mode.id
+        })),
+        task.permissionModeId
+      )
     },
-    { label: labels.reasoningEffort, value: task.reasoningEffort },
+    {
+      label: labels.reasoningEffort,
+      value: assignmentOptionLabel(
+        agentDetail?.reasoningEfforts ?? [],
+        task.reasoningEffort
+      )
+    },
     {
       label: labels.parallelizable,
       tone: "accent" as const,

--- a/packages/agent/gui/workspaceWorkflow/tuttiModePlan/TuttiModePlanTaskAssignmentEditor.tsx
+++ b/packages/agent/gui/workspaceWorkflow/tuttiModePlan/TuttiModePlanTaskAssignmentEditor.tsx
@@ -62,6 +62,18 @@ export function permissionModeAssignmentTone(
   }
 }
 
+export function assignmentOptionLabel(
+  options: readonly { label: string; value: string }[],
+  value: string | null | undefined
+): string | null {
+  const normalizedValue = value?.trim() ?? "";
+  if (!normalizedValue) return null;
+  return (
+    options.find((option) => option.value === normalizedValue)?.label ??
+    normalizedValue
+  );
+}
+
 /**
  * Per-task assignment selectors for the single review checkpoint, rendered as
  * one composer-styled row. Option catalogs are agent-scoped and supplied by
@@ -164,10 +176,7 @@ export function TuttiModePlanTaskAssignmentEditor({
         disabled={disabled || !agentValue || detailPending}
         fieldLabel={labels.model}
         notSpecifiedLabel={labels.notSpecified}
-        options={modelOptions.map((model) => ({
-          label: model,
-          value: model
-        }))}
+        options={modelOptions}
         pending={detailPending}
         pendingLabel={labels.assignmentOptionsLoading}
         value={modelValue}
@@ -191,10 +200,7 @@ export function TuttiModePlanTaskAssignmentEditor({
         disabled={disabled || !agentValue || detailPending}
         fieldLabel={labels.reasoningEffort}
         notSpecifiedLabel={labels.notSpecified}
-        options={(agentDetail?.reasoningEfforts ?? []).map((effort) => ({
-          label: effort,
-          value: effort
-        }))}
+        options={agentDetail?.reasoningEfforts ?? []}
         pending={detailPending}
         pendingLabel={labels.assignmentOptionsLoading}
         value={effortValue}
@@ -341,9 +347,7 @@ function AssignmentValueSelect({
   value: string;
 }): React.JSX.Element {
   const known = options.some((option) => option.value === value);
-  const selectedLabel = value
-    ? (options.find((option) => option.value === value)?.label ?? value)
-    : null;
+  const selectedLabel = assignmentOptionLabel(options, value);
   return (
     <Select
       disabled={disabled}

--- a/packages/agent/gui/workspaceWorkflow/tuttiModePlan/useTuttiModePlanPanels.spec.tsx
+++ b/packages/agent/gui/workspaceWorkflow/tuttiModePlan/useTuttiModePlanPanels.spec.tsx
@@ -268,10 +268,10 @@ describe("useTuttiModePlanPanels", () => {
     );
     const loadAgentOptions = vi.fn(() =>
       Promise.resolve({
-        models: ["gpt-5.4"],
+        models: [{ value: "gpt-5.4", label: "GPT-5.4" }],
         modelPlans: [],
         permissionModes: [{ id: "auto", label: "Auto" }],
-        reasoningEfforts: ["high"]
+        reasoningEfforts: [{ value: "high", label: "High" }]
       })
     );
     const runtime: TuttiModePlanReviewRuntime = {
@@ -291,7 +291,7 @@ describe("useTuttiModePlanPanels", () => {
     expect(
       rendered.result.current.assignmentCatalog.optionsByAgentId["codex"]
         ?.models
-    ).toEqual(["gpt-5.4"]);
+    ).toEqual([{ value: "gpt-5.4", label: "GPT-5.4" }]);
 
     // "Request changes" -> agent revises -> revision_created invalidation.
     await act(async () => {
@@ -320,16 +320,16 @@ describe("useTuttiModePlanPanels", () => {
       | Parameters<TuttiModePlanReviewRuntime["subscribe"]>[1]
       | undefined;
     const refreshed = deferred<{
-      models: string[];
+      models: { value: string; label: string }[];
       modelPlans: never[];
       permissionModes: { id: string; label: string }[];
-      reasoningEfforts: string[];
+      reasoningEfforts: { value: string; label: string }[];
     }>();
     const stale = {
-      models: ["gpt-5.4"],
+      models: [{ value: "gpt-5.4", label: "GPT-5.4" }],
       modelPlans: [],
       permissionModes: [{ id: "auto", label: "Auto" }],
-      reasoningEfforts: ["high"]
+      reasoningEfforts: [{ value: "high", label: "High" }]
     };
     const loadAgentOptions = vi
       .fn()
@@ -355,7 +355,7 @@ describe("useTuttiModePlanPanels", () => {
     expect(
       rendered.result.current.assignmentCatalog.optionsByAgentId["codex"]
         ?.models
-    ).toEqual(["gpt-5.4"]);
+    ).toEqual([{ value: "gpt-5.4", label: "GPT-5.4" }]);
 
     act(() => {
       invalidationListener?.({
@@ -368,20 +368,20 @@ describe("useTuttiModePlanPanels", () => {
     expect(
       rendered.result.current.assignmentCatalog.optionsByAgentId["codex"]
         ?.models
-    ).toEqual(["gpt-5.4"]);
+    ).toEqual([{ value: "gpt-5.4", label: "GPT-5.4" }]);
 
     await act(async () =>
       refreshed.resolve({
-        models: ["gpt-5.5"],
+        models: [{ value: "gpt-5.5", label: "GPT-5.5" }],
         modelPlans: [],
         permissionModes: [{ id: "auto", label: "Auto" }],
-        reasoningEfforts: ["xhigh"]
+        reasoningEfforts: [{ value: "xhigh", label: "Extra high" }]
       })
     );
     expect(
       rendered.result.current.assignmentCatalog.optionsByAgentId["codex"]
         ?.models
-    ).toEqual(["gpt-5.5"]);
+    ).toEqual([{ value: "gpt-5.5", label: "GPT-5.5" }]);
   });
 
   it("retries a failed assignment directory load on the next refresh", async () => {

--- a/packages/agent/gui/workspaceWorkflow/workspaceWorkflowRuntime.tsx
+++ b/packages/agent/gui/workspaceWorkflow/workspaceWorkflowRuntime.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, type JSX, type ReactNode } from "react";
+import type { AgentActivityComposerSettingOption } from "@tutti-os/agent-activity-core";
 import type { TuttiModePlanReviewSnapshot } from "./tuttiModePlan/tuttiModePlanPanelProjection";
 
 export interface TuttiModePlanReviewUpdate {
@@ -73,14 +74,14 @@ export interface TuttiModePlanAssignmentAgentOption {
 
 export interface TuttiModePlanAssignmentAgentDetail {
   /** Provider-native models usable without a model plan. */
-  models: readonly string[];
+  models: readonly AgentActivityComposerSettingOption[];
   modelPlans: readonly {
     modelPlanId: string;
     label: string;
-    models: readonly string[];
+    models: readonly AgentActivityComposerSettingOption[];
   }[];
   permissionModes: readonly { id: string; label: string }[];
-  reasoningEfforts: readonly string[];
+  reasoningEfforts: readonly AgentActivityComposerSettingOption[];
 }
 
 export interface TuttiPlanIssueTaskSnapshot {

--- a/packages/agent/runtimeprep/README.md
+++ b/packages/agent/runtimeprep/README.md
@@ -166,6 +166,14 @@ an isolated extra skill.
 `Prepare` and `RenderSkillBundle` use the same resolver, so provider files and
 the skill-bundle API cannot drift.
 
+The canonical Tutti CLI skill treats the daemon and CLI as the only supported
+execution control plane. Provider Agents must not inspect or modify Tutti's
+backing SQLite databases to infer runtime state or bypass a rejected command.
+When the source Agent has the Tutti execution snapshot capability, the skill
+also renders the checkpoint/action matrix and a bounded recovery protocol:
+refresh an outdated fence once, correct a documented mutation schema once, and
+report a repeated rejection with its stable reason and hint.
+
 ## Product Boundaries
 
 The module must not import `services/tuttid/*`. Product adapters translate

--- a/packages/agent/runtimeprep/README.md
+++ b/packages/agent/runtimeprep/README.md
@@ -92,7 +92,9 @@ provider runtime policy and dynamic skill bundles by default; set
 use, and computer use. `CoreSkillsPack` includes the provider-neutral Tutti
 workflow skills plus `tutti-model-allocation`, whose C0-C3 policy combines the
 current Tutti Mode effect/speed preferences with live composer model catalogs
-and derives speed's bounded 1-4 parallel planning target.
+and derives speed's bounded 1-4 parallel planning target. Allocation compares
+joint Agent/model candidates across every plausible target without favoring the
+planning Agent, its current model, or provider defaults.
 A non-desktop deployment should compose its own profile from `CoreSkillsPack`
 and deployment-owned packs instead of copying the desktop-host policy:
 

--- a/packages/agent/runtimeprep/command_test_helpers_test.go
+++ b/packages/agent/runtimeprep/command_test_helpers_test.go
@@ -76,6 +76,7 @@ func testCommandCapabilities() []CommandCapability {
 		command("issue-manager.issue.run.complete", []string{"issue", "run", "complete"}, []string{"issue-id", "run-id", "status"}, []string{"summary", "outputs"}),
 		command("issue-manager.issue.task.run.complete", []string{"issue", "task", "run", "complete"}, []string{"issue-id", "task-id", "run-id", "status"}, []string{"summary", "outputs"}),
 		command("issue-manager.issue.topic.list", []string{"issue", "topic", "list"}, []string{"issue-id"}, nil),
+		command("tutti-mode-plan.plan.issue.get", []string{"plan", "issue", "get"}, []string{"issue-id"}, nil),
 		command("workspace-apps.app.open", []string{"app", "open"}, []string{"app-id"}, nil),
 		command("references.task.list", []string{"reference", "list"}, []string{"source", "id"}, []string{"group-id"}),
 		command("agent-context.agent.list", []string{"agent", "list"}, nil, []string{"agent-id"}),

--- a/packages/agent/runtimeprep/provider_skill_test.go
+++ b/packages/agent/runtimeprep/provider_skill_test.go
@@ -139,9 +139,29 @@ func TestRenderSkillBundleIncludesGuideAndOptionalSkills(t *testing.T) {
 		t.Fatalf("model allocation parallel policy = %q", modelAllocation.Content)
 	}
 	modelTiers, ok := skillBundleFileContent(modelAllocation, tuttiModelAllocationReferencePath)
-	if !ok || !strings.Contains(modelTiers, "`gpt-5.6-sol`") ||
-		!strings.Contains(modelTiers, "`anthropic/claude-opus-4.8`") {
-		t.Fatalf("model tier reference = %q", modelTiers)
+	for _, expected := range []string{
+		"`gpt-5.6-luna`",
+		"`gpt-5.6-terra`",
+		"`gpt-5.6-sol`",
+		"`gpt-5.6-sol-pro`",
+		"`composer-2.5`",
+		"`grok-4.5`",
+		"`kimi-k3`",
+		"`moonshotai/kimi-k3`",
+		"`anthropic/claude-opus-4.8`",
+	} {
+		if !ok || !strings.Contains(modelTiers, expected) {
+			t.Fatalf("model tier reference missing %q: %q", expected, modelTiers)
+		}
+	}
+	for _, expected := range []string{
+		"Compare joint `(agentTargetId, model, reasoningEffort, permissionModeId)`",
+		"receive no suitability bonus",
+		"prefer a non-planning target",
+	} {
+		if !strings.Contains(modelAllocation.Content, expected) {
+			t.Fatalf("model allocation skill missing anti-affinity rule %q: %q", expected, modelAllocation.Content)
+		}
 	}
 	browser := skillBundleRecord(bundle.Skills, browserUseSkillName).Content
 	computer := skillBundleRecord(bundle.Skills, computerUseSkillName).Content

--- a/packages/agent/runtimeprep/provider_skill_test.go
+++ b/packages/agent/runtimeprep/provider_skill_test.go
@@ -126,6 +126,18 @@ func TestRenderSkillBundleIncludesGuideAndOptionalSkills(t *testing.T) {
 		t.Fatalf("skill slugs = %q", got)
 	}
 	tuttiSkill := skillBundleRecord(bundle.Skills, tuttiSkillName)
+	for _, expected := range []string{
+		"Never inspect or modify `~/.tutti*/*.db`",
+		"tutti-dev plan issue get --issue-id <issue-id> --json",
+		"`task_failed` or `task_canceled`",
+		"Rework it with a new `taskId`",
+		"Recovery is bounded",
+		"On `inactive_checkpoint` or `stale_graph_revision`",
+	} {
+		if !strings.Contains(tuttiSkill.Content, expected) {
+			t.Fatalf("tutti skill missing recovery rule %q: %q", expected, tuttiSkill.Content)
+		}
+	}
 	guide, ok := skillBundleFileContent(tuttiSkill, commandGuideReferencePath)
 	if !ok || !strings.Contains(guide, "tutti-dev issue get --issue-id <issue-id> --json") {
 		t.Fatalf("command guide = %q", guide)

--- a/packages/agent/runtimeprep/skill_templates/tutti-cli.md
+++ b/packages/agent/runtimeprep/skill_templates/tutti-cli.md
@@ -63,7 +63,29 @@ Use this protocol for every Tutti CLI command:
 5. Use IDs from mention URIs, prior command output, or list/get commands. {{if has "agent-context.agent.list"}}Before an Agent start, use `{{command "agent-context.agent.list"}}`. {{end}}Do not invent workspace ids, app scopes, issue ids, task ids, run ids, agent ids, provider names, or session ids.
 6. If a required input is missing, ask the user or run the relevant discovery command. Follow daemon recovery hints when an error includes one.
 7. Treat unknown-input or invalid-input errors as a signal to re-read current command help or the guide, not to retry with guessed flags.
+8. Treat the Tutti daemon and CLI as the only supported control plane. Never inspect or modify `~/.tutti*/*.db` or another backing SQLite database to recover state or bypass a rejected command. If the current CLI snapshot and documented recovery command do not resolve an error, report the exact command error instead.
 
+{{if has "tutti-mode-plan.plan.issue.get"}}
+
+## Tutti Mode Execution Recovery
+
+The `plan issue ...` scope is the source Agent's execution control plane. At every durable wake, first run `{{command "tutti-mode-plan.plan.issue.get" (args "issue-id" "<issue-id>")}}` once. Use only its `activeCheckpoint`, `graphRevision`, `readyTaskIds`, `blockerReason`, and `allowedActions`; do not reuse a revision from an older wake or infer the next revision.
+
+Checkpoint actions:
+
+- `initial_schedule`: schedule an exact ready task set, mutate the graph, or stop. Do not acknowledge.
+- `task_settled`: schedule or mutate follow-up work. Acknowledge only when another Run is active or a later checkpoint is pending.
+- `task_failed` or `task_canceled`: never update or reschedule the terminal task. Rework it with a new `taskId`; omitted launch settings and dependencies inherit from the old task. Then schedule the replacement with the `graphRevision` returned by the successful mutation.
+- `all_tasks_terminal`: complete Goal Review when satisfied, or mutate and schedule exact follow-up work. Do not acknowledge.
+
+Recovery is bounded:
+
+1. On `inactive_checkpoint` or `stale_graph_revision`, refresh with `plan issue get` once and retry the intended command once with the returned fence.
+2. On `invalid_mutation_operation`, read `tutti plan issue mutate --help` once, correct the documented `kind`/`taskId`/`task` schema, and retry once.
+3. On task, dependency, target, capacity, budget, or dispatch rejection, follow the returned hint and snapshot. Do not cycle through unrelated commands.
+4. If the same reason remains after the bounded retry, report the exact reason and hint. Do not inspect SQLite or mutate backing state.
+
+{{end}}
 App window opening:
 
 {{if has "workspace-apps.app.open"}}

--- a/packages/agent/runtimeprep/skill_templates/tutti-model-allocation-model-tiers.md
+++ b/packages/agent/runtimeprep/skill_templates/tutti-model-allocation-model-tiers.md
@@ -1,44 +1,69 @@
 # Model Tier Reference
 
-This is a routing prior adapted from the packaged OpenSquilla provider ladders
-at revision `d8652b72` (2026-07-28), plus Tutti-native families visible in this
-repository. It is not a benchmark result or an availability catalog.
+This routing prior combines the packaged OpenSquilla provider ladders at
+revision `d8652b72` (2026-07-28), Tutti live-catalog evidence, and current
+vendor descriptions. It is neither a benchmark result nor an availability
+catalog.
 
 Always intersect this table with the exact models returned by the current
 target's `agent composer-options` command. Never copy an unavailable id from
 this file into a plan.
 
-## OpenSquilla ladders
+## Provider ladders
 
-| Provider        | C0                              | C1                                         | C2                                | C3                                         | Vision route                 |
-| --------------- | ------------------------------- | ------------------------------------------ | --------------------------------- | ------------------------------------------ | ---------------------------- |
-| OpenAI          | `gpt-5.4-nano`                  | `gpt-5.4-mini`                             | `gpt-5.5` medium effort           | `gpt-5.5` high effort                      | Use current catalog evidence |
-| OpenRouter      | `deepseek/deepseek-v4-flash`    | `deepseek/deepseek-v4-pro`                 | `z-ai/glm-5.2`                    | `anthropic/claude-opus-4.8`                | `moonshotai/kimi-k2.6`       |
-| DashScope       | `qwen3.6-flash`                 | `qwen3.7-plus`                             | `qwen3.7-max`                     | `qwen3.7-max`                              | Use current catalog evidence |
-| Qwen Token Plan | `qwen3.6-flash`                 | `qwen3.7-plus`                             | `qwen3.7-max`                     | `qwen3.8-max-preview`                      | `qwen3.7-plus`               |
-| DeepSeek        | `deepseek-v4-flash` no thinking | `deepseek-v4-flash` low thinking           | `deepseek-v4-pro` medium thinking | `deepseek-v4-pro` high thinking            | Use current catalog evidence |
-| Gemini          | `gemini-3.1-flash-lite`         | `gemini-3.5-flash`                         | `gemini-3.1-pro-preview`          | `gemini-3.1-pro-preview` high thinking     | Use current catalog evidence |
-| Zhipu           | `glm-5-turbo`                   | `glm-5`                                    | `glm-5.1`                         | `glm-5.2`                                  | Use current catalog evidence |
-| Moonshot        | `kimi-k2.6` low thinking        | `kimi-k2.6` medium thinking                | `kimi-k2.6` medium thinking       | `kimi-k2.7-code`                           | `kimi-k2.6`                  |
-| Volcengine      | `doubao-seed-2-0-lite-260215`   | `doubao-seed-2-0-lite-260215` low thinking | `doubao-seed-2-0-pro-260215`      | `doubao-seed-2-0-pro-260215` high thinking | Use current catalog evidence |
-| BytePlus        | `seed-2-0-lite-260228`          | same model, low thinking                   | same model, medium thinking       | same model, high thinking                  | Use current catalog evidence |
-| TokenRhythm     | `deepseek-v4-flash`             | `deepseek-v4-pro`                          | `kimi-k2.7-code`                  | `glm-5.2`                                  | `kimi-k2.6`                  |
+| Provider        | C0                                   | C1                                         | C2                                     | C3                                                                        | Vision route                 |
+| --------------- | ------------------------------------ | ------------------------------------------ | -------------------------------------- | ------------------------------------------------------------------------- | ---------------------------- |
+| OpenAI          | `gpt-5.6-luna` low effort            | `gpt-5.6-luna` medium effort               | `gpt-5.6-terra` medium/high effort     | `gpt-5.6-sol` high/max/ultra; Sol Pro when advertised                     | Use current catalog evidence |
+| OpenAI legacy   | `gpt-5.4-nano`                       | `gpt-5.4-mini`                             | `gpt-5.5` medium effort                | `gpt-5.5` high effort                                                     | Use current catalog evidence |
+| Cursor          | `composer-2.5` fast, overqualified   | `composer-2.5` fast                        | `composer-2.5` standard or fast        | `composer-2.5` for long-horizon coding only                               | Current catalog evidence     |
+| Cursor Grok     | `grok-4.5` low effort, overqualified | `grok-4.5` low effort                      | `grok-4.5` medium effort               | `grok-4.5` high effort                                                    | Current catalog evidence     |
+| SpaceXAI        | `grok-4.5` low effort, overqualified | `grok-4.5` low effort                      | `grok-4.5` medium effort               | `grok-4.5` high effort                                                    | `grok-4.5`                   |
+| OpenRouter      | `deepseek/deepseek-v4-flash`         | `deepseek/deepseek-v4-pro`                 | `z-ai/glm-5.2`                         | `anthropic/claude-opus-4.8`; `moonshotai/kimi-k3` for long-context coding | `moonshotai/kimi-k3`         |
+| DashScope       | `qwen3.6-flash`                      | `qwen3.7-plus`                             | `qwen3.7-max`                          | `qwen3.7-max`                                                             | Use current catalog evidence |
+| Qwen Token Plan | `qwen3.6-flash`                      | `qwen3.7-plus`                             | `qwen3.7-max`                          | `qwen3.8-max-preview`                                                     | `qwen3.7-plus`               |
+| DeepSeek        | `deepseek-v4-flash` no thinking      | `deepseek-v4-flash` low thinking           | `deepseek-v4-pro` medium thinking      | `deepseek-v4-pro` high thinking                                           | Use current catalog evidence |
+| Gemini          | `gemini-3.1-flash-lite`              | `gemini-3.5-flash`                         | `gemini-3.1-pro-preview`               | `gemini-3.1-pro-preview` high thinking                                    | Use current catalog evidence |
+| Zhipu           | `glm-5-turbo`                        | `glm-5`                                    | `glm-5.1`                              | `glm-5.2`                                                                 | Use current catalog evidence |
+| Moonshot        | `kimi-k2.6` low thinking             | `kimi-k2.6` medium thinking                | `kimi-k2.7-code`; `kimi-k3` low effort | `kimi-k3` high/max effort                                                 | `kimi-k3`                    |
+| Volcengine      | `doubao-seed-2-0-lite-260215`        | `doubao-seed-2-0-lite-260215` low thinking | `doubao-seed-2-0-pro-260215`           | `doubao-seed-2-0-pro-260215` high thinking                                | Use current catalog evidence |
+| BytePlus        | `seed-2-0-lite-260228`               | same model, low thinking                   | same model, medium thinking            | same model, high thinking                                                 | Use current catalog evidence |
+| TokenRhythm     | `deepseek-v4-flash`                  | `deepseek-v4-pro`                          | `kimi-k2.7-code`                       | `glm-5.2`; `kimi-k3` for long-context coding                              | `kimi-k3`                    |
 
-## Tutti-native family additions
+## Differentiated route notes
 
-Use these only when the exact family is present in current
-`composer-options`.
+Use these only when the exact route is present in current `composer-options`.
+A tier is task-shape-specific: a coding-specialist C3 route is not automatically
+the best architecture, research, or final-synthesis route.
 
-| Family or exact model    | Prior tier | Notes                                                                      |
-| ------------------------ | ---------- | -------------------------------------------------------------------------- |
-| `gpt-5.6-terra`          | C2         | Balanced agentic coding model for everyday work                            |
-| `gpt-5.6-sol`            | C3         | Frontier agentic coding model for the hardest implementation and review    |
-| Claude Haiku family      | C0-C1      | Prefer for bounded, latency-sensitive work                                 |
-| Claude Sonnet family     | C2         | Prefer for substantial implementation and debugging                        |
-| Claude Opus family       | C3         | Prefer for architecture, deep review, and high-stakes synthesis            |
-| Gemini Flash-Lite family | C0         | Prefer for the fastest simple work                                         |
-| Gemini Flash family      | C1         | Balanced low-latency route                                                 |
-| Gemini Pro family        | C2-C3      | Use current description and reasoning controls to distinguish the top tier |
+| Family or exact route                                        | Prior tier  | Prefer for                                                                | Constraint                                                                |
+| ------------------------------------------------------------ | ----------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `gpt-5.6-luna`                                               | C1          | Fast, cost-efficient bounded and everyday coding                          | Use Terra or Sol when task/effect requires C2 or C3                       |
+| `gpt-5.6-terra`                                              | C2          | Balanced everyday implementation, debugging, and integration              | Do not prefer it over Sol solely because it is the planner's default      |
+| `gpt-5.6-sol`, `gpt-5.6-sol-pro`                             | C3          | Hard implementation, architecture, deep review, and final synthesis       | Prefer Sol Pro only when advertised; never synthesize a `-pro` route      |
+| `composer-2.5` and `composer-2.5[...]`                       | C2-C3       | Fast hands-on coding and sustained long-running implementation            | Count as C3 only for evidence-backed agentic coding; fast keeps base tier |
+| `grok-4.5`, `grok-4.5[...]`, `x-ai/grok-4.5`, `xai/grok-4.5` | C3          | Fast frontier coding, engineering, and tool-heavy agentic work            | Requested-origin entries are not availability evidence                    |
+| Kimi K3 family                                               | C2-C3       | Very long context, large repositories, multimodal and long-horizon coding | Low effort is C2; high/max is C3                                          |
+| Claude Haiku family                                          | C0-C1       | Bounded, latency-sensitive work                                           | Use current family generation                                             |
+| Claude Sonnet family                                         | C2          | Substantial implementation and debugging                                  | Use current family generation                                             |
+| Claude Opus family                                           | C3          | Architecture, deep review, and high-stakes synthesis                      | Use current family generation                                             |
+| Gemini Flash-Lite / Flash / Pro families                     | C0/C1/C2-C3 | Fast simple / balanced low-latency / strong multimodal work               | Use description and reasoning controls to distinguish Pro's top tier      |
+
+## Route aliases
+
+Classify aliases as one family, but preserve the exact value returned by
+`composer-options` in the plan:
+
+- Kimi Open Platform/Codex: `kimi-k3`; Claude-compatible catalogs may return
+  `kimi-k3[1m]`.
+- OpenAI-compatible plans may namespace GPT routes, for example
+  `openai/gpt-5.6-sol-pro`; classify the family but preserve the namespaced id.
+- Kimi Code: `k3` and `k3-256k`; the 256K route keeps K3's tier but does not
+  satisfy a task that requires more than 256K context.
+- OpenRouter: `moonshotai/kimi-k3`.
+- Cursor Composer: parameterized values such as
+  `composer-2.5[fast=true]`; standard and fast keep the same capability tier.
+- Cursor Grok: preserve bare or parameterized `grok-4.5` values exactly; do not
+  substitute a Model Plan's namespaced value.
 
 ## Family inference
 
@@ -55,5 +80,16 @@ When an exact model is absent from the table:
    as C3 priors.
 7. Treat `turbo` as a speed signal, not automatically as a lower capability
    tier.
-8. Do not infer image support, context size, tool support, or availability from
+8. Do not give the planning Agent, current provider/model, or a provider default
+   any family-inference bonus.
+9. Do not infer image support, context size, tool support, or availability from
    the name.
+
+## Refresh anchors
+
+When updating this prior, recheck the current runtime catalog and the vendor
+descriptions for [GPT-5.6](https://openai.com/index/gpt-5-6/),
+[Composer 2.5](https://cursor.com/changelog/composer-2-5),
+[Grok 4.5](https://docs.x.ai/developers/models/grok-4.5), and
+[Kimi K3](https://www.kimi.com/help/kimi-api/api-model-selection). Vendor
+descriptions inform task fit; they never override live availability evidence.

--- a/packages/agent/runtimeprep/skill_templates/tutti-model-allocation.md
+++ b/packages/agent/runtimeprep/skill_templates/tutti-model-allocation.md
@@ -33,10 +33,16 @@ tasks to fill the target. Dependencies, ownership boundaries, safe isolation,
 budget, ready work, and workspace capacity always win. Schedule no more than
 the target at one checkpoint.
 
-### 3. Discover current launch options
+### 3. Build the joint candidate matrix
 
-Run `agent list`, then `agent composer-options` for every candidate target
-needed by the plan.
+Run `agent list` once. Shortlist every launchable target whose description and
+advertised capabilities could plausibly fit any plan task, including
+non-current targets. Run `agent composer-options` for every shortlisted target.
+
+Compare joint `(agentTargetId, model, reasoningEffort, permissionModeId)`
+candidates. Do not select an Agent first and then limit model choice to that
+Agent. Do not skip a plausible non-current target merely to avoid another
+composer-options call.
 
 ### 4. Apply hard constraints
 
@@ -46,7 +52,24 @@ needed by the plan.
   by the current commands.
 - Ignore a requested-origin model entry as proof of provider support.
 
-### 5. Classify the task
+### 5. Remove affinity bias
+
+- The planning/source Agent, its provider, its current model, and provider
+  defaults receive no suitability bonus.
+- Require both Agent fit and model fit. A strong model cannot compensate for a
+  target whose description, instructions, or call conditions conflict with the
+  task; a familiar Agent cannot compensate for a model below the required tier.
+- Rank the joint candidates from task evidence even when another Agent exposes
+  a better model than the planner's own target.
+- The planning Agent may still win when its candidate is objectively the best
+  fit or the user selected it explicitly. Record the task-fit reason; familiarity
+  with the current Agent is not a reason.
+- When candidates are equivalently qualified for safely independent work,
+  prefer a non-planning target so the planning Agent remains available for
+  coordination and final integration. Never apply this tie-breaker against a
+  stronger or safer model.
+
+### 6. Classify the task
 
 | Tier | Task shape                                                                                                     |
 | ---- | -------------------------------------------------------------------------------------------------------------- |
@@ -55,7 +78,7 @@ needed by the plan.
 | C2   | Multi-step implementation, cross-module change, difficult debugging, integration, or substantial review        |
 | C3   | Architecture, high-stakes or ambiguous work, hard recovery, deep review, or final synthesis across workstreams |
 
-### 6. Derive the effect floor
+### 7. Derive the effect floor
 
 | Effect | Model floor | Verification floor                                                     |
 | ------ | ----------- | ---------------------------------------------------------------------- |
@@ -67,7 +90,7 @@ needed by the plan.
 The required tier is `max(task tier, effect floor)`. A low effect never makes an
 intrinsically difficult or high-risk task safe for a weak model.
 
-### 7. Rank eligible models
+### 8. Rank eligible models
 
 | Speed  | Choice within the eligible set                                                                                |
 | ------ | ------------------------------------------------------------------------------------------------------------- |
@@ -76,9 +99,10 @@ intrinsically difficult or high-risk task safe for a weak model.
 | 60-84  | Prefer the lowest-latency model that clearly satisfies the tier                                               |
 | 85-100 | Prefer the fastest qualified model or fast service variant; never reduce the tier or effect-derived reasoning |
 
-Rank only models at or above the required tier.
+Rank only models at or above the required tier. Apply task-shape fit before
+speed: a specialist C3 route is not automatically suitable for every C3 task.
 
-### 8. Encode the assignment
+### 9. Encode the assignment
 
 Write the exact assignment and concrete effect-scaled validation in every task
 brief. Use per-task `reasoningEffort` only when the task needs to differ from
@@ -103,6 +127,10 @@ Treat that file as a routing prior, not an availability catalog:
 
 Before proposing the plan, verify:
 
+- every plausible target was considered jointly with its models, and at least
+  one non-current target was compared when one was available;
+- no assignment received a bonus for matching the planning Agent, current
+  provider, current model, or a provider default;
 - every task clears its inherent tier and the effect floor;
 - speed changed the choice only within the qualified set;
 - the graph exposes real safe concurrency toward the parallel target without

--- a/packages/workspace/issue-manager/src/contracts/domain.ts
+++ b/packages/workspace/issue-manager/src/contracts/domain.ts
@@ -116,6 +116,8 @@ export interface IssueManagerTaskSummary {
   parallelizable?: boolean;
   acceptanceState?: IssueManagerAcceptanceState;
   acceptanceSummary?: string;
+  supersededAtUnix?: number;
+  supersededByTaskId?: string;
   createdAtUnix?: number;
   updatedAtUnix?: number;
 }

--- a/packages/workspace/issue-manager/src/ui/internal/issue/IssueManagerIssueAcceptanceState.test.ts
+++ b/packages/workspace/issue-manager/src/ui/internal/issue/IssueManagerIssueAcceptanceState.test.ts
@@ -200,3 +200,30 @@ test("issue subtask list keeps the issue-level execution task hidden while anoth
     ["task-selected"]
   );
 });
+
+test("issue subtask list excludes superseded tasks from the current board", () => {
+  const supersededTask = createTaskSummary({
+    issueId: "issue-1",
+    status: "pending_acceptance",
+    supersededAtUnix: 1_785_256_990_598,
+    supersededByTaskId: "task-replacement",
+    taskId: "task-original",
+    title: "Original task"
+  });
+  const replacementTask = createTaskSummary({
+    issueId: "issue-1",
+    status: "pending_acceptance",
+    taskId: "task-replacement",
+    title: "Replacement task"
+  });
+
+  const tasks = resolveIssueManagerVisibleSubtasks({
+    hiddenIssueRunTaskId: null,
+    tasks: [supersededTask, replacementTask]
+  });
+
+  assert.deepEqual(
+    tasks.map((task) => task.taskId),
+    ["task-replacement"]
+  );
+});

--- a/packages/workspace/issue-manager/src/ui/internal/issue/IssueManagerIssueAcceptanceState.ts
+++ b/packages/workspace/issue-manager/src/ui/internal/issue/IssueManagerIssueAcceptanceState.ts
@@ -56,11 +56,10 @@ export function resolveIssueManagerVisibleSubtasks(input: {
   tasks: readonly IssueManagerTaskSummary[];
 }): IssueManagerTaskSummary[] {
   const hiddenTaskId = input.hiddenIssueRunTaskId?.trim() ?? "";
-  if (!hiddenTaskId) {
-    return [...input.tasks];
-  }
-
   return input.tasks.filter((task) => {
-    return task.taskId !== hiddenTaskId;
+    return (
+      (task.supersededAtUnix ?? 0) <= 0 &&
+      (!hiddenTaskId || task.taskId !== hiddenTaskId)
+    );
   });
 }

--- a/packages/workspace/issues/normalize.go
+++ b/packages/workspace/issues/normalize.go
@@ -193,23 +193,53 @@ func IssueAutomaticRunAdmissionSlots(issue Issue, workspaceActiveRunCount int, i
 	return min(workspaceSlots, IssueAutomaticBudgetSlots(issue, issueActiveRunCount))
 }
 
-// IssueTaskEligibleForRun is the shared task/dependency predicate used by
-// generic dispatch and source-Agent exact-set scheduling. Callers retain
-// ownership of ordering, isolation, and transactional mutation.
-func IssueTaskEligibleForRun(task Task, tasksByID map[string]Task) bool {
-	if task.IsSuperseded() || task.Status != StatusNotStarted ||
-		strings.TrimSpace(task.AgentTargetID) == "" {
-		return false
+type TaskRunBlocker string
+
+const (
+	TaskRunBlockerSuperseded            TaskRunBlocker = "task_superseded"
+	TaskRunBlockerNotStarted            TaskRunBlocker = "task_not_started"
+	TaskRunBlockerMissingAgentTarget    TaskRunBlocker = "missing_agent_target"
+	TaskRunBlockerDependencyUnsatisfied TaskRunBlocker = "dependency_unsatisfied"
+)
+
+// IssueTaskRunBlocker is the shared task/dependency predicate used by generic
+// dispatch, source-Agent exact-set scheduling, and execution diagnostics.
+func IssueTaskRunBlocker(task Task, tasksByID map[string]Task) TaskRunBlocker {
+	if task.IsSuperseded() {
+		return TaskRunBlockerSuperseded
+	}
+	if task.Status != StatusNotStarted {
+		return TaskRunBlockerNotStarted
+	}
+	if strings.TrimSpace(task.AgentTargetID) == "" {
+		return TaskRunBlockerMissingAgentTarget
 	}
 	for _, dependencyID := range task.DependencyTaskIDs {
 		dependency, ok := tasksByID[dependencyID]
 		if !ok || dependency.IsSuperseded() ||
 			dependency.Status != StatusCompleted ||
 			dependency.AcceptanceState != AcceptanceUserAccepted {
-			return false
+			return TaskRunBlockerDependencyUnsatisfied
 		}
 	}
-	return true
+	return ""
+}
+
+// IssueTaskEligibleForRun preserves the boolean admission interface for
+// existing dispatch callers while diagnostics retain the exact blocker.
+func IssueTaskEligibleForRun(task Task, tasksByID map[string]Task) bool {
+	return IssueTaskRunBlocker(task, tasksByID) == ""
+}
+
+// ProjectReviewedSettlementTaskForRun applies the acceptance fact that an
+// exact-set schedule commits when it advances from a task_settled checkpoint.
+// The returned copy is for admission/readiness evaluation only.
+func ProjectReviewedSettlementTaskForRun(task Task) Task {
+	if task.Status == StatusPendingAcceptance {
+		task.Status = StatusCompleted
+		task.AcceptanceState = AcceptanceUserAccepted
+	}
+	return task
 }
 
 func IssueRunClientSubmitID(runID string) string {

--- a/services/tuttid/api/daemon_cli.go
+++ b/services/tuttid/api/daemon_cli.go
@@ -76,6 +76,14 @@ func writeInvokeCliCommandError(err error) tuttigenerated.InvokeCliCommandRespon
 		))
 	}
 	if errors.Is(err, cliservice.ErrInvalidInput) {
+		reason := cliservice.InvokeErrorReason(err)
+		if reason != "" {
+			return tuttigenerated.InvokeCliCommand400JSONResponse{
+				InvalidRequestErrorJSONResponse: invalidRequestError(
+					apierrors.InvalidRequest(reason, apierrors.WithCause(err)),
+				),
+			}
+		}
 		return tuttigenerated.InvokeCliCommand400JSONResponse{
 			InvalidRequestErrorJSONResponse: invalidRequestError(
 				apierrors.MalformedRequest(apierrors.WithCause(err)),

--- a/services/tuttid/api/daemon_cli_test.go
+++ b/services/tuttid/api/daemon_cli_test.go
@@ -151,6 +151,22 @@ func TestGeneratedCliWaitContractPreservesExecutionAndContinuation(t *testing.T)
 	}
 }
 
+func TestWriteInvokeCliCommandErrorPreservesStableInvalidInputReason(t *testing.T) {
+	response := writeInvokeCliCommandError(cliservice.InvalidInputReasonError(
+		"stale_graph_revision",
+		"schedule rejected. Hint: refresh the execution snapshot",
+		nil,
+	))
+	rejected, ok := response.(tuttigenerated.InvokeCliCommand400JSONResponse)
+	if !ok {
+		t.Fatalf("writeInvokeCliCommandError() = %#v", response)
+	}
+	payload := tuttigenerated.ApiErrorResponse(rejected.InvalidRequestErrorJSONResponse)
+	if payload.Error.Reason == nil || *payload.Error.Reason != "stale_graph_revision" {
+		t.Fatalf("error.reason = %#v", payload.Error.Reason)
+	}
+}
+
 type testFilteringCLIProvider struct{}
 
 func (testFilteringCLIProvider) AppID() string {

--- a/services/tuttid/biz/tuttimodeexecution/model.go
+++ b/services/tuttid/biz/tuttimodeexecution/model.go
@@ -367,9 +367,37 @@ const (
 )
 
 type MutationOperation struct {
-	Kind   MutationOperationKind `json:"kind"`
-	TaskID string                `json:"taskId,omitempty"`
-	Task   workspaceissues.Task  `json:"task,omitempty"`
+	Kind       MutationOperationKind `json:"kind"`
+	TaskID     string                `json:"taskId,omitempty"`
+	Task       workspaceissues.Task  `json:"task,omitempty"`
+	TaskFields MutationTaskFields    `json:"taskFields,omitempty"`
+}
+
+// MutationTaskFields distinguishes omitted patch fields from explicit zero
+// values. Add operations use the complete Task value; update and rework apply
+// only the fields present in the public mutation payload.
+type MutationTaskFields struct {
+	Title              bool `json:"title,omitempty"`
+	Content            bool `json:"content,omitempty"`
+	Priority           bool `json:"priority,omitempty"`
+	DueAtUnixMS        bool `json:"dueAtUnixMs,omitempty"`
+	AgentTargetID      bool `json:"agentTargetId,omitempty"`
+	ModelPlanID        bool `json:"modelPlanId,omitempty"`
+	Model              bool `json:"model,omitempty"`
+	PermissionModeID   bool `json:"permissionModeId,omitempty"`
+	ReasoningEffort    bool `json:"reasoningEffort,omitempty"`
+	ExecutionDirectory bool `json:"executionDirectory,omitempty"`
+	DependencyTaskIDs  bool `json:"dependencyTaskIds,omitempty"`
+	Parallelizable     bool `json:"parallelizable,omitempty"`
+	AutoAccept         bool `json:"autoAccept,omitempty"`
+}
+
+func (fields MutationTaskFields) Any() bool {
+	return fields.Title || fields.Content || fields.Priority || fields.DueAtUnixMS ||
+		fields.AgentTargetID || fields.ModelPlanID || fields.Model ||
+		fields.PermissionModeID || fields.ReasoningEffort ||
+		fields.ExecutionDirectory || fields.DependencyTaskIDs ||
+		fields.Parallelizable || fields.AutoAccept
 }
 
 type MutationAdmission struct {

--- a/services/tuttid/biz/tuttimodeexecution/model.go
+++ b/services/tuttid/biz/tuttimodeexecution/model.go
@@ -22,12 +22,24 @@ const (
 )
 
 type ArchiveRequest struct {
-	WorkspaceID string
-	IssueID     string
-	RequestID   string
-	RequestedBy string
-	Reason      string
-	Now         time.Time
+	WorkspaceID           string
+	IssueID               string
+	RequestID             string
+	RequestedBy           string
+	Reason                string
+	SourceSessionID       string
+	CheckpointID          string
+	ExpectedGraphRevision int64
+	Now                   time.Time
+}
+
+type SourceSessionArchiveRequest struct {
+	WorkspaceID     string
+	SourceSessionID string
+	RequestID       string
+	RequestedBy     string
+	Reason          string
+	Now             time.Time
 }
 
 type ArchiveOperation struct {

--- a/services/tuttid/biz/tuttimodeexecution/mutation.go
+++ b/services/tuttid/biz/tuttimodeexecution/mutation.go
@@ -1,0 +1,438 @@
+package tuttimodeexecution
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	workspaceissues "github.com/tutti-os/tutti/packages/workspace/issues"
+)
+
+type MutationGraphInput struct {
+	WorkspaceID string
+	IssueID     string
+	Tasks       map[string]workspaceissues.Task
+	Operations  []MutationOperation
+	Now         time.Time
+}
+
+type MutationGraphResult struct {
+	Tasks             map[string]workspaceissues.Task
+	InsertedTasks     []workspaceissues.Task
+	UpdatedTasks      []workspaceissues.Task
+	AddedTaskIDs      []string
+	UpdatedTaskIDs    []string
+	SupersededTaskIDs []string
+}
+
+func ApplyMutationGraph(input MutationGraphInput) (MutationGraphResult, error) {
+	result := MutationGraphResult{
+		Tasks:             cloneMutationTasks(input.Tasks),
+		InsertedTasks:     []workspaceissues.Task{},
+		UpdatedTasks:      []workspaceissues.Task{},
+		AddedTaskIDs:      []string{},
+		UpdatedTaskIDs:    []string{},
+		SupersededTaskIDs: []string{},
+	}
+	nextSortIndex := 1
+	replacements := make(map[string]string)
+	inserted := make(map[string]bool)
+	updated := make(map[string]bool)
+	for _, task := range result.Tasks {
+		nextSortIndex = max(nextSortIndex, task.SortIndex+1)
+	}
+
+	for _, operation := range input.Operations {
+		operation.TaskID = strings.TrimSpace(operation.TaskID)
+		operation.Task.TaskID = strings.TrimSpace(operation.Task.TaskID)
+		switch operation.Kind {
+		case MutationOperationAdd:
+			if operation.Task.TaskID == "" {
+				return MutationGraphResult{}, Reject(
+					ErrMutationRejected, RejectionInvalidMutation, "",
+				)
+			}
+			task := newMutationTask(
+				input.WorkspaceID, input.IssueID, operation.Task, nextSortIndex, input.Now,
+			)
+			nextSortIndex++
+			if _, exists := result.Tasks[task.TaskID]; exists ||
+				strings.TrimSpace(task.AgentTargetID) == "" {
+				return MutationGraphResult{}, Reject(
+					ErrMutationRejected, mutationAddRejectionReason(result.Tasks, task), task.TaskID,
+				)
+			}
+			result.Tasks[task.TaskID] = task
+			inserted[task.TaskID] = true
+			result.AddedTaskIDs = append(result.AddedTaskIDs, task.TaskID)
+		case MutationOperationUpdate:
+			if operation.TaskID == "" {
+				return MutationGraphResult{}, Reject(
+					ErrMutationRejected, RejectionInvalidMutation, "",
+				)
+			}
+			task, ok := result.Tasks[operation.TaskID]
+			if !ok {
+				return MutationGraphResult{}, Reject(
+					ErrMutationRejected, RejectionTaskNotFound, operation.TaskID,
+				)
+			}
+			if task.IsSuperseded() {
+				return MutationGraphResult{}, Reject(
+					ErrMutationRejected, RejectionTaskSuperseded, operation.TaskID,
+				)
+			}
+			if task.Status != workspaceissues.StatusNotStarted {
+				return MutationGraphResult{}, Reject(
+					ErrMutationRejected, RejectionTaskNotStarted, operation.TaskID,
+				)
+			}
+			if !operation.TaskFields.Any() {
+				return MutationGraphResult{}, Reject(
+					ErrMutationRejected, RejectionInvalidMutation, operation.TaskID,
+				)
+			}
+			applyMutationTaskPatch(&task, operation.Task, operation.TaskFields, input.Now)
+			result.Tasks[task.TaskID] = task
+			updated[task.TaskID] = true
+			result.UpdatedTaskIDs = appendUniqueMutationTaskID(result.UpdatedTaskIDs, task.TaskID)
+		case MutationOperationSupersede:
+			if operation.TaskID == "" {
+				return MutationGraphResult{}, Reject(
+					ErrMutationRejected, RejectionInvalidMutation, "",
+				)
+			}
+			task, ok := result.Tasks[operation.TaskID]
+			if !ok {
+				return MutationGraphResult{}, Reject(
+					ErrMutationRejected, RejectionTaskNotFound, operation.TaskID,
+				)
+			}
+			if task.IsSuperseded() {
+				return MutationGraphResult{}, Reject(
+					ErrMutationRejected, RejectionTaskSuperseded, operation.TaskID,
+				)
+			}
+			if task.Status == workspaceissues.StatusRunning ||
+				task.Status == workspaceissues.StatusCompleted {
+				return MutationGraphResult{}, Reject(
+					ErrMutationRejected, RejectionTaskNotStarted, operation.TaskID,
+				)
+			}
+			task.SupersededAtUnixMS = input.Now.UnixMilli()
+			task.UpdatedAtUnixMS = input.Now.UnixMilli()
+			result.Tasks[task.TaskID] = task
+			updated[task.TaskID] = true
+			result.SupersededTaskIDs = append(result.SupersededTaskIDs, task.TaskID)
+		case MutationOperationRework:
+			if operation.TaskID == "" || operation.Task.TaskID == "" {
+				return MutationGraphResult{}, Reject(
+					ErrMutationRejected, RejectionInvalidMutation, operation.TaskID,
+				)
+			}
+			oldTask, ok := result.Tasks[operation.TaskID]
+			if !ok {
+				return MutationGraphResult{}, Reject(
+					ErrMutationRejected, RejectionTaskNotFound, operation.TaskID,
+				)
+			}
+			if oldTask.IsSuperseded() {
+				return MutationGraphResult{}, Reject(
+					ErrMutationRejected, RejectionTaskSuperseded, operation.TaskID,
+				)
+			}
+			if oldTask.Status == workspaceissues.StatusRunning ||
+				oldTask.Status == workspaceissues.StatusCompleted {
+				return MutationGraphResult{}, Reject(
+					ErrMutationRejected, RejectionTaskNotStarted, operation.TaskID,
+				)
+			}
+			replacementInput := inheritMutationReworkTask(
+				oldTask, operation.Task, operation.TaskFields,
+			)
+			replacement := newMutationTask(
+				input.WorkspaceID, input.IssueID, replacementInput, nextSortIndex, input.Now,
+			)
+			nextSortIndex++
+			if _, exists := result.Tasks[replacement.TaskID]; exists {
+				return MutationGraphResult{}, Reject(
+					ErrMutationRejected, RejectionDuplicateTask, replacement.TaskID,
+				)
+			}
+			if strings.TrimSpace(replacement.AgentTargetID) == "" {
+				return MutationGraphResult{}, Reject(
+					ErrMutationRejected, RejectionMissingAgentTarget, replacement.TaskID,
+				)
+			}
+			oldTask.SupersededAtUnixMS = input.Now.UnixMilli()
+			oldTask.SupersededByTaskID = replacement.TaskID
+			oldTask.UpdatedAtUnixMS = input.Now.UnixMilli()
+			result.Tasks[oldTask.TaskID] = oldTask
+			result.Tasks[replacement.TaskID] = replacement
+			updated[oldTask.TaskID] = true
+			inserted[replacement.TaskID] = true
+			replacements[oldTask.TaskID] = replacement.TaskID
+			result.SupersededTaskIDs = append(result.SupersededTaskIDs, oldTask.TaskID)
+			result.AddedTaskIDs = append(result.AddedTaskIDs, replacement.TaskID)
+		default:
+			return MutationGraphResult{}, Reject(
+				ErrMutationRejected, RejectionInvalidMutation, operation.TaskID,
+			)
+		}
+	}
+
+	if err := rebindMutationDependents(
+		result.Tasks, replacements, updated, &result, input.Now,
+	); err != nil {
+		return MutationGraphResult{}, err
+	}
+	if err := validateMutationGraph(result.Tasks); err != nil {
+		return MutationGraphResult{}, err
+	}
+	result.InsertedTasks = mutationTasksForWrite(result.Tasks, inserted)
+	result.UpdatedTasks = mutationTasksForWrite(result.Tasks, updated)
+	return result, nil
+}
+
+func cloneMutationTasks(
+	tasks map[string]workspaceissues.Task,
+) map[string]workspaceissues.Task {
+	result := make(map[string]workspaceissues.Task, len(tasks))
+	for taskID, task := range tasks {
+		task.DependencyTaskIDs = append([]string(nil), task.DependencyTaskIDs...)
+		result[taskID] = task
+	}
+	return result
+}
+
+func newMutationTask(
+	workspaceID string,
+	issueID string,
+	task workspaceissues.Task,
+	sortIndex int,
+	now time.Time,
+) workspaceissues.Task {
+	unixMS := now.UnixMilli()
+	task.TaskID = strings.TrimSpace(task.TaskID)
+	task.WorkspaceID = workspaceID
+	task.IssueID = issueID
+	task.Title = strings.TrimSpace(task.Title)
+	task.Content = strings.TrimSpace(task.Content)
+	task.Status = workspaceissues.StatusNotStarted
+	task.Priority = workspaceissues.NormalizePriority(string(task.Priority))
+	task.DueAtUnixMS = max(task.DueAtUnixMS, 0)
+	task.AgentTargetID = strings.TrimSpace(task.AgentTargetID)
+	task.ModelPlanID = strings.TrimSpace(task.ModelPlanID)
+	task.Model = strings.TrimSpace(task.Model)
+	task.PermissionModeID = strings.TrimSpace(task.PermissionModeID)
+	task.ReasoningEffort = strings.TrimSpace(task.ReasoningEffort)
+	task.ExecutionDirectory = strings.TrimSpace(task.ExecutionDirectory)
+	task.SortIndex = sortIndex
+	task.DependencyTaskIDs = workspaceissues.NormalizeDependencyTaskIDs(task.DependencyTaskIDs)
+	task.AcceptanceState = workspaceissues.AcceptanceAgentClaimed
+	task.AcceptanceSummary = ""
+	task.LatestRunID = ""
+	task.SupersededAtUnixMS = 0
+	task.SupersededByTaskID = ""
+	task.CreatedAtUnixMS = unixMS
+	task.UpdatedAtUnixMS = unixMS
+	task.SearchText = strings.TrimSpace(task.Title + " " + task.Content)
+	return task
+}
+
+func applyMutationTaskPatch(
+	task *workspaceissues.Task,
+	patch workspaceissues.Task,
+	fields MutationTaskFields,
+	now time.Time,
+) {
+	oldTargetID := strings.TrimSpace(task.AgentTargetID)
+	if fields.Title {
+		task.Title = strings.TrimSpace(patch.Title)
+	}
+	if fields.Content {
+		task.Content = strings.TrimSpace(patch.Content)
+	}
+	if fields.Priority {
+		task.Priority = workspaceissues.NormalizePriority(string(patch.Priority))
+	}
+	if fields.DueAtUnixMS {
+		task.DueAtUnixMS = max(patch.DueAtUnixMS, 0)
+	}
+	if fields.AgentTargetID {
+		task.AgentTargetID = strings.TrimSpace(patch.AgentTargetID)
+		if strings.TrimSpace(patch.AgentTargetID) != oldTargetID {
+			if !fields.ModelPlanID {
+				task.ModelPlanID = ""
+			}
+			if !fields.Model {
+				task.Model = ""
+			}
+			if !fields.PermissionModeID {
+				task.PermissionModeID = ""
+			}
+			if !fields.ReasoningEffort {
+				task.ReasoningEffort = ""
+			}
+		}
+	}
+	if fields.ModelPlanID {
+		task.ModelPlanID = strings.TrimSpace(patch.ModelPlanID)
+	}
+	if fields.Model {
+		task.Model = strings.TrimSpace(patch.Model)
+	}
+	if fields.PermissionModeID {
+		task.PermissionModeID = strings.TrimSpace(patch.PermissionModeID)
+	}
+	if fields.ReasoningEffort {
+		task.ReasoningEffort = strings.TrimSpace(patch.ReasoningEffort)
+	}
+	if fields.ExecutionDirectory {
+		task.ExecutionDirectory = strings.TrimSpace(patch.ExecutionDirectory)
+	}
+	if fields.DependencyTaskIDs {
+		task.DependencyTaskIDs = workspaceissues.NormalizeDependencyTaskIDs(
+			patch.DependencyTaskIDs,
+		)
+	}
+	if fields.Parallelizable {
+		task.Parallelizable = patch.Parallelizable
+	}
+	if fields.AutoAccept {
+		task.AutoAccept = patch.AutoAccept
+	}
+	task.SearchText = strings.TrimSpace(task.Title + " " + task.Content)
+	task.UpdatedAtUnixMS = now.UnixMilli()
+}
+
+func inheritMutationReworkTask(
+	oldTask workspaceissues.Task,
+	replacement workspaceissues.Task,
+	fields MutationTaskFields,
+) workspaceissues.Task {
+	result := oldTask
+	result.TaskID = replacement.TaskID
+	applyMutationTaskPatch(&result, replacement, fields, time.UnixMilli(oldTask.UpdatedAtUnixMS))
+	result.TaskID = replacement.TaskID
+	return result
+}
+
+func rebindMutationDependents(
+	tasks map[string]workspaceissues.Task,
+	replacements map[string]string,
+	updated map[string]bool,
+	result *MutationGraphResult,
+	now time.Time,
+) error {
+	if len(replacements) == 0 {
+		return nil
+	}
+	dependents := make([]workspaceissues.Task, 0)
+	for _, task := range tasks {
+		if task.IsSuperseded() {
+			continue
+		}
+		dependencies := make([]string, 0, len(task.DependencyTaskIDs))
+		changed := false
+		for _, dependencyID := range task.DependencyTaskIDs {
+			reboundID := dependencyID
+			for hop := 0; ; hop++ {
+				if hop > len(replacements) {
+					return Reject(ErrMutationRejected, RejectionInvalidTaskGraph, task.TaskID)
+				}
+				replacementID, exists := replacements[reboundID]
+				if !exists {
+					break
+				}
+				reboundID = replacementID
+				changed = true
+			}
+			dependencies = append(dependencies, reboundID)
+		}
+		if !changed {
+			continue
+		}
+		if task.Status != workspaceissues.StatusNotStarted {
+			return Reject(ErrMutationRejected, RejectionTaskNotStarted, task.TaskID)
+		}
+		task.DependencyTaskIDs = workspaceissues.NormalizeDependencyTaskIDs(dependencies)
+		task.UpdatedAtUnixMS = now.UnixMilli()
+		dependents = append(dependents, task)
+	}
+	sortMutationTasks(dependents)
+	for _, task := range dependents {
+		tasks[task.TaskID] = task
+		updated[task.TaskID] = true
+		result.UpdatedTaskIDs = appendUniqueMutationTaskID(result.UpdatedTaskIDs, task.TaskID)
+	}
+	return nil
+}
+
+func validateMutationGraph(tasks map[string]workspaceissues.Task) error {
+	active := make([]workspaceissues.Task, 0, len(tasks))
+	for _, task := range tasks {
+		if task.IsSuperseded() {
+			continue
+		}
+		if strings.TrimSpace(task.Title) == "" {
+			return Reject(ErrMutationRejected, RejectionInvalidTaskGraph, task.TaskID)
+		}
+		if strings.TrimSpace(task.AgentTargetID) == "" {
+			return Reject(ErrMutationRejected, RejectionMissingAgentTarget, task.TaskID)
+		}
+		for _, dependencyID := range task.DependencyTaskIDs {
+			dependency, ok := tasks[dependencyID]
+			if !ok || dependency.IsSuperseded() {
+				return Reject(
+					ErrMutationRejected, RejectionDependencyUnsatisfied, task.TaskID,
+				)
+			}
+		}
+		active = append(active, task)
+	}
+	if len(active) == 0 || !workspaceissues.ValidateTaskDependencyGraph(active) {
+		return Reject(ErrMutationRejected, RejectionInvalidTaskGraph, "")
+	}
+	return nil
+}
+
+func mutationTasksForWrite(
+	tasks map[string]workspaceissues.Task,
+	selected map[string]bool,
+) []workspaceissues.Task {
+	result := make([]workspaceissues.Task, 0, len(selected))
+	for taskID := range selected {
+		result = append(result, tasks[taskID])
+	}
+	sortMutationTasks(result)
+	return result
+}
+
+func sortMutationTasks(tasks []workspaceissues.Task) {
+	sort.Slice(tasks, func(left int, right int) bool {
+		if tasks[left].SortIndex != tasks[right].SortIndex {
+			return tasks[left].SortIndex < tasks[right].SortIndex
+		}
+		return tasks[left].TaskID < tasks[right].TaskID
+	})
+}
+
+func mutationAddRejectionReason(
+	tasks map[string]workspaceissues.Task,
+	task workspaceissues.Task,
+) RejectionReason {
+	if _, exists := tasks[task.TaskID]; exists {
+		return RejectionDuplicateTask
+	}
+	return RejectionMissingAgentTarget
+}
+
+func appendUniqueMutationTaskID(values []string, taskID string) []string {
+	for _, value := range values {
+		if value == taskID {
+			return values
+		}
+	}
+	return append(values, taskID)
+}

--- a/services/tuttid/biz/tuttimodeexecution/mutation_test.go
+++ b/services/tuttid/biz/tuttimodeexecution/mutation_test.go
@@ -1,0 +1,155 @@
+package tuttimodeexecution
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	workspaceissues "github.com/tutti-os/tutti/packages/workspace/issues"
+)
+
+func TestApplyMutationGraphSparseReworkInheritsLaunchAndRebindsDependents(
+	t *testing.T,
+) {
+	now := time.Date(2026, time.July, 29, 2, 0, 0, 0, time.UTC)
+	failed := mutationTestTask("task-a", workspaceissues.StatusFailed, 1)
+	failed.ModelPlanID = "plan-a"
+	failed.Model = "model-a"
+	failed.PermissionModeID = "full-access"
+	failed.ReasoningEffort = "high"
+	failed.ExecutionDirectory = "/tmp/task-a"
+	failed.AutoAccept = true
+	dependent := mutationTestTask("task-b", workspaceissues.StatusNotStarted, 2)
+	dependent.DependencyTaskIDs = []string{"task-a"}
+
+	result, err := ApplyMutationGraph(MutationGraphInput{
+		WorkspaceID: "workspace-1",
+		IssueID:     "issue-1",
+		Tasks: map[string]workspaceissues.Task{
+			failed.TaskID:    failed,
+			dependent.TaskID: dependent,
+		},
+		Operations: []MutationOperation{{
+			Kind:   MutationOperationRework,
+			TaskID: failed.TaskID,
+			Task: workspaceissues.Task{
+				TaskID: "task-a-retry",
+				Title:  "Retry A",
+			},
+			TaskFields: MutationTaskFields{Title: true},
+		}},
+		Now: now,
+	})
+	if err != nil {
+		t.Fatalf("ApplyMutationGraph() error = %v", err)
+	}
+	retry := result.Tasks["task-a-retry"]
+	if retry.AgentTargetID != failed.AgentTargetID ||
+		retry.ModelPlanID != failed.ModelPlanID ||
+		retry.Model != failed.Model ||
+		retry.PermissionModeID != failed.PermissionModeID ||
+		retry.ReasoningEffort != failed.ReasoningEffort ||
+		retry.ExecutionDirectory != failed.ExecutionDirectory ||
+		retry.AutoAccept != failed.AutoAccept {
+		t.Fatalf("replacement launch fields = %#v, old = %#v", retry, failed)
+	}
+	if got := result.Tasks["task-b"].DependencyTaskIDs; !reflect.DeepEqual(
+		got, []string{"task-a-retry"},
+	) {
+		t.Fatalf("dependent dependencies = %#v", got)
+	}
+	if result.Tasks["task-a"].SupersededByTaskID != retry.TaskID ||
+		!reflect.DeepEqual(result.AddedTaskIDs, []string{"task-a-retry"}) ||
+		!reflect.DeepEqual(result.UpdatedTaskIDs, []string{"task-b"}) ||
+		!reflect.DeepEqual(result.SupersededTaskIDs, []string{"task-a"}) {
+		t.Fatalf("mutation result = %#v", result)
+	}
+}
+
+func TestApplyMutationGraphUpdateUsesPresenceAndClearsTargetSpecificDefaults(
+	t *testing.T,
+) {
+	now := time.Date(2026, time.July, 29, 2, 0, 0, 0, time.UTC)
+	task := mutationTestTask("task-a", workspaceissues.StatusNotStarted, 1)
+	task.Title = "Existing title"
+	task.Content = "Existing content"
+	task.AgentTargetID = "target-old"
+	task.ModelPlanID = "plan-old"
+	task.Model = "model-old"
+	task.PermissionModeID = "full-access"
+	task.ReasoningEffort = "high"
+	task.Parallelizable = true
+	task.AutoAccept = true
+
+	result, err := ApplyMutationGraph(MutationGraphInput{
+		WorkspaceID: "workspace-1",
+		IssueID:     "issue-1",
+		Tasks:       map[string]workspaceissues.Task{task.TaskID: task},
+		Operations: []MutationOperation{{
+			Kind:   MutationOperationUpdate,
+			TaskID: task.TaskID,
+			Task: workspaceissues.Task{
+				Content:        "",
+				AgentTargetID:  "target-new",
+				Parallelizable: false,
+				AutoAccept:     false,
+			},
+			TaskFields: MutationTaskFields{
+				Content: true, AgentTargetID: true, Parallelizable: true, AutoAccept: true,
+			},
+		}},
+		Now: now,
+	})
+	if err != nil {
+		t.Fatalf("ApplyMutationGraph() error = %v", err)
+	}
+	updated := result.Tasks[task.TaskID]
+	if updated.Content != "" ||
+		updated.AgentTargetID != "target-new" ||
+		updated.ModelPlanID != "" ||
+		updated.Model != "" ||
+		updated.PermissionModeID != "" ||
+		updated.ReasoningEffort != "" ||
+		updated.Parallelizable ||
+		updated.AutoAccept {
+		t.Fatalf("presence-aware update = %#v", updated)
+	}
+}
+
+func TestApplyMutationGraphRejectsMissingTargetWithTypedReason(t *testing.T) {
+	_, err := ApplyMutationGraph(MutationGraphInput{
+		WorkspaceID: "workspace-1",
+		IssueID:     "issue-1",
+		Tasks:       map[string]workspaceissues.Task{},
+		Operations: []MutationOperation{{
+			Kind: MutationOperationAdd,
+			Task: workspaceissues.Task{TaskID: "task-a", Title: "Task A"},
+		}},
+		Now: time.Date(2026, time.July, 29, 2, 0, 0, 0, time.UTC),
+	})
+	if !errors.Is(err, ErrMutationRejected) {
+		t.Fatalf("ApplyMutationGraph() error = %v", err)
+	}
+	reason, taskID, ok := RejectionDetails(err)
+	if !ok || reason != RejectionMissingAgentTarget || taskID != "task-a" {
+		t.Fatalf("RejectionDetails() = %q, %q, %v", reason, taskID, ok)
+	}
+}
+
+func mutationTestTask(
+	taskID string,
+	status workspaceissues.Status,
+	sortIndex int,
+) workspaceissues.Task {
+	return workspaceissues.Task{
+		WorkspaceID:     "workspace-1",
+		IssueID:         "issue-1",
+		TaskID:          taskID,
+		Title:           "Task " + taskID,
+		Status:          status,
+		AgentTargetID:   "target-a",
+		SortIndex:       sortIndex,
+		AcceptanceState: workspaceissues.AcceptanceAgentClaimed,
+	}
+}

--- a/services/tuttid/biz/tuttimodeexecution/normalize.go
+++ b/services/tuttid/biz/tuttimodeexecution/normalize.go
@@ -27,6 +27,62 @@ var ErrSwitchReviewToSelfMutationConflict = errors.New("tutti mode review fallba
 var ErrWakeRejected = errors.New("tutti mode wake operation was rejected")
 var ErrWakeIntegrity = errors.New("tutti mode wake conflicts with execution authority")
 
+type RejectionReason string
+
+const (
+	RejectionExecutionNotFound     RejectionReason = "execution_not_found"
+	RejectionWrongSourceSession    RejectionReason = "wrong_source_session"
+	RejectionInactiveExecution     RejectionReason = "inactive_execution"
+	RejectionInactiveCheckpoint    RejectionReason = "inactive_checkpoint"
+	RejectionStaleGraphRevision    RejectionReason = "stale_graph_revision"
+	RejectionTaskNotFound          RejectionReason = "task_not_found"
+	RejectionTaskNotStarted        RejectionReason = "task_not_started"
+	RejectionTaskSuperseded        RejectionReason = "task_superseded"
+	RejectionMissingAgentTarget    RejectionReason = "missing_agent_target"
+	RejectionDependencyUnsatisfied RejectionReason = "dependency_unsatisfied"
+	RejectionDispatchPaused        RejectionReason = "dispatch_paused"
+	RejectionBudgetUnavailable     RejectionReason = "budget_unavailable"
+	RejectionCapacityExhausted     RejectionReason = "capacity_exhausted"
+	RejectionParallelismRejected   RejectionReason = "parallelism_rejected"
+	RejectionDuplicateTask         RejectionReason = "duplicate_task"
+	RejectionInvalidTaskGraph      RejectionReason = "invalid_task_graph"
+	RejectionInvalidMutation       RejectionReason = "invalid_mutation_operation"
+)
+
+type RejectionError struct {
+	Kind          error
+	Reason        RejectionReason
+	SubjectTaskID string
+}
+
+func (err *RejectionError) Error() string {
+	if err == nil || err.Kind == nil {
+		return ""
+	}
+	return err.Kind.Error()
+}
+
+func (err *RejectionError) Unwrap() error {
+	if err == nil {
+		return nil
+	}
+	return err.Kind
+}
+
+func Reject(kind error, reason RejectionReason, subjectTaskID string) error {
+	return &RejectionError{
+		Kind: kind, Reason: reason, SubjectTaskID: strings.TrimSpace(subjectTaskID),
+	}
+}
+
+func RejectionDetails(err error) (RejectionReason, string, bool) {
+	var rejection *RejectionError
+	if !errors.As(err, &rejection) || rejection == nil || rejection.Reason == "" {
+		return "", "", false
+	}
+	return rejection.Reason, rejection.SubjectTaskID, true
+}
+
 func ExecutionID(issueID string) (string, bool) {
 	issueID = strings.TrimSpace(issueID)
 	if issueID == "" {

--- a/services/tuttid/data/workspace/sqlite_issue_run_admission.go
+++ b/services/tuttid/data/workspace/sqlite_issue_run_admission.go
@@ -427,10 +427,11 @@ LIMIT 1
 	if err == nil {
 		result, err = tx.ExecContext(ctx, `
 UPDATE workspace_tutti_execution_checkpoints
-SET status = 'active', updated_at_unix_ms = ?
+SET status = 'active', graph_revision = ?, updated_at_unix_ms = ?
 WHERE workspace_id = ? AND execution_id = ? AND checkpoint_id = ?
   AND status = 'pending'
-`, unixMs(admission.Now), admission.WorkspaceID, executionID, nextCheckpointID)
+`, admission.ExpectedGraphRevision, unixMs(admission.Now),
+			admission.WorkspaceID, executionID, nextCheckpointID)
 		if err != nil {
 			return fmt.Errorf("promote next Tutti mode schedule checkpoint: %w", err)
 		}
@@ -503,7 +504,15 @@ JOIN workspace_issue_run_launch_intents AS intents
  AND intents.issue_id = runs.issue_id
  AND intents.task_id = runs.task_id
  AND intents.run_id = runs.run_id
+JOIN workspace_issues AS issues
+  ON issues.workspace_id = runs.workspace_id
+ AND issues.issue_id = runs.issue_id
+JOIN workspace_tutti_executions AS executions
+  ON executions.workspace_id = runs.workspace_id
+ AND executions.issue_id = runs.issue_id
 WHERE %s
+  AND issues.dispatch_paused = 0
+  AND executions.status = 'running'
 ORDER BY runs.created_at_unix_ms ASC, runs.id ASC
 `, prefixedRunSelectColumns("runs"), strings.Join(where, " AND ")), args...)
 	if err != nil {
@@ -597,10 +606,18 @@ WHERE workspace_id = ? AND issue_id = ? AND run_id = ?
   AND EXISTS (
     SELECT 1
     FROM workspace_issue_runs AS runs
+    JOIN workspace_issues AS issues
+      ON issues.workspace_id = runs.workspace_id
+     AND issues.issue_id = runs.issue_id
+    JOIN workspace_tutti_executions AS executions
+      ON executions.workspace_id = runs.workspace_id
+     AND executions.issue_id = runs.issue_id
     WHERE runs.workspace_id = workspace_issue_run_launch_intents.workspace_id
       AND runs.issue_id = workspace_issue_run_launch_intents.issue_id
       AND runs.run_id = workspace_issue_run_launch_intents.run_id
       AND runs.status = 'running'
+      AND issues.dispatch_paused = 0
+      AND executions.status = 'running'
   )
 `, strings.TrimSpace(leaseOwner), unixMs(leaseExpires), unixMs(now),
 		strings.TrimSpace(workspaceID), strings.TrimSpace(issueID),

--- a/services/tuttid/data/workspace/sqlite_issue_run_admission.go
+++ b/services/tuttid/data/workspace/sqlite_issue_run_admission.go
@@ -185,11 +185,21 @@ WHERE workspace_id = ? AND issue_id = ?
 	if err != nil {
 		return "", fmt.Errorf("get Tutti mode execution schedule fence: %w", err)
 	}
-	if sourceSessionID != admission.SourceSessionID ||
-		graphRevision != admission.ExpectedGraphRevision ||
-		(status != string(executionbiz.StatusAwaitingSchedule) &&
-			status != string(executionbiz.StatusAwaitingMain)) {
-		return "", executionbiz.ErrScheduleRejected
+	if sourceSessionID != admission.SourceSessionID {
+		return "", executionbiz.Reject(
+			executionbiz.ErrScheduleRejected, executionbiz.RejectionWrongSourceSession, "",
+		)
+	}
+	if graphRevision != admission.ExpectedGraphRevision {
+		return "", executionbiz.Reject(
+			executionbiz.ErrScheduleRejected, executionbiz.RejectionStaleGraphRevision, "",
+		)
+	}
+	if status != string(executionbiz.StatusAwaitingSchedule) &&
+		status != string(executionbiz.StatusAwaitingMain) {
+		return "", executionbiz.Reject(
+			executionbiz.ErrScheduleRejected, executionbiz.RejectionInactiveExecution, "",
+		)
 	}
 	var checkpointStatus string
 	var checkpointRevision int64
@@ -201,13 +211,23 @@ WHERE workspace_id = ? AND execution_id = ? AND checkpoint_id = ?
 		Scan(&checkpointStatus, &checkpointRevision)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return "", executionbiz.ErrScheduleRejected
+			return "", executionbiz.Reject(
+				executionbiz.ErrScheduleRejected,
+				executionbiz.RejectionInactiveCheckpoint,
+				"",
+			)
 		}
 		return "", fmt.Errorf("get Tutti mode schedule checkpoint fence: %w", err)
 	}
-	if checkpointStatus != string(executionbiz.CheckpointStatusActive) ||
-		checkpointRevision != admission.ExpectedGraphRevision {
-		return "", executionbiz.ErrScheduleRejected
+	if checkpointStatus != string(executionbiz.CheckpointStatusActive) {
+		return "", executionbiz.Reject(
+			executionbiz.ErrScheduleRejected, executionbiz.RejectionInactiveCheckpoint, "",
+		)
+	}
+	if checkpointRevision != admission.ExpectedGraphRevision {
+		return "", executionbiz.Reject(
+			executionbiz.ErrScheduleRejected, executionbiz.RejectionStaleGraphRevision, "",
+		)
 	}
 	return executionID, nil
 }
@@ -229,10 +249,25 @@ WHERE workspace_id = ? AND issue_id = ?
 	if err != nil {
 		return nil, workspaceissues.Issue{}, fmt.Errorf("get scheduled Tutti mode Issue: %w", err)
 	}
-	if issue.PlanningSource != workspaceissues.PlanningSourceTuttiModePlan ||
-		issue.SourceSessionID != admission.SourceSessionID || issue.DispatchPaused ||
-		issue.Budget.Status != workspaceissues.BudgetStatusActive {
-		return nil, workspaceissues.Issue{}, executionbiz.ErrScheduleRejected
+	if issue.PlanningSource != workspaceissues.PlanningSourceTuttiModePlan {
+		return nil, workspaceissues.Issue{}, executionbiz.Reject(
+			executionbiz.ErrScheduleRejected, executionbiz.RejectionInactiveExecution, "",
+		)
+	}
+	if issue.SourceSessionID != admission.SourceSessionID {
+		return nil, workspaceissues.Issue{}, executionbiz.Reject(
+			executionbiz.ErrScheduleRejected, executionbiz.RejectionWrongSourceSession, "",
+		)
+	}
+	if issue.DispatchPaused {
+		return nil, workspaceissues.Issue{}, executionbiz.Reject(
+			executionbiz.ErrScheduleRejected, executionbiz.RejectionDispatchPaused, "",
+		)
+	}
+	if issue.Budget.Status != workspaceissues.BudgetStatusActive {
+		return nil, workspaceissues.Issue{}, executionbiz.Reject(
+			executionbiz.ErrScheduleRejected, executionbiz.RejectionBudgetUnavailable, "",
+		)
 	}
 
 	rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
@@ -259,11 +294,22 @@ ORDER BY sort_index ASC, id ASC
 	selected := make(map[string]workspaceissues.Task, len(admission.Runs))
 	for _, run := range admission.Runs {
 		if _, duplicate := selected[run.TaskID]; duplicate {
-			return nil, workspaceissues.Issue{}, executionbiz.ErrScheduleRejected
+			return nil, workspaceissues.Issue{}, executionbiz.Reject(
+				executionbiz.ErrScheduleRejected, executionbiz.RejectionDuplicateTask, run.TaskID,
+			)
 		}
 		task, ok := byID[run.TaskID]
-		if !ok || !workspaceissues.IssueTaskEligibleForRun(task, byID) {
-			return nil, workspaceissues.Issue{}, executionbiz.ErrScheduleRejected
+		if !ok {
+			return nil, workspaceissues.Issue{}, executionbiz.Reject(
+				executionbiz.ErrScheduleRejected, executionbiz.RejectionTaskNotFound, run.TaskID,
+			)
+		}
+		if blocker := workspaceissues.IssueTaskRunBlocker(task, byID); blocker != "" {
+			return nil, workspaceissues.Issue{}, executionbiz.Reject(
+				executionbiz.ErrScheduleRejected,
+				scheduleRejectionReasonForBlocker(blocker),
+				run.TaskID,
+			)
 		}
 		selected[run.TaskID] = task
 	}
@@ -287,9 +333,26 @@ WHERE workspace_id = ? AND status = 'running' AND TRIM(agent_session_id) <> ''
 	}
 	if requested < 1 ||
 		requested > workspaceissues.IssueAutomaticRunAdmissionSlots(issue, running, activeIssueRuns) {
-		return executionbiz.ErrScheduleRejected
+		return executionbiz.Reject(
+			executionbiz.ErrScheduleRejected, executionbiz.RejectionCapacityExhausted, "",
+		)
 	}
 	return nil
+}
+
+func scheduleRejectionReasonForBlocker(
+	blocker workspaceissues.TaskRunBlocker,
+) executionbiz.RejectionReason {
+	switch blocker {
+	case workspaceissues.TaskRunBlockerSuperseded:
+		return executionbiz.RejectionTaskSuperseded
+	case workspaceissues.TaskRunBlockerNotStarted:
+		return executionbiz.RejectionTaskNotStarted
+	case workspaceissues.TaskRunBlockerMissingAgentTarget:
+		return executionbiz.RejectionMissingAgentTarget
+	default:
+		return executionbiz.RejectionDependencyUnsatisfied
+	}
 }
 
 func insertTuttiModeScheduledRuns(

--- a/services/tuttid/data/workspace/sqlite_tutti_mode_activity_inbox.go
+++ b/services/tuttid/data/workspace/sqlite_tutti_mode_activity_inbox.go
@@ -63,6 +63,7 @@ WHERE (
 ) OR (
   i.entity_kind = 'turn'
   AND tt.phase = 'settled'
+  AND tt.outcome <> 'canceled'
   AND COALESCE(tt.settled_at_unix_ms, 0) > 0
 )`
 
@@ -107,6 +108,63 @@ func (s *SQLiteStore) DrainTuttiModeSourceActivityInbox(
 		return fmt.Errorf("begin Tutti mode source activity drain: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
+	canceledRows, err := tx.QueryContext(ctx, `
+SELECT DISTINCT i.agent_session_id, i.entity_id, tt.settled_at_unix_ms
+FROM workspace_tutti_source_activity_inbox i
+JOIN workspace_agent_turns tt
+  ON tt.workspace_id = i.workspace_id
+ AND tt.agent_session_id = i.agent_session_id
+ AND tt.turn_id = i.entity_id
+WHERE i.workspace_id = ? AND i.entity_kind = 'turn'
+  AND tt.phase = 'settled' AND tt.outcome = 'canceled'
+ORDER BY i.agent_session_id, i.entity_id
+`, workspaceID)
+	if err != nil {
+		return fmt.Errorf("list canceled Tutti source Turns: %w", err)
+	}
+	type sourceCancellation struct {
+		sessionID     string
+		turnID        string
+		settledAtUnix int64
+	}
+	var cancellations []sourceCancellation
+	for canceledRows.Next() {
+		var cancellation sourceCancellation
+		if err := canceledRows.Scan(
+			&cancellation.sessionID,
+			&cancellation.turnID,
+			&cancellation.settledAtUnix,
+		); err != nil {
+			_ = canceledRows.Close()
+			return fmt.Errorf("scan canceled Tutti source Turn: %w", err)
+		}
+		cancellations = append(cancellations, cancellation)
+	}
+	if err := canceledRows.Err(); err != nil {
+		_ = canceledRows.Close()
+		return fmt.Errorf("iterate canceled Tutti source Turns: %w", err)
+	}
+	if err := canceledRows.Close(); err != nil {
+		return fmt.Errorf("close canceled Tutti source Turns: %w", err)
+	}
+	for _, cancellation := range cancellations {
+		now := time.Now().UTC()
+		if cancellation.settledAtUnix > 0 {
+			now = time.UnixMilli(cancellation.settledAtUnix).UTC()
+		}
+		if _, err := requestTuttiModeArchivesForSourceSessionTx(
+			ctx,
+			tx,
+			executionbiz.SourceSessionArchiveRequest{
+				WorkspaceID: workspaceID, SourceSessionID: cancellation.sessionID,
+				RequestID:   "source-turn-canceled:" + cancellation.turnID,
+				RequestedBy: cancellation.sessionID, Reason: "source_turn_canceled",
+				Now: now,
+			},
+		); err != nil {
+			return fmt.Errorf("archive canceled Tutti source session: %w", err)
+		}
+	}
 	rows, err := tx.QueryContext(ctx, `
 SELECT relevant.agent_session_id, MAX(relevant.activity_at_unix_ms)
 FROM (`+tuttiModeRelevantSourceActivitySelectSQL+`) relevant

--- a/services/tuttid/data/workspace/sqlite_tutti_mode_archive.go
+++ b/services/tuttid/data/workspace/sqlite_tutti_mode_archive.go
@@ -24,9 +24,17 @@ func (s *SQLiteStore) RequestTuttiModeArchive(
 	request.RequestID = strings.TrimSpace(request.RequestID)
 	request.RequestedBy = strings.TrimSpace(request.RequestedBy)
 	request.Reason = strings.TrimSpace(request.Reason)
+	request.SourceSessionID = strings.TrimSpace(request.SourceSessionID)
+	request.CheckpointID = strings.TrimSpace(request.CheckpointID)
 	request.Now = request.Now.UTC()
+	sourceScoped := request.SourceSessionID != "" || request.CheckpointID != "" ||
+		request.ExpectedGraphRevision != 0
 	if s == nil || s.writeDB == nil || request.WorkspaceID == "" || request.IssueID == "" ||
 		request.RequestID == "" || request.RequestedBy == "" || request.Reason == "" || request.Now.IsZero() {
+		return executionbiz.ArchiveOperation{}, false, executionbiz.ErrInvalidExecution
+	}
+	if sourceScoped && (request.SourceSessionID == "" || request.CheckpointID == "" ||
+		request.ExpectedGraphRevision < 1 || request.RequestedBy != request.SourceSessionID) {
 		return executionbiz.ArchiveOperation{}, false, executionbiz.ErrInvalidExecution
 	}
 	tx, err := s.writeDB.BeginTx(ctx, nil)
@@ -39,6 +47,112 @@ func (s *SQLiteStore) RequestTuttiModeArchive(
 	if err != nil {
 		return executionbiz.ArchiveOperation{}, false, err
 	}
+	operation, replayed, err := requestTuttiModeArchiveTx(
+		ctx, tx, request, execution, sourceScoped,
+	)
+	if err != nil {
+		return executionbiz.ArchiveOperation{}, false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return executionbiz.ArchiveOperation{}, false, fmt.Errorf("commit Tutti archive request: %w", err)
+	}
+	return operation, replayed, nil
+}
+
+func (s *SQLiteStore) RequestTuttiModeArchivesForSourceSession(
+	ctx context.Context,
+	request executionbiz.SourceSessionArchiveRequest,
+) ([]executionbiz.ArchiveOperation, error) {
+	request.WorkspaceID = strings.TrimSpace(request.WorkspaceID)
+	request.SourceSessionID = strings.TrimSpace(request.SourceSessionID)
+	request.RequestID = strings.TrimSpace(request.RequestID)
+	request.RequestedBy = strings.TrimSpace(request.RequestedBy)
+	request.Reason = strings.TrimSpace(request.Reason)
+	request.Now = request.Now.UTC()
+	if s == nil || s.writeDB == nil || request.WorkspaceID == "" ||
+		request.SourceSessionID == "" || request.RequestID == "" ||
+		request.RequestedBy == "" || request.Reason == "" || request.Now.IsZero() {
+		return nil, executionbiz.ErrInvalidExecution
+	}
+	tx, err := s.writeDB.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin source-session Tutti archive request: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	operations, err := requestTuttiModeArchivesForSourceSessionTx(ctx, tx, request)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit source-session Tutti archive request: %w", err)
+	}
+	return operations, nil
+}
+
+func requestTuttiModeArchivesForSourceSessionTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	request executionbiz.SourceSessionArchiveRequest,
+) ([]executionbiz.ArchiveOperation, error) {
+	rows, err := tx.QueryContext(ctx, `
+SELECT execution_id, issue_id, source_session_id, status, graph_revision
+FROM workspace_tutti_executions
+WHERE workspace_id = ? AND source_session_id = ?
+  AND status NOT IN ('completed', 'archived')
+ORDER BY created_at_unix_ms, execution_id
+`, request.WorkspaceID, request.SourceSessionID)
+	if err != nil {
+		return nil, fmt.Errorf("list source-session Tutti executions: %w", err)
+	}
+	var executions []executionbiz.Execution
+	for rows.Next() {
+		var execution executionbiz.Execution
+		var status string
+		if err := rows.Scan(
+			&execution.ID, &execution.IssueID, &execution.SourceSessionID,
+			&status, &execution.GraphRevision,
+		); err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("scan source-session Tutti execution: %w", err)
+		}
+		execution.WorkspaceID = request.WorkspaceID
+		execution.Status = executionbiz.Status(status)
+		executions = append(executions, execution)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, fmt.Errorf("iterate source-session Tutti executions: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, fmt.Errorf("close source-session Tutti executions: %w", err)
+	}
+	operations := make([]executionbiz.ArchiveOperation, 0, len(executions))
+	for _, execution := range executions {
+		operation, _, err := requestTuttiModeArchiveTx(ctx, tx, executionbiz.ArchiveRequest{
+			WorkspaceID: request.WorkspaceID, IssueID: execution.IssueID,
+			RequestID: request.RequestID, RequestedBy: request.RequestedBy,
+			Reason: request.Reason, Now: request.Now,
+		}, execution, false)
+		if err != nil {
+			return nil, err
+		}
+		operations = append(operations, operation)
+	}
+	if err := cancelTuttiSourceSessionWorkflowsTx(
+		ctx, tx, request.WorkspaceID, request.SourceSessionID, request.Now,
+	); err != nil {
+		return nil, err
+	}
+	return operations, nil
+}
+
+func requestTuttiModeArchiveTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	request executionbiz.ArchiveRequest,
+	execution executionbiz.Execution,
+	sourceScoped bool,
+) (executionbiz.ArchiveOperation, bool, error) {
 	operation, found, err := getTuttiArchiveOperationByRequestTx(
 		ctx, tx, request.WorkspaceID, execution.ID, request.RequestID,
 	)
@@ -50,6 +164,26 @@ func (s *SQLiteStore) RequestTuttiModeArchive(
 			return executionbiz.ArchiveOperation{}, false, executionbiz.ErrExecutionConflict
 		}
 		return operation, true, nil
+	}
+	if sourceScoped {
+		if execution.SourceSessionID != request.SourceSessionID ||
+			execution.GraphRevision != request.ExpectedGraphRevision {
+			return executionbiz.ArchiveOperation{}, false, executionbiz.ErrExecutionConflict
+		}
+		var activeCheckpoint int
+		if err := tx.QueryRowContext(ctx, `
+SELECT COUNT(*)
+FROM workspace_tutti_execution_checkpoints
+WHERE workspace_id = ? AND execution_id = ? AND checkpoint_id = ?
+  AND status = 'active' AND graph_revision = ?
+`, request.WorkspaceID, execution.ID, request.CheckpointID,
+			request.ExpectedGraphRevision).Scan(&activeCheckpoint); err != nil {
+			return executionbiz.ArchiveOperation{}, false,
+				fmt.Errorf("validate source-scoped Tutti archive checkpoint: %w", err)
+		}
+		if activeCheckpoint != 1 {
+			return executionbiz.ArchiveOperation{}, false, executionbiz.ErrExecutionConflict
+		}
 	}
 	if execution.Status == executionbiz.StatusArchiving {
 		return currentTuttiArchiveOperationTx(ctx, tx, request.WorkspaceID, execution.ID)
@@ -90,9 +224,6 @@ WHERE workspace_id = ? AND issue_id = ?
 	}
 	if err := cancelTuttiArchiveOperationsTx(ctx, tx, operation, request.Now); err != nil {
 		return executionbiz.ArchiveOperation{}, false, err
-	}
-	if err := tx.Commit(); err != nil {
-		return executionbiz.ArchiveOperation{}, false, fmt.Errorf("commit Tutti archive request: %w", err)
 	}
 	return operation, false, nil
 }
@@ -344,11 +475,11 @@ func cancelTuttiArchiveOperationsTx(
 		    AND status IN ('prepared', 'leased', 'dispatched', 'turn_settled')`,
 			ownerID: operation.ExecutionID},
 		{statement: `UPDATE workspace_tutti_goal_reviews SET status = 'canceled', updated_at_unix_ms = ?
-		  WHERE workspace_id = ? AND execution_id = ? AND status IN ('prepared', 'dispatched')`,
+		  WHERE workspace_id = ? AND execution_id = ? AND status IN ('prepared', 'leased', 'dispatched')`,
 			ownerID: operation.ExecutionID},
 		{statement: `UPDATE workspace_issue_run_launch_intents SET status = 'canceled', lease_owner = '',
 		  lease_expires_at_unix_ms = 0, updated_at_unix_ms = ?
-		  WHERE workspace_id = ? AND issue_id = ? AND status = 'prepared'`,
+		  WHERE workspace_id = ? AND issue_id = ? AND status IN ('prepared', 'leased')`,
 			ownerID: operation.IssueID},
 	}
 	for _, update := range updates {
@@ -361,15 +492,77 @@ func cancelTuttiArchiveOperationsTx(
 	return nil
 }
 
+func cancelTuttiSourceSessionWorkflowsTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	workspaceID string,
+	sourceSessionID string,
+	now time.Time,
+) error {
+	if _, err := tx.ExecContext(ctx, `
+UPDATE workspace_workflow_checkpoints
+SET status = 'canceled', updated_at_unix_ms = ?
+WHERE workspace_id = ? AND status = 'pending'
+  AND workflow_id IN (
+    SELECT workflow_id FROM workspace_workflows
+    WHERE workspace_id = ? AND source_session_id = ?
+      AND status IN ('pending_review', 'in_progress', 'accepted')
+  )
+`, unixMs(now), workspaceID, workspaceID, sourceSessionID); err != nil {
+		return fmt.Errorf("cancel source-session workflow checkpoints: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+UPDATE workspace_workflows
+SET status = 'canceled', updated_at_unix_ms = ?
+WHERE workspace_id = ? AND source_session_id = ?
+  AND (
+    status IN ('pending_review', 'in_progress')
+    OR (
+      status = 'accepted'
+      AND (
+        EXISTS (
+          SELECT 1 FROM workspace_tutti_executions execution
+          WHERE execution.workspace_id = workspace_workflows.workspace_id
+            AND execution.workflow_id = workspace_workflows.workflow_id
+            AND execution.status NOT IN ('completed', 'archived')
+        )
+        OR EXISTS (
+          SELECT 1 FROM workspace_workflow_operations operation
+          WHERE operation.workspace_id = workspace_workflows.workspace_id
+            AND operation.workflow_id = workspace_workflows.workflow_id
+            AND operation.status IN ('pending', 'running', 'failed')
+        )
+      )
+    )
+  )
+`, unixMs(now), workspaceID, sourceSessionID); err != nil {
+		return fmt.Errorf("cancel source-session workflows: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+UPDATE workspace_workflow_operations
+SET status = 'canceled', updated_at_unix_ms = ?, completed_at_unix_ms = ?
+WHERE workspace_id = ? AND status IN ('pending', 'running', 'failed')
+  AND workflow_id IN (
+    SELECT workflow_id FROM workspace_workflows
+    WHERE workspace_id = ? AND source_session_id = ? AND status = 'canceled'
+  )
+`, unixMs(now), unixMs(now), workspaceID, workspaceID, sourceSessionID); err != nil {
+		return fmt.Errorf("cancel source-session workflow operations: %w", err)
+	}
+	return nil
+}
+
 func getTuttiArchiveExecutionTx(
 	ctx context.Context, tx *sql.Tx, workspaceID, issueID string,
 ) (executionbiz.Execution, error) {
 	var execution executionbiz.Execution
 	var status string
 	err := tx.QueryRowContext(ctx, `
-SELECT execution_id, source_session_id, status
+SELECT execution_id, source_session_id, status, graph_revision
 FROM workspace_tutti_executions WHERE workspace_id = ? AND issue_id = ?
-`, workspaceID, issueID).Scan(&execution.ID, &execution.SourceSessionID, &status)
+`, workspaceID, issueID).Scan(
+		&execution.ID, &execution.SourceSessionID, &status, &execution.GraphRevision,
+	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return execution, executionbiz.ErrExecutionNotFound
 	}

--- a/services/tuttid/data/workspace/sqlite_tutti_mode_archive_test.go
+++ b/services/tuttid/data/workspace/sqlite_tutti_mode_archive_test.go
@@ -81,6 +81,87 @@ SELECT
 	}
 }
 
+func TestRequestTuttiModeArchiveFencesSourceAgentByActiveCheckpointRevision(
+	t *testing.T,
+) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openTuttiModeExecutionStore(t)
+	now := time.UnixMilli(1_700_001_025_000).UTC()
+	prepareTuttiModeExecutionWorkspace(
+		t, store, "workspace-source-archive", "workflow-source-archive",
+		"source-archive-agent", now,
+	)
+	issues := workspaceissues.Service{
+		Store: store, Clock: func() time.Time { return now },
+	}
+	issue, tasks := prepareTuttiModeIssueGraph(
+		t, issues, "workspace-source-archive", "workflow-source-archive",
+		"source-archive-agent",
+	)
+	executions := executionservice.Service{
+		Store: store, Clock: func() time.Time { return now },
+	}
+	_, _, aggregate, err := executions.Materialize(
+		ctx,
+		executionservice.MaterializeInput{
+			Issue: issue, Tasks: tasks, WorkflowID: "workflow-source-archive",
+		},
+	)
+	if err != nil {
+		t.Fatalf("Materialize() error = %v", err)
+	}
+	checkpointID := aggregate.Checkpoints[0].ID
+	request := executionbiz.ArchiveRequest{
+		WorkspaceID: issue.WorkspaceID, IssueID: issue.IssueID,
+		RequestID: "source-stop", RequestedBy: issue.SourceSessionID,
+		Reason:          "superseded by replacement plan",
+		SourceSessionID: issue.SourceSessionID, CheckpointID: checkpointID,
+		ExpectedGraphRevision: 1, Now: now.Add(time.Minute),
+	}
+	for name, mutate := range map[string]func(*executionbiz.ArchiveRequest){
+		"wrong source": func(value *executionbiz.ArchiveRequest) {
+			value.SourceSessionID = "another-source"
+			value.RequestedBy = "another-source"
+		},
+		"wrong checkpoint": func(value *executionbiz.ArchiveRequest) {
+			value.CheckpointID = "another-checkpoint"
+		},
+		"wrong revision": func(value *executionbiz.ArchiveRequest) {
+			value.ExpectedGraphRevision = 2
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			rejected := request
+			rejected.RequestID += "-" + name
+			mutate(&rejected)
+			if _, _, err := store.RequestTuttiModeArchive(
+				ctx, rejected,
+			); !errors.Is(err, executionbiz.ErrExecutionConflict) {
+				t.Fatalf(
+					"RequestTuttiModeArchive(%s) error = %v, want conflict",
+					name, err,
+				)
+			}
+		})
+	}
+
+	first, replayed, err := store.RequestTuttiModeArchive(ctx, request)
+	if err != nil || replayed {
+		t.Fatalf(
+			"RequestTuttiModeArchive(source) = %#v/%v error=%v",
+			first, replayed, err,
+		)
+	}
+	second, replayed, err := store.RequestTuttiModeArchive(ctx, request)
+	if err != nil || !replayed || second.OperationID != first.OperationID {
+		t.Fatalf(
+			"RequestTuttiModeArchive(source replay) = %#v/%v error=%v",
+			second, replayed, err,
+		)
+	}
+}
+
 func TestCompleteTuttiModeArchiveIsIdempotentAndPreservesAuditTimestamp(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/services/tuttid/data/workspace/sqlite_tutti_mode_checkpoint_revision_recovery_test.go
+++ b/services/tuttid/data/workspace/sqlite_tutti_mode_checkpoint_revision_recovery_test.go
@@ -1,0 +1,97 @@
+package workspace
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	workspaceissues "github.com/tutti-os/tutti/packages/workspace/issues"
+	executionservice "github.com/tutti-os/tutti/services/tuttid/service/tuttimodeexecution"
+)
+
+func TestPrepareDueTuttiModeExecutionWatchdogsRebindsStaleActiveCheckpointRevision(
+	t *testing.T,
+) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openTuttiModeExecutionStore(t)
+	now := time.UnixMilli(1_700_000_000_000).UTC()
+	prepareTuttiModeExecutionWorkspace(
+		t, store, "workspace-checkpoint-recovery", "workflow-checkpoint-recovery",
+		"session-checkpoint-recovery", now,
+	)
+	issues := workspaceissues.Service{
+		Store: store, Clock: func() time.Time { return now },
+	}
+	issue, tasks := prepareTuttiModeIssueGraph(
+		t, issues, "workspace-checkpoint-recovery", "workflow-checkpoint-recovery",
+		"session-checkpoint-recovery",
+	)
+	executions := executionservice.Service{
+		Store: store, Clock: func() time.Time { return now },
+	}
+	_, _, aggregate, err := executions.Materialize(
+		ctx,
+		executionservice.MaterializeInput{
+			Issue: issue, Tasks: tasks, WorkflowID: "workflow-checkpoint-recovery",
+		},
+	)
+	if err != nil {
+		t.Fatalf("Materialize() error = %v", err)
+	}
+	checkpointID := aggregate.Checkpoints[0].ID
+	executionID := aggregate.Execution.ID
+	if _, err := store.writeDB.ExecContext(ctx, `
+UPDATE workspace_tutti_executions
+SET status = 'awaiting_main', graph_revision = 2,
+    watchdog_due_at_unix_ms = ?, updated_at_unix_ms = ?
+WHERE workspace_id = ? AND execution_id = ?
+`, now.Add(5*time.Minute).UnixMilli(), now.UnixMilli(),
+		issue.WorkspaceID, executionID); err != nil {
+		t.Fatalf("prepare execution revision error = %v", err)
+	}
+	if _, err := store.writeDB.ExecContext(ctx, `
+UPDATE workspace_tutti_execution_checkpoints
+SET kind = 'task_settled', graph_revision = 1, updated_at_unix_ms = ?
+WHERE workspace_id = ? AND execution_id = ? AND checkpoint_id = ?
+`, now.UnixMilli(), issue.WorkspaceID, executionID, checkpointID); err != nil {
+		t.Fatalf("prepare stale checkpoint revision error = %v", err)
+	}
+	if _, err := store.writeDB.ExecContext(ctx, `
+UPDATE workspace_tutti_execution_wakes
+SET status = 'turn_settled', turn_settled_at_unix_ms = ?,
+    updated_at_unix_ms = ?
+WHERE workspace_id = ? AND execution_id = ? AND checkpoint_id = ?
+`, now.UnixMilli(), now.UnixMilli(),
+		issue.WorkspaceID, executionID, checkpointID); err != nil {
+		t.Fatalf("prepare settled wake error = %v", err)
+	}
+
+	if err := store.PrepareDueTuttiModeExecutionWatchdogs(
+		ctx, issue.WorkspaceID, now,
+	); err != nil {
+		t.Fatalf("PrepareDueTuttiModeExecutionWatchdogs() error = %v", err)
+	}
+
+	var checkpointRevision, wakeSequence int64
+	var wakeStatus string
+	if err := store.readDB.QueryRowContext(ctx, `
+SELECT c.graph_revision, w.wake_sequence, w.status
+FROM workspace_tutti_execution_checkpoints c
+JOIN workspace_tutti_execution_wakes w
+  ON w.workspace_id = c.workspace_id AND w.execution_id = c.execution_id
+ AND w.checkpoint_id = c.checkpoint_id
+WHERE c.workspace_id = ? AND c.execution_id = ? AND c.checkpoint_id = ?
+ORDER BY w.wake_sequence DESC
+LIMIT 1
+`, issue.WorkspaceID, executionID, checkpointID).
+		Scan(&checkpointRevision, &wakeSequence, &wakeStatus); err != nil {
+		t.Fatalf("read recovered checkpoint error = %v", err)
+	}
+	if checkpointRevision != 2 || wakeSequence != 2 || wakeStatus != "prepared" {
+		t.Fatalf(
+			"recovered checkpoint revision/wake = %d/%d/%q, want 2/2/prepared",
+			checkpointRevision, wakeSequence, wakeStatus,
+		)
+	}
+}

--- a/services/tuttid/data/workspace/sqlite_tutti_mode_mutation.go
+++ b/services/tuttid/data/workspace/sqlite_tutti_mode_mutation.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 
 	workspaceissues "github.com/tutti-os/tutti/packages/workspace/issues"
 	executionbiz "github.com/tutti-os/tutti/services/tuttid/biz/tuttimodeexecution"
@@ -42,12 +41,33 @@ func (s *SQLiteStore) AdmitTuttiModeMutation(
 		GraphRevision: admission.ExpectedGraphRevision + 1,
 		AddedTaskIDs:  []string{}, UpdatedTaskIDs: []string{}, SupersededTaskIDs: []string{},
 	}
-	if err := applyTuttiModeMutationOperations(ctx, tx, admission, tasks, &result); err != nil {
+	graph, err := executionbiz.ApplyMutationGraph(executionbiz.MutationGraphInput{
+		WorkspaceID: admission.WorkspaceID,
+		IssueID:     admission.IssueID,
+		Tasks:       tasks,
+		Operations:  admission.Operations,
+		Now:         admission.Now,
+	})
+	if err != nil {
 		return executionbiz.MutationResult{}, err
 	}
-	if err := validateActiveTuttiModeMutationGraph(tasks); err != nil {
-		return executionbiz.MutationResult{}, err
+	for _, task := range graph.InsertedTasks {
+		if _, err := insertWorkspaceIssueTask(ctx, tx, task); err != nil {
+			return executionbiz.MutationResult{}, executionbiz.Reject(
+				executionbiz.ErrMutationRejected,
+				executionbiz.RejectionDuplicateTask,
+				task.TaskID,
+			)
+		}
 	}
+	for _, task := range graph.UpdatedTasks {
+		if err := updateTuttiModeMutationTask(ctx, tx, task); err != nil {
+			return executionbiz.MutationResult{}, err
+		}
+	}
+	result.AddedTaskIDs = graph.AddedTaskIDs
+	result.UpdatedTaskIDs = graph.UpdatedTaskIDs
+	result.SupersededTaskIDs = graph.SupersededTaskIDs
 	if err := projectScheduledTuttiModeIssue(
 		ctx, tx, admission.WorkspaceID, admission.IssueID, admission.Now,
 	); err != nil {
@@ -130,12 +150,22 @@ WHERE workspace_id = ? AND issue_id = ?
 	if err != nil {
 		return "", fmt.Errorf("get Tutti mode mutation fence: %w", err)
 	}
-	if sourceSessionID != admission.SourceSessionID ||
-		graphRevision != admission.ExpectedGraphRevision ||
-		(status != string(executionbiz.StatusAwaitingSchedule) &&
-			status != string(executionbiz.StatusAwaitingMain) &&
-			status != string(executionbiz.StatusPendingGoalReview)) {
-		return "", executionbiz.ErrMutationRejected
+	if sourceSessionID != admission.SourceSessionID {
+		return "", executionbiz.Reject(
+			executionbiz.ErrMutationRejected, executionbiz.RejectionWrongSourceSession, "",
+		)
+	}
+	if graphRevision != admission.ExpectedGraphRevision {
+		return "", executionbiz.Reject(
+			executionbiz.ErrMutationRejected, executionbiz.RejectionStaleGraphRevision, "",
+		)
+	}
+	if status != string(executionbiz.StatusAwaitingSchedule) &&
+		status != string(executionbiz.StatusAwaitingMain) &&
+		status != string(executionbiz.StatusPendingGoalReview) {
+		return "", executionbiz.Reject(
+			executionbiz.ErrMutationRejected, executionbiz.RejectionInactiveExecution, "",
+		)
 	}
 	var checkpointStatus string
 	var checkpointRevision int64
@@ -145,18 +175,30 @@ FROM workspace_tutti_execution_checkpoints
 WHERE workspace_id = ? AND execution_id = ? AND checkpoint_id = ?
 `, admission.WorkspaceID, executionID, admission.CheckpointID).
 		Scan(&checkpointStatus, &checkpointRevision)
-	if err != nil || checkpointStatus != string(executionbiz.CheckpointStatusActive) ||
-		checkpointRevision != admission.ExpectedGraphRevision {
-		return "", executionbiz.ErrMutationRejected
+	if err != nil || checkpointStatus != string(executionbiz.CheckpointStatusActive) {
+		return "", executionbiz.Reject(
+			executionbiz.ErrMutationRejected, executionbiz.RejectionInactiveCheckpoint, "",
+		)
+	}
+	if checkpointRevision != admission.ExpectedGraphRevision {
+		return "", executionbiz.Reject(
+			executionbiz.ErrMutationRejected, executionbiz.RejectionStaleGraphRevision, "",
+		)
 	}
 	var planningSource, issueSourceSessionID string
 	err = tx.QueryRowContext(ctx, `
 SELECT planning_source, source_session_id
 FROM workspace_issues WHERE workspace_id = ? AND issue_id = ?
 `, admission.WorkspaceID, admission.IssueID).Scan(&planningSource, &issueSourceSessionID)
-	if err != nil || planningSource != string(workspaceissues.PlanningSourceTuttiModePlan) ||
-		issueSourceSessionID != admission.SourceSessionID {
-		return "", executionbiz.ErrMutationRejected
+	if err != nil || planningSource != string(workspaceissues.PlanningSourceTuttiModePlan) {
+		return "", executionbiz.Reject(
+			executionbiz.ErrMutationRejected, executionbiz.RejectionInactiveExecution, "",
+		)
+	}
+	if issueSourceSessionID != admission.SourceSessionID {
+		return "", executionbiz.Reject(
+			executionbiz.ErrMutationRejected, executionbiz.RejectionWrongSourceSession, "",
+		)
 	}
 	return executionID, nil
 }
@@ -189,130 +231,6 @@ ORDER BY sort_index ASC, id ASC
 	return result, nil
 }
 
-func applyTuttiModeMutationOperations(
-	ctx context.Context,
-	tx *sql.Tx,
-	admission executionbiz.MutationAdmission,
-	tasks map[string]workspaceissues.Task,
-	result *executionbiz.MutationResult,
-) error {
-	nextSortIndex := 1
-	for _, task := range tasks {
-		nextSortIndex = max(nextSortIndex, task.SortIndex+1)
-	}
-	for _, operation := range admission.Operations {
-		switch operation.Kind {
-		case executionbiz.MutationOperationAdd:
-			task := newTuttiModeMutationTask(admission, operation.Task, nextSortIndex)
-			nextSortIndex++
-			if _, exists := tasks[task.TaskID]; exists {
-				return executionbiz.ErrMutationRejected
-			}
-			if _, err := insertWorkspaceIssueTask(ctx, tx, task); err != nil {
-				return executionbiz.ErrMutationRejected
-			}
-			tasks[task.TaskID] = task
-			result.AddedTaskIDs = append(result.AddedTaskIDs, task.TaskID)
-		case executionbiz.MutationOperationUpdate:
-			task, ok := tasks[operation.TaskID]
-			if !ok || task.IsSuperseded() || task.Status != workspaceissues.StatusNotStarted {
-				return executionbiz.ErrMutationRejected
-			}
-			mergeTuttiModeMutationTask(&task, operation.Task, admission)
-			if err := updateTuttiModeMutationTask(ctx, tx, task); err != nil {
-				return err
-			}
-			tasks[task.TaskID] = task
-			result.UpdatedTaskIDs = append(result.UpdatedTaskIDs, task.TaskID)
-		case executionbiz.MutationOperationSupersede:
-			task, ok := tasks[operation.TaskID]
-			if !ok || task.IsSuperseded() ||
-				task.Status == workspaceissues.StatusRunning ||
-				task.Status == workspaceissues.StatusCompleted {
-				return executionbiz.ErrMutationRejected
-			}
-			task.SupersededAtUnixMS = unixMs(admission.Now)
-			task.UpdatedAtUnixMS = unixMs(admission.Now)
-			if err := updateTuttiModeMutationTask(ctx, tx, task); err != nil {
-				return err
-			}
-			tasks[task.TaskID] = task
-			result.SupersededTaskIDs = append(result.SupersededTaskIDs, task.TaskID)
-		case executionbiz.MutationOperationRework:
-			oldTask, ok := tasks[operation.TaskID]
-			if !ok || oldTask.IsSuperseded() ||
-				oldTask.Status == workspaceissues.StatusRunning ||
-				oldTask.Status == workspaceissues.StatusCompleted {
-				return executionbiz.ErrMutationRejected
-			}
-			replacement := newTuttiModeMutationTask(admission, operation.Task, nextSortIndex)
-			nextSortIndex++
-			if _, exists := tasks[replacement.TaskID]; exists {
-				return executionbiz.ErrMutationRejected
-			}
-			oldTask.SupersededAtUnixMS = unixMs(admission.Now)
-			oldTask.SupersededByTaskID = replacement.TaskID
-			oldTask.UpdatedAtUnixMS = unixMs(admission.Now)
-			if err := updateTuttiModeMutationTask(ctx, tx, oldTask); err != nil {
-				return err
-			}
-			if _, err := insertWorkspaceIssueTask(ctx, tx, replacement); err != nil {
-				return executionbiz.ErrMutationRejected
-			}
-			tasks[oldTask.TaskID] = oldTask
-			tasks[replacement.TaskID] = replacement
-			result.SupersededTaskIDs = append(result.SupersededTaskIDs, oldTask.TaskID)
-			result.AddedTaskIDs = append(result.AddedTaskIDs, replacement.TaskID)
-		default:
-			return executionbiz.ErrMutationRejected
-		}
-	}
-	return nil
-}
-
-func newTuttiModeMutationTask(
-	admission executionbiz.MutationAdmission,
-	task workspaceissues.Task,
-	sortIndex int,
-) workspaceissues.Task {
-	now := unixMs(admission.Now)
-	task.WorkspaceID = admission.WorkspaceID
-	task.IssueID = admission.IssueID
-	task.Status = workspaceissues.StatusNotStarted
-	task.SortIndex = sortIndex
-	task.DependencyTaskIDs = workspaceissues.NormalizeDependencyTaskIDs(task.DependencyTaskIDs)
-	task.AcceptanceState = workspaceissues.AcceptanceAgentClaimed
-	task.AcceptanceSummary = ""
-	task.LatestRunID = ""
-	task.SupersededAtUnixMS = 0
-	task.SupersededByTaskID = ""
-	task.CreatedAtUnixMS = now
-	task.UpdatedAtUnixMS = now
-	return task
-}
-
-func mergeTuttiModeMutationTask(
-	task *workspaceissues.Task,
-	replacement workspaceissues.Task,
-	admission executionbiz.MutationAdmission,
-) {
-	task.Title = replacement.Title
-	task.Content = replacement.Content
-	task.SearchText = strings.TrimSpace(replacement.Title + " " + replacement.Content)
-	task.Priority = replacement.Priority
-	task.DueAtUnixMS = replacement.DueAtUnixMS
-	task.AgentTargetID = replacement.AgentTargetID
-	task.ModelPlanID = replacement.ModelPlanID
-	task.Model = replacement.Model
-	task.PermissionModeID = replacement.PermissionModeID
-	task.ReasoningEffort = replacement.ReasoningEffort
-	task.ExecutionDirectory = replacement.ExecutionDirectory
-	task.DependencyTaskIDs = workspaceissues.NormalizeDependencyTaskIDs(replacement.DependencyTaskIDs)
-	task.Parallelizable = replacement.Parallelizable
-	task.AutoAccept = replacement.AutoAccept
-	task.UpdatedAtUnixMS = unixMs(admission.Now)
-}
-
 func updateTuttiModeMutationTask(
 	ctx context.Context,
 	tx *sql.Tx,
@@ -340,26 +258,6 @@ WHERE workspace_id = ? AND issue_id = ? AND task_id = ?
 		return fmt.Errorf("update Tutti mode mutation task: %w", err)
 	}
 	return requireRowsAffected(result, executionbiz.ErrMutationRejected, "update Tutti mode mutation task")
-}
-
-func validateActiveTuttiModeMutationGraph(tasks map[string]workspaceissues.Task) error {
-	active := make([]workspaceissues.Task, 0, len(tasks))
-	for _, task := range tasks {
-		if task.IsSuperseded() {
-			continue
-		}
-		for _, dependencyID := range task.DependencyTaskIDs {
-			dependency, ok := tasks[dependencyID]
-			if !ok || dependency.IsSuperseded() {
-				return executionbiz.ErrMutationRejected
-			}
-		}
-		active = append(active, task)
-	}
-	if len(active) == 0 || !workspaceissues.ValidateTaskDependencyGraph(active) {
-		return executionbiz.ErrMutationRejected
-	}
-	return nil
 }
 
 func rebindTuttiModeMutationFence(

--- a/services/tuttid/data/workspace/sqlite_tutti_mode_settlement.go
+++ b/services/tuttid/data/workspace/sqlite_tutti_mode_settlement.go
@@ -577,9 +577,9 @@ ORDER BY sequence ASC LIMIT 1
 		next.Status = executionbiz.CheckpointStatusActive
 		nextCheckpointMutation, err := tx.ExecContext(ctx, `
 UPDATE workspace_tutti_execution_checkpoints
-SET status = 'active', updated_at_unix_ms = ?
+SET status = 'active', graph_revision = ?, updated_at_unix_ms = ?
 WHERE workspace_id = ? AND execution_id = ? AND checkpoint_id = ? AND status = 'pending'
-`, unixMs(admission.Now), admission.WorkspaceID, executionID, next.ID)
+`, graphRevision, unixMs(admission.Now), admission.WorkspaceID, executionID, next.ID)
 		if err != nil {
 			return executionbiz.AcknowledgeResult{}, err
 		}
@@ -589,6 +589,7 @@ WHERE workspace_id = ? AND execution_id = ? AND checkpoint_id = ? AND status = '
 		); err != nil {
 			return executionbiz.AcknowledgeResult{}, err
 		}
+		next.GraphRevision = graphRevision
 		if next.Kind == executionbiz.CheckpointKindAllTasksTerminal {
 			nextStatus = executionbiz.StatusPendingGoalReview
 			if err := prepareTuttiModeGoalReviewTx(

--- a/services/tuttid/data/workspace/sqlite_tutti_mode_wakes.go
+++ b/services/tuttid/data/workspace/sqlite_tutti_mode_wakes.go
@@ -107,6 +107,11 @@ func (s *SQLiteStore) PrepareDueTuttiModeExecutionWatchdogs(
 		return fmt.Errorf("begin Tutti mode watchdog preparation: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
+	if err := repairStaleActiveTuttiModeCheckpointRevisionsTx(
+		ctx, tx, workspaceID, now,
+	); err != nil {
+		return err
+	}
 	rows, err := tx.QueryContext(ctx, `
 SELECT execution_id, graph_revision, watchdog_due_at_unix_ms
 FROM workspace_tutti_executions
@@ -145,6 +150,58 @@ ORDER BY watchdog_due_at_unix_ms ASC, execution_id ASC
 	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit Tutti mode watchdog preparation: %w", err)
+	}
+	return nil
+}
+
+func repairStaleActiveTuttiModeCheckpointRevisionsTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	workspaceID string,
+	now time.Time,
+) error {
+	_, err := tx.ExecContext(ctx, `
+UPDATE workspace_tutti_executions
+SET watchdog_due_at_unix_ms = MIN(watchdog_due_at_unix_ms, ?),
+    updated_at_unix_ms = ?
+WHERE workspace_id = ?
+  AND status IN ('awaiting_schedule', 'running', 'awaiting_main', 'pending_goal_review')
+  AND EXISTS (
+    SELECT 1
+    FROM workspace_tutti_execution_checkpoints c
+    WHERE c.workspace_id = workspace_tutti_executions.workspace_id
+      AND c.execution_id = workspace_tutti_executions.execution_id
+      AND c.status = 'active'
+      AND c.kind IN ('task_settled', 'task_failed', 'task_canceled', 'watchdog')
+      AND c.graph_revision < workspace_tutti_executions.graph_revision
+  )
+`, unixMs(now), unixMs(now), workspaceID)
+	if err != nil {
+		return fmt.Errorf("advance stale Tutti mode checkpoint recovery: %w", err)
+	}
+	_, err = tx.ExecContext(ctx, `
+UPDATE workspace_tutti_execution_checkpoints
+SET graph_revision = (
+      SELECT e.graph_revision
+      FROM workspace_tutti_executions e
+      WHERE e.workspace_id = workspace_tutti_execution_checkpoints.workspace_id
+        AND e.execution_id = workspace_tutti_execution_checkpoints.execution_id
+    ),
+    updated_at_unix_ms = ?
+WHERE workspace_id = ?
+  AND status = 'active'
+  AND kind IN ('task_settled', 'task_failed', 'task_canceled', 'watchdog')
+  AND EXISTS (
+    SELECT 1
+    FROM workspace_tutti_executions e
+    WHERE e.workspace_id = workspace_tutti_execution_checkpoints.workspace_id
+      AND e.execution_id = workspace_tutti_execution_checkpoints.execution_id
+      AND e.status IN ('awaiting_schedule', 'running', 'awaiting_main', 'pending_goal_review')
+      AND workspace_tutti_execution_checkpoints.graph_revision < e.graph_revision
+  )
+`, unixMs(now), workspaceID)
+	if err != nil {
+		return fmt.Errorf("rebind stale active Tutti mode checkpoint revision: %w", err)
 	}
 	return nil
 }

--- a/services/tuttid/data/workspace/sqlite_workspace_workflow_recovery.go
+++ b/services/tuttid/data/workspace/sqlite_workspace_workflow_recovery.go
@@ -28,6 +28,19 @@ JOIN workspace_workflow_checkpoints c
 WHERE w.status = 'accepted'
   AND c.kind = 'task_review' AND c.status = 'accepted'
   AND o.kind = 'create_issue' AND o.status IN ('pending', 'failed')
+  AND NOT EXISTS (
+    SELECT 1
+    FROM workspace_tutti_source_activity_inbox activity
+    JOIN workspace_agent_turns source_turn
+      ON source_turn.workspace_id = activity.workspace_id
+     AND source_turn.agent_session_id = activity.agent_session_id
+     AND source_turn.turn_id = activity.entity_id
+    WHERE activity.workspace_id = w.workspace_id
+      AND activity.agent_session_id = w.source_session_id
+      AND activity.entity_kind = 'turn'
+      AND source_turn.phase = 'settled'
+      AND source_turn.outcome = 'canceled'
+  )
 ORDER BY o.created_at_unix_ms ASC, o.workspace_id ASC, o.workflow_id ASC, o.operation_id ASC
 `)
 	if err != nil {

--- a/services/tuttid/data/workspace/sqlite_workspace_workflows_test.go
+++ b/services/tuttid/data/workspace/sqlite_workspace_workflows_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 	workflowbiz "github.com/tutti-os/tutti/services/tuttid/biz/workspaceworkflow"
 )
@@ -831,6 +832,84 @@ func TestSQLiteStoreListsOnlyRecoverableAcceptedCreateIssueOperations(t *testing
 	recoverable, err = store.ListRecoverableCreateIssueOperations(ctx)
 	if err != nil || len(recoverable) != 1 || recoverable[0].Operation.Status != workflowbiz.OperationStatusFailed {
 		t.Fatalf("recoverable failed operations = %#v error=%v", recoverable, err)
+	}
+}
+
+func TestCanceledSourceTurnFencesWorkflowRecoveryBeforeInboxDrain(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := openTestSQLiteStore(t)
+	const workspaceID = "ws-canceled-source-workflow"
+	createWorkflowTestWorkspace(t, store, workspaceID)
+	now := time.UnixMilli(1_700_000_100_000).UTC()
+	createWorkflowProposalFixture(
+		t, store, workspaceID, "workflow-canceled-source", now,
+	)
+	appendInput := workflowAppendFixture(
+		workspaceID, "workflow-canceled-source", now.Add(time.Second),
+	)
+	if err := store.AppendWorkspaceWorkflowPlanRevision(ctx, appendInput); err != nil {
+		t.Fatal(err)
+	}
+	operation := workflowbiz.WorkflowOperation{
+		ID: "operation-canceled-source", WorkflowID: "workflow-canceled-source",
+		Kind: workflowbiz.OperationKindCreateIssue, Status: workflowbiz.OperationStatusPending,
+		RevisionID: "revision-2", CreatedAt: now.Add(2 * time.Second),
+		UpdatedAt: now.Add(2 * time.Second),
+	}
+	if _, changed, err := store.DecideWorkspaceWorkflowCheckpoint(
+		ctx,
+		DecideWorkspaceWorkflowCheckpointInput{
+			WorkspaceID: workspaceID, WorkflowID: "workflow-canceled-source",
+			CheckpointID:              "checkpoint-2",
+			ExpectedStatus:            workflowbiz.CheckpointStatusPending,
+			ExpectedCurrentRevisionID: "revision-2",
+			ExpectedWorkflowStatus:    workflowbiz.WorkflowStatusPendingReview,
+			Decision:                  workflowbiz.CheckpointStatusAccepted,
+			DecidedBy:                 "user", DecidedAt: now.Add(2 * time.Second),
+			WorkflowStatus: workflowbiz.WorkflowStatusAccepted,
+			Operation:      &operation,
+		},
+	); err != nil || !changed {
+		t.Fatalf("accept workflow changed=%v error=%v", changed, err)
+	}
+	if _, err := store.ReportActivityState(
+		ctx,
+		agentactivitybiz.ActivityStateReport{
+			Session: agentactivitybiz.SessionStateReport{
+				WorkspaceID: workspaceID, AgentSessionID: "source-session",
+				Kind: agentactivitybiz.SessionKindRoot, Origin: "runtime",
+				Provider: "codex", Status: "idle",
+				OccurredAtUnixMS: now.Add(3 * time.Second).UnixMilli(),
+			},
+			Turn: &agentactivitybiz.TurnTransition{
+				WorkspaceID: workspaceID, AgentSessionID: "source-session",
+				TurnID: "turn-canceled-source", Origin: agentactivitybiz.TurnOriginUserPrompt,
+				Phase:            agentactivitybiz.TurnPhaseSettled,
+				Outcome:          agentactivitybiz.TurnOutcomeCanceled,
+				StartedAtUnixMS:  now.UnixMilli(),
+				SettledAtUnixMS:  now.Add(3 * time.Second).UnixMilli(),
+				OccurredAtUnixMS: now.Add(3 * time.Second).UnixMilli(),
+			},
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+	recoverable, err := store.ListRecoverableCreateIssueOperations(ctx)
+	if err != nil || len(recoverable) != 0 {
+		t.Fatalf("recoverable operations after canonical Stop=%#v error=%v", recoverable, err)
+	}
+	if err := store.DrainTuttiModeSourceActivityInbox(ctx, workspaceID); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := store.GetWorkspaceWorkflowSnapshot(
+		ctx, workspaceID, "workflow-canceled-source",
+	)
+	if err != nil || snapshot.Workflow.Status != workflowbiz.WorkflowStatusCanceled ||
+		len(snapshot.Operations) != 1 ||
+		snapshot.Operations[0].Status != workflowbiz.OperationStatusCanceled {
+		t.Fatalf("workflow after Stop=%#v error=%v", snapshot, err)
 	}
 }
 

--- a/services/tuttid/issue_run_agent_adapters.go
+++ b/services/tuttid/issue_run_agent_adapters.go
@@ -34,6 +34,19 @@ type issueRunSettlementReader struct {
 	Host issueRunSettlementHost
 }
 
+func (c issueRunSessionCanceller) CancelAutomationTurn(
+	ctx context.Context,
+	workspaceID string,
+	agentSessionID string,
+	turnID string,
+) error {
+	if c.Sessions == nil {
+		return errors.New("automation Turn canceller is unavailable")
+	}
+	_, err := c.Sessions.CancelTurn(ctx, workspaceID, agentSessionID, turnID)
+	return err
+}
+
 func (r issueRunSettlementReader) ReadRunSettlement(ctx context.Context, workspaceID string, agentSessionID string, clientSubmitID string) (workspaceservice.IssueRunSettlement, bool, error) {
 	if r.Host == nil {
 		return workspaceservice.IssueRunSettlement{}, false, nil

--- a/services/tuttid/service/agent/service_turns.go
+++ b/services/tuttid/service/agent/service_turns.go
@@ -155,10 +155,12 @@ func (s *Service) CancelTurn(ctx context.Context, workspaceID string, agentSessi
 	if result.Canceled {
 		result.Reason = CancelTurnReasonTurnCanceled
 		if s.TurnCancelObserver != nil {
-			// Cascade asynchronously so cancel latency never depends on how many
-			// delegate runs are in flight; the cascade is a no-op for sessions
-			// that do not orchestrate an Issue.
-			go s.TurnCancelObserver.ObserveUserTurnCanceled(context.WithoutCancel(ctx), workspaceID, agentSessionID)
+			// Enter the product's durable stop boundary before returning. The
+			// canonical canceled Turn and source-activity inbox marker remain
+			// the crash-recovery fallback if this callback is interrupted.
+			s.TurnCancelObserver.ObserveUserTurnCanceled(
+				context.WithoutCancel(ctx), workspaceID, agentSessionID,
+			)
 		}
 	}
 	return result, nil

--- a/services/tuttid/service/cli/providers/tuttimodeplan/commands.go
+++ b/services/tuttid/service/cli/providers/tuttimodeplan/commands.go
@@ -3,16 +3,13 @@ package tuttimodeplan
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
-	executionbiz "github.com/tutti-os/tutti/services/tuttid/biz/tuttimodeexecution"
 	workflowbiz "github.com/tutti-os/tutti/services/tuttid/biz/workspaceworkflow"
-	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
 	cliservice "github.com/tutti-os/tutti/services/tuttid/service/cli"
 	"github.com/tutti-os/tutti/services/tuttid/service/cli/framework"
 	tuttimodeexecutionservice "github.com/tutti-os/tutti/services/tuttid/service/tuttimodeexecution"
@@ -318,7 +315,7 @@ func (p Provider) runIssueSchedule(
 		},
 	)
 	if err != nil {
-		return nil, agentPlanError(err)
+		return nil, agentScheduleError(err, input.IssueID)
 	}
 	return map[string]any{
 		"executionId":   result.ExecutionID,
@@ -356,7 +353,7 @@ func (p Provider) runIssueMutate(
 		},
 	)
 	if err != nil {
-		return nil, agentMutationError(err)
+		return nil, agentMutationError(err, input.IssueID)
 	}
 	return map[string]any{
 		"executionId": result.ExecutionID, "checkpointId": result.CheckpointID,
@@ -364,34 +361,6 @@ func (p Provider) runIssueMutate(
 		"updatedTaskIds":    result.UpdatedTaskIDs,
 		"supersededTaskIds": result.SupersededTaskIDs, "replayed": result.Replayed,
 	}, nil
-}
-
-func parseMutationOperationsJSON(value string) ([]executionbiz.MutationOperation, error) {
-	var operations []executionbiz.MutationOperation
-	if err := json.Unmarshal([]byte(value), &operations); err != nil || len(operations) == 0 {
-		return nil, cliservice.InvalidInputKeyError("operations-json")
-	}
-	for _, operation := range operations {
-		taskID := strings.TrimSpace(operation.TaskID)
-		replacementTaskID := strings.TrimSpace(operation.Task.TaskID)
-		valid := false
-		switch operation.Kind {
-		case executionbiz.MutationOperationAdd:
-			valid = replacementTaskID != ""
-		case executionbiz.MutationOperationUpdate,
-			executionbiz.MutationOperationSupersede:
-			valid = taskID != ""
-		case executionbiz.MutationOperationRework:
-			valid = taskID != "" && replacementTaskID != ""
-		}
-		if !valid {
-			return nil, fmt.Errorf(
-				"%w: operations-json entries must use the \"kind\" field and cannot use \"op\" or \"replacement\"; add requires task.taskId, update and supersede require taskId, and rework requires taskId plus task.taskId",
-				cliservice.ErrInvalidInput,
-			)
-		}
-	}
-	return operations, nil
 }
 
 func (p Provider) runIssueAcknowledge(
@@ -501,91 +470,6 @@ func callerAgentSessionID(invoke framework.InvokeContext) (string, error) {
 		return "", cliservice.MissingRequiredInputError("agent-session-id")
 	}
 	return sessionID, nil
-}
-
-func agentPlanError(err error) error {
-	if errors.Is(err, workspacedata.ErrWorkspaceWorkflowNotFound) {
-		return fmt.Errorf("%w: Tutti Mode plan was not found", cliservice.ErrInvalidInput)
-	}
-	if errors.Is(err, tuttimodeplanservice.ErrMutationConflict) {
-		return fmt.Errorf("%w: request-id was already used with different content; reuse the original content or choose a new request-id", cliservice.ErrInvalidInput)
-	}
-	if errors.Is(err, executionbiz.ErrScheduleMutationConflict) {
-		return fmt.Errorf("%w: request-id was already used with a different schedule payload", cliservice.ErrInvalidInput)
-	}
-	if errors.Is(err, executionbiz.ErrAcknowledgeMutationConflict) {
-		return fmt.Errorf("%w: request-id was already used with a different acknowledge payload", cliservice.ErrInvalidInput)
-	}
-	if errors.Is(err, executionbiz.ErrExecutionConflict) ||
-		errors.Is(err, executionbiz.ErrAcknowledgeRejected) {
-		return fmt.Errorf("%w: execution caller, checkpoint, or revision is not current", cliservice.ErrInvalidInput)
-	}
-	if errors.Is(err, executionbiz.ErrScheduleRejected) ||
-		errors.Is(err, executionbiz.ErrExecutionNotFound) {
-		return fmt.Errorf("%w: schedule caller, checkpoint, revision, or requested task set is not current", cliservice.ErrInvalidInput)
-	}
-	return err
-}
-
-func agentAcknowledgeError(err error) error {
-	if errors.Is(err, executionbiz.ErrExecutionNotFound) {
-		return fmt.Errorf(
-			"%w: acknowledge execution was not found or is no longer current",
-			cliservice.ErrInvalidInput,
-		)
-	}
-	return agentPlanError(err)
-}
-
-func agentMutationError(err error) error {
-	if errors.Is(err, executionbiz.ErrMutationConflict) {
-		return fmt.Errorf("%w: request-id was already used with a different graph mutation payload", cliservice.ErrInvalidInput)
-	}
-	if errors.Is(err, executionbiz.ErrMutationRejected) ||
-		errors.Is(err, executionbiz.ErrExecutionNotFound) {
-		return fmt.Errorf("%w: mutation caller, checkpoint, revision, or operation set is not current", cliservice.ErrInvalidInput)
-	}
-	return err
-}
-
-func agentCompleteError(err error) error {
-	if errors.Is(err, executionbiz.ErrExecutionNotFound) {
-		return fmt.Errorf(
-			"%w: completion execution was not found or is no longer current",
-			cliservice.ErrInvalidInput,
-		)
-	}
-	if errors.Is(err, executionbiz.ErrCompleteMutationConflict) {
-		return fmt.Errorf(
-			"%w: request-id was already used with a different completion payload",
-			cliservice.ErrInvalidInput,
-		)
-	}
-	if errors.Is(err, executionbiz.ErrExecutionConflict) ||
-		errors.Is(err, executionbiz.ErrCompleteRejected) {
-		return fmt.Errorf(
-			"%w: completion caller, checkpoint, revision, decision, or review evidence is not current",
-			cliservice.ErrInvalidInput,
-		)
-	}
-	return err
-}
-
-func agentStopError(err error) error {
-	if errors.Is(err, executionbiz.ErrInvalidExecution) {
-		return fmt.Errorf(
-			"%w: stop request is incomplete",
-			cliservice.ErrInvalidInput,
-		)
-	}
-	if errors.Is(err, executionbiz.ErrExecutionNotFound) ||
-		errors.Is(err, executionbiz.ErrExecutionConflict) {
-		return fmt.Errorf(
-			"%w: stop caller, checkpoint, revision, or request history is not current",
-			cliservice.ErrInvalidInput,
-		)
-	}
-	return err
 }
 
 func readPlanFile(path string) ([]byte, error) {

--- a/services/tuttid/service/cli/providers/tuttimodeplan/commands.go
+++ b/services/tuttid/service/cli/providers/tuttimodeplan/commands.go
@@ -53,7 +53,7 @@ type issueMutateInput struct {
 	IssueID               string `cli:"issue-id" validate:"required" description:"Tutti-owned Issue id."`
 	CheckpointID          string `cli:"checkpoint-id" validate:"required" description:"Active execution checkpoint to rebind."`
 	ExpectedGraphRevision int64  `cli:"expected-graph-revision" validate:"required,min=1" description:"Current execution graph revision."`
-	OperationsJSON        string `cli:"operations-json" validate:"required" description:"JSON array of add, update, rework, or supersede operations."`
+	OperationsJSON        string `cli:"operations-json" validate:"required" description:"JSON array whose entries use the kind field: add includes task, update includes taskId and task, rework includes taskId plus task whose taskId names the replacement, and supersede includes taskId. The op and replacement keys are invalid."`
 	RequestID             string `cli:"request-id" validate:"required" description:"Stable graph mutation id. Reuse it only with the identical payload."`
 }
 
@@ -71,6 +71,14 @@ type issueCompleteInput struct {
 	RequestID             string `cli:"request-id" validate:"required" description:"Stable completion mutation id. Reuse it only with the identical payload."`
 	Decision              string `cli:"decision" validate:"required" enum:"goal_satisfied" description:"Explicit source-Agent Goal Review decision."`
 	DisagreementReason    string `cli:"disagreement-reason" description:"Audited reason required when overriding a negative or inconclusive independent recommendation."`
+}
+
+type issueStopInput struct {
+	IssueID               string `cli:"issue-id" validate:"required" description:"Tutti-owned Issue id."`
+	CheckpointID          string `cli:"checkpoint-id" validate:"required" description:"Active execution checkpoint at which the source Agent decided to stop."`
+	ExpectedGraphRevision int64  `cli:"expected-graph-revision" validate:"required,min=1" description:"Current execution graph revision."`
+	RequestID             string `cli:"request-id" validate:"required" description:"Stable stop mutation id. Reuse it only with the identical reason."`
+	Reason                string `cli:"reason" validate:"required" description:"Audited reason the Issue should stop without Goal Review completion."`
 }
 
 func (p Provider) newProposeCommand() cliservice.Command {
@@ -182,6 +190,22 @@ func (p Provider) newIssueCompleteCommand() cliservice.Command {
 		Inputs:      framework.FromStruct[issueCompleteInput](),
 		Output:      planJSONOutput(framework.ViewSummary),
 		Run:         p.runIssueComplete,
+	})
+}
+
+func (p Provider) newIssueStopCommand() cliservice.Command {
+	return framework.Register(framework.CommandSpec[issueStopInput]{
+		ID:          appID + ".plan.issue.stop",
+		Path:        []string{"plan", "issue", "stop"},
+		Summary:     "Stop a Tutti Mode Issue",
+		Description: "Stop and durably archive an Issue that should not continue, canceling open Runs and closing checkpoint wakes. Caller authority comes from the invoking source Agent session and is fenced by the active checkpoint and graph revision.",
+		Kind:        framework.KindAction,
+		Visibility:  cliservice.CapabilityVisibilityPublic,
+		Workspace:   framework.WorkspaceRequired,
+		Workspaces:  p.workspaces,
+		Inputs:      framework.FromStruct[issueStopInput](),
+		Output:      planJSONOutput(framework.ViewSummary),
+		Run:         p.runIssueStop,
 	})
 }
 
@@ -317,10 +341,9 @@ func (p Provider) runIssueMutate(
 	if err != nil {
 		return nil, err
 	}
-	var operations []executionbiz.MutationOperation
-	if err := json.Unmarshal([]byte(input.OperationsJSON), &operations); err != nil ||
-		len(operations) == 0 {
-		return nil, cliservice.InvalidInputKeyError("operations-json")
+	operations, err := parseMutationOperationsJSON(input.OperationsJSON)
+	if err != nil {
+		return nil, err
 	}
 	result, err := p.mutations.MutateTuttiModeIssue(
 		ctx,
@@ -341,6 +364,34 @@ func (p Provider) runIssueMutate(
 		"updatedTaskIds":    result.UpdatedTaskIDs,
 		"supersededTaskIds": result.SupersededTaskIDs, "replayed": result.Replayed,
 	}, nil
+}
+
+func parseMutationOperationsJSON(value string) ([]executionbiz.MutationOperation, error) {
+	var operations []executionbiz.MutationOperation
+	if err := json.Unmarshal([]byte(value), &operations); err != nil || len(operations) == 0 {
+		return nil, cliservice.InvalidInputKeyError("operations-json")
+	}
+	for _, operation := range operations {
+		taskID := strings.TrimSpace(operation.TaskID)
+		replacementTaskID := strings.TrimSpace(operation.Task.TaskID)
+		valid := false
+		switch operation.Kind {
+		case executionbiz.MutationOperationAdd:
+			valid = replacementTaskID != ""
+		case executionbiz.MutationOperationUpdate,
+			executionbiz.MutationOperationSupersede:
+			valid = taskID != ""
+		case executionbiz.MutationOperationRework:
+			valid = taskID != "" && replacementTaskID != ""
+		}
+		if !valid {
+			return nil, fmt.Errorf(
+				"%w: operations-json entries must use the \"kind\" field and cannot use \"op\" or \"replacement\"; add requires task.taskId, update and supersede require taskId, and rework requires taskId plus task.taskId",
+				cliservice.ErrInvalidInput,
+			)
+		}
+	}
+	return operations, nil
 }
 
 func (p Provider) runIssueAcknowledge(
@@ -398,6 +449,35 @@ func (p Provider) runIssueComplete(
 		"executionId": result.ExecutionID, "checkpointId": result.CheckpointID,
 		"graphRevision": result.GraphRevision, "decision": result.Decision,
 		"replayed": result.Replayed,
+	}, nil
+}
+
+func (p Provider) runIssueStop(
+	ctx context.Context,
+	invoke framework.InvokeContext,
+	input issueStopInput,
+) (any, error) {
+	if err := p.requireArchives(); err != nil {
+		return nil, err
+	}
+	sessionID, err := callerAgentSessionID(invoke)
+	if err != nil {
+		return nil, err
+	}
+	operation, err := p.archives.Archive(ctx, tuttimodeexecutionservice.ArchiveInput{
+		WorkspaceID: invoke.WorkspaceID, IssueID: input.IssueID,
+		SourceSessionID: sessionID, CheckpointID: input.CheckpointID,
+		ExpectedGraphRevision: input.ExpectedGraphRevision,
+		RequestID:             input.RequestID,
+		Reason:                input.Reason,
+	})
+	if err != nil {
+		return nil, agentStopError(err)
+	}
+	return map[string]any{
+		"executionId": operation.ExecutionID, "issueId": operation.IssueID,
+		"operationId": operation.OperationID, "requestId": operation.RequestID,
+		"status": string(operation.Status), "reason": operation.Reason,
 	}, nil
 }
 
@@ -485,6 +565,23 @@ func agentCompleteError(err error) error {
 		errors.Is(err, executionbiz.ErrCompleteRejected) {
 		return fmt.Errorf(
 			"%w: completion caller, checkpoint, revision, decision, or review evidence is not current",
+			cliservice.ErrInvalidInput,
+		)
+	}
+	return err
+}
+
+func agentStopError(err error) error {
+	if errors.Is(err, executionbiz.ErrInvalidExecution) {
+		return fmt.Errorf(
+			"%w: stop request is incomplete",
+			cliservice.ErrInvalidInput,
+		)
+	}
+	if errors.Is(err, executionbiz.ErrExecutionNotFound) ||
+		errors.Is(err, executionbiz.ErrExecutionConflict) {
+		return fmt.Errorf(
+			"%w: stop caller, checkpoint, revision, or request history is not current",
 			cliservice.ErrInvalidInput,
 		)
 	}

--- a/services/tuttid/service/cli/providers/tuttimodeplan/execution_errors.go
+++ b/services/tuttid/service/cli/providers/tuttimodeplan/execution_errors.go
@@ -1,0 +1,229 @@
+package tuttimodeplan
+
+import (
+	"errors"
+	"strings"
+
+	workspaceissues "github.com/tutti-os/tutti/packages/workspace/issues"
+	executionbiz "github.com/tutti-os/tutti/services/tuttid/biz/tuttimodeexecution"
+	workflowdata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
+	cliservice "github.com/tutti-os/tutti/services/tuttid/service/cli"
+	tuttimodeplanservice "github.com/tutti-os/tutti/services/tuttid/service/tuttimodeplan"
+)
+
+func agentPlanError(err error) error {
+	if errors.Is(err, workflowdata.ErrWorkspaceWorkflowNotFound) {
+		return cliservice.InvalidInputReasonError(
+			string(executionbiz.RejectionExecutionNotFound),
+			"Tutti Mode plan was not found",
+			nil,
+		)
+	}
+	if errors.Is(err, tuttimodeplanservice.ErrMutationConflict) {
+		return requestIDConflictError(
+			"request-id was already used with different plan content. " +
+				"Hint: reuse the original content or choose a new request-id",
+		)
+	}
+	if errors.Is(err, executionbiz.ErrScheduleMutationConflict) {
+		return requestIDConflictError(
+			"request-id was already used with a different schedule payload. " +
+				"Hint: reuse it only with the identical task set",
+		)
+	}
+	if errors.Is(err, executionbiz.ErrAcknowledgeMutationConflict) {
+		return requestIDConflictError(
+			"request-id was already used with a different acknowledge payload. " +
+				"Hint: reuse it only for the identical checkpoint",
+		)
+	}
+	if errors.Is(err, executionbiz.ErrExecutionConflict) ||
+		errors.Is(err, executionbiz.ErrAcknowledgeRejected) {
+		return cliservice.InvalidInputReasonError(
+			string(executionbiz.RejectionInactiveCheckpoint),
+			"execution caller, checkpoint, or revision is not current. "+
+				"Hint: run `tutti plan issue get --issue-id <issue-id> --json` once and use its active checkpoint and graph revision",
+			nil,
+		)
+	}
+	if errors.Is(err, executionbiz.ErrScheduleRejected) ||
+		errors.Is(err, executionbiz.ErrExecutionNotFound) {
+		return rejectionCLIError("schedule", "", err)
+	}
+	return err
+}
+
+func agentScheduleError(err error, issueID string) error {
+	if errors.Is(err, executionbiz.ErrScheduleMutationConflict) {
+		return requestIDConflictError(
+			"request-id was already used with a different schedule payload. " +
+				"Hint: reuse it only with the identical task set",
+		)
+	}
+	if errors.Is(err, executionbiz.ErrExecutionNotFound) ||
+		errors.Is(err, workspaceissues.ErrIssueNotFound) {
+		return executionNotFoundError(issueID)
+	}
+	if errors.Is(err, executionbiz.ErrScheduleRejected) {
+		return rejectionCLIError("schedule", issueID, err)
+	}
+	return err
+}
+
+func agentAcknowledgeError(err error) error {
+	if errors.Is(err, executionbiz.ErrExecutionNotFound) {
+		return executionNotFoundError("")
+	}
+	return agentPlanError(err)
+}
+
+func agentMutationError(err error, issueID string) error {
+	if errors.Is(err, executionbiz.ErrMutationConflict) {
+		return requestIDConflictError(
+			"request-id was already used with a different graph mutation payload. " +
+				"Hint: reuse it only with identical operations or choose a new request-id",
+		)
+	}
+	if errors.Is(err, executionbiz.ErrExecutionNotFound) {
+		return executionNotFoundError(issueID)
+	}
+	if errors.Is(err, executionbiz.ErrMutationRejected) {
+		return rejectionCLIError("mutation", issueID, err)
+	}
+	return err
+}
+
+func agentCompleteError(err error) error {
+	if errors.Is(err, executionbiz.ErrExecutionNotFound) {
+		return executionNotFoundError("")
+	}
+	if errors.Is(err, executionbiz.ErrCompleteMutationConflict) {
+		return requestIDConflictError(
+			"request-id was already used with a different completion payload. " +
+				"Hint: reuse it only for the identical Goal Review decision",
+		)
+	}
+	if errors.Is(err, executionbiz.ErrExecutionConflict) ||
+		errors.Is(err, executionbiz.ErrCompleteRejected) {
+		return cliservice.InvalidInputReasonError(
+			string(executionbiz.RejectionInactiveCheckpoint),
+			"completion checkpoint, revision, decision, or review evidence is not current. "+
+				"Hint: refresh with `tutti plan issue get --issue-id <issue-id> --json`",
+			nil,
+		)
+	}
+	return err
+}
+
+func agentStopError(err error) error {
+	if errors.Is(err, executionbiz.ErrInvalidExecution) {
+		return cliservice.InvalidInputReasonError(
+			string(executionbiz.RejectionInvalidMutation),
+			"stop request is incomplete. Hint: provide the active checkpoint, graph revision, stable request-id, and audited reason",
+			nil,
+		)
+	}
+	if errors.Is(err, executionbiz.ErrExecutionNotFound) {
+		return executionNotFoundError("")
+	}
+	if errors.Is(err, executionbiz.ErrExecutionConflict) {
+		return cliservice.InvalidInputReasonError(
+			string(executionbiz.RejectionInactiveCheckpoint),
+			"stop checkpoint, revision, or request history is not current. "+
+				"Hint: refresh with `tutti plan issue get --issue-id <issue-id> --json`",
+			nil,
+		)
+	}
+	return err
+}
+
+func rejectionCLIError(action string, issueID string, err error) error {
+	reason, taskID, ok := executionbiz.RejectionDetails(err)
+	if !ok {
+		if errors.Is(err, executionbiz.ErrExecutionNotFound) {
+			return executionNotFoundError(issueID)
+		}
+		reason = executionbiz.RejectionReason(action + "_rejected")
+	}
+	message := action + " rejected"
+	if taskID != "" {
+		message += " for task " + taskID
+	}
+	message += ". Hint: " + rejectionHint(reason, issueID, taskID)
+	return cliservice.InvalidInputReasonError(string(reason), message, nil)
+}
+
+func rejectionHint(
+	reason executionbiz.RejectionReason,
+	issueID string,
+	taskID string,
+) string {
+	get := "`tutti plan issue get --issue-id " + issueIDPlaceholder(issueID) + " --json`"
+	switch reason {
+	case executionbiz.RejectionWrongSourceSession:
+		return "run the command from the original Tutti Mode source session; do not supply or guess a source session id"
+	case executionbiz.RejectionInactiveExecution:
+		return "run " + get + " and follow its allowedActions; the execution is not accepting this command"
+	case executionbiz.RejectionInactiveCheckpoint:
+		return "run " + get + " once and use the returned active checkpoint id"
+	case executionbiz.RejectionStaleGraphRevision:
+		return "run " + get + " once and use the returned graphRevision; never increment or guess it"
+	case executionbiz.RejectionTaskNotFound:
+		return "run " + get + " and choose an active task id"
+	case executionbiz.RejectionTaskNotStarted:
+		return "failed or canceled tasks require rework with a new taskId; running and completed tasks cannot be scheduled"
+	case executionbiz.RejectionTaskSuperseded:
+		return "run " + get + " and use the replacement task named by supersededByTaskId"
+	case executionbiz.RejectionMissingAgentTarget:
+		return "rework or update " + taskPlaceholder(taskID) +
+			" with agentTargetId, or rely on sparse rework inheritance from its superseded task"
+	case executionbiz.RejectionDependencyUnsatisfied:
+		return "run " + get + " and schedule only tasks whose ready field is true"
+	case executionbiz.RejectionDispatchPaused:
+		return "resume dispatch through the supported Issue control before scheduling"
+	case executionbiz.RejectionBudgetUnavailable:
+		return "the Issue budget is not active; report the blocker instead of retrying"
+	case executionbiz.RejectionCapacityExhausted:
+		return "wait for an active Run to settle, then use the next durable checkpoint wake"
+	case executionbiz.RejectionParallelismRejected:
+		return "schedule a smaller compatible task set shown as ready by " + get
+	case executionbiz.RejectionDuplicateTask:
+		return "use unique task ids and remove duplicates from the request"
+	case executionbiz.RejectionInvalidTaskGraph:
+		return "fix missing, superseded, self-referential, or cyclic dependencies in one atomic mutation"
+	case executionbiz.RejectionInvalidMutation:
+		return "run `tutti plan issue mutate --help` and submit the documented presence-aware operation schema"
+	default:
+		return "run " + get + " once; if the authoritative snapshot does not explain the rejection, report this exact error without querying SQLite"
+	}
+}
+
+func requestIDConflictError(message string) error {
+	return cliservice.InvalidInputReasonError("request_id_conflict", message, nil)
+}
+
+func executionNotFoundError(issueID string) error {
+	message := "Tutti Mode execution was not found"
+	if strings.TrimSpace(issueID) != "" {
+		message += " for Issue " + strings.TrimSpace(issueID)
+	}
+	message += ". Hint: verify the Issue id with `tutti issue get --issue-id " +
+		issueIDPlaceholder(issueID) + " --json`"
+	return cliservice.InvalidInputReasonError(
+		string(executionbiz.RejectionExecutionNotFound), message, nil,
+	)
+}
+
+func issueIDPlaceholder(issueID string) string {
+	if value := strings.TrimSpace(issueID); value != "" {
+		return value
+	}
+	return "<issue-id>"
+}
+
+func taskPlaceholder(taskID string) string {
+	if value := strings.TrimSpace(taskID); value != "" {
+		return "task " + value
+	}
+	return "the task"
+}

--- a/services/tuttid/service/cli/providers/tuttimodeplan/execution_snapshot.go
+++ b/services/tuttid/service/cli/providers/tuttimodeplan/execution_snapshot.go
@@ -1,0 +1,289 @@
+package tuttimodeplan
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	workspaceissues "github.com/tutti-os/tutti/packages/workspace/issues"
+	executionbiz "github.com/tutti-os/tutti/services/tuttid/biz/tuttimodeexecution"
+	cliservice "github.com/tutti-os/tutti/services/tuttid/service/cli"
+	"github.com/tutti-os/tutti/services/tuttid/service/cli/framework"
+)
+
+type issueGetInput struct {
+	IssueID string `cli:"issue-id" validate:"required" description:"Tutti-owned Issue id."`
+}
+
+func (p Provider) newIssueGetCommand() cliservice.Command {
+	return framework.Register(framework.CommandSpec[issueGetInput]{
+		ID:          appID + ".plan.issue.get",
+		Path:        []string{"plan", "issue", "get"},
+		Summary:     "Get authoritative Tutti Mode execution state",
+		Description: "Read the source-session-scoped execution, active checkpoint, graph revision, task readiness blockers, and allowed recovery actions.",
+		Kind:        framework.KindGet,
+		Visibility:  cliservice.CapabilityVisibilityPublic,
+		Workspace:   framework.WorkspaceRequired,
+		Workspaces:  p.workspaces,
+		Inputs:      framework.FromStruct[issueGetInput](),
+		Output:      planJSONOutput(framework.ViewDetail),
+		Run:         p.runIssueGet,
+	})
+}
+
+func (p Provider) runIssueGet(
+	ctx context.Context,
+	invoke framework.InvokeContext,
+	input issueGetInput,
+) (any, error) {
+	sessionID, err := callerAgentSessionID(invoke)
+	if err != nil {
+		return nil, err
+	}
+	aggregate, err := p.executionReads.GetByIssue(
+		ctx, invoke.WorkspaceID, strings.TrimSpace(input.IssueID),
+	)
+	if err != nil {
+		return nil, agentExecutionGetError(err, input.IssueID)
+	}
+	if strings.TrimSpace(aggregate.Execution.SourceSessionID) != sessionID {
+		return nil, cliservice.InvalidInputReasonError(
+			string(executionbiz.RejectionWrongSourceSession),
+			"execution belongs to a different source session. "+
+				"Hint: run this command from the original Tutti Mode conversation",
+			nil,
+		)
+	}
+	detail, err := p.issueDetails.GetIssueDetail(
+		ctx, invoke.WorkspaceID, strings.TrimSpace(input.IssueID),
+	)
+	if err != nil {
+		return nil, agentExecutionGetError(err, input.IssueID)
+	}
+	return issueExecutionSnapshotJSON(aggregate, detail), nil
+}
+
+func issueExecutionSnapshotJSON(
+	aggregate executionbiz.Aggregate,
+	detail workspaceissues.IssueDetail,
+) map[string]any {
+	activeCheckpoint, checkpoints := visibleExecutionCheckpoints(aggregate)
+	tasksByID := make(map[string]workspaceissues.Task, len(detail.Tasks))
+	for _, task := range detail.Tasks {
+		tasksByID[task.TaskID] = task
+	}
+	readinessTasksByID := executionReadinessTasks(tasksByID, activeCheckpoint)
+	tasks := make([]map[string]any, 0, len(detail.Tasks))
+	readyTaskIDs := make([]string, 0)
+	for _, task := range detail.Tasks {
+		readinessTask := readinessTasksByID[task.TaskID]
+		blocker := workspaceissues.IssueTaskRunBlocker(readinessTask, readinessTasksByID)
+		ready := blocker == ""
+		if ready {
+			readyTaskIDs = append(readyTaskIDs, task.TaskID)
+		}
+		tasks = append(tasks, executionTaskJSON(task, ready, blocker))
+	}
+	allowedActions := executionAllowedActions(
+		aggregate.Execution,
+		activeCheckpoint,
+		aggregate.Checkpoints,
+		detail.Tasks,
+		len(readyTaskIDs) > 0,
+	)
+	return map[string]any{
+		"issueId": aggregate.Execution.IssueID,
+		"execution": map[string]any{
+			"executionId":        aggregate.Execution.ID,
+			"status":             string(aggregate.Execution.Status),
+			"graphRevision":      aggregate.Execution.GraphRevision,
+			"activeCheckpointId": aggregate.Execution.ActiveCheckpointID,
+			"reviewMode":         string(aggregate.Execution.ReviewMode),
+			"archiveReason":      aggregate.Execution.ArchiveReason,
+		},
+		"activeCheckpoint": activeCheckpoint,
+		"checkpoints":      checkpoints,
+		"tasks":            tasks,
+		"readyTaskIds":     readyTaskIDs,
+		"allowedActions":   allowedActions,
+		"recoveryHint":     executionRecoveryHint(activeCheckpoint),
+	}
+}
+
+func visibleExecutionCheckpoints(
+	aggregate executionbiz.Aggregate,
+) (map[string]any, []map[string]any) {
+	var active map[string]any
+	visible := make([]map[string]any, 0)
+	for _, checkpoint := range aggregate.Checkpoints {
+		if checkpoint.Status != executionbiz.CheckpointStatusActive &&
+			checkpoint.Status != executionbiz.CheckpointStatusPending {
+			continue
+		}
+		value := executionCheckpointJSON(checkpoint)
+		visible = append(visible, value)
+		if checkpoint.ID == aggregate.Execution.ActiveCheckpointID &&
+			checkpoint.Status == executionbiz.CheckpointStatusActive {
+			active = value
+		}
+	}
+	return active, visible
+}
+
+func executionReadinessTasks(
+	tasks map[string]workspaceissues.Task,
+	activeCheckpoint map[string]any,
+) map[string]workspaceissues.Task {
+	projected := make(map[string]workspaceissues.Task, len(tasks))
+	for taskID, task := range tasks {
+		projected[taskID] = task
+	}
+	if activeCheckpoint == nil ||
+		executionbiz.CheckpointKind(activeCheckpoint["kind"].(string)) !=
+			executionbiz.CheckpointKindTaskSettled {
+		return projected
+	}
+	subjectTaskID, _ := activeCheckpoint["subjectTaskId"].(string)
+	subject, ok := projected[subjectTaskID]
+	if ok && subject.Status == workspaceissues.StatusPendingAcceptance {
+		// Exact-set scheduling accepts the reviewed settlement atomically.
+		// Readiness projects the same dependency fact without changing the
+		// persisted status presented to the caller.
+		projected[subjectTaskID] =
+			workspaceissues.ProjectReviewedSettlementTaskForRun(subject)
+	}
+	return projected
+}
+
+func executionCheckpointJSON(checkpoint executionbiz.Checkpoint) map[string]any {
+	return map[string]any{
+		"checkpointId":       checkpoint.ID,
+		"kind":               string(checkpoint.Kind),
+		"status":             string(checkpoint.Status),
+		"sequence":           checkpoint.Sequence,
+		"graphRevision":      checkpoint.GraphRevision,
+		"subjectTaskId":      checkpoint.SubjectTaskID,
+		"subjectRunId":       checkpoint.SubjectRunID,
+		"creationReason":     checkpoint.CreationReason,
+		"requiresGoalReview": checkpoint.RequiresGoalReview,
+	}
+}
+
+func executionTaskJSON(
+	task workspaceissues.Task,
+	ready bool,
+	blocker workspaceissues.TaskRunBlocker,
+) map[string]any {
+	return map[string]any{
+		"taskId":             task.TaskID,
+		"title":              task.Title,
+		"status":             string(task.Status),
+		"acceptanceState":    string(task.AcceptanceState),
+		"agentTargetId":      task.AgentTargetID,
+		"modelPlanId":        task.ModelPlanID,
+		"model":              task.Model,
+		"permissionModeId":   task.PermissionModeID,
+		"reasoningEffort":    task.ReasoningEffort,
+		"executionDirectory": task.ExecutionDirectory,
+		"dependencyTaskIds":  append([]string(nil), task.DependencyTaskIDs...),
+		"parallelizable":     task.Parallelizable,
+		"autoAccept":         task.AutoAccept,
+		"latestRunId":        task.LatestRunID,
+		"supersededAtUnixMs": task.SupersededAtUnixMS,
+		"supersededByTaskId": task.SupersededByTaskID,
+		"ready":              ready,
+		"blockerReason":      string(blocker),
+	}
+}
+
+func executionAllowedActions(
+	execution executionbiz.Execution,
+	activeCheckpoint map[string]any,
+	checkpoints []executionbiz.Checkpoint,
+	tasks []workspaceissues.Task,
+	hasReadyTasks bool,
+) []string {
+	if activeCheckpoint == nil ||
+		execution.Status == executionbiz.StatusCompleted ||
+		execution.Status == executionbiz.StatusArchiving ||
+		execution.Status == executionbiz.StatusArchived {
+		return []string{}
+	}
+	kind := executionbiz.CheckpointKind(activeCheckpoint["kind"].(string))
+	switch kind {
+	case executionbiz.CheckpointKindAllTasksTerminal:
+		return []string{
+			"plan issue complete",
+			"plan issue mutate",
+			"plan issue stop",
+		}
+	case executionbiz.CheckpointKindInitialSchedule:
+		return executionWorkActions(hasReadyTasks)
+	case executionbiz.CheckpointKindTaskSettled,
+		executionbiz.CheckpointKindTaskFailed,
+		executionbiz.CheckpointKindTaskCanceled:
+		actions := executionWorkActions(hasReadyTasks)
+		if executionCanAcknowledge(checkpoints, tasks) {
+			actions = append(actions, "plan issue acknowledge")
+		}
+		return actions
+	default:
+		actions := executionWorkActions(hasReadyTasks)
+		if kind == executionbiz.CheckpointKindWatchdog &&
+			executionCanAcknowledge(checkpoints, tasks) {
+			actions = append(actions, "plan issue acknowledge")
+		}
+		return actions
+	}
+}
+
+func executionWorkActions(hasReadyTasks bool) []string {
+	actions := []string{"plan issue mutate"}
+	if hasReadyTasks {
+		actions = append(actions, "plan issue schedule")
+	}
+	return append(actions, "plan issue stop")
+}
+
+func executionCanAcknowledge(
+	checkpoints []executionbiz.Checkpoint,
+	tasks []workspaceissues.Task,
+) bool {
+	for _, task := range tasks {
+		if task.Status == workspaceissues.StatusRunning {
+			return true
+		}
+	}
+	for _, checkpoint := range checkpoints {
+		if checkpoint.Status == executionbiz.CheckpointStatusPending {
+			return true
+		}
+	}
+	return false
+}
+
+func executionRecoveryHint(activeCheckpoint map[string]any) string {
+	if activeCheckpoint == nil {
+		return "No active checkpoint accepts a source-Agent command"
+	}
+	switch executionbiz.CheckpointKind(activeCheckpoint["kind"].(string)) {
+	case executionbiz.CheckpointKindTaskFailed,
+		executionbiz.CheckpointKindTaskCanceled:
+		return "Rework the terminal task with a new taskId, then schedule the replacement using the mutation result graphRevision"
+	case executionbiz.CheckpointKindAllTasksTerminal:
+		return "Complete Goal Review if satisfied, or mutate and schedule exact follow-up work"
+	default:
+		return "Choose one allowed action using this exact checkpointId and graphRevision"
+	}
+}
+
+func agentExecutionGetError(err error, issueID string) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, executionbiz.ErrExecutionNotFound) ||
+		errors.Is(err, workspaceissues.ErrIssueNotFound) {
+		return executionNotFoundError(issueID)
+	}
+	return err
+}

--- a/services/tuttid/service/cli/providers/tuttimodeplan/mutation_input.go
+++ b/services/tuttid/service/cli/providers/tuttimodeplan/mutation_input.go
@@ -1,0 +1,200 @@
+package tuttimodeplan
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	workspaceissues "github.com/tutti-os/tutti/packages/workspace/issues"
+	executionbiz "github.com/tutti-os/tutti/services/tuttid/biz/tuttimodeexecution"
+	cliservice "github.com/tutti-os/tutti/services/tuttid/service/cli"
+)
+
+type mutationOperationInput struct {
+	Kind   string             `json:"kind"`
+	TaskID string             `json:"taskId"`
+	Task   *mutationTaskInput `json:"task"`
+}
+
+type mutationTaskInput struct {
+	TaskID             string    `json:"taskId"`
+	Title              *string   `json:"title"`
+	Content            *string   `json:"content"`
+	Priority           *string   `json:"priority"`
+	DueAtUnixMS        *int64    `json:"dueAtUnixMs"`
+	AgentTargetID      *string   `json:"agentTargetId"`
+	ModelPlanID        *string   `json:"modelPlanId"`
+	Model              *string   `json:"model"`
+	PermissionModeID   *string   `json:"permissionModeId"`
+	ReasoningEffort    *string   `json:"reasoningEffort"`
+	ExecutionDirectory *string   `json:"executionDirectory"`
+	DependencyTaskIDs  *[]string `json:"dependencyTaskIds"`
+	Parallelizable     *bool     `json:"parallelizable"`
+	AutoAccept         *bool     `json:"autoAccept"`
+}
+
+func parseMutationOperationsJSON(value string) ([]executionbiz.MutationOperation, error) {
+	var parsed []mutationOperationInput
+	decoder := json.NewDecoder(bytes.NewBufferString(value))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&parsed); err != nil {
+		return nil, invalidMutationInput(
+			`operations-json must be one non-empty JSON array using "kind", "taskId", ` +
+				`and a "task" object with "taskId": ` +
+				err.Error(),
+		)
+	}
+	if len(parsed) == 0 {
+		return nil, invalidMutationInput("operations-json must not be empty")
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return nil, invalidMutationInput("operations-json must contain exactly one JSON value")
+	}
+
+	operations := make([]executionbiz.MutationOperation, 0, len(parsed))
+	for _, input := range parsed {
+		operation, err := mutationOperation(input)
+		if err != nil {
+			return nil, err
+		}
+		operations = append(operations, operation)
+	}
+	return operations, nil
+}
+
+func mutationOperation(input mutationOperationInput) (executionbiz.MutationOperation, error) {
+	operation := executionbiz.MutationOperation{
+		Kind:   executionbiz.MutationOperationKind(strings.TrimSpace(input.Kind)),
+		TaskID: strings.TrimSpace(input.TaskID),
+	}
+	if input.Task != nil {
+		if input.Task.Priority != nil {
+			priority := strings.ToLower(strings.TrimSpace(*input.Task.Priority))
+			if priority != string(workspaceissues.PriorityHigh) &&
+				priority != string(workspaceissues.PriorityMedium) &&
+				priority != string(workspaceissues.PriorityLow) {
+				return executionbiz.MutationOperation{}, invalidMutationInput(
+					"task.priority must be high, medium, or low",
+				)
+			}
+		}
+		if input.Task.DueAtUnixMS != nil && *input.Task.DueAtUnixMS < 0 {
+			return executionbiz.MutationOperation{}, invalidMutationInput(
+				"task.dueAtUnixMs must be zero or greater",
+			)
+		}
+		operation.Task, operation.TaskFields = input.Task.domainTask()
+	}
+	switch operation.Kind {
+	case executionbiz.MutationOperationAdd:
+		if input.Task == nil || operation.Task.TaskID == "" ||
+			strings.TrimSpace(operation.Task.Title) == "" {
+			return executionbiz.MutationOperation{}, invalidMutationInput(
+				"add requires task.taskId, task.title, and a complete schedulable task",
+			)
+		}
+		if strings.TrimSpace(operation.Task.AgentTargetID) == "" {
+			return executionbiz.MutationOperation{}, cliservice.InvalidInputReasonError(
+				string(executionbiz.RejectionMissingAgentTarget),
+				"add task "+operation.Task.TaskID+
+					" is missing agentTargetId. Hint: choose a target from `tutti agent list --json`",
+				nil,
+			)
+		}
+	case executionbiz.MutationOperationUpdate:
+		if operation.TaskID == "" || input.Task == nil || !operation.TaskFields.Any() {
+			return executionbiz.MutationOperation{}, invalidMutationInput(
+				"update requires taskId and at least one explicitly present task field",
+			)
+		}
+	case executionbiz.MutationOperationRework:
+		if operation.TaskID == "" || input.Task == nil || operation.Task.TaskID == "" {
+			return executionbiz.MutationOperation{}, invalidMutationInput(
+				"rework requires taskId plus task.taskId for the replacement",
+			)
+		}
+	case executionbiz.MutationOperationSupersede:
+		if operation.TaskID == "" || input.Task != nil {
+			return executionbiz.MutationOperation{}, invalidMutationInput(
+				"supersede requires taskId and does not accept task",
+			)
+		}
+	default:
+		return executionbiz.MutationOperation{}, invalidMutationInput(
+			"entries must use kind add, update, rework, or supersede; op and replacement are not supported",
+		)
+	}
+	return operation, nil
+}
+
+func (input mutationTaskInput) domainTask() (
+	workspaceissues.Task,
+	executionbiz.MutationTaskFields,
+) {
+	task := workspaceissues.Task{TaskID: strings.TrimSpace(input.TaskID)}
+	fields := executionbiz.MutationTaskFields{}
+	if input.Title != nil {
+		task.Title = *input.Title
+		fields.Title = true
+	}
+	if input.Content != nil {
+		task.Content = *input.Content
+		fields.Content = true
+	}
+	if input.Priority != nil {
+		task.Priority = workspaceissues.Priority(strings.TrimSpace(*input.Priority))
+		fields.Priority = true
+	}
+	if input.DueAtUnixMS != nil {
+		task.DueAtUnixMS = *input.DueAtUnixMS
+		fields.DueAtUnixMS = true
+	}
+	if input.AgentTargetID != nil {
+		task.AgentTargetID = strings.TrimSpace(*input.AgentTargetID)
+		fields.AgentTargetID = true
+	}
+	if input.ModelPlanID != nil {
+		task.ModelPlanID = strings.TrimSpace(*input.ModelPlanID)
+		fields.ModelPlanID = true
+	}
+	if input.Model != nil {
+		task.Model = strings.TrimSpace(*input.Model)
+		fields.Model = true
+	}
+	if input.PermissionModeID != nil {
+		task.PermissionModeID = strings.TrimSpace(*input.PermissionModeID)
+		fields.PermissionModeID = true
+	}
+	if input.ReasoningEffort != nil {
+		task.ReasoningEffort = strings.TrimSpace(*input.ReasoningEffort)
+		fields.ReasoningEffort = true
+	}
+	if input.ExecutionDirectory != nil {
+		task.ExecutionDirectory = strings.TrimSpace(*input.ExecutionDirectory)
+		fields.ExecutionDirectory = true
+	}
+	if input.DependencyTaskIDs != nil {
+		task.DependencyTaskIDs = append([]string(nil), (*input.DependencyTaskIDs)...)
+		fields.DependencyTaskIDs = true
+	}
+	if input.Parallelizable != nil {
+		task.Parallelizable = *input.Parallelizable
+		fields.Parallelizable = true
+	}
+	if input.AutoAccept != nil {
+		task.AutoAccept = *input.AutoAccept
+		fields.AutoAccept = true
+	}
+	return task, fields
+}
+
+func invalidMutationInput(message string) error {
+	return cliservice.InvalidInputReasonError(
+		string(executionbiz.RejectionInvalidMutation),
+		strings.TrimSpace(message)+
+			". Hint: run `tutti plan issue mutate --help` and use the documented schema",
+		fmt.Errorf("%w: invalid operations-json", cliservice.ErrInvalidInput),
+	)
+}

--- a/services/tuttid/service/cli/providers/tuttimodeplan/provider.go
+++ b/services/tuttid/service/cli/providers/tuttimodeplan/provider.go
@@ -6,6 +6,7 @@ package tuttimodeplan
 import (
 	"context"
 
+	workspaceissues "github.com/tutti-os/tutti/packages/workspace/issues"
 	executionbiz "github.com/tutti-os/tutti/services/tuttid/biz/tuttimodeexecution"
 	cliservice "github.com/tutti-os/tutti/services/tuttid/service/cli"
 	tuttimodeexecutionservice "github.com/tutti-os/tutti/services/tuttid/service/tuttimodeexecution"
@@ -64,10 +65,28 @@ type IssueMutations interface {
 	) (executionbiz.MutationResult, error)
 }
 
+type IssueDetails interface {
+	GetIssueDetail(
+		context.Context,
+		string,
+		string,
+	) (workspaceissues.IssueDetail, error)
+}
+
+type IssueExecutionReads interface {
+	GetByIssue(
+		context.Context,
+		string,
+		string,
+	) (executionbiz.Aggregate, error)
+}
+
 type Provider struct {
 	workspaces       cliservice.WorkspaceCatalog
 	plans            Plans
 	turns            ActiveTurns
+	issueDetails     IssueDetails
+	executionReads   IssueExecutionReads
 	schedules        IssueSchedules
 	mutations        IssueMutations
 	acknowledgements IssueAcknowledgements
@@ -116,6 +135,31 @@ func NewProviderWithExecution(
 	return provider
 }
 
+func NewProviderWithExecutionSnapshot(
+	workspaces cliservice.WorkspaceCatalog,
+	plans Plans,
+	turns ActiveTurns,
+	schedules IssueSchedules,
+	mutations IssueMutations,
+	acknowledgements IssueAcknowledgements,
+	issueDetails IssueDetails,
+	executionReads IssueExecutionReads,
+	completions ...IssueCompletions,
+) Provider {
+	provider := NewProviderWithExecution(
+		workspaces,
+		plans,
+		turns,
+		schedules,
+		mutations,
+		acknowledgements,
+		completions...,
+	)
+	provider.issueDetails = issueDetails
+	provider.executionReads = executionReads
+	return provider
+}
+
 func (Provider) AppID() string {
 	return appID
 }
@@ -124,7 +168,7 @@ func (Provider) AppID() string {
 // after propose/revise, and the user's review decision comes back as a new
 // user message (feedback dispatch), never as something the agent blocks on.
 func (p Provider) Commands() []cliservice.Command {
-	return []cliservice.Command{
+	commands := []cliservice.Command{
 		p.newProposeCommand(),
 		p.newReviseCommand(),
 		p.newGetCommand(),
@@ -134,6 +178,10 @@ func (p Provider) Commands() []cliservice.Command {
 		p.newIssueCompleteCommand(),
 		p.newIssueStopCommand(),
 	}
+	if p.issueDetails != nil && p.executionReads != nil {
+		commands = append(commands, p.newIssueGetCommand())
+	}
+	return commands
 }
 
 func (p Provider) requireArchives() error {

--- a/services/tuttid/service/cli/providers/tuttimodeplan/provider.go
+++ b/services/tuttid/service/cli/providers/tuttimodeplan/provider.go
@@ -49,6 +49,13 @@ type IssueCompletions interface {
 	) (tuttimodeexecutionservice.CompleteResult, error)
 }
 
+type IssueArchives interface {
+	Archive(
+		context.Context,
+		tuttimodeexecutionservice.ArchiveInput,
+	) (executionbiz.ArchiveOperation, error)
+}
+
 type IssueMutations interface {
 	MutateTuttiModeIssue(
 		context.Context,
@@ -65,6 +72,7 @@ type Provider struct {
 	mutations        IssueMutations
 	acknowledgements IssueAcknowledgements
 	completions      IssueCompletions
+	archives         IssueArchives
 }
 
 func NewProvider(
@@ -101,6 +109,9 @@ func NewProviderWithExecution(
 	provider.acknowledgements = acknowledgements
 	if len(completions) > 0 {
 		provider.completions = completions[0]
+		if archives, ok := completions[0].(IssueArchives); ok {
+			provider.archives = archives
+		}
 	}
 	return provider
 }
@@ -121,7 +132,15 @@ func (p Provider) Commands() []cliservice.Command {
 		p.newIssueScheduleCommand(),
 		p.newIssueAcknowledgeCommand(),
 		p.newIssueCompleteCommand(),
+		p.newIssueStopCommand(),
 	}
+}
+
+func (p Provider) requireArchives() error {
+	if p.archives == nil {
+		return cliservice.ServiceUnavailableError("Tutti Mode execution service is unavailable", nil)
+	}
+	return nil
 }
 
 func (p Provider) requireCompletions() error {

--- a/services/tuttid/service/cli/providers/tuttimodeplan/provider_test.go
+++ b/services/tuttid/service/cli/providers/tuttimodeplan/provider_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	workspaceissues "github.com/tutti-os/tutti/packages/workspace/issues"
 	executionbiz "github.com/tutti-os/tutti/services/tuttid/biz/tuttimodeexecution"
 	workflowbiz "github.com/tutti-os/tutti/services/tuttid/biz/workspaceworkflow"
 	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
@@ -118,6 +119,32 @@ type recordingIssueMutator struct {
 	err         error
 }
 
+type recordingIssueDetails struct {
+	detail workspaceissues.IssueDetail
+	err    error
+}
+
+func (reader *recordingIssueDetails) GetIssueDetail(
+	_ context.Context,
+	_ string,
+	_ string,
+) (workspaceissues.IssueDetail, error) {
+	return reader.detail, reader.err
+}
+
+type recordingExecutionReads struct {
+	aggregate executionbiz.Aggregate
+	err       error
+}
+
+func (reader *recordingExecutionReads) GetByIssue(
+	_ context.Context,
+	_ string,
+	_ string,
+) (executionbiz.Aggregate, error) {
+	return reader.aggregate, reader.err
+}
+
 func (mutator *recordingIssueMutator) MutateTuttiModeIssue(
 	_ context.Context,
 	workspaceID string,
@@ -211,6 +238,34 @@ func TestProviderExposesSourceScopedIssueMutateCommand(t *testing.T) {
 	}
 	if _, exists := properties["source-session-id"]; exists {
 		t.Fatalf("mutate properties expose untrusted source-session-id: %#v", properties)
+	}
+}
+
+func TestProviderExposesSourceScopedIssueExecutionSnapshot(t *testing.T) {
+	provider := NewProviderWithExecutionSnapshot(
+		nil,
+		&recordingPlans{},
+		nil,
+		&recordingIssueScheduler{},
+		&recordingIssueMutator{},
+		&recordingIssueAcknowledger{},
+		&recordingIssueDetails{},
+		&recordingExecutionReads{},
+	)
+	commands := provider.Commands()
+	if len(commands) != 9 {
+		t.Fatalf("commands = %#v, want execution snapshot command", commands)
+	}
+	command := commands[8]
+	if command.Capability.ID != "tutti-mode-plan.plan.issue.get" {
+		t.Fatalf("execution snapshot command id = %q", command.Capability.ID)
+	}
+	properties := command.Capability.InputSchema["properties"].(map[string]any)
+	if _, ok := properties["issue-id"]; !ok {
+		t.Fatalf("execution snapshot properties = %#v", properties)
+	}
+	if _, exists := properties["source-session-id"]; exists {
+		t.Fatalf("execution snapshot exposes untrusted source-session-id: %#v", properties)
 	}
 }
 
@@ -534,8 +589,9 @@ func TestRunIssueMutateDerivesCallerAndReturnsNewRevision(t *testing.T) {
 		issueMutateInput{
 			IssueID: "issue-1", CheckpointID: "checkpoint-1",
 			ExpectedGraphRevision: 3,
-			OperationsJSON:        `[{"kind":"add","task":{"TaskID":"task-c","Title":"Task C"}}]`,
-			RequestID:             "mutate-1",
+			OperationsJSON: `[{"kind":"add","task":{"taskId":"task-c","title":"Task C",` +
+				`"agentTargetId":"codex"}}]`,
+			RequestID: "mutate-1",
 		},
 	)
 	if err != nil {
@@ -552,6 +608,29 @@ func TestRunIssueMutateDerivesCallerAndReturnsNewRevision(t *testing.T) {
 	value := result.(map[string]any)
 	if value["graphRevision"] != int64(4) || value["replayed"] != true {
 		t.Fatalf("mutation result = %#v", value)
+	}
+}
+
+func TestParseMutationOperationsPreservesExplicitZeroValues(t *testing.T) {
+	operations, err := parseMutationOperationsJSON(
+		`[{"kind":"update","taskId":"task-a","task":{` +
+			`"title":"","dependencyTaskIds":[],"parallelizable":false,"autoAccept":false}}]`,
+	)
+	if err != nil {
+		t.Fatalf("parseMutationOperationsJSON() error = %v", err)
+	}
+	if len(operations) != 1 {
+		t.Fatalf("operations = %#v", operations)
+	}
+	operation := operations[0]
+	if !operation.TaskFields.Title ||
+		!operation.TaskFields.DependencyTaskIDs ||
+		!operation.TaskFields.Parallelizable ||
+		!operation.TaskFields.AutoAccept ||
+		operation.Task.Title != "" ||
+		operation.Task.Parallelizable ||
+		operation.Task.AutoAccept {
+		t.Fatalf("presence-aware operation = %#v", operation)
 	}
 }
 
@@ -633,7 +712,7 @@ func TestIssueMutateRejectsReplacementAliasBeforeCallingMutator(t *testing.T) {
 	)
 	if !errors.Is(err, cliservice.ErrInvalidInput) ||
 		!strings.Contains(err.Error(), `"replacement"`) ||
-		!strings.Contains(err.Error(), "task.taskId") {
+		!strings.Contains(err.Error(), `"task" object with "taskId"`) {
 		t.Fatalf("replacement alias error = %v, want actionable task validation", err)
 	}
 	if !reflect.DeepEqual(mutator.input, workspaceservice.MutateTuttiModeIssueInput{}) {
@@ -734,7 +813,7 @@ func TestRunIssueAcknowledgeMapsMissingExecutionWithoutScheduleCopy(t *testing.T
 		},
 	)
 	if !errors.Is(err, cliservice.ErrInvalidInput) ||
-		!strings.Contains(strings.ToLower(err.Error()), "acknowledge") ||
+		!strings.Contains(strings.ToLower(err.Error()), "execution") ||
 		strings.Contains(strings.ToLower(err.Error()), "schedule") {
 		t.Fatalf("missing execution acknowledge error = %v", err)
 	}
@@ -774,6 +853,156 @@ func TestRunScheduleDerivesCallerOnlyFromInvokeContext(t *testing.T) {
 		value["checkpointId"] != "checkpoint-1" ||
 		value["graphRevision"] != int64(3) {
 		t.Fatalf("schedule result = %#v", value)
+	}
+}
+
+func TestRunIssueGetReturnsAuthoritativeRecoverySnapshot(t *testing.T) {
+	reader := &recordingExecutionReads{aggregate: executionbiz.Aggregate{
+		Execution: executionbiz.Execution{
+			ID:                 "execution-1",
+			IssueID:            "issue-1",
+			SourceSessionID:    "source-session",
+			Status:             executionbiz.StatusAwaitingMain,
+			GraphRevision:      4,
+			ActiveCheckpointID: "checkpoint-canceled",
+			ReviewMode:         executionbiz.ReviewModeSelf,
+		},
+		Checkpoints: []executionbiz.Checkpoint{{
+			ID:             "checkpoint-canceled",
+			Kind:           executionbiz.CheckpointKindTaskCanceled,
+			Status:         executionbiz.CheckpointStatusActive,
+			Sequence:       2,
+			GraphRevision:  4,
+			SubjectTaskID:  "task-a",
+			SubjectRunID:   "run-a",
+			CreationReason: "run_canceled",
+		}},
+	}}
+	details := &recordingIssueDetails{detail: workspaceissues.IssueDetail{
+		Tasks: []workspaceissues.Task{
+			{
+				TaskID: "task-a", Status: workspaceissues.StatusCanceled,
+				SupersededAtUnixMS: 1, SupersededByTaskID: "task-a-retry",
+			},
+			{
+				TaskID: "task-a-retry", Status: workspaceissues.StatusNotStarted,
+				AgentTargetID: "local:codex", Model: "gpt-5.4-codex",
+			},
+			{
+				TaskID: "task-b", Status: workspaceissues.StatusNotStarted,
+				AgentTargetID: "local:codex", DependencyTaskIDs: []string{"task-a-retry"},
+			},
+		},
+	}}
+	provider := Provider{issueDetails: details, executionReads: reader}
+	result, err := provider.runIssueGet(
+		context.Background(),
+		framework.InvokeContext{
+			WorkspaceID: "workspace-1",
+			Request: cliservice.InvokeRequest{Context: cliservice.InvokeContext{
+				AgentSessionID: " source-session ",
+			}},
+		},
+		issueGetInput{IssueID: "issue-1"},
+	)
+	if err != nil {
+		t.Fatalf("runIssueGet() error = %v", err)
+	}
+	value := result.(map[string]any)
+	execution := value["execution"].(map[string]any)
+	active := value["activeCheckpoint"].(map[string]any)
+	ready := value["readyTaskIds"].([]string)
+	tasks := value["tasks"].([]map[string]any)
+	if execution["graphRevision"] != int64(4) ||
+		active["checkpointId"] != "checkpoint-canceled" ||
+		!reflect.DeepEqual(ready, []string{"task-a-retry"}) ||
+		tasks[0]["blockerReason"] != "task_superseded" ||
+		tasks[1]["agentTargetId"] != "local:codex" ||
+		tasks[2]["blockerReason"] != "dependency_unsatisfied" ||
+		!strings.Contains(value["recoveryHint"].(string), "new taskId") {
+		t.Fatalf("execution snapshot = %#v", value)
+	}
+}
+
+func TestRunIssueGetRejectsDifferentSourceSessionWithStableReason(t *testing.T) {
+	provider := Provider{
+		issueDetails: &recordingIssueDetails{},
+		executionReads: &recordingExecutionReads{aggregate: executionbiz.Aggregate{
+			Execution: executionbiz.Execution{
+				IssueID: "issue-1", SourceSessionID: "other-session",
+			},
+		}},
+	}
+	_, err := provider.runIssueGet(
+		context.Background(),
+		framework.InvokeContext{
+			WorkspaceID: "workspace-1",
+			Request: cliservice.InvokeRequest{Context: cliservice.InvokeContext{
+				AgentSessionID: "source-session",
+			}},
+		},
+		issueGetInput{IssueID: "issue-1"},
+	)
+	if !errors.Is(err, cliservice.ErrInvalidInput) ||
+		cliservice.InvokeErrorReason(err) != string(executionbiz.RejectionWrongSourceSession) {
+		t.Fatalf("runIssueGet() error = %v, reason = %q", err, cliservice.InvokeErrorReason(err))
+	}
+}
+
+func TestIssueExecutionSnapshotProjectsReviewedSettlementForReadiness(t *testing.T) {
+	value := issueExecutionSnapshotJSON(
+		executionbiz.Aggregate{
+			Execution: executionbiz.Execution{
+				ID:                 "execution-1",
+				IssueID:            "issue-1",
+				Status:             executionbiz.StatusAwaitingMain,
+				GraphRevision:      2,
+				ActiveCheckpointID: "checkpoint-settled",
+			},
+			Checkpoints: []executionbiz.Checkpoint{{
+				ID:            "checkpoint-settled",
+				Kind:          executionbiz.CheckpointKindTaskSettled,
+				Status:        executionbiz.CheckpointStatusActive,
+				GraphRevision: 2,
+				SubjectTaskID: "task-a",
+			}},
+		},
+		workspaceissues.IssueDetail{Tasks: []workspaceissues.Task{
+			{
+				TaskID: "task-a", Status: workspaceissues.StatusPendingAcceptance,
+				AgentTargetID: "local:codex",
+			},
+			{
+				TaskID: "task-b", Status: workspaceissues.StatusNotStarted,
+				AgentTargetID: "local:codex", DependencyTaskIDs: []string{"task-a"},
+			},
+		}},
+	)
+	if ready := value["readyTaskIds"].([]string); !reflect.DeepEqual(
+		ready, []string{"task-b"},
+	) {
+		t.Fatalf("readyTaskIds = %#v", ready)
+	}
+	tasks := value["tasks"].([]map[string]any)
+	if tasks[0]["status"] != string(workspaceissues.StatusPendingAcceptance) ||
+		tasks[1]["ready"] != true {
+		t.Fatalf("tasks = %#v", tasks)
+	}
+}
+
+func TestScheduleRejectionCarriesStableReasonAndHint(t *testing.T) {
+	err := agentScheduleError(
+		executionbiz.Reject(
+			executionbiz.ErrScheduleRejected,
+			executionbiz.RejectionMissingAgentTarget,
+			"task-a",
+		),
+		"issue-1",
+	)
+	if !errors.Is(err, cliservice.ErrInvalidInput) ||
+		cliservice.InvokeErrorReason(err) != string(executionbiz.RejectionMissingAgentTarget) ||
+		!strings.Contains(err.Error(), "agentTargetId") {
+		t.Fatalf("agentScheduleError() = %v, reason = %q", err, cliservice.InvokeErrorReason(err))
 	}
 }
 

--- a/services/tuttid/service/cli/providers/tuttimodeplan/provider_test.go
+++ b/services/tuttid/service/cli/providers/tuttimodeplan/provider_test.go
@@ -75,6 +75,7 @@ func TestProviderExposesAgentPlanAndExecutionCommands(t *testing.T) {
 		"tutti-mode-plan.plan.issue.schedule",
 		"tutti-mode-plan.plan.issue.acknowledge",
 		"tutti-mode-plan.plan.issue.complete",
+		"tutti-mode-plan.plan.issue.stop",
 	}
 	if len(commands) != len(wantIDs) {
 		t.Fatalf("commands = %#v", commands)
@@ -172,7 +173,7 @@ func (scheduler *recordingIssueScheduler) ScheduleTuttiModeIssue(
 
 func TestProviderExposesSourceScopedIssueScheduleCommand(t *testing.T) {
 	commands := NewProvider(nil, &recordingPlans{}, nil, &recordingIssueScheduler{}).Commands()
-	if len(commands) != 7 {
+	if len(commands) != 8 {
 		t.Fatalf("commands = %#v, want schedule and acknowledge commands", commands)
 	}
 	command := commands[4]
@@ -224,7 +225,7 @@ func TestProviderExposesSourceScopedIssueAcknowledgeCommand(t *testing.T) {
 		acknowledger,
 	)
 	commands := provider.Commands()
-	if len(commands) != 7 {
+	if len(commands) != 8 {
 		t.Fatalf("commands = %#v, want acknowledge command", commands)
 	}
 	command := commands[5]
@@ -249,7 +250,7 @@ func TestProviderExposesSourceScopedIssueAcknowledgeCommand(t *testing.T) {
 
 func TestProviderExposesSourceScopedGoalReviewCompleteCommand(t *testing.T) {
 	commands := NewProvider(nil, &recordingPlans{}, nil).Commands()
-	if len(commands) != 7 {
+	if len(commands) != 8 {
 		t.Fatalf("commands = %#v, want source-main complete command", commands)
 	}
 	command := commands[6]
@@ -274,9 +275,119 @@ func TestProviderExposesSourceScopedGoalReviewCompleteCommand(t *testing.T) {
 	}
 }
 
+func TestProviderExposesSourceScopedIssueStopCommand(t *testing.T) {
+	commands := NewProvider(nil, &recordingPlans{}, nil).Commands()
+	command := commands[7]
+	if command.Capability.ID != "tutti-mode-plan.plan.issue.stop" {
+		t.Fatalf("stop command id = %q", command.Capability.ID)
+	}
+	properties := command.Capability.InputSchema["properties"].(map[string]any)
+	for _, name := range []string{
+		"issue-id", "checkpoint-id", "expected-graph-revision",
+		"request-id", "reason",
+	} {
+		if _, ok := properties[name]; !ok {
+			t.Fatalf("stop properties = %#v, missing %q", properties, name)
+		}
+	}
+	if _, exists := properties["source-session-id"]; exists {
+		t.Fatalf("stop exposes untrusted source-session-id: %#v", properties)
+	}
+}
+
 type recordingIssueCompleter struct {
 	input tuttimodeexecutionservice.CompleteInput
 	err   error
+}
+
+type recordingIssueArchiver struct {
+	input tuttimodeexecutionservice.ArchiveInput
+	err   error
+}
+
+func (archiver *recordingIssueArchiver) Archive(
+	_ context.Context,
+	input tuttimodeexecutionservice.ArchiveInput,
+) (executionbiz.ArchiveOperation, error) {
+	archiver.input = input
+	if archiver.err != nil {
+		return executionbiz.ArchiveOperation{}, archiver.err
+	}
+	return executionbiz.ArchiveOperation{
+		ExecutionID: "execution-1", IssueID: input.IssueID,
+		OperationID: "archive:execution-1:" + input.RequestID,
+		RequestID:   input.RequestID, Status: executionbiz.ArchiveStatusCompleted,
+		RequestedBy: input.SourceSessionID, Reason: input.Reason,
+	}, nil
+}
+
+func TestRunIssueStopDerivesTrustedCallerAndReturnsStructuredResult(t *testing.T) {
+	archiver := &recordingIssueArchiver{}
+	result, err := (Provider{archives: archiver}).runIssueStop(
+		context.Background(),
+		framework.InvokeContext{
+			WorkspaceID: "workspace-1",
+			Request: cliservice.InvokeRequest{Context: cliservice.InvokeContext{
+				AgentSessionID: " source-session ",
+			}},
+		},
+		issueStopInput{
+			IssueID: "issue-1", CheckpointID: "checkpoint-1",
+			ExpectedGraphRevision: 7, RequestID: "stop-1",
+			Reason: "superseded by replacement plan",
+		},
+	)
+	if err != nil {
+		t.Fatalf("runIssueStop() error = %v", err)
+	}
+	if archiver.input.WorkspaceID != "workspace-1" ||
+		archiver.input.SourceSessionID != "source-session" ||
+		archiver.input.IssueID != "issue-1" ||
+		archiver.input.CheckpointID != "checkpoint-1" ||
+		archiver.input.ExpectedGraphRevision != 7 ||
+		archiver.input.RequestID != "stop-1" ||
+		archiver.input.Reason != "superseded by replacement plan" ||
+		archiver.input.RequestedBy != "" {
+		t.Fatalf("Archive input = %#v", archiver.input)
+	}
+	value := result.(map[string]any)
+	if value["executionId"] != "execution-1" ||
+		value["issueId"] != "issue-1" ||
+		value["operationId"] != "archive:execution-1:stop-1" ||
+		value["status"] != string(executionbiz.ArchiveStatusCompleted) ||
+		value["reason"] != "superseded by replacement plan" {
+		t.Fatalf("stop result = %#v", value)
+	}
+}
+
+func TestRunIssueStopMapsFenceErrorsWithoutLeakingDetails(t *testing.T) {
+	for _, contractErr := range []error{
+		executionbiz.ErrInvalidExecution,
+		executionbiz.ErrExecutionNotFound,
+		executionbiz.ErrExecutionConflict,
+	} {
+		archiver := &recordingIssueArchiver{
+			err: fmt.Errorf("%w: secret durable row", contractErr),
+		}
+		_, err := (Provider{archives: archiver}).runIssueStop(
+			context.Background(),
+			framework.InvokeContext{
+				WorkspaceID: "workspace-1",
+				Request: cliservice.InvokeRequest{Context: cliservice.InvokeContext{
+					AgentSessionID: "source-session",
+				}},
+			},
+			issueStopInput{
+				IssueID: "issue-1", CheckpointID: "checkpoint-1",
+				ExpectedGraphRevision: 7, RequestID: "stop-errors",
+				Reason: "replaced",
+			},
+		)
+		if !errors.Is(err, cliservice.ErrInvalidInput) ||
+			strings.Contains(err.Error(), "secret durable row") {
+			t.Fatalf("stop error %v mapped to %v", contractErr, err)
+		}
+	}
 }
 
 func (completer *recordingIssueCompleter) Complete(
@@ -473,6 +584,60 @@ func TestIssueMutateRejectsInvalidJSONAndMapsFenceErrors(t *testing.T) {
 		if !errors.Is(err, cliservice.ErrInvalidInput) {
 			t.Fatalf("mutation error %v mapped to %v", contractError, err)
 		}
+	}
+}
+
+func TestIssueMutateRejectsOpAliasBeforeCallingMutator(t *testing.T) {
+	mutator := &recordingIssueMutator{}
+	provider := Provider{mutations: mutator}
+	_, err := provider.runIssueMutate(
+		context.Background(),
+		framework.InvokeContext{
+			WorkspaceID: "workspace-1",
+			Request: cliservice.InvokeRequest{Context: cliservice.InvokeContext{
+				AgentSessionID: "source-session",
+			}},
+		},
+		issueMutateInput{
+			IssueID: "issue-1", CheckpointID: "checkpoint-1",
+			ExpectedGraphRevision: 3,
+			OperationsJSON:        `[{"op":"supersede","taskId":"task-a"}]`,
+			RequestID:             "mutate-invalid-op",
+		},
+	)
+	if !errors.Is(err, cliservice.ErrInvalidInput) || !strings.Contains(err.Error(), `"kind"`) {
+		t.Fatalf("op alias error = %v, want actionable kind validation", err)
+	}
+	if !reflect.DeepEqual(mutator.input, workspaceservice.MutateTuttiModeIssueInput{}) {
+		t.Fatalf("invalid operation reached mutation service: %#v", mutator.input)
+	}
+}
+
+func TestIssueMutateRejectsReplacementAliasBeforeCallingMutator(t *testing.T) {
+	mutator := &recordingIssueMutator{}
+	provider := Provider{mutations: mutator}
+	_, err := provider.runIssueMutate(
+		context.Background(),
+		framework.InvokeContext{
+			WorkspaceID: "workspace-1",
+			Request: cliservice.InvokeRequest{Context: cliservice.InvokeContext{
+				AgentSessionID: "source-session",
+			}},
+		},
+		issueMutateInput{
+			IssueID: "issue-1", CheckpointID: "checkpoint-1",
+			ExpectedGraphRevision: 3,
+			OperationsJSON:        `[{"kind":"rework","taskId":"task-a","replacement":{"taskId":"task-b"}}]`,
+			RequestID:             "mutate-invalid-replacement",
+		},
+	)
+	if !errors.Is(err, cliservice.ErrInvalidInput) ||
+		!strings.Contains(err.Error(), `"replacement"`) ||
+		!strings.Contains(err.Error(), "task.taskId") {
+		t.Fatalf("replacement alias error = %v, want actionable task validation", err)
+	}
+	if !reflect.DeepEqual(mutator.input, workspaceservice.MutateTuttiModeIssueInput{}) {
+		t.Fatalf("invalid operation reached mutation service: %#v", mutator.input)
 	}
 }
 

--- a/services/tuttid/service/cli/registry.go
+++ b/services/tuttid/service/cli/registry.go
@@ -16,9 +16,10 @@ var (
 )
 
 type InvokeError struct {
-	Kind   error
-	Reason string
-	Err    error
+	Kind       error
+	ReasonCode string
+	Reason     string
+	Err        error
 }
 
 func (e *InvokeError) Error() string {
@@ -59,9 +60,21 @@ func WorkspaceOperationError(reason string, err error) error {
 	return &InvokeError{Kind: ErrWorkspaceOperation, Reason: strings.TrimSpace(reason), Err: err}
 }
 
+func InvalidInputReasonError(reasonCode string, message string, err error) error {
+	return &InvokeError{
+		Kind:       ErrInvalidInput,
+		ReasonCode: strings.TrimSpace(reasonCode),
+		Reason:     strings.TrimSpace(message),
+		Err:        err,
+	}
+}
+
 func InvokeErrorReason(err error) string {
 	var invokeErr *InvokeError
 	if errors.As(err, &invokeErr) {
+		if invokeErr.ReasonCode != "" {
+			return invokeErr.ReasonCode
+		}
 		return invokeErr.Reason
 	}
 	return ""

--- a/services/tuttid/service/tuttimodeexecution/archive.go
+++ b/services/tuttid/service/tuttimodeexecution/archive.go
@@ -2,6 +2,7 @@ package tuttimodeexecution
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -9,11 +10,21 @@ import (
 )
 
 type ArchiveInput struct {
-	WorkspaceID string
-	IssueID     string
-	RequestID   string
-	RequestedBy string
-	Reason      string
+	WorkspaceID           string
+	IssueID               string
+	RequestID             string
+	RequestedBy           string
+	Reason                string
+	SourceSessionID       string
+	CheckpointID          string
+	ExpectedGraphRevision int64
+}
+
+type StopSourceSessionInput struct {
+	WorkspaceID     string
+	SourceSessionID string
+	RequestID       string
+	Reason          string
 }
 
 func (service Service) Archive(
@@ -28,6 +39,17 @@ func (service Service) Archive(
 	input.RequestID = strings.TrimSpace(input.RequestID)
 	input.RequestedBy = strings.TrimSpace(input.RequestedBy)
 	input.Reason = strings.TrimSpace(input.Reason)
+	input.SourceSessionID = strings.TrimSpace(input.SourceSessionID)
+	input.CheckpointID = strings.TrimSpace(input.CheckpointID)
+	sourceScoped := input.SourceSessionID != "" || input.CheckpointID != "" ||
+		input.ExpectedGraphRevision != 0
+	if sourceScoped {
+		if input.SourceSessionID == "" || input.CheckpointID == "" ||
+			input.ExpectedGraphRevision < 1 {
+			return executionbiz.ArchiveOperation{}, executionbiz.ErrInvalidExecution
+		}
+		input.RequestedBy = input.SourceSessionID
+	}
 	if input.WorkspaceID == "" || input.IssueID == "" || input.RequestID == "" ||
 		input.RequestedBy == "" || input.Reason == "" {
 		return executionbiz.ArchiveOperation{}, executionbiz.ErrInvalidExecution
@@ -35,7 +57,9 @@ func (service Service) Archive(
 	operation, _, err := service.Archives.RequestTuttiModeArchive(ctx, executionbiz.ArchiveRequest{
 		WorkspaceID: input.WorkspaceID, IssueID: input.IssueID,
 		RequestID: input.RequestID, RequestedBy: input.RequestedBy,
-		Reason: input.Reason, Now: service.now(),
+		Reason: input.Reason, SourceSessionID: input.SourceSessionID,
+		CheckpointID:          input.CheckpointID,
+		ExpectedGraphRevision: input.ExpectedGraphRevision, Now: service.now(),
 	})
 	if err != nil || operation.Status == executionbiz.ArchiveStatusCompleted {
 		return operation, err
@@ -45,6 +69,51 @@ func (service Service) Archive(
 		service.ArchiveRecoveryQueue.Enqueue(current.WorkspaceID)
 	}
 	return current, reconcileErr
+}
+
+func (service Service) StopSourceSession(
+	ctx context.Context,
+	input StopSourceSessionInput,
+) (int, error) {
+	if service.Archives == nil || service.ArchiveRuns == nil {
+		return 0, ErrServiceUnavailable
+	}
+	input.WorkspaceID = strings.TrimSpace(input.WorkspaceID)
+	input.SourceSessionID = strings.TrimSpace(input.SourceSessionID)
+	input.RequestID = strings.TrimSpace(input.RequestID)
+	input.Reason = strings.TrimSpace(input.Reason)
+	if input.WorkspaceID == "" || input.SourceSessionID == "" {
+		return 0, executionbiz.ErrInvalidExecution
+	}
+	if input.RequestID == "" {
+		input.RequestID = "source-session-stop"
+	}
+	if input.Reason == "" {
+		input.Reason = "source_turn_canceled"
+	}
+	operations, err := service.Archives.RequestTuttiModeArchivesForSourceSession(
+		ctx,
+		executionbiz.SourceSessionArchiveRequest{
+			WorkspaceID: input.WorkspaceID, SourceSessionID: input.SourceSessionID,
+			RequestID: input.RequestID, RequestedBy: input.SourceSessionID,
+			Reason: input.Reason, Now: service.now(),
+		},
+	)
+	if err != nil {
+		return 0, err
+	}
+	var reconcileErrors []error
+	for _, operation := range operations {
+		current, reconcileErr := service.reconcileArchive(ctx, operation)
+		if reconcileErr != nil {
+			reconcileErrors = append(reconcileErrors, reconcileErr)
+		}
+		if current.Status != executionbiz.ArchiveStatusCompleted &&
+			service.ArchiveRecoveryQueue != nil {
+			service.ArchiveRecoveryQueue.Enqueue(current.WorkspaceID)
+		}
+	}
+	return len(operations), errors.Join(reconcileErrors...)
 }
 
 func (service Service) GetArchive(
@@ -88,19 +157,133 @@ func (service Service) RecoverArchivesAndCount(ctx context.Context, workspaceID 
 func (service Service) reconcileArchive(
 	ctx context.Context, operation executionbiz.ArchiveOperation,
 ) (executionbiz.ArchiveOperation, error) {
-	if _, err := service.ArchiveRuns.CancelTuttiModeIssueExecution(
+	_, runErr := service.ArchiveRuns.CancelTuttiModeIssueExecution(
 		ctx, operation.WorkspaceID, operation.IssueID,
-	); err != nil {
+	)
+	automationErr := service.cancelArchivedAutomationTurns(ctx, operation)
+	if err := errors.Join(runErr, automationErr); err != nil {
 		failed, persistErr := service.Archives.FailTuttiModeArchive(
 			ctx, operation.WorkspaceID, operation.OperationID, err.Error(), service.now(),
 		)
 		if persistErr != nil {
 			return operation, fmt.Errorf("persist archive cancellation failure: %w", persistErr)
 		}
-		return failed, fmt.Errorf("cancel exact archive Runs: %w", err)
+		return failed, fmt.Errorf("cancel archived execution activity: %w", err)
 	}
 	current, _, err := service.Archives.CompleteTuttiModeArchiveIfSettled(
 		ctx, operation.WorkspaceID, operation.OperationID, service.now(),
 	)
 	return current, err
+}
+
+func (service Service) cancelArchivedAutomationTurns(
+	ctx context.Context,
+	operation executionbiz.ArchiveOperation,
+) error {
+	if service.ArchiveAutomationTurns == nil {
+		return nil
+	}
+	var cancelErrors []error
+	seen := make(map[string]struct{})
+	cancel := func(sessionID, turnID string) {
+		sessionID = strings.TrimSpace(sessionID)
+		turnID = strings.TrimSpace(turnID)
+		if sessionID == "" || turnID == "" {
+			return
+		}
+		key := sessionID + "\x00" + turnID
+		if _, found := seen[key]; found {
+			return
+		}
+		seen[key] = struct{}{}
+		if err := service.cancelAutomationTurn(
+			ctx, operation.WorkspaceID, sessionID, turnID,
+		); err != nil {
+			cancelErrors = append(cancelErrors, fmt.Errorf(
+				"cancel automation Turn %s/%s: %w", sessionID, turnID, err,
+			))
+		}
+	}
+	if wakeStore := service.wakeStore(); wakeStore != nil {
+		wakes, err := wakeStore.ListTuttiModeExecutionWakes(
+			ctx, operation.WorkspaceID, operation.IssueID,
+		)
+		if err != nil {
+			cancelErrors = append(cancelErrors, fmt.Errorf("list archived main wakes: %w", err))
+		} else {
+			for _, wake := range wakes {
+				sessionID := wake.CanonicalSessionID
+				turnID := wake.CanonicalTurnID
+				if turnID == "" && service.MainWakeTargets != nil {
+					observation, found, readErr := service.MainWakeTargets.ReadMainWakeTurn(
+						ctx, wake.WorkspaceID, wake.TargetSessionID, wake.ClientSubmitID,
+					)
+					if readErr != nil {
+						cancelErrors = append(cancelErrors, fmt.Errorf(
+							"resolve archived main wake %s: %w", wake.ID, readErr,
+						))
+						continue
+					}
+					if found {
+						sessionID = wake.TargetSessionID
+						turnID = observation.CanonicalTurnID
+					}
+				}
+				cancel(sessionID, turnID)
+			}
+		}
+	}
+	if reviewStore := service.reviewStore(); reviewStore != nil {
+		reviews, err := reviewStore.ListTuttiModeGoalReviews(
+			ctx, operation.WorkspaceID, operation.IssueID,
+		)
+		if err != nil {
+			cancelErrors = append(cancelErrors, fmt.Errorf("list archived reviewers: %w", err))
+		} else {
+			for _, review := range reviews {
+				sessionID := review.SessionID
+				turnID := review.TurnID
+				if turnID == "" && service.ReviewerTargets != nil {
+					delivery, found, readErr := service.ReviewerTargets.ReadReviewer(
+						ctx,
+						ReviewerLaunch{
+							WorkspaceID: review.WorkspaceID, IssueID: review.IssueID,
+							AgentTargetID: review.AgentTargetID, SessionID: review.SessionID,
+							ClientSubmitID: review.ClientSubmitID,
+						},
+					)
+					if readErr != nil {
+						cancelErrors = append(cancelErrors, fmt.Errorf(
+							"resolve archived reviewer %s: %w", review.ID, readErr,
+						))
+						continue
+					}
+					if found {
+						sessionID = delivery.CanonicalSessionID
+						turnID = delivery.CanonicalTurnID
+					}
+				}
+				cancel(sessionID, turnID)
+			}
+		}
+	}
+	return errors.Join(cancelErrors...)
+}
+
+func (service Service) cancelAutomationTurn(
+	ctx context.Context,
+	workspaceID string,
+	sessionID string,
+	turnID string,
+) error {
+	if service.ArchiveAutomationTurns == nil ||
+		strings.TrimSpace(sessionID) == "" || strings.TrimSpace(turnID) == "" {
+		return nil
+	}
+	return service.ArchiveAutomationTurns.CancelAutomationTurn(
+		context.WithoutCancel(ctx),
+		strings.TrimSpace(workspaceID),
+		strings.TrimSpace(sessionID),
+		strings.TrimSpace(turnID),
+	)
 }

--- a/services/tuttid/service/tuttimodeexecution/conformance/archive_scenarios.go
+++ b/services/tuttid/service/tuttimodeexecution/conformance/archive_scenarios.go
@@ -10,7 +10,292 @@ func ArchiveCatalog() []Scenario {
 	return []Scenario{
 		{Name: "ArchiveFencesRunsAndWaitsForSettlement", run: runArchiveFencesRunsAndWaitsForSettlement},
 		{Name: "ArchiveCancellationFailureRecoversAfterRestart", run: runArchiveCancellationFailureRecoversAfterRestart},
+		{Name: "SourceAgentStopRequiresCurrentCheckpoint", run: runSourceAgentStopRequiresCurrentCheckpoint},
+		{Name: "SourceSessionStopArchivesEveryNonterminalExecution", run: runSourceSessionStopArchivesEveryNonterminalExecution},
+		{Name: "CanceledSourceTurnRecoversStopFromDurableInbox", run: runCanceledSourceTurnRecoversStopFromDurableInbox},
+		{Name: "SourceSessionStopCancelsDispatchedAutomationTurns", run: runSourceSessionStopCancelsDispatchedAutomationTurns},
+		{Name: "SourceSessionStopCompensatesReviewerDispatchRace", run: runSourceSessionStopCompensatesReviewerDispatchRace},
+		{Name: "SourceSessionStopCompensatesMainWakeDispatchRace", run: runSourceSessionStopCompensatesMainWakeDispatchRace},
 	}
+}
+
+func runSourceSessionStopArchivesEveryNonterminalExecution(
+	ctx context.Context,
+	driver Driver,
+) error {
+	const (
+		workspaceID     = "workspace-materialization"
+		sourceSessionID = "source-session-stop-all"
+	)
+	issueIDs := make([]string, 0, 2)
+	for _, suffix := range []string{"first", "second"} {
+		issueID, err := driver.AcceptPlan(ctx, AcceptPlanInput{
+			WorkspaceID: workspaceID, WorkflowID: "workflow-stop-all-" + suffix,
+			RevisionID: "revision-stop-all-" + suffix, CheckpointID: "review-stop-all-" + suffix,
+			SourceSessionID: sourceSessionID, TopicID: "default",
+			Title: "Stop all " + suffix, Content: "Stop all " + suffix,
+			Tasks: []Task{schedulableTask("task-"+suffix, "/tmp/tutti-stop-all-"+suffix)},
+		})
+		if err != nil {
+			return err
+		}
+		issueIDs = append(issueIDs, issueID)
+	}
+	unrelatedIssueID, err := driver.AcceptPlan(ctx, AcceptPlanInput{
+		WorkspaceID: workspaceID, WorkflowID: "workflow-stop-all-unrelated",
+		RevisionID: "revision-stop-all-unrelated", CheckpointID: "review-stop-all-unrelated",
+		SourceSessionID: "source-session-unrelated", TopicID: "default",
+		Title: "Unrelated", Content: "Unrelated",
+		Tasks: []Task{schedulableTask("task-unrelated", "/tmp/tutti-stop-all-unrelated")},
+	})
+	if err != nil {
+		return err
+	}
+
+	stopped, err := driver.StopSourceSession(ctx, workspaceID, sourceSessionID)
+	if err != nil || stopped != len(issueIDs) {
+		return fmt.Errorf("StopSourceSession() count=%d error=%v, want %d", stopped, err, len(issueIDs))
+	}
+	replayed, err := driver.StopSourceSession(ctx, workspaceID, sourceSessionID)
+	if err != nil || replayed != 0 {
+		return fmt.Errorf("StopSourceSession(replay) count=%d error=%v, want 0", replayed, err)
+	}
+	for _, issueID := range issueIDs {
+		snapshot, err := driver.GetSnapshot(ctx, workspaceID, issueID)
+		if err != nil || snapshot.Execution.Status != "archived" ||
+			activeCheckpoint(snapshot).CheckpointID != "" {
+			return fmt.Errorf("stopped execution %q snapshot=%#v error=%v", issueID, snapshot, err)
+		}
+	}
+	unrelated, err := driver.GetSnapshot(ctx, workspaceID, unrelatedIssueID)
+	if err != nil || unrelated.Execution.Status != "awaiting_schedule" {
+		return fmt.Errorf("unrelated execution snapshot=%#v error=%v", unrelated, err)
+	}
+	return nil
+}
+
+func runCanceledSourceTurnRecoversStopFromDurableInbox(
+	ctx context.Context,
+	driver Driver,
+) error {
+	const (
+		workspaceID     = "workspace-materialization"
+		sourceSessionID = "source-canceled-turn-recovery"
+	)
+	issueID, err := driver.AcceptPlan(ctx, AcceptPlanInput{
+		WorkspaceID: workspaceID, WorkflowID: "workflow-canceled-turn-recovery",
+		RevisionID: "revision-canceled-turn-recovery", CheckpointID: "review-canceled-turn-recovery",
+		SourceSessionID: sourceSessionID, TopicID: "default",
+		Title: "Recover canceled source", Content: "Recover canceled source",
+		Tasks: []Task{schedulableTask("task-canceled-turn-recovery", "/tmp/tutti-canceled-turn-recovery")},
+	})
+	if err != nil {
+		return err
+	}
+	if err := driver.CommitCanonicalSourceCancellation(
+		ctx, workspaceID, sourceSessionID, "turn-canceled-source",
+	); err != nil {
+		return err
+	}
+	if err := driver.RunWatchdog(ctx, workspaceID, "watchdog-canceled-source"); err != nil {
+		return fmt.Errorf("RunWatchdog(canceled source recovery) error = %w", err)
+	}
+	snapshot, err := driver.GetSnapshot(ctx, workspaceID, issueID)
+	if err != nil || snapshot.Execution.Status != "archived" ||
+		activeCheckpoint(snapshot).CheckpointID != "" {
+		return fmt.Errorf("canceled source recovery snapshot=%#v error=%v", snapshot, err)
+	}
+	return nil
+}
+
+func runSourceSessionStopCancelsDispatchedAutomationTurns(
+	ctx context.Context,
+	driver Driver,
+) error {
+	fixture, issueID, before, err := reachGoalReview(
+		ctx, driver, "stop-reviewer-turn", "independent", "review-target",
+	)
+	if err != nil {
+		return err
+	}
+	if err := driver.RecoverReviewers(
+		ctx, fixture.WorkspaceID, "review-owner-stop",
+	); err != nil {
+		return err
+	}
+	dispatched, err := driver.GetSnapshot(ctx, fixture.WorkspaceID, issueID)
+	if err != nil || len(dispatched.Reviews) != 1 ||
+		dispatched.Reviews[0].Status != "dispatched" ||
+		dispatched.Reviews[0].TurnID == "" {
+		return fmt.Errorf("dispatched reviewer snapshot=%#v error=%v", dispatched, err)
+	}
+	review := dispatched.Reviews[0]
+	stopped, err := driver.StopSourceSession(
+		ctx, fixture.WorkspaceID, fixture.SourceSessionID,
+	)
+	if err != nil || stopped != 1 {
+		return fmt.Errorf("StopSourceSession(reviewer) count=%d error=%v", stopped, err)
+	}
+	found := false
+	for _, cancellation := range driver.AutomationTurnCancellations() {
+		if cancellation.SessionID == review.SessionID &&
+			cancellation.TurnID == review.TurnID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf(
+			"reviewer Turn %s/%s was not canceled: %#v (before=%#v)",
+			review.SessionID, review.TurnID,
+			driver.AutomationTurnCancellations(), before,
+		)
+	}
+	return nil
+}
+
+func runSourceSessionStopCompensatesReviewerDispatchRace(
+	ctx context.Context,
+	driver Driver,
+) error {
+	fixture, issueID, before, err := reachGoalReview(
+		ctx, driver, "stop-reviewer-race", "independent", "review-target",
+	)
+	if err != nil {
+		return err
+	}
+	review := before.Reviews[0]
+	driver.StopSourceSessionDuringNextReviewerSend(
+		fixture.WorkspaceID, fixture.SourceSessionID,
+	)
+	if err := driver.RecoverReviewers(
+		ctx, fixture.WorkspaceID, "review-owner-stop-race",
+	); err == nil {
+		return fmt.Errorf("RecoverReviewers(stop race) error=nil, want dispatch fence")
+	}
+	after, err := driver.GetSnapshot(ctx, fixture.WorkspaceID, issueID)
+	if err != nil || after.Execution.Status != "archived" ||
+		len(after.Reviews) != 1 || after.Reviews[0].Status != "canceled" {
+		return fmt.Errorf("reviewer stop race snapshot=%#v error=%v", after, err)
+	}
+	sessionID, turnID, found := driver.ReviewerCanonicalIdentity(review.ClientSubmitID)
+	if !found {
+		return fmt.Errorf("reviewer stop race lost canonical identity")
+	}
+	for _, cancellation := range driver.AutomationTurnCancellations() {
+		if cancellation.SessionID == sessionID && cancellation.TurnID == turnID {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"reviewer stop race did not compensate %s/%s: %#v",
+		sessionID, turnID, driver.AutomationTurnCancellations(),
+	)
+}
+
+func runSourceSessionStopCompensatesMainWakeDispatchRace(
+	ctx context.Context,
+	driver Driver,
+) error {
+	const (
+		workspaceID     = "workspace-materialization"
+		sourceSessionID = "source-stop-main-wake-race"
+	)
+	issueID, err := driver.AcceptPlan(ctx, AcceptPlanInput{
+		WorkspaceID: workspaceID, WorkflowID: "workflow-stop-main-wake-race",
+		RevisionID: "revision-stop-main-wake-race", CheckpointID: "review-stop-main-wake-race",
+		SourceSessionID: sourceSessionID, TopicID: "default",
+		Title: "Stop main wake race", Content: "Stop main wake race",
+		Tasks: []Task{schedulableTask("task-stop-main-wake-race", "/tmp/tutti-stop-main-wake-race")},
+	})
+	if err != nil {
+		return err
+	}
+	wakes, err := driver.ListWakes(ctx, workspaceID, issueID)
+	if err != nil || len(wakes) != 1 {
+		return fmt.Errorf("main wake race setup wakes=%#v error=%v", wakes, err)
+	}
+	wake := wakes[0]
+	driver.StopSourceSessionDuringNextWakeSend(workspaceID, sourceSessionID)
+	if err := driver.RecoverWakes(
+		ctx, workspaceID, "wake-owner-stop-race",
+	); err == nil {
+		return fmt.Errorf("RecoverWakes(stop race) error=nil, want dispatch fence")
+	}
+	after, err := driver.GetSnapshot(ctx, workspaceID, issueID)
+	if err != nil || after.Execution.Status != "archived" {
+		return fmt.Errorf("main wake stop race snapshot=%#v error=%v", after, err)
+	}
+	for _, cancellation := range driver.AutomationTurnCancellations() {
+		if cancellation.SessionID == sourceSessionID &&
+			cancellation.TurnID != "" {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"main wake stop race did not compensate %s: wake=%#v cancellations=%#v",
+		sourceSessionID, wake, driver.AutomationTurnCancellations(),
+	)
+}
+
+func runSourceAgentStopRequiresCurrentCheckpoint(
+	ctx context.Context,
+	driver Driver,
+) error {
+	fixture := settlementFixture("source-agent-stop")
+	issueID, err := driver.AcceptPlan(ctx, AcceptPlanInput{
+		WorkspaceID: fixture.WorkspaceID, WorkflowID: fixture.WorkflowID,
+		RevisionID:      "revision-source-agent-stop",
+		CheckpointID:    "review-source-agent-stop",
+		SourceSessionID: fixture.SourceSessionID,
+		TopicID:         "default", Title: "Stop", Content: "Stop",
+		Tasks: []Task{schedulableTask("task-a", "/tmp/tutti-source-agent-stop")},
+	})
+	if err != nil {
+		return err
+	}
+	snapshot, err := driver.GetSnapshot(ctx, fixture.WorkspaceID, issueID)
+	if err != nil {
+		return err
+	}
+	checkpoint := activeCheckpoint(snapshot)
+	rejected := ArchiveInput{
+		WorkspaceID: fixture.WorkspaceID, IssueID: issueID,
+		SourceSessionID: "another-source", CheckpointID: checkpoint.CheckpointID,
+		ExpectedGraphRevision: snapshot.Execution.GraphRevision,
+		RequestID:             "source-agent-stop-wrong-source", Reason: "replaced",
+	}
+	if _, err := driver.Archive(ctx, rejected); err == nil {
+		return fmt.Errorf("source Agent stop with wrong source error = nil")
+	}
+	stop := rejected
+	stop.SourceSessionID = fixture.SourceSessionID
+	stop.RequestID = "source-agent-stop"
+	operation, err := driver.Archive(ctx, stop)
+	if err != nil || operation.Status != "completed" ||
+		operation.RequestedBy != fixture.SourceSessionID {
+		return fmt.Errorf("source Agent stop=%#v error=%v", operation, err)
+	}
+	replay, err := driver.Archive(ctx, stop)
+	if err != nil || replay.OperationID != operation.OperationID {
+		return fmt.Errorf("source Agent stop replay=%#v error=%v", replay, err)
+	}
+	final, err := driver.GetSnapshot(ctx, fixture.WorkspaceID, issueID)
+	if err != nil || final.Execution.Status != "archived" ||
+		activeCheckpoint(final).CheckpointID != "" {
+		return fmt.Errorf("source Agent stop final=%#v error=%v", final, err)
+	}
+	wakes, err := driver.ListWakes(ctx, fixture.WorkspaceID, issueID)
+	if err != nil {
+		return err
+	}
+	for _, wake := range wakes {
+		if wake.Status != "canceled" && wake.Status != "acknowledged" &&
+			wake.Status != "failed" {
+			return fmt.Errorf("source Agent stop left open wake=%#v", wake)
+		}
+	}
+	return nil
 }
 
 func runArchiveFencesRunsAndWaitsForSettlement(ctx context.Context, driver Driver) error {

--- a/services/tuttid/service/tuttimodeexecution/conformance/catalog.go
+++ b/services/tuttid/service/tuttimodeexecution/conformance/catalog.go
@@ -33,6 +33,14 @@ func MutationCatalog() []Scenario {
 			run:  runMutationOperationsCommitAllOrNone,
 		},
 		{
+			Name: "FailedTaskReworkInheritsLaunchAndRebindsDependents",
+			run:  runFailedTaskReworkInheritsLaunchAndRebindsDependents,
+		},
+		{
+			Name: "CanceledTaskReworkInheritsLaunchAndSchedulesReplacement",
+			run:  runCanceledTaskReworkInheritsLaunchAndSchedulesReplacement,
+		},
+		{
 			Name: "LogicalSupersessionPreservesHistoryAndRequiresSettlement",
 			run:  runLogicalSupersessionPreservesHistoryAndRequiresSettlement,
 		},

--- a/services/tuttid/service/tuttimodeexecution/conformance/catalog.go
+++ b/services/tuttid/service/tuttimodeexecution/conformance/catalog.go
@@ -62,6 +62,10 @@ func SettlementCatalog() []Scenario {
 			run:  runScheduleReviewPromotesExistingSettlementBacklog,
 		},
 		{
+			Name: "GraphMutationRebindsPromotedSettlementBacklog",
+			run:  runGraphMutationRebindsPromotedSettlementBacklog,
+		},
+		{
 			Name: "TimedOutRunCreatesFailedCheckpoint",
 			run:  runTimedOutRunCreatesFailedCheckpoint,
 		},

--- a/services/tuttid/service/tuttimodeexecution/conformance/driver.go
+++ b/services/tuttid/service/tuttimodeexecution/conformance/driver.go
@@ -249,11 +249,14 @@ type SwitchReviewToSelfResult struct {
 }
 
 type ArchiveInput struct {
-	WorkspaceID string
-	IssueID     string
-	RequestID   string
-	RequestedBy string
-	Reason      string
+	WorkspaceID           string
+	IssueID               string
+	RequestID             string
+	RequestedBy           string
+	Reason                string
+	SourceSessionID       string
+	CheckpointID          string
+	ExpectedGraphRevision int64
 }
 
 type ArchiveOperation struct {
@@ -301,6 +304,11 @@ type SourceSessionActivity struct {
 	TurnStartedAt time.Time
 }
 
+type AutomationTurnCancellation struct {
+	SessionID string
+	TurnID    string
+}
+
 // Driver is the narrow public contract exercised by Tutti execution product
 // conformance. Implementations may compose real services and persistence, but
 // scenarios do not reach through this seam to implementation details.
@@ -339,6 +347,7 @@ type Driver interface {
 	FailNextReviewerAfterCanonical()
 	SubmitReviewerVerdictOnNextSend(ReviewerVerdictInput)
 	SettleReviewerOnNextSend()
+	StopSourceSessionDuringNextReviewerSend(string, string)
 	ReviewerLaunchCallCount() int
 	ReviewerCanonicalTurnCount() int
 	ReviewerCanonicalIdentity(string) (string, string, bool)
@@ -346,6 +355,9 @@ type Driver interface {
 	Archive(context.Context, ArchiveInput) (ArchiveOperation, error)
 	GetArchive(context.Context, string, string) (ArchiveOperation, error)
 	RestartRecoverArchives(context.Context, string) error
+	StopSourceSession(context.Context, string, string) (int, error)
+	CommitCanonicalSourceCancellation(context.Context, string, string, string) error
+	AutomationTurnCancellations() []AutomationTurnCancellation
 	AdmitSourceDeletion(context.Context, string, []string) error
 	ReleaseSourceDeletion(context.Context, string, []string, bool) error
 	SeedActiveRun(context.Context, string, string, string) error
@@ -437,6 +449,7 @@ type Driver interface {
 	CommitCanonicalSourceActivityDuringNextWakeSend(
 		context.Context, SourceSessionActivity, string,
 	)
+	StopSourceSessionDuringNextWakeSend(string, string)
 	RunWatchdog(context.Context, string, string) error
 	// StartupRecoverWatchdog must construct a fresh worker over the same
 	// durable store before scanning and recovering watchdog operations.

--- a/services/tuttid/service/tuttimodeexecution/conformance/mutation_scenarios.go
+++ b/services/tuttid/service/tuttimodeexecution/conformance/mutation_scenarios.go
@@ -221,6 +221,203 @@ func runMutationOperationsCommitAllOrNone(
 	return nil
 }
 
+func runFailedTaskReworkInheritsLaunchAndRebindsDependents(
+	ctx context.Context,
+	driver Driver,
+) error {
+	fixture := mutationFixture("failed-rework")
+	fixture.Tasks[1].DependencyTaskIDs = []string{"task-a"}
+	taskC := schedulableTask("task-c", "/tmp/tutti-mutation-failed-rework-c")
+	taskC.DependencyTaskIDs = []string{"task-a", "task-b"}
+	fixture.Tasks = append(fixture.Tasks, taskC)
+	issueID, err := driver.AcceptPlan(ctx, fixture)
+	if err != nil {
+		return fmt.Errorf("AcceptPlan() error = %w", err)
+	}
+	initial, err := driver.GetSnapshot(ctx, fixture.WorkspaceID, issueID)
+	if err != nil {
+		return fmt.Errorf("GetSnapshot(initial) error = %w", err)
+	}
+	scheduled, err := driver.Schedule(ctx, ScheduleInput{
+		WorkspaceID: fixture.WorkspaceID, IssueID: issueID,
+		SourceSessionID:       fixture.SourceSessionID,
+		CheckpointID:          initial.Checkpoints[0].CheckpointID,
+		ExpectedGraphRevision: initial.Execution.GraphRevision,
+		TaskIDs:               []string{"task-a"},
+		RequestID:             "schedule-failed-rework-a",
+	})
+	if err != nil {
+		return fmt.Errorf("Schedule(A) error = %w", err)
+	}
+	if err := driver.SettleRun(ctx, SettleRunInput{
+		WorkspaceID: fixture.WorkspaceID, IssueID: issueID,
+		TaskID: "task-a", RunID: scheduled.RunIDs[0], Status: "failed",
+	}); err != nil {
+		return fmt.Errorf("SettleRun(A failed) error = %w", err)
+	}
+	failed, err := driver.GetSnapshot(ctx, fixture.WorkspaceID, issueID)
+	if err != nil {
+		return fmt.Errorf("GetSnapshot(failed) error = %w", err)
+	}
+	checkpoint := failed.Checkpoints[len(failed.Checkpoints)-1]
+	if checkpoint.Kind != "task_failed" || checkpoint.Status != "active" {
+		return fmt.Errorf("failed checkpoint = %#v", checkpoint)
+	}
+	replacement := Task{
+		TaskID: "task-a-retry",
+		Title:  "Retry task A",
+		Content: "Continue the failed task without repeating its launch " +
+			"configuration.",
+	}
+	mutated, err := driver.Mutate(ctx, MutateInput{
+		WorkspaceID: fixture.WorkspaceID, IssueID: issueID,
+		SourceSessionID:       fixture.SourceSessionID,
+		CheckpointID:          checkpoint.CheckpointID,
+		ExpectedGraphRevision: failed.Execution.GraphRevision,
+		Operations: []MutationOperation{{
+			Kind: "rework", TaskID: "task-a", Task: replacement,
+		}},
+		RequestID: "rework-failed-a",
+	})
+	if err != nil {
+		return fmt.Errorf("Mutate(rework failed A) error = %w", err)
+	}
+	if !reflect.DeepEqual(mutated.AddedTaskIDs, []string{"task-a-retry"}) ||
+		!reflect.DeepEqual(mutated.UpdatedTaskIDs, []string{"task-b", "task-c"}) ||
+		!reflect.DeepEqual(mutated.SupersededTaskIDs, []string{"task-a"}) {
+		return fmt.Errorf("Mutate(rework failed A) result = %#v", mutated)
+	}
+	afterMutation, err := driver.GetSnapshot(ctx, fixture.WorkspaceID, issueID)
+	if err != nil {
+		return fmt.Errorf("GetSnapshot(after mutation) error = %w", err)
+	}
+	original := taskByID(afterMutation.Tasks, "task-a")
+	retry := taskByID(afterMutation.Tasks, "task-a-retry")
+	if original.SupersededByTaskID != "task-a-retry" ||
+		retry.AgentTargetID != original.AgentTargetID ||
+		retry.Model != original.Model ||
+		retry.PermissionModeID != original.PermissionModeID ||
+		retry.ExecutionDirectory != original.ExecutionDirectory ||
+		!reflect.DeepEqual(
+			taskByID(afterMutation.Tasks, "task-b").DependencyTaskIDs,
+			[]string{"task-a-retry"},
+		) ||
+		!reflect.DeepEqual(
+			taskByID(afterMutation.Tasks, "task-c").DependencyTaskIDs,
+			[]string{"task-a-retry", "task-b"},
+		) {
+		return fmt.Errorf("reworked dependency graph = %#v", afterMutation.Tasks)
+	}
+	retried, err := driver.Schedule(ctx, ScheduleInput{
+		WorkspaceID: fixture.WorkspaceID, IssueID: issueID,
+		SourceSessionID:       fixture.SourceSessionID,
+		CheckpointID:          checkpoint.CheckpointID,
+		ExpectedGraphRevision: mutated.GraphRevision,
+		TaskIDs:               []string{"task-a-retry"},
+		RequestID:             "schedule-failed-a-retry",
+	})
+	if err != nil {
+		return fmt.Errorf("Schedule(A retry) error = %w", err)
+	}
+	if len(retried.RunIDs) != 1 || retried.GraphRevision != mutated.GraphRevision {
+		return fmt.Errorf("Schedule(A retry) result = %#v", retried)
+	}
+	return nil
+}
+
+func runCanceledTaskReworkInheritsLaunchAndSchedulesReplacement(
+	ctx context.Context,
+	driver Driver,
+) error {
+	fixture := mutationFixture("canceled-rework")
+	issueID, err := driver.AcceptPlan(ctx, fixture)
+	if err != nil {
+		return fmt.Errorf("AcceptPlan() error = %w", err)
+	}
+	initial, err := driver.GetSnapshot(ctx, fixture.WorkspaceID, issueID)
+	if err != nil {
+		return fmt.Errorf("GetSnapshot(initial) error = %w", err)
+	}
+	scheduled, err := driver.Schedule(ctx, ScheduleInput{
+		WorkspaceID: fixture.WorkspaceID, IssueID: issueID,
+		SourceSessionID:       fixture.SourceSessionID,
+		CheckpointID:          initial.Checkpoints[0].CheckpointID,
+		ExpectedGraphRevision: initial.Execution.GraphRevision,
+		TaskIDs:               []string{"task-a"},
+		RequestID:             "schedule-canceled-rework-a",
+	})
+	if err != nil {
+		return fmt.Errorf("Schedule(A) error = %w", err)
+	}
+	if err := driver.SettleRun(ctx, SettleRunInput{
+		WorkspaceID: fixture.WorkspaceID, IssueID: issueID,
+		TaskID: "task-a", RunID: scheduled.RunIDs[0], Status: "canceled",
+	}); err != nil {
+		return fmt.Errorf("SettleRun(A canceled) error = %w", err)
+	}
+	canceled, err := driver.GetSnapshot(ctx, fixture.WorkspaceID, issueID)
+	if err != nil {
+		return fmt.Errorf("GetSnapshot(canceled) error = %w", err)
+	}
+	checkpoint := Checkpoint{}
+	for _, candidate := range canceled.Checkpoints {
+		if candidate.Status == "active" {
+			checkpoint = candidate
+			break
+		}
+	}
+	if checkpoint.Kind != "task_canceled" {
+		return fmt.Errorf("canceled checkpoint = %#v", checkpoint)
+	}
+	result, err := driver.Mutate(ctx, MutateInput{
+		WorkspaceID: fixture.WorkspaceID, IssueID: issueID,
+		SourceSessionID:       fixture.SourceSessionID,
+		CheckpointID:          checkpoint.CheckpointID,
+		ExpectedGraphRevision: canceled.Execution.GraphRevision,
+		Operations: []MutationOperation{{
+			Kind: "rework", TaskID: "task-a",
+			Task: Task{
+				TaskID: "task-a-retry",
+				Title:  "Retry canceled task A",
+				Content: "Continue the canceled task without repeating its " +
+					"launch configuration.",
+			},
+		}},
+		RequestID: "rework-canceled-a",
+	})
+	if err != nil {
+		return fmt.Errorf("Mutate(rework canceled A) error = %w", err)
+	}
+	afterMutation, err := driver.GetSnapshot(ctx, fixture.WorkspaceID, issueID)
+	if err != nil {
+		return fmt.Errorf("GetSnapshot(after mutation) error = %w", err)
+	}
+	original := taskByID(afterMutation.Tasks, "task-a")
+	retry := taskByID(afterMutation.Tasks, "task-a-retry")
+	if original.SupersededByTaskID != retry.TaskID ||
+		retry.AgentTargetID != original.AgentTargetID ||
+		retry.Model != original.Model ||
+		retry.PermissionModeID != original.PermissionModeID ||
+		retry.ExecutionDirectory != original.ExecutionDirectory {
+		return fmt.Errorf("canceled rework launch inheritance = %#v", afterMutation.Tasks)
+	}
+	retried, err := driver.Schedule(ctx, ScheduleInput{
+		WorkspaceID: fixture.WorkspaceID, IssueID: issueID,
+		SourceSessionID:       fixture.SourceSessionID,
+		CheckpointID:          checkpoint.CheckpointID,
+		ExpectedGraphRevision: result.GraphRevision,
+		TaskIDs:               []string{retry.TaskID},
+		RequestID:             "schedule-canceled-a-retry",
+	})
+	if err != nil {
+		return fmt.Errorf("Schedule(A retry) error = %w", err)
+	}
+	if len(retried.RunIDs) != 1 || retried.GraphRevision != result.GraphRevision {
+		return fmt.Errorf("Schedule(A retry) result = %#v", retried)
+	}
+	return nil
+}
+
 func runLogicalSupersessionPreservesHistoryAndRequiresSettlement(
 	ctx context.Context,
 	driver Driver,

--- a/services/tuttid/service/tuttimodeexecution/conformance/settlement_revision_scenarios.go
+++ b/services/tuttid/service/tuttimodeexecution/conformance/settlement_revision_scenarios.go
@@ -1,0 +1,124 @@
+package conformance
+
+import (
+	"context"
+	"fmt"
+)
+
+func runGraphMutationRebindsPromotedSettlementBacklog(
+	ctx context.Context,
+	driver Driver,
+) error {
+	fixture := settlementFixture("mutation-rebinds-backlog")
+	issueID, scheduled, err := acceptAndScheduleSettlement(
+		ctx, driver, fixture, []string{"task-a", "task-c"},
+	)
+	if err != nil {
+		return err
+	}
+	for index, taskID := range []string{"task-a", "task-c"} {
+		if err := driver.SettleRun(ctx, SettleRunInput{
+			WorkspaceID: fixture.WorkspaceID, IssueID: issueID,
+			TaskID: taskID, RunID: scheduled.RunIDs[index], Status: "completed",
+		}); err != nil {
+			return fmt.Errorf("SettleRun(%s) error = %w", taskID, err)
+		}
+	}
+	backlog, err := driver.GetSnapshot(ctx, fixture.WorkspaceID, issueID)
+	if err != nil || len(backlog.Checkpoints) != 3 ||
+		backlog.Checkpoints[1].Status != "active" ||
+		backlog.Checkpoints[2].Status != "pending" {
+		return fmt.Errorf("pre-mutation backlog = %#v error=%v", backlog.Checkpoints, err)
+	}
+	firstMutation, err := driver.Mutate(ctx, MutateInput{
+		WorkspaceID: fixture.WorkspaceID, IssueID: issueID,
+		SourceSessionID:       fixture.SourceSessionID,
+		CheckpointID:          backlog.Checkpoints[1].CheckpointID,
+		ExpectedGraphRevision: backlog.Execution.GraphRevision,
+		Operations: []MutationOperation{{
+			Kind: "add",
+			Task: schedulableTask("task-g", "/tmp/tutti-settlement-task-g"),
+		}},
+		RequestID: "mutate-add-g-before-schedule-promotion",
+	})
+	if err != nil {
+		return fmt.Errorf("Mutate(add G) error = %w", err)
+	}
+	runG, err := driver.Schedule(ctx, ScheduleInput{
+		WorkspaceID: fixture.WorkspaceID, IssueID: issueID,
+		SourceSessionID:       fixture.SourceSessionID,
+		CheckpointID:          backlog.Checkpoints[1].CheckpointID,
+		ExpectedGraphRevision: firstMutation.GraphRevision,
+		TaskIDs:               []string{"task-g"},
+		RequestID:             "schedule-g-promotes-c",
+	})
+	if err != nil {
+		return fmt.Errorf("Schedule(G) error = %w", err)
+	}
+	afterSchedule, err := driver.GetSnapshot(ctx, fixture.WorkspaceID, issueID)
+	if err != nil ||
+		afterSchedule.Checkpoints[2].Status != "active" ||
+		afterSchedule.Checkpoints[2].GraphRevision != firstMutation.GraphRevision {
+		return fmt.Errorf(
+			"schedule promoted stale checkpoint = %#v mutation=%#v error=%v",
+			afterSchedule.Checkpoints, firstMutation, err,
+		)
+	}
+	if err := driver.SettleRun(ctx, SettleRunInput{
+		WorkspaceID: fixture.WorkspaceID, IssueID: issueID,
+		TaskID: "task-g", RunID: runG.RunIDs[0], Status: "completed",
+	}); err != nil {
+		return fmt.Errorf("SettleRun(G) error = %w", err)
+	}
+	withPendingG, err := driver.GetSnapshot(ctx, fixture.WorkspaceID, issueID)
+	if err != nil || len(withPendingG.Checkpoints) != 4 ||
+		withPendingG.Checkpoints[2].Status != "active" ||
+		withPendingG.Checkpoints[3].Status != "pending" {
+		return fmt.Errorf("g settlement backlog = %#v error=%v", withPendingG.Checkpoints, err)
+	}
+	secondMutation, err := driver.Mutate(ctx, MutateInput{
+		WorkspaceID: fixture.WorkspaceID, IssueID: issueID,
+		SourceSessionID:       fixture.SourceSessionID,
+		CheckpointID:          withPendingG.Checkpoints[2].CheckpointID,
+		ExpectedGraphRevision: withPendingG.Execution.GraphRevision,
+		Operations: []MutationOperation{{
+			Kind: "add",
+			Task: schedulableTask("task-h", "/tmp/tutti-settlement-task-h"),
+		}},
+		RequestID: "mutate-add-h-before-acknowledge-promotion",
+	})
+	if err != nil {
+		return fmt.Errorf("Mutate(add H) error = %w", err)
+	}
+	acknowledged, err := driver.Acknowledge(ctx, AcknowledgeInput{
+		WorkspaceID: fixture.WorkspaceID, IssueID: issueID,
+		SourceSessionID:       fixture.SourceSessionID,
+		CheckpointID:          withPendingG.Checkpoints[2].CheckpointID,
+		ExpectedGraphRevision: secondMutation.GraphRevision,
+		RequestID:             "ack-c-promotes-g",
+	})
+	if err != nil {
+		return fmt.Errorf("Acknowledge(C) error = %w", err)
+	}
+	afterAcknowledge, err := driver.GetSnapshot(ctx, fixture.WorkspaceID, issueID)
+	if err != nil ||
+		acknowledged.NextCheckpointID != withPendingG.Checkpoints[3].CheckpointID ||
+		afterAcknowledge.Checkpoints[3].Status != "active" ||
+		afterAcknowledge.Checkpoints[3].GraphRevision != secondMutation.GraphRevision {
+		return fmt.Errorf(
+			"acknowledge promoted stale checkpoint = %#v result=%#v mutation=%#v error=%v",
+			afterAcknowledge.Checkpoints, acknowledged, secondMutation, err,
+		)
+	}
+	if _, err := driver.Schedule(ctx, ScheduleInput{
+		WorkspaceID: fixture.WorkspaceID, IssueID: issueID,
+		SourceSessionID:       fixture.SourceSessionID,
+		CheckpointID:          withPendingG.Checkpoints[3].CheckpointID,
+		ExpectedGraphRevision: secondMutation.GraphRevision,
+		TaskIDs:               []string{"task-h"},
+		RequestID:             "schedule-h-from-rebound-g",
+	}); err != nil {
+		return fmt.Errorf("Schedule(H from rebound G) error = %w", err)
+	}
+	return nil
+}

--- a/services/tuttid/service/tuttimodeexecution/conformance_test.go
+++ b/services/tuttid/service/tuttimodeexecution/conformance_test.go
@@ -523,6 +523,18 @@ func (*sqliteConformanceDriver) mutateWith(
 ) (tuttimodeexecutionconformance.MutateResult, error) {
 	operations := make([]executionbiz.MutationOperation, 0, len(input.Operations))
 	for _, operation := range input.Operations {
+		taskFields := executionbiz.MutationTaskFields{
+			Title:              operation.Task.Title != "",
+			Content:            operation.Task.Content != "",
+			Priority:           operation.Task.Priority != "",
+			AgentTargetID:      operation.Task.AgentTargetID != "",
+			Model:              operation.Task.Model != "",
+			PermissionModeID:   operation.Task.PermissionModeID != "",
+			ExecutionDirectory: operation.Task.ExecutionDirectory != "",
+			DependencyTaskIDs:  operation.Task.DependencyTaskIDs != nil,
+			Parallelizable:     operation.Task.Parallelizable,
+			AutoAccept:         operation.Task.AutoAccept,
+		}
 		operations = append(operations, executionbiz.MutationOperation{
 			Kind:   executionbiz.MutationOperationKind(operation.Kind),
 			TaskID: operation.TaskID,
@@ -536,6 +548,7 @@ func (*sqliteConformanceDriver) mutateWith(
 				Parallelizable:     operation.Task.Parallelizable,
 				AutoAccept:         operation.Task.AutoAccept,
 			},
+			TaskFields: taskFields,
 		})
 	}
 	result, err := service.Mutate(ctx, tuttimodeexecutionservice.MutateInput{

--- a/services/tuttid/service/tuttimodeexecution/conformance_test.go
+++ b/services/tuttid/service/tuttimodeexecution/conformance_test.go
@@ -37,6 +37,7 @@ type sqliteConformanceDriver struct {
 	wakeTarget         *recordingMainWakeTarget
 	wakeStore          *injectableWakeStore
 	reviewer           *recordingReviewerTarget
+	automationTurns    *recordingAutomationTurnCanceller
 	reviewMu           sync.Mutex
 	failReviewStep     string
 	deletionAdmissions map[string]executionbiz.SourceSessionDeletionAdmission
@@ -46,6 +47,28 @@ type sqliteConformanceDriver struct {
 type controlledClock struct {
 	mu  sync.Mutex
 	now time.Time
+}
+
+type recordingAutomationTurnCanceller struct {
+	mu            sync.Mutex
+	cancellations []tuttimodeexecutionconformance.AutomationTurnCancellation
+}
+
+func (canceller *recordingAutomationTurnCanceller) CancelAutomationTurn(
+	_ context.Context,
+	_ string,
+	sessionID string,
+	turnID string,
+) error {
+	canceller.mu.Lock()
+	defer canceller.mu.Unlock()
+	canceller.cancellations = append(
+		canceller.cancellations,
+		tuttimodeexecutionconformance.AutomationTurnCancellation{
+			SessionID: sessionID, TurnID: turnID,
+		},
+	)
+	return nil
 }
 
 func (clock *controlledClock) Now() time.Time {
@@ -287,9 +310,11 @@ func newSQLiteConformanceDriver(t *testing.T) *sqliteConformanceDriver {
 		busyBySession:           make(map[string]bool),
 		canonicalByClientSubmit: make(map[string]tuttimodeexecutionservice.ReviewerDelivery),
 	}
+	automationTurns := &recordingAutomationTurnCanceller{}
 	executions := &tuttimodeexecutionservice.Service{
 		Store: store, Wakes: wakeStore, MainWakeTargets: wakeTarget,
 		ReviewerActivity: store, ReviewerTargets: reviewer, Clock: clock.Now,
+		ArchiveAutomationTurns: automationTurns,
 	}
 	driver := &sqliteConformanceDriver{
 		dbPath: dbPath, store: store,
@@ -309,6 +334,7 @@ func newSQLiteConformanceDriver(t *testing.T) *sqliteConformanceDriver {
 		wakeTarget:         wakeTarget,
 		wakeStore:          wakeStore,
 		reviewer:           reviewer,
+		automationTurns:    automationTurns,
 		deletionAdmissions: make(map[string]executionbiz.SourceSessionDeletionAdmission),
 	}
 	driver.executions.Archives = store
@@ -1041,6 +1067,8 @@ func (driver *sqliteConformanceDriver) Archive(
 	operation, err := driver.executions.Archive(ctx, tuttimodeexecutionservice.ArchiveInput{
 		WorkspaceID: input.WorkspaceID, IssueID: input.IssueID,
 		RequestID: input.RequestID, RequestedBy: input.RequestedBy, Reason: input.Reason,
+		SourceSessionID: input.SourceSessionID, CheckpointID: input.CheckpointID,
+		ExpectedGraphRevision: input.ExpectedGraphRevision,
 	})
 	return conformanceArchiveOperation(operation), err
 }
@@ -1057,12 +1085,52 @@ func (driver *sqliteConformanceDriver) RestartRecoverArchives(
 ) error {
 	replica := &tuttimodeexecutionservice.Service{
 		Store: driver.store, Wakes: driver.wakeStore, Archives: driver.store,
+		ArchiveAutomationTurns: driver.automationTurns,
 		ArchiveRuns: &workspaceservice.IssueExecutionCoordinator{
 			Issues: &driver.issues, RunSessionCanceller: driver.canceller,
 		},
 		Clock: driver.clock.Now,
 	}
 	return replica.RecoverArchives(ctx, workspaceID)
+}
+
+func (driver *sqliteConformanceDriver) AutomationTurnCancellations() []tuttimodeexecutionconformance.AutomationTurnCancellation {
+	driver.automationTurns.mu.Lock()
+	defer driver.automationTurns.mu.Unlock()
+	return append(
+		[]tuttimodeexecutionconformance.AutomationTurnCancellation(nil),
+		driver.automationTurns.cancellations...,
+	)
+}
+
+func (driver *sqliteConformanceDriver) StopSourceSession(
+	ctx context.Context,
+	workspaceID string,
+	sourceSessionID string,
+) (int, error) {
+	return driver.executions.StopSourceSession(
+		ctx,
+		tuttimodeexecutionservice.StopSourceSessionInput{
+			WorkspaceID: workspaceID, SourceSessionID: sourceSessionID,
+		},
+	)
+}
+
+func (driver *sqliteConformanceDriver) StopSourceSessionDuringNextReviewerSend(
+	workspaceID string,
+	sourceSessionID string,
+) {
+	driver.reviewer.mu.Lock()
+	defer driver.reviewer.mu.Unlock()
+	driver.reviewer.onNextSend = func(
+		tuttimodeexecutionservice.ReviewerLaunch,
+		tuttimodeexecutionservice.ReviewerDelivery,
+	) error {
+		_, err := driver.StopSourceSession(
+			context.Background(), workspaceID, sourceSessionID,
+		)
+		return err
+	}
 }
 
 func (driver *sqliteConformanceDriver) AdmitSourceDeletion(

--- a/services/tuttid/service/tuttimodeexecution/prompts.go
+++ b/services/tuttid/service/tuttimodeexecution/prompts.go
@@ -11,6 +11,14 @@ func MainWakePrompt(wake executionbiz.Wake) string {
 		"tutti plan issue schedule --issue-id %s --checkpoint-id %s --expected-graph-revision %d",
 		wake.IssueID, wake.CheckpointID, wake.CheckpointRevision,
 	)
+	mutate := fmt.Sprintf(
+		"tutti plan issue mutate --issue-id %s --checkpoint-id %s --expected-graph-revision %d",
+		wake.IssueID, wake.CheckpointID, wake.CheckpointRevision,
+	)
+	stop := fmt.Sprintf(
+		"tutti plan issue stop --issue-id %s --checkpoint-id %s --expected-graph-revision %d",
+		wake.IssueID, wake.CheckpointID, wake.CheckpointRevision,
+	)
 	header := fmt.Sprintf(`A durable Tutti Mode execution checkpoint requires your review.
 
 Issue: %s
@@ -21,9 +29,20 @@ Graph revision: %d
 Review the current Issue, task results, and evidence before choosing the next action. The daemon does not dispatch a successor automatically.
 
 To schedule an exact next set, use:
-%s --task-ids-json '<json-array>' --request-id '<stable-request-id>'`,
+%s --task-ids-json '<json-array>' --request-id '<stable-request-id>'
+
+To change the remaining graph at this checkpoint before scheduling, use:
+%s --operations-json '[{"kind":"supersede","taskId":"<task-id>"}]' --request-id '<stable-request-id>'
+
+To replace a task while preserving its history, use:
+%s --operations-json '[{"kind":"rework","taskId":"<old-task-id>","task":{"taskId":"<replacement-task-id>","title":"<title>","content":"<details>"}}]' --request-id '<stable-request-id>'
+
+Mutation entries use the "kind" field; "op" and "replacement" are not supported. Rework and supersede preserve task and Run history.
+
+If this Issue has been replaced or should not continue, stop it explicitly so no later checkpoint wake is emitted:
+%s --reason '<audited-reason>' --request-id '<stable-request-id>'`,
 		wake.IssueID, wake.CheckpointID, wake.CheckpointKind,
-		wake.CheckpointRevision, schedule,
+		wake.CheckpointRevision, schedule, mutate, mutate, stop,
 	)
 	switch wake.CheckpointKind {
 	case executionbiz.CheckpointKindTaskSettled,

--- a/services/tuttid/service/tuttimodeexecution/prompts.go
+++ b/services/tuttid/service/tuttimodeexecution/prompts.go
@@ -28,6 +28,9 @@ Graph revision: %d
 
 Review the current Issue, task results, and evidence before choosing the next action. The daemon does not dispatch a successor automatically.
 
+First read the source-scoped execution snapshot:
+tutti plan issue get --issue-id %s --json
+
 To schedule an exact next set, use:
 %s --task-ids-json '<json-array>' --request-id '<stable-request-id>'
 
@@ -37,17 +40,32 @@ To change the remaining graph at this checkpoint before scheduling, use:
 To replace a task while preserving its history, use:
 %s --operations-json '[{"kind":"rework","taskId":"<old-task-id>","task":{"taskId":"<replacement-task-id>","title":"<title>","content":"<details>"}}]' --request-id '<stable-request-id>'
 
-Mutation entries use the "kind" field; "op" and "replacement" are not supported. Rework and supersede preserve task and Run history.
+Mutation entries use the "kind" field; "op" and "replacement" are not supported. Rework and supersede preserve task and Run history. A rework replacement inherits omitted launch settings, execution directory, and dependencies from the old task; explicit replacement values override those defaults. Rework automatically redirects active, not-started dependents from the old task ID to the replacement task ID in the same mutation.
+
+Use the Tutti CLI as the only supported execution control plane. Do not inspect or modify Tutti's backing SQLite databases to diagnose or bypass a rejected command; report the CLI error if the current Issue snapshot and documented recovery commands cannot resolve it.
 
 If this Issue has been replaced or should not continue, stop it explicitly so no later checkpoint wake is emitted:
 %s --reason '<audited-reason>' --request-id '<stable-request-id>'`,
 		wake.IssueID, wake.CheckpointID, wake.CheckpointKind,
-		wake.CheckpointRevision, schedule, mutate, mutate, stop,
+		wake.CheckpointRevision, wake.IssueID, schedule, mutate, mutate, stop,
 	)
 	switch wake.CheckpointKind {
-	case executionbiz.CheckpointKindTaskSettled,
-		executionbiz.CheckpointKindTaskFailed,
+	case executionbiz.CheckpointKindTaskFailed,
 		executionbiz.CheckpointKindTaskCanceled:
+		outcome := "failed"
+		if wake.CheckpointKind == executionbiz.CheckpointKindTaskCanceled {
+			outcome = "canceled"
+		}
+		return header + fmt.Sprintf(`
+
+The %s task cannot be updated or scheduled directly. To retry it, rework it with a new taskId and corrected launch settings, then schedule the replacement using the graphRevision returned by the successful mutation. Keep checkpoint %s; do not guess or increment the revision before a command succeeds.
+
+If another Run is active or a later checkpoint is pending, you may resolve this review without adding work:
+tutti plan issue acknowledge --issue-id %s --checkpoint-id %s --expected-graph-revision %d --request-id '<stable-request-id>'`,
+			outcome, wake.CheckpointID, wake.IssueID, wake.CheckpointID,
+			wake.CheckpointRevision,
+		)
+	case executionbiz.CheckpointKindTaskSettled:
 		return header + fmt.Sprintf(`
 
 If another Run is active or a later checkpoint is pending, you may resolve this review without adding work:

--- a/services/tuttid/service/tuttimodeexecution/prompts_test.go
+++ b/services/tuttid/service/tuttimodeexecution/prompts_test.go
@@ -56,6 +56,7 @@ func TestTaskCanceledMainWakePromptCarriesExactMutationSchema(t *testing.T) {
 		CheckpointRevision: 7,
 	})
 	for _, want := range []string{
+		"tutti plan issue get --issue-id issue-1 --json",
 		"tutti plan issue mutate",
 		"--issue-id issue-1",
 		"--checkpoint-id checkpoint-1",
@@ -64,9 +65,34 @@ func TestTaskCanceledMainWakePromptCarriesExactMutationSchema(t *testing.T) {
 		`--operations-json '[{"kind":"rework","taskId":"<old-task-id>","task":{"taskId":"<replacement-task-id>"`,
 		`"op" and "replacement" are not supported`,
 		"preserve task and Run history",
+		"inherits omitted launch settings, execution directory, and dependencies",
+		"canceled task cannot be updated or scheduled directly",
+		"graphRevision returned by the successful mutation",
+		"only supported execution control plane",
+		"Do not inspect or modify Tutti's backing SQLite databases",
 		"tutti plan issue stop",
 		"--reason '<audited-reason>'",
 		"so no later checkpoint wake is emitted",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("MainWakePrompt() missing %q:\n%s", want, prompt)
+		}
+	}
+}
+
+func TestTaskFailedMainWakePromptExplainsReworkRecovery(t *testing.T) {
+	prompt := MainWakePrompt(executionbiz.Wake{
+		IssueID: "issue-1", CheckpointID: "checkpoint-1",
+		CheckpointKind:     executionbiz.CheckpointKindTaskFailed,
+		CheckpointRevision: 7,
+	})
+	for _, want := range []string{
+		"automatically redirects active, not-started dependents",
+		"failed task cannot be updated or scheduled directly",
+		"rework it with a new taskId and corrected launch settings",
+		"graphRevision returned by the successful mutation",
+		"Keep checkpoint checkpoint-1",
+		"do not guess or increment the revision",
 	} {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("MainWakePrompt() missing %q:\n%s", want, prompt)

--- a/services/tuttid/service/tuttimodeexecution/prompts_test.go
+++ b/services/tuttid/service/tuttimodeexecution/prompts_test.go
@@ -49,6 +49,31 @@ func TestGoalReviewMainWakePromptCarriesExactCompleteCommand(t *testing.T) {
 	}
 }
 
+func TestTaskCanceledMainWakePromptCarriesExactMutationSchema(t *testing.T) {
+	prompt := MainWakePrompt(executionbiz.Wake{
+		IssueID: "issue-1", CheckpointID: "checkpoint-1",
+		CheckpointKind:     executionbiz.CheckpointKindTaskCanceled,
+		CheckpointRevision: 7,
+	})
+	for _, want := range []string{
+		"tutti plan issue mutate",
+		"--issue-id issue-1",
+		"--checkpoint-id checkpoint-1",
+		"--expected-graph-revision 7",
+		`--operations-json '[{"kind":"supersede","taskId":"<task-id>"}]'`,
+		`--operations-json '[{"kind":"rework","taskId":"<old-task-id>","task":{"taskId":"<replacement-task-id>"`,
+		`"op" and "replacement" are not supported`,
+		"preserve task and Run history",
+		"tutti plan issue stop",
+		"--reason '<audited-reason>'",
+		"so no later checkpoint wake is emitted",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("MainWakePrompt() missing %q:\n%s", want, prompt)
+		}
+	}
+}
+
 func TestIndependentGoalReviewMainWakePromptCarriesRecommendationEvidence(
 	t *testing.T,
 ) {

--- a/services/tuttid/service/tuttimodeexecution/reviews.go
+++ b/services/tuttid/service/tuttimodeexecution/reviews.go
@@ -298,6 +298,18 @@ func (service Service) RecoverReviewers(
 	if workspaceID == "" || leaseOwner == "" {
 		return executionbiz.ErrReviewerVerdictRejected
 	}
+	if service.Wakes != nil {
+		if err := service.Wakes.DrainTuttiModeSourceActivityInbox(
+			ctx, workspaceID,
+		); err != nil {
+			return err
+		}
+	}
+	if service.Archives != nil && service.ArchiveRuns != nil {
+		if _, err := service.RecoverArchivesAndCount(ctx, workspaceID); err != nil {
+			return err
+		}
+	}
 	reviews, err := store.ListDispatchableTuttiModeGoalReviews(
 		ctx, workspaceID, service.now(),
 	)
@@ -356,7 +368,10 @@ func (service Service) recoverOneReviewer(
 			recovered.CanonicalSessionID, recovered.CanonicalTurnID,
 			service.now(),
 		); err != nil {
-			return err
+			return errors.Join(err, service.cancelAutomationTurn(
+				ctx, review.WorkspaceID,
+				recovered.CanonicalSessionID, recovered.CanonicalTurnID,
+			))
 		}
 		return service.reconcileReviewerSettlement(
 			ctx, store, launch, recovered,
@@ -368,7 +383,10 @@ func (service Service) recoverOneReviewer(
 			ctx, review.WorkspaceID, review.ID, leaseOwner,
 			delivery.CanonicalSessionID, delivery.CanonicalTurnID, service.now(),
 		); err != nil {
-			return err
+			return errors.Join(err, service.cancelAutomationTurn(
+				ctx, review.WorkspaceID,
+				delivery.CanonicalSessionID, delivery.CanonicalTurnID,
+			))
 		}
 		return service.reconcileReviewerSettlement(
 			ctx, store, launch, delivery,
@@ -388,6 +406,11 @@ func (service Service) recoverOneReviewer(
 			markErr = service.reconcileReviewerSettlement(
 				ctx, store, launch, recovered,
 			)
+		} else {
+			markErr = errors.Join(markErr, service.cancelAutomationTurn(
+				ctx, review.WorkspaceID,
+				recovered.CanonicalSessionID, recovered.CanonicalTurnID,
+			))
 		}
 		return errors.Join(sendErr, markErr)
 	}

--- a/services/tuttid/service/tuttimodeexecution/service.go
+++ b/services/tuttid/service/tuttimodeexecution/service.go
@@ -660,7 +660,11 @@ func (service Service) Mutate(
 		input.SourceSessionID == "" || input.CheckpointID == "" ||
 		input.RequestID == "" || input.ExpectedGraphRevision < 1 ||
 		len(input.Operations) == 0 {
-		return executionbiz.MutationResult{}, executionbiz.ErrMutationRejected
+		return executionbiz.MutationResult{}, executionbiz.Reject(
+			executionbiz.ErrMutationRejected,
+			executionbiz.RejectionInvalidMutation,
+			"",
+		)
 	}
 	operations := append([]executionbiz.MutationOperation(nil), input.Operations...)
 	for index := range operations {
@@ -669,19 +673,50 @@ func (service Service) Mutate(
 		switch operations[index].Kind {
 		case executionbiz.MutationOperationAdd:
 			if operations[index].Task.TaskID == "" {
-				return executionbiz.MutationResult{}, executionbiz.ErrMutationRejected
+				return executionbiz.MutationResult{}, executionbiz.Reject(
+					executionbiz.ErrMutationRejected,
+					executionbiz.RejectionInvalidMutation,
+					"",
+				)
+			}
+			if strings.TrimSpace(operations[index].Task.AgentTargetID) == "" {
+				return executionbiz.MutationResult{}, executionbiz.Reject(
+					executionbiz.ErrMutationRejected,
+					executionbiz.RejectionMissingAgentTarget,
+					operations[index].Task.TaskID,
+				)
 			}
 		case executionbiz.MutationOperationUpdate, executionbiz.MutationOperationSupersede,
 			executionbiz.MutationOperationRework:
 			if operations[index].TaskID == "" {
-				return executionbiz.MutationResult{}, executionbiz.ErrMutationRejected
+				return executionbiz.MutationResult{}, executionbiz.Reject(
+					executionbiz.ErrMutationRejected,
+					executionbiz.RejectionInvalidMutation,
+					"",
+				)
+			}
+			if operations[index].Kind == executionbiz.MutationOperationUpdate &&
+				!operations[index].TaskFields.Any() {
+				return executionbiz.MutationResult{}, executionbiz.Reject(
+					executionbiz.ErrMutationRejected,
+					executionbiz.RejectionInvalidMutation,
+					operations[index].TaskID,
+				)
 			}
 			if operations[index].Kind == executionbiz.MutationOperationRework &&
 				operations[index].Task.TaskID == "" {
-				return executionbiz.MutationResult{}, executionbiz.ErrMutationRejected
+				return executionbiz.MutationResult{}, executionbiz.Reject(
+					executionbiz.ErrMutationRejected,
+					executionbiz.RejectionInvalidMutation,
+					operations[index].TaskID,
+				)
 			}
 		default:
-			return executionbiz.MutationResult{}, executionbiz.ErrMutationRejected
+			return executionbiz.MutationResult{}, executionbiz.Reject(
+				executionbiz.ErrMutationRejected,
+				executionbiz.RejectionInvalidMutation,
+				operations[index].TaskID,
+			)
 		}
 	}
 	payload, err := json.Marshal(struct {

--- a/services/tuttid/service/tuttimodeexecution/service.go
+++ b/services/tuttid/service/tuttimodeexecution/service.go
@@ -63,6 +63,7 @@ type MutationStore interface {
 
 type ArchiveStore interface {
 	RequestTuttiModeArchive(context.Context, executionbiz.ArchiveRequest) (executionbiz.ArchiveOperation, bool, error)
+	RequestTuttiModeArchivesForSourceSession(context.Context, executionbiz.SourceSessionArchiveRequest) ([]executionbiz.ArchiveOperation, error)
 	GetTuttiModeArchiveOperation(context.Context, string, string) (executionbiz.ArchiveOperation, error)
 	FailTuttiModeArchive(context.Context, string, string, string, time.Time) (executionbiz.ArchiveOperation, error)
 	CompleteTuttiModeArchiveIfSettled(context.Context, string, string, time.Time) (executionbiz.ArchiveOperation, bool, error)
@@ -75,6 +76,10 @@ type ArchiveRunCanceller interface {
 
 type ArchiveRecoveryEnqueuer interface {
 	Enqueue(string)
+}
+
+type ArchiveAutomationTurnCanceller interface {
+	CancelAutomationTurn(context.Context, string, string, string) error
 }
 
 type WakeStore interface {
@@ -111,6 +116,7 @@ type Service struct {
 	BeforeGoalReviewCommitStep func(string) error
 	Archives                   ArchiveStore
 	ArchiveRuns                ArchiveRunCanceller
+	ArchiveAutomationTurns     ArchiveAutomationTurnCanceller
 	ArchiveRecoveryQueue       ArchiveRecoveryEnqueuer
 	MainWakeSendTimeout        time.Duration
 	MainWakeCleanupTimeout     time.Duration

--- a/services/tuttid/service/tuttimodeexecution/wake_contract_red_test.go
+++ b/services/tuttid/service/tuttimodeexecution/wake_contract_red_test.go
@@ -610,6 +610,21 @@ func (driver *sqliteConformanceDriver) CommitCanonicalSourceActivityDuringNextWa
 	driver.wakeTarget.mu.Unlock()
 }
 
+func (driver *sqliteConformanceDriver) StopSourceSessionDuringNextWakeSend(
+	workspaceID string,
+	sourceSessionID string,
+) {
+	key := wakeTargetKey(workspaceID, sourceSessionID)
+	driver.wakeTarget.mu.Lock()
+	driver.wakeTarget.activityDuringSend[key] = func() error {
+		_, err := driver.StopSourceSession(
+			context.Background(), workspaceID, sourceSessionID,
+		)
+		return err
+	}
+	driver.wakeTarget.mu.Unlock()
+}
+
 func (driver *sqliteConformanceDriver) CorruptWakeTargetSession(
 	ctx context.Context,
 	workspaceID string,
@@ -729,6 +744,33 @@ func (driver *sqliteConformanceDriver) CommitCanonicalSourceActivity(
 			},
 			Turn:     turn,
 			Messages: messages,
+		},
+	)
+	return err
+}
+
+func (driver *sqliteConformanceDriver) CommitCanonicalSourceCancellation(
+	ctx context.Context,
+	workspaceID string,
+	sourceSessionID string,
+	turnID string,
+) error {
+	now := driver.CurrentTime()
+	_, err := driver.store.ReportActivityState(
+		ctx,
+		agentactivitybiz.ActivityStateReport{
+			Session: agentactivitybiz.SessionStateReport{
+				WorkspaceID: workspaceID, AgentSessionID: sourceSessionID,
+				Kind: agentactivitybiz.SessionKindRoot, Origin: "runtime",
+				Provider: "codex", Status: "idle", OccurredAtUnixMS: now.UnixMilli(),
+			},
+			Turn: &agentactivitybiz.TurnTransition{
+				WorkspaceID: workspaceID, AgentSessionID: sourceSessionID,
+				TurnID: turnID, Origin: agentactivitybiz.TurnOriginUserPrompt,
+				Phase: agentactivitybiz.TurnPhaseSettled, Outcome: agentactivitybiz.TurnOutcomeCanceled,
+				StartedAtUnixMS: now.Add(-time.Second).UnixMilli(),
+				SettledAtUnixMS: now.UnixMilli(), OccurredAtUnixMS: now.UnixMilli(),
+			},
 		},
 	)
 	return err

--- a/services/tuttid/service/tuttimodeexecution/wakes.go
+++ b/services/tuttid/service/tuttimodeexecution/wakes.go
@@ -404,12 +404,16 @@ func (service Service) DispatchClaimedMainWake(
 	if delivery.CanonicalSessionID != wake.TargetSessionID ||
 		delivery.CanonicalTurnID == "" {
 		message := "wake delivery returned invalid canonical identity"
+		cancelErr := service.cancelAutomationTurn(
+			ctx, wake.WorkspaceID,
+			delivery.CanonicalSessionID, delivery.CanonicalTurnID,
+		)
 		if releaseErr := service.releaseClaimedMainWake(
 			ctx, store, wake, message,
 		); releaseErr != nil {
-			return releaseErr
+			return errors.Join(cancelErr, releaseErr)
 		}
-		return ErrMainWakeDeliveryPending
+		return errors.Join(ErrMainWakeDeliveryPending, cancelErr)
 	}
 	finalizeCtx, cancelFinalize := service.mainWakeCleanupContext(ctx)
 	defer cancelFinalize()
@@ -419,30 +423,49 @@ func (service Service) DispatchClaimedMainWake(
 		delivery.CanonicalSessionID, delivery.CanonicalTurnID,
 		wake.DueAt, finalizedAt,
 	)
+	if finalizeErr == nil {
+		return nil
+	}
 	if !errors.Is(finalizeErr, executionbiz.ErrWakeRejected) {
-		return finalizeErr
+		cancelErr := service.cancelAutomationTurn(
+			finalizeCtx, wake.WorkspaceID,
+			delivery.CanonicalSessionID, delivery.CanonicalTurnID,
+		)
+		return errors.Join(finalizeErr, cancelErr)
 	}
 	if drainErr := store.DrainTuttiModeSourceActivityInbox(
 		finalizeCtx, wake.WorkspaceID,
 	); drainErr != nil {
-		return errors.Join(finalizeErr, drainErr)
+		cancelErr := service.cancelAutomationTurn(
+			finalizeCtx, wake.WorkspaceID,
+			delivery.CanonicalSessionID, delivery.CanonicalTurnID,
+		)
+		return errors.Join(finalizeErr, cancelErr, drainErr)
 	}
 	current, found, readErr := store.GetTuttiModeExecutionWake(
 		finalizeCtx, wake.WorkspaceID, wake.ID,
 	)
 	if readErr != nil {
-		return errors.Join(finalizeErr, readErr)
+		cancelErr := service.cancelAutomationTurn(
+			finalizeCtx, wake.WorkspaceID,
+			delivery.CanonicalSessionID, delivery.CanonicalTurnID,
+		)
+		return errors.Join(finalizeErr, cancelErr, readErr)
 	}
-	if !found ||
-		current.Status != executionbiz.WakeStatusLeased ||
-		current.LeaseOwner != wake.LeaseOwner ||
-		!current.DueAt.After(finalizedAt) {
-		return finalizeErr
+	if found &&
+		current.Status == executionbiz.WakeStatusLeased &&
+		current.LeaseOwner == wake.LeaseOwner &&
+		current.DueAt.After(finalizedAt) {
+		return service.releaseClaimedMainWake(
+			ctx, store, current,
+			"source activity advanced the wake deadline during delivery",
+		)
 	}
-	return service.releaseClaimedMainWake(
-		ctx, store, current,
-		"source activity advanced the wake deadline during delivery",
+	cancelErr := service.cancelAutomationTurn(
+		finalizeCtx, wake.WorkspaceID,
+		delivery.CanonicalSessionID, delivery.CanonicalTurnID,
 	)
+	return errors.Join(finalizeErr, cancelErr)
 }
 
 func (service Service) releaseClaimedMainWake(

--- a/services/tuttid/service/tuttimodeexecution/worker.go
+++ b/services/tuttid/service/tuttimodeexecution/worker.go
@@ -72,6 +72,11 @@ func (service Service) RunWatchdog(
 	if err := service.PrepareStartupMainWakeRecovery(ctx, workspaceID); err != nil {
 		return err
 	}
+	if service.Archives != nil && service.ArchiveRuns != nil {
+		if _, err := service.RecoverArchivesAndCount(ctx, workspaceID); err != nil {
+			return err
+		}
+	}
 	reconcileErr := service.reconcileDispatchedMainWakes(
 		ctx, store, workspaceID,
 	)
@@ -134,14 +139,14 @@ func (worker Worker) sweep(ctx context.Context) error {
 	}
 	var sweepErrors []error
 	for _, workspaceID := range workspaceIDs {
-		if err := worker.Executions.RecoverReviewers(
-			ctx, workspaceID, worker.LeaseOwner,
-		); err != nil && !errors.Is(err, ErrServiceUnavailable) {
-			sweepErrors = append(sweepErrors, err)
-		}
 		if err := reportableMainWakeRecoveryError(worker.Executions.RunWatchdog(
 			ctx, workspaceID, worker.LeaseOwner,
 		)); err != nil {
+			sweepErrors = append(sweepErrors, err)
+		}
+		if err := worker.Executions.RecoverReviewers(
+			ctx, workspaceID, worker.LeaseOwner,
+		); err != nil && !errors.Is(err, ErrServiceUnavailable) {
 			sweepErrors = append(sweepErrors, err)
 		}
 	}

--- a/services/tuttid/service/workspace/issue_execution_coordinator.go
+++ b/services/tuttid/service/workspace/issue_execution_coordinator.go
@@ -10,6 +10,7 @@ import (
 
 	workspaceissues "github.com/tutti-os/tutti/packages/workspace/issues"
 	eventstreamservice "github.com/tutti-os/tutti/services/tuttid/service/eventstream"
+	tuttimodeexecutionservice "github.com/tutti-os/tutti/services/tuttid/service/tuttimodeexecution"
 )
 
 // IssueExecutionCoordinator is the product-owned seam between durable Issue
@@ -120,10 +121,18 @@ func (c *IssueExecutionCoordinator) cancelIssueRuns(
 					continue
 				}
 			case IssueRunCancelNotFound:
-				// The launch gate now owns the pending intent. If launch has
-				// not begun it will be skipped; if it is in flight, completion
-				// performs exact-turn compensation.
-				continue
+				if launching {
+					// The in-flight launch gate owns exact-turn compensation
+					// once canonical delivery becomes observable.
+					continue
+				}
+				// No launch owns this prepared Run, so the product can settle
+				// it immediately instead of leaving archive recovery blocked
+				// on a Run that never acquired a canonical Agent Turn.
+				result.Settlement = &IssueRunSettlement{
+					WorkspaceID: workspaceID, AgentSessionID: run.AgentSessionID,
+					Status: workspaceissues.StatusCanceled,
+				}
 			default:
 				cancelErrors = append(cancelErrors, fmt.Errorf("cancel run %s: unsupported cancellation result %q", run.RunID, result.State))
 				continue
@@ -182,13 +191,9 @@ func (s IssueManagerService) pauseIssueExecution(ctx context.Context, workspaceI
 			return nil, err
 		}
 	}
-	allRunning, err := s.domainService().ListRunningRuns(ctx, workspaceID, defaultIssueRunReconcileLimit)
-	if err != nil {
-		return nil, err
-	}
-	running := make([]workspaceissues.Run, 0, len(allRunning))
-	for _, run := range allRunning {
-		if run.IssueID == issueID {
+	running := make([]workspaceissues.Run, 0, len(detail.RecentRuns))
+	for _, run := range detail.RecentRuns {
+		if run.Status == workspaceissues.StatusRunning {
 			running = append(running, run)
 		}
 	}
@@ -214,73 +219,40 @@ func (s IssueManagerService) pauseTuttiModeIssueExecution(
 			return nil, err
 		}
 	}
-	allRunning, err := s.domainService().ListRunningRuns(ctx, workspaceID, defaultIssueRunReconcileLimit)
-	if err != nil {
-		return nil, err
-	}
-	running := make([]workspaceissues.Run, 0, len(allRunning))
-	for _, run := range allRunning {
-		if run.IssueID == issueID {
+	running := make([]workspaceissues.Run, 0, len(detail.RecentRuns))
+	for _, run := range detail.RecentRuns {
+		if run.Status == workspaceissues.StatusRunning {
 			running = append(running, run)
 		}
 	}
 	return running, nil
 }
 
-// CancelIssueExecutionForSourceSession stops every running tutti-mode-plan
-// Issue that the given planning session created. It backs the user's stop
-// gesture on the planning conversation: stopping the orchestrator stops all
-// work in flight.
+// CancelIssueExecutionForSourceSession durably archives every nonterminal
+// Tutti execution owned by the planning session. Archive is the product's
+// terminal stop boundary: it fences future dispatch before canceling Runs,
+// main wakes, reviewers, checkpoints, and workflow recovery.
 func (c *IssueExecutionCoordinator) CancelIssueExecutionForSourceSession(ctx context.Context, workspaceID string, agentSessionID string) (int, error) {
-	if c == nil || c.Issues == nil {
+	if c == nil || c.Issues == nil || c.Issues.TuttiModeExecutions == nil {
 		return 0, workspaceissues.ErrInvalidArgument
 	}
 	agentSessionID = strings.TrimSpace(agentSessionID)
 	if agentSessionID == "" {
 		return 0, nil
 	}
-	running, err := c.Issues.domainService().ListRunningRuns(ctx, workspaceID, defaultIssueRunReconcileLimit)
-	if err != nil {
-		return 0, err
-	}
-	issueIDs := make([]string, 0, len(running))
-	seen := make(map[string]struct{}, len(running))
-	for _, run := range running {
-		if _, exists := seen[run.IssueID]; exists {
-			continue
-		}
-		seen[run.IssueID] = struct{}{}
-		issueIDs = append(issueIDs, run.IssueID)
-	}
-	canceled := 0
-	for _, issueID := range issueIDs {
-		detail, err := c.Issues.domainService().GetIssueDetail(ctx, workspaceID, issueID)
-		if err != nil ||
-			detail.Issue.PlanningSource != workspaceissues.PlanningSourceTuttiModePlan ||
-			strings.TrimSpace(detail.Issue.SourceSessionID) != agentSessionID {
-			continue
-		}
-		count, cancelErr := c.CancelTuttiModeIssueExecution(ctx, workspaceID, issueID)
-		if cancelErr != nil {
-			slog.Warn("cancel Issue execution for source session failed",
-				"event", "workspace_issue.source_session_cancel_failed",
-				"workspace_id", workspaceID,
-				"issue_id", issueID,
-				"agent_session_id", agentSessionID,
-				"error", cancelErr,
-			)
-			continue
-		}
-		canceled += count
-	}
-	return canceled, nil
+	return c.Issues.TuttiModeExecutions.StopSourceSession(
+		ctx,
+		tuttimodeexecutionservice.StopSourceSessionInput{
+			WorkspaceID: workspaceID, SourceSessionID: agentSessionID,
+			RequestID: "source-session-stop", Reason: "source_turn_canceled",
+		},
+	)
 }
 
 // ObserveUserTurnCanceled implements the agent service's turn-cancel
-// observer: a user stopping the planning conversation stops every running
-// task of the plans that conversation orchestrates. Sessions that are not a
-// tutti-mode-plan source are a no-op, so cascaded child-session cancels
-// cannot loop.
+// observer: a user stopping the planning conversation enters the durable
+// source-session stop boundary. Sessions that are not a Tutti plan source are
+// a no-op, so cascaded child-session cancels cannot loop.
 func (c *IssueExecutionCoordinator) ObserveUserTurnCanceled(ctx context.Context, workspaceID string, agentSessionID string) {
 	if _, err := c.CancelIssueExecutionForSourceSession(ctx, workspaceID, agentSessionID); err != nil {
 		slog.Warn("issue execution cascade on turn cancel failed",

--- a/services/tuttid/service/workspace/issue_scheduled_dispatch.go
+++ b/services/tuttid/service/workspace/issue_scheduled_dispatch.go
@@ -157,8 +157,9 @@ func (s IssueManagerService) projectReviewedSettlementSubjectForSchedule(
 	for index := range projected {
 		if projected[index].TaskID == subjectTaskID &&
 			projected[index].Status == workspaceissues.StatusPendingAcceptance {
-			projected[index].Status = workspaceissues.StatusCompleted
-			projected[index].AcceptanceState = workspaceissues.AcceptanceUserAccepted
+			projected[index] = workspaceissues.ProjectReviewedSettlementTaskForRun(
+				projected[index],
+			)
 		}
 	}
 	return projected
@@ -179,7 +180,11 @@ func (s IssueManagerService) validateTuttiModeScheduleIsolation(
 			if !task.Parallelizable {
 				for _, taskID := range taskIDs {
 					if strings.TrimSpace(taskID) != task.TaskID {
-						return executionbiz.ErrScheduleRejected
+						return executionbiz.Reject(
+							executionbiz.ErrScheduleRejected,
+							executionbiz.RejectionParallelismRejected,
+							strings.TrimSpace(taskID),
+						)
 					}
 				}
 			}
@@ -189,7 +194,11 @@ func (s IssueManagerService) validateTuttiModeScheduleIsolation(
 	for _, taskID := range taskIDs {
 		task, ok := byID[strings.TrimSpace(taskID)]
 		if !ok {
-			return executionbiz.ErrScheduleRejected
+			return executionbiz.Reject(
+				executionbiz.ErrScheduleRejected,
+				executionbiz.RejectionTaskNotFound,
+				strings.TrimSpace(taskID),
+			)
 		}
 		if task.Status == workspaceissues.StatusNotStarted {
 			newTasks = append(newTasks, task)
@@ -201,11 +210,19 @@ func (s IssueManagerService) validateTuttiModeScheduleIsolation(
 	}
 	for _, task := range newTasks {
 		if !task.Parallelizable {
-			return executionbiz.ErrScheduleRejected
+			return executionbiz.Reject(
+				executionbiz.ErrScheduleRejected,
+				executionbiz.RejectionParallelismRejected,
+				task.TaskID,
+			)
 		}
 		if issue.SequentialExecution {
 			if _, concurrent := s.sequentialTaskIsolation(issue, tasks, task); !concurrent {
-				return executionbiz.ErrScheduleRejected
+				return executionbiz.Reject(
+					executionbiz.ErrScheduleRejected,
+					executionbiz.RejectionParallelismRejected,
+					task.TaskID,
+				)
 			}
 		}
 	}
@@ -218,7 +235,11 @@ func (s IssueManagerService) prepareTuttiModeScheduleRuns(
 	taskIDs []string,
 ) ([]workspaceissues.Run, error) {
 	if issue.PlanningSource != workspaceissues.PlanningSourceTuttiModePlan {
-		return nil, executionbiz.ErrScheduleRejected
+		return nil, executionbiz.Reject(
+			executionbiz.ErrScheduleRejected,
+			executionbiz.RejectionInactiveExecution,
+			"",
+		)
 	}
 	byID := make(map[string]workspaceissues.Task, len(tasks))
 	for _, task := range tasks {
@@ -231,10 +252,18 @@ func (s IssueManagerService) prepareTuttiModeScheduleRuns(
 		taskID := strings.TrimSpace(rawTaskID)
 		task, ok := byID[taskID]
 		if taskID == "" || !ok {
-			return nil, executionbiz.ErrScheduleRejected
+			return nil, executionbiz.Reject(
+				executionbiz.ErrScheduleRejected,
+				executionbiz.RejectionTaskNotFound,
+				taskID,
+			)
 		}
 		if _, duplicate := seen[taskID]; duplicate {
-			return nil, executionbiz.ErrScheduleRejected
+			return nil, executionbiz.Reject(
+				executionbiz.ErrScheduleRejected,
+				executionbiz.RejectionDuplicateTask,
+				taskID,
+			)
 		}
 		seen[taskID] = struct{}{}
 		runID := uuid.NewString()

--- a/services/tuttid/service/workspace/issues_test.go
+++ b/services/tuttid/service/workspace/issues_test.go
@@ -24,6 +24,15 @@ type issueLookupFailingStore struct {
 	err error
 }
 
+type notFoundRunSessionCanceller struct{}
+
+func (notFoundRunSessionCanceller) RequestRunCancellation(
+	context.Context,
+	IssueRunCancellationRequest,
+) (IssueRunCancelResult, error) {
+	return IssueRunCancelResult{State: IssueRunCancelNotFound}, nil
+}
+
 func (store issueLookupFailingStore) GetIssue(
 	context.Context,
 	string,
@@ -102,7 +111,55 @@ func TestCancelIssueExecutionRejectsGenericMutationOfManagedIssue(t *testing.T) 
 	}
 }
 
-func TestCancelIssueExecutionForSourceSessionUsesManagedTuttiStopPath(t *testing.T) {
+func TestCancelIssueExecutionSettlesPreparedRunWithoutCanonicalTurn(t *testing.T) {
+	ctx := context.Background()
+	store := openIssueServiceStore(t)
+	const workspaceID = "workspace-cancel-prepared-run"
+	if err := store.Create(ctx, workspacebiz.Summary{
+		ID: workspaceID, Name: "Cancel prepared Run",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	service := IssueManagerService{
+		Store: store, MutationLocks: NewIssueMutationLocks(),
+	}
+	issue, err := service.CreateIssue(
+		ctx, workspaceID,
+		CreateIssueManagerIssueInput{
+			IssueID: "issue-cancel-prepared-run",
+			TopicID: workspaceissues.DefaultTopicID,
+			Title:   "Cancel prepared Run",
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := service.CreateRun(
+		ctx, workspaceID, issue.IssueID, "",
+		CreateIssueManagerRunInput{
+			RunID: "run-cancel-prepared", AgentProvider: "codex",
+			AgentSessionID: "session-cancel-prepared",
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	coordinator := IssueExecutionCoordinator{
+		Issues: &service, RunSessionCanceller: notFoundRunSessionCanceller{},
+	}
+	canceled, err := coordinator.CancelIssueExecution(ctx, workspaceID, issue.IssueID)
+	if err != nil || canceled != 1 {
+		t.Fatalf("CancelIssueExecution() canceled=%d error=%v", canceled, err)
+	}
+	persisted, err := store.GetRun(
+		ctx, workspaceID, issue.IssueID, run.TaskID, run.RunID,
+	)
+	if err != nil || persisted.Status != workspaceissues.StatusCanceled {
+		t.Fatalf("prepared Run after Stop=%#v error=%v", persisted, err)
+	}
+}
+
+func TestCancelIssueExecutionForSourceSessionRequiresDurableTuttiService(t *testing.T) {
 	ctx := context.Background()
 	store := openIssueServiceStore(t)
 	const (
@@ -145,15 +202,15 @@ func TestCancelIssueExecutionForSourceSessionUsesManagedTuttiStopPath(t *testing
 	coordinator := IssueExecutionCoordinator{Issues: &service}
 	if _, err := coordinator.CancelIssueExecutionForSourceSession(
 		ctx, workspaceID, sourceSessionID,
-	); err != nil {
-		t.Fatalf("CancelIssueExecutionForSourceSession() error = %v", err)
+	); !errors.Is(err, workspaceissues.ErrInvalidArgument) {
+		t.Fatalf("CancelIssueExecutionForSourceSession() error = %v, want durable service requirement", err)
 	}
 	persisted, err := store.GetIssue(ctx, workspaceID, issueID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !persisted.DispatchPaused {
-		t.Fatal("managed Tutti Issue dispatch was not paused by source-session cancellation")
+	if persisted.DispatchPaused {
+		t.Fatal("managed Tutti Issue was partially stopped without the durable execution service")
 	}
 }
 

--- a/services/tuttid/wiring_daemon_api.go
+++ b/services/tuttid/wiring_daemon_api.go
@@ -732,14 +732,10 @@ func buildDaemonAPI(
 			agentTargets,
 			preferences,
 		),
-		tuttimodeplancli.NewProviderWithExecution(
-			workspaceService,
-			tuttiModePlans,
-			agentSessionService,
-			&issueService,
-			&issueService,
-			tuttiModeExecutions,
-			tuttiModeExecutions,
+		tuttimodeplancli.NewProviderWithExecutionSnapshot(
+			workspaceService, tuttiModePlans, agentSessionService,
+			&issueService, &issueService, tuttiModeExecutions,
+			&issueService, tuttiModeExecutions, tuttiModeExecutions,
 		),
 		tuttigoalreviewcli.NewProvider(
 			tuttiModeExecutions,

--- a/services/tuttid/wiring_daemon_api.go
+++ b/services/tuttid/wiring_daemon_api.go
@@ -473,9 +473,10 @@ func buildDaemonAPI(
 	issueRunCanceller := issueRunSessionCanceller{Host: agentHost, Sessions: agentSessionService}
 	tuttiModeMainWakeOwner := "tuttid-main-wake:" + uuid.NewString()
 	tuttiModeExecutions := &tuttimodeexecutionservice.Service{
-		Store:    tuttiModeExecutionStore,
-		Archives: tuttiModeArchiveStore,
-		Wakes:    tuttiModeWakeStore,
+		Store:                  tuttiModeExecutionStore,
+		Archives:               tuttiModeArchiveStore,
+		Wakes:                  tuttiModeWakeStore,
+		ArchiveAutomationTurns: issueRunCanceller,
 		MainWakeTargets: tuttiModeMainWakeAgentAdapter{
 			Host:     agentHost,
 			Sessions: agentSessionService,


### PR DESCRIPTION
## Summary

- make source-session Stop a durable Tutti execution boundary, with restart-safe archive, wake, reviewer, Run-launch, and workflow recovery
- reuse canonical Composer options and rank `(agentTargetId, model, reasoningEffort, permissionModeId)` candidates jointly; remove obsolete one-dimensional Turbo preset labels
- suppress the transient `workspace agent session not found` reconcile race while a new Tutti conversation is still being created
- add a source-scoped `tutti plan issue get` execution snapshot with checkpoint, revision, task readiness blockers, allowed actions, and recovery guidance
- make schedule/mutation rejections return stable reason codes and actionable hints through the daemon/CLI error envelope
- move graph transition semantics into `biz/tuttimodeexecution`, add presence-aware patches, sparse rework launch inheritance, atomic dependent-edge rebinding, and failed/canceled rework conformance
- teach the injected Tutti CLI skill a checkpoint/action matrix, bounded retry policy, and an explicit no-SQLite recovery boundary

## Why

The exported logs showed several failures collapsing into the same generic rejection. In particular, a sparse rework could create a replacement without its original launch configuration, so the following schedule failed with an empty `agentTargetId`. The Agent had no authoritative execution read command or stable rejection reason, then explored unrelated CLI calls and even queried a guessed SQLite database. A separate renderer race also reconciled a Tutti session before its create transaction was query-visible, briefly surfacing `workspace agent session not found`.

This change keeps lifecycle and graph policy in the owning modules, gives the source Agent one authoritative refresh path, and bounds recovery to the exact checkpoint/revision/schema correction instead of open-ended tool exploration.

## Validation

- `pnpm check:changed` — 24/24 lanes passed
- `pnpm check:changed -- --push-ready` — 26/26 lanes passed twice
- targeted Go suites passed for workspace issues, Tutti execution biz/data/service/conformance, workspace scheduling, CLI provider/API, and runtime preparation
- pre-commit staged formatting, lint, renderer/UI boundaries, Agent GUI degradation, and runtime image budget checks passed

## Documentation

Updated the Issue execution architecture, Tutti CLI contract, runtime preparation contract, and symptom-driven troubleshooting entries for source Stop, sparse rework recovery, stable rejection hints, the no-backing-store boundary, and the new-session reconcile race.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core Tutti execution orchestration, archive/stop boundaries, checkpoint revision promotion, and agent reconcile behavior; regressions could leave executions stuck, over-archive, or mis-schedule tasks.
> 
> **Overview**
> **Tutti Mode execution** gains a source-scoped **`plan issue get`** snapshot, stable schedule/mutation **rejection reasons** with CLI recovery hints, and graph transitions moved into **`biz/tuttimodeexecution`** (presence-aware updates, sparse **rework** launch inheritance, dependent-edge rebinding). **Stop** and canceled source Turns now drive **archive** across all nonterminal executions for that workspace/source session, with inbox-drain recovery before dispatch. Checkpoint **promotion** and watchdog repair **rebind** stale active checkpoint revisions to the current graph revision.
> 
> **Desktop** plan-review assignment catalogs load composer options through the same **activity-core** path as the main Composer, preserving **`value`/`label`** metadata end to end. **`workspace.tuttimode.updated`** reconcile hints are ignored while a new session activation is still **requested/uncertain**, avoiding a transient “session not found” tombstone race.
> 
> **Agent GUI** read-only plan panels show canonical labels; **Issue Manager** hides **superseded** tasks from current board views. **Model-allocation** skills rank joint agent/model candidates without affinity for the planning agent or defaults.
> 
> **Docs/troubleshooting** and **runtimeprep** Tutti CLI skills document checkpoint/action matrices, bounded retry, and a no-SQLite control-plane boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f107902428cd0762656a588bcc19e069047fabdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->