### PR TITLE
refactor(agent): unify session activation admission

### DIFF
--- a/apps/mobile/src/services/workspaceActivityService.test.ts
+++ b/apps/mobile/src/services/workspaceActivityService.test.ts
@@ -266,15 +266,89 @@ describe("WorkspaceActivityService", () => {
 
     await service.start();
     await flushAsyncWork();
+    const engine = (
+      service as unknown as {
+        engine: AgentSessionEngine;
+      }
+    ).engine;
+    const activateSession = jest.spyOn(engine, "activateSession");
     service.startCreating();
     service.setDraft("start");
     await service.send();
     await flushAsyncWork();
 
+    expect(activateSession).toHaveBeenCalledTimes(1);
+    expect(activateSession).toHaveBeenCalledWith({
+      agentSessionId: expect.any(String),
+      agentTargetId: "target-1",
+      clientSubmitId: expect.any(String),
+      initialContent: [{ text: "start", type: "text" }],
+      initialTurnExpected: true,
+      mode: "new",
+      requestId: expect.any(String),
+      runtimeContent: [{ text: "start", type: "text" }],
+      settings: {
+        model: null,
+        permissionModeId: null,
+        planMode: null,
+        reasoningEffort: null,
+        speed: null
+      },
+      submitDiagnostics: {
+        blockCount: 1,
+        promptLength: 5,
+        source: "mobile",
+        submittedAtUnixMs: expect.any(Number)
+      },
+      visible: true
+    });
+    const activationInput = activateSession.mock.calls[0]?.[0];
+    expect(activationInput?.mode).toBe("new");
+    if (activationInput?.mode === "new") {
+      expect(activationInput.requestId).toBe(activationInput.clientSubmitId);
+    }
     expect(createCalls).toBe(1);
     expect(service.getSnapshot().selectedAgentSessionId).not.toBeNull();
     expect(service.getSnapshot().sending).toBe(false);
 
+    service.dispose();
+  });
+
+  test("preserves the new-Session draft when activation admission is rejected", async () => {
+    const service = createService(
+      createClient({
+        composerOptions: async () => ({
+          behavior: {
+            collapseModelOptionsToLatest: false,
+            modelOptionsAuthoritative: true,
+            planModeExclusiveWithPermissionMode: false,
+            prewarmDraftSession: false,
+            refreshModelOptionsAfterSettings: false
+          },
+          effectiveSettings: {},
+          provider: "codex"
+        }),
+        listMessages: emptyMessagePage,
+        session: () => null,
+        targets: [createTarget()]
+      })
+    );
+
+    await service.start();
+    await flushAsyncWork();
+    const engine = (
+      service as unknown as {
+        engine: AgentSessionEngine;
+      }
+    ).engine;
+    jest.spyOn(engine, "activateSession").mockReturnValue(false);
+    service.startCreating();
+    service.setDraft("start");
+
+    await service.send();
+
+    expect(service.getSnapshot().draft).toBe("start");
+    expect(service.getSnapshot().sending).toBe(false);
     service.dispose();
   });
 

--- a/apps/mobile/src/services/workspaceActivityService.ts
+++ b/apps/mobile/src/services/workspaceActivityService.ts
@@ -46,7 +46,6 @@ import { WorkspaceMediaService } from "./workspaceMediaService";
 export type { WorkspaceActivitySnapshot } from "./workspaceActivityTypes";
 
 const MESSAGE_POLL_MS = 1_000;
