### PR TITLE
fix(agent): preserve open provider runtime snapshots

### DIFF
--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -23,7 +23,9 @@ Use the focused runtime index or open one area directly:
   Includes shared-device recovery that looks terminal while the host is still retrying.
   Also covers new-conversation requests that silently fail after a Chats
   Session working directory is mistaken for a selected project, and one hung
-  provider startup blocking unrelated Agent sessions. Includes cassette replay
+  provider startup blocking unrelated Agent sessions. Extension snapshot
+  failures that erase the Agent's Tutti CLI command catalog or block restart
+  resume are covered here as well. Includes cassette replay
   startup that fails when concurrent provider input and output are treated as a
   strict scheduling order, false final-state mismatches caused by replay-generated
   child identities, and canonical completion delayed behind a streaming activity-report

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -1759,13 +1759,26 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
 - Symptom:
   An Agent Extension conversation works until `tuttid` restarts. Its history
   remains visible, but AgentGUI says it cannot resume on this device and only
-  offers continuing through an `@` mention.
+  offers continuing through an `@` mention. In an affected live extension
+  session, the `tutti` shim can be present on `PATH` while many public commands,
+  including `tutti agent list`, return `command_not_found`. After restart,
+  sending to the same session can fail with
+  `session runtime snapshot is unavailable: launch identity is incomplete`.
 - Quick checks:
   Confirm the persisted session still has `provider_session_id` and
   `agent_target_id`. If the Target remains enabled and names a fixed extension
   installation, compare list-time `resumable` calculation with the actual
   Resume path. An empty process-local adapter registry after restart is not
   evidence that the session cannot be restored.
+  For the CLI variant, first distinguish discovery from routing: look for
+  `tutti cli shim ready` in Desktop logs and `path_contains_tutti_bin=true` in
+  the provider process diagnostics. If both are present but the provider tool
+  reports `unknown command`, compare
+  `workspace_agent_sessions.provider` with
+  `internal_runtime_context_json.$.sessionRuntimeSnapshot.provider`. An
+  extension provider such as `acp:<name>` beside an empty snapshot provider,
+  followed by `launch identity is incomplete`, identifies the durable snapshot
+  path rather than a PATH or listener failure.
 - Root cause:
   Dynamic Agent Extension adapters are created on demand and cached only for
   the daemon lifetime. Computing `resumable` from that cache maps restart state
@@ -1773,7 +1786,14 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   The same false result occurs when an adapter rebuilds the runtime resume input
   but drops `agentTargetId`: the fixed Target ref then fails the controller's
   complete binding check even though persistence and Target resolution are
-  correct.
+  correct. A separate snapshot variant occurs when provider-neutral metadata
+  uses the closed built-in-provider normalizer for an open extension identity.
+  The writer then persists an empty provider and fingerprints the
+  provider-native configuration with that empty value. Session-scoped CLI
+  capability projection validates the snapshot before returning the command
+  catalog; validation failure collapses discovery to an empty catalog, so
+  otherwise valid commands appear unknown. Runtime resume rejects the same
+  incomplete identity after daemon restart.
 - Fix:
   At the service boundary, re-derive `ProviderTargetRef` from the persisted
   session's enabled `agentTargetId`. At the runtime boundary, validate the
@@ -1786,15 +1806,27 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   preserve `agentTargetId` and `ProviderTargetRef` together. Cover the complete
   service-to-adapter-to-controller path instead of testing each endpoint with
   independently constructed valid inputs.
+  Persist and compare snapshot provider metadata with the open provider
+  normalizer; launch authority still comes exclusively from the exact enabled
+  Agent Target. For already-written empty-provider extension snapshots, recover
+  only when the canonical session provider is a valid unregistered open
+  identity, the snapshot declares provider-native configuration, and its
+  fingerprint exactly matches the historical empty-provider payload. Keep
+  every other malformed or mismatched snapshot fail-closed, and do not rewrite
+  the database merely to make discovery succeed.
 - Validation:
   Start from a controller with no cached extension adapter. Assert a persisted
   Target-bound session is resumable, malformed or mismatched bindings fail
   closed, and the eligibility check does not launch the provider. Then run
   `go test ./packages/agent/daemon/runtime ./services/tuttid/service/agent`.
