### PR TITLE
fix(agent-gui): align activation contracts across hosts

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { AgentActivitySessionSettings } from "@tutti-os/agent-activity-core";
 import type {
   CreateWorkspaceAgentSessionRequest,
   TuttidClient,
@@ -1643,16 +1644,26 @@ test("desktop agent activity adapter loads Claude models via composer options re
     runtimeApi: createRuntimeApi()
   });
 
+  const settings: AgentActivitySessionSettings = {
+    browserUse: false,
+    computerUse: false,
+    model: "opus"
+  };
   const options = await adapter.loadComposerOptions({
     cwd: "/repo",
     provider: "claude-code",
+    settings,
     workspaceId
   });
 
   assert.deepEqual(composerOptionsCalls, [
     {
       provider: "claude-code",
-      request: { cwd: "/repo", settings: {}, workspaceId }
+      request: {
+        cwd: "/repo",
+        settings: { browserUse: false, model: "opus" },
+        workspaceId
+      }
     }
   ]);
   assert.equal(options.modelConfigurable, true);

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -10,7 +10,8 @@ import {
   agentActivityMessageFromTuttidMessage,
   agentActivitySessionDetailFromTuttid as mapAgentActivitySessionDetailFromTuttid,
   agentActivitySessionFromTuttidSession as mapAgentActivitySessionFromTuttidSession,
-  agentActivityTuttiModeActivationFromTuttid
+  agentActivityTuttiModeActivationFromTuttid,
+  tuttiAgentSessionComposerSettingsFromActivity
 } from "@tutti-os/agent-activity-tuttid-adapter";
 export {
   agentActivityMessageFromTuttidMessage,
@@ -165,7 +166,9 @@ export function createDesktopAgentActivityAdapter({
                 ...(agentTargetId ? { agentTargetId } : {}),
                 ...(cwd ? { cwd } : {}),
                 workspaceId: input.workspaceId,
-                settings: input.settings ?? {}
+                settings: tuttiAgentSessionComposerSettingsFromActivity(
+                  input.settings
+                )
               },
               { signal }
             ),

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -234,6 +234,9 @@ export function createDesktopAgentActivityAdapter({
         const request: CreateWorkspaceAgentSessionRequest = {
           agentSessionId,
           agentTargetId,
+          ...(typeof input.browserUse === "boolean"
+            ? { browserUse: input.browserUse }
+            : {}),
           ...(recordingId ? { recordingId } : {}),
           ...(input.capabilityRefs?.length
             ? {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentHostProjection.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentHostProjection.ts
@@ -9,6 +9,8 @@ export type AgentHostAgentSessionComposerSettings =
   SharedAgentHostAgentSessionComposerSettings;
 
 export interface AgentHostAgentSessionComposerSettingsInput {
+  browserUse?: boolean | null;
+  computerUse?: boolean | null;
   model?: string | null;
   permissionModeId?: string | null;
   planMode?: boolean | null;
@@ -35,6 +37,12 @@ export function normalizeComposerSettings(
   settings: AgentHostAgentSessionComposerSettingsInput | null | undefined
 ): AgentHostAgentSessionComposerSettings {
   return {
+    ...(typeof settings?.browserUse === "boolean"
+      ? { browserUse: settings.browserUse }
+      : {}),
+    ...(typeof settings?.computerUse === "boolean"
+      ? { computerUse: settings.computerUse }
+      : {}),
     model: normalizedOptionalString(settings?.model),
     permissionModeId: resolveComposerPermissionMode(settings),
     planMode: Boolean(settings?.planMode),

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityMutationOperations.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityMutationOperations.ts
@@ -3,6 +3,7 @@ import type {
   AgentActivityGoalControlResult,
   AgentActivitySession
 } from "@tutti-os/agent-activity-core";
+import { tuttiAgentSessionComposerSettingsFromActivity } from "@tutti-os/agent-activity-tuttid-adapter";
 import type { AgentActivityRuntime } from "@tutti-os/agent-gui";
 import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
 import type { DesktopRuntimeApi } from "@preload/types";
@@ -146,7 +147,9 @@ export class WorkspaceAgentActivityMutationOperations {
     settings: Parameters<typeof normalizeComposerSettings>[0];
     workspaceId: string;
   }): ReturnType<IWorkspaceAgentActivityService["updateSessionSettings"]> {
-    const settingsInput = normalizeComposerSettings(input.settings);
+    const normalizedSettings = normalizeComposerSettings(input.settings);
+    const settingsInput =
+      tuttiAgentSessionComposerSettingsFromActivity(normalizedSettings);
     const session = input.signal
       ? await this.dependencies.tuttidClient.updateWorkspaceAgentSessionSettings(
           input.workspaceId,
@@ -161,7 +164,7 @@ export class WorkspaceAgentActivityMutationOperations {
         );
     const settings = session.settings
       ? normalizeComposerSettings(session.settings)
-      : normalizeComposerSettings(input.settings);
+      : normalizedSettings;
     return {
       agentSessionId: input.agentSessionId,
       settings,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -961,7 +961,6 @@ test("WorkspaceAgentActivityService returns the authoritative canonical session 
   assert.equal(requestSignal, controller.signal);
   assert.deepEqual(requestSettings, {
     browserUse: false,
-    computerUse: true,
     model: "opus",
     permissionModeId: null,
     planMode: true,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -307,6 +307,14 @@ test("WorkspaceAgentActivityService.activateSession creates target-backed sessio
       status: "active"
     },
     mode: "new",
+    settings: {
+      browserUse: false,
+      model: "gpt-5",
+      permissionModeId: "auto",
+      planMode: true,
+      reasoningEffort: "high",
+      speed: "fast"
+    },
     title: "Shared Codex",
     visible: true,
     workspaceId: "ws-1"
@@ -329,12 +337,13 @@ test("WorkspaceAgentActivityService.activateSession creates target-backed sessio
         source: "slash_command",
         status: "active"
       },
-      model: null,
+      browserUse: false,
+      model: "gpt-5",
       noProject: null,
-      permissionModeId: null,
-      planMode: null,
-      reasoningEffort: null,
-      speed: null,
+      permissionModeId: "auto",
+      planMode: true,
+      reasoningEffort: "high",
+      speed: "fast",
       title: "Shared Codex",
       visible: true
     }
@@ -912,9 +921,15 @@ test("WorkspaceAgentActivityService does not reinterpret a failed Turn as activa
 test("WorkspaceAgentActivityService returns the authoritative canonical session after settings update", async () => {
   const controller = new AbortController();
   let requestSignal: AbortSignal | undefined;
+  let requestSettings: unknown = null;
   const updatedSession = workspaceAgentSession({
     provider: "claude-code",
-    settings: { model: "opus", planMode: true },
+    settings: {
+      browserUse: false,
+      computerUse: true,
+      model: "opus",
+      planMode: true
+    },
     status: "waiting"
   });
   const service = new WorkspaceAgentActivityService({
@@ -922,6 +937,7 @@ test("WorkspaceAgentActivityService returns the authoritative canonical session 
       updateWorkspaceAgentSessionSettings: async (
         ...args: Parameters<TuttidClient["updateWorkspaceAgentSessionSettings"]>
       ) => {
+        requestSettings = args[2];
         requestSignal = args[3]?.signal ?? undefined;
         return updatedSession;
       }
@@ -932,13 +948,29 @@ test("WorkspaceAgentActivityService returns the authoritative canonical session 
   const result = await service.updateSessionSettings({
     agentSessionId: "session-1",
     signal: controller.signal,
-    settings: { model: "opus", planMode: true },
+    settings: {
+      browserUse: false,
+      computerUse: true,
+      model: "opus",
+      planMode: true
+    },
     workspaceId: "ws-1"
   });
 
   assert.equal(result.agentSessionId, "session-1");
   assert.equal(requestSignal, controller.signal);
+  assert.deepEqual(requestSettings, {
+    browserUse: false,
+    computerUse: true,
+    model: "opus",
+    permissionModeId: null,
+    planMode: true,
+    reasoningEffort: null,
+    speed: null
+  });
   assert.deepEqual(result.settings, {
+    browserUse: false,
+    computerUse: true,
     model: "opus",
     permissionModeId: null,
     planMode: true,
@@ -949,6 +981,8 @@ test("WorkspaceAgentActivityService returns the authoritative canonical session 
   assert.equal(result.session.agentSessionId, "session-1");
   assert.equal(result.session.provider, "claude-code");
   assert.deepEqual(result.session.settings, {
+    browserUse: false,
+    computerUse: true,
     model: "opus",
     planMode: true
   });

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -603,6 +603,9 @@ export class WorkspaceAgentActivityService
         initialDisplayPrompt: input.initialDisplayPrompt ?? null,
         initialTuttiModeActivation: input.initialTuttiModeActivation ?? null,
         submitDiagnostics: input.submitDiagnostics,
+        ...(typeof input.settings?.browserUse === "boolean"
+          ? { browserUse: input.settings.browserUse }
+          : {}),
         model: input.settings?.model ?? null,
         planMode: input.settings?.planMode ?? null,
         permissionModeId: resolveComposerPermissionMode(input.settings),

--- a/apps/mobile/src/services/workspaceActivityEngineCommandPort.test.ts
+++ b/apps/mobile/src/services/workspaceActivityEngineCommandPort.test.ts
@@ -3,6 +3,7 @@ import type {
   AgentActivitySendInput,
   AgentActivitySession,
   AgentActivitySessionDetailSnapshot,
+  AgentActivitySessionSettings,
   AgentSessionActivateEffectInput,
   TurnEditRetryCommand,
   TurnRecoverEditRetryCommand
@@ -18,6 +19,56 @@ function unexpectedGoalControlMapping(): never {
 }
 
 describe("createWorkspaceActivityEffectPort", () => {
+  test("filters unsupported settings from composer options requests", async () => {
+    const stopAfterCapture = new Error("stop after composer request capture");
+    const getAgentProviderComposerOptions = jest
+      .fn()
+      .mockRejectedValue(stopAfterCapture);
+    const settings: AgentActivitySessionSettings = {
+      browserUse: false,
+      computerUse: false,
+      model: "gpt-5"
+    };
+    await expect(
+      executeWorkspaceActivityExtensionCommand(
+        {
+          client: {
+            getAgentProviderComposerOptions
+          } as unknown as TuttidClient,
+          mapGoalControlResult: unexpectedGoalControlMapping,
+          mapSession(): AgentActivitySession {
+            throw new Error("unexpected Session mapping");
+          },
+          mapSessionDetail() {
+            throw new Error("unexpected detail mapping");
+          },
+          async reconcileSession() {},
+          async reconcileWorkspace() {}
+        },
+        {
+          commandId: "composer-1",
+          correlationId: "target-1",
+          provider: "codex",
+          settings,
+          targetKey: "target-1",
+          type: "composerOptions/load",
+          workspaceId: "workspace-1"
+        }
+      )
+    ).rejects.toBe(stopAfterCapture);
+
+    expect(getAgentProviderComposerOptions).toHaveBeenCalledWith(
+      "codex",
+      {
+        agentTargetId: "target-1",
+        locale: expect.any(String),
+        settings: { browserUse: false, model: "gpt-5" },
+        workspaceId: "workspace-1"
+      },
+      { signal: undefined }
+    );
+  });
+
   test("explicitly rejects edit-retry commands that Mobile does not support", async () => {
     const context = {
       client: {} as TuttidClient,
@@ -406,7 +457,11 @@ describe("createWorkspaceActivityEffectPort", () => {
         agentSessionId: "session-1",
         commandId: "settings-1",
         correlationId: "request-1",
-        settings: { model: "model-1" },
+        settings: {
+          browserUse: false,
+          computerUse: false,
+          model: "model-1"
+        },
         workspaceId: "workspace-1"
       },
       { signal: controller.signal }
@@ -415,7 +470,7 @@ describe("createWorkspaceActivityEffectPort", () => {
     expect(updateWorkspaceAgentSessionSettings).toHaveBeenCalledWith(
       "workspace-1",
       "session-1",
-      { model: "model-1" },
+      { browserUse: false, model: "model-1" },
       { signal: controller.signal }
     );
     expect(result).toEqual({

--- a/apps/mobile/src/services/workspaceActivityEngineCommandPort.ts
+++ b/apps/mobile/src/services/workspaceActivityEngineCommandPort.ts
@@ -18,7 +18,8 @@ import type {
 import {
   agentActivityComposerOptionsFromTuttidResult,
   agentActivitySessionFromTuttidSession,
-  agentActivityTurnFromTuttidTurn
+  agentActivityTurnFromTuttidTurn,
+  tuttiAgentSessionComposerSettingsFromActivity
 } from "@tutti-os/agent-activity-tuttid-adapter";
 import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
 import { mobileLocale } from "../i18n";
@@ -113,7 +114,9 @@ export function executeWorkspaceActivityExtensionCommand(
             ...(command.cwd ? { cwd: command.cwd } : {}),
             locale: mobileLocale,
             workspaceId: command.workspaceId,
-            settings: command.settings ?? {}
+            settings: tuttiAgentSessionComposerSettingsFromActivity(
+              command.settings
+            )
           },
           { signal }
         )
@@ -336,7 +339,7 @@ function updateSessionSettings(
     .updateWorkspaceAgentSessionSettings(
       input.workspaceId,
       input.agentSessionId,
-      input.settings,
+      tuttiAgentSessionComposerSettingsFromActivity(input.settings),
       ...requestOptionsArgs(signal)
     )
     .then((session) => {

--- a/apps/mobile/src/services/workspaceActivityService.test.ts
+++ b/apps/mobile/src/services/workspaceActivityService.test.ts
@@ -1,5 +1,6 @@
 import {
   canonicalInteractionKey,
+  selectPendingActivations,
   type AgentSessionEngine
 } from "@tutti-os/agent-activity-core";
 import type {
@@ -569,6 +570,67 @@ describe("WorkspaceActivityService", () => {
 
     expect(service.getSnapshot().draft).toBe("start");
     expect(service.getSnapshot().sending).toBe(false);
+    service.dispose();
+  });
+
+  test("restores a canceled activation draft and uses a fresh submission identity", async () => {
+    const createInputs: Array<
+      Parameters<TuttidClient["createWorkspaceAgentSession"]>[1]
+    > = [];
+    const service = createService(
+      createClient({
+        composerOptions: async () => ({
+          behavior: {
+            collapseModelOptionsToLatest: false,
+            modelOptionsAuthoritative: true,
+            planModeExclusiveWithPermissionMode: false,
+            prewarmDraftSession: false,
+            refreshModelOptionsAfterSettings: false
+          },
+          effectiveSettings: {},
+          provider: "codex"
+        }),
+        create: (_workspaceId, input) => {
+          createInputs.push(input);
+          return new Promise<WorkspaceAgentSession>(() => undefined);
+        },
+        listMessages: emptyMessagePage,
+        session: () => null,
+        targets: [createTarget()]
+      })
+    );
+
+    await service.start();
+    await flushAsyncWork();
+    const engine = (
+      service as unknown as {
+        engine: AgentSessionEngine;
+      }
+    ).engine;
+    service.startCreating();
+    service.setDraft("start");
+
+    await service.send();
+    const activation = selectPendingActivations(engine.getSnapshot()).find(
+      (candidate) => candidate.mode === "new"
+    );
+    expect(activation).toBeDefined();
+    expect(service.getSnapshot().draft).toBe("");
+
+    engine.stopSession({
+      agentSessionId: activation!.agentSessionId
+    });
+    await flushAsyncWork();
+
+    expect(service.getSnapshot().draft).toBe("start");
+    expect(service.getSnapshot().ambiguousSubmission).toBe(false);
+
+    await service.send();
+
+    expect(createInputs).toHaveLength(2);
+    expect(createInputs[1]?.clientSubmitId).not.toBe(
+      createInputs[0]?.clientSubmitId
+    );
     service.dispose();
   });
 

--- a/apps/mobile/src/services/workspaceActivityService.ts
+++ b/apps/mobile/src/services/workspaceActivityService.ts
@@ -4,6 +4,7 @@ import {
   createAgentSessionEngine,
   parseAgentActivityGoalControlText,
   selectEngineSessionRuntimeAvailability,
+  selectPendingActivations,
   selectSessionGoalControlSettlement,
   type AgentActivitySessionSettings,
   type AgentActivityInteraction,
@@ -735,10 +736,20 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
           this.navigation.selectSession(submission.agentSessionId);
           continue;
         }
-        const record =
-          state.pendingIntents.activationsByRequestId[
-            submission.clientSubmitId
-          ];
+        const record = selectPendingActivations(state).find(
+          (activation) =>
+            activation.mode === "new" &&
+            activation.clientSubmitId === submission.clientSubmitId
+        );
+        if (record?.status === "canceled") {
+          this.pendingSubmissionsByDraftKey.delete(draftKey);
+          this.ambiguousDraftKeys.delete(draftKey);
+          this.errorCode = null;
+          if (!this.drafts.get(draftKey)) {
+            this.drafts.set(draftKey, submission.text);
+          }
+          continue;
+        }
         if (record?.status === "failed" || record?.status === "uncertain") {
           this.markSubmissionAmbiguous(draftKey, submission.text);
         }

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -726,6 +726,10 @@ disable submission, but must not change editor editability.
   Canonical monotonicity guards prevent a late activation response from
   regressing newer realtime state.
   Surfaces clear a new-Session draft only after activation admission succeeds.
+  If an admitted new-Session activation is canceled before canonical Session
+  confirmation, the surface restores the submitted draft only while the
+  current draft is still empty, releases the pending `clientSubmitId`, and
+  allocates a fresh identity for the next explicit submission.
   Existing-Session Prompt submission enters through `engine.submitPrompt`.
   The surface keeps the stable `clientSubmitId` used by its draft-recovery and
   idempotent-retry bookkeeping; the Engine owns workspace scope, timestamps,
@@ -955,7 +959,9 @@ timeout and retry policy, and translates the semantic call to its internal
 the activation intent instead; provider-independent draft projection and
 Desktop-persisted defaults remain surface policy until activation. A renderer
 must not call the settings endpoint from a component or invent a
-provider-specific settings schema.
+provider-specific settings schema. Host normalization must preserve every
+shared setting supported by that operation; in particular, both Desktop and
+Mobile preserve `browserUse` and `computerUse` for existing-Session updates.
 Existing-Session Prompt sends similarly enter through `engine.submitPrompt`;
 Desktop and Mobile provide content plus a stable client submit identity, while
 the Engine owns common routing, confirmation expiry, and admission projection.
@@ -969,10 +975,11 @@ the host effect port.
 An activation intent's shared Session settings are not an HTTP create-field
 allowlist. Each host must construct a typed
 `CreateWorkspaceAgentSessionRequest` and forward only fields present in the
-generated contract. In particular, `computerUse` is a default-on runtime
-setting but is not currently a create-request field; Mobile must not add it as
-an extra property. Supporting an explicit first-Turn opt-out requires changing
-OpenAPI and the create adapter first.
+generated contract. Both hosts preserve `browserUse`, which is a supported
+create field. In contrast, `computerUse` is a default-on runtime setting but is
+not currently a create-request field; neither host may add it as an extra
+property. Supporting an explicit first-Turn opt-out requires changing OpenAPI
+and the create adapters first.
 
 Desktop and Mobile construct the headless controller through
 `@tutti-os/agent-gui/conversation-rail-controller` and supply its narrow

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -959,9 +959,10 @@ timeout and retry policy, and translates the semantic call to its internal
 the activation intent instead; provider-independent draft projection and
 Desktop-persisted defaults remain surface policy until activation. A renderer
 must not call the settings endpoint from a component or invent a
-provider-specific settings schema. Host normalization must preserve every
-shared setting supported by that operation; in particular, both Desktop and
-Mobile preserve `browserUse` and `computerUse` for existing-Session updates.
+provider-specific settings schema. Desktop and Mobile project the broader
+Engine settings through one generated-contract allowlist before composer-option
+or existing-Session settings requests. Both preserve supported fields such as
+`browserUse`; neither sends `computerUse` until OpenAPI adds that request field.
 Existing-Session Prompt sends similarly enter through `engine.submitPrompt`;
 Desktop and Mobile provide content plus a stable client submit identity, while
 the Engine owns common routing, confirmation expiry, and admission projection.

--- a/packages/agent/activity-core/src/types.ts
+++ b/packages/agent/activity-core/src/types.ts
@@ -356,6 +356,7 @@ export interface AgentActivityCreateSessionInput {
   /** 仅展示用的首轮文本(bundle 折叠成一个 chip);initialContent 仍带展开后的文件。 */
   initialDisplayPrompt?: string | null;
   submitDiagnostics?: AgentActivitySubmitDiagnostics;
+  browserUse?: boolean | null;
   model?: string | null;
   planMode?: boolean | null;
   permissionModeId?: string | null;

--- a/packages/agent/activity-tuttid-adapter/README.md
+++ b/packages/agent/activity-tuttid-adapter/README.md
@@ -16,6 +16,12 @@ public mapper accepts the generated `AgentProviderComposerOptionsResponse`
 contract. Only its documented `runtimeContext` remains opaque; typed Skill and
 capability catalogs do not grow compatibility fields in this adapter.
 
+`tuttiAgentSessionComposerSettingsFromActivity` is the reverse request
+projection shared by Desktop and Mobile. It forwards only fields declared by
+the generated `AgentSessionComposerSettings` contract. Broader Engine or
+presentation settings such as `computerUse` remain local unless OpenAPI first
+adds a matching request field.
+
 `agentActivitySessionDetailFromTuttid` is the single detail aggregate mapper for
 Desktop and Mobile. It validates and maps the root Session, nested child
 Sessions, and Turns as one value. The caller supplies the requested Session id;

--- a/packages/agent/activity-tuttid-adapter/src/composerSettings.test.ts
+++ b/packages/agent/activity-tuttid-adapter/src/composerSettings.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { tuttiAgentSessionComposerSettingsFromActivity } from "./composerSettings.ts";
+
+test("projects only settings supported by the tuttid composer contract", () => {
+  assert.deepEqual(
+    tuttiAgentSessionComposerSettingsFromActivity({
+      browserUse: false,
+      computerUse: false,
+      model: null,
+      permissionModeId: "auto",
+      planMode: true,
+      reasoningEffort: "high",
+      speed: "fast"
+    }),
+    {
+      browserUse: false,
+      model: null,
+      permissionModeId: "auto",
+      planMode: true,
+      reasoningEffort: "high",
+      speed: "fast"
+    }
+  );
+});
+
+test("does not invent a tuttid request field for computer use", () => {
+  assert.deepEqual(
+    tuttiAgentSessionComposerSettingsFromActivity({ computerUse: true }),
+    {}
+  );
+});

--- a/packages/agent/activity-tuttid-adapter/src/composerSettings.ts
+++ b/packages/agent/activity-tuttid-adapter/src/composerSettings.ts
@@ -1,0 +1,23 @@
+import type { AgentActivitySessionSettings } from "@tutti-os/agent-activity-core";
+import type { AgentSessionComposerSettings } from "@tutti-os/client-tuttid-ts";
+
+export function tuttiAgentSessionComposerSettingsFromActivity(
+  settings: AgentActivitySessionSettings | null | undefined
+): AgentSessionComposerSettings {
+  return {
+    ...(settings?.model !== undefined ? { model: settings.model } : {}),
+    ...(settings?.permissionModeId !== undefined
+      ? { permissionModeId: settings.permissionModeId }
+      : {}),
+    ...(settings?.planMode !== undefined
+      ? { planMode: settings.planMode }
+      : {}),
+    ...(settings?.browserUse !== undefined
+      ? { browserUse: settings.browserUse }
+      : {}),
+    ...(settings?.reasoningEffort !== undefined
+      ? { reasoningEffort: settings.reasoningEffort }
+      : {}),
+    ...(settings?.speed !== undefined ? { speed: settings.speed } : {})
+  };
+}

--- a/packages/agent/activity-tuttid-adapter/src/index.ts
+++ b/packages/agent/activity-tuttid-adapter/src/index.ts
@@ -7,5 +7,6 @@ export {
   type AgentActivitySessionMappingOptions
 } from "./mappers.ts";
 export { agentActivityComposerOptionsFromTuttidResult } from "./composerOptions.ts";
+export { tuttiAgentSessionComposerSettingsFromActivity } from "./composerSettings.ts";
 export { agentActivityGoalControlResultFromTuttid } from "./goalControl.ts";
 export { agentActivitySessionDetailFromTuttid } from "./sessionDetail.ts";


### PR DESCRIPTION
## Summary

- preserve the supported `browserUse` setting through Desktop new-Session activation
- project Desktop and Mobile composer settings through one generated-contract allowlist so neither host sends unsupported `computerUse`
- align Mobile canceled-activation settlement with Desktop by restoring an untouched empty draft and releasing the canceled submission identity
- document the cross-host activation and settings projection contract

## Root cause

Desktop translated the Engine's typed activation settings through the compatibility `AgentActivityCreateSessionInput`, whose create-field projection omitted the supported `browserUse` field.

The frontend settings model is broader than the generated tuttid request DTO. Desktop's initial normalization change and Mobile's existing transport path could forward `computerUse` into strict composer-options or settings-update requests even though OpenAPI does not declare that field. TypeScript structural assignability did not reject the wider variables at those call sites.

Mobile also tracked new-Session submissions locally without settling the `canceled` Engine activation state. That could leave the cleared draft and canceled `clientSubmitId` retained locally, so a later retry could reuse an identity that the Engine treats as single-use.

## Impact

Desktop and Mobile now share one tuttid request projection and send only generated-contract composer settings. `computerUse` may remain in Engine or presentation state but is not serialized to tuttid until OpenAPI supports it. Canceling an in-flight Mobile activation restores the submitted text only when the user has not entered replacement content, and the next explicit send uses a fresh identity.

## Validation

- `pnpm check:changed` — 19 lanes passed
- pre-push `pnpm check:changed -- --push-ready` — 22 lanes passed
- shared tuttid adapter tests — 18 passed
- Desktop focused tests — 99 passed
- Mobile focused tests — 42 passed
- `git diff --check` — passed

## Documentation

Updated `docs/architecture/agent-gui-node.md` and `packages/agent/activity-tuttid-adapter/README.md` with the shared request-projection boundary and canceled-activation settlement rule.