### PR TITLE
fix(agent-extension): pin managed uv Python

### DIFF
--- a/docs/architecture/agent-extensions.md
+++ b/docs/architecture/agent-extensions.md
@@ -311,18 +311,21 @@ first resolves a Tutti-managed uv toolchain — a pinned uv version declared in
 archives, SHA-256, and byte sizes — downloaded with the same streaming
 verification as binary artifacts, extracted as a single pinned member, and
 cached under `~/.local/share/tutti/agent-runtimes/_tools/uv/<platform>/<version>`.
-The user machine needs no preinstalled uv or Python. The install runs `uv` by
-bare name with the toolchain directory prepended to PATH and confinement
-variables pointing into the final root: `UV_TOOL_DIR=<installRoot>/tools`,
-`UV_TOOL_BIN_DIR=<installRoot>/bin`, `UV_PYTHON_INSTALL_DIR=<installRoot>/python`,
-a shared content-addressed `UV_CACHE_DIR` under `_tools/uv/cache`, and
-`UV_NO_CONFIG=1`. A previously committed root (valid `activation.json`) is moved
-to `<runtimeIdentity>.previous` before installing and restored on any failure;
-an uncommitted partial root is discarded, and a missing root with a
-self-consistent backup (matching activation identity plus executable
-fingerprint) is restored instead of reinstalling. `activation.json` remains the
-commit marker, and the fingerprint/version/ACP-probe verification chain is
-unchanged.
+The user machine needs no preinstalled uv or Python. The install invokes the
+managed uv executable by absolute path, while also prepending its directory to
+`PATH` for uv subprocesses. Confinement variables point into the final root:
+`UV_TOOL_DIR=<installRoot>/tools`, `UV_TOOL_BIN_DIR=<installRoot>/bin`,
+`UV_PYTHON_INSTALL_DIR=<installRoot>/python`, a shared content-addressed
+`UV_CACHE_DIR` under `_tools/uv/cache`, and `UV_NO_CONFIG=1`. Tutti also sets
+`UV_PYTHON=3.12` and `UV_MANAGED_PYTHON=1`, so package resolution and execution
+use a Tutti-owned Python 3.12 instead of whichever system Python happens to
+appear on the daemon PATH. A previously committed root (valid
+`activation.json`) is moved to `<runtimeIdentity>.previous` before installing
+and restored on any failure; an uncommitted partial root is discarded, and a
+missing root with a self-consistent backup (matching activation identity plus
+executable fingerprint) is restored instead of reinstalling. `activation.json`
+remains the commit marker, and the fingerprint/version/ACP-probe verification
+chain is unchanged.
 
 For both install kinds, Tutti fingerprints the ordinary in-root executable,
 runs the discovery profile's version check, then performs ACP `initialize` and

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -17,6 +17,8 @@ Use the focused runtime index or open one area directly:
 - [Agent Providers And Setup](./agent-provider-setup.md): Provider discovery, installation, authentication, models, configuration, and runtime reachability.
   Includes Codex Model Plan Responses-to-Chat routing and extension
   command/Skill palette hydration failures.
