### PR TITLE
feat(agent-activity): add shared agent binding attribution

### DIFF
--- a/packages/agent/activity-replication/conformance/conformance.go
+++ b/packages/agent/activity-replication/conformance/conformance.go
@@ -108,7 +108,16 @@ type ApplyReport struct {
 type Sink interface {
 	Reset(context.Context) error
 	Apply(context.Context, activityreplication.ChangeBatch) (ApplyReport, error)
-	Lookup(context.Context, activityreplication.EntityType, activityreplication.EntityKey) (json.RawMessage, bool, error)
+	Lookup(context.Context, activityreplication.EntityType, activityreplication.EntityKey) (SinkSnapshot, bool, error)
+}
+
+// SinkSnapshot is the persisted read model observed by the sink conformance
+// harness. Scopes are explicit because acknowledgements and entity payloads
+// alone cannot prove that routing and authorization attribution was retained.
+type SinkSnapshot struct {
+	Entity       json.RawMessage
+	TargetScope  *activityreplication.TargetScope
+	SessionScope *activityreplication.SessionScope
 }
 
 type SinkStep struct {
@@ -129,7 +138,7 @@ type SnapshotExpectation struct {
 	EntityType activityreplication.EntityType
 	Key        activityreplication.EntityKey
 	Present    bool
-	Snapshot   json.RawMessage
+	Snapshot   SinkSnapshot
 }
 
 type SinkFixture struct {
@@ -178,8 +187,17 @@ func RunSink(ctx context.Context, sink Sink, fixture SinkFixture) error {
 		if found != expectation.Present {
 			return fmt.Errorf("lookup %s: found %t, want %t", expectation.EntityType, found, expectation.Present)
 		}
-		if expectation.Present && !jsonEqual(got, expectation.Snapshot) {
-			return fmt.Errorf("lookup %s: snapshot %s, want %s", expectation.EntityType, got, expectation.Snapshot)
+		if !expectation.Present {
+			continue
+		}
+		if !jsonEqual(got.Entity, expectation.Snapshot.Entity) {
+			return fmt.Errorf("lookup %s: entity snapshot %s, want %s", expectation.EntityType, got.Entity, expectation.Snapshot.Entity)
+		}
+		if !reflect.DeepEqual(got.TargetScope, expectation.Snapshot.TargetScope) {
+			return fmt.Errorf("lookup %s: target scope %#v, want %#v", expectation.EntityType, got.TargetScope, expectation.Snapshot.TargetScope)
+		}
+		if !reflect.DeepEqual(got.SessionScope, expectation.Snapshot.SessionScope) {
+			return fmt.Errorf("lookup %s: session scope %#v, want %#v", expectation.EntityType, got.SessionScope, expectation.Snapshot.SessionScope)
 		}
 	}
 	return nil

--- a/packages/agent/activity-replication/conformance/conformance_test.go
+++ b/packages/agent/activity-replication/conformance/conformance_test.go
@@ -97,9 +97,42 @@ func TestRunSinkRejectsResultThatDoesNotSummarizeAcknowledgements(t *testing.T) 
 	}
 }
 
+func TestRunSinkRejectsMissingPersistedSessionScope(t *testing.T) {
+	t.Parallel()
+
+	mutation := sessionMutation("mutation-1", "transaction-1", "title", 100)
+	acknowledgement := activityreplication.AcknowledgeApplied(mutation, 1)
+	entity, err := json.Marshal(mutation.Session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink := &scriptedSink{
+		report: ApplyReport{
+			Result:           activityreplication.ApplyResult{AcceptedCount: 1, Cursor: 1},
+			Acknowledgements: []activityreplication.MutationAcknowledgement{acknowledgement},
+		},
+		snapshot: SinkSnapshot{Entity: entity},
+		found:    true,
+	}
+	err = RunSink(context.Background(), sink, SinkFixture{
+		Name: "missing persisted session scope",
+		Steps: []SinkStep{{
+			Name: "apply", Batch: batch(mutation),
+			WantResult: activityreplication.ApplyResult{AcceptedCount: 1, Cursor: 1}, WantAcknowledgements: []activityreplication.MutationAcknowledgement{acknowledgement},
+		}},
+		WantSnapshots: []SnapshotExpectation{presentSnapshot(mutation)},
+	})
+	if err == nil || !strings.Contains(err.Error(), "session scope") {
+		t.Fatalf("RunSink() error = %v, want missing session scope", err)
+	}
+}
+
 type scriptedSink struct {
-	report ApplyReport
-	err    error
+	report    ApplyReport
+	err       error
+	snapshot  SinkSnapshot
+	found     bool
+	lookupErr error
 }
 
 func (*scriptedSink) Reset(context.Context) error { return nil }
@@ -108,6 +141,9 @@ func (s *scriptedSink) Apply(context.Context, activityreplication.ChangeBatch) (
 	return s.report, s.err
 }
 
-func (*scriptedSink) Lookup(context.Context, activityreplication.EntityType, activityreplication.EntityKey) (json.RawMessage, bool, error) {
-	return nil, false, errors.New("unexpected lookup")
+func (s *scriptedSink) Lookup(context.Context, activityreplication.EntityType, activityreplication.EntityKey) (SinkSnapshot, bool, error) {
+	if s.lookupErr != nil || s.found {
+		return s.snapshot, s.found, s.lookupErr
+	}
+	return SinkSnapshot{}, false, errors.New("unexpected lookup")
 }

--- a/packages/agent/activity-replication/conformance/fixtures.go
+++ b/packages/agent/activity-replication/conformance/fixtures.go
@@ -312,7 +312,7 @@ func messageMutation(mutationID, transactionID string, updatedAt int64) activity
 func sessionScope(deviceID string) *activityreplication.SessionScope {
 	return &activityreplication.SessionScope{
 		InitiatorUserID: "caller-1", ExecutorOwnerUserID: "owner-1", SourceDeviceID: deviceID,
-		LaunchKind: "shared-agent", Visibility: activityreplication.VisibilityMembers,
+		SharedAgentBindingID: "binding-1", LaunchKind: "shared-agent", Visibility: activityreplication.VisibilityMembers,
 	}
 }
 

--- a/packages/agent/activity-replication/conformance/fixtures.go
+++ b/packages/agent/activity-replication/conformance/fixtures.go
@@ -336,5 +336,14 @@ func presentSnapshot(mutation activityreplication.Mutation) SnapshotExpectation 
 	if err != nil {
 		panic(err)
 	}
-	return SnapshotExpectation{EntityType: mutation.EntityType, Key: mutation.Key, Present: true, Snapshot: raw}
+	return SnapshotExpectation{
+		EntityType: mutation.EntityType,
+		Key:        mutation.Key,
+		Present:    true,
+		Snapshot: SinkSnapshot{
+			Entity:       raw,
+			TargetScope:  mutation.TargetScope,
+			SessionScope: mutation.SessionScope,
+		},
+	}
 }

--- a/packages/agent/activity-replication/session_scope_compat_test.go
+++ b/packages/agent/activity-replication/session_scope_compat_test.go
@@ -1,0 +1,56 @@
+package activityreplication_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	activityreplication "github.com/tutti-os/tutti/packages/agent/activity-replication"
+)
+
+func TestSessionScopeSharedAgentBindingIDIsAdditive(t *testing.T) {
+	t.Parallel()
+
+	const legacyJSON = `{"initiatorUserId":"caller-1","executorOwnerUserId":"owner-1","sourceDeviceId":"device-1","launchKind":"shared-agent","visibility":"members"}`
+	var legacy activityreplication.SessionScope
+	if err := json.Unmarshal([]byte(legacyJSON), &legacy); err != nil {
+		t.Fatal(err)
+	}
+	if legacy.SharedAgentBindingID != "" {
+		t.Fatalf("legacy binding id = %q, want empty", legacy.SharedAgentBindingID)
+	}
+
+	encoded, err := json.Marshal(activityreplication.SessionScope{
+		InitiatorUserID: "caller-1", ExecutorOwnerUserID: "owner-1", SourceDeviceID: "device-1",
+		SharedAgentBindingID: "binding-1", LaunchKind: "shared-agent", Visibility: activityreplication.VisibilityMembers,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(encoded), `"sharedAgentBindingId":"binding-1"`) {
+		t.Fatalf("encoded scope = %s", encoded)
+	}
+
+	var roundTrip activityreplication.SessionScope
+	if err := json.Unmarshal(encoded, &roundTrip); err != nil {
+		t.Fatal(err)
+	}
+	if roundTrip.SharedAgentBindingID != "binding-1" {
+		t.Fatalf("round-trip binding id = %q", roundTrip.SharedAgentBindingID)
+	}
+}
+
+func TestSessionScopeOmitsEmptySharedAgentBindingID(t *testing.T) {
+	t.Parallel()
+
+	encoded, err := json.Marshal(activityreplication.SessionScope{
+		ExecutorOwnerUserID: "owner-1", SourceDeviceID: "device-1",
+		LaunchKind: "direct", Visibility: activityreplication.VisibilityMembers,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "sharedAgentBindingId") {
+		t.Fatalf("encoded legacy-compatible scope = %s", encoded)
+	}
+}

--- a/packages/agent/activity-replication/types.go
+++ b/packages/agent/activity-replication/types.go
@@ -172,8 +172,12 @@ type SessionScope struct {
 	InitiatorUserID     string `json:"initiatorUserId"`
 	ExecutorOwnerUserID string `json:"executorOwnerUserId"`
 	SourceDeviceID      string `json:"sourceDeviceId"`
-	LaunchKind          string `json:"launchKind"`
-	Visibility          string `json:"visibility"`
+	// SharedAgentBindingID is the optional typed provenance that relates an
+	// owner-local canonical session to a product-owned shared-agent binding.
+	// Empty remains valid so older producers can continue replicating sessions.
+	SharedAgentBindingID string `json:"sharedAgentBindingId,omitempty"`
+	LaunchKind           string `json:"launchKind"`
+	Visibility           string `json:"visibility"`
 }
 
 // Mutation is a closed tagged union. Command-state payloads are intentionally

--- a/packages/agent/activity-replication/validation_test.go
+++ b/packages/agent/activity-replication/validation_test.go
@@ -13,7 +13,7 @@ func TestValidateMutationAcceptsEveryProjectionSnapshot(t *testing.T) {
 
 	sessionScope := &activityreplication.SessionScope{
 		ExecutorOwnerUserID: "owner-1", SourceDeviceID: "device-1",
-		Visibility: activityreplication.VisibilityMembers,
+		SharedAgentBindingID: "binding-1", Visibility: activityreplication.VisibilityMembers,
 	}
 	base := func(entityType activityreplication.EntityType, key activityreplication.EntityKey) activityreplication.Mutation {
 		return activityreplication.Mutation{


### PR DESCRIPTION
## What changed

- Add optional `sharedAgentBindingId` attribution to replicated Agent session scope.
- Preserve the field through official conformance fixtures.
- Add compatibility coverage proving older payloads without the field still decode safely.

## Why

Goal-first shared-agent sessions were replicated without a durable binding identity. Downstream systems could see the canonical session but could not prove which shared-agent binding owned it, leaving transcript projection ambiguous.

The field is optional so old producers remain compatible; missing attribution may lose transcript data but must not crash synchronization.

## Impact and risk

This is an additive replication contract. Downstream TSH and tsh-server changes must consume a published Tutti release before they can compile independently. No historical backfill is introduced.

## Verification

- `go test -count=1 ./packages/agent/activity-replication/... ./packages/agent/store-sqlite`
- `git diff --check`