### PR TITLE
fix(agent): expose Tutti Agent slash commands

### DIFF
--- a/packages/agent/daemon/providerregistry/providers.go
+++ b/packages/agent/daemon/providerregistry/providers.go
@@ -84,6 +84,14 @@ func tuttiAgentDescriptor() ProviderDescriptor {
 			Capabilities: []string{CapabilityImageInput, CapabilitySkills, CapabilityCompact, CapabilityTokenUsage, CapabilityPlanMode, CapabilityInterrupt, CapabilityActiveTurnGuidance, CapabilityModelSwitch, CapabilityModelPlanBinding}, PermissionConfigurable: true, DefaultPermissionModeID: "auto",
 			PermissionModes: []PermissionModeDescriptor{{ID: "read-only", Semantic: "ask-before-write"}, {ID: "auto", Semantic: "auto"}, {ID: "full-access", Semantic: "full-access"}}, ConfigOptionIDs: ComposerConfigOptionIDs{Model: "model", Permission: "mode"},
 			CapabilityCatalog: CapabilityCatalogDescriptor{Kind: CapabilityCatalogKindAppServerSkills},
+			SlashCommandPolicy: SlashCommandPolicyDescriptor{
+				FallbackCommands: []string{"plan", "goal", "review"},
+				CommandEffects: []SlashCommandEffectDescriptor{
+					{Command: "plan", Effect: SlashCommandEffectTogglePlanMode},
+					{Command: "goal", Effect: SlashCommandEffectActivateGoalMode},
+					{Command: "review", Effect: SlashCommandEffectShowReviewPicker},
+				},
+			},
 		},
 		Target:  TargetDescriptor{ID: TuttiAgentTargetID, LaunchRefType: TargetLaunchRefTypeLocalCLI, Enabled: true, SortOrder: 5},
 		Events:  EventsDescriptor{Enabled: true, Aliases: []string{"tutti_agent"}, TurnLifecycleProjection: TurnLifecycleProjectionExplicit},

--- a/packages/agent/daemon/providerregistry/registry_test.go
+++ b/packages/agent/daemon/providerregistry/registry_test.go
@@ -79,6 +79,22 @@ func TestMigratedTuttiAgentDescriptorRequiresRefreshCapableVersion(t *testing.T)
 	if descriptor.ComposerProfile.CapabilityCatalog.Kind != CapabilityCatalogKindAppServerSkills {
 		t.Fatalf("CapabilityCatalog = %#v, want skills-only app-server catalog", descriptor.ComposerProfile.CapabilityCatalog)
 	}
+	if !slices.Equal(
+		descriptor.ComposerProfile.SlashCommandPolicy.FallbackCommands,
+		[]string{"plan", "goal", "review"},
+	) {
+		t.Fatalf("SlashCommandPolicy.FallbackCommands = %#v", descriptor.ComposerProfile.SlashCommandPolicy.FallbackCommands)
+	}
+	if !slices.Equal(
+		descriptor.ComposerProfile.SlashCommandPolicy.CommandEffects,
+		[]SlashCommandEffectDescriptor{
+			{Command: "plan", Effect: SlashCommandEffectTogglePlanMode},
+			{Command: "goal", Effect: SlashCommandEffectActivateGoalMode},
+			{Command: "review", Effect: SlashCommandEffectShowReviewPicker},
+		},
+	) {
+		t.Fatalf("SlashCommandPolicy.CommandEffects = %#v", descriptor.ComposerProfile.SlashCommandPolicy.CommandEffects)
+	}
 }
 
 func TestValidateRejectsInvalidMinimumVersionFloor(t *testing.T) {

--- a/services/tuttid/service/agent/provider_descriptor_test.go
+++ b/services/tuttid/service/agent/provider_descriptor_test.go
@@ -38,6 +38,17 @@ func TestTuttiAgentComposerProfileUsesSkillsOnlyAppServerCatalog(t *testing.T) {
 	if profile.CapabilityCatalogKind != providerregistry.CapabilityCatalogKindAppServerSkills {
 		t.Fatalf("capability catalog profile = %#v", profile)
 	}
+	if !reflect.DeepEqual(profile.SlashCommandPolicy.FallbackCommands, []string{"plan", "goal", "review"}) {
+		t.Fatalf("fallbackCommands = %#v", profile.SlashCommandPolicy.FallbackCommands)
+	}
+	wantEffects := []providerregistry.SlashCommandEffectDescriptor{
+		{Command: "plan", Effect: providerregistry.SlashCommandEffectTogglePlanMode},
+		{Command: "goal", Effect: providerregistry.SlashCommandEffectActivateGoalMode},
+		{Command: "review", Effect: providerregistry.SlashCommandEffectShowReviewPicker},
+	}
+	if !reflect.DeepEqual(profile.SlashCommandPolicy.CommandEffects, wantEffects) {
+		t.Fatalf("commandEffects = %#v", profile.SlashCommandPolicy.CommandEffects)
+	}
 }
 
 func TestClaudeCodeComposerProfileComesFromProviderDescriptor(t *testing.T) {


### PR DESCRIPTION
## Summary

- expose `/plan`, `/goal`, and `/review` for the Tutti Agent provider
- route each command through the existing typed AgentGUI effect
- add provider descriptor and composer profile regression coverage

## Data flow

- `/plan` toggles the negotiated plan-mode setting locally
- `/goal` enters typed Goal control backed by the app-server goal RPCs
- `/review` opens the review picker and uses the app-server review RPC

## Validation

- `pnpm check:changed` (11 lanes)
- pre-push `pnpm check:changed -- --push-ready` (12 lanes)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1868" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->