### PR TITLE
perf(ci): scope and shard TypeScript tests

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -22,6 +22,10 @@ jobs:
       run_go: ${{ steps.changed-files.outputs.run_go }}
       run_pack: ${{ steps.changed-files.outputs.run_pack }}
       run_ts: ${{ steps.changed-files.outputs.run_ts }}
+      run_ts_tests: ${{ steps.changed-files.outputs.run_ts_tests }}
+      test_all: ${{ steps.changed-files.outputs.test_all }}
+      test_packages: ${{ steps.changed-files.outputs.test_packages }}
+      test_shards: ${{ steps.changed-files.outputs.test_shards }}
 
     steps:
       - name: Checkout repository
@@ -173,11 +177,15 @@ jobs:
       - name: Run workspace typecheck
         run: pnpm typecheck
 
-  ts-tests:
-    name: TypeScript Tests
+  ts-test-shards:
+    name: TypeScript Test Shard ${{ matrix.shard }}
     needs: changes
-    if: needs.changes.outputs.run_ts == 'true'
+    if: needs.changes.outputs.run_ts_tests == 'true'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(needs.changes.outputs.test_shards) }}
 
     steps:
       - name: Checkout repository
@@ -197,7 +205,41 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run TypeScript tests
-        run: pnpm test:ts
+        env:
+          TEST_ALL: ${{ needs.changes.outputs.test_all }}
+          TEST_PACKAGES: ${{ needs.changes.outputs.test_packages }}
+          TEST_SHARD: ${{ matrix.shard }}
+        run: >-
+          if [ "${TEST_ALL}" = "true" ]; then
+            pnpm test:ts -- --shard "${TEST_SHARD}";
+          else
+            pnpm test:ts -- --packages-json "${TEST_PACKAGES}"
+            --shard "${TEST_SHARD}";
+          fi
+
+  ts-tests:
+    name: TypeScript Tests
+    needs:
+      - changes
+      - ts-test-shards
+    if: always()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Require change classification
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+        run: test "${CHANGES_RESULT}" = "success"
+
+      - name: Require selected test shards
+        if: needs.changes.outputs.run_ts_tests == 'true'
+        env:
+          SHARDS_RESULT: ${{ needs.ts-test-shards.result }}
+        run: test "${SHARDS_RESULT}" = "success"
+
+      - name: No workspace package tests selected
+        if: needs.changes.outputs.run_ts_tests != 'true'
+        run: echo "No workspace package tests selected"
 
   npm-package-packs:
     name: npm Package Pack Check

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -213,8 +213,7 @@ jobs:
           if [ "${TEST_ALL}" = "true" ]; then
             pnpm test:ts -- --shard "${TEST_SHARD}";
           else
-            pnpm test:ts -- --packages-json "${TEST_PACKAGES}"
-            --shard "${TEST_SHARD}";
+            pnpm test:ts -- --packages-json "${TEST_PACKAGES}" --shard "${TEST_SHARD}";
           fi
 
   ts-tests:

--- a/docs/conventions/testing.md
+++ b/docs/conventions/testing.md
@@ -5,6 +5,9 @@ This document defines the repository-managed test discovery and gate policy.
 ## Commands
 
 - `pnpm test:ts`: all TypeScript/JavaScript workspace package tests
+- `pnpm test:ts -- --packages-json '["@tutti-os/agent-gui"]'`: tests for an
+  explicit validated workspace package subset
+- `pnpm test:ts -- --shard 1/3`: the first deterministic package shard
 - `pnpm test:tools`: repository tool tests only
 - `pnpm test:go`: generate builtin app assets, then run the blocking Go workspace test set
 - `pnpm test:go:prepared`: run the blocking Go workspace test set when builtin app assets are already prepared
@@ -56,6 +59,16 @@ live output or `--tail-lines <n>` to change each failed task's excerpt size.
 TypeScript and JavaScript package tests are discovered from workspace
 `package.json` files. Every workspace package with a `test` script is included
 automatically; do not add package names to a root test whitelist.
+
+Pull-request CI keeps the stable `TypeScript Tests` required-check context but
+uses changed-file classification to select package lanes. Package-local changes
+run the owning package and transitive workspace dependents' tests; tool-only
+changes keep the context as a passing no-op because repository tool tests belong
+to `Tooling Consistency`. Lockfile, workspace, shared test configuration, runner,
+deleted-package, and relevant root manifest changes run all package tests.
+Selected packages are distributed across at most three runner shards; packages
+inside each runner remain serial so their own test workers do not oversubscribe
+the runner.
 
 A package that declares a `test` script must contain at least one package-local
 `*.test.*` or `*.spec.*` file. The root runner rejects zero-test scripts so an