-const ACTIVATION_EXPIRY_MS = 60_000;
 
 export class WorkspaceActivityService extends ObservableService<WorkspaceActivitySnapshot> {
   readonly _serviceBrand: undefined;
@@ -431,24 +430,22 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
       submittedAtUnixMs: now
     };
     if (snapshot.creating) {
-      this.engine.dispatch({
+      const accepted = this.engine.activateSession({
         agentSessionId: submission.agentSessionId,
         agentTargetId: submission.agentTargetId!,
         clientSubmitId: submission.clientSubmitId,
-        content,
-        expiresAtUnixMs: now + ACTIVATION_EXPIRY_MS,
+        initialContent: content,
         initialTurnExpected: true,
         mode: "new",
         requestId: submission.clientSubmitId,
-        requestedAtUnixMs: now,
         runtimeContent: content,
         settings: snapshot.composerSettings,
         submitDiagnostics,
-        type: "activation/requested",
-        visible: true,
-        workspaceId: this.workspace.id
+        visible: true
       });
-      this.drafts.clear("new");
+      if (accepted) {
+        this.drafts.clear("new");
+      }
       return;
     }
     if (!snapshot.selectedAgentSessionId) return;

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -206,10 +206,14 @@ It owns:
   new-Session activation command instead of allowing presentation expiry to
   race a valid slow startup. The caller retains the stable activation request
   and client submit identities used by optimistic state, dismissal, draft
-  recovery, and idempotent retry. Prompt submission owns routing, the same
-  confirmation window, and the accepted/queued result while its caller retains
-  the stable client submit identity. Stop, Interaction, and settings
-  additionally own command identity plus the 30-second delivery timeout.
+  recovery, and idempotent retry. While an activation record exists, its
+  request identity is single-use: the semantic method reports acceptance only
+  when the current dispatch creates a new record, not when a rejected duplicate
+  finds an older record for the same Session and mode. Prompt submission owns
+  routing, the same confirmation window, and the accepted/queued result while
+  its caller retains the stable client submit identity. Stop, Interaction, and
+  settings additionally own command identity plus the 30-second delivery
+  timeout.
   Session stop owns the 30-second first-Turn waiting window and duplicate
   admission across Desktop and Mobile. Interaction submission owns canonical
   pending-target admission,

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -196,14 +196,19 @@ It owns:
   validation for rename and pin, validated delete-result tombstone projection,
   shared mutation settlement, and a serialized settings-precondition state
   machine
-- semantic `AgentSessionEngine` methods for composer-option loading,
-  existing-Session Prompt submission, Session stop, Interaction response
-  submission, existing-Session settings updates, rename, pin, and batch
-  delete. Prompt, stop, Interaction, and settings updates are intent admission:
-  the Engine owns workspace and protocol construction. Prompt submission owns
-  routing, the 120-second confirmation window, and the accepted/queued
-  admission result while the caller retains the stable client submit identity
-  used by draft recovery and idempotent retry. Stop, Interaction, and settings
+- semantic `AgentSessionEngine` methods for composer-option loading, Session
+  activation, existing-Session Prompt submission, Session stop, Interaction
+  response submission, existing-Session settings updates, rename, pin, and
+  batch delete. Activation, Prompt, stop, Interaction, and settings updates are
+  intent admission: the Engine owns workspace and protocol construction.
+  Activation owns requested/expiry timestamps, the 120-second confirmation
+  window, and the accepted result. This window contains the 90-second
+  new-Session activation command instead of allowing presentation expiry to
+  race a valid slow startup. The caller retains the stable activation request
+  and client submit identities used by optimistic state, dismissal, draft
+  recovery, and idempotent retry. Prompt submission owns routing, the same
+  confirmation window, and the accepted/queued result while its caller retains
+  the stable client submit identity. Stop, Interaction, and settings
   additionally own command identity plus the 30-second delivery timeout.
   Session stop owns the 30-second first-Turn waiting window and duplicate
   admission across Desktop and Mobile. Interaction submission owns canonical
@@ -225,6 +230,13 @@ Product hosts call `updateSessionSettings` for an existing Session instead of
 constructing `session/settingsUpdateRequested` protocol fields. Settings held
 before Session activation remain part of the activation flow and do not pass
 through this existing-Session method.
+Desktop AgentGUI and Mobile call `activateSession` instead of constructing
+`activation/requested` protocol fields. Product surfaces still choose target,
+placement, initial settings/content, and durable request identities; the Engine
+admits that domain request under one workspace scope and confirmation policy.
+Only an admitted activation may clear the new-Session draft. Actual Session
+creation, resume, and initial Turn lifecycle remain Agent Host semantics behind
+the host effect port.
 Desktop AgentGUI and Mobile call `stopSession` instead of constructing
 `session/stopRequested` protocol fields. The same method stops an active Turn
 or records a bounded request that cancels the first Turn produced by an

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -668,7 +668,7 @@ disable submission, but must not change editor editability.
   into `AgentSessionEffectPort` calls. Desktop and Mobile effect ports retain
   transport and DTO mapping but must not duplicate a command-type switch for
   these shared effects. Host activity facades call
-  `engine.submitPrompt`, `engine.stopSession`,
+  `engine.activateSession`, `engine.submitPrompt`, `engine.stopSession`,
   `engine.updateSessionSettings`, `engine.renameSession`,
   `engine.setSessionPinned`, and `engine.deleteSessions`; these deep methods own
   the applicable workspace projection, protocol or mutation identity, timeout,
@@ -682,6 +682,14 @@ disable submission, but must not change editor editability.
   identity, 30-second cancellation timeout, duplicate fence, and 30-second
   first-Turn waiting window. Desktop AgentGUI and Native Mobile call
   `engine.stopSession` and never construct raw `session/stopRequested` fields.
+  Session activation enters through `engine.activateSession`. Desktop AgentGUI
+  and Native Mobile keep product-specific target selection, placement, initial
+  content/settings, and stable request identities, while the Engine owns
+  workspace scope, timestamps, construction of `activation/requested`, the
+  accepted result, and one 120-second confirmation window. The confirmation
+  deadline is later than the 90-second new-Session command timeout so a valid
+  slow runtime startup cannot expire while the command may still succeed.
+  Surfaces clear a new-Session draft only after activation admission succeeds.
   Existing-Session Prompt submission enters through `engine.submitPrompt`.
   The surface keeps the stable `clientSubmitId` used by its draft-recovery and
   idempotent-retry bookkeeping; the Engine owns workspace scope, timestamps,
@@ -915,6 +923,12 @@ provider-specific settings schema.
 Existing-Session Prompt sends similarly enter through `engine.submitPrompt`;
 Desktop and Mobile provide content plus a stable client submit identity, while
 the Engine owns common routing, confirmation expiry, and admission projection.
+New- and existing-Session activation enters through `engine.activateSession`.
+The surfaces retain target selection, placement, initial draft projection, and
+stable request identity; the Engine derives workspace and timing fields,
+projects the typed intent, and reports whether it was admitted. Actual Session
+creation, resume, and initial Turn lifecycle remain owned by Agent Host behind
+the host effect port.
 
 An activation intent's shared Session settings are not an HTTP create-field
 allowlist. Each host must construct a typed

--- a/packages/agent/activity-core/README.md
+++ b/packages/agent/activity-core/README.md
@@ -62,9 +62,12 @@ Engine rules:
   identity or target scope and hide reducer protocol from hosts. Activation
   owns its timestamps, the 120-second confirmation window, intent projection,
   and admission result while the caller retains the exact request and client
-  submit identities used by optimistic state and idempotent retry. Session
-  mutations additionally allocate command identity, await exact settlement,
-  return canonical results, and own the default timeout and caller cancellation.
+  submit identities used by optimistic state and idempotent retry. A live
+  activation request identity is single-use: `activateSession` returns `true`
+  only when the current dispatch creates a new activation record, never because
+  an older record happens to match its Session and mode. Session mutations
+  additionally allocate command identity, await exact settlement, return
+  canonical results, and own the default timeout and caller cancellation.
   Cancellation aborts a mutation host effect; once delivery may have started,
   the mutation remains delivery-unknown rather than becoming a confirmed
   failure.

--- a/packages/agent/activity-core/README.md
+++ b/packages/agent/activity-core/README.md
@@ -54,13 +54,17 @@ Engine rules:
   explicitly. There is no module-level singleton; hosts running multiple
   runtimes against one workspace create one engine per origin.
 - Normalized observations and advanced lifecycle intents enter through
-  `dispatch(intent)`. Session rename, pin, and batch delete enter through the
-  semantic `engine.renameSession`, `engine.setSessionPinned`, and
-  `engine.deleteSessions` methods. Composer-option reads enter through
-  `engine.loadComposerOptions`. These methods derive workspace identity or
-  target scope, allocate command identity, await exact settlement, and return
-  canonical results without exposing reducer protocol to hosts. Session
-  mutations additionally own the default timeout and caller cancellation.
+  `dispatch(intent)`. Frontend activation enters through
+  `engine.activateSession`; Session rename, pin, and batch delete enter through
+  `engine.renameSession`, `engine.setSessionPinned`, and
+  `engine.deleteSessions`. Composer-option reads enter through
+  `engine.loadComposerOptions`. These semantic methods derive workspace
+  identity or target scope and hide reducer protocol from hosts. Activation
+  owns its timestamps, the 120-second confirmation window, intent projection,
+  and admission result while the caller retains the exact request and client
+  submit identities used by optimistic state and idempotent retry. Session
+  mutations additionally allocate command identity, await exact settlement,
+  return canonical results, and own the default timeout and caller cancellation.
   Cancellation aborts a mutation host effect; once delivery may have started,
   the mutation remains delivery-unknown rather than becoming a confirmed
   failure.

--- a/packages/agent/activity-core/src/engine/createAgentSessionEngine.ts
+++ b/packages/agent/activity-core/src/engine/createAgentSessionEngine.ts
@@ -21,6 +21,7 @@ import {
   dispatchSessionMutationWithCancellation,
   type SessionMutationCancellation
 } from "./sessionMutationDispatch.ts";
+import { requestSessionActivation } from "./sessionActivation.operation.ts";
 import {
   createInitialAgentSessionEngineState,
   rootEngineReducer
@@ -31,6 +32,7 @@ import {
   type AgentSessionEngineIdentity,
   type AgentSessionEngineIntentObserver,
   type AgentSessionEngineListener,
+  type AgentSessionActivationInput,
   type AgentSessionLoadComposerOptionsInput,
   type AgentSessionStopInput,
   type AgentSessionSubmitInteractionResponseInput,
@@ -50,10 +52,7 @@ import type {
   RootEngineIntent
 } from "./rootReducer.types.ts";
 
-// Session engine factory (docs/architecture/agent-gui-refactor-plan.md,
-// sections 3.3 and 4.1, engine skeleton slice).
-//
-// All state lives inside this closure: one instance per workspace + origin
+// All engine state lives inside this closure: one instance per workspace + origin
 // pair, injected explicitly by the host. The dispatch loop is serial — an
 // intent dispatched while a drain is running is queued and reduced within the
 // same drain — and subscribers are notified at most once per drain cycle.
@@ -459,6 +458,18 @@ export function createAgentSessionEngine({
     );
   }
 
+  function activateSession(input: AgentSessionActivationInput): boolean {
+    return requestSessionActivation(
+      {
+        clock,
+        dispatch,
+        getSnapshot: () => publicSnapshot,
+        workspaceId: engineIdentity.workspaceId
+      },
+      input
+    );
+  }
+
   function submitPrompt(
     input: AgentSessionSubmitPromptInput
   ): AgentSessionSubmitPromptResult {
@@ -560,6 +571,7 @@ export function createAgentSessionEngine({
   }
 
   const engine: AgentSessionEngine = {
+    activateSession,
     identity: engineIdentity,
     async deleteSessions(input) {
       const mutation = await dispatchSessionMutationWithCancellation(

--- a/packages/agent/activity-core/src/engine/sessionActivation.operation.ts
+++ b/packages/agent/activity-core/src/engine/sessionActivation.operation.ts
@@ -75,6 +75,10 @@ export function requestSessionActivation(
     ...(input.visible !== undefined ? { visible: input.visible } : {}),
     workspaceId: context.workspaceId
   };
+  const activationBeforeDispatch = selectPendingActivationByRequestId(
+    context.getSnapshot(),
+    requestId
+  );
   context.dispatch(
     input.mode === "new"
       ? {
@@ -110,6 +114,7 @@ export function requestSessionActivation(
     requestId
   );
   return (
+    activation !== activationBeforeDispatch &&
     activation?.agentSessionId === agentSessionId &&
     activation.mode === input.mode
   );

--- a/packages/agent/activity-core/src/engine/sessionActivation.operation.ts
+++ b/packages/agent/activity-core/src/engine/sessionActivation.operation.ts
@@ -1,0 +1,116 @@
+import { selectPendingActivationByRequestId } from "./pendingIntents.selectors.ts";
+import type {
+  AgentSessionActivationInput,
+  AgentSessionEngineState,
+  EngineClock,
+  EngineIntent
+} from "./types.ts";
+
+const SESSION_ACTIVATION_CONFIRMATION_TIMEOUT_MS = 120_000;
+
+interface SessionActivationOperationContext {
+  clock: EngineClock;
+  dispatch(intent: EngineIntent): void;
+  getSnapshot(): AgentSessionEngineState;
+  workspaceId: string;
+}
+
+export function requestSessionActivation(
+  context: SessionActivationOperationContext,
+  input: AgentSessionActivationInput
+): boolean {
+  const agentSessionId = input.agentSessionId.trim();
+  const requestId = input.requestId.trim();
+  const agentTargetId = input.agentTargetId?.trim() ?? "";
+  const clientSubmitId =
+    input.mode === "new" ? input.clientSubmitId.trim() : "";
+  const initialDisplayPrompt = input.initialDisplayPrompt?.trim() || undefined;
+  const title = input.title?.trim() || undefined;
+  if (
+    !agentSessionId ||
+    !requestId ||
+    (input.mode === "new" && (!agentTargetId || !clientSubmitId))
+  ) {
+    return false;
+  }
+  const requestedAtUnixMs = context.clock.nowUnixMs();
+  const sharedIntent = {
+    agentSessionId,
+    ...(input.capabilityRefs?.length
+      ? {
+          capabilityRefs: input.capabilityRefs.map((reference) => ({
+            ...reference
+          }))
+        }
+      : {}),
+    ...(input.initialContent
+      ? { content: input.initialContent.map((block) => ({ ...block })) }
+      : {}),
+    ...(input.cwd !== undefined ? { cwd: input.cwd.trim() } : {}),
+    expiresAtUnixMs:
+      requestedAtUnixMs + SESSION_ACTIVATION_CONFIRMATION_TIMEOUT_MS,
+    ...(initialDisplayPrompt ? { initialDisplayPrompt } : {}),
+    ...(input.initialTurnExpected !== undefined
+      ? { initialTurnExpected: input.initialTurnExpected }
+      : {}),
+    ...(input.railPlacement
+      ? { railPlacement: { ...input.railPlacement } }
+      : {}),
+    ...(input.railSectionKey?.trim()
+      ? { railSectionKey: input.railSectionKey.trim() }
+      : {}),
+    requestId,
+    requestedAtUnixMs,
+    ...(input.runtimeContent
+      ? {
+          runtimeContent: input.runtimeContent.map((block) => ({ ...block }))
+        }
+      : {}),
+    ...(input.settings ? { settings: { ...input.settings } } : {}),
+    ...(input.submitDiagnostics
+      ? { submitDiagnostics: { ...input.submitDiagnostics } }
+      : {}),
+    ...(title ? { title } : {}),
+    type: "activation/requested" as const,
+    ...(input.visible !== undefined ? { visible: input.visible } : {}),
+    workspaceId: context.workspaceId
+  };
+  context.dispatch(
+    input.mode === "new"
+      ? {
+          ...sharedIntent,
+          agentTargetId,
+          clientSubmitId,
+          ...(input.initialGoalControl
+            ? { initialGoalControl: { ...input.initialGoalControl } }
+            : {}),
+          ...(input.initialTuttiModeActivation
+            ? {
+                initialTuttiModeActivation: {
+                  ...input.initialTuttiModeActivation
+                }
+              }
+            : {}),
+          mode: "new",
+          ...(input.optimisticTitle?.trim()
+            ? { optimisticTitle: input.optimisticTitle.trim() }
+            : {}),
+          ...(input.tuttiModeDraftKey?.trim()
+            ? { tuttiModeDraftKey: input.tuttiModeDraftKey.trim() }
+            : {})
+        }
+      : {
+          ...sharedIntent,
+          ...(agentTargetId ? { agentTargetId } : {}),
+          mode: "existing"
+        }
+  );
+  const activation = selectPendingActivationByRequestId(
+    context.getSnapshot(),
+    requestId
+  );
+  return (
+    activation?.agentSessionId === agentSessionId &&
+    activation.mode === input.mode
+  );
+}

--- a/packages/agent/activity-core/src/engine/sessionActivation.semantic.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionActivation.semantic.test.ts
@@ -1,0 +1,203 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createAgentSessionEngine } from "./createAgentSessionEngine.ts";
+import type {
+  EngineCommandPort,
+  EngineExternalCommand,
+  EngineIntent,
+  EngineScheduler
+} from "./types.ts";
+
+function createHarness() {
+  const commands: EngineExternalCommand[] = [];
+  const observedIntents: EngineIntent[] = [];
+  const scheduled: Array<{ canceled: boolean; delayMs: number }> = [];
+  const commandPort: EngineCommandPort = {
+    execute(command) {
+      commands.push(command);
+      return new Promise(() => undefined);
+    }
+  };
+  const scheduler: EngineScheduler = {
+    schedule(delayMs) {
+      const task = { canceled: false, delayMs };
+      scheduled.push(task);
+      return {
+        cancel() {
+          task.canceled = true;
+        }
+      };
+    }
+  };
+  const engine = createAgentSessionEngine({
+    clock: { nowUnixMs: () => 100 },
+    commandPort,
+    identity: { origin: "test", workspaceId: "workspace-1" },
+    intentObserver: (intent) => {
+      observedIntents.push(intent);
+    },
+    scheduler
+  });
+  return { commands, engine, observedIntents, scheduled };
+}
+
+test("semantic new-Session activation owns scope, confirmation window, and command projection", () => {
+  const harness = createHarness();
+
+  const accepted = harness.engine.activateSession({
+    agentSessionId: " session-new ",
+    agentTargetId: " target-1 ",
+    capabilityRefs: [{ capability: "tutti", source: "slash_command" }],
+    clientSubmitId: " submit-new ",
+    cwd: " /workspace ",
+    initialContent: [{ text: "display instructions", type: "text" }],
+    initialDisplayPrompt: " /browser ",
+    initialGoalControl: { action: "set", objective: "ship it" },
+    initialTurnExpected: false,
+    mode: "new",
+    optimisticTitle: " Review browser flow ",
+    railPlacement: {
+      kind: "project",
+      projectPath: "/workspace",
+      sectionKey: "project:/workspace",
+      version: 1
+    },
+    railSectionKey: " project:/workspace ",
+    requestId: " activation-1 ",
+    runtimeContent: [{ text: "runtime instructions", type: "text" }],
+    settings: { model: "model-1" },
+    submitDiagnostics: { source: "test", submittedAtUnixMs: 100 },
+    title: " New session ",
+    tuttiModeDraftKey: " draft-1 ",
+    initialTuttiModeActivation: {
+      effect: 80,
+      source: "slash_command",
+      speed: 60,
+      status: "active"
+    },
+    visible: true
+  });
+
+  assert.equal(accepted, true);
+  assert.deepEqual(harness.observedIntents.at(-1), {
+    agentSessionId: "session-new",
+    agentTargetId: "target-1",
+    capabilityRefs: [{ capability: "tutti", source: "slash_command" }],
+    clientSubmitId: "submit-new",
+    content: [{ text: "display instructions", type: "text" }],
+    cwd: "/workspace",
+    expiresAtUnixMs: 120_100,
+    initialDisplayPrompt: "/browser",
+    initialGoalControl: { action: "set", objective: "ship it" },
+    initialTurnExpected: false,
+    initialTuttiModeActivation: {
+      effect: 80,
+      source: "slash_command",
+      speed: 60,
+      status: "active"
+    },
+    mode: "new",
+    optimisticTitle: "Review browser flow",
+    railPlacement: {
+      kind: "project",
+      projectPath: "/workspace",
+      sectionKey: "project:/workspace",
+      version: 1
+    },
+    railSectionKey: "project:/workspace",
+    requestId: "activation-1",
+    requestedAtUnixMs: 100,
+    runtimeContent: [{ text: "runtime instructions", type: "text" }],
+    settings: { model: "model-1" },
+    submitDiagnostics: { source: "test", submittedAtUnixMs: 100 },
+    title: "New session",
+    tuttiModeDraftKey: "draft-1",
+    type: "activation/requested",
+    visible: true,
+    workspaceId: "workspace-1"
+  });
+  assert.deepEqual(harness.commands, [
+    {
+      agentSessionId: "session-new",
+      agentTargetId: "target-1",
+      capabilityRefs: [{ capability: "tutti", source: "slash_command" }],
+      clientSubmitId: "submit-new",
+      commandId: "activate:activation-1",
+      correlationId: "activation-1",
+      cwd: "/workspace",
+      initialContent: [{ text: "runtime instructions", type: "text" }],
+      initialDisplayPrompt: "/browser",
+      initialGoalControl: { action: "set", objective: "ship it" },
+      initialTuttiModeActivation: {
+        effect: 80,
+        source: "slash_command",
+        speed: 60,
+        status: "active"
+      },
+      mode: "new",
+      railPlacement: {
+        kind: "project",
+        projectPath: "/workspace",
+        sectionKey: "project:/workspace",
+        version: 1
+      },
+      settings: { model: "model-1" },
+      submitDiagnostics: { source: "test", submittedAtUnixMs: 100 },
+      timeoutMs: 90_000,
+      title: "New session",
+      type: "session/activate",
+      visible: true,
+      workspaceId: "workspace-1"
+    }
+  ]);
+  assert.deepEqual(
+    harness.scheduled.map((task) => task.delayMs),
+    [120_000, 90_000]
+  );
+});
+
+test("semantic existing-Session activation uses the shared confirmation window", () => {
+  const harness = createHarness();
+
+  const accepted = harness.engine.activateSession({
+    agentSessionId: " session-1 ",
+    agentTargetId: " target-1 ",
+    mode: "existing",
+    requestId: " activation-existing "
+  });
+
+  assert.equal(accepted, true);
+  assert.deepEqual(harness.commands, [
+    {
+      agentSessionId: "session-1",
+      agentTargetId: "target-1",
+      commandId: "activate:activation-existing",
+      correlationId: "activation-existing",
+      mode: "existing",
+      timeoutMs: 30_000,
+      type: "session/activate",
+      workspaceId: "workspace-1"
+    }
+  ]);
+  assert.deepEqual(
+    harness.scheduled.map((task) => task.delayMs),
+    [120_000, 30_000]
+  );
+});
+
+test("semantic activation rejects invalid identity without side effects", () => {
+  const harness = createHarness();
+
+  const accepted = harness.engine.activateSession({
+    agentSessionId: "session-new",
+    agentTargetId: " ",
+    clientSubmitId: "submit-new",
+    mode: "new",
+    requestId: "activation-1"
+  });
+
+  assert.equal(accepted, false);
+  assert.deepEqual(harness.observedIntents, []);
+  assert.deepEqual(harness.commands, []);
+  assert.deepEqual(harness.scheduled, []);
+});

--- a/packages/agent/activity-core/src/engine/sessionActivation.semantic.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionActivation.semantic.test.ts
@@ -185,6 +185,58 @@ test("semantic existing-Session activation uses the shared confirmation window",
   );
 });
 
+test("semantic activation does not admit changed input under a reused request identity", () => {
+  const harness = createHarness();
+
+  const firstAccepted = harness.engine.activateSession({
+    agentSessionId: "session-new",
+    agentTargetId: "target-1",
+    clientSubmitId: "submit-1",
+    initialContent: [{ text: "first prompt", type: "text" }],
+    mode: "new",
+    requestId: "activation-1"
+  });
+  const reusedAccepted = harness.engine.activateSession({
+    agentSessionId: "session-new",
+    agentTargetId: "target-2",
+    clientSubmitId: "submit-2",
+    initialContent: [{ text: "changed prompt", type: "text" }],
+    mode: "new",
+    requestId: "activation-1"
+  });
+
+  assert.equal(firstAccepted, true);
+  assert.equal(reusedAccepted, false);
+  assert.equal(harness.commands.length, 1);
+  assert.deepEqual(
+    harness.engine.getSnapshot().pendingIntents.activationsByRequestId[
+      "activation-1"
+    ],
+    {
+      agentSessionId: "session-new",
+      agentTargetId: "target-1",
+      clientSubmitId: "submit-1",
+      content: [{ text: "first prompt", type: "text" }],
+      cwd: "",
+      errorCode: null,
+      errorMessage: null,
+      expiresAtUnixMs: 120_100,
+      initialPromptRetracted: false,
+      initialTurnExpected: true,
+      mode: "new",
+      requestedAtUnixMs: 100,
+      requestId: "activation-1",
+      status: "requested",
+      title: null,
+      workspaceId: "workspace-1"
+    }
+  );
+  assert.deepEqual(
+    harness.scheduled.map((task) => task.delayMs),
+    [120_000, 90_000]
+  );
+});
+
 test("semantic activation rejects invalid identity without side effects", () => {
   const harness = createHarness();
 

--- a/packages/agent/activity-core/src/engine/types.ts
+++ b/packages/agent/activity-core/src/engine/types.ts
@@ -454,6 +454,43 @@ export interface AgentSessionSubmitInteractionResponseInput {
   turnId: string;
 }
 
+interface AgentSessionActivationInputBase {
+  agentSessionId: string;
+  capabilityRefs?: readonly AgentActivityCapabilityReference[];
+  cwd?: string;
+  initialContent?: readonly AgentPromptContentBlock[];
+  initialDisplayPrompt?: string;
+  initialTurnExpected?: boolean;
+  railPlacement?: AgentActivityRailPlacement;
+  railSectionKey?: string;
+  requestId: string;
+  runtimeContent?: readonly AgentPromptContentBlock[];
+  settings?: AgentActivitySessionSettings;
+  submitDiagnostics?: Readonly<AgentActivitySubmitDiagnostics>;
+  title?: string;
+  visible?: boolean;
+}
+
+export type AgentSessionActivationInput =
+  | (AgentSessionActivationInputBase & {
+      agentTargetId: string;
+      clientSubmitId: string;
+      initialGoalControl?: Readonly<AgentActivityInitialGoalControl>;
+      initialTuttiModeActivation?: AgentActivityInitialTuttiModeActivation;
+      mode: "new";
+      optimisticTitle?: string;
+      tuttiModeDraftKey?: string;
+    })
+  | (AgentSessionActivationInputBase & {
+      agentTargetId?: string | null;
+      clientSubmitId?: never;
+      initialGoalControl?: never;
+      initialTuttiModeActivation?: never;
+      mode: "existing";
+      optimisticTitle?: never;
+      tuttiModeDraftKey?: never;
+    });
+
 export interface AgentSessionSubmitPromptInput {
   agentSessionId: string;
   capabilityRefs?: readonly AgentActivityCapabilityReference[];
@@ -477,6 +514,7 @@ export interface AgentSessionStopInput {
 
 export interface AgentSessionEngine {
   readonly identity: AgentSessionEngineIdentity;
+  activateSession(input: AgentSessionActivationInput): boolean;
   deleteSessions(
     input: Omit<AgentActivityDeleteSessionsInput, "signal" | "workspaceId"> & {
       signal?: AbortSignal;

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiNewConversationRequest.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiNewConversationRequest.spec.tsx
@@ -53,6 +53,7 @@ describe("P0 new-conversation placement scenarios", () => {
     );
 
     const activation = await scenario.waitForActivation();
+    expect(scenario.activateSession).toHaveBeenCalledTimes(1);
     expect(activation).toMatchObject({
       cwd: "",
       initialContent: [{ type: "text", text: "start a new chat" }],
@@ -190,6 +191,7 @@ function renderNewConversationScenario(input: {
     identity: { origin: "test", workspaceId: "workspace-1" },
     scheduler: { schedule: () => ({ cancel() {} }) }
   });
+  const activateSession = vi.spyOn(sessionEngine, "activateSession");
   const target = createLocalAgentGUIAgentTarget("codex");
   const dataRef: { current: AgentGUINodeData } = {
     current: {
@@ -358,6 +360,7 @@ function renderNewConversationScenario(input: {
   });
 
   return {
+    activateSession,
     requestNewConversation() {
       requestAgentGUINewConversation({
         activeConversationId: activeConversationIdRef.current,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIActivation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIActivation.ts
@@ -1,56 +1,22 @@
 import {
   selectSessionActivationPresentations,
   sessionActivationPresentationMapsEqual,
-  type AgentActivityCapabilityReference,
-  type AgentActivityInitialGoalControl,
-  type AgentActivityInitialTuttiModeActivation,
-  type AgentActivitySubmitDiagnostics,
-  type AgentActivityRailPlacement,
   type PendingActivationIntentRecord,
   type AgentSessionEngine
 } from "@tutti-os/agent-activity-core";
 import { useCallback, useMemo, useRef } from "react";
-import {
-  type AppErrorCode,
-  type AgentPromptContentBlock
-} from "../../../shared/contracts/dto";
-import type { AgentSessionComposerSettings } from "../../../shared/agentSessionTypes";
+import { type AppErrorCode } from "../../../shared/contracts/dto";
 import { useEngineSelector } from "../../../shared/engine/useEngineSelector";
 
 type AgentGUILiveState = "inactive" | "activating" | "active" | "failed";
 
-interface AgentGUIActivateInputBase {
-  agentSessionId: string;
-  capabilityRefs?: readonly AgentActivityCapabilityReference[];
-  cwd?: string;
-  initialContent?: AgentPromptContentBlock[];
-  initialTurnExpected?: boolean;
-  initialGoalControl?: AgentActivityInitialGoalControl;
-  railSectionKey?: string;
-  railPlacement?: AgentActivityRailPlacement;
-  initialDisplayPrompt?: string;
-  runtimeContent?: AgentPromptContentBlock[];
-  submitDiagnostics?: AgentActivitySubmitDiagnostics;
-  settings?: AgentSessionComposerSettings;
-  title?: string;
-  visible?: boolean;
-}
-
-type AgentGUIActivateInput =
-  | (AgentGUIActivateInputBase & {
-      agentTargetId: string;
-      clientSubmitId: string;
-      initialTuttiModeActivation?: AgentActivityInitialTuttiModeActivation;
-      mode: "new";
-      optimisticTitle?: string;
-      tuttiModeDraftKey?: string;
-    })
-  | (AgentGUIActivateInputBase & {
-      agentTargetId?: string | null;
-      clientSubmitId?: never;
-      mode: "existing";
-      optimisticTitle?: never;
-    });
+type AgentGUIActivateInput = Parameters<
+  AgentSessionEngine["activateSession"]
+>[0] extends infer TInput
+  ? TInput extends { requestId: string }
+    ? Omit<TInput, "requestId">
+    : never
+  : never;
 
 interface UseAgentGUIActivationInput {
   engine: AgentSessionEngine;
@@ -58,8 +24,6 @@ interface UseAgentGUIActivationInput {
   getErrorMessage: (error: unknown) => string;
   getErrorCode?: (error: unknown) => AppErrorCode | null;
 }
-
-const ACTIVATION_EXPIRY_MS = 45_000;
 
 export function isPendingNewConversationActivation(
   activation:
@@ -109,89 +73,14 @@ export function useAgentGUIActivation({
   const activate = useCallback(
     (input: AgentGUIActivateInput): string | null => {
       const agentSessionId = input.agentSessionId.trim();
-      const agentTargetId = input.agentTargetId?.trim() ?? "";
-      if (!agentSessionId) {
-        return null;
-      }
-      if (input.mode === "new" && !agentTargetId) {
-        return null;
-      }
-
-      const requestedAtUnixMs = Date.now();
       const requestId = nextRequestId("activation", agentSessionId);
-      const clientSubmitId = input.clientSubmitId?.trim() ?? "";
-      if (input.mode === "new" && !clientSubmitId) {
-        return null;
-      }
-      const sharedIntent = {
-        type: "activation/requested",
+      return engine.activateSession({
+        ...input,
         agentSessionId,
-        ...(input.capabilityRefs?.length
-          ? { capabilityRefs: input.capabilityRefs }
-          : {}),
-        ...(input.initialContent ? { content: input.initialContent } : {}),
-        ...(input.cwd !== undefined ? { cwd: input.cwd } : {}),
-        expiresAtUnixMs: requestedAtUnixMs + ACTIVATION_EXPIRY_MS,
-        ...(input.initialTurnExpected !== undefined
-          ? { initialTurnExpected: input.initialTurnExpected }
-          : {}),
-        ...(input.initialGoalControl
-          ? { initialGoalControl: { ...input.initialGoalControl } }
-          : {}),
-        ...(input.railSectionKey?.trim()
-          ? { railSectionKey: input.railSectionKey.trim() }
-          : {}),
-        ...(input.railPlacement
-          ? { railPlacement: { ...input.railPlacement } }
-          : {}),
-        ...(input.initialDisplayPrompt
-          ? { initialDisplayPrompt: input.initialDisplayPrompt }
-          : {}),
-        ...(input.runtimeContent
-          ? { runtimeContent: input.runtimeContent }
-          : {}),
-        ...(input.submitDiagnostics
-          ? { submitDiagnostics: input.submitDiagnostics }
-          : {}),
-        requestedAtUnixMs,
-        requestId,
-        ...(input.settings
-          ? {
-              settings: input.settings
-            }
-          : {}),
-        ...(input.title ? { title: input.title } : {}),
-        ...(input.visible !== undefined ? { visible: input.visible } : {}),
-        workspaceId
-      } as const;
-      if (input.mode === "new") {
-        engine.dispatch({
-          ...sharedIntent,
-          agentTargetId,
-          clientSubmitId,
-          ...(input.initialTuttiModeActivation
-            ? {
-                initialTuttiModeActivation: {
-                  ...input.initialTuttiModeActivation
-                }
-              }
-            : {}),
-          mode: "new",
-          ...(input.optimisticTitle
-            ? { optimisticTitle: input.optimisticTitle }
-            : {}),
-          ...(input.tuttiModeDraftKey?.trim()
-            ? { tuttiModeDraftKey: input.tuttiModeDraftKey.trim() }
-            : {})
-        });
-      } else {
-        engine.dispatch({
-          ...sharedIntent,
-          ...(agentTargetId ? { agentTargetId } : {}),
-          mode: "existing"
-        });
-      }
-      return requestId;
+        requestId
+      })
+        ? requestId
+        : null;
     },
     [engine, workspaceId]
   );


### PR DESCRIPTION
## Summary

- add `AgentSessionEngine.activateSession()` as the shared Desktop/Mobile activation-admission entrypoint
- move workspace scope, timestamp/expiry construction, normalization, and admission projection into an internal Activity Core operation
- migrate Desktop AgentGUI and Native Mobile away from constructing raw `activation/requested` intents
- preserve Mobile's new-Session draft when activation admission is rejected
- update the Activity Core README and AgentGUI architecture documents

## Why

Desktop previously used a 45-second activation confirmation window and Mobile used 60 seconds, while a valid new-Session activation command may run for up to 90 seconds. A slow but valid runtime startup could therefore be marked expired before the command itself reached its allowed timeout. Both surfaces also duplicated the same activation protocol fields.

The Engine now owns one 120-second confirmation policy, which contains the 90-second command timeout. Product surfaces continue to own target selection, placement, initial draft/settings, and stable request identities used for retry and dismissal.

Actual Session creation, resume, and initial Turn lifecycle remain owned by Agent Host behind the host effect port; this PR changes only frontend admission/orchestration.

## User impact

- normal new-Session and history-resume behavior remains aligned with Desktop
- slow Agent Provider startup no longer races an earlier frontend activation expiry
- Mobile does not lose the new-Session draft when the Engine rejects admission
- one submitted activation still maps to one Session activation command

## Validation

- `pnpm check:changed` — 15 lanes passed locally
- pre-push `pnpm check:changed -- --push-ready` — 16 lanes passed
- `pnpm --filter @tutti-os/agent-activity-core test` — 409 tests passed
- `pnpm --filter @tutti-os/agent-gui test` — 311 files / 2595 tests passed
- `pnpm --filter @tutti-os/mobile test -- workspaceActivityService.test.ts` — 26 tests passed
- Activity Core, AgentGUI, and Mobile typechecks passed
- Activity Core package build passed
- Agent activity runtime boundary and AgentGUI degradation checks passed

## Review notes

| Lane | Result | Evidence | Consumers |
| --- | --- | --- | --- |
| Architecture | pass | Raw activation admission is centralized in Activity Core; Host lifecycle ownership is unchanged | Desktop AgentGUI, Mobile |
| Performance | pass | No new subscriptions or render projections; one bounded expiry remains per activation; degradation budget passed | Desktop AgentGUI, Mobile |
| Compatibility | pass | No existing package-root export was removed; published DTS build and both in-repository consumers passed | Desktop, Mobile, factory-based external hosts |
