### PR TITLE
Fix/agent gui 0731

### DIFF
--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -410,7 +410,7 @@ provider-status-focus-refresh --all-process-time-profile` on macOS when a
   but unable to start. A registry can also be reachable but too slow for the
   platform tarball, so retrying the same source burns the install timeout before
   mirrors are tried. The launcher itself uses `#!/usr/bin/env node`, so
-  daemon-run Codex commands (`--version`, `login status`, and `app-server`) need
+  daemon-run Codex commands (`--version`, login, and `app-server`) need
   a usable Node on `PATH`. Tutti should prefer the user's Node environment, but
   fall back to the managed Node runtime when the visible `codex` shim exists and
   no user Node is resolvable.
@@ -713,6 +713,30 @@ file or directory`. A failed `codex app-server` probe is diagnostic evidence,
   [providers.go](../../../packages/agent/daemon/providerregistry/providers.go)
   [acp_provider_cursor.go](../../../packages/agent/daemon/runtime/acp_provider_cursor.go)
   [standard_acp_adapter_test.go](../../../packages/agent/daemon/runtime/standard_acp_adapter_test.go)
+
+### Codex provider appears logged in with an empty auth.json
+
+- Symptom:
+  Provider management reports Codex as logged in when `~/.codex/auth.json` is
+  `{}`, but starting Codex fails during TUI bootstrap with
+  `account/read failed: plan type is required for chatgpt authentication`.
+- Quick checks:
+  Compare `codex login status` with a direct app-server `account/read`. The
+  former may print `Logged in using ChatGPT` and exit successfully solely
+  because `auth.json` exists, while the latter rejects the incomplete account.
+- Root cause:
+  Codex provider status used the generic text-command runner and accepted
+  `codex login status` as authoritative. That command's file-level check is
+  weaker than the account validation performed by the TUI and app-server.
+- Fix:
+  Use the descriptor-owned `codex_app_server_account` auth runner. It performs
+  the formal app-server initialize handshake and calls `account/read`; only a
+  structurally valid returned account is authenticated. A failed or malformed
+  response remains unknown and never falls back to auth-file existence.
+- Validation:
+  Cover authenticated, login-required, and account/read-error responses in the
+  shared app-server probe, then verify tuttID does not authenticate from a
+  present marker when account/read is unknown.
 
 ### Codex provider shows login required when global service tier is legacy
 

--- a/docs/conventions/troubleshooting/desktop-release.md
+++ b/docs/conventions/troubleshooting/desktop-release.md
@@ -268,7 +268,7 @@
   `CSSMERR_TP_CERT_REVOKED`, remove or reinstall that specific Codex package.
 - Root cause:
   Provider status and composer capability discovery intentionally start Codex
-  commands such as `codex login status` and `codex app-server`. If the daemon
+  commands such as `codex app-server`. If the daemon
   resolves an older nvm global Codex package whose Developer ID certificate has
   been revoked, each otherwise harmless background probe can become a
   Gatekeeper dialog. This can happen even when `which codex` in the user's shell

--- a/packages/agent/claude-sdk-sidecar/README.md
+++ b/packages/agent/claude-sdk-sidecar/README.md
@@ -83,6 +83,11 @@ promise twice, while a changed replay reports `conflict`.
 applied but its acknowledgment was lost; transport ambiguity therefore remains
 non-terminal until the sidecar reports an authoritative disposition.
 
+Claude plan files keep the SDK default directory unless the host opts in to a
+different location. A host can set `TUTTI_CLAUDE_PLANS_DIRECTORY` in the
+session environment; the sidecar forwards its non-empty value through the
+SDK-native `plansDirectory` setting.
+
 ## Module layout
 
 `src/main.ts` only owns the stdio server and request routing. Session lifecycle,

--- a/packages/agent/claude-sdk-sidecar/src/sessionSettings.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionSettings.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  querySettingsFromSessionSettings,
+  sidecarSessionSettings
+} from "./sessionSettings.ts";
+
+test("plansDirectory can be configured by the host environment", () => {
+  const settings = sidecarSessionSettings({
+    env: {
+      TUTTI_CLAUDE_PLANS_DIRECTORY: "."
+    },
+    settings: {}
+  });
+
+  assert.equal(settings.plansDirectory, ".");
+  assert.deepEqual(querySettingsFromSessionSettings(settings), {
+    plansDirectory: "."
+  });
+});
+
+test("blank host plansDirectory keeps the Claude SDK default", () => {
+  const settings = sidecarSessionSettings({
+    env: {
+      TUTTI_CLAUDE_PLANS_DIRECTORY: "   "
+    }
+  });
+
+  assert.equal(settings.plansDirectory, "");
+  assert.deepEqual(querySettingsFromSessionSettings(settings), {});
+});

--- a/packages/agent/claude-sdk-sidecar/src/sessionSettings.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionSettings.ts
@@ -2,6 +2,8 @@ import type { PermissionMode, Settings } from "@anthropic-ai/claude-agent-sdk";
 import { recordValue } from "./normalizer.ts";
 import { booleanValue, stringValue } from "./runtimeValues.ts";
 
+const claudePlansDirectoryEnv = "TUTTI_CLAUDE_PLANS_DIRECTORY";
+
 export type PendingFlagSettings = {
   [K in keyof Settings]?: Settings[K] | null;
 };
@@ -10,6 +12,7 @@ export type SidecarSessionSettings = {
   model: string;
   permissionModeId: string;
   planMode: boolean;
+  plansDirectory?: string;
   effort: string;
   speed: string;
 };
@@ -37,6 +40,7 @@ export function sidecarSessionSettings(
   payload: Record<string, unknown>
 ): SidecarSessionSettings {
   const settings = recordValue(payload.settings) ?? {};
+  const env = recordValue(payload.env) ?? {};
   return {
     model: stringValue(settings.model),
     permissionModeId:
@@ -44,6 +48,7 @@ export function sidecarSessionSettings(
       stringValue(settings.permissionModeId) ||
       "default",
     planMode: booleanValue(settings.planMode),
+    plansDirectory: stringValue(env[claudePlansDirectoryEnv]),
     effort:
       stringValue(payload.effort) ||
       stringValue(settings.effort) ||
@@ -162,6 +167,9 @@ export function querySettingsFromSessionSettings(
   settings: SidecarSessionSettings
 ): Partial<Settings> {
   const result: Partial<Settings> = {};
+  if (settings.plansDirectory) {
+    result.plansDirectory = settings.plansDirectory;
+  }
   if (settings.speed === "fast") {
     result.fastMode = true;
   } else if (settings.speed === "standard") {

--- a/packages/agent/daemon/README.md
+++ b/packages/agent/daemon/README.md
@@ -118,9 +118,12 @@ The host daemon owns:
 
 ## Provider Authentication Status
 
-`providerregistry` owns each provider's auth status command and parser kind.
-Hosts execute that descriptor-owned command in their provider runtime, then use
-`providerstatus.ParseAuthStatusOutput` to interpret the output consistently.
+`providerregistry` owns each provider's auth status command, runner kind, and
+parser kind. Hosts execute the descriptor-owned runner in their provider
+runtime, then use `providerstatus.ParseAuthStatusOutput` for text-command
+results. Codex uses the dedicated `codex_app_server_account` runner: it
+initializes `codex app-server` and calls `account/read`, matching session
+startup instead of trusting the shallower `codex login status` output.
 The same package exposes narrow helpers for explicit Codex and Claude API
 billing configuration. Credential-file or token presence must not be used as
 proof that an OAuth session is still authenticated.

--- a/packages/agent/daemon/providerregistry/codex.go
+++ b/packages/agent/daemon/providerregistry/codex.go
@@ -34,11 +34,11 @@ func codexDescriptor() ProviderDescriptor {
 			Kind:                   StatusKindCodexCLI,
 			AuthOutputParserKind:   AuthOutputParserKindCodex,
 			AuthMarkerParserKind:   AuthMarkerParserKindFileExists,
-			AuthCommandRunnerKind:  AuthCommandRunnerKindGeneric,
+			AuthCommandRunnerKind:  AuthCommandRunnerKindCodexAppServerAccount,
 			StaticSpecResolverKind: StaticSpecResolverKindManagedNode,
 			MinVersion:             CodexMinVersion,
 			BinaryNames:            []string{"codex"},
-			AuthStatusCommand:      []string{"login", "-c", `service_tier="fast"`, "status"},
+			AuthStatusCommand:      []string{"-c", `service_tier="fast"`, "app-server"},
 			AuthMarkerPaths:        []string{"~/.codex/auth.json"},
 			APIEndpoints: []string{
 				"https://chatgpt.com/backend-api/codex",

--- a/packages/agent/daemon/providerregistry/registry.go
+++ b/packages/agent/daemon/providerregistry/registry.go
@@ -256,7 +256,7 @@ func Validate(descriptor ProviderDescriptor) error {
 		return fmt.Errorf("provider %q auth marker parser kind %q is unsupported", providerID, descriptor.Status.AuthMarkerParserKind)
 	}
 	switch descriptor.Status.AuthCommandRunnerKind {
-	case AuthCommandRunnerKindGeneric, AuthCommandRunnerKindClaudeGate, AuthCommandRunnerKindCursor:
+	case AuthCommandRunnerKindGeneric, AuthCommandRunnerKindClaudeGate, AuthCommandRunnerKindCodexAppServerAccount, AuthCommandRunnerKindCursor:
 	default:
 		return fmt.Errorf("provider %q auth command runner kind %q is unsupported", providerID, descriptor.Status.AuthCommandRunnerKind)
 	}

--- a/packages/agent/daemon/providerregistry/registry_test.go
+++ b/packages/agent/daemon/providerregistry/registry_test.go
@@ -182,6 +182,10 @@ func TestMigratedCodexDescriptorIsComplete(t *testing.T) {
 	if descriptor.Status.MinVersion != CodexMinVersion {
 		t.Fatalf("Status.MinVersion = %q", descriptor.Status.MinVersion)
 	}
+	if descriptor.Status.AuthCommandRunnerKind != AuthCommandRunnerKindCodexAppServerAccount ||
+		!slices.Equal(descriptor.Status.AuthStatusCommand, []string{"-c", `service_tier="fast"`, "app-server"}) {
+		t.Fatalf("Status auth probe = %q / %#v", descriptor.Status.AuthCommandRunnerKind, descriptor.Status.AuthStatusCommand)
+	}
 	if descriptor.Status.Install.PackageName != "@openai/codex" ||
 		descriptor.Status.Install.BinaryName != "codex" ||
 		!descriptor.Status.Install.IncludeOptional {

--- a/packages/agent/daemon/providerregistry/types.go
+++ b/packages/agent/daemon/providerregistry/types.go
@@ -129,9 +129,10 @@ const (
 type AuthCommandRunnerKind string
 
 const (
-	AuthCommandRunnerKindGeneric    AuthCommandRunnerKind = "generic"
-	AuthCommandRunnerKindClaudeGate AuthCommandRunnerKind = "claude_gate"
-	AuthCommandRunnerKindCursor     AuthCommandRunnerKind = "cursor"
+	AuthCommandRunnerKindGeneric               AuthCommandRunnerKind = "generic"
+	AuthCommandRunnerKindClaudeGate            AuthCommandRunnerKind = "claude_gate"
+	AuthCommandRunnerKindCodexAppServerAccount AuthCommandRunnerKind = "codex_app_server_account"
+	AuthCommandRunnerKindCursor                AuthCommandRunnerKind = "cursor"
 )
 
 type StaticSpecResolverKind string

--- a/packages/agent/daemon/runtime/claude_sdk_session_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_session_test.go
@@ -341,6 +341,10 @@ func TestClaudeCodeSDKAdapterStartPassesPreparedClaudeMetaPathsToSidecar(t *test
 	if got, _ := payload["planModeInstructions"].(string); !strings.Contains(got, "do not edit files") || !strings.Contains(got, "implementation plan") {
 		t.Fatalf("planModeInstructions = %#v, want Tutti plan workflow instructions", payload["planModeInstructions"])
 	}
+	settings := payloadMap(payload, "settings")
+	if _, ok := settings["plansDirectory"]; ok {
+		t.Fatalf("settings.plansDirectory = %#v, want Claude SDK default", settings["plansDirectory"])
+	}
 	allowedTools, ok := payload["allowedTools"].([]any)
 	grepAllowed := false
 	globAllowed := false

--- a/packages/agent/daemon/runtime/codex_appserver_probe.go
+++ b/packages/agent/daemon/runtime/codex_appserver_probe.go
@@ -2,6 +2,7 @@ package agentruntime
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand/v2"
@@ -17,11 +18,23 @@ type CodexAppServerProbeInput struct {
 	Env              []string
 	CWD              string
 	Host             HostMetadata
+	ReadAccount      bool
 	StartupTimeout   time.Duration
 	HandshakeTimeout time.Duration
 	ShutdownTimeout  time.Duration
 	Transport        ProcessTransport
 }
+
+// CodexAppServerAccountState is the account/read authentication result. An
+// unknown state means the app-server could not return a structurally valid
+// account response and must not be treated as authenticated.
+type CodexAppServerAccountState string
+
+const (
+	CodexAppServerAccountUnknown       CodexAppServerAccountState = "unknown"
+	CodexAppServerAccountAuthenticated CodexAppServerAccountState = "authenticated"
+	CodexAppServerAccountRequired      CodexAppServerAccountState = "required"
+)
 
 // CodexAppServerProbeResult keeps command-start and protocol-handshake facts
 // separate. Callers must use ProtocolReady, not CommandStarted, as runtime
@@ -29,8 +42,13 @@ type CodexAppServerProbeInput struct {
 type CodexAppServerProbeResult struct {
 	CommandStarted   bool
 	ProtocolReady    bool
+	AccountRead      bool
+	AccountState     CodexAppServerAccountState
+	AccountLabel     string
+	AuthMethod       string
 	CommandCategory  string
 	ProtocolCategory string
+	AccountCategory  string
 	// Category is the compatibility projection of the failing stage.
 	Category   string
 	Message    string
@@ -50,11 +68,16 @@ const (
 )
 
 // ProbeCodexAppServer reuses the production ProcessTransport, JSON-RPC client,
-// typed initialize request and initialized notification. The connection is
-// always closed before returning; no user-facing Codex state is created.
+// typed initialize request and initialized notification. When ReadAccount is
+// set, it also calls the same account/read method used during session startup.
+// The connection is always closed before returning; no user-facing Codex state
+// is created.
 func ProbeCodexAppServer(ctx context.Context, input CodexAppServerProbeInput) (result CodexAppServerProbeResult) {
 	startedAt := time.Now()
-	result = CodexAppServerProbeResult{Category: CodexProbeUnknownRuntimeFail}
+	result = CodexAppServerProbeResult{
+		AccountState: CodexAppServerAccountUnknown,
+		Category:     CodexProbeUnknownRuntimeFail,
+	}
 	defer func() { result.Duration = time.Since(startedAt) }()
 	if ctx == nil {
 		ctx = context.Background()
@@ -163,7 +186,66 @@ func ProbeCodexAppServer(ctx context.Context, input CodexAppServerProbeInput) (r
 	// final protocol fact.
 	result.CommandStarted = true
 	result.Category = ""
+	if !input.ReadAccount {
+		return result
+	}
+	accountRaw, err := client.AccountRead(handshakeCtx, handshakeTimeout, map[string]any{},
+		func(context.Context, acpMessage) error { return nil })
+	if err != nil {
+		result.AccountCategory = codexProbeErrorCategory(handshakeCtx, err)
+		result.Category = result.AccountCategory
+		result.Message = err.Error()
+		return result
+	}
+	account, ok := parseCodexProbeAccount(accountRaw)
+	if !ok {
+		result.AccountCategory = CodexProbeInvalidResponse
+		result.Category = result.AccountCategory
+		result.Message = "account/read returned an invalid account response"
+		return result
+	}
+	result.AccountRead = true
+	result.AccountState = account.State
+	result.AccountLabel = account.Label
+	result.AuthMethod = account.AuthMethod
 	return result
+}
+
+type codexProbeAccount struct {
+	State      CodexAppServerAccountState
+	Label      string
+	AuthMethod string
+}
+
+func parseCodexProbeAccount(raw json.RawMessage) (codexProbeAccount, bool) {
+	var payload struct {
+		Account            map[string]any `json:"account"`
+		RequiresOpenaiAuth *bool          `json:"requiresOpenaiAuth"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil || payload.RequiresOpenaiAuth == nil {
+		return codexProbeAccount{}, false
+	}
+	if payload.Account == nil {
+		if *payload.RequiresOpenaiAuth {
+			return codexProbeAccount{State: CodexAppServerAccountRequired}, true
+		}
+		return codexProbeAccount{State: CodexAppServerAccountUnknown}, true
+	}
+	authMethod := strings.TrimSpace(asString(payload.Account["type"]))
+	switch authMethod {
+	case "chatgpt":
+		if strings.TrimSpace(asString(payload.Account["planType"])) == "" {
+			return codexProbeAccount{}, false
+		}
+	case "apiKey", "amazonBedrock":
+	default:
+		return codexProbeAccount{}, false
+	}
+	return codexProbeAccount{
+		State:      CodexAppServerAccountAuthenticated,
+		Label:      strings.TrimSpace(asString(payload.Account["email"])),
+		AuthMethod: authMethod,
+	}, true
 }
 
 func closeCodexProbeConnection(conn ProcessConnection, _ time.Duration) {

--- a/packages/agent/daemon/runtime/codex_appserver_probe_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_probe_test.go
@@ -52,6 +52,75 @@ func TestProbeCodexAppServerStartsExactlyOneProcess(t *testing.T) {
 	}
 }
 
