### PR TITLE
fix(mobile): tighten compact screen layouts

### DIFF
--- a/apps/mobile/src/components/MobileComposerDock.tsx
+++ b/apps/mobile/src/components/MobileComposerDock.tsx
@@ -479,10 +479,10 @@ function createStyles(theme: NativeTheme) {
     actionButton: {
       alignItems: "center",
       backgroundColor: theme.color.text,
-      borderRadius: 22,
-      height: 44,
+      borderRadius: 18,
+      height: 36,
       justifyContent: "center",
-      width: 44
+      width: 36
     },
     actionIcon: {
       color: theme.color.background,
@@ -495,18 +495,18 @@ function createStyles(theme: NativeTheme) {
     },
     chevron: {
       color: theme.color.muted,
-      fontSize: 25,
-      lineHeight: 27
+      fontSize: 20,
+      lineHeight: 22
     },
     addButton: {
       alignItems: "center",
       backgroundColor: theme.color.panelRaised,
       borderColor: theme.color.border,
-      borderRadius: 28,
+      borderRadius: 20,
       borderWidth: StyleSheet.hairlineWidth,
-      height: 56,
+      height: 40,
       justifyContent: "center",
-      width: 56
+      width: 40
     },
     dock: {
       gap: theme.space.small,
@@ -529,24 +529,24 @@ function createStyles(theme: NativeTheme) {
     input: {
       color: theme.color.text,
       flex: 1,
-      fontSize: 17,
+      fontSize: 16,
       lineHeight: 22,
-      maxHeight: 132,
-      minHeight: 54,
-      paddingLeft: theme.space.medium,
-      paddingVertical: 15
+      maxHeight: 120,
+      minHeight: 40,
+      paddingLeft: 14,
+      paddingVertical: 9
     },
     inputPill: {
       alignItems: "center",
       backgroundColor: theme.color.panelRaised,
       borderColor: theme.color.border,
-      borderRadius: 28,
+      borderRadius: 22,
       borderWidth: StyleSheet.hairlineWidth,
       flex: 1,
       flexDirection: "row",
       gap: theme.space.small,
-      minHeight: 56,
-      paddingRight: 6
+      minHeight: 44,
+      paddingRight: 4
     },
     inputRow: {
       alignItems: "flex-end",
@@ -556,20 +556,20 @@ function createStyles(theme: NativeTheme) {
     loading: { marginVertical: theme.space.medium },
     plus: {
       color: theme.color.text,
-      fontSize: 31,
+      fontSize: 24,
       fontWeight: "300",
-      lineHeight: 34
+      lineHeight: 26
     },
     sendIcon: {
       color: theme.color.background,
-      fontSize: 25,
+      fontSize: 18,
       fontWeight: "700",
-      lineHeight: 27
+      lineHeight: 20
     },
     menu: {
       backgroundColor: theme.color.panelRaised,
       borderColor: theme.color.border,
-      borderRadius: 24,
+      borderRadius: theme.radius.large,
       borderWidth: StyleSheet.hairlineWidth,
       marginHorizontal: theme.space.medium,
       maxHeight: "70%",
@@ -587,7 +587,7 @@ function createStyles(theme: NativeTheme) {
     },
     menuBackIcon: {
       color: theme.color.text,
-      fontSize: 24
+      fontSize: 20
     },
     menuHeader: {
       alignItems: "center",

--- a/apps/mobile/src/components/MobileConversationImages.tsx
+++ b/apps/mobile/src/components/MobileConversationImages.tsx
@@ -211,8 +211,8 @@ function createStyles(theme: NativeTheme) {
     },
     previewCloseText: {
       color: theme.color.text,
-      fontSize: 34,
-      lineHeight: 36
+      fontSize: 26,
+      lineHeight: 30
     },
     previewImage: { height: "88%", width: "100%" },
     thumbnail: {

--- a/apps/mobile/src/components/MobileConversationTimeline.tsx
+++ b/apps/mobile/src/components/MobileConversationTimeline.tsx
@@ -329,7 +329,7 @@ function MobileGoalControlRow({ body }: { body: string }) {
 
 function createStyles(theme: NativeTheme) {
   return StyleSheet.create({
-    disclosure: { color: theme.color.muted, fontSize: 22, lineHeight: 22 },
+    disclosure: { color: theme.color.muted, fontSize: 18, lineHeight: 18 },
     errorText: { color: theme.color.danger, fontSize: 14, lineHeight: 21 },
     fileList: { gap: theme.space.small, paddingTop: theme.space.small },
     fileName: { color: theme.color.textSecondary, fontSize: 13 },

--- a/apps/mobile/src/components/MobileConversationsView.tsx
+++ b/apps/mobile/src/components/MobileConversationsView.tsx
@@ -145,7 +145,7 @@ export function MobileConversationsView({
       >
         <View style={styles.devicePill}>
           <View style={styles.deviceDot} />
-          <MobileComputerGlyph color={theme.color.background} size={18} />
+          <MobileComputerGlyph color={theme.color.background} size={14} />
           <Text numberOfLines={1} style={styles.deviceName}>
             {deviceName || t("desktopFallback")}
           </Text>
@@ -155,7 +155,7 @@ export function MobileConversationsView({
       <View style={styles.projectSection}>
         <Text style={styles.groupTitle}>{t("projects")}</Text>
         <View style={styles.projectRow}>
-          <MobileFolderGlyph color={theme.color.text} size={26} />
+          <MobileFolderGlyph color={theme.color.text} size={18} />
           <Text numberOfLines={1} style={styles.projectName}>
             {workspaceName}
           </Text>
@@ -518,9 +518,9 @@ function createStyles(theme: NativeTheme) {
     },
     backIcon: {
       color: theme.color.text,
-      fontSize: 32,
-      fontWeight: "300",
-      lineHeight: 34
+      fontSize: 22,
+      fontWeight: "400",
+      lineHeight: 26
     },
     bottomDock: {
       alignItems: "center",
@@ -533,16 +533,16 @@ function createStyles(theme: NativeTheme) {
     },
     chatButton: {
       backgroundColor: theme.color.text,
-      borderRadius: 28,
-      height: 56,
+      borderRadius: 22,
+      height: 44,
       width: "100%"
     },
     chatButtonSlot: {
       flexShrink: 0,
-      height: 56,
-      width: 112
+      height: 44,
+      width: 104
     },
-    chatIcon: { color: theme.color.background, fontSize: 22 },
+    chatIcon: { color: theme.color.background, fontSize: 18 },
     deleteDescription: {
       color: theme.color.textSecondary,
       fontSize: 14,
@@ -550,34 +550,34 @@ function createStyles(theme: NativeTheme) {
     },
     deviceDot: {
       backgroundColor: theme.color.success,
-      borderRadius: 5,
-      height: 10,
-      width: 10
+      borderRadius: 4,
+      height: 8,
+      width: 8
     },
     deviceName: {
       color: theme.color.background,
       flexShrink: 1,
-      fontSize: 15,
-      fontWeight: "700"
+      fontSize: 13,
+      fontWeight: "600"
     },
     devicePill: {
       alignItems: "center",
       backgroundColor: theme.color.text,
-      borderRadius: 24,
+      borderRadius: 18,
       flexDirection: "row",
       gap: theme.space.small,
-      height: 48,
-      maxWidth: 340,
-      paddingHorizontal: theme.space.medium
+      height: 36,
+      maxWidth: 280,
+      paddingHorizontal: 12
     },
     deviceRail: {
       alignItems: "center",
-      paddingBottom: theme.space.medium,
-      paddingTop: theme.space.large
+      paddingBottom: theme.space.small,
+      paddingTop: theme.space.small
     },
     deviceScroller: {
       flexGrow: 0,
-      maxHeight: 88
+      maxHeight: 48
     },
     root: {
       backgroundColor: theme.color.background,
@@ -601,16 +601,16 @@ function createStyles(theme: NativeTheme) {
       alignItems: "center",
       backgroundColor: theme.color.panelRaised,
       borderColor: theme.color.border,
-      borderRadius: 28,
+      borderRadius: 20,
       borderWidth: StyleSheet.hairlineWidth,
-      height: 56,
+      height: 40,
       justifyContent: "center",
-      width: 56
+      width: 40
     },
     headerButtonSlot: {
       flexShrink: 0,
-      height: 56,
-      width: 56
+      height: 40,
+      width: 40
     },
     feedback: {
       alignItems: "center",
@@ -630,9 +630,9 @@ function createStyles(theme: NativeTheme) {
     },
     inlineErrorText: { color: theme.color.danger, flex: 1, fontSize: 12 },
     list: {
-      gap: theme.space.large,
+      gap: theme.space.medium,
       paddingBottom: theme.space.medium,
-      paddingTop: theme.space.medium
+      paddingTop: theme.space.small
     },
     loadMoreButton: {
       alignItems: "center",
@@ -658,34 +658,35 @@ function createStyles(theme: NativeTheme) {
     },
     moreIconLarge: {
       color: theme.color.text,
-      fontSize: 30,
+      fontSize: 22,
       fontWeight: "800",
-      lineHeight: 31
+      lineHeight: 24
     },
     pressed: { opacity: 0.7 },
     groupTitle: {
-      color: theme.color.text,
-      fontSize: 18,
-      fontWeight: "700",
-      marginBottom: theme.space.medium
+      color: theme.color.textSecondary,
+      fontSize: 13,
+      fontWeight: "600",
+      letterSpacing: 0.4,
+      marginBottom: theme.space.small
     },
     projectName: {
       color: theme.color.text,
       flexShrink: 1,
-      fontSize: 18,
-      fontWeight: "500",
+      fontSize: 16,
+      fontWeight: "600",
       minWidth: 0
     },
     projectRow: {
       alignItems: "center",
       alignSelf: "stretch",
       flexDirection: "row",
-      gap: theme.space.medium,
-      minHeight: 48,
+      gap: theme.space.small,
+      minHeight: 36,
       width: "100%"
     },
     projectSection: {
-      paddingBottom: theme.space.medium
+      paddingBottom: theme.space.small
     },
     renameInput: {
       backgroundColor: theme.color.panel,
@@ -699,28 +700,28 @@ function createStyles(theme: NativeTheme) {
     },
     searchIcon: {
       color: theme.color.textSecondary,
-      fontSize: 30,
-      lineHeight: 32
+      fontSize: 18,
+      lineHeight: 22
     },
     searchInput: {
       color: theme.color.text,
       flex: 1,
-      fontSize: 16,
+      fontSize: 15,
       minWidth: 0,
-      minHeight: 54,
-      paddingVertical: 12
+      minHeight: 40,
+      paddingVertical: 10
     },
     searchPill: {
       alignItems: "center",
       backgroundColor: theme.color.panelRaised,
       borderColor: theme.color.border,
-      borderRadius: 28,
+      borderRadius: 22,
       borderWidth: StyleSheet.hairlineWidth,
       flex: 1,
       flexDirection: "row",
       gap: theme.space.small,
       minWidth: 0,
-      minHeight: 56,
+      minHeight: 44,
       paddingHorizontal: theme.space.medium
     },
     section: { gap: 2 },
@@ -731,8 +732,8 @@ function createStyles(theme: NativeTheme) {
     },
     sectionChevron: {
       color: theme.color.muted,
-      fontSize: 18,
-      lineHeight: 20
+      fontSize: 16,
+      lineHeight: 18
     },
     sectionHeader: {
       alignItems: "center",
@@ -744,8 +745,8 @@ function createStyles(theme: NativeTheme) {
     sectionTitle: {
       color: theme.color.text,
       flex: 1,
-      fontSize: 17,
-      fontWeight: "700",
+      fontSize: 15,
+      fontWeight: "600",
       letterSpacing: 0.2
     },
     sessionScroller: { flex: 1 },
@@ -759,8 +760,8 @@ function createStyles(theme: NativeTheme) {
     title: {
       color: theme.color.text,
       flex: 1,
-      fontSize: 24,
-      fontWeight: "700",
+      fontSize: 17,
+      fontWeight: "600",
       textAlign: "center"
     }
   });

--- a/apps/mobile/src/screens/ConversationScreenView.tsx
+++ b/apps/mobile/src/screens/ConversationScreenView.tsx
@@ -308,21 +308,15 @@ function createStyles(theme: NativeTheme) {
       alignItems: "center",
       flexDirection: "row",
       gap: theme.space.small,
-      minHeight: 82,
       paddingHorizontal: theme.space.medium,
       paddingVertical: theme.space.small
     },
     conversationBody: { flex: 1, minHeight: 0, position: "relative" },
     conversationTitle: {
-      backgroundColor: theme.color.panelRaised,
-      borderColor: theme.color.border,
-      borderRadius: 28,
-      borderWidth: StyleSheet.hairlineWidth,
+      alignItems: "center",
       flex: 1,
       justifyContent: "center",
-      minWidth: 0,
-      minHeight: 56,
-      paddingHorizontal: theme.space.medium
+      minWidth: 0
     },
     emptyText: {
       color: theme.color.textSecondary,
@@ -332,25 +326,25 @@ function createStyles(theme: NativeTheme) {
     },
     backIcon: {
       color: theme.color.text,
-      fontSize: 32,
-      fontWeight: "300",
-      lineHeight: 34
+      fontSize: 22,
+      fontWeight: "400",
+      lineHeight: 26
     },
     headerCircleButton: {
       alignItems: "center",
       backgroundColor: theme.color.panelRaised,
       borderColor: theme.color.border,
-      borderRadius: 28,
+      borderRadius: 20,
       borderWidth: StyleSheet.hairlineWidth,
       flexShrink: 0,
-      height: 56,
+      height: 40,
       justifyContent: "center",
-      width: 56
+      width: 40
     },
     headerButtonSlot: {
       flexShrink: 0,
-      height: 56,
-      width: 56
+      height: 40,
+      width: 40
     },
     inlineError: {
       backgroundColor: theme.color.panel,
@@ -368,27 +362,27 @@ function createStyles(theme: NativeTheme) {
     },
     locationLabel: {
       color: theme.color.textSecondary,
-      flex: 1,
       flexShrink: 1,
       fontSize: 12
     },
     locationItem: {
       alignItems: "center",
-      flex: 1,
       flexDirection: "row",
+      flexShrink: 1,
       gap: 4,
       minWidth: 0
     },
     locationRow: {
       flexDirection: "row",
       gap: theme.space.small,
+      justifyContent: "center",
       marginTop: 3,
       overflow: "hidden"
     },
     messageList: {
-      gap: theme.space.large,
+      gap: theme.space.medium,
       paddingBottom: theme.space.xlarge,
-      paddingHorizontal: theme.space.large,
+      paddingHorizontal: theme.space.medium,
       paddingTop: theme.space.medium
     },
     messageScroller: { flex: 1 },
@@ -409,6 +403,11 @@ function createStyles(theme: NativeTheme) {
       height: 64,
       width: "78%"
     },
-    sessionTitle: { color: theme.color.text, fontSize: 16, fontWeight: "700" }
+    sessionTitle: {
+      color: theme.color.text,
+      fontSize: 16,
+      fontWeight: "700",
+      textAlign: "center"
+    }
   });
 }

--- a/apps/mobile/src/screens/DeviceScreenView.tsx
+++ b/apps/mobile/src/screens/DeviceScreenView.tsx
@@ -252,7 +252,8 @@ function createStyles(theme: NativeTheme) {
       borderBottomWidth: StyleSheet.hairlineWidth,
       flexDirection: "row",
       justifyContent: "space-between",
-      padding: theme.space.large
+      paddingHorizontal: theme.space.large,
+      paddingVertical: theme.space.medium
     },
     manualInput: {
       borderColor: theme.color.border,
@@ -290,9 +291,9 @@ function createStyles(theme: NativeTheme) {
     statusText: { color: theme.color.textSecondary, flex: 1, fontSize: 14 },
     title: {
       color: theme.color.text,
-      fontSize: 28,
+      fontSize: 24,
       fontWeight: "700",
-      marginTop: 4
+      marginTop: 2
     }
   });
 }

--- a/apps/mobile/src/screens/LoginScreenView.tsx
+++ b/apps/mobile/src/screens/LoginScreenView.tsx
@@ -164,7 +164,7 @@ function createStyles(theme: NativeTheme) {
       borderWidth: 1,
       color: theme.color.text,
       fontSize: 16,
-      height: 54,
+      height: 50,
       marginBottom: 4,
       paddingHorizontal: theme.space.medium
     },
@@ -200,10 +200,10 @@ function createStyles(theme: NativeTheme) {
     },
     title: {
       color: theme.color.text,
-      fontSize: 34,
+      fontSize: 30,
       fontWeight: "700",
-      letterSpacing: -1,
-      lineHeight: 41,
+      letterSpacing: -0.5,
+      lineHeight: 37,
       marginTop: 8
     }
   });


### PR DESCRIPTION
## What changed

- reduce oversized controls, icons, and typography across the mobile composer, conversation list, and supporting screens
- tighten vertical spacing so narrow screens devote more room to conversation content
- center conversation title and location metadata for a clearer header hierarchy

## Why

The mobile surfaces used overly large controls and spacing for compact screens, which reduced usable content area and made the interface feel visually unbalanced.

## Impact

Mobile layouts are denser and more consistent without changing interaction or data behavior.

## Validation

- Not run (UI presentation-only change; repository policy exempts these changes from checks)
- `git diff --check`

## Documentation

- No documentation impact
