### PR TITLE
test(agent): stabilize goal recovery deadlines

### DIFF
--- a/docs/conventions/testing.md
+++ b/docs/conventions/testing.md
@@ -47,6 +47,14 @@ pre-running every boundary/typecheck lane that `check:changed` already owns;
 some overlap between its selected tests and an intentionally broader suite may
 be unavoidable.
 
+Tests that verify recovery semantics after a timeout should inject the
+appropriate deadline error directly instead of depending on a very short
+wall-clock timer. Reserve real timers for tests whose subject is the timeout
+boundary itself, and give those timers enough scheduling margin for a parallel
+CI runner while keeping a separate generous upper-bound assertion. This keeps
+provider-timeout behavior distinct from runner scheduling and fixture startup
+latency.
+
 `pnpm check:full` prepares builtin app assets once, then uses the prepared Go
 lint and test entrypoints. This prevents concurrent validation lanes from
 writing the same generated assets. It captures complete task output under

--- a/packages/agent/host/goal_operation_recovery_test.go
+++ b/packages/agent/host/goal_operation_recovery_test.go
@@ -129,9 +129,8 @@ func TestGoalClearRepeatedTimeoutEventuallyFails(t *testing.T) {
 	})
 	runtime := &goalWorkerRuntime{
 		sessions: map[string]ProviderRuntimeSession{},
-		controlHook: func(ctx context.Context, _ RuntimeGoalControlInput) (RuntimeGoalControlResult, error) {
-			<-ctx.Done()
-			return RuntimeGoalControlResult{}, ctx.Err()
+		controlHook: func(context.Context, RuntimeGoalControlInput) (RuntimeGoalControlResult, error) {
+			return RuntimeGoalControlResult{}, context.DeadlineExceeded
 		},
 	}
 	runtime.setSession(ProviderRuntimeSession{
@@ -141,7 +140,7 @@ func TestGoalClearRepeatedTimeoutEventuallyFails(t *testing.T) {
 	host := New(Config{
 		CanonicalStore: goalWorkerCanonicalStore(session), Runtime: runtime,
 		GoalStore: store, GoalRuntime: runtime, GoalClock: fixedClock{at: time.UnixMilli(now)},
-		GoalAttemptTimeout: 20 * time.Millisecond, GoalMaxAttempts: 1,
+		GoalMaxAttempts: 1,
 	})
 	if err := host.StepGoalOperationWorker(t.Context(), false); err != nil {
 		t.Fatal(err)
@@ -168,16 +167,15 @@ func TestGoalRuntimeUnavailableKeepsPreparedUntilFirstProviderDispatch(t *testin
 	})
 	runtime := &goalWorkerRuntime{
 		sessions: map[string]ProviderRuntimeSession{},
-		controlHook: func(ctx context.Context, _ RuntimeGoalControlInput) (RuntimeGoalControlResult, error) {
-			<-ctx.Done()
-			return RuntimeGoalControlResult{}, ctx.Err()
+		controlHook: func(context.Context, RuntimeGoalControlInput) (RuntimeGoalControlResult, error) {
+			return RuntimeGoalControlResult{}, context.DeadlineExceeded
 		},
 	}
 	now := int64(20)
 	host := New(Config{
 		CanonicalStore: goalWorkerCanonicalStore(session), Runtime: runtime,
 		GoalStore: store, GoalRuntime: runtime, GoalClock: fixedClock{at: time.UnixMilli(now)},
-		GoalAttemptTimeout: 20 * time.Millisecond, GoalMaxAttempts: 1,
+		GoalMaxAttempts: 1,
 	})
 	if err := host.StepGoalOperationWorker(t.Context(), false); err != nil {
 		t.Fatal(err)
@@ -260,13 +258,13 @@ func TestGoalRecoveryProviderQueryAndApplyTimeoutReleaseLease(t *testing.T) {
 				CanonicalStore: goalWorkerCanonicalStore(session), Runtime: runtime,
 				GoalStore: store, GoalRuntime: runtime, GoalOwner: "goal-hang-worker",
 				GoalClock:          fixedClock{at: time.UnixMilli(now)},
-				GoalAttemptTimeout: 25 * time.Millisecond, GoalMaxAttempts: 1,
+				GoalAttemptTimeout: 500 * time.Millisecond, GoalMaxAttempts: 1,
 			})
 			started := time.Now()
 			if err := host.StepGoalOperationWorker(t.Context(), false); err != nil {
 				t.Fatalf("worker timeout: %v", err)
 			}
-			if elapsed := time.Since(started); elapsed > time.Second {
+			if elapsed := time.Since(started); elapsed > 5*time.Second {
 				t.Fatalf("worker timeout took %s", elapsed)
 			}
 			op, found, err := store.GetGoalControlOperation(
@@ -319,13 +317,13 @@ func TestGoalRecoveryStartupBudgetBoundsHangingProvider(t *testing.T) {
 		CanonicalStore: goalWorkerCanonicalStore(session), Runtime: runtime,
 		GoalStore: store, GoalRuntime: runtime, GoalOwner: "goal-startup-budget-worker",
 		GoalClock: fixedClock{at: time.UnixMilli(30)}, GoalAttemptTimeout: time.Second,
-		GoalRecoveryBudget: 40 * time.Millisecond,
+		GoalRecoveryBudget: 500 * time.Millisecond,
 	})
 	started := time.Now()
 	if err := host.RecoverGoalOperations(t.Context()); err != nil {
 		t.Fatal(err)
 	}
-	if elapsed := time.Since(started); elapsed > time.Second {
+	if elapsed := time.Since(started); elapsed > 5*time.Second {
 		t.Fatalf("startup recovery exceeded bounded budget: %s", elapsed)
 	}
 	op, found, err := store.GetGoalControlOperation(
@@ -411,14 +409,14 @@ func TestManualGoalReconcileProviderTimeoutIsBounded(t *testing.T) {
 	})
 	host := New(Config{
 		CanonicalStore: goalWorkerCanonicalStore(session), Runtime: runtime,
-		GoalRuntime: runtime, GoalAttemptTimeout: 25 * time.Millisecond,
+		GoalRuntime: runtime, GoalAttemptTimeout: 500 * time.Millisecond,
 	})
 	started := time.Now()
 	_, err := host.ReconcileGoal(t.Context(), SessionRef{
 		WorkspaceID:    session.WorkspaceID,
 		AgentSessionID: session.ID,
 	})
-	if err == nil || time.Since(started) > time.Second {
+	if err == nil || time.Since(started) > 5*time.Second {
 		t.Fatalf("err=%v elapsed=%s", err, time.Since(started))
 	}
 }

--- a/services/tuttid/service/agent/host_goal_recovery_integration_test.go
+++ b/services/tuttid/service/agent/host_goal_recovery_integration_test.go
@@ -90,23 +90,17 @@ func TestGoalRecoveryTimeoutThenRestartDoesNotReplayClaudeSet(t *testing.T) {
 	runtime.sessions["ws-goal-timeout:session-goal-timeout"] = ProviderRuntimeSession{
 		ID: "session-goal-timeout", Provider: "claude-code", ProviderSessionID: "claude-timeout", Status: "ready",
 	}
-	runtime.goalControlHook = func(ctx context.Context, _ RuntimeGoalControlInput) (RuntimeGoalControlResult, error) {
-		<-ctx.Done()
-		return RuntimeGoalControlResult{}, ctx.Err()
+	runtime.goalControlHook = func(context.Context, RuntimeGoalControlInput) (RuntimeGoalControlResult, error) {
+		return RuntimeGoalControlResult{}, context.DeadlineExceeded
 	}
 	nowMS := int64(30)
 	service := newIsolatedAgentService(runtime)
 	service.GoalStateStore = store
 	service.GoalOperationOwner = "goal-timeout-worker"
 	service.GoalOperationClock = func() time.Time { return time.UnixMilli(nowMS) }
-	service.GoalOperationAttemptTimeout = 25 * time.Millisecond
 	service.GoalOperationMaxAttempts = 1
-	started := time.Now()
 	if err := service.ApplicationHost().StepGoalOperationWorker(ctx, false); err != nil {
 		t.Fatalf("timeout attempt: %v", err)
-	}
-	if elapsed := time.Since(started); elapsed > time.Second {
-		t.Fatalf("timeout attempt took %s", elapsed)
 	}
 	op, found, err := store.GetGoalControlOperation(ctx, "ws-goal-timeout", "goal-timeout-set")
 	if err != nil || !found || op.Status != agentactivitybiz.GoalOperationStatusDispatched ||
@@ -166,16 +160,14 @@ func TestGoalRepairSetTimeoutThenRestartDoesNotReplayClaudeSet(t *testing.T) {
 	runtime.sessions["ws-repair-set-timeout:session-repair-set-timeout"] = ProviderRuntimeSession{
 		ID: "session-repair-set-timeout", Provider: "claude-code", ProviderSessionID: "claude-repair-timeout", Status: "ready",
 	}
-	runtime.goalControlHook = func(ctx context.Context, _ RuntimeGoalControlInput) (RuntimeGoalControlResult, error) {
-		<-ctx.Done()
-		return RuntimeGoalControlResult{}, ctx.Err()
+	runtime.goalControlHook = func(context.Context, RuntimeGoalControlInput) (RuntimeGoalControlResult, error) {
+		return RuntimeGoalControlResult{}, context.DeadlineExceeded
 	}
 	nowMS := int64(30)
 	service := newIsolatedAgentService(runtime)
 	service.GoalStateStore = store
 	service.GoalOperationOwner = "goal-repair-timeout-worker"
 	service.GoalOperationClock = func() time.Time { return time.UnixMilli(nowMS) }
-	service.GoalOperationAttemptTimeout = 25 * time.Millisecond
 	service.GoalOperationMaxAttempts = 1
 	if err := service.ApplicationHost().StepGoalOperationWorker(ctx, false); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary

- inject `context.DeadlineExceeded` directly in Goal recovery tests whose subject is retry and no-replay semantics
- retain real wall-clock waits only in tests that explicitly verify timeout and recovery-budget boundaries, with enough scheduling margin for parallel CI runners
- document the repository testing convention for separating deadline semantics from timing-boundary coverage

## Root cause

Several Goal recovery tests used 20–40 ms wall-clock deadlines while also initializing SQLite fixtures and running inside parallel Go workspace CI lanes. Those tests were intended to verify durable retry, lease release, and unsafe-set no-replay behavior, but the short timers also measured runner scheduling and fixture startup latency. Under CI load, the operation context could expire before the intended lifecycle path completed, producing intermittent `context deadline exceeded` failures.

This PR changes tests only; production Goal lifecycle behavior is unchanged.

## Validation

- Host semantic Goal recovery cases repeated 100 times
- tuttid Goal recovery integration cases repeated 100 times
- real timeout/recovery-budget boundary cases repeated 10 times
- `pnpm check:changed` — 10 lanes passed
- push-ready `pnpm check:changed -- --push-ready` — 11 lanes passed
