### PR TITLE
fix(tooling): isolate validation lanes from Git hooks

### DIFF
--- a/docs/conventions/static-analysis.md
+++ b/docs/conventions/static-analysis.md
@@ -77,6 +77,13 @@ committing, fetching, or checking out. A temporary cwd alone is not isolation
 because `GIT_DIR` takes precedence and can redirect `git init` and later
 commands into a caller's linked-worktree metadata.
 
+Repository validation lane runners must remove the same inherited repository
+selectors before spawning checks or tests. Git hooks export repository-local
+environment variables, so a pre-push validation run otherwise gives every
+child test authority over the caller's linked-worktree metadata. Spawned lanes
+rediscover the intended repository from their cwd; temporary Git fixtures still
+apply their own per-command environment and ceiling.
+
 ## TypeScript Baseline
 
 TypeScript linting uses Oxlint.

--- a/docs/conventions/troubleshooting/toolchain-browser-terminal.md
+++ b/docs/conventions/troubleshooting/toolchain-browser-terminal.md
@@ -140,19 +140,24 @@ deadline exceeded`. The failing test can take several seconds even though its
   Later fixture `add` and `commit` commands can then stage the fixture tree
   against the real branch.
 - Fix:
-  Remove repository-local Git environment variables for every fixture Git
-  command using case-insensitive name matching, set `GIT_CEILING_DIRECTORIES` to
-  the fixture root, stop on any command failure, verify `--absolute-git-dir`
-  after initialization, and pass fixture author identity through commit-local
-  `-c` arguments instead of `git config`.
+  Remove repository-local Git environment variables at the validation-lane
+  spawn boundary and for every fixture Git command using case-insensitive name
+  matching. Let normal lanes rediscover the repository from their cwd. For
+  fixtures, also set `GIT_CEILING_DIRECTORIES` to the fixture root, stop on any
+  command failure, verify `--absolute-git-dir` after initialization, and pass
+  fixture author identity through commit-local `-c` arguments instead of
+  `git config`.
 - Validation:
-  Run `git-environment.test.mjs`, which launches the temporary-repository test
-  suites with a poisoned linked-worktree `GIT_DIR` that points only at a
-  disposable repository. Confirm each fixture initializes its own `.git`, then
-  verify the caller's config and branch remain unchanged. Keep the lower-level
-  environment test coverage for `GIT_WORK_TREE` and `GIT_CONFIG_*` inputs.
+  Run `run-validation-lanes.test.mjs` to confirm spawned lanes remove poisoned
+  Git selectors while preserving unrelated environment, then run
+  `git-environment.test.mjs`, which launches the temporary-repository test suites
+  with a poisoned linked-worktree `GIT_DIR` that points only at a disposable
+  repository. Confirm each fixture initializes its own `.git`, then verify the
+  caller's config and branch remain unchanged. Keep the lower-level environment
+  test coverage for `GIT_WORK_TREE` and `GIT_CONFIG_*` inputs.
 - References:
   [git-environment.mjs](../../../tools/scripts/git-environment.mjs)
+  [run-validation-lanes.mjs](../../../tools/scripts/run-validation-lanes.mjs)
   [check-agent-gui-degradation.test.mjs](../../../tools/scripts/check-agent-gui-degradation.test.mjs)
   [push-checked.test.mjs](../../../tools/scripts/push-checked.test.mjs)
   [run-check-changed.test.mjs](../../../tools/scripts/run-check-changed.test.mjs)

--- a/tools/scripts/git-environment.mjs
+++ b/tools/scripts/git-environment.mjs
@@ -22,6 +22,14 @@ export function createIsolatedGitEnvironment(
   fixtureRoot,
   inheritedEnvironment = process.env
 ) {
+  const env = createGitDiscoveryEnvironment(inheritedEnvironment);
+  env.GIT_CEILING_DIRECTORIES = fixtureRoot;
+  return env;
+}
+
+export function createGitDiscoveryEnvironment(
+  inheritedEnvironment = process.env
+) {
   const env = { ...inheritedEnvironment };
   for (const name of Object.keys(env)) {
     const normalizedName = name.toUpperCase();
@@ -32,6 +40,5 @@ export function createIsolatedGitEnvironment(
       delete env[name];
     }
   }
-  env.GIT_CEILING_DIRECTORIES = fixtureRoot;
   return env;
 }

--- a/tools/scripts/run-validation-lanes.mjs
+++ b/tools/scripts/run-validation-lanes.mjs
@@ -9,6 +9,8 @@ import {
 import { join, relative } from "node:path";
 import { stripVTControlCharacters } from "node:util";
 
+import { createGitDiscoveryEnvironment } from "./git-environment.mjs";
+
 export async function runValidationLanes({
   lanes,
   maxParallel,
@@ -117,7 +119,7 @@ function runLane({ index, lane, runDirectory, tailLines, workspaceRoot }) {
     let settled = false;
     const child = spawn(lane.command[0], lane.command.slice(1), {
       cwd: lane.cwd ?? workspaceRoot,
-      env: process.env,
+      env: createGitDiscoveryEnvironment(),
       stdio: ["ignore", "pipe", "pipe"]
     });
 

--- a/tools/scripts/run-validation-lanes.test.mjs
+++ b/tools/scripts/run-validation-lanes.test.mjs
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { createIsolatedGitEnvironment } from "./git-environment.mjs";
 import {
   formatFailureExcerpt,
   formatSlowestLanes,
@@ -123,6 +125,70 @@ test("runValidationLanes prints a filtered failure as soon as its lane ends", as
     assert.match(output, /full logs:/u);
   } finally {
     console.error = originalError;
+    rmSync(workspaceRoot, { force: true, recursive: true });
+  }
+});
+
+test("runValidationLanes removes inherited Git repository selectors from child lanes", async () => {
+  const workspaceRoot = mkdtempSync(join(tmpdir(), "validation-git-env-"));
+  const nestedDirectory = join(workspaceRoot, "nested");
+  mkdirSync(nestedDirectory);
+  const initResult = spawnSync("git", ["init", "--quiet"], {
+    cwd: workspaceRoot,
+    encoding: "utf8",
+    env: createIsolatedGitEnvironment(workspaceRoot)
+  });
+  assert.equal(initResult.status, 0, initResult.stderr || initResult.stdout);
+  const poisonedEnvironment = {
+    GIT_CONFIG_VALUE_0: "true",
+    GIT_DIR: "/poison/git-dir",
+    Git_Config_Key_0: "core.bare",
+    Git_Work_Tree: "/poison/worktree",
+    PRESERVED_VALIDATION_VALUE: "preserved"
+  };
+  const originalEnvironment = Object.fromEntries(
+    Object.keys(poisonedEnvironment).map((name) => [name, process.env[name]])
+  );
+  Object.assign(process.env, poisonedEnvironment);
+
+  try {
+    const result = await runValidationLanes({
+      lanes: [
+        {
+          command: [
+            process.execPath,
+            "-e",
+            [
+              "const env = process.env",
+              'const { spawnSync } = require("node:child_process")',
+              'const forbidden = ["GIT_DIR", "Git_Work_Tree", "Git_Config_Key_0", "GIT_CONFIG_VALUE_0"]',
+              "if (forbidden.some((name) => Object.hasOwn(env, name))) process.exit(1)",
+              'if (env.PRESERVED_VALIDATION_VALUE !== "preserved") process.exit(1)',
+              'const git = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], { encoding: "utf8" })',
+              'if (git.status !== 0 || git.stdout.trim() !== "true") process.exit(1)'
+            ].join(";")
+          ],
+          cwd: nestedDirectory,
+          key: "git-environment",
+          label: "Git environment"
+        }
+      ],
+      maxParallel: 1,
+      summaryLabel: "fixture tests",
+      tailLines: 80,
+      tmpDirectoryName: "test-runs/git-environment",
+      workspaceRoot
+    });
+
+    assert.equal(result.exitCode, 0);
+  } finally {
+    for (const [name, value] of Object.entries(originalEnvironment)) {
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+    }
     rmSync(workspaceRoot, { force: true, recursive: true });
   }
 });


### PR DESCRIPTION
## Summary
- strip inherited Git repository selectors before spawning validation lanes
- keep fixture-specific Git ceilings separate from normal repository discovery
- add linked-worktree regression coverage and document the durable rule

## Tests
- `node --test tools/scripts/run-validation-lanes.test.mjs tools/scripts/git-environment.test.mjs`
- poisoned linked-worktree `GIT_DIR` + `pnpm test:tools` with unchanged shared config hash
- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready`

## Notes
- normal lanes rediscover the intended repository from their cwd; temporary Git fixtures retain per-command isolation and ceilings
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->