### PR TITLE
fix(agent-gui): use agent label in composer

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.memo.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.memo.spec.tsx
@@ -1,7 +1,12 @@
 import "@testing-library/jest-dom/vitest";
 import { render } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { AgentGUINodeData, NodeFrame } from "../../types";
+import type {
+  AgentGUIAgentTarget,
+  AgentGUINodeData,
+  NodeFrame
+} from "../../types";
+import type { AgentGUIConversationSummary } from "./model/agentGuiConversationModel";
 import type {
   AgentComposerDraft,
   AgentGUINodeViewModel
@@ -21,6 +26,9 @@ const { agentGuiNodeViewSpy, translate } = vi.hoisted(() => ({
   translate: (key: string, options?: Record<string, unknown>) => {
     if (key === "agentHost.workspaceAgentSessionDetailToolCalls") {
       return `${options?.count ?? 0} tool calls`;
+    }
+    if (key === "agentHost.agentGui.followupPlaceholder") {
+      return `Request ${options?.provider ?? ""} to continue`;
     }
     return key;
   }
@@ -429,6 +437,46 @@ describe("AgentGUINode memoization", () => {
     expect(secondViewProps!.labels).not.toBe(firstViewProps!.labels);
     expect(secondViewProps!.conversationRailLabels).toBe(
       firstViewProps!.conversationRailLabels
+    );
+  });
+
+  it("uses the exact active Agent target label in provider-facing copy", () => {
+    const kimiTarget: AgentGUIAgentTarget = {
+      agentTargetId: "extension:kimi-code",
+      label: "Kimi Code",
+      provider: "acp:kimi-code",
+      ref: {
+        kind: "agent_extension",
+        provider: "acp:kimi-code"
+      },
+      targetId: "extension:kimi-code"
+    };
+    const activeConversation: AgentGUIConversationSummary = {
+      agentTargetId: kimiTarget.agentTargetId,
+      cwd: "/workspace",
+      id: "session-1",
+      provider: kimiTarget.provider,
+      status: "ready",
+      title: "Hello",
+      updatedAtUnixMs: 1
+    };
+    mockViewModel = createViewModel({
+      activeConversation,
+      activeConversationId: activeConversation.id,
+      agentTargets: [kimiTarget]
+    });
+
+    render(<AgentGUINode {...createProps()} />);
+
+    const viewProps = agentGuiNodeViewSpy.mock.calls.at(-1)?.[0] as
+      | {
+          labels: {
+            followupPlaceholder: string;
+          };
+        }
+      | undefined;
+    expect(viewProps?.labels.followupPlaceholder).toBe(
+      "Request Kimi Code to continue"
     );
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -11,6 +11,7 @@ import { CanvasNodeGhostIconButton } from "../shared/CanvasNodeGhostIconButton";
 import { CanvasNodePanelLinedIcon } from "../shared/canvasNodeChromeIcons";
 import { useAgentGUINodeController } from "./controller/useAgentGUINodeController";
 import { useAgentGUIStatus } from "./controller/useAgentGUIStatus";
+import { agentTargetForConversation } from "./controller/agentGuiController.providerHelpers";
 import { AgentGUINodeView } from "./AgentGUINodeView";
 import {
   normalizeAgentGUIProviderIdentity,
@@ -323,12 +324,17 @@ export const AgentGUINode = memo(function AgentGUINode({
   const fallbackAgentTitle = t("sidebar.fallbackAgentLabel");
   const activeProvider =
     viewModel.rail.activeConversation?.provider ?? state.provider;
-  const selectedAgentTargetLabel =
-    viewModel.rail.selectedAgentTarget?.label ??
-    resolveAgentGUIProviderDisplayLabel(state.provider, fallbackAgentTitle);
-  const displayProviderLabel = viewModel.rail.activeConversation
-    ? resolveAgentGUIProviderDisplayLabel(activeProvider, fallbackAgentTitle)
-    : selectedAgentTargetLabel;
+  const activeConversationAgentTarget = agentTargetForConversation(
+    viewModel.rail.activeConversation,
+    viewModel.rail.agentTargets
+  );
+  const displayProviderLabel = resolveAgentGUIProviderDisplayLabel(
+    activeProvider,
+    fallbackAgentTitle,
+    viewModel.rail.activeConversation
+      ? activeConversationAgentTarget?.label
+      : viewModel.rail.selectedAgentTarget?.label
+  );
   const conversationRailLabels = useAgentGUIConversationRailLabels(t);
   const labels = useAgentGUIViewLabels({
     disabledHomeSuggestions,

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiProviderIdentity.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiProviderIdentity.spec.ts
@@ -141,6 +141,16 @@ describe("agentGuiProviderIdentity", () => {
     );
   });
 
+  it("prefers an exact Agent target label for extension providers", () => {
+    expect(
+      resolveAgentGUIProviderDisplayLabel(
+        "acp:kimi-code",
+        "Agent",
+        " Kimi Code "
+      )
+    ).toBe("Kimi Code");
+  });
+
   it("resolves dock conversation titles only from real conversation titles", () => {
     expect(
       resolveAgentGUIDockConversationTitle({

--- a/packages/agent/gui/shared/agentConversationTitleProjection.ts
+++ b/packages/agent/gui/shared/agentConversationTitleProjection.ts
@@ -379,8 +379,13 @@ export function resolveAgentGUIExplicitConversationTitleFromMessages(input: {
 
 export function resolveAgentGUIProviderDisplayLabel(
   provider: string | null | undefined,
-  fallbackAgentLabel: string
+  fallbackAgentLabel: string,
+  exactAgentTargetLabel?: string | null
 ): string {
+  const normalizedAgentTargetLabel = exactAgentTargetLabel?.trim() ?? "";
+  if (normalizedAgentTargetLabel) {
+    return normalizedAgentTargetLabel;
+  }
   const resolvedProvider = normalizeAgentGUIProviderIdentity(provider);
   if (resolvedProvider === "unknown") {
     return fallbackAgentLabel;


### PR DESCRIPTION
## Summary

- preserve the existing composer placeholder states:
  - new conversation: reference sessions, files, tasks, and apps
  - active conversation: ask the selected Agent to continue making changes
- centralize exact Agent target label precedence in `resolveAgentGUIProviderDisplayLabel`
- add unit and integration coverage for ACP extension Agents such as Kimi Code

## Root cause

The extension label is parsed correctly. `tutti.agent.json` supplies `Kimi Code`,
and that name is preserved through the daemon/Desktop Agent directory into
`AgentGUIAgentTarget.label`.

The label was lost when the active-conversation composer ignored the exact
Agent target and resolved its display name only from provider metadata.
Built-in Codex and Claude providers happened to work because they are present
in the static provider catalog, while dynamic `acp:*` extension providers are
not.

This change keeps provider metadata provider-neutral and makes the shared
display-label resolver prefer the exact Agent target label when one is
available.

## Validation

- `pnpm check:changed -- --base upstream/main` — passed 11 lanes
- pre-push `pnpm check:changed -- --push-ready` — passed 12 lanes

## Documentation impact

No documentation update is needed. The existing Agent GUI architecture already
defines the Agent target as UI/launch identity and the provider as execution
metadata.
