### PR TITLE
fix(agent-gui): reuse Home status for unavailable targets

### DIFF
--- a/.changeset/quiet-owners-return.md
+++ b/.changeset/quiet-owners-return.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/agent-gui": patch
+---
+
+Keep the normal empty conversation Home visible for unavailable Agent targets, project offline and revoked-sharing copy through the existing Home status chrome, remove the duplicate Host unavailable-state slot, and block both editing and submission until the selected target is available.

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1808,6 +1808,13 @@ while the Tooltip content is mounted. Conversation rows resolve the target by
 canonical `agentTargetId` from the current Host directory and fail closed when
 it is absent. They do not copy owner, device, availability, or other target
 metadata into Session state.
+
+Unavailable Agent targets retain the standard empty-home identity. AgentGUI
+projects offline transport and revoked-sharing states through the same Home
+status chrome used by other runtime failures, immediately above the composer;
+it does not expose a second Host-owned availability container. The canonical
+composer gate blocks both editing and submission until the selected target is
+available.
 Host chrome that aligns to AgentGUI's internal layout must consume explicit
 package signals such as `hostActions.onConversationRailLayoutChange`; it must
 not observe package DOM, CSS variables, or class names with

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -151,7 +151,6 @@ export const AgentGUINode = memo(function AgentGUINode({
     projectDirectoryPickerHeaderActions:
       renderProjectDirectoryPickerHeaderActions,
     providerRailEmpty: renderProviderRailEmpty,
-    providerUnavailableState: renderProviderUnavailableState,
     sidebarFooter: renderSidebarFooter
   } = renderSlots;
   const { i18n, locale, t } = useTranslation();
@@ -472,7 +471,6 @@ export const AgentGUINode = memo(function AgentGUINode({
               renderAgentTargetInfo={renderAgentTargetInfo}
               renderSidebarFooter={renderSidebarFooter}
               renderProviderRailEmpty={renderProviderRailEmpty}
-              renderProviderUnavailableState={renderProviderUnavailableState}
               providerRailAllPresentation={providerRailAllPresentation}
               actions={viewActions}
               isActive={isActive}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.types.ts
@@ -38,7 +38,6 @@ import type {
   AgentGUIConversationRailLayout,
   AgentGUIAgentsEmptyRenderer,
   AgentGUIComposerFooterAccessoryRenderer,
-  AgentGUIProviderUnavailableStateRenderer,
   AgentMentionReferenceTargetResolver,
   AgentWorkspaceReferenceInitialTargetResolver
 } from "./AgentGUINodeView";
@@ -231,7 +230,6 @@ export interface AgentGUINodeRenderSlots {
   agentConfigAccount?: (context: AgentGUIAgentConfigMenuContext) => ReactNode;
   projectDirectoryPickerHeaderActions?: ReferenceSourcePickerProps["renderHeaderActions"];
   providerRailEmpty?: AgentGUIAgentsEmptyRenderer;
-  providerUnavailableState?: AgentGUIProviderUnavailableStateRenderer;
   sidebarFooter?: (ctx: AgentGUISidebarFooterContext) => ReactNode;
 }
 
@@ -457,7 +455,6 @@ export function areAgentGUINodePropsEqual(
     ps.agentTargetInfo === ns.agentTargetInfo &&
     ps.composerFooterAccessory === ns.composerFooterAccessory &&
     ps.providerRailEmpty === ns.providerRailEmpty &&
-    ps.providerUnavailableState === ns.providerUnavailableState &&
     ps.projectDirectoryPickerHeaderActions ===
       ns.projectDirectoryPickerHeaderActions &&
     ps.sidebarFooter === ns.sidebarFooter

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -62,8 +62,6 @@ export type {
   AgentGUINodeViewProps,
   AgentGUIAgentsEmptyRenderer,
   AgentGUIConversationRailLayout,
-  AgentGUIProviderUnavailableStateContext,
-  AgentGUIProviderUnavailableStateRenderer,
   AgentGUISidebarFooterContext,
   AgentGUISidebarFooterRenderer,
   AgentGUIViewLabels,
@@ -95,7 +93,6 @@ export function AgentGUINodeView({
   renderProjectDirectoryPickerHeaderActions,
   renderSidebarFooter,
   renderProviderRailEmpty,
-  renderProviderUnavailableState,
   providerRailAllPresentation,
   onLinkAction,
   onHandoffConversation,
@@ -737,7 +734,6 @@ export function AgentGUINodeView({
                 onRequestComposerFocus={requestComposerFocus}
                 workspaceAppIcons={effectiveWorkspaceAppIcons}
                 workspaceUserProjectI18n={workspaceUserProjectI18n}
-                renderProviderUnavailableState={renderProviderUnavailableState}
                 renderComposerFooterAccessory={renderComposerFooterAccessory}
               />
             </AgentConversationClockProvider>

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.spec.tsx
@@ -8,7 +8,10 @@ import type {
   AgentGUITargetConnectionSource,
   AgentGUITargetConnectionState
 } from "../../../types";
-import { useAgentGUISessionPresentation } from "./useAgentGUISessionPresentation";
+import {
+  resolveAgentGUISharingRevokedRecovery,
+  useAgentGUISessionPresentation
+} from "./useAgentGUISessionPresentation";
 
 class FakeTargetConnectionSource implements AgentGUITargetConnectionSource {
   private readonly listeners = new Set<() => void>();
@@ -54,6 +57,22 @@ class FakeObservationGapSource implements AgentGUIObservationGapSource {
 }
 
 describe("useAgentGUISessionPresentation", () => {
+  it("projects a revoked selected Home target into the shared status chrome", () => {
+    expect(
+      resolveAgentGUISharingRevokedRecovery({
+        activeConversationId: null,
+        selectedAgentTargetOwnerLabel: "Jackson",
+        selectedAgentTargetUnavailable: true,
+        selectedAgentTargetUnavailableReason: "agent_sharing_revoked",
+        sessionRuntimeBlock: null
+      })
+    ).toEqual({
+      kind: "agent-sharing-revoked",
+      message: "Jackson stopped sharing this agent",
+      canRetry: false
+    });
+  });
+
   it("makes a shared Agent composer editable in the same snapshot that its target connects", () => {
     const targetConnectionSource = new FakeTargetConnectionSource();
     const sessionEngine = createAgentSessionEngine({
@@ -110,6 +129,9 @@ describe("useAgentGUISessionPresentation", () => {
       pendingApproval: null,
       planImplementationTurnIdRef: { current: null },
       providerReadinessGate: null,
+      selectedAgentTargetOwnerLabel: null,
+      selectedAgentTargetUnavailable: false,
+      selectedAgentTargetUnavailableReason: null,
       serverInteractivePrompt: null,
       sessionEngine,
       targetConnectionAgentTargetId: "shared-agent:shared-1",
@@ -216,6 +238,9 @@ describe("useAgentGUISessionPresentation", () => {
       pendingApproval: null,
       planImplementationTurnIdRef: { current: null },
       providerReadinessGate: null,
+      selectedAgentTargetOwnerLabel: null,
+      selectedAgentTargetUnavailable: false,
+      selectedAgentTargetUnavailableReason: null,
       serverInteractivePrompt: null,
       sessionEngine,
       targetConnectionAgentTargetId: "shared-agent:shared-1",
@@ -307,6 +332,9 @@ describe("useAgentGUISessionPresentation", () => {
       pendingApproval: null,
       planImplementationTurnIdRef: { current: null },
       providerReadinessGate: null,
+      selectedAgentTargetOwnerLabel: null,
+      selectedAgentTargetUnavailable: false,
+      selectedAgentTargetUnavailableReason: null,
       serverInteractivePrompt: null,
       sessionEngine,
       targetConnectionAgentTargetId: "shared-agent:shared-1",

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.ts
@@ -51,6 +51,40 @@ interface CurrentValue<T> {
   current: T;
 }
 
+export function resolveAgentGUISharingRevokedRecovery(input: {
+  activeConversationId: string | null;
+  selectedAgentTargetOwnerLabel: string | null;
+  selectedAgentTargetUnavailable: boolean;
+  selectedAgentTargetUnavailableReason: string | null;
+  sessionRuntimeBlock: Extract<
+    SessionRuntimeAvailability,
+    { state: "blocked" }
+  > | null;
+}): AgentGUISessionChrome["recovery"] {
+  const selectedTargetSharingRevoked =
+    input.activeConversationId === null &&
+    input.selectedAgentTargetUnavailable &&
+    input.selectedAgentTargetUnavailableReason === "agent_sharing_revoked";
+  if (
+    input.sessionRuntimeBlock?.reason !== "agent_sharing_revoked" &&
+    !selectedTargetSharingRevoked
+  ) {
+    return null;
+  }
+  return {
+    kind: "agent-sharing-revoked",
+    message: translate("agentHost.agentGui.agentSharingRevoked", {
+      owner:
+        (input.sessionRuntimeBlock?.reason === "agent_sharing_revoked"
+          ? input.sessionRuntimeBlock.ownerLabel
+          : null) ??
+        input.selectedAgentTargetOwnerLabel ??
+        translate("agentHost.agentGui.sharedDeviceLabel")
+    }),
+    canRetry: false
+  };
+}
+
 interface UseAgentGUISessionPresentationInput {
   activeConversation: AgentGUIConversationSummary | null;
   activeConversationId: string | null;
@@ -88,6 +122,9 @@ interface UseAgentGUISessionPresentationInput {
   providerReadinessGate:
     | import("../../../types").AgentGUIProviderReadinessGate
     | null;
+  selectedAgentTargetUnavailable: boolean;
+  selectedAgentTargetUnavailableReason: string | null;
+  selectedAgentTargetOwnerLabel: string | null;
   agentTargetsLoading: boolean;
   ownerDeviceLabel?: string | null;
   serverInteractivePrompt: AgentGUIInteractivePrompt | null;
@@ -198,17 +235,19 @@ export function useAgentGUISessionPresentation(
     input.activeGoalControlPresentation
   ]);
   const sessionChrome = useMemo<AgentGUISessionChrome>(() => {
-    if (sessionRuntimeBlock?.reason === "agent_sharing_revoked") {
+    const sharingRevokedRecovery = resolveAgentGUISharingRevokedRecovery({
+      activeConversationId: input.activeConversationId,
+      selectedAgentTargetOwnerLabel: input.selectedAgentTargetOwnerLabel,
+      selectedAgentTargetUnavailable: input.selectedAgentTargetUnavailable,
+      selectedAgentTargetUnavailableReason:
+        input.selectedAgentTargetUnavailableReason,
+      sessionRuntimeBlock
+    });
+    if (sharingRevokedRecovery) {
       return {
         auth: null,
         approval: null,
-        recovery: {
-          kind: "agent-sharing-revoked",
-          message: translate("agentHost.agentGui.agentSharingRevoked", {
-            owner: sessionRuntimeBlock.ownerLabel
-          }),
-          canRetry: false
-        },
+        recovery: sharingRevokedRecovery,
         rawState: sessionChromeRawState
       };
     }
@@ -318,6 +357,9 @@ export function useAgentGUISessionPresentation(
     input.activePendingActivation?.mode,
     input.pendingApproval,
     input.ownerDeviceLabel,
+    input.selectedAgentTargetOwnerLabel,
+    input.selectedAgentTargetUnavailable,
+    input.selectedAgentTargetUnavailableReason,
     sessionRuntimeBlock,
     targetConnection.visibleState,
     observationGap,
@@ -353,6 +395,7 @@ export function useAgentGUISessionPresentation(
         pendingApproval,
         pendingInteractivePrompt: hasPendingInteractivePrompt,
         providerReadinessGate: input.providerReadinessGate,
+        selectedAgentTargetUnavailable: input.selectedAgentTargetUnavailable,
         sessionRuntimeBlockedReason,
         targetConnectionBlocked:
           targetConnection.blocked || observationGap !== null
@@ -371,6 +414,7 @@ export function useAgentGUISessionPresentation(
       input.isInterrupting,
       input.isSubmitting,
       input.providerReadinessGate,
+      input.selectedAgentTargetUnavailable,
       isCollaboratorConversation,
       pendingApproval,
       sessionRuntimeBlockedReason,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIViewAssembly.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIViewAssembly.ts
@@ -44,6 +44,9 @@ type SessionPresentationInput = Omit<
   | "isInterrupting"
   | "pendingApproval"
   | "providerReadinessGate"
+  | "selectedAgentTargetUnavailable"
+  | "selectedAgentTargetUnavailableReason"
+  | "selectedAgentTargetOwnerLabel"
   | "serverInteractivePrompt"
 >;
 type ProviderHomeInput = Parameters<typeof useAgentGUIProviderHome>[0];
@@ -151,12 +154,29 @@ export function useAgentGUIViewAssembly(input: UseAgentGUIViewAssemblyInput) {
       input.providerReadinessGates
     ]
   );
+  const selectedAgentTargetUnavailable =
+    input.activeConversationId === null &&
+    input.effectiveSelectedProviderTarget.disabled === true &&
+    !isAgentGUIAgentTargetComingSoon(
+      input.effectiveSelectedProviderTarget,
+      input.normalizedComingSoonProviders
+    );
+  const selectedAgentTargetUnavailableReason = selectedAgentTargetUnavailable
+    ? input.effectiveSelectedProviderTarget.availability?.reason?.trim() ||
+      input.effectiveSelectedProviderTarget.unavailableReason?.trim() ||
+      null
+    : null;
+  const selectedAgentTargetOwnerLabel =
+    input.effectiveSelectedProviderTarget.ownerLabel?.trim() || null;
   const session = useAgentGUISessionPresentation({
     ...input,
     activeConversation,
     currentUserId: input.currentUserId,
     ownerDeviceLabel: targetConnection.ownerDeviceLabel,
     providerReadinessGate,
+    selectedAgentTargetUnavailable,
+    selectedAgentTargetUnavailableReason,
+    selectedAgentTargetOwnerLabel,
     targetConnectionAgentTargetId: targetConnection.agentTargetId,
     activeLiveState: detail.activeLiveState,
     activationError: detail.activationError,

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiComposerGate.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiComposerGate.spec.ts
@@ -21,6 +21,7 @@ const readyInput: ResolveAgentGUIComposerGateInput = {
   pendingApproval: false,
   pendingInteractivePrompt: false,
   providerReadinessGate: null,
+  selectedAgentTargetUnavailable: false,
   sessionRuntimeBlockedReason: null,
   targetConnectionBlocked: false
 };
@@ -81,6 +82,21 @@ describe("resolveAgentGUIComposerGate", () => {
         expect(gate.editor.status).toBe("editable");
       }
     }
+  });
+
+  it("blocks editing and submission when the selected Home target is unavailable", () => {
+    expect(
+      resolveAgentGUIComposerGate({
+        ...readyInput,
+        activeConversationId: null,
+        activeLiveState: "inactive",
+        selectedAgentTargetUnavailable: true
+      })
+    ).toMatchObject({
+      runtime: { status: "ready", reason: null },
+      editor: { status: "blocked", reason: "provider_readiness" },
+      submission: { status: "blocked", reason: "provider_readiness" }
+    });
   });
 
   it("keeps the editor editable and projects queue submission while busy", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiComposerGate.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiComposerGate.ts
@@ -22,6 +22,7 @@ export interface ResolveAgentGUIComposerGateInput {
   pendingApproval: boolean;
   pendingInteractivePrompt: boolean;
   providerReadinessGate: AgentGUIProviderReadinessGate | null;
+  selectedAgentTargetUnavailable: boolean;
   sessionRuntimeBlockedReason: AgentGUIRuntimeBlockedReason | null;
   targetConnectionBlocked: boolean;
 }
@@ -62,6 +63,7 @@ export function resolveAgentGUIComposerGate(
   const canSubmit =
     !input.agentTargetsLoading &&
     input.providerReadinessGate === null &&
+    !input.selectedAgentTargetUnavailable &&
     runtime.status === "ready" &&
     input.activeLiveState !== "activating" &&
     input.activeLiveState !== "failed" &&
@@ -133,7 +135,7 @@ function resolveEditorGate(
   input: ResolveAgentGUIComposerGateInput
 ): AgentGUIComposerGate["editor"] {
   const reason: AgentGUIComposerEditorBlockedReason | null =
-    input.providerReadinessGate !== null
+    input.providerReadinessGate !== null || input.selectedAgentTargetUnavailable
       ? "provider_readiness"
       : input.pendingApproval
         ? "pending_approval"
@@ -155,7 +157,12 @@ function resolveSubmissionBlockReason(
   input: ResolveAgentGUIComposerGateInput
 ): AgentGUIComposerSubmissionBlockedReason {
   if (input.agentTargetsLoading) return "agent_targets_loading";
-  if (input.providerReadinessGate !== null) return "provider_readiness";
+  if (
+    input.providerReadinessGate !== null ||
+    input.selectedAgentTargetUnavailable
+  ) {
+    return "provider_readiness";
+  }
   if (input.activeLiveState === "activating") return "activation_pending";
   if (input.activeLiveState === "failed") return "activation_failed";
   if (input.activeConversationResumeUnavailable) return "resume_unavailable";

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
@@ -2,7 +2,6 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { AgentMessageMarkdownWorkspaceAppIcon } from "../../../shared/AgentMessageMarkdown";
 import { latestAssistantMessageText } from "../../../shared/agentConversation/projection/agentConversationProjection";
 import { AGENT_GUI_WORKBENCH_OPEN_EXTERNAL_IMPORT_EVENT } from "../../../workbench/contribution";
-import { resolveAgentGuiWorkbenchProviderLabel } from "../../../workbench/providerCatalog";
 import type { AgentComposerProps } from "../AgentComposer";
 import type { AgentHomeSuggestionAction } from "../model/agentGuiNodeTypes";
 import { updateAgentComposerDraft } from "../model/agentComposerDraft";
@@ -15,8 +14,7 @@ import {
 import { AgentGUIBottomDockPane } from "./AgentGUIBottomDockPane";
 import {
   AgentGUIEmptyHomePane,
-  EMPTY_HOME_SUGGESTIONS,
-  resolveAgentGUIHeroIconUrl
+  EMPTY_HOME_SUGGESTIONS
 } from "./AgentGUIEmptyState";
 import { AgentGUIContentToast } from "./AgentGUIContentToast";
 import { AgentGUIDetailTimeline } from "./AgentGUIDetailTimeline";
@@ -77,7 +75,6 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
   onRequestGitBranches,
   onRequestComposerFocus,
   workspaceAppIcons = EMPTY_WORKSPACE_APP_ICONS,
-  renderProviderUnavailableState,
   renderComposerFooterAccessory
 }: AgentGUIDetailPaneProps): React.JSX.Element {
   "use memo";
@@ -130,7 +127,6 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
     inlineNoticeChrome,
     interactivePromptLabels,
     isComposerSending,
-    selectedAgentTargetComingSoon,
     sessionChrome,
     showStopButton,
     stopDisabled,
@@ -621,15 +617,6 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
   );
   const emptyHeroProvider =
     composerSelectedProviderTarget?.provider ?? viewModel.shell.data.provider;
-  const disabledProviderTarget =
-    composerSelectedProviderTarget?.disabled === true ||
-    selectedAgentTargetComingSoon
-      ? composerSelectedProviderTarget
-      : null;
-  const shouldRenderProviderUnavailableState =
-    !hasActiveConversation &&
-    disabledProviderTarget !== null &&
-    renderProviderUnavailableState !== undefined;
   const bottomDockStoreRevision = [
     bottomDockLiftedPrompt?.requestId ?? "",
     bottomDockReplacementPrompt?.requestId ?? "",
@@ -668,51 +655,33 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
     viewModel
   });
   const homeContent = !hasActiveConversation ? (
-    shouldRenderProviderUnavailableState && disabledProviderTarget ? (
-      <>
-        {renderProviderUnavailableState?.({
-          provider: disabledProviderTarget.provider,
-          providerLabel:
-            labels.emptyProviderForProvider?.(
-              disabledProviderTarget.provider
-            ) ??
-            resolveAgentGuiWorkbenchProviderLabel(
-              disabledProviderTarget.provider
-            ),
-          target: disabledProviderTarget,
-          iconUrl: resolveAgentGUIHeroIconUrl(disabledProviderTarget.provider),
-          unavailableReason: disabledProviderTarget.unavailableReason ?? null
-        })}
-      </>
-    ) : (
-      <AgentGUIEmptyHomePane
-        isActive={isActive}
-        isVisible={isVisible}
-        provider={emptyHeroProvider}
-        providerReadinessGate={emptyProviderReadinessGate}
-        showAllProviders={viewModel.rail.conversationFilter.kind === "all"}
-        agentTargets={composerProviderTargets}
-        selectedAgentTarget={composerSelectedProviderTarget}
-        onProviderSelect={
-          viewModel.rail.activeConversationId === null
-            ? selectHomeComposerAgentTargetAndFocus
-            : undefined
-        }
-        noticeChrome={homeNoticeChrome}
-        isRespondingApproval={isInteractionPending}
-        onSubmitApprovalOption={submitApprovalOption}
-        onRetryActivation={retryActivation}
-        onAuthLogin={authLogin}
-        onContinueInNewConversation={continueInNewConversation}
-        chromeLabels={chromeLabels}
-        composerProps={emptyHeroComposerProps}
-        labels={labels}
-        suggestions={labels.homeSuggestions ?? EMPTY_HOME_SUGGESTIONS}
-        suggestionsCloseLabel={labels.homeSuggestionsClose}
-        onSelectSuggestion={handleSelectHomeSuggestion}
-        onSelectSuggestionAction={handleHomeSuggestionAction}
-      />
-    )
+    <AgentGUIEmptyHomePane
+      isActive={isActive}
+      isVisible={isVisible}
+      provider={emptyHeroProvider}
+      providerReadinessGate={emptyProviderReadinessGate}
+      showAllProviders={viewModel.rail.conversationFilter.kind === "all"}
+      agentTargets={composerProviderTargets}
+      selectedAgentTarget={composerSelectedProviderTarget}
+      onProviderSelect={
+        viewModel.rail.activeConversationId === null
+          ? selectHomeComposerAgentTargetAndFocus
+          : undefined
+      }
+      noticeChrome={homeNoticeChrome}
+      isRespondingApproval={isInteractionPending}
+      onSubmitApprovalOption={submitApprovalOption}
+      onRetryActivation={retryActivation}
+      onAuthLogin={authLogin}
+      onContinueInNewConversation={continueInNewConversation}
+      chromeLabels={chromeLabels}
+      composerProps={emptyHeroComposerProps}
+      labels={labels}
+      suggestions={labels.homeSuggestions ?? EMPTY_HOME_SUGGESTIONS}
+      suggestionsCloseLabel={labels.homeSuggestionsClose}
+      onSelectSuggestion={handleSelectHomeSuggestion}
+      onSelectSuggestionAction={handleHomeSuggestionAction}
+    />
   ) : null;
   const forkedFrom =
     viewModel.detail.conversationDetail?.session.forkedFrom ?? null;

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyState.notice.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyState.notice.spec.tsx
@@ -69,4 +69,54 @@ describe("AgentGUIEmptyHeroPane notices", () => {
     ).toBeInTheDocument();
     expect(screen.queryByText(/unknown/i)).not.toBeInTheDocument();
   });
+
+  it("reuses the Home status chrome for revoked sharing above the disabled composer", () => {
+    render(
+      <AgentGUIEmptyHomePane
+        isActive
+        isVisible
+        provider="codex"
+        providerReadinessGate={null}
+        showAllProviders={false}
+        agentTargets={[]}
+        selectedAgentTarget={null}
+        labels={
+          {
+            empty: "What can Agent help with?",
+            emptyForProvider: () => "What can Agent help with?",
+            emptyProvider: "Agent",
+            emptyProviderForProvider: () => "Agent",
+            providerSwitchLabel: "Select Agent",
+            sharedAgentOwnerSeparator: "'s"
+          } as unknown as AgentGUIViewLabels
+        }
+        noticeChrome={{
+          auth: null,
+          approval: null,
+          recovery: {
+            kind: "agent-sharing-revoked",
+            message: "Jackson stopped sharing this agent",
+            canRetry: false
+          },
+          rawState: null
+        }}
+        isRespondingApproval={false}
+        onSubmitApprovalOption={vi.fn()}
+        onRetryActivation={vi.fn()}
+        onContinueInNewConversation={vi.fn()}
+        chromeLabels={{} as never}
+        composerProps={{} as AgentComposerProps}
+        suggestions={[]}
+        onSelectSuggestion={vi.fn()}
+      />
+    );
+
+    const status = screen.getByRole("alert");
+    const composer = screen.getByTestId("agent-composer");
+    expect(status).toHaveTextContent("Jackson stopped sharing this agent");
+    expect(
+      status.compareDocumentPosition(composer) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
@@ -17,7 +17,6 @@ import type { WorkspaceLinkAction } from "../../../actions/workspaceLinkActions"
 import type {
   AgentGUIProvider,
   AgentGUIProviderRailAllPresentation,
-  AgentGUIAgentTarget,
   AgentGUIAgentTargetInfoRenderer
 } from "../../../types";
 import type { AgentMessageMarkdownWorkspaceAppIcon } from "../../../shared/AgentMessageMarkdown";
@@ -533,8 +532,6 @@ export interface AgentGUINodeViewProps {
   renderSidebarFooter?: AgentGUISidebarFooterRenderer;
   /** Renders the provider rail empty state in "exact" mode. See the type doc. */
   renderProviderRailEmpty?: AgentGUIAgentsEmptyRenderer;
-  /** Renders the selected provider's unavailable state. */
-  renderProviderUnavailableState?: AgentGUIProviderUnavailableStateRenderer;
   providerRailAllPresentation?: AgentGUIProviderRailAllPresentation | null;
   onLinkAction?: (action: WorkspaceLinkAction) => void;
   onHandoffConversation?: (input: {
@@ -755,7 +752,6 @@ export interface AgentGUIDetailPaneProps {
   onRequestGitBranches?: AgentComposerGitBranchLoader | null;
   onRequestComposerFocus: () => void;
   workspaceAppIcons?: readonly AgentMessageMarkdownWorkspaceAppIcon[];
-  renderProviderUnavailableState?: AgentGUIProviderUnavailableStateRenderer;
   renderComposerFooterAccessory?: AgentGUIComposerFooterAccessoryRenderer;
 }
 
@@ -770,20 +766,3 @@ export type AgentGUISidebarFooterRenderer = (
 
 /** Renders the host-owned empty state for an exact provider rail. */
 export type AgentGUIAgentsEmptyRenderer = () => ReactNode;
-
-export interface AgentGUIProviderUnavailableStateContext {
-  provider: AgentGUIProvider;
-  providerLabel: string;
-  target: AgentGUIAgentTarget;
-  iconUrl: string;
-  unavailableReason: string | null;
-}
-
-/**
- * Renders the main-pane unavailable state for a selected provider target that
- * the host explicitly marks as disabled. This does not replace install,
- * login, checking, or retry readiness gates.
- */
-export type AgentGUIProviderUnavailableStateRenderer = (
-  ctx: AgentGUIProviderUnavailableStateContext
-) => ReactNode;

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildAgentConversationHandoffPrompt,
   handoffProjectPathForConversation,
-  isAgentGUITransportNoticeVisible,
+  isAgentGUIHomeStatusNoticeVisible,
   resolveAgentGUITuttiStopTargets,
   resolveAgentGUIHomeNoticeChrome,
   resolveAgentGUIStopControl,
@@ -114,12 +114,16 @@ describe("resolveAgentGUITuttiStopTargets", () => {
   });
 });
 
-describe("transport availability presentation", () => {
-  it.each(["transport-connecting", "transport-unavailable"] as const)(
+describe("Home status presentation", () => {
+  it.each([
+    "agent-sharing-revoked",
+    "transport-connecting",
+    "transport-unavailable"
+  ] as const)(
     "gives %s recovery chrome priority over other bottom-dock notices",
     (kind) => {
       expect(
-        isAgentGUITransportNoticeVisible({
+        isAgentGUIHomeStatusNoticeVisible({
           kind,
           message: "Connection unavailable",
           canRetry: false
@@ -129,9 +133,9 @@ describe("transport availability presentation", () => {
   );
 
   it("does not hide existing chrome while reconnecting is still delayed", () => {
-    expect(isAgentGUITransportNoticeVisible(null)).toBe(false);
+    expect(isAgentGUIHomeStatusNoticeVisible(null)).toBe(false);
     expect(
-      isAgentGUITransportNoticeVisible({
+      isAgentGUIHomeStatusNoticeVisible({
         kind: "failed",
         message: "Existing failure",
         canRetry: false

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.ts
@@ -240,10 +240,11 @@ export function shouldShowAgentGUIStopButton(input: {
   );
 }
 
-export function isAgentGUITransportNoticeVisible(
+export function isAgentGUIHomeStatusNoticeVisible(
   recovery: AgentGUISessionChrome["recovery"]
 ): boolean {
   return (
+    recovery?.kind === "agent-sharing-revoked" ||
     recovery?.kind === "transport-connecting" ||
     recovery?.kind === "transport-unavailable"
   );
@@ -253,7 +254,7 @@ export function resolveAgentGUIHomeNoticeChrome(input: {
   inlineNoticeChrome: AgentGUISessionChrome | null;
   sessionChrome: AgentGUISessionChrome;
 }): AgentGUISessionChrome | null {
-  return isAgentGUITransportNoticeVisible(input.sessionChrome.recovery)
+  return isAgentGUIHomeStatusNoticeVisible(input.sessionChrome.recovery)
     ? input.sessionChrome
     : input.inlineNoticeChrome;
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailModel.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailModel.tsx
@@ -12,7 +12,7 @@ import type {
 import type { AgentGUIViewLabels } from "../AgentGUINodeView";
 import {
   isContextCanceledMessage,
-  isAgentGUITransportNoticeVisible,
+  isAgentGUIHomeStatusNoticeVisible,
   resolveAgentGUIHomeNoticeChrome,
   resolveAgentGUIStopControl,
   resolveSlashStatus,
@@ -90,7 +90,7 @@ export function useAgentGUIDetailModel(input: Input) {
     () => ({ ...viewModel.interaction.sessionChrome, approval: null }),
     [viewModel.interaction.sessionChrome]
   );
-  const transportNoticeVisible = isAgentGUITransportNoticeVisible(
+  const homeStatusNoticeVisible = isAgentGUIHomeStatusNoticeVisible(
     sessionChrome.recovery
   );
   const rawSlashStatus = useMemo(
@@ -125,7 +125,7 @@ export function useAgentGUIDetailModel(input: Input) {
     ]
   );
   const displayedInlineNotice = useMemo(() => {
-    if (transportNoticeVisible) {
+    if (homeStatusNoticeVisible) {
       return null;
     }
     const inlineNotice =
@@ -160,7 +160,7 @@ export function useAgentGUIDetailModel(input: Input) {
     tuttiModeUpdateNotice,
     viewModel.rail.activeConversation?.status,
     viewModel.readiness.activeLiveState,
-    transportNoticeVisible,
+    homeStatusNoticeVisible,
     viewModel.interaction.inlineNotice
   ]);
   const inlineNoticeChrome = useMemo<AgentGUISessionChrome | null>(() => {
@@ -192,7 +192,7 @@ export function useAgentGUIDetailModel(input: Input) {
     activePrompt?.kind === "plan-implementation";
   const activePromptIsVisible =
     activePrompt !== null &&
-    !transportNoticeVisible &&
+    !homeStatusNoticeVisible &&
     bottomDockDismissedPromptRequestId !== activePromptRequestId;
   const bottomDockReplacementPrompt =
     activePromptIsPlanDecision && activePromptIsVisible ? activePrompt : null;

--- a/packages/agent/gui/index.ts
+++ b/packages/agent/gui/index.ts
@@ -155,8 +155,6 @@ export type {
 export type {
   AgentGUIAgentsEmptyRenderer,
   AgentGUIConversationRailLayout,
-  AgentGUIProviderUnavailableStateContext,
-  AgentGUIProviderUnavailableStateRenderer,
   AgentGUISidebarFooterContext,
   AgentGUISidebarFooterRenderer
 } from "./agent-gui/agentGuiNode/AgentGUINodeView";


### PR DESCRIPTION
## Summary

- Keep the normal empty conversation Home visible when the selected Agent target is unavailable.
- Reuse the existing Home status chrome for offline transport and revoked-sharing states.
- Remove the duplicate Host-owned provider unavailable-state render slot.
- Block both composer editing and submission until the selected target is available.

## Why

Unavailable shared Agents were replacing the whole Home surface or rendering a second status container beside the existing runtime status strip. Revoked sharing could also fall through to an offline presentation. The Home page should keep one status surface and one canonical composer gate.

## Impact and risk

- Affects AgentGUI Home presentation and composer gating for disabled exact targets.
- Removes the public providerUnavailableState render slot. TSH is the known consumer and is updated in https://github.com/tutti-lab/tsh/pull/2286.
- Existing install, login, checking, coming-soon, retry, active-conversation, and streaming paths remain unchanged.

## Verification

- `pnpm check:changed` (11 lanes)
- Pre-push `pnpm check:changed -- --push-ready` (12 lanes)
- Focused AgentGUI tests for Home status projection, revoked sharing, and composer gating passed.

## Consumer review

- Architecture: updated the AgentGUI public contract documentation and added a changeset.
- Performance: no polling, transport, timeline, or streaming hot path changes.
- Consumer compatibility: TSH removes the retired render slot and consumes the built-in status chrome in https://github.com/tutti-lab/tsh/pull/2286.