### PR TITLE
fix(mobile): recover device connection after background

### DIFF
--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -9,6 +9,7 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import { type NativeTheme, useNativeTheme } from "@tutti-os/ui-system/native";
 import { useServiceSnapshot } from "./bindings/useServiceSnapshot";
+import { MobileConnectionRecoveryOverlay } from "./components/MobileConnectionRecoveryOverlay";
 import { MobileUIProviders } from "./components/MobileUIProviders";
 import { NativeComponentGallery } from "./dev/NativeComponentGallery";
 import { t } from "./i18n";
@@ -43,18 +44,33 @@ function AppContent() {
         barStyle={theme.mode === "dark" ? "light-content" : "dark-content"}
       />
       <SafeAreaView edges={["top", "bottom"]} style={styles.safeArea}>
-        {galleryOpen ? (
-          <NativeComponentGallery onClose={() => setGalleryOpen(false)} />
-        ) : snapshot.status === "bootstrapping" ? (
-          <View style={styles.loading}>
-            <ActivityIndicator color={theme.color.accent} size="large" />
-          </View>
-        ) : (
-          <MobileNavigator
-            application={mobileApplicationService}
-            snapshot={snapshot}
-          />
-        )}
+        <View style={styles.content}>
+          {galleryOpen ? (
+            <NativeComponentGallery onClose={() => setGalleryOpen(false)} />
+          ) : snapshot.status === "bootstrapping" ? (
+            <View style={styles.loading}>
+              <ActivityIndicator color={theme.color.accent} size="large" />
+            </View>
+          ) : (
+            <MobileNavigator
+              application={mobileApplicationService}
+              snapshot={snapshot}
+            />
+          )}
+          {snapshot.status === "authenticated" &&
+          snapshot.device &&
+          snapshot.workspace ? (
+            <MobileConnectionRecoveryOverlay
+              connection={snapshot.connection}
+              onBackToDevices={() =>
+                void mobileApplicationService.disconnectDevice()
+              }
+              onRetry={() =>
+                void mobileApplicationService.retryDeviceConnection()
+              }
+            />
+          ) : null}
+        </View>
       </SafeAreaView>
     </>
   );
