### PR TITLE
fix(agent): preserve Claude continuation lifecycle

### DIFF
--- a/docs/architecture/claude-code-sdk-runtime.md
+++ b/docs/architecture/claude-code-sdk-runtime.md
@@ -153,8 +153,11 @@ current generation without creating a resumable successor.
 Background-task lifecycle uses the SDK's `background_tasks_changed` system
 message as a level signal. Its `tasks` array fully replaces the previous live
 set. An empty set means the background children have quiesced; it does not mean
-the root Turn is complete. If the root result already settled, the sidecar
-reserves a synthetic continuation. It remains in the existing running phase,
+the root Turn is complete. When a successful ordinary root result arrives while
+a background continuation is already pending, the sidecar retains the original
+root Turn until session idle instead of emitting a terminal/start pair. If the
+root result already settled before the pending signal, the sidecar reserves a
+synthetic continuation. It remains in the existing running phase,
 and results with `origin.kind = task-notification` confirm background
 follow-up output without settling it by notification/result count. The SDK's
 `session_state_changed: idle` event is the authoritative turn-over edge after

--- a/docs/conventions/troubleshooting/agent-approvals-subagents.md
+++ b/docs/conventions/troubleshooting/agent-approvals-subagents.md
@@ -167,6 +167,11 @@ session-level child summaries.
   - Identify background follow-up results from
     `origin.kind=task-notification`. Do not compare task-notification and result
     counts: the SDK may coalesce queued follow-ups.
+  - If the background level or task notifications make continuation pending
+    before the ordinary root result, retain the original root Turn until
+    session idle. Do not emit `turn_completed(root)` followed by
+    `turn_started(synthetic)`: with every child already terminal, durable state
+    can settle between those events and must reject the late provider start.
   - Settle normally on `session_state_changed: idle`, after the SDK has flushed
     its held-back result and exited the background-agent loop. Do not start a
     post-result settlement timeout: queued follow-ups may begin several seconds

--- a/packages/agent/claude-sdk-sidecar/README.md
+++ b/packages/agent/claude-sdk-sidecar/README.md
@@ -26,7 +26,11 @@ Protocol types and validation live in `src/protocol.ts`.
 Protocol version 6 adds background-task level and continuation diagnostics.
 `background_tasks_changed` is a full replace-set of currently running SDK
 background tasks, not a terminal root-turn signal. When the set becomes empty,
-the sidecar reserves a synthetic continuation. Results whose
+the sidecar records a pending continuation. If the ordinary root result arrives
+while that continuation is already pending, the original turn stays active
+until session idle; no terminal/start pair is emitted. A synthetic continuation
+is reserved only when the pending signal arrives after the root already
+settled. Results whose
 `origin.kind` is `task-notification` confirm background follow-up output without
 assuming one result per notification. The SDK's `session_state_changed: idle`
 event authoritatively settles the continuation after its background loop

--- a/packages/agent/claude-sdk-sidecar/src/messageRouter.ts
+++ b/packages/agent/claude-sdk-sidecar/src/messageRouter.ts
@@ -421,16 +421,23 @@ export class SDKMessageRouter {
       void this.emitResultUsage(turnId, contextUsageGeneration, result);
       return;
     }
+    const pendingBackgroundContinuation =
+      succeeded && this.activities.hasPendingBackgroundContinuation();
     const completedSyntheticContinuation =
-      succeeded &&
-      this.turns.activeTurn?.synthetic === true &&
-      this.activities.hasPendingBackgroundContinuation();
+      pendingBackgroundContinuation &&
+      this.turns.activeTurn?.synthetic === true;
+    // When the background level or task notifications already proved that
+    // follow-up output is pending, a successful root result is only the end of
+    // that provider response—not the canonical turn. Keep the original turn
+    // live until session idle instead of emitting a terminal/start pair that
+    // can settle durable state between the two events.
+    const retainRootForBackgroundContinuation =
+      pendingBackgroundContinuation &&
+      this.turns.activeTurn?.synthetic !== true;
     if (this.turns.cancelled) {
       this.turns.settleActive("turn_canceled");
       this.turns.clearCancelled();
-    } else if (succeeded) {
-      this.turns.settleActive("turn_completed", { stopReason: "end_turn" });
-    } else {
+    } else if (!succeeded) {
       this.turns.settleActive("turn_failed", {
         error:
           result.errors?.[0] ||
@@ -442,6 +449,8 @@ export class SDKMessageRouter {
           ? { apiErrorStatus: result.api_error_status }
           : {})
       });
+    } else if (!retainRootForBackgroundContinuation) {
+      this.turns.settleActive("turn_completed", { stopReason: "end_turn" });
     }
     if (completedSyntheticContinuation) {
       this.activities.clearBackgroundContinuation();

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.delegated.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.delegated.test.ts
@@ -391,6 +391,58 @@ test("parallel delegated notifications keep the original turn open until session
   }
 });
 