--- a/docs/conventions/testing.md
+++ b/docs/conventions/testing.md
@@ -66,9 +66,9 @@ run the owning package and transitive workspace dependents' tests; tool-only
 changes keep the context as a passing no-op because repository tool tests belong
 to `Tooling Consistency`. Lockfile, workspace, shared test configuration, runner,
 deleted-package, and relevant root manifest changes run all package tests.
-Selected packages are distributed across at most three runner shards; packages
-inside each runner remain serial so their own test workers do not oversubscribe
-the runner.
+Selected packages are greedily balanced across at most three runner shards by
+their discovered test file counts; packages inside each runner remain serial so
+their own test workers do not oversubscribe the runner.
 
 A package that declares a `test` script must contain at least one package-local
 `*.test.*` or `*.spec.*` file. The root runner rejects zero-test scripts so an

--- a/tools/scripts/change-classification.mjs
+++ b/tools/scripts/change-classification.mjs
@@ -13,7 +13,9 @@ export function classifyChangedFiles(
   changedFiles,
   {
     isPackageManifestPackRelevant = () => true,
-    releasePackages = discoverReleasePackages()
+    isRootManifestTestRelevant = () => true,
+    releasePackages = discoverReleasePackages(),
+    workspacePackages = discoverWorkspacePackages()
   } = {}
 ) {
   const normalizedFiles = changedFiles.map((file) =>
@@ -24,6 +26,11 @@ export function classifyChangedFiles(
     isPackageManifestPackRelevant,
     releasePackages
   });
+  const testSelection = selectTypeScriptTestPackages(normalizedFiles, {
+    isRootManifestTestRelevant,
+    workspacePackages
+  });
+  const testShards = buildTypeScriptTestShards(testSelection.packageNames);
 
   return {
     packAll: packSelection.packAll,
@@ -33,8 +40,57 @@ export function classifyChangedFiles(
     runGenerated: groups.has("generated"),
     runGo: normalizedFiles.some(isGoRelevant),
     runPack: packSelection.packAll || packSelection.packageNames.length > 0,
-    runTs: normalizedFiles.some(isTypeScriptRelevant)
+    runTs: normalizedFiles.some(isTypeScriptRelevant),
+    runTsTests: testSelection.testAll || testSelection.packageNames.length > 0,
+    testAll: testSelection.testAll,
+    testPackages: testSelection.packageNames,
+    testShards
   };
+}
+
+export function discoverWorkspacePackages(root = workspaceRoot) {
+  const packageRoots = [
+    ...readChildPackageRoots(join(root, "apps")),
+    ...readGrandchildPackageRoots(join(root, "packages")),
+    ...readChildPackageRoots(join(root, "services/tuttid/builtin-apps")),
+    ...readChildPackageRoots(join(root, "tools/fixtures"))
+  ];
+  const packages = [];
+
+  for (const packageRoot of packageRoots) {
+    try {
+      const manifest = JSON.parse(
+        readFileSync(join(packageRoot, "package.json"), "utf8")
+      );
+      if (typeof manifest.name === "string") {
+        packages.push({
+          hasTests: typeof manifest.scripts?.test === "string",
+          manifest,
+          name: manifest.name,
+          root: packageRoot.slice(root.length + 1).replaceAll("\\", "/")
+        });
+      }
+    } catch {
+      // Non-package directories are outside the workspace package surface.
+    }
+  }
+
+  const workspaceNames = new Set(
+    packages.map((packageConfig) => packageConfig.name)
+  );
+  return packages
+    .map(({ manifest, ...packageConfig }) => ({
+      ...packageConfig,
+      workspaceDependencies: Object.keys({
+        ...manifest.dependencies,
+        ...manifest.devDependencies,
+        ...manifest.optionalDependencies,
+        ...manifest.peerDependencies
+      })
+        .filter((name) => workspaceNames.has(name))
+        .sort()
+    }))
+    .sort((left, right) => left.root.localeCompare(right.root));
 }
 
 export function discoverReleasePackages(root = workspaceRoot) {
@@ -75,10 +131,22 @@ export function formatClassificationOutputs(classification) {
     ["run_generated", classification.runGenerated],
     ["run_go", classification.runGo],
     ["run_pack", classification.runPack],
-    ["run_ts", classification.runTs]
+    ["run_ts", classification.runTs],
+    ["run_ts_tests", classification.runTsTests],
+    ["test_all", classification.testAll],
+    ["test_packages", JSON.stringify(classification.testPackages)],
+    ["test_shards", JSON.stringify(classification.testShards)]
   ]
     .map(([key, value]) => `${key}=${value}`)
     .join("\n");
+}
+
+export function buildTypeScriptTestShards(packageNames, maximum = 3) {
+  const shardCount = Math.max(1, Math.min(maximum, packageNames.length));
+  return Array.from(
+    { length: shardCount },
+    (_, index) => `${index + 1}/${shardCount}`
+  );
 }
 
 function isGoRelevant(file) {
@@ -96,6 +164,82 @@ function isTypeScriptRelevant(file) {
     /(?:^|\/)(?:package\.json|tsconfig[^/]*\.json)$/u.test(file) ||
     ["pnpm-lock.yaml", "pnpm-workspace.yaml"].includes(file) ||
     file.startsWith("packages/configs/")
+  );
+}
+
+export function selectTypeScriptTestPackages(
+  files,
+  { isRootManifestTestRelevant, workspacePackages }
+) {
+  const testPackages = workspacePackages.filter(
+    (packageConfig) => packageConfig.hasTests
+  );
+  const testAll =
+    files.some(isGlobalTypeScriptTestRelevant) ||
+    (files.includes("package.json") && isRootManifestTestRelevant());
+  if (testAll) {
+    return {
+      packageNames: testPackages.map((packageConfig) => packageConfig.name),
+      testAll: true
+    };
+  }
+
+  const affectedPackageNames = new Set();
+  for (const file of files) {
+    const packageConfig = workspacePackages.find(
+      ({ root }) => file === root || file.startsWith(`${root}/`)
+    );
+    if (packageConfig) {
+      affectedPackageNames.add(packageConfig.name);
+      continue;
+    }
+    if (
+      /^(?:apps\/[^/]+|packages\/[^/]+\/[^/]+|services\/tuttid\/builtin-apps\/[^/]+|tools\/fixtures\/[^/]+)\/package\.json$/u.test(
+        file
+      )
+    ) {
+      return {
+        packageNames: testPackages.map((testPackage) => testPackage.name),
+        testAll: true
+      };
+    }
+  }
+
+  addTransitiveWorkspaceDependents(affectedPackageNames, workspacePackages);
+  return {
+    packageNames: testPackages
+      .filter((packageConfig) => affectedPackageNames.has(packageConfig.name))
+      .map((packageConfig) => packageConfig.name),
+    testAll: false
+  };
+}
+
+function addTransitiveWorkspaceDependents(affectedPackageNames, packages) {
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const packageConfig of packages) {
+      if (
+        !affectedPackageNames.has(packageConfig.name) &&
+        (packageConfig.workspaceDependencies ?? []).some((name) =>
+          affectedPackageNames.has(name)
+        )
+      ) {
+        affectedPackageNames.add(packageConfig.name);
+        changed = true;
+      }
+    }
+  }
+}
+
+function isGlobalTypeScriptTestRelevant(file) {
+  return (
+    [".node-version", "pnpm-lock.yaml", "pnpm-workspace.yaml"].includes(file) ||
+    file.startsWith("packages/configs/") ||
+    [
+      "tools/scripts/run-validation-lanes.mjs",
+      "tools/scripts/run-workspace-tests.mjs"
+    ].includes(file)
   );
 }
 
