### PR TITLE
feat(agent): truncate oversized tool output

### DIFF
--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -993,10 +993,14 @@ reconciliation instead of guessed concatenation. When an explicit provider
 output notification races immediately ahead of its `item/started`, the
 provider normalizer may retain that prefix in a bounded pre-anchor buffer, but
 it must emit nothing until the real anchor arrives; it then publishes the
-anchor first and the retained prefix as `set`. An unmatched or oversized
-prefix is dropped with diagnostics rather than inventing a tool row.
-Completed, failed, canceled, and rewritten tool results remain full canonical
-`message_update` snapshots.
+anchor first and the retained prefix as `set`. Output beyond the canonical
+1 MiB field budget becomes a valid UTF-8 prefix plus `[Output truncated]`; the
+live projection expresses that bounded snapshot as one `set` followed by
+contiguous `append_text` operations that fit the transport envelope. An
+unmatched prefix, or one rejected by the aggregate pre-anchor call or byte
+budget, is dropped with diagnostics rather than inventing a tool row.
+Completed, failed, canceled, and rewritten tool results remain authoritative,
+bounded canonical `message_update` snapshots.
 
 Durable tool snapshots contain the business projection, not a provider-result
 archive. Before `workspace_agent_messages.payload_json` is written, the
@@ -1007,7 +1011,10 @@ Provider envelopes and duplicate representations such as top-level `content`,
 `output.content`, `rawInput`/`rawOutput`, Claude `toolResponse`, adapter
 metadata, image base64, and unknown provider-only result keys are not retained.
 Provider adapters may continue accepting those wire shapes, but shared
-business code consumes only the explicit canonical fields. Agent
+business code consumes only the explicit canonical fields. Each canonical
+`output` or `error` `text`, `stdout`, and `stderr` field, including nested tool
+steps, is bounded to 1 MiB total by retaining a valid UTF-8 prefix and the fixed
+`[Output truncated]` marker. Agent
 reference/session output uses the same canonical projection rather than
 depending on a retained raw tool result. This is a forward-write rule: existing
 rows are not rewritten, their removed fields are ignored, and normal retention
@@ -1041,15 +1048,18 @@ projection remains explicitly not caught up until the matching barrier is
 replayed. A host must not publish `AttachmentCaughtUp` for a replacement
 attachment until it has rerun the complete canonical baseline.
 
-Frames are bounded but not fragmented. The publisher may coalesce only adjacent
-pure `append_text` operations for the same message and Turn; tool-output
-operations additionally require contiguous byte offsets. Status, payload,
-semantic, or lifecycle mutations remain separate deliveries. A single delivery
-over the configured safe limit (1 MiB by default, with a 2 MiB encoded-frame
-ceiling and an 8 MiB replay-byte budget) is replaced with a `delivery_too_large`
-discontinuity carrying reconcile keys, and the caller falls back to canonical
-data. This avoids maintaining a second chunk assembly protocol while ensuring
-that the final oversized event is not silently lost.
+Frames are bounded but not fragmented. Before publication, a canonical
+tool-output operation that would consume the delivery budget is represented as
+one `set` followed by contiguous `append_text` operations; this reuses the
+existing semantic operation contract rather than introducing transport-frame
+fragment assembly. The publisher may coalesce only adjacent pure `append_text`
+operations for the same message and Turn; tool-output operations additionally
+require contiguous byte offsets. Status, payload, semantic, or lifecycle
+mutations remain separate deliveries. A single delivery over the configured
+safe limit (1 MiB by default, with a 2 MiB encoded-frame ceiling and an 8 MiB
+replay-byte budget) is replaced with a `delivery_too_large` discontinuity
+carrying reconcile keys, and the caller falls back to canonical data. This
+ensures that the final oversized event is not silently lost.
 
 The publisher also keeps a bounded FIFO of the most recent settled Turn ids.
 Those fences convert late text or tool deltas into scoped discontinuities

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -77,6 +77,9 @@ Realtime events reduce latency but are not automatically complete truth:
 - normalized provider text/reasoning streams and explicitly appendable textual
   tool output arrive as optimistic `message_delta` payloads on the
   `/v1/events/ws` business-event WebSocket
+- canonical tool `output`/`error` bodies bound each `text`, `stdout`, and
+  `stderr` field to 1 MiB total, including nested tool steps, by retaining a
+  valid UTF-8 prefix and the fixed `[Output truncated]` marker
 - continuous, version-complete `message_update` events may merge inline
 - terminal `message_update` is the durable confirmation; message version gaps,
   invalid/unanchored deltas, nonterminal deltas after known terminal message

