### PR TITLE
refactor(workbench): unify minimized preview runtime

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostInputResolver.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostInputResolver.ts
@@ -11,6 +11,7 @@ import {
   type WorkbenchHostSessionResolution
 } from "@tutti-os/workbench-host";
 import {
+  createWorkbenchNodePreviewCaptureAdapter,
   resolveWorkbenchHostPrepareClose,
   type WorkbenchDebugDiagnostics,
   type WorkbenchHostCloseDialogRequest
@@ -347,258 +348,25 @@ function createDesktopWorkspaceNodePreviewCapture(
   runtimeApi: Pick<DesktopRuntimeApi, "logRendererDiagnostic">,
   workspaceId: string
 ): NonNullable<WorkspaceWorkbenchHostInput["captureNodePreviewImages"]> {
-  return async (node) => {
-    if (node.isMinimized || document.visibilityState !== "visible") {
-      logDockPreviewCaptureDiagnostic(runtimeApi, workspaceId, {
-        details: {
-          documentVisibilityState: document.visibilityState,
-          isMinimized: node.isMinimized,
-          nodeId: node.id,
-          typeId: node.data.typeId
-        },
-        event: "dock_preview_capture.skipped",
-        level: "debug"
-      });
-      return null;
-    }
-
-    const captureContext = resolveWorkspaceNodeCaptureTarget(node.id);
-    if (!captureContext) {
-      logDockPreviewCaptureDiagnostic(runtimeApi, workspaceId, {
-        details: { nodeId: node.id, typeId: node.data.typeId },
-        event: "dock_preview_capture.target_missing",
-        level: "warn"
-      });
-      return null;
-    }
-
-    const { captureTarget, windowElement } = captureContext;
-    if (!isForegroundWorkspaceNodeCaptureTarget(windowElement)) {
-      return null;
-    }
-
-    const rect = captureTarget.getBoundingClientRect();
-    if (rect.width <= 0 || rect.height <= 0) {
-      logDockPreviewCaptureDiagnostic(runtimeApi, workspaceId, {
-        details: {
-          height: rect.height,
-          nodeId: node.id,
-          typeId: node.data.typeId,
-          width: rect.width,
-          x: rect.left,
-          y: rect.top
-        },
-        event: "dock_preview_capture.invalid_rect",
-        level: "warn"
-      });
-      return null;
-    }
-
-    const nativeCaptureBlockReason = resolveNativeCaptureBlockReason(
-      captureTarget,
-      rect
-    );
-    if (nativeCaptureBlockReason) {
-      logDockPreviewCaptureDiagnostic(runtimeApi, workspaceId, {
-        details: {
-          height: rect.height,
-          nodeId: node.id,
-          reason: nativeCaptureBlockReason,
-          typeId: node.data.typeId,
-          width: rect.width,
-          x: rect.left,
-          y: rect.top
-        },
-        event: "dock_preview_capture.native_skipped",
-        level: "debug"
-      });
-      return null;
-    }
-
-    const captureStartedAt = performance.now();
-    logDockPreviewCaptureDiagnostic(runtimeApi, workspaceId, {
-      details: {
-        height: rect.height,
-        nodeId: node.id,
-        timeoutMs: workspaceDockNativePreviewTimeoutMs,
-        typeId: node.data.typeId,
-        width: rect.width,
-        x: rect.left,
-        y: rect.top
-      },
-      event: "dock_preview_capture.started",
-      level: "info"
-    });
-
-    let captureResult: PreviewImagesCaptureResult;
-    try {
-      const capturePromise = hostWindowApi.capturePreviewImages({
-        maxHeight: workspaceDockNativePreviewMaxHeightPx,
-        maxWidth: workspaceDockNativePreviewMaxWidthPx,
-        rect: {
-          height: rect.height,
-          width: rect.width,
-          x: rect.left,
-          y: rect.top
-        }
-      });
-      capturePromise.catch(() => undefined);
-      captureResult = await resolvePreviewImagesCaptureWithTimeout(
-        capturePromise,
-        workspaceDockNativePreviewTimeoutMs
-      );
-    } catch (error) {
-      logDockPreviewCaptureDiagnostic(runtimeApi, workspaceId, {
-        details: {
-          durationMs: Math.round(performance.now() - captureStartedAt),
-          error: error instanceof Error ? error.message : String(error),
-          nodeId: node.id,
-          typeId: node.data.typeId
-        },
-        event: "dock_preview_capture.ipc_failed",
-        level: "warn"
-      });
-      return null;
-    }
-
-    if (captureResult.status === "timeout") {
-      logDockPreviewCaptureDiagnostic(runtimeApi, workspaceId, {
-        details: {
-          durationMs: Math.round(performance.now() - captureStartedAt),
-          nodeId: node.id,
-          timeoutMs: workspaceDockNativePreviewTimeoutMs,
-          typeId: node.data.typeId
-        },
-        event: "dock_preview_capture.timed_out",
-        level: "warn"
-      });
-      return null;
-    }
-
-    const previewImages = captureResult.previewImages;
-
-    if (!previewImages) {
-      logDockPreviewCaptureDiagnostic(runtimeApi, workspaceId, {
-        details: {
-          durationMs: Math.round(performance.now() - captureStartedAt),
-          height: rect.height,
-          nodeId: node.id,
-          typeId: node.data.typeId,
-          width: rect.width,
-          x: rect.left,
-          y: rect.top
-        },
-        event: "dock_preview_capture.empty_result",
-        level: "warn"
-      });
-    } else {
-      logDockPreviewCaptureDiagnostic(runtimeApi, workspaceId, {
-        details: {
-          durationMs: Math.round(performance.now() - captureStartedAt),
-          nodeId: node.id,
-          dockPreviewLength: previewImages.dockPreviewImageUrl.length,
-          genieImageLength: previewImages.genieImageUrl.length,
-          typeId: node.data.typeId
-        },
-        event: "dock_preview_capture.succeeded",
-        level: "info"
-      });
-    }
-
-    return previewImages;
-  };
-}
-
-function resolveNativeCaptureBlockReason(
-  _target: HTMLElement,
-  rect: DOMRect
-): "outside_viewport" | null {
-  if (
-    rect.left < 0 ||
-    rect.top < 0 ||
-    rect.right > window.innerWidth ||
-    rect.bottom > window.innerHeight
-  ) {
-    return "outside_viewport";
-  }
-  return null;
-}
-
-function isForegroundWorkspaceNodeCaptureTarget(
-  windowElement: HTMLElement
-): boolean {
-  return windowElement.dataset.focused === "true";
-}
-
-type PreviewImagesCaptureResult =
-  | {
-      previewImages: Awaited<
-        ReturnType<DesktopHostWindowApi["capturePreviewImages"]>
-      >;
-      status: "resolved";
-    }
-  | { status: "timeout" };
-
-function resolvePreviewImagesCaptureWithTimeout(
-  capturePromise: ReturnType<DesktopHostWindowApi["capturePreviewImages"]>,
-  timeoutMs: number
-): Promise<PreviewImagesCaptureResult> {
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  const timeoutPromise = new Promise<PreviewImagesCaptureResult>((resolve) => {
-    timeout = setTimeout(() => resolve({ status: "timeout" }), timeoutMs);
+  return createWorkbenchNodePreviewCaptureAdapter({
+    captureRect: ({ maxHeight, maxWidth, rect }) =>
+      hostWindowApi.capturePreviewImages({ maxHeight, maxWidth, rect }),
+    diagnostics: (diagnostic) => {
+      void runtimeApi
+        .logRendererDiagnostic({
+          details: diagnostic.details,
+          event: `dock_preview_${diagnostic.event}`,
+          level: diagnostic.level,
+          source: "workspace-workbench",
+          workspaceId
+        })
+        .catch(() => undefined);
+    },
+    maxHeight: workspaceDockNativePreviewMaxHeightPx,
+    maxWidth: workspaceDockNativePreviewMaxWidthPx,
+    resolveDiagnosticContext: (node) => ({ typeId: node.data.typeId }),
+    timeoutMs: workspaceDockNativePreviewTimeoutMs
   });
-  return Promise.race([
-    capturePromise.then((previewImages) => ({
-      previewImages,
-      status: "resolved" as const
-    })),
-    timeoutPromise
-  ]).finally(() => {
-    if (timeout) {
-      clearTimeout(timeout);
-    }
-  });
-}
-
-function logDockPreviewCaptureDiagnostic(
-  runtimeApi: Pick<DesktopRuntimeApi, "logRendererDiagnostic">,
-  workspaceId: string,
-  input: {
-    details: Record<string, unknown>;
-    event: string;
-    level: "debug" | "info" | "warn";
-  }
-): void {
-  void runtimeApi
-    .logRendererDiagnostic({
-      details: input.details,
-      event: input.event,
-      level: input.level,
-      source: "workspace-workbench",
-      workspaceId
-    })
-    .catch(() => undefined);
-}
-
-function resolveWorkspaceNodeCaptureTarget(nodeId: string): {
-  captureTarget: HTMLElement;
-  windowElement: HTMLElement;
-} | null {
-  const windowElement =
-    Array.from(
-      document.querySelectorAll<HTMLElement>("[data-workbench-window-id]")
-    ).find((candidate) => candidate.dataset.workbenchWindowId === nodeId) ??
-    null;
-  if (!windowElement) {
-    return null;
-  }
-  const captureTarget =
-    windowElement.querySelector<HTMLElement>(
-      '[data-workbench-window-capture="true"]'
-    ) ??
-    windowElement.querySelector<HTMLElement>(".workbench-window") ??
-    windowElement;
-  return { captureTarget, windowElement };
 }
 
 function createWorkspaceWorkbenchDebugDiagnostics(

--- a/packages/workbench/surface/package.json
+++ b/packages/workbench/surface/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "build": "tsup --config tsup.config.ts && node ../../../tools/scripts/copy-package-assets.mjs src/styles dist/styles",
-    "test": "node --test --experimental-strip-types ./src/**/*.test.ts && vitest run ./src/host/WorkbenchHostDock.render.test.tsx ./src/host/WorkbenchHost.render.test.tsx ./src/react/genieTextureCapture.test.tsx --environment jsdom",
+    "test": "node --test --experimental-strip-types ./src/**/*.test.ts && vitest run ./src/host/WorkbenchHostDock.render.test.tsx ./src/host/WorkbenchHost.render.test.tsx ./src/host/useWorkbenchMinimizedDockPreview.test.tsx ./src/preview/createWorkbenchNodePreviewCaptureAdapter.test.tsx ./src/react/genieTextureCapture.test.tsx --environment jsdom",
     "typecheck": "node ../../../tools/scripts/run-tsgo-typecheck.mjs"
   },
   "devDependencies": {

--- a/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
@@ -22,10 +22,11 @@ import {
 } from "@tutti-os/ui-system";
 import type { WorkbenchDockContext } from "../react/types.ts";
 import {
-  captureWorkbenchNodePreviewImage,
-  readCachedWorkbenchNodePreviewImage,
-  writeCachedWorkbenchNodePreviewImage
-} from "../react/useWorkbenchGenieAnimation.tsx";
+  readWorkbenchMinimizedDockPreviewImage,
+  resolveWorkbenchMinimizedDockPreviewImage,
+  resolveWorkbenchMinimizedDockPreviewRevision,
+  useWorkbenchMinimizedDockPreview
+} from "./useWorkbenchMinimizedDockPreview.ts";
 import {
   canCreateNewWindow,
   canCreateNewWindowInDockPopup,
@@ -2435,7 +2436,12 @@ export function WorkbenchHostDock({
           placement={dockPlacement}
           debugDiagnostics={debugDiagnostics}
           capturePreview={async (item) => {
-            const src = await captureMinimizedNodePreview(item.node);
+            const src = await resolveWorkbenchMinimizedDockPreviewImage({
+              capturePreview: () => captureMinimizedNodePreview(item.node),
+              dockPreviewCache,
+              node: item.node,
+              workspaceId
+            });
             return src ? { kind: "image", src } : null;
           }}
           dockPreviewCache={dockPreviewCache}
@@ -2462,12 +2468,13 @@ export function WorkbenchHostDock({
                     ? null
                     : (() => {
                         const previewImageUrl =
-                          readCachedWorkbenchNodePreviewImage(node.id);
+                          readWorkbenchMinimizedDockPreviewImage(node.id);
                         return previewImageUrl
                           ? ({ kind: "image", src: previewImageUrl } as const)
                           : null;
                       })(),
-              previewRevision: null,
+              previewRevision:
+                resolveWorkbenchMinimizedDockPreviewRevision(node),
               subtitle: node.data.instanceKey ?? node.data.instanceId,
               title: node.title
             };
@@ -2552,147 +2559,15 @@ function WorkbenchHostDockMinimizedNodePreview({
   ) => WorkbenchDockPreviewContent | null;
   workspaceId: string;
 }) {
-  const [componentPreview, setComponentPreview] = useState<
-    WorkbenchDockPreviewContent | null | undefined
-  >(undefined);
-  const [previewImageUrl, setPreviewImageUrl] = useState<string | null>(() =>
-    deferPreview ? null : readCachedWorkbenchNodePreviewImage(node.id)
-  );
-
-  useEffect(() => {
-    if (
-      deferPreview ||
-      !providePreview ||
-      componentPreview !== undefined ||
-      previewImageUrl
-    ) {
-      return undefined;
-    }
-
-    let cancelled = false;
-    let frameId: number | null = null;
-    let idleId: number | null = null;
-    let timeoutId: ReturnType<typeof globalThis.setTimeout> | null = null;
-    const setDeferredComponentPreview = () => {
-      if (cancelled) {
-        return;
-      }
-      setComponentPreview(providePreview(node) ?? null);
-    };
-    const scheduler = globalThis as typeof globalThis & {
-      cancelIdleCallback?: (id: number) => void;
-      cancelAnimationFrame?: (id: number) => void;
-      requestIdleCallback?: (
-        callback: () => void,
-        options?: { timeout?: number }
-      ) => number;
-      requestAnimationFrame?: (callback: () => void) => number;
-    };
-
-    if (typeof scheduler.requestIdleCallback === "function") {
-      idleId = scheduler.requestIdleCallback(setDeferredComponentPreview, {
-        timeout: 250
-      });
-    } else if (typeof scheduler.requestAnimationFrame === "function") {
-      frameId = scheduler.requestAnimationFrame(() => {
-        frameId = null;
-        timeoutId = globalThis.setTimeout(setDeferredComponentPreview, 0);
-      });
-    } else {
-      timeoutId = globalThis.setTimeout(setDeferredComponentPreview, 0);
-    }
-
-    return () => {
-      cancelled = true;
-      if (
-        idleId !== null &&
-        typeof scheduler.cancelIdleCallback === "function"
-      ) {
-        scheduler.cancelIdleCallback(idleId);
-      }
-      if (
-        frameId !== null &&
-        typeof scheduler.cancelAnimationFrame === "function"
-      ) {
-        scheduler.cancelAnimationFrame(frameId);
-      }
-      if (timeoutId !== null) {
-        globalThis.clearTimeout(timeoutId);
-      }
-    };
-  }, [
-    componentPreview,
-    deferPreview,
-    node.data.instanceId,
-    node.data.instanceKey,
-    node.data.typeId,
-    node.id,
-    node.minimizedAtUnixMs,
-    previewImageUrl,
-    providePreview
-  ]);
-
-  useEffect(() => {
-    if (deferPreview) {
-      return undefined;
-    }
-
-    let cancelled = false;
-    const cachedPreviewImageUrl = readCachedWorkbenchNodePreviewImage(node.id);
-    setPreviewImageUrl(cachedPreviewImageUrl);
-    const cacheKey = resolveDockPreviewCacheKey(workspaceId, node);
-    if (!cachedPreviewImageUrl && dockPreviewCache) {
-      void dockPreviewCache
-        .read(cacheKey)
-        .catch(() => null)
-        .then((persistedPreview) => {
-          if (cancelled || !persistedPreview) {
-            return;
-          }
-          writeCachedWorkbenchNodePreviewImage(node.id, persistedPreview);
-          setPreviewImageUrl(persistedPreview);
-        });
-    }
-    if (capturePreview) {
-      void Promise.resolve(capturePreview(node))
-        .catch(() => null)
-        .then((nextPreview) => {
-          if (cancelled || !nextPreview) {
-            return;
-          }
-          writeCachedWorkbenchNodePreviewImage(node.id, nextPreview);
-          dockPreviewCache?.write({
-            key: cacheKey,
-            previewImageUrl: nextPreview
-          });
-          setPreviewImageUrl(nextPreview);
-        });
-    }
-    if (cachedPreviewImageUrl || node.isMinimized || capturePreview) {
-      return () => {
-        cancelled = true;
-      };
-    }
-    void captureWorkbenchNodePreviewImage(node.id).then((nextPreview) => {
-      if (!cancelled) {
-        setPreviewImageUrl(nextPreview);
-      }
+  const { componentPreview, previewImageUrl } =
+    useWorkbenchMinimizedDockPreview({
+      capturePreview,
+      deferPreview,
+      dockPreviewCache,
+      node,
+      providePreview,
+      workspaceId
     });
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    capturePreview,
-    deferPreview,
-    dockPreviewCache,
-    node.data.instanceId,
-    node.data.instanceKey,
-    node.data.typeId,
-    node.id,
-    node.minimizedAtUnixMs,
-    providePreview,
-    workspaceId
-  ]);
 
   if (deferPreview) {
     return renderMinimizedDockPreviewPlaceholder(className);

--- a/packages/workbench/surface/src/host/useWorkbenchMinimizedDockPreview.test.tsx
+++ b/packages/workbench/surface/src/host/useWorkbenchMinimizedDockPreview.test.tsx
@@ -1,0 +1,203 @@
+import { act, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, it, vi } from "vitest";
+import type { WorkbenchDockPreviewCache } from "../react/dockPreviewCache.ts";
+import type { WorkbenchMinimizedDockNode } from "./minimizedDockSlots.ts";
+import { useWorkbenchMinimizedDockPreview } from "./useWorkbenchMinimizedDockPreview.ts";
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+function createNode(
+  id: string,
+  minimizedAtUnixMs = 1
+): WorkbenchMinimizedDockNode {
+  return {
+    data: {
+      instanceId: `instance-${id}`,
+      instanceKey: null,
+      typeId: "test-node"
+    },
+    displayMode: "floating",
+    frame: { height: 600, width: 800, x: 20, y: 20 },
+    id,
+    isMinimized: true,
+    kind: "test",
+    minimizedAtUnixMs,
+    restoreFrame: null,
+    title: id
+  };
+}
+
+function deferred<T>() {
+  let resolvePromise: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return {
+    promise,
+    resolve(value: T) {
+      resolvePromise?.(value);
+    }
+  };
+}
+
+function renderPreviewHook(
+  initialNode: WorkbenchMinimizedDockNode,
+  input: {
+    capturePreview: (
+      node: WorkbenchMinimizedDockNode
+    ) => Promise<string | null>;
+    dockPreviewCache?: WorkbenchDockPreviewCache;
+    workspaceId: string;
+  }
+) {
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  let current: ReturnType<typeof useWorkbenchMinimizedDockPreview> | undefined;
+  function Test({ node }: { node: WorkbenchMinimizedDockNode }): ReactNode {
+    current = useWorkbenchMinimizedDockPreview({
+      capturePreview: input.capturePreview,
+      deferPreview: false,
+      dockPreviewCache: input.dockPreviewCache,
+      node,
+      workspaceId: input.workspaceId
+    });
+    return null;
+  }
+  act(() => {
+    root.render(<Test node={initialNode} />);
+  });
+  return {
+    get current() {
+      if (!current) {
+        throw new Error("preview hook did not render");
+      }
+      return current;
+    },
+    rerender(node: WorkbenchMinimizedDockNode) {
+      act(() => {
+        root.render(<Test node={node} />);
+      });
+    },
+    unmount() {
+      act(() => root.unmount());
+    }
+  };
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+describe("useWorkbenchMinimizedDockPreview", () => {
+  it("deduplicates capture across concurrent slot and popup consumers", async () => {
+    const node = createNode("dedupe-node");
+    const captureResult = deferred<string | null>();
+    const capturePreview = vi.fn(() => captureResult.promise);
+    const input = {
+      capturePreview,
+      workspaceId: "workspace-dedupe"
+    };
+
+    const slot = renderPreviewHook(node, input);
+    const popup = renderPreviewHook(node, input);
+    await flushEffects();
+    expect(capturePreview).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      captureResult.resolve("data:image/png;base64,SHARED=");
+      await captureResult.promise;
+    });
+    expect(slot.current.previewImageUrl).toBe("data:image/png;base64,SHARED=");
+    expect(popup.current.previewImageUrl).toBe("data:image/png;base64,SHARED=");
+
+    slot.unmount();
+    popup.unmount();
+  });
+
+  it("fences a late result after switching nodes", async () => {
+    const oldNode = createNode("stale-node", 1);
+    const newNode = createNode("stale-node", 2);
+    const oldResult = deferred<string | null>();
+    const newResult = deferred<string | null>();
+    const capturePreview = vi.fn((node: WorkbenchMinimizedDockNode) =>
+      node.minimizedAtUnixMs === 1 ? oldResult.promise : newResult.promise
+    );
+    const hook = renderPreviewHook(oldNode, {
+      capturePreview,
+      workspaceId: "workspace-stale"
+    });
+
+    hook.rerender(newNode);
+    await act(async () => {
+      newResult.resolve("data:image/png;base64,NEW=");
+      await newResult.promise;
+    });
+    expect(hook.current.previewImageUrl).toBe("data:image/png;base64,NEW=");
+
+    await act(async () => {
+      oldResult.resolve("data:image/png;base64,OLD=");
+      await oldResult.promise;
+    });
+    expect(hook.current.previewImageUrl).toBe("data:image/png;base64,NEW=");
+    hook.unmount();
+  });
+
+  it("uses persistent cache without starting live capture", async () => {
+    const node = createNode("persistent-node");
+    const capturePreview = vi.fn(async () => "data:image/png;base64,LIVE=");
+    const dockPreviewCache = {
+      read: vi.fn(async () => "data:image/png;base64,PERSISTED="),
+      write: vi.fn()
+    };
+    const hook = renderPreviewHook(node, {
+      capturePreview,
+      dockPreviewCache,
+      workspaceId: "workspace-persisted"
+    });
+
+    await flushEffects();
+    expect(hook.current.previewImageUrl).toBe(
+      "data:image/png;base64,PERSISTED="
+    );
+    expect(capturePreview).not.toHaveBeenCalled();
+    expect(dockPreviewCache.read).toHaveBeenCalledWith(
+      expect.objectContaining({ revision: "1" })
+    );
+    expect(dockPreviewCache.write).not.toHaveBeenCalled();
+    hook.unmount();
+  });
+
+  it("falls back to the unrevisioned Genie cache identity", async () => {
+    const node = createNode("genie-cache-node", 7);
+    const capturePreview = vi.fn(async () => "data:image/png;base64,LIVE=");
+    const dockPreviewCache = {
+      read: vi.fn(async (key: { revision?: string | null }) =>
+        key.revision ? null : "data:image/png;base64,GENIE="
+      ),
+      write: vi.fn()
+    };
+    const hook = renderPreviewHook(node, {
+      capturePreview,
+      dockPreviewCache,
+      workspaceId: "workspace-genie"
+    });
+
+    await flushEffects();
+    expect(hook.current.previewImageUrl).toBe("data:image/png;base64,GENIE=");
+    expect(dockPreviewCache.read).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ revision: "7" })
+    );
+    expect(dockPreviewCache.read).toHaveBeenNthCalledWith(
+      2,
+      expect.not.objectContaining({ revision: expect.anything() })
+    );
+    expect(capturePreview).not.toHaveBeenCalled();
+    hook.unmount();
+  });
+});

--- a/packages/workbench/surface/src/host/useWorkbenchMinimizedDockPreview.ts
+++ b/packages/workbench/surface/src/host/useWorkbenchMinimizedDockPreview.ts
@@ -1,0 +1,204 @@
+import { useEffect, useState } from "react";
+import type { WorkbenchDockPreviewCache } from "../react/dockPreviewCache.ts";
+import type { WorkbenchDockPreviewContent } from "./types.ts";
+import type { WorkbenchMinimizedDockNode } from "./minimizedDockSlots.ts";
+import {
+  workbenchMinimizedDockPreviewIdentity,
+  workbenchNodePreviewRuntime
+} from "../preview/workbenchNodePreviewRuntime.ts";
+
+export interface WorkbenchMinimizedDockPreviewState {
+  componentPreview: WorkbenchDockPreviewContent | null | undefined;
+  previewImageUrl: string | null;
+}
+
+export function useWorkbenchMinimizedDockPreview({
+  capturePreview,
+  deferPreview,
+  dockPreviewCache,
+  node,
+  providePreview,
+  workspaceId
+}: {
+  capturePreview?: (
+    node: WorkbenchMinimizedDockNode
+  ) => Promise<string | null> | string | null;
+  deferPreview: boolean;
+  dockPreviewCache?: WorkbenchDockPreviewCache;
+  node: WorkbenchMinimizedDockNode;
+  providePreview?: (
+    node: WorkbenchMinimizedDockNode
+  ) => WorkbenchDockPreviewContent | null;
+  workspaceId: string;
+}): WorkbenchMinimizedDockPreviewState {
+  const [componentPreview, setComponentPreview] = useState<
+    WorkbenchDockPreviewContent | null | undefined
+  >(undefined);
+  const [previewImageUrl, setPreviewImageUrl] = useState<string | null>(() =>
+    deferPreview ? null : workbenchNodePreviewRuntime.readLatest(node.id)
+  );
+
+  useEffect(() => {
+    if (
+      deferPreview ||
+      !providePreview ||
+      componentPreview !== undefined ||
+      previewImageUrl
+    ) {
+      return undefined;
+    }
+    return scheduleDeferredPreview(() => {
+      setComponentPreview(providePreview(node) ?? null);
+    });
+  }, [
+    componentPreview,
+    deferPreview,
+    node.data.instanceId,
+    node.data.instanceKey,
+    node.data.typeId,
+    node.id,
+    node.minimizedAtUnixMs,
+    previewImageUrl,
+    providePreview
+  ]);
+
+  useEffect(() => {
+    if (deferPreview) {
+      return undefined;
+    }
+
+    let active = true;
+    const cachedPreview = readWorkbenchMinimizedDockPreviewImage(node.id);
+    setPreviewImageUrl(cachedPreview);
+    void resolveWorkbenchMinimizedDockPreviewImage({
+      capturePreview: capturePreview
+        ? () => Promise.resolve(capturePreview(node))
+        : undefined,
+      dockPreviewCache,
+      node,
+      workspaceId
+    }).then((nextPreview) => {
+      if (active && nextPreview) {
+        setPreviewImageUrl(nextPreview);
+      }
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [
+    capturePreview,
+    deferPreview,
+    dockPreviewCache,
+    node.data.instanceId,
+    node.data.instanceKey,
+    node.data.typeId,
+    node.id,
+    node.minimizedAtUnixMs,
+    workspaceId
+  ]);
+
+  return { componentPreview, previewImageUrl };
+}
+
+export function readWorkbenchMinimizedDockPreviewImage(
+  nodeId: string
+): string | null {
+  return workbenchNodePreviewRuntime.readLatest(nodeId);
+}
+
+export function resolveWorkbenchMinimizedDockPreviewRevision(
+  node: WorkbenchMinimizedDockNode
+): string {
+  return String(node.minimizedAtUnixMs);
+}
+
+export function resolveWorkbenchMinimizedDockPreviewImage({
+  capturePreview,
+  dockPreviewCache,
+  node,
+  workspaceId
+}: {
+  capturePreview?: () => Promise<string | null> | string | null;
+  dockPreviewCache?: WorkbenchDockPreviewCache;
+  node: WorkbenchMinimizedDockNode;
+  workspaceId: string;
+}): Promise<string | null> {
+  const cacheKey = {
+    instanceId: node.data.instanceId,
+    instanceKey: node.data.instanceKey ?? null,
+    nodeId: node.id,
+    revision: resolveWorkbenchMinimizedDockPreviewRevision(node),
+    typeId: node.data.typeId,
+    workspaceId
+  };
+  const genieCacheKey = {
+    ...cacheKey,
+    revision: undefined
+  };
+  return workbenchNodePreviewRuntime.ensure({
+    capture: capturePreview,
+    identity: workbenchMinimizedDockPreviewIdentity(
+      cacheKey,
+      node.minimizedAtUnixMs
+    ),
+    nodeId: node.id,
+    readPersisted: dockPreviewCache
+      ? async () =>
+          (await dockPreviewCache.read(cacheKey)) ??
+          dockPreviewCache.read(genieCacheKey)
+      : undefined,
+    writePersisted: dockPreviewCache
+      ? (previewImageUrl) =>
+          dockPreviewCache.write({ key: cacheKey, previewImageUrl })
+      : undefined
+  });
+}
+
+function scheduleDeferredPreview(run: () => void): () => void {
+  let cancelled = false;
+  let frameId: number | null = null;
+  let idleId: number | null = null;
+  let timeoutId: ReturnType<typeof globalThis.setTimeout> | null = null;
+  const invoke = () => {
+    if (!cancelled) {
+      run();
+    }
+  };
+  const scheduler = globalThis as typeof globalThis & {
+    cancelIdleCallback?: (id: number) => void;
+    cancelAnimationFrame?: (id: number) => void;
+    requestIdleCallback?: (
+      callback: () => void,
+      options?: { timeout?: number }
+    ) => number;
+    requestAnimationFrame?: (callback: () => void) => number;
+  };
+
+  if (typeof scheduler.requestIdleCallback === "function") {
+    idleId = scheduler.requestIdleCallback(invoke, { timeout: 250 });
+  } else if (typeof scheduler.requestAnimationFrame === "function") {
+    frameId = scheduler.requestAnimationFrame(() => {
+      frameId = null;
+      timeoutId = globalThis.setTimeout(invoke, 0);
+    });
+  } else {
+    timeoutId = globalThis.setTimeout(invoke, 0);
+  }
+
+  return () => {
+    cancelled = true;
+    if (idleId !== null && typeof scheduler.cancelIdleCallback === "function") {
+      scheduler.cancelIdleCallback(idleId);
+    }
+    if (
+      frameId !== null &&
+      typeof scheduler.cancelAnimationFrame === "function"
+    ) {
+      scheduler.cancelAnimationFrame(frameId);
+    }
+    if (timeoutId !== null) {
+      globalThis.clearTimeout(timeoutId);
+    }
+  };
+}

--- a/packages/workbench/surface/src/index.ts
+++ b/packages/workbench/surface/src/index.ts
@@ -99,6 +99,12 @@ export type {
   WorkbenchNodePreviewImagesCapture
 } from "./react/nodePreviewCapture.ts";
 export {
+  createWorkbenchNodePreviewCaptureAdapter,
+  type WorkbenchNodePreviewCaptureAdapterOptions,
+  type WorkbenchNodePreviewCaptureDiagnostic,
+  type WorkbenchNodePreviewCaptureRectInput
+} from "./preview/createWorkbenchNodePreviewCaptureAdapter.ts";
+export {
   WorkbenchDockComponentPreviewFrame,
   type WorkbenchDockComponentPreviewFrameProps
 } from "./react/WorkbenchDockComponentPreviewFrame.tsx";

--- a/packages/workbench/surface/src/preview/createWorkbenchNodePreviewCaptureAdapter.test.tsx
+++ b/packages/workbench/surface/src/preview/createWorkbenchNodePreviewCaptureAdapter.test.tsx
@@ -1,0 +1,231 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorkbenchNode } from "../core/types.ts";
+import { createWorkbenchNodePreviewCaptureAdapter } from "./createWorkbenchNodePreviewCaptureAdapter.ts";
+
+const previewImages = {
+  dockPreviewImageUrl: "data:image/png;base64,ZG9jaw==",
+  genieImageUrl: "data:image/png;base64,Z2VuaWU="
+};
+
+function createNode(
+  input: { id?: string; isMinimized?: boolean } = {}
+): WorkbenchNode {
+  return {
+    data: null,
+    displayMode: "floating",
+    frame: { height: 400, width: 600, x: 30, y: 40 },
+    id: input.id ?? "node-1",
+    isMinimized: input.isMinimized ?? false,
+    kind: "test",
+    minimizedAtUnixMs: null,
+    restoreFrame: null,
+    title: "Node"
+  };
+}
+
+function installCaptureTarget(
+  input: {
+    focused?: boolean;
+    rect?: Partial<DOMRect>;
+  } = {}
+): HTMLElement {
+  document.body.innerHTML = `
+    <section
+      data-focused="${input.focused ?? true}"
+      data-workbench-window-id="node-1"
+    >
+      <div data-workbench-window-capture="true"></div>
+    </section>
+  `;
+  const target = document.querySelector<HTMLElement>(
+    '[data-workbench-window-capture="true"]'
+  );
+  if (!target) {
+    throw new Error("Expected capture target");
+  }
+  vi.spyOn(target, "getBoundingClientRect").mockReturnValue({
+    bottom: 440,
+    height: 400,
+    left: 30,
+    right: 630,
+    top: 40,
+    width: 600,
+    x: 30,
+    y: 40,
+    ...input.rect,
+    toJSON: () => ({})
+  } as DOMRect);
+  return target;
+}
+
+describe("createWorkbenchNodePreviewCaptureAdapter", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "visible"
+    });
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 800
+    });
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 1200
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("captures the focused visible node through the injected transport", async () => {
+    installCaptureTarget();
+    const captureRect = vi.fn().mockResolvedValue(previewImages);
+    const capture = createWorkbenchNodePreviewCaptureAdapter({
+      captureRect,
+      maxHeight: 170,
+      maxWidth: 260
+    });
+
+    await expect(capture(createNode())).resolves.toEqual(previewImages);
+    expect(captureRect).toHaveBeenCalledWith({
+      maxHeight: 170,
+      maxWidth: 260,
+      nodeId: "node-1",
+      rect: { height: 400, width: 600, x: 30, y: 40 }
+    });
+  });
+
+  it.each([
+    ["node_minimized", { isMinimized: true }],
+    ["document_not_visible", { visibilityState: "hidden" }],
+    ["window_not_focused", { focused: false }],
+    ["capture_rect_invalid", { rect: { left: 900, right: 1500 } }]
+  ])("skips capture when %s", async (reason, setup) => {
+    installCaptureTarget({
+      focused: "focused" in setup ? setup.focused : undefined,
+      rect: "rect" in setup ? setup.rect : undefined
+    });
+    if ("visibilityState" in setup) {
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        value: setup.visibilityState
+      });
+    }
+    const captureRect = vi.fn().mockResolvedValue(previewImages);
+    const diagnostics = vi.fn();
+    const capture = createWorkbenchNodePreviewCaptureAdapter({
+      captureRect,
+      diagnostics,
+      maxHeight: 170,
+      maxWidth: 260
+    });
+
+    await expect(
+      capture(
+        createNode({
+          isMinimized: "isMinimized" in setup ? setup.isMinimized : undefined
+        })
+      )
+    ).resolves.toBeNull();
+    expect(captureRect).not.toHaveBeenCalled();
+    expect(diagnostics).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({ reason }),
+        event: "capture_skipped"
+      })
+    );
+  });
+
+  it("adds product diagnostic context without coupling the shared adapter", async () => {
+    installCaptureTarget();
+    const diagnostics = vi.fn();
+    const capture = createWorkbenchNodePreviewCaptureAdapter({
+      captureRect: vi.fn().mockResolvedValue(previewImages),
+      diagnostics,
+      maxHeight: 170,
+      maxWidth: 260,
+      resolveDiagnosticContext: (node) => ({
+        typeId: "terminal",
+        workspaceId: `workspace-for-${node.id}`
+      })
+    });
+
+    await capture(createNode());
+
+    expect(diagnostics).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          typeId: "terminal",
+          workspaceId: "workspace-for-node-1"
+        }),
+        event: "capture_requested"
+      })
+    );
+  });
+
+  it("contains transport rejection and emits a failed diagnostic", async () => {
+    installCaptureTarget();
+    const diagnostics = vi.fn();
+    const capture = createWorkbenchNodePreviewCaptureAdapter({
+      captureRect: vi.fn().mockRejectedValue(new Error("ipc failed")),
+      diagnostics,
+      maxHeight: 170,
+      maxWidth: 260
+    });
+
+    await expect(capture(createNode())).resolves.toBeNull();
+    expect(diagnostics).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({ error: "ipc failed" }),
+        event: "capture_failed"
+      })
+    );
+  });
+
+  it("contains synchronous transport failures and emits a failed diagnostic", async () => {
+    installCaptureTarget();
+    const diagnostics = vi.fn();
+    const capture = createWorkbenchNodePreviewCaptureAdapter({
+      captureRect: vi.fn(() => {
+        throw new Error("synchronous ipc failure");
+      }),
+      diagnostics,
+      maxHeight: 170,
+      maxWidth: 260
+    });
+
+    await expect(capture(createNode())).resolves.toBeNull();
+    expect(diagnostics).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({ error: "synchronous ipc failure" }),
+        event: "capture_failed"
+      })
+    );
+  });
+
+  it("stops waiting after the configured timeout", async () => {
+    vi.useFakeTimers();
+    installCaptureTarget();
+    const diagnostics = vi.fn();
+    const capture = createWorkbenchNodePreviewCaptureAdapter({
+      captureRect: vi.fn(
+        (): Promise<typeof previewImages | null> => new Promise(() => undefined)
+      ),
+      diagnostics,
+      maxHeight: 170,
+      maxWidth: 260,
+      timeoutMs: 25
+    });
+
+    const result = capture(createNode());
+    await vi.advanceTimersByTimeAsync(25);
+
+    await expect(result).resolves.toBeNull();
+    expect(diagnostics).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "capture_timed_out" })
+    );
+  });
+});