+test("root success before delegated continuation keeps the original turn open until session idle", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) =>
+        fakeParallelDelegatedTaskContinuationQuery(prompt, {
+          rootResultBeforeContinuations: true
+        })
+    );
+
+    await session.start();
+    session.exec("turn-1", "delegate parallel tasks");
+    await waitForEvent(events, "turn_completed");
+
+    assert.deepEqual(
+      events
+        .filter((event) => event.type === "turn_completed")
+        .map((event) => ({
+          turnId: event.payload?.turnId,
+          stopReason: event.payload?.stopReason
+        })),
+      [{ turnId: "turn-1", stopReason: "background_agent_idle" }]
+    );
+    assert.equal(
+      events.some(
+        (event) =>
+          event.type === "turn_started" && event.payload?.synthetic === true
+      ),
+      false
+    );
+  } finally {
+    restoreSink();
+  }
+});
+
 test("session idle settles coalesced delegated notifications without result-count pairing", async () => {
   const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
   const restoreSink = withSidecarEventSinkForTest((event) =>

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntimeTestQueries.delegated.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntimeTestQueries.delegated.ts
@@ -166,7 +166,8 @@ export function fakeDelegatedTaskQuery(
 }
 
 export function fakeParallelDelegatedTaskContinuationQuery(
-  prompt: AsyncIterable<SDKUserMessage>
+  prompt: AsyncIterable<SDKUserMessage>,
+  options: { rootResultBeforeContinuations?: boolean } = {}
 ): AsyncIterable<SDKMessage> {
   return {
     async *[Symbol.asyncIterator]() {
@@ -211,6 +212,12 @@ export function fakeParallelDelegatedTaskContinuationQuery(
           task_id: `task-${index}`,
           status: "completed",
           summary: `Result ${index}`
+        } as unknown as SDKMessage;
+      }
+      if (options.rootResultBeforeContinuations) {
+        yield {
+          type: "result",
+          subtype: "success"
         } as unknown as SDKMessage;
       }
       for (const index of [1, 2]) {

--- a/packages/agent/daemon/runtime/controller_test.go
+++ b/packages/agent/daemon/runtime/controller_test.go
@@ -5679,6 +5679,56 @@ func TestControllerFinishParentTurnDoesNotOverwriteSyntheticLifecycle(t *testing
 	}
 }
 
+func TestControllerStoreTurnSessionRejectsOlderAdapterLifecycle(t *testing.T) {
+	t.Parallel()
+
+	controller := NewController(nil, nil)
+	turnID := "parent-turn-1"
+	current := Session{
+		RoomID:             "room-1",
+		AgentSessionID:     "agent-session-1",
+		Provider:           ProviderClaudeCode,
+		Status:             SessionStatusWorking,
+		LifecycleAuthority: true,
+		LifecycleSeq:       3,
+		TurnLifecycle: &TurnLifecycle{
+			ActiveTurnID: &turnID,
+			Phase:        "running",
+		},
+		SubmitAvailability: blockedSubmitAvailability("active_turn"),
+	}
+	controller.store(current)
+	controller.mu.Lock()
+	controller.turns[sessionKey("room-1", "agent-session-1")] = activeTurn{turnID: turnID}
+	controller.mu.Unlock()
+
+	outcome := "completed"
+	stale := current
+	stale.Status = SessionStatusReady
+	stale.LifecycleSeq = 2
+	stale.TurnLifecycle = &TurnLifecycle{
+		Phase:   "settled",
+		Outcome: &outcome,
+	}
+	stale.SubmitAvailability = availableSubmitAvailability()
+
+	if controller.storeTurnSession(stale, turnID) {
+		t.Fatal("older adapter lifecycle overwrote current session")
+	}
+	stored, ok := controller.get("room-1", "agent-session-1")
+	if !ok {
+		t.Fatal("stored session missing")
+	}
+	if stored.LifecycleSeq != current.LifecycleSeq ||
+		stored.Status != SessionStatusWorking ||
+		stored.TurnLifecycle == nil ||
+		stored.TurnLifecycle.ActiveTurnID == nil ||
+		*stored.TurnLifecycle.ActiveTurnID != turnID ||
+		stored.TurnLifecycle.Phase != "running" {
+		t.Fatalf("stored session = %#v, want newer running lifecycle preserved", stored)
+	}
+}
+
 func TestControllerFinishTurnDoesNotRestoreClosedSession(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/controller_turn_finish.go
+++ b/packages/agent/daemon/runtime/controller_turn_finish.go
@@ -17,7 +17,14 @@ func (c *Controller) storeTurnSession(session Session, turnID string) bool {
 	if !ok || strings.TrimSpace(active.turnID) != strings.TrimSpace(turnID) {
 		return false
 	}
-	if _, ok := c.sessions[key]; !ok {
+	current, ok := c.sessions[key]
+	if !ok {
+		return false
+	}
+	// A blocking Exec owns a local Session snapshot while the adapter's
+	// session-event sink can advance lifecycle concurrently. Never let the
+	// older local snapshot erase a newer synthetic continuation.
+	if current.LifecycleAuthority && current.LifecycleSeq > session.LifecycleSeq {
 		return false
 	}
 	c.sessions[key] = session


### PR DESCRIPTION
## Summary
- keep the original Claude root turn active when background continuation is already pending
- reject stale adapter lifecycle snapshots from overwriting a newer controller lifecycle
- add regression coverage for the observed result ordering and document the lifecycle rule

## Tests
- `pnpm check:changed`
- `pnpm check:changed -- --push-ready`
- `go test ./packages/agent/daemon/runtime`
- focused controller and canonical store tests with `-count=20`
- Claude SDK sidecar test suite (113 tests)
- `git diff --check`

## Notes
- fixes the lifecycle ordering observed in dev session `efea9c1c-05cd-4996-a3f0-1d637fd358f8`
- no public API or configuration changes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->