### PR TITLE
fix: align agent settlements and app catalog compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,9 @@ DCO sign-off, PR workflow, review gates, and multilingual documentation updates.
 - Chinese user-facing UI copy must not end with a Chinese full stop (。); keep this punctuation rule consistent across settings and other product surfaces.
 - Change `services/tuttid/api/openapi/tuttid.v1.yaml` before daemon HTTP request/response contracts.
 - Document new supported runtime/env overrides in the matching durable convention doc.
-- Business-code files should stay at or below `800` lines. Prefer decomposition before adding more logic.
+- Business-code files should stay at or below `800` lines as measured by the
+  repository `file-length-limit` lint rule, which excludes blank and
+  comment-only lines. Prefer decomposition before adding more logic.
 - When changing repository-managed checks, hooks, or static analysis, update `docs/conventions/local-git-hooks.md` or `docs/conventions/static-analysis.md`.
 - When a fix captures a recurring debugging trap, route it through `docs/conventions/troubleshooting/README.md` and update the matching domain file.
 

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -708,6 +708,16 @@ message cannot become the result of an already settled Turn. Result readers use
 the exact frozen message, return no message for a resolved-empty watermark, and
 reserve the bounded fallback scan for legacy turns without resolution metadata.
 
+Root-provider settlement notifications are a separate compatibility path
+because provider adapters do not emit the legacy terminal Turn state patch.
+Production composition must register every session-state observer through
+`ConfigureSessionStateObservers` and explicitly choose whether it observes
+canonical root-Turn settlements. An omitted choice is a configuration error.
+Settlement delivery is at-least-once, so opted-in consumers must use the exact
+canonical Turn ID for durable deduplication or otherwise serialize an
+idempotent terminal transition. Choosing to ignore settlements requires an
+explicit lifecycle ruling for that consumer.
+
 Cancellation of the caller waiting on an interactive-response operation is not
 a provider outcome and must not terminalize the runtime request. Before a
 response is dispatched it remains `pending` for durable retry; after dispatch it

--- a/docs/conventions/troubleshooting/desktop-release.md
+++ b/docs/conventions/troubleshooting/desktop-release.md
@@ -120,7 +120,9 @@
   `no such table: model_plan_first_use_candidates`, followed by
   `tuttid exited before it published its listener info`. Another early form
   exits while checking prerequisites because a stale `pnpm` shim reports that
-  its bundled `../node/bin/node` no longer exists.
+  its bundled `../node/bin/node` no longer exists. A catalog form starts
+  successfully but selects a legacy workspace-app release because the daemon
+  reports the development package placeholder version `0.0.0`.
 - Quick checks:
   Run `DEV_GUI_SKIP_START=1 make dev-gui` to isolate prerequisite setup from
   Electron startup. If full startup exits after `start electron app...`, inspect
@@ -136,6 +138,9 @@
   app makes the dev app quit as a secondary instance. Agent shells launched from
   the packaged app may inherit `TUTTI_ENV=production`, so `make dev-gui` must
   force the development environment instead of preserving that inherited value.
+  Electron development reads the placeholder version from
+  `apps/desktop/package.json`; passing that value to the daemon makes
+  compatibility-gated catalog releases ineligible.
   The missing-table variant comes from a development database that already
   recorded `model_plans_v1` before the candidate table was added behind that
   same marker. SQLite correctly skips the recorded migration, so startup
@@ -147,14 +152,17 @@
   Electron userData to an environment-specific path before requesting the
   single-instance lock. Ensure the dev-gui script exports
   `TUTTI_ENV=development` before resolving pid files, installing the dev CLI, or
-  launching Electron.
+  launching Electron. Resolve and export `TUTTI_APP_VERSION` from the repository
+  Git description before launch, while preserving an explicit developer
+  override.
   Apply a new, idempotent `model_plan_first_use_candidates_v1` forward migration
   after `model_plans_v1`; do not require deleting the development database and
   do not rewrite or reuse the recorded migration identifier.
 - Validation:
-  Run `DEV_GUI_SKIP_START=1 make dev-gui`, then run full `make dev-gui` while
-  the packaged app is open and confirm the renderer dev server and development
-  `tuttid` start. Also run `pnpm --filter @tutti-os/desktop test`,
+  Run `DEV_GUI_SKIP_START=1 make dev-gui` and confirm it logs a SemVer-compatible
+  Git-derived desktop version rather than `0.0.0`. Then run full `make dev-gui`
+  while the packaged app is open and confirm the renderer dev server and
+  development `tuttid` start. Also run `pnpm --filter @tutti-os/desktop test`,
   `pnpm --filter @tutti-os/desktop typecheck`, and
   `pnpm check:electron-runtime-boundaries`.
   Retain a migration test that starts with `model_plans_v1` recorded and the

--- a/docs/conventions/troubleshooting/workspace-apps-files.md
+++ b/docs/conventions/troubleshooting/workspace-apps-files.md
@@ -18,20 +18,26 @@
 - Root cause:
   AgentGUI sessions are resumable, so stopping one turn does not necessarily
   make the durable session terminal. App Factory job lifecycle is a separate
-  projection: it must treat explicit canceled session/turn outcomes as job
-  cancellation, but it must not collapse every raw `interrupted` turn into a
-  canceled job because approval rejections and transient turn-level
-  interruptions can use the same vocabulary.
+  projection. Host-owned root-provider completion, failure, and cancellation
+  settle the canonical root Turn without sending the legacy live Turn state
+  patch. A consumer registered only on that legacy notification path therefore
+  misses all three terminal outcomes. Plain `interrupted` remains ambiguous
+  because approval rejections and transient turn-level interruptions can use
+  the same vocabulary.
 - Fix:
-  Keep plain active-session `interrupted` turn outcomes non-terminal. Cancel an
-  active App Factory job only when the state carries an explicit canceled
-  outcome, or when accepted message updates contain the runtime's canceled
-  interrupted non-approval tool-call shape.
+  Register App Factory explicitly for synthesized canonical root-Turn
+  settlement states. Route `completed` into validation, `failed` into job
+  failure, and `canceled` into job cancellation. Serialize terminal handling
+  per linked agent session so at-least-once or concurrent delivery cannot start
+  validation twice. Keep plain active-session `interrupted` non-terminal; only
+  the explicit canceled state or the runtime's canceled interrupted
+  non-approval tool-call shape cancels the job.
 - Validation:
   Add App Factory service tests for plain `interrupted` staying non-terminal,
   explicit `canceled` outcome canceling the job, canceled interrupted
-  non-approval tool calls canceling the job, and canceled approval updates being
-  ignored.
+  non-approval tool calls canceling the job, canceled approval updates being
+  ignored, all three canonical root-Turn terminal outcomes updating the job,
+  and duplicate completed settlements starting only one validation pass.
 - References:
   [app_factory_agent_state.go](../../../services/tuttid/service/workspace/app_factory_agent_state.go)
   [app_factory_test.go](../../../services/tuttid/service/workspace/app_factory_test.go)

--- a/docs/conventions/workspace-app-catalog.md
+++ b/docs/conventions/workspace-app-catalog.md
@@ -125,9 +125,11 @@ each app it contains the highest active release whose `minTuttiVersion` is
 
 The full compatibility entries contain the same manifest, localization, and
 remote distribution fields as `apps[]`; they are abbreviated above only for
-clarity. The frontier keeps only versions that can be selected for some Tutti
-version. The builder rejects catalog output above 1 MiB because legacy daemons
-enforce that response limit.
+clarity. For a valid host version, the daemon selects the eligible entry with
+the greatest `minTuttiVersion`; releases from lower compatibility tiers do not
+compete by app version. The frontier keeps only versions that can be selected
+for some Tutti version. The builder rejects catalog output above 1 MiB because
+legacy daemons enforce that response limit.
 
 Each app also owns `apps/<appId>/versions.json`. It retains the full active and
 withdrawn release history plus the explicit `minTuttiVersion` for each
@@ -135,6 +137,8 @@ immutable release. `latest.json` remains the absolute latest published release
 and is not a compatibility input.
 
 Managed Desktop passes its version to `tuttid` through `TUTTI_APP_VERSION`.
+Packaged Desktop uses the Electron package version; `make dev-gui` resolves the
+same Git-derived version used by desktop packaging before launching Electron.
 The daemon applies compatibility selection consistently to list, refresh,
 install, and update workflows. Missing or invalid host versions use `apps[]`.
 An installed app is updateable only when the selected catalog version is

--- a/packages/agent/gui/AGENTS.md
+++ b/packages/agent/gui/AGENTS.md
@@ -14,6 +14,10 @@ module, read this architecture document first:
 
 - [docs/architecture/agent-gui-node.md](../../../docs/architecture/agent-gui-node.md)
 
+Before reviewing changes in this package, also read
+[REVIEW.md](./REVIEW.md) and report every triggered review lane with concrete
+evidence.
+
 When changing `AgentActivityRuntime`, `agent-activity-core`, workspace engine,
 event/reconcile behavior, package exports, or a host adapter, also read the
 package/activity boundary document:

