### PR TITLE
fix(agent): enable Tutti Agent by default

### DIFF
--- a/packages/agent/daemon/providerregistry/providers.go
+++ b/packages/agent/daemon/providerregistry/providers.go
@@ -84,7 +84,7 @@ func tuttiAgentDescriptor() ProviderDescriptor {
 			Capabilities: []string{CapabilityImageInput, CapabilitySkills, CapabilityCompact, CapabilityTokenUsage, CapabilityPlanMode, CapabilityInterrupt, CapabilityActiveTurnGuidance, CapabilityModelSwitch, CapabilityModelPlanBinding}, PermissionConfigurable: true, DefaultPermissionModeID: "auto",
 			PermissionModes: []PermissionModeDescriptor{{ID: "read-only", Semantic: "ask-before-write"}, {ID: "auto", Semantic: "auto"}, {ID: "full-access", Semantic: "full-access"}}, ConfigOptionIDs: ComposerConfigOptionIDs{Model: "model", Permission: "mode"},
 		},
-		Target:  TargetDescriptor{ID: TuttiAgentTargetID, LaunchRefType: TargetLaunchRefTypeLocalCLI, Enabled: false, SortOrder: 40},
+		Target:  TargetDescriptor{ID: TuttiAgentTargetID, LaunchRefType: TargetLaunchRefTypeLocalCLI, Enabled: true, SortOrder: 40},
 		Events:  EventsDescriptor{Enabled: true, Aliases: []string{"tutti_agent"}, TurnLifecycleProjection: TurnLifecycleProjectionExplicit},
 		Sidecar: SidecarDescriptor{ExecutionEnvironment: SidecarExecutionEnvironmentLocalIPC},
 		Desktop: DesktopIntegrationDescriptor{Managed: true, ManagedOrder: 4, StatusProbePriority: 4, VisibilityGate: DesktopVisibilityGateTuttiAgent, CommandNetworkAccess: true, InstallBootstrap: true, RefreshOnAccountChange: true, DeveloperLogs: true},

--- a/packages/agent/gui/agentTargets.spec.ts
+++ b/packages/agent/gui/agentTargets.spec.ts
@@ -106,12 +106,6 @@ describe("agent gui provider targets", () => {
         provider: "claude-code"
       },
       {
-        agentTargetId: "local:tutti-agent",
-        disabled: true,
-        label: "Tutti Agent",
-        provider: "tutti-agent"
-      },
-      {
         agentTargetId: "local:nexight",
         disabled: true,
         label: "Nexight",
@@ -287,7 +281,7 @@ describe("agent gui provider targets", () => {
       { disabled: false, provider: "codex" },
       { disabled: false, provider: "claude-code" },
       { disabled: false, provider: "cursor" },
-      { disabled: true, provider: "tutti-agent" },
+      { disabled: false, provider: "tutti-agent" },
       { disabled: false, provider: "opencode" },
       { disabled: true, provider: "nexight" },
       { disabled: true, provider: "openclaw" }

--- a/packages/agent/gui/generated/providerIdentityCatalog.ts
+++ b/packages/agent/gui/generated/providerIdentityCatalog.ts
@@ -99,7 +99,7 @@ export const generatedProviderIdentityCatalog = [
     target: {
       id: "local:tutti-agent",
       launchRefType: "local_cli",
-      enabled: false,
+      enabled: true,
       sortOrder: 40
     },
     desktop: {

--- a/services/tuttid/biz/agenttarget/model_enabled_test.go
+++ b/services/tuttid/biz/agenttarget/model_enabled_test.go
@@ -2,14 +2,14 @@ package agenttarget
 
 import "testing"
 
-func TestDefaultSystemTargetsDisableTuttiAgent(t *testing.T) {
+func TestDefaultSystemTargetsEnableTuttiAgent(t *testing.T) {
 	targets := DefaultSystemTargets(1)
 	for _, target := range targets {
 		if target.ID != IDLocalTuttiAgent {
 			continue
 		}
-		if target.Enabled {
-			t.Fatal("Tutti Agent target is enabled by default, want disabled")
+		if !target.Enabled {
+			t.Fatal("Tutti Agent target is disabled by default, want enabled")
 		}
 		return
 	}


### PR DESCRIPTION
## Summary

- enable the Tutti Agent system target by default in the provider registry
- regenerate the AgentGUI provider catalog and update default-target expectations
- preserve existing persisted target choices; the new default applies when the system target is seeded

## Testing

- `pnpm check:changed -- --push-ready` (19 lanes passed)

## Documentation impact

No durable documentation update is needed; this changes the existing target default without changing APIs, ownership, or configuration surfaces.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1805" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->