### PR TITLE
fix(agent-gui): hide handoff ownership labels by default

### DIFF
--- a/packages/agent/gui/AgentGUI.spec.tsx
+++ b/packages/agent/gui/AgentGUI.spec.tsx
@@ -20,6 +20,7 @@ interface AgentGUINodeProbeProps {
       availability: unknown;
       ref: unknown;
     }[];
+    showHandoffTargetOwnershipLabels?: boolean;
   };
 }
 
@@ -193,6 +194,20 @@ describe("AgentGUI i18n", () => {
     expect(
       screen.getByTestId("agent-gui-handoff-targets-probe")
     ).toHaveTextContent('["local-codex","shared-agent:claude"]');
+  });
+
+  it("forwards the host-owned handoff ownership presentation", () => {
+    render(
+      <AgentGUI
+        {...createAgentGUIProps("en")}
+        hostCapabilities={{ showHandoffTargetOwnershipLabels: true }}
+      />
+    );
+
+    const props = agentGuiNodeSpy.mock.calls.at(-1)?.[0] as
+      | AgentGUINodeProbeProps
+      | undefined;
+    expect(props?.hostCapabilities.showHandoffTargetOwnershipLabels).toBe(true);
   });
 
   it("reuses agent target projections across frame-only renders", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -101,6 +101,7 @@ export const AgentGUINode = memo(function AgentGUINode({
     agentTargetsLoading = false,
     handoffAgentTargets,
     handoffAgentTargetsLoading = false,
+    showHandoffTargetOwnershipLabels = false,
     providerRailAllPresentation = null,
     providerRailMode = "catalog",
     comingSoonProviders,
@@ -489,6 +490,9 @@ export const AgentGUINode = memo(function AgentGUINode({
               onSlashStatusRefresh={handleSlashStatusRefresh}
               onLinkAction={handleLinkAction}
               onHandoffConversation={onHandoffConversation}
+              showHandoffTargetOwnershipLabels={
+                showHandoffTargetOwnershipLabels
+              }
               capabilityMenuState={capabilityMenuState}
               capabilityControlsReadOnly={capabilityControlsReadOnly}
               onCapabilitySettingsRequest={onCapabilitySettingsRequest}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.types.ts
@@ -142,6 +142,8 @@ export interface AgentGUINodeHostCapabilities {
   /** Launch-only targets for active-conversation handoff. */
   handoffAgentTargets?: readonly AgentGUIAgentTarget[];
   handoffAgentTargetsLoading?: boolean;
+  /** Hidden by default; hosts may opt into ownership copy for collaborative products. */
+  showHandoffTargetOwnershipLabels?: boolean;
   providerRailAllPresentation?: AgentGUIProviderRailAllPresentation | null;
   providerRailMode?: AgentGUIProviderRailMode;
   comingSoonProviders?: readonly AgentGUIProvider[];
@@ -416,6 +418,8 @@ export function areAgentGUINodePropsEqual(
     pc.agentTargetsLoading === nc.agentTargetsLoading &&
     pc.handoffAgentTargets === nc.handoffAgentTargets &&
     pc.handoffAgentTargetsLoading === nc.handoffAgentTargetsLoading &&
+    pc.showHandoffTargetOwnershipLabels ===
+      nc.showHandoffTargetOwnershipLabels &&
     pc.providerRailAllPresentation?.iconUrl ===
       nc.providerRailAllPresentation?.iconUrl &&
     pc.providerRailMode === nc.providerRailMode &&

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -95,6 +95,7 @@ export function AgentGUINodeView({
   providerRailAllPresentation,
   onLinkAction,
   onHandoffConversation,
+  showHandoffTargetOwnershipLabels = false,
   capabilityMenuState,
   capabilityControlsReadOnly = false,
   onCapabilitySettingsRequest,
@@ -715,6 +716,9 @@ export function AgentGUINodeView({
                 onSlashStatusRefresh={onSlashStatusRefresh}
                 onLinkAction={onLinkAction}
                 onHandoffConversation={onHandoffConversation}
+                showHandoffTargetOwnershipLabels={
+                  showHandoffTargetOwnershipLabels
+                }
                 capabilityMenuState={capabilityMenuState}
                 capabilityControlsReadOnly={capabilityControlsReadOnly}
                 onCapabilitySettingsRequest={onCapabilitySettingsRequest}

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
@@ -111,6 +111,7 @@ export interface AgentComposerProps {
   footerAccessory?: ReactNode;
   agentTargets?: readonly AgentGUIAgentTarget[];
   handoffAgentTargets?: readonly AgentGUIAgentTarget[];
+  showHandoffTargetOwnershipLabels?: boolean;
   providerSelectReadonly?: boolean;
   onProviderSelect?: (input: {
     provider: AgentGUIProvider;

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerView.tsx
@@ -641,6 +641,9 @@ export function AgentComposerView(input: Props): React.JSX.Element {
             effectiveHandoffMenuLabel={effectiveHandoffMenuLabel}
             handoffMenuTargets={handoffMenuTargets}
             onHandoffConversation={onHandoffConversation}
+            showHandoffTargetOwnershipLabels={
+              input.props.showHandoffTargetOwnershipLabels
+            }
             showProviderSelect={showProviderSelect}
             selectedProviderSwitchTarget={selectedProviderSwitchTarget}
             providerSelectDisabled={providerSelectDisabled}

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentHandoffMenu.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentHandoffMenu.spec.tsx
@@ -51,6 +51,7 @@ describe("AgentHandoffMenu", () => {
     render(
       <AgentHandoffMenu
         labels={labels}
+        showOwnershipLabels
         targets={targets}
         triggerLabel="Handoff"
         onSelect={onSelect}
@@ -86,6 +87,27 @@ describe("AgentHandoffMenu", () => {
 
     expect(onSelect).toHaveBeenCalledOnce();
     expect(onSelect).toHaveBeenCalledWith(targets[1]);
+  });
+
+  it("hides ownership labels by default", async () => {
+    render(
+      <AgentHandoffMenu
+        labels={labels}
+        targets={targets.filter((target) => target.ownership === "self")}
+        onSelect={vi.fn()}
+      />
+    );
+
+    fireEvent.pointerDown(screen.getByRole("combobox", { name: "Handoff" }), {
+      button: 0,
+      ctrlKey: false,
+      pointerType: "mouse"
+    });
+
+    const options = await screen.findAllByRole("option");
+    expect(options).toHaveLength(2);
+    expect(screen.queryByText("My Agent")).not.toBeInTheDocument();
+    expect(within(options[0]!).getByText("From My Mac mini")).toBeVisible();
   });
 
   it("supports an icon-only trigger and owns hover animation state", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentHandoffMenu.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentHandoffMenu.tsx
@@ -37,6 +37,7 @@ export interface AgentHandoffMenuProps {
   isolateTriggerEvents?: boolean;
   labels: AgentHandoffMenuLabels;
   onSelect: (target: AgentGUIAgentTarget) => void;
+  showOwnershipLabels?: boolean;
   targets: readonly AgentGUIAgentTarget[];
   testId?: string;
   triggerClassName?: string;
@@ -56,6 +57,7 @@ export function AgentHandoffMenu({
   isolateTriggerEvents = false,
   labels,
   onSelect,
+  showOwnershipLabels = false,
   targets,
   testId,
   triggerClassName,
@@ -184,10 +186,12 @@ export function AgentHandoffMenu({
           aria-label={labels.menu}
         >
           {targets.map((target) => {
-            const ownershipLabel = resolveHandoffTargetOwnershipLabel(target, {
-              self: labels.self,
-              shared: labels.shared
-            });
+            const ownershipLabel = showOwnershipLabels
+              ? resolveHandoffTargetOwnershipLabel(target, {
+                  self: labels.self,
+                  shared: labels.shared
+                })
+              : null;
             const ownerDeviceLabel = target.ownerDeviceLabel?.trim() ?? "";
             const deviceSourceLabel = ownerDeviceLabel
               ? (labels.deviceSource?.(ownerDeviceLabel) ?? ownerDeviceLabel)

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerFooter.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerFooter.tsx
@@ -64,6 +64,7 @@ interface Props {
   effectiveHandoffMenuLabel: string;
   handoffMenuTargets: readonly AgentGUIAgentTarget[];
   onHandoffConversation?: (target: AgentGUIAgentTarget) => void;
+  showHandoffTargetOwnershipLabels?: boolean;
   showProviderSelect: boolean;
   selectedProviderSwitchTarget: AgentGUIAgentTarget | null;
   providerSelectDisabled: boolean;
@@ -111,6 +112,7 @@ export function ComposerFooter({
   effectiveHandoffMenuLabel,
   handoffMenuTargets,
   onHandoffConversation,
+  showHandoffTargetOwnershipLabels = false,
   showProviderSelect,
   selectedProviderSwitchTarget,
   providerSelectDisabled,
@@ -236,6 +238,7 @@ export function ComposerFooter({
                 shared: labels.handoffTargetShared,
                 tooltip: labels.handoffConversationTooltip
               }}
+              showOwnershipLabels={showHandoffTargetOwnershipLabels}
               targets={handoffMenuTargets}
               triggerLabel={effectiveHandoffLabel}
               onSelect={(target) => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
@@ -64,6 +64,7 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
   onSlashStatusRefresh,
   onLinkAction,
   onHandoffConversation,
+  showHandoffTargetOwnershipLabels = false,
   capabilityMenuState,
   capabilityControlsReadOnly = false,
   onCapabilitySettingsRequest,
@@ -395,6 +396,7 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       selectedAgentTarget: composerSelectedProviderTarget,
       agentTargets: composerProviderTargets,
       handoffAgentTargets: composerHandoffProviderTargets,
+      showHandoffTargetOwnershipLabels,
       providerSelectReadonly:
         !canSwitchComposerProvider ||
         viewModel.rail.activeConversationId !== null,
@@ -541,6 +543,7 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       sendQueuedPromptNext,
       showPromptImagesUnsupported,
       showStopButton,
+      showHandoffTargetOwnershipLabels,
       stopDisabled,
       slashStatus,
       setTuttiModeEffect,

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
@@ -541,6 +541,7 @@ export interface AgentGUINodeViewProps {
     sourceAgentSessionId: string;
     userProjectPath?: string | null;
   }) => void | Promise<void>;
+  showHandoffTargetOwnershipLabels?: boolean;
   capabilityMenuState?: AgentComposerProps["capabilityMenuState"];
   capabilityControlsReadOnly?: AgentComposerProps["capabilityControlsReadOnly"];
   onCapabilitySettingsRequest?: AgentComposerProps["onCapabilitySettingsRequest"];
@@ -733,6 +734,7 @@ export interface AgentGUIDetailPaneProps {
   onSlashStatusRefresh?: AgentComposerProps["onSlashStatusRefresh"];
   onLinkAction?: (action: WorkspaceLinkAction) => void;
   onHandoffConversation?: AgentGUINodeViewProps["onHandoffConversation"];
+  showHandoffTargetOwnershipLabels?: boolean;
   capabilityMenuState?: AgentComposerProps["capabilityMenuState"];
   capabilityControlsReadOnly?: AgentComposerProps["capabilityControlsReadOnly"];
   onCapabilitySettingsRequest?: AgentComposerProps["onCapabilitySettingsRequest"];


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Verification

<!-- Commands run, manual checks, or why verification is not applicable. -->

## Fallback Three Questions

<!--
Required when this change adds a timer, retry, cache, or defensive branch;
delete otherwise.

- Source: which event or state does this fallback compensate for?
- Why can it not be fixed at that source?
- Removal condition: when can this fallback be deleted?
-->

## Checklist

- [ ] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter.
- [ ] I kept the change focused on one concern.
- [ ] I updated documentation when behavior, setup, or contributor workflow changed.
- [ ] I updated all README/CONTRIBUTING language variants when changing their English source.
- [ ] I ran the lowest meaningful local checks for the changed surface.
- [ ] My commits are signed off with DCO when required: `git commit -s`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->