### PR TITLE
fix(agent-gui): keep single target title inline

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyState.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyState.tsx
@@ -701,7 +701,7 @@ function EmptyHeroTitle({
         </Select>
       ) : selectedAgentTarget ? (
         <AgentGUIAgentTargetName
-          className={cn(styles.emptyHeroProvider, "max-w-[240px]")}
+          className={cn(styles.emptyHeroProvider, "inline-flex max-w-[240px]")}
           ownerSeparator={sharedAgentOwnerSeparator}
           target={selectedAgentTarget}
         />


### PR DESCRIPTION
## Summary

- keep the selected Agent Target inline in the empty new-conversation title when only one target is available
- preserve the existing multi-target switcher and single-target non-interactive behavior

## Root cause

The multi-target path wraps the target name in an inline-flex Select trigger. The single-target path rendered `AgentGUIAgentTargetName` directly; its default block-level flex display forced the title prefix, target name, and suffix onto separate lines.

## Impact

Single- and multi-Agent new-conversation titles now use consistent inline layout. This is presentation-only and does not change Agent selection, lifecycle, or public contracts.

## Validation

- pre-commit formatting, lint, UI boundary, renderer boundary, AgentGUI degradation, and runtime image budget checks
- `pnpm check:changed -- --push-ready` — 12 lanes passed
- local `@tutti-os/agent-gui` build, pack, TSH link, and package import succeeded
- confirmed UI System class merging resolves `flex` plus `inline-flex` to `inline-flex`

## AgentGUI review

| Lane | Trigger | Result | Evidence | Affected consumers |
| --- | --- | --- | --- | --- |
| Architecture | Empty Home Agent Target presentation | pass | Only the view class changes; exact target identity, selection action, and lifecycle paths are unchanged | Desktop AgentGUI, TSH AgentGUI |
| Performance | Title layout display changes | pass | Static class substitution; no new measurement, observer, subscription, or render state | Empty Home title |
| Consumers | Published AgentGUI visual output changes | pass | Package builds and imports through TSH; no props, exports, or runtime contracts changed | Desktop and external AgentGUI hosts |

No durable documentation impact was found. Manual GUI inspection was not run.