### PR TITLE
fix(agent): fail over npm registry mirrors when installing extension runtimes

### DIFF
--- a/services/tuttid/service/agentextension/installer.go
+++ b/services/tuttid/service/agentextension/installer.go
@@ -158,7 +158,12 @@ func (s *SetupService) executeInstall(
 		if runner == nil {
 			runner = localInstallCommandRunner{}
 		}
-		if err := runner.Run(installCtx, command, scratch, cleanInstallEnvironment(scratch)); err != nil {
+		baseEnv := cleanInstallEnvironment(scratch)
+		if isNPMRunner(plan.Runner) {
+			if err := s.runNPMInstallWithRegistryFallback(installCtx, runner, command, scratch, staging, baseEnv, plan); err != nil {
+				return err
+			}
+		} else if err := runner.Run(installCtx, command, scratch, baseEnv); err != nil {
 			return fmt.Errorf("%w: %w", ErrRuntimeInstallFailed, err)
 		}
 	}

--- a/services/tuttid/service/agentextension/npm_registry.go
+++ b/services/tuttid/service/agentextension/npm_registry.go
@@ -1,0 +1,194 @@
+package agentextension
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/tutti-os/tutti/packages/agent/daemon/managednpm"
+)
+
+// perRegistryNPMInstallTimeout bounds a single registry attempt so a blocked or
+// stalled source fails over to the next one instead of consuming the whole
+// install budget. Mirrors the provider installer's per-registry budget.
+const perRegistryNPMInstallTimeout = 150 * time.Second
+
+// isNPMRunner reports whether an extension runtime installs through an npm-style
+// client, which is the only runner that resolves packages through a registry
+// and therefore benefits from the mirror fallback.
+func isNPMRunner(runner string) bool {
+	switch runner {
+	case "npm", "pnpm":
+		return true
+	default:
+		return false
+	}
+}
+
+// runNPMInstallWithRegistryFallback installs an npm-based extension runtime,
+// trying the official registry and the CN-available mirrors in ranked order.
+// Each attempt is bounded and, on failure, the half-written install tree is
+// purged so the next attempt starts clean. The install command is unchanged
+// across attempts; only npm_config_registry selects the source, so the plan's
+// runner-identity contract is preserved.
+func (s *SetupService) runNPMInstallWithRegistryFallback(
+	ctx context.Context,
+	runner InstallCommandRunner,
+	command []string,
+	scratch string,
+	staging string,
+	baseEnv []string,
+	plan InstallPlan,
+) error {
+	registries := rankedNPMRegistries(ctx, s.npmRegistryHTTPClient(), plan.PackageName, plan.PackageVersion)
+	var lastErr error
+	for index, registry := range registries {
+		attemptCtx, cancel := context.WithTimeout(ctx, perRegistryNPMInstallTimeout)
+		env := withNPMRegistry(slices.Clone(baseEnv), registry)
+		err := runner.Run(attemptCtx, command, scratch, env)
+		cancel()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		// A cancelled or expired parent context means the whole install is being
+		// torn down (user cancel or daemon shutdown); do not fail over to another
+		// registry — return the interruption immediately. A per-registry timeout
+		// leaves the parent context live, so genuine failover still proceeds.
+		if ctx.Err() != nil {
+			break
+		}
+		// A failed or interrupted npm install can leave a half-written
+		// node_modules (notably a `.<pkg>-<hash>` staging dir) that makes the
+		// next attempt fail with ENOTEMPTY against the dirty tree. Purge it so
+		// the next registry — or a later retry — starts clean.
+		purgeStagingNPMTree(staging)
+		if index < len(registries)-1 {
+			slog.Warn(
+				"agent extension npm install failed on registry, trying next",
+				"event", "tutti.agent_extension.npm_install.registry_failover",
+				"agentKey", plan.AgentKey,
+				"registry", managednpm.DisplayRegistryHost(registry),
+				"error", err,
+			)
+		}
+	}
+	if lastErr == nil {
+		lastErr = errors.New("no npm registry available")
+	}
+	return fmt.Errorf("%w: %w", ErrRuntimeInstallFailed, lastErr)
+}
+
+func (s *SetupService) npmRegistryHTTPClient() *http.Client {
+	if s.Plans.Manager != nil {
+		return s.Plans.Manager.Client
+	}
+	return nil
+}
+
+// rankedNPMRegistries orders the official registry and the CN mirrors by a
+// lightweight metadata probe so a blocked or slow source is tried last. It
+// always returns at least one registry so the install still attempts, and it
+// honours the TUTTI_AGENT_NPM_REGISTRY override (a single pinned source).
+// Without an HTTP client the probe is skipped and the default order is used —
+// ranking is a best-effort optimisation, the fallback loop is the guarantee.
+func rankedNPMRegistries(ctx context.Context, client *http.Client, packageName, version string) []string {
+	registries := managednpm.DefaultRegistries(strings.TrimSpace(os.Getenv(managednpm.RegistryOverrideEnv)))
+	if len(registries) <= 1 || client == nil {
+		return registryURLs(registries)
+	}
+	ranked := managednpm.RankRegistries(
+		ctx,
+		managednpm.Descriptor{PackageName: packageName, RecommendedVersion: version},
+		registries,
+		runtime.GOOS,
+		runtime.GOARCH,
+		extensionNPMRegistryProber{client: client},
+	)
+	urls := make([]string, len(ranked))
+	for index := range ranked {
+		urls[index] = ranked[index].Registry.URL
+	}
+	return urls
+}
+
+func registryURLs(registries []managednpm.Registry) []string {
+	urls := make([]string, len(registries))
+	for index := range registries {
+		urls[index] = registries[index].URL
+	}
+	return urls
+}
+
+// extensionNPMRegistryProber implements managednpm.RegistryProber with a bounded
+// GET against the package-version metadata endpoint. The managednpm package
+// stays transport-free; the host owns the HTTP client.
+type extensionNPMRegistryProber struct {
+	client *http.Client
+}
+
+func (p extensionNPMRegistryProber) ProbeRegistry(
+	ctx context.Context,
+	request managednpm.RegistryProbeRequest,
+) managednpm.RegistryProbeResult {
+	if p.client == nil {
+		return managednpm.RegistryProbeResult{}
+	}
+	endpoint := managednpm.PackageEndpoint(request.Registry.URL, request.PackageName, request.Version)
+	httpRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return managednpm.RegistryProbeResult{}
+	}
+	response, err := p.client.Do(httpRequest)
+	if err != nil {
+		return managednpm.RegistryProbeResult{}
+	}
+	defer response.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 64*1024))
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return managednpm.RegistryProbeResult{}
+	}
+	return managednpm.RegistryProbeResult{Reachable: true, Complete: true}
+}
+
+// withNPMRegistry returns env with exactly one npm_config_registry entry,
+// dropping any inherited value so the ranked source is authoritative.
+func withNPMRegistry(env []string, registry string) []string {
+	const prefix = "npm_config_registry="
+	result := make([]string, 0, len(env)+1)
+	for _, kv := range env {
+		if strings.HasPrefix(strings.ToLower(kv), prefix) {
+			continue
+		}
+		result = append(result, kv)
+	}
+	return append(result, prefix+registry)
+}
+
+// purgeStagingNPMTree removes the npm install tree under the staging root so a
+// retry starts from a clean slate. Best-effort: a removal failure is logged and
+// the next attempt is still allowed to run.
+func purgeStagingNPMTree(staging string) {
+	staging = strings.TrimSpace(staging)
+	if staging == "" {
+		return
+	}
+	nodeModules := filepath.Join(staging, "node_modules")
+	if err := os.RemoveAll(nodeModules); err != nil {
+		slog.Warn(
+			"agent extension npm install tree purge failed",
+			"event", "tutti.agent_extension.npm_install.tree_purge_failed",
+			"path", nodeModules,
+			"error", err,
+		)
+	}
+}

