### PR TITLE
fix(agent): rewrite Tutti Mode description and tidy its toggle surfaces (backport to release/0729)

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerTuttiModeChip.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerTuttiModeChip.spec.tsx
@@ -22,18 +22,23 @@ function chipProps(
 }
 
 describe("ComposerTuttiModeChip", () => {
-  it("arms tutti mode through the activation callback", () => {
+  it("arms tutti mode through the activation callback", async () => {
     const onTuttiModeChange = vi.fn();
     render(<ComposerTuttiModeChip {...chipProps({ onTuttiModeChange })} />);
 
     expect(screen.getByText("Tutti Mode")).toBeInTheDocument();
-    // The chip shows only icon + label + switch; the description stays a tooltip.
+    // The chip shows only icon + label + switch; the description surfaces in a
+    // hover tooltip (design-system Tooltip), not inline.
     expect(
       screen.queryByText("Plan first, then orchestrate agents")
     ).not.toBeInTheDocument();
-    expect(
-      screen.getByTestId("agent-gui-composer-tutti-mode-toggle")
-    ).toHaveAttribute("title", "Plan first, then orchestrate agents");
+    fireEvent.pointerMove(
+      screen.getByTestId("agent-gui-composer-tutti-mode-toggle"),
+      { pointerType: "mouse" }
+    );
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Plan first, then orchestrate agents"
+    );
     const toggle = screen.getByTestId(
       "agent-gui-composer-tutti-mode-toggle-switch"
     );

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerTuttiModeChip.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerTuttiModeChip.tsx
@@ -1,5 +1,11 @@
 import { useId, useState } from "react";
-import { Switch } from "@tutti-os/ui-system";
+import {
+  Switch,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger
+} from "@tutti-os/ui-system";
 import { cn } from "../../../app/renderer/lib/utils";
 import tuttiModeLinedIconUrl from "../../../app/renderer/assets/icons/tutti-mode-lined.svg";
 import tuttiSnapStarsLightUrl from "../../../app/renderer/assets/animations/tutti-snap-stars-light.png";
@@ -43,53 +49,59 @@ export function ComposerTuttiModeChip({
     return null;
   }
   return (
-    <label
-      htmlFor={switchId}
-      title={description ?? label}
-      data-testid="agent-gui-composer-tutti-mode-toggle"
-      data-agent-tutti-mode-active={active ? "true" : undefined}
-      className={cn(
-        styles.composerMenuTrigger,
-        "group w-auto !gap-1.5",
-        updating ? "cursor-wait" : "cursor-pointer"
-      )}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
-    >
-      <span
-        aria-hidden
-        className={styles.composerTuttiModeIcon}
-        data-snap-active={shouldPlaySnap ? "true" : undefined}
-      >
-        <span
-          className={styles.composerTuttiModeIconStatic}
-          style={{
-            WebkitMaskImage: `url("${tuttiModeLinedIconUrl}")`,
-            WebkitMaskPosition: "center",
-            WebkitMaskRepeat: "no-repeat",
-            WebkitMaskSize: "contain",
-            maskImage: `url("${tuttiModeLinedIconUrl}")`,
-            maskPosition: "center",
-            maskRepeat: "no-repeat",
-            maskSize: "contain"
-          }}
-        />
-        {shouldPlaySnap ? (
-          <ComposerTuttiModeSnapAnimation active={active} />
-        ) : null}
-      </span>
-      <span className="min-w-0 truncate">{label}</span>
-      <Switch
-        id={switchId}
-        size="sm"
-        checked={active}
-        disabled={updating}
-        aria-label={label}
-        className="ml-0.5"
-        data-testid="agent-gui-composer-tutti-mode-toggle-switch"
-        onCheckedChange={(checked) => onTuttiModeChange(checked)}
-      />
-    </label>
+    <TooltipProvider delayDuration={120}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <label
+            htmlFor={switchId}
+            data-testid="agent-gui-composer-tutti-mode-toggle"
+            data-agent-tutti-mode-active={active ? "true" : undefined}
+            className={cn(
+              styles.composerMenuTrigger,
+              "group w-auto !gap-1.5",
+              updating ? "cursor-wait" : "cursor-pointer"
+            )}
+            onMouseEnter={() => setHovered(true)}
+            onMouseLeave={() => setHovered(false)}
+          >
+            <span
+              aria-hidden
+              className={styles.composerTuttiModeIcon}
+              data-snap-active={shouldPlaySnap ? "true" : undefined}
+            >
+              <span
+                className={styles.composerTuttiModeIconStatic}
+                style={{
+                  WebkitMaskImage: `url("${tuttiModeLinedIconUrl}")`,
+                  WebkitMaskPosition: "center",
+                  WebkitMaskRepeat: "no-repeat",
+                  WebkitMaskSize: "contain",
+                  maskImage: `url("${tuttiModeLinedIconUrl}")`,
+                  maskPosition: "center",
+                  maskRepeat: "no-repeat",
+                  maskSize: "contain"
+                }}
+              />
+              {shouldPlaySnap ? (
+                <ComposerTuttiModeSnapAnimation active={active} />
+              ) : null}
+            </span>
+            <span className="min-w-0 truncate">{label}</span>
+            <Switch
+              id={switchId}
+              size="sm"
+              checked={active}
+              disabled={updating}
+              aria-label={label}
+              className="ml-0.5"
+              data-testid="agent-gui-composer-tutti-mode-toggle-switch"
+              onCheckedChange={(checked) => onTuttiModeChange(checked)}
+            />
+          </label>
+        </TooltipTrigger>
+        <TooltipContent side="top">{description ?? label}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerPaletteCatalog.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerPaletteCatalog.ts
@@ -207,7 +207,13 @@ export function useComposerPaletteCatalog({
             label: capLabel,
             description: capDescription,
             settingsAriaLabel: capSettingsLabel,
-            settingsLabel: labels.capabilityInlineSettingsLabel,
+            // Tutti Mode has no inline settings surface (its "settings" button
+            // was a no-op), so omit the label to drop the button entirely; the
+            // row body still toggles the capability.
+            settingsLabel:
+              command.capability === "tutti"
+                ? undefined
+                : labels.capabilityInlineSettingsLabel,
             disabled: capabilityControlsReadOnly,
             selectAction:
               command.capability === "computerUse" &&

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGuiOrchestration.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGuiOrchestration.ts
@@ -6,7 +6,7 @@ export const enAgentGuiOrchestration = {
   normalModeDescription: "Execute the request directly",
   tuttiModeLabel: "Tutti Mode",
   tuttiModeDescription:
-    "Ask the agent to prefer Tutti's native workflow capabilities",
+    "Type what you want done — Tutti plans it, splits the tasks, and assigns each to the right agent and model",
   tuttiModeRemove: "Turn off Tutti mode",
   tuttiBudgetTitle: "Tutti preferences",
   tuttiBudgetEffectLabel: "Effect",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
@@ -261,7 +261,8 @@ export const zhCNAgentGui = {
   normalModeLabel: "普通",
   normalModeDescription: "直接执行请求",
   tuttiModeLabel: "Tutti Mode",
-  tuttiModeDescription: "提示 Agent 优先使用 Tutti 原生工作流能力",
+  tuttiModeDescription:
+    "输入你想做的，Tutti 会规划、拆分任务，并分派给合适的 Agent 和模型",
   tuttiModeRemove: "关闭 Tutti mode",
   tuttiBudgetTitle: "Tutti 偏好",
   tuttiBudgetEffectLabel: "效果",


### PR DESCRIPTION
## Backport to `release/0729`

Backport of #1820 (`fix(agent): rewrite Tutti Mode description and tidy its toggle surfaces`) onto the `release/0729` line. Cherry-picked from `13566ab3b` — clean pick, no conflicts, identical diff.

## What & why

The **Tutti Mode** toggle didn't explain itself. Its description was internal jargon — *"Ask the agent to prefer Tutti's native workflow capabilities"* / *"提示 Agent 优先使用 Tutti 原生工作流能力"* — which tells the user nothing about what turning it on does. It also carried a dead "Settings" affordance in the slash-command palette.

## Changes

- **Rewrite `tuttiModeDescription` (en + zh)** to describe what the mode actually does from the user's point of view: you say what you want, and Tutti **plans it, splits the tasks, and assigns each to a suitable agent and model**. Shared by both surfaces (composer chip tooltip + slash-command palette row).
  - zh: `输入你想做的，Tutti 会规划、拆分任务，并分派给合适的 Agent 和模型`
  - en: `Type what you want done — Tutti plans it, splits the tasks, and assigns each to the right agent and model`
- **Remove the "Settings" button on the Tutti capability row** in the slash-command palette. For `tutti` that button was a no-op (it only closed the palette), so `settingsLabel` is omitted for that entry; the row body still toggles the capability. `computerUse` / `browserUse` settings buttons unchanged.
- **Swap the composer chip's native `title` tooltip for the design-system `Tooltip`** (same usage as `AgentHandoffMenu`). DOM/layout and the hover snap animation are unaffected — `asChild` merges onto the same `<label>`.
- **Update the chip spec** to assert the tooltip via hover (`pointerMove` → `findByRole("tooltip")`) instead of the removed `title` attribute.

## Verification

- `agent-gui` specs: **22 passed** (`ComposerTuttiModeChip.spec.tsx` + `AgentSlashCommandPalette.spec.tsx`)
- package `typecheck`: **pass**
- push `check:changed`: all lanes green (on the source branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1821" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and presentation-only changes in Agent GUI composer and slash palette; no auth, data, or execution-path logic.
> 
> **Overview**
> **Tutti Mode** copy and UI are tightened so users see what the mode does and lose a useless control.
> 
> **`tuttiModeDescription`** is rewritten in English and Chinese to describe user-visible behavior (you state the goal; Tutti plans, splits work, and assigns agents/models), replacing internal jargon. That string is shared by the composer chip tooltip and the slash palette capability row.
> 
> On the **composer Tutti chip**, the native **`title`** tooltip is replaced with the design-system **`Tooltip`** (`TooltipProvider` / `TooltipTrigger asChild` on the same `<label>`). Hover snap animation and layout stay the same. Tests now hover the chip and assert **`role="tooltip"`** instead of a `title` attribute.
> 
> In the **slash-command palette**, the Tutti capability row no longer shows an inline **Settings** button: **`settingsLabel`** is **`undefined`** for `tutti` (it was a no-op). Row selection still toggles the capability; browser/computer settings buttons are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb8676fc225728e1ac42ee8ecdfeb70c7d1685f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->