### PR TITLE
fix(mobile): gate remote polling behind access setting

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceSettingsService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceSettingsService.test.ts
@@ -413,9 +413,8 @@ test("WorkspaceSettingsService reports a mobile remote access settings save fail
 
   assert.equal(notifications.items.length, 1);
   assert.ok(
-    notifications.items[0] ===
-      "We couldn't update mobile remote access visibility." ||
-      notifications.items[0] === "暂时无法更新手机远程访问显示设置"
+    notifications.items[0] === "We couldn't update mobile remote access." ||
+      notifications.items[0] === "暂时无法更新手机远程访问设置"
   );
 });
 

--- a/apps/desktop/src/shared/i18n/locales/en.ts
+++ b/apps/desktop/src/shared/i18n/locales/en.ts
@@ -1249,10 +1249,10 @@ export const en = {
         logsSummary: "{{count}} files, {{size}} total",
         logsTitle: "Logs",
         mobileRemoteAccessSettingsDescription:
-          "Show Connection settings with phone pairing and remote access controls.",
-        mobileRemoteAccessSettingsLabel: "Show mobile remote access settings",
+          "Allow paired phones to connect to this computer and show the related Connection settings.",
+        mobileRemoteAccessSettingsLabel: "Enable mobile remote access",
         mobileRemoteAccessSettingsSaveFailed:
-          "We couldn't update mobile remote access visibility.",
+          "We couldn't update mobile remote access.",
         openDaemonLog: "Open daemon log",
         openDesktopLog: "Open desktop log",
         openLogsDirectory: "Open logs folder",

--- a/apps/desktop/src/shared/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/shared/i18n/locales/zh-CN.ts
@@ -1172,10 +1172,9 @@ export const zhCN = {
         logsSummary: "{{count}} 个文件，共 {{size}}",
         logsTitle: "日志",
         mobileRemoteAccessSettingsDescription:
-          "显示连接设置以及手机配对与远程访问控制项",
-        mobileRemoteAccessSettingsLabel: "显示手机远程访问设置",
-        mobileRemoteAccessSettingsSaveFailed:
-          "暂时无法更新手机远程访问显示设置",
+          "允许已配对手机连接到这台电脑，并显示相关连接设置",
+        mobileRemoteAccessSettingsLabel: "启用手机远程访问",
+        mobileRemoteAccessSettingsSaveFailed: "暂时无法更新手机远程访问设置",
         openDaemonLog: "打开 daemon 日志",
         openDesktopLog: "打开 desktop 日志",
         openLogsDirectory: "打开日志目录",

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -449,6 +449,8 @@ Google Play 账号。以下事项等正式分发前再处理：
 - Personal `tuttid` 已接入设备注册、QR challenge、Desktop confirm、配对列表和撤销；
 - Personal 配对 API 已进入生成的 Go/TypeScript daemon client，账号 cookie 和设备私钥不会返回给 UI。
 - Desktop 设置页已接入二维码创建、配对码复制、轮询确认和撤销；
+- Desktop owner host 仅在持久化的 `mobile.remoteAccessSettings` 能力开关开启时
+  轮询配对和 DeviceLink attempt 控制面；关闭会停止 discovery 并断开已有远程链路；
 - `apps/mobile` 已接入平台原生浏览器认证 GitHub 登录和邮箱验证码登录、Android Keystore
   设备身份、设备列表、内置 ZXing 二维码扫描或手动粘贴配对码，以及 challenge
   claim/poll；
@@ -584,7 +586,7 @@ pnpm mobile:android
 App 启动后，使用与 Desktop 相同的账号登录方式。如果 Desktop 使用 GitHub 登录，
 Mobile 也点击“使用 GitHub 登录”并在平台浏览器认证会话中完成登录；仅输入 GitHub 展示的
 相同邮箱不保证得到同一个账号 identity。Desktop 先在设置的开发者页打开
-“显示手机远程访问设置”，再进入「连接」并点击“配对手机”生成二维码。Mobile
+“启用手机远程访问”，再进入「连接」并点击“配对手机”生成二维码。Mobile
 登录成功后点击配对，优先扫描 Desktop 二维码。首次扫码时允许 App 使用相机；如果
 当前环境无法使用相机，就在 Desktop 点击“复制配对码”，再在 Mobile 展开手动配对
 入口并粘贴。

--- a/docs/specs/2026-07-23-mobile-agentgui-device-link-design.md
+++ b/docs/specs/2026-07-23-mobile-agentgui-device-link-design.md
@@ -253,9 +253,10 @@ Cookie，也不新增移动端账号实体。Android 在浏览器 provider 支�
 
 Desktop 的账号登录入口与手机远程访问入口独立发布。Tutti Agent 及工作区账号菜单
 默认显示且不再提供独立的开发者可见性开关。独立持久化的
-`mobile.remoteAccessSettings` feature flag 控制「连接」设置入口是否显示；「连接」
-页承载账号登录、退出、刷新、手机配对和远程访问能力。该开关只控制 Desktop
-入口可见性，不创建第二套登录态、设备实体或协议能力。
+`mobile.remoteAccessSettings` feature flag 控制手机远程访问能力和「连接」设置入口；
+关闭时 `tuttid` owner host 不得轮询账号、配对或 DeviceLink attempt 控制面，并关闭
+已有远程链路；开启时立即开始 owner-side discovery。「连接」页承载账号登录、退出、
+刷新、手机配对和远程访问能力。该开关不创建第二套登录态、设备实体或协议能力。
 
 QR 不包含 bearer token、私钥、原始候选或可长期使用的连接凭据。
 

--- a/services/tuttid/biz/preferences/feature_flags.go
+++ b/services/tuttid/biz/preferences/feature_flags.go
@@ -1,9 +1,13 @@
 package preferences
 
-const FeatureFlagAgentSessionRecording = "agent.sessionRecording"
+const (
+	FeatureFlagAgentSessionRecording = "agent.sessionRecording"
+	FeatureFlagMobileRemoteAccess    = "mobile.remoteAccessSettings"
+)
 
 var capabilityFlagDefaults = map[string]bool{
 	FeatureFlagAgentSessionRecording: false,
+	FeatureFlagMobileRemoteAccess:    false,
 }
 
 // IsCapabilityFlagEnabled resolves daemon-enforced feature behavior. Stored

--- a/services/tuttid/biz/preferences/feature_flags_test.go
+++ b/services/tuttid/biz/preferences/feature_flags_test.go
@@ -16,3 +16,15 @@ func TestAgentSessionRecordingCapabilityFlagFailsClosed(t *testing.T) {
 		t.Fatal("unknown capability flag must resolve false")
 	}
 }
+
+func TestMobileRemoteAccessCapabilityFlagFailsClosed(t *testing.T) {
+	if IsCapabilityFlagEnabled(nil, FeatureFlagMobileRemoteAccess) {
+		t.Fatal("absent mobile remote access flag must resolve false")
+	}
+	if !IsCapabilityFlagEnabled(
+		map[string]bool{FeatureFlagMobileRemoteAccess: true},
+		FeatureFlagMobileRemoteAccess,
+	) {
+		t.Fatal("stored mobile remote access true must win")
+	}
+}

--- a/services/tuttid/service/mobileremote/remote_host.go
+++ b/services/tuttid/service/mobileremote/remote_host.go
@@ -40,12 +40,8 @@ type remoteHostState struct {
 	mu sync.Mutex
 
 	cancel             context.CancelFunc
-	enabled            bool
 	stopping           bool
 	stopDone           chan struct{}
-	wake               chan struct{}
-	pollCancel         context.CancelFunc
-	pollGeneration     uint64
 	handler            http.Handler
 	liveEvents         AgentLiveEventSource
 	attempts           map[string]activeRemoteAttempt
@@ -85,10 +81,6 @@ func (s *Service) StartRemoteHost(handler http.Handler) {
 		s.remoteHost.managedLinks = make(map[string]remoteManagedLink)
 		s.remoteHost.observedLinkEvents = make(map[string]uint64)
 		s.remoteHost.linkManager = s.newRemoteLinkManager()
-		if !s.remoteHost.enabled {
-			_ = s.remoteHost.linkManager.SetEnabled(false)
-		}
-		s.remoteHost.wake = make(chan struct{}, 1)
 		s.remoteHost.mu.Unlock()
 
 		go func() {
@@ -100,6 +92,10 @@ func (s *Service) StartRemoteHost(handler http.Handler) {
 }
 
 func (s *Service) Close() {
+	s.StopRemoteHost()
+}
+
+func (s *Service) StopRemoteHost() {
 	if s == nil {
 		return
 	}
@@ -139,49 +135,10 @@ func (s *Service) Close() {
 	s.remoteHost.attempts = nil
 	s.remoteHost.managedLinks = nil
 	s.remoteHost.observedLinkEvents = nil
-	s.remoteHost.wake = nil
-	s.remoteHost.pollCancel = nil
 	s.remoteHost.stopping = false
 	s.remoteHost.stopDone = nil
 	close(done)
 	s.remoteHost.mu.Unlock()
-}
-
-// SetRemoteAccessEnabled gates all Desktop owner-side DeviceLink discovery.
-// Disabled hosts keep no pooled links and make no account, pairing, or attempt
-// control-plane requests. Enabling wakes the host immediately instead of
-// waiting for the next periodic interval.
-func (s *Service) SetRemoteAccessEnabled(enabled bool) {
-	if s == nil {
-		return
-	}
-	s.remoteHost.mu.Lock()
-	if s.remoteHost.enabled == enabled {
-		s.remoteHost.mu.Unlock()
-		return
-	}
-	s.remoteHost.enabled = enabled
-	manager := s.remoteHost.linkManager
-	wake := s.remoteHost.wake
-	pollCancel := s.remoteHost.pollCancel
-	s.remoteHost.mu.Unlock()
-
-	if enabled {
-		if manager != nil {
-			_ = manager.SetEnabled(true)
-		}
-	} else {
-		if pollCancel != nil {
-			pollCancel()
-		}
-		s.stopRemoteAttempts(nil)
-	}
-	if wake != nil {
-		select {
-		case wake <- struct{}{}:
-		default:
-		}
-	}
 }
 
 func (s *Service) runRemoteHost(ctx context.Context) {
@@ -189,9 +146,6 @@ func (s *Service) runRemoteHost(ctx context.Context) {
 	if interval <= 0 {
 		interval = defaultRemotePollInterval
 	}
-	s.remoteHost.mu.Lock()
-	wake := s.remoteHost.wake
-	s.remoteHost.mu.Unlock()
 	timer := time.NewTimer(0)
 	defer timer.Stop()
 	for {
@@ -199,73 +153,42 @@ func (s *Service) runRemoteHost(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-timer.C:
-			if s.remoteAccessEnabled() {
-				s.pollRemoteHost(ctx)
-			}
+			s.pollRemoteHost(ctx)
 			timer.Reset(interval)
-		case <-wake:
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
-			}
-			if s.remoteAccessEnabled() {
-				timer.Reset(0)
-			} else {
-				timer.Reset(interval)
-			}
 		}
 	}
 }
 
 func (s *Service) pollRemoteHost(ctx context.Context) {
-	pollCtx, finishPoll, ok := s.beginRemotePoll(ctx)
-	if !ok {
-		return
-	}
-	defer finishPoll()
-	session, identity, err := s.readyIdentity(pollCtx)
+	session, identity, err := s.readyIdentity(ctx)
 	if err != nil {
 		s.stopRemoteAttempts(nil)
 		return
 	}
-	if !s.remoteAccessEnabled() {
-		return
-	}
 	s.setRemoteLinkEnabled(true)
-	registered, err := s.ensureRegisteredDevice(pollCtx, session.SessionID, session.Cookie, identity)
+	registered, err := s.ensureRegisteredDevice(ctx, session.SessionID, session.Cookie, identity)
 	if err != nil {
 		if isControlPlaneUnauthorized(err) {
 			s.stopRemoteAttempts(nil)
 		}
 		return
 	}
-	if !s.remoteAccessEnabled() {
-		return
-	}
-	pairings, err := s.ControlPlane.ListPairings(pollCtx, session.Cookie)
+	pairings, err := s.ControlPlane.ListPairings(ctx, session.Cookie)
 	if err != nil {
 		if isControlPlaneUnauthorized(err) {
 			s.stopRemoteAttempts(nil)
 		}
-		return
-	}
-	if !s.remoteAccessEnabled() {
 		return
 	}
 	validPairings := make(map[string]struct{})
 	for _, pairing := range pairings {
-		if !s.remoteAccessEnabled() {
-			return
-		}
 		if pairing.State != "active" || pairing.TargetUserDeviceID != registered.UserDeviceID {
 			continue
 		}
 		validPairings[pairing.PairingID] = struct{}{}
 		signature := ed25519.Sign(identity.PrivateKey, deviceLinkProof("list", pairing.PairingID, "", ""))
 		attempts, err := s.ControlPlane.ListDeviceLinkAttempts(
-			pollCtx, session.Cookie, pairing.PairingID, identity.DeviceID, signature,
+			ctx, session.Cookie, pairing.PairingID, identity.DeviceID, signature,
 		)
 		if err != nil {
 			if isControlPlaneUnauthorized(err) {
@@ -283,28 +206,6 @@ func (s *Service) pollRemoteHost(ctx context.Context) {
 		}
 	}
 	s.stopRemoteAttempts(validPairings)
-}
-
-func (s *Service) beginRemotePoll(parent context.Context) (context.Context, func(), bool) {
-	s.remoteHost.mu.Lock()
-	if !s.remoteHost.enabled || s.remoteHost.stopping || s.remoteHost.cancel == nil {
-		s.remoteHost.mu.Unlock()
-		return nil, nil, false
-	}
-	pollCtx, cancel := context.WithCancel(parent)
-	s.remoteHost.pollGeneration++
-	generation := s.remoteHost.pollGeneration
-	s.remoteHost.pollCancel = cancel
-	s.remoteHost.mu.Unlock()
-
-	return pollCtx, func() {
-		cancel()
-		s.remoteHost.mu.Lock()
-		if s.remoteHost.pollGeneration == generation {
-			s.remoteHost.pollCancel = nil
-		}
-		s.remoteHost.mu.Unlock()
-	}, true
 }
 
 func (s *Service) ensureRegisteredDevice(
@@ -345,7 +246,7 @@ func (s *Service) startRemoteAttempt(
 	attempt DeviceLinkAttempt,
 ) {
 	s.remoteHost.mu.Lock()
-	if !s.remoteHost.enabled || s.remoteHost.stopping || s.remoteHost.cancel == nil || parent.Err() != nil {
+	if s.remoteHost.stopping || s.remoteHost.cancel == nil || parent.Err() != nil {
 		s.remoteHost.mu.Unlock()
 		return
 	}
@@ -375,15 +276,6 @@ func (s *Service) startRemoteAttempt(
 		}
 		s.serveRemoteAttempt(ctx, handler, liveEvents, cookie, identity, pairingID, attempt)
 	}()
-}
-
-func (s *Service) remoteAccessEnabled() bool {
-	if s == nil {
-		return false
-	}
-	s.remoteHost.mu.Lock()
-	defer s.remoteHost.mu.Unlock()
-	return s.remoteHost.enabled
 }
 
 func (s *Service) finishRemoteAttempt(attemptID string, generation uint64) {
@@ -585,10 +477,6 @@ func (s *Service) stopRemoteAttempts(validPairings map[string]struct{}) {
 
 func (s *Service) setRemoteLinkEnabled(enabled bool) {
 	s.remoteHost.mu.Lock()
-	if enabled && !s.remoteHost.enabled {
-		s.remoteHost.mu.Unlock()
-		return
-	}
 	manager := s.remoteHost.linkManager
 	s.remoteHost.mu.Unlock()
 	if manager != nil {

--- a/services/tuttid/service/mobileremote/remote_host.go
+++ b/services/tuttid/service/mobileremote/remote_host.go
@@ -40,8 +40,12 @@ type remoteHostState struct {
 	mu sync.Mutex
 
 	cancel             context.CancelFunc
+	enabled            bool
 	stopping           bool
 	stopDone           chan struct{}
+	wake               chan struct{}
+	pollCancel         context.CancelFunc
+	pollGeneration     uint64
 	handler            http.Handler
 	liveEvents         AgentLiveEventSource
 	attempts           map[string]activeRemoteAttempt
@@ -81,6 +85,10 @@ func (s *Service) StartRemoteHost(handler http.Handler) {
 		s.remoteHost.managedLinks = make(map[string]remoteManagedLink)
 		s.remoteHost.observedLinkEvents = make(map[string]uint64)
 		s.remoteHost.linkManager = s.newRemoteLinkManager()
+		if !s.remoteHost.enabled {
+			_ = s.remoteHost.linkManager.SetEnabled(false)
+		}
+		s.remoteHost.wake = make(chan struct{}, 1)
 		s.remoteHost.mu.Unlock()
 
 		go func() {
@@ -131,10 +139,49 @@ func (s *Service) Close() {
 	s.remoteHost.attempts = nil
 	s.remoteHost.managedLinks = nil
 	s.remoteHost.observedLinkEvents = nil
+	s.remoteHost.wake = nil
+	s.remoteHost.pollCancel = nil
 	s.remoteHost.stopping = false
 	s.remoteHost.stopDone = nil
 	close(done)
 	s.remoteHost.mu.Unlock()
+}
+
+// SetRemoteAccessEnabled gates all Desktop owner-side DeviceLink discovery.
+// Disabled hosts keep no pooled links and make no account, pairing, or attempt
+// control-plane requests. Enabling wakes the host immediately instead of
+// waiting for the next periodic interval.
+func (s *Service) SetRemoteAccessEnabled(enabled bool) {
+	if s == nil {
+		return
+	}
+	s.remoteHost.mu.Lock()
+	if s.remoteHost.enabled == enabled {
+		s.remoteHost.mu.Unlock()
+		return
+	}
+	s.remoteHost.enabled = enabled
+	manager := s.remoteHost.linkManager
+	wake := s.remoteHost.wake
+	pollCancel := s.remoteHost.pollCancel
+	s.remoteHost.mu.Unlock()
+
+	if enabled {
+		if manager != nil {
+			_ = manager.SetEnabled(true)
+		}
+	} else {
+		if pollCancel != nil {
+			pollCancel()
+		}
+		s.stopRemoteAttempts(nil)
+	}
+	if wake != nil {
+		select {
+		case wake <- struct{}{}:
+		default:
+		}
+	}
 }
 
 func (s *Service) runRemoteHost(ctx context.Context) {
@@ -142,6 +189,9 @@ func (s *Service) runRemoteHost(ctx context.Context) {
 	if interval <= 0 {
 		interval = defaultRemotePollInterval
 	}
+	s.remoteHost.mu.Lock()
+	wake := s.remoteHost.wake
+	s.remoteHost.mu.Unlock()
 	timer := time.NewTimer(0)
 	defer timer.Stop()
 	for {
@@ -149,42 +199,73 @@ func (s *Service) runRemoteHost(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-timer.C:
-			s.pollRemoteHost(ctx)
+			if s.remoteAccessEnabled() {
+				s.pollRemoteHost(ctx)
+			}
 			timer.Reset(interval)
+		case <-wake:
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			if s.remoteAccessEnabled() {
+				timer.Reset(0)
+			} else {
+				timer.Reset(interval)
+			}
 		}
 	}
 }
 
 func (s *Service) pollRemoteHost(ctx context.Context) {
-	session, identity, err := s.readyIdentity(ctx)
+	pollCtx, finishPoll, ok := s.beginRemotePoll(ctx)
+	if !ok {
+		return
+	}
+	defer finishPoll()
+	session, identity, err := s.readyIdentity(pollCtx)
 	if err != nil {
 		s.stopRemoteAttempts(nil)
 		return
 	}
+	if !s.remoteAccessEnabled() {
+		return
+	}
 	s.setRemoteLinkEnabled(true)
-	registered, err := s.ensureRegisteredDevice(ctx, session.SessionID, session.Cookie, identity)
+	registered, err := s.ensureRegisteredDevice(pollCtx, session.SessionID, session.Cookie, identity)
 	if err != nil {
 		if isControlPlaneUnauthorized(err) {
 			s.stopRemoteAttempts(nil)
 		}
 		return
 	}
-	pairings, err := s.ControlPlane.ListPairings(ctx, session.Cookie)
+	if !s.remoteAccessEnabled() {
+		return
+	}
+	pairings, err := s.ControlPlane.ListPairings(pollCtx, session.Cookie)
 	if err != nil {
 		if isControlPlaneUnauthorized(err) {
 			s.stopRemoteAttempts(nil)
 		}
+		return
+	}
+	if !s.remoteAccessEnabled() {
 		return
 	}
 	validPairings := make(map[string]struct{})
 	for _, pairing := range pairings {
+		if !s.remoteAccessEnabled() {
+			return
+		}
 		if pairing.State != "active" || pairing.TargetUserDeviceID != registered.UserDeviceID {
 			continue
 		}
 		validPairings[pairing.PairingID] = struct{}{}
 		signature := ed25519.Sign(identity.PrivateKey, deviceLinkProof("list", pairing.PairingID, "", ""))
 		attempts, err := s.ControlPlane.ListDeviceLinkAttempts(
-			ctx, session.Cookie, pairing.PairingID, identity.DeviceID, signature,
+			pollCtx, session.Cookie, pairing.PairingID, identity.DeviceID, signature,
 		)
 		if err != nil {
 			if isControlPlaneUnauthorized(err) {
@@ -202,6 +283,28 @@ func (s *Service) pollRemoteHost(ctx context.Context) {
 		}
 	}
 	s.stopRemoteAttempts(validPairings)
+}
+
+func (s *Service) beginRemotePoll(parent context.Context) (context.Context, func(), bool) {
+	s.remoteHost.mu.Lock()
+	if !s.remoteHost.enabled || s.remoteHost.stopping || s.remoteHost.cancel == nil {
+		s.remoteHost.mu.Unlock()
+		return nil, nil, false
+	}
+	pollCtx, cancel := context.WithCancel(parent)
+	s.remoteHost.pollGeneration++
+	generation := s.remoteHost.pollGeneration
+	s.remoteHost.pollCancel = cancel
+	s.remoteHost.mu.Unlock()
+
+	return pollCtx, func() {
+		cancel()
+		s.remoteHost.mu.Lock()
+		if s.remoteHost.pollGeneration == generation {
+			s.remoteHost.pollCancel = nil
+		}
+		s.remoteHost.mu.Unlock()
+	}, true
 }
 
 func (s *Service) ensureRegisteredDevice(
@@ -242,7 +345,7 @@ func (s *Service) startRemoteAttempt(
 	attempt DeviceLinkAttempt,
 ) {
 	s.remoteHost.mu.Lock()
-	if s.remoteHost.stopping || s.remoteHost.cancel == nil || parent.Err() != nil {
+	if !s.remoteHost.enabled || s.remoteHost.stopping || s.remoteHost.cancel == nil || parent.Err() != nil {
 		s.remoteHost.mu.Unlock()
 		return
 	}
@@ -272,6 +375,15 @@ func (s *Service) startRemoteAttempt(
 		}
 		s.serveRemoteAttempt(ctx, handler, liveEvents, cookie, identity, pairingID, attempt)
 	}()
+}
+
+func (s *Service) remoteAccessEnabled() bool {
+	if s == nil {
+		return false
+	}
+	s.remoteHost.mu.Lock()
+	defer s.remoteHost.mu.Unlock()
+	return s.remoteHost.enabled
 }
 
 func (s *Service) finishRemoteAttempt(attemptID string, generation uint64) {
@@ -473,6 +585,10 @@ func (s *Service) stopRemoteAttempts(validPairings map[string]struct{}) {
 
 func (s *Service) setRemoteLinkEnabled(enabled bool) {
 	s.remoteHost.mu.Lock()
+	if enabled && !s.remoteHost.enabled {
+		s.remoteHost.mu.Unlock()
+		return
+	}
 	manager := s.remoteHost.linkManager
 	s.remoteHost.mu.Unlock()
 	if manager != nil {

--- a/services/tuttid/service/mobileremote/remote_host_test.go
+++ b/services/tuttid/service/mobileremote/remote_host_test.go
@@ -150,7 +150,6 @@ func TestRemoteHostConnectsAuthenticatedLinkAndServesAgentHTTP(t *testing.T) {
 		RemotePollInterval: 10 * time.Millisecond,
 		includeLoopback:    true,
 	}
-	service.SetRemoteAccessEnabled(true)
 	service.StartRemoteHost(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet || r.URL.Path != "/v1/workspaces" {
 			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
@@ -215,44 +214,6 @@ func TestRemoteHostConnectsAuthenticatedLinkAndServesAgentHTTP(t *testing.T) {
 	}
 }
 
-func TestRemoteHostDoesNotPollUntilRemoteAccessIsEnabled(t *testing.T) {
-	t.Parallel()
-	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		t.Fatal(err)
-	}
-	registered := make(chan struct{}, 1)
-	service := &Service{
-		Account: &stubAccount{session: &authbridge.Session{
-			SessionID: "account-session", Cookie: "session=cookie",
-		}},
-		Identities: &stubIdentityStore{identity: mobileremotebiz.DeviceIdentity{
-			DeviceID: "desktop-device", PublicKey: publicKey, PrivateKey: privateKey,
-		}},
-		ControlPlane: &remoteHostControlPlane{
-			identityKey: publicKey,
-			registered:  registered,
-			updated:     make(chan DeviceLinkAttempt, 1),
-		},
-		RemotePollInterval: 5 * time.Millisecond,
-	}
-	service.StartRemoteHost(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
-	defer service.Close()
-
-	select {
-	case <-registered:
-		t.Fatal("disabled remote host contacted the control plane")
-	case <-time.After(30 * time.Millisecond):
-	}
-
-	service.SetRemoteAccessEnabled(true)
-	select {
-	case <-registered:
-	case <-time.After(time.Second):
-		t.Fatal("enabling remote access did not wake the remote host")
-	}
-}
-
 func TestRemoteHostAttemptCleanupDoesNotDeleteNewGeneration(t *testing.T) {
 	t.Parallel()
 	service := &Service{}
@@ -272,7 +233,6 @@ func TestRemoteHostAttemptCleanupDoesNotDeleteNewGeneration(t *testing.T) {
 func TestRemoteHostDisablesSharedAdmissionUntilIdentityRecovers(t *testing.T) {
 	t.Parallel()
 	service := &Service{}
-	service.SetRemoteAccessEnabled(true)
 	service.remoteHost.managedLinks = make(map[string]remoteManagedLink)
 	service.remoteHost.observedLinkEvents = make(map[string]uint64)
 	service.remoteHost.linkManager = service.newRemoteLinkManager()

--- a/services/tuttid/service/mobileremote/remote_host_test.go
+++ b/services/tuttid/service/mobileremote/remote_host_test.go
@@ -150,6 +150,7 @@ func TestRemoteHostConnectsAuthenticatedLinkAndServesAgentHTTP(t *testing.T) {
 		RemotePollInterval: 10 * time.Millisecond,
 		includeLoopback:    true,
 	}
+	service.SetRemoteAccessEnabled(true)
 	service.StartRemoteHost(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet || r.URL.Path != "/v1/workspaces" {
 			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
@@ -214,6 +215,44 @@ func TestRemoteHostConnectsAuthenticatedLinkAndServesAgentHTTP(t *testing.T) {
 	}
 }
 
+func TestRemoteHostDoesNotPollUntilRemoteAccessIsEnabled(t *testing.T) {
+	t.Parallel()
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	registered := make(chan struct{}, 1)
+	service := &Service{
+		Account: &stubAccount{session: &authbridge.Session{
+			SessionID: "account-session", Cookie: "session=cookie",
+		}},
+		Identities: &stubIdentityStore{identity: mobileremotebiz.DeviceIdentity{
+			DeviceID: "desktop-device", PublicKey: publicKey, PrivateKey: privateKey,
+		}},
+		ControlPlane: &remoteHostControlPlane{
+			identityKey: publicKey,
+			registered:  registered,
+			updated:     make(chan DeviceLinkAttempt, 1),
+		},
+		RemotePollInterval: 5 * time.Millisecond,
+	}
+	service.StartRemoteHost(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer service.Close()
+
+	select {
+	case <-registered:
+		t.Fatal("disabled remote host contacted the control plane")
+	case <-time.After(30 * time.Millisecond):
+	}
+
+	service.SetRemoteAccessEnabled(true)
+	select {
+	case <-registered:
+	case <-time.After(time.Second):
+		t.Fatal("enabling remote access did not wake the remote host")
+	}
+}
+
 func TestRemoteHostAttemptCleanupDoesNotDeleteNewGeneration(t *testing.T) {
 	t.Parallel()
 	service := &Service{}
@@ -233,6 +272,7 @@ func TestRemoteHostAttemptCleanupDoesNotDeleteNewGeneration(t *testing.T) {
 func TestRemoteHostDisablesSharedAdmissionUntilIdentityRecovers(t *testing.T) {
 	t.Parallel()
 	service := &Service{}
+	service.SetRemoteAccessEnabled(true)
 	service.remoteHost.managedLinks = make(map[string]remoteManagedLink)
 	service.remoteHost.observedLinkEvents = make(map[string]uint64)
 	service.remoteHost.linkManager = service.newRemoteLinkManager()

--- a/services/tuttid/service/preferences/service.go
+++ b/services/tuttid/service/preferences/service.go
@@ -22,12 +22,26 @@ type AgentComposerDefaultsPatchValidator interface {
 	ValidateAgentComposerDefaultsPatch(context.Context, string, preferencesbiz.AgentComposerDefaultsPatch) error
 }
 
+type ChangeObserver func(
+	context.Context,
+	preferencesbiz.DesktopPreferences,
+	preferencesbiz.DesktopPreferences,
+)
+
 type Service struct {
 	Store                          workspacedata.PreferencesStore
 	Publisher                      DesktopPreferencesPublisher
-	AfterPut                       func(context.Context, preferencesbiz.DesktopPreferences, preferencesbiz.DesktopPreferences)
 	AgentComposerDefaultsPublisher AgentComposerDefaultsPublisher
 	AgentComposerDefaultsValidator AgentComposerDefaultsPatchValidator
+	changeObservers                []ChangeObserver
+}
+
+// RegisterChangeObserver adds a startup-wired observer for successful preference changes.
+func (s *Service) RegisterChangeObserver(observer ChangeObserver) {
+	if s == nil || observer == nil {
+		return
+	}
+	s.changeObservers = append(s.changeObservers, observer)
 }
 
 type PatchAgentComposerDefaultsForTargetInput struct {
@@ -173,8 +187,8 @@ func (s Service) Put(ctx context.Context, input PutInput) (preferencesbiz.Deskto
 	if err != nil {
 		return preferencesbiz.DesktopPreferences{}, err
 	}
-	if s.AfterPut != nil {
-		s.AfterPut(ctx, stored, preferences)
+	for _, observer := range s.changeObservers {
+		observer(ctx, stored, preferences)
 	}
 	if s.Publisher != nil {
 		_ = s.Publisher.PublishDesktopPreferencesUpdated(ctx, preferences)

--- a/services/tuttid/service/preferences/service_test.go
+++ b/services/tuttid/service/preferences/service_test.go
@@ -120,18 +120,22 @@ func TestServiceGetReturnsStoredDesktopPreferences(t *testing.T) {
 	}
 }
 
-func TestServicePutNotifiesAfterPutWithPreviousAndCurrentPreferences(t *testing.T) {
+func TestServicePutNotifiesChangeObserversWithPreviousAndCurrentPreferences(t *testing.T) {
 	store := &preferencesStoreStub{getResult: preferencesbiz.DesktopPreferences{
 		FeatureFlags: map[string]bool{"agent.extension.gemini": false},
 	}}
 	var previous, current preferencesbiz.DesktopPreferences
 	service := Service{
 		Store: store,
-		AfterPut: func(_ context.Context, before, after preferencesbiz.DesktopPreferences) {
-			previous = before
-			current = after
-		},
 	}
+	observed := 0
+	service.RegisterChangeObserver(func(_ context.Context, before, after preferencesbiz.DesktopPreferences) {
+		previous = before
+		current = after
+	})
+	service.RegisterChangeObserver(func(context.Context, preferencesbiz.DesktopPreferences, preferencesbiz.DesktopPreferences) {
+		observed++
+	})
 
 	_, err := service.Put(context.Background(), PutInput{
 		FeatureFlags: map[string]bool{"agent.extension.gemini": true},
@@ -144,6 +148,9 @@ func TestServicePutNotifiesAfterPutWithPreviousAndCurrentPreferences(t *testing.
 	}
 	if !current.FeatureFlags["agent.extension.gemini"] {
 		t.Fatalf("current feature flags = %#v", current.FeatureFlags)
+	}
+	if observed != 1 {
+		t.Fatalf("second observer calls = %d, want 1", observed)
 	}
 }
 

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -128,7 +128,7 @@ func buildTuttiServer() (*http.Server, net.Listener, *tuttiWiring, error) {
 	wiring.startAgentCLIUpdateScheduler()
 
 	routes := wiring.routes()
-	wiring.mobileRemoteService.StartRemoteHost(tuttiserver.NewMux(routes))
+	wiring.startMobileRemoteHost(tuttiserver.NewMux(routes))
 	return tuttiserver.NewHTTPServer(listenerSpec, routes), listener, wiring, nil
 }
 
@@ -196,6 +196,17 @@ func (w *tuttiWiring) buildWorkspaceModule(ctx context.Context) error {
 		}
 		if previous.AgentCLIUpdateCheckEnabled != current.AgentCLIUpdateCheckEnabled {
 			w.agentCLIUpdateScheduler.SetEnabled(current.AgentCLIUpdateCheckEnabled)
+		}
+		previousMobileRemoteEnabled := preferencesbiz.IsCapabilityFlagEnabled(
+			previous.FeatureFlags,
+			preferencesbiz.FeatureFlagMobileRemoteAccess,
+		)
+		currentMobileRemoteEnabled := preferencesbiz.IsCapabilityFlagEnabled(
+			current.FeatureFlags,
+			preferencesbiz.FeatureFlagMobileRemoteAccess,
+		)
+		if previousMobileRemoteEnabled != currentMobileRemoteEnabled {
+			w.mobileRemoteService.SetRemoteAccessEnabled(currentMobileRemoteEnabled)
 		}
 	}
 
@@ -303,6 +314,28 @@ func (w *tuttiWiring) startAgentCLIUpdateScheduler() {
 		return
 	}
 	w.agentCLIUpdateScheduler.Start(preferences.AgentCLIUpdateCheckEnabled)
+}
+
+func (w *tuttiWiring) startMobileRemoteHost(handler http.Handler) {
+	if w == nil || w.mobileRemoteService == nil || w.api.PreferencesService == nil {
+		return
+	}
+	enabled := false
+	preferences, err := w.api.PreferencesService.Get(context.Background())
+	if err != nil {
+		slog.Warn(
+			"failed to read mobile remote access preference",
+			"event", "tutti.mobile_remote.preference_read_failed",
+			"error", err,
+		)
+	} else {
+		enabled = preferencesbiz.IsCapabilityFlagEnabled(
+			preferences.FeatureFlags,
+			preferencesbiz.FeatureFlagMobileRemoteAccess,
+		)
+	}
+	w.mobileRemoteService.SetRemoteAccessEnabled(enabled)
+	w.mobileRemoteService.StartRemoteHost(handler)
 }
 
 func resolveAnalyticsDebugPublisher(analyticsConfig tuttitypes.AnalyticsConfig, service analyticsDebugEventStream) reporterservice.DebugPublisher {

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -49,8 +49,14 @@ type tuttiWiring struct {
 	tuttiModeWatchdogCancel      context.CancelFunc
 	tuttiModeWatchdogDone        <-chan struct{}
 	tuttiModeWatchdogClosed      bool
-	mobileRemoteService          *mobileremoteservice.Service
+	mobileRemoteHost             mobileRemoteHost
+	mobileRemoteHandler          http.Handler
 	modelGateway                 *modelgatewayservice.Gateway
+}
+
+type mobileRemoteHost interface {
+	StartRemoteHost(http.Handler)
+	StopRemoteHost()
 }
 
 type analyticsDebugEventPublisher struct {
@@ -180,7 +186,7 @@ func (w *tuttiWiring) buildWorkspaceModule(ctx context.Context) error {
 	if !mobileRemoteOK {
 		return errors.New("mobile remote service wiring is invalid")
 	}
-	w.mobileRemoteService = mobileRemoteService
+	w.mobileRemoteHost = mobileRemoteService
 	preferencesService, preferencesOK := api.PreferencesService.(*preferencesservice.Service)
 	agentStatusService, agentStatusOK := api.AgentStatusService.(*agentstatusservice.Service)
 	if !preferencesOK || !agentStatusOK {
@@ -189,26 +195,7 @@ func (w *tuttiWiring) buildWorkspaceModule(ctx context.Context) error {
 	w.agentCLIUpdateScheduler = agentstatusservice.NewProviderUpdateScheduler(
 		agentstatusservice.ProviderUpdateSchedulerConfig{Discoverer: agentStatusService},
 	)
-	previousAfterPut := preferencesService.AfterPut
-	preferencesService.AfterPut = func(ctx context.Context, previous, current preferencesbiz.DesktopPreferences) {
-		if previousAfterPut != nil {
-			previousAfterPut(ctx, previous, current)
-		}
-		if previous.AgentCLIUpdateCheckEnabled != current.AgentCLIUpdateCheckEnabled {
-			w.agentCLIUpdateScheduler.SetEnabled(current.AgentCLIUpdateCheckEnabled)
-		}
-		previousMobileRemoteEnabled := preferencesbiz.IsCapabilityFlagEnabled(
-			previous.FeatureFlags,
-			preferencesbiz.FeatureFlagMobileRemoteAccess,
-		)
-		currentMobileRemoteEnabled := preferencesbiz.IsCapabilityFlagEnabled(
-			current.FeatureFlags,
-			preferencesbiz.FeatureFlagMobileRemoteAccess,
-		)
-		if previousMobileRemoteEnabled != currentMobileRemoteEnabled {
-			w.mobileRemoteService.SetRemoteAccessEnabled(currentMobileRemoteEnabled)
-		}
-	}
+	w.observeDesktopPreferenceChanges(preferencesService)
 
 	analyticsConfig := tuttitypes.ResolveAnalyticsConfig()
 	debugPublisher := resolveAnalyticsDebugPublisher(analyticsConfig, api.EventStreamService)
@@ -238,6 +225,30 @@ func (w *tuttiWiring) buildWorkspaceModule(ctx context.Context) error {
 	w.appCenterService = appCenterService
 	w.tuttiModeWakeRecoveryStarter = api.OnListenerReady
 	return nil
+}
+
+func (w *tuttiWiring) observeDesktopPreferenceChanges(preferences *preferencesservice.Service) {
+	if w == nil || preferences == nil {
+		return
+	}
+	preferences.RegisterChangeObserver(func(_ context.Context, previous, current preferencesbiz.DesktopPreferences) {
+		if w.agentCLIUpdateScheduler != nil && previous.AgentCLIUpdateCheckEnabled != current.AgentCLIUpdateCheckEnabled {
+			w.agentCLIUpdateScheduler.SetEnabled(current.AgentCLIUpdateCheckEnabled)
+		}
+	})
+	preferences.RegisterChangeObserver(func(_ context.Context, previous, current preferencesbiz.DesktopPreferences) {
+		previousMobileRemoteEnabled := preferencesbiz.IsCapabilityFlagEnabled(
+			previous.FeatureFlags,
+			preferencesbiz.FeatureFlagMobileRemoteAccess,
+		)
+		currentMobileRemoteEnabled := preferencesbiz.IsCapabilityFlagEnabled(
+			current.FeatureFlags,
+			preferencesbiz.FeatureFlagMobileRemoteAccess,
+		)
+		if previousMobileRemoteEnabled != currentMobileRemoteEnabled {
+			w.setMobileRemoteAccessEnabled(currentMobileRemoteEnabled)
+		}
+	})
 }
 
 func (w *tuttiWiring) startTuttiModeWakeRecovery() {
@@ -317,9 +328,10 @@ func (w *tuttiWiring) startAgentCLIUpdateScheduler() {
 }
 
 func (w *tuttiWiring) startMobileRemoteHost(handler http.Handler) {
-	if w == nil || w.mobileRemoteService == nil || w.api.PreferencesService == nil {
+	if w == nil || w.mobileRemoteHost == nil || handler == nil || w.api.PreferencesService == nil {
 		return
 	}
+	w.mobileRemoteHandler = handler
 	enabled := false
 	preferences, err := w.api.PreferencesService.Get(context.Background())
 	if err != nil {
@@ -334,8 +346,18 @@ func (w *tuttiWiring) startMobileRemoteHost(handler http.Handler) {
 			preferencesbiz.FeatureFlagMobileRemoteAccess,
 		)
 	}
-	w.mobileRemoteService.SetRemoteAccessEnabled(enabled)
-	w.mobileRemoteService.StartRemoteHost(handler)
+	w.setMobileRemoteAccessEnabled(enabled)
+}
+
+func (w *tuttiWiring) setMobileRemoteAccessEnabled(enabled bool) {
+	if w == nil || w.mobileRemoteHost == nil {
+		return
+	}
+	if enabled {
+		w.mobileRemoteHost.StartRemoteHost(w.mobileRemoteHandler)
+		return
+	}
+	w.mobileRemoteHost.StopRemoteHost()
 }
 
 func resolveAnalyticsDebugPublisher(analyticsConfig tuttitypes.AnalyticsConfig, service analyticsDebugEventStream) reporterservice.DebugPublisher {
@@ -386,8 +408,8 @@ func (w *tuttiWiring) Close() error {
 	w.stopTuttiModeWatchdogWorker()
 
 	var closeErr error
-	if w.mobileRemoteService != nil {
-		w.mobileRemoteService.Close()
+	if w.mobileRemoteHost != nil {
+		w.mobileRemoteHost.StopRemoteHost()
 	}
 	if w.agentCLIUpdateScheduler != nil {
 		w.agentCLIUpdateScheduler.Close()

--- a/services/tuttid/wiring_daemon_api.go
+++ b/services/tuttid/wiring_daemon_api.go
@@ -120,12 +120,12 @@ func buildDaemonAPI(
 		Discovery:         agentSetupDiscovery,
 		Preferences:       preferencesStore,
 	}
-	preferences.AfterPut = func(ctx context.Context, previous, current preferencesbiz.DesktopPreferences) {
+	preferences.RegisterChangeObserver(func(ctx context.Context, previous, current preferencesbiz.DesktopPreferences) {
 		for _, reconcileErr := range agentExtensionManager.ReconcileDesktopPreferencesChange(ctx, previous, current) {
 			payload, _ := json.Marshal(map[string]string{"error": reconcileErr.Error()})
 			slog.Warn("agent_extension.reconcile_failed", "payload", string(payload))
 		}
-	}
+	})
 	agentTargetInstallPlans := agentextensionservice.InstallPlanService{
 		Manager: agentExtensionManager, Workspaces: store, Targets: agentTargetStore,
 	}

--- a/services/tuttid/wiring_mobile_remote_test.go
+++ b/services/tuttid/wiring_mobile_remote_test.go
@@ -3,11 +3,120 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"net/http"
 	"testing"
 	"time"
 
+	tuttiapi "github.com/tutti-os/tutti/services/tuttid/api"
+	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
 	eventstreamservice "github.com/tutti-os/tutti/services/tuttid/service/eventstream"
+	preferencesservice "github.com/tutti-os/tutti/services/tuttid/service/preferences"
 )
+
+type mobileRemotePreferencesStore struct {
+	current preferencesbiz.DesktopPreferences
+	getErr  error
+}
+
+func (s *mobileRemotePreferencesStore) GetDesktopPreferences(context.Context) (preferencesbiz.DesktopPreferences, error) {
+	return s.current, s.getErr
+}
+
+func (s *mobileRemotePreferencesStore) PutDesktopPreferences(
+	_ context.Context,
+	preferences preferencesbiz.DesktopPreferences,
+) (preferencesbiz.DesktopPreferences, error) {
+	s.current = preferences
+	return preferences, nil
+}
+
+type recordingMobileRemoteHost struct {
+	starts  int
+	closes  int
+	handler http.Handler
+}
+
+func (h *recordingMobileRemoteHost) StartRemoteHost(handler http.Handler) {
+	h.starts++
+	h.handler = handler
+}
+
+func (h *recordingMobileRemoteHost) StopRemoteHost() {
+	h.closes++
+}
+
+func TestStartMobileRemoteHostFollowsPersistedPreference(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name       string
+		flags      map[string]bool
+		getErr     error
+		wantStarts int
+		wantCloses int
+	}{
+		{name: "enabled", flags: map[string]bool{preferencesbiz.FeatureFlagMobileRemoteAccess: true}, wantStarts: 1},
+		{name: "disabled", wantCloses: 1},
+		{name: "read failure fails closed", getErr: errors.New("read failed"), wantCloses: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			preferences := &preferencesservice.Service{Store: &mobileRemotePreferencesStore{
+				current: preferencesbiz.DesktopPreferences{FeatureFlags: test.flags},
+				getErr:  test.getErr,
+			}}
+			host := &recordingMobileRemoteHost{}
+			wiring := &tuttiWiring{
+				api:              tuttiapi.DaemonAPI{PreferencesService: preferences},
+				mobileRemoteHost: host,
+			}
+
+			wiring.startMobileRemoteHost(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+			if host.starts != test.wantStarts || host.closes != test.wantCloses {
+				t.Fatalf(
+					"host lifecycle calls = start %d, close %d; want start %d, close %d",
+					host.starts,
+					host.closes,
+					test.wantStarts,
+					test.wantCloses,
+				)
+			}
+			if test.wantStarts == 1 && host.handler == nil {
+				t.Fatal("started remote host received a nil handler")
+			}
+		})
+	}
+}
+
+func TestMobileRemoteHostTracksPreferenceChanges(t *testing.T) {
+	store := &mobileRemotePreferencesStore{}
+	preferences := &preferencesservice.Service{Store: store}
+	host := &recordingMobileRemoteHost{}
+	wiring := &tuttiWiring{
+		api:              tuttiapi.DaemonAPI{PreferencesService: preferences},
+		mobileRemoteHost: host,
+	}
+	wiring.observeDesktopPreferenceChanges(preferences)
+	wiring.startMobileRemoteHost(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	if _, err := preferences.Put(context.Background(), preferencesservice.PutInput{
+		FeatureFlags: map[string]bool{preferencesbiz.FeatureFlagMobileRemoteAccess: true},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if host.starts != 1 || host.closes != 1 {
+		t.Fatalf("enabled lifecycle calls = start %d, close %d; want start 1, close 1", host.starts, host.closes)
+	}
+
+	if _, err := preferences.Put(context.Background(), preferencesservice.PutInput{}); err != nil {
+		t.Fatal(err)
+	}
+	if host.starts != 1 || host.closes != 2 {
+		t.Fatalf("disabled lifecycle calls = start %d, close %d; want start 1, close 2", host.starts, host.closes)
+	}
+}
 
 func TestMobileAgentLiveEventSourceSubscribesBeforeReady(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- enforce `mobile.remoteAccessSettings` as the daemon-side capability gate for Desktop DeviceLink discovery
- start the existing RemoteHost lifecycle only when access is enabled, and stop it when access is disabled
- replace the mutable single preferences callback with explicit startup-wired change observers
- update Desktop copy, boundary tests, and durable Mobile/DeviceLink documentation

## Root cause

The existing feature flag only controlled whether Mobile Remote Access settings were visible in the Desktop renderer. `tuttid` started RemoteHost unconditionally and polled the control plane every two seconds, even when the user had never enabled the feature.

## Design

The preference-to-lifecycle mapping lives in the daemon composition root. Mobile Remote keeps ownership of polling, attempt cancellation, link quiescence, and restart safety through its existing `StartRemoteHost` lifecycle and the narrow `StopRemoteHost` counterpart.

No parallel `enabled`/wake/poll-generation state machine is introduced. When disabled, Desktop creates no RemoteHost worker or polling timer. Preference effects register through an explicit multi-observer seam, so Mobile Remote, Agent CLI update checks, and Agent Extension reconciliation cannot overwrite one another.

## Impact

Mobile remote access now fails closed. Desktop owner-side discovery starts only after the user enables mobile remote access. Disabling it cancels discovery and active attempts and closes existing remote links.

## Validation

- `go test ./service/preferences ./service/mobileremote .`
- `go test -race ./service/preferences ./service/mobileremote .`
- `pnpm check:changed` — 14 lanes passed
- pre-push `pnpm check:changed -- --push-ready` — 16 lanes passed
- focused Desktop, tuttid, and cross-cutting architecture reviews — no findings

## Documentation

- updated `docs/mobile/README.md`
- updated `docs/specs/2026-07-23-mobile-agentgui-device-link-design.md`
