### PR TITLE
fix(agent): link local server endpoints

### DIFF
--- a/packages/agent/runtimeprep/policy_templates/host-app-context.md
+++ b/packages/agent/runtimeprep/policy_templates/host-app-context.md
@@ -17,6 +17,16 @@ You are running inside the Tutti desktop app host, which can render local and we
 - No inline base64.
 - No plain-text-only image paths.
 
+## Local Server Output
+
+When you successfully start a local development server for the user:
+
+- Report every verified user-reachable HTTP(S) endpoint as a descriptive Markdown link using `[label](url)`.
+- Prefer a clickable link such as `[Open the local app](http://localhost:3000/)` over a plain-text URL.
+- Use only URLs confirmed by server output, tool results, or host-provided port mappings. Never invent, guess, or assume a port or URL.
+- If no user-reachable URL is available, say so clearly and provide the verified listening address and port as inline code.
+- If multiple endpoints are available, provide one clearly labeled Markdown link for each.
+
 ## References
 
 - Code/workspace files: use `[filename](/abs/path)` Markdown links; target must be absolute. For spaces: `[filename](</abs/path with spaces>)`.


### PR DESCRIPTION
## What changed

Add explicit output rules for local development servers in the runtime host context.

## Why

A verified `localhost` endpoint could previously be rendered as inline code even though the desktop host can make it clickable. The existing generic URL guidance did not clearly connect Markdown links with successful local-server startup.

## Behavior

- Report verified user-reachable HTTP(S) endpoints as descriptive Markdown links.
- Use only URLs confirmed by server output, tool results, or host-provided port mappings.
- Provide the verified listening address and port as inline code only when no user-reachable URL is available.
- Provide separate labeled links when multiple endpoints are available.

## Validation

- `pnpm check:changed`
- Pre-commit staged checks
- Push-ready changed-aware checks