--- a/packages/agent/gui/REVIEW.md
+++ b/packages/agent/gui/REVIEW.md
@@ -1,0 +1,141 @@
+# AgentGUI Review Contract
+
+This file adds AgentGUI-specific review requirements. It does not replace the
+repository contribution, testing, security, accessibility, or code-quality
+rules.
+
+Review only the lanes triggered by the change. For every triggered lane, report
+one of:
+
+- `pass`: include concrete evidence
+- `not applicable`: explain why the change cannot affect the lane
+- `blocked`: name the missing evidence or unavailable consumer
+
+Do not use an unsupported statement such as "no impact" as review evidence.
+
+## 1. Architecture Integrity
+
+Trigger this lane when a change touches:
+
+- Session, Turn, Interaction, Goal, runtime-operation, or prompt lifecycle
+- `AgentActivityRuntime`, `AgentHostApi`, engine state, selectors, projections,
+  controllers, event handling, reconciliation, or public exports
+- composer, Rail, timeline, Message Center, approvals, interactive prompts,
+  Workbench integration, or host adapters
+
+Review against:
+
+- [Agent GUI Node](../../../docs/architecture/agent-gui-node.md)
+- [Agent Activity Packages](../../../docs/architecture/agent-activity-packages.md)
+
+Verify:
+
+1. The existing owner still owns each fact and state transition.
+2. The command and observation paths still follow the documented direction.
+3. Events remain invalidation hints and canonical reads remain authoritative.
+4. Session, Turn, Interaction, request, and Workbench identities stay exact.
+5. Shared behavior remains provider-neutral and capability-driven.
+6. React renders projections and dispatches actions; it does not recreate
+   lifecycle or reconciliation orchestration.
+7. New public exports are durable consumer contracts, not convenience exports
+   for one host.
+
+If the change alters ownership, data flow, or a public contract, update the
+durable architecture document in the same change.
+
+## 2. Performance
+
+Trigger this lane when a change touches:
+
+- high-frequency engine subscriptions, selectors, snapshots, or stream updates
+- Session list, Rail, timeline, transcript, message projection, or reconciliation
+- scroll, resize, layout measurement, virtualization, rich-text rendering, or
+  hidden surfaces
+- caches, retained per-Session state, timers, observers, or diagnostic logging
+
+Verify:
+
+1. A change in one Session does not rebuild unrelated Session projections.
+2. High-frequency render paths do not consume whole-workspace snapshots.
+3. Streaming does not add per-token logging, broad reconciliation, repeated
+   parsing, or synchronous full-layout reads.
+4. Lists, history reads, caches, and retained UI state remain bounded.
+5. Memoized boundaries keep stable references and do not receive aggregate
+   objects when scalar projections are sufficient.
+6. Virtualization, scroll following, and prepend restoration keep one geometry
+   and intent owner.
+7. `pnpm check:agent-gui-degradation` budgets do not increase.
+
+Use evidence proportional to risk:
+
+- For a statically isolated change, identify the unchanged hot path and
+  boundary.
+- For state or projection changes, provide focused test results and reference
+  stability or fanout evidence.
+- For reported jank, long tasks, or render storms, provide a trace or profiler
+  comparison tied to the exact interaction.
+
+Use
+[Agent session lifecycle troubleshooting](../../../docs/conventions/troubleshooting/agent-session-lifecycle.md)
+for known large-history, streaming, reconciliation, and diagnostic-log traps.
+
+## 3. Consumer Compatibility
+
+Trigger this lane when a change touches an exported symbol, subpath export,
+runtime or host input, projection shape, event/DTO mapping, command behavior,
+feature capability, or lifecycle ordering.
+
+Review these known in-repository consumers:
+
+- Desktop workspace AgentGUI and standalone Agent windows
+- Desktop Message Center, Workbench, Issue Manager, and App Center integrations
+- Mobile conversation, Rail, composer, media, and activity services
+- `agent-activity-core` and the `tuttid` activity adapter
+
+Also review the published contract for out-of-repository consumers:
+
+- TSH and other AgentGUI hosts
+- closed-source cloud hosts
+- external workspace applications
+
+Verify:
+
+1. Existing imports and documented subpath exports remain valid.
+2. Optional capabilities still fail closed when absent or unknown.
+3. Consumers do not need to copy engine, lifecycle, merge, or attention logic.
+4. Cancellation, failure, retry, reconnect, stale response, and recovery paths
+   preserve their documented ordering and terminal semantics.
+5. Unknown providers, enum values, missing optional data, and unavailable host
+   capabilities remain explicit rather than silently reinterpreted.
+6. A contract change has consumer coverage or a named migration plan.
+
+For a closed-source consumer, record only:
+
+- the sanitized consumer role
+- the public contract or capability it uses
+- validation status and any remaining uncertainty
+
+Do not record private repository URLs, customer names, credentials, deployment
+topology, proprietary feature names, or unreleased operational details.
+
+## 4. Review Output
+
+The review summary must include:
+
+| Lane         | Trigger        | Result                                 | Evidence                                           | Affected consumers |
+| ------------ | -------------- | -------------------------------------- | -------------------------------------------------- | ------------------ |
+| Architecture | Why it applies | `pass`, `not applicable`, or `blocked` | Document section, code path, or test               | Named surfaces     |
+| Performance  | Why it applies | `pass`, `not applicable`, or `blocked` | Static boundary, test, budget, or trace            | Named surfaces     |
+| Consumers    | Why it applies | `pass`, `not applicable`, or `blocked` | Import search, contract test, or validation status | Named consumers    |
+
+List unresolved risks separately. Do not convert unavailable evidence into a
+pass.
+
+## 5. Automation Boundary
+
+`REVIEW.md` defines semantic review requirements; it is not itself an
+executable gate. Agent instructions route reviewers to this file. Repository
+checks and hooks may verify objective invariants such as forbidden imports,
+dependency direction, public-export shape, degradation budgets, and required
+test fixtures. They must not claim to prove semantic compatibility or
+performance without the evidence required above.

