### PR TITLE
Fix managed runtime Corepack packaging and release ordering

### DIFF
--- a/.github/workflows/desktop-release-promote.yml
+++ b/.github/workflows/desktop-release-promote.yml
@@ -202,6 +202,9 @@ jobs:
         with:
           node-version-file: .node-version
 
+      - name: Verify managed app runtime is published
+        run: node tools/scripts/verify-tutti-app-runtime-release.mjs
+
       - name: Download staged GitHub release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-tutti-app-runtime.yml
+++ b/.github/workflows/publish-tutti-app-runtime.yml
@@ -186,13 +186,23 @@ jobs:
           script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
           exec "${script_dir}/node" "${script_dir}/../lib/node_modules/npm/bin/npx-cli.js" "$@"
           SH
-          chmod 0755 "${node_staging}/node/bin/npm" "${node_staging}/node/bin/npx"
+          cat > "${node_staging}/node/bin/corepack" <<'SH'
+          #!/bin/sh
+          script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+          exec "${script_dir}/node" "${script_dir}/../lib/node_modules/corepack/dist/corepack.js" "$@"
+          SH
+          chmod 0755 \
+            "${node_staging}/node/bin/npm" \
+            "${node_staging}/node/bin/npx" \
+            "${node_staging}/node/bin/corepack"
           test -x "${python_staging}/python/bin/python3"
           test -x "${node_staging}/node/bin/node"
           test -x "${node_staging}/node/bin/npm"
           test -x "${node_staging}/node/bin/npx"
+          test -x "${node_staging}/node/bin/corepack"
           PATH="${node_staging}/node/bin:${PATH}" "${node_staging}/node/bin/npm" --version
           PATH="${node_staging}/node/bin:${PATH}" "${node_staging}/node/bin/npx" --version
+          PATH="${node_staging}/node/bin:${PATH}" "${node_staging}/node/bin/corepack" --version
           find "${python_staging}" "${node_staging}" -exec touch -h -t 202606010000 {} +
           (cd "${python_staging}" && zip -X -qry "${python_artifact_dir}/${python_artifact_file}" .)
           (cd "${node_staging}" && zip -X -qry "${node_artifact_dir}/${node_artifact_file}" .)

--- a/config/tutti.app-runtime.lock.json
+++ b/config/tutti.app-runtime.lock.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "tutti.app.runtime-lock.v1",
-  "runtimeVersion": "2026.06.0",
+  "runtimeVersion": "2026.07.0",
   "uv": {
     "version": "0.11.19"
   },

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -310,8 +310,15 @@ Promotion performs these checks before changing public state:
 
 - the GitHub Release exists and its stable, RC, or beta shape matches the tag
 - the tag still points to the staged commit
+- the production managed app runtime catalog publishes the target commit's
+  locked `runtimeVersion` for every supported platform
 - `SHA256SUMS.txt` exists and the downloaded draft assets match it
 - the target version does not move the selected public channel backwards
+
+When `config/tutti.app-runtime.lock.json` changes, run `Publish Tutti App
+Runtime` and verify the production catalog before promoting the desktop release.
+The promotion gate reads the lock from the exact release target, so a later
+manual promotion cannot bypass this ordering.
 
 It then consumes the checksummed `release-summary.json` staged with the Draft Release, repairs or uploads the immutable AWS objects, updates release notes, publishes a stable GitHub Release when applicable, writes the selected stable/RC/beta pointer, refreshes the stable alias, verifies the public CloudFront pointer, and sends the promoted release notification. Promotion never regenerates the summary or calls the summary model. GitHub Draft assets remain mutable until promotion, so any restage or asset replacement invalidates the prior human approval and requires another review of the current `SHA256SUMS.txt`; cryptographic binding to an external approval record or immutable candidate ID is not implemented. Promotion is serialized with the `desktop-release-promotion` concurrency group because stable and prerelease pointers are mutable shared state.
 

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -310,8 +310,8 @@ Promotion performs these checks before changing public state:
 
 - the GitHub Release exists and its stable, RC, or beta shape matches the tag
 - the tag still points to the staged commit
