### PR TITLE
fix(tutti-mode): relax activation source CHECK constraints for agent_command (migration v5)

### DIFF
--- a/services/tuttid/data/workspace/migrations.go
+++ b/services/tuttid/data/workspace/migrations.go
@@ -77,6 +77,7 @@ const schemaMigrationTuttiModeActivationsV1 = "tutti_mode_activations_v1"
 const schemaMigrationTuttiModeTurnDispatchV2 = "tutti_mode_turn_dispatch_v2"
 const schemaMigrationTuttiModeOrchestrationIntensityV3 = "tutti_mode_orchestration_intensity_v3"
 const schemaMigrationTuttiModeEffectSpeedV4 = "tutti_mode_effect_speed_v4"
+const schemaMigrationTuttiModeAgentCommandSourceV5 = "tutti_mode_agent_command_source_v5"
 const schemaMigrationWorkspaceWorkflowTaskAssignmentsV4 = "workspace_workflow_task_assignments_v4"
 const schemaMigrationWorkspaceTuttiModeExecutionV1 = "workspace_tutti_mode_execution_v1"
 const schemaMigrationWorkspaceTuttiModeRunCancelCompensationV2 = "workspace_tutti_mode_run_cancel_compensation_v2"
@@ -352,6 +353,9 @@ INSERT OR IGNORE INTO tuttid_schema_migrations (id, applied_at_unix_ms)
 		return err
 	}
 	if err := s.applyTuttiModeEffectSpeedV4(ctx); err != nil {
+		return err
+	}
+	if err := s.applyTuttiModeAgentCommandSourceV5(ctx); err != nil {
 		return err
 	}
 	if err := s.applyWorkspaceWorkflowTaskAssignmentsV4(ctx); err != nil {

--- a/services/tuttid/data/workspace/migrations_tutti_mode_activations.go
+++ b/services/tuttid/data/workspace/migrations_tutti_mode_activations.go
@@ -232,6 +232,147 @@ VALUES (?, ?)
 	return nil
 }
 
