### PR TITLE
fix(mobile): return from browser authentication

### DIFF
--- a/apps/mobile/android/app/build.gradle
+++ b/apps/mobile/android/app/build.gradle
@@ -49,6 +49,7 @@ tasks.named("preBuild").configure {
 }
 
 dependencies {
+    implementation("androidx.browser:browser:1.10.0")
     implementation("androidx.lifecycle:lifecycle-process:2.6.2")
     implementation("com.facebook.react:react-android")
     implementation("com.facebook.react:hermes-android")

--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,12 @@
     android:required="false"
   />
 
+  <queries>
+    <intent>
+      <action android:name="android.support.customtabs.action.CustomTabsService" />
+    </intent>
+  </queries>
+
   <application
     android:name=".MainApplication"
     android:allowBackup="false"

--- a/apps/mobile/android/app/src/main/java/dev/tutti/mobile/MainActivity.kt
+++ b/apps/mobile/android/app/src/main/java/dev/tutti/mobile/MainActivity.kt
@@ -1,6 +1,9 @@
 package dev.tutti.mobile
 
+import android.net.Uri
 import android.os.Bundle
+import androidx.browser.auth.AuthTabIntent
+import androidx.browser.customtabs.CustomTabsClient
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
@@ -8,6 +11,16 @@ import com.facebook.react.defaults.DefaultReactActivityDelegate
 import com.swmansion.rnscreens.fragment.restoration.RNScreensFragmentFactory
 
 class MainActivity : ReactActivity() {
+    private var authTabResultHandler: ((AuthTabIntent.AuthResult) -> Unit)? = null
+    private val authTabLauncher =
+        registerForActivityResult(
+            AuthTabIntent.AuthenticateUserResultContract(),
+        ) { result ->
+            val handler = authTabResultHandler
+            authTabResultHandler = null
+            handler?.invoke(result)
+        }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         supportFragmentManager.fragmentFactory = RNScreensFragmentFactory()
         super.onCreate(savedInstanceState)
@@ -17,4 +30,30 @@ class MainActivity : ReactActivity() {
 
     override fun createReactActivityDelegate(): ReactActivityDelegate =
         DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled)
+
+    fun launchBrowserAuthentication(
+        loginURL: Uri,
+        callbackScheme: String,
+        onResult: (AuthTabIntent.AuthResult) -> Unit,
+    ): Boolean {
+        val provider = CustomTabsClient.getPackageName(this, null) ?: return false
+        if (!CustomTabsClient.isAuthTabSupported(this, provider)) {
+            return false
+        }
+        check(authTabResultHandler == null) {
+            "A browser authentication tab is already active"
+        }
+        authTabResultHandler = onResult
+        return try {
+            AuthTabIntent.Builder().build().launch(
+                authTabLauncher,
+                loginURL,
+                callbackScheme,
+            )
+            true
+        } catch (cause: Exception) {
+            authTabResultHandler = null
+            throw cause
+        }
+    }
 }

--- a/apps/mobile/android/app/src/main/java/dev/tutti/mobile/MobileBrowserAuthBridge.kt
+++ b/apps/mobile/android/app/src/main/java/dev/tutti/mobile/MobileBrowserAuthBridge.kt
@@ -3,9 +3,11 @@ package dev.tutti.mobile
 import android.content.Intent
 import android.net.Uri
 import android.util.Base64
+import androidx.browser.auth.AuthTabIntent
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.UiThreadUtil
 import java.io.BufferedReader
 import java.io.BufferedWriter
 import java.io.Closeable
@@ -14,6 +16,7 @@ import java.io.OutputStreamWriter
 import java.net.InetAddress
 import java.net.ServerSocket
 import java.net.Socket
+import java.net.SocketException
 import java.net.SocketTimeoutException
 import java.net.URI
 import java.net.URLDecoder
@@ -80,7 +83,7 @@ internal class MobileBrowserAuthBridge(
                     starting = false
                     active = attempt
                 }
-                openBrowser(attempt.loginURL)
+                openBrowser(attempt)
                 serve(attempt)
             } catch (cause: Exception) {
                 val attempt =
@@ -141,6 +144,11 @@ internal class MobileBrowserAuthBridge(
                 }
             } catch (_: SocketTimeoutException) {
                 // Re-check expiry and module lifecycle.
+            } catch (cause: SocketException) {
+                if (!isActive(attempt)) {
+                    return
+                }
+                throw cause
             }
         }
         finish(
@@ -321,7 +329,61 @@ internal class MobileBrowserAuthBridge(
     private fun isActive(attempt: LoginAttempt): Boolean =
         synchronized(lock) { active === attempt && !closed }
 
-    private fun openBrowser(url: String) {
+    private fun openBrowser(attempt: LoginAttempt) {
+        UiThreadUtil.runOnUiThread {
+            if (!isActive(attempt)) {
+                return@runOnUiThread
+            }
+            try {
+                val activity = context.currentActivity as? MainActivity
+                val callbackScheme = URI(attempt.appCallbackURL).scheme
+                val launchedAuthTab =
+                    activity?.launchBrowserAuthentication(
+                        Uri.parse(attempt.loginURL),
+                        callbackScheme,
+                    ) { result -> handleAuthTabResult(attempt, result) } == true
+                if (!launchedAuthTab) {
+                    openSystemBrowser(attempt.loginURL)
+                }
+            } catch (cause: Exception) {
+                finish(
+                    attempt,
+                    Result.failure(
+                        BrowserLoginException(
+                            "BROWSER_LOGIN_FAILED",
+                            "Unable to open the system browser",
+                            cause,
+                        ),
+                    ),
+                )
+            }
+        }
+    }
+
+    private fun handleAuthTabResult(
+        attempt: LoginAttempt,
+        result: AuthTabIntent.AuthResult,
+    ) {
+        if (result.resultCode == AuthTabIntent.RESULT_OK) {
+            return
+        }
+        val cancelled = result.resultCode == AuthTabIntent.RESULT_CANCELED
+        finish(
+            attempt,
+            Result.failure(
+                BrowserLoginException(
+                    if (cancelled) "BROWSER_LOGIN_CANCELLED" else "BROWSER_LOGIN_FAILED",
+                    if (cancelled) {
+                        "Browser login was cancelled"
+                    } else {
+                        "Browser authentication tab failed"
+                    },
+                ),
+            ),
+        )
+    }
+
+    private fun openSystemBrowser(url: String) {
         context.startActivity(
             Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
                 addCategory(Intent.CATEGORY_BROWSABLE)

--- a/apps/mobile/ios/TuttiMobile.xcodeproj/project.pbxproj
+++ b/apps/mobile/ios/TuttiMobile.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		A10000000000000000000007 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = A30000000000000000000001 /* Localizable.strings */; };
 		A10000000000000000000008 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = A30000000000000000000002 /* InfoPlist.strings */; };
 		A10000000000000000000009 /* AppLifecycleModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000010 /* AppLifecycleModule.swift */; };
+		A10000000000000000000010 /* MobileWebAuthenticationSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000011 /* MobileWebAuthenticationSession.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -42,6 +43,7 @@
 		A20000000000000000000008 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = TuttiMobile/en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		A20000000000000000000009 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "TuttiMobile/zh-Hans.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		A20000000000000000000010 /* AppLifecycleModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppLifecycleModule.swift; path = TuttiMobile/AppLifecycleModule.swift; sourceTree = "<group>"; };
+		A20000000000000000000011 /* MobileWebAuthenticationSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MobileWebAuthenticationSession.swift; path = TuttiMobile/MobileWebAuthenticationSession.swift; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -65,6 +67,7 @@
 				A20000000000000000000010 /* AppLifecycleModule.swift */,
 				A20000000000000000000005 /* DeviceLinkModule.mm */,
 				A20000000000000000000002 /* MobileBrowserAuthBridge.swift */,
+				A20000000000000000000011 /* MobileWebAuthenticationSession.swift */,
 				A20000000000000000000004 /* MobileNativeModules.m */,
 				A20000000000000000000001 /* MobileSecurityModule.swift */,
 				A20000000000000000000003 /* QRCodeScannerViewController.swift */,
@@ -274,6 +277,7 @@
 				761780ED2CA45674006654EE /* AppDelegate.swift in Sources */,
 				A10000000000000000000001 /* MobileSecurityModule.swift in Sources */,
 				A10000000000000000000002 /* MobileBrowserAuthBridge.swift in Sources */,
+				A10000000000000000000010 /* MobileWebAuthenticationSession.swift in Sources */,
 				A10000000000000000000003 /* QRCodeScannerViewController.swift in Sources */,
 				A10000000000000000000004 /* MobileNativeModules.m in Sources */,
 				A10000000000000000000009 /* AppLifecycleModule.swift in Sources */,

--- a/apps/mobile/ios/TuttiMobile/MobileBrowserAuthBridge.swift
+++ b/apps/mobile/ios/TuttiMobile/MobileBrowserAuthBridge.swift
@@ -1,6 +1,5 @@
 import Darwin
 import Foundation
-import UIKit
 
 struct MobileBrowserAuthError: LocalizedError {
   let code: String
@@ -16,6 +15,7 @@ final class MobileBrowserAuthBridge {
   )
   private let lock = NSLock()
   private var active: BrowserLoginAttempt?
+  private let webAuthenticationSession = MobileWebAuthenticationSession()
   private var closed = false
   private var starting = false
 
@@ -85,20 +85,7 @@ final class MobileBrowserAuthBridge {
         self.lock.unlock()
 
         DispatchQueue.main.async {
-          UIApplication.shared.open(attempt.loginURL) { opened in
-            guard !opened else { return }
-            self.queue.async {
-              self.finish(
-                attempt,
-                result: .failure(
-                  MobileBrowserAuthError(
-                    code: "BROWSER_LOGIN_FAILED",
-                    message: "Unable to open the system browser"
-                  )
-                )
-              )
-            }
-          }
+          self.openAuthenticationSession(attempt)
         }
         self.serve(attempt)
       } catch {
@@ -124,6 +111,9 @@ final class MobileBrowserAuthBridge {
     active = nil
     lock.unlock()
 
+    DispatchQueue.main.async {
+      self.webAuthenticationSession.cancel()
+    }
     guard let attempt else { return }
     Self.closeSocket(attempt.server.fileDescriptor)
     DispatchQueue.main.async {
@@ -392,8 +382,60 @@ final class MobileBrowserAuthBridge {
           ])
         )
       case .failure(let error):
+        self.webAuthenticationSession.cancel()
         attempt.completion(.failure(error))
       }
+    }
+  }
+
+  private func openAuthenticationSession(_ attempt: BrowserLoginAttempt) {
+    guard isActive(attempt) else { return }
+    guard
+      let callbackScheme = URL(string: attempt.appCallbackURL)?.scheme,
+      !callbackScheme.isEmpty
+    else {
+      finish(
+        attempt,
+        result: .failure(
+          MobileBrowserAuthError(
+            code: "BROWSER_LOGIN_FAILED",
+            message: "Unable to present browser login"
+          )
+        )
+      )
+      return
+    }
+
+    let started = webAuthenticationSession.start(
+      url: attempt.loginURL,
+      callbackScheme: callbackScheme
+    ) { [weak self, weak attempt] result in
+      guard let self, let attempt else { return }
+      guard result != .callback else { return }
+      let cancelled = result == .cancelled
+      self.finish(
+        attempt,
+        result: .failure(
+          MobileBrowserAuthError(
+            code: cancelled ? "BROWSER_LOGIN_CANCELLED" : "BROWSER_LOGIN_FAILED",
+            message: cancelled
+              ? "Browser login was cancelled"
+              : "Browser authentication session failed"
+          )
+        )
+      )
+    }
+    guard started else {
+      finish(
+        attempt,
+        result: .failure(
+          MobileBrowserAuthError(
+            code: "BROWSER_LOGIN_FAILED",
+            message: "Unable to start browser authentication session"
+          )
+        )
+      )
+      return
     }
   }
 

--- a/apps/mobile/ios/TuttiMobile/MobileWebAuthenticationSession.swift
+++ b/apps/mobile/ios/TuttiMobile/MobileWebAuthenticationSession.swift
@@ -1,0 +1,88 @@
+import AuthenticationServices
+import Foundation
+import UIKit
+
+enum MobileWebAuthenticationResult {
+  case callback
+  case cancelled
+  case failed
+}
+
+final class MobileWebAuthenticationSession: NSObject,
+  ASWebAuthenticationPresentationContextProviding
+{
+  private var authenticationSession: ASWebAuthenticationSession?
+  private weak var presentationAnchor: ASPresentationAnchor?
+
+  func start(
+    url: URL,
+    callbackScheme: String,
+    completion: @escaping (MobileWebAuthenticationResult) -> Void
+  ) -> Bool {
+    guard authenticationSession == nil, let anchor = Self.currentAnchor() else {
+      return false
+    }
+
+    let completionHandler: ASWebAuthenticationSession.CompletionHandler = {
+      [weak self] _, error in
+      self?.authenticationSession = nil
+      self?.presentationAnchor = nil
+      guard let error else {
+        completion(.callback)
+        return
+      }
+      let browserError = error as NSError
+      let cancelled =
+        browserError.domain == ASWebAuthenticationSessionError.errorDomain
+        && browserError.code
+          == ASWebAuthenticationSessionError.Code.canceledLogin.rawValue
+      completion(cancelled ? .cancelled : .failed)
+    }
+    let session: ASWebAuthenticationSession
+    if #available(iOS 17.4, *) {
+      session = ASWebAuthenticationSession(
+        url: url,
+        callback: .customScheme(callbackScheme),
+        completionHandler: completionHandler
+      )
+    } else {
+      session = ASWebAuthenticationSession(
+        url: url,
+        callbackURLScheme: callbackScheme,
+        completionHandler: completionHandler
+      )
+    }
+    presentationAnchor = anchor
+    authenticationSession = session
+    session.presentationContextProvider = self
+    session.prefersEphemeralWebBrowserSession = false
+    guard session.start() else {
+      authenticationSession = nil
+      presentationAnchor = nil
+      return false
+    }
+    return true
+  }
+
+  func cancel() {
+    authenticationSession?.cancel()
+    authenticationSession = nil
+    presentationAnchor = nil
+  }
+
+  func presentationAnchor(
+    for _: ASWebAuthenticationSession
+  ) -> ASPresentationAnchor {
+    presentationAnchor ?? ASPresentationAnchor()
+  }
+
+  private static func currentAnchor() -> ASPresentationAnchor? {
+    let scenes = UIApplication.shared.connectedScenes.compactMap {
+      $0 as? UIWindowScene
+    }
+    return scenes
+      .flatMap(\.windows)
+      .first(where: \.isKeyWindow)
+      ?? scenes.flatMap(\.windows).first
+  }
+}

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -156,6 +156,7 @@ Android app login, native bridge, secure identity, and mobile transport diagnost
 - [Mobile quick prompts are missing from the plus menu](./mobile.md#mobile-quick-prompts-are-missing-from-the-plus-menu)
 - [Mobile composer model and permission controls are missing](./mobile.md#mobile-composer-model-and-permission-controls-are-missing)
 - [Mobile composer option chips do not open](./mobile.md#mobile-composer-option-chips-do-not-open)
+- [Browser login completes but leaves the browser in front](./mobile.md#browser-login-completes-but-leaves-the-browser-in-front)
 - [Browser login returns to the App but remains signed out](./mobile.md#browser-login-returns-to-the-app-but-remains-signed-out)
 - [Android DeviceLink opens a session and then repeatedly restarts](./mobile.md#android-devicelink-opens-a-session-and-then-repeatedly-restarts)
 - [Mobile stays connected after a long lock-screen interval but sends fail](./mobile.md#mobile-stays-connected-after-a-long-lock-screen-interval-but-sends-fail)

--- a/docs/conventions/troubleshooting/mobile.md
+++ b/docs/conventions/troubleshooting/mobile.md
@@ -158,6 +158,35 @@
   `apps/mobile/src/components/MobileComposerDock.tsx`,
   `apps/mobile/src/components/MobileComposerSettingsSheet.tsx`
 
+## Browser login completes but leaves the browser in front
+
+- **Symptom:** Mobile completes provider login, but the browser stays in front.
+  Switching back to Tutti manually reveals that the account session is already
+  available or allows the login flow to finish.
+- **Quick checks:** Confirm the localhost callback received a transfer code and
+  that transfer-code redemption succeeds. If the hosted result page's manual
+  “open App” action works, the account flow is healthy and only the browser-to-App
+  return path failed.
+- **Root cause:** Opening a raw external browser makes the hosted result page
+  responsible for returning to `tutti://auth/login`. Mobile browsers can reject
+  a custom-scheme navigation started by delayed JavaScript because it no longer
+  carries a direct user gesture, even though the localhost bridge already
+  completed the account transfer.
+- **Fix:** Keep the shared hosted login page, localhost bridge, and one-time
+  transfer-code redemption. Present that flow with `ASWebAuthenticationSession`
+  on iOS and AndroidX Auth Tab when the Android browser provider supports it, so
+  the operating system owns callback matching and foreground return. Android
+  falls back to the external system browser when Auth Tab is unavailable; the
+  hosted manual return action remains the recovery path for that fallback.
+- **Validation:** On physical iOS and Android devices, complete a real provider
+  login and confirm the browser dismisses and Tutti becomes foreground without
+  a manual app switch. Also cancel once, exercise an Android browser without Auth
+  Tab support, and verify the transfer code is redeemed no more than once.
+- **References:** `apps/mobile/ios/TuttiMobile/MobileWebAuthenticationSession.swift`,
+  `apps/mobile/ios/TuttiMobile/MobileBrowserAuthBridge.swift`,
+  `apps/mobile/android/app/src/main/java/dev/tutti/mobile/MainActivity.kt`,
+  `apps/mobile/android/app/src/main/java/dev/tutti/mobile/MobileBrowserAuthBridge.kt`
+
 ## Browser login returns to the App but remains signed out
 
 - **Symptom:** Android opens the Tutti Web login page, completes the provider
@@ -179,7 +208,7 @@
   cookie store. During migration, clear the legacy native `session_id` cookie
   at startup and sign-out, but keep cookie installation outside the application
   port contract.
-- **Validation:** Complete a real system-browser login, verify the App reaches the
+- **Validation:** Complete a real browser login, verify the App reaches the
   device page, restart the App, and verify the same account session still
   authorizes device-list requests.
 - **References:** `apps/mobile/src/services/accountClient.ts`,

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -214,6 +214,21 @@ transport、Agent live Subscriber 和产品 adapter 的现有所有权，不把 
 `cocoapods_pathname_workaround.rb`；GitHub macOS runner 和本机 pnpm workspace
 都可能在 CocoaPods 生成工程时触发该符号链接解析缺陷。
 
+### 账号浏览器认证边界
+
+Mobile 继续复用 Desktop 使用的托管 Web 登录页、localhost callback bridge 和账号
+服务的一次性 transfer code，不维护独立登录页，也不把 provider 凭据或网页 Cookie
+带入 App。平台原生层只负责展示与回到前台：Android 在默认浏览器支持时使用
+AndroidX Auth Tab，不支持时降级到外部系统浏览器；iOS 使用
+`ASWebAuthenticationSession`。两端都以 `tutti://auth/login` 作为原生认证会话的
+callback，同时仍由 localhost bridge 交付 transfer code，因此展示方式不会成为新的
+账号 session owner。
+
+托管结果页应继续保留手动“打开 App”入口，供 Android 外部浏览器降级路径恢复。
+不要把 provider OAuth callback 改成 Mobile 专属页面，也不要绕过现有 transfer code
+兑换逻辑。后续若启用 verified App/Universal Links，应只替换前台返回地址，不改变
+Web 登录和账号会话边界。
+
 ## 5. 正式 App 的日常开发循环
 
 典型开发循环是：
@@ -412,7 +427,7 @@ Google Play 账号。以下事项等正式分发前再处理：
 - Personal `tuttid` 已接入设备注册、QR challenge、Desktop confirm、配对列表和撤销；
 - Personal 配对 API 已进入生成的 Go/TypeScript daemon client，账号 cookie 和设备私钥不会返回给 UI。
 - Desktop 设置页已接入二维码创建、配对码复制、轮询确认和撤销；
-- `apps/mobile` 已接入系统浏览器 GitHub 登录和邮箱验证码登录、Android Keystore
+- `apps/mobile` 已接入平台原生浏览器认证 GitHub 登录和邮箱验证码登录、Android Keystore
   设备身份、设备列表、内置 ZXing 二维码扫描或手动粘贴配对码，以及 challenge
   claim/poll；
 - React Native 0.86、Kotlin native module、DeviceLink AAR 和四 ABI debug APK
@@ -497,8 +512,8 @@ Google Play 账号。以下事项等正式分发前再处理：
 
 ## 10. Personal MVP 真机验收
 
-这一步需要真实 Tutti 账号和 Android 13 或更高版本的手机。GitHub 登录会打开系统
-浏览器，并通过短时 localhost bridge 将一次性 transfer code 返回 App；GitHub
+这一步需要真实 Tutti 账号和 Android 13 或更高版本的手机。GitHub 登录会打开平台
+浏览器认证会话，并通过短时 localhost bridge 将一次性 transfer code 返回 App；GitHub
 凭据和网页 Cookie 不会进入 App。邮箱验证码仍可作为备选。不要在 Issue、PR、聊天
 或日志中粘贴验证码、session cookie、二维码、transfer code 或配对码。
 
@@ -544,7 +559,7 @@ pnpm mobile:android
 ```
 
 App 启动后，使用与 Desktop 相同的账号登录方式。如果 Desktop 使用 GitHub 登录，
-Mobile 也点击“使用 GitHub 登录”并在系统浏览器中完成登录；仅输入 GitHub 展示的
+Mobile 也点击“使用 GitHub 登录”并在平台浏览器认证会话中完成登录；仅输入 GitHub 展示的
 相同邮箱不保证得到同一个账号 identity。Desktop 先在设置的开发者页打开
 “显示手机远程访问设置”，再进入「连接」并点击“配对手机”生成二维码。Mobile
 登录成功后点击配对，优先扫描 Desktop 二维码。首次扫码时允许 App 使用相机；如果

--- a/docs/specs/2026-07-23-mobile-agentgui-device-link-design.md
+++ b/docs/specs/2026-07-23-mobile-agentgui-device-link-design.md
@@ -236,9 +236,11 @@ Mobile、Tutti Personal 和 TSH 使用同一 tsh-server 账号体系。Tutti Per
 “同账号”以账号服务返回的 canonical `user_id` 为准，不以界面展示的邮箱字符串
 判断。GitHub 登录与邮箱验证码登录即使展示相同邮箱，也可能对应不同账号 identity；
 Mobile 应优先允许用户复用 Desktop 的登录方式，不能通过邮箱相等放宽配对校验。
-Android GitHub 登录直接打开现有 Web 登录页，通过只监听 `127.0.0.1` 的短时 bridge
+Mobile GitHub 登录直接打开现有 Web 登录页，通过只监听 `127.0.0.1` 的短时 bridge
 接收一次性 transfer code，再复用账号服务兑换会话；App 不接触 GitHub 凭据或网页
-Cookie，也不新增移动端账号实体。
+Cookie，也不新增移动端账号实体。Android 在浏览器 provider 支持时使用 Auth Tab，
+不支持时降级到外部系统浏览器；iOS 使用 `ASWebAuthenticationSession`。平台认证会话
+只负责 callback 匹配与回到前台，不拥有账号 session 或 provider OAuth 流程。
 
 配对必须同时满足：
 
@@ -533,7 +535,7 @@ pairing lifecycle 和 paired-device rendezvous 已完成并部署。Tutti Person
 控制面 adapter，以及 start/status/confirm/list/revoke 本地 API；challenge secret
 不会持久化，Desktop renderer 只在配对界面打开期间临时持有二维码 payload。
 Desktop UI 已接入 QR 创建、配对码显示/复制、状态轮询、自动确认和撤销；Android
-已接入系统浏览器 GitHub 登录、邮箱验证码登录、Keystore 设备身份、内置 ZXing
+已接入平台原生浏览器认证 GitHub 登录、邮箱验证码登录、Keystore 设备身份、内置 ZXing
 扫码/手动粘贴配对码、
 challenge claim/poll，并只展示属于当前 Mobile identity 的配对设备。
 真实账号二维码联调仍是 M2 的剩余端到端完成条件。
@@ -573,7 +575,8 @@ scoped discontinuity，再触发权威 snapshot reconcile。Session/Message poll
 
 完成条件：登录、配对、选设备、解析唯一 workspace、重连和撤销形成完整非 Agent UI 闭环。
 
-当前进度：bare React Native 0.86 Android 工程、系统浏览器 GitHub 登录、邮箱验证码登录、Keystore
+当前进度：bare React Native 0.86 Android 工程、Auth Tab（不支持时降级系统浏览器）
+GitHub 登录、邮箱验证码登录、Keystore
 Ed25519 identity、扫码/粘贴配对码、配对设备列表、Native DeviceLink bridge、移动端 i18n
 和 semantic theme mapping 已完成。账号、设备、workspace 和前后台生命周期已迁入
 纯 TypeScript DI service；页面只保留 binding 与 Native presentation。登录、
@@ -587,7 +590,8 @@ Ed25519 identity、扫码/粘贴配对码、配对设备列表、Native DeviceLi
 iOS Simulator host 已在相同 `apps/mobile` application core 上建立。它复用全部
 TypeScript service、AgentGUI projection、Native renderer 和 Composer，只实现
 `TuttiMobileSecurity` / `TuttiDeviceLink` 平台 port。当前 iOS adapter 包含
-Keychain/CryptoKit identity、账号 session/Cookie、localhost browser login bridge、
+Keychain/CryptoKit identity、账号 session/Cookie、`ASWebAuthenticationSession`、
+localhost browser login bridge、
 AVFoundation scanner、gomobile XCFramework、Agent HTTP/live framing 和前后台 grace；
 Simulator 的相机路径明确使用现有手动配对码降级。真机与分发仍不属于本阶段完成条件。
 


### PR DESCRIPTION
## Summary

- present the shared hosted login flow with AndroidX Auth Tab when the browser supports it, with the existing external-browser fallback
- present the same flow with `ASWebAuthenticationSession` on iOS
- preserve the localhost callback bridge and one-time transfer-code redemption as the account-session boundary
- document the authentication boundary, fallback behavior, and troubleshooting path

## Why

Mobile previously opened the hosted login flow in a raw external browser. Provider login and transfer-code delivery could complete successfully while the browser remained in front because delayed custom-scheme navigation was not a reliable way to foreground the App.

The platform authentication sessions now own callback matching and foreground return without introducing a separate Mobile login page or moving account-session ownership out of the existing bridge.

## User impact

Supported Android browsers and iOS return to Tutti after browser authentication. Android browsers without Auth Tab support continue through the existing external-browser fallback and rely on the hosted result page's manual “open App” recovery action.

A physical Android device with Chrome 107 reproduced the original completed-login/browser-stays-foreground behavior and verified successful transfer redemption after manually returning to the App. That browser does not support Auth Tab, so the Auth Tab foreground-return path still requires validation on a supported physical browser.

## Validation

- `pnpm check:changed`
- `pnpm check:changed -- --push-ready`
- Android `app:compileDebugKotlin`
- iOS Debug Simulator build
- physical Android login flow and fallback behavior
