### PR TITLE
fix(agent-gui): distinguish revoked shared agents

### DIFF
--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -1396,10 +1396,13 @@ The host owns:
 
 When command reachability differs by Session, the host also projects
 `session/runtimeAvailabilityChanged` into the shared engine. This state is
-ephemeral transport coordination, not a canonical Session field. The engine
-gates runtime-dependent commands and AgentGUI presents the same frozen/loading
-interaction for every host; a host must not map one Session's transport loss to
-the workspace-wide engine connection state.
+ephemeral command coordination, not a canonical Session field. In addition to
+transport and capability reasons, a shared host may project
+`agent_sharing_revoked` with the owner display label. The engine gates
+runtime-dependent commands and AgentGUI presents the same blocked interaction
+for every host; history remains canonical and readable. A host must not map one
+Session's transport loss or revoked sharing relationship to the workspace-wide
+engine connection state.
 
 ## Needs Attention Contract
 

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -734,14 +734,17 @@ Session, never crosses into another conversation, and is never written back to
 the workspace engine.
 
 Runtime command availability is session-scoped whenever one workspace engine
-can contain Sessions backed by different transports. The host projects
-`available`, `transport_reconnecting`, or `transport_unavailable`; the engine
-uses that single fact to gate sends, cancellation, settings, and Interaction or
-plan responses. AgentGUI preserves the composer draft content but disables
-editing and runtime-dependent actions, and keeps an active Stop control visible
-but disabled until the transport recovers. It must not reuse the engine-wide
-connection state for this case, because one remote Session losing its owner must
-not disable Local Agent or another remote Session.
+can contain Sessions backed by different transports or access policies. The
+host projects `available`, transport/capability blocking, or the explicit
+`agent_sharing_revoked` state with the owner display label. The engine uses that
+single fact to gate sends, cancellation, settings, and Interaction or plan
+responses. AgentGUI preserves the composer draft content but disables editing
+and runtime-dependent actions. A revoked shared Session keeps its history and
+renders the package-owned owner-specific notice; it becomes available again
+only when the host projects the sharing relationship as active. It must not
+reuse the engine-wide connection state for this case, because one remote
+Session losing its owner or access must not disable Local Agent or another
+remote Session.
 
 Mobile projects pending Interactions from the root conversation plus its child
 Sessions and reads each exact Engine response record for submitting/failure
@@ -760,6 +763,12 @@ target or the selected Home target. This lets a new-conversation composer show
 and enforce connection state before any Session exists. Session runtime
 availability remains the independent command safety gate for existing
 Sessions; it is not the source of device connection presentation.
+
+Sharing eligibility is a parent gate for device connection. When an owner has
+revoked a Session's shared Agent relationship, the host projects
+`agent_sharing_revoked` and does not manufacture a target transport state for
+that relationship. Device reconnect and automatic retry presentation begins
+only while the sharing relationship is active.
 
 AgentGUI projects a blocked target connection through the chrome above the
 composer and gives it precedence over other recovery, approval, or prompt

--- a/packages/agent/activity-core/README.md
+++ b/packages/agent/activity-core/README.md
@@ -202,10 +202,11 @@ The engine derives submit availability from canonical Turns and pending
 Interactions. Hosts must not copy deprecated session-level lifecycle or submit
 availability fields into the frontend.
 
-A host whose command transport can differ per Session may dispatch
-`session/runtimeAvailabilityChanged`. This ephemeral, session-scoped fact is
-kept outside the canonical Session and blocks runtime-dependent commands while
-the exact Session transport reconnects or is unavailable. Omitted availability
+A host whose command transport or access policy can differ per Session may
+dispatch `session/runtimeAvailabilityChanged`. This ephemeral, session-scoped
+fact is kept outside the canonical Session and blocks runtime-dependent
+commands while the exact Session transport reconnects, is unavailable, or
+shared access has been revoked. Omitted availability
 defaults to available, so ordinary local runtimes retain their existing
 behavior. A workspace-wide `engine/connectionChanged` event must not be used to
 represent one remote Session's transport because that would also block

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.availability.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.availability.ts
@@ -6,6 +6,7 @@ export interface CanonicalSubmitAvailability {
     | "active_turn"
     | "agent_capability_checking"
     | "agent_capability_unavailable"
+    | "agent_sharing_revoked"
     | "waiting"
     | "transport_reconnecting"
     | "transport_unavailable";

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.test.ts
@@ -468,6 +468,42 @@ test("blocked runtime availability rejects settings and interactive commands", (
   );
 });
 
