### PR TITLE
fix(tutti-mode): trust turn activation state

### DIFF
--- a/docs/architecture/workspace-workflows.md
+++ b/docs/architecture/workspace-workflows.md
@@ -199,7 +199,13 @@ uses a coordinator-owned synthetic message. These fallbacks are transport
 details, not user-authored messages: Tutti's visible user message, prompt
 preview, and activity transcript remain unchanged. The context explicitly
 distinguishes Tutti activation from provider Default/Plan mode and reasoning
-effort. An active snapshot is a directive, not a suggestion: the Agent must
+effort. Reusing an existing provider Session does not weaken that boundary:
+each new Turn receives the current immutable activation snapshot before
+dispatch. The snapshot's `state` is the sole authority for reporting Tutti Mode
+status; provider Default/Plan mode and workflow existence are independent facts
+that cannot override it. A clear plan request still enters the Tutti proposal
+workflow instead of returning a chat-only plan. An active snapshot is a
+directive, not a suggestion: the Agent must
 not execute the user's request directly in that turn. It first asks focused
 clarifying questions when the request is ambiguous or missing key
 constraints, then submits one complete tutti-mode-plan/v1 document through a

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -29,12 +29,13 @@ Use the focused runtime index or open one area directly:
   startup that fails when concurrent provider input and output are treated as a
   strict scheduling order, false final-state mismatches caused by replay-generated
   child identities, and canonical completion delayed behind a streaming activity-report
