### PR TITLE
fix(agent): require tutti-agent 0.0.10

### DIFF
--- a/packages/agent/daemon/providerregistry/providers.go
+++ b/packages/agent/daemon/providerregistry/providers.go
@@ -9,8 +9,8 @@ const (
 	CursorTargetID               = "local:cursor"
 	TuttiAgentProviderID         = canonical.TuttiAgentProviderID
 	TuttiAgentTargetID           = "local:tutti-agent"
-	TuttiAgentMinVersion         = "0.0.8"
-	TuttiAgentRecommendedVersion = "0.0.8"
+	TuttiAgentMinVersion         = "0.0.10"
+	TuttiAgentRecommendedVersion = "0.0.10"
 	NexightProviderID            = canonical.NexightProviderID
 	NexightTargetID              = "local:nexight"
 	OpenClawProviderID           = canonical.OpenClawProviderID

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -156,7 +156,7 @@ func TestDefaultRegistryUsesTuttiAgentManagedNPMInstaller(t *testing.T) {
 }
 
 func TestServiceListUsesDescriptorOwnedDaemonLoginAction(t *testing.T) {
-	service, _ := updateTestService(t, "0.0.8")
+	service, _ := updateTestService(t, "0.0.10")
 
 	snapshot, err := service.List(context.Background(), ListInput{Providers: []string{"tutti-agent"}})
 	if err != nil {
@@ -1999,7 +1999,7 @@ func TestServiceListUsesManagedNodeForTuttiAgentVersionProbe(t *testing.T) {
 	writeExecutable(
 		t,
 		filepath.Join(runtimeRoot, "node", "bin", nodeBinaryNameForTest()),
-		"#!/bin/sh\necho 'tutti-agent 0.0.8'\n",
+		"#!/bin/sh\necho 'tutti-agent 0.0.10'\n",
 	)
 
 	service := probeTestService(home)
@@ -2019,8 +2019,8 @@ func TestServiceListUsesManagedNodeForTuttiAgentVersionProbe(t *testing.T) {
 		t.Fatalf("List() error = %v", err)
 	}
 	status := onlyStatus(t, snapshot)
-	if status.CLI.Version != "0.0.8" {
-		t.Fatalf("CLI.Version = %q, want 0.0.8", status.CLI.Version)
+	if status.CLI.Version != "0.0.10" {
+		t.Fatalf("CLI.Version = %q, want 0.0.10", status.CLI.Version)
 	}
 	if status.Availability.Status != AvailabilityReady {
 		t.Fatalf(

--- a/services/tuttid/service/agentstatus/service_update_test.go
+++ b/services/tuttid/service/agentstatus/service_update_test.go
@@ -69,8 +69,8 @@ func TestTuttiAgentBelowMinimumRequiresManagedInstall(t *testing.T) {
 	if status.Availability.Status != AvailabilityNotInstalled || status.Availability.ReasonCode != "cli_version_unsupported" {
 		t.Fatalf("Availability = %#v, want minimum-version repair", status.Availability)
 	}
-	if status.CLI.Version != "0.0.2" || status.CLI.MinVersion != "0.0.8" {
-		t.Fatalf("CLI = %#v, want current 0.0.2 and minimum 0.0.8", status.CLI)
+	if status.CLI.Version != "0.0.2" || status.CLI.MinVersion != "0.0.10" {
+		t.Fatalf("CLI = %#v, want current 0.0.2 and minimum 0.0.10", status.CLI)
 	}
 	if !hasProviderAction(status.Actions, ActionInstall) {
 		t.Fatalf("Actions = %#v, want install", status.Actions)
@@ -116,7 +116,7 @@ func TestTuttiAgentUnknownVersionFailsClosed(t *testing.T) {
 			if status.Availability.Status != AvailabilityNotInstalled || status.Availability.ReasonCode != "cli_version_unsupported" {
 				t.Fatalf("Availability = %#v, want unknown-version repair", status.Availability)
 			}
-			if status.CLI.Version != "" || status.CLI.MinVersion != "0.0.8" || !hasProviderAction(status.Actions, ActionInstall) {
+			if status.CLI.Version != "" || status.CLI.MinVersion != "0.0.10" || !hasProviderAction(status.Actions, ActionInstall) {
 				t.Fatalf("CLI/actions = %#v/%#v, want unknown current version and managed install", status.CLI, status.Actions)
 			}
 
@@ -165,13 +165,13 @@ func TestTuttiAgentVersionFloorPrecedesAdapterFailure(t *testing.T) {
 	if status.Availability.ReasonCode != "cli_version_unsupported" {
 		t.Fatalf("Availability = %#v, want CLI floor before adapter failure", status.Availability)
 	}
-	if status.CLI.Version != "0.0.2" || status.CLI.MinVersion != "0.0.8" {
+	if status.CLI.Version != "0.0.2" || status.CLI.MinVersion != "0.0.10" {
 		t.Fatalf("CLI = %#v, want version evidence retained", status.CLI)
 	}
 }
 
 func TestCompatibleTuttiAgentDoesNotRequireManagedInstall(t *testing.T) {
-	for _, version := range []string{"0.0.8", "0.0.9"} {
+	for _, version := range []string{"0.0.10", "0.0.11"} {
 		t.Run(version, func(t *testing.T) {
 			service, _ := updateTestService(t, version)
 			snapshot, err := service.List(context.Background(), ListInput{Providers: []string{"tutti-agent"}})
@@ -217,10 +217,10 @@ func TestRunInstallActionUpgradesTuttiAgentBelowMinimumAndReprobes(t *testing.T)
 	var commands atomic.Int32
 	service.InstallCommand = func(_ context.Context, input InstallCommandInput) (InstallCommandResult, error) {
 		commands.Add(1)
-		if !strings.Contains(input.Command, "@tutti-os/tutti-agent@0.0.8") {
-			t.Fatalf("install command = %q, want exact managed Tutti Agent 0.0.8 package", input.Command)
+		if !strings.Contains(input.Command, "@tutti-os/tutti-agent@0.0.10") {
+			t.Fatalf("install command = %q, want exact managed Tutti Agent 0.0.10 package", input.Command)
 		}
-		writeUpdateTestCLI(t, binaryPath, "0.0.8")
+		writeUpdateTestCLI(t, binaryPath, "0.0.10")
 		return InstallCommandResult{ExitCode: 0, Stdout: "updated"}, nil
 	}
 
@@ -237,7 +237,7 @@ func TestRunInstallActionUpgradesTuttiAgentBelowMinimumAndReprobes(t *testing.T)
 		t.Fatalf("post-install List() error = %v", err)
 	}
 	status := onlyStatus(t, snapshot)
-	if status.Availability.Status != AvailabilityReady || status.CLI.Version != "0.0.8" {
+	if status.Availability.Status != AvailabilityReady || status.CLI.Version != "0.0.10" {
 		t.Fatalf("post-install status = %#v", status)
 	}
 }


### PR DESCRIPTION
## Summary
- raise the Tutti Agent minimum and recommended versions to 0.0.10
- update daemon version-contract tests for the complete Linux/macOS 0.0.10 npm release

## Validation
- `pnpm check:changed`
- `pnpm check:changed -- --push-ready`
- `pnpm lint:go`
- `go test ./service/agentstatus`
- `go test ./service/agent ./service/agentextension`
- `pnpm build:go`

The first full `pnpm test:go` attempt passed agentstatus but hit unrelated process-timeout flakes in `service/agent` and `service/agentextension`; both failed packages passed on immediate focused rerun (974 tests).

## Documentation impact
No durable documentation impact; this only advances the managed provider release floor and its version-contract tests.