### PR TITLE
fix(tuttid): backport duplicate install coalescing to release/0729

### DIFF
--- a/services/tuttid/service/agentstatus/active_action.go
+++ b/services/tuttid/service/agentstatus/active_action.go
@@ -11,9 +11,9 @@ import (
 // Each install run owns its provider's active action via a unique token carried
 // on the run's context. Mutators are token-scoped: a stale or superseded run can
 // neither append into, overwrite, nor clear a newer run's active action for the
-// same provider. This prevents two concurrent installs of the SAME provider from
-// cross-contaminating stdout or having the first run's deferred clear delete the
-// second run's entry. Concurrent installs of DIFFERENT providers are unaffected
+// same provider. Install requests for the same provider are coalesced before
+// reaching this layer, but token scoping still protects overlapping install and
+// update actions. Concurrent actions for DIFFERENT providers are unaffected
 // (separate map entries).
 type activeActionTokenKey struct{}
 

--- a/services/tuttid/service/agentstatus/service.go
+++ b/services/tuttid/service/agentstatus/service.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerstatus"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/singleflight"
 
 	agentproviderbiz "github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 	externalagentregistry "github.com/tutti-os/tutti/services/tuttid/service/externalagentregistry"
@@ -346,6 +347,11 @@ const defaultProbeTimeout = 3 * time.Second
 const defaultProbeWaitDelay = 500 * time.Millisecond
 const externalRegistryNPMProbeTimeoutPadding = 100 * time.Millisecond
 
+// providerInstallActions coalesces overlapping install requests for the same
+// provider inside the daemon process. The file-based installer lock still
+// arbitrates npm mutations across processes and different providers.
+var providerInstallActions singleflight.Group
+
 // statusDetectionConcurrency bounds how many providers are detected at once.
 // Per-provider detection is dominated by short-lived subprocesses (auth status
 // command, `--version`, adapter probe), so running providers concurrently drops
@@ -560,16 +566,7 @@ func (s Service) RunAction(ctx context.Context, input RunActionInput) (RunAction
 
 	switch input.ActionID {
 	case ActionInstall:
-		startedAt := s.now()
-		result, err := s.runInstallAction(ctx, spec, result)
-		s.reportProviderSetupNodeResult(ctx, providerSetupNodeResultInput{
-			Error:     err,
-			Node:      "install_daemon_action",
-			Provider:  spec.Provider,
-			Result:    result,
-			StartedAt: startedAt,
-		})
-		return result, err
+		return s.runInstallAction(ctx, spec, result)
 	case ActionUpdate:
 		return s.runUpdateAction(ctx, spec, result)
 	default:
@@ -578,12 +575,34 @@ func (s Service) RunAction(ctx context.Context, input RunActionInput) (RunAction
 }
 
 func (s Service) runInstallAction(ctx context.Context, spec ProviderSpec, result RunActionResult) (RunActionResult, error) {
+	value, err, shared := providerInstallActions.Do(spec.Provider, func() (any, error) {
+		startedAt := s.now()
+		actionResult, actionErr := s.runInstallActionOnce(ctx, spec, result)
+		s.reportProviderSetupNodeResult(ctx, providerSetupNodeResultInput{
+			Error:     actionErr,
+			Node:      "install_daemon_action",
+			Provider:  spec.Provider,
+			Result:    actionResult,
+			StartedAt: startedAt,
+		})
+		return actionResult, actionErr
+	})
+	if shared {
+		slog.Info(
+			"agent provider install action coalesced",
+			"event", "tutti.agent_provider.install.coalesced",
+			"provider", spec.Provider,
+		)
+	}
+	return value.(RunActionResult), err
+}
+
+func (s Service) runInstallActionOnce(ctx context.Context, spec ProviderSpec, result RunActionResult) (RunActionResult, error) {
 	if result, ok := unsupportedProviderRunActionResult(spec, result); ok {
 		return result, nil
 	}
-	// Tag this run's context with a unique token and claim ownership of the
-	// provider's active action, so a concurrent install of the same provider
-	// can't cross-contaminate stdout or have our deferred clear delete its entry.
+	// Tag this run's context with a unique token so an overlapping update action
+	// cannot overwrite or clear the install's active action after ownership moves.
 	installCtx := withActiveActionToken(baseContext(ctx), nextActiveActionToken())
 	claimActiveAction(installCtx, spec.Provider, ActiveAction{
 		ID:     ActionInstall,

--- a/services/tuttid/service/agentstatus/service.go
+++ b/services/tuttid/service/agentstatus/service.go
@@ -576,9 +576,13 @@ func (s Service) RunAction(ctx context.Context, input RunActionInput) (RunAction
 
 func (s Service) runInstallAction(ctx context.Context, spec ProviderSpec, result RunActionResult) (RunActionResult, error) {
 	value, err, shared := providerInstallActions.Do(spec.Provider, func() (any, error) {
+		// The shared install must outlive any one caller's request. In
+		// particular, a disconnected renderer request must not cancel an
+		// install that the readiness reconciler is also waiting for.
+		sharedCtx := context.WithoutCancel(baseContext(ctx))
 		startedAt := s.now()
-		actionResult, actionErr := s.runInstallActionOnce(ctx, spec, result)
-		s.reportProviderSetupNodeResult(ctx, providerSetupNodeResultInput{
+		actionResult, actionErr := s.runInstallActionOnce(sharedCtx, spec, result)
+		s.reportProviderSetupNodeResult(sharedCtx, providerSetupNodeResultInput{
 			Error:     actionErr,
 			Node:      "install_daemon_action",
 			Provider:  spec.Provider,

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -2536,9 +2536,11 @@ func TestServiceRunActionCoalescesConcurrentInstallsForSameProvider(t *testing.T
 		result RunActionResult
 		err    error
 	}
+	firstCtx, cancelFirst := context.WithCancel(context.Background())
+	defer cancelFirst()
 	firstDone := make(chan runResult, 1)
 	go func() {
-		result, err := service.RunAction(context.Background(), RunActionInput{
+		result, err := service.RunAction(firstCtx, RunActionInput{
 			Provider: "codex",
 			ActionID: ActionInstall,
 		})
@@ -2558,6 +2560,12 @@ func TestServiceRunActionCoalescesConcurrentInstallsForSameProvider(t *testing.T
 	select {
 	case second := <-secondDone:
 		t.Fatalf("second RunAction() returned before the shared install completed: %#v", second)
+	case <-time.After(100 * time.Millisecond):
+	}
+	cancelFirst()
+	select {
+	case first := <-firstDone:
+		t.Fatalf("first RunAction() returned after its request was canceled but before the shared install completed: %#v", first)
 	case <-time.After(100 * time.Millisecond):
 	}
 	close(releaseFirstInstall)

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -2494,13 +2494,7 @@ func TestInstallCommandLockRecoverRetriesMalformedMetadataBeforeRemoving(t *test
 	}
 }
 
-func TestServiceRunActionStartsInstallTimeoutAfterLockAcquisition(t *testing.T) {
-	const (
-		installTimeout        = 2 * time.Second
-		firstInstallHold      = 800 * time.Millisecond
-		secondInstallDuration = 1400 * time.Millisecond
-	)
-
+func TestServiceRunActionCoalescesConcurrentInstallsForSameProvider(t *testing.T) {
 	home := t.TempDir()
 	binDir := filepath.Join(home, ".nvm", "versions", "node", "v24.12.0", "bin")
 	if err := os.MkdirAll(binDir, 0o755); err != nil {
@@ -2508,7 +2502,6 @@ func TestServiceRunActionStartsInstallTimeoutAfterLockAcquisition(t *testing.T) 
 	}
 	service := probeTestService(home)
 	service.CodexProtocolProbe = codexProtocolReadyFixture
-	service.InstallTimeout = installTimeout
 	service.Registry = Registry{Specs: []ProviderSpec{{
 		Provider:           "codex",
 		BinaryNames:        []string{"codex"},
@@ -2526,22 +2519,13 @@ func TestServiceRunActionStartsInstallTimeoutAfterLockAcquisition(t *testing.T) 
 	var installCallCount atomic.Int32
 	firstInstallStarted := make(chan struct{})
 	releaseFirstInstall := make(chan struct{})
-	var startMu sync.Mutex
-	startedAt := make([]time.Time, 0, 2)
 	service.InstallCommand = func(ctx context.Context, _ InstallCommandInput) (InstallCommandResult, error) {
-		callIndex := installCallCount.Add(1)
-		startMu.Lock()
-		startedAt = append(startedAt, time.Now())
-		startMu.Unlock()
-		if callIndex == 1 {
-			close(firstInstallStarted)
-			select {
-			case <-releaseFirstInstall:
-			case <-ctx.Done():
-				return InstallCommandResult{ExitCode: 1, Stderr: ctx.Err().Error()}, ctx.Err()
-			}
-		} else {
-			time.Sleep(secondInstallDuration)
+		installCallCount.Add(1)
+		close(firstInstallStarted)
+		select {
+		case <-releaseFirstInstall:
+		case <-ctx.Done():
+			return InstallCommandResult{ExitCode: 1, Stderr: ctx.Err().Error()}, ctx.Err()
 		}
 		writeExecutable(t, filepath.Join(binDir, "codex"), "#!/bin/sh\nexit 0\n")
 		writeExecutable(t, filepath.Join(binDir, "codex-acp"), "#!/bin/sh\nsleep 5\n")
@@ -2563,7 +2547,6 @@ func TestServiceRunActionStartsInstallTimeoutAfterLockAcquisition(t *testing.T) 
 
 	<-firstInstallStarted
 	secondDone := make(chan runResult, 1)
-	secondStartedAt := time.Now()
 	go func() {
 		result, err := service.RunAction(context.Background(), RunActionInput{
 			Provider: "codex",
@@ -2572,7 +2555,11 @@ func TestServiceRunActionStartsInstallTimeoutAfterLockAcquisition(t *testing.T) 
 		secondDone <- runResult{result: result, err: err}
 	}()
 
-	time.Sleep(firstInstallHold)
+	select {
+	case second := <-secondDone:
+		t.Fatalf("second RunAction() returned before the shared install completed: %#v", second)
+	case <-time.After(100 * time.Millisecond):
+	}
 	close(releaseFirstInstall)
 
 	first := <-firstDone
@@ -2590,17 +2577,11 @@ func TestServiceRunActionStartsInstallTimeoutAfterLockAcquisition(t *testing.T) 
 	if second.result.Status != RunActionCompleted {
 		t.Fatalf("second status = %q, want %q; result=%#v", second.result.Status, RunActionCompleted, second.result)
 	}
-	if got := installCallCount.Load(); got != 2 {
-		t.Fatalf("install call count = %d, want 2", got)
+	if got := installCallCount.Load(); got != 1 {
+		t.Fatalf("install call count = %d, want 1", got)
 	}
-
-	startMu.Lock()
-	defer startMu.Unlock()
-	if len(startedAt) != 2 {
-		t.Fatalf("len(startedAt) = %d, want 2", len(startedAt))
-	}
-	if wait := startedAt[1].Sub(secondStartedAt); wait < firstInstallHold-100*time.Millisecond {
-		t.Fatalf("second install started too early after %v, want it to wait for the lock", wait)
+	if !reflect.DeepEqual(second.result, first.result) {
+		t.Fatalf("second result = %#v, want shared first result %#v", second.result, first.result)
 	}
 }
 


### PR DESCRIPTION
## Summary

- backport the merged fix from #1779 to `release/0729`
- coalesce overlapping install actions for the same provider inside `tuttid`
- detach the shared install from any single request cancellation while retaining the existing installer and probe timeouts
- preserve token-scoped active-action ownership for overlapping install/update actions

## Verification

- `go test ./services/tuttid/service/agentstatus -count=1` — 295 tests passed
- `pnpm lint:go` — 0 issues
- `pnpm check:changed -- --push-ready` — all 39 selected lanes passed
- the first full push-ready run hit unrelated timing/process flakes in one Codex discovery threshold test and three Desktop IPC test files; `--failed-only` passed, followed by a clean full 39-lane push-ready run

## Risk

Low and scoped to daemon-side provider install coordination. Different providers remain independent. The shared install remains bounded by the existing install/probe timeouts.

## Checklist

- [x] This does not change agent session/turn/goal/runtime-operation lifecycle semantics
- [x] I kept the change focused on one concern
- [x] No durable documentation impact was found; this is a release backport of an existing fix
- [x] README/CONTRIBUTING language variants are unaffected
- [x] I ran the lowest meaningful local checks for the changed surface
- [x] Commits retain DCO sign-off

AI-assisted conflict resolution, validation, and backport preparation were performed with Codex.