### PR TITLE
fix(agent-gui): preserve workbench interactions

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -70,6 +70,7 @@ import { useDesktopAgentGUIOpenConversationWindow } from "./useDesktopAgentGUIOp
 import { useStableDesktopAgentGUIHostProps } from "./useStableDesktopAgentGUIHostProps.ts";
 import { resolveDesktopAgentGUIEmbeddedDesktopSize } from "./desktopAgentGUIEmbeddedFrame.ts";
 import { scheduleDesktopAgentGUIWorkbenchHydration } from "./desktopAgentGUIWorkbenchHydration.ts";
+import { resolveDesktopAgentGUIWorkbenchBodyVisibility } from "./desktopAgentGUIWorkbenchVisibility.ts";
 import { useDesktopAgentConfigCommerce } from "./useDesktopAgentConfigCommerce.tsx";
 import { hasDesktopLocalTuttiAgent } from "./desktopAgentConfigCommerceContext.ts";
 import { useDesktopAgentGUIComposerFooterAccessory } from "./useDesktopAgentGUIComposerFooterAccessory.tsx";
@@ -718,7 +719,11 @@ function DesktopAgentGUIWorkbenchBodyAdapter({
       visualOcclusionPresentation
     )
   );
-  const isBodyVisible = context.isVisible && isVisuallyExposed;
+  const isBodyVisible = resolveDesktopAgentGUIWorkbenchBodyVisibility({
+    isPresentationVisible: context.isPresentationVisible,
+    isVisible: context.isVisible,
+    isVisuallyExposed
+  });
   const [bodyHydrated, setBodyHydrated] = useState(
     context.isFocused || isBodyVisible
   );

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/desktopAgentGUIWorkbenchModel.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/desktopAgentGUIWorkbenchModel.ts
@@ -236,6 +236,7 @@ export function areDesktopAgentGUIWorkbenchBodyContextsEqual(
       previous.isFocused === next.isFocused &&
       previous.isResizing === next.isResizing &&
       previous.isVisible === next.isVisible &&
+      previous.isPresentationVisible === next.isPresentationVisible &&
       previous.presentationMode === next.presentationMode &&
       previous.node.id === next.node.id &&
       previous.node.isMinimized === next.node.isMinimized &&

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/desktopAgentGUIWorkbenchVisibility.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/desktopAgentGUIWorkbenchVisibility.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveDesktopAgentGUIWorkbenchBodyVisibility } from "./desktopAgentGUIWorkbenchVisibility.ts";
+
+test("keeps a visible Mission Control preview rendering", () => {
+  assert.equal(
+    resolveDesktopAgentGUIWorkbenchBodyVisibility({
+      isPresentationVisible: true,
+      isVisible: false,
+      isVisuallyExposed: false
+    }),
+    true
+  );
+});
+
+test("pauses a fully occluded normal Workbench body", () => {
+  assert.equal(
+    resolveDesktopAgentGUIWorkbenchBodyVisibility({
+      isPresentationVisible: false,
+      isVisible: true,
+      isVisuallyExposed: false
+    }),
+    false
+  );
+});

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/desktopAgentGUIWorkbenchVisibility.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/desktopAgentGUIWorkbenchVisibility.ts
@@ -1,0 +1,10 @@
+export function resolveDesktopAgentGUIWorkbenchBodyVisibility(input: {
+  isPresentationVisible?: boolean;
+  isVisible: boolean;
+  isVisuallyExposed: boolean;
+}): boolean {
+  return (
+    input.isPresentationVisible === true ||
+    (input.isVisible && input.isVisuallyExposed)
+  );
+}

--- a/docs/conventions/workbench.md
+++ b/docs/conventions/workbench.md
@@ -67,6 +67,10 @@ Rules:
 - project normal-window visibility through the mounted body context; it is
   false while minimized, Genie-hidden, or in Mission Control, so heavy child
   presentation can wait without importing Workbench animation state
+- project Mission Control preview visibility separately from normal-window
+  visibility. A preview that Workbench paints must keep its body rendering even
+  when normal-window visibility is false; a preview filtered out of the
+  presentation must remain paused
 - separate a node's own exposure from whether it may occlude lower nodes.
   Scale restore, shell frame transitions, and onboarding entry keep their own
   body visible but do not cover lower bodies until the matching DOM animation

