### PR TITLE
fix(agent): recover Claude query after connection loss

### DIFF
--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -38,7 +38,8 @@ Use the focused runtime index or open one area directly:
   unknown after canonical message provenance conflicts, completed Claude Code
   Turns that lack a Fork entry because provider identity was not observed from
   the durable transcript, and Claude Fork operations that fail because an empty
-  SDK query never creates a durable provider child.
+  query never creates a durable provider child. It also covers a Claude Query
+  that keeps returning connection errors after the machine network recovers.
 - [Agent Approvals And Child Sessions](./agent-approvals-subagents.md): Approval gates, plan exits, root/parent/child event attribution, child sessions, and Message Center.
   Includes provider-native work that continues invisibly after root cancellation
   and late child creation racing the durable cancel boundary.

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -99,6 +99,7 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 - [Shared Agent composer stays disabled after the target connects](./agent-session-lifecycle.md#shared-agent-composer-stays-disabled-after-the-target-connects)
 - [Goal clear stays planning and leaves the session running](./agent-session-lifecycle.md#goal-clear-stays-planning-and-leaves-the-session-running)
 - [Cursor session/new is canceled before its 30-second timeout](./agent-session-lifecycle.md#cursor-sessionnew-is-canceled-before-its-30-second-timeout)
+- [Claude Code keeps returning ConnectionRefused after network recovery](./agent-session-lifecycle.md#claude-code-keeps-returning-connectionrefused-after-network-recovery)
 - [Cursor auto-continue invents interrupted work after a network drop](./agent-session-lifecycle.md#cursor-auto-continue-invents-interrupted-work-after-a-network-drop)
 
 ## [Agent Approvals And Sub-Agents](./agent-approvals-subagents.md)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -2945,6 +2945,45 @@ inline data URL instead`. Claude or standard ACP may instead receive no
   [pendingIntents.reducer.ts](../../../packages/agent/activity-core/src/engine/pendingIntents.reducer.ts)
   [acp_shared.go](../../../packages/agent/daemon/runtime/acp_shared.go)
 
+### Claude Code keeps returning ConnectionRefused after network recovery
+
+- Symptom:
+  A Claude Code Turn loses network access while sending and eventually reports
+  `API Error: Unable to connect to API (ConnectionRefused)`. After the machine
+  network recovers, later sends in the same Session keep failing, while a newly
+  created Claude Session succeeds.
+- Quick checks:
+  Correlate `agent_session.claude_sdk.lifecycle_event` by Agent Session and
+  provider Session id. An SDK `system/api_retry` event now records
+  `sdk_connection_error`, `sdk_retry_attempt`, `sdk_max_retries`, and
+  `sdk_retry_delay_ms`. A terminal result should carry
+  `sdk_result_is_error=true`; a numeric `sdk_api_error_status` instead points to
+  an HTTP/auth/provider response rather than a connection failure.
+- Root cause:
+  The Claude Agent SDK owns one long-lived Query and Claude Code subprocess for
+  streaming multi-Turn input. A connection failure can terminate the Turn while
+  leaving that Query unsuitable for later requests. Reusing it preserves the
+  bad per-process state even though host and VM networking have recovered.
+  Older sidecars also treated every `result/subtype=success` as a completed
+  Turn, ignoring the SDK's independent `is_error` flag.
+- Fix:
+  Preserve the failed Turn and its provider error. When the SDK terminal result
+  explicitly reports a connection failure, revoke and close that Query. The
+  next user send creates a fresh Query with `resume` set to the same provider
+  Session id. Do not automatically resend the failed prompt because delivery
+  may be ambiguous. Do not recycle the Query for a transient retry that
+  eventually succeeds or for a terminal HTTP/authentication error.
+- Validation:
+  Simulate `api_retry/error_status=null` followed by
+  `result/is_error=true/api_error_status=null`, then send a second Turn. Require
+  two Query generations, closure of the first, and `resume` on the second.
+  Also prove that retry-then-success and HTTP 401 failures retain the existing
+  Query.
+- References:
+  [messageRouter.ts](../../../packages/agent/claude-sdk-sidecar/src/messageRouter.ts)
+  [sessionRuntime.ts](../../../packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts)
+  [sessionRuntime.recovery.test.ts](../../../packages/agent/claude-sdk-sidecar/src/sessionRuntime.recovery.test.ts)
+
 ### Cursor auto-continue invents interrupted work after a network drop
 
 - Symptom:

--- a/packages/agent/claude-sdk-sidecar/src/messageRouter.ts
+++ b/packages/agent/claude-sdk-sidecar/src/messageRouter.ts
@@ -31,6 +31,7 @@ export class SDKMessageRouter {
   private readonly onRuntimeModel: (value: string) => void;
   private readonly onSessionState: () => void;
   private readonly onMaybeTitle: (shouldEmit?: () => boolean) => Promise<void>;
+  private readonly onTerminalConnectionError: () => void;
   private readonly turns: TurnLifecycle;
   private readonly assistant: AssistantStreamProjector;
   private readonly activities: ToolActivityProjector;
@@ -39,6 +40,7 @@ export class SDKMessageRouter {
   private readonly emit: ClaudeSDKSidecarEventEmitter;
   private contextUsageGeneration = 0;
   private activeRootAssistantError = "";
+  private activeRootConnectionRetry = false;
 
   constructor(options: {
     getProviderSessionId: () => string;
@@ -47,6 +49,7 @@ export class SDKMessageRouter {
     onRuntimeModel: (value: string) => void;
     onSessionState: () => void;
     onMaybeTitle: (shouldEmit?: () => boolean) => Promise<void>;
+    onTerminalConnectionError: () => void;
     turns: TurnLifecycle;
     assistant: AssistantStreamProjector;
     activities: ToolActivityProjector;
@@ -60,6 +63,7 @@ export class SDKMessageRouter {
     this.onRuntimeModel = options.onRuntimeModel;
     this.onSessionState = options.onSessionState;
     this.onMaybeTitle = options.onMaybeTitle;
+    this.onTerminalConnectionError = options.onTerminalConnectionError;
     this.turns = options.turns;
     this.assistant = options.assistant;
     this.activities = options.activities;
@@ -100,6 +104,13 @@ export class SDKMessageRouter {
     if (message.type === "system") {
       const raw = message as unknown as Record<string, unknown>;
       const systemSubtype = stringValue(raw.subtype);
+      if (
+        systemSubtype === "api_retry" &&
+        raw.error_status === null &&
+        this.turns.activeId
+      ) {
+        this.activeRootConnectionRetry = true;
+      }
       if (
         systemSubtype === "session_state_changed" &&
         stringValue(raw.state) === "idle" &&
@@ -178,6 +189,7 @@ export class SDKMessageRouter {
         messageSubtype === "task_updated" ||
         messageSubtype === "background_tasks_changed" ||
         messageSubtype === "session_state_changed");
+    const apiRetry = messageType === "system" && messageSubtype === "api_retry";
     const rootContinuationCandidate =
       messageType === "assistant" &&
       !parentToolUseID &&
@@ -186,6 +198,7 @@ export class SDKMessageRouter {
     if (
       !taskNotification &&
       !systemTaskLifecycle &&
+      !apiRetry &&
       !rootContinuationCandidate &&
       !result
     ) {
@@ -201,6 +214,7 @@ export class SDKMessageRouter {
         ...(rootContinuationCandidate
           ? { rootContinuationCandidate: true }
           : {}),
+        ...(apiRetry ? { apiRetry: true } : {}),
         activeTurnIdBefore: this.turns.activeId,
         ...(parentToolUseID ? { parentToolUseId: parentToolUseID } : {}),
         ...(stringValue(raw.task_id)
@@ -220,6 +234,24 @@ export class SDKMessageRouter {
         ...(raw.is_error === true ? { sdkResultIsError: true } : {}),
         ...(typeof raw.api_error_status === "number"
           ? { sdkApiErrorStatus: raw.api_error_status }
+          : {}),
+        ...(apiRetry && raw.error_status === null
+          ? { sdkConnectionError: true }
+          : {}),
+        ...(apiRetry && typeof raw.error_status === "number"
+          ? { sdkApiErrorStatus: raw.error_status }
+          : {}),
+        ...(apiRetry && typeof raw.attempt === "number"
+          ? { sdkRetryAttempt: raw.attempt }
+          : {}),
+        ...(apiRetry && typeof raw.max_retries === "number"
+          ? { sdkMaxRetries: raw.max_retries }
+          : {}),
+        ...(apiRetry && typeof raw.retry_delay_ms === "number"
+          ? { sdkRetryDelayMs: raw.retry_delay_ms }
+          : {}),
+        ...(apiRetry && stringValue(raw.error)
+          ? { sdkAssistantError: stringValue(raw.error) }
           : {})
       }
     });
@@ -393,6 +425,7 @@ export class SDKMessageRouter {
       this.activities.beginRootTurn();
       this.contextUsageGeneration += 1;
       this.activeRootAssistantError = "";
+      this.activeRootConnectionRetry = false;
     }
     const blocks = contentBlocksFromMessage(message);
     if (
@@ -442,7 +475,16 @@ export class SDKMessageRouter {
     const turnId = this.turns.activeId;
     const contextUsageGeneration = this.contextUsageGeneration;
     const assistantError = this.activeRootAssistantError;
+    const terminalConnectionError =
+      result.is_error === true &&
+      (result.api_error_status === null ||
+        (result.api_error_status === undefined &&
+          this.activeRootConnectionRetry));
     this.activeRootAssistantError = "";
+    this.activeRootConnectionRetry = false;
+    if (terminalConnectionError) {
+      this.onTerminalConnectionError();
+    }
     const succeeded =
       !this.turns.cancelled &&
       result.subtype === "success" &&

--- a/packages/agent/claude-sdk-sidecar/src/queryGeneration.ts
+++ b/packages/agent/claude-sdk-sidecar/src/queryGeneration.ts
@@ -39,6 +39,17 @@ export class QueryGeneration {
     this.quarantineCanceledTail = quarantineCanceledTail;
   }
 
+  static retire(
+    generation: QueryGeneration | undefined,
+    detachOwner: () => void
+  ): void {
+    // Detach first so the consumer's finally block cannot close the live
+    // Session while this obsolete generation unwinds.
+    detachOwner();
+    generation?.revoke();
+    generation?.closeQuery();
+  }
+
   expectPromptEcho(promptUuid: string): void {
     if (this.quarantineCanceledTail) {
       this.expectedPromptUuid = promptUuid.trim();

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.recovery.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.recovery.test.ts
@@ -1,0 +1,196 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type {
+  Options as ClaudeQueryOptions,
+  SDKMessage,
+  SDKUserMessage
+} from "@anthropic-ai/claude-agent-sdk";
+import { withSidecarEventSinkForTest } from "./eventSink.ts";
+import { sidecarClaudeOptionsFromPayload } from "./options.ts";
+import { SessionRuntime } from "./sessionRuntime.ts";
+import { waitForEvent } from "./sessionRuntimeTestQueries.nested.ts";
+
+type FirstTurnOutcome = "connection-error" | "http-error" | "retry-success";
+
+function recoveryQueryFactory(
+  outcome: FirstTurnOutcome,
+  calls: Array<{ generation: number; options: ClaudeQueryOptions }>,
+  closes: number[]
+) {
+  return ({
+    prompt,
+    options
+  }: {
+    prompt: AsyncIterable<SDKUserMessage>;
+    options: ClaudeQueryOptions;
+  }) => {
+    const generation = calls.length + 1;
+    calls.push({ generation, options });
+    return {
+      async *[Symbol.asyncIterator]() {
+        let promptNumber = 0;
+        for await (const message of prompt) {
+          promptNumber += 1;
+          yield {
+            ...message,
+            type: "user",
+            parent_tool_use_id: null,
+            session_id: "provider-session-recovery"
+          } as SDKMessage;
+          if (generation === 1 && promptNumber === 1) {
+            yield {
+              type: "system",
+              subtype: "api_retry",
+              attempt: 1,
+              max_retries: 3,
+              retry_delay_ms: 100,
+              error_status: null,
+              error: "unknown",
+              uuid: "00000000-0000-4000-8000-000000000001",
+              session_id: "provider-session-recovery"
+            } as SDKMessage;
+            if (outcome === "connection-error") {
+              yield {
+                type: "result",
+                subtype: "success",
+                is_error: true,
+                api_error_status: null,
+                result:
+                  "API Error: Unable to connect to API (ConnectionRefused)",
+                session_id: "provider-session-recovery"
+              } as SDKMessage;
+              continue;
+            }
+            if (outcome === "http-error") {
+              yield {
+                type: "result",
+                subtype: "success",
+                is_error: true,
+                api_error_status: 401,
+                result: "API Error: Unauthorized",
+                session_id: "provider-session-recovery"
+              } as SDKMessage;
+              continue;
+            }
+          }
+          yield {
+            type: "result",
+            subtype: "success",
+            is_error: false,
+            result: "ok",
+            session_id: "provider-session-recovery"
+          } as SDKMessage;
+        }
+      },
+      close() {
+        closes.push(generation);
+      }
+    };
+  };
+}
+
+function createSession(
+  outcome: FirstTurnOutcome,
+  calls: Array<{ generation: number; options: ClaudeQueryOptions }>,
+  closes: number[]
+): SessionRuntime {
+  return new SessionRuntime(
+    "provider-session-recovery",
+    "/repo",
+    {},
+    false,
+    false,
+    {
+      model: "",
+      permissionModeId: "default",
+      planMode: false,
+      effort: "",
+      speed: ""
+    },
+    sidecarClaudeOptionsFromPayload({}),
+    undefined,
+    recoveryQueryFactory(outcome, calls, closes)
+  );
+}
+
+test("terminal SDK connection error replaces the query before the next turn", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const calls: Array<{
+    generation: number;
+    options: ClaudeQueryOptions;
+  }> = [];
+  const closes: number[] = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  const session = createSession("connection-error", calls, closes);
+  try {
+    await session.start();
+    session.exec("turn-failed", "first");
+    await waitForEvent(events, "turn_failed");
+
+    const retry = events.find(
+      (event) =>
+        event.type === "sdk_lifecycle_observed" &&
+        event.payload?.sdkMessageSubtype === "api_retry"
+    );
+    assert.equal(retry?.payload?.sdkConnectionError, true);
+    assert.equal(retry?.payload?.sdkRetryAttempt, 1);
+    assert.equal(retry?.payload?.sdkMaxRetries, 3);
+    assert.equal(retry?.payload?.sdkRetryDelayMs, 100);
+
+    session.exec("turn-recovered", "second");
+    await waitForEvent(events, "turn_completed");
+
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0]?.options.sessionId, "provider-session-recovery");
+    assert.equal(calls[1]?.options.resume, "provider-session-recovery");
+    assert.deepEqual(closes, [1]);
+  } finally {
+    await session.close();
+    restoreSink();
+  }
+});
+
+for (const scenario of [
+  {
+    name: "a transient connection retry that succeeds",
+    outcome: "retry-success" as const
+  },
+  {
+    name: "a terminal HTTP authentication error",
+    outcome: "http-error" as const
+  }
+]) {
+  test(`${scenario.name} keeps the current query`, async () => {
+    const events: Array<{ type: string; payload?: Record<string, unknown> }> =
+      [];
+    const calls: Array<{
+      generation: number;
+      options: ClaudeQueryOptions;
+    }> = [];
+    const closes: number[] = [];
+    const restoreSink = withSidecarEventSinkForTest((event) =>
+      events.push(event)
+    );
+    const session = createSession(scenario.outcome, calls, closes);
+    try {
+      await session.start();
+      session.exec("turn-first", "first");
+      await waitForEvent(
+        events,
+        scenario.outcome === "http-error" ? "turn_failed" : "turn_completed"
+      );
+
+      events.length = 0;
+      session.exec("turn-second", "second");
+      await waitForEvent(events, "turn_completed");
+
+      assert.equal(calls.length, 1);
+      assert.deepEqual(closes, []);
+    } finally {
+      await session.close();
+      restoreSink();
+    }
+  });
+}

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.recovery.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.recovery.test.ts
@@ -152,6 +152,36 @@ test("terminal SDK connection error replaces the query before the next turn", as
   }
 });
 
+test("terminal SDK connection error fails another turn queued on the retired query", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const calls: Array<{
+    generation: number;
+    options: ClaudeQueryOptions;
+  }> = [];
+  const closes: number[] = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  const session = createSession("connection-error", calls, closes);
+  try {
+    await session.start();
+    session.exec("turn-failed", "first");
+    session.exec("turn-queued", "second");
+    await waitForEvent(events, "turn_failed");
+
+    assert.deepEqual(
+      events
+        .filter((event) => event.type === "turn_failed")
+        .map((event) => event.payload?.turnId)
+        .sort(),
+      ["turn-failed", "turn-queued"]
+    );
+  } finally {
+    await session.close();
+    restoreSink();
+  }
+});
+
 for (const scenario of [
   {
     name: "a transient connection retry that succeeds",

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts
@@ -204,12 +204,10 @@ export class SessionRuntime {
       onSessionState: () => this.emitSessionState(),
       onMaybeTitle: (shouldEmit) =>
         this.maybeEmitSessionTitleUpdated(shouldEmit),
-      onTerminalConnectionError: () => {
-        const generation = this.queryGeneration;
-        this.queryGeneration = undefined;
-        generation?.revoke();
-        generation?.closeQuery();
-      },
+      onTerminalConnectionError: () =>
+        QueryGeneration.retire(this.queryGeneration, () => {
+          this.queryGeneration = undefined;
+        }),
       turns: this.turns,
       assistant: this.assistantStream,
       activities: this.activities,

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts
@@ -204,6 +204,12 @@ export class SessionRuntime {
       onSessionState: () => this.emitSessionState(),
       onMaybeTitle: (shouldEmit) =>
         this.maybeEmitSessionTitleUpdated(shouldEmit),
+      onTerminalConnectionError: () => {
+        const generation = this.queryGeneration;
+        this.queryGeneration = undefined;
+        generation?.revoke();
+        generation?.closeQuery();
+      },
       turns: this.turns,
       assistant: this.assistantStream,
       activities: this.activities,

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts
@@ -206,6 +206,8 @@ export class SessionRuntime {
         this.maybeEmitSessionTitleUpdated(shouldEmit),
       onTerminalConnectionError: () =>
         QueryGeneration.retire(this.queryGeneration, () => {
+          this.executionEpoch += 1;
+          this.turns.failQueuedTurns("Claude SDK connection lost");
           this.queryGeneration = undefined;
         }),
       turns: this.turns,

--- a/packages/agent/daemon/runtime/claude_sdk_diagnostics.go
+++ b/packages/agent/daemon/runtime/claude_sdk_diagnostics.go
@@ -1,0 +1,20 @@
+package agentruntime
+
+func appendClaudeSDKRetryDiagnostics(args []any, payload map[string]any) []any {
+	if payloadBoolValue(payload, "apiRetry") {
+		args = append(args, "api_retry", true)
+	}
+	if payloadBoolValue(payload, "sdkConnectionError") {
+		args = append(args, "sdk_connection_error", true)
+	}
+	if retryAttempt := payloadInt64(payload, "sdkRetryAttempt"); retryAttempt > 0 {
+		args = append(args, "sdk_retry_attempt", retryAttempt)
+	}
+	if maxRetries := payloadInt64(payload, "sdkMaxRetries"); maxRetries > 0 {
+		args = append(args, "sdk_max_retries", maxRetries)
+	}
+	if retryDelayMS := payloadInt64(payload, "sdkRetryDelayMs"); retryDelayMS > 0 {
+		args = append(args, "sdk_retry_delay_ms", retryDelayMS)
+	}
+	return args
+}

--- a/packages/agent/daemon/runtime/claude_sdk_event_projection_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_event_projection_test.go
@@ -1,16 +1,65 @@
 package agentruntime
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"log/slog"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 	"github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
 )
+
+func TestClaudeCodeSDKAdapterLogsAPIRetryDiagnostics(t *testing.T) {
+	previousLogger := slog.Default()
+	var output bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&output, nil)))
+	t.Cleanup(func() {
+		slog.SetDefault(previousLogger)
+	})
+
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	adapterSession := &claudeSDKAdapterSession{
+		providerSessionID: "provider-session-retry",
+		rootTurnID:        "turn-retry",
+	}
+	adapter.logClaudeSDKLifecycleEvent(
+		"agent-session-retry",
+		adapterSession,
+		claudeSDKSidecarEvent{
+			Type: "sdk_lifecycle_observed",
+			Payload: map[string]any{
+				"sdkMessageType":     "system",
+				"sdkMessageSubtype":  "api_retry",
+				"apiRetry":           true,
+				"sdkConnectionError": true,
+				"sdkRetryAttempt":    2,
+				"sdkMaxRetries":      3,
+				"sdkRetryDelayMs":    400,
+				"sdkAssistantError":  "unknown",
+			},
+		},
+	)
+
+	logged := output.String()
+	for _, expected := range []string{
+		"sdk_message_subtype=api_retry",
+		"api_retry=true",
+		"sdk_connection_error=true",
+		"sdk_retry_attempt=2",
+		"sdk_max_retries=3",
+		"sdk_retry_delay_ms=400",
+		"sdk_assistant_error=unknown",
+	} {
+		if !strings.Contains(logged, expected) {
+			t.Fatalf("log = %q, want %q", logged, expected)
+		}
+	}
+}
 
 func TestClaudeCodeSDKAdapterMapsSyntheticTurnStarted(t *testing.T) {
 	adapter := NewClaudeCodeSDKAdapter(nil)

--- a/packages/agent/daemon/runtime/claude_sdk_lifecycle_log.go
+++ b/packages/agent/daemon/runtime/claude_sdk_lifecycle_log.go
@@ -32,6 +32,7 @@ func claudeSDKLifecycleLogArgs(payload map[string]any) []any {
 		{logKey: "status", payloadKey: "status"},
 		{logKey: "state", payloadKey: "state"},
 		{logKey: "stop_reason", payloadKey: "stopReason"},
+		{logKey: "sdk_assistant_error", payloadKey: "sdkAssistantError"},
 	} {
 		if value := strings.TrimSpace(payloadString(payload, field.payloadKey)); value != "" {
 			args = append(args, field.logKey, value)
@@ -49,6 +50,7 @@ func claudeSDKLifecycleLogArgs(payload map[string]any) []any {
 	if payloadBoolValue(payload, "sdkResultIsError") {
 		args = append(args, "sdk_result_is_error", true)
 	}
+	args = appendClaudeSDKRetryDiagnostics(args, payload)
 	if apiErrorStatus := payloadInt64(payload, "sdkApiErrorStatus"); apiErrorStatus > 0 {
 		args = append(args, "sdk_api_error_status", apiErrorStatus)
 	}


### PR DESCRIPTION
## Summary
- retire a Claude SDK Query after a terminal connection error so the next send resumes the same provider session with a fresh Query
- preserve the current Query for successful retries and terminal HTTP/authentication failures
- log structured API retry diagnostics and document the recovery pattern

## Tests
- `node --test --experimental-strip-types packages/agent/claude-sdk-sidecar/src/sessionRuntime.recovery.test.ts`
- `pnpm --filter @tutti-os/claude-sdk-sidecar test`
- `pnpm check:changed -- --push-ready`

## Notes
- failed prompts are not replayed automatically because provider delivery may be ambiguous

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1790" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->