--- a/services/tuttid/service/agentextension/npm_registry_test.go
+++ b/services/tuttid/service/agentextension/npm_registry_test.go
@@ -1,0 +1,241 @@
+package agentextension
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tutti-os/tutti/packages/agent/daemon/managednpm"
+)
+
+type npmProbeRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f npmProbeRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func npmProbeResponse(status int) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader("{}")),
+		Header:     make(http.Header),
+	}
+}
+
+func npmProbeClient(fn func(host string) int) *http.Client {
+	return &http.Client{Transport: npmProbeRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		return npmProbeResponse(fn(request.URL.Host)), nil
+	})}
+}
+
+func npmRegistryFromEnv(env []string) string {
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "npm_config_registry=") {
+			return strings.TrimPrefix(kv, "npm_config_registry=")
+		}
+	}
+	return ""
+}
+
+// sequencedInstallRunner returns a scripted result per call, records the
+// npm_config_registry each attempt saw, and simulates a half-written install
+// tree on failure so the caller's purge can be observed.
+type sequencedInstallRunner struct {
+	staging    string
+	results    []error
+	calls      int
+	registries []string
+}
+
+func (r *sequencedInstallRunner) Run(_ context.Context, _ []string, _ string, env []string) error {
+	r.registries = append(r.registries, npmRegistryFromEnv(env))
+	index := r.calls
+	r.calls++
+	var result error
+	if index < len(r.results) {
+		result = r.results[index]
+	}
+	if result != nil && r.staging != "" {
+		_ = os.MkdirAll(filepath.Join(r.staging, "node_modules", ".pkg-staging"), 0o700)
+	}
+	return result
+}
+
+func newNPMFallbackService(client *http.Client) *SetupService {
+	return &SetupService{Plans: InstallPlanService{Manager: &Manager{Client: client}}}
+}
+
+func npmFallbackPlan() InstallPlan {
+	return InstallPlan{AgentKey: "kimi-code", Runner: "npm", PackageName: "pkg", PackageVersion: "1.0.0"}
+}
+
+func TestIsNPMRunner(t *testing.T) {
+	for _, runner := range []string{"npm", "pnpm"} {
+		if !isNPMRunner(runner) {
+			t.Fatalf("isNPMRunner(%q) = false, want true", runner)
+		}
+	}
+	for _, runner := range []string{"uv", "binary", "", "pip"} {
+		if isNPMRunner(runner) {
+			t.Fatalf("isNPMRunner(%q) = true, want false", runner)
+		}
+	}
+}
+
+func TestWithNPMRegistryReplacesInherited(t *testing.T) {
+	env := []string{"PATH=/x", "NPM_CONFIG_REGISTRY=https://old.example", "npm_config_registry=https://stale.example"}
+	got := withNPMRegistry(env, "https://mirror.example")
+	registries := 0
+	for _, kv := range got {
+		if strings.HasPrefix(strings.ToLower(kv), "npm_config_registry=") {
+			registries++
+		}
+	}
+	if registries != 1 {
+		t.Fatalf("npm_config_registry entries = %d, want 1 (env=%v)", registries, got)
+	}
+	if npmRegistryFromEnv(got) != "https://mirror.example" {
+		t.Fatalf("registry = %q, want https://mirror.example", npmRegistryFromEnv(got))
+	}
+	if !slicesContains(got, "PATH=/x") {
+		t.Fatalf("unrelated env dropped: %v", got)
+	}
+}
+
+func TestRankedNPMRegistriesHonoursOverride(t *testing.T) {
+	t.Setenv(managednpm.RegistryOverrideEnv, "https://pinned.example")
+	got := rankedNPMRegistries(context.Background(), npmProbeClient(func(string) int { return 200 }), "pkg", "1.0.0")
+	if len(got) != 1 || got[0] != "https://pinned.example" {
+		t.Fatalf("ranked registries = %v, want [https://pinned.example]", got)
+	}
+}
+
+func TestRankedNPMRegistriesDeprioritisesUnreachableOfficial(t *testing.T) {
+	t.Setenv(managednpm.RegistryOverrideEnv, "")
+	client := npmProbeClient(func(host string) int {
+		if strings.Contains(host, "registry.npmjs.org") {
+			return 404
+		}
+		return 200
+	})
+	got := rankedNPMRegistries(context.Background(), client, "pkg", "1.0.0")
+	if len(got) != 3 {
+		t.Fatalf("ranked registries = %v, want 3 entries", got)
+	}
+	if got[len(got)-1] != managednpm.OfficialRegistryURL {
+		t.Fatalf("unreachable official registry ranked %v, want last", got)
+	}
+}
+
+func TestRunNPMInstallWithRegistryFallbackFailsOverAndPurges(t *testing.T) {
+	t.Setenv(managednpm.RegistryOverrideEnv, "")
+	staging := t.TempDir()
+	service := newNPMFallbackService(npmProbeClient(func(string) int { return 200 }))
+	runner := &sequencedInstallRunner{staging: staging, results: []error{errors.New("registry unreachable")}}
+
+	err := service.runNPMInstallWithRegistryFallback(
+		context.Background(), runner, []string{"npm", "install"}, t.TempDir(), staging,
+		[]string{"PATH=/x"}, npmFallbackPlan(),
+	)
+	if err != nil {
+		t.Fatalf("runNPMInstallWithRegistryFallback err = %v, want nil", err)
+	}
+	if runner.calls != 2 {
+		t.Fatalf("runner calls = %d, want 2 (fail then succeed)", runner.calls)
+	}
+	if runner.registries[0] == runner.registries[1] {
+		t.Fatalf("fallover did not switch registry: both %q", runner.registries[0])
+	}
+	if runner.registries[0] != managednpm.OfficialRegistryURL {
+		t.Fatalf("first attempt registry = %q, want official first", runner.registries[0])
+	}
+	if _, statErr := os.Stat(filepath.Join(staging, "node_modules")); !os.IsNotExist(statErr) {
+		t.Fatalf("staging node_modules not purged after failed attempt (stat err = %v)", statErr)
+	}
+}
+
+func TestRunNPMInstallWithRegistryFallbackExhaustsAllRegistries(t *testing.T) {
+	t.Setenv(managednpm.RegistryOverrideEnv, "")
+	staging := t.TempDir()
+	service := newNPMFallbackService(npmProbeClient(func(string) int { return 200 }))
+	runner := &sequencedInstallRunner{
+		staging: staging,
+		results: []error{errors.New("a"), errors.New("b"), errors.New("c")},
+	}
+
+	err := service.runNPMInstallWithRegistryFallback(
+		context.Background(), runner, []string{"npm", "install"}, t.TempDir(), staging,
+		[]string{"PATH=/x"}, npmFallbackPlan(),
+	)
+	if !errors.Is(err, ErrRuntimeInstallFailed) {
+		t.Fatalf("err = %v, want wrap of ErrRuntimeInstallFailed", err)
+	}
+	if runner.calls != 3 {
+		t.Fatalf("runner calls = %d, want 3 (all registries tried)", runner.calls)
+	}
+	distinct := map[string]struct{}{}
+	for _, registry := range runner.registries {
+		distinct[registry] = struct{}{}
+	}
+	if len(distinct) != 3 {
+		t.Fatalf("attempted registries = %v, want 3 distinct", runner.registries)
+	}
+}
+
+func TestRankedNPMRegistriesSkipsProbeWithoutClient(t *testing.T) {
+	t.Setenv(managednpm.RegistryOverrideEnv, "")
+	got := rankedNPMRegistries(context.Background(), nil, "pkg", "1.0.0")
+	want := []string{managednpm.OfficialRegistryURL, managednpm.HuaweiRegistryURL, managednpm.TencentRegistryURL}
+	if len(got) != len(want) {
+		t.Fatalf("registries = %v, want default order %v", got, want)
+	}
+	for index := range want {
+		if got[index] != want[index] {
+			t.Fatalf("registries = %v, want default order %v", got, want)
+		}
+	}
+}
+
+type cancelOnFirstInstallRunner struct {
+	cancel context.CancelFunc
+	calls  int
+}
+
+func (r *cancelOnFirstInstallRunner) Run(_ context.Context, _ []string, _ string, _ []string) error {
+	r.calls++
+	r.cancel()
+	return context.Canceled
+}
+
+func TestRunNPMInstallStopsFailoverOnContextCancel(t *testing.T) {
+	t.Setenv(managednpm.RegistryOverrideEnv, "")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	service := newNPMFallbackService(npmProbeClient(func(string) int { return 200 }))
+	runner := &cancelOnFirstInstallRunner{cancel: cancel}
+
+	err := service.runNPMInstallWithRegistryFallback(
+		ctx, runner, []string{"npm", "install"}, t.TempDir(), t.TempDir(),
+		[]string{"PATH=/x"}, npmFallbackPlan(),
+	)
+	if !errors.Is(err, ErrRuntimeInstallFailed) {
+		t.Fatalf("err = %v, want wrap of ErrRuntimeInstallFailed", err)
+	}
+	if runner.calls != 1 {
+		t.Fatalf("runner calls = %d, want 1 (no failover after parent cancel)", runner.calls)
+	}
+}
+
+func slicesContains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Problem