--- a/packages/agent/gui/actions/workspaceFilePathCandidate.ts
+++ b/packages/agent/gui/actions/workspaceFilePathCandidate.ts
@@ -32,7 +32,9 @@ export function resolveWorkspaceFilePathCandidate({
     return null;
   }
 
-  const normalizedPath = normalizeWorkspaceFilePath(rawPath);
+  const normalizedPath = normalizeWorkspaceFilePath(
+    stripWorkspaceFileLineAnchor(rawPath)
+  );
   if (isUnsupportedSpecialWorkspaceFilePath(normalizedPath)) {
     return null;
   }
@@ -140,6 +142,15 @@ export function decodeWorkspaceLinkPath(path: string): string {
   } catch {
     return path;
   }
+}
+
+/**
+ * Agent Markdown source links use a terminal `:line` suffix. File launchers
+ * operate on filesystem paths, so remove that presentation-only location
+ * anchor before resolving the path.
+ */
+function stripWorkspaceFileLineAnchor(path: string): string {
+  return path.replace(/:[1-9]\d*$/, "");
 }
 
 export function workspaceFilePathBasename(path: string): string {

--- a/packages/agent/gui/actions/workspaceLinkActions.spec.ts
+++ b/packages/agent/gui/actions/workspaceLinkActions.spec.ts
@@ -42,6 +42,35 @@ describe("resolveWorkspaceFileLinkAction", () => {
     });
   });
 