--- a/packages/agent/daemon/runtime/acp_turn_normalizer.go
+++ b/packages/agent/daemon/runtime/acp_turn_normalizer.go
@@ -27,6 +27,7 @@ type acpTurnNormalizer struct {
 	toolCallsSeen             map[string]bool
 	pendingToolCalls          map[string]pendingToolCallSnapshot
 	toolOutputText            map[string]string
+	toolOutputTruncated       map[string]bool
 	earlyToolOutput           map[string]earlyToolOutputSnapshot
 	earlyToolOutputBytes      int
 	fileChanges               map[string]any
@@ -114,11 +115,12 @@ func (n *acpTurnNormalizer) SuppressAssistantOutput() {
 
 func newACPTurnNormalizer() *acpTurnNormalizer {
 	return &acpTurnNormalizer{
-		toolItemIDs:      make(map[string]string),
-		toolCallsSeen:    make(map[string]bool),
-		pendingToolCalls: make(map[string]pendingToolCallSnapshot),
-		toolOutputText:   make(map[string]string),
-		earlyToolOutput:  make(map[string]earlyToolOutputSnapshot),
+		toolItemIDs:         make(map[string]string),
+		toolCallsSeen:       make(map[string]bool),
+		pendingToolCalls:    make(map[string]pendingToolCallSnapshot),
+		toolOutputText:      make(map[string]string),
+		toolOutputTruncated: make(map[string]bool),
+		earlyToolOutput:     make(map[string]earlyToolOutputSnapshot),
 	}
 }
 
@@ -610,6 +612,7 @@ func (n *acpTurnNormalizer) trackToolCallEvent(event activityshared.Event) {
 	case activityshared.EventCallCompleted, activityshared.EventCallFailed:
 		delete(n.pendingToolCalls, event.EventID)
 		delete(n.toolOutputText, event.EventID)
+		delete(n.toolOutputTruncated, event.EventID)
 	}
 }
 

--- a/packages/agent/daemon/runtime/acp_turn_normalizer_tool_output.go
+++ b/packages/agent/daemon/runtime/acp_turn_normalizer_tool_output.go
@@ -3,15 +3,18 @@ package agentruntime
 import (
 	"log/slog"
 	"strings"
+	"unicode/utf8"
 
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 	"github.com/tutti-os/tutti/packages/agent/daemon/liveprotocol"
+	"github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
 )
 
 type earlyToolOutputSnapshot struct {
-	turnID  string
-	text    string
-	dropped bool
+	turnID    string
+	text      string
+	dropped   bool
+	truncated bool
 }
 
 const maxEarlyToolOutputCalls = 64
@@ -39,8 +42,11 @@ func (n *acpTurnNormalizer) AppendToolOutputDelta(
 		n.bufferEarlyToolOutput(turnID, rawToolCallID, delta)
 		return nil
 	}
+	if n.toolOutputTruncated[eventID] {
+		return nil
+	}
 	current := n.toolOutputText[eventID]
-	next := current + delta
+	next, truncated := appendBoundedToolOutputText(current, delta)
 	payload := clonePayload(pending.payload)
 	if payload == nil {
 		payload = map[string]any{}
@@ -58,11 +64,15 @@ func (n *acpTurnNormalizer) AppendToolOutputDelta(
 		Operation: "set",
 		Text:      next,
 	}
-	if current != "" {
+	if current != "" && (!truncated || strings.HasPrefix(next, current)) {
 		offset := int64(len(current))
+		operationText := delta
+		if truncated {
+			operationText = strings.TrimPrefix(next, current)
+		}
 		operation = &liveprotocol.MessageToolOutputOperation{
 			Operation:   "append_text",
-			Text:        delta,
+			Text:        operationText,
 			OffsetBytes: &offset,
 		}
 	}
@@ -78,8 +88,20 @@ func (n *acpTurnNormalizer) AppendToolOutputDelta(
 	)
 	attachToolOutputLiveOperation(&event, operation)
 	n.toolOutputText[eventID] = next
+	n.toolOutputTruncated[eventID] = truncated
 	n.trackToolCallEvent(event)
 	return []activityshared.Event{event}
+}
+
+func appendBoundedToolOutputText(current string, delta string) (string, bool) {
+	if len(current)+len(delta) <= canonical.ToolOutputTextMaxBytes {
+		return current + delta, false
+	}
+	remaining := canonical.ToolOutputTextMaxBytes + utf8.UTFMax - len(current)
+	if remaining < len(delta) {
+		delta = delta[:remaining]
+	}
+	return canonical.TruncateToolOutputText(current + delta), true
 }
 
 func (n *acpTurnNormalizer) bufferEarlyToolOutput(turnID string, rawToolCallID string, delta string) {
@@ -105,10 +127,12 @@ func (n *acpTurnNormalizer) bufferEarlyToolOutput(turnID string, rawToolCallID s
 		n.earlyToolOutputBytes -= len(current.text)
 		current = earlyToolOutputSnapshot{turnID: turnID}
 	}
-	if current.dropped {
+	if current.dropped || current.truncated {
 		return
 	}
-	if n.earlyToolOutputBytes+len(delta) > liveprotocol.DefaultDeliveryMaxBytes {
+	next, truncated := appendBoundedToolOutputText(current.text, delta)
+	nextTotalBytes := n.earlyToolOutputBytes - len(current.text) + len(next)
+	if nextTotalBytes > liveprotocol.DefaultDeliveryMaxBytes {
 		n.earlyToolOutputBytes -= len(current.text)
 		current.text = ""
 		current.dropped = true
@@ -122,8 +146,9 @@ func (n *acpTurnNormalizer) bufferEarlyToolOutput(turnID string, rawToolCallID s
 		return
 	}
 	current.turnID = turnID
-	current.text += delta
-	n.earlyToolOutputBytes += len(delta)
+	current.text = next
+	current.truncated = truncated
+	n.earlyToolOutputBytes = nextTotalBytes
 	n.earlyToolOutput[rawToolCallID] = current
 }
 
@@ -145,5 +170,11 @@ func (n *acpTurnNormalizer) consumeEarlyToolOutput(
 	if pending.dropped || pending.turnID != strings.TrimSpace(turnID) || pending.text == "" {
 		return nil
 	}
-	return n.AppendToolOutputDelta(session, turnID, rawToolCallID, pending.text)
+	events := n.AppendToolOutputDelta(session, turnID, rawToolCallID, pending.text)
+	if pending.truncated {
+		if eventID := n.knownToolItemID(rawToolCallID); eventID != "" {
+			n.toolOutputTruncated[eventID] = true
+		}
+	}
+	return events
 }

--- a/packages/agent/daemon/runtime/activity_projection.go
+++ b/packages/agent/daemon/runtime/activity_projection.go
@@ -3,6 +3,7 @@ package agentruntime
 import (
 	"encoding/json"
 	"strings"
+	"unicode/utf8"
 
 	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
@@ -40,11 +41,13 @@ func ProjectActivityEventsToStreamEvents(session Session, events []activityshare
 				Data:      patch,
 			})
 		}
-		if delta, ok := liveMessageDeltaFromSessionEvent(session, event, sessionID, timestamp); ok {
-			out = append(out, StreamEvent{
-				EventType: StreamEventMessageDelta,
-				Data:      delta,
-			})
+		if deltas := liveMessageDeltasFromSessionEvent(session, event, sessionID, timestamp); len(deltas) > 0 {
+			for _, delta := range deltas {
+				out = append(out, StreamEvent{
+					EventType: StreamEventMessageDelta,
+					Data:      delta,
+				})
+			}
 			continue
 		}
 		if isPrecommitTerminalTextMessage(event) {
@@ -71,16 +74,16 @@ func ProjectActivityEventsToStreamEvents(session Session, events []activityshare
 	return out
 }
 
-func liveMessageDeltaFromSessionEvent(
+func liveMessageDeltasFromSessionEvent(
 	session Session,
 	event activityshared.Event,
 	sessionID string,
 	timestamp int64,
-) (liveprotocol.Event, bool) {
+) []liveprotocol.Event {
 	contentOperation, _ := event.Payload.Metadata[liveContentOperationMetadataKey].(*liveprotocol.MessageContentOperation)
 	toolOutputOperation, _ := event.Payload.Metadata[liveToolOutputOperationMetadataKey].(*liveprotocol.MessageToolOutputOperation)
 	if contentOperation == nil && toolOutputOperation == nil {
-		return liveprotocol.Event{}, false
+		return nil
 	}
 	messageID := firstNonEmptyString(stringFromPayload(event.Payload.Metadata, "messageId"), event.EventID)
 	if toolOutputOperation != nil {
@@ -92,7 +95,7 @@ func liveMessageDeltaFromSessionEvent(
 		messageID = toolCallMessageUpdateID(event, sessionID, timestamp)
 	}
 	if messageID == "" || strings.TrimSpace(event.Payload.TurnID) == "" || timestamp <= 0 {
-		return liveprotocol.Event{}, false
+		return nil
 	}
 	var contentOperationCopy *liveprotocol.MessageContentOperation
 	if contentOperation != nil {
@@ -124,8 +127,69 @@ func liveMessageDeltaFromSessionEvent(
 	if status != "" {
 		data.Status = &status
 	}
-	delta, err := liveprotocol.NewMessageDeltaEvent(data)
-	return delta, err == nil
+	return deliverableMessageDeltaEvents(data)
+}
+
+// JSON encoding can expand a single source byte to six bytes (for example,
+// control characters become \u00XX). Keeping each semantic tool-output chunk
+// to one eighth of the live delivery budget leaves room for that worst-case
+// expansion plus the message and protobuf envelopes.
+const liveToolOutputTextChunkMaxBytes = liveprotocol.DefaultDeliveryMaxBytes / 8
+
+func deliverableMessageDeltaEvents(data liveprotocol.MessageDeltaData) []liveprotocol.Event {
+	operation := data.ToolOutput
+	if operation == nil || len(operation.Text) <= liveToolOutputTextChunkMaxBytes {
+		delta, err := liveprotocol.NewMessageDeltaEvent(data)
+		if err != nil {
+			return nil
+		}
+		return []liveprotocol.Event{delta}
+	}
+
+	chunks := splitLiveToolOutputText(operation.Text)
+	out := make([]liveprotocol.Event, 0, len(chunks))
+	consumedBytes := int64(0)
+	if operation.OffsetBytes != nil {
+		consumedBytes = *operation.OffsetBytes
+	}
+	for index, chunk := range chunks {
+		part := data
+		partOperation := *operation
+		partOperation.Text = chunk
+		if index > 0 {
+			part.Status = nil
+			partOperation.Operation = "append_text"
+			offset := consumedBytes
+			partOperation.OffsetBytes = &offset
+		}
+		part.ToolOutput = &partOperation
+		delta, err := liveprotocol.NewMessageDeltaEvent(part)
+		if err != nil {
+			return nil
+		}
+		out = append(out, delta)
+		consumedBytes += int64(len(chunk))
+	}
+	return out
+}
+
+func splitLiveToolOutputText(text string) []string {
+	chunks := make([]string, 0, len(text)/liveToolOutputTextChunkMaxBytes+1)
+	for len(text) > liveToolOutputTextChunkMaxBytes {
+		end := liveToolOutputTextChunkMaxBytes
+		for end > 0 && !utf8.RuneStart(text[end]) {
+			end--
+		}
+		if end == 0 {
+			end = liveToolOutputTextChunkMaxBytes
+		}
+		chunks = append(chunks, text[:end])
+		text = text[end:]
+	}
+	if text != "" {
+		chunks = append(chunks, text)
+	}
+	return chunks
 }
 
 func isPrecommitTerminalTextMessage(event activityshared.Event) bool {

--- a/packages/agent/daemon/runtime/activity_projection_test.go
+++ b/packages/agent/daemon/runtime/activity_projection_test.go
@@ -2,11 +2,13 @@ package agentruntime
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 	"github.com/tutti-os/tutti/packages/agent/daemon/liveprotocol"
+	"github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
 )
 
 func TestACPNormalizerProjectsSemanticMessageDeltaWithoutSnapshotDiff(t *testing.T) {
@@ -243,6 +245,80 @@ func TestExplicitToolOutputDeltaPersistsSnapshotAndProjectsOffsetAppend(t *testi
 	}
 }
 
+func TestExplicitToolOutputDeltaTruncatesOnceAndDropsLaterChunks(t *testing.T) {
+	t.Parallel()
+
+	session := reportTestSession()
+	normalizer := newACPTurnNormalizer()
+	started, ok := normalizer.ToolCallEvents(session, "turn-1", map[string]any{
+		"sessionUpdate": "tool_call",
+		"toolCallId":    "command-large",
+		"title":         "printf",
+		"kind":          "execute",
+		"status":        "in_progress",
+	})
+	if !ok || len(started) != 1 {
+		t.Fatalf("started = %#v, ok = %v", started, ok)
+	}
+
+	firstLength := canonical.ToolOutputTextMaxBytes -
+		len(canonical.ToolOutputTruncationMarker) -
+		len("\n") -
+		8
+	if events := normalizer.AppendToolOutputDelta(
+		session,
+		"turn-1",
+		"command-large",
+		strings.Repeat("x", firstLength),
+	); len(events) != 1 {
+		t.Fatalf("first output events = %#v, want one", events)
+	}
+	truncated := normalizer.AppendToolOutputDelta(
+		session,
+		"turn-1",
+		"command-large",
+		strings.Repeat("y", 64),
+	)
+	if len(truncated) != 1 {
+		t.Fatalf("truncated output events = %#v, want one", truncated)
+	}
+	if later := normalizer.AppendToolOutputDelta(
+		session,
+		"turn-1",
+		"command-large",
+		"ignored",
+	); len(later) != 0 {
+		t.Fatalf("later output events = %#v, want dropped after truncation", later)
+	}
+
+	output := payloadMap(truncated[0].Payload.Metadata, "output")["text"].(string)
+	if len(output) > canonical.ToolOutputTextMaxBytes ||
+		!strings.HasSuffix(output, canonical.ToolOutputTruncationMarker) {
+		t.Fatalf("snapshot output was not bounded: %d bytes", len(output))
+	}
+	stream := ProjectActivityEventsToStreamEvents(session, truncated)
+	if len(stream) != 1 || stream[0].EventType != StreamEventMessageDelta {
+		t.Fatalf("stream = %#v, want one tool output delta", stream)
+	}
+	var delta liveprotocol.MessageDeltaData
+	if err := json.Unmarshal(stream[0].Data.(liveprotocol.Event).Data, &delta); err != nil {
+		t.Fatal(err)
+	}
+	if delta.ToolOutput == nil ||
+		delta.ToolOutput.Operation != "append_text" ||
+		delta.ToolOutput.OffsetBytes == nil ||
+		*delta.ToolOutput.OffsetBytes != int64(firstLength) ||
+		!strings.HasSuffix(delta.ToolOutput.Text, canonical.ToolOutputTruncationMarker) {
+		t.Fatalf("truncated live operation = %#v", delta.ToolOutput)
+	}
+
+	report := reportActivityInput(session, truncated)
+	persisted := report.MessageUpdates[0].Payload["output"].(map[string]any)["text"].(string)
+	if persisted != output {
+		t.Fatal("live runtime snapshot and durable report used different truncated output")
+	}
+}
+
 func TestToolOutputDeltaWaitsForKnownStartAnchor(t *testing.T) {
 	t.Parallel()
 	session := reportTestSession()
@@ -283,6 +359,163 @@ func TestToolOutputDeltaWaitsForKnownStartAnchor(t *testing.T) {
 		delta.ToolOutput.Operation != "set" ||
 		delta.ToolOutput.Text != "first" {
 		t.Fatalf("buffered tool output = %#v", delta.ToolOutput)
+	}
+}
+
+func TestToolOutputDeltaTruncatesBufferedPreAnchorOutput(t *testing.T) {
+	t.Parallel()
+
+	session := reportTestSession()
+	normalizer := newACPTurnNormalizer()
+	large := strings.Repeat("x", canonical.ToolOutputTextMaxBytes+64)
+	if events := normalizer.AppendToolOutputDelta(
+		session,
+		"turn-1",
+		"buffered-large-command",
+		large,
+	); len(events) != 0 {
+		t.Fatalf("pre-anchor output events = %#v, want buffered output", events)
+	}
+	started, ok := normalizer.ToolCallEvents(session, "turn-1", map[string]any{
+		"sessionUpdate": "tool_call",
+		"toolCallId":    "buffered-large-command",
+		"title":         "printf",
+		"kind":          "execute",
+		"status":        "in_progress",
+	})
+	if !ok || len(started) != 2 {
+		t.Fatalf("started = %#v, ok = %v, want anchor and truncated buffered output", started, ok)
+	}
+	output := payloadMap(started[1].Payload.Metadata, "output")["text"].(string)
+	if len(output) > canonical.ToolOutputTextMaxBytes ||
+		!strings.HasSuffix(output, canonical.ToolOutputTruncationMarker) {
+		t.Fatalf("buffered output was not bounded: %d bytes", len(output))
+	}
+	if later := normalizer.AppendToolOutputDelta(
+		session,
+		"turn-1",
+		"buffered-large-command",
+		"ignored",
+	); len(later) != 0 {
+		t.Fatalf("later output events = %#v, want dropped after buffered truncation", later)
+	}
+}
+
+func TestTruncatedBufferedToolOutputFitsLivePublisher(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name  string
+		large string
+	}{
+		{
+			name:  "ASCII",
+			large: strings.Repeat("x", canonical.ToolOutputTextMaxBytes+64),
+		},
+		{
+			name:  "JSON escaping",
+			large: strings.Repeat("\x00", canonical.ToolOutputTextMaxBytes+64),
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			session := reportTestSession()
+			normalizer := newACPTurnNormalizer()
+			if events := normalizer.AppendToolOutputDelta(
+				session,
+				"turn-1",
+				"buffered-large-command",
+				test.large,
+			); len(events) != 0 {
+				t.Fatalf("pre-anchor output events = %#v, want buffered output", events)
+			}
+			started, ok := normalizer.ToolCallEvents(session, "turn-1", map[string]any{
+				"sessionUpdate": "tool_call",
+				"toolCallId":    "buffered-large-command",
+				"title":         "printf",
+				"kind":          "execute",
+				"status":        "in_progress",
+			})
+			if !ok || len(started) != 2 {
+				t.Fatalf("started = %#v, ok = %v, want anchor and buffered output", started, ok)
+			}
+			expected := payloadMap(started[1].Payload.Metadata, "output")["text"].(string)
+			stream := ProjectActivityEventsToStreamEvents(session, started)
+
+			publisher, err := liveprotocol.NewPublisher(liveprotocol.PublisherConfig{
+				StreamID: "stream-1", BindingID: "binding-1", Epoch: 1,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			var delivered string
+			deltaCount := 0
+			for _, streamEvent := range stream {
+				if streamEvent.EventType != StreamEventMessageDelta {
+					continue
+				}
+				event, ok := streamEvent.Data.(liveprotocol.Event)
+				if !ok {
+					t.Fatalf("stream event data has type %T", streamEvent.Data)
+				}
+				frames, err := publisher.Publish(liveprotocol.PublishInput{
+					Event: &event, Immediate: true,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(frames) != 1 || len(frames[0].Deliveries) != 1 {
+					t.Fatalf("published frames = %#v, want one delivery", frames)
+				}
+				delivery := frames[0].Deliveries[0]
+				if delivery.Kind != liveprotocol.DeliveryKindEvent {
+					t.Fatalf("delivery kind = %v, want event", delivery.Kind)
+				}
+				deliveredEvent, err := liveprotocol.DecodeEvent(delivery.Event)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var delta liveprotocol.MessageDeltaData
+				if err := json.Unmarshal(deliveredEvent.Data, &delta); err != nil {
+					t.Fatal(err)
+				}
+				if delta.ToolOutput == nil {
+					t.Fatalf("delivered delta = %#v, want tool output", delta)
+				}
+				switch delta.ToolOutput.Operation {
+				case "set":
+					if deltaCount != 0 {
+						t.Fatalf("set operation arrived after %d deltas", deltaCount)
+					}
+					delivered = delta.ToolOutput.Text
+				case "append_text":
+					if delta.ToolOutput.OffsetBytes == nil ||
+						*delta.ToolOutput.OffsetBytes != int64(len(delivered)) {
+						t.Fatalf(
+							"append offset = %#v, delivered bytes = %d",
+							delta.ToolOutput.OffsetBytes,
+							len(delivered),
+						)
+					}
+					delivered += delta.ToolOutput.Text
+				default:
+					t.Fatalf("tool output operation = %#v", delta.ToolOutput)
+				}
+				deltaCount++
+			}
+			if deltaCount < 2 {
+				t.Fatalf("delta count = %d, want split delivery", deltaCount)
+			}
+			if delivered != expected ||
+				len(delivered) > canonical.ToolOutputTextMaxBytes ||
+				!strings.HasSuffix(delivered, canonical.ToolOutputTruncationMarker) {
+				t.Fatalf(
+					"delivered output mismatch: got %d bytes, want %d",
+					len(delivered),
+					len(expected),
+				)
+			}
+		})
 	}
 }
 

--- a/packages/agent/daemon/runtime/reporter_message.go
+++ b/packages/agent/daemon/runtime/reporter_message.go
@@ -185,7 +185,7 @@ func callMessageUpdateFromSessionEvent(
 		payload["toolName"] = toolName
 	}
 	if metadata, ok := event.Payload.Metadata["metadata"].(map[string]any); ok && len(metadata) > 0 {
-		payload["metadata"] = clonePayloadValue(metadata)
+		payload["metadata"] = canonicalToolMetadataPayload(metadata)
 	}
 	for _, key := range []string{"input", "output", "error", "content", "locations"} {
 		if value, ok := event.Payload.Metadata[key]; ok && !payloadValueIsEmpty(value) {
@@ -263,7 +263,17 @@ func canonicalToolBodyPayload(value any) any {
 			body["text"] = text
 		}
 	}
-	return body
+	return canonical.TruncateToolOutputBody(body)
+}
+
+func canonicalToolMetadataPayload(metadata map[string]any) map[string]any {
+	result := clonePayload(metadata)
+	if result == nil || result["steps"] == nil {
+		return result
+	}
+	truncated := canonical.TruncateToolOutputBody(map[string]any{"steps": result["steps"]})
+	result["steps"] = truncated["steps"]
+	return result
 }
 
 func canonicalToolBodyText(body map[string]any) string {

--- a/packages/agent/daemon/runtime/reporter_test.go
+++ b/packages/agent/daemon/runtime/reporter_test.go
@@ -973,6 +973,89 @@ func TestReporterCanonicalizesToolOutputTextFromContentBlocks(t *testing.T) {
 	}
 }
 
+func TestReporterTruncatesFormalToolOutputFieldsBeforeLiveAndDurableProjection(t *testing.T) {
+	t.Parallel()
+
+	large := strings.Repeat("x", canonical.ToolOutputTextMaxBytes+64)
+	session := reportTestSession()
+	event := newTurnActivityEventWithID(
+		session,
+		"large-tool-output",
+		EventCallFailed,
+		"turn-large",
+		messageStreamStateFailed,
+		"",
+		"Run command",
+		map[string]any{
+			"callId": "call-large",
+			"input":  map[string]any{"text": large},
+			"output": map[string]any{
+				"text":    large,
+				"stdout":  large,
+				"message": large,
+				"steps": []any{
+					map[string]any{
+						"toolResult": map[string]any{"stdout": large},
+					},
+				},
+			},
+			"error": map[string]any{
+				"stderr": large,
+			},
+			"metadata": map[string]any{
+				"steps": []any{
+					map[string]any{
+						"toolError": map[string]any{"stderr": large},
+					},
+				},
+			},
+		},
+	)
+
+	stream := ProjectActivityEventsToStreamEvents(session, []activityshared.Event{event})
+	report := reportActivityInput(session, []activityshared.Event{event})
+	if len(stream) != 1 || len(report.MessageUpdates) != 1 {
+		t.Fatalf("stream=%#v report=%#v, want one update in each projection", stream, report)
+	}
+	liveUpdate := stream[0].Data.(agentsessionstore.WorkspaceAgentMessageUpdate)
+	for _, update := range []agentsessionstore.WorkspaceAgentMessageUpdate{
+		liveUpdate,
+		report.MessageUpdates[0],
+	} {
+		if update.Payload["input"].(map[string]any)["text"] != large {
+			t.Fatal("tool input was truncated")
+		}
+		output := update.Payload["output"].(map[string]any)
+		for _, key := range []string{"text", "stdout"} {
+			value := output[key].(string)
+			if len(value) > canonical.ToolOutputTextMaxBytes ||
+				!strings.HasSuffix(value, canonical.ToolOutputTruncationMarker) {
+				t.Fatalf("output.%s was not bounded: %d bytes", key, len(value))
+			}
+		}
+		if output["message"] != large {
+			t.Fatal("non-target structured output field was truncated")
+		}
+		step := output["steps"].([]any)[0].(map[string]any)
+		stdout := step["toolResult"].(map[string]any)["stdout"].(string)
+		if len(stdout) > canonical.ToolOutputTextMaxBytes ||
+			!strings.HasSuffix(stdout, canonical.ToolOutputTruncationMarker) {
+			t.Fatalf("nested stdout was not bounded: %d bytes", len(stdout))
+		}
+		stderr := update.Payload["error"].(map[string]any)["stderr"].(string)
+		if len(stderr) > canonical.ToolOutputTextMaxBytes ||
+			!strings.HasSuffix(stderr, canonical.ToolOutputTruncationMarker) {
+			t.Fatalf("error.stderr was not bounded: %d bytes", len(stderr))
+		}
+		metadataStep := update.Payload["metadata"].(map[string]any)["steps"].([]any)[0].(map[string]any)
+		metadataStderr := metadataStep["toolError"].(map[string]any)["stderr"].(string)
+		if len(metadataStderr) > canonical.ToolOutputTextMaxBytes ||
+			!strings.HasSuffix(metadataStderr, canonical.ToolOutputTruncationMarker) {
+			t.Fatalf("metadata step stderr was not bounded: %d bytes", len(metadataStderr))
+		}
+	}
+}
+
 func TestReporterProjectsFailedCallOutputAlongsideError(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/store-sqlite/canonical/tool_output_truncation.go
+++ b/packages/agent/store-sqlite/canonical/tool_output_truncation.go
@@ -1,0 +1,91 @@
+package canonical
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	// ToolOutputTextMaxBytes is the per-field persisted and live projection bound.
+	ToolOutputTextMaxBytes = 1 << 20
+	// ToolOutputTruncationMarker identifies a tool output prefix with omitted bytes.
+	ToolOutputTruncationMarker    = "[Output truncated]"
+	toolOutputTruncationSeparator = "\n"
+)
+
+var truncatedToolOutputTextKeys = [...]string{"text", "stdout", "stderr"}
+
+// TruncateToolOutputText bounds one canonical tool output field while
+// preserving a valid UTF-8 prefix and an explicit truncation marker.
+func TruncateToolOutputText(value string) string {
+	if len(value) <= ToolOutputTextMaxBytes {
+		return value
+	}
+
+	value = strings.ToValidUTF8(value, string(utf8.RuneError))
+	if len(value) <= ToolOutputTextMaxBytes {
+		return value
+	}
+
+	prefixLimit := ToolOutputTextMaxBytes -
+		len(toolOutputTruncationSeparator) -
+		len(ToolOutputTruncationMarker)
+	for prefixLimit > 0 && !utf8.RuneStart(value[prefixLimit]) {
+		prefixLimit--
+	}
+	prefix := value[:prefixLimit]
+	separator := toolOutputTruncationSeparator
+	if prefix == "" || strings.HasSuffix(prefix, "\n") {
+		separator = ""
+	}
+	return prefix + separator + ToolOutputTruncationMarker
+}
+
+// TruncateToolOutputBody clones one canonical output/error body and applies
+// the same text-field bound to its nested canonical tool steps.
+func TruncateToolOutputBody(body map[string]any) map[string]any {
+	result := cloneToolMap(body)
+	truncateToolOutputBodyInPlace(result)
+	return result
+}
+
+func truncateToolOutputBodyInPlace(body map[string]any) {
+	if len(body) == 0 {
+		return
+	}
+	for _, key := range truncatedToolOutputTextKeys {
+		if value, ok := body[key].(string); ok {
+			body[key] = TruncateToolOutputText(value)
+		}
+	}
+	steps, _ := body["steps"].([]any)
+	for _, value := range steps {
+		step, _ := value.(map[string]any)
+		truncateToolOutputStepInPlace(step)
+	}
+}
+
+func truncateToolOutputStepInPlace(step map[string]any) {
+	if len(step) == 0 {
+		return
+	}
+	for _, key := range []string{
+		"toolResult",
+		"tool_result",
+		"toolError",
+		"tool_error",
+		"output",
+		"error",
+	} {
+		if body, ok := step[key].(map[string]any); ok {
+			truncateToolOutputBodyInPlace(body)
+		}
+	}
+	if payload, ok := step["payload"].(map[string]any); ok {
+		for _, key := range []string{"output", "error"} {
+			if body, ok := payload[key].(map[string]any); ok {
+				truncateToolOutputBodyInPlace(body)
+			}
+		}
+	}
+}

--- a/packages/agent/store-sqlite/canonical/tool_output_truncation_test.go
+++ b/packages/agent/store-sqlite/canonical/tool_output_truncation_test.go
@@ -1,0 +1,114 @@
+package canonical
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestTruncateToolOutputTextKeepsValuesWithinLimit(t *testing.T) {
+	t.Parallel()
+
+	value := strings.Repeat("x", ToolOutputTextMaxBytes)
+	if got := TruncateToolOutputText(value); got != value {
+		t.Fatalf("value at limit changed: got %d bytes, want %d", len(got), len(value))
+	}
+}
+
+func TestTruncateToolOutputTextKeepsValidUTF8PrefixAndMarker(t *testing.T) {
+	t.Parallel()
+
+	prefixLimit := ToolOutputTextMaxBytes -
+		len(toolOutputTruncationSeparator) -
+		len(ToolOutputTruncationMarker)
+	value := strings.Repeat("a", prefixLimit-1) + "你" + strings.Repeat("z", 64)
+	got := TruncateToolOutputText(value)
+
+	if len(got) > ToolOutputTextMaxBytes {
+		t.Fatalf("truncated value has %d bytes, limit is %d", len(got), ToolOutputTextMaxBytes)
+	}
+	if !utf8.ValidString(got) {
+		t.Fatal("truncated value is not valid UTF-8")
+	}
+	if !strings.HasSuffix(got, "\n"+ToolOutputTruncationMarker) {
+		t.Fatalf("truncated value suffix = %q", got[len(got)-64:])
+	}
+	if strings.Contains(got, "你") || strings.Contains(got, "z") {
+		t.Fatal("truncated value retained content after the valid prefix boundary")
+	}
+	if repeated := TruncateToolOutputText(got); repeated != got {
+		t.Fatal("truncation marker was not idempotent")
+	}
+}
+
+func TestTruncateToolOutputBodyLimitsOnlyFormalTextFieldsAndNestedSteps(t *testing.T) {
+	t.Parallel()
+
+	large := strings.Repeat("x", ToolOutputTextMaxBytes+64)
+	body := map[string]any{
+		"text":    large,
+		"stdout":  large,
+		"stderr":  large,
+		"message": large,
+		"steps": []any{
+			map[string]any{
+				"toolResult": map[string]any{"text": large, "stdout": large},
+				"toolError":  map[string]any{"stderr": large},
+			},
+		},
+	}
+	got := TruncateToolOutputBody(body)
+
+	assertTruncatedToolTextFields(t, got, "text", "stdout", "stderr")
+	if got["message"] != large {
+		t.Fatal("non-target output field was truncated")
+	}
+	step := got["steps"].([]any)[0].(map[string]any)
+	assertTruncatedToolTextFields(t, step["toolResult"].(map[string]any), "text", "stdout")
+	assertTruncatedToolTextFields(t, step["toolError"].(map[string]any), "stderr")
+	if body["text"] != large {
+		t.Fatal("input body was mutated")
+	}
+}
+
+func TestCompactToolCallPayloadLimitsOutputErrorAndStepBodiesWithoutChangingInput(t *testing.T) {
+	t.Parallel()
+
+	large := strings.Repeat("x", ToolOutputTextMaxBytes+64)
+	got := CompactToolCallPayload("failed", map[string]any{
+		"callId": "call-1",
+		"input":  map[string]any{"text": large},
+		"output": map[string]any{"text": large, "stdout": large},
+		"error":  map[string]any{"text": large, "stderr": large},
+		"steps": []any{
+			map[string]any{
+				"id":         "step-1",
+				"status":     "failed",
+				"toolResult": map[string]any{"stdout": large},
+				"toolError":  map[string]any{"stderr": large},
+			},
+		},
+	})
+
+	if got["input"].(map[string]any)["text"] != large {
+		t.Fatal("tool input was truncated")
+	}
+	assertTruncatedToolTextFields(t, got["output"].(map[string]any), "text", "stdout")
+	assertTruncatedToolTextFields(t, got["error"].(map[string]any), "text", "stderr")
+	step := got["steps"].([]any)[0].(map[string]any)
+	assertTruncatedToolTextFields(t, step["toolResult"].(map[string]any), "stdout")
+	assertTruncatedToolTextFields(t, step["toolError"].(map[string]any), "stderr")
+}
+
+func assertTruncatedToolTextFields(t *testing.T, body map[string]any, keys ...string) {
+	t.Helper()
+	for _, key := range keys {
+		value, _ := body[key].(string)
+		if len(value) > ToolOutputTextMaxBytes {
+			t.Fatalf("%s has %d bytes, limit is %d", key, len(value), ToolOutputTextMaxBytes)
+		}
+		if !strings.HasSuffix(value, ToolOutputTruncationMarker) {
+			t.Fatalf("%s does not end with truncation marker", key)
+		}
+	}
+}

--- a/packages/agent/store-sqlite/canonical/tool_payload.go
+++ b/packages/agent/store-sqlite/canonical/tool_payload.go
@@ -189,11 +189,11 @@ func CompactToolCallPayload(status string, payload map[string]any) map[string]an
 
 	if output != nil {
 		delete(output, "content")
-		output = selectToolKeys(output, canonicalToolBodyKeys)
+		output = TruncateToolOutputBody(selectToolKeys(output, canonicalToolBodyKeys))
 	}
 	if toolError != nil {
 		delete(toolError, "content")
-		toolError = selectToolKeys(toolError, canonicalToolBodyKeys)
+		toolError = TruncateToolOutputBody(selectToolKeys(toolError, canonicalToolBodyKeys))
 	}
 
 	delete(result, "content")
@@ -386,7 +386,7 @@ func compactToolBody(value any) map[string]any {
 	delete(body, "content")
 	delete(body, "metadata")
 	delete(body, "toolResponse")
-	return selectToolKeys(body, canonicalToolBodyKeys)
+	return TruncateToolOutputBody(selectToolKeys(body, canonicalToolBodyKeys))
 }
 
 func compactToolMetadata(value any) map[string]any {


### PR DESCRIPTION
## Summary

- bound canonical tool `output` and `error` `text`, `stdout`, and `stderr` fields to 1 MiB each, including nested tool steps
- retain a valid UTF-8 prefix and append the fixed `[Output truncated]` marker within that budget
- stop accumulating later ACP output chunks after truncation and split large live projections into transport-safe `set` / `append_text` operations
- apply the same canonical policy to live projection, durable reporting, and final store compaction without changing provider internals or rewriting historical rows
- document the canonical and live-delivery contracts

## Why

Very large tool results have little direct user value but create substantial local database and event-delivery pressure. The live fast lane also has a 1 MiB delivery envelope, so a 1 MiB field cannot be sent as one encoded event after JSON and protocol overhead are added.

## Behavior

Tool input and non-text structured result fields remain unchanged. Oversized textual output keeps its prefix and ends with:

```text
[Output truncated]
```

The 1 MiB limit includes the marker and is measured in UTF-8 bytes.

## Validation

- `go test ./packages/agent/daemon/runtime ./packages/agent/store-sqlite/canonical -count=1`
- `pnpm check:changed` — 9 lanes passed
- pre-push `pnpm check:changed -- --push-ready` — 10 lanes passed
- Computer Use smoke test in Tutti Dev: generated 1,200,000 bytes of command stdout, observed the truncation marker in the live tool card, confirmed the turn completed with `TEST_DONE`, switched away and reopened the session, and observed the marker again from durable reload
- read-only SQLite verification: persisted `output.text` and `output.stdout` were both exactly 1,048,576 bytes and ended with `[Output truncated]`
