### PR TITLE
fix(agent-gui): restore projected message streaming

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -598,6 +598,10 @@ disable submission, but must not change editor editability.
   command. Concurrent AgentGUI surfaces subscribe through exact
   Session-family or target selectors; a selector preserves its selected
   reference when another root Session changes
+- AgentGUI transcript presentation subscribes to projected messages for only
+  the selected root Session and its current child Sessions. This projection
+  includes optimistic `message_delta` text before durable confirmation, while
+  preserving message-array references for every unrelated Session
 - whole-workspace `AgentActivitySnapshot` projections remain valid for bounded
   aggregate reads, but do not belong in high-frequency AgentGUI render paths.
   Event callbacks that need current canonical data read the engine snapshot at
@@ -621,6 +625,9 @@ disable submission, but must not change editor editability.
 - newest-to-oldest reads attach their authoritative message-window coverage to
   the same snapshot intent; incremental/realtime updates preserve that coverage
 - realtime authoritative entities use upsert intents
+- optimistic `message_delta` updates invalidate the exact Session projection;
+  they do not write an unconfirmed message into canonical Engine state.
+  Terminal `message_update` reconciliation replaces that optimistic projection
 - an authoritative Session detail result enters through
   `session/detailSnapshotReceived`; `agent-activity-core` expands the root
   Session, Turns, child Sessions, and optional message coverage in one engine

--- a/docs/conventions/testing.md
+++ b/docs/conventions/testing.md
@@ -150,10 +150,12 @@ renderer analysis, and report rendering stay scenario-neutral.
 `concurrent-agent-streaming` selects two settled root Sessions, restores them
 into two non-overlapping visible AgentGUI windows, and routes each through an
 isolated fake Cursor ACP Session. Both Composer forms submit in one renderer
-task. The scenario requires both windows to enter working state, produce
-repeated transcript mutations, and settle before the trace tail. It reports
-the sampled conversation-projection and streaming-text functions without
-setting a cross-device timing threshold.
+task. The scenario requires both windows to enter working state, render at
+least three distinct intermediate assistant-text lengths, reach the final
+fixture chunk, and settle before the trace tail. Generic status or spinner DOM
+mutations do not satisfy the streaming assertion. It reports the sampled
+conversation-projection and streaming-text functions without setting a
+cross-device timing threshold.
 
 `virtualized-streaming` and `virtualized-scroll-locator` require one root
 Session with at least thirty settled Turns. They change only the isolated copy

--- a/packages/agent/activity-core/src/optimisticMessageOverlay.ts
+++ b/packages/agent/activity-core/src/optimisticMessageOverlay.ts
@@ -60,16 +60,28 @@ interface OptimisticEntry {
   explicitlyTerminal: boolean;
 }
 
+interface ProjectionCacheEntry {
+  canonicalMessages: readonly AgentActivityMessage[];
+  projectedMessages: AgentActivityMessage[];
+  revision: number;
+}
+
 export function createAgentActivityOptimisticMessageOverlay(): AgentActivityOptimisticMessageOverlay {
   const optimistic = new Map<string, OptimisticEntry>();
   const canonical = new Map<string, AgentActivityMessage>();
+  const projectionCache = new Map<string, ProjectionCacheEntry>();
+  const scopeRevisions = new Map<string, number>();
 
   return {
     apply(event) {
       if (event.eventType !== "message_delta") {
         return { applied: false, needsReconcile: false };
       }
-      return applyMessageDelta(event);
+      const result = applyMessageDelta(event);
+      if (result.applied) {
+        markScopeChanged(event);
+      }
+      return result;
     },
 
     reconcile(scope, messages) {
@@ -93,21 +105,31 @@ export function createAgentActivityOptimisticMessageOverlay(): AgentActivityOpti
           optimistic.delete(key);
         }
       }
+      markScopeChanged(scope);
     },
 
     reset(scope) {
       const prefix = scopePrefix(scope);
       deleteScopeEntries(optimistic, prefix);
       deleteScopeEntries(canonical, prefix);
+      markScopeChanged(scope);
     },
 
     project(scope, messages) {
+      const prefix = scopePrefix(scope);
+      const revision = scopeRevisions.get(prefix) ?? 0;
+      const cached = projectionCache.get(prefix);
+      if (
+        cached?.canonicalMessages === messages &&
+        cached.revision === revision
+      ) {
+        return cached.projectedMessages;
+      }
       const normalized = normalizeCanonicalMessages(scope, messages);
       const byKey = new Map<string, AgentActivityMessage>();
       for (const message of normalized) {
         byKey.set(messageKey(message), cloneMessage(message));
       }
-      const prefix = scopePrefix(scope);
       for (const [key, entry] of optimistic) {
         if (!key.startsWith(prefix)) {
           continue;
@@ -120,9 +142,23 @@ export function createAgentActivityOptimisticMessageOverlay(): AgentActivityOpti
             : cloneMessage(entry.message)
         );
       }
-      return [...byKey.values()].sort(compareAgentActivityMessages);
+      const projectedMessages = [...byKey.values()].sort(
+        compareAgentActivityMessages
+      );
+      projectionCache.set(prefix, {
+        canonicalMessages: messages,
+        projectedMessages,
+        revision
+      });
+      return projectedMessages;
     }
   };
