### PR TITLE
fix(browser): attach cold automation guests

### DIFF
--- a/docs/architecture/browser-node-package.md
+++ b/docs/architecture/browser-node-package.md
@@ -211,17 +211,22 @@ same path.
 
 Network authorization runs before leasing or creating a tab. `new_page`
 creates only `about:blank`, attaches CDP request interception, and then loads
-the requested URL. The same policy therefore covers the initial document,
-main-frame redirects, subresources, and script-initiated requests. For an
-attached target, hostname checks use that target's Chromium Session resolver,
-keeping policy resolution in the browser network context that will make the
-request. The standard policy permits public HTTP/HTTPS destinations while
-rejecting private, link-local, metadata, multicast, and local-network targets.
-Loopback is denied by default; a virtualized host may permit an exact URL only
-through the trusted `isLoopbackUrlRouted` capability after its product-owned
-preview router maps the URL to the caller's sandbox instead of host localhost.
-`list_pages` remains metadata-only so an Agent can report a restricted page's
-title and URL without reading its contents.
+the requested URL. An automation-projected blank tab is the deliberate
+exception to ordinary cold-node lazy rendering: its renderer mounts the blank
+webview so the Electron guest can register without initiating an external
+request. Guest binding registers an already-ready webview immediately and also
+retries on `did-attach` and `dom-ready`, so restored guests can repopulate a
+fresh main-process registry. The same policy therefore covers the initial
+document, main-frame redirects, subresources, and script-initiated requests.
+For an attached target, hostname checks use that target's Chromium Session
+resolver, keeping policy resolution in the browser network context that will
+make the request. The standard policy permits public HTTP/HTTPS destinations
+while rejecting private, link-local, metadata, multicast, and local-network
+targets. Loopback is denied by default; a virtualized host may permit an exact
+URL only through the trusted `isLoopbackUrlRouted` capability after its
+product-owned preview router maps the URL to the caller's sandbox instead of
+host localhost. `list_pages` remains metadata-only so an Agent can report a
+restricted page's title and URL without reading its contents.
 
 `BrowserNode` also accepts a `renderHome` slot. The package shows it only for
 an empty/`about:blank` tab and supplies a package-owned navigation callback.

