### PR TITLE
fix(tutti-mode): rearm terminal checkpoint after rework

### DIFF
--- a/docs/architecture/workspace-workflows.md
+++ b/docs/architecture/workspace-workflows.md
@@ -562,7 +562,16 @@ When every task is terminal and every terminal Run has its settlement
 checkpoint, the execution appends one ordered `all_tasks_terminal` checkpoint
 with `requiresGoalReview`. Promoting it moves the execution to
 `pending_goal_review`; the generic acknowledge command deliberately cannot
-resolve this boundary.
+resolve this boundary. If a graph mutation adds or reworks tasks while that
+terminal checkpoint is still pending, the mutation supersedes the stale
+terminal boundary. After the replacement work settles, the same deterministic
+terminal checkpoint is rearmed at the current graph revision and moved behind
+the new settlement checkpoint. This preserves one terminal identity while
+ensuring the final settlement can always promote a current Goal Review. The
+settlement recovery scan applies the same readiness check to persisted
+executions whose replacement Run had already settled before this invariant was
+enforced, so daemon recovery repairs the stranded terminal backlog without
+weakening acknowledge fences.
 
 After acceptance the source conversation embeds a live "issue panel view"
 (board/list) of the materialized Issue, fed by the same workspace issue events

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -52,6 +52,7 @@ Issue dispatch, Run cancellation, Agent settlement, and stop coordination.
 
 - [Managed task deletion is reported as a stale checkpoint](./issue-execution.md#managed-task-deletion-is-reported-as-a-stale-checkpoint)
 - [Reworked task scheduling is reported as a stale checkpoint](./issue-execution.md#reworked-task-scheduling-is-reported-as-a-stale-checkpoint)
+- [Final rework passes review but Tutti never reaches Goal Review](./issue-execution.md#final-rework-passes-review-but-tutti-never-reaches-goal-review)
 - [Settled checkpoint keeps reopening the source Session](./issue-execution.md#settled-checkpoint-keeps-reopening-the-source-session)
 - [Paused Tutti Issue keeps reopening and reports no resume command](./issue-execution.md#paused-tutti-issue-keeps-reopening-and-reports-no-resume-command)
 - [Tutti composer stays busy after every task Turn settles](./issue-execution.md#tutti-composer-stays-busy-after-every-task-turn-settles)

--- a/docs/conventions/troubleshooting/issue-execution.md
+++ b/docs/conventions/troubleshooting/issue-execution.md
@@ -58,6 +58,38 @@ failed and canceled terminal-run paths, sparse rework, inherited launch
 settings, dependency redirect, and replacement scheduling in the execution
 conformance suite.
 
+## Final rework passes review but Tutti never reaches Goal Review
+
+If the last replacement Run is complete and its evidence passes review, but
+`plan issue acknowledge` returns `inactive_checkpoint` even after one refresh,
+inspect the ordered checkpoint backlog rather than weakening the caller or
+revision fence. The characteristic state is an active final `task_settled`
+checkpoint with no running Run and no later pending checkpoint, plus an older
+`all_tasks_terminal` row in `superseded` state.
+
+This state occurs when the previous final Run queued the deterministic
+`all_tasks_terminal` checkpoint, then the source Agent reworked that Run before
+the terminal checkpoint was promoted. The graph mutation correctly supersedes
+the stale terminal boundary. When the replacement Run later settles, terminal
+checkpoint creation must rearm that superseded singleton with the current graph
+revision and a sequence after the replacement settlement. Treating any existing
+terminal checkpoint ID as current strands the replacement in
+`pending_acceptance`: acknowledge has neither active work nor a later checkpoint
+to justify advancing, so the execution never reaches Goal Review.
+
+Validate the complete chain in the execution conformance suite: settle the
+original final Run, rework while its terminal checkpoint is pending, schedule
+and settle the replacement, acknowledge its settlement, and assert that the
+rearmed terminal checkpoint becomes the active `pending_goal_review` boundary.
+Do not bypass the failure with a generic Issue task update or by relaxing the
+checkpoint/revision fence.
+
+For an execution already persisted in this state, run the normal settlement
+recovery path (or restart a daemon that invokes it). Recovery only rearms a
+superseded terminal singleton when the execution is `awaiting_main`, a terminal
+task checkpoint is active, every active task is terminal, and every terminal
+Run already has a settlement checkpoint.
+
 ## Tutti composer stays busy after every task Turn settles
 
 The Tutti composer deliberately shows Stop while its managed Issue still has

--- a/services/tuttid/data/workspace/sqlite_tutti_mode_settlement.go
+++ b/services/tuttid/data/workspace/sqlite_tutti_mode_settlement.go
@@ -355,7 +355,10 @@ WHERE r.workspace_id = ? AND r.issue_id = ?
 		return nil
 	}
 	checkpointID, _ := executionbiz.AllTasksTerminalCheckpointID(executionID)
-	if _, found, err := getTuttiModeCheckpointTx(ctx, tx, workspaceID, executionID, checkpointID); err != nil || found {
+	existing, found, err := getTuttiModeCheckpointTx(
+		ctx, tx, workspaceID, executionID, checkpointID,
+	)
+	if err != nil {
 		return err
 	}
 	var maxSequence int64
@@ -365,6 +368,28 @@ FROM workspace_tutti_execution_checkpoints
 WHERE workspace_id = ? AND execution_id = ?
 `, workspaceID, executionID).Scan(&maxSequence); err != nil {
 		return fmt.Errorf("get terminal checkpoint sequence: %w", err)
+	}
+	if found {
+		if existing.Status != executionbiz.CheckpointStatusSuperseded {
+			return nil
+		}
+		result, err := tx.ExecContext(ctx, `
+UPDATE workspace_tutti_execution_checkpoints
+SET status = 'pending', sequence = ?, graph_revision = ?,
+    creation_reason = 'all_issue_tasks_terminal', requires_goal_review = 1,
+    created_at_unix_ms = ?, updated_at_unix_ms = ?, resolved_at_unix_ms = 0
+WHERE workspace_id = ? AND execution_id = ? AND checkpoint_id = ?
+  AND kind = 'all_tasks_terminal' AND status = 'superseded'
+`, maxSequence+1, graphRevision, unixMs(now), unixMs(now), workspaceID,
+			executionID, checkpointID)
+		if err != nil {
+			return fmt.Errorf("rearm superseded Tutti mode terminal checkpoint: %w", err)
+		}
+		return requireRowsAffected(
+			result,
+			executionbiz.ErrExecutionConflict,
+			"rearm superseded Tutti mode terminal checkpoint",
+		)
 	}
 	return insertTuttiModeExecutionCheckpoint(ctx, tx, workspaceID, executionbiz.Checkpoint{
 		ID: checkpointID, ExecutionID: executionID,
@@ -453,7 +478,96 @@ ORDER BY r.completed_at_unix_ms ASC, r.created_at_unix_ms ASC, r.run_id ASC
 			repaired++
 		}
 	}
-	return repaired, nil
+	terminalRepairs, err := s.repairSupersededTuttiModeTerminalCheckpoints(
+		ctx, workspaceID, now,
+	)
+	if err != nil {
+		return repaired, err
+	}
+	return repaired + terminalRepairs, nil
+}
+
+func (s *SQLiteStore) repairSupersededTuttiModeTerminalCheckpoints(
+	ctx context.Context,
+	workspaceID string,
+	now time.Time,
+) (int, error) {
+	tx, err := s.writeDB.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	type candidate struct {
+		issueID       string
+		executionID   string
+		graphRevision int64
+	}
+	rows, err := tx.QueryContext(ctx, `
+SELECT e.issue_id, e.execution_id, e.graph_revision
+FROM workspace_tutti_executions e
+JOIN workspace_tutti_execution_checkpoints terminal
+  ON terminal.workspace_id = e.workspace_id
+ AND terminal.execution_id = e.execution_id
+ AND terminal.kind = 'all_tasks_terminal'
+ AND terminal.status = 'superseded'
+WHERE e.workspace_id = ? AND e.status = 'awaiting_main'
+  AND EXISTS (
+    SELECT 1 FROM workspace_tutti_execution_checkpoints active
+    WHERE active.workspace_id = e.workspace_id
+      AND active.execution_id = e.execution_id
+      AND active.status = 'active'
+      AND active.kind IN ('task_settled', 'task_failed', 'task_canceled')
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM workspace_issue_tasks task
+    WHERE task.workspace_id = e.workspace_id
+      AND task.issue_id = e.issue_id
+      AND task.superseded_at_unix_ms = 0
+      AND task.status IN ('not_started', 'running')
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM workspace_issue_runs run
+    LEFT JOIN workspace_tutti_execution_checkpoints settlement
+      ON settlement.workspace_id = run.workspace_id
+     AND settlement.execution_id = e.execution_id
+     AND settlement.subject_run_id = run.run_id
+    WHERE run.workspace_id = e.workspace_id
+      AND run.issue_id = e.issue_id
+      AND run.status IN ('completed', 'failed', 'canceled')
+      AND settlement.checkpoint_id IS NULL
+  )
+ORDER BY e.updated_at_unix_ms ASC, e.execution_id ASC
+`, workspaceID)
+	if err != nil {
+		return 0, fmt.Errorf("list superseded Tutti mode terminal checkpoints: %w", err)
+	}
+	var candidates []candidate
+	for rows.Next() {
+		var current candidate
+		if err := rows.Scan(
+			&current.issueID, &current.executionID, &current.graphRevision,
+		); err != nil {
+			_ = rows.Close()
+			return 0, fmt.Errorf("scan superseded Tutti mode terminal checkpoint: %w", err)
+		}
+		candidates = append(candidates, current)
+	}
+	if err := rows.Close(); err != nil {
+		return 0, err
+	}
+	for _, current := range candidates {
+		if err := appendAllTasksTerminalCheckpointIfReady(
+			ctx, tx, workspaceID, current.issueID, current.executionID,
+			current.graphRevision, now,
+		); err != nil {
+			return 0, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return len(candidates), nil
 }
 
 func (s *SQLiteStore) AdmitTuttiModeAcknowledge(

--- a/services/tuttid/service/tuttimodeexecution/conformance/catalog.go
+++ b/services/tuttid/service/tuttimodeexecution/conformance/catalog.go
@@ -74,6 +74,10 @@ func SettlementCatalog() []Scenario {
 			run:  runGraphMutationRebindsPromotedSettlementBacklog,
 		},
 		{
+			Name: "ReworkRearmsSupersededTerminalCheckpoint",
+			run:  runReworkRearmsSupersededTerminalCheckpoint,
+		},
+		{
 			Name: "TimedOutRunCreatesFailedCheckpoint",
 			run:  runTimedOutRunCreatesFailedCheckpoint,
 		},

--- a/services/tuttid/service/tuttimodeexecution/conformance/driver.go
+++ b/services/tuttid/service/tuttimodeexecution/conformance/driver.go
@@ -326,6 +326,7 @@ type Driver interface {
 	ReturnUnknownNextCancellation()
 	HoldNextLaunchThenFailAuthoritatively() (<-chan struct{}, func())
 	PersistTerminalRunWithoutCheckpoint(context.Context, SettleRunInput) error
+	SupersedeTerminalCheckpointForRecovery(context.Context, string, string) error
 	RepairSettlements(context.Context, string) error
 	Acknowledge(context.Context, AcknowledgeInput) (AcknowledgeResult, error)
 	AcknowledgeReplica(context.Context, AcknowledgeInput) (AcknowledgeResult, error)

--- a/services/tuttid/service/tuttimodeexecution/conformance/settlement_revision_scenarios.go
+++ b/services/tuttid/service/tuttimodeexecution/conformance/settlement_revision_scenarios.go
@@ -122,3 +122,117 @@ func runGraphMutationRebindsPromotedSettlementBacklog(
 	}
 	return nil
 }
+
+func runReworkRearmsSupersededTerminalCheckpoint(
+	ctx context.Context,
+	driver Driver,
+) error {
+	fixture := settlementFixture("rework-rearms-terminal")
+	fixture.Tasks = fixture.Tasks[:1]
+	issueID, firstRun, err := acceptAndScheduleSettlement(
+		ctx, driver, fixture, []string{"task-a"},
+	)
+	if err != nil {
+		return err
+	}
+	if err := driver.SettleRun(ctx, SettleRunInput{
+		WorkspaceID: fixture.WorkspaceID, IssueID: issueID,
+		TaskID: "task-a", RunID: firstRun.RunIDs[0], Status: "completed",
+	}); err != nil {
+		return fmt.Errorf("SettleRun(A) error = %w", err)
+	}
+	settled, err := driver.GetSnapshot(ctx, fixture.WorkspaceID, issueID)
+	if err != nil || len(settled.Checkpoints) != 3 ||
+		settled.Checkpoints[1].Status != "active" ||
+		settled.Checkpoints[2].Kind != "all_tasks_terminal" ||
+		settled.Checkpoints[2].Status != "pending" {
+		return fmt.Errorf("initial terminal backlog = %#v error=%v", settled.Checkpoints, err)
+	}
+	mutation, err := driver.Mutate(ctx, MutateInput{
+		WorkspaceID: fixture.WorkspaceID, IssueID: issueID,
+		SourceSessionID:       fixture.SourceSessionID,
+		CheckpointID:          settled.Checkpoints[1].CheckpointID,
+		ExpectedGraphRevision: settled.Execution.GraphRevision,
+		Operations: []MutationOperation{{
+			Kind: "rework", TaskID: "task-a",
+			Task: schedulableTask("task-a-rework", "/tmp/tutti-settlement-task-a-rework"),
+		}},
+		RequestID: "rework-a-after-terminal-queued",
+	})
+	if err != nil {
+		return fmt.Errorf("Mutate(rework A) error = %w", err)
+	}
+	afterMutation, err := driver.GetSnapshot(ctx, fixture.WorkspaceID, issueID)
+	if err != nil || afterMutation.Checkpoints[2].Status != "superseded" {
+		return fmt.Errorf(
+			"mutation did not supersede stale terminal checkpoint: %#v error=%v",
+			afterMutation.Checkpoints, err,
+		)
+	}
+	reworkRun, err := driver.Schedule(ctx, ScheduleInput{
+		WorkspaceID: fixture.WorkspaceID, IssueID: issueID,
+		SourceSessionID:       fixture.SourceSessionID,
+		CheckpointID:          settled.Checkpoints[1].CheckpointID,
+		ExpectedGraphRevision: mutation.GraphRevision,
+		TaskIDs:               []string{"task-a-rework"},
+		RequestID:             "schedule-reworked-a",
+	})
+	if err != nil {
+		return fmt.Errorf("Schedule(reworked A) error = %w", err)
+	}
+	if err := driver.SettleRun(ctx, SettleRunInput{
+		WorkspaceID: fixture.WorkspaceID, IssueID: issueID,
+		TaskID: "task-a-rework", RunID: reworkRun.RunIDs[0], Status: "completed",
+	}); err != nil {
+		return fmt.Errorf("SettleRun(reworked A) error = %w", err)
+	}
+	reworked, err := driver.GetSnapshot(ctx, fixture.WorkspaceID, issueID)
+	if err != nil || len(reworked.Checkpoints) != 4 {
+		return fmt.Errorf("reworked settlement checkpoints = %#v error=%v", reworked.Checkpoints, err)
+	}
+	reworkSettlement := reworked.Checkpoints[2]
+	terminal := reworked.Checkpoints[3]
+	if reworkSettlement.Kind != "task_settled" || reworkSettlement.Status != "active" ||
+		terminal.Kind != "all_tasks_terminal" || terminal.Status != "pending" ||
+		terminal.Sequence <= reworkSettlement.Sequence ||
+		terminal.GraphRevision != mutation.GraphRevision {
+		return fmt.Errorf("rearmed terminal backlog = %#v", reworked.Checkpoints)
+	}
+	if err := driver.SupersedeTerminalCheckpointForRecovery(
+		ctx, fixture.WorkspaceID, issueID,
+	); err != nil {
+		return fmt.Errorf("SupersedeTerminalCheckpointForRecovery() error = %w", err)
+	}
+	if err := driver.RepairSettlements(ctx, fixture.WorkspaceID); err != nil {
+		return fmt.Errorf("RepairSettlements() error = %w", err)
+	}
+	recovered, err := driver.GetSnapshot(ctx, fixture.WorkspaceID, issueID)
+	if err != nil || len(recovered.Checkpoints) != 4 ||
+		recovered.Checkpoints[3].Status != "pending" ||
+		recovered.Checkpoints[3].Sequence <= reworkSettlement.Sequence ||
+		recovered.Checkpoints[3].GraphRevision != mutation.GraphRevision {
+		return fmt.Errorf("recovered terminal backlog = %#v error=%v", recovered.Checkpoints, err)
+	}
+	terminal = recovered.Checkpoints[3]
+	acknowledged, err := driver.Acknowledge(ctx, AcknowledgeInput{
+		WorkspaceID: fixture.WorkspaceID, IssueID: issueID,
+		SourceSessionID:       fixture.SourceSessionID,
+		CheckpointID:          reworkSettlement.CheckpointID,
+		ExpectedGraphRevision: mutation.GraphRevision,
+		RequestID:             "acknowledge-reworked-a",
+	})
+	if err != nil {
+		return fmt.Errorf("Acknowledge(reworked A) error = %w", err)
+	}
+	goalReview, err := driver.GetSnapshot(ctx, fixture.WorkspaceID, issueID)
+	if err != nil || acknowledged.NextCheckpointID != terminal.CheckpointID ||
+		acknowledged.NextCheckpointKind != "all_tasks_terminal" ||
+		goalReview.Execution.Status != "pending_goal_review" ||
+		goalReview.Checkpoints[3].Status != "active" {
+		return fmt.Errorf(
+			"reworked goal review transition = %#v result=%#v error=%v",
+			goalReview.Checkpoints, acknowledged, err,
+		)
+	}
+	return nil
+}

--- a/services/tuttid/service/tuttimodeexecution/conformance_test.go
+++ b/services/tuttid/service/tuttimodeexecution/conformance_test.go
@@ -2,6 +2,7 @@ package tuttimodeexecution_test
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -847,6 +848,39 @@ func (driver *sqliteConformanceDriver) PersistTerminalRunWithoutCheckpoint(
 	}
 	_, err = driver.store.RecalculateIssueProjection(ctx, input.WorkspaceID, input.IssueID)
 	return err
+}
+
+func (driver *sqliteConformanceDriver) SupersedeTerminalCheckpointForRecovery(
+	ctx context.Context,
+	workspaceID string,
+	issueID string,
+) error {
+	db, err := sql.Open("sqlite", "file:"+driver.dbPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	result, err := db.ExecContext(ctx, `
+UPDATE workspace_tutti_execution_checkpoints
+SET status = 'superseded', updated_at_unix_ms = ?
+WHERE workspace_id = ?
+  AND execution_id = (
+    SELECT execution_id FROM workspace_tutti_executions
+    WHERE workspace_id = ? AND issue_id = ?
+  )
+  AND kind = 'all_tasks_terminal' AND status = 'pending'
+`, driver.clock.Now().UnixMilli(), workspaceID, workspaceID, issueID)
+	if err != nil {
+		return err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows != 1 {
+		return fmt.Errorf("supersede terminal checkpoint rows = %d, want 1", rows)
+	}
+	return nil
 }
 
 func (driver *sqliteConformanceDriver) RepairSettlements(


### PR DESCRIPTION
## Summary

Fix Tutti executions that remain in `pending_acceptance` after the final task is reworked and its replacement Run settles.

- rearm a superseded deterministic `all_tasks_terminal` checkpoint at the current graph revision and after the replacement settlement
- recover already-persisted stranded executions during the normal settlement repair pass
- add Tutti execution conformance coverage for both the normal settlement path and persisted-state recovery
- document the lifecycle invariant and troubleshooting signature

## Root cause and impact

When the previous final Run settled, Tutti queued the singleton `all_tasks_terminal` checkpoint. A subsequent rework correctly superseded that stale terminal boundary when the graph revision advanced. After the replacement Run settled, checkpoint creation treated the existing deterministic checkpoint ID as current regardless of its `superseded` status and returned without rearming it.

The execution was then left with an active final `task_settled` checkpoint, no running Run, and no later pending checkpoint. The acknowledge safety guard correctly refused to advance, so the Issue stayed in `pending_acceptance` and never reached Goal Review even though all Agent Turns had settled.

## Behavior and safety

The settlement path now reuses the deterministic terminal checkpoint only when its current status is `superseded`, assigning the current graph revision and a sequence after the latest checkpoint. Existing non-superseded terminal states remain unchanged.

The recovery scan only repairs persisted executions when all of these conditions hold:

- the execution is `awaiting_main`
- a terminal task settlement checkpoint is active
- no active task is `not_started` or `running`
- every terminal Run already has a settlement checkpoint
- the terminal singleton is `superseded`

Caller, checkpoint, and graph-revision fences remain unchanged.

## Verification

- `go test ./service/tuttimodeexecution -run TestSettlementSQLiteServiceConformance -count=1`
- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready` (6 lanes)
- `git diff --check`

## Fallback Three Questions

- **Source:** persisted executions created by the old settlement path can contain a superseded terminal singleton after the replacement Run has already settled.
- **Why can it not be fixed at that source?** The source settlement path is fixed for future events, but already-terminal Runs will not naturally replay settlement, so their checkpoint backlog needs bounded recovery.
- **Removal condition:** the recovery scan can be removed only after supported installations cannot contain pre-fix persisted executions, or a storage migration establishes the same invariant. The normal settlement rearm behavior remains required.

## Checklist

- [x] This does not change Agent Host session/turn/goal/runtime-operation lifecycle semantics; it changes Tutti product execution checkpoint orchestration in `services/tuttid`.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] README/CONTRIBUTING translation updates are not applicable.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] The commit is signed off with DCO.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Tutti execution checkpoint orchestration on the path to Goal Review; scope is bounded to superseded terminal singleton rearm and settlement repair, with conformance coverage and no weakening of acknowledge fences.
> 
> **Overview**
> Fixes Tutti executions that stay in **`pending_acceptance`** after the final task is reworked and the replacement Run settles, so **`plan issue acknowledge`** keeps returning **`inactive_checkpoint`** and Goal Review never opens.
> 
> **Settlement path:** When all tasks are terminal and every terminal Run has a settlement checkpoint, creating the deterministic **`all_tasks_terminal`** checkpoint no longer treats an existing row with that ID as “done” regardless of status. If the singleton is **`superseded`** (e.g. rework while the terminal boundary was still pending), it is **rearmed** as **`pending`** at the **current graph revision** and with a **sequence after** the latest checkpoint—including behind the replacement **`task_settled`**. Non-superseded terminal states are unchanged.
> 
> **Recovery:** The normal **`RepairTuttiModeRunSettlements`** pass also scans persisted **`awaiting_main`** executions that match the stranded signature (active terminal task settlement, no active non-terminal tasks, no missing settlements, superseded terminal singleton) and applies the same rearm logic.
> 
> **Tests and docs:** Conformance scenario **`ReworkRearmsSupersededTerminalCheckpoint`** covers settle → rework → settle → acknowledge → **`pending_goal_review`**, plus recovery after simulating old persisted state. Architecture and troubleshooting entries document the invariant and diagnostic backlog pattern. Caller, checkpoint, and revision fences are not relaxed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfc997347ff4c549256d4a222e600df83a745647. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->