@@ -62,6 +78,7 @@ function AppContent() {
 
 function createStyles(theme: NativeTheme) {
   return StyleSheet.create({
+    content: { flex: 1 },
     loading: {
       alignItems: "center",
       flex: 1,

--- a/apps/mobile/src/components/MobileConnectionRecoveryOverlay.tsx
+++ b/apps/mobile/src/components/MobileConnectionRecoveryOverlay.tsx
@@ -1,0 +1,112 @@
+import {
+  NativeButton,
+  type NativeTheme,
+  useNativeTheme
+} from "@tutti-os/ui-system/native";
+import { ActivityIndicator, Modal, StyleSheet, Text, View } from "react-native";
+import { t } from "../i18n";
+import type { MobileConnectionSnapshot } from "../services/mobileApplicationService";
+
+interface MobileConnectionRecoveryOverlayProps {
+  connection: MobileConnectionSnapshot;
+  onBackToDevices(): void;
+  onRetry(): void;
+}
+
+export function MobileConnectionRecoveryOverlay({
+  connection,
+  onBackToDevices,
+  onRetry
+}: MobileConnectionRecoveryOverlayProps) {
+  const theme = useNativeTheme();
+  const styles = createStyles(theme);
+  if (connection.phase === "idle" || connection.phase === "connected") {
+    return null;
+  }
+  const failed = connection.phase === "failed";
+
+  return (
+    <Modal
+      animationType="fade"
+      onRequestClose={onBackToDevices}
+      statusBarTranslucent
+      transparent
+      visible
+    >
+      <View accessibilityViewIsModal style={styles.backdrop}>
+        <View style={styles.card}>
+          {failed ? null : (
+            <ActivityIndicator color={theme.color.accent} size="large" />
+          )}
+          <Text accessibilityRole="header" style={styles.title}>
+            {failed
+              ? t("connectionRecoveryFailedTitle")
+              : connection.phase === "synchronizing"
+                ? t("connectionSynchronizingTitle")
+                : t("connectionReconnectingTitle")}
+          </Text>
+          <Text style={styles.description}>
+            {failed
+              ? t("connectionRecoveryFailedDescription")
+              : t("connectionRecoveryDescription")}
+          </Text>
+          <View style={styles.actions}>
+            {failed ? (
+              <NativeButton
+                label={t("retryConnection")}
+                onPress={onRetry}
+                size="large"
+              />
+            ) : null}
+            <NativeButton
+              label={t("backToDevices")}
+              onPress={onBackToDevices}
+              size="large"
+              variant="secondary"
+            />
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+function createStyles(theme: NativeTheme) {
+  return StyleSheet.create({
+    actions: {
+      gap: theme.space.small,
+      marginTop: theme.space.small,
+      width: "100%"
+    },
+    backdrop: {
+      alignItems: "center",
+      backgroundColor: theme.color.scrim,
+      flex: 1,
+      justifyContent: "center",
+      padding: theme.space.large
+    },
+    card: {
+      alignItems: "center",
+      backgroundColor: theme.color.panelRaised,
+      borderColor: theme.color.border,
+      borderRadius: theme.radius.large,
+      borderWidth: StyleSheet.hairlineWidth,
+      gap: theme.space.medium,
+      maxWidth: 420,
+      padding: theme.space.large,
+      width: "100%"
+    },
+    description: {
+      color: theme.color.textSecondary,
+      fontSize: 15,
+      lineHeight: 22,
+      textAlign: "center"
+    },
+    title: {
+      color: theme.color.text,
+      fontSize: 20,
+      fontWeight: "700",
+      textAlign: "center"
+    }
+  });
+}

--- a/apps/mobile/src/i18n.ts
+++ b/apps/mobile/src/i18n.ts
@@ -25,6 +25,13 @@ const messages = {
     connecting: "Connecting securely…",
     connectionFailed:
       "Could not reach this computer. Make sure Tutti is running and try again.",
+    connectionReconnectingTitle: "Reconnecting to your computer",
+    connectionRecoveryDescription:
+      "Your current screen will remain available while the latest data is restored.",
+    connectionRecoveryFailedDescription:
+      "Make sure Tutti is running on your computer, then try again or return to your computers.",
+    connectionRecoveryFailedTitle: "Could not reconnect",
+    connectionSynchronizingTitle: "Syncing the latest data",
     deviceEmpty:
       "Pair your computer to start using Agent sessions on your phone.",
     deviceEmptyTitle: "No computer paired",
@@ -104,6 +111,7 @@ const messages = {
       "This pairing code could not be used. Create a new code on your computer.",
     pairingWaiting: "Waiting for your computer to confirm…",
     retry: "Retry",
+    retryConnection: "Reconnect",
     running: "Running",
     ready: "Ready",
     recentSessions: "Recent",
@@ -165,6 +173,13 @@ const messages = {
     collapseSection: "收起分组",
     connecting: "正在建立安全连接…",
     connectionFailed: "无法连接这台电脑，请确认 Tutti 正在运行后重试",
+    connectionReconnectingTitle: "正在重新连接电脑",
+    connectionRecoveryDescription:
+      "恢复连接并同步最新数据后，会继续显示当前页面",
+    connectionRecoveryFailedDescription:
+      "请确认电脑端 Tutti 正在运行，然后重试或返回电脑列表",
+    connectionRecoveryFailedTitle: "无法重新连接",
+    connectionSynchronizingTitle: "正在同步最新数据",
     deviceEmpty: "先配对你的电脑，即可在手机上使用 Agent 会话",
     deviceEmptyTitle: "还没有配对电脑",
     devices: "你的电脑",
@@ -238,6 +253,7 @@ const messages = {
     pairingFailed: "无法使用此配对二维码，请在电脑上重新生成",
     pairingWaiting: "等待电脑确认…",
     retry: "重试",
+    retryConnection: "重新连接",
     running: "运行中",
     ready: "就绪",
     recentSessions: "最近会话",

--- a/apps/mobile/src/navigation/mobileNavigation.test.ts
+++ b/apps/mobile/src/navigation/mobileNavigation.test.ts
@@ -27,6 +27,7 @@ describe("mobile navigation access", () => {
   test("uses Devices as the authenticated root without a workspace route", () => {
     expect(
       availableMobileRoutes({
+        connection: { phase: "idle" },
         device: null,
         session,
         status: "authenticated",
@@ -38,6 +39,7 @@ describe("mobile navigation access", () => {
   test("opens conversation routes only after the Personal workspace resolves", () => {
     expect(
       availableMobileRoutes({
+        connection: { phase: "connected" },
         device: { name: "Desktop", pairingId: "pairing-1" },
         session,
         status: "authenticated",

--- a/apps/mobile/src/services/composerDraftService.ts
+++ b/apps/mobile/src/services/composerDraftService.ts
@@ -8,10 +8,15 @@ export interface ComposerDraftSnapshot {
 
 export class ComposerDraftService extends ObservableService<ComposerDraftSnapshot> {
   readonly _serviceBrand: undefined;
-  private snapshot: ComposerDraftSnapshot = {
-    drafts: {},
-    settingsByTargetId: {}
-  };
+  private snapshot: ComposerDraftSnapshot;
+
+  constructor(previous?: ComposerDraftSnapshot) {
+    super();
+    this.snapshot = {
+      drafts: { ...previous?.drafts },
+      settingsByTargetId: { ...previous?.settingsByTargetId }
+    };
+  }
 
   getSnapshot = (): ComposerDraftSnapshot => this.snapshot;
 

--- a/apps/mobile/src/services/deviceService.ts
+++ b/apps/mobile/src/services/deviceService.ts
@@ -210,30 +210,39 @@ export class DeviceService extends ObservableService<DeviceSnapshot> {
     }
   }
 
-  async connect(pairing: DevicePairing, device?: UserDevice): Promise<void> {
+  connect(pairing: DevicePairing, device?: UserDevice): Promise<boolean> {
+    return this.connectDevice({
+      name: device?.displayName || device?.reportedName || "",
+      pairingId: pairing.pairingId
+    });
+  }
+
+  reconnect(device: ConnectedDevice): Promise<boolean> {
+    return this.connectDevice(device);
+  }
+
+  private async connectDevice(device: ConnectedDevice): Promise<boolean> {
     if (
       this.disposed ||
       !this.remoteOperationsEnabled ||
       this.snapshot.connectingPairingId !== null
     ) {
-      return;
+      return false;
     }
     const generation = ++this.connectionGeneration;
     this.patch({
-      connectingPairingId: pairing.pairingId,
+      connectingPairingId: device.pairingId,
       errorCode: null
     });
     try {
       await this.pairing.connectPairedDevice(
         this.session.sessionId,
-        pairing.pairingId,
+        device.pairingId,
         () => this.isConnectionCurrent(generation)
       );
-      if (!this.isConnectionCurrent(generation)) return;
-      await this.onConnected({
-        name: device?.displayName || device?.reportedName || "",
-        pairingId: pairing.pairingId
-      });
+      if (!this.isConnectionCurrent(generation)) return false;
+      await this.onConnected(device);
+      return this.isConnectionCurrent(generation);
     } catch (cause) {
       if (this.isConnectionCurrent(generation)) {
         this.patch({
@@ -243,6 +252,7 @@ export class DeviceService extends ObservableService<DeviceSnapshot> {
               : "connection_failed"
         });
       }
+      return false;
     } finally {
       if (this.isConnectionCurrent(generation)) {
         this.patch({ connectingPairingId: null });

--- a/apps/mobile/src/services/mobileApplicationService.test.ts
+++ b/apps/mobile/src/services/mobileApplicationService.test.ts
@@ -62,26 +62,109 @@ describe("MobileApplicationService scopes", () => {
     expect(harness.legacyCookieClearCalls).toBe(2);
   });
 
-  test("background grace closes DeviceLink only after the deadline", async () => {
-    const harness = createHarness(session);
+  test("reconnects after the native background deadline without dropping the workspace", async () => {
+    const harness = createHarness(session, [workspace]);
     const service = new MobileApplicationService(
       new InstantiationService(),
       harness.ports
     );
     await service.start();
+    await service.deviceService!.connect(pairing);
+    harness.emitAgentLiveConnection("connected");
+    const previousActivity = service.workspaceActivityService!;
+    previousActivity.startCreating();
+    previousActivity.setDraft("RECOVERY_DRAFT");
+    expect(service.getSnapshot()).toMatchObject({
+      connection: { phase: "connected" },
+      device: { pairingId: pairing.pairingId },
+      workspace: { id: workspace.id }
+    });
 
     harness.emitLifecycle("background");
     expect(harness.closeCalls).toBe(0);
-    harness.clock.advanceBy(14_999);
+    harness.clock.advanceBy(15_000);
     expect(harness.closeCalls).toBe(0);
-    harness.clock.advanceBy(1);
-    await flushPromises();
+    harness.emitLifecycle("foreground");
+    await service.retryDeviceConnection();
 
     expect(harness.closeCalls).toBe(1);
+    expect(harness.connectCalls).toBe(2);
     expect(service.getSnapshot()).toMatchObject({
-      device: null,
+      connection: {
+        phase: "synchronizing",
+        trigger: "background_expired"
+      },
+      device: { pairingId: pairing.pairingId },
       status: "authenticated",
-      workspace: null
+      workspace: { id: workspace.id }
+    });
+    harness.emitAgentLiveConnection("connected");
+    expect(service.getSnapshot()).toMatchObject({
+      connection: { phase: "connected" },
+      workspace: { id: workspace.id }
+    });
+    expect(service.workspaceActivityService).not.toBe(previousActivity);
+    expect(service.workspaceActivityService!.getSnapshot()).toMatchObject({
+      creating: true,
+      draft: "RECOVERY_DRAFT"
+    });
+  });
+
+  test("lets the live stream retry briefly before rebuilding a lost DeviceLink", async () => {
+    const harness = createHarness(session, [workspace]);
+    const service = new MobileApplicationService(
+      new InstantiationService(),
+      harness.ports
+    );
+    await service.start();
+    await service.deviceService!.connect(pairing);
+    harness.emitAgentLiveConnection("connected");
+
+    harness.emitAgentLiveConnection("disconnected");
+    expect(service.getSnapshot()).toMatchObject({
+      connection: { phase: "synchronizing", trigger: "transport_lost" },
+      workspace: { id: workspace.id }
+    });
+    harness.clock.advanceBy(1_499);
+    await flushPromises();
+    expect(harness.closeCalls).toBe(0);
+    expect(harness.connectCalls).toBe(1);
+
+    harness.clock.advanceBy(1);
+    await flushPromises();
+    expect(harness.closeCalls).toBe(1);
+    expect(harness.connectCalls).toBe(2);
+  });
+
+  test("keeps the workspace available after recovery fails and retries explicitly", async () => {
+    const harness = createHarness(session, [workspace]);
+    const service = new MobileApplicationService(
+      new InstantiationService(),
+      harness.ports
+    );
+    await service.start();
+    await service.deviceService!.connect(pairing);
+    harness.emitAgentLiveConnection("connected");
+    harness.failNextConnection();
+
+    harness.emitLifecycle("background");
+    harness.clock.advanceBy(15_000);
+    harness.emitLifecycle("foreground");
+    await service.retryDeviceConnection();
+    expect(service.getSnapshot()).toMatchObject({
+      connection: { phase: "failed", trigger: "background_expired" },
+      device: { pairingId: pairing.pairingId },
+      workspace: { id: workspace.id }
+    });
+
+    await service.retryDeviceConnection();
+    expect(service.getSnapshot()).toMatchObject({
+      connection: { phase: "synchronizing", trigger: "manual_retry" },
+      workspace: { id: workspace.id }
+    });
+    harness.emitAgentLiveConnection("connected");
+    expect(service.getSnapshot()).toMatchObject({
+      connection: { phase: "connected" }
     });
   });
 
@@ -195,21 +278,33 @@ function createHarness(
   clock: ManualClock;
   closeCalls: number;
   connectCalls: number;
+  emitAgentLiveConnection(status: "connected" | "disconnected"): void;
   emitLifecycle(state: AppLifecycleState): void;
+  failNextConnection(): void;
   legacyCookieClearCalls: number;
   ports: MobileServicePorts;
   registerCalls: number;
 } {
   const clock = new ManualClock();
   let lifecycleListener: ((state: AppLifecycleState) => void) | null = null;
+  let liveListener:
+    | Parameters<MobileServicePorts["deviceLink"]["subscribeAgentLive"]>[1]
+    | null = null;
+  let failNextConnection = false;
   const harness = {
     clock,
     closeCalls: 0,
     connectCalls: 0,
+    emitAgentLiveConnection(status: "connected" | "disconnected") {
+      liveListener?.({ kind: "connection", status });
+    },
     legacyCookieClearCalls: 0,
     registerCalls: 0,
     emitLifecycle(state: AppLifecycleState) {
       lifecycleListener?.(state);
+    },
+    failNextConnection() {
+      failNextConnection = true;
     },
     ports: null as unknown as MobileServicePorts
   };
@@ -253,7 +348,14 @@ function createHarness(
         protocolEpoch: 1,
         status: 204
       }),
-      subscribeAgentLive: () => ({ close() {} })
+      subscribeAgentLive: (_workspaceId, listener) => {
+        liveListener = listener;
+        return {
+          close() {
+            if (liveListener === listener) liveListener = null;
+          }
+        };
+      }
     },
     diagnostics: {
       record: () => undefined
@@ -271,6 +373,10 @@ function createHarness(
       }),
       connectPairedDevice: async () => {
         harness.connectCalls += 1;
+        if (failNextConnection) {
+          failNextConnection = false;
+          throw new Error("connection failed");
+        }
       },
       getPairingChallenge: async () => ({
         challengeId: "challenge-1",

--- a/apps/mobile/src/services/mobileApplicationService.ts
+++ b/apps/mobile/src/services/mobileApplicationService.ts
@@ -35,6 +35,23 @@ import type { WorkspaceConversationRailService } from "./workspaceConversationRa
 import { WorkspaceNavigationService } from "./workspaceNavigationService";
 
 const BACKGROUND_GRACE_MS = 15_000;
+const CONNECTION_READY_TIMEOUT_MS = 15_000;
+const TRANSPORT_RECOVERY_GRACE_MS = 1_500;
+
+export type MobileConnectionRecoveryTrigger =
+  | "background_expired"
+  | "foreground_resume"
+  | "initial_connect"
+  | "manual_retry"
+  | "transport_lost";
+
+export type MobileConnectionSnapshot =
+  | { phase: "idle" }
+  | { phase: "connected" }
+  | {
+      phase: "failed" | "reconnecting" | "synchronizing";
+      trigger: MobileConnectionRecoveryTrigger;
+    };
 
 export type MobileApplicationSnapshot =
   | { status: "bootstrapping" }
@@ -42,6 +59,7 @@ export type MobileApplicationSnapshot =
   | {
       status: "authenticated";
       device: ConnectedDevice | null;
+      connection: MobileConnectionSnapshot;
       session: AccountSession;
       workspace: WorkspaceSummary | null;
     };
@@ -61,6 +79,7 @@ interface WorkspaceScope {
   activity: WorkspaceActivityService;
   container: IInstantiationService;
   drafts: ComposerDraftService;
+  generation: number;
   navigation: WorkspaceNavigationService;
   rail: WorkspaceConversationRailService;
   workspace: WorkspaceSummary;
@@ -77,11 +96,15 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
   private workspaceScope: WorkspaceScope | null = null;
   private workspaceCandidate: WorkspaceScope | null = null;
   private lifecycleDispose: (() => void) | null = null;
-  private backgroundTask: { cancel(): void } | null = null;
+  private connectionReadyTask: { cancel(): void } | null = null;
+  private transportRecoveryTask: { cancel(): void } | null = null;
   private deviceDisconnectTask: Promise<void> | null = null;
+  private deviceReconnectTask: Promise<void> | null = null;
   private deviceLinkCloseTask: Promise<void> | null = null;
+  private backgroundStartedAtUnixMs: number | null = null;
   private appForeground = true;
   private startPromise: Promise<void> | null = null;
+  private connectionRecoveryGeneration = 0;
   private workspaceGeneration = 0;
   private disposed = false;
 
@@ -145,6 +168,7 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
 
   disconnectDevice(): Promise<void> {
     if (this.deviceDisconnectTask) return this.deviceDisconnectTask;
+    this.cancelConnectionRecovery();
     const scope = this.authenticatedScope;
     const task = this.closeDeviceLink().finally(() => {
       if (this.deviceDisconnectTask === task) {
@@ -165,13 +189,30 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
     return task;
   }
 
-  private async selectWorkspace(workspace: WorkspaceSummary): Promise<boolean> {
+  retryDeviceConnection(): Promise<void> {
+    return this.recoverDeviceConnection("manual_retry");
+  }
+
+  private async selectWorkspace(
+    workspace: WorkspaceSummary,
+    trigger: MobileConnectionRecoveryTrigger
+  ): Promise<boolean> {
     const authenticated = this.authenticatedScope;
     if (!authenticated?.device) return false;
-    this.disposeWorkspaceScope();
+    const previousCandidate = this.workspaceCandidate;
+    this.workspaceCandidate = null;
+    previousCandidate?.container.dispose();
     const generation = ++this.workspaceGeneration;
-    const navigation = new WorkspaceNavigationService();
-    const drafts = new ComposerDraftService();
+    const previousWorkspace =
+      this.workspaceScope?.workspace.id === workspace.id
+        ? this.workspaceScope
+        : null;
+    const navigation = new WorkspaceNavigationService(
+      previousWorkspace?.navigation.getSnapshot()
+    );
+    const drafts = new ComposerDraftService(
+      previousWorkspace?.drafts.getSnapshot()
+    );
     const activity = new WorkspaceActivityService(
       workspace,
       authenticated.client,
@@ -180,7 +221,9 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
       drafts,
       this.ports.clock,
       authenticated.session.userId,
-      this.ports.deviceLink
+      this.ports.deviceLink,
+      (connected) =>
+        this.handleWorkspaceTransportConnectionChanged(generation, connected)
     );
     const rail = activity.rail;
     const services = new ServiceCollection();
@@ -194,6 +237,7 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
       activity,
       container,
       drafts,
+      generation,
       navigation,
       rail,
       workspace
@@ -214,30 +258,22 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
         return false;
       }
       this.workspaceCandidate = null;
+      const previousScope = this.workspaceScope;
       this.workspaceScope = candidate;
-      this.publish({
-        device: authenticated.device,
-        session: authenticated.session,
-        status: "authenticated",
-        workspace
-      });
+      previousScope?.container.dispose();
+      const connection: MobileConnectionSnapshot =
+        candidate.activity.isTransportConnected()
+          ? { phase: "connected" }
+          : { phase: "synchronizing", trigger };
+      this.publishAuthenticated(authenticated, connection, workspace);
+      if (connection.phase === "synchronizing") {
+        this.scheduleConnectionReadyDeadline(candidate, trigger);
+      }
       return true;
     } catch {
       if (this.workspaceCandidate === candidate) {
         this.workspaceCandidate = null;
         candidate.container.dispose();
-      }
-      if (
-        generation === this.workspaceGeneration &&
-        this.authenticatedScope === authenticated &&
-        authenticated.device
-      ) {
-        this.publish({
-          device: authenticated.device,
-          session: authenticated.session,
-          status: "authenticated",
-          workspace: null
-        });
       }
       return false;
     }
@@ -246,8 +282,7 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
-    this.backgroundTask?.cancel();
-    this.backgroundTask = null;
+    this.cancelConnectionRecovery();
     this.lifecycleDispose?.();
     this.lifecycleDispose = null;
     this.disposeWorkspaceScope();
@@ -310,6 +345,7 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
       workspaceCatalog
     };
     this.publish({
+      connection: { phase: "idle" },
       device: null,
       session,
       status: "authenticated",
@@ -321,15 +357,29 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
   private async onDeviceConnected(device: ConnectedDevice): Promise<void> {
     const scope = this.authenticatedScope;
     if (!scope) return;
+    const current =
+      this.snapshot.status === "authenticated" ? this.snapshot : null;
+    const preservingWorkspace = Boolean(
+      current?.device &&
+      current.workspace &&
+      current.device.pairingId === device.pairingId
+    );
+    const trigger: MobileConnectionRecoveryTrigger =
+      current?.connection.phase === "reconnecting" ||
+      current?.connection.phase === "synchronizing" ||
+      current?.connection.phase === "failed"
+        ? current.connection.trigger
+        : "initial_connect";
     scope.device = device;
     void scope.directory.load();
     void scope.quickPrompts.refresh();
-    this.publish({
-      device,
-      session: scope.session,
-      status: "authenticated",
-      workspace: null
-    });
+    if (!preservingWorkspace) {
+      this.publishAuthenticated(
+        scope,
+        { phase: "synchronizing", trigger },
+        null
+      );
+    }
     await scope.workspaceCatalog.start();
     if (this.authenticatedScope !== scope || scope.device !== device) return;
     const catalog = scope.workspaceCatalog.getSnapshot();
@@ -338,12 +388,12 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
       catalog.errorCode ||
       catalog.workspaces.length !== 1
     ) {
-      this.clearConnectedDevice(scope);
+      if (!preservingWorkspace) this.clearConnectedDevice(scope);
       await this.closeDeviceLink();
       throw new DeviceConnectionSetupError("workspace_unavailable");
     }
-    if (!(await this.selectWorkspace(catalog.workspaces[0]!))) {
-      this.clearConnectedDevice(scope);
+    if (!(await this.selectWorkspace(catalog.workspaces[0]!, trigger))) {
+      if (!preservingWorkspace) this.clearConnectedDevice(scope);
       await this.closeDeviceLink();
       throw new DeviceConnectionSetupError("workspace_unavailable");
     }
@@ -357,30 +407,200 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
       state
     });
     if (foreground) {
-      const hadPendingGrace = this.backgroundTask !== null;
-      this.backgroundTask?.cancel();
-      this.backgroundTask = null;
-      if (hadPendingGrace) {
-        this.workspaceScope?.activity.resume();
-        this.workspaceCandidate?.activity.resume();
-      }
+      const backgroundStartedAtUnixMs = this.backgroundStartedAtUnixMs;
+      this.backgroundStartedAtUnixMs = null;
+      const backgroundElapsedMs =
+        backgroundStartedAtUnixMs === null
+          ? 0
+          : Math.max(0, this.ports.clock.now() - backgroundStartedAtUnixMs);
+      const authenticated = this.authenticatedScope;
+      authenticated?.deviceService.resumeRemoteOperations();
       if (
         this.snapshot.status === "authenticated" &&
-        this.snapshot.device === null &&
-        this.deviceDisconnectTask === null
+        this.snapshot.device &&
+        this.snapshot.workspace
       ) {
-        this.authenticatedScope?.deviceService.resumeRemoteOperations();
+        if (
+          backgroundElapsedMs >= BACKGROUND_GRACE_MS ||
+          this.snapshot.connection.phase === "reconnecting" ||
+          this.snapshot.connection.phase === "failed"
+        ) {
+          void this.recoverDeviceConnection("background_expired");
+        } else {
+          this.resumeWorkspaceConnection("foreground_resume");
+        }
       }
       return;
     }
-    if (this.backgroundTask) return;
+    if (this.backgroundStartedAtUnixMs !== null) return;
+    this.backgroundStartedAtUnixMs = this.ports.clock.now();
+    this.cancelConnectionRecovery();
     this.workspaceScope?.activity.pause();
     this.workspaceCandidate?.activity.pause();
     this.authenticatedScope?.deviceService.suspendRemoteOperations();
-    this.backgroundTask = this.ports.clock.schedule(BACKGROUND_GRACE_MS, () => {
-      this.backgroundTask = null;
-      void this.disconnectDevice();
+  }
+
+  private resumeWorkspaceConnection(
+    trigger: MobileConnectionRecoveryTrigger
+  ): void {
+    const authenticated = this.authenticatedScope;
+    const workspace = this.workspaceScope;
+    if (!authenticated?.device || !workspace) return;
+    this.cancelConnectionTimers();
+    this.publishAuthenticated(authenticated, {
+      phase: "synchronizing",
+      trigger
     });
+    workspace.activity.resume();
+    if (workspace.activity.isTransportConnected()) {
+      this.publishAuthenticated(authenticated, { phase: "connected" });
+      return;
+    }
+    this.scheduleConnectionReadyDeadline(workspace, trigger);
+  }
+
+  private recoverDeviceConnection(
+    trigger: MobileConnectionRecoveryTrigger
+  ): Promise<void> {
+    if (this.deviceReconnectTask) return this.deviceReconnectTask;
+    const authenticated = this.authenticatedScope;
+    const current =
+      this.snapshot.status === "authenticated" ? this.snapshot : null;
+    const device = current?.device ?? null;
+    const workspace = current?.workspace ?? null;
+    if (!authenticated || !device || !workspace || !this.appForeground) {
+      return Promise.resolve();
+    }
+    const recoveryGeneration = ++this.connectionRecoveryGeneration;
+    this.cancelConnectionTimers();
+    this.publishAuthenticated(
+      authenticated,
+      { phase: "reconnecting", trigger },
+      workspace
+    );
+    this.workspaceScope?.activity.pause();
+    authenticated.deviceService.resumeRemoteOperations();
+    const task = this.closeDeviceLink()
+      .then(async () => {
+        if (!this.isConnectionRecoveryCurrent(recoveryGeneration, device)) {
+          return;
+        }
+        const connected = await authenticated.deviceService.reconnect(device);
+        if (
+          !connected &&
+          this.isConnectionRecoveryCurrent(recoveryGeneration, device)
+        ) {
+          this.markConnectionFailed(trigger);
+        }
+      })
+      .finally(() => {
+        if (this.deviceReconnectTask === task) {
+          this.deviceReconnectTask = null;
+        }
+      });
+    this.deviceReconnectTask = task;
+    return task;
+  }
+
+  private handleWorkspaceTransportConnectionChanged(
+    generation: number,
+    connected: boolean
+  ): void {
+    if (
+      this.disposed ||
+      !this.appForeground ||
+      generation !== this.workspaceGeneration
+    ) {
+      return;
+    }
+    const workspace = this.workspaceScope;
+    if (!workspace || workspace.generation !== generation) return;
+    const authenticated = this.authenticatedScope;
+    if (!authenticated?.device) return;
+    if (connected) {
+      this.cancelConnectionTimers();
+      this.publishAuthenticated(authenticated, { phase: "connected" });
+      return;
+    }
+    const current =
+      this.snapshot.status === "authenticated"
+        ? this.snapshot.connection
+        : null;
+    if (current?.phase === "reconnecting" || current?.phase === "failed") {
+      return;
+    }
+    this.cancelConnectionTimers();
+    this.publishAuthenticated(authenticated, {
+      phase: "synchronizing",
+      trigger: "transport_lost"
+    });
+    this.scheduleConnectionReadyDeadline(workspace, "transport_lost");
+    this.transportRecoveryTask = this.ports.clock.schedule(
+      TRANSPORT_RECOVERY_GRACE_MS,
+      () => {
+        this.transportRecoveryTask = null;
+        if (
+          this.appForeground &&
+          this.workspaceScope === workspace &&
+          !workspace.activity.isTransportConnected()
+        ) {
+          void this.recoverDeviceConnection("transport_lost");
+        }
+      }
+    );
+  }
+
+  private scheduleConnectionReadyDeadline(
+    workspace: WorkspaceScope,
+    trigger: MobileConnectionRecoveryTrigger
+  ): void {
+    this.connectionReadyTask?.cancel();
+    this.connectionReadyTask = this.ports.clock.schedule(
+      CONNECTION_READY_TIMEOUT_MS,
+      () => {
+        this.connectionReadyTask = null;
+        if (
+          this.appForeground &&
+          this.workspaceScope === workspace &&
+          !workspace.activity.isTransportConnected()
+        ) {
+          this.markConnectionFailed(trigger);
+        }
+      }
+    );
+  }
+
+  private markConnectionFailed(trigger: MobileConnectionRecoveryTrigger): void {
+    const authenticated = this.authenticatedScope;
+    if (!authenticated?.device || !this.appForeground) return;
+    this.cancelConnectionTimers();
+    this.workspaceScope?.activity.pause();
+    this.publishAuthenticated(authenticated, { phase: "failed", trigger });
+  }
+
+  private isConnectionRecoveryCurrent(
+    generation: number,
+    device: ConnectedDevice
+  ): boolean {
+    return (
+      !this.disposed &&
+      this.appForeground &&
+      generation === this.connectionRecoveryGeneration &&
+      this.authenticatedScope?.device?.pairingId === device.pairingId
+    );
+  }
+
+  private cancelConnectionRecovery(): void {
+    this.connectionRecoveryGeneration += 1;
+    this.deviceReconnectTask = null;
+    this.cancelConnectionTimers();
+  }
+
+  private cancelConnectionTimers(): void {
+    this.connectionReadyTask?.cancel();
+    this.connectionReadyTask = null;
+    this.transportRecoveryTask?.cancel();
+    this.transportRecoveryTask = null;
   }
 
   private disposeWorkspaceScope(): void {
@@ -397,6 +617,7 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
   }
 
   private disposeAuthenticatedScope(): void {
+    this.cancelConnectionRecovery();
     this.disposeWorkspaceScope();
     const scope = this.authenticatedScope;
     this.authenticatedScope = null;
@@ -416,17 +637,47 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
     this.emitChange();
   }
 
+  private publishAuthenticated(
+    scope: AuthenticatedScope,
+    connection: MobileConnectionSnapshot,
+    workspace: WorkspaceSummary | null = this.workspaceScope?.workspace ?? null
+  ): void {
+    if (this.authenticatedScope !== scope) return;
+    const previousConnection =
+      this.snapshot.status === "authenticated"
+        ? this.snapshot.connection
+        : null;
+    const previousTrigger =
+      previousConnection && "trigger" in previousConnection
+        ? previousConnection.trigger
+        : null;
+    const nextTrigger = "trigger" in connection ? connection.trigger : null;
+    if (
+      previousConnection?.phase !== connection.phase ||
+      previousTrigger !== nextTrigger
+    ) {
+      this.ports.diagnostics.record({
+        name: "device_connection.phase_changed",
+        phase: connection.phase,
+        ...(nextTrigger ? { trigger: nextTrigger } : {})
+      });
+    }
+    this.publish({
+      connection,
+      device: scope.device,
+      session: scope.session,
+      status: "authenticated",
+      workspace
+    });
+  }
+
   private clearConnectedDevice(scope: AuthenticatedScope): void {
     if (this.authenticatedScope !== scope) return;
+    this.cancelConnectionRecovery();
     this.disposeWorkspaceScope();
     scope.device = null;
     scope.quickPrompts.reset();
-    this.publish({
-      device: null,
-      session: scope.session,
-      status: "authenticated",
-      workspace: null
-    });
+    this.publishAuthenticated(scope, { phase: "idle" }, null);
   }
 
   private closeDeviceLink(): Promise<void> {

--- a/apps/mobile/src/services/servicePorts.ts
+++ b/apps/mobile/src/services/servicePorts.ts
@@ -139,6 +139,16 @@ export type MobileDiagnosticEvent =
       state: AppLifecycleState;
     }
   | {
+      name: "device_connection.phase_changed";
+      phase: "connected" | "failed" | "idle" | "reconnecting" | "synchronizing";
+      trigger?:
+        | "background_expired"
+        | "foreground_resume"
+        | "initial_connect"
+        | "manual_retry"
+        | "transport_lost";
+    }
+  | {
       name: "device_pairing.phase_changed";
       phase: DevicePairingPhase;
       source?: "manual" | "scanner";

--- a/apps/mobile/src/services/workspaceActivityService.test.ts
+++ b/apps/mobile/src/services/workspaceActivityService.test.ts
@@ -1438,6 +1438,7 @@ describe("WorkspaceActivityService", () => {
 
     await service.start();
     await flushAsyncWork();
+    liveListener!({ kind: "connection", status: "connected" });
     liveListener!({
       kind: "discontinuity",
       reason: "canonical_update",
@@ -1487,6 +1488,11 @@ describe("WorkspaceActivityService", () => {
         ?.runtimeAvailable
     ).toBe(false);
     service.resume();
+    expect(
+      service.getSnapshot().interactionStates[childInteractionKey]
+        ?.runtimeAvailable
+    ).toBe(false);
+    liveListener!({ kind: "connection", status: "connected" });
     expect(
       service.getSnapshot().interactionStates[childInteractionKey]
         ?.runtimeAvailable

--- a/apps/mobile/src/services/workspaceActivityService.ts
+++ b/apps/mobile/src/services/workspaceActivityService.ts
@@ -69,6 +69,8 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
   private errorCode: "request_failed" | null = null;
   private loading = true;
   private observedSelectedSessionId: string | null = null;
+  private readonly requiresLiveTransport: boolean;
+  private transportConnected: boolean;
   private previousConversation: WorkspaceActivitySnapshot["conversation"] =
     null;
   private snapshotCache: WorkspaceActivitySnapshot | null = null;
@@ -87,9 +89,12 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
     private readonly drafts: ComposerDraftService,
     private readonly clock: ClockPort,
     currentUserId: string,
-    deviceLink?: DeviceLinkPort
+    deviceLink?: DeviceLinkPort,
+    private readonly onTransportConnectionChanged?: (connected: boolean) => void
   ) {
     super();
+    this.requiresLiveTransport = deviceLink !== undefined;
+    this.transportConnected = !this.requiresLiveTransport;
     this.media = new WorkspaceMediaService(workspace.id, client);
     this.mapping = createMobileAgentActivityMapping({
       currentUserId,
@@ -142,12 +147,14 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
       navigation: this.navigation,
       onActivityChanged: () => this.onDependencyChanged(),
       onConnectionChanged: (connected) => {
+        this.setTransportConnected(connected);
         if (connected) {
           this.messagePollTask?.cancel();
           this.messagePollTask = null;
         } else {
           this.scheduleMessagesPoll();
         }
+        this.onTransportConnectionChanged?.(connected);
       },
       rail: this.rail,
       readCanonicalActivity: () =>
@@ -277,18 +284,7 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
   start(): Promise<void> {
     if (this.initializePromise) return this.initializePromise;
     if (this.disposed) return Promise.resolve();
-    this.engine.dispatch({
-      status: "connected",
-      type: "engine/connectionChanged",
-      workspaceId: this.workspace.id
-    });
-    for (const session of this.getSnapshot().activity.sessions) {
-      this.engine.dispatch({
-        agentSessionId: session.agentSessionId,
-        availability: { state: "available" },
-        type: "session/runtimeAvailabilityChanged"
-      });
-    }
+    this.setTransportConnected(this.transportConnected, true);
     this.initializePromise = Promise.all([
       this.directory.load(),
       this.rail.start()
@@ -302,6 +298,10 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
         this.onDependencyChanged();
       });
     return this.initializePromise;
+  }
+
+  isTransportConnected(): boolean {
+    return this.transportConnected;
   }
 
   setDraft(value: string): void {
@@ -528,21 +528,7 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
     this.liveLane.stop();
     this.cancelPolls();
     this.rail.pause();
-    this.engine.dispatch({
-      status: "disconnected",
-      type: "engine/connectionChanged",
-      workspaceId: this.workspace.id
-    });
-    for (const session of this.getSnapshot().activity.sessions) {
-      this.engine.dispatch({
-        agentSessionId: session.agentSessionId,
-        availability: {
-          reason: "transport_unavailable",
-          state: "blocked"
-        },
-        type: "session/runtimeAvailabilityChanged"
-      });
-    }
+    this.setTransportConnected(false, true);
   }
 
   resume(): void {
@@ -550,19 +536,7 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
     this.paused = false;
     this.rail.resume();
     this.liveLane.start();
-    this.engine.dispatch({
-      status: "connected",
-      type: "engine/connectionChanged",
-      workspaceId: this.workspace.id
-    });
-    for (const session of this.projectActivity(this.engine.getSnapshot())
-      .sessions) {
-      this.engine.dispatch({
-        agentSessionId: session.agentSessionId,
-        availability: { state: "available" },
-        type: "session/runtimeAvailabilityChanged"
-      });
-    }
+    this.setTransportConnected(!this.requiresLiveTransport, true);
     this.engine.dispatch({
       retry: true,
       type: "workspace/reconcileRequested",
@@ -697,21 +671,51 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
 
   private markRailSessionsAvailable(agentSessionIds: readonly string[]): void {
     const state = this.engine.getSnapshot();
+    const availability = this.transportConnected
+      ? ({ state: "available" } as const)
+      : ({
+          reason: "transport_unavailable",
+          state: "blocked"
+        } as const);
     for (const agentSessionId of agentSessionIds) {
       if (
         selectEngineSessionRuntimeAvailability(state, agentSessionId)?.state ===
-        "available"
+        availability.state
       ) {
         continue;
       }
       this.engine.dispatch(
         {
           agentSessionId,
-          availability: { state: "available" },
+          availability,
           type: "session/runtimeAvailabilityChanged"
         },
         { batch: true }
       );
+    }
+  }
+
+  private setTransportConnected(connected: boolean, force = false): void {
+    if (!force && this.transportConnected === connected) return;
+    this.transportConnected = connected;
+    this.engine.dispatch({
+      status: connected ? "connected" : "disconnected",
+      type: "engine/connectionChanged",
+      workspaceId: this.workspace.id
+    });
+    const availability = connected
+      ? ({ state: "available" } as const)
+      : ({
+          reason: "transport_unavailable",
+          state: "blocked"
+        } as const);
+    for (const session of this.projectActivity(this.engine.getSnapshot())
+      .sessions) {
+      this.engine.dispatch({
+        agentSessionId: session.agentSessionId,
+        availability,
+        type: "session/runtimeAvailabilityChanged"
+      });
     }
   }
 

--- a/apps/mobile/src/services/workspaceAgentLiveLane.ts
+++ b/apps/mobile/src/services/workspaceAgentLiveLane.ts
@@ -138,7 +138,7 @@ export class WorkspaceAgentLiveLane {
       this.coordinator.eventStreamConnectionChanged({
         status: "disconnected"
       });
-      this.setConnected(false);
+      this.setConnected(false, true);
       this.scheduleRetry();
       return;
     }
@@ -208,7 +208,7 @@ export class WorkspaceAgentLiveLane {
     this.coordinator.eventStreamConnectionChanged({
       status: "disconnected"
     });
-    this.setConnected(false);
+    this.setConnected(false, true);
     this.reconcileDiscontinuity({
       kind: "discontinuity",
       reason,
@@ -262,11 +262,16 @@ export class WorkspaceAgentLiveLane {
     );
   }
 
-  private setConnected(connected: boolean): void {
-    if (this.connected === connected) return;
-    this.connected = connected;
-    this.options.rail.setLiveConnected(connected);
-    this.options.onConnectionChanged(connected);
+  private setConnected(connected: boolean, observedFailure = false): void {
+    if (this.connected !== connected) {
+      this.connected = connected;
+      this.options.rail.setLiveConnected(connected);
+      this.options.onConnectionChanged(connected);
+      return;
+    }
+    if (observedFailure) {
+      this.options.onConnectionChanged(false);
+    }
   }
 }
 

--- a/apps/mobile/src/services/workspaceNavigationService.ts
+++ b/apps/mobile/src/services/workspaceNavigationService.ts
@@ -8,12 +8,20 @@ export interface WorkspaceNavigationSnapshot {
 
 export class WorkspaceNavigationService extends ObservableService<WorkspaceNavigationSnapshot> {
   readonly _serviceBrand: undefined;
-  private sessionSelectionExplicit = false;
-  private snapshot: WorkspaceNavigationSnapshot = {
-    creating: false,
-    selectedAgentSessionId: null,
-    selectedAgentTargetId: null
-  };
+  private sessionSelectionExplicit: boolean;
+  private snapshot: WorkspaceNavigationSnapshot;
+
+  constructor(previous?: WorkspaceNavigationSnapshot) {
+    super();
+    this.sessionSelectionExplicit = previous !== undefined;
+    this.snapshot = previous
+      ? { ...previous }
+      : {
+          creating: false,
+          selectedAgentSessionId: null,
+          selectedAgentTargetId: null
+        };
+  }
 
   getSnapshot = (): WorkspaceNavigationSnapshot => this.snapshot;
 

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -925,6 +925,24 @@ foreground/background pause-resume around the shared controller. Native hosts
 also own their renderer, localized status projection, and interaction layout;
 those host concerns must not leak back into the shared query controller.
 
+Mobile DeviceLink recovery is application-scoped rather than screen-scoped.
+`MobileApplicationService` is the single owner of the paired-device connection
+phase (`idle`, `reconnecting`, `synchronizing`, `connected`, or `failed`).
+Native owns the actual background-grace link close; JavaScript records the
+background entry time and uses elapsed time on foreground instead of relying on
+a timer that the runtime may suspend. An unexpected live-lane disconnect first
+allows one bounded stream retry, then rebuilds DeviceLink if the stream remains
+offline. Runtime commands stay blocked until the replacement live lane reports
+ready.
+
+Recovery retains the current device, workspace, navigation, and drafts behind a
+global blocking presentation. A replacement workspace scope is started and
+authoritatively hydrated before it atomically replaces the paused scope; a
+failed candidate cannot clear the visible conversation. The App-root overlay
+only projects the service phase and exposes retry or explicit return-to-device
+commands. It does not own timers, transport checks, retry policy, or copied
+connection state.
+
 Cross-platform hosts may reuse the DOM-free canonical Rail summary projection
 from `@tutti-os/agent-gui/conversation-rail-projection`. They must still obtain
 ordered membership, project labels, totals, and cursors from the authoritative

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -154,6 +154,7 @@ Android app login, native bridge, secure identity, and mobile transport diagnost
 - [Mobile composer option chips do not open](./mobile.md#mobile-composer-option-chips-do-not-open)
 - [Browser login returns to the App but remains signed out](./mobile.md#browser-login-returns-to-the-app-but-remains-signed-out)
 - [Android DeviceLink opens a session and then repeatedly restarts](./mobile.md#android-devicelink-opens-a-session-and-then-repeatedly-restarts)
+- [Mobile stays connected after a long lock-screen interval but sends fail](./mobile.md#mobile-stays-connected-after-a-long-lock-screen-interval-but-sends-fail)
 - [iOS pod install intermittently reports pathname contains null byte](./mobile.md#ios-pod-install-intermittently-reports-pathname-contains-null-byte)
 - [Mobile Jest discovers tests inside iOS Pods](./mobile.md#mobile-jest-discovers-tests-inside-ios-pods)
 - [React Native Pressable rows stack their children vertically](./mobile.md#react-native-pressable-rows-stack-their-children-vertically)

--- a/docs/conventions/troubleshooting/mobile.md
+++ b/docs/conventions/troubleshooting/mobile.md
@@ -220,6 +220,36 @@ dev.tutti.mobile` and inspect a narrow logcat window for the Go fatal message.
 - **References:** `packages/device-link/mobile/link.go`,
   `apps/mobile/android/app/src/main/java/dev/tutti/mobile/DeviceLinkModule.kt`
 
+## Mobile stays connected after a long lock-screen interval but sends fail
+
+- **Symptom:** After Mobile remains locked or backgrounded for at least the
+  DeviceLink grace interval, the previous conversation is still visible but the
+  next command fails. Returning to the computer list and connecting again
+  restores service.
+- **Quick checks:** Compare `application.lifecycle_changed` and
+  `device_connection.phase_changed` diagnostics with Native `TuttiDeviceLink`
+  logs. If Native closed the link after its grace deadline while JavaScript
+  never published its own delayed disconnect, verify whether the foreground
+  transition used elapsed background time. Confirm the workspace runtime is
+  blocked until a replacement live lane reports ready.
+- **Root cause:** Native lifecycle handlers continue running while React Native
+  timers may be suspended. When both layers independently scheduled the same
+  background deadline, Native closed the real link but JavaScript canceled its
+  still pending timer on foreground and resumed a stale connected workspace.
+- **Fix:** Keep the close deadline Native-owned. Record background entry time in
+  the application service and decide short resume versus full reconnect from
+  elapsed time on foreground. Project one application-scoped connection phase,
+  retain the paused workspace until a hydrated replacement is ready, and let a
+  root overlay render that phase without owning recovery logic.
+- **Validation:** Cover foreground before and after the grace boundary, an
+  active live-stream loss, failed reconnect plus explicit retry, and generation
+  fencing when the app backgrounds during recovery. On a physical device, lock
+  beyond the deadline, unlock, observe reconnect/synchronize presentation, and
+  send from the original conversation without revisiting the computer list.
+- **References:**
+  `apps/mobile/src/services/mobileApplicationService.ts`,
+  `apps/mobile/android/app/src/main/java/dev/tutti/mobile/DeviceLinkModule.kt`
+
 ## iOS pod install intermittently reports pathname contains null byte
 
 - **Symptom:** `pnpm --filter @tutti-os/mobile ios:pods` downloads and installs


### PR DESCRIPTION
## Summary

- add an application-scoped Mobile connection recovery state machine for initial connection, foreground resume, long-background reconnect, transport loss, and manual retry
- keep Agent runtime commands blocked until the replacement live stream is actually ready
- preserve the selected conversation, creation state, composer drafts, and settings while the transport/runtime scope is replaced
- render recovery as an App-root overlay with retry and return-to-devices actions; the UI only projects service state
- document the Mobile connection ownership, recovery flow, and recurring lock-screen failure mode

## Root cause

Android Native lifecycle handling continues to run while React Native timers may be suspended. Native correctly closed DeviceLink after the background grace deadline, but JavaScript could cancel its still-pending timer on foreground and resume a stale workspace that still looked connected. The next send then failed until the user returned to the device page and connected again.

The previous workspace runtime also owned navigation and draft services, so replacing the runtime could discard current UI working state. This change keeps those responsibilities in their state services and carries their snapshots into the replacement scope.

## Behavior

- short background intervals restart the live lane and synchronize in place
- intervals beyond the 15-second Native deadline rebuild DeviceLink automatically
- live-stream loss gets one bounded retry window before the full link is rebuilt
- the previous workspace remains visible while reconnecting, but writes remain unavailable
- failed recovery offers explicit retry or a return to the computer list

## Validation

- `pnpm --filter @tutti-os/mobile typecheck`
- `pnpm --filter @tutti-os/mobile test` — 21 suites, 130 tests
- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready` — 7 lanes
- `pnpm --filter @tutti-os/mobile build:android`
- physical Android device: initial DeviceLink connection, existing conversation load, short-background live resynchronization, long-background reconnect phase, and global recovery overlay observed

The final post-follow-up single-host send was not rerun because a concurrently started `tsh-desktopd` made the paired Personal target return a non-single workspace catalog. The state-preservation follow-up is covered by the focused application-service recovery test.