### PR TITLE
Fix/agent gui 0731

### DIFF
--- a/docs/architecture/claude-code-sdk-runtime.md
+++ b/docs/architecture/claude-code-sdk-runtime.md
@@ -132,6 +132,24 @@ collaborators. Collaborators must not import `main.ts` or own the stdio loop.
 Projection modules emit typed sidecar events; they do not call daemon or GUI
 code.
 
+The outbound root user UUID is correlation evidence, not provider identity.
+Normally the live SDK iterator returns the persisted root user message and the
+sidecar binds its UUID before projecting the provider Turn. A successful query
+may omit that echo and begin with assistant output or an interactive tool.
+Every root assistant, stream, tool, approval, user-input, and result path enters
+one shared single-flight identity barrier before projection. The barrier reads
+the official provider transcript, resolves exactly one root user message by the
+opaque correlation UUID, and emits `provider_turn_identity_resolved` with the
+latest persisted checkpoint. A bounded cancellable retry handles short
+transcript write delay; absence at the deadline and ambiguity fail explicitly.
+
+The Go adapter converts the resolved identity into a durable acceptance
+receipt. Its event reader blocks until the Host atomically persists the
+canonical Turn, provider Session, and provider Turn mapping. The canonical
+`root_provider_turn.started` is published exactly once before streaming or
+interactive activity is released. Provider start, checkpoint, and completion
+never derive identity from the outbound UUID alone.
+
 Raw sidecar stderr is never copied into activity, logs, or user-visible errors.
 The Go transport retains only a bounded failure classification; explicitly
 prefixed auth diagnostics are separately sanitized before structured logging.

--- a/docs/conventions/troubleshooting/agent-approvals-subagents.md
+++ b/docs/conventions/troubleshooting/agent-approvals-subagents.md
@@ -496,6 +496,27 @@ session-level child summaries.
   ordering still settles the child, while a late cancel-caused child terminal
   emits no second activity transition and produces no rejected-report log.
 
