### PR TITLE
fix(agent): serialize managed npm installs

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/tuttiAgentInstallBootstrap.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/tuttiAgentInstallBootstrap.test.ts
@@ -81,6 +81,31 @@ test("runTuttiAgentInstallBootstrap skips ready tutti-agent", async () => {
   assert.deepEqual(calls, ["ensureLoaded"]);
 });
 
+test("runTuttiAgentInstallBootstrap skips a daemon-owned active install", async () => {
+  const calls: string[] = [];
+  const status = createStatus("not_installed", [
+    { id: "install", kind: "daemon_action" }
+  ]);
+  status.activeAction = {
+    error: null,
+    log: [],
+    phase: "install",
+    registry: null,
+    steps: []
+  };
+  const service = createService(status, {
+    ensureLoaded: () => calls.push("ensureLoaded"),
+    runAction: () => calls.push("runAction")
+  });
+
+  await runManagedAgentInstallBootstrap(service, "tutti-agent", {
+    now: () => 1_000,
+    storage: createMemoryStorage()
+  });
+
+  assert.deepEqual(calls, ["ensureLoaded"]);
+});
+
 test("runTuttiAgentInstallBootstrap backs off after recent install failure", async () => {
   const calls: string[] = [];
   const storage = createMemoryStorage();

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/tuttiAgentInstallBootstrap.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/tuttiAgentInstallBootstrap.ts
@@ -109,6 +109,9 @@ export async function runManagedAgentInstallBootstrap(
   if (status.availability.status !== "not_installed") {
     return;
   }
+  if (status.activeAction !== null && status.activeAction !== undefined) {
+    return;
+  }
   if (service.isActionPending(provider, installActionId)) {
     return;
   }

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -970,6 +970,11 @@ file or directory`. A failed `codex app-server` probe is diagnostic evidence,
   Confirm whether more than one `tuttid` agent-provider install action or
   desktop install button fired at roughly the same time for commands shaped
   like `npm install -g ...`.
+  A daemon readiness install followed within seconds by
+  `agent_provider_status.pending_action_added` for the same provider identifies
+  the renderer/daemon bootstrap race. An npm exit code of `190` on macOS,
+  package staging cleanup, and a surviving PPID-1 npm process are strong
+  evidence that overlapping installs mutated the same prefix.
   Inspect the daemon run-state lock path under
   `TUTTI_STATE_DIR/run/locks/npm-global-install.lock` while an install is in
   progress to verify later installs are waiting instead of running in parallel.
@@ -977,18 +982,28 @@ file or directory`. A failed `codex app-server` probe is diagnostic evidence,
   npm global installs mutate shared package and bin locations. Without a
   daemon-owned cross-process lock, concurrent `npm install -g` commands can
   race while writing the same global state and leave a corrupted runtime.
+  Internal managed-npm installers use semantic command ids such as
+  `managed_npm_package:<package>` rather than a literal npm command, so the lock
+  recognizer must cover those ids too. Renderer bootstrap must also treat the
+  daemon's `activeAction` as authoritative; its local pending-action set cannot
+  see a readiness install that the daemon started first.
 - Fix:
   Serialize agent-provider `npm install -g` commands behind the daemon install
   lock and keep the lock path under daemon-owned state. Start the install
   timeout only after the lock is acquired so queued installs do not consume
   their npm execution budget while waiting. Do not auto-delete the lock on a
   timer. Instead, recover the lock during daemon startup only when the recorded
-  owner pid is no longer running. If recovery is still needed manually, clear
-  `npm-global-install.lock` only after verifying no install is still running.
+  owner pid is no longer running. Make managed npm and Codex-latest semantic
+  installer ids acquire the same global lock, and have renderer auto-bootstrap
+  skip any provider with a daemon-reported active action. If recovery is still
+  needed manually, clear `npm-global-install.lock` only after verifying no
+  install is still running.
 - Validation:
-  Run `pnpm lint:go` plus `cd services/tuttid && go test ./... && go build ./...`.
-  Then trigger two install actions in quick succession and confirm the second
-  waits for the first instead of starting another global npm mutation.
+  Cover managed npm and Codex-latest installer ids in the lock recognizer, plus
+  renderer bootstrap receiving an active daemon install. Run `pnpm lint:go`
+  plus `cd services/tuttid && go test ./... && go build ./...`. Then trigger two
+  install actions in quick succession and confirm the second waits for the
+  first instead of starting another global npm mutation.
 
 ### Agent provider install looks idle while a non-Codex installer is running
 

--- a/services/tuttid/service/agentstatus/install_lock.go
+++ b/services/tuttid/service/agentstatus/install_lock.go
@@ -132,6 +132,8 @@ func requiresInstallCommandLock(command string) bool {
 	command = strings.TrimSpace(command)
 	return strings.HasPrefix(command, "npm install -g") ||
 		strings.HasPrefix(command, "npm i -g") ||
+		strings.HasPrefix(command, string(InstallerKindCodexCLILatest)+":") ||
+		strings.HasPrefix(command, string(InstallerKindManagedNPMPackage)+":") ||
 		strings.HasPrefix(command, string(InstallerKindExternalAgentRegistryNPM)+":") ||
 		command == claudeCodeBinaryLockCommand
 }

--- a/services/tuttid/service/agentstatus/installer.go
+++ b/services/tuttid/service/agentstatus/installer.go
@@ -530,6 +530,12 @@ func installerLockCommand(spec InstallerSpec) string {
 	if spec.Kind == InstallerKindShellCommand {
 		return spec.ShellCommand
 	}
+	if spec.Kind == InstallerKindCodexCLILatest && spec.CodexCLI != nil {
+		return strings.Join([]string{
+			string(spec.Kind),
+			strings.TrimSpace(spec.CodexCLI.PackageName),
+		}, ":")
+	}
 	if spec.Kind == InstallerKindExternalAgentRegistryNPM && spec.RegistryNPM != nil {
 		return strings.Join([]string{
 			string(spec.Kind),

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -2239,6 +2239,33 @@ func TestInstallCommandLockSerializesConcurrentNPMGlobalInstalls(t *testing.T) {
 	}
 }
 
+func TestInstallerLockCommandRecognizesManagedNPMGlobalInstalls(t *testing.T) {
+	specs := []InstallerSpec{
+		{
+			Kind: InstallerKindCodexCLILatest,
+			CodexCLI: &CodexCLILatestInstallerSpec{
+				PackageName: "@openai/codex",
+			},
+		},
+		{
+			Kind: InstallerKindManagedNPMPackage,
+			ManagedNPM: &ManagedNPMPackageInstallerSpec{
+				PackageName: "@tutti-os/tutti-agent",
+			},
+		},
+	}
+
+	for _, spec := range specs {
+		command := installerLockCommand(spec)
+		if !requiresInstallCommandLock(command) {
+			t.Errorf("installerLockCommand(%q) = %q, want a recognized global npm lock command", spec.Kind, command)
+		}
+		if got := filepath.Base(installCommandLockPath(command)); got != "npm-global-install.lock" {
+			t.Errorf("installCommandLockPath(%q) = %q, want npm-global-install.lock", command, got)
+		}
+	}
+}
+
 func TestInstallCommandLockSerializesConcurrentExternalRegistryNPMInstalls(t *testing.T) {
 	lockPath := filepath.Join(t.TempDir(), "run", "locks", "agent-provider-install.lock")
 	lock := installCommandLock{


### PR DESCRIPTION
## Summary

- prevent the desktop managed-provider bootstrap from starting a second install while `tuttid` already reports an active provider action
- make managed npm and Codex-latest semantic installer commands acquire the existing global npm install lock
- add regression coverage and document the concurrent-install troubleshooting pattern

## Root cause

The daemon readiness coordinator and renderer bootstrap could initiate the same Tutti Agent install within seconds of each other. The renderer only checked its local pending-action state, so it did not honor an install that the daemon had already started.

At the same time, internal managed installers identify themselves with semantic command IDs such as `managed_npm_package:<package>`. The existing install lock only recognized literal `npm install -g` commands, so both installers could mutate the same global npm prefix concurrently. This could temporarily remove the CLI launcher, leave npm staging state behind, and surface `provider CLI is still unavailable after install` or `cli_not_found`.

## Impact

Managed provider installation now has two narrow safeguards: the renderer defers to daemon-owned active actions, and daemon-side managed npm mutations are serialized across callers and processes.

## Validation

- `pnpm check:changed` — 14 lanes passed
- `pnpm check:changed -- --push-ready` — 16 lanes passed
- `pnpm --filter @tutti-os/desktop build`
- `go build ./...` in `services/tuttid`
- focused Go install-lock tests
- desktop test suite, including the new daemon-active-install bootstrap case