Agent-extension runtimes installed through **npm** (e.g. **Kimi Code** — `@moonshot-ai/kimi-code`) fail on networks that can't reach `registry.npmjs.org`, surfacing in the setup dialog as:

> `安装运行时` failed — `agent target runtime install failed: install command npm failed: exit status 1`

Root cause is an asymmetry between the two install paths:

- **Built-in providers** (tutti-agent, codex, claude-code) install via `agentstatus` + `managednpm`, which **ranks and fails over across mirrors** — `registry.npmjs.org → Huawei → Tencent` (`managednpm.DefaultRegistries`). In the field we see them recover: `agent provider managed npm install failed on registry ... registry=https://registry.npmjs.org exitCode=190 ... trying next`.
- **Agent extensions** install via `agentextension/installer.go`, which ran a **single `npm install`** with `npm_config_registry` unset and the user's `.npmrc` isolated (`cleanInstallEnvironment` points `userconfig`/`globalconfig` at empty files). So the only reachable source is the default `registry.npmjs.org`, with **no fallback** — one failure ⇒ `exit status 1`.

## Change

Route **npm/pnpm** extension installs through the same `managednpm` registry policy:

- Try the official registry and the CN mirrors in ranked order, each attempt bounded (`150s`), purging the half-written install tree between attempts (ENOTEMPTY recovery).
- Only `npm_config_registry` varies across attempts — the **install command is unchanged**, so the plan's runner-identity check (`command[0] == plan.Runner`) and plan digest are preserved.
- **`uv` and `binary` runners are untouched.** The provider path (`agentstatus`) is untouched.
- Honors `TUTTI_AGENT_NPM_REGISTRY` as a single-registry override (escape hatch).

