### PR TITLE
fix(agent-gui): harden extension runtime setup

### DIFF
--- a/services/tuttid/service/agentextension/installer.go
+++ b/services/tuttid/service/agentextension/installer.go
@@ -41,7 +41,11 @@ func (localInstallCommandRunner) Run(ctx context.Context, command []string, cwd 
 		if errors.Is(err, exec.ErrNotFound) {
 			return fmt.Errorf("install command %s failed: %[1]s is not installed or not on the daemon PATH", filepath.Base(command[0]))
 		}
-		return fmt.Errorf("install command %s failed: %w", filepath.Base(command[0]), err)
+		detail := strings.TrimSpace(output.buffer.String())
+		if detail == "" {
+			return fmt.Errorf("install command %s failed: %w", filepath.Base(command[0]), err)
+		}
+		return fmt.Errorf("install command %s failed: %w: %s", filepath.Base(command[0]), err, detail)
 	}
 	return nil
 }

--- a/services/tuttid/service/agentextension/manager.go
+++ b/services/tuttid/service/agentextension/manager.go
@@ -29,6 +29,8 @@ import (
 
 var safeKey = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9._-]{0,62}[a-z0-9])?$`)
 
+const runtimeVersionProbeTimeout = 30 * time.Second
+
 type Manager struct {
 	Sources           []tuttitypes.AgentExtensionSource
 	RuntimeInstallDir string
@@ -678,13 +680,13 @@ func runtimeVersionWithEnv(ctx context.Context, executable string, args []string
 	if len(args) == 0 {
 		return "", nil
 	}
-	probeCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	probeCtx, cancel := context.WithTimeout(ctx, runtimeVersionProbeTimeout)
 	defer cancel()
 	command := exec.CommandContext(probeCtx, executable, args...)
 	command.Env = env
 	output, err := command.CombinedOutput()
 	if err != nil {
-		return "", err
+		return "", runtimeVersionProbeError(ctx, probeCtx, err)
 	}
 	version := regexp.MustCompile(`\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?`).FindString(string(output))
 	if !validSemver(version) || !matchesConstraint(version, constraint) {
@@ -734,7 +736,7 @@ func runtimeVersionWithIdentity(
 	if len(args) == 0 {
 		return "", nil
 	}
-	probeCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	probeCtx, cancel := context.WithTimeout(ctx, runtimeVersionProbeTimeout)
 	defer cancel()
 	var output []byte
 	var err error
@@ -744,13 +746,27 @@ func runtimeVersionWithIdentity(
 		output, err = exec.CommandContext(probeCtx, executable, args...).CombinedOutput()
 	}
 	if err != nil {
-		return "", err
+		return "", runtimeVersionProbeError(ctx, probeCtx, err)
 	}
 	version := regexp.MustCompile(`\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?`).FindString(string(output))
 	if !validSemver(version) || !matchesConstraint(version, constraint) {
 		return "", errors.New("runtime version is incompatible")
 	}
 	return version, nil
+}
+
+func runtimeVersionProbeError(ctx, probeCtx context.Context, err error) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return fmt.Errorf("runtime version probe aborted: %w", ctxErr)
+	}
+	if errors.Is(probeCtx.Err(), context.DeadlineExceeded) {
+		return fmt.Errorf(
+			"runtime version probe timed out after %s: %w",
+			runtimeVersionProbeTimeout,
+			context.DeadlineExceeded,
+		)
+	}
+	return err
 }
 
 func matchesConstraint(version, constraint string) bool {

--- a/services/tuttid/service/agentextension/manager.go
+++ b/services/tuttid/service/agentextension/manager.go
@@ -678,7 +678,7 @@ func runtimeVersionWithEnv(ctx context.Context, executable string, args []string
 	if len(args) == 0 {
 		return "", nil
 	}
-	probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	probeCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 	command := exec.CommandContext(probeCtx, executable, args...)
 	command.Env = env
@@ -734,7 +734,7 @@ func runtimeVersionWithIdentity(
 	if len(args) == 0 {
 		return "", nil
 	}
-	probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	probeCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 	var output []byte
 	var err error

--- a/services/tuttid/service/agentextension/manager_test.go
+++ b/services/tuttid/service/agentextension/manager_test.go
@@ -37,6 +37,37 @@ type preferencesStoreStub struct {
 	preferences preferencesbiz.DesktopPreferences
 }
 
+func TestRuntimeVersionProbeErrorClassifiesTimeoutAndCancellation(t *testing.T) {
+	t.Run("probe timeout", func(t *testing.T) {
+		probeCtx, cancel := context.WithDeadline(
+			context.Background(),
+			time.Now().Add(-time.Second),
+		)
+		defer cancel()
+
+		err := runtimeVersionProbeError(
+			context.Background(),
+			probeCtx,
+			errors.New("signal: killed"),
+		)
+		if !errors.Is(err, context.DeadlineExceeded) ||
+			!strings.Contains(err.Error(), "runtime version probe timed out after 30s") {
+			t.Fatalf("runtimeVersionProbeError() = %v", err)
+		}
+	})
+
+	t.Run("parent cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := runtimeVersionProbeError(ctx, ctx, errors.New("signal: killed"))
+		if !errors.Is(err, context.Canceled) ||
+			!strings.Contains(err.Error(), "runtime version probe aborted") {
+			t.Fatalf("runtimeVersionProbeError() = %v", err)
+		}
+	})
+}
+
 func (s *preferencesStoreStub) GetDesktopPreferences(context.Context) (preferencesbiz.DesktopPreferences, error) {
 	return s.preferences, nil
 }


### PR DESCRIPTION
## Summary
- allow slow cold-starting Agent Extension CLIs enough time to report their version
- preserve bounded installer diagnostics when npm/uv setup fails

## Evidence
- field Hermes install completed but its 5-second version probe was killed
- field Kimi install only surfaced `npm failed: exit status 1` because captured output was discarded

## Validation
- `go test ./services/tuttid/service/agentextension`
- `git diff --check`

## Documentation impact
No durable contract or user workflow changed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1830" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->