### PR TITLE
fix(events): recover event stream setup failures

### DIFF
--- a/packages/clients/tuttid-ts/src/eventStreamClient.test.ts
+++ b/packages/clients/tuttid-ts/src/eventStreamClient.test.ts
@@ -843,6 +843,72 @@ test("tuttid event stream client tears down a failed handshake before retrying",
   client.dispose();
 });
 
+test("tuttid event stream client reconnects after URL resolution recovers", async () => {
+  const sockets: FakeEventStreamSocket[] = [];
+  const reconnectScheduler = new FakeReconnectScheduler();
+  const connectionStates: string[] = [];
+  let resolveCalls = 0;
+  const client = createTuttidEventStreamClient({
+    reconnect: reconnectScheduler.config,
+    async resolveUrl() {
+      resolveCalls += 1;
+      if (resolveCalls === 1) {
+        throw new Error("Desktop daemon endpoint is not ready yet.");
+      }
+      return "ws://127.0.0.1:4545/v1/events/ws?access_token=token-1";
+    },
+    webSocketFactory(url) {
+      const socket = new FakeEventStreamSocket(url);
+      sockets.push(socket);
+      return socket;
+    }
+  });
+
+  client.subscribeConnectionState((state) => {
+    connectionStates.push(state);
+  });
+  const unsubscribe = client.subscribe("preferences.desktop.updated", () => {});
+
+  await assert.rejects(
+    client.connect(),
+    /Desktop daemon endpoint is not ready yet/
+  );
+  assert.equal(resolveCalls, 1);
+  assert.equal(reconnectScheduler.timeoutCount(), 1);
+  assert.deepEqual(connectionStates, ["connecting", "disconnected"]);
+
+  reconnectScheduler.tickTimeout();
+  await Promise.resolve();
+  const reconnectSocket = sockets[0];
+  assert.ok(reconnectSocket);
+  assert.equal(resolveCalls, 2);
+
+  reconnectSocket.emitMessage({
+    catalogRevision: businessEventCatalogRevision,
+    kind: "ready",
+    protocolVersion: 1,
+    serverTime: "2026-05-30T08:00:00Z"
+  });
+  await Promise.resolve();
+
+  assert.deepEqual(reconnectSocket.sent, [
+    {
+      kind: "subscribe",
+      requestId: "1",
+      topics: ["preferences.desktop.updated"]
+    }
+  ]);
+  assert.deepEqual(connectionStates, [
+    "connecting",
+    "disconnected",
+    "connecting",
+    "connected"
+  ]);
+
+  unsubscribe();
+  client.dispose();
+});
+
 test("tuttid event stream client sends heartbeat pings after ready and clears pong timeout on pong", async () => {
   const sockets: FakeEventStreamSocket[] = [];
   const scheduler = new FakeHeartbeatScheduler();

--- a/packages/events/stream-core/src/eventStreamClient.ts
+++ b/packages/events/stream-core/src/eventStreamClient.ts
@@ -321,7 +321,7 @@ export function createEventStreamClient<
       return connectPromise;
     }
 
-    connectPromise = (async () => {
+    const currentConnectPromise = (async () => {
       notifyConnectionState("connecting");
       const url = await input.resolveUrl();
       const nextSocket = webSocketFactory(url);
@@ -439,9 +439,22 @@ export function createEventStreamClient<
         nextSocket.addEventListener("close", closeListener);
       });
     })();
+    connectPromise = currentConnectPromise;
+    void currentConnectPromise.catch(() => {
+      if (connectPromise !== currentConnectPromise) {
+        return;
+      }
 
-    connectPromise.catch(() => {});
-    return connectPromise;
+      const failedSocket = socket;
+      if (failedSocket) {
+        resetSocketState(failedSocket);
+        failedSocket.close(handshakeFailureCloseCode, "handshake_failed");
+      } else {
+        resetConnectionState();
+      }
+      scheduleReconnect();
+    });
+    return currentConnectPromise;
   }
 
   function createRequestID(): string {
@@ -573,6 +586,10 @@ export function createEventStreamClient<
     if (socket === nextSocket) {
       socket = null;
     }
+    resetConnectionState();
+  }
+
+  function resetConnectionState(): void {
     connectPromise = null;
     ready = false;
     stopHeartbeat();


### PR DESCRIPTION
## Summary

- clear a failed event-stream connection attempt when URL resolution or socket setup rejects
- transition to `disconnected` and schedule the existing reconnect backoff instead of retaining a permanently rejected `connectPromise`
- add a regression test proving that an initially unavailable daemon endpoint is resolved again, reconnects, and flushes existing subscriptions

## Root cause

If `resolveUrl()` rejected before a WebSocket was created, the failure bypassed the socket handshake cleanup path. The rejected `connectPromise` remained cached, so every later `connect()` returned the same rejection and no reconnect was scheduled. A transient daemon-readiness race could therefore leave renderer business events permanently disconnected while HTTP requests continued to work.

## Impact

Desktop activity updates recover automatically after a transient daemon endpoint readiness failure, preventing Agent conversations from appearing stuck until they are reopened.

## Validation

- `pnpm check:changed -- --push-ready` (11 lanes passed)
