### PR TITLE
feat(analytics): track account login identity context

### DIFF
--- a/docs/architecture/analytics-tracking.md
+++ b/docs/architecture/analytics-tracking.md
@@ -48,9 +48,9 @@ business events continue to report from the window where the action occurs.
 
 - tuttid always starts before the renderer, so there is no Tea SDK startup
   ordering problem in the renderer
-- Common params such as `device_id`, `session_id`, `os`, and `app_version` are
-  owned by tuttid and do not need to be replicated or synchronized to the
-  renderer
+- Common params such as `device_id`, `session_id`, `os`, `app_version`, and
+  account identity are owned by tuttid and do not need to be replicated or
+  synchronized to the renderer
 - Batch scheduling and retry behavior live in one place (the Go Tea SDK)
 - Renderer has no dependency on external scripts or CSP relaxations for Tea
 
@@ -60,19 +60,38 @@ Common params are split by ownership. tuttid injects its params on every event
 before forwarding to Tea. The renderer supplies only the params it uniquely
 knows.
 
-| Param              | Owner    | Notes                                               |
-| ------------------ | -------- | --------------------------------------------------- |
-| `device_id`        | tuttid   | Persisted UUID in state dir; stable across restarts |
-| `session_id`       | tuttid   | UUID generated once at daemon startup               |
-| `app_version`      | tuttid   | Resolved from generated defaults or env override    |
-| `os`               | tuttid   | Resolved at startup                                 |
-| `client_ts`        | renderer | Millisecond timestamp at the moment the event fired |
-| `dark_mode`        | renderer | `"1"` or `"0"`                                      |
-| `mode`             | renderer | Current workspace shell: `"os"` or `"agent"`        |
-| UI-specific params | renderer | Passed through `params` object                      |
+| Param               | Owner    | Notes                                               |
+| ------------------- | -------- | --------------------------------------------------- |
+| `device_id`         | tuttid   | Persisted UUID in state dir; stable across restarts |
+| `session_id`        | tuttid   | UUID generated once at daemon startup               |
+| `app_version`       | tuttid   | Resolved from generated defaults or env override    |
+| `os`                | tuttid   | Resolved at startup                                 |
+| `event_id`          | tuttid   | Generated UUID when the event does not supply one   |
+| `authority`         | tuttid   | `"client"` for Tutti Desktop events                 |
+| `business_app_id`   | tuttid   | Tutti account/commerce application ID               |
+| `client`            | tuttid   | `"desktop"`                                         |
+| `environment`       | tuttid   | Runtime environment                                 |
+| `schema_version`    | tuttid   | Current analytics contract version                  |
+| `uid`               | tuttid   | Authenticated account ID; absent when anonymous     |
+| `login_state`       | tuttid   | `"authenticated"` or `"anonymous"`                  |
+| `identity_status`   | tuttid   | Identity readiness for the current event            |
+| `membership_status` | tuttid   | Current membership state or `"unknown"`             |
+| `membership_tier`   | tuttid   | Current tier key, `"free"`, or `"unknown"`          |
+| `client_ts`         | renderer | Millisecond timestamp at the moment the event fired |
+| `dark_mode`         | renderer | `"1"` or `"0"`                                      |
+| `mode`              | renderer | Current workspace shell: `"os"` or `"agent"`        |
+| UI-specific params  | renderer | Passed through `params` object                      |
 
 tuttid never tries to infer UI-state params. Renderer never tries to supply
 identity or platform params.
+
+The account service supplies dynamic identity parameters and the matching
+DataFinder `user_unique_id` as one atomic snapshot. A login or logout cannot
+produce an event whose SDK identity disagrees with its own `uid` and
+`login_state`. Anonymous events use the stable `device_id` as the SDK identity.
+When tuttid starts with a persisted account session, it restores the UID before
+the reporter begins handling product events; membership fields remain
+`"unknown"` until the product summary is refreshed.
 
 The renderer derives `mode` from the native window route. `view=agent` reports
 `"agent"`; `view=workspace`, legacy routes, and unknown routes report `"os"`,
@@ -100,6 +119,21 @@ pattern.
 | `<domain>.<action>` | Product domain plus confirmed business event | `workspace.opened`            |
 | Nested domains      | Larger feature area plus action              | `agent.session_started`       |
 | Error domains       | Feature-specific error event                 | `error.workspace_unavailable` |
+
+### Account login
+
+Tutti Desktop reports the unified `account.login` event:
+
+| Stage   | Action     | Result                         | Meaning                             |
+| ------- | ---------- | ------------------------------ | ----------------------------------- |
+| `login` | `start`    | `started`                      | Desktop login attempt accepted      |
+| `login` | `complete` | `success`                      | Login completed with a resolved UID |
+| `login` | `complete` | `failed / cancelled / expired` | Terminal unsuccessful result        |
+
+Every attempt carries a stable `flow_id`. Login success rate is distinct
+successful terminal `flow_id` divided by distinct started `flow_id`. Daily
+logged-in users are distinct `uid` values on successful terminal events, with
+dashboard day boundaries evaluated in `Asia/Shanghai`.
 
 ## API Contract
 
