### PR TITLE
fix(mobile): keep inputs above software keyboard

### DIFF
--- a/apps/mobile/src/components/MobileComposerDock.test.tsx
+++ b/apps/mobile/src/components/MobileComposerDock.test.tsx
@@ -1,6 +1,7 @@
 import { NativeListRow, NativeSheet } from "@tutti-os/ui-system/native";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { Modal, TextInput } from "react-native";
+import { SafeAreaProvider } from "react-native-safe-area-context";
 import type { AgentActivitySessionSettings } from "@tutti-os/agent-activity-core";
 import type { WorkspaceActivitySnapshot } from "../services/workspaceActivityService";
 import { MobileComposerDock } from "./MobileComposerDock";
@@ -113,20 +114,27 @@ function composerDock(
   onUpdate: (settings: AgentActivitySessionSettings) => void = () => undefined
 ) {
   return (
-    <MobileComposerDock
-      model={model}
-      onDraftChange={() => undefined}
-      onRefreshQuickPrompts={() => Promise.resolve()}
-      onSend={() => undefined}
-      onStop={() => undefined}
-      onUpdate={onUpdate}
-      quickPromptLibrary={{
-        enabled: false,
-        errorCode: null,
-        prompts: [],
-        status: "ready"
+    <SafeAreaProvider
+      initialMetrics={{
+        frame: { height: 800, width: 400, x: 0, y: 0 },
+        insets: { bottom: 16, left: 0, right: 0, top: 24 }
       }}
-    />
+    >
+      <MobileComposerDock
+        model={model}
+        onDraftChange={() => undefined}
+        onRefreshQuickPrompts={() => Promise.resolve()}
+        onSend={() => undefined}
+        onStop={() => undefined}
+        onUpdate={onUpdate}
+        quickPromptLibrary={{
+          enabled: false,
+          errorCode: null,
+          prompts: [],
+          status: "ready"
+        }}
+      />
+    </SafeAreaProvider>
   );
 }
 

--- a/apps/mobile/src/components/MobileComposerDock.tsx
+++ b/apps/mobile/src/components/MobileComposerDock.tsx
@@ -26,6 +26,10 @@ import {
   type ComposerSettingMenu
 } from "./MobileComposerSettingsSheet";
 import {
+  MobileKeyboardAvoidingView,
+  mobileKeyboardDismissMode
+} from "./MobileKeyboardAvoidingView";
+import {
   addMobileQuickPrompt,
   filterMobileQuickPrompts,
   previewMobileQuickPromptContent,
@@ -241,208 +245,217 @@ export function MobileComposerDock({
         transparent
         visible={model.commandsAvailable && toolsMenu !== null}
       >
-        <Pressable onPress={() => setToolsMenu(null)} style={styles.backdrop}>
-          <Pressable
-            onPress={(event) => event.stopPropagation()}
-            style={styles.menu}
-          >
-            {toolsMenu === "tools" ? (
-              <>
-                {model.composerSettingsSupport.model &&
-                modelOptions.length > 0 ? (
-                  <NativeListRow
-                    description={selectedModelLabel}
-                    onPress={() => setToolsMenu("model")}
-                    title={t("model")}
-                    trailing={<Text style={styles.chevron}>›</Text>}
-                  />
-                ) : null}
-                {model.composerSettingsSupport.permission &&
-                permissionOptions.length > 0 ? (
-                  <NativeListRow
-                    description={selectedPermissionLabel}
-                    onPress={() => setToolsMenu("permission")}
-                    title={t("permissions")}
-                    trailing={<Text style={styles.chevron}>›</Text>}
-                  />
-                ) : null}
-                {model.composerSettingsSupport.plan ? (
-                  <NativeListRow
-                    description={
-                      model.composerSettings.planMode
-                        ? t("planModeOn")
-                        : t("planModeOff")
-                    }
-                    onPress={() => {
-                      onUpdate({
-                        planMode: !model.composerSettings.planMode
-                      });
-                      setToolsMenu(null);
-                    }}
-                    selected={model.composerSettings.planMode === true}
-                    title={t("planMode")}
-                  />
-                ) : null}
-                {quickPromptLibrary.enabled ? (
-                  <NativeListRow
-                    description={
-                      quickPromptLibrary.status === "loading"
-                        ? t("loadingQuickPrompts")
-                        : t("quickPromptsCount", {
-                            count: quickPromptLibrary.prompts.length
-                          })
-                    }
-                    onPress={() => setToolsMenu("quickPrompts")}
-                    title={t("quickPrompts")}
-                    trailing={<Text style={styles.chevron}>›</Text>}
-                  />
-                ) : null}
-                {model.composerOptionsLoadStatus === "loading" ? (
-                  <ActivityIndicator
-                    color={theme.color.accent}
-                    size="small"
-                    style={styles.loading}
-                  />
-                ) : null}
-                {quickPromptLibrary.status === "loading" &&
-                !quickPromptLibrary.enabled ? (
-                  <ActivityIndicator
-                    color={theme.color.accent}
-                    size="small"
-                    style={styles.loading}
-                  />
-                ) : null}
-                {!hasComposerTools &&
-                quickPromptLibrary.status !== "loading" ? (
-                  <Text style={styles.emptyMenu}>{t("noComposerActions")}</Text>
-                ) : null}
-              </>
-            ) : (
-              <>
-                <View style={styles.menuHeader}>
-                  <NativeIconButton
-                    accessibilityLabel={t("cancel")}
-                    icon={<Text style={styles.menuBackIcon}>←</Text>}
-                    onPress={() => setToolsMenu("tools")}
-                    style={styles.menuBackButton}
-                  />
-                  <Text style={styles.menuTitle}>
+        <MobileKeyboardAvoidingView
+          keyboardVerticalOffset={0}
+          style={styles.modalRoot}
+        >
+          <Pressable onPress={() => setToolsMenu(null)} style={styles.backdrop}>
+            <Pressable
+              onPress={(event) => event.stopPropagation()}
+              style={styles.menu}
+            >
+              {toolsMenu === "tools" ? (
+                <>
+                  {model.composerSettingsSupport.model &&
+                  modelOptions.length > 0 ? (
+                    <NativeListRow
+                      description={selectedModelLabel}
+                      onPress={() => setToolsMenu("model")}
+                      title={t("model")}
+                      trailing={<Text style={styles.chevron}>›</Text>}
+                    />
+                  ) : null}
+                  {model.composerSettingsSupport.permission &&
+                  permissionOptions.length > 0 ? (
+                    <NativeListRow
+                      description={selectedPermissionLabel}
+                      onPress={() => setToolsMenu("permission")}
+                      title={t("permissions")}
+                      trailing={<Text style={styles.chevron}>›</Text>}
+                    />
+                  ) : null}
+                  {model.composerSettingsSupport.plan ? (
+                    <NativeListRow
+                      description={
+                        model.composerSettings.planMode
+                          ? t("planModeOn")
+                          : t("planModeOff")
+                      }
+                      onPress={() => {
+                        onUpdate({
+                          planMode: !model.composerSettings.planMode
+                        });
+                        setToolsMenu(null);
+                      }}
+                      selected={model.composerSettings.planMode === true}
+                      title={t("planMode")}
+                    />
+                  ) : null}
+                  {quickPromptLibrary.enabled ? (
+                    <NativeListRow
+                      description={
+                        quickPromptLibrary.status === "loading"
+                          ? t("loadingQuickPrompts")
+                          : t("quickPromptsCount", {
+                              count: quickPromptLibrary.prompts.length
+                            })
+                      }
+                      onPress={() => setToolsMenu("quickPrompts")}
+                      title={t("quickPrompts")}
+                      trailing={<Text style={styles.chevron}>›</Text>}
+                    />
+                  ) : null}
+                  {model.composerOptionsLoadStatus === "loading" ? (
+                    <ActivityIndicator
+                      color={theme.color.accent}
+                      size="small"
+                      style={styles.loading}
+                    />
+                  ) : null}
+                  {quickPromptLibrary.status === "loading" &&
+                  !quickPromptLibrary.enabled ? (
+                    <ActivityIndicator
+                      color={theme.color.accent}
+                      size="small"
+                      style={styles.loading}
+                    />
+                  ) : null}
+                  {!hasComposerTools &&
+                  quickPromptLibrary.status !== "loading" ? (
+                    <Text style={styles.emptyMenu}>
+                      {t("noComposerActions")}
+                    </Text>
+                  ) : null}
+                </>
+              ) : (
+                <>
+                  <View style={styles.menuHeader}>
+                    <NativeIconButton
+                      accessibilityLabel={t("cancel")}
+                      icon={<Text style={styles.menuBackIcon}>←</Text>}
+                      onPress={() => setToolsMenu("tools")}
+                      style={styles.menuBackButton}
+                    />
+                    <Text style={styles.menuTitle}>
+                      {toolsMenu === "model"
+                        ? t("model")
+                        : toolsMenu === "permission"
+                          ? t("permissions")
+                          : t("quickPrompts")}
+                    </Text>
+                  </View>
+                  {toolsMenu === "quickPrompts" ? (
+                    <TextInput
+                      accessibilityLabel={t("searchQuickPrompts")}
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                      onChangeText={setQuickPromptQuery}
+                      placeholder={t("searchQuickPrompts")}
+                      placeholderTextColor={theme.color.muted}
+                      style={styles.searchInput}
+                      value={quickPromptQuery}
+                    />
+                  ) : null}
+                  <ScrollView
+                    keyboardDismissMode={mobileKeyboardDismissMode}
+                    keyboardShouldPersistTaps="handled"
+                    nestedScrollEnabled
+                    showsVerticalScrollIndicator
+                    style={styles.menuOptions}
+                  >
                     {toolsMenu === "model"
-                      ? t("model")
-                      : toolsMenu === "permission"
-                        ? t("permissions")
-                        : t("quickPrompts")}
-                  </Text>
-                </View>
-                {toolsMenu === "quickPrompts" ? (
-                  <TextInput
-                    accessibilityLabel={t("searchQuickPrompts")}
-                    autoCapitalize="none"
-                    autoCorrect={false}
-                    onChangeText={setQuickPromptQuery}
-                    placeholder={t("searchQuickPrompts")}
-                    placeholderTextColor={theme.color.muted}
-                    style={styles.searchInput}
-                    value={quickPromptQuery}
-                  />
-                ) : null}
-                <ScrollView
-                  nestedScrollEnabled
-                  showsVerticalScrollIndicator
-                  style={styles.menuOptions}
-                >
-                  {toolsMenu === "model"
-                    ? modelOptions.map((option) => (
+                      ? modelOptions.map((option) => (
+                          <NativeListRow
+                            key={option.value}
+                            onPress={() => {
+                              onUpdate({ model: option.value });
+                              setToolsMenu(null);
+                            }}
+                            selected={
+                              option.value === model.composerSettings.model
+                            }
+                            title={option.label}
+                          />
+                        ))
+                      : null}
+                    {toolsMenu === "permission"
+                      ? permissionOptions.map((option) => (
+                          <NativeListRow
+                            description={option.description}
+                            key={option.id}
+                            onPress={() => {
+                              onUpdate({ permissionModeId: option.id });
+                              setToolsMenu(null);
+                            }}
+                            selected={
+                              option.id ===
+                              model.composerSettings.permissionModeId
+                            }
+                            title={option.label ?? option.id}
+                          />
+                        ))
+                      : null}
+                    {toolsMenu === "quickPrompts"
+                      ? filteredQuickPrompts.map((prompt) => (
+                          <NativeListRow
+                            description={previewMobileQuickPromptContent(
+                              prompt.content
+                            )}
+                            key={prompt.id}
+                            onPress={() => selectQuickPrompt(prompt.content)}
+                            title={prompt.title}
+                          />
+                        ))
+                      : null}
+                    {toolsMenu === "quickPrompts" &&
+                    quickPromptLibrary.status === "error" ? (
+                      <View style={styles.quickPromptStatus}>
+                        <Text style={styles.errorText}>
+                          {t("quickPromptsLoadError")}
+                        </Text>
                         <NativeListRow
-                          key={option.value}
-                          onPress={() => {
-                            onUpdate({ model: option.value });
-                            setToolsMenu(null);
-                          }}
-                          selected={
-                            option.value === model.composerSettings.model
-                          }
-                          title={option.label}
+                          onPress={() => void onRefreshQuickPrompts()}
+                          title={t("retry")}
                         />
-                      ))
-                    : null}
-                  {toolsMenu === "permission"
-                    ? permissionOptions.map((option) => (
-                        <NativeListRow
-                          description={option.description}
-                          key={option.id}
-                          onPress={() => {
-                            onUpdate({ permissionModeId: option.id });
-                            setToolsMenu(null);
-                          }}
-                          selected={
-                            option.id ===
-                            model.composerSettings.permissionModeId
-                          }
-                          title={option.label ?? option.id}
-                        />
-                      ))
-                    : null}
-                  {toolsMenu === "quickPrompts"
-                    ? filteredQuickPrompts.map((prompt) => (
-                        <NativeListRow
-                          description={previewMobileQuickPromptContent(
-                            prompt.content
-                          )}
-                          key={prompt.id}
-                          onPress={() => selectQuickPrompt(prompt.content)}
-                          title={prompt.title}
-                        />
-                      ))
-                    : null}
-                  {toolsMenu === "quickPrompts" &&
-                  quickPromptLibrary.status === "error" ? (
-                    <View style={styles.quickPromptStatus}>
-                      <Text style={styles.errorText}>
-                        {t("quickPromptsLoadError")}
-                      </Text>
-                      <NativeListRow
-                        onPress={() => void onRefreshQuickPrompts()}
-                        title={t("retry")}
+                      </View>
+                    ) : null}
+                    {toolsMenu === "quickPrompts" &&
+                    quickPromptLibrary.status === "loading" ? (
+                      <ActivityIndicator
+                        color={theme.color.accent}
+                        size="small"
+                        style={styles.loading}
                       />
-                    </View>
-                  ) : null}
-                  {toolsMenu === "quickPrompts" &&
-                  quickPromptLibrary.status === "loading" ? (
-                    <ActivityIndicator
-                      color={theme.color.accent}
-                      size="small"
-                      style={styles.loading}
-                    />
-                  ) : null}
-                  {toolsMenu === "quickPrompts" &&
-                  quickPromptLibrary.status === "ready" &&
-                  quickPromptLibrary.prompts.length === 0 ? (
-                    <Text style={styles.emptyMenu}>
-                      {t("emptyQuickPrompts")}
-                    </Text>
-                  ) : null}
-                  {toolsMenu === "quickPrompts" &&
-                  quickPromptLibrary.status === "ready" &&
-                  quickPromptLibrary.prompts.length > 0 &&
-                  filteredQuickPrompts.length === 0 ? (
-                    <Text style={styles.emptyMenu}>
-                      {t("noQuickPromptResults")}
-                    </Text>
-                  ) : null}
-                  {toolsMenu !== "quickPrompts" &&
-                  model.composerOptionsLoadStatus === "loading" ? (
-                    <ActivityIndicator
-                      color={theme.color.accent}
-                      size="small"
-                      style={styles.loading}
-                    />
-                  ) : null}
-                </ScrollView>
-              </>
-            )}
+                    ) : null}
+                    {toolsMenu === "quickPrompts" &&
+                    quickPromptLibrary.status === "ready" &&
+                    quickPromptLibrary.prompts.length === 0 ? (
+                      <Text style={styles.emptyMenu}>
+                        {t("emptyQuickPrompts")}
+                      </Text>
+                    ) : null}
+                    {toolsMenu === "quickPrompts" &&
+                    quickPromptLibrary.status === "ready" &&
+                    quickPromptLibrary.prompts.length > 0 &&
+                    filteredQuickPrompts.length === 0 ? (
+                      <Text style={styles.emptyMenu}>
+                        {t("noQuickPromptResults")}
+                      </Text>
+                    ) : null}
+                    {toolsMenu !== "quickPrompts" &&
+                    model.composerOptionsLoadStatus === "loading" ? (
+                      <ActivityIndicator
+                        color={theme.color.accent}
+                        size="small"
+                        style={styles.loading}
+                      />
+                    ) : null}
+                  </ScrollView>
+                </>
+              )}
+            </Pressable>
           </Pressable>
-        </Pressable>
+        </MobileKeyboardAvoidingView>
       </Modal>
     </View>
   );
@@ -463,11 +476,9 @@ function createStyles(theme: NativeTheme) {
       fontSize: 11
     },
     backdrop: {
-      bottom: 0,
-      left: 0,
-      position: "absolute",
-      right: 0,
-      top: 0
+      flex: 1,
+      justifyContent: "flex-end",
+      paddingBottom: 96
     },
     chevron: {
       color: theme.color.muted,
@@ -547,18 +558,16 @@ function createStyles(theme: NativeTheme) {
       borderColor: theme.color.border,
       borderRadius: 24,
       borderWidth: StyleSheet.hairlineWidth,
-      bottom: 96,
-      left: theme.space.medium,
-      maxHeight: 560,
+      marginHorizontal: theme.space.medium,
+      maxHeight: "70%",
       padding: theme.space.small,
-      position: "absolute",
-      right: theme.space.medium,
       shadowColor: theme.color.text,
       shadowOffset: { height: 10, width: 0 },
       shadowOpacity: 0.16,
       shadowRadius: 24,
       elevation: 12
     },
+    modalRoot: { flex: 1 },
     menuBackButton: {
       height: 40,
       width: 40

--- a/apps/mobile/src/components/MobileConversationsView.tsx
+++ b/apps/mobile/src/components/MobileConversationsView.tsx
@@ -18,6 +18,10 @@ import {
 } from "react-native";
 import { t } from "../i18n";
 import type { WorkspaceActivitySnapshot } from "../services/workspaceActivityService";
+import {
+  MobileKeyboardAvoidingView,
+  mobileKeyboardDismissMode
+} from "./MobileKeyboardAvoidingView";
 import { MobileComputerGlyph, MobileFolderGlyph } from "./MobileLocationGlyphs";
 
 type ConversationDialog =
@@ -102,7 +106,7 @@ export function MobileConversationsView({
   };
 
   return (
-    <View style={styles.root}>
+    <MobileKeyboardAvoidingView style={styles.root}>
       <View style={styles.header}>
         <View style={styles.headerButtonSlot}>
           <NativeIconButton
@@ -160,6 +164,8 @@ export function MobileConversationsView({
 
       <ScrollView
         contentContainerStyle={styles.list}
+        keyboardDismissMode={mobileKeyboardDismissMode}
+        keyboardShouldPersistTaps="handled"
         style={styles.sessionScroller}
       >
         {model.railStatus === "loading" && model.railSections.length === 0 ? (
@@ -438,7 +444,7 @@ export function MobileConversationsView({
           </View>
         </NativeSheet>
       ) : null}
-    </View>
+    </MobileKeyboardAvoidingView>
   );
 }
 

--- a/apps/mobile/src/components/MobileKeyboardAvoidingView.test.tsx
+++ b/apps/mobile/src/components/MobileKeyboardAvoidingView.test.tsx
@@ -1,0 +1,44 @@
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { KeyboardAvoidingView, Platform, Text } from "react-native";
+import {
+  MobileKeyboardAvoidingView,
+  mobileKeyboardDismissMode
+} from "./MobileKeyboardAvoidingView";
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ bottom: 12, left: 0, right: 0, top: 24 })
+}));
+
+test("uses the platform keyboard layout and dismissal behavior", () => {
+  let renderer: ReactTestRenderer;
+  act(() => {
+    renderer = create(
+      <MobileKeyboardAvoidingView>
+        <Text>content</Text>
+      </MobileKeyboardAvoidingView>
+    );
+  });
+
+  const avoidingView = renderer!.root.findByType(KeyboardAvoidingView);
+  expect(avoidingView.props.behavior).toBe(
+    Platform.OS === "ios" ? "padding" : "height"
+  );
+  expect(avoidingView.props.keyboardVerticalOffset).toBe(24);
+  expect(mobileKeyboardDismissMode).toBe(
+    Platform.OS === "ios" ? "interactive" : "on-drag"
+  );
+});
+
+test("allows full-screen overlays to override the safe-area offset", () => {
+  let renderer: ReactTestRenderer;
+  act(() => {
+    renderer = create(
+      <MobileKeyboardAvoidingView keyboardVerticalOffset={0}>
+        <Text>content</Text>
+      </MobileKeyboardAvoidingView>
+    );
+  });
+
+  const avoidingView = renderer!.root.findByType(KeyboardAvoidingView);
+  expect(avoidingView.props.keyboardVerticalOffset).toBe(0);
+});

--- a/apps/mobile/src/components/MobileKeyboardAvoidingView.tsx
+++ b/apps/mobile/src/components/MobileKeyboardAvoidingView.tsx
@@ -1,0 +1,28 @@
+import type { PropsWithChildren } from "react";
+import {
+  KeyboardAvoidingView,
+  type KeyboardAvoidingViewProps,
+  Platform
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+export const mobileKeyboardDismissMode =
+  Platform.OS === "ios" ? "interactive" : "on-drag";
+
+export function MobileKeyboardAvoidingView({
+  children,
+  keyboardVerticalOffset,
+  ...props
+}: PropsWithChildren<Omit<KeyboardAvoidingViewProps, "behavior">>) {
+  const insets = useSafeAreaInsets();
+
+  return (
+    <KeyboardAvoidingView
+      {...props}
+      behavior={Platform.OS === "ios" ? "padding" : "height"}
+      keyboardVerticalOffset={keyboardVerticalOffset ?? insets.top}
+    >
+      {children}
+    </KeyboardAvoidingView>
+  );
+}

--- a/apps/mobile/src/dev/NativeComponentGallery.tsx
+++ b/apps/mobile/src/dev/NativeComponentGallery.tsx
@@ -7,7 +7,7 @@ import {
   useNativeTheme
 } from "@tutti-os/ui-system/native";
 import { useState, type ReactNode } from "react";
-import { ScrollView, StyleSheet, Text, View } from "react-native";
+import { ScrollView, StyleSheet, Text, TextInput, View } from "react-native";
 import { t } from "../i18n";
 
 /** Native-only visual review surface for UI System primitive promotion. */
@@ -120,6 +120,11 @@ export function NativeComponentGallery({ onClose }: { onClose(): void }) {
         <View style={styles.sheetContent}>
           <Text style={styles.sheetTitle}>{t("nativeGallerySheet")}</Text>
           <Text style={styles.description}>{t("nativeGallerySheetBody")}</Text>
+          <TextInput
+            placeholder={t("messageHint")}
+            placeholderTextColor={theme.color.muted}
+            style={styles.sheetInput}
+          />
           <NativeButton
             label={t("cancel")}
             onPress={() => setSheetOpen(false)}
@@ -180,6 +185,16 @@ function createStyles(theme: NativeTheme) {
     sheetContent: {
       gap: theme.space.medium,
       padding: theme.space.large
+    },
+    sheetInput: {
+      backgroundColor: theme.color.panel,
+      borderColor: theme.color.border,
+      borderRadius: theme.radius.medium,
+      borderWidth: StyleSheet.hairlineWidth,
+      color: theme.color.text,
+      fontSize: 16,
+      minHeight: 48,
+      paddingHorizontal: theme.space.medium
     },
     sheetTitle: {
       color: theme.color.text,

--- a/apps/mobile/src/screens/ConversationScreenView.tsx
+++ b/apps/mobile/src/screens/ConversationScreenView.tsx
@@ -13,9 +13,7 @@ import {
 } from "@tutti-os/ui-system/native";
 import { useEffect, useRef, useState } from "react";
 import {
-  KeyboardAvoidingView,
   Linking,
-  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -25,6 +23,10 @@ import {
 import { MobileInteractionCard } from "../components/MobileConversationRows";
 import { MobileComposerDock } from "../components/MobileComposerDock";
 import { MobileConversationTimeline } from "../components/MobileConversationTimeline";
+import {
+  MobileKeyboardAvoidingView,
+  mobileKeyboardDismissMode
+} from "../components/MobileKeyboardAvoidingView";
 import {
   MobileComputerGlyph,
   MobileFolderGlyph
@@ -126,10 +128,7 @@ export function ConversationScreenView({
   };
 
   return (
-    <KeyboardAvoidingView
-      behavior={Platform.OS === "ios" ? "padding" : undefined}
-      style={styles.root}
-    >
+    <MobileKeyboardAvoidingView style={styles.root}>
       <View style={styles.conversationHeader}>
         <View style={styles.headerButtonSlot}>
           <NativeIconButton
@@ -178,7 +177,7 @@ export function ConversationScreenView({
         <View style={styles.conversationBody}>
           <ScrollView
             contentContainerStyle={styles.messageList}
-            keyboardDismissMode="interactive"
+            keyboardDismissMode={mobileKeyboardDismissMode}
             keyboardShouldPersistTaps="handled"
             maintainVisibleContentPosition={{ minIndexForVisible: 0 }}
             onContentSizeChange={() => {
@@ -312,7 +311,7 @@ export function ConversationScreenView({
           onUpdate={onUpdateComposerSettings}
         />
       ) : null}
-    </KeyboardAvoidingView>
+    </MobileKeyboardAvoidingView>
   );
 }
 
@@ -333,7 +332,7 @@ function createStyles(theme: NativeTheme) {
       paddingHorizontal: theme.space.medium,
       paddingVertical: theme.space.small
     },
-    conversationBody: { flex: 1, position: "relative" },
+    conversationBody: { flex: 1, minHeight: 0, position: "relative" },
     conversationTitle: {
       backgroundColor: theme.color.panelRaised,
       borderColor: theme.color.border,

--- a/apps/mobile/src/screens/DeviceScreenView.tsx
+++ b/apps/mobile/src/screens/DeviceScreenView.tsx
@@ -10,6 +10,10 @@ import {
   View
 } from "react-native";
 import { type NativeTheme, useNativeTheme } from "@tutti-os/ui-system/native";
+import {
+  MobileKeyboardAvoidingView,
+  mobileKeyboardDismissMode
+} from "../components/MobileKeyboardAvoidingView";
 import { PrimaryButton } from "../components/PrimaryButton";
 import { t } from "../i18n";
 import type { DeviceSnapshot } from "../services/deviceService";
@@ -70,7 +74,7 @@ export function DeviceScreenView({
                 : null;
 
   return (
-    <View style={styles.root}>
+    <MobileKeyboardAvoidingView style={styles.root}>
       <View style={styles.header}>
         <View>
           <Text style={styles.eyebrow}>{accountName || t("welcome")}</Text>
@@ -85,6 +89,8 @@ export function DeviceScreenView({
       </View>
       <ScrollView
         contentContainerStyle={styles.content}
+        keyboardDismissMode={mobileKeyboardDismissMode}
+        keyboardShouldPersistTaps="handled"
         refreshControl={
           <RefreshControl
             onRefresh={onRefresh}
@@ -194,7 +200,7 @@ export function DeviceScreenView({
           />
         )}
       </View>
-    </View>
+    </MobileKeyboardAvoidingView>
   );
 }
 

--- a/apps/mobile/src/screens/LoginScreenView.tsx
+++ b/apps/mobile/src/screens/LoginScreenView.tsx
@@ -1,12 +1,9 @@
-import {
-  KeyboardAvoidingView,
-  Platform,
-  StyleSheet,
-  Text,
-  TextInput,
-  View
-} from "react-native";
+import { ScrollView, StyleSheet, Text, TextInput, View } from "react-native";
 import { type NativeTheme, useNativeTheme } from "@tutti-os/ui-system/native";
+import {
+  MobileKeyboardAvoidingView,
+  mobileKeyboardDismissMode
+} from "../components/MobileKeyboardAvoidingView";
 import { t } from "../i18n";
 import type { LoginSnapshot } from "../services/loginService";
 import { PrimaryButton } from "../components/PrimaryButton";
@@ -35,68 +32,73 @@ export function LoginScreenView({
       : code.trim().length < 4;
 
   return (
-    <KeyboardAvoidingView
-      behavior={Platform.OS === "ios" ? "padding" : undefined}
-      style={styles.root}
-    >
-      <View style={styles.brand}>
-        <View style={styles.mark}>
-          <Text style={styles.markText}>T</Text>
-        </View>
-        <Text style={styles.appName}>{t("appName")}</Text>
-      </View>
-      <View style={styles.content}>
-        <Text style={styles.eyebrow}>{t("welcome")}</Text>
-        <Text style={styles.title}>{t("loginTitle")}</Text>
-        <Text style={styles.subtitle}>{t("loginSubtitle")}</Text>
-
-        <View style={styles.form}>
-          <PrimaryButton
-            disabled={pending !== null}
-            label={t("githubLoginAction")}
-            loading={pending === "github"}
-            onPress={onSubmitGitHub}
-          />
-          <View style={styles.alternative}>
-            <View style={styles.divider} />
-            <Text style={styles.alternativeText}>{t("loginAlternative")}</Text>
-            <View style={styles.divider} />
+    <MobileKeyboardAvoidingView style={styles.root}>
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        keyboardDismissMode={mobileKeyboardDismissMode}
+        keyboardShouldPersistTaps="handled"
+      >
+        <View style={styles.brand}>
+          <View style={styles.mark}>
+            <Text style={styles.markText}>T</Text>
           </View>
-          <Text style={styles.label}>
-            {t(step === "email" ? "email" : "code")}
-          </Text>
-          <TextInput
-            autoCapitalize="none"
-            autoComplete={step === "email" ? "email" : "one-time-code"}
-            editable={pending === null}
-            inputMode={step === "email" ? "email" : "numeric"}
-            keyboardType={step === "email" ? "email-address" : "number-pad"}
-            onChangeText={step === "email" ? onEmailChange : onCodeChange}
-            onSubmitEditing={() => {
-              if (!disabled && pending === null) {
-                onSubmitEmail();
-              }
-            }}
-            placeholder={t(step === "email" ? "emailHint" : "codeHint")}
-            placeholderTextColor={theme.color.muted}
-            style={styles.input}
-            value={step === "email" ? email : code}
-          />
-          {step === "code" ? (
-            <Text style={styles.hint}>{t("emailSent")}</Text>
-          ) : null}
-          {errorCode === "request_failed" ? (
-            <Text style={styles.error}>{t("genericError")}</Text>
-          ) : null}
-          <PrimaryButton
-            disabled={disabled || pending !== null}
-            label={t(step === "email" ? "loginAction" : "verifyAction")}
-            loading={pending === "email"}
-            onPress={onSubmitEmail}
-          />
+          <Text style={styles.appName}>{t("appName")}</Text>
         </View>
-      </View>
-    </KeyboardAvoidingView>
+        <View style={styles.content}>
+          <Text style={styles.eyebrow}>{t("welcome")}</Text>
+          <Text style={styles.title}>{t("loginTitle")}</Text>
+          <Text style={styles.subtitle}>{t("loginSubtitle")}</Text>
+
+          <View style={styles.form}>
+            <PrimaryButton
+              disabled={pending !== null}
+              label={t("githubLoginAction")}
+              loading={pending === "github"}
+              onPress={onSubmitGitHub}
+            />
+            <View style={styles.alternative}>
+              <View style={styles.divider} />
+              <Text style={styles.alternativeText}>
+                {t("loginAlternative")}
+              </Text>
+              <View style={styles.divider} />
+            </View>
+            <Text style={styles.label}>
+              {t(step === "email" ? "email" : "code")}
+            </Text>
+            <TextInput
+              autoCapitalize="none"
+              autoComplete={step === "email" ? "email" : "one-time-code"}
+              editable={pending === null}
+              inputMode={step === "email" ? "email" : "numeric"}
+              keyboardType={step === "email" ? "email-address" : "number-pad"}
+              onChangeText={step === "email" ? onEmailChange : onCodeChange}
+              onSubmitEditing={() => {
+                if (!disabled && pending === null) {
+                  onSubmitEmail();
+                }
+              }}
+              placeholder={t(step === "email" ? "emailHint" : "codeHint")}
+              placeholderTextColor={theme.color.muted}
+              style={styles.input}
+              value={step === "email" ? email : code}
+            />
+            {step === "code" ? (
+              <Text style={styles.hint}>{t("emailSent")}</Text>
+            ) : null}
+            {errorCode === "request_failed" ? (
+              <Text style={styles.error}>{t("genericError")}</Text>
+            ) : null}
+            <PrimaryButton
+              disabled={disabled || pending !== null}
+              label={t(step === "email" ? "loginAction" : "verifyAction")}
+              loading={pending === "email"}
+              onPress={onSubmitEmail}
+            />
+          </View>
+        </View>
+      </ScrollView>
+    </MobileKeyboardAvoidingView>
   );
 }
 
@@ -188,6 +190,7 @@ function createStyles(theme: NativeTheme) {
       backgroundColor: theme.color.background,
       flex: 1
     },
+    scrollContent: { flexGrow: 1 },
     subtitle: {
       color: theme.color.textSecondary,
       fontSize: 15,

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -261,6 +261,15 @@ screen composition and product-specific interaction.
 - `MobileUIProviders` owns the gesture root, safe-area provider, Bottom Sheet
   modal provider, and RN Primitives portal host. Do not mount duplicate roots
   inside screens.
+- Every screen with editable content uses the app-owned
+  `MobileKeyboardAvoidingView`: iOS applies keyboard padding, Android reduces
+  the available height, and Android keeps Activity `adjustResize` enabled for
+  edge-to-edge compatibility. The wrapper includes the top safe-area inset as
+  its screen-to-content offset; full-screen modal windows override that offset
+  to zero and bound keyboard-editable panels relative to the remaining height
+  instead of a fixed screen height. Scrollable content uses interactive
+  keyboard dismissal on iOS and on-drag dismissal on Android. Do not store
+  keyboard height in a service or add per-screen native keyboard listeners.
 - In a debug build, open the React Native developer menu and choose “Native UI
   gallery” to review the shared Native primitives on the actual renderer.
 - React Native Reusables is a source-copy starting point for a Native primitive;
@@ -270,9 +279,10 @@ screen composition and product-specific interaction.
   and dynamic-height sheets; wrap it behind a UI System Native component when
   it becomes a reusable product pattern. The shared compact `NativeSheet` uses
   React Native's window-level `Modal` instead, so its controlled open state does
-  not pass through `@gorhom/portal`. Callers provide its localized accessible
-  close label and may set one fixed height; multi-snap behavior remains outside
-  the compact primitive.
+  not pass through `@gorhom/portal`. It owns keyboard avoidance inside that
+  separate window; callers provide its localized accessible close label and may
+  set one fixed height. Multi-snap behavior remains outside the compact
+  primitive.
 - Agent message Markdown is rendered natively with
   `react-native-enriched-markdown`; it consumes the existing AgentGUI
   conversation VM and maps every color, radius, and spacing decision back to

--- a/packages/ui/system/src/metadata/components.json
+++ b/packages/ui/system/src/metadata/components.json
@@ -3504,7 +3504,7 @@
       "status": "experimental",
       "source": "src/native/sheet.tsx",
       "propsType": "NativeSheetProps",
-      "description": "Controlled compact sheet backed by React Native Modal with a token-backed scrim and panel.",
+      "description": "Controlled keyboard-avoiding compact sheet backed by React Native Modal with a token-backed scrim and panel.",
       "useCases": ["Row actions", "Confirmation flows", "Compact forms"],
       "migrationHints": [
         "Provide a localized closeAccessibilityLabel and replace a single snapPoints value with height; keep multi-snap sheets app-owned."

--- a/packages/ui/system/src/native/sheet.spec.tsx
+++ b/packages/ui/system/src/native/sheet.spec.tsx
@@ -4,12 +4,33 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NativeSheet } from "./sheet";
 
 const nativeModal = vi.hoisted(() => ({
+  keyboardBehavior: null as string | null,
+  keyboardVerticalOffset: null as number | null,
   onAccessibilityEscape: null as (() => void) | null,
   onRequestClose: null as (() => void) | null,
   panelStyle: null as unknown
 }));
 
 vi.mock("react-native", () => ({
+  KeyboardAvoidingView: ({
+    accessible,
+    behavior,
+    children,
+    keyboardVerticalOffset,
+    onAccessibilityEscape
+  }: {
+    accessible?: boolean;
+    behavior?: string;
+    children: ReactNode;
+    keyboardVerticalOffset?: number;
+    onAccessibilityEscape?(): void;
+  }) => {
+    nativeModal.keyboardBehavior = behavior ?? null;
+    nativeModal.keyboardVerticalOffset = keyboardVerticalOffset ?? null;
+    nativeModal.onAccessibilityEscape =
+      onAccessibilityEscape ?? nativeModal.onAccessibilityEscape;
+    return <div data-accessible={String(accessible)}>{children}</div>;
+  },
   Modal: ({
     children,
     onRequestClose,
@@ -22,6 +43,7 @@ vi.mock("react-native", () => ({
     nativeModal.onRequestClose = onRequestClose;
     return visible ? <div>{children}</div> : null;
   },
+  Platform: { OS: "android" },
   Pressable: ({
     accessibilityLabel,
     accessibilityRole,
@@ -54,20 +76,7 @@ vi.mock("react-native", () => ({
       </div>
     );
   },
-  StyleSheet: { create: (styles: unknown) => styles },
-  View: ({
-    accessible,
-    children,
-    onAccessibilityEscape
-  }: {
-    accessible?: boolean;
-    children: ReactNode;
-    onAccessibilityEscape?(): void;
-  }) => {
-    nativeModal.onAccessibilityEscape =
-      onAccessibilityEscape ?? nativeModal.onAccessibilityEscape;
-    return <div data-accessible={String(accessible)}>{children}</div>;
-  }
+  StyleSheet: { create: (styles: unknown) => styles }
 }));
 
 vi.mock("./theme-provider", () => ({
@@ -84,6 +93,8 @@ vi.mock("./theme-provider", () => ({
 
 describe("NativeSheet", () => {
   beforeEach(() => {
+    nativeModal.keyboardBehavior = null;
+    nativeModal.keyboardVerticalOffset = null;
     nativeModal.onAccessibilityEscape = null;
     nativeModal.onRequestClose = null;
     nativeModal.panelStyle = null;
@@ -175,5 +186,20 @@ describe("NativeSheet", () => {
     expect(nativeModal.panelStyle).toEqual(
       expect.arrayContaining([{ height: "50%" }])
     );
+  });
+
+  it("keeps the panel above the Android keyboard", () => {
+    render(
+      <NativeSheet
+        closeAccessibilityLabel="Close sheet"
+        onOpenChange={() => undefined}
+        open
+      >
+        content
+      </NativeSheet>
+    );
+
+    expect(nativeModal.keyboardBehavior).toBe("height");
+    expect(nativeModal.keyboardVerticalOffset).toBe(0);
   });
 });

--- a/packages/ui/system/src/native/sheet.tsx
+++ b/packages/ui/system/src/native/sheet.tsx
@@ -1,5 +1,11 @@
 import type { ReactNode } from "react";
-import { Modal, Pressable, StyleSheet, View } from "react-native";
+import {
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  StyleSheet
+} from "react-native";
 import { useNativeTheme } from "./theme-provider";
 
 export interface NativeSheetProps {
@@ -36,8 +42,10 @@ export function NativeSheet({
       transparent
       visible={open}
     >
-      <View
+      <KeyboardAvoidingView
         accessible={false}
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+        keyboardVerticalOffset={0}
         onAccessibilityEscape={dismiss}
         style={styles.backdrop}
       >
@@ -57,7 +65,7 @@ export function NativeSheet({
         >
           {children}
         </Pressable>
-      </View>
+      </KeyboardAvoidingView>
     </Modal>
   );
 }

--- a/packages/ui/system/ui-system.md
+++ b/packages/ui/system/ui-system.md
@@ -328,11 +328,13 @@ component implementation.
 `NativeSheet` uses React Native's window-level `Modal` for its controlled
 overlay and does not require a portal provider. It owns the semantic scrim,
 bottom-aligned panel, system-back dismissal, screen-reader escape gesture,
-accessible backdrop dismissal, and optional fixed `height`. Callers must supply
-the localized `closeAccessibilityLabel`; one fixed height replaces the former
+accessible backdrop dismissal, keyboard avoidance, and optional fixed `height`.
+Its window-level keyboard container uses padding on iOS and height reduction on
+Android, with no caller-supplied keyboard height. Callers must supply the
+localized `closeAccessibilityLabel`; one fixed height replaces the former
 single-value `snapPoints` usage. Keep `@gorhom/bottom-sheet` app-owned for
-genuinely complex gesture, keyboard, or multi-snap-point sheets rather than
-routing the shared compact sheet through its React 19-incompatible portal.
+genuinely complex gesture, animated keyboard, or multi-snap-point sheets rather
+than routing the shared compact sheet through its React 19-incompatible portal.
 
 For cross-surface stacking, use shared semantic `z-index` tokens instead of
 local magic numbers. Current global layer tokens live in


### PR DESCRIPTION
## Summary

- add a shared mobile keyboard-avoidance wrapper and apply it to editable screens
- account for safe-area offsets on edge-to-edge Android layouts and support drag-to-dismiss behavior
- keep composer tools and shared native sheets within the keyboard-reduced viewport
- document the mobile and UI System keyboard-handling conventions

## Root cause

Editable screens were laid out against the full viewport without a consistent keyboard-avoidance boundary. On edge-to-edge Android, the screen-space keyboard coordinates also differed from the safe-area content origin, leaving the composer partially covered. The quick-prompt overlay additionally used a fixed-height, absolutely positioned panel, so its search field could move above the screen when the keyboard opened.

## User impact

Inputs now remain visible while typing across the conversation composer, conversation search, pairing-code entry, login, quick prompts, and shared native sheets. Scrollable content can dismiss the keyboard with the platform-appropriate gesture.

## Validation

- physical vivo V2507A running Android 16: verified composer input, real typing, drag dismissal, conversation search, pairing-code input, and quick-prompt search
- standalone release build installed and launched without Metro; account and pairing data remained intact
- `pnpm --filter @tutti-os/mobile test` — 22 suites / 132 tests passed
- `pnpm --filter @tutti-os/mobile typecheck`
- `pnpm check:changed -- --push-ready` — 12 lanes passed
- `./gradlew app:assembleRelease`