-  backlog. It also covers stopped Tutti Mode conversations revived by legacy
-  startup wakes, provider-completed submissions reported as delivery unknown
-  after canonical message provenance conflicts, completed Claude Code Turns
-  that lack a Fork entry because provider identity was not observed from the
-  durable transcript, and Claude Fork operations that fail because an empty SDK
-  query never creates a durable provider child.
+  backlog. It also covers an active existing-Session Tutti snapshot being
+  misread as provider Default mode, stopped Tutti Mode conversations revived by
+  legacy startup wakes, provider-completed submissions reported as delivery
+  unknown after canonical message provenance conflicts, completed Claude Code
+  Turns that lack a Fork entry because provider identity was not observed from
+  the durable transcript, and Claude Fork operations that fail because an empty
+  SDK query never creates a durable provider child.
 - [Agent Approvals And Child Sessions](./agent-approvals-subagents.md): Approval gates, plan exits, root/parent/child event attribution, child sessions, and Message Center.
   Includes provider-native work that continues invisibly after root cancellation
   and late child creation racing the durable cancel boundary.

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -52,6 +52,7 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 
 - [AgentGUI turn actions return plain-text route 404s](./agent-session-lifecycle.md#agentgui-turn-actions-return-plain-text-route-404s)
 - [One hung provider startup blocks unrelated Agent sessions](./agent-session-lifecycle.md#one-hung-provider-startup-blocks-unrelated-agent-sessions)
+- [Existing Session shows Tutti active but the Agent reports Default mode](./agent-session-lifecycle.md#existing-session-shows-tutti-active-but-the-agent-reports-default-mode)
 - [Many stopped Tutti Mode conversations start again when the app opens](./agent-session-lifecycle.md#many-stopped-tutti-mode-conversations-start-again-when-the-app-opens)
 - [A new Tutti conversation briefly reports session not found after submit](./agent-session-lifecycle.md#a-new-tutti-conversation-briefly-reports-session-not-found-after-submit)
 - [AgentGUI rail shows a failed Turn but the detail has no error](./agent-session-lifecycle.md#agentgui-rail-shows-a-failed-turn-but-the-detail-has-no-error)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -130,6 +130,40 @@
   [commands.go](../../../services/tuttid/service/cli/providers/tuttimodeplan/commands.go),
   [useTuttiModePlanPanels.ts](../../../packages/agent/gui/workspaceWorkflow/tuttiModePlan/useTuttiModePlanPanels.ts)
 
+### Existing Session shows Tutti active but the Agent reports Default mode
+
+- **Symptom:** Tutti Mode is enabled on an already-existing Session, but the
+  next Turn says the conversation is still in provider Default mode or has not
+  entered Tutti Mode because `plan propose` has not run.
+- **Quick checks:** Confirm the activation revision is active in the exported
+  Session or activation endpoint, then confirm the affected Turn owns an active
+  `TuttiModeTurnSnapshot`. For Codex, inspect that Turn's provider rollout
+  `turn_context`: the collaboration mode may legitimately remain `default`,
+  while its developer instructions must contain `<tutti-host-context>` with
+  `"state":"active"`. If both facts are present, existing-Session snapshot
+  delivery works and the response is an interpretation failure. If the host
+  context is absent, trace snapshot preparation and runtime dispatch instead.
+- **Root cause:** Tutti activation, provider Default/Plan collaboration mode,
+  and Tutti workflow existence are three independent facts. An instruction
+  that says a workflow exists only after `plan propose` can make a provider
+  incorrectly use the missing workflow as evidence that activation is
+  inactive, even though the active snapshot reached the reused provider
+  Session.
+- **Fix:** Make the Host Context's snapshot state the sole authority for
+  reporting Tutti Mode status. Provider Default/Plan mode and workflow
+  existence remain independent facts and cannot override it. A clear plan
+  request must still run `plan propose` instead of returning a chat-only plan.
+- **Validation:** On an existing Session, activate Tutti Mode and send a new
+  Turn while the provider collaboration mode remains Default. Verify the
+  provider receives the active Host Context, a status-only question reports
+  active without proposing a workflow, and a clear plan-generation request
+  invokes `plan propose`. Repeat with an inactive revision and verify it
+  reports inactive.
+- **References:**
+  [workspace-workflows.md](../../architecture/workspace-workflows.md),
+  [tutti_mode_host_context.go](../../../packages/agent/daemon/runtime/tutti_mode_host_context.go),
+  [tutti_mode_host_context_test.go](../../../packages/agent/daemon/runtime/tutti_mode_host_context_test.go)
+
 ### Tutti Mode Plan stops loading after a task-graph revision
 
 - **Symptom:** The configuration review panel works and `tutti plan revise`

--- a/packages/agent/daemon/runtime/tutti_mode_host_context.go
+++ b/packages/agent/daemon/runtime/tutti_mode_host_context.go
@@ -118,11 +118,16 @@ func renderTuttiModeHostContextForCLI(snapshot *TuttiModeTurnSnapshot, cliName s
 	if err != nil {
 		return ""
 	}
-	stateSentence := "Tutti mode is inactive for this turn."
+	activationRule := "The JSON `state` field is authoritative for whether Tutti Mode is active for this turn. " +
+		"Determine and report Tutti Mode status only from that field. " +
+		"Provider collaboration mode and Tutti workflow existence are independent facts and must not override the activation state. "
+	stateSentence := "Tutti mode is inactive for this turn. " + activationRule
 	workflowGuide := ""
 	if normalized.State == TuttiModeStateActive {
-		stateSentence = "Tutti mode is active for this turn. Do not execute the user's request directly in this turn. " +
+		stateSentence = "Tutti mode is active for this turn. " + activationRule +
+			"Do not execute the user's request directly in this turn. " +
 			"Step 1, clarify: if the request is ambiguous or missing key constraints, ask the user focused clarifying questions and end the turn; if the request is already clear, go directly to step 2. " +
+			fmt.Sprintf("When the user requests a plan and the request is clear, follow step 2 and submit it through `%s plan propose`; a chat-only plan is not a proposal. ", cliName) +
 			fmt.Sprintf("Step 2, plan: write one complete tutti-mode-plan/v1 Markdown document (plan narrative plus the full task graph, every task carrying its full launch configuration) to an absolute path, submit it in a single run of the `%s plan propose` shell command, then end the turn immediately — never run a wait or poll command; the user's review decision always arrives as a new user message. ", cliName) +
 			"Treat effect and speed as independent 0-100 preferences. Effect drives outcome quality: higher values require stronger suitable models and stronger task verification. Speed drives completion latency: higher values favor faster suitable models and raise the parallel Agent target carried in parallelTarget. Combine them rather than averaging them: first satisfy the requested effect, then choose the fastest suitable option; never satisfy speed by selecting a model that cannot meet the requested effect. " +
 			"Use the injected `$tutti-model-allocation` skill as the assignment policy: classify every task on its C0-C3 capability ladder, combine the task tier with the effect floor, use speed to rank models that clear that floor, and shape independent work toward parallelTarget. " +

--- a/packages/agent/daemon/runtime/tutti_mode_host_context_test.go
+++ b/packages/agent/daemon/runtime/tutti_mode_host_context_test.go
@@ -199,6 +199,10 @@ func TestRenderTuttiModeHostContextCarriesTypedActiveState(t *testing.T) {
 		`"revisionId":"revision-7"`,
 		`"revision":7`,
 		`"state":"active"`,
+		"The JSON `state` field is authoritative",
+		"Determine and report Tutti Mode status only from that field",
+		"Provider collaboration mode and Tutti workflow existence are independent facts",
+		"When the user requests a plan and the request is clear",
 		"Do not execute the user's request directly in this turn.",
 		"ask the user focused clarifying questions",
 		"`tutti plan propose` shell command",
@@ -244,6 +248,9 @@ func TestRenderTuttiModeHostContextCarriesExplicitInactiveState(t *testing.T) {
 		`"revision":8`,
 		`"state":"inactive"`,
 		"Tutti mode is inactive for this turn.",
+		"The JSON `state` field is authoritative",
+		"Determine and report Tutti Mode status only from that field",
+		"Provider collaboration mode and Tutti workflow existence are independent facts",
 		"Tutti CLI capabilities remain available",
 	} {
 		if !strings.Contains(contextText, expected) {
@@ -259,6 +266,19 @@ func TestRenderTuttiModeHostContextCarriesExplicitInactiveState(t *testing.T) {
 	} {
 		if strings.Contains(contextText, forbidden) {
 			t.Fatalf("inactive host context = %q, must not contain active-only directive %q", contextText, forbidden)
+		}
+	}
+}
+
+func TestRenderTuttiModeHostContextSeparatesActivationFromWorkflowExistence(t *testing.T) {
+	t.Parallel()
+	contextText := renderTuttiModeHostContextForCLI(testActiveTuttiModeSnapshot(), "tutti")
+	for _, expected := range []string{
+		"must not override the activation state",
+		"A Tutti plan exists only after plan propose returns a workflowId",
+	} {
+		if !strings.Contains(contextText, expected) {
+			t.Fatalf("host context = %q, want %q", contextText, expected)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- make the per-Turn Tutti Host Context `state` the sole authority for reporting whether Tutti Mode is active
- keep provider Default/Plan mode and Tutti workflow existence as independent facts that cannot override activation
- require clear plan requests in active Tutti Mode to use `tutti plan propose` instead of returning a chat-only plan
- add active/inactive regression coverage and document the existing-Session diagnostic path

## Root cause

An exported production session showed an active Tutti activation revision reaching two new Turns on an existing Codex provider session. The Codex `turn_context` contained `state: active` while its independent collaboration mode remained `default`. Because the existing instructions also said that a Tutti plan exists only after `plan propose`, the model conflated provider mode and workflow existence with activation and incorrectly reported that Tutti Mode had not been entered.

## User impact

After enabling Tutti Mode on an existing Session, the next new Turn reports status from its immutable activation snapshot. An already-running Turn remains bound to its original snapshot. Status checks do not create workflows, while clear plan-generation requests still enter the Tutti proposal workflow.

## Validation

- `go test ./packages/agent/daemon/runtime -run 'Test(RenderTuttiModeHostContext|AppServerTurnStartKeepsTuttiContextOutOfUserInput)' -count=1`
- `pnpm check:changed -- --failed-only` — 7 lanes passed
- pre-push `pnpm check:changed -- --push-ready` — 8 lanes passed
- Husky pre-commit checks passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only Tutti Host Context prompt text and docs; wrong wording could still mis-steer planning agents, but there is no runtime dispatch or persistence change.
> 
> **Overview**
> Fixes agents on **existing provider sessions** misreporting Tutti Mode as inactive when Codex collaboration mode stays `default` but the per-turn snapshot is active.
> 
> **`renderTuttiModeHostContext`** now states that the JSON **`state`** field is the **sole authority** for whether Tutti Mode is active. Provider Default/Plan mode and whether a Tutti workflow already exist are **independent** and must not override that field. For active turns, clear plan requests must go through **`tutti plan propose`**—a chat-only plan is not a proposal.
> 
> Docs add the existing-session diagnostic (Codex `turn_context` with `state: active` vs collaboration `default`) and architecture notes that each new turn on a reused session still gets the current immutable activation snapshot.
> 
> Tests assert the new activation wording for active and inactive snapshots and that workflow-existence guidance stays separate from activation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bb76558819afb21b48aba250b452ee00d8db735. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->