### PR TITLE
fix(file-reference): scope type-only filters

### DIFF
--- a/.changeset/scoped-host-reference-filters.md
+++ b/.changeset/scoped-host-reference-filters.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/workspace-file-reference": patch
+---
+
+Allow permission-sensitive reference sources to route file-type-only filters through scoped search, and constrain recursive browse filtering to the selected sidebar root.

--- a/packages/workspace/file-reference/src/contracts/referenceSource.ts
+++ b/packages/workspace/file-reference/src/contracts/referenceSource.ts
@@ -168,9 +168,16 @@ export interface ReferenceSourceCapabilities {
   navigable?: boolean;
   /**
    * 是否支持「全局文件类型筛选」(图片/文档/表格…)。为 true 时 picker 展示筛选下拉,
-   * 已选分类作为 search() 的 filters 下钻到 daemon 过滤。三源(本地/应用/任务)均为 true。
+   * 搜索态下已选分类作为 search() 的 filters 下钻到 source;无关键词时默认由 picker
+   * 递归投影浏览树。三源(本地/应用/任务)均为 true。
    */
   filterable?: boolean;
+  /**
+   * 无关键词、只有文件类型筛选时是否走 search(),而非由 picker 递归 listChildren()
+   * 投影浏览树。仅对同时支持 filterable/searchable/search() 的源有效。Host-local 等
+   * 权限敏感源可开启,避免筛选时递归触碰未授权目录。
+   */
+  filtersUseSearch?: boolean;
   /** 是否允许 picker 在该源的目录下创建子目录。 */
   directoryCreatable?: boolean;
   /** Provenance dimensions this source can enforce before pagination. */

--- a/packages/workspace/file-reference/src/react/internal/reference/referenceSourcePickerController.test.ts
+++ b/packages/workspace/file-reference/src/react/internal/reference/referenceSourcePickerController.test.ts
@@ -734,6 +734,50 @@ test("file-type filters keep browse mode until a keyword search starts", async (
   assert.deepEqual(searchInputs[0]?.kinds, ["file"]);
 });
 
+test("sources can route file-type-only filters through scoped search", async () => {
+  const searchInputs: SearchInput[] = [];
+  const controller = createReferenceSourcePickerController({
+    aggregator: fakeAggregator({
+      tabs: [
+        {
+          sourceId: "host-local-file",
+          label: "Local files",
+          capabilities: {
+            filterable: true,
+            filtersUseSearch: true,
+            paginated: false,
+            previewable: true,
+            searchable: true
+          }
+        }
+      ],
+      children: {
+        [`host-local-file:${SOURCE_ROOT_NODE_ID}`]: {
+          entries: [],
+          nextCursor: null
+        }
+      },
+      onSearch: (input) => searchInputs.push(input)
+    }),
+    scope,
+    searchDebounceMs: 0,
+    searchResultKind: "file"
+  });
+  controller.open();
+  await flush();
+
+  controller.setSearchFilters(["webpage"], "host-path-downloads");
+  await flush();
+
+  const tab = controller.getSnapshot().bySource["host-local-file"];
+  assert.equal(tab?.mode, "search");
+  assert.equal(searchInputs.length, 1);
+  assert.equal(searchInputs[0]?.query, "");
+  assert.deepEqual(searchInputs[0]?.filters, ["webpage"]);
+  assert.deepEqual(searchInputs[0]?.kinds, ["file"]);
+  assert.equal(searchInputs[0]?.withinNodeId, "host-path-downloads");
+});
+
 test("semantically equal provenance filters do not repeat the active search", async () => {
   const searchInputs: SearchInput[] = [];
   const controller = createReferenceSourcePickerController({

--- a/packages/workspace/file-reference/src/react/internal/reference/referenceSourcePickerController.ts
+++ b/packages/workspace/file-reference/src/react/internal/reference/referenceSourcePickerController.ts
@@ -131,12 +131,13 @@ export interface ReferenceSourcePickerController {
   loadMoreSourceRoot(sourceId: string): void;
   /**
    * 设置搜索关键词。scopeNodeId 指定把搜索限定在 active 源内某个二级分组(左栏选中分组)
-   * 的节点 nodeId;缺省/null = 跨整源搜索。只有关键词或 provenance 约束进入扁平查询态。
+   * 的节点 nodeId;缺省/null = 跨整源搜索。关键词、provenance 约束,以及声明
+   * filtersUseSearch 的源上的类型筛选会进入扁平查询态。
    */
   setSearchQuery(query: string, scopeNodeId?: string | null): void;
   /**
-   * 设置已选文件类型筛选分类(全局统一口径)。无关键词时保持可导航的浏览树;
-   * 有关键词时作为搜索参数下钻到 source。
+   * 设置已选文件类型筛选分类(全局统一口径)。默认无关键词时保持可导航的浏览树;
+   * 有关键词或源声明 filtersUseSearch 时作为搜索参数下钻到 source。
    */
   setSearchFilters(filters: string[], scopeNodeId?: string | null): void;
   setProvenanceFilter(
@@ -339,7 +340,7 @@ export function createReferenceSourcePickerController(
     }
 
     // ROOT_CHILDREN_KEY 等常量 key 在各源间复用,故 ticket 表按 (source, key) 命名空间。
-    const seqKey = `${sourceId} ${key}`;
+    const seqKey = `${sourceId}\0${key}`;
     const sequence = ++nextBrowseSeq;
     latestBrowseSeqByKey.set(seqKey, sequence);
     setChildrenState(sourceId, key, { loading: true, error: null });
@@ -444,6 +445,19 @@ export function createReferenceSourcePickerController(
     searchAbortController?.abort();
     searchAbortController = null;
   };
+
+  const sourceUsesSearchForFilters = (sourceId: string): boolean =>
+    snapshot.tabs.find((tab) => tab.sourceId === sourceId)?.capabilities
+      .filtersUseSearch === true;
+
+  const hasSearchInput = (
+    sourceId: string,
+    query: string,
+    filters: readonly string[]
+  ): boolean =>
+    Boolean(query) ||
+    referenceProvenanceFilterIsActive(provenanceFilter) ||
+    (filters.length > 0 && sourceUsesSearchForFilters(sourceId));
 
   const runSearch = async (
     sourceId: string,
@@ -555,11 +569,7 @@ export function createReferenceSourcePickerController(
     scopeNodeId: string | null
   ) => {
     clearSearchTimer();
-    // 类型筛选自身属于浏览树投影,不触发递归搜索。
-    if (
-      !retained ||
-      (!query && !referenceProvenanceFilterIsActive(provenanceFilter))
-    ) {
+    if (!retained || !hasSearchInput(sourceId, query, filters)) {
       return;
     }
     // 新查询恒从首页(SEARCH_PAGE_SIZE)起。
@@ -640,12 +650,10 @@ export function createReferenceSourcePickerController(
           : (snapshot.bySource[sourceId]?.searchScopeNodeId ?? null);
       cancelSearch();
       setSnapshot({ activeSourceId: sourceId });
-      if (
-        trimmed === "" &&
-        !referenceProvenanceFilterIsActive(provenanceFilter)
-      ) {
+      if (!hasSearchInput(sourceId, trimmed, carriedFilters)) {
         // 没有关键词/来源查询时,目标源保持浏览态。文件类型筛选由视图层递归投影
         // 浏览树,不能把它误判为扁平搜索；切源/回源根时也必须继续保留。
+        // 权限敏感源可通过 filtersUseSearch 声明 filters-only 也走 search。
         updateTab(sourceId, (tab) =>
           tab.mode === "browse" &&
           tab.searchQuery === "" &&
@@ -825,11 +833,15 @@ export function createReferenceSourcePickerController(
       }
       const filters = snapshot.bySource[sourceId]?.searchFilters ?? [];
       const trimmed = query.trim();
-      // 类型筛选不改变浏览/查询模式;只在已有关键词时参与搜索。
-      const nextMode: ReferenceSourcePickerMode =
-        trimmed || referenceProvenanceFilterIsActive(provenanceFilter)
-          ? "search"
-          : "browse";
+      // 默认类型筛选不改变浏览/查询模式;声明 filtersUseSearch 的源可让
+      // filters-only 进入 search,避免递归浏览权限敏感目录。
+      const nextMode: ReferenceSourcePickerMode = hasSearchInput(
+        sourceId,
+        trimmed,
+        filters
+      )
+        ? "search"
+        : "browse";
       updateTab(sourceId, (tab) => ({
         ...tab,
         searchQuery: query,
@@ -856,10 +868,13 @@ export function createReferenceSourcePickerController(
       const tab = snapshot.bySource[sourceId];
       const trimmed = tab?.searchQuery.trim() ?? "";
       const scopeId = scopeNodeId ?? tab?.searchScopeNodeId ?? null;
-      const nextMode: ReferenceSourcePickerMode =
-        trimmed || referenceProvenanceFilterIsActive(provenanceFilter)
-          ? "search"
-          : "browse";
+      const nextMode: ReferenceSourcePickerMode = hasSearchInput(
+        sourceId,
+        trimmed,
+        filters
+      )
+        ? "search"
+        : "browse";
       updateTab(sourceId, (current) => ({
         ...current,
         searchFilters: filters,
@@ -897,16 +912,16 @@ export function createReferenceSourcePickerController(
       if (!sourceId) return;
       const query = tab?.searchQuery.trim() ?? "";
       const filters = tab?.searchFilters ?? [];
-      const active = referenceProvenanceFilterIsActive(provenanceFilter);
+      const searchActive = hasSearchInput(sourceId, query, filters);
       updateTab(sourceId, (current) => ({
         ...current,
         searchScopeNodeId: scopeId,
-        mode: query || active ? "search" : "browse",
-        ...(query || active
+        mode: searchActive ? "search" : "browse",
+        ...(searchActive
           ? { isSearchLoading: true, searchError: null }
           : { isSearchLoading: false, searchEntries: [], searchError: null })
       }));
-      if (query || active) {
+      if (searchActive) {
         scheduleSearch(sourceId, query, filters, scopeId);
       } else {
         cancelSearch();
@@ -929,10 +944,7 @@ export function createReferenceSourcePickerController(
       }));
       const trimmed = tab.searchQuery.trim();
       const filters = tab.searchFilters;
-      if (
-        tab.mode === "search" &&
-        (trimmed || referenceProvenanceFilterIsActive(provenanceFilter))
-      ) {
+      if (tab.mode === "search" && hasSearchInput(sourceId, trimmed, filters)) {
         scheduleSearch(sourceId, trimmed, filters, scopeNodeId);
       }
     },
@@ -951,7 +963,7 @@ export function createReferenceSourcePickerController(
         return;
       }
       const trimmed = tab.searchQuery.trim();
-      if (!trimmed && !referenceProvenanceFilterIsActive(provenanceFilter)) {
+      if (!hasSearchInput(sourceId, trimmed, tab.searchFilters)) {
         return;
       }
       const nextLimit = Math.min(

--- a/packages/workspace/file-reference/src/react/internal/reference/referenceSourcePickerFilterTree.test.ts
+++ b/packages/workspace/file-reference/src/react/internal/reference/referenceSourcePickerFilterTree.test.ts
@@ -108,6 +108,77 @@ test("filter tree isolates an unreadable descendant folder", async () => {
   );
 });
 
+test("filter tree scopes recursive reads to the selected root node", async () => {
+  const downloads = folder(
+    "/Users/me/Downloads",
+    "Downloads",
+    "host-local-file"
+  );
+  const documents = folder(
+    "/Users/me/Documents",
+    "Documents",
+    "host-local-file"
+  );
+  const website = file(
+    "/Users/me/Downloads/site.html",
+    "site.html",
+    "host-local-file"
+  );
+  const documentWebsite = file(
+    "/Users/me/Documents/private.html",
+    "private.html",
+    "host-local-file"
+  );
+  const entriesByNodeId: Record<string, ReferenceNode[]> = {
+    [SOURCE_ROOT_NODE_ID]: [downloads, documents],
+    [downloads.ref.nodeId]: [website],
+    [documents.ref.nodeId]: [documentWebsite]
+  };
+  const listedNodeIds: string[] = [];
+  const aggregator = {
+    async listChildren(_scope, node) {
+      listedNodeIds.push(node.nodeId);
+      assert.notEqual(
+        node.nodeId,
+        SOURCE_ROOT_NODE_ID,
+        "scoped filter should not read the source root"
+      );
+      assert.notEqual(
+        node.nodeId,
+        documents.ref.nodeId,
+        "scoped filter should not read sibling folders"
+      );
+      return {
+        entries: entriesByNodeId[node.nodeId] ?? [],
+        nextCursor: null
+      };
+    }
+  } as ReferenceSourceAggregator;
+
+  const tree = await buildReferenceSourcePickerFilteredTree({
+    aggregator,
+    filters: ["webpage"],
+    rootNode: downloads,
+    scope: { workspaceId: "workspace-1" },
+    signal: new AbortController().signal,
+    sourceId: "host-local-file"
+  });
+
+  assert.deepEqual(listedNodeIds, [downloads.ref.nodeId]);
+  assert.deepEqual(
+    tree.childrenByKey[ROOT_CHILDREN_KEY]?.entries.map(
+      (entry) => entry.displayName
+    ),
+    ["Downloads"]
+  );
+  assert.deepEqual(
+    tree.childrenByKey[nodeRefKey(downloads.ref)]?.entries.map(
+      (entry) => entry.displayName
+    ),
+    ["site.html"]
+  );
+});
+
 test("filter tree terminates when folders form a cycle", async () => {
   const photos = folder("/workspace/photos", "photos");
   const nested = folder("/workspace/photos/nested", "nested");
@@ -175,19 +246,27 @@ test("filter tree still reports a source-root read failure", async () => {
   );
 });
 
-function folder(nodeId: string, displayName: string): ReferenceNode {
+function folder(
+  nodeId: string,
+  displayName: string,
+  sourceId = "workspace-file"
+): ReferenceNode {
   return {
     displayName,
     hasChildren: true,
     kind: "folder",
-    ref: { nodeId, sourceId: "workspace-file" }
+    ref: { nodeId, sourceId }
   };
 }
 
-function file(nodeId: string, displayName: string): ReferenceNode {
+function file(
+  nodeId: string,
+  displayName: string,
+  sourceId = "workspace-file"
+): ReferenceNode {
   return {
     displayName,
     kind: "file",
-    ref: { nodeId, sourceId: "workspace-file" }
+    ref: { nodeId, sourceId }
   };
 }

--- a/packages/workspace/file-reference/src/react/internal/reference/referenceSourcePickerFilterTree.ts
+++ b/packages/workspace/file-reference/src/react/internal/reference/referenceSourcePickerFilterTree.ts
@@ -22,6 +22,7 @@ export interface ReferenceSourcePickerFilteredTree {
 export async function buildReferenceSourcePickerFilteredTree(input: {
   aggregator: ReferenceSourceAggregator;
   filters: readonly string[];
+  rootNode?: ReferenceNode | null;
   scope: ReferenceScope;
   signal: AbortSignal;
   sourceId: string;
@@ -81,11 +82,16 @@ export async function buildReferenceSourcePickerFilteredTree(input: {
     folderLoadsByKey.set(key, pending);
   };
 
-  const rootRef = {
+  const scopedRootNode = input.rootNode ?? null;
+  const rootRef = scopedRootNode?.ref ?? {
     sourceId: input.sourceId,
     nodeId: SOURCE_ROOT_NODE_ID
   };
+  const rootKey = scopedRootNode
+    ? nodeRefKey(scopedRootNode.ref)
+    : ROOT_CHILDREN_KEY;
   const rootEntries = await runListTask(() => loadAllChildren(rootRef));
+  folderEntriesByKey.set(rootKey, rootEntries);
   for (const entry of rootEntries) {
     if (entry.kind === "folder") {
       scheduleFolderLoad(entry);
@@ -107,9 +113,11 @@ export async function buildReferenceSourcePickerFilteredTree(input: {
       filterEntries(entries, matchingFolderKeys, input.filters)
     );
   }
-  childrenByKey[ROOT_CHILDREN_KEY] = loadedChildrenState(
-    filterEntries(rootEntries, matchingFolderKeys, input.filters)
-  );
+  if (scopedRootNode) {
+    childrenByKey[ROOT_CHILDREN_KEY] = loadedChildrenState(
+      filterEntries([scopedRootNode], matchingFolderKeys, input.filters)
+    );
+  }
   throwIfAborted(input.signal);
   return { childrenByKey };
 }

--- a/packages/workspace/file-reference/src/react/internal/reference/useReferenceSourcePickerView.ts
+++ b/packages/workspace/file-reference/src/react/internal/reference/useReferenceSourcePickerView.ts
@@ -293,11 +293,19 @@ export function useReferenceSourcePickerView({
   const currentKey = currentNode
     ? nodeRefKey(currentNode.ref)
     : ROOT_CHILDREN_KEY;
+  // 左栏二级分组高亮 = 当前所在的「根 most 分组」(面包屑首项),而非最深叶子节点。
+  // 这样下钻进事项(topic → 事项 → 产物)时,左栏仍高亮其所属 topic;进 app 子目录时仍高亮该 app。
+  const rootGroupNode = breadcrumb[0] ?? null;
+  // 搜索限定范围 = 左栏选中的二级分组(面包屑根项)的源内 nodeId;无选中分组(本地根)→ null,
+  // 退回跨整源搜索。供「只搜选中应用」而非所有应用。
+  const searchScopeNodeId = rootGroupNode ? rootGroupNode.ref.nodeId : null;
+  const selectedGroupKey = rootGroupNode ? nodeRefKey(rootGroupNode.ref) : null;
 
   const activeTabState = activeSourceId
     ? snapshot.bySource[activeSourceId]
     : undefined;
-  // 已选文件类型筛选分类。无关键词时它只投影当前浏览树,不切成扁平查询态。
+  // 已选文件类型筛选分类。默认无关键词时只投影当前浏览树;
+  // 声明 filtersUseSearch 的源会由 controller 切到扁平查询态。
   const activeFilters = activeTabState?.searchFilters ?? [];
   const activeFiltersSerialized = JSON.stringify(activeFilters);
   const recursiveFilters = useMemo(
@@ -307,7 +315,7 @@ export function useReferenceSourcePickerView({
   const isQuery = activeTabState?.mode === "search";
   const recursiveFilterKey =
     activeSourceId && recursiveFilters.length > 0 && !isQuery
-      ? JSON.stringify([activeSourceId, recursiveFilters])
+      ? JSON.stringify([activeSourceId, searchScopeNodeId, recursiveFilters])
       : null;
   const recursiveFilterActive = recursiveFilterKey !== null;
   const recursiveFilterRequestKey = recursiveFilterKey
@@ -340,6 +348,7 @@ export function useReferenceSourcePickerView({
     void buildReferenceSourcePickerFilteredTree({
       aggregator,
       filters: recursiveFilters,
+      rootNode: rootGroupNode,
       scope,
       signal: abortController.signal,
       sourceId: activeSourceId
@@ -373,6 +382,7 @@ export function useReferenceSourcePickerView({
     recursiveFilterKey,
     recursiveFilterRequestKey,
     recursiveFilters,
+    rootGroupNode,
     scope
   ]);
 
@@ -488,14 +498,6 @@ export function useReferenceSourcePickerView({
   const sidebarGroups = activeSourceId
     ? (sidebarGroupsBySource[activeSourceId] ?? [])
     : [];
-
-  // 左栏二级分组高亮 = 当前所在的「根 most 分组」(面包屑首项),而非最深叶子节点。
-  // 这样下钻进事项(topic → 事项 → 产物)时,左栏仍高亮其所属 topic;进 app 子目录时仍高亮该 app。
-  const rootGroupNode = breadcrumb[0] ?? null;
-  // 搜索限定范围 = 左栏选中的二级分组(面包屑根项)的源内 nodeId;无选中分组(本地根)→ null,
-  // 退回跨整源搜索。供「只搜选中应用」而非所有应用。
-  const searchScopeNodeId = rootGroupNode ? rootGroupNode.ref.nodeId : null;
-  const selectedGroupKey = rootGroupNode ? nodeRefKey(rootGroupNode.ref) : null;
 
   // 搜索进行中切换左栏分组(选中应用变化)时,把搜索限定范围同步给 controller 并重搜。
   // controller 内部仅在范围实际变化且处于搜索态时才重搜,浏览态/范围未变为 no-op。


### PR DESCRIPTION
## Summary

- add an opt-in `filtersUseSearch` source capability for file-type-only filtering
- route opted-in sources through `search()` with the selected sidebar group as `withinNodeId`
- constrain recursive browse filtering to the selected root for sources that keep the default browse projection
- add focused controller and filtered-tree regression coverage plus a package changeset

## Problem

The shared picker normally implements type-only filters by recursively projecting the browse tree. For permission-sensitive host-local sources, that can escape the directory selected in the sidebar, traverse the wider host source root, stall the picker, and trigger operating-system permission prompts.

## Approach

The default behavior remains unchanged. Sources that explicitly set `filtersUseSearch: true` treat active file-type filters as search input even when the keyword is empty. The controller preserves the current group scope and passes it to the source as `withinNodeId`.

For sources that continue using recursive browse projection, the filtered-tree builder now starts from the selected sidebar root instead of always starting from the source root.

## Validation

- `pnpm --filter @tutti-os/workspace-file-reference test` (90 tests)
- `pnpm --filter @tutti-os/workspace-file-reference typecheck`
- `pnpm check:changed` (9 lanes)
- pre-push `pnpm check:changed -- --push-ready` (10 lanes)
- downstream TSH live check: switching Downloads across image, video, document, webpage, and other filters issued one shallow directory read per selection with no loading stall

## Documentation

Added a package changeset and documented the new capability in the public TypeScript contract. No durable architecture or ownership documentation changes are required.
