### PR TITLE
refactor(agent): remove activity core compatibility ports

### DIFF
--- a/.changeset/agent-gui-runtime-facade.md
+++ b/.changeset/agent-gui-runtime-facade.md
@@ -1,5 +1,6 @@
 ---
 "@tutti-os/agent-gui": major
+"@tutti-os/agent-activity-core": major
 ---
 
 Make `AgentGUIRuntime` the sole AgentGUI host contract and remove the legacy
@@ -7,3 +8,9 @@ Make `AgentGUIRuntime` the sole AgentGUI host contract and remove the legacy
 and TSH now use the narrow contract without duplicating lifecycle callbacks
 already owned by `AgentSessionEngine`; Mobile was audited and has no dependency
 on the removed contract.
+
+Remove the legacy `EngineCommandPort`,
+`EngineExternalCommandExceptPlanDecision`, and `dispatchSessionMutation`
+exports from `@tutti-os/agent-activity-core`. Hosts must use
+`EngineTypedCommandPort`, `AgentSessionEffectPort`, and the semantic mutation
+methods on `AgentSessionEngine`.

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAgentOutcomeNotification.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAgentOutcomeNotification.test.ts
@@ -6,6 +6,7 @@ import {
   normalizeAgentActivitySession,
   type AgentActivitySession,
   type AgentActivityTurn,
+  type AgentSessionEffectPort,
   type AgentSessionEngine
 } from "@tutti-os/agent-activity-core";
 import type { NotificationMessage } from "@tutti-os/ui-notifications";
