### PR TITLE
refactor(agent-activity): settle activation results in engine

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityMutationOperations.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityMutationOperations.test.ts
@@ -7,55 +7,6 @@ import type {
 import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
 import { WorkspaceAgentActivityMutationOperations } from "./workspaceAgentActivityMutationOperations.ts";
 
-test("WorkspaceAgentActivityMutationOperations carries Tutti activation metadata through new-session activation", async () => {
-  const createInputs: Parameters<AgentActivityAdapter["createSession"]>[0][] =
-    [];
-  const upserts: { session: AgentActivitySession; source: string }[] = [];
-  const session = activitySession();
-  const adapter = {
-    async createSession(
-      input: Parameters<AgentActivityAdapter["createSession"]>[0]
-    ) {
-      createInputs.push(input);
-      return session;
-    }
-  } as AgentActivityAdapter;
-  const operations = createOperations({
-    adapter,
-    upsertAuthoritativeSession: (authoritativeSession, source) => {
-      upserts.push({ session: authoritativeSession, source });
-    }
-  });
-
-  const result = await operations.activateSession({
-    agentSessionId: "session-1",
-    agentTargetId: "local:codex",
-    capabilityRefs: [{ capability: "tutti", source: "slash_command" }],
-    clientSubmitId: "submit-1",
-    cwd: " /workspace ",
-    initialContent: [{ type: "text", text: "Build the plan" }],
-    initialTuttiModeActivation: {
-      source: "slash_command",
-      status: "active"
-    },
-    mode: "new",
-    workspaceId: " ws-1 "
-  });
-
-  assert.equal(result.activation.status, "attached");
-  assert.equal(createInputs.length, 1);
-  assert.deepEqual(createInputs[0]?.capabilityRefs, [
-    { capability: "tutti", source: "slash_command" }
-  ]);
-  assert.deepEqual(createInputs[0]?.initialTuttiModeActivation, {
-    source: "slash_command",
-    status: "active"
-  });
-  assert.equal(createInputs[0]?.cwd, "/workspace");
-  assert.equal(createInputs[0]?.workspaceId, "ws-1");
-  assert.deepEqual(upserts, [{ session, source: "create_session_result" }]);
-});
-
 test("WorkspaceAgentActivityMutationOperations sends existing-session Tutti activation updates through the facade-owned adapter", async () => {
   const updateInputs: Parameters<
     AgentActivityAdapter["updateTuttiModeActivation"]
@@ -113,51 +64,9 @@ function createOperations(input: {
   ) => void;
 }): WorkspaceAgentActivityMutationOperations {
   return new WorkspaceAgentActivityMutationOperations({
-    getSession: async () => activitySession(),
     runtimeApi: { logTerminalDiagnostic: async () => {} },
     sessionCommandTarget: () => ({ adapter: input.adapter }),
     tuttidClient: {} as TuttidClient,
     upsertAuthoritativeSession: input.upsertAuthoritativeSession ?? (() => {})
   });
-}
-
-function activitySession(): AgentActivitySession {
-  return {
-    activeTurn: null,
-    activeTurnId: null,
-    agentSessionId: "session-1",
-    agentTargetId: "local:codex",
-    capabilities: null,
-    lifecycleCapabilities: { fork: false, forkThroughTurn: false },
-    forkedFrom: null,
-    createdAtUnixMs: 1,
-    cwd: "/workspace",
-    endedAtUnixMs: null,
-    goal: null,
-    imported: false,
-    kind: "root",
-    lastEventUnixMs: 1,
-    latestTurn: null,
-    latestTurnInteractions: [],
-    messageVersion: 0,
-    parentAgentSessionId: null,
-    parentToolCallId: null,
-    parentTurnId: null,
-    pendingInteractions: [],
-    permissionConfig: { configurable: false, modes: [] },
-    pinnedAtUnixMs: null,
-    provider: "codex",
-    providerSessionId: null,
-    resumable: true,
-    rootAgentSessionId: null,
-    rootTurnId: null,
-    settings: {},
-    startedAtUnixMs: 1,
-    title: "Session",
-    tuttiModeActivation: null,
-    updatedAtUnixMs: 1,
-    usage: null,
-    visible: true,
-    workspaceId: "ws-1"
-  };
 }

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityMutationOperations.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityMutationOperations.ts
@@ -5,15 +5,11 @@ import type {
 } from "@tutti-os/agent-activity-core";
 import type { AgentActivityRuntime } from "@tutti-os/agent-gui";
 import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
-import type { DesktopHostFilesApi, DesktopRuntimeApi } from "@preload/types";
-import type { IWorkspaceUserProjectService } from "../../../workspace-user-project/index.ts";
+import type { DesktopRuntimeApi } from "@preload/types";
 import { agentActivitySessionFromTuttidSession } from "../desktopAgentActivityAdapter.ts";
 import { reportAgentSubmitTraceDiagnostic } from "../desktopAgentRuntimeSubmitDiagnostics.ts";
 import type { IWorkspaceAgentActivityService } from "../workspaceAgentActivityService.interface.ts";
-import {
-  normalizeComposerSettings,
-  resolveComposerPermissionMode
-} from "./desktopAgentHostProjection.ts";
+import { normalizeComposerSettings } from "./desktopAgentHostProjection.ts";
 import { normalizeWorkspaceId } from "./workspaceAgentActivityDiagnostics.ts";
 
 interface WorkspaceAgentActivityMutationCommandTarget {
@@ -21,15 +17,6 @@ interface WorkspaceAgentActivityMutationCommandTarget {
 }
 
 export interface WorkspaceAgentActivityMutationOperationsDependencies {
-  getSession(
-    workspaceId: string,
-    agentSessionId: string,
-    signal?: AbortSignal
-  ): Promise<AgentActivitySession>;
-  hostFilesApi?: Pick<
-    DesktopHostFilesApi,
-    "createUserDocumentsProjectDirectory"
-  >;
   runtimeApi: Pick<DesktopRuntimeApi, "logTerminalDiagnostic">;
   sessionCommandTarget(
     workspaceId: string
@@ -39,10 +26,6 @@ export interface WorkspaceAgentActivityMutationOperationsDependencies {
     session: AgentActivitySession,
     source: string
   ): void;
-  workspaceUserProjectService?: Pick<
-    IWorkspaceUserProjectService,
-    "rememberNoProjectPath"
-  >;
 }
 
 export class WorkspaceAgentActivityMutationOperations {
@@ -86,10 +69,6 @@ export class WorkspaceAgentActivityMutationOperations {
       workspaceId: input.workspaceId,
       fields: { activeTurnPhase: session.activeTurn?.phase ?? null }
     });
-    this.dependencies.upsertAuthoritativeSession(
-      session,
-      "create_session_result"
-    );
     reportAgentSubmitTraceDiagnostic(this.dependencies.runtimeApi, {
       agentSessionId: session.agentSessionId,
       clientSubmitId: input.clientSubmitId,
@@ -100,122 +79,6 @@ export class WorkspaceAgentActivityMutationOperations {
       fields: { activeTurnPhase: session.activeTurn?.phase ?? null }
     });
     return session;
-  }
-
-  async activateSession(
-    input: Parameters<AgentActivityRuntime["activateSession"]>[0]
-  ): ReturnType<IWorkspaceAgentActivityService["activateSession"]> {
-    const workspaceId = normalizeWorkspaceId(input.workspaceId);
-    const requestedAgentSessionId = input.agentSessionId.trim();
-    reportAgentSubmitTraceDiagnostic(this.dependencies.runtimeApi, {
-      agentSessionId: requestedAgentSessionId,
-      clientSubmitId: input.mode === "new" ? input.clientSubmitId : null,
-      event: "activity_service.activate.entered",
-      provider: null,
-      submitDiagnostics: input.submitDiagnostics,
-      workspaceId,
-      fields: { agentTargetId: input.agentTargetId ?? null, mode: input.mode }
-    });
-    if (input.mode === "new") {
-      reportAgentSubmitTraceDiagnostic(this.dependencies.runtimeApi, {
-        agentSessionId: requestedAgentSessionId,
-        clientSubmitId: input.clientSubmitId,
-        event: "activity_service.activate.cwd_resolve_requested",
-        provider: null,
-        submitDiagnostics: input.submitDiagnostics,
-        workspaceId
-      });
-    }
-    const resolvedCwd =
-      input.mode === "new"
-        ? await this.resolveWorkspaceAgentCwd({
-            agentSessionId: requestedAgentSessionId,
-            cwd: input.cwd,
-            workspaceId
-          })
-        : null;
-    if (input.mode === "new") {
-      reportAgentSubmitTraceDiagnostic(this.dependencies.runtimeApi, {
-        agentSessionId: requestedAgentSessionId,
-        clientSubmitId: input.clientSubmitId,
-        event: "activity_service.activate.cwd_resolved",
-        provider: null,
-        submitDiagnostics: input.submitDiagnostics,
-        workspaceId,
-        fields: {
-          agentTargetId: input.agentTargetId ?? null,
-          cwd: resolvedCwd?.cwd ?? null
-        }
-      });
-    }
-    let session: AgentActivitySession;
-    if (input.mode === "existing") {
-      session = await this.dependencies.getSession(
-        workspaceId,
-        requestedAgentSessionId,
-        input.signal
-      );
-    } else {
-      reportAgentSubmitTraceDiagnostic(this.dependencies.runtimeApi, {
-        agentSessionId: requestedAgentSessionId,
-        clientSubmitId: input.clientSubmitId,
-        event: "activity_service.activate.create_requested",
-        provider: null,
-        submitDiagnostics: input.submitDiagnostics,
-        workspaceId,
-        fields: { agentTargetId: input.agentTargetId ?? null }
-      });
-      session = await this.createSession({
-        clientSubmitId: input.clientSubmitId,
-        workspaceId,
-        agentSessionId: requestedAgentSessionId,
-        agentTargetId: input.agentTargetId,
-        capabilityRefs: input.capabilityRefs ?? null,
-        cwd: resolvedCwd?.cwd ?? null,
-        initialContent: input.initialContent ?? [],
-        initialDisplayPrompt: input.initialDisplayPrompt ?? null,
-        initialTuttiModeActivation: input.initialTuttiModeActivation ?? null,
-        submitDiagnostics: input.submitDiagnostics,
-        model: input.settings?.model ?? null,
-        planMode: input.settings?.planMode ?? null,
-        permissionModeId: resolveComposerPermissionMode(input.settings),
-        reasoningEffort: input.settings?.reasoningEffort ?? null,
-        ...(resolvedCwd?.noProject ? { noProject: true } : {}),
-        speed: input.settings?.speed ?? null,
-        title: input.title ?? null,
-        visible: input.visible ?? true,
-        signal: input.signal
-      });
-      reportAgentSubmitTraceDiagnostic(this.dependencies.runtimeApi, {
-        agentSessionId: session.agentSessionId,
-        clientSubmitId: input.clientSubmitId,
-        event: "activity_service.activate.create_resolved",
-        provider: session.provider,
-        submitDiagnostics: input.submitDiagnostics,
-        workspaceId,
-        fields: { activeTurnPhase: session.activeTurn?.phase ?? null }
-      });
-    }
-    reportAgentSubmitTraceDiagnostic(this.dependencies.runtimeApi, {
-      agentSessionId: session.agentSessionId,
-      clientSubmitId: input.mode === "new" ? input.clientSubmitId : null,
-      event: "activity_service.activate.resolved",
-      provider: session.provider,
-      submitDiagnostics: input.submitDiagnostics,
-      workspaceId,
-      fields: {
-        mode: input.mode,
-        activeTurnPhase: session.activeTurn?.phase ?? null,
-        latestTurnOutcome: session.latestTurn?.outcome ?? null
-      }
-    });
-    return {
-      activation: {
-        mode: input.mode,
-        status: input.mode === "existing" ? "already_attached" : "attached"
-      },
-      session
-    };
   }
 
   async sendInput(
@@ -366,33 +229,5 @@ export class WorkspaceAgentActivityMutationOperations {
       agentSessionId: input.agentSessionId,
       buffered: false
     });
-  }
-
-  private async resolveWorkspaceAgentCwd(input: {
-    agentSessionId: string;
-    cwd: string | null | undefined;
-    workspaceId: string;
-  }): Promise<{ cwd: string | null; noProject: boolean }> {
-    const trimmed = input.cwd?.trim() ?? "";
-    if (!trimmed) {
-      const directory =
-        await this.dependencies.hostFilesApi?.createUserDocumentsProjectDirectory(
-          {
-            name: `session-${input.agentSessionId.trim()}`,
-            allowExisting: true
-          }
-        );
-      this.dependencies.workspaceUserProjectService?.rememberNoProjectPath(
-        directory?.path
-      );
-      return { cwd: directory?.path ?? null, noProject: true };
-    }
-    if (trimmed !== "/") return { cwd: trimmed, noProject: false };
-    const response =
-      await this.dependencies.tuttidClient.listWorkspaceFileDirectory(
-        input.workspaceId,
-        {}
-      );
-    return { cwd: response.root, noProject: false };
   }
 }

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -294,6 +294,41 @@ test("WorkspaceAgentActivityService.activateSession creates target-backed sessio
   });
 });
 
