### PR TITLE
fix(agent-activity): coalesce streaming message sync

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -306,7 +306,7 @@ test("desktop agent activity adapter maps tuttid sessions and messages", async (
       order: null
     },
     event: "agent.activity.messages.list",
-    level: "info",
+    level: "debug",
     workspaceId
   });
   const resolvedDiagnostic = diagnostics[1] as {
@@ -316,7 +316,7 @@ test("desktop agent activity adapter maps tuttid sessions and messages", async (
     workspaceId?: string;
   };
   assert.equal(resolvedDiagnostic.event, "agent.activity.messages.list");
-  assert.equal(resolvedDiagnostic.level, "info");
+  assert.equal(resolvedDiagnostic.level, "debug");
   assert.equal(resolvedDiagnostic.workspaceId, workspaceId);
   assert.equal(resolvedDiagnostic.details?.agentSessionId, "agent-session-1");
   assert.equal(resolvedDiagnostic.details?.event, "resolved");

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -726,7 +726,7 @@ function reportDesktopAgentMessageListDiagnostic(
       .logTerminalDiagnostic({
         details,
         event: "agent.activity.messages.list",
-        level: details.event === "failed" ? "warn" : "info",
+        level: details.event === "failed" ? "warn" : "debug",
         workspaceId
       })
       .catch(() => {});

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -1153,7 +1153,7 @@ test("WorkspaceAgentActivityService starts session-event streams and forwards ca
   assert.deepEqual(await receivedTurnEvent, turnEvent);
 });
 
-test("WorkspaceAgentActivityService reconciles a realtime message version gap before advancing the cursor", async () => {
+test("WorkspaceAgentActivityService reconciles a realtime message version gap after its streaming debounce", async () => {
   const listenersByTopic = new Map<string, (event: unknown) => void>();
   const messageRequests: Array<Record<string, unknown>> = [];
   const diagnostics: Array<{
@@ -1303,6 +1303,7 @@ test("WorkspaceAgentActivityService reconciles a realtime message version gap be
     }
   });
 
+  await new Promise((resolve) => setTimeout(resolve, 75));
   for (let attempt = 0; attempt < 10 && messageRequests.length < 2; attempt++) {
     await new Promise((resolve) => setImmediate(resolve));
   }

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -183,6 +183,11 @@ It owns:
 - authoritative Session reconcile execution: scope selection, mapped detail
   aggregation, message cursor/window policy, bounded page draining, the
   discovery/detail race fence, and atomic Engine application
+- a 50ms streaming message reconcile window, aligned with the daemon streaming
+  report coalescer, for cached `message_update` observations whose inline
+  message versions have a gap; explicit reads, lifecycle transitions, and state
+  repair remain immediate, and the deferred read still uses the authoritative
+  message cursor
 - selectors for reusable derived state
 - `selectNeedsAttentionCount`
 - `selectNeedsAttentionItems`

--- a/packages/agent/activity-core/src/engine/sessionReconcile.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionReconcile.reducer.test.ts
@@ -78,6 +78,76 @@ test("activity observation derives reconcile scope inside the engine", () => {
   ]);
 });
 
+test("streaming message gaps coalesce into one delayed reconcile and one trailing read", () => {
+  const observation = {
+    agentSessionId: "session-1",
+    eventType: "message_update",
+    hasCachedSession: true,
+    hasInlineMessages: true,
+    inlineApplied: false,
+    type: "session/activityObserved" as const,
+    workspaceId: "workspace-1"
+  };
+  let result = reduce(createInitialSessionReconcileState(), observation);
+
+  assert.deepEqual(result.commands, [
+    {
+      delayMs: 50,
+      expiryId: "session:streaming-message-reconcile:session-1",
+      type: "engine/scheduleExpiryAfter"
+    }
+  ]);
+  result = reduce(result.state, observation);
+  assert.equal(result.commands.length, 0);
+
+  result = reduce(result.state, {
+    dueAtUnixMs: 50,
+    expiryId: "session:streaming-message-reconcile:session-1",
+    type: "engine/intentExpired"
+  });
+  assert.equal(result.commands[0]?.type, "session/reconcile");
+
+  result = reduce(result.state, observation);
+  assert.equal(result.commands.length, 0);
+
+  result = reduce(result.state, {
+    commandId: "session:reconcile:session-1:1",
+    commandType: "session/reconcile",
+    outcome: "succeeded",
+    type: "engine/commandResult"
+  });
+  assert.deepEqual(result.commands, [
+    {
+      delayMs: 50,
+      expiryId: "session:streaming-message-reconcile:session-1",
+      type: "engine/scheduleExpiryAfter"
+    }
+  ]);
+});
+
+test("an explicit message reconcile bypasses a pending streaming delay", () => {
+  const deferred = reduce(createInitialSessionReconcileState(), {
+    agentSessionId: "session-1",
+    eventType: "message_update",
+    hasCachedSession: true,
+    hasInlineMessages: true,
+    inlineApplied: false,
+    type: "session/activityObserved",
+    workspaceId: "workspace-1"
+  });
+
+  const immediate = reduce(deferred.state, {
+    agentSessionId: "session-1",
+    needsMessages: true,
+    needsState: false,
+    type: "session/reconcileRequested",
+    workspaceId: "workspace-1"
+  });
+
+  assert.equal(immediate.commands[0]?.type, "engine/cancelExpiry");
+  assert.equal(immediate.commands[1]?.type, "session/reconcile");
+});
+
 test("inline-applied activity does not schedule redundant transport work", () => {
   const result = reduce(createInitialSessionReconcileState(), {
     type: "session/activityObserved",
@@ -222,9 +292,11 @@ test("failed reconcile preserves typed error details for exact recovery", () => 
     inFlightCommandId: null,
     inFlightLive: false,
     inFlightScope: null,
+    messageRefreshScheduled: false,
     messagesHydrated: false,
     pendingLive: false,
     pendingMessages: false,
+    pendingMessagesImmediate: false,
     pendingState: false,
     requiredHistoryRevision: null,
     workspaceId: "workspace-1"
@@ -397,9 +469,11 @@ test("a history checkpoint initializes a complete inactive reconcile record", ()
     inFlightCommandId: null,
     inFlightLive: false,
     inFlightScope: null,
+    messageRefreshScheduled: false,
     messagesHydrated: false,
     pendingLive: false,
     pendingMessages: false,
+    pendingMessagesImmediate: false,
     pendingState: false,
     requiredHistoryRevision: null,
     workspaceId: "workspace-1"

--- a/packages/agent/activity-core/src/engine/sessionReconcile.reducer.ts
+++ b/packages/agent/activity-core/src/engine/sessionReconcile.reducer.ts
@@ -11,6 +11,10 @@ import type {
 import type { CanonicalAgentSession } from "./sessionLifecycle.types.ts";
 
 const NO_COMMANDS: readonly EngineCommand[] = [];
+// Keep the renderer recovery window aligned with the daemon's fixed 50ms
+// streaming-report coalescer. They run in separate processes, so this is a
+// shared timing contract rather than one shared timer.
+const STREAMING_MESSAGE_COALESCE_WINDOW_MS = 50;
 
 export function createInitialSessionReconcileState(): SessionReconcileState {
   return { nextCommandSequence: 1, recordsBySessionId: {} };
@@ -51,6 +55,11 @@ export function sessionReconcileReducer(
       }
       return requestReconcile(state, {
         agentSessionId: intent.agentSessionId,
+        deferMessages:
+          intent.eventType === "message_update" &&
+          intent.hasCachedSession &&
+          intent.hasInlineMessages &&
+          intent.terminalTurn !== true,
         needsMessages:
           intent.eventType === "message_update" ||
           intent.eventType === "session_audit" ||
@@ -82,6 +91,8 @@ export function sessionReconcileReducer(
       return requestReconcile(state, intent);
     case "session/removed":
       return removeRecord(state, intent.agentSessionId);
+    case "engine/intentExpired":
+      return expireStreamingMessageReconcile(state, intent.expiryId);
     case "engine/commandResult":
       if (
         intent.commandType === "engine/reconcileWorkspace" &&
@@ -209,6 +220,7 @@ function requestReconcile(
     agentSessionId: string;
     live?: boolean;
     authoritativeMessages?: boolean;
+    deferMessages?: boolean;
     needsMessages: boolean;
     needsState: boolean;
     requiredHistoryRevision?: number;
@@ -239,9 +251,11 @@ function requestReconcile(
     inFlightCommandId: null,
     inFlightLive: false,
     inFlightScope: null,
+    messageRefreshScheduled: false,
     messagesHydrated: false,
     pendingLive: false,
     pendingMessages: false,
+    pendingMessagesImmediate: false,
     pendingState: false,
     requiredHistoryRevision: null,
     workspaceId
@@ -254,6 +268,19 @@ function requestReconcile(
           (current.requiredHistoryRevision ??
             current.appliedHistoryRevision ??
             -1)));
+  const deferMessages =
+    input.deferMessages === true &&
+    input.needsMessages &&
+    !input.needsState &&
+    input.live !== true &&
+    input.authoritativeMessages !== true &&
+    requiredHistoryRevision === null &&
+    !current.authoritativeMessagesRequired &&
+    !historyRevisionIsPending(current);
+  const pendingMessages =
+    current.pendingMessages ||
+    input.needsMessages ||
+    authoritativeDemandArrivedWhileInFlight;
   const record = {
     ...current,
     authoritativeMessagesRequired:
@@ -262,10 +289,11 @@ function requestReconcile(
     errorCode: null,
     errorMessage: null,
     pendingLive: current.pendingLive || input.live === true,
-    pendingMessages:
-      current.pendingMessages ||
-      input.needsMessages ||
-      authoritativeDemandArrivedWhileInFlight,
+    pendingMessages,
+    pendingMessagesImmediate:
+      pendingMessages &&
+      (current.pendingMessagesImmediate ||
+        (input.needsMessages && !deferMessages)),
     pendingState: current.pendingState || input.needsState,
     requiredHistoryRevision:
       requiredHistoryRevision === null
@@ -276,12 +304,31 @@ function requestReconcile(
           )
   };
   const next = replaceRecord(state, record);
-  return record.inFlightCommandId ||
-    (!record.pendingMessages &&
-      !record.pendingState &&
-      !record.authoritativeMessagesRequired &&
-      !historyRevisionIsPending(record))
-    ? { commands: NO_COMMANDS, state: next }
+  if (record.inFlightCommandId || !hasReconcileDemand(record)) {
+    return { commands: NO_COMMANDS, state: next };
+  }
+  if (record.messageRefreshScheduled) {
+    if (deferMessages) {
+      return { commands: NO_COMMANDS, state: next };
+    }
+    const unscheduled = { ...record, messageRefreshScheduled: false };
+    const started = startReconcile(
+      replaceRecord(state, unscheduled),
+      unscheduled
+    );
+    return {
+      commands: [
+        {
+          expiryId: streamingMessageReconcileExpiryId(record.agentSessionId),
+          type: "engine/cancelExpiry"
+        },
+        ...started.commands
+      ],
+      state: started.state
+    };
+  }
+  return deferMessages
+    ? scheduleStreamingMessageReconcile(next, record)
     : startReconcile(next, record);
 }
 
@@ -316,13 +363,74 @@ function settleReconcile(
       (intent.outcome !== "succeeded" && record.inFlightLive)
   };
   const next = replaceRecord(state, settled);
-  return settled.pendingMessages ||
+  const shouldContinue =
+    settled.pendingMessages ||
     settled.pendingState ||
     (intent.outcome === "succeeded" &&
       (settled.authoritativeMessagesRequired ||
-        historyRevisionIsPending(settled)))
-    ? startReconcile(next, settled)
-    : { commands: NO_COMMANDS, state: next };
+        historyRevisionIsPending(settled)));
+  if (!shouldContinue) {
+    return { commands: NO_COMMANDS, state: next };
+  }
+  return settled.pendingMessages &&
+    !settled.pendingMessagesImmediate &&
+    !settled.pendingState &&
+    !settled.pendingLive &&
+    !settled.authoritativeMessagesRequired &&
+    !historyRevisionIsPending(settled)
+    ? scheduleStreamingMessageReconcile(next, settled)
+    : startReconcile(next, settled);
+}
+
+function expireStreamingMessageReconcile(
+  state: SessionReconcileState,
+  expiryId: string
+): EngineReducerResult<SessionReconcileState> {
+  const record = Object.values(state.recordsBySessionId).find(
+    (candidate) =>
+      candidate.messageRefreshScheduled &&
+      streamingMessageReconcileExpiryId(candidate.agentSessionId) === expiryId
+  );
+  if (!record) return unchanged(state);
+  const ready = { ...record, messageRefreshScheduled: false };
+  const next = replaceRecord(state, ready);
+  if (ready.inFlightCommandId || !hasReconcileDemand(ready)) {
+    return { commands: NO_COMMANDS, state: next };
+  }
+  return startReconcile(next, ready);
+}
+
+function scheduleStreamingMessageReconcile(
+  state: SessionReconcileState,
+  record: SessionReconcileRecord
+): EngineReducerResult<SessionReconcileState> {
+  if (record.messageRefreshScheduled || record.inFlightCommandId) {
+    return { commands: NO_COMMANDS, state };
+  }
+  const scheduled = { ...record, messageRefreshScheduled: true };
+  return {
+    commands: [
+      {
+        delayMs: STREAMING_MESSAGE_COALESCE_WINDOW_MS,
+        expiryId: streamingMessageReconcileExpiryId(record.agentSessionId),
+        type: "engine/scheduleExpiryAfter"
+      }
+    ],
+    state: replaceRecord(state, scheduled)
+  };
+}
+
+function streamingMessageReconcileExpiryId(agentSessionId: string): string {
+  return `session:streaming-message-reconcile:${agentSessionId}`;
+}
+
+function hasReconcileDemand(record: SessionReconcileRecord): boolean {
+  return (
+    record.pendingMessages ||
+    record.pendingState ||
+    record.authoritativeMessagesRequired ||
+    historyRevisionIsPending(record)
+  );
 }
 
 function startReconcile(
@@ -368,8 +476,10 @@ function startReconcile(
         inFlightCommandId: commandId,
         inFlightLive: live,
         inFlightScope: scope,
+        messageRefreshScheduled: false,
         pendingLive: false,
         pendingMessages: false,
+        pendingMessagesImmediate: false,
         pendingState: false
       }
     )
@@ -400,9 +510,11 @@ function applyHistoryCheckpoint(
     inFlightCommandId: null,
     inFlightLive: false,
     inFlightScope: null,
+    messageRefreshScheduled: false,
     messagesHydrated: false,
     pendingLive: false,
     pendingMessages: false,
+    pendingMessagesImmediate: false,
     pendingState: false,
     requiredHistoryRevision: null,
     workspaceId
@@ -428,7 +540,11 @@ function applyHistoryCheckpoint(
     pendingMessages:
       authoritative && !requiredHistoryRevisionRemainsPending
         ? false
-        : current.pendingMessages
+        : current.pendingMessages,
+    pendingMessagesImmediate:
+      authoritative && !requiredHistoryRevisionRemainsPending
+        ? false
+        : current.pendingMessagesImmediate
   };
   return {
     commands: NO_COMMANDS,
@@ -468,12 +584,21 @@ function removeRecord(
   rawAgentSessionId: string
 ): EngineReducerResult<SessionReconcileState> {
   const records = { ...state.recordsBySessionId };
-  if (!records[rawAgentSessionId.trim()]) {
+  const agentSessionId = rawAgentSessionId.trim();
+  const record = records[agentSessionId];
+  if (!record) {
     return unchanged(state);
   }
-  delete records[rawAgentSessionId.trim()];
+  delete records[agentSessionId];
   return {
-    commands: NO_COMMANDS,
+    commands: record.messageRefreshScheduled
+      ? [
+          {
+            expiryId: streamingMessageReconcileExpiryId(agentSessionId),
+            type: "engine/cancelExpiry"
+          }
+        ]
+      : NO_COMMANDS,
     state: { ...state, recordsBySessionId: records }
   };
 }

--- a/packages/agent/activity-core/src/engine/sessionReconcile.types.ts
+++ b/packages/agent/activity-core/src/engine/sessionReconcile.types.ts
@@ -33,9 +33,11 @@ export interface SessionReconcileRecord {
   inFlightCommandId: string | null;
   inFlightLive: boolean;
   inFlightScope: SessionReconcileScope | null;
+  messageRefreshScheduled: boolean;
   messagesHydrated: boolean;
   pendingLive: boolean;
   pendingMessages: boolean;
+  pendingMessagesImmediate: boolean;
   pendingState: boolean;
   requiredHistoryRevision: number | null;
   workspaceId: string;

--- a/services/tuttid/api/daemon_agent_sessions.go
+++ b/services/tuttid/api/daemon_agent_sessions.go
@@ -215,7 +215,7 @@ func (api DaemonAPI) ListWorkspaceAgentSessionMessages(ctx context.Context, requ
 		}
 		input.Limit = *request.Params.Limit
 	}
-	slog.Info("workspace agent session messages list requested",
+	slog.Debug("workspace agent session messages list requested",
 		"event", "workspace.agent_session.messages.api.list_requested",
 		"workspace_id", workspaceID,
 		"agent_session_id", agentSessionID,
@@ -270,7 +270,7 @@ func (api DaemonAPI) ListWorkspaceAgentSessionMessages(ctx context.Context, requ
 		return writeListWorkspaceAgentSessionMessagesError(err), nil
 	}
 	firstVersion, lastVersion := generatedAgentSessionMessageVersionRange(messages)
-	slog.Info("workspace agent session messages list completed",
+	slog.Debug("workspace agent session messages list completed",
 		"event", "workspace.agent_session.messages.api.list_completed",
 		"workspace_id", workspaceID,
 		"agent_session_id", agentSessionID,


### PR DESCRIPTION
## Summary

- Coalesce cached streaming `message_update` version gaps into one 50ms reconcile window, aligned with the daemon streaming-report coalescer; explicit, lifecycle, and repair reads remain immediate.
- Move successful per-request message-list diagnostics to `debug`, preserve failures at `warn`, and retain the existing daemon activity-report summary instead of adding a second aggregator.
- Add reducer and service-level timing coverage; document activity-core ownership.

## Verification

- `pnpm check:changed -- --push-ready`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm --filter @tutti-os/agent-activity-core exec node --test --experimental-strip-types src/engine/sessionReconcile.reducer.test.ts`
- `pnpm --filter @tutti-os/desktop exec node --import ./test/register-asset-stub.mjs --test --experimental-strip-types src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts`

## Fallback Three Questions

- Source: cached sessions can receive a streaming `message_update` whose inline message versions have a gap, so the cursor cannot advance safely without a reconcile.
- Why it cannot be fixed at the source: activity messages can validly be batched or arrive out of order while preserving low-latency provider updates; the shared reconcile layer is the durable authority for cursor repair.
- Removal condition: every supported provider event guarantees a contiguous authoritative message projection that lets the engine advance the cursor without a list read.

## Checklist

- [x] No agent lifecycle semantics changed; this is activity-core read scheduling.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] README/CONTRIBUTING English sources were not changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commit is signed off with DCO.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1862" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->