### PR TITLE
refactor(agent-gui): converge desktop engine entry paths

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUIOpenSessionActivation.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUIOpenSessionActivation.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { AgentSessionEngine } from "@tutti-os/agent-activity-core";
 import type { AgentActivityRuntime } from "@tutti-os/agent-gui";
 import {
   consumeDesktopAgentGUIOpenSessionActivation,
@@ -10,6 +11,18 @@ import type {
   DesktopAgentGUINodeState,
   DesktopAgentGUIWorkbenchState
 } from "../desktopAgentGUINodeState.ts";
+
+function agentActivityRuntimeWithActivation(
+  activateSession: AgentSessionEngine["activateSession"],
+  onWorkspace?: (workspaceId: string) => void
+): Pick<AgentActivityRuntime, "getSessionEngine"> {
+  return {
+    getSessionEngine(workspaceId) {
+      onWorkspace?.(workspaceId);
+      return { activateSession } as AgentSessionEngine;
+    }
+  };
+}
 
 test("resolveDesktopAgentGUIOpenSessionActivation extracts valid open-session requests", () => {
   assert.deepEqual(
@@ -34,8 +47,9 @@ test("resolveDesktopAgentGUIOpenSessionActivation extracts valid open-session re
   );
 });
 
-test("consumeDesktopAgentGUIOpenSessionActivation activates and selects the requested session once", async () => {
+test("consumeDesktopAgentGUIOpenSessionActivation activates and selects the requested session once", () => {
   const activated: unknown[] = [];
+  const engineWorkspaceIds: string[] = [];
   const cleared: unknown[] = [];
   const handled: number[] = [];
   const openSessionRequests: unknown[] = [];
@@ -44,12 +58,15 @@ test("consumeDesktopAgentGUIOpenSessionActivation activates and selects the requ
     provider: "codex",
     lastActiveAgentSessionId: "session-1"
   };
-  const agentActivityRuntime = {
-    async activateSession(input: unknown) {
+  const agentActivityRuntime = agentActivityRuntimeWithActivation(
+    (input) => {
       activated.push(input);
-      return {};
+      return true;
+    },
+    (workspaceId) => {
+      engineWorkspaceIds.push(workspaceId);
     }
-  } as unknown as Pick<AgentActivityRuntime, "activateSession">;
+  );
 
   const consumed = consumeDesktopAgentGUIOpenSessionActivation({
     activation: {
@@ -79,8 +96,6 @@ test("consumeDesktopAgentGUIOpenSessionActivation activates and selects the requ
     }
   });
 
-  await Promise.resolve();
-
   assert.equal(consumed, true);
   assert.deepEqual(handled, [11]);
   assert.deepEqual(cleared, [{ nodeId: "node-1", sequence: 11 }]);
@@ -92,11 +107,12 @@ test("consumeDesktopAgentGUIOpenSessionActivation activates and selects the requ
   ]);
   assert.deepEqual(activated, [
     {
-      workspaceId: "workspace-1",
       agentSessionId: "session-2",
-      mode: "existing"
+      mode: "existing",
+      requestId: "workbench-open-session:workspace-1:node-1:session-2:11"
     }
   ]);
+  assert.deepEqual(engineWorkspaceIds, ["workspace-1"]);
   assert.equal(nodeState.lastActiveAgentSessionId, "session-2");
   assert.deepEqual(stateChanges, [
     {
@@ -130,11 +146,12 @@ test("consumeDesktopAgentGUIOpenSessionActivation activates and selects the requ
   assert.deepEqual(handled, [11]);
   assert.deepEqual(activated, [
     {
-      workspaceId: "workspace-1",
       agentSessionId: "session-2",
-      mode: "existing"
+      mode: "existing",
+      requestId: "workbench-open-session:workspace-1:node-1:session-2:11"
     }
   ]);
+  assert.deepEqual(engineWorkspaceIds, ["workspace-1"]);
   assert.deepEqual(openSessionRequests, [
     {
       agentSessionId: "session-2",
@@ -143,17 +160,13 @@ test("consumeDesktopAgentGUIOpenSessionActivation activates and selects the requ
   ]);
 });
 
-test("consumeDesktopAgentGUIOpenSessionActivation clears stale cross-provider targets", async () => {
+test("consumeDesktopAgentGUIOpenSessionActivation clears stale cross-provider targets", () => {
   let nodeState: DesktopAgentGUINodeState = {
     agentTargetId: "local:claude-code",
     provider: "claude-code",
     lastActiveAgentSessionId: "session-claude-1"
   };
-  const agentActivityRuntime = {
-    async activateSession() {
-      return {};
-    }
-  } as unknown as Pick<AgentActivityRuntime, "activateSession">;
+  const agentActivityRuntime = agentActivityRuntimeWithActivation(() => true);
 
   const consumed = consumeDesktopAgentGUIOpenSessionActivation({
     activation: {
@@ -175,27 +188,23 @@ test("consumeDesktopAgentGUIOpenSessionActivation clears stale cross-provider ta
     }
   });
 
-  await Promise.resolve();
-
   assert.equal(consumed, true);
   assert.equal(nodeState.lastActiveAgentSessionId, "session-codex-1");
   assert.equal(nodeState.provider, "codex");
   assert.equal(nodeState.agentTargetId, null);
 });
 
-test("consumeDesktopAgentGUIOpenSessionActivation reports activation errors after selecting the session", async () => {
-  const error = new Error("session not found");
-  const activationErrors: unknown[] = [];
+test("consumeDesktopAgentGUIOpenSessionActivation leaves rejected admission settlement to the engine", () => {
+  const activated: unknown[] = [];
   const openSessionRequests: unknown[] = [];
   let nodeState: DesktopAgentGUINodeState = {
     provider: "codex",
     lastActiveAgentSessionId: "session-1"
   };
-  const agentActivityRuntime = {
-    async activateSession() {
-      throw error;
-    }
-  } as unknown as Pick<AgentActivityRuntime, "activateSession">;
+  const agentActivityRuntime = agentActivityRuntimeWithActivation((input) => {
+    activated.push(input);
+    return false;
+  });
 
   const consumed = consumeDesktopAgentGUIOpenSessionActivation({
     activation: {
@@ -207,9 +216,6 @@ test("consumeDesktopAgentGUIOpenSessionActivation reports activation errors afte
     handledSequence: null,
     markHandled: () => {},
     nodeId: "node-1",
-    onActivationError: (input) => {
-      activationErrors.push(input);
-    },
     onOpenSessionRequest: (request) => {
       openSessionRequests.push(request);
     },
@@ -221,8 +227,6 @@ test("consumeDesktopAgentGUIOpenSessionActivation reports activation errors afte
     }
   });
 
-  await Promise.resolve();
-
   assert.equal(consumed, true);
   assert.deepEqual(openSessionRequests, [
     {
@@ -231,10 +235,11 @@ test("consumeDesktopAgentGUIOpenSessionActivation reports activation errors afte
     }
   ]);
   assert.equal(nodeState.lastActiveAgentSessionId, "missing-session");
-  assert.deepEqual(activationErrors, [
+  assert.deepEqual(activated, [
     {
       agentSessionId: "missing-session",
-      error
+      mode: "existing",
+      requestId: "workbench-open-session:workspace-1:node-1:missing-session:12"
     }
   ]);
 });

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUIOpenSessionActivation.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUIOpenSessionActivation.ts
@@ -17,15 +17,11 @@ import {
 
 export interface ConsumeDesktopAgentGUIOpenSessionActivationInput {
   activation: WorkbenchHostActivation | null;
-  agentActivityRuntime: Pick<AgentActivityRuntime, "activateSession">;
+  agentActivityRuntime: Pick<AgentActivityRuntime, "getSessionEngine">;
   clearNodeActivation?: (this: void, nodeId: string, sequence: number) => void;
   handledSequence: number | null;
   markHandled(this: void, sequence: number): void;
   nodeId: string;
-  onActivationError?(
-    this: void,
-    input: { agentSessionId: string; error: unknown }
-  ): void;
   onOpenSessionRequest?(
     this: void,
     request: { agentSessionId: string; sequence: number }
@@ -54,7 +50,6 @@ export function consumeDesktopAgentGUIOpenSessionActivation({
   handledSequence,
   markHandled,
   nodeId,
-  onActivationError,
   onOpenSessionRequest,
   onOpenSessionComposerRequest,
   onStateChange,
@@ -78,15 +73,17 @@ export function consumeDesktopAgentGUIOpenSessionActivation({
       ? composerRequest
       : null
   );
-  void agentActivityRuntime
-    .activateSession({
+  agentActivityRuntime.getSessionEngine(workspaceId).activateSession({
+    agentSessionId: request.agentSessionId,
+    mode: "existing",
+    requestId: [
+      "workbench-open-session",
       workspaceId,
-      agentSessionId: request.agentSessionId,
-      mode: "existing"
-    })
-    .catch((error: unknown) => {
-      onActivationError?.({ agentSessionId: request.agentSessionId, error });
-    });
+      nodeId,
+      request.agentSessionId,
+      request.sequence
+    ].join(":")
+  });
   updateNodeState((current) => {
     const currentAgentTargetId = current.agentTargetId?.trim() || null;
     const currentAgentTargetProvider = currentAgentTargetId

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUIOpenSessionComposerActivation.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUIOpenSessionComposerActivation.test.ts
@@ -1,20 +1,25 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { AgentSessionEngine } from "@tutti-os/agent-activity-core";
 import type { AgentActivityRuntime } from "@tutti-os/agent-gui";
 import { desktopAgentGUIOpenSessionActivationType } from "../desktopAgentGUINodeState.ts";
 import { consumeDesktopAgentGUIOpenSessionActivation } from "./desktopAgentGUIOpenSessionActivation.ts";
 import { clearDesktopAgentGUIOpenSessionComposerRequest } from "./desktopAgentGUIOpenSessionComposerActivation.ts";
 
-test("source-session activation selects the exact session and requests a non-submitting composer append", async () => {
+test("source-session activation selects the exact session and requests a non-submitting composer append", () => {
   const selected: unknown[] = [];
   const composerRequests: unknown[] = [];
   const submissions: unknown[] = [];
   const runtime = {
-    async activateSession(input: unknown) {
-      selected.push(input);
-      return {};
+    getSessionEngine() {
+      return {
+        activateSession(input: unknown) {
+          selected.push(input);
+          return true;
+        }
+      } as AgentSessionEngine;
     }
-  } as unknown as Pick<AgentActivityRuntime, "activateSession">;
+  } as Pick<AgentActivityRuntime, "getSessionEngine">;
 
   consumeDesktopAgentGUIOpenSessionActivation({
     activation: {
@@ -51,13 +56,11 @@ test("source-session activation selects the exact session and requests a non-sub
     onSubmit(request: unknown): void;
   });
 
-  await Promise.resolve();
-
   assert.deepEqual(selected, [
     {
       agentSessionId: "source-session-9",
       mode: "existing",
-      workspaceId: "workspace-1"
+      requestId: "workbench-open-session:workspace-1:node-1:source-session-9:19"
     }
   ]);
   assert.deepEqual(composerRequests, [

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityMutationOperations.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityMutationOperations.ts
@@ -81,51 +81,6 @@ export class WorkspaceAgentActivityMutationOperations {
     return session;
   }
 
-  async sendInput(
-    input: Parameters<AgentActivityAdapter["sendInput"]>[0]
-  ): ReturnType<IWorkspaceAgentActivityService["sendInput"]> {
-    const workspaceId = normalizeWorkspaceId(input.workspaceId);
-    const agentSessionId = input.agentSessionId.trim();
-    reportAgentSubmitTraceDiagnostic(this.dependencies.runtimeApi, {
-      agentSessionId,
-      clientSubmitId: input.clientSubmitId,
-      event: "activity_service.send.entered",
-      submitDiagnostics: input.submitDiagnostics,
-      workspaceId
-    });
-    const target = this.dependencies.sessionCommandTarget(workspaceId);
-    reportAgentSubmitTraceDiagnostic(this.dependencies.runtimeApi, {
-      agentSessionId,
-      clientSubmitId: input.clientSubmitId,
-      event: "activity_service.send.adapter_requested",
-      submitDiagnostics: input.submitDiagnostics,
-      workspaceId
-    });
-    const result = await target.adapter.sendInput({ ...input, workspaceId });
-    reportAgentSubmitTraceDiagnostic(this.dependencies.runtimeApi, {
-      agentSessionId,
-      clientSubmitId: input.clientSubmitId,
-      event: "activity_service.send.adapter_resolved",
-      provider: result.session.provider,
-      submitDiagnostics: input.submitDiagnostics,
-      workspaceId,
-      fields:
-        result.kind === "goalControl"
-          ? { resultKind: "goalControl" }
-          : {
-              resultKind: "turn",
-              turnOutcome: result.turn.outcome ?? null,
-              turnId: result.turnId,
-              turnPhase: result.turn.phase
-            }
-    });
-    this.dependencies.upsertAuthoritativeSession(
-      result.session,
-      "send_input_result"
-    );
-    return result;
-  }
-
   async cancelTurn(input: {
     agentSessionId: string;
     signal?: AbortSignal;

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -201,6 +201,53 @@ test("WorkspaceAgentActivityService.sendInput preserves the authoritative ready 
   assert.equal(snapshotSession?.activeTurn, null);
 });
 
+test("Desktop Engine applies send results without a host-side Session dispatch", async () => {
+  const readySession = workspaceAgentSession({ status: "ready" });
+  const observedIntentTypes: string[] = [];
+  const service = new WorkspaceAgentActivityService({
+    tuttidClient: {
+      listWorkspaceAgentSessions: async () => ({
+        hasMore: false,
+        sessions: [readySession],
+        workspaceId: "ws-1"
+      }),
+      sendWorkspaceAgentSessionInput: async () => ({
+        kind: "turn",
+        session: readySession,
+        turnId: "turn-1",
+        turn: workspaceAgentTurn({ phase: "submitted" })
+      })
+    } as unknown as TuttidClient,
+    runtimeApi: { logTerminalDiagnostic: async () => {} }
+  });
+  await service.load("ws-1");
+  service.addSessionEngineActivityObserver("ws-1", {
+    observeCommand() {},
+    observeIntent(intent) {
+      observedIntentTypes.push(intent.type);
+    }
+  });
+  const engine = service.getSessionEngine("ws-1");
+
+  assert.deepEqual(
+    engine.submitPrompt({
+      agentSessionId: "session-1",
+      clientSubmitId: "submit-1",
+      content: [{ type: "text", text: "continue" }]
+    }),
+    { accepted: true, queued: false }
+  );
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  assert.ok(observedIntentTypes.includes("submit/requested"));
+  assert.ok(observedIntentTypes.includes("engine/commandResult"));
+  assert.equal(observedIntentTypes.includes("session/upserted"), false);
+  assert.equal(
+    selectEngineTurnsForSession(engine.getSnapshot(), "session-1")[0]?.phase,
+    "submitted"
+  );
+});
+
 test("WorkspaceAgentActivityService.cancelTurn delegates the exact turn", async () => {
   const calls: unknown[][] = [];
   const controller = new AbortController();

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -657,6 +657,14 @@ export class WorkspaceAgentActivityService
   async sendInput(
     input: Parameters<AgentActivityAdapter["sendInput"]>[0]
   ): ReturnType<IWorkspaceAgentActivityService["sendInput"]> {
+    const result = await this.executeSendInputEffect(input);
+    this.upsertAuthoritativeSession(result.session, "send_input_result");
+    return result;
+  }
+
+  private async executeSendInputEffect(
+    input: Parameters<AgentActivityAdapter["sendInput"]>[0]
+  ): ReturnType<IWorkspaceAgentActivityService["sendInput"]> {
     const workspaceId = normalizeWorkspaceId(input.workspaceId);
     const agentSessionId = input.agentSessionId.trim();
     reportAgentSubmitTraceDiagnostic(this.dependencies.runtimeApi, {
@@ -695,7 +703,6 @@ export class WorkspaceAgentActivityService
               turnPhase: result.turn.phase
             }
     });
-    this.upsertAuthoritativeSession(result.session, "send_input_result");
     return result;
   }
 
@@ -1026,7 +1033,7 @@ export class WorkspaceAgentActivityService
       restorePendingSessionRecording: (workspaceId, recordingId) =>
         this.restoreNextSessionRecording(workspaceId, recordingId),
       sendInput: async (input) => {
-        const result = await this.sendInput(input);
+        const result = await this.executeSendInputEffect(input);
         this.analytics.trackEngineSend(input, result);
         return result;
       },

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -44,10 +44,7 @@ import {
   consumeDesktopAgentGUIPrefillPromptActivation,
   type DesktopAgentGUIPrefillPromptRequest
 } from "../services/desktopAgentGUIPrefillPromptActivation.ts";
-import {
-  logAgentComposerDefaultsDiagnostic,
-  stringifyDiagnosticError
-} from "./desktopAgentGUIWorkbenchDiagnostics.ts";
+import { logAgentComposerDefaultsDiagnostic } from "./desktopAgentGUIWorkbenchDiagnostics.ts";
 import {
   hasDesktopAgentGUIConversationRailCollapsedState,
   resolveDesktopAgentGUIProviderForAgentTarget
@@ -345,25 +342,6 @@ function DesktopAgentGUISurfaceImpl({
     },
     agentStatusSource
   );
-  const handleOpenSessionActivationError = useCallback(
-    (input: { agentSessionId: string; error: unknown }) => {
-      Toast.Error(
-        i18n.t("workspace.agentGui.openSessionUnavailableTitle"),
-        i18n.t("workspace.agentGui.openSessionUnavailableDescription")
-      );
-      void runtimeApi?.logTerminalDiagnostic({
-        details: {
-          agentSessionId: input.agentSessionId,
-          error: stringifyDiagnosticError(input.error)
-        },
-        event: "agent.gui.open_session_activation_failed",
-        level: "warn",
-        workspaceId
-      });
-    },
-    [i18n, runtimeApi, workspaceId]
-  );
-
   useEffect(() => {
     if (!provider) {
       return;
@@ -377,7 +355,6 @@ function DesktopAgentGUISurfaceImpl({
         handledOpenSessionActivationSequenceRef.current = sequence;
       },
       nodeId: surface.nodeId,
-      onActivationError: handleOpenSessionActivationError,
       onOpenSessionRequest: setOpenSessionRequest,
       onOpenSessionComposerRequest: setOpenSessionComposerRequest,
       // Persistence is owned by handleUpdateNode (the single writer).
@@ -397,7 +374,6 @@ function DesktopAgentGUISurfaceImpl({
     surface.activation,
     surface.host,
     surface.nodeId,
-    handleOpenSessionActivationError,
     handleUpdateNode,
     provider,
     agents,

--- a/apps/desktop/src/shared/i18n/locales/en.ts
+++ b/apps/desktop/src/shared/i18n/locales/en.ts
@@ -195,9 +195,6 @@ export const en = {
       newConversation: "New session",
       openNewWindow: "Open new window",
       untitledConversation: "Untitled conversation",
-      openSessionUnavailableDescription:
-        "This agent session no longer exists or cannot be opened.",
-      openSessionUnavailableTitle: "Session unavailable",
       sessionMenu: {
         copyAsMarkdown: "Copy as Markdown",
         copyAsReference: "Copy as reference",

--- a/apps/desktop/src/shared/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/shared/i18n/locales/zh-CN.ts
@@ -191,8 +191,6 @@ export const zhCN = {
       newConversation: "新建会话",
       openNewWindow: "打开新窗口",
       untitledConversation: "未命名对话",
-      openSessionUnavailableDescription: "这个 Agent 会话已不存在或无法打开。",
-      openSessionUnavailableTitle: "会话不可用",
       sessionMenu: {
         copyAsMarkdown: "复制为 Markdown",
         copyAsReference: "复制为引用",


### PR DESCRIPTION
## Summary

- route Desktop Workbench existing-session activation through `AgentSessionEngine.activateSession` with a stable request identity
- make the Desktop Engine send callback a transport-only effect so authoritative Session/Turn results are projected once by the Engine
- keep the direct compatibility facade authoritative for its remaining callers, and remove the unused duplicate mutation implementation
- remove the Desktop-specific activation error callback and toast now that AgentGUI renders the Engine-owned failure and retry state

## Why

Desktop still had two residual paths that bypassed or raced the shared Engine model: Workbench session activation called the runtime facade directly, and the Engine send effect pre-upserted the returned Session before the Engine processed its command result. This created dual ownership of admission, failure settlement, and canonical projection, making Desktop behavior diverge from Mobile and allowing the same state transition to be applied twice.

This change makes the Engine the single owner for Workbench activation and Engine-path send settlement while preserving the narrow direct compatibility facade for callers that still require the legacy Promise result.

## Impact

Desktop open-session requests now use the same Engine lifecycle and inline retryable failure presentation as the shared AgentGUI. Engine-originated prompt sends no longer emit a host-side `session/upserted` intent before `engine/commandResult`. Mobile is unchanged because its effect path already returns results without pre-projecting them.

## Validation

- focused Desktop activation and activity-service tests
- `pnpm check:changed` — 12 lanes passed
- pre-commit hooks passed
- pre-push `pnpm check:changed -- --push-ready` — 13 lanes passed
- architecture review — no findings

## Documentation

No durable documentation update is required: the existing AgentGUI and Agent Activity architecture documents already define semantic Engine methods as the application-write seam and prohibit host effects from pre-dispatching authoritative projections.