### PR TITLE
fix(agent): settle Claude turns when reader disconnects

### DIFF
--- a/packages/agent/daemon/runtime/claude_sdk_event_projection_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_event_projection_test.go
@@ -1736,16 +1736,12 @@ func TestClaudeCodeSDKAdapterTurnCanceledFailsOpenToolCalls(t *testing.T) {
 	}
 }
 
-// TestClaudeCodeSDKAdapterReaderFailureFailsPendingInteractive guards against
-// a real bug found while investigating a Feishu report (LENj32): if the
-// sidecar connection/process dies while a permission dialog is still
-// unanswered (e.g. the user left it open for a while), failClaudeSDKReader
-// used to discard the pending approval bookkeeping silently along with the
-// rest of the session. The GUI would then see the request vanish on the next
-// reconnect with no terminal event explaining why, while the turn itself
-// failed for an unrelated-looking reason -- giving the impression the
-// approval was answered or bypassed when it never was.
-func TestClaudeCodeSDKAdapterReaderFailureFailsPendingInteractive(t *testing.T) {
+// TestClaudeCodeSDKAdapterReaderFailureConvergesPendingInteractiveAndProviderTurn
+// guards the disconnect path while a permission dialog is unanswered. The
+// authoritative sink must settle the interaction, call, and provider turn
+// before Exec is released; otherwise its stale return batch can be rejected
+// and leave the durable root turn running forever.
+func TestClaudeCodeSDKAdapterReaderFailureConvergesPendingInteractiveAndProviderTurn(t *testing.T) {
 	adapter := NewClaudeCodeSDKAdapter(nil)
 	session := standardTestSession(ProviderClaudeCode)
 	adapterSession := &claudeSDKAdapterSession{
@@ -1762,6 +1758,7 @@ func TestClaudeCodeSDKAdapterReaderFailureFailsPendingInteractive(t *testing.T) 
 		"turn-disconnect",
 		"provider-turn-disconnect",
 	)
+	waiter := adapter.registerClaudeSDKTurn(adapterSession, "turn-disconnect", nil)
 
 	if _, _, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-disconnect", claudeSDKSidecarEvent{
 		Type: "approval_requested",
@@ -1780,9 +1777,15 @@ func TestClaudeCodeSDKAdapterReaderFailureFailsPendingInteractive(t *testing.T) 
 
 	var mu sync.Mutex
 	var received []activityshared.Event
+	waiterReleasedBeforeSink := false
 	adapter.SetSessionEventSink(func(_ string, events []activityshared.Event) {
 		mu.Lock()
 		defer mu.Unlock()
+		select {
+		case <-waiter.done:
+			waiterReleasedBeforeSink = true
+		default:
+		}
 		received = append(received, events...)
 	})
 
@@ -1790,12 +1793,41 @@ func TestClaudeCodeSDKAdapterReaderFailureFailsPendingInteractive(t *testing.T) 
 
 	mu.Lock()
 	events := append([]activityshared.Event(nil), received...)
+	releasedBeforeSink := waiterReleasedBeforeSink
 	mu.Unlock()
-	if len(events) != 2 || events[0].Type != activityshared.EventInteractionSuperseded || events[1].Type != activityshared.EventCallFailed {
-		t.Fatalf("disconnect events = %#v, want superseded interaction and failed pending approval", events)
+	if releasedBeforeSink {
+		t.Fatal("turn waiter was released before authoritative disconnect events reached the session sink")
+	}
+	if len(events) != 3 ||
+		events[0].Type != activityshared.EventInteractionSuperseded ||
+		events[1].Type != activityshared.EventCallFailed ||
+		events[2].Type != activityshared.EventRootProviderTurnCompleted {
+		t.Fatalf("disconnect events = %#v, want superseded interaction, failed pending approval, and failed provider turn", events)
 	}
 	if msg, _ := events[1].Payload.Error["message"].(string); msg != "sidecar connection lost" {
 		t.Fatalf("failed approval error = %#v, want the disconnect reason", events[1].Payload.Error)
+	}
+	if events[2].Payload.TurnID != "turn-disconnect" ||
+		events[2].Payload.ProviderTurnID != "provider-turn-disconnect" ||
+		events[2].Payload.TurnOutcome != string(activityshared.TurnOutcomeFailed) {
+		t.Fatalf("provider failure = %#v, want matching root/provider identities and failed outcome", events[2])
+	}
+	select {
+	case result := <-waiter.done:
+		if result.err == nil || result.err.Error() != "sidecar connection lost" {
+			t.Fatalf("waiter error = %v, want the disconnect reason", result.err)
+		}
+	default:
+		t.Fatal("turn waiter was not released after terminal session events were emitted")
+	}
+	if duplicate := adapter.claudeSDKRootProviderFailureEvents(
+		adapterSession,
+		session,
+		"turn-disconnect",
+		"provider-turn-disconnect",
+		errors.New("sidecar connection lost"),
+	); len(activityEventsWithType(duplicate, activityshared.EventRootProviderTurnCompleted)) != 0 {
+		t.Fatalf("duplicate provider terminal events = %#v, want none after reader failure convergence", duplicate)
 	}
 	if adapter.getSession(session.AgentSessionID) != nil {
 		t.Fatal("session should be removed after the reader fails")

--- a/packages/agent/daemon/runtime/claude_sdk_events.go
+++ b/packages/agent/daemon/runtime/claude_sdk_events.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"sort"
 	"strings"
 
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
@@ -690,6 +691,32 @@ func (a *ClaudeCodeSDKAdapter) failClaudeSDKReader(agentSessionID string, adapte
 		delete(adapterSession.pendingResponses, id)
 	}
 	a.mu.Unlock()
+	// Converge every provider-owned lifecycle through the session sink before
+	// releasing Exec/round-trip waiters. Those waiters can return stale local
+	// lifecycle snapshots; if they win this race, the controller can reject
+	// their whole batch and lose the only provider terminal event.
+	//
+	// Any interactive/permission request still awaiting a human decision must
+	// also be resolved explicitly. Otherwise the pending approval bookkeeping
+	// is discarded silently with the session and the GUI is left without a
+	// terminal explanation.
+	session := a.claudeSDKSessionSnapshot(adapterSession)
+	if strings.TrimSpace(session.AgentSessionID) == "" {
+		session.AgentSessionID = agentSessionID
+	}
+	pendingFailureEvents := a.claudeSDKPendingRequestFailureEvents(adapterSession, session, "", err)
+	pendingFailureEvents = append(pendingFailureEvents, a.finishAllClaudeSDKTurnLifecycles(
+		adapterSession,
+		session,
+		claudeSDKTurnFinishFailed,
+		err.Error(),
+	)...)
+	pendingFailureEvents = append(
+		pendingFailureEvents,
+		a.failAllClaudeSDKRootProviderTurns(adapterSession, session, err)...,
+	)
+	a.removeSession(agentSessionID, adapterSession)
+	a.emitClaudeSDKSessionEvents(agentSessionID, pendingFailureEvents)
 	for _, waiter := range turns {
 		waiter.mu.Lock()
 		if waiter.completed {
@@ -707,26 +734,46 @@ func (a *ClaudeCodeSDKAdapter) failClaudeSDKReader(agentSessionID string, adapte
 	for _, response := range responses {
 		response <- claudeSDKSidecarEvent{Type: "error", Payload: map[string]any{"error": err.Error(), "transport": true}}
 	}
-	// Any interactive/permission request still awaiting a human decision when
-	// the sidecar connection is lost must be resolved explicitly. Without
-	// this, the pending approval bookkeeping is discarded silently along
-	// with the session (below), leaving the GUI's permission dialog with no
-	// terminal event: on the next reconnect/resume it simply vanishes with
-	// no explanation while the turn itself fails, giving the appearance that
-	// the request was answered (or bypassed) when it never was.
-	session := a.claudeSDKSessionSnapshot(adapterSession)
-	if strings.TrimSpace(session.AgentSessionID) == "" {
-		session.AgentSessionID = agentSessionID
+}
+
+func (a *ClaudeCodeSDKAdapter) failAllClaudeSDKRootProviderTurns(
+	adapterSession *claudeSDKAdapterSession,
+	session Session,
+	err error,
+) []activityshared.Event {
+	if a == nil || adapterSession == nil {
+		return nil
 	}
-	pendingFailureEvents := a.claudeSDKPendingRequestFailureEvents(adapterSession, session, "", err)
-	pendingFailureEvents = append(pendingFailureEvents, a.finishAllClaudeSDKTurnLifecycles(
-		adapterSession,
-		session,
-		claudeSDKTurnFinishFailed,
-		err.Error(),
-	)...)
-	a.removeSession(agentSessionID, adapterSession)
-	a.emitClaudeSDKSessionEvents(agentSessionID, pendingFailureEvents)
+	a.mu.Lock()
+	rootTurnID := strings.TrimSpace(adapterSession.rootTurnID)
+	providerTurnIDs := make([]string, 0, len(adapterSession.rootProviderTurns))
+	for providerTurnID := range adapterSession.rootProviderTurns {
+		providerTurnID = strings.TrimSpace(providerTurnID)
+		if providerTurnID != "" {
+			providerTurnIDs = append(providerTurnIDs, providerTurnID)
+		}
+	}
+	adapterSession.rootProviderTurns = make(map[string]struct{})
+	a.mu.Unlock()
+	if rootTurnID == "" || len(providerTurnIDs) == 0 {
+		return nil
+	}
+	sort.Strings(providerTurnIDs)
+	metadata := map[string]any{"adapter": claudeSDKSidecarAdapterName}
+	if err != nil {
+		metadata["error"] = err.Error()
+	}
+	events := make([]activityshared.Event, 0, len(providerTurnIDs))
+	for _, providerTurnID := range providerTurnIDs {
+		events = append(events, claudeSDKRootProviderTurnCompletedEvent(
+			session,
+			rootTurnID,
+			providerTurnID,
+			activityshared.TurnOutcomeFailed,
+			metadata,
+		))
+	}
+	return events
 }
 
 func (a *ClaudeCodeSDKAdapter) takeClaudeSDKResponseWaiter(adapterSession *claudeSDKAdapterSession, event claudeSDKSidecarEvent) chan claudeSDKSidecarEvent {

--- a/packages/agent/daemon/runtime/claude_sdk_execution.go
+++ b/packages/agent/daemon/runtime/claude_sdk_execution.go
@@ -286,6 +286,18 @@ func claudeSDKExecPayload(
 
 func (a *ClaudeCodeSDKAdapter) claudeSDKRootProviderFailureEvents(adapterSession *claudeSDKAdapterSession, session Session, turnID string, providerTurnID string, err error) []activityshared.Event {
 	events := a.finishClaudeSDKTurnLifecycle(adapterSession, session, turnID, claudeSDKTurnFinishFailed, "provider_transport_failed")
+	activeProviderTurnID := a.activeClaudeSDKRootProviderTurnID(adapterSession)
+	if activeProviderTurnID != "" {
+		providerTurnID = activeProviderTurnID
+	}
+	if !a.consumeClaudeSDKRootProviderTurn(adapterSession, providerTurnID) {
+		a.mu.Lock()
+		readerFailed := adapterSession != nil && adapterSession.invalid
+		a.mu.Unlock()
+		if readerFailed {
+			return events
+		}
+	}
 	metadata := map[string]any{"adapter": claudeSDKSidecarAdapterName}
 	if err != nil {
 		metadata["error"] = err.Error()
@@ -297,7 +309,6 @@ func (a *ClaudeCodeSDKAdapter) claudeSDKRootProviderFailureEvents(adapterSession
 		activityshared.TurnOutcomeFailed,
 		metadata,
 	))
-	a.consumeClaudeSDKRootProviderTurn(adapterSession, providerTurnID)
 	return events
 }
 


### PR DESCRIPTION
## Summary
- emit failed provider-turn terminal events through the authoritative session sink when the Claude SDK reader disconnects
- settle pending approvals and tool calls before releasing Exec waiters
- prevent duplicate provider terminal events after disconnect convergence

## Root cause
The reader failure path released the Exec waiter before publishing authoritative disconnect events. The returned Exec batch could then be rejected as stale, dropping the only provider terminal event and leaving the durable root turn running.

## Tests
- `go test -race ./packages/agent/daemon/runtime -run ^TestClaudeCodeSDKAdapterReaderFailureConvergesPendingInteractiveAndProviderTurn$ -count=1`
- `go test ./packages/agent/daemon/runtime -count=1`
- TSH: `go test ./cmd/desktopd/adapter/agentsession ./cmd/desktopd/adapter/agenthost`
- TSH: `make build-runtime-host`