--- a/services/tuttid/builtin-apps/catalog_compatibility.go
+++ b/services/tuttid/builtin-apps/catalog_compatibility.go
@@ -96,6 +96,8 @@ func parseRemoteCatalogForHost(data []byte, host CatalogHost) ([]App, error) {
 			seenVersions := make(map[string]struct{}, len(entries))
 			seenMinimums := make(map[string]struct{}, len(entries))
 			selected, hasSelected := appsByID[appID]
+			selectedMinimum := ""
+			hasCompatibleSelection := false
 			for _, entry := range entries {
 				minimum, ok := tuttitypes.NormalizeSemver(entry.MinTuttiVersion)
 				if !ok {
@@ -123,9 +125,11 @@ func parseRemoteCatalogForHost(data []byte, host CatalogHost) ([]App, error) {
 					return nil, fmt.Errorf("app catalog compatibility app %q has duplicate version %q", appID, app.Manifest.Version)
 				}
 				seenVersions[version] = struct{}{}
-				if !hasSelected || compareCatalogAppVersions(app, selected) > 0 {
+				if !hasCompatibleSelection || semver.Compare(minimum, selectedMinimum) > 0 {
 					selected = app
 					hasSelected = true
+					selectedMinimum = minimum
+					hasCompatibleSelection = true
 				}
 			}
 			if hasSelected {

--- a/services/tuttid/builtin-apps/catalog_test.go
+++ b/services/tuttid/builtin-apps/catalog_test.go
@@ -403,6 +403,30 @@ func TestParseRemoteCatalogSelectsHighestCompatibleAppVersion(t *testing.T) {
 	}
 }
 
+func TestParseRemoteCatalogSelectsHighestCompatibleTuttiVersionTier(t *testing.T) {
+	legacy := remoteCatalogAppForVersionTest("automation", "0.1.0+f279cf1f96ab")
+	current := remoteCatalogAppForVersionTest("automation", "0.1.0+954ca3ea7534")
+	document := remoteCatalogDocument{
+		SchemaVersion: remoteCatalogSchemaVersionV1,
+		Apps:          []remoteCatalogApp{legacy},
+		Compatibility: &remoteCatalogCompatibility{Apps: map[string][]remoteCatalogCompatibilityEntry{
+			"automation": {
+				{MinTuttiVersion: "0.0.0", App: legacy},
+				{MinTuttiVersion: "0.1.18", App: current},
+			},
+		}},
+	}
+	data := remoteCatalogDataForTest(t, document)
+
+	apps, err := parseRemoteCatalogForTuttiVersion(data, "0.2.4-rc.1-14-g5cbafc453-dirty")
+	if err != nil {
+		t.Fatalf("parse catalog: %v", err)
+	}
+	if app := findCatalogAppForTest(apps, "automation"); app == nil || app.Manifest.Version != "0.1.0+954ca3ea7534" {
+		t.Fatalf("automation app = %#v, want current compatibility tier", app)
+	}
+}
+
 func TestParseRemoteCatalogSelectsCapabilityCompatibleAppVersion(t *testing.T) {
 	legacy := remoteCatalogAppForVersionTest("capability-app", "1.0.0")
 	versionCompatible := remoteCatalogAppForVersionTest("capability-app", "1.1.0")

--- a/services/tuttid/service/agent/activity_projection.go
+++ b/services/tuttid/service/agent/activity_projection.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -60,6 +61,21 @@ type SessionStateObserver interface {
 	ObserveAgentSessionState(context.Context, canonical.ReportSessionStateInput, canonical.ReportSessionStateReply)
 }
 
+type RootTurnSettlementPolicy string
+
+const (
+	RootTurnSettlementsObserve RootTurnSettlementPolicy = "observe"
+	RootTurnSettlementsIgnore  RootTurnSettlementPolicy = "ignore"
+)
+
+// SessionStateObserverRegistration forces production composition to make an
+// explicit decision about canonical root-turn settlements for every legacy
+// session-state observer.
+type SessionStateObserverRegistration struct {
+	Observer            SessionStateObserver
+	RootTurnSettlements RootTurnSettlementPolicy
+}
+
 type SessionMessageObserver interface {
 	ObserveAgentSessionMessages(context.Context, canonical.ReportSessionMessagesInput, canonical.ReportSessionMessagesReply)
 }
@@ -100,11 +116,28 @@ func (p *ActivityProjection) SetSessionMessageObserver(observer SessionMessageOb
 	p.sessionMessageObserver = observer
 }
 
-func (p *ActivityProjection) SetSessionStateObserver(observer SessionStateObserver) {
+func (p *ActivityProjection) ConfigureSessionStateObservers(registrations ...SessionStateObserverRegistration) error {
 	if p == nil {
-		return
+		return errors.New("activity projection is unavailable")
 	}
-	p.sessionStateObserver = observer
+	all := make(SessionStateObservers, 0, len(registrations))
+	rootSettlements := make(SessionStateObservers, 0, len(registrations))
+	for index, registration := range registrations {
+		if registration.Observer == nil {
+			return fmt.Errorf("session state observer %d is unavailable", index)
+		}
+		switch registration.RootTurnSettlements {
+		case RootTurnSettlementsObserve:
+			rootSettlements = append(rootSettlements, registration.Observer)
+		case RootTurnSettlementsIgnore:
+		default:
+			return fmt.Errorf("session state observer %d has no root-turn settlement policy", index)
+		}
+		all = append(all, registration.Observer)
+	}
+	p.sessionStateObserver = all
+	p.rootTurnSettleStateObserver = rootSettlements
+	return nil
 }
 
 func (p *ActivityProjection) SetRootTurnObserver(observer RootTurnObserver) {
@@ -160,16 +193,6 @@ func activityGoalProvenanceBinding(binding agentactivitybiz.GoalProvenanceBindin
 		OperationID: binding.OperationID, Revision: binding.Revision, RepairEpoch: binding.RepairEpoch,
 		Ambiguous: binding.Ambiguous, CreatedAtUnixMS: binding.CreatedAtUnixMS, UpdatedAtUnixMS: binding.UpdatedAtUnixMS,
 	}
-}
-
-// SetRootTurnSettleStateObserver registers the dedicated, opt-in consumer of
-// synthesized canonical root-turn settlement states (automation rules today).
-// Delivery is at-least-once; observers must be idempotent per settled turn.
-func (p *ActivityProjection) SetRootTurnSettleStateObserver(observer SessionStateObserver) {
-	if p == nil {
-		return
-	}
-	p.rootTurnSettleStateObserver = observer
 }
 
 func normalizeReportSessionOrigins(

--- a/services/tuttid/service/agent/activity_projection_observers_test.go
+++ b/services/tuttid/service/agent/activity_projection_observers_test.go
@@ -1,0 +1,65 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
+)
+
+func TestConfigureSessionStateObserversRequiresRootSettlementPolicy(t *testing.T) {
+	t.Parallel()
+
+	projection := &ActivityProjection{}
+	err := projection.ConfigureSessionStateObservers(SessionStateObserverRegistration{
+		Observer: &recordingSessionStateObserver{},
+	})
+	if err == nil {
+		t.Fatal("ConfigureSessionStateObservers() error = nil, want unclassified root settlement policy rejected")
+	}
+}
+
+func TestConfigureSessionStateObserversRoutesRootSettlementsByPolicy(t *testing.T) {
+	t.Parallel()
+
+	rootConsumer := &recordingSessionStateObserver{}
+	legacyOnlyConsumer := &recordingSessionStateObserver{}
+	projection := &ActivityProjection{}
+	err := projection.ConfigureSessionStateObservers(
+		SessionStateObserverRegistration{
+			Observer:            rootConsumer,
+			RootTurnSettlements: RootTurnSettlementsObserve,
+		},
+		SessionStateObserverRegistration{
+			Observer:            legacyOnlyConsumer,
+			RootTurnSettlements: RootTurnSettlementsIgnore,
+		},
+	)
+	if err != nil {
+		t.Fatalf("ConfigureSessionStateObservers() error = %v", err)
+	}
+
+	input := canonical.ReportSessionStateInput{WorkspaceID: "ws-1", AgentSessionID: "session-1"}
+	reply := canonical.ReportSessionStateReply{Accepted: true, StateApplied: true}
+	projection.observeSessionState(context.Background(), input, reply)
+	projection.rootTurnSettleStateObserver.ObserveAgentSessionState(context.Background(), input, reply)
+
+	if rootConsumer.calls != 2 {
+		t.Fatalf("root consumer calls = %d, want legacy + root settlement", rootConsumer.calls)
+	}
+	if legacyOnlyConsumer.calls != 1 {
+		t.Fatalf("legacy-only consumer calls = %d, want legacy only", legacyOnlyConsumer.calls)
+	}
+}
+
+type recordingSessionStateObserver struct {
+	calls int
+}
+
+func (s *recordingSessionStateObserver) ObserveAgentSessionState(
+	context.Context,
+	canonical.ReportSessionStateInput,
+	canonical.ReportSessionStateReply,
+) {
+	s.calls++
+}

--- a/services/tuttid/service/automationrule/service_root_settlement_test.go
+++ b/services/tuttid/service/automationrule/service_root_settlement_test.go
@@ -65,7 +65,12 @@ func TestAutomationRuleFiresFromLiveRootProviderTurnSettlement(t *testing.T) {
 	automation := &Service{Store: rules, Executor: recordingExecutor{calls: calls}, Usage: staticUsage{}}
 
 	projection := agentservice.NewActivityProjection(store)
-	projection.SetRootTurnSettleStateObserver(automation)
+	if err := projection.ConfigureSessionStateObservers(agentservice.SessionStateObserverRegistration{
+		Observer:            automation,
+		RootTurnSettlements: agentservice.RootTurnSettlementsObserve,
+	}); err != nil {
+		t.Fatalf("ConfigureSessionStateObservers() error = %v", err)
+	}
 
 	const (
 		workspaceID = "ws"
@@ -163,7 +168,12 @@ func TestAutomationRuleFiresOnceFromCancelRuntimeOperationSettlement(t *testing.
 
 	projection := agentservice.NewActivityProjection(store)
 	projection.SetPublisher(noopActivityPublisher{})
-	projection.SetRootTurnSettleStateObserver(automation)
+	if err := projection.ConfigureSessionStateObservers(agentservice.SessionStateObserverRegistration{
+		Observer:            automation,
+		RootTurnSettlements: agentservice.RootTurnSettlementsObserve,
+	}); err != nil {
+		t.Fatalf("ConfigureSessionStateObservers() error = %v", err)
+	}
 
 	const (
 		workspaceID = "ws"

--- a/services/tuttid/service/collabrun/policy_review.go
+++ b/services/tuttid/service/collabrun/policy_review.go
@@ -51,3 +51,24 @@ func (s *Service) SumPolicyReviewUsage(ctx context.Context, workspaceID string, 
 	}
 	return count, totalTokens, nil
 }
+
+func (s *Service) HasPolicyReviewForTurn(ctx context.Context, workspaceID string, sourceSessionID string, turnID string) (bool, error) {
+	turnID = strings.TrimSpace(turnID)
+	if turnID == "" {
+		return false, nil
+	}
+	runs, err := s.ListRuns(ctx, strings.TrimSpace(workspaceID), strings.TrimSpace(sourceSessionID), 0)
+	if err != nil {
+		return false, err
+	}
+	suffix := ":turn:" + turnID
+	for _, run := range runs {
+		if run.Mode == collabrunbiz.ModeConsult &&
+			run.TriggerSource == collabrunbiz.TriggerPolicy &&
+			strings.HasPrefix(run.TriggerReason, "review_rule:") &&
+			strings.HasSuffix(run.TriggerReason, suffix) {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/services/tuttid/service/collabrun/service_test.go
+++ b/services/tuttid/service/collabrun/service_test.go
@@ -268,6 +268,41 @@ func TestStartConsultSuccessRecordsResultUsageAndEvents(t *testing.T) {
 	}
 }
 
+func TestHasPolicyReviewForTurnMatchesExactPolicyRun(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newMemoryRunStore()
+	for _, run := range []collabrunbiz.Run{
+		{
+			ID: "matching", WorkspaceID: "ws", Mode: collabrunbiz.ModeConsult,
+			TriggerSource:   collabrunbiz.TriggerPolicy,
+			TriggerReason:   "review_rule:on_task_complete:turn:turn-1",
+			SourceSessionID: "session-1",
+		},
+		{
+			ID: "user-consult", WorkspaceID: "ws", Mode: collabrunbiz.ModeConsult,
+			TriggerSource:   collabrunbiz.TriggerUser,
+			TriggerReason:   "review_rule:on_task_complete:turn:turn-2",
+			SourceSessionID: "session-1",
+		},
+	} {
+		if err := store.PutCollaborationRun(ctx, run); err != nil {
+			t.Fatalf("PutCollaborationRun() error = %v", err)
+		}
+	}
+	service := &Service{Store: store}
+
+	reviewed, err := service.HasPolicyReviewForTurn(ctx, "ws", "session-1", "turn-1")
+	if err != nil || !reviewed {
+		t.Fatalf("matching review = %v, error = %v, want true", reviewed, err)
+	}
+	reviewed, err = service.HasPolicyReviewForTurn(ctx, "ws", "session-1", "turn-2")
+	if err != nil || reviewed {
+		t.Fatalf("user consult review = %v, error = %v, want false", reviewed, err)
+	}
+}
+
 func TestStartConsultFailureRecordsSanitizedFailureReason(t *testing.T) {
 	t.Parallel()
 

--- a/services/tuttid/service/modelpolicy/review_engine.go
+++ b/services/tuttid/service/modelpolicy/review_engine.go
@@ -28,6 +28,7 @@ type SessionTargetResolver interface {
 type ReviewConsultInput struct {
 	WorkspaceID   string
 	SourceSession string
+	TurnID        string
 	ModelPlanID   string
 	Model         string
 	Question      string
@@ -53,6 +54,7 @@ type ReviewConsultRunner interface {
 // ReviewBudgetReader reports how much policy-triggered review the session has
 // already consumed.
 type ReviewBudgetReader interface {
+	HasPolicyReviewForTurn(ctx context.Context, workspaceID string, sourceSessionID string, turnID string) (bool, error)
 	SumPolicyReviewUsage(ctx context.Context, workspaceID string, sourceSessionID string) (runs int, totalTokens int64, err error)
 }
 
@@ -91,7 +93,10 @@ func (s *Service) ObserveAgentSessionState(ctx context.Context, input canonical.
 	}
 	sessionKey := workspaceID + "/" + agentSessionID
 	turnID := ""
-	if lifecycle.ActiveTurnID != nil {
+	if input.State.Turn != nil {
+		turnID = strings.TrimSpace(input.State.Turn.TurnID)
+	}
+	if turnID == "" && lifecycle.ActiveTurnID != nil {
 		turnID = strings.TrimSpace(*lifecycle.ActiveTurnID)
 	}
 
@@ -149,7 +154,7 @@ func (s *Service) ObserveAgentSessionState(ctx context.Context, input canonical.
 		}()
 		reviewCtx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 		defer cancel()
-		s.runReview(reviewCtx, workspaceID, agentSessionID, policy)
+		s.runReview(reviewCtx, workspaceID, agentSessionID, turnID, policy)
 	}()
 }
 
@@ -186,8 +191,25 @@ func (s *Service) resolveEffectivePolicy(ctx context.Context, workspaceID string
 	return policy, true
 }
 
-func (s *Service) runReview(ctx context.Context, workspaceID string, agentSessionID string, policy modelpolicybiz.Policy) {
+func (s *Service) runReview(ctx context.Context, workspaceID string, agentSessionID string, turnID string, policy modelpolicybiz.Policy) {
 	if s.Budget != nil {
+		if turnID != "" {
+			reviewed, err := s.Budget.HasPolicyReviewForTurn(ctx, workspaceID, agentSessionID, turnID)
+			if err != nil {
+				slog.Warn("model policy review turn dedup read failed; skipping automated review",
+					"event", "model_policy.review_turn_dedup_read_failed",
+					"workspace_id", workspaceID,
+					"agent_session_id", agentSessionID,
+					"turn_id", turnID,
+					"policy_id", policy.ID,
+					"error", err,
+				)
+				return
+			}
+			if reviewed {
+				return
+			}
+		}
 		runs, totalTokens, err := s.Budget.SumPolicyReviewUsage(ctx, workspaceID, agentSessionID)
 		if err != nil {
 			// Fail closed: without trustworthy usage accounting the per-session
@@ -217,12 +239,13 @@ func (s *Service) runReview(ctx context.Context, workspaceID string, agentSessio
 	result, err := s.Runner.RunPolicyReviewConsult(ctx, ReviewConsultInput{
 		WorkspaceID:   workspaceID,
 		SourceSession: agentSessionID,
+		TurnID:        turnID,
 		ModelPlanID:   policy.Review.ModelPlanID,
 		Model:         policy.Review.Model,
 		Question: "Review the work this coding agent session just claimed to complete. " +
 			"Judge whether the claimed outcome is plausible and internally consistent. " +
 			"Answer with your findings, then end with exactly one final line: VERDICT: PASS or VERDICT: FAIL.",
-		TriggerReason: "review_rule:" + string(policy.ReviewRule.Trigger),
+		TriggerReason: policyReviewTriggerReason(policy.ReviewRule.Trigger, turnID),
 		MaxTokens:     2048,
 	})
 	if err != nil || result.Failed {
@@ -252,6 +275,14 @@ func (s *Service) runReview(ctx context.Context, workspaceID string, agentSessio
 		ReviewRunID:    result.RunID,
 		UpdatedAt:      s.now(),
 	})
+}
+
+func policyReviewTriggerReason(trigger modelpolicybiz.ReviewTrigger, turnID string) string {
+	reason := "review_rule:" + string(trigger)
+	if turnID != "" {
+		reason += ":turn:" + turnID
+	}
+	return reason
 }
 
 // reviewVerdictPassed parses the required final verdict line. Missing or

--- a/services/tuttid/service/modelpolicy/service_test.go
+++ b/services/tuttid/service/modelpolicy/service_test.go
@@ -152,8 +152,13 @@ func (r *recordingRunner) RunPolicyReviewConsult(_ context.Context, input Review
 }
 
 type staticBudget struct {
-	runs   int
-	tokens int64
+	reviewedTurn bool
+	runs         int
+	tokens       int64
+}
+
+func (s staticBudget) HasPolicyReviewForTurn(context.Context, string, string, string) (bool, error) {
+	return s.reviewedTurn, nil
 }
 
 func (s staticBudget) SumPolicyReviewUsage(context.Context, string, string) (int, int64, error) {
@@ -161,6 +166,10 @@ func (s staticBudget) SumPolicyReviewUsage(context.Context, string, string) (int
 }
 
 type erroringBudget struct{ err error }
+
+func (b erroringBudget) HasPolicyReviewForTurn(context.Context, string, string, string) (bool, error) {
+	return false, b.err
+}
 
 func (b erroringBudget) SumPolicyReviewUsage(context.Context, string, string) (int, int64, error) {
 	return 0, 0, b.err
@@ -185,6 +194,11 @@ func settledCompletedInput(turnID string) canonical.ReportSessionStateInput {
 				ActiveTurnID: &turnID,
 				Phase:        "settled",
 				Outcome:      &completed,
+			},
+			Turn: &canonical.WorkspaceAgentTurnStateUpdate{
+				TurnID:  turnID,
+				Phase:   "settled",
+				Outcome: "completed",
 			},
 		},
 	}
@@ -250,6 +264,9 @@ func TestReviewRuleRunsAndMarksAutoChecked(t *testing.T) {
 	if len(runner.inputs) != 1 || runner.inputs[0].ModelPlanID != "mp-1" || runner.inputs[0].Model != "review-model" {
 		t.Fatalf("runner inputs = %#v", runner.inputs)
 	}
+	if runner.inputs[0].TurnID != "turn-1" {
+		t.Fatalf("runner turn id = %q, want turn-1", runner.inputs[0].TurnID)
+	}
 	if !strings.Contains(runner.inputs[0].TriggerReason, "review_rule:on_task_complete") {
 		t.Fatalf("trigger reason = %q", runner.inputs[0].TriggerReason)
 	}
@@ -259,6 +276,35 @@ func TestReviewRuleRunsAndMarksAutoChecked(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 	if len(runner.inputs) != 1 {
 		t.Fatalf("same turn should not re-trigger: %#v", runner.inputs)
+	}
+}
+
+func TestCanonicalRootSettlementUsesTurnIDAndSkipsDurableReviewReplay(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newMemoryPolicyStore()
+	service := newPolicyTestService(store)
+	policy := seedReviewPolicy(t, service)
+	runner := &recordingRunner{result: ReviewConsultResult{RunID: "duplicate", ResultText: "VERDICT: PASS"}}
+	service.ConfigureReviewAutomation(
+		staticBindings{binding: modelbindingbiz.Binding{ModelPolicyID: policy.ID}},
+		nil,
+		runner,
+		staticBudget{reviewedTurn: true},
+	)
+	input := settledCompletedInput("turn-replayed")
+	input.State.TurnLifecycle.ActiveTurnID = nil
+
+	service.ObserveAgentSessionState(ctx, input, canonical.ReportSessionStateReply{})
+	time.Sleep(100 * time.Millisecond)
+
+	if len(runner.inputs) != 0 {
+		t.Fatalf("durably reviewed root turn triggered another review: %#v", runner.inputs)
+	}
+	acceptance, ok, err := service.GetAcceptance(ctx, "ws", "session-1")
+	if err != nil || !ok || acceptance.State != modelpolicybiz.AcceptanceAgentClaimed {
+		t.Fatalf("acceptance = %#v ok=%v err=%v, want agent_claimed", acceptance, ok, err)
 	}
 }
 

--- a/services/tuttid/service/workspace/app_factory.go
+++ b/services/tuttid/service/workspace/app_factory.go
@@ -47,7 +47,8 @@ type AppFactoryService struct {
 	StateDir              string
 	Publisher             WorkspaceAppFactoryEventPublisher
 
-	publishLocks keyedOperationLocks
+	publishLocks    keyedOperationLocks
+	settlementLocks keyedOperationLocks
 }
 
 type keyedOperationLocks struct {

--- a/services/tuttid/service/workspace/app_factory_agent_state.go
+++ b/services/tuttid/service/workspace/app_factory_agent_state.go
@@ -66,6 +66,9 @@ func (s *AppFactoryService) ObserveAgentSessionState(_ context.Context, input ca
 }
 
 func (s *AppFactoryService) handleAgentSessionTerminalState(ctx context.Context, workspaceID string, agentSessionID string, status string, lastError string) error {
+	unlock := s.settlementLocks.Lock(appFactoryActionKey("agent-settlement", workspaceID, agentSessionID))
+	defer unlock()
+
 	job, ok, err := s.findAppFactoryJobByAgentSessionID(ctx, workspaceID, agentSessionID)
 	if err != nil || !ok {
 		return err

--- a/services/tuttid/service/workspace/app_factory_test.go
+++ b/services/tuttid/service/workspace/app_factory_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1654,6 +1655,98 @@ func TestAppFactoryServiceFailedTurnOutcomeFailsGeneratingJob(t *testing.T) {
 	}
 	if job.FailureReason != state.LastError {
 		t.Fatalf("failure reason = %q, want %q", job.FailureReason, state.LastError)
+	}
+}
+
+func TestAppFactoryServiceCanonicalRootTurnSettlementUpdatesGeneratingJob(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		outcome    string
+		wantStatus workspacebiz.AppFactoryJobStatus
+	}{
+		{name: "completed starts validation", outcome: "completed", wantStatus: workspacebiz.AppFactoryJobStatusFailed},
+		{name: "failed marks failed", outcome: "failed", wantStatus: workspacebiz.AppFactoryJobStatusFailed},
+		{name: "canceled marks canceled", outcome: "canceled", wantStatus: workspacebiz.AppFactoryJobStatusCanceled},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			store := newAppFactoryStoreStub()
+			if err := store.PutAppFactoryJob(ctx, workspacebiz.AppFactoryJob{
+				AgentSessionID: "session-1",
+				AppID:          "app_1",
+				DraftDir:       t.TempDir(),
+				JobID:          "job-1",
+				Status:         workspacebiz.AppFactoryJobStatusGenerating,
+				WorkspaceID:    "ws-1",
+			}); err != nil {
+				t.Fatalf("PutAppFactoryJob() error = %v", err)
+			}
+			service := AppFactoryService{Store: store}
+			service.ObserveAgentSessionState(ctx, canonical.ReportSessionStateInput{
+				WorkspaceID:    "ws-1",
+				AgentSessionID: "session-1",
+				State: canonical.WorkspaceAgentSessionStateUpdate{
+					LastError: "provider failed",
+					Turn: &canonical.WorkspaceAgentTurnStateUpdate{
+						TurnID:  "turn-1",
+						Phase:   agentactivitybiz.TurnPhaseSettled,
+						Outcome: test.outcome,
+					},
+				},
+			}, canonical.ReportSessionStateReply{Accepted: true, StateApplied: true})
+
+			job := waitForAppFactoryJobStatus(t, store, "ws-1", "job-1", test.wantStatus)
+			if test.outcome == "completed" && strings.TrimSpace(job.ValidationResultJSON) == "" {
+				t.Fatal("completed root turn did not run validation")
+			}
+		})
+	}
+}
+
+func TestAppFactoryServiceSerializesDuplicateCompletedSettlements(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newAppFactoryStoreStub()
+	if err := store.PutAppFactoryJob(ctx, workspacebiz.AppFactoryJob{
+		AgentSessionID: "session-1",
+		AppID:          "app_1",
+		DraftDir:       t.TempDir(),
+		JobID:          "job-1",
+		Status:         workspacebiz.AppFactoryJobStatusGenerating,
+		WorkspaceID:    "ws-1",
+	}); err != nil {
+		t.Fatalf("PutAppFactoryJob() error = %v", err)
+	}
+	publisher := &workspaceAppFactoryPublisherStub{}
+	service := AppFactoryService{Store: store, Publisher: publisher}
+
+	var wg sync.WaitGroup
+	errorsByAttempt := make([]error, 2)
+	for attempt := range errorsByAttempt {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errorsByAttempt[attempt] = service.handleAgentSessionTerminalState(
+				ctx, "ws-1", "session-1", "completed", "",
+			)
+		}()
+	}
+	wg.Wait()
+
+	for attempt, err := range errorsByAttempt {
+		if err != nil {
+			t.Fatalf("settlement attempt %d error = %v", attempt, err)
+		}
+	}
+	if len(publisher.published) != 3 {
+		t.Fatalf("published updates = %d, want one preparing, one validating, and one validation failure", len(publisher.published))
 	}
 }
 

--- a/services/tuttid/wiring_daemon_api.go
+++ b/services/tuttid/wiring_daemon_api.go
@@ -573,19 +573,6 @@ func buildDaemonAPI(
 			}
 		}
 	}
-	agentActivityProjection.SetRootTurnObserver(rootTurnObserverFanout{
-		agentRuntimeController,
-		tuttiModeSourceTurnActivityObserver{
-			Activities: tuttiModeSourceActivity,
-		},
-		tuttiModeMainWakeTurnObserver{
-			Settlements: tuttiModeExecutions,
-			Queue:       issueService.ExecutionRecoveryQueue,
-		},
-		tuttiModeReviewerTurnObserver{
-			Settlements: tuttiModeExecutions,
-		},
-	})
 	appCenterService := &workspaceservice.AppCenterService{
 		Store:                 appStore,
 		AppFactoryStore:       appFactoryStore,
@@ -646,18 +633,30 @@ func buildDaemonAPI(
 		StateDir:              tuttitypes.DefaultStateDir(),
 		Publisher:             eventstreamservice.WorkspaceAppFactoryPublisher{Service: events},
 	}
+	agentActivityProjection.SetRootTurnObserver(rootTurnObserverFanout{
+		agentRuntimeController,
+		tuttiModeSourceTurnActivityObserver{
+			Activities: tuttiModeSourceActivity,
+		},
+		tuttiModeMainWakeTurnObserver{
+			Settlements: tuttiModeExecutions,
+			Queue:       issueService.ExecutionRecoveryQueue,
+		},
+		tuttiModeReviewerTurnObserver{
+			Settlements: tuttiModeExecutions,
+		},
+	})
 	agentActivityProjection.SetSessionMessageObserver(appFactoryService)
-	agentActivityProjection.SetSessionStateObserver(agentservice.SessionStateObservers{appFactoryService, modelPolicies, automationRules, issueExecutionCoordinator})
-	// Canonical root-turn settlements (root-provider aggregation, child-drain
-	// reconcile, cancel) fan out at-least-once to this dedicated opt-in list
-	// only. Automation rules and the Issue-run observer are the consumers
-	// cleared for it today: the general session-state observers historically
-	// never received live turn settles, and each needs its own semantic ruling
-	// before opting in (W4③-11). The Issue-run observer matches the settled
-	// turn against the run's initiating "issue-run:<runID>" submit, so an
-	// unrelated turn settling in a delegate session can never complete the
-	// run, and repeated terminal completion is idempotent.
-	agentActivityProjection.SetRootTurnSettleStateObserver(agentservice.SessionStateObservers{automationRules, issueExecutionCoordinator})
+	sessionStateObservers := []agentservice.SessionStateObserverRegistration{
+		{Observer: appFactoryService, RootTurnSettlements: agentservice.RootTurnSettlementsObserve},
+		{Observer: modelPolicies, RootTurnSettlements: agentservice.RootTurnSettlementsObserve},
+		{Observer: automationRules, RootTurnSettlements: agentservice.RootTurnSettlementsObserve},
+		{Observer: issueExecutionCoordinator, RootTurnSettlements: agentservice.RootTurnSettlementsObserve},
+	}
+	if err := agentActivityProjection.ConfigureSessionStateObservers(sessionStateObservers...); err != nil {
+		agentRuntime.Close()
+		return tuttiapi.DaemonAPI{}, nil, nil, nil, fmt.Errorf("configure agent session state observers: %w", err)
+	}
 	if _, err := appFactoryService.ReconcileInterruptedJobs(ctx); err != nil {
 		agentRuntime.Close()
 		return tuttiapi.DaemonAPI{}, nil, nil, nil, fmt.Errorf("reconcile interrupted app factory jobs: %w", err)

--- a/tools/scripts/dev-gui.sh
+++ b/tools/scripts/dev-gui.sh
@@ -468,6 +468,19 @@ check_runtime_prerequisites() {
   ensure_go_runtime
 }
 
+configure_desktop_dev_version() {
+  if [[ -n "${TUTTI_APP_VERSION:-}" ]]; then
+    log "desktop version ${TUTTI_APP_VERSION} (environment override)"
+    return
+  fi
+
+  TUTTI_APP_VERSION="$(
+    node "${DESKTOP_APP_DIR}/scripts/resolve-build-version.mjs"
+  )"
+  export TUTTI_APP_VERSION
+  log "desktop version ${TUTTI_APP_VERSION}"
+}
+
 resolve_tuttid_binary_name() {
   case "$(uname -s)" in
     CYGWIN*|MINGW*|MSYS*)
@@ -575,6 +588,7 @@ main() {
   local binary_name
 
   check_runtime_prerequisites
+  configure_desktop_dev_version
   ensure_workspace_dependencies
 
   binary_name="$(resolve_tuttid_binary_name)"


### PR DESCRIPTION
## Summary
- route App Factory and Model Policy through canonical root-Turn settlement notifications with explicit observer policy and replay-safe handling
- select the highest compatible Tutti release tier and provide a Git-derived version to development desktop launches
- clarify the executable 800-line lint measurement and add AgentGUI review governance, architecture, and troubleshooting guidance

## Tests
- `go test ./service/agent ./service/workspace ./service/modelpolicy ./service/collabrun ./service/automationrule`
- `go test ./builtin-apps`
- `bash -n tools/scripts/dev-gui.sh`
- `node apps/desktop/scripts/resolve-build-version.mjs`
- `pnpm check:changed -- --push-ready`
- pre-commit staged formatting and boundary checks

## Notes
- desktop manual click-through was not run
- push-ready initially hit unrelated process-start timing failures; the failed lanes and subsequent complete push-ready gates passed