### PR TITLE
refactor(tuttid): clarify launch ref vocabulary

### DIFF
--- a/services/tuttid/biz/agenttarget/model.go
+++ b/services/tuttid/biz/agenttarget/model.go
@@ -23,9 +23,6 @@ const (
 
 	LaunchRefTypeBuiltinLocal   = "builtin_local"
 	LaunchRefTypeAgentExtension = "agent_extension"
-	// LaunchRefTypeLocalCLI is retained as a source compatibility name while
-	// persisted and API output normalize to builtin_local.
-	LaunchRefTypeLocalCLI       = LaunchRefTypeBuiltinLocal
 	launchRefTypeLegacyLocalCLI = "local_cli"
 
 	SourceSystem = "system"

--- a/services/tuttid/biz/agenttarget/model_test.go
+++ b/services/tuttid/biz/agenttarget/model_test.go
@@ -31,34 +31,36 @@ func TestDefaultSystemTargetsUseMigratedProviderDescriptors(t *testing.T) {
 		}
 	}
 	for _, descriptor := range providerregistry.Migrated() {
-		var target *Target
+		var target Target
+		found := false
 		for index := range targets {
 			if targets[index].ID == descriptor.Target.ID {
-				target = &targets[index]
+				target = targets[index]
+				found = true
 				break
 			}
 		}
-		if target == nil {
+		if !found {
 			t.Fatalf("migrated target %q missing from %#v", descriptor.Target.ID, targets)
 		}
 		if target.ID != descriptor.Target.ID || target.Provider != descriptor.Identity.ID {
-			t.Fatalf("target identity = %#v", target)
+			t.Fatalf("target identity = %#v", &target)
 		}
 		if target.Name != descriptor.Identity.DisplayName || target.IconKey != descriptor.Identity.IconKey {
-			t.Fatalf("target presentation = %#v", target)
+			t.Fatalf("target presentation = %#v", &target)
 		}
 		if target.IconURL == "" {
-			t.Fatalf("target icon URL missing = %#v", target)
+			t.Fatalf("target icon URL missing = %#v", &target)
 		}
 		if target.IconKey == "hermes" || target.IconKey == "openclaw" {
 			if target.MaskIconURL != "" {
 				t.Fatalf("target mask icon URL = %q, want empty image fallback for %s", target.MaskIconURL, target.IconKey)
 			}
 		} else if target.MaskIconURL == "" {
-			t.Fatalf("target mask icon URL missing = %#v", target)
+			t.Fatalf("target mask icon URL missing = %#v", &target)
 		}
 		if target.SortOrder != descriptor.Target.SortOrder || target.CreatedAtUnixMS != 123 {
-			t.Fatalf("target ordering/timestamp = %#v", target)
+			t.Fatalf("target ordering/timestamp = %#v", &target)
 		}
 	}
 }

--- a/services/tuttid/service/agent/service_create_test.go
+++ b/services/tuttid/service/agent/service_create_test.go
@@ -387,10 +387,10 @@ func TestServiceCreateResolvesProviderFromAgentTarget(t *testing.T) {
 		t.Fatalf("runtime agent target id = %q, want %s", got, agenttargetbiz.IDLocalClaudeCode)
 	}
 	ref := visibleStart.ProviderTargetRef
-	if ref["kind"] != agenttargetbiz.LaunchRefTypeLocalCLI ||
+	if ref["kind"] != agenttargetbiz.LaunchRefTypeBuiltinLocal ||
 		ref["provider"] != "claude-code" ||
 		ref["targetId"] != agenttargetbiz.IDLocalClaudeCode {
-		t.Fatalf("runtime provider target ref = %#v, want daemon-derived local_cli claude target", ref)
+		t.Fatalf("runtime provider target ref = %#v, want daemon-derived builtin_local claude target", ref)
 	}
 }
 

--- a/services/tuttid/service/agent/service_session_capabilities_test.go
+++ b/services/tuttid/service/agent/service_session_capabilities_test.go
@@ -51,6 +51,7 @@ func assertSessionCapabilityValues(t *testing.T, snapshot *canonical.CapabilityS
 	t.Helper()
 	if snapshot == nil {
 		t.Fatal("capability snapshot = nil")
+		return
 	}
 	if len(snapshot.Values) != len(expected) {
 		t.Fatalf("capability values = %#v, want %#v", snapshot.Values, expected)


### PR DESCRIPTION
## Summary

- remove the misleading `services/tuttid` source alias `LaunchRefTypeLocalCLI`, whose value was actually `builtin_local`
- update the sole in-repository consumer to assert the canonical `LaunchRefTypeBuiltinLocal` vocabulary
- preserve the private `local_cli` legacy decoder and canonicalization path for existing persisted Agent Targets
- make nil guards explicit in the two test packages selected by the current Go lint gate

## Compatibility

- no HTTP or OpenAPI contract changes
- no persisted-data migration changes; legacy `"local_cli"` values still normalize to `"builtin_local"`
- no Agent Host lifecycle changes
- `services/tuttid` is product-core code rather than a published package, so no TSH source or version update is required

## Validation

- `go test ./biz/agenttarget`
- `go test ./data/workspace -run '^TestSQLiteStorePutAgentTargetCanonicalizesLaunchRef$'`
- `go test ./service/agent -run '^TestServiceCreateResolvesProviderFromAgentTarget$'`
- `pnpm test:go` — 18 lanes passed
- `pnpm build:go`
- `pnpm check:agent-host-boundary`
- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready` — 7 lanes passed
- independent pre-commit review — PASS, no blocking or non-blocking findings

A standalone full `pnpm lint:go` also exposed unrelated pre-existing SA5011 findings in unmodified `service/account` and `service/agentstatus` tests. The changed-aware lint lane for this PR passes.

## Documentation

No durable documentation update is needed because ownership, data flow, wire/API behavior, and legacy persistence compatibility are unchanged.
