### PR TITLE
fix(agent-gui): replace edited retry tail in place

### DIFF
--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -304,6 +304,13 @@ newest-page anchor, drains the ascending tail, fences the read with session
 detail before and after, and retries transient projection failures while the
 event stream is connected. Reconnect rechecks every cached Session.
 
+Before that authoritative replacement completes, the edit-retry slice retains
+only the exact last-Turn fence and edited prompt. The message and pending-submit
+projections use it to discard the retracted Turn while leaving the already
+rendered prefix intact, then render the edited prompt as the new local tail.
+The fence is not an event log or history cache: the committed daemon revision
+remains the only authority and a mismatch falls back to the composite snapshot.
+
 That composite snapshot also reconciles settled optimistic submissions and
 completion attention. It removes an optimistic row only when its stable Turn
 and client-submit identity are both absent from effective history; unresolved

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -535,6 +535,13 @@ An accepted transport result enters an engine-owned `reconciling` state and
 does not overwrite canonical availability. Editing stays blocked until a
 session-detail read confirms the returned history revision and recovery state;
 Desktop must not manufacture recovery actions from the command response.
+While that confirmation is pending, the Engine keeps a Session-scoped tail
+fence for the exact retracted Turn and projects the edited prompt as its local
+replacement. Cached messages, late realtime messages, and confirmed optimistic
+submits for that Turn are all excluded by the same fence, so the old tail
+cannot flash back. This is a bounded presentation checkpoint over the retained
+prefix, not a second history authority; any identity or revision mismatch
+continues through the existing authoritative reconcile path.
 `resend_pending` and `recovery_required` are explicit recovery states rather
 than indefinite loading. GUI recovery commands delegate to Host and never
 choose whether rollback or replacement should be repeated. Completion and

