### PR TITLE
fix(agent): settle Claude goal turns reliably

### DIFF
--- a/.changeset/claude-goal-turn-settlement.md
+++ b/.changeset/claude-goal-turn-settlement.md
@@ -1,0 +1,6 @@
+---
+"@tutti-os/agent-gui": patch
+"@tutti-os/claude-sdk-sidecar": patch
+---
+
+Settle Claude Goal turns reliably when provider identity and lifecycle events race, and preserve turnless runtime failures as visible session errors.

--- a/packages/agent/claude-sdk-sidecar/src/messageRouter.ts
+++ b/packages/agent/claude-sdk-sidecar/src/messageRouter.ts
@@ -497,12 +497,14 @@ export class SDKMessageRouter {
     );
     if (
       this.turns.consumeTimedOutContinuationResult() ||
-      this.turns.consumePendingOrphan() ||
-      !this.turns.ensureActive("result")
+      this.turns.consumePendingOrphan()
     ) {
       return;
     }
     await this.ensureProviderTurnAcceptance("streaming");
+    if (!this.turns.ensureActive("result")) {
+      return;
+    }
     const turnId = this.turns.activeId;
     const contextUsageGeneration = this.contextUsageGeneration;
     const assistantError = this.activeRootAssistantError;

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.session.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.session.test.ts
@@ -204,6 +204,87 @@ test("successful result recovers provider Turn identity when SDK omits the root 
   }
 });
 