-- the production managed app runtime catalog publishes the target commit's
-  locked `runtimeVersion` for every supported platform
+- the production managed app runtime catalog publishes at least the target
+  commit's locked `runtimeVersion` for every supported platform
 - `SHA256SUMS.txt` exists and the downloaded draft assets match it
 - the target version does not move the selected public channel backwards
 

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -109,6 +109,7 @@ App Center, workspace-app lifecycle, App Factory, file references, and File Mana
 
 - [App Factory job keeps loading after AgentGUI Stop](./workspace-apps-files.md#app-factory-job-keeps-loading-after-agentgui-stop)
 - [App Center list requests repeatedly log runtime preload](./workspace-apps-files.md#app-center-list-requests-repeatedly-log-runtime-preload)
+- [Workspace app commands fail inside Corepack before pnpm starts](./workspace-apps-files.md#workspace-app-commands-fail-inside-corepack-before-pnpm-starts)
 - [Workspace app uninstall fails on cached manifest validation](./workspace-apps-files.md#workspace-app-uninstall-fails-on-cached-manifest-validation)
 - [Workspace app update reopens the old dock window](./workspace-apps-files.md#workspace-app-update-reopens-the-old-dock-window)
 - [Agent inline app opening leaks into the OS App Center](./workspace-apps-files.md#agent-inline-app-opening-leaks-into-the-os-app-center)

--- a/docs/conventions/troubleshooting/workspace-apps-files.md
+++ b/docs/conventions/troubleshooting/workspace-apps-files.md
@@ -68,6 +68,41 @@
   [apps.go](../../../services/tuttid/service/workspace/apps.go)
   [apps_test.go](../../../services/tuttid/service/workspace/apps_test.go)
 
+### Workspace app commands fail inside Corepack before pnpm starts
+
+- Symptom:
+  A workspace app launches successfully, but a repository check or Git hook
+  fails immediately with `Cannot find module './lib/corepack.cjs'`. The require
+  stack points at the managed runtime's `node/bin/corepack`, and several
+  unrelated check lanes fail before executing their own logic.
+- Quick checks:
+  Inspect `node/bin/corepack` below the injected `TUTTI_APP_RUNTIME_ROOT`. A
+  broken artifact contains the same JavaScript as Corepack's
+  `dist/corepack.js` as a regular file. A valid artifact contains a standalone
+  wrapper that invokes the packaged Node binary and
+  `../lib/node_modules/corepack/dist/corepack.js`.
+- Root cause:
+  Node publishes `bin/corepack` as a relative symlink. Dereferencing that
+  symlink while staging a zip copies the target JavaScript into `node/bin`;
+  its relative `./lib/corepack.cjs` import then resolves from the wrong
+  directory. Rewriting only the npm and npx shims leaves Corepack broken and
+  shadows any usable Corepack later on `PATH`.
+- Fix:
+  Replace `node/bin/corepack` during runtime artifact assembly with a standalone
+  wrapper, validate it with `corepack --version`, and bump the immutable runtime
+  version before publishing. Treat cached Node components without that wrapper
+  contract as unavailable so the resolver replaces an already-broken cache.
+- Validation:
+  Run
+  `node --test tools/scripts/build-tutti-app-runtime-catalog.test.mjs` and
+  `cd services/tuttid && go test ./service/managedruntime ./service/workspace`.
+  Inspect the assembled archive and confirm `node/bin/corepack --version`
+  succeeds with only the packaged runtime directory first on `PATH`.
+- References:
+  [publish-tutti-app-runtime.yml](../../../.github/workflows/publish-tutti-app-runtime.yml)
+  [runtime.go](../../../services/tuttid/service/managedruntime/runtime.go)
+  [workspace-app-runtime.md](../workspace-app-runtime.md)
+
 ### Workspace app uninstall fails on cached manifest validation
 
 - Symptom:

--- a/docs/conventions/workspace-app-runtime.md
+++ b/docs/conventions/workspace-app-runtime.md
@@ -39,6 +39,7 @@ node component zip:
   node/bin/node
   node/bin/npm
   node/bin/npx
+  node/bin/corepack
 ```
 
 Windows runtime artifacts, when added, must use the Windows executable names expected by tuttid:
@@ -47,6 +48,7 @@ Windows runtime artifacts, when added, must use the Windows executable names exp
 python/bin/python.exe
 node/bin/node.exe
 node/bin/npm.cmd
+node/bin/corepack.cmd
 ```
 
 Catalog platform keys must use Go runtime names because tuttid resolves them with `runtime.GOOS` and `runtime.GOARCH`. Use `darwin-amd64` and `linux-amd64`, not Node's `darwin-x64` or `linux-x64` download labels.
@@ -100,6 +102,12 @@ https://d1x7gb6wqsqmnm.cloudfront.net/tutti-app-runtimes/catalog.json
 ```
 
 Artifacts are immutable and should use long cache headers. The catalog is mutable and should use a short cache header.
+
+The production runtime catalog must publish the `runtimeVersion` locked by the
+desktop release target for every supported platform before that desktop release
+is promoted. The promotion workflow enforces this ordering with
+`tools/scripts/verify-tutti-app-runtime-release.mjs`; publish the managed runtime
+first when the lock version changes.
 
 ## Catalog Shape
 
@@ -157,9 +165,12 @@ Agent provider installers may also use the managed `TUTTI_APP_NPM` path to
 install ACP npm adapters into daemon-owned per-agent prefixes instead of npm
 global locations.
 
-Runtime artifacts must make `node/bin/npm` and `node/bin/npx` standalone
-wrappers that execute the packaged Node binary with npm's packaged CLI scripts.
-Do not rely on Node release symlinks surviving zip packaging.
+Runtime artifacts must make `node/bin/npm`, `node/bin/npx`, and
+`node/bin/corepack` standalone wrappers that execute the packaged Node binary
+with their packaged CLI scripts. Do not rely on Node release symlinks surviving
+zip packaging. The resolver treats a dereferenced Corepack distribution entry
+as an invalid Node component and downloads the current catalog artifact again,
+so existing caches recover when this wrapper contract changes.
 
 ## Validation
 

--- a/docs/conventions/workspace-app-runtime.md
+++ b/docs/conventions/workspace-app-runtime.md
@@ -103,9 +103,12 @@ https://d1x7gb6wqsqmnm.cloudfront.net/tutti-app-runtimes/catalog.json
 
 Artifacts are immutable and should use long cache headers. The catalog is mutable and should use a short cache header.
 
-The production runtime catalog must publish the `runtimeVersion` locked by the
-desktop release target for every supported platform before that desktop release
-is promoted. The promotion workflow enforces this ordering with
+The production runtime catalog must publish at least the `runtimeVersion` locked
+by the desktop release target for every supported platform before that desktop
+release is promoted. Runtime versions use an ordered `YYYY.MM.PATCH` format and
+newer runtime releases remain compatible with older desktop releases because
+tuttid always resolves the mutable catalog's current entry. The promotion
+workflow enforces this ordering with
 `tools/scripts/verify-tutti-app-runtime-release.mjs`; publish the managed runtime
 first when the lock version changes.
 

--- a/services/tuttid/service/agentstatus/provider_resolution.go
+++ b/services/tuttid/service/agentstatus/provider_resolution.go
@@ -411,7 +411,7 @@ func resolvedExistingManagedNodeRuntime(root string, environ func() []string) (m
 	nodeBinDir := filepath.Join(root, "node", "bin")
 	nodePath := filepath.Join(nodeBinDir, nodeBinaryName())
 	npmPath := filepath.Join(nodeBinDir, npmBinaryName())
-	if !isExecutablePath(nodePath) || !isExecutablePath(npmPath) {
+	if !managedruntime.NodeReady(root) {
 		return managedruntime.ResolvedRuntime{}, false
 	}
 	baseEnv := []string(nil)
@@ -431,11 +431,6 @@ func resolvedExistingManagedNodeRuntime(root string, environ func() []string) (m
 			"PATH=" + strings.Join(append([]string{nodeBinDir}, filepath.SplitList(basePath)...), string(os.PathListSeparator)),
 		},
 	}, true
-}
-
-func isExecutablePath(path string) bool {
-	info, err := os.Stat(path)
-	return err == nil && !info.IsDir() && info.Mode().Perm()&0o111 != 0
 }
 
 func (s Service) resolveManagedRuntimeForProvider(ctx context.Context, require bool) (managedruntime.ResolvedRuntime, bool) {

--- a/services/tuttid/service/agentstatus/provider_resolution_managed_runtime_test.go
+++ b/services/tuttid/service/agentstatus/provider_resolution_managed_runtime_test.go
@@ -1,0 +1,58 @@
+package agentstatus
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/tutti-os/tutti/services/tuttid/service/managedruntime"
+)
+
+func TestResolvedExistingManagedNodeRuntimeRejectsBrokenCorepack(t *testing.T) {
+	root := fakeManagedRuntimeRoot(t)
+	writeExecutable(
+		t,
+		filepath.Join(root, "node", "bin", corepackBinaryNameForTest()),
+		"#!/bin/sh\nexit 0\n",
+	)
+
+	if runtime, ok := resolvedExistingManagedNodeRuntime(root, func() []string {
+		return []string{"PATH=/usr/bin:/bin"}
+	}); ok {
+		t.Fatalf("resolvedExistingManagedNodeRuntime() = %#v, want incompatible cache rejected", runtime)
+	}
+}
+
+func TestResolveManagedNodeRuntimeForProviderDoesNotUseBrokenOptionalCache(t *testing.T) {
+	root := fakeManagedRuntimeRoot(t)
+	writeExecutable(
+		t,
+		filepath.Join(root, "node", "bin", corepackBinaryNameForTest()),
+		"#!/bin/sh\nexit 0\n",
+	)
+	service := Service{
+		Environ: func() []string {
+			return []string{"PATH=/usr/bin:/bin"}
+		},
+		ManagedRuntime: managedruntime.DefaultResolver{RuntimeRoot: root},
+	}
+
+	if runtime, ok := service.resolveManagedNodeRuntimeForProvider(context.Background(), false); ok {
+		t.Fatalf("resolveManagedNodeRuntimeForProvider() = %#v, want incompatible optional cache skipped", runtime)
+	}
+}
+
+func TestResolvedExistingManagedNodeRuntimeAcceptsCompatibleCorepack(t *testing.T) {
+	root := fakeManagedRuntimeRoot(t)
+
+	runtime, ok := resolvedExistingManagedNodeRuntime(root, func() []string {
+		return []string{"PATH=/usr/bin:/bin"}
+	})
+	if !ok {
+		t.Fatal("resolvedExistingManagedNodeRuntime() rejected compatible cache")
+	}
+	wantNode := filepath.Join(root, "node", "bin", nodeBinaryNameForTest())
+	if runtime.Node != wantNode {
+		t.Fatalf("Node = %q, want %q", runtime.Node, wantNode)
+	}
+}

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -1034,6 +1034,7 @@ func TestServiceRunActionReinstallsCodexWhenPlatformPackageIncomplete(t *testing
 	platformBinary := requireTestCodexPlatformBinaryPath(t, pkgDir)
 
 	service := probeTestService(home)
+	service.ManagedRuntime = fakeManagedRuntimeResolver(t, fakeManagedRuntimeRoot(t))
 	// The default 1s probe timeout is tuned for the old "still alive after
 	// 200ms" liveness check; the real ACP handshake needs to actually spawn,
 	// write, and read a response, which is slower under test-suite load.

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -3192,6 +3192,11 @@ func fakeManagedRuntimeRoot(t *testing.T) string {
 	writeExecutable(t, filepath.Join(root, "python", "bin", pythonBinaryNameForTest()), "#!/bin/sh\nexit 0\n")
 	writeExecutable(t, filepath.Join(root, "node", "bin", nodeBinaryNameForTest()), "#!/bin/sh\nexit 0\n")
 	writeExecutable(t, filepath.Join(root, "node", "bin", npmBinaryNameForTest()), "#!/bin/sh\nexit 0\n")
+	writeExecutable(
+		t,
+		filepath.Join(root, "node", "bin", corepackBinaryNameForTest()),
+		"#!/bin/sh\nexec \"$(dirname \"$0\")/node\" \"$(dirname \"$0\")/../lib/node_modules/corepack/dist/corepack.js\" \"$@\"\n",
+	)
 	return root
 }
 
@@ -3229,6 +3234,13 @@ func npmBinaryNameForTest() string {
 		return "npm.cmd"
 	}
 	return "npm"
+}
+
+func corepackBinaryNameForTest() string {
+	if runtime.GOOS == "windows" {
+		return "corepack.cmd"
+	}
+	return "corepack"
 }
 
 func quoteJSONString(value string) string {

--- a/services/tuttid/service/managedruntime/runtime.go
+++ b/services/tuttid/service/managedruntime/runtime.go
@@ -271,6 +271,11 @@ func RootReady(root string) bool {
 		runtime.NPM != ""
 }
 
+// NodeReady reports whether root contains a compatible managed Node component.
+func NodeReady(root string) bool {
+	return appRuntimeComponentReady(root, "node")
+}
+
 func appRuntimeComponentReady(root string, name string) bool {
 	if strings.TrimSpace(root) == "" {
 		return false

--- a/services/tuttid/service/managedruntime/runtime.go
+++ b/services/tuttid/service/managedruntime/runtime.go
@@ -139,6 +139,7 @@ func (r DefaultResolver) resolvedRuntimeForComponents(root string, components []
 	python := filepath.Join(pythonBinDir, pythonBinaryName())
 	node := filepath.Join(nodeBinDir, nodeBinaryName())
 	npm := filepath.Join(nodeBinDir, npmBinaryName())
+	corepack := filepath.Join(nodeBinDir, corepackBinaryName())
 
 	var (
 		binDirs      []string
@@ -162,6 +163,9 @@ func (r DefaultResolver) resolvedRuntimeForComponents(root string, components []
 				if !isExecutableFile(path) {
 					return ResolvedRuntime{}, fmt.Errorf("managed app runtime %s executable is unavailable at %s", name, path)
 				}
+			}
+			if !isStandaloneCorepackWrapper(corepack) {
+				return ResolvedRuntime{}, fmt.Errorf("managed app runtime corepack wrapper is unavailable or incompatible at %s", corepack)
 			}
 			resolved.Node = node
 			resolved.NPM = npm
@@ -277,7 +281,8 @@ func appRuntimeComponentReady(root string, name string) bool {
 	case "node":
 		nodeBinDir := filepath.Join(root, "node", "bin")
 		return isExecutableFile(filepath.Join(nodeBinDir, nodeBinaryName())) &&
-			isExecutableFile(filepath.Join(nodeBinDir, npmBinaryName()))
+			isExecutableFile(filepath.Join(nodeBinDir, npmBinaryName())) &&
+			isStandaloneCorepackWrapper(filepath.Join(nodeBinDir, corepackBinaryName()))
 	default:
 		info, err := os.Stat(filepath.Join(root, name))
 		return err == nil && info.IsDir()
@@ -652,6 +657,28 @@ func npmBinaryName() string {
 		return "npm.cmd"
 	}
 	return "npm"
+}
+
+func corepackBinaryName() string {
+	if runtime.GOOS == "windows" {
+		return "corepack.cmd"
+	}
+	return "corepack"
+}
+
+func isStandaloneCorepackWrapper(path string) bool {
+	if !isExecutableFile(path) {
+		return false
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	normalized := strings.ReplaceAll(string(content), `\`, "/")
+	return strings.Contains(
+		normalized,
+		"lib/node_modules/corepack/dist/corepack.js",
+	)
 }
 
 func isExecutableFile(path string) bool {

--- a/services/tuttid/service/managedruntime/runtime_test.go
+++ b/services/tuttid/service/managedruntime/runtime_test.go
@@ -22,6 +22,7 @@ func TestDefaultResolverInjectsBaselineRuntime(t *testing.T) {
 	writeExecutable(t, filepath.Join(pythonBinDir, pythonBinaryName()))
 	writeExecutable(t, filepath.Join(nodeBinDir, nodeBinaryName()))
 	writeExecutable(t, filepath.Join(nodeBinDir, npmBinaryName()))
+	writeCorepackWrapper(t, filepath.Join(nodeBinDir, corepackBinaryName()))
 
 	resolved, err := DefaultResolver{
 		RuntimeRoot: root,
@@ -253,6 +254,63 @@ func TestDefaultResolverPreloadsRuntimeProfileComponents(t *testing.T) {
 	}
 }
 
+func TestDefaultResolverReplacesNodeComponentWithBrokenCorepackWrapper(t *testing.T) {
+	cacheRoot := t.TempDir()
+	root := filepath.Join(cacheRoot, appRuntimePlatformArch(runtime.GOOS, runtime.GOARCH))
+	nodeBinDir := filepath.Join(root, "node", "bin")
+	writeExecutable(t, filepath.Join(nodeBinDir, nodeBinaryName()))
+	writeExecutable(t, filepath.Join(nodeBinDir, npmBinaryName()))
+	writeExecutable(t, filepath.Join(nodeBinDir, corepackBinaryName()))
+
+	nodeArtifactPath := createManagedRuntimeComponentArchiveForTest(t, "node")
+	nodeSHA256, _, err := fileSHA256AndSize(nodeArtifactPath)
+	if err != nil {
+		t.Fatalf("fileSHA256AndSize() error = %v", err)
+	}
+	catalogPath := filepath.Join(t.TempDir(), "runtimes.json")
+	catalogJSON := `{
+  "schemaVersion": "tutti.app.runtimes.v2",
+  "runtimes": {
+    "` + appRuntimePlatformArch(runtime.GOOS, runtime.GOARCH) + `": {
+      "version": "test",
+      "components": {
+        "node": {
+          "version": "test-node",
+          "artifactUrl": "` + filepath.ToSlash(nodeArtifactPath) + `",
+          "artifactSha256": "` + nodeSHA256 + `"
+        }
+      },
+      "profiles": {
+        "baseline": ["node"],
+        "node-static": ["node"]
+      }
+    }
+  }
+}`
+	if err := os.WriteFile(catalogPath, []byte(catalogJSON), 0o644); err != nil {
+		t.Fatalf("write catalog: %v", err)
+	}
+
+	resolved, err := DefaultResolver{
+		Environ: func() []string {
+			return []string{
+				tuttiAppRuntimeCacheRootEnv + "=" + cacheRoot,
+				tuttiAppRuntimeCatalogEnv + "=" + catalogPath,
+				"PATH=/usr/bin:/bin",
+			}
+		},
+	}.ResolveProfile(context.Background(), appRuntimeNodeStaticProfile)
+	if err != nil {
+		t.Fatalf("ResolveProfile() error = %v", err)
+	}
+	if !isStandaloneCorepackWrapper(filepath.Join(nodeBinDir, corepackBinaryName())) {
+		t.Fatal("ResolveProfile() did not replace the broken corepack wrapper")
+	}
+	if resolved.Node != filepath.Join(nodeBinDir, nodeBinaryName()) {
+		t.Fatalf("resolved Node = %q, want managed node component", resolved.Node)
+	}
+}
+
 func TestDefaultResolverRejectsRuntimeShaMismatch(t *testing.T) {
 	cacheRoot := t.TempDir()
 	pythonArtifactPath := createManagedRuntimeComponentArchiveForTest(t, "python")
@@ -318,6 +376,27 @@ func writeExecutable(t *testing.T, path string) {
 	}
 }
 
+func writeCorepackWrapper(t *testing.T, path string) {
+	t.Helper()
+	body := `#!/bin/sh
+script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+exec "${script_dir}/node" "${script_dir}/../lib/node_modules/corepack/dist/corepack.js" "$@"
+`
+	mode := os.FileMode(0o755)
+	if runtime.GOOS == "windows" {
+		body = `@echo off
+"%~dp0node.exe" "%~dp0..\lib\node_modules\corepack\dist\corepack.js" %*
+`
+		mode = 0o644
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create corepack wrapper parent %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(body), mode); err != nil {
+		t.Fatalf("write corepack wrapper %s: %v", path, err)
+	}
+}
+
 func createManagedRuntimeComponentArchiveForTest(t *testing.T, componentName string) string {
 	t.Helper()
 
@@ -328,6 +407,7 @@ func createManagedRuntimeComponentArchiveForTest(t *testing.T, componentName str
 	case "node":
 		writeExecutable(t, filepath.Join(sourceDir, "node", "bin", nodeBinaryName()))
 		writeExecutable(t, filepath.Join(sourceDir, "node", "bin", npmBinaryName()))
+		writeCorepackWrapper(t, filepath.Join(sourceDir, "node", "bin", corepackBinaryName()))
 	default:
 		t.Fatalf("unsupported runtime component %q", componentName)
 	}

--- a/services/tuttid/service/workspace/apps_runner_test.go
+++ b/services/tuttid/service/workspace/apps_runner_test.go
@@ -886,6 +886,11 @@ exit 0
 `), 0o755); err != nil {
 		t.Fatalf("WriteFile(managed npm) error = %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(nodeBinDir, "corepack"), []byte(`#!/bin/sh
+exec "$(dirname "$0")/node" "$(dirname "$0")/../lib/node_modules/corepack/dist/corepack.js" "$@"
+`), 0o755); err != nil {
+		t.Fatalf("WriteFile(managed corepack) error = %v", err)
+	}
 	return runtimeRoot
 }
 

--- a/tools/scripts/build-tutti-app-runtime-catalog.test.mjs
+++ b/tools/scripts/build-tutti-app-runtime-catalog.test.mjs
@@ -121,9 +121,12 @@ test("Tutti app runtime workflow publishes immutable artifacts and mutable catal
   assert.match(workflow, /npm-cli\.js/);
   assert.match(workflow, /node\/bin\/npx/);
   assert.match(workflow, /npx-cli\.js/);
+  assert.match(workflow, /node\/bin\/corepack/);
+  assert.match(workflow, /corepack\/dist\/corepack\.js/);
   assert.match(workflow, /\$\{node_staging\}\/node\/bin\/npm" --version/);
   assert.match(workflow, /"node-static": \["node"\]/);
   assert.match(workflow, /\$\{node_staging\}\/node\/bin\/npx" --version/);
+  assert.match(workflow, /\$\{node_staging\}\/node\/bin\/corepack" --version/);
   assert.match(workflow, /path: downloaded-tutti-app-runtime/);
   assert.match(workflow, /merge-multiple: false/);
   assert.match(workflow, /Restore runtime artifact layout/);

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -129,6 +129,33 @@ test("desktop release workflow gates manual rc and stable modes by release branc
   );
 });
 
+test("desktop promotion requires the managed app runtime release first", async () => {
+  const promoteWorkflow = await readFile(promoteWorkflowPath, "utf8");
+  const checkoutIndex = promoteWorkflow.indexOf(
+    "name: Checkout release target"
+  );
+  const runtimeGateIndex = promoteWorkflow.indexOf(
+    "name: Verify managed app runtime is published"
+  );
+  const downloadIndex = promoteWorkflow.indexOf(
+    "name: Download staged GitHub release assets"
+  );
+
+  assert.ok(checkoutIndex >= 0, "promotion should checkout the release target");
+  assert.ok(
+    runtimeGateIndex > checkoutIndex,
+    "runtime gate should read the lock from the release target"
+  );
+  assert.ok(
+    downloadIndex > runtimeGateIndex,
+    "runtime gate should pass before promotion begins"
+  );
+  assert.match(
+    promoteWorkflow,
+    /node tools\/scripts\/verify-tutti-app-runtime-release\.mjs/
+  );
+});
+
 test("desktop release workflow schedules a daily Beijing 4:16am rc release", async () => {
   const workflow = await readFile(workflowPath, "utf8");
 

--- a/tools/scripts/verify-tutti-app-runtime-release.mjs
+++ b/tools/scripts/verify-tutti-app-runtime-release.mjs
@@ -10,6 +10,10 @@ export function validateTuttiAppRuntimeRelease({ catalog, lock }) {
     lock?.runtimeVersion,
     "runtimeVersion"
   );
+  const expectedVersionParts = parseRuntimeVersion(
+    expectedVersion,
+    "runtime lock runtimeVersion"
+  );
   const platforms = Object.keys(lock?.platforms ?? {});
   if (platforms.length === 0) {
     throw new Error("runtime lock must declare at least one platform");
@@ -23,9 +27,27 @@ export function validateTuttiAppRuntimeRelease({ catalog, lock }) {
   const mismatches = [];
   for (const platform of platforms) {
     const publishedVersion = catalog.runtimes?.[platform]?.version;
-    if (publishedVersion !== expectedVersion) {
+    if (typeof publishedVersion !== "string") {
       mismatches.push(
-        `${platform}: expected ${expectedVersion}, got ${publishedVersion ?? "missing"}`
+        `${platform}: expected at least ${expectedVersion}, got missing`
+      );
+      continue;
+    }
+    let publishedVersionParts;
+    try {
+      publishedVersionParts = parseRuntimeVersion(
+        publishedVersion,
+        `${platform} published runtime version`
+      );
+    } catch (error) {
+      mismatches.push(`${platform}: ${error.message}`);
+      continue;
+    }
+    if (
+      compareRuntimeVersions(publishedVersionParts, expectedVersionParts) < 0
+    ) {
+      mismatches.push(
+        `${platform}: expected at least ${expectedVersion}, got ${publishedVersion}`
       );
     }
   }
@@ -106,6 +128,29 @@ function requiredString(value, name) {
     throw new Error(`runtime lock ${name} is required`);
   }
   return value.trim();
+}
+
+function parseRuntimeVersion(value, name) {
+  const match = /^(\d{4})\.(\d{2})\.(0|[1-9]\d*)$/u.exec(value);
+  if (!match) {
+    throw new Error(
+      `${name} must use YYYY.MM.PATCH, got ${JSON.stringify(value)}`
+    );
+  }
+  const parts = match.slice(1).map(Number);
+  if (parts[1] < 1 || parts[1] > 12) {
+    throw new Error(`${name} has an invalid month in ${JSON.stringify(value)}`);
+  }
+  return parts;
+}
+
+function compareRuntimeVersions(left, right) {
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) {
+      return left[index] - right[index];
+    }
+  }
+  return 0;
 }
 
 if (

--- a/tools/scripts/verify-tutti-app-runtime-release.mjs
+++ b/tools/scripts/verify-tutti-app-runtime-release.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+export const defaultTuttiAppRuntimeCatalogURL =
+  "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-app-runtimes/catalog.json";
+
+export function validateTuttiAppRuntimeRelease({ catalog, lock }) {
+  const expectedVersion = requiredString(
+    lock?.runtimeVersion,
+    "runtimeVersion"
+  );
+  const platforms = Object.keys(lock?.platforms ?? {});
+  if (platforms.length === 0) {
+    throw new Error("runtime lock must declare at least one platform");
+  }
+  if (catalog?.schemaVersion !== "tutti.app.runtimes.v2") {
+    throw new Error(
+      `runtime catalog schemaVersion must be tutti.app.runtimes.v2, got ${JSON.stringify(catalog?.schemaVersion)}`
+    );
+  }
+
+  const mismatches = [];
+  for (const platform of platforms) {
+    const publishedVersion = catalog.runtimes?.[platform]?.version;
+    if (publishedVersion !== expectedVersion) {
+      mismatches.push(
+        `${platform}: expected ${expectedVersion}, got ${publishedVersion ?? "missing"}`
+      );
+    }
+  }
+  if (mismatches.length > 0) {
+    throw new Error(
+      [
+        `managed app runtime ${expectedVersion} is not published for every desktop platform:`,
+        ...mismatches.map((mismatch) => `- ${mismatch}`),
+        "Run Publish Tutti App Runtime for this release target and verify the production catalog before promoting the desktop release."
+      ].join("\n")
+    );
+  }
+
+  return { platforms, runtimeVersion: expectedVersion };
+}
+
+export async function verifyTuttiAppRuntimeRelease({
+  catalogURL = defaultTuttiAppRuntimeCatalogURL,
+  fetchImpl = globalThis.fetch,
+  lockFile = "config/tutti.app-runtime.lock.json"
+} = {}) {
+  const lock = JSON.parse(await readFile(lockFile, "utf8"));
+  const response = await fetchImpl(catalogURL, {
+    headers: {
+      accept: "application/json",
+      "cache-control": "no-cache"
+    },
+    redirect: "follow",
+    signal: AbortSignal.timeout(15_000)
+  });
+  if (!response.ok) {
+    throw new Error(
+      `failed to fetch managed app runtime catalog ${catalogURL}: HTTP ${response.status}`
+    );
+  }
+  const result = validateTuttiAppRuntimeRelease({
+    catalog: await response.json(),
+    lock
+  });
+  return { ...result, catalogURL };
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  const result = await verifyTuttiAppRuntimeRelease(options);
+  console.log(
+    `Verified managed app runtime ${result.runtimeVersion} for ${result.platforms.join(", ")} at ${result.catalogURL}`
+  );
+}
+
+function parseArgs(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--catalog-url":
+        options.catalogURL = requiredArgument(argv[++index], arg);
+        break;
+      case "--lock-file":
+        options.lockFile = requiredArgument(argv[++index], arg);
+        break;
+      default:
+        throw new Error(`unknown argument ${arg}`);
+    }
+  }
+  return options;
+}
+
+function requiredArgument(value, flag) {
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function requiredString(value, name) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`runtime lock ${name} is required`);
+  }
+  return value.trim();
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/tools/scripts/verify-tutti-app-runtime-release.test.mjs
+++ b/tools/scripts/verify-tutti-app-runtime-release.test.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  defaultTuttiAppRuntimeCatalogURL,
+  validateTuttiAppRuntimeRelease,
+  verifyTuttiAppRuntimeRelease
+} from "./verify-tutti-app-runtime-release.mjs";
+
+const runtimeSourcePath = new URL(
+  "../../services/tuttid/service/managedruntime/runtime.go",
+  import.meta.url
+);
+
+test("validateTuttiAppRuntimeRelease accepts the locked version for every platform", () => {
+  const result = validateTuttiAppRuntimeRelease({
+    catalog: runtimeCatalog("2026.07.0"),
+    lock: runtimeLock("2026.07.0")
+  });
+
+  assert.deepEqual(result, {
+    platforms: ["darwin-arm64", "linux-amd64"],
+    runtimeVersion: "2026.07.0"
+  });
+});
+
+test("validateTuttiAppRuntimeRelease rejects stale or missing platforms with release guidance", () => {
+  const catalog = runtimeCatalog("2026.06.0");
+  delete catalog.runtimes["linux-amd64"];
+
+  assert.throws(
+    () =>
+      validateTuttiAppRuntimeRelease({
+        catalog,
+        lock: runtimeLock("2026.07.0")
+      }),
+    (error) => {
+      assert.match(
+        error.message,
+        /darwin-arm64: expected 2026\.07\.0, got 2026\.06\.0/
+      );
+      assert.match(
+        error.message,
+        /linux-amd64: expected 2026\.07\.0, got missing/
+      );
+      assert.match(error.message, /Publish Tutti App Runtime/);
+      assert.match(error.message, /before promoting the desktop release/);
+      return true;
+    }
+  );
+});
+
+test("verifyTuttiAppRuntimeRelease fetches the production catalog without cache", async () => {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "tutti-runtime-gate-"));
+  const lockFile = path.join(tempDir, "runtime-lock.json");
+  await writeFile(
+    lockFile,
+    `${JSON.stringify(runtimeLock("2026.07.0"))}\n`,
+    "utf8"
+  );
+  let request;
+
+  const result = await verifyTuttiAppRuntimeRelease({
+    fetchImpl: async (url, options) => {
+      request = { options, url };
+      return {
+        json: async () => runtimeCatalog("2026.07.0"),
+        ok: true,
+        status: 200
+      };
+    },
+    lockFile
+  });
+
+  assert.equal(request.url, defaultTuttiAppRuntimeCatalogURL);
+  assert.equal(request.options.headers["cache-control"], "no-cache");
+  assert.equal(request.options.redirect, "follow");
+  assert.equal(result.runtimeVersion, "2026.07.0");
+});
+
+test("release gate default catalog stays aligned with tuttid", async () => {
+  const runtimeSource = await readFile(runtimeSourcePath, "utf8");
+
+  assert.match(
+    runtimeSource,
+    new RegExp(
+      `defaultTuttiAppRuntimeCatalogURL = ${JSON.stringify(defaultTuttiAppRuntimeCatalogURL)}`
+    )
+  );
+});
+
+function runtimeLock(runtimeVersion) {
+  return {
+    runtimeVersion,
+    platforms: {
+      "darwin-arm64": {},
+      "linux-amd64": {}
+    }
+  };
+}
+
+function runtimeCatalog(runtimeVersion) {
+  return {
+    schemaVersion: "tutti.app.runtimes.v2",
+    runtimes: {
+      "darwin-arm64": { version: runtimeVersion },
+      "linux-amd64": { version: runtimeVersion }
+    }
+  };
+}

--- a/tools/scripts/verify-tutti-app-runtime-release.test.mjs
+++ b/tools/scripts/verify-tutti-app-runtime-release.test.mjs
@@ -27,6 +27,18 @@ test("validateTuttiAppRuntimeRelease accepts the locked version for every platfo
   });
 });
 
+test("validateTuttiAppRuntimeRelease accepts newer published runtimes", () => {
+  const catalog = runtimeCatalog("2026.08.0");
+  catalog.runtimes["linux-amd64"].version = "2027.01.2";
+
+  const result = validateTuttiAppRuntimeRelease({
+    catalog,
+    lock: runtimeLock("2026.07.3")
+  });
+
+  assert.equal(result.runtimeVersion, "2026.07.3");
+});
+
 test("validateTuttiAppRuntimeRelease rejects stale or missing platforms with release guidance", () => {
   const catalog = runtimeCatalog("2026.06.0");
   delete catalog.runtimes["linux-amd64"];
@@ -40,16 +52,35 @@ test("validateTuttiAppRuntimeRelease rejects stale or missing platforms with rel
     (error) => {
       assert.match(
         error.message,
-        /darwin-arm64: expected 2026\.07\.0, got 2026\.06\.0/
+        /darwin-arm64: expected at least 2026\.07\.0, got 2026\.06\.0/
       );
       assert.match(
         error.message,
-        /linux-amd64: expected 2026\.07\.0, got missing/
+        /linux-amd64: expected at least 2026\.07\.0, got missing/
       );
       assert.match(error.message, /Publish Tutti App Runtime/);
       assert.match(error.message, /before promoting the desktop release/);
       return true;
     }
+  );
+});
+
+test("validateTuttiAppRuntimeRelease rejects malformed runtime versions", () => {
+  assert.throws(
+    () =>
+      validateTuttiAppRuntimeRelease({
+        catalog: runtimeCatalog("2026.7.0"),
+        lock: runtimeLock("2026.07.0")
+      }),
+    /darwin-arm64: darwin-arm64 published runtime version must use YYYY\.MM\.PATCH/
+  );
+  assert.throws(
+    () =>
+      validateTuttiAppRuntimeRelease({
+        catalog: runtimeCatalog("2026.07.0"),
+        lock: runtimeLock("2026.13.0")
+      }),
+    /runtime lock runtimeVersion has an invalid month/
   );
 });
 


### PR DESCRIPTION
## Summary

- replace the dereferenced packaged Corepack entry with a standalone wrapper that launches the bundled Corepack CLI through the managed Node binary
- reject and replace existing managed Node caches that contain the incompatible Corepack layout, including agent provider and installer fast paths
- bump the immutable managed runtime version to `2026.07.0`
- gate desktop release promotion on the production runtime catalog publishing at least the locked `YYYY.MM.PATCH` version for every supported platform
- add workflow contracts, resolver/provider recovery coverage, release-gate tests, and durable runtime troubleshooting documentation

## Root cause

The runtime publisher stages Node with `rsync -aL`, which dereferences Node's relative `bin/corepack` symlink. The copied JavaScript then lives under `node/bin` and resolves `./lib/corepack.cjs` from the wrong directory. Because the managed runtime is prepended to `PATH`, this broken Corepack shadows a usable user installation and causes unrelated `corepack pnpm` validation lanes to fail before their own logic starts.

## User and developer impact

New runtime artifacts contain a self-contained Corepack launcher and validate it with `corepack --version` during publishing. Existing broken caches are treated as unavailable and replaced from the catalog; provider paths that do not require the managed runtime skip incompatible optional caches instead of injecting their `node/bin` into `PATH`.

Desktop promotion now fails closed until every locked platform publishes a runtime version at least as new as the release target's lock. Numeric `YYYY.MM.PATCH` ordering permits an older compatible desktop release to be promoted again after a newer runtime is published.

The production catalog currently reports `2026.06.0`; run **Publish Tutti App Runtime** and verify `2026.07.0` before promoting a desktop release containing this change.

## Validation

- `node --test tools/scripts/verify-tutti-app-runtime-release.test.mjs tools/scripts/desktop-release-config.test.mjs tools/scripts/build-tutti-app-runtime-catalog.test.mjs` — 49 passed
- `cd services/tuttid && go test ./service/managedruntime ./service/workspace ./service/agentstatus` — passed
- `cd services/tuttid && go test -race ./service/managedruntime` — passed
- `pnpm test:tools` — passed
- `pnpm build:go` — passed
- `git diff --check` — passed
- `pnpm check:changed` — 7/8 lanes passed; the remaining Go lint lane reports six pre-existing SA5011 findings in unchanged tests (`service/agentstatus/active_action_test.go`, `service/agentstatus/installer_codex_cli_test.go`, and `service/workspace/apps_test.go`)

## Review note

The cache compatibility check intentionally remains at the wrapper-contract level for this PR; it does not add target-script existence validation.