### PR TITLE
fix(agent-gui): hide sign-in step for auth-less targets and polish setup dialog actions

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentTargetSetupGate.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentTargetSetupGate.tsx
@@ -3,6 +3,8 @@ import { useState } from "react";
 import { useExternalStoreSnapshot } from "@tutti-os/ui-react-hooks";
 import {
   Button,
+  CheckIcon,
+  CopyIcon,
   RefreshIcon,
   Select,
   SelectContent,
@@ -125,6 +127,11 @@ export function AgentTargetSetupGate({
         : t("agentHost.agentGui.targetSetupDescription");
   const authenticationAvailable =
     snapshot?.status === "auth_required" || snapshot?.status === "ready";
+  const signInApplicable =
+    authMethods.length > 0 ||
+    account !== null ||
+    snapshot?.status === "auth_required" ||
+    snapshot?.status === "authenticating";
 
   return (
     <>
@@ -175,6 +182,7 @@ export function AgentTargetSetupGate({
           footer={
             <Button
               size="dialog"
+              variant="secondary"
               type="button"
               disabled={loading}
               onClick={() => void controller.refresh()}
@@ -244,100 +252,102 @@ export function AgentTargetSetupGate({
                 ) : null}
               </SetupTrackRow>
 
-              <SetupTrackRow
-                label={t(
-                  snapshot?.status === "ready"
-                    ? "agentHost.agentGui.targetSetupLoggedInAccount"
-                    : "agentHost.agentGui.targetSetupStage.login"
-                )}
-                status={loginStatus}
-                warning={snapshot?.status === "auth_required"}
-                detail={
-                  snapshot?.status === "ready" ? accountDetail : undefined
-                }
-                action={
-                  authenticationAvailable &&
-                  authMethods.length > 0 &&
-                  !terminalLoginCommand ? (
-                    <Button
-                      type="button"
-                      size="sm"
-                      disabled={!effectiveAuthMethodId || authenticatePending}
-                      onClick={() => void handleAuthenticate()}
-                    >
-                      {authenticatePending
-                        ? t("agentHost.agentGui.targetSetupAuthStarting")
-                        : snapshot?.status === "ready"
-                          ? t("agentHost.agentGui.targetSetupReauthenticate")
-                          : t("agentHost.agentGui.targetSetupAuthenticate")}
-                    </Button>
-                  ) : terminalLoginCommand &&
-                    terminalLoginLaunchAvailable &&
-                    terminalLoginPhase !== "waiting" ? (
-                    <Button
-                      type="button"
-                      size="sm"
-                      onClick={() => void handleTerminalLoginStart()}
-                    >
-                      {t("agentHost.agentGui.targetSetupTerminalLoginStart")}
-                    </Button>
-                  ) : undefined
-                }
-              >
-                {terminalLoginCommand ? (
-                  <TerminalLoginGuide
-                    command={terminalLoginCommand}
-                    error={
-                      terminalLoginError === "timed_out"
-                        ? t(
-                            "agentHost.agentGui.targetSetupTerminalLoginTimedOut"
-                          )
-                        : terminalLoginError === "unavailable"
+              {signInApplicable ? (
+                <SetupTrackRow
+                  label={t(
+                    snapshot?.status === "ready"
+                      ? "agentHost.agentGui.targetSetupLoggedInAccount"
+                      : "agentHost.agentGui.targetSetupStage.login"
+                  )}
+                  status={loginStatus}
+                  warning={snapshot?.status === "auth_required"}
+                  detail={
+                    snapshot?.status === "ready" ? accountDetail : undefined
+                  }
+                  action={
+                    authenticationAvailable &&
+                    authMethods.length > 0 &&
+                    !terminalLoginCommand ? (
+                      <Button
+                        type="button"
+                        size="sm"
+                        disabled={!effectiveAuthMethodId || authenticatePending}
+                        onClick={() => void handleAuthenticate()}
+                      >
+                        {authenticatePending
+                          ? t("agentHost.agentGui.targetSetupAuthStarting")
+                          : snapshot?.status === "ready"
+                            ? t("agentHost.agentGui.targetSetupReauthenticate")
+                            : t("agentHost.agentGui.targetSetupAuthenticate")}
+                      </Button>
+                    ) : terminalLoginCommand &&
+                      terminalLoginLaunchAvailable &&
+                      terminalLoginPhase !== "waiting" ? (
+                      <Button
+                        type="button"
+                        size="sm"
+                        onClick={() => void handleTerminalLoginStart()}
+                      >
+                        {t("agentHost.agentGui.targetSetupTerminalLoginStart")}
+                      </Button>
+                    ) : undefined
+                  }
+                >
+                  {terminalLoginCommand ? (
+                    <TerminalLoginGuide
+                      command={terminalLoginCommand}
+                      error={
+                        terminalLoginError === "timed_out"
                           ? t(
-                              "agentHost.agentGui.targetSetupTerminalLoginUnavailable"
+                              "agentHost.agentGui.targetSetupTerminalLoginTimedOut"
                             )
-                          : null
-                    }
-                    onCancelLogin={
-                      terminalLoginPhase === "waiting"
-                        ? handleTerminalLoginCancel
-                        : undefined
-                    }
-                    waiting={terminalLoginPhase === "waiting"}
-                  />
-                ) : null}
-                {snapshot?.status === "auth_required" &&
-                authMethods.length > 0 ? (
-                  <label className="mt-2 flex flex-col gap-1 text-[12px] text-[var(--text-secondary)]">
-                    {t("agentHost.agentGui.targetSetupAuthMethod")}
-                    <Select
-                      value={effectiveAuthMethodId}
-                      onValueChange={controller.selectAuthMethod}
-                    >
-                      <SelectTrigger
-                        aria-label={t(
-                          "agentHost.agentGui.targetSetupAuthMethod"
-                        )}
+                          : terminalLoginError === "unavailable"
+                            ? t(
+                                "agentHost.agentGui.targetSetupTerminalLoginUnavailable"
+                              )
+                            : null
+                      }
+                      onCancelLogin={
+                        terminalLoginPhase === "waiting"
+                          ? handleTerminalLoginCancel
+                          : undefined
+                      }
+                      waiting={terminalLoginPhase === "waiting"}
+                    />
+                  ) : null}
+                  {snapshot?.status === "auth_required" &&
+                  authMethods.length > 0 ? (
+                    <label className="mt-2 flex flex-col gap-1 text-[12px] text-[var(--text-secondary)]">
+                      {t("agentHost.agentGui.targetSetupAuthMethod")}
+                      <Select
+                        value={effectiveAuthMethodId}
+                        onValueChange={controller.selectAuthMethod}
                       >
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent
-                        style={{ zIndex: "var(--z-dialog-popover)" }}
-                      >
-                        {authMethods.map((method) => (
-                          <SelectItem key={method.id} value={method.id}>
-                            {method.name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </label>
-                ) : snapshot?.status === "auth_required" ? (
-                  <p className="mt-2 mb-0 text-[12px] text-[var(--text-secondary)]">
-                    {t("agentHost.agentGui.targetSetupNoAuthMethods")}
-                  </p>
-                ) : null}
-              </SetupTrackRow>
+                        <SelectTrigger
+                          aria-label={t(
+                            "agentHost.agentGui.targetSetupAuthMethod"
+                          )}
+                        >
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent
+                          style={{ zIndex: "var(--z-dialog-popover)" }}
+                        >
+                          {authMethods.map((method) => (
+                            <SelectItem key={method.id} value={method.id}>
+                              {method.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </label>
+                  ) : snapshot?.status === "auth_required" ? (
+                    <p className="mt-2 mb-0 text-[12px] text-[var(--text-secondary)]">
+                      {t("agentHost.agentGui.targetSetupNoAuthMethods")}
+                    </p>
+                  ) : null}
+                </SetupTrackRow>
+              ) : null}
             </ol>
 
             {failed || snapshot?.status === "failed" || actionFailed ? (
@@ -396,10 +406,27 @@ function TerminalLoginGuide({
         <code className="min-w-0 flex-1 select-all break-all rounded-md border border-[var(--line-2)] bg-[var(--background-fronted)] px-3 py-2 font-mono text-[11px] leading-5 text-[var(--text-primary)]">
           {command}
         </code>
-        <Button type="button" size="sm" onClick={() => void handleCopy()}>
-          {copied
-            ? t("agentHost.agentGui.targetSetupCommandCopied")
-            : t("agentHost.agentGui.targetSetupCopyCommand")}
+        <Button
+          type="button"
+          size="icon-sm"
+          variant="ghost"
+          aria-label={
+            copied
+              ? t("agentHost.agentGui.targetSetupCommandCopied")
+              : t("agentHost.agentGui.targetSetupCopyCommand")
+          }
+          title={
+            copied
+              ? t("agentHost.agentGui.targetSetupCommandCopied")
+              : t("agentHost.agentGui.targetSetupCopyCommand")
+          }
+          onClick={() => void handleCopy()}
+        >
+          {copied ? (
+            <CheckIcon aria-hidden="true" />
+          ) : (
+            <CopyIcon aria-hidden="true" />
+          )}
         </Button>
       </div>
       {waiting && onCancelLogin ? (


### PR DESCRIPTION
## Summary

Cherry-picks the new AgentGUI setup-dialog fix from #1843 (already merged into `main`) onto `release/0729`:

- fix(agent-gui): hide sign-in step for auth-less targets and polish setup dialog actions
  - Only render the Sign in setup track when the target declares auth methods or has an authenticated account, so runtime-only targets such as Hermes no longer show a dead pending step
  - Use the ui-system secondary variant for the dialog footer retry action
  - Replace the copy-command text button with a ghost icon button that swaps to a check icon after copying

Cherry-picked cleanly; no conflicts.

## Validation

- `pnpm check:changed -- --push-ready`: 38 lanes passed (pre-push)
- agent-gui package: 311 spec files / 2588 tests passed on the original commit
- Note: `TestProbeCodexAppServerClassifiesMissingOptionalDependencyFromStderr` flaked once under parallel lane load ("acp initialize timed out after 3s"); it passes standalone in 0.23s and passed on the push retry — unrelated to this change (TSX-only)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1844" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->