### PR TITLE
Unify collaboration adoption transport and timeline projection

### DIFF
--- a/apps/desktop/src/main/host/workspaceHostAccess.test.ts
+++ b/apps/desktop/src/main/host/workspaceHostAccess.test.ts
@@ -584,6 +584,9 @@ function createTransportClient(
     async cancelWorkspaceIssueExecution() {
       throw new Error("not used");
     },
+    async setCollaborationRunAdoption() {
+      throw new Error("not used");
+    },
     async cancelTuttiModeExecution() {
       throw new Error("not used");
     }

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type {
   AgentActivityUpdatedEventV1,
+  CollaborationRun,
   TuttidClient
 } from "@tutti-os/client-tuttid-ts";
 import { TuttidProtocolError } from "@tutti-os/client-tuttid-ts";
@@ -3794,32 +3795,9 @@ test("WorkspaceAgentActivityService exposes durable AutomationRule session overr
   ]);
 });
 
-function createCollaborationService(
-  fetchStub: typeof fetch
-): WorkspaceAgentActivityService {
-  // The collaboration/model-plan requests call the generated SDK directly with
-  // a client built from getBackendConfig; the stubbed global fetch observes
-  // the raw HTTP request.
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = fetchStub;
-  test.after(() => {
-    globalThis.fetch = originalFetch;
-  });
-  return new WorkspaceAgentActivityService({
-    tuttidClient: {} as TuttidClient,
-    runtimeApi: {
-      getBackendConfig: async () => ({
-        accessToken: "token-1",
-        baseUrl: "http://127.0.0.1:7777"
-      }),
-      logTerminalDiagnostic: async () => {}
-    }
-  });
-}
-
 function collaborationRunResponseBody(
   overrides: Record<string, unknown> = {}
-): Record<string, unknown> {
+): CollaborationRun {
   return {
     id: "run-1",
     workspaceId: "ws-1",
@@ -3838,39 +3816,42 @@ function collaborationRunResponseBody(
     createdAt: "2026-07-12T00:00:00.000Z",
     updatedAt: "2026-07-12T00:00:05.200Z",
     ...overrides
-  };
+  } as CollaborationRun;
 }
 