--- a/packages/workbench/surface/src/preview/createWorkbenchNodePreviewCaptureAdapter.ts
+++ b/packages/workbench/surface/src/preview/createWorkbenchNodePreviewCaptureAdapter.ts
@@ -1,0 +1,283 @@
+import type { WorkbenchNode } from "../core/types.ts";
+import type {
+  WorkbenchNodePreviewImages,
+  WorkbenchNodePreviewImagesCapture
+} from "../react/nodePreviewCapture.ts";
+
+export interface WorkbenchNodePreviewCaptureRectInput {
+  maxHeight: number;
+  maxWidth: number;
+  nodeId: string;
+  rect: {
+    height: number;
+    width: number;
+    x: number;
+    y: number;
+  };
+}
+
+export interface WorkbenchNodePreviewCaptureDiagnostic {
+  details: Record<string, unknown>;
+  event:
+    | "capture_failed"
+    | "capture_requested"
+    | "capture_resolved"
+    | "capture_skipped"
+    | "capture_started"
+    | "capture_timed_out";
+  level: "debug" | "info" | "warn";
+}
+
+export interface WorkbenchNodePreviewCaptureAdapterOptions<TData = unknown> {
+  captureRect: (
+    input: WorkbenchNodePreviewCaptureRectInput
+  ) => Promise<WorkbenchNodePreviewImages | null>;
+  diagnostics?: (diagnostic: WorkbenchNodePreviewCaptureDiagnostic) => void;
+  maxHeight: number;
+  maxWidth: number;
+  resolveDiagnosticContext?: (
+    node: WorkbenchNode<TData>
+  ) => Record<string, unknown>;
+  timeoutMs?: number;
+}
+
+const defaultCaptureTimeoutMs = 2_500;
+
+export function createWorkbenchNodePreviewCaptureAdapter<TData = unknown>(
+  options: WorkbenchNodePreviewCaptureAdapterOptions<TData>
+): WorkbenchNodePreviewImagesCapture<TData> {
+  const {
+    captureRect,
+    diagnostics,
+    maxHeight,
+    maxWidth,
+    resolveDiagnosticContext,
+    timeoutMs = defaultCaptureTimeoutMs
+  } = options;
+
+  return async (node) => {
+    const diagnosticContext = resolveDiagnosticContext?.(node) ?? {};
+    const emit = (diagnostic: WorkbenchNodePreviewCaptureDiagnostic): void => {
+      emitDiagnostic(diagnostics, {
+        ...diagnostic,
+        details: { ...diagnosticContext, ...diagnostic.details }
+      });
+    };
+    emit({
+      details: {
+        documentVisibilityState: document.visibilityState,
+        isMinimized: node.isMinimized,
+        nodeId: node.id
+      },
+      event: "capture_requested",
+      level: "debug"
+    });
+
+    const skip = resolveCaptureTarget(node);
+    if (skip.status === "skipped") {
+      emit({
+        details: {
+          ...skip.details,
+          nodeId: node.id,
+          reason: skip.reason
+        },
+        event: "capture_skipped",
+        level: skip.level
+      });
+      return null;
+    }
+
+    const rect = skip.target.getBoundingClientRect();
+    if (!isUsableCaptureRect(rect)) {
+      emit({
+        details: {
+          nodeId: node.id,
+          reason: "capture_rect_invalid",
+          rect: captureRectDetails(rect),
+          viewport: { height: window.innerHeight, width: window.innerWidth }
+        },
+        event: "capture_skipped",
+        level: "warn"
+      });
+      return null;
+    }
+
+    const input: WorkbenchNodePreviewCaptureRectInput = {
+      maxHeight,
+      maxWidth,
+      nodeId: node.id,
+      rect: captureRectDetails(rect)
+    };
+    emit({
+      details: { ...input, timeoutMs },
+      event: "capture_started",
+      level: "info"
+    });
+
+    const startedAt = performance.now();
+    const capturePromise = Promise.resolve().then(() => captureRect(input));
+    const outcome = await resolveCaptureOutcome(capturePromise, timeoutMs);
+    if (outcome.status === "timed_out") {
+      emit({
+        details: {
+          durationMs: Math.round(performance.now() - startedAt),
+          nodeId: node.id,
+          timeoutMs
+        },
+        event: "capture_timed_out",
+        level: "warn"
+      });
+      return null;
+    }
+    if (outcome.status === "failed") {
+      emit({
+        details: {
+          durationMs: Math.round(performance.now() - startedAt),
+          error: serializeError(outcome.error),
+          nodeId: node.id
+        },
+        event: "capture_failed",
+        level: "warn"
+      });
+      return null;
+    }
+
+    emit({
+      details: {
+        dockPreviewImageUrlLength:
+          outcome.previewImages?.dockPreviewImageUrl?.length ?? 0,
+        durationMs: Math.round(performance.now() - startedAt),
+        genieImageUrlLength: outcome.previewImages?.genieImageUrl?.length ?? 0,
+        hasResult: outcome.previewImages !== null,
+        nodeId: node.id
+      },
+      event: "capture_resolved",
+      level: outcome.previewImages ? "info" : "warn"
+    });
+    return outcome.previewImages;
+  };
+}
+
+function resolveCaptureTarget<TData>(node: WorkbenchNode<TData>):
+  | { status: "ready"; target: HTMLElement }
+  | {
+      details?: Record<string, unknown>;
+      level: "debug" | "warn";
+      reason:
+        | "document_not_visible"
+        | "node_minimized"
+        | "window_element_missing"
+        | "window_not_focused";
+      status: "skipped";
+    } {
+  if (node.isMinimized) {
+    return { level: "debug", reason: "node_minimized", status: "skipped" };
+  }
+  if (document.visibilityState !== "visible") {
+    return {
+      details: { documentVisibilityState: document.visibilityState },
+      level: "debug",
+      reason: "document_not_visible",
+      status: "skipped"
+    };
+  }
+
+  const windowElement =
+    Array.from(
+      document.querySelectorAll<HTMLElement>("[data-workbench-window-id]")
+    ).find((candidate) => candidate.dataset.workbenchWindowId === node.id) ??
+    null;
+  if (!windowElement) {
+    return {
+      level: "warn",
+      reason: "window_element_missing",
+      status: "skipped"
+    };
+  }
+  if (windowElement.dataset.focused !== "true") {
+    return {
+      details: { focused: windowElement.dataset.focused ?? null },
+      level: "debug",
+      reason: "window_not_focused",
+      status: "skipped"
+    };
+  }
+
+  return {
+    status: "ready",
+    target:
+      windowElement.querySelector<HTMLElement>(
+        '[data-workbench-window-capture="true"]'
+      ) ??
+      windowElement.querySelector<HTMLElement>(".workbench-window") ??
+      windowElement
+  };
+}
+
+function isUsableCaptureRect(rect: DOMRect): boolean {
+  return (
+    Number.isFinite(rect.left) &&
+    Number.isFinite(rect.top) &&
+    Number.isFinite(rect.width) &&
+    Number.isFinite(rect.height) &&
+    rect.width > 0 &&
+    rect.height > 0 &&
+    rect.left >= 0 &&
+    rect.top >= 0 &&
+    rect.left + rect.width <= window.innerWidth &&
+    rect.top + rect.height <= window.innerHeight
+  );
+}
+
+function captureRectDetails(rect: DOMRect): {
+  height: number;
+  width: number;
+  x: number;
+  y: number;
+} {
+  return {
+    height: rect.height,
+    width: rect.width,
+    x: rect.left,
+    y: rect.top
+  };
+}
+
+type CaptureOutcome =
+  | { error: unknown; status: "failed" }
+  | { previewImages: WorkbenchNodePreviewImages | null; status: "resolved" }
+  | { status: "timed_out" };
+
+async function resolveCaptureOutcome(
+  capturePromise: Promise<WorkbenchNodePreviewImages | null>,
+  timeoutMs: number
+): Promise<CaptureOutcome> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const settledCapture = capturePromise.then<CaptureOutcome, CaptureOutcome>(
+    (previewImages) => ({ previewImages, status: "resolved" }),
+    (error) => ({ error, status: "failed" })
+  );
+  const timeoutOutcome = new Promise<CaptureOutcome>((resolve) => {
+    timeout = setTimeout(() => resolve({ status: "timed_out" }), timeoutMs);
+  });
+  return Promise.race([settledCapture, timeoutOutcome]).finally(() => {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  });
+}
+
+function emitDiagnostic(
+  diagnostics: WorkbenchNodePreviewCaptureAdapterOptions<unknown>["diagnostics"],
+  diagnostic: WorkbenchNodePreviewCaptureDiagnostic
+): void {
+  try {
+    diagnostics?.(diagnostic);
+  } catch {
+    // Diagnostics must never affect preview capture.
+  }
+}
+
+function serializeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/workbench/surface/src/preview/workbenchNodePreviewRuntime.test.ts
+++ b/packages/workbench/surface/src/preview/workbenchNodePreviewRuntime.test.ts
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createWorkbenchNodePreviewRuntime } from "./workbenchNodePreviewRuntime.ts";
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+} {
+  let resolvePromise: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return {
+    promise,
+    resolve(value) {
+      resolvePromise?.(value);
+    }
+  };
+}
+
+describe("workbenchNodePreviewRuntime", () => {
+  it("deduplicates concurrent requests for one preview identity", async () => {
+    const runtime = createWorkbenchNodePreviewRuntime();
+    const result = deferred<string | null>();
+    let captureCount = 0;
+    const request = {
+      capture: () => {
+        captureCount += 1;
+        return result.promise;
+      },
+      identity: "workspace-1:node-1:revision-1",
+      nodeId: "node-1"
+    };
+
+    const first = runtime.ensure(request);
+    const second = runtime.ensure(request);
+    result.resolve("data:image/png;base64,ONE=");
+
+    assert.equal(await first, "data:image/png;base64,ONE=");
+    assert.equal(await second, "data:image/png;base64,ONE=");
+    assert.equal(captureCount, 1);
+  });
+
+  it("uses a persisted preview before starting live capture", async () => {
+    const runtime = createWorkbenchNodePreviewRuntime();
+    let captureCount = 0;
+
+    const preview = await runtime.ensure({
+      capture: async () => {
+        captureCount += 1;
+        return "data:image/png;base64,LIVE=";
+      },
+      identity: "workspace-1:node-1:revision-1",
+      nodeId: "node-1",
+      readPersisted: async () => "data:image/png;base64,CACHED="
+    });
+
+    assert.equal(preview, "data:image/png;base64,CACHED=");
+    assert.equal(captureCount, 0);
+    assert.equal(runtime.readLatest("node-1"), preview);
+  });
+
+  it("does not negatively cache an unavailable preview", async () => {
+    const runtime = createWorkbenchNodePreviewRuntime();
+    let captureCount = 0;
+    const request = {
+      capture: async () => {
+        captureCount += 1;
+        return captureCount === 1 ? null : "data:image/png;base64,RETRY=";
+      },
+      identity: "workspace-1:node-1:revision-1",
+      nodeId: "node-1"
+    };
+
+    assert.equal(await runtime.ensure(request), null);
+    assert.equal(await runtime.ensure(request), "data:image/png;base64,RETRY=");
+    assert.equal(captureCount, 2);
+  });
+
+  it("does not let an older identity overwrite a newer node preview", async () => {
+    const runtime = createWorkbenchNodePreviewRuntime();
+    const oldResult = deferred<string | null>();
+    const newResult = deferred<string | null>();
+    const persisted: string[] = [];
+
+    const oldRequest = runtime.ensure({
+      capture: () => oldResult.promise,
+      identity: "workspace-1:node-1:revision-1",
+      nodeId: "node-1",
+      writePersisted(value: string) {
+        persisted.push(`old:${value}`);
+      }
+    });
+    const newRequest = runtime.ensure({
+      capture: () => newResult.promise,
+      identity: "workspace-1:node-1:revision-2",
+      nodeId: "node-1",
+      writePersisted(value: string) {
+        persisted.push(`new:${value}`);
+      }
+    });
+
+    newResult.resolve("data:image/png;base64,NEW=");
+    assert.equal(await newRequest, "data:image/png;base64,NEW=");
+    oldResult.resolve("data:image/png;base64,OLD=");
+    assert.equal(await oldRequest, "data:image/png;base64,OLD=");
+
+    assert.equal(runtime.readLatest("node-1"), "data:image/png;base64,NEW=");
+    assert.equal(
+      runtime.read("workspace-1:node-1:revision-1"),
+      "data:image/png;base64,OLD="
+    );
+    assert.deepEqual(persisted, ["new:data:image/png;base64,NEW="]);
+  });
+
+  it("reselecting a cached identity fences an older pending request", async () => {
+    const runtime = createWorkbenchNodePreviewRuntime();
+    const oldResult = deferred<string | null>();
+    const persisted: string[] = [];
+
+    assert.equal(
+      await runtime.ensure({
+        capture: async () => "data:image/png;base64,NEW=",
+        identity: "workspace-1:node-1:revision-new",
+        nodeId: "node-1"
+      }),
+      "data:image/png;base64,NEW="
+    );
+    const oldRequest = runtime.ensure({
+      capture: () => oldResult.promise,
+      identity: "workspace-1:node-1:revision-old",
+      nodeId: "node-1",
+      writePersisted(value: string) {
+        persisted.push(value);
+      }
+    });
+
+    assert.equal(
+      await runtime.ensure({
+        identity: "workspace-1:node-1:revision-new",
+        nodeId: "node-1"
+      }),
+      "data:image/png;base64,NEW="
+    );
+    oldResult.resolve("data:image/png;base64,OLD=");
+    assert.equal(await oldRequest, "data:image/png;base64,OLD=");
+
+    assert.equal(runtime.readLatest("node-1"), "data:image/png;base64,NEW=");
+    assert.deepEqual(persisted, []);
+  });
+
+  it("contains synchronous adapter failures and continues fallback", async () => {
+    const runtime = createWorkbenchNodePreviewRuntime();
+
+    assert.equal(
+      await runtime.ensure({
+        capture: () => "data:image/png;base64,FALLBACK=",
+        identity: "workspace-1:node-sync:revision-1",
+        nodeId: "node-sync",
+        readPersisted() {
+          throw new Error("sync read failure");
+        },
+        writePersisted() {
+          throw new Error("sync write failure");
+        }
+      }),
+      "data:image/png;base64,FALLBACK="
+    );
+  });
+
+  it("persists successful capture without awaiting the write", async () => {
+    const runtime = createWorkbenchNodePreviewRuntime();
+    const writes: string[] = [];
+
+    const preview = await runtime.ensure({
+      capture: async () => "data:image/png;base64,WRITE=",
+      identity: "workspace-1:node-1:revision-1",
+      nodeId: "node-1",
+      writePersisted(value: string) {
+        writes.push(value);
+      }
+    });
+
+    assert.equal(preview, "data:image/png;base64,WRITE=");
+    assert.deepEqual(writes, ["data:image/png;base64,WRITE="]);
+  });
+});

