### PR TITLE
fix(agent): PyPI index fallback for uv extension installs + widen version probe to 15s

### DIFF
--- a/services/tuttid/service/agentextension/installer_uv.go
+++ b/services/tuttid/service/agentextension/installer_uv.go
@@ -147,9 +147,9 @@ func (s *SetupService) executeUVInstallInPlace(
 		installCtx, cancel := context.WithTimeout(ctx, 15*time.Minute)
 		defer cancel()
 		env := uvInstallEnvironment(scratch, finalRoot, uvDir, uvToolchainCacheDir(manager.RuntimeInstallDir))
-		if err := runner.Run(installCtx, command, scratch, env); err != nil {
+		if err := s.runUVInstallWithIndexFallback(installCtx, runner, command, scratch, env, plan); err != nil {
 			rollback()
-			return fmt.Errorf("%w: %w", ErrRuntimeInstallFailed, err)
+			return err
 		}
 	}
 	if err := rootDir.verify(); err != nil {

--- a/services/tuttid/service/agentextension/installer_uv_test.go
+++ b/services/tuttid/service/agentextension/installer_uv_test.go
@@ -125,8 +125,10 @@ func TestUVInstallFailureRestoresPreviousRuntime(t *testing.T) {
 	if !errors.Is(err, ErrRuntimeInstallFailed) {
 		t.Fatalf("second install error = %v, want ErrRuntimeInstallFailed", err)
 	}
-	if runner.calls != 2 {
-		t.Fatalf("install calls = %d, want 2", runner.calls)
+	// 1 successful install + 3 failed attempts: a persistent uv failure is
+	// retried once per package index in the fallback chain.
+	if runner.calls != 1+len(defaultPyPIIndexes()) {
+		t.Fatalf("install calls = %d, want %d", runner.calls, 1+len(defaultPyPIIndexes()))
 	}
 	restoredBytes, err := os.ReadFile(filepath.Join(plan.InstallRoot, "tools", "kimi-cli", "bin", "kimi"))
 	if err != nil {

--- a/services/tuttid/service/agentextension/manager.go
+++ b/services/tuttid/service/agentextension/manager.go
@@ -674,11 +674,20 @@ func activateExtensionPackage(staging, finalDir, expectedDigest string) error {
 	return nil
 }
 
+// runtimeVersionProbeTimeout bounds one `<cli> --version` probe. Matches the
+// ACP-initialize probe budget rather than the previous 5s: version commands of
+// Python-based runtimes are not instant — a cold first run pays interpreter
+// start-up plus bytecode compilation, and some CLIs (observed with hermes)
+// perform a synchronous network update check with its own 5s timeout, so the
+// legitimate worst case lands well above 5s and the SIGKILL surfaced as
+// "installed runtime version is incompatible: signal: killed".
+const runtimeVersionProbeTimeout = 15 * time.Second
+
 func runtimeVersionWithEnv(ctx context.Context, executable string, args []string, constraint string, env []string) (string, error) {
 	if len(args) == 0 {
 		return "", nil
 	}
-	probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	probeCtx, cancel := context.WithTimeout(ctx, runtimeVersionProbeTimeout)
 	defer cancel()
 	command := exec.CommandContext(probeCtx, executable, args...)
 	command.Env = env
@@ -734,7 +743,7 @@ func runtimeVersionWithIdentity(
 	if len(args) == 0 {
 		return "", nil
 	}
-	probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	probeCtx, cancel := context.WithTimeout(ctx, runtimeVersionProbeTimeout)
 	defer cancel()
 	var output []byte
 	var err error

--- a/services/tuttid/service/agentextension/uv_index.go
+++ b/services/tuttid/service/agentextension/uv_index.go
@@ -1,0 +1,116 @@
+package agentextension
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"os"
+	"slices"
+	"strings"
+	"time"
+)
+
+// PyPI package indexes for uv-runner extension runtimes, tried in order. The
+// official index comes first; the CN-available mirrors follow so a network
+// that cannot reach pypi.org (the field failure mode this exists for) still
+// installs. Same vendors as the npm mirror chain in managednpm, so a network
+// that admits one family admits the other.
+const (
+	officialPyPIIndexURL = "https://pypi.org/simple"
+	huaweiPyPIIndexURL   = "https://repo.huaweicloud.com/repository/pypi/simple"
+	tencentPyPIIndexURL  = "https://mirrors.cloud.tencent.com/pypi/simple"
+
+	// uvIndexOverrideEnv pins a single package index, mirroring
+	// TUTTI_AGENT_NPM_REGISTRY on the npm side.
+	uvIndexOverrideEnv = "TUTTI_AGENT_PYPI_INDEX"
+)
+
+// uvPerIndexInstallTimeout bounds one index attempt so a blocked or stalled
+// source fails over instead of consuming the whole 15-minute install budget.
+// uv installs are heavier than npm ones (managed CPython plus the package
+// graph), so the budget is wider than the npm installer's per-registry bound.
+const uvPerIndexInstallTimeout = 5 * time.Minute
+
+// defaultPyPIIndexes returns the package indexes to try in order. No
+// reachability ranking: unlike the npm path there is no probing client on this
+// path today, and the fallback loop — not ordering — is the guarantee.
+func defaultPyPIIndexes() []string {
+	if value := strings.TrimSpace(os.Getenv(uvIndexOverrideEnv)); value != "" {
+		return []string{value}
+	}
+	return []string{officialPyPIIndexURL, huaweiPyPIIndexURL, tencentPyPIIndexURL}
+}
+
+// runUVInstallWithIndexFallback runs the uv install command against each
+// package index in turn. Only UV_DEFAULT_INDEX varies across attempts — the
+// command itself is unchanged, so the plan's runner-identity contract holds.
+// uv tool installs are idempotent per attempt (no receipt is written on
+// failure, and partial downloads live in the content-addressed cache), so a
+// retry against the next index starts from a consistent state without
+// touching the install root.
+func (s *SetupService) runUVInstallWithIndexFallback(
+	ctx context.Context,
+	runner InstallCommandRunner,
+	command []string,
+	cwd string,
+	baseEnv []string,
+	plan InstallPlan,
+) error {
+	indexes := defaultPyPIIndexes()
+	var lastErr error
+	for position, index := range indexes {
+		attemptCtx, cancel := context.WithTimeout(ctx, uvPerIndexInstallTimeout)
+		env := withUVDefaultIndex(slices.Clone(baseEnv), index)
+		err := runner.Run(attemptCtx, command, cwd, env)
+		cancel()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		// A cancelled or expired parent context means the install is being torn
+		// down (user cancel or daemon shutdown); surface the interruption instead
+		// of failing over. A per-index timeout leaves the parent context live.
+		if ctx.Err() != nil {
+			break
+		}
+		if position < len(indexes)-1 {
+			slog.Warn(
+				"agent extension uv install failed on package index, trying next",
+				"event", "tutti.agent_extension.uv_install.index_failover",
+				"agentKey", plan.AgentKey,
+				"index", displayPyPIIndexHost(index),
+				"error", err,
+			)
+		}
+	}
+	if lastErr == nil {
+		lastErr = errors.New("no package index available")
+	}
+	return fmt.Errorf("%w: %w", ErrRuntimeInstallFailed, lastErr)
+}
+
+// withUVDefaultIndex returns env with exactly one UV_DEFAULT_INDEX entry,
+// dropping any inherited value so the selected index is authoritative.
+// UV_NO_CONFIG=1 (set by uvInstallEnvironment) only suppresses configuration
+// files; environment variables still apply.
+func withUVDefaultIndex(env []string, index string) []string {
+	const prefix = "UV_DEFAULT_INDEX="
+	result := make([]string, 0, len(env)+1)
+	for _, kv := range env {
+		if strings.HasPrefix(strings.ToUpper(kv), prefix) {
+			continue
+		}
+		result = append(result, kv)
+	}
+	return append(result, prefix+index)
+}
+
+func displayPyPIIndexHost(index string) string {
+	parsed, err := url.Parse(strings.TrimSpace(index))
+	if err != nil || parsed.Host == "" {
+		return index
+	}
+	return parsed.Host
+}

--- a/services/tuttid/service/agentextension/uv_index_test.go
+++ b/services/tuttid/service/agentextension/uv_index_test.go
@@ -1,0 +1,149 @@
+package agentextension
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func uvIndexFromEnv(env []string) string {
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "UV_DEFAULT_INDEX=") {
+			return strings.TrimPrefix(kv, "UV_DEFAULT_INDEX=")
+		}
+	}
+	return ""
+}
+
+// sequencedUVInstallRunner returns a scripted result per call and records the
+// UV_DEFAULT_INDEX each attempt saw.
+type sequencedUVInstallRunner struct {
+	results []error
+	calls   int
+	indexes []string
+}
+
+func (r *sequencedUVInstallRunner) Run(_ context.Context, _ []string, _ string, env []string) error {
+	r.indexes = append(r.indexes, uvIndexFromEnv(env))
+	index := r.calls
+	r.calls++
+	if index < len(r.results) {
+		return r.results[index]
+	}
+	return nil
+}
+
+func uvIndexFallbackPlan() InstallPlan {
+	return InstallPlan{AgentKey: "hermes", Runner: "uv", PackageName: "hermes-agent[acp]", PackageVersion: "0.18.2"}
+}
+
+func TestDefaultPyPIIndexesHonoursOverride(t *testing.T) {
+	t.Setenv(uvIndexOverrideEnv, "https://pinned.example/simple")
+	got := defaultPyPIIndexes()
+	if len(got) != 1 || got[0] != "https://pinned.example/simple" {
+		t.Fatalf("indexes = %v, want single pinned entry", got)
+	}
+}
+
+func TestDefaultPyPIIndexesOfficialFirst(t *testing.T) {
+	t.Setenv(uvIndexOverrideEnv, "")
+	got := defaultPyPIIndexes()
+	if len(got) != 3 || got[0] != officialPyPIIndexURL {
+		t.Fatalf("indexes = %v, want official first of 3", got)
+	}
+}
+
+func TestWithUVDefaultIndexReplacesInherited(t *testing.T) {
+	env := []string{"PATH=/x", "UV_DEFAULT_INDEX=https://stale.example/simple", "UV_NO_CONFIG=1"}
+	got := withUVDefaultIndex(env, "https://mirror.example/simple")
+	entries := 0
+	for _, kv := range got {
+		if strings.HasPrefix(kv, "UV_DEFAULT_INDEX=") {
+			entries++
+		}
+	}
+	if entries != 1 {
+		t.Fatalf("UV_DEFAULT_INDEX entries = %d, want 1 (env=%v)", entries, got)
+	}
+	if uvIndexFromEnv(got) != "https://mirror.example/simple" {
+		t.Fatalf("index = %q, want mirror", uvIndexFromEnv(got))
+	}
+}
+
+func TestRunUVInstallWithIndexFallbackFailsOver(t *testing.T) {
+	t.Setenv(uvIndexOverrideEnv, "")
+	service := &SetupService{}
+	runner := &sequencedUVInstallRunner{results: []error{errors.New("index unreachable")}}
+
+	err := service.runUVInstallWithIndexFallback(
+		context.Background(), runner, []string{"uv", "tool", "install", "hermes-agent[acp]==0.18.2"},
+		t.TempDir(), []string{"PATH=/x", "UV_NO_CONFIG=1"}, uvIndexFallbackPlan(),
+	)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if runner.calls != 2 {
+		t.Fatalf("runner calls = %d, want 2 (fail then succeed)", runner.calls)
+	}
+	if runner.indexes[0] != officialPyPIIndexURL {
+		t.Fatalf("first index = %q, want official first", runner.indexes[0])
+	}
+	if runner.indexes[1] == runner.indexes[0] {
+		t.Fatalf("failover did not switch index: both %q", runner.indexes[0])
+	}
+}
+
+func TestRunUVInstallWithIndexFallbackExhaustsAllIndexes(t *testing.T) {
+	t.Setenv(uvIndexOverrideEnv, "")
+	service := &SetupService{}
+	runner := &sequencedUVInstallRunner{results: []error{errors.New("a"), errors.New("b"), errors.New("c")}}
+
+	err := service.runUVInstallWithIndexFallback(
+		context.Background(), runner, []string{"uv", "tool", "install", "hermes-agent[acp]==0.18.2"},
+		t.TempDir(), []string{"PATH=/x"}, uvIndexFallbackPlan(),
+	)
+	if !errors.Is(err, ErrRuntimeInstallFailed) {
+		t.Fatalf("err = %v, want wrap of ErrRuntimeInstallFailed", err)
+	}
+	if runner.calls != 3 {
+		t.Fatalf("runner calls = %d, want 3", runner.calls)
+	}
+	distinct := map[string]struct{}{}
+	for _, index := range runner.indexes {
+		distinct[index] = struct{}{}
+	}
+	if len(distinct) != 3 {
+		t.Fatalf("attempted indexes = %v, want 3 distinct", runner.indexes)
+	}
+}
+
+type cancelOnFirstUVInstallRunner struct {
+	cancel context.CancelFunc
+	calls  int
+}
+
+func (r *cancelOnFirstUVInstallRunner) Run(_ context.Context, _ []string, _ string, _ []string) error {
+	r.calls++
+	r.cancel()
+	return context.Canceled
+}
+
+func TestRunUVInstallStopsFailoverOnContextCancel(t *testing.T) {
+	t.Setenv(uvIndexOverrideEnv, "")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	service := &SetupService{}
+	runner := &cancelOnFirstUVInstallRunner{cancel: cancel}
+
+	err := service.runUVInstallWithIndexFallback(
+		ctx, runner, []string{"uv", "tool", "install", "hermes-agent[acp]==0.18.2"},
+		t.TempDir(), []string{"PATH=/x"}, uvIndexFallbackPlan(),
+	)
+	if !errors.Is(err, ErrRuntimeInstallFailed) {
+		t.Fatalf("err = %v, want wrap of ErrRuntimeInstallFailed", err)
+	}
+	if runner.calls != 1 {
+		t.Fatalf("runner calls = %d, want 1 (no failover after parent cancel)", runner.calls)
+	}
+}


### PR DESCRIPTION
## Problem

Two remaining gaps in the agent-extension install path for networks that cannot reach the default upstream sources (the same field failure family as #1824):

**1. uv installs have no index fallback.** Extension runtimes installed through `uv` (Hermes `hermes-agent[acp]==0.18.2`, and kimi-code's uv profile) run `uv tool install` with `UV_NO_CONFIG=1` and no index injection — the user's own uv/pip mirror configuration is suppressed *and* the only reachable source is the default `pypi.org`. One unreachable index ⇒ `agent target runtime install failed`, with no fallback. This is exactly the defect shape the npm side had before #1824, while built-in providers already fail over across mirrors (`managednpm`: npmjs → Huawei → Tencent).

**2. The 5s version probe SIGKILLs legitimate slow CLIs.** After install, verification runs `<cli> --version` under a hard 5s timeout (`manager.go`) and reports the kill as *"installed runtime version is incompatible: signal: killed"*. That budget is too tight for Python-based runtimes, reproduced end-to-end with the released `hermes-agent==0.18.2`:

- hermes' `--version` has no fast path outside Termux, and performs a **synchronous PyPI update check** (`urlopen`, its own 5s timeout) on first run — which is precisely when verification runs (the 6h check cache is empty right after install);
- the probe subprocess inherits the daemon environment including the system proxy (`proxy_source=system` in the field logs);
- measured on an M-series dev machine with the real 0.18.2: 1.98s cold with a fast network, **5.14s when the proxy accepts the connection but stalls** (the common blocked-network shape) — already over the 5s budget on the fastest hardware; slower machines with a cold bytecode cache only go up. The ACP-initialize probe in the same flow gets 15s.

## Change

- **`uv_index.go` (new):** run uv installs against a package-index chain — `pypi.org → Huawei → Tencent` (same mirror vendors as `managednpm`) — one bounded attempt per index (5min; uv installs carry managed CPython plus the package graph), failing over on error and stopping immediately when the parent context is cancelled. Only `UV_DEFAULT_INDEX` varies across attempts (env vars still apply under `UV_NO_CONFIG=1`); the command itself is unchanged, preserving the plan's runner-identity contract. `TUTTI_AGENT_PYPI_INDEX` pins a single index, mirroring `TUTTI_AGENT_NPM_REGISTRY`. No reachability ranking on this path — the fallback loop is the guarantee. Retrying against the next index needs no root cleanup: uv writes no receipt on failure and partial downloads live in the content-addressed cache.
- **`manager.go`:** version-probe timeout 5s → 15s (`runtimeVersionProbeTimeout`), aligned with the ACP probe budget. Applies to both the managed-runtime verification and local-runtime discovery probes — a locally discovered hermes hits the same update-check stall.

## Tests

- New `uv_index_test.go` (hermetic): override pins a single index; official index first; failover switches `UV_DEFAULT_INDEX`; exhausting all indexes wraps `ErrRuntimeInstallFailed`; parent-context cancel stops failover; env de-dup.
- `TestUVInstallFailureRestoresPreviousRuntime` updated: a persistent uv failure is now attempted once per index (rollback/restore behavior unchanged).
- `go build` / `go vet` / `gofmt` clean; full `agentextension` suite passes.

## Out of scope

- The **uv toolchain binary** itself still downloads from `github.com/astral-sh` releases only (single source, CN-hostile). Fixing that properly means hosting the archives on the tutti CloudFront distribution (release-pipeline work, cf. the claude-code binary precedent), not an installer change.
- Hermes' own `--version` doing synchronous network I/O is an upstream issue (it already has a fast path for Termux; macOS could join it). The 15s budget here makes the observed worst case (~8–10s, bounded by hermes' internal 5s network timeout) pass regardless.

Related: #1824 (same fallback pattern for the npm runner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1829" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes managed runtime install and verification paths for uv extensions; behavior is bounded (timeouts, rollback) and mirrors an existing npm pattern, but install success and version checks now depend on mirror failover and longer probes.
> 
> **Overview**
> **uv-managed extension installs** now retry `uv tool install` across a PyPI index chain (`pypi.org` → Huawei → Tencent), matching the npm mirror pattern from #1824. Each attempt sets `UV_DEFAULT_INDEX` (5-minute cap per index); `TUTTI_AGENT_PYPI_INDEX` pins a single index. Failover stops when the parent install context is cancelled.
> 
> **Runtime version probes** (`--version` during managed verification and local discovery) use a **15s** timeout instead of 5s, aligned with the ACP probe budget, so slow Python CLIs (e.g. Hermes’ post-install PyPI check) are not killed and reported as incompatible.
> 
> Tests cover index override, failover, exhaustion, cancel behavior, and updated rollback expectations when uv fails on every index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca8ae00fb2c3b889d11efa998d18605294cd5840. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->