### PR TITLE
fix(mobile): fence stale agent live subscriptions

### DIFF
--- a/apps/mobile/android/app/src/main/java/dev/tutti/mobile/DeviceLinkModule.kt
+++ b/apps/mobile/android/app/src/main/java/dev/tutti/mobile/DeviceLinkModule.kt
@@ -5,12 +5,16 @@ import android.os.Looper
 import android.os.SystemClock
 import android.util.Base64
 import android.util.Log
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.LifecycleEventListener
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.modules.core.DeviceEventManagerModule
 import dev.tutti.mobile.bindings.liveprotocolmobile.Liveprotocolmobile
 import dev.tutti.mobile.bindings.mobile.Link
@@ -32,7 +36,8 @@ import org.json.JSONObject
 class DeviceLinkModule(
     reactContext: ReactApplicationContext,
 ) : ReactContextBaseJavaModule(reactContext),
-    LifecycleEventListener {
+    LifecycleEventListener,
+    DefaultLifecycleObserver {
     @Volatile
     private var link: Link? = null
     @Volatile
@@ -43,6 +48,9 @@ class DeviceLinkModule(
     private val agentLiveExecutor = Executors.newSingleThreadExecutor()
     private val closeExecutor = Executors.newSingleThreadExecutor()
     private val handler = Handler(Looper.getMainLooper())
+    private val processLifecycle = ProcessLifecycleOwner.get().lifecycle
+    @Volatile
+    private var invalidated = false
     private val executor =
         ThreadPoolExecutor(
             2,
@@ -55,6 +63,11 @@ class DeviceLinkModule(
 
     init {
         reactContext.addLifecycleEventListener(this)
+        UiThreadUtil.runOnUiThread {
+            if (!invalidated) {
+                processLifecycle.addObserver(this)
+            }
+        }
     }
 
     override fun getName(): String = "TuttiDeviceLink"
@@ -224,6 +237,7 @@ class DeviceLinkModule(
     @ReactMethod
     fun startAgentLive(
         workspaceId: String,
+        subscriptionGeneration: Double,
         promise: Promise,
     ) {
         val normalizedWorkspaceId = workspaceId.trim()
@@ -231,6 +245,17 @@ class DeviceLinkModule(
             promise.reject(
                 "AGENT_LIVE_SUBSCRIBE_FAILED",
                 "Agent live workspace id is required",
+            )
+            return
+        }
+        if (
+            !subscriptionGeneration.isFinite() ||
+            subscriptionGeneration <= 0 ||
+            subscriptionGeneration % 1.0 != 0.0
+        ) {
+            promise.reject(
+                "AGENT_LIVE_SUBSCRIBE_FAILED",
+                "Agent live subscription generation must be a positive integer",
             )
             return
         }
@@ -309,6 +334,10 @@ class DeviceLinkModule(
                             emitAgentLive(
                                 JSONObject()
                                     .put("workspaceId", normalizedWorkspaceId)
+                                    .put(
+                                        "subscriptionGeneration",
+                                        subscriptionGeneration,
+                                    )
                                     .put("result", result)
                                     .toString(),
                             )
@@ -326,6 +355,10 @@ class DeviceLinkModule(
                         emitAgentLive(
                             JSONObject()
                                 .put("workspaceId", normalizedWorkspaceId)
+                                .put(
+                                    "subscriptionGeneration",
+                                    subscriptionGeneration,
+                                )
                                 .put("status", "disconnected")
                                 .put("reason", "stream_closed")
                                 .toString(),
@@ -372,14 +405,22 @@ class DeviceLinkModule(
         handler.postDelayed(backgroundClose, BACKGROUND_GRACE_MILLIS)
     }
 
+    override fun onStop(owner: LifecycleOwner) {
+        closeCurrentAgentLiveStream()
+    }
+
     override fun onHostDestroy() {
         handler.removeCallbacks(backgroundClose)
         closeCurrentLink()
     }
 
     override fun invalidate() {
+        invalidated = true
         handler.removeCallbacks(backgroundClose)
         reactApplicationContext.removeLifecycleEventListener(this)
+        UiThreadUtil.runOnUiThread {
+            processLifecycle.removeObserver(this)
+        }
         closeCurrentLink()
         agentLiveExecutor.shutdownNow()
         executor.shutdownNow()

--- a/apps/mobile/ios/TuttiMobile/DeviceLinkModule.mm
+++ b/apps/mobile/ios/TuttiMobile/DeviceLinkModule.mm
@@ -301,6 +301,7 @@ RCT_REMAP_METHOD(requestAgentHTTP,
 
 RCT_REMAP_METHOD(startAgentLive,
                  startAgentLive:(NSString *)workspaceID
+                 subscriptionGeneration:(nonnull NSNumber *)subscriptionGeneration
                  resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
   NSString *normalized =
@@ -309,6 +310,14 @@ RCT_REMAP_METHOD(startAgentLive,
   if (normalized.length == 0) {
     reject(@"AGENT_LIVE_SUBSCRIBE_FAILED",
            @"Agent live workspace id is required", nil);
+    return;
+  }
+  if (subscriptionGeneration.longLongValue <= 0 ||
+      subscriptionGeneration.doubleValue !=
+          (double)subscriptionGeneration.longLongValue) {
+    reject(@"AGENT_LIVE_SUBSCRIBE_FAILED",
+           @"Agent live subscription generation must be a positive integer",
+           nil);
     return;
   }
   TUTMobileLink *selected = [self linkSnapshot];
@@ -391,6 +400,7 @@ RCT_REMAP_METHOD(startAgentLive,
       if ([self isAgentLiveCurrent:stream generation:generation]) {
         NSDictionary *delivery = @{
           @"workspaceId" : normalized,
+          @"subscriptionGeneration" : subscriptionGeneration,
           @"result" : [self objectFromJSONString:result] ?: @{},
         };
         NSData *encoded = TUTJSONData(delivery, nil);
@@ -407,6 +417,7 @@ RCT_REMAP_METHOD(startAgentLive,
     if (current) {
       NSData *encoded = TUTJSONData(@{
         @"workspaceId" : normalized,
+        @"subscriptionGeneration" : subscriptionGeneration,
         @"status" : @"disconnected",
         @"reason" : @"stream_closed",
       }, nil);
@@ -662,6 +673,7 @@ RCT_REMAP_METHOD(closeLink,
 }
 
 - (void)applicationDidEnterBackground {
+  [self closeCurrentAgentLiveStream];
   @synchronized(self) {
     if (self.backgroundClose != nil) {
       dispatch_block_cancel(self.backgroundClose);

--- a/apps/mobile/src/native/agentLiveNativeBridge.test.ts
+++ b/apps/mobile/src/native/agentLiveNativeBridge.test.ts
@@ -5,6 +5,7 @@ describe("parseAgentLiveDeliveries", () => {
     expect(
       parseAgentLiveDeliveries(
         "workspace-1",
+        7,
         JSON.stringify({
           result: {
             accepted: [
@@ -37,6 +38,7 @@ describe("parseAgentLiveDeliveries", () => {
               }
             ]
           },
+          subscriptionGeneration: 7,
           workspaceId: "workspace-1"
         })
       )
@@ -68,9 +70,11 @@ describe("parseAgentLiveDeliveries", () => {
     expect(
       parseAgentLiveDeliveries(
         "workspace-1",
+        7,
         JSON.stringify({
           reason: "stream_closed",
           status: "disconnected",
+          subscriptionGeneration: 7,
           workspaceId: "workspace-1"
         })
       )
@@ -84,9 +88,31 @@ describe("parseAgentLiveDeliveries", () => {
     expect(
       parseAgentLiveDeliveries(
         "workspace-1",
+        7,
         JSON.stringify({
           result: { accepted: [{ kind: "stream_ready" }] },
+          subscriptionGeneration: 7,
           workspaceId: "workspace-2"
+        })
+      )
+    ).toEqual([]);
+  });
+
+  test("rejects queued deliveries from an obsolete native subscription", () => {
+    const delivery = JSON.stringify({
+      result: { accepted: [{ kind: "stream_ready" }] },
+      subscriptionGeneration: 6,
+      workspaceId: "workspace-1"
+    });
+
+    expect(parseAgentLiveDeliveries("workspace-1", 7, delivery)).toEqual([]);
+    expect(
+      parseAgentLiveDeliveries(
+        "workspace-1",
+        7,
+        JSON.stringify({
+          result: { accepted: [{ kind: "stream_ready" }] },
+          workspaceId: "workspace-1"
         })
       )
     ).toEqual([]);
@@ -96,6 +122,7 @@ describe("parseAgentLiveDeliveries", () => {
     expect(
       parseAgentLiveDeliveries(
         "workspace-1",
+        7,
         JSON.stringify({
           result: {
             accepted: [
@@ -115,6 +142,7 @@ describe("parseAgentLiveDeliveries", () => {
             ],
             reconcileRequired: true
           },
+          subscriptionGeneration: 7,
           workspaceId: "workspace-1"
         })
       )
@@ -130,6 +158,7 @@ describe("parseAgentLiveDeliveries", () => {
     expect(
       parseAgentLiveDeliveries(
         "workspace-1",
+        7,
         JSON.stringify({
           result: {
             accepted: [
@@ -157,6 +186,7 @@ describe("parseAgentLiveDeliveries", () => {
               }
             ]
           },
+          subscriptionGeneration: 7,
           workspaceId: "workspace-1"
         })
       )
@@ -210,8 +240,10 @@ describe("parseAgentLiveDeliveries", () => {
     expect(
       parseAgentLiveDeliveries(
         "workspace-1",
+        7,
         JSON.stringify({
           result: { accepted: [accepted] },
+          subscriptionGeneration: 7,
           workspaceId: "workspace-1"
         })
       )
@@ -225,7 +257,7 @@ describe("parseAgentLiveDeliveries", () => {
   });
 
   test("turns invalid or unknown native deliveries into reconciliation", () => {
-    expect(parseAgentLiveDeliveries("workspace-1", "{")).toEqual([
+    expect(parseAgentLiveDeliveries("workspace-1", 7, "{")).toEqual([
       {
         kind: "discontinuity",
         reason: "invalid_native_delivery",
@@ -235,8 +267,10 @@ describe("parseAgentLiveDeliveries", () => {
     expect(
       parseAgentLiveDeliveries(
         "workspace-1",
+        7,
         JSON.stringify({
           result: { accepted: [{ kind: "future_delivery" }] },
+          subscriptionGeneration: 7,
           workspaceId: "workspace-1"
         })
       )

--- a/apps/mobile/src/native/agentLiveNativeBridge.ts
+++ b/apps/mobile/src/native/agentLiveNativeBridge.ts
@@ -6,6 +6,7 @@ import type {
 
 export function parseAgentLiveDeliveries(
   workspaceId: string,
+  subscriptionGeneration: number,
   payload: string
 ): AgentLiveDelivery[] {
   try {
@@ -17,9 +18,15 @@ export function parseAgentLiveDeliveries(
         reconcileRequired?: unknown;
       };
       status?: unknown;
+      subscriptionGeneration?: unknown;
       workspaceId?: unknown;
     };
-    if (envelope.workspaceId !== workspaceId) return [];
+    if (
+      envelope.workspaceId !== workspaceId ||
+      envelope.subscriptionGeneration !== subscriptionGeneration
+    ) {
+      return [];
+    }
     if (envelope.status === "disconnected") {
       return [
         {

--- a/apps/mobile/src/native/createMobileServicePorts.ts
+++ b/apps/mobile/src/native/createMobileServicePorts.ts
@@ -23,6 +23,7 @@ const AGENT_LIVE_EVENT_NAME = "TuttiDeviceLinkAgentLive";
 const appLifecycleEvents = new NativeEventEmitter(appLifecycle);
 
 export function createMobileServicePorts(): MobileServicePorts {
+  let nextAgentLiveSubscriptionGeneration = 0;
   return {
     account: {
       sendEmailCode,
@@ -43,27 +44,31 @@ export function createMobileServicePorts(): MobileServicePorts {
         deviceLink.requestAgentHTTP(method, path, body, timeoutMillis),
       subscribeAgentLive(workspaceId, listener) {
         let active = true;
+        const subscriptionGeneration = ++nextAgentLiveSubscriptionGeneration;
         const subscription = DeviceEventEmitter.addListener(
           AGENT_LIVE_EVENT_NAME,
           (payload: string) => {
             if (!active) return;
             for (const delivery of parseAgentLiveDeliveries(
               workspaceId,
+              subscriptionGeneration,
               payload
             )) {
               listener(delivery);
             }
           }
         );
-        void deviceLink.startAgentLive(workspaceId).catch(() => {
-          if (active) {
-            listener({
-              kind: "connection",
-              reason: "subscribe_failed",
-              status: "disconnected"
-            });
-          }
-        });
+        void deviceLink
+          .startAgentLive(workspaceId, subscriptionGeneration)
+          .catch(() => {
+            if (active) {
+              listener({
+                kind: "connection",
+                reason: "subscribe_failed",
+                status: "disconnected"
+              });
+            }
+          });
         return {
           close() {
             if (!active) return;

--- a/apps/mobile/src/native/mobileNative.ts
+++ b/apps/mobile/src/native/mobileNative.ts
@@ -63,7 +63,10 @@ interface DeviceLinkNative {
   }>;
   removeListeners(count: number): void;
   runLoopbackProbe(timeoutMillis: number): Promise<string>;
-  startAgentLive(workspaceId: string): Promise<void>;
+  startAgentLive(
+    workspaceId: string,
+    subscriptionGeneration: number
+  ): Promise<void>;
   stopAgentLive(): Promise<void>;
 }
 

--- a/apps/mobile/src/services/workspaceActivityService.test.ts
+++ b/apps/mobile/src/services/workspaceActivityService.test.ts
@@ -1237,6 +1237,36 @@ describe("WorkspaceActivityService", () => {
     service.dispose();
   });
 
+  test("ignores an obsolete live subscription after background resume", async () => {
+    const liveListeners: Array<(delivery: AgentLiveDelivery) => void> = [];
+    const service = createService(
+      createClient({ listMessages: emptyMessagePage }),
+      {
+        deviceLink: createLiveDeviceLink((listener) => {
+          liveListeners.push(listener);
+        })
+      }
+    );
+
+    await service.start();
+    await flushAsyncWork();
+    expect(liveListeners).toHaveLength(1);
+    liveListeners[0]!({ kind: "connection", status: "connected" });
+    expect(service.isTransportConnected()).toBe(true);
+
+    service.pause();
+    service.resume();
+    expect(liveListeners).toHaveLength(2);
+    expect(service.isTransportConnected()).toBe(false);
+
+    liveListeners[0]!({ kind: "connection", status: "connected" });
+    expect(service.isTransportConnected()).toBe(false);
+    liveListeners[1]!({ kind: "connection", status: "connected" });
+    expect(service.isTransportConnected()).toBe(true);
+
+    service.dispose();
+  });
+
   test("projects live message deltas and disables fallback message polling", async () => {
     const clock = new RecordingClock();
     let liveListener: ((delivery: AgentLiveDelivery) => void) | null = null;

--- a/apps/mobile/src/services/workspaceActivityService.ts
+++ b/apps/mobile/src/services/workspaceActivityService.ts
@@ -615,7 +615,6 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
     if (!this.paused || this.disposed) return;
     this.paused = false;
     this.rail.resume();
-    this.liveLane.start();
     this.setTransportConnected(!this.requiresLiveTransport, true);
     this.engine.dispatch({
       retry: true,
@@ -633,6 +632,7 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
         workspaceId: this.workspace.id
       });
     }
+    this.liveLane.start();
     this.scheduleMessagesPoll();
   }
 

--- a/apps/mobile/src/services/workspaceAgentLiveLane.ts
+++ b/apps/mobile/src/services/workspaceAgentLiveLane.ts
@@ -38,6 +38,7 @@ export class WorkspaceAgentLiveLane {
   private retryTask: { cancel(): void } | null = null;
   private railReconcileTask: { cancel(): void } | null = null;
   private subscription: { close(): void } | null = null;
+  private subscriptionGeneration = 0;
   // Mobile currently opens every native stream from epoch/sequence zero, so
   // this projection has the same lifetime as the subscription. A future
   // persisted resume cursor must persist this fence with it.
@@ -60,9 +61,13 @@ export class WorkspaceAgentLiveLane {
     this.retryTask?.cancel();
     this.retryTask = null;
     this.attachmentFence = null;
+    const subscriptionGeneration = ++this.subscriptionGeneration;
     this.subscription = this.options.deviceLink.subscribeAgentLive(
       this.options.workspaceId,
-      (delivery) => this.handleDelivery(delivery)
+      (delivery) => {
+        if (subscriptionGeneration !== this.subscriptionGeneration) return;
+        this.handleDelivery(delivery);
+      }
     );
   }
 
@@ -73,6 +78,7 @@ export class WorkspaceAgentLiveLane {
     this.retryTask = null;
     this.railReconcileTask?.cancel();
     this.railReconcileTask = null;
+    this.subscriptionGeneration += 1;
     this.subscription?.close();
     this.subscription = null;
     this.attachmentFence = null;
@@ -132,6 +138,7 @@ export class WorkspaceAgentLiveLane {
         this.setConnected(true);
         return;
       }
+      this.subscriptionGeneration += 1;
       this.subscription?.close();
       this.subscription = null;
       this.attachmentFence = null;
@@ -203,6 +210,7 @@ export class WorkspaceAgentLiveLane {
 
   private rejectAttachmentFence(reason: string): void {
     this.attachmentFence = null;
+    this.subscriptionGeneration += 1;
     this.subscription?.close();
     this.subscription = null;
     this.coordinator.eventStreamConnectionChanged({

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -1232,11 +1232,16 @@ publishing `stream_ready`, so events produced during ready-frame delivery are
 already buffered instead of falling through a subscribe gap. The Android
 bridge keeps one long-lived DeviceLink stream and delegates frame decoding and
 continuity checks to the Agent-owned Go mobile Subscriber before emitting
-accepted deliveries to React Native. The Mobile Android host co-links that
-Subscriber and DeviceLink into its own composite AAR; the transport package's
-AAR and Java namespace remain Agent-free. Mobile disables its message and Rail
-pollers after `stream_ready`; those pollers are disconnected-transport fallback
-only.
+accepted deliveries to React Native. Each bridge subscription also carries a
+caller-owned local generation that is independent of the wire epoch and
+sequence cursor. Native stops the live stream immediately when the App enters
+the background, and both the Native-to-JS adapter and workspace live lane reject
+queued deliveries from a closed generation after foreground resume. The
+underlying DeviceLink may remain open for its background grace interval. The
+Mobile Android host co-links that Subscriber and DeviceLink into its own
+composite AAR; the transport package's AAR and Java namespace remain Agent-free.
+Mobile disables its message and Rail pollers after `stream_ready`; those pollers
+are disconnected-transport fallback only.
 
 After either transport is normalized, Desktop and Mobile call the same
 `AgentActivityWorkspaceEventCoordinator`. Its package-internal rules derive

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1030,12 +1030,17 @@ those host concerns must not leak back into the shared query controller.
 Mobile DeviceLink recovery is application-scoped rather than screen-scoped.
 `MobileApplicationService` is the single owner of the paired-device connection
 phase (`idle`, `reconnecting`, `synchronizing`, `connected`, or `failed`).
-Native owns the actual background-grace link close; JavaScript records the
-background entry time and uses elapsed time on foreground instead of relying on
-a timer that the runtime may suspend. An unexpected live-lane disconnect first
-allows one bounded stream retry, then rebuilds DeviceLink if the stream remains
-offline. Runtime commands stay blocked until the replacement live lane reports
-ready.
+Native stops Agent Live immediately on background entry while retaining the
+underlying DeviceLink for its background grace interval. Every Native-to-JS
+live delivery carries the caller-owned subscription generation; the bridge and
+workspace live lane reject deliveries from a closed generation before they can
+reach the coordinator. JavaScript records the background entry time and uses
+elapsed time on foreground instead of relying on a timer that the runtime may
+suspend. Foreground resume queues canonical workspace and selected-Session
+reconciliation before opening the replacement live lane. An unexpected
+live-lane disconnect first allows one bounded stream retry, then rebuilds
+DeviceLink if the stream remains offline. Runtime commands stay blocked until
+the replacement live lane reports ready.
 
 Recovery retains the current device, workspace, navigation, and drafts behind a
 global blocking presentation. A replacement workspace scope is started and

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -159,6 +159,7 @@ Android app login, native bridge, secure identity, and mobile transport diagnost
 - [Browser login completes but leaves the browser in front](./mobile.md#browser-login-completes-but-leaves-the-browser-in-front)
 - [Browser login returns to the App but remains signed out](./mobile.md#browser-login-returns-to-the-app-but-remains-signed-out)
 - [Android DeviceLink opens a session and then repeatedly restarts](./mobile.md#android-devicelink-opens-a-session-and-then-repeatedly-restarts)
+- [Mobile shows output from a completed Session after foreground resume](./mobile.md#mobile-shows-output-from-a-completed-session-after-foreground-resume)
 - [Mobile stays connected after a long lock-screen interval but sends fail](./mobile.md#mobile-stays-connected-after-a-long-lock-screen-interval-but-sends-fail)
 - [iOS App crashes after loading the JavaScript bundle](./mobile.md#ios-app-crashes-after-loading-the-javascript-bundle)
 - [iOS pod install intermittently reports pathname contains null byte](./mobile.md#ios-pod-install-intermittently-reports-pathname-contains-null-byte)

--- a/docs/conventions/troubleshooting/mobile.md
+++ b/docs/conventions/troubleshooting/mobile.md
@@ -249,6 +249,41 @@ dev.tutti.mobile` and inspect a narrow logcat window for the Go fatal message.
 - **References:** `packages/device-link/mobile/link.go`,
   `apps/mobile/android/app/src/main/java/dev/tutti/mobile/DeviceLinkModule.kt`
 
+## Mobile shows output from a completed Session after foreground resume
+
+- **Symptom:** After the App enters the background and is reopened, transcript
+  output from the previously selected Session continues streaming even though
+  that Session already ended on the host.
+- **Quick checks:** Compare App lifecycle events with Native `TuttiDeviceLink`
+  Agent Live logs. Capture the subscription generation on the last delivery
+  before background and the first delivery after foreground. If a delivery from
+  the closed generation reaches the replacement JavaScript listener, the fault
+  is lifecycle fencing rather than canonical Session state or server replay.
+- **Root cause:** DeviceLink intentionally stays open for a short background
+  grace period, but Agent Live used to share that lifetime. A suspended
+  JavaScript runtime could therefore miss or delay its stop call while Native
+  continued reading the old stream. React Native could queue those deliveries
+  and publish them to the newly attached listener after foreground resume. The
+  Native envelope carried workspace identity but no local subscription
+  generation, so the replacement listener could not distinguish queued old
+  output from its new stream.
+- **Fix:** Stop Agent Live immediately at the Android and iOS background
+  boundary while preserving the underlying DeviceLink grace interval. Give
+  every bridge subscription a caller-owned generation, include it in every
+  Native delivery, and reject mismatched generations in both the bridge parser
+  and workspace live lane. Queue canonical workspace and selected-Session
+  reconciliation before opening the replacement stream.
+- **Validation:** Background and foreground a connected workspace, invoke a
+  captured old listener after the replacement subscription exists, and verify
+  it cannot mark transport connected or change projected activity. Verify
+  matching-generation ready and event deliveries still apply, missing or stale
+  generations fail closed, and Android/iOS Native binding checks pass.
+- **References:**
+  `apps/mobile/src/native/createMobileServicePorts.ts`,
+  `apps/mobile/src/services/workspaceAgentLiveLane.ts`,
+  `apps/mobile/android/app/src/main/java/dev/tutti/mobile/DeviceLinkModule.kt`,
+  `apps/mobile/ios/TuttiMobile/DeviceLinkModule.mm`
+
 ## Mobile stays connected after a long lock-screen interval but sends fail
 
 - **Symptom:** After Mobile remains locked or backgrounded for at least the


### PR DESCRIPTION
## Summary

- stop Agent Live immediately when Android or iOS enters the background while retaining the underlying DeviceLink grace period
- carry a caller-owned subscription generation through the Native-to-JS envelope and reject obsolete generations at both the bridge and workspace live lane
- queue authoritative workspace and selected-Session reconciliation before opening the replacement foreground stream
- document the Mobile recovery ownership and the recurring troubleshooting pattern

## Root cause

DeviceLink intentionally remains alive for a 15-second background grace period, but Agent Live previously shared that lifetime. If JavaScript was suspended before its asynchronous stop completed, Native could continue reading the old stream and React Native could queue those deliveries. After foreground resume, the replacement global listener had only workspace identity and could not distinguish queued output from the closed subscription, so stale deltas could reach the activity coordinator and appear in the transcript.

## Impact

Returning to Mobile after backgrounding no longer allows output from a closed Agent Live subscription to mark the transport ready or update the visible conversation. Android uses process lifecycle rather than Activity pause, so in-app Activity transitions such as QR scanning do not trigger the immediate Live shutdown.

## Validation

- `pnpm check:changed` — 7 lanes passed
- `pnpm check:changed -- --push-ready` — 7 lanes passed
- focused Mobile Jest tests — 44 tests passed
- Mobile TypeScript typecheck passed
- Android Kotlin debug compilation passed
- iOS Simulator Debug build passed
- Android and iOS gomobile binding checks passed

## Review

Three independent sub-agent reviews covered repository architecture, Native lifecycle/bridge concurrency, and JavaScript live-lane fencing. No deterministic code defects were found. One non-blocking P3 test gap remains: the Native background callbacks are compile-validated but do not yet have platform-level lifecycle unit tests; TypeScript regression tests cover stale Native envelope generations and stale workspace callbacks.