+
+  function markScopeChanged(scope: AgentActivityOptimisticMessageScope): void {
+    const prefix = scopePrefix(scope);
+    scopeRevisions.set(prefix, (scopeRevisions.get(prefix) ?? 0) + 1);
+    projectionCache.delete(prefix);
+  }
 
   function applyMessageDelta(
     event: AgentActivityMessageDeltaEvent

--- a/packages/agent/activity-core/src/workspaceEventCoordinator.test.ts
+++ b/packages/agent/activity-core/src/workspaceEventCoordinator.test.ts
@@ -86,6 +86,51 @@ test("projects message deltas and clears them on authoritative deletion", () => 
   harness.engine.dispose();
 });
 
+test("preserves unrelated Session message projections during an optimistic delta", () => {
+  const harness = createHarness();
+  harness.engine.dispatch({
+    messages: [
+      message("session-a", "message-a", "canonical a"),
+      message("session-b", "message-b", "canonical b")
+    ],
+    type: "message/snapshotReceived",
+    workspaceId: "workspace-1"
+  });
+  const before = harness.coordinator.project(harness.readCanonicalSnapshot());
+
+  harness.coordinator.ingestEvent({
+    workspaceId: "workspace-1",
+    agentSessionId: "session-a",
+    eventType: "message_delta",
+    data: {
+      workspaceId: "workspace-1",
+      agentSessionId: "session-a",
+      messageId: "message-a",
+      turnId: "turn-1",
+      role: "assistant",
+      kind: "text",
+      occurredAtUnixMs: 10,
+      content: { operation: "set", value: "canonical a live" }
+    }
+  });
+
+  const after = harness.coordinator.project(harness.readCanonicalSnapshot());
+  assert.notEqual(
+    after.sessionMessagesById["session-a"],
+    before.sessionMessagesById["session-a"]
+  );
+  assert.equal(
+    after.sessionMessagesById["session-a"]?.[0]?.payload.text,
+    "canonical a live"
+  );
+  assert.equal(
+    after.sessionMessagesById["session-b"],
+    before.sessionMessagesById["session-b"]
+  );
+  harness.coordinator.dispose();
+  harness.engine.dispose();
+});
+
 test("reconnect hydrates the workspace, priority session, and cached messages", () => {
   const harness = createHarness();
   harness.engine.dispatch({
@@ -168,6 +213,21 @@ test("reconnect hydrates the workspace, priority session, and cached messages", 
   harness.coordinator.dispose();
   harness.engine.dispose();
 });
+
+function message(agentSessionId: string, messageId: string, text: string) {
+  return {
+    workspaceId: "workspace-1",
+    agentSessionId,
+    messageId,
+    version: 1,
+    sequence: 1,
+    turnId: "turn-1",
+    role: "assistant" as const,
+    kind: "text",
+    payload: { text },
+    occurredAtUnixMs: 1
+  };
+}
 
 test("invalid wire delta stays inside the coordinator and requests reconcile", () => {
   const harness = createHarness();

--- a/packages/agent/activity-core/src/workspaceEventCoordinator.ts
+++ b/packages/agent/activity-core/src/workspaceEventCoordinator.ts
@@ -15,6 +15,8 @@ import type {
   EngineConnectionStatus
 } from "./engine/types.ts";
 
+const EMPTY_MESSAGES: readonly AgentActivityMessage[] = [];
+
 export interface AgentActivityWorkspaceReconcileKey {
   agentSessionId?: string;
   workspaceId: string;
@@ -172,7 +174,7 @@ export function createAgentActivityWorkspaceEventCoordinator({
     for (const agentSessionId of sessionIds) {
       sessionMessagesById[agentSessionId] = overlay.project(
         { agentSessionId, workspaceId: normalizedWorkspaceId },
-        canonical.sessionMessagesById[agentSessionId] ?? []
+        canonical.sessionMessagesById[agentSessionId] ?? EMPTY_MESSAGES
       );
     }
     const projected = { ...canonical, sessionMessagesById };

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationDetail.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationDetail.spec.tsx
@@ -42,6 +42,7 @@ function conversationDetailInput(
     draftByScopeKey: {},
     errorFor: () => null,
     providerComposerOptions: null,
+    projectedSessionMessagesById: {},
     selectedComposerTargetData: {
       agentTargetId: null,
       data: {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationDetail.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationDetail.ts
@@ -82,6 +82,9 @@ interface UseAgentGUIConversationDetailInput {
   >[0];
   selectedComposerTargetData: AgentGUIComposerTargetData;
   selectedProjectPath: string | null;
+  projectedSessionMessagesById: Readonly<
+    Record<string, readonly AgentActivityMessage[]>
+  >;
   sessionEngine: AgentSessionEngine;
   workspaceId: string;
   workspacePath: string;
@@ -174,16 +177,16 @@ export function useAgentGUIConversationDetail(
       conversation: projectionConversation,
       canonicalSession: input.activeSessionFamily.rootSession,
       childSessions: input.activeSessionFamily.childSessions,
-      childMessagesBySessionId: input.activeSessionFamily.messagesBySessionId,
+      childMessagesBySessionId: input.projectedSessionMessagesById,
       workspaceRoot: input.workspacePath,
       avoidGroupingEdits: input.avoidGroupingEdits
     });
   }, [
     input.activeTimelineItems,
     input.activeSessionFamily.childSessions,
-    input.activeSessionFamily.messagesBySessionId,
     input.activeSessionFamily.rootSession,
     input.avoidGroupingEdits,
+    input.projectedSessionMessagesById,
     input.workspacePath,
     projectionConversation
   ]);

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -340,6 +340,7 @@ export function useAgentGUINodeController({
     agentActivityRuntimeOrigin,
     dataRef,
     isMountedRef,
+    sessionFamily: activeSessionFamily,
     sessionEngine,
     workspaceId
   });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionDetailTransport.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionDetailTransport.ts
@@ -1,11 +1,15 @@
 import {
   selectSessionMessages,
   selectSessionMessageWindow,
+  type AgentSessionFamilySnapshot,
   type AgentSessionEngine
 } from "@tutti-os/agent-activity-core";
 import type { RefObject } from "react";
 import { useCallback } from "react";
-import type { AgentActivityRuntime } from "../../../agentActivityRuntime";
+import {
+  useAgentActivitySessionMessages,
+  type AgentActivityRuntime
+} from "../../../agentActivityRuntime";
 import { useAgentSessionControllerState } from "../../../contexts/workspace/presentation/renderer/agentSessions/useAgentSessionControllerState";
 import type { AgentGUINodeData } from "../../../types";
 import {
@@ -22,6 +26,7 @@ export function useAgentGUISessionDetailTransport(input: {
   agentActivityRuntimeOrigin: string;
   dataRef: RefObject<AgentGUINodeData>;
   isMountedRef: RefObject<boolean>;
+  sessionFamily: AgentSessionFamilySnapshot;
   sessionEngine: AgentSessionEngine;
   workspaceId: string;
 }) {
@@ -32,6 +37,7 @@ export function useAgentGUISessionDetailTransport(input: {
     agentActivityRuntimeOrigin,
     dataRef,
     isMountedRef,
+    sessionFamily,
     sessionEngine,
     workspaceId
   } = input;
@@ -47,6 +53,18 @@ export function useAgentGUISessionDetailTransport(input: {
     sessionEngine,
     (engineState) => selectSessionMessages(engineState, activeConversationId)
   );
+  const projectedSessionMessagesById = useAgentActivitySessionMessages(
+    workspaceId,
+    [
+      activeConversationId,
+      sessionFamily.rootSession?.agentSessionId,
+      ...sessionFamily.childSessions.map((session) => session.agentSessionId)
+    ]
+  );
+  const activeProjectedMessages = activeConversationId
+    ? (projectedSessionMessagesById[activeConversationId] ??
+      activeCanonicalMessages)
+    : activeCanonicalMessages;
   const activeCanonicalWindow = useEngineSelector(
     sessionEngine,
     (engineState) =>
@@ -54,17 +72,19 @@ export function useAgentGUISessionDetailTransport(input: {
   );
   const state = useAgentSessionControllerState(
     sessionViewRef(activeConversationId),
-    activeCanonicalMessages,
+    activeProjectedMessages,
     activeCanonicalWindow
   );
   const resolveSessionMessages = useCallback(
     (agentSessionId: string | null | undefined) => {
       const normalized = agentSessionId?.trim() ?? "";
-      return normalized
-        ? selectSessionMessages(sessionEngine.getSnapshot(), normalized)
-        : [];
+      if (!normalized) return [];
+      return (
+        projectedSessionMessagesById[normalized] ??
+        selectSessionMessages(sessionEngine.getSnapshot(), normalized)
+      );
     },
-    [sessionEngine]
+    [projectedSessionMessagesById, sessionEngine]
   );
   const loadSessionState = useCallback(
     (agentSessionId: string) => {
@@ -131,6 +151,7 @@ export function useAgentGUISessionDetailTransport(input: {
     loadSelectedConversationMessages: paging.loadInitialMessages,
     loadSessionState,
     markSelectedConversationDetailPending,
+    projectedSessionMessagesById,
     resolveSessionMessages,
     setActiveMessageSession: paging.setActiveSession,
     sessionViewRef

--- a/packages/agent/gui/agentActivityRuntime.sessionMessages.spec.tsx
+++ b/packages/agent/gui/agentActivityRuntime.sessionMessages.spec.tsx
@@ -1,0 +1,134 @@
+import { act, renderHook } from "@testing-library/react";
+import type {
+  AgentActivityMessage,
+  AgentActivitySnapshot
+} from "@tutti-os/agent-activity-core";
+import type { PropsWithChildren } from "react";
+import { describe, expect, it } from "vitest";
+import {
+  AgentActivityRuntimeProvider,
+  useAgentActivitySessionMessages,
+  type AgentActivityRuntime
+} from "./agentActivityRuntime";
+
+describe("useAgentActivitySessionMessages", () => {
+  it("delivers projected streaming text without rendering an unrelated Session", () => {
+    const messagesA = [message("session-a", "partial")];
+    const messagesB = [message("session-b", "settled")];
+    const store = createRuntimeStore(
+      snapshot({ "session-a": messagesA, "session-b": messagesB })
+    );
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <AgentActivityRuntimeProvider runtime={store.runtime}>
+        {children}
+      </AgentActivityRuntimeProvider>
+    );
+    let rendersA = 0;
+    let rendersB = 0;
+    const renderedA = renderHook(
+      () => {
+        rendersA += 1;
+        return useAgentActivitySessionMessages("workspace-1", ["session-a"]);
+      },
+      { wrapper }
+    );
+    renderHook(
+      () => {
+        rendersB += 1;
+        return useAgentActivitySessionMessages("workspace-1", ["session-b"]);
+      },
+      { wrapper }
+    );
+    const initialRendersA = rendersA;
+    const initialRendersB = rendersB;
+
+    act(() => {
+      store.publish(
+        snapshot({
+          "session-a": [message("session-a", "partial text")],
+          "session-b": messagesB
+        })
+      );
+    });
+
+    expect(renderedA.result.current["session-a"]?.[0]?.payload.text).toBe(
+      "partial text"
+    );
+    expect(rendersA).toBeGreaterThan(initialRendersA);
+    expect(rendersB).toBe(initialRendersB);
+  });
+
+  it("subscribes to projected messages for child Sessions in the family", () => {
+    const rootMessages = [message("root", "root text")];
+    const store = createRuntimeStore(
+      snapshot({
+        root: rootMessages,
+        child: [message("child", "child partial")]
+      })
+    );
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <AgentActivityRuntimeProvider runtime={store.runtime}>
+        {children}
+      </AgentActivityRuntimeProvider>
+    );
+    const rendered = renderHook(
+      () => useAgentActivitySessionMessages("workspace-1", ["root", "child"]),
+      { wrapper }
+    );
+
+    act(() => {
+      store.publish(
+        snapshot({
+          root: rootMessages,
+          child: [message("child", "child partial text")]
+        })
+      );
+    });
+
+    expect(rendered.result.current.child?.[0]?.payload.text).toBe(
+      "child partial text"
+    );
+  });
+});
+
+function createRuntimeStore(initial: AgentActivitySnapshot) {
+  let current = initial;
+  const listeners = new Set<() => void>();
+  const runtime = {
+    getSnapshot: () => current,
+    origin: "test",
+    subscribe(_workspaceId: string, listener: () => void) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    }
+  } as unknown as AgentActivityRuntime;
+  return {
+    publish(next: AgentActivitySnapshot) {
+      current = next;
+      for (const listener of listeners) listener();
+    },
+    runtime
+  };
+}
+
+function snapshot(
+  sessionMessagesById: Record<string, readonly AgentActivityMessage[]>
+): AgentActivitySnapshot {
+  return { sessionMessagesById } as AgentActivitySnapshot;
+}
+
+function message(agentSessionId: string, text: string): AgentActivityMessage {
+  return {
+    agentSessionId,
+    kind: "text",
+    messageId: `message-${agentSessionId}`,
+    occurredAtUnixMs: 1,
+    payload: { text },
+    role: "assistant",
+    sequence: 1,
+    status: "streaming",
+    turnId: "turn-1",
+    version: 1,
+    workspaceId: "workspace-1"
+  };
+}

--- a/packages/agent/gui/agentActivityRuntime.tsx
+++ b/packages/agent/gui/agentActivityRuntime.tsx
@@ -1,6 +1,7 @@
 import {
   createContext,
   useContext,
+  useMemo,
   useSyncExternalStore,
   type JSX,
   type PropsWithChildren
@@ -11,6 +12,7 @@ import type {
   AgentActivityComposerOptions,
   AgentActivityGoalControlInput,
   AgentActivityGoalControlResult,
+  AgentActivityMessage,
   AgentActivityCreateSessionInput,
   AgentActivityDeleteSessionInput,
   AgentActivityDeleteSessionResult,
@@ -50,6 +52,13 @@ import type {
   AgentConversationRailSessionsPageResult,
   AgentConversationRailUserProject
 } from "./agentConversationRailContracts";
+import { useEngineSelector } from "./shared/engine/useEngineSelector";
+
+const EMPTY_SESSION_MESSAGES: readonly AgentActivityMessage[] = [];
+
+export type AgentActivitySessionMessages = Readonly<
+  Record<string, readonly AgentActivityMessage[]>
+>;
 
 export interface AgentActivityRuntimeUpdateSessionSettingsResult {
   agentSessionId: string;
@@ -475,6 +484,35 @@ export function useAgentActivitySnapshot(
   );
 }
 
+export function useAgentActivitySessionMessages(
+  workspaceId: string,
+  agentSessionIds: readonly (string | null | undefined)[]
+): AgentActivitySessionMessages {
+  const runtime = useAgentActivityRuntime();
+  const normalizedWorkspaceId = workspaceId.trim();
+  const sessionIdsKey = agentSessionIds
+    .map((agentSessionId) => agentSessionId?.trim() ?? "")
+    .filter(Boolean)
+    .join("\u0000");
+  const normalizedSessionIds = useMemo(
+    () => [...new Set(sessionIdsKey.split("\u0000").filter(Boolean))],
+    [sessionIdsKey]
+  );
+  const workspaceStore = useMemo(
+    () => ({
+      getSnapshot: () => runtime.getSnapshot(normalizedWorkspaceId),
+      subscribe: (listener: () => void) =>
+        runtime.subscribe(normalizedWorkspaceId, listener)
+    }),
+    [normalizedWorkspaceId, runtime]
+  );
+  const selectMessages = useMemo(
+    () => createSessionMessagesSelector(normalizedSessionIds),
+    [normalizedSessionIds]
+  );
+  return useEngineSelector(workspaceStore, selectMessages);
+}
+
 export function resetAgentActivityRuntimeForTests(): void {
   if (process.env.NODE_ENV === "test") {
     testAgentActivityRuntimeHolder.set(null);
@@ -487,6 +525,30 @@ export function setAgentActivityRuntimeForTests(
   if (process.env.NODE_ENV === "test") {
     testAgentActivityRuntimeHolder.set(runtime);
   }
+}
+
+function createSessionMessagesSelector(
+  agentSessionIds: readonly string[]
+): (snapshot: AgentActivitySnapshot) => AgentActivitySessionMessages {
+  let previous: AgentActivitySessionMessages = {};
+  return (snapshot) => {
+    const next = Object.fromEntries(
+      agentSessionIds.map((agentSessionId) => [
+        agentSessionId,
+        snapshot.sessionMessagesById[agentSessionId] ?? EMPTY_SESSION_MESSAGES
+      ])
+    );
+    if (
+      Object.keys(previous).length === agentSessionIds.length &&
+      agentSessionIds.every(
+        (agentSessionId) => previous[agentSessionId] === next[agentSessionId]
+      )
+    ) {
+      return previous;
+    }
+    previous = next;
+    return previous;
+  };
 }
 
 function getTestAgentActivityRuntime(): AgentActivityRuntime | null {

--- a/packages/agent/gui/index.ts
+++ b/packages/agent/gui/index.ts
@@ -176,12 +176,14 @@ export {
   AgentActivityRuntimeProvider,
   resetAgentActivityRuntimeForTests,
   setAgentActivityRuntimeForTests,
+  useAgentActivitySessionMessages,
   useAgentActivitySnapshot,
   useAgentActivityRuntime,
   useOptionalAgentActivityRuntime
 } from "./agentActivityRuntime";
 export type {
   AgentActivityRuntime,
+  AgentActivitySessionMessages,
   AgentActivityRuntimeListSessionMessagesInput,
   AgentActivityRuntimeProviderProps,
   AgentActivityRuntimePromptContentBlock,

--- a/tools/scripts/agent-gui-concurrent-streaming-performance-scenario.mjs
+++ b/tools/scripts/agent-gui-concurrent-streaming-performance-scenario.mjs
@@ -33,7 +33,7 @@ export const concurrentAgentStreamingScenario = {
     },
     {
       key: "bothMutated",
-      label: "both transcripts first mutated",
+      label: "both transcripts first rendered streamed text",
       marker: markers.bothMutated
     },
     {
@@ -69,8 +69,8 @@ export const concurrentAgentStreamingScenario = {
           passed: result.startedCount === 2 && result.submitDeltaMs <= 5
         },
         {
-          name: "both transcripts mutated repeatedly",
-          passed: result.mutationBatches.every((count) => count >= 8)
+          name: "both transcripts rendered intermediate streamed text",
+          passed: result.streamingTextSamples.every((count) => count >= 3)
         },
         {
           name: "both streams settled",
@@ -95,9 +95,17 @@ export const concurrentAgentStreamingScenario = {
           label: "DOM mutations",
           value: result.mutations.join(" + ")
         },
+        {
+          label: "Streaming text samples",
+          value: result.streamingTextSamples.join(" + ")
+        },
+        {
+          label: "Final streaming text lengths",
+          value: result.finalStreamingTextLengths.join(" + ")
+        },
         { label: "Provider", value: "two isolated fake Cursor ACP sessions" }
       ],
-      "two non-overlapping AgentGUI bodies show different restored sessions; both forms submit in one renderer task; each local ACP stream produces at least eight MutationObserver batches and settles"
+      "two non-overlapping AgentGUI bodies show different restored sessions; both forms submit in one renderer task; each local ACP stream renders at least three distinct intermediate text lengths, reaches the final chunk, and settles"
     );
   }
 };
@@ -377,15 +385,35 @@ async function executeConcurrentAgentStreaming(context, prepared, options) {
         windowState.state = {
           firstMutation: false,
           mutationBatches: 0,
-          mutations: 0
+          mutations: 0,
+          streamingTextLengths: []
         };
+        const sampleStreamingText = () => {
+          const text =
+            [...windowState.timeline.querySelectorAll(
+              '.agent-gui-conversation__assistant-message-flow'
+            )]
+              .map((element) => element.textContent ?? '')
+              .find((value) =>
+                value.includes('Virtualized streaming fixture chunk')
+              ) ?? '';
+          const lengths = windowState.state.streamingTextLengths;
+          if (text.length > 0 && lengths.at(-1) !== text.length) {
+            lengths.push(text.length);
+          }
+          return text;
+        };
+        windowState.sampleStreamingText = sampleStreamingText;
         const observer = new MutationObserver((records) => {
           windowState.state.mutationBatches += 1;
           windowState.state.mutations += records.length;
           windowState.state.firstMutation = true;
+          sampleStreamingText();
           if (
             runtime.windows.every(
-              (candidate) => candidate.state.firstMutation
+              (candidate) =>
+                candidate.state.firstMutation &&
+                candidate.state.streamingTextLengths.length > 0
             ) &&
             !runtime.bothMutated
           ) {
@@ -462,13 +490,29 @@ async function executeConcurrentAgentStreaming(context, prepared, options) {
         state?.windows?.map(({ state: windowState }) =>
           windowState.mutations
         ) ?? [];
+      const streamingTextSamples =
+        state?.windows?.map(({ state: windowState }) =>
+          windowState.streamingTextLengths.length
+        ) ?? [];
+      const finalStreamingTexts =
+        state?.windows?.map((windowState) =>
+          windowState.sampleStreamingText()
+        ) ?? [];
       return {
         ready:
           settledCount === 2 &&
           mutationBatches.length === 2 &&
-          mutationBatches.every((count) => count >= 8),
+          mutationBatches.every((count) => count >= 8) &&
+          streamingTextSamples.every((count) => count >= 3) &&
+          finalStreamingTexts.every((text) =>
+            text.includes('Virtualized streaming fixture chunk 48')
+          ),
+        finalStreamingTextLengths: finalStreamingTexts.map(
+          (text) => text.length
+        ),
         mutationBatches,
         mutations,
+        streamingTextSamples,
         settledCount
       };
     })()`,
@@ -490,6 +534,8 @@ async function executeConcurrentAgentStreaming(context, prepared, options) {
   return {
     mutationBatches: settled.mutationBatches,
     mutations: settled.mutations,
+    finalStreamingTextLengths: settled.finalStreamingTextLengths,
+    streamingTextSamples: settled.streamingTextSamples,
     settledCount: settled.settledCount,
     startedCount: started.startedCount,
     submitDeltaMs: submit.submitDeltaMs


### PR DESCRIPTION
## Summary
- subscribe AgentGUI transcripts to projected messages for the selected root and child Session family
- preserve unrelated Session message references when optimistic deltas arrive
- strengthen the concurrent headless performance scenario to require intermediate assistant text
- document the optimistic projection and exact-Session subscription contract

Follow-up to #1739. That render-isolation change correctly removed the whole-workspace snapshot from the hot path, but left transcript bodies reading canonical Engine messages only. Optimistic `message_delta` text therefore stayed invisible until terminal `message_update`.

## Tests
- `node --test --experimental-strip-types src/workspaceEventCoordinator.test.ts src/optimisticMessageOverlay.test.ts`
- `pnpm --filter @tutti-os/agent-gui exec vitest run agentActivityRuntime.sessionMessages.spec.tsx agent-gui/agentGuiNode/controller/useAgentGUIConversationDetail.spec.tsx agent-gui/agentGuiNode/controller/useAgentGUISessionFamilySubscription.spec.tsx`
- `pnpm perf:agent-gui -- --scenario concurrent-agent-streaming`
- pre-push: `pnpm check:changed -- --push-ready` (15 lanes)

## Notes
- the headless scenario captured 35 distinct intermediate text lengths in each AgentGUI window and reached the final fixture chunk
- performance timing remains report-only because this capture has no comparable baseline

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1803" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->