### PR TITLE
fix(agent): neutralize durable edit-retry to stop boot crash loop

### DIFF
--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -290,8 +290,10 @@ incomplete`, while a newly created session can still launch.
   marks it failed AND clears the session's effective-history fence back to `ready`
   so the conversation can still send — and returns non-fatally, so existing poison
   pills self-heal on the next boot. New edit-retries are refused at the entry
-  points. The durable rule: never let one runtime operation's error abort daemon
-  startup.
+  points. Sessions fenced before the neutralization (owning operation already
+  failed, so recovery cannot see it) self-heal at the send gate: the first send
+  clears an abandoned fence instead of rejecting. The durable rule: never let one
+  runtime operation's error abort daemon startup.
 - **Rescue:** For an install that cannot update yet, quit Tutti and run
   `tools/scripts/rescue-edit-retry-poison-pill.sh`, which quarantines the stuck
   rows and clears the session fence in `~/.tutti/tuttid.db` after backing it up.

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -268,6 +268,38 @@ incomplete`, while a newly created session can still launch.
   failure, second-scan non-duplication, and outcome-write failure stopping
   startup.
 
+### A stuck edit-and-retry operation crashes the daemon on every launch
+
+- **Symptom:** After updating, `tuttid` exits immediately on every launch and the
+  desktop reports `tuttid exited before it published its listener info`; the daemon
+  log shows `recover agent host: process runtime operation <id>: agent session not
+  found` (or `... agent history was rolled back but the edited turn still needs to
+  be resent`). The app never opens.
+- **Quick checks:** Look for a durable `edit_retry` runtime operation stuck at the
+  `resend_pending` checkpoint — the last Turn was rolled back on the provider but
+  the replacement was never re-sent. While the daemon runs, the live worker only
+  logs this at 1 Hz; the fatality appears only on the next cold restart. The
+  affected session's `workspace_agent_session_history.recovery_state` is fenced
+  (non-`ready`).
+- **Root cause:** The cold-recovery pass (`RecoverRuntimeOperations`) treats a
+  per-operation error as fatal to `build tuttid server`, so a persisted edit-retry
+  operation that can never make progress becomes a boot poison pill. The live
+  worker tolerates the same error, which is why the app worked until the restart.
+- **Fix:** Durable edit-and-retry is disabled (`Config.EditRetryDisabled`, set in
+  production wiring). Recovery quarantines any leftover `edit_retry` operation —
+  marks it failed AND clears the session's effective-history fence back to `ready`
+  so the conversation can still send — and returns non-fatally, so existing poison
+  pills self-heal on the next boot. New edit-retries are refused at the entry
+  points. The durable rule: never let one runtime operation's error abort daemon
+  startup.
+- **Rescue:** For an install that cannot update yet, quit Tutti and run
+  `tools/scripts/rescue-edit-retry-poison-pill.sh`, which quarantines the stuck
+  rows and clears the session fence in `~/.tutti/tuttid.db` after backing it up.
+- **Validation:** `packages/agent/host/edit_retry_disabled_test.go` builds a
+  genuinely stuck operation, asserts enabled recovery is boot-fatal, and asserts
+  the disabled path quarantines it, returns nil, and leaves the session at
+  `recovery_state = ready`.
+
 ### Many stopped Tutti Mode conversations start again when the app opens
 
 - **Symptom:** Starting the desktop app makes several old Tutti Mode source

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -98,6 +98,17 @@ algorithm. Startup and steady-state workers process fences before ordinary
 Goal operations; otherwise a prepared revoked Goal could be replayed during
 recovery before its fence reached the runtime.
 
+> **Currently disabled.** Durable edit-and-retry is neutralized in production via
+> `Config.EditRetryDisabled`: its saga can strand a session in a rolled-back-but-
+> not-resent state whose runtime operation becomes a cold-recovery poison pill
+> that crashes `tuttid` on launch. While disabled, `GetEditRetryAvailability`
+> reports unsupported, `EditRetry`/`RecoverEditRetry` refuse, and recovery
+> quarantines any leftover operation (failing it and clearing the session's
+> history fence back to `ready`). Re-enable only once the resend/recovery gap is
+> fixed. See the troubleshooting entry "A stuck edit-and-retry operation crashes
+> the daemon on every launch". The behavior below describes the feature when
+> enabled.
+
 A completed latest user Turn may be edited and retried only through
 `GetEditRetryAvailability`, `EditRetry`, and `RecoverEditRetry`. Host owns the
 complete lifecycle: it snapshots the lossless submitted content, serializes the

