### PR TITLE
fix(agent-gui): backport signed-out Tutti usage chrome fix

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/useDesktopAgentConfigCommerce.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/useDesktopAgentConfigCommerce.test.ts
@@ -38,7 +38,7 @@ test("agent config Commerce is scoped to the self-owned Tutti Agent target", () 
   );
 });
 
-test("agent config Commerce falls back while disabled or signed out", () => {
+test("agent config Commerce renders content only while enabled and signed in", () => {
   assert.equal(
     shouldRenderDesktopAgentConfigCommerce({
       context: context(),

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/useDesktopAgentConfigCommerce.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/useDesktopAgentConfigCommerce.tsx
@@ -1,5 +1,8 @@
 import { useCallback, useMemo } from "react";
-import type { AgentGUIProps } from "@tutti-os/agent-gui";
+import {
+  AgentGUIConfigAccountFallbackSuppressed,
+  type AgentGUIProps
+} from "@tutti-os/agent-gui";
 import type { CommerceMenuState } from "@tutti-os/commerce";
 import { AgentConfigCommerceContent } from "@tutti-os/commerce/react";
 import { useService } from "@tutti-os/infra/di";
@@ -99,18 +102,22 @@ export function useDesktopAgentConfigCommerce(enabled: boolean) {
     NonNullable<AgentGUIProps["renderSlots"]["agentConfigAccount"]>
   >(
     (context) => {
+      if (!enabled || !isDesktopLocalTuttiAgentConfigContext(context)) {
+        return null;
+      }
       if (
         !shouldRenderDesktopAgentConfigCommerce({
           context,
-          enabled: enabled && commerceProjection.commerceVisible,
+          enabled: commerceProjection.commerceVisible,
           hasAccount
         })
       ) {
-        return null;
+        return <AgentGUIConfigAccountFallbackSuppressed />;
       }
       return (
         <AgentConfigCommerceContent
           accountName={accountName}
+          showAccountIdentity={false}
           state={commerceState}
           labels={{
             account: t("workspace.accountMenu.title"),

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1489,16 +1489,20 @@ start a Commerce request.
 The optional `renderSlots.agentConfigAccount` is a presentation-only Host
 chrome seam for the exact selected Agent Target. Its paired
 `hostActions.onAgentConfigMenuOpen` notification lets the Host refresh account
-state without hiding workflow in the render slot. Returning no content keeps
-the provider account and quota block unchanged. AgentGUI never derives billing
-ownership from provider identity.
+state without hiding workflow in the render slot. Returning no renderable
+content keeps the provider account and quota block unchanged. Returning the
+package-owned `AgentGUIConfigAccountFallbackSuppressed` marker suppresses those
+generic fallback rows without adding Host content.
 
 Tutti Desktop fills this seam only for its self-owned local Tutti Agent target.
 The Desktop Account service remains the source of account, membership, credit,
 and Commerce-link state; opening the target menu asks that service to refresh,
-and the render slot stays request-free. Signed-out, shared, and non-Tutti
-targets return no Host content and retain AgentGUI's provider account and quota
-presentation.
+and the render slot stays request-free. Its compact Agent menu omits the
+redundant Tutti account identity row while retaining credit, membership, and
+account-center actions. A signed-out local Tutti Agent returns the suppression
+marker because the generic provider-account and quota rows do not describe its
+Host-owned account model. Other providers return `null` and retain AgentGUI's
+default provider-account and quota presentation.
 The optional `renderSlots.agentTargetInfo` seam enriches the exact target icon
 in the provider Rail and Conversation Rail. The same
 `AgentGUIAgentTargetInfoRenderer` may be passed to

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAccountConfig.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAccountConfig.spec.tsx
@@ -2,7 +2,10 @@ import "@testing-library/jest-dom/vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentGUIViewLabels } from "../AgentGUINodeView";
-import { AgentGUIConfigMenu } from "./AgentGUIAccountConfig";
+import {
+  AgentGUIConfigAccountFallbackSuppressed,
+  AgentGUIConfigMenu
+} from "./AgentGUIAccountConfig";
 
 afterEach(cleanup);
 
@@ -128,4 +131,35 @@ describe("AgentGUIConfigMenu", () => {
       expect(screen.getByText("Weekly")).toBeInTheDocument();
     }
   );
+
+  it("hides generic account and usage rows when Host claims the surface without content", () => {
+    render(
+      <AgentGUIConfigMenu
+        environmentSetupVisible={false}
+        labels={labels}
+        providerScopedActionsVisible
+        accountContent={<AgentGUIConfigAccountFallbackSuppressed />}
+        provider="tutti-agent"
+        providerAuthAccountLabel="233749"
+        slashStatusLimits={[]}
+        slashStatusLimitsLoading={false}
+        slashStatusLimitsResolvedEmpty={false}
+        slashStatusUsageCapturedAtUnixMs={null}
+        slashStatusUsageDidFail
+        slashStatusUsageAttempted
+        onAgentConfigMenuOpen={vi.fn()}
+        onOpenAgentEnvSetup={vi.fn()}
+        onOpenAgentSettings={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "More" }));
+
+    expect(screen.queryByText("Limits")).not.toBeInTheDocument();
+    expect(screen.queryByText("Unavailable")).not.toBeInTheDocument();
+    expect(screen.queryByText("Refresh failed")).not.toBeInTheDocument();
+    expect(screen.queryByText("tutti-agent account")).not.toBeInTheDocument();
+    expect(screen.queryByText("233749")).not.toBeInTheDocument();
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+  });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAccountConfig.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAccountConfig.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from "react";
+import { isValidElement, useState, type ReactNode } from "react";
 import { Gauge, Wrench } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@tutti-os/ui-system";
 import { MoreHorizontalIcon } from "@tutti-os/ui-system/icons";
@@ -30,6 +30,10 @@ interface AgentGUIConfigMenuProps {
   onOpenAgentSettings: () => void;
 }
 
+export function AgentGUIConfigAccountFallbackSuppressed(): null {
+  return null;
+}
+
 export function AgentGUIConfigMenu({
   accountContent,
   environmentSetupVisible,
@@ -57,8 +61,15 @@ export function AgentGUIConfigMenu({
     ? labels.slashStatusProviderAccount(provider.trim())
     : null;
   const accountTitle = providerDisplayTitle ?? labels.slashStatusAccount;
+  const accountFallbackSuppressed =
+    isValidElement(accountContent) &&
+    accountContent.type === AgentGUIConfigAccountFallbackSuppressed;
   const hasAccountContent =
-    Boolean(accountContent) && typeof accountContent !== "boolean";
+    !accountFallbackSuppressed &&
+    Boolean(accountContent) &&
+    typeof accountContent !== "boolean";
+  const providerAccountFallbackVisible =
+    !accountFallbackSuppressed && !hasAccountContent;
   return (
     <Popover
       open={open}
@@ -99,7 +110,7 @@ export function AgentGUIConfigMenu({
               </div>
             </>
           ) : null}
-          {!hasAccountContent &&
+          {providerAccountFallbackVisible &&
           providerScopedActionsVisible &&
           providerAuthAccountLabel ? (
             <>
@@ -132,7 +143,7 @@ export function AgentGUIConfigMenu({
               ) : null}
             </>
           ) : null}
-          {!hasAccountContent &&
+          {providerAccountFallbackVisible &&
           providerScopedActionsVisible &&
           (slashStatusLimits.length > 0 ||
             slashStatusUsageAttempted ||

--- a/packages/agent/gui/index.ts
+++ b/packages/agent/gui/index.ts
@@ -17,6 +17,7 @@ export type {
   AgentGUIReferenceProvenanceFilterCatalog
 } from "./AgentGUI";
 export type { AgentGUIAgentConfigMenuContext } from "./agent-gui/agentGuiNode/AgentGUINode.types";
+export { AgentGUIConfigAccountFallbackSuppressed } from "./agent-gui/agentGuiNode/view/AgentGUIAccountConfig";
 export type {
   TuttiModePlanAssignmentAgentDetail,
   TuttiModePlanAssignmentAgentOption,

--- a/packages/commerce/web/src/react/AgentConfigCommerceContent.spec.tsx
+++ b/packages/commerce/web/src/react/AgentConfigCommerceContent.spec.tsx
@@ -153,6 +153,23 @@ describe("AgentConfigCommerceContent", () => {
     expect(onRefresh).toHaveBeenCalledOnce();
   });
 
+  it("can omit the account identity row for compact Agent config menus", () => {
+    render(
+      <AgentConfigCommerceContent
+        accountName="Mia"
+        showAccountIdentity={false}
+        state={state()}
+        labels={labels}
+        onRefresh={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText("Tutti Agent account")).not.toBeInTheDocument();
+    expect(screen.queryByText("Mia")).not.toBeInTheDocument();
+    expect(screen.getByText("Credits")).toBeInTheDocument();
+    expect(screen.getByText("Membership")).toBeInTheDocument();
+  });
+
   it("uses the free membership fallback without inventing a paid tier", () => {
     render(
       <AgentConfigCommerceContent

--- a/packages/commerce/web/src/react/AgentConfigCommerceContent.tsx
+++ b/packages/commerce/web/src/react/AgentConfigCommerceContent.tsx
@@ -23,6 +23,7 @@ export interface AgentConfigCommerceLabels {
 
 export interface AgentConfigCommerceContentProps {
   accountName: string | null;
+  showAccountIdentity?: boolean;
   state: CommerceMenuState;
   labels: AgentConfigCommerceLabels;
   onRefresh(): void;
@@ -34,6 +35,7 @@ const menuItemClassName = `${menuItemBaseClassName} w-full px-2`;
 
 export function AgentConfigCommerceContent({
   accountName,
+  showAccountIdentity = true,
   state,
   labels,
   onRefresh
@@ -58,20 +60,24 @@ export function AgentConfigCommerceContent({
       className="flex min-w-0 flex-col gap-1"
       data-testid="agent-config-commerce-content"
     >
-      <div className="flex min-w-0 flex-col gap-1 p-2">
-        <div className="flex min-w-0 items-center gap-2">
-          <UserLinedIcon aria-hidden="true" size={16} />
-          <span className="truncate text-[13px] font-semibold leading-4">
-            {labels.account}
-          </span>
-        </div>
-        <span className="truncate pl-6 text-[13px] leading-5 text-[var(--text-secondary)]">
-          {accountNameLabel}
-        </span>
-      </div>
-      <div className="px-2">
-        <span className="block h-px bg-[var(--border-1)]" />
-      </div>
+      {showAccountIdentity ? (
+        <>
+          <div className="flex min-w-0 flex-col gap-1 p-2">
+            <div className="flex min-w-0 items-center gap-2">
+              <UserLinedIcon aria-hidden="true" size={16} />
+              <span className="truncate text-[13px] font-semibold leading-4">
+                {labels.account}
+              </span>
+            </div>
+            <span className="truncate pl-6 text-[13px] leading-5 text-[var(--text-secondary)]">
+              {accountNameLabel}
+            </span>
+          </div>
+          <div className="px-2">
+            <span className="block h-px bg-[var(--border-1)]" />
+          </div>
+        </>
+      ) : null}
       <div className="flex min-w-0 items-center">
         <button
           type="button"


### PR DESCRIPTION
Backport of #1841 to release/0729.\n\nCherry-picked commit: 37c9d817ca8910b85d3a5a42bef81b09756d490a\nRelease commit: f2aceded8
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1857" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->