### PR TITLE
feat(agent): default Desktop to Tutti Agent

### DIFF
--- a/apps/desktop/src/main/desktopHostPreferences.test.ts
+++ b/apps/desktop/src/main/desktopHostPreferences.test.ts
@@ -63,7 +63,7 @@ test("createDesktopHostPreferencesState initializes missing preferences with dar
         deletedAgentConversationRetentionDays: 30,
         appCatalogChannel: "production",
         browserUseConnectionMode: "isolated",
-        defaultAgentProvider: "codex",
+        defaultAgentProvider: "tutti-agent",
         featureFlags: {},
         workbenchShortcuts: defaultDesktopWorkbenchShortcuts,
         dockIconStyle: "default",
@@ -87,7 +87,7 @@ test("createDesktopHostPreferencesState initializes missing preferences with dar
   assert.equal(state.getAgentCliUpdateCheckEnabled(), true);
   assert.equal(state.getDockPlacement(), "bottom");
   assert.equal(state.getLocale(), "zh-CN");
-  assert.equal(state.getDefaultAgentProvider(), "codex");
+  assert.equal(state.getDefaultAgentProvider(), "tutti-agent");
   assert.deepEqual(state.getAgentGUIConversationRailCollapsedByProvider(), {});
   assert.equal(state.getBrowserUseConnectionMode(), "isolated");
   assert.equal(state.getSleepPreventionMode(), "never");

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
@@ -6,7 +6,6 @@ import type {
   AgentGUIAgent,
   AgentGUIAgentDirectoryPort
 } from "@tutti-os/agent-gui";
-import { resolveAgentGUIProviderCatalogIdentity } from "@tutti-os/agent-gui/provider-catalog";
 import {
   createAgentGuiWorkbenchContribution,
   type AgentGuiWorkbenchConversationIdentity
@@ -99,10 +98,8 @@ export function createWorkspaceAgentGuiContribution(input: {
   workspaceUserProjectService: IWorkspaceUserProjectService;
   workspaceId: string;
 }): WorkbenchContribution {
-  const initialAgentDirectory = input.agentsService.getSnapshot();
-  const defaultAgentProvider = isWorkspaceAgentGuiProviderEnabledForNewEntry(
-    input.defaultAgentProvider,
-    initialAgentDirectory.agents
+  const defaultAgentProvider = isAgentGuiWorkbenchProvider(
+    input.defaultAgentProvider
   )
     ? input.defaultAgentProvider
     : null;
@@ -325,35 +322,26 @@ function resolveDefaultAgentTargetId(input: {
   );
 }
 
-function isWorkspaceAgentGuiProviderEnabledForNewEntry(
-  provider: string | null | undefined,
-  agents: readonly AgentGUIAgent[] | null | undefined
-): provider is AgentGuiWorkbenchProvider {
-  if (!isAgentGuiWorkbenchProvider(provider)) {
-    return false;
-  }
-  if (
-    resolveAgentGUIProviderCatalogIdentity(provider)?.desktop.visibilityGate !==
-    "tutti_agent"
-  ) {
-    return true;
-  }
-  return (agents ?? []).some(
-    (agent) =>
-      agent.provider === provider && agent.availability.status === "ready"
-  );
-}
-
 function resolveWorkspaceAgentGuiProviderAvailability(
   service: AgentProviderStatusService
 ): Partial<Record<AgentGuiWorkbenchProvider, boolean>> {
-  const availability: Partial<Record<AgentGuiWorkbenchProvider, boolean>> = {};
-  for (const status of service.getSnapshot().statuses) {
-    if (isAgentGuiWorkbenchProvider(status.provider)) {
-      availability[status.provider] = status.availability.status === "ready";
+  return new Proxy(
+    {},
+    {
+      get: (_target, property) => {
+        if (
+          typeof property !== "string" ||
+          !isAgentGuiWorkbenchProvider(property)
+        ) {
+          return undefined;
+        }
+        const status = service
+          .getSnapshot()
+          .statuses.find((entry) => entry.provider === property);
+        return status ? status.availability.status === "ready" : undefined;
+      }
     }
-  }
-  return availability;
+  );
 }
 
 function resolveWorkspaceAgentGuiDockPopupIdentity(

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
@@ -252,9 +252,10 @@ export function createWorkspaceAgentGuiContribution(input: {
     frame: workspaceAgentGuiNodeFrame,
     defaultProvider: defaultAgentProvider,
     agentDirectory: input.agentsService,
-    providerAvailability: resolveWorkspaceAgentGuiProviderAvailability(
-      input.agentProviderStatusService
-    ),
+    providerAvailability: () =>
+      resolveWorkspaceAgentGuiProviderAvailability(
+        input.agentProviderStatusService
+      ),
     renderBody: (context, helpers) =>
       renderAgentGuiWorkbenchBody(context, helpers),
     resolveDockPopupIdentity: (state) =>
@@ -325,23 +326,13 @@ function resolveDefaultAgentTargetId(input: {
 function resolveWorkspaceAgentGuiProviderAvailability(
   service: AgentProviderStatusService
 ): Partial<Record<AgentGuiWorkbenchProvider, boolean>> {
-  return new Proxy(
-    {},
-    {
-      get: (_target, property) => {
-        if (
-          typeof property !== "string" ||
-          !isAgentGuiWorkbenchProvider(property)
-        ) {
-          return undefined;
-        }
-        const status = service
-          .getSnapshot()
-          .statuses.find((entry) => entry.provider === property);
-        return status ? status.availability.status === "ready" : undefined;
-      }
+  const availability: Partial<Record<AgentGuiWorkbenchProvider, boolean>> = {};
+  for (const status of service.getSnapshot().statuses) {
+    if (isAgentGuiWorkbenchProvider(status.provider)) {
+      availability[status.provider] = status.availability.status === "ready";
     }
-  );
+  }
+  return availability;
 }
 
 function resolveWorkspaceAgentGuiDockPopupIdentity(

--- a/apps/desktop/src/shared/preferences/core.ts
+++ b/apps/desktop/src/shared/preferences/core.ts
@@ -217,8 +217,9 @@ export const desktopAgentProviders = [
 export type DesktopAgentProvider = (typeof desktopAgentProviders)[number];
 
 export const desktopDefaultAgentProviders = [
-  "claude-code",
+  "tutti-agent",
   "codex",
+  "claude-code",
   "cursor",
   "opencode"
 ] as const;
@@ -226,7 +227,8 @@ export const desktopDefaultAgentProviders = [
 export type DesktopDefaultAgentProvider =
   (typeof desktopDefaultAgentProviders)[number];
 
-export const defaultDesktopAgentProvider: DesktopDefaultAgentProvider = "codex";
+export const defaultDesktopAgentProvider: DesktopDefaultAgentProvider =
+  "tutti-agent";
 
 export interface DesktopAgentComposerDefaults {
   model?: string;

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1157,6 +1157,12 @@ order. Tutti Agent is the first built-in target; an explicit device-local
 Provider Rail reorder remains a presentation preference and takes precedence
 over that default.
 
+Tutti Agent is also the first Desktop default Provider for ambiguous new
+entries. An exact persisted Agent Target or an explicit launch request still
+takes precedence. AgentGUI and launch surfaces that require readiness fall back
+through the authoritative ready Agent Directory when that default is
+unavailable.
+
 The directory owns Agent presentation. `agents[].iconUrl` is the primary
 presentation asset used by conversation identity, Message Center, mentions,
 and the empty-home carousel and Provider Rail. It is decorative metadata:

--- a/packages/agent/daemon/providerregistry/claude_code.go
+++ b/packages/agent/daemon/providerregistry/claude_code.go
@@ -146,7 +146,7 @@ func claudeCodeDescriptor() ProviderDescriptor {
 			TurnLifecycleProjection: TurnLifecycleProjectionExplicit,
 		},
 		Sidecar: SidecarDescriptor{MentionRouting: SidecarMentionRoutingClaudeNamespaced, ExecutionEnvironment: SidecarExecutionEnvironmentClaudeIPC},
-		Desktop: DesktopIntegrationDescriptor{Managed: true, ManagedOrder: 1, StatusProbePriority: 2, UsageProbeKind: DesktopUsageProbeClaudeCode, DeveloperLogs: true, DefaultProviderEligible: true, DefaultProviderPriority: 2},
+		Desktop: DesktopIntegrationDescriptor{Managed: true, ManagedOrder: 1, StatusProbePriority: 2, UsageProbeKind: DesktopUsageProbeClaudeCode, DeveloperLogs: true, DefaultProviderEligible: true, DefaultProviderPriority: 3},
 		ExternalImport: ExternalImportDescriptor{
 			Enabled:               true,
 			RootEnvVar:            "CLAUDE_CONFIG_DIR",

--- a/packages/agent/daemon/providerregistry/codex.go
+++ b/packages/agent/daemon/providerregistry/codex.go
@@ -149,7 +149,7 @@ func codexDescriptor() ProviderDescriptor {
 			TurnLifecycleProjection: TurnLifecycleProjectionExplicit,
 		},
 		Sidecar: SidecarDescriptor{ExecutionEnvironment: SidecarExecutionEnvironmentCodexSandbox},
-		Desktop: DesktopIntegrationDescriptor{Managed: true, ManagedOrder: 2, StatusProbePriority: 1, UsageProbeKind: DesktopUsageProbeCodex, CommandNetworkAccess: true, DeveloperLogs: true, DefaultProviderEligible: true, DefaultProviderPriority: 1},
+		Desktop: DesktopIntegrationDescriptor{Managed: true, ManagedOrder: 2, StatusProbePriority: 1, UsageProbeKind: DesktopUsageProbeCodex, CommandNetworkAccess: true, DeveloperLogs: true, DefaultProviderEligible: true, DefaultProviderPriority: 2},
 		ExternalImport: ExternalImportDescriptor{
 			Enabled:                  true,
 			RootEnvVar:               "CODEX_HOME",

--- a/packages/agent/daemon/providerregistry/opencode.go
+++ b/packages/agent/daemon/providerregistry/opencode.go
@@ -131,6 +131,6 @@ func openCodeDescriptor() ProviderDescriptor {
 			TurnLifecycleProjection: TurnLifecycleProjectionExplicit,
 		},
 		Sidecar: SidecarDescriptor{ExecutionEnvironment: SidecarExecutionEnvironmentLocalIPC},
-		Desktop: DesktopIntegrationDescriptor{Managed: true, ManagedOrder: 5, StatusProbePriority: 5, DefaultProviderEligible: true, DefaultProviderPriority: 4},
+		Desktop: DesktopIntegrationDescriptor{Managed: true, ManagedOrder: 5, StatusProbePriority: 5, DefaultProviderEligible: true, DefaultProviderPriority: 5},
 	}
 }

--- a/packages/agent/daemon/providerregistry/providers.go
+++ b/packages/agent/daemon/providerregistry/providers.go
@@ -57,7 +57,7 @@ func cursorDescriptor() ProviderDescriptor {
 		Target:  TargetDescriptor{ID: CursorTargetID, LaunchRefType: TargetLaunchRefTypeLocalCLI, Enabled: true, SortOrder: 30},
 		Events:  EventsDescriptor{Enabled: true, Aliases: []string{"cursor-agent", "cursor_agent"}, TurnLifecycleProjection: TurnLifecycleProjectionExplicit},
 		Sidecar: SidecarDescriptor{ExecutionEnvironment: SidecarExecutionEnvironmentLocalIPC},
-		Desktop: DesktopIntegrationDescriptor{Managed: true, ManagedOrder: 3, StatusProbePriority: 3, RuntimeProbeFallback: DesktopRuntimeProbeFallbackDirect, DeveloperLogs: true, DefaultProviderEligible: true, DefaultProviderPriority: 3},
+		Desktop: DesktopIntegrationDescriptor{Managed: true, ManagedOrder: 3, StatusProbePriority: 3, RuntimeProbeFallback: DesktopRuntimeProbeFallbackDirect, DeveloperLogs: true, DefaultProviderEligible: true, DefaultProviderPriority: 4},
 	}
 }
 
@@ -88,7 +88,7 @@ func tuttiAgentDescriptor() ProviderDescriptor {
 		Target:  TargetDescriptor{ID: TuttiAgentTargetID, LaunchRefType: TargetLaunchRefTypeLocalCLI, Enabled: true, SortOrder: 5},
 		Events:  EventsDescriptor{Enabled: true, Aliases: []string{"tutti_agent"}, TurnLifecycleProjection: TurnLifecycleProjectionExplicit},
 		Sidecar: SidecarDescriptor{ExecutionEnvironment: SidecarExecutionEnvironmentLocalIPC},
-		Desktop: DesktopIntegrationDescriptor{Managed: true, ManagedOrder: 4, StatusProbePriority: 4, VisibilityGate: DesktopVisibilityGateTuttiAgent, CommandNetworkAccess: true, InstallBootstrap: true, RefreshOnAccountChange: true, DeveloperLogs: true},
+		Desktop: DesktopIntegrationDescriptor{Managed: true, ManagedOrder: 4, StatusProbePriority: 4, VisibilityGate: DesktopVisibilityGateTuttiAgent, CommandNetworkAccess: true, InstallBootstrap: true, RefreshOnAccountChange: true, DeveloperLogs: true, DefaultProviderEligible: true, DefaultProviderPriority: 1},
 	}
 }
 

--- a/packages/agent/daemon/providerregistry/registry_test.go
+++ b/packages/agent/daemon/providerregistry/registry_test.go
@@ -285,11 +285,11 @@ func TestMigratedProviderSidecarPoliciesAreDescriptorOwned(t *testing.T) {
 
 func TestMigratedProviderDesktopIntegrationIsDescriptorOwned(t *testing.T) {
 	want := map[string]DesktopIntegrationDescriptor{
-		CodexProviderID:      {Managed: true, ManagedOrder: 2, StatusProbePriority: 1, UsageProbeKind: DesktopUsageProbeCodex, CommandNetworkAccess: true, DeveloperLogs: true, DefaultProviderEligible: true, DefaultProviderPriority: 1},
-		ClaudeCodeProviderID: {Managed: true, ManagedOrder: 1, StatusProbePriority: 2, UsageProbeKind: DesktopUsageProbeClaudeCode, DeveloperLogs: true, DefaultProviderEligible: true, DefaultProviderPriority: 2},
-		CursorProviderID:     {Managed: true, ManagedOrder: 3, StatusProbePriority: 3, RuntimeProbeFallback: DesktopRuntimeProbeFallbackDirect, DeveloperLogs: true, DefaultProviderEligible: true, DefaultProviderPriority: 3},
-		TuttiAgentProviderID: {Managed: true, ManagedOrder: 4, StatusProbePriority: 4, VisibilityGate: DesktopVisibilityGateTuttiAgent, CommandNetworkAccess: true, InstallBootstrap: true, RefreshOnAccountChange: true, DeveloperLogs: true},
-		OpenCodeProviderID:   {Managed: true, ManagedOrder: 5, StatusProbePriority: 5, DefaultProviderEligible: true, DefaultProviderPriority: 4},
+		CodexProviderID:      {Managed: true, ManagedOrder: 2, StatusProbePriority: 1, UsageProbeKind: DesktopUsageProbeCodex, CommandNetworkAccess: true, DeveloperLogs: true, DefaultProviderEligible: true, DefaultProviderPriority: 2},
+		ClaudeCodeProviderID: {Managed: true, ManagedOrder: 1, StatusProbePriority: 2, UsageProbeKind: DesktopUsageProbeClaudeCode, DeveloperLogs: true, DefaultProviderEligible: true, DefaultProviderPriority: 3},
+		CursorProviderID:     {Managed: true, ManagedOrder: 3, StatusProbePriority: 3, RuntimeProbeFallback: DesktopRuntimeProbeFallbackDirect, DeveloperLogs: true, DefaultProviderEligible: true, DefaultProviderPriority: 4},
+		TuttiAgentProviderID: {Managed: true, ManagedOrder: 4, StatusProbePriority: 4, VisibilityGate: DesktopVisibilityGateTuttiAgent, CommandNetworkAccess: true, InstallBootstrap: true, RefreshOnAccountChange: true, DeveloperLogs: true, DefaultProviderEligible: true, DefaultProviderPriority: 1},
+		OpenCodeProviderID:   {Managed: true, ManagedOrder: 5, StatusProbePriority: 5, DefaultProviderEligible: true, DefaultProviderPriority: 5},
 		NexightProviderID:    {},
 		OpenClawProviderID:   {Managed: true, ManagedOrder: 7, StatusProbePriority: 7, UnavailableDockOrderOffset: 200},
 	}

--- a/packages/agent/gui/generated/providerIdentityCatalog.ts
+++ b/packages/agent/gui/generated/providerIdentityCatalog.ts
@@ -27,7 +27,7 @@ export const generatedProviderIdentityCatalog = [
       unavailableDockOrderOffset: 0,
       developerLogs: true,
       defaultProviderEligible: true,
-      defaultProviderPriority: 1
+      defaultProviderPriority: 2
     }
   },
   {
@@ -56,7 +56,7 @@ export const generatedProviderIdentityCatalog = [
       unavailableDockOrderOffset: 0,
       developerLogs: true,
       defaultProviderEligible: true,
-      defaultProviderPriority: 2
+      defaultProviderPriority: 3
     }
   },
   {
@@ -85,7 +85,7 @@ export const generatedProviderIdentityCatalog = [
       unavailableDockOrderOffset: 0,
       developerLogs: true,
       defaultProviderEligible: true,
-      defaultProviderPriority: 3
+      defaultProviderPriority: 4
     }
   },
   {
@@ -113,8 +113,8 @@ export const generatedProviderIdentityCatalog = [
       refreshOnAccountChange: true,
       unavailableDockOrderOffset: 0,
       developerLogs: true,
-      defaultProviderEligible: false,
-      defaultProviderPriority: 0
+      defaultProviderEligible: true,
+      defaultProviderPriority: 1
     }
   },
   {
@@ -143,7 +143,7 @@ export const generatedProviderIdentityCatalog = [
       unavailableDockOrderOffset: 0,
       developerLogs: false,
       defaultProviderEligible: true,
-      defaultProviderPriority: 4
+      defaultProviderPriority: 5
     }
   },
   {

--- a/packages/agent/gui/workbench/contribution.test.ts
+++ b/packages/agent/gui/workbench/contribution.test.ts
@@ -491,12 +491,10 @@ describe("agent GUI workbench contribution copy", () => {
     const contribution = createTestAgentGuiWorkbenchContribution({
       agentDirectory,
       defaultProvider: "tutti-agent",
-      providerAvailability: {
+      providerAvailability: () => ({
         codex: true,
-        get "tutti-agent"() {
-          return tuttiAgentReady;
-        }
-      },
+        "tutti-agent": tuttiAgentReady
+      }),
       renderBody: () => null,
       workspaceId: "workspace-1"
     });

--- a/packages/agent/gui/workbench/contribution.test.ts
+++ b/packages/agent/gui/workbench/contribution.test.ts
@@ -476,6 +476,64 @@ describe("agent GUI workbench contribution copy", () => {
     });
   });
 
+  it("uses a default provider that becomes ready after contribution creation", () => {
+    let tuttiAgentReady = false;
+    let currentAgents = [createAgent("codex")];
+    const agentDirectory: AgentGUIAgentDirectoryPort = {
+      getSnapshot: () => ({
+        agents: currentAgents,
+        capturedAtUnixMs: 1,
+        error: null,
+        status: "ready"
+      }),
+      subscribe: () => () => {}
+    };
+    const contribution = createTestAgentGuiWorkbenchContribution({
+      agentDirectory,
+      defaultProvider: "tutti-agent",
+      providerAvailability: {
+        codex: true,
+        get "tutti-agent"() {
+          return tuttiAgentReady;
+        }
+      },
+      renderBody: () => null,
+      workspaceId: "workspace-1"
+    });
+    const [dockEntry] = contribution.dockEntries ?? [];
+
+    expect(dockEntry?.launchPayload).toMatchObject({
+      provider: "codex"
+    });
+
+    tuttiAgentReady = true;
+    currentAgents = [createAgent("codex"), createAgent("tutti-agent")];
+
+    const launchResult = contribution.onLaunchRequest?.({
+      dockEntryId: dockEntry?.id,
+      layoutConstraints: testLaunchLayout.layoutConstraints,
+      payload: dockEntry?.launchPayload,
+      reason: "dock",
+      surfaceSize: testLaunchLayout.surfaceSize,
+      typeId: agentGuiWorkbenchTypeId,
+      workspaceId: "workspace-1"
+    }) as
+      | {
+          instanceId: string;
+        }
+      | null
+      | undefined;
+
+    expect(
+      contribution.externalStateSource?.getSnapshotNodeState?.({
+        instanceId: launchResult?.instanceId ?? "",
+        typeId: agentGuiWorkbenchTypeId
+      } as never)
+    ).toMatchObject({
+      agentTargetId: "local:tutti-agent"
+    });
+  });
+
   it("keeps one contribution while dock launches and body reads follow live directory updates", () => {
     let currentAgents = [createAgent("codex")];
     const listeners = new Set<() => void>();

--- a/packages/agent/gui/workbench/contribution.ts
+++ b/packages/agent/gui/workbench/contribution.ts
@@ -115,7 +115,7 @@ export interface CreateAgentGuiWorkbenchContributionInput {
   dockSectionId?: string;
   frame?: WorkbenchFrame;
   id?: string;
-  providerAvailability?: AgentGuiWorkbenchProviderAvailability;
+  providerAvailability?: AgentGuiWorkbenchProviderAvailabilitySource;
   renderBody(
     context: WorkbenchHostNodeBodyContext<
       AgentGuiWorkbenchState | null,
@@ -586,7 +586,7 @@ import {
   resolveAgentGuiWorkbenchContributionCopy,
   resolveAgentGuiWorkbenchDefaultLaunchFrame
 } from "./contributionDock.tsx";
-import type { AgentGuiWorkbenchProviderAvailability } from "./contributionDock.tsx";
+import type { AgentGuiWorkbenchProviderAvailabilitySource } from "./contributionDock.tsx";
 export {
   agentGuiWorkbenchCompactVisibleAreaRatio,
   agentGuiWorkbenchDefaultCopy,
@@ -602,5 +602,6 @@ export {
 } from "./contributionDock.tsx";
 export type {
   AgentGuiWorkbenchProviderAvailability,
+  AgentGuiWorkbenchProviderAvailabilitySource,
   BuildAgentGuiDockEntriesInput
 } from "./contributionDock.tsx";

--- a/packages/agent/gui/workbench/contributionDock.tsx
+++ b/packages/agent/gui/workbench/contributionDock.tsx
@@ -355,7 +355,9 @@ export function resolveAgentGuiWorkbenchLaunchPayload(
   const requestedProvider = providerFromState(payload);
   const resolved = resolveAgentGuiUnifiedDockLaunchPayload({
     agentDirectory: input.agentDirectory,
-    defaultProvider: requestedProvider ?? input.defaultProvider,
+    defaultProvider: isUnifiedDockLaunch
+      ? input.defaultProvider
+      : (requestedProvider ?? input.defaultProvider),
     providerAvailability: input.providerAvailability
   });
   if (!resolved.agentTargetId) {

--- a/packages/agent/gui/workbench/contributionDock.tsx
+++ b/packages/agent/gui/workbench/contributionDock.tsx
@@ -80,6 +80,10 @@ export type AgentGuiWorkbenchProviderAvailability = Partial<
   >
 >;
 
+export type AgentGuiWorkbenchProviderAvailabilitySource =
+  | AgentGuiWorkbenchProviderAvailability
+  | (() => AgentGuiWorkbenchProviderAvailability);
+
 export interface BuildAgentGuiDockEntriesInput {
   agentDirectory: AgentGUIAgentDirectoryPort;
   defaultProvider?: AgentGuiWorkbenchProvider | null;
@@ -87,7 +91,7 @@ export interface BuildAgentGuiDockEntriesInput {
   dockIconUrls?: Partial<Record<AgentGuiWorkbenchProvider, string>>;
   label?: string;
   order?: number;
-  providerAvailability?: AgentGuiWorkbenchProviderAvailability;
+  providerAvailability?: AgentGuiWorkbenchProviderAvailabilitySource;
   resolveDockPopupIdentity?: CreateAgentGuiWorkbenchContributionInput["resolveDockPopupIdentity"];
   resolveDockPopupTitle?: CreateAgentGuiWorkbenchContributionInput["resolveDockPopupTitle"];
   sectionId?: string;
@@ -318,7 +322,7 @@ export function resolveAgentGuiWorkbenchLaunchPayload(
   input: {
     agentDirectory: AgentGUIAgentDirectoryPort;
     defaultProvider?: AgentGuiWorkbenchProvider | null;
-    providerAvailability?: AgentGuiWorkbenchProviderAvailability;
+    providerAvailability?: AgentGuiWorkbenchProviderAvailabilitySource;
   }
 ): unknown | null {
   if (hasAgentSessionId(request.payload)) {
@@ -465,8 +469,15 @@ function preferredAgentGuiDockTargetForProvider(
 
 function isAgentGuiProviderAvailable(
   provider: AgentGuiWorkbenchProvider,
-  availability: AgentGuiWorkbenchProviderAvailability | null | undefined
+  availabilitySource:
+    | AgentGuiWorkbenchProviderAvailabilitySource
+    | null
+    | undefined
 ): boolean {
+  const availability =
+    typeof availabilitySource === "function"
+      ? availabilitySource()
+      : availabilitySource;
   const value = availability?.[provider];
   if (value === null || value === undefined) {
     return true;

--- a/packages/agent/gui/workbench/index.ts
+++ b/packages/agent/gui/workbench/index.ts
@@ -10,6 +10,7 @@ export {
 } from "./contribution.ts";
 export type {
   AgentGuiWorkbenchProviderAvailability,
+  AgentGuiWorkbenchProviderAvailabilitySource,
   AgentGuiWorkbenchContributionCopy,
   AgentGuiWorkbenchContributionCopyOverrides,
   AgentGuiWorkbenchConversationRailToggleDetail,

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -460,6 +460,7 @@ export type DesktopAgentComposerDefaults = {
 export type DesktopAgentConversationDetailMode = "coding" | "general";
 
 export type DesktopDefaultAgentProvider =
+  | "tutti-agent"
   | "claude-code"
   | "codex"
   | "cursor"

--- a/packages/events/protocol/schemas/topics/preferences/desktop-preferences.schema.json
+++ b/packages/events/protocol/schemas/topics/preferences/desktop-preferences.schema.json
@@ -79,7 +79,7 @@
     },
     "defaultAgentProvider": {
       "type": "string",
-      "enum": ["claude-code", "codex", "cursor", "opencode"]
+      "enum": ["tutti-agent", "claude-code", "codex", "cursor", "opencode"]
     },
     "dockIconStyle": {
       "type": "string",

--- a/packages/events/protocol/src/generated/contracts.ts
+++ b/packages/events/protocol/src/generated/contracts.ts
@@ -117,7 +117,12 @@ export interface PreferencesDesktopPreferencesV1 {
   agentDockLayout: "legacySplit" | "unified";
   appCatalogChannel: "production" | "staging";
   browserUseConnectionMode?: "isolated" | "autoConnect";
-  defaultAgentProvider: "claude-code" | "codex" | "cursor" | "opencode";
+  defaultAgentProvider:
+    | "tutti-agent"
+    | "claude-code"
+    | "codex"
+    | "cursor"
+    | "opencode";
   dockIconStyle: "default" | "flat";
   dockPlacement: "bottom" | "left";
   deletedAgentConversationRetentionDays: 15 | 30;

--- a/packages/events/protocol/src/generated/registry.ts
+++ b/packages/events/protocol/src/generated/registry.ts
@@ -53,7 +53,7 @@ export interface BusinessEventDefinition {
   scope: BusinessEventScopeName;
 }
 
-export const businessEventCatalogRevision = "sha256:0883cf9e6ae0b25c" as const;
+export const businessEventCatalogRevision = "sha256:bbb3396091e770f0" as const;
 
 export const businessEventDefinitions = [
   {

--- a/packages/events/protocol/src/generated/schemas.ts
+++ b/packages/events/protocol/src/generated/schemas.ts
@@ -231,7 +231,7 @@ export const preferencesDesktopPreferencesSchema = {
     },
     defaultAgentProvider: {
       type: "string",
-      enum: ["claude-code", "codex", "cursor", "opencode"]
+      enum: ["tutti-agent", "claude-code", "codex", "cursor", "opencode"]
     },
     dockIconStyle: {
       type: "string",
@@ -1917,7 +1917,7 @@ export const preferencesDesktopUpdateRequestedPayloadSchema = {
         },
         defaultAgentProvider: {
           type: "string",
-          enum: ["claude-code", "codex", "cursor", "opencode"]
+          enum: ["tutti-agent", "claude-code", "codex", "cursor", "opencode"]
         },
         dockIconStyle: {
           type: "string",
@@ -2265,7 +2265,7 @@ export const preferencesDesktopUpdatedPayloadSchema = {
         },
         defaultAgentProvider: {
           type: "string",
-          enum: ["claude-code", "codex", "cursor", "opencode"]
+          enum: ["tutti-agent", "claude-code", "codex", "cursor", "opencode"]
         },
         dockIconStyle: {
           type: "string",

--- a/services/tuttid/api/events/generated/protocol.gen.go
+++ b/services/tuttid/api/events/generated/protocol.gen.go
@@ -6,7 +6,7 @@ import "encoding/json"
 
 const (
 	BusinessEventProtocolVersion = 1
-	BusinessEventCatalogRevision = "sha256:0883cf9e6ae0b25c"
+	BusinessEventCatalogRevision = "sha256:bbb3396091e770f0"
 )
 
 type Topic string

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -1444,6 +1444,7 @@ const (
 	DesktopDefaultAgentProviderCodex      DesktopDefaultAgentProvider = "codex"
 	DesktopDefaultAgentProviderCursor     DesktopDefaultAgentProvider = "cursor"
 	DesktopDefaultAgentProviderOpencode   DesktopDefaultAgentProvider = "opencode"
+	DesktopDefaultAgentProviderTuttiAgent DesktopDefaultAgentProvider = "tutti-agent"
 )
 
 // Valid indicates whether the value is a known member of the DesktopDefaultAgentProvider enum.
@@ -1456,6 +1457,8 @@ func (e DesktopDefaultAgentProvider) Valid() bool {
 	case DesktopDefaultAgentProviderCursor:
 		return true
 	case DesktopDefaultAgentProviderOpencode:
+		return true
+	case DesktopDefaultAgentProviderTuttiAgent:
 		return true
 	default:
 		return false

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -7881,11 +7881,13 @@ components:
     DesktopDefaultAgentProvider:
       type: string
       enum:
+        - tutti-agent
         - claude-code
         - codex
         - cursor
         - opencode
       x-enum-varnames:
+        - DesktopDefaultAgentProviderTuttiAgent
         - DesktopDefaultAgentProviderClaudeCode
         - DesktopDefaultAgentProviderCodex
         - DesktopDefaultAgentProviderCursor

--- a/services/tuttid/data/workspace/desktop_preferences_migrations.go
+++ b/services/tuttid/data/workspace/desktop_preferences_migrations.go
@@ -28,7 +28,7 @@ CREATE TABLE IF NOT EXISTS desktop_preferences (
   dock_icon_style TEXT NOT NULL DEFAULT 'flat',
   dock_placement TEXT NOT NULL DEFAULT 'bottom',
   deleted_agent_conversation_retention_days INTEGER NOT NULL DEFAULT 30,
-  default_agent_provider TEXT NOT NULL DEFAULT 'codex',
+  default_agent_provider TEXT NOT NULL DEFAULT 'tutti-agent',
   agent_conversation_detail_mode TEXT NOT NULL DEFAULT 'coding',
   agent_composer_defaults_by_provider_json TEXT NOT NULL DEFAULT '{}',
   agent_gui_conversation_rail_collapsed_by_provider_json TEXT NOT NULL DEFAULT '{}',
@@ -600,7 +600,7 @@ func (s *SQLiteStore) applyDesktopPreferencesDefaultAgentProviderV1(ctx context.
 	if !hasDefaultAgentProvider {
 		if _, err := s.writeDB.ExecContext(ctx, `
 ALTER TABLE desktop_preferences
-  ADD COLUMN default_agent_provider TEXT NOT NULL DEFAULT 'codex';`); err != nil {
+  ADD COLUMN default_agent_provider TEXT NOT NULL DEFAULT 'tutti-agent';`); err != nil {
 			return fmt.Errorf("migrate workspace database for desktop default agent provider: %w", err)
 		}
 	}

--- a/services/tuttid/data/workspace/sqlite_preferences_test.go
+++ b/services/tuttid/data/workspace/sqlite_preferences_test.go
@@ -32,8 +32,8 @@ func TestSQLiteStoreGetDesktopPreferencesDefaultsWhenUnset(t *testing.T) {
 	if preferences.DeletedAgentConversationRetentionDays != 30 {
 		t.Fatalf("GetDesktopPreferences() retention days = %d, want 30", preferences.DeletedAgentConversationRetentionDays)
 	}
-	if preferences.DefaultAgentProvider != "codex" {
-		t.Fatalf("GetDesktopPreferences() defaultAgentProvider = %q, want codex", preferences.DefaultAgentProvider)
+	if preferences.DefaultAgentProvider != "tutti-agent" {
+		t.Fatalf("GetDesktopPreferences() defaultAgentProvider = %q, want tutti-agent", preferences.DefaultAgentProvider)
 	}
 	if preferences.AgentConversationDetailMode != "coding" {
 		t.Fatalf("GetDesktopPreferences() agentConversationDetailMode = %q, want coding", preferences.AgentConversationDetailMode)

--- a/services/tuttid/service/cli/providers/agentcontext/provider_test.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider_test.go
@@ -1151,8 +1151,8 @@ func TestAgentsCommandReturnsAvailability(t *testing.T) {
 	if len(agents) != 1 || agents[0].(map[string]any)["id"] != agenttargetbiz.IDLocalCodex {
 		t.Fatalf("agents = %#v", agents)
 	}
-	if output.Value["defaultAgentTargetId"] != agenttargetbiz.IDLocalCodex {
-		t.Fatalf("defaultAgentTargetId = %#v, want global default %q", output.Value["defaultAgentTargetId"], agenttargetbiz.IDLocalCodex)
+	if output.Value["defaultAgentTargetId"] != agenttargetbiz.IDLocalTuttiAgent {
+		t.Fatalf("defaultAgentTargetId = %#v, want global default %q", output.Value["defaultAgentTargetId"], agenttargetbiz.IDLocalTuttiAgent)
 	}
 	if len(sessions.availabilityIn) != 1 || sessions.availabilityIn[0].Provider != "codex" {
 		t.Fatalf("availability inputs = %#v, want only requested provider", sessions.availabilityIn)
@@ -1768,8 +1768,8 @@ func TestAgentListKeepsMultipleAgentsForOneProvider(t *testing.T) {
 	if !equalStrings(codexAgentIDs, []string{"user:reviewer", agenttargetbiz.IDLocalCodex}) {
 		t.Fatalf("codex agent ids = %#v", codexAgentIDs)
 	}
-	if output.Value["defaultAgentTargetId"] != agenttargetbiz.IDLocalCodex {
-		t.Fatalf("defaultAgentTargetId = %#v, want exact built-in target %q", output.Value["defaultAgentTargetId"], agenttargetbiz.IDLocalCodex)
+	if output.Value["defaultAgentTargetId"] != agenttargetbiz.IDLocalTuttiAgent {
+		t.Fatalf("defaultAgentTargetId = %#v, want exact built-in target %q", output.Value["defaultAgentTargetId"], agenttargetbiz.IDLocalTuttiAgent)
 	}
 }
 
@@ -1871,8 +1871,8 @@ func TestAgentListFallsBackWhenDesktopPreferencesCannotBeRead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Handler: %v", err)
 	}
-	if output.Value["defaultAgentTargetId"] != agenttargetbiz.IDLocalCodex {
-		t.Fatalf("defaultAgentTargetId = %#v, want built-in fallback %q", output.Value["defaultAgentTargetId"], agenttargetbiz.IDLocalCodex)
+	if output.Value["defaultAgentTargetId"] != agenttargetbiz.IDLocalTuttiAgent {
+		t.Fatalf("defaultAgentTargetId = %#v, want built-in fallback %q", output.Value["defaultAgentTargetId"], agenttargetbiz.IDLocalTuttiAgent)
 	}
 }
 


### PR DESCRIPTION
## Summary

- make Tutti Agent the first eligible Desktop default Provider
- add `tutti-agent` to Desktop preferences, OpenAPI, and event contracts, then regenerate clients and catalogs
- preserve explicit existing preferences while using Tutti Agent for new or uninitialized defaults
- document precedence and readiness fallback behavior

## Testing

- `pnpm check:changed -- --failed-only` (30 lanes passed)
- pre-push `pnpm check:changed -- --push-ready` (33 lanes passed)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1861" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->