### PR TITLE
fix(agent-gui): backport catalog skill grouping to release/0729

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentSlashCommandPalette.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentSlashCommandPalette.spec.tsx
@@ -402,7 +402,7 @@ describe("AgentSlashCommandPalette", () => {
     expect(onSelectCapabilitySettings).not.toHaveBeenCalled();
   });
 
-  it("separates plugin and connector skill entries into source groups", () => {
+  it("separates catalog skills, plugins, and connectors into source groups", () => {
     render(
       <AgentSlashCommandPalette
         label="Slash commands"
@@ -414,6 +414,17 @@ describe("AgentSlashCommandPalette", () => {
         mcpGroupLabel="MCP"
         highlightedIndex={0}
         entries={[
+          {
+            type: "skill",
+            key: "skill:catalog-review",
+            label: "catalog-review",
+            skill: {
+              name: "catalog-review",
+              trigger: "$catalog-review",
+              sourceKind: "plugin",
+              kind: "skill"
+            }
+          },
           {
             type: "skill",
             key: "skill:plugin-review",
@@ -444,6 +455,7 @@ describe("AgentSlashCommandPalette", () => {
       />
     );
 
+    expect(screen.getByText("Skills")).toBeInTheDocument();
     expect(screen.getByText("Plugins")).toBeInTheDocument();
     expect(screen.getByText("Connectors")).toHaveClass(
       "mt-3",
@@ -452,6 +464,5 @@ describe("AgentSlashCommandPalette", () => {
       "before:border-t",
       "before:border-[var(--border-1)]"
     );
-    expect(screen.queryByText("Skills")).toBeNull();
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentSlashCommandPalette.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentSlashCommandPalette.tsx
@@ -328,6 +328,9 @@ function entryGroupType(
   ) {
     return "connector";
   }
+  if (entry.skill.kind === "skill") {
+    return "skill";
+  }
   if (entry.skill.sourceKind === "plugin") {
     return "plugin";
   }


### PR DESCRIPTION
## Summary

Backport #1853 to `release/0729`.

- route semantic Skill entries to the existing Skills group
- preserve plugin, connector, `/`, and `$` behavior

Cherry-picked from `bb213ed5b128c057a8f5d294eab1ea94996a83a5`.

## Verification

- `pnpm check:changed -- --failed-only` — 25/25 lanes passed
- final pre-push `pnpm check:changed -- --push-ready` — 25/25 lanes passed

## Checklist

- [x] Focused release backport
- [x] No documentation impact
- [x] DCO sign-off preserved by cherry-pick
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1859" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->