### PR TITLE
fix(agent-gui): improve image preview dismissal

### DIFF
--- a/.changeset/quiet-images-close.md
+++ b/.changeset/quiet-images-close.md
@@ -1,0 +1,6 @@
+---
+"@tutti-os/agent-gui": patch
+---
+
+Close enlarged image previews from their empty backdrop and present the
+top-right action as an explicit close control.

--- a/packages/agent/gui/app/renderer/components/ZoomableImage.tsx
+++ b/packages/agent/gui/app/renderer/components/ZoomableImage.tsx
@@ -15,9 +15,9 @@ import {
   ToastRoot,
   ToastTitle,
   ToastViewport,
+  CloseIcon,
   CopyIcon,
-  DownloadIcon,
-  RestoreIcon
+  DownloadIcon
 } from "@tutti-os/ui-system";
 import { RotateCcwIcon, ZoomInIcon, ZoomOutIcon } from "lucide-react";
 import { useTranslation } from "../../../i18n/index";
@@ -101,6 +101,25 @@ export function ZoomableImage({
     closeContextMenu();
     setIsImagePreviewClosing(false);
     setIsImagePreviewOpen(true);
+  };
+
+  const handlePreviewSurfaceClick = (
+    event: MouseEvent<HTMLDivElement>
+  ): void => {
+    const target = event.target;
+    if (target === event.currentTarget) {
+      closePreviewImage();
+      return;
+    }
+    if (!(target instanceof HTMLElement)) {
+      return;
+    }
+    if (
+      target.hasAttribute("data-rmiz-modal-overlay") ||
+      target.hasAttribute("data-rmiz-modal-content")
+    ) {
+      closePreviewImage();
+    }
   };
 
   useEffect(() => {
@@ -338,6 +357,7 @@ export function ZoomableImage({
               data-rmiz-modal=""
               role="dialog"
               tabIndex={-1}
+              onClick={handlePreviewSurfaceClick}
               onAnimationEnd={(event) => {
                 if (
                   isImagePreviewClosing &&
@@ -347,10 +367,7 @@ export function ZoomableImage({
                 }
               }}
             >
-              <div
-                data-rmiz-modal-overlay="visible"
-                onClick={closePreviewImage}
-              />
+              <div data-rmiz-modal-overlay="visible" />
               <div data-rmiz-modal-content="true">{previewContent}</div>
               <ImagePreviewZoomControls
                 canZoomIn={canZoomIn}
@@ -371,10 +388,10 @@ export function ZoomableImage({
               <div className="tsh-zoom-dialog__toolbar-actions nodrag tsh-desktop-no-drag">
                 {actionButtons}
                 <Button
-                  aria-label={t("common.minimizeImage")}
+                  aria-label={t("common.close")}
                   className="tsh-zoom-dialog__icon-button nodrag tsh-desktop-no-drag"
                   size="icon"
-                  title={t("common.minimizeImage")}
+                  title={t("common.close")}
                   onPointerDown={(event) => event.stopPropagation()}
                   variant="chrome"
                   onClick={(event) => {
@@ -383,7 +400,7 @@ export function ZoomableImage({
                     closePreviewImage();
                   }}
                 >
-                  <RestoreIcon aria-hidden="true" className="size-4" />
+                  <CloseIcon aria-hidden="true" className="size-4" />
                 </Button>
               </div>
               {contextMenuPosition?.inZoomDialog && actionButtons ? (

--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -963,7 +963,7 @@ describe("AgentMessageMarkdown", () => {
       window.removeEventListener("wheel", windowWheel);
     }
 
-    fireEvent.click(screen.getByRole("button", { name: /Minimize image/ }));
+    fireEvent.click(screen.getByRole("button", { name: /^Close$/ }));
     await waitFor(() => {
       expect(modalImage).toHaveAttribute("data-tsh-image-zoom", "1");
     });
@@ -1041,7 +1041,7 @@ describe("AgentMessageMarkdown", () => {
     const previewActionButtons = [
       screen.getByRole("button", { name: "Copy image" }),
       screen.getByRole("button", { name: "Download image" }),
-      screen.getByRole("button", { name: /Minimize image/ })
+      screen.getByRole("button", { name: /^Close$/ })
     ];
     expect(Array.from(toolbarActions?.children ?? [])).toEqual(
       previewActionButtons
@@ -1081,7 +1081,7 @@ describe("AgentMessageMarkdown", () => {
     clickDownload.mockRestore();
   });
 
-  it("closes the zoom preview when the unzoom button is clicked", async () => {
+  it("closes the zoom preview when the close button is clicked", async () => {
     const readFile = vi.fn().mockResolvedValue({
       bytes: new Uint8Array([137, 80, 78, 71])
     });
@@ -1113,11 +1113,52 @@ describe("AgentMessageMarkdown", () => {
     const dialog = await screen.findByRole("dialog");
     expect(dialog).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: /Minimize image/ }));
+    fireEvent.click(screen.getByRole("button", { name: /^Close$/ }));
     const modalImage = dialog.querySelector("[data-rmiz-modal-img]");
     expect(modalImage).toBeInstanceOf(HTMLElement);
     fireEvent.transitionEnd(modalImage as HTMLElement);
 
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+  });
+
+  it("closes the zoom preview when its empty content area is clicked", async () => {
+    const readFile = vi.fn().mockResolvedValue({
+      bytes: new Uint8Array([137, 80, 78, 71])
+    });
+    window.agentHostApi = {
+      ...(window.agentHostApi ?? {}),
+      workspace: {
+        ...(window.agentHostApi?.workspace ?? {}),
+        readFile
+      }
+    } as typeof window.agentHostApi;
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: vi.fn(() => "blob:tsh-markdown-image")
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: vi.fn()
+    });
+
+    render(
+      <AgentMessageMarkdown
+        content={"![generated image](/workspace/output/imagegen/dance.png)"}
+        enableImageZoom
+      />
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /Zoom image/ }));
+    const dialog = await screen.findByRole("dialog");
+    const emptyContentArea = dialog.querySelector("[data-rmiz-modal-content]");
+    expect(emptyContentArea).toBeInstanceOf(HTMLElement);
+
+    fireEvent.click(emptyContentArea as HTMLElement);
+
+    expect(dialog).toHaveAttribute("data-closing", "true");
+    fireEvent.animationEnd(dialog);
     await waitFor(() => {
       expect(screen.queryByRole("dialog")).toBeNull();
     });


### PR DESCRIPTION
## Summary

- close enlarged image previews when the backdrop or empty modal content area is clicked
- replace the top-right restore/minimize affordance with an explicit Close button and X icon
- add regression coverage and a patch changeset for @tutti-os/agent-gui

No public API, lifecycle, runtime, data-flow, or CSS contract changes. Documentation is not affected because this is a local interaction correction.

## Verification

- pnpm --filter @tutti-os/agent-gui test — 298 files, 2553 tests passed
- pnpm check:changed — 11 selected lanes passed
- pnpm release:pack:check -- --packages-json ["@tutti-os/agent-gui"] — package build and tarball contents passed
- pnpm check:changed -- --push-ready — 12 lanes passed, including the pre-push rerun
- Chromium E2E harness — verified Close label and X icon; backdrop click and Close button each removed the dialog
- independent subagent review — architecture, performance, event propagation, and TSH consumer compatibility passed with no actionable findings

## AgentGUI review lanes

| Lane | Result | Evidence |
| --- | --- | --- |
| Architecture | Pass | UI-local event handling only; no runtime or lifecycle boundary changes |
| Performance | Pass | One click target discriminator; no layout reads, timers, observers, or subscriptions |
| Consumers | Pass | No exported prop or styling contract change; TSH can consume the patch through the normal cohort release |

## Checklist

- [x] Agent lifecycle semantics are unchanged.
- [x] I kept the change focused on one concern.
- [x] Documentation is not affected by this local interaction correction.
- [x] README/CONTRIBUTING language variants are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: git commit -s.