### PR TITLE
refactor(agent): unify session stop admission

### DIFF
--- a/apps/mobile/src/services/workspaceActivityService.test.ts
+++ b/apps/mobile/src/services/workspaceActivityService.test.ts
@@ -316,6 +316,29 @@ describe("WorkspaceActivityService", () => {
     service.dispose();
   });
 
+  test("routes Session stop through the Engine semantic operation", async () => {
+    const service = createService(
+      createClient({ listMessages: emptyMessagePage })
+    );
+
+    await service.start();
+    await flushAsyncWork();
+    const engine = (
+      service as unknown as {
+        engine: AgentSessionEngine;
+      }
+    ).engine;
+    const stopSession = jest.spyOn(engine, "stopSession");
+
+    service.stop();
+
+    expect(stopSession).toHaveBeenCalledTimes(1);
+    expect(stopSession).toHaveBeenCalledWith({
+      agentSessionId: "session-1"
+    });
+    service.dispose();
+  });
+
   test("treats a new Mobile settings selection as a retry after unknown delivery", async () => {
     const settingsRequests: Array<Record<string, unknown>> = [];
     const client = createClient({

--- a/apps/mobile/src/services/workspaceActivityService.ts
+++ b/apps/mobile/src/services/workspaceActivityService.ts
@@ -37,7 +37,6 @@ import {
   resolveWorkspaceComposerTarget
 } from "./workspaceActivityProjection";
 import { WorkspaceConversationRailService } from "./workspaceConversationRailService";
-import { createMobileActivityCommandId } from "./workspaceActivityCommandSupport";
 import type { WorkspaceActivitySnapshot } from "./workspaceActivityTypes";
 import { WorkspaceAgentLiveLane } from "./workspaceAgentLiveLane";
 import { selectWorkspaceConversationRailSessionIds } from "./workspaceConversationRailProjection";
@@ -47,7 +46,6 @@ import { WorkspaceMediaService } from "./workspaceMediaService";
 export type { WorkspaceActivitySnapshot } from "./workspaceActivityTypes";
 
 const MESSAGE_POLL_MS = 1_000;
-const COMMAND_TIMEOUT_MS = 30_000;
 const PENDING_EXPIRY_MS = 60_000;
 
 export class WorkspaceActivityService extends ObservableService<WorkspaceActivitySnapshot> {
@@ -474,14 +472,8 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
     if (!snapshot.commandsAvailable) return;
     const selected = snapshot.selectedSession;
     if (!selected) return;
-    const now = this.clock.now();
-    this.engine.dispatch({
-      agentSessionId: selected.agentSessionId,
-      awaitingTurnExpiresAtUnixMs: now + PENDING_EXPIRY_MS,
-      commandId: createMobileActivityCommandId(),
-      timeoutMs: COMMAND_TIMEOUT_MS,
-      type: "session/stopRequested",
-      workspaceId: this.workspace.id
+    this.engine.stopSession({
+      agentSessionId: selected.agentSessionId
     });
   }
 

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -197,19 +197,21 @@ It owns:
   shared mutation settlement, and a serialized settings-precondition state
   machine
 - semantic `AgentSessionEngine` methods for composer-option loading,
-  Interaction response submission, existing-Session settings updates, rename,
-  pin, and batch delete. Interaction and settings updates are intent admission:
-  the Engine owns workspace and command identity plus the 30-second delivery
-  timeout. Interaction submission additionally owns canonical pending-target
-  admission, in-flight deduplication, and exact failed-response retry; it never
-  recovers omitted answer fields from a prior attempt. Settings updates own
-  serialized patch merging and recognition of a fresh user update as retry
-  after unknown delivery. Consumers observe the existing operation
-  projections. The other methods additionally hide cache or mutation
-  coordination, settlement waiting, and canonical result projection from
-  product hosts. Mutation methods own timeout and cancellation policy; hosts
-  retain transport, DTO mapping, AbortSignal propagation, and product-specific
-  command extensions (see
+  Session stop, Interaction response submission, existing-Session settings
+  updates, rename, pin, and batch delete. Stop, Interaction, and settings
+  updates are intent admission: the Engine owns workspace and command identity
+  plus the 30-second delivery timeout. Session stop additionally owns the
+  30-second first-Turn waiting window and duplicate admission across Desktop
+  and Mobile. Interaction submission owns canonical pending-target admission,
+  in-flight deduplication, and exact failed-response retry; it never recovers
+  omitted answer fields from a prior attempt. Settings updates own serialized
+  patch merging and recognition of a fresh user update as retry after unknown
+  delivery. Consumers observe the existing operation projections. The other
+  methods additionally hide cache or mutation coordination, settlement
+  waiting, and canonical result projection from product hosts. Mutation
+  methods own timeout and cancellation policy; hosts retain transport, DTO
+  mapping, AbortSignal propagation, and product-specific command extensions
+  (see
   [Agent GUI Node](./agent-gui-node.md#4-workspace-frontend-engine))
 
 The public host-effect seam is `AgentSessionEffectPort`; the public
@@ -218,6 +220,10 @@ Product hosts call `updateSessionSettings` for an existing Session instead of
 constructing `session/settingsUpdateRequested` protocol fields. Settings held
 before Session activation remain part of the activation flow and do not pass
 through this existing-Session method.
+Desktop AgentGUI and Mobile call `stopSession` instead of constructing
+`session/stopRequested` protocol fields. The same method stops an active Turn
+or records a bounded request that cancels the first Turn produced by an
+in-flight activation.
 AgentGUI, Message Center, Desktop notifications, and Mobile call
 `submitInteractionResponse` for a canonical pending Interaction instead of
 constructing `interaction/responseRequested` protocol fields. A failed

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -668,7 +668,7 @@ disable submission, but must not change editor editability.
   into `AgentSessionEffectPort` calls. Desktop and Mobile effect ports retain
   transport and DTO mapping but must not duplicate a command-type switch for
   these shared effects. Host activity facades call
-  `engine.updateSessionSettings`, `engine.renameSession`,
+  `engine.stopSession`, `engine.updateSessionSettings`, `engine.renameSession`,
   `engine.setSessionPinned`, and `engine.deleteSessions`; these deep methods
   own the applicable workspace projection, command or mutation identity,
   timeout, cancellation, settlement, and canonical result projection. Settings
@@ -677,6 +677,10 @@ disable submission, but must not change editor editability.
   failed, and unknown state. Hosts must not reconstruct mutation protocol with
   `dispatchSessionMutation` and snapshot reads or construct raw
   `session/settingsUpdateRequested` fields for an existing Session.
+  Session stop is also fire-and-observe admission: the Engine owns its command
+  identity, 30-second cancellation timeout, duplicate fence, and 30-second
+  first-Turn waiting window. Desktop AgentGUI and Native Mobile call
+  `engine.stopSession` and never construct raw `session/stopRequested` fields.
   Platform-only commands remain in each host's `EngineExtensionCommand`
   adapter. Every effect propagates the Engine-owned AbortSignal to its
   transport. Rename, pin, and delete settle through the shared Session-mutation

--- a/packages/agent/activity-core/src/engine/createAgentSessionEngine.ts
+++ b/packages/agent/activity-core/src/engine/createAgentSessionEngine.ts
@@ -30,6 +30,7 @@ import {
   type AgentSessionEngineIntentObserver,
   type AgentSessionEngineListener,
   type AgentSessionLoadComposerOptionsInput,
+  type AgentSessionStopInput,
   type AgentSessionSubmitInteractionResponseInput,
   type AgentSessionUpdateSettingsInput,
   type EngineClock,
@@ -61,6 +62,7 @@ import type {
 export const ENGINE_INTENT_BATCH_DELAY_MS = 33;
 const SESSION_MUTATION_TIMEOUT_MS = 30_000;
 const SESSION_SETTINGS_UPDATE_TIMEOUT_MS = 30_000;
+const SESSION_STOP_TIMEOUT_MS = 30_000;
 const INTERACTION_RESPONSE_TIMEOUT_MS = 30_000;
 
 export interface CreateAgentSessionEngineInput {
@@ -106,6 +108,7 @@ export function createAgentSessionEngine({
   let interactionResponseCommandSequence = 1;
   let sessionMutationSequence = 1;
   let sessionSettingsUpdateSequence = 1;
+  let sessionStopCommandSequence = 1;
   const pendingComposerOptionsDisposals = new Set<() => void>();
 
   const expiryClock = createEngineExpiryClock({
@@ -391,6 +394,23 @@ export function createAgentSessionEngine({
     return `interaction:${clock.nowUnixMs()}:${sequence}`;
   }
 
+  function stopSession(input: AgentSessionStopInput): void {
+    const agentSessionId = input.agentSessionId.trim();
+    if (!agentSessionId) {
+      return;
+    }
+    const requestedAtUnixMs = clock.nowUnixMs();
+    const sequence = sessionStopCommandSequence++;
+    dispatch({
+      agentSessionId,
+      awaitingTurnExpiresAtUnixMs: requestedAtUnixMs + SESSION_STOP_TIMEOUT_MS,
+      commandId: `stop:${requestedAtUnixMs}:${sequence}`,
+      timeoutMs: SESSION_STOP_TIMEOUT_MS,
+      type: "session/stopRequested",
+      workspaceId: engineIdentity.workspaceId
+    });
+  }
+
   function submitInteractionResponse(
     input: AgentSessionSubmitInteractionResponseInput
   ): boolean {
@@ -575,6 +595,7 @@ export function createAgentSessionEngine({
       return session;
     },
     submitInteractionResponse,
+    stopSession,
     subscribe(listener) {
       listeners.add(listener);
       return () => {

--- a/packages/agent/activity-core/src/engine/sessionStop.semantic.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionStop.semantic.test.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { normalizeAgentActivitySession } from "../sessionNormalization.ts";
+import type { AgentActivityTurn } from "../types.ts";
+import { createAgentSessionEngine } from "./createAgentSessionEngine.ts";
+import { selectEngineCancelState } from "./sessionLifecycle.selectors.ts";
+import type {
+  EngineCommandPort,
+  EngineExternalCommand,
+  EngineScheduler
+} from "./types.ts";
+
+function createHarness(active: boolean) {
+  let nowUnixMs = 100;
+  const commands: EngineExternalCommand[] = [];
+  const scheduled: Array<{
+    canceled: boolean;
+    delayMs: number;
+  }> = [];
+  const commandPort: EngineCommandPort = {
+    execute(command) {
+      commands.push(command);
+      return new Promise(() => undefined);
+    }
+  };
+  const scheduler: EngineScheduler = {
+    schedule(delayMs) {
+      const task = { canceled: false, delayMs };
+      scheduled.push(task);
+      return {
+        cancel() {
+          task.canceled = true;
+        }
+      };
+    }
+  };
+  const engine = createAgentSessionEngine({
+    clock: { nowUnixMs: () => nowUnixMs },
+    commandPort,
+    identity: { origin: "test", workspaceId: "workspace-1" },
+    scheduler
+  });
+  engine.dispatch({
+    sessions: [session(active ? activeTurn() : null)],
+    type: "session/snapshotReceived"
+  });
+  return {
+    commands,
+    engine,
+    scheduled,
+    setNow(value: number) {
+      nowUnixMs = value;
+    }
+  };
+}
+
+test("semantic session stop owns command identity, scope, and timeout", () => {
+  const harness = createHarness(true);
+
+  harness.engine.stopSession({ agentSessionId: " session-1 " });
+
+  assert.deepEqual(harness.commands, [
+    {
+      agentSessionId: "session-1",
+      commandId: "stop:100:1",
+      timeoutMs: 30_000,
+      turnId: "turn-1",
+      type: "turn/cancel",
+      workspaceId: "workspace-1"
+    }
+  ]);
+  assert.equal(
+    selectEngineCancelState(harness.engine.getSnapshot(), "session-1")?.status,
+    "requested"
+  );
+});
+
+test("semantic session stop waits 30 seconds for a first Turn and deduplicates repeated requests", () => {
+  const harness = createHarness(false);
+
+  harness.engine.stopSession({ agentSessionId: "session-1" });
+  harness.engine.stopSession({ agentSessionId: "session-1" });
+
+  assert.deepEqual(harness.commands, []);
+  assert.deepEqual(harness.scheduled, [
+    {
+      canceled: false,
+      delayMs: 30_000
+    }
+  ]);
+  assert.equal(
+    selectEngineCancelState(harness.engine.getSnapshot(), "session-1")?.status,
+    "awaitingTurn"
+  );
+
+  harness.setNow(200);
+  harness.engine.dispatch({
+    session: session(activeTurn()),
+    type: "session/upserted"
+  });
+
+  assert.deepEqual(harness.commands, [
+    {
+      agentSessionId: "session-1",
+      commandId: "stop:100:1",
+      timeoutMs: 30_000,
+      turnId: "turn-1",
+      type: "turn/cancel",
+      workspaceId: "workspace-1"
+    }
+  ]);
+  assert.equal(harness.scheduled[0]?.canceled, true);
+});
+
+function activeTurn(): AgentActivityTurn {
+  return {
+    agentSessionId: "session-1",
+    origin: "user_prompt",
+    phase: "running",
+    startedAtUnixMs: 1,
+    turnId: "turn-1",
+    updatedAtUnixMs: 2
+  };
+}
+
+function session(turn: AgentActivityTurn | null) {
+  return normalizeAgentActivitySession({
+    activeTurn: turn,
+    activeTurnId: turn?.turnId ?? null,
+    agentSessionId: "session-1",
+    cwd: "/workspace",
+    latestTurn: turn,
+    latestTurnInteractions: [],
+    pendingInteractions: [],
+    provider: "codex",
+    title: "Session",
+    workspaceId: "workspace-1"
+  });
+}

--- a/packages/agent/activity-core/src/engine/types.ts
+++ b/packages/agent/activity-core/src/engine/types.ts
@@ -454,6 +454,10 @@ export interface AgentSessionSubmitInteractionResponseInput {
   turnId: string;
 }
 
+export interface AgentSessionStopInput {
+  agentSessionId: string;
+}
+
 export interface AgentSessionEngine {
   readonly identity: AgentSessionEngineIdentity;
   deleteSessions(
@@ -483,6 +487,7 @@ export interface AgentSessionEngine {
   submitInteractionResponse(
     input: AgentSessionSubmitInteractionResponseInput
   ): boolean;
+  stopSession(input: AgentSessionStopInput): void;
   subscribe(listener: AgentSessionEngineListener): () => void;
   updateSessionSettings(input: AgentSessionUpdateSettingsInput): void;
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.spec.ts
@@ -160,26 +160,22 @@ describe("new-conversation home draft lifecycle", () => {
 });
 
 describe("conversation stop", () => {
-  it("dispatches one unified stop intent for activation and active-turn states", () => {
+  it("routes activation and active-turn stop through the Engine semantic operation", () => {
     const goalControl = vi.fn(async () => undefined);
     const { input, sessionEngine } = createGoalControlInput(
       goalControl as never
     );
-    const dispatch = vi.spyOn(sessionEngine, "dispatch");
+    const stopSession = vi.spyOn(sessionEngine, "stopSession");
     const { result } = renderHook(() =>
       useAgentGUISubmitInteractionActions(input)
     );
 
     act(() => result.current.interruptCurrentTurn("not running"));
 
-    expect(dispatch).toHaveBeenCalledTimes(1);
-    expect(dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        agentSessionId: "session-1",
-        type: "session/stopRequested",
-        workspaceId: "workspace-1"
-      })
-    );
+    expect(stopSession).toHaveBeenCalledTimes(1);
+    expect(stopSession).toHaveBeenCalledWith({
+      agentSessionId: "session-1"
+    });
   });
 });
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.ts
@@ -1,5 +1,4 @@
 import {
-  selectEngineCancelState,
   selectEngineHasVisibleQueuedSubmit,
   selectPendingSubmitsForSession,
   type AgentActivityGoalControlAction,
@@ -47,7 +46,6 @@ import {
   getAgentGUIErrorMessage,
   isNonRetryableResumeErrorCode
 } from "./agentGuiController.errors";
-import { createAgentGUIConversationId } from "./agentGuiController.promptHelpers";
 import {
   agentSubmitTraceDiagnostics,
   createAgentSubmitTraceState,
@@ -705,29 +703,12 @@ export function useAgentGUISubmitInteractionActions(
   const interruptCurrentTurn = useCallback(
     (noRunningResponseMessage: string) => {
       const agentSessionId = activeConversationIdRef.current;
-      const cancelStatus = agentSessionId
-        ? selectEngineCancelState(sessionEngine.getSnapshot(), agentSessionId)
-            ?.status
-        : null;
-      if (
-        !agentSessionId ||
-        cancelStatus === "requested" ||
-        cancelStatus === "awaitingTurn"
-      ) {
-        return;
-      }
+      if (!agentSessionId) return;
       void noRunningResponseMessage;
       setDetailError(null);
-      sessionEngine.dispatch({
-        agentSessionId,
-        awaitingTurnExpiresAtUnixMs: Date.now() + 30_000,
-        commandId: createAgentGUIConversationId(),
-        timeoutMs: 30_000,
-        type: "session/stopRequested",
-        workspaceId
-      });
+      sessionEngine.stopSession({ agentSessionId });
     },
-    [sessionEngine, workspaceId]
+    [sessionEngine]
   );
 
   const updateDraftContent = useCallback(


### PR DESCRIPTION
## What changed

- add the semantic `AgentSessionEngine.stopSession` operation
- migrate Desktop AgentGUI and Native Mobile away from constructing raw `session/stopRequested` intents
- let the Engine own workspace scope, command identity, duplicate admission, the 30-second cancel timeout, and the 30-second first-Turn waiting window
- keep active-Turn cancellation and in-flight activation cancellation on the same reducer path
- add Engine semantic coverage plus Desktop and Mobile caller regressions
- document the shared frontend Engine ownership boundary

## Why

Desktop and Mobile were expressing the same Stop action by assembling reducer protocol fields independently. That duplicated command identity and timeout policy, and the behavior had already drifted: Desktop waited 30 seconds for the first Turn while Mobile reused a 60-second pending-submission expiry.

This change moves Stop admission to the existing semantic Engine surface, using historical Desktop behavior as the shared contract. Product hosts now provide only the Session identity; transport and DTO mapping remain in their effect ports.

## User impact

Stop keeps its existing Desktop behavior: it cancels an active Turn immediately, or records a bounded request that cancels the first Turn produced by an in-flight activation. Desktop and Mobile now share the same 30-second behavior and Engine-owned duplicate fence.

There are no Host lifecycle, daemon HTTP, or OpenAPI contract changes.

## Validation

- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready` (16 lanes)
- `@tutti-os/agent-activity-core` full test suite (403 tests)
- focused Desktop AgentGUI and Mobile service tests
- activity-core, AgentGUI, and Mobile typechecks
- `pnpm --filter @tutti-os/desktop build`
- `make dev-gui` development-window reload smoke: existing Session list, Rail projection, and current conversation messages loaded without new Desktop/tuttid warnings or errors