### PR TITLE
fix(agent): respect system network for prompt images

### DIFF
--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -835,41 +835,49 @@ inline data URL instead`. Claude or standard ACP may instead receive no
   SDK and standard ACP must receive base64 `data`. Search every provider send
   and guidance path for `materializeProviderPromptImagesAtBoundary`; the helper
   and its unit test can remain green even when a refactor removes all production
-  callers.
+  callers. If the visible failure detail is
+  `download remote prompt image: request failed`, compare the URL with a normal
+  system HTTP client and inspect its DNS result. A URL that succeeds normally
+  but resolves to a VPN or transparent-proxy synthetic address indicates that
+  the runtime is bypassing or second-guessing the system network path.
 - Root cause:
   Remote image URLs are the durable transport representation, while current
   Codex app-server, Claude SDK, and standard ACP provider wires require inline
   data. A provider-adapter refactor can preserve the materialization helper but
-  omit its call sites in newly split turn files.
+  omit its call sites in newly split turn files. Separately, pre-resolving and
+  classifying destination IPs at this boundary is incompatible with VPN, TUN,
+  split-DNS, and Fake-IP network stacks: their synthetic address is intentionally
+  not the public origin address, but the system transport still knows how to
+  reach the origin.
 - Fix:
   Materialize only at the final provider boundary. Keep the original URL-backed
   content for activity projection, and convert the provider-only copy after
   local slash/control handling but immediately before Codex `turn/start` or
   `turn/steer`, Claude SDK `exec` or `guide`, and standard ACP
-  `session/prompt`. Resolve and pin every download or redirect hop to a public
-  Internet address so prompt content cannot reach loopback, private, link-local,
-  transition-mapped, or other IANA special-purpose networks. Preserve the
-  configured proxy decision using the original URL, but send the proxy a pinned
-  public-IP tunnel target while retaining the original TLS server name and HTTP
-  Host. Strip redirect `Referer` headers so signed URL query parameters cannot
-  cross origins. Admit an asynchronous Codex guidance continuation before
-  publishing its provisional provider turn, and settle that exact attempt when
-  preparation ends without starting a real provider turn. For standard ACP,
-  publish the original user activity and provider-turn start before remote
-  materialization; if preparation fails, complete that same provider turn as
-  failed so the message remains durable and root settlement cannot strand.
+  `session/prompt`. Use the repository proxy-aware HTTP client and leave DNS,
+  proxy, VPN, and connect-target selection to the system network stack; do not
+  pre-resolve, pin, or reject resolved IP ranges at this provider compatibility
+  boundary. Continue accepting only HTTPS URLs, require every redirect hop to
+  remain HTTPS, strip redirect `Referer` headers so signed URL query parameters
+  cannot cross hops, and keep timeout, response-size, and image MIME checks.
+  Admit an asynchronous Codex guidance continuation before publishing its
+  provisional provider turn, and settle that exact attempt when preparation
+  ends without starting a real provider turn. For standard ACP, publish the
+  original user activity and provider-turn start before remote materialization;
+  if preparation fails, complete that same provider turn as failed so the
+  message remains durable and root settlement cannot strand.
 - Validation:
   Exercise URL-only content through the real adapter request paths and assert
   the captured provider payload contains inline data. Cover Codex send and
   guidance, Claude SDK exec and guide, and standard ACP exec; do not rely only
-  on direct helper tests. Also reject loopback literals and redirects whose
-  target resolves to an internal or transition-mapped address, verify proxy
-  CONNECT uses the pinned public IP, and assert redirects omit signed-URL
-  referrers. Cover failed and concurrent guidance continuation admission so
-  every published provisional attempt either yields a real provider lifecycle
-  or receives its matching provider-turn completion. Also fail standard ACP
-  materialization and assert the original user message, turn start, and failed
-  provider-turn completion are all emitted without sending `session/prompt`.
+  on direct helper tests. Verify the production client can materialize through a
+  system-routed reserved address, reject a redirect that downgrades to HTTP, and
+  assert redirects omit signed-URL referrers. Cover failed and concurrent
+  guidance continuation admission so every published provisional attempt either
+  yields a real provider lifecycle or receives its matching provider-turn
+  completion. Also fail standard ACP materialization and assert the original
+  user message, turn start, and failed provider-turn completion are all emitted
+  without sending `session/prompt`.
 - References:
   [prompt_content.go](../../../packages/agent/daemon/runtime/prompt_content.go)
   [codex_appserver_turn.go](../../../packages/agent/daemon/runtime/codex_appserver_turn.go)

--- a/packages/agent/daemon/runtime/prompt_content.go
+++ b/packages/agent/daemon/runtime/prompt_content.go
@@ -2,16 +2,13 @@ package agentruntime
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"mime"
-	"net"
 	"net/http"
-	"net/netip"
 	"net/url"
 	"strings"
 	"time"
@@ -25,36 +22,6 @@ var ErrPromptImageUnsupported = errors.New("agent prompt image input is unsuppor
 const clientSubmitUserMessageIDPrefix = "client-submit:user:"
 
 const maxProviderPromptImageBytes int64 = 20 << 20
-
-var (
-	providerPromptImageGlobalIPv6UnicastPrefix = netip.MustParsePrefix("2000::/3")
-	// Fail closed for IANA special-purpose ranges, including transition
-	// addresses that can encode an otherwise blocked IPv4 destination.
-	providerPromptImageNonPublicPrefixes = []netip.Prefix{
-		netip.MustParsePrefix("0.0.0.0/8"),
-		netip.MustParsePrefix("10.0.0.0/8"),
-		netip.MustParsePrefix("100.64.0.0/10"),
-		netip.MustParsePrefix("127.0.0.0/8"),
-		netip.MustParsePrefix("169.254.0.0/16"),
-		netip.MustParsePrefix("172.16.0.0/12"),
-		netip.MustParsePrefix("192.0.0.0/24"),
-		netip.MustParsePrefix("192.0.2.0/24"),
-		netip.MustParsePrefix("192.31.196.0/24"),
-		netip.MustParsePrefix("192.52.193.0/24"),
-		netip.MustParsePrefix("192.88.99.0/24"),
-		netip.MustParsePrefix("192.168.0.0/16"),
-		netip.MustParsePrefix("192.175.48.0/24"),
-		netip.MustParsePrefix("198.18.0.0/15"),
-		netip.MustParsePrefix("198.51.100.0/24"),
-		netip.MustParsePrefix("203.0.113.0/24"),
-		netip.MustParsePrefix("240.0.0.0/4"),
-		netip.MustParsePrefix("2001::/23"),
-		netip.MustParsePrefix("2001:db8::/32"),
-		netip.MustParsePrefix("2002::/16"),
-		netip.MustParsePrefix("2620:4f:8000::/48"),
-		netip.MustParsePrefix("3fff::/20"),
-	}
-)
 
 type canonicalSubmitFactContextKey struct{}
 
@@ -404,139 +371,8 @@ func materializeProviderPromptImagesAtBoundary(
 	return materializer(ctx, content)
 }
 
-type providerPromptImageResolver interface {
-	LookupNetIP(context.Context, string, string) ([]netip.Addr, error)
-}
-
-type providerPromptImageTransport struct {
-	base     *http.Transport
-	resolver providerPromptImageResolver
-}
-
 func newProviderPromptImageHTTPClient(timeout time.Duration) *http.Client {
-	client := httpx.NewClient(timeout)
-	client.Transport = &providerPromptImageTransport{
-		base:     client.Transport.(*http.Transport),
-		resolver: net.DefaultResolver,
-	}
-	return client
-}
-
-func newProviderPromptImageHTTPClientWithNetwork(
-	timeout time.Duration,
-	resolver providerPromptImageResolver,
-	transport *http.Transport,
-) *http.Client {
-	client := httpx.NewClient(timeout)
-	if transport == nil {
-		transport = client.Transport.(*http.Transport)
-	}
-	client.Transport = &providerPromptImageTransport{base: transport, resolver: resolver}
-	return client
-}
-
-func (t *providerPromptImageTransport) RoundTrip(request *http.Request) (*http.Response, error) {
-	if t == nil || t.base == nil || t.resolver == nil || request == nil || request.URL == nil ||
-		request.Method != http.MethodGet || request.Body != nil || !runtimePromptImageURLSafe(request.URL.String()) {
-		return nil, ErrPromptImageUnsupported
-	}
-	addresses, err := t.resolver.LookupNetIP(request.Context(), "ip", request.URL.Hostname())
-	if err != nil {
-		return nil, errors.New("resolve remote prompt image: request failed")
-	}
-	port := request.URL.Port()
-	if port == "" {
-		port = "443"
-	}
-	var proxyURL *url.URL
-	if t.base.Proxy != nil {
-		proxyURL, err = t.base.Proxy(request)
-		if err != nil {
-			return nil, errors.New("resolve remote prompt image proxy: request failed")
-		}
-	}
-	var lastErr error
-	for _, resolved := range addresses {
-		if !providerPromptImageAddressPublic(resolved) {
-			continue
-		}
-		pinnedRequest := request.Clone(request.Context())
-		pinnedURL := *request.URL
-		pinnedURL.Host = net.JoinHostPort(resolved.String(), port)
-		pinnedRequest.URL = &pinnedURL
-		pinnedRequest.Host = request.URL.Host
-
-		transport := t.base.Clone()
-		transport.DisableKeepAlives = true
-		if proxyURL == nil {
-			transport.Proxy = nil
-		} else {
-			transport.Proxy = http.ProxyURL(proxyURL)
-		}
-		baseTLSConfig := &tls.Config{}
-		if transport.TLSClientConfig != nil {
-			baseTLSConfig = transport.TLSClientConfig.Clone()
-		}
-		transport.TLSClientConfig = baseTLSConfig.Clone()
-		transport.TLSClientConfig.ServerName = request.URL.Hostname()
-		if proxyURL != nil && proxyURL.Scheme == "https" && transport.DialTLSContext == nil {
-			proxyTLSConfig := baseTLSConfig.Clone()
-			proxyTLSConfig.ServerName = proxyURL.Hostname()
-			dialContext := transport.DialContext
-			if dialContext == nil {
-				dialContext = (&net.Dialer{}).DialContext
-			}
-			handshakeTimeout := transport.TLSHandshakeTimeout
-			transport.DialTLSContext = func(ctx context.Context, network, address string) (net.Conn, error) {
-				connection, dialErr := dialContext(ctx, network, address)
-				if dialErr != nil {
-					return nil, dialErr
-				}
-				tlsConnection := tls.Client(connection, proxyTLSConfig)
-				handshakeCtx := ctx
-				cancel := func() {}
-				if handshakeTimeout > 0 {
-					handshakeCtx, cancel = context.WithTimeout(ctx, handshakeTimeout)
-				}
-				defer cancel()
-				if handshakeErr := tlsConnection.HandshakeContext(handshakeCtx); handshakeErr != nil {
-					_ = connection.Close()
-					return nil, handshakeErr
-				}
-				return tlsConnection, nil
-			}
-		}
-
-		response, requestErr := transport.RoundTrip(pinnedRequest)
-		if requestErr == nil {
-			response.Request = request
-			return response, nil
-		}
-		lastErr = requestErr
-	}
-	if lastErr != nil {
-		return nil, lastErr
-	}
-	return nil, ErrPromptImageUnsupported
-}
-
-func providerPromptImageAddressPublic(address netip.Addr) bool {
-	if !address.IsValid() || address.Zone() != "" {
-		return false
-	}
-	address = address.Unmap()
-	if !address.IsGlobalUnicast() || address.IsPrivate() || address.IsLoopback() || address.IsLinkLocalUnicast() {
-		return false
-	}
-	if address.Is6() && !providerPromptImageGlobalIPv6UnicastPrefix.Contains(address) {
-		return false
-	}
-	for _, prefix := range providerPromptImageNonPublicPrefixes {
-		if prefix.Contains(address) {
-			return false
-		}
-	}
-	return true
+	return httpx.NewClient(timeout)
 }
 
 func materializeProviderPromptImagesWithClient(ctx context.Context, content []PromptContentBlock, client *http.Client) ([]PromptContentBlock, error) {

--- a/packages/agent/daemon/runtime/prompt_content_test.go
+++ b/packages/agent/daemon/runtime/prompt_content_test.go
@@ -2,15 +2,10 @@ package agentruntime
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"errors"
-	"io"
-	"net"
 	"net/http"
 	"net/http/httptest"
-	"net/netip"
-	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -74,16 +69,6 @@ func testRemotePromptImageMaterializer(t *testing.T) (string, providerPromptImag
 	}
 }
 
-type staticProviderPromptImageResolver map[string][]netip.Addr
-
-func (r staticProviderPromptImageResolver) LookupNetIP(_ context.Context, _ string, host string) ([]netip.Addr, error) {
-	addresses, ok := r[host]
-	if !ok {
-		return nil, &net.DNSError{Name: host, Err: "not found"}
-	}
-	return append([]netip.Addr(nil), addresses...), nil
-}
-
 func TestNormalizeRuntimePromptContentPreservesURLOnlyImage(t *testing.T) {
 	signedURL := "https://bucket.example/image.webp?token=secret"
 	content := normalizeRuntimePromptContent([]PromptContentBlock{{Type: "image", MimeType: " image/webp ", URL: " " + signedURL + " ", Name: " image.webp "}})
@@ -92,90 +77,57 @@ func TestNormalizeRuntimePromptContentPreservesURLOnlyImage(t *testing.T) {
 	}
 }
 
-func TestProviderPromptImageAddressPublicRejectsInternalNetworks(t *testing.T) {
+func TestProviderPromptImageHTTPClientUsesSystemNetworkForReservedAddress(t *testing.T) {
 	t.Parallel()
 
-	for _, test := range []struct {
-		address string
-		want    bool
-	}{
-		{address: "8.8.8.8", want: true},
-		{address: "2606:4700:4700::1111", want: true},
-		{address: "0.0.0.1"},
-		{address: "127.0.0.1"},
-		{address: "10.0.0.1"},
-		{address: "100.64.0.1"},
-		{address: "169.254.1.1"},
-		{address: "192.168.1.1"},
-		{address: "198.18.0.1"},
-		{address: "240.0.0.1"},
-		{address: "::1"},
-		{address: "64:ff9b::a00:1"},
-		{address: "2002:a00:1::"},
-		{address: "fc00::1"},
-		{address: "fe80::1"},
-	} {
-		test := test
-		t.Run(test.address, func(t *testing.T) {
-			t.Parallel()
-			if got := providerPromptImageAddressPublic(netip.MustParseAddr(test.address)); got != test.want {
-				t.Fatalf("providerPromptImageAddressPublic(%q) = %v, want %v", test.address, got, test.want)
-			}
-		})
-	}
-}
-
-func TestMaterializeProviderPromptImagesRejectsLoopbackLiteral(t *testing.T) {
-	t.Parallel()
-
-	var requests int
-	server := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-		requests++
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		response.Header().Set("Content-Type", "image/png")
+		_, _ = response.Write([]byte("hi"))
 	}))
 	defer server.Close()
 
-	_, err := materializeProviderPromptImages(context.Background(), []PromptContentBlock{{
-		Type: "image", MimeType: "image/png", URL: server.URL + "/image.png",
-	}})
-	if err == nil {
-		t.Fatal("materialize error = nil, want loopback rejection")
+	client := newProviderPromptImageHTTPClient(time.Second)
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("prompt image transport = %T, want *http.Transport", client.Transport)
 	}
-	if requests != 0 {
-		t.Fatalf("loopback server received %d requests, want 0", requests)
+	testTransport, ok := server.Client().Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("test transport = %T, want *http.Transport", server.Client().Transport)
+	}
+	transport = transport.Clone()
+	transport.TLSClientConfig = testTransport.TLSClientConfig.Clone()
+	client.Transport = transport
+
+	content, err := materializeProviderPromptImagesWithClient(context.Background(), []PromptContentBlock{{
+		Type: "image", MimeType: "image/png", URL: server.URL + "/image.png",
+	}}, client)
+	if err != nil {
+		t.Fatalf("materialize reserved-address image: %v", err)
+	}
+	if len(content) != 1 || content[0].URL != "" || content[0].Data != "aGk=" {
+		t.Fatalf("materialized content = %#v, want inline image data", content)
 	}
 }
 
-func TestMaterializeProviderPromptImagesRejectsRedirectToInternalAddress(t *testing.T) {
+func TestMaterializeProviderPromptImagesRejectsHTTPRedirect(t *testing.T) {
 	t.Parallel()
 
 	var requests int
 	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		requests++
-		if request.URL.Path != "/start" {
-			t.Fatalf("request path = %q, want /start", request.URL.Path)
-		}
-		http.Redirect(response, request, "https://private.example/image.png", http.StatusFound)
+		http.Redirect(response, request, "http://127.0.0.1/image.png", http.StatusFound)
 	}))
 	defer server.Close()
 
-	resolver := staticProviderPromptImageResolver{
-		"example.com":     {netip.MustParseAddr("8.8.8.8")},
-		"private.example": {netip.MustParseAddr("127.0.0.1")},
-	}
-	transport := server.Client().Transport.(*http.Transport).Clone()
-	transport.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
-		return (&net.Dialer{}).DialContext(ctx, network, server.Listener.Addr().String())
-	}
-	client := newProviderPromptImageHTTPClientWithNetwork(time.Second, resolver, transport)
-
 	_, err := materializeProviderPromptImagesWithClient(context.Background(), []PromptContentBlock{{
-		Type: "image", MimeType: "image/png", URL: "https://example.com/start",
-	}}, client)
+		Type: "image", MimeType: "image/png", URL: server.URL + "/start",
+	}}, server.Client())
 	if err == nil {
-		t.Fatal("materialize error = nil, want internal redirect rejection")
+		t.Fatal("materialize error = nil, want HTTP redirect rejection")
 	}
 	if requests != 1 {
-		t.Fatalf("server received %d requests, want only the public request; error = %v", requests, err)
+		t.Fatalf("server received %d requests, want only the HTTPS request", requests)
 	}
 }
 
@@ -187,7 +139,7 @@ func TestMaterializeProviderPromptImagesDoesNotForwardSignedURLReferer(t *testin
 		requests++
 		switch request.URL.Path {
 		case "/start":
-			http.Redirect(response, request, "https://redirect.example/image.png", http.StatusFound)
+			http.Redirect(response, request, "/image.png", http.StatusFound)
 		case "/image.png":
 			if referer := request.Header.Get("Referer"); referer != "" {
 				t.Errorf("redirect Referer = %q, want empty", referer)
@@ -200,139 +152,14 @@ func TestMaterializeProviderPromptImagesDoesNotForwardSignedURLReferer(t *testin
 	}))
 	defer server.Close()
 
-	resolver := staticProviderPromptImageResolver{
-		"example.com":      {netip.MustParseAddr("8.8.8.8")},
-		"redirect.example": {netip.MustParseAddr("1.1.1.1")},
-	}
-	transport := server.Client().Transport.(*http.Transport).Clone()
-	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // test-only cross-host redirect
-	transport.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
-		return (&net.Dialer{}).DialContext(ctx, network, server.Listener.Addr().String())
-	}
-	client := newProviderPromptImageHTTPClientWithNetwork(time.Second, resolver, transport)
-
 	content, err := materializeProviderPromptImagesWithClient(context.Background(), []PromptContentBlock{{
-		Type: "image", MimeType: "image/png", URL: "https://example.com/start?X-Amz-Signature=secret",
-	}}, client)
+		Type: "image", MimeType: "image/png", URL: server.URL + "/start?X-Amz-Signature=secret",
+	}}, server.Client())
 	if err != nil {
 		t.Fatalf("materialize: %v", err)
 	}
 	if requests != 2 || len(content) != 1 || content[0].Data != "aGk=" {
 		t.Fatalf("requests = %d, content = %#v, want redirected inline image", requests, content)
-	}
-}
-
-func TestProviderPromptImageHTTPClientKeepsProxyAndPinsConnectTarget(t *testing.T) {
-	t.Parallel()
-
-	imageServer := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
-		if request.Host != "example.com" {
-			t.Errorf("image Host = %q, want example.com", request.Host)
-		}
-		response.Header().Set("Content-Type", "image/png")
-		_, _ = response.Write([]byte("hi"))
-	}))
-	defer imageServer.Close()
-
-	for _, testCase := range []struct {
-		name     string
-		proxyTLS bool
-	}{
-		{name: "HTTP"},
-		{name: "HTTPS", proxyTLS: true},
-	} {
-		testCase := testCase
-		t.Run(testCase.name, func(t *testing.T) {
-			connectTargets := make(chan string, 1)
-			proxyServerNames := make(chan string, 1)
-			proxy := httptest.NewUnstartedServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
-				if request.Method != http.MethodConnect {
-					http.Error(response, "CONNECT required", http.StatusMethodNotAllowed)
-					return
-				}
-				connectTargets <- request.Host
-				downstream, _, err := response.(http.Hijacker).Hijack()
-				if err != nil {
-					t.Errorf("hijack proxy: %v", err)
-					return
-				}
-				upstream, err := net.Dial("tcp", imageServer.Listener.Addr().String())
-				if err != nil {
-					_ = downstream.Close()
-					t.Errorf("dial image server: %v", err)
-					return
-				}
-				_, _ = io.WriteString(downstream, "HTTP/1.1 200 Connection Established\r\n\r\n")
-				go func() {
-					_, _ = io.Copy(upstream, downstream)
-					_ = upstream.Close()
-				}()
-				_, _ = io.Copy(downstream, upstream)
-				_ = downstream.Close()
-			}))
-			if testCase.proxyTLS {
-				proxy.TLS = &tls.Config{
-					GetConfigForClient: func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
-						proxyServerNames <- hello.ServerName
-						return nil, nil
-					},
-				}
-				proxy.StartTLS()
-			} else {
-				proxy.Start()
-			}
-			defer proxy.Close()
-			proxyURL, err := url.Parse(proxy.URL)
-			if err != nil {
-				t.Fatal(err)
-			}
-			proxyAddress := proxy.Listener.Addr().String()
-			_, proxyPort, err := net.SplitHostPort(proxyURL.Host)
-			if err != nil {
-				t.Fatal(err)
-			}
-			proxyURL.Host = net.JoinHostPort("proxy.example", proxyPort)
-
-			transport := imageServer.Client().Transport.(*http.Transport).Clone()
-			transport.Proxy = http.ProxyURL(proxyURL)
-			transport.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
-				return (&net.Dialer{}).DialContext(ctx, network, proxyAddress)
-			}
-			if testCase.proxyTLS {
-				transport.TLSClientConfig.InsecureSkipVerify = true // test-only proxy and target routing assertion
-			}
-			client := newProviderPromptImageHTTPClientWithNetwork(time.Second, staticProviderPromptImageResolver{
-				"example.com": {netip.MustParseAddr("8.8.8.8")},
-			}, transport)
-
-			content, err := materializeProviderPromptImagesWithClient(context.Background(), []PromptContentBlock{{
-				Type: "image", MimeType: "image/png", URL: "https://example.com/image.png",
-			}}, client)
-			if err != nil {
-				t.Fatalf("materialize through proxy: %v", err)
-			}
-			if len(content) != 1 || content[0].Data != "aGk=" {
-				t.Fatalf("content = %#v, want inline image", content)
-			}
-			select {
-			case target := <-connectTargets:
-				if target != "8.8.8.8:443" {
-					t.Fatalf("proxy CONNECT target = %q, want pinned public IP", target)
-				}
-			case <-time.After(time.Second):
-				t.Fatal("proxy received no CONNECT")
-			}
-			if testCase.proxyTLS {
-				select {
-				case serverName := <-proxyServerNames:
-					if serverName != proxyURL.Hostname() {
-						t.Fatalf("proxy TLS server name = %q, want %q", serverName, proxyURL.Hostname())
-					}
-				case <-time.After(time.Second):
-					t.Fatal("proxy received no TLS ClientHello")
-				}
-			}
-		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- remove prompt-image DNS pre-resolution, connect-target pinning, and resolved-IP range rejection
- use the repository proxy-aware system HTTP client so VPN, TUN, split-DNS, and Fake-IP routing work normally
- retain HTTPS-only source URLs, HTTPS-only redirects, redirect Referer stripping, request timeout, response-size limits, and image MIME validation
- update the agent session troubleshooting guide with the failure mode and validation approach

## Root cause

The prompt-image downloader resolved and classified the origin address before sending the request. VPN/TUN Fake-IP DNS intentionally returns a synthetic address such as `198.18.0.0/15`; the system network stack knows how to route that address, but the downloader rejected it as non-public before the request could use the VPN path. Enumerating synthetic ranges would remain incomplete and could misclassify user networks.

## Impact

Remote prompt images now follow the same proxy and network routing policy as other daemon HTTP requests, including VPN Fake-IP setups. Destination IP classification is intentionally no longer performed at this provider compatibility boundary.

## Validation

- `go test ./packages/agent/daemon/runtime -run 'PromptImage|PromptContent' -count=1`
- `pnpm check:changed` — 7 lanes passed
- pre-push `pnpm check:changed -- --push-ready` — 8 lanes passed