### PR TITLE
fix(agent): restore goal control copy and initial goal session titles

### DIFF
--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -262,9 +262,11 @@ migrate without payload-shape heuristics.
 New-Session Goal Control uses the same activation path. The Engine carries a
 typed `initialGoalControl`; Desktop and Mobile send it through the typed Create
 contract with empty initial content. Agent Host creates the Session and durable
-Goal operation without creating a Turn. Non-empty initial content and typed
-initial Goal are mutually exclusive, and product adapters must not reconstruct
-the command from display text.
+Goal operation without creating a Turn. It establishes the canonical Session
+title from the display prompt, or from a synthesized `/goal` command when the
+display prompt is absent. Non-empty initial content and typed initial Goal are
+mutually exclusive, and product adapters must not reconstruct the command from
+display text.
 Desktop AgentGUI and Mobile call `stopSession` instead of constructing
 `session/stopRequested` protocol fields. The same method stops an active Turn
 or records a bounded request that cancels the first Turn produced by an

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -507,7 +507,7 @@ Interaction responses.
 
 Goal is a Session-level durable entity, not a Turn command. It owns desired/observed state, revision, and an independent operation.
 
-A Goal operation may produce zero or more provider Turns, but it cannot reserve or fabricate Turn IDs. Goal control bypasses the prompt pipeline and does not create a user transcript Turn message. AgentGUI may project its durable session audit as a dedicated `goal-control` timeline row; that row has no Turn ID and does not participate in Turn counts, processing ownership, cancellation, or settlement.
+A Goal operation may produce zero or more provider Turns, but it cannot reserve or fabricate Turn IDs. Goal control bypasses the prompt pipeline and does not create a user transcript Turn message. AgentGUI dispatches `goal/controlRequested`; the workspace Engine owns the provider-neutral `goal/control` command, typed effect execution, and exact Session-scoped result reconciliation. AgentGUI may project its durable session audit as a dedicated `goal-control` timeline row; that row has no Turn ID and does not participate in Turn counts, processing ownership, cancellation, or settlement. When the audit carries a user-visible command body, the dedicated row also uses the shared user-message action surface, including copy.
 
 When a session-level timeline row occurs chronologically between two rows from
 the same Turn, transcript presentation keeps one Turn group and renders the

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -30,6 +30,56 @@ incomplete`, while a newly created session can still launch.
   [session_runtime_snapshot.go](../../../services/tuttid/service/agent/session_runtime_snapshot.go),
   [model_plan_binding.go](../../../services/tuttid/service/agent/model_plan_binding.go)
 
+### Initial Goal session remains unnamed
+
+- Symptom:
+  A new session created from `/goal <objective>` keeps an empty canonical title
+  and the UI shows the localized unnamed-conversation label after the optimistic
+  activation disappears.
+- Quick checks:
+  Read `workspace_agent_sessions.title` and the first
+  `workspace_agent_messages` row. The affected shape has `kind=session_audit`,
+  `role=user`, `goalControl=true`, and no normal text Turn.
+- Root cause:
+  Typed initial Goal intentionally skips the ordinary initial Turn. Title
+  derivation existed only in the normal initial-content `Exec` path, so the
+  session was persisted without a title even though the Goal audit contained the
+  submitted command.
+- Fix:
+  Derive the title in Host before provider startup from `InitialDisplayPrompt`;
+  when that field is absent, synthesize `/goal <objective>` or `/goal <action>`.
+  Mark the derived title established so later runtime state cannot replace it.
+- Validation:
+  Run the shared initial-Goal conformance scenario through both direct Host and
+  service-adapter drivers. Assert the returned canonical title and verify the
+  zero-Turn Goal operation still replays without a second provider startup.
+- References:
+  [packages/agent/host/README.md](../../../packages/agent/host/README.md)
+  [lifecycle.go](../../../packages/agent/host/lifecycle.go)
+  [session_lifecycle_scenarios.go](../../../packages/agent/host/conformance/session_lifecycle_scenarios.go)
+
+### Goal-control row has no copy action
+
+- Symptom:
+  A visible `/goal ...` user bubble has no copy button on hover, while ordinary
+  user text bubbles have one.
+- Quick checks:
+  Inspect the row kind. `goal-control` renders through `AgentGoalControlRow`,
+  not `AgentMessageBlock`; search direct `AgentRichTextReadonly` uses for a
+  renderer that bypasses `AgentCopyableMessageGroup`.
+- Root cause:
+  The special row reused the read-only rich-text renderer but not the shared
+  message action wrapper.
+- Fix:
+  Wrap the row in `AgentCopyableMessageGroup` and write through the host
+  clipboard, with the browser clipboard as the renderer fallback.
+- Validation:
+  Render a durable goal-control row, hover it, assert the copy button exists,
+  click it, and verify the exact command body is written.
+- References:
+  [AgentGoalControlRow.tsx](../../../packages/agent/gui/shared/agentConversation/components/AgentGoalControlRow.tsx)
+  [AgentMessageActions.tsx](../../../packages/agent/gui/shared/agentConversation/components/AgentMessageActions.tsx)
+
 ### One hung provider startup blocks unrelated Agent sessions
 
 - **Symptom:** One provider process starts but never reaches runtime-ready, then

--- a/packages/agent/gui/shared/agentConversation/components/AgentGoalControlRow.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentGoalControlRow.tsx
@@ -1,9 +1,11 @@
-import type { JSX } from "react";
+import { useCallback, type JSX } from "react";
 import type { AgentMessageMarkdownWorkspaceAppIcon } from "../../AgentMessageMarkdown";
 import { AgentRichTextReadonly } from "../../AgentRichTextReadonly";
+import { useOptionalAgentHostApi } from "../../../agentActivityHost";
 import type { AgentGUIProviderSkillOption } from "../../../agent-gui/agentGuiNode/model/agentGuiNodeTypes";
 import styles from "../../../agent-gui/agentGuiNode/AgentGUIConversation.styles";
 import type { AgentGoalControlRowVM } from "../contracts/agentGoalControlRowVM";
+import { AgentCopyableMessageGroup } from "./AgentMessageActions";
 
 interface AgentGoalControlRowProps {
   row: AgentGoalControlRowVM;
@@ -17,18 +19,53 @@ export function AgentGoalControlRow({
   workspaceAppIcons
 }: AgentGoalControlRowProps): JSX.Element {
   "use memo";
+  const agentHostApi = useOptionalAgentHostApi();
+  const handleCopyMessageText = useCallback(
+    async (text: string): Promise<boolean> => {
+      if (!text.trim()) {
+        return false;
+      }
+
+      try {
+        const hostWriteText = agentHostApi?.clipboard?.writeText;
+        if (typeof hostWriteText === "function") {
+          await hostWriteText(text);
+          return true;
+        }
+        if (
+          typeof navigator !== "undefined" &&
+          typeof navigator.clipboard?.writeText === "function"
+        ) {
+          await navigator.clipboard.writeText(text);
+          return true;
+        }
+      } catch {
+        return false;
+      }
+      return false;
+    },
+    [agentHostApi]
+  );
   return (
     <div
       className={styles.userMessageFlow}
       data-agent-goal-control-action={row.action}
     >
-      <AgentRichTextReadonly
-        value={row.body}
-        className={`workspace-agents-status-panel__detail-user-message ${styles.userMessageBubble}`}
-        editorClassName="text-[inherit]"
-        availableSkills={availableSkills}
-        workspaceAppIcons={workspaceAppIcons}
-      />
+      <AgentCopyableMessageGroup
+        copyText={row.body.trim() ? row.body : null}
+        editAction={null}
+        occurredAtUnixMs={row.occurredAtUnixMs}
+        onCopyMessageText={handleCopyMessageText}
+        speaker="user"
+      >
+        <AgentRichTextReadonly
+          value={row.body}
+          className={`workspace-agents-status-panel__detail-user-message ${styles.userMessageBubble}`}
+          editorClassName="text-[inherit]"
+          availableSkills={availableSkills}
+          workspaceAppIcons={workspaceAppIcons}
+        />
+      </AgentCopyableMessageGroup>
     </div>
   );
 }

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
@@ -80,7 +80,7 @@ beforeEach(() => {
 });
 
 describe("AgentTranscriptItemView render stability", () => {
-  it("renders a goal control as a dedicated transcript row", () => {
+  it("renders and copies a goal control as a dedicated transcript row", async () => {
     const row: AgentGoalControlRowVM = {
       kind: "goal-control",
       id: "goal-control:client-submit:user:submit-goal-1",
@@ -89,6 +89,8 @@ describe("AgentTranscriptItemView render stability", () => {
       body: "/goal ship it",
       occurredAtUnixMs: 1
     };
+    const writeText = vi.fn(async () => undefined);
+    installAgentHostClipboard(writeText);
 
     const { container } = render(
       <AgentTranscriptItemView
@@ -103,6 +105,20 @@ describe("AgentTranscriptItemView render stability", () => {
     expect(
       container.querySelector('[data-agent-goal-control-action="set"]')
     ).toBeInTheDocument();
+    expect(
+      container.querySelector(
+        '[data-agent-message-footer="true"] [aria-label="agentHost.agentGui.copyMessage"]'
+      )
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "agentHost.agentGui.copyMessage"
+      })
+    );
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("/goal ship it");
+    });
   });
 
   it("renders a generated image artifact independently from tool-call expansion", () => {

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -53,6 +53,9 @@ eligibility is decided by `ResolveResumePolicy`: root sessions resume normally,
 explicit imports may recreate a missing provider session, and child,
 tombstoned, or non-resumable imports are rejected. Canonical titles may be
 empty; only an explicit title or the first eligible prompt establishes one.
+For typed initial Goal, the display prompt (or a synthesized `/goal` command)
+is the eligible prompt and is established before provider startup, even though
+the Goal path does not create a Turn.
 `CreateSessionInput.RailPlacement` optionally carries the caller-selected,
 versioned canonical rail identity. Host validates it before provider startup
 and persists its opaque `SectionKey` exactly on first creation. An idempotent

--- a/packages/agent/host/conformance/session_lifecycle_scenarios.go
+++ b/packages/agent/host/conformance/session_lifecycle_scenarios.go
@@ -86,10 +86,11 @@ func runCreateWithInitialGoal(ctx context.Context, driver Driver) error {
 		return err
 	}
 	input := agenthost.CreateSessionInput{
-		AgentSessionID: "session-initial-goal",
-		AgentTargetID:  "target-1",
-		Provider:       "codex",
-		ClientSubmitID: "create-goal-submit-1",
+		AgentSessionID:       "session-initial-goal",
+		AgentTargetID:        "target-1",
+		Provider:             "codex",
+		ClientSubmitID:       "create-goal-submit-1",
+		InitialDisplayPrompt: "/goal ship the feature",
 		InitialGoalControl: &agenthost.TypedGoalControl{
 			Action:    "set",
 			Objective: "ship the feature",
@@ -101,6 +102,9 @@ func runCreateWithInitialGoal(ctx context.Context, driver Driver) error {
 	}
 	if session.SessionID != "session-initial-goal" || turnID != "" {
 		return fmt.Errorf("create with typed initial goal = %#v turn %q", session, turnID)
+	}
+	if session.Title != "/goal ship the feature" {
+		return fmt.Errorf("typed initial goal title=%q", session.Title)
 	}
 	goal, err := driver.GetGoalState(ctx, agenthost.SessionRef{
 		WorkspaceID:    "workspace-1",

--- a/packages/agent/host/goal_control.go
+++ b/packages/agent/host/goal_control.go
@@ -177,6 +177,29 @@ func ParseTypedGoalControl(content []PromptContentBlock, guidance bool) (TypedGo
 	}
 }
 
+func typedGoalDisplayPrompt(goal TypedGoalControl) string {
+	if goal.Action == "set" {
+		return firstNonEmpty("/goal "+strings.TrimSpace(goal.Objective), "")
+	}
+	return firstNonEmpty("/goal "+strings.TrimSpace(goal.Action), "")
+}
+
+func initialGoalRuntimeTitle(
+	explicitTitle string,
+	displayPrompt string,
+	goal TypedGoalControl,
+	isTypedGoal bool,
+) (string, bool) {
+	title := strings.TrimSpace(explicitTitle)
+	if isTypedGoal && NormalizeTitle(title) == "" {
+		title = DeriveInitialTitle(
+			"",
+			firstNonEmpty(strings.TrimSpace(displayPrompt), typedGoalDisplayPrompt(goal)),
+		)
+	}
+	return title, NormalizeTitle(title) != ""
+}
+
 // GoalControl performs a direct goal action (pause/resume/clear/set) on the
 // session's thread. Like Cancel it is a control operation: it never opens a
 // turn, so it works while a turn is running.

--- a/packages/agent/host/lifecycle.go
+++ b/packages/agent/host/lifecycle.go
@@ -122,10 +122,11 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 	}
 	session, err := func() (ProviderRuntimeSession, error) {
 		defer release()
+		runtimeTitle, initialTitleEstablished := initialGoalRuntimeTitle(value(input.Title), input.InitialDisplayPrompt, typedGoal, isTypedGoal)
 		return h.runtime.Start(ctx, RuntimeStartInput{
 			WorkspaceID: workspaceID, AgentSessionID: input.AgentSessionID, AgentTargetID: input.AgentTargetID,
 			Provider: input.Provider, Cwd: prepared.Cwd, Env: append([]string(nil), prepared.Env...),
-			Title: value(input.Title), InitialTitleEstablished: NormalizeTitle(value(input.Title)) != "",
+			Title: runtimeTitle, InitialTitleEstablished: initialTitleEstablished,
 			PermissionModeID: value(input.PermissionModeID), Model: value(input.Model), PlanMode: valueBool(input.PlanMode),
 			BrowserUse: input.BrowserUse, ComputerUse: input.ComputerUse,
 			ProviderTargetRef: cloneMap(firstMap(prepared.ProviderTargetRef, input.ProviderTargetRef)),


### PR DESCRIPTION
## Summary
- Add the shared copy action to dedicated goal-control user rows.
- Derive the canonical session title for typed initial goals before provider startup, with a synthesized `/goal` fallback.
- Add UI and Host/service conformance coverage plus architecture and troubleshooting documentation.

## Tests
- `pnpm check:changed -- --push-ready` — 15/15 lanes passed.

## Review
| Lane | Result | Evidence |
| --- | --- | --- |
| Architecture | pass | Goal lifecycle remains Host-owned; the goal-control row stays a presentation-only row; architecture docs and Host conformance were updated. |
| Performance | pass | No high-frequency engine or projection path was broadened; AgentGUI degradation and changed-aware checks passed. |
| Consumers | pass | Desktop AgentGUI, direct Host, and service adapter coverage pass; no public API or DTO changed. |

## Notes
- The collaboration-result copy follow-up is intentionally outside this PR.