### PR TITLE
fix(agent-gui): synchronize live rail widths

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -119,6 +119,7 @@ function DesktopAgentGUISurfaceImpl({
   runtimeApi,
   trackAgentProviderChatReady,
   onEngagementEvent,
+  onConversationRailLayoutChange,
   trackWorkspaceFileReferences,
   workspaceFileReferenceAdapter,
   resolveExternalPromptEntries,
@@ -657,6 +658,7 @@ function DesktopAgentGUISurfaceImpl({
       onUpdateNode: handleUpdateNode,
       onRememberComposerDefaults: handleRememberComposerDefaults,
       onEngagementEvent: onEngagementEvent,
+      onConversationRailLayoutChange,
       onOpenConversationWindow: !onOpenAgentConversationWindow
         ? undefined
         : handleOpenConversationWindow

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/desktopAgentGUIWorkbenchModel.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/desktopAgentGUIWorkbenchModel.ts
@@ -104,6 +104,7 @@ export interface DesktopAgentGUIWorkbenchBodyProps {
   >;
   trackAgentProviderChatReady?: (input: { provider: string }) => Promise<void>;
   onEngagementEvent?: AgentGUIProps["hostActions"]["onEngagementEvent"];
+  onConversationRailLayoutChange?: AgentGUIProps["hostActions"]["onConversationRailLayoutChange"];
   trackWorkspaceFileReferences?: AgentGUIProps["workspace"]["onFileReferencesAdded"];
   workspaceFileReferenceAdapter: NonNullable<
     AgentGUIProps["workspace"]["fileReferenceAdapter"]
@@ -199,6 +200,8 @@ export function areDesktopAgentGUIWorkbenchBodyPropsEqual(
     previous.runtimeApi === next.runtimeApi &&
     previous.trackAgentProviderChatReady === next.trackAgentProviderChatReady &&
     previous.onEngagementEvent === next.onEngagementEvent &&
+    previous.onConversationRailLayoutChange ===
+      next.onConversationRailLayoutChange &&
     previous.trackWorkspaceFileReferences ===
       next.trackWorkspaceFileReferences &&
     previous.workspaceFileReferenceAdapter ===

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/useStableDesktopAgentGUIHostProps.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/useStableDesktopAgentGUIHostProps.test.ts
@@ -94,6 +94,23 @@ test("forwards the host-owned Session fork experiment opt-in", () => {
   assert.equal(result.hostCapabilities.sessionForkEnabled, true);
 });
 
+test("forwards the live conversation rail layout signal", () => {
+  const onConversationRailLayoutChange = () => {};
+  const result = useStableDesktopAgentGUIHostProps({
+    hostActions: { onConversationRailLayoutChange },
+    hostCapabilities: {},
+    identity: { currentUserId: null, nodeId: "node-1", workspaceId: "ws-1" },
+    renderSlots: {},
+    runtimeRequests: {},
+    workspace: {}
+  } as never);
+
+  assert.strictEqual(
+    result.hostActions.onConversationRailLayoutChange,
+    onConversationRailLayoutChange
+  );
+});
+
 test("forwards every runtimeRequests field instead of silently dropping new ones", () => {
   // The manual field-keyed reconstruction below is exactly the pattern that
   // let an optional host request silently vanish. This test round-trips every

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/useStableDesktopAgentGUIHostProps.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/useStableDesktopAgentGUIHostProps.ts
@@ -48,6 +48,7 @@ export type DesktopAgentGUIHostProps = {
     | "onUpdateNode"
     | "onRememberComposerDefaults"
     | "onEngagementEvent"
+    | "onConversationRailLayoutChange"
     | "onOpenConversationWindow"
   >;
   renderSlots: Pick<
@@ -128,6 +129,8 @@ export function useStableDesktopAgentGUIHostProps({
       onUpdateNode: nextHostActions.onUpdateNode,
       onRememberComposerDefaults: nextHostActions.onRememberComposerDefaults,
       onEngagementEvent: nextHostActions.onEngagementEvent,
+      onConversationRailLayoutChange:
+        nextHostActions.onConversationRailLayoutChange,
       onOpenConversationWindow: nextHostActions.onOpenConversationWindow
     },
     renderSlots: {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
@@ -185,6 +185,7 @@ export function createWorkspaceAgentGuiContribution(input: {
         });
       },
       onStateChange: (...args) => helpers.onStateChange(...args),
+      onConversationRailLayoutChange: helpers.onConversationRailLayoutChange,
       agentsService: helpers.agentDirectory,
       allAgentsPresentation: input.allAgentsPresentation,
       renderAgentsEmpty: input.renderAgentsEmpty,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
@@ -20,9 +20,11 @@ import { RichTextMentionServiceProvider } from "@tutti-os/ui-rich-text/editor";
 import type { WorkspaceSummary } from "@tutti-os/client-tuttid-ts";
 import { agentGuiWorkbenchProviderRailWidthPx } from "@tutti-os/agent-gui/workbench/contribution";
 import {
+  createAgentGuiWorkbenchRailLayoutStore,
   dispatchAgentGuiWorkbenchCommand,
   type AgentGuiWorkbenchSessionAction
 } from "@tutti-os/agent-gui/workbench";
+import type { AgentGUIConversationRailLayout } from "@tutti-os/agent-gui";
 import type {
   WorkbenchContribution,
   WorkbenchHostHandle
@@ -509,6 +511,10 @@ export function StandaloneAgentWindow({
     [desktopApi.dockPreviewCache]
   );
   const instanceId = useMemo(() => createAgentGuiWorkbenchInstanceId(), []);
+  const railLayoutStore = useMemo(
+    () => createAgentGuiWorkbenchRailLayoutStore(),
+    []
+  );
   const activeAgentTargetId = nodeState.agentTargetId?.trim() || null;
   const activeAgent = agents.find(
     (agent) => agent.agentTargetId === activeAgentTargetId
@@ -664,6 +670,12 @@ export function StandaloneAgentWindow({
     (width: number, animate = false) => resizeContentWidth(width, animate),
     [resizeContentWidth]
   );
+  const handleConversationRailLayoutChange = useCallback(
+    (layout: AgentGUIConversationRailLayout) => {
+      railLayoutStore.report(standaloneAgentNodeId, layout);
+    },
+    [railLayoutStore]
+  );
   const handleCapabilitySettingsRequest = useCallback(
     (target: WorkspaceWorkbenchCapabilitySettingsTarget) => {
       workspaceSettingsService.openPanel(
@@ -774,6 +786,7 @@ export function StandaloneAgentWindow({
               identity={headerIdentity}
               nodeId={standaloneAgentNodeId}
               providerRailWidthPx={agentGuiWorkbenchProviderRailWidthPx}
+              railLayoutStore={railLayoutStore}
               primaryAccessory={<AppUpdateStatus presentation="standalone" />}
               toolSidebar={isContentLoading ? null : toolSidebar}
               showConversationRailToggle={!isContentLoading}
@@ -859,6 +872,9 @@ export function StandaloneAgentWindow({
                 agentGuiHostInput.trackAgentProviderChatReady
               }
               onEngagementEvent={trackStandaloneAgentGUIEngagement}
+              onConversationRailLayoutChange={
+                handleConversationRailLayoutChange
+              }
               trackWorkspaceFileReferences={
                 agentGuiHostInput.trackWorkspaceFileReferences
               }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
@@ -20,11 +20,9 @@ import { RichTextMentionServiceProvider } from "@tutti-os/ui-rich-text/editor";
 import type { WorkspaceSummary } from "@tutti-os/client-tuttid-ts";
 import { agentGuiWorkbenchProviderRailWidthPx } from "@tutti-os/agent-gui/workbench/contribution";
 import {
-  createAgentGuiWorkbenchRailLayoutStore,
   dispatchAgentGuiWorkbenchCommand,
   type AgentGuiWorkbenchSessionAction
 } from "@tutti-os/agent-gui/workbench";
-import type { AgentGUIConversationRailLayout } from "@tutti-os/agent-gui";
 import type {
   WorkbenchContribution,
   WorkbenchHostHandle
@@ -81,6 +79,7 @@ import { useWorkspaceSettingsService } from "./useWorkspaceSettingsService";
 import type { WorkspaceWorkbenchCapabilitySettingsTarget } from "../services/workspaceWorkbenchHostService.interface";
 import { resolveDesktopWindowIntent } from "@shared/contracts/windowIntent.ts";
 import { useStandaloneAgentLaunchRouting } from "./useStandaloneAgentLaunchRouting.ts";
+import { useStandaloneAgentWindowConversationRailLayout } from "./useStandaloneAgentWindowConversationRailLayout.ts";
 import {
   StandaloneAgentWindowHeader,
   useStandaloneAgentWindowHeaderIdentity
@@ -511,10 +510,8 @@ export function StandaloneAgentWindow({
     [desktopApi.dockPreviewCache]
   );
   const instanceId = useMemo(() => createAgentGuiWorkbenchInstanceId(), []);
-  const railLayoutStore = useMemo(
-    () => createAgentGuiWorkbenchRailLayoutStore(),
-    []
-  );
+  const { onConversationRailLayoutChange, railLayoutStore } =
+    useStandaloneAgentWindowConversationRailLayout(standaloneAgentNodeId);
   const activeAgentTargetId = nodeState.agentTargetId?.trim() || null;
   const activeAgent = agents.find(
     (agent) => agent.agentTargetId === activeAgentTargetId
@@ -669,12 +666,6 @@ export function StandaloneAgentWindow({
   const resizeStandaloneAgentWindowContentWidth = useCallback(
     (width: number, animate = false) => resizeContentWidth(width, animate),
     [resizeContentWidth]
-  );
-  const handleConversationRailLayoutChange = useCallback(
-    (layout: AgentGUIConversationRailLayout) => {
-      railLayoutStore.report(standaloneAgentNodeId, layout);
-    },
-    [railLayoutStore]
   );
   const handleCapabilitySettingsRequest = useCallback(
     (target: WorkspaceWorkbenchCapabilitySettingsTarget) => {
@@ -872,9 +863,7 @@ export function StandaloneAgentWindow({
                 agentGuiHostInput.trackAgentProviderChatReady
               }
               onEngagementEvent={trackStandaloneAgentGUIEngagement}
-              onConversationRailLayoutChange={
-                handleConversationRailLayoutChange
-              }
+              onConversationRailLayoutChange={onConversationRailLayoutChange}
               trackWorkspaceFileReferences={
                 agentGuiHostInput.trackWorkspaceFileReferences
               }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindowHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindowHeader.tsx
@@ -6,6 +6,7 @@ import {
   agentGuiWorkbenchConversationIdentitiesEqual,
   resolveAgentGuiWorkbenchConversationIdentity
 } from "@tutti-os/agent-gui/workbench";
+import type { AgentGuiWorkbenchRailLayoutStore } from "@tutti-os/agent-gui/workbench";
 import type { IWorkspaceAgentActivityService as WorkspaceAgentActivityService } from "@renderer/features/workspace-agent/services/workspaceAgentActivityService.interface.ts";
 import type {
   DesktopAgentGUIProvider,
@@ -78,10 +79,12 @@ export interface StandaloneAgentWindowHeaderProps extends Omit<
   | "hasConversation"
 > {
   identity: StandaloneAgentWindowHeaderIdentity;
+  railLayoutStore: AgentGuiWorkbenchRailLayoutStore;
 }
 
 export function StandaloneAgentWindowHeader({
   identity,
+  railLayoutStore,
   ...props
 }: StandaloneAgentWindowHeaderProps): ReactNode {
   return (
@@ -93,6 +96,7 @@ export function StandaloneAgentWindowHeader({
       conversationTitle={identity.conversationTitle}
       conversationTitleDisplayPrompt={identity.conversationTitleDisplayPrompt}
       hasConversation={identity.hasConversation}
+      onHeaderElementChange={railLayoutStore.getHeaderElementRef(props.nodeId)}
     />
   );
 }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useStandaloneAgentWindowConversationRailLayout.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useStandaloneAgentWindowConversationRailLayout.ts
@@ -1,0 +1,28 @@
+import { useCallback, useMemo } from "react";
+import type { AgentGUIConversationRailLayout } from "@tutti-os/agent-gui";
+import {
+  createAgentGuiWorkbenchRailLayoutStore,
+  type AgentGuiWorkbenchRailLayoutStore
+} from "@tutti-os/agent-gui/workbench";
+
+export function useStandaloneAgentWindowConversationRailLayout(
+  nodeId: string
+): {
+  onConversationRailLayoutChange: (
+    layout: AgentGUIConversationRailLayout
+  ) => void;
+  railLayoutStore: AgentGuiWorkbenchRailLayoutStore;
+} {
+  const railLayoutStore = useMemo(
+    () => createAgentGuiWorkbenchRailLayoutStore(),
+    []
+  );
+  const onConversationRailLayoutChange = useCallback(
+    (layout: AgentGUIConversationRailLayout) => {
+      railLayoutStore.report(nodeId, layout);
+    },
+    [nodeId, railLayoutStore]
+  );
+
+  return { onConversationRailLayoutChange, railLayoutStore };
+}

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1590,7 +1590,15 @@ package signals such as `hostActions.onConversationRailLayoutChange`; it must
 not observe package DOM, CSS variables, or class names with
 `MutationObserver`. Composer affordances belong in AgentGUI itself or a
 narrow `renderSlots` contract, not in host-owned portals inserted into package
-DOM.
+DOM. During a Conversation Rail drag, AgentGUI emits this signal with
+`resizing: true`; the Workbench and standalone desktop headers apply that
+ephemeral width only to their own grid alignment, while the existing
+`onUpdateNode` path remains the sole persistent width write. Hosts must not
+write node state for each pointer movement. AgentGUI updates both its grid
+track (`--agent-gui-conversation-rail-width`) and the Rail content width
+(`--agent-gui-conversation-rail-content-width`) in that same pointer move;
+updating only one leaves blank space when expanding or overflows detail content
+when shrinking.
 
 ### 6.3 `AgentActivityRuntime` and `AgentHostApi`
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIConversationRailResizePointerMove.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIConversationRailResizePointerMove.spec.tsx
@@ -45,6 +45,11 @@ describe("useAgentGUIConversationRailResizePointerMove", () => {
         "--agent-gui-conversation-rail-width"
       )
     ).toBe("280px");
+    expect(
+      layoutElement.style.getPropertyValue(
+        "--agent-gui-conversation-rail-content-width"
+      )
+    ).toBe("280px");
     expect(resizeHandle.getAttribute("aria-valuenow")).toBe("280");
     expect(onConversationRailLayoutChange).toHaveBeenCalledWith({
       providerRailWidthPx: 52,

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIConversationRailResizePointerMove.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIConversationRailResizePointerMove.ts
@@ -47,6 +47,10 @@ export function useAgentGUIConversationRailResizePointerMove({
         "--agent-gui-conversation-rail-width",
         `${nextWidthPx}px`
       );
+      layoutElementRef.current?.style.setProperty(
+        "--agent-gui-conversation-rail-content-width",
+        `${nextWidthPx}px`
+      );
       reportConversationRailLayoutChange?.({
         providerRailWidthPx,
         conversationRailWidthPx: nextWidthPx,

--- a/packages/agent/gui/workbench/AgentGuiWorkbenchRailAlignedHeader.tsx
+++ b/packages/agent/gui/workbench/AgentGuiWorkbenchRailAlignedHeader.tsx
@@ -1,0 +1,51 @@
+import type { ReactNode } from "react";
+import type { AgentSessionEngine } from "@tutti-os/agent-activity-core";
+import type { AgentGUIAgentDirectoryPort } from "../types.ts";
+import { AgentGuiWorkbenchReactiveHeader } from "./AgentGuiWorkbenchReactiveHeader.tsx";
+import type { AgentGuiWorkbenchRailLayoutStore } from "./agentGuiWorkbenchRailLayout.ts";
+import { AgentGuiWorkbenchHeader } from "./header.ts";
+import type { AgentGuiWorkbenchHeaderProps } from "./header.ts";
+import type {
+  AgentGuiWorkbenchProvider,
+  AgentGuiWorkbenchState
+} from "./types.ts";
+
+interface AgentGuiWorkbenchRailAlignedHeaderProps extends AgentGuiWorkbenchHeaderProps {
+  agentDirectory: AgentGUIAgentDirectoryPort;
+  dockIconUrls?: Partial<Record<AgentGuiWorkbenchProvider, string>>;
+  railLayoutStore: AgentGuiWorkbenchRailLayoutStore;
+  sessionEngine?: AgentSessionEngine;
+  workbenchState: AgentGuiWorkbenchState | null;
+}
+
+export function AgentGuiWorkbenchRailAlignedHeader({
+  agentDirectory,
+  conversationRailWidthPx,
+  dockIconUrls,
+  nodeId,
+  providerRailWidthPx,
+  railLayoutStore,
+  sessionEngine,
+  workbenchState,
+  ...headerProps
+}: AgentGuiWorkbenchRailAlignedHeaderProps): ReactNode {
+  const liveHeaderProps = {
+    ...headerProps,
+    conversationRailWidthPx,
+    nodeId,
+    onHeaderElementChange: railLayoutStore.getHeaderElementRef(nodeId),
+    providerRailWidthPx
+  } satisfies AgentGuiWorkbenchHeaderProps;
+
+  return sessionEngine ? (
+    <AgentGuiWorkbenchReactiveHeader
+      {...liveHeaderProps}
+      agentDirectory={agentDirectory}
+      dockIconUrls={dockIconUrls}
+      sessionEngine={sessionEngine}
+      workbenchState={workbenchState}
+    />
+  ) : (
+    <AgentGuiWorkbenchHeader {...liveHeaderProps} />
+  );
+}

--- a/packages/agent/gui/workbench/agentGuiWorkbenchRailLayout.ts
+++ b/packages/agent/gui/workbench/agentGuiWorkbenchRailLayout.ts
@@ -1,0 +1,64 @@
+import type { AgentGUIConversationRailLayout } from "../agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts";
+
+type HeaderElementRef = (element: HTMLElement | null) => void;
+
+export interface AgentGuiWorkbenchRailLayoutStore {
+  getHeaderElementRef(nodeId: string): HeaderElementRef;
+  report(nodeId: string, layout: AgentGUIConversationRailLayout): void;
+}
+
+export function createAgentGuiWorkbenchRailLayoutStore(): AgentGuiWorkbenchRailLayoutStore {
+  const layoutsByNodeId = new Map<string, AgentGUIConversationRailLayout>();
+  const headerElementsByNodeId = new Map<string, HTMLElement>();
+  const headerElementRefsByNodeId = new Map<string, HeaderElementRef>();
+
+  const applyLayout = (
+    element: HTMLElement,
+    layout: AgentGUIConversationRailLayout
+  ): void => {
+    element.style.setProperty(
+      "--agent-gui-workbench-header-rail-width",
+      `${Math.round(layout.leftPanelWidthPx)}px`
+    );
+  };
+
+  return {
+    getHeaderElementRef(nodeId) {
+      const existingRef = headerElementRefsByNodeId.get(nodeId);
+      if (existingRef) {
+        return existingRef;
+      }
+      const ref: HeaderElementRef = (element) => {
+        if (element) {
+          headerElementsByNodeId.set(nodeId, element);
+          const layout = layoutsByNodeId.get(nodeId);
+          if (layout) {
+            applyLayout(element, layout);
+          }
+          return;
+        }
+        headerElementsByNodeId.delete(nodeId);
+        headerElementRefsByNodeId.delete(nodeId);
+        layoutsByNodeId.delete(nodeId);
+      };
+      headerElementRefsByNodeId.set(nodeId, ref);
+      return ref;
+    },
+    report(nodeId, layout) {
+      const current = layoutsByNodeId.get(nodeId);
+      if (
+        current?.conversationRailWidthPx === layout.conversationRailWidthPx &&
+        current?.leftPanelWidthPx === layout.leftPanelWidthPx &&
+        current?.providerRailWidthPx === layout.providerRailWidthPx &&
+        current?.resizing === layout.resizing
+      ) {
+        return;
+      }
+      layoutsByNodeId.set(nodeId, layout);
+      const element = headerElementsByNodeId.get(nodeId);
+      if (element) {
+        applyLayout(element, layout);
+      }
+    }
+  };
+}

--- a/packages/agent/gui/workbench/contribution.test.ts
+++ b/packages/agent/gui/workbench/contribution.test.ts
@@ -1966,6 +1966,99 @@ describe("agent GUI workbench contribution copy", () => {
       }px`
     });
   });
+
+  it("keeps the unified header aligned while the conversation rail is resizing", () => {
+    let reportConversationRailLayout:
+      | ((layout: {
+          conversationRailWidthPx: number;
+          leftPanelWidthPx: number;
+          providerRailWidthPx: number;
+          resizing: boolean;
+        }) => void)
+      | null = null;
+    const contribution = createTestAgentGuiWorkbenchContribution({
+      renderBody: (_context, helpers) => {
+        reportConversationRailLayout = helpers.onConversationRailLayoutChange;
+        return null;
+      },
+      workspaceId: "workspace-1"
+    });
+
+    contribution.nodes?.[0]?.renderBody?.({
+      activation: null,
+      externalNodeState: {
+        conversationRailCollapsed: false,
+        conversationRailWidthPx: 360,
+        lastActiveAgentSessionId: null
+      },
+      externalWorkspaceState: null,
+      instanceId: "agent-gui:codex:panel:test-1",
+      instanceKey: null,
+      node: {
+        data: {
+          runtimeNodeState: null
+        },
+        displayMode: "floating",
+        frame: { height: 560, width: 1040, x: 0, y: 0 },
+        id: "agent-gui-node-1",
+        title: "Agent"
+      }
+    } as never);
+
+    render(
+      contribution.nodes?.[0]?.renderHeader?.({
+        activation: null,
+        defaultActions: null,
+        displayMode: "floating",
+        dragHandleProps: {},
+        externalNodeState: {
+          conversationRailCollapsed: false,
+          conversationRailWidthPx: 360,
+          lastActiveAgentSessionId: null
+        },
+        externalWorkspaceState: null,
+        instanceId: "agent-gui:codex:panel:test-1",
+        instanceKey: null,
+        isFocused: true,
+        node: {
+          data: {
+            dockEntryId: agentGuiWorkbenchUnifiedDockEntryId(),
+            runtimeNodeState: null
+          },
+          displayMode: "floating",
+          frame: { height: 560, width: 1040, x: 0, y: 0 },
+          id: "agent-gui-node-1",
+          title: "Agent"
+        },
+        surfaceSize: { height: 800, width: 1200 },
+        windowActions: {
+          applyQuickLayout: () => {},
+          close: () => {},
+          focus: () => {},
+          minimize: () => {},
+          resize: () => {},
+          toggleDisplayMode: () => {}
+        }
+      } as never) ?? null
+    );
+
+    act(() => {
+      reportConversationRailLayout?.({
+        conversationRailWidthPx: 420,
+        leftPanelWidthPx: 420 + agentGuiWorkbenchProviderRailWidthPx,
+        providerRailWidthPx: agentGuiWorkbenchProviderRailWidthPx,
+        resizing: true
+      });
+    });
+
+    expect(
+      document.querySelector('[data-agent-gui-workbench-header="true"]')
+    ).toHaveStyle({
+      "--agent-gui-workbench-header-rail-width": `${
+        420 + agentGuiWorkbenchProviderRailWidthPx
+      }px`
+    });
+  });
 });
 
 function createWorkbenchSession(title: string, updatedAtUnixMs: number) {

--- a/packages/agent/gui/workbench/contribution.ts
+++ b/packages/agent/gui/workbench/contribution.ts
@@ -9,12 +9,11 @@ import {
   resolveAgentGUIConversationRailPresentation,
   resolveAgentGUIExpandedWindowFrame
 } from "../agent-gui/agentGuiNode/model/agentGuiRailLayout.ts";
-import { AgentGuiWorkbenchReactiveHeader } from "./AgentGuiWorkbenchReactiveHeader.tsx";
+import type { AgentGUIConversationRailLayout } from "../agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts";
 import { setAgentGuiWorkbenchBodyRenderError } from "./bodyRenderErrorRegistry.ts";
-import {
-  AgentGuiWorkbenchHeader,
-  type AgentGuiWorkbenchHeaderProps
-} from "./header.ts";
+import { AgentGuiWorkbenchRailAlignedHeader } from "./AgentGuiWorkbenchRailAlignedHeader.tsx";
+import { createAgentGuiWorkbenchRailLayoutStore } from "./agentGuiWorkbenchRailLayout.ts";
+import type { AgentGuiWorkbenchHeaderProps } from "./header.ts";
 import type { AgentGuiWorkbenchConversationIdentity } from "./conversationIdentity.ts";
 import {
   agentGuiWorkbenchTypeId,
@@ -79,6 +78,7 @@ export interface AgentGuiWorkbenchRenderBodyHelpers {
   agentDirectory: AgentGUIAgentDirectoryPort;
   agentTargetId: string | null;
   nodeTypeId: string;
+  onConversationRailLayoutChange(layout: AgentGUIConversationRailLayout): void;
   onStateChange(state: AgentGuiWorkbenchState): void;
   provider: AgentGuiWorkbenchProvider | null;
 }
@@ -122,6 +122,7 @@ export function createAgentGuiWorkbenchContribution(
   const nodeStateSource = createAgentGuiWorkbenchNodeStateSource({
     workspaceId: input.workspaceId
   });
+  const railLayoutStore = createAgentGuiWorkbenchRailLayoutStore();
   const frame = input.frame ?? agentGuiWorkbenchDefaultNodeFrame;
   const copy = resolveAgentGuiWorkbenchContributionCopy(input.copy);
   return {
@@ -191,6 +192,9 @@ export function createAgentGuiWorkbenchContribution(
               agentDirectory: input.agentDirectory,
               agentTargetId: state.agentTargetId ?? null,
               nodeTypeId: agentGuiWorkbenchTypeId,
+              onConversationRailLayoutChange: (layout) => {
+                railLayoutStore.report(context.node.id, layout);
+              },
               onStateChange: (nextState) => {
                 nodeStateSource.writeNodeState({
                   instanceId: context.instanceId,
@@ -356,21 +360,18 @@ export function createAgentGuiWorkbenchContribution(
               persistConversationRailCollapsed(nextCollapsed);
             }
           } satisfies AgentGuiWorkbenchHeaderProps;
-          return input.sessionEngine
-            ? createElement(AgentGuiWorkbenchReactiveHeader, {
-                ...headerProps,
-                agentDirectory: input.agentDirectory,
-                dockIconUrls: input.dockIconUrls,
-                sessionEngine: input.sessionEngine,
-                workbenchState
-              })
-            : createElement(AgentGuiWorkbenchHeader, {
-                ...headerProps,
-                agentTitle: conversationIdentity?.agentTitle,
-                conversationIconUrl,
-                conversationTitle,
-                hasConversation
-              });
+          return createElement(AgentGuiWorkbenchRailAlignedHeader, {
+            ...headerProps,
+            agentDirectory: input.agentDirectory,
+            agentTitle: conversationIdentity?.agentTitle,
+            conversationIconUrl,
+            conversationTitle,
+            dockIconUrls: input.dockIconUrls,
+            hasConversation,
+            railLayoutStore,
+            sessionEngine: input.sessionEngine,
+            workbenchState
+          });
         },
         title: copy.nodeTitle,
         typeId: agentGuiWorkbenchTypeId,

--- a/packages/agent/gui/workbench/header.ts
+++ b/packages/agent/gui/workbench/header.ts
@@ -88,6 +88,7 @@ export interface AgentGuiWorkbenchHeaderProps extends HTMLAttributes<HTMLElement
   conversationTitle?: string | null;
   conversationTitleDisplayPrompt?: string | null;
   nodeId: string;
+  onHeaderElementChange?: (element: HTMLElement | null) => void;
   onCreateConversation?: () => void;
   onOpenDetachedWindow?: () => void;
   onSessionAction?: (action: AgentGuiWorkbenchSessionAction) => void;
@@ -125,6 +126,7 @@ export function AgentGuiWorkbenchHeader({
   conversationTitle,
   conversationTitleDisplayPrompt,
   nodeId,
+  onHeaderElementChange,
   onCreateConversation,
   onOpenDetachedWindow,
   onSessionAction,
@@ -213,6 +215,7 @@ export function AgentGuiWorkbenchHeader({
     "header",
     {
       ...headerProps,
+      ref: onHeaderElementChange,
       className: cn("agent-gui-workbench-header", className),
       "data-agent-gui-workbench-header": "true",
       "data-agent-gui-workbench-header-body-error": hasBodyRenderError

--- a/packages/agent/gui/workbench/index.ts
+++ b/packages/agent/gui/workbench/index.ts
@@ -74,6 +74,10 @@ export {
   type AgentGuiWorkbenchHeaderCopy,
   type AgentGuiWorkbenchHeaderProps
 } from "./header.ts";
+export {
+  createAgentGuiWorkbenchRailLayoutStore,
+  type AgentGuiWorkbenchRailLayoutStore
+} from "./agentGuiWorkbenchRailLayout.ts";
 export type { AgentGuiWorkbenchSessionMenuAdditionalAction } from "./AgentGuiWorkbenchSessionMenu.tsx";
 export {
   resolveAgentGuiWorkbenchHeaderTitle,


### PR DESCRIPTION
## Summary
- update both conversation-rail CSS width variables during pointer drag, keeping the list content aligned with the grid
- forward the existing live rail-layout signal to workbench and standalone headers so their divider follows the rail
- cover both CSS variables and header synchronization; document the explicit, non-persistent layout contract

## Tests
- `pnpm check:changed -- --push-ready`

## Notes
- The initial isolated-worktree run hit an Electron first-download write race. After Electron completed installation, the failed desktop lane passed (1,665 passed, 0 failed), and the pre-push gate then passed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1870" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->