### PR TITLE
refactor(agent): tighten session mutation effect contracts

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityMutationOperations.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityMutationOperations.test.ts
@@ -114,10 +114,6 @@ function createOperations(input: {
 }): WorkspaceAgentActivityMutationOperations {
   return new WorkspaceAgentActivityMutationOperations({
     getSession: async () => activitySession(),
-    load: async () => {
-      throw new Error("unexpected load");
-    },
-    markSessionDeleted: () => {},
     runtimeApi: { logTerminalDiagnostic: async () => {} },
     sessionCommandTarget: () => ({ adapter: input.adapter }),
     tuttidClient: {} as TuttidClient,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityMutationOperations.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityMutationOperations.ts
@@ -30,12 +30,6 @@ export interface WorkspaceAgentActivityMutationOperationsDependencies {
     DesktopHostFilesApi,
     "createUserDocumentsProjectDirectory"
   >;
-  load(workspaceId: string, signal?: AbortSignal): Promise<unknown>;
-  markSessionDeleted(input: {
-    agentSessionId: string;
-    data?: unknown;
-    workspaceId: string;
-  }): void;
   runtimeApi: Pick<DesktopRuntimeApi, "logTerminalDiagnostic">;
   sessionCommandTarget(
     workspaceId: string
@@ -58,57 +52,6 @@ export class WorkspaceAgentActivityMutationOperations {
     dependencies: WorkspaceAgentActivityMutationOperationsDependencies
   ) {
     this.dependencies = dependencies;
-  }
-
-  async deleteSessionsBatch(
-    input: Parameters<IWorkspaceAgentActivityService["deleteSessionsBatch"]>[0]
-  ): ReturnType<IWorkspaceAgentActivityService["deleteSessionsBatch"]> {
-    const workspaceId = normalizeWorkspaceId(input.workspaceId);
-    const response =
-      await this.dependencies.tuttidClient.deleteWorkspaceAgentSessionsBatch(
-        workspaceId,
-        { sessionIds: input.sessionIds },
-        { signal: input.signal }
-      );
-    const removedSessionIds = response.removedSessionIds
-      .map((id) => id.trim())
-      .filter(Boolean);
-    for (const agentSessionId of removedSessionIds) {
-      this.dependencies.markSessionDeleted({
-        agentSessionId,
-        data: { deletedAtUnixMs: Date.now() },
-        workspaceId
-      });
-    }
-    if (removedSessionIds.length > 0) {
-      await this.dependencies.load(workspaceId, input.signal);
-    }
-    return {
-      cleanupFailedSessionIds: [...(response.cleanupFailedSessionIds ?? [])],
-      removedMessages: response.removedMessages,
-      removedSessionIds,
-      removedSessions: response.removedSessions
-    };
-  }
-
-  async setSessionPinned(input: {
-    agentSessionId: string;
-    pinned: boolean;
-    workspaceId: string;
-  }): Promise<AgentActivitySession> {
-    const workspaceId = normalizeWorkspaceId(input.workspaceId);
-    const session =
-      await this.dependencies.tuttidClient.updateWorkspaceAgentSessionPin(
-        workspaceId,
-        input.agentSessionId,
-        { pinned: input.pinned }
-      );
-    const activitySession = agentActivitySessionFromTuttidSession(
-      workspaceId,
-      session
-    );
-    this.dependencies.upsertAuthoritativeSession(activitySession, "pin_result");
-    return activitySession;
   }
 
   async createSession(
@@ -377,24 +320,6 @@ export class WorkspaceAgentActivityMutationOperations {
         promptKind: input.promptKind
       }
     );
-  }
-
-  async deleteSession(
-    input: Parameters<AgentActivityAdapter["deleteSession"]>[0]
-  ) {
-    const workspaceId = normalizeWorkspaceId(input.workspaceId);
-    const agentSessionId = input.agentSessionId.trim();
-    const target = this.dependencies.sessionCommandTarget(workspaceId);
-    const result = await target.adapter.deleteSession(input);
-    if (result.removed) {
-      this.dependencies.markSessionDeleted({
-        agentSessionId,
-        data: { deletedAtUnixMs: Date.now() },
-        workspaceId
-      });
-      await this.dependencies.load(workspaceId, input.signal);
-    }
-    return result;
   }
 
   async updateSessionSettings(input: {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -169,8 +169,6 @@ export class WorkspaceAgentActivityService
       getSession: (workspaceId, agentSessionId, signal) =>
         this.getSession(workspaceId, agentSessionId, signal),
       hostFilesApi: dependencies.hostFilesApi,
-      load: (workspaceId, signal) => this.load(workspaceId, signal),
-      markSessionDeleted: (input) => this.markSessionDeleted(input),
       runtimeApi: dependencies.runtimeApi,
       sessionCommandTarget: (workspaceId) => ({
         adapter: this.entry(workspaceId).adapter

--- a/apps/mobile/src/services/workspaceActivityEngineCommandPort.ts
+++ b/apps/mobile/src/services/workspaceActivityEngineCommandPort.ts
@@ -2,6 +2,7 @@ import type {
   AgentSessionActivateEffectInput,
   AgentSessionEffectPort,
   AgentActivityCancelTurnInput,
+  AgentActivityDeleteSessionsResult,
   AgentActivitySendInput,
   AgentActivitySession,
   AgentActivitySessionDetailSnapshot,
@@ -224,7 +225,7 @@ function deleteSessions(
     workspaceId: string;
   },
   signal?: AbortSignal
-): Promise<unknown> {
+): Promise<AgentActivityDeleteSessionsResult> {
   return context.client
     .deleteWorkspaceAgentSessionsBatch(
       input.workspaceId,
@@ -268,7 +269,7 @@ function renameSession(
     workspaceId: string;
   },
   signal?: AbortSignal
-): Promise<unknown> {
+): Promise<{ session: AgentActivitySession }> {
   return context.client
     .updateWorkspaceAgentSessionTitle(
       input.workspaceId,
@@ -287,7 +288,7 @@ function setSessionPinned(
     workspaceId: string;
   },
   signal?: AbortSignal
-): Promise<unknown> {
+): Promise<{ session: AgentActivitySession }> {
   return context.client
     .updateWorkspaceAgentSessionPin(
       input.workspaceId,

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -205,6 +205,10 @@ It owns:
 
 The public host-effect seam is `AgentSessionEffectPort`; the public
 application-write seam is the semantic `AgentSessionEngine` methods.
+Rename and pin effects return an authoritative Session envelope, and batch
+delete returns the complete typed deletion result. Reducers still validate
+those results before applying canonical state, while the public port prevents
+hosts from inventing a different result shape.
 `dispatchSessionMutation` remains compatibility-only while published consumers
 migrate and must not be used by new product-host code. Prompt precondition
 ordering and its helper port are Engine implementation details and are not

--- a/packages/agent/activity-core/README.md
+++ b/packages/agent/activity-core/README.md
@@ -311,6 +311,10 @@ display prompt, guidance, activation placement, Tutti-mode intent, and
 diagnostics survive the shared projection.
 Goal-on-create and settings command/correlation identities are also retained
 for external hosts that use them for goal setup or idempotency.
+Rename and pin effects return `{ session }` with the authoritative canonical
+Session, while batch delete returns `AgentActivityDeleteSessionsResult`.
+Runtime validation remains fail-closed, but the public port type prevents hosts
+from implementing a different result envelope.
 
 Prompt command ordering is an Engine implementation detail. Consumers implement
 `AgentSessionEffectPort`; the package root does not expose the internal prompt

--- a/packages/agent/activity-core/src/engine/effectExecutor.test.ts
+++ b/packages/agent/activity-core/src/engine/effectExecutor.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { createEngineEffectExecutor } from "./effectExecutor.ts";
+import type { AgentActivitySession } from "../types.ts";
 import type {
   AgentSessionEffectPort,
   EngineCommandPort,
@@ -12,6 +13,7 @@ import type {
 test("projects shared commands onto typed lifecycle effects without host switches", async () => {
   const calls: Array<{ input: unknown; kind: string; signal?: AbortSignal }> =
     [];
+  const session = {} as AgentActivitySession;
   const effects: AgentSessionEffectPort = {
     async activateSession(input, options) {
       calls.push({ input, kind: "activate", signal: options?.signal });
@@ -22,18 +24,26 @@ test("projects shared commands onto typed lifecycle effects without host switche
     },
     async deleteSessions(input, options) {
       calls.push({ input, kind: "delete", signal: options?.signal });
+      return {
+        cleanupFailedSessionIds: [],
+        removedMessages: 0,
+        removedSessionIds: [],
+        removedSessions: 0
+      };
     },
     async respondToInteraction(input, options) {
       calls.push({ input, kind: "respond", signal: options?.signal });
     },
     async renameSession(input, options) {
       calls.push({ input, kind: "rename", signal: options?.signal });
+      return { session };
     },
     async sendInput(input, options) {
       calls.push({ input, kind: "send", signal: options?.signal });
     },
     async setSessionPinned(input, options) {
       calls.push({ input, kind: "pin", signal: options?.signal });
+      return { session };
     },
     async updateSessionSettings(input, options) {
       calls.push({ input, kind: "settings", signal: options?.signal });

--- a/packages/agent/activity-core/src/engine/publicContract.typecheck.ts
+++ b/packages/agent/activity-core/src/engine/publicContract.typecheck.ts
@@ -1,4 +1,7 @@
 import type {
+  AgentActivityDeleteSessionsResult,
+  AgentActivitySession,
+  AgentSessionEffectPort,
   AgentSessionEngine,
   AgentSessionEngineState,
   EngineExtensionCommand,
@@ -6,6 +9,7 @@ import type {
 } from "../index.ts";
 
 type Assert<T extends true> = T;
+type IsEqual<Left, Right> = [Left, Right] extends [Right, Left] ? true : false;
 type IsNever<T> = [T] extends [never] ? true : false;
 
 export type PromptExecutionIntentRemainsPrivate = Assert<
@@ -27,4 +31,25 @@ type SessionMutationOperation =
 
 export type SessionMutationsUseSemanticEngineOperations = Assert<
   SessionMutationOperation extends keyof AgentSessionEngine ? true : false
+>;
+
+export type DeleteSessionsEffectReturnsTypedResult = Assert<
+  IsEqual<
+    Awaited<ReturnType<AgentSessionEffectPort["deleteSessions"]>>,
+    AgentActivityDeleteSessionsResult
+  >
+>;
+
+export type RenameSessionEffectReturnsTypedResult = Assert<
+  IsEqual<
+    Awaited<ReturnType<AgentSessionEffectPort["renameSession"]>>,
+    { session: AgentActivitySession }
+  >
+>;
+
+export type SetSessionPinnedEffectReturnsTypedResult = Assert<
+  IsEqual<
+    Awaited<ReturnType<AgentSessionEffectPort["setSessionPinned"]>>,
+    { session: AgentActivitySession }
+  >
 >;

--- a/packages/agent/activity-core/src/engine/types.ts
+++ b/packages/agent/activity-core/src/engine/types.ts
@@ -349,7 +349,7 @@ export interface AgentSessionEffectPort {
   deleteSessions(
     input: Omit<AgentActivityDeleteSessionsInput, "signal">,
     options?: EngineEffectOptions
-  ): Promise<unknown>;
+  ): Promise<AgentActivityDeleteSessionsResult>;
   respondToInteraction(
     input: AgentActivitySubmitInteractiveInput,
     options?: EngineEffectOptions
@@ -357,7 +357,7 @@ export interface AgentSessionEffectPort {
   renameSession(
     input: Omit<AgentActivityRenameSessionInput, "signal">,
     options?: EngineEffectOptions
-  ): Promise<unknown>;
+  ): Promise<{ session: AgentActivitySession }>;
   sendInput(
     input: AgentActivitySendInput,
     options?: EngineEffectOptions
@@ -365,7 +365,7 @@ export interface AgentSessionEffectPort {
   setSessionPinned(
     input: Omit<AgentActivitySetSessionPinnedInput, "signal">,
     options?: EngineEffectOptions
-  ): Promise<unknown>;
+  ): Promise<{ session: AgentActivitySession }>;
   updateSessionSettings(
     input: {
       agentSessionId: string;


### PR DESCRIPTION
## Summary

- give `AgentSessionEffectPort` exact result contracts for rename, pin, and batch delete
- remove the obsolete Desktop delete/pin mutation implementations and their reload/tombstone dependencies
- add compile-time contract ratchets and document the typed mutation result envelope

## Why

The Engine now owns rename, pin, and delete mutation identity, timeout, cancellation, settlement, and canonical projection. However, the host effect seam still returned `Promise<unknown>`, so Desktop and Mobile could silently implement different result envelopes. Desktop also retained an unused pre-Engine mutation path, leaving a second implementation available for accidental reuse.

This change makes the shared seam enforce the result shape while retaining runtime fail-closed validation. It also leaves Desktop with one mutation path: facade → Engine semantic operation → typed effect → transport adapter.

## Impact

There is no intended user-visible behavior change. The public package contract becomes safer for the upcoming tsh migration, and Desktop no longer carries parallel mutation orchestration.

## Validation

- `pnpm check:changed` — 17 lanes passed
- pre-push `pnpm check:changed -- --push-ready` — 19 lanes passed
- `@tutti-os/agent-activity-core` — 390 tests passed
- Desktop — 1669 tests passed, 2 skipped
- Mobile — 115 tests passed
- focused Desktop-layering and package-boundary architecture reviews passed
