### PR TITLE
fix(agent): emit goal mutations for runtime reports

### DIFF
--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -199,6 +199,13 @@ message. Host passes it to both runtime execution and durable submit-provenance
 reporting; adapters must derive the same message sequence from that occurrence
 regardless of which report reaches storage first. `ClientSubmitID` identifies
 the submission but is not itself an ordering value.
+Accepted runtime Session reports reconcile their Goal snapshot through the
+canonical bottom-up observation path without overwriting a newer desired
+intent. When that changes the public Goal projection, the same transaction
+emits a `goal_state` mutation; timestamp- or evidence-only refreshes remain
+silent. A matching applied observation may also complete the pending Goal
+operation in that transaction. Consumers use these post-commit facts only as
+wake hints and reread canonical Goal state.
 For a user Turn, runtime acceptance is not complete until the provider returns
 its exact Turn identity and the activity reporter durably installs
 `canonicalTurnId -> providerSessionId + providerTurnId`. The direct acceptance

--- a/packages/agent/store-sqlite/activity.go
+++ b/packages/agent/store-sqlite/activity.go
@@ -79,6 +79,10 @@ func (s *Store) ReportActivityState(
 	if input.Session.OccurredAtUnixMS <= 0 {
 		input.Session.OccurredAtUnixMS = now
 	}
+	goalBefore, err := readSessionGoalProjectionTx(ctx, tx, input.Session)
+	if err != nil {
+		return ActivityStateReportResult{}, err
+	}
 	accepted, stateApplied, lastEventUnixMS, session, err := s.upsertAgentSessionTx(ctx, tx, input.Session, now)
 	if err != nil {
 		return ActivityStateReportResult{}, err
@@ -165,6 +169,11 @@ func (s *Store) ReportActivityState(
 		}
 	}
 	mutations := activityStateMutations(result)
+	goalMutations, err := sessionGoalMutationsTx(ctx, tx, input.Session, goalBefore)
+	if err != nil {
+		return ActivityStateReportResult{}, err
+	}
+	mutations = append(mutations, goalMutations...)
 	delta, err := s.commitTransaction(ctx, tx, workspaceID, mutations)
 	if err != nil {
 		return ActivityStateReportResult{}, fmt.Errorf("commit workspace agent activity state report: %w", err)

--- a/packages/agent/store-sqlite/activity_transaction.go
+++ b/packages/agent/store-sqlite/activity_transaction.go
@@ -24,6 +24,10 @@ func (s *Store) upsertAgentSession(
 			_ = tx.Rollback()
 		}
 	}()
+	goalBefore, err := readSessionGoalProjectionTx(ctx, tx, input)
+	if err != nil {
+		return false, false, 0, Session{}, err
+	}
 	accepted, stateApplied, lastEventUnixMS, session, err := s.upsertAgentSessionTx(ctx, tx, input, now)
 	if err != nil {
 		return false, false, 0, Session{}, err
@@ -32,6 +36,11 @@ func (s *Store) upsertAgentSession(
 	if accepted {
 		mutations = append(mutations, transactionMutation(input.WorkspaceID, input.AgentSessionID, MutationEntitySession, input.AgentSessionID, "upsert", session.UpdatedAtUnixMS))
 	}
+	goalMutations, err := sessionGoalMutationsTx(ctx, tx, input, goalBefore)
+	if err != nil {
+		return false, false, 0, Session{}, err
+	}
+	mutations = append(mutations, goalMutations...)
 	delta, err := s.commitTransaction(ctx, tx, input.WorkspaceID, mutations)
 	if err != nil {
 		return false, false, 0, Session{}, fmt.Errorf("commit workspace agent session state report: %w", err)

--- a/packages/agent/store-sqlite/goal_session_report_mutations.go
+++ b/packages/agent/store-sqlite/goal_session_report_mutations.go
@@ -1,0 +1,105 @@
+package storesqlite
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+)
+
+// sessionGoalProjection captures the public canonical Goal fields that may be
+// changed as a side effect of accepting a runtime Session report. Observation
+// timestamps and evidence remain durability/fencing details and do not wake
+// presentation consumers on their own.
+type sessionGoalProjection struct {
+	found bool
+	state SessionGoalState
+}
+
+func readSessionGoalProjectionTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	input SessionStateReport,
+) (sessionGoalProjection, error) {
+	if len(input.RuntimeContext) == 0 {
+		return sessionGoalProjection{}, nil
+	}
+	workspaceID := strings.TrimSpace(input.WorkspaceID)
+	agentSessionID := strings.TrimSpace(input.AgentSessionID)
+	if workspaceID == "" || agentSessionID == "" {
+		return sessionGoalProjection{}, nil
+	}
+	state, found, err := getSessionGoalStateTx(ctx, tx, workspaceID, agentSessionID)
+	return sessionGoalProjection{found: found, state: state}, err
+}
+
+func sessionGoalMutationsTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	input SessionStateReport,
+	before sessionGoalProjection,
+) ([]TransactionMutation, error) {
+	if len(input.RuntimeContext) == 0 {
+		return nil, nil
+	}
+	workspaceID := strings.TrimSpace(input.WorkspaceID)
+	agentSessionID := strings.TrimSpace(input.AgentSessionID)
+	afterState, afterFound, err := getSessionGoalStateTx(ctx, tx, workspaceID, agentSessionID)
+	if err != nil || !afterFound || goalProjectionEqual(before, sessionGoalProjection{found: true, state: afterState}) {
+		return nil, err
+	}
+
+	mutations := []TransactionMutation{
+		transactionMutation(
+			workspaceID,
+			agentSessionID,
+			MutationEntityGoalState,
+			agentSessionID,
+			"reconcile",
+			afterState.Revision,
+		),
+	}
+	if !before.found || before.state.PendingOperationID == "" || afterState.PendingOperationID != "" {
+		return mutations, nil
+	}
+	operation, found, err := getGoalControlOperationTx(ctx, tx, workspaceID, before.state.PendingOperationID)
+	if err != nil || !found || operation.Status != GoalOperationStatusCompleted {
+		return mutations, err
+	}
+	return append(mutations, transactionMutation(
+		workspaceID,
+		agentSessionID,
+		MutationEntityGoalOperation,
+		operation.OperationID,
+		"complete",
+		operation.UpdatedAtUnixMS,
+	)), nil
+}
+
+func goalProjectionEqual(left, right sessionGoalProjection) bool {
+	if left.found != right.found {
+		if left.found {
+			return goalProjectionEmpty(left.state)
+		}
+		return goalProjectionEmpty(right.state)
+	}
+	if !left.found {
+		return true
+	}
+	return jsonMapsEqual(left.state.Desired, right.state.Desired) &&
+		jsonMapsEqual(left.state.Observed, right.state.Observed) &&
+		left.state.Revision == right.state.Revision &&
+		left.state.Tombstoned == right.state.Tombstoned &&
+		left.state.SyncStatus == right.state.SyncStatus &&
+		left.state.PendingOperationID == right.state.PendingOperationID &&
+		left.state.LastError == right.state.LastError
+}
+
+func goalProjectionEmpty(state SessionGoalState) bool {
+	return len(state.Desired) == 0 &&
+		len(state.Observed) == 0 &&
+		state.Revision == 0 &&
+		!state.Tombstoned &&
+		(state.SyncStatus == "" || state.SyncStatus == GoalSyncStatusUnknown) &&
+		state.PendingOperationID == "" &&
+		state.LastError == ""
+}

--- a/packages/agent/store-sqlite/goal_state_test.go
+++ b/packages/agent/store-sqlite/goal_state_test.go
@@ -314,7 +314,7 @@ func TestGoalAcceptedRemainsApplyingUntilMatchingLifecycleEvidence(t *testing.T)
 	if err != nil || !changed || state.SyncStatus != GoalSyncStatusApplying || state.PendingOperationID != "goal-op-accepted" {
 		t.Fatalf("ack state=%#v changed=%v error=%v", state, changed, err)
 	}
-	if _, err := store.ReportSessionState(ctx, SessionStateReport{
+	appliedReport, err := store.ReportSessionState(ctx, SessionStateReport{
 		WorkspaceID: "ws-accepted", AgentSessionID: "session-accepted", Provider: "claude-code", OccurredAtUnixMS: 30,
 		RuntimeContext: map[string]any{
 			"goal": map[string]any{"objective": "ship it", "status": "active"},
@@ -322,9 +322,12 @@ func TestGoalAcceptedRemainsApplyingUntilMatchingLifecycleEvidence(t *testing.T)
 				"phase": "applied", "operationId": "goal-op-accepted", "revision": float64(1), "action": "set",
 			},
 		},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
+	assertParticipantMutationKinds(t, appliedReport.CommitDelta,
+		MutationEntitySession, MutationEntityGoalState, MutationEntityGoalOperation)
 	state, found, err := store.GetSessionGoalState(ctx, "ws-accepted", "session-accepted")
 	if err != nil || !found || state.SyncStatus != GoalSyncStatusSynced || state.PendingOperationID != "" {
 		t.Fatalf("applied state=%#v found=%v error=%v", state, found, err)

--- a/packages/agent/store-sqlite/transaction_participant_test.go
+++ b/packages/agent/store-sqlite/transaction_participant_test.go
@@ -78,6 +78,47 @@ func TestTransactionParticipantCommitsWithSessionTurnAndInteraction(t *testing.T
 	}
 }
 
+func TestRuntimeGoalProjectionParticipatesOnlyOnSemanticChange(t *testing.T) {
+	t.Parallel()
+	participant := &testTransactionParticipant{}
+	store := openParticipantTestStore(t, participant)
+	ctx := context.Background()
+
+	reportGoal := func(occurredAt int64, status string) TransactionDelta {
+		t.Helper()
+		result, err := store.ReportActivityState(ctx, ActivityStateReport{Session: SessionStateReport{
+			WorkspaceID: "ws-goal", AgentSessionID: "session-goal", Origin: "runtime",
+			Provider: "codex", OccurredAtUnixMS: occurredAt,
+			RuntimeContext: map[string]any{
+				"goal": map[string]any{"objective": "ship it", "status": status},
+			},
+		}})
+		if err != nil {
+			t.Fatalf("report Goal %q: %v", status, err)
+		}
+		return result.CommitDelta
+	}
+
+	active := reportGoal(100, "active")
+	assertParticipantMutationKinds(t, active, MutationEntitySession, MutationEntityGoalState)
+	completed := reportGoal(200, "complete")
+	assertParticipantMutationKinds(t, completed, MutationEntitySession, MutationEntityGoalState)
+	replayed := reportGoal(300, "complete")
+	assertParticipantMutationKinds(t, replayed, MutationEntitySession)
+	stale := reportGoal(250, "active")
+	assertParticipantMutationKinds(t, stale, MutationEntitySession)
+
+	metadataOnly, err := store.ReportActivityState(ctx, ActivityStateReport{Session: SessionStateReport{
+		WorkspaceID: "ws-goal", AgentSessionID: "session-without-goal", Origin: "runtime",
+		Provider: "codex", OccurredAtUnixMS: 100,
+		RuntimeContext: map[string]any{"providerResumeCheckpoint": "checkpoint"},
+	}})
+	if err != nil {
+		t.Fatalf("report metadata-only Session: %v", err)
+	}
+	assertParticipantMutationKinds(t, metadataOnly.CommitDelta, MutationEntitySession)
+}
+
 func TestTransactionParticipantFailureRollsBackCanonicalAndMarkerFacts(t *testing.T) {
 	t.Parallel()
 	participant := &testTransactionParticipant{fail: true}


### PR DESCRIPTION
## What changed

- derive `goal_state` mutations from accepted runtime Session reports in the same SQLite transaction
- emit `goal_operation/complete` when matching applied evidence clears a completed pending operation
- suppress timestamp-, evidence-only, duplicate, and stale Goal wakes
- document the bottom-up Goal observation commit contract

## Why

Runtime providers can update the canonical Goal projection through Session reports. Those updates were persisted, but their transaction delta only described the Session, so downstream commit observers could not wake Goal subscribers. The durable state became complete while consumers remained on the previous active projection.

## Impact and risk

This adds post-commit mutation facts only; Goal state ownership and reconciliation remain unchanged. Consumers must continue to treat mutations as lossy wake hints and reread canonical Goal state.

The main risk is excess wake traffic. Semantic comparison is limited to public Goal projection fields and explicitly ignores timestamps and evidence-only refreshes.

## Verification

- `go test ./packages/agent/store-sqlite/... -count=1`
- `go test -race ./packages/agent/store-sqlite -run 'Test(RuntimeGoalProjectionParticipatesOnlyOnSemanticChange|GoalAcceptedRemainsApplyingUntilMatchingLifecycleEvidence)' -count=10`
- `corepack pnpm check:changed`
- push-ready repository checks
- cross-repository TSH tests using a temporary Go workspace linked to this branch