+func TestProbeCodexAppServerReadsAuthenticatedAccount(t *testing.T) {
+	t.Parallel()
+	transport := newScriptedAppServerTransport()
+	result := ProbeCodexAppServer(context.Background(), CodexAppServerProbeInput{
+		Command: []string{"codex", "app-server"}, Transport: transport,
+		HandshakeTimeout: time.Second, ReadAccount: true,
+	})
+	if !result.ProtocolReady || !result.AccountRead ||
+		result.AccountState != CodexAppServerAccountAuthenticated {
+		t.Fatalf("probe = %#v, want authenticated account/read", result)
+	}
+	if result.AuthMethod != "chatgpt" || result.AccountLabel != "dev@example.com" {
+		t.Fatalf("account identity = %q / %q, want chatgpt / dev@example.com", result.AuthMethod, result.AccountLabel)
+	}
+	if got := len(appServerRequestParamsList(t, transport.conn, appServerMethodAccountRead)); got != 1 {
+		t.Fatalf("account/read calls = %d, want 1", got)
+	}
+	assertScriptedProbeConnectionClosed(t, transport.conn)
+}
+
+func TestProbeCodexAppServerReadsRequiredAccount(t *testing.T) {
+	t.Parallel()
+	transport := newScriptedAppServerTransport()
+	transport.server.requiresAuth = true
+	result := ProbeCodexAppServer(context.Background(), CodexAppServerProbeInput{
+		Command: []string{"codex", "app-server"}, Transport: transport,
+		HandshakeTimeout: time.Second, ReadAccount: true,
+	})
+	if !result.ProtocolReady || !result.AccountRead ||
+		result.AccountState != CodexAppServerAccountRequired {
+		t.Fatalf("probe = %#v, want required account/read", result)
+	}
+	assertScriptedProbeConnectionClosed(t, transport.conn)
+}
+
+func TestProbeCodexAppServerDoesNotAuthenticateAccountReadFailure(t *testing.T) {
+	t.Parallel()
+	transport := newScriptedAppServerTransport()
+	transport.server.accountReadError = true
+	transport.server.accountReadErrorCode = -32600
+	transport.server.accountReadErrorMessage = "plan type is required for chatgpt authentication"
+	result := ProbeCodexAppServer(context.Background(), CodexAppServerProbeInput{
+		Command: []string{"codex", "app-server"}, Transport: transport,
+		HandshakeTimeout: time.Second, ReadAccount: true,
+	})
+	if !result.ProtocolReady || result.AccountRead ||
+		result.AccountState != CodexAppServerAccountUnknown {
+		t.Fatalf("probe = %#v, want unknown account after account/read failure", result)
+	}
+	if result.AccountCategory != CodexProbeProtocolFailure {
+		t.Fatalf("account category = %q, want %q", result.AccountCategory, CodexProbeProtocolFailure)
+	}
+	assertScriptedProbeConnectionClosed(t, transport.conn)
+}
+
+func TestParseCodexProbeAccountRejectsIncompleteResponses(t *testing.T) {
+	t.Parallel()
+	for _, raw := range []string{
+		`{}`,
+		`{"requiresOpenaiAuth":false,"account":{}}`,
+		`{"requiresOpenaiAuth":false,"account":{"type":"chatgpt","email":"dev@example.com"}}`,
+		`{"requiresOpenaiAuth":false,"account":{"type":"unexpected"}}`,
+	} {
+		if account, ok := parseCodexProbeAccount(json.RawMessage(raw)); ok {
+			t.Fatalf("parseCodexProbeAccount(%s) = %#v, true; want invalid", raw, account)
+		}
+	}
+}
+
 func TestProbeCodexAppServerTimesOutDuringStart(t *testing.T) {
 	t.Parallel()
 	transport := &blockingStartProbeTransport{entered: make(chan struct{})}

--- a/packages/agent/daemon/runtime/codex_appserver_scripted_session_rpc_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_scripted_session_rpc_test.go
@@ -16,6 +16,8 @@ type scriptedSessionState struct {
 	requiresAuth                 bool
 	collaborationModeUnsupported bool
 	accountReadError             bool
+	accountReadErrorCode         int
+	accountReadErrorMessage      string
 	childNicknames               map[string]string
 	historyTurns                 []any
 	rollbackHistoryTurns         []any
@@ -41,9 +43,17 @@ func (s *fakeCodexAppServer) handleSessionRPC(message scriptedAppServerMessage) 
 		// notification, no response
 	case appServerMethodAccountRead:
 		if s.accountReadError {
+			errorMessage := s.accountReadErrorMessage
+			if errorMessage == "" {
+				errorMessage = "account backend unavailable"
+			}
+			errorCode := s.accountReadErrorCode
+			if errorCode == 0 {
+				errorCode = -32000
+			}
 			s.sendJSON(map[string]any{
 				"id":    message.ID,
-				"error": map[string]any{"code": -32000, "message": "account backend unavailable"},
+				"error": map[string]any{"code": errorCode, "message": errorMessage},
 			})
 			return true
 		}

--- a/services/tuttid/service/agentstatus/codex_auth.go
+++ b/services/tuttid/service/agentstatus/codex_auth.go
@@ -1,0 +1,56 @@
+package agentstatus
+
+import (
+	"context"
+	"time"
+
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
+)
+
+type CodexAuthProbeEvidence struct {
+	State        agentruntime.CodexAppServerAccountState
+	AccountLabel string
+	AuthMethod   string
+}
+
+func (s Service) probeCodexAuth(
+	ctx context.Context,
+	command []string,
+	env []string,
+	timeout time.Duration,
+) CodexAuthProbeEvidence {
+	if s.CodexAuthProbe != nil {
+		return s.CodexAuthProbe(ctx, append([]string(nil), command...), append([]string(nil), env...))
+	}
+	result := agentruntime.ProbeCodexAppServer(ctx, agentruntime.CodexAppServerProbeInput{
+		Command: command,
+		Env:     env,
+		Host: agentruntime.HostMetadata{ClientInfo: agentruntime.ClientInfo{
+			Name: "tutti-desktop", Title: "Tutti", Version: "0.1.0",
+		}},
+		ReadAccount:      true,
+		StartupTimeout:   timeout,
+		HandshakeTimeout: timeout,
+		ShutdownTimeout:  s.probeReadyAfter(),
+	})
+	return CodexAuthProbeEvidence{
+		State:        result.AccountState,
+		AccountLabel: result.AccountLabel,
+		AuthMethod:   result.AuthMethod,
+	}
+}
+
+func authInfoFromCodexProbe(evidence CodexAuthProbeEvidence) AuthInfo {
+	switch evidence.State {
+	case agentruntime.CodexAppServerAccountAuthenticated:
+		return AuthInfo{
+			Status:       AuthAuthenticated,
+			AccountLabel: evidence.AccountLabel,
+			AuthMethod:   evidence.AuthMethod,
+		}
+	case agentruntime.CodexAppServerAccountRequired:
+		return AuthInfo{Status: AuthRequired}
+	default:
+		return AuthInfo{Status: AuthUnknown}
+	}
+}

--- a/services/tuttid/service/agentstatus/codex_auth_test.go
+++ b/services/tuttid/service/agentstatus/codex_auth_test.go
@@ -1,0 +1,68 @@
+package agentstatus
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
+	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
+)
+
+func TestResolveCodexAuthUsesAppServerAccountRead(t *testing.T) {
+	specs, err := DefaultRegistry().Select([]string{agentprovider.Codex})
+	if err != nil {
+		t.Fatalf("Select() error = %v", err)
+	}
+	spec := specs[0]
+
+	tests := []struct {
+		name       string
+		evidence   CodexAuthProbeEvidence
+		wantStatus AuthStatus
+		wantLabel  string
+		wantMethod string
+	}{
+		{
+			name: "authenticated account",
+			evidence: CodexAuthProbeEvidence{
+				State:        agentruntime.CodexAppServerAccountAuthenticated,
+				AccountLabel: "dev@example.com",
+				AuthMethod:   "chatgpt",
+			},
+			wantStatus: AuthAuthenticated,
+			wantLabel:  "dev@example.com",
+			wantMethod: "chatgpt",
+		},
+		{
+			name:       "login required",
+			evidence:   CodexAuthProbeEvidence{State: agentruntime.CodexAppServerAccountRequired},
+			wantStatus: AuthRequired,
+		},
+		{
+			name:       "account read failure",
+			evidence:   CodexAuthProbeEvidence{State: agentruntime.CodexAppServerAccountUnknown},
+			wantStatus: AuthUnknown,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			service := Service{
+				FileExists: func(string) bool { return true },
+				CodexAuthProbe: func(_ context.Context, command, _ []string) CodexAuthProbeEvidence {
+					if !slices.Equal(command, []string{"/usr/local/bin/codex", "-c", `service_tier="fast"`, "app-server"}) {
+						t.Fatalf("command = %#v, want codex app-server with service tier override", command)
+					}
+					return test.evidence
+				},
+			}
+			auth := service.resolveAuth(context.Background(), spec, true, "/usr/local/bin/codex")
+			if auth.Status != test.wantStatus ||
+				auth.AccountLabel != test.wantLabel ||
+				auth.AuthMethod != test.wantMethod {
+				t.Fatalf("auth = %#v, want status=%q label=%q method=%q", auth, test.wantStatus, test.wantLabel, test.wantMethod)
+			}
+		})
+	}
+}

