### PR TITLE
refactor(agent): unify existing session prompt admission

### DIFF
--- a/apps/mobile/src/services/workspaceActivityService.test.ts
+++ b/apps/mobile/src/services/workspaceActivityService.test.ts
@@ -175,10 +175,29 @@ describe("WorkspaceActivityService", () => {
 
     await service.start();
     await flushAsyncWork();
+    const engine = (
+      service as unknown as {
+        engine: AgentSessionEngine;
+      }
+    ).engine;
+    const submitPrompt = jest.spyOn(engine, "submitPrompt");
     service.setDraft("continue");
     await service.send();
     await flushAsyncWork();
 
+    expect(submitPrompt).toHaveBeenCalledWith({
+      agentSessionId: "session-1",
+      clientSubmitId: expect.any(String),
+      content: [{ text: "continue", type: "text" }],
+      routing: "auto",
+      runtimeContent: [{ text: "continue", type: "text" }],
+      submitDiagnostics: {
+        blockCount: 1,
+        promptLength: 8,
+        source: "mobile",
+        submittedAtUnixMs: expect.any(Number)
+      }
+    });
     expect(sends).toHaveLength(1);
     expect(sends[0]).toMatchObject({
       agentSessionId: "session-1",
@@ -190,6 +209,30 @@ describe("WorkspaceActivityService", () => {
     expect(service.getSnapshot().draft).toBe("");
     expect(service.getSnapshot().sending).toBe(true);
 
+    service.dispose();
+  });
+
+  test("preserves the Mobile draft when the Engine rejects submission admission", async () => {
+    const service = createService(
+      createClient({ listMessages: emptyMessagePage })
+    );
+
+    await service.start();
+    await flushAsyncWork();
+    const engine = (
+      service as unknown as {
+        engine: AgentSessionEngine;
+      }
+    ).engine;
+    jest.spyOn(engine, "submitPrompt").mockReturnValue({
+      accepted: false,
+      queued: false
+    });
+    service.setDraft("continue");
+
+    await service.send();
+
+    expect(service.getSnapshot().draft).toBe("continue");
     service.dispose();
   });
 

--- a/apps/mobile/src/services/workspaceActivityService.ts
+++ b/apps/mobile/src/services/workspaceActivityService.ts
@@ -46,7 +46,7 @@ import { WorkspaceMediaService } from "./workspaceMediaService";
 export type { WorkspaceActivitySnapshot } from "./workspaceActivityTypes";
 
 const MESSAGE_POLL_MS = 1_000;
-const PENDING_EXPIRY_MS = 60_000;
+const ACTIVATION_EXPIRY_MS = 60_000;
 
 export class WorkspaceActivityService extends ObservableService<WorkspaceActivitySnapshot> {
   readonly _serviceBrand: undefined;
@@ -436,7 +436,7 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
         agentTargetId: submission.agentTargetId!,
         clientSubmitId: submission.clientSubmitId,
         content,
-        expiresAtUnixMs: now + PENDING_EXPIRY_MS,
+        expiresAtUnixMs: now + ACTIVATION_EXPIRY_MS,
         initialTurnExpected: true,
         mode: "new",
         requestId: submission.clientSubmitId,
@@ -452,19 +452,17 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
       return;
     }
     if (!snapshot.selectedAgentSessionId) return;
-    this.engine.dispatch({
+    const { accepted, queued } = this.engine.submitPrompt({
       agentSessionId: snapshot.selectedAgentSessionId,
       clientSubmitId: submission.clientSubmitId,
       content,
-      expiresAtUnixMs: now + PENDING_EXPIRY_MS,
-      requestedAtUnixMs: now,
       routing: "auto",
       runtimeContent: content,
-      submitDiagnostics,
-      type: "submit/requested",
-      workspaceId: this.workspace.id
+      submitDiagnostics
     });
-    this.drafts.clear(snapshot.selectedAgentSessionId);
+    if (accepted || queued) {
+      this.drafts.clear(snapshot.selectedAgentSessionId);
+    }
   }
 
   stop(): void {

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -197,12 +197,17 @@ It owns:
   shared mutation settlement, and a serialized settings-precondition state
   machine
 - semantic `AgentSessionEngine` methods for composer-option loading,
-  Session stop, Interaction response submission, existing-Session settings
-  updates, rename, pin, and batch delete. Stop, Interaction, and settings
-  updates are intent admission: the Engine owns workspace and command identity
-  plus the 30-second delivery timeout. Session stop additionally owns the
-  30-second first-Turn waiting window and duplicate admission across Desktop
-  and Mobile. Interaction submission owns canonical pending-target admission,
+  existing-Session Prompt submission, Session stop, Interaction response
+  submission, existing-Session settings updates, rename, pin, and batch
+  delete. Prompt, stop, Interaction, and settings updates are intent admission:
+  the Engine owns workspace and protocol construction. Prompt submission owns
+  routing, the 120-second confirmation window, and the accepted/queued
+  admission result while the caller retains the stable client submit identity
+  used by draft recovery and idempotent retry. Stop, Interaction, and settings
+  additionally own command identity plus the 30-second delivery timeout.
+  Session stop owns the 30-second first-Turn waiting window and duplicate
+  admission across Desktop and Mobile. Interaction submission owns canonical
+  pending-target admission,
   in-flight deduplication, and exact failed-response retry; it never recovers
   omitted answer fields from a prior attempt. Settings updates own serialized
   patch merging and recognition of a fresh user update as retry after unknown
@@ -224,6 +229,12 @@ Desktop AgentGUI and Mobile call `stopSession` instead of constructing
 `session/stopRequested` protocol fields. The same method stops an active Turn
 or records a bounded request that cancels the first Turn produced by an
 in-flight activation.
+Desktop AgentGUI and Mobile call `submitPrompt` for an existing Session instead
+of constructing `submit/requested` protocol fields or reading multiple Engine
+selectors to infer whether the submission was admitted. The Engine fixes the
+same confirmation window and routing semantics for both surfaces; each surface
+uses the returned accepted/queued result to decide whether its submitted draft
+may be cleared. New-Session initial content remains part of activation.
 AgentGUI, Message Center, Desktop notifications, and Mobile call
 `submitInteractionResponse` for a canonical pending Interaction instead of
 constructing `interaction/responseRequested` protocol fields. A failed

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -668,10 +668,11 @@ disable submission, but must not change editor editability.
   into `AgentSessionEffectPort` calls. Desktop and Mobile effect ports retain
   transport and DTO mapping but must not duplicate a command-type switch for
   these shared effects. Host activity facades call
-  `engine.stopSession`, `engine.updateSessionSettings`, `engine.renameSession`,
-  `engine.setSessionPinned`, and `engine.deleteSessions`; these deep methods
-  own the applicable workspace projection, command or mutation identity,
-  timeout, cancellation, settlement, and canonical result projection. Settings
+  `engine.submitPrompt`, `engine.stopSession`,
+  `engine.updateSessionSettings`, `engine.renameSession`,
+  `engine.setSessionPinned`, and `engine.deleteSessions`; these deep methods own
+  the applicable workspace projection, protocol or mutation identity, timeout,
+  cancellation, settlement, and canonical result projection. Settings
   update is fire-and-observe intent admission rather than a settlement Promise:
   the existing settings-operation selector remains the source of pending,
   failed, and unknown state. Hosts must not reconstruct mutation protocol with
@@ -681,6 +682,14 @@ disable submission, but must not change editor editability.
   identity, 30-second cancellation timeout, duplicate fence, and 30-second
   first-Turn waiting window. Desktop AgentGUI and Native Mobile call
   `engine.stopSession` and never construct raw `session/stopRequested` fields.
+  Existing-Session Prompt submission enters through `engine.submitPrompt`.
+  The surface keeps the stable `clientSubmitId` used by its draft-recovery and
+  idempotent-retry bookkeeping; the Engine owns workspace scope, timestamps,
+  routing protocol, the shared 120-second confirmation window, and the
+  accepted/queued admission result. Desktop AgentGUI and Native Mobile clear a
+  submitted draft only after that result confirms admission, and never
+  construct raw `submit/requested` fields or rebuild admission from selectors.
+  New-Session initial content continues to travel with activation.
   Platform-only commands remain in each host's `EngineExtensionCommand`
   adapter. Every effect propagates the Engine-owned AbortSignal to its
   transport. Rename, pin, and delete settle through the shared Session-mutation
@@ -903,6 +912,9 @@ the activation intent instead; provider-independent draft projection and
 Desktop-persisted defaults remain surface policy until activation. A renderer
 must not call the settings endpoint from a component or invent a
 provider-specific settings schema.
+Existing-Session Prompt sends similarly enter through `engine.submitPrompt`;
+Desktop and Mobile provide content plus a stable client submit identity, while
+the Engine owns common routing, confirmation expiry, and admission projection.
 
 An activation intent's shared Session settings are not an HTTP create-field
 allowlist. Each host must construct a typed

--- a/packages/agent/activity-core/src/engine/createAgentSessionEngine.ts
+++ b/packages/agent/activity-core/src/engine/createAgentSessionEngine.ts
@@ -15,6 +15,8 @@ import {
   selectEngineSession,
   selectEngineSessionSettingsUpdate
 } from "./sessionLifecycle.selectors.ts";
+import { selectPendingSubmitsForSession } from "./pendingIntents.selectors.ts";
+import { selectEngineHasVisibleQueuedSubmit } from "./promptQueue.selectors.ts";
 import {
   dispatchSessionMutationWithCancellation,
   type SessionMutationCancellation
@@ -32,6 +34,8 @@ import {
   type AgentSessionLoadComposerOptionsInput,
   type AgentSessionStopInput,
   type AgentSessionSubmitInteractionResponseInput,
+  type AgentSessionSubmitPromptInput,
+  type AgentSessionSubmitPromptResult,
   type AgentSessionUpdateSettingsInput,
   type EngineClock,
   type EngineCommandPort,
@@ -64,6 +68,7 @@ const SESSION_MUTATION_TIMEOUT_MS = 30_000;
 const SESSION_SETTINGS_UPDATE_TIMEOUT_MS = 30_000;
 const SESSION_STOP_TIMEOUT_MS = 30_000;
 const INTERACTION_RESPONSE_TIMEOUT_MS = 30_000;
+const SESSION_PROMPT_CONFIRMATION_TIMEOUT_MS = 120_000;
 
 export interface CreateAgentSessionEngineInput {
   batchDelayMs?: number;
@@ -454,6 +459,62 @@ export function createAgentSessionEngine({
     );
   }
 
+  function submitPrompt(
+    input: AgentSessionSubmitPromptInput
+  ): AgentSessionSubmitPromptResult {
+    const agentSessionId = input.agentSessionId.trim();
+    const clientSubmitId = input.clientSubmitId.trim();
+    const content = input.content.map((block) => ({ ...block }));
+    if (!agentSessionId || !clientSubmitId || content.length === 0) {
+      return { accepted: false, queued: false };
+    }
+    const requestedAtUnixMs = clock.nowUnixMs();
+    const displayPrompt = input.displayPrompt?.trim() || undefined;
+    dispatch({
+      agentSessionId,
+      ...(input.capabilityRefs?.length
+        ? {
+            capabilityRefs: input.capabilityRefs.map((reference) => ({
+              ...reference
+            }))
+          }
+        : {}),
+      clientSubmitId,
+      content,
+      ...(displayPrompt ? { displayPrompt } : {}),
+      expiresAtUnixMs:
+        requestedAtUnixMs + SESSION_PROMPT_CONFIRMATION_TIMEOUT_MS,
+      ...(input.requiredSettingsPatch
+        ? { requiredSettingsPatch: { ...input.requiredSettingsPatch } }
+        : {}),
+      requestedAtUnixMs,
+      routing: input.routing ?? "auto",
+      ...(input.runtimeContent
+        ? {
+            runtimeContent: input.runtimeContent.map((block) => ({
+              ...block
+            }))
+          }
+        : {}),
+      ...(input.submitDiagnostics
+        ? { submitDiagnostics: { ...input.submitDiagnostics } }
+        : {}),
+      type: "submit/requested",
+      workspaceId: engineIdentity.workspaceId
+    });
+    const snapshot = publicSnapshot;
+    return {
+      accepted: selectPendingSubmitsForSession(snapshot, agentSessionId).some(
+        (record) => record.clientSubmitId === clientSubmitId
+      ),
+      queued: selectEngineHasVisibleQueuedSubmit(
+        snapshot,
+        agentSessionId,
+        clientSubmitId
+      )
+    };
+  }
+
   function updateSessionSettings(input: AgentSessionUpdateSettingsInput): void {
     const agentSessionId = input.agentSessionId.trim();
     const settings = { ...input.settings };
@@ -595,6 +656,7 @@ export function createAgentSessionEngine({
       return session;
     },
     submitInteractionResponse,
+    submitPrompt,
     stopSession,
     subscribe(listener) {
       listeners.add(listener);

--- a/packages/agent/activity-core/src/engine/sessionPrompt.semantic.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionPrompt.semantic.test.ts
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { normalizeAgentActivitySession } from "../sessionNormalization.ts";
+import type { AgentActivityTurn } from "../types.ts";
+import { createAgentSessionEngine } from "./createAgentSessionEngine.ts";
+import type {
+  EngineCommandPort,
+  EngineExternalCommand,
+  EngineIntent,
+  EngineScheduler
+} from "./types.ts";
+
+function createHarness(active: boolean) {
+  const commands: EngineExternalCommand[] = [];
+  const observedIntents: EngineIntent[] = [];
+  const scheduled: Array<{ canceled: boolean; delayMs: number }> = [];
+  const commandPort: EngineCommandPort = {
+    execute(command) {
+      commands.push(command);
+      return new Promise(() => undefined);
+    }
+  };
+  const scheduler: EngineScheduler = {
+    schedule(delayMs) {
+      const task = { canceled: false, delayMs };
+      scheduled.push(task);
+      return {
+        cancel() {
+          task.canceled = true;
+        }
+      };
+    }
+  };
+  const engine = createAgentSessionEngine({
+    clock: { nowUnixMs: () => 100 },
+    commandPort,
+    identity: { origin: "test", workspaceId: "workspace-1" },
+    intentObserver: (intent) => {
+      observedIntents.push(intent);
+    },
+    scheduler
+  });
+  engine.dispatch({
+    sessions: [session(active ? activeTurn() : null)],
+    type: "session/snapshotReceived"
+  });
+  return { commands, engine, observedIntents, scheduled };
+}
+
+test("semantic prompt submission owns scope, confirmation window, and send projection", () => {
+  const harness = createHarness(false);
+
+  const result = harness.engine.submitPrompt({
+    agentSessionId: " session-1 ",
+    capabilityRefs: [{ capability: "tutti", source: "slash_command" }],
+    clientSubmitId: " submit-1 ",
+    content: [{ text: "display text", type: "text" }],
+    displayPrompt: " Display text ",
+    runtimeContent: [{ text: "runtime text", type: "text" }],
+    submitDiagnostics: { source: "test" }
+  });
+
+  assert.deepEqual(result, { accepted: true, queued: false });
+  assert.deepEqual(harness.observedIntents.at(-1), {
+    agentSessionId: "session-1",
+    capabilityRefs: [{ capability: "tutti", source: "slash_command" }],
+    clientSubmitId: "submit-1",
+    content: [{ text: "display text", type: "text" }],
+    displayPrompt: "Display text",
+    expiresAtUnixMs: 120_100,
+    requestedAtUnixMs: 100,
+    routing: "auto",
+    runtimeContent: [{ text: "runtime text", type: "text" }],
+    submitDiagnostics: { source: "test" },
+    type: "submit/requested",
+    workspaceId: "workspace-1"
+  });
+  assert.deepEqual(harness.commands, [
+    {
+      agentSessionId: "session-1",
+      capabilityRefs: [{ capability: "tutti", source: "slash_command" }],
+      clientSubmitId: "submit-1",
+      commandId: "queue:send:session-1:1",
+      content: [{ text: "runtime text", type: "text" }],
+      correlationId: "submit-1",
+      displayPrompt: "Display text",
+      promptId: "submit-1",
+      submitDiagnostics: {
+        blockCount: 1,
+        queued: false,
+        source: "test",
+        submittedAtUnixMs: 100
+      },
+      timeoutMs: 30_000,
+      type: "queue/sendPrompt",
+      workspaceId: "workspace-1"
+    }
+  ]);
+  assert.deepEqual(
+    harness.scheduled.map((task) => task.delayMs),
+    [120_000, 30_000]
+  );
+});
+
+test("semantic prompt submission reports visible queue admission for a busy Session", () => {
+  const harness = createHarness(true);
+
+  const result = harness.engine.submitPrompt({
+    agentSessionId: "session-1",
+    clientSubmitId: "submit-1",
+    content: [{ text: "continue", type: "text" }]
+  });
+
+  assert.deepEqual(result, { accepted: true, queued: true });
+  assert.deepEqual(harness.commands, []);
+  assert.deepEqual(
+    harness.scheduled.map((task) => task.delayMs),
+    [120_000]
+  );
+});
+
+test("semantic prompt submission rejects an invalid identity without side effects", () => {
+  const harness = createHarness(false);
+
+  const result = harness.engine.submitPrompt({
+    agentSessionId: " ",
+    clientSubmitId: "submit-1",
+    content: [{ text: "continue", type: "text" }]
+  });
+
+  assert.deepEqual(result, { accepted: false, queued: false });
+  assert.deepEqual(harness.commands, []);
+  assert.deepEqual(harness.scheduled, []);
+});
+
+function activeTurn(): AgentActivityTurn {
+  return {
+    agentSessionId: "session-1",
+    origin: "user_prompt",
+    phase: "running",
+    startedAtUnixMs: 1,
+    turnId: "turn-1",
+    updatedAtUnixMs: 2
+  };
+}
+
+function session(turn: AgentActivityTurn | null) {
+  return normalizeAgentActivitySession({
+    activeTurn: turn,
+    activeTurnId: turn?.turnId ?? null,
+    agentSessionId: "session-1",
+    cwd: "/workspace",
+    latestTurn: turn,
+    latestTurnInteractions: [],
+    pendingInteractions: [],
+    provider: "codex",
+    title: "Session",
+    workspaceId: "workspace-1"
+  });
+}

--- a/packages/agent/activity-core/src/engine/types.ts
+++ b/packages/agent/activity-core/src/engine/types.ts
@@ -454,6 +454,23 @@ export interface AgentSessionSubmitInteractionResponseInput {
   turnId: string;
 }
 
+export interface AgentSessionSubmitPromptInput {
+  agentSessionId: string;
+  capabilityRefs?: readonly AgentActivityCapabilityReference[];
+  clientSubmitId: string;
+  content: readonly AgentPromptContentBlock[];
+  displayPrompt?: string;
+  requiredSettingsPatch?: Readonly<AgentActivitySubmitSettingsPatch>;
+  routing?: "auto" | "immediate" | "send_now";
+  runtimeContent?: readonly AgentPromptContentBlock[];
+  submitDiagnostics?: Readonly<AgentActivitySubmitDiagnostics>;
+}
+
+export interface AgentSessionSubmitPromptResult {
+  accepted: boolean;
+  queued: boolean;
+}
+
 export interface AgentSessionStopInput {
   agentSessionId: string;
 }
@@ -487,6 +504,9 @@ export interface AgentSessionEngine {
   submitInteractionResponse(
     input: AgentSessionSubmitInteractionResponseInput
   ): boolean;
+  submitPrompt(
+    input: AgentSessionSubmitPromptInput
+  ): AgentSessionSubmitPromptResult;
   stopSession(input: AgentSessionStopInput): void;
   subscribe(listener: AgentSessionEngineListener): () => void;
   updateSessionSettings(input: AgentSessionUpdateSettingsInput): void;
@@ -559,6 +579,7 @@ import type {
   AgentActivitySessionSettings,
   AgentActivitySubmitDiagnostics,
   AgentActivitySubmitInteractiveInput,
+  AgentActivitySubmitSettingsPatch,
   AgentPromptContentBlock
 } from "../types.ts";
 import type { AgentActivityRailPlacement } from "../railPlacement.types.ts";

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.spec.ts
@@ -219,6 +219,76 @@ describe("interaction submissions", () => {
   });
 });
 
+describe("existing-session prompt submission", () => {
+  it("routes submission through the Engine semantic operation", () => {
+    const goalControl = vi.fn(async () => undefined);
+    const { input, draftByScopeKeyRef, sessionEngine, setDraftByScopeKey } =
+      createGoalControlInput(goalControl as never);
+    draftByScopeKeyRef.current = {
+      "session:session-1": draft("continue")
+    };
+    const submitPrompt = vi
+      .spyOn(sessionEngine, "submitPrompt")
+      .mockReturnValue({ accepted: true, queued: false });
+    const { result } = renderHook(() =>
+      useAgentGUISubmitInteractionActions(input)
+    );
+
+    act(() =>
+      result.current.submitPrompt(
+        [{ type: "text", text: "continue" }],
+        " Continue ",
+        {
+          capabilityRefs: [{ capability: "tutti", source: "slash_command" }],
+          requiredSettingsPatch: { computerUse: true }
+        }
+      )
+    );
+
+    expect(submitPrompt).toHaveBeenCalledWith({
+      agentSessionId: "session-1",
+      capabilityRefs: [{ capability: "tutti", source: "slash_command" }],
+      clientSubmitId: expect.any(String),
+      content: [{ type: "text", text: "continue" }],
+      displayPrompt: " Continue ",
+      requiredSettingsPatch: { computerUse: true },
+      runtimeContent: [{ type: "text", text: "continue" }],
+      submitDiagnostics: expect.objectContaining({
+        source: "agent-gui"
+      })
+    });
+    expect(setDraftByScopeKey).toHaveBeenCalledTimes(1);
+    expect(
+      agentComposerDraftPrompt(draftByScopeKeyRef.current["session:session-1"]!)
+    ).toBe("");
+  });
+
+  it("keeps the draft when the Engine does not admit the submission", () => {
+    const goalControl = vi.fn(async () => undefined);
+    const { input, draftByScopeKeyRef, sessionEngine, setDraftByScopeKey } =
+      createGoalControlInput(goalControl as never);
+    draftByScopeKeyRef.current = {
+      "session:session-1": draft("continue")
+    };
+    vi.spyOn(sessionEngine, "submitPrompt").mockReturnValue({
+      accepted: false,
+      queued: false
+    });
+    const { result } = renderHook(() =>
+      useAgentGUISubmitInteractionActions(input)
+    );
+
+    act(() =>
+      result.current.submitPrompt([{ type: "text", text: "continue" }])
+    );
+
+    expect(setDraftByScopeKey).not.toHaveBeenCalled();
+    expect(
+      agentComposerDraftPrompt(draftByScopeKeyRef.current["session:session-1"]!)
+    ).toBe("continue");
+  });
+});
+
 describe("goal controls", () => {
   it("publishes an optimistic goal before the control API settles", async () => {
     const goalControl = vi.fn(() => new Promise<void>(() => {}));

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.ts
@@ -1,6 +1,4 @@
 import {
-  selectEngineHasVisibleQueuedSubmit,
-  selectPendingSubmitsForSession,
   type AgentActivityGoalControlAction,
   type AgentActivityInteraction,
   type AgentActivityTurn,
@@ -295,17 +293,15 @@ export function useAgentGUISubmitInteractionActions(
           targetMode: "existing"
         }
       });
-      sessionEngine.dispatch({
+      const { accepted, queued } = sessionEngine.submitPrompt({
         agentSessionId,
         ...(options?.capabilityRefs?.length
           ? { capabilityRefs: options.capabilityRefs }
           : {}),
         clientSubmitId: submitTrace.clientSubmitId,
         content: normalizedContent,
-        expiresAtUnixMs: submittedAtUnixMs + 120_000,
         ...(displayPrompt && displayPrompt.trim() ? { displayPrompt } : {}),
         submitDiagnostics: agentSubmitTraceDiagnostics(submitTrace),
-        requestedAtUnixMs: submittedAtUnixMs,
         ...(options?.requiredSettingsPatch
           ? {
               requiredSettingsPatch: {
@@ -318,21 +314,8 @@ export function useAgentGUISubmitInteractionActions(
           : options?.sendNow === true
             ? { routing: "send_now" as const }
             : {}),
-        runtimeContent: toRuntimeSendContent(normalizedContent),
-        type: "submit/requested",
-        workspaceId
+        runtimeContent: toRuntimeSendContent(normalizedContent)
       });
-      const queued = Boolean(
-        selectEngineHasVisibleQueuedSubmit(
-          sessionEngine.getSnapshot(),
-          agentSessionId,
-          submitTrace.clientSubmitId
-        )
-      );
-      const accepted = selectPendingSubmitsForSession(
-        sessionEngine.getSnapshot(),
-        agentSessionId
-      ).some((record) => record.clientSubmitId === submitTrace.clientSubmitId);
       submitTrace.queued = queued;
       setDetailError(null);
       // Clear the composer optimistically the instant the engine takes the


### PR DESCRIPTION
## Summary

- add `AgentSessionEngine.submitPrompt` as the semantic entry point for existing-Session Prompt admission
- migrate Desktop AgentGUI and Native Mobile away from raw `submit/requested` construction
- make the Engine own workspace scope, timestamps, routing, the shared 120-second confirmation window, and accepted/queued admission projection
- preserve caller-owned stable `clientSubmitId` for draft recovery and idempotent retry
- clear Desktop and Mobile drafts only after Engine admission
- document the updated frontend Engine boundary

## Why

Desktop and Mobile were assembling the same Engine protocol independently. Desktop used a 120-second confirmation window and checked Engine admission before clearing the draft, while Mobile used 60 seconds and cleared unconditionally. That duplicated policy created behavioral drift and made future fixes surface-specific.

This change moves the shared application semantics into Activity Core without moving UI-local draft bookkeeping or new-Session activation policy into the Engine method.

## Impact

Existing-session sends now follow the same admission and queue semantics on Desktop and Mobile. New-session activation remains unchanged and is intentionally out of scope.

## Validation

- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready` (16 lanes)
- Activity Core: 406 tests passed
- AgentGUI: 2,591 tests passed
- Mobile: 117 tests passed
- Activity Core and AgentGUI package builds passed
- `make dev-gui` smoke: existing-session send reached the daemon; a second submit during an active Turn appeared as one queued Prompt; stopping the Turn paused the queue per existing Desktop behavior

## Documentation

Updated `docs/architecture/agent-activity-packages.md` and `docs/architecture/agent-gui-node.md` with the new semantic submission ownership and Desktop/Mobile responsibilities.