### PR TITLE
fix(workspace-app-center): use stable category ids

### DIFF
--- a/.changeset/app-center-stable-category-ids.md
+++ b/.changeset/app-center-stable-category-ids.md
@@ -1,0 +1,6 @@
+---
+"@tutti-os/workspace-app-center": patch
+"@tutti-os/desktop": patch
+---
+
+Classify recommended workspace apps with stable category ids so category counts and filtering no longer depend on the active display language.

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/ui/WorkspaceAppCenterPane.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/ui/WorkspaceAppCenterPane.tsx
@@ -199,10 +199,6 @@ export function WorkspaceAppCenterPane({
     () => createComingSoonWorkspaceApps(i18n, locale),
     [i18n, locale]
   );
-  const categoryLabels = useMemo(
-    () => createWorkspaceAppCategoryLabels(i18n),
-    [i18n]
-  );
   const loadFactoryProviderConfiguration = useMemo(
     () =>
       async (
@@ -344,12 +340,7 @@ export function WorkspaceAppCenterPane({
     ).filter((app) => shouldShowWorkspaceApp(app.appId));
 
     return createAppCenterViewModel({
-      apps: recommendedApps.map((app) =>
-        toWorkspaceAppRecord(
-          app,
-          resolveWorkspaceAppCategory(app.appId, categoryLabels)
-        )
-      ),
+      apps: recommendedApps.map((app) => toWorkspaceAppRecord(app)),
       factoryJobs: state.factoryJobs.map((job) => ({
         agentSessionId: job.agentSessionId,
         appId: job.appId,
@@ -371,14 +362,7 @@ export function WorkspaceAppCenterPane({
         toWorkspaceAppRuntimeState(app)
       )
     });
-  }, [
-    categoryLabels,
-    comingSoonApps,
-    i18n,
-    locale,
-    state.apps,
-    state.factoryJobs
-  ]);
+  }, [comingSoonApps, i18n, locale, state.apps, state.factoryJobs]);
 
   return (
     <>
@@ -488,60 +472,6 @@ function withComingSoonWorkspaceApps(
     : mergedApps;
 }
 
-function createWorkspaceAppCategoryLabels(i18n: {
-  readonly t: (key: string) => string;
-}): Record<WorkspaceAppCategoryID, string> {
-  return {
-    contentCreation: i18n.t("appCenter.categories.contentCreation"),
-    office: i18n.t("appCenter.categories.office"),
-    productDesign: i18n.t("appCenter.categories.productDesign"),
-    tools: i18n.t("appCenter.categories.tools")
-  };
-}
-
-type WorkspaceAppCategoryID =
-  | "contentCreation"
-  | "office"
-  | "productDesign"
-  | "tools";
-
-function resolveWorkspaceAppCategory(
-  appId: string,
-  labels: Record<WorkspaceAppCategoryID, string>
-): string | null {
-  switch (appId.trim().toLowerCase()) {
-    case "product-competition":
-    case "daily-product-radar":
-    case "daily-tech-radar":
-    case "radar":
-    case "design-review":
-    case "vibe-design":
-      return labels.productDesign;
-    case "ai-slide":
-    case "ai-doc":
-    case "ai-sheet":
-      return labels.office;
-    case "ai-media-canvas":
-    case "media-canvas":
-    case "open-cut":
-      return labels.contentCreation;
-    case "automation":
-    case "group-chat":
-    case "issue":
-    case "issues":
-    case "issue-manager":
-    case "workspace-issue":
-    case "workspace-issue-manager":
-    case "draw-topic-app":
-    case "answer-book":
-    case "app_answer_book":
-    case "idea-draw":
-      return labels.tools;
-    default:
-      return null;
-  }
-}
-
 function resolveAppCenterReadyAgentProviderOptions(
   statuses: readonly AgentProviderStatus[],
   agentTargets: readonly AgentTargetPresentation[]
@@ -567,10 +497,7 @@ function resolveAppCenterReadyAgentProviderOptions(
     }));
 }
 
-function toWorkspaceAppRecord(
-  app: WorkspaceAppCenterApp,
-  category: string | null
-): WorkspaceAppRecord {
+function toWorkspaceAppRecord(app: WorkspaceAppCenterApp): WorkspaceAppRecord {
   const manifest = toWorkspaceAppManifest(app);
   return {
     availableIconUrl: app.availableIconUrl,
@@ -592,7 +519,6 @@ function toWorkspaceAppRecord(
               : "local"
       }
     },
-    category,
     createdAtUnixMs: app.createdAtUnixMs,
     install: app.installed
       ? {

--- a/packages/workspace/app-center/README.md
+++ b/packages/workspace/app-center/README.md
@@ -76,3 +76,14 @@ that only exposes the official catalog can render:
 
 If the controlled active tab is not visible, the panel renders the first
 visible tab. An empty configuration falls back to the recommended tab.
+
+## Recommended App Categories
+
+Recommended category filtering uses the stable ids `product-design`,
+`content-creation`, `office`, and `tools`. The package classifies the supported
+official app ids and aliases in its core view-model layer, while the shared i18n
+resources own the labels shown to users. Hosts may provide one of the stable ids
+through `WorkspaceAppRecord.categoryId` for apps outside the built-in map. The
+legacy free-form `category` field remains supported for host compatibility, but
+new integrations should keep localized presentation labels out of category
+data.

--- a/packages/workspace/app-center/src/contracts/catalog.ts
+++ b/packages/workspace/app-center/src/contracts/catalog.ts
@@ -1,5 +1,11 @@
 import type { WorkspaceAppManifest } from "./manifest.ts";
 
+export type WorkspaceAppCategoryId =
+  | "product-design"
+  | "content-creation"
+  | "office"
+  | "tools";
+
 export type WorkspaceAppCatalogSourceKind =
   | "bundled"
   | "local"
@@ -39,6 +45,7 @@ export interface WorkspaceAppRecord {
   readonly availableVersion?: string | null;
   readonly catalog?: WorkspaceAppCatalogEntry | null;
   readonly category?: string | null;
+  readonly categoryId?: WorkspaceAppCategoryId | null;
   readonly createdAtUnixMs?: number | null;
   readonly install?: WorkspaceAppInstallRecord | null;
   readonly manifest: WorkspaceAppManifest;

--- a/packages/workspace/app-center/src/contracts/index.ts
+++ b/packages/workspace/app-center/src/contracts/index.ts
@@ -39,6 +39,7 @@ export {
   type WorkspaceAppManifestWindowMinimizeBehavior
 } from "./manifest.ts";
 export {
+  type WorkspaceAppCategoryId,
   type WorkspaceAppCatalogEntry,
   type WorkspaceAppCatalogLocalization,
   type WorkspaceAppCatalogSource,

--- a/packages/workspace/app-center/src/contracts/viewModel.ts
+++ b/packages/workspace/app-center/src/contracts/viewModel.ts
@@ -1,6 +1,7 @@
 import type { WorkspaceAppRuntimeStatus } from "./runtime.ts";
 import type { WorkspaceAppCatalogSourceKind } from "./catalog.ts";
 import type { WorkspaceAppInstallProgress } from "./runtime.ts";
+import type { WorkspaceAppCategoryId } from "./catalog.ts";
 
 export type WorkspaceAppStatusTone =
   | "neutral"
@@ -49,6 +50,7 @@ export interface WorkspaceAppCardViewModel {
   readonly version?: string;
   readonly availableVersion?: string;
   readonly category?: string | null;
+  readonly categoryId?: WorkspaceAppCategoryId | null;
   readonly updateAvailable: boolean;
   readonly icon?: {
     readonly type: "asset";

--- a/packages/workspace/app-center/src/core/appCenterViewModel.test.ts
+++ b/packages/workspace/app-center/src/core/appCenterViewModel.test.ts
@@ -151,6 +151,7 @@ describe("createAppCenterViewModel", () => {
 
     assert.equal(viewModel.apps[0]?.name, "自动化");
     assert.equal(viewModel.apps[0]?.category, "工具");
+    assert.equal(viewModel.apps[0]?.categoryId, "tools");
     assert.equal(viewModel.apps[0]?.description, "管理工作区自动化任务。");
     assert.deepEqual(viewModel.apps[0]?.tags, ["自动化", "工作区"]);
   });

--- a/packages/workspace/app-center/src/core/appCenterViewModel.ts
+++ b/packages/workspace/app-center/src/core/appCenterViewModel.ts
@@ -1,4 +1,5 @@
 import type {
+  WorkspaceAppCategoryId,
   WorkspaceAppCatalogEntry,
   WorkspaceAppCatalogSourceKind,
   WorkspaceAppCatalogLocalization,
@@ -15,6 +16,10 @@ import type {
 import type { WorkspaceAppRuntimeState } from "../contracts/runtime.ts";
 import { mapWorkspaceAppRuntimeStatus } from "./statusMapping.ts";
 import { resolveWorkspaceAppStatusPresentation } from "./statusMapping.ts";
+import {
+  normalizeWorkspaceAppCategoryId,
+  resolveWorkspaceAppCategoryId
+} from "./workspaceAppCategory.ts";
 
 export interface CreateAppCenterViewModelInput {
   readonly apps: readonly WorkspaceAppRecord[];
@@ -114,6 +119,11 @@ export function createAppCenterViewModel({
       });
 
       const iconUrl = resolveWorkspaceAppIconUrl(app);
+      const category = app.category?.trim() || null;
+      const categoryId =
+        normalizeWorkspaceAppCategoryId(app.categoryId) ??
+        normalizeWorkspaceAppCategoryId(category) ??
+        resolveWorkspaceAppCategoryId(app.manifest.appId);
 
       return {
         id: app.manifest.appId,
@@ -127,7 +137,8 @@ export function createAppCenterViewModel({
         ...(app.availableVersion && !comingSoon
           ? { availableVersion: app.availableVersion }
           : {}),
-        ...(app.category?.trim() ? { category: app.category.trim() } : {}),
+        ...(category ? { category } : {}),
+        ...(categoryId ? { categoryId } : {}),
         updateAvailable: app.updateAvailable ?? false,
         ...(iconUrl
           ? {
@@ -519,6 +530,7 @@ function createFactoryJobViewModel(
 export function createWorkspaceAppRecord(input: {
   readonly catalog?: WorkspaceAppCatalogEntry | null;
   readonly category?: string | null;
+  readonly categoryId?: WorkspaceAppCategoryId | null;
   readonly createdAtUnixMs?: number | null;
   readonly install?: WorkspaceAppInstallRecord | null;
 }): WorkspaceAppRecord {
@@ -530,6 +542,7 @@ export function createWorkspaceAppRecord(input: {
   return {
     catalog: input.catalog,
     category: input.category,
+    categoryId: input.categoryId,
     createdAtUnixMs: input.createdAtUnixMs ?? null,
     install: input.install ?? null,
     manifest

--- a/packages/workspace/app-center/src/core/index.ts
+++ b/packages/workspace/app-center/src/core/index.ts
@@ -42,6 +42,14 @@ export {
   sortRecommendedAppsForAllTab
 } from "./appCenterAppOrdering.ts";
 export {
+  countWorkspaceAppsInCategory,
+  filterWorkspaceAppsByCategory,
+  matchesWorkspaceAppCategory,
+  normalizeWorkspaceAppCategoryId,
+  resolveWorkspaceAppCategoryId,
+  workspaceAppCategoryIds
+} from "./workspaceAppCategory.ts";
+export {
   DEFAULT_APP_FACTORY_PROVIDER,
   resolveDefaultAppFactoryProvider,
   resolveSelectedAppFactoryProvider,

--- a/packages/workspace/app-center/src/core/workspaceAppCategory.test.ts
+++ b/packages/workspace/app-center/src/core/workspaceAppCategory.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  countWorkspaceAppsInCategory,
+  filterWorkspaceAppsByCategory,
+  normalizeWorkspaceAppCategoryId,
+  resolveWorkspaceAppCategoryId
+} from "./workspaceAppCategory.ts";
+
+const expectedCategoryByAppId = {
+  "product-competition": "product-design",
+  "daily-product-radar": "product-design",
+  "daily-tech-radar": "product-design",
+  radar: "product-design",
+  "design-review": "product-design",
+  "vibe-design": "product-design",
+  "ai-media-canvas": "content-creation",
+  "media-canvas": "content-creation",
+  "open-cut": "content-creation",
+  "ai-slide": "office",
+  "ai-doc": "office",
+  "ai-sheet": "office",
+  automation: "tools",
+  "tutti-onboarding": "tools",
+  "group-chat": "tools",
+  issue: "tools",
+  issues: "tools",
+  "issue-manager": "tools",
+  "workspace-issue": "tools",
+  "workspace-issue-manager": "tools",
+  "draw-topic-app": "tools",
+  "answer-book": "tools",
+  app_answer_book: "tools",
+  "idea-draw": "tools",
+  "omni-catcher": "tools"
+} as const;
+
+describe("resolveWorkspaceAppCategoryId", () => {
+  it("classifies every supported official app id and alias", () => {
+    for (const [appId, categoryId] of Object.entries(expectedCategoryByAppId)) {
+      assert.equal(resolveWorkspaceAppCategoryId(appId), categoryId, appId);
+    }
+    assert.equal(resolveWorkspaceAppCategoryId("unknown-app"), null);
+  });
+
+  it("normalizes app ids before lookup", () => {
+    assert.equal(resolveWorkspaceAppCategoryId(" AI-DOC "), "office");
+  });
+});
+
+describe("normalizeWorkspaceAppCategoryId", () => {
+  it("accepts stable ids and rejects presentation labels", () => {
+    assert.equal(normalizeWorkspaceAppCategoryId(" TOOLS "), "tools");
+    assert.equal(normalizeWorkspaceAppCategoryId("其他工具"), null);
+  });
+});
+
+describe("workspace app category projection", () => {
+  const apps = [
+    { categoryId: "product-design" as const, id: "stable" },
+    { category: "Product design", id: "legacy-en" },
+    { category: "产品设计", id: "legacy-zh" },
+    { category: "Unknown", id: "unknown" },
+    {
+      category: "Product design",
+      categoryId: "tools" as const,
+      id: "stable-wins"
+    }
+  ];
+
+  it("counts stable ids and English legacy labels without mixing categories", () => {
+    assert.equal(
+      countWorkspaceAppsInCategory(apps, "product-design", "Product design"),
+      2
+    );
+  });
+
+  it("counts stable ids and Chinese legacy labels without language-dependent ids", () => {
+    assert.equal(
+      countWorkspaceAppsInCategory(apps, "product-design", "产品设计"),
+      2
+    );
+  });
+
+  it("filters by stable id while preserving legacy host compatibility", () => {
+    assert.deepEqual(
+      filterWorkspaceAppsByCategory(
+        apps,
+        "product-design",
+        "Product design"
+      ).map((app) => app.id),
+      ["stable", "legacy-en"]
+    );
+    assert.deepEqual(
+      filterWorkspaceAppsByCategory(apps, "tools", "Other tools").map(
+        (app) => app.id
+      ),
+      ["stable-wins"]
+    );
+  });
+});

--- a/packages/workspace/app-center/src/core/workspaceAppCategory.ts
+++ b/packages/workspace/app-center/src/core/workspaceAppCategory.ts
@@ -1,0 +1,99 @@
+import type { WorkspaceAppCategoryId } from "../contracts/catalog.ts";
+
+export const workspaceAppCategoryIds = [
+  "product-design",
+  "content-creation",
+  "office",
+  "tools"
+] as const satisfies readonly WorkspaceAppCategoryId[];
+
+const workspaceAppCategoryById = new Map<string, WorkspaceAppCategoryId>([
+  ["product-competition", "product-design"],
+  ["daily-product-radar", "product-design"],
+  ["daily-tech-radar", "product-design"],
+  ["radar", "product-design"],
+  ["design-review", "product-design"],
+  ["vibe-design", "product-design"],
+  ["ai-media-canvas", "content-creation"],
+  ["media-canvas", "content-creation"],
+  ["open-cut", "content-creation"],
+  ["ai-slide", "office"],
+  ["ai-doc", "office"],
+  ["ai-sheet", "office"],
+  ["automation", "tools"],
+  ["tutti-onboarding", "tools"],
+  ["group-chat", "tools"],
+  ["issue", "tools"],
+  ["issues", "tools"],
+  ["issue-manager", "tools"],
+  ["workspace-issue", "tools"],
+  ["workspace-issue-manager", "tools"],
+  ["draw-topic-app", "tools"],
+  ["answer-book", "tools"],
+  ["app_answer_book", "tools"],
+  ["idea-draw", "tools"],
+  ["omni-catcher", "tools"]
+]);
+
+const workspaceAppCategoryIdSet = new Set<string>(workspaceAppCategoryIds);
+
+export function resolveWorkspaceAppCategoryId(
+  appId: string
+): WorkspaceAppCategoryId | null {
+  return workspaceAppCategoryById.get(appId.trim().toLowerCase()) ?? null;
+}
+
+export function normalizeWorkspaceAppCategoryId(
+  categoryId: string | null | undefined
+): WorkspaceAppCategoryId | null {
+  const normalized = categoryId?.trim().toLowerCase() ?? "";
+  return workspaceAppCategoryIdSet.has(normalized)
+    ? (normalized as WorkspaceAppCategoryId)
+    : null;
+}
+
+interface WorkspaceAppCategoryProjection {
+  readonly category?: string | null;
+  readonly categoryId?: WorkspaceAppCategoryId | null;
+}
+
+export function matchesWorkspaceAppCategory(
+  app: WorkspaceAppCategoryProjection,
+  categoryId: WorkspaceAppCategoryId,
+  legacyCategoryLabel?: string | null
+): boolean {
+  if (app.categoryId === categoryId) {
+    return true;
+  }
+  if (app.categoryId) {
+    return false;
+  }
+  const legacyCategory = app.category?.trim();
+  return Boolean(
+    legacyCategory &&
+    legacyCategoryLabel &&
+    legacyCategory === legacyCategoryLabel.trim()
+  );
+}
+
+export function countWorkspaceAppsInCategory(
+  apps: readonly WorkspaceAppCategoryProjection[],
+  categoryId: WorkspaceAppCategoryId,
+  legacyCategoryLabel?: string | null
+): number {
+  return apps.filter((app) =>
+    matchesWorkspaceAppCategory(app, categoryId, legacyCategoryLabel)
+  ).length;
+}
+
+export function filterWorkspaceAppsByCategory<
+  App extends WorkspaceAppCategoryProjection
+>(
+  apps: readonly App[],
+  categoryId: WorkspaceAppCategoryId,
+  legacyCategoryLabel?: string | null
+): App[] {
+  return apps.filter((app) =>
+    matchesWorkspaceAppCategory(app, categoryId, legacyCategoryLabel)
+  );
+}

--- a/packages/workspace/app-center/src/ui/AppCenterPanel.tsx
+++ b/packages/workspace/app-center/src/ui/AppCenterPanel.tsx
@@ -65,10 +65,15 @@ import {
   type AppCenterHostActions
 } from "./AppCard.tsx";
 import {
+  countWorkspaceAppsInCategory,
+  filterWorkspaceAppsByCategory
+} from "../core/workspaceAppCategory.ts";
+import {
   resolveActiveAppCenterTab,
   resolveVisibleAppCenterTabs,
   type AppCenterAppTab
 } from "./appCenterTabs.ts";
+import type { WorkspaceAppCategoryId } from "../contracts/catalog.ts";
 
 type FactoryTemplateID =
   | "lovart"
@@ -78,12 +83,7 @@ type FactoryTemplateID =
   | "news"
   | "gomoku";
 export type { AppCenterAppTab } from "./appCenterTabs.ts";
-type RecommendedCategoryTabID =
-  | "all"
-  | "product-design"
-  | "office"
-  | "tools"
-  | "content-creation";
+type RecommendedCategoryTabID = "all" | WorkspaceAppCategoryId;
 type FactorySettingsMenu = "model" | "permission" | "provider" | "reasoning";
 
 interface FactoryTemplate {
@@ -537,15 +537,16 @@ export function AppCenterPanel({
     recommendedApps,
     copy
   );
-  const activeRecommendedCategoryLabel =
-    recommendedCategoryTabs.find(
-      (tab) => tab.id === activeRecommendedCategoryTab
-    )?.category ?? null;
+  const activeRecommendedCategory = recommendedCategoryTabs.find(
+    (tab) => tab.id === activeRecommendedCategoryTab
+  );
   const activeRecommendedApps =
-    activeRecommendedCategoryLabel == null
+    activeRecommendedCategory?.category == null
       ? recommendedAppsForAllTab
-      : recommendedApps.filter(
-          (app) => app.category === activeRecommendedCategoryLabel
+      : filterWorkspaceAppsByCategory(
+          recommendedApps,
+          activeRecommendedCategory.category,
+          activeRecommendedCategory.label
         );
   const activeApps =
     activeAppTab === "recommended"
@@ -1483,7 +1484,7 @@ function AppCardGrid({
 }
 
 interface RecommendedCategoryTab {
-  readonly category: string | null;
+  readonly category: WorkspaceAppCategoryId | null;
   readonly count: number;
   readonly id: RecommendedCategoryTabID;
   readonly label: string;
@@ -1493,16 +1494,6 @@ function createRecommendedCategoryTabs(
   apps: AppCenterViewModel["apps"],
   copy: AppCenterI18nRuntime
 ): RecommendedCategoryTab[] {
-  const categoryCounts = new Map<string, number>();
-
-  for (const app of apps) {
-    const category = app.category?.trim();
-    if (!category) {
-      continue;
-    }
-    categoryCounts.set(category, (categoryCounts.get(category) ?? 0) + 1);
-  }
-
   return recommendedCategoryTabDefinitions.map((definition) => {
     if (definition.id === "all") {
       return {
@@ -1513,12 +1504,12 @@ function createRecommendedCategoryTabs(
       };
     }
 
-    const category = copy.t(definition.labelKey);
+    const label = copy.t(definition.labelKey);
     return {
-      category,
-      count: categoryCounts.get(category) ?? 0,
+      category: definition.id,
+      count: countWorkspaceAppsInCategory(apps, definition.id, label),
       id: definition.id,
-      label: category
+      label
     };
   });
 }

--- a/packages/workspace/app-center/src/ui/AppCenterPanel.tsx
+++ b/packages/workspace/app-center/src/ui/AppCenterPanel.tsx
@@ -1,5 +1,12 @@
 import type { FormEvent, ReactElement } from "react";
-import { useEffect, useId, useMemo, useState } from "react";
+import {
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState
+} from "react";
 import {
   Badge,
   BareIconButton,
@@ -69,7 +76,10 @@ import {
   filterWorkspaceAppsByCategory
 } from "../core/workspaceAppCategory.ts";
 import {
+  handoffHiddenAppCenterCategoryTab,
+  resolveActiveAppCenterCategoryTab,
   resolveActiveAppCenterTab,
+  resolveVisibleAppCenterCategoryTabs,
   resolveVisibleAppCenterTabs,
   type AppCenterAppTab
 } from "./appCenterTabs.ts";
@@ -537,8 +547,18 @@ export function AppCenterPanel({
     recommendedApps,
     copy
   );
-  const activeRecommendedCategory = recommendedCategoryTabs.find(
-    (tab) => tab.id === activeRecommendedCategoryTab
+  const visibleRecommendedCategoryTabs = resolveVisibleAppCenterCategoryTabs(
+    recommendedCategoryTabs,
+    "all"
+  );
+  const resolvedActiveRecommendedCategoryTab =
+    resolveActiveAppCenterCategoryTab(
+      activeRecommendedCategoryTab,
+      visibleRecommendedCategoryTabs,
+      "all"
+    );
+  const activeRecommendedCategory = visibleRecommendedCategoryTabs.find(
+    (tab) => tab.id === resolvedActiveRecommendedCategoryTab
   );
   const activeRecommendedApps =
     activeRecommendedCategory?.category == null
@@ -1483,7 +1503,7 @@ function AppCardGrid({
   );
 }
 
-interface RecommendedCategoryTab {
+export interface RecommendedCategoryTab {
   readonly category: WorkspaceAppCategoryId | null;
   readonly count: number;
   readonly id: RecommendedCategoryTabID;
@@ -1514,7 +1534,7 @@ function createRecommendedCategoryTabs(
   });
 }
 
-function RecommendedCategoryTabs({
+export function RecommendedCategoryTabs({
   copy,
   tabs,
   value,
@@ -1525,14 +1545,39 @@ function RecommendedCategoryTabs({
   readonly value: RecommendedCategoryTabID;
   readonly onValueChange: (value: RecommendedCategoryTabID) => void;
 }): ReactElement {
+  const visibleTabs = resolveVisibleAppCenterCategoryTabs(tabs, "all");
+  const resolvedValue = resolveActiveAppCenterCategoryTab(
+    value,
+    visibleTabs,
+    "all"
+  );
+  const fallbackTabRef = useRef<HTMLButtonElement>(null);
+  const activeTabRef = useRef<HTMLButtonElement>(null);
+  const visibleTabIds = new Set(visibleTabs.map((tab) => tab.id));
+  const renderedTabs =
+    resolvedValue === value
+      ? visibleTabs
+      : tabs.filter((tab) => visibleTabIds.has(tab.id) || tab.id === value);
+  useLayoutEffect(() => {
+    const activeTabHadFocus =
+      activeTabRef.current != null &&
+      activeTabRef.current.ownerDocument.activeElement === activeTabRef.current;
+    handoffHiddenAppCenterCategoryTab(
+      value,
+      resolvedValue,
+      activeTabHadFocus ? fallbackTabRef.current : null,
+      onValueChange
+    );
+  }, [onValueChange, resolvedValue, value]);
+
   return (
     <div
       aria-label={copy.t("labels.appCategories")}
       className="-mx-1 flex min-h-10 min-w-0 items-center gap-2 overflow-x-auto px-1 py-1"
       role="tablist"
     >
-      {tabs.map((tab) => {
-        const selected = tab.id === value;
+      {renderedTabs.map((tab) => {
+        const selected = tab.id === resolvedValue;
         return (
           <button
             aria-selected={selected}
@@ -1543,6 +1588,13 @@ function RecommendedCategoryTabs({
                 : "text-[var(--text-tertiary)] hover:text-[var(--text-primary)]"
             )}
             key={tab.id}
+            ref={
+              tab.id === "all"
+                ? fallbackTabRef
+                : tab.id === value
+                  ? activeTabRef
+                  : undefined
+            }
             role="tab"
             type="button"
             onClick={() => onValueChange(tab.id)}

--- a/packages/workspace/app-center/src/ui/appCenterTabs.test.ts
+++ b/packages/workspace/app-center/src/ui/appCenterTabs.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  handoffHiddenAppCenterCategoryTab,
+  resolveActiveAppCenterCategoryTab,
   resolveActiveAppCenterTab,
+  resolveVisibleAppCenterCategoryTabs,
   resolveVisibleAppCenterTabs
 } from "./appCenterTabs.ts";
 
@@ -29,4 +32,75 @@ test("a hidden active tab falls back to the first visible tab", () => {
     resolveActiveAppCenterTab("community", ["recommended"]),
     "recommended"
   );
+});
+
+test("category tabs keep all and hide empty categories", () => {
+  assert.deepEqual(
+    resolveVisibleAppCenterCategoryTabs(
+      [
+        { count: 4, id: "all", label: "All" },
+        { count: 1, id: "design", label: "Design" },
+        { count: 0, id: "office", label: "Office" }
+      ],
+      "all"
+    ),
+    [
+      { count: 4, id: "all", label: "All" },
+      { count: 1, id: "design", label: "Design" }
+    ]
+  );
+});
+
+test("all remains visible when every category is empty", () => {
+  assert.deepEqual(
+    resolveVisibleAppCenterCategoryTabs(
+      [
+        { count: 0, id: "all" },
+        { count: 0, id: "design" }
+      ],
+      "all"
+    ),
+    [{ count: 0, id: "all" }]
+  );
+});
+
+test("a category that becomes hidden falls back to all", () => {
+  assert.equal(
+    resolveActiveAppCenterCategoryTab(
+      "office",
+      [{ id: "all" }, { id: "design" }],
+      "all"
+    ),
+    "all"
+  );
+});
+
+test("a hidden focused category hands focus to all before updating state", () => {
+  const events: string[] = [];
+  handoffHiddenAppCenterCategoryTab(
+    "office",
+    "all",
+    { focus: () => events.push("focus:all") },
+    (value) => events.push(`change:${value}`)
+  );
+  assert.deepEqual(events, ["focus:all", "change:all"]);
+});
+
+test("a hidden unfocused category updates state without stealing focus", () => {
+  const events: string[] = [];
+  handoffHiddenAppCenterCategoryTab("office", "all", null, (value) =>
+    events.push(`change:${value}`)
+  );
+  assert.deepEqual(events, ["change:all"]);
+});
+
+test("a category that remains visible does not move focus", () => {
+  const events: string[] = [];
+  handoffHiddenAppCenterCategoryTab(
+    "office",
+    "office",
+    { focus: () => events.push("focus:all") },
+    (value) => events.push(`change:${value}`)
+  );
+  assert.deepEqual(events, []);
 });

--- a/packages/workspace/app-center/src/ui/appCenterTabs.ts
+++ b/packages/workspace/app-center/src/ui/appCenterTabs.ts
@@ -29,3 +29,37 @@ export function resolveActiveAppCenterTab(
     ? requestedTab
     : (visibleTabs[0] ?? "recommended");
 }
+
+interface CountedAppCenterCategoryTab<CategoryId extends string> {
+  readonly count: number;
+  readonly id: CategoryId;
+}
+
+export function resolveVisibleAppCenterCategoryTabs<
+  Tab extends CountedAppCenterCategoryTab<string>
+>(tabs: readonly Tab[], allTabId: Tab["id"]): Tab[] {
+  return tabs.filter((tab) => tab.id === allTabId || tab.count > 0);
+}
+
+export function resolveActiveAppCenterCategoryTab<CategoryId extends string>(
+  requestedTab: CategoryId,
+  visibleTabs: readonly { readonly id: CategoryId }[],
+  fallbackTab: CategoryId
+): CategoryId {
+  return visibleTabs.some((tab) => tab.id === requestedTab)
+    ? requestedTab
+    : fallbackTab;
+}
+
+export function handoffHiddenAppCenterCategoryTab<CategoryId extends string>(
+  requestedTab: CategoryId,
+  resolvedTab: CategoryId,
+  fallbackTab: { readonly focus: () => void } | null,
+  onValueChange: (value: CategoryId) => void
+): void {
+  if (requestedTab === resolvedTab) {
+    return;
+  }
+  fallbackTab?.focus();
+  onValueChange(resolvedTab);
+}


### PR DESCRIPTION
## Summary

- introduce stable `categoryId` values for App Center tabs and centralize the official app/alias mapping
- preserve the legacy free-form `category` contract for external hosts and translated-label compatibility
- remove the Desktop-only duplicate category mapping so all consumers use the shared view model
- document the classification contract and add a patch changeset

## Verification

- `pnpm check:changed` (15 lanes passed in the pre-push hook)
- `pnpm release:pack:check -- --packages-json ["@tutti-os/workspace-app-center"]`
- shared App Center tests: 126 passed
- Desktop and package type checks passed
- downstream TSH local-package assertion resolved `vibe-design`, `ai-media-canvas`, `ai-doc`, and `automation` to all four stable IDs

## Checklist

- [x] Change is focused and avoids unrelated cleanup
- [x] Tests cover all current app IDs/aliases, unknown IDs, both locale labels, counting, and filtering
- [x] Package README documents the stable-ID and legacy compatibility contract
- [x] Changeset added
- [x] Commit includes DCO sign-off
- [x] Independent review completed; compatibility and regression-test findings were fixed