+  Also covers uv-managed Extension installs that accidentally select an
+  incompatible system Python.
   Also covers focus-driven provider CLI scans, repeated Extension Target version
   probes, extension release refresh delaying daemon startup, and CPU spikes.
 - [Agent Sessions And Lifecycle](./agent-session-lifecycle.md): Turn state, activation, planning-mode classification, Tutti workflow response contracts, loading, cancel, goal controls, restore, file-change undo, rail projection, realtime completion provenance, event updates, imports, and performance.

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -1728,6 +1728,43 @@ invalid_grant`. Search `tuttid.log` for
   [AgentTargetSetupGate.tsx](../../../packages/agent/gui/agent-gui/agentGuiNode/view/AgentTargetSetupGate.tsx)
   [agentTargetSetupNotificationController.ts](../../../packages/agent/gui/shared/agentEnv/agentTargetSetupNotificationController.ts)
 
+### Extension uv runtime install selects an incompatible system Python
+
+- Symptom:
+  Reinstalling an Agent Extension runtime fails with
+  `install command uv failed: exit status 1`. Replaying the signed
+  `uv tool install` command reports that the current Python version does not
+  satisfy the package's `Requires-Python` constraint. A common macOS example is
+  the system Python 3.9 being selected for a package that requires Python 3.11
+  or newer.
+- Quick checks:
+  Inspect the Extension manifest's exact uv package pin and the package's
+  `Requires-Python` metadata. Reproduce with the Tutti-managed uv binary and
+  the same `UV_TOOL_DIR`, `UV_TOOL_BIN_DIR`, `UV_PYTHON_INSTALL_DIR`,
+  `UV_CACHE_DIR`, and `UV_NO_CONFIG=1` values. If adding `UV_PYTHON=3.12`
+  resolves the package and downloads managed CPython beneath the install root,
+  the package pin and network path are not the root cause.
+- Root cause:
+  Setting `UV_PYTHON_INSTALL_DIR` confines Python versions that uv downloads,
+  but it does not request an interpreter version. Without an explicit request,
+  `uv tool install` may select the daemon's system Python before it resolves
+  the package metadata, making a valid pinned package appear unsatisfiable.
+- Fix:
+  Tutti's uv install environment requests Python 3.12 with
+  `UV_PYTHON=3.12` and requires uv-managed interpreters with
+  `UV_MANAGED_PYTHON=1`. Keep `UV_PYTHON_INSTALL_DIR` inside the final runtime
+  root so the tool remains isolated and does not depend on or mutate a system
+  Python installation.
+- Validation:
+  Cover the two Python selection variables in the uv installer test. Re-run
+  the real signed package installation in an isolated root, assert the
+  executable reports the pinned package version and Python 3.12, then run the
+  changed-aware repository validation.
+- References:
+  [installer_uv.go](../../../services/tuttid/service/agentextension/installer_uv.go)
+  [installer_uv_test.go](../../../services/tuttid/service/agentextension/installer_uv_test.go)
+  [Agent Extensions](../../architecture/agent-extensions.md)
+
 ### Extension runtime installation stays failed after restart
 
 - Symptom:

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -45,6 +45,7 @@ Provider discovery, installation, authentication, models, configuration, and run
 - [OpenCode effort changes fail with `effort not found`](./agent-provider-setup.md#opencode-effort-changes-fail-with-effort-not-found)
 - [OpenCode model picker has fewer models than the terminal](./agent-provider-setup.md#opencode-model-picker-has-fewer-models-than-the-terminal)
 - [Provider setup notice flashes after switching to an already-connected agent](./agent-provider-setup.md#provider-setup-notice-flashes-after-switching-to-an-already-connected-agent)
+- [Extension uv runtime install selects an incompatible system Python](./agent-provider-setup.md#extension-uv-runtime-install-selects-an-incompatible-system-python)
 - [Extension runtime installation stays failed after restart](./agent-provider-setup.md#extension-runtime-installation-stays-failed-after-restart)
 - [Extension slash palette is empty or ignores its command filter](./agent-provider-setup.md#extension-slash-palette-is-empty-or-ignores-its-command-filter)
 

--- a/services/tuttid/service/agentextension/installer_uv.go
+++ b/services/tuttid/service/agentextension/installer_uv.go
@@ -10,6 +10,8 @@ import (
 	"time"
 )
 
+const managedUVPythonVersion = "3.12"
+
 // executeUVInstallInPlace installs uv-runner runtimes directly into the final
 // install root. Unlike npm/pnpm packages, uv tool environments embed absolute
 // paths (bin symlinks, venv shebangs, pyvenv.cfg) and cannot survive the
@@ -310,12 +312,12 @@ func uvCommittedActivation(
 }
 
 // uvInstallEnvironment builds the hermetic install environment for the uv
-// runner. The managed uv directory is prepended to PATH so the runner is still
-// executed by bare name, and the UV_* variables confine the tool environment,
-// executables, managed CPython, and cache to Tutti-owned directories.
+// runner. The managed uv directory is prepended to PATH for uv subprocesses,
+// and the UV_* variables confine the tool environment, executables, managed
+// CPython, and cache to Tutti-owned directories.
 func uvInstallEnvironment(scratch, installRoot, uvDir, cacheDir string) []string {
 	base := cleanInstallEnvironment(scratch)
-	result := make([]string, 0, len(base)+6)
+	result := make([]string, 0, len(base)+8)
 	pathValue := uvDir
 	for _, entry := range base {
 		key, value, _ := strings.Cut(entry, "=")
@@ -332,5 +334,7 @@ func uvInstallEnvironment(scratch, installRoot, uvDir, cacheDir string) []string
 		"UV_PYTHON_INSTALL_DIR="+filepath.Join(installRoot, "python"),
 		"UV_CACHE_DIR="+cacheDir,
 		"UV_NO_CONFIG=1",
+		"UV_PYTHON="+managedUVPythonVersion,
+		"UV_MANAGED_PYTHON=1",
 	)
 }

--- a/services/tuttid/service/agentextension/installer_uv_test.go
+++ b/services/tuttid/service/agentextension/installer_uv_test.go
@@ -63,6 +63,12 @@ func TestAgentTargetSetupInstallsUVExtensionRuntimeInPlace(t *testing.T) {
 	if value := environmentValue(runner.env, "UV_NO_CONFIG"); value != "1" {
 		t.Fatalf("UV_NO_CONFIG = %q, want 1", value)
 	}
+	if value := environmentValue(runner.env, "UV_PYTHON"); value != managedUVPythonVersion {
+		t.Fatalf("UV_PYTHON = %q, want %q", value, managedUVPythonVersion)
+	}
+	if value := environmentValue(runner.env, "UV_MANAGED_PYTHON"); value != "1" {
+		t.Fatalf("UV_MANAGED_PYTHON = %q, want 1", value)
+	}
 	pathValue := environmentValue(runner.env, "PATH")
 	if !strings.HasPrefix(pathValue, runner.uvDir+string(os.PathListSeparator)) {
 		t.Fatalf("PATH = %q, want prefix %q", pathValue, runner.uvDir)


### PR DESCRIPTION
## What changed

- request Tutti-managed Python 3.12 for uv-based Agent Extension installs
- require uv to use a managed interpreter instead of a system Python
- cover the install environment in tests
- document the runtime contract and troubleshooting evidence

## Why

Hermes Agent 0.18.2 requires Python 3.11 or newer. The managed uv install confined downloaded interpreters but did not request one, so uv could select macOS system Python 3.9 and reject an otherwise valid pinned package.

## Impact

Reinstalling a uv-based Agent Extension runtime now uses an isolated Tutti-owned Python 3.12 and no longer depends on the daemon PATH's system Python.

## Related

- Hermes extension publication policy: https://github.com/tutti-os/agent-extension-hermes/pull/3

## Validation

- reproduced the failure with the managed uv binary and system Python 3.9
- verified the same install succeeds with managed Python 3.12
- verified Hermes 0.18.2 completes ACP initialize
- `pnpm check:changed -- --push-ready --base upstream/main` (6 lanes passed)