+  it("opens Markdown source links by removing their terminal line anchor", () => {
+    expect(
+      resolveWorkspaceFileLinkAction({
+        path: "/Users/test/project/tutti/src/App.tsx:87",
+        workspaceRoot: "/Users/test/project/tutti",
+        basePath: "/Users/test/project/tutti",
+        source: "agent-markdown"
+      })
+    ).toMatchObject({
+      type: "open-workspace-file",
+      path: "/Users/test/project/tutti/src/App.tsx",
+      directoryPath: "/Users/test/project/tutti/src",
+      workspaceRoot: "/Users/test/project/tutti"
+    });
+
+    expect(
+      resolveWorkspaceFileLinkAction({
+        path: "C:\\Users\\test\\project\\tutti\\src\\App.tsx:87",
+        workspaceRoot: "C:\\Users\\test\\project\\tutti",
+        source: "agent-markdown"
+      })
+    ).toMatchObject({
+      type: "open-workspace-file",
+      path: "C:/Users/test/project/tutti/src/App.tsx",
+      directoryPath: "C:/Users/test/project/tutti/src",
+      workspaceRoot: "C:/Users/test/project/tutti"
+    });
+  });
+
   it("allows local absolute paths when the workspace root is the filesystem root", () => {
     expect(
       resolveWorkspaceFileLinkAction({

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -3892,6 +3892,7 @@ aside.workspace-agents-status-panel
   min-width: 0;
   min-height: 36px;
   max-height: 132px;
+  overflow-y: auto;
   border: 0;
   border-radius: 0;
   background: transparent;
@@ -3900,11 +3901,34 @@ aside.workspace-agents-status-panel
   line-height: 1.45;
   padding: 9px 10px;
   resize: vertical;
+  scrollbar-width: thin;
+  scrollbar-color: var(--transparency-hover) transparent;
+  scrollbar-gutter: stable;
 }
 
 .agent-gui-conversation__interactive-feedback-composer
   .agent-gui-conversation__interactive-prompt-textarea::placeholder {
   color: var(--text-placeholder);
+}
+
+.agent-gui-conversation__interactive-feedback-composer
+  .agent-gui-conversation__interactive-prompt-textarea::-webkit-scrollbar {
+  display: block;
+  width: 4px;
+  height: 4px;
+}
+
+.agent-gui-conversation__interactive-feedback-composer
+  .agent-gui-conversation__interactive-prompt-textarea::-webkit-scrollbar-track,
+.agent-gui-conversation__interactive-feedback-composer
+  .agent-gui-conversation__interactive-prompt-textarea::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+.agent-gui-conversation__interactive-feedback-composer
+  .agent-gui-conversation__interactive-prompt-textarea::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+  background: var(--transparency-hover);
 }
 
 .agent-gui-conversation__interactive-feedback-send-button {

--- a/packages/workbench/surface/src/host/WorkbenchHostNodeBodyRenderer.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostNodeBodyRenderer.tsx
@@ -35,6 +35,8 @@ function areWorkbenchHostNodeBodyRendererPropsEqual(
     previousContext.isFocused !== nextContext.isFocused ||
     previousContext.isResizing !== nextContext.isResizing ||
     previousContext.isVisible !== nextContext.isVisible ||
+    previousContext.isPresentationVisible !==
+      nextContext.isPresentationVisible ||
     previousContext.presentationMode !== nextContext.presentationMode ||
     !areWorkbenchOptionalSizesEqual(
       previousContext.previewViewport,

--- a/packages/workbench/surface/src/host/hostNodeContext.test.ts
+++ b/packages/workbench/surface/src/host/hostNodeContext.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { WorkbenchNode } from "../core/types.ts";
+import type { WorkbenchRenderNodeContext } from "../react/types.ts";
+import type {
+  WorkbenchHostHandle,
+  WorkbenchHostNodeData,
+  WorkbenchHostNodeDefinition
+} from "./types.ts";
+import { createWorkbenchHostNodeBodyContext } from "./hostNodeContext.ts";
+
+test("marks a Mission Control preview as presentation-visible", () => {
+  const node = createNode("visible");
+  const context = createRenderContext(node, new Set([node.id]));
+
+  const bodyContext = createWorkbenchHostNodeBodyContext({
+    context,
+    definition: {} as WorkbenchHostNodeDefinition,
+    externalState: {
+      externalNodeState: null,
+      externalWorkspaceState: null
+    },
+    host: createHost(),
+    isVisible: false,
+    workspaceId: "workspace-1"
+  });
+
+  assert.equal(bodyContext.isVisible, false);
+  assert.equal(bodyContext.isPresentationVisible, true);
+});
+
+test("does not mark a filtered Mission Control node as presentation-visible", () => {
+  const node = createNode("filtered");
+  const bodyContext = createWorkbenchHostNodeBodyContext({
+    context: createRenderContext(node, new Set()),
+    definition: {} as WorkbenchHostNodeDefinition,
+    externalState: {
+      externalNodeState: null,
+      externalWorkspaceState: null
+    },
+    host: createHost(),
+    isVisible: false,
+    workspaceId: "workspace-1"
+  });
+
+  assert.equal(bodyContext.isPresentationVisible, false);
+});
+
+function createNode(id: string): WorkbenchNode<WorkbenchHostNodeData> {
+  return {
+    data: {
+      instanceId: id,
+      typeId: "test"
+    },
+    displayMode: "floating",
+    frame: { height: 240, width: 320, x: 0, y: 0 },
+    id,
+    isMinimized: false,
+    kind: "test",
+    restoreFrame: null,
+    title: id
+  };
+}
+
+function createRenderContext(
+  node: WorkbenchNode<WorkbenchHostNodeData>,
+  visibleNodeIds: ReadonlySet<string>
+): WorkbenchRenderNodeContext<WorkbenchHostNodeData> {
+  return {
+    controller:
+      {} as WorkbenchRenderNodeContext<WorkbenchHostNodeData>["controller"],
+    isDragging: false,
+    isResizing: false,
+    layout: {
+      frame: node.frame,
+      isFocused: false,
+      presentation: {
+        frameByNodeId: new Map([[node.id, node.frame]]),
+        mode: "mission-control",
+        visibleNodeIds
+      },
+      zIndex: 1
+    },
+    node
+  };
+}
+
+function createHost(): WorkbenchHostHandle {
+  return {
+    getSnapshot() {
+      return { nodes: [], nodeStack: [] };
+    }
+  } as unknown as WorkbenchHostHandle;
+}

--- a/packages/workbench/surface/src/host/hostNodeContext.ts
+++ b/packages/workbench/surface/src/host/hostNodeContext.ts
@@ -64,6 +64,9 @@ export function createWorkbenchHostNodeBodyContext<
       selectFocusedWorkbenchNode(host.getSnapshot())?.id === context.node.id,
     isResizing: context.isResizing,
     isVisible,
+    isPresentationVisible:
+      context.layout.presentation?.mode === "mission-control" &&
+      context.layout.presentation.visibleNodeIds.has(context.node.id),
     presentationMode: context.layout.presentation?.mode ?? null,
     node: context.node,
     setNodeRuntimeState(state) {

--- a/packages/workbench/surface/src/host/types.ts
+++ b/packages/workbench/surface/src/host/types.ts
@@ -413,6 +413,11 @@ export interface WorkbenchHostNodeBodyContext<
    * False while minimized, Genie-hidden, or inside Mission Control.
    */
   isVisible: boolean;
+  /**
+   * True when a non-normal Workbench presentation currently paints this node.
+   * Omitted by direct hosts that do not use a Workbench presentation.
+   */
+  isPresentationVisible?: boolean;
   /** Current host presentation mode; null for the normal window layout. */
   presentationMode?: WorkbenchSurfacePresentation["mode"] | null;
   node: WorkbenchNode<WorkbenchHostNodeData>;


### PR DESCRIPTION
## Summary
- keep Mission Control previews rendered while preserving normal-window occlusion pauses
- resolve Agent Markdown file links that include terminal line anchors
- make interactive feedback composer overflow scrollable

## Tests
- `pnpm check:changed -- --push-ready`

## Notes
- Includes the complete user-authorized working-tree diff
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1851" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->