### PR TITLE
refactor(agent): unify session mutation effects

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -841,6 +841,47 @@ test("desktop agent activity adapter submits interactive responses through tutti
   assert.equal(result.session.activeTurn?.phase, "waiting");
 });
 
+test("desktop agent activity adapter forwards pin cancellation to tuttid", async () => {
+  const calls: unknown[] = [];
+  const controller = new AbortController();
+  const adapter = createDesktopAgentActivityAdapter({
+    tuttidClient: createTuttidClient({
+      async updateWorkspaceAgentSessionPin(
+        requestWorkspaceId,
+        agentSessionId,
+        request,
+        requestOptions
+      ) {
+        calls.push([
+          requestWorkspaceId,
+          agentSessionId,
+          request,
+          requestOptions
+        ]);
+        return createSession({ id: agentSessionId, pinnedAtUnixMs: 10 });
+      }
+    }),
+    runtimeApi: createRuntimeApi()
+  });
+
+  const result = await adapter.setSessionPinned({
+    agentSessionId: "agent-session-1",
+    pinned: true,
+    signal: controller.signal,
+    workspaceId
+  });
+
+  assert.deepEqual(calls, [
+    [
+      workspaceId,
+      "agent-session-1",
+      { pinned: true },
+      { signal: controller.signal }
+    ]
+  ]);
+  assert.equal(result.pinnedAtUnixMs, 10);
+});
+
 test("desktop agent activity adapter normalizes provider composer options", async () => {
   const calls: unknown[] = [];
   const diagnostics: unknown[] = [];

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -521,7 +521,8 @@ export function createDesktopAgentActivityAdapter({
       const session = await tuttidClient.updateWorkspaceAgentSessionPin(
         input.workspaceId,
         input.agentSessionId,
-        { pinned: input.pinned }
+        { pinned: input.pinned },
+        { signal: input.signal }
       );
       return agentActivitySessionFromTuttidSession(input.workspaceId, session);
     },

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentSessionEngineHost.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentSessionEngineHost.ts
@@ -147,6 +147,11 @@ export function createWorkspaceAgentSessionEngineHost(
           }),
         cancelTurn: (effectInput, options) =>
           input.cancelTurn({ ...effectInput, signal: options?.signal }),
+        deleteSessions: (effectInput, options) =>
+          adapter.deleteSessions({
+            ...effectInput,
+            signal: options?.signal
+          }),
         respondToInteraction: (effectInput, options) =>
           input.submitInteractive({
             ...effectInput,
@@ -157,6 +162,13 @@ export function createWorkspaceAgentSessionEngineHost(
             ...effectInput,
             signal: options?.signal
           }),
+        setSessionPinned: async (effectInput, options) => {
+          const session = await adapter.setSessionPinned({
+            ...effectInput,
+            signal: options?.signal
+          });
+          return { session };
+        },
         updateSessionSettings: (
           { agentSessionId, settings, workspaceId },
           options
@@ -214,15 +226,6 @@ export function createWorkspaceAgentSessionEngineHost(
               signal: options?.signal,
               workspaceId: command.workspaceId
             });
-          case "session/setPinned": {
-            const session = await adapter.setSessionPinned({
-              agentSessionId: command.agentSessionId,
-              pinned: command.pinned,
-              signal: options?.signal,
-              workspaceId: command.workspaceId
-            });
-            return { session };
-          }
           case "session/forkThroughTurn":
             return adapter.forkSession({
               requestId: command.requestId,
@@ -238,12 +241,6 @@ export function createWorkspaceAgentSessionEngineHost(
               command,
               options?.signal
             );
-          case "sessions/delete":
-            return adapter.deleteSessions({
-              agentSessionIds: command.agentSessionIds,
-              signal: options?.signal,
-              workspaceId: command.workspaceId
-            });
           case "tuttiMode/update":
             return executeWorkspaceAgentTuttiModeUpdateCommand(
               input,

--- a/apps/mobile/src/services/workspaceActivityEngineCommandPort.test.ts
+++ b/apps/mobile/src/services/workspaceActivityEngineCommandPort.test.ts
@@ -309,4 +309,68 @@ describe("createWorkspaceActivityEffectPort", () => {
       { signal: controller.signal }
     );
   });
+
+  test("projects pin and delete mutations with the Engine cancellation signal", async () => {
+    const controller = new AbortController();
+    const updateWorkspaceAgentSessionPin = jest.fn().mockResolvedValue({});
+    const deleteWorkspaceAgentSessionsBatch = jest.fn().mockResolvedValue({
+      cleanupFailedSessionIds: [],
+      removedMessages: 3,
+      removedSessionIds: ["session-1", "session-2"],
+      removedSessions: 2
+    });
+    const activitySession = {
+      agentSessionId: "session-1",
+      workspaceId: "workspace-1"
+    } as AgentActivitySession;
+    const port = createWorkspaceActivityEffectPort(() => ({
+      client: {
+        deleteWorkspaceAgentSessionsBatch,
+        updateWorkspaceAgentSessionPin
+      } as unknown as TuttidClient,
+      engine: {} as AgentSessionEngine,
+      loadComposerOptions() {},
+      mapSession: () => activitySession,
+      mapSessionDetail() {
+        throw new Error("unexpected detail mapping");
+      },
+      async reconcileSession() {},
+      async reconcileWorkspace() {}
+    }));
+
+    const pinResult = await port.setSessionPinned(
+      {
+        agentSessionId: "session-1",
+        pinned: true,
+        workspaceId: "workspace-1"
+      },
+      { signal: controller.signal }
+    );
+    const deleteResult = await port.deleteSessions(
+      {
+        agentSessionIds: ["session-1", "session-2"],
+        workspaceId: "workspace-1"
+      },
+      { signal: controller.signal }
+    );
+
+    expect(updateWorkspaceAgentSessionPin).toHaveBeenCalledWith(
+      "workspace-1",
+      "session-1",
+      { pinned: true },
+      { signal: controller.signal }
+    );
+    expect(deleteWorkspaceAgentSessionsBatch).toHaveBeenCalledWith(
+      "workspace-1",
+      { sessionIds: ["session-1", "session-2"] },
+      { signal: controller.signal }
+    );
+    expect(pinResult).toEqual({ session: activitySession });
+    expect(deleteResult).toEqual({
+      cleanupFailedSessionIds: [],
+      removedMessages: 3,
+      removedSessionIds: ["session-1", "session-2"],
+      removedSessions: 2
+    });
+  });
 });

--- a/apps/mobile/src/services/workspaceActivityEngineCommandPort.ts
+++ b/apps/mobile/src/services/workspaceActivityEngineCommandPort.ts
@@ -47,10 +47,14 @@ export function createWorkspaceActivityEffectPort(
       activateSession(getContext(), input, options?.signal),
     cancelTurn: (input, options) =>
       cancelTurn(getContext(), input, options?.signal),
+    deleteSessions: (input, options) =>
+      deleteSessions(getContext(), input, options?.signal),
     respondToInteraction: (input, options) =>
       respondToInteraction(getContext(), input, options?.signal),
     sendInput: (input, options) =>
       sendPrompt(getContext(), input, options?.signal),
+    setSessionPinned: (input, options) =>
+      setSessionPinned(getContext(), input, options?.signal),
     updateSessionSettings: (input, options) =>
       updateSessionSettings(getContext(), input, options?.signal)
   };
@@ -87,27 +91,6 @@ export function executeWorkspaceActivityExtensionCommand(
         .then((result) =>
           agentActivityComposerOptionsFromTuttidResult(command.provider, result)
         );
-    case "session/setPinned":
-      return context.client
-        .updateWorkspaceAgentSessionPin(
-          command.workspaceId,
-          command.agentSessionId,
-          { pinned: command.pinned }
-        )
-        .then((session) => ({ session: context.mapSession(session) }));
-    case "sessions/delete":
-      return context.client
-        .deleteWorkspaceAgentSessionsBatch(
-          command.workspaceId,
-          { sessionIds: [...command.agentSessionIds] },
-          { signal }
-        )
-        .then((response) => ({
-          cleanupFailedSessionIds: response.cleanupFailedSessionIds,
-          removedMessages: response.removedMessages,
-          removedSessionIds: response.removedSessionIds,
-          removedSessions: response.removedSessions
-        }));
     case "attention/readState/read":
     case "attention/readState/write":
     case "session/ackForkObserved":
@@ -229,6 +212,28 @@ function cancelTurn(
     }));
 }
 
+function deleteSessions(
+  context: WorkspaceActivityEngineCommandContext,
+  input: {
+    agentSessionIds: readonly string[];
+    workspaceId: string;
+  },
+  signal?: AbortSignal
+): Promise<unknown> {
+  return context.client
+    .deleteWorkspaceAgentSessionsBatch(
+      input.workspaceId,
+      { sessionIds: [...input.agentSessionIds] },
+      ...requestOptionsArgs(signal)
+    )
+    .then((response) => ({
+      cleanupFailedSessionIds: response.cleanupFailedSessionIds,
+      removedMessages: response.removedMessages,
+      removedSessionIds: response.removedSessionIds,
+      removedSessions: response.removedSessions
+    }));
+}
+
 function respondToInteraction(
   context: WorkspaceActivityEngineCommandContext,
   input: AgentActivitySubmitInteractiveInput,
@@ -245,6 +250,25 @@ function respondToInteraction(
         payload: input.payload ?? null,
         turnId: input.turnId
       },
+      ...requestOptionsArgs(signal)
+    )
+    .then((session) => ({ session: context.mapSession(session) }));
+}
+
+function setSessionPinned(
+  context: WorkspaceActivityEngineCommandContext,
+  input: {
+    agentSessionId: string;
+    pinned: boolean;
+    workspaceId: string;
+  },
+  signal?: AbortSignal
+): Promise<unknown> {
+  return context.client
+    .updateWorkspaceAgentSessionPin(
+      input.workspaceId,
+      input.agentSessionId,
+      { pinned: input.pinned },
       ...requestOptionsArgs(signal)
     )
     .then((session) => ({ session: context.mapSession(session) }));

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -191,10 +191,10 @@ It owns:
   command-description effect executor, expiry-intent clock, and intent frame
   batching, with scheduler/clock/command ports injected by the host
 - the typed frontend effect seam for activation, prompt send, settings update,
-  turn cancellation, and Interaction response, including lossless command
-  projection and required-settings-before-send ordering; hosts retain
-  transport, DTO mapping, AbortSignal propagation, and product-specific command
-  extensions (see
+  turn cancellation, Interaction response, pin, and batch delete, including
+  lossless command projection and required-settings-before-send ordering; hosts
+  retain transport, DTO mapping, AbortSignal propagation, and product-specific
+  command extensions (see
   [Agent GUI Node](./agent-gui-node.md#4-workspace-frontend-engine))
 
 The public seam is `AgentSessionEffectPort`. Prompt precondition ordering and

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -598,7 +598,7 @@ disable submission, but must not change editor editability.
   event time instead of retaining a whole-workspace render snapshot
 - lifecycle writes use typed intents/commands
 - the Engine alone translates shared activation, prompt send, settings update,
-  turn cancel, and Interaction response commands into
+  turn cancel, Interaction response, pin, and batch-delete commands into
   `AgentSessionEffectPort` calls. Desktop and Mobile implement those semantic
   methods and must not duplicate a command-type switch for them. Platform-only
   commands remain in each host's `EngineExtensionCommand` adapter. Every effect

--- a/packages/agent/activity-core/README.md
+++ b/packages/agent/activity-core/README.md
@@ -19,8 +19,9 @@ transport commands and normalize observations before they enter the engine.
 - merges persisted and live messages with version-aware conflict handling
 - analyzes normalized activity events into one inline-observation intent plus
   an explicit authoritative-reconcile requirement
-- projects shared activation, prompt send, settings update, turn cancel, and
-  Interaction response commands onto one typed host effect port
+- projects shared activation, prompt send, settings update, turn cancel,
+  Interaction response, pin, and batch-delete commands onto one typed host
+  effect port
 - executes the shared prompt sequence, including required settings persistence
   before send
 - exposes selectors such as `selectNeedsAttentionCount`
@@ -57,11 +58,12 @@ Engine rules:
   every settlement (success, failure, timeout) back into the loop as
   command-result intents.
 - New hosts implement `AgentSessionEffectPort` for activation, prompt send,
-  settings update, turn cancellation, and Interaction response. The Engine
-  owns command-to-capability projection and required-settings-before-send
-  ordering. A typed port declares `kind: "typed"` and its `execute` callback
-  receives only `EngineExtensionCommand`; the discriminated legacy shape keeps
-  the complete-command callback while existing package consumers migrate.
+  settings update, turn cancellation, Interaction response, pin, and batch
+  delete. The Engine owns command-to-capability projection and
+  required-settings-before-send ordering. A typed port declares
+  `kind: "typed"` and its `execute` callback receives only
+  `EngineExtensionCommand`; the discriminated legacy shape keeps the
+  complete-command callback while existing package consumers migrate.
 - Timing is never read inside reducers. Deadlines are `scheduleExpiry`
   commands handled by the expiry clock, which re-enters the loop with expiry
   intents through the injected host scheduler.
@@ -270,14 +272,15 @@ identity exists, with identical attention semantics on Desktop and Mobile.
 
 The Engine projects shared lifecycle command descriptions onto
 `AgentSessionEffectPort`: `activateSession`, `sendInput`,
-`updateSessionSettings`, `cancelTurn`, and `respondToInteraction`. Hosts
-implement transport and result mapping without switching on those command
-types. When a queued prompt includes a required settings patch, the Engine
-waits for that exact settings write before sending; a failed write prevents the
-send. Capability references, structured content, display prompt, guidance,
-activation placement, Tutti-mode intent, and diagnostics survive the shared
-projection. Goal-on-create and settings command/correlation identities are also
-retained for external hosts that use them for goal setup or idempotency.
+`updateSessionSettings`, `cancelTurn`, `respondToInteraction`,
+`setSessionPinned`, and `deleteSessions`. Hosts implement transport and result
+mapping without switching on those command types. When a queued prompt includes
+a required settings patch, the Engine waits for that exact settings write
+before sending; a failed write prevents the send. Capability references,
+structured content, display prompt, guidance, activation placement, Tutti-mode
+intent, and diagnostics survive the shared projection. Goal-on-create and
+settings command/correlation identities are also retained for external hosts
+that use them for goal setup or idempotency.
 
 Prompt command ordering is an Engine implementation detail. Consumers implement
 `AgentSessionEffectPort`; the package root does not expose the internal prompt

--- a/packages/agent/activity-core/src/engine/effectExecutor.test.ts
+++ b/packages/agent/activity-core/src/engine/effectExecutor.test.ts
@@ -20,11 +20,17 @@ test("projects shared commands onto typed lifecycle effects without host switche
     async cancelTurn(input, options) {
       calls.push({ input, kind: "cancel", signal: options?.signal });
     },
+    async deleteSessions(input, options) {
+      calls.push({ input, kind: "delete", signal: options?.signal });
+    },
     async respondToInteraction(input, options) {
       calls.push({ input, kind: "respond", signal: options?.signal });
     },
     async sendInput(input, options) {
       calls.push({ input, kind: "send", signal: options?.signal });
+    },
+    async setSessionPinned(input, options) {
+      calls.push({ input, kind: "pin", signal: options?.signal });
     },
     async updateSessionSettings(input, options) {
       calls.push({ input, kind: "settings", signal: options?.signal });
@@ -99,6 +105,21 @@ test("projects shared commands onto typed lifecycle effects without host switche
     workspaceId: "workspace-1"
   });
   await executeAndWait(port, {
+    agentSessionId: "session-1",
+    commandId: "pin-1",
+    correlationId: "pin-1",
+    pinned: true,
+    type: "session/setPinned",
+    workspaceId: "workspace-1"
+  });
+  await executeAndWait(port, {
+    agentSessionIds: ["session-1", "session-2"],
+    commandId: "delete-1",
+    correlationId: "delete-1",
+    type: "sessions/delete",
+    workspaceId: "workspace-1"
+  });
+  await executeAndWait(port, {
     action: "accept",
     agentSessionId: "session-1",
     commandId: "respond-1",
@@ -114,7 +135,16 @@ test("projects shared commands onto typed lifecycle effects without host switche
   assert.equal(extensionCalls, 0);
   assert.deepEqual(
     calls.map((call) => call.kind),
-    ["activate", "settings", "send", "settings", "cancel", "respond"]
+    [
+      "activate",
+      "settings",
+      "send",
+      "settings",
+      "cancel",
+      "pin",
+      "delete",
+      "respond"
+    ]
   );
   assert.deepEqual(calls[0]?.input, {
     agentSessionId: "session-1",
@@ -164,6 +194,15 @@ test("projects shared commands onto typed lifecycle effects without host switche
     commandId: "settings-1",
     correlationId: "settings-1",
     settings: { speed: "fast" },
+    workspaceId: "workspace-1"
+  });
+  assert.deepEqual(calls[5]?.input, {
+    agentSessionId: "session-1",
+    pinned: true,
+    workspaceId: "workspace-1"
+  });
+  assert.deepEqual(calls[6]?.input, {
+    agentSessionIds: ["session-1", "session-2"],
     workspaceId: "workspace-1"
   });
   assert.ok(calls.every((call) => call.signal instanceof AbortSignal));

--- a/packages/agent/activity-core/src/engine/effectExecutor.ts
+++ b/packages/agent/activity-core/src/engine/effectExecutor.ts
@@ -215,6 +215,14 @@ function executeCommand(
         },
         { signal }
       );
+    case "sessions/delete":
+      return effects.deleteSessions(
+        {
+          agentSessionIds: [...command.agentSessionIds],
+          workspaceId: command.workspaceId
+        },
+        { signal }
+      );
     case "interaction/respond":
       return effects.respondToInteraction(
         {
@@ -224,6 +232,15 @@ function executeCommand(
           ...(command.payload ? { payload: { ...command.payload } } : {}),
           requestId: command.requestId,
           turnId: command.turnId,
+          workspaceId: command.workspaceId
+        },
+        { signal }
+      );
+    case "session/setPinned":
+      return effects.setSessionPinned(
+        {
+          agentSessionId: command.agentSessionId,
+          pinned: command.pinned,
           workspaceId: command.workspaceId
         },
         { signal }

--- a/packages/agent/activity-core/src/engine/types.ts
+++ b/packages/agent/activity-core/src/engine/types.ts
@@ -191,6 +191,10 @@ export type EngineExternalCommandExceptPlanDecision = Exclude<
 >;
 
 type AgentSessionEffectCommand =
+  | Extract<
+      SessionMutationCommand,
+      { type: "session/setPinned" | "sessions/delete" }
+    >
   | InteractionRespondCommand
   | PromptQueueSendCommand
   | SessionActivateCommand
@@ -331,12 +335,20 @@ export interface AgentSessionEffectPort {
     input: AgentActivityCancelTurnInput,
     options?: EngineEffectOptions
   ): Promise<unknown>;
+  deleteSessions(
+    input: Omit<AgentActivityDeleteSessionsInput, "signal">,
+    options?: EngineEffectOptions
+  ): Promise<unknown>;
   respondToInteraction(
     input: AgentActivitySubmitInteractiveInput,
     options?: EngineEffectOptions
   ): Promise<unknown>;
   sendInput(
     input: AgentActivitySendInput,
+    options?: EngineEffectOptions
+  ): Promise<unknown>;
+  setSessionPinned(
+    input: Omit<AgentActivitySetSessionPinnedInput, "signal">,
     options?: EngineEffectOptions
   ): Promise<unknown>;
   updateSessionSettings(
@@ -467,8 +479,10 @@ import type {
 } from "./tuttiModeActivation.types.ts";
 import type {
   AgentActivityCancelTurnInput,
+  AgentActivityDeleteSessionsInput,
   AgentActivityInitialGoalControl,
   AgentActivitySendInput,
+  AgentActivitySetSessionPinnedInput,
   AgentActivitySessionSettings,
   AgentActivitySubmitDiagnostics,
   AgentActivitySubmitInteractiveInput,

--- a/packages/clients/tuttid-ts/src/index.test.ts
+++ b/packages/clients/tuttid-ts/src/index.test.ts
@@ -834,9 +834,15 @@ test("shared tuttid client forwards AbortSignal for Agent effect writes", async 
     { turnId: "turn-1" },
     options
   );
+  await client.updateWorkspaceAgentSessionPin(
+    "ws-1",
+    "session-1",
+    { pinned: true },
+    options
+  );
 
   abortController.abort();
-  assert.equal(requests.length, 4);
+  assert.equal(requests.length, 5);
   assert.equal(
     requests.every((request) => request.signal.aborted),
     true

--- a/packages/clients/tuttid-ts/src/tuttidClientTypes.ts
+++ b/packages/clients/tuttid-ts/src/tuttidClientTypes.ts
@@ -917,7 +917,8 @@ export interface TuttidClient
   updateWorkspaceAgentSessionPin(
     workspaceID: string,
     agentSessionID: string,
-    request: UpdateWorkspaceAgentSessionPinRequest
+    request: UpdateWorkspaceAgentSessionPinRequest,
+    requestOptions?: TuttidRequestOptions
   ): Promise<WorkspaceAgentSession>;
   updateWorkspaceAgentSessionTitle(
     workspaceID: string,

--- a/packages/clients/tuttid-ts/src/workspaceAgentClient.ts
+++ b/packages/clients/tuttid-ts/src/workspaceAgentClient.ts
@@ -604,12 +604,18 @@ export function createWorkspaceAgentClient(
         "Update workspace agent session settings failed."
       ).session;
     },
-    async updateWorkspaceAgentSessionPin(workspaceID, agentSessionID, request) {
+    async updateWorkspaceAgentSessionPin(
+      workspaceID,
+      agentSessionID,
+      request,
+      requestOptions
+    ) {
       return unwrapData(
         await updateWorkspaceAgentSessionPin({
           client,
           body: request,
-          path: { agentSessionID, workspaceID }
+          path: { agentSessionID, workspaceID },
+          ...requestOptions
         }),
         "Update workspace agent session pin failed."
       ).session;


### PR DESCRIPTION
## What changed

- Extend `AgentSessionEffectPort` with typed `setSessionPinned` and `deleteSessions` effects
- Move `session/setPinned` and `sessions/delete` command projection into the shared Engine effect executor
- Remove the duplicate pin/delete branches from the Desktop and Mobile extension command switches
- Propagate the Engine-owned `AbortSignal` through Desktop and Mobile pin requests
- Add request options support to `TuttidClient.updateWorkspaceAgentSessionPin`
- Preserve the authoritative pin Session result and batch-delete result shapes expected by Engine reducers
- Update the AgentGUI and Agent Activity architecture documentation

## Why

Pin and batch delete are canonical Session mutations implemented by Desktop and Mobile with the same semantics, but both hosts still translated the Engine commands independently. Pin also exposed a real cancellation gap: the Engine created an AbortSignal, but the shared tuttid client method could not accept it, so the underlying request continued after timeout or disposal.

The Engine now owns command-to-effect projection once. Hosts retain transport and DTO mapping, while platform-only commands remain in `EngineExtensionCommand` adapters.

## Impact

- Desktop and Mobile settle pin/delete through the same typed effect contract
- Pin requests can now be canceled through the full Engine-to-transport chain
- Batch-delete response mapping remains authoritative and consistent
- Existing legacy full-command consumers such as tsh remain source-compatible until their typed-port migration
- No new package-root helper exports were introduced; the existing typed port was extended

## Validation

- Activity Core typecheck and 333 tests passed
- Tuttid Client typecheck and 66 tests passed
- Mobile typecheck and 6 focused effect-port tests passed
- Desktop typecheck and 47 focused adapter/Engine-host tests passed
- `pnpm check:changed` — 19 lanes passed
- pre-push `pnpm check:changed -- --push-ready` — 21 lanes passed
- `git diff --check` passed