### PR TITLE
fix(mobile): avoid iOS lifecycle bridge crash

### DIFF
--- a/apps/mobile/ios/TuttiMobile/AppLifecycleModule.swift
+++ b/apps/mobile/ios/TuttiMobile/AppLifecycleModule.swift
@@ -15,12 +15,14 @@ final class AppLifecycleModule: RCTEventEmitter {
   }
 
   @objc
-  func isForeground() -> Bool {
+  func isForeground() -> NSNumber {
     if Thread.isMainThread {
-      return UIApplication.shared.applicationState != .background
+      return NSNumber(
+        value: UIApplication.shared.applicationState != .background
+      )
     }
     return DispatchQueue.main.sync {
-      UIApplication.shared.applicationState != .background
+      NSNumber(value: UIApplication.shared.applicationState != .background)
     }
   }
 

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -157,6 +157,7 @@ Android app login, native bridge, secure identity, and mobile transport diagnost
 - [Browser login returns to the App but remains signed out](./mobile.md#browser-login-returns-to-the-app-but-remains-signed-out)
 - [Android DeviceLink opens a session and then repeatedly restarts](./mobile.md#android-devicelink-opens-a-session-and-then-repeatedly-restarts)
 - [Mobile stays connected after a long lock-screen interval but sends fail](./mobile.md#mobile-stays-connected-after-a-long-lock-screen-interval-but-sends-fail)
+- [iOS App crashes after loading the JavaScript bundle](./mobile.md#ios-app-crashes-after-loading-the-javascript-bundle)
 - [iOS pod install intermittently reports pathname contains null byte](./mobile.md#ios-pod-install-intermittently-reports-pathname-contains-null-byte)
 - [Mobile Jest discovers tests inside iOS Pods](./mobile.md#mobile-jest-discovers-tests-inside-ios-pods)
 - [React Native Pressable rows stack their children vertically](./mobile.md#react-native-pressable-rows-stack-their-children-vertically)

--- a/docs/conventions/troubleshooting/mobile.md
+++ b/docs/conventions/troubleshooting/mobile.md
@@ -250,6 +250,31 @@ dev.tutti.mobile` and inspect a narrow logcat window for the Go fatal message.
   `apps/mobile/src/services/mobileApplicationService.ts`,
   `apps/mobile/android/app/src/main/java/dev/tutti/mobile/DeviceLinkModule.kt`
 
+## iOS App crashes after loading the JavaScript bundle
+
+- **Symptom:** A physical iOS device downloads or evaluates the React Native
+  bundle, then the App exits with `SIGSEGV`. The crash report points at
+  `objc_retain` or `objc_storeStrong` below
+  `ObjCTurboModule::performMethodInvocation` on the JavaScript thread.
+- **Quick checks:** Capture the App console and the latest `.ips` crash report.
+  If the last log is JavaScript bundle evaluation and the faulting stack is a
+  synchronous Objective-C TurboModule invocation, inspect every blocking
+  synchronous Swift export used during startup before investigating Metro or
+  DeviceLink.
+- **Root cause:** React Native's Objective-C interoperability path expects an
+  object from a blocking synchronous method. Exporting a Swift method with a
+  primitive `Bool` return can leave the invocation result buffer shaped like an
+  object pointer; retaining that value then causes an invalid-address crash.
+- **Fix:** Return `NSNumber` from the Swift export. React Native converts it to
+  a JavaScript boolean, so the TypeScript contract remains `boolean`.
+- **Validation:** Build and sign the physical-device target, install it, launch
+  it with the device console attached, and keep the process alive beyond the
+  previous post-bundle crash window. Confirm the initial lifecycle state still
+  arrives as a JavaScript boolean.
+- **References:** `apps/mobile/ios/TuttiMobile/AppLifecycleModule.swift`,
+  `apps/mobile/ios/TuttiMobile/MobileNativeModules.m`,
+  `apps/mobile/src/native/appLifecyclePort.ts`
+
 ## iOS pod install intermittently reports pathname contains null byte
 
 - **Symptom:** `pnpm --filter @tutti-os/mobile ios:pods` downloads and installs


### PR DESCRIPTION
## Summary

- return an Objective-C object from the blocking synchronous iOS lifecycle bridge
- preserve the JavaScript `boolean` lifecycle contract through `NSNumber`
- document the physical-device crash signature and diagnosis path

## Root cause

The Swift `isForeground` export returned a primitive `Bool`. React Native 0.86's Objective-C TurboModule interoperability path handled the synchronous return buffer as an object and attempted to retain it, causing a `SIGSEGV` in `objc_retain`/`objc_storeStrong` immediately after JavaScript bundle evaluation.

## User impact

The iOS app no longer exits after loading its JavaScript bundle on a physical device.

## Validation

- built and signed the Debug iPhoneOS target with Xcode
- installed and launched the app on a physical iPhone
- confirmed the process remained alive beyond the previous crash window and no new crash report was generated
- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready`