@@ -246,9 +247,11 @@ function createTestEngine(): AgentSessionEngine {
   return createAgentSessionEngine({
     clock: { nowUnixMs: () => 1 },
     commandPort: {
+      effects: unexpectedSessionEffects(),
       execute: () => Promise.resolve(undefined),
       executePlanDecision: () =>
-        Promise.reject(new Error("unexpected plan decision command"))
+        Promise.reject(new Error("unexpected plan decision command")),
+      kind: "typed"
     },
     identity: {
       origin: AGENT_SESSION_ENGINE_LOCAL_ORIGIN,
@@ -260,6 +263,21 @@ function createTestEngine(): AgentSessionEngine {
       }
     }
   });
+}
+
+function unexpectedSessionEffects(): AgentSessionEffectPort {
+  const reject = () => Promise.reject(new Error("unexpected session effect"));
+  return {
+    activateSession: reject,
+    cancelTurn: reject,
+    controlGoal: reject,
+    deleteSessions: reject,
+    renameSession: reject,
+    respondToInteraction: reject,
+    sendInput: reject,
+    setSessionPinned: reject,
+    updateSessionSettings: reject
+  };
 }
 
 function dispatchSession(

--- a/apps/mobile/src/services/workspaceConversationRailService.test.ts
+++ b/apps/mobile/src/services/workspaceConversationRailService.test.ts
@@ -2,6 +2,7 @@ import {
   AGENT_SESSION_ENGINE_LOCAL_ORIGIN,
   createAgentSessionEngine,
   selectEngineSession,
+  type AgentSessionEffectPort,
   type AgentSessionEngine
 } from "@tutti-os/agent-activity-core";
 import { agentActivitySessionFromTuttidSession } from "@tutti-os/agent-activity-tuttid-adapter";
@@ -354,7 +355,9 @@ function createRailService(
   const engine = createAgentSessionEngine({
     clock: { nowUnixMs: () => clock.now() },
     commandPort: {
-      execute: () => Promise.reject(new Error("unexpected engine command"))
+      effects: unexpectedSessionEffects(),
+      execute: () => Promise.reject(new Error("unexpected engine command")),
+      kind: "typed"
     },
     identity: {
       origin: AGENT_SESSION_ENGINE_LOCAL_ORIGIN,
@@ -375,6 +378,21 @@ function createRailService(
       });
     }
   });
+}
+
+function unexpectedSessionEffects(): AgentSessionEffectPort {
+  const reject = () => Promise.reject(new Error("unexpected session effect"));
+  return {
+    activateSession: reject,
+    cancelTurn: reject,
+    controlGoal: reject,
+    deleteSessions: reject,
+    renameSession: reject,
+    respondToInteraction: reject,
+    sendInput: reject,
+    setSessionPinned: reject,
+    updateSessionSettings: reject
+  };
 }
 
 function createSession(

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -253,12 +253,9 @@ activation. The Engine validates activation mode plus workspace/Session
 identity and nested Session/Turn/Interaction entities before applying that
 result through its canonical reducers. Desktop and Mobile effects may retain
 product-local integration and observability, but must not dispatch Session
-state before returning. The effect executor marks only typed activation results
-with the versioned `activation-v1` result contract; commands whose result shape
-is not authoritative remain opaque. An untagged or opaque result from the
-legacy complete-command port remains an acknowledgement and is never
-reinterpreted as an authoritative projection, so published consumers can
-migrate without payload-shape heuristics.
+state before returning. The effect executor marks activation results with the
+versioned `activation-v1` result contract; commands whose result shape is not
+authoritative remain opaque.
 New-Session Goal Control uses the same activation path. The Engine carries a
 typed `initialGoalControl`; Desktop and Mobile send it through the typed Create
 contract with empty initial content. Agent Host creates the Session and durable
@@ -323,10 +320,9 @@ Rename and pin effects return an authoritative Session envelope, and batch
 delete returns the complete typed deletion result. Reducers still validate
 those results before applying canonical state, while the public port prevents
 hosts from inventing a different result shape.
-`dispatchSessionMutation` remains compatibility-only while published consumers
-migrate and must not be used by new product-host code. Prompt precondition
-ordering and its helper port are Engine implementation details and are not
-exported from the package root. Reducer-only prompt continuation intents are
+The reducer mutation protocol remains an Engine implementation detail; product
+hosts use the semantic mutation methods. Prompt precondition ordering and its
+helper port are also not exported from the package root. Reducer-only prompt continuation intents are
 absent from public `EngineIntent`; their bookkeeping is also absent from
 `AgentSessionEngineState`, `getSnapshot()`, and subscription callbacks.
 
@@ -955,7 +951,7 @@ createAgentSessionEngine({
 ```
 
 `plan/submitDecision` uses the dedicated
-`EngineCommandPort.executePlanDecision` method. Its public
+`EngineTypedCommandPort.executePlanDecision` method. Its public
 `PlanSubmitDecisionResult` contains the durable operation identity returned by
 the Host. It must not pass through the generic `execute(): Promise<unknown>`
 path or manufacture an operation id from a command id.

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -807,7 +807,7 @@ disable submission, but must not change editor editability.
   update is fire-and-observe intent admission rather than a settlement Promise:
   the existing settings-operation selector remains the source of pending,
   failed, and unknown state. Hosts must not reconstruct mutation protocol with
-  `dispatchSessionMutation` and snapshot reads or construct raw
+  reducer intents and snapshot reads or construct raw
   `session/settingsUpdateRequested` fields for an existing Session.
   Session stop is also fire-and-observe admission: the Engine owns its command
   identity, 30-second cancellation timeout, duplicate fence, and 30-second
@@ -833,10 +833,9 @@ disable submission, but must not change editor editability.
   or the resumed Session's authoritative detail aggregate. The Engine validates
   the versioned `activation-v1` result contract, result scope, mode, and every
   nested Session/Turn/Interaction entity, then projects the aggregate in its
-  own drain. Untagged or opaque legacy command-port results remain
-  acknowledgements and do not enter canonical state. Desktop and Mobile effects
-  retain transport, DTO mapping, and product-local integration/observability
-  concerns, but must not pre-dispatch those projections.
+  own drain. Desktop and Mobile effects retain transport, DTO mapping, and
+  product-local integration/observability concerns, but must not pre-dispatch
+  those projections.
   Canonical monotonicity guards prevent a late activation response from
   regressing newer realtime state.
   Surfaces clear a new-Session draft only after activation admission succeeds.
@@ -2052,8 +2051,8 @@ the requested value, because Host owns the durable revision, operation, and
 audit. A typed response with `pending` or `applying` Goal state is `accepted`;
 `synced` is `succeeded`; explicit `failed`, `diverged`, and `unknown` states
 remain distinct. Only definitive protocol rejections become frontend
-`failed`. Timeout, transport loss, an opaque legacy acknowledgement, or a
-malformed typed success remains `unknown`; generic Session reconciliation does
+`failed`. Timeout, transport loss, or a malformed typed success remains
+`unknown`; generic Session reconciliation does
 not prove the outcome of a particular Goal operation. Retrying the same action
 from `unknown` reuses its original `clientSubmitId`, so Host resolves the same
 durable operation instead of creating a second one. A canonical Session Goal

--- a/packages/agent/activity-core/README.md
+++ b/packages/agent/activity-core/README.md
@@ -75,14 +75,12 @@ Engine rules:
 - Reducers are pure and return new state plus command descriptions; the effect
   executor performs commands and feeds every settlement (success, failure,
   timeout) back into the loop as command-result intents.
-- New hosts implement `AgentSessionEffectPort` for activation, prompt send,
+- Hosts implement `AgentSessionEffectPort` for activation, prompt send,
   Goal Control, settings update, turn cancellation, Interaction response,
   rename, pin, and batch delete. The Engine owns command-to-capability
-  projection and
-  the settings-precondition state machine. A typed port declares
+  projection and the settings-precondition state machine. The command port declares
   `kind: "typed"` and its `execute` callback receives only
-  `EngineExtensionCommand`; the discriminated legacy shape keeps the
-  complete-command callback while existing package consumers migrate.
+  `EngineExtensionCommand`.
 - Timing is never read inside reducers. Deadlines are `scheduleExpiry`
   commands handled by the expiry clock, which re-enters the loop with expiry
   intents through the injected host scheduler.
@@ -92,9 +90,8 @@ Engine rules:
 - `getSnapshot()` / `subscribe()` expose the immutable state tree. React
   surfaces subscribe through the single `useEngineSelector` binding in
   `@tutti-os/agent-gui`.
-- `dispatchSessionMutation` remains a compatibility entrypoint for published
-  consumers migrating to the semantic Engine methods. New product-host code
-  must not construct mutation ids, timeout policy, or mutation-record reads.
+- Product hosts use the semantic Engine mutation methods and must not construct
+  mutation ids, timeout policy, or mutation-record reads.
 
 The state tree includes lifecycle entities, message windows, prompt queue,
 pending intents, composer options, runtime availability, reconciliation, and
@@ -379,9 +376,7 @@ settings result requires a provider-declared options refresh. That refresh is
 target-scoped and non-blocking for the current send. Timeout, abort,
 observation, and command-result dispatch remain owned by the Engine effect
 executor. Every typed effect receives its own Engine command's `AbortSignal`;
-hosts must propagate it through their transport. The legacy full-command
-`execute` path is compatibility-only for existing published-package consumers
-such as tsh.
+hosts must propagate it through their transport.
 
 ## Message Merge Rules
 

--- a/packages/agent/activity-core/src/engine/composerOptions.semantic.test.ts
+++ b/packages/agent/activity-core/src/engine/composerOptions.semantic.test.ts
@@ -2,11 +2,8 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import type { AgentActivityComposerOptions } from "../types.ts";
 import { createAgentSessionEngine } from "./createAgentSessionEngine.ts";
-import type {
-  EngineCommandPort,
-  EngineExternalCommand,
-  EngineScheduler
-} from "./types.ts";
+import { createTestEngineCommandPort } from "./testEngineCommandPort.ts";
+import type { EngineExternalCommand, EngineScheduler } from "./types.ts";
 
 function composerOptions(model: string): AgentActivityComposerOptions {
   return {
@@ -33,14 +30,12 @@ function createHarness() {
     string,
     { reject(error: unknown): void; resolve(value: unknown): void }
   >();
-  const commandPort: EngineCommandPort = {
-    execute(command) {
-      commands.push(command);
-      return new Promise((resolve, reject) => {
-        settlers.set(command.commandId, { reject, resolve });
-      });
-    }
-  };
+  const commandPort = createTestEngineCommandPort((command) => {
+    commands.push(command);
+    return new Promise((resolve, reject) => {
+      settlers.set(command.commandId, { reject, resolve });
+    });
+  });
   const scheduler: EngineScheduler = {
     schedule() {
       return { cancel() {} };

--- a/packages/agent/activity-core/src/engine/createAgentSessionEngine.test.ts
+++ b/packages/agent/activity-core/src/engine/createAgentSessionEngine.test.ts
@@ -2,14 +2,15 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { createAgentSessionEngine } from "./createAgentSessionEngine.ts";
 import type { EngineDiagnosticEvent } from "./diagnostics.ts";
+import { createTestEngineCommandPort } from "./testEngineCommandPort.ts";
 import type {
   AgentSessionEngine,
   AgentSessionEngineState,
   EngineClock,
-  EngineCommandPort,
   EngineExternalCommand,
   EngineIntent,
-  EngineScheduler
+  EngineScheduler,
+  EngineTypedCommandPort
 } from "./types.ts";
 import type { AgentActivityTurn } from "../types.ts";
 import type { AgentActivitySessionInput } from "../sessionNormalization.ts";
@@ -79,7 +80,7 @@ function createManualTimer(): ManualTimer {
   };
 }
 
-interface ManualCommandPort extends EngineCommandPort {
+interface ManualCommandPort extends EngineTypedCommandPort {
   abortSignalsByCommandId: Map<string, AbortSignal>;
   executedCommands: EngineExternalCommand[];
   fail(commandId: string, error: unknown): void;
@@ -93,42 +94,27 @@ function createManualCommandPort(): ManualCommandPort {
   >();
   const executedCommands: EngineExternalCommand[] = [];
   const abortSignalsByCommandId = new Map<string, AbortSignal>();
-  return {
-    executePlanDecision(command, options) {
-      executedCommands.push(command);
-      if (options?.signal) {
-        abortSignalsByCommandId.set(command.commandId, options.signal);
-      }
-      return new Promise((resolve, reject) => {
-        settlersByCommandId.set(command.commandId, {
-          reject,
-          resolve: (value) =>
-            resolve(
-              value as import("./planDecision.types.ts").PlanSubmitDecisionResult
-            )
-        });
-      });
-    },
-    execute(command, options) {
-      executedCommands.push(command);
-      if (options?.signal) {
-        abortSignalsByCommandId.set(command.commandId, options.signal);
-      }
-      return new Promise((resolve, reject) => {
-        settlersByCommandId.set(command.commandId, { reject, resolve });
-      });
-    },
+  const commandPort = createTestEngineCommandPort((command, options) => {
+    executedCommands.push(command);
+    if (options?.signal) {
+      abortSignalsByCommandId.set(command.commandId, options.signal);
+    }
+    return new Promise((resolve, reject) => {
+      settlersByCommandId.set(command.commandId, { reject, resolve });
+    });
+  });
+  return Object.assign(commandPort, {
     abortSignalsByCommandId,
     executedCommands,
-    fail(commandId, error) {
+    fail(commandId: string, error: unknown) {
       settlersByCommandId.get(commandId)?.reject(error);
       settlersByCommandId.delete(commandId);
     },
-    succeed(commandId, value) {
+    succeed(commandId: string, value?: unknown) {
       settlersByCommandId.get(commandId)?.resolve(value);
       settlersByCommandId.delete(commandId);
     }
-  };
+  });
 }
 
 function createHarness(input?: {
@@ -330,12 +316,10 @@ test("command execution observes the state produced by its triggering intent", (
   const timer = createManualTimer();
   let engine: AgentSessionEngine;
   let snapshotDuringExecution: AgentSessionEngineState | undefined;
-  const commandPort: EngineCommandPort = {
-    execute() {
-      snapshotDuringExecution = engine.getSnapshot();
-      return new Promise(() => {});
-    }
-  };
+  const commandPort = createTestEngineCommandPort(async () => {
+    snapshotDuringExecution = engine.getSnapshot();
+    return new Promise(() => {});
+  });
   engine = createAgentSessionEngine({
     clock: timer.clock,
     commandPort,

--- a/packages/agent/activity-core/src/engine/createAgentSessionEngine.ts
+++ b/packages/agent/activity-core/src/engine/createAgentSessionEngine.ts
@@ -43,7 +43,6 @@ import {
   type AgentSessionSubmitPromptResult,
   type AgentSessionUpdateSettingsInput,
   type EngineClock,
-  type EngineCommandPort,
   type EngineDispatchOptions,
   type EngineIntent,
   type EngineScheduledTask,
@@ -80,7 +79,7 @@ const SESSION_PROMPT_CONFIRMATION_TIMEOUT_MS = 120_000;
 export interface CreateAgentSessionEngineInput {
   batchDelayMs?: number;
   clock: EngineClock;
-  commandPort: EngineCommandPort | EngineTypedCommandPort;
+  commandPort: EngineTypedCommandPort;
   diagnosticSink?: EngineDiagnosticSink;
   identity: AgentSessionEngineIdentity;
   intentObserver?: AgentSessionEngineIntentObserver;

--- a/packages/agent/activity-core/src/engine/effectExecutor.test.ts
+++ b/packages/agent/activity-core/src/engine/effectExecutor.test.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { createEngineEffectExecutor } from "./effectExecutor.ts";
+import { createTestEngineCommandPort } from "./testEngineCommandPort.ts";
 import type { AgentActivitySession } from "../types.ts";
 import type {
   AgentSessionEffectPort,
-  EngineCommandPort,
   EngineCommandResultIntent,
   EngineExternalCommand,
   EngineTypedCommandPort
@@ -334,41 +334,14 @@ test("projects shared commands onto typed lifecycle effects without host switche
   );
 });
 
-test("keeps the complete command union available to legacy hosts", async () => {
-  const observed: string[] = [];
-  const executed: EngineExternalCommand[] = [];
-  const command: EngineExternalCommand = {
-    agentSessionId: "session-legacy",
-    commandId: "cancel-legacy",
-    turnId: "turn-legacy",
-    type: "turn/cancel",
-    workspaceId: "workspace-legacy"
-  };
-  const result = await executeAndWait(
-    {
-      async execute(candidate) {
-        executed.push(candidate);
-      },
-      observe(candidate) {
-        observed.push(candidate.commandId);
-      }
-    },
-    command
-  );
-
-  assert.deepEqual(executed, [command]);
-  assert.deepEqual(observed, ["cancel-legacy"]);
-  assert.equal(result.resultContract, "opaque");
-});
-
 test("projects plan decisions with exact Engine provenance", async () => {
   let receivedOptions: unknown;
   let receivedSignal: AbortSignal | undefined;
   const result = await executeAndWait(
     {
-      async execute() {
+      ...createTestEngineCommandPort(async () => {
         throw new Error("unexpected generic execute");
-      },
+      }),
       async executePlanDecision(_command, options) {
         assert.ok(options);
         receivedOptions = options;
@@ -412,11 +385,9 @@ test("projects plan decisions with exact Engine provenance", async () => {
 test("rejects prompt settings preconditions that bypass the Engine state machine", async () => {
   let executed = false;
   const result = await executeAndWait(
-    {
-      async execute() {
-        executed = true;
-      }
-    },
+    createTestEngineCommandPort(async () => {
+      executed = true;
+    }),
     {
       agentSessionId: "session-1",
       clientSubmitId: "submit-1",
@@ -438,7 +409,7 @@ test("rejects prompt settings preconditions that bypass the Engine state machine
 });
 
 function executeAndWait(
-  commandPort: EngineCommandPort | EngineTypedCommandPort,
+  commandPort: EngineTypedCommandPort,
   command: EngineExternalCommand
 ): Promise<EngineCommandResultIntent> {
   return new Promise((resolve) => {

--- a/packages/agent/activity-core/src/engine/effectExecutor.ts
+++ b/packages/agent/activity-core/src/engine/effectExecutor.ts
@@ -2,7 +2,6 @@ import type { EngineDiagnosticSink } from "./diagnostics.ts";
 import type { AgentActivitySendInput } from "../types.ts";
 import type {
   AgentSessionActivateEffectInput,
-  EngineCommandPort,
   EngineCommandResultContract,
   EngineCommandResultIntent,
   EngineExternalCommand,
@@ -19,7 +18,7 @@ import type {
 // reducer transitions, never executed in place here.
 
 export interface CreateEngineEffectExecutorInput {
-  commandPort: EngineCommandPort | EngineTypedCommandPort;
+  commandPort: EngineTypedCommandPort;
   diagnosticSink?: EngineDiagnosticSink;
   onResult: (intent: EngineCommandResultIntent) => void;
   scheduler: EngineScheduler;
@@ -80,7 +79,7 @@ export function createEngineEffectExecutor({
       let timeoutTask: EngineScheduledTask | null = null;
       const abortController = new AbortController();
       abortControllersByCommandId.set(command.commandId, abortController);
-      const resultContract = commandResultContract(commandPort, command);
+      const resultContract = commandResultContract(command);
       const execution = executeCommand(
         commandPort,
         command,
@@ -168,7 +167,7 @@ export function createEngineEffectExecutor({
 }
 
 function executeCommand(
-  commandPort: EngineCommandPort | EngineTypedCommandPort,
+  commandPort: EngineTypedCommandPort,
   command: EngineExternalCommand,
   signal: AbortSignal
 ): Promise<unknown> {
@@ -190,15 +189,10 @@ function executeCommand(
           signal
         })
       : Promise.reject(
-          new Error("EngineCommandPort.executePlanDecision is not configured")
+          new Error(
+            "EngineTypedCommandPort.executePlanDecision is not configured"
+          )
         );
-  }
-  if (commandPort.kind !== "typed") {
-    return commandPort.execute(command, {
-      commandId: command.commandId,
-      origin: "engine",
-      signal
-    });
   }
   const effects = commandPort.effects;
   switch (command.type) {
@@ -298,10 +292,8 @@ function executeCommand(
 }
 
 function commandResultContract(
-  commandPort: EngineCommandPort | EngineTypedCommandPort,
   command: EngineExternalCommand
 ): EngineCommandResultContract {
-  if (commandPort.kind !== "typed") return "opaque";
   if (command.type === "session/activate") return "activation-v1";
   if (command.type === "goal/control") return "goal-control-v1";
   return "opaque";

--- a/packages/agent/activity-core/src/engine/interactionResponse.semantic.test.ts
+++ b/packages/agent/activity-core/src/engine/interactionResponse.semantic.test.ts
@@ -5,24 +5,19 @@ import type { AgentActivityInteraction, AgentActivityTurn } from "../types.ts";
 import { createAgentSessionEngine } from "./createAgentSessionEngine.ts";
 import { canonicalInteractionKey } from "./sessionEntityKeys.ts";
 import { selectEngineInteractionResponse } from "./sessionLifecycle.selectors.ts";
-import type {
-  EngineCommandPort,
-  EngineExternalCommand,
-  EngineScheduler
-} from "./types.ts";
+import { createTestEngineCommandPort } from "./testEngineCommandPort.ts";
+import type { EngineExternalCommand, EngineScheduler } from "./types.ts";
 
 function createHarness() {
   let nowUnixMs = 100;
   const commands: EngineExternalCommand[] = [];
   const rejecters = new Map<string, (error: unknown) => void>();
-  const commandPort: EngineCommandPort = {
-    execute(command) {
-      commands.push(command);
-      return new Promise((_resolve, reject) => {
-        rejecters.set(command.commandId, reject);
-      });
-    }
-  };
+  const commandPort = createTestEngineCommandPort((command) => {
+    commands.push(command);
+    return new Promise((_resolve, reject) => {
+      rejecters.set(command.commandId, reject);
+    });
+  });
   const scheduler: EngineScheduler = {
     schedule() {
       return { cancel() {} };

--- a/packages/agent/activity-core/src/engine/sessionActivation.semantic.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionActivation.semantic.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { createAgentSessionEngine } from "./createAgentSessionEngine.ts";
+import { createTestEngineCommandPort } from "./testEngineCommandPort.ts";
 import type {
-  EngineCommandPort,
   EngineExternalCommand,
   EngineIntent,
   EngineScheduler
@@ -12,12 +12,10 @@ function createHarness() {
   const commands: EngineExternalCommand[] = [];
   const observedIntents: EngineIntent[] = [];
   const scheduled: Array<{ canceled: boolean; delayMs: number }> = [];
-  const commandPort: EngineCommandPort = {
-    execute(command) {
-      commands.push(command);
-      return new Promise(() => undefined);
-    }
-  };
+  const commandPort = createTestEngineCommandPort((command) => {
+    commands.push(command);
+    return new Promise(() => undefined);
+  });
   const scheduler: EngineScheduler = {
     schedule(delayMs) {
       const task = { canceled: false, delayMs };

--- a/packages/agent/activity-core/src/engine/sessionGoalControl.semantic.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionGoalControl.semantic.test.ts
@@ -3,6 +3,7 @@ import { test } from "node:test";
 import { normalizeAgentActivitySession } from "../sessionNormalization.ts";
 import type { AgentActivityGoalControlResult } from "../types.ts";
 import { createAgentSessionEngine } from "./createAgentSessionEngine.ts";
+import { createTestEngineCommandPort } from "./testEngineCommandPort.ts";
 import {
   selectSessionGoalControlPresentation,
   selectSessionGoalControlSettlement
@@ -487,9 +488,9 @@ test("uncertain rejection stays retryable while pre-admission rejection fails", 
 test("new-session Goal projection stops being optimistic after canonical hydration", () => {
   const engine = createAgentSessionEngine({
     clock: { nowUnixMs: () => 100 },
-    commandPort: {
-      execute: () => new Promise(() => undefined)
-    },
+    commandPort: createTestEngineCommandPort(
+      () => new Promise(() => undefined)
+    ),
     identity: { origin: "test", workspaceId: "workspace-1" },
     scheduler: { schedule: () => ({ cancel() {} }) }
   });

--- a/packages/agent/activity-core/src/engine/sessionMutationDispatch.ts
+++ b/packages/agent/activity-core/src/engine/sessionMutationDispatch.ts
@@ -22,21 +22,6 @@ export interface SessionMutationCancellation {
   signal?: AbortSignal;
 }
 
-/**
- * Compatibility entrypoint for consumers that still dispatch the reducer
- * protocol directly. Product hosts should use the semantic mutation methods
- * on AgentSessionEngine instead.
- *
- * @deprecated Use AgentSessionEngine.renameSession, setSessionPinned, or
- * deleteSessions.
- */
-export function dispatchSessionMutation(
-  engine: AgentSessionEngine,
-  intent: SessionMutationsIntent
-): Promise<SessionMutationRecord> {
-  return dispatchSessionMutationWithCancellation(engine, intent);
-}
-
 /** @internal */
 export function dispatchSessionMutationWithCancellation(
   engine: AgentSessionEngine,
@@ -127,7 +112,7 @@ export function dispatchSessionForkThroughTurn(
     retryableExisting?.mutationId ?? createSessionForkIdentity();
   const targetAgentSessionId =
     retryableExisting?.targetAgentSessionId ?? createSessionForkIdentity();
-  return dispatchSessionMutation(engine, {
+  return dispatchSessionMutationWithCancellation(engine, {
     requestId,
     sourceAgentSessionId,
     targetAgentSessionId,

--- a/packages/agent/activity-core/src/engine/sessionMutations.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionMutations.reducer.test.ts
@@ -4,7 +4,7 @@ import { normalizeAgentActivitySession } from "../sessionNormalization.ts";
 import { createAgentSessionEngine } from "./createAgentSessionEngine.ts";
 import {
   dispatchSessionForkThroughTurn,
-  dispatchSessionMutation
+  dispatchSessionMutationWithCancellation
 } from "./sessionMutationDispatch.ts";
 import { canonicalTurnKey } from "./sessionEntityKeys.ts";
 import {
@@ -17,10 +17,11 @@ import {
   selectPendingSessionForkThroughTurnIds,
   selectSessionForkThroughTurnMutation
 } from "./sessionMutations.selectors.ts";
+import { createTestEngineCommandPort } from "./testEngineCommandPort.ts";
 import type {
   AgentSessionEngineState,
   EngineClock,
-  EngineCommandPort,
+  EngineExtensionCommand,
   EngineExternalCommand,
   EngineScheduler
 } from "./types.ts";
@@ -179,15 +180,12 @@ async function flushCommandResults(): Promise<void> {
 
 test("pin result commits mutation and canonical session in one engine notification", async () => {
   let resolveCommand: (value: unknown) => void = () => {};
-  const commandPort: EngineCommandPort = {
-    executePlanDecision: async () => {
-      throw new Error("unexpected plan decision command");
-    },
-    execute: async () =>
+  const commandPort = createTestEngineCommandPort(
+    async () =>
       new Promise((resolve) => {
         resolveCommand = resolve;
       })
-  };
+  );
   const engine = createAgentSessionEngine({
     clock: { nowUnixMs: () => 0 },
     commandPort,
@@ -200,7 +198,7 @@ test("pin result commits mutation and canonical session in one engine notificati
   const states: AgentSessionEngineState[] = [];
   engine.subscribe((state) => states.push(state));
 
-  const resultPromise = dispatchSessionMutation(engine, {
+  const resultPromise = dispatchSessionMutationWithCancellation(engine, {
     agentSessionId: "session-1",
     mutationId: "pin-1",
     pinned: true,
@@ -244,15 +242,12 @@ test("pin result commits mutation and canonical session in one engine notificati
 
 test("rename result commits mutation and canonical session in one engine notification", async () => {
   let resolveCommand: (value: unknown) => void = () => {};
-  const commandPort: EngineCommandPort = {
-    executePlanDecision: async () => {
-      throw new Error("unexpected plan decision command");
-    },
-    execute: async () =>
+  const commandPort = createTestEngineCommandPort(
+    async () =>
       new Promise((resolve) => {
         resolveCommand = resolve;
       })
-  };
+  );
   const engine = createAgentSessionEngine({
     clock: { nowUnixMs: () => 0 },
     commandPort,
@@ -265,7 +260,7 @@ test("rename result commits mutation and canonical session in one engine notific
   const states: AgentSessionEngineState[] = [];
   engine.subscribe((state) => states.push(state));
 
-  const resultPromise = dispatchSessionMutation(engine, {
+  const resultPromise = dispatchSessionMutationWithCancellation(engine, {
     agentSessionId: "session-1",
     mutationId: "rename-1",
     title: "  Renamed session  ",
@@ -320,14 +315,12 @@ test("engine rename method owns mutation protocol and returns the canonical sess
   let command: EngineExternalCommand | null = null;
   const engine = createAgentSessionEngine({
     clock: { nowUnixMs: () => 42 },
-    commandPort: {
-      execute: async (nextCommand) => {
-        command = nextCommand;
-        return new Promise((resolve) => {
-          resolveCommand = resolve;
-        });
-      }
-    },
+    commandPort: createTestEngineCommandPort(async (nextCommand) => {
+      command = nextCommand;
+      return new Promise((resolve) => {
+        resolveCommand = resolve;
+      });
+    }),
     identity: { origin: "local", workspaceId: "workspace-1" },
     scheduler: {
       schedule: () => ({ cancel() {} })
@@ -366,18 +359,16 @@ test("engine rename method aborts its host effect when the caller cancels", asyn
   let effectSignal: AbortSignal | undefined;
   const engine = createAgentSessionEngine({
     clock: { nowUnixMs: () => 42 },
-    commandPort: {
-      execute: async (_command, options) => {
-        effectSignal = options?.signal;
-        return new Promise((_resolve, reject) => {
-          options?.signal?.addEventListener(
-            "abort",
-            () => reject(options.signal?.reason),
-            { once: true }
-          );
-        });
-      }
-    },
+    commandPort: createTestEngineCommandPort(async (_command, options) => {
+      effectSignal = options?.signal;
+      return new Promise((_resolve, reject) => {
+        options?.signal?.addEventListener(
+          "abort",
+          () => reject(options.signal?.reason),
+          { once: true }
+        );
+      });
+    }),
     identity: { origin: "local", workspaceId: "workspace-1" },
     scheduler: {
       schedule: () => ({ cancel() {} })
@@ -448,11 +439,9 @@ test("rename rejects empty titles before reaching the command port", async () =>
   let commandCalls = 0;
   const engine = createAgentSessionEngine({
     clock: { nowUnixMs: () => 0 },
-    commandPort: {
-      execute: async () => {
-        commandCalls += 1;
-      }
-    },
+    commandPort: createTestEngineCommandPort(async () => {
+      commandCalls += 1;
+    }),
     identity: { origin: "local", workspaceId: "workspace-1" },
     scheduler: {
       schedule: () => ({ cancel() {} })
@@ -461,7 +450,7 @@ test("rename rejects empty titles before reaching the command port", async () =>
   engine.dispatch({ session, type: "session/upserted" });
 
   await assert.rejects(
-    dispatchSessionMutation(engine, {
+    dispatchSessionMutationWithCancellation(engine, {
       agentSessionId: "session-1",
       mutationId: "rename-empty",
       title: "   ",
@@ -1191,34 +1180,32 @@ test("hung fork ACK times out, retries with the same identity, and stops after s
   const executedCommands: EngineExternalCommand[] = [];
   const engine = createAgentSessionEngine({
     clock: timer.clock,
-    commandPort: {
-      execute: async (command) => {
-        executedCommands.push(command);
-        if (command.type === "session/forkThroughTurn") {
-          const child = forkChild(
-            command.targetAgentSessionId,
-            `operation-${command.requestId}`,
-            command.sourceAgentSessionId,
-            command.turnId
-          );
-          return committedForkResult(child, {
-            requestId: command.requestId,
-            sourceAgentSessionId: command.sourceAgentSessionId,
-            turnId: command.turnId
-          });
-        }
-        if (command.type === "session/ackForkObserved") {
-          const attempts = executedCommands.filter(
-            (candidate) => candidate.type === "session/ackForkObserved"
-          ).length;
-          if (attempts === 1) {
-            return new Promise(() => {});
-          }
-          return {};
-        }
-        throw new Error(`unexpected command ${command.type}`);
+    commandPort: createTestEngineCommandPort(async (command) => {
+      executedCommands.push(command);
+      if (command.type === "session/forkThroughTurn") {
+        const child = forkChild(
+          command.targetAgentSessionId,
+          `operation-${command.requestId}`,
+          command.sourceAgentSessionId,
+          command.turnId
+        );
+        return committedForkResult(child, {
+          requestId: command.requestId,
+          sourceAgentSessionId: command.sourceAgentSessionId,
+          turnId: command.turnId
+        });
       }
-    },
+      if (command.type === "session/ackForkObserved") {
+        const attempts = executedCommands.filter(
+          (candidate) => candidate.type === "session/ackForkObserved"
+        ).length;
+        if (attempts === 1) {
+          return new Promise(() => {});
+        }
+        return {};
+      }
+      throw new Error(`unexpected command ${command.type}`);
+    }),
     identity: { origin: "local", workspaceId: "workspace-1" },
     scheduler: timer.scheduler
   });
@@ -1709,31 +1696,26 @@ test("through-turn fork facade allocates a new identity after a confirmed failur
     title: "Forked session"
   });
   const commands: Array<
-    Extract<
-      Parameters<EngineCommandPort["execute"]>[0],
-      { type: "session/forkThroughTurn" }
-    >
+    Extract<EngineExtensionCommand, { type: "session/forkThroughTurn" }>
   > = [];
   let resolveReplay: (value: unknown) => void = () => {};
   const engine = createAgentSessionEngine({
     clock: { nowUnixMs: () => 0 },
-    commandPort: {
-      execute: async (command) => {
-        if (command.type === "session/ackForkObserved") {
-          return {};
-        }
-        if (command.type !== "session/forkThroughTurn") {
-          throw new Error(`unexpected command ${command.type}`);
-        }
-        commands.push(command);
-        if (commands.length === 1) {
-          throw new Error("definitive first failure");
-        }
-        return new Promise((resolve) => {
-          resolveReplay = resolve;
-        });
+    commandPort: createTestEngineCommandPort(async (command) => {
+      if (command.type === "session/ackForkObserved") {
+        return {};
       }
-    },
+      if (command.type !== "session/forkThroughTurn") {
+        throw new Error(`unexpected command ${command.type}`);
+      }
+      commands.push(command);
+      if (commands.length === 1) {
+        throw new Error("definitive first failure");
+      }
+      return new Promise((resolve) => {
+        resolveReplay = resolve;
+      });
+    }),
     identity: { origin: "local", workspaceId: "workspace-1" },
     scheduler: {
       schedule: () => ({ cancel() {} })
@@ -1818,33 +1800,28 @@ test("through-turn fork facade reuses an Engine-owned delivery-unknown identity"
     lifecycleCapabilities: { fork: true, forkThroughTurn: true }
   });
   const commands: Array<
-    Extract<
-      Parameters<EngineCommandPort["execute"]>[0],
-      { type: "session/forkThroughTurn" }
-    >
+    Extract<EngineExtensionCommand, { type: "session/forkThroughTurn" }>
   > = [];
   let resolveReplay: (value: unknown) => void = () => {};
   const engine = createAgentSessionEngine({
     clock: { nowUnixMs: () => 0 },
-    commandPort: {
-      execute: async (command) => {
-        if (command.type === "session/ackForkObserved") {
-          return {};
-        }
-        if (command.type !== "session/forkThroughTurn") {
-          throw new Error(`unexpected command ${command.type}`);
-        }
-        commands.push(command);
-        if (commands.length === 1) {
-          throw Object.assign(new Error("delivery outcome unknown"), {
-            reason: "agent_session_fork_delivery_unknown"
-          });
-        }
-        return new Promise((resolve) => {
-          resolveReplay = resolve;
+    commandPort: createTestEngineCommandPort(async (command) => {
+      if (command.type === "session/ackForkObserved") {
+        return {};
+      }
+      if (command.type !== "session/forkThroughTurn") {
+        throw new Error(`unexpected command ${command.type}`);
+      }
+      commands.push(command);
+      if (commands.length === 1) {
+        throw Object.assign(new Error("delivery outcome unknown"), {
+          reason: "agent_session_fork_delivery_unknown"
         });
       }
-    },
+      return new Promise((resolve) => {
+        resolveReplay = resolve;
+      });
+    }),
     identity: { origin: "local", workspaceId: "workspace-1" },
     scheduler: {
       schedule: () => ({ cancel() {} })
@@ -1914,10 +1891,7 @@ test("through-turn fork facade reuses an Engine-owned in-flight identity", async
     lifecycleCapabilities: { fork: true, forkThroughTurn: true }
   });
   const commands: Array<
-    Extract<
-      Parameters<EngineCommandPort["execute"]>[0],
-      { type: "session/forkThroughTurn" }
-    >
+    Extract<EngineExtensionCommand, { type: "session/forkThroughTurn" }>
   > = [];
   let resolveCommands: (value: unknown) => void = () => {};
   const sharedExecution = new Promise((resolve) => {
@@ -1925,18 +1899,16 @@ test("through-turn fork facade reuses an Engine-owned in-flight identity", async
   });
   const engine = createAgentSessionEngine({
     clock: { nowUnixMs: () => 0 },
-    commandPort: {
-      execute: async (command) => {
-        if (command.type === "session/ackForkObserved") {
-          return {};
-        }
-        if (command.type !== "session/forkThroughTurn") {
-          throw new Error(`unexpected command ${command.type}`);
-        }
-        commands.push(command);
-        return sharedExecution;
+    commandPort: createTestEngineCommandPort(async (command) => {
+      if (command.type === "session/ackForkObserved") {
+        return {};
       }
-    },
+      if (command.type !== "session/forkThroughTurn") {
+        throw new Error(`unexpected command ${command.type}`);
+      }
+      commands.push(command);
+      return sharedExecution;
+    }),
     identity: { origin: "local", workspaceId: "workspace-1" },
     scheduler: {
       schedule: () => ({ cancel() {} })
@@ -2005,24 +1977,22 @@ test("through-turn fork facade reuses the mutation key after committed recovery 
   let providerForkCalls = 0;
   const engine = createAgentSessionEngine({
     clock: { nowUnixMs: () => 0 },
-    commandPort: {
-      execute: async (command) => {
-        if (command.type === "session/ackForkObserved") {
-          return new Promise(() => {});
-        }
-        if (command.type !== "session/forkThroughTurn") {
-          throw new Error(`unexpected command ${command.type}`);
-        }
-        providerForkCalls += 1;
-        return committedForkResult(
-          normalizeAgentActivitySession({
-            ...session,
-            agentSessionId: "durable-target"
-          }),
-          { requestId: "durable-request" }
-        );
+    commandPort: createTestEngineCommandPort(async (command) => {
+      if (command.type === "session/ackForkObserved") {
+        return new Promise(() => {});
       }
-    },
+      if (command.type !== "session/forkThroughTurn") {
+        throw new Error(`unexpected command ${command.type}`);
+      }
+      providerForkCalls += 1;
+      return committedForkResult(
+        normalizeAgentActivitySession({
+          ...session,
+          agentSessionId: "durable-target"
+        }),
+        { requestId: "durable-request" }
+      );
+    }),
     identity: { origin: "local", workspaceId: "workspace-1" },
     scheduler: {
       schedule: () => ({ cancel() {} })

--- a/packages/agent/activity-core/src/engine/sessionPrompt.semantic.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionPrompt.semantic.test.ts
@@ -3,8 +3,8 @@ import { test } from "node:test";
 import { normalizeAgentActivitySession } from "../sessionNormalization.ts";
 import type { AgentActivityTurn } from "../types.ts";
 import { createAgentSessionEngine } from "./createAgentSessionEngine.ts";
+import { createTestEngineCommandPort } from "./testEngineCommandPort.ts";
 import type {
-  EngineCommandPort,
   EngineExternalCommand,
   EngineIntent,
   EngineScheduler
@@ -14,12 +14,10 @@ function createHarness(active: boolean) {
   const commands: EngineExternalCommand[] = [];
   const observedIntents: EngineIntent[] = [];
   const scheduled: Array<{ canceled: boolean; delayMs: number }> = [];
-  const commandPort: EngineCommandPort = {
-    execute(command) {
-      commands.push(command);
-      return new Promise(() => undefined);
-    }
-  };
+  const commandPort = createTestEngineCommandPort((command) => {
+    commands.push(command);
+    return new Promise(() => undefined);
+  });
   const scheduler: EngineScheduler = {
     schedule(delayMs) {
       const task = { canceled: false, delayMs };

--- a/packages/agent/activity-core/src/engine/sessionSettings.semantic.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionSettings.semantic.test.ts
@@ -4,11 +4,8 @@ import { normalizeAgentActivitySession } from "../sessionNormalization.ts";
 import type { AgentActivitySessionSettings } from "../types.ts";
 import { createAgentSessionEngine } from "./createAgentSessionEngine.ts";
 import { selectEngineSessionSettingsUpdate } from "./sessionLifecycle.selectors.ts";
-import type {
-  EngineCommandPort,
-  EngineExternalCommand,
-  EngineScheduler
-} from "./types.ts";
+import { createTestEngineCommandPort } from "./testEngineCommandPort.ts";
+import type { EngineExternalCommand, EngineScheduler } from "./types.ts";
 
 function createHarness() {
   let nowUnixMs = 100;
@@ -21,14 +18,12 @@ function createHarness() {
     run(): void;
     sequence: number;
   }> = [];
-  const commandPort: EngineCommandPort = {
-    execute(command) {
-      commands.push(command);
-      return new Promise((resolve) => {
-        settlers.set(command.commandId, resolve);
-      });
-    }
-  };
+  const commandPort = createTestEngineCommandPort((command) => {
+    commands.push(command);
+    return new Promise((resolve) => {
+      settlers.set(command.commandId, resolve);
+    });
+  });
   const scheduler: EngineScheduler = {
     schedule(delayMs, run) {
       const task = {

--- a/packages/agent/activity-core/src/engine/sessionStop.semantic.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionStop.semantic.test.ts
@@ -4,11 +4,8 @@ import { normalizeAgentActivitySession } from "../sessionNormalization.ts";
 import type { AgentActivityTurn } from "../types.ts";
 import { createAgentSessionEngine } from "./createAgentSessionEngine.ts";
 import { selectEngineCancelState } from "./sessionLifecycle.selectors.ts";
-import type {
-  EngineCommandPort,
-  EngineExternalCommand,
-  EngineScheduler
-} from "./types.ts";
+import { createTestEngineCommandPort } from "./testEngineCommandPort.ts";
+import type { EngineExternalCommand, EngineScheduler } from "./types.ts";
 
 function createHarness(active: boolean) {
   let nowUnixMs = 100;
@@ -17,12 +14,10 @@ function createHarness(active: boolean) {
     canceled: boolean;
     delayMs: number;
   }> = [];
-  const commandPort: EngineCommandPort = {
-    execute(command) {
-      commands.push(command);
-      return new Promise(() => undefined);
-    }
-  };
+  const commandPort = createTestEngineCommandPort((command) => {
+    commands.push(command);
+    return new Promise(() => undefined);
+  });
   const scheduler: EngineScheduler = {
     schedule(delayMs) {
       const task = { canceled: false, delayMs };

--- a/packages/agent/activity-core/src/engine/testEngineCommandPort.ts
+++ b/packages/agent/activity-core/src/engine/testEngineCommandPort.ts
@@ -1,0 +1,76 @@
+import type {
+  AgentSessionEffectPort,
+  EngineEffectOptions,
+  EngineExternalCommand,
+  EngineTypedCommandPort
+} from "./types.ts";
+import type { PlanSubmitDecisionResult } from "./planDecision.types.ts";
+
+export type TestEngineCommandExecutor = (
+  command: EngineExternalCommand,
+  options?: EngineEffectOptions
+) => Promise<unknown>;
+
+/** Test-only adapter that records typed effects as their originating command. */
+export function createTestEngineCommandPort(
+  execute: TestEngineCommandExecutor = async () => ({ ok: true })
+): EngineTypedCommandPort {
+  const commands = new Map<string, EngineExternalCommand>();
+
+  function executeObserved<TResult>(
+    options: EngineEffectOptions | undefined
+  ): Promise<TResult> {
+    const commandId = options?.commandId.trim();
+    const command = commandId ? commands.get(commandId) : undefined;
+    if (!command) {
+      return Promise.reject(
+        new Error(`test command was not observed: ${commandId ?? "unknown"}`)
+      );
+    }
+    return execute(command, options) as Promise<TResult>;
+  }
+
+  const effects: AgentSessionEffectPort = {
+    activateSession(_input, options) {
+      return executeObserved(options);
+    },
+    cancelTurn(_input, options) {
+      return executeObserved(options);
+    },
+    controlGoal(_input, options) {
+      return executeObserved(options);
+    },
+    deleteSessions(_input, options) {
+      return executeObserved(options);
+    },
+    renameSession(_input, options) {
+      return executeObserved(options);
+    },
+    respondToInteraction(_input, options) {
+      return executeObserved(options);
+    },
+    sendInput(_input, options) {
+      return executeObserved(options);
+    },
+    setSessionPinned(_input, options) {
+      return executeObserved(options);
+    },
+    updateSessionSettings(_input, options) {
+      return executeObserved(options);
+    }
+  };
+
+  return {
+    effects,
+    execute(command, options) {
+      return execute(command, options);
+    },
+    executePlanDecision(command, options) {
+      return execute(command, options) as Promise<PlanSubmitDecisionResult>;
+    },
+    kind: "typed",
+    observe(command) {
+      commands.set(command.commandId, command);
+    }
+  };
+}

--- a/packages/agent/activity-core/src/engine/types.ts
+++ b/packages/agent/activity-core/src/engine/types.ts
@@ -67,8 +67,8 @@ export type EngineCommandOutcome = "failed" | "succeeded" | "timedOut";
 
 /**
  * Describes the runtime result contract used by one command execution.
- * Older command ports and manually dispatched results omit this field and
- * retain opaque acknowledgement semantics.
+ * Manually dispatched results may omit this field and retain opaque
+ * acknowledgement semantics.
  */
 export type EngineCommandResultContract =
   | "activation-v1"
@@ -204,11 +204,6 @@ export type EngineExternalCommand =
   | EditRetryCommand
   | TuttiModeActivationCommand;
 
-export type EngineExternalCommandExceptPlanDecision = Exclude<
-  EngineExternalCommand,
-  PlanSubmitDecisionCommand
->;
-
 type AgentSessionEffectCommand =
   | Extract<
       SessionMutationCommand,
@@ -222,8 +217,8 @@ type AgentSessionEffectCommand =
   | TurnCancelCommand;
 
 export type EngineExtensionCommand = Exclude<
-  EngineExternalCommandExceptPlanDecision,
-  AgentSessionEffectCommand
+  EngineExternalCommand,
+  AgentSessionEffectCommand | PlanSubmitDecisionCommand
 >;
 
 export type EngineCommand = EngineExternalCommand | EngineInternalCommand;
@@ -423,37 +418,18 @@ export interface AgentSessionEffectPort {
   ): Promise<unknown>;
 }
 
-interface EngineCommandPortBase {
-  observe?(command: EngineExternalCommand): void;
-  executePlanDecision?(
-    command: PlanSubmitDecisionCommand,
-    options?: EngineEffectOptions
-  ): Promise<PlanSubmitDecisionResult>;
-}
-
-/**
- * Compatibility surface for published-package consumers that still translate
- * the complete command union themselves.
- */
-export interface EngineCommandPort extends EngineCommandPortBase {
-  effects?: never;
-  kind?: "legacy";
-  execute(
-    command: EngineExternalCommandExceptPlanDecision,
-    options?: EngineEffectOptions
-  ): Promise<unknown>;
-}
-
-/**
- * Preferred host surface. The Engine owns shared lifecycle projection and the
- * host executes only platform/product extensions.
- */
-export interface EngineTypedCommandPort extends EngineCommandPortBase {
+/** The Engine owns lifecycle projection; hosts execute product extensions. */
+export interface EngineTypedCommandPort {
   effects: AgentSessionEffectPort;
   execute(
     command: EngineExtensionCommand,
     options?: EngineEffectOptions
   ): Promise<unknown>;
+  observe?(command: EngineExternalCommand): void;
+  executePlanDecision?(
+    command: PlanSubmitDecisionCommand,
+    options?: EngineEffectOptions
+  ): Promise<PlanSubmitDecisionResult>;
   kind: "typed";
 }
 

--- a/packages/agent/activity-core/src/index.ts
+++ b/packages/agent/activity-core/src/index.ts
@@ -82,13 +82,11 @@ export type {
   EngineClock,
   EngineCommand,
   EngineCommandOutcome,
-  EngineCommandPort,
   EngineConnectionStatus,
   EngineDispatchOptions,
   EngineDomainReducer,
   EngineEffectOptions,
   EngineExternalCommand,
-  EngineExternalCommandExceptPlanDecision,
   EngineExtensionCommand,
   EngineIntent,
   EngineInternalCommand,
@@ -141,7 +139,6 @@ export type {
 } from "./engine/editRetry.types.ts";
 export {
   dispatchSessionForkThroughTurn,
-  dispatchSessionMutation,
   type DispatchSessionForkThroughTurnInput
 } from "./engine/sessionMutationDispatch.ts";
 export {

--- a/packages/agent/activity-core/src/sessionReconcileExecutor.test.ts
+++ b/packages/agent/activity-core/src/sessionReconcileExecutor.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { createAgentActivitySnapshotProjector } from "./engine/agentActivitySnapshot.projector.ts";
 import { createAgentSessionEngine } from "./engine/createAgentSessionEngine.ts";
+import { createTestEngineCommandPort } from "./engine/testEngineCommandPort.ts";
 import type {
   AgentActivitySessionDetailSnapshot,
   SessionReconcileCommand
@@ -561,9 +562,9 @@ function createHarness(
 ) {
   const engine = createAgentSessionEngine({
     clock: { nowUnixMs: () => 1 },
-    commandPort: {
-      execute: () => Promise.reject(new Error("unexpected engine command"))
-    },
+    commandPort: createTestEngineCommandPort(() =>
+      Promise.reject(new Error("unexpected engine command"))
+    ),
     identity: { origin: "test", workspaceId: WORKSPACE_ID },
     scheduler: {
       schedule: () => ({ cancel() {} })

--- a/packages/agent/activity-core/src/workspaceEventCoordinator.test.ts
+++ b/packages/agent/activity-core/src/workspaceEventCoordinator.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import { createAgentActivitySnapshotProjector } from "./engine/agentActivitySnapshot.projector.ts";
 import { createAgentSessionEngine } from "./engine/createAgentSessionEngine.ts";
 import { canonicalTurnKey } from "./engine/sessionEntityKeys.ts";
+import { createTestEngineCommandPort } from "./engine/testEngineCommandPort.ts";
 import type { EngineExternalCommand } from "./engine/types.ts";
 import { normalizeAgentActivitySession } from "./sessionNormalization.ts";
 import type {
@@ -15,16 +16,10 @@ function createHarness() {
   const commands: EngineExternalCommand[] = [];
   const engine = createAgentSessionEngine({
     clock: { nowUnixMs: () => 10 },
-    commandPort: {
-      execute(command) {
-        commands.push(command);
-        return Promise.resolve(undefined);
-      },
-      executePlanDecision(command) {
-        commands.push(command);
-        return Promise.reject(new Error("not used by coordinator tests"));
-      }
-    },
+    commandPort: createTestEngineCommandPort((command) => {
+      commands.push(command);
+      return Promise.resolve(undefined);
+    }),
     identity: { origin: "test", workspaceId: "workspace-1" },
     scheduler: {
       schedule(_delayMs, task) {

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/TuttiBudgetPopover.presession.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/TuttiBudgetPopover.presession.spec.tsx
@@ -3,6 +3,7 @@ import type { MouseEvent as ReactMouseEvent } from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { createAgentSessionEngine } from "@tutti-os/agent-activity-core";
 import { describe, expect, it, vi } from "vitest";
+import { createTestEngineCommandPort } from "../../../shared/testing/createTestAgentSessionEngine";
 import {
   resolveAgentGUITuttiModeDraftKey,
   useAgentGUITuttiModeActivation
@@ -32,7 +33,9 @@ const labels = {
 function createTestEngine() {
   return createAgentSessionEngine({
     clock: { nowUnixMs: () => 1 },
-    commandPort: { execute: vi.fn(() => new Promise<never>(() => {})) },
+    commandPort: createTestEngineCommandPort({
+      execute: vi.fn(() => new Promise<never>(() => {}))
+    }),
     identity: { origin: "test", workspaceId: "workspace-1" },
     scheduler: { schedule: () => ({ cancel() {} }) }
   });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIEngineSettlementController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIEngineSettlementController.spec.ts
@@ -4,7 +4,10 @@ import {
   selectPendingSubmitsForSession
 } from "@tutti-os/agent-activity-core";
 import { describe, expect, it, vi } from "vitest";
-import { createTestAgentSessionEngine } from "../../../shared/testing/createTestAgentSessionEngine";
+import {
+  createTestAgentSessionEngine,
+  createTestAgentSessionEngineWithEffects
+} from "../../../shared/testing/createTestAgentSessionEngine";
 import {
   agentComposerDraftPrompt,
   emptyAgentComposerDraft
@@ -294,28 +297,24 @@ describe("AgentGUIEngineSettlementController", () => {
   });
 
   it("settles a Goal draft when Host durably accepts an applying operation", async () => {
-    const engine = createTestAgentSessionEngine("test-workspace", {
-      effects: {
-        controlGoal: () =>
-          Promise.resolve({
-            goal: { objective: "ship it", status: "active" },
-            operationId: "goal-operation-1",
-            session: sessionWithGoal("old goal"),
-            state: {
-              desired: { objective: "ship it", status: "active" },
-              lastEvidence: { source: "test" },
-              observed: { objective: "old goal", status: "active" },
-              pendingOperationId: "goal-operation-1",
-              revision: 2,
-              syncStatus: "applying",
-              tombstoned: false,
-              updatedAtUnixMs: 2
-            }
-          })
-      },
-      execute: () => Promise.resolve({ ok: true }),
-      kind: "typed"
-    } as never);
+    const engine = createTestAgentSessionEngineWithEffects("test-workspace", {
+      controlGoal: () =>
+        Promise.resolve({
+          goal: { objective: "ship it", status: "active" },
+          operationId: "goal-operation-1",
+          session: sessionWithGoal("old goal"),
+          state: {
+            desired: { objective: "ship it", status: "active" },
+            lastEvidence: { source: "test" },
+            observed: { objective: "old goal", status: "active" },
+            pendingOperationId: "goal-operation-1",
+            revision: 2,
+            syncStatus: "applying",
+            tombstoned: false,
+            updatedAtUnixMs: 2
+          }
+        })
+    });
     engine.dispatch({
       session: sessionWithGoal("old goal"),
       type: "session/upserted"
@@ -369,13 +368,9 @@ describe("AgentGUIEngineSettlementController", () => {
     const rejection = Object.assign(new Error("invalid goal"), {
       code: "invalid_request"
     });
-    const engine = createTestAgentSessionEngine("test-workspace", {
-      effects: {
-        controlGoal: () => Promise.reject(rejection)
-      },
-      execute: () => Promise.resolve({ ok: true }),
-      kind: "typed"
-    } as never);
+    const engine = createTestAgentSessionEngineWithEffects("test-workspace", {
+      controlGoal: () => Promise.reject(rejection)
+    });
     engine.dispatch({
       session: sessionWithGoal("old goal"),
       type: "session/upserted"

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiNewConversationRequest.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiNewConversationRequest.spec.tsx
@@ -8,6 +8,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createLocalAgentGUIAgentTarget } from "../../../agentTargets";
 import type { AgentGUIRuntime } from "../../../agentActivityRuntime";
 import type { AgentHostUserProject } from "../../../host/agentHostApi";
+import { createTestEngineCommandPort } from "../../../shared/testing/createTestAgentSessionEngine";
 import type { AgentGUINodeData } from "../../../types";
 import type { AgentGUIConversationSummary } from "../model/agentGuiConversationModel";
 import type { AgentComposerDraft } from "../model/agentGuiNodeTypes";
@@ -182,12 +183,12 @@ function renderNewConversationScenario(input: {
   const commands: EngineExternalCommand[] = [];
   const sessionEngine = createAgentSessionEngine({
     clock: { nowUnixMs: () => 1 },
-    commandPort: {
+    commandPort: createTestEngineCommandPort({
       execute: (command) => {
         commands.push(command);
         return new Promise<never>(() => {});
       }
-    },
+    }),
     identity: { origin: "test", workspaceId: "workspace-1" },
     scheduler: { schedule: () => ({ cancel() {} }) }
   });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerSettingsActions.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerSettingsActions.spec.tsx
@@ -7,6 +7,7 @@ import {
 } from "@tutti-os/agent-activity-core";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentGUIRuntime } from "../../../agentActivityRuntime";
+import { createTestEngineCommandPort } from "../../../shared/testing/createTestAgentSessionEngine";
 import type { AgentSessionComposerSettings } from "../../../shared/agentSessionTypes";
 import type { AgentGUINodeData } from "../../../types";
 import type { AgentGUIRememberComposerDefaultsResult } from "./agentGuiController.providerHelpers";
@@ -18,7 +19,7 @@ describe("useAgentGUIComposerSettingsActions", () => {
   it("retires a remembered model rejected by the authoritative target catalog", () => {
     const sessionEngine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 1 },
-      commandPort: { execute: vi.fn() },
+      commandPort: createTestEngineCommandPort({ execute: vi.fn() }),
       identity: { origin: "test", workspaceId: "workspace-1" },
       scheduler: { schedule: () => ({ cancel() {} }) }
     });
@@ -124,7 +125,7 @@ describe("useAgentGUIComposerSettingsActions", () => {
   it("preserves all explicit home defaults across stale options, transient empty selects, and unrelated patches", () => {
     const sessionEngine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 1 },
-      commandPort: { execute: vi.fn() },
+      commandPort: createTestEngineCommandPort({ execute: vi.fn() }),
       identity: { origin: "test", workspaceId: "workspace-1" },
       scheduler: { schedule: () => ({ cancel() {} }) }
     });
@@ -257,7 +258,7 @@ describe("useAgentGUIComposerSettingsActions", () => {
     const execute = vi.fn(() => new Promise<unknown>(() => undefined));
     const sessionEngine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 1 },
-      commandPort: { execute },
+      commandPort: createTestEngineCommandPort({ execute }),
       identity: { origin: "test", workspaceId: "workspace-1" },
       scheduler: { schedule: () => ({ cancel() {} }) }
     });
@@ -385,7 +386,7 @@ describe("useAgentGUIComposerSettingsActions", () => {
   it("reconciles A to B to A by exact field generation", async () => {
     const sessionEngine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 1 },
-      commandPort: { execute: vi.fn() },
+      commandPort: createTestEngineCommandPort({ execute: vi.fn() }),
       identity: { origin: "test", workspaceId: "workspace-1" },
       scheduler: { schedule: () => ({ cancel() {} }) }
     });
@@ -536,7 +537,7 @@ describe("useAgentGUIComposerSettingsActions", () => {
   it("keeps acknowledged intent after a failed reload and releases confirmation when authority omits the field", async () => {
     const sessionEngine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 1 },
-      commandPort: { execute: vi.fn() },
+      commandPort: createTestEngineCommandPort({ execute: vi.fn() }),
       identity: { origin: "test", workspaceId: "workspace-1" },
       scheduler: { schedule: () => ({ cancel() {} }) }
     });
@@ -680,7 +681,7 @@ describe("useAgentGUIComposerSettingsActions", () => {
   it("does not sanitize an acknowledged model before a stale authority read is reconciled", async () => {
     const sessionEngine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 1 },
-      commandPort: { execute: vi.fn() },
+      commandPort: createTestEngineCommandPort({ execute: vi.fn() }),
       identity: { origin: "test", workspaceId: "workspace-1" },
       scheduler: { schedule: () => ({ cancel() {} }) }
     });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRouting.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRouting.spec.tsx
@@ -4,13 +4,16 @@ import {
   selectEngineSessionReconcile
 } from "@tutti-os/agent-activity-core";
 import { describe, expect, it, vi } from "vitest";
+import { createTestEngineCommandPort } from "../../../shared/testing/createTestAgentSessionEngine";
 import { useAgentGUIConversationRouting } from "./useAgentGUIConversationRouting";
 
 describe("useAgentGUIConversationRouting", () => {
   it("keeps an explicitly selected active session outside bounded rail state", () => {
     const sessionEngine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 1 },
-      commandPort: { execute: async () => undefined },
+      commandPort: createTestEngineCommandPort({
+        execute: async () => undefined
+      }),
       identity: { origin: "test", workspaceId: "workspace-1" },
       scheduler: { schedule: () => ({ cancel() {} }) }
     });
@@ -43,7 +46,9 @@ describe("useAgentGUIConversationRouting", () => {
   it("reconciles a persisted selection outside the bounded list after restart", () => {
     const sessionEngine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 1 },
-      commandPort: { execute: async () => undefined },
+      commandPort: createTestEngineCommandPort({
+        execute: async () => undefined
+      }),
       identity: { origin: "test", workspaceId: "workspace-1" },
       scheduler: { schedule: () => ({ cancel() {} }) }
     });
@@ -86,7 +91,9 @@ describe("useAgentGUIConversationRouting", () => {
     (intentTag) => {
       const sessionEngine = createAgentSessionEngine({
         clock: { nowUnixMs: () => 1 },
-        commandPort: { execute: () => new Promise(() => {}) },
+        commandPort: createTestEngineCommandPort({
+          execute: () => new Promise(() => {})
+        }),
         identity: { origin: "test", workspaceId: "workspace-1" },
         scheduler: { schedule: () => ({ cancel() {} }) }
       });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIQueueActions.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIQueueActions.spec.tsx
@@ -6,6 +6,7 @@ import {
 import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentGUIRuntime } from "../../../agentActivityRuntime";
+import { createTestEngineCommandPort } from "../../../shared/testing/createTestAgentSessionEngine";
 import type { AgentComposerDraft } from "../model/agentGuiNodeTypes";
 import { agentComposerDraftImages } from "../model/agentComposerDraft";
 import { useAgentGUIQueueActions } from "./useAgentGUIQueueActions";
@@ -23,7 +24,9 @@ describe("useAgentGUIQueueActions", () => {
     );
     const sessionEngine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 1 },
-      commandPort: { execute: async () => undefined },
+      commandPort: createTestEngineCommandPort({
+        execute: async () => undefined
+      }),
       identity: { origin: "test", workspaceId: "workspace-1" },
       scheduler: { schedule: () => ({ cancel() {} }) }
     });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionEngineState.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionEngineState.spec.tsx
@@ -5,13 +5,16 @@ import {
   selectEngineSessionSettingsUpdate
 } from "@tutti-os/agent-activity-core";
 import { describe, expect, it, vi } from "vitest";
+import { createTestEngineCommandPort } from "../../../shared/testing/createTestAgentSessionEngine";
 import { useAgentGUISessionEngineState } from "./useAgentGUISessionEngineState";
 
 describe("useAgentGUISessionEngineState", () => {
   it("shows an optimistic session selection then silently restores canonical settings on failure", () => {
     const sessionEngine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 1 },
-      commandPort: { execute: vi.fn(() => new Promise(() => undefined)) },
+      commandPort: createTestEngineCommandPort({
+        execute: vi.fn(() => new Promise(() => undefined))
+      }),
       identity: { origin: "test", workspaceId: "workspace-1" },
       scheduler: { schedule: () => ({ cancel() {} }) }
     });
@@ -72,7 +75,9 @@ describe("useAgentGUISessionEngineState", () => {
   it("keeps the latest queued settings visible while the session runtime reconnects", () => {
     const sessionEngine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 1 },
-      commandPort: { execute: vi.fn(() => new Promise(() => undefined)) },
+      commandPort: createTestEngineCommandPort({
+        execute: vi.fn(() => new Promise(() => undefined))
+      }),
       identity: { origin: "test", workspaceId: "workspace-1" },
       scheduler: { schedule: () => ({ cancel() {} }) }
     });
@@ -189,7 +194,9 @@ describe("useAgentGUISessionEngineState", () => {
   it("observes runtime availability for the selected session only", () => {
     const sessionEngine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 1 },
-      commandPort: { execute: vi.fn(() => new Promise(() => undefined)) },
+      commandPort: createTestEngineCommandPort({
+        execute: vi.fn(() => new Promise(() => undefined))
+      }),
       identity: { origin: "test", workspaceId: "workspace-1" },
       scheduler: { schedule: () => ({ cancel() {} }) }
     });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.spec.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook } from "@testing-library/react";
 import { createAgentSessionEngine } from "@tutti-os/agent-activity-core";
 import { describe, expect, it, vi } from "vitest";
+import { createTestEngineCommandPort } from "../../../shared/testing/createTestAgentSessionEngine";
 import type {
   AgentGUIObservationGap,
   AgentGUIObservationGapSource,
@@ -57,7 +58,9 @@ describe("useAgentGUISessionPresentation", () => {
     const targetConnectionSource = new FakeTargetConnectionSource();
     const sessionEngine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 1 },
-      commandPort: { execute: vi.fn(() => new Promise(() => undefined)) },
+      commandPort: createTestEngineCommandPort({
+        execute: vi.fn(() => new Promise(() => undefined))
+      }),
       identity: { origin: "test", workspaceId: "workspace-1" },
       scheduler: { schedule: () => ({ cancel() {} }) }
     });
@@ -149,7 +152,9 @@ describe("useAgentGUISessionPresentation", () => {
     const observationGapSource = new FakeObservationGapSource();
     const sessionEngine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 1 },
-      commandPort: { execute: vi.fn(() => new Promise(() => undefined)) },
+      commandPort: createTestEngineCommandPort({
+        execute: vi.fn(() => new Promise(() => undefined))
+      }),
       identity: { origin: "test", workspaceId: "workspace-1" },
       scheduler: { schedule: () => ({ cancel() {} }) }
     });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUITuttiModeActivation.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUITuttiModeActivation.spec.tsx
@@ -6,6 +6,7 @@ import {
   type EngineExternalCommand
 } from "@tutti-os/agent-activity-core";
 import { describe, expect, it, vi } from "vitest";
+import { createTestEngineCommandPort } from "../../../shared/testing/createTestAgentSessionEngine";
 import {
   resolveAgentGUITuttiModeDraftKey,
   useAgentGUITuttiModeActivation
@@ -259,7 +260,7 @@ function createTestEngine() {
   });
   const engine = createAgentSessionEngine({
     clock: { nowUnixMs: () => 1 },
-    commandPort: { execute },
+    commandPort: createTestEngineCommandPort({ execute }),
     identity: { origin: "test", workspaceId: "workspace-1" },
     scheduler: { schedule: () => ({ cancel() {} }) }
   });

--- a/packages/agent/gui/agent-message-center/workspaceAgentConsumerSelectors.spec.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentConsumerSelectors.spec.ts
@@ -4,6 +4,7 @@ import {
   normalizeAgentActivitySession,
   type AgentActivitySession
 } from "@tutti-os/agent-activity-core";
+import { createTestEngineCommandPort } from "../shared/testing/createTestAgentSessionEngine";
 import {
   buildWorkspaceAgentMessageCenterModelFromEngine,
   selectWorkspaceAgentAttentionItems,
@@ -602,7 +603,7 @@ describe("workspaceAgentConsumerSelectors", () => {
 function createEngine() {
   return createAgentSessionEngine({
     clock: { nowUnixMs: () => 1 },
-    commandPort: { execute: async () => ({}) },
+    commandPort: createTestEngineCommandPort({ execute: async () => ({}) }),
     identity: { origin: "test", workspaceId: "workspace-1" },
     scheduler: { schedule: () => ({ cancel() {} }) }
   });

--- a/packages/agent/gui/agentConversationMessageController.spec.ts
+++ b/packages/agent/gui/agentConversationMessageController.spec.ts
@@ -1,11 +1,13 @@
 import {
   selectSessionMessages,
   selectSessionMessageWindow,
-  type AgentActivityMessagePage,
-  type EngineCommandPort
+  type AgentActivityMessagePage
 } from "@tutti-os/agent-activity-core";
 import { describe, expect, it, vi } from "vitest";
-import { createTestAgentSessionEngine } from "./shared/testing/createTestAgentSessionEngine";
+import {
+  createTestAgentSessionEngine,
+  type TestEngineCommandHandler
+} from "./shared/testing/createTestAgentSessionEngine";
 import {
   createAgentConversationMessageController,
   type AgentConversationMessagePageInput
@@ -13,7 +15,7 @@ import {
 
 describe("createAgentConversationMessageController", () => {
   it("routes initial and latest hydration through Engine reconcile commands", async () => {
-    const execute = vi.fn<EngineCommandPort["execute"]>(async () => ({
+    const execute = vi.fn<TestEngineCommandHandler["execute"]>(async () => ({
       affectedSessionIds: [],
       appliedMessages: [],
       session: null,
@@ -52,9 +54,11 @@ describe("createAgentConversationMessageController", () => {
   });
 
   it("treats repeated initial hydration as idempotent while reconcile is pending", async () => {
-    type CommandResult = Awaited<ReturnType<EngineCommandPort["execute"]>>;
+    type CommandResult = Awaited<
+      ReturnType<TestEngineCommandHandler["execute"]>
+    >;
     let resolveExecute: (result: CommandResult) => void = () => {};
-    const execute = vi.fn<EngineCommandPort["execute"]>(
+    const execute = vi.fn<TestEngineCommandHandler["execute"]>(
       () =>
         new Promise((resolve) => {
           resolveExecute = resolve;

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/useAgentGuiConversationList.spec.tsx
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/useAgentGuiConversationList.spec.tsx
@@ -2,13 +2,14 @@ import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { createAgentSessionEngine } from "@tutti-os/agent-activity-core";
 import { createLocalAgentGUIAgentTarget } from "../../../../../agentTargets";
+import { createTestEngineCommandPort } from "../../../../../shared/testing/createTestAgentSessionEngine";
 import { useAgentGuiConversationList } from "./useAgentGuiConversationList";
 
 describe("useAgentGuiConversationList", () => {
   it("projects a child interaction as user action on its root conversation", () => {
     const engine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 1 },
-      commandPort: { execute: async () => ({}) },
+      commandPort: createTestEngineCommandPort({ execute: async () => ({}) }),
       identity: { origin: "test", workspaceId: "workspace-1" },
       scheduler: { schedule: () => ({ cancel() {} }) }
     });
@@ -98,7 +99,7 @@ describe("useAgentGuiConversationList", () => {
   it("projects a plain @ title from a matching mention-rich initial prompt", () => {
     const engine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 1 },
-      commandPort: { execute: async () => ({}) },
+      commandPort: createTestEngineCommandPort({ execute: async () => ({}) }),
       identity: { origin: "test", workspaceId: "workspace-1" },
       scheduler: { schedule: () => ({ cancel() {} }) }
     });
@@ -145,7 +146,7 @@ describe("useAgentGuiConversationList", () => {
   it("shows only conversation text for a browser-element activation", () => {
     const engine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 1 },
-      commandPort: { execute: async () => ({}) },
+      commandPort: createTestEngineCommandPort({ execute: async () => ({}) }),
       identity: { origin: "test", workspaceId: "workspace-1" },
       scheduler: { schedule: () => ({ cancel() {} }) }
     });
@@ -191,7 +192,7 @@ describe("useAgentGuiConversationList", () => {
   it("shows only conversation text for a canonical browser-element session", () => {
     const engine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 1 },
-      commandPort: { execute: async () => ({}) },
+      commandPort: createTestEngineCommandPort({ execute: async () => ({}) }),
       identity: { origin: "test", workspaceId: "workspace-1" },
       scheduler: { schedule: () => ({ cancel() {} }) }
     });
@@ -259,7 +260,7 @@ describe("useAgentGuiConversationList", () => {
   it("shows a historical session marker after its first message is loaded", () => {
     const engine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 1 },
-      commandPort: { execute: async () => ({}) },
+      commandPort: createTestEngineCommandPort({ execute: async () => ({}) }),
       identity: { origin: "test", workspaceId: "workspace-1" },
       scheduler: { schedule: () => ({ cancel() {} }) }
     });
@@ -333,7 +334,7 @@ describe("useAgentGuiConversationList", () => {
   it("keeps the projected list stable while an assistant message streams", () => {
     const engine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 1 },
-      commandPort: { execute: async () => ({}) },
+      commandPort: createTestEngineCommandPort({ execute: async () => ({}) }),
       identity: { origin: "test", workspaceId: "workspace-1" },
       scheduler: { schedule: () => ({ cancel() {} }) }
     });
@@ -413,7 +414,7 @@ describe("useAgentGuiConversationList", () => {
   it("keeps the optimistic activation title until canonical title arrives", () => {
     const engine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 1 },
-      commandPort: { execute: async () => ({}) },
+      commandPort: createTestEngineCommandPort({ execute: async () => ({}) }),
       identity: { origin: "test", workspaceId: "workspace-1" },
       scheduler: { schedule: () => ({ cancel() {} }) }
     });
@@ -486,7 +487,7 @@ describe("useAgentGuiConversationList", () => {
   it("projects canonical sessions and pending activation records without a list store", () => {
     const engine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 1 },
-      commandPort: { execute: async () => ({}) },
+      commandPort: createTestEngineCommandPort({ execute: async () => ({}) }),
       identity: { origin: "test", workspaceId: "workspace-1" },
       scheduler: { schedule: () => ({ cancel() {} }) }
     });
@@ -552,7 +553,7 @@ describe("useAgentGuiConversationList", () => {
   it("keeps concurrent pending activations ordered and replaces only the canonicalized row", () => {
     const engine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 1 },
-      commandPort: { execute: async () => ({}) },
+      commandPort: createTestEngineCommandPort({ execute: async () => ({}) }),
       identity: { origin: "test", workspaceId: "workspace-1" },
       scheduler: { schedule: () => ({ cancel() {} }) }
     });
@@ -658,7 +659,7 @@ describe("useAgentGuiConversationList", () => {
   it("orders canonical sessions by latest turn start instead of update timestamps", () => {
     const engine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 1 },
-      commandPort: { execute: async () => ({}) },
+      commandPort: createTestEngineCommandPort({ execute: async () => ({}) }),
       identity: { origin: "test", workspaceId: "workspace-1" },
       scheduler: { schedule: () => ({ cancel() {} }) }
     });

--- a/packages/agent/gui/shared/agentConversation/agentPlanPromptDispatch.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/agentPlanPromptDispatch.spec.ts
@@ -3,6 +3,7 @@ import {
   createAgentSessionEngine,
   type EngineCommand
 } from "@tutti-os/agent-activity-core";
+import { createTestEngineCommandPort } from "../testing/createTestAgentSessionEngine";
 import { dispatchAgentPlanPromptAction } from "./agentPlanPromptDispatch";
 
 describe("dispatchAgentPlanPromptAction", () => {
@@ -16,7 +17,7 @@ describe("dispatchAgentPlanPromptAction", () => {
       const executedTypes: string[] = [];
       const engine = createAgentSessionEngine({
         clock: { nowUnixMs: () => 10 },
-        commandPort: {
+        commandPort: createTestEngineCommandPort({
           async executePlanDecision(command) {
             executedTypes.push(command.type);
             return {
@@ -34,7 +35,7 @@ describe("dispatchAgentPlanPromptAction", () => {
           async execute(command) {
             executedTypes.push(command.type);
           }
-        },
+        }),
         identity: { origin: "test", workspaceId: "workspace-1" },
         scheduler: { schedule: () => ({ cancel() {} }) }
       });
@@ -86,7 +87,9 @@ describe("dispatchAgentPlanPromptAction", () => {
   it("rejects a request id that is not the latest settled completed turn", () => {
     const engine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 1 },
-      commandPort: { execute: async () => undefined },
+      commandPort: createTestEngineCommandPort({
+        execute: async () => undefined
+      }),
       identity: { origin: "test", workspaceId: "workspace-1" },
       scheduler: { schedule: () => ({ cancel() {} }) }
     });
@@ -105,11 +108,11 @@ describe("dispatchAgentPlanPromptAction", () => {
     const executed: EngineCommand[] = [];
     const engine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 10 },
-      commandPort: {
+      commandPort: createTestEngineCommandPort({
         async execute(command) {
           executed.push(command);
         }
-      },
+      }),
       identity: { origin: "test", workspaceId: "workspace-1" },
       scheduler: { schedule: () => ({ cancel() {} }) }
     });

--- a/packages/agent/gui/shared/testing/createTestAgentSessionEngine.ts
+++ b/packages/agent/gui/shared/testing/createTestAgentSessionEngine.ts
@@ -1,15 +1,51 @@
 import {
   AGENT_SESSION_ENGINE_LOCAL_ORIGIN,
   createAgentSessionEngine,
+  type AgentSessionEffectPort,
   type AgentSessionEngine,
-  type EngineCommandPort
+  type EngineEffectOptions,
+  type EngineExternalCommand,
+  type EngineTypedCommandPort,
+  type PlanSubmitDecisionCommand,
+  type PlanSubmitDecisionResult
 } from "@tutti-os/agent-activity-core";
+
+export interface TestEngineCommandHandler {
+  execute(
+    command: EngineExternalCommand,
+    options?: EngineEffectOptions
+  ): Promise<unknown>;
+  executePlanDecision?(
+    command: PlanSubmitDecisionCommand,
+    options?: EngineEffectOptions
+  ): Promise<PlanSubmitDecisionResult>;
+}
 
 export function createTestAgentSessionEngine(
   workspaceId = "test-workspace",
-  commandPort: EngineCommandPort = {
+  commandHandler: TestEngineCommandHandler = {
     execute: async () => ({ ok: true })
   }
+): AgentSessionEngine {
+  return createEngine(workspaceId, createTestEngineCommandPort(commandHandler));
+}
+
+export function createTestAgentSessionEngineWithEffects(
+  workspaceId: string,
+  effectOverrides: Partial<AgentSessionEffectPort>
+): AgentSessionEngine {
+  const commandPort = createTestEngineCommandPort({
+    execute: async () => ({ ok: true })
+  });
+  return createEngine(workspaceId, {
+    ...commandPort,
+    effects: { ...commandPort.effects, ...effectOverrides }
+  });
+}
+
+function createEngine(
+  workspaceId: string,
+  commandPort: EngineTypedCommandPort
 ): AgentSessionEngine {
   const engine = createAgentSessionEngine({
     clock: { nowUnixMs: () => Date.now() },
@@ -17,7 +53,6 @@ export function createTestAgentSessionEngine(
     identity: { origin: AGENT_SESSION_ENGINE_LOCAL_ORIGIN, workspaceId },
     scheduler: {
       schedule(delayMs, task) {
-        // timing: temp code, commit first
         const timer = setTimeout(task, delayMs);
         return { cancel: () => clearTimeout(timer) };
       }
@@ -25,4 +60,48 @@ export function createTestAgentSessionEngine(
   });
   engine.dispatch({ type: "workspace/reconcileRequested", workspaceId });
   return engine;
+}
+
+export function createTestEngineCommandPort(
+  commandHandler: TestEngineCommandHandler
+): EngineTypedCommandPort {
+  const commands = new Map<string, EngineExternalCommand>();
+  function executeObserved<TResult>(
+    options: EngineEffectOptions | undefined
+  ): Promise<TResult> {
+    const command = options ? commands.get(options.commandId) : undefined;
+    if (!command) {
+      return Promise.reject(new Error("test Engine command was not observed"));
+    }
+    return commandHandler.execute(command, options) as Promise<TResult>;
+  }
+  const effects: AgentSessionEffectPort = {
+    activateSession: (_input, options) => executeObserved(options),
+    cancelTurn: (_input, options) => executeObserved(options),
+    controlGoal: (_input, options) => executeObserved(options),
+    deleteSessions: (_input, options) => executeObserved(options),
+    renameSession: (_input, options) => executeObserved(options),
+    respondToInteraction: (_input, options) => executeObserved(options),
+    sendInput: (_input, options) => executeObserved(options),
+    setSessionPinned: (_input, options) => executeObserved(options),
+    updateSessionSettings: (_input, options) => executeObserved(options)
+  };
+  return {
+    effects,
+    execute(command, options) {
+      return commandHandler.execute(command, options);
+    },
+    executePlanDecision(command, options) {
+      return commandHandler.executePlanDecision
+        ? commandHandler.executePlanDecision(command, options)
+        : (commandHandler.execute(
+            command,
+            options
+          ) as Promise<PlanSubmitDecisionResult>);
+    },
+    kind: "typed",
+    observe(command) {
+      commands.set(command.commandId, command);
+    }
+  };
 }

--- a/packages/agent/gui/workbench/conversationIdentity.test.ts
+++ b/packages/agent/gui/workbench/conversationIdentity.test.ts
@@ -3,6 +3,7 @@ import {
   createAgentSessionEngine,
   type AgentActivityMessage
 } from "@tutti-os/agent-activity-core";
+import { createTestEngineCommandPort } from "../shared/testing/createTestAgentSessionEngine";
 import {
   resolveAgentGuiWorkbenchConversationIdentity,
   resolveAgentGuiWorkbenchTitleDisplayPrompt
@@ -26,7 +27,7 @@ describe("resolveAgentGuiWorkbenchTitleDisplayPrompt", () => {
       "[@img](mention://browser-element/browser-element%3A1?tag=img&workspaceId=workspace-1) 这张图片打出来给我看看";
     const engine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 1 },
-      commandPort: { execute: async () => ({}) },
+      commandPort: createTestEngineCommandPort({ execute: async () => ({}) }),
       identity: { origin: "test", workspaceId: "workspace-1" },
       scheduler: { schedule: () => ({ cancel() {} }) }
     });
@@ -118,7 +119,7 @@ describe("resolveAgentGuiWorkbenchConversationIdentity", () => {
   it("preserves the exact Session Agent target for Host header presentation", () => {
     const engine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 1 },
-      commandPort: { execute: async () => ({}) },
+      commandPort: createTestEngineCommandPort({ execute: async () => ({}) }),
       identity: { origin: "test", workspaceId: "workspace-1" },
       scheduler: { schedule: () => ({ cancel() {} }) }
     });


### PR DESCRIPTION
## Summary

- remove the legacy `EngineCommandPort`, `EngineExternalCommandExceptPlanDecision`, and root `dispatchSessionMutation` exports
- make `EngineTypedCommandPort` plus `AgentSessionEffectPort` the only Agent Session Engine execution seam
- remove the non-typed executor branch and migrate package tests/test hosts to typed effects
- update architecture docs and the existing major changeset with the activity-core migration

## Behavior impact

This is a compatibility-layer cleanup only. Desktop and Mobile already use typed effects, and TSH on the upgraded Tutti cohort has no references to the removed APIs. Local and Shared hosts retain their existing transport, permission, attachment, subscription, and diagnostics behavior.

## Validation

- `pnpm check:changed` — 13 lanes passed
- pre-push `pnpm check:changed -- --push-ready` — 14 lanes passed
- `@tutti-os/agent-activity-core` — 432 tests passed
- `@tutti-os/agent-gui` — 2,578 tests passed
- static consumer audit found no legacy API references in Desktop, Mobile, or TSH

## Review lanes

- Architecture: pass; production code exposes only the typed lifecycle/extension boundary
- Performance: pass; no new subscriptions, timers, caches, or effect calls
- Consumers: pass; Desktop, Mobile, and TSH are migrated, and the breaking migration is documented in the changeset