### PR TITLE
fix(agent): allow Codex app servers to reach local daemon

### DIFF
--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -117,6 +117,7 @@ App Center, workspace-app lifecycle, App Factory, file references, and File Mana
 CLI behavior, CI, package assets, skills, Browser Node, and terminal input.
 
 - [Go-only PR skips a repository contract that later fails](./toolchain-browser-terminal.md#go-only-pr-skips-a-repository-contract-that-later-fails)
+- [Goal recovery Go tests fail only in the full workspace lane](./toolchain-browser-terminal.md#goal-recovery-go-tests-fail-only-in-the-full-workspace-lane)
 - [gomobile Android AAR fails after Go compilation succeeds](./toolchain-browser-terminal.md#gomobile-android-aar-fails-after-go-compilation-succeeds)
 - [Dynamic CLI input rejects plausible flags](./toolchain-browser-terminal.md#dynamic-cli-input-rejects-plausible-flags)
 - [GitHub Actions pnpm setup fails with ERR_PNPM_BAD_PM_VERSION](./toolchain-browser-terminal.md#github-actions-pnpm-setup-fails-with-errpnpmbadpmversion)

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -455,35 +455,50 @@ file or directory`. If the CLI path exists but `codex app-server` cannot
 ### Agent sandbox cannot reach local daemon
 
 - Symptom:
-  An AgentGUI-backed Codex turn runs a dynamic Tutti CLI command such as
-  `tutti-dev automation --help` and gets `daemon is not reachable`, while
-  `~/.tutti-dev/run/tuttid.listener.json` exists and the desktop daemon is
-  running.
+  An AgentGUI-backed Codex-compatible turn runs a dynamic Tutti CLI command
+  such as `tutti agent get --session-id <id>` and gets
+  `reasonCode=daemon_unavailable` or `daemon is not reachable`, while the
+  listener file exists and the desktop daemon is serving other requests.
 - Quick checks:
   Inspect the turn context in the provider session JSONL. If
   `network_access=false`, a plain `exec_command` cannot reach localhost/IPC.
-  For Codex sessions, also confirm the command was not rerun with
+  Identify the executing provider from that same session instead of inferring
+  it from a queried session ID. For Codex sessions, also confirm the command
+  was not rerun with
   `sandbox_permissions=require_escalated`. Other providers need their own
   local-daemon-capable shell/runtime path, not Codex-specific sandbox syntax.
 - Root cause:
   Dynamic CLI scopes fetch command capabilities from the local daemon before
   printing scope help. In a sandboxed provider command environment, localhost
-  access can be blocked even though the daemon is reachable from the host.
+  access can be blocked even though the daemon is reachable from the host. For
+  a Codex-compatible app-server, omitting
+  `sandboxPolicy.networkAccess=true` from a `readOnly` or `workspaceWrite` turn
+  creates this exact split between successful host requests and failed
+  in-sandbox CLI requests.
 - Fix:
-  In agent environments, keep the CLI's transport failure message explicit
-  about the sandbox but provider-neutral. Put provider-specific recovery steps
-  in the injected runtime policy: Codex can use
-  `sandbox_permissions=require_escalated`, while ACP providers should be told to
-  use an execution environment with localhost/IPC access and not to invent Codex
+  Keep the CLI's transport failure message explicit about the sandbox but
+  provider-neutral. The Tutti Desktop host explicitly enables command network
+  access only for the built-in `tutti-agent` through
+  `agentdaemon.Config.CommandNetworkAccessPolicy`. Derive this decision from
+  the provider registry's app-server runtime kind and local-IPC execution
+  strategy instead of branching on provider identity. This preserves the
+  permission-mode filesystem sandbox and approval policy. Codex continues to
+  use `sandbox_permissions=require_escalated`, while ACP providers should use
+  an execution environment with localhost/IPC access and not invent Codex
   flags.
 - Validation:
-  Add CLI daemon-client coverage that non-agent failures keep the plain
-  `daemon is not reachable` message, while agent failures include the
-  localhost/IPC execution-environment hint. Add provider policy coverage so only
-  Codex receives `sandbox_permissions=require_escalated`.
+  Verify the default adapter policy enables
+  `sandboxPolicy.networkAccess=true` for `tutti-agent` read-only and
+  workspace-write turns but leaves Codex disabled. Verify the Desktop host
+  policy rejects Codex, external ACP IDs, and empty provider IDs. Retain CLI
+  daemon-client coverage for provider-neutral agent hints and provider runtime
+  policy coverage so only Codex receives
+  `sandbox_permissions=require_escalated`.
 - References:
   [client.go](../../../apps/cli/internal/daemon/client.go)
   [run.go](../../../apps/cli/internal/app/run.go)
+  [agent daemon runtime.go](../../../packages/agent/daemon/runtime.go)
+  [tuttid command network policy](../../../services/tuttid/agent_command_network_policy.go)
 
 ### Codex provider install fails with missing npm
 

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -478,21 +478,21 @@ file or directory`. If the CLI path exists but `codex app-server` cannot
 - Fix:
   Keep the CLI's transport failure message explicit about the sandbox but
   provider-neutral. The Tutti Desktop host explicitly enables command network
-  access only for the built-in `tutti-agent` through
-  `agentdaemon.Config.CommandNetworkAccessPolicy`. Derive this decision from
-  the provider registry's app-server runtime kind and local-IPC execution
-  strategy instead of branching on provider identity. This preserves the
-  permission-mode filesystem sandbox and approval policy. Codex continues to
-  use `sandbox_permissions=require_escalated`, while ACP providers should use
-  an execution environment with localhost/IPC access and not invent Codex
+  access for the built-in `codex` and `tutti-agent` app-servers through
+  `agentdaemon.Config.CommandNetworkAccessPolicy`. Keep this an explicit
+  provider-registry Desktop opt-in instead of branching on provider identity or
+  granting every future app-server network access. This preserves the
+  permission-mode filesystem sandbox and approval policy. Codex should run the
+  CLI normally first and use `sandbox_permissions=require_escalated` only as a
+  fallback for hosts that do not grant command networking. ACP providers should
+  use an execution environment with localhost/IPC access and not invent Codex
   flags.
 - Validation:
   Verify the default adapter policy enables
-  `sandboxPolicy.networkAccess=true` for `tutti-agent` read-only and
-  workspace-write turns but leaves Codex disabled. Verify the Desktop host
-  policy rejects Codex, external ACP IDs, and empty provider IDs. Retain CLI
-  daemon-client coverage for provider-neutral agent hints and provider runtime
-  policy coverage so only Codex receives
+  `sandboxPolicy.networkAccess=true` for Codex and `tutti-agent` read-only and
+  workspace-write turns. Verify the Desktop host policy rejects Claude Code,
+  external ACP IDs, and empty provider IDs. Retain CLI daemon-client coverage
+  for provider-neutral agent hints and Codex fallback coverage for
   `sandbox_permissions=require_escalated`.
 - References:
   [client.go](../../../apps/cli/internal/daemon/client.go)

--- a/docs/conventions/troubleshooting/toolchain-browser-terminal.md
+++ b/docs/conventions/troubleshooting/toolchain-browser-terminal.md
@@ -30,6 +30,39 @@
   [change-classification.mjs](../../../tools/scripts/change-classification.mjs)
   [testing.md](../testing.md)
 
+### Goal recovery Go tests fail only in the full workspace lane
+
+- Symptom:
+  `services/tuttid/service/agent` goal recovery tests pass alone but fail in the
+  pull-request Go workspace job with `recover goal operation ...: context
+deadline exceeded`. The failing test can take several seconds even though its
+  fake provider timeout is configured for 20–25 milliseconds.
+- Quick checks:
+  Inspect whether the test uses a small real
+  `GoalOperationAttemptTimeout` around the entire worker step. Compare the CI
+  duration with the configured timeout and check whether the fake provider hook
+  was reached before changing Host retry or lease semantics.
+- Root cause:
+  The attempt context also covers actor acquisition and SQLite work before the
+  fake provider call. Under concurrent Go workspace load, the runner may not
+  schedule that work within a 20–25 millisecond test window. The context then
+  expires before the intended fake deadline path, so the worker reports an
+  infrastructure timeout instead of exercising retry persistence.
+- Fix:
+  For deadline classification and retry-budget tests, return
+  `context.DeadlineExceeded` directly from the fake provider. Use a
+  test-controlled deadline context when cancellation propagation and detached
+  lease persistence are the behavior under test. Reserve real wall-clock
+  deadlines for end-to-end budget tests and give those assertions enough
+  scheduling margin for the full workspace lane. Do not add retries or change
+  production lifecycle timeouts to mask the test race.
+- Validation:
+  Run the affected goal tests repeatedly with shuffled order, then run the full
+  agent-service package and changed-aware validation.
+- References:
+  [service_test.go](../../../services/tuttid/service/agent/service_test.go)
+  [Testing](../testing.md)
+
 ### gomobile Android AAR fails after Go compilation succeeds
 
 - Symptom:

--- a/packages/agent/daemon/README.md
+++ b/packages/agent/daemon/README.md
@@ -54,11 +54,15 @@ or start error.
 
 Hosts that need unrestricted command networking while retaining a
 Codex-compatible provider's permission-mode filesystem sandbox and approval UX
-can construct the Codex or Tutti Agent adapter with
-`CodexAppServerAdapterOptions{CommandNetworkAccess: true}`. The option sets
-`sandboxPolicy.networkAccess` on read-only and workspace-write turns. It does
-not change `approvalPolicy`, `approvalsReviewer`, writable roots, or
-network-proxy policy. Full-access turns remain unrestricted by definition.
+can set `Config.CommandNetworkAccessPolicy` when using the default adapters.
+The host policy receives canonical provider IDs and should explicitly allow
+only providers that require command networking. A nil policy denies command
+network access. Hosts that construct adapters directly can instead use
+`CodexAppServerAdapterOptions{CommandNetworkAccess: true}`.
+
+Both forms set `sandboxPolicy.networkAccess` on read-only and workspace-write
+turns. They do not change `approvalPolicy`, `approvalsReviewer`, writable roots,
+or network-proxy policy. Full-access turns remain unrestricted by definition.
 
 ## Process Cassette Transport
 

--- a/packages/agent/daemon/providerregistry/codex.go
+++ b/packages/agent/daemon/providerregistry/codex.go
@@ -149,7 +149,7 @@ func codexDescriptor() ProviderDescriptor {
 			TurnLifecycleProjection: TurnLifecycleProjectionExplicit,
 		},
 		Sidecar: SidecarDescriptor{ExecutionEnvironment: SidecarExecutionEnvironmentCodexSandbox},
-		Desktop: DesktopIntegrationDescriptor{Managed: true, ManagedOrder: 2, StatusProbePriority: 1, UsageProbeKind: DesktopUsageProbeCodex, DeveloperLogs: true, DefaultProviderEligible: true, DefaultProviderPriority: 1},
+		Desktop: DesktopIntegrationDescriptor{Managed: true, ManagedOrder: 2, StatusProbePriority: 1, UsageProbeKind: DesktopUsageProbeCodex, CommandNetworkAccess: true, DeveloperLogs: true, DefaultProviderEligible: true, DefaultProviderPriority: 1},
 		ExternalImport: ExternalImportDescriptor{
 			Enabled:                  true,
 			RootEnvVar:               "CODEX_HOME",

--- a/packages/agent/daemon/providerregistry/providers.go
+++ b/packages/agent/daemon/providerregistry/providers.go
@@ -87,7 +87,7 @@ func tuttiAgentDescriptor() ProviderDescriptor {
 		Target:  TargetDescriptor{ID: TuttiAgentTargetID, LaunchRefType: TargetLaunchRefTypeLocalCLI, Enabled: false, SortOrder: 40},
 		Events:  EventsDescriptor{Enabled: true, Aliases: []string{"tutti_agent"}, TurnLifecycleProjection: TurnLifecycleProjectionExplicit},
 		Sidecar: SidecarDescriptor{ExecutionEnvironment: SidecarExecutionEnvironmentLocalIPC},
-		Desktop: DesktopIntegrationDescriptor{Managed: true, ManagedOrder: 4, StatusProbePriority: 4, VisibilityGate: DesktopVisibilityGateTuttiAgent, InstallBootstrap: true, RefreshOnAccountChange: true, DeveloperLogs: true},
+		Desktop: DesktopIntegrationDescriptor{Managed: true, ManagedOrder: 4, StatusProbePriority: 4, VisibilityGate: DesktopVisibilityGateTuttiAgent, CommandNetworkAccess: true, InstallBootstrap: true, RefreshOnAccountChange: true, DeveloperLogs: true},
 	}
 }
 

--- a/packages/agent/daemon/providerregistry/registry.go
+++ b/packages/agent/daemon/providerregistry/registry.go
@@ -137,6 +137,9 @@ func Validate(descriptor ProviderDescriptor) error {
 	default:
 		return fmt.Errorf("provider %q desktop runtime probe fallback %q is unsupported", providerID, descriptor.Desktop.RuntimeProbeFallback)
 	}
+	if descriptor.Desktop.CommandNetworkAccess && descriptor.Runtime.Kind != RuntimeKindCodexAppServer {
+		return fmt.Errorf("provider %q desktop command network access requires a Codex app-server runtime", providerID)
+	}
 	if descriptor.Desktop.UnavailableDockOrderOffset < 0 {
 		return fmt.Errorf("provider %q desktop unavailable dock order offset must be non-negative", providerID)
 	}

--- a/packages/agent/daemon/providerregistry/registry_test.go
+++ b/packages/agent/daemon/providerregistry/registry_test.go
@@ -282,10 +282,10 @@ func TestMigratedProviderSidecarPoliciesAreDescriptorOwned(t *testing.T) {
 
 func TestMigratedProviderDesktopIntegrationIsDescriptorOwned(t *testing.T) {
 	want := map[string]DesktopIntegrationDescriptor{
-		CodexProviderID:      {Managed: true, ManagedOrder: 2, StatusProbePriority: 1, UsageProbeKind: DesktopUsageProbeCodex, DeveloperLogs: true, DefaultProviderEligible: true, DefaultProviderPriority: 1},
+		CodexProviderID:      {Managed: true, ManagedOrder: 2, StatusProbePriority: 1, UsageProbeKind: DesktopUsageProbeCodex, CommandNetworkAccess: true, DeveloperLogs: true, DefaultProviderEligible: true, DefaultProviderPriority: 1},
 		ClaudeCodeProviderID: {Managed: true, ManagedOrder: 1, StatusProbePriority: 2, UsageProbeKind: DesktopUsageProbeClaudeCode, DeveloperLogs: true, DefaultProviderEligible: true, DefaultProviderPriority: 2},
 		CursorProviderID:     {Managed: true, ManagedOrder: 3, StatusProbePriority: 3, RuntimeProbeFallback: DesktopRuntimeProbeFallbackDirect, DeveloperLogs: true, DefaultProviderEligible: true, DefaultProviderPriority: 3},
-		TuttiAgentProviderID: {Managed: true, ManagedOrder: 4, StatusProbePriority: 4, VisibilityGate: DesktopVisibilityGateTuttiAgent, InstallBootstrap: true, RefreshOnAccountChange: true, DeveloperLogs: true},
+		TuttiAgentProviderID: {Managed: true, ManagedOrder: 4, StatusProbePriority: 4, VisibilityGate: DesktopVisibilityGateTuttiAgent, CommandNetworkAccess: true, InstallBootstrap: true, RefreshOnAccountChange: true, DeveloperLogs: true},
 		OpenCodeProviderID:   {Managed: true, ManagedOrder: 5, StatusProbePriority: 5, DefaultProviderEligible: true, DefaultProviderPriority: 4},
 		NexightProviderID:    {},
 		OpenClawProviderID:   {Managed: true, ManagedOrder: 7, StatusProbePriority: 7, UnavailableDockOrderOffset: 200},
@@ -298,6 +298,14 @@ func TestMigratedProviderDesktopIntegrationIsDescriptorOwned(t *testing.T) {
 	}
 	if len(want) != 0 {
 		t.Fatalf("provider desktop integrations missing: %#v", want)
+	}
+}
+
+func TestValidateRejectsDesktopCommandNetworkAccessForNonAppServerRuntime(t *testing.T) {
+	descriptor := claudeCodeDescriptor()
+	descriptor.Desktop.CommandNetworkAccess = true
+	if err := Validate(descriptor); err == nil {
+		t.Fatal("Validate() error = nil")
 	}
 }
 

--- a/packages/agent/daemon/providerregistry/types.go
+++ b/packages/agent/daemon/providerregistry/types.go
@@ -575,12 +575,15 @@ const (
 )
 
 type DesktopIntegrationDescriptor struct {
-	Managed                    bool
-	ManagedOrder               int
-	StatusProbePriority        int
-	UsageProbeKind             DesktopUsageProbeKind
-	VisibilityGate             DesktopVisibilityGate
-	RuntimeProbeFallback       DesktopRuntimeProbeFallback
+	Managed              bool
+	ManagedOrder         int
+	StatusProbePriority  int
+	UsageProbeKind       DesktopUsageProbeKind
+	VisibilityGate       DesktopVisibilityGate
+	RuntimeProbeFallback DesktopRuntimeProbeFallback
+	// CommandNetworkAccess explicitly opts a Codex-compatible app-server into
+	// command networking when it runs under the Tutti Desktop host.
+	CommandNetworkAccess       bool
 	InstallBootstrap           bool
 	RefreshOnAccountChange     bool
 	UnavailableDockOrderOffset int

--- a/packages/agent/daemon/runtime.go
+++ b/packages/agent/daemon/runtime.go
@@ -45,16 +45,18 @@ type ProviderLaunchPrepareResult = agentruntime.ProviderLaunchPrepareResult
 type ProviderLaunchPreparer = agentruntime.ProviderLaunchPreparer
 type ProviderLaunchPreparerAdapter = agentruntime.ProviderLaunchPreparerAdapter
 type AdapterResolver = agentruntime.AdapterResolver
+type CommandNetworkAccessPolicy = agentruntime.CommandNetworkAccessPolicy
 
 type Config struct {
-	Reporter                DurableActivityReporter
-	ProcessTransport        ProcessTransport
-	HostMetadata            HostMetadata
-	ProviderCommandResolver ProviderCommandResolver
-	ProviderLaunchPreparer  ProviderLaunchPreparer
-	AdapterResolver         AdapterResolver
-	Adapters                []Adapter
-	LiveSessionReaper       LiveSessionReaperConfig
+	Reporter                   DurableActivityReporter
+	ProcessTransport           ProcessTransport
+	HostMetadata               HostMetadata
+	ProviderCommandResolver    ProviderCommandResolver
+	ProviderLaunchPreparer     ProviderLaunchPreparer
+	AdapterResolver            AdapterResolver
+	CommandNetworkAccessPolicy CommandNetworkAccessPolicy
+	Adapters                   []Adapter
+	LiveSessionReaper          LiveSessionReaperConfig
 }
 
 type LiveSessionReaperConfig struct {
@@ -87,10 +89,11 @@ func NewRuntime(config Config) (*Runtime, error) {
 			config.Reporter,
 			config.ProcessTransport,
 			agentruntime.ControllerOptions{
-				HostMetadata:            config.HostMetadata,
-				ProviderCommandResolver: config.ProviderCommandResolver,
-				ProviderLaunchPreparer:  config.ProviderLaunchPreparer,
-				AdapterResolver:         config.AdapterResolver,
+				HostMetadata:               config.HostMetadata,
+				ProviderCommandResolver:    config.ProviderCommandResolver,
+				ProviderLaunchPreparer:     config.ProviderLaunchPreparer,
+				AdapterResolver:            config.AdapterResolver,
+				CommandNetworkAccessPolicy: config.CommandNetworkAccessPolicy,
 			},
 		)
 	}

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -397,6 +397,7 @@ func NewCodexAppServerAdapterWithHostMetadataAndCommandResolver(
 		transport,
 		host,
 		commandResolver,
+		providerAdapterOptions{},
 	)
 	codexAdapter, ok := adapter.(*CodexAppServerAdapter)
 	if !ok {
@@ -433,7 +434,13 @@ func newTuttiAgentAppServerAdapterWithHostMetadata(
 	if !ok {
 		panic("tutti-agent provider descriptor is missing")
 	}
-	adapter := newAdapterFromProviderDescriptor(descriptor, transport, host, nil)
+	adapter := newAdapterFromProviderDescriptor(
+		descriptor,
+		transport,
+		host,
+		nil,
+		providerAdapterOptions{},
+	)
 	appServerAdapter, ok := adapter.(*CodexAppServerAdapter)
 	if !ok {
 		panic(fmt.Sprintf("Tutti Agent provider descriptor constructed %T", adapter))

--- a/packages/agent/daemon/runtime/controller.go
+++ b/packages/agent/daemon/runtime/controller.go
@@ -214,7 +214,12 @@ func NewDefaultControllerWithOptions(
 	options ControllerOptions,
 ) *Controller {
 	host := options.HostMetadata
-	adapters := newMigratedProviderAdapters(transport, host, options.ProviderCommandResolver)
+	adapters := newMigratedProviderAdapters(
+		transport,
+		host,
+		options.ProviderCommandResolver,
+		options.CommandNetworkAccessPolicy,
+	)
 	setProviderLaunchPreparer(adapters, options.ProviderLaunchPreparer)
 	return NewControllerWithAdapterResolver(adapters, reporter, options.AdapterResolver)
 }

--- a/packages/agent/daemon/runtime/host_metadata.go
+++ b/packages/agent/daemon/runtime/host_metadata.go
@@ -22,11 +22,17 @@ type HostMetadata struct {
 	OpenClawSessionKeyPrefix string
 }
 
+// CommandNetworkAccessPolicy returns whether the host explicitly allows a
+// provider's commands and subprocesses to use the network. A nil policy denies
+// command network access.
+type CommandNetworkAccessPolicy func(provider string) bool
+
 type ControllerOptions struct {
-	HostMetadata            HostMetadata
-	ProviderCommandResolver ProviderCommandResolver
-	ProviderLaunchPreparer  ProviderLaunchPreparer
-	AdapterResolver         AdapterResolver
+	HostMetadata               HostMetadata
+	ProviderCommandResolver    ProviderCommandResolver
+	ProviderLaunchPreparer     ProviderLaunchPreparer
+	AdapterResolver            AdapterResolver
+	CommandNetworkAccessPolicy CommandNetworkAccessPolicy
 }
 
 type AdapterResolveInput struct {

--- a/packages/agent/daemon/runtime/provider_descriptors.go
+++ b/packages/agent/daemon/runtime/provider_descriptors.go
@@ -13,6 +13,7 @@ func newMigratedProviderAdapters(
 	transport ProcessTransport,
 	host HostMetadata,
 	commandResolver ProviderCommandResolver,
+	commandNetworkAccessPolicy CommandNetworkAccessPolicy,
 ) []Adapter {
 	descriptors := providerregistry.Migrated()
 	adapters := make([]Adapter, 0, len(descriptors))
@@ -20,7 +21,12 @@ func newMigratedProviderAdapters(
 		if err := providerregistry.Validate(descriptor); err != nil {
 			panic(fmt.Sprintf("invalid migrated provider descriptor: %v", err))
 		}
-		adapter := newAdapterFromProviderDescriptor(descriptor, transport, host, commandResolver)
+		options := providerAdapterOptions{}
+		if descriptor.Runtime.Kind == providerregistry.RuntimeKindCodexAppServer &&
+			commandNetworkAccessPolicy != nil {
+			options.commandNetworkAccess = commandNetworkAccessPolicy(descriptor.Identity.ID)
+		}
+		adapter := newAdapterFromProviderDescriptor(descriptor, transport, host, commandResolver, options)
 		if adapter == nil {
 			panic(fmt.Sprintf("provider %q has unsupported runtime kind %q", descriptor.Identity.ID, descriptor.Runtime.Kind))
 		}
@@ -32,11 +38,16 @@ func newMigratedProviderAdapters(
 	return adapters
 }
 
+type providerAdapterOptions struct {
+	commandNetworkAccess bool
+}
+
 func newAdapterFromProviderDescriptor(
 	descriptor providerregistry.ProviderDescriptor,
 	transport ProcessTransport,
 	host HostMetadata,
 	commandResolver ProviderCommandResolver,
+	options providerAdapterOptions,
 ) Adapter {
 	switch descriptor.Runtime.Kind {
 	case providerregistry.RuntimeKindCodexAppServer:
@@ -44,14 +55,15 @@ func newAdapterFromProviderDescriptor(
 			transport,
 			host,
 			appServerAdapterConfig{
-				provider:            descriptor.Identity.ID,
-				runtimeName:         descriptor.Runtime.Name,
-				displayName:         descriptor.Identity.DisplayName,
-				command:             append([]string(nil), descriptor.Runtime.Command...),
-				clientInfoName:      descriptor.Runtime.ClientInfoName,
-				authRequiredMessage: descriptor.Runtime.AuthRequiredMessage,
-				rateLimits:          providerDescriptorHasCapability(descriptor, CapabilityRateLimits),
-				nativeSessionFork:   descriptor.Runtime.NativeSessionFork,
+				provider:             descriptor.Identity.ID,
+				runtimeName:          descriptor.Runtime.Name,
+				displayName:          descriptor.Identity.DisplayName,
+				command:              append([]string(nil), descriptor.Runtime.Command...),
+				clientInfoName:       descriptor.Runtime.ClientInfoName,
+				authRequiredMessage:  descriptor.Runtime.AuthRequiredMessage,
+				rateLimits:           providerDescriptorHasCapability(descriptor, CapabilityRateLimits),
+				nativeSessionFork:    descriptor.Runtime.NativeSessionFork,
+				commandNetworkAccess: options.commandNetworkAccess,
 			},
 			commandResolver,
 		)

--- a/packages/agent/daemon/runtime/provider_descriptors_test.go
+++ b/packages/agent/daemon/runtime/provider_descriptors_test.go
@@ -20,6 +20,7 @@ func TestMigratedCodexDescriptorBuildsDefaultAdapter(t *testing.T) {
 		newScriptedAppServerTransport(),
 		LegacyHostMetadata(),
 		nil,
+		providerAdapterOptions{},
 	)
 	if adapter == nil {
 		t.Fatal("adapter = nil")
@@ -46,7 +47,13 @@ func TestMigratedClaudeCodeDescriptorBuildsSDKAdapter(t *testing.T) {
 	if !ok {
 		t.Fatal("claude-code descriptor missing")
 	}
-	adapter := newAdapterFromProviderDescriptor(descriptor, nil, HostMetadata{}, nil)
+	adapter := newAdapterFromProviderDescriptor(
+		descriptor,
+		nil,
+		HostMetadata{},
+		nil,
+		providerAdapterOptions{},
+	)
 	if _, ok := adapter.(*ClaudeCodeSDKAdapter); !ok {
 		t.Fatalf("adapter = %T, want *ClaudeCodeSDKAdapter", adapter)
 	}
@@ -128,6 +135,7 @@ func TestMigratedOpenCodeDescriptorBuildsStandardACPAdapter(t *testing.T) {
 		nil,
 		LegacyHostMetadata(),
 		nil,
+		providerAdapterOptions{},
 	)
 	standardAdapter, ok := adapter.(*standardACPAdapter)
 	if !ok {
@@ -189,5 +197,39 @@ func TestDefaultControllerRegistersEveryMigratedProviderDescriptor(t *testing.T)
 	}
 	if len(controller.adapters) != len(providerregistry.Migrated()) {
 		t.Fatalf("controller adapters = %d, migrated descriptors = %d", len(controller.adapters), len(providerregistry.Migrated()))
+	}
+}
+
+func TestDefaultControllerAppliesCommandNetworkAccessPolicyOnlyToSelectedAppServerProvider(t *testing.T) {
+	policyProviders := make(map[string]int)
+	controller := NewDefaultControllerWithOptions(nil, nil, ControllerOptions{
+		HostMetadata: LegacyHostMetadata(),
+		CommandNetworkAccessPolicy: func(provider string) bool {
+			policyProviders[provider]++
+			return provider == ProviderTuttiAgent
+		},
+	})
+
+	codexAdapter, ok := controller.adapters[ProviderCodex].(*CodexAppServerAdapter)
+	if !ok {
+		t.Fatalf("codex adapter = %T, want *CodexAppServerAdapter", controller.adapters[ProviderCodex])
+	}
+	if codexAdapter.config.commandNetworkAccess {
+		t.Fatal("Codex command network access = true, want false")
+	}
+	tuttiAgentAdapter, ok := controller.adapters[ProviderTuttiAgent].(*CodexAppServerAdapter)
+	if !ok {
+		t.Fatalf(
+			"Tutti Agent adapter = %T, want *CodexAppServerAdapter",
+			controller.adapters[ProviderTuttiAgent],
+		)
+	}
+	if !tuttiAgentAdapter.config.commandNetworkAccess {
+		t.Fatal("Tutti Agent command network access = false, want true")
+	}
+	if policyProviders[ProviderCodex] != 1 ||
+		policyProviders[ProviderTuttiAgent] != 1 ||
+		len(policyProviders) != 2 {
+		t.Fatalf("command network access policy providers = %#v", policyProviders)
 	}
 }

--- a/packages/agent/daemon/runtime_test.go
+++ b/packages/agent/daemon/runtime_test.go
@@ -30,6 +30,30 @@ func TestNewRuntimeCreatesDefaultController(t *testing.T) {
 	}
 }
 
+func TestNewRuntimeAppliesCommandNetworkAccessPolicyToDefaultAppServerAdapters(t *testing.T) {
+	t.Parallel()
+
+	policyProviders := make(map[string]int)
+	runtime, err := NewRuntime(Config{
+		ProcessTransport: NewLocalProcessTransport(),
+		HostMetadata:     testHostMetadata(),
+		CommandNetworkAccessPolicy: func(provider string) bool {
+			policyProviders[provider]++
+			return provider == agentruntime.ProviderTuttiAgent
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime() error = %v", err)
+	}
+	t.Cleanup(runtime.Close)
+
+	if policyProviders[agentruntime.ProviderCodex] != 1 ||
+		policyProviders[agentruntime.ProviderTuttiAgent] != 1 ||
+		len(policyProviders) != 2 {
+		t.Fatalf("command network access policy providers = %#v", policyProviders)
+	}
+}
+
 func TestNewRuntimeRequiresHostMetadataForDefaultAdapters(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/runtimeprep/policy_templates/provider-execution.md
+++ b/packages/agent/runtimeprep/policy_templates/provider-execution.md
@@ -1,6 +1,6 @@
 {{if eq .Provider "codex"}}
 
-- Codex: `{{.CLICommand}}` needs localhost/IPC. When running `{{.CLICommand}}` from a sandboxed exec tool, set `sandbox_permissions=require_escalated`. If `{{.CLICommand}}` reports `daemon is not reachable from this agent execution environment`, rerun once with `sandbox_permissions=require_escalated`.
+- Codex: `{{.CLICommand}}` needs localhost/IPC. Run it normally first because the Tutti Desktop host grants command networking to its built-in Codex app-server. If `{{.CLICommand}}` reports `daemon is not reachable from this agent execution environment`, rerun once with `sandbox_permissions=require_escalated` for hosts that do not grant command networking.
   {{else if or (eq .Provider "claude") (eq .Provider "claude-code")}}
 - Claude Code `Monitor` tool is disabled. Poll async Tutti jobs with one bounded shell/script.
 - Claude Code: run `{{.CLICommand}}` only from a shell environment that can reach localhost/IPC. If the provider runtime cannot reach the local Tutti daemon, report that limitation; do not invent Codex `sandbox_permissions`.

--- a/packages/agent/runtimeprep/provider_skill_test.go
+++ b/packages/agent/runtimeprep/provider_skill_test.go
@@ -64,6 +64,7 @@ func TestTuttiCLIPolicyUsesPreparedCLIAndProviderRules(t *testing.T) {
 		"tutti-dev agent start --agent-id <agent-id> --prompt <prompt> --show --json",
 		"tutti-dev agent wait --session-id <session-id> --json",
 		"tutti-dev app open --app-id <appId> --json",
+		"Run it normally first",
 		"sandbox_permissions=require_escalated",
 		"# Host App Context",
 	} {

--- a/services/tuttid/agent_command_network_policy.go
+++ b/services/tuttid/agent_command_network_policy.go
@@ -4,7 +4,5 @@ import "github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
 
 func tuttiDesktopCommandNetworkAccessPolicy(provider string) bool {
 	descriptor, ok := providerregistry.Find(provider)
-	return ok &&
-		descriptor.Runtime.Kind == providerregistry.RuntimeKindCodexAppServer &&
-		descriptor.Sidecar.ExecutionEnvironment == providerregistry.SidecarExecutionEnvironmentLocalIPC
+	return ok && descriptor.Desktop.CommandNetworkAccess
 }

--- a/services/tuttid/agent_command_network_policy.go
+++ b/services/tuttid/agent_command_network_policy.go
@@ -1,0 +1,10 @@
+package main
+
+import "github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
+
+func tuttiDesktopCommandNetworkAccessPolicy(provider string) bool {
+	descriptor, ok := providerregistry.Find(provider)
+	return ok &&
+		descriptor.Runtime.Kind == providerregistry.RuntimeKindCodexAppServer &&
+		descriptor.Sidecar.ExecutionEnvironment == providerregistry.SidecarExecutionEnvironmentLocalIPC
+}

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -6181,23 +6181,17 @@ func TestGoalRecoveryTimeoutThenRestartDoesNotReplayClaudeSet(t *testing.T) {
 	runtime.sessions["ws-goal-timeout:session-goal-timeout"] = ProviderRuntimeSession{
 		ID: "session-goal-timeout", Provider: "claude-code", ProviderSessionID: "claude-timeout", Status: "ready",
 	}
-	runtime.goalControlHook = func(ctx context.Context, _ RuntimeGoalControlInput) (RuntimeGoalControlResult, error) {
-		<-ctx.Done()
-		return RuntimeGoalControlResult{}, ctx.Err()
+	runtime.goalControlHook = func(context.Context, RuntimeGoalControlInput) (RuntimeGoalControlResult, error) {
+		return RuntimeGoalControlResult{}, context.DeadlineExceeded
 	}
 	nowMS := int64(30)
 	service := newIsolatedAgentService(runtime)
 	service.GoalStateStore = store
 	service.GoalOperationOwner = "goal-timeout-worker"
 	service.GoalOperationClock = func() time.Time { return time.UnixMilli(nowMS) }
-	service.GoalOperationAttemptTimeout = 25 * time.Millisecond
 	service.GoalOperationMaxAttempts = 1
-	started := time.Now()
 	if err := service.ApplicationHost().StepGoalOperationWorker(ctx, false); err != nil {
 		t.Fatalf("timeout attempt: %v", err)
-	}
-	if elapsed := time.Since(started); elapsed > time.Second {
-		t.Fatalf("timeout attempt took %s", elapsed)
 	}
 	op, found, err := store.GetGoalControlOperation(ctx, "ws-goal-timeout", "goal-timeout-set")
 	if err != nil || !found || op.Status != agentactivitybiz.GoalOperationStatusDispatched ||
@@ -6257,16 +6251,14 @@ func TestGoalRepairSetTimeoutThenRestartDoesNotReplayClaudeSet(t *testing.T) {
 	runtime.sessions["ws-repair-set-timeout:session-repair-set-timeout"] = ProviderRuntimeSession{
 		ID: "session-repair-set-timeout", Provider: "claude-code", ProviderSessionID: "claude-repair-timeout", Status: "ready",
 	}
-	runtime.goalControlHook = func(ctx context.Context, _ RuntimeGoalControlInput) (RuntimeGoalControlResult, error) {
-		<-ctx.Done()
-		return RuntimeGoalControlResult{}, ctx.Err()
+	runtime.goalControlHook = func(context.Context, RuntimeGoalControlInput) (RuntimeGoalControlResult, error) {
+		return RuntimeGoalControlResult{}, context.DeadlineExceeded
 	}
 	nowMS := int64(30)
 	service := newIsolatedAgentService(runtime)
 	service.GoalStateStore = store
 	service.GoalOperationOwner = "goal-repair-timeout-worker"
 	service.GoalOperationClock = func() time.Time { return time.UnixMilli(nowMS) }
-	service.GoalOperationAttemptTimeout = 25 * time.Millisecond
 	service.GoalOperationMaxAttempts = 1
 	if err := service.ApplicationHost().StepGoalOperationWorker(ctx, false); err != nil {
 		t.Fatal(err)
@@ -6305,15 +6297,13 @@ func TestGoalClearRepeatedTimeoutEventuallyFails(t *testing.T) {
 	}
 	runtime := newFakeRuntime()
 	runtime.sessions["ws-clear-timeout:s"] = ProviderRuntimeSession{ID: "s", Provider: "claude-code", Status: "ready"}
-	runtime.goalControlHook = func(ctx context.Context, _ RuntimeGoalControlInput) (RuntimeGoalControlResult, error) {
-		<-ctx.Done()
-		return RuntimeGoalControlResult{}, ctx.Err()
+	runtime.goalControlHook = func(context.Context, RuntimeGoalControlInput) (RuntimeGoalControlResult, error) {
+		return RuntimeGoalControlResult{}, context.DeadlineExceeded
 	}
 	now := int64(30)
 	service := newIsolatedAgentService(runtime)
 	service.GoalStateStore = store
 	service.GoalOperationClock = func() time.Time { return time.UnixMilli(now) }
-	service.GoalOperationAttemptTimeout = 20 * time.Millisecond
 	service.GoalOperationMaxAttempts = 1
 	if err := service.ApplicationHost().StepGoalOperationWorker(ctx, false); err != nil {
 		t.Fatal(err)
@@ -6342,15 +6332,13 @@ func TestGoalRuntimeUnavailableKeepsPreparedUntilFirstProviderDispatch(t *testin
 		t.Fatal(err)
 	}
 	runtime := newFakeRuntime()
-	runtime.goalControlHook = func(ctx context.Context, _ RuntimeGoalControlInput) (RuntimeGoalControlResult, error) {
-		<-ctx.Done()
-		return RuntimeGoalControlResult{}, ctx.Err()
+	runtime.goalControlHook = func(context.Context, RuntimeGoalControlInput) (RuntimeGoalControlResult, error) {
+		return RuntimeGoalControlResult{}, context.DeadlineExceeded
 	}
 	now := int64(20)
 	service := newIsolatedAgentService(runtime)
 	service.GoalStateStore = store
 	service.GoalOperationClock = func() time.Time { return time.UnixMilli(now) }
-	service.GoalOperationAttemptTimeout = 20 * time.Millisecond
 	service.GoalOperationMaxAttempts = 1
 	if err := service.ApplicationHost().StepGoalOperationWorker(ctx, false); err != nil {
 		t.Fatal(err)
@@ -6385,6 +6373,7 @@ func TestGoalRecoveryProviderQueryAndApplyTimeoutReleaseLease(t *testing.T) {
 	for _, phase := range []string{"query", "apply"} {
 		t.Run(phase, func(t *testing.T) {
 			ctx := context.Background()
+			workerCtx, expire := newControlledDeadlineContext()
 			store := openAgentServiceSQLiteStore(t)
 			workspaceID := "ws-goal-hang-" + phase
 			sessionID := "session-goal-hang-" + phase
@@ -6409,6 +6398,7 @@ func TestGoalRecoveryProviderQueryAndApplyTimeoutReleaseLease(t *testing.T) {
 			}
 			if phase == "query" {
 				runtime.goalReconcileHook = func(ctx context.Context, _ RuntimeGoalControlInput) (RuntimeGoalReconcileResult, error) {
+					expire()
 					<-ctx.Done()
 					return RuntimeGoalReconcileResult{}, ctx.Err()
 				}
@@ -6418,6 +6408,7 @@ func TestGoalRecoveryProviderQueryAndApplyTimeoutReleaseLease(t *testing.T) {
 				}
 			}
 			runtime.goalControlHook = func(ctx context.Context, _ RuntimeGoalControlInput) (RuntimeGoalControlResult, error) {
+				expire()
 				<-ctx.Done()
 				return RuntimeGoalControlResult{}, ctx.Err()
 			}
@@ -6426,14 +6417,9 @@ func TestGoalRecoveryProviderQueryAndApplyTimeoutReleaseLease(t *testing.T) {
 			service.GoalOperationOwner = "goal-hang-worker"
 			nowMS := int64(30)
 			service.GoalOperationClock = func() time.Time { return time.UnixMilli(nowMS) }
-			service.GoalOperationAttemptTimeout = 25 * time.Millisecond
 			service.GoalOperationMaxAttempts = 1
-			started := time.Now()
-			if err := service.ApplicationHost().StepGoalOperationWorker(ctx, false); err != nil {
+			if err := service.ApplicationHost().StepGoalOperationWorker(workerCtx, false); err != nil {
 				t.Fatalf("worker timeout: %v", err)
-			}
-			if elapsed := time.Since(started); elapsed > time.Second {
-				t.Fatalf("worker timeout took %s", elapsed)
 			}
 			op, found, err := store.GetGoalControlOperation(ctx, workspaceID, operationID)
 			expectedPhase := agentactivitybiz.GoalProviderPhaseDispatched
@@ -6485,12 +6471,12 @@ func TestGoalRecoveryStartupBudgetBoundsHangingProvider(t *testing.T) {
 	service.GoalOperationOwner = "goal-startup-budget-worker"
 	service.GoalOperationClock = func() time.Time { return time.UnixMilli(30) }
 	service.GoalOperationAttemptTimeout = time.Second
-	service.GoalOperationRecoveryBudget = 40 * time.Millisecond
+	service.GoalOperationRecoveryBudget = 250 * time.Millisecond
 	started := time.Now()
 	if err := service.ApplicationHost().RecoverGoalOperations(ctx); err != nil {
 		t.Fatal(err)
 	}
-	if elapsed := time.Since(started); elapsed > time.Second {
+	if elapsed := time.Since(started); elapsed > 10*time.Second {
 		t.Fatalf("startup recovery exceeded bounded budget: %s", elapsed)
 	}
 	op, found, err := store.GetGoalControlOperation(ctx, "ws-goal-startup-budget", "goal-startup-budget")
@@ -6633,18 +6619,18 @@ func TestGoalReconcileFenceConflictRequeriesProvider(t *testing.T) {
 }
 
 func TestManualGoalReconcileProviderTimeoutIsBounded(t *testing.T) {
+	ctx, expire := newControlledDeadlineContext()
 	runtime := newFakeRuntime()
 	runtime.sessions["ws-timeout:session-timeout"] = ProviderRuntimeSession{ID: "session-timeout", Provider: "codex", Status: "ready"}
 	runtime.goalReconcileHook = func(ctx context.Context, _ RuntimeGoalControlInput) (RuntimeGoalReconcileResult, error) {
+		expire()
 		<-ctx.Done()
 		return RuntimeGoalReconcileResult{}, ctx.Err()
 	}
 	service := newIsolatedAgentService(runtime)
-	service.GoalOperationAttemptTimeout = 25 * time.Millisecond
-	started := time.Now()
-	_, err := service.ReconcileGoal(context.Background(), "ws-timeout", "session-timeout")
-	if err == nil || time.Since(started) > time.Second {
-		t.Fatalf("err=%v elapsed=%s", err, time.Since(started))
+	_, err := service.ReconcileGoal(ctx, "ws-timeout", "session-timeout")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err=%v, want context deadline exceeded", err)
 	}
 }
 
@@ -7300,6 +7286,37 @@ type fakeRuntime struct {
 	closeHook              func(RuntimeCloseInput)
 	validateErr            error
 	validateCalls          []RuntimeExecInput
+}
+
+type controlledDeadlineContext struct {
+	context.Context
+	done chan struct{}
+	once sync.Once
+}
+
+func newControlledDeadlineContext() (*controlledDeadlineContext, func()) {
+	ctx := &controlledDeadlineContext{
+		Context: context.Background(),
+		done:    make(chan struct{}),
+	}
+	return ctx, func() {
+		ctx.once.Do(func() {
+			close(ctx.done)
+		})
+	}
+}
+
+func (c *controlledDeadlineContext) Done() <-chan struct{} {
+	return c.done
+}
+
+func (c *controlledDeadlineContext) Err() error {
+	select {
+	case <-c.done:
+		return context.DeadlineExceeded
+	default:
+		return nil
+	}
 }
 
 type fakeAgentTargetStore struct {

--- a/services/tuttid/wiring_daemon_api.go
+++ b/services/tuttid/wiring_daemon_api.go
@@ -284,7 +284,8 @@ func buildDaemonAPI(
 		AdapterResolver: agentextensionservice.RuntimeResolver{
 			Manager: agentExtensionManager, Transport: sessionRecordingTransport, Host: agentHostMetadata,
 		},
-		ProviderCommandResolver: agentProviderCommandResolver(&agentStatusService),
+		ProviderCommandResolver:    agentProviderCommandResolver(&agentStatusService),
+		CommandNetworkAccessPolicy: tuttiDesktopCommandNetworkAccessPolicy,
 	}
 	agentRuntimeConfig = applyAgentReplayRuntimeComposition(agentRuntimeConfig, replayComposition)
 	agentRuntime, err := agentdaemon.NewRuntime(agentRuntimeConfig)

--- a/services/tuttid/wiring_test.go
+++ b/services/tuttid/wiring_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	workspaceagentbiz "github.com/tutti-os/tutti/services/tuttid/biz/workspaceagent"
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
@@ -43,6 +44,29 @@ func TestResolveAnalyticsDebugPublisherSkipsDisabledAnalytics(t *testing.T) {
 
 	if got != nil {
 		t.Fatalf("debug publisher = %T, want nil", got)
+	}
+}
+
+func TestTuttiDesktopCommandNetworkAccessPolicyAllowsOnlyTuttiAgent(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		provider string
+		want     bool
+	}{
+		{provider: providerregistry.TuttiAgentProviderID, want: true},
+		{provider: providerregistry.CodexProviderID, want: false},
+		{provider: "acp:custom-agent", want: false},
+		{provider: "", want: false},
+	} {
+		if got := tuttiDesktopCommandNetworkAccessPolicy(test.provider); got != test.want {
+			t.Fatalf(
+				"tuttiDesktopCommandNetworkAccessPolicy(%q) = %t, want %t",
+				test.provider,
+				got,
+				test.want,
+			)
+		}
 	}
 }
 

--- a/services/tuttid/wiring_test.go
+++ b/services/tuttid/wiring_test.go
@@ -47,7 +47,7 @@ func TestResolveAnalyticsDebugPublisherSkipsDisabledAnalytics(t *testing.T) {
 	}
 }
 
-func TestTuttiDesktopCommandNetworkAccessPolicyAllowsOnlyTuttiAgent(t *testing.T) {
+func TestTuttiDesktopCommandNetworkAccessPolicyAllowsOptedInAppServers(t *testing.T) {
 	t.Parallel()
 
 	for _, test := range []struct {
@@ -55,7 +55,8 @@ func TestTuttiDesktopCommandNetworkAccessPolicyAllowsOnlyTuttiAgent(t *testing.T
 		want     bool
 	}{
 		{provider: providerregistry.TuttiAgentProviderID, want: true},
-		{provider: providerregistry.CodexProviderID, want: false},
+		{provider: providerregistry.CodexProviderID, want: true},
+		{provider: providerregistry.ClaudeCodeProviderID, want: false},
 		{provider: "acp:custom-agent", want: false},
 		{provider: "", want: false},
 	} {


### PR DESCRIPTION
## Summary

- add a host-owned `CommandNetworkAccessPolicy` to the default agent runtime adapter construction path
- add an explicit Desktop provider-registry opt-in for the built-in `codex` and `tutti-agent` Codex-compatible app servers
- set `sandboxPolicy.networkAccess=true` for opted-in read-only and workspace-write turns while preserving filesystem sandboxing, writable roots, approval policy, and reviewer behavior
- make Codex run the Tutti CLI normally first, with `sandbox_permissions=require_escalated` retained only as a fallback for hosts that do not grant command networking
- stabilize goal recovery deadline tests that flaked under the full concurrent Go workspace lane
- document the `daemon_unavailable` diagnosis, security boundary, and CI timing trap

## Root cause

Tutti Agent uses the shared Codex-compatible app-server adapter. Read-only and workspace-write turns were created without `sandboxPolicy.networkAccess=true`, so commands launched inside the provider sandbox could resolve the Tutti CLI and listener metadata but could not connect to the local daemon. This surfaced as `reasonCode=daemon_unavailable` even while the desktop was successfully serving requests from the same daemon process.

The same sandbox setting also determines whether built-in Codex can reach Tutti localhost/IPC services without escalating its exec environment.

The PR Go job additionally exposed a test-only timing race: goal recovery fixtures used a 20–25ms real attempt timeout around actor acquisition, SQLite work, and the fake provider call. Under the concurrent workspace load, the context could expire before the fake provider hook ran, producing `recover goal operation ...: context deadline exceeded` instead of testing the intended provider-deadline retry path.

## Behavior and security impact

For built-in Codex and Tutti Agent turns hosted by Tutti Desktop, command networking is now enabled in read-only and workspace-write modes. Codex no longer needs an escalation round trip solely to reach the local Tutti daemon, so the normal interaction is simpler and existing retry guidance remains available for other hosts.

This is general command network access, not a loopback-only grant: sandboxed commands may reach localhost, LAN, and internet destinations. That expands network and possible data-exfiltration capability for these two built-in providers. Filesystem permissions, approval prompts for protected actions, reviewer selection, writable roots, and full-access behavior are unchanged. Claude Code, external ACP providers, unknown providers, and future app servers remain denied unless their registry descriptor explicitly opts in; validation rejects this flag on non-Codex-app-server runtimes.

This does not change Agent Host session, turn, goal, runtime-operation, or recovery lifecycle semantics. The CI fix changes test control only: classification tests inject `context.DeadlineExceeded` deterministically, cancellation/persistence coverage uses a controllable deadline context, and the remaining real recovery-budget assertion has CI scheduling margin.

## Validation

- affected goal deadline tests: 20 repeated shuffled runs passed
- `go test ./service/agent -count=1` passed
- focused `golangci-lint` passed with 0 issues
- `pnpm check:changed` — 13/13 lanes passed
- `pnpm check:changed -- --push-ready` — 14/14 lanes passed
- documentation formatting and `git diff --check` passed
