### PR TITLE
fix(file-manager): own search cancellation lifecycle

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/desktopWorkspaceFileManagerAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/desktopWorkspaceFileManagerAdapter.ts
@@ -169,7 +169,8 @@ export function createDesktopWorkspaceFileManagerAdapter(
     async listRecentEntries(input): Promise<WorkspaceFileDirectoryListing> {
       const response = await tuttidClient.listWorkspaceRecentFiles(
         input.workspaceID,
-        { limit: input.limit }
+        { limit: input.limit },
+        input.signal ? { signal: input.signal } : undefined
       );
       return {
         directoryPath: response.directoryPath,
@@ -195,7 +196,8 @@ export function createDesktopWorkspaceFileManagerAdapter(
           limit: input.limit,
           query: input.query,
           within: input.within
-        }
+        },
+        { signal: input.signal }
       );
       return {
         entries: response.entries.map((entry) => ({

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.test.ts
@@ -638,12 +638,16 @@ test("desktop workspace file locations include projects and local entries", () =
 test("desktop workspace file manager adapter forwards recent and scoped search requests", async () => {
   const dependencies = createDependenciesStub();
   let recentLimit: number | undefined;
+  let recentSignal: AbortSignal | null = null;
   let searchWithin: string | undefined;
+  let searchSignal: AbortSignal | null = null;
   dependencies.tuttidClient.listWorkspaceRecentFiles = async (
     workspaceId,
-    input
+    input,
+    requestOptions
   ) => {
     recentLimit = input?.limit;
+    recentSignal = requestOptions?.signal ?? null;
     return {
       directoryPath: "/Users/local",
       entries: [],
@@ -653,9 +657,11 @@ test("desktop workspace file manager adapter forwards recent and scoped search r
   };
   dependencies.tuttidClient.searchWorkspaceFiles = async (
     workspaceId,
-    input
+    input,
+    requestOptions
   ) => {
     searchWithin = input.within;
+    searchSignal = requestOptions?.signal ?? null;
     return {
       entries: [],
       root: "/Users/local",
@@ -670,19 +676,25 @@ test("desktop workspace file manager adapter forwards recent and scoped search r
     },
     () => "en"
   );
+  const recentController = new AbortController();
+  const searchController = new AbortController();
 
   await adapter.listRecentEntries?.({
     limit: 7,
+    signal: recentController.signal,
     workspaceID: "workspace-1"
   });
   await adapter.search?.({
     query: "app",
+    signal: searchController.signal,
     within: "/Users/local/repo",
     workspaceID: "workspace-1"
   });
 
   assert.equal(recentLimit, 7);
+  assert.equal(recentSignal, recentController.signal);
   assert.equal(searchWithin, "/Users/local/repo");
+  assert.equal(searchSignal, searchController.signal);
 });
 
 async function flushMicrotasks(): Promise<void> {

--- a/packages/workspace/file-manager/CONTRACT.md
+++ b/packages/workspace/file-manager/CONTRACT.md
@@ -120,6 +120,10 @@ keep truly product-specific flows outside the shared session.
 - Location selection (`selectedLocationId`) and host-supplied
   `locationSections`
 - Search query/results projection when `canSearch`
+- Search request lifecycle: starting a replacement search, clearing search
+  state, or disposing the session aborts the active request. The session passes
+  that lifecycle through `AbortSignal` on `search`; recent-location filtering
+  passes the same signal to `listRecentEntries`.
 - Mutation busy state and shared error projection helpers
 - Entry-name validation for create and rename operations before host mutation;
   one name segment is limited to 255 UTF-8 bytes
@@ -267,6 +271,9 @@ Hosts own:
   the OS edge)
 - Implementing required `listDirectory` plus whichever optional Host methods
   they want capabilities for
+- Forwarding the session-provided search `AbortSignal` through the host
+  transport so superseded work can stop promptly; hosts must still tolerate a
+  request completing after cancellation
 - Import / export / upload / download pipelines, including any transfer-center
   integration
 - Context-menu action trees through `resolveContextMenu`

--- a/packages/workspace/file-manager/README.md
+++ b/packages/workspace/file-manager/README.md
@@ -18,6 +18,12 @@ package keeps shared state in logical workspace paths such as
 `/workspace/src/index.ts` and does not depend on tuttid, TSH, TACH, VM paths,
 or host absolute paths.
 
+The session owns search cancellation. It aborts the active host request when a
+new search replaces it, search state is cleared, or the session is disposed.
+Hosts that implement `search` must forward the supplied `AbortSignal` to their
+transport; `listRecentEntries` receives the same optional signal when it is
+called for recent-location filtering.
+
 This package is intentionally a reusable frontend workspace-domain surface, not
 only a transport-agnostic data kernel. Shared session orchestration, preview
 flow, activation flow, and React-facing interaction state may live here when

--- a/packages/workspace/file-manager/src/services/internal/workspaceFileManagerSession.ts
+++ b/packages/workspace/file-manager/src/services/internal/workspaceFileManagerSession.ts
@@ -72,6 +72,7 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
   private readonly onMutationErrorMessage?: (
     message: WorkspaceFileManagerMutationErrorMessage
   ) => boolean | void;
+  private activeSearchController: AbortController | null = null;
   private searchRequestSeq = 0;
   private readonly activationController: WorkspaceFileManagerActivationController;
   private copy: WorkspaceFileManagerI18nRuntime;
@@ -321,6 +322,7 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
     this.initializePromise = null;
     this.isActive = false;
     this.searchRequestSeq += 1;
+    this.cancelActiveSearch();
     this.store.isSearching = false;
     this.unsubscribeStore?.();
     this.unsubscribeStore = null;
@@ -624,6 +626,7 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
 
   async search(query: string): Promise<void> {
     const requestID = ++this.searchRequestSeq;
+    this.cancelActiveSearch();
     this.store.searchQuery = query;
     this.store.searchError = null;
     const trimmedQuery = query.trim();
@@ -634,11 +637,17 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
     }
 
     this.store.isSearching = true;
+    const searchController = new AbortController();
+    this.activeSearchController = searchController;
     try {
       const selectedLocation = this.selectedLocation();
       const entries = isWorkspaceFileRecentLocation(selectedLocation)
-        ? await this.searchRecentEntries(trimmedQuery)
-        : await this.searchDirectoryEntries(query, selectedLocation);
+        ? await this.searchRecentEntries(trimmedQuery, searchController.signal)
+        : await this.searchDirectoryEntries(
+            query,
+            selectedLocation,
+            searchController.signal
+          );
       if (this.isDisposed || requestID !== this.searchRequestSeq) {
         return;
       }
@@ -648,6 +657,9 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
         this.store.searchError = this.resolveErrorMessage(error);
       }
     } finally {
+      if (this.activeSearchController === searchController) {
+        this.activeSearchController = null;
+      }
       if (!this.isDisposed && requestID === this.searchRequestSeq) {
         this.store.isSearching = false;
       }
@@ -915,7 +927,9 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
   }
 
   private clearSearchState(): void {
+    const canceledSearch = this.cancelActiveSearch();
     if (
+      !canceledSearch &&
       this.store.searchQuery === "" &&
       this.store.searchEntries.length === 0 &&
       this.store.searchError === null &&
@@ -930,15 +944,27 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
     this.store.isSearching = false;
   }
 
+  private cancelActiveSearch(): boolean {
+    const searchController = this.activeSearchController;
+    if (!searchController) {
+      return false;
+    }
+    this.activeSearchController = null;
+    searchController.abort();
+    return true;
+  }
+
   private async searchDirectoryEntries(
     query: string,
-    selectedLocation: WorkspaceFileLocation | null
+    selectedLocation: WorkspaceFileLocation | null,
+    signal: AbortSignal
   ): Promise<WorkspaceFileSearchEntry[]> {
     if (!this.host.search) {
       return [];
     }
     const result = await this.host.search({
       query,
+      signal,
       workspaceID: this.store.workspaceID,
       ...(selectedLocation?.kind === "directory"
         ? { within: selectedLocation.path }
@@ -948,13 +974,15 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
   }
 
   private async searchRecentEntries(
-    query: string
+    query: string,
+    signal: AbortSignal
   ): Promise<WorkspaceFileSearchEntry[]> {
     if (!this.host.listRecentEntries) {
       return [];
     }
     const listing = await this.host.listRecentEntries({
       limit: 100,
+      signal,
       workspaceID: this.store.workspaceID
     });
     const normalizedQuery = query.trim().toLowerCase();

--- a/packages/workspace/file-manager/src/services/workspaceFileManagerHost.interface.ts
+++ b/packages/workspace/file-manager/src/services/workspaceFileManagerHost.interface.ts
@@ -29,11 +29,13 @@ export interface WorkspaceFileManagerHost {
   }): Promise<WorkspaceFileDirectoryListing>;
   search?(
     input: WorkspaceFileSearchInput & {
+      signal: AbortSignal;
       workspaceID: string;
     }
   ): Promise<WorkspaceFileSearchResult>;
   listRecentEntries?(input: {
     limit?: number;
+    signal?: AbortSignal;
     workspaceID: string;
   }): Promise<WorkspaceFileDirectoryListing>;
   createDirectory?(input: {

--- a/packages/workspace/file-manager/src/services/workspaceFileManagerSession.test.ts
+++ b/packages/workspace/file-manager/src/services/workspaceFileManagerSession.test.ts
@@ -644,9 +644,11 @@ test("copyToClipboard reports false when the host cannot copy", async () => {
 test("stale search results do not overwrite newer query results", async () => {
   const firstSearch = createDeferred<WorkspaceFileSearchResult>();
   const secondSearch = createDeferred<WorkspaceFileSearchResult>();
+  const searchSignals: AbortSignal[] = [];
   const session = createSession({
     host: {
       async search(input) {
+        searchSignals.push(input.signal);
         return input.query === "first"
           ? firstSearch.promise
           : secondSearch.promise;
@@ -659,6 +661,9 @@ test("stale search results do not overwrite newer query results", async () => {
   await flushMicrotasks();
   const secondPromise = session.search("second");
   await flushMicrotasks();
+
+  assert.equal(searchSignals[0]?.aborted, true);
+  assert.equal(searchSignals[1]?.aborted, false);
 
   secondSearch.resolve(createSearchResult("/Users/demo/project/second.txt"));
   await secondPromise;
@@ -676,8 +681,38 @@ test("stale search results do not overwrite newer query results", async () => {
   session.dispose();
 });
 
+test("clearing a search query aborts its active host request", async () => {
+  const deferredSearch = createDeferred<WorkspaceFileSearchResult>();
+  const searchSignals: AbortSignal[] = [];
+  const session = createSession({
+    host: {
+      async search(input) {
+        searchSignals.push(input.signal);
+        return deferredSearch.promise;
+      }
+    }
+  });
+
+  await session.initialize();
+  const searchPromise = session.search("notes");
+  await flushMicrotasks();
+
+  await session.search("");
+
+  assert.equal(searchSignals[0]?.aborted, true);
+  assert.equal(session.store.searchQuery, "");
+  assert.equal(session.store.isSearching, false);
+
+  deferredSearch.resolve(createSearchResult("/Users/demo/project/notes.txt"));
+  await searchPromise;
+  assert.deepEqual(session.store.searchEntries, []);
+
+  session.dispose();
+});
+
 test("entering directories clears search state and ignores stale results", async () => {
   const deferredSearch = createDeferred<WorkspaceFileSearchResult>();
+  const searchSignals: AbortSignal[] = [];
   const srcEntry = createEntry("/Users/demo/project/src", {
     hasChildren: true,
     kind: "directory",
@@ -693,7 +728,8 @@ test("entering directories clears search state and ignores stale results", async
           directoryPath === defaultRoot ? [srcEntry] : [appEntry]
         );
       },
-      async search() {
+      async search(input) {
+        searchSignals.push(input.signal);
         return deferredSearch.promise;
       }
     }
@@ -707,6 +743,7 @@ test("entering directories clears search state and ignores stale results", async
 
   await session.openEntry(srcEntry);
 
+  assert.equal(searchSignals[0]?.aborted, true);
   assert.equal(session.store.currentDirectoryPath, "/Users/demo/project/src");
   assert.equal(session.store.searchQuery, "");
   assert.deepEqual(session.store.searchEntries, []);
@@ -1074,6 +1111,7 @@ test("recent locations load recent entries, search locally, and block mutations"
   let hostSearchCalls = 0;
   let listDirectoryCalls = 0;
   let listRecentCalls = 0;
+  const recentSignals: Array<AbortSignal | undefined> = [];
   const session = createWorkspaceFileManagerService().createSession({
     host: {
       async listDirectory(input) {
@@ -1087,6 +1125,7 @@ test("recent locations load recent entries, search locally, and block mutations"
       },
       async listRecentEntries(input) {
         listRecentCalls += 1;
+        recentSignals.push(input.signal);
         return {
           directoryPath: "/Users/demo",
           entries: [
@@ -1164,6 +1203,12 @@ test("recent locations load recent entries, search locally, and block mutations"
   assert.equal(hostSearchCalls, 0);
   assert.equal(listDirectoryCalls, 0);
   assert.equal(listRecentCalls, 4);
+  assert.deepEqual(
+    recentSignals.map((signal) =>
+      signal === undefined ? "none" : signal.aborted
+    ),
+    ["none", false, false, "none"]
+  );
   session.dispose();
 });
 
@@ -1243,6 +1288,7 @@ test("explicit directory loads leave recent read-only mode", async () => {
 
 test("directory location search is scoped with within", async () => {
   const withinValues: Array<string | undefined> = [];
+  const searchSignals: AbortSignal[] = [];
   const session = createWorkspaceFileManagerService().createSession({
     host: {
       async listDirectory(input) {
@@ -1255,6 +1301,7 @@ test("directory location search is scoped with within", async () => {
       },
       async search(input) {
         withinValues.push(input.within);
+        searchSignals.push(input.signal);
         return {
           entries: [],
           root: "/Users/demo",
@@ -1285,11 +1332,13 @@ test("directory location search is scoped with within", async () => {
   await session.search("app");
 
   assert.deepEqual(withinValues, ["/Users/demo/repo"]);
+  assert.equal(searchSignals[0]?.aborted, false);
   session.dispose();
 });
 
 test("pending search results do not mutate disposed sessions", async () => {
   const deferredSearch = createDeferred<WorkspaceFileSearchResult>();
+  const searchSignals: AbortSignal[] = [];
   const session = createWorkspaceFileManagerService().createSession({
     host: {
       async listDirectory(input) {
@@ -1300,7 +1349,8 @@ test("pending search results do not mutate disposed sessions", async () => {
           workspaceID: input.workspaceID
         };
       },
-      async search() {
+      async search(input) {
+        searchSignals.push(input.signal);
         return deferredSearch.promise;
       }
     },
@@ -1314,6 +1364,7 @@ test("pending search results do not mutate disposed sessions", async () => {
   assert.equal(session.store.isSearching, true);
 
   session.dispose();
+  assert.equal(searchSignals[0]?.aborted, true);
   assert.equal(session.store.isSearching, false);
   deferredSearch.resolve({
     entries: [


### PR DESCRIPTION
## What changed

- make `WorkspaceFileManagerSession` own the active search `AbortController`
- abort superseded searches when a new query starts, search state is cleared, navigation clears search, or the session is disposed
- pass the session `AbortSignal` through the `WorkspaceFileManagerHost.search` contract and recent-entry filtering
- retain request sequencing so late results cannot overwrite current state even when a host ignores cancellation
- document the session/host ownership boundary and add lifecycle coverage

## Why

Search cancellation is shared session orchestration. Keeping it in individual hosts duplicates lifecycle state and leaves stale backend work running after query replacement or session disposal.

## Impact and risk

This changes the public `WorkspaceFileManagerHost.search` input contract: hosts must forward the supplied signal to their transport. `listRecentEntries.signal` is optional because regular recent-location loads are not search requests. Existing stale-result guards remain in place.

A new fixed Tutti package cohort must be published before downstream TSH can consume this contract from a released version.

## Validation

- `pnpm check:changed` — 9 lanes passed before commit
- push-ready `pnpm check:changed` — 10 lanes passed
- `pnpm --filter @tutti-os/workspace-file-manager typecheck`
- `pnpm --filter @tutti-os/workspace-file-manager test` — 141 Node tests and 24 Vitest tests passed
- `pnpm release:pack:check -- --packages-json '["@tutti-os/workspace-file-manager"]'`
- packed declaration verified to expose `signal: AbortSignal`