--- a/packages/agent/activity-core/src/engine/editRetry.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/editRetry.reducer.test.ts
@@ -33,6 +33,14 @@ test("edit retry owns stable identity and command settlement in the engine", () 
   const command = first.commands[0];
   assert.equal(command?.type, "turn/editRetry");
   if (command?.type !== "turn/editRetry") return;
+  assert.deepEqual(first.state.editRetry.tailBySessionId["session-1"], {
+    clientOperationId: command.clientOperationId,
+    editedText: "edited",
+    operationId: null,
+    replacementTurnId: null,
+    retractedTurnId: "turn-1",
+    workspaceId: "workspace-1"
+  });
 
   const failed = rootEngineReducer(first.state, {
     commandId: command.commandId,
@@ -53,6 +61,10 @@ test("edit retry owns stable identity and command settlement in the engine", () 
   assert.equal(retryCommand?.type, "turn/editRetry");
   if (retryCommand?.type !== "turn/editRetry") return;
   assert.equal(retryCommand.clientOperationId, command.clientOperationId);
+  assert.equal(
+    failed.state.editRetry.tailBySessionId["session-1"]?.retractedTurnId,
+    "turn-1"
+  );
 
   const changed = rootEngineReducer(failed.state, {
     agentSessionId: "session-1",
@@ -107,6 +119,14 @@ test("successful edit retry waits for authoritative availability and requests re
   assert.equal(
     settled.state.editRetry.operationBySessionId["session-1"]?.status,
     "reconciling"
+  );
+  assert.equal(
+    settled.state.editRetry.tailBySessionId["session-1"]?.replacementTurnId,
+    "turn-2"
+  );
+  assert.equal(
+    settled.state.editRetry.tailBySessionId["session-1"]?.operationId,
+    "operation-1"
   );
   assert.deepEqual(settled.followUpIntents, [
     {

--- a/packages/agent/activity-core/src/engine/editRetry.reducer.ts
+++ b/packages/agent/activity-core/src/engine/editRetry.reducer.ts
@@ -8,7 +8,8 @@ import type {
   AgentActivityEditRetryAvailability,
   AgentActivityEditRetryResult,
   EditRetryOperationRecord,
-  EditRetryState
+  EditRetryState,
+  EditRetryTailPresentation
 } from "./editRetry.types.ts";
 
 const NO_COMMANDS: readonly EngineCommand[] = [];
@@ -27,7 +28,8 @@ export function createInitialEditRetryState(): EditRetryState {
   return {
     availabilityBySessionId: {},
     nextCommandSequence: 1,
-    operationBySessionId: {}
+    operationBySessionId: {},
+    tailBySessionId: {}
   };
 }
 
@@ -158,6 +160,17 @@ function requestEditRetry(
           status: "pending",
           workspaceId
         }
+      },
+      tailBySessionId: {
+        ...state.tailBySessionId,
+        [agentSessionId]: {
+          clientOperationId,
+          editedText: intent.editedText,
+          operationId: null,
+          replacementTurnId: null,
+          retractedTurnId: turnId,
+          workspaceId
+        }
       }
     }
   };
@@ -257,6 +270,15 @@ function settleCommand(
       })
     };
   }
+  const tail = state.tailBySessionId[agentSessionId];
+  const nextState = replaceOperation(state, agentSessionId, {
+    ...operation,
+    commandId: null,
+    errorCode: null,
+    errorMessage: null,
+    result,
+    status: "reconciling"
+  });
   return {
     commands: NO_COMMANDS,
     followUpIntents: [
@@ -270,14 +292,14 @@ function settleCommand(
         workspaceId
       }
     ],
-    state: replaceOperation(state, agentSessionId, {
-      ...operation,
-      commandId: null,
-      errorCode: null,
-      errorMessage: null,
-      result,
-      status: "reconciling"
-    })
+    state:
+      tail && tail.retractedTurnId === result.retractedTurnId
+        ? replaceTail(nextState, agentSessionId, {
+            ...tail,
+            operationId: result.operationId,
+            replacementTurnId: result.replacementTurnId?.trim() || null
+          })
+        : nextState
   };
 }
 
@@ -357,6 +379,20 @@ function replaceOperation(
   };
 }
 
+function replaceTail(
+  state: EditRetryState,
+  agentSessionId: string,
+  tail: EditRetryTailPresentation
+): EditRetryState {
+  return {
+    ...state,
+    tailBySessionId: {
+      ...state.tailBySessionId,
+      [agentSessionId]: tail
+    }
+  };
+}
+
 function removeSession(
   state: EditRetryState,
   rawAgentSessionId: string
@@ -364,17 +400,25 @@ function removeSession(
   const agentSessionId = rawAgentSessionId.trim();
   if (
     !state.availabilityBySessionId[agentSessionId] &&
-    !state.operationBySessionId[agentSessionId]
+    !state.operationBySessionId[agentSessionId] &&
+    !state.tailBySessionId[agentSessionId]
   ) {
     return unchanged(state);
   }
   const availabilityBySessionId = { ...state.availabilityBySessionId };
   const operationBySessionId = { ...state.operationBySessionId };
+  const tailBySessionId = { ...state.tailBySessionId };
   delete availabilityBySessionId[agentSessionId];
   delete operationBySessionId[agentSessionId];
+  delete tailBySessionId[agentSessionId];
   return {
     commands: NO_COMMANDS,
-    state: { ...state, availabilityBySessionId, operationBySessionId }
+    state: {
+      ...state,
+      availabilityBySessionId,
+      operationBySessionId,
+      tailBySessionId
+    }
   };
 }
 

--- a/packages/agent/activity-core/src/engine/editRetry.selectors.ts
+++ b/packages/agent/activity-core/src/engine/editRetry.selectors.ts
@@ -1,6 +1,7 @@
 import type { AgentSessionEngineState } from "./types.ts";
 import type {
   AgentActivityEditRetryAvailability,
+  EditRetryTailPresentation,
   EditRetryOperationRecord
 } from "./editRetry.types.ts";
 
@@ -49,6 +50,14 @@ export function selectEditRetryAvailabilityIsNewer(
     editRetryRecoveryRank(current.recoveryState) >
     editRetryRecoveryRank(incoming.recoveryState)
   );
+}
+
+export function selectSessionEditRetryTailPresentation(
+  state: AgentSessionEngineState,
+  agentSessionId: string | null | undefined
+): EditRetryTailPresentation | null {
+  const normalized = agentSessionId?.trim() ?? "";
+  return state.editRetry.tailBySessionId[normalized] ?? null;
 }
 
 export function editRetryPresentationRecordsEqual(

--- a/packages/agent/activity-core/src/engine/editRetry.types.ts
+++ b/packages/agent/activity-core/src/engine/editRetry.types.ts
@@ -76,12 +76,29 @@ export interface EditRetryOperationRecord {
   workspaceId: string | null;
 }
 
+/**
+ * A bounded local projection of the committed-history replacement that an
+ * edit retry is driving. It is deliberately scoped to the last Turn: the
+ * canonical history remains the daemon's authority, while this fence prevents
+ * a cached or late projection of the retracted tail from flashing back into
+ * the conversation before normal reconciliation observes the replacement.
+ */
+export interface EditRetryTailPresentation {
+  clientOperationId: string;
+  editedText: string;
+  operationId: string | null;
+  replacementTurnId: string | null;
+  retractedTurnId: string;
+  workspaceId: string;
+}
+
 export interface EditRetryState {
   availabilityBySessionId: Readonly<
     Record<string, AgentActivityEditRetryAvailability>
   >;
   nextCommandSequence: number;
   operationBySessionId: Readonly<Record<string, EditRetryOperationRecord>>;
+  tailBySessionId: Readonly<Record<string, EditRetryTailPresentation>>;
 }
 
 export interface EditRetryAvailabilityReceivedIntent {

--- a/packages/agent/activity-core/src/engine/pendingIntents.selectors.test.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.selectors.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createInitialAgentSessionEngineState } from "./rootReducer.ts";
+import { selectPendingSubmitsForSession } from "./pendingIntents.selectors.ts";
+
+test("does not reproject a confirmed submit from the retracted edit-retry tail", () => {
+  const state = createInitialAgentSessionEngineState();
+  state.editRetry = {
+    ...state.editRetry,
+    tailBySessionId: {
+      "session-1": {
+        clientOperationId: "client-operation-1",
+        editedText: "replacement",
+        operationId: null,
+        replacementTurnId: null,
+        retractedTurnId: "turn-retracted",
+        workspaceId: "workspace-1"
+      }
+    }
+  };
+  state.pendingIntents = {
+    ...state.pendingIntents,
+    submitsByClientSubmitId: {
+      "submit-retracted": submit("submit-retracted", "turn-retracted"),
+      "submit-before": submit("submit-before", "turn-before")
+    }
+  };
+
+  assert.deepEqual(
+    selectPendingSubmitsForSession(state, "session-1").map(
+      (record) => record.clientSubmitId
+    ),
+    ["submit-before"]
+  );
+});
+
+test("keeps a turnless pending submit when no edit-retry tail is active", () => {
+  const state = createInitialAgentSessionEngineState();
+  state.pendingIntents = {
+    ...state.pendingIntents,
+    submitsByClientSubmitId: {
+      "submit-turnless": submit("submit-turnless", " ")
+    }
+  };
+
+  assert.deepEqual(
+    selectPendingSubmitsForSession(state, "session-1").map(
+      (record) => record.clientSubmitId
+    ),
+    ["submit-turnless"]
+  );
+});
+
+function submit(clientSubmitId: string, turnId: string) {
+  return {
+    acceptedSessionVersion: 1,
+    agentSessionId: "session-1",
+    clientSubmitId,
+    content: [{ type: "text" as const, text: clientSubmitId }],
+    errorCode: null,
+    errorMessage: null,
+    expiresAtUnixMs: 2,
+    requestedAtUnixMs: 1,
+    status: "confirmed" as const,
+    turnId,
+    workspaceId: "workspace-1"
+  };
+}

--- a/packages/agent/activity-core/src/engine/pendingIntents.selectors.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.selectors.ts
@@ -4,6 +4,7 @@ import type {
   PendingSubmitIntentRecord
 } from "./pendingIntents.types.ts";
 import { canonicalTurnKey } from "./sessionEntityKeys.ts";
+import { selectSessionEditRetryTailPresentation } from "./editRetry.selectors.ts";
 
 export function selectPendingActivations(
   state: AgentSessionEngineState
@@ -37,9 +38,15 @@ export function selectPendingSubmitsForSession(
   agentSessionId: string | null | undefined
 ): readonly PendingSubmitIntentRecord[] {
   const id = agentSessionId?.trim() ?? "";
+  const retractedTurnId =
+    selectSessionEditRetryTailPresentation(state, id)?.retractedTurnId ?? "";
   const matches = Object.values(
     state.pendingIntents.submitsByClientSubmitId
-  ).filter((pending) => pending.agentSessionId === id);
+  ).filter(
+    (pending) =>
+      pending.agentSessionId === id &&
+      (!retractedTurnId || pending.turnId?.trim() !== retractedTurnId)
+  );
   return matches.length > 0 ? matches : EMPTY_PENDING_SUBMITS;
 }
 

--- a/packages/agent/activity-core/src/engine/rootReducer.ts
+++ b/packages/agent/activity-core/src/engine/rootReducer.ts
@@ -421,6 +421,11 @@ export function rootEngineReducer(
     intent,
     {
       previousSessionsById: state.sessionLifecycle.sessionsById,
+      retractedTurnIdsBySessionId: Object.fromEntries(
+        Object.entries(editRetry.state.tailBySessionId).map(
+          ([sessionId, tail]) => [sessionId, tail.retractedTurnId]
+        )
+      ),
       sessionsById: sessionLifecycle.state.sessionsById
     }
   );

--- a/packages/agent/activity-core/src/engine/sessionMessages.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionMessages.reducer.test.ts
@@ -37,6 +37,11 @@ const context: SessionMessagesReducerContext = {
   }
 };
 
+const retractedContext: SessionMessagesReducerContext = {
+  ...context,
+  retractedTurnIdsBySessionId: { "session-1": "turn-retracted" }
+};
+
 test("merges messages into the canonical session bucket", () => {
   const state = sessionMessagesReducer(
     createInitialSessionMessagesState(),
@@ -49,6 +54,59 @@ test("merges messages into the canonical session bucket", () => {
   assert.deepEqual(
     state.messagesBySessionId["session-1"]?.map((item) => item.messageId),
     ["m1"]
+  );
+});
+
+test("tail rewind drops the retracted Turn and rejects its late message", () => {
+  let state = sessionMessagesReducer(
+    createInitialSessionMessagesState(),
+    {
+      type: "message/snapshotReceived",
+      messages: [
+        message({
+          messageId: "before",
+          agentSessionId: "session-1",
+          turnId: "turn-before"
+        }),
+        message({
+          messageId: "retracted",
+          agentSessionId: "session-1",
+          turnId: "turn-retracted",
+          version: 2
+        })
+      ]
+    },
+    context
+  ).state;
+  state = sessionMessagesReducer(
+    state,
+    {
+      agentSessionId: "session-1",
+      editedText: "replacement",
+      turnId: "turn-retracted",
+      type: "editRetry/requested",
+      workspaceId: "workspace-1"
+    },
+    retractedContext
+  ).state;
+  state = sessionMessagesReducer(
+    state,
+    {
+      type: "message/snapshotReceived",
+      messages: [
+        message({
+          messageId: "late-retracted",
+          agentSessionId: "session-1",
+          turnId: "turn-retracted",
+          version: 3
+        })
+      ]
+    },
+    retractedContext
+  ).state;
+  assert.deepEqual(
+    state.messagesBySessionId["session-1"]?.map((item) => item.messageId),
+    ["before"]
   );
 });
 

--- a/packages/agent/activity-core/src/engine/sessionMessages.reducer.ts
+++ b/packages/agent/activity-core/src/engine/sessionMessages.reducer.ts
@@ -25,6 +25,9 @@ export interface SessionMessagesReducerContext {
   previousSessionsById?: Readonly<
     Record<string, SessionMessagesSessionIdentity>
   >;
+  retractedTurnIdsBySessionId?: Readonly<
+    Record<string, string | null | undefined>
+  >;
   sessionsById: Readonly<Record<string, SessionMessagesSessionIdentity>>;
 }
 
@@ -62,9 +65,15 @@ export function sessionMessagesReducer(
         intent.messages,
         intent.sessionMessageWindows ?? []
       );
+    case "editRetry/requested":
+      return removeRetractedTurnMessages(state, context, intent.agentSessionId);
     case "session/snapshotReceived":
     case "session/upserted":
-      return canonicalizeSessionBuckets(state, context.sessionsById);
+      return canonicalizeSessionBuckets(
+        state,
+        context.sessionsById,
+        context.retractedTurnIdsBySessionId
+      );
     case "session/removed":
       return dropSessionBuckets(
         state,
@@ -88,7 +97,11 @@ function replaceSessionMessages(
     rawAgentSessionId
   );
   if (!canonicalAgentSessionId) return unchanged(state);
-  const replacement = canonicalizeMessages(messages, canonicalAgentSessionId);
+  const replacement = canonicalizeMessages(
+    messages,
+    canonicalAgentSessionId,
+    retractedTurnId(context, canonicalAgentSessionId)
+  );
   const current = state.messagesBySessionId[canonicalAgentSessionId] ?? [];
   const windowsBySessionId = window
     ? mergeSessionMessageWindow(state.windowsBySessionId, context, window)
@@ -215,12 +228,20 @@ function mergeSessionMessages(
     aliasMessages.length > 0
       ? mergeAgentActivityMessages(
           currentMessages,
-          canonicalizeMessages(aliasMessages, canonicalAgentSessionId)
+          canonicalizeMessages(
+            aliasMessages,
+            canonicalAgentSessionId,
+            retractedTurnId(context, canonicalAgentSessionId)
+          )
         )
       : currentMessages;
   const mergedMessages = mergeAgentActivityMessages(
     currentCanonicalMessages,
-    canonicalizeMessages(messages, canonicalAgentSessionId)
+    canonicalizeMessages(
+      messages,
+      canonicalAgentSessionId,
+      retractedTurnId(context, canonicalAgentSessionId)
+    )
   );
   if (areAgentActivityMessageArraysEqual(currentMessages, mergedMessages)) {
     return hasAliasBucket
@@ -239,7 +260,8 @@ function mergeSessionMessages(
 
 function canonicalizeSessionBuckets(
   state: SessionMessagesState,
-  sessionsById: Readonly<Record<string, SessionMessagesSessionIdentity>>
+  sessionsById: Readonly<Record<string, SessionMessagesSessionIdentity>>,
+  retractedTurnIdsBySessionId: SessionMessagesReducerContext["retractedTurnIdsBySessionId"]
 ): EngineReducerResult<SessionMessagesState> {
   let nextMessages = state.messagesBySessionId;
   for (const [rawAgentSessionId, messages] of Object.entries(
@@ -257,7 +279,11 @@ function canonicalizeSessionBuckets(
     }
     const merged = mergeAgentActivityMessages(
       nextMessages[canonicalAgentSessionId] ?? [],
-      canonicalizeMessages(messages, canonicalAgentSessionId)
+      canonicalizeMessages(
+        messages,
+        canonicalAgentSessionId,
+        retractedTurnIdsBySessionId?.[canonicalAgentSessionId]?.trim() ?? ""
+      )
     );
     nextMessages = deleteBucket(
       {
@@ -297,6 +323,31 @@ function canonicalizeSessionBuckets(
         messagesBySessionId: nextMessages,
         windowsBySessionId: nextWindows
       });
+}
+
+function removeRetractedTurnMessages(
+  state: SessionMessagesState,
+  context: SessionMessagesReducerContext,
+  rawAgentSessionId: string
+): EngineReducerResult<SessionMessagesState> {
+  const agentSessionId = resolveCanonicalAgentSessionId(
+    context.sessionsById,
+    rawAgentSessionId
+  );
+  const turnId = retractedTurnId(context, agentSessionId);
+  const current = state.messagesBySessionId[agentSessionId];
+  if (!agentSessionId || !turnId || !current) return unchanged(state);
+  const messages = current.filter(
+    (message) => message.turnId?.trim() !== turnId
+  );
+  if (messages.length === current.length) return unchanged(state);
+  return changed({
+    ...state,
+    messagesBySessionId: {
+      ...state.messagesBySessionId,
+      [agentSessionId]: messages
+    }
+  });
 }
 
 function dropSessionBuckets(
@@ -371,13 +422,23 @@ export function resolveCanonicalAgentSessionId(
 
 function canonicalizeMessages(
   messages: readonly AgentActivityMessage[],
-  agentSessionId: string
+  agentSessionId: string,
+  retractedTurnId = ""
 ): AgentActivityMessage[] {
-  return messages.map((message) =>
-    message.agentSessionId === agentSessionId
-      ? message
-      : { ...message, agentSessionId }
-  );
+  return messages
+    .filter((message) => message.turnId?.trim() !== retractedTurnId)
+    .map((message) =>
+      message.agentSessionId === agentSessionId
+        ? message
+        : { ...message, agentSessionId }
+    );
+}
+
+function retractedTurnId(
+  context: SessionMessagesReducerContext,
+  agentSessionId: string
+): string {
+  return context.retractedTurnIdsBySessionId?.[agentSessionId]?.trim() ?? "";
 }
 
 function deleteBucket<T>(

--- a/packages/agent/activity-core/src/index.ts
+++ b/packages/agent/activity-core/src/index.ts
@@ -103,6 +103,7 @@ export {
   editRetryPresentationRecordsEqual,
   selectEditRetryAvailabilityIsNewer,
   selectEditRetryPresentation,
+  selectSessionEditRetryTailPresentation,
   type EditRetryPresentationRecord
 } from "./engine/editRetry.selectors.ts";
 export {
@@ -122,6 +123,7 @@ export type {
   EditRetryOperationRecord,
   EditRetryOperationStatus,
   EditRetryState,
+  EditRetryTailPresentation,
   TurnEditRetryCommand,
   TurnRecoverEditRetryCommand
 } from "./engine/editRetry.types.ts";

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIActiveMessages.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIActiveMessages.spec.tsx
@@ -1,6 +1,7 @@
 import { renderHook } from "@testing-library/react";
 import type {
   AgentActivityMessage,
+  EditRetryTailPresentation,
   PendingActivationIntentRecord
 } from "@tutti-os/agent-activity-core";
 import { describe, expect, it } from "vitest";
@@ -17,6 +18,7 @@ describe("useAgentGUIActiveMessages", () => {
     const { result } = renderHook(() =>
       useAgentGUIActiveMessages({
         activeConversationId: "session-1",
+        editRetryTail: null,
         activePendingActivation: activation({ initialPromptRetracted: true }),
         activePendingSubmits: [],
         activeQueuedPrompts: [],
@@ -33,6 +35,7 @@ describe("useAgentGUIActiveMessages", () => {
     const { result } = renderHook(() =>
       useAgentGUIActiveMessages({
         activeConversationId: "session-1",
+        editRetryTail: null,
         activePendingActivation: activation({
           initialPromptRetracted: false
         }),
@@ -50,7 +53,46 @@ describe("useAgentGUIActiveMessages", () => {
       clientSubmitId: "initial-submit"
     });
   });
+
+  it("replaces the retracted tail with the edited optimistic prompt", () => {
+    const { result } = renderHook(() =>
+      useAgentGUIActiveMessages({
+        activeConversationId: "session-1",
+        activePendingActivation: null,
+        activePendingSubmits: [],
+        activeQueuedPrompts: [],
+        currentUserId: "user-1",
+        editRetryTail: tail(),
+        storedMessages: [
+          message("before", "before-submit", "turn-before"),
+          message("retracted", "old-submit", "turn-retracted")
+        ],
+        workspaceId: "workspace-1"
+      })
+    );
+
+    expect(result.current.activeMessages).toHaveLength(2);
+    expect(result.current.activeMessages.map((item) => item.turnId)).toEqual([
+      "turn-before",
+      "pending:edit-retry:operation-1"
+    ]);
+    expect(result.current.activeMessages[1]?.payload).toMatchObject({
+      clientSubmitId: "edit-retry:operation-1",
+      text: "edited prompt"
+    });
+  });
 });
+
+function tail(): EditRetryTailPresentation {
+  return {
+    clientOperationId: "operation-1",
+    editedText: "edited prompt",
+    operationId: null,
+    replacementTurnId: null,
+    retractedTurnId: "turn-retracted",
+    workspaceId: "workspace-1"
+  };
+}
 
 function activation(
   patch: Partial<NewPendingActivationIntentRecord>
@@ -78,7 +120,8 @@ function activation(
 
 function message(
   messageId: string,
-  clientSubmitId: string
+  clientSubmitId: string,
+  turnId = "replacement-turn"
 ): AgentActivityMessage {
   return {
     agentSessionId: "session-1",
@@ -87,7 +130,7 @@ function message(
     occurredAtUnixMs: 2,
     payload: { clientSubmitId, text: "replacement prompt" },
     role: "user",
-    turnId: "replacement-turn",
+    turnId,
     version: 1,
     workspaceId: "workspace-1"
   };

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIActiveMessages.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIActiveMessages.ts
@@ -3,6 +3,7 @@ import {
   selectLatestActivationForSession,
   selectPendingSubmitsForSession,
   type AgentActivityMessage,
+  type EditRetryTailPresentation,
   type EngineQueuedPrompt
 } from "@tutti-os/agent-activity-core";
 import { useMemo } from "react";
@@ -16,6 +17,7 @@ import {
 
 export function useAgentGUIActiveMessages(input: {
   activeConversationId: string | null;
+  editRetryTail: EditRetryTailPresentation | null;
   activePendingActivation: ReturnType<typeof selectLatestActivationForSession>;
   activePendingSubmits: ReturnType<typeof selectPendingSubmitsForSession>;
   activeQueuedPrompts: readonly EngineQueuedPrompt[];
@@ -25,6 +27,7 @@ export function useAgentGUIActiveMessages(input: {
 }) {
   const {
     activeConversationId,
+    editRetryTail,
     activePendingActivation,
     activePendingSubmits,
     activeQueuedPrompts,
@@ -34,6 +37,11 @@ export function useAgentGUIActiveMessages(input: {
   } = input;
   const activeMessages = useMemo(() => {
     if (!activeConversationId) return storedMessages;
+    const durableMessages = editRetryTail
+      ? storedMessages.filter(
+          (message) => message.turnId?.trim() !== editRetryTail.retractedTurnId
+        )
+      : storedMessages;
     const visibleQueuedSubmitIds = new Set(
       activeQueuedPrompts
         .map((prompt) =>
@@ -95,14 +103,47 @@ export function useAgentGUIActiveMessages(input: {
               workspaceId
             })
         : null;
+    const replacementClientSubmitId = editRetryTail
+      ? `edit-retry:${editRetryTail.operationId ?? editRetryTail.clientOperationId}`
+      : null;
+    const replacementAlreadyDurable = replacementClientSubmitId
+      ? durableMessages.some(
+          (message) =>
+            message.payload?.clientSubmitId === replacementClientSubmitId ||
+            (editRetryTail?.replacementTurnId !== null &&
+              message.turnId === editRetryTail?.replacementTurnId)
+        )
+      : false;
+    const latestOccurredAtUnixMs = durableMessages.reduce(
+      (latest, message) => Math.max(latest, message.occurredAtUnixMs),
+      0
+    );
+    const replacementMessage =
+      editRetryTail && replacementClientSubmitId && !replacementAlreadyDurable
+        ? createOptimisticPromptMessage({
+            agentSessionId: activeConversationId,
+            clientSubmitId: replacementClientSubmitId,
+            content: [{ type: "text", text: editRetryTail.editedText }],
+            occurredAtUnixMs: latestOccurredAtUnixMs + 1,
+            turnId:
+              editRetryTail.replacementTurnId ??
+              createPendingOptimisticTurnId(replacementClientSubmitId),
+            userId: currentUserId?.trim() || "user",
+            workspaceId
+          })
+        : null;
     const optimisticMessages = pendingActivationMessage
       ? [...pendingMessages, pendingActivationMessage]
       : pendingMessages;
-    return optimisticMessages.length > 0
-      ? mergeWorkspaceAgentMessages(storedMessages, optimisticMessages)
-      : storedMessages;
+    const mergedOptimisticMessages = replacementMessage
+      ? [...optimisticMessages, replacementMessage]
+      : optimisticMessages;
+    return mergedOptimisticMessages.length > 0
+      ? mergeWorkspaceAgentMessages(durableMessages, mergedOptimisticMessages)
+      : durableMessages;
   }, [
     activeConversationId,
+    editRetryTail,
     activePendingActivation,
     activePendingSubmits,
     activeQueuedPrompts,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -237,6 +237,7 @@ export function useAgentGUINodeController({
   });
   const {
     activeEngineSession,
+    activeEditRetryTail,
     activePendingActivation,
     activePendingSubmits,
     activeQueuedPrompts,
@@ -356,6 +357,7 @@ export function useAgentGUINodeController({
     : EMPTY_AGENT_GUI_MESSAGES;
   const { activeMessages, activeTimelineItems } = useAgentGUIActiveMessages({
     activeConversationId,
+    editRetryTail: activeEditRetryTail,
     activePendingActivation,
     activePendingSubmits,
     activeQueuedPrompts,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionEngineState.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionEngineState.ts
@@ -21,6 +21,7 @@ import {
   selectLatestActivationForSession,
   selectLatestPendingSubmitForSession,
   selectPendingSubmitsForSession,
+  selectSessionEditRetryTailPresentation,
   selectSessionHasUnconfirmedSubmit,
   selectSessionIsSubmitting,
   type AgentSessionEngine,
@@ -62,6 +63,9 @@ export function useAgentGUISessionEngineState(input: {
     sessionEngine,
     (state) => selectPendingSubmitsForSession(state, activeConversationId),
     pendingSubmitRecordListsEqual
+  );
+  const activeEditRetryTail = useEngineSelector(sessionEngine, (state) =>
+    selectSessionEditRetryTailPresentation(state, activeConversationId)
   );
   const activeLatestPendingSubmit = useEngineSelector(sessionEngine, (state) =>
     selectLatestPendingSubmitForSession(state, activeConversationId)
@@ -211,6 +215,7 @@ export function useAgentGUISessionEngineState(input: {
     activeEngineRuntimeAvailability,
     activeEngineSession,
     activeEngineSessionDeleted,
+    activeEditRetryTail,
     activeLatestPendingSubmit,
     activePendingActivation,
     activePendingSubmits,


### PR DESCRIPTION
## Summary

- replace the edited last Turn in place instead of rendering the retracted prompt beside its replacement
- retain the already projected conversation prefix and add a bounded, Session-scoped edit-retry tail fence
- prevent cached messages, late realtime messages, and confirmed pending submits from reviving the retracted Turn
- render the edited prompt optimistically until the canonical replacement Turn arrives

## Problem

After editing the latest Turn `A` to `C`, the daemon's effective history no longer treats `A` as active. The renderer could still display both `A` and `C`, however, because cached activity messages and the confirmed pending-submit projection could independently reintroduce `A`.

The resulting UI was:

```text
B + A + C
```

instead of:

```text
B + C
```

## Approach

The Activity Engine now retains one bounded tail presentation per Session:

- the exact retracted Turn id
- the edited prompt
- the client operation id
- the Host operation and replacement Turn ids once known

Message and pending-submit projections use the same fence to exclude `A`. AgentGUI reuses the retained `B` prefix and appends an optimistic `C`. Once canonical `C` is present, the optimistic row is deduplicated by the Host operation identity or replacement Turn identity.

The fence remains after success so a delayed projection of `A` cannot flash back. It is bounded to one record per Session, replaced by the next edit retry, and removed with the Session.

## Authority and recovery boundary

This change does not introduce a new daemon protocol or a second history authority. Tutti's effective history and the existing composite authoritative reconcile remain canonical. The immediate UI path reuses the local prefix and does not reload old history; identity or revision mismatches still converge through the existing authoritative reconcile path.

This focused follow-up does not add an inline failure-retry control to the optimistic `C` row. It also does not address model KV-cache restoration, provider prefill behavior, or arbitrary historical branching.

## Validation

- `pnpm test:ts -- --packages-json '["@tutti-os/agent-activity-core"]'`
- `pnpm --filter @tutti-os/agent-gui exec vitest run agent-gui/agentGuiNode/controller/useAgentGUIActiveMessages.spec.tsx --reporter=verbose`
- `pnpm --filter @tutti-os/agent-activity-core typecheck`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready` (51 lanes)
- `git diff --check`

Regression coverage includes:

- confirmed pending submits for `A` do not reappear
- turnless pending submits remain visible without an active fence
- cached and late messages for `A` are rejected
- AgentGUI replaces `A` with optimistic `C`

## Documentation

Updated the Agent Activity package and AgentGUI architecture documents with the bounded tail-fence data flow and authority boundary.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1884" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->