+test("Desktop Engine applies activation results without a host-side Session dispatch", async () => {
+  const observedIntentTypes: string[] = [];
+  const service = new WorkspaceAgentActivityService({
+    tuttidClient: {
+      createWorkspaceAgentSession: async () =>
+        workspaceAgentSession({ status: "created" })
+    } as unknown as TuttidClient,
+    runtimeApi: { logTerminalDiagnostic: async () => {} }
+  });
+  service.addSessionEngineActivityObserver("ws-1", {
+    observeCommand() {},
+    observeIntent(intent) {
+      observedIntentTypes.push(intent.type);
+    }
+  });
+  const engine = service.getSessionEngine("ws-1");
+
+  assert.equal(
+    engine.activateSession({
+      agentSessionId: "session-1",
+      agentTargetId: "local:codex",
+      clientSubmitId: "submit-1",
+      mode: "new",
+      requestId: "activation-1"
+    }),
+    true
+  );
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  assert.ok(selectEngineSession(engine.getSnapshot(), "session-1"));
+  assert.ok(observedIntentTypes.includes("activation/requested"));
+  assert.ok(observedIntentTypes.includes("engine/commandResult"));
+  assert.equal(observedIntentTypes.includes("session/upserted"), false);
+});
+
 test("WorkspaceAgentActivityService force-refreshes only the failed conversation provider before reporting availability", async () => {
   const refreshCalls: string[][] = [];
   const reporterEvents: ReporterEventInput[] = [];
@@ -3299,6 +3334,7 @@ test("WorkspaceAgentActivityService preserves a pending new session when the Tut
     createdAtUnixMs: requestedAtUnixMs
   });
   await activationResolved;
+  await new Promise<void>((resolve) => setImmediate(resolve));
 
   assert.equal(
     selectEngineSession(engine.getSnapshot(), "session-1")?.provider,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -329,7 +329,7 @@ test("Desktop Engine applies activation results without a host-side Session disp
   assert.equal(observedIntentTypes.includes("session/upserted"), false);
 });
 
-test("WorkspaceAgentActivityService force-refreshes only the failed conversation provider before reporting availability", async () => {
+test("Desktop Engine activation reports a failed conversation provider from the shared create effect", async (t) => {
   const refreshCalls: string[][] = [];
   const reporterEvents: ReporterEventInput[] = [];
   const service = new WorkspaceAgentActivityService({
@@ -375,16 +375,19 @@ test("WorkspaceAgentActivityService force-refreshes only the failed conversation
     } as unknown as TuttidClient,
     runtimeApi: { logTerminalDiagnostic: async () => {} }
   });
+  t.after(() => service.dispose());
 
-  await assert.rejects(
-    service.createSession({
+  const engine = service.getSessionEngine("ws-1");
+  assert.equal(
+    engine.activateSession({
       agentSessionId: "session-failed",
       agentTargetId: "target-cursor",
       clientSubmitId: "submit-failed",
       initialContent: [{ type: "text", text: "hello" }],
-      workspaceId: "ws-1"
+      mode: "new",
+      requestId: "activation-failed"
     }),
-    /provider launch failed/
+    true
   );
   await new Promise((resolve) => setImmediate(resolve));
 
@@ -3583,6 +3586,7 @@ function workspaceAgentTurn(
     completedCommand: null,
     error: null,
     fileChanges: null,
+    origin: "user_prompt" as const,
     phase: "running" as const,
     startedAtUnixMs: 1,
     turnId: "turn-1",

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -5,6 +5,8 @@ import {
   type AgentActivityGoalControlResult,
   type AgentActivityMessagePage,
   type AgentActivitySession,
+  type AgentActivitySessionDetailSnapshot,
+  type AgentSessionActivateEffectResult,
   type AgentSessionEngine,
   type AgentActivitySnapshot,
   type EngineExternalCommand,
@@ -164,17 +166,13 @@ export class WorkspaceAgentActivityService
       tuttidClient: dependencies.tuttidClient
     });
     this.mutationOperations = new WorkspaceAgentActivityMutationOperations({
-      getSession: (workspaceId, agentSessionId, signal) =>
-        this.getSession(workspaceId, agentSessionId, signal),
-      hostFilesApi: dependencies.hostFilesApi,
       runtimeApi: dependencies.runtimeApi,
       sessionCommandTarget: (workspaceId) => ({
         adapter: this.entry(workspaceId).adapter
       }),
       tuttidClient: dependencies.tuttidClient,
       upsertAuthoritativeSession: (session, source) =>
-        this.upsertAuthoritativeSession(session, source),
-      workspaceUserProjectService: dependencies.workspaceUserProjectService
+        this.upsertAuthoritativeSession(session, source)
     });
   }
 
@@ -485,7 +483,9 @@ export class WorkspaceAgentActivityService
     input: Parameters<AgentActivityAdapter["createSession"]>[0]
   ): Promise<AgentActivitySession> {
     try {
-      return await this.mutationOperations.createSession(input);
+      const session = await this.mutationOperations.createSession(input);
+      this.upsertAuthoritativeSession(session, "create_session_result");
+      return session;
     } catch (error) {
       this.analytics.trackSessionCreateFailure({
         agentTargetId: input.agentTargetId
@@ -497,6 +497,21 @@ export class WorkspaceAgentActivityService
   async activateSession(
     input: Parameters<AgentActivityRuntime["activateSession"]>[0]
   ): ReturnType<IWorkspaceAgentActivityService["activateSession"]> {
+    const result = await this.executeSessionActivationEffect(input);
+    if ("detail" in result) {
+      this.upsertAuthoritativeSessionDetail(
+        result.detail,
+        "get_session_result"
+      );
+    } else {
+      this.upsertAuthoritativeSession(result.session, "create_session_result");
+    }
+    return result;
+  }
+
+  private async executeSessionActivationEffect(
+    input: Parameters<AgentActivityRuntime["activateSession"]>[0]
+  ): Promise<AgentSessionActivateEffectResult> {
     const workspaceId = normalizeWorkspaceId(input.workspaceId);
     const requestedAgentSessionId = input.agentSessionId.trim();
     reportAgentSubmitTraceDiagnostic(this.dependencies.runtimeApi, {
@@ -545,13 +560,17 @@ export class WorkspaceAgentActivityService
         }
       });
     }
+    let detail: AgentActivitySessionDetailSnapshot | null = null;
     let session: AgentActivitySession;
     if (input.mode === "existing") {
-      session = await this.getSession(
+      detail = await this.fetchActivitySessionDetail(
         workspaceId,
         requestedAgentSessionId,
+        "get_session",
+        "full",
         input.signal
       );
+      session = detail.session;
     } else {
       reportAgentSubmitTraceDiagnostic(this.dependencies.runtimeApi, {
         agentSessionId: requestedAgentSessionId,
@@ -566,7 +585,7 @@ export class WorkspaceAgentActivityService
             input.initialTuttiModeActivation != null
         }
       });
-      session = await this.createSession({
+      session = await this.mutationOperations.createSession({
         clientSubmitId: input.clientSubmitId,
         workspaceId,
         agentSessionId: requestedAgentSessionId,
@@ -613,11 +632,18 @@ export class WorkspaceAgentActivityService
         latestTurnOutcome: session.latestTurn?.outcome ?? null
       }
     });
+    if (input.mode === "existing") {
+      if (!detail) {
+        throw new Error("workspace_agent_activation_detail_missing");
+      }
+      return {
+        activation: { mode: "existing", status: "already_attached" },
+        detail,
+        session
+      };
+    }
     return {
-      activation: {
-        mode: input.mode,
-        status: input.mode === "existing" ? "already_attached" : "attached"
-      },
+      activation: { mode: "new", status: "attached" },
       session
     };
   }
@@ -981,7 +1007,7 @@ export class WorkspaceAgentActivityService
         }
       },
       activateSession: async (input) => {
-        const activation = await this.activateSession(input);
+        const activation = await this.executeSessionActivationEffect(input);
         this.analytics.trackEngineActivation(input, activation);
         return activation;
       },

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -482,10 +482,16 @@ export class WorkspaceAgentActivityService
   async createSession(
     input: Parameters<AgentActivityAdapter["createSession"]>[0]
   ): Promise<AgentActivitySession> {
+    const session = await this.executeCreateSessionEffect(input);
+    this.upsertAuthoritativeSession(session, "create_session_result");
+    return session;
+  }
+
+  private async executeCreateSessionEffect(
+    input: Parameters<AgentActivityAdapter["createSession"]>[0]
+  ): Promise<AgentActivitySession> {
     try {
-      const session = await this.mutationOperations.createSession(input);
-      this.upsertAuthoritativeSession(session, "create_session_result");
-      return session;
+      return await this.mutationOperations.createSession(input);
     } catch (error) {
       this.analytics.trackSessionCreateFailure({
         agentTargetId: input.agentTargetId
@@ -585,7 +591,7 @@ export class WorkspaceAgentActivityService
             input.initialTuttiModeActivation != null
         }
       });
-      session = await this.mutationOperations.createSession({
+      session = await this.executeCreateSessionEffect({
         clientSubmitId: input.clientSubmitId,
         workspaceId,
         agentSessionId: requestedAgentSessionId,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentSessionEngineHost.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentSessionEngineHost.ts
@@ -3,6 +3,7 @@ import {
   createAgentSessionEngine,
   type AgentActivityAdapter,
   type AgentActivitySendInput,
+  type AgentSessionActivateEffectResult,
   type AgentSessionEngine,
   type EngineExternalCommand,
   type EngineIntent,
@@ -35,7 +36,9 @@ export interface WorkspaceAgentSessionEngineActivityObserver {
 
 interface CreateWorkspaceAgentSessionEngineHostInput {
   activityEventObserver?: WorkspaceAgentSessionEngineActivityObserver;
-  activateSession: AgentActivityRuntime["activateSession"];
+  activateSession(
+    input: Parameters<AgentActivityRuntime["activateSession"]>[0]
+  ): Promise<AgentSessionActivateEffectResult>;
   cancelTurn(input: {
     agentSessionId: string;
     signal?: AbortSignal;

--- a/apps/mobile/src/services/workspaceActivityEngineCommandPort.test.ts
+++ b/apps/mobile/src/services/workspaceActivityEngineCommandPort.test.ts
@@ -1,8 +1,8 @@
 import type {
   AgentActivitySendInput,
   AgentActivitySession,
+  AgentActivitySessionDetailSnapshot,
   AgentSessionActivateEffectInput,
-  AgentSessionEngine,
   TurnEditRetryCommand,
   TurnRecoverEditRetryCommand
 } from "@tutti-os/agent-activity-core";
@@ -16,7 +16,6 @@ describe("createWorkspaceActivityEffectPort", () => {
   test("explicitly rejects edit-retry commands that Mobile does not support", async () => {
     const context = {
       client: {} as TuttidClient,
-      engine: {} as AgentSessionEngine,
       loadComposerOptions() {},
       mapSession(): AgentActivitySession {
         throw new Error("unexpected Session mapping");
@@ -93,7 +92,6 @@ describe("createWorkspaceActivityEffectPort", () => {
     await expect(
       createWorkspaceActivityEffectPort(() => ({
         client,
-        engine: {} as AgentSessionEngine,
         loadComposerOptions() {},
         mapSession(): AgentActivitySession {
           throw new Error("unexpected Session mapping");
@@ -162,7 +160,6 @@ describe("createWorkspaceActivityEffectPort", () => {
     await expect(
       createWorkspaceActivityEffectPort(() => ({
         client,
-        engine: {} as AgentSessionEngine,
         loadComposerOptions() {},
         mapSession(): AgentActivitySession {
           throw new Error("unexpected Session mapping");
@@ -208,7 +205,6 @@ describe("createWorkspaceActivityEffectPort", () => {
     await expect(
       createWorkspaceActivityEffectPort(() => ({
         client: { getWorkspaceAgentSession } as unknown as TuttidClient,
-        engine: {} as AgentSessionEngine,
         loadComposerOptions() {},
         mapSession(): AgentActivitySession {
           throw new Error("unexpected Session mapping");
@@ -237,8 +233,43 @@ describe("createWorkspaceActivityEffectPort", () => {
     );
   });
 
+  test("returns existing-session detail without writing host state", async () => {
+    const rawDetail = { session: { id: "session-1" } };
+    const activitySession = {
+      agentSessionId: "session-1",
+      workspaceId: "workspace-1"
+    } as AgentActivitySession;
+    const mappedDetail: AgentActivitySessionDetailSnapshot = {
+      childSessions: [],
+      lifecycleCapabilitiesProjected: true,
+      projection: "authoritative",
+      session: activitySession,
+      turns: []
+    };
+    const getWorkspaceAgentSession = jest.fn().mockResolvedValue(rawDetail);
+    const mapSessionDetail = jest.fn().mockReturnValue(mappedDetail);
+
+    const result = await createWorkspaceActivityEffectPort(() => ({
+      client: { getWorkspaceAgentSession } as unknown as TuttidClient,
+      mapSession: () => activitySession,
+      mapSessionDetail,
+      async reconcileSession() {},
+      async reconcileWorkspace() {}
+    })).activateSession({
+      agentSessionId: "session-1",
+      mode: "existing",
+      workspaceId: "workspace-1"
+    });
+
+    expect(mapSessionDetail).toHaveBeenCalledWith("session-1", rawDetail);
+    expect(result).toEqual({
+      activation: { mode: "existing", status: "already_attached" },
+      detail: mappedDetail,
+      session: activitySession
+    });
+  });
+
   test("returns authoritative settings data without host-owned projection", async () => {
-    const dispatch = jest.fn();
     const updateWorkspaceAgentSessionSettings = jest.fn().mockResolvedValue({});
     const activitySession = {
       agentSessionId: "session-1",
@@ -246,24 +277,10 @@ describe("createWorkspaceActivityEffectPort", () => {
       workspaceId: "workspace-1"
     } as AgentActivitySession;
     const controller = new AbortController();
-    const engine = {
-      dispatch,
-      getSnapshot: () => ({
-        composerOptions: {
-          optionsByTargetKey: {
-            "target-1": {
-              behavior: { refreshModelOptionsAfterSettings: true }
-            }
-          }
-        }
-      })
-    } as unknown as AgentSessionEngine;
-
     const result = await createWorkspaceActivityEffectPort(() => ({
       client: {
         updateWorkspaceAgentSessionSettings
       } as unknown as TuttidClient,
-      engine,
       mapSession: () => activitySession,
       mapSessionDetail() {
         throw new Error("unexpected detail mapping");
@@ -287,7 +304,6 @@ describe("createWorkspaceActivityEffectPort", () => {
       { model: "model-1" },
       { signal: controller.signal }
     );
-    expect(dispatch).not.toHaveBeenCalled();
     expect(result).toEqual({
       agentSessionId: "session-1",
       session: activitySession,
@@ -310,7 +326,6 @@ describe("createWorkspaceActivityEffectPort", () => {
         cancelWorkspaceAgentTurn,
         submitWorkspaceAgentInteractive
       } as unknown as TuttidClient,
-      engine: {} as AgentSessionEngine,
       loadComposerOptions() {},
       mapSession: () => activitySession,
       mapSessionDetail() {
@@ -378,7 +393,6 @@ describe("createWorkspaceActivityEffectPort", () => {
         updateWorkspaceAgentSessionPin,
         updateWorkspaceAgentSessionTitle
       } as unknown as TuttidClient,
-      engine: {} as AgentSessionEngine,
       loadComposerOptions() {},
       mapSession: () => activitySession,
       mapSessionDetail() {

--- a/apps/mobile/src/services/workspaceActivityEngineCommandPort.ts
+++ b/apps/mobile/src/services/workspaceActivityEngineCommandPort.ts
@@ -1,5 +1,6 @@
 import type {
   AgentSessionActivateEffectInput,
+  AgentSessionActivateEffectResult,
   AgentSessionEffectPort,
   AgentActivityCancelTurnInput,
   AgentActivityDeleteSessionsResult,
@@ -8,7 +9,6 @@ import type {
   AgentActivitySessionDetailSnapshot,
   AgentActivitySessionSettings,
   AgentActivitySubmitInteractiveInput,
-  AgentSessionEngine,
   EngineEffectOptions,
   EngineExtensionCommand,
   SessionReconcileCommand
@@ -24,7 +24,6 @@ import { toTuttidPromptContent } from "./workspaceActivityCommandSupport";
 
 interface WorkspaceActivityEngineCommandContext {
   client: TuttidClient;
-  engine: AgentSessionEngine;
   mapSession(
     session: Parameters<typeof agentActivitySessionFromTuttidSession>[1]
   ): AgentActivitySession;
@@ -121,7 +120,7 @@ async function activateSession(
   context: WorkspaceActivityEngineCommandContext,
   input: AgentSessionActivateEffectInput,
   signal?: AbortSignal
-): Promise<unknown> {
+): Promise<AgentSessionActivateEffectResult> {
   if (input.mode === "existing") {
     if (signal?.aborted) throw signal.reason;
     const detail = await context.client.getWorkspaceAgentSession(
@@ -131,13 +130,9 @@ async function activateSession(
       ...requestOptionsArgs(signal)
     );
     const mapped = context.mapSessionDetail(input.agentSessionId, detail);
-    context.engine.dispatch({
-      ...mapped,
-      type: "session/detailSnapshotReceived",
-      workspaceId: input.workspaceId
-    });
     return {
       activation: { mode: "existing", status: "already_attached" },
+      detail: mapped,
       session: mapped.session
     };
   }
@@ -188,10 +183,6 @@ async function activateSession(
     { signal }
   );
   const activitySession = context.mapSession(session);
-  context.engine.dispatch({
-    session: activitySession,
-    type: "session/upserted"
-  });
   return {
     activation: { mode: "new", status: "attached" },
     session: activitySession

--- a/apps/mobile/src/services/workspaceActivityService.ts
+++ b/apps/mobile/src/services/workspaceActivityService.ts
@@ -95,7 +95,6 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
     this.projectActivity = createAgentActivitySnapshotProjector(workspace.id);
     const commandContext = () => ({
       client: this.client,
-      engine: this.engine,
       mapSession: this.mapping.mapSession,
       mapSessionDetail: this.mapping.mapSessionDetail,
       reconcileSession: (

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -248,10 +248,15 @@ creation, resume, and initial Turn lifecycle remain Agent Host semantics behind
 the host effect port. The typed effect returns an authoritative Session for a
 new activation and the complete authoritative detail aggregate for an existing
 activation. The Engine validates activation mode plus workspace/Session
-identity and applies that result through its canonical reducers; Desktop and
-Mobile effects must not dispatch Session state before returning. The legacy
-complete-command port may retain its existing projection behavior while
-published consumers migrate to the typed effect contract.
+identity and nested Session/Turn/Interaction entities before applying that
+result through its canonical reducers. Desktop and Mobile effects may retain
+product-local integration and observability, but must not dispatch Session
+state before returning. The effect executor marks only typed activation results
+with the versioned `activation-v1` result contract; commands whose result shape
+is not authoritative remain opaque. An untagged or opaque result from the
+legacy complete-command port remains an acknowledgement and is never
+reinterpreted as an authoritative projection, so published consumers can
+migrate without payload-shape heuristics.
 Desktop AgentGUI and Mobile call `stopSession` instead of constructing
 `session/stopRequested` protocol fields. The same method stops an active Turn
 or records a bounded request that cancels the first Turn produced by an

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -245,7 +245,13 @@ placement, initial settings/content, and durable request identities; the Engine
 admits that domain request under one workspace scope and confirmation policy.
 Only an admitted activation may clear the new-Session draft. Actual Session
 creation, resume, and initial Turn lifecycle remain Agent Host semantics behind
-the host effect port.
+the host effect port. The typed effect returns an authoritative Session for a
+new activation and the complete authoritative detail aggregate for an existing
+activation. The Engine validates activation mode plus workspace/Session
+identity and applies that result through its canonical reducers; Desktop and
+Mobile effects must not dispatch Session state before returning. The legacy
+complete-command port may retain its existing projection behavior while
+published consumers migrate to the typed effect contract.
 Desktop AgentGUI and Mobile call `stopSession` instead of constructing
 `session/stopRequested` protocol fields. The same method stops an active Turn
 or records a bounded request that cancels the first Turn produced by an

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -691,9 +691,12 @@ disable submission, but must not change editor editability.
   slow runtime startup cannot expire while the command may still succeed.
   The typed activation effect returns either the created authoritative Session
   or the resumed Session's authoritative detail aggregate. The Engine validates
-  the result scope and mode, then projects Session, child Session, Turn, and
-  Interaction state in its own drain. Desktop and Mobile effects perform only
-  transport and DTO mapping and must not pre-dispatch those projections.
+  the versioned `activation-v1` result contract, result scope, mode, and every
+  nested Session/Turn/Interaction entity, then projects the aggregate in its
+  own drain. Untagged or opaque legacy command-port results remain
+  acknowledgements and do not enter canonical state. Desktop and Mobile effects
+  retain transport, DTO mapping, and product-local integration/observability
+  concerns, but must not pre-dispatch those projections.
   Canonical monotonicity guards prevent a late activation response from
   regressing newer realtime state.
   Surfaces clear a new-Session draft only after activation admission succeeds.

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -689,6 +689,13 @@ disable submission, but must not change editor editability.
   accepted result, and one 120-second confirmation window. The confirmation
   deadline is later than the 90-second new-Session command timeout so a valid
   slow runtime startup cannot expire while the command may still succeed.
+  The typed activation effect returns either the created authoritative Session
+  or the resumed Session's authoritative detail aggregate. The Engine validates
+  the result scope and mode, then projects Session, child Session, Turn, and
+  Interaction state in its own drain. Desktop and Mobile effects perform only
+  transport and DTO mapping and must not pre-dispatch those projections.
+  Canonical monotonicity guards prevent a late activation response from
+  regressing newer realtime state.
   Surfaces clear a new-Session draft only after activation admission succeeds.
   Existing-Session Prompt submission enters through `engine.submitPrompt`.
   The surface keeps the stable `clientSubmitId` used by its draft-recovery and

--- a/packages/agent/activity-core/src/engine/createAgentSessionEngine.test.ts
+++ b/packages/agent/activity-core/src/engine/createAgentSessionEngine.test.ts
@@ -817,7 +817,7 @@ test("stop aborts activation immediately and cancels the first turn when it arri
 });
 
 test("activation command result settles a new Session inside the Engine", async () => {
-  const { commandPort, engine } = createHarness({
+  const { engine } = createHarness({
     workspaceId: "workspace-1"
   });
   assert.equal(
@@ -834,9 +834,17 @@ test("activation command result settles a new Session inside the Engine", async 
     createdAtUnixMs: 1,
     updatedAtUnixMs: 1
   });
-  commandPort.succeed("activate:activation-created", {
-    activation: { mode: "new", status: "attached" },
-    session: created
+  engine.dispatch({
+    commandId: "activate:activation-created",
+    commandType: "session/activate",
+    correlationId: "activation-created",
+    outcome: "succeeded",
+    resultContract: "activation-v1",
+    type: "engine/commandResult",
+    value: {
+      activation: { mode: "new", status: "attached" },
+      session: created
+    }
   });
   await flushMicrotasks();
 
@@ -854,7 +862,7 @@ test("activation command result settles a new Session inside the Engine", async 
 });
 
 test("activation command result hydrates existing Session detail inside the Engine", async () => {
-  const { commandPort, engine } = createHarness({
+  const { engine } = createHarness({
     workspaceId: "workspace-1"
   });
   assert.equal(
@@ -869,16 +877,24 @@ test("activation command result hydrates existing Session detail inside the Engi
     updatedAtUnixMs: 2
   });
   const turn = activityTurn("session-existing", "turn-existing");
-  commandPort.succeed("activate:activation-existing", {
-    activation: { mode: "existing", status: "already_attached" },
-    detail: {
-      childSessions: [],
-      lifecycleCapabilitiesProjected: true,
-      projection: "authoritative",
-      session: existing,
-      turns: [turn]
-    },
-    session: existing
+  engine.dispatch({
+    commandId: "activate:activation-existing",
+    commandType: "session/activate",
+    correlationId: "activation-existing",
+    outcome: "succeeded",
+    resultContract: "activation-v1",
+    type: "engine/commandResult",
+    value: {
+      activation: { mode: "existing", status: "already_attached" },
+      detail: {
+        childSessions: [],
+        lifecycleCapabilitiesProjected: true,
+        projection: "authoritative",
+        session: existing,
+        turns: [turn]
+      },
+      session: existing
+    }
   });
   await flushMicrotasks();
 
@@ -895,7 +911,7 @@ test("activation command result hydrates existing Session detail inside the Engi
 });
 
 test("late activation projection cannot regress a newer realtime Session", async () => {
-  const { commandPort, engine } = createHarness({
+  const { engine } = createHarness({
     workspaceId: "workspace-1"
   });
   assert.equal(
@@ -917,16 +933,24 @@ test("late activation projection cannot regress a newer realtime Session", async
     title: "Stale activation title",
     updatedAtUnixMs: 10
   });
-  commandPort.succeed("activate:activation-existing", {
-    activation: { mode: "existing", status: "already_attached" },
-    detail: {
-      childSessions: [],
-      lifecycleCapabilitiesProjected: true,
-      projection: "authoritative",
-      session: stale,
-      turns: []
-    },
-    session: stale
+  engine.dispatch({
+    commandId: "activate:activation-existing",
+    commandType: "session/activate",
+    correlationId: "activation-existing",
+    outcome: "succeeded",
+    resultContract: "activation-v1",
+    type: "engine/commandResult",
+    value: {
+      activation: { mode: "existing", status: "already_attached" },
+      detail: {
+        childSessions: [],
+        lifecycleCapabilitiesProjected: true,
+        projection: "authoritative",
+        session: stale,
+        turns: []
+      },
+      session: stale
+    }
   });
   await flushMicrotasks();
 

--- a/packages/agent/activity-core/src/engine/createAgentSessionEngine.test.ts
+++ b/packages/agent/activity-core/src/engine/createAgentSessionEngine.test.ts
@@ -816,6 +816,127 @@ test("stop aborts activation immediately and cancels the first turn when it arri
   );
 });
 
+test("activation command result settles a new Session inside the Engine", async () => {
+  const { commandPort, engine } = createHarness({
+    workspaceId: "workspace-1"
+  });
+  assert.equal(
+    engine.activateSession({
+      agentSessionId: "session-created",
+      agentTargetId: "target-1",
+      clientSubmitId: "submit-created",
+      mode: "new",
+      requestId: "activation-created"
+    }),
+    true
+  );
+  const created = activitySession("session-created", {
+    createdAtUnixMs: 1,
+    updatedAtUnixMs: 1
+  });
+  commandPort.succeed("activate:activation-created", {
+    activation: { mode: "new", status: "attached" },
+    session: created
+  });
+  await flushMicrotasks();
+
+  assert.equal(
+    engine.getSnapshot().sessionLifecycle.sessionsById["session-created"]
+      ?.agentSessionId,
+    "session-created"
+  );
+  assert.equal(
+    engine.getSnapshot().pendingIntents.activationsByRequestId[
+      "activation-created"
+    ]?.status,
+    "confirmed"
+  );
+});
+
+test("activation command result hydrates existing Session detail inside the Engine", async () => {
+  const { commandPort, engine } = createHarness({
+    workspaceId: "workspace-1"
+  });
+  assert.equal(
+    engine.activateSession({
+      agentSessionId: "session-existing",
+      mode: "existing",
+      requestId: "activation-existing"
+    }),
+    true
+  );
+  const existing = activitySession("session-existing", {
+    updatedAtUnixMs: 2
+  });
+  const turn = activityTurn("session-existing", "turn-existing");
+  commandPort.succeed("activate:activation-existing", {
+    activation: { mode: "existing", status: "already_attached" },
+    detail: {
+      childSessions: [],
+      lifecycleCapabilitiesProjected: true,
+      projection: "authoritative",
+      session: existing,
+      turns: [turn]
+    },
+    session: existing
+  });
+  await flushMicrotasks();
+
+  const snapshot = engine.getSnapshot();
+  assert.equal(
+    snapshot.pendingIntents.activationsByRequestId["activation-existing"]
+      ?.status,
+    "confirmed"
+  );
+  assert.equal(
+    Object.values(snapshot.sessionLifecycle.turnsById)[0]?.turnId,
+    "turn-existing"
+  );
+});
+
+test("late activation projection cannot regress a newer realtime Session", async () => {
+  const { commandPort, engine } = createHarness({
+    workspaceId: "workspace-1"
+  });
+  assert.equal(
+    engine.activateSession({
+      agentSessionId: "session-existing",
+      mode: "existing",
+      requestId: "activation-existing"
+    }),
+    true
+  );
+  engine.dispatch({
+    session: activitySession("session-existing", {
+      title: "Realtime title",
+      updatedAtUnixMs: 20
+    }),
+    type: "session/upserted"
+  });
+  const stale = activitySession("session-existing", {
+    title: "Stale activation title",
+    updatedAtUnixMs: 10
+  });
+  commandPort.succeed("activate:activation-existing", {
+    activation: { mode: "existing", status: "already_attached" },
+    detail: {
+      childSessions: [],
+      lifecycleCapabilitiesProjected: true,
+      projection: "authoritative",
+      session: stale,
+      turns: []
+    },
+    session: stale
+  });
+  await flushMicrotasks();
+
+  assert.equal(
+    engine.getSnapshot().sessionLifecycle.sessionsById["session-existing"]
+      ?.title,
+    "Realtime title"
+  );
+});
+
 test("interleaving: expiry firing between probe start and probe result", async () => {
   const { commandPort, engine, timer } = createHarness();
   engine.dispatch({ probeId: "p-4", type: "engine/probeRequested" });

--- a/packages/agent/activity-core/src/engine/effectExecutor.test.ts
+++ b/packages/agent/activity-core/src/engine/effectExecutor.test.ts
@@ -17,7 +17,10 @@ test("projects shared commands onto typed lifecycle effects without host switche
   const effects: AgentSessionEffectPort = {
     async activateSession(input, options) {
       calls.push({ input, kind: "activate", signal: options?.signal });
-      return { accepted: true };
+      return {
+        activation: { mode: "new", status: "attached" },
+        session
+      };
     },
     async cancelTurn(input, options) {
       calls.push({ input, kind: "cancel", signal: options?.signal });

--- a/packages/agent/activity-core/src/engine/effectExecutor.test.ts
+++ b/packages/agent/activity-core/src/engine/effectExecutor.test.ts
@@ -61,7 +61,7 @@ test("projects shared commands onto typed lifecycle effects without host switche
     }
   };
 
-  await executeAndWait(port, {
+  const activationResult = await executeAndWait(port, {
     agentSessionId: "session-1",
     agentTargetId: "target-1",
     capabilityRefs: [{ capability: "tutti", source: "slash_command" }],
@@ -92,7 +92,8 @@ test("projects shared commands onto typed lifecycle effects without host switche
     visible: false,
     workspaceId: "workspace-1"
   });
-  await executeAndWait(port, {
+  assert.equal(activationResult.resultContract, "activation-v1");
+  const sendResult = await executeAndWait(port, {
     agentSessionId: "session-1",
     capabilityRefs: [{ capability: "tutti", source: "slash_command" }],
     clientSubmitId: "submit-send",
@@ -104,6 +105,7 @@ test("projects shared commands onto typed lifecycle effects without host switche
     type: "queue/sendPrompt",
     workspaceId: "workspace-1"
   });
+  assert.equal(sendResult.resultContract, "opaque");
   await executeAndWait(port, {
     agentSessionId: "session-1",
     commandId: "settings-1",
@@ -239,7 +241,7 @@ test("keeps the complete command union available to legacy hosts", async () => {
     type: "turn/cancel",
     workspaceId: "workspace-legacy"
   };
-  await executeAndWait(
+  const result = await executeAndWait(
     {
       async execute(candidate) {
         executed.push(candidate);
@@ -253,6 +255,7 @@ test("keeps the complete command union available to legacy hosts", async () => {
 
   assert.deepEqual(executed, [command]);
   assert.deepEqual(observed, ["cancel-legacy"]);
+  assert.equal(result.resultContract, "opaque");
 });
 
 test("rejects prompt settings preconditions that bypass the Engine state machine", async () => {

--- a/packages/agent/activity-core/src/engine/effectExecutor.ts
+++ b/packages/agent/activity-core/src/engine/effectExecutor.ts
@@ -3,6 +3,7 @@ import type { AgentActivitySendInput } from "../types.ts";
 import type {
   AgentSessionActivateEffectInput,
   EngineCommandPort,
+  EngineCommandResultContract,
   EngineCommandResultIntent,
   EngineExternalCommand,
   EngineScheduledTask,
@@ -79,6 +80,12 @@ export function createEngineEffectExecutor({
       let timeoutTask: EngineScheduledTask | null = null;
       const abortController = new AbortController();
       abortControllersByCommandId.set(command.commandId, abortController);
+      const resultContract = commandResultContract(commandPort, command);
+      const execution = executeCommand(
+        commandPort,
+        command,
+        abortController.signal
+      );
 
       const finishTimeoutTask = (): void => {
         if (
@@ -107,17 +114,13 @@ export function createEngineEffectExecutor({
             commandType: command.type,
             ...commandCorrelationFields(command),
             outcome: "timedOut",
+            resultContract,
             type: "engine/commandResult"
           });
         });
         timeoutTasks.add(timeoutTask);
       }
 
-      const execution = executeCommand(
-        commandPort,
-        command,
-        abortController.signal
-      );
       execution.then(
         (value) => {
           if (settled) {
@@ -134,6 +137,7 @@ export function createEngineEffectExecutor({
             commandType: command.type,
             ...commandCorrelationFields(command),
             outcome: "succeeded",
+            resultContract,
             type: "engine/commandResult",
             value
           });
@@ -154,6 +158,7 @@ export function createEngineEffectExecutor({
             ...commandCorrelationFields(command),
             ...engineCommandErrorFields(error),
             outcome: "failed",
+            resultContract,
             type: "engine/commandResult"
           });
         }
@@ -257,6 +262,15 @@ function executeCommand(
     default:
       return commandPort.execute(command, { signal });
   }
+}
+
+function commandResultContract(
+  commandPort: EngineCommandPort | EngineTypedCommandPort,
+  command: EngineExternalCommand
+): EngineCommandResultContract {
+  return commandPort.kind === "typed" && command.type === "session/activate"
+    ? "activation-v1"
+    : "opaque";
 }
 
 function promptInput(

--- a/packages/agent/activity-core/src/engine/pendingIntents.activationResult.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.activationResult.ts
@@ -1,0 +1,278 @@
+import type { AgentActivitySessionInput } from "../sessionNormalization.ts";
+import type { AgentActivityTurn } from "../types.ts";
+import type { AgentActivityEditRetryAvailability } from "./editRetry.types.ts";
+import type {
+  PendingActivationIntentRecord,
+  PendingActivationStatus
+} from "./pendingIntents.types.ts";
+import type { EngineIntent } from "./types.ts";
+
+export type ActivationCommandSettlement =
+  | {
+      errorCode: string | null;
+      errorMessage: string | null;
+      kind: "acknowledged";
+      projectionIntent: EngineIntent | null;
+    }
+  | {
+      errorCode: string | null;
+      errorMessage: string | null;
+      kind: "failed";
+      projectionIntent: null;
+    }
+  | {
+      errorCode: "invalid_command_result";
+      errorMessage: null;
+      kind: "invalid";
+      projectionIntent: null;
+    };
+
+/**
+ * Accepts legacy activation acknowledgements without a projection, while
+ * validating and extracting the richer result required by typed hosts.
+ */
+export function validateActivationCommandResult(
+  value: unknown,
+  record: PendingActivationIntentRecord
+): ActivationCommandSettlement {
+  if (!value || typeof value !== "object") return invalid();
+  const result = value as {
+    activation?: { mode?: unknown; status?: unknown };
+    detail?: unknown;
+    error?: { code?: unknown; message?: unknown } | null;
+    session?: unknown;
+  };
+  const status = result.activation?.status;
+  if (typeof status !== "string") return invalid();
+  const mode = result.activation?.mode;
+  if (mode !== undefined && mode !== record.mode) return invalid();
+  if (status === "failed") {
+    return {
+      errorCode: normalizedString(result.error?.code),
+      errorMessage: normalizedString(result.error?.message),
+      kind: "failed",
+      projectionIntent: null
+    };
+  }
+
+  const projectionIntent =
+    record.mode === "new"
+      ? newSessionProjection(result, record)
+      : existingSessionProjection(result, record);
+  if (projectionIntent === false) return invalid();
+  return {
+    errorCode: null,
+    errorMessage: null,
+    kind: "acknowledged",
+    projectionIntent
+  };
+}
+
+function newSessionProjection(
+  result: {
+    activation?: { mode?: unknown; status?: unknown };
+    session?: unknown;
+  },
+  record: PendingActivationIntentRecord
+): EngineIntent | null | false {
+  if (
+    result.activation?.mode === undefined &&
+    result.activation?.status !== "attached"
+  ) {
+    return null;
+  }
+  if (result.activation?.status !== "attached") return false;
+  if (result.session === undefined) {
+    return result.activation?.mode === undefined ? null : false;
+  }
+  if (!sessionMatches(result.session, record)) return false;
+  return {
+    session: result.session,
+    type: "session/upserted"
+  };
+}
+
+function existingSessionProjection(
+  result: {
+    activation?: { mode?: unknown; status?: unknown };
+    detail?: unknown;
+    session?: unknown;
+  },
+  record: PendingActivationIntentRecord
+): EngineIntent | null | false {
+  if (
+    result.activation?.mode === undefined &&
+    result.activation?.status !== "already_attached"
+  ) {
+    return null;
+  }
+  if (result.activation?.status !== "already_attached") return false;
+  if (result.detail === undefined) {
+    return result.activation?.mode === undefined ? null : false;
+  }
+  if (
+    result.activation?.mode !== undefined &&
+    !sessionMatches(result.session, record)
+  ) {
+    return false;
+  }
+  if (!result.detail || typeof result.detail !== "object") return false;
+  const detail = result.detail as {
+    childSessions?: unknown;
+    editRetry?: unknown;
+    projection?: unknown;
+    session?: unknown;
+    turns?: unknown;
+  };
+  const entities =
+    Array.isArray(detail.childSessions) && Array.isArray(detail.turns)
+      ? scopedDetailEntities(detail.childSessions, detail.turns, record)
+      : null;
+  if (
+    detail.projection !== "authoritative" ||
+    !sessionMatches(detail.session, record) ||
+    entities === null ||
+    (detail.editRetry !== undefined &&
+      !isEditRetryAvailability(detail.editRetry))
+  ) {
+    return false;
+  }
+  return {
+    childSessions: entities.childSessions,
+    ...(detail.editRetry === undefined ? {} : { editRetry: detail.editRetry }),
+    session: detail.session,
+    turns: entities.turns,
+    type: "session/detailSnapshotReceived",
+    workspaceId: record.workspaceId
+  };
+}
+
+function sessionMatches(
+  value: unknown,
+  record: Pick<PendingActivationIntentRecord, "agentSessionId" | "workspaceId">
+): value is AgentActivitySessionInput {
+  if (!value || typeof value !== "object") return false;
+  const session = value as {
+    activeTurnId?: unknown;
+    agentSessionId?: unknown;
+    cwd?: unknown;
+    latestTurnInteractions?: unknown;
+    pendingInteractions?: unknown;
+    provider?: unknown;
+    title?: unknown;
+    workspaceId?: unknown;
+  };
+  return (
+    typeof session.agentSessionId === "string" &&
+    session.agentSessionId.trim() === record.agentSessionId &&
+    typeof session.workspaceId === "string" &&
+    session.workspaceId.trim() === record.workspaceId &&
+    (session.activeTurnId === null ||
+      typeof session.activeTurnId === "string") &&
+    typeof session.cwd === "string" &&
+    isString(session.provider) &&
+    typeof session.title === "string" &&
+    Array.isArray(session.latestTurnInteractions) &&
+    Array.isArray(session.pendingInteractions)
+  );
+}
+
+function scopedDetailEntities(
+  childSessions: readonly unknown[],
+  turns: readonly unknown[],
+  record: Pick<PendingActivationIntentRecord, "agentSessionId" | "workspaceId">
+): {
+  childSessions: readonly AgentActivitySessionInput[];
+  turns: readonly AgentActivityTurn[];
+} | null {
+  const sessionIds = new Set([record.agentSessionId]);
+  for (const childSession of childSessions) {
+    if (!sessionInWorkspace(childSession, record.workspaceId)) return null;
+    sessionIds.add(childSession.agentSessionId.trim());
+  }
+  if (
+    !turns.every((turn): turn is AgentActivityTurn =>
+      Boolean(
+        turn &&
+        typeof turn === "object" &&
+        typeof (turn as Partial<AgentActivityTurn>).agentSessionId ===
+          "string" &&
+        sessionIds.has(
+          (turn as Partial<AgentActivityTurn>).agentSessionId!.trim()
+        ) &&
+        typeof (turn as Partial<AgentActivityTurn>).turnId === "string" &&
+        Boolean((turn as Partial<AgentActivityTurn>).turnId!.trim())
+      )
+    )
+  ) {
+    return null;
+  }
+  return {
+    childSessions: childSessions as readonly AgentActivitySessionInput[],
+    turns
+  };
+}
+
+function isEditRetryAvailability(
+  value: unknown
+): value is AgentActivityEditRetryAvailability {
+  if (!value || typeof value !== "object") return false;
+  const availability = value as Partial<AgentActivityEditRetryAvailability>;
+  return Boolean(
+    typeof availability.supported === "boolean" &&
+    typeof availability.eligible === "boolean" &&
+    typeof availability.historyRevision === "number" &&
+    Number.isFinite(availability.historyRevision) &&
+    typeof availability.recoveryState === "string" &&
+    Array.isArray(availability.availableActions) &&
+    availability.availableActions.every(
+      (action) => action === "reconcile" || action === "retry_replacement"
+    )
+  );
+}
+
+function sessionInWorkspace(
+  value: unknown,
+  workspaceId: string
+): value is AgentActivitySessionInput {
+  if (!value || typeof value !== "object") return false;
+  const session = value as Partial<AgentActivitySessionInput>;
+  return (
+    typeof session.agentSessionId === "string" &&
+    Boolean(session.agentSessionId.trim()) &&
+    typeof session.workspaceId === "string" &&
+    session.workspaceId.trim() === workspaceId &&
+    (session.activeTurnId === null ||
+      typeof session.activeTurnId === "string") &&
+    typeof session.cwd === "string" &&
+    isString(session.provider) &&
+    typeof session.title === "string" &&
+    Array.isArray(session.latestTurnInteractions) &&
+    Array.isArray(session.pendingInteractions)
+  );
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+function normalizedString(value: unknown): string | null {
+  return typeof value === "string" ? value.trim() || null : null;
+}
+
+function invalid(): ActivationCommandSettlement {
+  return {
+    errorCode: "invalid_command_result",
+    errorMessage: null,
+    kind: "invalid",
+    projectionIntent: null
+  };
+}
+
+export function activationCanAcceptCommandResult(
+  status: PendingActivationStatus
+): boolean {
+  return (
+    status === "requested" || status === "uncertain" || status === "confirmed"
+  );
+}

--- a/packages/agent/activity-core/src/engine/pendingIntents.activationResult.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.activationResult.ts
@@ -5,7 +5,11 @@ import type {
   PendingActivationIntentRecord,
   PendingActivationStatus
 } from "./pendingIntents.types.ts";
-import type { EngineIntent } from "./types.ts";
+import {
+  decodeSessionProjection,
+  decodeTurnProjection
+} from "./sessionProjection.validation.ts";
+import type { EngineCommandResultContract, EngineIntent } from "./types.ts";
 
 export type ActivationCommandSettlement =
   | {
@@ -33,7 +37,8 @@ export type ActivationCommandSettlement =
  */
 export function validateActivationCommandResult(
   value: unknown,
-  record: PendingActivationIntentRecord
+  record: PendingActivationIntentRecord,
+  resultContract: EngineCommandResultContract | undefined
 ): ActivationCommandSettlement {
   if (!value || typeof value !== "object") return invalid();
   const result = value as {
@@ -44,8 +49,10 @@ export function validateActivationCommandResult(
   };
   const status = result.activation?.status;
   if (typeof status !== "string") return invalid();
-  const mode = result.activation?.mode;
-  if (mode !== undefined && mode !== record.mode) return invalid();
+  const authoritativeResult = resultContract === "activation-v1";
+  if (authoritativeResult && result.activation?.mode !== record.mode) {
+    return invalid();
+  }
   if (status === "failed") {
     return {
       errorCode: normalizedString(result.error?.code),
@@ -54,7 +61,14 @@ export function validateActivationCommandResult(
       projectionIntent: null
     };
   }
-
+  if (!authoritativeResult) {
+    return {
+      errorCode: null,
+      errorMessage: null,
+      kind: "acknowledged",
+      projectionIntent: null
+    };
+  }
   const projectionIntent =
     record.mode === "new"
       ? newSessionProjection(result, record)
@@ -75,19 +89,11 @@ function newSessionProjection(
   },
   record: PendingActivationIntentRecord
 ): EngineIntent | null | false {
-  if (
-    result.activation?.mode === undefined &&
-    result.activation?.status !== "attached"
-  ) {
-    return null;
-  }
   if (result.activation?.status !== "attached") return false;
-  if (result.session === undefined) {
-    return result.activation?.mode === undefined ? null : false;
-  }
-  if (!sessionMatches(result.session, record)) return false;
+  const session = decodeSessionProjection(result.session, record);
+  if (!session) return false;
   return {
-    session: result.session,
+    session,
     type: "session/upserted"
   };
 }
@@ -100,37 +106,25 @@ function existingSessionProjection(
   },
   record: PendingActivationIntentRecord
 ): EngineIntent | null | false {
-  if (
-    result.activation?.mode === undefined &&
-    result.activation?.status !== "already_attached"
-  ) {
-    return null;
-  }
   if (result.activation?.status !== "already_attached") return false;
-  if (result.detail === undefined) {
-    return result.activation?.mode === undefined ? null : false;
-  }
-  if (
-    result.activation?.mode !== undefined &&
-    !sessionMatches(result.session, record)
-  ) {
-    return false;
-  }
+  if (!decodeSessionProjection(result.session, record)) return false;
   if (!result.detail || typeof result.detail !== "object") return false;
   const detail = result.detail as {
     childSessions?: unknown;
     editRetry?: unknown;
+    lifecycleCapabilitiesProjected?: unknown;
     projection?: unknown;
     session?: unknown;
     turns?: unknown;
   };
-  const entities =
-    Array.isArray(detail.childSessions) && Array.isArray(detail.turns)
-      ? scopedDetailEntities(detail.childSessions, detail.turns, record)
-      : null;
+  const session = decodeSessionProjection(detail.session, record);
+  const entities = session
+    ? scopedDetailEntities(detail.childSessions, detail.turns, record)
+    : null;
   if (
     detail.projection !== "authoritative" ||
-    !sessionMatches(detail.session, record) ||
+    detail.lifecycleCapabilitiesProjected !== true ||
+    session === null ||
     entities === null ||
     (detail.editRetry !== undefined &&
       !isEditRetryAvailability(detail.editRetry))
@@ -140,76 +134,48 @@ function existingSessionProjection(
   return {
     childSessions: entities.childSessions,
     ...(detail.editRetry === undefined ? {} : { editRetry: detail.editRetry }),
-    session: detail.session,
+    session,
     turns: entities.turns,
     type: "session/detailSnapshotReceived",
     workspaceId: record.workspaceId
   };
 }
 
-function sessionMatches(
-  value: unknown,
-  record: Pick<PendingActivationIntentRecord, "agentSessionId" | "workspaceId">
-): value is AgentActivitySessionInput {
-  if (!value || typeof value !== "object") return false;
-  const session = value as {
-    activeTurnId?: unknown;
-    agentSessionId?: unknown;
-    cwd?: unknown;
-    latestTurnInteractions?: unknown;
-    pendingInteractions?: unknown;
-    provider?: unknown;
-    title?: unknown;
-    workspaceId?: unknown;
-  };
-  return (
-    typeof session.agentSessionId === "string" &&
-    session.agentSessionId.trim() === record.agentSessionId &&
-    typeof session.workspaceId === "string" &&
-    session.workspaceId.trim() === record.workspaceId &&
-    (session.activeTurnId === null ||
-      typeof session.activeTurnId === "string") &&
-    typeof session.cwd === "string" &&
-    isString(session.provider) &&
-    typeof session.title === "string" &&
-    Array.isArray(session.latestTurnInteractions) &&
-    Array.isArray(session.pendingInteractions)
-  );
-}
-
 function scopedDetailEntities(
-  childSessions: readonly unknown[],
-  turns: readonly unknown[],
+  childSessions: unknown,
+  turns: unknown,
   record: Pick<PendingActivationIntentRecord, "agentSessionId" | "workspaceId">
 ): {
   childSessions: readonly AgentActivitySessionInput[];
   turns: readonly AgentActivityTurn[];
 } | null {
+  if (!Array.isArray(childSessions) || !Array.isArray(turns)) return null;
   const sessionIds = new Set([record.agentSessionId]);
+  const decodedChildSessions: AgentActivitySessionInput[] = [];
   for (const childSession of childSessions) {
-    if (!sessionInWorkspace(childSession, record.workspaceId)) return null;
-    sessionIds.add(childSession.agentSessionId.trim());
+    const decoded = decodeSessionProjection(childSession, {
+      workspaceId: record.workspaceId
+    });
+    const childSessionId = decoded?.agentSessionId.trim() ?? "";
+    if (
+      !decoded ||
+      childSessionId === record.agentSessionId ||
+      sessionIds.has(childSessionId)
+    ) {
+      return null;
+    }
+    sessionIds.add(childSessionId);
+    decodedChildSessions.push(decoded);
   }
-  if (
-    !turns.every((turn): turn is AgentActivityTurn =>
-      Boolean(
-        turn &&
-        typeof turn === "object" &&
-        typeof (turn as Partial<AgentActivityTurn>).agentSessionId ===
-          "string" &&
-        sessionIds.has(
-          (turn as Partial<AgentActivityTurn>).agentSessionId!.trim()
-        ) &&
-        typeof (turn as Partial<AgentActivityTurn>).turnId === "string" &&
-        Boolean((turn as Partial<AgentActivityTurn>).turnId!.trim())
-      )
-    )
-  ) {
-    return null;
+  const decodedTurns: AgentActivityTurn[] = [];
+  for (const turn of turns) {
+    const decoded = decodeTurnProjection(turn, sessionIds);
+    if (!decoded) return null;
+    decodedTurns.push(decoded);
   }
   return {
-    childSessions: childSessions as readonly AgentActivitySessionInput[],
-    turns
+    childSessions: decodedChildSessions,
+    turns: decodedTurns
   };
 }
 
@@ -229,31 +195,6 @@ function isEditRetryAvailability(
       (action) => action === "reconcile" || action === "retry_replacement"
     )
   );
-}
-
-function sessionInWorkspace(
-  value: unknown,
-  workspaceId: string
-): value is AgentActivitySessionInput {
-  if (!value || typeof value !== "object") return false;
-  const session = value as Partial<AgentActivitySessionInput>;
-  return (
-    typeof session.agentSessionId === "string" &&
-    Boolean(session.agentSessionId.trim()) &&
-    typeof session.workspaceId === "string" &&
-    session.workspaceId.trim() === workspaceId &&
-    (session.activeTurnId === null ||
-      typeof session.activeTurnId === "string") &&
-    typeof session.cwd === "string" &&
-    isString(session.provider) &&
-    typeof session.title === "string" &&
-    Array.isArray(session.latestTurnInteractions) &&
-    Array.isArray(session.pendingInteractions)
-  );
-}
-
-function isString(value: unknown): value is string {
-  return typeof value === "string";
 }
 
 function normalizedString(value: unknown): string | null {

--- a/packages/agent/activity-core/src/engine/pendingIntents.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.reducer.test.ts
@@ -449,6 +449,178 @@ test("invalid successful activation acknowledgement remains uncertain", () => {
   );
 });
 
+test("typed new-session activation returns its authoritative Session to the Engine", () => {
+  const state = reduce(createInitialPendingIntentsState(), activation()).state;
+  const authoritativeSession = {
+    ...session("session-new"),
+    createdAtUnixMs: 2
+  };
+  const result = reduce(state, {
+    commandId: "activate:activation-1",
+    commandType: "session/activate",
+    correlationId: "activation-1",
+    outcome: "succeeded",
+    type: "engine/commandResult",
+    value: {
+      activation: { mode: "new", status: "attached" },
+      session: authoritativeSession
+    }
+  });
+
+  assert.deepEqual(result.followUpIntents, [
+    { session: authoritativeSession, type: "session/upserted" }
+  ]);
+  assert.equal(
+    result.state.activationsByRequestId["activation-1"]?.status,
+    "requested"
+  );
+});
+
+test("typed existing-session activation returns its detail aggregate to the Engine", () => {
+  const state = reduce(
+    createInitialPendingIntentsState(),
+    existingActivation()
+  ).state;
+  const authoritativeSession = session("session-new");
+  const turn = { ...runningTurn(), agentSessionId: "session-new" };
+  const result = reduce(state, {
+    commandId: "activate:activation-existing",
+    commandType: "session/activate",
+    correlationId: "activation-existing",
+    outcome: "succeeded",
+    type: "engine/commandResult",
+    value: {
+      activation: { mode: "existing", status: "already_attached" },
+      detail: {
+        childSessions: [],
+        lifecycleCapabilitiesProjected: true,
+        projection: "authoritative",
+        session: authoritativeSession,
+        turns: [turn]
+      },
+      session: authoritativeSession
+    }
+  });
+
+  assert.deepEqual(result.followUpIntents, [
+    {
+      childSessions: [],
+      session: authoritativeSession,
+      turns: [turn],
+      type: "session/detailSnapshotReceived",
+      workspaceId: "workspace-1"
+    }
+  ]);
+});
+
+test("typed activation results cannot omit or escape their requested scope", () => {
+  const newState = reduce(
+    createInitialPendingIntentsState(),
+    activation()
+  ).state;
+  const missingSession = reduce(newState, {
+    commandId: "activate:activation-1",
+    commandType: "session/activate",
+    correlationId: "activation-1",
+    outcome: "succeeded",
+    type: "engine/commandResult",
+    value: {
+      activation: { mode: "new", status: "attached" }
+    }
+  });
+  assert.equal(
+    missingSession.state.activationsByRequestId["activation-1"]?.status,
+    "uncertain"
+  );
+  assert.deepEqual(missingSession.followUpIntents, undefined);
+
+  const existingState = reduce(
+    createInitialPendingIntentsState(),
+    existingActivation()
+  ).state;
+  const escapedChild = reduce(existingState, {
+    commandId: "activate:activation-existing",
+    commandType: "session/activate",
+    correlationId: "activation-existing",
+    outcome: "succeeded",
+    type: "engine/commandResult",
+    value: {
+      activation: { mode: "existing", status: "already_attached" },
+      detail: {
+        childSessions: [
+          {
+            ...session("session-child"),
+            workspaceId: "workspace-other"
+          }
+        ],
+        lifecycleCapabilitiesProjected: true,
+        projection: "authoritative",
+        session: session("session-new"),
+        turns: []
+      },
+      session: session("session-new")
+    }
+  });
+  assert.equal(
+    escapedChild.state.activationsByRequestId["activation-existing"]?.status,
+    "uncertain"
+  );
+  assert.deepEqual(escapedChild.followUpIntents, undefined);
+});
+
+test("confirmed activation may hydrate detail but cannot be failed by a late result", () => {
+  let state = reduce(
+    createInitialPendingIntentsState(),
+    existingActivation()
+  ).state;
+  state = reduce(state, {
+    session: session("session-new"),
+    type: "session/upserted"
+  }).state;
+  assert.equal(
+    state.activationsByRequestId["activation-existing"]?.status,
+    "confirmed"
+  );
+
+  const failed = reduce(state, {
+    commandId: "activate:activation-existing",
+    commandType: "session/activate",
+    correlationId: "activation-existing",
+    outcome: "succeeded",
+    type: "engine/commandResult",
+    value: {
+      activation: { mode: "existing", status: "failed" },
+      error: { code: "late_failure", message: "late failure" }
+    }
+  });
+  assert.equal(failed.state, state);
+  assert.deepEqual(failed.followUpIntents, undefined);
+
+  const hydrated = reduce(state, {
+    commandId: "activate:activation-existing",
+    commandType: "session/activate",
+    correlationId: "activation-existing",
+    outcome: "succeeded",
+    type: "engine/commandResult",
+    value: {
+      activation: { mode: "existing", status: "already_attached" },
+      detail: {
+        childSessions: [],
+        lifecycleCapabilitiesProjected: true,
+        projection: "authoritative",
+        session: session("session-new"),
+        turns: [{ ...runningTurn(), agentSessionId: "session-new" }]
+      },
+      session: session("session-new")
+    }
+  });
+  assert.equal(hydrated.state, state);
+  assert.equal(
+    hydrated.followUpIntents?.[0]?.type,
+    "session/detailSnapshotReceived"
+  );
+});
+
 test("activation confirmation requires an exact workspace-scoped fresh snapshot", () => {
   let state = reduce(createInitialPendingIntentsState(), activation()).state;
   state = reduce(state, {
@@ -703,6 +875,19 @@ function activation() {
     settings: { model: "model-1" },
     title: "New session",
     workspaceId: "workspace-1"
+  };
+}
+
+function existingActivation() {
+  const {
+    clientSubmitId: _clientSubmitId,
+    optimisticTitle: _optimisticTitle,
+    ...input
+  } = activation();
+  return {
+    ...input,
+    mode: "existing" as const,
+    requestId: "activation-existing"
   };
 }
 

--- a/packages/agent/activity-core/src/engine/pendingIntents.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.reducer.test.ts
@@ -449,6 +449,30 @@ test("invalid successful activation acknowledgement remains uncertain", () => {
   );
 });
 
+test("legacy activation results remain opaque acknowledgements", () => {
+  const state = reduce(
+    createInitialPendingIntentsState(),
+    existingActivation()
+  ).state;
+  const result = reduce(state, {
+    commandId: "activate:activation-existing",
+    commandType: "session/activate",
+    correlationId: "activation-existing",
+    outcome: "succeeded",
+    type: "engine/commandResult",
+    value: {
+      activation: { mode: "existing", status: "already_attached" },
+      session: session("session-new")
+    }
+  });
+
+  assert.equal(
+    result.state.activationsByRequestId["activation-existing"]?.status,
+    "requested"
+  );
+  assert.deepEqual(result.followUpIntents, undefined);
+});
+
 test("typed new-session activation returns its authoritative Session to the Engine", () => {
   const state = reduce(createInitialPendingIntentsState(), activation()).state;
   const authoritativeSession = {
@@ -460,6 +484,7 @@ test("typed new-session activation returns its authoritative Session to the Engi
     commandType: "session/activate",
     correlationId: "activation-1",
     outcome: "succeeded",
+    resultContract: "activation-v1",
     type: "engine/commandResult",
     value: {
       activation: { mode: "new", status: "attached" },
@@ -488,6 +513,7 @@ test("typed existing-session activation returns its detail aggregate to the Engi
     commandType: "session/activate",
     correlationId: "activation-existing",
     outcome: "succeeded",
+    resultContract: "activation-v1",
     type: "engine/commandResult",
     value: {
       activation: { mode: "existing", status: "already_attached" },
@@ -523,6 +549,7 @@ test("typed activation results cannot omit or escape their requested scope", () 
     commandType: "session/activate",
     correlationId: "activation-1",
     outcome: "succeeded",
+    resultContract: "activation-v1",
     type: "engine/commandResult",
     value: {
       activation: { mode: "new", status: "attached" }
@@ -543,6 +570,7 @@ test("typed activation results cannot omit or escape their requested scope", () 
     commandType: "session/activate",
     correlationId: "activation-existing",
     outcome: "succeeded",
+    resultContract: "activation-v1",
     type: "engine/commandResult",
     value: {
       activation: { mode: "existing", status: "already_attached" },
@@ -568,6 +596,35 @@ test("typed activation results cannot omit or escape their requested scope", () 
   assert.deepEqual(escapedChild.followUpIntents, undefined);
 });
 
+test("typed activation rejects malformed nested Session entities", () => {
+  const state = reduce(createInitialPendingIntentsState(), activation()).state;
+  const result = reduce(state, {
+    commandId: "activate:activation-1",
+    commandType: "session/activate",
+    correlationId: "activation-1",
+    outcome: "succeeded",
+    resultContract: "activation-v1",
+    type: "engine/commandResult",
+    value: {
+      activation: { mode: "new", status: "attached" },
+      session: {
+        ...session("session-new"),
+        pendingInteractions: [null]
+      }
+    }
+  });
+
+  assert.equal(
+    result.state.activationsByRequestId["activation-1"]?.errorCode,
+    "invalid_command_result"
+  );
+  assert.equal(
+    result.state.activationsByRequestId["activation-1"]?.status,
+    "uncertain"
+  );
+  assert.deepEqual(result.followUpIntents, undefined);
+});
+
 test("confirmed activation may hydrate detail but cannot be failed by a late result", () => {
   let state = reduce(
     createInitialPendingIntentsState(),
@@ -587,6 +644,7 @@ test("confirmed activation may hydrate detail but cannot be failed by a late res
     commandType: "session/activate",
     correlationId: "activation-existing",
     outcome: "succeeded",
+    resultContract: "activation-v1",
     type: "engine/commandResult",
     value: {
       activation: { mode: "existing", status: "failed" },
@@ -601,6 +659,7 @@ test("confirmed activation may hydrate detail but cannot be failed by a late res
     commandType: "session/activate",
     correlationId: "activation-existing",
     outcome: "succeeded",
+    resultContract: "activation-v1",
     type: "engine/commandResult",
     value: {
       activation: { mode: "existing", status: "already_attached" },

--- a/packages/agent/activity-core/src/engine/pendingIntents.reducer.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.reducer.ts
@@ -18,6 +18,10 @@ import {
   settlePendingActivationSettings
 } from "./pendingIntents.activationSettings.ts";
 import {
+  activationCanAcceptCommandResult,
+  validateActivationCommandResult
+} from "./pendingIntents.activationResult.ts";
+import {
   markSessionActive,
   markSessionInactive,
   removeInactiveSession,
@@ -525,35 +529,47 @@ function settleActivationCommand(
   if (!record) {
     return unchanged(state);
   }
-  if (record.status === "canceled") return unchanged(state);
-  if (
-    intent.outcome === "succeeded" &&
-    isActivationCommandResult(intent.value)
-  ) {
-    const result = intent.value;
-    const failed = result.activation.status === "failed";
+  if (!activationCanAcceptCommandResult(record.status)) {
+    return unchanged(state);
+  }
+  if (intent.outcome === "succeeded") {
+    const settlement = validateActivationCommandResult(intent.value, record);
+    if (record.status === "confirmed") {
+      return settlement.kind === "acknowledged" &&
+        settlement.projectionIntent !== null
+        ? {
+            commands: NO_COMMANDS,
+            followUpIntents: [settlement.projectionIntent],
+            state
+          }
+        : unchanged(state);
+    }
+    if (settlement.kind === "invalid") {
+      return {
+        commands: NO_COMMANDS,
+        state: replaceActivation(state, {
+          ...record,
+          errorCode: settlement.errorCode,
+          errorMessage: settlement.errorMessage,
+          status: "uncertain"
+        })
+      };
+    }
+    const failed = settlement.kind === "failed";
     return {
       commands: NO_COMMANDS,
+      ...(settlement.projectionIntent
+        ? { followUpIntents: [settlement.projectionIntent] }
+        : {}),
       state: replaceActivation(
         markSessionActive(state, record.agentSessionId),
         {
           ...record,
-          errorCode: failed ? result.error?.code?.trim() || null : null,
-          errorMessage: failed ? result.error?.message?.trim() || null : null,
+          errorCode: settlement.errorCode,
+          errorMessage: settlement.errorMessage,
           status: failed ? "failed" : record.status
         }
       )
-    };
-  }
-  if (intent.outcome === "succeeded") {
-    return {
-      commands: NO_COMMANDS,
-      state: replaceActivation(state, {
-        ...record,
-        errorCode: "invalid_command_result",
-        errorMessage: null,
-        status: "uncertain"
-      })
     };
   }
   return {
@@ -718,22 +734,6 @@ function removeSessionIntents(
       agentSessionId
     )
   };
-}
-
-function isActivationCommandResult(value: unknown): value is {
-  activation: { status: string };
-  error?: { code?: string; message?: string } | null;
-} {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const result = value as {
-    activation?: { status?: unknown };
-    error?: { code?: string; message?: string } | null;
-  };
-  return Boolean(
-    result.activation && typeof result.activation.status === "string"
-  );
 }
 
 function activationExpiryId(requestId: string): string {

--- a/packages/agent/activity-core/src/engine/pendingIntents.reducer.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.reducer.ts
@@ -533,7 +533,11 @@ function settleActivationCommand(
     return unchanged(state);
   }
   if (intent.outcome === "succeeded") {
-    const settlement = validateActivationCommandResult(intent.value, record);
+    const settlement = validateActivationCommandResult(
+      intent.value,
+      record,
+      intent.resultContract
+    );
     if (record.status === "confirmed") {
       return settlement.kind === "acknowledged" &&
         settlement.projectionIntent !== null

--- a/packages/agent/activity-core/src/engine/sessionProjection.validation.ts
+++ b/packages/agent/activity-core/src/engine/sessionProjection.validation.ts
@@ -1,0 +1,486 @@
+import type {
+  AgentActivityInteraction,
+  AgentActivitySessionCapabilities,
+  AgentActivitySessionPermissionModeOption,
+  AgentActivitySessionSettings,
+  AgentActivityTurn
+} from "../types.ts";
+import type { AgentActivitySessionInput } from "../sessionNormalization.ts";
+
+export interface SessionProjectionScope {
+  agentSessionId?: string;
+  workspaceId: string;
+}
+
+/**
+ * Decodes a Session projection before it reaches canonical reducers. Product
+ * adapters own transport DTO validation; this boundary additionally protects
+ * Engine invariants and every nested entity the reducers dereference.
+ */
+export function decodeSessionProjection(
+  value: unknown,
+  scope: SessionProjectionScope
+): AgentActivitySessionInput | null {
+  if (!isRecord(value)) return null;
+  const agentSessionId = trimmedString(value.agentSessionId);
+  if (
+    !agentSessionId ||
+    (scope.agentSessionId !== undefined &&
+      agentSessionId !== scope.agentSessionId) ||
+    trimmedString(value.workspaceId) !== scope.workspaceId ||
+    !isNullableString(value.activeTurnId) ||
+    typeof value.cwd !== "string" ||
+    !isString(value.provider) ||
+    typeof value.title !== "string" ||
+    !isInteractionArray(value.latestTurnInteractions, agentSessionId) ||
+    !isInteractionArray(value.pendingInteractions, agentSessionId)
+  ) {
+    return null;
+  }
+  const activeTurn = optionalTurn(value.activeTurn, agentSessionId);
+  const latestTurn = optionalTurn(value.latestTurn, agentSessionId);
+  if (
+    activeTurn === false ||
+    latestTurn === false ||
+    (activeTurn &&
+      value.activeTurnId !== null &&
+      activeTurn.turnId.trim() !== value.activeTurnId.trim()) ||
+    !optionalSessionFieldsMatch(value, agentSessionId, scope.workspaceId)
+  ) {
+    return null;
+  }
+  return value as unknown as AgentActivitySessionInput;
+}
+
+export function decodeTurnProjection(
+  value: unknown,
+  allowedSessionIds: ReadonlySet<string>
+): AgentActivityTurn | null {
+  if (!isRecord(value)) return null;
+  const agentSessionId = trimmedString(value.agentSessionId);
+  const turnId = trimmedString(value.turnId);
+  if (
+    !agentSessionId ||
+    !allowedSessionIds.has(agentSessionId) ||
+    !turnId ||
+    !isOneOf(value.origin, TURN_ORIGINS) ||
+    !isOneOf(value.phase, TURN_PHASES) ||
+    !isFiniteNumber(value.startedAtUnixMs) ||
+    !isFiniteNumber(value.updatedAtUnixMs) ||
+    !optionalNullableOneOf(value.outcome, TURN_OUTCOMES) ||
+    !optionalNullableNumber(value.settledAtUnixMs) ||
+    !optionalNullableString(value.sourceGoalOperationId) ||
+    !optionalNullableNumber(value.sourceGoalRevision) ||
+    !optionalNullableNumber(value.sourceGoalRepairEpoch) ||
+    !optionalBoolean(value.providerForkBindingAvailable) ||
+    !optionalOneOf(
+      value.providerForkBindingState,
+      PROVIDER_FORK_BINDING_STATES
+    ) ||
+    !optionalCapabilityReferences(value.capabilityRefs) ||
+    !optionalCompletedCommand(value.completedCommand) ||
+    !optionalTurnError(value.error) ||
+    !optionalNullableRecord(value.fileChanges)
+  ) {
+    return null;
+  }
+  return value as unknown as AgentActivityTurn;
+}
+
+function optionalSessionFieldsMatch(
+  value: Record<string, unknown>,
+  agentSessionId: string,
+  workspaceId: string
+): boolean {
+  return (
+    optionalOneOf(value.kind, SESSION_KINDS) &&
+    optionalNullableString(value.rootAgentSessionId) &&
+    optionalNullableString(value.rootTurnId) &&
+    optionalNullableString(value.parentAgentSessionId) &&
+    optionalNullableString(value.parentTurnId) &&
+    optionalNullableString(value.parentToolCallId) &&
+    optionalNullableString(value.agentTargetId) &&
+    optionalNullableString(value.providerSessionId) &&
+    optionalString(value.userId) &&
+    optionalNullableString(value.model) &&
+    optionalNullableBoolean(value.noProject) &&
+    optionalString(value.railSectionKey) &&
+    optionalSettings(value.settings) &&
+    optionalPermissionConfig(value.permissionConfig) &&
+    optionalCapabilities(value.capabilities) &&
+    optionalLifecycleCapabilities(value.lifecycleCapabilities) &&
+    optionalBoolean(value.lifecycleCapabilitiesProjected) &&
+    optionalForkLineage(value.forkedFrom) &&
+    optionalUsage(value.usage) &&
+    optionalGoal(value.goal) &&
+    optionalTuttiModeActivation(
+      value.tuttiModeActivation,
+      agentSessionId,
+      workspaceId
+    ) &&
+    optionalBoolean(value.imported) &&
+    optionalBoolean(value.visible) &&
+    optionalBoolean(value.resumable) &&
+    optionalNonNegativeInteger(value.messageVersion) &&
+    optionalFiniteNumber(value.lastEventUnixMs) &&
+    optionalFiniteNumber(value.startedAtUnixMs) &&
+    optionalNullableNumber(value.endedAtUnixMs) &&
+    optionalNullableNumber(value.pinnedAtUnixMs) &&
+    optionalFiniteNumber(value.createdAtUnixMs) &&
+    optionalFiniteNumber(value.updatedAtUnixMs)
+  );
+}
+
+function isInteractionArray(
+  value: unknown,
+  agentSessionId: string
+): value is readonly AgentActivityInteraction[] {
+  return (
+    Array.isArray(value) &&
+    value.every((interaction) =>
+      isInteractionProjection(interaction, agentSessionId)
+    )
+  );
+}
+
+function isInteractionProjection(
+  value: unknown,
+  agentSessionId: string
+): value is AgentActivityInteraction {
+  if (!isRecord(value)) return false;
+  return (
+    trimmedString(value.agentSessionId) === agentSessionId &&
+    Boolean(trimmedString(value.turnId)) &&
+    Boolean(trimmedString(value.requestId)) &&
+    isOneOf(value.kind, INTERACTION_KINDS) &&
+    isOneOf(value.status, INTERACTION_STATUSES) &&
+    isFiniteNumber(value.createdAtUnixMs) &&
+    isFiniteNumber(value.updatedAtUnixMs) &&
+    optionalNullableRecord(value.input) &&
+    optionalNullableRecord(value.metadata) &&
+    optionalNullableRecord(value.output) &&
+    optionalNullableString(value.toolName)
+  );
+}
+
+function optionalTurn(
+  value: unknown,
+  agentSessionId: string
+): AgentActivityTurn | null | false {
+  if (value === undefined || value === null) return null;
+  return decodeTurnProjection(value, new Set([agentSessionId])) ?? false;
+}
+
+function optionalSettings(value: unknown): boolean {
+  if (value === undefined) return true;
+  if (!isRecord(value)) return false;
+  const settings = value as Record<keyof AgentActivitySessionSettings, unknown>;
+  return (
+    optionalNullableString(settings.model) &&
+    optionalNullableString(settings.permissionModeId) &&
+    optionalNullableBoolean(settings.planMode) &&
+    optionalNullableBoolean(settings.browserUse) &&
+    optionalNullableBoolean(settings.computerUse) &&
+    optionalNullableString(settings.reasoningEffort) &&
+    optionalNullableString(settings.speed)
+  );
+}
+
+function optionalPermissionConfig(value: unknown): boolean {
+  if (value === undefined) return true;
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.configurable === "boolean" &&
+    optionalString(value.defaultValue) &&
+    Array.isArray(value.modes) &&
+    value.modes.every(isPermissionMode)
+  );
+}
+
+function isPermissionMode(
+  value: unknown
+): value is AgentActivitySessionPermissionModeOption {
+  return Boolean(
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    typeof value.label === "string" &&
+    optionalString(value.description) &&
+    isOneOf(value.semantic, PERMISSION_MODE_SEMANTICS)
+  );
+}
+
+function optionalCapabilities(value: unknown): boolean {
+  if (value === undefined || value === null) return true;
+  if (!isRecord(value)) return false;
+  return SESSION_CAPABILITIES.every(
+    (capability) =>
+      typeof (value as Record<keyof AgentActivitySessionCapabilities, unknown>)[
+        capability
+      ] === "boolean"
+  );
+}
+
+function optionalLifecycleCapabilities(value: unknown): boolean {
+  return Boolean(
+    value === undefined ||
+    (isRecord(value) &&
+      typeof value.fork === "boolean" &&
+      typeof value.forkThroughTurn === "boolean")
+  );
+}
+
+function optionalForkLineage(value: unknown): boolean {
+  return Boolean(
+    value === undefined ||
+    value === null ||
+    (isRecord(value) &&
+      Boolean(trimmedString(value.sourceAgentSessionId)) &&
+      Boolean(trimmedString(value.sourceTurnId)) &&
+      Boolean(trimmedString(value.targetTurnId)) &&
+      Boolean(trimmedString(value.operationId)) &&
+      isFiniteNumber(value.forkedAtUnixMs))
+  );
+}
+
+function optionalUsage(value: unknown): boolean {
+  if (value === undefined || value === null) return true;
+  if (!isRecord(value)) return false;
+  const contextWindow = value.contextWindow;
+  return Boolean(
+    (contextWindow === null ||
+      (isRecord(contextWindow) &&
+        isFiniteNumber(contextWindow.usedTokens) &&
+        isFiniteNumber(contextWindow.totalTokens))) &&
+    Array.isArray(value.quotas) &&
+    value.quotas.every(
+      (quota) =>
+        isRecord(quota) &&
+        typeof quota.quotaType === "string" &&
+        isFiniteNumber(quota.percentRemaining) &&
+        isNullableNumber(quota.resetsAtUnixMs)
+    )
+  );
+}
+
+function optionalGoal(value: unknown): boolean {
+  return Boolean(
+    value === undefined ||
+    value === null ||
+    (isRecord(value) &&
+      typeof value.objective === "string" &&
+      isOneOf(value.status, GOAL_STATUSES) &&
+      optionalString(value.reason) &&
+      optionalFiniteNumber(value.iterations) &&
+      optionalFiniteNumber(value.durationMs) &&
+      optionalFiniteNumber(value.tokens))
+  );
+}
+
+function optionalTuttiModeActivation(
+  value: unknown,
+  agentSessionId: string,
+  workspaceId: string
+): boolean {
+  if (value === undefined || value === null) return true;
+  if (!isRecord(value) || !isRecord(value.currentRevision)) return false;
+  const revision = value.currentRevision;
+  return (
+    Boolean(trimmedString(value.id)) &&
+    trimmedString(value.workspaceId) === workspaceId &&
+    trimmedString(value.agentSessionId) === agentSessionId &&
+    isOneOf(value.status, TUTTI_MODE_STATUSES) &&
+    isFiniteNumber(value.createdAtUnixMs) &&
+    isFiniteNumber(value.updatedAtUnixMs) &&
+    Boolean(trimmedString(revision.activationId)) &&
+    isFiniteNumber(revision.revision) &&
+    isOneOf(revision.status, TUTTI_MODE_STATUSES) &&
+    isOneOf(revision.source, TUTTI_MODE_SOURCES) &&
+    isFiniteNumber(revision.orchestrationIntensity) &&
+    optionalFiniteNumber(revision.effect) &&
+    optionalFiniteNumber(revision.speed) &&
+    isFiniteNumber(revision.createdAtUnixMs)
+  );
+}
+
+function optionalCapabilityReferences(value: unknown): boolean {
+  return Boolean(
+    value === undefined ||
+    (Array.isArray(value) &&
+      value.every(
+        (reference) =>
+          isRecord(reference) &&
+          reference.capability === "tutti" &&
+          reference.source === "slash_command"
+      ))
+  );
+}
+
+function optionalCompletedCommand(value: unknown): boolean {
+  return Boolean(
+    value === undefined ||
+    value === null ||
+    (isRecord(value) &&
+      isOneOf(value.kind, COMPLETED_COMMAND_KINDS) &&
+      isOneOf(value.status, COMPLETED_COMMAND_STATUSES))
+  );
+}
+
+function optionalTurnError(value: unknown): boolean {
+  return Boolean(
+    value === undefined ||
+    value === null ||
+    (isRecord(value) &&
+      typeof value.message === "string" &&
+      optionalString(value.code))
+  );
+}
+
+function optionalNullableRecord(value: unknown): boolean {
+  return value === undefined || value === null || isRecord(value);
+}
+
+function optionalNullableString(value: unknown): boolean {
+  return value === undefined || isNullableString(value);
+}
+
+function optionalString(value: unknown): boolean {
+  return value === undefined || typeof value === "string";
+}
+
+function isNullableString(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+function optionalNullableBoolean(value: unknown): boolean {
+  return value === undefined || value === null || typeof value === "boolean";
+}
+
+function optionalBoolean(value: unknown): boolean {
+  return value === undefined || typeof value === "boolean";
+}
+
+function optionalNullableNumber(value: unknown): boolean {
+  return value === undefined || isNullableNumber(value);
+}
+
+function isNullableNumber(value: unknown): value is number | null {
+  return value === null || isFiniteNumber(value);
+}
+
+function optionalFiniteNumber(value: unknown): boolean {
+  return value === undefined || isFiniteNumber(value);
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function optionalNonNegativeInteger(value: unknown): boolean {
+  return (
+    value === undefined ||
+    (Number.isSafeInteger(value) && (value as number) >= 0)
+  );
+}
+
+function optionalOneOf<const Value extends string>(
+  value: unknown,
+  allowed: readonly Value[]
+): boolean {
+  return value === undefined || isOneOf(value, allowed);
+}
+
+function optionalNullableOneOf<const Value extends string>(
+  value: unknown,
+  allowed: readonly Value[]
+): boolean {
+  return value === undefined || value === null || isOneOf(value, allowed);
+}
+
+function isOneOf<const Value extends string>(
+  value: unknown,
+  allowed: readonly Value[]
+): value is Value {
+  return typeof value === "string" && allowed.includes(value as Value);
+}
+
+function trimmedString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+const SESSION_KINDS = ["root", "child"] as const;
+const TURN_ORIGINS = [
+  "user_prompt",
+  "goal_arm",
+  "goal_continuation",
+  "provider_initiated",
+  "legacy_unknown"
+] as const;
+const TURN_PHASES = [
+  "submitted",
+  "running",
+  "waiting",
+  "settling",
+  "settled"
+] as const;
+const TURN_OUTCOMES = [
+  "completed",
+  "failed",
+  "canceled",
+  "interrupted"
+] as const;
+const PROVIDER_FORK_BINDING_STATES = [
+  "bound",
+  "recovery_required",
+  "unavailable"
+] as const;
+const INTERACTION_KINDS = ["approval", "question", "plan"] as const;
+const INTERACTION_STATUSES = ["pending", "answered", "superseded"] as const;
+const PERMISSION_MODE_SEMANTICS = [
+  "ask-before-write",
+  "accept-edits",
+  "locked-down",
+  "auto",
+  "full-access",
+  "unconfigurable"
+] as const;
+const GOAL_STATUSES = [
+  "active",
+  "paused",
+  "blocked",
+  "usageLimited",
+  "budgetLimited",
+  "complete"
+] as const;
+const TUTTI_MODE_STATUSES = ["active", "inactive"] as const;
+const TUTTI_MODE_SOURCES = ["slash_command", "badge_remove"] as const;
+const COMPLETED_COMMAND_KINDS = ["compact", "review", "undo", "goal"] as const;
+const COMPLETED_COMMAND_STATUSES = ["completed", "failed", "canceled"] as const;
+const SESSION_CAPABILITIES = [
+  "imageInput",
+  "modelImageInputRequired",
+  "modelPlanBinding",
+  "skills",
+  "compact",
+  "tokenUsage",
+  "rateLimits",
+  "planMode",
+  "interrupt",
+  "modelSwitch",
+  "activeTurnGuidance",
+  "browserUse",
+  "computerUse",
+  "goalPause",
+  "planImplementation",
+  "permissionModeChangeDuringTurn",
+  "permissionModeChangeDeferred",
+  "review",
+  "resumeRunningTurn"
+] as const satisfies readonly (keyof AgentActivitySessionCapabilities)[];

--- a/packages/agent/activity-core/src/engine/types.ts
+++ b/packages/agent/activity-core/src/engine/types.ts
@@ -66,6 +66,13 @@ export interface EngineExpiryCancelRequestedIntent {
 export type EngineCommandOutcome = "failed" | "succeeded" | "timedOut";
 
 /**
+ * Describes the runtime result contract used by one command execution.
+ * Older command ports and manually dispatched results omit this field and
+ * retain opaque acknowledgement semantics.
+ */
+export type EngineCommandResultContract = "activation-v1" | "opaque";
+
+/**
  * Every command execution settles back into the loop as this intent, so
  * failure and timeout handling are explicit reducer transitions instead of
  * executor-side improvisation.
@@ -76,6 +83,7 @@ export interface EngineCommandResultIntent {
   commandType: EngineExternalCommand["type"];
   correlationId?: string;
   outcome: EngineCommandOutcome;
+  resultContract?: EngineCommandResultContract;
   value?: unknown;
   errorCode?: string;
   errorReason?: string;

--- a/packages/agent/activity-core/src/engine/types.ts
+++ b/packages/agent/activity-core/src/engine/types.ts
@@ -337,11 +337,27 @@ export type AgentSessionActivateEffectInput =
       mode: "existing";
     });
 
+/**
+ * Authoritative activation payload returned by preferred typed hosts.
+ * Existing-session activation carries the complete detail aggregate so the
+ * Engine, rather than the host effect, applies Session/Turn state.
+ */
+export type AgentSessionActivateEffectResult =
+  | {
+      activation: { mode: "new"; status: "attached" };
+      session: AgentActivitySession;
+    }
+  | {
+      activation: { mode: "existing"; status: "already_attached" };
+      detail: AgentActivitySessionDetailSnapshot;
+      session: AgentActivitySession;
+    };
+
 export interface AgentSessionEffectPort {
   activateSession(
     input: AgentSessionActivateEffectInput,
     options?: EngineEffectOptions
-  ): Promise<unknown>;
+  ): Promise<AgentSessionActivateEffectResult>;
   cancelTurn(
     input: AgentActivityCancelTurnInput,
     options?: EngineEffectOptions
@@ -568,6 +584,7 @@ import type {
   TurnCancelCommand
 } from "./sessionLifecycle.types.ts";
 import type {
+  AgentActivitySessionDetailSnapshot,
   SessionReconcileCommand,
   SessionReconcileIntent,
   SessionReconcileState

--- a/packages/agent/activity-core/src/index.ts
+++ b/packages/agent/activity-core/src/index.ts
@@ -72,6 +72,7 @@ export type {
 } from "./engine/diagnostics.ts";
 export type {
   AgentSessionActivateEffectInput,
+  AgentSessionActivateEffectResult,
   AgentSessionEffectPort,
   AgentSessionEngine,
   AgentSessionEngineIdentity,


### PR DESCRIPTION
## Summary

- define a typed activation effect result for new and existing Sessions
- move authoritative Session/detail projection into the shared Agent Session Engine
- make Desktop and Mobile activation effects transport-and-mapping-only
- validate activation mode, workspace, Session, child Session, Turn, and optional edit/retry scope before projection
- preserve legacy command-port acknowledgements while typed consumers migrate
- document the unified activation result ownership boundary

## Why

The Engine already owned activation admission and pending-intent lifecycle, but Desktop and Mobile effects still wrote the returned Session state directly. That split ownership meant activation completion could bypass the Engine's canonical reducers, duplicated host behavior, and made late-result monotonicity harder to enforce consistently across consumers.

This change makes the Engine the single owner of activation result settlement. Effects return authoritative data; the Engine validates and applies it through existing Session/detail intents. A late activation projection therefore cannot regress newer realtime state.

## Impact

Desktop and Mobile now share the same activation result contract and reducer path. New-session activation projects the authoritative Session, while existing-session activation hydrates the complete authoritative detail aggregate. Host-specific cwd resolution, transport, DTO mapping, analytics, and diagnostics remain in their adapters.

## Validation

- `pnpm check:changed` — passed before manual testing
- `make dev-gui` — Desktop launched successfully
- created and completed a real Codex Session (`DEV_ACTIVATION_OK`)
- loaded a historical Session and continued it successfully (`EXISTING_ACTIVATION_OK`)
- verified activation logs contain no missing-result, duplicate-settlement, or timeout-after-settlement errors
- pre-commit format, lint, Electron/runtime, UI, renderer, and AgentGUI boundary checks passed
- pre-push `pnpm check:changed -- --push-ready` — passed 19 lanes

## Documentation

Updated `docs/architecture/agent-activity-packages.md` and `docs/architecture/agent-gui-node.md` to record Engine ownership of typed activation result validation and projection.