+  Also cover new extension snapshots preserving `acp:*`, verified legacy
+  empty-provider recovery, registered-provider fallback rejection, CLI command
+  projection for the recovered session, and runtime preparation after restart.
 - References:
   [controller_session_registry.go](../../../packages/agent/daemon/runtime/controller_session_registry.go)
   [agent_runtime_adapter.go](../../../services/tuttid/agent_runtime_adapter.go)
   [service_session.go](../../../services/tuttid/service/agent/service_session.go)
+  [session_runtime_snapshot.go](../../../services/tuttid/service/agent/session_runtime_snapshot.go)
   [agent-extensions.md](../../architecture/agent-extensions.md)
 
 ### An authorized observer loops unavailable while a session is resuming

--- a/services/tuttid/service/agent/model_plan_binding.go
+++ b/services/tuttid/service/agent/model_plan_binding.go
@@ -126,7 +126,7 @@ type modelConfigurationFingerprintPayload struct {
 
 func newProviderNativeModelConfiguration(provider string, agentTargetID string) modelConfigurationRuntimeContext {
 	payload := modelConfigurationFingerprintPayload{
-		Provider:      agentprovider.Normalize(provider),
+		Provider:      agentprovider.NormalizeOpen(provider),
 		AgentTargetID: strings.TrimSpace(agentTargetID),
 		Source:        modelConfigurationSourceProviderNative,
 	}
@@ -245,7 +245,7 @@ func (s *Service) resolveModelPlanEndpoint(ctx context.Context, workspaceID stri
 // for composer reconciliation. Unsupported, missing, disabled, and
 // protocol-mismatched bindings all resolve to provider-native configuration.
 func (s *Service) resolveModelPlan(ctx context.Context, workspaceID string, agentTargetID string, provider string, requestedModel string) modelPlanResolution {
-	provider = agentprovider.Normalize(provider)
+	provider = agentprovider.NormalizeOpen(provider)
 	agentTargetID = strings.TrimSpace(agentTargetID)
 	providerNative := modelPlanResolution{
 		ModelConfiguration: newProviderNativeModelConfiguration(provider, agentTargetID),

--- a/services/tuttid/service/agent/service_resume_helpers.go
+++ b/services/tuttid/service/agent/service_resume_helpers.go
@@ -44,7 +44,10 @@ func (s *Service) ensureRuntimeSessionResult(
 }
 
 func (s *Service) resolveProviderTargetRefForResume(ctx context.Context, persisted PersistedSession) (map[string]any, error) {
-	snapshot, exists, err := sessionRuntimeSnapshotFromContext(persisted.InternalRuntimeContext)
+	snapshot, exists, err := sessionRuntimeSnapshotFromContext(
+		persisted.InternalRuntimeContext,
+		persisted.Provider,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +80,10 @@ func (s *Service) resolveProviderTargetRefForResume(ctx context.Context, persist
 
 func (s *Service) prepareRuntimeForResume(ctx context.Context, session PersistedSession) (preparedRuntime, error) {
 	input := createSessionInputFromPersisted(session)
-	snapshot, exists, err := sessionRuntimeSnapshotFromContext(session.InternalRuntimeContext)
+	snapshot, exists, err := sessionRuntimeSnapshotFromContext(
+		session.InternalRuntimeContext,
+		session.Provider,
+	)
 	if err != nil {
 		return preparedRuntime{}, err
 	}

--- a/services/tuttid/service/agent/service_settings.go
+++ b/services/tuttid/service/agent/service_settings.go
@@ -117,6 +117,7 @@ func (s *Service) UpdateSettings(ctx context.Context, workspaceID string, agentS
 		if err := s.validateSessionModelAgainstRuntimeSnapshot(
 			ctx,
 			strings.TrimSpace(workspaceID),
+			provider,
 			runtimeContext,
 			strings.TrimSpace(*settings.Model),
 		); err != nil {

--- a/services/tuttid/service/agent/session_runtime_snapshot.go
+++ b/services/tuttid/service/agent/session_runtime_snapshot.go
@@ -31,6 +31,7 @@ type sessionRuntimeSnapshot struct {
 	WorkspaceAgentRevision      int64
 	HarnessAgentTargetID        string
 	Provider                    string
+	LegacyEmptyOpenProvider     bool
 	Model                       string
 	ModelConfigurationSource    string
 	ModelPlanID                 string
@@ -66,6 +67,7 @@ func (s *Service) AgentSessionCommandCapabilityProjection(
 	}
 	snapshot, exists, err := sessionRuntimeSnapshotFromContext(
 		result.Canonical.InternalRuntimeContext,
+		result.Canonical.Provider,
 	)
 	if err != nil {
 		return nil, err
@@ -97,7 +99,7 @@ func runtimeContextWithSessionRuntimeSnapshot(
 		"version":              sessionRuntimeSnapshotVersion,
 		"agentTargetId":        strings.TrimSpace(input.AgentTargetID),
 		"harnessAgentTargetId": harnessAgentTargetID,
-		"provider":             agentprovider.Normalize(provider),
+		"provider":             agentprovider.NormalizeOpen(provider),
 		"model":                strings.TrimSpace(value(input.Model)),
 		"modelConfiguration": map[string]any{
 			"source":       configuration.Source,
@@ -179,7 +181,10 @@ func sessionRuntimeEffectiveConfig(input CreateSessionInput) map[string]any {
 	return result
 }
 
-func sessionRuntimeSnapshotFromContext(runtimeContext map[string]any) (sessionRuntimeSnapshot, bool, error) {
+func sessionRuntimeSnapshotFromContext(
+	runtimeContext map[string]any,
+	fallbackProviders ...string,
+) (sessionRuntimeSnapshot, bool, error) {
 	raw, exists := runtimeContext[sessionRuntimeSnapshotContextKey]
 	if !exists {
 		return sessionRuntimeSnapshot{}, false, nil
@@ -196,11 +201,12 @@ func sessionRuntimeSnapshotFromContext(runtimeContext map[string]any) (sessionRu
 	if !ok {
 		return sessionRuntimeSnapshot{}, true, fmt.Errorf("%w: model configuration is missing", ErrSessionRuntimeSnapshotUnavailable)
 	}
+	rawProvider := snapshotString(payload["provider"])
 	snapshot := sessionRuntimeSnapshot{
 		Version:                     int(version),
 		AgentTargetID:               snapshotString(payload["agentTargetId"]),
 		HarnessAgentTargetID:        snapshotString(payload["harnessAgentTargetId"]),
-		Provider:                    agentprovider.Normalize(snapshotString(payload["provider"])),
+		Provider:                    agentprovider.NormalizeOpen(rawProvider),
 		Model:                       snapshotString(payload["model"]),
 		ModelConfigurationSource:    snapshotString(configuration["source"]),
 		ModelPlanID:                 snapshotString(configuration["modelPlanId"]),
@@ -221,6 +227,16 @@ func sessionRuntimeSnapshotFromContext(runtimeContext map[string]any) (sessionRu
 	}
 	if revision, ok := snapshotUint64(configuration["modelPlanRevision"]); ok {
 		snapshot.ModelPlanRevision = revision
+	}
+	if snapshot.Provider == "" && rawProvider == "" && len(fallbackProviders) > 0 {
+		fallbackProvider := agentprovider.NormalizeOpen(fallbackProviders[0])
+		if fallbackProvider != "" &&
+			agentprovider.Normalize(fallbackProvider) == "" &&
+			snapshot.ModelConfigurationSource == modelConfigurationSourceProviderNative &&
+			snapshot.ModelFingerprint == legacyEmptyProviderNativeModelFingerprint(snapshot.AgentTargetID) {
+			snapshot.Provider = fallbackProvider
+			snapshot.LegacyEmptyOpenProvider = true
+		}
 	}
 	if snapshot.AgentTargetID == "" || snapshot.HarnessAgentTargetID == "" || snapshot.Provider == "" || snapshot.ModelFingerprint == "" {
 		return sessionRuntimeSnapshot{}, true, fmt.Errorf("%w: launch identity is incomplete", ErrSessionRuntimeSnapshotUnavailable)
@@ -265,7 +281,10 @@ func (s *Service) modelEndpointFromSessionRuntimeSnapshot(
 ) (*runtimeprep.ModelEndpointConfig, error) {
 	if snapshot.ModelConfigurationSource == modelConfigurationSourceProviderNative {
 		expected := newProviderNativeModelConfiguration(snapshot.Provider, snapshot.AgentTargetID)
-		if expected.Fingerprint != snapshot.ModelFingerprint {
+		if expected.Fingerprint != snapshot.ModelFingerprint &&
+			(!snapshot.LegacyEmptyOpenProvider ||
+				legacyEmptyProviderNativeModelFingerprint(snapshot.AgentTargetID) !=
+					snapshot.ModelFingerprint) {
 			return nil, fmt.Errorf("%w: provider-native fingerprint does not match", ErrSessionRuntimeSnapshotUnavailable)
 		}
 		return nil, nil
@@ -352,10 +371,11 @@ func modelPlanFingerprintMatchesSnapshot(snapshot sessionRuntimeSnapshot, plan m
 func (s *Service) validateSessionModelAgainstRuntimeSnapshot(
 	ctx context.Context,
 	workspaceID string,
+	provider string,
 	runtimeContext map[string]any,
 	model string,
 ) error {
-	snapshot, exists, err := sessionRuntimeSnapshotFromContext(runtimeContext)
+	snapshot, exists, err := sessionRuntimeSnapshotFromContext(runtimeContext, provider)
 	if err != nil || !exists {
 		return err
 	}
@@ -387,12 +407,20 @@ func (s *Service) applyHarnessFromSessionRuntimeSnapshot(
 		return fmt.Errorf("%w: harness launch reference is invalid", ErrSessionRuntimeSnapshotUnavailable)
 	}
 	provider, _ := providerTargetRef["provider"].(string)
-	if agentprovider.Normalize(provider) != snapshot.Provider {
+	if agentprovider.NormalizeOpen(provider) != snapshot.Provider {
 		return fmt.Errorf("%w: harness provider does not match", ErrSessionRuntimeSnapshotUnavailable)
 	}
 	input.HarnessAgentTargetID = snapshot.HarnessAgentTargetID
 	input.ProviderTargetRef = providerTargetRef
 	return nil
+}
+
+func legacyEmptyProviderNativeModelFingerprint(agentTargetID string) string {
+	return fingerprintModelConfiguration(modelConfigurationFingerprintPayload{
+		Provider:      "",
+		AgentTargetID: strings.TrimSpace(agentTargetID),
+		Source:        modelConfigurationSourceProviderNative,
+	})
 }
 
 func normalizedSnapshotStrings(values []string) []string {

--- a/services/tuttid/service/agent/session_runtime_snapshot_test.go
+++ b/services/tuttid/service/agent/session_runtime_snapshot_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	runtimeprep "github.com/tutti-os/tutti/packages/agent/runtimeprep"
+	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 	modelbindingbiz "github.com/tutti-os/tutti/services/tuttid/biz/modelbinding"
 	modelplanbiz "github.com/tutti-os/tutti/services/tuttid/biz/modelplan"
 	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
@@ -27,6 +28,35 @@ func (catalog snapshotCommandCatalog) Capabilities(
 	runtimeprep.CommandContext,
 ) []runtimeprep.CommandCapability {
 	return append([]runtimeprep.CommandCapability(nil), catalog...)
+}
+
+func legacyEmptyOpenProviderRuntimeContext(
+	provider string,
+	agentTargetID string,
+	projection *runtimeprep.CommandCapabilityProjection,
+) map[string]any {
+	runtimeContext := runtimeContextWithSessionRuntimeSnapshot(
+		nil,
+		CreateSessionInput{
+			AgentTargetID:               agentTargetID,
+			HarnessAgentTargetID:        agentTargetID,
+			CommandCapabilityProjection: projection,
+		},
+		provider,
+		modelPlanResolution{
+			ModelConfiguration: newProviderNativeModelConfiguration(
+				provider,
+				agentTargetID,
+			),
+		},
+	)
+	snapshot := runtimeContext[sessionRuntimeSnapshotContextKey].(map[string]any)
+	snapshot["provider"] = ""
+	configuration := snapshot["modelConfiguration"].(map[string]any)
+	configuration["fingerprint"] = legacyEmptyProviderNativeModelFingerprint(
+		agentTargetID,
+	)
+	return runtimeContext
 }
 
 func (s revisionPlanSource) GetModelPlan(context.Context, string, string) (modelplanbiz.Plan, error) {
@@ -123,6 +153,98 @@ func TestSessionRuntimeSnapshotIsVersionedAndRedactionSafe(t *testing.T) {
 	}
 	if snapshot.Name != "Focused Writer" || snapshot.Description != "Make narrow repository changes." {
 		t.Fatalf("snapshot name/description = %q/%q", snapshot.Name, snapshot.Description)
+	}
+}
+
+func TestSessionRuntimeSnapshotPreservesOpenProviderIdentity(t *testing.T) {
+	t.Parallel()
+
+	const (
+		provider      = "acp:kimi-code"
+		agentTargetID = "extension:kimi-code"
+	)
+	runtimeContext := runtimeContextWithSessionRuntimeSnapshot(
+		nil,
+		CreateSessionInput{
+			AgentTargetID:        agentTargetID,
+			HarnessAgentTargetID: agentTargetID,
+		},
+		provider,
+		modelPlanResolution{
+			ModelConfiguration: newProviderNativeModelConfiguration(
+				provider,
+				agentTargetID,
+			),
+		},
+	)
+	raw := runtimeContext[sessionRuntimeSnapshotContextKey].(map[string]any)
+	if raw["provider"] != provider {
+		t.Fatalf("persisted provider = %#v, want %q", raw["provider"], provider)
+	}
+	snapshot, exists, err := sessionRuntimeSnapshotFromContext(runtimeContext)
+	if err != nil || !exists {
+		t.Fatalf(
+			"sessionRuntimeSnapshotFromContext() = %#v, exists=%v, error=%v",
+			snapshot,
+			exists,
+			err,
+		)
+	}
+	if snapshot.Provider != provider || snapshot.LegacyEmptyOpenProvider {
+		t.Fatalf("snapshot provider identity = %#v", snapshot)
+	}
+}
+
+func TestSessionRuntimeSnapshotRecoversVerifiedLegacyEmptyOpenProvider(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	const (
+		provider      = "acp:kimi-code"
+		agentTargetID = "extension:kimi-code"
+	)
+	runtimeContext := legacyEmptyOpenProviderRuntimeContext(
+		provider,
+		agentTargetID,
+		nil,
+	)
+	if _, _, err := sessionRuntimeSnapshotFromContext(runtimeContext); !errors.Is(
+		err,
+		ErrSessionRuntimeSnapshotUnavailable,
+	) {
+		t.Fatalf("snapshot without canonical fallback error = %v", err)
+	}
+	if _, _, err := sessionRuntimeSnapshotFromContext(
+		runtimeContext,
+		"codex",
+	); !errors.Is(err, ErrSessionRuntimeSnapshotUnavailable) {
+		t.Fatalf("snapshot with registered fallback error = %v", err)
+	}
+
+	snapshot, exists, err := sessionRuntimeSnapshotFromContext(
+		runtimeContext,
+		provider,
+	)
+	if err != nil || !exists {
+		t.Fatalf(
+			"legacy sessionRuntimeSnapshotFromContext() = %#v, exists=%v, error=%v",
+			snapshot,
+			exists,
+			err,
+		)
+	}
+	if snapshot.Provider != provider || !snapshot.LegacyEmptyOpenProvider {
+		t.Fatalf("recovered legacy snapshot = %#v", snapshot)
+	}
+	service := &Service{}
+	if _, err := service.modelEndpointFromSessionRuntimeSnapshot(
+		context.Background(),
+		"workspace-1",
+		snapshot,
+		"",
+	); err != nil {
+		t.Fatalf("legacy provider-native fingerprint recovery error = %v", err)
 	}
 }
 
@@ -340,6 +462,48 @@ func TestAgentSessionCommandCapabilityProjectionReadsCanonicalSnapshot(t *testin
 	}
 }
 
+func TestAgentSessionCommandCapabilityProjectionRecoversLegacyOpenProvider(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	const (
+		provider      = "acp:hermes"
+		agentTargetID = "extension:hermes"
+	)
+	runtimeContext := legacyEmptyOpenProviderRuntimeContext(
+		provider,
+		agentTargetID,
+		&runtimeprep.CommandCapabilityProjection{
+			AllowedIDs: []string{"issue-manager.issue.get"},
+		},
+	)
+	service := NewService(newFakeRuntime())
+	service.SessionReader = fakeSessionReader{sessions: map[string]PersistedSession{
+		"workspace-1:session-1": {
+			ID: "session-1", WorkspaceID: "workspace-1",
+			AgentTargetID: agentTargetID, Provider: provider,
+			InternalRuntimeContext: runtimeContext,
+		},
+	}}
+	configureTestApplicationHost(service)
+
+	projection, err := service.AgentSessionCommandCapabilityProjection(
+		context.Background(),
+		"workspace-1",
+		"session-1",
+	)
+	if err != nil {
+		t.Fatalf("AgentSessionCommandCapabilityProjection() error = %v", err)
+	}
+	if projection == nil || !reflect.DeepEqual(
+		projection.AllowedIDs,
+		[]string{"issue-manager.issue.get"},
+	) {
+		t.Fatalf("legacy extension projection = %#v", projection)
+	}
+}
+
 // Sessions created before the Wave 4-2 contract cleanup persisted the Agent
 // description under the retired purpose key. Their durable snapshots must
 // keep resuming without a rewrite.
@@ -532,6 +696,56 @@ func TestPrepareRuntimeForResumeProviderNativeSnapshotIgnoresNewBinding(t *testi
 	}
 	if preparedInput.ModelEndpoint != nil {
 		t.Fatalf("provider-native resume used new binding endpoint %#v", preparedInput.ModelEndpoint)
+	}
+}
+
+func TestPrepareRuntimeForResumeRecoversLegacyEmptyOpenProvider(t *testing.T) {
+	t.Parallel()
+
+	const (
+		provider      = "acp:kimi-code"
+		agentTargetID = "extension:kimi-code"
+	)
+	targets := defaultTestAgentTargets()
+	targets[agentTargetID] = agenttargetbiz.Target{
+		ID:            agentTargetID,
+		Provider:      provider,
+		LaunchRefJSON: `{"type":"agent_extension","extensionInstallationId":"installation-1"}`,
+		Name:          "Kimi Code",
+		Enabled:       true,
+		Source:        agenttargetbiz.SourceUser,
+	}
+	service := &Service{}
+	service.AgentTargetStore = fakeAgentTargetStore{targets: targets}
+	var preparedInput runtimeprep.PrepareInput
+	service.RuntimePreparer = fakeRuntimePreparer{input: &preparedInput}
+
+	_, err := service.prepareRuntimeForResume(
+		context.Background(),
+		PersistedSession{
+			ID:            "session-1",
+			WorkspaceID:   "workspace-1",
+			AgentTargetID: agentTargetID,
+			Provider:      provider,
+			InternalRuntimeContext: legacyEmptyOpenProviderRuntimeContext(
+				provider,
+				agentTargetID,
+				nil,
+			),
+		},
+	)
+	if err != nil {
+		t.Fatalf("prepareRuntimeForResume() error = %v", err)
+	}
+	if preparedInput.Provider != provider {
+		t.Fatalf("prepared provider = %q, want %q", preparedInput.Provider, provider)
+	}
+	if preparedInput.ProviderTargetRef["kind"] !=
+		agenttargetbiz.LaunchRefTypeAgentExtension {
+		t.Fatalf(
+			"prepared provider target ref = %#v",
+			preparedInput.ProviderTargetRef,
+		)
 	}
 }
 


### PR DESCRIPTION
## Summary

- preserve extension-owned open provider IDs in session runtime snapshots and provider-native model fingerprints
- recover legacy empty-provider extension snapshots only when canonical provider, provider-native source, Agent Target, and the historical fingerprint agree
- cover session-scoped Tutti CLI capability discovery and daemon-restart resume with regression tests
- document the recurring diagnosis and recovery path

## Root cause

Agent Extension support already provided `agentprovider.NormalizeOpen` for identities such as `acp:hermes` and `acp:kimi-code`. The later runtime-snapshot and provider-native fingerprint path used the closed built-in-provider `Normalize` helper instead. That helper intentionally returns an empty string for extension-owned IDs, so new extension sessions persisted an incomplete launch identity and an empty-provider fingerprint.

Session-scoped CLI capability projection added in #1759 validates that durable snapshot before returning the command catalog. The malformed snapshot therefore made discovery fail closed to an empty catalog, causing valid commands such as `tutti agent list` to appear unknown. The same snapshot blocked runtime preparation after a daemon restart with `launch identity is incomplete`.

## Fix

New snapshots now use the existing open-provider normalization seam for write, read, comparison, and provider-native fingerprinting. Existing affected sessions use a strict upgrade read path: recovery is allowed only for an unregistered canonical open provider, a provider-native snapshot, and an exact match with the historical empty-provider fingerprint for the same Agent Target. Other malformed or mismatched snapshots still fail closed, and no database rewrite is performed.

This remains daemon adapter work: Agent Target resolution is still the launch authority, while `packages/agent/host` continues to own session lifecycle and recovery policy.

## Validation

- `go test ./service/agent -run 'Test(SessionRuntimeSnapshot|AgentSessionCommandCapabilityProjection|PrepareRuntimeForResume)' -count=1`
- `pnpm check:changed -- --push-ready` (7 lanes passed)
- focused Tutti architecture review: no architecture findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session launch identity, resume, and CLI capability projection for extension providers; recovery is narrowly gated but incorrect gates could still block resume or accept wrong snapshots.
> 
> **Overview**
> Fixes **Agent Extension** sessions that broke after daemon restart or during Tutti CLI discovery when runtime snapshots stored an **empty provider** instead of open identities like `acp:kimi-code`.
> 
> **Write/read path:** Session runtime snapshot persistence and provider-native model fingerprints now use **`NormalizeOpen`** (replacing closed **`Normalize`**, which cleared extension-owned IDs). Resume, settings validation, and harness matching follow the same normalization.
> 
> **Legacy recovery:** When a snapshot still has an empty `provider` but matches the historical empty-provider fingerprint for provider-native config, **`sessionRuntimeSnapshotFromContext`** can recover the provider from the canonical session provider—only for unregistered open IDs, with **`LegacyEmptyOpenProvider`** flagged so fingerprint checks accept the old payload. Registered-provider fallbacks and other malformed snapshots remain **fail-closed** (no DB rewrite).
> 
> **Docs:** Troubleshooting entries for extension history non-resumable after restart, unknown CLI commands, and `launch identity is incomplete` are expanded with diagnosis steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8dd96decaa4af871d0c206b736075af96d25cdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->