### PR TITLE
refactor(agent): unify session settings updates

### DIFF
--- a/apps/mobile/src/services/workspaceActivityService.test.ts
+++ b/apps/mobile/src/services/workspaceActivityService.test.ts
@@ -297,9 +297,19 @@ describe("WorkspaceActivityService", () => {
 
     await service.start();
     await flushAsyncWork();
+    const engine = (
+      service as unknown as {
+        engine: AgentSessionEngine;
+      }
+    ).engine;
+    const updateSessionSettings = jest.spyOn(engine, "updateSessionSettings");
     service.updateComposerSettings({ planMode: true });
     await flushAsyncWork();
 
+    expect(updateSessionSettings).toHaveBeenCalledWith({
+      agentSessionId: "session-1",
+      settings: { planMode: true }
+    });
     expect(settingsRequests).toEqual([{ planMode: true }]);
     expect(service.getSnapshot().selectedSession?.settings.planMode).toBe(true);
 

--- a/apps/mobile/src/services/workspaceActivityService.ts
+++ b/apps/mobile/src/services/workspaceActivityService.ts
@@ -2,7 +2,6 @@ import {
   AGENT_SESSION_ENGINE_LOCAL_ORIGIN,
   createAgentActivitySnapshotProjector,
   createAgentSessionEngine,
-  selectEngineSessionSettingsUpdate,
   selectEngineSessionRuntimeAvailability,
   type AgentActivitySessionSettings,
   type AgentActivityInteraction,
@@ -335,18 +334,9 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
       return;
     }
     if (!target.agentSessionId) return;
-    const settingsUpdate = selectEngineSessionSettingsUpdate(
-      this.engine.getSnapshot(),
-      target.agentSessionId
-    );
-    this.engine.dispatch({
+    this.engine.updateSessionSettings({
       agentSessionId: target.agentSessionId,
-      commandId: createMobileActivityCommandId(),
-      retry: settingsUpdate?.status === "unknown",
-      settings,
-      timeoutMs: COMMAND_TIMEOUT_MS,
-      type: "session/settingsUpdateRequested",
-      workspaceId: this.workspace.id
+      settings
     });
   }
 

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -196,16 +196,24 @@ It owns:
   validation for rename and pin, validated delete-result tombstone projection,
   shared mutation settlement, and a serialized settings-precondition state
   machine
-- semantic `AgentSessionEngine` methods for composer-option loading, rename,
-  pin, and batch delete; these methods hide target/workspace projection,
-  command identity, cache or mutation coordination, settlement waiting, and
-  canonical result projection from product hosts; mutation methods also own
-  timeout and cancellation policy; hosts retain transport, DTO mapping,
-  AbortSignal propagation, and product-specific command extensions (see
+- semantic `AgentSessionEngine` methods for composer-option loading,
+  existing-Session settings updates, rename, pin, and batch delete. Settings
+  updates are intent admission: the Engine owns workspace and command identity,
+  the 30-second delivery timeout, serialized patch merging, and recognition of
+  a fresh user update as retry after unknown delivery, while consumers observe
+  the existing settings-operation projection. The other methods additionally
+  hide cache or mutation coordination, settlement waiting, and canonical
+  result projection from product hosts. Mutation methods own timeout and
+  cancellation policy; hosts retain transport, DTO mapping, AbortSignal
+  propagation, and product-specific command extensions (see
   [Agent GUI Node](./agent-gui-node.md#4-workspace-frontend-engine))
 
 The public host-effect seam is `AgentSessionEffectPort`; the public
 application-write seam is the semantic `AgentSessionEngine` methods.
+Product hosts call `updateSessionSettings` for an existing Session instead of
+constructing `session/settingsUpdateRequested` protocol fields. Settings held
+before Session activation remain part of the activation flow and do not pass
+through this existing-Session method.
 Rename and pin effects return an authoritative Session envelope, and batch
 delete returns the complete typed deletion result. Reducers still validate
 those results before applying canonical state, while the public port prevents

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -650,13 +650,18 @@ disable submission, but must not change editor editability.
   `EngineExtensionCommand` adapters
 - the Engine alone translates shared activation, prompt send, settings update,
   turn cancel, Interaction response, rename, pin, and batch-delete commands
-  into `AgentSessionEffectPort` calls. Desktop and Mobile implement those
-  semantic methods and must not duplicate a command-type switch for them.
-  Host activity facades call `engine.renameSession`,
+  into `AgentSessionEffectPort` calls. Desktop and Mobile effect ports retain
+  transport and DTO mapping but must not duplicate a command-type switch for
+  these shared effects. Host activity facades call
+  `engine.updateSessionSettings`, `engine.renameSession`,
   `engine.setSessionPinned`, and `engine.deleteSessions`; these deep methods
-  own workspace projection, mutation identity, default timeout, cancellation,
-  settlement waiting, and canonical result projection. Hosts must not
-  reconstruct that protocol with `dispatchSessionMutation` and snapshot reads.
+  own the applicable workspace projection, command or mutation identity,
+  timeout, cancellation, settlement, and canonical result projection. Settings
+  update is fire-and-observe intent admission rather than a settlement Promise:
+  the existing settings-operation selector remains the source of pending,
+  failed, and unknown state. Hosts must not reconstruct mutation protocol with
+  `dispatchSessionMutation` and snapshot reads or construct raw
+  `session/settingsUpdateRequested` fields for an existing Session.
   Platform-only commands remain in each host's `EngineExtensionCommand`
   adapter. Every effect propagates the Engine-owned AbortSignal to its
   transport. Rename, pin, and delete settle through the shared Session-mutation
@@ -673,8 +678,9 @@ disable submission, but must not change editor editability.
   while a failed or timed-out precondition prevents delivery. A timed-out
   settings write remains delivery-unknown and does not release queued writes
   automatically. A fresh explicit settings selection is the user's retry:
-  Desktop AgentGUI and Native Mobile derive that retry from the exact Engine
-  settings-operation state
+  `engine.updateSessionSettings` recognizes the exact Engine
+  settings-operation state, so Desktop AgentGUI and Native Mobile do not derive
+  retry flags independently
 - consumers do not read reducer maps directly
 - consumers do not create canonical session/message mirrors
 - optimistic records define confirmation, rejection, timeout, and uncertain-delivery paths
@@ -865,10 +871,14 @@ is mapped once by `@tutti-os/agent-activity-tuttid-adapter` into
 `AgentActivityComposerOptions`, while the host extension adapter remains the
 transport seam. Hosts render provider-authored options and use the shared
 support projection, but keep Native/DOM menus and temporary open state local.
-Existing-session setting changes enter the engine as
-`session/settingsUpdateRequested`; new-session draft settings travel on the
-activation intent. A renderer must not call the settings endpoint from a
-component or invent a provider-specific settings schema.
+Existing-Session setting changes enter through
+`engine.updateSessionSettings`. The Engine allocates command identity, fixes
+timeout and retry policy, and translates the semantic call to its internal
+`session/settingsUpdateRequested` intent. New-Session draft settings travel on
+the activation intent instead; provider-independent draft projection and
+Desktop-persisted defaults remain surface policy until activation. A renderer
+must not call the settings endpoint from a component or invent a
+provider-specific settings schema.
 
 An activation intent's shared Session settings are not an HTTP create-field
 allowlist. Each host must construct a typed

--- a/packages/agent/activity-core/src/engine/createAgentSessionEngine.ts
+++ b/packages/agent/activity-core/src/engine/createAgentSessionEngine.ts
@@ -11,7 +11,8 @@ import {
   selectEngineInteractionsForSession,
   selectEngineLatestTurn,
   selectEnginePendingInteractions,
-  selectEngineSession
+  selectEngineSession,
+  selectEngineSessionSettingsUpdate
 } from "./sessionLifecycle.selectors.ts";
 import {
   dispatchSessionMutationWithCancellation,
@@ -28,6 +29,7 @@ import {
   type AgentSessionEngineIntentObserver,
   type AgentSessionEngineListener,
   type AgentSessionLoadComposerOptionsInput,
+  type AgentSessionUpdateSettingsInput,
   type EngineClock,
   type EngineCommandPort,
   type EngineDispatchOptions,
@@ -56,6 +58,7 @@ import type {
  */
 export const ENGINE_INTENT_BATCH_DELAY_MS = 33;
 const SESSION_MUTATION_TIMEOUT_MS = 30_000;
+const SESSION_SETTINGS_UPDATE_TIMEOUT_MS = 30_000;
 
 export interface CreateAgentSessionEngineInput {
   batchDelayMs?: number;
@@ -98,6 +101,7 @@ export function createAgentSessionEngine({
   let disposed = false;
   let composerOptionsCommandSequence = 1;
   let sessionMutationSequence = 1;
+  let sessionSettingsUpdateSequence = 1;
   const pendingComposerOptionsDisposals = new Set<() => void>();
 
   const expiryClock = createEngineExpiryClock({
@@ -373,6 +377,32 @@ export function createAgentSessionEngine({
     return `${kind}:${clock.nowUnixMs()}:${sequence}`;
   }
 
+  function nextSessionSettingsUpdateCommandId(): string {
+    const sequence = sessionSettingsUpdateSequence++;
+    return `settings:${clock.nowUnixMs()}:${sequence}`;
+  }
+
+  function updateSessionSettings(input: AgentSessionUpdateSettingsInput): void {
+    const agentSessionId = input.agentSessionId.trim();
+    const settings = { ...input.settings };
+    if (!agentSessionId || Object.keys(settings).length === 0) {
+      return;
+    }
+    const current = selectEngineSessionSettingsUpdate(
+      publicSnapshot,
+      agentSessionId
+    );
+    dispatch({
+      agentSessionId,
+      commandId: nextSessionSettingsUpdateCommandId(),
+      retry: current?.status === "unknown",
+      settings,
+      timeoutMs: SESSION_SETTINGS_UPDATE_TIMEOUT_MS,
+      type: "session/settingsUpdateRequested",
+      workspaceId: engineIdentity.workspaceId
+    });
+  }
+
   function mutationSessionResult(agentSessionId: string) {
     const session = selectEngineSession(publicSnapshot, agentSessionId);
     if (!session) return null;
@@ -497,7 +527,8 @@ export function createAgentSessionEngine({
       return () => {
         listeners.delete(listener);
       };
-    }
+    },
+    updateSessionSettings
   };
   return engine;
 }

--- a/packages/agent/activity-core/src/engine/sessionSettings.semantic.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionSettings.semantic.test.ts
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { normalizeAgentActivitySession } from "../sessionNormalization.ts";
+import type { AgentActivitySessionSettings } from "../types.ts";
+import { createAgentSessionEngine } from "./createAgentSessionEngine.ts";
+import { selectEngineSessionSettingsUpdate } from "./sessionLifecycle.selectors.ts";
+import type {
+  EngineCommandPort,
+  EngineExternalCommand,
+  EngineScheduler
+} from "./types.ts";
+
+function createHarness() {
+  let nowUnixMs = 100;
+  let taskSequence = 0;
+  const commands: EngineExternalCommand[] = [];
+  const settlers = new Map<string, (value: unknown) => void>();
+  const scheduled: Array<{
+    atUnixMs: number;
+    canceled: boolean;
+    run(): void;
+    sequence: number;
+  }> = [];
+  const commandPort: EngineCommandPort = {
+    execute(command) {
+      commands.push(command);
+      return new Promise((resolve) => {
+        settlers.set(command.commandId, resolve);
+      });
+    }
+  };
+  const scheduler: EngineScheduler = {
+    schedule(delayMs, run) {
+      const task = {
+        atUnixMs: nowUnixMs + delayMs,
+        canceled: false,
+        run,
+        sequence: taskSequence++
+      };
+      scheduled.push(task);
+      return {
+        cancel() {
+          task.canceled = true;
+        }
+      };
+    }
+  };
+  const engine = createAgentSessionEngine({
+    clock: { nowUnixMs: () => nowUnixMs },
+    commandPort,
+    identity: { origin: "test", workspaceId: "workspace-1" },
+    scheduler
+  });
+  engine.dispatch({
+    sessions: [session()],
+    type: "session/snapshotReceived"
+  });
+  return {
+    advance(ms: number) {
+      nowUnixMs += ms;
+      for (;;) {
+        const due = scheduled
+          .filter((task) => !task.canceled && task.atUnixMs <= nowUnixMs)
+          .sort(
+            (left, right) =>
+              left.atUnixMs - right.atUnixMs || left.sequence - right.sequence
+          )[0];
+        if (!due) return;
+        due.canceled = true;
+        due.run();
+      }
+    },
+    commands,
+    engine,
+    succeed(commandId: string, settings: AgentActivitySessionSettings) {
+      settlers.get(commandId)?.({
+        agentSessionId: "session-1",
+        session: session(settings)
+      });
+      settlers.delete(commandId);
+    }
+  };
+}
+
+test("semantic settings update owns command identity, scope, and timeout", async () => {
+  const harness = createHarness();
+
+  harness.engine.updateSessionSettings({
+    agentSessionId: " session-1 ",
+    settings: { planMode: true }
+  });
+
+  assert.deepEqual(harness.commands, [
+    {
+      agentSessionId: "session-1",
+      commandId: "settings:100:1",
+      correlationId: "session-1",
+      settings: { planMode: true },
+      timeoutMs: 30_000,
+      type: "session/updateSettings",
+      workspaceId: "workspace-1"
+    }
+  ]);
+
+  harness.succeed("settings:100:1", { planMode: true });
+  await flushMicrotasks();
+
+  assert.equal(
+    selectEngineSessionSettingsUpdate(harness.engine.getSnapshot(), "session-1")
+      ?.status,
+    "idle"
+  );
+});
+
+test("semantic settings update treats a new user selection as the retry after unknown delivery", () => {
+  const harness = createHarness();
+
+  harness.engine.updateSessionSettings({
+    agentSessionId: "session-1",
+    settings: { planMode: true }
+  });
+  harness.advance(30_000);
+
+  assert.equal(
+    selectEngineSessionSettingsUpdate(harness.engine.getSnapshot(), "session-1")
+      ?.status,
+    "unknown"
+  );
+
+  harness.engine.updateSessionSettings({
+    agentSessionId: "session-1",
+    settings: { model: "model-2" }
+  });
+
+  assert.deepEqual(harness.commands[1], {
+    agentSessionId: "session-1",
+    commandId: "settings:30100:2",
+    correlationId: "session-1",
+    settings: { model: "model-2", planMode: true },
+    timeoutMs: 30_000,
+    type: "session/updateSettings",
+    workspaceId: "workspace-1"
+  });
+});
+
+function session(settings: AgentActivitySessionSettings = {}) {
+  return normalizeAgentActivitySession({
+    activeTurnId: null,
+    agentSessionId: "session-1",
+    cwd: "/workspace",
+    latestTurnInteractions: [],
+    pendingInteractions: [],
+    provider: "codex",
+    settings,
+    title: "Session",
+    workspaceId: "workspace-1"
+  });
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}

--- a/packages/agent/activity-core/src/engine/types.ts
+++ b/packages/agent/activity-core/src/engine/types.ts
@@ -440,6 +440,11 @@ export interface AgentSessionLoadComposerOptionsInput {
   targetKey: string;
 }
 
+export interface AgentSessionUpdateSettingsInput {
+  agentSessionId: string;
+  settings: AgentActivitySessionSettings;
+}
+
 export interface AgentSessionEngine {
   readonly identity: AgentSessionEngineIdentity;
   deleteSessions(
@@ -467,6 +472,7 @@ export interface AgentSessionEngine {
     }
   ): Promise<AgentActivitySession>;
   subscribe(listener: AgentSessionEngineListener): () => void;
+  updateSessionSettings(input: AgentSessionUpdateSettingsInput): void;
 }
 import type {
   PromptQueueIntent,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerSettingsActions.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerSettingsActions.spec.tsx
@@ -310,7 +310,10 @@ describe("useAgentGUIComposerSettingsActions", () => {
     const draftSettingsBySessionIdRef: {
       current: Record<string, AgentSessionComposerSettings>;
     } = { current: {} };
-    const dispatch = vi.spyOn(sessionEngine, "dispatch");
+    const updateSessionSettings = vi.spyOn(
+      sessionEngine,
+      "updateSessionSettings"
+    );
     const activeSettings: AgentSessionComposerSettings = {
       browserUse: true,
       computerUse: true,
@@ -364,14 +367,10 @@ describe("useAgentGUIComposerSettingsActions", () => {
       });
     });
 
-    expect(dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        agentSessionId: "session-1",
-        retry: true,
-        settings: { permissionModeId: "acceptEdits" },
-        type: "session/settingsUpdateRequested"
-      })
-    );
+    expect(updateSessionSettings).toHaveBeenCalledWith({
+      agentSessionId: "session-1",
+      settings: { permissionModeId: "acceptEdits" }
+    });
     expect(execute).toHaveBeenCalledTimes(2);
     expect(onRememberComposerDefaults).toHaveBeenCalledWith({
       agentTargetId: "local:claude-code",

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerSettingsActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerSettingsActions.ts
@@ -1,6 +1,5 @@
 import {
   selectEngineSession,
-  selectEngineSessionSettingsUpdate,
   type AgentActivityTurn,
   type AgentSessionEngine
 } from "@tutti-os/agent-activity-core";
@@ -28,7 +27,6 @@ import {
   resolveEffectiveComposerSettings,
   sameComposerSettings
 } from "./agentGuiController.composerHelpers";
-import { shouldRetrySessionSettingsUpdate } from "../model/composerModeSelection";
 import {
   enforceComposerModelBindingForHomeDefaults,
   nodeDataMatchesComposerTarget,
@@ -48,10 +46,7 @@ import {
   type AgentGUIComposerDefaultsMutation,
   type AgentGUIRetiredComposerDefault
 } from "./agentGuiComposerDefaultsReconciliation";
-import {
-  normalizeOptionalText,
-  createAgentGUIConversationId
-} from "./agentGuiController.promptHelpers";
+import { normalizeOptionalText } from "./agentGuiController.promptHelpers";
 import {
   composerDefaultsPatchFromSettings,
   composerOptionsForTarget,
@@ -455,18 +450,9 @@ export function useAgentGUIComposerSettingsActions(
             settings: { ...sessionSettingsPatch }
           });
         } else {
-          const settingsUpdate = selectEngineSessionSettingsUpdate(
-            sessionEngine.getSnapshot(),
-            agentSessionId
-          );
-          sessionEngine.dispatch({
+          sessionEngine.updateSessionSettings({
             agentSessionId,
-            commandId: `settings:${createAgentGUIConversationId()}`,
-            retry: shouldRetrySessionSettingsUpdate(settingsUpdate?.status),
-            settings: { ...sessionSettingsPatch },
-            timeoutMs: 30_000,
-            type: "session/settingsUpdateRequested",
-            workspaceId
+            settings: { ...sessionSettingsPatch }
           });
         }
         return;

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/composerModeSelection.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/composerModeSelection.spec.ts
@@ -2,8 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   normalizePermissionModeSelection,
   permissionModeSelectionPatch,
-  resolvePermissionModeControlsDisabled,
-  shouldRetrySessionSettingsUpdate
+  resolvePermissionModeControlsDisabled
 } from "./composerModeSelection";
 
 describe("normalizePermissionModeSelection", () => {
@@ -78,17 +77,4 @@ describe("resolvePermissionModeControlsDisabled", () => {
       })
     ).toBe(false);
   });
-});
-
-describe("shouldRetrySessionSettingsUpdate", () => {
-  it("treats a new user selection as an explicit retry after an unknown result", () => {
-    expect(shouldRetrySessionSettingsUpdate("unknown")).toBe(true);
-  });
-
-  it.each([null, "idle", "inFlight", "failed"])(
-    "does not mark %s as an uncertain retry",
-    (status) => {
-      expect(shouldRetrySessionSettingsUpdate(status)).toBe(false);
-    }
-  );
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/composerModeSelection.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/composerModeSelection.ts
@@ -45,15 +45,3 @@ export function resolvePermissionModeControlsDisabled(options: {
     options.showStopButton
   );
 }
-
-/**
- * A settings timeout means delivery is uncertain, so the engine blocks a new
- * command until the caller explicitly identifies a user retry. A fresh menu
- * selection is that explicit retry; ordinary idle/in-flight/failed updates are
- * not.
- */
-export function shouldRetrySessionSettingsUpdate(
-  status: string | null | undefined
-): boolean {
-  return status === "unknown";
-}


### PR DESCRIPTION
## What changed

- add `AgentSessionEngine.updateSessionSettings` as the semantic application-write entry for existing Session settings
- move command identity, timeout, serialized patch merging, and unknown-delivery retry recognition into the Engine
- migrate Desktop AgentGUI and Native Mobile away from assembling raw `session/settingsUpdateRequested` intents
- remove the now-duplicated AgentGUI retry helper
- add Engine, Desktop, and Mobile regression coverage
- document the existing-Session settings boundary and keep pre-activation draft settings on the activation flow

## Why

Desktop and Mobile previously duplicated the protocol details needed to update settings for an existing Session. That left command identity, timeout, and uncertain-delivery retry policy exposed to product hosts and allowed the two clients to drift. The shared Engine already owned the settings queue and lifecycle, so the missing piece was a semantic admission method at that same boundary.

## Impact

Desktop and Mobile now express only the user intent to update an existing Session. Their effect ports continue to own transport and DTO mapping. New-Session draft settings are intentionally unchanged and still travel with activation.

## Validation

- `pnpm --filter @tutti-os/agent-activity-core test` — 397 passed
- focused AgentGUI tests — 13 passed
- focused Mobile service tests — 23 passed
- Activity Core, AgentGUI, and Mobile typechecks passed
- `pnpm check:changed` — 15 lanes passed
- pre-push `pnpm check:changed -- --push-ready` — 16 lanes passed
- `make dev-gui` smoke test: changed an existing Session permission and model, switched Sessions, verified persisted database state, then restored the original settings
