### PR TITLE
fix(agent-gui): preserve message whitespace

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -86,6 +86,11 @@ Realtime events reduce latency but are not automatically complete truth:
   truth, reconnects, Turn, Interaction, and state changes trigger authoritative
   reconciliation
 - event publication or observer failure cannot roll back a committed canonical transaction
+- message projections preserve the original textual content, including leading
+  and trailing whitespace; trimmed or whitespace-collapsed copies may decide
+  emptiness, synthetic-control suppression, or duplicate identity, but must not
+  replace the body passed to renderers. Markdown renderers continue to own
+  soft-break presentation.
 
 ### 1.6 Identity and correlation are explicit
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.spec.ts
@@ -1591,7 +1591,7 @@ describe("agentGuiConversationModel", () => {
 
     expect(rows.map((row) => [row.role, row.content])).toEqual([
       ["assistant", "Hi"],
-      ["assistant", "there."]
+      ["assistant", " there."]
     ]);
   });
 

--- a/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.spec.ts
@@ -51,6 +51,37 @@ describe("projectWorkspaceAgentMessagesToConversationVM", () => {
     ).toBeNull();
   });
 
+  it("preserves message whitespace through the Mobile conversation projection", () => {
+    const selectedSession = session();
+    const selectedMessage = message({
+      messageId: "streaming-whitespace",
+      version: 1,
+      role: "assistant",
+      kind: "text",
+      payload: { text: "\nHello  \n" }
+    });
+    const activitySnapshot: AgentActivitySnapshot = {
+      workspaceId: "workspace-1",
+      sessions: [selectedSession],
+      presences: [],
+      sessionMessagesById: {
+        [selectedSession.agentSessionId]: [selectedMessage]
+      }
+    };
+
+    const conversation = projectAgentActivitySessionToConversationVM({
+      activitySnapshot,
+      agentSessionId: selectedSession.agentSessionId
+    });
+    const assistantRow = conversation?.rows.find(
+      (row) => row.kind === "message" && row.speaker === "assistant"
+    );
+
+    expect(
+      assistantRow?.kind === "message" ? assistantRow.messages[0]?.body : null
+    ).toBe("\nHello  \n");
+  });
+
   it("filters supplied Turns to the selected Session", () => {
     const selectedSession = session();
     const selectedMessage = message({

--- a/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.ts
@@ -545,12 +545,12 @@ function toolCallItemType(status: string | undefined): string {
 function messageText(message: AgentActivityMessage): string {
   const payload = normalizedPayload(message.payload);
   const title = messagePayloadString(message, "title");
-  return firstNonEmptyString(
-    stringValue(payload.displayPrompt),
-    stringValue(payload.text),
-    stringValue(payload.content),
-    stringValue(payload.message),
-    stringValue(payload.body),
+  return firstNonEmptyMessageText(
+    rawNonEmptyString(payload.displayPrompt),
+    rawNonEmptyString(payload.text),
+    rawNonEmptyString(payload.content),
+    rawNonEmptyString(payload.message),
+    rawNonEmptyString(payload.body),
     title
   );
 }
@@ -615,6 +615,21 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function stringValue(value: unknown): string {
   return typeof value === "string" && value.trim() ? value.trim() : "";
+}
+
+function rawNonEmptyString(value: unknown): string {
+  return typeof value === "string" && value.trim() ? value : "";
+}
+
+function firstNonEmptyMessageText(
+  ...values: Array<string | undefined | null>
+): string {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) {
+      return value;
+    }
+  }
+  return "";
 }
 
 function firstNonEmptyString(

--- a/packages/agent/gui/shared/workspaceAgentTimelineMessageHelpers.spec.ts
+++ b/packages/agent/gui/shared/workspaceAgentTimelineMessageHelpers.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { messageBody } from "./workspaceAgentTimelineMessageHelpers";
+import type { WorkspaceAgentActivityTimelineItem } from "./workspaceAgentTimelineTypes";
+
+describe("messageBody", () => {
+  it.each([
+    ["payload content", { payload: { content: "\nHello\n" } }],
+    ["top-level content", { content: "\nHello\n" }],
+    ["payload text", { payload: { text: "\nHello\n" } }]
+  ])("preserves whitespace from %s", (_label, fields) => {
+    expect(messageBody(item(fields))).toBe("\nHello\n");
+  });
+
+  it("uses trimming only to reject whitespace-only content", () => {
+    expect(
+      messageBody(
+        item({
+          content: "fallback",
+          payload: { content: " \n\t", text: "unused" }
+        })
+      )
+    ).toBe("fallback");
+    expect(messageBody(item({ payload: { text: " \n\t" } }))).toBe("");
+  });
+
+  it("still suppresses synthetic control messages surrounded by whitespace", () => {
+    expect(
+      messageBody(
+        item({ payload: { content: "\n[Request interrupted by user]\n" } })
+      )
+    ).toBe("");
+  });
+});
+
+function item(
+  fields: Partial<WorkspaceAgentActivityTimelineItem>
+): WorkspaceAgentActivityTimelineItem {
+  return {
+    actorId: "agent",
+    actorType: "agent",
+    agentSessionId: "session-1",
+    eventId: "event-1",
+    id: 1,
+    itemType: "message",
+    ...fields
+  };
+}

--- a/packages/agent/gui/shared/workspaceAgentTimelineMessageHelpers.ts
+++ b/packages/agent/gui/shared/workspaceAgentTimelineMessageHelpers.ts
@@ -32,12 +32,13 @@ export function messageRole(
 export function messageBody(item: WorkspaceAgentActivityTimelineItem): string {
   const payloadContent = item.payload?.content;
   if (typeof payloadContent === "string" && payloadContent.trim()) {
-    const content = payloadContent.trim();
-    return isWorkspaceAgentSyntheticControlMessage(content) ? "" : content;
+    return isWorkspaceAgentSyntheticControlMessage(payloadContent)
+      ? ""
+      : payloadContent;
   }
 
-  const content = item.content?.trim();
-  if (content) {
+  const content = item.content;
+  if (content?.trim()) {
     return isWorkspaceAgentSyntheticControlMessage(content) ? "" : content;
   }
 
@@ -45,8 +46,10 @@ export function messageBody(item: WorkspaceAgentActivityTimelineItem): string {
   if (typeof payloadText !== "string") {
     return "";
   }
-  const text = payloadText.trim();
-  return isWorkspaceAgentSyntheticControlMessage(text) ? "" : text;
+  return payloadText.trim() &&
+    !isWorkspaceAgentSyntheticControlMessage(payloadText)
+    ? payloadText
+    : "";
 }
 
 export function thinkingStatusKind(


### PR DESCRIPTION
## Summary

- preserve leading and trailing whitespace when projecting AgentGUI message bodies
- preserve raw message text before the public conversation projection builds timeline items
- keep trimming only for emptiness checks and synthetic control-message detection
- add regression coverage for payload content, top-level content, payload text, and the Mobile conversation entrypoint
- document the whitespace-preservation invariant at the AgentGUI boundary

## Root cause

The shared AgentGUI timeline and conversation projections called `trim()` on message content before passing it to renderers. During streaming, this removed trailing Markdown line-break whitespace and newline characters. The final canonical message later replaced the optimistic projection, which made Desktop appear to correct all line breaks only when the turn completed. Mobile consumed the same shared projection through its public conversation entrypoint.

## Impact

Streaming and settled message bodies now reach Desktop and Mobile renderers byte-for-byte, while whitespace-only messages and synthetic control messages remain suppressed.

## Validation

- `pnpm --filter @tutti-os/agent-gui test` (313 files, 2630 tests)
- targeted conversation projection regressions (2 files, 35 tests)
- `pnpm check:changed` (11 lanes)
- pre-push `pnpm check:changed -- --push-ready` (12 lanes)