+// applyTuttiModeAgentCommandSourceV5 relaxes the activation source vocabulary
+// so the Agent-issued 'agent_command' source may originate both activation
+// states, mirroring activationbiz.IsStateSource. The v1 rules live in
+// table-level CHECK constraints that SQLite cannot ALTER, so both tables are
+// rebuilt with their full post-v4 column set and the relaxed CHECKs, following
+// the applyWorkspaceWorkflowRevisionPathReuseV3 rebuild pattern.
+func (s *SQLiteStore) applyTuttiModeAgentCommandSourceV5(ctx context.Context) (returnErr error) {
+	applied, err := s.hasMigration(ctx, schemaMigrationTuttiModeAgentCommandSourceV5)
+	if err != nil {
+		return err
+	}
+	if applied {
+		return nil
+	}
+
+	conn, err := s.writeDB.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire Tutti mode agent command source migration connection: %w", err)
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx, "PRAGMA foreign_keys = OFF"); err != nil {
+		return fmt.Errorf("disable foreign keys for Tutti mode agent command source migration: %w", err)
+	}
+	foreignKeysDisabled := true
+	defer func() {
+		if !foreignKeysDisabled {
+			return
+		}
+		if _, enableErr := conn.ExecContext(context.Background(), "PRAGMA foreign_keys = ON"); returnErr == nil && enableErr != nil {
+			returnErr = fmt.Errorf("restore foreign keys after Tutti mode agent command source migration: %w", enableErr)
+		}
+	}()
+
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin Tutti mode agent command source migration: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `
+CREATE TABLE tutti_mode_activation_revisions_v5 (
+  workspace_id TEXT NOT NULL,
+  activation_id TEXT NOT NULL,
+  revision_id TEXT NOT NULL,
+  revision INTEGER NOT NULL CHECK (revision > 0),
+  state TEXT NOT NULL CHECK (state IN ('active', 'inactive')),
+  source TEXT NOT NULL CHECK (source IN ('slash_command', 'badge_remove', 'agent_command')),
+  created_at_unix_ms INTEGER NOT NULL,
+  orchestration_intensity INTEGER NOT NULL DEFAULT 50 CHECK (orchestration_intensity BETWEEN 0 AND 100),
+  speed INTEGER NOT NULL DEFAULT 50 CHECK (speed BETWEEN 0 AND 100),
+  PRIMARY KEY (workspace_id, activation_id, revision_id),
+  UNIQUE (workspace_id, activation_id, revision),
+  FOREIGN KEY (workspace_id, activation_id)
+    REFERENCES tutti_mode_activations(workspace_id, activation_id) ON DELETE CASCADE,
+  CHECK ((state = 'active' AND source IN ('slash_command', 'agent_command')) OR
+         (state = 'inactive' AND source IN ('badge_remove', 'agent_command')))
+);
+
+INSERT INTO tutti_mode_activation_revisions_v5 (
+  workspace_id, activation_id, revision_id, revision, state, source,
+  created_at_unix_ms, orchestration_intensity, speed
+)
+SELECT
+  workspace_id, activation_id, revision_id, revision, state, source,
+  created_at_unix_ms, orchestration_intensity, speed
+FROM tutti_mode_activation_revisions;
+
+DROP TABLE tutti_mode_activation_revisions;
+ALTER TABLE tutti_mode_activation_revisions_v5 RENAME TO tutti_mode_activation_revisions;
+
+CREATE TABLE tutti_mode_turn_snapshots_v5 (
+  workspace_id TEXT NOT NULL,
+  agent_session_id TEXT NOT NULL,
+  turn_id TEXT NOT NULL,
+  activation_id TEXT NOT NULL DEFAULT '',
+  revision_id TEXT NOT NULL DEFAULT '',
+  revision INTEGER NOT NULL DEFAULT 0 CHECK (revision >= 0),
+  state TEXT NOT NULL CHECK (state IN ('active', 'inactive')),
+  source TEXT NOT NULL DEFAULT '' CHECK (source IN ('', 'slash_command', 'badge_remove', 'agent_command')),
+  created_at_unix_ms INTEGER NOT NULL,
+  dispatch_state TEXT NOT NULL DEFAULT 'accepted' CHECK (dispatch_state IN ('prepared', 'accepted')),
+  accepted_at_unix_ms INTEGER,
+  orchestration_intensity INTEGER NOT NULL DEFAULT 0 CHECK (orchestration_intensity BETWEEN 0 AND 100),
+  speed INTEGER NOT NULL DEFAULT 0 CHECK (speed BETWEEN 0 AND 100),
+  PRIMARY KEY (workspace_id, agent_session_id, turn_id),
+  FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE,
+  CHECK ((activation_id = '' AND revision_id = '' AND revision = 0 AND state = 'inactive' AND source = '') OR
+         (activation_id != '' AND revision_id != '' AND revision > 0 AND
+          ((state = 'active' AND source IN ('slash_command', 'agent_command')) OR
+           (state = 'inactive' AND source IN ('badge_remove', 'agent_command')))))
+);
+
+INSERT INTO tutti_mode_turn_snapshots_v5 (
+  workspace_id, agent_session_id, turn_id, activation_id, revision_id, revision,
+  state, source, created_at_unix_ms, dispatch_state, accepted_at_unix_ms,
+  orchestration_intensity, speed
+)
+SELECT
+  workspace_id, agent_session_id, turn_id, activation_id, revision_id, revision,
+  state, source, created_at_unix_ms, dispatch_state, accepted_at_unix_ms,
+  orchestration_intensity, speed
+FROM tutti_mode_turn_snapshots;
+
+DROP TABLE tutti_mode_turn_snapshots;
+ALTER TABLE tutti_mode_turn_snapshots_v5 RENAME TO tutti_mode_turn_snapshots;
+
+CREATE INDEX idx_tutti_mode_turn_snapshots_revision
+  ON tutti_mode_turn_snapshots(workspace_id, activation_id, revision);
+
+INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
+  VALUES (?, ?);
+`, schemaMigrationTuttiModeAgentCommandSourceV5, unixMs(time.Now().UTC())); err != nil {
+		return fmt.Errorf("rebuild Tutti mode activation tables for agent command source: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit Tutti mode agent command source migration: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx, "PRAGMA foreign_keys = ON"); err != nil {
+		return fmt.Errorf("restore foreign keys after Tutti mode agent command source migration: %w", err)
+	}
+	foreignKeysDisabled = false
+
+	rows, err := conn.QueryContext(ctx, "PRAGMA foreign_key_check")
+	if err != nil {
+		return fmt.Errorf("check foreign keys after Tutti mode agent command source migration: %w", err)
+	}
+	defer rows.Close()
+	if rows.Next() {
+		var table, parent string
+		var rowID sql.NullInt64
+		var foreignKeyID int
+		if err := rows.Scan(&table, &rowID, &parent, &foreignKeyID); err != nil {
+			return fmt.Errorf("scan foreign key violation after Tutti mode agent command source migration: %w", err)
+		}
+		return fmt.Errorf("tutti mode agent command source migration left foreign key violation: table=%s parent=%s id=%d", table, parent, foreignKeyID)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate foreign key check after Tutti mode agent command source migration: %w", err)
+	}
+	return nil
+}
+
 func tuttiModeColumnExistsTx(ctx context.Context, tx *sql.Tx, tableName, columnName string) (bool, error) {
 	var count int
 	if err := tx.QueryRowContext(ctx, `

--- a/services/tuttid/data/workspace/sqlite_tutti_mode_activations_test.go
+++ b/services/tuttid/data/workspace/sqlite_tutti_mode_activations_test.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -387,4 +388,256 @@ func TestSQLiteStoreTuttiModeActivationPreferenceRevisions(t *testing.T) {
 	}); err == nil {
 		t.Fatal("SetTuttiModeActivation(101) error = nil, want validation failure")
 	}
+}
+
+func TestSQLiteStoreTuttiModeActivationAgentCommandSource(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openTestSQLiteStore(t)
+	if err := store.Create(ctx, workspacebiz.Summary{ID: "ws-agent-command", Name: "Agent Command"}); err != nil {
+		t.Fatal(err)
+	}
+	now := time.UnixMilli(1_700_000_000_000).UTC()
+
+	// The Agent-issued source may originate an activation.
+	activated, changed, err := store.SetTuttiModeActivation(ctx, SetTuttiModeActivationInput{
+		WorkspaceID: "ws-agent-command", AgentSessionID: "session-1",
+		ActivationID: "activation-1", RevisionID: "revision-1",
+		State: activationbiz.StateActive, Source: activationbiz.SourceAgentCommand, ChangedAt: now,
+	})
+	if err != nil || !changed || activated.CurrentRevision.State != activationbiz.StateActive ||
+		activated.CurrentRevision.Source != activationbiz.SourceAgentCommand {
+		t.Fatalf("agent_command activate activation=%#v changed=%v err=%v", activated, changed, err)
+	}
+
+	// ... and a deactivation.
+	expected := int64(1)
+	deactivated, changed, err := store.SetTuttiModeActivation(ctx, SetTuttiModeActivationInput{
+		WorkspaceID: "ws-agent-command", AgentSessionID: "session-1",
+		RevisionID: "revision-2", ExpectedRevision: &expected,
+		State: activationbiz.StateInactive, Source: activationbiz.SourceAgentCommand, ChangedAt: now.Add(time.Second),
+	})
+	if err != nil || !changed || deactivated.CurrentRevision.State != activationbiz.StateInactive ||
+		deactivated.CurrentRevision.Source != activationbiz.SourceAgentCommand {
+		t.Fatalf("agent_command deactivate activation=%#v changed=%v err=%v", deactivated, changed, err)
+	}
+
+	// Turn snapshots accept agent_command for both configured states.
+	inactiveSnapshot := activationbiz.TurnSnapshot{
+		ActivationID: "activation-1", RevisionID: "revision-2", Revision: 2,
+		State: activationbiz.StateInactive, Source: activationbiz.SourceAgentCommand,
+	}
+	stored, created, err := store.PutTuttiModeTurnSnapshot(ctx, "ws-agent-command", "session-1", "turn-1", inactiveSnapshot, now.Add(2*time.Second))
+	if err != nil || !created || stored != inactiveSnapshot {
+		t.Fatalf("inactive agent_command PutTuttiModeTurnSnapshot()=%#v created=%v err=%v", stored, created, err)
+	}
+	activeSnapshot := activationbiz.TurnSnapshot{
+		ActivationID: "activation-1", RevisionID: "revision-1", Revision: 1,
+		State: activationbiz.StateActive, Source: activationbiz.SourceAgentCommand,
+	}
+	stored, created, err = store.PutTuttiModeTurnSnapshot(ctx, "ws-agent-command", "session-1", "turn-2", activeSnapshot, now.Add(3*time.Second))
+	if err != nil || !created || stored != activeSnapshot {
+		t.Fatalf("active agent_command PutTuttiModeTurnSnapshot()=%#v created=%v err=%v", stored, created, err)
+	}
+
+	// The relaxed CHECKs keep the human sources single-direction.
+	if _, err := store.writeDB.ExecContext(ctx, `
+INSERT INTO tutti_mode_activation_revisions (
+  workspace_id, activation_id, revision_id, revision, state, source, created_at_unix_ms
+) VALUES ('ws-agent-command', 'activation-1', 'revision-bad', 3, 'active', 'badge_remove', 1)
+`); err == nil || !strings.Contains(err.Error(), "CHECK constraint failed") {
+		t.Fatalf("active badge_remove revision error = %v, want CHECK constraint failure", err)
+	}
+	if _, err := store.writeDB.ExecContext(ctx, `
+INSERT INTO tutti_mode_turn_snapshots (
+  workspace_id, agent_session_id, turn_id, activation_id, revision_id, revision, state, source, created_at_unix_ms
+) VALUES ('ws-agent-command', 'session-1', 'turn-bad', 'activation-1', 'revision-1', 1, 'active', 'badge_remove', 1)
+`); err == nil || !strings.Contains(err.Error(), "CHECK constraint failed") {
+		t.Fatalf("active badge_remove snapshot error = %v, want CHECK constraint failure", err)
+	}
+}
+
+func TestSQLiteStoreTuttiModeAgentCommandSourceMigrationUpgradesLegacySchema(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := openTestSQLiteStore(t)
+	if err := store.Create(ctx, workspacebiz.Summary{ID: "ws-agent-command-upgrade", Name: "Upgrade"}); err != nil {
+		t.Fatal(err)
+	}
+	now := time.UnixMilli(1_700_000_000_000).UTC()
+	if _, _, err := store.SetTuttiModeActivation(ctx, SetTuttiModeActivationInput{
+		WorkspaceID: "ws-agent-command-upgrade", AgentSessionID: "session-1",
+		ActivationID: "activation-1", RevisionID: "revision-1",
+		State: activationbiz.StateActive, Source: activationbiz.SourceSlashCommand, ChangedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	configured := activationbiz.TurnSnapshot{
+		ActivationID: "activation-1", RevisionID: "revision-1", Revision: 1,
+		State: activationbiz.StateActive, Source: activationbiz.SourceSlashCommand,
+		Effect: activationbiz.DefaultEffect, Speed: activationbiz.DefaultSpeed,
+	}
+	if _, _, err := store.PutTuttiModeTurnSnapshot(ctx, "ws-agent-command-upgrade", "session-1", "turn-1", configured, now); err != nil {
+		t.Fatal(err)
+	}
+	if accepted, err := store.AcceptTuttiModeTurnSnapshot(ctx, "ws-agent-command-upgrade", "session-1", "turn-1", now.Add(time.Second)); err != nil || !accepted {
+		t.Fatalf("accept snapshot accepted=%v err=%v", accepted, err)
+	}
+	if _, _, err := store.PutTuttiModeTurnSnapshot(ctx, "ws-agent-command-upgrade", "session-1", "turn-2",
+		activationbiz.TurnSnapshot{State: activationbiz.StateInactive}, now); err != nil {
+		t.Fatal(err)
+	}
+
+	// Downgrade both tables to the pre-v5 shape: the v1 CHECK vocabulary plus
+	// the columns appended by v2-v4, simulating an installed database that ran
+	// v1..v4 before this release.
+	if _, err := store.writeDB.ExecContext(ctx, "PRAGMA foreign_keys = OFF"); err != nil {
+		t.Fatalf("disable foreign keys: %v", err)
+	}
+	if _, err := store.writeDB.ExecContext(ctx, `
+CREATE TABLE tutti_mode_activation_revisions_legacy (
+  workspace_id TEXT NOT NULL,
+  activation_id TEXT NOT NULL,
+  revision_id TEXT NOT NULL,
+  revision INTEGER NOT NULL CHECK (revision > 0),
+  state TEXT NOT NULL CHECK (state IN ('active', 'inactive')),
+  source TEXT NOT NULL CHECK (source IN ('slash_command', 'badge_remove')),
+  created_at_unix_ms INTEGER NOT NULL,
+  orchestration_intensity INTEGER NOT NULL DEFAULT 50 CHECK (orchestration_intensity BETWEEN 0 AND 100),
+  speed INTEGER NOT NULL DEFAULT 50 CHECK (speed BETWEEN 0 AND 100),
+  PRIMARY KEY (workspace_id, activation_id, revision_id),
+  UNIQUE (workspace_id, activation_id, revision),
+  FOREIGN KEY (workspace_id, activation_id)
+    REFERENCES tutti_mode_activations(workspace_id, activation_id) ON DELETE CASCADE,
+  CHECK ((state = 'active' AND source = 'slash_command') OR
+         (state = 'inactive' AND source = 'badge_remove'))
+);
+INSERT INTO tutti_mode_activation_revisions_legacy SELECT * FROM tutti_mode_activation_revisions;
+DROP TABLE tutti_mode_activation_revisions;
+ALTER TABLE tutti_mode_activation_revisions_legacy RENAME TO tutti_mode_activation_revisions;
+
+CREATE TABLE tutti_mode_turn_snapshots_legacy (
+  workspace_id TEXT NOT NULL,
+  agent_session_id TEXT NOT NULL,
+  turn_id TEXT NOT NULL,
+  activation_id TEXT NOT NULL DEFAULT '',
+  revision_id TEXT NOT NULL DEFAULT '',
+  revision INTEGER NOT NULL DEFAULT 0 CHECK (revision >= 0),
+  state TEXT NOT NULL CHECK (state IN ('active', 'inactive')),
+  source TEXT NOT NULL DEFAULT '' CHECK (source IN ('', 'slash_command', 'badge_remove')),
+  created_at_unix_ms INTEGER NOT NULL,
+  dispatch_state TEXT NOT NULL DEFAULT 'accepted' CHECK (dispatch_state IN ('prepared', 'accepted')),
+  accepted_at_unix_ms INTEGER,
+  orchestration_intensity INTEGER NOT NULL DEFAULT 0 CHECK (orchestration_intensity BETWEEN 0 AND 100),
+  speed INTEGER NOT NULL DEFAULT 0 CHECK (speed BETWEEN 0 AND 100),
+  PRIMARY KEY (workspace_id, agent_session_id, turn_id),
+  FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE,
+  CHECK ((activation_id = '' AND revision_id = '' AND revision = 0 AND state = 'inactive' AND source = '') OR
+         (activation_id != '' AND revision_id != '' AND revision > 0 AND
+          ((state = 'active' AND source = 'slash_command') OR
+           (state = 'inactive' AND source = 'badge_remove'))))
+);
+INSERT INTO tutti_mode_turn_snapshots_legacy SELECT * FROM tutti_mode_turn_snapshots;
+DROP TABLE tutti_mode_turn_snapshots;
+ALTER TABLE tutti_mode_turn_snapshots_legacy RENAME TO tutti_mode_turn_snapshots;
+CREATE INDEX idx_tutti_mode_turn_snapshots_revision
+  ON tutti_mode_turn_snapshots(workspace_id, activation_id, revision);
+
+DELETE FROM tuttid_schema_migrations WHERE id = ?;
+`, schemaMigrationTuttiModeAgentCommandSourceV5); err != nil {
+		t.Fatalf("install legacy pre-v5 Tutti mode schema: %v", err)
+	}
+	if _, err := store.writeDB.ExecContext(ctx, "PRAGMA foreign_keys = ON"); err != nil {
+		t.Fatalf("restore foreign keys: %v", err)
+	}
+
+	// The legacy vocabulary rejects agent_command, proving the downgrade held.
+	if _, err := store.writeDB.ExecContext(ctx, `
+INSERT INTO tutti_mode_activation_revisions (
+  workspace_id, activation_id, revision_id, revision, state, source, created_at_unix_ms
+) VALUES ('ws-agent-command-upgrade', 'activation-1', 'revision-agent', 2, 'inactive', 'agent_command', 1)
+`); err == nil || !strings.Contains(err.Error(), "CHECK constraint failed") {
+		t.Fatalf("legacy agent_command insert error = %v, want CHECK constraint failure", err)
+	}
+
+	if err := store.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate() legacy Tutti mode schema error = %v", err)
+	}
+	if err := store.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate() repeated after v5 error = %v", err)
+	}
+
+	// All pre-upgrade rows survived the rebuild.
+	preserved, ok, err := store.GetTuttiModeActivation(ctx, "ws-agent-command-upgrade", "session-1")
+	if err != nil || !ok || preserved.CurrentRevision.ID != "revision-1" ||
+		preserved.CurrentRevision.Source != activationbiz.SourceSlashCommand ||
+		preserved.CurrentRevision.Effect != activationbiz.DefaultEffect ||
+		preserved.CurrentRevision.Speed != activationbiz.DefaultSpeed {
+		t.Fatalf("preserved activation=%#v ok=%v err=%v", preserved, ok, err)
+	}
+	snapshot, ok, err := store.GetTuttiModeTurnSnapshot(ctx, "ws-agent-command-upgrade", "session-1", "turn-1")
+	if err != nil || !ok || snapshot != configured {
+		t.Fatalf("preserved snapshot=%#v ok=%v err=%v", snapshot, ok, err)
+	}
+	if accepted, err := store.IsTuttiModeTurnSnapshotAccepted(ctx, "ws-agent-command-upgrade", "session-1", "turn-1"); err != nil || !accepted {
+		t.Fatalf("preserved dispatch state accepted=%v err=%v", accepted, err)
+	}
+	unconfigured, ok, err := store.GetTuttiModeTurnSnapshot(ctx, "ws-agent-command-upgrade", "session-1", "turn-2")
+	if err != nil || !ok || unconfigured.State != activationbiz.StateInactive || unconfigured.ActivationID != "" {
+		t.Fatalf("preserved unconfigured snapshot=%#v ok=%v err=%v", unconfigured, ok, err)
+	}
+
+	// The rebuilt schema admits agent_command transitions.
+	expected := int64(1)
+	deactivated, changed, err := store.SetTuttiModeActivation(ctx, SetTuttiModeActivationInput{
+		WorkspaceID: "ws-agent-command-upgrade", AgentSessionID: "session-1",
+		RevisionID: "revision-2", ExpectedRevision: &expected,
+		State: activationbiz.StateInactive, Source: activationbiz.SourceAgentCommand, ChangedAt: now.Add(2 * time.Second),
+	})
+	if err != nil || !changed || deactivated.CurrentRevision.Source != activationbiz.SourceAgentCommand {
+		t.Fatalf("agent_command after upgrade activation=%#v changed=%v err=%v", deactivated, changed, err)
+	}
+
+	foreignKeyRows, err := store.writeDB.QueryContext(ctx, "PRAGMA foreign_key_check")
+	if err != nil {
+		t.Fatalf("foreign_key_check error = %v", err)
+	}
+	violation := foreignKeyRows.Next()
+	if err := foreignKeyRows.Err(); err != nil {
+		_ = foreignKeyRows.Close()
+		t.Fatalf("iterate foreign_key_check error = %v", err)
+	}
+	_ = foreignKeyRows.Close()
+	if violation {
+		t.Fatal("agent command source migration left a foreign key violation")
+	}
+
+	// A fresh install (v1 then v5) and this upgraded database converge on
+	// identical effective schemas.
+	fresh := openTestSQLiteStore(t)
+	for _, objectName := range []string{
+		"tutti_mode_activation_revisions",
+		"tutti_mode_turn_snapshots",
+		"idx_tutti_mode_turn_snapshots_revision",
+	} {
+		upgradedSQL := tuttiModeSchemaSQL(t, store, objectName)
+		freshSQL := tuttiModeSchemaSQL(t, fresh, objectName)
+		if upgradedSQL != freshSQL {
+			t.Fatalf("schema for %s diverged:\nupgraded: %s\nfresh: %s", objectName, upgradedSQL, freshSQL)
+		}
+		if objectName != "idx_tutti_mode_turn_snapshots_revision" && !strings.Contains(upgradedSQL, "agent_command") {
+			t.Fatalf("schema for %s does not admit agent_command: %s", objectName, upgradedSQL)
+		}
+	}
+}
+
+func tuttiModeSchemaSQL(t *testing.T, store *SQLiteStore, objectName string) string {
+	t.Helper()
+	var text string
+	if err := store.writeDB.QueryRowContext(context.Background(), `
+SELECT sql FROM sqlite_master WHERE name = ?
+`, objectName).Scan(&text); err != nil {
+		t.Fatalf("read sqlite_master sql for %s: %v", objectName, err)
+	}
+	return text
 }


### PR DESCRIPTION
## Summary

Follow-up to #1825, which merged before the migration amendment landed: the new `tutti mode set --state active|inactive` CLI relaxed the Go-level validation (`IsStateSource`) but the v1 migration baked the old source vocabulary into table-level CHECK constraints, so the daemon rejects the write at the data layer (live repro):

```
workspace_operation_failed: insert Tutti mode activation revision:
CHECK constraint failed: source IN ('slash_command', 'badge_remove')
```

SQLite cannot ALTER a CHECK, so **migration v5** rebuilds `tutti_mode_activation_revisions` and `tutti_mode_turn_snapshots` with the full post-v4 column set and CHECKs mirroring `IsStateSource` exactly (`agent_command` valid for both states; legacy `slash_command`→active / `badge_remove`→inactive pairings unchanged). Follows the `applyWorkspaceWorkflowRevisionPathReuseV3` rebuild precedent (pinned connection, FK OFF/ON around the tx, `foreign_key_check` scan, index recreated in-tx). v1–v4 SQL untouched.

## Verification

- `go build ./...` (tuttid) clean on the merged main tip.
- New tests: `agent_command` accepted for both states via the store API; legacy invalid pairings still rejected; upgrade test seeds pre-v5 rows, downgrades the schema, re-runs `Migrate()` twice (idempotent), asserts row survival (incl. `dispatch_state`/`accepted_at`), clean `foreign_key_check`, and **byte-identical** fresh-install vs upgraded schema.
- Pre-push `check:changed --push-ready` passed on this branch.

After merge, a daemon rebuild/restart is required for v5 to apply.

Release counterpart: cherry-picked to `release/0729` (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1827" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> SQLite table rebuild migrations touch persisted Tutti mode activation data; risk is mitigated by copy-and-rename, FK verification, and extensive upgrade/idempotency tests, but a daemon restart is required for v5 to apply on existing installs.
> 
> **Overview**
> Fixes a **data-layer mismatch** after Go validation already allowed `agent_command` for Tutti mode activate/deactivate: v1 SQLite CHECK constraints still only permitted `slash_command` / `badge_remove`, so daemon writes failed with `CHECK constraint failed`.
> 
> Adds **migration v5** (`tutti_mode_agent_command_source_v5`), wired into `Migrate()` after v4. Because SQLite cannot alter CHECKs, it **rebuilds** `tutti_mode_activation_revisions` and `tutti_mode_turn_snapshots` with the full post-v4 columns and CHECK rules aligned with `IsStateSource` (`agent_command` for both `active` and `inactive`; human sources stay one-way). Uses the same rebuild pattern as other migrations (pinned connection, FK off/on, `foreign_key_check`, turn-snapshot index recreated).
> 
> **Tests** cover store acceptance of `agent_command` for activations and turn snapshots, legacy invalid pairings still rejected, and an upgrade path that simulates pre-v5 schema, runs `Migrate()` twice, preserves rows (including dispatch state), and matches a fresh install schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a294d81c254f3969199eb1a916ce3553565eef3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->