### PR TITLE
perf(tooling): scope package pack validation

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -14,6 +14,8 @@ jobs:
     name: PR Change Classification
     runs-on: ubuntu-latest
     outputs:
+      pack_all: ${{ steps.changed-files.outputs.pack_all }}
+      pack_packages: ${{ steps.changed-files.outputs.pack_packages }}
       run_boundaries: ${{ steps.changed-files.outputs.run_boundaries }}
       run_contracts: ${{ steps.changed-files.outputs.run_contracts }}
       run_generated: ${{ steps.changed-files.outputs.run_generated }}
@@ -221,7 +223,15 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Validate package tarballs
-        run: pnpm release:pack:check
+        env:
+          PACK_ALL: ${{ needs.changes.outputs.pack_all }}
+          PACK_PACKAGES: ${{ needs.changes.outputs.pack_packages }}
+        run: >-
+          if [ "${PACK_ALL}" = "true" ]; then
+            pnpm release:pack:check;
+          else
+            pnpm release:pack:check -- --packages-json "${PACK_PACKAGES}";
+          fi
 
   go-tests:
     name: Go Tests

--- a/docs/conventions/local-git-hooks.md
+++ b/docs/conventions/local-git-hooks.md
@@ -61,6 +61,15 @@ selects only the relevant validation lanes, and adds build lanes for changed Go
 or package surfaces that require push-time build confidence. Unrelated
 TypeScript, Go, package, and boundary lanes do not run.
 
+Published-package validation is package-scoped. Runtime source, build config,
+published documentation, and runtime asset changes build the affected public
+package with its workspace dependencies and inspect only that package's
+tarball. Root manifests, lockfiles, workspace or Changesets config, package
+additions/removals, publish-relevant package manifest changes, and release-tool
+changes retain the full public-package gate. Test files, Vitest support files,
+and package manifests whose only changes are `test` scripts do not schedule a
+package build or tarball check.
+
 `check:full` remains the stable root command for explicit local full validation.
 It is no longer the default gate for every push; PR CI selects affected lanes
 from the same repository check registry used by `check:changed`.
@@ -153,7 +162,8 @@ uses the same selectors.
 
 `pnpm check:changed -- --push-ready` is the `pre-push` mode. In addition to the
 normal changed-aware lanes, it schedules Go or package builds when the changed
-surface requires them.
+surface requires them. Package lanes receive the exact public-package subset
+from the shared change classifier; pull-request CI consumes the same subset.
 
 Failure output prints an 80-line tail by default. Use
 `pnpm check:changed -- --tail-lines <n>` when a larger or smaller tail is more

