### PR TITLE
fix(agent-gui): allow host folder references

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIWorkspaceReferencePicker.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIWorkspaceReferencePicker.spec.tsx
@@ -31,6 +31,23 @@ function createInput(
 }
 
 describe("useAgentGUIWorkspaceReferencePicker project directory purpose", () => {
+  it("allows Host folders for ordinary workspace references", () => {
+    const { result } = renderHook(() =>
+      useAgentGUIWorkspaceReferencePicker(
+        createInput({} as ReferenceSourceAggregator)
+      )
+    );
+
+    expect(result.current.workspaceReferencePickerPurpose).toBe("reference");
+    expect(
+      result.current.isWorkspaceReferencePickerNodeSelectable({
+        displayName: "host-folder",
+        kind: "folder",
+        ref: { nodeId: "/Users/me/project", sourceId: "host-local-file" }
+      })
+    ).toBe(true);
+  });
+
   it("opens the shared picker with the directory aggregator and resolves one folder", async () => {
     const projectDirectorySourceAggregator = {} as ReferenceSourceAggregator;
     const { result } = renderHook(() =>

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIWorkspaceReferencePicker.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIWorkspaceReferencePicker.ts
@@ -58,11 +58,9 @@ export function useAgentGUIWorkspaceReferencePicker(input: Input) {
       if (workspaceReferencePickerPurpose === "directory") {
         return node.kind === "folder";
       }
-      return (
-        node.ref.sourceId !== hostLocalFileSourceId || node.kind === "file"
-      );
+      return true;
     },
-    [hostLocalFileSourceId, workspaceReferencePickerPurpose]
+    [workspaceReferencePickerPurpose]
   );
   const requestWorkspaceReferences = useCallback(
     async (


### PR DESCRIPTION
## Summary

- allow ordinary AgentGUI workspace references to select Host folders
- keep project-directory picker behavior constrained to folders
- add regression coverage for a Host folder reference

## Verification

- `pnpm check:changed` — 11 selected lanes passed
- `pnpm release:pack:check -- --packages-json '["@tutti-os/agent-gui"]'`
- TSH Host projection directory selection and Agent execution were manually verified by the consumer owner

## AgentGUI Review

| Lane | Trigger | Result | Evidence | Affected consumers |
| --- | --- | --- | --- | --- |
| Architecture | Composer reference selection policy changes | pass | Existing reference-source ownership is unchanged; the host source still prepares and authorizes the selected node | AgentGUI composer, TSH |
| Performance | Selection predicate changes | not applicable | The predicate removes a source/kind branch and adds no subscription, I/O, allocation, or render fanout | AgentGUI picker |
| Consumers | Host folder behavior changes | pass | Regression test covers Host folders; TSH local-link end-to-end verification passed; no exported type or API shape changed | Tutti Desktop, TSH, other AgentGUI hosts |

Unresolved risks: none. Hosts remain responsible for rejecting or preparing unsupported folder references.

Documentation impact: no update required. The existing Agent Reference Sources architecture and AgentGUI README already define ordinary references as file/folder mentions.

## Checklist

- [x] This change does not alter Agent lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] Existing durable documentation already describes the resulting behavior.
- [x] No README/CONTRIBUTING language source changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] The commit is signed off with DCO.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1892" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->