### PR TITLE
feat(browser): import Dia cookie profiles

### DIFF
--- a/apps/desktop/src/shared/i18n/locales/en.ts
+++ b/apps/desktop/src/shared/i18n/locales/en.ts
@@ -1,11 +1,11 @@
 export const en = {
   browser: {
     chromeImportNotification: {
-      completed: "Imported {{imported}} Cookies from Chrome.",
-      failed: "Chrome Cookie import did not complete.",
+      completed: "Imported {{imported}} login Cookies.",
+      failed: "Login Cookie import did not complete.",
       partial:
-        "Imported {{imported}} Cookies from Chrome; some entries were skipped or failed.",
-      title: "Chrome login state import"
+        "Imported {{imported}} login Cookies; some entries were skipped or failed.",
+      title: "Login state import"
     }
   },
   common: {

--- a/apps/desktop/src/shared/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/shared/i18n/locales/zh-CN.ts
@@ -3,10 +3,10 @@ import type { TranslationDictionary } from "../core/resources.ts";
 export const zhCN = {
   browser: {
     chromeImportNotification: {
-      completed: "已从 Chrome 导入 {{imported}} 项 Cookie",
-      failed: "Chrome Cookie 导入未完成",
-      partial: "已从 Chrome 导入 {{imported}} 项 Cookie，部分条目被跳过或失败",
-      title: "Chrome 登录状态导入"
+      completed: "已导入 {{imported}} 项登录 Cookie",
+      failed: "登录 Cookie 导入未完成",
+      partial: "已导入 {{imported}} 项登录 Cookie，部分条目被跳过或失败",
+      title: "登录状态导入"
     }
   },
   common: {

--- a/docs/architecture/browser-node-package.md
+++ b/docs/architecture/browser-node-package.md
@@ -138,8 +138,8 @@ The Browser Node package owns:
 - guest preload bridge framework
 - guest `window.open` and link interception
 - generic runtime preview proxy mechanics
-- the reusable macOS Chrome Stable Profile, SQLite snapshot, Keychain, and
-  Cookie decryption adapter
+- the reusable macOS Chrome Stable and Dia Profile, SQLite snapshot, Keychain,
+  and Cookie decryption adapter
 - default package i18n resources for generic browser behavior
 - an optional host-rendered Browser Home slot for empty tabs; the host owns
   service discovery and product-specific shortcuts while the package owns
@@ -251,10 +251,10 @@ The package validates each entry and writes it only to the registered guest's
 Electron session Cookie store. Invalid or rejected entries are counted and
 skipped without logging their values.
 
-Hosts may additionally inject a renderer-safe Chrome Cookie capability. The
+Hosts may additionally inject a renderer-safe Chrome and Dia Cookie capability. The
 Browser package owns its opaque Profile/display contracts, selection and
 prompt state model, normalized write aggregation, and same-`Electron.Session`
-Browser refresh behavior. Its macOS adapter owns Chrome-specific discovery,
+Browser refresh behavior. Its macOS adapter owns Chrome- and Dia-specific discovery,
 absolute paths, database snapshots, OS credential access, decryption, and
 schema/integrity compatibility checks. Hosts own only enablement, diagnostics,
 notification, and registration policy. Preparation must complete before the
@@ -271,10 +271,11 @@ refresh additionally requires `sessionPartition === null`, so custom Workspace
 App Sessions are excluded even if a host accidentally shares an Electron
 Session object with an ordinary Browser.
 
-Tutti's first adapter supports macOS Chrome Stable at its standard User Data
-root and imports only ordinary, non-partitioned Cookies. It deliberately omits
-CHIPS, custom Chrome roots, non-Chrome Chromium browsers, incognito and Guest
-profiles, Workspace App sessions, and all non-Cookie browser data. The Desktop
+Tutti's macOS adapter supports Chrome Stable at its standard User Data root and
+Dia at `~/Library/Application Support/Dia/User Data`; it imports only ordinary,
+non-partitioned Cookies. It deliberately omits CHIPS, custom browser roots,
+other Chromium browsers, incognito and Guest profiles, Workspace App sessions,
+and all non-Cookie browser data. The Desktop
 renderer supplies the global versioned prompt-dismissal adapter; the reusable
 package does not embed a Tutti preference key.
 

--- a/packages/browser/workbench-node/README.md
+++ b/packages/browser/workbench-node/README.md
@@ -18,9 +18,9 @@ operating-system file open/reveal behavior are supplied by the host. Cookie
 file contents stay in the main process and are written only to the registered
 guest session.
 
-## Chrome login-state import
+## Chrome and Dia login-state import
 
-The optional Chrome import capability is host-injected. The Browser package
+The optional Chrome and Dia import capability is host-injected. The Browser package
 owns renderer-safe profile contracts, Profile selection and prompt UI,
 normalized non-partitioned Cookie writes, aggregate results, and refreshing
 every registered ordinary Browser Node that shares the target Electron
@@ -30,12 +30,13 @@ feature-toggle and logging policy, then inject the returned discovery and
 preparation callbacks into the Electron main registration. The package does
 not own a product preference key.
 
-The macOS adapter currently supports only Google Chrome Stable at the standard
-`~/Library/Application Support/Google/Chrome` location. It
-discovers `Default` and `Profile N` entries from `Local State`, prepares a
-consistent SQLite snapshot, obtains Chrome Safe Storage from Keychain only
-after an explicit import, decrypts `v10` values, and validates the version 24+
-host hash before returning normalized Cookies to the Browser package. Paths,
+The macOS adapter supports Google Chrome Stable at the standard
+`~/Library/Application Support/Google/Chrome` location and Dia at
+`~/Library/Application Support/Dia/User Data`. It discovers `Default` and
+`Profile N` entries from each browser's `Local State`, prepares a consistent
+SQLite snapshot, obtains the selected browser's Safe Storage secret from
+Keychain only after an explicit import, decrypts `v10` values, and validates
+the version 24+ host hash before returning normalized Cookies to the Browser package. Paths,
 database contents, secrets, keys, decrypted values, and Cookie identifiers
 never cross into renderer code. A validated local Profile picture may cross as
 a size-limited PNG/JPEG data URL; local paths and Chrome-internal avatar URIs
@@ -73,14 +74,14 @@ registerBrowserNodeElectronMain({
 
 For manual verification on macOS:
 
-1. Open a normal persistent Browser Node and choose a discovered Chrome
+1. Open a normal persistent Browser Node and choose a discovered Chrome or Dia
    Profile from the prompt or Browser settings.
-2. Allow the Chrome Safe Storage Keychain request and verify signed-in sites
+2. Allow the selected browser's Safe Storage Keychain request and verify signed-in sites
    reload in every open Browser Node sharing that Electron session.
 3. Verify independent Profiles, incognito nodes, and Workspace App browsers do
    not reload or inherit the imported Cookies.
-4. With Chrome writing Cookies, repeat the import; if snapshot validation
-   fails, quit Chrome and retry as prompted.
+4. With Chrome or Dia writing Cookies, repeat the import; if snapshot validation
+   fails, quit that browser and retry as prompted.
 
 The package supports ordinary HTTP and HTTPS browser navigation by default. For
 hosts that need local runtime previews, the Electron main integration can also

--- a/packages/browser/workbench-node/src/chrome-cookie-import/macos/chromeCookieImport.test.ts
+++ b/packages/browser/workbench-node/src/chrome-cookie-import/macos/chromeCookieImport.test.ts
@@ -48,7 +48,7 @@ interface CookieFixture {
   value?: string;
 }
 
-test("discovers renderer-safe metadata for all Local State profiles with old and new Cookie DB paths", async (t) => {
+test("discovers renderer-safe Chrome metadata for all Local State profiles with old and new Cookie DB paths", async (t) => {
   const root = await chromeRoot(t);
   await createProfileDatabase(root, "Default", [], 24, "new");
   await createProfileDatabase(root, "Profile 1", [], 24, "old");
@@ -85,6 +85,7 @@ test("discovers renderer-safe metadata for all Local State profiles with old and
     ["Personal", "Work account", "No unsafe avatar"]
   );
   assert.equal(profiles[0]?.email, "person@example.com");
+  assert.ok(profiles.every((profile) => profile.source === "chrome"));
   assert.equal(
     profiles[0]?.avatarDataUrl,
     `data:image/png;base64,${avatarBytes.toString("base64")}`
@@ -97,6 +98,52 @@ test("discovers renderer-safe metadata for all Local State profiles with old and
     profiles.every((profile) => !JSON.stringify(profile).includes("chrome://"))
   );
   assert.equal(new Set(profiles.map((profile) => profile.id)).size, 3);
+});
+
+test("discovers Dia profiles from its User Data root and decrypts with Dia Safe Storage", async (t) => {
+  const root = await diaRoot(t);
+  const secret = Buffer.from("dia-safe-storage-secret");
+  await createProfileDatabase(
+    root,
+    "Default",
+    [
+      {
+        encryptedValue: encryptCookie("dia-session", secret, ".dia.test", 24),
+        expiresUtc: FUTURE_CHROME_TIME,
+        hasExpires: 1,
+        hostKey: ".dia.test",
+        name: "session",
+        persistent: 1,
+        secure: 1
+      }
+    ],
+    24,
+    "old"
+  );
+  await writeLocalState(root, { Default: { name: "Dia profile" } });
+  const requestedSources: string[] = [];
+  const sourceDependencies = {
+    chromeUserDataRoot: join(root, "missing-chrome"),
+    diaUserDataRoot: root,
+    now: () => NOW_MS,
+    platform: "darwin" as const,
+    readKeychainSecret: async (source: "chrome" | "dia") => {
+      requestedSources.push(source);
+      return Buffer.from(secret);
+    }
+  };
+
+  const profiles = await discoverChromeCookieProfiles(sourceDependencies);
+
+  assert.deepEqual(
+    profiles.map(({ name, source }) => ({ name, source })),
+    [{ name: "Dia profile", source: "dia" }]
+  );
+  const [profile] = profiles;
+  assert.ok(profile);
+  const prepared = await prepareChromeCookies(profile.id, sourceDependencies);
+  assert.deepEqual(requestedSources, ["dia"]);
+  assert.equal(prepared.cookies[0]?.value, "dia-session");
 });
 
 test("rejects symlinked Chrome Profile avatar files", async (t) => {
@@ -518,11 +565,19 @@ test("rejects missing required schema before requesting Keychain", async (t) => 
 });
 
 function dependencies(root: string) {
-  return { chromeUserDataRoot: root, platform: "darwin" as const };
+  return {
+    chromeUserDataRoot: root,
+    diaUserDataRoot: join(root, "missing-dia"),
+    platform: "darwin" as const
+  };
 }
 
 async function chromeRoot(t: test.TestContext): Promise<string> {
   return testDirectory(t, "tutti-chrome-root-");
+}
+
+async function diaRoot(t: test.TestContext): Promise<string> {
+  return testDirectory(t, "tutti-dia-user-data-");
 }
 
 async function testDirectory(

--- a/packages/browser/workbench-node/src/chrome-cookie-import/macos/chromeCookieImport.ts
+++ b/packages/browser/workbench-node/src/chrome-cookie-import/macos/chromeCookieImport.ts
@@ -12,6 +12,7 @@ import { DatabaseSync, backup } from "node:sqlite";
 import { readChromeProfileAvatarDataUrl } from "./chromeProfileMetadata.ts";
 
 const CHROME_KEYCHAIN_SERVICE = "Chrome Safe Storage";
+const DIA_KEYCHAIN_SERVICE = "Dia Safe Storage";
 const CHROME_KEYCHAIN_TIMEOUT_MS = 60_000;
 const CHROME_COOKIE_EPOCH_OFFSET_SECONDS = 11_644_473_600;
 const CHROME_V10_PREFIX = Buffer.from("v10");
@@ -19,11 +20,14 @@ const MACOS_CHROME_IV = Buffer.alloc(16, 0x20);
 const MACOS_CHROME_SALT = Buffer.from("saltysalt");
 const PROFILE_DIRECTORY_PATTERN = /^(?:Default|Profile \d+)$/;
 
+export type ChromeCookieProfileSource = "chrome" | "dia";
+
 export interface ChromeCookieProfile {
   avatarDataUrl?: string;
   email?: string;
   id: string;
   name: string;
+  source?: ChromeCookieProfileSource;
 }
 
 export interface PreparedChromeCookie {
@@ -70,9 +74,10 @@ export class ChromeCookieImportError extends Error {
 
 interface ChromeCookieImportDependencies {
   chromeUserDataRoot: string;
+  diaUserDataRoot: string;
   now: () => number;
   platform: NodeJS.Platform;
-  readKeychainSecret: () => Promise<Buffer>;
+  readKeychainSecret: (source: ChromeCookieProfileSource) => Promise<Buffer>;
   withSnapshot: <T>(
     sourcePath: string,
     readSnapshot: (snapshotPath: string) => Promise<T>
@@ -82,9 +87,11 @@ interface ChromeCookieImportDependencies {
 export type ChromeCookieImportDependencyOverrides =
   Partial<ChromeCookieImportDependencies>;
 
-interface ResolvedChromeProfile extends ChromeCookieProfile {
+interface ResolvedChromeProfile extends Omit<ChromeCookieProfile, "source"> {
   cookieDatabasePath: string;
   directoryName: string;
+  source: ChromeCookieProfileSource;
+  userDataRoot: string;
 }
 
 interface ChromeLocalState {
@@ -123,9 +130,16 @@ const defaultDependencies: ChromeCookieImportDependencies = {
     "Google",
     "Chrome"
   ),
+  diaUserDataRoot: join(
+    homedir(),
+    "Library",
+    "Application Support",
+    "Dia",
+    "User Data"
+  ),
   now: Date.now,
   platform: process.platform,
-  readKeychainSecret: readChromeSafeStorageSecret,
+  readKeychainSecret: readChromiumSafeStorageSecret,
   withSnapshot: withChromeCookieDatabaseSnapshot
 };
 
@@ -137,11 +151,12 @@ export async function discoverChromeCookieProfiles(
     return [];
   }
   return (await resolveChromeProfiles(dependencies)).map(
-    ({ avatarDataUrl, email, id, name }) => ({
+    ({ avatarDataUrl, email, id, name, source }) => ({
       ...(avatarDataUrl ? { avatarDataUrl } : {}),
       ...(email ? { email } : {}),
       id,
-      name
+      name,
+      source
     })
   );
 }
@@ -164,7 +179,7 @@ export async function prepareChromeCookies(
     throw new ChromeCookieImportError("profile_not_found");
   }
   await validateProfileAndDatabase(
-    dependencies.chromeUserDataRoot,
+    profile.userDataRoot,
     profile.directoryName,
     profile.cookieDatabasePath
   );
@@ -183,7 +198,7 @@ export async function prepareChromeCookies(
     let key: Buffer | null = null;
     try {
       if (needsKeychain) {
-        secret = await dependencies.readKeychainSecret();
+        secret = await dependencies.readKeychainSecret(profile.source);
         signal?.throwIfAborted();
         if (secret.length === 0) {
           throw new ChromeCookieImportError("keychain_failed");
@@ -223,7 +238,23 @@ export function decryptChromeV10CookieForTesting(
 async function resolveChromeProfiles(
   dependencies: ChromeCookieImportDependencies
 ): Promise<ResolvedChromeProfile[]> {
-  const root = resolve(dependencies.chromeUserDataRoot);
+  const profiles: ResolvedChromeProfile[] = [];
+  for (const source of [
+    { id: "chrome" as const, userDataRoot: dependencies.chromeUserDataRoot },
+    { id: "dia" as const, userDataRoot: dependencies.diaUserDataRoot }
+  ]) {
+    profiles.push(
+      ...(await resolveChromeProfilesAtRoot(source.id, source.userDataRoot))
+    );
+  }
+  return profiles;
+}
+
+async function resolveChromeProfilesAtRoot(
+  source: ChromeCookieProfileSource,
+  userDataRoot: string
+): Promise<ResolvedChromeProfile[]> {
+  const root = resolve(userDataRoot);
   try {
     const rootStat = await lstat(root);
     if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
@@ -281,8 +312,10 @@ async function resolveChromeProfiles(
       cookieDatabasePath,
       directoryName,
       ...(email ? { email } : {}),
-      id: opaqueProfileId(directoryName),
-      name
+      id: opaqueProfileId(source, directoryName),
+      name,
+      source,
+      userDataRoot: root
     });
   }
   return profiles;
@@ -667,11 +700,15 @@ export function classifyChromeKeychainFailure(
     : "keychain_failed";
 }
 
-export async function readChromeSafeStorageSecret(): Promise<Buffer> {
+export async function readChromiumSafeStorageSecret(
+  source: ChromeCookieProfileSource
+): Promise<Buffer> {
+  const service =
+    source === "dia" ? DIA_KEYCHAIN_SERVICE : CHROME_KEYCHAIN_SERVICE;
   return new Promise((resolvePromise, rejectPromise) => {
     execFile(
       "/usr/bin/security",
-      ["find-generic-password", "-w", "-s", CHROME_KEYCHAIN_SERVICE],
+      ["find-generic-password", "-w", "-s", service],
       {
         encoding: "buffer",
         maxBuffer: 64 * 1024,
@@ -715,9 +752,14 @@ export async function readChromeSafeStorageSecret(): Promise<Buffer> {
   });
 }
 
-function opaqueProfileId(directoryName: string): string {
+function opaqueProfileId(
+  source: ChromeCookieProfileSource,
+  directoryName: string
+): string {
   return createHash("sha256")
-    .update("tutti:chrome-stable-profile:v1:\0")
+    .update("tutti:chromium-profile:v2:\0")
+    .update(source)
+    .update("\0")
     .update(directoryName)
     .digest("base64url");
 }

--- a/packages/browser/workbench-node/src/chrome-cookie-import/macos/macosChromeCookieImportAdapter.ts
+++ b/packages/browser/workbench-node/src/chrome-cookie-import/macos/macosChromeCookieImportAdapter.ts
@@ -128,7 +128,8 @@ export function createChromeCookieProfileDiscovery(input: {
             ? {
                 profiles: profiles.map((profile) => ({
                   ...profile,
-                  id: profile.id as BrowserNodeChromeProfileId
+                  id: profile.id as BrowserNodeChromeProfileId,
+                  source: profile.source ?? "chrome"
                 })),
                 status: "available"
               }

--- a/packages/browser/workbench-node/src/core/types.ts
+++ b/packages/browser/workbench-node/src/core/types.ts
@@ -265,11 +265,14 @@ export type BrowserNodeChromeProfileId = string & {
   readonly [browserNodeChromeProfileIdBrand]: true;
 };
 
+export type BrowserNodeChromeProfileSource = "chrome" | "dia";
+
 export interface BrowserNodeChromeProfile {
   avatarDataUrl?: string;
   email?: string;
   id: BrowserNodeChromeProfileId;
   name: string;
+  source?: BrowserNodeChromeProfileSource;
 }
 
 export type BrowserNodeChromeProfileDiscoveryResult =

--- a/packages/browser/workbench-node/src/i18n/browserNodeI18n.ts
+++ b/packages/browser/workbench-node/src/i18n/browserNodeI18n.ts
@@ -60,19 +60,21 @@ const browserNodeEn = {
   chromeImport: {
     cancel: "Cancel",
     dialogDescription:
-      "Choose a Chrome profile. Tutti imports only login Cookies, not passwords, bookmarks, or history.",
-    dialogTitle: "Import login state from Chrome",
+      "Choose a Chrome or Dia profile. Tutti imports only login Cookies, not passwords, bookmarks, or history.",
+    dialogTitle: "Import login state",
     dismissTooltip: "Close and never show again",
-    fromChrome: "Import from Chrome",
+    fromChrome: "Import from browser",
     import: "Import Cookies",
     importing: "Importing…",
     keychainFailed:
-      "Chrome Safe Storage access was not granted. Try again and allow Keychain access.",
+      "Browser Safe Storage access was not granted. Try again and allow Keychain access.",
     promptDescription:
       "Bring your signed-in website sessions into this browser. Only Cookies are imported.",
-    promptTitle: "Import login state from Chrome",
+    promptTitle: "Import login state",
     selectProfile: "Choose Profile",
-    snapshotFailed: "Close Chrome and try the import again."
+    snapshotFailed: "Close the selected browser and try the import again.",
+    sourceChrome: "Chrome",
+    sourceDia: "Dia"
   },
   dockLabel: "Browser",
   downloads: {
@@ -188,17 +190,19 @@ const browserNodeZhCN = {
   chromeImport: {
     cancel: "取消",
     dialogDescription:
-      "选择 Chrome Profile。Tutti 只导入登录 Cookie，不导入密码、书签或历史记录",
-    dialogTitle: "从 Chrome 导入登录状态",
+      "选择 Chrome 或 Dia Profile。Tutti 只导入登录 Cookie，不导入密码、书签或历史记录",
+    dialogTitle: "导入登录状态",
     dismissTooltip: "关闭且不再显示",
-    fromChrome: "从 Chrome 导入",
+    fromChrome: "从浏览器导入",
     import: "导入 Cookie",
     importing: "正在导入…",
-    keychainFailed: "未获准访问 Chrome 安全存储，请重试并允许钥匙串访问",
+    keychainFailed: "未获准访问浏览器安全存储，请重试并允许钥匙串访问",
     promptDescription: "将网站登录状态带入此浏览器，只会导入 Cookie",
-    promptTitle: "从 Chrome 导入登录状态",
+    promptTitle: "导入登录状态",
     selectProfile: "选择 Profile",
-    snapshotFailed: "请退出 Chrome 后重试导入"
+    snapshotFailed: "请退出所选浏览器后重试导入",
+    sourceChrome: "Chrome",
+    sourceDia: "Dia"
   },
   dockLabel: "浏览器",
   downloads: {
@@ -312,6 +316,8 @@ export type BrowserNodeI18nKey =
   | "chromeImport.promptTitle"
   | "chromeImport.selectProfile"
   | "chromeImport.snapshotFailed"
+  | "chromeImport.sourceChrome"
+  | "chromeImport.sourceDia"
   | "dockLabel"
   | "downloads.empty"
   | "downloads.status.cancelled"

--- a/packages/browser/workbench-node/src/react/BrowserNodeChromeImportDialog.tsx
+++ b/packages/browser/workbench-node/src/react/BrowserNodeChromeImportDialog.tsx
@@ -124,6 +124,7 @@ export function BrowserNodeChromeImportDialog({
               buttonRef={(button) => {
                 profileButtons.current[index] = button;
               }}
+              feature={feature}
               index={index}
               profileCount={profiles.length}
               profile={profile}
@@ -164,6 +165,7 @@ export function BrowserNodeChromeImportDialog({
 
 function ChromeProfileButton({
   buttonRef,
+  feature,
   index,
   onMove,
   onSelect,
@@ -173,6 +175,7 @@ function ChromeProfileButton({
   tabStop
 }: {
   buttonRef(button: HTMLButtonElement | null): void;
+  feature: BrowserNodeFeature;
   index: number;
   onMove(index: number): void;
   onSelect(): void;
@@ -224,6 +227,11 @@ function ChromeProfileButton({
             {profile.email}
           </span>
         ) : null}
+        <span className="block truncate text-[11px] text-[var(--text-secondary)]">
+          {profile.source === "dia"
+            ? feature.i18n.t("chromeImport.sourceDia")
+            : feature.i18n.t("chromeImport.sourceChrome")}
+        </span>
       </span>
       <RadioIndicator checked={selected} className="ml-auto" />
     </button>


### PR DESCRIPTION
## Summary
- Import cookies from Dia browser profiles alongside Chrome profiles
- Show each profile source and fix the profile-card render failure

## Tests
- `pnpm check:changed -- --failed-only`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1858" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->