### PR TITLE
fix(workbench): 支持自定义 Agent 名称中文输入

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAgentEditor.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAgentEditor.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const source = readFileSync(
+  resolve(dirname(fileURLToPath(import.meta.url)), "WorkspaceAgentEditor.tsx"),
+  "utf8"
+);
+
+test("custom Agent name keeps IME composition local until commit", () => {
+  assert.match(source, /const nameInput = useComposedInputValue\(\{/);
+  assert.match(source, /onCommit: \(name\) => onUpdate\(\{ name \}\)/);
+  assert.match(source, /value: draft\.name/);
+
+  const nameInputStart = source.indexOf(
+    "<Input",
+    source.indexOf("workspace.settings.apps.agents.nameLabel")
+  );
+  const nameInputEnd = source.indexOf("/>", nameInputStart);
+  const nameInputSource = source.slice(nameInputStart, nameInputEnd);
+
+  assert.match(nameInputSource, /value=\{nameInput\.value\}/);
+  assert.match(nameInputSource, /onBlur=\{nameInput\.onBlur\}/);
+  assert.match(nameInputSource, /onChange=\{nameInput\.onChange\}/);
+  assert.match(
+    nameInputSource,
+    /onCompositionEnd=\{nameInput\.onCompositionEnd\}/
+  );
+  assert.match(
+    nameInputSource,
+    /onCompositionStart=\{nameInput\.onCompositionStart\}/
+  );
+  assert.doesNotMatch(nameInputSource, /value=\{draft\.name\}/);
+});

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAgentEditor.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAgentEditor.tsx
@@ -1,3 +1,4 @@
+import { useComposedInputValue } from "@tutti-os/ui-react-hooks";
 import {
   Button,
   CloseIcon,
@@ -82,6 +83,10 @@ export function WorkspaceAgentEditor({
     protocol,
     draft.modelPlanId
   );
+  const nameInput = useComposedInputValue({
+    onCommit: (name) => onUpdate({ name }),
+    value: draft.name
+  });
   const selectedPlan =
     compatiblePlans.find((plan) => plan.id === draft.modelPlanId) ?? null;
   const editing = draft.agentId !== null;
@@ -120,8 +125,11 @@ export function WorkspaceAgentEditor({
           <Input
             placeholder={t("workspace.settings.apps.agents.namePlaceholder")}
             type="text"
-            value={draft.name}
-            onChange={(event) => onUpdate({ name: event.currentTarget.value })}
+            value={nameInput.value}
+            onBlur={nameInput.onBlur}
+            onChange={nameInput.onChange}
+            onCompositionEnd={nameInput.onCompositionEnd}
+            onCompositionStart={nameInput.onCompositionStart}
           />
         </label>
 


### PR DESCRIPTION
## 背景

自定义 Agent 的名称输入框在中文输入法组合输入期间，会把每个中间值同步写入设置 Store。同步快照触发的受控输入重渲染会干扰浏览器的 IME 组合过程，导致候选词无法正常落入输入框。

## 修改内容

- 复用 `useComposedInputValue` 管理名称字段
- 在 `compositionstart` 到 `compositionend` 期间将输入值保留在组件本地，组合结束或失焦后再提交到设置 Store
- 保持普通键盘输入和外部值同步行为不变
- 新增回归测试，固定名称字段必须绑定完整的 IME 组合事件处理

## 用户影响

用户现在可以使用中文输入法填写或修改自定义 Agent 名称，英文等普通输入行为不受影响。

## 验证

- `pnpm check:changed -- --base upstream/main`：11/11 通过
- `pnpm check:changed -- --base upstream/main --push-ready`：12/12 通过
- `pnpm check:full`：27/27 通过

## 文档影响

该改动仅修复内部输入事件处理，不改变公开 API、配置、模块职责或产品文案，因此无需更新文档。