+test("goal result-only recovery binds provider identity before activation", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-goal-result-only",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) => ({
+        async *[Symbol.asyncIterator]() {
+          await prompt[Symbol.asyncIterator]().next();
+          yield { type: "result", subtype: "success" } as never;
+        },
+        close() {}
+      }),
+      30_000,
+      async (input) => ({
+        providerSessionId: input.sessionId,
+        providerTurnId: "persisted-goal-user-uuid",
+        providerCheckpointMessageId: "persisted-goal-result-uuid"
+      })
+    );
+
+    await session.start();
+    session.exec(
+      "goal-result-only",
+      "/goal ship it",
+      undefined,
+      "goal_arm",
+      {
+        operationId: "goal-op-result",
+        revision: 3,
+        repairEpoch: 2,
+        action: "set"
+      },
+      "",
+      "goal-result-correlation-id"
+    );
+    await waitForEvent(events, "turn_completed");
+
+    const identityIndex = events.findIndex(
+      (event) => event.type === "provider_turn_identity_resolved"
+    );
+    const startedIndex = events.findIndex(
+      (event) => event.type === "turn_started"
+    );
+    const completedIndex = events.findIndex(
+      (event) => event.type === "turn_completed"
+    );
+    assert.ok(identityIndex >= 0 && identityIndex < startedIndex);
+    assert.ok(startedIndex < completedIndex);
+    assert.deepEqual(events[identityIndex]?.payload, {
+      turnId: "goal-result-only",
+      providerTurnId: "persisted-goal-user-uuid",
+      turnOrigin: "goal_arm",
+      sourceGoalOperationId: "goal-op-result",
+      sourceGoalRevision: 3,
+      sourceGoalRepairEpoch: 2
+    });
+    assert.equal(
+      events[completedIndex]?.payload?.providerTurnId,
+      "persisted-goal-user-uuid"
+    );
+  } finally {
+    restoreSink();
+  }
+});
+
 test("interactive request recovers provider Turn identity before waiting when SDK omits the root user echo", async () => {
   const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
   const recoveryInputs: Array<Record<string, string>> = [];

--- a/packages/agent/claude-sdk-sidecar/src/turnLifecycle.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/turnLifecycle.test.ts
@@ -47,6 +47,17 @@ test("turn lifecycle announces a goal arm before its first output", () => {
   lifecycle.activateForUserMessage("prompt-goal");
 
   assert.deepEqual(
+    events.find((event) => event.type === "provider_turn_identity_resolved"),
+    {
+      type: "provider_turn_identity_resolved",
+      payload: {
+        turnId: "goal-arm-1",
+        providerTurnId: "prompt-goal",
+        turnOrigin: "goal_arm"
+      }
+    }
+  );
+  assert.deepEqual(
     events.find((event) => event.type === "turn_started"),
     {
       type: "turn_started",
@@ -126,6 +137,13 @@ test("goal activation carries its immutable command identity", () => {
   assert.equal(applied?.payload?.operationId, "goal-op-1");
   assert.equal(applied?.payload?.revision, 1);
   assert.equal(applied?.payload?.repairEpoch, 7);
+  const identity = events.find(
+    (event) => event.type === "provider_turn_identity_resolved"
+  );
+  assert.equal(identity?.payload?.turnOrigin, "goal_arm");
+  assert.equal(identity?.payload?.sourceGoalOperationId, "goal-op-1");
+  assert.equal(identity?.payload?.sourceGoalRevision, 1);
+  assert.equal(identity?.payload?.sourceGoalRepairEpoch, 7);
   const started = events.find((event) => event.type === "turn_started");
   assert.equal(started?.payload?.sourceGoalOperationId, "goal-op-1");
   assert.equal(started?.payload?.sourceGoalRevision, 1);

--- a/packages/agent/claude-sdk-sidecar/src/turnLifecycle.ts
+++ b/packages/agent/claude-sdk-sidecar/src/turnLifecycle.ts
@@ -24,6 +24,21 @@ export type RuntimeTurn = {
 
 type TerminalEvent = "turn_completed" | "turn_canceled" | "turn_failed";
 
+function turnProvenancePayload(
+  turn: RuntimeTurn
+): Record<string, string | number> {
+  return {
+    ...(turn.origin ? { turnOrigin: turn.origin } : {}),
+    ...(turn.goalOperationId
+      ? { sourceGoalOperationId: turn.goalOperationId }
+      : {}),
+    ...(turn.goalRevision ? { sourceGoalRevision: turn.goalRevision } : {}),
+    ...(turn.goalRepairEpoch
+      ? { sourceGoalRepairEpoch: turn.goalRepairEpoch }
+      : {})
+  };
+}
+
 export class TurnLifecycle {
   private readonly turns: RuntimeTurn[] = [];
   private readonly emit: ClaudeSDKSidecarEventEmitter;
@@ -386,16 +401,7 @@ export class TurnLifecycle {
         payload: {
           turnId: turn.turnId,
           ...(turn.synthetic ? { synthetic: true } : {}),
-          ...(turn.origin ? { turnOrigin: turn.origin } : {}),
-          ...(turn.goalOperationId
-            ? { sourceGoalOperationId: turn.goalOperationId }
-            : {}),
-          ...(turn.goalRevision
-            ? { sourceGoalRevision: turn.goalRevision }
-            : {}),
-          ...(turn.goalRepairEpoch
-            ? { sourceGoalRepairEpoch: turn.goalRepairEpoch }
-            : {})
+          ...turnProvenancePayload(turn)
         }
       });
     }
@@ -460,7 +466,8 @@ export class TurnLifecycle {
       type: "provider_turn_identity_resolved",
       payload: {
         turnId: turn.turnId,
-        providerTurnId
+        providerTurnId,
+        ...turnProvenancePayload(turn)
       }
     });
     return true;

--- a/packages/agent/daemon/runtime/activity_projection.go
+++ b/packages/agent/daemon/runtime/activity_projection.go
@@ -63,7 +63,9 @@ func ProjectActivityEventsToStreamEvents(session Session, events []activityshare
 			out = append(out, StreamEvent{EventType: StreamEventSessionAudit, Data: audit})
 		}
 		if shouldAppendVisibleFailure(events, event) {
-			if update, ok := visibleFailureMessageUpdate(source, event, sessionID, timestamp); ok {
+			if audit, ok := visibleFailureSessionAuditUpdate(source, event, sessionID, timestamp); ok {
+				out = append(out, StreamEvent{EventType: StreamEventSessionAudit, Data: audit})
+			} else if update, ok := visibleFailureMessageUpdate(source, event, sessionID, timestamp); ok {
 				out = append(out, StreamEvent{
 					EventType: StreamEventMessageUpdate,
 					Data:      update,

--- a/packages/agent/daemon/runtime/activity_projection_test.go
+++ b/packages/agent/daemon/runtime/activity_projection_test.go
@@ -564,6 +564,33 @@ func TestSessionAuditProjectsSeparatelyFromTurnMessages(t *testing.T) {
 	}
 }
 
+func TestSessionFailureProjectsVisibleAuditWithoutTurn(t *testing.T) {
+	t.Parallel()
+	session := reportTestSession()
+	event := newSessionActivityEvent(session, EventSessionFailed, SessionStatusFailed, map[string]any{
+		"error": "provider failed before turn admission",
+	})
+
+	report := reportActivityInput(session, []activityshared.Event{event})
+	if len(report.StatePatches) != 1 || len(report.SessionAudits) != 1 || len(report.MessageUpdates) != 0 {
+		t.Fatalf("report = %#v, want state plus turnless visible audit", report)
+	}
+	audit := report.SessionAudits[0]
+	if audit.AuditID == "" || audit.Role != RoleAssistant || audit.Payload["kind"] != visibleErrorKind ||
+		audit.Payload["phase"] != "start" || audit.Payload["detail"] != "provider failed before turn admission" {
+		t.Fatalf("visible failure audit = %#v", audit)
+	}
+
+	stream := ProjectActivityEventsToStreamEvents(session, []activityshared.Event{event})
+	if len(stream) != 2 || stream[0].EventType != StreamEventStatePatch || stream[1].EventType != StreamEventSessionAudit {
+		t.Fatalf("stream = %#v, want state plus session audit", stream)
+	}
+	streamAudit, ok := stream[1].Data.(agentsessionstore.WorkspaceAgentSessionAuditUpdate)
+	if !ok || streamAudit.AuditID != audit.AuditID {
+		t.Fatalf("stream audit = %#v, want durable audit identity %q", stream[1].Data, audit.AuditID)
+	}
+}
+
 func TestGoalReconcileRequiredProjectsOnlyToInternalControlReport(t *testing.T) {
 	t.Parallel()
 	session := reportTestSession()
@@ -954,6 +981,14 @@ func TestProjectActivityEventsToStreamEventsAddsVisibleTurnFailureMessage(t *tes
 			"error": "\x1b[33mAPI Error: 429 rate limit\x1b[39m",
 		}),
 	})
+	report := reportActivityInput(session, []activityshared.Event{
+		newTurnActivityEventWithID(session, "turn-failed-report-1", EventTurnFailed, "turn-1", SessionStatusFailed, "", "", map[string]any{
+			"error": "API Error: 429 rate limit",
+		}),
+	})
+	if len(report.MessageUpdates) != 1 || len(report.SessionAudits) != 0 {
+		t.Fatalf("turn failure report = %#v, want turn message only", report)
+	}
 
 	if len(events) != 2 {
 		t.Fatalf("stream events = %#v, want state patch and visible failure message", events)

--- a/packages/agent/daemon/runtime/claude_sdk_adapter.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter.go
@@ -93,7 +93,24 @@ type claudeSDKAdapterSession struct {
 	goalRevision         int64
 	goalRepairEpoch      int64
 	fencedGoalIdentities map[goalOperationIdentity]struct{}
-	fencedGoalTurns      map[string]struct{}
+	fencedGoalTurns      map[string]claudeSDKGoalTurnFenceState
+	goalTurnBindings     map[string]claudeSDKGoalTurnBinding
+}
+
+type claudeSDKGoalTurnFenceState uint8
+
+const (
+	claudeSDKGoalTurnFenceSuppress claudeSDKGoalTurnFenceState = iota + 1
+	claudeSDKGoalTurnFenceSettle
+)
+
+type claudeSDKGoalTurnBinding struct {
+	turnID          string
+	providerTurnID  string
+	origin          string
+	identity        goalOperationIdentity
+	published       bool
+	publicationDone chan struct{}
 }
 
 type claudeSDKCompactMessage struct {

--- a/packages/agent/daemon/runtime/claude_sdk_events.go
+++ b/packages/agent/daemon/runtime/claude_sdk_events.go
@@ -50,12 +50,6 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 	}
 	explicitProviderTurnID := payloadString(event.Payload, "providerTurnId")
 	activeProviderTurnID := a.activeClaudeSDKRootProviderTurnID(adapterSession)
-	if explicitProviderTurnID != "" &&
-		activeProviderTurnID != "" &&
-		explicitProviderTurnID != activeProviderTurnID &&
-		claudeSDKEventRequiresBoundProviderIdentity(event.Type) {
-		return nil, false, errors.New("claude SDK provider turn identity changed after binding")
-	}
 	boundProviderTurnID := firstNonEmptyString(
 		explicitProviderTurnID,
 		activeProviderTurnID,
@@ -65,31 +59,55 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 		strings.TrimSpace(turnID),
 		eventTurnID,
 	)
-	if event.Type == "turn_started" {
-		providerTurnID = firstNonEmptyString(
-			explicitProviderTurnID,
-			strings.TrimSpace(turnID),
-			eventTurnID,
-		)
-	}
 	a.mu.Lock()
-	_, fencedGoalTurn := adapterSession.fencedGoalTurns[providerTurnID]
-	if fencedGoalTurn && isClaudeSDKTerminalEvent(event.Type) {
+	fenceState := adapterSession.fencedGoalTurns[providerTurnID]
+	if turnFenceState := adapterSession.fencedGoalTurns[eventTurnID]; turnFenceState > fenceState {
+		fenceState = turnFenceState
+	}
+	if fenceState != 0 && event.Type == "provider_turn_identity_resolved" && explicitProviderTurnID != "" {
+		binding, bound := adapterSession.goalTurnBindings[eventTurnID]
+		if bound && (binding.providerTurnID == "" || binding.providerTurnID == explicitProviderTurnID) {
+			binding.providerTurnID = explicitProviderTurnID
+			adapterSession.goalTurnBindings[eventTurnID] = binding
+			adapterSession.fencedGoalTurns[explicitProviderTurnID] = fenceState
+			if adapterSession.rootProviderTurns == nil {
+				adapterSession.rootProviderTurns = make(map[string]struct{})
+			}
+			adapterSession.rootProviderTurns[explicitProviderTurnID] = struct{}{}
+		}
+	}
+	terminalEvent := isClaudeSDKTerminalEvent(event.Type)
+	if fenceState != 0 && terminalEvent {
 		delete(adapterSession.fencedGoalTurns, providerTurnID)
+		delete(adapterSession.fencedGoalTurns, eventTurnID)
+		delete(adapterSession.goalTurnBindings, eventTurnID)
+		delete(adapterSession.rootProviderTurns, providerTurnID)
+		delete(adapterSession.rootProviderTurns, eventTurnID)
 	}
 	a.mu.Unlock()
-	if fencedGoalTurn {
-		return nil, isClaudeSDKTerminalEvent(event.Type), nil
+	if fenceState != 0 && (!terminalEvent || fenceState == claudeSDKGoalTurnFenceSuppress) {
+		return nil, terminalEvent, nil
 	}
-	goalClearControlTurn := a.isGoalClearControlTurn(adapterSession, providerTurnID)
+	if explicitProviderTurnID != "" &&
+		activeProviderTurnID != "" &&
+		explicitProviderTurnID != activeProviderTurnID &&
+		claudeSDKEventRequiresBoundProviderIdentity(event.Type) {
+		return nil, false, errors.New("claude SDK provider turn identity changed after binding")
+	}
+	goalClearControlTurn := a.isGoalClearControlTurn(adapterSession, providerTurnID) ||
+		a.isGoalClearControlTurn(adapterSession, eventTurnID)
 	if goalClearControlTurn && isClaudeSDKGoalClearHiddenEvent(event.Type) {
 		return nil, false, nil
 	}
 	if goalClearControlTurn && isClaudeSDKTerminalEvent(event.Type) {
 		a.forgetGoalClearControlTurn(adapterSession, providerTurnID)
+		a.forgetGoalClearControlTurn(adapterSession, eventTurnID)
 		return nil, true, nil
 	}
-	rootTurnID := a.claudeSDKRootTurnID(adapterSession, providerTurnID)
+	rootTurnID := ""
+	if event.Type != "provider_turn_identity_resolved" && event.Type != "turn_started" {
+		rootTurnID = a.claudeSDKRootTurnID(adapterSession, providerTurnID)
+	}
 	if events, handled := claudeSDKSidecarBackgroundTaskEvents(adapterSession, session, event); handled {
 		return events, false, nil
 	}
@@ -102,12 +120,27 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 		if eventTurnID == "" || explicitProviderTurnID == "" {
 			return nil, false, errors.New("claude SDK provider turn identity resolution omitted identity")
 		}
+		admission, err := a.admitClaudeSDKGoalTurn(adapterSession, eventTurnID, explicitProviderTurnID, event.Payload)
+		if err != nil {
+			return nil, false, err
+		}
+		if admission.denied() {
+			a.rejectClaudeSDKGoalTurn(adapterSession, session, eventTurnID, explicitProviderTurnID, admission)
+			return nil, false, nil
+		}
+		if admission.goalTurn && !a.publishClaudeSDKGoalTurn(adapterSession, eventTurnID) {
+			return nil, false, nil
+		}
 		a.beginClaudeSDKRootTurn(adapterSession, eventTurnID, explicitProviderTurnID)
+		metadata := map[string]any{"adapter": claudeSDKSidecarAdapterName}
+		for key, value := range admission.metadata {
+			metadata[key] = value
+		}
 		return []activityshared.Event{a.claudeSDKRootProviderTurnStartedEvent(
 			session,
 			eventTurnID,
 			explicitProviderTurnID,
-			map[string]any{"adapter": claudeSDKSidecarAdapterName},
+			metadata,
 		)}, false, nil
 	case "provider_turn_checkpoint":
 		checkpointMessageID := payloadString(
@@ -129,48 +162,34 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 		metadata := map[string]any{
 			"adapter": claudeSDKSidecarAdapterName,
 		}
-		providerCreatedGoalTurn := false
-		if origin := payloadString(event.Payload, "turnOrigin"); origin != "" {
-			metadata["turnOrigin"] = origin
-			if origin == "goal_arm" || origin == "goal_continuation" {
-				providerCreatedGoalTurn = true
-				// Goal control does not pre-allocate a canonical Turn. The provider's
-				// turn_started event is the first authoritative Turn fact, so it also
-				// starts a fresh root mapping instead of inheriting the preceding user
-				// Turn from this long-lived SDK session.
-				rootTurnID = providerTurnID
-				a.beginClaudeSDKRootTurn(adapterSession, rootTurnID, providerTurnID)
-				operationID := payloadString(event.Payload, "sourceGoalOperationId")
-				revision := payloadInt64(event.Payload, "sourceGoalRevision")
-				repairEpoch := payloadInt64(event.Payload, "sourceGoalRepairEpoch")
-				metadata["sourceGoalOperationId"] = operationID
-				metadata["sourceGoalRevision"] = revision
-				metadata["sourceGoalRepairEpoch"] = repairEpoch
-				a.mu.Lock()
-				latestRevision, latestRepairEpoch := adapterSession.goalRevision, adapterSession.goalRepairEpoch
-				identity := goalOperationIdentity{
-					operationID: operationID,
-					revision:    revision,
-					repairEpoch: repairEpoch,
-				}
-				_, fenced := adapterSession.fencedGoalIdentities[identity]
-				if fenced {
-					if adapterSession.fencedGoalTurns == nil {
-						adapterSession.fencedGoalTurns = make(map[string]struct{})
-					}
-					adapterSession.fencedGoalTurns[providerTurnID] = struct{}{}
-				}
-				a.mu.Unlock()
-				if fenced {
-					a.cancelClaudeSDKGoalTurn(adapterSession, session, providerTurnID, revision, repairEpoch)
-					return nil, false, nil
-				}
-				if revision > 0 && revision == latestRevision && repairEpoch < latestRepairEpoch {
-					a.cancelClaudeSDKGoalTurn(adapterSession, session, providerTurnID, revision, repairEpoch)
-				}
-			}
+		admission, err := a.admitClaudeSDKGoalTurn(adapterSession, eventTurnID, explicitProviderTurnID, event.Payload)
+		if err != nil {
+			return nil, false, err
 		}
-		if !providerCreatedGoalTurn {
+		if admission.denied() {
+			a.rejectClaudeSDKGoalTurn(adapterSession, session, eventTurnID, providerTurnID, admission)
+			return nil, false, nil
+		}
+		if admission.goalTurn && explicitProviderTurnID == "" {
+			return nil, false, nil
+		}
+		if admission.goalTurn && !a.publishClaudeSDKGoalTurn(adapterSession, eventTurnID) {
+			return nil, false, nil
+		}
+		if !admission.goalTurn {
+			providerTurnID = firstNonEmptyString(explicitProviderTurnID, strings.TrimSpace(turnID), eventTurnID)
+		}
+		for key, value := range admission.metadata {
+			metadata[key] = value
+		}
+		if admission.goalTurn {
+			// Goal control does not pre-allocate a canonical Turn. The provider's
+			// first identity/start fact starts a fresh root mapping instead of
+			// inheriting the preceding user Turn from this long-lived SDK session.
+			rootTurnID = firstNonEmptyString(eventTurnID, strings.TrimSpace(turnID), providerTurnID)
+			a.beginClaudeSDKRootTurn(adapterSession, rootTurnID, providerTurnID)
+		} else {
+			rootTurnID = a.claudeSDKRootTurnID(adapterSession, providerTurnID)
 			a.rememberClaudeSDKRootProviderTurn(adapterSession, providerTurnID)
 		}
 		if payloadBoolValue(event.Payload, "synthetic") {
@@ -350,7 +369,8 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 			"adapter":    claudeSDKSidecarAdapterName,
 			"stopReason": firstNonEmpty(payloadString(event.Payload, "stopReason"), "end_turn"),
 		}))
-		events = append(events, a.goalEventsOnTurnSettled(adapterSession, session, providerTurnID, true)...)
+		events = append(events, a.goalEventsOnTurnSettled(adapterSession, session, firstNonEmptyString(eventTurnID, strings.TrimSpace(turnID), providerTurnID), true)...)
+		a.forgetClaudeSDKGoalTurnBinding(adapterSession, eventTurnID)
 		return events, true, nil
 	case "turn_canceled":
 		if boundProviderTurnID == "" {
@@ -366,7 +386,8 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 		events = append(events, claudeSDKRootProviderTurnCompletedEvent(session, rootTurnID, boundProviderTurnID, activityshared.TurnOutcomeCanceled, map[string]any{
 			"adapter": claudeSDKSidecarAdapterName,
 		}))
-		events = append(events, a.goalEventsOnTurnSettled(adapterSession, session, providerTurnID, false)...)
+		events = append(events, a.goalEventsOnTurnSettled(adapterSession, session, firstNonEmptyString(eventTurnID, strings.TrimSpace(turnID), providerTurnID), false)...)
+		a.forgetClaudeSDKGoalTurnBinding(adapterSession, eventTurnID)
 		return events, true, nil
 	case "turn_failed":
 		if boundProviderTurnID == "" {
@@ -383,29 +404,11 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 			"adapter": claudeSDKSidecarAdapterName,
 			"error":   payloadString(event.Payload, "error"),
 		}))
-		events = append(events, a.goalEventsOnTurnSettled(adapterSession, session, providerTurnID, false)...)
+		events = append(events, a.goalEventsOnTurnSettled(adapterSession, session, firstNonEmptyString(eventTurnID, strings.TrimSpace(turnID), providerTurnID), false)...)
+		a.forgetClaudeSDKGoalTurnBinding(adapterSession, eventTurnID)
 		return events, true, nil
 	default:
 		return nil, false, nil
-	}
-}
-
-func claudeSDKEventRequiresBoundProviderIdentity(eventType string) bool {
-	switch eventType {
-	case "provider_turn_identity_resolved",
-		"provider_turn_checkpoint":
-		return true
-	default:
-		return false
-	}
-}
-
-func isClaudeSDKGoalClearHiddenEvent(eventType string) bool {
-	switch eventType {
-	case "turn_started", "provider_turn_checkpoint", "assistant_delta", "assistant_completed", "assistant_failed", "thinking_delta", "thinking_completed":
-		return true
-	default:
-		return false
 	}
 }
 
@@ -541,6 +544,7 @@ func (a *ClaudeCodeSDKAdapter) dispatchClaudeSDKEvent(agentSessionID string, ada
 		}))
 	}
 	a.emitClaudeSDKSessionEvents(agentSessionID, next)
+	a.finishClaudeSDKGoalTurnPublication(adapterSession, next)
 }
 
 func (a *ClaudeCodeSDKAdapter) logClaudeSDKLifecycleEvent(agentSessionID string, adapterSession *claudeSDKAdapterSession, event claudeSDKSidecarEvent) {

--- a/packages/agent/daemon/runtime/claude_sdk_goal.go
+++ b/packages/agent/daemon/runtime/claude_sdk_goal.go
@@ -123,7 +123,7 @@ func (*ClaudeCodeSDKAdapter) GoalCapabilities() GoalAdapterCapabilities {
 }
 
 func (a *ClaudeCodeSDKAdapter) FenceGoalGeneration(
-	_ context.Context,
+	ctx context.Context,
 	session Session,
 	input GoalGenerationFenceInput,
 ) error {
@@ -136,15 +136,40 @@ func (a *ClaudeCodeSDKAdapter) FenceGoalGeneration(
 		return errors.New("valid Goal generation fence identity is required")
 	}
 	a.mu.Lock()
-	defer a.mu.Unlock()
 	adapterSession := a.sessions[strings.TrimSpace(session.AgentSessionID)]
 	if adapterSession == nil {
+		a.mu.Unlock()
 		return ErrSessionDisconnected
 	}
 	if adapterSession.fencedGoalIdentities == nil {
 		adapterSession.fencedGoalIdentities = make(map[goalOperationIdentity]struct{})
 	}
 	adapterSession.fencedGoalIdentities[identity] = struct{}{}
+	bindings := make([]claudeSDKGoalTurnBinding, 0, 1)
+	publicationDone := make([]<-chan struct{}, 0, 1)
+	for _, binding := range adapterSession.goalTurnBindings {
+		if binding.identity != identity {
+			continue
+		}
+		markClaudeSDKGoalTurnFencedLocked(adapterSession, binding.published, binding.turnID, binding.providerTurnID)
+		bindings = append(bindings, binding)
+		if binding.published && binding.publicationDone != nil {
+			publicationDone = append(publicationDone, binding.publicationDone)
+		}
+	}
+	a.mu.Unlock()
+	for _, binding := range bindings {
+		a.rememberClaudeSDKRootProviderTurn(adapterSession, binding.turnID)
+		a.rememberClaudeSDKRootProviderTurn(adapterSession, binding.providerTurnID)
+		a.cancelClaudeSDKGoalTurn(adapterSession, session, binding.turnID, identity.revision, identity.repairEpoch)
+	}
+	for _, done := range publicationDone {
+		select {
+		case <-done:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
 	return nil
 }
 
@@ -232,6 +257,211 @@ func (a *ClaudeCodeSDKAdapter) restoreClaudeGoalOperationIdentity(adapterSession
 		return
 	}
 	adapterSession.goalOperationID, adapterSession.goalRevision, adapterSession.goalRepairEpoch = previousOperationID, previousRevision, previousRepairEpoch
+}
+
+type claudeSDKGoalTurnAdmission struct {
+	metadata map[string]any
+	origin   string
+	identity goalOperationIdentity
+	goalTurn bool
+	fenced   bool
+	stale    bool
+}
+
+func (admission claudeSDKGoalTurnAdmission) denied() bool {
+	return admission.fenced || admission.stale
+}
+
+// admitClaudeSDKGoalTurn applies the same exact Goal-generation rule at both
+// provider identity and turn-start barriers. Provenance comes only from the
+// sidecar's immutable RuntimeTurn; mutable session Goal state is never used to
+// guess which durable operation created a Turn.
+func (a *ClaudeCodeSDKAdapter) admitClaudeSDKGoalTurn(
+	adapterSession *claudeSDKAdapterSession,
+	turnID string,
+	providerTurnID string,
+	payload map[string]any,
+) (claudeSDKGoalTurnAdmission, error) {
+	origin := strings.TrimSpace(payloadString(payload, "turnOrigin"))
+	operationID := strings.TrimSpace(payloadString(payload, "sourceGoalOperationId"))
+	revision := payloadInt64(payload, "sourceGoalRevision")
+	repairEpoch := payloadInt64(payload, "sourceGoalRepairEpoch")
+	if origin != "goal_arm" && origin != "goal_continuation" {
+		return claudeSDKGoalTurnAdmission{}, nil
+	}
+	admission := claudeSDKGoalTurnAdmission{
+		metadata: map[string]any{
+			"turnOrigin":            origin,
+			"sourceGoalOperationId": operationID,
+			"sourceGoalRevision":    revision,
+			"sourceGoalRepairEpoch": repairEpoch,
+		},
+		origin: origin,
+		identity: goalOperationIdentity{
+			operationID: operationID,
+			revision:    revision,
+			repairEpoch: repairEpoch,
+		},
+		goalTurn: true,
+	}
+	if !admission.identity.valid() {
+		return claudeSDKGoalTurnAdmission{}, errors.New("claude SDK Goal turn omitted generation identity")
+	}
+	if a == nil || adapterSession == nil {
+		return admission, nil
+	}
+
+	turnID = strings.TrimSpace(turnID)
+	providerTurnID = strings.TrimSpace(providerTurnID)
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	_, admission.fenced = adapterSession.fencedGoalIdentities[admission.identity]
+	admission.stale = adapterSession.goalOperationID == admission.identity.operationID &&
+		adapterSession.goalRevision == admission.identity.revision &&
+		adapterSession.goalRepairEpoch > admission.identity.repairEpoch
+	if admission.denied() {
+		markClaudeSDKGoalTurnFencedLocked(adapterSession, false, turnID, providerTurnID)
+		return admission, nil
+	}
+	if turnID == "" {
+		return claudeSDKGoalTurnAdmission{}, errors.New("claude SDK Goal turn omitted identity")
+	}
+	if adapterSession.goalTurnBindings == nil {
+		adapterSession.goalTurnBindings = make(map[string]claudeSDKGoalTurnBinding)
+	}
+	if existing, ok := adapterSession.goalTurnBindings[turnID]; ok {
+		if existing.origin != admission.origin || existing.identity != admission.identity ||
+			(existing.providerTurnID != "" && providerTurnID != "" && existing.providerTurnID != providerTurnID) {
+			return claudeSDKGoalTurnAdmission{}, errors.New("claude SDK Goal turn provenance changed after binding")
+		}
+		if existing.providerTurnID == "" {
+			existing.providerTurnID = providerTurnID
+		}
+		adapterSession.goalTurnBindings[turnID] = existing
+		return admission, nil
+	}
+	adapterSession.goalTurnBindings[turnID] = claudeSDKGoalTurnBinding{
+		turnID: turnID, providerTurnID: providerTurnID,
+		origin: admission.origin, identity: admission.identity,
+	}
+	return admission, nil
+}
+
+func markClaudeSDKGoalTurnFencedLocked(adapterSession *claudeSDKAdapterSession, settle bool, turnIDs ...string) {
+	if adapterSession == nil {
+		return
+	}
+	if adapterSession.fencedGoalTurns == nil {
+		adapterSession.fencedGoalTurns = make(map[string]claudeSDKGoalTurnFenceState)
+	}
+	state := claudeSDKGoalTurnFenceSuppress
+	if settle {
+		state = claudeSDKGoalTurnFenceSettle
+	}
+	for _, turnID := range turnIDs {
+		if turnID = strings.TrimSpace(turnID); turnID != "" {
+			if adapterSession.fencedGoalTurns[turnID] < state {
+				adapterSession.fencedGoalTurns[turnID] = state
+			}
+		}
+	}
+}
+
+// publishClaudeSDKGoalTurn is the in-memory linearization point between
+// provider admission and event publication. A fence that wins first suppresses
+// the start entirely; a fence that wins after this point must preserve the
+// terminal event so the reporter FIFO can settle the already-published start.
+func (a *ClaudeCodeSDKAdapter) publishClaudeSDKGoalTurn(
+	adapterSession *claudeSDKAdapterSession,
+	turnID string,
+) bool {
+	if a == nil || adapterSession == nil {
+		return false
+	}
+	turnID = strings.TrimSpace(turnID)
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	binding, ok := adapterSession.goalTurnBindings[turnID]
+	if !ok || adapterSession.fencedGoalTurns[turnID] != 0 {
+		return false
+	}
+	if binding.published {
+		return false
+	}
+	if _, fenced := adapterSession.fencedGoalIdentities[binding.identity]; fenced {
+		markClaudeSDKGoalTurnFencedLocked(adapterSession, false, binding.turnID, binding.providerTurnID)
+		return false
+	}
+	binding.published = true
+	binding.publicationDone = make(chan struct{})
+	adapterSession.goalTurnBindings[turnID] = binding
+	return true
+}
+
+func (a *ClaudeCodeSDKAdapter) finishClaudeSDKGoalTurnPublication(
+	adapterSession *claudeSDKAdapterSession,
+	events []activityshared.Event,
+) {
+	if a == nil || adapterSession == nil || len(events) == 0 {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, event := range events {
+		if event.Type != activityshared.EventRootProviderTurnStarted {
+			continue
+		}
+		origin := strings.TrimSpace(payloadString(event.Payload.Metadata, "turnOrigin"))
+		if origin != "goal_arm" && origin != "goal_continuation" {
+			continue
+		}
+		turnID := strings.TrimSpace(event.Payload.TurnID)
+		binding, ok := adapterSession.goalTurnBindings[turnID]
+		if !ok || !binding.published || binding.publicationDone == nil {
+			continue
+		}
+		close(binding.publicationDone)
+		binding.publicationDone = nil
+		adapterSession.goalTurnBindings[turnID] = binding
+	}
+}
+
+func isClaudeSDKGoalClearHiddenEvent(eventType string) bool {
+	switch eventType {
+	case "provider_turn_identity_resolved", "turn_started", "provider_turn_checkpoint", "assistant_delta", "assistant_completed", "assistant_failed", "thinking_delta", "thinking_completed":
+		return true
+	default:
+		return false
+	}
+}
+
+func (a *ClaudeCodeSDKAdapter) rejectClaudeSDKGoalTurn(
+	adapterSession *claudeSDKAdapterSession,
+	session Session,
+	turnID string,
+	providerTurnID string,
+	admission claudeSDKGoalTurnAdmission,
+) {
+	// Retain both aliases until the provider terminal event so dispatcher
+	// filtering cannot discard the cleanup event before the fence consumes it.
+	a.rememberClaudeSDKRootProviderTurn(adapterSession, turnID)
+	a.rememberClaudeSDKRootProviderTurn(adapterSession, providerTurnID)
+	a.cancelClaudeSDKGoalTurn(
+		adapterSession,
+		session,
+		turnID,
+		admission.identity.revision,
+		admission.identity.repairEpoch,
+	)
+}
+
+func (a *ClaudeCodeSDKAdapter) forgetClaudeSDKGoalTurnBinding(adapterSession *claudeSDKAdapterSession, turnID string) {
+	if a == nil || adapterSession == nil {
+		return
+	}
+	a.mu.Lock()
+	delete(adapterSession.goalTurnBindings, strings.TrimSpace(turnID))
+	a.mu.Unlock()
 }
 
 func (a *ClaudeCodeSDKAdapter) ReconcileGoal(_ context.Context, session Session) (GoalAdapterResult, error) {

--- a/packages/agent/daemon/runtime/claude_sdk_goal_lifecycle_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_goal_lifecycle_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
@@ -38,6 +40,41 @@ func claudeSDKSnapshotForEvent(t *testing.T, events []activityshared.Event, even
 	}
 	t.Fatalf("no %s event in %#v", eventType, events)
 	return activityshared.TurnLifecycleSnapshot{}
+}
+
+type blockingFirstClaudeGoalReporter struct {
+	mu      sync.Mutex
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+	reports []agentsessionstore.ReportActivityInput
+}
+
+func (r *blockingFirstClaudeGoalReporter) Report(ctx context.Context, report agentsessionstore.ReportActivityInput) error {
+	r.once.Do(func() {
+		close(r.entered)
+		select {
+		case <-r.release:
+		case <-ctx.Done():
+		}
+	})
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	r.mu.Lock()
+	r.reports = append(r.reports, report)
+	r.mu.Unlock()
+	return nil
+}
+
+func (r *blockingFirstClaudeGoalReporter) ReportSubmitProvenance(ctx context.Context, report agentsessionstore.ReportActivityInput) error {
+	return r.Report(ctx, report)
+}
+
+func (r *blockingFirstClaudeGoalReporter) snapshot() []agentsessionstore.ReportActivityInput {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]agentsessionstore.ReportActivityInput(nil), r.reports...)
 }
 
 // Interaction transitions still carry adapter snapshots, while SDK provider
@@ -650,6 +687,7 @@ func TestClaudeSDKGoalArmTurnCarriesDurableGoalIdentity(t *testing.T) {
 	defer func() { _ = conn.Close() }()
 	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, conn)
 	adapter.beginClaudeSDKRootTurn(adapterSession, "preceding-user-turn", "preceding-provider-turn")
+	adapter.consumeClaudeSDKRootProviderTurn(adapterSession, "preceding-provider-turn")
 
 	done := make(chan error, 1)
 	go func() {
@@ -671,21 +709,70 @@ func TestClaudeSDKGoalArmTurnCarriesDurableGoalIdentity(t *testing.T) {
 	if payloadString(setRequest.Payload, "goalOperationId") != "goal-op-7" || payloadInt64(setRequest.Payload, "goalRevision") != 7 {
 		t.Fatalf("goal exec payload = %#v", setRequest.Payload)
 	}
+	identityEvents, _, err := adapter.sidecarTurnEvents(adapterSession, session, turnID, claudeSDKSidecarEvent{
+		Type: "provider_turn_identity_resolved",
+		Payload: map[string]any{
+			"turnId": turnID, "providerTurnId": "provider-turn-7", "turnOrigin": "goal_arm",
+			"sourceGoalOperationId": "goal-op-7", "sourceGoalRevision": float64(7), "sourceGoalRepairEpoch": float64(2),
+		},
+	})
+	if err != nil || len(identityEvents) != 1 {
+		t.Fatalf("provider identity events=%#v error=%v", identityEvents, err)
+	}
+	identityMetadata := identityEvents[0].Payload.Metadata
+	if identityMetadata["turnOrigin"] != "goal_arm" || identityMetadata["sourceGoalOperationId"] != "goal-op-7" ||
+		identityMetadata["sourceGoalRevision"] != int64(7) || identityMetadata["sourceGoalRepairEpoch"] != int64(2) {
+		t.Fatalf("goal provider identity metadata = %#v", identityMetadata)
+	}
+	identityPatch, ok := statePatchFromSessionEvent(reportTestSource(), identityEvents[0], session.AgentSessionID, 100)
+	if !ok || identityPatch.Turn == nil || identityPatch.RootProviderTurn == nil {
+		t.Fatalf("goal provider identity patch = %#v, want atomic turn and provider transition", identityPatch)
+	}
+	if identityPatch.Turn.TurnID != turnID || identityPatch.Turn.Origin != "goal_arm" ||
+		identityPatch.RootProviderTurn.ProviderTurnID != "provider-turn-7" {
+		t.Fatalf("goal provider identity patch = %#v", identityPatch)
+	}
+	adapter.finishClaudeSDKGoalTurnPublication(adapterSession, identityEvents)
 	events, _, err := adapter.sidecarTurnEvents(adapterSession, session, turnID, claudeSDKSidecarEvent{
 		Type: "turn_started", Payload: map[string]any{
 			"turnId": turnID, "turnOrigin": "goal_arm",
 			"sourceGoalOperationId": "goal-op-7", "sourceGoalRevision": float64(7), "sourceGoalRepairEpoch": float64(2),
 		},
 	})
-	if err != nil || len(events) != 1 {
-		t.Fatalf("turn_started events=%#v error=%v", events, err)
+	if err != nil || len(events) != 0 {
+		t.Fatalf("duplicate turn_started events=%#v error=%v", events, err)
 	}
-	metadata := events[0].Payload.Metadata
-	if metadata["turnOrigin"] != "goal_arm" || metadata["sourceGoalOperationId"] != "goal-op-7" || metadata["sourceGoalRevision"] != int64(7) || metadata["sourceGoalRepairEpoch"] != int64(2) {
-		t.Fatalf("goal arm metadata = %#v", metadata)
+	if adapter.claudeSDKRootTurnID(adapterSession, "") != turnID {
+		t.Fatalf("goal arm root mapping = %q, want %q", adapter.claudeSDKRootTurnID(adapterSession, ""), turnID)
 	}
-	if events[0].Payload.TurnID != turnID || adapter.claudeSDKRootTurnID(adapterSession, "") != turnID {
-		t.Fatalf("goal arm root mapping = event:%q adapter:%q, want %q", events[0].Payload.TurnID, adapter.claudeSDKRootTurnID(adapterSession, ""), turnID)
+	completedEvents, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, turnID, claudeSDKSidecarEvent{
+		Type: "turn_completed",
+		Payload: map[string]any{
+			"turnId": turnID, "providerTurnId": "provider-turn-7", "stopReason": "end_turn",
+		},
+	})
+	if err != nil || !terminal {
+		t.Fatalf("goal arm completion events=%#v terminal=%v error=%v", completedEvents, terminal, err)
+	}
+	providerCompleted := activityEventsWithType(completedEvents, activityshared.EventRootProviderTurnCompleted)
+	if len(providerCompleted) != 1 {
+		t.Fatalf("goal arm provider completion events=%#v", completedEvents)
+	}
+	completedPatch, ok := statePatchFromSessionEvent(reportTestSource(), providerCompleted[0], session.AgentSessionID, 200)
+	if !ok || completedPatch.Turn != nil || completedPatch.RootProviderTurn == nil ||
+		completedPatch.RootProviderTurn.RootTurnID != turnID ||
+		completedPatch.RootProviderTurn.ProviderTurnID != "provider-turn-7" ||
+		completedPatch.RootProviderTurn.Phase != agentsessionstore.RootProviderTurnPhaseCompleted {
+		t.Fatalf("goal arm provider completion patch=%#v", completedPatch)
+	}
+	if goal := adapter.localGoal(adapterSession); goal["status"] != "complete" {
+		t.Fatalf("goal arm completion mirror=%#v", goal)
+	}
+	adapter.mu.Lock()
+	_, bindingRetained := adapterSession.goalTurnBindings[turnID]
+	adapter.mu.Unlock()
+	if bindingRetained {
+		t.Fatalf("settled goal arm retained provenance binding for %q", turnID)
 	}
 }
 
@@ -727,6 +814,21 @@ func TestClaudeSDKGoalSetAckThenImmediateClearPreservesDelayedArmUntilTerminal(t
 	}
 
 	setTurnID := payloadString(setRequest.Payload, "turnId")
+	identityEvents, _, err := adapter.sidecarTurnEvents(adapterSession, session, setTurnID, claudeSDKSidecarEvent{
+		Type: "provider_turn_identity_resolved",
+		Payload: map[string]any{
+			"turnId": setTurnID, "providerTurnId": "provider-goal-set", "turnOrigin": "goal_arm",
+			"sourceGoalOperationId": "goal-op-set", "sourceGoalRevision": float64(1),
+		},
+	})
+	if err != nil || len(identityEvents) != 1 {
+		t.Fatalf("delayed arm identity events=%#v error=%v", identityEvents, err)
+	}
+	identityMetadata := identityEvents[0].Payload.Metadata
+	if identityMetadata["sourceGoalOperationId"] != "goal-op-set" || identityMetadata["sourceGoalRevision"] != int64(1) {
+		t.Fatalf("delayed arm identity provenance=%#v", identityMetadata)
+	}
+	adapter.finishClaudeSDKGoalTurnPublication(adapterSession, identityEvents)
 	events, _, err := adapter.sidecarTurnEvents(adapterSession, session, setTurnID, claudeSDKSidecarEvent{
 		Type: "turn_started",
 		Payload: map[string]any{
@@ -734,19 +836,16 @@ func TestClaudeSDKGoalSetAckThenImmediateClearPreservesDelayedArmUntilTerminal(t
 			"sourceGoalOperationId": "goal-op-set", "sourceGoalRevision": float64(1),
 		},
 	})
-	if err != nil || len(events) != 1 {
-		t.Fatalf("delayed arm events=%#v error=%v", events, err)
-	}
-	metadata := events[0].Payload.Metadata
-	if metadata["sourceGoalOperationId"] != "goal-op-set" || metadata["sourceGoalRevision"] != int64(1) {
-		t.Fatalf("delayed arm provenance=%#v", metadata)
+	if err != nil || len(events) != 0 {
+		t.Fatalf("delayed arm duplicate events=%#v error=%v", events, err)
 	}
 	assertClaudeSDKNoCancelForGoalExec(t, conn.sentRequests(), "/goal clear")
+	clearTurnID := payloadString(clearRequest.Payload, "turnId")
 
-	clearEvents, _, err := adapter.sidecarTurnEvents(adapterSession, session, payloadString(clearRequest.Payload, "turnId"), claudeSDKSidecarEvent{
+	clearEvents, _, err := adapter.sidecarTurnEvents(adapterSession, session, clearTurnID, claudeSDKSidecarEvent{
 		Type: "goal_command_started",
 		Payload: map[string]any{
-			"turnId":      payloadString(clearRequest.Payload, "turnId"),
+			"turnId":      clearTurnID,
 			"operationId": "goal-op-clear", "revision": float64(2), "repairEpoch": float64(7), "action": "clear",
 		},
 	})
@@ -756,6 +855,41 @@ func TestClaudeSDKGoalSetAckThenImmediateClearPreservesDelayedArmUntilTerminal(t
 	evidence := payloadObject(clearEvents[0].Payload.Metadata["goalControlEvidence"])
 	if evidence["phase"] != "applied" || evidence["operationId"] != "goal-op-clear" || evidence["revision"] != int64(2) || evidence["repairEpoch"] != int64(7) {
 		t.Fatalf("clear applied evidence=%#v", evidence)
+	}
+}
+
+func TestClaudeSDKGoalClearProviderIdentityStaysTurnless(t *testing.T) {
+	t.Parallel()
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	conn := newBlockingClaudeSDKConnection()
+	defer func() { _ = conn.Close() }()
+	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, conn)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := adapter.ApplyGoal(context.Background(), session, GoalApplyInput{
+			Action: GoalControlClear, OperationID: "goal-op-clear", Revision: 2, RepairEpoch: 7,
+		})
+		done <- err
+	}()
+	request := waitForClaudeSDKSentRequestMatching(t, conn, "exec", "/goal clear")
+	conn.pushEvent(claudeSDKSidecarEvent{ID: request.ID, Type: "ok"})
+	if err := <-done; err != nil {
+		t.Fatalf("clear ack: %v", err)
+	}
+	turnID := payloadString(request.Payload, "turnId")
+	events, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, turnID, claudeSDKSidecarEvent{
+		Type: "provider_turn_identity_resolved",
+		Payload: map[string]any{
+			"turnId": turnID, "providerTurnId": "provider-goal-clear",
+			"sourceGoalOperationId": "goal-op-clear", "sourceGoalRevision": float64(2), "sourceGoalRepairEpoch": float64(7),
+		},
+	})
+	if err != nil || terminal || len(events) != 0 {
+		t.Fatalf("goal clear identity events=%#v terminal=%v error=%v", events, terminal, err)
+	}
+	if rootTurnID := adapter.claudeSDKRootTurnID(adapterSession, ""); rootTurnID != "" {
+		t.Fatalf("goal clear created root turn %q", rootTurnID)
 	}
 }
 
@@ -807,9 +941,9 @@ func TestClaudeSDKDelayedOlderRepairEpochIsPreciselyCanceled(t *testing.T) {
 	adapterSession.goalRepairEpoch = 2
 	adapter.mu.Unlock()
 	_, _, err := adapter.sidecarTurnEvents(adapterSession, session, "goal-turn-old", claudeSDKSidecarEvent{
-		Type: "turn_started",
+		Type: "provider_turn_identity_resolved",
 		Payload: map[string]any{
-			"turnId": "goal-turn-old", "turnOrigin": "goal_continuation",
+			"turnId": "goal-turn-old", "providerTurnId": "provider-goal-turn-old", "turnOrigin": "goal_continuation",
 			"sourceGoalOperationId": "goal-op", "sourceGoalRevision": float64(7), "sourceGoalRepairEpoch": float64(1),
 		},
 	})
@@ -834,9 +968,9 @@ func TestClaudeSDKFencedGoalGenerationNeverBecomesCanonical(t *testing.T) {
 		t.Fatal(err)
 	}
 	events, _, err := adapter.sidecarTurnEvents(adapterSession, session, "goal-turn-fenced", claudeSDKSidecarEvent{
-		Type: "turn_started",
+		Type: "provider_turn_identity_resolved",
 		Payload: map[string]any{
-			"turnId": "goal-turn-fenced", "turnOrigin": "goal_continuation",
+			"turnId": "goal-turn-fenced", "providerTurnId": "provider-goal-turn-fenced", "turnOrigin": "goal_continuation",
 			"sourceGoalOperationId": "goal-fenced", "sourceGoalRevision": float64(7), "sourceGoalRepairEpoch": float64(2),
 		},
 	})
@@ -849,10 +983,360 @@ func TestClaudeSDKFencedGoalGenerationNeverBecomesCanonical(t *testing.T) {
 		t.Fatalf("fenced turn cancellation=%#v", sent)
 	}
 	events, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "goal-turn-fenced", claudeSDKSidecarEvent{
-		Type: "turn_canceled", Payload: map[string]any{"turnId": "goal-turn-fenced"},
+		Type: "turn_started", Payload: map[string]any{
+			"turnId": "goal-turn-fenced", "turnOrigin": "goal_continuation",
+			"sourceGoalOperationId": "goal-fenced", "sourceGoalRevision": float64(7), "sourceGoalRepairEpoch": float64(2),
+		},
+	})
+	if err != nil || terminal || len(events) != 0 {
+		t.Fatalf("fenced turn_started events=%#v terminal=%v error=%v", events, terminal, err)
+	}
+	events, terminal, err = adapter.sidecarTurnEvents(adapterSession, session, "goal-turn-fenced", claudeSDKSidecarEvent{
+		Type: "turn_canceled", Payload: map[string]any{"turnId": "goal-turn-fenced", "providerTurnId": "provider-goal-turn-fenced"},
 	})
 	if err != nil || !terminal || len(events) != 0 {
 		t.Fatalf("fenced terminal events=%#v terminal=%v error=%v", events, terminal, err)
+	}
+}
+
+func TestClaudeSDKFenceQuiescesAlreadyAdmittedGoalGeneration(t *testing.T) {
+	t.Parallel()
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	conn := newBlockingClaudeSDKConnection()
+	defer func() { _ = conn.Close() }()
+	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, conn)
+	identityPayload := map[string]any{
+		"turnId": "goal-turn-admitted", "providerTurnId": "provider-goal-turn-admitted", "turnOrigin": "goal_continuation",
+		"sourceGoalOperationId": "goal-admitted", "sourceGoalRevision": float64(8), "sourceGoalRepairEpoch": float64(3),
+	}
+	events, _, err := adapter.sidecarTurnEvents(adapterSession, session, "goal-turn-admitted", claudeSDKSidecarEvent{
+		Type: "provider_turn_identity_resolved", Payload: identityPayload,
+	})
+	if err != nil || len(events) != 1 {
+		t.Fatalf("admitted identity events=%#v error=%v", events, err)
+	}
+	adapter.finishClaudeSDKGoalTurnPublication(adapterSession, events)
+	startReport := reportActivityInput(session, events)
+	if len(startReport.StatePatches) != 1 || startReport.StatePatches[0].Turn == nil ||
+		startReport.StatePatches[0].RootProviderTurn == nil {
+		t.Fatalf("admitted identity report=%#v", startReport)
+	}
+	if err := adapter.FenceGoalGeneration(context.Background(), session, GoalGenerationFenceInput{
+		OperationID: "goal-admitted", Revision: 8, RepairEpoch: 3, Reason: "binding_revoked",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	sent := conn.sentRequests()
+	if len(sent) != 1 || sent[0].Type != "cancel" || payloadString(sent[0].Payload, "turnId") != "goal-turn-admitted" {
+		t.Fatalf("admitted goal cancellation=%#v", sent)
+	}
+	events, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "goal-turn-admitted", claudeSDKSidecarEvent{
+		Type: "turn_started", Payload: map[string]any{
+			"turnId": "goal-turn-admitted", "turnOrigin": "goal_continuation",
+			"sourceGoalOperationId": "goal-admitted", "sourceGoalRevision": float64(8), "sourceGoalRepairEpoch": float64(3),
+		},
+	})
+	if err != nil || terminal || len(events) != 0 {
+		t.Fatalf("fenced admitted turn_started events=%#v terminal=%v error=%v", events, terminal, err)
+	}
+	events, terminal, err = adapter.sidecarTurnEvents(adapterSession, session, "goal-turn-admitted", claudeSDKSidecarEvent{
+		Type: "turn_canceled", Payload: map[string]any{
+			"turnId": "goal-turn-admitted", "providerTurnId": "provider-goal-turn-admitted",
+		},
+	})
+	if err != nil || !terminal {
+		t.Fatalf("fenced admitted terminal events=%#v terminal=%v error=%v", events, terminal, err)
+	}
+	completed := activityEventsWithType(events, activityshared.EventRootProviderTurnCompleted)
+	if len(completed) != 1 || completed[0].Payload.TurnID != "goal-turn-admitted" {
+		t.Fatalf("fenced admitted completion events=%#v", events)
+	}
+	terminalReport := reportActivityInput(session, events)
+	settlementFound := false
+	for _, patch := range terminalReport.StatePatches {
+		if patch.RootProviderTurn != nil && patch.RootProviderTurn.Phase == agentsessionstore.RootProviderTurnPhaseCompleted {
+			settlementFound = true
+			break
+		}
+	}
+	if !settlementFound {
+		t.Fatalf("fenced admitted terminal report=%#v", terminalReport)
+	}
+}
+
+func TestClaudeSDKFenceWinsBetweenGoalAdmissionAndPublication(t *testing.T) {
+	t.Parallel()
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	conn := newBlockingClaudeSDKConnection()
+	defer func() { _ = conn.Close() }()
+	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, conn)
+	payload := map[string]any{
+		"turnId": "goal-turn-racing", "providerTurnId": "provider-goal-turn-racing", "turnOrigin": "goal_continuation",
+		"sourceGoalOperationId": "goal-racing", "sourceGoalRevision": float64(9), "sourceGoalRepairEpoch": float64(4),
+	}
+	admission, err := adapter.admitClaudeSDKGoalTurn(
+		adapterSession,
+		"goal-turn-racing",
+		"provider-goal-turn-racing",
+		payload,
+	)
+	if err != nil || admission.denied() || !admission.goalTurn {
+		t.Fatalf("initial admission=%#v error=%v", admission, err)
+	}
+	if err := adapter.FenceGoalGeneration(context.Background(), session, GoalGenerationFenceInput{
+		OperationID: "goal-racing", Revision: 9, RepairEpoch: 4, Reason: "binding_revoked",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if adapter.publishClaudeSDKGoalTurn(adapterSession, "goal-turn-racing") {
+		t.Fatal("fence that won before publication allowed Goal start")
+	}
+	events, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "goal-turn-racing", claudeSDKSidecarEvent{
+		Type: "provider_turn_identity_resolved", Payload: payload,
+	})
+	if err != nil || terminal || len(events) != 0 {
+		t.Fatalf("raced identity events=%#v terminal=%v error=%v", events, terminal, err)
+	}
+	events, terminal, err = adapter.sidecarTurnEvents(adapterSession, session, "goal-turn-racing", claudeSDKSidecarEvent{
+		Type: "turn_canceled", Payload: map[string]any{
+			"turnId": "goal-turn-racing", "providerTurnId": "provider-goal-turn-racing",
+		},
+	})
+	if err != nil || !terminal || len(events) != 0 {
+		t.Fatalf("raced terminal events=%#v terminal=%v error=%v", events, terminal, err)
+	}
+}
+
+func TestClaudeSDKFenceBetweenRepeatedAdmissionAndPublicationSettlesPublishedTurn(t *testing.T) {
+	t.Parallel()
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	conn := newBlockingClaudeSDKConnection()
+	defer func() { _ = conn.Close() }()
+	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, conn)
+	payload := map[string]any{
+		"turnId": "goal-turn-repeated", "providerTurnId": "provider-goal-turn-repeated", "turnOrigin": "goal_continuation",
+		"sourceGoalOperationId": "goal-repeated", "sourceGoalRevision": float64(10), "sourceGoalRepairEpoch": float64(4),
+	}
+	events, _, err := adapter.sidecarTurnEvents(adapterSession, session, "goal-turn-repeated", claudeSDKSidecarEvent{
+		Type: "provider_turn_identity_resolved", Payload: payload,
+	})
+	if err != nil || len(events) != 1 {
+		t.Fatalf("identity events=%#v error=%v", events, err)
+	}
+	adapter.finishClaudeSDKGoalTurnPublication(adapterSession, events)
+
+	// The sidecar emits turn_started after identity resolution. A fence may
+	// arrive after this second admission but before its duplicate start fact is
+	// published; the first start is already durable and must still be settled.
+	admission, err := adapter.admitClaudeSDKGoalTurn(
+		adapterSession,
+		"goal-turn-repeated",
+		"provider-goal-turn-repeated",
+		payload,
+	)
+	if err != nil || admission.denied() {
+		t.Fatalf("repeated admission=%#v error=%v", admission, err)
+	}
+	if err := adapter.FenceGoalGeneration(context.Background(), session, GoalGenerationFenceInput{
+		OperationID: "goal-repeated", Revision: 10, RepairEpoch: 4, Reason: "binding_revoked",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	events, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "goal-turn-repeated", claudeSDKSidecarEvent{
+		Type: "turn_canceled", Payload: map[string]any{
+			"turnId": "goal-turn-repeated", "providerTurnId": "provider-goal-turn-repeated",
+		},
+	})
+	if err != nil || !terminal || len(activityEventsWithType(events, activityshared.EventRootProviderTurnCompleted)) != 1 {
+		t.Fatalf("published turn settlement events=%#v terminal=%v error=%v", events, terminal, err)
+	}
+}
+
+func TestClaudeSDKGoalLateProviderIdentityPublishesOnceAndSettles(t *testing.T) {
+	t.Parallel()
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	conn := newBlockingClaudeSDKConnection()
+	defer func() { _ = conn.Close() }()
+	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, conn)
+	var emitted []activityshared.Event
+	adapter.SetSessionEventSink(func(_ string, events []activityshared.Event) {
+		emitted = append(emitted, events...)
+	})
+	provenance := map[string]any{
+		"turnId": "goal-turn-late-identity", "turnOrigin": "goal_arm",
+		"sourceGoalOperationId": "goal-late-identity", "sourceGoalRevision": float64(11), "sourceGoalRepairEpoch": float64(2),
+	}
+
+	adapter.dispatchClaudeSDKEvent(session.AgentSessionID, adapterSession, claudeSDKSidecarEvent{
+		Type: "turn_started", Payload: provenance,
+	})
+	if len(emitted) != 0 {
+		t.Fatalf("unbound Goal start published canonical events=%#v", emitted)
+	}
+	identityPayload := clonePayload(provenance)
+	identityPayload["providerTurnId"] = "provider-goal-late-identity"
+	adapter.dispatchClaudeSDKEvent(session.AgentSessionID, adapterSession, claudeSDKSidecarEvent{
+		Type: "provider_turn_identity_resolved", Payload: identityPayload,
+	})
+	started := activityEventsWithType(emitted, activityshared.EventRootProviderTurnStarted)
+	if len(started) != 1 || started[0].Payload.TurnID != "goal-turn-late-identity" ||
+		started[0].Payload.ProviderTurnID != "provider-goal-late-identity" {
+		t.Fatalf("late identity start events=%#v", emitted)
+	}
+
+	adapter.dispatchClaudeSDKEvent(session.AgentSessionID, adapterSession, claudeSDKSidecarEvent{
+		Type: "turn_completed",
+		Payload: map[string]any{
+			"turnId": "goal-turn-late-identity", "providerTurnId": "provider-goal-late-identity", "stopReason": "end_turn",
+		},
+	})
+	completed := activityEventsWithType(emitted, activityshared.EventRootProviderTurnCompleted)
+	if len(completed) != 1 || completed[0].Payload.TurnID != "goal-turn-late-identity" ||
+		completed[0].Payload.ProviderTurnID != "provider-goal-late-identity" {
+		t.Fatalf("late identity settlement events=%#v", emitted)
+	}
+	if failures := activityEventsWithType(emitted, activityshared.EventSessionFailed); len(failures) != 0 {
+		t.Fatalf("late identity emitted session failure=%#v", failures)
+	}
+}
+
+func TestClaudeSDKFencedUnboundGoalLateIdentityCleansAliases(t *testing.T) {
+	t.Parallel()
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	conn := newBlockingClaudeSDKConnection()
+	defer func() { _ = conn.Close() }()
+	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, conn)
+	var emitted []activityshared.Event
+	adapter.SetSessionEventSink(func(_ string, events []activityshared.Event) {
+		emitted = append(emitted, events...)
+	})
+	provenance := map[string]any{
+		"turnId": "goal-turn-fenced-unbound", "turnOrigin": "goal_continuation",
+		"sourceGoalOperationId": "goal-fenced-unbound", "sourceGoalRevision": float64(12), "sourceGoalRepairEpoch": float64(3),
+	}
+	adapter.dispatchClaudeSDKEvent(session.AgentSessionID, adapterSession, claudeSDKSidecarEvent{
+		Type: "turn_started", Payload: provenance,
+	})
+	if err := adapter.FenceGoalGeneration(context.Background(), session, GoalGenerationFenceInput{
+		OperationID: "goal-fenced-unbound", Revision: 12, RepairEpoch: 3, Reason: "binding_revoked",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	identityPayload := clonePayload(provenance)
+	identityPayload["providerTurnId"] = "provider-goal-fenced-unbound"
+	adapter.dispatchClaudeSDKEvent(session.AgentSessionID, adapterSession, claudeSDKSidecarEvent{
+		Type: "provider_turn_identity_resolved", Payload: identityPayload,
+	})
+	adapter.dispatchClaudeSDKEvent(session.AgentSessionID, adapterSession, claudeSDKSidecarEvent{
+		Type: "turn_canceled",
+		Payload: map[string]any{
+			"turnId": "goal-turn-fenced-unbound", "providerTurnId": "provider-goal-fenced-unbound",
+		},
+	})
+	adapter.mu.Lock()
+	fencedTurns := len(adapterSession.fencedGoalTurns)
+	bindings := len(adapterSession.goalTurnBindings)
+	providerAliases := len(adapterSession.rootProviderTurns)
+	adapter.mu.Unlock()
+	if fencedTurns != 0 || bindings != 0 || providerAliases != 0 {
+		t.Fatalf("fenced late identity cleanup: fences=%d bindings=%d providerAliases=%d", fencedTurns, bindings, providerAliases)
+	}
+	if failures := activityEventsWithType(emitted, activityshared.EventSessionFailed); len(failures) != 0 {
+		t.Fatalf("fenced late identity emitted session failure=%#v", failures)
+	}
+
+	nextIdentity := map[string]any{
+		"turnId": "goal-turn-next", "providerTurnId": "provider-goal-next", "turnOrigin": "goal_continuation",
+		"sourceGoalOperationId": "goal-next", "sourceGoalRevision": float64(13), "sourceGoalRepairEpoch": float64(0),
+	}
+	adapter.dispatchClaudeSDKEvent(session.AgentSessionID, adapterSession, claudeSDKSidecarEvent{
+		Type: "provider_turn_identity_resolved", Payload: nextIdentity,
+	})
+	started := activityEventsWithType(emitted, activityshared.EventRootProviderTurnStarted)
+	if len(started) != 1 || started[0].Payload.TurnID != "goal-turn-next" ||
+		started[0].Payload.ProviderTurnID != "provider-goal-next" {
+		t.Fatalf("next Goal identity after cleanup events=%#v", emitted)
+	}
+}
+
+func TestClaudeSDKGoalFenceFlushesPublishedStartBeforeReturning(t *testing.T) {
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	reporter := &blockingFirstClaudeGoalReporter{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	controller := NewController([]Adapter{adapter}, reporter)
+	conn := newBlockingClaudeSDKConnection()
+	defer func() { _ = conn.Close() }()
+	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, conn)
+	controller.store(session)
+
+	adapter.dispatchClaudeSDKEvent(session.AgentSessionID, adapterSession, claudeSDKSidecarEvent{
+		Type: "provider_turn_identity_resolved",
+		Payload: map[string]any{
+			"turnId": "goal-turn-flush", "providerTurnId": "provider-goal-turn-flush", "turnOrigin": "goal_continuation",
+			"sourceGoalOperationId": "goal-flush", "sourceGoalRevision": float64(10), "sourceGoalRepairEpoch": float64(5),
+		},
+	})
+	select {
+	case <-reporter.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Goal start did not reach the durable reporter")
+	}
+
+	fenceDone := make(chan error, 1)
+	go func() {
+		fenceDone <- controller.FenceGoalGeneration(context.Background(), GoalGenerationFenceRequest{
+			RoomID: session.RoomID, AgentSessionID: session.AgentSessionID,
+			OperationID: "goal-flush", Revision: 10, RepairEpoch: 5,
+			Reason: "binding_revoked", RequireLive: true,
+		})
+	}()
+	select {
+	case err := <-fenceDone:
+		t.Fatalf("Fence returned before the published start was durable: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(reporter.release)
+	select {
+	case err := <-fenceDone:
+		if err != nil {
+			t.Fatalf("FenceGoalGeneration: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Fence did not return after the start report became durable")
+	}
+
+	adapter.dispatchClaudeSDKEvent(session.AgentSessionID, adapterSession, claudeSDKSidecarEvent{
+		Type: "turn_canceled",
+		Payload: map[string]any{
+			"turnId": "goal-turn-flush", "providerTurnId": "provider-goal-turn-flush",
+		},
+	})
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		reports := reporter.snapshot()
+		if len(reports) >= 2 {
+			if len(reports[0].StatePatches) != 1 || reports[0].StatePatches[0].Turn == nil ||
+				reports[0].StatePatches[0].RootProviderTurn == nil {
+				t.Fatalf("durable Goal start report=%#v", reports[0])
+			}
+			settlementFound := false
+			for _, patch := range reports[1].StatePatches {
+				if patch.RootProviderTurn != nil && patch.RootProviderTurn.Phase == agentsessionstore.RootProviderTurnPhaseCompleted {
+					settlementFound = true
+					break
+				}
+			}
+			if !settlementFound {
+				t.Fatalf("durable Goal terminal report=%#v", reports[1])
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for terminal report; reports=%#v", reports)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 

--- a/packages/agent/daemon/runtime/claude_sdk_turn_binding.go
+++ b/packages/agent/daemon/runtime/claude_sdk_turn_binding.go
@@ -7,6 +7,15 @@ import (
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
+func claudeSDKEventRequiresBoundProviderIdentity(eventType string) bool {
+	switch eventType {
+	case "provider_turn_identity_resolved", "provider_turn_checkpoint":
+		return true
+	default:
+		return false
+	}
+}
+
 func (a *ClaudeCodeSDKAdapter) claudeSDKRootProviderTurnStartedEvent(
 	session Session,
 	rootTurnID string,

--- a/packages/agent/daemon/runtime/controller.go
+++ b/packages/agent/daemon/runtime/controller.go
@@ -105,6 +105,7 @@ type reportRequest struct {
 	ctx              context.Context
 	report           agentsessionstore.ReportActivityInput
 	submitProvenance bool
+	barrier          bool
 	done             chan error
 }
 

--- a/packages/agent/daemon/runtime/controller_goal_generation_fence.go
+++ b/packages/agent/daemon/runtime/controller_goal_generation_fence.go
@@ -54,7 +54,10 @@ func (c *Controller) FenceGoalGeneration(ctx context.Context, input GoalGenerati
 	} else if err := c.ensureLiveAdapterSession(ctx, session, adapter); err != nil {
 		return err
 	}
-	return c.applyRetainedGoalGenerationFencesOrClose(ctx, session, adapter)
+	if err := c.applyRetainedGoalGenerationFencesOrClose(ctx, session, adapter); err != nil {
+		return err
+	}
+	return c.flushSessionReports(ctx, session)
 }
 
 func normalizeGoalGenerationFenceInput(input GoalGenerationFenceRequest) (GoalGenerationFenceInput, error) {

--- a/packages/agent/daemon/runtime/controller_report_worker.go
+++ b/packages/agent/daemon/runtime/controller_report_worker.go
@@ -113,6 +113,32 @@ func (c *Controller) reportProviderAcceptanceDurable(
 	}
 }
 
+// flushSessionReports waits until every report enqueued earlier for this
+// Session has crossed the durable reporter. Goal-generation fencing uses this
+// after the adapter's publication handoff, so Host cannot observe an idle
+// Session immediately before an already-published Goal start commits.
+func (c *Controller) flushSessionReports(ctx context.Context, session Session) error {
+	if c == nil || c.reportQueue == nil {
+		return nil
+	}
+	request := reportRequest{
+		ctx: context.WithoutCancel(ctx),
+		report: agentsessionstore.ReportActivityInput{
+			WorkspaceID: session.RoomID,
+			Source:      eventSourceFromSession(session),
+		},
+		barrier: true,
+		done:    make(chan error, 1),
+	}
+	c.reportQueue.enqueue(request)
+	select {
+	case err := <-request.done:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 func containsDurableProviderAcceptance(events []activityshared.Event) bool {
 	for _, event := range events {
 		if event.Type != activityshared.EventRootProviderTurnStarted {
@@ -371,6 +397,9 @@ func (c *Controller) report(ctx context.Context, request reportRequest) (reportE
 			request.done <- reportErr
 			close(request.done)
 		}()
+	}
+	if request.barrier {
+		return nil
 	}
 	if c.reporter == nil {
 		return errors.New("agent session activity reporter is unavailable")

--- a/packages/agent/daemon/runtime/reporter.go
+++ b/packages/agent/daemon/runtime/reporter.go
@@ -247,7 +247,9 @@ func reportActivityInput(session Session, events []activityshared.Event) agentse
 			input.GoalReconcileRequests = append(input.GoalReconcileRequests, request)
 		}
 		if shouldAppendVisibleFailure(events, event) {
-			if update, ok := visibleFailureMessageUpdate(source, event, sessionID, timestamp); ok {
+			if audit, ok := visibleFailureSessionAuditUpdate(source, event, sessionID, timestamp); ok {
+				input.SessionAudits = append(input.SessionAudits, audit)
+			} else if update, ok := visibleFailureMessageUpdate(source, event, sessionID, timestamp); ok {
 				input.MessageUpdates = append(input.MessageUpdates, update)
 			}
 		}

--- a/packages/agent/daemon/runtime/visible_error.go
+++ b/packages/agent/daemon/runtime/visible_error.go
@@ -67,19 +67,19 @@ var (
 	}
 )
 
-func visibleFailureTimelineItem(
-	roomID string,
-	source canonical.EventSource,
-	event activityshared.Event,
-	sessionID string,
-	timestamp int64,
-) (agentsessionstore.WorkspaceAgentTimelineItem, bool) {
+type visibleFailureProjection struct {
+	eventID string
+	content string
+	payload map[string]any
+}
+
+func projectVisibleFailure(source canonical.EventSource, event activityshared.Event) (visibleFailureProjection, bool) {
 	if event.Type != activityshared.EventSessionFailed && event.Type != activityshared.EventTurnFailed {
-		return agentsessionstore.WorkspaceAgentTimelineItem{}, false
+		return visibleFailureProjection{}, false
 	}
 	eventID := strings.TrimSpace(event.EventID)
-	if strings.TrimSpace(sessionID) == "" || eventID == "" {
-		return agentsessionstore.WorkspaceAgentTimelineItem{}, false
+	if eventID == "" {
+		return visibleFailureProjection{}, false
 	}
 	phase := "turn"
 	if event.Type == activityshared.EventSessionFailed {
@@ -103,21 +103,7 @@ func visibleFailureTimelineItem(
 	if detail != "" {
 		payload["detail"] = detail
 	}
-	return agentsessionstore.WorkspaceAgentTimelineItem{
-		RoomID:           strings.TrimSpace(roomID),
-		AgentSessionID:   strings.TrimSpace(sessionID),
-		TurnID:           strings.TrimSpace(event.Payload.TurnID),
-		EventSource:      "runtime",
-		EventID:          "visible-error:" + eventID,
-		ActorType:        "agent",
-		ActorID:          provider,
-		OccurredAtUnixMS: timestamp,
-		CreatedAtUnixMS:  timestamp,
-		Role:             string(activityshared.MessageRoleAssistant),
-		ItemType:         "message.assistant",
-		Status:           messageStreamStateFailed,
-		Payload:          payload,
-	}, true
+	return visibleFailureProjection{eventID: eventID, content: content, payload: payload}, true
 }
 
 func visibleFailureMessageUpdate(
@@ -126,44 +112,42 @@ func visibleFailureMessageUpdate(
 	sessionID string,
 	timestamp int64,
 ) (agentsessionstore.WorkspaceAgentMessageUpdate, bool) {
-	if event.Type != activityshared.EventSessionFailed && event.Type != activityshared.EventTurnFailed {
+	turnID := strings.TrimSpace(event.Payload.TurnID)
+	projection, ok := projectVisibleFailure(source, event)
+	if strings.TrimSpace(sessionID) == "" || turnID == "" || !ok {
 		return agentsessionstore.WorkspaceAgentMessageUpdate{}, false
 	}
-	eventID := strings.TrimSpace(event.EventID)
-	if strings.TrimSpace(sessionID) == "" || eventID == "" {
-		return agentsessionstore.WorkspaceAgentMessageUpdate{}, false
-	}
-	phase := "turn"
-	if event.Type == activityshared.EventSessionFailed {
-		phase = "start"
-	}
-	detail := visibleFailureDetail(event)
-	code := visibleFailureCode(detail)
-	provider := firstNonEmptyString(string(event.Provider), source.Provider)
-	content := visibleFailureContent(provider, phase, code)
-	payload := map[string]any{
-		"kind":          visibleErrorKind,
-		"severity":      visibleErrorSeverity,
-		"phase":         phase,
-		"code":          code,
-		"provider":      provider,
-		"sourceEventId": eventID,
-		"retryable":     visibleFailureRetryable(code, detail),
-		"content":       content,
-		"text":          content,
-		"source":        "runtime",
-	}
-	if detail != "" {
-		payload["detail"] = detail
-	}
+	payload := clonePayload(projection.payload)
+	payload["source"] = "runtime"
 	return agentsessionstore.WorkspaceAgentMessageUpdate{
 		AgentSessionID:   strings.TrimSpace(sessionID),
-		MessageID:        "visible-error:" + eventID,
+		MessageID:        "visible-error:" + projection.eventID,
 		Seq:              uint64(timestamp),
-		TurnID:           strings.TrimSpace(event.Payload.TurnID),
+		TurnID:           turnID,
 		Role:             string(activityshared.MessageRoleAssistant),
 		Kind:             "text",
 		Status:           messageStreamStateFailed,
+		Payload:          payload,
+		OccurredAtUnixMS: timestamp,
+	}, true
+}
+
+func visibleFailureSessionAuditUpdate(
+	source canonical.EventSource,
+	event activityshared.Event,
+	sessionID string,
+	timestamp int64,
+) (agentsessionstore.WorkspaceAgentSessionAuditUpdate, bool) {
+	projection, ok := projectVisibleFailure(source, event)
+	if strings.TrimSpace(sessionID) == "" || strings.TrimSpace(event.Payload.TurnID) != "" || !ok {
+		return agentsessionstore.WorkspaceAgentSessionAuditUpdate{}, false
+	}
+	payload := clonePayload(projection.payload)
+	payload["source"] = "runtime"
+	return agentsessionstore.WorkspaceAgentSessionAuditUpdate{
+		AuditID:          "visible-error:" + projection.eventID,
+		Role:             string(activityshared.MessageRoleAssistant),
+		Content:          projection.content,
 		Payload:          payload,
 		OccurredAtUnixMS: timestamp,
 	}, true

--- a/packages/agent/daemon/runtime/visible_error_test.go
+++ b/packages/agent/daemon/runtime/visible_error_test.go
@@ -340,24 +340,6 @@ func TestVisibleFailureRetryableForNetworkButNotMissingCli(t *testing.T) {
 	}
 }
 
-func TestVisibleFailureTimelineItemCarriesTimeoutCodeForTurnFailures(t *testing.T) {
-	session := reportTestSession()
-	event := newTurnActivityEvent(session, EventTurnFailed, "turn-1", SessionStatusFailed, "", "", map[string]any{
-		"error": "context deadline exceeded",
-	})
-
-	item, ok := visibleFailureTimelineItem("room-1", reportTestSource(), event, session.AgentSessionID, 123)
-	if !ok {
-		t.Fatal("visibleFailureTimelineItem() returned ok=false")
-	}
-	if got := item.Payload["code"]; got != "request_timed_out" {
-		t.Fatalf("visible failure code = %#v, want request_timed_out", got)
-	}
-	if got := item.Payload["phase"]; got != "turn" {
-		t.Fatalf("visible failure phase = %#v, want turn", got)
-	}
-}
-
 func reportTestSource() canonical.EventSource {
 	return canonical.EventSource{Provider: ProviderClaudeCode}
 }

--- a/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.spec.ts
@@ -582,6 +582,49 @@ describe("projectWorkspaceAgentMessagesToConversationVM", () => {
     );
   });
 
+  it("preserves a turnless runtime failure audit as a visible error", () => {
+    const conversation = projectWorkspaceAgentMessagesToConversationVM({
+      activity: activity(),
+      session: session({ effectiveStatus: "failed", turnPhase: "failed" }),
+      messages: [
+        message({
+          messageId: "visible-error:session-failed-1",
+          version: 1,
+          turnId: undefined,
+          role: "assistant",
+          kind: "session_audit",
+          status: "failed",
+          payload: {
+            kind: "agent_visible_error",
+            severity: "error",
+            phase: "start",
+            code: "provider_stream_disconnected",
+            provider: "claude-code",
+            retryable: true,
+            content: "Claude Code connection was interrupted.",
+            text: "Claude Code connection was interrupted.",
+            detail: "sidecar stream disconnected"
+          },
+          occurredAtUnixMs: 100
+        })
+      ]
+    });
+
+    const assistantRow = conversation.rows.find(
+      (row) => row.kind === "message" && row.speaker === "assistant"
+    );
+    const item =
+      assistantRow?.kind === "message" ? assistantRow.messages[0] : null;
+    expect(item?.visibleError).toEqual({
+      code: "provider_stream_disconnected",
+      phase: "start",
+      provider: "claude-code",
+      detail: "sidecar stream disconnected",
+      retryable: true
+    });
+    expect(item?.systemNotice ?? null).toBeNull();
+  });
+
   it("keeps turnless session audits in chronological conversation order", () => {
     const conversation = projectWorkspaceAgentMessagesToConversationVM({
       activity: activity(),

--- a/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.ts
@@ -272,24 +272,29 @@ export function projectWorkspaceAgentMessagesToTimelineItems(
       });
     }
 
+    const visibleError =
+      kind === "error" ||
+      normalizeToken(stringValue(payload.kind)) === "agent_visible_error";
     const statusTurnId =
-      turnId ?? `session-status:${kind === "error" ? "error" : "notice"}`;
+      turnId ?? `session-status:${visibleError ? "error" : "notice"}`;
     const statusMessage: AgentActivityMessage = {
       ...message,
-      payload:
-        kind === "error"
-          ? {
-              ...payload,
-              detail: messageText(message),
-              kind: "agent_visible_error"
-            }
-          : {
-              ...payload,
-              detail: messageText(message),
-              kind: "agent_system_notice",
-              noticeKind: kind,
-              severity: "info"
-            }
+      payload: visibleError
+        ? {
+            ...payload,
+            detail: firstNonEmptyString(
+              stringValue(payload.detail),
+              messageText(message)
+            ),
+            kind: "agent_visible_error"
+          }
+        : {
+            ...payload,
+            detail: messageText(message),
+            kind: "agent_system_notice",
+            noticeKind: kind,
+            severity: "info"
+          }
     };
     return messageTimelineItem({
       message: statusMessage,

--- a/packages/agent/store-sqlite/root_turn_completion_test.go
+++ b/packages/agent/store-sqlite/root_turn_completion_test.go
@@ -261,6 +261,23 @@ func TestReportActivityStateAtomicallyCreatesGoalTurnAndProviderBinding(t *testi
 	if err != nil || messageResult.AcceptedCount != 1 {
 		t.Fatalf("persist first goal assistant message = %#v err=%v", messageResult, err)
 	}
+	completed, err := store.ReportActivityState(ctx, ActivityStateReport{
+		Session: SessionStateReport{
+			WorkspaceID: "ws-1", AgentSessionID: "root", OccurredAtUnixMS: 30,
+		},
+		RootProviderTurn: &RootProviderTurnTransition{
+			WorkspaceID: "ws-1", RootAgentSessionID: "root", RootTurnID: "goal-turn",
+			ProviderTurnID: "provider-turn", Phase: RootProviderTurnPhaseCompleted,
+			Outcome: TurnOutcomeCompleted, OccurredAtUnixMS: 30,
+		},
+	})
+	if err != nil || !completed.RootTurnAccepted || completed.RootTurn.Phase != TurnPhaseSettled {
+		t.Fatalf("settle compound goal turn = %#v err=%v", completed, err)
+	}
+	settledSession, found, err := store.GetSession(ctx, "ws-1", "root")
+	if err != nil || !found || settledSession.ActiveTurnID != "" {
+		t.Fatalf("settled compound goal session = %#v found=%v err=%v", settledSession, found, err)
+	}
 }
 
 func TestReportActivityStateRollsBackGoalTurnWhenProviderBindingFails(t *testing.T) {


### PR DESCRIPTION
## Summary

- carry immutable Goal provenance on the earliest Claude provider-identity event
- linearize Goal fencing against canonical start publication, flush the durable report queue, and preserve terminal settlement for already-published turns
- suppress unbound and duplicate Goal starts while safely handling late provider identities and cleaning both canonical/provider aliases
- project turnless runtime failures as session audits and preserve them as visible AgentGUI errors
- add regression coverage across the sidecar, daemon runtime, report ordering, AgentGUI projection, and SQLite settlement

## Root cause

Claude can resolve provider identity before or after other lifecycle signals, including result-only executions without a root user echo. The runtime could therefore publish a provider turn before its canonical Turn existed, or let Goal fencing return while a start was queued but not durable. Subsequent terminal events were then filtered or rejected, leaving the canonical Turn and Session active indefinitely. Error handling compounded the incident by projecting a turnless session failure as a turn-scoped message.

## User impact

Claude Goal sessions now converge to a terminal state instead of remaining stuck in loading. Turnless provider failures also remain visible without violating the canonical message contract.

## Validation

- `pnpm check:changed -- --push-ready` — 20 lanes passed
- focused Go concurrency tests with `-race`
- Claude SDK sidecar test suite — 139 tests passed
- AgentGUI projection suite and SQLite settlement coverage
- independent sub-agent review — no P0/P1/P2 findings

## Review lanes

| Lane | Result | Evidence |
| --- | --- | --- |
| Architecture | Pass | immutable sidecar Turn provenance flows through the provider-neutral runtime into one canonical Turn/provider transition; no ownership boundary changed |
| Performance | Pass | state is bounded per Turn, cleaned on terminal, and introduces no new subscription or fan-out path |
| Consumers | Pass | no public DTO/export break; AgentGUI preserves the existing visible-error payload and all changed-aware consumer checks passed |

## Release and documentation

- includes patch changesets for `@tutti-os/claude-sdk-sidecar` and `@tutti-os/agent-gui`
- no durable documentation change: this fixes internal ordering and settlement invariants without changing module ownership, public API, configuration, or documented user workflow