+test("revoked sharing availability updates owner presentation without changing its reason", () => {
+  let state = reduce(createInitialSessionLifecycleState(), {
+    type: "session/snapshotReceived",
+    sessions: [session(null, 1)]
+  }).state;
+  state = reduce(state, {
+    type: "session/runtimeAvailabilityChanged",
+    agentSessionId: "session-1",
+    availability: {
+      state: "blocked",
+      reason: "agent_sharing_revoked",
+      ownerLabel: "Old owner"
+    }
+  }).state;
+
+  const renamed = reduce(state, {
+    type: "session/runtimeAvailabilityChanged",
+    agentSessionId: "session-1",
+    availability: {
+      state: "blocked",
+      reason: "agent_sharing_revoked",
+      ownerLabel: "Current owner"
+    }
+  });
+
+  assert.notEqual(renamed.state, state);
+  assert.deepEqual(
+    renamed.state.operationBySessionId["session-1"]?.runtimeAvailability,
+    {
+      state: "blocked",
+      reason: "agent_sharing_revoked",
+      ownerLabel: "Current owner"
+    }
+  );
+});
+
 test("a queued settings update waits for runtime reconnection", () => {
   let state = reduce(createInitialSessionLifecycleState(), {
     type: "session/snapshotReceived",

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.ts
@@ -323,12 +323,7 @@ function changeRuntimeAvailability(
   const operation = state.operationBySessionId[agentSessionId];
   if (!agentSessionId || !operation) return unchanged(state);
   const current = operation.runtimeAvailability;
-  if (
-    current.state === availability.state &&
-    (current.state !== "blocked" ||
-      (availability.state === "blocked" &&
-        current.reason === availability.reason))
-  ) {
+  if (runtimeAvailabilityEquals(current, availability)) {
     return unchanged(state);
   }
   const changed = updateOperation(state, agentSessionId, (value) => ({
@@ -338,6 +333,22 @@ function changeRuntimeAvailability(
   return availability.state === "available"
     ? resumeSettingsUpdateWhenRuntimeAvailable(changed.state, agentSessionId)
     : changed;
+}
+
+function runtimeAvailabilityEquals(
+  left: SessionOperationState["runtimeAvailability"],
+  right: SessionOperationState["runtimeAvailability"]
+): boolean {
+  if (left.state !== right.state) return false;
+  if (left.state === "available" || right.state === "available") return true;
+  if (left.reason !== right.reason) return false;
+  if (
+    left.reason === "agent_sharing_revoked" &&
+    right.reason === "agent_sharing_revoked"
+  ) {
+    return left.ownerLabel === right.ownerLabel;
+  }
+  return true;
 }
 
 function settleInteractionResponse(

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.types.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.types.ts
@@ -38,8 +38,8 @@ export interface SessionOperationState {
 /**
  * Host-projected, session-scoped availability for commands that must reach the
  * session runtime. This is intentionally separate from the canonical Session:
- * transport reachability and exact-target Agent capabilities are ephemeral and
- * may differ between Sessions sharing one workspace engine.
+ * transport reachability, exact-target Agent capabilities, and shared access
+ * are ephemeral and may differ between Sessions sharing one workspace engine.
  */
 export type SessionRuntimeAvailability =
   | { state: "available" }
@@ -50,6 +50,11 @@ export type SessionRuntimeAvailability =
         | "agent_capability_unavailable"
         | "transport_reconnecting"
         | "transport_unavailable";
+    }
+  | {
+      state: "blocked";
+      reason: "agent_sharing_revoked";
+      ownerLabel: string;
     };
 
 export type SessionSettingsUpdateStatus =

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentSessionChrome.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentSessionChrome.spec.tsx
@@ -192,6 +192,40 @@ describe("AgentSessionChrome", () => {
 
     expect(onContinueInNewConversation).toHaveBeenCalledTimes(1);
   });
+
+  it("renders revoked sharing as a terminal notice without a retry action", () => {
+    render(
+      <AgentSessionChrome
+        chrome={{
+          auth: null,
+          approval: null,
+          recovery: {
+            kind: "agent-sharing-revoked",
+            message: "riceballmama stopped sharing this agent",
+            canRetry: false
+          },
+          rawState: null
+        }}
+        isRespondingApproval={false}
+        onSubmitApprovalOption={vi.fn()}
+        onRetryActivation={vi.fn()}
+        onContinueInNewConversation={vi.fn()}
+        labels={{
+          approvalRequired: "Approval required",
+          authRequired: "Authentication required",
+          activatingSession: "Connecting session...",
+          retryActivation: "Retry",
+          continueInNewConversation: "Continue in new session"
+        }}
+      />
+    );
+
+    expect(
+      screen.getByText("riceballmama stopped sharing this agent")
+    ).toBeTruthy();
+    expect(screen.getByRole("alert")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+  });
 });
 
 function chromeState(): AgentGUISessionChrome {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentSessionChrome.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentSessionChrome.tsx
@@ -114,6 +114,7 @@ export function AgentSessionChrome({
   "use memo";
   const visibleAuth =
     chrome.recovery?.kind === "activating" ||
+    chrome.recovery?.kind === "agent-sharing-revoked" ||
     chrome.recovery?.kind === "transport-connecting" ||
     chrome.recovery?.kind === "transport-unavailable"
       ? null
@@ -202,6 +203,7 @@ export function AgentSessionChrome({
         <section
           role={
             visibleRecovery.kind === "failed" ||
+            visibleRecovery.kind === "agent-sharing-revoked" ||
             visibleRecovery.kind === "transport-unavailable"
               ? "alert"
               : visibleRecovery.kind === "resume-unavailable" ||
@@ -211,6 +213,7 @@ export function AgentSessionChrome({
           }
           aria-live={
             visibleRecovery.kind === "failed" ||
+            visibleRecovery.kind === "agent-sharing-revoked" ||
             visibleRecovery.kind === "transport-unavailable"
               ? "assertive"
               : visibleRecovery.kind === "transport-connecting"
@@ -223,6 +226,7 @@ export function AgentSessionChrome({
           className={cn(
             styles.chromeCard,
             visibleRecovery.kind === "failed" ||
+              visibleRecovery.kind === "agent-sharing-revoked" ||
               visibleRecovery.kind === "transport-unavailable"
               ? styles.chromeCardDanger
               : visibleRecovery.kind === "resume-unavailable"

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.spec.tsx
@@ -241,4 +241,95 @@ describe("useAgentGUISessionPresentation", () => {
       reason: null
     });
   });
+
+  it("keeps shared history visible while revoked sharing blocks commands with owner copy", () => {
+    const targetConnectionSource = new FakeTargetConnectionSource();
+    targetConnectionSource.set({ status: "unavailable", retryAttempt: 4 });
+    const sessionEngine = createAgentSessionEngine({
+      clock: { nowUnixMs: () => 1 },
+      commandPort: createTestEngineCommandPort({
+        execute: vi.fn(() => new Promise(() => undefined))
+      }),
+      identity: { origin: "test", workspaceId: "workspace-1" },
+      scheduler: { schedule: () => ({ cancel() {} }) }
+    });
+    const input = {
+      activeConversation: null,
+      activeConversationId: "session-1",
+      activeEngineActiveTurn: null,
+      activeEngineAvailability: "available",
+      activeEngineHasPendingInteractions: false,
+      activeEngineLatestTurn: null,
+      activeEngineRuntimeAvailability: {
+        state: "blocked",
+        reason: "agent_sharing_revoked",
+        ownerLabel: "riceballmama"
+      },
+      activeEngineSession: {
+        agentSessionId: "session-1",
+        goal: null,
+        resumable: true
+      },
+      activeGoalControlPresentation: {
+        agentSessionId: "session-1",
+        goal: null,
+        optimistic: false,
+        status: "idle"
+      },
+      activeLatestPendingSubmitTurnId: null,
+      activeLiveState: "active",
+      activeMessages: [],
+      activePendingActivation: null,
+      activeSessionState: null,
+      activeTimelineItems: [{ role: "user" }],
+      activationError: null,
+      activationErrorCode: null,
+      activationState: "active",
+      activityDisplayStatus: null,
+      agentActivityRuntime: {},
+      agentTargetsLoading: false,
+      composerSupport: {
+        model: false,
+        reasoningEffort: false,
+        permissionMode: false,
+        planMode: false,
+        planImplementation: false,
+        plan: false
+      },
+      conversation: null,
+      currentUserId: "user-1",
+      isCreatingConversation: false,
+      isInterrupting: false,
+      isLoadingMessages: false,
+      isRespondingToInteraction: false,
+      isSubmitting: false,
+      lastRenderStateDiagnosticKeyRef: { current: null },
+      pendingApproval: null,
+      planImplementationTurnIdRef: { current: null },
+      providerReadinessGate: null,
+      serverInteractivePrompt: null,
+      sessionEngine,
+      targetConnectionAgentTargetId: "shared-agent:shared-1",
+      targetConnectionSource,
+      workspaceId: "workspace-1"
+    } as unknown as Parameters<typeof useAgentGUISessionPresentation>[0];
+
+    const rendered = renderHook(() => useAgentGUISessionPresentation(input));
+
+    expect(rendered.result.current.sessionChrome.recovery).toEqual({
+      kind: "agent-sharing-revoked",
+      message: "riceballmama stopped sharing this agent",
+      canRetry: false
+    });
+    expect(rendered.result.current.hasSentUserMessage).toBe(true);
+    expect(rendered.result.current.composerGate).toMatchObject({
+      runtime: {
+        status: "blocked",
+        reason: "session_runtime",
+        sessionRuntimeReason: "agent_sharing_revoked"
+      },
+      editor: { status: "blocked", reason: "runtime_blocked" },
+      submission: { status: "blocked", reason: "runtime_blocked" }
+    });
+  });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.ts
@@ -148,10 +148,11 @@ export function useAgentGUISessionPresentation(
     input.activeConversationId && input.activeLatestPendingSubmitTurnId
   );
   const activeSubmitBlocked = input.activeEngineAvailability === "blocked";
-  const sessionRuntimeBlockedReason =
+  const sessionRuntimeBlock =
     input.activeEngineRuntimeAvailability?.state === "blocked"
-      ? input.activeEngineRuntimeAvailability.reason
+      ? input.activeEngineRuntimeAvailability
       : null;
+  const sessionRuntimeBlockedReason = sessionRuntimeBlock?.reason ?? null;
   const targetConnection = useAgentGUITargetConnectionState({
     agentTargetId: input.targetConnectionAgentTargetId,
     source: input.targetConnectionSource
@@ -197,6 +198,20 @@ export function useAgentGUISessionPresentation(
     input.activeGoalControlPresentation
   ]);
   const sessionChrome = useMemo<AgentGUISessionChrome>(() => {
+    if (sessionRuntimeBlock?.reason === "agent_sharing_revoked") {
+      return {
+        auth: null,
+        approval: null,
+        recovery: {
+          kind: "agent-sharing-revoked",
+          message: translate("agentHost.agentGui.agentSharingRevoked", {
+            owner: sessionRuntimeBlock.ownerLabel
+          }),
+          canRetry: false
+        },
+        rawState: sessionChromeRawState
+      };
+    }
     if (
       targetConnection.visibleState?.status === "connecting" ||
       targetConnection.visibleState?.status === "unavailable"
@@ -303,6 +318,7 @@ export function useAgentGUISessionPresentation(
     input.activePendingActivation?.mode,
     input.pendingApproval,
     input.ownerDeviceLabel,
+    sessionRuntimeBlock,
     targetConnection.visibleState,
     observationGap,
     sessionChromeRawState

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiComposerGate.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiComposerGate.ts
@@ -30,23 +30,31 @@ export function resolveAgentGUIComposerGate(
   input: ResolveAgentGUIComposerGateInput
 ): AgentGUIComposerGate {
   const conversationBusy = input.activeConversationBusy || input.isSubmitting;
-  const runtime: AgentGUIComposerGate["runtime"] = input.targetConnectionBlocked
+  const sharingRevoked =
+    input.sessionRuntimeBlockedReason === "agent_sharing_revoked";
+  const runtime: AgentGUIComposerGate["runtime"] = sharingRevoked
     ? {
         status: "blocked",
-        reason: "target_connection",
-        sessionRuntimeReason: null
+        reason: "session_runtime",
+        sessionRuntimeReason: "agent_sharing_revoked"
       }
-    : input.sessionRuntimeBlockedReason !== null
+    : input.targetConnectionBlocked
       ? {
           status: "blocked",
-          reason: "session_runtime",
-          sessionRuntimeReason: input.sessionRuntimeBlockedReason
-        }
-      : {
-          status: "ready",
-          reason: null,
+          reason: "target_connection",
           sessionRuntimeReason: null
-        };
+        }
+      : input.sessionRuntimeBlockedReason !== null
+        ? {
+            status: "blocked",
+            reason: "session_runtime",
+            sessionRuntimeReason: input.sessionRuntimeBlockedReason
+          }
+        : {
+            status: "ready",
+            reason: null,
+            sessionRuntimeReason: null
+          };
   const canQueue =
     input.activeConversationId !== null &&
     runtime.status === "ready" &&

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
@@ -47,6 +47,7 @@ export interface AgentGUISessionChrome {
           | "activating"
           | "failed"
           | "warning"
+          | "agent-sharing-revoked"
           | "transport-connecting"
           | "transport-unavailable";
         message: string;

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGuiRuntimeNotices.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGuiRuntimeNotices.ts
@@ -49,6 +49,7 @@ export const enAgentGuiRuntimeNotices = {
   systemNoticeWarning: "Agent warning",
   systemNoticeDefault: "Agent notice",
   sharedDeviceLabel: "shared device",
+  agentSharingRevoked: "{{owner}} stopped sharing this agent",
   runtimeConnecting: "Connecting to {{device}}…",
   runtimeReconnectingAttempt: "Reconnecting to {{device}} · Retry {{attempt}}…",
   runtimeUnavailable:

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGuiRuntimeNotices.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGuiRuntimeNotices.ts
@@ -41,6 +41,7 @@ export const zhCNAgentGuiRuntimeNotices = {
   systemNoticeWarning: "Agent 警告",
   systemNoticeDefault: "Agent 通知",
   sharedDeviceLabel: "共享设备",
+  agentSharingRevoked: "{{owner}} 已取消共享该智能体",
   runtimeConnecting: "正在连接 {{device}}…",
   runtimeReconnectingAttempt:
     "正在重新连接 {{device}} · 第 {{attempt}} 次重试…",


### PR DESCRIPTION
## Summary

- add a session-scoped `agent_sharing_revoked` runtime availability state with owner presentation
- make revoked sharing outrank stale target-connection notices in AgentGUI Chrome and composer gating
- keep historical conversations visible while disabling commands and showing localized owner-specific copy
- update architecture and package documentation for access-policy availability

## Why

Canceling a shared Agent was previously indistinguishable from an offline owner device. A stale transport snapshot could therefore show an automatic-retry notice even after the owner had revoked access.

## Impact and risk

This changes the public `SessionRuntimeAvailability` union and AgentGUI presentation priority for the new revoked-sharing reason only. Other target-connection and runtime reasons preserve their existing ordering.

Consumer integration: https://github.com/tutti-lab/tsh/pull/2260

## Verification

- `pnpm check:changed`
- `pnpm --filter @tutti-os/agent-activity-core test` (429 tests)
- `pnpm --filter @tutti-os/agent-gui exec vitest run agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.spec.tsx agent-gui/agentGuiNode/AgentSessionChrome.spec.tsx` (8 tests)
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm check:i18n`
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm check:agent-gui-degradation`