--- a/packages/agent/host/edit_retry.go
+++ b/packages/agent/host/edit_retry.go
@@ -38,6 +38,14 @@ func (h *Host) GetEditRetryAvailability(ctx context.Context, ref SessionRef) (Ed
 	if ref.WorkspaceID == "" || ref.AgentSessionID == "" {
 		return EditRetryAvailability{}, ErrInvalidArgument
 	}
+	if h != nil && h.editRetryDisabled {
+		// Feature neutralized: report unsupported so the GUI hides the
+		// edit-and-retry affordance entirely.
+		return EditRetryAvailability{
+			RecoveryState: EditRetryStatePrepared,
+			ReasonCode:    EditRetryReasonCodeProviderUnsupported,
+		}, nil
+	}
 	if h == nil || h.store == nil || h.operations == nil || h.effectiveHistory == nil ||
 		h.turnSubmissions == nil || h.historyRuntime == nil || h.runtime == nil {
 		return EditRetryAvailability{
@@ -153,6 +161,10 @@ func (h *Host) EditRetry(
 	if h == nil || ref.WorkspaceID == "" || ref.AgentSessionID == "" {
 		return EditRetryResult{}, ErrInvalidArgument
 	}
+	if h.editRetryDisabled {
+		// Feature neutralized: refuse before any durable operation is created.
+		return EditRetryResult{}, ErrRuntimeHistoryUnsupported
+	}
 	var result EditRetryResult
 	err := h.withSessionMutationActor(ctx, ref.WorkspaceID, ref.AgentSessionID, func(actorCtx context.Context) error {
 		var commandErr error
@@ -179,6 +191,11 @@ func (h *Host) RecoverEditRetry(
 		(action != EditRetryRecoveryActionReconcile &&
 			action != EditRetryRecoveryActionRetryReplacement) {
 		return EditRetryResult{}, ErrInvalidArgument
+	}
+	if h.editRetryDisabled {
+		// Feature neutralized: leftover operations are quarantined by the
+		// recovery worker, so there is nothing to recover here.
+		return EditRetryResult{}, ErrRuntimeHistoryUnsupported
 	}
 	var result EditRetryResult
 	err := h.withSessionMutationActor(ctx, ref.WorkspaceID, ref.AgentSessionID, func(actorCtx context.Context) error {

--- a/packages/agent/host/edit_retry_disabled_test.go
+++ b/packages/agent/host/edit_retry_disabled_test.go
@@ -1,0 +1,123 @@
+package agenthost_test
+
+import (
+	"errors"
+	"testing"
+
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+// newDisabledEditRetryHost builds a second Host over an existing fixture
+// store+runtime with the edit-and-retry feature neutralized, mirroring how
+// production wires composeApplicationHost with EditRetryDisabled: true.
+func newDisabledEditRetryHost(store *storesqlite.Store, runtime *hostEditRetryRuntime) *agenthost.Host {
+	return agenthost.New(agenthost.Config{
+		CanonicalStore:  sqliteCanonicalStore{Store: store},
+		TurnSubmissions: store, EffectiveHistory: store, RuntimeOperations: store,
+		Runtime: runtime, HistoryRuntime: runtime, GoalRuntime: runtime,
+		OperationOwner:    "worker-disabled",
+		EditRetryDisabled: true,
+	})
+}
+
+// TestEditRetryDisabledRefusesNewOperations verifies the entry points are
+// neutralized: availability reports unsupported (so the GUI hides the affordance)
+// and EditRetry refuses without creating any durable runtime operation.
+func TestEditRetryDisabledRefusesNewOperations(t *testing.T) {
+	_, store, runtime := newHostEditRetryFixture(t)
+	host := newDisabledEditRetryHost(store, runtime)
+	ref := agenthost.SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-1"}
+
+	availability, err := host.GetEditRetryAvailability(t.Context(), ref)
+	if err != nil {
+		t.Fatalf("GetEditRetryAvailability() error = %v", err)
+	}
+	if availability.Supported || availability.Eligible {
+		t.Fatalf("availability = %#v, want Supported=false Eligible=false", availability)
+	}
+
+	_, err = host.EditRetry(t.Context(), ref, "turn-original", agenthost.EditRetryInput{
+		EditedText: "edited prompt", ClientOperationID: "edit-1", ExpectedHistoryRevision: 0,
+	})
+	if !errors.Is(err, agenthost.ErrRuntimeHistoryUnsupported) {
+		t.Fatalf("EditRetry() error = %v, want ErrRuntimeHistoryUnsupported", err)
+	}
+
+	claimable, err := store.ListClaimableRuntimeOperations(t.Context(), storesqlite.ListClaimableRuntimeOperationsInput{
+		NowUnixMS: 1 << 62, Limit: 100,
+	})
+	if err != nil {
+		t.Fatalf("ListClaimableRuntimeOperations() error = %v", err)
+	}
+	if len(claimable) != 0 {
+		t.Fatalf("EditRetry(disabled) created %d runtime operation(s), want 0", len(claimable))
+	}
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	if runtime.rollbackCalls != 0 || runtime.execCalls != 0 {
+		t.Fatalf("provider was touched: rollback=%d exec=%d, want 0,0", runtime.rollbackCalls, runtime.execCalls)
+	}
+}
+
+// TestEditRetryDisabledQuarantinesStuckOperationDuringRecovery is the crash
+// regression guard. It creates a genuinely stuck edit-retry operation (rolled
+// back, replacement never landed — the exact state from the incident), proves
+// that recovering it with the feature ENABLED is fatal to the boot pass, and
+// proves that with the feature DISABLED recovery instead quarantines it and
+// returns nil so tuttid can start.
+func TestEditRetryDisabledQuarantinesStuckOperationDuringRecovery(t *testing.T) {
+	enabled, store, runtime := newHostEditRetryFixture(t)
+	ref := agenthost.SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-1"}
+
+	// Drive a real edit-retry whose replacement dispatch never lands, leaving a
+	// claimable operation parked at the resend-pending checkpoint.
+	runtime.mu.Lock()
+	runtime.execNotDispatchedBeforeTurn = true
+	runtime.mu.Unlock()
+	result, err := enabled.EditRetry(t.Context(), ref, "turn-original", agenthost.EditRetryInput{
+		EditedText: "edited prompt", ClientOperationID: "edit-stuck", ExpectedHistoryRevision: 0,
+	})
+	if !errors.Is(err, agenthost.ErrEditRetryResendPending) {
+		t.Fatalf("EditRetry() error = %v, want ErrEditRetryResendPending", err)
+	}
+	operationID := result.OperationID
+	if operationID == "" {
+		t.Fatal("EditRetry() returned empty operation id")
+	}
+
+	// With the feature enabled, cold recovery of the stuck operation is fatal —
+	// this is the boot crash the neutralization fixes.
+	if recErr := enabled.RecoverRuntimeOperations(t.Context()); recErr == nil {
+		t.Fatal("RecoverRuntimeOperations(enabled) = nil, want the stuck operation to surface a boot-fatal error")
+	}
+
+	runtime.mu.Lock()
+	rollbackBefore, execBefore, readsBefore := runtime.rollbackCalls, runtime.execCalls, runtime.historyReads
+	runtime.mu.Unlock()
+
+	// With the feature disabled, recovery must quarantine the operation and
+	// return nil so the daemon can finish booting.
+	disabled := newDisabledEditRetryHost(store, runtime)
+	if recErr := disabled.RecoverRuntimeOperations(t.Context()); recErr != nil {
+		t.Fatalf("RecoverRuntimeOperations(disabled) = %v, want nil (must not abort boot)", recErr)
+	}
+
+	operation, found, err := store.GetRuntimeOperation(t.Context(), "workspace-1", operationID)
+	if err != nil {
+		t.Fatalf("GetRuntimeOperation() error = %v", err)
+	}
+	if !found || operation.Status != storesqlite.RuntimeOperationStatusFailed {
+		t.Fatalf("operation status = %q found=%v, want %q", operation.Status, found, storesqlite.RuntimeOperationStatusFailed)
+	}
+
+	// Quarantine is a pure store transition: it must not re-engage the provider.
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	if runtime.rollbackCalls != rollbackBefore || runtime.execCalls != execBefore || runtime.historyReads != readsBefore {
+		t.Fatalf(
+			"disabled recovery touched provider: rollback %d->%d exec %d->%d reads %d->%d",
+			rollbackBefore, runtime.rollbackCalls, execBefore, runtime.execCalls, readsBefore, runtime.historyReads,
+		)
+	}
+}

--- a/packages/agent/host/edit_retry_disabled_test.go
+++ b/packages/agent/host/edit_retry_disabled_test.go
@@ -86,6 +86,14 @@ func TestEditRetryDisabledQuarantinesStuckOperationDuringRecovery(t *testing.T) 
 		t.Fatal("EditRetry() returned empty operation id")
 	}
 
+	// The stuck operation fences the session's effective history, which blocks
+	// every subsequent send until the fence returns to ready.
+	if history, found, herr := store.GetSessionHistory(t.Context(), "workspace-1", "session-1"); herr != nil || !found ||
+		history.RecoveryState != storesqlite.SessionHistoryRecoveryResendPending {
+		t.Fatalf("pre-quarantine recovery_state = %q found=%v error=%v, want %q",
+			history.RecoveryState, found, herr, storesqlite.SessionHistoryRecoveryResendPending)
+	}
+
 	// With the feature enabled, cold recovery of the stuck operation is fatal —
 	// this is the boot crash the neutralization fixes.
 	if recErr := enabled.RecoverRuntimeOperations(t.Context()); recErr == nil {
@@ -109,6 +117,17 @@ func TestEditRetryDisabledQuarantinesStuckOperationDuringRecovery(t *testing.T) 
 	}
 	if !found || operation.Status != storesqlite.RuntimeOperationStatusFailed {
 		t.Fatalf("operation status = %q found=%v, want %q", operation.Status, found, storesqlite.RuntimeOperationStatusFailed)
+	}
+
+	// The session fence must be cleared back to ready, otherwise the daemon boots
+	// but the conversation can never send another message.
+	history, found, err := store.GetSessionHistory(t.Context(), "workspace-1", "session-1")
+	if err != nil || !found {
+		t.Fatalf("GetSessionHistory() found=%v error=%v", found, err)
+	}
+	if history.RecoveryState != storesqlite.SessionHistoryRecoveryReady {
+		t.Fatalf("post-quarantine recovery_state = %q, want %q (session must be able to send again)",
+			history.RecoveryState, storesqlite.SessionHistoryRecoveryReady)
 	}
 
 	// Quarantine is a pure store transition: it must not re-engage the provider.

--- a/packages/agent/host/edit_retry_disabled_test.go
+++ b/packages/agent/host/edit_retry_disabled_test.go
@@ -3,6 +3,7 @@ package agenthost_test
 import (
 	"errors"
 	"testing"
+	"time"
 
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
@@ -138,5 +139,74 @@ func TestEditRetryDisabledQuarantinesStuckOperationDuringRecovery(t *testing.T) 
 			"disabled recovery touched provider: rollback %d->%d exec %d->%d reads %d->%d",
 			rollbackBefore, runtime.rollbackCalls, execBefore, runtime.execCalls, readsBefore, runtime.historyReads,
 		)
+	}
+}
+
+// TestEditRetryDisabledHealsLegacyFencedSessionOnSend covers sessions fenced
+// BEFORE the feature was neutralized: the operation is already failed (e.g. via
+// FailEditRetryRecovery), so recovery — which only sees claimable operations —
+// can never quarantine it and the fence would survive every boot. The send gate
+// must self-heal such a fence so the conversation is not blocked forever.
+func TestEditRetryDisabledHealsLegacyFencedSessionOnSend(t *testing.T) {
+	enabled, store, runtime := newHostEditRetryFixture(t)
+	ref := agenthost.SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-1"}
+
+	// Strand an edit-retry at resend_pending, then reproduce the legacy terminal
+	// state: FailEditRetryRecovery fences the session at recovery_required and
+	// fails the operation in one transaction.
+	runtime.mu.Lock()
+	runtime.execNotDispatchedBeforeTurn = true
+	runtime.mu.Unlock()
+	result, err := enabled.EditRetry(t.Context(), ref, "turn-original", agenthost.EditRetryInput{
+		EditedText: "edited prompt", ClientOperationID: "edit-legacy", ExpectedHistoryRevision: 0,
+	})
+	if !errors.Is(err, agenthost.ErrEditRetryResendPending) {
+		t.Fatalf("EditRetry() error = %v, want ErrEditRetryResendPending", err)
+	}
+	now := time.Now().UnixMilli()
+	if _, claimed, claimErr := store.ClaimRuntimeOperationLease(t.Context(), storesqlite.ClaimRuntimeOperationLeaseInput{
+		WorkspaceID: "workspace-1", OperationID: result.OperationID,
+		LeaseOwner: "legacy-worker", NowUnixMS: now, LeaseExpiresAtMS: now + 30_000,
+	}); claimErr != nil || !claimed {
+		t.Fatalf("ClaimRuntimeOperationLease() claimed=%v error=%v", claimed, claimErr)
+	}
+	if _, changed, failErr := store.FailEditRetryRecovery(t.Context(), storesqlite.FailEditRetryRecoveryInput{
+		WorkspaceID: "workspace-1", OperationID: result.OperationID, LeaseOwner: "legacy-worker",
+		ReasonCode: storesqlite.EditRetryReasonRecoveryRequired, NowUnixMS: now,
+	}); failErr != nil || !changed {
+		t.Fatalf("FailEditRetryRecovery() changed=%v error=%v", changed, failErr)
+	}
+	if history, _, _ := store.GetSessionHistory(t.Context(), "workspace-1", "session-1"); history.RecoveryState != storesqlite.SessionHistoryRecoveryRequired {
+		t.Fatalf("legacy recovery_state = %q, want %q", history.RecoveryState, storesqlite.SessionHistoryRecoveryRequired)
+	}
+
+	// Guard: the enabled host's send gate rejects this state, proving SendInput
+	// reaches the effective-history fence in this fixture.
+	prompt := agenthost.SendInput{Content: []agenthost.PromptContentBlock{{Type: "text", Text: "hello again"}}}
+	if _, sendErr := enabled.SendInput(t.Context(), ref, prompt); !errors.Is(sendErr, agenthost.ErrEditRetryRecoveryRequired) {
+		t.Fatalf("SendInput(enabled) error = %v, want ErrEditRetryRecoveryRequired", sendErr)
+	}
+
+	// Recovery on the disabled host is non-fatal but cannot see the failed
+	// operation, so the fence survives the boot pass.
+	disabled := newDisabledEditRetryHost(store, runtime)
+	if recErr := disabled.RecoverRuntimeOperations(t.Context()); recErr != nil {
+		t.Fatalf("RecoverRuntimeOperations(disabled) = %v, want nil", recErr)
+	}
+	if history, _, _ := store.GetSessionHistory(t.Context(), "workspace-1", "session-1"); history.RecoveryState != storesqlite.SessionHistoryRecoveryRequired {
+		t.Fatalf("post-recovery recovery_state = %q, want it untouched (%q)", history.RecoveryState, storesqlite.SessionHistoryRecoveryRequired)
+	}
+
+	// The first send self-heals the abandoned fence and proceeds past the gate.
+	if _, sendErr := disabled.SendInput(t.Context(), ref, prompt); errors.Is(sendErr, agenthost.ErrEditRetryRecoveryRequired) ||
+		errors.Is(sendErr, agenthost.ErrEditRetryResendPending) || errors.Is(sendErr, agenthost.ErrEditRetryInProgress) {
+		t.Fatalf("SendInput(disabled) error = %v, want the fence error healed", sendErr)
+	}
+	history, found, err := store.GetSessionHistory(t.Context(), "workspace-1", "session-1")
+	if err != nil || !found {
+		t.Fatalf("GetSessionHistory() found=%v error=%v", found, err)
+	}
+	if history.RecoveryState != storesqlite.SessionHistoryRecoveryReady {
+		t.Fatalf("post-send recovery_state = %q, want %q", history.RecoveryState, storesqlite.SessionHistoryRecoveryReady)
 	}
 }

--- a/packages/agent/host/host.go
+++ b/packages/agent/host/host.go
@@ -48,6 +48,14 @@ type Config struct {
 	GoalDispatchDeadline   time.Duration
 	GoalActor              *SessionActor
 	SessionMutationActor   *SessionActor
+
+	// EditRetryDisabled neutralizes the durable edit-and-retry feature (PR
+	// #1681). When set, new edit-retry operations are refused and any operation
+	// left over from before it was disabled is quarantined during recovery
+	// instead of engaging the saga. The zero value keeps the feature enabled so
+	// its unit/conformance tests still exercise it; production wiring sets this
+	// true. Remove once the saga's resend/recovery gap is fixed.
+	EditRetryDisabled bool
 }
 
 type Host struct {
@@ -92,6 +100,7 @@ type Host struct {
 	goalDispatchDeadline   time.Duration
 	goalActor              *SessionActor
 	sessionMutationActor   *SessionActor
+	editRetryDisabled      bool
 	goalFencesRestored     sync.Map
 }
 
@@ -124,6 +133,7 @@ func New(config Config) *Host {
 		goalAttemptTimeout: config.GoalAttemptTimeout, goalRecoveryBudget: config.GoalRecoveryBudget,
 		goalMaxAttempts: config.GoalMaxAttempts, goalDispatchDeadline: config.GoalDispatchDeadline,
 		goalActor: goalActor, sessionMutationActor: sessionMutationActor,
+		editRetryDisabled: config.EditRetryDisabled,
 	}
 	if host.sessionForkRecovery == nil {
 		host.sessionForkRecovery, _ = host.sessionForks.(SessionForkRecoveryStore)

--- a/packages/agent/host/lifecycle.go
+++ b/packages/agent/host/lifecycle.go
@@ -678,6 +678,19 @@ func (h *Host) requireSendAllowedByEffectiveHistory(ctx context.Context, ref Ses
 	if err != nil || !found || history.RecoveryState == storesqlite.SessionHistoryRecoveryReady {
 		return err
 	}
+	if h.editRetryDisabled {
+		// Durable edit-retry is neutralized, so a fence whose owning operation is
+		// no longer in flight can never clear through the saga (recovery only
+		// quarantines claimable operations; a previously failed one is invisible
+		// to it). Heal it here so the session is not send-blocked forever; if the
+		// clear does not apply (operation still in flight), fall through to the
+		// normal fence error.
+		if cleared, clearErr := h.effectiveHistory.ClearAbandonedEditRetryFence(ctx, storesqlite.ClearAbandonedEditRetryFenceInput{
+			WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID, NowUnixMS: h.now().UnixMilli(),
+		}); clearErr == nil && cleared {
+			return nil
+		}
+	}
 	switch history.RecoveryState {
 	case storesqlite.SessionHistoryRecoveryRollbackPending:
 		return ErrEditRetryInProgress

--- a/packages/agent/host/observed_stores.go
+++ b/packages/agent/host/observed_stores.go
@@ -81,6 +81,17 @@ func (s *observedEffectiveHistoryStore) FailEditRetryRecovery(
 	return op, changed, err
 }
 
+func (s *observedEffectiveHistoryStore) QuarantineEditRetryOperation(
+	ctx context.Context,
+	input storesqlite.QuarantineEditRetryOperationInput,
+) (storesqlite.RuntimeOperation, bool, error) {
+	op, changed, err := s.EffectiveHistoryStore.QuarantineEditRetryOperation(ctx, input)
+	if err == nil && changed {
+		s.host.notifyCommitted(ctx, runtimeOperationDelta(RuntimeOperationFailed, op, nil))
+	}
+	return op, changed, err
+}
+
 type observedRuntimeOperationStore struct {
 	RuntimeOperationStore
 	host *Host

--- a/packages/agent/host/ports.go
+++ b/packages/agent/host/ports.go
@@ -55,6 +55,7 @@ type EffectiveHistoryStore interface {
 	PrepareEditRetryReplacementRedispatch(context.Context, storesqlite.PrepareEditRetryReplacementRedispatchInput) (storesqlite.RuntimeOperation, bool, error)
 	CompleteEditRetryRuntimeOperation(context.Context, storesqlite.CompleteEditRetryRuntimeOperationInput) (storesqlite.RuntimeOperationCompletion, bool, error)
 	FailEditRetryRecovery(context.Context, storesqlite.FailEditRetryRecoveryInput) (storesqlite.RuntimeOperation, bool, error)
+	QuarantineEditRetryOperation(context.Context, storesqlite.QuarantineEditRetryOperationInput) (storesqlite.RuntimeOperation, bool, error)
 }
 
 type CanonicalSubmitClaimStore interface {

--- a/packages/agent/host/ports.go
+++ b/packages/agent/host/ports.go
@@ -56,6 +56,7 @@ type EffectiveHistoryStore interface {
 	CompleteEditRetryRuntimeOperation(context.Context, storesqlite.CompleteEditRetryRuntimeOperationInput) (storesqlite.RuntimeOperationCompletion, bool, error)
 	FailEditRetryRecovery(context.Context, storesqlite.FailEditRetryRecoveryInput) (storesqlite.RuntimeOperation, bool, error)
 	QuarantineEditRetryOperation(context.Context, storesqlite.QuarantineEditRetryOperationInput) (storesqlite.RuntimeOperation, bool, error)
+	ClearAbandonedEditRetryFence(context.Context, storesqlite.ClearAbandonedEditRetryFenceInput) (bool, error)
 }
 
 type CanonicalSubmitClaimStore interface {

--- a/packages/agent/host/runtime_operations.go
+++ b/packages/agent/host/runtime_operations.go
@@ -352,21 +352,28 @@ func (h *Host) releaseRuntimeOperation(ctx context.Context, operation storesqlit
 
 // quarantineDisabledEditRetryOperation dead-letters an edit-retry operation left
 // over from before the feature was neutralized (see Config.EditRetryDisabled).
-// Marking it failed drops it from the claimable set (ListClaimableRuntimeOperations
-// only returns prepared/leased rows), so it can neither fail cold recovery nor
-// hot-spin the live worker. It returns a nil error on success: a completed
-// quarantine is a terminal, non-fatal outcome for the worker — that is the whole
-// point of the neutralization, so it must never abort daemon boot.
+// It both marks the operation failed — dropping it from the claimable set
+// (ListClaimableRuntimeOperations only returns prepared/leased rows), so it can
+// neither fail cold recovery nor hot-spin the live worker — AND clears the
+// session's effective-history fence back to ready. The fence clear is essential:
+// a stuck operation leaves the session at resend_pending/rollback_pending/
+// recovery_required, and with the feature disabled no recovery path can move it
+// back to ready, so requireSendAllowedByEffectiveHistory would otherwise reject
+// every subsequent send for that conversation forever. It returns a nil error on
+// success: a completed quarantine is a terminal, non-fatal outcome for the worker,
+// so it must never abort daemon boot.
 func (h *Host) quarantineDisabledEditRetryOperation(ctx context.Context, operation storesqlite.RuntimeOperation, owner string) (storesqlite.RuntimeOperation, error) {
-	failed, _, err := h.operations.ReleaseOrFailRuntimeOperation(ctx, storesqlite.ReleaseOrFailRuntimeOperationInput{
+	if h.effectiveHistory == nil {
+		return operation, errors.New("effective history store is unavailable")
+	}
+	failed, _, err := h.effectiveHistory.QuarantineEditRetryOperation(ctx, storesqlite.QuarantineEditRetryOperationInput{
 		WorkspaceID: operation.WorkspaceID, OperationID: operation.OperationID, LeaseOwner: owner,
-		LastError: "edit_retry runtime operations are disabled; operation quarantined",
-		NowUnixMS: h.now().UnixMilli(), Fail: true,
+		NowUnixMS: h.now().UnixMilli(),
 	})
 	if err != nil {
 		return operation, err
 	}
-	logRuntimeOperationFailure(failed, errors.New("edit_retry disabled: quarantined orphaned runtime operation"))
+	logRuntimeOperationFailure(failed, errors.New("edit_retry disabled: quarantined orphaned runtime operation and cleared session history fence"))
 	if publishErr := h.publishRuntimeOperationEvents(ctx, operation.WorkspaceID); publishErr != nil {
 		logRuntimeOperationFailure(failed, publishErr)
 	}

--- a/packages/agent/host/runtime_operations.go
+++ b/packages/agent/host/runtime_operations.go
@@ -180,6 +180,12 @@ func (h *Host) processRuntimeOperation(ctx context.Context, operation storesqlit
 	case storesqlite.RuntimeOperationKindPlanDecision:
 		return h.executePlanDecisionRuntimeOperation(ctx, leased, owner)
 	case storesqlite.RuntimeOperationKindEditRetry:
+		if h.editRetryDisabled {
+			// Feature neutralized (PR #1681). Quarantine any leftover edit-retry
+			// operation so it can neither crash cold recovery nor hot-spin the
+			// live worker. See quarantineDisabledEditRetryOperation.
+			return h.quarantineDisabledEditRetryOperation(ctx, leased, owner)
+		}
 		if !editRetryActorHeld(ctx) {
 			var result storesqlite.RuntimeOperation
 			var executeErr error
@@ -342,6 +348,29 @@ func (h *Host) releaseRuntimeOperation(ctx context.Context, operation storesqlit
 		return released, fmt.Errorf("%w: %v", ErrRuntimeOperationInProgress, cause)
 	}
 	return released, cause
+}
+
+// quarantineDisabledEditRetryOperation dead-letters an edit-retry operation left
+// over from before the feature was neutralized (see Config.EditRetryDisabled).
+// Marking it failed drops it from the claimable set (ListClaimableRuntimeOperations
+// only returns prepared/leased rows), so it can neither fail cold recovery nor
+// hot-spin the live worker. It returns a nil error on success: a completed
+// quarantine is a terminal, non-fatal outcome for the worker — that is the whole
+// point of the neutralization, so it must never abort daemon boot.
+func (h *Host) quarantineDisabledEditRetryOperation(ctx context.Context, operation storesqlite.RuntimeOperation, owner string) (storesqlite.RuntimeOperation, error) {
+	failed, _, err := h.operations.ReleaseOrFailRuntimeOperation(ctx, storesqlite.ReleaseOrFailRuntimeOperationInput{
+		WorkspaceID: operation.WorkspaceID, OperationID: operation.OperationID, LeaseOwner: owner,
+		LastError: "edit_retry runtime operations are disabled; operation quarantined",
+		NowUnixMS: h.now().UnixMilli(), Fail: true,
+	})
+	if err != nil {
+		return operation, err
+	}
+	logRuntimeOperationFailure(failed, errors.New("edit_retry disabled: quarantined orphaned runtime operation"))
+	if publishErr := h.publishRuntimeOperationEvents(ctx, operation.WorkspaceID); publishErr != nil {
+		logRuntimeOperationFailure(failed, publishErr)
+	}
+	return failed, nil
 }
 
 func (h *Host) StepRuntimeOperationWorker(ctx context.Context, recovering bool) error {

--- a/packages/agent/host/sqlite_workspace_store.go
+++ b/packages/agent/host/sqlite_workspace_store.go
@@ -626,6 +626,14 @@ func (s *SQLiteWorkspaceStore) FailEditRetryRecovery(ctx context.Context, input 
 	return store.FailEditRetryRecovery(ctx, input)
 }
 
+func (s *SQLiteWorkspaceStore) QuarantineEditRetryOperation(ctx context.Context, input storesqlite.QuarantineEditRetryOperationInput) (storesqlite.RuntimeOperation, bool, error) {
+	store, err := s.store(input.WorkspaceID)
+	if err != nil {
+		return storesqlite.RuntimeOperation{}, false, err
+	}
+	return store.QuarantineEditRetryOperation(ctx, input)
+}
+
 func (s *SQLiteWorkspaceStore) ListSessionTurnSummaries(ctx context.Context, input storesqlite.ListSessionTurnSummariesInput) (storesqlite.SessionTurnSummaryPage, error) {
 	store, err := s.store(input.WorkspaceID)
 	if err != nil {

--- a/packages/agent/host/sqlite_workspace_store.go
+++ b/packages/agent/host/sqlite_workspace_store.go
@@ -634,6 +634,14 @@ func (s *SQLiteWorkspaceStore) QuarantineEditRetryOperation(ctx context.Context,
 	return store.QuarantineEditRetryOperation(ctx, input)
 }
 
+func (s *SQLiteWorkspaceStore) ClearAbandonedEditRetryFence(ctx context.Context, input storesqlite.ClearAbandonedEditRetryFenceInput) (bool, error) {
+	store, err := s.store(input.WorkspaceID)
+	if err != nil {
+		return false, err
+	}
+	return store.ClearAbandonedEditRetryFence(ctx, input)
+}
+
 func (s *SQLiteWorkspaceStore) ListSessionTurnSummaries(ctx context.Context, input storesqlite.ListSessionTurnSummariesInput) (storesqlite.SessionTurnSummaryPage, error) {
 	store, err := s.store(input.WorkspaceID)
 	if err != nil {

--- a/packages/agent/store-sqlite/edit_retry.go
+++ b/packages/agent/store-sqlite/edit_retry.go
@@ -539,6 +539,88 @@ WHERE workspace_id = ? AND operation_id = ? AND status = 'leased' AND lease_owne
 	return op, true, nil
 }
 
+// QuarantineEditRetryOperation abandons a stuck edit-retry operation: it fails
+// the runtime operation AND clears the session's effective-history fence back to
+// ready (dropping operation_id), in one transaction. It is used when durable
+// edit-retry is disabled — the operation can never make progress, so leaving the
+// session fenced at rollback_pending/resend_pending/recovery_required would
+// permanently block every subsequent send (requireSendAllowedByEffectiveHistory).
+// Unlike AbortEditRetryRollback it tolerates any fenced state and does not restore
+// the retracted turn; the edit is abandoned so the conversation becomes usable.
+func (s *Store) QuarantineEditRetryOperation(ctx context.Context, input QuarantineEditRetryOperationInput) (RuntimeOperation, bool, error) {
+	if s == nil || s.db == nil {
+		return RuntimeOperation{}, false, errors.New("workspace database is not initialized")
+	}
+	input.WorkspaceID = strings.TrimSpace(input.WorkspaceID)
+	input.OperationID = strings.TrimSpace(input.OperationID)
+	input.LeaseOwner = strings.TrimSpace(input.LeaseOwner)
+	if input.WorkspaceID == "" || input.OperationID == "" || input.LeaseOwner == "" || input.NowUnixMS <= 0 {
+		return RuntimeOperation{}, false, errors.New("valid edit retry quarantine input is required")
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return RuntimeOperation{}, false, fmt.Errorf("begin edit retry quarantine: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	op, found, err := getRuntimeOperationTx(ctx, tx, input.WorkspaceID, input.OperationID)
+	if err != nil {
+		return RuntimeOperation{}, false, err
+	}
+	if !validEditRetryLease(op, found, input.LeaseOwner, input.NowUnixMS) {
+		return op, false, ErrRuntimeOperationLeaseLost
+	}
+	// Clear only the fence this operation owns so the session can send again. A
+	// fence owned by a newer operation (or already ready) is left untouched — that
+	// is not an error; the runtime operation is still abandoned below.
+	if _, err := tx.ExecContext(ctx, `
+UPDATE workspace_agent_session_history
+SET recovery_state = 'ready', operation_id = '', updated_at_unix_ms = ?
+WHERE workspace_id = ? AND agent_session_id = ?
+  AND operation_id = ? AND recovery_state != 'ready'
+`, input.NowUnixMS, op.WorkspaceID, op.AgentSessionID, op.OperationID); err != nil {
+		return RuntimeOperation{}, false, fmt.Errorf("clear edit retry history fence: %w", err)
+	}
+	var revision int64
+	if err := tx.QueryRowContext(ctx, `
+SELECT COALESCE((SELECT history_revision FROM workspace_agent_session_history
+    WHERE workspace_id = ? AND agent_session_id = ?), 0)
+`, op.WorkspaceID, op.AgentSessionID).Scan(&revision); err != nil {
+		return RuntimeOperation{}, false, fmt.Errorf("read edit retry quarantine history revision: %w", err)
+	}
+	update, err := tx.ExecContext(ctx, `
+UPDATE workspace_agent_runtime_operations
+SET status = 'failed', result = 'failed', lease_owner = NULL,
+    lease_expires_at_unix_ms = NULL, next_attempt_at_unix_ms = NULL,
+    version = version + 1, last_error = ?, updated_at_unix_ms = ?
+WHERE workspace_id = ? AND operation_id = ? AND status = 'leased' AND lease_owner = ?
+`, "edit_retry disabled; operation quarantined", input.NowUnixMS, op.WorkspaceID, op.OperationID, input.LeaseOwner)
+	if err != nil {
+		return RuntimeOperation{}, false, fmt.Errorf("fail quarantined edit retry operation: %w", err)
+	}
+	if changed, err := rowsWereAffected(update, "fail quarantined edit retry operation"); err != nil || !changed {
+		return RuntimeOperation{}, false, ErrRuntimeOperationLeaseLost
+	}
+	op, _, err = getRuntimeOperationTx(ctx, tx, op.WorkspaceID, op.OperationID)
+	if err != nil {
+		return RuntimeOperation{}, false, err
+	}
+	delta, err := s.commitTransaction(ctx, tx, op.WorkspaceID, []TransactionMutation{
+		transactionMutation(op.WorkspaceID, op.AgentSessionID, MutationEntitySession, op.AgentSessionID, "history_edit_retry_quarantined", revision),
+		transactionMutation(op.WorkspaceID, op.AgentSessionID, MutationEntityRuntimeOperation, op.OperationID, "fail", op.Version),
+	})
+	if err != nil {
+		return RuntimeOperation{}, false, fmt.Errorf("commit edit retry quarantine: %w", err)
+	}
+	committed = true
+	op.CommitTransactionID, op.CommitDelta = delta.TransactionID, delta
+	return op, true, nil
+}
+
 func validEditRetryLease(op RuntimeOperation, found bool, owner string, now int64) bool {
 	return found && op.Kind == RuntimeOperationKindEditRetry &&
 		op.Status == RuntimeOperationStatusLeased && op.LeaseOwner == owner &&

--- a/packages/agent/store-sqlite/edit_retry.go
+++ b/packages/agent/store-sqlite/edit_retry.go
@@ -621,6 +621,72 @@ WHERE workspace_id = ? AND operation_id = ? AND status = 'leased' AND lease_owne
 	return op, true, nil
 }
 
+// ClearAbandonedEditRetryFence clears one session's effective-history fence back
+// to ready when the edit-retry operation that owns it can no longer make
+// progress: the owning operation is missing (e.g. removed by an older rescue
+// script) or already terminal (failed/completed). Fences owned by an in-flight
+// (prepared/leased) operation are left untouched — while durable edit-retry is
+// disabled those are quarantined by the recovery worker, which clears the fence
+// itself. This exists for sessions fenced before the feature was neutralized
+// (e.g. recovery_required from FailEditRetryRecovery, or a failed operation
+// quarantined without a fence clear); without it those sessions would reject
+// every send forever. Returns whether the fence was cleared.
+func (s *Store) ClearAbandonedEditRetryFence(ctx context.Context, input ClearAbandonedEditRetryFenceInput) (bool, error) {
+	if s == nil || s.db == nil {
+		return false, errors.New("workspace database is not initialized")
+	}
+	input.WorkspaceID = strings.TrimSpace(input.WorkspaceID)
+	input.AgentSessionID = strings.TrimSpace(input.AgentSessionID)
+	if input.WorkspaceID == "" || input.AgentSessionID == "" || input.NowUnixMS <= 0 {
+		return false, errors.New("valid edit retry fence clear input is required")
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, fmt.Errorf("begin edit retry fence clear: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	update, err := tx.ExecContext(ctx, `
+UPDATE workspace_agent_session_history
+SET recovery_state = 'ready', operation_id = '', updated_at_unix_ms = ?
+WHERE workspace_id = ? AND agent_session_id = ?
+  AND recovery_state != 'ready'
+  AND NOT EXISTS (
+    SELECT 1 FROM workspace_agent_runtime_operations o
+    WHERE o.workspace_id = workspace_agent_session_history.workspace_id
+      AND o.operation_id = workspace_agent_session_history.operation_id
+      AND o.status IN ('prepared','leased'))
+`, input.NowUnixMS, input.WorkspaceID, input.AgentSessionID)
+	if err != nil {
+		return false, fmt.Errorf("clear abandoned edit retry fence: %w", err)
+	}
+	changed, err := rowsWereAffected(update, "clear abandoned edit retry fence")
+	if err != nil {
+		return false, err
+	}
+	if !changed {
+		return false, nil
+	}
+	var revision int64
+	if err := tx.QueryRowContext(ctx, `
+SELECT history_revision FROM workspace_agent_session_history
+WHERE workspace_id = ? AND agent_session_id = ?
+`, input.WorkspaceID, input.AgentSessionID).Scan(&revision); err != nil {
+		return false, fmt.Errorf("read edit retry fence clear history revision: %w", err)
+	}
+	if _, err := s.commitTransaction(ctx, tx, input.WorkspaceID, []TransactionMutation{
+		transactionMutation(input.WorkspaceID, input.AgentSessionID, MutationEntitySession, input.AgentSessionID, "history_edit_retry_fence_cleared", revision),
+	}); err != nil {
+		return false, fmt.Errorf("commit edit retry fence clear: %w", err)
+	}
+	committed = true
+	return true, nil
+}
+
 func validEditRetryLease(op RuntimeOperation, found bool, owner string, now int64) bool {
 	return found && op.Kind == RuntimeOperationKindEditRetry &&
 		op.Status == RuntimeOperationStatusLeased && op.LeaseOwner == owner &&

--- a/packages/agent/store-sqlite/runtime_operation_types.go
+++ b/packages/agent/store-sqlite/runtime_operation_types.go
@@ -199,6 +199,13 @@ type FailEditRetryRecoveryInput struct {
 	NowUnixMS   int64
 }
 
+type QuarantineEditRetryOperationInput struct {
+	WorkspaceID string
+	OperationID string
+	LeaseOwner  string
+	NowUnixMS   int64
+}
+
 type RuntimeOperationEvent struct {
 	ID                int64
 	OperationID       string

--- a/packages/agent/store-sqlite/runtime_operation_types.go
+++ b/packages/agent/store-sqlite/runtime_operation_types.go
@@ -206,6 +206,12 @@ type QuarantineEditRetryOperationInput struct {
 	NowUnixMS   int64
 }
 
+type ClearAbandonedEditRetryFenceInput struct {
+	WorkspaceID    string
+	AgentSessionID string
+	NowUnixMS      int64
+}
+
 type RuntimeOperationEvent struct {
 	ID                int64
 	OperationID       string

--- a/services/tuttid/service/agent/host_composition.go
+++ b/services/tuttid/service/agent/host_composition.go
@@ -208,5 +208,9 @@ func composeApplicationHost(
 		GoalAttemptTimeout: support.GoalAttemptTimeout, GoalRecoveryBudget: support.GoalRecoveryBudget,
 		GoalMaxAttempts: support.GoalMaxAttempts, GoalDispatchDeadline: support.GoalDispatchDeadline,
 		GoalActor: agenthost.NewSessionActor(),
+		// Durable edit-and-retry (PR #1681) is neutralized: its saga can strand a
+		// session in a rolled-back-but-not-resent state whose runtime operation
+		// becomes a cold-recovery poison pill that crashes tuttid on launch.
+		EditRetryDisabled: true,
 	})
 }

--- a/tools/scripts/rescue-edit-retry-poison-pill.sh
+++ b/tools/scripts/rescue-edit-retry-poison-pill.sh
@@ -74,8 +74,19 @@ BAK="${DB}.bak.$(date +%Y%m%d%H%M%S)"
 sqlite3 "$DB" ".backup '$BAK'"
 echo "🗄  Backup written: $BAK"
 
-# 5. Apply. next_attempt/lease cleared so the row can never be claimed again.
+# 5. Apply. Two parts, both required:
+#    (a) unfence the affected sessions' effective history back to 'ready' so they
+#        can send again — a stuck edit_retry leaves recovery_state at
+#        resend_pending/rollback_pending/recovery_required, which blocks every
+#        subsequent prompt. This MUST run before deleting the operation rows,
+#        because it identifies the fenced sessions via those rows.
+#    (b) fail (or delete) the stuck operation rows so recovery no longer trips.
 NOW_MS="CAST((julianday('now')-2440587.5)*86400000 AS INTEGER)"
+sqlite3 "$DB" ".timeout 5000" "
+  UPDATE workspace_agent_session_history
+     SET recovery_state='ready', operation_id='', updated_at_unix_ms=$NOW_MS
+   WHERE recovery_state != 'ready'
+     AND operation_id IN (SELECT operation_id FROM workspace_agent_runtime_operations WHERE kind='edit_retry');"
 if [[ "$MODE" == "delete" ]]; then
   sqlite3 "$DB" ".timeout 5000" "DELETE FROM workspace_agent_runtime_operations WHERE $WHERE;"
 else

--- a/tools/scripts/rescue-edit-retry-poison-pill.sh
+++ b/tools/scripts/rescue-edit-retry-poison-pill.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# rescue-edit-retry-poison-pill.sh
+#
+# Unbricks a Tutti install that crashes on launch with:
+#   "build tuttid server: recover agent host:
+#      process runtime operation <id>: agent session not found"
+#   "failed to start managed tuttid: tuttid exited before it published its listener info."
+#
+# Cause: a durable `edit_retry` runtime operation is stuck (rolled back but never
+# resent). It is harmless while the daemon runs, but on the next daemon restart
+# the cold-recovery pass treats it as fatal, so tuttid exits(1) on every launch.
+#
+# This script quarantines those stuck operations (marks them `failed`, which
+# removes them from the recovery claimable set) so the daemon can boot again.
+# It does NOT delete history and it backs the database up first.
+#
+# Usage:
+#   1. Fully quit Tutti (Cmd-Q). The daemon must be stopped.
+#   2. bash tools/scripts/rescue-edit-retry-poison-pill.sh
+#   3. Reopen Tutti.
+#
+# Options (env vars):
+#   TUTTI_DB=/path/to/tuttid.db   Override DB path (default: ~/.tutti/tuttid.db)
+#   MODE=delete                   Delete the rows instead of marking them failed
+#   YES=1                         Skip the confirmation prompt
+#
+set -euo pipefail
+
+DB="${TUTTI_DB:-$HOME/.tutti/tuttid.db}"
+MODE="${MODE:-quarantine}"
+
+die() { echo "❌ $*" >&2; exit 1; }
+
+command -v sqlite3 >/dev/null 2>&1 || die "sqlite3 not found (macOS ships it at /usr/bin/sqlite3)."
+[[ -f "$DB" ]] || die "database not found: $DB (set TUTTI_DB=... to override)"
+
+# 1. Refuse to run while the daemon/app is alive (avoids a locked DB and racing recovery).
+if pgrep -x tuttid >/dev/null 2>&1 || pgrep -f "Tutti.app/Contents/" >/dev/null 2>&1; then
+  die "Tutti / tuttid is still running. Fully quit Tutti (Cmd-Q) and re-run this script."
+fi
+
+WHERE="kind='edit_retry' AND status IN ('prepared','leased')"
+
+# 2. Show what will change.
+CNT="$(sqlite3 "$DB" "SELECT count(*) FROM workspace_agent_runtime_operations WHERE $WHERE;")"
+echo "Database: $DB"
+echo "Stuck edit_retry operations found: $CNT"
+if [[ "$CNT" -eq 0 ]]; then
+  echo "✅ Nothing to fix — no stuck edit_retry operations. The crash is caused by something else."
+  exit 0
+fi
+echo
+echo "-------------------------------------------------------------------------------"
+sqlite3 -header -column "$DB" \
+  "SELECT substr(operation_id,1,8) AS op, substr(agent_session_id,1,8) AS session, status, attempt, substr(last_error,1,40) AS last_error
+   FROM workspace_agent_runtime_operations WHERE $WHERE;"
+echo "-------------------------------------------------------------------------------"
+echo
+if [[ "$MODE" == "delete" ]]; then
+  echo "Action: DELETE these $CNT operation row(s)."
+else
+  echo "Action: mark these $CNT operation row(s) as 'failed' (quarantine; reversible from backup)."
+fi
+
+# 3. Confirm.
+if [[ "${YES:-}" != "1" ]]; then
+  read -r -p "Proceed? [y/N] " reply
+  [[ "$reply" == "y" || "$reply" == "Y" ]] || die "Aborted; no changes made."
+fi
+
+# 4. Consistent backup (includes any WAL) before mutating.
+BAK="${DB}.bak.$(date +%Y%m%d%H%M%S)"
+sqlite3 "$DB" ".backup '$BAK'"
+echo "🗄  Backup written: $BAK"
+
+# 5. Apply. next_attempt/lease cleared so the row can never be claimed again.
+NOW_MS="CAST((julianday('now')-2440587.5)*86400000 AS INTEGER)"
+if [[ "$MODE" == "delete" ]]; then
+  sqlite3 "$DB" ".timeout 5000" "DELETE FROM workspace_agent_runtime_operations WHERE $WHERE;"
+else
+  sqlite3 "$DB" ".timeout 5000" "
+    UPDATE workspace_agent_runtime_operations
+       SET status='failed', result='failed',
+           lease_owner=NULL, lease_expires_at_unix_ms=NULL, next_attempt_at_unix_ms=NULL,
+           last_error='quarantined by rescue-edit-retry-poison-pill.sh',
+           version=version+1, updated_at_unix_ms=$NOW_MS
+     WHERE $WHERE;"
+fi
+
+REMAIN="$(sqlite3 "$DB" "SELECT count(*) FROM workspace_agent_runtime_operations WHERE $WHERE;")"
+[[ "$REMAIN" -eq 0 ]] || die "expected 0 stuck rows after fix, still $REMAIN — restore from $BAK and report."
+echo "✅ Done. Cleared $CNT stuck operation(s). Reopen Tutti now."
+echo "   (If anything looks wrong, restore with:  cp '$BAK' '$DB')"


### PR DESCRIPTION
## Symptom
Users on 0.2.7-rc.0 hit a permanent **crash-on-open**: `tuttid` exits(1) on every launch with
`build tuttid server: recover agent host: process runtime operation <id>: agent session not found`,
and the desktop reports `failed to start managed tuttid: tuttid exited before it published its listener info.`

## Root cause
A durable `edit_retry` runtime operation that rolled back the last turn but never re-sent the
replacement (`ErrEditRetryResendPending`) is harmless while the daemon runs — the live worker just
logs and retries at 1 Hz. But on the next daemon restart the **cold-recovery pass**
(`RecoverRuntimeOperations`) treats the same error as **fatal**, aborting `build tuttid server`
before the listener is published. The operation is persisted in `workspace_agent_runtime_operations`,
so every relaunch re-reads it and re-crashes — a permanent loop for anyone who had a pending
edit-retry when they updated to a build containing #1681.

The upstream saga defect (why the op got stuck): the destructive `thread/rollback` runs before the
replacement is confirmed, the `ReplacementDispatched` checkpoint is a one-way fence that disables
auto-redispatch, and the replacement send is skipped when the submit-claim was already accepted — so
the edited turn is silently never resent, and the op hot-spins forever.

## Why not `git revert` #1681
It's a 183-file squash commit with ~37 conflicts against later work, and it ships a **destructive
one-way schema migration (v5)** that already ran on users' databases. Reverting the migration would
brick already-migrated installs a different way.

## This change — forward neutralization (no schema change)
Gate the feature behind `Config.EditRetryDisabled`, enabled in production via `composeApplicationHost`:
- `GetEditRetryAvailability` reports unsupported → the GUI hides the affordance
- `EditRetry` / `RecoverEditRetry` refuse before creating any operation
- the runtime-operation worker **quarantines** any leftover `edit_retry` op (marks it failed, returns
  nil) so it can neither crash cold recovery nor hot-spin the live worker

Existing poison pills **self-heal on the next boot** (they get quarantined during recovery). The zero
value keeps the feature enabled so its unit/conformance tests still exercise it; re-enable once the
saga's resend/recovery gap is fixed.

## Tests
- New `edit_retry_disabled_test.go`: builds a genuinely stuck op via the enabled saga, asserts
  recovering it with the feature **enabled is boot-fatal**, and asserts the **disabled path
  quarantines** it and returns nil (provider untouched).
- Full `packages/agent/host` module + tuttid edit-retry/conformance/api suites green; both modules vet clean.

## Operator rescue
`tools/scripts/rescue-edit-retry-poison-pill.sh` quarantines the stuck rows in `~/.tutti/tuttid.db`
for an already-bricked install that can't update yet (backs up first; refuses to run while tuttid is alive).

## Follow-up
A separate PR targets `release/0729` (its production host is composed in `host_adapters.go`, so the
wiring line differs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1887" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes daemon boot recovery and disables a user-facing mutation path in production, but scope is bounded to edit-retry and avoids schema changes; incorrect quarantine logic could leave claimable poison pills or hide real recovery errors.
> 
> **Overview**
> Stops **tuttid** crash-on-launch when a stuck durable `edit_retry` runtime operation survives in SQLite and makes cold recovery fatal.
> 
> Adds **`Config.EditRetryDisabled`** on the agent host (production sets it in `composeApplicationHost`). When enabled: **`GetEditRetryAvailability`** reports provider unsupported so the UI hides edit-and-retry; **`EditRetry`** and **`RecoverEditRetry`** return **`ErrRuntimeHistoryUnsupported`** before creating or driving saga work; the runtime worker **`quarantineDisabledEditRetryOperation`** marks leftover `edit_retry` ops **failed** instead of running the saga, so boot recovery completes without touching the provider.
> 
> Adds **`edit_retry_disabled_test.go`** (refuse new ops; quarantine stuck op on recovery vs boot-fatal when enabled) and **`tools/scripts/rescue-edit-retry-poison-pill.sh`** to quarantine stuck rows in an already-bricked local DB after backup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f3e6ac9e983d52805645d95ce603a54a16776d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->