-test("WorkspaceAgentActivityService.setCollaborationAdoption posts the adoption decision", async () => {
-  const observedRequests: Array<{ body: unknown; url: string }> = [];
-  const service = createCollaborationService((async (
-    input: RequestInfo | URL,
-    init?: RequestInit
-  ) => {
-    const request = new Request(input, init);
-    observedRequests.push({ body: await request.json(), url: request.url });
-    return new Response(
-      JSON.stringify(collaborationRunResponseBody({ adoption: "adopted" })),
-      {
-        headers: { "Content-Type": "application/json" },
-        status: 200
+test("WorkspaceAgentActivityService.setCollaborationAdoption delegates to the canonical tuttid client", async () => {
+  const calls: Parameters<TuttidClient["setCollaborationRunAdoption"]>[] = [];
+  const abortController = new AbortController();
+  const service = new WorkspaceAgentActivityService({
+    tuttidClient: {
+      async setCollaborationRunAdoption(
+        ...args: Parameters<TuttidClient["setCollaborationRunAdoption"]>
+      ) {
+        calls.push(args);
+        return collaborationRunResponseBody({ adoption: "adopted" });
       }
-    );
-  }) as typeof fetch);
+    } as unknown as TuttidClient,
+    runtimeApi: { logTerminalDiagnostic: async () => {} }
+  });
 
   const run = await service.setCollaborationAdoption({
     adoption: "adopted",
     agentSessionId: "session-1",
     runId: "run-1",
-    workspaceId: "ws-1"
+    signal: abortController.signal,
+    workspaceId: " ws-1 "
   });
 
-  assert.equal(
-    observedRequests[0]?.url,
-    "http://127.0.0.1:7777/v1/workspaces/ws-1/collaboration-runs/run-1/adoption"
-  );
-  assert.deepEqual(observedRequests[0]?.body, { adoption: "adopted" });
+  assert.deepEqual(calls, [
+    [
+      "ws-1",
+      "run-1",
+      { adoption: "adopted" },
+      { signal: abortController.signal }
+    ]
+  ]);
   assert.equal(run.adoption, "adopted");
+  assert.equal(run.workspaceId, "ws-1");
 });
 
 test("WorkspaceAgentActivityService engine owns edit retry and authoritative reconcile", async () => {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -15,16 +15,10 @@ import {
 import type { AgentActivityRuntime } from "@tutti-os/agent-gui";
 import type {
   AgentProviderStatusListResponse,
-  Client,
   CollaborationRun,
   TuttidClient,
   TuttidEventStreamClient,
   WorkspaceAgentProvider
-} from "@tutti-os/client-tuttid-ts";
-import {
-  createClient,
-  normalizeTuttidError,
-  setCollaborationRunAdoption
 } from "@tutti-os/client-tuttid-ts";
 import type { DesktopHostFilesApi, DesktopRuntimeApi } from "@preload/types";
 import type { IReporterService } from "../../../analytics/services/reporterService.interface.ts";
@@ -95,8 +89,7 @@ export interface WorkspaceAgentActivityServiceDependencies {
   tuttidClient: TuttidClient;
   reporterNow?: () => number;
   reporterService?: Pick<IReporterService, "trackEvents">;
-  runtimeApi: Pick<DesktopRuntimeApi, "logTerminalDiagnostic"> &
-    Partial<Pick<DesktopRuntimeApi, "getBackendConfig">>;
+  runtimeApi: Pick<DesktopRuntimeApi, "logTerminalDiagnostic">;
   forceRefreshAgentProviderStatuses?: (
     providers: WorkspaceAgentProvider[]
   ) => Promise<AgentProviderStatusListResponse | null>;
@@ -135,15 +128,6 @@ export class WorkspaceAgentActivityService
       observeIntent(intent: EngineIntent): void;
     }>
   >();
-  // Collaboration-run/model-plan requests are not part of the TuttidClient
-  // wrapper yet, so they call the generated SDK directly. The client is
-  // re-resolved from the backend config on every call (cached per endpoint)
-  // because the managed daemon can restart onto a new ephemeral port.
-  private collaborationClientCache: {
-    accessToken: string;
-    baseUrl: string;
-    client: Client;
-  } | null = null;
   constructor(dependencies: WorkspaceAgentActivityServiceDependencies) {
     super(dependencies);
     this.dependencies = dependencies;
@@ -742,51 +726,14 @@ export class WorkspaceAgentActivityService
     NonNullable<IWorkspaceAgentActivityService["setCollaborationAdoption"]>
   > {
     const workspaceId = normalizeWorkspaceId(input.workspaceId);
-    const client = await this.resolveCollaborationClient();
-    const response = await setCollaborationRunAdoption({
-      body: { adoption: input.adoption },
-      client,
-      path: {
-        collaborationRunID: input.runId,
-        workspaceID: workspaceId
-      },
-      signal: input.signal
-    });
-    return agentActivityCollaborationRunFromTuttid(
-      unwrapCollaborationData(
-        response,
-        "Collaboration adoption request failed."
-      )
-    );
-  }
-
-  private async resolveCollaborationClient(): Promise<Client> {
-    const getBackendConfig = this.dependencies.runtimeApi.getBackendConfig;
-    if (!getBackendConfig) {
-      throw new Error(
-        "Collaboration requests are unavailable: backend config resolver is missing."
+    const run =
+      await this.dependencies.tuttidClient.setCollaborationRunAdoption(
+        workspaceId,
+        input.runId,
+        { adoption: input.adoption },
+        { signal: input.signal }
       );
-    }
-    const config = await getBackendConfig();
-    const cached = this.collaborationClientCache;
-    if (
-      cached &&
-      cached.baseUrl === config.baseUrl &&
-      cached.accessToken === config.accessToken
-    ) {
-      return cached.client;
-    }
-    const client = createClient({
-      auth: config.accessToken,
-      baseUrl: config.baseUrl,
-      fetch: globalThis.fetch.bind(globalThis)
-    });
-    this.collaborationClientCache = {
-      accessToken: config.accessToken,
-      baseUrl: config.baseUrl,
-      client
-    };
-    return client;
+    return agentActivityCollaborationRunFromTuttid(run);
   }
 
   async listAutomationRules(input: {
@@ -1098,24 +1045,6 @@ export class WorkspaceAgentActivityService
       }
     }
   }
-}
-
-// Local equivalent of the TuttidClient unwrap helper for direct generated-SDK
-// calls: normalize protocol errors, otherwise fall back to the caller message.
-function unwrapCollaborationData<TResult>(
-  response: { data?: TResult; error?: unknown; response?: Response },
-  fallback: string
-): TResult {
-  if (response.error !== undefined) {
-    throw (
-      normalizeTuttidError(response.error, response.response?.status ?? 0) ??
-      new Error(fallback)
-    );
-  }
-  if (response.data === undefined) {
-    throw new Error(fallback);
-  }
-  return response.data;
 }
 
 function agentActivityCollaborationRunFromTuttid(run: CollaborationRun): {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/registerWorkspaceAgentServices.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/registerWorkspaceAgentServices.ts
@@ -51,11 +51,7 @@ export interface WorkspaceAgentServiceRegistrationInput {
   runtimeApi: Pick<
     DesktopRuntimeApi,
     "logRendererDiagnostic" | "logTerminalDiagnostic"
-  > &
-    // Collaboration-run/model-plan requests resolve the daemon endpoint
-    // per-call; older hosts/tests may omit the resolver and those optional
-    // commands then fail at call time instead of registration time.
-    Partial<Pick<DesktopRuntimeApi, "getBackendConfig">>;
+  >;
   resolveAgentTargetIconUrl?: (identity: {
     iconKey: string | null;
     provider: string;

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.test.ts
@@ -1025,6 +1025,7 @@ function createDependenciesStub(): {
       listWorkspaceWorkflows: fail,
       decideWorkspaceWorkflowCheckpoint: fail,
       cancelWorkspaceIssueExecution: fail,
+      setCollaborationRunAdoption: fail,
       cancelTuttiModeExecution: fail
     },
     platformApi: {

--- a/packages/agent/store-sqlite/activity_messages.go
+++ b/packages/agent/store-sqlite/activity_messages.go
@@ -95,6 +95,10 @@ func (*Store) upsertAgentMessageTx(
 		if turnID != "" {
 			return Message{}, false, fmt.Errorf("workspace agent session audit must not reference turn %q", turnID)
 		}
+	} else if kind == "collaboration" {
+		if turnID != "" {
+			return Message{}, false, fmt.Errorf("workspace agent collaboration message must not reference turn %q", turnID)
+		}
 	} else if turnID == "" && !allowLegacyTurnless {
 		return Message{}, false, fmt.Errorf("workspace agent message %q kind %q is missing turn", message.MessageID, kind)
 	} else if turnID != "" {

--- a/packages/agent/store-sqlite/store_test.go
+++ b/packages/agent/store-sqlite/store_test.go
@@ -511,6 +511,47 @@ func TestSessionAuditIsTurnlessAndDoesNotChangeActiveTurn(t *testing.T) {
 	}
 }
 
+func TestCollaborationMessageIsTurnlessAndDoesNotChangeActiveTurn(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	ctx := context.Background()
+	if _, err := store.ReportSessionState(ctx, SessionStateReport{
+		WorkspaceID: "ws-collaboration", AgentSessionID: "session-collaboration", Origin: "runtime", Provider: "codex",
+		Status: "running", CurrentPhase: "working", OccurredAtUnixMS: 100,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, accepted, err := store.RecordTurnTransition(ctx, TurnTransition{
+		WorkspaceID: "ws-collaboration", AgentSessionID: "session-collaboration", TurnID: "turn-active",
+		Phase: TurnPhaseRunning, Origin: TurnOriginUserPrompt, OccurredAtUnixMS: 101,
+	}); err != nil || !accepted {
+		t.Fatalf("RecordTurnTransition() accepted=%v error=%v", accepted, err)
+	}
+
+	result, err := store.ReportSessionMessages(ctx, SessionMessageReport{
+		WorkspaceID: "ws-collaboration", AgentSessionID: "session-collaboration", Origin: "runtime", Provider: "codex",
+		Messages: []MessageUpdate{{
+			MessageID: "collab:run-1", Role: "assistant", Kind: "collaboration", Status: "completed",
+			Payload: map[string]any{"runId": "run-1", "adoption": "pending"}, OccurredAtUnixMS: 102,
+		}},
+	})
+	if err != nil || result.AcceptedCount != 1 || result.Messages[0].TurnID != "" {
+		t.Fatalf("collaboration result=%#v error=%v", result, err)
+	}
+	turn, ok, err := store.GetTurn(ctx, "ws-collaboration", "session-collaboration", "turn-active")
+	if err != nil || !ok || turn.Phase != TurnPhaseRunning {
+		t.Fatalf("active turn=%#v ok=%v error=%v", turn, ok, err)
+	}
+	if _, err := store.ReportSessionMessages(ctx, SessionMessageReport{
+		WorkspaceID: "ws-collaboration", AgentSessionID: "session-collaboration", Origin: "runtime",
+		Messages: []MessageUpdate{{
+			MessageID: "collab:run-with-turn", TurnID: "turn-active", Role: "assistant", Kind: "collaboration", OccurredAtUnixMS: 103,
+		}},
+	}); err == nil {
+		t.Fatal("turn-scoped collaboration message was accepted")
+	}
+}
+
 func TestHistoricalImportCompatibilityCannotBeForgedByOrigin(t *testing.T) {
 	t.Parallel()
 	store := openTestStore(t, testOptions(&staticProjectPaths{}))

--- a/packages/clients/tuttid-ts/src/collaborationRunsClient.ts
+++ b/packages/clients/tuttid-ts/src/collaborationRunsClient.ts
@@ -1,0 +1,40 @@
+import {
+  setCollaborationRunAdoption as setCollaborationRunAdoptionRequest,
+  type CollaborationRun,
+  type SetCollaborationRunAdoptionRequest
+} from "./generated/index.ts";
+import type { Client } from "./generated/client/index.ts";
+import { unwrapData } from "./tuttidClientResponse.ts";
+import type { TuttidRequestOptions } from "./tuttidClientTypes.ts";
+
+export interface CollaborationRunsClient {
+  setCollaborationRunAdoption(
+    workspaceID: string,
+    collaborationRunID: string,
+    request: SetCollaborationRunAdoptionRequest,
+    requestOptions?: TuttidRequestOptions
+  ): Promise<CollaborationRun>;
+}
+
+export function createCollaborationRunsClient(
+  client: Client
+): CollaborationRunsClient {
+  return {
+    async setCollaborationRunAdoption(
+      workspaceID,
+      collaborationRunID,
+      request,
+      requestOptions
+    ) {
+      return unwrapData(
+        await setCollaborationRunAdoptionRequest({
+          client,
+          body: request,
+          path: { collaborationRunID, workspaceID },
+          ...requestOptions
+        }),
+        "Collaboration adoption request failed."
+      );
+    }
+  };
+}

--- a/packages/clients/tuttid-ts/src/index.test.ts
+++ b/packages/clients/tuttid-ts/src/index.test.ts
@@ -184,6 +184,47 @@ test("shared tuttid client performs Agent quick prompt CRUD", async () => {
   );
 });
 
+test("shared tuttid client records Collaboration Run adoption", async () => {
+  const abortController = new AbortController();
+  const run = {
+    id: "run-1",
+    workspaceId: "ws-1",
+    mode: "consult",
+    triggerSource: "user",
+    sourceSessionId: "session-1",
+    modelPlanId: "plan-1",
+    model: "kimi-k2",
+    status: "completed",
+    adoption: "adopted",
+    usage: { inputTokens: 812, outputTokens: 96 },
+    durationMs: 5200,
+    startedAt: "2026-07-12T00:00:00.000Z",
+    completedAt: "2026-07-12T00:00:05.200Z",
+    createdAt: "2026-07-12T00:00:00.000Z",
+    updatedAt: "2026-07-12T00:00:05.200Z"
+  } as const;
+  const { client, requests } = captureClient(jsonResponse(run));
+
+  assert.deepEqual(
+    await client.setCollaborationRunAdoption(
+      "ws-1",
+      "run-1",
+      { adoption: "adopted" },
+      { signal: abortController.signal }
+    ),
+    run
+  );
+  assertRequest(requests[0]!, {
+    authorization: null,
+    body: { adoption: "adopted" },
+    method: "POST",
+    path: "/v1/workspaces/ws-1/collaboration-runs/run-1/adoption",
+    query: {}
+  });
+  abortController.abort();
+  assert.equal(requests[0]!.signal.aborted, true);
+});
+
 test("generated tuttid client returns parsed health response", async () => {
   const client = createClient({
     baseUrl: "http://localhost:4545/",

--- a/packages/clients/tuttid-ts/src/index.ts
+++ b/packages/clients/tuttid-ts/src/index.ts
@@ -31,6 +31,10 @@ export {
   type TuttidClient
 } from "./tuttidClient.ts";
 export {
+  createCollaborationRunsClient,
+  type CollaborationRunsClient
+} from "./collaborationRunsClient.ts";
+export {
   createWorkspaceAgentConfigurationClient,
   type ModelPlanBillingMode,
   type ModelPlanPricing,

--- a/packages/clients/tuttid-ts/src/tuttidClient.ts
+++ b/packages/clients/tuttid-ts/src/tuttidClient.ts
@@ -96,6 +96,7 @@ import {
 } from "./generated/index.ts";
 import { createClient } from "./generated/client/index.ts";
 import { createAgentProvidersClient } from "./agentProvidersClient.ts";
+import { createCollaborationRunsClient } from "./collaborationRunsClient.ts";
 import { unwrapAccepted, unwrapData } from "./tuttidClientResponse.ts";
 import { createWorkspaceAppsClient } from "./workspaceAppsClient.ts";
 import { createWorkspaceAgentClient } from "./workspaceAgentClient.ts";
@@ -130,6 +131,7 @@ export function createTuttidClient(
   });
 
   return {
+    ...createCollaborationRunsClient(client),
     ...createWorkspaceAgentConfigurationClient(client),
     ...createWorkspaceIssueOrchestrationClient(client),
     async listAgentQuickPrompts() {

--- a/packages/clients/tuttid-ts/src/tuttidClientTypes.ts
+++ b/packages/clients/tuttid-ts/src/tuttidClientTypes.ts
@@ -179,6 +179,7 @@ import type {
   UserProjectPathCheckResponse
 } from "./generated/index.ts";
 import type { WorkspaceAgentConfigurationClient } from "./workspaceAgentConfigurationClient.ts";
+import type { CollaborationRunsClient } from "./collaborationRunsClient.ts";
 import type { WorkspaceIssueOrchestrationClient } from "./workspaceIssueOrchestrationClient.ts";
 
 export type TuttidRequestOptions = Omit<
@@ -204,7 +205,10 @@ export interface MobileRemoteAccessClient {
 }
 
 export interface TuttidClient
-  extends WorkspaceAgentConfigurationClient, WorkspaceIssueOrchestrationClient {
+  extends
+    CollaborationRunsClient,
+    WorkspaceAgentConfigurationClient,
+    WorkspaceIssueOrchestrationClient {
   listAgentQuickPrompts(): Promise<AgentQuickPromptListResponse>;
   createAgentQuickPrompt(
     request: CreateAgentQuickPromptRequest

--- a/packages/events/protocol/definitions/agent/activity.updated.event.json
+++ b/packages/events/protocol/definitions/agent/activity.updated.event.json
@@ -271,76 +271,151 @@
               "messages": {
                 "type": "array",
                 "items": {
-                  "type": "object",
-                  "required": [
-                    "agentSessionId",
-                    "kind",
-                    "messageId",
-                    "occurredAtUnixMs",
-                    "payload",
-                    "role",
-                    "sequence",
-                    "turnId",
-                    "version"
-                  ],
-                  "properties": {
-                    "agentSessionId": {
-                      "type": "string",
-                      "minLength": 1
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "required": [
+                        "agentSessionId",
+                        "kind",
+                        "messageId",
+                        "occurredAtUnixMs",
+                        "payload",
+                        "role",
+                        "sequence",
+                        "turnId",
+                        "version"
+                      ],
+                      "properties": {
+                        "agentSessionId": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "kind": {
+                          "const": "collaboration"
+                        },
+                        "messageId": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "payload": {
+                          "type": "object"
+                        },
+                        "role": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "sequence": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "description": "Stable message presentation order assigned when the durable message row is first created."
+                        },
+                        "version": {
+                          "type": "integer",
+                          "minimum": 1
+                        },
+                        "turnId": {
+                          "type": ["null"],
+                          "description": "Session-level collaboration messages do not belong to an agent turn."
+                        },
+                        "status": {
+                          "type": "string"
+                        },
+                        "occurredAtUnixMs": {
+                          "type": "integer",
+                          "minimum": 1
+                        },
+                        "startedAtUnixMs": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "completedAtUnixMs": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "createdAtUnixMs": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "updatedAtUnixMs": {
+                          "type": "integer",
+                          "minimum": 0
+                        }
+                      }
                     },
-                    "kind": {
-                      "type": "string",
-                      "minLength": 1
-                    },
-                    "messageId": {
-                      "type": "string",
-                      "minLength": 1
-                    },
-                    "payload": {
-                      "type": "object"
-                    },
-                    "role": {
-                      "type": "string",
-                      "minLength": 1
-                    },
-                    "sequence": {
-                      "type": "integer",
-                      "minimum": 1,
-                      "description": "Stable message presentation order assigned when the durable message row is first created."
-                    },
-                    "version": {
-                      "type": "integer",
-                      "minimum": 1
-                    },
-                    "turnId": {
-                      "type": "string",
-                      "minLength": 1,
-                      "description": "Turn-scoped messages always reference a real persisted Turn. Session audits use the separate session_audit event."
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "occurredAtUnixMs": {
-                      "type": "integer",
-                      "minimum": 1
-                    },
-                    "startedAtUnixMs": {
-                      "type": "integer",
-                      "minimum": 0
-                    },
-                    "completedAtUnixMs": {
-                      "type": "integer",
-                      "minimum": 0
-                    },
-                    "createdAtUnixMs": {
-                      "type": "integer",
-                      "minimum": 0
-                    },
-                    "updatedAtUnixMs": {
-                      "type": "integer",
-                      "minimum": 0
+                    {
+                      "type": "object",
+                      "required": [
+                        "agentSessionId",
+                        "kind",
+                        "messageId",
+                        "occurredAtUnixMs",
+                        "payload",
+                        "role",
+                        "sequence",
+                        "turnId",
+                        "version"
+                      ],
+                      "properties": {
+                        "agentSessionId": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "kind": {
+                          "type": "string",
+                          "minLength": 1,
+                          "pattern": "^(?!collaboration$|session_audit$).+"
+                        },
+                        "messageId": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "payload": {
+                          "type": "object"
+                        },
+                        "role": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "sequence": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "description": "Stable message presentation order assigned when the durable message row is first created."
+                        },
+                        "version": {
+                          "type": "integer",
+                          "minimum": 1
+                        },
+                        "turnId": {
+                          "type": "string",
+                          "minLength": 1,
+                          "description": "Turn-scoped messages always reference a real persisted Turn. Session audits use the separate session_audit event."
+                        },
+                        "status": {
+                          "type": "string"
+                        },
+                        "occurredAtUnixMs": {
+                          "type": "integer",
+                          "minimum": 1
+                        },
+                        "startedAtUnixMs": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "completedAtUnixMs": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "createdAtUnixMs": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "updatedAtUnixMs": {
+                          "type": "integer",
+                          "minimum": 0
+                        }
+                      }
                     }
-                  }
+                  ]
                 }
               }
             }

--- a/packages/events/protocol/src/generated/contracts.ts
+++ b/packages/events/protocol/src/generated/contracts.ts
@@ -299,22 +299,40 @@ export type AgentActivityUpdatedPayloadV1 =
         eventType: "message_update";
         latestVersion: number;
         acceptedCount: number;
-        messages: readonly {
-          agentSessionId: string;
-          kind: string;
-          messageId: string;
-          payload: Record<string, unknown>;
-          role: string;
-          sequence: number;
-          version: number;
-          turnId: string;
-          status?: string;
-          occurredAtUnixMs: number;
-          startedAtUnixMs?: number;
-          completedAtUnixMs?: number;
-          createdAtUnixMs?: number;
-          updatedAtUnixMs?: number;
-        }[];
+        messages: readonly (
+          | {
+              agentSessionId: string;
+              kind: "collaboration";
+              messageId: string;
+              payload: Record<string, unknown>;
+              role: string;
+              sequence: number;
+              version: number;
+              turnId: null;
+              status?: string;
+              occurredAtUnixMs: number;
+              startedAtUnixMs?: number;
+              completedAtUnixMs?: number;
+              createdAtUnixMs?: number;
+              updatedAtUnixMs?: number;
+            }
+          | {
+              agentSessionId: string;
+              kind: string;
+              messageId: string;
+              payload: Record<string, unknown>;
+              role: string;
+              sequence: number;
+              version: number;
+              turnId: string;
+              status?: string;
+              occurredAtUnixMs: number;
+              startedAtUnixMs?: number;
+              completedAtUnixMs?: number;
+              createdAtUnixMs?: number;
+              updatedAtUnixMs?: number;
+            }
+        )[];
       };
     }
   | {

--- a/packages/events/protocol/src/generated/registry.ts
+++ b/packages/events/protocol/src/generated/registry.ts
@@ -53,7 +53,7 @@ export interface BusinessEventDefinition {
   scope: BusinessEventScopeName;
 }
 
-export const businessEventCatalogRevision = "sha256:bbb3396091e770f0" as const;
+export const businessEventCatalogRevision = "sha256:2e36dcc0d1c65637" as const;
 
 export const businessEventDefinitions = [
   {

--- a/packages/events/protocol/src/generated/schemas.ts
+++ b/packages/events/protocol/src/generated/schemas.ts
@@ -990,78 +990,155 @@ export const agentActivityUpdatedPayloadSchema = {
             messages: {
               type: "array",
               items: {
-                type: "object",
-                required: [
-                  "agentSessionId",
-                  "kind",
-                  "messageId",
-                  "occurredAtUnixMs",
-                  "payload",
-                  "role",
-                  "sequence",
-                  "turnId",
-                  "version"
-                ],
-                properties: {
-                  agentSessionId: {
-                    type: "string",
-                    minLength: 1
+                oneOf: [
+                  {
+                    type: "object",
+                    required: [
+                      "agentSessionId",
+                      "kind",
+                      "messageId",
+                      "occurredAtUnixMs",
+                      "payload",
+                      "role",
+                      "sequence",
+                      "turnId",
+                      "version"
+                    ],
+                    properties: {
+                      agentSessionId: {
+                        type: "string",
+                        minLength: 1
+                      },
+                      kind: {
+                        const: "collaboration"
+                      },
+                      messageId: {
+                        type: "string",
+                        minLength: 1
+                      },
+                      payload: {
+                        type: "object"
+                      },
+                      role: {
+                        type: "string",
+                        minLength: 1
+                      },
+                      sequence: {
+                        type: "integer",
+                        minimum: 1,
+                        description:
+                          "Stable message presentation order assigned when the durable message row is first created."
+                      },
+                      version: {
+                        type: "integer",
+                        minimum: 1
+                      },
+                      turnId: {
+                        type: ["null"],
+                        description:
+                          "Session-level collaboration messages do not belong to an agent turn."
+                      },
+                      status: {
+                        type: "string"
+                      },
+                      occurredAtUnixMs: {
+                        type: "integer",
+                        minimum: 1
+                      },
+                      startedAtUnixMs: {
+                        type: "integer",
+                        minimum: 0
+                      },
+                      completedAtUnixMs: {
+                        type: "integer",
+                        minimum: 0
+                      },
+                      createdAtUnixMs: {
+                        type: "integer",
+                        minimum: 0
+                      },
+                      updatedAtUnixMs: {
+                        type: "integer",
+                        minimum: 0
+                      }
+                    }
                   },
-                  kind: {
-                    type: "string",
-                    minLength: 1
-                  },
-                  messageId: {
-                    type: "string",
-                    minLength: 1
-                  },
-                  payload: {
-                    type: "object"
-                  },
-                  role: {
-                    type: "string",
-                    minLength: 1
-                  },
-                  sequence: {
-                    type: "integer",
-                    minimum: 1,
-                    description:
-                      "Stable message presentation order assigned when the durable message row is first created."
-                  },
-                  version: {
-                    type: "integer",
-                    minimum: 1
-                  },
-                  turnId: {
-                    type: "string",
-                    minLength: 1,
-                    description:
-                      "Turn-scoped messages always reference a real persisted Turn. Session audits use the separate session_audit event."
-                  },
-                  status: {
-                    type: "string"
-                  },
-                  occurredAtUnixMs: {
-                    type: "integer",
-                    minimum: 1
-                  },
-                  startedAtUnixMs: {
-                    type: "integer",
-                    minimum: 0
-                  },
-                  completedAtUnixMs: {
-                    type: "integer",
-                    minimum: 0
-                  },
-                  createdAtUnixMs: {
-                    type: "integer",
-                    minimum: 0
-                  },
-                  updatedAtUnixMs: {
-                    type: "integer",
-                    minimum: 0
+                  {
+                    type: "object",
+                    required: [
+                      "agentSessionId",
+                      "kind",
+                      "messageId",
+                      "occurredAtUnixMs",
+                      "payload",
+                      "role",
+                      "sequence",
+                      "turnId",
+                      "version"
+                    ],
+                    properties: {
+                      agentSessionId: {
+                        type: "string",
+                        minLength: 1
+                      },
+                      kind: {
+                        type: "string",
+                        minLength: 1,
+                        pattern: "^(?!collaboration$|session_audit$).+"
+                      },
+                      messageId: {
+                        type: "string",
+                        minLength: 1
+                      },
+                      payload: {
+                        type: "object"
+                      },
+                      role: {
+                        type: "string",
+                        minLength: 1
+                      },
+                      sequence: {
+                        type: "integer",
+                        minimum: 1,
+                        description:
+                          "Stable message presentation order assigned when the durable message row is first created."
+                      },
+                      version: {
+                        type: "integer",
+                        minimum: 1
+                      },
+                      turnId: {
+                        type: "string",
+                        minLength: 1,
+                        description:
+                          "Turn-scoped messages always reference a real persisted Turn. Session audits use the separate session_audit event."
+                      },
+                      status: {
+                        type: "string"
+                      },
+                      occurredAtUnixMs: {
+                        type: "integer",
+                        minimum: 1
+                      },
+                      startedAtUnixMs: {
+                        type: "integer",
+                        minimum: 0
+                      },
+                      completedAtUnixMs: {
+                        type: "integer",
+                        minimum: 0
+                      },
+                      createdAtUnixMs: {
+                        type: "integer",
+                        minimum: 0
+                      },
+                      updatedAtUnixMs: {
+                        type: "integer",
+                        minimum: 0
+                      }
+                    }
                   }
-                }
+                ]
               }
             }
           }

--- a/services/tuttid/api/events/generated/protocol.gen.go
+++ b/services/tuttid/api/events/generated/protocol.gen.go
@@ -6,7 +6,7 @@ import "encoding/json"
 
 const (
 	BusinessEventProtocolVersion = 1
-	BusinessEventCatalogRevision = "sha256:bbb3396091e770f0"
+	BusinessEventCatalogRevision = "sha256:2e36dcc0d1c65637"
 )
 
 type Topic string

--- a/services/tuttid/service/agent/collab_timeline_test.go
+++ b/services/tuttid/service/agent/collab_timeline_test.go
@@ -1,0 +1,61 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+	"github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
+	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
+	collabrunbiz "github.com/tutti-os/tutti/services/tuttid/biz/collabrun"
+	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
+)
+
+func TestCollaborationTimelineReporterPersistsTurnlessMessageUpdatesInPlace(t *testing.T) {
+	ctx := context.Background()
+	store := openAgentServiceSQLiteStore(t)
+	if err := store.Create(ctx, workspacebiz.Summary{ID: "ws-1", Name: "Workspace"}); err != nil {
+		t.Fatalf("Create workspace error = %v", err)
+	}
+	projection := NewActivityProjection(store)
+	if _, err := projection.ReportSessionState(ctx, canonical.ReportSessionStateInput{
+		WorkspaceID: "ws-1", AgentSessionID: "session-1",
+		SessionOrigin: agentsessionstore.WorkspaceAgentSessionOriginRuntime,
+		State: canonical.WorkspaceAgentSessionStateUpdate{
+			Provider: "codex", CurrentPhase: "idle", OccurredAtUnixMS: 1000,
+		},
+	}); err != nil {
+		t.Fatalf("ReportSessionState() error = %v", err)
+	}
+
+	reporter := CollaborationTimelineReporter{Projection: projection}
+	run := collabrunbiz.Run{
+		ID: "run-1", WorkspaceID: "ws-1", SourceSessionID: "session-1",
+		Mode: collabrunbiz.ModeDelegate, TriggerSource: collabrunbiz.TriggerUser,
+		Status: collabrunbiz.StatusCompleted, Adoption: collabrunbiz.AdoptionPending,
+		CreatedAt: time.UnixMilli(2000), UpdatedAt: time.UnixMilli(2000),
+	}
+	reporter.ReportCollaborationTimeline(ctx, run)
+
+	run.Adoption = collabrunbiz.AdoptionAdopted
+	run.UpdatedAt = time.UnixMilli(3000)
+	reporter.ReportCollaborationTimeline(ctx, run)
+
+	page, ok := projection.ListSessionMessages(agentactivitybiz.ListSessionMessagesInput{
+		WorkspaceID: "ws-1", AgentSessionID: "session-1", Order: agentactivitybiz.MessageOrderAsc, Limit: 20,
+	})
+	if !ok || len(page.Messages) != 1 {
+		t.Fatalf("messages = %#v, ok = %v", page.Messages, ok)
+	}
+	message := page.Messages[0]
+	if message.MessageID != "collab:run-1" || message.Kind != "collaboration" || message.TurnID != "" {
+		t.Fatalf("message = %#v", message)
+	}
+	if message.Version != 2 || message.Payload["adoption"] != string(collabrunbiz.AdoptionAdopted) {
+		t.Fatalf("updated message = %#v", message)
+	}
+	if _, exists, err := store.GetTurn(ctx, "ws-1", "session-1", "collab:run-1"); err != nil || exists {
+		t.Fatalf("synthetic turn exists = %v, err = %v; want absent", exists, err)
+	}
+}

--- a/services/tuttid/service/eventstream/agent_activity_validation.go
+++ b/services/tuttid/service/eventstream/agent_activity_validation.go
@@ -30,6 +30,29 @@ func requireJSONFields(raw json.RawMessage, objectKey string, fields ...string) 
 	return nil
 }
 
+func requireJSONArrayItemFields(raw json.RawMessage, arrayKey string, fields ...string) error {
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &root); err != nil {
+		return fmt.Errorf("decode data presence: %w", err)
+	}
+	value, ok := root[arrayKey]
+	if !ok {
+		return fmt.Errorf("data.%s is required", arrayKey)
+	}
+	var items []map[string]json.RawMessage
+	if err := json.Unmarshal(value, &items); err != nil {
+		return fmt.Errorf("data.%s must be an array of objects", arrayKey)
+	}
+	for index, item := range items {
+		for _, field := range fields {
+			if _, ok := item[field]; !ok {
+				return fmt.Errorf("data.%s[%d].%s is required", arrayKey, index, field)
+			}
+		}
+	}
+	return nil
+}
+
 func isOneOf(value string, allowed ...string) bool {
 	for _, candidate := range allowed {
 		if value == candidate {

--- a/services/tuttid/service/eventstream/catalog.go
+++ b/services/tuttid/service/eventstream/catalog.go
@@ -631,6 +631,9 @@ func validateAgentActivityUpdatedData(decoded agentActivityUpdatedPayload) error
 			return fmt.Errorf("data.deletedAtUnixMs is required")
 		}
 	case "message_update":
+		if err := requireJSONArrayItemFields(decoded.Data, "messages", "turnId"); err != nil {
+			return err
+		}
 		var data agentActivityMessageUpdateData
 		if err := decodeJSONStrict(decoded.Data, &data); err != nil {
 			return fmt.Errorf("decode message_update data: %w", err)
@@ -651,10 +654,11 @@ func validateAgentActivityUpdatedData(decoded agentActivityUpdatedPayload) error
 			if strings.TrimSpace(message.AgentSessionID) != agentSessionID {
 				return fmt.Errorf("data.messages[%d].agentSessionId must match agentSessionId", index)
 			}
-			if strings.TrimSpace(message.Kind) == "" {
+			kind := strings.TrimSpace(message.Kind)
+			if kind == "" {
 				return fmt.Errorf("data.messages[%d].kind is required", index)
 			}
-			if strings.TrimSpace(message.Kind) == "session_audit" {
+			if kind == "session_audit" {
 				return fmt.Errorf("data.messages[%d].kind must not be session_audit", index)
 			}
 			if strings.TrimSpace(message.MessageID) == "" {
@@ -672,7 +676,11 @@ func validateAgentActivityUpdatedData(decoded agentActivityUpdatedPayload) error
 			if message.Version == nil || *message.Version == 0 {
 				return fmt.Errorf("data.messages[%d].version is required", index)
 			}
-			if message.TurnID == nil || strings.TrimSpace(*message.TurnID) == "" {
+			if kind == "collaboration" {
+				if message.TurnID != nil {
+					return fmt.Errorf("data.messages[%d].turnId must be null for collaboration", index)
+				}
+			} else if message.TurnID == nil || strings.TrimSpace(*message.TurnID) == "" {
 				return fmt.Errorf("data.messages[%d].turnId is required", index)
 			}
 			if message.OccurredAtMS == nil || *message.OccurredAtMS <= 0 {

--- a/services/tuttid/service/eventstream/service_test.go
+++ b/services/tuttid/service/eventstream/service_test.go
@@ -229,6 +229,35 @@ func TestAgentActivityUpdatedSessionAuditProtocolBoundary(t *testing.T) {
 	}
 }
 
+func TestAgentActivityUpdatedCollaborationMessageProtocolBoundary(t *testing.T) {
+	t.Parallel()
+	catalog := DefaultCatalog()
+	turnlessCollaboration := []byte(`{
+		"workspaceId":"workspace-1","agentSessionId":"session-1","eventType":"message_update",
+		"data":{"workspaceId":"workspace-1","agentSessionId":"session-1","eventType":"message_update","latestVersion":1,"acceptedCount":1,
+		"messages":[{"agentSessionId":"session-1","kind":"collaboration","messageId":"collab:run-1","payload":{"runId":"run-1"},"role":"assistant","sequence":1,"turnId":null,"occurredAtUnixMs":100,"version":1}]}
+	}`)
+	if err := catalog.ValidatePublish(TopicAgentActivityUpdated, DirectionServerToClient, turnlessCollaboration); err != nil {
+		t.Fatalf("turnless collaboration message rejected: %v", err)
+	}
+	missingTurnIDCollaboration := []byte(`{
+		"workspaceId":"workspace-1","agentSessionId":"session-1","eventType":"message_update",
+		"data":{"workspaceId":"workspace-1","agentSessionId":"session-1","eventType":"message_update","latestVersion":1,"acceptedCount":1,
+		"messages":[{"agentSessionId":"session-1","kind":"collaboration","messageId":"collab:run-1","payload":{"runId":"run-1"},"role":"assistant","sequence":1,"occurredAtUnixMs":100,"version":1}]}
+	}`)
+	if err := catalog.ValidatePublish(TopicAgentActivityUpdated, DirectionServerToClient, missingTurnIDCollaboration); err == nil {
+		t.Fatal("collaboration message without turnId passed event protocol validation")
+	}
+	turnScopedCollaboration := []byte(`{
+		"workspaceId":"workspace-1","agentSessionId":"session-1","eventType":"message_update",
+		"data":{"workspaceId":"workspace-1","agentSessionId":"session-1","eventType":"message_update","latestVersion":1,"acceptedCount":1,
+		"messages":[{"agentSessionId":"session-1","kind":"collaboration","messageId":"collab:run-1","payload":{"runId":"run-1"},"role":"assistant","sequence":1,"turnId":"turn-1","occurredAtUnixMs":100,"version":1}]}
+	}`)
+	if err := catalog.ValidatePublish(TopicAgentActivityUpdated, DirectionServerToClient, turnScopedCollaboration); err == nil {
+		t.Fatal("turn-scoped collaboration message passed event protocol validation")
+	}
+}
+
 func TestAgentActivityUpdatedValidationRejectsUnknownTypedEntityFields(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- add a narrow Collaboration Runs adapter to the canonical TypeScript `TuttidClient`
- route Workspace Agent collaboration-adoption commands through the injected client and Desktop's restart-aware transport
- remove renderer-owned backend config resolution, generated-client caching, raw fetch construction, and local protocol-error unwrapping
- allow Collaboration timeline entries to remain session-level (`turnId: null`) across SQLite storage and the `agent.activity.updated` protocol
- add regression coverage for persistence, in-place adoption updates, protocol validation, and active-Turn isolation

## Motivation

`WorkspaceAgentActivityService` bypassed the established Desktop transport seam for `setCollaborationAdoption`. That feature-local path duplicated endpoint/token resolution, generated client construction, cache invalidation, raw fetch, and protocol error handling. The new `CollaborationRunsClient` composes into the canonical `createTuttidClient`, so managed-daemon restart and authentication behavior remain owned by `createRestartAwareFetch`.

Runtime dogfooding also exposed a pre-existing projection mismatch: `CollaborationTimelineReporter` intentionally emits session-level Collaboration messages without a Turn, while the SQLite store and realtime event protocol only admitted Turn-scoped messages. Runs were persisted and adoption requests succeeded, but the timeline card could not be projected. The fix explicitly models Collaboration messages as the second session-level message kind alongside `session_audit`, while ordinary messages continue to require a real persisted Turn.

## Architecture

- Desktop continues to own only Collaboration Run → Activity DTO mapping.
- `packages/clients/tuttid-ts` owns the HTTP/generated-client adapter.
- SQLite accepts turnless `collaboration` messages without changing the active Turn and rejects turn-scoped Collaboration messages.
- `message_update` accepts `kind: "collaboration"` only with an explicitly present `turnId: null`; ordinary messages still require a non-empty Turn ID, and `session_audit` remains on its dedicated event variant.

No Session, Turn, Goal, runtime-operation, Collaboration Run, or Agent Host lifecycle transition semantics are changed.

## Validation

- `corepack pnpm --filter @tutti-os/client-tuttid-ts test -- src/index.test.ts` — 69 passed
- `go test ./packages/agent/store-sqlite ./services/tuttid/service/agent ./services/tuttid/service/eventstream` — passed
- `corepack pnpm check:event-protocol-generated` — passed
- `corepack pnpm --filter @tutti-os/desktop typecheck` — passed
- `corepack pnpm check:changed` — 23 lanes passed
- `corepack pnpm --filter @tutti-os/desktop build` — passed
- generated TypeScript protocol validator matrix — `collaboration/null`, `collaboration/string`, `session_audit/string`, `text/null`, `text/string` returned `true, false, false, false, true`
- `make dev-gui` — Collaboration card rendered in its source session; clicking **采纳** updated the backend adoption state to `adopted`; no timeline projection or event-publish validation warning remained
- independent subagent review — first two rounds found protocol-boundary inconsistencies, both were fixed with regression tests; final review passed with no security or logic findings

## Documentation impact

No durable documentation update is required. The transport change conforms to `docs/architecture/desktop-transport.md`; the projection fix makes the implementation match the existing Collaboration timeline design and public event contract.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tutti-os/tutti/pull/1894" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
