### PR TITLE
feat(agent-gui): add dismiss interactions for the composer mention pa…

### DIFF
--- a/.changeset/agent-mention-palette-dismiss.md
+++ b/.changeset/agent-mention-palette-dismiss.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/agent-gui": patch
+---
+
+Add natural dismiss interactions for the Agent composer `@`-mention palette: pointer interactions outside the prompt input area and the palette surface now close the palette, and a settled multi-word query with zero matching results dismisses it instead of pinning an empty panel, aligning the mention palette with the slash-command palette's dismissal contract.

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -13,6 +13,7 @@ import {
   isAgentMentionItemDisabled
 } from "./AgentFileMentionPalette";
 import { type AgentFileMentionSuggestionState } from "./agentRichText/agentFileMentionExtension";
+import { shouldDismissMentionSearchAsNonQuery } from "./agentMentionSearchHelpers";
 import { formatSlashStatusTokenCount } from "./AgentSlashStatusPanel";
 import { useOptionalAgentActivityRuntime } from "../../agentActivityRuntime";
 import { useComposerDraftAttachments } from "./composer/useComposerDraftAttachments";
@@ -319,7 +320,10 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     promptBeforeSelection
   } = paletteCatalog;
   const showFileMentionPalette =
-    !disabled && isPaletteOpen && fileMentionSuggestion !== null;
+    !disabled &&
+    isPaletteOpen &&
+    fileMentionSuggestion !== null &&
+    !shouldDismissMentionSearchAsNonQuery(mentionSearchState);
   const showSlashPalette =
     !showFileMentionPalette &&
     !disabled &&
@@ -511,6 +515,7 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     workspaceReferencePickerOpen,
     composerRef,
     paletteContentRef,