@@ -186,6 +330,38 @@ export function createPackageManifestPackRelevance({
   };
 }
 
+export function createRootManifestTestRelevance({
+  baseRef,
+  root = workspaceRoot
+}) {
+  return () => {
+    try {
+      const before = normalizedManifestAtRef(
+        baseRef,
+        "package.json",
+        root,
+        testRelevantRootManifest
+      );
+      const candidates = [
+        normalizedManifestAtRef(
+          "HEAD",
+          "package.json",
+          root,
+          testRelevantRootManifest
+        ),
+        JSON.stringify(
+          testRelevantRootManifest(
+            JSON.parse(readFileSync(join(root, "package.json"), "utf8"))
+          )
+        )
+      ];
+      return candidates.some((candidate) => candidate !== before);
+    } catch {
+      return true;
+    }
+  };
+}
+
 function isPackageManifestPackRelevant(baseRef, file, root) {
   try {
     const before = normalizedManifestAtRef(baseRef, file, root);
@@ -201,7 +377,12 @@ function isPackageManifestPackRelevant(baseRef, file, root) {
   }
 }
 
-function normalizedManifestAtRef(ref, file, root) {
+function normalizedManifestAtRef(
+  ref,
+  file,
+  root,
+  normalize = withoutTestScripts
+) {
   const manifest = JSON.parse(
     execFileSync("git", ["show", `${ref}:${file}`], {
       cwd: root,
@@ -209,7 +390,7 @@ function normalizedManifestAtRef(ref, file, root) {
       env: createIsolatedGitEnvironment(root)
     })
   );
-  return JSON.stringify(withoutTestScripts(manifest));
+  return JSON.stringify(normalize(manifest));
 }
 
 function withoutTestScripts(manifest) {
@@ -227,6 +408,46 @@ function withoutTestScripts(manifest) {
     delete normalized.scripts;
   }
   return normalized;
+}
+
+function testRelevantRootManifest(manifest) {
+  const relevant = {};
+  for (const key of [
+    "dependencies",
+    "devDependencies",
+    "engines",
+    "optionalDependencies",
+    "packageManager",
+    "peerDependencies",
+    "pnpm",
+    "workspaces"
+  ]) {
+    if (manifest[key] !== undefined) {
+      relevant[key] = manifest[key];
+    }
+  }
+
+  const scripts = Object.fromEntries(
+    Object.entries(manifest.scripts ?? {}).filter(([name]) =>
+      /^(?:preinstall|install|postinstall|prepare|(?:pre|post)?test:ts(?::.*)?)$/u.test(
+        name
+      )
+    )
+  );
+  if (Object.keys(scripts).length > 0) {
+    relevant.scripts = scripts;
+  }
+  return relevant;
+}
+
+function readChildPackageRoots(root) {
+  return readDirectories(root).map((name) => join(root, name));
+}
+
+function readGrandchildPackageRoots(root) {
+  return readDirectories(root).flatMap((group) =>
+    readChildPackageRoots(join(root, group))
+  );
 }
 
 function readDirectories(root) {
@@ -267,6 +488,9 @@ if (isMainModule()) {
   const output = formatClassificationOutputs(
     classifyChangedFiles(changedFiles, {
       isPackageManifestPackRelevant: createPackageManifestPackRelevance({
+        baseRef: base
+      }),
+      isRootManifestTestRelevant: createRootManifestTestRelevance({
         baseRef: base
       })
     })

--- a/tools/scripts/change-classification.test.mjs
+++ b/tools/scripts/change-classification.test.mjs
@@ -6,8 +6,10 @@ import { join } from "node:path";
 import test from "node:test";
 
 import {
+  buildTypeScriptTestShards,
   classifyChangedFiles,
-  createPackageManifestPackRelevance
+  createPackageManifestPackRelevance,
+  createRootManifestTestRelevance
 } from "./change-classification.mjs";
 import { createIsolatedGitEnvironment } from "./git-environment.mjs";
 import { selectRepositoryChecks } from "./repository-checks.mjs";
@@ -16,6 +18,35 @@ const releasePackages = [
   { name: "@tutti-os/agent-gui", root: "packages/agent/gui" },
   { name: "@tutti-os/ui-system", root: "packages/ui/system" }
 ];
+const workspacePackages = [
+  {
+    hasTests: true,
+    name: "@tutti-os/agent-gui",
+    root: "packages/agent/gui"
+  },
+  {
+    hasTests: true,
+    name: "@tutti-os/desktop",
+    root: "apps/desktop",
+    workspaceDependencies: ["@tutti-os/agent-gui"]
+  },
+  {
+    hasTests: false,
+    name: "@tutti-os/no-tests",
+    root: "packages/example/no-tests"
+  }
+];
+
+test("builds no more TypeScript test shards than selected packages", () => {
+  assert.deepEqual(buildTypeScriptTestShards([]), ["1/1"]);
+  assert.deepEqual(buildTypeScriptTestShards(["one"]), ["1/1"]);
+  assert.deepEqual(buildTypeScriptTestShards(["one", "two"]), ["1/2", "2/2"]);
+  assert.deepEqual(buildTypeScriptTestShards(["one", "two", "three", "four"]), [
+    "1/3",
+    "2/3",
+    "3/3"
+  ]);
+});
 
 test("Go-only changes do not select TypeScript validation", () => {
   const classification = classifyChangedFiles(
@@ -237,6 +268,138 @@ test("global release inputs select every published package", () => {
     "@tutti-os/agent-gui",
     "@tutti-os/ui-system"
   ]);
+});
+
+test("tool-only changes do not select workspace package tests", () => {
+  const classification = classifyChangedFiles(
+    ["tools/scripts/check-package-packs.mjs"],
+    {
+      isRootManifestTestRelevant: () => false,
+      releasePackages,
+      workspacePackages
+    }
+  );
+
+  assert.equal(classification.runTs, true);
+  assert.equal(classification.runTsTests, false);
+  assert.deepEqual(classification.testPackages, []);
+});
+
+test("package changes select owning and dependent package tests", () => {
+  const classification = classifyChangedFiles(
+    ["packages/agent/gui/controller.spec.ts"],
+    { releasePackages, workspacePackages }
+  );
+
+  assert.equal(classification.runTsTests, true);
+  assert.equal(classification.testAll, false);
+  assert.deepEqual(classification.testPackages, [
+    "@tutti-os/agent-gui",
+    "@tutti-os/desktop"
+  ]);
+});
+
+test("packages without tests do not select workspace package tests", () => {
+  const classification = classifyChangedFiles(
+    ["packages/example/no-tests/index.ts"],
+    { releasePackages, workspacePackages }
+  );
+
+  assert.equal(classification.runTsTests, false);
+});
+
+test("global test inputs select every workspace test package", () => {
+  const classification = classifyChangedFiles(["pnpm-lock.yaml"], {
+    releasePackages,
+    workspacePackages
+  });
+
+  assert.equal(classification.runTsTests, true);
+  assert.equal(classification.testAll, true);
+  assert.deepEqual(classification.testPackages, [
+    "@tutti-os/agent-gui",
+    "@tutti-os/desktop"
+  ]);
+});
+
+test("deleted package manifests select every workspace test package", () => {
+  const classification = classifyChangedFiles(
+    ["packages/example/deleted/package.json"],
+    { releasePackages, workspacePackages }
+  );
+
+  assert.equal(classification.testAll, true);
+});
+
+test("root manifest comparison ignores unrelated scripts", () => {
+  const root = mkdtempSync(join(tmpdir(), "root-manifest-tests-"));
+  const manifestPath = join(root, "package.json");
+  const gitEnv = createIsolatedGitEnvironment(root);
+  const runGit = (args) =>
+    execFileSync("git", args, { cwd: root, env: gitEnv });
+
+  try {
+    writeFileSync(
+      manifestPath,
+      `${JSON.stringify({
+        packageManager: "pnpm@10.11.0",
+        scripts: {
+          "release:pack:check": "old",
+          "test:ts": "node test.mjs"
+        }
+      })}\n`
+    );
+    runGit(["init", "--quiet"]);
+    runGit(["add", "."]);
+    runGit([
+      "-c",
+      "user.name=Test",
+      "-c",
+      "user.email=test@example.com",
+      "commit",
+      "--quiet",
+      "-m",
+      "init"
+    ]);
+
+    writeFileSync(
+      manifestPath,
+      `${JSON.stringify({
+        packageManager: "pnpm@10.11.0",
+        scripts: {
+          "release:pack:check": "new",
+          "test:ts": "node test.mjs"
+        }
+      })}\n`
+    );
+    assert.equal(
+      createRootManifestTestRelevance({
+        baseRef: "HEAD",
+        root
+      })(),
+      false
+    );
+
+    writeFileSync(
+      manifestPath,
+      `${JSON.stringify({
+        packageManager: "pnpm@10.11.0",
+        scripts: {
+          "release:pack:check": "new",
+          "test:ts": "node changed-test.mjs"
+        }
+      })}\n`
+    );
+    assert.equal(
+      createRootManifestTestRelevance({
+        baseRef: "HEAD",
+        root
+      })(),
+      true
+    );
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
 });
 
 test("repository check registry selects only relevant generated checks", () => {

--- a/tools/scripts/pr-checks-workflow.test.mjs
+++ b/tools/scripts/pr-checks-workflow.test.mjs
@@ -92,6 +92,7 @@ test("TypeScript Tests preserves its required context across package shards", ()
   );
   assert.match(testStep.run, /--packages-json/u);
   assert.match(testStep.run, /--shard/u);
+  assert.match(testStep.run, /--packages-json[^\n]*--shard/u);
   assert.equal(
     requireShardsStep.env.SHARDS_RESULT,
     "${{ needs.ts-test-shards.result }}"

--- a/tools/scripts/pr-checks-workflow.test.mjs
+++ b/tools/scripts/pr-checks-workflow.test.mjs
@@ -28,7 +28,13 @@ test("PR checks route repository groups through shared scripts", () => {
 });
 
 test("language jobs do not own repository checks", () => {
-  for (const jobName of ["ts-lint", "ts-tests", "go-tests", "go-lint"]) {
+  for (const jobName of [
+    "ts-lint",
+    "ts-test-shards",
+    "ts-tests",
+    "go-tests",
+    "go-lint"
+  ]) {
     assert.doesNotMatch(
       stepScripts(workflow.jobs[jobName]),
       /run-repository-checks|test:tools|pnpm check:/u,
@@ -53,6 +59,43 @@ test("package pack CI receives the classified package subset", () => {
     "${{ needs.changes.outputs.pack_packages }}"
   );
   assert.match(packStep.run, /--packages-json/u);
+});
+
+test("TypeScript Tests preserves its required context across package shards", () => {
+  const changes = workflow.jobs.changes;
+  const testJob = workflow.jobs["ts-tests"];
+  const shardJob = workflow.jobs["ts-test-shards"];
+  const testStep = shardJob.steps.find(
+    (step) => step.name === "Run TypeScript tests"
+  );
+  const requireShardsStep = testJob.steps.find(
+    (step) => step.name === "Require selected test shards"
+  );
+
+  assert.equal(testJob.name, "TypeScript Tests");
+  assert.equal(testJob.if, "always()");
+  assert.equal(
+    changes.outputs.test_packages,
+    "${{ steps.changed-files.outputs.test_packages }}"
+  );
+  assert.equal(
+    changes.outputs.test_shards,
+    "${{ steps.changed-files.outputs.test_shards }}"
+  );
+  assert.equal(
+    shardJob.strategy.matrix.shard,
+    "${{ fromJSON(needs.changes.outputs.test_shards) }}"
+  );
+  assert.equal(
+    testStep.env.TEST_PACKAGES,
+    "${{ needs.changes.outputs.test_packages }}"
+  );
+  assert.match(testStep.run, /--packages-json/u);
+  assert.match(testStep.run, /--shard/u);
+  assert.equal(
+    requireShardsStep.env.SHARDS_RESULT,
+    "${{ needs.ts-test-shards.result }}"
+  );
 });
 
 function stepScripts(job) {

--- a/tools/scripts/run-check-changed.mjs
+++ b/tools/scripts/run-check-changed.mjs
@@ -27,6 +27,7 @@ import {
 import {
   classifyChangedFiles,
   createPackageManifestPackRelevance,
+  createRootManifestTestRelevance,
   isPackagePackRelevantPath
 } from "./change-classification.mjs";
 import {
@@ -157,7 +158,11 @@ function buildChangedLanes() {
     root: workspaceRoot
   });
   const classification = classifyChangedFiles(changedFiles, {
-    isPackageManifestPackRelevant
+    isPackageManifestPackRelevant,
+    isRootManifestTestRelevant: createRootManifestTestRelevance({
+      baseRef,
+      root: workspaceRoot
+    })
   });
   const lanesByKey = new Map();
   const addLane = (lane) => {

--- a/tools/scripts/run-workspace-tests.mjs
+++ b/tools/scripts/run-workspace-tests.mjs
@@ -12,6 +12,8 @@ const workspaceRoot = join(scriptDirectory, "..", "..");
 
 if (isMainModule()) {
   const toolsOnly = process.argv.includes("--tools-only");
+  const packageNames = parseWorkspaceTestPackageFilters(process.argv.slice(2));
+  const shard = parseWorkspaceTestShard(process.argv.slice(2));
   const trackedFiles = gitLines([
     "ls-files",
     "--cached",
@@ -36,6 +38,12 @@ if (isMainModule()) {
     toolsOnly,
     trackedFiles
   });
+  const packageSelection = selectWorkspaceTestPackages(
+    plan.packages,
+    packageNames
+  );
+  plan.errors.push(...packageSelection.errors);
+  plan.packages = shardWorkspaceTestPackages(packageSelection.packages, shard);
 
   if (plan.errors.length > 0) {
     for (const error of plan.errors) {
@@ -116,6 +124,110 @@ export function buildWorkspaceTestPlan({
 
   packages.sort((left, right) => left.root.localeCompare(right.root));
   return { errors, packages, toolTests };
+}
+
+export function parseWorkspaceTestPackageFilters(args) {
+  let packageNames = null;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--" || arg === "--tools-only") {
+      continue;
+    }
+    if (arg === "--max-parallel" || arg === "--tail-lines") {
+      index += 1;
+      continue;
+    }
+    if (arg === "--shard") {
+      index += 1;
+      continue;
+    }
+    if (arg !== "--packages-json" || packageNames !== null) {
+      throw new Error(`unknown workspace test option: ${arg}`);
+    }
+    try {
+      packageNames = JSON.parse(args[++index] ?? "");
+    } catch {
+      throw new Error("--packages-json must contain valid JSON");
+    }
+  }
+  if (packageNames === null) {
+    return null;
+  }
+  if (
+    !Array.isArray(packageNames) ||
+    packageNames.length === 0 ||
+    packageNames.some((name) => typeof name !== "string" || name.length === 0)
+  ) {
+    throw new Error("--packages-json must contain a non-empty string array");
+  }
+  return [...new Set(packageNames)];
+}
+
+export function parseWorkspaceTestShard(args) {
+  let shard = null;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--shard") {
+      if (shard !== null) {
+        throw new Error("--shard may only be provided once");
+      }
+      const value = args[++index] ?? "";
+      const match = /^(\d+)\/(\d+)$/u.exec(value);
+      if (!match) {
+        throw new Error("--shard must use the positive index/total format");
+      }
+      const indexValue = Number.parseInt(match[1], 10);
+      const total = Number.parseInt(match[2], 10);
+      if (indexValue < 1 || total < 1 || indexValue > total) {
+        throw new Error("--shard index must be between 1 and its total");
+      }
+      shard = { index: indexValue, total };
+      continue;
+    }
+    if (arg === "--" || arg === "--tools-only" || arg === "--packages-json") {
+      if (arg === "--packages-json") {
+        index += 1;
+      }
+      continue;
+    }
+    if (arg === "--max-parallel" || arg === "--tail-lines") {
+      index += 1;
+      continue;
+    }
+  }
+  return shard;
+}
+
+export function selectWorkspaceTestPackages(packages, packageNames) {
+  if (packageNames === null) {
+    return { errors: [], packages };
+  }
+
+  const selectedNames = new Set(packageNames);
+  const packageNameSet = new Set(
+    packages.map((packageConfig) => packageConfig.name)
+  );
+  const unknownNames = packageNames.filter((name) => !packageNameSet.has(name));
+  return {
+    errors:
+      unknownNames.length === 0
+        ? []
+        : [
+            `Unknown workspace test package filter(s): ${unknownNames.join(", ")}`
+          ],
+    packages: packages.filter((packageConfig) =>
+      selectedNames.has(packageConfig.name)
+    )
+  };
+}
+
+export function shardWorkspaceTestPackages(packages, shard) {
+  if (shard === null) {
+    return packages;
+  }
+  return packages.filter(
+    (_packageConfig, index) => index % shard.total === shard.index - 1
+  );
 }
 
 function gitLines(args) {

--- a/tools/scripts/run-workspace-tests.mjs
+++ b/tools/scripts/run-workspace-tests.mjs
@@ -225,8 +225,30 @@ export function shardWorkspaceTestPackages(packages, shard) {
   if (shard === null) {
     return packages;
   }
-  return packages.filter(
-    (_packageConfig, index) => index % shard.total === shard.index - 1
+
+  const buckets = Array.from({ length: shard.total }, () => ({
+    packageNames: new Set(),
+    testFileCount: 0
+  }));
+  const packagesByWeight = packages
+    .map((packageConfig, index) => ({ index, packageConfig }))
+    .sort(
+      (left, right) =>
+        (right.packageConfig.testFileCount ?? 1) -
+          (left.packageConfig.testFileCount ?? 1) || left.index - right.index
+    );
+
+  for (const { packageConfig } of packagesByWeight) {
+    const bucket = buckets.reduce((lightest, candidate) =>
+      candidate.testFileCount < lightest.testFileCount ? candidate : lightest
+    );
+    bucket.packageNames.add(packageConfig.name);
+    bucket.testFileCount += packageConfig.testFileCount ?? 1;
+  }
+
+  const selectedNames = buckets[shard.index - 1].packageNames;
+  return packages.filter((packageConfig) =>
+    selectedNames.has(packageConfig.name)
   );
 }
 

--- a/tools/scripts/run-workspace-tests.test.mjs
+++ b/tools/scripts/run-workspace-tests.test.mjs
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { buildWorkspaceTestPlan } from "./run-workspace-tests.mjs";
+import {
+  buildWorkspaceTestPlan,
+  parseWorkspaceTestPackageFilters,
+  parseWorkspaceTestShard,
+  selectWorkspaceTestPackages,
+  shardWorkspaceTestPackages
+} from "./run-workspace-tests.mjs";
 
 test("workspace test plan discovers package tests without repository tools", () => {
   const plan = buildWorkspaceTestPlan({
@@ -66,4 +72,89 @@ test("tools-only plans skip package completeness checks", () => {
   assert.deepEqual(plan.errors, []);
   assert.deepEqual(plan.packages, []);
   assert.deepEqual(plan.toolTests, ["tools/scripts/example.test.mjs"]);
+});
+
+test("parses a workspace test package subset with runner options", () => {
+  assert.deepEqual(
+    parseWorkspaceTestPackageFilters([
+      "--",
+      "--max-parallel",
+      "1",
+      "--shard",
+      "1/3",
+      "--packages-json",
+      '["@tutti-os/agent-gui"]'
+    ]),
+    ["@tutti-os/agent-gui"]
+  );
+  assert.equal(parseWorkspaceTestPackageFilters([]), null);
+  assert.throws(
+    () => parseWorkspaceTestPackageFilters(["--packages-json", "not-json"]),
+    /valid JSON/u
+  );
+  assert.throws(
+    () => parseWorkspaceTestPackageFilters(["--packages", "agent-gui"]),
+    /unknown workspace test option/u
+  );
+});
+
+test("parses and validates a workspace test shard", () => {
+  assert.deepEqual(parseWorkspaceTestShard(["--shard", "2/3"]), {
+    index: 2,
+    total: 3
+  });
+  assert.equal(parseWorkspaceTestShard([]), null);
+  assert.throws(
+    () => parseWorkspaceTestShard(["--shard", "0/3"]),
+    /between 1/u
+  );
+  assert.throws(
+    () => parseWorkspaceTestShard(["--shard", "4/3"]),
+    /between 1/u
+  );
+  assert.throws(
+    () => parseWorkspaceTestShard(["--shard", "one"]),
+    /index\/total/u
+  );
+});
+
+test("selects only requested workspace test packages", () => {
+  const packages = [
+    { name: "@tutti-os/agent-gui", root: "packages/agent/gui" },
+    { name: "@tutti-os/ui-system", root: "packages/ui/system" }
+  ];
+
+  assert.deepEqual(
+    selectWorkspaceTestPackages(packages, ["@tutti-os/agent-gui"]),
+    {
+      errors: [],
+      packages: [packages[0]]
+    }
+  );
+  assert.deepEqual(
+    selectWorkspaceTestPackages(packages, ["@tutti-os/missing"]),
+    {
+      errors: ["Unknown workspace test package filter(s): @tutti-os/missing"],
+      packages: []
+    }
+  );
+});
+
+test("partitions workspace tests deterministically by plan order", () => {
+  const packages = [
+    { name: "one", root: "apps/one" },
+    { name: "two", root: "apps/two" },
+    { name: "three", root: "packages/three" },
+    { name: "four", root: "packages/four" }
+  ];
+
+  assert.deepEqual(
+    shardWorkspaceTestPackages(packages, { index: 1, total: 3 }),
+    [packages[0], packages[3]]
+  );
+  assert.deepEqual(
+    shardWorkspaceTestPackages(packages, { index: 2, total: 3 }),
+    [packages[1]]
+  );
+  assert.deepEqual(shardWorkspaceTestPackages(packages, null), packages);
 });

--- a/tools/scripts/run-workspace-tests.test.mjs
+++ b/tools/scripts/run-workspace-tests.test.mjs
@@ -158,3 +158,26 @@ test("partitions workspace tests deterministically by plan order", () => {
   );
   assert.deepEqual(shardWorkspaceTestPackages(packages, null), packages);
 });
+
+test("balances workspace test shards by package test file count", () => {
+  const packages = [
+    { name: "heavy", root: "apps/heavy", testFileCount: 100 },
+    { name: "medium", root: "apps/medium", testFileCount: 90 },
+    { name: "small-one", root: "packages/small-one", testFileCount: 30 },
+    { name: "small-two", root: "packages/small-two", testFileCount: 30 },
+    { name: "small-three", root: "packages/small-three", testFileCount: 30 }
+  ];
+
+  assert.deepEqual(
+    shardWorkspaceTestPackages(packages, { index: 1, total: 3 }),
+    [packages[0]]
+  );
+  assert.deepEqual(
+    shardWorkspaceTestPackages(packages, { index: 2, total: 3 }),
+    [packages[1]]
+  );
+  assert.deepEqual(
+    shardWorkspaceTestPackages(packages, { index: 3, total: 3 }),
+    packages.slice(2)
+  );
+});


### PR DESCRIPTION
## Summary
- select TypeScript package tests from changed workspace packages and their transitive dependents
- keep tool-only changes as a passing no-op for the stable `TypeScript Tests` required context
- split selected packages across at most three serial-per-runner CI shards
- greedily balance shards by discovered test file count instead of package count

## Tests
- `node --test tools/scripts/change-classification.test.mjs tools/scripts/run-workspace-tests.test.mjs tools/scripts/pr-checks-workflow.test.mjs tools/scripts/run-check-changed.test.mjs`
- `pnpm test:tools`
- `pnpm test:ts -- --packages-json '["@tutti-os/analytics","@tutti-os/analytics-debug"]' --shard 1/2`
- `pnpm test:ts -- --packages-json '["@tutti-os/analytics","@tutti-os/analytics-debug"]' --shard 2/2`
- full-plan shard audit: 30/30 packages covered, 0 duplicates, test-file weights 301/300/300
- pre-push: `pnpm check:changed -- --push-ready`

## Notes
- full-suite changes produce three shards; package-local changes use only as many shards as selected packages
- the historical #1771 change set now classifies with `run_ts_tests=false`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
