### PR TITLE
feat(agent-gui): preserve session scroll position

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -901,10 +901,15 @@ High-frequency transcript updates must not pair DOM mutation with unconditional 
 Transcript end-following is one UI-local state machine shared by DOM, TanStack
 Virtual, and React Native adapters. It has only `following` and `detached`
 modes. User scroll-away intent detaches synchronously, before the first scroll
-frame. Conversation selection, prompt submission, an explicit scroll-to-end
-request, or the user actually reaching the end may reattach. Content growth,
-layout effects, observers, virtualizer geometry, and near-end thresholds are
-sensors or executors only; they must not transition the mode.
+frame. A mounted detail view retains the scroll anchor and follow-end mode for
+each exact Agent Session it visits. First selection follows the end; returning
+to a detached Session restores its retained position, while returning to a
+following Session stays at the end. This memory expires with the mounted view
+and never enters navigation, Engine, or Session state. Prompt submission, an
+explicit scroll-to-end request, or the user actually reaching the end may
+reattach. Content growth, layout effects, observers, virtualizer geometry, and
+near-end thresholds are sensors or executors only; they must not transition the
+mode.
 
 Turn-level virtualization has one geometry owner. When the transcript is
 virtualized and the state machine is `following`, TanStack Virtual owns append

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIScrollMemory.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIScrollMemory.ts
@@ -1,0 +1,34 @@
+import type { AgentConversationFollowEndMode } from "../../../shared/agentConversation/agentConversationFollowEndController";
+
+export interface TimelineScrollAnchor {
+  conversationId: string;
+  scrollHeight: number;
+  scrollTop: number;
+  clientHeight: number;
+}
+
+interface ConversationScrollMemory {
+  anchor: TimelineScrollAnchor;
+  followEndMode: AgentConversationFollowEndMode;
+}
+
+export class AgentGUIConversationScrollMemory {
+  private readonly memoryByConversationId = new Map<
+    string,
+    ConversationScrollMemory
+  >();
+
+  read(conversationId: string): ConversationScrollMemory | undefined {
+    return this.memoryByConversationId.get(conversationId);
+  }
+
+  write(
+    anchor: TimelineScrollAnchor,
+    followEndMode: AgentConversationFollowEndMode
+  ): void {
+    this.memoryByConversationId.set(anchor.conversationId, {
+      anchor,
+      followEndMode
+    });
+  }
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.spec.tsx
@@ -38,6 +38,115 @@ describe("useAgentGUIDetailScroll", () => {
     expect(harness.timeline.scrollTop).toBe(7_900);
   });
 
+  it("restores a conversation's detached scroll position when it is reselected", () => {
+    const harness = createHarness({ scrollHeight: 5_000 });
+    const { result, rerender } = renderHook(
+      ({ activeConversationId }) =>
+        useAgentGUIDetailScroll(
+          harness.input({ activeConversationId, showTimelineSkeleton: false })
+        ),
+      { initialProps: { activeConversationId: "conversation-a" } }
+    );
+
+    act(() => {
+      harness.timeline.dispatchEvent(new WheelEvent("wheel", { deltaY: -100 }));
+      harness.timeline.scrollTop = 2_000;
+      harness.timeline.dispatchEvent(new Event("scroll"));
+    });
+    expect(result.current.isTimelineScrolledToBottom).toBe(false);
+
+    harness.setScrollHeight(8_000);
+    rerender({ activeConversationId: "conversation-b" });
+    expect(harness.timeline.scrollTop).toBe(7_900);
+    expect(result.current.isTimelineScrolledToBottom).toBe(true);
+
+    harness.setScrollHeight(5_000);
+    rerender({ activeConversationId: "conversation-a" });
+    expect(harness.timeline.scrollTop).toBe(2_000);
+    expect(result.current.isTimelineScrolledToBottom).toBe(false);
+  });
+
+  it("keeps a detached position while the reselected conversation hydrates", () => {
+    const harness = createHarness({ scrollHeight: 5_000 });
+    const { result, rerender } = renderHook(
+      ({ activeConversationId, showTimelineSkeleton }) =>
+        useAgentGUIDetailScroll(
+          harness.input({ activeConversationId, showTimelineSkeleton })
+        ),
+      {
+        initialProps: {
+          activeConversationId: "conversation-a",
+          showTimelineSkeleton: false
+        }
+      }
+    );
+
+    act(() => {
+      harness.timeline.dispatchEvent(new WheelEvent("wheel", { deltaY: -100 }));
+      harness.timeline.scrollTop = 2_000;
+      harness.timeline.dispatchEvent(new Event("scroll"));
+    });
+
+    harness.setScrollHeight(8_000);
+    rerender({
+      activeConversationId: "conversation-b",
+      showTimelineSkeleton: false
+    });
+    expect(harness.timeline.scrollTop).toBe(7_900);
+
+    rerender({
+      activeConversationId: "conversation-a",
+      showTimelineSkeleton: true
+    });
+    expect(harness.timeline.scrollTop).toBe(7_900);
+    expect(result.current.isTimelineScrolledToBottom).toBe(false);
+
+    harness.setScrollHeight(5_000);
+    rerender({
+      activeConversationId: "conversation-a",
+      showTimelineSkeleton: false
+    });
+    expect(harness.timeline.scrollTop).toBe(2_000);
+    expect(result.current.isTimelineScrolledToBottom).toBe(false);
+  });
+
+  it("restores a virtualized conversation's detached scroll position", () => {
+    const harness = createHarness({ scrollHeight: 5_000 });
+    const firstController = virtualScrollController("conversation-a", false);
+    harness.virtualScrollControllerRef.current = firstController;
+    const { result, rerender } = renderHook(
+      ({ activeConversationId }) =>
+        useAgentGUIDetailScroll(
+          harness.input({ activeConversationId, showTimelineSkeleton: false })
+        ),
+      { initialProps: { activeConversationId: "conversation-a" } }
+    );
+
+    act(() => {
+      harness.timeline.dispatchEvent(new WheelEvent("wheel", { deltaY: -100 }));
+      harness.timeline.scrollTop = 2_000;
+      harness.timeline.dispatchEvent(new Event("scroll"));
+    });
+    expect(result.current.isTimelineScrolledToBottom).toBe(false);
+
+    const secondController = virtualScrollController("conversation-b");
+    harness.virtualScrollControllerRef.current = secondController;
+    rerender({ activeConversationId: "conversation-b" });
+    expect(secondController.scrollToEnd).toHaveBeenCalledWith({
+      behavior: "auto"
+    });
+
+    harness.virtualScrollControllerRef.current = firstController;
+    firstController.scrollToEnd.mockClear();
+    rerender({ activeConversationId: "conversation-a" });
+
+    expect(firstController.scrollToOffset).toHaveBeenCalledWith(2_000, {
+      behavior: "auto"
+    });
+    expect(firstController.scrollToEnd).not.toHaveBeenCalled();
+    expect(result.current.isTimelineScrolledToBottom).toBe(false);
+  });
+
   it("reads timeline geometry once for a semantic conversation switch", () => {
     const harness = createHarness({ scrollHeight: 5_000 });
     const { rerender } = renderHook(
@@ -1327,12 +1436,17 @@ function virtualScrollController(
 ): AgentTranscriptVirtualScrollController & {
   isAtEnd: Mock<() => boolean>;
   scrollToEnd: Mock<(options?: { behavior?: ScrollBehavior }) => void>;
+  scrollToOffset: Mock<
+    (offset: number, options?: { behavior?: ScrollBehavior }) => void
+  >;
 } {
   return {
     agentSessionId,
     enabled: true,
     isAtEnd: vi.fn(() => atEnd),
-    scrollToEnd: vi.fn<(options?: { behavior?: ScrollBehavior }) => void>()
+    scrollToEnd: vi.fn<(options?: { behavior?: ScrollBehavior }) => void>(),
+    scrollToOffset:
+      vi.fn<(offset: number, options?: { behavior?: ScrollBehavior }) => void>()
   };
 }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailScroll.ts
@@ -13,6 +13,10 @@ import {
   createAgentConversationFollowEndController,
   type AgentConversationFollowEndEvent
 } from "../../../shared/agentConversation/agentConversationFollowEndController";
+import {
+  AgentGUIConversationScrollMemory,
+  type TimelineScrollAnchor
+} from "./agentGUIScrollMemory";
 import type { AgentGUINodeViewModel } from "../model/agentGuiNodeTypes";
 import type { AgentGUINodeViewProps } from "../AgentGUINodeView";
 import {
@@ -49,12 +53,7 @@ interface Input {
   timelineConversationId: string | null;
   timelineContentRef: RefObject<HTMLDivElement | null>;
   timelineRef: RefObject<HTMLDivElement | null>;
-  timelineScrollAnchorRef: MutableRefObject<{
-    conversationId: string;
-    scrollHeight: number;
-    scrollTop: number;
-    clientHeight: number;
-  } | null>;
+  timelineScrollAnchorRef: MutableRefObject<TimelineScrollAnchor | null>;
   virtualScrollControllerRef: RefObject<AgentTranscriptVirtualScrollController | null>;
   viewModel: AgentGUINodeViewModel;
 }
@@ -81,14 +80,32 @@ export function useAgentGUIDetailScroll(input: Input) {
     createAgentConversationFollowEndController()
   );
   const followEndController = followEndControllerRef.current;
+  const conversationScrollMemoryRef = useRef(
+    new AgentGUIConversationScrollMemory()
+  );
   const [followEndMode, setFollowEndMode] = useState(
     followEndController.getSnapshot
   );
   const dispatchFollowEnd = useCallback(
     (event: AgentConversationFollowEndEvent): void => {
-      setFollowEndMode(followEndController.dispatch(event));
+      const nextMode = followEndController.dispatch(event);
+      const anchor = timelineScrollAnchorRef.current;
+      if (anchor) {
+        conversationScrollMemoryRef.current.write(anchor, nextMode);
+      }
+      setFollowEndMode(nextMode);
     },
-    [followEndController]
+    [followEndController, timelineScrollAnchorRef]
+  );
+  const writeTimelineScrollAnchor = useCallback(
+    (anchor: TimelineScrollAnchor): void => {
+      timelineScrollAnchorRef.current = anchor;
+      conversationScrollMemoryRef.current.write(
+        anchor,
+        followEndController.getSnapshot()
+      );
+    },
+    [followEndController, timelineScrollAnchorRef]
   );
   const pointerScrollConversationRef = useRef<string | null>(null);
   const userScrollDirectionRef = useRef<"away" | "toward-end" | null>(null);
@@ -135,13 +152,48 @@ export function useAgentGUIDetailScroll(input: Input) {
     if (activeConversationId !== viewModel.rail.activeConversationId) {
       return;
     }
-    const anchor = timelineScrollAnchorRef.current;
+    let anchor = timelineScrollAnchorRef.current;
     const conversationChanged =
       !anchor || anchor.conversationId !== activeConversationId;
     if (conversationChanged) {
-      dispatchFollowEnd("conversation-changed");
+      if (anchor) {
+        conversationScrollMemoryRef.current.write(
+          anchor,
+          followEndController.getSnapshot()
+        );
+      }
+      const rememberedScroll =
+        conversationScrollMemoryRef.current.read(activeConversationId);
+      const restoredFollowEndMode =
+        rememberedScroll?.followEndMode ?? "following";
+      setFollowEndMode(
+        followEndController.dispatch(
+          restoredFollowEndMode === "detached"
+            ? "user-scrolled-away"
+            : "conversation-changed"
+        )
+      );
       pointerScrollConversationRef.current = null;
       userScrollDirectionRef.current = null;
+      if (showTimelineSkeleton) {
+        timelineScrollAnchorRef.current = null;
+        setIsTimelineScrolledToTop(true);
+        return;
+      }
+      anchor = rememberedScroll?.anchor ?? {
+        clientHeight: 0,
+        conversationId: activeConversationId,
+        scrollHeight: Number.POSITIVE_INFINITY,
+        scrollTop: 0
+      };
+      timelineScrollAnchorRef.current = anchor;
+      conversationScrollMemoryRef.current.write(
+        anchor,
+        rememberedScroll?.followEndMode ?? "following"
+      );
+    }
+    if (!anchor) {
+      return;
     }
     if (
       hasStaleVirtualScrollController(
@@ -160,10 +212,6 @@ export function useAgentGUIDetailScroll(input: Input) {
     const virtualScrollControllerChanged =
       lastVirtualScrollControllerRevisionRef.current !==
       virtualScrollControllerRevision;
-    if (conversationChanged && showTimelineSkeleton) {
-      setIsTimelineScrolledToTop(true);
-      return;
-    }
     lastVirtualScrollControllerRevisionRef.current =
       virtualScrollControllerRevision;
     if (
@@ -180,11 +228,10 @@ export function useAgentGUIDetailScroll(input: Input) {
       activeConversationId
     );
     if (virtualScrollController) {
+      const followsEnd = followEndController.getSnapshot() === "following";
       if (
-        conversationChanged ||
         shouldScrollSubmittedPromptToBottom ||
-        (virtualScrollControllerChanged &&
-          followEndController.getSnapshot() === "following")
+        (followsEnd && (conversationChanged || virtualScrollControllerChanged))
       ) {
         if (shouldScrollSubmittedPromptToBottom) {
           dispatchFollowEnd("prompt-submitted");
@@ -197,24 +244,26 @@ export function useAgentGUIDetailScroll(input: Input) {
           pendingPrependScrollAnchorRef.current = null;
         }
       } else if (
+        !followsEnd &&
+        (conversationChanged ||
+          virtualScrollControllerChanged ||
+          (timelineSkeletonChanged && !showTimelineSkeleton))
+      ) {
+        virtualScrollController.scrollToOffset(anchor.scrollTop, {
+          behavior: "auto"
+        });
+      }
+      if (
         shouldRestorePrependAnchor &&
         !viewModel.detail.isLoadingOlderMessages
       ) {
         pendingPrependScrollAnchorRef.current = null;
       }
-      const virtualAnchor =
-        anchor?.conversationId === activeConversationId
-          ? anchor
-          : {
-              clientHeight: 0,
-              conversationId: activeConversationId,
-              scrollHeight: Number.POSITIVE_INFINITY,
-              scrollTop: 0
-            };
-      timelineScrollAnchorRef.current = {
+      const virtualAnchor = anchor;
+      writeTimelineScrollAnchor({
         ...virtualAnchor,
         conversationId: activeConversationId
-      };
+      });
       setIsTimelineScrolledToTop(
         virtualAnchor.scrollTop <= AGENT_GUI_TOP_MASK_SCROLL_EPSILON_PX
       );
@@ -233,11 +282,7 @@ export function useAgentGUIDetailScroll(input: Input) {
     const shouldKeepBottomLocked =
       followEndController.getSnapshot() === "following";
 
-    if (
-      conversationChanged ||
-      shouldScrollSubmittedPromptToBottom ||
-      shouldKeepBottomLocked
-    ) {
+    if (shouldScrollSubmittedPromptToBottom || shouldKeepBottomLocked) {
       setTimelineScrollTopInstantly(timeline, maxScrollTop);
       nextScrollTop = maxScrollTop;
       submittedPromptScrollConversationRef.current = null;
@@ -263,12 +308,12 @@ export function useAgentGUIDetailScroll(input: Input) {
       timeline.scrollTop = nextScrollTop;
     }
 
-    timelineScrollAnchorRef.current = {
+    writeTimelineScrollAnchor({
       conversationId: activeConversationId,
       scrollHeight: geometry.scrollHeight,
       scrollTop: nextScrollTop,
       clientHeight: geometry.clientHeight
-    };
+    });
     setIsTimelineScrolledToTop(
       nextScrollTop <= AGENT_GUI_TOP_MASK_SCROLL_EPSILON_PX
     );
@@ -281,7 +326,8 @@ export function useAgentGUIDetailScroll(input: Input) {
     timelineConversationId,
     virtualScrollControllerRevision,
     viewModel.rail.activeConversationId,
-    viewModel.detail.isLoadingOlderMessages
+    viewModel.detail.isLoadingOlderMessages,
+    writeTimelineScrollAnchor
   ]);
 
   const hasTimelineConversation = timelineConversationId !== null;
@@ -368,12 +414,12 @@ export function useAgentGUIDetailScroll(input: Input) {
         const geometry = readTimelineGeometry(timeline);
         const maxScrollTop = geometry.maxScrollTop;
         timeline.scrollTop = maxScrollTop;
-        timelineScrollAnchorRef.current = {
+        writeTimelineScrollAnchor({
           conversationId: scheduledConversationId,
           scrollHeight: geometry.scrollHeight,
           scrollTop: maxScrollTop,
           clientHeight: geometry.clientHeight
-        };
+        });
         setIsTimelineScrolledToTop(
           maxScrollTop <= AGENT_GUI_TOP_MASK_SCROLL_EPSILON_PX
         );
@@ -419,7 +465,8 @@ export function useAgentGUIDetailScroll(input: Input) {
     bottomDockStoreRevision,
     followEndController,
     hasTimelineConversation,
-    isVisible
+    isVisible,
+    writeTimelineScrollAnchor
   ]);
 
   useEffect(() => {
@@ -519,12 +566,12 @@ export function useAgentGUIDetailScroll(input: Input) {
       ) {
         dispatchFollowEnd("user-reached-end");
       }
-      timelineScrollAnchorRef.current = {
+      writeTimelineScrollAnchor({
         conversationId: activeConversationId,
         scrollHeight: previousAnchor.scrollHeight,
         scrollTop,
         clientHeight: previousAnchor.clientHeight
-      };
+      });
       setIsTimelineScrolledToTop(
         scrollTop <= AGENT_GUI_TOP_MASK_SCROLL_EPSILON_PX
       );
@@ -560,12 +607,12 @@ export function useAgentGUIDetailScroll(input: Input) {
           observedScrollHeight === undefined
             ? anchor.scrollHeight
             : Math.max(clientHeight, observedScrollHeight);
-        timelineScrollAnchorRef.current = {
+        writeTimelineScrollAnchor({
           ...anchor,
           clientHeight,
           scrollHeight,
           scrollTop
-        };
+        });
         setIsTimelineScrolledToTop(
           scrollTop <= AGENT_GUI_TOP_MASK_SCROLL_EPSILON_PX
         );
@@ -580,12 +627,12 @@ export function useAgentGUIDetailScroll(input: Input) {
         setTimelineScrollTopInstantly(timeline, maxScrollTop);
         scrollTop = maxScrollTop;
       }
-      timelineScrollAnchorRef.current = {
+      writeTimelineScrollAnchor({
         conversationId: activeConversationId,
         scrollHeight,
         scrollTop,
         clientHeight
-      };
+      });
       setIsTimelineScrolledToTop(
         scrollTop <= AGENT_GUI_TOP_MASK_SCROLL_EPSILON_PX
       );
@@ -685,7 +732,8 @@ export function useAgentGUIDetailScroll(input: Input) {
     showTimelineSkeleton,
     viewModel.rail.activeConversationId,
     viewModel.detail.hasOlderMessages,
-    viewModel.detail.isLoadingOlderMessages
+    viewModel.detail.isLoadingOlderMessages,
+    writeTimelineScrollAnchor
   ]);
 
   const scrollTimelineToBottom = useCallback(() => {
@@ -721,12 +769,12 @@ export function useAgentGUIDetailScroll(input: Input) {
     const geometry = readTimelineGeometry(timeline);
     const maxScrollTop = geometry.maxScrollTop;
     setTimelineScrollTopWithUserTransition(timeline, maxScrollTop);
-    timelineScrollAnchorRef.current = {
+    writeTimelineScrollAnchor({
       conversationId: activeConversationId,
       scrollHeight: geometry.scrollHeight,
       scrollTop: maxScrollTop,
       clientHeight: geometry.clientHeight
-    };
+    });
     setIsTimelineScrolledToTop(
       maxScrollTop <= AGENT_GUI_TOP_MASK_SCROLL_EPSILON_PX
     );
@@ -735,7 +783,8 @@ export function useAgentGUIDetailScroll(input: Input) {
     isVisible,
     timelineConversationId,
     viewModel.rail.activeConversationId,
-    virtualScrollControllerRef
+    virtualScrollControllerRef,
+    writeTimelineScrollAnchor
   ]);
 
   return {

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.virtual.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.virtual.spec.tsx
@@ -20,6 +20,7 @@ const virtualizerMockState = vi.hoisted(() => ({
   containerRef: vi.fn(),
   isAtEnd: vi.fn(() => true),
   scrollToEnd: vi.fn(),
+  scrollToOffset: vi.fn(),
   scrollToIndex: vi.fn(),
   instance: {
     shouldAdjustScrollPositionOnItemSizeChange: undefined as
@@ -54,6 +55,7 @@ vi.mock("@tanstack/react-virtual", () => ({
       scrollOffset: virtualizerMockState.scrollOffset,
       scrollRect: virtualizerMockState.scrollRect,
       scrollToEnd: virtualizerMockState.scrollToEnd,
+      scrollToOffset: virtualizerMockState.scrollToOffset,
       scrollToIndex: virtualizerMockState.scrollToIndex
     })
   )
@@ -99,6 +101,7 @@ describe("AgentTranscriptView virtual rendering", () => {
     virtualizerMockState.isAtEnd.mockReset();
     virtualizerMockState.isAtEnd.mockReturnValue(true);
     virtualizerMockState.scrollToEnd.mockClear();
+    virtualizerMockState.scrollToOffset.mockClear();
     virtualizerMockState.scrollToIndex.mockClear();
     virtualizerMockState.instance.shouldAdjustScrollPositionOnItemSizeChange =
       undefined;
@@ -342,6 +345,12 @@ describe("AgentTranscriptView virtual rendering", () => {
     expect(virtualScrollController.current?.agentSessionId).toBe("session-1");
     expect(virtualScrollController.current?.enabled).toBe(true);
     expect(virtualScrollController.current?.isAtEnd()).toBe(true);
+    virtualScrollController.current?.scrollToOffset(640, {
+      behavior: "auto"
+    });
+    expect(virtualizerMockState.scrollToOffset).toHaveBeenCalledWith(640, {
+      behavior: "auto"
+    });
     virtualScrollController.current?.scrollToEnd({ behavior: "smooth" });
     expect(virtualizerMockState.scrollToEnd).toHaveBeenCalledWith({
       behavior: "smooth"

--- a/packages/agent/gui/shared/agentConversation/components/useAgentTranscriptVirtualizer.ts
+++ b/packages/agent/gui/shared/agentConversation/components/useAgentTranscriptVirtualizer.ts
@@ -17,6 +17,7 @@ export interface AgentTranscriptVirtualScrollController {
   agentSessionId: string;
   enabled: boolean;
   isAtEnd(threshold?: number): boolean;
+  scrollToOffset(offset: number, options?: { behavior?: ScrollBehavior }): void;
   scrollToEnd(options?: { behavior?: ScrollBehavior }): void;
 }
 
@@ -77,6 +78,11 @@ export function useAgentTranscriptVirtualizer({
       enabled: shouldVirtualize,
       isAtEnd: (threshold) =>
         shouldVirtualize && rowVirtualizer.isAtEnd(threshold),
+      scrollToOffset: (offset, options) => {
+        if (shouldVirtualize) {
+          rowVirtualizer.scrollToOffset(offset, options);
+        }
+      },
       scrollToEnd: (options) => {
         if (shouldVirtualize) {
           rowVirtualizer.scrollToEnd(options);


### PR DESCRIPTION
## What changed

- retain the scroll anchor and follow-end mode for each Agent Session visited by a mounted AgentGUI detail view
- restore detached DOM and TanStack Virtual transcripts to their previous offset when the user returns
- keep first-time and end-following sessions pinned to the latest turn
- document the UI-local ownership and lifetime of session scroll memory

## Why

Switching away from a Session discarded its viewport state. Returning to it therefore behaved like a fresh selection and jumped to the latest Turn instead of preserving the user's reading position.

## Impact

Users can move between Sessions without losing their place. The state remains local to the mounted AgentGUI view and does not change navigation, Engine, Session lifecycle, or persisted daemon state.

## Validation

- `pnpm check:changed -- --push-ready --base upstream/main` — 12 lanes passed
- focused AgentGUI scroll and virtual transcript tests — 58 tests passed
- pre-commit formatting, renderer/UI boundary, degradation, and runtime image budget checks passed