--- a/packages/workbench/surface/src/preview/workbenchNodePreviewRuntime.ts
+++ b/packages/workbench/surface/src/preview/workbenchNodePreviewRuntime.ts
@@ -1,0 +1,192 @@
+import type { WorkbenchDockPreviewCacheKey } from "../react/dockPreviewCache.ts";
+
+export interface WorkbenchNodePreviewRequest {
+  capture?: () => Promise<string | null> | string | null;
+  identity: string;
+  nodeId: string;
+  readPersisted?: () => Promise<string | null>;
+  writePersisted?: (previewImageUrl: string) => Promise<unknown> | unknown;
+}
+
+export interface WorkbenchNodePreviewRuntime {
+  ensure(request: WorkbenchNodePreviewRequest): Promise<string | null>;
+  read(identity: string): string | null;
+  readLatest(nodeId: string): string | null;
+  write(input: {
+    identity: string;
+    nodeId: string;
+    previewImageUrl: string | null | undefined;
+  }): void;
+}
+
+const defaultMaxEntries = 96;
+
+export function createWorkbenchNodePreviewRuntime(
+  input: { maxEntries?: number } = {}
+): WorkbenchNodePreviewRuntime {
+  const maxEntries = input.maxEntries ?? defaultMaxEntries;
+  const previewByIdentity = new Map<string, string>();
+  const latestPreviewByNodeId = new Map<
+    string,
+    { identity: string; previewImageUrl: string }
+  >();
+  const pendingByIdentity = new Map<string, Promise<string | null>>();
+  const activeIdentityByNodeId = new Map<string, string>();
+
+  const writeIdentity = (identity: string, previewImageUrl: string): void => {
+    previewByIdentity.delete(identity);
+    previewByIdentity.set(identity, previewImageUrl);
+    trimOldest(previewByIdentity, maxEntries);
+  };
+
+  const writeLatest = (
+    nodeId: string,
+    identity: string,
+    previewImageUrl: string
+  ): void => {
+    latestPreviewByNodeId.delete(nodeId);
+    latestPreviewByNodeId.set(nodeId, { identity, previewImageUrl });
+    trimOldest(latestPreviewByNodeId, maxEntries);
+  };
+
+  return {
+    async ensure(request) {
+      activeIdentityByNodeId.set(request.nodeId, request.identity);
+      const cached = previewByIdentity.get(request.identity);
+      if (cached) {
+        writeLatest(request.nodeId, request.identity, cached);
+        return cached;
+      }
+      const pending = pendingByIdentity.get(request.identity);
+      if (pending) {
+        return pending;
+      }
+
+      const operation = (async (): Promise<string | null> => {
+        const persistedPreview = await invokePreviewAdapter(
+          request.readPersisted
+        );
+        if (persistedPreview) {
+          writeIdentity(request.identity, persistedPreview);
+          if (activeIdentityByNodeId.get(request.nodeId) === request.identity) {
+            writeLatest(request.nodeId, request.identity, persistedPreview);
+          }
+          return persistedPreview;
+        }
+
+        const capturedPreview = await invokePreviewAdapter(request.capture);
+        if (!capturedPreview) {
+          return null;
+        }
+        writeIdentity(request.identity, capturedPreview);
+        const isCurrentGeneration =
+          activeIdentityByNodeId.get(request.nodeId) === request.identity;
+        if (isCurrentGeneration) {
+          writeLatest(request.nodeId, request.identity, capturedPreview);
+        }
+        if (isCurrentGeneration && request.writePersisted) {
+          invokePreviewPersistence(request.writePersisted, capturedPreview);
+        }
+        return capturedPreview;
+      })();
+      pendingByIdentity.set(request.identity, operation);
+      try {
+        return await operation;
+      } finally {
+        if (pendingByIdentity.get(request.identity) === operation) {
+          pendingByIdentity.delete(request.identity);
+        }
+      }
+    },
+
+    read(identity) {
+      const previewImageUrl = previewByIdentity.get(identity) ?? null;
+      if (previewImageUrl) {
+        previewByIdentity.delete(identity);
+        previewByIdentity.set(identity, previewImageUrl);
+      }
+      return previewImageUrl;
+    },
+
+    readLatest(nodeId) {
+      const latest = latestPreviewByNodeId.get(nodeId) ?? null;
+      if (latest) {
+        latestPreviewByNodeId.delete(nodeId);
+        latestPreviewByNodeId.set(nodeId, latest);
+      }
+      return latest?.previewImageUrl ?? null;
+    },
+
+    write({ identity, nodeId, previewImageUrl }) {
+      if (!previewImageUrl) {
+        return;
+      }
+      activeIdentityByNodeId.set(nodeId, identity);
+      writeIdentity(identity, previewImageUrl);
+      writeLatest(nodeId, identity, previewImageUrl);
+    }
+  };
+}
+
+async function invokePreviewAdapter(
+  adapter: (() => Promise<string | null> | string | null) | undefined
+): Promise<string | null> {
+  if (!adapter) {
+    return null;
+  }
+  try {
+    return await adapter();
+  } catch {
+    return null;
+  }
+}
+
+function invokePreviewPersistence(
+  persist: (previewImageUrl: string) => Promise<unknown> | unknown,
+  previewImageUrl: string
+): void {
+  try {
+    void Promise.resolve(persist(previewImageUrl)).catch(() => undefined);
+  } catch {
+    // Product cache adapters are best-effort and must not break preview state.
+  }
+}
+
+function trimOldest<TKey, TValue>(
+  entries: Map<TKey, TValue>,
+  maxEntries: number
+): void {
+  while (entries.size > maxEntries) {
+    const oldestKey = entries.keys().next().value;
+    if (oldestKey === undefined) {
+      return;
+    }
+    entries.delete(oldestKey);
+  }
+}
+
+export const workbenchNodePreviewRuntime = createWorkbenchNodePreviewRuntime();
+
+export function workbenchNodePreviewIdentity(nodeId: string): string {
+  return `node:${nodeId}`;
+}
+
+export function workbenchDockPreviewIdentity(
+  key: WorkbenchDockPreviewCacheKey
+): string {
+  return JSON.stringify([
+    key.workspaceId,
+    key.typeId,
+    key.instanceId,
+    key.instanceKey ?? null,
+    key.nodeId,
+    key.revision ?? null
+  ]);
+}
+
+export function workbenchMinimizedDockPreviewIdentity(
+  key: WorkbenchDockPreviewCacheKey,
+  minimizedAtUnixMs: number | null | undefined
+): string {
+  return `${workbenchDockPreviewIdentity(key)}:${minimizedAtUnixMs ?? "unknown"}`;
+}

