### PR TITLE
fix(agent): bound Codex composer option loading

### DIFF
--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -753,6 +753,44 @@ file or directory`. If the CLI path exists but `codex app-server` cannot
   [codex_model_catalog.go](../../../services/tuttid/service/agent/codex_model_catalog.go)
   [codex_model_catalog_test.go](../../../services/tuttid/service/agent/codex_model_catalog_test.go)
 
+### Codex composer model and reasoning selectors stay loading
+
+- Symptom:
+  The empty Codex composer shows loading placeholders for both model and
+  reasoning, even though provider status reports Codex as ready.
+- Quick checks:
+  Correlate a ready Codex provider snapshot in `tuttid.log` with
+  `agent.composer_options.load` in `tutti-desktop.log`. A duration near 15
+  seconds with `errorCode=ETIMEDOUT` means the Desktop request deadline expired
+  before Composer Options returned. If tuttid later logs
+  `superfluous response.WriteHeader`, or a detached `codex app-server` remains
+  after the request, the canceled handler did not finish cleaning up its
+  discovery subprocess.
+- Root cause:
+  Codex Composer Options needs both `model/list` and the app-server capability
+  catalog. Running those independent, individually bounded probes in series
+  can exceed the Desktop's aggregate request deadline. A second failure mode
+  occurs when timeout kills only the JavaScript launcher: its native child
+  inherits stdout, the response scanner never receives EOF, and deferred
+  `Wait` cannot run because it sits behind that scanner.
+- Fix:
+  Start model-catalog loading before capability discovery so the two independent
+  app-server exchanges overlap. Run every short-lived Codex app-server in its
+  own process group, begin process reaping immediately, and make timeout cancel
+  the entire group. Keep the Desktop deadline unchanged so a genuinely stuck
+  daemon request still fails closed.
+- Validation:
+  Block both catalog fixtures and assert both start before either is released.
+  Use a fake app-server whose child retains stdout and assert model and
+  capability timeouts return promptly with no surviving child. Finally, time a
+  cold Composer Options request and confirm it completes within the Desktop
+  deadline.
+- References:
+  [composer_options.go](../../../services/tuttid/service/agent/composer_options.go)
+  [codex_appserver_process.go](../../../services/tuttid/service/agent/codex_appserver_process.go)
+  [codex_model_catalog.go](../../../services/tuttid/service/agent/codex_model_catalog.go)
+  [codex_capability_catalog.go](../../../services/tuttid/service/agent/codex_capability_catalog.go)
+
 ### Codex custom model_provider mixes models, duplicates replies, or shows metadata warnings
 
 - Symptom:

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -24,6 +24,7 @@ Provider discovery, installation, authentication, models, configuration, and run
 - [Codex provider shows login required when global service tier is legacy](./agent-provider-setup.md#codex-provider-shows-login-required-when-global-service-tier-is-legacy)
 - [Codex provider shows login required when only an API key is configured](./agent-provider-setup.md#codex-provider-shows-login-required-when-only-an-api-key-is-configured)
 - [Codex session fails with not connected when model_catalog_json is relative](./agent-provider-setup.md#codex-session-fails-with-not-connected-when-modelcatalogjson-is-relative)
+- [Codex composer model and reasoning selectors stay loading](./agent-provider-setup.md#codex-composer-model-and-reasoning-selectors-stay-loading)
 - [Codex custom model_provider mixes models, duplicates replies, or shows metadata warnings](./agent-provider-setup.md#codex-custom-modelprovider-mixes-models-duplicates-replies-or-shows-metadata-warnings)
 - [Claude SDK Grep or Glob unavailable despite Claude Code preset](./agent-provider-setup.md#claude-sdk-grep-or-glob-unavailable-despite-claude-code-preset)
 - [Provider process loses final stdout or a sidecar fails during startup](./agent-provider-setup.md#provider-process-loses-final-stdout-or-a-sidecar-fails-during-startup)

--- a/services/tuttid/service/agent/codex_appserver_process.go
+++ b/services/tuttid/service/agent/codex_appserver_process.go
@@ -1,0 +1,69 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+)
+
+type codexAppServerProcess struct {
+	stdin    io.WriteCloser
+	stdout   *io.PipeReader
+	stderr   *truncatingBuffer
+	waitDone <-chan error
+}
+
+func startCodexAppServerProcess(
+	ctx context.Context,
+	command string,
+	args []string,
+	env []string,
+) (*codexAppServerProcess, error) {
+	cmd := exec.CommandContext(ctx, command, args...)
+	cmd.Env = env
+	cmd.WaitDelay = codexAppServerShutdownWaitDelay
+	prepareCodexAppServerCommand(cmd)
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("open codex app-server stdin: %w", err)
+	}
+	stdout, stdoutWriter := io.Pipe()
+	cmd.Stdout = stdoutWriter
+	stderr := &truncatingBuffer{max: codexModelListMaxStderrBytes}
+	cmd.Stderr = stderr
+	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
+		_ = stdout.Close()
+		_ = stdoutWriter.Close()
+		return nil, fmt.Errorf("start codex app-server: %w", err)
+	}
+
+	waitDone := make(chan error, 1)
+	go func() {
+		waitErr := cmd.Wait()
+		_ = stdoutWriter.Close()
+		waitDone <- waitErr
+	}()
+	return &codexAppServerProcess{
+		stdin:    stdin,
+		stdout:   stdout,
+		stderr:   stderr,
+		waitDone: waitDone,
+	}, nil
+}
+
+func (p *codexAppServerProcess) stop(cancel context.CancelFunc) error {
+	if p == nil {
+		cancel()
+		return nil
+	}
+	_ = p.stdin.Close()
+	cancel()
+	// A response parser can finish before the app-server exits. Closing the
+	// reader keeps os/exec's stdout copier from making process reaping depend on
+	// unread provider notifications.
+	_ = p.stdout.Close()
+	return <-p.waitDone
+}

--- a/services/tuttid/service/agent/codex_appserver_process_unix.go
+++ b/services/tuttid/service/agent/codex_appserver_process_unix.go
@@ -1,0 +1,25 @@
+//go:build !windows
+
+package agent
+
+import (
+	"errors"
+	"os/exec"
+	"syscall"
+)
+
+func prepareCodexAppServerCommand(command *exec.Cmd) {
+	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	command.Cancel = func() error {
+		if command.Process == nil {
+			return nil
+		}
+		if err := syscall.Kill(-command.Process.Pid, syscall.SIGKILL); err != nil {
+			if errors.Is(err, syscall.ESRCH) {
+				return nil
+			}
+			return command.Process.Kill()
+		}
+		return nil
+	}
+}

--- a/services/tuttid/service/agent/codex_appserver_process_unix_test.go
+++ b/services/tuttid/service/agent/codex_appserver_process_unix_test.go
@@ -1,0 +1,95 @@
+//go:build !windows
+
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestCodexCLIModelListerStopsProcessTreeOnTimeout(t *testing.T) {
+	childPIDPath := filepath.Join(t.TempDir(), "model-child.pid")
+	scriptPath := writeHangingCodexAppServer(t, childPIDPath)
+
+	startedAt := time.Now()
+	_, err := (CodexCLIModelLister{
+		Command: scriptPath,
+		Timeout: time.Second,
+	}).ListModels(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "model/list timed out") {
+		t.Fatalf("ListModels error = %v, want model/list timeout", err)
+	}
+	if elapsed := time.Since(startedAt); elapsed > 3*time.Second {
+		t.Fatalf("ListModels returned after %s, want bounded process cleanup", elapsed)
+	}
+	assertProcessExited(t, readChildPID(t, childPIDPath))
+}
+
+func TestCodexCLICapabilityListerStopsProcessTreeOnTimeout(t *testing.T) {
+	childPIDPath := filepath.Join(t.TempDir(), "capability-child.pid")
+	scriptPath := writeHangingCodexAppServer(t, childPIDPath)
+
+	startedAt := time.Now()
+	_, err := (CodexCLICapabilityLister{
+		Command: scriptPath,
+		Timeout: time.Second,
+	}).List(context.Background(), "")
+	if err == nil || !strings.Contains(err.Error(), "capability discovery timed out") {
+		t.Fatalf("List error = %v, want capability discovery timeout", err)
+	}
+	if elapsed := time.Since(startedAt); elapsed > 3*time.Second {
+		t.Fatalf("List returned after %s, want bounded process cleanup", elapsed)
+	}
+	assertProcessExited(t, readChildPID(t, childPIDPath))
+}
+
+func writeHangingCodexAppServer(t *testing.T, childPIDPath string) string {
+	t.Helper()
+	scriptPath := filepath.Join(t.TempDir(), "codex")
+	script := fmt.Sprintf(`#!/bin/sh
+sleep 5 &
+child_pid=$!
+printf '%%s\n' "$child_pid" > %q
+wait "$child_pid"
+`, childPIDPath)
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake codex app-server: %v", err)
+	}
+	return scriptPath
+}
+
+func readChildPID(t *testing.T, path string) int {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read child pid: %v", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(raw)))
+	if err != nil {
+		t.Fatalf("parse child pid %q: %v", raw, err)
+	}
+	return pid
+}
+
+func assertProcessExited(t *testing.T, pid int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		err := syscall.Kill(pid, 0)
+		if errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("child process %d is still alive after app-server timeout", pid)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/services/tuttid/service/agent/codex_appserver_process_windows.go
+++ b/services/tuttid/service/agent/codex_appserver_process_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package agent
+
+import "os/exec"
+
+func prepareCodexAppServerCommand(command *exec.Cmd) {
+	command.Cancel = func() error {
+		if command.Process == nil {
+			return nil
+		}
+		return command.Process.Kill()
+	}
+}

--- a/services/tuttid/service/agent/codex_capability_catalog.go
+++ b/services/tuttid/service/agent/codex_capability_catalog.go
@@ -6,9 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os/exec"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
@@ -94,8 +92,6 @@ func (l CodexCLICapabilityLister) List(ctx context.Context, cwd string) ([]Compo
 	if timeout <= 0 {
 		timeout = codexAppServerCapabilityListTimeout
 	}
-	processCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	command := strings.TrimSpace(l.Command)
 	if command == "" {
@@ -110,51 +106,30 @@ func (l CodexCLICapabilityLister) List(ctx context.Context, cwd string) ([]Compo
 	processEnv := resolver.Env(nil)
 	command = resolver.Resolve(command, processEnv)
 	args := append([]string{}, l.Args...)
-	cmd := exec.CommandContext(processCtx, command, args...)
-	cmd.Env = processEnv
-	cmd.WaitDelay = codexAppServerShutdownWaitDelay
-	stdin, err := cmd.StdinPipe()
+	processCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	process, err := startCodexAppServerProcess(processCtx, command, args, processEnv)
 	if err != nil {
-		return nil, fmt.Errorf("open codex app-server stdin: %w", err)
-	}
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return nil, fmt.Errorf("open codex app-server stdout: %w", err)
-	}
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		return nil, fmt.Errorf("open codex app-server stderr: %w", err)
-	}
-	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("start codex app-server: %w", err)
-	}
-
-	stderrBuf := &truncatingBuffer{max: codexModelListMaxStderrBytes}
-	var stderrWG sync.WaitGroup
-	stderrWG.Add(1)
-	go func() {
-		defer stderrWG.Done()
-		_, _ = io.Copy(stderrBuf, stderr)
-	}()
-
-	defer func() {
-		_ = stdin.Close()
-		cancel()
-		_ = cmd.Wait()
-		stderrWG.Wait()
-	}()
-
-	if err := writeCodexCapabilityListRequests(stdin, cwd); err != nil {
 		return nil, err
 	}
-	options, err := readCodexCapabilityListResponses(stdout)
+	if err := writeCodexCapabilityListRequests(process.stdin, cwd); err != nil {
+		processErr := processCtx.Err()
+		_ = process.stop(cancel)
+		if processErr != nil {
+			return nil, fmt.Errorf("codex app-server capability discovery timed out: %w", processErr)
+		}
+		return nil, err
+	}
+	options, err := readCodexCapabilityListResponses(process.stdout)
+	processErr := processCtx.Err()
+	_ = process.stop(cancel)
 	if err == nil {
 		return options, nil
 	}
-	if processCtx.Err() != nil {
-		return nil, fmt.Errorf("codex app-server capability discovery timed out: %w", processCtx.Err())
+	if processErr != nil {
+		return nil, fmt.Errorf("codex app-server capability discovery timed out: %w", processErr)
 	}
-	if stderr := strings.TrimSpace(stderrBuf.String()); stderr != "" {
+	if stderr := strings.TrimSpace(process.stderr.String()); stderr != "" {
 		return nil, fmt.Errorf("%w: %s", err, stderr)
 	}
 	return nil, err

--- a/services/tuttid/service/agent/codex_model_catalog.go
+++ b/services/tuttid/service/agent/codex_model_catalog.go
@@ -8,9 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os/exec"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/tutti-os/tutti/packages/agent/daemon/modelcatalog"
@@ -109,48 +107,20 @@ func (l CodexCLIModelLister) ListModels(ctx context.Context) (AgentModelListResu
 	if len(args) == 0 {
 		args = []string{"app-server"}
 	}
-	cmd := exec.CommandContext(processCtx, command, args...)
-	cmd.Env = env
-	cmd.WaitDelay = codexAppServerShutdownWaitDelay
-	stdin, err := cmd.StdinPipe()
+	process, err := startCodexAppServerProcess(processCtx, command, args, env)
 	if err != nil {
-		return AgentModelListResult{}, fmt.Errorf("open codex app-server stdin: %w", err)
+		return AgentModelListResult{}, err
 	}
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return AgentModelListResult{}, fmt.Errorf("open codex app-server stdout: %w", err)
-	}
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		return AgentModelListResult{}, fmt.Errorf("open codex app-server stderr: %w", err)
-	}
-	if err := cmd.Start(); err != nil {
-		return AgentModelListResult{}, fmt.Errorf("start codex app-server: %w", err)
-	}
-
-	stderrBuf := &truncatingBuffer{max: codexModelListMaxStderrBytes}
-	var stderrWG sync.WaitGroup
-	stderrWG.Add(1)
-	go func() {
-		defer stderrWG.Done()
-		_, _ = io.Copy(stderrBuf, stderr)
-	}()
-
-	defer func() {
-		_ = stdin.Close()
-		cancel()
-		_ = cmd.Wait()
-		stderrWG.Wait()
-	}()
-
-	models, err := requestCodexModelList(stdin, stdout, l.clientName())
+	models, err := requestCodexModelList(process.stdin, process.stdout, l.clientName())
+	processErr := processCtx.Err()
+	_ = process.stop(cancel)
 	if err == nil {
 		return AgentModelListResult{Models: models}, nil
 	}
-	if processCtx.Err() != nil {
-		return AgentModelListResult{}, fmt.Errorf("codex app-server model/list timed out: %w", processCtx.Err())
+	if processErr != nil {
+		return AgentModelListResult{}, fmt.Errorf("codex app-server model/list timed out: %w", processErr)
 	}
-	if stderr := strings.TrimSpace(stderrBuf.String()); stderr != "" {
+	if stderr := strings.TrimSpace(process.stderr.String()); stderr != "" {
 		return AgentModelListResult{}, fmt.Errorf("%w: %s", err, stderr)
 	}
 	return AgentModelListResult{}, err

--- a/services/tuttid/service/agent/composer_model_catalog.go
+++ b/services/tuttid/service/agent/composer_model_catalog.go
@@ -15,6 +15,26 @@ type composerModelCatalogProjection struct {
 	Source            string
 }
 
+type composerModelCatalogLoadResult struct {
+	projection composerModelCatalogProjection
+	ok         bool
+}
+
+func startComposerModelCatalogLoad(
+	ctx context.Context,
+	catalog AgentModelCatalog,
+	provider string,
+	cwd string,
+	selectedModel string,
+) <-chan composerModelCatalogLoadResult {
+	result := make(chan composerModelCatalogLoadResult, 1)
+	go func() {
+		projection, ok := composerModelOptionsFromCatalog(ctx, catalog, provider, cwd, selectedModel)
+		result <- composerModelCatalogLoadResult{projection: projection, ok: ok}
+	}()
+	return result
+}
+
 func composerModelOptionsFromCatalog(ctx context.Context, catalog AgentModelCatalog, provider string, cwd string, selectedModel string) (composerModelCatalogProjection, bool) {
 	if catalog == nil {
 		return composerModelCatalogProjection{}, false

--- a/services/tuttid/service/agent/composer_options.go
+++ b/services/tuttid/service/agent/composer_options.go
@@ -244,16 +244,37 @@ func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsI
 	if planEndpoint != nil {
 		settings.Model = planEndpoint.Model
 	}
-	catalogProjection := composerModelCatalogProjection{}
-	catalogProjectionOK := false
+	var catalogLoad <-chan composerModelCatalogLoadResult
 	if planEndpoint == nil && composerOptionsProviderUsesModelCatalog(provider) {
-		catalogProjection, catalogProjectionOK = composerModelOptionsFromCatalog(
+		catalogLoad = startComposerModelCatalogLoad(
 			ctx,
 			s.ModelCatalog,
 			provider,
 			input.Cwd,
 			settings.Model,
 		)
+	}
+	skills := filterWorkspaceAgentComposerSkills(
+		s.discoverComposerSkillOptionsForLaunch(ctx, provider, input.Cwd, nil, input.providerTargetRef),
+		launchInput.AgentSkills,
+		launchInput.AgentCapabilitiesExplicit,
+	)
+	capabilityCatalog := []ComposerCapabilityOption{}
+	capabilityErrors := []string(nil)
+	if composerOptionsIncludeCapabilityCatalog(input) {
+		capabilityCatalog, capabilityErrors = s.listComposerCapabilityOptions(ctx, provider, input.Cwd, skills)
+		capabilityCatalog = filterWorkspaceAgentComposerCapabilities(
+			capabilityCatalog,
+			launchInput.AgentTools,
+			launchInput.AgentCapabilitiesExplicit,
+		)
+	}
+	catalogProjection := composerModelCatalogProjection{}
+	catalogProjectionOK := false
+	if catalogLoad != nil {
+		result := <-catalogLoad
+		catalogProjection = result.projection
+		catalogProjectionOK = result.ok
 	}
 	defaultModel := composerConfiguredDefaultModel(provider)
 	if catalogProjectionOK && catalogProjection.Selection.Found {
@@ -322,21 +343,6 @@ func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsI
 	if launchInput.WorkspaceAgentRevision > 0 {
 		runtimeContext["workspaceAgentRevision"] = launchInput.WorkspaceAgentRevision
 		runtimeContext["harnessAgentTargetId"] = launchInput.HarnessAgentTargetID
-	}
-	skills := filterWorkspaceAgentComposerSkills(
-		s.discoverComposerSkillOptionsForLaunch(ctx, provider, input.Cwd, nil, input.providerTargetRef),
-		launchInput.AgentSkills,
-		launchInput.AgentCapabilitiesExplicit,
-	)
-	capabilityCatalog := []ComposerCapabilityOption{}
-	capabilityErrors := []string(nil)
-	if composerOptionsIncludeCapabilityCatalog(input) {
-		capabilityCatalog, capabilityErrors = s.listComposerCapabilityOptions(ctx, provider, input.Cwd, skills)
-		capabilityCatalog = filterWorkspaceAgentComposerCapabilities(
-			capabilityCatalog,
-			launchInput.AgentTools,
-			launchInput.AgentCapabilitiesExplicit,
-		)
 	}
 	runtimeContext["skills"] = composerSkillOptionsRuntimeContext(skills)
 	if launchInput.WorkspaceAgentRevision > 0 {

--- a/services/tuttid/service/agent/composer_options_catalog_concurrency_test.go
+++ b/services/tuttid/service/agent/composer_options_catalog_concurrency_test.go
@@ -1,0 +1,109 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+type blockingComposerModelCatalog struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (c *blockingComposerModelCatalog) ListModels(
+	ctx context.Context,
+	_ AgentModelCatalogInput,
+) (AgentModelCatalogResult, error) {
+	close(c.started)
+	select {
+	case <-c.release:
+		return AgentModelCatalogResult{
+			Models: []AgentModelOption{{
+				ID:          "gpt-5.6-sol",
+				DisplayName: "GPT-5.6",
+				IsDefault:   true,
+			}},
+			Source: "test",
+		}, nil
+	case <-ctx.Done():
+		return AgentModelCatalogResult{}, ctx.Err()
+	}
+}
+
+type blockingComposerCapabilityLister struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (l *blockingComposerCapabilityLister) ListComposerCapabilityOptions(
+	ctx context.Context,
+	_ string,
+	_ string,
+	_ []ComposerSkillOption,
+) ([]ComposerCapabilityOption, []string) {
+	close(l.started)
+	select {
+	case <-l.release:
+		return nil, nil
+	case <-ctx.Done():
+		return nil, []string{ctx.Err().Error()}
+	}
+}
+
+func TestServiceGetComposerOptionsLoadsModelAndCapabilityCatalogsConcurrently(t *testing.T) {
+	modelCatalog := &blockingComposerModelCatalog{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	capabilityLister := &blockingComposerCapabilityLister{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	defer closeTestRelease(modelCatalog.release)
+	defer closeTestRelease(capabilityLister.release)
+
+	service := newIsolatedAgentService(newFakeRuntime())
+	service.ModelCatalog = modelCatalog
+	service.CapabilityLister = capabilityLister
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
+			Provider:               "codex",
+			IgnoreModelPlanBinding: true,
+		})
+		result <- err
+	}()
+
+	waitForCatalogLoadStart(t, modelCatalog.started, "model")
+	waitForCatalogLoadStart(t, capabilityLister.started, "capability")
+	close(modelCatalog.release)
+	close(capabilityLister.release)
+
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("GetComposerOptions returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("GetComposerOptions did not finish after catalog releases")
+	}
+}
+
+func waitForCatalogLoadStart(t *testing.T, started <-chan struct{}, catalog string) {
+	t.Helper()
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("%s catalog did not start while the other catalog was blocked", catalog)
+	}
+}
+
+func closeTestRelease(release chan struct{}) {
+	select {
+	case <-release:
+	default:
+		close(release)
+	}
+}


### PR DESCRIPTION
## Summary

- load Codex model and capability catalogs concurrently so Composer Options stays within the Desktop request deadline
- manage short-lived `codex app-server` processes through a shared bounded runner and terminate the full process group on Unix cancellation
- add regression coverage for catalog concurrency and inherited-stdout child cleanup
- document the `ETIMEDOUT` / stuck-selector troubleshooting path

## Root cause

The exported logs showed Codex provider status as ready (`0.145.0`), while duplicate `agent.composer_options.load` requests failed after 15,002 ms with `ETIMEDOUT`. The daemon attempted to write a response later, after the Desktop request had already expired.

Composer Options loaded the independent Codex model and capability catalogs serially. Each app-server exchange could consume close to its eight-second budget, so a successful response could still exceed the aggregate 15-second Desktop deadline. On timeout, killing only the JavaScript launcher could also leave its native child holding stdout open; the scanner then never reached EOF and deferred process reaping could not run.

## Impact

The empty Codex composer can resolve model and reasoning options without extending the Desktop timeout. Genuine app-server hangs remain bounded and no longer leave detached discovery children on macOS/Linux.

A local real-Codex timing probe improved from 16.82 seconds (and one 45-second no-response cold request) to 8.02 seconds, returning five models and 76 capability entries.

## Validation

- `go test ./service/agent -run 'TestCodexCLIModelListerStopsProcessTreeOnTimeout|TestCodexCLICapabilityListerStopsProcessTreeOnTimeout|TestServiceGetComposerOptionsLoadsModelAndCapabilityCatalogsConcurrently|TestCodexCLIModelListerCompletesInitializeHandshakeBeforeModelList' -count=1`
- `pnpm check:changed` — 6/6 selected lanes passed
- pre-push `pnpm check:changed -- --push-ready` — 7/7 selected lanes passed
- DCO sign-off included

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Codex Composer Options timing and subprocess lifecycle in tuttid; bounded impact to Codex discovery paths but subprocess group kill and concurrent catalog loading could affect edge cases on timeout or cancellation.
> 
> **Overview**
> Fixes Codex empty-composer **model** and **reasoning** selectors that stayed on loading placeholders when provider status was already ready—often with Desktop `agent.composer_options.load` hitting **~15s `ETIMEDOUT`** while tuttid could leave a detached `codex app-server` or log `superfluous response.WriteHeader`.
> 
> **Composer Options** now starts Codex **model-catalog** loading in a background goroutine before **capability** discovery runs, so the two independent app-server probes overlap instead of stacking serial ~8s budgets against the Desktop deadline.
> 
> Short-lived Codex app-server runs share **`startCodexAppServerProcess`**: stdout via an `io.Pipe`, immediate `Wait` in a goroutine, and on timeout **`stop`** closes stdin/stdout and cancels the context. On Unix, **`Setpgid`** plus **`Kill(-pid, SIGKILL)`** tears down the whole process group so a JS launcher’s native child cannot keep stdout open and block cleanup.
> 
> Regression tests cover concurrent catalog loads, process-tree cleanup on timeout, and new troubleshooting docs for correlating logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 090ab6441e1e4d71797ffe325da785b0eb487a12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->