--- a/docs/conventions/npm-package-release.md
+++ b/docs/conventions/npm-package-release.md
@@ -231,6 +231,19 @@ Use this command to inspect publish contents:
 pnpm release:pack:check
 ```
 
+Without arguments the command builds and inspects every configured public npm
+package. Repository-managed changed-file gates may pass a validated package
+subset:
+
+```bash
+pnpm release:pack:check -- --packages-json '["@tutti-os/agent-gui"]'
+```
+
+The subset build includes the selected packages' workspace dependencies, but
+only the selected package tarballs are inspected. Use the unfiltered command
+for release infrastructure, workspace dependency, lockfile, Changesets, or
+fixed release-group changes.
+
 Before publishing a package that exposes runtime assets, verify all of the
 following:
 

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "release:beta": "node ./tools/scripts/release-beta.mjs",
     "release:packages:apply-version": "node ./tools/scripts/apply-ci-package-release-version.mjs",
     "release:packages:next-version": "node ./tools/scripts/next-package-release-version.mjs",
-    "release:pack:check": "pnpm build:npm-packages && node ./tools/scripts/check-package-packs.mjs",
+    "release:pack:check": "node ./tools/scripts/run-package-pack-check.mjs",
     "release:packages": "node ./tools/scripts/publish-packages.mjs",
     "review:architecture": "node ./.codex/skills/tutti-architecture-review/scripts/plan-review.mjs --format summary",
     "review:architecture:package": "node ./.codex/skills/tutti-architecture-review/scripts/plan-review.mjs --format json --output-temp",

--- a/tools/scripts/build-npm-packages.mjs
+++ b/tools/scripts/build-npm-packages.mjs
@@ -2,13 +2,15 @@ import { execFileSync } from "node:child_process";
 
 import {
   getNpmReleasePackages,
+  parseReleasePackageFilters,
   workspaceRoot
 } from "./npm-release-packages.mjs";
 
-const packages = await getNpmReleasePackages();
+const packageNames = parseReleasePackageFilters(process.argv.slice(2));
+const packages = await getNpmReleasePackages({ packageNames });
 const args = packages.flatMap((packageConfig) => [
   "--filter",
-  packageConfig.name
+  packageNames === null ? packageConfig.name : `${packageConfig.name}...`
 ]);
 
 args.push("build");

--- a/tools/scripts/change-classification.mjs
+++ b/tools/scripts/change-classification.mjs
@@ -1,8 +1,9 @@
 import { readFileSync, readdirSync, writeFileSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { execFileSync } from "node:child_process";
 
+import { createIsolatedGitEnvironment } from "./git-environment.mjs";
 import { selectedRepositoryCheckGroups } from "./repository-checks.mjs";
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
@@ -10,28 +11,35 @@ const workspaceRoot = resolve(scriptDirectory, "../..");
 
 export function classifyChangedFiles(
   changedFiles,
-  { releasePackageRoots = discoverReleasePackageRoots() } = {}
+  {
+    isPackageManifestPackRelevant = () => true,
+    releasePackages = discoverReleasePackages()
+  } = {}
 ) {
   const normalizedFiles = changedFiles.map((file) =>
     file.replaceAll("\\", "/")
   );
   const groups = selectedRepositoryCheckGroups(normalizedFiles);
+  const packSelection = selectPackPackages(normalizedFiles, {
+    isPackageManifestPackRelevant,
+    releasePackages
+  });
 
   return {
+    packAll: packSelection.packAll,
+    packPackages: packSelection.packageNames,
     runBoundaries: groups.has("boundaries"),
     runContracts: groups.has("contracts"),
     runGenerated: groups.has("generated"),
     runGo: normalizedFiles.some(isGoRelevant),
-    runPack: normalizedFiles.some((file) =>
-      isPackRelevant(file, releasePackageRoots)
-    ),
+    runPack: packSelection.packAll || packSelection.packageNames.length > 0,
     runTs: normalizedFiles.some(isTypeScriptRelevant)
   };
 }
 
-export function discoverReleasePackageRoots(root = workspaceRoot) {
+export function discoverReleasePackages(root = workspaceRoot) {
   const packagesRoot = join(root, "packages");
-  const roots = [];
+  const packages = [];
 
   for (const group of readDirectories(packagesRoot)) {
     const groupRoot = join(packagesRoot, group);
@@ -44,7 +52,10 @@ export function discoverReleasePackageRoots(root = workspaceRoot) {
           manifest.private === false &&
           manifest.publishConfig?.access === "public"
         ) {
-          roots.push(packageRoot.slice(root.length + 1).replaceAll("\\", "/"));
+          packages.push({
+            name: manifest.name,
+            root: packageRoot.slice(root.length + 1).replaceAll("\\", "/")
+          });
         }
       } catch {
         // Non-package directories are outside the release surface.
@@ -52,11 +63,13 @@ export function discoverReleasePackageRoots(root = workspaceRoot) {
     }
   }
 
-  return roots.sort();
+  return packages.sort((left, right) => left.root.localeCompare(right.root));
 }
 
 export function formatClassificationOutputs(classification) {
   return [
+    ["pack_all", classification.packAll],
+    ["pack_packages", JSON.stringify(classification.packPackages)],
     ["run_boundaries", classification.runBoundaries],
     ["run_contracts", classification.runContracts],
     ["run_generated", classification.runGenerated],
@@ -86,19 +99,134 @@ function isTypeScriptRelevant(file) {
   );
 }
 
-function isPackRelevant(file, releasePackageRoots) {
+function selectPackPackages(
+  files,
+  { isPackageManifestPackRelevant, releasePackages }
+) {
+  const packAll = files.some((file) => isGlobalPackRelevant(file));
+  if (packAll) {
+    return {
+      packAll: true,
+      packageNames: releasePackages.map((packageConfig) => packageConfig.name)
+    };
+  }
+
+  const packageNames = new Set();
+  for (const file of files) {
+    const packageConfig = releasePackages.find(
+      ({ root }) => file === root || file.startsWith(`${root}/`)
+    );
+
+    if (!packageConfig) {
+      if (/^packages\/[^/]+\/[^/]+\/package\.json$/u.test(file)) {
+        return {
+          packAll: true,
+          packageNames: releasePackages.map(
+            (releasePackage) => releasePackage.name
+          )
+        };
+      }
+      continue;
+    }
+
+    const relativePath = file.slice(packageConfig.root.length + 1);
+    if (relativePath === "package.json") {
+      if (!isPackageManifestPackRelevant(file)) {
+        continue;
+      }
+      return {
+        packAll: true,
+        packageNames: releasePackages.map(
+          (releasePackage) => releasePackage.name
+        )
+      };
+    }
+    if (isPackagePackRelevantPath(relativePath)) {
+      packageNames.add(packageConfig.name);
+    }
+  }
+
+  return {
+    packAll: false,
+    packageNames: [...packageNames].sort()
+  };
+}
+
+function isGlobalPackRelevant(file) {
   return (
     ["package.json", "pnpm-lock.yaml", "pnpm-workspace.yaml"].includes(file) ||
-    /^packages\/[^/]+\/[^/]+\/package\.json$/u.test(file) ||
     file === ".changeset/config.json" ||
     file === "tools/scripts/build-npm-packages.mjs" ||
     file === "tools/scripts/check-package-packs.mjs" ||
     file === "tools/scripts/npm-release-packages.mjs" ||
-    releasePackageRoots.some(
-      (packageRoot) =>
-        file === packageRoot || file.startsWith(`${packageRoot}/`)
+    file === "tools/scripts/run-package-pack-check.mjs"
+  );
+}
+
+export function isPackagePackRelevantPath(file) {
+  return !(
+    /\.(?:test|spec)\.(?:ts|tsx|mts|cts|js|jsx|mjs|cjs)$/u.test(file) ||
+    /^vitest(?:\.[^/]+)*\.(?:ts|tsx|mts|cts|js|jsx|mjs|cjs)$/u.test(
+      basename(file)
     )
   );
+}
+
+export function createPackageManifestPackRelevance({
+  baseRef,
+  root = workspaceRoot
+}) {
+  const cache = new Map();
+
+  return (file) => {
+    if (!cache.has(file)) {
+      cache.set(file, isPackageManifestPackRelevant(baseRef, file, root));
+    }
+    return cache.get(file);
+  };
+}
+
+function isPackageManifestPackRelevant(baseRef, file, root) {
+  try {
+    const before = normalizedManifestAtRef(baseRef, file, root);
+    const candidates = [
+      normalizedManifestAtRef("HEAD", file, root),
+      JSON.stringify(
+        withoutTestScripts(JSON.parse(readFileSync(join(root, file), "utf8")))
+      )
+    ];
+    return candidates.some((candidate) => candidate !== before);
+  } catch {
+    return true;
+  }
+}
+
+function normalizedManifestAtRef(ref, file, root) {
+  const manifest = JSON.parse(
+    execFileSync("git", ["show", `${ref}:${file}`], {
+      cwd: root,
+      encoding: "utf8",
+      env: createIsolatedGitEnvironment(root)
+    })
+  );
+  return JSON.stringify(withoutTestScripts(manifest));
+}
+
+function withoutTestScripts(manifest) {
+  const normalized = structuredClone(manifest);
+  if (!normalized.scripts || typeof normalized.scripts !== "object") {
+    return normalized;
+  }
+
+  for (const name of Object.keys(normalized.scripts)) {
+    if (/^(?:pre|post)?test(?::|$)/u.test(name)) {
+      delete normalized.scripts[name];
+    }
+  }
+  if (Object.keys(normalized.scripts).length === 0) {
+    delete normalized.scripts;
+  }
+  return normalized;
 }
 
 function readDirectories(root) {
@@ -137,7 +265,11 @@ if (isMainModule()) {
     .map((line) => line.trim())
     .filter(Boolean);
   const output = formatClassificationOutputs(
-    classifyChangedFiles(changedFiles)
+    classifyChangedFiles(changedFiles, {
+      isPackageManifestPackRelevant: createPackageManifestPackRelevance({
+        baseRef: base
+      })
+    })
   );
   const githubOutput = readOption("--github-output");
   if (githubOutput) {

--- a/tools/scripts/change-classification.test.mjs
+++ b/tools/scripts/change-classification.test.mjs
@@ -1,15 +1,26 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 
-import { classifyChangedFiles } from "./change-classification.mjs";
+import {
+  classifyChangedFiles,
+  createPackageManifestPackRelevance
+} from "./change-classification.mjs";
+import { createIsolatedGitEnvironment } from "./git-environment.mjs";
 import { selectRepositoryChecks } from "./repository-checks.mjs";
 
-const releasePackageRoots = ["packages/agent/gui", "packages/ui/system"];
+const releasePackages = [
+  { name: "@tutti-os/agent-gui", root: "packages/agent/gui" },
+  { name: "@tutti-os/ui-system", root: "packages/ui/system" }
+];
 
 test("Go-only changes do not select TypeScript validation", () => {
   const classification = classifyChangedFiles(
     ["services/tuttid/service/workspace/apps.go"],
-    { releasePackageRoots }
+    { releasePackages }
   );
 
   assert.equal(classification.runGo, true);
@@ -26,7 +37,7 @@ test("generated source files select generated contracts before outputs change", 
     "packages/workbench/snapshot/src/schema.json"
   ]) {
     const classification = classifyChangedFiles([file], {
-      releasePackageRoots
+      releasePackages
     });
     assert.equal(classification.runGenerated, true, file);
   }
@@ -39,7 +50,7 @@ test("workflow and hook changes select repository tool contracts", () => {
     ".husky/pre-push"
   ]) {
     const classification = classifyChangedFiles([file], {
-      releasePackageRoots
+      releasePackages
     });
     assert.equal(classification.runContracts, true, file);
   }
@@ -51,7 +62,7 @@ test("published CSS and assets select package packing and UI boundaries", () => 
     "packages/ui/system/src/icons/recent-lined.svg"
   ]) {
     const classification = classifyChangedFiles([file], {
-      releasePackageRoots
+      releasePackages
     });
     assert.equal(classification.runPack, true, file);
     assert.equal(classification.runBoundaries, true, file);
@@ -62,10 +73,170 @@ test("published CSS and assets select package packing and UI boundaries", () => 
 test("deleted package manifests still select package packing", () => {
   const classification = classifyChangedFiles(
     ["packages/example/removed/package.json"],
-    { releasePackageRoots }
+    { releasePackages }
   );
 
   assert.equal(classification.runPack, true);
+  assert.equal(classification.packAll, true);
+  assert.deepEqual(classification.packPackages, [
+    "@tutti-os/agent-gui",
+    "@tutti-os/ui-system"
+  ]);
+});
+
+test("test files and Vitest support files do not select package packing", () => {
+  const classification = classifyChangedFiles(
+    [
+      "packages/agent/gui/agent-gui/controller.spec.ts",
+      "packages/agent/gui/vitest.config.ts",
+      "packages/agent/gui/vitest.shared.setup.ts"
+    ],
+    { releasePackages }
+  );
+
+  assert.equal(classification.runPack, false);
+  assert.deepEqual(classification.packPackages, []);
+});
+
+test("test-only package manifest changes do not select package packing", () => {
+  const classification = classifyChangedFiles(
+    ["packages/agent/gui/package.json"],
+    {
+      isPackageManifestPackRelevant: () => false,
+      releasePackages
+    }
+  );
+
+  assert.equal(classification.runPack, false);
+});
+
+test("publish-relevant package manifest changes select every package", () => {
+  const classification = classifyChangedFiles(
+    ["packages/agent/gui/package.json"],
+    { releasePackages }
+  );
+
+  assert.equal(classification.packAll, true);
+  assert.deepEqual(classification.packPackages, [
+    "@tutti-os/agent-gui",
+    "@tutti-os/ui-system"
+  ]);
+});
+
+test("package manifest comparison ignores only test scripts", () => {
+  const root = mkdtempSync(join(tmpdir(), "package-manifest-pack-"));
+  const packageRoot = join(root, "packages/agent/gui");
+  const manifestPath = join(packageRoot, "package.json");
+  const gitEnv = createIsolatedGitEnvironment(root);
+  const runGit = (args) =>
+    execFileSync("git", args, { cwd: root, env: gitEnv });
+  mkdirSync(packageRoot, { recursive: true });
+
+  try {
+    writeFileSync(
+      manifestPath,
+      `${JSON.stringify({
+        name: "@tutti-os/agent-gui",
+        scripts: { build: "tsup", test: "vitest run --old" }
+      })}\n`
+    );
+    runGit(["init", "--quiet"]);
+    runGit(["add", "."]);
+    runGit([
+      "-c",
+      "user.name=Test",
+      "-c",
+      "user.email=test@example.com",
+      "commit",
+      "--quiet",
+      "-m",
+      "init"
+    ]);
+    const isRelevant = createPackageManifestPackRelevance({
+      baseRef: "HEAD",
+      root
+    });
+
+    writeFileSync(
+      manifestPath,
+      `${JSON.stringify({
+        name: "@tutti-os/agent-gui",
+        scripts: { build: "tsup", test: "vitest run" }
+      })}\n`
+    );
+    assert.equal(isRelevant("packages/agent/gui/package.json"), false);
+
+    const buildChangeIsRelevant = createPackageManifestPackRelevance({
+      baseRef: "HEAD",
+      root
+    });
+    writeFileSync(
+      manifestPath,
+      `${JSON.stringify({
+        name: "@tutti-os/agent-gui",
+        scripts: { build: "tsup --config tsup.config.ts", test: "vitest run" }
+      })}\n`
+    );
+    assert.equal(
+      buildChangeIsRelevant("packages/agent/gui/package.json"),
+      true
+    );
+
+    runGit(["add", "."]);
+    runGit([
+      "-c",
+      "user.name=Test",
+      "-c",
+      "user.email=test@example.com",
+      "commit",
+      "--quiet",
+      "-m",
+      "change build"
+    ]);
+    writeFileSync(
+      manifestPath,
+      `${JSON.stringify({
+        name: "@tutti-os/agent-gui",
+        scripts: {
+          build: "tsup --config tsup.config.ts",
+          test: "vitest run --working-copy"
+        }
+      })}\n`
+    );
+    const committedBuildChangeIsRelevant = createPackageManifestPackRelevance({
+      baseRef: "HEAD^",
+      root
+    });
+    assert.equal(
+      committedBuildChangeIsRelevant("packages/agent/gui/package.json"),
+      true
+    );
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+test("published package changes select only their owning package", () => {
+  const classification = classifyChangedFiles(["packages/agent/gui/index.ts"], {
+    releasePackages
+  });
+
+  assert.equal(classification.runPack, true);
+  assert.equal(classification.packAll, false);
+  assert.deepEqual(classification.packPackages, ["@tutti-os/agent-gui"]);
+});
+
+test("global release inputs select every published package", () => {
+  const classification = classifyChangedFiles(["pnpm-lock.yaml"], {
+    releasePackages
+  });
+
+  assert.equal(classification.runPack, true);
+  assert.equal(classification.packAll, true);
+  assert.deepEqual(classification.packPackages, [
+    "@tutti-os/agent-gui",
+    "@tutti-os/ui-system"
+  ]);
 });
 
 test("repository check registry selects only relevant generated checks", () => {

--- a/tools/scripts/check-package-packs.mjs
+++ b/tools/scripts/check-package-packs.mjs
@@ -5,6 +5,7 @@ import { join } from "node:path";
 
 import {
   getNpmReleasePackages,
+  parseReleasePackageFilters,
   workspaceRoot
 } from "./npm-release-packages.mjs";
 import {
@@ -31,7 +32,8 @@ const forbiddenPrefixes = [
 // `node --experimental-strip-types src/main.ts`, so it ships src/ on purpose.
 const sourcePublishingPackages = new Set(["@tutti-os/claude-sdk-sidecar"]);
 
-const packages = await getNpmReleasePackages();
+const packageNames = parseReleasePackageFilters(process.argv.slice(2));
+const packages = await getNpmReleasePackages({ packageNames });
 const tempDirectory = await mkdtemp(join(tmpdir(), "tutti-pack-check-"));
 
 try {

--- a/tools/scripts/npm-release-packages.mjs
+++ b/tools/scripts/npm-release-packages.mjs
@@ -6,12 +6,18 @@ const defaultWorkspaceRoot = fileURLToPath(new URL("../..", import.meta.url));
 export const workspaceRoot =
   process.env.TUTTI_WORKSPACE_ROOT ?? defaultWorkspaceRoot;
 
-export async function getNpmReleasePackages() {
+export async function getNpmReleasePackages({
+  packageNames: selectedNames = null
+} = {}) {
   const packageMap = await discoverWorkspacePackages();
-  const packageNames = await readReleasePackageNames();
-  validateReleasePackageSelection(packageMap, packageNames);
+  const releasePackageNames = await readReleasePackageNames();
+  validateReleasePackageSelection(packageMap, releasePackageNames);
+  const selectedPackageNames = selectReleasePackageNames(
+    releasePackageNames,
+    selectedNames
+  );
 
-  return packageNames.map((name) => {
+  return selectedPackageNames.map((name) => {
     const packageConfig = packageMap.get(name);
 
     if (!packageConfig) {
@@ -34,6 +40,53 @@ export async function getNpmReleasePackages() {
 
     return packageConfig;
   });
+}
+
+export function parseReleasePackageFilters(args) {
+  const normalizedArgs = args.filter((arg) => arg !== "--");
+  if (normalizedArgs.length === 0) {
+    return null;
+  }
+  if (normalizedArgs.length !== 2 || normalizedArgs[0] !== "--packages-json") {
+    throw new Error(
+      "release package selection accepts only --packages-json <json-array>"
+    );
+  }
+
+  let packageNames;
+  try {
+    packageNames = JSON.parse(normalizedArgs[1]);
+  } catch {
+    throw new Error("--packages-json must contain valid JSON");
+  }
+  if (
+    !Array.isArray(packageNames) ||
+    packageNames.length === 0 ||
+    packageNames.some((name) => typeof name !== "string" || name.length === 0)
+  ) {
+    throw new Error("--packages-json must contain a non-empty string array");
+  }
+  return [...new Set(packageNames)];
+}
+
+export function selectReleasePackageNames(
+  releasePackageNames,
+  selectedPackageNames
+) {
+  if (selectedPackageNames === null) {
+    return releasePackageNames;
+  }
+
+  const releaseNameSet = new Set(releasePackageNames);
+  const unknownNames = selectedPackageNames.filter(
+    (name) => !releaseNameSet.has(name)
+  );
+  if (unknownNames.length > 0) {
+    throw new Error(
+      `Unknown npm release package filter(s): ${unknownNames.join(", ")}`
+    );
+  }
+  return selectedPackageNames;
 }
 
 async function readReleasePackageNames() {

--- a/tools/scripts/npm-release-packages.test.mjs
+++ b/tools/scripts/npm-release-packages.test.mjs
@@ -4,6 +4,8 @@ import test from "node:test";
 import {
   collectWorkspaceRuntimeDependencyNames,
   isPublicReleaseWorkspacePackage,
+  parseReleasePackageFilters,
+  selectReleasePackageNames,
   validateReleasePackageSelection
 } from "./npm-release-packages.mjs";
 
@@ -171,5 +173,43 @@ test("accepts a complete fixed release group", () => {
       "@tutti-os/ui-i18n-runtime",
       "@tutti-os/ui-system"
     ])
+  );
+});
+
+test("parses an explicit release package subset", () => {
+  assert.deepEqual(
+    parseReleasePackageFilters([
+      "--",
+      "--packages-json",
+      '["@tutti-os/agent-gui","@tutti-os/ui-system"]'
+    ]),
+    ["@tutti-os/agent-gui", "@tutti-os/ui-system"]
+  );
+  assert.equal(parseReleasePackageFilters([]), null);
+  assert.throws(
+    () => parseReleasePackageFilters(["--package", "@tutti-os/agent-gui"]),
+    /accepts only --packages-json/u
+  );
+  assert.throws(
+    () => parseReleasePackageFilters(["--packages-json", "[]"]),
+    /non-empty string array/u
+  );
+});
+
+test("rejects package filters outside the fixed release group", () => {
+  assert.deepEqual(
+    selectReleasePackageNames(
+      ["@tutti-os/agent-gui", "@tutti-os/ui-system"],
+      ["@tutti-os/agent-gui"]
+    ),
+    ["@tutti-os/agent-gui"]
+  );
+  assert.throws(
+    () =>
+      selectReleasePackageNames(
+        ["@tutti-os/agent-gui"],
+        ["@tutti-os/not-released"]
+      ),
+    /Unknown npm release package filter/u
   );
 });

--- a/tools/scripts/pr-checks-workflow.test.mjs
+++ b/tools/scripts/pr-checks-workflow.test.mjs
@@ -37,6 +37,24 @@ test("language jobs do not own repository checks", () => {
   }
 });
 
+test("package pack CI receives the classified package subset", () => {
+  const changes = workflow.jobs.changes;
+  const packJob = workflow.jobs["npm-package-packs"];
+  const packStep = packJob.steps.find(
+    (step) => step.name === "Validate package tarballs"
+  );
+
+  assert.equal(
+    changes.outputs.pack_packages,
+    "${{ steps.changed-files.outputs.pack_packages }}"
+  );
+  assert.equal(
+    packStep.env.PACK_PACKAGES,
+    "${{ needs.changes.outputs.pack_packages }}"
+  );
+  assert.match(packStep.run, /--packages-json/u);
+});
+
 function stepScripts(job) {
   return job.steps.map((step) => step.run ?? "").join("\n");
 }

--- a/tools/scripts/run-check-changed.mjs
+++ b/tools/scripts/run-check-changed.mjs
@@ -24,7 +24,11 @@ import {
   resolveGoModuleRoot,
   resolveGoValidationTargets
 } from "./run-check-changed-targets.mjs";
-import { classifyChangedFiles } from "./change-classification.mjs";
+import {
+  classifyChangedFiles,
+  createPackageManifestPackRelevance,
+  isPackagePackRelevantPath
+} from "./change-classification.mjs";
 import {
   selectRepositoryCheckInputs,
   selectRepositoryChecks
@@ -148,7 +152,13 @@ export async function main() {
 
 function buildChangedLanes() {
   const changedFiles = listChangedFiles(baseRef);
-  const classification = classifyChangedFiles(changedFiles);
+  const isPackageManifestPackRelevant = createPackageManifestPackRelevance({
+    baseRef,
+    root: workspaceRoot
+  });
+  const classification = classifyChangedFiles(changedFiles, {
+    isPackageManifestPackRelevant
+  });
   const lanesByKey = new Map();
   const addLane = (lane) => {
     const normalizedInputs = Array.from(new Set(lane.inputFiles)).sort();
@@ -310,9 +320,11 @@ function buildChangedLanes() {
 
     if (
       pushReady &&
-      !classification.runPack &&
+      !classification.packPackages.includes(packageInfo.name) &&
       packageInfo.scripts.build &&
-      packageFiles.some(isBuildRelevant)
+      packageFiles.some((file) =>
+        isPackageBuildRelevant(file, isPackageManifestPackRelevant)
+      )
     ) {
       addLane({
         key: `${packageInfo.name}:build`,
@@ -324,10 +336,13 @@ function buildChangedLanes() {
   }
 
   if (pushReady && classification.runPack) {
+    const packageArgs = classification.packAll
+      ? []
+      : ["--", "--packages-json", JSON.stringify(classification.packPackages)];
     addLane({
       key: "pack:npm",
       label: "npm package pack",
-      command: [...pnpmCommand, "run", "release:pack:check"],
+      command: [...pnpmCommand, "run", "release:pack:check", ...packageArgs],
       inputFiles: changedFiles
     });
   }
@@ -639,7 +654,16 @@ function isPackageValidationRelevant(file) {
   );
 }
 
-function isBuildRelevant(file) {
+export function isPackageBuildRelevant(file, isPackageManifestPackRelevant) {
+  if (!isPackagePackRelevantPath(file)) {
+    return false;
+  }
+  if (
+    /(?:^|\/)package\.json$/u.test(file) &&
+    !isPackageManifestPackRelevant(file)
+  ) {
+    return false;
+  }
   return (
     isPackageValidationRelevant(file) ||
     /(?:^|\/)(assets|public|style|styles)\//u.test(file) ||

--- a/tools/scripts/run-check-changed.test.mjs
+++ b/tools/scripts/run-check-changed.test.mjs
@@ -12,6 +12,7 @@ import {
   selectFailedOnlyLanes
 } from "./run-check-changed-cache.mjs";
 import {
+  isPackageBuildRelevant,
   parseCliArgs,
   printSummary,
   runLanes,
@@ -56,6 +57,34 @@ test("parseCliArgs accepts pnpm separators and explicit values", () => {
       tailLines: 40,
       verbose: false
     }
+  );
+});
+
+test("package builds exclude test-only inputs", () => {
+  const manifestIsNotRelevant = () => false;
+
+  for (const file of [
+    "packages/agent/gui/controller.spec.ts",
+    "packages/agent/gui/vitest.config.ts",
+    "packages/agent/gui/vitest.shared.setup.ts",
+    "packages/agent/gui/package.json"
+  ]) {
+    assert.equal(
+      isPackageBuildRelevant(file, manifestIsNotRelevant),
+      false,
+      file
+    );
+  }
+  assert.equal(
+    isPackageBuildRelevant(
+      "packages/agent/gui/index.ts",
+      manifestIsNotRelevant
+    ),
+    true
+  );
+  assert.equal(
+    isPackageBuildRelevant("packages/agent/gui/package.json", () => true),
+    true
   );
 });
 

--- a/tools/scripts/run-package-pack-check.mjs
+++ b/tools/scripts/run-package-pack-check.mjs
@@ -1,0 +1,16 @@
+import { execFileSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const forwardedArgs = process.argv.slice(2);
+
+for (const script of ["build-npm-packages.mjs", "check-package-packs.mjs"]) {
+  execFileSync(
+    process.execPath,
+    [join(scriptDirectory, script), ...forwardedArgs],
+    {
+      stdio: "inherit"
+    }
+  );
+}


### PR DESCRIPTION
## Summary
- skip package builds and tarball checks for test files, Vitest support files, and package manifests whose only changes are test scripts
- classify affected public npm packages and build/pack only that subset while retaining full validation for release-wide inputs
- pass the same package subset to local push-ready validation and PR CI
- isolate package-manifest Git comparisons from inherited repository environment variables

## Tests
- `node --test tools/scripts/change-classification.test.mjs tools/scripts/npm-release-packages.test.mjs tools/scripts/pr-checks-workflow.test.mjs tools/scripts/run-check-changed.test.mjs`
- `pnpm release:pack:check -- --packages-json '["@tutti-os/event-stream-core"]'`
- `pnpm release:pack:check -- --packages-json '["@tutti-os/agent-gui"]'`
- `pnpm check:changed -- --failed-only` (push-ready mode inherited; 25 lanes passed)
- pre-push `pnpm check:changed -- --push-ready` (25 lanes passed)

## Benchmark
- prior AgentGUI test-only change: `run_pack=true`, 58.3s pre-push
- optimized classification for the same diff: `run_pack=false`
- filtered event-stream-core build/pack: 2.3s
- filtered AgentGUI cold build/pack: 44.3s versus 55.7s full package pack lane

## Notes
- package manifest changes outside test scripts, lockfiles, workspace/Changesets configuration, package additions/removals, and release tooling still select the full public package set

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->