### PR TITLE
fix(agent): separate hydration from capability probes

### DIFF
--- a/apps/desktop/src/main/agentPowerSaveBlocker.test.ts
+++ b/apps/desktop/src/main/agentPowerSaveBlocker.test.ts
@@ -160,7 +160,13 @@ function createFakeTuttidClient(input: {
       if (!session) {
         throw new Error("session not found");
       }
-      return { session, childSessions: [], turns: [] };
+      return {
+        session,
+        childSessions: [],
+        lifecycleCapabilitiesProjected: true,
+        projection: "full",
+        turns: []
+      };
     },
     async listWorkspaceAgentSessions(workspaceID) {
       return {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityReconcileBridge.ts
@@ -211,6 +211,7 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
     workspaceId: string,
     agentSessionId: string,
     source: string,
+    projection: "full" | "messageHydration" = "full",
     signal?: AbortSignal
   ): Promise<AgentActivitySessionDetailSnapshot> {
     const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
@@ -225,6 +226,7 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
       await this.reconcileDependencies.tuttidClient.getWorkspaceAgentSession(
         normalizedWorkspaceId,
         agentSessionId,
+        projection,
         { signal }
       );
     const mapped = agentActivitySessionDetailFromTuttid(
@@ -692,11 +694,12 @@ export abstract class WorkspaceAgentActivityReconcileBridge {
         });
       },
       port: {
-        getSessionDetail: ({ agentSessionId, signal }) =>
+        getSessionDetail: ({ agentSessionId, projection, signal }) =>
           this.fetchActivitySessionDetail(
             normalizedWorkspaceId,
             agentSessionId,
             "",
+            projection === "message_hydration" ? "messageHydration" : "full",
             signal
           ),
         listSessionMessages: (query) => entry.adapter.listSessionMessages(query)

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -16,6 +16,16 @@ import {
 import type { ReporterEventInput } from "../../../analytics/services/reporterService.interface.ts";
 import { WorkspaceAgentActivityService } from "./workspaceAgentActivityService.ts";
 
+function sessionDetailProjection(
+  projection: Parameters<TuttidClient["getWorkspaceAgentSession"]>[2]
+) {
+  const resolved = projection ?? "full";
+  return {
+    lifecycleCapabilitiesProjected: resolved === "full",
+    projection: resolved
+  };
+}
+
 test("WorkspaceAgentActivityService starts one canonical workspace load when the shared engine is created", async () => {
   let listCalls = 0;
   const service = new WorkspaceAgentActivityService({
@@ -51,7 +61,10 @@ test("WorkspaceAgentActivityService applies authoritative Session detail in one 
   };
   const service = new WorkspaceAgentActivityService({
     tuttidClient: {
-      getWorkspaceAgentSession: async () => ({
+      getWorkspaceAgentSession: async (
+        ...args: Parameters<TuttidClient["getWorkspaceAgentSession"]>
+      ) => ({
+        ...sessionDetailProjection(args[2]),
         childSessions: [childSession],
         session: rootSession,
         turns: [workspaceAgentTurn()]
@@ -687,7 +700,10 @@ test("WorkspaceAgentActivityService reads existing session settings from the dae
   const service = new WorkspaceAgentActivityService({
     tuttidClient: {
       createWorkspaceAgentSession: async () => createdSession,
-      getWorkspaceAgentSession: async () => ({
+      getWorkspaceAgentSession: async (
+        ...args: Parameters<TuttidClient["getWorkspaceAgentSession"]>
+      ) => ({
+        ...sessionDetailProjection(args[2]),
         session: loadedSession,
         childSessions: [],
         turns: []
@@ -729,7 +745,10 @@ test("WorkspaceAgentActivityService does not reinterpret a failed Turn as activa
   const service = new WorkspaceAgentActivityService({
     tuttidClient: {
       createWorkspaceAgentSession: async () => failedSession,
-      getWorkspaceAgentSession: async () => ({
+      getWorkspaceAgentSession: async (
+        ...args: Parameters<TuttidClient["getWorkspaceAgentSession"]>
+      ) => ({
+        ...sessionDetailProjection(args[2]),
         childSessions: [],
         session: failedSession,
         turns: []
@@ -1011,7 +1030,10 @@ test("WorkspaceAgentActivityService starts session-event streams and forwards ca
       subscribeConnectionState: () => () => {}
     } as never,
     tuttidClient: {
-      getWorkspaceAgentSession: async () => ({
+      getWorkspaceAgentSession: async (
+        ...args: Parameters<TuttidClient["getWorkspaceAgentSession"]>
+      ) => ({
+        ...sessionDetailProjection(args[2]),
         session: workspaceAgentSession({
           currentPhase: "idle",
           status: "completed",
@@ -1158,7 +1180,10 @@ test("WorkspaceAgentActivityService reconciles a realtime message version gap be
       subscribeConnectionState: () => () => {}
     } as never,
     tuttidClient: {
-      getWorkspaceAgentSession: async () => ({
+      getWorkspaceAgentSession: async (
+        ...args: Parameters<TuttidClient["getWorkspaceAgentSession"]>
+      ) => ({
+        ...sessionDetailProjection(args[2]),
         session,
         childSessions: [],
         turns: []
@@ -1315,7 +1340,10 @@ test("WorkspaceAgentActivityService reconciles cached messages after reconnect w
       }
     } as never,
     tuttidClient: {
-      getWorkspaceAgentSession: async () => ({
+      getWorkspaceAgentSession: async (
+        ...args: Parameters<TuttidClient["getWorkspaceAgentSession"]>
+      ) => ({
+        ...sessionDetailProjection(args[2]),
         session,
         childSessions: [],
         turns: []
@@ -1559,7 +1587,10 @@ test("WorkspaceAgentActivityService preserves realtime turn provenance for atten
       subscribeConnectionState: () => () => {}
     } as never,
     tuttidClient: {
-      getWorkspaceAgentSession: async () => ({
+      getWorkspaceAgentSession: async (
+        ...args: Parameters<TuttidClient["getWorkspaceAgentSession"]>
+      ) => ({
+        ...sessionDetailProjection(args[2]),
         session: settled,
         childSessions: [],
         turns: []
@@ -1646,7 +1677,9 @@ test("WorkspaceAgentActivityService preserves live provenance across a transient
       subscribeConnectionState: () => () => {}
     } as never,
     tuttidClient: {
-      getWorkspaceAgentSession: async () => {
+      getWorkspaceAgentSession: async (
+        ...args: Parameters<TuttidClient["getWorkspaceAgentSession"]>
+      ) => {
         getCalls += 1;
         if (getCalls === 2) {
           throw new TuttidProtocolError({
@@ -1657,6 +1690,7 @@ test("WorkspaceAgentActivityService preserves live provenance across a transient
           });
         }
         return {
+          ...sessionDetailProjection(args[2]),
           session: getCalls === 1 ? running : settled,
           childSessions: [],
           turns: []
@@ -1874,9 +1908,12 @@ test("WorkspaceAgentActivityService fetches detail before combined message recon
   });
   const service = new WorkspaceAgentActivityService({
     tuttidClient: {
-      getWorkspaceAgentSession: async () => {
+      getWorkspaceAgentSession: async (
+        ...args: Parameters<TuttidClient["getWorkspaceAgentSession"]>
+      ) => {
         calls.push("getSession");
         return {
+          ...sessionDetailProjection(args[2]),
           session: messagesResolved ? finalSession : staleSession,
           childSessions: [],
           turns: []
@@ -1978,7 +2015,10 @@ test("WorkspaceAgentActivityService reconciles child sessions and their messages
   }> = [];
   const service = new WorkspaceAgentActivityService({
     tuttidClient: {
-      getWorkspaceAgentSession: async () => ({
+      getWorkspaceAgentSession: async (
+        ...args: Parameters<TuttidClient["getWorkspaceAgentSession"]>
+      ) => ({
+        ...sessionDetailProjection(args[2]),
         session: root,
         childSessions: [child],
         turns: [
@@ -2117,11 +2157,13 @@ test("WorkspaceAgentActivityService catches up children that advance between det
     tuttidClient: {
       getWorkspaceAgentSession: async (
         _workspaceId: string,
-        requestedSessionId: string
+        requestedSessionId: string,
+        projection?: Parameters<TuttidClient["getWorkspaceAgentSession"]>[2]
       ) => {
         detailReads += 1;
         if (requestedSessionId === "child-1") {
           return {
+            ...sessionDetailProjection(projection),
             session: {
               ...child,
               messageVersion: detailReads === 2 ? 3 : 2
@@ -2131,6 +2173,7 @@ test("WorkspaceAgentActivityService catches up children that advance between det
           };
         }
         return {
+          ...sessionDetailProjection(projection),
           session: root,
           childSessions: [
             {
@@ -2239,7 +2282,10 @@ test("WorkspaceAgentActivityService loads the newest history page first", async 
   const session = workspaceAgentSession({ status: "ready" });
   const service = new WorkspaceAgentActivityService({
     tuttidClient: {
-      getWorkspaceAgentSession: async () => ({
+      getWorkspaceAgentSession: async (
+        ...args: Parameters<TuttidClient["getWorkspaceAgentSession"]>
+      ) => ({
+        ...sessionDetailProjection(args[2]),
         session,
         childSessions: [],
         turns: []
@@ -2317,7 +2363,10 @@ test("WorkspaceAgentActivityService drains child incremental pages from its dura
   });
   const service = new WorkspaceAgentActivityService({
     tuttidClient: {
-      getWorkspaceAgentSession: async () => ({
+      getWorkspaceAgentSession: async (
+        ...args: Parameters<TuttidClient["getWorkspaceAgentSession"]>
+      ) => ({
+        ...sessionDetailProjection(args[2]),
         session,
         childSessions: [],
         turns: []

--- a/apps/mobile/src/services/mobileAgentActivityReconcileExecutor.ts
+++ b/apps/mobile/src/services/mobileAgentActivityReconcileExecutor.ts
@@ -24,15 +24,19 @@ export function createMobileAgentActivityReconcileExecutor(input: {
     isAvailable: input.isAvailable,
     isSessionDeleted: input.isSessionDeleted,
     port: {
-      getSessionDetail: async ({ agentSessionId, signal }) =>
-        input.mapping.mapSessionDetail(
+      getSessionDetail: async ({ agentSessionId, projection, signal }) => {
+        const detailProjection =
+          projection === "message_hydration" ? "messageHydration" : "full";
+        return input.mapping.mapSessionDetail(
           agentSessionId,
           await input.client.getWorkspaceAgentSession(
             input.workspaceId,
             agentSessionId,
+            detailProjection,
             { signal }
           )
-        ),
+        );
+      },
       listSessionMessages: async ({
         afterVersion,
         agentSessionId,

--- a/apps/mobile/src/services/workspaceActivityService.test.ts
+++ b/apps/mobile/src/services/workspaceActivityService.test.ts
@@ -21,6 +21,11 @@ const workspace: WorkspaceSummary = {
   name: "Workspace"
 };
 
+const fullSessionDetailProjection = {
+  lifecycleCapabilitiesProjected: true,
+  projection: "full"
+} as const;
+
 describe("WorkspaceActivityService", () => {
   test("disposes the conversation Rail it owns", () => {
     const service = createService(
@@ -606,6 +611,7 @@ describe("WorkspaceActivityService", () => {
       detail: async () => {
         detailReads += 1;
         return {
+          ...fullSessionDetailProjection,
           childSessions: [],
           session: createSession(),
           turns: []
@@ -682,6 +688,7 @@ describe("WorkspaceActivityService", () => {
     const queries: Array<Record<string, unknown>> = [];
     const client = createClient({
       detail: async () => ({
+        ...fullSessionDetailProjection,
         childSessions: [],
         session: createSession(),
         turns: []
@@ -740,6 +747,7 @@ describe("WorkspaceActivityService", () => {
     const queries: Array<Record<string, unknown>> = [];
     const client = createClient({
       detail: async () => ({
+        ...fullSessionDetailProjection,
         childSessions: [],
         session: createSession(),
         turns: []
@@ -798,6 +806,7 @@ describe("WorkspaceActivityService", () => {
     let messageVersion = 1;
     const client = createClient({
       detail: async () => ({
+        ...fullSessionDetailProjection,
         childSessions: [],
         session: createSession(),
         turns: []
@@ -894,6 +903,7 @@ describe("WorkspaceActivityService", () => {
     };
     const client = createClient({
       detail: async () => ({
+        ...fullSessionDetailProjection,
         childSessions: [child],
         session: root,
         turns: [createTurn(root.id, "turn-root-1")]
@@ -1148,19 +1158,30 @@ function createClient(options: {
     createWorkspaceAgentSession: options.create,
     deleteWorkspaceAgentSessionsBatch: options.deleteBatch,
     getAgentProviderComposerOptions: options.composerOptions,
-    getWorkspaceAgentSession:
-      options.detail ??
-      (async (_workspaceId: string, agentSessionId: string) => {
-        const session = railSessions().find(
-          (candidate) => candidate.id === agentSessionId
-        );
-        if (!session) throw new Error("session not found");
-        return {
-          childSessions: [],
-          session,
-          turns: session.latestTurn ? [session.latestTurn] : []
-        };
-      }),
+    getWorkspaceAgentSession: async (
+      ...args: Parameters<NonNullable<TuttidClient["getWorkspaceAgentSession"]>>
+    ) => {
+      const detail = options.detail
+        ? await options.detail(args[0], args[1])
+        : await (async () => {
+            const session = railSessions().find(
+              (candidate) => candidate.id === args[1]
+            );
+            if (!session) throw new Error("session not found");
+            return {
+              ...fullSessionDetailProjection,
+              childSessions: [],
+              session,
+              turns: session.latestTurn ? [session.latestTurn] : []
+            };
+          })();
+      const projection = args[2] ?? "full";
+      return {
+        ...detail,
+        lifecycleCapabilitiesProjected: projection === "full",
+        projection
+      };
+    },
     listAgentTargets: async () => ({ targets: options.targets ?? [] }),
     listWorkspaceAgentSessionMessages: options.listMessages,
     listWorkspaceAgentPinnedSessionPage: async () => {

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -1003,10 +1003,21 @@ it owns the three reconcile scopes, cancellation and deletion fences,
 conversation-versus-durable cursors, pagination, the two-detail race closure,
 and atomic Engine dispatch. A host selects either requested-Session or
 Session-hierarchy message hydration according to the transcript surface it
-renders. HTTP execution, generated DTO mapping, absent/error interpretation,
-logging, polling, and legacy event fanout stay in the host. The canonical
-detail aggregate type belongs to activity-core; the tuttid adapter only maps
-the generated response into it.
+renders. The executor labels its first combined read as `message_hydration`;
+tuttid serves that projection without resolving provider-backed lifecycle
+capabilities. The final read remains authoritative and resolves those
+capabilities once. Hosts must preserve this distinction: caching provider
+capabilities or removing the final race-closing read can return stale actions,
+while using the full projection for discovery can launch an otherwise unused
+provider capability probe. Each HTTP response echoes its projection and whether
+lifecycle capability projection ran; clients fail closed on a mismatch, and
+values from a deliberately unprojected hydration response must never clear
+authoritative actions. Full projection remains fail-closed when a provider
+probe fails, preserving existing detail availability while making the action
+unavailable for that response. HTTP execution, generated DTO mapping,
+absent/error interpretation, logging, polling, and legacy event fanout stay in
+the host. The canonical detail aggregate type belongs to activity-core; the
+tuttid adapter only maps the generated response into it.
 
 Focused transcript paging is the adjacent AgentGUI application boundary.
 Desktop and Mobile construct the same
@@ -1018,10 +1029,13 @@ Engine. Mobile's disconnected poller and app lifecycle, Desktop diagnostics
 and WebSocket integration, and both renderers' scroll behavior remain host
 concerns. Hosts must not add a second older-message store or a host-local
 cursor/retry state machine. Desktop conversation selection owns activation
-guards and Rail projection coordination, then delegates initial or forced
-detail hydration to this controller. Message paging adapters do not call back
-into selection or Rail orchestration, and hosts do not maintain a second
-messages-only reconcile entrypoint.
+guards and Rail projection coordination, then asks this controller to ensure
+initial detail hydration. Automatic selection restoration is idempotent: it
+must not reinterpret a repeated selection as a forced refresh or enqueue a
+second reconcile while the first is pending. Explicit refresh remains a
+separate command. Message paging adapters do not call back into selection or
+Rail orchestration, and hosts do not maintain a second messages-only reconcile
+entrypoint.
 
 Event-stream continuity and command reachability are separate host facts.
 `eventStreamConnectionChanged` belongs to the coordinator and triggers

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -656,6 +656,19 @@ rows never advance this cursor. This child policy is separate from the root
 conversation's user-boundary repair policy, which may intentionally restart an
 incremental read at zero.
 
+The discovery detail request uses the daemon's `messageHydration` projection.
+That projection retains the hierarchy and `messageVersion` cursors needed by
+the shared executor but does not resolve provider-backed lifecycle
+capabilities. The final detail request uses the full projection and is the only
+read in one combined reconcile that may perform a historical provider
+capability probe. Desktop and Mobile derive this choice from the same
+activity-core request purpose; host adapters must not infer it from timing or
+add a TTL cache for capability results. The detail response echoes the selected
+projection and an explicit lifecycle-capability projection flag. The shared
+tuttid client rejects mismatched responses, and consumers must not treat
+false-valued capabilities from an unresolved hydration projection as
+authoritative.
+
 A `waiting` Turn does not imply user action. Only a pending Interaction produces approval/question attention.
 
 ### 4.4 Prompt queue
@@ -847,10 +860,13 @@ Selecting an already hydrated Session must not start another detail reconcile;
 the selection controller alone decides whether hydration is missing. Composer
 option synchronization does not own Session detail reloads. On Desktop the
 selection controller also owns activation guards and Rail projection
-coordination before requesting a forced detail hydration. The message paging
-adapter owns only focused message-controller lifetime, transport mapping,
-diagnostics, and initial/older commands; it does not call back into selection
-or Rail state. There is no separate messages-only Engine reconcile helper.
+coordination before requesting idempotent initial hydration. A repeated
+automatic selection restoration must not become a forced refresh or append
+pending demand to the in-flight reconcile; explicit user refresh is a separate
+intent. The message paging adapter owns only focused message-controller
+lifetime, transport mapping, diagnostics, and initial/older commands; it does
+not call back into selection or Rail state. There is no separate messages-only
+Engine reconcile helper.
 
 Timeline projection is pure, deterministic, and provider-neutral. React views render rows/cards and dispatch actions.
 Transcript Turn membership and order come only from timeline items in the

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -584,6 +584,47 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   [codex_appserver_adapter_test.go](../../../packages/agent/daemon/runtime/codex_appserver_adapter_test.go)
   [agent-gui-node.md](../../architecture/agent-gui-node.md)
 
+### Opening a historical Codex session starts two short provider processes
+
+- Symptom:
+  Selecting one settled Codex conversation logs two process starts, each with
+  `initialize` followed by `thread/read`, even though no turn was resumed.
+- Quick checks:
+  Confirm neither sequence contains `thread/resume`. Enable reconcile trace
+  diagnostics temporarily and count complete `state_and_messages` commands.
+  Two discovery/message/final sequences indicate two reconciles; one sequence
+  with two probes indicates that both detail projections resolved capabilities.
+- Root cause:
+  There are two independent boundaries to verify. Combined reconciliation
+  intentionally reads detail twice to close races while messages load, but its
+  discovery read only needs hierarchy and `messageVersion`; using the full
+  Session projection there adds an accidental provider-history capability
+  probe. Separately, automatic selection restoration can be replayed while the
+  first reconcile is running. Treating that ordinary selection as
+  `force: true` appends a second complete reconcile, whose final detail read
+  launches another probe.
+- Fix:
+  Preserve the two-read race fence. Send the first request with the
+  `messageHydration` projection and the final request with `full`; only the
+  latter resolves provider-backed lifecycle capabilities. Model automatic
+  selection as idempotent “ensure hydrated” work, leaving force refresh as an
+  explicit intent. Do not mask either symptom with a TTL cache, single-flight
+  delay, or by removing the final read.
+- Validation:
+  Select a historical root-only Codex Session with no child hierarchy through
+  `make dev-gui`. One combined reconcile should issue two detail requests and
+  one message-list request, but only the final detail request should emit the short
+  `initialize`/`thread/read` capability probe. Replaying the same selection
+  while that reconcile is pending must not start another combined reconcile.
+  Sessions with child hierarchy or additional message pages may issue more than
+  one message-list request; each request must still follow the shared executor's
+  Session and cursor policy.
+- References:
+  [sessionReconcileExecutor.ts](../../../packages/agent/activity-core/src/sessionReconcileExecutor.ts)
+  [useAgentConversationSelection.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentConversationSelection.ts)
+  [service_turns.go](../../../services/tuttid/service/agent/service_turns.go)
+  [codex_appserver_fork.go](../../../packages/agent/daemon/runtime/codex_appserver_fork.go)
+
 ### Codex turn stays working before any reply or tool activity
 
 - Symptom:

--- a/packages/agent/activity-core/src/engine/sessionReconcile.types.ts
+++ b/packages/agent/activity-core/src/engine/sessionReconcile.types.ts
@@ -9,10 +9,14 @@ import type { AgentActivitySessionInput } from "../sessionNormalization.ts";
 export type SessionReconcileScope = "messages" | "state" | "state_and_messages";
 
 /**
- * Host-neutral authoritative detail aggregate consumed by reconcile flows.
- * Transport adapters map their DTOs into this contract before Core sees them.
+ * Host-neutral projection-qualified detail aggregate consumed by reconcile
+ * flows. Transport adapters preserve projection authority so Core can use an
+ * unprojected discovery snapshot for cursors without applying its capability
+ * values as canonical state.
  */
 export interface AgentActivitySessionDetailSnapshot {
+  projection: "authoritative" | "message_hydration";
+  lifecycleCapabilitiesProjected: boolean;
   session: AgentActivitySession;
   childSessions: readonly AgentActivitySession[];
   turns: readonly AgentActivityTurn[];

--- a/packages/agent/activity-core/src/sessionReconcileExecutor.test.ts
+++ b/packages/agent/activity-core/src/sessionReconcileExecutor.test.ts
@@ -178,13 +178,19 @@ test("combined reconcile closes root and child races before one apply", async ()
     sessionDetail(rootV2, [childV1, childV2])
   ];
   const requests: MessageRequest[] = [];
+  const detailProjections: string[] = [];
   const callsBySessionId = new Map<string, number>();
   const harness = createHarness(
     {
-      getSessionDetail: async () => {
+      getSessionDetail: async ({ projection }) => {
+        detailProjections.push(projection);
         const detail = details.shift();
         assert.ok(detail);
-        return detail;
+        return sessionDetail(
+          detail.session,
+          [...detail.childSessions],
+          projection
+        );
       },
       listSessionMessages: async (input) => {
         requests.push({ ...input });
@@ -211,6 +217,7 @@ test("combined reconcile closes root and child races before one apply", async ()
   const result = await harness.execute("state_and_messages");
 
   assert.equal(result.status, "applied");
+  assert.deepEqual(detailProjections, ["message_hydration", "authoritative"]);
   assert.equal(callsBySessionId.get("root-1"), 2);
   assert.equal(callsBySessionId.get("child-1"), 1);
   assert.equal(callsBySessionId.get("child-2"), 1);
@@ -237,7 +244,8 @@ test("requested-session policy keeps child entities without prefetching child me
   const requests: MessageRequest[] = [];
   const harness = createHarness(
     {
-      getSessionDetail: async () => sessionDetail(session("root-1"), [child]),
+      getSessionDetail: async ({ projection }) =>
+        sessionDetail(session("root-1"), [child], projection),
       listSessionMessages: async (input) => {
         requests.push({ ...input });
         return page([], false, 0);
@@ -272,8 +280,8 @@ test("combined reconcile removes the full descendant closure of a tombstoned chi
   const requestedSessionIds: string[] = [];
   const harness = createHarness(
     {
-      getSessionDetail: async () =>
-        sessionDetail(session("root-1"), [child, grandchild]),
+      getSessionDetail: async ({ projection }) =>
+        sessionDetail(session("root-1"), [child, grandchild], projection),
       listSessionMessages: async (input) => {
         requestedSessionIds.push(input.agentSessionId);
         if (input.agentSessionId !== "root-1") {
@@ -357,10 +365,14 @@ test("combined result deduplicates messages replayed by root repair", async () =
   ];
   let messageReadCount = 0;
   const harness = createHarness({
-    getSessionDetail: async () => {
+    getSessionDetail: async ({ projection }) => {
       const detail = details.shift();
       assert.ok(detail);
-      return detail;
+      return sessionDetail(
+        detail.session,
+        [...detail.childSessions],
+        projection
+      );
     },
     listSessionMessages: async () => {
       messageReadCount += 1;
@@ -520,9 +532,16 @@ function session(
 
 function sessionDetail(
   root: AgentActivitySession,
-  childSessions: AgentActivitySession[] = []
+  childSessions: AgentActivitySession[] = [],
+  projection: AgentActivitySessionDetailSnapshot["projection"] = "authoritative"
 ): AgentActivitySessionDetailSnapshot {
-  return { childSessions, session: root, turns: [] };
+  return {
+    childSessions,
+    lifecycleCapabilitiesProjected: projection === "authoritative",
+    projection,
+    session: root,
+    turns: []
+  };
 }
 
 function message(

--- a/packages/agent/activity-core/src/sessionReconcileExecutor.ts
+++ b/packages/agent/activity-core/src/sessionReconcileExecutor.ts
@@ -24,6 +24,7 @@ export type AgentActivityChildMessageHydration =
 export interface AgentActivitySessionReconcilePort {
   getSessionDetail(input: {
     agentSessionId: string;
+    projection: "authoritative" | "message_hydration";
     signal?: AbortSignal;
     workspaceId: string;
   }): Promise<AgentActivitySessionDetailSnapshot>;
@@ -145,10 +146,26 @@ export function createAgentActivitySessionReconcileExecutor(
     });
     const detail = await input.port.getSessionDetail({
       agentSessionId,
+      projection: phase === "discovery" ? "message_hydration" : "authoritative",
       signal,
       workspaceId
     });
     assertExecutionActive(signal);
+    const expectedProjection =
+      phase === "discovery" ? "message_hydration" : "authoritative";
+    if (detail.projection !== expectedProjection) {
+      throw new Error(
+        `session reconcile detail projection mismatch: expected ${expectedProjection}, received ${detail.projection}`
+      );
+    }
+    if (
+      detail.lifecycleCapabilitiesProjected !==
+      (expectedProjection === "authoritative")
+    ) {
+      throw new Error(
+        `session reconcile lifecycle capability projection mismatch for ${expectedProjection} detail`
+      );
+    }
     if (detail.session.agentSessionId !== agentSessionId) {
       throw new Error(
         `session reconcile detail identity mismatch: expected ${agentSessionId}, received ${detail.session.agentSessionId}`
@@ -591,6 +608,8 @@ function withoutDeletedChildren(
     ...childSessions.map((session) => session.agentSessionId)
   ]);
   return {
+    projection: detail.projection,
+    lifecycleCapabilitiesProjected: detail.lifecycleCapabilitiesProjected,
     session: detail.session,
     childSessions,
     turns: detail.turns.filter((turn) => retainedIds.has(turn.agentSessionId))

--- a/packages/agent/activity-tuttid-adapter/src/sessionDetail.test.ts
+++ b/packages/agent/activity-tuttid-adapter/src/sessionDetail.test.ts
@@ -12,6 +12,8 @@ test("detail mapping preserves the authoritative root, children, and Turns", () 
     "workspace-1",
     "root-1",
     {
+      projection: "full",
+      lifecycleCapabilitiesProjected: true,
       session: createSession({
         id: "root-1",
         kind: "root"
@@ -60,6 +62,38 @@ test("detail mapping preserves the authoritative root, children, and Turns", () 
   );
 });
 
+test("detail mapping keeps unresolved capability projections out of authoritative reads", () => {
+  const detail = {
+    projection: "messageHydration",
+    lifecycleCapabilitiesProjected: false,
+    session: createSession({ id: "root-1", kind: "root" }),
+    childSessions: [],
+    turns: []
+  } satisfies WorkspaceAgentSessionDetailResponse;
+
+  assert.doesNotThrow(() =>
+    agentActivitySessionDetailFromTuttid("workspace-1", "root-1", detail, {
+      currentUserId: "account-user-1"
+    })
+  );
+  const inconsistent = {
+    ...detail,
+    lifecycleCapabilitiesProjected: true
+  };
+  assert.throws(
+    () =>
+      agentActivitySessionDetailFromTuttid(
+        "workspace-1",
+        "root-1",
+        inconsistent,
+        {
+          currentUserId: "account-user-1"
+        }
+      ),
+    /lifecycle capability projection does not match detail projection/
+  );
+});
+
 test("detail mapping fails the entire aggregate when a child violates protocol v2", () => {
   const child = createSession({
     id: "child-1",
@@ -76,6 +110,8 @@ test("detail mapping fails the entire aggregate when a child violates protocol v
         "workspace-1",
         "root-1",
         {
+          projection: "full",
+          lifecycleCapabilitiesProjected: true,
           session: createSession({ id: "root-1", kind: "root" }),
           childSessions: [malformedChild as WorkspaceAgentSession],
           turns: []
@@ -93,6 +129,8 @@ test("detail mapping rejects a response for a different requested Session", () =
         "workspace-1",
         "requested-1",
         {
+          projection: "full",
+          lifecycleCapabilitiesProjected: true,
           session: createSession({ id: "other-1", kind: "root" }),
           childSessions: [],
           turns: []
@@ -110,6 +148,8 @@ test("detail mapping rejects children outside the requested hierarchy", () => {
         "workspace-1",
         "root-1",
         {
+          projection: "full",
+          lifecycleCapabilitiesProjected: true,
           session: createSession({ id: "root-1", kind: "root" }),
           childSessions: [
             createSession({
@@ -132,6 +172,8 @@ test("detail mapping accepts descendants below a requested child Session", () =>
     "workspace-1",
     "child-1",
     {
+      projection: "full",
+      lifecycleCapabilitiesProjected: true,
       session: createSession({
         id: "child-1",
         kind: "child",
@@ -166,6 +208,8 @@ test("detail mapping rejects malformed or foreign Turns atomically", () => {
           "workspace-1",
           "root-1",
           {
+            projection: "full",
+            lifecycleCapabilitiesProjected: true,
             session: createSession({ id: "root-1", kind: "root" }),
             childSessions: [],
             turns: [turn]

--- a/packages/agent/activity-tuttid-adapter/src/sessionDetail.ts
+++ b/packages/agent/activity-tuttid-adapter/src/sessionDetail.ts
@@ -20,6 +20,9 @@ export function agentActivitySessionDetailFromTuttid(
 ): AgentActivitySessionDetailSnapshot {
   assertTuttidSessionDetailContract(expectedAgentSessionId, detail);
   return {
+    projection:
+      detail.projection === "full" ? "authoritative" : "message_hydration",
+    lifecycleCapabilitiesProjected: detail.lifecycleCapabilitiesProjected,
     session: agentActivitySessionFromTuttidSession(
       workspaceId,
       detail.session,
@@ -36,6 +39,20 @@ function assertTuttidSessionDetailContract(
   expectedAgentSessionId: string,
   detail: WorkspaceAgentSessionDetailResponse
 ): void {
+  if (
+    detail.projection !== "full" &&
+    detail.projection !== "messageHydration"
+  ) {
+    throw detailContractError(
+      `projection ${JSON.stringify(detail.projection)} is invalid`
+    );
+  }
+  const capabilitiesShouldBeProjected = detail.projection === "full";
+  if (detail.lifecycleCapabilitiesProjected !== capabilitiesShouldBeProjected) {
+    throw detailContractError(
+      `lifecycle capability projection does not match detail projection ${JSON.stringify(detail.projection)}`
+    );
+  }
   const expectedId = trimmedString(expectedAgentSessionId);
   const rootId = trimmedString(detail.session?.id);
   if (!expectedId || rootId !== expectedId) {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentConversationSelection.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentConversationSelection.spec.tsx
@@ -7,7 +7,7 @@ describe("useAgentConversationSelection", () => {
   it("reconciles detail when a selected rail session has no cached messages", () => {
     const active = { current: "recent-session" as string | null };
     const markPending = vi.fn();
-    const reload = vi.fn();
+    const ensureHydrated = vi.fn();
     const setLoading = vi.fn();
     const requestReveal = vi.fn();
     const hasConversationListQuery = vi.fn(() => true);
@@ -23,9 +23,9 @@ describe("useAgentConversationSelection", () => {
           contains: () => true
         },
         detail: {
+          ensureHydrated,
           isHydrated: () => false,
           markPending,
-          reload,
           setLoading
         },
         hasConversationListQuery,
@@ -57,7 +57,7 @@ describe("useAgentConversationSelection", () => {
     expect(markPending).toHaveBeenCalledWith("historical-session");
     expect(setLoading).not.toHaveBeenCalled();
     expect(hasConversationListQuery).toHaveBeenCalledOnce();
-    expect(reload).toHaveBeenCalledWith("historical-session");
+    expect(ensureHydrated).toHaveBeenCalledWith("historical-session");
     expect(requestReveal).toHaveBeenCalledWith(
       "historical-session",
       "external-open"
@@ -67,7 +67,7 @@ describe("useAgentConversationSelection", () => {
   it("reuses cached detail when selecting another hydrated session", () => {
     const active = { current: "session-1" as string | null };
     const markPending = vi.fn();
-    const reload = vi.fn();
+    const ensureHydrated = vi.fn();
     const setLoading = vi.fn();
     const data: AgentGUINodeData = {
       agentTargetId: null,
@@ -86,9 +86,9 @@ describe("useAgentConversationSelection", () => {
           contains: () => true
         },
         detail: {
+          ensureHydrated,
           isHydrated: () => true,
           markPending,
-          reload,
           setLoading
         },
         hasConversationListQuery: () => true,
@@ -119,12 +119,12 @@ describe("useAgentConversationSelection", () => {
 
     expect(setLoading).toHaveBeenCalledWith(false);
     expect(markPending).not.toHaveBeenCalled();
-    expect(reload).not.toHaveBeenCalled();
+    expect(ensureHydrated).not.toHaveBeenCalled();
   });
 
   it("selects an optimistic pending session without reloading durable detail", () => {
     const active = { current: "session-b" as string | null };
-    const reload = vi.fn();
+    const ensureHydrated = vi.fn();
     const setLoading = vi.fn();
     const setIntent = vi.fn();
     const { result } = renderHook(() =>
@@ -139,9 +139,9 @@ describe("useAgentConversationSelection", () => {
           contains: () => true
         },
         detail: {
+          ensureHydrated,
           isHydrated: () => false,
           markPending: vi.fn(),
-          reload,
           setLoading
         },
         hasConversationListQuery: () => true,
@@ -172,13 +172,13 @@ describe("useAgentConversationSelection", () => {
       id: "session-a"
     });
     expect(setLoading).toHaveBeenCalledWith(false);
-    expect(reload).not.toHaveBeenCalled();
+    expect(ensureHydrated).not.toHaveBeenCalled();
   });
 
   it("does not reload Rail or detail for an activation that cannot reload", () => {
     const active = { current: "session-b" as string | null };
     const hasConversationListQuery = vi.fn(() => true);
-    const reload = vi.fn();
+    const ensureHydrated = vi.fn();
     const { result } = renderHook(() =>
       useAgentConversationSelection({
         activation: {
@@ -191,9 +191,9 @@ describe("useAgentConversationSelection", () => {
           contains: () => true
         },
         detail: {
+          ensureHydrated,
           isHydrated: () => false,
           markPending: vi.fn(),
-          reload,
           setLoading: vi.fn()
         },
         hasConversationListQuery,
@@ -219,6 +219,6 @@ describe("useAgentConversationSelection", () => {
     act(() => result.current.selectConversation("session-a"));
 
     expect(hasConversationListQuery).not.toHaveBeenCalled();
-    expect(reload).not.toHaveBeenCalled();
+    expect(ensureHydrated).not.toHaveBeenCalled();
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentConversationSelection.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentConversationSelection.ts
@@ -38,9 +38,9 @@ interface AgentConversationSelectionInput {
     contains(agentSessionId: string): boolean;
   };
   detail: {
+    ensureHydrated(agentSessionId: string): void;
     isHydrated(agentSessionId: string): boolean;
     markPending(agentSessionId: string): void;
-    reload(agentSessionId: string): void;
     setLoading(loading: boolean): void;
   };
   hasConversationListQuery(): boolean;
@@ -141,8 +141,8 @@ export function useAgentConversationSelection(
         if (reloadConversations) {
           void syncConversationListProjection(normalized);
         }
-        if (previous === normalized || !detailHydrated) {
-          current.detail.reload(normalized);
+        if (!detailHydrated) {
+          current.detail.ensureHydrated(normalized);
         }
       }
       persistActiveConversation(normalized);

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.spec.ts
@@ -375,7 +375,7 @@ describe("clearRolledBackAgentGUISelection", () => {
 });
 
 describe("conversation reload ownership", () => {
-  it("coordinates forced message hydration from selection", () => {
+  it("ensures message hydration without turning selection into a forced refresh", () => {
     const sessionEngine = createTestAgentSessionEngine("workspace-1");
     const loadSelectedConversationMessages = vi.fn(async () => undefined);
     const data: AgentGUINodeData = {
@@ -442,8 +442,7 @@ describe("conversation reload ownership", () => {
     act(() => result.current.selectConversation("session-next"));
 
     expect(loadSelectedConversationMessages).toHaveBeenCalledWith(
-      "session-next",
-      { force: true }
+      "session-next"
     );
     sessionEngine.dispose();
   });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.ts
@@ -412,17 +412,15 @@ export function useAgentGUIConversationSelectionController(
         conversationIdsRef.current.has(agentSessionId)
     },
     detail: {
+      ensureHydrated: (agentSessionId) => {
+        void loadSelectedConversationMessages(agentSessionId);
+      },
       isHydrated: (agentSessionId) =>
         selectEngineSessionDetailHydrated(
           sessionEngine.getSnapshot(),
           agentSessionId
         ),
       markPending: markSelectedConversationDetailPending,
-      reload: (agentSessionId) => {
-        void loadSelectedConversationMessages(agentSessionId, {
-          force: true
-        });
-      },
       setLoading: setIsLoadingMessages
     },
     hasConversationListQuery: () => Boolean(conversationListQuery),

--- a/packages/agent/gui/agentConversationMessageController.spec.ts
+++ b/packages/agent/gui/agentConversationMessageController.spec.ts
@@ -51,6 +51,39 @@ describe("createAgentConversationMessageController", () => {
     engine.dispose();
   });
 
+  it("treats repeated initial hydration as idempotent while reconcile is pending", async () => {
+    type CommandResult = Awaited<ReturnType<EngineCommandPort["execute"]>>;
+    let resolveExecute: (result: CommandResult) => void = () => {};
+    const execute = vi.fn<EngineCommandPort["execute"]>(
+      () =>
+        new Promise((resolve) => {
+          resolveExecute = resolve;
+        })
+    );
+    const engine = createTestAgentSessionEngine("workspace-1", { execute });
+    const controller = createController({ engine });
+
+    controller.requestInitial("session-1");
+    controller.requestInitial("session-1");
+
+    await vi.waitFor(() => {
+      expect(
+        execute.mock.calls.filter(
+          ([command]) => command.type === "session/reconcile"
+        )
+      ).toHaveLength(1);
+    });
+    resolveExecute({
+      affectedSessionIds: [],
+      appliedMessages: [],
+      session: null,
+      status: "applied"
+    });
+
+    controller.dispose();
+    engine.dispose();
+  });
+
   it("loads older history only from the authoritative Engine window", async () => {
     const engine = createTestAgentSessionEngine("workspace-1");
     const listSessionMessages = vi.fn(async () =>

--- a/packages/clients/tuttid-ts/src/generated/index.ts
+++ b/packages/clients/tuttid-ts/src/generated/index.ts
@@ -1805,6 +1805,7 @@ export type {
   WorkspaceAgentRailPlacement,
   WorkspaceAgentSession,
   WorkspaceAgentSessionAttachmentResponse,
+  WorkspaceAgentSessionDetailProjection,
   WorkspaceAgentSessionDetailResponse,
   WorkspaceAgentSessionEventEnvelope,
   WorkspaceAgentSessionForkLineage,

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -2145,6 +2145,11 @@ export type WorkspaceAgentSessionKind = "root" | "child";
  */
 export type WorkspaceAgentMessageCursor = number;
 
+/**
+ * Projection applied to a Session detail response. messageHydration preserves hierarchy and message cursors but leaves provider-backed lifecycle capabilities unresolved.
+ */
+export type WorkspaceAgentSessionDetailProjection = "full" | "messageHydration";
+
 export type WorkspaceAgentSessionLifecycleCapabilities = {
   /**
    * Whether this exact session can fork its latest settled state.
@@ -2344,6 +2349,11 @@ export type WorkspaceAgentSessionResponse = {
 };
 
 export type WorkspaceAgentSessionDetailResponse = {
+  projection: WorkspaceAgentSessionDetailProjection;
+  /**
+   * Whether provider-backed lifecycle capability projection ran for session and childSessions. A full projection reports true even when a provider probe fails closed, because false then means the action is unavailable for this response. When false, projection was intentionally skipped and capability values must not be applied as authoritative.
+   */
+  lifecycleCapabilitiesProjected: boolean;
   session: WorkspaceAgentSession;
   /**
    * Flat collection of every nested child session below session. Clients reconstruct the tree from the immutable parent fields.
@@ -10473,7 +10483,12 @@ export type GetWorkspaceAgentSessionData = {
     workspaceID: string;
     agentSessionID: string;
   };
-  query?: never;
+  query?: {
+    /**
+     * Selects the detail projection. messageHydration preserves the session hierarchy and message cursors used by reconciliation discovery without resolving provider-backed lifecycle capabilities.
+     */
+    projection?: WorkspaceAgentSessionDetailProjection;
+  };
   url: "/v1/workspaces/{workspaceID}/agent-sessions/{agentSessionID}";
 };
 

--- a/packages/clients/tuttid-ts/src/index.test.ts
+++ b/packages/clients/tuttid-ts/src/index.test.ts
@@ -702,6 +702,59 @@ test("shared tuttid client lists workspace agent sessions with query params", as
   });
 });
 
+test("shared tuttid client requests the message hydration session projection", async () => {
+  const response = {
+    childSessions: [],
+    lifecycleCapabilitiesProjected: false,
+    projection: "messageHydration",
+    session: {},
+    turns: []
+  };
+  const { client, requests } = captureClient(jsonResponse(response));
+  const controller = new AbortController();
+
+  assert.deepEqual(
+    await client.getWorkspaceAgentSession(
+      "workspace-1",
+      "session-1",
+      "messageHydration",
+      { signal: controller.signal }
+    ),
+    response
+  );
+  assertRequest(requests[0]!, {
+    authorization: null,
+    body: null,
+    method: "GET",
+    path: "/v1/workspaces/workspace-1/agent-sessions/session-1",
+    query: { projection: "messageHydration" }
+  });
+  assert.equal(requests[0]!.signal?.aborted, false);
+  controller.abort();
+  assert.equal(requests[0]!.signal?.aborted, true);
+});
+
+test("shared tuttid client rejects a mismatched session detail projection", async () => {
+  const { client } = captureClient(
+    jsonResponse({
+      childSessions: [],
+      lifecycleCapabilitiesProjected: true,
+      projection: "full",
+      session: {},
+      turns: []
+    })
+  );
+
+  await assert.rejects(
+    client.getWorkspaceAgentSession(
+      "workspace-1",
+      "session-1",
+      "messageHydration"
+    ),
+    /projection mismatch/
+  );
+});
+
 test("shared tuttid client forwards AbortSignal for issue topic and issue list requests", async () => {
   const requests: Request[] = [];
   const client = createTuttidClient({

--- a/packages/clients/tuttid-ts/src/tuttidClientTypes.ts
+++ b/packages/clients/tuttid-ts/src/tuttidClientTypes.ts
@@ -135,6 +135,7 @@ import type {
   WorkspaceWorkflowSnapshot,
   DecideWorkspaceWorkflowCheckpointRequest,
   WorkspaceAgentSession,
+  WorkspaceAgentSessionDetailProjection,
   TuttiModeActivation,
   WorkspaceAgentSessionDetailResponse,
   WorkspaceAgentPlanDecisionResponse,
@@ -441,6 +442,7 @@ export interface TuttidClient
   getWorkspaceAgentSession(
     workspaceID: string,
     agentSessionID: string,
+    projection?: WorkspaceAgentSessionDetailProjection,
     requestOptions?: TuttidRequestOptions
   ): Promise<WorkspaceAgentSessionDetailResponse>;
   getAgentProviderComposerOptions(

--- a/packages/clients/tuttid-ts/src/workspaceAgentClient.ts
+++ b/packages/clients/tuttid-ts/src/workspaceAgentClient.ts
@@ -307,16 +307,33 @@ export function createWorkspaceAgentClient(
     async getWorkspaceAgentSession(
       workspaceID,
       agentSessionID,
+      projection,
       requestOptions
     ) {
-      return unwrapData(
+      const expectedProjection = projection ?? "full";
+      const detail = unwrapData(
         await getWorkspaceAgentSession({
           client,
           path: { agentSessionID, workspaceID },
+          query: projection === undefined ? undefined : { projection },
           ...requestOptions
         }),
         "Workspace agent session request failed."
       );
+      if (detail.projection !== expectedProjection) {
+        throw new Error(
+          `Workspace agent session projection mismatch: requested ${expectedProjection}, received ${detail.projection}.`
+        );
+      }
+      if (
+        detail.lifecycleCapabilitiesProjected !==
+        (expectedProjection === "full")
+      ) {
+        throw new Error(
+          `Workspace agent session lifecycle capability projection does not match detail projection ${expectedProjection}.`
+        );
+      }
+      return detail;
     },
     async listWorkspaceAgentSessions(workspaceID, request, requestOptions) {
       return unwrapData(

--- a/services/tuttid/api/daemon_agent_sessions.go
+++ b/services/tuttid/api/daemon_agent_sessions.go
@@ -36,7 +36,7 @@ type AgentSessionService interface {
 	GetSessionForkOperation(context.Context, string, string) (agentservice.SessionForkOperation, error)
 	AcknowledgeSessionForkOperation(context.Context, string, string) (agentservice.SessionForkOperation, error)
 	Get(context.Context, string, string) (agentservice.Session, error)
-	GetDetail(context.Context, string, string) (agentservice.SessionDetail, error)
+	GetDetailWithProjection(context.Context, string, string, agentservice.SessionDetailProjection) (agentservice.SessionDetail, error)
 	ReadAttachment(context.Context, string, string, string) (agentservice.PromptAttachment, error)
 	ListGitBranches(context.Context, string, string) (agentservice.GitBranches, error)
 	ListGitBranchesForPath(context.Context, string, string) (agentservice.GitBranches, error)
@@ -105,12 +105,32 @@ func (api DaemonAPI) GetAgentProviderComposerOptions(ctx context.Context, reques
 }
 
 func (api DaemonAPI) GetWorkspaceAgentSession(ctx context.Context, request tuttigenerated.GetWorkspaceAgentSessionRequestObject) (tuttigenerated.GetWorkspaceAgentSessionResponseObject, error) {
+	if request.Params.Projection != nil && !request.Params.Projection.Valid() {
+		return tuttigenerated.GetWorkspaceAgentSession400JSONResponse{
+			InvalidRequestErrorJSONResponse: invalidRequestError(
+				apierrors.InvalidRequest(
+					apierrors.ReasonMalformedRequest,
+					apierrors.WithDeveloperMessage("unsupported agent session detail projection"),
+				),
+			),
+		}, nil
+	}
 	if api.AgentSessionService == nil {
 		return tuttigenerated.GetWorkspaceAgentSession503JSONResponse{
 			ServiceUnavailableErrorJSONResponse: agentSessionServiceUnavailableError(),
 		}, nil
 	}
-	detail, err := api.AgentSessionService.GetDetail(ctx, string(request.WorkspaceID), string(request.AgentSessionID))
+	projection := agentservice.SessionDetailProjectionFull
+	if request.Params.Projection != nil &&
+		*request.Params.Projection == tuttigenerated.MessageHydration {
+		projection = agentservice.SessionDetailProjectionMessageHydration
+	}
+	detail, err := api.AgentSessionService.GetDetailWithProjection(
+		ctx,
+		string(request.WorkspaceID),
+		string(request.AgentSessionID),
+		projection,
+	)
 	if err != nil {
 		return writeGetWorkspaceAgentSessionError(err), nil
 	}
@@ -123,9 +143,11 @@ func (api DaemonAPI) GetWorkspaceAgentSession(ctx context.Context, request tutti
 		return writeGetWorkspaceAgentSessionError(err), nil
 	}
 	return tuttigenerated.GetWorkspaceAgentSession200JSONResponse{
-		Session:       generatedSession,
-		ChildSessions: generatedChildren,
-		Turns:         generatedAgentTurns(detail.Turns),
+		Session:                        generatedSession,
+		ChildSessions:                  generatedChildren,
+		Turns:                          generatedAgentTurns(detail.Turns),
+		Projection:                     tuttigenerated.WorkspaceAgentSessionDetailProjection(projection),
+		LifecycleCapabilitiesProjected: projection == agentservice.SessionDetailProjectionFull,
 	}, nil
 }
 

--- a/services/tuttid/api/daemon_agent_sessions_projection_test.go
+++ b/services/tuttid/api/daemon_agent_sessions_projection_test.go
@@ -1,0 +1,75 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	tuttigenerated "github.com/tutti-os/tutti/services/tuttid/api/generated"
+	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
+)
+
+func TestGetWorkspaceAgentSessionUsesMessageHydrationProjection(t *testing.T) {
+	var received agentservice.SessionDetailProjection
+	service := stubAgentSessionService{
+		getDetailWithProjectionFn: func(
+			_ context.Context,
+			_, _ string,
+			projection agentservice.SessionDetailProjection,
+		) (agentservice.SessionDetail, error) {
+			received = projection
+			return agentservice.SessionDetail{
+				Session: agentservice.Session{
+					ID:             "session-1",
+					Kind:           "root",
+					RailSectionKey: "conversations",
+				},
+				ChildSessions: []agentservice.Session{},
+			}, nil
+		},
+	}
+	projection := tuttigenerated.MessageHydration
+
+	response, err := (DaemonAPI{AgentSessionService: service}).
+		GetWorkspaceAgentSession(t.Context(), tuttigenerated.GetWorkspaceAgentSessionRequestObject{
+			WorkspaceID:    "workspace-1",
+			AgentSessionID: "session-1",
+			Params: tuttigenerated.GetWorkspaceAgentSessionParams{
+				Projection: &projection,
+			},
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved, ok := response.(tuttigenerated.GetWorkspaceAgentSession200JSONResponse)
+	if !ok {
+		t.Fatalf("response=%T, want 200", response)
+	}
+	if resolved.Projection != tuttigenerated.MessageHydration {
+		t.Fatalf("response projection=%q, want messageHydration", resolved.Projection)
+	}
+	if resolved.LifecycleCapabilitiesProjected {
+		t.Fatal("message hydration capabilities unexpectedly resolved")
+	}
+	if received != agentservice.SessionDetailProjectionMessageHydration {
+		t.Fatalf("projection=%q, want messageHydration", received)
+	}
+}
+
+func TestGetWorkspaceAgentSessionRejectsUnknownProjection(t *testing.T) {
+	projection := tuttigenerated.WorkspaceAgentSessionDetailProjection("unknown")
+
+	response, err := (DaemonAPI{}).
+		GetWorkspaceAgentSession(t.Context(), tuttigenerated.GetWorkspaceAgentSessionRequestObject{
+			WorkspaceID:    "workspace-1",
+			AgentSessionID: "session-1",
+			Params: tuttigenerated.GetWorkspaceAgentSessionParams{
+				Projection: &projection,
+			},
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := response.(tuttigenerated.GetWorkspaceAgentSession400JSONResponse); !ok {
+		t.Fatalf("response=%T, want 400", response)
+	}
+}

--- a/services/tuttid/api/daemon_test.go
+++ b/services/tuttid/api/daemon_test.go
@@ -99,6 +99,7 @@ type stubAgentSessionService struct {
 	getSessionForkOperationFn         func(context.Context, string, string) (agentservice.SessionForkOperation, error)
 	acknowledgeSessionForkOperationFn func(context.Context, string, string) (agentservice.SessionForkOperation, error)
 	getDetailFn                       func(context.Context, string, string) (agentservice.SessionDetail, error)
+	getDetailWithProjectionFn         func(context.Context, string, string, agentservice.SessionDetailProjection) (agentservice.SessionDetail, error)
 	getFn                             func(context.Context, string, string) (agentservice.Session, error)
 	deleteFn                          func(context.Context, string, string) (agentservice.DeleteSessionResult, error)
 	listSectionDeletionCandidatesFn   func(context.Context, string, agentservice.ListSessionSectionDeletionCandidatesInput) (agentservice.SessionSectionDeletionCandidates, error)
@@ -391,6 +392,22 @@ func (s stubAgentSessionService) GetDetail(ctx context.Context, workspaceID, age
 		return s.getDetailFn(ctx, workspaceID, agentSessionID)
 	}
 	return agentservice.SessionDetail{ChildSessions: []agentservice.Session{}}, nil
+}
+
+func (s stubAgentSessionService) GetDetailWithProjection(
+	ctx context.Context,
+	workspaceID, agentSessionID string,
+	projection agentservice.SessionDetailProjection,
+) (agentservice.SessionDetail, error) {
+	if s.getDetailWithProjectionFn != nil {
+		return s.getDetailWithProjectionFn(
+			ctx,
+			workspaceID,
+			agentSessionID,
+			projection,
+		)
+	}
+	return s.GetDetail(ctx, workspaceID, agentSessionID)
 }
 
 func (s stubAgentSessionService) ReadAttachment(ctx context.Context, workspaceID string, agentSessionID string, attachmentID string) (agentservice.PromptAttachment, error) {

--- a/services/tuttid/api/generated/server.gen.go
+++ b/services/tuttid/api/generated/server.gen.go
@@ -253,7 +253,7 @@ type ServerInterface interface {
 	DeleteWorkspaceAgentSession(w http.ResponseWriter, r *http.Request, workspaceID WorkspaceID, agentSessionID AgentSessionID)
 	// Get one workspace agent session
 	// (GET /v1/workspaces/{workspaceID}/agent-sessions/{agentSessionID})
-	GetWorkspaceAgentSession(w http.ResponseWriter, r *http.Request, workspaceID WorkspaceID, agentSessionID AgentSessionID)
+	GetWorkspaceAgentSession(w http.ResponseWriter, r *http.Request, workspaceID WorkspaceID, agentSessionID AgentSessionID, params GetWorkspaceAgentSessionParams)
 	// Get the session acceptance ladder state
 	// (GET /v1/workspaces/{workspaceID}/agent-sessions/{agentSessionID}/acceptance)
 	GetAgentSessionAcceptance(w http.ResponseWriter, r *http.Request, workspaceID WorkspaceID, agentSessionID AgentSessionID)
@@ -3429,8 +3429,24 @@ func (siw *ServerInterfaceWrapper) GetWorkspaceAgentSession(w http.ResponseWrite
 
 	r = r.WithContext(ctx)
 
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetWorkspaceAgentSessionParams
+
+	// ------------- Optional query parameter "projection" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "projection", r.URL.Query(), &params.Projection, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "projection"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "projection", Err: err})
+		}
+		return
+	}
+
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetWorkspaceAgentSession(w, r, workspaceID, agentSessionID)
+		siw.Handler.GetWorkspaceAgentSession(w, r, workspaceID, agentSessionID, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -17426,6 +17442,7 @@ func (response DeleteWorkspaceAgentSession503JSONResponse) VisitDeleteWorkspaceA
 type GetWorkspaceAgentSessionRequestObject struct {
 	WorkspaceID    WorkspaceID    `json:"workspaceID"`
 	AgentSessionID AgentSessionID `json:"agentSessionID"`
+	Params         GetWorkspaceAgentSessionParams
 }
 
 type GetWorkspaceAgentSessionResponseObject interface {
@@ -38750,11 +38767,12 @@ func (sh *strictHandler) DeleteWorkspaceAgentSession(w http.ResponseWriter, r *h
 }
 
 // GetWorkspaceAgentSession operation middleware
-func (sh *strictHandler) GetWorkspaceAgentSession(w http.ResponseWriter, r *http.Request, workspaceID WorkspaceID, agentSessionID AgentSessionID) {
+func (sh *strictHandler) GetWorkspaceAgentSession(w http.ResponseWriter, r *http.Request, workspaceID WorkspaceID, agentSessionID AgentSessionID, params GetWorkspaceAgentSessionParams) {
 	var request GetWorkspaceAgentSessionRequestObject
 
 	request.WorkspaceID = workspaceID
 	request.AgentSessionID = agentSessionID
+	request.Params = params
 
 	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
 		return sh.ssi.GetWorkspaceAgentSession(ctx, request.(GetWorkspaceAgentSessionRequestObject))

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -2518,6 +2518,24 @@ func (e WorkspaceAgentSessionAttachmentResponseMimeType) Valid() bool {
 	}
 }
 
+// Defines values for WorkspaceAgentSessionDetailProjection.
+const (
+	Full             WorkspaceAgentSessionDetailProjection = "full"
+	MessageHydration WorkspaceAgentSessionDetailProjection = "messageHydration"
+)
+
+// Valid indicates whether the value is a known member of the WorkspaceAgentSessionDetailProjection enum.
+func (e WorkspaceAgentSessionDetailProjection) Valid() bool {
+	switch e {
+	case Full:
+		return true
+	case MessageHydration:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for WorkspaceAgentSessionForkOperationStatus.
 const (
 	WorkspaceAgentSessionForkOperationStatusAccepted  WorkspaceAgentSessionForkOperationStatus = "accepted"
@@ -6962,11 +6980,20 @@ type WorkspaceAgentSessionAttachmentResponse struct {
 // WorkspaceAgentSessionAttachmentResponseMimeType defines model for WorkspaceAgentSessionAttachmentResponse.MimeType.
 type WorkspaceAgentSessionAttachmentResponseMimeType string
 
+// WorkspaceAgentSessionDetailProjection Projection applied to a Session detail response. messageHydration preserves hierarchy and message cursors but leaves provider-backed lifecycle capabilities unresolved.
+type WorkspaceAgentSessionDetailProjection string
+
 // WorkspaceAgentSessionDetailResponse defines model for WorkspaceAgentSessionDetailResponse.
 type WorkspaceAgentSessionDetailResponse struct {
 	// ChildSessions Flat collection of every nested child session below session. Clients reconstruct the tree from the immutable parent fields.
 	ChildSessions []WorkspaceAgentSession `json:"childSessions"`
-	Session       WorkspaceAgentSession   `json:"session"`
+
+	// LifecycleCapabilitiesProjected Whether provider-backed lifecycle capability projection ran for session and childSessions. A full projection reports true even when a provider probe fails closed, because false then means the action is unavailable for this response. When false, projection was intentionally skipped and capability values must not be applied as authoritative.
+	LifecycleCapabilitiesProjected bool `json:"lifecycleCapabilitiesProjected"`
+
+	// Projection Projection applied to a Session detail response. messageHydration preserves hierarchy and message cursors but leaves provider-backed lifecycle capabilities unresolved.
+	Projection WorkspaceAgentSessionDetailProjection `json:"projection"`
+	Session    WorkspaceAgentSession                 `json:"session"`
 
 	// Turns Ordered durable turns owned by session. This detail-only collection is the canonical source for turn-scoped history such as file changes; clients must not reconstruct it from provider tool payloads.
 	Turns []WorkspaceAgentTurn `json:"turns"`
@@ -8195,6 +8222,12 @@ type ListWorkspaceAgentSessionsParams struct {
 	SearchQuery *string `form:"searchQuery,omitempty" json:"searchQuery,omitempty"`
 	Cursor      *string `form:"cursor,omitempty" json:"cursor,omitempty"`
 	Limit       *int    `form:"limit,omitempty" json:"limit,omitempty"`
+}
+
+// GetWorkspaceAgentSessionParams defines parameters for GetWorkspaceAgentSession.
+type GetWorkspaceAgentSessionParams struct {
+	// Projection Selects the detail projection. messageHydration preserves the session hierarchy and message cursors used by reconciliation discovery without resolving provider-backed lifecycle capabilities.
+	Projection *WorkspaceAgentSessionDetailProjection `form:"projection,omitempty" json:"projection,omitempty"`
 }
 
 // ListWorkspaceAgentSessionMessagesParams defines parameters for ListWorkspaceAgentSessionMessages.

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -4141,6 +4141,14 @@ paths:
       tags:
         - agent-session
       summary: Get one workspace agent session
+      parameters:
+        - name: projection
+          in: query
+          required: false
+          description: Selects the detail projection. messageHydration preserves the session hierarchy and message cursors used by reconciliation discovery without resolving provider-backed lifecycle capabilities.
+          schema:
+            $ref: "#/components/schemas/WorkspaceAgentSessionDetailProjection"
+            default: full
       responses:
         "200":
           description: Workspace agent session
@@ -11548,6 +11556,15 @@ components:
       description: >-
         Per-session durable message change cursor. The upper bound preserves
         exact integer representation in JavaScript clients.
+    WorkspaceAgentSessionDetailProjection:
+      type: string
+      enum:
+        - full
+        - messageHydration
+      description: >-
+        Projection applied to a Session detail response. messageHydration
+        preserves hierarchy and message cursors but leaves provider-backed
+        lifecycle capabilities unresolved.
     WorkspaceAgentSessionLifecycleCapabilities:
       type: object
       additionalProperties: false
@@ -11934,7 +11951,20 @@ components:
         - session
         - childSessions
         - turns
+        - projection
+        - lifecycleCapabilitiesProjected
       properties:
+        projection:
+          $ref: "#/components/schemas/WorkspaceAgentSessionDetailProjection"
+        lifecycleCapabilitiesProjected:
+          type: boolean
+          description: >-
+            Whether provider-backed lifecycle capability projection ran for
+            session and childSessions. A full projection reports true even
+            when a provider probe fails closed, because false then means the
+            action is unavailable for this response. When false, projection
+            was intentionally skipped and capability values must not be
+            applied as authoritative.
         session:
           $ref: "#/components/schemas/WorkspaceAgentSession"
         childSessions:

--- a/services/tuttid/service/agent/host_conformance_test.go
+++ b/services/tuttid/service/agent/host_conformance_test.go
@@ -742,7 +742,7 @@ func (d *legacyHostConformanceDriver) GetSession(ctx context.Context, ref agenth
 		if err != nil {
 			return hostconformance.SessionObservation{}, err
 		}
-		session, err := d.service.projectHostSessionResult(ctx, result.Canonical, result.Session, result.Live, false)
+		session, err := d.service.projectHostSessionResult(ctx, result.Canonical, result.Session, result.Live, false, true)
 		return legacyHostSessionObservationWithLive(session, result.Live), err
 	}
 	session, err := d.service.Get(ctx, ref.WorkspaceID, ref.AgentSessionID)
@@ -774,7 +774,7 @@ func (d *legacyHostConformanceDriver) UpdateSettings(ctx context.Context, input 
 		if err != nil {
 			return hostconformance.SessionObservation{}, err
 		}
-		session, err := d.service.projectHostSessionResult(ctx, result.Canonical, result.Session, result.Live, false)
+		session, err := d.service.projectHostSessionResult(ctx, result.Canonical, result.Session, result.Live, false, true)
 		return legacyHostSessionObservationWithLive(session, result.Live), err
 	}
 	session, err := d.service.UpdateSettings(ctx, input.WorkspaceID, input.AgentSessionID, input.Settings)
@@ -788,7 +788,7 @@ func (d *legacyHostConformanceDriver) UpdatePin(ctx context.Context, input agent
 		if err != nil {
 			return hostconformance.SessionObservation{}, err
 		}
-		session, err := d.service.projectHostSessionResult(ctx, result.Canonical, result.Session, result.Live, false)
+		session, err := d.service.projectHostSessionResult(ctx, result.Canonical, result.Session, result.Live, false, true)
 		return legacyHostSessionObservationWithLive(session, result.Live), err
 	}
 	session, err := d.service.UpdatePin(ctx, input.WorkspaceID, input.AgentSessionID, input.Pinned)

--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -577,8 +577,30 @@ func (s *Service) Get(ctx context.Context, workspaceID string, agentSessionID st
 	return s.get(ctx, workspaceID, agentSessionID, true)
 }
 
+type SessionDetailProjection string
+
+const (
+	SessionDetailProjectionFull             SessionDetailProjection = "full"
+	SessionDetailProjectionMessageHydration SessionDetailProjection = "messageHydration"
+)
+
 func (s *Service) GetDetail(ctx context.Context, workspaceID string, agentSessionID string) (SessionDetail, error) {
-	session, err := s.Get(ctx, workspaceID, agentSessionID)
+	return s.GetDetailWithProjection(
+		ctx,
+		workspaceID,
+		agentSessionID,
+		SessionDetailProjectionFull,
+	)
+}
+
+func (s *Service) GetDetailWithProjection(
+	ctx context.Context,
+	workspaceID string,
+	agentSessionID string,
+	projection SessionDetailProjection,
+) (SessionDetail, error) {
+	resolveProviderCapabilities := projection != SessionDetailProjectionMessageHydration
+	session, err := s.get(ctx, workspaceID, agentSessionID, resolveProviderCapabilities)
 	if err != nil {
 		return SessionDetail{}, err
 	}
@@ -646,7 +668,7 @@ func (s *Service) LocalAttachmentPath(ctx context.Context, workspaceID string, a
 	return store.LocalPath(workspaceID, agentSessionID, attachmentID, mimeType)
 }
 
-func (s *Service) get(ctx context.Context, workspaceID string, agentSessionID string, _ bool) (Session, error) {
+func (s *Service) get(ctx context.Context, workspaceID string, agentSessionID string, resolveProviderCapabilities bool) (Session, error) {
 	result, err := s.ApplicationHost().GetSession(ctx, agenthost.SessionRef{
 		WorkspaceID: workspaceID, AgentSessionID: agentSessionID,
 	})
@@ -660,7 +682,14 @@ func (s *Service) get(ctx context.Context, workspaceID string, agentSessionID st
 		}
 		return Session{}, ErrSessionNotFound
 	}
-	return s.projectHostSessionResult(ctx, result.Canonical, result.Session, result.Live, true)
+	return s.projectHostSessionResult(
+		ctx,
+		result.Canonical,
+		result.Session,
+		result.Live,
+		true,
+		resolveProviderCapabilities,
+	)
 }
 
 func (s *Service) UpdatePin(ctx context.Context, workspaceID string, agentSessionID string, pinned bool) (Session, error) {
@@ -672,7 +701,7 @@ func (s *Service) UpdatePin(ctx context.Context, workspaceID string, agentSessio
 	if err != nil {
 		return Session{}, err
 	}
-	return s.projectHostSessionResult(ctx, result.Canonical, result.Session, result.Live, false)
+	return s.projectHostSessionResult(ctx, result.Canonical, result.Session, result.Live, false, true)
 }
 
 func (s *Service) cleanupRuntime(ctx context.Context, workspaceID string, agentSessionID string) error {

--- a/services/tuttid/service/agent/service_session.go
+++ b/services/tuttid/service/agent/service_session.go
@@ -288,6 +288,7 @@ func (s *Service) projectHostSessionResult(
 	runtime ProviderRuntimeSession,
 	live bool,
 	requireRailSection bool,
+	resolveProviderCapabilities bool,
 ) (Session, error) {
 	persisted := persistedSessionFromHost(canonical)
 	if requireRailSection && s.SessionReader != nil {
@@ -305,7 +306,12 @@ func (s *Service) projectHostSessionResult(
 	} else {
 		result = sessionFromPersisted(persisted, s.persistedSessionCanResume(ctx, persisted))
 	}
-	return s.withProtocolV2TurnState(ctx, canonical.WorkspaceID, result)
+	return s.withProtocolV2TurnStateProjectionOptions(
+		ctx,
+		canonical.WorkspaceID,
+		result,
+		resolveProviderCapabilities,
+	)
 }
 
 func persistedSessionIsNewerThanRuntime(persisted PersistedSession, session ProviderRuntimeSession) bool {

--- a/services/tuttid/service/agent/service_session_fork.go
+++ b/services/tuttid/service/agent/service_session_fork.go
@@ -180,6 +180,7 @@ func (s *Service) projectSessionForkOperation(
 			ProviderRuntimeSession{},
 			false,
 			true,
+			true,
 		)
 		if err != nil {
 			return SessionForkOperation{}, err

--- a/services/tuttid/service/agent/service_session_fork_test.go
+++ b/services/tuttid/service/agent/service_session_fork_test.go
@@ -176,6 +176,44 @@ func TestProtocolV2BatchProjectionDoesNotProbeSessionForkCapabilities(t *testing
 	}
 }
 
+func TestMessageHydrationProjectionDoesNotProbeSessionForkCapabilities(t *testing.T) {
+	store := &sessionForkListProjectionStore{}
+	runtime := &sessionForkCapabilityRuntime{}
+	service := &Service{}
+	service.SetApplicationHost(agenthost.New(agenthost.Config{
+		SessionForks: store, SessionForkRuntime: runtime,
+	}))
+
+	projected, err := service.withProtocolV2TurnStateProjectionOptions(
+		t.Context(),
+		"workspace-1",
+		Session{
+			ID: "source-1", Kind: agentactivitybiz.SessionKindRoot,
+		},
+		false,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.calls != 0 || store.sourceReads != 0 {
+		t.Fatalf(
+			"message hydration projection probed fork capability: runtime=%d sourceReads=%d",
+			runtime.calls,
+			store.sourceReads,
+		)
+	}
+	if projected.LifecycleCapabilities.Fork ||
+		projected.LifecycleCapabilities.ForkThroughTurn {
+		t.Fatalf(
+			"message hydration lifecycle capabilities=%#v, want fail-closed projection",
+			projected.LifecycleCapabilities,
+		)
+	}
+	if store.lineageReads != 1 {
+		t.Fatalf("lineage reads=%d, want one canonical read", store.lineageReads)
+	}
+}
+
 func TestSessionForkContextPolicyRejectsWorktreeIsolation(t *testing.T) {
 	policy := serviceHostSessionForkContextPolicy{}
 	_, err := policy.PrepareSessionForkTargetContext(t.Context(), storesqlite.Session{

--- a/services/tuttid/service/agent/service_settings.go
+++ b/services/tuttid/service/agent/service_settings.go
@@ -156,5 +156,12 @@ func (s *Service) UpdateSettings(ctx context.Context, workspaceID string, agentS
 	if err != nil {
 		return Session{}, err
 	}
-	return s.projectHostSessionResult(ctx, result.Canonical, result.Session, result.Live, result.Live)
+	return s.projectHostSessionResult(
+		ctx,
+		result.Canonical,
+		result.Session,
+		result.Live,
+		result.Live,
+		true,
+	)
 }

--- a/services/tuttid/service/agent/service_turns.go
+++ b/services/tuttid/service/agent/service_turns.go
@@ -221,8 +221,24 @@ func (s *Service) projectSessionsForResponse(ctx context.Context, workspaceID st
 // projection; it is never persisted on the session row. The Tutti-owned,
 // session-associated TuttiModeActivation read projection is attached last.
 func (s *Service) withProtocolV2TurnState(ctx context.Context, workspaceID string, session Session) (Session, error) {
+	return s.withProtocolV2TurnStateProjectionOptions(
+		ctx,
+		workspaceID,
+		session,
+		true,
+	)
+}
+
+func (s *Service) withProtocolV2TurnStateProjectionOptions(
+	ctx context.Context,
+	workspaceID string,
+	session Session,
+	resolveProviderCapabilities bool,
+) (Session, error) {
 	if s == nil || s.TurnStore == nil {
-		session = s.withSessionForkCapabilities(ctx, workspaceID, session)
+		if resolveProviderCapabilities {
+			session = s.withSessionForkCapabilities(ctx, workspaceID, session)
+		}
 		var err error
 		session, err = s.withSessionForkLineage(ctx, workspaceID, session)
 		if err != nil {
@@ -246,7 +262,9 @@ func (s *Service) withProtocolV2TurnState(ctx context.Context, workspaceID strin
 	if err != nil {
 		return Session{}, err
 	}
-	session = s.withSessionForkCapabilities(ctx, workspaceID, session)
+	if resolveProviderCapabilities {
+		session = s.withSessionForkCapabilities(ctx, workspaceID, session)
+	}
 	session, err = s.withSessionForkLineage(ctx, workspaceID, session)
 	if err != nil {
 		return Session{}, err


### PR DESCRIPTION
## Summary

- make automatic AgentGUI session selection hydration idempotent instead of replaying it as a forced refresh
- distinguish message-hydration discovery reads from authoritative session-detail reads in the shared activity-core reconcile seam
- map the shared projection purpose consistently in Desktop and Mobile
- add a typed tuttid session-detail projection contract (`messageHydration` / `full`) and preserve projection authority metadata through the client and adapter
- skip provider-backed lifecycle capability probing during message hydration while retaining the final authoritative race-closing read
- document the ownership, data flow, and recurring debugging symptoms

## Root cause

Restoring the selected conversation was treated as `force: true`, so it queued a second complete reconcile while the first reconcile was still running. In addition, both detail reads used the full projection, so the discovery read performed an expensive provider capability probe even though it only needed session hierarchy and message cursor information.

## Impact

Opening or restoring a conversation now performs one hydration reconcile. Historical messages remain independently paged, and provider-backed lifecycle capabilities are resolved only by the authoritative detail read. Explicit refresh remains available as a separate forced intent.

This PR keeps the existing detail endpoint compatible by adding a projection parameter. A future change can move provider-backed session capabilities to a dedicated endpoint/controller; this PR does not add caching, TTL, or request suppression as a workaround.

## Validation

- `pnpm check:changed` — passed 28 lanes during implementation
- pre-push `pnpm check:changed -- --push-ready` — passed 30 lanes
- `pnpm generate:api --check`
- Desktop tests — 1645 passed, 0 failed, 2 skipped
- Mobile workspace activity tests — 22 passed
- `make dev-gui` cold-start and interaction verification:
  - long session loaded one 100-message page (`131–296`, `has_more=true`)
  - upward pagination loaded the remaining 78 messages (`1–128`, `has_more=false`)
  - switching to the short historical session produced one message read and one `initialize → thread/read` sequence, with no second reconcile after waiting
- final architecture review: no findings across tuttid layering/contracts, package boundaries/cross-cutting architecture, and desktop/repository structure

## Documentation

Updated:

- `docs/architecture/agent-activity-packages.md`
- `docs/architecture/agent-gui-node.md`
- `docs/conventions/troubleshooting/agent-session-lifecycle.md`