### PR TITLE
fix(ui-system): align mobile dark brand color

### DIFF
--- a/packages/ui/system/src/native/generated-tokens.ts
+++ b/packages/ui/system/src/native/generated-tokens.ts
@@ -39,8 +39,8 @@ export const nativeThemes = {
     textSecondary: "#6c6c6c"
   },
   dark: {
-    accent: "#ff6b4a",
-    accentPressed: "#eb5839",
+    accent: "#5a9bff",
+    accentPressed: "#4f8fff",
     background: "#111216",
     backgroundFronted: "#22252d",
     backgroundPanel: "#1a1c22",

--- a/packages/ui/system/src/tokens/renderer-theme.json
+++ b/packages/ui/system/src/tokens/renderer-theme.json
@@ -85,11 +85,11 @@
     },
     "dark": {
       "accent": {
-        "native": "#ff6b4a",
+        "native": "#5a9bff",
         "web": "rgb(90 155 255)"
       },
       "accentPressed": {
-        "native": "#eb5839",
+        "native": "#4f8fff",
         "web": "rgb(79 143 255)"
       },
       "background": {


### PR DESCRIPTION
## Summary

- align the Native dark-theme accent with the UI System brand blue
- update the generated Native theme tokens from the shared renderer token manifest
- keep the pressed accent aligned with the Web dark-theme value

## Root cause

The shared renderer token manifest defined an orange Native accent for dark mode while the Web dark theme used the UI System brand blue. Mobile correctly consumed `useNativeTheme()`, but therefore received the divergent Native value.

## Impact

Mobile primary actions, focus accents, links, activity indicators, and other semantic accent consumers now inherit the same blue brand treatment in dark mode. Light mode and non-accent colors are unchanged.

## Validation

- renderer token outputs regenerated successfully
- staged formatting, lint, renderer-token, metadata, UI-boundary, and related repository hooks passed
- `pnpm check:changed -- --push-ready` passed all 10 selected lanes

## Documentation

No durable documentation update is required because the existing UI System documentation already defines the renderer token manifest as the shared Web/Native source of truth.