### PR TITLE
fix(agent-runtime): restore remote image delivery

### DIFF
--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -58,6 +58,7 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 - [AgentGUI Stop reports no active turn after cancel succeeds](./agent-session-lifecycle.md#agentgui-stop-reports-no-active-turn-after-cancel-succeeds)
 - [AgentGUI send blocked by active_turn after settled snapshot](./agent-session-lifecycle.md#agentgui-send-blocked-by-activeturn-after-settled-snapshot)
 - [AgentGUI rejects a pasted image as unsupported before send](./agent-session-lifecycle.md#agentgui-rejects-a-pasted-image-as-unsupported-before-send)
+- [Remote Agent image reaches the provider as an unsupported URL](./agent-session-lifecycle.md#remote-agent-image-reaches-the-provider-as-an-unsupported-url)
 - [AgentGUI loading disappears before active turn settles](./agent-session-lifecycle.md#agentgui-loading-disappears-before-active-turn-settles)
 - [Queued AgentGUI prompt stalls after no-active-turn failure](./agent-session-lifecycle.md#queued-agentgui-prompt-stalls-after-no-active-turn-failure)
 - [Agent session stays loading after a completed turn](./agent-session-lifecycle.md#agent-session-stays-loading-after-a-completed-turn)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -727,6 +727,55 @@ Turn state, loading, cancel, restore, file-change undo, rail projection, event u
   [controller.go](../../../packages/agent/daemon/runtime/controller.go)
   [service_send_input.go](../../../services/tuttid/service/agent/service_send_input.go)
 
+### Remote Agent image reaches the provider as an unsupported URL
+
+- Symptom:
+  A URL-backed PNG, JPEG, or WebP is accepted and appears in the user activity,
+  but Codex rejects the turn with `remote image URLs are not supported; use an
+inline data URL instead`. Claude or standard ACP may instead receive no
+  usable image data.
+- Quick checks:
+  Confirm the durable prompt block intentionally contains an HTTPS `url`, then
+  inspect the final provider payload. Codex must receive a `data:` URL; Claude
+  SDK and standard ACP must receive base64 `data`. Search every provider send
+  and guidance path for `materializeProviderPromptImagesAtBoundary`; the helper
+  and its unit test can remain green even when a refactor removes all production
+  callers.
+- Root cause:
+  Remote image URLs are the durable transport representation, while current
+  Codex app-server, Claude SDK, and standard ACP provider wires require inline
+  data. A provider-adapter refactor can preserve the materialization helper but
+  omit its call sites in newly split turn files.
+- Fix:
+  Materialize only at the final provider boundary. Keep the original URL-backed
+  content for activity projection, and convert the provider-only copy after
+  local slash/control handling but immediately before Codex `turn/start` or
+  `turn/steer`, Claude SDK `exec` or `guide`, and standard ACP
+  `session/prompt`. Resolve and pin every download or redirect hop to a public
+  Internet address so prompt content cannot reach loopback, private, link-local,
+  transition-mapped, or other IANA special-purpose networks. Preserve the
+  configured proxy decision using the original URL, but send the proxy a pinned
+  public-IP tunnel target while retaining the original TLS server name and HTTP
+  Host. Strip redirect `Referer` headers so signed URL query parameters cannot
+  cross origins. Admit an asynchronous Codex guidance continuation before
+  publishing its provisional provider turn, and settle that exact attempt when
+  preparation ends without starting a real provider turn.
+- Validation:
+  Exercise URL-only content through the real adapter request paths and assert
+  the captured provider payload contains inline data. Cover Codex send and
+  guidance, Claude SDK exec and guide, and standard ACP exec; do not rely only
+  on direct helper tests. Also reject loopback literals and redirects whose
+  target resolves to an internal or transition-mapped address, verify proxy
+  CONNECT uses the pinned public IP, and assert redirects omit signed-URL
+  referrers. Cover failed and concurrent guidance continuation admission so
+  every published provisional attempt either yields a real provider lifecycle
+  or receives its matching provider-turn completion.
+- References:
+  [prompt_content.go](../../../packages/agent/daemon/runtime/prompt_content.go)
+  [codex_appserver_turn.go](../../../packages/agent/daemon/runtime/codex_appserver_turn.go)
+  [claude_sdk_execution.go](../../../packages/agent/daemon/runtime/claude_sdk_execution.go)
+  [standard_acp_turn.go](../../../packages/agent/daemon/runtime/standard_acp_turn.go)
+
 ### AgentGUI Stop reports no active turn after cancel succeeds
 
 - Symptom:

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -759,7 +759,10 @@ inline data URL instead`. Claude or standard ACP may instead receive no
   Host. Strip redirect `Referer` headers so signed URL query parameters cannot
   cross origins. Admit an asynchronous Codex guidance continuation before
   publishing its provisional provider turn, and settle that exact attempt when
-  preparation ends without starting a real provider turn.
+  preparation ends without starting a real provider turn. For standard ACP,
+  publish the original user activity and provider-turn start before remote
+  materialization; if preparation fails, complete that same provider turn as
+  failed so the message remains durable and root settlement cannot strand.
 - Validation:
   Exercise URL-only content through the real adapter request paths and assert
   the captured provider payload contains inline data. Cover Codex send and
@@ -769,7 +772,9 @@ inline data URL instead`. Claude or standard ACP may instead receive no
   CONNECT uses the pinned public IP, and assert redirects omit signed-URL
   referrers. Cover failed and concurrent guidance continuation admission so
   every published provisional attempt either yields a real provider lifecycle
-  or receives its matching provider-turn completion.
+  or receives its matching provider-turn completion. Also fail standard ACP
+  materialization and assert the original user message, turn start, and failed
+  provider-turn completion are all emitted without sending `session/prompt`.
 - References:
   [prompt_content.go](../../../packages/agent/daemon/runtime/prompt_content.go)
   [codex_appserver_turn.go](../../../packages/agent/daemon/runtime/codex_appserver_turn.go)

--- a/packages/agent/daemon/runtime/claude_sdk_adapter.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter.go
@@ -29,6 +29,7 @@ type ClaudeCodeSDKAdapter struct {
 	interactiveDispositionSink InteractiveDispositionSink
 	commandSink                CommandSnapshotSink
 	eventSink                  SessionEventSink
+	promptImageMaterializer    providerPromptImageMaterializer
 	interactiveAckTimeout      time.Duration
 }
 

--- a/packages/agent/daemon/runtime/claude_sdk_execution.go
+++ b/packages/agent/daemon/runtime/claude_sdk_execution.go
@@ -51,13 +51,18 @@ func (a *ClaudeCodeSDKAdapter) Exec(
 	}
 	emitEvents(a.stampTurnLifecycleSnapshots(adapterSession, startEvents))
 
+	providerContent, err := materializeProviderPromptImagesAtBoundary(ctx, content, a.promptImageMaterializer)
+	if err != nil {
+		events = append(events, a.claudeSDKRootProviderFailureEvents(adapterSession, session, turnID, promptCorrelationID, err)...)
+		return events, err
+	}
 	waiter := a.registerClaudeSDKTurn(adapterSession, turnID, emit)
 	if err := a.startClaudeSDKReader(session.AgentSessionID, adapterSession); err != nil {
 		a.unregisterClaudeSDKTurn(adapterSession, turnID, waiter)
 		events = append(events, a.claudeSDKRootProviderFailureEvents(adapterSession, session, turnID, promptCorrelationID, err)...)
 		return events, err
 	}
-	payload := claudeSDKExecPayload(ctx, session, turnID, promptCorrelationID, content, visibleText)
+	payload := claudeSDKExecPayload(ctx, session, turnID, promptCorrelationID, providerContent, visibleText)
 	if err := adapterSession.send(claudeSDKSidecarRequest{
 		ID:      newID(),
 		Type:    "exec",
@@ -146,6 +151,10 @@ func (a *ClaudeCodeSDKAdapter) GuideActiveTurn(
 	}
 	session.ProviderSessionID = adapterSession.providerSessionID
 	explicitDisplayPrompt, visibleText := explicitAndVisiblePromptText(content, displayPrompt)
+	providerContent, err := materializeProviderPromptImagesAtBoundary(ctx, content, a.promptImageMaterializer)
+	if err != nil {
+		return nil, err
+	}
 	events := []activityshared.Event{
 		newUserPromptActivityEvent(ctx, session, content, explicitDisplayPrompt, visibleText, turnID, map[string]any{
 			"adapter":  claudeSDKSidecarAdapterName,
@@ -163,8 +172,8 @@ func (a *ClaudeCodeSDKAdapter) GuideActiveTurn(
 		Type: "guide",
 		Payload: map[string]any{
 			"agentSessionId": session.AgentSessionID,
-			"prompt":         promptTextForClaudeSDK(content, visibleText),
-			"content":        promptContentForClaudeSDK(content, visibleText),
+			"prompt":         promptTextForClaudeSDK(providerContent, visibleText),
+			"content":        promptContentForClaudeSDK(providerContent, visibleText),
 		},
 	}); err != nil {
 		return events, err

--- a/packages/agent/daemon/runtime/claude_sdk_session_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_session_test.go
@@ -573,6 +573,8 @@ func TestClaudeCodeSDKAdapterExecSendsStructuredPromptContent(t *testing.T) {
 		}},
 	}
 	adapter := NewClaudeCodeSDKAdapter(nil)
+	imageURL, materializer := testRemotePromptImageMaterializer(t)
+	adapter.promptImageMaterializer = materializer
 	session := standardTestSession(ProviderClaudeCode)
 	adapter.storeSession(session.AgentSessionID, &claudeSDKAdapterSession{
 		conn:              conn,
@@ -587,7 +589,7 @@ func TestClaudeCodeSDKAdapterExecSendsStructuredPromptContent(t *testing.T) {
 		session,
 		[]PromptContentBlock{
 			{Type: "text", Text: "what is in this image?"},
-			{Type: "image", MimeType: "image/png", Data: "aW1hZ2U="},
+			{Type: "image", MimeType: "image/png", URL: imageURL},
 		},
 		"what is in this image?",
 		"turn-image",
@@ -620,7 +622,7 @@ func TestClaudeCodeSDKAdapterExecSendsStructuredPromptContent(t *testing.T) {
 		t.Fatalf("text block = %#v", textBlock)
 	}
 	imageBlock, _ := content[1].(map[string]any)
-	if imageBlock["type"] != "image" || imageBlock["mimeType"] != "image/png" || imageBlock["data"] != "aW1hZ2U=" {
+	if imageBlock["type"] != "image" || imageBlock["mimeType"] != "image/png" || imageBlock["data"] != "aGk=" || imageBlock["url"] != nil {
 		t.Fatalf("image block = %#v", imageBlock)
 	}
 }

--- a/packages/agent/daemon/runtime/claude_sdk_settings_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_settings_test.go
@@ -38,6 +38,8 @@ func TestClaudeCodeSDKAdapterApplySessionSettingsSpeedSendsSidecarAndUpdatesRunt
 
 func TestClaudeCodeSDKAdapterGuideActiveTurnSendsSidecarGuide(t *testing.T) {
 	adapter := NewClaudeCodeSDKAdapter(nil)
+	imageURL, materializer := testRemotePromptImageMaterializer(t)
+	adapter.promptImageMaterializer = materializer
 	session := standardTestSession(ProviderClaudeCode)
 	conn := newBlockingClaudeSDKConnection()
 	defer func() { _ = conn.Close() }()
@@ -56,13 +58,24 @@ func TestClaudeCodeSDKAdapterGuideActiveTurnSendsSidecarGuide(t *testing.T) {
 	}
 	results := make(chan guidanceResult, 1)
 	go func() {
-		events, err := adapter.GuideActiveTurn(context.Background(), session, textPrompt("guide current turn"), "", "turn-guidance", nil, nil)
+		events, err := adapter.GuideActiveTurn(context.Background(), session, []PromptContentBlock{
+			{Type: "text", Text: "guide current turn"},
+			{Type: "image", MimeType: "image/png", URL: imageURL},
+		}, "", "turn-guidance", nil, nil)
 		results <- guidanceResult{events: events, err: err}
 	}()
 
 	request := waitForClaudeSDKSentRequest(t, conn, "guide")
 	if _, ok := request.Payload["turnId"]; ok || request.Payload["prompt"] != "guide current turn" {
 		t.Fatalf("guide payload = %#v", request.Payload)
+	}
+	content, _ := request.Payload["content"].([]any)
+	if len(content) != 2 {
+		t.Fatalf("guide content = %#v, want text+image", request.Payload["content"])
+	}
+	image, _ := content[1].(map[string]any)
+	if image["data"] != "aGk=" || image["url"] != nil {
+		t.Fatalf("guide image = %#v, want inline image data", image)
 	}
 	conn.pushEvent(claudeSDKSidecarEvent{ID: request.ID, Type: "ok"})
 

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -154,6 +154,7 @@ type CodexAppServerAdapter struct {
 	eventSink                  SessionEventSink
 	goalReconcileSink          GoalReconcileDurableSink
 	goalProvenanceSink         GoalProvenanceDurableSink
+	promptImageMaterializer    providerPromptImageMaterializer
 	goalReconcileAckTimeout    time.Duration
 	configSink                 ConfigOptionsUpdateSink
 	// lifecycleMu guards lifecycleLocks; the per-session locks serialize

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -2136,6 +2136,31 @@ func TestCodexAppServerAdapterExecImagePrompt(t *testing.T) {
 	}
 }
 
+func TestCodexAppServerAdapterExecMaterializesRemoteImageAtProviderBoundary(t *testing.T) {
+	t.Parallel()
+
+	adapter, transport, session := startedAppServerAdapter(t)
+	imageURL, materializer := testRemotePromptImageMaterializer(t)
+	adapter.promptImageMaterializer = materializer
+
+	if _, err := adapter.Exec(context.Background(), session, []PromptContentBlock{
+		{Type: "text", Text: "look at this"},
+		{Type: "image", MimeType: "image/png", URL: imageURL},
+	}, "", "turn-remote-image", nil, nil); err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+
+	turnStart := appServerRequestParams(t, transport.conn, appServerMethodTurnStart)
+	input, _ := turnStart["input"].([]any)
+	if len(input) != 2 {
+		t.Fatalf("turn/start input = %#v, want text+image", turnStart["input"])
+	}
+	image := payloadObject(input[1])
+	if got := asString(image["url"]); got != "data:image/png;base64,aGk=" {
+		t.Fatalf("turn/start image URL = %q, want inline data URL", got)
+	}
+}
+
 func TestCodexAppServerAdapterExecTurnFailed(t *testing.T) {
 	t.Parallel()
 
@@ -3140,6 +3165,48 @@ func TestCodexAppServerAdapterGuideActiveTurnUsesTurnSteer(t *testing.T) {
 	}
 }
 
+func TestCodexAppServerAdapterGuideMaterializesRemoteImageAtProviderBoundary(t *testing.T) {
+	t.Parallel()
+
+	adapter, transport, session := startedAppServerAdapter(t)
+	imageURL, materializer := testRemotePromptImageMaterializer(t)
+	adapter.promptImageMaterializer = materializer
+	transport.conn.holdTurn = true
+
+	execDone := make(chan struct{})
+	go func() {
+		_, _ = adapter.Exec(context.Background(), session, textPrompt("long task"), "", "turn-local-1", nil, nil)
+		close(execDone)
+	}()
+	waitForCondition(t, func() bool {
+		return adapter.sessionActiveTurnID(session.AgentSessionID) == "turn-1"
+	})
+
+	if _, err := adapter.GuideActiveTurn(context.Background(), session, []PromptContentBlock{
+		{Type: "text", Text: "use this screenshot"},
+		{Type: "image", MimeType: "image/png", URL: imageURL},
+	}, "", "turn-guidance", nil, nil); err != nil {
+		t.Fatalf("GuideActiveTurn: %v", err)
+	}
+
+	steer := appServerRequestParams(t, transport.conn, appServerMethodTurnSteer)
+	input, _ := steer["input"].([]any)
+	if len(input) != 2 {
+		t.Fatalf("turn/steer input = %#v, want text+image", steer["input"])
+	}
+	image := payloadObject(input[1])
+	if got := asString(image["url"]); got != "data:image/png;base64,aGk=" {
+		t.Fatalf("turn/steer image URL = %q, want inline data URL", got)
+	}
+
+	transport.conn.completePendingTurn()
+	select {
+	case <-execDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Exec did not finish after guidance")
+	}
+}
+
 func TestCodexAppServerAdapterGuidanceStartsProviderContinuationOnSameRootTurn(t *testing.T) {
 	t.Parallel()
 
@@ -3203,6 +3270,217 @@ func TestCodexAppServerAdapterGuidanceStartsProviderContinuationOnSameRootTurn(t
 	})
 	if requests := appServerRequestParamsList(t, transport.conn, appServerMethodTurnStart); len(requests) < 2 {
 		t.Fatalf("turn/start requests = %#v, want initial turn and same-root continuation", requests)
+	}
+}
+
+func TestCodexAppServerAdapterGuidanceContinuationMaterializationFailureClosesProvisionalProviderTurn(t *testing.T) {
+	t.Parallel()
+
+	adapter, transport, session := startedAppServerAdapter(t)
+	if _, err := adapter.Exec(context.Background(), session, textPrompt("delegate work"), "", "root-turn-1", nil, nil); err != nil {
+		t.Fatalf("initial Exec: %v", err)
+	}
+	_, childEvents := adapter.rememberAppServerChildThreads(
+		session,
+		session.ProviderSessionID,
+		session.AgentSessionID,
+		"root-turn-1",
+		session.AgentSessionID,
+		"root-turn-1",
+		map[string]any{
+			"type":              "collabAgentToolCall",
+			"id":                "spawn-child-1",
+			"tool":              "spawnAgent",
+			"receiverThreadIds": []any{"child-thread-1"},
+		},
+	)
+	if len(childEvents) != 1 || childEvents[0].Type != activityshared.EventSessionStarted {
+		t.Fatalf("child creation events = %#v", childEvents)
+	}
+	adapter.promptImageMaterializer = func(context.Context, []PromptContentBlock) ([]PromptContentBlock, error) {
+		return nil, errors.New("signed image expired")
+	}
+
+	var mu sync.Mutex
+	var streamed []activityshared.Event
+	returned, err := adapter.GuideActiveTurn(
+		context.Background(),
+		session,
+		[]PromptContentBlock{
+			{Type: "text", Text: "include this image"},
+			{Type: "image", MimeType: "image/png", URL: "https://public.example/image.png"},
+		},
+		"",
+		"root-turn-1",
+		func(events []activityshared.Event) {
+			mu.Lock()
+			streamed = append(streamed, events...)
+			mu.Unlock()
+		},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("GuideActiveTurn: %v", err)
+	}
+	if len(returned) != 1 || returned[0].Type != activityshared.EventRootProviderTurnStarted {
+		t.Fatalf("guidance return events = %#v, want provisional provider continuation", returned)
+	}
+	attemptID := returned[0].Payload.ProviderTurnID
+	waitForCondition(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, event := range streamed {
+			if event.Type == activityshared.EventRootProviderTurnCompleted &&
+				event.Payload.ProviderTurnID == attemptID &&
+				event.Payload.TurnOutcome == string(activityshared.TurnOutcomeFailed) {
+				return true
+			}
+		}
+		return false
+	})
+	if requests := appServerRequestParamsList(t, transport.conn, appServerMethodTurnStart); len(requests) != 1 {
+		t.Fatalf("turn/start requests = %#v, want no continuation provider request", requests)
+	}
+}
+
+func TestCodexAppServerAdapterConcurrentGuidancePublishesSingleProvisionalContinuation(t *testing.T) {
+	t.Parallel()
+
+	adapter, transport, session := startedAppServerAdapter(t)
+	if _, err := adapter.Exec(context.Background(), session, textPrompt("delegate work"), "", "root-turn-1", nil, nil); err != nil {
+		t.Fatalf("initial Exec: %v", err)
+	}
+	_, childEvents := adapter.rememberAppServerChildThreads(
+		session,
+		session.ProviderSessionID,
+		session.AgentSessionID,
+		"root-turn-1",
+		session.AgentSessionID,
+		"root-turn-1",
+		map[string]any{
+			"type":              "collabAgentToolCall",
+			"id":                "spawn-child-1",
+			"tool":              "spawnAgent",
+			"receiverThreadIds": []any{"child-thread-1"},
+		},
+	)
+	if len(childEvents) != 1 || childEvents[0].Type != activityshared.EventSessionStarted {
+		t.Fatalf("child creation events = %#v", childEvents)
+	}
+	transport.conn.holdTurn = true
+
+	type guidanceCallResult struct {
+		events []activityshared.Event
+		err    error
+	}
+	var streamedMu sync.Mutex
+	var streamed []activityshared.Event
+	emit := func(events []activityshared.Event) {
+		streamedMu.Lock()
+		defer streamedMu.Unlock()
+		streamed = append(streamed, events...)
+	}
+	start := make(chan struct{})
+	results := make(chan guidanceCallResult, 2)
+	for index := 0; index < 2; index++ {
+		index := index
+		go func() {
+			<-start
+			events, err := adapter.GuideActiveTurn(
+				context.Background(),
+				session,
+				textPrompt(fmt.Sprintf("guidance %d", index)),
+				"",
+				"root-turn-1",
+				emit,
+				nil,
+			)
+			results <- guidanceCallResult{events: events, err: err}
+		}()
+	}
+	close(start)
+
+	provisionalStarts := 0
+	for index := 0; index < 2; index++ {
+		select {
+		case result := <-results:
+			for _, event := range result.events {
+				if event.Type == activityshared.EventRootProviderTurnStarted &&
+					strings.HasPrefix(event.Payload.ProviderTurnID, "continuation:") {
+					provisionalStarts++
+				}
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for concurrent guidance")
+		}
+	}
+	if provisionalStarts != 1 {
+		t.Fatalf("provisional provider starts = %d, want exactly 1", provisionalStarts)
+	}
+	waitForCondition(t, func() bool {
+		streamedMu.Lock()
+		defer streamedMu.Unlock()
+		started := 0
+		for _, event := range streamed {
+			if event.Type == activityshared.EventTurnStarted {
+				started++
+			}
+		}
+		return started >= 1
+	})
+	streamedMu.Lock()
+	started := 0
+	for _, event := range streamed {
+		if event.Type == activityshared.EventTurnStarted {
+			started++
+		}
+	}
+	streamedMu.Unlock()
+	if started != 1 {
+		t.Fatalf("streamed turn starts = %d, want exactly 1 admitted continuation", started)
+	}
+
+	waitForCondition(t, func() bool {
+		return adapter.sessionActiveTurnID(session.AgentSessionID) != ""
+	})
+	transport.conn.completePendingTurn()
+	waitForCondition(t, func() bool {
+		return adapter.sessionActiveTurnID(session.AgentSessionID) == ""
+	})
+}
+
+func TestCodexAppServerAdapterRejectedContinuationAdmissionEmitsNoTurnStart(t *testing.T) {
+	t.Parallel()
+
+	adapter, _, session := startedAppServerAdapter(t)
+	blockingTurn := &codexAppServerActiveTurn{turnID: "blocking-turn"}
+	if !adapter.beginActiveTurn(session.AgentSessionID, blockingTurn) {
+		t.Fatal("failed to reserve blocking turn")
+	}
+	defer adapter.endActiveTurn(session.AgentSessionID, blockingTurn)
+
+	var streamed []activityshared.Event
+	continuation := newCodexGuidanceContinuationAdmission("continuation:rejected")
+	events, err := adapter.execBlocking(
+		context.Background(),
+		session,
+		textPrompt("guidance"),
+		"",
+		"root-turn-1",
+		func(next []activityshared.Event) {
+			streamed = append(streamed, next...)
+		},
+		nil,
+		continuation,
+	)
+	if !errors.Is(err, ErrSessionActiveTurn) {
+		t.Fatalf("execBlocking error = %v, want ErrSessionActiveTurn", err)
+	}
+	if admittedErr := <-continuation.admitted; !errors.Is(admittedErr, ErrSessionActiveTurn) {
+		t.Fatalf("admission error = %v, want ErrSessionActiveTurn", admittedErr)
+	}
+	if len(events) != 0 || len(streamed) != 0 {
+		t.Fatalf("rejected continuation events = %#v, streamed = %#v; want none", events, streamed)
 	}
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_turn.go
+++ b/packages/agent/daemon/runtime/codex_appserver_turn.go
@@ -20,7 +20,7 @@ func (a *CodexAppServerAdapter) Exec(
 	emit EventSink,
 	emitCommands CommandSnapshotSink,
 ) ([]activityshared.Event, error) {
-	return a.execBlocking(ctx, session, content, displayPrompt, turnID, emit, emitCommands)
+	return a.execBlocking(ctx, session, content, displayPrompt, turnID, emit, emitCommands, nil)
 }
 
 func (a *CodexAppServerAdapter) ExecAsync(
@@ -32,21 +32,127 @@ func (a *CodexAppServerAdapter) ExecAsync(
 	emit EventSink,
 	emitCommands CommandSnapshotSink,
 ) error {
+	return a.execAsync(ctx, session, content, displayPrompt, turnID, emit, emitCommands, nil)
+}
+
+type codexGuidanceContinuationAdmission struct {
+	providerTurnID     string
+	admitted           chan error
+	provisionalStarted chan struct{}
+}
+
+func newCodexGuidanceContinuationAdmission(providerTurnID string) *codexGuidanceContinuationAdmission {
+	return &codexGuidanceContinuationAdmission{
+		providerTurnID:     providerTurnID,
+		admitted:           make(chan error, 1),
+		provisionalStarted: make(chan struct{}),
+	}
+}
+
+func (a *codexGuidanceContinuationAdmission) published() bool {
+	if a == nil {
+		return false
+	}
+	select {
+	case <-a.provisionalStarted:
+		return true
+	default:
+		return false
+	}
+}
+
+func (a *CodexAppServerAdapter) execAsync(
+	ctx context.Context,
+	session Session,
+	content []PromptContentBlock,
+	displayPrompt string,
+	turnID string,
+	emit EventSink,
+	emitCommands CommandSnapshotSink,
+	continuation *codexGuidanceContinuationAdmission,
+) error {
 	go func() {
-		if _, err := a.execBlocking(ctx, session, content, displayPrompt, turnID, emit, emitCommands); err != nil {
-			if emit == nil {
-				return
+		events, err := a.execBlocking(
+			ctx,
+			session,
+			content,
+			displayPrompt,
+			turnID,
+			emit,
+			emitCommands,
+			continuation,
+		)
+		if continuation != nil && !continuation.published() {
+			return
+		}
+		if emit == nil {
+			return
+		}
+		outcome := codexAsyncTerminalOutcome(events, err)
+		terminalEvents := make([]activityshared.Event, 0, 2)
+		if continuation != nil &&
+			!codexAsyncProviderLifecycleSupersedes(events, continuation.providerTurnID) {
+			metadata := map[string]any{
+				"guidanceContinuation": true,
+				"providerTurnStarted":  false,
 			}
-			if errors.Is(err, context.Canceled) {
-				emit([]activityshared.Event{newTurnActivityEvent(session, EventTurnCanceled, turnID, SessionStatusCanceled, "", "", map[string]any{
+			if err != nil {
+				metadata["error"] = err.Error()
+			}
+			terminalEvents = append(terminalEvents, appServerRootProviderTurnCompletedEvent(
+				session,
+				turnID,
+				continuation.providerTurnID,
+				outcome,
+				metadata,
+			))
+		}
+		if err != nil {
+			if outcome == activityshared.TurnOutcomeCanceled {
+				terminalEvents = append(terminalEvents, newTurnActivityEvent(session, EventTurnCanceled, turnID, SessionStatusCanceled, "", "", map[string]any{
 					"error": err.Error(),
-				})})
-				return
+				}))
+			} else {
+				terminalEvents = append(terminalEvents, newTurnActivityEvent(session, EventTurnFailed, turnID, SessionStatusFailed, "", "", acpFailureMetadata(err)))
 			}
-			emit([]activityshared.Event{newTurnActivityEvent(session, EventTurnFailed, turnID, SessionStatusFailed, "", "", acpFailureMetadata(err))})
+		}
+		if len(terminalEvents) > 0 {
+			emit(terminalEvents)
 		}
 	}()
 	return nil
+}
+
+func codexAsyncProviderLifecycleSupersedes(events []activityshared.Event, provisionalProviderTurnID string) bool {
+	for _, event := range events {
+		if event.Type != activityshared.EventRootProviderTurnStarted &&
+			event.Type != activityshared.EventRootProviderTurnCompleted {
+			continue
+		}
+		providerTurnID := strings.TrimSpace(event.Payload.ProviderTurnID)
+		if providerTurnID != "" && providerTurnID != provisionalProviderTurnID {
+			return true
+		}
+	}
+	return false
+}
+
+func codexAsyncTerminalOutcome(events []activityshared.Event, err error) activityshared.TurnOutcome {
+	if errors.Is(err, context.Canceled) {
+		return activityshared.TurnOutcomeCanceled
+	}
+	for _, event := range events {
+		switch event.Type {
+		case activityshared.EventTurnCanceled:
+			return activityshared.TurnOutcomeCanceled
+		case activityshared.EventTurnFailed:
+			return activityshared.TurnOutcomeFailed
+		}
+	}
+	if err != nil {
+		return activityshared.TurnOutcomeFailed
+	}
+	return activityshared.TurnOutcomeCompleted
 }
 
 func (a *CodexAppServerAdapter) GuideActiveTurn(
@@ -66,11 +172,16 @@ func (a *CodexAppServerAdapter) GuideActiveTurn(
 	session.ProviderSessionID = appSession.threadID
 	explicitDisplayPrompt, visibleText := explicitAndVisiblePromptText(content, displayPrompt)
 	mentionRoutingApplied, mentionRoutingSkills := tuttiMentionRoutingSkills(visibleText)
-	providerContent := content
-	if mentionRoutingApplied {
-		providerContent = appendTuttiMentionRoutingContent(providerContent, mentionRoutingSkills)
-	}
 	if activeTurnID != "" {
+		providerContent := content
+		if mentionRoutingApplied {
+			providerContent = appendTuttiMentionRoutingContent(providerContent, mentionRoutingSkills)
+		}
+		var err error
+		providerContent, err = materializeProviderPromptImagesAtBoundary(ctx, providerContent, a.promptImageMaterializer)
+		if err != nil {
+			return nil, err
+		}
 		return a.steerActiveTurn(ctx, appSession, session, content, providerContent, explicitDisplayPrompt, visibleText, turnID, activeTurnID, emit)
 	}
 	// The canonical root turn remains active while child sessions drain even
@@ -89,10 +200,8 @@ func (a *CodexAppServerAdapter) GuideActiveTurn(
 	}
 	started := activityshared.NewRootProviderTurnStarted(eventContext, turnID, attemptID)
 	started.Payload.Metadata = map[string]any{"guidanceContinuation": true}
-	if emit != nil {
-		emit([]activityshared.Event{started})
-	}
-	if err := a.ExecAsync(
+	continuation := newCodexGuidanceContinuationAdmission(attemptID)
+	if err := a.execAsync(
 		context.WithoutCancel(ctx),
 		session,
 		content,
@@ -100,9 +209,17 @@ func (a *CodexAppServerAdapter) GuideActiveTurn(
 		turnID,
 		emit,
 		emitCommands,
+		continuation,
 	); err != nil {
-		return []activityshared.Event{started}, err
+		return nil, err
 	}
+	if err := <-continuation.admitted; err != nil {
+		return nil, err
+	}
+	if emit != nil {
+		emit([]activityshared.Event{started})
+	}
+	close(continuation.provisionalStarted)
 	return []activityshared.Event{started}, nil
 }
 
@@ -247,9 +364,13 @@ func (a *CodexAppServerAdapter) execBlocking(
 	turnID string,
 	emit EventSink,
 	emitCommands CommandSnapshotSink,
+	continuation *codexGuidanceContinuationAdmission,
 ) ([]activityshared.Event, error) {
 	execState, ok := a.snapshotExecState(session.AgentSessionID)
 	if !ok {
+		if continuation != nil {
+			continuation.admitted <- ErrSessionDisconnected
+		}
 		return nil, ErrSessionDisconnected
 	}
 	appSession := execState.liveSession
@@ -262,17 +383,26 @@ func (a *CodexAppServerAdapter) execBlocking(
 	session.ProviderSessionID = appSession.threadID
 	explicitDisplayPrompt, visibleText := explicitAndVisiblePromptText(content, displayPrompt)
 	mentionRoutingApplied, mentionRoutingSkills := tuttiMentionRoutingSkills(visibleText)
-	providerContent := content
-	if mentionRoutingApplied {
-		providerContent = appendTuttiMentionRoutingContent(providerContent, mentionRoutingSkills)
-	}
 
 	if activeTurnID := a.sessionActiveTurnID(session.AgentSessionID); activeTurnID != "" {
+		if continuation != nil {
+			continuation.admitted <- ErrSessionActiveTurn
+			return nil, ErrSessionActiveTurn
+		}
 		if command, args := splitSlashCommand(visibleText); command == appServerSlashGoal {
 			// Goal commands are thread-level control operations; steering them
 			// would paste "/goal …" into the running turn as prompt text
 			// instead of executing the RPC.
 			return a.execGoalControlCommand(ctx, appSession, session, args, turnID, content, explicitDisplayPrompt, visibleText, emit)
+		}
+		providerContent := content
+		if mentionRoutingApplied {
+			providerContent = appendTuttiMentionRoutingContent(providerContent, mentionRoutingSkills)
+		}
+		var err error
+		providerContent, err = materializeProviderPromptImagesAtBoundary(ctx, providerContent, a.promptImageMaterializer)
+		if err != nil {
+			return nil, err
 		}
 		return a.steerActiveTurn(ctx, appSession, session, content, providerContent, explicitDisplayPrompt, visibleText, turnID, activeTurnID, emit)
 	}
@@ -325,7 +455,6 @@ func (a *CodexAppServerAdapter) execBlocking(
 		newUserPromptActivityEvent(ctx, session, content, explicitDisplayPrompt, visibleText, turnID, nil),
 		newTurnActivityEvent(session, EventTurnStarted, turnID, SessionStatusWorking, "", "", nil),
 	}
-	emitEvents(startEvents)
 
 	appTurn := &codexAppServerActiveTurn{
 		turnID:       turnID,
@@ -346,11 +475,29 @@ func (a *CodexAppServerAdapter) execBlocking(
 	// The settle path may finalize first; the Once keeps the close single.
 	defer appTurn.markTerminated()
 	if !a.beginActiveTurn(session.AgentSessionID, appTurn) {
+		if continuation != nil {
+			continuation.admitted <- ErrSessionActiveTurn
+		}
 		return nil, ErrSessionActiveTurn
 	}
 	defer a.endActiveTurn(session.AgentSessionID, appTurn)
+	if continuation != nil {
+		continuation.admitted <- nil
+		<-continuation.provisionalStarted
+	}
+	emitEvents(startEvents)
 
 	if handled, err := a.execSlashCommand(ctx, appSession, session, visibleText, turnID, appTurn, normalizer, emitEvents, emitTerminal, emitCommands); handled {
+		return snapshotEvents(), err
+	}
+
+	providerContent := content
+	if mentionRoutingApplied {
+		providerContent = appendTuttiMentionRoutingContent(providerContent, mentionRoutingSkills)
+	}
+	var err error
+	providerContent, err = materializeProviderPromptImagesAtBoundary(ctx, providerContent, a.promptImageMaterializer)
+	if err != nil {
 		return snapshotEvents(), err
 	}
 

--- a/packages/agent/daemon/runtime/prompt_content.go
+++ b/packages/agent/daemon/runtime/prompt_content.go
@@ -2,17 +2,22 @@ package agentruntime
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"mime"
+	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"strings"
+	"time"
 
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+	"github.com/tutti-os/tutti/packages/agent/daemon/httpx"
 )
 
 var ErrPromptImageUnsupported = errors.New("agent prompt image input is unsupported")
@@ -20,6 +25,36 @@ var ErrPromptImageUnsupported = errors.New("agent prompt image input is unsuppor
 const clientSubmitUserMessageIDPrefix = "client-submit:user:"
 
 const maxProviderPromptImageBytes int64 = 20 << 20
+
+var (
+	providerPromptImageGlobalIPv6UnicastPrefix = netip.MustParsePrefix("2000::/3")
+	// Fail closed for IANA special-purpose ranges, including transition
+	// addresses that can encode an otherwise blocked IPv4 destination.
+	providerPromptImageNonPublicPrefixes = []netip.Prefix{
+		netip.MustParsePrefix("0.0.0.0/8"),
+		netip.MustParsePrefix("10.0.0.0/8"),
+		netip.MustParsePrefix("100.64.0.0/10"),
+		netip.MustParsePrefix("127.0.0.0/8"),
+		netip.MustParsePrefix("169.254.0.0/16"),
+		netip.MustParsePrefix("172.16.0.0/12"),
+		netip.MustParsePrefix("192.0.0.0/24"),
+		netip.MustParsePrefix("192.0.2.0/24"),
+		netip.MustParsePrefix("192.31.196.0/24"),
+		netip.MustParsePrefix("192.52.193.0/24"),
+		netip.MustParsePrefix("192.88.99.0/24"),
+		netip.MustParsePrefix("192.168.0.0/16"),
+		netip.MustParsePrefix("192.175.48.0/24"),
+		netip.MustParsePrefix("198.18.0.0/15"),
+		netip.MustParsePrefix("198.51.100.0/24"),
+		netip.MustParsePrefix("203.0.113.0/24"),
+		netip.MustParsePrefix("240.0.0.0/4"),
+		netip.MustParsePrefix("2001::/23"),
+		netip.MustParsePrefix("2001:db8::/32"),
+		netip.MustParsePrefix("2002::/16"),
+		netip.MustParsePrefix("2620:4f:8000::/48"),
+		netip.MustParsePrefix("3fff::/20"),
+	}
+)
 
 type canonicalSubmitFactContextKey struct{}
 
@@ -61,6 +96,8 @@ func canonicalSubmitFactFromContext(ctx context.Context) canonicalSubmitFact {
 	fact, _ := ctx.Value(canonicalSubmitFactContextKey{}).(canonicalSubmitFact)
 	return fact
 }
+
+type providerPromptImageMaterializer func(context.Context, []PromptContentBlock) ([]PromptContentBlock, error)
 
 func normalizeRuntimePromptContent(content []PromptContentBlock) []PromptContentBlock {
 	out := make([]PromptContentBlock, 0, len(content))
@@ -352,10 +389,161 @@ func promptContentForACP(content []PromptContentBlock) []map[string]any {
 // require inline image data. AgentGUI and durable activity state intentionally
 // keep the uploaded URL; when a provider gains native URL support, only its
 // final adapter needs to stop calling this compatibility conversion.
+func materializeProviderPromptImages(ctx context.Context, content []PromptContentBlock) ([]PromptContentBlock, error) {
+	return materializeProviderPromptImagesWithClient(ctx, content, newProviderPromptImageHTTPClient(30*time.Second))
+}
+
+func materializeProviderPromptImagesAtBoundary(
+	ctx context.Context,
+	content []PromptContentBlock,
+	materializer providerPromptImageMaterializer,
+) ([]PromptContentBlock, error) {
+	if materializer == nil {
+		materializer = materializeProviderPromptImages
+	}
+	return materializer(ctx, content)
+}
+
+type providerPromptImageResolver interface {
+	LookupNetIP(context.Context, string, string) ([]netip.Addr, error)
+}
+
+type providerPromptImageTransport struct {
+	base     *http.Transport
+	resolver providerPromptImageResolver
+}
+
+func newProviderPromptImageHTTPClient(timeout time.Duration) *http.Client {
+	client := httpx.NewClient(timeout)
+	client.Transport = &providerPromptImageTransport{
+		base:     client.Transport.(*http.Transport),
+		resolver: net.DefaultResolver,
+	}
+	return client
+}
+
+func newProviderPromptImageHTTPClientWithNetwork(
+	timeout time.Duration,
+	resolver providerPromptImageResolver,
+	transport *http.Transport,
+) *http.Client {
+	client := httpx.NewClient(timeout)
+	if transport == nil {
+		transport = client.Transport.(*http.Transport)
+	}
+	client.Transport = &providerPromptImageTransport{base: transport, resolver: resolver}
+	return client
+}
+
+func (t *providerPromptImageTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	if t == nil || t.base == nil || t.resolver == nil || request == nil || request.URL == nil ||
+		request.Method != http.MethodGet || request.Body != nil || !runtimePromptImageURLSafe(request.URL.String()) {
+		return nil, ErrPromptImageUnsupported
+	}
+	addresses, err := t.resolver.LookupNetIP(request.Context(), "ip", request.URL.Hostname())
+	if err != nil {
+		return nil, errors.New("resolve remote prompt image: request failed")
+	}
+	port := request.URL.Port()
+	if port == "" {
+		port = "443"
+	}
+	var proxyURL *url.URL
+	if t.base.Proxy != nil {
+		proxyURL, err = t.base.Proxy(request)
+		if err != nil {
+			return nil, errors.New("resolve remote prompt image proxy: request failed")
+		}
+	}
+	var lastErr error
+	for _, resolved := range addresses {
+		if !providerPromptImageAddressPublic(resolved) {
+			continue
+		}
+		pinnedRequest := request.Clone(request.Context())
+		pinnedURL := *request.URL
+		pinnedURL.Host = net.JoinHostPort(resolved.String(), port)
+		pinnedRequest.URL = &pinnedURL
+		pinnedRequest.Host = request.URL.Host
+
+		transport := t.base.Clone()
+		transport.DisableKeepAlives = true
+		if proxyURL == nil {
+			transport.Proxy = nil
+		} else {
+			transport.Proxy = http.ProxyURL(proxyURL)
+		}
+		baseTLSConfig := &tls.Config{}
+		if transport.TLSClientConfig != nil {
+			baseTLSConfig = transport.TLSClientConfig.Clone()
+		}
+		transport.TLSClientConfig = baseTLSConfig.Clone()
+		transport.TLSClientConfig.ServerName = request.URL.Hostname()
+		if proxyURL != nil && proxyURL.Scheme == "https" && transport.DialTLSContext == nil {
+			proxyTLSConfig := baseTLSConfig.Clone()
+			proxyTLSConfig.ServerName = proxyURL.Hostname()
+			dialContext := transport.DialContext
+			if dialContext == nil {
+				dialContext = (&net.Dialer{}).DialContext
+			}
+			handshakeTimeout := transport.TLSHandshakeTimeout
+			transport.DialTLSContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+				connection, dialErr := dialContext(ctx, network, address)
+				if dialErr != nil {
+					return nil, dialErr
+				}
+				tlsConnection := tls.Client(connection, proxyTLSConfig)
+				handshakeCtx := ctx
+				cancel := func() {}
+				if handshakeTimeout > 0 {
+					handshakeCtx, cancel = context.WithTimeout(ctx, handshakeTimeout)
+				}
+				defer cancel()
+				if handshakeErr := tlsConnection.HandshakeContext(handshakeCtx); handshakeErr != nil {
+					_ = connection.Close()
+					return nil, handshakeErr
+				}
+				return tlsConnection, nil
+			}
+		}
+
+		response, requestErr := transport.RoundTrip(pinnedRequest)
+		if requestErr == nil {
+			response.Request = request
+			return response, nil
+		}
+		lastErr = requestErr
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, ErrPromptImageUnsupported
+}
+
+func providerPromptImageAddressPublic(address netip.Addr) bool {
+	if !address.IsValid() || address.Zone() != "" {
+		return false
+	}
+	address = address.Unmap()
+	if !address.IsGlobalUnicast() || address.IsPrivate() || address.IsLoopback() || address.IsLinkLocalUnicast() {
+		return false
+	}
+	if address.Is6() && !providerPromptImageGlobalIPv6UnicastPrefix.Contains(address) {
+		return false
+	}
+	for _, prefix := range providerPromptImageNonPublicPrefixes {
+		if prefix.Contains(address) {
+			return false
+		}
+	}
+	return true
+}
+
 func materializeProviderPromptImagesWithClient(ctx context.Context, content []PromptContentBlock, client *http.Client) ([]PromptContentBlock, error) {
 	requestClient := *client
 	existingRedirectCheck := client.CheckRedirect
 	requestClient.CheckRedirect = func(request *http.Request, via []*http.Request) error {
+		request.Header.Del("Referer")
 		if !runtimePromptImageURLSafe(request.URL.String()) {
 			return ErrPromptImageUnsupported
 		}

--- a/packages/agent/daemon/runtime/prompt_content_test.go
+++ b/packages/agent/daemon/runtime/prompt_content_test.go
@@ -2,16 +2,48 @@ package agentruntime
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
+	"net/url"
 	"strings"
 	"testing"
+	"time"
 )
 
 func textPrompt(text string) []PromptContentBlock {
 	return []PromptContentBlock{{Type: "text", Text: text}}
+}
+
+func testRemotePromptImageMaterializer(t *testing.T) (string, providerPromptImageMaterializer) {
+	t.Helper()
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodGet || request.URL.Path != "/image.png" {
+			http.Error(response, "unexpected request", http.StatusBadRequest)
+			return
+		}
+		response.Header().Set("Content-Type", "image/png")
+		_, _ = response.Write([]byte("hi"))
+	}))
+	t.Cleanup(server.Close)
+	return server.URL + "/image.png", func(ctx context.Context, content []PromptContentBlock) ([]PromptContentBlock, error) {
+		return materializeProviderPromptImagesWithClient(ctx, content, server.Client())
+	}
+}
+
+type staticProviderPromptImageResolver map[string][]netip.Addr
+
+func (r staticProviderPromptImageResolver) LookupNetIP(_ context.Context, _ string, host string) ([]netip.Addr, error) {
+	addresses, ok := r[host]
+	if !ok {
+		return nil, &net.DNSError{Name: host, Err: "not found"}
+	}
+	return append([]netip.Addr(nil), addresses...), nil
 }
 
 func TestNormalizeRuntimePromptContentPreservesURLOnlyImage(t *testing.T) {
@@ -19,6 +51,250 @@ func TestNormalizeRuntimePromptContentPreservesURLOnlyImage(t *testing.T) {
 	content := normalizeRuntimePromptContent([]PromptContentBlock{{Type: "image", MimeType: " image/webp ", URL: " " + signedURL + " ", Name: " image.webp "}})
 	if len(content) != 1 || content[0].URL != signedURL || content[0].Data != "" {
 		t.Fatalf("content = %#v, want normalized URL-only image", content)
+	}
+}
+
+func TestProviderPromptImageAddressPublicRejectsInternalNetworks(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		address string
+		want    bool
+	}{
+		{address: "8.8.8.8", want: true},
+		{address: "2606:4700:4700::1111", want: true},
+		{address: "0.0.0.1"},
+		{address: "127.0.0.1"},
+		{address: "10.0.0.1"},
+		{address: "100.64.0.1"},
+		{address: "169.254.1.1"},
+		{address: "192.168.1.1"},
+		{address: "198.18.0.1"},
+		{address: "240.0.0.1"},
+		{address: "::1"},
+		{address: "64:ff9b::a00:1"},
+		{address: "2002:a00:1::"},
+		{address: "fc00::1"},
+		{address: "fe80::1"},
+	} {
+		test := test
+		t.Run(test.address, func(t *testing.T) {
+			t.Parallel()
+			if got := providerPromptImageAddressPublic(netip.MustParseAddr(test.address)); got != test.want {
+				t.Fatalf("providerPromptImageAddressPublic(%q) = %v, want %v", test.address, got, test.want)
+			}
+		})
+	}
+}
+
+func TestMaterializeProviderPromptImagesRejectsLoopbackLiteral(t *testing.T) {
+	t.Parallel()
+
+	var requests int
+	server := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests++
+	}))
+	defer server.Close()
+
+	_, err := materializeProviderPromptImages(context.Background(), []PromptContentBlock{{
+		Type: "image", MimeType: "image/png", URL: server.URL + "/image.png",
+	}})
+	if err == nil {
+		t.Fatal("materialize error = nil, want loopback rejection")
+	}
+	if requests != 0 {
+		t.Fatalf("loopback server received %d requests, want 0", requests)
+	}
+}
+
+func TestMaterializeProviderPromptImagesRejectsRedirectToInternalAddress(t *testing.T) {
+	t.Parallel()
+
+	var requests int
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		requests++
+		if request.URL.Path != "/start" {
+			t.Fatalf("request path = %q, want /start", request.URL.Path)
+		}
+		http.Redirect(response, request, "https://private.example/image.png", http.StatusFound)
+	}))
+	defer server.Close()
+
+	resolver := staticProviderPromptImageResolver{
+		"example.com":     {netip.MustParseAddr("8.8.8.8")},
+		"private.example": {netip.MustParseAddr("127.0.0.1")},
+	}
+	transport := server.Client().Transport.(*http.Transport).Clone()
+	transport.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, server.Listener.Addr().String())
+	}
+	client := newProviderPromptImageHTTPClientWithNetwork(time.Second, resolver, transport)
+
+	_, err := materializeProviderPromptImagesWithClient(context.Background(), []PromptContentBlock{{
+		Type: "image", MimeType: "image/png", URL: "https://example.com/start",
+	}}, client)
+	if err == nil {
+		t.Fatal("materialize error = nil, want internal redirect rejection")
+	}
+	if requests != 1 {
+		t.Fatalf("server received %d requests, want only the public request; error = %v", requests, err)
+	}
+}
+
+func TestMaterializeProviderPromptImagesDoesNotForwardSignedURLReferer(t *testing.T) {
+	t.Parallel()
+
+	var requests int
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		requests++
+		switch request.URL.Path {
+		case "/start":
+			http.Redirect(response, request, "https://redirect.example/image.png", http.StatusFound)
+		case "/image.png":
+			if referer := request.Header.Get("Referer"); referer != "" {
+				t.Errorf("redirect Referer = %q, want empty", referer)
+			}
+			response.Header().Set("Content-Type", "image/png")
+			_, _ = response.Write([]byte("hi"))
+		default:
+			http.NotFound(response, request)
+		}
+	}))
+	defer server.Close()
+
+	resolver := staticProviderPromptImageResolver{
+		"example.com":      {netip.MustParseAddr("8.8.8.8")},
+		"redirect.example": {netip.MustParseAddr("1.1.1.1")},
+	}
+	transport := server.Client().Transport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // test-only cross-host redirect
+	transport.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, server.Listener.Addr().String())
+	}
+	client := newProviderPromptImageHTTPClientWithNetwork(time.Second, resolver, transport)
+
+	content, err := materializeProviderPromptImagesWithClient(context.Background(), []PromptContentBlock{{
+		Type: "image", MimeType: "image/png", URL: "https://example.com/start?X-Amz-Signature=secret",
+	}}, client)
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	if requests != 2 || len(content) != 1 || content[0].Data != "aGk=" {
+		t.Fatalf("requests = %d, content = %#v, want redirected inline image", requests, content)
+	}
+}
+
+func TestProviderPromptImageHTTPClientKeepsProxyAndPinsConnectTarget(t *testing.T) {
+	t.Parallel()
+
+	imageServer := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.Host != "example.com" {
+			t.Errorf("image Host = %q, want example.com", request.Host)
+		}
+		response.Header().Set("Content-Type", "image/png")
+		_, _ = response.Write([]byte("hi"))
+	}))
+	defer imageServer.Close()
+
+	for _, testCase := range []struct {
+		name     string
+		proxyTLS bool
+	}{
+		{name: "HTTP"},
+		{name: "HTTPS", proxyTLS: true},
+	} {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			connectTargets := make(chan string, 1)
+			proxyServerNames := make(chan string, 1)
+			proxy := httptest.NewUnstartedServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+				if request.Method != http.MethodConnect {
+					http.Error(response, "CONNECT required", http.StatusMethodNotAllowed)
+					return
+				}
+				connectTargets <- request.Host
+				downstream, _, err := response.(http.Hijacker).Hijack()
+				if err != nil {
+					t.Errorf("hijack proxy: %v", err)
+					return
+				}
+				upstream, err := net.Dial("tcp", imageServer.Listener.Addr().String())
+				if err != nil {
+					_ = downstream.Close()
+					t.Errorf("dial image server: %v", err)
+					return
+				}
+				_, _ = io.WriteString(downstream, "HTTP/1.1 200 Connection Established\r\n\r\n")
+				go func() {
+					_, _ = io.Copy(upstream, downstream)
+					_ = upstream.Close()
+				}()
+				_, _ = io.Copy(downstream, upstream)
+				_ = downstream.Close()
+			}))
+			if testCase.proxyTLS {
+				proxy.TLS = &tls.Config{
+					GetConfigForClient: func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+						proxyServerNames <- hello.ServerName
+						return nil, nil
+					},
+				}
+				proxy.StartTLS()
+			} else {
+				proxy.Start()
+			}
+			defer proxy.Close()
+			proxyURL, err := url.Parse(proxy.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			proxyAddress := proxy.Listener.Addr().String()
+			_, proxyPort, err := net.SplitHostPort(proxyURL.Host)
+			if err != nil {
+				t.Fatal(err)
+			}
+			proxyURL.Host = net.JoinHostPort("proxy.example", proxyPort)
+
+			transport := imageServer.Client().Transport.(*http.Transport).Clone()
+			transport.Proxy = http.ProxyURL(proxyURL)
+			transport.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, network, proxyAddress)
+			}
+			if testCase.proxyTLS {
+				transport.TLSClientConfig.InsecureSkipVerify = true // test-only proxy and target routing assertion
+			}
+			client := newProviderPromptImageHTTPClientWithNetwork(time.Second, staticProviderPromptImageResolver{
+				"example.com": {netip.MustParseAddr("8.8.8.8")},
+			}, transport)
+
+			content, err := materializeProviderPromptImagesWithClient(context.Background(), []PromptContentBlock{{
+				Type: "image", MimeType: "image/png", URL: "https://example.com/image.png",
+			}}, client)
+			if err != nil {
+				t.Fatalf("materialize through proxy: %v", err)
+			}
+			if len(content) != 1 || content[0].Data != "aGk=" {
+				t.Fatalf("content = %#v, want inline image", content)
+			}
+			select {
+			case target := <-connectTargets:
+				if target != "8.8.8.8:443" {
+					t.Fatalf("proxy CONNECT target = %q, want pinned public IP", target)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("proxy received no CONNECT")
+			}
+			if testCase.proxyTLS {
+				select {
+				case serverName := <-proxyServerNames:
+					if serverName != proxyURL.Hostname() {
+						t.Fatalf("proxy TLS server name = %q, want %q", serverName, proxyURL.Hostname())
+					}
+				case <-time.After(time.Second):
+					t.Fatal("proxy received no TLS ClientHello")
+				}
+			}
+		})
 	}
 }
 

--- a/packages/agent/daemon/runtime/standard_acp_adapter.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter.go
@@ -106,6 +106,7 @@ type standardACPAdapter struct {
 	commandSink                CommandSnapshotSink
 	eventSink                  SessionEventSink
 	configSink                 ConfigOptionsUpdateSink
+	promptImageMaterializer    providerPromptImageMaterializer
 	lifecycleMu                sync.Mutex
 	lifecycleLocks             map[string]*standardACPSessionLock
 }

--- a/packages/agent/daemon/runtime/standard_acp_adapter_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter_test.go
@@ -1694,6 +1694,58 @@ func TestStandardACPAdapterExecMaterializesRemoteImageAtProviderBoundary(t *test
 	}
 }
 
+func TestStandardACPAdapterRemoteImageFailurePreservesPromptAndClosesProviderTurn(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("OpenCode", "opencode-session-remote-image-failure")
+	adapter := newOpenCodeTestAdapter(transport)
+	materializeErr := errors.New("remote image unavailable")
+	adapter.promptImageMaterializer = func(context.Context, []PromptContentBlock) ([]PromptContentBlock, error) {
+		return nil, materializeErr
+	}
+	session := standardTestSession(ProviderOpenCode)
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	session.ProviderSessionID = "opencode-session-remote-image-failure"
+
+	var streamed []activityshared.Event
+	events, err := adapter.Exec(context.Background(), session, []PromptContentBlock{
+		{Type: "text", Text: "what is in this screenshot?"},
+		{Type: "image", MimeType: "image/png", URL: "https://images.example/screenshot.png"},
+	}, "", "turn-remote-image-failure", func(next []activityshared.Event) {
+		streamed = append(streamed, next...)
+	}, nil)
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if params := transport.conn.lastPromptParams(); len(params) != 0 {
+		t.Fatalf("session/prompt params = %#v, want no provider request after materialization failure", params)
+	}
+	messages := eventsOfType(events, activityshared.EventMessageAppended)
+	if len(messages) != 1 || messages[0].Payload.Role != activityshared.MessageRoleUser ||
+		messages[0].Payload.Content != "what is in this screenshot?" {
+		t.Fatalf("user prompt events = %#v, want original prompt preserved", messages)
+	}
+	if turnStarted := eventsOfType(events, activityshared.EventTurnStarted); len(turnStarted) != 1 {
+		t.Fatalf("turn started events = %#v, want one", turnStarted)
+	}
+	started := eventsOfType(events, activityshared.EventRootProviderTurnStarted)
+	if len(started) != 1 || started[0].Payload.ProviderTurnID != "turn-remote-image-failure" {
+		t.Fatalf("provider turn started events = %#v, want one", started)
+	}
+	completed := eventsOfType(events, activityshared.EventRootProviderTurnCompleted)
+	if len(completed) != 1 ||
+		completed[0].Payload.ProviderTurnID != "turn-remote-image-failure" ||
+		completed[0].Payload.TurnOutcome != string(activityshared.TurnOutcomeFailed) ||
+		completed[0].Payload.Metadata["error"] != materializeErr.Error() {
+		t.Fatalf("provider turn completed events = %#v, want failed materialization lifecycle", completed)
+	}
+	if len(streamed) != len(events) {
+		t.Fatalf("streamed event count = %d, returned = %d", len(streamed), len(events))
+	}
+}
+
 func TestStandardACPAdapterRejectsImagePromptWithoutCapability(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/standard_acp_adapter_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter_test.go
@@ -1663,6 +1663,37 @@ func TestCursorAdapterAllowsImagePromptWithoutInitializeCapability(t *testing.T)
 	}
 }
 
+func TestStandardACPAdapterExecMaterializesRemoteImageAtProviderBoundary(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("OpenCode", "opencode-session-remote-image")
+	adapter := newOpenCodeTestAdapter(transport)
+	imageURL, materializer := testRemotePromptImageMaterializer(t)
+	adapter.promptImageMaterializer = materializer
+	session := standardTestSession(ProviderOpenCode)
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	session.ProviderSessionID = "opencode-session-remote-image"
+
+	if _, err := adapter.Exec(context.Background(), session, []PromptContentBlock{
+		{Type: "text", Text: "what is in this screenshot?"},
+		{Type: "image", MimeType: "image/png", URL: imageURL},
+	}, "", "turn-remote-image", nil, nil); err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+
+	params := transport.conn.lastPromptParams()
+	prompt, _ := params["prompt"].([]any)
+	if len(prompt) != 2 {
+		t.Fatalf("session/prompt content = %#v, want text+image", params["prompt"])
+	}
+	image, _ := prompt[1].(map[string]any)
+	if image["mimeType"] != "image/png" || image["data"] != "aGk=" {
+		t.Fatalf("session/prompt image = %#v, want inline image data", image)
+	}
+}
+
 func TestStandardACPAdapterRejectsImagePromptWithoutCapability(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/standard_acp_turn.go
+++ b/packages/agent/daemon/runtime/standard_acp_turn.go
@@ -31,23 +31,7 @@ func (a *standardACPAdapter) Exec(
 	session.ProviderSessionID = acpSession.providerSessionID
 	explicitDisplayPrompt, visibleText := explicitAndVisiblePromptText(content, displayPrompt)
 	mentionRoutingApplied, mentionRoutingSkills := tuttiMentionRoutingSkills(visibleText)
-	providerContent, err := materializeProviderPromptImagesAtBoundary(ctx, content, a.promptImageMaterializer)
-	if err != nil {
-		return nil, err
-	}
 	a.rememberSessionTurn(session.AgentSessionID, turnID)
-	acpPromptContent := promptContentForACP(providerContent)
-	if mentionRoutingApplied {
-		acpPromptContent = appendTuttiMentionRoutingPrompt(acpPromptContent, mentionRoutingSkills)
-	}
-	// ACP v1 has no developer/system or synthetic-message channel. Keep the
-	// canonical Tutti-owned context in the provider-only prompt payload; the
-	// activity event below is still projected exclusively from the original
-	// user content.
-	acpPromptContent = appendTuttiModeHostContextPrompt(
-		acpPromptContent,
-		tuttiModeTurnSnapshotFromContext(ctx),
-	)
 	normalizer := newACPTurnNormalizer()
 	var events []activityshared.Event
 	emitEvents := func(next []activityshared.Event) {
@@ -67,6 +51,38 @@ func (a *standardACPAdapter) Exec(
 		standardACPRootProviderTurnStartedEvent(session, turnID),
 	}
 	emitEvents(startEvents)
+
+	providerContent, err := materializeProviderPromptImagesAtBoundary(ctx, content, a.promptImageMaterializer)
+	if err != nil {
+		outcome := activityshared.TurnOutcomeFailed
+		terminalEvents := normalizer.FinishFailed(session, turnID)
+		if errors.Is(err, context.Canceled) || errors.Is(err, errPermissionRequestCanceled) {
+			outcome = activityshared.TurnOutcomeCanceled
+			terminalEvents = normalizer.FinishInterrupted(session, turnID, "interrupted")
+		}
+		terminalEvents = append(terminalEvents, standardACPRootProviderTurnCompletedEvent(
+			session,
+			turnID,
+			outcome,
+			map[string]any{"error": err.Error()},
+		))
+		emitEvents(terminalEvents)
+		// Standard ACP reports provider failures through lifecycle events. Return
+		// nil so the controller does not replay the already-emitted event batch.
+		return events, nil
+	}
+	acpPromptContent := promptContentForACP(providerContent)
+	if mentionRoutingApplied {
+		acpPromptContent = appendTuttiMentionRoutingPrompt(acpPromptContent, mentionRoutingSkills)
+	}
+	// ACP v1 has no developer/system or synthetic-message channel. Keep the
+	// canonical Tutti-owned context in the provider-only prompt payload; the
+	// activity event above is still projected exclusively from the original
+	// user content.
+	acpPromptContent = appendTuttiModeHostContextPrompt(
+		acpPromptContent,
+		tuttiModeTurnSnapshotFromContext(ctx),
+	)
 	slog.Info("agent session ACP exec started",
 		"event", "agent_session.acp.exec.start",
 		"provider", a.config.provider,

--- a/packages/agent/daemon/runtime/standard_acp_turn.go
+++ b/packages/agent/daemon/runtime/standard_acp_turn.go
@@ -29,10 +29,14 @@ func (a *standardACPAdapter) Exec(
 		)}, ErrSessionDisconnected
 	}
 	session.ProviderSessionID = acpSession.providerSessionID
-	a.rememberSessionTurn(session.AgentSessionID, turnID)
 	explicitDisplayPrompt, visibleText := explicitAndVisiblePromptText(content, displayPrompt)
 	mentionRoutingApplied, mentionRoutingSkills := tuttiMentionRoutingSkills(visibleText)
-	acpPromptContent := promptContentForACP(content)
+	providerContent, err := materializeProviderPromptImagesAtBoundary(ctx, content, a.promptImageMaterializer)
+	if err != nil {
+		return nil, err
+	}
+	a.rememberSessionTurn(session.AgentSessionID, turnID)
+	acpPromptContent := promptContentForACP(providerContent)
 	if mentionRoutingApplied {
 		acpPromptContent = appendTuttiMentionRoutingPrompt(acpPromptContent, mentionRoutingSkills)
 	}


### PR DESCRIPTION
## Summary

- Materialize URL-backed image prompts at the provider boundary for Codex start/steer, Claude exec/guide, and standard ACP prompts while preserving the original URL in activity history.
- Harden remote image downloads by resolving and pinning every redirect hop, rejecting private and IANA special-purpose ranges (including NAT64/6to4), preserving proxy policy, separating HTTPS proxy TLS identity from target TLS identity, and stripping redirect `Referer` headers.
- Atomically admit Codex guidance continuations so rejected concurrent attempts emit no phantom turn lifecycle, while published provisional attempts always close.

## Root cause

The provider adapter refactor retained the shared image materialization helper but removed the production call sites. As a result, providers received remote URLs even though these provider protocols require inline image data.

## Validation

- `pnpm check:changed` — 7 lanes passed
- pre-push `pnpm check:changed -- --push-ready` — 8 lanes passed
- `go test ./packages/agent/daemon/runtime -count=1`
- targeted continuation/proxy tests repeated 20 times and passed with `-race`
- TSH integration: `go test ./cmd/desktopd/service/agentsession ./cmd/desktopd`
- independent code review completed with no blocking findings

## Documentation

Updated the agent runtime/session lifecycle troubleshooting guidance with the failure signature, boundary rules, security constraints, and regression coverage.