@@ -289,11 +323,12 @@ type Reporter interface {
 
 `TeaReporter` wraps `github.com/volcengine/datarangers-sdk-go`. It injects
 common params on every `Track` call before handing events to the SDK. Hosts may
-supply an existing durable `DeviceID` and product-owned common parameters; the
-shared reporter always owns and protects `device_id`, `session_id`,
-`app_version`, and `os`. The SDK uses HTTP mode with SDK batch mode disabled, a
-bounded async queue wait, and controlled SDK log paths under the product state
-directory.
+supply an existing durable `DeviceID`, static common parameters, and one
+`DynamicContextProvider`. That provider returns dynamic common parameters and
+the matching DataFinder user identity in one snapshot. The shared reporter
+always owns and protects `device_id`, `session_id`, `app_version`, and `os`.
+The SDK uses HTTP mode with SDK batch mode disabled, a bounded async queue wait,
+and controlled SDK log paths under the product state directory.
 
 `NoopReporter` is used in unit tests and when Tea credentials are absent (e.g.
 local development without credentials configured).
@@ -381,8 +416,9 @@ The method calls the generated OpenAPI SDK and reuses generated request types.
   the moment the HTTP call is made
 - `daemon_` prefixed events are reported directly via `Reporter.Track()`; they
   do not go through the HTTP endpoint
-- Common params (`device_id`, `session_id`, `os`, `app_version`) must not be
-  sent by the renderer; tuttid always overwrites them
+- Daemon-owned common params (`device_id`, `session_id`, `os`, `app_version`,
+  identity fields, authority, app, client, environment, and schema version)
+  must not be sent by the renderer; tuttid always overwrites them
 - `TeaReporter.Close()` must be called during graceful shutdown; with the
   current DataFinder Go SDK HTTP mode this is a best-effort lifecycle hook, not
   a hard flush guarantee

--- a/packages/analytics/reporter-go/README.md
+++ b/packages/analytics/reporter-go/README.md
@@ -8,6 +8,11 @@ Product repositories own event names, schemas, HTTP contracts, and typed event
 helpers. Renderer code must report through its daemon rather than importing this
 Go module directly.
 
+Hosts that attach dynamic account context must use
+`Config.DynamicContextProvider`. It returns the event common parameters and the
+matching DataFinder user identity together so one event cannot mix account
+states across a concurrent login or logout.
+
 Production DataFinder reporting requires either `Config.StateDir` or an explicit
 `Config.SDKLogDir` for bounded SDK log files. `SDKLogDir` is useful when a host
 must preserve an existing log path; otherwise logs default to

--- a/packages/analytics/reporter-go/debug_reporter.go
+++ b/packages/analytics/reporter-go/debug_reporter.go
@@ -24,7 +24,7 @@ func (r *DebugReporter) Track(ctx context.Context, events ...Event) {
 		return
 	}
 
-	common := r.common.params()
+	common, _ := r.common.snapshot()
 	normalized := normalizeEvents(events, common)
 	if len(normalized) == 0 {
 		return

--- a/packages/analytics/reporter-go/reporter.go
+++ b/packages/analytics/reporter-go/reporter.go
@@ -60,12 +60,14 @@ type AnalyticsConfig struct {
 // hosts preserve an existing log location; when omitted it defaults beneath
 // StateDir.
 type Config struct {
-	Analytics      AnalyticsConfig
-	DebugPublisher DebugPublisher
-	StateDir       string
-	SDKLogDir      string
-	DeviceID       string
-	CommonParams   map[string]any
+	Analytics            AnalyticsConfig
+	DebugPublisher       DebugPublisher
+	StateDir             string
+	SDKLogDir            string
+	DeviceID             string
+	CommonParams         map[string]any
+	CommonParamsProvider func() map[string]any
+	UserUniqueIDProvider func() string
 }
 
 // New selects a disabled, debug-only, or DataFinder-backed reporter.
@@ -172,11 +174,13 @@ func readDeviceID(path string) (value string, exists bool, err error) {
 }
 
 type reporterCommon struct {
-	deviceID   string
-	sessionID  string
-	appVersion string
-	osName     string
-	additional map[string]any
+	deviceID             string
+	sessionID            string
+	appVersion           string
+	osName               string
+	additional           map[string]any
+	additionalProvider   func() map[string]any
+	userUniqueIDProvider func() string
 }
 
 func newReporterCommon(config Config) (reporterCommon, error) {
@@ -185,11 +189,13 @@ func newReporterCommon(config Config) (reporterCommon, error) {
 		return reporterCommon{}, err
 	}
 	return reporterCommon{
-		deviceID:   deviceID,
-		sessionID:  uuid.NewString(),
-		appVersion: config.Analytics.AppVersion,
-		osName:     runtime.GOOS,
-		additional: copyParams(config.CommonParams),
+		deviceID:             deviceID,
+		sessionID:            uuid.NewString(),
+		appVersion:           config.Analytics.AppVersion,
+		osName:               runtime.GOOS,
+		additional:           copyParams(config.CommonParams),
+		additionalProvider:   config.CommonParamsProvider,
+		userUniqueIDProvider: config.UserUniqueIDProvider,
 	}, nil
 }
 
@@ -198,11 +204,41 @@ func (c reporterCommon) params() map[string]any {
 	if params == nil {
 		params = map[string]any{}
 	}
+	for key, value := range c.providedParams() {
+		params[key] = value
+	}
 	params["device_id"] = c.deviceID
 	params["session_id"] = c.sessionID
 	params["app_version"] = c.appVersion
 	params["os"] = c.osName
 	return params
+}
+
+func (c reporterCommon) providedParams() (params map[string]any) {
+	if c.additionalProvider == nil {
+		return nil
+	}
+	defer func() {
+		if recover() != nil {
+			params = nil
+		}
+	}()
+	return copyParams(c.additionalProvider())
+}
+
+func (c reporterCommon) userUniqueID() (userID string) {
+	if c.userUniqueIDProvider == nil {
+		return c.deviceID
+	}
+	defer func() {
+		if recover() != nil {
+			userID = c.deviceID
+		}
+	}()
+	if value := strings.TrimSpace(c.userUniqueIDProvider()); value != "" {
+		return value
+	}
+	return c.deviceID
 }
 
 func normalizeEvents(events []Event, common map[string]any) []teaSDKEvent {
@@ -216,8 +252,14 @@ func normalizeEvents(events []Event, common map[string]any) []teaSDKEvent {
 			clientTS = time.Now().UnixMilli()
 		}
 		params := copyParams(event.Params)
+		if params == nil {
+			params = map[string]any{}
+		}
 		for key := range common {
 			delete(params, key)
+		}
+		if _, exists := params["event_id"]; !exists {
+			params["event_id"] = uuid.NewString()
 		}
 		normalized = append(normalized, teaSDKEvent{
 			Name:     event.Name,

--- a/packages/analytics/reporter-go/reporter.go
+++ b/packages/analytics/reporter-go/reporter.go
@@ -60,14 +60,20 @@ type AnalyticsConfig struct {
 // hosts preserve an existing log location; when omitted it defaults beneath
 // StateDir.
 type Config struct {
-	Analytics            AnalyticsConfig
-	DebugPublisher       DebugPublisher
-	StateDir             string
-	SDKLogDir            string
-	DeviceID             string
-	CommonParams         map[string]any
-	CommonParamsProvider func() map[string]any
-	UserUniqueIDProvider func() string
+	Analytics              AnalyticsConfig
+	DebugPublisher         DebugPublisher
+	StateDir               string
+	SDKLogDir              string
+	DeviceID               string
+	CommonParams           map[string]any
+	DynamicContextProvider func() DynamicContext
+}
+
+// DynamicContext is one atomic snapshot of host-owned dynamic common
+// parameters and the matching DataFinder user identity.
+type DynamicContext struct {
+	CommonParams map[string]any
+	UserUniqueID string
 }
 
 // New selects a disabled, debug-only, or DataFinder-backed reporter.
@@ -174,13 +180,12 @@ func readDeviceID(path string) (value string, exists bool, err error) {
 }
 
 type reporterCommon struct {
-	deviceID             string
-	sessionID            string
-	appVersion           string
-	osName               string
-	additional           map[string]any
-	additionalProvider   func() map[string]any
-	userUniqueIDProvider func() string
+	deviceID               string
+	sessionID              string
+	appVersion             string
+	osName                 string
+	additional             map[string]any
+	dynamicContextProvider func() DynamicContext
 }
 
 func newReporterCommon(config Config) (reporterCommon, error) {
@@ -189,56 +194,47 @@ func newReporterCommon(config Config) (reporterCommon, error) {
 		return reporterCommon{}, err
 	}
 	return reporterCommon{
-		deviceID:             deviceID,
-		sessionID:            uuid.NewString(),
-		appVersion:           config.Analytics.AppVersion,
-		osName:               runtime.GOOS,
-		additional:           copyParams(config.CommonParams),
-		additionalProvider:   config.CommonParamsProvider,
-		userUniqueIDProvider: config.UserUniqueIDProvider,
+		deviceID:               deviceID,
+		sessionID:              uuid.NewString(),
+		appVersion:             config.Analytics.AppVersion,
+		osName:                 runtime.GOOS,
+		additional:             copyParams(config.CommonParams),
+		dynamicContextProvider: config.DynamicContextProvider,
 	}, nil
 }
 
-func (c reporterCommon) params() map[string]any {
+func (c reporterCommon) snapshot() (map[string]any, string) {
 	params := copyParams(c.additional)
 	if params == nil {
 		params = map[string]any{}
 	}
-	for key, value := range c.providedParams() {
+	dynamic := c.dynamicContext()
+	for key, value := range dynamic.CommonParams {
 		params[key] = value
 	}
 	params["device_id"] = c.deviceID
 	params["session_id"] = c.sessionID
 	params["app_version"] = c.appVersion
 	params["os"] = c.osName
-	return params
+	userUniqueID := strings.TrimSpace(dynamic.UserUniqueID)
+	if userUniqueID == "" {
+		userUniqueID = c.deviceID
+	}
+	return params, userUniqueID
 }
 
-func (c reporterCommon) providedParams() (params map[string]any) {
-	if c.additionalProvider == nil {
-		return nil
+func (c reporterCommon) dynamicContext() (dynamic DynamicContext) {
+	if c.dynamicContextProvider == nil {
+		return DynamicContext{}
 	}
 	defer func() {
 		if recover() != nil {
-			params = nil
+			dynamic = DynamicContext{}
 		}
 	}()
-	return copyParams(c.additionalProvider())
-}
-
-func (c reporterCommon) userUniqueID() (userID string) {
-	if c.userUniqueIDProvider == nil {
-		return c.deviceID
-	}
-	defer func() {
-		if recover() != nil {
-			userID = c.deviceID
-		}
-	}()
-	if value := strings.TrimSpace(c.userUniqueIDProvider()); value != "" {
-		return value
-	}
-	return c.deviceID
+	dynamic = c.dynamicContextProvider()
+	dynamic.CommonParams = copyParams(dynamic.CommonParams)
+	return dynamic
 }
 
 func normalizeEvents(events []Event, common map[string]any) []teaSDKEvent {

--- a/packages/analytics/reporter-go/reporter_test.go
+++ b/packages/analytics/reporter-go/reporter_test.go
@@ -206,6 +206,7 @@ func TestTeaReporterPersistsIdentityAndSendsSanitizedEvents(t *testing.T) {
 func TestTeaReporterUsesDynamicIdentityForCommonParamsAndSDKUserID(t *testing.T) {
 	sdk := &fakeTeaSDK{}
 	userID := ""
+	providerCalls := 0
 	reporter, err := newTeaReporterWithSDK(Config{
 		Analytics: AnalyticsConfig{
 			AppID:         20004092,
@@ -214,14 +215,17 @@ func TestTeaReporterUsesDynamicIdentityForCommonParamsAndSDKUserID(t *testing.T)
 		},
 		DeviceID:  "host-device",
 		SDKLogDir: t.TempDir(),
-		CommonParamsProvider: func() map[string]any {
+		DynamicContextProvider: func() DynamicContext {
+			providerCalls++
 			if userID == "" {
-				return map[string]any{"login_state": "anonymous"}
+				return DynamicContext{
+					CommonParams: map[string]any{"login_state": "anonymous"},
+				}
 			}
-			return map[string]any{"login_state": "authenticated", "uid": userID}
-		},
-		UserUniqueIDProvider: func() string {
-			return userID
+			return DynamicContext{
+				CommonParams: map[string]any{"login_state": "authenticated", "uid": userID},
+				UserUniqueID: userID,
+			}
 		},
 	}, sdk)
 	if err != nil {
@@ -234,6 +238,9 @@ func TestTeaReporterUsesDynamicIdentityForCommonParamsAndSDKUserID(t *testing.T)
 
 	if len(sdk.sends) != 2 {
 		t.Fatalf("send calls = %d, want 2", len(sdk.sends))
+	}
+	if providerCalls != 2 {
+		t.Fatalf("dynamic context provider calls = %d, want one per Track", providerCalls)
 	}
 	if sdk.sends[0].uuid != "host-device" || sdk.sends[0].common["login_state"] != "anonymous" {
 		t.Fatalf("anonymous send = %#v", sdk.sends[0])

--- a/packages/analytics/reporter-go/reporter_test.go
+++ b/packages/analytics/reporter-go/reporter_test.go
@@ -203,6 +203,49 @@ func TestTeaReporterPersistsIdentityAndSendsSanitizedEvents(t *testing.T) {
 	}
 }
 
+func TestTeaReporterUsesDynamicIdentityForCommonParamsAndSDKUserID(t *testing.T) {
+	sdk := &fakeTeaSDK{}
+	userID := ""
+	reporter, err := newTeaReporterWithSDK(Config{
+		Analytics: AnalyticsConfig{
+			AppID:         20004092,
+			AppKey:        "app-key",
+			ChannelDomain: "https://example.test",
+		},
+		DeviceID:  "host-device",
+		SDKLogDir: t.TempDir(),
+		CommonParamsProvider: func() map[string]any {
+			if userID == "" {
+				return map[string]any{"login_state": "anonymous"}
+			}
+			return map[string]any{"login_state": "authenticated", "uid": userID}
+		},
+		UserUniqueIDProvider: func() string {
+			return userID
+		},
+	}, sdk)
+	if err != nil {
+		t.Fatalf("newTeaReporterWithSDK() error = %v", err)
+	}
+
+	reporter.Track(context.Background(), Event{Name: "account.login"})
+	userID = "user-1"
+	reporter.Track(context.Background(), Event{Name: "account.login"})
+
+	if len(sdk.sends) != 2 {
+		t.Fatalf("send calls = %d, want 2", len(sdk.sends))
+	}
+	if sdk.sends[0].uuid != "host-device" || sdk.sends[0].common["login_state"] != "anonymous" {
+		t.Fatalf("anonymous send = %#v", sdk.sends[0])
+	}
+	if sdk.sends[1].uuid != "user-1" || sdk.sends[1].common["uid"] != "user-1" {
+		t.Fatalf("authenticated send = %#v", sdk.sends[1])
+	}
+	if sdk.sends[1].events[0].Params["event_id"] == "" {
+		t.Fatal("event_id was not generated")
+	}
+}
+
 func TestReporterRequiresIdentitySourceWhenEnabled(t *testing.T) {
 	_, err := New(Config{
 		Analytics: AnalyticsConfig{

--- a/packages/analytics/reporter-go/tea_reporter.go
+++ b/packages/analytics/reporter-go/tea_reporter.go
@@ -60,7 +60,7 @@ func (r *TeaReporter) Track(ctx context.Context, events ...Event) {
 	}
 
 	r.publishDebugEvents(ctx, sendEvents, common)
-	_ = r.sdk.Send(r.appID, r.common.deviceID, sendEvents, common)
+	_ = r.sdk.Send(r.appID, r.common.userUniqueID(), sendEvents, common)
 }
 
 func (r *TeaReporter) Close() error {

--- a/packages/analytics/reporter-go/tea_reporter.go
+++ b/packages/analytics/reporter-go/tea_reporter.go
@@ -53,14 +53,14 @@ func (r *TeaReporter) Track(ctx context.Context, events ...Event) {
 		return
 	}
 
-	common := r.common.params()
+	common, userUniqueID := r.common.snapshot()
 	sendEvents := normalizeEvents(events, common)
 	if len(sendEvents) == 0 {
 		return
 	}
 
 	r.publishDebugEvents(ctx, sendEvents, common)
-	_ = r.sdk.Send(r.appID, r.common.userUniqueID(), sendEvents, common)
+	_ = r.sdk.Send(r.appID, userUniqueID, sendEvents, common)
 }
 
 func (r *TeaReporter) Close() error {

--- a/services/tuttid/service/account/product_summary.go
+++ b/services/tuttid/service/account/product_summary.go
@@ -76,6 +76,7 @@ func (s *Service) productSummary(ctx context.Context) (ProductSummary, error) {
 		PartialError:              remote.PartialError,
 		Links:                     links,
 	}
+	s.updateAnalyticsProductSummary(summary)
 	slog.Info("account product summary completed",
 		"event", "account.product_summary.completed",
 		"user_hash", accountLogHash(user.UserID),

--- a/services/tuttid/service/account/service.go
+++ b/services/tuttid/service/account/service.go
@@ -162,9 +162,18 @@ func (s *Service) SetAnalyticsReporter(reporter reporterservice.Reporter) {
 	s.analyticsMu.Lock()
 	s.analyticsReporter = reporter
 	s.analyticsMu.Unlock()
+	s.restoreAnalyticsIdentity()
 }
 
-func (s *Service) AnalyticsCommonParams() map[string]any {
+func (s *Service) restoreAnalyticsIdentity() {
+	session, err := s.ReadSession()
+	if err != nil || session == nil || strings.TrimSpace(session.UserID) == "" {
+		return
+	}
+	s.updateAnalyticsUser(&authbridge.UserInfo{UserID: session.UserID})
+}
+
+func (s *Service) AnalyticsContext() reporterservice.DynamicContext {
 	s.analyticsMu.RLock()
 	defer s.analyticsMu.RUnlock()
 	params := map[string]any{
@@ -184,13 +193,10 @@ func (s *Service) AnalyticsCommonParams() map[string]any {
 	if s.analyticsTier != "" {
 		params["membership_tier"] = s.analyticsTier
 	}
-	return params
-}
-
-func (s *Service) AnalyticsUserUniqueID() string {
-	s.analyticsMu.RLock()
-	defer s.analyticsMu.RUnlock()
-	return s.analyticsUserID
+	return reporterservice.DynamicContext{
+		CommonParams: params,
+		UserUniqueID: s.analyticsUserID,
+	}
 }
 
 func (s *Service) reportLogin(
@@ -212,7 +218,8 @@ func (s *Service) reportLogin(
 		"schema_version": 1,
 		"client":         "desktop",
 		"source":         "desktop_daemon",
-		"method":         "desktop_bridge",
+		"auth_method":    "desktop_bridge",
+		"auth_flow":      "desktop_bridge",
 		"stage":          stage,
 		"action":         action,
 		"result":         result,

--- a/services/tuttid/service/account/service.go
+++ b/services/tuttid/service/account/service.go
@@ -11,6 +11,7 @@ import (
 
 	authbridge "github.com/tutti-os/tutti/packages/auth/bridge-go"
 	"github.com/tutti-os/tutti/packages/commerce"
+	reporterservice "github.com/tutti-os/tutti/services/tuttid/service/reporter"
 	tuttitypes "github.com/tutti-os/tutti/services/tuttid/types"
 )
 
@@ -40,6 +41,12 @@ type Service struct {
 
 	commerceMu sync.Mutex
 	commerce   *commerce.Service
+
+	analyticsMu         sync.RWMutex
+	analyticsReporter   reporterservice.Reporter
+	analyticsUserID     string
+	analyticsMembership string
+	analyticsTier       string
 }
 
 type LoginStart struct {
@@ -63,15 +70,18 @@ func NewService(authJSONPath string) *Service {
 func (s *Service) StartLogin(ctx context.Context) (LoginStart, error) {
 	client, err := s.authClient()
 	if err != nil {
+		s.reportLogin(ctx, "", "login", "start", "failed", "auth_client_unavailable", nil)
 		return LoginStart{}, err
 	}
 	attempt, err := client.StartLogin(context.WithoutCancel(ctx))
 	if err != nil {
+		s.reportLogin(ctx, "", "login", "start", "failed", "start_failed", nil)
 		return LoginStart{}, err
 	}
 	s.mu.Lock()
 	s.attempts[attempt.ID] = attempt
 	s.mu.Unlock()
+	s.reportLogin(ctx, attempt.ID, "login", "start", "started", "", nil)
 	return LoginStart{
 		AttemptID: attempt.ID,
 		ExpiresAt: attempt.ExpiresAt.UnixMilli(),
@@ -82,18 +92,22 @@ func (s *Service) StartLogin(ctx context.Context) (LoginStart, error) {
 func (s *Service) LoginStatus(attemptID string) (authbridge.LoginStatus, error) {
 	s.mu.Lock()
 	attempt := s.attempts[strings.TrimSpace(attemptID)]
-	s.mu.Unlock()
 	if attempt == nil {
+		s.mu.Unlock()
 		return authbridge.LoginStatus{}, ErrAttemptNotFound
 	}
 	status := attempt.Status()
 	if status.Status != "pending" {
-		s.mu.Lock()
 		delete(s.attempts, attempt.ID)
-		s.mu.Unlock()
 	}
+	s.mu.Unlock()
 	if status.Status == "completed" {
+		s.updateAnalyticsUser(status.User)
+		s.reportLogin(context.Background(), attempt.ID, "login", "complete", "success", "", status.User)
 		s.notifyLoginCompleted()
+	} else if status.Status != "pending" {
+		result, errorCode := loginAnalyticsResult(status.Status)
+		s.reportLogin(context.Background(), attempt.ID, "login", "complete", result, errorCode, nil)
 	}
 	return status, nil
 }
@@ -110,7 +124,11 @@ func (s *Service) GetUserInfo(ctx context.Context) (*authbridge.UserInfo, error)
 	if err != nil {
 		return nil, err
 	}
-	return client.GetUserInfo(ctx)
+	user, err := client.GetUserInfo(ctx)
+	if err == nil {
+		s.updateAnalyticsUser(user)
+	}
+	return user, err
 }
 
 // ReadSession exposes the daemon-owned account session to trusted service
@@ -135,8 +153,129 @@ func (s *Service) Logout(ctx context.Context) error {
 	if err := client.Logout(ctx); err != nil {
 		return err
 	}
+	s.clearAnalyticsIdentity()
 	s.notifyLogoutCompleted()
 	return nil
+}
+
+func (s *Service) SetAnalyticsReporter(reporter reporterservice.Reporter) {
+	s.analyticsMu.Lock()
+	s.analyticsReporter = reporter
+	s.analyticsMu.Unlock()
+}
+
+func (s *Service) AnalyticsCommonParams() map[string]any {
+	s.analyticsMu.RLock()
+	defer s.analyticsMu.RUnlock()
+	params := map[string]any{
+		"identity_status": "anonymous",
+		"login_state":     "anonymous",
+	}
+	if s.analyticsUserID != "" {
+		params["identity_status"] = "ready"
+		params["login_state"] = "authenticated"
+		params["membership_status"] = "unknown"
+		params["membership_tier"] = "unknown"
+		params["uid"] = s.analyticsUserID
+	}
+	if s.analyticsMembership != "" {
+		params["membership_status"] = s.analyticsMembership
+	}
+	if s.analyticsTier != "" {
+		params["membership_tier"] = s.analyticsTier
+	}
+	return params
+}
+
+func (s *Service) AnalyticsUserUniqueID() string {
+	s.analyticsMu.RLock()
+	defer s.analyticsMu.RUnlock()
+	return s.analyticsUserID
+}
+
+func (s *Service) reportLogin(
+	ctx context.Context,
+	flowID string,
+	stage string,
+	action string,
+	result string,
+	errorCode string,
+	user *authbridge.UserInfo,
+) {
+	s.analyticsMu.RLock()
+	reporter := s.analyticsReporter
+	s.analyticsMu.RUnlock()
+	if reporter == nil {
+		return
+	}
+	params := map[string]any{
+		"schema_version": 1,
+		"client":         "desktop",
+		"source":         "desktop_daemon",
+		"method":         "desktop_bridge",
+		"stage":          stage,
+		"action":         action,
+		"result":         result,
+	}
+	if flowID != "" {
+		params["flow_id"] = flowID
+	}
+	if errorCode != "" {
+		params["error_code"] = errorCode
+	}
+	if user != nil && strings.TrimSpace(user.UserID) != "" {
+		params["uid"] = strings.TrimSpace(user.UserID)
+	}
+	reporter.Track(ctx, reporterservice.Event{
+		Name:   "account.login",
+		Params: params,
+	})
+}
+
+func (s *Service) updateAnalyticsUser(user *authbridge.UserInfo) {
+	if user == nil || strings.TrimSpace(user.UserID) == "" {
+		return
+	}
+	s.analyticsMu.Lock()
+	s.analyticsUserID = strings.TrimSpace(user.UserID)
+	s.analyticsMu.Unlock()
+}
+
+func (s *Service) updateAnalyticsProductSummary(summary ProductSummary) {
+	s.updateAnalyticsUser(summary.User)
+	s.analyticsMu.Lock()
+	s.analyticsMembership = string(summary.MembershipAccess)
+	s.analyticsTier = ""
+	if summary.Membership != nil {
+		if strings.TrimSpace(summary.Membership.Status) != "" {
+			s.analyticsMembership = strings.TrimSpace(summary.Membership.Status)
+		}
+		s.analyticsTier = strings.TrimSpace(summary.Membership.TierKey)
+	} else if summary.MembershipAccess == commerce.MembershipAccessFree {
+		s.analyticsTier = "free"
+	}
+	s.analyticsMu.Unlock()
+}
+
+func (s *Service) clearAnalyticsIdentity() {
+	s.analyticsMu.Lock()
+	s.analyticsUserID = ""
+	s.analyticsMembership = ""
+	s.analyticsTier = ""
+	s.analyticsMu.Unlock()
+}
+
+func loginAnalyticsResult(status string) (result string, errorCode string) {
+	switch strings.TrimSpace(status) {
+	case "expired":
+		return "expired", "attempt_expired"
+	case "cancelled":
+		return "cancelled", "user_cancelled"
+	case "failed":
+		return "failed", "authentication_failed"
+	default:
+		return "failed", "unknown_terminal_status"
+	}
 }
 
 func (s *Service) notifyLogoutCompleted() {

--- a/services/tuttid/service/account/service_test.go
+++ b/services/tuttid/service/account/service_test.go
@@ -143,7 +143,13 @@ func TestLoginStatusCompletedTriggersCallbackOnce(t *testing.T) {
 	if got := analytics.events[1].Params["result"]; got != "success" {
 		t.Fatalf("completed result = %v, want success", got)
 	}
-	if got := service.AnalyticsUserUniqueID(); got != "user-1" {
+	if got := analytics.events[1].Params["auth_method"]; got != "desktop_bridge" {
+		t.Fatalf("completed auth_method = %v, want desktop_bridge", got)
+	}
+	if got := analytics.events[1].Params["auth_flow"]; got != "desktop_bridge" {
+		t.Fatalf("completed auth_flow = %v, want desktop_bridge", got)
+	}
+	if got := service.AnalyticsContext().UserUniqueID; got != "user-1" {
 		t.Fatalf("analytics user ID = %q, want user-1", got)
 	}
 }
@@ -159,17 +165,48 @@ func TestAnalyticsCommonParamsTrackMembershipAndClearIdentity(t *testing.T) {
 		MembershipAccess: commerce.MembershipAccessActive,
 	})
 
-	params := service.AnalyticsCommonParams()
+	context := service.AnalyticsContext()
+	params := context.CommonParams
 	if params["uid"] != "user-2" || params["membership_tier"] != "pro" || params["membership_status"] != "active" {
 		t.Fatalf("analytics common params = %#v", params)
 	}
+	if context.UserUniqueID != "user-2" {
+		t.Fatalf("analytics user ID = %q, want user-2", context.UserUniqueID)
+	}
 	service.clearAnalyticsIdentity()
-	params = service.AnalyticsCommonParams()
+	context = service.AnalyticsContext()
+	params = context.CommonParams
 	if _, exists := params["uid"]; exists {
 		t.Fatalf("anonymous common params contain uid: %#v", params)
 	}
 	if params["login_state"] != "anonymous" {
 		t.Fatalf("login_state = %v, want anonymous", params["login_state"])
+	}
+	if context.UserUniqueID != "" {
+		t.Fatalf("anonymous analytics user ID = %q, want empty", context.UserUniqueID)
+	}
+}
+
+func TestSetAnalyticsReporterRestoresPersistedIdentity(t *testing.T) {
+	authPath := filepath.Join(t.TempDir(), "auth.json")
+	if err := os.WriteFile(
+		authPath,
+		[]byte(`{"session_id":"session-1","cookie":"session_id=session-1","user_id":"persisted-user"}`),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	service := NewService(authPath)
+
+	service.SetAnalyticsReporter(&recordingAccountAnalyticsReporter{})
+
+	context := service.AnalyticsContext()
+	if context.UserUniqueID != "persisted-user" {
+		t.Fatalf("analytics user ID = %q, want persisted-user", context.UserUniqueID)
+	}
+	if context.CommonParams["uid"] != "persisted-user" ||
+		context.CommonParams["login_state"] != "authenticated" {
+		t.Fatalf("analytics context = %#v", context)
 	}
 }
 

--- a/services/tuttid/service/account/service_test.go
+++ b/services/tuttid/service/account/service_test.go
@@ -16,7 +16,20 @@ import (
 
 	authbridge "github.com/tutti-os/tutti/packages/auth/bridge-go"
 	"github.com/tutti-os/tutti/packages/commerce"
+	reporterservice "github.com/tutti-os/tutti/services/tuttid/service/reporter"
 )
+
+type recordingAccountAnalyticsReporter struct {
+	events []reporterservice.Event
+}
+
+func (r *recordingAccountAnalyticsReporter) Track(_ context.Context, events ...reporterservice.Event) {
+	r.events = append(r.events, events...)
+}
+
+func (*recordingAccountAnalyticsReporter) Close() error {
+	return nil
+}
 
 func TestNewServiceReadsLocalAuthOverrides(t *testing.T) {
 	t.Setenv("TUTTI_ACCOUNT_BASE_URL", "http://127.0.0.1:1/api/account")
@@ -78,6 +91,8 @@ func TestLoginStatusCompletedTriggersCallbackOnce(t *testing.T) {
 	service := NewService(filepath.Join(t.TempDir(), "auth.json"))
 	service.AccountBaseURL = account.URL
 	service.AuthLoginURL = account.URL + "/auth/login"
+	analytics := &recordingAccountAnalyticsReporter{}
+	service.SetAnalyticsReporter(analytics)
 	var callbackCount atomic.Int32
 	done := make(chan struct{}, 1)
 	service.OnLoginCompleted = func(context.Context) {
@@ -118,6 +133,82 @@ func TestLoginStatusCompletedTriggersCallbackOnce(t *testing.T) {
 	}
 	if got := callbackCount.Load(); got != 1 {
 		t.Fatalf("callback count = %d, want 1", got)
+	}
+	if len(analytics.events) != 2 {
+		t.Fatalf("analytics events = %d, want start and completed", len(analytics.events))
+	}
+	if got := analytics.events[0].Params["stage"]; got != "login" {
+		t.Fatalf("start stage = %v, want login", got)
+	}
+	if got := analytics.events[1].Params["result"]; got != "success" {
+		t.Fatalf("completed result = %v, want success", got)
+	}
+	if got := service.AnalyticsUserUniqueID(); got != "user-1" {
+		t.Fatalf("analytics user ID = %q, want user-1", got)
+	}
+}
+
+func TestAnalyticsCommonParamsTrackMembershipAndClearIdentity(t *testing.T) {
+	service := NewService(filepath.Join(t.TempDir(), "auth.json"))
+	service.updateAnalyticsProductSummary(ProductSummary{
+		User: &authbridge.UserInfo{UserID: "user-2"},
+		Membership: &MembershipSummary{
+			Status:  "active",
+			TierKey: "pro",
+		},
+		MembershipAccess: commerce.MembershipAccessActive,
+	})
+
+	params := service.AnalyticsCommonParams()
+	if params["uid"] != "user-2" || params["membership_tier"] != "pro" || params["membership_status"] != "active" {
+		t.Fatalf("analytics common params = %#v", params)
+	}
+	service.clearAnalyticsIdentity()
+	params = service.AnalyticsCommonParams()
+	if _, exists := params["uid"]; exists {
+		t.Fatalf("anonymous common params contain uid: %#v", params)
+	}
+	if params["login_state"] != "anonymous" {
+		t.Fatalf("login_state = %v, want anonymous", params["login_state"])
+	}
+}
+
+func TestConcurrentTerminalLoginStatusReportsOnce(t *testing.T) {
+	service := NewService(filepath.Join(t.TempDir(), "auth.json"))
+	analytics := &recordingAccountAnalyticsReporter{}
+	service.SetAnalyticsReporter(analytics)
+	started, err := service.StartLogin(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	service.mu.Lock()
+	service.attempts[started.AttemptID].ExpiresAt = time.Now().Add(-time.Second)
+	service.mu.Unlock()
+
+	results := make(chan error, 2)
+	for range 2 {
+		go func() {
+			_, statusErr := service.LoginStatus(started.AttemptID)
+			results <- statusErr
+		}()
+	}
+	firstErr := <-results
+	secondErr := <-results
+	successes := 0
+	notFound := 0
+	for _, statusErr := range []error{firstErr, secondErr} {
+		switch statusErr {
+		case nil:
+			successes++
+		case ErrAttemptNotFound:
+			notFound++
+		}
+	}
+	if successes != 1 || notFound != 1 {
+		t.Fatalf("concurrent errors = %v/%v, want one success and one not found", firstErr, secondErr)
+	}
+	if len(analytics.events) != 2 {
+		t.Fatalf("analytics events = %d, want start and one terminal", len(analytics.events))
 	}
 }
 

--- a/services/tuttid/service/reporter/reporter.go
+++ b/services/tuttid/service/reporter/reporter.go
@@ -12,14 +12,14 @@ type Reporter = analyticsreporter.Reporter
 type NoopReporter = analyticsreporter.NoopReporter
 type DebugReporter = analyticsreporter.DebugReporter
 type TeaReporter = analyticsreporter.TeaReporter
+type DynamicContext = analyticsreporter.DynamicContext
 
 type Config struct {
-	Analytics            tuttitypes.AnalyticsConfig
-	DebugPublisher       DebugPublisher
-	StateDir             string
-	CommonParams         map[string]any
-	CommonParamsProvider func() map[string]any
-	UserUniqueIDProvider func() string
+	Analytics              tuttitypes.AnalyticsConfig
+	DebugPublisher         DebugPublisher
+	StateDir               string
+	CommonParams           map[string]any
+	DynamicContextProvider func() DynamicContext
 }
 
 func New(config Config) (Reporter, error) {
@@ -33,10 +33,9 @@ func New(config Config) (Reporter, error) {
 			ChannelDomain: config.Analytics.ChannelDomain,
 			AppVersion:    config.Analytics.AppVersion,
 		},
-		DebugPublisher:       config.DebugPublisher,
-		StateDir:             config.StateDir,
-		CommonParams:         config.CommonParams,
-		CommonParamsProvider: config.CommonParamsProvider,
-		UserUniqueIDProvider: config.UserUniqueIDProvider,
+		DebugPublisher:         config.DebugPublisher,
+		StateDir:               config.StateDir,
+		CommonParams:           config.CommonParams,
+		DynamicContextProvider: config.DynamicContextProvider,
 	})
 }

--- a/services/tuttid/service/reporter/reporter.go
+++ b/services/tuttid/service/reporter/reporter.go
@@ -14,9 +14,12 @@ type DebugReporter = analyticsreporter.DebugReporter
 type TeaReporter = analyticsreporter.TeaReporter
 
 type Config struct {
-	Analytics      tuttitypes.AnalyticsConfig
-	DebugPublisher DebugPublisher
-	StateDir       string
+	Analytics            tuttitypes.AnalyticsConfig
+	DebugPublisher       DebugPublisher
+	StateDir             string
+	CommonParams         map[string]any
+	CommonParamsProvider func() map[string]any
+	UserUniqueIDProvider func() string
 }
 
 func New(config Config) (Reporter, error) {
@@ -30,7 +33,10 @@ func New(config Config) (Reporter, error) {
 			ChannelDomain: config.Analytics.ChannelDomain,
 			AppVersion:    config.Analytics.AppVersion,
 		},
-		DebugPublisher: config.DebugPublisher,
-		StateDir:       config.StateDir,
+		DebugPublisher:       config.DebugPublisher,
+		StateDir:             config.StateDir,
+		CommonParams:         config.CommonParams,
+		CommonParamsProvider: config.CommonParamsProvider,
+		UserUniqueIDProvider: config.UserUniqueIDProvider,
 	})
 }

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -201,11 +201,9 @@ func (w *tuttiWiring) buildWorkspaceModule(ctx context.Context) error {
 
 	analyticsConfig := tuttitypes.ResolveAnalyticsConfig()
 	debugPublisher := resolveAnalyticsDebugPublisher(analyticsConfig, api.EventStreamService)
-	var commonParamsProvider func() map[string]any
-	var userUniqueIDProvider func() string
+	var dynamicContextProvider func() reporterservice.DynamicContext
 	if account, ok := api.AccountService.(*accountservice.Service); ok {
-		commonParamsProvider = account.AnalyticsCommonParams
-		userUniqueIDProvider = account.AnalyticsUserUniqueID
+		dynamicContextProvider = account.AnalyticsContext
 	}
 	analyticsReporter, err := reporterservice.New(reporterservice.Config{
 		Analytics:      analyticsConfig,
@@ -218,8 +216,7 @@ func (w *tuttiWiring) buildWorkspaceModule(ctx context.Context) error {
 			"environment":     tuttitypes.ResolveDefaultsFromEnv().Runtime.Env,
 			"schema_version":  1,
 		},
-		CommonParamsProvider: commonParamsProvider,
-		UserUniqueIDProvider: userUniqueIDProvider,
+		DynamicContextProvider: dynamicContextProvider,
 	})
 	if err != nil {
 		return fmt.Errorf("create analytics reporter: %w", err)

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -16,6 +16,7 @@ import (
 	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
 	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
 	tuttiserver "github.com/tutti-os/tutti/services/tuttid/server"
+	accountservice "github.com/tutti-os/tutti/services/tuttid/service/account"
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
 	agentextensionservice "github.com/tutti-os/tutti/services/tuttid/service/agentextension"
 	agentstatusservice "github.com/tutti-os/tutti/services/tuttid/service/agentstatus"
@@ -200,10 +201,25 @@ func (w *tuttiWiring) buildWorkspaceModule(ctx context.Context) error {
 
 	analyticsConfig := tuttitypes.ResolveAnalyticsConfig()
 	debugPublisher := resolveAnalyticsDebugPublisher(analyticsConfig, api.EventStreamService)
+	var commonParamsProvider func() map[string]any
+	var userUniqueIDProvider func() string
+	if account, ok := api.AccountService.(*accountservice.Service); ok {
+		commonParamsProvider = account.AnalyticsCommonParams
+		userUniqueIDProvider = account.AnalyticsUserUniqueID
+	}
 	analyticsReporter, err := reporterservice.New(reporterservice.Config{
 		Analytics:      analyticsConfig,
 		DebugPublisher: debugPublisher,
 		StateDir:       tuttitypes.DefaultStateDir(),
+		CommonParams: map[string]any{
+			"authority":       "client",
+			"business_app_id": "233749",
+			"client":          "desktop",
+			"environment":     tuttitypes.ResolveDefaultsFromEnv().Runtime.Env,
+			"schema_version":  1,
+		},
+		CommonParamsProvider: commonParamsProvider,
+		UserUniqueIDProvider: userUniqueIDProvider,
 	})
 	if err != nil {
 		return fmt.Errorf("create analytics reporter: %w", err)
@@ -314,6 +330,9 @@ func attachAnalyticsReporter(api *tuttiapi.DaemonAPI, analyticsReporter reporter
 	}
 	if service, ok := api.AgentStatusService.(*agentstatusservice.Service); ok {
 		service.AnalyticsReporter = analyticsReporter
+	}
+	if service, ok := api.AccountService.(*accountservice.Service); ok {
+		service.SetAnalyticsReporter(analyticsReporter)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Extend the daemon analytics reporter with one atomic dynamic context containing common parameters and DataFinder user identity.
- Emit the unified `account.login` start and terminal events from the desktop login bridge.
- Keep `uid`, login state, identity status, membership status and tier synchronized as common parameters.
- Restore the persisted account identity when the daemon starts, and clear it on logout.
- Atomically consume terminal login attempts so concurrent polling cannot double count successful login.
- Keep analytics best-effort and independent of the account callback.

Metric contract:

- Login success rate: distinct `flow_id` where `stage=login, action=complete, result=success` divided by distinct `flow_id` where `stage=login, action=start, result=started`.
- Daily logged-in users: distinct non-empty `uid` where `stage=login, action=complete, result=success`; dashboard timezone is `Asia/Shanghai`.

## Verification

- `go test ./packages/analytics/reporter-go/... ./services/tuttid/...` — 3387 tests passed in 90 packages.
- Targeted `go test -race` for concurrent terminal reporting and atomic identity context — 3 tests passed.
- `pnpm check:changed -- --push-ready` — 7 lanes passed.
- CI Go tests/lint, tooling checks and external PR review gate passed.
- Devin findings for non-atomic identity reads and missing durable documentation were fixed; both review threads are resolved.
- Independent subagent review completed; all Blocker/High findings were fixed and re-reviewed.

## Fallback Three Questions

- Source: the analytics dynamic-context provider and vendor transport are extension boundaries that may panic or become unavailable.
- Why can it not be fixed at that source: provider implementations and the third-party SDK are outside account state-transition ownership.
- Removal condition: remove the guards only if the Reporter contract can guarantee panic-free providers and transport calls.

## Checklist

- [x] This does not change agent lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] Setup and contributor workflow are unchanged.
- [x] README and CONTRIBUTING language are unchanged.
- [x] Durable analytics architecture and reporter documentation are updated.
- [x] I ran the lowest meaningful local checks and the affected daemon suite.
- [x] The commit is signed off with DCO.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1875" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