--- a/services/tuttid/service/agentstatus/provider_descriptor_test.go
+++ b/services/tuttid/service/agentstatus/provider_descriptor_test.go
@@ -22,7 +22,8 @@ func TestCodexStatusSpecComesFromProviderDescriptor(t *testing.T) {
 	if !reflect.DeepEqual(spec.AdapterCommand, []string{"codex", "app-server"}) {
 		t.Fatalf("AdapterCommand = %#v", spec.AdapterCommand)
 	}
-	if !reflect.DeepEqual(spec.AuthStatusCommand, []string{"login", "-c", `service_tier="fast"`, "status"}) {
+	if !reflect.DeepEqual(spec.AuthStatusCommand, []string{"-c", `service_tier="fast"`, "app-server"}) ||
+		spec.AuthCommandRunnerKind != providerregistry.AuthCommandRunnerKindCodexAppServerAccount {
 		t.Fatalf("AuthStatusCommand = %#v", spec.AuthStatusCommand)
 	}
 	if spec.Install.Kind != InstallerKindCodexCLILatest || spec.Install.CodexCLI == nil {

--- a/services/tuttid/service/agentstatus/service.go
+++ b/services/tuttid/service/agentstatus/service.go
@@ -292,6 +292,9 @@ type Service struct {
 	// CodexProtocolProbe is injectable for deterministic status tests. Nil uses
 	// the production app-server transport and formal initialize handshake.
 	CodexProtocolProbe func(context.Context, []string, []string) CodexProbeEvidence
+	// CodexAuthProbe is injectable for deterministic auth tests. Nil uses the
+	// production app-server transport and account/read, matching TUI startup.
+	CodexAuthProbe func(context.Context, []string, []string) CodexAuthProbeEvidence
 	// CodexRuntimeSelectionStore persists only an explicit Codex launcher
 	// choice. A missing selection permits only one uniquely ready candidate;
 	// multiple ready candidates require the user to choose one.

--- a/services/tuttid/service/agentstatus/service_helpers.go
+++ b/services/tuttid/service/agentstatus/service_helpers.go
@@ -298,13 +298,17 @@ func (s Service) resolveAuthFromCommand(ctx context.Context, spec ProviderSpec, 
 }
 
 func isCursorAuthCommandSpec(spec ProviderSpec) bool {
-	runnerKind := spec.AuthCommandRunnerKind
-	if runnerKind == "" {
-		if status, ok := migratedProviderStatus(spec.Provider); ok {
-			runnerKind = status.AuthCommandRunnerKind
-		}
+	return authCommandRunnerKind(spec) == providerregistry.AuthCommandRunnerKindCursor
+}
+
+func authCommandRunnerKind(spec ProviderSpec) providerregistry.AuthCommandRunnerKind {
+	if spec.AuthCommandRunnerKind != "" {
+		return spec.AuthCommandRunnerKind
 	}
-	return runnerKind == providerregistry.AuthCommandRunnerKindCursor
+	if status, ok := migratedProviderStatus(spec.Provider); ok {
+		return status.AuthCommandRunnerKind
+	}
+	return ""
 }
 
 func (s Service) runAuthStatusCommand(ctx context.Context, spec ProviderSpec, binaryPath string) (AuthInfo, bool) {
@@ -316,7 +320,16 @@ func (s Service) runAuthStatusCommand(ctx context.Context, spec ProviderSpec, bi
 		return AuthInfo{}, false
 	}
 	defer release()
-	return runAuthStatusCommand(ctx, spec, binaryPath, s.commandResolver().Env(spec.AdapterEnv))
+	env := s.commandResolver().Env(spec.AdapterEnv)
+	if authCommandRunnerKind(spec) == providerregistry.AuthCommandRunnerKindCodexAppServerAccount {
+		command := append([]string{binaryPath}, spec.AuthStatusCommand...)
+		evidence := s.probeCodexAuth(ctx, command, env, authStatusTimeout(spec))
+		// account/read is the canonical authentication check used by Codex
+		// startup. Even a failed probe is authoritative as "unknown": falling
+		// back to auth.json file existence would recreate the false positive.
+		return authInfoFromCodexProbe(evidence), true
+	}
+	return runAuthStatusCommand(ctx, spec, binaryPath, env)
 }
 
 // cliVersionTokenPattern matches the first semver-ish token in `--version`
@@ -411,12 +424,7 @@ func (s Service) authStatusCommandRetryDelay() time.Duration {
 }
 
 func runAuthStatusCommand(ctx context.Context, spec ProviderSpec, binaryPath string, env []string) (AuthInfo, bool) {
-	runnerKind := spec.AuthCommandRunnerKind
-	if runnerKind == "" {
-		if status, ok := migratedProviderStatus(spec.Provider); ok {
-			runnerKind = status.AuthCommandRunnerKind
-		}
-	}
+	runnerKind := authCommandRunnerKind(spec)
 	if runnerKind == providerregistry.AuthCommandRunnerKindCursor {
 		auth, _, ok := runCursorAuthStatusCommand(ctx, binaryPath, env)
 		return auth, ok

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerstatus"
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
 	externalagentregistry "github.com/tutti-os/tutti/services/tuttid/service/externalagentregistry"
 	managedruntime "github.com/tutti-os/tutti/services/tuttid/service/managedruntime"
 )
@@ -276,6 +277,9 @@ func TestServiceListReportsLoginAndRefreshActionsWhenAuthMarkerMissing(t *testin
 	service := testService(func(name string) (string, error) {
 		return "/usr/local/bin/" + name, nil
 	}, map[string]bool{})
+	service.CodexAuthProbe = func(context.Context, []string, []string) CodexAuthProbeEvidence {
+		return CodexAuthProbeEvidence{State: agentruntime.CodexAppServerAccountRequired}
+	}
 
 	snapshot, err := service.List(context.Background(), ListInput{Providers: []string{"codex"}})
 	if err != nil {
@@ -402,6 +406,13 @@ func TestServiceListReportsReadyWhenInstalledAndAuthenticated(t *testing.T) {
 	service := testService(func(name string) (string, error) {
 		return "/usr/local/bin/" + name, nil
 	}, map[string]bool{"/home/test/.codex/auth.json": true})
+	service.CodexAuthProbe = func(context.Context, []string, []string) CodexAuthProbeEvidence {
+		return CodexAuthProbeEvidence{
+			State:        agentruntime.CodexAppServerAccountAuthenticated,
+			AccountLabel: "dev@example.com",
+			AuthMethod:   "chatgpt",
+		}
+	}
 
 	snapshot, err := service.List(context.Background(), ListInput{Providers: []string{"codex"}})
 	if err != nil {
@@ -431,7 +442,7 @@ func TestServiceListReportsReadyWhenInstalledAndAuthenticated(t *testing.T) {
 	}
 }
 
-func TestServiceListUsesCodexLoginStatusCommand(t *testing.T) {
+func TestServiceListUsesCodexAppServerAccountCommand(t *testing.T) {
 	service := testService(func(name string) (string, error) {
 		return "/usr/local/bin/" + name, nil
 	}, map[string]bool{})
@@ -439,8 +450,11 @@ func TestServiceListUsesCodexLoginStatusCommand(t *testing.T) {
 		if spec.Provider != "codex" {
 			t.Fatalf("Provider = %q, want codex", spec.Provider)
 		}
-		if strings.Join(spec.AuthStatusCommand, " ") != `login -c service_tier="fast" status` {
-			t.Fatalf("AuthStatusCommand = %v, want login service tier override status", spec.AuthStatusCommand)
+		if strings.Join(spec.AuthStatusCommand, " ") != `-c service_tier="fast" app-server` {
+			t.Fatalf("AuthStatusCommand = %v, want app-server with service tier override", spec.AuthStatusCommand)
+		}
+		if spec.AuthCommandRunnerKind != providerregistry.AuthCommandRunnerKindCodexAppServerAccount {
+			t.Fatalf("AuthCommandRunnerKind = %q, want Codex app-server account probe", spec.AuthCommandRunnerKind)
 		}
 		if binaryPath != "/usr/local/bin/codex" {
 			t.Fatalf("binaryPath = %q, want /usr/local/bin/codex", binaryPath)


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Verification

<!-- Commands run, manual checks, or why verification is not applicable. -->

## Fallback Three Questions

<!--
Required when this change adds a timer, retry, cache, or defensive branch;
delete otherwise.

- Source: which event or state does this fallback compensate for?
- Why can it not be fixed at that source?
- Removal condition: when can this fallback be deleted?
-->

## Checklist

- [ ] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter.
- [ ] I kept the change focused on one concern.
- [ ] I updated documentation when behavior, setup, or contributor workflow changed.
- [ ] I updated all README/CONTRIBUTING language variants when changing their English source.
- [ ] I ran the lowest meaningful local checks for the changed surface.
- [ ] My commits are signed off with DCO when required: `git commit -s`.