--- a/docs/conventions/troubleshooting/toolchain-browser-terminal.md
+++ b/docs/conventions/troubleshooting/toolchain-browser-terminal.md
@@ -318,34 +318,52 @@ delimited by ---`, and the composer skill picker may show partial or
 - Symptom:
   The standalone Agent window opens its Browser sidebar with the expected
   title and panel background, but no page, error card, or Browser Node guest
-  appears. Desktop logs contain no `Browser Node webview will attach` entry for
-  the standalone browser node.
+  appears. Desktop logs may contain no `Browser Node webview will attach` entry
+  for the standalone browser node. Browser CLI calls may instead fail with
+  `In-app Browser page did not attach`, followed by `No in-app Browser pages
+are available`.
 - Quick checks:
   Inspect `window.tutti.browser` in the `view=agent` renderer before debugging
   BrowserNode lifecycle or network access. Compare the preload route gate for
-  `view=agent` with `view=workspace`. An absent browser API explains a panel
-  that renders only host chrome and never reaches Electron guest attachment.
+  `view=agent` with `view=workspace`. If the browser API exists, inspect the
+  requested tab's URL, runtime lifecycle, and automation metadata. An
+  `about:blank` automation target that remains cold must still render a webview.
+  For a restored visible page that is missing from `list-pages`, check whether
+  guest registration depended only on attach events that already fired.
 - Root cause:
-  The desktop preload exposed browser and workspace-app bridges only when the
-  renderer query used `view=workspace`. Standalone Agent windows use
-  `view=agent`, so their renderer received no `DesktopBrowserApi`; the sidebar
-  correctly reserved panel space but had no host API with which to activate or
-  register a `<webview>` guest.
+  Two lifecycle gaps can produce the same blank panel. The desktop preload may
+  expose browser and workspace-app bridges only for `view=workspace`, leaving
+  a `view=agent` renderer without `DesktopBrowserApi`. Separately, automation
+  deliberately creates `about:blank` before installing its request guard, but
+  the ordinary Browser Node cold policy does not auto-activate blank URLs and
+  does not render cold webviews. The target then cannot register and the main
+  process times out waiting for attachment. Registration that runs only from
+  `did-attach` or `dom-ready` can also miss an already-ready restored webview
+  after the host registry is recreated.
 - Fix:
   Treat both `workspace` and `agent` as workspace surfaces in the preload route
-  gate. Keep dashboard and unrelated window routes excluded. Because preload
-  code is loaded when the Electron renderer is created, restart the Electron
-  process after changing this gate; renderer HMR is insufficient.
+  gate. Keep dashboard and unrelated window routes excluded. Keep
+  automation-projected blank tabs mounted while cold, without navigating them,
+  so their guest can register before the request guard loads the requested URL.
+  Attempt guest registration immediately when binding a webview and retry
+  idempotently on Electron attach events. Because preload code is loaded when
+  the Electron renderer is created, restart the Electron process after changing
+  that gate; renderer HMR is insufficient.
 - Validation:
   Unit-test the route predicate for `workspace`, `agent`, `dashboard`, and an
-  absent view. Run the desktop typecheck, Electron runtime-boundary check, and
-  desktop build. Confirm the preload remains a self-contained `index.cjs`, then
-  open the Agent Browser panel and verify desktop logs record the shared
-  Browser Node partition attaching with the browser guest preload.
+  absent view. Add Browser Node controller coverage that ordinary cold tabs
+  remain lazy, cold automation targets render and register, and an already-ready
+  webview registers without another attach event. Run the desktop typecheck,
+  Electron runtime-boundary check, and desktop build. Confirm the preload
+  remains a self-contained `index.cjs`, then open the Agent Browser panel and
+  verify desktop logs record the shared Browser Node partition attaching with
+  the browser guest preload.
 - References:
   [main.ts](../../../apps/desktop/src/preload/entries/main.ts)
   [workspaceSurfacePreload.ts](../../../apps/desktop/src/preload/entries/workspaceSurfacePreload.ts)
   [StandaloneAgentToolSidebar.tsx](../../../apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebar.tsx)
+  [webviewController.ts](../../../packages/browser/workbench-node/src/core/webviewController.ts)
+  [automationRegistry.ts](../../../packages/browser/workbench-node/src/electron-main/automationRegistry.ts)
 
 ### Browser Node action finds a webview but page injection does nothing
 

--- a/packages/browser/workbench-node/README.md
+++ b/packages/browser/workbench-node/README.md
@@ -106,10 +106,15 @@ Agent Browser surfaces. The package registry then exposes the current
 workspace's User tabs and only the calling Agent session's Agent tabs, with
 stable page selection and per-tab leases. Website Apps remain excluded unless
 a host explicitly opts them in. `new_page` is created as `about:blank`; the
-package attaches request interception before navigating to the requested URL,
-so the initial document, redirects, and subresources all cross the same guard.
-Agent release is a lifecycle barrier: queued target work drains before guards
-are disabled and retained Agent pages are closed, and later calls fail closed.
+package keeps automation-projected blank tabs mounted even while their runtime
+is cold so the Electron guest can register, then attaches request interception
+before navigating to the requested URL. Ordinary cold tabs remain lazy. Guest
+binding also attempts registration immediately and again on Electron attach
+events, allowing an already-ready or restored webview to re-register with a
+fresh host registry. The initial document, redirects, and subresources
+therefore all cross the same guard. Agent release is a lifecycle barrier:
+queued target work drains before guards are disabled and retained Agent pages
+are closed, and later calls fail closed.
 
 `createBrowserNodeAutomationServer` publishes the registry on authenticated
 loopback and writes a private listener-info file for an explicitly configured

--- a/packages/browser/workbench-node/src/core/webviewController.test.ts
+++ b/packages/browser/workbench-node/src/core/webviewController.test.ts
@@ -56,6 +56,96 @@ test("Browser Node webview controller derives render state and partition", () =>
   assert.equal(state.webviewSrc, "about:blank");
 });
 
+test("Browser Node webview controller renders and registers cold automation targets", async () => {
+  const registerCalls: Array<{
+    automationTarget: unknown;
+    url: string | undefined;
+    webContentsId: number;
+  }> = [];
+  const feature = createBrowserNodeFeature({
+    hostApi: createBrowserNodeHostApi({
+      registerGuest(payload) {
+        registerCalls.push({
+          automationTarget: payload.automationTarget,
+          url: payload.url,
+          webContentsId: payload.webContentsId
+        });
+        return Promise.resolve();
+      }
+    })
+  });
+
+  const automationTarget = {
+    agentSessionId: "agent-a",
+    focused: false,
+    selected: true,
+    surfaceId: "agent-browser",
+    surfaceRole: "agent" as const,
+    tabId: "tab-1",
+    workspaceId: "workspace-a"
+  };
+  const controller = acquireBrowserNodeWebviewController({
+    automationTarget,
+    feature,
+    initialUrl: "about:blank",
+    lifecycle: "cold",
+    nodeId: "browser-cold-automation",
+    profileId: null,
+    sessionMode: "shared"
+  });
+
+  controller.retain();
+  assert.equal(controller.getState().shouldRenderWebview, true);
+  controller.setWebview(
+    new MockBrowserNodeWebviewTag(17) as unknown as BrowserNodeWebviewTag
+  );
+  await Promise.resolve();
+  await Promise.resolve();
+
+  assert.deepEqual(registerCalls, [
+    {
+      automationTarget,
+      url: "about:blank",
+      webContentsId: 17
+    }
+  ]);
+  controller.release();
+});
+
+test("Browser Node webview controller immediately registers an already-ready webview", async () => {
+  const registerCalls: number[] = [];
+  const feature = createBrowserNodeFeature({
+    hostApi: createBrowserNodeHostApi({
+      registerGuest(payload) {
+        registerCalls.push(payload.webContentsId);
+        return Promise.resolve();
+      }
+    })
+  });
+
+  const controller = acquireBrowserNodeWebviewController({
+    feature,
+    initialUrl: "https://example.com/",
+    lifecycle: "active",
+    nodeId: "browser-already-ready",
+    profileId: null,
+    sessionMode: "shared"
+  });
+
+  controller.setWebview(
+    new MockBrowserNodeWebviewTag(19) as unknown as BrowserNodeWebviewTag
+  );
+  await Promise.resolve();
+  assert.deepEqual(registerCalls, []);
+
+  controller.retain();
+  await Promise.resolve();
+  await Promise.resolve();
+
+  assert.deepEqual(registerCalls, [19]);
+  controller.release();
+});
+
 test("Browser Node webview controller tolerates webviews before dom-ready exposes webContentsId", async () => {
   const registerCalls: number[] = [];
   const feature = createBrowserNodeFeature({

--- a/packages/browser/workbench-node/src/core/webviewController.ts
+++ b/packages/browser/workbench-node/src/core/webviewController.ts
@@ -60,6 +60,7 @@ interface BrowserNodeWebviewControllerEntry {
   refCount: number;
   registeredGuestId: number | null;
   registeringGuestId: number | null;
+  requestGuestRegistration: (() => void) | null;
   state: BrowserNodeWebviewControllerState;
   webview: BrowserNodeWebviewTag | null;
 }
@@ -136,6 +137,7 @@ function createBrowserNodeWebviewControllerEntry(
     refCount: 0,
     registeredGuestId: null,
     registeringGuestId: null,
+    requestGuestRegistration: null,
     state,
     webview: null
   } as BrowserNodeWebviewControllerEntry;
@@ -186,6 +188,7 @@ function createBrowserNodeWebviewControllerEntry(
         notifyListeners: true,
         rebindWebview: true
       });
+      entry.requestGuestRegistration?.();
     },
     setWebview(element) {
       if (entry.webview === element) {
@@ -223,7 +226,10 @@ function resolveBrowserNodeWebviewControllerState(
   });
   return {
     devToolsContextMenu: null,
-    shouldRenderWebview: context.lifecycle !== "cold",
+    // Automation creates about:blank first so main can attach its request guard
+    // before any external navigation. That blank guest must mount while cold.
+    shouldRenderWebview:
+      context.lifecycle !== "cold" || context.automationTarget != null,
     webviewKey: `${context.nodeId}:${webviewPartition}`,
     webviewPartition,
     webviewSrc: browserNodeInitialWebviewSrc
@@ -255,7 +261,7 @@ function reconcileBrowserNodeWebviewControllerState(
         })
         .catch(() => undefined);
     }
-    if (entry.context.lifecycle === "cold") {
+    if (!nextState.shouldRenderWebview) {
       scheduleBrowserNodeGuestUnregister(entry);
     } else {
       const pendingGuestId = clearPendingBrowserNodeGuestUnregister(
@@ -264,16 +270,18 @@ function reconcileBrowserNodeWebviewControllerState(
       if (entry.registeredGuestId === null && pendingGuestId !== null) {
         entry.registeredGuestId = pendingGuestId;
       }
-      void entry.context.feature.hostApi
-        .prepareSession({
-          navigationPolicy: entry.context.navigationPolicy,
-          nodeId: entry.context.nodeId,
-          profileId: entry.context.profileId,
-          sessionMode: entry.context.sessionMode,
-          sessionPartition: entry.context.sessionPartition,
-          url: entry.context.initialUrl
-        })
-        .catch(() => undefined);
+      if (entry.context.lifecycle !== "cold") {
+        void entry.context.feature.hostApi
+          .prepareSession({
+            navigationPolicy: entry.context.navigationPolicy,
+            nodeId: entry.context.nodeId,
+            profileId: entry.context.profileId,
+            sessionMode: entry.context.sessionMode,
+            sessionPartition: entry.context.sessionPartition,
+            url: entry.context.initialUrl
+          })
+          .catch(() => undefined);
+      }
     }
   }
 
@@ -383,6 +391,7 @@ function scheduleBrowserNodeGuestUnregister(
 function detachBrowserNodeWebview(
   entry: BrowserNodeWebviewControllerEntry
 ): void {
+  entry.requestGuestRegistration = null;
   if (!entry.webview) {
     entry.attachedListeners = [];
     return;
@@ -434,12 +443,25 @@ function attachBrowserNodeWebview(
     }
   };
 
-  const handleDidAttach: EventListener = () => {
-    void registerGuest().catch(() => undefined);
+  const requestGuestRegistration = (): void => {
+    if (entry.refCount === 0) {
+      return;
+    }
+    void registerGuest().catch((error: unknown) => {
+      reportBrowserNodeWebviewDiagnostic(
+        entry,
+        "guest.registration.failed",
+        {
+          error: error instanceof Error ? error.message : String(error),
+          webContentsId: readBrowserNodeWebContentsId(webview),
+          webviewPartition: entry.state.webviewPartition
+        },
+        "warn"
+      );
+    });
   };
-  const handleDomReady: EventListener = () => {
-    void registerGuest().catch(() => undefined);
-  };
+  const handleDidAttach: EventListener = requestGuestRegistration;
+  const handleDomReady: EventListener = requestGuestRegistration;
   const handleGuestInteraction: EventListener = () => {
     entry.context.onGuestInteraction?.();
     if (entry.context.automationTarget) {
@@ -509,6 +531,10 @@ function attachBrowserNodeWebview(
     webview.addEventListener(record.event, record.listener);
   }
   entry.attachedListeners = records;
+  entry.requestGuestRegistration = requestGuestRegistration;
+  // A restored or already-ready webview may have emitted both events before
+  // this controller bound its listeners. Registration is safe to retry.
+  requestGuestRegistration();
 }
 
 function resolveBrowserNodeContextMenuPoint(


### PR DESCRIPTION
## Summary

- keep automation-projected `about:blank` tabs mounted while their Browser Node runtime is cold, allowing the Electron guest to register before any external navigation
- register already-ready webviews immediately while retaining `did-attach` and `dom-ready` retries, and emit a diagnostic when host registration fails
- add regression coverage for cold automation attachment and restored/already-ready guest registration
- document the lifecycle exception and improve the existing Browser Node troubleshooting playbook

## Root cause

Browser automation intentionally creates a new page as `about:blank` so CDP request interception can be installed before loading the requested URL. Browser Node's ordinary cold lifecycle skips auto-activation for `about:blank` and does not render cold webviews, so the guest could never register and Desktop timed out with `In-app Browser page did not attach`. Registration also depended only on Electron attach events, which can already have fired for a restored webview after the main-process registry is recreated.

This change preserves the security ordering: the blank guest attaches first, the request guard is installed, and only then may automation navigate. Loopback/private-network policy remains fail-closed.

## Validation

- `pnpm --filter @tutti-os/browser-node test` (153 tests)
- `pnpm --filter @tutti-os/browser-node typecheck`
- `pnpm check:changed` (9 lanes)
- pre-push `pnpm check:changed -- --push-ready` (10 lanes)