+### Claude reply completed but a detached command keeps the turn busy
+
+- Symptom: Claude has printed its final answer after starting a long-lived
+  `run_in_background` command, while the session rail and composer remain
+  loading. The launch tool may end as `turn_completed_without_call_result`.
+- Check: correlate the root `turn_completed` with SDK `task_started` and
+  `background_tasks_changed`. If the task has a `tool_use_id` but no subagent
+  identity (`agent_id` or explicit agent task type), inspect whether the Host
+  created a child session/turn for it or left the launch call running.
+- Cause: generic Claude task-system events were classified as delegated
+  subagents. A persistent server therefore became child work whose terminal
+  notification might never arrive, so it gated root activity indefinitely.
+- Fix: classify detached processes separately in the Claude sidecar. A
+  successful provider result completes a root `run_in_background` launch even
+  if `task_started` arrives later; retain the provider task id only for stop
+  routing. Do not emit child task lifecycle events or reserve a delegated
+  continuation for the process.
+- Validate: cover `task_started` both before and after the successful result,
+  leave the process running indefinitely, and assert the launch call and root
+  turn complete with no child session, call failure, or synthetic continuation.
+
 ### Deleted root leaves orphan child sessions
 
 - Symptom: a deleted conversation disappears from the rail, but its child

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -2322,30 +2322,48 @@ inline data URL instead`. Claude or standard ACP may instead receive no
   A Claude Code Turn is settled and has assistant output, but AgentGUI does not
   offer Fork. The session capability reports `forkThroughTurn=false`, or its
   supported provider Turn list is empty even though the Claude transcript is
-  readable.
+  readable. On a newly created Session, the same missing binding can make the
+  completed reply roll back to the new-conversation screen with
+  `provider turn was not durably accepted`.
 - Quick checks:
   Compare the canonical Turn's `root_provider_turn_id` with the UUID of the
   matching root user message returned by the official Claude SDK
   `getSessionMessages` API. If they differ, inspect the live sidecar event
-  sequence for `provider_turn_started`. Do not infer identity from transcript
-  position or substitute the canonical Tutti Turn ID.
+  sequence for `provider_turn_identity_resolved` and the canonical activity
+  sequence for `root_provider_turn.started`. Do not infer identity from
+  transcript position or substitute the canonical Tutti Turn ID.
 - Root cause:
   The outbound user-message UUID is only a prompt correlation value. Claude
   Code may rewrite that UUID before persisting the transcript. Publishing the
   caller-generated value as canonical provider identity makes strict prefix
   verification correctly reject the Turn, which removes the Fork capability.
+  The SDK can also omit the persisted root user echo from a successful live
+  query. Activating on assistant output while waiting exclusively for that echo
+  can deadlock when approval or user input occurs before result: the Provider
+  waits for the user, the sidecar waits for result-time recovery, and the Host
+  waits for durable acceptance.
 - Fix:
   Mark the next root prompt echo as causally expected before submitting it.
-  Bind provider Turn identity from that observed root user-message UUID, emit
-  `provider_turn_started`, and only then persist the root provider lifecycle.
+  Bind provider Turn identity from that observed root user-message UUID. Route
+  every root assistant, stream, tool, approval, user-input, and result path
+  through the shared single-flight identity barrier. Without an echo, resolve
+  exactly one root user UUID and checkpoint through the official
+  `getSessionMessages` transcript read with bounded cancellable retries.
+  Emit `provider_turn_identity_resolved`, synchronously persist the acceptance
+  binding in the Host, then publish canonical `root_provider_turn.started`
+  before any interaction or streaming event. Never substitute the outbound
+  correlation UUID.
   Keep historical Turns without observed provider identity fail-closed rather
   than guessing or backfilling them.
 - Validation:
   Cover a query whose root user echo rewrites the outbound UUID. Assert
-  `provider_turn_started` and terminal events both carry the persisted UUID,
-  then verify the daemon stores the same identity and the fork capability
-  accepts it. Restart the daemon/sidecar before manually checking a newly
-  completed Claude Code Turn; historical affected Turns remain intentionally
+  `provider_turn_identity_resolved`, checkpoint, and terminal events all carry
+  the persisted UUID. Cover successful assistant/result, approval,
+  `AskUserQuestion`, and `ExitPlanMode` sequences with no root user echo.
+  Assert canonical `root_provider_turn.started` is durable and ordered before
+  every interaction, then verify Fork accepts the same identity. Restart the
+  daemon/sidecar with an accepted incomplete Turn and confirm it is recovered
+  without re-dispatch. Historical affected Turns remain intentionally
   non-forkable.
 - References:
   [sessionRuntime.ts](../../../packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts)

--- a/docs/specs/2026-07-15-provider-native-subagents.md
+++ b/docs/specs/2026-07-15-provider-native-subagents.md
@@ -6,17 +6,15 @@ This spec covers provider-native child agents only:
 
 - Codex app-server multi-agent child threads.
 - Claude Code SDK `Task` / subagent sessions and turns.
-- Claude Code SDK task-system background work that is not a subagent launch,
-  such as `run_in_background` Bash shells. It follows the same child contract:
-  it gates the root turn, projects as a child, and is individually cancelable.
 - ACP providers that expose an equivalent nested/background agent concept.
 
 It does not cover Tutti launching another top-level AgentGUI session with
 `tutti-dev agent start`, handoff mentions, or another Codex/Claude Code process.
-A background command that merely tracks such a top-level session (for example
-`tutti agent wait` running in a background shell) is itself SDK task-system
-work and is covered: the tracked session stays out of scope, but the tracking
-task holds the root turn open for exactly as long as the wait runs.
+It also does not turn Claude Code SDK task-system processes into child agents.
+A detached `run_in_background` Bash shell, including one that merely tracks a
+top-level session such as `tutti agent wait`, remains a root-owned tool launch.
+Its provider task id is retained for explicit stop, but the process does not
+create a child session, gate the root turn, or reserve an agent continuation.
 
 ## Product Contract
 
@@ -544,21 +542,21 @@ Mapping:
 - A foreground `Task` may settle its child turn from the terminal parent tool
   result. An async/background `Task` does not settle from the launch tool
   result; it waits for the matching task lifecycle terminal.
-- SDK task-system work that has no subagent launch result — most importantly a
-  `run_in_background` Bash shell — announces itself only through `task_started`
-  carrying a `tool_use_id` and `task_id`. The sidecar registers such an
-  unclaimed task as delegated child work keyed by that launching tool-use id,
-  so it gates the root turn, counts in the final-child continuation gate, and
-  can be stopped individually. A task event without a launching tool-use id is
-  not registered this way: it may be a racing alias for a not-yet-registered
-  subagent launch, and binding it would poison the alias maps.
-- Background task lifecycle events frequently arrive after the launching root
-  provider turn already reached its terminal. The sidecar attributes them to
-  the most recent turn instead of dropping them for lack of an active turn id.
+- SDK task-system work that has no subagent identity — most importantly a
+  `run_in_background` Bash shell — is tracked separately from delegated child
+  work. The successful root result completes the launch tool call even when
+  `task_started` is delayed; an earlier `task_started` may complete it with the
+  provider task id. The detached process remains independently stoppable, but
+  its lifetime does not create a child session, gate the root turn, count in
+  the final-child continuation gate, or synthesize follow-up model work.
+- Task-system process events frequently arrive after the launching root
+  provider turn reached its terminal. The sidecar may retain their
+  `tool_use_id` / `task_id` correlation for stop routing, but must not project
+  them as late child activity.
 - A terminal `task_notification` for a task the current sidecar instance never
-  saw start — typically a task launched before a sidecar restart and reported
-  as `stopped` on the next prompt — is registered and settled in one step so
-  the child reaches a terminal state instead of the notice being dropped.
+  saw start may recreate delegated state only when the message carries explicit
+  subagent identity. An unclaimed generic task-system notice is not enough to
+  invent a child session.
 - `parent_tool_use_id` is the canonical child scope marker for nested messages.
 - `taskId` and `agentId` are aliases. They must bind back to the existing child
   session/turn, never to "the only running task" when that would cross-bind

--- a/packages/agent/claude-sdk-sidecar/README.md
+++ b/packages/agent/claude-sdk-sidecar/README.md
@@ -72,8 +72,20 @@ For live Turns, the UUID supplied on the outbound SDK user message is a
 `promptCorrelationId` only because Claude Code may rewrite it in the durable
 transcript. `SessionRuntime` causally binds the next expected root prompt echo
 to its canonical Turn, takes provider identity from the observed root
-user-message UUID, and emits `provider_turn_started`; the daemon persists only
-that observed identity.
+user-message UUID, and emits `provider_turn_identity_resolved`. Some successful
+SDK queries omit that echo from the live iterator. A shared, idempotent
+single-flight identity barrier runs before every root assistant, stream, tool,
+approval, user-input, and result projection. It uses the official
+`getSessionMessages()` transcript read to resolve exactly one root user message
+by the opaque correlation UUID, with a bounded cancellable retry window for
+transcript persistence lag.
+
+The daemon synchronously persists the canonical Turn, provider Session, and
+provider Turn binding when it receives `provider_turn_identity_resolved`. Only
+after that durable barrier succeeds does it publish canonical
+`root_provider_turn.started` and allow later output or interaction events to
+proceed. Checkpoint and terminal events use the same bound provider Turn ID and
+never fall back to the outbound correlation UUID.
 
 Interactive responses use `(turnId, requestId)` identity. The sidecar keeps a
 bounded terminal disposition registry so `submit_interactive` is idempotent:

--- a/packages/agent/claude-sdk-sidecar/package.json
+++ b/packages/agent/claude-sdk-sidecar/package.json
@@ -19,6 +19,7 @@
     "src/messageRouter.ts",
     "src/normalizer.ts",
     "src/options.ts",
+    "src/providerTurnAcceptance.ts",
     "src/promptQueue.ts",
     "src/protocol.ts",
     "src/queryGeneration.ts",

--- a/packages/agent/claude-sdk-sidecar/src/backgroundTaskLifecycle.ts
+++ b/packages/agent/claude-sdk-sidecar/src/backgroundTaskLifecycle.ts
@@ -90,7 +90,9 @@ export class BackgroundTaskLifecycle {
     if (!previouslyObserved || previousCount === 0) {
       return;
     }
-    this.levelContinuationPending = this.rootResultSucceeded !== false;
+    const delegated = this.delegatedTaskCounts(turnId);
+    this.levelContinuationPending =
+      this.rootResultSucceeded !== false && delegated.running > 0;
     this.scheduleQuiescence(turnId);
     this.reserveContinuation();
   }

--- a/packages/agent/claude-sdk-sidecar/src/interactive.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/interactive.test.ts
@@ -14,6 +14,7 @@ test("interactive coordinator resolves approval on its originating turn", async 
       toolUseID: "tool-1"
     }
   );
+  await waitForInteraction(events);
   const request = events[0];
   const requestId = String(request?.payload?.requestId);
 
@@ -48,6 +49,7 @@ test("interactive coordinator replays identical submissions and rejects conflict
     { command: "pwd" },
     { signal: new AbortController().signal }
   );
+  await waitForInteraction(events);
   const requestId = String(events[0]?.payload?.requestId);
   const payload = { reason: "approved" };
 
@@ -87,6 +89,7 @@ test("interactive coordinator rejects all live requests on shutdown", async () =
     { command: "pwd" },
     { signal: new AbortController().signal }
   );
+  await waitForInteraction(events);
 
   coordinator.rejectAll(new Error("session closed"));
 
@@ -98,8 +101,39 @@ test("interactive coordinator rejects all live requests on shutdown", async () =
   });
 });
 
+test("interactive coordinator does not publish a canceled request before acceptance", async () => {
+  const events: Array<Omit<ClaudeSDKSidecarEvent, "version">> = [];
+  const controller = new AbortController();
+  const coordinator = createCoordinator(events, async (_phase, signal) => {
+    await new Promise<void>((_resolve, reject) => {
+      signal?.addEventListener(
+        "abort",
+        () => {
+          const error = new Error("acceptance canceled");
+          error.name = "AbortError";
+          reject(error);
+        },
+        { once: true }
+      );
+    });
+  });
+  const resultPromise = coordinator.handleToolPermission(
+    "Bash",
+    { command: "pwd" },
+    { signal: controller.signal }
+  );
+
+  controller.abort();
+
+  await assert.rejects(resultPromise, { name: "AbortError" });
+  assert.deepEqual(events, []);
+});
+
 function createCoordinator(
-  events: Array<Omit<ClaudeSDKSidecarEvent, "version">>
+  events: Array<Omit<ClaudeSDKSidecarEvent, "version">>,
+  ensureProviderTurnAcceptance: ConstructorParameters<
+    typeof InteractiveCoordinator
+  >[0]["ensureProviderTurnAcceptance"] = async () => {}
 ): InteractiveCoordinator {
   return new InteractiveCoordinator({
     settings: {
@@ -111,6 +145,16 @@ function createCoordinator(
     },
     resolveTurnId: () => "turn-1",
     activateSyntheticTurn: () => "synthetic-1",
+    ensureProviderTurnAcceptance,
     emit: (event) => events.push(event)
   });
+}
+
+async function waitForInteraction(
+  events: Array<Omit<ClaudeSDKSidecarEvent, "version">>
+): Promise<void> {
+  for (let attempt = 0; attempt < 10 && events.length === 0; attempt += 1) {
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+  assert.notEqual(events.length, 0);
 }

--- a/packages/agent/claude-sdk-sidecar/src/interactive.ts
+++ b/packages/agent/claude-sdk-sidecar/src/interactive.ts
@@ -7,6 +7,7 @@ import type {
 import { isDeepStrictEqual } from "node:util";
 import { answersFromInteractivePayload } from "./normalizer.ts";
 import type { ClaudeSDKSidecarEventEmitter } from "./protocol.ts";
+import type { ProviderTurnPhase } from "./providerTurnAcceptance.ts";
 import { stringValue } from "./runtimeValues.ts";
 import {
   approvalOptions,
@@ -65,17 +66,26 @@ export class InteractiveCoordinator {
   private readonly settings: SidecarSessionSettings;
   private readonly resolveTurnId: (options: ToolPermissionOptions) => string;
   private readonly activateSyntheticTurn: () => string;
+  private readonly ensureProviderTurnAcceptance: (
+    phase: Extract<ProviderTurnPhase, "waiting_approval" | "waiting_input">,
+    signal?: AbortSignal
+  ) => Promise<void>;
   private readonly emit: ClaudeSDKSidecarEventEmitter;
 
   constructor(options: {
     settings: SidecarSessionSettings;
     resolveTurnId: (permission: ToolPermissionOptions) => string;
     activateSyntheticTurn: () => string;
+    ensureProviderTurnAcceptance: (
+      phase: Extract<ProviderTurnPhase, "waiting_approval" | "waiting_input">,
+      signal?: AbortSignal
+    ) => Promise<void>;
     emit: ClaudeSDKSidecarEventEmitter;
   }) {
     this.settings = options.settings;
     this.resolveTurnId = options.resolveTurnId;
     this.activateSyntheticTurn = options.activateSyntheticTurn;
+    this.ensureProviderTurnAcceptance = options.ensureProviderTurnAcceptance;
     this.emit = options.emit;
   }
 
@@ -236,13 +246,17 @@ export class InteractiveCoordinator {
     };
   }
 
-  private request(
+  private async request(
     eventType: "approval_requested" | "user_input_requested",
     toolName: string,
     toolInput: Record<string, unknown>,
     options: Array<Record<string, unknown>>,
     callbackOptions: ToolPermissionOptions
   ): Promise<InteractiveSubmission> {
+    await this.ensureProviderTurnAcceptance(
+      eventType === "approval_requested" ? "waiting_approval" : "waiting_input",
+      callbackOptions.signal
+    );
     const requestId = crypto.randomUUID();
     const toolUseID = callbackOptions.toolUseID || requestId;
     const agentId = stringValue(callbackOptions.agentID);

--- a/packages/agent/claude-sdk-sidecar/src/messageRouter.ts
+++ b/packages/agent/claude-sdk-sidecar/src/messageRouter.ts
@@ -527,6 +527,13 @@ export class SDKMessageRouter {
       void this.emitResultUsage(turnId, contextUsageGeneration, result);
       return;
     }
+    if (succeeded) {
+      // A successful provider result is authoritative that a root
+      // run_in_background invocation launched. Close the launch tool before
+      // the root terminal even when the SDK's task_started notification is
+      // delayed; the detached process itself remains independently stoppable.
+      this.activities.completePendingRootBackgroundLaunches();
+    }
     const pendingBackgroundContinuation =
       succeeded && this.activities.hasPendingBackgroundContinuation();
     const completedSyntheticContinuation =

--- a/packages/agent/claude-sdk-sidecar/src/messageRouter.ts
+++ b/packages/agent/claude-sdk-sidecar/src/messageRouter.ts
@@ -23,6 +23,12 @@ import type { CompactionTracker } from "./compaction.ts";
 import type { MessageProjection } from "./messageProjection.ts";
 import type { ToolActivityProjector } from "./toolActivity.ts";
 import type { TurnLifecycle } from "./turnLifecycle.ts";
+import type { ProviderTurnPhase } from "./providerTurnAcceptance.ts";
+
+type ObservableProviderTurnPhase = Extract<
+  ProviderTurnPhase,
+  "streaming" | "running_tool"
+>;
 
 export class SDKMessageRouter {
   private readonly getProviderSessionId: () => string;
@@ -38,6 +44,14 @@ export class SDKMessageRouter {
   private readonly projection: MessageProjection;
   private readonly compaction: CompactionTracker;
   private readonly emit: ClaudeSDKSidecarEventEmitter;
+  private readonly emitProviderCheckpointEvent: (
+    turnId: string,
+    providerTurnId: string,
+    providerCheckpointMessageId: string
+  ) => void;
+  private readonly ensureProviderTurnAcceptance: (
+    phase: ObservableProviderTurnPhase
+  ) => Promise<void>;
   private contextUsageGeneration = 0;
   private activeRootAssistantError = "";
   private activeRootConnectionRetry = false;
@@ -56,6 +70,14 @@ export class SDKMessageRouter {
     projection: MessageProjection;
     compaction: CompactionTracker;
     emit: ClaudeSDKSidecarEventEmitter;
+    emitProviderCheckpoint: (
+      turnId: string,
+      providerTurnId: string,
+      providerCheckpointMessageId: string
+    ) => void;
+    ensureProviderTurnAcceptance: (
+      phase: ObservableProviderTurnPhase
+    ) => Promise<void>;
   }) {
     this.getProviderSessionId = options.getProviderSessionId;
     this.setProviderSessionId = options.setProviderSessionId;
@@ -70,6 +92,8 @@ export class SDKMessageRouter {
     this.projection = options.projection;
     this.compaction = options.compaction;
     this.emit = options.emit;
+    this.emitProviderCheckpointEvent = options.emitProviderCheckpoint;
+    this.ensureProviderTurnAcceptance = options.ensureProviderTurnAcceptance;
   }
 
   async handle(message: SDKMessage): Promise<void> {
@@ -132,11 +156,17 @@ export class SDKMessageRouter {
     }
 
     if (message.type === "stream_event") {
+      if (!parentToolUseID) {
+        await this.ensureProviderTurnAcceptance("streaming");
+      }
       this.handleStreamEvent(message, parentToolUseID);
       return;
     }
 
     if (message.type === "assistant") {
+      if (!parentToolUseID) {
+        await this.ensureProviderTurnAcceptance("streaming");
+      }
       this.handleAssistant(message, parentToolUseID);
       this.emitProviderCheckpoint(message, parentToolUseID);
       return;
@@ -152,6 +182,9 @@ export class SDKMessageRouter {
     }
 
     if (message.type === "tool_progress") {
+      if (!parentToolUseID) {
+        await this.ensureProviderTurnAcceptance("running_tool");
+      }
       if (!this.turns.ensureActive("tool_progress")) {
         return;
       }
@@ -393,14 +426,11 @@ export class SDKMessageRouter {
     if (!checkpointMessageId || !turnId || !providerTurnId) {
       return;
     }
-    this.emit({
-      type: "provider_turn_checkpoint",
-      payload: {
-        turnId,
-        providerTurnId,
-        providerCheckpointMessageId: checkpointMessageId
-      }
-    });
+    this.emitProviderCheckpointEvent(
+      turnId,
+      providerTurnId,
+      checkpointMessageId
+    );
   }
 
   private handleUser(message: SDKMessage, parentToolUseID: string): void {
@@ -472,6 +502,7 @@ export class SDKMessageRouter {
     ) {
       return;
     }
+    await this.ensureProviderTurnAcceptance("streaming");
     const turnId = this.turns.activeId;
     const contextUsageGeneration = this.contextUsageGeneration;
     const assistantError = this.activeRootAssistantError;

--- a/packages/agent/claude-sdk-sidecar/src/providerTurnAcceptance.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/providerTurnAcceptance.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  ProviderTurnAcceptanceCoordinator,
+  type ProviderTurnIdentityBindingDisposition
+} from "./providerTurnAcceptance.ts";
+import { ClaudeTurnBindingResolutionError } from "./sessionFork.ts";
+
+test("provider acceptance retries transient transcript lag and binds once", async () => {
+  let now = 0;
+  let attempts = 0;
+  const bindings: string[] = [];
+  const checkpoints: string[] = [];
+  const coordinator = new ProviderTurnAcceptanceCoordinator({
+    cwd: "/repo",
+    getProviderSessionId: () => "provider-session",
+    resolveTarget: () => ({
+      turnId: "turn-1",
+      promptCorrelationId: "correlation-1",
+      providerTurnId: bindings[0] ?? ""
+    }),
+    resolveBinding: async () => {
+      attempts += 1;
+      if (attempts < 3) {
+        throw new ClaudeTurnBindingResolutionError("absent");
+      }
+      return {
+        providerSessionId: "provider-session",
+        providerTurnId: "provider-turn-1",
+        providerCheckpointMessageId: "checkpoint-1"
+      };
+    },
+    bindIdentity: (_turnId, providerTurnId) => {
+      bindings.push(providerTurnId);
+      return "bound";
+    },
+    emitCheckpoint: (_turnId, binding) =>
+      checkpoints.push(binding.providerCheckpointMessageId),
+    now: () => now,
+    wait: async (delayMs) => {
+      now += delayMs;
+    }
+  });
+
+  await Promise.all([
+    coordinator.ensure("streaming"),
+    coordinator.ensure("waiting_approval"),
+    coordinator.ensure("waiting_input")
+  ]);
+
+  assert.equal(attempts, 3);
+  assert.deepEqual(bindings, ["provider-turn-1"]);
+  assert.deepEqual(checkpoints, ["checkpoint-1"]);
+  assert.equal(coordinator.phase("turn-1"), "waiting_input");
+});
+
+test("provider acceptance fails closed on ambiguous identity", async () => {
+  const coordinator = createCoordinator({
+    resolveBinding: async () => {
+      throw new ClaudeTurnBindingResolutionError("ambiguous");
+    }
+  });
+
+  await assert.rejects(
+    coordinator.ensure("waiting_approval"),
+    /proof is ambiguous/u
+  );
+});
+
+test("provider acceptance cancellation aborts the shared identity flight", async () => {
+  const coordinator = createCoordinator({
+    resolveBinding: () => new Promise(() => {})
+  });
+  const pending = coordinator.ensure("waiting_input");
+
+  coordinator.cancel("turn-1");
+
+  await assert.rejects(pending, { name: "AbortError" });
+});
+
+function createCoordinator(options: {
+  resolveBinding: ConstructorParameters<
+    typeof ProviderTurnAcceptanceCoordinator
+  >[0]["resolveBinding"];
+}): ProviderTurnAcceptanceCoordinator {
+  return new ProviderTurnAcceptanceCoordinator({
+    cwd: "/repo",
+    getProviderSessionId: () => "provider-session",
+    resolveTarget: () => ({
+      turnId: "turn-1",
+      promptCorrelationId: "correlation-1",
+      providerTurnId: ""
+    }),
+    resolveBinding: options.resolveBinding,
+    bindIdentity: () =>
+      "bound" satisfies ProviderTurnIdentityBindingDisposition,
+    emitCheckpoint: () => {}
+  });
+}

--- a/packages/agent/claude-sdk-sidecar/src/providerTurnAcceptance.ts
+++ b/packages/agent/claude-sdk-sidecar/src/providerTurnAcceptance.ts
@@ -1,0 +1,306 @@
+import {
+  ClaudeTurnBindingResolutionError,
+  type ClaudeTurnBinding,
+  type ClaudeTurnBindingResolver
+} from "./sessionFork.ts";
+
+export type ProviderTurnPhase =
+  | "queued"
+  | "dispatched"
+  | "provider_observed"
+  | "resolving_identity"
+  | "identity_resolved"
+  | "streaming"
+  | "waiting_approval"
+  | "waiting_input"
+  | "running_tool"
+  | "terminal";
+
+export type ProviderTurnIdentityBindingDisposition =
+  | "bound"
+  | "already_bound"
+  | "conflict"
+  | "missing";
+
+export type ProviderTurnAcceptanceTarget = {
+  turnId: string;
+  promptCorrelationId: string;
+  providerTurnId: string;
+};
+
+type ActiveAcceptance = {
+  readonly turnId: string;
+  readonly controller: AbortController;
+  readonly promise: Promise<void>;
+};
+
+const DEFAULT_RESOLUTION_TIMEOUT_MS = 5_000;
+const DEFAULT_RETRY_DELAY_MS = 25;
+const MAX_RETRY_DELAY_MS = 250;
+
+export class ProviderTurnAcceptanceCoordinator {
+  private readonly cwd: string;
+  private readonly getProviderSessionId: () => string;
+  private readonly resolveTarget: () =>
+    | ProviderTurnAcceptanceTarget
+    | undefined;
+  private readonly resolveBinding: ClaudeTurnBindingResolver;
+  private readonly bindIdentity: (
+    turnId: string,
+    providerTurnId: string
+  ) => ProviderTurnIdentityBindingDisposition;
+  private readonly emitCheckpoint: (
+    turnId: string,
+    binding: ClaudeTurnBinding
+  ) => void;
+  private readonly resolutionTimeoutMs: number;
+  private readonly retryDelayMs: number;
+  private readonly now: () => number;
+  private readonly wait: (
+    delayMs: number,
+    signal: AbortSignal
+  ) => Promise<void>;
+  private readonly phases = new Map<string, ProviderTurnPhase>();
+  private active: ActiveAcceptance | undefined;
+
+  constructor(options: {
+    cwd: string;
+    getProviderSessionId: () => string;
+    resolveTarget: () => ProviderTurnAcceptanceTarget | undefined;
+    resolveBinding: ClaudeTurnBindingResolver;
+    bindIdentity: (
+      turnId: string,
+      providerTurnId: string
+    ) => ProviderTurnIdentityBindingDisposition;
+    emitCheckpoint: (turnId: string, binding: ClaudeTurnBinding) => void;
+    resolutionTimeoutMs?: number;
+    retryDelayMs?: number;
+    now?: () => number;
+    wait?: (delayMs: number, signal: AbortSignal) => Promise<void>;
+  }) {
+    this.cwd = options.cwd;
+    this.getProviderSessionId = options.getProviderSessionId;
+    this.resolveTarget = options.resolveTarget;
+    this.resolveBinding = options.resolveBinding;
+    this.bindIdentity = options.bindIdentity;
+    this.emitCheckpoint = options.emitCheckpoint;
+    this.resolutionTimeoutMs =
+      options.resolutionTimeoutMs ?? DEFAULT_RESOLUTION_TIMEOUT_MS;
+    this.retryDelayMs = options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
+    this.now = options.now ?? Date.now;
+    this.wait = options.wait ?? abortableDelay;
+  }
+
+  markQueued(turnId: string): void {
+    this.setPhase(turnId, "queued");
+  }
+
+  markDispatched(turnId: string): void {
+    this.setPhase(turnId, "dispatched");
+  }
+
+  phase(turnId: string): ProviderTurnPhase | undefined {
+    return this.phases.get(turnId.trim());
+  }
+
+  async ensure(
+    nextPhase: Extract<
+      ProviderTurnPhase,
+      "streaming" | "waiting_approval" | "waiting_input" | "running_tool"
+    >,
+    signal?: AbortSignal
+  ): Promise<void> {
+    const target = this.resolveTarget();
+    if (!target || !target.turnId.trim()) {
+      return;
+    }
+    if (target.providerTurnId.trim()) {
+      this.setPhase(target.turnId, nextPhase);
+      return;
+    }
+    this.setPhase(target.turnId, "provider_observed");
+    const active = this.active;
+    if (active?.turnId === target.turnId) {
+      await raceWithAbort(active.promise, signal);
+      this.setPhase(target.turnId, nextPhase);
+      return;
+    }
+    if (active) {
+      active.controller.abort();
+    }
+    const controller = new AbortController();
+    const promise = this.resolveAndBind(target, controller.signal).finally(
+      () => {
+        if (this.active?.promise === promise) {
+          this.active = undefined;
+        }
+      }
+    );
+    this.active = { turnId: target.turnId, controller, promise };
+    await raceWithAbort(promise, signal);
+    this.setPhase(target.turnId, nextPhase);
+  }
+
+  cancel(turnId = ""): void {
+    const normalizedTurnId = turnId.trim();
+    if (
+      this.active &&
+      (!normalizedTurnId || this.active.turnId === normalizedTurnId)
+    ) {
+      this.active.controller.abort();
+    }
+  }
+
+  terminal(turnId: string): void {
+    const normalizedTurnId = turnId.trim();
+    this.cancel(normalizedTurnId);
+    this.setPhase(normalizedTurnId, "terminal");
+    while (this.phases.size > 64) {
+      const oldest = this.phases.keys().next().value;
+      if (typeof oldest !== "string") {
+        break;
+      }
+      this.phases.delete(oldest);
+    }
+  }
+
+  private async resolveAndBind(
+    target: ProviderTurnAcceptanceTarget,
+    signal: AbortSignal
+  ): Promise<void> {
+    const providerSessionId = this.getProviderSessionId().trim();
+    const recoveryToken = target.promptCorrelationId.trim();
+    if (!providerSessionId || !recoveryToken) {
+      throw new Error(
+        "Claude provider turn identity resolution requires session and correlation identities"
+      );
+    }
+    const deadline = this.now() + Math.max(0, this.resolutionTimeoutMs);
+    let retryDelayMs = Math.max(1, this.retryDelayMs);
+    this.setPhase(target.turnId, "resolving_identity");
+    for (;;) {
+      throwIfAborted(signal);
+      try {
+        const binding = await raceWithAbort(
+          this.resolveBinding({
+            sessionId: providerSessionId,
+            cwd: this.cwd,
+            recoveryToken
+          }),
+          signal
+        );
+        this.acceptBinding(target.turnId, providerSessionId, binding);
+        this.setPhase(target.turnId, "identity_resolved");
+        return;
+      } catch (error) {
+        if (signal.aborted) {
+          throw abortError();
+        }
+        if (
+          !(error instanceof ClaudeTurnBindingResolutionError) ||
+          error.reason !== "absent"
+        ) {
+          throw error;
+        }
+        const remainingMs = deadline - this.now();
+        if (remainingMs <= 0) {
+          throw new Error(
+            "Claude provider turn identity was not persisted before the acceptance deadline",
+            { cause: error }
+          );
+        }
+        await this.wait(Math.min(retryDelayMs, remainingMs), signal);
+        retryDelayMs = Math.min(retryDelayMs * 2, MAX_RETRY_DELAY_MS);
+      }
+    }
+  }
+
+  private acceptBinding(
+    turnId: string,
+    expectedProviderSessionId: string,
+    binding: ClaudeTurnBinding
+  ): void {
+    const providerSessionId = binding.providerSessionId.trim();
+    const providerTurnId = binding.providerTurnId.trim();
+    if (providerSessionId !== expectedProviderSessionId || !providerTurnId) {
+      throw new Error(
+        "Claude provider turn recovery returned inconsistent identity"
+      );
+    }
+    const disposition = this.bindIdentity(turnId, providerTurnId);
+    if (disposition === "conflict" || disposition === "missing") {
+      throw new Error(
+        "Claude provider turn recovery returned inconsistent identity"
+      );
+    }
+    if (disposition === "bound") {
+      this.emitCheckpoint(turnId, binding);
+    }
+  }
+
+  private setPhase(turnId: string, phase: ProviderTurnPhase): void {
+    const normalizedTurnId = turnId.trim();
+    if (!normalizedTurnId) {
+      return;
+    }
+    this.phases.set(normalizedTurnId, phase);
+  }
+}
+
+function abortableDelay(delayMs: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) {
+    return Promise.reject(abortError());
+  }
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(
+      () => {
+        signal.removeEventListener("abort", abort);
+        resolve();
+      },
+      Math.max(0, delayMs)
+    );
+    const abort = () => {
+      clearTimeout(timeout);
+      reject(abortError());
+    };
+    signal.addEventListener("abort", abort, { once: true });
+  });
+}
+
+function raceWithAbort<T>(
+  promise: Promise<T>,
+  signal?: AbortSignal
+): Promise<T> {
+  if (!signal) {
+    return promise;
+  }
+  if (signal.aborted) {
+    return Promise.reject(abortError());
+  }
+  return new Promise<T>((resolve, reject) => {
+    const abort = () => reject(abortError());
+    signal.addEventListener("abort", abort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", abort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", abort);
+        reject(error);
+      }
+    );
+  });
+}
+
+function throwIfAborted(signal: AbortSignal): void {
+  if (signal.aborted) {
+    throw abortError();
+  }
+}
+
+function abortError(): Error {
+  const error = new Error("Provider turn acceptance was canceled");
+  error.name = "AbortError";
+  return error;
+}

--- a/packages/agent/claude-sdk-sidecar/src/sessionFork.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionFork.test.ts
@@ -10,7 +10,8 @@ import {
 import {
   forkClaudeSession,
   inspectClaudeForkCheckpoints,
-  recoverClaudeTurnBinding
+  recoverClaudeTurnBinding,
+  resolveClaudeTurnBindingByRecoveryToken
 } from "./sessionFork.ts";
 
 const childSessionId = "11111111-1111-4111-8111-111111111111";
@@ -95,6 +96,17 @@ test("Claude turn recovery resolves one exact opaque UUID and checkpoint", async
     providerTurnId: token,
     providerCheckpointMessageId: "answer-2"
   });
+  assert.deepEqual(
+    await resolveClaudeTurnBindingByRecoveryToken(
+      {
+        sessionId: "source",
+        cwd: "/workspace",
+        recoveryToken: token
+      },
+      sdk
+    ),
+    result
+  );
 });
 
 test("Claude legacy text recovery fails closed for multimodal content", async () => {
@@ -125,7 +137,7 @@ test("Claude legacy text recovery fails closed for multimodal content", async ()
       },
       sdk
     ),
-    /absent or ambiguous/
+    /proof is absent/
   );
 });
 

--- a/packages/agent/claude-sdk-sidecar/src/sessionFork.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionFork.ts
@@ -33,6 +33,28 @@ type TurnBindingRecoveryInput = ForkInspectInput & {
   legacyTextHMACDigest: string;
 };
 
+export type ClaudeTurnBinding = {
+  providerSessionId: string;
+  providerTurnId: string;
+  providerCheckpointMessageId: string;
+};
+
+export type ClaudeTurnBindingResolver = (input: {
+  sessionId: string;
+  cwd: string;
+  recoveryToken: string;
+}) => Promise<ClaudeTurnBinding>;
+
+export class ClaudeTurnBindingResolutionError extends Error {
+  readonly reason: "absent" | "ambiguous";
+
+  constructor(reason: "absent" | "ambiguous") {
+    super(`Claude provider turn recovery proof is ${reason}`);
+    this.name = "ClaudeTurnBindingResolutionError";
+    this.reason = reason;
+  }
+}
+
 type ClaudeForkSDK = {
   forkSession: typeof forkSession;
   getSessionMessages: typeof getSessionMessages;
@@ -65,16 +87,39 @@ export async function recoverClaudeTurnBinding(
   input: TurnBindingRecoveryInput,
   sdk: ClaudeForkSDK = defaultClaudeForkSDK
 ): Promise<Record<string, unknown>> {
+  return resolveClaudeTurnBinding(input, sdk);
+}
+
+export async function resolveClaudeTurnBindingByRecoveryToken(
+  input: ForkInspectInput & { recoveryToken: string },
+  sdk: ClaudeForkSDK = defaultClaudeForkSDK
+): Promise<ClaudeTurnBinding> {
+  requireIdentity(input.recoveryToken, "provider turn recovery token");
+  return resolveClaudeTurnBinding(
+    {
+      ...input,
+      legacyTextHMACKey: "",
+      legacyTextHMACDigest: ""
+    },
+    sdk
+  );
+}
+
+async function resolveClaudeTurnBinding(
+  input: TurnBindingRecoveryInput,
+  sdk: ClaudeForkSDK
+): Promise<ClaudeTurnBinding> {
   requireIdentity(input.sessionId, "provider session id");
   const messages = (await sdk.getSessionMessages(
     input.sessionId,
     transcriptOptions(input.cwd)
   )) as SDKMessage[];
   const matches = rootTurnBindingMatches(messages, input);
-  if (matches.length !== 1) {
-    throw new Error(
-      "Claude provider turn recovery proof is absent or ambiguous"
-    );
+  if (matches.length === 0) {
+    throw new ClaudeTurnBindingResolutionError("absent");
+  }
+  if (matches.length > 1) {
+    throw new ClaudeTurnBindingResolutionError("ambiguous");
   }
   return {
     providerSessionId: input.sessionId,

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.delegated.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.delegated.test.ts
@@ -11,6 +11,7 @@ import {
   fakeDelegatedAssistantParentQuery,
   fakeDelegatedTaskQuery,
   fakeFailedBackgroundTaskSignalQuery,
+  fakeLongRunningBackgroundBashQuery,
   fakeGuidedDelegatedContinuationQuery,
   fakeParallelDelegatedTaskContinuationQuery,
   fakeRacedDelegatedTaskAliasQuery,
@@ -931,7 +932,7 @@ async function waitForMatchingEvent(
   );
 }
 
-test("background bash registers as a delegated task and defers the synthetic continuation", async () => {
+test("background bash completes its launch without gating the root turn or becoming a child task", async () => {
   const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
   const restoreSink = withSidecarEventSinkForTest((event) =>
     events.push(event)
@@ -960,38 +961,121 @@ test("background bash registers as a delegated task and defers the synthetic con
     session.exec("turn-1", "delegate and background");
     await waitForEvent(events, "turn_started");
 
-    // The background shell's task_started arrives after the provider turn
-    // settled, yet it must register and attribute to the launching turn.
     const bashStarted = events.find(
       (event) =>
         event.type === "task_started" && event.payload?.taskId === "bs-1"
     );
-    assert.equal(bashStarted?.payload?.turnId, "turn-1");
-    assert.equal(bashStarted?.payload?.parentToolUseId, "toolu-bash");
+    assert.equal(bashStarted, undefined);
+    const bashCompleted = events.find(
+      (event) =>
+        event.type === "tool_completed" &&
+        event.payload?.toolCallId === "toolu-bash"
+    );
+    assert.equal(bashCompleted?.payload?.turnId, "turn-1");
+    assert.deepEqual(
+      (bashCompleted?.payload?.metadata as Record<string, unknown> | undefined)
+        ?.backgroundProcess,
+      {
+        taskId: "bs-1",
+        status: "running"
+      }
+    );
 
     const agentCompletedIndex = events.findIndex(
       (event) =>
         event.type === "task_completed" && event.payload?.taskId === "task-1"
     );
-    const bashCompletedIndex = events.findIndex(
+    const rootCompletedIndex = events.findIndex(
       (event) =>
-        event.type === "task_completed" && event.payload?.taskId === "bs-1"
+        event.type === "turn_completed" && event.payload?.turnId === "turn-1"
     );
     const syntheticStartedIndex = events.findIndex(
       (event) =>
         event.type === "turn_started" && event.payload?.synthetic === true
     );
     assert.ok(agentCompletedIndex >= 0);
-    assert.ok(bashCompletedIndex > agentCompletedIndex);
-    // The subagent finishing first must not reserve the continuation while
-    // the background shell still runs; only the final bash completion may
-    // (the synthetic turn is reserved just before its task_completed).
-    assert.ok(syntheticStartedIndex > agentCompletedIndex);
-    assert.ok(bashCompletedIndex > syntheticStartedIndex);
-    assert.equal(events[bashCompletedIndex]?.payload?.turnId, "turn-1");
+    assert.ok(rootCompletedIndex >= 0);
+    // The delegated Agent still owns its provider continuation. The detached
+    // process remains alive but contributes no child task or continuation.
+    assert.ok(syntheticStartedIndex >= 0);
+    assert.ok(syntheticStartedIndex < agentCompletedIndex);
+    assert.equal(
+      events.some(
+        (event) =>
+          (event.type === "task_completed" ||
+            event.type === "task_result_updated") &&
+          event.payload?.taskId === "bs-1"
+      ),
+      false
+    );
     // Disarm the short continuation timer so it cannot leak into later tests.
     await session.close();
   } finally {
+    restoreSink();
+  }
+});
+
+test("long-running background bash does not keep a completed root turn busy", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  const session = new SessionRuntime(
+    "provider-session-1",
+    "/repo",
+    {},
+    false,
+    false,
+    {
+      model: "",
+      permissionModeId: "default",
+      planMode: false,
+      effort: "",
+      speed: ""
+    },
+    sidecarClaudeOptionsFromPayload({}),
+    undefined,
+    ({ prompt }) => fakeLongRunningBackgroundBashQuery(prompt),
+    50
+  );
+  try {
+    await session.start();
+    session.exec("turn-1", "start a persistent web server");
+    await waitForMatchingEvent(
+      events,
+      (event) =>
+        event.type === "turn_completed" && event.payload?.turnId === "turn-1",
+      "completed root turn"
+    );
+
+    const bashCompleted = events.find(
+      (event) =>
+        event.type === "tool_completed" &&
+        event.payload?.toolCallId === "toolu-bash"
+    );
+    assert.deepEqual(
+      (bashCompleted?.payload?.metadata as Record<string, unknown> | undefined)
+        ?.backgroundProcess,
+      {
+        status: "running"
+      }
+    );
+    assert.equal(
+      events.some(
+        (event) =>
+          event.type === "task_started" && event.payload?.taskId === "bs-1"
+      ),
+      false
+    );
+    assert.equal(
+      events.some(
+        (event) =>
+          event.type === "turn_started" && event.payload?.synthetic === true
+      ),
+      false
+    );
+  } finally {
+    await session.close();
     restoreSink();
   }
 });

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.session.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.session.test.ts
@@ -70,7 +70,7 @@ test("Claude-persisted user UUID becomes the provider Turn identity", async () =
     await waitForEvent(events, "turn_completed");
 
     const providerStarted = events.find(
-      (event) => event.type === "provider_turn_started"
+      (event) => event.type === "provider_turn_identity_resolved"
     );
     const providerCheckpoint = events.find(
       (event) => event.type === "provider_turn_checkpoint"
@@ -93,6 +93,407 @@ test("Claude-persisted user UUID becomes the provider Turn identity", async () =
     restoreSink();
   }
 });
+
+test("successful result recovers provider Turn identity when SDK omits the root user echo", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const recoveryInputs: Array<Record<string, string>> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-recovered",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) => ({
+        async *[Symbol.asyncIterator]() {
+          await prompt[Symbol.asyncIterator]().next();
+          yield {
+            type: "assistant",
+            uuid: "persisted-assistant-uuid",
+            parent_tool_use_id: null,
+            session_id: "provider-session-recovered",
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "hello" }]
+            }
+          } as never;
+          yield { type: "result", subtype: "success" } as never;
+        },
+        close() {}
+      }),
+      30_000,
+      async (input) => {
+        recoveryInputs.push(input);
+        return {
+          providerSessionId: input.sessionId,
+          providerTurnId: "persisted-user-uuid",
+          providerCheckpointMessageId: "persisted-assistant-uuid"
+        };
+      }
+    );
+
+    await session.start();
+    session.exec(
+      "turn-recovered",
+      "hello",
+      undefined,
+      undefined,
+      undefined,
+      "",
+      "outbound-correlation-id"
+    );
+    await waitForEvent(events, "turn_completed");
+
+    assert.deepEqual(recoveryInputs, [
+      {
+        sessionId: "provider-session-recovered",
+        cwd: "/repo",
+        recoveryToken: "outbound-correlation-id"
+      }
+    ]);
+    assert.deepEqual(
+      events
+        .filter((event) =>
+          [
+            "provider_turn_identity_resolved",
+            "provider_turn_checkpoint",
+            "turn_completed"
+          ].includes(event.type)
+        )
+        .map(({ type, payload }) => ({ type, payload })),
+      [
+        {
+          type: "provider_turn_identity_resolved",
+          payload: {
+            turnId: "turn-recovered",
+            providerTurnId: "persisted-user-uuid"
+          }
+        },
+        {
+          type: "provider_turn_checkpoint",
+          payload: {
+            turnId: "turn-recovered",
+            providerTurnId: "persisted-user-uuid",
+            providerCheckpointMessageId: "persisted-assistant-uuid"
+          }
+        },
+        {
+          type: "turn_completed",
+          payload: {
+            stopReason: "end_turn",
+            turnId: "turn-recovered",
+            providerTurnId: "persisted-user-uuid"
+          }
+        }
+      ]
+    );
+  } finally {
+    restoreSink();
+  }
+});
+
+test("interactive request recovers provider Turn identity before waiting when SDK omits the root user echo", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const recoveryInputs: Array<Record<string, string>> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  let permissionResult: unknown;
+  try {
+    const session = new SessionRuntime(
+      "provider-session-interactive-recovered",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt, options }) => ({
+        async *[Symbol.asyncIterator]() {
+          await prompt[Symbol.asyncIterator]().next();
+          yield {
+            type: "assistant",
+            uuid: "persisted-tool-assistant-uuid",
+            parent_tool_use_id: null,
+            session_id: "provider-session-interactive-recovered",
+            message: {
+              role: "assistant",
+              content: [
+                {
+                  type: "tool_use",
+                  id: "toolu-write",
+                  name: "Write",
+                  input: { file_path: "/repo/tetris.html" }
+                }
+              ]
+            }
+          } as never;
+          permissionResult = await options.canUseTool?.(
+            "Write",
+            { file_path: "/repo/tetris.html" },
+            testCanUseToolOptions({
+              requestId: "request-write",
+              toolUseID: "toolu-write"
+            })
+          );
+          yield { type: "result", subtype: "success" } as never;
+        },
+        close() {}
+      }),
+      30_000,
+      async (input) => {
+        recoveryInputs.push(input);
+        return {
+          providerSessionId: input.sessionId,
+          providerTurnId: "persisted-tool-user-uuid",
+          providerCheckpointMessageId: "persisted-tool-assistant-uuid"
+        };
+      }
+    );
+
+    await session.start();
+    session.exec(
+      "turn-interactive-recovered",
+      "write a file",
+      undefined,
+      undefined,
+      undefined,
+      "",
+      "outbound-interactive-correlation-id"
+    );
+    await waitForEvent(events, "approval_requested");
+
+    assert.deepEqual(recoveryInputs, [
+      {
+        sessionId: "provider-session-interactive-recovered",
+        cwd: "/repo",
+        recoveryToken: "outbound-interactive-correlation-id"
+      }
+    ]);
+    assert.deepEqual(
+      events
+        .filter((event) =>
+          [
+            "provider_turn_identity_resolved",
+            "provider_turn_checkpoint",
+            "approval_requested"
+          ].includes(event.type)
+        )
+        .map(({ type, payload }) => ({ type, payload })),
+      [
+        {
+          type: "provider_turn_identity_resolved",
+          payload: {
+            turnId: "turn-interactive-recovered",
+            providerTurnId: "persisted-tool-user-uuid"
+          }
+        },
+        {
+          type: "provider_turn_checkpoint",
+          payload: {
+            turnId: "turn-interactive-recovered",
+            providerTurnId: "persisted-tool-user-uuid",
+            providerCheckpointMessageId: "persisted-tool-assistant-uuid"
+          }
+        },
+        {
+          type: "approval_requested",
+          payload: events.find((event) => event.type === "approval_requested")
+            ?.payload
+        }
+      ]
+    );
+
+    const request = events.find((event) => event.type === "approval_requested");
+    session.submitInteractive(
+      "turn-interactive-recovered",
+      String(request?.payload?.requestId ?? ""),
+      "submit",
+      "allow",
+      {}
+    );
+    await waitForEvent(events, "turn_completed");
+
+    assert.deepEqual(permissionResult, {
+      behavior: "allow",
+      updatedInput: { file_path: "/repo/tetris.html" }
+    });
+    assert.equal(
+      events.filter((event) => event.type === "provider_turn_identity_resolved")
+        .length,
+      1
+    );
+  } finally {
+    restoreSink();
+  }
+});
+
+test("AskUserQuestion and ExitPlanMode share one accepted identity without root user echo", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  let recoveryCalls = 0;
+  try {
+    const session = new SessionRuntime(
+      "provider-session-multi-interaction",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt, options }) => ({
+        async *[Symbol.asyncIterator]() {
+          await prompt[Symbol.asyncIterator]().next();
+          yield {
+            type: "assistant",
+            uuid: "assistant-before-interactions",
+            parent_tool_use_id: null,
+            session_id: "provider-session-multi-interaction",
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "I need two answers." }]
+            }
+          } as never;
+          await options.canUseTool?.(
+            "AskUserQuestion",
+            {
+              questions: [
+                {
+                  header: "Choice",
+                  question: "Pick one",
+                  options: [{ label: "A", description: "Alpha" }]
+                }
+              ]
+            },
+            testCanUseToolOptions({
+              requestId: "request-ask",
+              toolUseID: "toolu-ask"
+            })
+          );
+          await options.canUseTool?.(
+            "ExitPlanMode",
+            { plan: "Implement the selected option." },
+            testCanUseToolOptions({
+              requestId: "request-exit-plan",
+              toolUseID: "toolu-exit-plan"
+            })
+          );
+          yield { type: "result", subtype: "success" } as never;
+        },
+        close() {}
+      }),
+      30_000,
+      async (input) => {
+        recoveryCalls += 1;
+        return {
+          providerSessionId: input.sessionId,
+          providerTurnId: "provider-turn-multi-interaction",
+          providerCheckpointMessageId: "assistant-before-interactions"
+        };
+      }
+    );
+
+    await session.start();
+    session.exec(
+      "turn-multi-interaction",
+      "ask then exit plan",
+      undefined,
+      undefined,
+      undefined,
+      "",
+      "correlation-multi-interaction"
+    );
+    await waitForEventCount(events, "user_input_requested", 1);
+    const ask = events.find((event) => event.type === "user_input_requested");
+    session.submitInteractive(
+      "turn-multi-interaction",
+      String(ask?.payload?.requestId ?? ""),
+      "submit",
+      "",
+      { answers: { "Pick one": "A" } }
+    );
+    await waitForEventCount(events, "user_input_requested", 2);
+    const exitPlan = events.filter(
+      (event) => event.type === "user_input_requested"
+    )[1];
+    session.submitInteractive(
+      "turn-multi-interaction",
+      String(exitPlan?.payload?.requestId ?? ""),
+      "submit",
+      "default",
+      {}
+    );
+    await waitForEvent(events, "turn_completed");
+
+    const ordered = events.filter((event) =>
+      [
+        "provider_turn_identity_resolved",
+        "user_input_requested",
+        "turn_completed"
+      ].includes(event.type)
+    );
+    assert.equal(ordered[0]?.type, "provider_turn_identity_resolved");
+    assert.equal(
+      ordered.filter(
+        (event) => event.type === "provider_turn_identity_resolved"
+      ).length,
+      1
+    );
+    assert.equal(
+      ordered.filter((event) => event.type === "user_input_requested").length,
+      2
+    );
+    assert.equal(recoveryCalls, 1);
+    assert.equal(
+      ordered.at(-1)?.payload?.providerTurnId,
+      "provider-turn-multi-interaction"
+    );
+  } finally {
+    restoreSink();
+  }
+});
+
+async function waitForEventCount(
+  events: Array<{ type: string }>,
+  type: string,
+  count: number
+): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (events.filter((event) => event.type === type).length >= count) {
+      return;
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 5));
+  }
+  assert.fail(`timed out waiting for ${count} ${type} events`);
+}
 
 test("ephemeral Claude session state UUID does not replace the durable checkpoint", async () => {
   const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts
@@ -46,6 +46,14 @@ import { MessageProjection } from "./messageProjection.ts";
 import { SDKMessageRouter } from "./messageRouter.ts";
 import { emit } from "./eventSink.ts";
 import {
+  resolveClaudeTurnBindingByRecoveryToken,
+  type ClaudeTurnBindingResolver
+} from "./sessionFork.ts";
+import {
+  ProviderTurnAcceptanceCoordinator,
+  type ProviderTurnPhase
+} from "./providerTurnAcceptance.ts";
+import {
   canBypassPermissions,
   effectivePermissionMode,
   modelOptionValue,
@@ -89,6 +97,8 @@ export class SessionRuntime {
   private readonly router: SDKMessageRouter;
   private readonly driver?: SidecarTestDriver;
   private readonly goalExecQueue: GoalExecQueue;
+  private readonly providerTurnAcceptance: ProviderTurnAcceptanceCoordinator;
+  private readonly emittedProviderCheckpoints = new Set<string>();
 
   get query(): ClaudeQueryRuntime | undefined {
     return this.queryGeneration?.query;
@@ -104,7 +114,9 @@ export class SessionRuntime {
     claudeOptions: SidecarClaudeOptions,
     resumeCursor?: Record<string, unknown>,
     queryFactory?: ClaudeQueryFactory,
-    continuationStartTimeoutMs = 30_000
+    continuationStartTimeoutMs = 30_000,
+    resolveProviderTurnIdentity: ClaudeTurnBindingResolver = resolveClaudeTurnBindingByRecoveryToken,
+    providerTurnIdentityResolutionTimeoutMs = 5_000
   ) {
     const resumeSessionId = stringValue(resumeCursor?.resume);
     this.providerSessionId = resumeSessionId || providerSessionId;
@@ -115,7 +127,10 @@ export class SessionRuntime {
     this.turns = new TurnLifecycle({
       emit,
       onActivate: () => this.resetTurnScratch(),
-      onSettled: () => this.emitSessionState(),
+      onSettled: (turnId) => {
+        this.providerTurnAcceptance.terminal(turnId);
+        this.emitSessionState();
+      },
       continuationStartTimeoutMs,
       onContinuationStartTimeout: () => {
         this.activities.clearBackgroundContinuation();
@@ -128,6 +143,38 @@ export class SessionRuntime {
           });
         });
       }
+    });
+    this.providerTurnAcceptance = new ProviderTurnAcceptanceCoordinator({
+      cwd: this.cwd,
+      getProviderSessionId: () => this.providerSessionId,
+      resolveTarget: () => {
+        const turn =
+          this.turns.activeTurn ??
+          this.turns.queue.find(
+            (candidate) =>
+              !candidate.settled &&
+              !candidate.synthetic &&
+              candidate.awaitingProviderTurnIdentity === true
+          );
+        if (!turn || turn.synthetic) {
+          return undefined;
+        }
+        return {
+          turnId: turn.turnId,
+          promptCorrelationId: turn.promptUuid,
+          providerTurnId: turn.providerTurnId?.trim() ?? ""
+        };
+      },
+      resolveBinding: resolveProviderTurnIdentity,
+      bindIdentity: (turnId, providerTurnId) =>
+        this.turns.bindProviderTurnIdentity(turnId, providerTurnId),
+      emitCheckpoint: (turnId, binding) =>
+        this.emitProviderCheckpoint(
+          turnId,
+          binding.providerTurnId,
+          binding.providerCheckpointMessageId
+        ),
+      resolutionTimeoutMs: providerTurnIdentityResolutionTimeoutMs
     });
     this.assistantStream = new AssistantStreamProjector(
       () => this.turns.activeId,
@@ -172,6 +219,8 @@ export class SessionRuntime {
       resolveTurnId: (options) =>
         resolveInteractiveTurnId(options, this.turns, this.activities),
       activateSyntheticTurn: () => this.turns.activateSynthetic().turnId,
+      ensureProviderTurnAcceptance: (phase, signal) =>
+        this.ensureProviderTurnAcceptance(phase, signal),
       emit
     });
     this.driver = testDriver
@@ -215,7 +264,19 @@ export class SessionRuntime {
       activities: this.activities,
       projection: this.projection,
       compaction: this.compaction,
-      emit
+      emit,
+      emitProviderCheckpoint: (
+        turnId,
+        providerTurnId,
+        providerCheckpointMessageId
+      ) =>
+        this.emitProviderCheckpoint(
+          turnId,
+          providerTurnId,
+          providerCheckpointMessageId
+        ),
+      ensureProviderTurnAcceptance: (phase) =>
+        this.ensureProviderTurnAcceptance(phase)
     });
     this.claudeOptions = claudeOptions;
     this.queryFactory = queryFactory;
@@ -330,6 +391,7 @@ export class SessionRuntime {
         : {}),
       settled: false
     };
+    this.providerTurnAcceptance.markQueued(turnId);
     const executionEpoch = this.executionEpoch;
     this.turns.enqueue(turn);
     this.compaction.selectCommand(turnId, isCompactCommandPrompt(prompt));
@@ -366,6 +428,7 @@ export class SessionRuntime {
         }
         generation.expectPromptEcho(turn.promptUuid);
         this.turns.expectProviderTurnIdentity(turn.turnId);
+        this.providerTurnAcceptance.markDispatched(turn.turnId);
         generation.promptQueue.push({
           uuid: turn.promptUuid,
           type: "user",
@@ -469,6 +532,7 @@ export class SessionRuntime {
     }
     this.activities.cancel();
     this.executionEpoch += 1;
+    this.providerTurnAcceptance.cancel(expectedTurnId);
     this.canceledQueryTailPending = true;
     this.interactions.rejectAll(new Error("Tool use aborted"));
     const generation = this.queryGeneration;
@@ -508,6 +572,7 @@ export class SessionRuntime {
     }
     this.sessionClosed = true;
     this.executionEpoch += 1;
+    this.providerTurnAcceptance.cancel();
     this.interactions.rejectAll(new Error("Tool use aborted"));
     this.activities.close();
     this.turns.close();
@@ -789,6 +854,45 @@ export class SessionRuntime {
       toolInput,
       callbackOptions
     );
+  }
+
+  private ensureProviderTurnAcceptance(
+    phase: Extract<
+      ProviderTurnPhase,
+      "streaming" | "waiting_approval" | "waiting_input" | "running_tool"
+    >,
+    signal?: AbortSignal
+  ): Promise<void> {
+    return this.providerTurnAcceptance.ensure(phase, signal);
+  }
+
+  private emitProviderCheckpoint(
+    turnId: string,
+    providerTurnId: string,
+    providerCheckpointMessageId: string
+  ): void {
+    turnId = turnId.trim();
+    providerTurnId = providerTurnId.trim();
+    providerCheckpointMessageId = providerCheckpointMessageId.trim();
+    if (!turnId || !providerTurnId || !providerCheckpointMessageId) {
+      return;
+    }
+    const key = `${turnId}\u0000${providerTurnId}\u0000${providerCheckpointMessageId}`;
+    if (this.emittedProviderCheckpoints.has(key)) {
+      return;
+    }
+    this.emittedProviderCheckpoints.add(key);
+    while (this.emittedProviderCheckpoints.size > 128) {
+      const oldest = this.emittedProviderCheckpoints.values().next().value;
+      if (typeof oldest !== "string") {
+        break;
+      }
+      this.emittedProviderCheckpoints.delete(oldest);
+    }
+    emit({
+      type: "provider_turn_checkpoint",
+      payload: { turnId, providerTurnId, providerCheckpointMessageId }
+    });
   }
 
   private isQueryGenerationActive(generation: QueryGeneration): boolean {

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntimeTestQueries.delegated.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntimeTestQueries.delegated.ts
@@ -545,6 +545,26 @@ export function fakeBackgroundBashAndSubagentQuery(
       yield delegatedAgentToolUse("toolu-agent", "Slow child");
       yield delegatedAgentToolResult("toolu-agent", "agent-1");
       yield {
+        type: "assistant",
+        uuid: "assistant-bash",
+        parent_tool_use_id: null,
+        session_id: "provider-session-1",
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu-bash",
+              name: "Bash",
+              input: {
+                command: "python3 -m http.server 8000",
+                run_in_background: true
+              }
+            }
+          ]
+        }
+      } as unknown as SDKMessage;
+      yield {
         type: "system",
         subtype: "task_started",
         task_id: "task-1",
@@ -552,17 +572,15 @@ export function fakeBackgroundBashAndSubagentQuery(
         description: "Slow child"
       } as unknown as SDKMessage;
       yield {
-        type: "result",
-        subtype: "success"
-      } as unknown as SDKMessage;
-      // A run_in_background Bash announces itself only through the task
-      // system, after the provider turn already settled.
-      yield {
         type: "system",
         subtype: "task_started",
         task_id: "bs-1",
         tool_use_id: "toolu-bash",
-        description: "sleep 60"
+        description: "python3 -m http.server 8000"
+      } as unknown as SDKMessage;
+      yield {
+        type: "result",
+        subtype: "success"
       } as unknown as SDKMessage;
       yield {
         type: "system",
@@ -571,12 +589,87 @@ export function fakeBackgroundBashAndSubagentQuery(
         status: "completed",
         summary: "Child done"
       } as unknown as SDKMessage;
+      await hold;
+    },
+    async interrupt() {
+      releaseHold();
+    },
+    close() {
+      releaseHold();
+    }
+  };
+}
+
+export function fakeLongRunningBackgroundBashQuery(
+  prompt: AsyncIterable<SDKUserMessage>
+): AsyncIterable<SDKMessage> & {
+  interrupt: () => Promise<void>;
+  close: () => void;
+} {
+  let releaseHold: () => void = () => {};
+  const hold = new Promise<void>((resolve) => {
+    releaseHold = resolve;
+  });
+  return {
+    async *[Symbol.asyncIterator]() {
+      const firstPrompt = await prompt[Symbol.asyncIterator]().next();
+      const promptMessage = firstPrompt.value as SDKUserMessage & {
+        uuid?: string;
+      };
+      yield {
+        ...promptMessage,
+        uuid: promptMessage.uuid,
+        type: "user",
+        parent_tool_use_id: null,
+        session_id: "provider-session-1"
+      } as SDKMessage;
+      yield {
+        type: "assistant",
+        uuid: "assistant-bash",
+        parent_tool_use_id: null,
+        session_id: "provider-session-1",
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu-bash",
+              name: "Bash",
+              input: {
+                command: "python3 -m http.server 8000",
+                run_in_background: true
+              }
+            }
+          ]
+        }
+      } as unknown as SDKMessage;
       yield {
         type: "system",
-        subtype: "task_notification",
+        subtype: "background_tasks_changed",
+        tasks: [{ task_id: "bs-1" }]
+      } as unknown as SDKMessage;
+      yield {
+        type: "assistant",
+        uuid: "assistant-final",
+        parent_tool_use_id: null,
+        session_id: "provider-session-1",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Server started." }]
+        }
+      } as unknown as SDKMessage;
+      yield {
+        type: "result",
+        subtype: "success"
+      } as unknown as SDKMessage;
+      // The SDK may announce the detached task only after it has reported the
+      // provider turn successful.
+      yield {
+        type: "system",
+        subtype: "task_started",
         task_id: "bs-1",
-        status: "completed",
-        summary: "Command done"
+        tool_use_id: "toolu-bash",
+        description: "python3 -m http.server 8000"
       } as unknown as SDKMessage;
       await hold;
     },

--- a/packages/agent/claude-sdk-sidecar/src/testDriver.ts
+++ b/packages/agent/claude-sdk-sidecar/src/testDriver.ts
@@ -12,14 +12,13 @@ export class SidecarTestDriver {
     this.interactions = interactions;
   }
 
-  exec(turnId: string, prompt: string, promptCorrelationId = ""): void {
+  exec(turnId: string, prompt: string, _promptCorrelationId = ""): void {
     this.turns.activateTransient(turnId);
-    if (promptCorrelationId) {
-      emit({
-        type: "provider_turn_started",
-        payload: { turnId, providerTurnId: promptCorrelationId }
-      });
-    }
+    const providerTurnId = crypto.randomUUID();
+    emit({
+      type: "provider_turn_identity_resolved",
+      payload: { turnId, providerTurnId }
+    });
     if (prompt.includes("approval")) {
       void this.interactions
         .handleToolPermission(
@@ -32,9 +31,9 @@ export class SidecarTestDriver {
           }
         )
         .then(() =>
-          this.completeTurn(turnId, promptCorrelationId, "Approval accepted.")
+          this.completeTurn(turnId, providerTurnId, "Approval accepted.")
         )
-        .catch((error) => this.failTurn(turnId, promptCorrelationId, error));
+        .catch((error) => this.failTurn(turnId, providerTurnId, error));
       return;
     }
     if (prompt.includes("ask-user")) {
@@ -56,9 +55,9 @@ export class SidecarTestDriver {
           }
         )
         .then(() =>
-          this.completeTurn(turnId, promptCorrelationId, "Question answered.")
+          this.completeTurn(turnId, providerTurnId, "Question answered.")
         )
-        .catch((error) => this.failTurn(turnId, promptCorrelationId, error));
+        .catch((error) => this.failTurn(turnId, providerTurnId, error));
       return;
     }
     if (prompt.includes("exit-plan")) {
@@ -71,22 +70,20 @@ export class SidecarTestDriver {
             toolUseID: "test-exit-plan-tool"
           }
         )
-        .then(() =>
-          this.completeTurn(turnId, promptCorrelationId, "Plan captured.")
-        )
-        .catch((error) => this.failTurn(turnId, promptCorrelationId, error));
+        .then(() => this.completeTurn(turnId, providerTurnId, "Plan captured."))
+        .catch((error) => this.failTurn(turnId, providerTurnId, error));
       return;
     }
     emit({
       type: "assistant_delta",
       payload: {
         turnId,
-        ...(promptCorrelationId ? { providerTurnId: promptCorrelationId } : {}),
+        providerTurnId,
         content: `Echo: ${prompt}`,
         snapshot: `Echo: ${prompt}`
       }
     });
-    this.completeTurn(turnId, promptCorrelationId, `Echo: ${prompt}`);
+    this.completeTurn(turnId, providerTurnId, `Echo: ${prompt}`);
   }
 
   guide(prompt: string): void {

--- a/packages/agent/claude-sdk-sidecar/src/toolActivity.ts
+++ b/packages/agent/claude-sdk-sidecar/src/toolActivity.ts
@@ -15,6 +15,7 @@ import {
   taskNotificationToSystemMessage
 } from "./taskNotification.ts";
 import type {
+  BackgroundProcessState,
   DelegatedTaskState,
   DelegatedTaskStatus
 } from "./toolActivityTypes.ts";
@@ -31,6 +32,11 @@ export class ToolActivityProjector {
   >();
   private readonly delegatedParentByAgentID = new Map<string, string>();
   private readonly delegatedParentByTaskID = new Map<string, string>();
+  private readonly backgroundProcessesByParentToolUseID = new Map<
+    string,
+    BackgroundProcessState
+  >();
+  private readonly backgroundProcessParentByTaskID = new Map<string, string>();
   private readonly activeTurnId: () => string;
   private readonly emit: ClaudeSDKSidecarEventEmitter;
   private readonly lastTurnId: () => string;
@@ -101,6 +107,10 @@ export class ToolActivityProjector {
     this.backgroundTasks.handleRootResultSettled(succeeded);
   }
 
+  completePendingRootBackgroundLaunches(): void {
+    this.tools.completePendingRootBackgroundLaunches();
+  }
+
   completeToolIndex(index: number): boolean {
     return this.tools.completeIndex(index);
   }
@@ -144,7 +154,16 @@ export class ToolActivityProjector {
     const task = parentByAlias
       ? this.delegatedTasksByParentToolUseID.get(parentByAlias)
       : this.delegatedTasksByParentToolUseID.get(parentToolUseId || taskId);
-    return task?.status === "running" ? (task.taskId ?? "") : "";
+    if (task?.status === "running") {
+      return task.taskId ?? "";
+    }
+    const backgroundParent =
+      this.backgroundProcessParentByTaskID.get(taskId) ||
+      parentToolUseId ||
+      taskId;
+    const background =
+      this.backgroundProcessesByParentToolUseID.get(backgroundParent);
+    return background?.status === "running" ? background.taskId : "";
   }
 
   handleTaskNotificationFromText(text: string): void {
@@ -166,17 +185,16 @@ export class ToolActivityProjector {
       | "task_notification",
     message: Record<string, unknown>
   ): void {
-    // task_notification is included so a terminal notice for a task launched
-    // before a sidecar restart (reported e.g. as stopped on the next prompt)
-    // still settles a card instead of being dropped by the fresh instance.
     const task =
       this.resolveDelegatedTaskFromMessage(message) ??
-      (subtype === "task_started" ||
-      subtype === "task_updated" ||
-      subtype === "task_notification"
-        ? this.rememberBackgroundTask(message)
+      ((subtype === "task_started" ||
+        subtype === "task_updated" ||
+        subtype === "task_notification") &&
+      isExplicitSubagentTaskMessage(message)
+        ? this.rememberUnclaimedDelegatedTask(message)
         : undefined);
     if (!task) {
+      this.handleBackgroundProcessTaskMessage(subtype, message);
       return;
     }
     const taskId = stringValue(message.task_id) || stringValue(message.taskId);
@@ -474,29 +492,21 @@ export class ToolActivityProjector {
     }
   }
 
-  // Background launches the launch-result path does not register (most
-  // importantly `run_in_background` Bash) still announce themselves through
-  // the SDK task system. Registering them here puts them on the same
-  // delegated-task rails as background subagents, so they gate the root turn,
-  // show up as child sessions, and can be stopped individually — instead of
-  // running invisibly after the turn settled.
-  private rememberBackgroundTask(
+  // A sidecar restarted between a subagent launch and its terminal notice may
+  // receive an explicit agent task before rebuilding its alias maps. Only
+  // provider-declared agent work may recreate delegated state here; an
+  // unclaimed task-system event can also represent a detached Bash process.
+  private rememberUnclaimedDelegatedTask(
     message: Record<string, unknown>
   ): DelegatedTaskState | undefined {
     const parentToolUseId =
       stringValue(message.tool_use_id) || stringValue(message.toolCallId);
     const taskId = stringValue(message.task_id) || stringValue(message.taskId);
     if (!parentToolUseId || !taskId) {
-      // Without a launching tool use id this could be a racing alias for a
-      // not-yet-registered subagent launch; binding it here would poison the
-      // alias maps, so leave it for the launch result to register.
       return undefined;
     }
     const task: DelegatedTaskState = {
       parentToolUseId,
-      // Background task_started frequently arrives after the launching
-      // provider turn already settled; fall back to that turn so lifecycle
-      // events are not dropped for lack of a turn id.
       turnId: this.activeTurnId() || this.lastTurnId(),
       input: {},
       taskId,
@@ -505,6 +515,51 @@ export class ToolActivityProjector {
     this.delegatedTasksByParentToolUseID.set(parentToolUseId, task);
     this.delegatedParentByTaskID.set(taskId, parentToolUseId);
     return task;
+  }
+
+  private handleBackgroundProcessTaskMessage(
+    subtype:
+      | "task_started"
+      | "task_progress"
+      | "task_updated"
+      | "task_notification",
+    message: Record<string, unknown>
+  ): void {
+    const parentToolUseId =
+      stringValue(message.parentToolUseId) ||
+      stringValue(message.parent_tool_use_id) ||
+      stringValue(message.tool_use_id) ||
+      stringValue(message.toolCallId) ||
+      stringValue(message.callId);
+    const taskId = stringValue(message.task_id) || stringValue(message.taskId);
+    const knownParent =
+      this.backgroundProcessParentByTaskID.get(taskId) || parentToolUseId;
+    let process = knownParent
+      ? this.backgroundProcessesByParentToolUseID.get(knownParent)
+      : undefined;
+    if (!process && subtype === "task_started" && parentToolUseId && taskId) {
+      process = {
+        parentToolUseId,
+        taskId,
+        status: "running"
+      };
+      this.backgroundProcessesByParentToolUseID.set(parentToolUseId, process);
+      this.backgroundProcessParentByTaskID.set(taskId, parentToolUseId);
+      this.tools.completeBackgroundLaunch(parentToolUseId, taskId);
+      return;
+    }
+    if (
+      !process ||
+      (subtype !== "task_updated" && subtype !== "task_notification")
+    ) {
+      return;
+    }
+    if (!isTerminalTaskStatus(message.status)) {
+      return;
+    }
+    process.status = delegatedTaskStatus(message.status);
+    this.backgroundProcessesByParentToolUseID.delete(process.parentToolUseId);
+    this.backgroundProcessParentByTaskID.delete(process.taskId);
   }
 
   private resolveDelegatedTaskFromMessage(
@@ -748,6 +803,35 @@ function delegatedTaskSummaryFromMessage(
     stringValue(message.summary) ||
     stringValue(message.description)
   );
+}
+
+function isExplicitSubagentTaskMessage(
+  message: Record<string, unknown>
+): boolean {
+  const taskType = (
+    stringValue(message.task_type) || stringValue(message.taskType)
+  ).toLowerCase();
+  return Boolean(
+    stringValue(message.agent_id) ||
+    stringValue(message.agentId) ||
+    stringValue(message.agentID) ||
+    taskType === "agent" ||
+    taskType === "subagent"
+  );
+}
+
+function isTerminalTaskStatus(value: unknown): boolean {
+  switch (stringValue(value).toLowerCase()) {
+    case "completed":
+    case "failed":
+    case "error":
+    case "stopped":
+    case "canceled":
+    case "cancelled":
+      return true;
+    default:
+      return false;
+  }
 }
 
 function delegatedTaskStatus(value: unknown): DelegatedTaskStatus {

--- a/packages/agent/claude-sdk-sidecar/src/toolActivityTypes.ts
+++ b/packages/agent/claude-sdk-sidecar/src/toolActivityTypes.ts
@@ -18,3 +18,9 @@ export type DelegatedTaskState = {
   // nested agent launch is observed inside a child stream.
   parentTaskToolUseId?: string;
 };
+
+export type BackgroundProcessState = {
+  parentToolUseId: string;
+  taskId: string;
+  status: DelegatedTaskStatus;
+};

--- a/packages/agent/claude-sdk-sidecar/src/toolEvents.ts
+++ b/packages/agent/claude-sdk-sidecar/src/toolEvents.ts
@@ -54,6 +54,40 @@ export class ToolEventProjector {
     return true;
   }
 
+  completeBackgroundLaunch(toolUseID: string, taskID = ""): boolean {
+    const tool = this.toolByID.get(toolUseID);
+    if (!tool) {
+      return false;
+    }
+    const payload = toolPayload(this.resolveTurnId(tool), tool, "completed");
+    const metadata = recordValue(payload.metadata);
+    if (metadata) {
+      metadata.backgroundProcess = {
+        ...(taskID ? { taskId: taskID } : {}),
+        status: "running"
+      };
+    }
+    this.appendParentTaskStep(tool, payload);
+    this.onTerminal(tool, payload);
+    this.emit({ type: "tool_completed", payload });
+    this.removeTool(toolUseID);
+    return true;
+  }
+
+  completePendingRootBackgroundLaunches(): void {
+    const toolUseIDs = [...this.toolByID.values()]
+      .filter(
+        (tool) =>
+          !tool.parentToolUseId &&
+          (tool.input.run_in_background === true ||
+            tool.input.runInBackground === true)
+      )
+      .map((tool) => tool.id);
+    for (const toolUseID of toolUseIDs) {
+      this.completeBackgroundLaunch(toolUseID);
+    }
+  }
+
   parentToolUseID(toolUseID: string): string {
     return stringValue(this.toolByID.get(toolUseID)?.parentToolUseId);
   }
@@ -115,13 +149,7 @@ export class ToolEventProjector {
       failed ? "failed" : "completed",
       result
     );
-    this.toolHookResultByID.delete(toolUseID);
-    this.toolByID.delete(toolUseID);
-    for (const [index, indexedTool] of this.toolByIndex) {
-      if (indexedTool.id === toolUseID) {
-        this.toolByIndex.delete(index);
-      }
-    }
+    this.removeTool(toolUseID);
   }
 
   handlePostToolUseHook(
@@ -236,6 +264,16 @@ export class ToolEventProjector {
       this.onTerminal(tool, payload);
     }
     this.emit({ type, payload });
+  }
+
+  private removeTool(toolUseID: string): void {
+    this.toolHookResultByID.delete(toolUseID);
+    this.toolByID.delete(toolUseID);
+    for (const [index, indexedTool] of this.toolByIndex) {
+      if (indexedTool.id === toolUseID) {
+        this.toolByIndex.delete(index);
+      }
+    }
   }
 
   private appendParentTaskStep(

--- a/packages/agent/claude-sdk-sidecar/src/turnLifecycle.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/turnLifecycle.test.ts
@@ -19,7 +19,7 @@ test("turn lifecycle activates and settles a queued turn", () => {
   assert.equal(activations.count, 1);
   assert.equal(settlements.count, 1);
   assert.deepEqual(events[0], {
-    type: "provider_turn_started",
+    type: "provider_turn_identity_resolved",
     payload: {
       turnId: "turn-1",
       providerTurnId: "prompt-1"
@@ -69,7 +69,7 @@ test("turn lifecycle uses Claude's persisted root user UUID as provider identity
 
   assert.deepEqual(events, [
     {
-      type: "provider_turn_started",
+      type: "provider_turn_identity_resolved",
       payload: {
         turnId: "turn-rewritten",
         providerTurnId: "persisted-claude-user-uuid"
@@ -80,6 +80,28 @@ test("turn lifecycle uses Claude's persisted root user UUID as provider identity
       payload: {
         turnId: "turn-rewritten",
         providerTurnId: "persisted-claude-user-uuid"
+      }
+    }
+  ]);
+});
+
+test("turn lifecycle never treats the outbound correlation UUID as provider identity", () => {
+  const { lifecycle, events } = createLifecycle();
+  lifecycle.enqueue({
+    turnId: "turn-without-provider-echo",
+    promptUuid: "outbound-correlation-id",
+    settled: false
+  });
+
+  lifecycle.expectProviderTurnIdentity("turn-without-provider-echo");
+  lifecycle.ensureActive("assistant");
+  lifecycle.settleActive("turn_completed");
+
+  assert.deepEqual(events, [
+    {
+      type: "turn_completed",
+      payload: {
+        turnId: "turn-without-provider-echo"
       }
     }
   ]);

--- a/packages/agent/claude-sdk-sidecar/src/turnLifecycle.ts
+++ b/packages/agent/claude-sdk-sidecar/src/turnLifecycle.ts
@@ -1,4 +1,5 @@
 import type { ClaudeSDKSidecarEventEmitter } from "./protocol.ts";
+import type { ProviderTurnIdentityBindingDisposition } from "./providerTurnAcceptance.ts";
 
 export type RuntimeTurn = {
   readonly turnId: string;
@@ -27,7 +28,7 @@ export class TurnLifecycle {
   private readonly turns: RuntimeTurn[] = [];
   private readonly emit: ClaudeSDKSidecarEventEmitter;
   private readonly onActivate: () => void;
-  private readonly onSettled: () => void;
+  private readonly onSettled: (turnId: string) => void;
   private readonly onContinuationStartTimeout: () => void;
   private readonly continuationStartTimeoutMs: number;
   private active: RuntimeTurn | undefined;
@@ -43,7 +44,7 @@ export class TurnLifecycle {
   constructor(options: {
     emit: ClaudeSDKSidecarEventEmitter;
     onActivate: () => void;
-    onSettled: () => void;
+    onSettled: (turnId: string) => void;
     onContinuationStartTimeout?: () => void;
     continuationStartTimeoutMs?: number;
   }) {
@@ -147,6 +148,29 @@ export class TurnLifecycle {
       return;
     }
     this.ensureActive("user");
+  }
+
+  bindProviderTurnIdentity(
+    turnId: string,
+    providerTurnId: string
+  ): ProviderTurnIdentityBindingDisposition {
+    const normalizedTurnId = turnId.trim();
+    const turn = this.turns.find(
+      (candidate) => !candidate.settled && candidate.turnId === normalizedTurnId
+    );
+    if (!turn) {
+      return "missing";
+    }
+    const normalizedProviderTurnId = providerTurnId.trim();
+    const existingProviderTurnId = turn.providerTurnId?.trim() ?? "";
+    if (existingProviderTurnId) {
+      return existingProviderTurnId === normalizedProviderTurnId
+        ? "already_bound"
+        : "conflict";
+    }
+    return this.bindProviderTurnId(turn, normalizedProviderTurnId)
+      ? "bound"
+      : "conflict";
   }
 
   ensureActive(messageType: string): RuntimeTurn | undefined {
@@ -257,7 +281,7 @@ export class TurnLifecycle {
     this.active = undefined;
     this.activeIdValue = "";
     this.compactQueue();
-    this.onSettled();
+    this.onSettled(turn.turnId);
   }
 
   failLiveTurns(error: string): void {
@@ -414,14 +438,17 @@ export class TurnLifecycle {
     });
   }
 
-  private bindProviderTurnId(turn: RuntimeTurn, providerTurnId: string): void {
+  private bindProviderTurnId(
+    turn: RuntimeTurn,
+    providerTurnId: string
+  ): boolean {
     if (
       turn.synthetic ||
       !providerTurnId ||
       turn.providerTurnId?.trim() ||
       turn.providerTurnStarted
     ) {
-      return;
+      return false;
     }
     turn.providerTurnId = providerTurnId;
     if (turn === this.active || turn.turnId === this.lastTurnIdValue) {
@@ -430,16 +457,17 @@ export class TurnLifecycle {
     turn.awaitingProviderTurnIdentity = false;
     turn.providerTurnStarted = true;
     this.emit({
-      type: "provider_turn_started",
+      type: "provider_turn_identity_resolved",
       payload: {
         turnId: turn.turnId,
         providerTurnId
       }
     });
+    return true;
   }
 
   private providerTurnId(turn: RuntimeTurn): string {
-    return turn.providerTurnId?.trim() || turn.promptUuid.trim();
+    return turn.providerTurnId?.trim() || "";
   }
 
   private compactQueue(): void {

--- a/packages/agent/daemon/runtime/adapter.go
+++ b/packages/agent/daemon/runtime/adapter.go
@@ -145,6 +145,7 @@ type ProviderAcceptanceExecAdapter interface {
 		EventSink,
 		CommandSnapshotSink,
 		ProviderDispatchSink,
+		ProviderAcceptanceBarrier,
 	) ([]activityshared.Event, error)
 }
 
@@ -177,6 +178,12 @@ type HistoryReplacementExecInput struct {
 // DispatchDispositionAppliedWithoutProviderTurn. Implementations must report
 // exactly once before a typed execution method returns.
 type ProviderDispatchSink func(ProviderDispatchResult)
+
+// ProviderAcceptanceBarrier durably binds the canonical Turn to the exact
+// provider session and provider Turn before the adapter exposes any event that
+// depends on that identity. Implementations must call it synchronously on the
+// provider event path and stop event publication when it fails.
+type ProviderAcceptanceBarrier func(ProviderAcceptanceReceipt) error
 
 // EffectiveHistoryAdapter is the complete provider capability required by
 // edit-retry: authoritative history reads, rollback, and a fresh replacement

--- a/packages/agent/daemon/runtime/claude_sdk_acceptance_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_acceptance_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
+
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 func TestClaudeSDKProviderAcceptanceReportsPreDispatchFailures(t *testing.T) {
@@ -60,6 +63,7 @@ func TestClaudeSDKProviderAcceptanceReportsPreDispatchFailures(t *testing.T) {
 					default:
 					}
 				},
+				nil,
 			)
 			if err == nil {
 				t.Fatal("ExecWithProviderAcceptance() error=nil, want pre-dispatch failure")
@@ -74,5 +78,221 @@ func TestClaudeSDKProviderAcceptanceReportsPreDispatchFailures(t *testing.T) {
 				t.Fatal("provider dispatch was not reported")
 			}
 		})
+	}
+}
+
+func TestClaudeSDKProviderAcceptanceUsesRecoveredSidecarIdentityBeforeCompletion(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	conn := newBlockingClaudeSDKConnection()
+	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, conn)
+	adapterSession.providerSessionID = session.ProviderSessionID
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	dispatch := make(chan ProviderDispatchResult, 1)
+	execDone := make(chan error, 1)
+	go func() {
+		_, err := adapter.ExecWithProviderAcceptance(
+			ctx,
+			session,
+			[]PromptContentBlock{{Type: "text", Text: "hello"}},
+			"hello",
+			"canonical-turn",
+			nil,
+			nil,
+			func(result ProviderDispatchResult) {
+				dispatch <- result
+			},
+			func(receipt ProviderAcceptanceReceipt) error {
+				dispatch <- ProviderDispatchResult{
+					Disposition: DispatchDispositionApplied,
+					Acceptance:  &receipt,
+				}
+				return nil
+			},
+		)
+		execDone <- err
+	}()
+
+	waitForClaudeSDKSentRequest(t, conn, "exec")
+	conn.pushEvent(claudeSDKSidecarEvent{
+		Type: "provider_turn_identity_resolved",
+		Payload: map[string]any{
+			"turnId":         "canonical-turn",
+			"providerTurnId": "persisted-claude-user-uuid",
+		},
+	})
+	conn.pushEvent(claudeSDKSidecarEvent{
+		Type: "provider_turn_checkpoint",
+		Payload: map[string]any{
+			"turnId":                      "canonical-turn",
+			"providerTurnId":              "persisted-claude-user-uuid",
+			"providerCheckpointMessageId": "persisted-claude-assistant-uuid",
+		},
+	})
+	conn.pushEvent(claudeSDKSidecarEvent{
+		Type: "turn_completed",
+		Payload: map[string]any{
+			"turnId":         "canonical-turn",
+			"providerTurnId": "persisted-claude-user-uuid",
+			"stopReason":     "end_turn",
+		},
+	})
+
+	select {
+	case result := <-dispatch:
+		if result.Disposition != DispatchDispositionApplied ||
+			result.Acceptance == nil ||
+			result.Acceptance.ProviderSessionID != session.ProviderSessionID ||
+			result.Acceptance.ProviderTurnID != "persisted-claude-user-uuid" {
+			t.Fatalf("provider dispatch = %#v, want recovered durable identity", result)
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for provider acceptance")
+	}
+	select {
+	case err := <-execDone:
+		if err != nil {
+			t.Fatalf("ExecWithProviderAcceptance: %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for turn completion")
+	}
+}
+
+func TestClaudeSDKDurableAcceptanceBlocksInteractionPublication(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	conn := newBlockingClaudeSDKConnection()
+	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, conn)
+	adapterSession.providerSessionID = session.ProviderSessionID
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	emitted := make(chan activityshared.Event, 16)
+	barrierEntered := make(chan ProviderAcceptanceReceipt, 1)
+	releaseBarrier := make(chan struct{})
+	execDone := make(chan error, 1)
+	go func() {
+		_, err := adapter.ExecWithProviderAcceptance(
+			ctx,
+			session,
+			[]PromptContentBlock{{Type: "text", Text: "write a file"}},
+			"write a file",
+			"canonical-turn",
+			func(events []activityshared.Event) {
+				for _, event := range events {
+					emitted <- event
+				}
+			},
+			nil,
+			func(ProviderDispatchResult) {},
+			func(receipt ProviderAcceptanceReceipt) error {
+				barrierEntered <- receipt
+				select {
+				case <-releaseBarrier:
+					return nil
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			},
+		)
+		execDone <- err
+	}()
+
+	waitForClaudeSDKSentRequest(t, conn, "exec")
+	for {
+		select {
+		case <-emitted:
+			continue
+		default:
+		}
+		break
+	}
+	conn.pushEvent(claudeSDKSidecarEvent{
+		Type: "provider_turn_identity_resolved",
+		Payload: map[string]any{
+			"turnId":         "canonical-turn",
+			"providerTurnId": "provider-turn",
+		},
+	})
+	select {
+	case receipt := <-barrierEntered:
+		if receipt.ProviderTurnID != "provider-turn" {
+			t.Fatalf("acceptance receipt = %#v", receipt)
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for acceptance barrier")
+	}
+	conn.pushEvent(claudeSDKSidecarEvent{
+		Type: "approval_requested",
+		Payload: map[string]any{
+			"turnId":     "canonical-turn",
+			"requestId":  "approval-1",
+			"toolCallId": "toolu-write",
+			"toolName":   "Write",
+			"input":      map[string]any{"file_path": "/workspace/file.txt"},
+			"options": []any{
+				map[string]any{
+					"kind":     "allow_once",
+					"name":     "Allow",
+					"optionId": "allow",
+				},
+			},
+		},
+	})
+	select {
+	case event := <-emitted:
+		t.Fatalf("event %q escaped before durable acceptance", event.Type)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	close(releaseBarrier)
+	var ordered []activityshared.EventType
+	for len(ordered) < 4 {
+		select {
+		case event := <-emitted:
+			ordered = append(ordered, event.Type)
+			if event.Type == activityshared.EventInteractionRequested {
+				goto interactionObserved
+			}
+		case <-ctx.Done():
+			t.Fatal("timed out waiting for accepted interaction")
+		}
+	}
+
+interactionObserved:
+	startedIndex := -1
+	interactionIndex := -1
+	for index, eventType := range ordered {
+		switch eventType {
+		case activityshared.EventRootProviderTurnStarted:
+			startedIndex = index
+		case activityshared.EventInteractionRequested:
+			interactionIndex = index
+		}
+	}
+	if startedIndex < 0 || interactionIndex <= startedIndex {
+		t.Fatalf("published order = %#v, want started before interaction", ordered)
+	}
+
+	conn.pushEvent(claudeSDKSidecarEvent{
+		Type: "turn_completed",
+		Payload: map[string]any{
+			"turnId":         "canonical-turn",
+			"providerTurnId": "provider-turn",
+			"stopReason":     "end_turn",
+		},
+	})
+	select {
+	case err := <-execDone:
+		if err != nil {
+			t.Fatalf("ExecWithProviderAcceptance: %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for turn completion")
 	}
 }

--- a/packages/agent/daemon/runtime/claude_sdk_activity_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_activity_test.go
@@ -145,7 +145,7 @@ func TestClaudeCodeSDKAdapterExecLeavesInitialTitleToController(t *testing.T) {
 	session := standardTestSession(ProviderClaudeCode)
 	conn := &scriptedClaudeSDKConnection{
 		frames: []ProcessFrame{{
-			Stdout: []byte(`{"type":"turn_completed","payload":{"turnId":"turn-1","stopReason":"end_turn"}}` + "\n"),
+			Stdout: []byte(`{"type":"provider_turn_identity_resolved","payload":{"turnId":"turn-1","providerTurnId":"provider-turn-1"}}` + "\n" + `{"type":"turn_completed","payload":{"turnId":"turn-1","providerTurnId":"provider-turn-1","stopReason":"end_turn"}}` + "\n"),
 		}},
 	}
 	adapterSession := &claudeSDKAdapterSession{

--- a/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
@@ -29,10 +29,10 @@ func TestClaudeCodeSDKAdapterInteractiveApprovalRoundTrip(t *testing.T) {
 	adapter.storeSession(session.AgentSessionID, adapterSession)
 	adapter.beginClaudeSDKRootTurn(adapterSession, "turn-approval", "provider-turn-approval")
 
-	started, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "provider-turn-approval", claudeSDKSidecarEvent{
+	started, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-approval", claudeSDKSidecarEvent{
 		Type: "approval_requested",
 		Payload: map[string]any{
-			"turnId":     "provider-turn-approval",
+			"turnId":     "turn-approval",
 			"requestId":  "approval-1",
 			"toolCallId": "toolu-approval",
 			"toolName":   "Bash",
@@ -63,6 +63,16 @@ func TestClaudeCodeSDKAdapterInteractiveApprovalRoundTrip(t *testing.T) {
 	if prompt := adapter.SessionState(session).PendingInteractive; prompt == nil || prompt.Kind != "approval" || prompt.RequestID != "approval-1" {
 		t.Fatalf("pending prompt = %#v, want approval", prompt)
 	}
+	pending := adapter.getClaudeSDKPendingRequest(
+		session.AgentSessionID,
+		"turn-approval",
+		"approval-1",
+	)
+	if pending == nil ||
+		pending.providerTurnID != "provider-turn-approval" ||
+		pending.transportTurnID != "turn-approval" {
+		t.Fatalf("pending identities = %#v", pending)
+	}
 
 	type submitResult struct {
 		result SubmitInteractiveResult
@@ -75,14 +85,14 @@ func TestClaudeCodeSDKAdapterInteractiveApprovalRoundTrip(t *testing.T) {
 	}()
 	waitForCondition(t, func() bool { return len(conn.sentRequests()) == 1 })
 	sent := conn.sentRequests()
-	if len(sent) != 1 || sent[0].Type != "submit_interactive" || sent[0].Payload["requestId"] != "approval-1" || sent[0].Payload["optionId"] != "allow" || sent[0].Payload["turnId"] != "provider-turn-approval" {
+	if len(sent) != 1 || sent[0].Type != "submit_interactive" || sent[0].Payload["requestId"] != "approval-1" || sent[0].Payload["optionId"] != "allow" || sent[0].Payload["turnId"] != "turn-approval" {
 		t.Fatalf("sent requests = %#v", sent)
 	}
 
-	resolved, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "provider-turn-approval", claudeSDKSidecarEvent{
+	resolved, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-approval", claudeSDKSidecarEvent{
 		Type: "approval_resolved",
 		Payload: map[string]any{
-			"turnId":    "provider-turn-approval",
+			"turnId":    "turn-approval",
 			"requestId": "approval-1",
 			"optionId":  "allow",
 		},
@@ -523,6 +533,11 @@ func TestClaudeCodeSDKAdapterApprovalResolvedUsesStoredTurnIDWhenEventTurnMissin
 		liveState:       newClaudeSDKLiveState(),
 	}
 	adapter.storeSession(session.AgentSessionID, adapterSession)
+	adapter.beginClaudeSDKRootTurn(
+		adapterSession,
+		"turn-approval",
+		"provider-turn-approval",
+	)
 
 	if _, _, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-approval", claudeSDKSidecarEvent{
 		Type: "approval_requested",

--- a/packages/agent/daemon/runtime/claude_sdk_event_projection_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_event_projection_test.go
@@ -140,7 +140,7 @@ func TestClaudeCodeSDKAdapterMapsObservedProviderTurnIdentity(t *testing.T) {
 		session,
 		"canonical-turn-1",
 		claudeSDKSidecarEvent{
-			Type: "provider_turn_started",
+			Type: "provider_turn_identity_resolved",
 			Payload: map[string]any{
 				"turnId":         "canonical-turn-1",
 				"providerTurnId": "persisted-claude-user-uuid",
@@ -148,7 +148,7 @@ func TestClaudeCodeSDKAdapterMapsObservedProviderTurnIdentity(t *testing.T) {
 		},
 	)
 	if err != nil || terminal {
-		t.Fatalf("provider_turn_started err=%v terminal=%v", err, terminal)
+		t.Fatalf("provider_turn_identity_resolved err=%v terminal=%v", err, terminal)
 	}
 	if len(events) != 1 ||
 		events[0].Type != activityshared.EventRootProviderTurnStarted ||
@@ -326,6 +326,11 @@ func TestClaudeCodeSDKAdapterApprovalDoesNotMergeWithApprovedToolCall(t *testing
 		liveState:       newClaudeSDKLiveState(),
 	}
 	adapter.storeSession(session.AgentSessionID, adapterSession)
+	adapter.beginClaudeSDKRootTurn(
+		adapterSession,
+		"turn-web",
+		"provider-turn-web",
+	)
 
 	approvalEvents, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-web", claudeSDKSidecarEvent{
 		Type: "approval_requested",
@@ -792,8 +797,11 @@ func TestClaudeCodeSDKAdapterKeepsDelegationCompletionOnParentAndUpdatesChildTit
 	}
 
 	settled, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-task", claudeSDKSidecarEvent{
-		Type:    "turn_completed",
-		Payload: map[string]any{"turnId": "turn-task"},
+		Type: "turn_completed",
+		Payload: map[string]any{
+			"turnId":         "turn-task",
+			"providerTurnId": "provider-turn-task",
+		},
 	})
 	if err != nil || !terminal {
 		t.Fatalf("turn_completed events=%#v terminal=%v err=%v", settled, terminal, err)
@@ -1337,6 +1345,11 @@ func TestClaudeCodeSDKAdapterMapsAskUserQuestionInteractive(t *testing.T) {
 		liveState:       newClaudeSDKLiveState(),
 	}
 	adapter.storeSession(session.AgentSessionID, adapterSession)
+	adapter.beginClaudeSDKRootTurn(
+		adapterSession,
+		"turn-ask",
+		"provider-turn-ask",
+	)
 
 	events, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-ask", claudeSDKSidecarEvent{
 		Type: "user_input_requested",
@@ -1371,6 +1384,11 @@ func TestClaudeCodeSDKAdapterMapsExitPlanModeInteractive(t *testing.T) {
 		liveState:       newClaudeSDKLiveState(),
 	}
 	adapter.storeSession(session.AgentSessionID, adapterSession)
+	adapter.beginClaudeSDKRootTurn(
+		adapterSession,
+		"turn-plan",
+		"provider-turn-plan",
+	)
 
 	events, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-plan", claudeSDKSidecarEvent{
 		Type: "user_input_requested",
@@ -1423,6 +1441,11 @@ func TestClaudeCodeSDKAdapterCancelClearsPendingInteractive(t *testing.T) {
 		liveState:       newClaudeSDKLiveState(),
 	}
 	adapter.storeSession(session.AgentSessionID, adapterSession)
+	adapter.beginClaudeSDKRootTurn(
+		adapterSession,
+		"turn-cancel",
+		"provider-turn-cancel",
+	)
 
 	// A turn parked on an approval has a live Exec waiter in the registry; the
 	// interrupted terminal is stamped for that registered turnID, not for the
@@ -1620,8 +1643,11 @@ func TestClaudeCodeSDKAdapterTurnCanceledFailsOpenToolCalls(t *testing.T) {
 	}
 
 	events, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-write", claudeSDKSidecarEvent{
-		Type:    "turn_canceled",
-		Payload: map[string]any{"turnId": "turn-write"},
+		Type: "turn_canceled",
+		Payload: map[string]any{
+			"turnId":         "turn-write",
+			"providerTurnId": "turn-write",
+		},
 	})
 	if err != nil || !terminal {
 		t.Fatalf("turn_canceled err=%v terminal=%v", err, terminal)
@@ -1660,6 +1686,11 @@ func TestClaudeCodeSDKAdapterReaderFailureFailsPendingInteractive(t *testing.T) 
 		liveState:        newClaudeSDKLiveState(),
 	}
 	adapter.storeSession(session.AgentSessionID, adapterSession)
+	adapter.beginClaudeSDKRootTurn(
+		adapterSession,
+		"turn-disconnect",
+		"provider-turn-disconnect",
+	)
 
 	if _, _, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-disconnect", claudeSDKSidecarEvent{
 		Type: "approval_requested",

--- a/packages/agent/daemon/runtime/claude_sdk_event_projection_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_event_projection_test.go
@@ -813,6 +813,77 @@ func TestClaudeCodeSDKAdapterKeepsDelegationCompletionOnParentAndUpdatesChildTit
 	}
 }
 
+func TestClaudeCodeSDKAdapterSettlesDetachedProcessLaunchWithoutCreatingChildWork(t *testing.T) {
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session := standardTestSession(ProviderClaudeCode)
+	adapterSession := &claudeSDKAdapterSession{
+		conn:            &recordingClaudeSDKConnection{},
+		pendingRequests: make(map[string]*pendingInteractiveRequest),
+		liveState:       newClaudeSDKLiveState(),
+	}
+	adapter.storeSession(session.AgentSessionID, adapterSession)
+
+	started, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-bash", claudeSDKSidecarEvent{
+		Type: "tool_started",
+		Payload: map[string]any{
+			"turnId":     "turn-bash",
+			"toolCallId": "toolu-bash",
+			"toolName":   "Bash",
+			"callType":   "tool",
+			"input": map[string]any{
+				"command":           "python3 -m http.server 8000",
+				"run_in_background": true,
+			},
+		},
+	})
+	if err != nil || terminal || len(started) != 1 || started[0].Type != activityshared.EventCallStarted {
+		t.Fatalf("tool_started events=%#v terminal=%v err=%v", started, terminal, err)
+	}
+	if len(adapterSession.childSessions) != 0 {
+		t.Fatalf("detached process created child sessions: %#v", adapterSession.childSessions)
+	}
+
+	completed, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-bash", claudeSDKSidecarEvent{
+		Type: "tool_completed",
+		Payload: map[string]any{
+			"turnId":     "turn-bash",
+			"toolCallId": "toolu-bash",
+			"toolName":   "Bash",
+			"callType":   "tool",
+			"status":     "completed",
+			"input": map[string]any{
+				"command":           "python3 -m http.server 8000",
+				"run_in_background": true,
+			},
+			"metadata": map[string]any{
+				"backgroundProcess": map[string]any{"status": "running"},
+			},
+		},
+	})
+	if err != nil || terminal || len(completed) != 1 || completed[0].Type != activityshared.EventCallCompleted {
+		t.Fatalf("tool_completed events=%#v terminal=%v err=%v", completed, terminal, err)
+	}
+
+	settled, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-bash", claudeSDKSidecarEvent{
+		Type: "turn_completed",
+		Payload: map[string]any{
+			"turnId":         "turn-bash",
+			"providerTurnId": "provider-turn-bash",
+		},
+	})
+	if err != nil || !terminal {
+		t.Fatalf("turn_completed events=%#v terminal=%v err=%v", settled, terminal, err)
+	}
+	for _, event := range settled {
+		if event.Type == activityshared.EventCallFailed {
+			t.Fatalf("detached process launch was left dangling: %#v", settled)
+		}
+	}
+	if len(adapterSession.childSessions) != 0 {
+		t.Fatalf("completed detached process created child sessions: %#v", adapterSession.childSessions)
+	}
+}
+
 func TestClaudeCodeSDKAdapterCreatesNestedChildUnderParentChildTurn(t *testing.T) {
 	adapter := NewClaudeCodeSDKAdapter(nil)
 	session := standardTestSession(ProviderClaudeCode)

--- a/packages/agent/daemon/runtime/claude_sdk_events.go
+++ b/packages/agent/daemon/runtime/claude_sdk_events.go
@@ -47,11 +47,30 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 	if eventTurnID != "" && strings.TrimSpace(turnID) != "" && eventTurnID != strings.TrimSpace(turnID) {
 		return nil, false, nil
 	}
+	explicitProviderTurnID := payloadString(event.Payload, "providerTurnId")
+	activeProviderTurnID := a.activeClaudeSDKRootProviderTurnID(adapterSession)
+	if explicitProviderTurnID != "" &&
+		activeProviderTurnID != "" &&
+		explicitProviderTurnID != activeProviderTurnID &&
+		claudeSDKEventRequiresBoundProviderIdentity(event.Type) {
+		return nil, false, errors.New("claude SDK provider turn identity changed after binding")
+	}
+	boundProviderTurnID := firstNonEmptyString(
+		explicitProviderTurnID,
+		activeProviderTurnID,
+	)
 	providerTurnID := firstNonEmptyString(
-		payloadString(event.Payload, "providerTurnId"),
+		boundProviderTurnID,
 		strings.TrimSpace(turnID),
 		eventTurnID,
 	)
+	if event.Type == "turn_started" {
+		providerTurnID = firstNonEmptyString(
+			explicitProviderTurnID,
+			strings.TrimSpace(turnID),
+			eventTurnID,
+		)
+	}
 	a.mu.Lock()
 	_, fencedGoalTurn := adapterSession.fencedGoalTurns[providerTurnID]
 	if fencedGoalTurn && isClaudeSDKTerminalEvent(event.Type) {
@@ -78,15 +97,15 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 		return nil, false, nil
 	case "session_state":
 		return []activityshared.Event{newSessionActivityEvent(session, EventSessionUpdated, firstNonEmpty(session.Status, SessionStatusReady), claudeSDKRuntimeContext(session, adapterSession))}, false, nil
-	case "provider_turn_started":
-		if eventTurnID == "" || providerTurnID == "" {
-			return nil, false, errors.New("claude SDK provider turn start omitted identity")
+	case "provider_turn_identity_resolved":
+		if eventTurnID == "" || explicitProviderTurnID == "" {
+			return nil, false, errors.New("claude SDK provider turn identity resolution omitted identity")
 		}
-		a.beginClaudeSDKRootTurn(adapterSession, eventTurnID, providerTurnID)
+		a.beginClaudeSDKRootTurn(adapterSession, eventTurnID, explicitProviderTurnID)
 		return []activityshared.Event{a.claudeSDKRootProviderTurnStartedEvent(
 			session,
 			eventTurnID,
-			providerTurnID,
+			explicitProviderTurnID,
 			map[string]any{"adapter": claudeSDKSidecarAdapterName},
 		)}, false, nil
 	case "provider_turn_checkpoint":
@@ -94,7 +113,7 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 			event.Payload,
 			"providerCheckpointMessageId",
 		)
-		if eventTurnID == "" || providerTurnID == "" || checkpointMessageID == "" {
+		if eventTurnID == "" || boundProviderTurnID == "" || checkpointMessageID == "" {
 			return nil, false, errors.New(
 				"claude SDK provider turn checkpoint omitted identity",
 			)
@@ -102,7 +121,7 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 		return []activityshared.Event{a.claudeSDKRootProviderTurnCheckpointEvent(
 			session,
 			eventTurnID,
-			providerTurnID,
+			boundProviderTurnID,
 			checkpointMessageID,
 		)}, false, nil
 	case "turn_started":
@@ -191,7 +210,18 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 	case "error":
 		return nil, false, errors.New(payloadString(event.Payload, "error"))
 	case "approval_requested", "user_input_requested":
-		events, err := a.claudeSDKInteractiveRequested(adapterSession, session, rootTurnID, providerTurnID, event.Payload)
+		if boundProviderTurnID == "" {
+			return nil, false, errors.New(
+				"claude SDK interaction omitted bound provider turn identity",
+			)
+		}
+		events, err := a.claudeSDKInteractiveRequested(
+			adapterSession,
+			session,
+			rootTurnID,
+			boundProviderTurnID,
+			event.Payload,
+		)
 		return events, false, err
 	case "approval_resolved", "user_input_resolved":
 		return a.claudeSDKInteractiveResolved(adapterSession, session, rootTurnID, event.Payload), false, nil
@@ -311,23 +341,44 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 		events = append(events, newSessionActivityEvent(session, EventSessionUpdated, firstNonEmpty(session.Status, SessionStatusReady), claudeSDKRuntimeContext(session, adapterSession)))
 		return events, false, nil
 	case "turn_completed":
+		if boundProviderTurnID == "" {
+			return nil, false, errors.New("claude SDK provider turn completion omitted identity")
+		}
 		events := a.finishClaudeSDKTurnLifecycle(adapterSession, session, rootTurnID, claudeSDKTurnFinishCompleted, "")
-		events = append(events, claudeSDKRootProviderTurnCompletedEvent(session, rootTurnID, providerTurnID, activityshared.TurnOutcomeCompleted, map[string]any{
+		events = append(events, claudeSDKRootProviderTurnCompletedEvent(session, rootTurnID, boundProviderTurnID, activityshared.TurnOutcomeCompleted, map[string]any{
 			"adapter":    claudeSDKSidecarAdapterName,
 			"stopReason": firstNonEmpty(payloadString(event.Payload, "stopReason"), "end_turn"),
 		}))
 		events = append(events, a.goalEventsOnTurnSettled(adapterSession, session, providerTurnID, true)...)
 		return events, true, nil
 	case "turn_canceled":
+		if boundProviderTurnID == "" {
+			return a.finishClaudeSDKTurnLifecycle(
+				adapterSession,
+				session,
+				rootTurnID,
+				claudeSDKTurnFinishInterrupted,
+				"interrupted_before_provider_acceptance",
+			), true, nil
+		}
 		events := a.finishClaudeSDKTurnLifecycle(adapterSession, session, rootTurnID, claudeSDKTurnFinishInterrupted, "interrupted")
-		events = append(events, claudeSDKRootProviderTurnCompletedEvent(session, rootTurnID, providerTurnID, activityshared.TurnOutcomeCanceled, map[string]any{
+		events = append(events, claudeSDKRootProviderTurnCompletedEvent(session, rootTurnID, boundProviderTurnID, activityshared.TurnOutcomeCanceled, map[string]any{
 			"adapter": claudeSDKSidecarAdapterName,
 		}))
 		events = append(events, a.goalEventsOnTurnSettled(adapterSession, session, providerTurnID, false)...)
 		return events, true, nil
 	case "turn_failed":
+		if boundProviderTurnID == "" {
+			return a.finishClaudeSDKTurnLifecycle(
+				adapterSession,
+				session,
+				rootTurnID,
+				claudeSDKTurnFinishFailed,
+				"failed_before_provider_acceptance",
+			), true, nil
+		}
 		events := a.finishClaudeSDKTurnLifecycle(adapterSession, session, rootTurnID, claudeSDKTurnFinishFailed, "turn_failed")
-		events = append(events, claudeSDKRootProviderTurnCompletedEvent(session, rootTurnID, providerTurnID, activityshared.TurnOutcomeFailed, map[string]any{
+		events = append(events, claudeSDKRootProviderTurnCompletedEvent(session, rootTurnID, boundProviderTurnID, activityshared.TurnOutcomeFailed, map[string]any{
 			"adapter": claudeSDKSidecarAdapterName,
 			"error":   payloadString(event.Payload, "error"),
 		}))
@@ -335,6 +386,16 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 		return events, true, nil
 	default:
 		return nil, false, nil
+	}
+}
+
+func claudeSDKEventRequiresBoundProviderIdentity(eventType string) bool {
+	switch eventType {
+	case "provider_turn_identity_resolved",
+		"provider_turn_checkpoint":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -513,6 +574,8 @@ func (a *ClaudeCodeSDKAdapter) logClaudeSDKLifecycleEvent(agentSessionID string,
 func claudeSDKLifecycleEventDiagnostic(event claudeSDKSidecarEvent) bool {
 	switch strings.TrimSpace(event.Type) {
 	case "sdk_lifecycle_observed",
+		"provider_turn_identity_resolved", "provider_turn_checkpoint",
+		"approval_requested", "user_input_requested",
 		"turn_started", "turn_completed", "turn_canceled", "turn_failed",
 		"continuation_delayed",
 		"background_tasks_changed", "background_tasks_quiesced",

--- a/packages/agent/daemon/runtime/claude_sdk_execution.go
+++ b/packages/agent/daemon/runtime/claude_sdk_execution.go
@@ -2,7 +2,9 @@ package agentruntime
 
 import (
 	"context"
+	"errors"
 	"strings"
+	"sync"
 
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
@@ -143,6 +145,7 @@ func (a *ClaudeCodeSDKAdapter) ExecWithProviderAcceptance(
 	emit EventSink,
 	emitCommands CommandSnapshotSink,
 	reportDispatch ProviderDispatchSink,
+	acceptProviderTurn ProviderAcceptanceBarrier,
 ) ([]activityshared.Event, error) {
 	adapterSession := a.getSession(session.AgentSessionID)
 	if adapterSession == nil {
@@ -153,7 +156,17 @@ func (a *ClaudeCodeSDKAdapter) ExecWithProviderAcceptance(
 		}
 		return nil, ErrSessionDisconnected
 	}
+	acceptanceCtx, cancelAcceptance := context.WithCancel(ctx)
+	defer cancelAcceptance()
+	var acceptanceOnce sync.Once
+	var acceptanceErr error
+	accepted := false
+	acceptedProviderTurnID := ""
 	wrappedEmit := func(events []activityshared.Event) {
+		if acceptanceErr != nil {
+			return
+		}
+		observedAcceptance := false
 		for _, event := range events {
 			if event.Type != activityshared.EventRootProviderTurnStarted ||
 				strings.TrimSpace(event.Payload.TurnID) != strings.TrimSpace(turnID) {
@@ -163,23 +176,59 @@ func (a *ClaudeCodeSDKAdapter) ExecWithProviderAcceptance(
 			if providerTurnID == "" {
 				continue
 			}
+			if accepted &&
+				acceptedProviderTurnID != "" &&
+				providerTurnID != acceptedProviderTurnID {
+				acceptanceErr = errors.New(
+					"claude SDK changed provider Turn identity after acceptance",
+				)
+				cancelAcceptance()
+				return
+			}
+			observedAcceptance = true
+			receipt := ProviderAcceptanceReceipt{
+				Source:            AcceptanceSourceTurnStartResponse,
+				ProviderSessionID: strings.TrimSpace(adapterSession.providerSessionID),
+				ProviderTurnID:    providerTurnID,
+			}
+			acceptanceOnce.Do(func() {
+				if acceptProviderTurn == nil {
+					acceptanceErr = errors.New(
+						"provider acceptance barrier is unavailable",
+					)
+					return
+				}
+				acceptanceErr = acceptProviderTurn(receipt)
+				accepted = acceptanceErr == nil
+				if accepted {
+					acceptedProviderTurnID = providerTurnID
+				}
+			})
+			if acceptanceErr != nil {
+				cancelAcceptance()
+				return
+			}
+		}
+		if !accepted &&
+			!observedAcceptance &&
+			!claudeSDKEventsMayPrecedeProviderAcceptance(events) {
+			acceptanceErr = errors.New(
+				"claude SDK published provider output before durable acceptance",
+			)
 			if reportDispatch != nil {
 				reportDispatch(ProviderDispatchResult{
-					Disposition: DispatchDispositionApplied,
-					Acceptance: &ProviderAcceptanceReceipt{
-						Source:            AcceptanceSourceTurnStartResponse,
-						ProviderSessionID: strings.TrimSpace(adapterSession.providerSessionID),
-						ProviderTurnID:    providerTurnID,
-					},
+					Disposition: DispatchDispositionOutcomeUnknown,
 				})
 			}
+			cancelAcceptance()
+			return
 		}
 		if emit != nil {
 			emit(events)
 		}
 	}
 	return a.exec(
-		ctx,
+		acceptanceCtx,
 		session,
 		content,
 		displayPrompt,
@@ -188,6 +237,28 @@ func (a *ClaudeCodeSDKAdapter) ExecWithProviderAcceptance(
 		emitCommands,
 		reportDispatch,
 	)
+}
+
+func claudeSDKEventsMayPrecedeProviderAcceptance(
+	events []activityshared.Event,
+) bool {
+	if len(events) == 0 {
+		return true
+	}
+	for _, event := range events {
+		if event.Type == EventTurnStarted {
+			continue
+		}
+		if event.Type == activityshared.EventMessageAppended &&
+			strings.EqualFold(
+				strings.TrimSpace(string(event.Payload.Role)),
+				"user",
+			) {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 var _ ProviderAcceptanceExecAdapter = (*ClaudeCodeSDKAdapter)(nil)

--- a/packages/agent/daemon/runtime/claude_sdk_fork_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_fork_test.go
@@ -158,7 +158,8 @@ func TestClaudeSDKForkedChildCanResumeAndStartTurn(t *testing.T) {
 			},
 			{
 				Stdout: []byte(
-					`{"type":"turn_completed","payload":{"turnId":"canonical-child-turn","stopReason":"end_turn"}}` + "\n",
+					`{"type":"provider_turn_identity_resolved","payload":{"turnId":"canonical-child-turn","providerTurnId":"child-provider-turn"}}` + "\n" +
+						`{"type":"turn_completed","payload":{"turnId":"canonical-child-turn","providerTurnId":"child-provider-turn","stopReason":"end_turn"}}` + "\n",
 				),
 			},
 		},

--- a/packages/agent/daemon/runtime/claude_sdk_goal_lifecycle_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_goal_lifecycle_test.go
@@ -53,6 +53,11 @@ func TestClaudeSDKAdapterKeepsCanonicalLifecycleLiveAtProviderCompletion(t *test
 	waiter := adapter.registerClaudeSDKTurn(adapterSession, "turn-1", func(events []activityshared.Event) {
 		emitted = append(emitted, events...)
 	})
+	adapter.beginClaudeSDKRootTurn(
+		adapterSession,
+		"turn-1",
+		"provider-turn-1",
+	)
 
 	adapter.dispatchClaudeSDKEvent(session.AgentSessionID, adapterSession, claudeSDKSidecarEvent{
 		Type: "approval_requested",
@@ -88,8 +93,12 @@ func TestClaudeSDKAdapterKeepsCanonicalLifecycleLiveAtProviderCompletion(t *test
 
 	emitted = nil
 	adapter.dispatchClaudeSDKEvent(session.AgentSessionID, adapterSession, claudeSDKSidecarEvent{
-		Type:    "turn_completed",
-		Payload: map[string]any{"turnId": "turn-1", "stopReason": "end_turn"},
+		Type: "turn_completed",
+		Payload: map[string]any{
+			"turnId":         "turn-1",
+			"providerTurnId": "turn-1",
+			"stopReason":     "end_turn",
+		},
 	})
 	providerCompleted := activityEventsWithType(emitted, activityshared.EventRootProviderTurnCompleted)
 	if len(providerCompleted) != 1 || providerCompleted[0].Payload.TurnID != "turn-1" ||
@@ -519,8 +528,11 @@ func TestClaudeSDKGoalCompletesWhenTurnSettles(t *testing.T) {
 	adapter.applyLocalGoal(adapterSession, map[string]any{"objective": "ship it", "status": "active"})
 
 	events, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-goal", claudeSDKSidecarEvent{
-		Type:    "turn_completed",
-		Payload: map[string]any{"turnId": "turn-goal"},
+		Type: "turn_completed",
+		Payload: map[string]any{
+			"turnId":         "turn-goal",
+			"providerTurnId": "turn-goal",
+		},
 	})
 	if err != nil || !terminal {
 		t.Fatalf("turn_completed terminal=%v err=%v", terminal, err)
@@ -601,8 +613,11 @@ func TestClaudeSDKGoalArmTurnGatesCompletion(t *testing.T) {
 
 	// An earlier turn settling must not complete the not-yet-started goal.
 	if _, _, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-earlier", claudeSDKSidecarEvent{
-		Type:    "turn_completed",
-		Payload: map[string]any{"turnId": "turn-earlier"},
+		Type: "turn_completed",
+		Payload: map[string]any{
+			"turnId":         "turn-earlier",
+			"providerTurnId": "turn-earlier",
+		},
 	}); err != nil {
 		t.Fatalf("earlier turn_completed: %v", err)
 	}
@@ -612,8 +627,11 @@ func TestClaudeSDKGoalArmTurnGatesCompletion(t *testing.T) {
 
 	// The arm turn's own completion is the achievement signal.
 	events, _, err := adapter.sidecarTurnEvents(adapterSession, session, armTurnID, claudeSDKSidecarEvent{
-		Type:    "turn_completed",
-		Payload: map[string]any{"turnId": armTurnID},
+		Type: "turn_completed",
+		Payload: map[string]any{
+			"turnId":         armTurnID,
+			"providerTurnId": armTurnID,
+		},
 	})
 	if err != nil {
 		t.Fatalf("arm turn_completed: %v", err)
@@ -762,8 +780,11 @@ func TestClaudeSDKGoalArmTurnCanceledClearsMirror(t *testing.T) {
 	armTurnID := payloadString(setRequest.Payload, "turnId")
 
 	events, _, err := adapter.sidecarTurnEvents(adapterSession, session, armTurnID, claudeSDKSidecarEvent{
-		Type:    "turn_canceled",
-		Payload: map[string]any{"turnId": armTurnID},
+		Type: "turn_canceled",
+		Payload: map[string]any{
+			"turnId":         armTurnID,
+			"providerTurnId": armTurnID,
+		},
 	})
 	if err != nil {
 		t.Fatalf("arm turn_canceled: %v", err)

--- a/packages/agent/daemon/runtime/claude_sdk_interactive.go
+++ b/packages/agent/daemon/runtime/claude_sdk_interactive.go
@@ -72,7 +72,7 @@ func (a *ClaudeCodeSDKAdapter) SubmitInteractive(ctx context.Context, session Se
 
 	payload := map[string]any{
 		"agentSessionId": providerAgentSessionID,
-		"turnId":         claudeSDKInteractiveProviderTurnID(pending),
+		"turnId":         claudeSDKInteractiveTransportTurnID(pending),
 		"requestId":      requestID,
 		"action":         response.action,
 		"optionId":       optionID,
@@ -201,7 +201,7 @@ func (a *ClaudeCodeSDKAdapter) queryClaudeSDKInteractiveDisposition(
 		Type: "interactive_disposition",
 		Payload: map[string]any{
 			"agentSessionId": providerAgentSessionID,
-			"turnId":         claudeSDKInteractiveProviderTurnID(pending),
+			"turnId":         claudeSDKInteractiveTransportTurnID(pending),
 			"requestId":      pending.requestID,
 			"action":         response.action,
 			"optionId":       response.optionID,
@@ -319,6 +319,15 @@ func (a *ClaudeCodeSDKAdapter) claudeSDKInteractiveRequested(
 		eventSession = claudeSDKChildRuntimeSession(session, child)
 		eventTurnID = child.TurnID
 	}
+	transportTurnID := firstNonEmptyString(
+		payloadString(payload, "turnId"),
+		payloadString(payload, "turnID"),
+	)
+	if transportTurnID == "" {
+		return nil, errors.New(
+			"claude SDK interaction omitted transport turn identity",
+		)
+	}
 	options := claudeSDKInteractiveOptions(payload, toolCall)
 	interactivePrompt := normalizedInteractivePrompt(toolCall, options, requestID)
 	title := firstNonEmpty(
@@ -373,17 +382,14 @@ func (a *ClaudeCodeSDKAdapter) claudeSDKInteractiveRequested(
 		}
 	}
 	pending := &pendingInteractiveRequest{
-		agentSessionID: strings.TrimSpace(eventSession.AgentSessionID),
-		requestID:      requestID,
-		eventID:        newID(),
-		callID:         callID,
-		callType:       callType,
-		turnID:         eventTurnID,
-		providerTurnID: firstNonEmptyString(
-			payloadString(payload, "turnId"),
-			payloadString(payload, "turnID"),
-			strings.TrimSpace(providerTurnID),
-		),
+		agentSessionID:  strings.TrimSpace(eventSession.AgentSessionID),
+		requestID:       requestID,
+		eventID:         newID(),
+		callID:          callID,
+		callType:        callType,
+		turnID:          eventTurnID,
+		providerTurnID:  strings.TrimSpace(providerTurnID),
+		transportTurnID: transportTurnID,
 		input:           input,
 		kind:            firstNonEmpty(interactivePromptKind(interactivePrompt), "approval"),
 		approvalPurpose: approvalPurpose,
@@ -419,11 +425,13 @@ func (a *ClaudeCodeSDKAdapter) claudeSDKInteractiveRequested(
 	return events, nil
 }
 
-func claudeSDKInteractiveProviderTurnID(pending *pendingInteractiveRequest) string {
+func claudeSDKInteractiveTransportTurnID(
+	pending *pendingInteractiveRequest,
+) string {
 	if pending == nil {
 		return ""
 	}
-	return firstNonEmptyString(strings.TrimSpace(pending.providerTurnID), strings.TrimSpace(pending.turnID))
+	return strings.TrimSpace(pending.transportTurnID)
 }
 
 func (a *ClaudeCodeSDKAdapter) claudeSDKInteractiveResolved(

--- a/packages/agent/daemon/runtime/claude_sdk_session_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_session_test.go
@@ -573,7 +573,7 @@ func TestClaudeCodeSDKAdapterAcceptsImagePromptContent(t *testing.T) {
 func TestClaudeCodeSDKAdapterExecSendsStructuredPromptContent(t *testing.T) {
 	conn := &scriptedClaudeSDKConnection{
 		frames: []ProcessFrame{{
-			Stdout: []byte(`{"type":"turn_completed","payload":{"turnId":"turn-image","stopReason":"end_turn"}}` + "\n"),
+			Stdout: []byte(`{"type":"provider_turn_identity_resolved","payload":{"turnId":"turn-image","providerTurnId":"provider-turn-image"}}` + "\n" + `{"type":"turn_completed","payload":{"turnId":"turn-image","providerTurnId":"provider-turn-image","stopReason":"end_turn"}}` + "\n"),
 		}},
 	}
 	adapter := NewClaudeCodeSDKAdapter(nil)

--- a/packages/agent/daemon/runtime/claude_sdk_transport_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_transport_test.go
@@ -208,8 +208,19 @@ func TestClaudeCodeSDKAdapterReaderKeepsDrainingAfterTurnTerminal(t *testing.T) 
 	}()
 	waitForClaudeSDKSentRequest(t, conn, "exec")
 	conn.pushEvent(claudeSDKSidecarEvent{
-		Type:    "turn_completed",
-		Payload: map[string]any{"turnId": "turn-background", "stopReason": "end_turn"},
+		Type: "provider_turn_identity_resolved",
+		Payload: map[string]any{
+			"turnId":         "turn-background",
+			"providerTurnId": "provider-turn-background",
+		},
+	})
+	conn.pushEvent(claudeSDKSidecarEvent{
+		Type: "turn_completed",
+		Payload: map[string]any{
+			"turnId":         "turn-background",
+			"providerTurnId": "provider-turn-background",
+			"stopReason":     "end_turn",
+		},
 	})
 	select {
 	case err := <-done:
@@ -278,8 +289,19 @@ func TestClaudeCodeSDKAdapterDropsUntrackedTurnTerminalEvent(t *testing.T) {
 	}()
 	waitForClaudeSDKSentRequest(t, conn, "exec")
 	conn.pushEvent(claudeSDKSidecarEvent{
-		Type:    "turn_completed",
-		Payload: map[string]any{"turnId": "turn-real", "stopReason": "end_turn"},
+		Type: "provider_turn_identity_resolved",
+		Payload: map[string]any{
+			"turnId":         "turn-real",
+			"providerTurnId": "provider-turn-real",
+		},
+	})
+	conn.pushEvent(claudeSDKSidecarEvent{
+		Type: "turn_completed",
+		Payload: map[string]any{
+			"turnId":         "turn-real",
+			"providerTurnId": "provider-turn-real",
+			"stopReason":     "end_turn",
+		},
 	})
 	select {
 	case err := <-done:
@@ -363,8 +385,9 @@ func TestClaudeCodeSDKAdapterClosesSyntheticTurnLifecycleWithoutExecWaiter(t *te
 	adapter.dispatchClaudeSDKEvent(session.AgentSessionID, adapterSession, claudeSDKSidecarEvent{
 		Type: "turn_completed",
 		Payload: map[string]any{
-			"turnId":     "synthetic-continuation-1",
-			"stopReason": "end_turn",
+			"turnId":         "synthetic-continuation-1",
+			"providerTurnId": "synthetic-continuation-1",
+			"stopReason":     "end_turn",
 		},
 	})
 
@@ -419,8 +442,19 @@ func TestClaudeCodeSDKAdapterRoundTripUsesReaderDispatcherAfterExec(t *testing.T
 	}()
 	waitForClaudeSDKSentRequest(t, conn, "exec")
 	conn.pushEvent(claudeSDKSidecarEvent{
-		Type:    "turn_completed",
-		Payload: map[string]any{"turnId": "turn-settings", "stopReason": "end_turn"},
+		Type: "provider_turn_identity_resolved",
+		Payload: map[string]any{
+			"turnId":         "turn-settings",
+			"providerTurnId": "provider-turn-settings",
+		},
+	})
+	conn.pushEvent(claudeSDKSidecarEvent{
+		Type: "turn_completed",
+		Payload: map[string]any{
+			"turnId":         "turn-settings",
+			"providerTurnId": "provider-turn-settings",
+			"stopReason":     "end_turn",
+		},
 	})
 	select {
 	case err := <-done:

--- a/packages/agent/daemon/runtime/claude_sdk_turn_binding.go
+++ b/packages/agent/daemon/runtime/claude_sdk_turn_binding.go
@@ -15,7 +15,7 @@ func (a *ClaudeCodeSDKAdapter) claudeSDKRootProviderTurnStartedEvent(
 ) activityshared.Event {
 	ctx, ok := activityEventContext(
 		session,
-		"claude-sdk:provider-turn-started:"+providerTurnID,
+		"root-provider-turn-started:"+providerTurnID,
 		rootTurnID,
 	)
 	if !ok {
@@ -142,6 +142,23 @@ func (a *ClaudeCodeSDKAdapter) rememberClaudeSDKRootProviderTurn(
 	}
 	adapterSession.rootProviderTurns[strings.TrimSpace(providerTurnID)] = struct{}{}
 	a.mu.Unlock()
+}
+
+func (a *ClaudeCodeSDKAdapter) activeClaudeSDKRootProviderTurnID(
+	adapterSession *claudeSDKAdapterSession,
+) string {
+	if a == nil || adapterSession == nil {
+		return ""
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if len(adapterSession.rootProviderTurns) != 1 {
+		return ""
+	}
+	for providerTurnID := range adapterSession.rootProviderTurns {
+		return strings.TrimSpace(providerTurnID)
+	}
+	return ""
 }
 
 func (a *ClaudeCodeSDKAdapter) consumeClaudeSDKRootProviderTurn(

--- a/packages/agent/daemon/runtime/codex_appserver_acceptance.go
+++ b/packages/agent/daemon/runtime/codex_appserver_acceptance.go
@@ -1,0 +1,79 @@
+package agentruntime
+
+import (
+	"errors"
+	"strings"
+)
+
+func reportCodexDispatchFailure(report ProviderDispatchSink, err error) {
+	if report == nil {
+		return
+	}
+	disposition := DispatchDispositionOutcomeUnknown
+	var callErr *acpCallError
+	if errors.As(err, &callErr) {
+		disposition = DispatchDispositionRejected
+	}
+	report(ProviderDispatchResult{Disposition: disposition})
+}
+
+func reportCodexAppliedWithoutProviderTurn(report ProviderDispatchSink) {
+	if report != nil {
+		report(ProviderDispatchResult{
+			Disposition: DispatchDispositionAppliedWithoutProviderTurn,
+		})
+	}
+}
+
+func reportCodexProviderTurnAccepted(
+	report ProviderDispatchSink,
+	providerSessionID string,
+	providerTurnID string,
+) {
+	if report == nil {
+		return
+	}
+	providerSessionID = strings.TrimSpace(providerSessionID)
+	providerTurnID = strings.TrimSpace(providerTurnID)
+	if providerSessionID == "" || providerTurnID == "" {
+		report(ProviderDispatchResult{
+			Disposition: DispatchDispositionOutcomeUnknown,
+		})
+		return
+	}
+	report(ProviderDispatchResult{
+		Disposition: DispatchDispositionApplied,
+		Acceptance: &ProviderAcceptanceReceipt{
+			Source:            AcceptanceSourceTurnStartResponse,
+			ProviderSessionID: providerSessionID,
+			ProviderTurnID:    providerTurnID,
+		},
+	})
+}
+
+func (options codexTurnExecOptions) confirmProviderTurnAcceptance(
+	providerSessionID string,
+	providerTurnID string,
+) error {
+	if options.acceptProviderTurn == nil {
+		reportCodexProviderTurnAccepted(
+			options.reportDispatch,
+			providerSessionID,
+			providerTurnID,
+		)
+		return nil
+	}
+	providerSessionID = strings.TrimSpace(providerSessionID)
+	providerTurnID = strings.TrimSpace(providerTurnID)
+	if providerSessionID == "" || providerTurnID == "" {
+		options.report(ProviderDispatchResult{
+			Disposition: DispatchDispositionOutcomeUnknown,
+		})
+		return errors.New("codex provider turn acceptance omitted identity")
+	}
+	return options.acceptProviderTurn(ProviderAcceptanceReceipt{
+		Source:            AcceptanceSourceTurnStartResponse,
+		ProviderSessionID: providerSessionID,
+		ProviderTurnID:    providerTurnID,
+	})
+}

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_goal_lifecycle_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_goal_lifecycle_test.go
@@ -612,6 +612,7 @@ func TestCodexAppServerAdapterMidTurnGoalClearDoesNotSteer(t *testing.T) {
 		nil,
 		nil,
 		func(result ProviderDispatchResult) { dispatches <- result },
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("Exec /goal clear: %v", err)

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_guidance_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_guidance_test.go
@@ -40,6 +40,7 @@ func TestCodexAppServerAdapterExecSteersActiveTurn(t *testing.T) {
 		nil,
 		nil,
 		func(result ProviderDispatchResult) { dispatches <- result },
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("steer Exec: %v", err)

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_review_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_review_test.go
@@ -23,6 +23,7 @@ func TestCodexAppServerAdapterSlashCompact(t *testing.T) {
 		nil,
 		nil,
 		func(result ProviderDispatchResult) { dispatches <- result },
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("Exec: %v", err)
@@ -133,6 +134,13 @@ func TestCodexAppServerAdapterSlashReview(t *testing.T) {
 		nil,
 		nil,
 		func(result ProviderDispatchResult) { dispatches <- result },
+		func(receipt ProviderAcceptanceReceipt) error {
+			dispatches <- ProviderDispatchResult{
+				Disposition: DispatchDispositionApplied,
+				Acceptance:  &receipt,
+			}
+			return nil
+		},
 	)
 	if err != nil {
 		t.Fatalf("Exec: %v", err)

--- a/packages/agent/daemon/runtime/codex_appserver_async.go
+++ b/packages/agent/daemon/runtime/codex_appserver_async.go
@@ -1,0 +1,129 @@
+package agentruntime
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+)
+
+type codexGuidanceContinuationAdmission struct {
+	providerTurnID     string
+	admitted           chan error
+	provisionalStarted chan struct{}
+}
+
+func newCodexGuidanceContinuationAdmission(providerTurnID string) *codexGuidanceContinuationAdmission {
+	return &codexGuidanceContinuationAdmission{
+		providerTurnID:     providerTurnID,
+		admitted:           make(chan error, 1),
+		provisionalStarted: make(chan struct{}),
+	}
+}
+
+func (a *codexGuidanceContinuationAdmission) published() bool {
+	if a == nil {
+		return false
+	}
+	select {
+	case <-a.provisionalStarted:
+		return true
+	default:
+		return false
+	}
+}
+
+func (a *CodexAppServerAdapter) execAsync(
+	ctx context.Context,
+	session Session,
+	content []PromptContentBlock,
+	displayPrompt string,
+	turnID string,
+	emit EventSink,
+	emitCommands CommandSnapshotSink,
+	continuation *codexGuidanceContinuationAdmission,
+) error {
+	go func() {
+		events, err := a.execBlocking(
+			ctx,
+			session,
+			content,
+			displayPrompt,
+			turnID,
+			emit,
+			emitCommands,
+			codexTurnExecOptions{continuation: continuation},
+		)
+		if continuation != nil && !continuation.published() {
+			return
+		}
+		if emit == nil {
+			return
+		}
+		outcome := codexAsyncTerminalOutcome(events, err)
+		terminalEvents := make([]activityshared.Event, 0, 2)
+		if continuation != nil &&
+			!codexAsyncProviderLifecycleSupersedes(events, continuation.providerTurnID) {
+			metadata := map[string]any{
+				"guidanceContinuation": true,
+				"providerTurnStarted":  false,
+			}
+			if err != nil {
+				metadata["error"] = err.Error()
+			}
+			terminalEvents = append(terminalEvents, appServerRootProviderTurnCompletedEvent(
+				session,
+				turnID,
+				continuation.providerTurnID,
+				outcome,
+				metadata,
+			))
+		}
+		if err != nil {
+			if outcome == activityshared.TurnOutcomeCanceled {
+				terminalEvents = append(terminalEvents, newTurnActivityEvent(session, EventTurnCanceled, turnID, SessionStatusCanceled, "", "", map[string]any{
+					"error": err.Error(),
+				}))
+			} else {
+				terminalEvents = append(terminalEvents, newTurnActivityEvent(session, EventTurnFailed, turnID, SessionStatusFailed, "", "", acpFailureMetadata(err)))
+			}
+		}
+		if len(terminalEvents) > 0 {
+			emit(terminalEvents)
+		}
+	}()
+	return nil
+}
+
+func codexAsyncProviderLifecycleSupersedes(events []activityshared.Event, provisionalProviderTurnID string) bool {
+	for _, event := range events {
+		if event.Type != activityshared.EventRootProviderTurnStarted &&
+			event.Type != activityshared.EventRootProviderTurnCompleted {
+			continue
+		}
+		providerTurnID := strings.TrimSpace(event.Payload.ProviderTurnID)
+		if providerTurnID != "" && providerTurnID != provisionalProviderTurnID {
+			return true
+		}
+	}
+	return false
+}
+
+func codexAsyncTerminalOutcome(events []activityshared.Event, err error) activityshared.TurnOutcome {
+	if errors.Is(err, context.Canceled) {
+		return activityshared.TurnOutcomeCanceled
+	}
+	for _, event := range events {
+		switch event.Type {
+		case activityshared.EventTurnCanceled:
+			return activityshared.TurnOutcomeCanceled
+		case activityshared.EventTurnFailed:
+			return activityshared.TurnOutcomeFailed
+		}
+	}
+	if err != nil {
+		return activityshared.TurnOutcomeFailed
+	}
+	return activityshared.TurnOutcomeCompleted
+}

--- a/packages/agent/daemon/runtime/codex_appserver_goal.go
+++ b/packages/agent/daemon/runtime/codex_appserver_goal.go
@@ -330,6 +330,8 @@ func (a *CodexAppServerAdapter) execSlashCommand(
 	emitTerminal func([]activityshared.Event),
 	emitCommands CommandSnapshotSink,
 	reportDispatch ProviderDispatchSink,
+	admitProviderTurn func(string) error,
+	admitWithoutProviderTurn func(),
 ) (bool, error) {
 	command, args := splitSlashCommand(displayPrompt)
 	switch command {
@@ -358,7 +360,7 @@ func (a *CodexAppServerAdapter) execSlashCommand(
 			))
 			return true, nil
 		}
-		reportCodexAppliedWithoutProviderTurn(reportDispatch)
+		admitWithoutProviderTurn()
 		// Block until the App Server signals turn/completed. The session-level
 		// handler keeps activeTurn alive during this wait, so the
 		// contextCompaction item/completed notification fires appServerItemEvents
@@ -430,13 +432,11 @@ func (a *CodexAppServerAdapter) execSlashCommand(
 		}
 		if goalDrivesTurn {
 			initialTurn := appServerTurnFromResult(result)
-			reportCodexProviderTurnAccepted(
-				reportDispatch,
-				appSession.threadID,
-				asString(initialTurn["id"]),
-			)
+			if err := admitProviderTurn(asString(initialTurn["id"])); err != nil {
+				return true, err
+			}
 		} else {
-			reportCodexAppliedWithoutProviderTurn(reportDispatch)
+			admitWithoutProviderTurn()
 		}
 		if method == appServerMethodThreadGoalClear {
 			a.applyGoalClear(session.AgentSessionID)
@@ -512,7 +512,20 @@ func (a *CodexAppServerAdapter) execSlashCommand(
 		emitTerminal(terminalEvents)
 		return true, nil
 	case appServerSlashReview:
-		return a.execReviewSlashCommand(ctx, appSession, session, args, turnID, appTurn, normalizer, emitEvents, emitTerminal, emitCommands, reportDispatch)
+		return a.execReviewSlashCommand(
+			ctx,
+			appSession,
+			session,
+			args,
+			turnID,
+			appTurn,
+			normalizer,
+			emitEvents,
+			emitTerminal,
+			emitCommands,
+			reportDispatch,
+			admitProviderTurn,
+		)
 	case appServerSlashUndo:
 		_, err := appSession.client.ThreadRollback(ctx, map[string]any{
 			"threadId": appSession.threadID,
@@ -523,7 +536,7 @@ func (a *CodexAppServerAdapter) execSlashCommand(
 			emitTerminal([]activityshared.Event{newTurnActivityEvent(session, EventTurnFailed, turnID, SessionStatusFailed, "", "", acpFailureMetadata(err))})
 			return true, nil
 		}
-		reportCodexAppliedWithoutProviderTurn(reportDispatch)
+		admitWithoutProviderTurn()
 		emitTerminal([]activityshared.Event{
 			appServerSystemNoticeEvent(session, turnID, "system_notice", "Removed the last turn from the conversation. Local file changes are not reverted.", ""),
 			newTurnActivityEvent(session, EventTurnCompleted, turnID, SessionStatusReady, "", "", map[string]any{

--- a/packages/agent/daemon/runtime/codex_appserver_review.go
+++ b/packages/agent/daemon/runtime/codex_appserver_review.go
@@ -89,6 +89,7 @@ func (a *CodexAppServerAdapter) execReviewSlashCommand(
 	emitTerminal func([]activityshared.Event),
 	emitCommands CommandSnapshotSink,
 	reportDispatch ProviderDispatchSink,
+	admitProviderTurn func(string) error,
 ) (bool, error) {
 	normalizer.SetThinkingPresentation("review-process")
 	params := map[string]any{
@@ -122,11 +123,9 @@ func (a *CodexAppServerAdapter) execReviewSlashCommand(
 	if providerTurnID := asString(initialTurn["id"]); providerTurnID != "" {
 		a.setSessionActiveTurnID(session.AgentSessionID, appTurn, providerTurnID)
 	}
-	reportCodexProviderTurnAccepted(
-		reportDispatch,
-		appSession.threadID,
-		asString(initialTurn["id"]),
-	)
+	if err := admitProviderTurn(asString(initialTurn["id"])); err != nil {
+		return true, err
+	}
 	finalTurn, finishErr := a.awaitTurnCompletion(ctx, appSession, appTurn, initialTurn)
 	if finishErr != nil {
 		if errors.Is(finishErr, context.Canceled) || errors.Is(finishErr, errPermissionRequestCanceled) {

--- a/packages/agent/daemon/runtime/codex_appserver_turn.go
+++ b/packages/agent/daemon/runtime/codex_appserver_turn.go
@@ -41,6 +41,7 @@ func (a *CodexAppServerAdapter) ExecWithProviderAcceptance(
 	emit EventSink,
 	emitCommands CommandSnapshotSink,
 	reportDispatch ProviderDispatchSink,
+	acceptProviderTurn ProviderAcceptanceBarrier,
 ) ([]activityshared.Event, error) {
 	return a.execBlocking(
 		ctx,
@@ -50,7 +51,10 @@ func (a *CodexAppServerAdapter) ExecWithProviderAcceptance(
 		turnID,
 		emit,
 		emitCommands,
-		codexTurnExecOptions{reportDispatch: reportDispatch},
+		codexTurnExecOptions{
+			reportDispatch:     reportDispatch,
+			acceptProviderTurn: acceptProviderTurn,
+		},
 	)
 }
 
@@ -64,126 +68,6 @@ func (a *CodexAppServerAdapter) ExecAsync(
 	emitCommands CommandSnapshotSink,
 ) error {
 	return a.execAsync(ctx, session, content, displayPrompt, turnID, emit, emitCommands, nil)
-}
-
-type codexGuidanceContinuationAdmission struct {
-	providerTurnID     string
-	admitted           chan error
-	provisionalStarted chan struct{}
-}
-
-func newCodexGuidanceContinuationAdmission(providerTurnID string) *codexGuidanceContinuationAdmission {
-	return &codexGuidanceContinuationAdmission{
-		providerTurnID:     providerTurnID,
-		admitted:           make(chan error, 1),
-		provisionalStarted: make(chan struct{}),
-	}
-}
-
-func (a *codexGuidanceContinuationAdmission) published() bool {
-	if a == nil {
-		return false
-	}
-	select {
-	case <-a.provisionalStarted:
-		return true
-	default:
-		return false
-	}
-}
-
-func (a *CodexAppServerAdapter) execAsync(
-	ctx context.Context,
-	session Session,
-	content []PromptContentBlock,
-	displayPrompt string,
-	turnID string,
-	emit EventSink,
-	emitCommands CommandSnapshotSink,
-	continuation *codexGuidanceContinuationAdmission,
-) error {
-	go func() {
-		events, err := a.execBlocking(
-			ctx,
-			session,
-			content,
-			displayPrompt,
-			turnID,
-			emit,
-			emitCommands,
-			codexTurnExecOptions{continuation: continuation},
-		)
-		if continuation != nil && !continuation.published() {
-			return
-		}
-		if emit == nil {
-			return
-		}
-		outcome := codexAsyncTerminalOutcome(events, err)
-		terminalEvents := make([]activityshared.Event, 0, 2)
-		if continuation != nil &&
-			!codexAsyncProviderLifecycleSupersedes(events, continuation.providerTurnID) {
-			metadata := map[string]any{
-				"guidanceContinuation": true,
-				"providerTurnStarted":  false,
-			}
-			if err != nil {
-				metadata["error"] = err.Error()
-			}
-			terminalEvents = append(terminalEvents, appServerRootProviderTurnCompletedEvent(
-				session,
-				turnID,
-				continuation.providerTurnID,
-				outcome,
-				metadata,
-			))
-		}
-		if err != nil {
-			if outcome == activityshared.TurnOutcomeCanceled {
-				terminalEvents = append(terminalEvents, newTurnActivityEvent(session, EventTurnCanceled, turnID, SessionStatusCanceled, "", "", map[string]any{
-					"error": err.Error(),
-				}))
-			} else {
-				terminalEvents = append(terminalEvents, newTurnActivityEvent(session, EventTurnFailed, turnID, SessionStatusFailed, "", "", acpFailureMetadata(err)))
-			}
-		}
-		if len(terminalEvents) > 0 {
-			emit(terminalEvents)
-		}
-	}()
-	return nil
-}
-
-func codexAsyncProviderLifecycleSupersedes(events []activityshared.Event, provisionalProviderTurnID string) bool {
-	for _, event := range events {
-		if event.Type != activityshared.EventRootProviderTurnStarted &&
-			event.Type != activityshared.EventRootProviderTurnCompleted {
-			continue
-		}
-		providerTurnID := strings.TrimSpace(event.Payload.ProviderTurnID)
-		if providerTurnID != "" && providerTurnID != provisionalProviderTurnID {
-			return true
-		}
-	}
-	return false
-}
-
-func codexAsyncTerminalOutcome(events []activityshared.Event, err error) activityshared.TurnOutcome {
-	if errors.Is(err, context.Canceled) {
-		return activityshared.TurnOutcomeCanceled
-	}
-	for _, event := range events {
-		switch event.Type {
-		case activityshared.EventTurnCanceled:
-			return activityshared.TurnOutcomeCanceled
-		case activityshared.EventTurnFailed:
-			return activityshared.TurnOutcomeFailed
-		}
-	}
-	if err != nil {
-		return activityshared.TurnOutcomeFailed
-	}
-	return activityshared.TurnOutcomeCompleted
 }
 
 func (a *CodexAppServerAdapter) ExecHistoryReplacement(
@@ -212,6 +96,7 @@ func (a *CodexAppServerAdapter) ExecHistoryReplacement(
 type codexTurnExecOptions struct {
 	historyReplacement bool
 	reportDispatch     ProviderDispatchSink
+	acceptProviderTurn ProviderAcceptanceBarrier
 	continuation       *codexGuidanceContinuationAdmission
 }
 
@@ -219,52 +104,6 @@ func (options codexTurnExecOptions) report(result ProviderDispatchResult) {
 	if options.reportDispatch != nil {
 		options.reportDispatch(result)
 	}
-}
-
-func reportCodexDispatchFailure(report ProviderDispatchSink, err error) {
-	if report == nil {
-		return
-	}
-	disposition := DispatchDispositionOutcomeUnknown
-	var callErr *acpCallError
-	if errors.As(err, &callErr) {
-		disposition = DispatchDispositionRejected
-	}
-	report(ProviderDispatchResult{Disposition: disposition})
-}
-
-func reportCodexAppliedWithoutProviderTurn(report ProviderDispatchSink) {
-	if report != nil {
-		report(ProviderDispatchResult{
-			Disposition: DispatchDispositionAppliedWithoutProviderTurn,
-		})
-	}
-}
-
-func reportCodexProviderTurnAccepted(
-	report ProviderDispatchSink,
-	providerSessionID string,
-	providerTurnID string,
-) {
-	if report == nil {
-		return
-	}
-	providerSessionID = strings.TrimSpace(providerSessionID)
-	providerTurnID = strings.TrimSpace(providerTurnID)
-	if providerSessionID == "" || providerTurnID == "" {
-		report(ProviderDispatchResult{
-			Disposition: DispatchDispositionOutcomeUnknown,
-		})
-		return
-	}
-	report(ProviderDispatchResult{
-		Disposition: DispatchDispositionApplied,
-		Acceptance: &ProviderAcceptanceReceipt{
-			Source:            AcceptanceSourceTurnStartResponse,
-			ProviderSessionID: providerSessionID,
-			ProviderTurnID:    providerTurnID,
-		},
-	})
 }
 
 func (a *CodexAppServerAdapter) GuideActiveTurn(
@@ -557,12 +396,21 @@ func (a *CodexAppServerAdapter) execBlocking(
 	var eventsMu sync.Mutex
 	var events []activityshared.Event
 	turnClosed := false
+	providerAccepted := options.acceptProviderTurn == nil
+	var pendingProviderEvents []activityshared.Event
 	emitLocked := func(next []activityshared.Event) {
 		next = a.stampTurnLifecycleSnapshots(session.AgentSessionID, next)
 		events = append(events, next...)
 		if emit != nil {
 			emit(next)
 		}
+	}
+	emitProviderLocked := func(next []activityshared.Event) {
+		if !providerAccepted {
+			pendingProviderEvents = append(pendingProviderEvents, next...)
+			return
+		}
+		emitLocked(next)
 	}
 	emitEvents := func(next []activityshared.Event) {
 		if len(next) == 0 {
@@ -573,7 +421,7 @@ func (a *CodexAppServerAdapter) execBlocking(
 		if turnClosed {
 			return
 		}
-		emitLocked(next)
+		emitProviderLocked(next)
 	}
 	emitTerminal := func(next []activityshared.Event) {
 		eventsMu.Lock()
@@ -583,8 +431,25 @@ func (a *CodexAppServerAdapter) execBlocking(
 		}
 		turnClosed = true
 		if len(next) > 0 {
-			emitLocked(next)
+			emitProviderLocked(next)
 		}
+	}
+	releaseProviderEvents := func() {
+		eventsMu.Lock()
+		defer eventsMu.Unlock()
+		if providerAccepted {
+			return
+		}
+		providerAccepted = true
+		if len(pendingProviderEvents) > 0 {
+			emitLocked(pendingProviderEvents)
+			pendingProviderEvents = nil
+		}
+	}
+	discardProviderEvents := func() {
+		eventsMu.Lock()
+		defer eventsMu.Unlock()
+		pendingProviderEvents = nil
 	}
 	snapshotEvents := func() []activityshared.Event {
 		eventsMu.Lock()
@@ -610,6 +475,27 @@ func (a *CodexAppServerAdapter) execBlocking(
 		terminated:   make(chan struct{}),
 	}
 	appTurn.emitTerminal = emitTerminal
+	admitProviderTurn := func(providerTurnID string) error {
+		if err := options.confirmProviderTurnAcceptance(appSession.threadID, providerTurnID); err != nil {
+			discardProviderEvents()
+			if providerTurnID != "" {
+				a.interruptActiveTurnAsync(
+					appSession,
+					session,
+					appTurn,
+					providerTurnID,
+					"durable acceptance failed",
+				)
+			}
+			return err
+		}
+		releaseProviderEvents()
+		return nil
+	}
+	admitWithoutProviderTurn := func() {
+		reportCodexAppliedWithoutProviderTurn(options.reportDispatch)
+		releaseProviderEvents()
+	}
 	// Signal turn termination once this goroutine returns (after terminal events
 	// are emitted), so a concurrent Cancel only responds after the turn stopped.
 	// The settle path may finalize first; the Once keeps the close single.
@@ -626,10 +512,26 @@ func (a *CodexAppServerAdapter) execBlocking(
 		continuation.admitted <- nil
 		<-continuation.provisionalStarted
 	}
-	emitEvents(startEvents)
+	eventsMu.Lock()
+	emitLocked(startEvents)
+	eventsMu.Unlock()
 
 	if !options.historyReplacement {
-		if handled, err := a.execSlashCommand(ctx, appSession, session, visibleText, turnID, appTurn, normalizer, emitEvents, emitTerminal, emitCommands, options.reportDispatch); handled {
+		if handled, err := a.execSlashCommand(
+			ctx,
+			appSession,
+			session,
+			visibleText,
+			turnID,
+			appTurn,
+			normalizer,
+			emitEvents,
+			emitTerminal,
+			emitCommands,
+			options.reportDispatch,
+			admitProviderTurn,
+			admitWithoutProviderTurn,
+		); handled {
 			return snapshotEvents(), err
 		}
 	}
@@ -733,9 +635,15 @@ func (a *CodexAppServerAdapter) execBlocking(
 		if a.setSessionActiveTurnID(session.AgentSessionID, appTurn, providerTurnID) {
 			a.interruptActiveTurnAsync(appSession, session, appTurn, providerTurnID, "queued cancel")
 		}
-		reportCodexProviderTurnAccepted(options.reportDispatch, appSession.threadID, providerTurnID)
+		if err := admitProviderTurn(providerTurnID); err != nil {
+			a.endActiveTurn(session.AgentSessionID, appTurn)
+			return snapshotEvents(), err
+		}
 	} else {
-		reportCodexProviderTurnAccepted(options.reportDispatch, appSession.threadID, "")
+		if err := admitProviderTurn(""); err != nil {
+			a.endActiveTurn(session.AgentSessionID, appTurn)
+			return snapshotEvents(), err
+		}
 	}
 	go a.watchTurnExternalTermination(appSession, appTurn)
 	finalTurn, finishErr := a.awaitTurnCompletion(ctx, appSession, appTurn, initialTurn)

--- a/packages/agent/daemon/runtime/controller_dispatch.go
+++ b/packages/agent/daemon/runtime/controller_dispatch.go
@@ -11,19 +11,33 @@ import (
 
 type providerDispatchObserver struct {
 	once   sync.Once
-	result chan ProviderDispatchResult
+	result chan providerDispatchObservation
+}
+
+type providerDispatchObservation struct {
+	dispatch ProviderDispatchResult
+	err      error
 }
 
 func newProviderDispatchObserver() *providerDispatchObserver {
-	return &providerDispatchObserver{result: make(chan ProviderDispatchResult, 1)}
+	return &providerDispatchObserver{
+		result: make(chan providerDispatchObservation, 1),
+	}
 }
 
 func (observer *providerDispatchObserver) Report(result ProviderDispatchResult) {
+	observer.ReportWithError(result, nil)
+}
+
+func (observer *providerDispatchObserver) ReportWithError(result ProviderDispatchResult, err error) {
 	if observer == nil {
 		return
 	}
 	observer.once.Do(func() {
-		observer.result <- result
+		observer.result <- providerDispatchObservation{
+			dispatch: result,
+			err:      err,
+		}
 		close(observer.result)
 	})
 }

--- a/packages/agent/daemon/runtime/controller_exec.go
+++ b/packages/agent/daemon/runtime/controller_exec.go
@@ -198,6 +198,25 @@ func (c *Controller) Exec(ctx context.Context, input ExecInput) (result ExecResu
 			dispatchObserver.Report,
 		)
 	} else if acceptanceAdapter != nil {
+		acceptProviderTurn := func(receipt ProviderAcceptanceReceipt) error {
+			dispatch := ProviderDispatchResult{
+				Disposition: DispatchDispositionApplied,
+				Acceptance:  &receipt,
+			}
+			confirmed, confirmErr := c.confirmProviderDispatchDurable(
+				// Provider acceptance persistence must finish even when the
+				// caller concurrently cancels the submitted request.
+				context.WithoutCancel(runCtx),
+				session,
+				turnID,
+				dispatch,
+			)
+			dispatchObserver.ReportWithError(confirmed, confirmErr)
+			if confirmErr != nil {
+				cancel()
+			}
+			return confirmErr
+		}
 		go c.runProviderAcceptanceTurn(
 			runCtx,
 			session,
@@ -206,6 +225,7 @@ func (c *Controller) Exec(ctx context.Context, input ExecInput) (result ExecResu
 			displayPrompt,
 			turnID,
 			dispatchObserver.Report,
+			acceptProviderTurn,
 		)
 	} else {
 		go c.runExecTurn(runCtx, session, adapter, content, displayPrompt, turnID)
@@ -229,15 +249,19 @@ func (c *Controller) Exec(ctx context.Context, input ExecInput) (result ExecResu
 		return result, nil
 	}
 	select {
-	case dispatch := <-dispatchObserver.result:
-		dispatch, confirmErr := c.confirmProviderDispatchDurable(
-			// Once the provider has positively accepted a Turn, user
-			// cancellation must not abort persistence of that identity.
-			context.WithoutCancel(runCtx),
-			session,
-			turnID,
-			dispatch,
-		)
+	case observation := <-dispatchObserver.result:
+		dispatch := observation.dispatch
+		confirmErr := observation.err
+		if acceptanceAdapter == nil {
+			dispatch, confirmErr = c.confirmProviderDispatchDurable(
+				// Once the provider has positively accepted a Turn, user
+				// cancellation must not abort persistence of that identity.
+				context.WithoutCancel(runCtx),
+				session,
+				turnID,
+				dispatch,
+			)
+		}
 		result.ProviderDispatch = &dispatch
 		if confirmErr != nil {
 			return result, confirmErr

--- a/packages/agent/daemon/runtime/controller_turn_exec.go
+++ b/packages/agent/daemon/runtime/controller_turn_exec.go
@@ -94,6 +94,7 @@ func (c *Controller) runProviderAcceptanceTurn(
 	displayPrompt string,
 	turnID string,
 	reportDispatch ProviderDispatchSink,
+	acceptProviderTurn ProviderAcceptanceBarrier,
 ) {
 	c.runBlockingExecTurn(ctx, session, adapter, turnID, func(
 		emit EventSink,
@@ -108,6 +109,7 @@ func (c *Controller) runProviderAcceptanceTurn(
 			emit,
 			emitCommands,
 			reportDispatch,
+			acceptProviderTurn,
 		)
 		if reportDispatch != nil {
 			reportDispatch(ProviderDispatchResult{

--- a/packages/agent/daemon/runtime/interactive_request_state.go
+++ b/packages/agent/daemon/runtime/interactive_request_state.go
@@ -15,8 +15,11 @@ type pendingInteractiveRequest struct {
 	callID         string
 	callType       string
 	turnID         string
-	// providerTurnID is transport correlation; turnID remains canonical ownership.
+	// turnID is canonical ownership. providerTurnID is the authoritative
+	// provider lifecycle identity; transportTurnID is adapter-private
+	// correlation used only when replying to the originating request.
 	providerTurnID  string
+	transportTurnID string
 	input           map[string]any
 	kind            string
 	approvalPurpose string

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -46,6 +46,17 @@ Session and operation; an in-progress or failed operation returns its existing
 state instead of starting another provider Session. This preflight is durable
 across Host process restarts and does not depend on the runtime's in-memory
 Session registry.
+
+Provider Turn acceptance is a cross-process barrier, not a generic lifecycle
+notification. The runtime may move through `queued`, `dispatched`,
+`provider_observed`, and `resolving_identity`, but it must not expose provider
+output or interaction until the exact provider identity has been resolved. The
+adapter then blocks its provider event path while the Host atomically persists
+`canonicalTurnId + providerSessionId + providerTurnId`; only that commit moves
+the Turn to `durably_accepted`. Streaming, waiting for approval/input, running
+tools, checkpoints, and terminal events all follow the barrier and retain the
+same authoritative provider Turn ID. Correlation IDs are never provider IDs.
+
 Adapters must carry the structured action/objective instead of reconstructing
 it from presentation text. `ParseTypedGoalControl` remains the compatibility
 path for callers that still send `/goal ...` as initial content. Resume

--- a/packages/agent/host/conformance/coordinator_scenarios.go
+++ b/packages/agent/host/conformance/coordinator_scenarios.go
@@ -2,6 +2,7 @@ package conformance
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
@@ -55,7 +56,12 @@ func runPlanDecision(ctx context.Context, driver Driver) error {
 
 func runRecoveryOrder(ctx context.Context, driver Driver) error {
 	fixture := liveSessionFixture("session-recovery", "turn-recovery")
-	fixture.Turn = &TurnSeed{TurnID: "turn-recovery", Phase: canonical.TurnPhaseWaiting}
+	fixture.Turn = &TurnSeed{
+		TurnID:                  "turn-recovery",
+		Phase:                   canonical.TurnPhaseWaiting,
+		RootProviderTurnID:      "provider-turn-recovery",
+		ProviderTurnBindingJSON: json.RawMessage(`{"schemaVersion":1}`),
+	}
 	fixture.Interaction = &InteractionSeed{
 		RequestID: "request-recovery", TurnID: "turn-recovery",
 		Kind: canonical.InteractionKindApproval, Status: canonical.InteractionStatusPending,
@@ -67,7 +73,14 @@ func runRecoveryOrder(ctx context.Context, driver Driver) error {
 	if err := driver.Recover(ctx); err != nil {
 		return fmt.Errorf("recover host: %w", err)
 	}
-	steps := driver.Metrics().RecoverySteps
+	metrics := driver.Metrics()
+	if metrics.ExecCalls != 0 {
+		return fmt.Errorf(
+			"accepted incomplete turn was re-dispatched during recovery: exec calls=%d",
+			metrics.ExecCalls,
+		)
+	}
+	steps := metrics.RecoverySteps
 	want := []string{"runtime_requeue", "runtime_complete", "goal_requeue", "goal_inbox_requeue", "stale_settle", "worktree_sweep"}
 	if len(steps) != len(want) {
 		return fmt.Errorf("recovery steps=%v, want %v", steps, want)

--- a/services/tuttid/agent_runtime_adapter_test.go
+++ b/services/tuttid/agent_runtime_adapter_test.go
@@ -98,17 +98,17 @@ func (a *providerAcceptanceMappingTestAdapter) ExecWithProviderAcceptance(
 	_ string,
 	_ agentruntime.EventSink,
 	_ agentruntime.CommandSnapshotSink,
-	report agentruntime.ProviderDispatchSink,
+	_ agentruntime.ProviderDispatchSink,
+	acceptProviderTurn agentruntime.ProviderAcceptanceBarrier,
 ) ([]activityshared.Event, error) {
 	a.acceptanceExecCalls++
-	report(agentruntime.ProviderDispatchResult{
-		Disposition: agentruntime.DispatchDispositionApplied,
-		Acceptance: &agentruntime.ProviderAcceptanceReceipt{
-			Source:            agentruntime.AcceptanceSourceTurnStartResponse,
-			ProviderSessionID: "provider-session-1",
-			ProviderTurnID:    "provider-turn-1",
-		},
-	})
+	if err := acceptProviderTurn(agentruntime.ProviderAcceptanceReceipt{
+		Source:            agentruntime.AcceptanceSourceTurnStartResponse,
+		ProviderSessionID: "provider-session-1",
+		ProviderTurnID:    "provider-turn-1",
+	}); err != nil {
+		return nil, err
+	}
 	return nil, nil
 }
 


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Verification

<!-- Commands run, manual checks, or why verification is not applicable. -->

## Fallback Three Questions

<!--
Required when this change adds a timer, retry, cache, or defensive branch;
delete otherwise.

- Source: which event or state does this fallback compensate for?
- Why can it not be fixed at that source?
- Removal condition: when can this fallback be deleted?
-->

## Checklist

- [ ] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter.
- [ ] I kept the change focused on one concern.
- [ ] I updated documentation when behavior, setup, or contributor workflow changed.
- [ ] I updated all README/CONTRIBUTING language variants when changing their English source.
- [ ] I ran the lowest meaningful local checks for the changed surface.
- [ ] My commits are signed off with DCO when required: `git commit -s`.
