### PR TITLE
fix(agent-gui): keep optimistic messages out of cursor

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionDetailTransport.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionDetailTransport.spec.tsx
@@ -1,0 +1,80 @@
+import { renderHook } from "@testing-library/react";
+import type {
+  AgentActivityMessage,
+  AgentActivitySnapshot
+} from "@tutti-os/agent-activity-core";
+import type { PropsWithChildren, RefObject } from "react";
+import { describe, expect, it } from "vitest";
+import {
+  AgentActivityRuntimeProvider,
+  type AgentActivityRuntime
+} from "../../../agentActivityRuntime";
+import { createTestAgentSessionEngine } from "../../../shared/testing/createTestAgentSessionEngine";
+import type { AgentGUINodeData } from "../../../types";
+import { useAgentGUISessionDetailTransport } from "./useAgentGUISessionDetailTransport";
+
+describe("useAgentGUISessionDetailTransport", () => {
+  it("renders optimistic text without treating its version as history coverage", () => {
+    const optimisticMessage = message();
+    const runtime = createRuntime({
+      sessionMessagesById: { "session-1": [optimisticMessage] }
+    } as unknown as AgentActivitySnapshot);
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <AgentActivityRuntimeProvider runtime={runtime}>
+        {children}
+      </AgentActivityRuntimeProvider>
+    );
+    const rendered = renderHook(
+      () =>
+        useAgentGUISessionDetailTransport({
+          activeConversationId: "session-1",
+          activeConversationIdRef: ref("session-1"),
+          agentActivityRuntime: runtime,
+          agentActivityRuntimeOrigin: "test",
+          dataRef: ref({ provider: "codex" } as AgentGUINodeData),
+          isMountedRef: ref(true),
+          sessionEngine: createTestAgentSessionEngine("workspace-1"),
+          sessionFamily: {
+            childSessions: [],
+            messagesBySessionId: {},
+            pendingInteractions: [],
+            rootSession: null
+          },
+          workspaceId: "workspace-1"
+        }),
+      { wrapper }
+    );
+
+    expect(rendered.result.current.activeSessionView).toBeNull();
+    expect(rendered.result.current.resolveSessionMessages("session-1")).toEqual(
+      [optimisticMessage]
+    );
+  });
+});
+
+function createRuntime(snapshot: AgentActivitySnapshot): AgentActivityRuntime {
+  return {
+    getSnapshot: () => snapshot,
+    origin: "test",
+    subscribe: () => () => {}
+  } as unknown as AgentActivityRuntime;
+}
+
+function message(): AgentActivityMessage {
+  return {
+    agentSessionId: "session-1",
+    kind: "text",
+    messageId: "message-1",
+    occurredAtUnixMs: 1,
+    payload: { text: "streaming" },
+    role: "assistant",
+    status: "streaming",
+    turnId: "turn-1",
+    version: 0,
+    workspaceId: "workspace-1"
+  };
+}
+
+function ref<T>(current: T): RefObject<T> {
+  return { current };
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionDetailTransport.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionDetailTransport.ts
@@ -61,10 +61,6 @@ export function useAgentGUISessionDetailTransport(input: {
       ...sessionFamily.childSessions.map((session) => session.agentSessionId)
     ]
   );
-  const activeProjectedMessages = activeConversationId
-    ? (projectedSessionMessagesById[activeConversationId] ??
-      activeCanonicalMessages)
-    : activeCanonicalMessages;
   const activeCanonicalWindow = useEngineSelector(
     sessionEngine,
     (engineState) =>
@@ -72,7 +68,7 @@ export function useAgentGUISessionDetailTransport(input: {
   );
   const state = useAgentSessionControllerState(
     sessionViewRef(activeConversationId),
-    activeProjectedMessages,
+    activeCanonicalMessages,
     activeCanonicalWindow
   );
   const resolveSessionMessages = useCallback(


### PR DESCRIPTION
## Summary
- keep optimistic projected messages available to AgentGUI transcript rendering
- derive message-window fallback state from canonical messages only
- cover a version-0 streaming placeholder with a transport-level regression test

Follow-up to #1803 and [review comment](https://github.com/tutti-os/tutti/pull/1803#discussion_r3674127192).

## Tests
- `pnpm --filter @tutti-os/agent-gui exec vitest run agent-gui/agentGuiNode/controller/useAgentGUISessionDetailTransport.spec.tsx agentActivityRuntime.sessionMessages.spec.tsx agent-gui/agentGuiNode/controller/useAgentGUIConversationDetail.spec.tsx`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- pre-push: `pnpm check:changed -- --push-ready` (12 lanes)

## Notes
- no user-visible behavior changes beyond preventing optimistic version `0` from becoming `oldestLoadedVersion`
- the streaming transcript still reads the projected Session-family message list

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1804" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->