### PR TITLE
test(workspace): stabilize remote app repair assertion

### DIFF
--- a/services/tuttid/service/workspace/apps_runtime_test.go
+++ b/services/tuttid/service/workspace/apps_runtime_test.go
@@ -185,7 +185,7 @@ func TestAppCenterServiceStartEnabledRepairsMissingRemoteBuiltinCacheBeforeStart
 		t.Fatalf("StartEnabled() error = %v", err)
 	}
 	app := findWorkspaceAppForTest(apps, "large-builtin")
-	if app == nil || app.Installation == nil || app.Package.PackageDir != missingPackageDir {
+	if app == nil || app.Installation == nil {
 		t.Fatalf("StartEnabled() initial app = %#v", app)
 	}
 	active := waitForActiveAppPackageDirChangeForTest(t, store, "large-builtin", missingPackageDir)


### PR DESCRIPTION
## What changed

Relax the transient package-directory assertion in `TestAppCenterServiceStartEnabledRepairsMissingRemoteBuiltinCacheBeforeStarting`.

The test still verifies the durable behavior:

- the enabled app and installation are returned
- the missing active package is repaired
- the repaired package validates successfully
- runtime startup is attempted after repair and reaches the expected terminal failure state

## Root cause

`StartEnabled` launches remote package repair asynchronously. The test assumed its returned projection must still contain the missing package directory, but a fast artifact copy can complete before `StartEnabled` returns. CI observed the valid repaired projection in `preparing` state and failed the stale-snapshot assertion.

This is a test race rather than a product regression.

## Validation

- failing test repeated 100 times: passed
- `go test ./service/workspace/...`: passed
- `pnpm check:changed`: 5 lanes passed
- push-ready validation: 6 lanes passed

## Documentation impact

None. This changes only a test assertion and does not alter product behavior or public contracts.
