### PR TITLE
feat(agent): gate session fork behind Lab opt-in

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -86,7 +86,8 @@ import {
   AGENT_SESSION_RECORDING_FLAG,
   AGENT_REFERENCE_PROVENANCE_FILTER_FLAG,
   isFeatureEnabled,
-  LAB_AGENT_INPUT_HISTORY_FLAG
+  LAB_AGENT_INPUT_HISTORY_FLAG,
+  LAB_AGENT_SESSION_FORK_FLAG
 } from "../../../../../shared/featureFlags/catalog.ts";
 
 function DesktopAgentGUISurfaceImpl({
@@ -577,6 +578,10 @@ function DesktopAgentGUISurfaceImpl({
     desktopPreferencesState.featureFlags,
     LAB_AGENT_INPUT_HISTORY_FLAG
   );
+  const sessionForkEnabled = isFeatureEnabled(
+    desktopPreferencesState.featureFlags,
+    LAB_AGENT_SESSION_FORK_FLAG
+  );
   const providerAuthAccountLabels = useDesktopAgentGUIProviderAuthAccountLabels(
     providerStatusSnapshot.statuses
   );
@@ -647,6 +652,7 @@ function DesktopAgentGUISurfaceImpl({
     hostCapabilities: {
       referenceProvenanceFilterEnabled,
       sessionInputHistoryEnabled,
+      sessionForkEnabled,
       capabilityMenuState,
       visibleErrorPresentationOverrides,
       comingSoonProviders: comingSoonAgentProviders,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/useStableDesktopAgentGUIHostProps.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/useStableDesktopAgentGUIHostProps.test.ts
@@ -81,6 +81,19 @@ test("forwards the host-owned composer footer accessory slot", () => {
   );
 });
 
+test("forwards the host-owned Session fork experiment opt-in", () => {
+  const result = useStableDesktopAgentGUIHostProps({
+    hostActions: {},
+    hostCapabilities: { sessionForkEnabled: true },
+    identity: { currentUserId: null, nodeId: "node-1", workspaceId: "ws-1" },
+    renderSlots: {},
+    runtimeRequests: {},
+    workspace: {}
+  } as never);
+
+  assert.equal(result.hostCapabilities.sessionForkEnabled, true);
+});
+
 test("forwards every runtimeRequests field instead of silently dropping new ones", () => {
   // The manual field-keyed reconstruction below is exactly the pattern that
   // let `sessionAction` silently vanish (dropped this exact way, then wired

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/useStableDesktopAgentGUIHostProps.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/useStableDesktopAgentGUIHostProps.ts
@@ -23,6 +23,7 @@ export type DesktopAgentGUIHostProps = {
     AgentGUIProps["hostCapabilities"],
     | "referenceProvenanceFilterEnabled"
     | "sessionInputHistoryEnabled"
+    | "sessionForkEnabled"
     | "capabilityMenuState"
     | "visibleErrorPresentationOverrides"
     | "comingSoonProviders"
@@ -103,6 +104,7 @@ export function useStableDesktopAgentGUIHostProps({
         nextHostCapabilities.referenceProvenanceFilterEnabled,
       sessionInputHistoryEnabled:
         nextHostCapabilities.sessionInputHistoryEnabled,
+      sessionForkEnabled: nextHostCapabilities.sessionForkEnabled,
       capabilityMenuState: nextHostCapabilities.capabilityMenuState,
       visibleErrorPresentationOverrides:
         nextHostCapabilities.visibleErrorPresentationOverrides,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceLabFeatureGateRows.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceLabFeatureGateRows.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "@renderer/i18n";
 import {
   EARLY_ACCESS_AGENT_INTEGRATIONS_FLAG,
   LAB_AGENT_INPUT_HISTORY_FLAG,
+  LAB_AGENT_SESSION_FORK_FLAG,
   LAB_AUTOMATION_RULES_FLAG,
   LAB_WORKBENCH_SHORTCUTS_FLAG,
   isFeatureEnabled
@@ -26,6 +27,12 @@ const featureGateRows = [
     labelKey: "workspace.settings.lab.agentInputHistoryLabel" as const,
     descriptionKey:
       "workspace.settings.lab.agentInputHistoryDescription" as const
+  },
+  {
+    key: LAB_AGENT_SESSION_FORK_FLAG,
+    labelKey: "workspace.settings.lab.agentSessionForkLabel" as const,
+    descriptionKey:
+      "workspace.settings.lab.agentSessionForkDescription" as const
   },
   {
     key: EARLY_ACCESS_AGENT_INTEGRATIONS_FLAG,

--- a/apps/desktop/src/shared/featureFlags/catalog.test.ts
+++ b/apps/desktop/src/shared/featureFlags/catalog.test.ts
@@ -17,6 +17,7 @@ import {
   labFeatureDefinitions,
   LAB_ENABLED_FLAG,
   LAB_AGENT_INPUT_HISTORY_FLAG,
+  LAB_AGENT_SESSION_FORK_FLAG,
   LAB_AUTOMATION_RULES_FLAG,
   MOBILE_REMOTE_ACCESS_SETTINGS_FLAG,
   resolveDesktopWorkspaceUiMode,
@@ -93,7 +94,11 @@ test("labFeatureDefinitions excludes the master switch", () => {
 });
 
 test("experimental Agent features require independent Lab opt-ins", () => {
-  const flags = [LAB_AGENT_INPUT_HISTORY_FLAG, LAB_AUTOMATION_RULES_FLAG];
+  const flags = [
+    LAB_AGENT_INPUT_HISTORY_FLAG,
+    LAB_AGENT_SESSION_FORK_FLAG,
+    LAB_AUTOMATION_RULES_FLAG
+  ];
 
   for (const flag of flags) {
     assert.equal(isFeatureEnabled({}, flag), false);

--- a/apps/desktop/src/shared/featureFlags/catalog.ts
+++ b/apps/desktop/src/shared/featureFlags/catalog.ts
@@ -9,6 +9,7 @@ export const BROWSER_CHROME_COOKIE_IMPORT_FLAG = "browser.chromeCookieImport";
 export const LAB_AUTOMATION_RULES_FLAG = "lab.automationRules";
 export const LAB_WORKBENCH_SHORTCUTS_FLAG = "lab.workbenchShortcuts";
 export const LAB_AGENT_INPUT_HISTORY_FLAG = "lab.agentInputHistory";
+export const LAB_AGENT_SESSION_FORK_FLAG = "lab.agentSessionFork";
 // Keep the durable key for existing profiles while naming the product concept
 // after Tutti's integration maturity rather than the upstream Agent maturity.
 export const EARLY_ACCESS_AGENT_INTEGRATIONS_FLAG = "lab.previewAgents";
@@ -186,6 +187,13 @@ export const FEATURE_FLAG_DEFINITIONS: readonly FeatureFlagDefinition[] = [
     group: "lab",
     labelKey: "workspace.settings.lab.agentInputHistoryLabel",
     descriptionKey: "workspace.settings.lab.agentInputHistoryDescription"
+  },
+  {
+    key: LAB_AGENT_SESSION_FORK_FLAG,
+    default: false,
+    group: "lab",
+    labelKey: "workspace.settings.lab.agentSessionForkLabel",
+    descriptionKey: "workspace.settings.lab.agentSessionForkDescription"
   },
   {
     key: EARLY_ACCESS_AGENT_INTEGRATIONS_FLAG,

--- a/apps/desktop/src/shared/i18n/locales/en.ts
+++ b/apps/desktop/src/shared/i18n/locales/en.ts
@@ -1233,6 +1233,9 @@ export const en = {
         agentInputHistoryDescription:
           "Use Up and Down in Agent input to recall earlier prompts from the current session.",
         agentInputHistoryLabel: "Agent input history",
+        agentSessionForkDescription:
+          "Allow branching a new Agent conversation from a supported completed turn.",
+        agentSessionForkLabel: "Agent session fork",
         backLabel: "Back",
         automationRulesDescription:
           "Shows Automation Rule configuration and session overrides.",

--- a/apps/desktop/src/shared/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/shared/i18n/locales/zh-CN.ts
@@ -1156,6 +1156,9 @@ export const zhCN = {
         agentInputHistoryDescription:
           "在 Agent 输入框中使用上下键切换当前会话的历史输入",
         agentInputHistoryLabel: "Agent 输入历史",
+        agentSessionForkDescription:
+          "允许从支持的已完成轮次创建新的 Agent 会话分支",
+        agentSessionForkLabel: "Agent 会话分支",
         backLabel: "返回",
         automationRulesDescription: "显示自动化规则配置与会话覆盖选项",
         automationRulesLabel: "自动化规则",

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -378,6 +378,12 @@ transactionally rejects an unverified prefix, descendant lane, or
 session-scoped local attachment. This prevents a later unavailable Turn from
 hiding an earlier valid Turn while preserving a fail-closed commit.
 
+Session Fork is also a default-off Lab capability. Desktop maps
+`lab.agentSessionFork` to an explicit AgentGUI host opt-in, so provider support
+alone does not expose the action. Tuttid independently enforces the same flag
+on new Fork writes; disabling it leaves existing lineage, operation reads, and
+operation acknowledgements available.
+
 Tuttid currently rejects worktree-isolated sources at the Session capability
 layer. A provider-native thread Fork keeps the provider cwd; copying the
 source worktree ownership or silently selecting another checkout would be

--- a/docs/conventions/feature-flags.md
+++ b/docs/conventions/feature-flags.md
@@ -59,6 +59,11 @@ the registry default; absent unregistered keys resolve to `false`
 
 ## Existing reference pattern
 
+`lab.agentSessionFork` is a capability flag. Desktop hides new Session Fork
+actions unless the flag is enabled, and tuttid rejects direct Fork writes when
+it is absent, false, or unreadable. Existing fork lineage plus operation reads
+and acknowledgements remain available while the flag is off.
+
 `services/tuttid/service/agentextension/manager.go` is the existing example
 of feature-owned semantics: it reads the raw flag map, derives its own keys
 (`"agent.extension."+source.Key`), and decides what disabled means for Agent

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.memo.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.memo.spec.tsx
@@ -151,6 +151,28 @@ describe("AgentGUINode memoization", () => {
     );
   });
 
+  it("rerenders when Session fork is enabled", () => {
+    mockViewModel = createViewModel();
+    const props = createProps();
+    const { rerender } = render(<AgentGUINode {...props} />);
+
+    expect(agentGuiNodeViewSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ sessionForkEnabled: false })
+    );
+    agentGuiNodeViewSpy.mockClear();
+
+    rerender(
+      <AgentGUINode
+        {...props}
+        hostCapabilities={{ sessionForkEnabled: true }}
+      />
+    );
+
+    expect(agentGuiNodeViewSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ sessionForkEnabled: true })
+    );
+  });
+
   it("rerenders when per-target composer overrides change", () => {
     mockViewModel = createViewModel();
     const props = createProps({

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -114,7 +114,8 @@ export const AgentGUINode = memo(function AgentGUINode({
     disabledHomeSuggestions,
     referenceProvenanceFilterCatalog: injectedReferenceProvenanceFilterCatalog,
     referenceProvenanceFilterEnabled = false,
-    sessionInputHistoryEnabled = false
+    sessionInputHistoryEnabled = false,
+    sessionForkEnabled = false
   } = hostCapabilities;
   const referenceProvenanceFilters = useAgentMentionProvenanceFilters({
     agentTargets,
@@ -548,6 +549,7 @@ export const AgentGUINode = memo(function AgentGUINode({
               workspaceAppIcons={workspaceAppIcons}
               referenceProvenanceFilters={referenceProvenanceFilters}
               sessionInputHistoryEnabled={sessionInputHistoryEnabled}
+              sessionForkEnabled={sessionForkEnabled}
               renderProjectDirectoryPickerHeaderActions={
                 renderProjectDirectoryPickerHeaderActions
               }

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.types.ts
@@ -128,6 +128,8 @@ export interface AgentGUINodeHostCapabilities {
   referenceProvenanceFilterEnabled?: boolean;
   /** Host-owned experimental opt-in for current-Session composer history. */
   sessionInputHistoryEnabled?: boolean;
+  /** Host-owned experimental opt-in for creating Session forks. */
+  sessionForkEnabled?: boolean;
   capabilityMenuState?: AgentComposerCapabilityMenuState;
   /**
    * Keeps owner-supported Browser/Computer capability entries visible while
@@ -390,6 +392,7 @@ export function areAgentGUINodePropsEqual(
     pc.referenceProvenanceFilterEnabled ===
       nc.referenceProvenanceFilterEnabled &&
     pc.sessionInputHistoryEnabled === nc.sessionInputHistoryEnabled &&
+    pc.sessionForkEnabled === nc.sessionForkEnabled &&
     agentGuiStateEquals(previous.state, next.state) &&
     pf.position.x === nf.position.x &&
     pf.position.y === nf.position.y &&

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -86,6 +86,7 @@ export function AgentGUINodeView({
   viewModel,
   referenceProvenanceFilters = null,
   sessionInputHistoryEnabled = false,
+  sessionForkEnabled = false,
   renderAgentTargetInfo,
   renderProjectDirectoryPickerHeaderActions,
   renderSidebarFooter,
@@ -696,6 +697,7 @@ export function AgentGUINodeView({
                 homeTargetProjection={homeTargetProjection}
                 referenceProvenanceFilters={referenceProvenanceFilters}
                 sessionInputHistoryEnabled={sessionInputHistoryEnabled}
+                sessionForkEnabled={sessionForkEnabled}
                 composerEngagement={composerEngagement}
                 actions={actions}
                 labels={labels}

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
@@ -44,6 +44,7 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
   homeTargetProjection,
   referenceProvenanceFilters = null,
   sessionInputHistoryEnabled = false,
+  sessionForkEnabled = false,
   composerEngagement,
   actions,
   labels,
@@ -152,6 +153,7 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       void actions.forkConversationThroughTurn(agentSessionId, turnId);
     }
   });
+  const forkHandler = sessionForkEnabled ? handleForkThroughTurn : undefined;
   const openForkSourceSession = useStableEventCallback(
     actions.openForkSourceConversation
   );
@@ -748,7 +750,7 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
         isTimelineScrolledToTop={isTimelineScrolledToTop}
         labels={labels}
         onAuthLogin={authLogin}
-        onForkThroughTurn={handleForkThroughTurn}
+        onForkThroughTurn={forkHandler}
         onOpenForkSourceSession={openForkSourceSession}
         forkThroughTurnPendingTurnIds={
           viewModel.operations.forkThroughTurnPendingTurnIds

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
@@ -527,11 +527,11 @@ export type AgentGUIConversationRailLabels = Pick<
   | "unpinSession"
   | "untitledConversationTitle"
 >;
-
 export interface AgentGUINodeViewProps {
   viewModel: AgentGUINodeViewModel;
   referenceProvenanceFilters?: AgentComposerReferenceProvenanceFilters | null;
   sessionInputHistoryEnabled?: boolean;
+  sessionForkEnabled?: boolean;
   /** Host-owned presentation for exact Agent targets; tooltip behavior stays AgentGUI-owned. */
   renderAgentTargetInfo?: AgentGUIAgentTargetInfoRenderer;
   renderProjectDirectoryPickerHeaderActions?: ReferenceSourcePickerProps["renderHeaderActions"];
@@ -715,7 +715,6 @@ export interface AgentGUINodeViewProps {
   workspaceAppIcons?: readonly AgentMessageMarkdownWorkspaceAppIcon[];
   renderComposerFooterAccessory?: AgentGUIComposerFooterAccessoryRenderer;
 }
-
 export interface AgentGUIDetailPaneProps {
   shell: AgentGUINodeViewModel["shell"];
   rail: AgentGUINodeViewModel["rail"];
@@ -727,6 +726,7 @@ export interface AgentGUIDetailPaneProps {
   homeTargetProjection: AgentGUIManagedHomeTargetProjection;
   referenceProvenanceFilters?: AgentComposerProps["referenceProvenanceFilters"];
   sessionInputHistoryEnabled?: boolean;
+  sessionForkEnabled?: boolean;
   composerEngagement?: AgentGUIComposerEngagement;
   actions: AgentGUINodeViewProps["actions"];
   labels: AgentGUIViewLabels;

--- a/services/tuttid/api/agent_session_fork_feature_gate.go
+++ b/services/tuttid/api/agent_session_fork_feature_gate.go
@@ -1,0 +1,35 @@
+package api
+
+import (
+	"context"
+
+	tuttigenerated "github.com/tutti-os/tutti/services/tuttid/api/generated"
+	"github.com/tutti-os/tutti/services/tuttid/apierrors"
+	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
+)
+
+// agentSessionForkWritesEnabled reports whether callers may create new Session
+// forks. Reads and acknowledgements remain available so existing operations and
+// lineage stay observable when the Lab experiment is disabled.
+func (api DaemonAPI) agentSessionForkWritesEnabled(ctx context.Context) bool {
+	if api.PreferencesService == nil {
+		return false
+	}
+	preferences, err := api.PreferencesService.Get(ctx)
+	if err != nil {
+		return false
+	}
+	return preferencesbiz.IsLabFlagEnabled(
+		preferences.FeatureFlags,
+		preferencesbiz.LabFlagAgentSessionFork,
+	)
+}
+
+func agentSessionForkWriteDisabledError() tuttigenerated.InvalidRequestErrorJSONResponse {
+	return invalidRequestError(apierrors.InvalidRequest(
+		"agent_session_fork_disabled",
+		apierrors.WithDeveloperMessage(
+			"agent session fork writes require the lab.agentSessionFork feature flag",
+		),
+	))
+}

--- a/services/tuttid/api/daemon_agent_session_fork.go
+++ b/services/tuttid/api/daemon_agent_session_fork.go
@@ -15,6 +15,11 @@ func (api DaemonAPI) ForkWorkspaceAgentSession(
 	ctx context.Context,
 	request tuttigenerated.ForkWorkspaceAgentSessionRequestObject,
 ) (tuttigenerated.ForkWorkspaceAgentSessionResponseObject, error) {
+	if !api.agentSessionForkWritesEnabled(ctx) {
+		return tuttigenerated.ForkWorkspaceAgentSession400JSONResponse{
+			InvalidRequestErrorJSONResponse: agentSessionForkWriteDisabledError(),
+		}, nil
+	}
 	if api.AgentSessionService == nil {
 		return tuttigenerated.ForkWorkspaceAgentSession503JSONResponse{
 			ServiceUnavailableErrorJSONResponse: agentSessionServiceUnavailableError(),

--- a/services/tuttid/api/daemon_agent_session_fork_test.go
+++ b/services/tuttid/api/daemon_agent_session_fork_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -13,8 +14,107 @@ import (
 	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 	tuttigenerated "github.com/tutti-os/tutti/services/tuttid/api/generated"
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
+	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
 )
+
+func sessionForkTestPreferences(flags map[string]bool, err error) stubPreferencesService {
+	return stubPreferencesService{
+		getFn: func(context.Context) (preferencesbiz.DesktopPreferences, error) {
+			if err != nil {
+				return preferencesbiz.DesktopPreferences{}, err
+			}
+			return preferencesbiz.DesktopPreferences{FeatureFlags: flags}, nil
+		},
+	}
+}
+
+func enabledSessionForkTestPreferences() stubPreferencesService {
+	return sessionForkTestPreferences(
+		map[string]bool{preferencesbiz.LabFlagAgentSessionFork: true},
+		nil,
+	)
+}
+
+func TestForkWorkspaceAgentSessionRequiresLabOptIn(t *testing.T) {
+	for _, test := range []struct {
+		name               string
+		flags              map[string]bool
+		preferencesError   error
+		omitPreferencesAPI bool
+	}{
+		{name: "flag absent", flags: map[string]bool{}},
+		{
+			name: "flag explicitly disabled",
+			flags: map[string]bool{
+				preferencesbiz.LabFlagAgentSessionFork: false,
+			},
+		},
+		{
+			name:             "preferences unreadable",
+			preferencesError: errors.New("preferences unavailable"),
+		},
+		{name: "preferences service missing", omitPreferencesAPI: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			forkCalls := 0
+			api := DaemonAPI{
+				AgentSessionService: stubAgentSessionService{
+					forkFn: func(
+						context.Context,
+						string,
+						string,
+						agentservice.ForkSessionInput,
+					) (agentservice.SessionForkOperation, error) {
+						forkCalls++
+						return agentservice.SessionForkOperation{}, nil
+					},
+				},
+			}
+			if !test.omitPreferencesAPI {
+				api.PreferencesService = sessionForkTestPreferences(
+					test.flags,
+					test.preferencesError,
+				)
+			}
+			mux := http.NewServeMux()
+			RegisterRoutes(mux, NewRoutes(api))
+
+			recorder := performGeneratedRouteRequest(
+				t,
+				mux,
+				http.MethodPost,
+				"/v1/workspaces/workspace-1/agent-sessions/source-1/fork",
+				map[string]any{
+					"targetAgentSessionId": "f0f21d94-af7c-4bdd-8f24-bffd169474bc",
+					"requestId":            "request-1",
+					"point": map[string]any{
+						"type": "throughTurn", "turnId": "turn-7",
+					},
+				},
+			)
+
+			if recorder.Code != http.StatusBadRequest {
+				t.Fatalf(
+					"status = %d, want 400; body=%s",
+					recorder.Code,
+					recorder.Body.String(),
+				)
+			}
+			var body tuttigenerated.ApiErrorResponse
+			if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
+				t.Fatal(err)
+			}
+			if body.Error.Reason == nil ||
+				*body.Error.Reason != "agent_session_fork_disabled" {
+				t.Fatalf("reason=%v, want agent_session_fork_disabled", body.Error.Reason)
+			}
+			if forkCalls != 0 {
+				t.Fatalf("fork service called %d times, want 0", forkCalls)
+			}
+		})
+	}
+}
 
 func TestForkWorkspaceAgentSessionPreservesExactThroughTurnIdentity(t *testing.T) {
 	var observedWorkspaceID, observedSourceID string
@@ -54,7 +154,10 @@ func TestForkWorkspaceAgentSessionPreservesExactThroughTurnIdentity(t *testing.T
 		},
 	}
 	mux := http.NewServeMux()
-	RegisterRoutes(mux, NewRoutes(DaemonAPI{AgentSessionService: service}))
+	RegisterRoutes(mux, NewRoutes(DaemonAPI{
+		AgentSessionService: service,
+		PreferencesService:  enabledSessionForkTestPreferences(),
+	}))
 
 	recorder := performGeneratedRouteRequest(
 		t,
@@ -122,6 +225,7 @@ func TestForkWorkspaceAgentSessionPreservesExactThroughTurnIdentity(t *testing.T
 func TestForkWorkspaceAgentSessionUnsupportedIsConflict(t *testing.T) {
 	mux := http.NewServeMux()
 	RegisterRoutes(mux, NewRoutes(DaemonAPI{
+		PreferencesService: enabledSessionForkTestPreferences(),
 		AgentSessionService: stubAgentSessionService{
 			forkFn: func(
 				context.Context,
@@ -155,6 +259,7 @@ func TestForkWorkspaceAgentSessionUnsupportedIsConflict(t *testing.T) {
 func TestForkWorkspaceAgentSessionReportsBoundaryRejectionReason(t *testing.T) {
 	mux := http.NewServeMux()
 	RegisterRoutes(mux, NewRoutes(DaemonAPI{
+		PreferencesService: enabledSessionForkTestPreferences(),
 		AgentSessionService: stubAgentSessionService{
 			forkFn: func(
 				context.Context,
@@ -222,6 +327,7 @@ func TestForkWorkspaceAgentSessionReturnsDurableOutcomesAsOperationSnapshots(t *
 		t.Run(test.name, func(t *testing.T) {
 			mux := http.NewServeMux()
 			RegisterRoutes(mux, NewRoutes(DaemonAPI{
+				PreferencesService: enabledSessionForkTestPreferences(),
 				AgentSessionService: stubAgentSessionService{
 					forkFn: func(
 						context.Context,
@@ -519,6 +625,7 @@ func TestForkWorkspaceAgentSessionRejectsUnknownPoint(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	mux := http.NewServeMux()
 	RegisterRoutes(mux, NewRoutes(DaemonAPI{
+		PreferencesService:  enabledSessionForkTestPreferences(),
 		AgentSessionService: stubAgentSessionService{},
 	}))
 	request := httptest.NewRequest(

--- a/services/tuttid/biz/preferences/lab_flags.go
+++ b/services/tuttid/biz/preferences/lab_flags.go
@@ -6,15 +6,17 @@ package preferences
 // apps/desktop/src/shared/featureFlags/catalog.ts and must carry identical
 // keys and defaults. See docs/conventions/feature-flags.md.
 const (
-	LabFlagAutomationRules = "lab.automationRules"
+	LabFlagAutomationRules  = "lab.automationRules"
+	LabFlagAgentSessionFork = "lab.agentSessionFork"
 	// Durable key for Early Access agent-integration visibility (Agents directory).
 	LabFlagPreviewAgents = "lab.previewAgents"
 )
 
 // labFlagDefaults is fail-closed: every Lab flag defaults to off.
 var labFlagDefaults = map[string]bool{
-	LabFlagAutomationRules: false,
-	LabFlagPreviewAgents:   false,
+	LabFlagAutomationRules:  false,
+	LabFlagAgentSessionFork: false,
+	LabFlagPreviewAgents:    false,
 }
 
 // IsLabFlag reports whether key is a registered Lab flag.

--- a/services/tuttid/biz/preferences/lab_flags_test.go
+++ b/services/tuttid/biz/preferences/lab_flags_test.go
@@ -5,6 +5,7 @@ import "testing"
 func TestLabFlagRegistryKeysAndDefaults(t *testing.T) {
 	keys := []string{
 		LabFlagAutomationRules,
+		LabFlagAgentSessionFork,
 		LabFlagPreviewAgents,
 	}
 	if len(labFlagDefaults) != len(keys) {
@@ -35,6 +36,7 @@ func TestIsLabFlagRejectsUnregisteredKeys(t *testing.T) {
 func TestIsLabFlagEnabledFailsClosed(t *testing.T) {
 	for _, key := range []string{
 		LabFlagAutomationRules,
+		LabFlagAgentSessionFork,
 		LabFlagPreviewAgents,
 	} {
 		if IsLabFlagEnabled(nil, key) {


### PR DESCRIPTION
## Summary

- add a default-off `lab.agentSessionFork` Lab preference with localized Desktop settings
- hide Session Fork actions unless the host opt-in is enabled and enforce the same gate for tuttid Fork writes
- keep existing lineage, operation reads, and acknowledgements available while the experiment is off
- document the product gate without changing the Host-owned Fork lifecycle or HTTP contract

## Verification

- `pnpm check:changed -- --failed-only` (17 lanes passed; 11 run, 6 reused)
- `pnpm --filter @tutti-os/desktop build`
- `cd services/tuttid && go build ./...`
- focused Desktop, AgentGUI, tuttid API, and preferences tests
- manual Desktop development startup with tuttid and Agent providers ready

## Checklist

- [x] This change does not alter Agent lifecycle semantics; the Host Fork saga and conformance contract are unchanged.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior changed.
- [x] README/CONTRIBUTING language variants are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] The commit is signed off with DCO.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1794" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->