--- a/packages/workbench/surface/src/react/useWorkbenchGenieAnimation.tsx
+++ b/packages/workbench/surface/src/react/useWorkbenchGenieAnimation.tsx
@@ -52,6 +52,10 @@ import type {
 } from "./nodePreviewCapture.ts";
 import type { WorkbenchNodePresentationTransitionStore } from "./nodePresentationTransitions.ts";
 import {
+  workbenchNodePreviewIdentity,
+  workbenchNodePreviewRuntime
+} from "../preview/workbenchNodePreviewRuntime.ts";
+import {
   resolveNativeFirstGenieTexture,
   scheduleWorkbenchGeniePostAnimationIdleTask,
   scheduleWorkbenchGenieWarmup,
@@ -68,14 +72,13 @@ const minimizedDockSlotEnterAnimationMs = 720;
 const dockAnchorResolveMaxAnimationFrames = 3;
 const dockPreviewMaxWidth = 260;
 const dockPreviewMaxHeight = 170;
-const dockPreviewImageCacheMaxEntries = 96;
 const minimizedGenieTextureCacheMaxBytes = 64 * 1024 * 1024;
 const minimizedGenieTextureCacheMaxEntries = 8;
 const inlineImageResourceCacheMaxEntries = 160;
 const inlineImageResizeTargetCacheMaxEntries = 4;
 const dockAnchorFallbackSizePx = 43.2;
 const genieInlineImageMaxDevicePixelRatio = 2;
-const dockPreviewImageByNodeID = new Map<string, string>();
+
 const inlineImageResourceByUrl = new Map<string, Promise<string | null>>();
 const resizedInlineImageResourceByUrl = new Map<
   string,
@@ -598,23 +601,17 @@ export function writeCachedWorkbenchNodePreviewImage(
   nodeID: string,
   previewImageUrl: string | null | undefined
 ): void {
-  if (previewImageUrl) {
-    dockPreviewImageByNodeID.delete(nodeID);
-    dockPreviewImageByNodeID.set(nodeID, previewImageUrl);
-    while (dockPreviewImageByNodeID.size > dockPreviewImageCacheMaxEntries) {
-      const oldestNodeID = dockPreviewImageByNodeID.keys().next().value;
-      if (typeof oldestNodeID !== "string") {
-        break;
-      }
-      dockPreviewImageByNodeID.delete(oldestNodeID);
-    }
-  }
+  workbenchNodePreviewRuntime.write({
+    identity: workbenchNodePreviewIdentity(nodeID),
+    nodeId: nodeID,
+    previewImageUrl
+  });
 }
 
 export function readCachedWorkbenchNodePreviewImage(
   nodeID: string
 ): string | null {
-  return dockPreviewImageByNodeID.get(nodeID) ?? null;
+  return workbenchNodePreviewRuntime.readLatest(nodeID);
 }
 
 export async function captureWorkbenchNodePreviewImage(


### PR DESCRIPTION
## Summary

- introduce a neutral minimized-node preview runtime that owns memory/persisted cache orchestration, in-flight capture deduplication, active-identity fencing, and best-effort persistence
- move minimized Dock slots and minimized-stack popup cards onto the same preview hook, identity, and revision-aware cache path
- move low-resolution preview cache ownership out of the Genie animation hook while preserving Genie minimize/restore compatibility and legacy persisted-cache fallback reads
- add and export a renderer capture adapter, then migrate Tutti Desktop to the shared DOM/focus/viewport/timeout/diagnostic policy

## Why

Minimized preview generation, cache reads/writes, scheduling, and stale-result handling were split between `WorkbenchHostDock`, the minimized-stack popup, and the Genie animation hook. That duplicated lifecycle policy and allowed old captures to overwrite a newer minimization cycle.

This change gives the lifecycle one neutral owner while leaving product-specific Electron transport, persistence, and diagnostics at the Desktop boundary.

## Main risks and affected surfaces

- minimized Dock slot preview rendering
- minimized-stack popup preview rendering and persistent cache keys
- Genie minimize/restore preview reuse
- Desktop renderer native capture diagnostics and timeout behavior

The node minimize/restore/focus/close state machine, Dock layout, snapshot schema, IPC DTOs, and normal non-minimized Dock popup capture are intentionally unchanged.

## Verification

Run on Node `v24.18.1`:

- `pnpm --filter @tutti-os/workbench-surface typecheck`
- `pnpm --filter @tutti-os/workbench-surface test` — 270 Node tests and 39 Vitest tests passed before rebase; post-rebase package suite passed with the latest main test set
- `pnpm --filter @tutti-os/workbench-surface build`
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm --filter @tutti-os/desktop test`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm check:renderer-boundaries`
- `pnpm release:pack:check -- --packages-json '["@tutti-os/workbench-surface"]'`
- pre-commit formatting, lint, UI-boundary, renderer-boundary, degradation, and runtime-image checks
- pre-push `pnpm check:changed -- --push-ready` — 16 lanes passed
- `make dev-gui` reached Vite, Electron, and tuttid startup; the process was then intentionally terminated and tuttid completed shutdown

## Review findings addressed

- stale captures cannot update latest memory or persistent cache
- a cached identity becoming active again fences older pending identities
- minimized revisions participate in runtime and persistent cache identity
- stack popup writes use the same revisioned key as minimized slots
- Genie unrevisioned cache entries remain a compatibility fallback only
- synchronous transport throws and asynchronous rejections both resolve to `null` and emit `capture_failed`

## Downstream tracking

- tutti-lab/tsh#2232 records the fixed-cohort upgrade and post-release adapter migration.

## Known gap

Automated checks and real process startup were completed, but the full minimized slot/stack/restore matrix was not manually clicked through in this environment.
