### PR TITLE
fix(agent): report exact session fork boundary failures

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -1912,6 +1912,42 @@ test("desktop agent activity adapter classifies an ambiguous POST failure as del
   );
 });
 
+test("desktop agent activity adapter promotes the exact fork boundary reason", async () => {
+  const adapter = createDesktopAgentActivityAdapter({
+    tuttidClient: createTuttidClient({
+      async forkWorkspaceAgentSession() {
+        throw new TuttidProtocolError({
+          code: "workspace_operation_failed",
+          developerMessage:
+            "agent session fork turn is not a verified settled boundary: selected turn sequence provenance is legacy_unverified",
+          params: {
+            forkBoundaryReason: "agent_session_fork_turn_sequence_unverified"
+          },
+          reason: "agent_session_fork_conflict",
+          statusCode: 409
+        });
+      }
+    }),
+    runtimeApi: createRuntimeApi()
+  });
+
+  await assert.rejects(
+    adapter.forkSession({
+      requestId: "fork-request",
+      sourceAgentSessionId: "source-session",
+      targetAgentSessionId: "target-session",
+      turnId: "source-turn",
+      workspaceId
+    }),
+    (error: unknown) =>
+      error instanceof TuttidProtocolError &&
+      error.reason === "agent_session_fork_turn_sequence_unverified" &&
+      error.params.forkBoundaryReason ===
+        "agent_session_fork_turn_sequence_unverified" &&
+      error.message.includes("legacy_unverified")
+  );
+});
+
 test("desktop agent activity adapter classifies an aborted POST as delivery unknown", async () => {
   const controller = new AbortController();
   const adapter = createDesktopAgentActivityAdapter({

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -26,7 +26,10 @@ import type {
   WorkspaceAgentSessionForkOperation,
   WorkspaceAgentProvider
 } from "@tutti-os/client-tuttid-ts";
-import { isTuttidProtocolError } from "@tutti-os/client-tuttid-ts";
+import {
+  isTuttidProtocolError,
+  TuttidProtocolError
+} from "@tutti-os/client-tuttid-ts";
 import type { DesktopRuntimeApi } from "@preload/types";
 import { getActiveLocale } from "../../../i18n/runtime.ts";
 import { wrapLocalizedTuttidErrorIfSpecific } from "../../../lib/desktopErrors.ts";
@@ -520,7 +523,9 @@ export function createDesktopAgentActivityAdapter({
           { signal: input.signal }
         );
       } catch (error) {
-        if (isTuttidProtocolError(error)) throw error;
+        if (isTuttidProtocolError(error)) {
+          throw sessionForkProtocolError(error);
+        }
         throw sessionForkDeliveryUnknownError(error);
       }
       const operation = await waitForWorkspaceAgentSessionForkOperation(
@@ -615,6 +620,28 @@ function sessionForkDeliveryUnknownError(error: unknown): Error {
     ),
     { reason: "agent_session_fork_delivery_unknown" }
   );
+}
+
+function sessionForkProtocolError(
+  error: TuttidProtocolError
+): TuttidProtocolError {
+  const boundaryReason = error.params.forkBoundaryReason;
+  if (
+    typeof boundaryReason !== "string" ||
+    !boundaryReason.trim() ||
+    error.reason !== "agent_session_fork_conflict"
+  ) {
+    return error;
+  }
+  return new TuttidProtocolError({
+    code: error.code,
+    correlationId: error.correlationId,
+    developerMessage: error.developerMessage,
+    params: error.params,
+    reason: boundaryReason.trim(),
+    retryable: error.retryable,
+    statusCode: error.statusCode
+  });
 }
 
 function agentActivityForkSessionResult(

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -82,6 +82,7 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 - [Claude Code starts another command after Stop](./agent-session-lifecycle.md#claude-code-starts-another-command-after-stop)
 - [AgentGUI freezes when session history is large](./agent-session-lifecycle.md#agentgui-freezes-when-session-history-is-large)
 - [AgentGUI @ Sessions tab is empty](./agent-session-lifecycle.md#agentgui--sessions-tab-is-empty)
+- [Fork reports only `agent_session_fork_conflict`](./agent-session-lifecycle.md#fork-reports-only-agent_session_fork_conflict)
 - [Agent diagnostics flood while a turn is streaming](./agent-session-lifecycle.md#agent-diagnostics-flood-while-a-turn-is-streaming)
 - [Codex turn stays working before any reply or tool activity](./agent-session-lifecycle.md#codex-turn-stays-working-before-any-reply-or-tool-activity)
 - [Codex WebSocket reconnect rejects a long prompt metadata header](./agent-session-lifecycle.md#codex-websocket-reconnect-rejects-a-long-prompt-metadata-header)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -2114,6 +2114,45 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   [claude_sdk_fork.go](../../../packages/agent/daemon/runtime/claude_sdk_fork.go)
   [session_fork.go](../../../packages/agent/host/session_fork.go)
 
+### Fork reports only `agent_session_fork_conflict`
+
+- Symptom:
+  A through-Turn Fork returns HTTP 409 before any provider `thread/fork`
+  request. Desktop diagnostics contain only
+  `reason=agent_session_fork_conflict` or a developer-message length, so
+  provenance, attachment, descendant-lane, and provider-Turn failures are
+  indistinguishable.
+- Quick checks:
+  Read `error.params.forkBoundaryReason` from the 409 response or the promoted
+  Desktop diagnostic `reason`. For example,
+  `agent_session_fork_turn_sequence_unverified` means the selected Turn has
+  unverified sequence provenance, while
+  `agent_session_fork_prefix_sequence_unverified` identifies an earlier Turn
+  in the inclusive prefix. The developer message carries the observed phase,
+  provenance, sequence, or identity condition without message content.
+- Root cause:
+  `CheckSessionForkThroughTurn` collapsed every fail-closed boundary branch to
+  `supported=false`; Host replaced it with one generic Turn-state error, and
+  the service formatted the nested error with `%v`, which discarded the error
+  chain before transport classification.
+- Fix:
+  Preserve one stable boundary rejection reason from the Store through Host
+  and Service. Keep the public 409 reason
+  `agent_session_fork_conflict` for compatibility, add the exact stable code
+  as `error.params.forkBoundaryReason`, and promote that code only for Desktop
+  diagnostics. Do not log transcript payloads or attachment contents.
+- Validation:
+  Cover unverified selected/prefix sequences, duplicate provider Turn IDs,
+  descendant lanes, and session-local attachments at the Store. Verify Service
+  wrapping preserves both the generic conflict and typed boundary error, the
+  API includes the structured parameter, and Desktop promotes it to the
+  diagnostic reason.
+- References:
+  [session_fork.go](../../../packages/agent/store-sqlite/session_fork.go)
+  [session_fork_types.go](../../../packages/agent/store-sqlite/session_fork_types.go)
+  [daemon_agent_session_fork.go](../../../services/tuttid/api/daemon_agent_session_fork.go)
+  [desktopAgentActivityAdapter.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts)
+
 ### Claude Code cancel leaves Write/tool cards or thinking stuck in progress
 
 - Symptom:

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -178,6 +178,10 @@ dispatch; an existing live observation bypasses preparation. Consumers hide
 settled Turn actions when that capability is absent.
 Boundary validity remains a separate transactional proof, so an unavailable
 latest Turn does not suppress an earlier valid boundary.
+Every fail-closed boundary rejection retains a stable, content-free reason
+through Host. HTTP adapters may project it as structured diagnostic metadata
+while preserving their existing coarse conflict reason; transcript payloads
+and attachment contents never enter that reason.
 
 Fork uses a durable `prepared -> dispatching -> provider_accepted -> committed`
 saga. `RequestID` is the replay key. A source fence serializes the snapshot

--- a/packages/agent/host/session_fork.go
+++ b/packages/agent/host/session_fork.go
@@ -100,6 +100,9 @@ func (h *Host) forkSessionSerialized(
 		return ForkSessionResult{}, err
 	}
 	if !supported {
+		if rejectionErr := boundary.RejectionError(); rejectionErr != nil {
+			return ForkSessionResult{}, rejectionErr
+		}
 		return ForkSessionResult{}, storesqlite.ErrSessionForkTurnState
 	}
 	runtimeSource, err := h.sessionForkRuntimeSource(ctx, boundary.Session)
@@ -383,9 +386,13 @@ func (h *Host) processSessionForkOperationWithSource(
 		)
 	}
 	if !supported {
+		cause := storesqlite.ErrSessionForkTurnState
+		if rejectionErr := boundary.RejectionError(); rejectionErr != nil {
+			cause = rejectionErr
+		}
 		return failBeforeDispatch(
 			"canonical through-turn boundary is no longer forkable",
-			storesqlite.ErrSessionForkTurnState,
+			cause,
 		)
 	}
 	var source ProviderRuntimeSession

--- a/packages/agent/host/session_fork_test.go
+++ b/packages/agent/host/session_fork_test.go
@@ -773,6 +773,8 @@ func TestForkSessionDistinguishesMissingSourceFromUnavailableBoundary(t *testing
 	t.Run("unavailable boundary", func(t *testing.T) {
 		store := newFakeSessionForkStore()
 		store.boundaryUnsupported = true
+		store.boundaryReason =
+			storesqlite.SessionForkBoundaryReasonTurnSequenceUnverified
 		runtime := &fakeSessionForkRuntime{}
 		host := New(Config{SessionForks: store, SessionForkRuntime: runtime})
 		_, err := host.ForkSession(context.Background(), ForkSessionInput{
@@ -782,6 +784,12 @@ func TestForkSessionDistinguishesMissingSourceFromUnavailableBoundary(t *testing
 		})
 		if !errors.Is(err, storesqlite.ErrSessionForkTurnState) {
 			t.Fatalf("ForkSession() error=%v, want boundary conflict", err)
+		}
+		var reasoner interface{ ForkBoundaryReason() string }
+		if !errors.As(err, &reasoner) ||
+			reasoner.ForkBoundaryReason() !=
+				string(storesqlite.SessionForkBoundaryReasonTurnSequenceUnverified) {
+			t.Fatalf("ForkSession() boundary reason=%v", err)
 		}
 		if runtime.resolveCalls != 0 || runtime.forkCalls != 0 {
 			t.Fatalf("runtime calls resolve=%d fork=%d", runtime.resolveCalls, runtime.forkCalls)
@@ -946,6 +954,7 @@ type fakeSessionForkStore struct {
 	failCommit          bool
 	sourceMissing       bool
 	boundaryUnsupported bool
+	boundaryReason      storesqlite.SessionForkBoundaryReason
 	source              storesqlite.Session
 	turnIdentities      []storesqlite.SessionForkTurnIdentity
 }
@@ -1021,7 +1030,9 @@ func (f *fakeSessionForkStore) CheckSessionForkThroughTurn(
 	context.Context, string, string, string,
 ) (storesqlite.SessionForkBoundary, bool, error) {
 	if f.boundaryUnsupported {
-		return storesqlite.SessionForkBoundary{}, false, nil
+		return storesqlite.SessionForkBoundary{
+			RejectionReason: f.boundaryReason,
+		}, false, nil
 	}
 	return storesqlite.SessionForkBoundary{
 		Session: f.session(),

--- a/packages/agent/store-sqlite/session_fork.go
+++ b/packages/agent/store-sqlite/session_fork.go
@@ -147,28 +147,45 @@ SELECT EXISTS(
 		return SessionForkOperation{}, false, err
 	}
 	if !found {
-		return SessionForkOperation{}, false, ErrSessionForkTurnState
+		return SessionForkOperation{}, false, newSessionForkBoundaryError(
+			SessionForkBoundaryReasonTurnNotFound,
+			"selected turn does not exist in the source session",
+		)
 	}
 	if err := tx.QueryRowContext(ctx, `
 SELECT turn_sequence, provenance
 FROM workspace_agent_turn_sequences
 WHERE workspace_id = ? AND agent_session_id = ? AND turn_id = ?
-`, input.WorkspaceID, input.SourceAgentSessionID, input.SourceTurnID).Scan(&selectedSequence, &selectedProvenance); err != nil {
+	`, input.WorkspaceID, input.SourceAgentSessionID, input.SourceTurnID).Scan(&selectedSequence, &selectedProvenance); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return SessionForkOperation{}, false, ErrSessionForkTurnState
+			return SessionForkOperation{}, false, newSessionForkBoundaryError(
+				SessionForkBoundaryReasonTurnSequenceMissing,
+				"selected turn has no canonical turn sequence",
+			)
 		}
 		return SessionForkOperation{}, false, fmt.Errorf("read session fork turn sequence: %w", err)
 	}
-	if selected.Phase != TurnPhaseSettled || !isVerifiedSessionForkSequence(selectedProvenance) ||
-		strings.TrimSpace(selected.RootProviderTurnID) == "" {
-		return SessionForkOperation{}, false, ErrSessionForkTurnState
+	if err := sessionForkSelectedTurnStateError(selected, selectedProvenance); err != nil {
+		return SessionForkOperation{}, false, err
+	}
+	if err := invalidSessionForkPrefixErrorTx(
+		ctx,
+		tx,
+		input.WorkspaceID,
+		input.SourceAgentSessionID,
+		selectedSequence,
+	); err != nil {
+		return SessionForkOperation{}, false, err
 	}
 	if descendants, err := hasSessionForkDescendantsTx(
 		ctx, tx, input.WorkspaceID, input.SourceAgentSessionID, selectedSequence,
 	); err != nil {
 		return SessionForkOperation{}, false, err
 	} else if descendants {
-		return SessionForkOperation{}, false, ErrSessionForkTurnState
+		return SessionForkOperation{}, false, newSessionForkBoundaryError(
+			SessionForkBoundaryReasonDescendantLaneUnsupported,
+			"fork boundary contains a provider-native descendant lane",
+		)
 	}
 	snapshot, err := loadSessionForkSnapshotTx(ctx, tx, source, selectedSequence, 0)
 	if err != nil {
@@ -188,7 +205,10 @@ WHERE workspace_id = ? AND agent_session_id = ? AND turn_id = ?
 		// through-Turn resource manifest. Never copy the whole source
 		// namespace because it can contain resources created after the
 		// selected boundary.
-		return SessionForkOperation{}, false, ErrSessionForkTurnState
+		return SessionForkOperation{}, false, newSessionForkBoundaryError(
+			SessionForkBoundaryReasonAttachmentUnsupported,
+			"fork boundary contains a session-local attachment reference",
+		)
 	}
 	snapshot.TargetCwd = strings.TrimSpace(input.TargetCwd)
 	snapshot.TargetRuntimeContext = cloneJSONMap(input.TargetRuntimeContext)
@@ -210,7 +230,10 @@ WHERE workspace_id = ? AND agent_session_id = ? AND turn_id = ?
 	}
 	snapshotHash := hashSessionForkBytes(snapshotJSON)
 	if len(snapshot.Turns) == 0 || snapshot.Turns[len(snapshot.Turns)-1].Turn.TurnID != input.SourceTurnID {
-		return SessionForkOperation{}, false, ErrSessionForkTurnState
+		return SessionForkOperation{}, false, newSessionForkBoundaryError(
+			SessionForkBoundaryReasonProviderTurnBoundaryMismatch,
+			"canonical snapshot does not end at the selected turn",
+		)
 	}
 
 	var targetExists int
@@ -429,9 +452,23 @@ func (s *Store) CheckSessionForkThroughTurn(
 	if err != nil || !found {
 		return SessionForkBoundary{}, false, err
 	}
-	if session.Kind != SessionKindRoot || session.ActiveTurnID != "" ||
-		strings.TrimSpace(session.ProviderSessionID) == "" {
-		return SessionForkBoundary{}, false, nil
+	if session.Kind != SessionKindRoot {
+		return rejectedSessionForkBoundary(
+			SessionForkBoundaryReasonSourceNotRoot,
+			fmt.Sprintf("source session kind is %q, want %q", session.Kind, SessionKindRoot),
+		), false, nil
+	}
+	if session.ActiveTurnID != "" {
+		return rejectedSessionForkBoundary(
+			SessionForkBoundaryReasonSourceActiveTurn,
+			"source session has an active turn",
+		), false, nil
+	}
+	if strings.TrimSpace(session.ProviderSessionID) == "" {
+		return rejectedSessionForkBoundary(
+			SessionForkBoundaryReasonProviderSessionMissing,
+			"source session has no provider session id",
+		), false, nil
 	}
 	var pendingInteractions int
 	if err := tx.QueryRowContext(ctx, `
@@ -443,57 +480,54 @@ SELECT EXISTS(
 		return SessionForkBoundary{}, false, err
 	}
 	if pendingInteractions != 0 {
-		return SessionForkBoundary{}, false, nil
+		return rejectedSessionForkBoundary(
+			SessionForkBoundaryReasonPendingInteraction,
+			"source session has a pending interaction",
+		), false, nil
 	}
 	if err := requireSessionForkSourceQuiescentTx(ctx, tx, workspaceID, sourceSessionID); err != nil {
 		if errors.Is(err, ErrSessionForkSourceState) {
-			return SessionForkBoundary{}, false, nil
+			return rejectedSessionForkBoundary(
+				SessionForkBoundaryReasonSourceNotQuiescent,
+				"source session has unfinished goal, runtime, reconcile, or submit work",
+			), false, nil
 		}
 		return SessionForkBoundary{}, false, err
 	}
 	turn, found, err := getAgentTurnTx(ctx, tx, workspaceID, sourceSessionID, throughTurnID)
-	if err != nil || !found {
+	if err != nil {
 		return SessionForkBoundary{}, false, err
+	}
+	if !found {
+		return rejectedSessionForkBoundary(
+			SessionForkBoundaryReasonTurnNotFound,
+			"selected turn does not exist in the source session",
+		), false, nil
 	}
 	var sequence int64
 	var provenance string
 	if err := tx.QueryRowContext(ctx, `
 SELECT turn_sequence, provenance FROM workspace_agent_turn_sequences
 WHERE workspace_id = ? AND agent_session_id = ? AND turn_id = ?
-`, workspaceID, sourceSessionID, throughTurnID).Scan(&sequence, &provenance); err != nil {
+	`, workspaceID, sourceSessionID, throughTurnID).Scan(&sequence, &provenance); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return SessionForkBoundary{}, false, nil
+			return rejectedSessionForkBoundary(
+				SessionForkBoundaryReasonTurnSequenceMissing,
+				"selected turn has no canonical turn sequence",
+			), false, nil
 		}
 		return SessionForkBoundary{}, false, err
 	}
-	if turn.Phase != TurnPhaseSettled || !isVerifiedSessionForkSequence(provenance) ||
-		strings.TrimSpace(turn.RootProviderTurnID) == "" {
-		return SessionForkBoundary{}, false, nil
+	if err := sessionForkSelectedTurnStateError(turn, provenance); err != nil {
+		return rejectedSessionForkBoundaryFromError(err), false, nil
 	}
-	var invalidPrefix int
-	if err := tx.QueryRowContext(ctx, `
-SELECT EXISTS(
-  SELECT 1
-  FROM workspace_agent_turn_sequences sequence
-  LEFT JOIN workspace_agent_turns turn
-    ON turn.workspace_id = sequence.workspace_id
-   AND turn.agent_session_id = sequence.agent_session_id
-   AND turn.turn_id = sequence.turn_id
-  WHERE sequence.workspace_id = ?
-    AND sequence.agent_session_id = ?
-    AND sequence.turn_sequence <= ?
-    AND (
-      sequence.provenance NOT IN ('verified','fork_clone_verified')
-      OR turn.turn_id IS NULL
-      OR turn.phase <> ?
-      OR COALESCE(turn.root_provider_turn_id, '') = ''
-    )
-)
-`, workspaceID, sourceSessionID, sequence, TurnPhaseSettled).Scan(&invalidPrefix); err != nil {
+	if err := invalidSessionForkPrefixErrorTx(
+		ctx, tx, workspaceID, sourceSessionID, sequence,
+	); err != nil {
+		if errors.Is(err, ErrSessionForkTurnState) {
+			return rejectedSessionForkBoundaryFromError(err), false, nil
+		}
 		return SessionForkBoundary{}, false, err
-	}
-	if invalidPrefix != 0 {
-		return SessionForkBoundary{}, false, nil
 	}
 	providerTurnRows, err := tx.QueryContext(ctx, `
 SELECT turn.root_provider_turn_id
@@ -521,11 +555,17 @@ ORDER BY sequence.turn_sequence
 		providerTurnID = strings.TrimSpace(providerTurnID)
 		if providerTurnID == "" {
 			providerTurnRows.Close()
-			return SessionForkBoundary{}, false, nil
+			return rejectedSessionForkBoundary(
+				SessionForkBoundaryReasonPrefixProviderTurnMissing,
+				"canonical turn prefix contains an empty root provider turn id",
+			), false, nil
 		}
 		if _, exists := seenRootProviderTurnIDs[providerTurnID]; exists {
 			providerTurnRows.Close()
-			return SessionForkBoundary{}, false, nil
+			return rejectedSessionForkBoundary(
+				SessionForkBoundaryReasonProviderTurnDuplicate,
+				fmt.Sprintf("root provider turn id %q appears more than once", providerTurnID),
+			), false, nil
 		}
 		seenRootProviderTurnIDs[providerTurnID] = struct{}{}
 		rootProviderTurnIDs = append(rootProviderTurnIDs, providerTurnID)
@@ -539,14 +579,20 @@ ORDER BY sequence.turn_sequence
 	}
 	if len(rootProviderTurnIDs) == 0 ||
 		rootProviderTurnIDs[len(rootProviderTurnIDs)-1] != strings.TrimSpace(turn.RootProviderTurnID) {
-		return SessionForkBoundary{}, false, nil
+		return rejectedSessionForkBoundary(
+			SessionForkBoundaryReasonProviderTurnBoundaryMismatch,
+			"ordered root provider turn prefix does not end at the selected turn",
+		), false, nil
 	}
 	if descendants, err := hasSessionForkDescendantsTx(
 		ctx, tx, workspaceID, sourceSessionID, sequence,
 	); err != nil {
 		return SessionForkBoundary{}, false, err
 	} else if descendants {
-		return SessionForkBoundary{}, false, nil
+		return rejectedSessionForkBoundary(
+			SessionForkBoundaryReasonDescendantLaneUnsupported,
+			"fork boundary contains a provider-native descendant lane",
+		), false, nil
 	}
 	var boundaryMessageID int64
 	if err := tx.QueryRowContext(ctx, `
@@ -564,7 +610,10 @@ WHERE message.workspace_id = ?
 		return SessionForkBoundary{}, false, err
 	}
 	if boundaryMessageID <= 0 {
-		return SessionForkBoundary{}, false, nil
+		return rejectedSessionForkBoundary(
+			SessionForkBoundaryReasonBoundaryMessagesMissing,
+			"fork boundary contains no canonical messages",
+		), false, nil
 	}
 	var unsupportedTurnless int
 	if err := tx.QueryRowContext(ctx, `
@@ -582,7 +631,10 @@ SELECT EXISTS(
 		return SessionForkBoundary{}, false, err
 	}
 	if unsupportedTurnless != 0 {
-		return SessionForkBoundary{}, false, nil
+		return rejectedSessionForkBoundary(
+			SessionForkBoundaryReasonTurnlessMessageUnsupported,
+			"fork boundary contains a non-audit message without a turn",
+		), false, nil
 	}
 	var attachmentReferences int
 	if err := tx.QueryRowContext(ctx, `
@@ -616,7 +668,10 @@ SELECT EXISTS(
 		return SessionForkBoundary{}, false, err
 	}
 	if attachmentReferences != 0 {
-		return SessionForkBoundary{}, false, nil
+		return rejectedSessionForkBoundary(
+			SessionForkBoundaryReasonAttachmentUnsupported,
+			"fork boundary contains a session-local attachment reference",
+		), false, nil
 	}
 	return SessionForkBoundary{
 		Session:             session,

--- a/packages/agent/store-sqlite/session_fork_boundary_validation.go
+++ b/packages/agent/store-sqlite/session_fork_boundary_validation.go
@@ -1,0 +1,119 @@
+package storesqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+func sessionForkSelectedTurnStateError(turn Turn, provenance string) error {
+	switch {
+	case turn.Phase != TurnPhaseSettled:
+		return newSessionForkBoundaryError(
+			SessionForkBoundaryReasonTurnNotSettled,
+			fmt.Sprintf("selected turn phase is %q, want %q", turn.Phase, TurnPhaseSettled),
+		)
+	case !isVerifiedSessionForkSequence(provenance):
+		return newSessionForkBoundaryError(
+			SessionForkBoundaryReasonTurnSequenceUnverified,
+			fmt.Sprintf("selected turn sequence provenance is %q", provenance),
+		)
+	case strings.TrimSpace(turn.RootProviderTurnID) == "":
+		return newSessionForkBoundaryError(
+			SessionForkBoundaryReasonProviderTurnMissing,
+			"selected turn has no root provider turn id",
+		)
+	default:
+		return nil
+	}
+}
+
+func invalidSessionForkPrefixErrorTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	workspaceID, sourceSessionID string,
+	throughSequence int64,
+) error {
+	var turnID, provenance, phase, providerTurnID string
+	var sequence int64
+	err := tx.QueryRowContext(ctx, `
+SELECT sequence.turn_id, sequence.turn_sequence, sequence.provenance,
+       COALESCE(turn.phase, ''), COALESCE(turn.root_provider_turn_id, '')
+FROM workspace_agent_turn_sequences sequence
+LEFT JOIN workspace_agent_turns turn
+  ON turn.workspace_id = sequence.workspace_id
+ AND turn.agent_session_id = sequence.agent_session_id
+ AND turn.turn_id = sequence.turn_id
+WHERE sequence.workspace_id = ?
+  AND sequence.agent_session_id = ?
+  AND sequence.turn_sequence <= ?
+  AND (
+    sequence.provenance NOT IN ('verified','fork_clone_verified')
+    OR turn.turn_id IS NULL
+    OR turn.phase <> ?
+    OR COALESCE(turn.root_provider_turn_id, '') = ''
+  )
+ORDER BY sequence.turn_sequence
+LIMIT 1
+`, workspaceID, sourceSessionID, throughSequence, TurnPhaseSettled).Scan(
+		&turnID,
+		&sequence,
+		&provenance,
+		&phase,
+		&providerTurnID,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read invalid session fork prefix: %w", err)
+	}
+	switch {
+	case phase == "":
+		return newSessionForkBoundaryError(
+			SessionForkBoundaryReasonPrefixTurnMissing,
+			fmt.Sprintf("turn sequence %d references missing turn %q", sequence, turnID),
+		)
+	case !isVerifiedSessionForkSequence(provenance):
+		return newSessionForkBoundaryError(
+			SessionForkBoundaryReasonPrefixSequenceUnverified,
+			fmt.Sprintf(
+				"turn %q at sequence %d has provenance %q",
+				turnID,
+				sequence,
+				provenance,
+			),
+		)
+	case phase != TurnPhaseSettled:
+		return newSessionForkBoundaryError(
+			SessionForkBoundaryReasonPrefixTurnNotSettled,
+			fmt.Sprintf(
+				"turn %q at sequence %d has phase %q",
+				turnID,
+				sequence,
+				phase,
+			),
+		)
+	case strings.TrimSpace(providerTurnID) == "":
+		return newSessionForkBoundaryError(
+			SessionForkBoundaryReasonPrefixProviderTurnMissing,
+			fmt.Sprintf(
+				"turn %q at sequence %d has no root provider turn id",
+				turnID,
+				sequence,
+			),
+		)
+	default:
+		return nil
+	}
+}
+
+func rejectedSessionForkBoundaryFromError(err error) SessionForkBoundary {
+	var boundaryErr *SessionForkBoundaryError
+	if !errors.As(err, &boundaryErr) {
+		return SessionForkBoundary{}
+	}
+	return rejectedSessionForkBoundary(boundaryErr.Reason, boundaryErr.detail)
+}

--- a/packages/agent/store-sqlite/session_fork_snapshot.go
+++ b/packages/agent/store-sqlite/session_fork_snapshot.go
@@ -48,9 +48,47 @@ ORDER BY turn_sequence
 		if err != nil {
 			return snapshot, err
 		}
-		if !found || !isVerifiedSessionForkSequence(boundary.provenance) ||
-			turn.Phase != TurnPhaseSettled || strings.TrimSpace(turn.RootProviderTurnID) == "" {
-			return snapshot, ErrSessionForkTurnState
+		if !found {
+			return snapshot, newSessionForkBoundaryError(
+				SessionForkBoundaryReasonPrefixTurnMissing,
+				fmt.Sprintf(
+					"turn sequence %d references missing turn %q",
+					boundary.sequence,
+					boundary.turnID,
+				),
+			)
+		}
+		if !isVerifiedSessionForkSequence(boundary.provenance) {
+			return snapshot, newSessionForkBoundaryError(
+				SessionForkBoundaryReasonPrefixSequenceUnverified,
+				fmt.Sprintf(
+					"turn %q at sequence %d has provenance %q",
+					boundary.turnID,
+					boundary.sequence,
+					boundary.provenance,
+				),
+			)
+		}
+		if turn.Phase != TurnPhaseSettled {
+			return snapshot, newSessionForkBoundaryError(
+				SessionForkBoundaryReasonPrefixTurnNotSettled,
+				fmt.Sprintf(
+					"turn %q at sequence %d has phase %q",
+					boundary.turnID,
+					boundary.sequence,
+					turn.Phase,
+				),
+			)
+		}
+		if strings.TrimSpace(turn.RootProviderTurnID) == "" {
+			return snapshot, newSessionForkBoundaryError(
+				SessionForkBoundaryReasonPrefixProviderTurnMissing,
+				fmt.Sprintf(
+					"turn %q at sequence %d has no root provider turn id",
+					boundary.turnID,
+					boundary.sequence,
+				),
+			)
 		}
 		snapshot.Turns = append(snapshot.Turns, sessionForkTurnSnapshot{Sequence: boundary.sequence, Turn: turn})
 	}
@@ -72,7 +110,10 @@ WHERE message.workspace_id = ?
 		}
 	}
 	if boundaryMessageID <= 0 {
-		return snapshot, ErrSessionForkTurnState
+		return snapshot, newSessionForkBoundaryError(
+			SessionForkBoundaryReasonBoundaryMessagesMissing,
+			"fork boundary contains no canonical messages",
+		)
 	}
 	snapshot.BoundaryMessageID = boundaryMessageID
 	var unsupportedTurnless int
@@ -91,7 +132,10 @@ SELECT EXISTS(
 		return snapshot, fmt.Errorf("read unsupported turnless session fork messages: %w", err)
 	}
 	if unsupportedTurnless != 0 {
-		return snapshot, ErrSessionForkTurnState
+		return snapshot, newSessionForkBoundaryError(
+			SessionForkBoundaryReasonTurnlessMessageUnsupported,
+			"fork boundary contains a non-audit message without a turn",
+		)
 	}
 	messageRows, err := tx.QueryContext(ctx, `
 SELECT message.id, message.agent_session_id, message.message_id, message.version,

--- a/packages/agent/store-sqlite/session_fork_test.go
+++ b/packages/agent/store-sqlite/session_fork_test.go
@@ -791,7 +791,8 @@ WHERE workspace_id = 'ws-1' AND agent_session_id = 'source' AND turn_id = 'turn-
 		"ws-1",
 		"source",
 		"turn-2",
-	); err != nil || supported || len(boundary.RootProviderTurnIDs) != 0 {
+	); err != nil || supported || len(boundary.RootProviderTurnIDs) != 0 ||
+		boundary.RejectionReason != SessionForkBoundaryReasonProviderTurnDuplicate {
 		t.Fatalf(
 			"duplicate provider turn prefix boundary=%#v supported=%v error=%v",
 			boundary,
@@ -850,15 +851,25 @@ WHERE workspace_id = 'ws-1' AND agent_session_id = 'source' AND turn_id = 'turn-
 `); err != nil {
 		t.Fatal(err)
 	}
-	if _, supported, err := store.CheckSessionForkThroughTurn(ctx, "ws-1", "source", "turn-1"); err != nil || supported {
-		t.Fatalf("CheckSessionForkThroughTurn() supported=%v error=%v", supported, err)
+	if boundary, supported, err := store.CheckSessionForkThroughTurn(
+		ctx, "ws-1", "source", "turn-1",
+	); err != nil || supported ||
+		boundary.RejectionReason != SessionForkBoundaryReasonTurnSequenceUnverified {
+		t.Fatalf(
+			"CheckSessionForkThroughTurn() boundary=%#v supported=%v error=%v",
+			boundary,
+			supported,
+			err,
+		)
 	}
 	if _, _, err := prepareSessionForkForTest(t, store, ctx, SessionForkPrepare{
 		OperationID: "fork-op", WorkspaceID: "ws-1", RequestID: "request-1",
 		RequestHash: "hash-1", SourceAgentSessionID: "source",
 		TargetAgentSessionID: "target", SourceTurnID: "turn-1",
 		DriverKind: "codex", DriverVersion: "1", OccurredAtUnixMS: 100,
-	}); !errors.Is(err, ErrSessionForkTurnState) {
+	}); !errors.Is(err, ErrSessionForkTurnState) ||
+		sessionForkBoundaryReasonForTest(err) != SessionForkBoundaryReasonTurnSequenceUnverified ||
+		!strings.Contains(err.Error(), `provenance is "legacy_unverified"`) {
 		t.Fatalf("PrepareSessionFork() error=%v", err)
 	}
 }
@@ -882,10 +893,16 @@ func TestSessionForkThroughTurnFailsClosedForLocalAttachmentReferences(t *testin
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if _, supported, err := store.CheckSessionForkThroughTurn(
+	if boundary, supported, err := store.CheckSessionForkThroughTurn(
 		ctx, "ws-1", "source", "turn-1",
-	); err != nil || supported {
-		t.Fatalf("CheckSessionForkThroughTurn() supported=%v error=%v", supported, err)
+	); err != nil || supported ||
+		boundary.RejectionReason != SessionForkBoundaryReasonAttachmentUnsupported {
+		t.Fatalf(
+			"CheckSessionForkThroughTurn() boundary=%#v supported=%v error=%v",
+			boundary,
+			supported,
+			err,
+		)
 	}
 	if _, _, err := prepareSessionForkForTest(t, store, ctx, SessionForkPrepare{
 		OperationID: "fork-attachment", WorkspaceID: "ws-1",
@@ -893,7 +910,8 @@ func TestSessionForkThroughTurnFailsClosedForLocalAttachmentReferences(t *testin
 		SourceAgentSessionID: "source", TargetAgentSessionID: "target-attachment",
 		SourceTurnID: "turn-1", DriverKind: "codex", DriverVersion: "1",
 		OccurredAtUnixMS: 100,
-	}); !errors.Is(err, ErrSessionForkTurnState) {
+	}); !errors.Is(err, ErrSessionForkTurnState) ||
+		sessionForkBoundaryReasonForTest(err) != SessionForkBoundaryReasonAttachmentUnsupported {
 		t.Fatalf("PrepareSessionFork() error=%v", err)
 	}
 }
@@ -1308,10 +1326,16 @@ func TestSessionForkRejectsDescendantLaneInsideBoundary(t *testing.T) {
 		t, store, "source", "turn-3", "provider-turn-3",
 		RootProviderTurnPhaseCompleted, 42,
 	)
-	if _, supported, err := store.CheckSessionForkThroughTurn(
+	if boundary, supported, err := store.CheckSessionForkThroughTurn(
 		ctx, "ws-1", "source", "turn-3",
-	); err != nil || supported {
-		t.Fatalf("CheckSessionForkThroughTurn() supported=%v error=%v", supported, err)
+	); err != nil || supported ||
+		boundary.RejectionReason != SessionForkBoundaryReasonDescendantLaneUnsupported {
+		t.Fatalf(
+			"CheckSessionForkThroughTurn() boundary=%#v supported=%v error=%v",
+			boundary,
+			supported,
+			err,
+		)
 	}
 	if _, _, err := prepareSessionForkForTest(t, store, ctx, SessionForkPrepare{
 		OperationID: "fork-descendant", WorkspaceID: "ws-1",
@@ -1319,7 +1343,8 @@ func TestSessionForkRejectsDescendantLaneInsideBoundary(t *testing.T) {
 		SourceAgentSessionID: "source", TargetAgentSessionID: "target-descendant",
 		SourceTurnID: "turn-3", DriverKind: "codex", DriverVersion: "1",
 		OccurredAtUnixMS: 100,
-	}); !errors.Is(err, ErrSessionForkTurnState) {
+	}); !errors.Is(err, ErrSessionForkTurnState) ||
+		sessionForkBoundaryReasonForTest(err) != SessionForkBoundaryReasonDescendantLaneUnsupported {
 		t.Fatalf("PrepareSessionFork() error=%v", err)
 	}
 }
@@ -1697,6 +1722,14 @@ func TestListRecoverableSessionForkOperationsPage(t *testing.T) {
 	if err != nil || len(second) != 1 || second[0].OperationID != "recover-b" {
 		t.Fatalf("second recovery page=%#v error=%v", second, err)
 	}
+}
+
+func sessionForkBoundaryReasonForTest(err error) SessionForkBoundaryReason {
+	var boundaryErr *SessionForkBoundaryError
+	if !errors.As(err, &boundaryErr) {
+		return ""
+	}
+	return boundaryErr.Reason
 }
 
 func prepareSessionForkForTest(

--- a/packages/agent/store-sqlite/session_fork_types.go
+++ b/packages/agent/store-sqlite/session_fork_types.go
@@ -12,6 +12,33 @@ const (
 	SessionForkStatusUnknown          = "unknown"
 )
 
+// SessionForkBoundaryReason is a stable, content-free diagnostic code for one
+// fail-closed through-Turn boundary validation.
+type SessionForkBoundaryReason string
+
+const (
+	SessionForkBoundaryReasonSourceNotRoot                SessionForkBoundaryReason = "agent_session_fork_source_not_root"
+	SessionForkBoundaryReasonSourceActiveTurn             SessionForkBoundaryReason = "agent_session_fork_source_active_turn"
+	SessionForkBoundaryReasonProviderSessionMissing       SessionForkBoundaryReason = "agent_session_fork_provider_session_missing"
+	SessionForkBoundaryReasonPendingInteraction           SessionForkBoundaryReason = "agent_session_fork_pending_interaction"
+	SessionForkBoundaryReasonSourceNotQuiescent           SessionForkBoundaryReason = "agent_session_fork_source_not_quiescent"
+	SessionForkBoundaryReasonTurnNotFound                 SessionForkBoundaryReason = "agent_session_fork_turn_not_found"
+	SessionForkBoundaryReasonTurnSequenceMissing          SessionForkBoundaryReason = "agent_session_fork_turn_sequence_missing"
+	SessionForkBoundaryReasonTurnNotSettled               SessionForkBoundaryReason = "agent_session_fork_turn_not_settled"
+	SessionForkBoundaryReasonTurnSequenceUnverified       SessionForkBoundaryReason = "agent_session_fork_turn_sequence_unverified"
+	SessionForkBoundaryReasonProviderTurnMissing          SessionForkBoundaryReason = "agent_session_fork_provider_turn_missing"
+	SessionForkBoundaryReasonPrefixTurnMissing            SessionForkBoundaryReason = "agent_session_fork_prefix_turn_missing"
+	SessionForkBoundaryReasonPrefixTurnNotSettled         SessionForkBoundaryReason = "agent_session_fork_prefix_turn_not_settled"
+	SessionForkBoundaryReasonPrefixSequenceUnverified     SessionForkBoundaryReason = "agent_session_fork_prefix_sequence_unverified"
+	SessionForkBoundaryReasonPrefixProviderTurnMissing    SessionForkBoundaryReason = "agent_session_fork_prefix_provider_turn_missing"
+	SessionForkBoundaryReasonProviderTurnDuplicate        SessionForkBoundaryReason = "agent_session_fork_provider_turn_duplicate"
+	SessionForkBoundaryReasonProviderTurnBoundaryMismatch SessionForkBoundaryReason = "agent_session_fork_provider_turn_boundary_mismatch"
+	SessionForkBoundaryReasonDescendantLaneUnsupported    SessionForkBoundaryReason = "agent_session_fork_descendant_lane_unsupported"
+	SessionForkBoundaryReasonBoundaryMessagesMissing      SessionForkBoundaryReason = "agent_session_fork_boundary_messages_missing"
+	SessionForkBoundaryReasonTurnlessMessageUnsupported   SessionForkBoundaryReason = "agent_session_fork_turnless_message_unsupported"
+	SessionForkBoundaryReasonAttachmentUnsupported        SessionForkBoundaryReason = "agent_session_fork_attachment_unsupported"
+)
+
 var (
 	ErrSessionForkRequestConflict = errors.New("agent session fork request conflicts with an existing operation")
 	ErrSessionForkSourceState     = errors.New("agent session cannot be forked in its current state")
@@ -20,6 +47,42 @@ var (
 	ErrSessionForkTargetReserved  = errors.New("agent session fork target is reserved")
 	ErrSessionForkTransition      = errors.New("agent session fork operation transition is invalid")
 )
+
+// SessionForkBoundaryError preserves the exact failed boundary invariant while
+// remaining compatible with ErrSessionForkTurnState.
+type SessionForkBoundaryError struct {
+	Reason SessionForkBoundaryReason
+	detail string
+}
+
+func (e *SessionForkBoundaryError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.detail == "" {
+		return ErrSessionForkTurnState.Error()
+	}
+	return ErrSessionForkTurnState.Error() + ": " + e.detail
+}
+
+func (*SessionForkBoundaryError) Unwrap() error {
+	return ErrSessionForkTurnState
+}
+
+// ForkBoundaryReason exposes the stable code without exposing canonical data.
+func (e *SessionForkBoundaryError) ForkBoundaryReason() string {
+	if e == nil {
+		return ""
+	}
+	return string(e.Reason)
+}
+
+func newSessionForkBoundaryError(
+	reason SessionForkBoundaryReason,
+	detail string,
+) error {
+	return &SessionForkBoundaryError{Reason: reason, detail: detail}
+}
 
 type SessionForkLineage struct {
 	WorkspaceID          string
@@ -106,6 +169,26 @@ type SessionForkBoundary struct {
 	Session             Session
 	Turn                Turn
 	RootProviderTurnIDs []string
+	RejectionReason     SessionForkBoundaryReason
+	rejectionDetail     string
+}
+
+// RejectionError returns the typed reason carried by an unsupported boundary.
+func (b SessionForkBoundary) RejectionError() error {
+	if b.RejectionReason == "" {
+		return nil
+	}
+	return newSessionForkBoundaryError(b.RejectionReason, b.rejectionDetail)
+}
+
+func rejectedSessionForkBoundary(
+	reason SessionForkBoundaryReason,
+	detail string,
+) SessionForkBoundary {
+	return SessionForkBoundary{
+		RejectionReason: reason,
+		rejectionDetail: detail,
+	}
 }
 
 type SessionForkTurnIdentity struct {

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -10716,7 +10716,7 @@ export type ForkWorkspaceAgentSessionErrors = {
    */
   405: ApiErrorResponse;
   /**
-   * The source session or requested fork boundary is not forkable
+   * The source session or requested fork boundary is not forkable. Boundary validation failures keep reason `agent_session_fork_conflict` and include the stable rejection code in `error.params.forkBoundaryReason`.
    */
   409: ApiErrorResponse;
   /**

--- a/services/tuttid/api/daemon_agent_session_fork.go
+++ b/services/tuttid/api/daemon_agent_session_fork.go
@@ -240,11 +240,17 @@ func writeForkWorkspaceAgentSessionError(
 			protocolErrorResponse(protocolErr),
 		)
 	case errors.Is(err, agentservice.ErrSessionForkConflict):
+		options := []apierrors.Option{apierrors.WithCause(err)}
+		if boundaryReason := sessionForkBoundaryReason(err); boundaryReason != "" {
+			options = append(options, apierrors.WithParams(map[string]any{
+				"forkBoundaryReason": boundaryReason,
+			}))
+		}
 		protocolErr = apierrors.New(
 			409,
 			tuttigenerated.WorkspaceOperationFailed,
 			"agent_session_fork_conflict",
-			apierrors.WithCause(err),
+			options...,
 		)
 		return tuttigenerated.ForkWorkspaceAgentSession409JSONResponse(
 			protocolErrorResponse(protocolErr),
@@ -279,4 +285,16 @@ func writeForkWorkspaceAgentSessionError(
 			WorkspaceOperationErrorJSONResponse: workspaceOperationError(protocolErr),
 		}
 	}
+}
+
+type sessionForkBoundaryReasoner interface {
+	ForkBoundaryReason() string
+}
+
+func sessionForkBoundaryReason(err error) string {
+	var reasoner sessionForkBoundaryReasoner
+	if !errors.As(err, &reasoner) {
+		return ""
+	}
+	return strings.TrimSpace(reasoner.ForkBoundaryReason())
 }

--- a/services/tuttid/api/daemon_agent_session_fork_test.go
+++ b/services/tuttid/api/daemon_agent_session_fork_test.go
@@ -3,11 +3,15 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+	tuttigenerated "github.com/tutti-os/tutti/services/tuttid/api/generated"
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
 )
@@ -145,6 +149,62 @@ func TestForkWorkspaceAgentSessionUnsupportedIsConflict(t *testing.T) {
 	)
 	if recorder.Code != http.StatusConflict {
 		t.Fatalf("status = %d, want 409; body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestForkWorkspaceAgentSessionReportsBoundaryRejectionReason(t *testing.T) {
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, NewRoutes(DaemonAPI{
+		AgentSessionService: stubAgentSessionService{
+			forkFn: func(
+				context.Context,
+				string,
+				string,
+				agentservice.ForkSessionInput,
+			) (agentservice.SessionForkOperation, error) {
+				boundaryErr := &storesqlite.SessionForkBoundaryError{
+					Reason: storesqlite.SessionForkBoundaryReasonTurnSequenceUnverified,
+				}
+				return agentservice.SessionForkOperation{}, fmt.Errorf(
+					"%w: %w",
+					agentservice.ErrSessionForkConflict,
+					boundaryErr,
+				)
+			},
+		},
+	}))
+
+	recorder := performGeneratedRouteRequest(
+		t,
+		mux,
+		http.MethodPost,
+		"/v1/workspaces/workspace-1/agent-sessions/source-1/fork",
+		map[string]any{
+			"targetAgentSessionId": "f0f21d94-af7c-4bdd-8f24-bffd169474bc",
+			"requestId":            "request-1",
+			"point": map[string]any{
+				"type": "throughTurn", "turnId": "turn-7",
+			},
+		},
+	)
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body=%s", recorder.Code, recorder.Body.String())
+	}
+	var body tuttigenerated.ApiErrorResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Error.Reason == nil || *body.Error.Reason != "agent_session_fork_conflict" {
+		t.Fatalf("reason=%v", body.Error.Reason)
+	}
+	if body.Error.Params == nil ||
+		(*body.Error.Params)["forkBoundaryReason"] !=
+			string(storesqlite.SessionForkBoundaryReasonTurnSequenceUnverified) {
+		t.Fatalf("params=%v", body.Error.Params)
+	}
+	if body.Error.DeveloperMessage == nil ||
+		!strings.Contains(*body.Error.DeveloperMessage, storesqlite.ErrSessionForkTurnState.Error()) {
+		t.Fatalf("developerMessage=%v", body.Error.DeveloperMessage)
 	}
 }
 

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -4336,7 +4336,7 @@ paths:
         "405":
           $ref: "#/components/responses/MethodNotAllowedError"
         "409":
-          description: The source session or requested fork boundary is not forkable
+          description: The source session or requested fork boundary is not forkable. Boundary validation failures keep reason `agent_session_fork_conflict` and include the stable rejection code in `error.params.forkBoundaryReason`.
           content:
             application/json:
               schema:

--- a/services/tuttid/service/agent/service_session_fork.go
+++ b/services/tuttid/service/agent/service_session_fork.go
@@ -296,7 +296,7 @@ func normalizeSessionForkError(err error) error {
 		errors.Is(err, storesqlite.ErrSessionForkTurnState),
 		errors.Is(err, storesqlite.ErrSessionForkTargetReserved),
 		errors.Is(err, storesqlite.ErrSessionForkTransition):
-		return fmt.Errorf("%w: %v", ErrSessionForkConflict, err)
+		return fmt.Errorf("%w: %w", ErrSessionForkConflict, err)
 	default:
 		return err
 	}

--- a/services/tuttid/service/agent/service_session_fork_test.go
+++ b/services/tuttid/service/agent/service_session_fork_test.go
@@ -16,6 +16,23 @@ type sessionForkCapabilityStore struct {
 	workspaceID, sourceSessionID, throughTurnID string
 }
 
+func TestNormalizeSessionForkErrorPreservesBoundaryReason(t *testing.T) {
+	input := &storesqlite.SessionForkBoundaryError{
+		Reason: storesqlite.SessionForkBoundaryReasonAttachmentUnsupported,
+	}
+	normalized := normalizeSessionForkError(input)
+	if !errors.Is(normalized, ErrSessionForkConflict) ||
+		!errors.Is(normalized, storesqlite.ErrSessionForkTurnState) {
+		t.Fatalf("normalized error=%v", normalized)
+	}
+	var reasoner interface{ ForkBoundaryReason() string }
+	if !errors.As(normalized, &reasoner) ||
+		reasoner.ForkBoundaryReason() !=
+			string(storesqlite.SessionForkBoundaryReasonAttachmentUnsupported) {
+		t.Fatalf("boundary reason not preserved: %v", normalized)
+	}
+}
+
 func (s *sessionForkCapabilityStore) CheckSessionForkThroughTurn(
 	_ context.Context,
 	workspaceID, sourceSessionID, throughTurnID string,


### PR DESCRIPTION
## What changed

- add stable, content-free reason codes for every fail-closed session fork boundary check
- preserve the concrete boundary error through store, host, service, and API layers
- expose the reason as `error.params.forkBoundaryReason` while keeping the existing public `agent_session_fork_conflict` reason for compatibility
- promote the boundary reason into Desktop agent activity diagnostics
- add Store, Host, Service, API, and Desktop coverage plus troubleshooting documentation

## Why

Session fork eligibility checks previously collapsed all unsafe boundary states into `supported=false`. The host and API then emitted only the generic `agent_session_fork_conflict`, so logs could not distinguish an unverified turn sequence, missing provider turn ID, unsettled turn, attachment, descendant lane, or another rejected invariant.

For the reported legacy session case, diagnostics can now report `agent_session_fork_prefix_sequence_unverified` and include the affected turn, sequence, and `legacy_unverified` provenance in the developer message.

## Impact

This does not relax fork eligibility or change provider fork behavior. Existing clients still receive HTTP 409 with `agent_session_fork_conflict`; newer diagnostics can inspect `params.forkBoundaryReason` for the exact failure class.

## Validation

- `go test ./packages/agent/store-sqlite ./packages/agent/host ./services/tuttid/service/agent ./services/tuttid/api`
- Desktop adapter tests: 42/42 passed
- `pnpm check:changed`: 24/24 lanes passed
- push-ready gate: 26/26 lanes passed
- `git diff --check`