### Two deliberate design points

1. **Ranking is best-effort.** The probe needs an `http.Client`; the daemon currently constructs `agentextension.Manager` with `Client: nil` (`wiring_daemon_api.go`), and `uv`/`release`/`binary` paths all tolerate nil. So when no client is set, the probe is **skipped** and the **default order** (`npmjs → Huawei → Tencent`) is used — the fallback still applies. Wiring a client would activate ranking but also touch uv/release/binary behavior, so it's intentionally left out of scope here.
2. **Cancellation stops failover.** A cancelled/expired parent context breaks the loop immediately instead of retrying the next mirror (correct behavior for user-cancel / daemon shutdown, and it avoids re-invoking a torn-down install runner).

## Tests

New `npm_registry_test.go` (hermetic — fake `RoundTripper`, no network):

- override pins a single registry; unreachable official registry ranked last; probe skipped without a client
- fail-over switches source + purges the staging tree; exhausting all registries wraps `ErrRuntimeInstallFailed`
- a cancelled parent context stops failover (no second attempt)
- `withNPMRegistry` / `isNPMRunner` units

`go build` / `go vet` / `gofmt` clean; full `agentextension` (`ok ~11s`) and `managednpm` (`ok`) suites pass.

## Scope / caveat

This fixes the **install-step** failure for npm-based extensions. The **Hermes** failure (`verification failed: ... signal: killed`) is a *different* stage (verification of an installed binary) and is **out of scope** here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1824" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes extension runtime install behavior and network/registry selection for npm-based extensions, but reuses existing managednpm policy and leaves non-npm runners untouched; mis-ranking could delay installs rather than corrupt data.
> 
> **Overview**
> **npm/pnpm** agent-extension runtime installs now use the same **registry ranking and mirror failover** as built-in providers (`managednpm`), instead of a single `npm install` with no fallback when `registry.npmjs.org` is unreachable.
> 
> `executeInstall` routes **npm** and **pnpm** runners through `runNPMInstallWithRegistryFallback`, which tries official npm plus CN mirrors in ranked order (optional HTTP probe when `Manager.Client` is set; otherwise default order). Each attempt is capped at **150s**, sets **`npm_config_registry`** only (install command unchanged for runner-identity checks), purges **`staging/node_modules`** between failures to avoid ENOTEMPTY, and stops failover when the parent context is cancelled. **`TUTTI_AGENT_NPM_REGISTRY`** pins a single registry. **uv**, **binary**, and the provider (`agentstatus`) paths are unchanged.
> 
> New **`npm_registry_test.go`** covers runner detection, env override, ranking, failover/purge, registry exhaustion, cancel behavior, and nil-client default order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75998f014ff10127dd868ca6bfcccdb6f0028dd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->