+    promptInputAreaRef,
     shouldCenterMentionHighlight
   });
   const { clearActiveFileMentionTrigger } = mentionActions;

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentMentionSearchHelpers.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentMentionSearchHelpers.spec.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { shouldDismissMentionSearchAsNonQuery } from "./agentMentionSearchHelpers";
+import type {
+  AgentMentionGroup,
+  AgentMentionSearchState
+} from "./AgentMentionSearchContracts";
+import type { AgentContextMentionItem } from "./agentRichText/agentFileMentionExtension";
+
+function createResultsState(
+  overrides: Partial<AgentMentionSearchState>
+): AgentMentionSearchState {
+  return {
+    status: "ready",
+    query: "hello world",
+    mode: "results",
+    filter: "session",
+    categories: [],
+    groups: [],
+    error: null,
+    ...overrides
+  } as AgentMentionSearchState;
+}
+
+function createGroup(
+  items: readonly AgentContextMentionItem[]
+): AgentMentionGroup {
+  return {
+    id: "my_sessions",
+    items,
+    totalCount: items.length,
+    visibleCount: items.length,
+    hasMore: false
+  };
+}
+
+const fileItem = {
+  kind: "file",
+  name: "hello world.md"
+} as AgentContextMentionItem;
+
+describe("shouldDismissMentionSearchAsNonQuery", () => {
+  it("dismisses a settled multi-word query with zero results", () => {
+    expect(
+      shouldDismissMentionSearchAsNonQuery(createResultsState({ groups: [] }))
+    ).toBe(true);
+    expect(
+      shouldDismissMentionSearchAsNonQuery(
+        createResultsState({ groups: [createGroup([])] })
+      )
+    ).toBe(true);
+  });
+
+  it("keeps a single-word miss visible so category tabs stay reachable", () => {
+    expect(
+      shouldDismissMentionSearchAsNonQuery(
+        createResultsState({ query: "zzz-no-match", groups: [] })
+      )
+    ).toBe(false);
+  });
+
+  it("keeps a multi-word query with matching results visible", () => {
+    expect(
+      shouldDismissMentionSearchAsNonQuery(
+        createResultsState({ groups: [createGroup([fileItem])] })
+      )
+    ).toBe(false);
+  });
+
+  it("never dismisses while the search is still loading", () => {
+    expect(
+      shouldDismissMentionSearchAsNonQuery(
+        createResultsState({ status: "loading", groups: [] })
+      )
+    ).toBe(false);
+  });
+
+  it("never dismisses browse mode or error states", () => {
+    expect(
+      shouldDismissMentionSearchAsNonQuery(
+        createResultsState({ mode: "browse", query: "" })
+      )
+    ).toBe(false);
+    expect(
+      shouldDismissMentionSearchAsNonQuery(
+        createResultsState({ status: "error", error: "boom" })
+      )
+    ).toBe(false);
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentMentionSearchHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentMentionSearchHelpers.ts
@@ -20,7 +20,10 @@ import type {
   AgentMentionGroup,
   AgentMentionGroupId
 } from "./AgentMentionSearchController";
-import type { AgentMentionRawGroups } from "./AgentMentionSearchContracts";
+import type {
+  AgentMentionRawGroups,
+  AgentMentionSearchState
+} from "./AgentMentionSearchContracts";
 import type {
   AgentActivityMessage,
   AgentActivitySession
@@ -359,6 +362,27 @@ export function resolveMentionGroupTotalCount(
 
 export function normalizeQuery(value: string): string {
   return value.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * A settled multi-word search with zero visible results reads as "the user
+ * typed past the mention query" (e.g. `@hello world` as plain prose), so the
+ * palette dismisses instead of pinning an empty panel over the composer —
+ * mirroring how the slash palette hides once its query stops matching.
+ * Single-word misses keep the palette open: search only covers the active
+ * filter tab, so another category may still match and tab cycling must stay
+ * reachable.
+ */
+export function shouldDismissMentionSearchAsNonQuery(
+  state: AgentMentionSearchState
+): boolean {
+  if (state.mode !== "results" || state.status !== "ready") {
+    return false;
+  }
+  if (!state.query.includes(" ")) {
+    return false;
+  }
+  return state.groups.every((group) => group.items.length === 0);
 }
 
 export function compactText(value: string | null | undefined): string {

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerChrome.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerChrome.tsx
@@ -292,13 +292,6 @@ export const EMPTY_PROVIDER_SKILLS: readonly AgentGUIProviderSkillOption[] = [];
 export const EMPTY_WORKSPACE_APP_ICONS: readonly AgentMessageMarkdownWorkspaceAppIcon[] =
   [];
 export const GOAL_MODE_SLASH_COMMAND = "/goal";
-export const MENTION_PALETTE_DISMISS_INTERACTION_SELECTOR = [
-  "[data-node-drag-handle]",
-  '[data-workbench-drag-handle="true"]',
-  ".workspace-node-window__resizer",
-  ".workbench-window__resize-handle",
-  "#agent-gui-conversation-rail-resize"
-].join(",");
 
 export function resolveComposerProviderIconUrl(
   provider: AgentGUIProvider

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerMentionActions.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerMentionActions.spec.tsx
@@ -1,0 +1,153 @@
+import { fireEvent, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useComposerMentionActions } from "./useComposerMentionActions";
+import { emptyAgentComposerDraft } from "../model/agentComposerDraft";
+import type { AgentGUIComposerSettingsVM } from "../model/agentGuiNodeTypes";
+import type { AgentMentionSearchState } from "../AgentMentionSearchController";
+
+type MentionActionsInput = Parameters<typeof useComposerMentionActions>[0];
+
+const idleSearchState: AgentMentionSearchState = {
+  status: "idle",
+  query: "",
+  mode: "browse",
+  filter: "session",
+  categories: [],
+  groups: [],
+  error: null
+};
+
+const composerSettings = {
+  sessionSettings: null,
+  draftSettings: {
+    model: null,
+    reasoningEffort: null,
+    speed: null,
+    planMode: false
+  },
+  supportsModel: false,
+  supportsReasoningEffort: false,
+  supportsSpeed: false,
+  supportsPlanMode: false,
+  isSettingsLoading: false,
+  modelUnavailable: false,
+  reasoningUnavailable: false,
+  speedUnavailable: false,
+  availableModels: [],
+  availableReasoningEfforts: [],
+  availableSpeeds: [],
+  projectLocked: false,
+  projectPathIsRemote: false
+} as unknown as AgentGUIComposerSettingsVM;
+
+function createMentionActionsInput(
+  overrides: Partial<MentionActionsInput>
+): MentionActionsInput {
+  return {
+    workspaceId: "ws-1",
+    currentUserId: "user-1",
+    selectedProjectPath: "",
+    selectedProjectSectionKey: "",
+    draftContent: emptyAgentComposerDraft(),
+    fileMentionSuggestion: null,
+    setFileMentionSuggestion: vi.fn(),
+    mentionControllerRef: { current: null },
+    editorHandleRef: { current: null },
+    draftPromptRef: { current: "" },
+    setPaletteDraftPrompt: vi.fn(),
+    setIsPaletteOpen: vi.fn(),
+    onDraftContentChange: vi.fn(),
+    showFileMentionPalette: true,
+    mentionHighlightedKey: null,
+    mentionSearchState: idleSearchState,
+    setMentionHighlightedKey: vi.fn(),
+    setShouldCenterMentionHighlight: vi.fn(),
+    setShouldResetMentionHighlightToFilter: vi.fn(),
+    autoMentionHighlightedKeyRef: { current: null },
+    composerSettings,
+    isSendingTurn: false,
+    isSubmittingPrompt: false,
+    showStopButton: false,
+    onSettingsChange: vi.fn(),
+    handleSlashPaletteKeyDown: vi.fn(() => false),
+    handleSlashCommandMenuKeyDown: vi.fn(() => false),
+    showPalette: true,
+    workspaceReferencePickerOpen: false,
+    composerRef: { current: null },
+    paletteContentRef: { current: null },
+    promptInputAreaRef: { current: null },
+    shouldCenterMentionHighlight: false,
+    ...overrides
+  };
+}
+
+function createDismissHarness() {
+  const promptInputArea = document.createElement("div");
+  const paletteSurface = document.createElement("div");
+  const outside = document.createElement("div");
+  document.body.append(promptInputArea, paletteSurface, outside);
+  const setIsPaletteOpen = vi.fn();
+  const input = createMentionActionsInput({
+    paletteContentRef: { current: paletteSurface },
+    promptInputAreaRef: { current: promptInputArea },
+    setIsPaletteOpen
+  });
+  return { input, outside, paletteSurface, promptInputArea, setIsPaletteOpen };
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("useComposerMentionActions palette dismissal", () => {
+  it("closes the palette on pointerdown outside the composer surfaces", () => {
+    const harness = createDismissHarness();
+    renderHook(() => useComposerMentionActions(harness.input));
+
+    fireEvent.pointerDown(harness.outside);
+
+    expect(harness.setIsPaletteOpen).toHaveBeenCalledWith(false);
+  });
+
+  it("keeps the palette open for pointerdown inside the palette surface", () => {
+    const harness = createDismissHarness();
+    renderHook(() => useComposerMentionActions(harness.input));
+
+    fireEvent.pointerDown(harness.paletteSurface);
+
+    expect(harness.setIsPaletteOpen).not.toHaveBeenCalled();
+  });
+
+  it("keeps the palette open for pointerdown inside the prompt input area", () => {
+    const harness = createDismissHarness();
+    renderHook(() => useComposerMentionActions(harness.input));
+
+    fireEvent.pointerDown(harness.promptInputArea);
+
+    expect(harness.setIsPaletteOpen).not.toHaveBeenCalled();
+  });
+
+  it("does not listen for outside pointerdown while the palette is hidden", () => {
+    const harness = createDismissHarness();
+    renderHook(() =>
+      useComposerMentionActions({
+        ...harness.input,
+        showFileMentionPalette: false
+      })
+    );
+
+    fireEvent.pointerDown(harness.outside);
+
+    expect(harness.setIsPaletteOpen).not.toHaveBeenCalled();
+  });
+
+  it("still closes the palette when the window resizes", () => {
+    const harness = createDismissHarness();
+    renderHook(() => useComposerMentionActions(harness.input));
+
+    fireEvent.resize(window);
+
+    expect(harness.setIsPaletteOpen).toHaveBeenCalledWith(false);
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerMentionActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerMentionActions.ts
@@ -26,7 +26,6 @@ import {
   agentMentionItemKey,
   isAgentMentionItemDisabled
 } from "../AgentFileMentionPalette";
-import { MENTION_PALETTE_DISMISS_INTERACTION_SELECTOR } from "./AgentComposerChrome";
 import { updateAgentComposerDraft } from "../model/agentComposerDraft";
 import {
   type AgentMentionFilterId,
@@ -69,6 +68,7 @@ interface Input {
   workspaceReferencePickerOpen: boolean;
   composerRef: RefObject<HTMLFormElement | null>;
   paletteContentRef: RefObject<HTMLDivElement | null>;
+  promptInputAreaRef: RefObject<HTMLDivElement | null>;
   shouldCenterMentionHighlight: boolean;
 }
 
@@ -113,6 +113,7 @@ export function useComposerMentionActions(input: Input) {
     workspaceReferencePickerOpen,
     composerRef,
     paletteContentRef,
+    promptInputAreaRef,
     shouldCenterMentionHighlight
   } = input;
   const selectFileMention = useCallback(
@@ -396,14 +397,24 @@ export function useComposerMentionActions(input: Input) {
       return;
     }
 
+    // Mirror the slash palette's ComposerFloatingMenuSurface dismissal: any
+    // pointer interaction outside the prompt input area and the palette
+    // surface closes the palette, instead of forcing Escape or a selection.
+    // The prompt input stays interactive because caret moves inside the
+    // active trigger are handled by the suggestion plugin itself.
     const handlePointerDown = (event: PointerEvent): void => {
       const target = event.target;
-      if (!(target instanceof Element)) {
+      if (!(target instanceof Node)) {
         return;
       }
-      if (target.closest(MENTION_PALETTE_DISMISS_INTERACTION_SELECTOR)) {
-        closeOpenPalette();
+      const isInsidePromptInput =
+        promptInputAreaRef.current?.contains(target) ?? false;
+      const isInsidePalette =
+        paletteContentRef.current?.contains(target) ?? false;
+      if (isInsidePromptInput || isInsidePalette) {
+        return;
       }
+      closeOpenPalette();
     };
     const handleWindowResize = (): void => {
       closeOpenPalette();


### PR DESCRIPTION
Fixes #1066

## What
- Clicking outside the @ mention palette (and the prompt input area) now dismisses it,
  mirroring the slash palette's ComposerFloatingMenuSurface dismissal boundary
- A settled multi-word query with zero results (e.g. `@hello world`) dismisses the
  palette instead of pinning an empty panel

## Design note
Mention search only covers the active filter tab, so a single-word miss keeps the
palette open — hiding it would make other category tabs unreachable via Tab cycling.
Only multi-word zero-result queries (clearly prose, not a mention query) trigger dismissal.

## Testing
- 10 new unit tests (outside-click boundaries + dismissal predicate)
- Manually verified in `make dev-gui`: outside click, `@hello world` typing,
  Esc/Enter/selection and filter cycling unchanged
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1880" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->