### PR TITLE
refactor(workbench): extract minimized preview presentation

### DIFF
--- a/packages/workbench/surface/package.json
+++ b/packages/workbench/surface/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "build": "tsup --config tsup.config.ts && node ../../../tools/scripts/copy-package-assets.mjs src/styles dist/styles",
-    "test": "node --test --experimental-strip-types ./src/**/*.test.ts && vitest run ./src/host/WorkbenchHostDock.render.test.tsx ./src/host/WorkbenchHost.render.test.tsx ./src/host/useWorkbenchMinimizedDockPreview.test.tsx ./src/preview/createWorkbenchNodePreviewCaptureAdapter.test.tsx ./src/react/genieTextureCapture.test.tsx --environment jsdom",
+    "test": "node --test --experimental-strip-types ./src/**/*.test.ts && vitest run ./src/host/WorkbenchHostDock.render.test.tsx ./src/host/WorkbenchHostDockMinimizedPreview.test.tsx ./src/host/WorkbenchHost.render.test.tsx ./src/host/useWorkbenchMinimizedDockPreview.test.tsx ./src/preview/createWorkbenchNodePreviewCaptureAdapter.test.tsx ./src/react/genieTextureCapture.test.tsx --environment jsdom",
     "typecheck": "node ../../../tools/scripts/run-tsgo-typecheck.mjs"
   },
   "devDependencies": {

--- a/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
@@ -24,9 +24,13 @@ import type { WorkbenchDockContext } from "../react/types.ts";
 import {
   readWorkbenchMinimizedDockPreviewImage,
   resolveWorkbenchMinimizedDockPreviewImage,
-  resolveWorkbenchMinimizedDockPreviewRevision,
-  useWorkbenchMinimizedDockPreview
+  resolveWorkbenchMinimizedDockPreviewRevision
 } from "./useWorkbenchMinimizedDockPreview.ts";
+import {
+  minimizedDockPreviewFreezeKey,
+  WorkbenchHostDockMinimizedNodePreview
+} from "./WorkbenchHostDockMinimizedPreview.tsx";
+export { renderMinimizedDockPreviewContent } from "./WorkbenchHostDockMinimizedPreview.tsx";
 import {
   canCreateNewWindow,
   canCreateNewWindowInDockPopup,
@@ -2536,170 +2540,6 @@ export function WorkbenchHostDock({
       ) : null}
     </div>
   );
-}
-
-function WorkbenchHostDockMinimizedNodePreview({
-  capturePreview,
-  className,
-  deferPreview = false,
-  dockPreviewCache,
-  node,
-  providePreview,
-  workspaceId
-}: {
-  capturePreview?: (
-    node: WorkbenchMinimizedDockNode
-  ) => Promise<string | null> | string | null;
-  className?: string;
-  deferPreview?: boolean;
-  dockPreviewCache?: WorkbenchDockPreviewCache;
-  node: WorkbenchMinimizedDockNode;
-  providePreview?: (
-    node: WorkbenchMinimizedDockNode
-  ) => WorkbenchDockPreviewContent | null;
-  workspaceId: string;
-}) {
-  const { componentPreview, previewImageUrl } =
-    useWorkbenchMinimizedDockPreview({
-      capturePreview,
-      deferPreview,
-      dockPreviewCache,
-      node,
-      providePreview,
-      workspaceId
-    });
-
-  if (deferPreview) {
-    return renderMinimizedDockPreviewPlaceholder(className);
-  }
-
-  if (previewImageUrl) {
-    return (
-      <span
-        className={[
-          "desktop-dock__minimized-preview",
-          "desktop-dock__minimized-preview--snapshot",
-          className
-        ]
-          .filter(Boolean)
-          .join(" ")}
-        aria-hidden="true"
-      >
-        <img
-          alt=""
-          className="desktop-dock__minimized-preview-image"
-          draggable={false}
-          src={previewImageUrl}
-        />
-      </span>
-    );
-  }
-
-  if (componentPreview) {
-    return renderMinimizedDockPreviewContent(componentPreview, className);
-  }
-
-  return renderMinimizedDockPreviewPlaceholder(className);
-}
-
-function renderMinimizedDockPreviewPlaceholder(className?: string) {
-  return (
-    <span
-      className={["desktop-dock__minimized-preview", className]
-        .filter(Boolean)
-        .join(" ")}
-      aria-hidden="true"
-    >
-      <span className="desktop-dock__minimized-preview-line" />
-      <span className="desktop-dock__minimized-preview-line desktop-dock__minimized-preview-line--short" />
-      <span className="desktop-dock__minimized-preview-line desktop-dock__minimized-preview-line--accent" />
-    </span>
-  );
-}
-
-export function renderMinimizedDockPreviewContent(
-  preview: WorkbenchDockPreviewContent,
-  className?: string
-) {
-  if (preview.kind === "image") {
-    return (
-      <span
-        className={[
-          "desktop-dock__minimized-preview",
-          "desktop-dock__minimized-preview--snapshot",
-          className
-        ]
-          .filter(Boolean)
-          .join(" ")}
-        aria-hidden="true"
-      >
-        <img
-          alt=""
-          className="desktop-dock__minimized-preview-image"
-          draggable={false}
-          src={preview.src}
-        />
-      </span>
-    );
-  }
-
-  return (
-    <WorkbenchHostDockFrozenComponentPreview
-      className={className}
-      preview={preview}
-    />
-  );
-}
-
-function WorkbenchHostDockFrozenComponentPreview({
-  className,
-  preview
-}: {
-  className?: string;
-  preview: Extract<WorkbenchDockPreviewContent, { kind: "component" }>;
-}) {
-  const sourceRef = useRef<HTMLSpanElement | null>(null);
-  const [frozenMarkup, setFrozenMarkup] = useState<string | null>(null);
-
-  useLayoutEffect(() => {
-    if (frozenMarkup !== null) {
-      return;
-    }
-    setFrozenMarkup(sourceRef.current?.innerHTML ?? "");
-  }, [frozenMarkup]);
-
-  return (
-    <span
-      className={[
-        "desktop-dock__minimized-preview",
-        "desktop-dock__minimized-preview--component",
-        className
-      ]
-        .filter(Boolean)
-        .join(" ")}
-      aria-hidden="true"
-    >
-      {frozenMarkup === null ? (
-        <span
-          ref={sourceRef}
-          className="desktop-dock__minimized-preview-freeze-source"
-        >
-          {preview.element}
-        </span>
-      ) : (
-        <span
-          className="desktop-dock__minimized-preview-frozen-content"
-          dangerouslySetInnerHTML={{ __html: frozenMarkup }}
-        />
-      )}
-    </span>
-  );
-}
-
-function minimizedDockPreviewFreezeKey(
-  node: WorkbenchMinimizedDockNode
-): string {
-  return `${node.id}:${node.minimizedAtUnixMs ?? "pending"}`;
 }
 
 function dockEntryHasHoverPanel(entry: WorkbenchHostDockEntry): boolean {

--- a/packages/workbench/surface/src/host/WorkbenchHostDockMinimizedPreview.test.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDockMinimizedPreview.test.tsx
@@ -1,0 +1,155 @@
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { renderMinimizedDockPreviewContent as renderMinimizedDockPreviewContentCompatibility } from "./WorkbenchHostDock.tsx";
+import type { WorkbenchMinimizedDockNode } from "./minimizedDockSlots.ts";
+import {
+  minimizedDockPreviewFreezeKey,
+  renderMinimizedDockPreviewContent,
+  renderMinimizedDockPreviewPlaceholder
+} from "./WorkbenchHostDockMinimizedPreview.tsx";
+
+const mountedRoots: Array<{ container: HTMLDivElement; root: Root }> = [];
+const previousActEnvironment = (
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT;
+
+beforeAll(() => {
+  (
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  (
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+});
+
+afterEach(async () => {
+  while (mountedRoots.length > 0) {
+    const mounted = mountedRoots.pop();
+    if (!mounted) {
+      continue;
+    }
+    await act(async () => {
+      mounted.root.unmount();
+    });
+    mounted.container.remove();
+  }
+});
+
+describe("WorkbenchHostDockMinimizedPreview", () => {
+  it("preserves the WorkbenchHostDock file-level renderer export", () => {
+    expect(renderMinimizedDockPreviewContentCompatibility).toBe(
+      renderMinimizedDockPreviewContent
+    );
+  });
+
+  it("renders image previews with the shared snapshot DOM contract", async () => {
+    const container = await render(
+      renderMinimizedDockPreviewContent(
+        { kind: "image", src: "data:image/png;base64,preview" },
+        "custom-preview"
+      )
+    );
+
+    const preview = container.firstElementChild;
+    expect(preview?.classList.contains("desktop-dock__minimized-preview")).toBe(
+      true
+    );
+    expect(
+      preview?.classList.contains("desktop-dock__minimized-preview--snapshot")
+    ).toBe(true);
+    expect(preview?.classList.contains("custom-preview")).toBe(true);
+    expect(preview?.getAttribute("aria-hidden")).toBe("true");
+
+    const image = preview?.querySelector("img");
+    expect(image?.className).toBe("desktop-dock__minimized-preview-image");
+    expect(image?.getAttribute("alt")).toBe("");
+    expect(image?.draggable).toBe(false);
+    expect(image?.getAttribute("src")).toBe("data:image/png;base64,preview");
+  });
+
+  it("renders the shared placeholder structure", async () => {
+    const container = await render(
+      renderMinimizedDockPreviewPlaceholder("custom-placeholder")
+    );
+
+    const preview = container.firstElementChild;
+    expect(preview?.classList.contains("desktop-dock__minimized-preview")).toBe(
+      true
+    );
+    expect(preview?.classList.contains("custom-placeholder")).toBe(true);
+    expect(preview?.getAttribute("aria-hidden")).toBe("true");
+    expect(
+      Array.from(preview?.children ?? []).map((element) => element.className)
+    ).toEqual([
+      "desktop-dock__minimized-preview-line",
+      "desktop-dock__minimized-preview-line desktop-dock__minimized-preview-line--short",
+      "desktop-dock__minimized-preview-line desktop-dock__minimized-preview-line--accent"
+    ]);
+  });
+
+  it("freezes component previews after mounting their source once", async () => {
+    const refPhases: string[] = [];
+    const container = await render(
+      renderMinimizedDockPreviewContent({
+        element: (
+          <strong
+            data-preview="component"
+            ref={(element) => {
+              refPhases.push(element ? "mounted" : "unmounted");
+            }}
+          >
+            Preview
+          </strong>
+        ),
+        kind: "component"
+      })
+    );
+
+    expect(refPhases).toEqual(["mounted", "unmounted"]);
+    expect(
+      container.querySelector(".desktop-dock__minimized-preview-freeze-source")
+    ).toBeNull();
+    const frozen = container.querySelector(
+      ".desktop-dock__minimized-preview-frozen-content"
+    );
+    expect(frozen?.innerHTML).toBe(
+      '<strong data-preview="component">Preview</strong>'
+    );
+  });
+
+  it("changes the freeze key when the minimized revision changes", () => {
+    const node = {
+      id: "node-1",
+      minimizedAtUnixMs: 10
+    } as WorkbenchMinimizedDockNode;
+
+    expect(minimizedDockPreviewFreezeKey(node)).toBe("node-1:10");
+    expect(
+      minimizedDockPreviewFreezeKey({
+        ...node,
+        minimizedAtUnixMs: 11
+      })
+    ).toBe("node-1:11");
+    expect(
+      minimizedDockPreviewFreezeKey({
+        ...node,
+        minimizedAtUnixMs: undefined
+      })
+    ).toBe("node-1:pending");
+  });
+});
+
+async function render(element: ReactElement): Promise<HTMLDivElement> {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  mountedRoots.push({ container, root });
+  await act(async () => {
+    root.render(element);
+  });
+  return container;
+}

--- a/packages/workbench/surface/src/host/WorkbenchHostDockMinimizedPreview.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDockMinimizedPreview.tsx
@@ -1,0 +1,154 @@
+import { useLayoutEffect, useRef, useState } from "react";
+import type { WorkbenchDockPreviewCache } from "../react/dockPreviewCache.ts";
+import type { WorkbenchMinimizedDockNode } from "./minimizedDockSlots.ts";
+import type { WorkbenchDockPreviewContent } from "./types.ts";
+import { useWorkbenchMinimizedDockPreview } from "./useWorkbenchMinimizedDockPreview.ts";
+
+export function WorkbenchHostDockMinimizedNodePreview({
+  capturePreview,
+  className,
+  deferPreview = false,
+  dockPreviewCache,
+  node,
+  providePreview,
+  workspaceId
+}: {
+  capturePreview?: (
+    node: WorkbenchMinimizedDockNode
+  ) => Promise<string | null> | string | null;
+  className?: string;
+  deferPreview?: boolean;
+  dockPreviewCache?: WorkbenchDockPreviewCache;
+  node: WorkbenchMinimizedDockNode;
+  providePreview?: (
+    node: WorkbenchMinimizedDockNode
+  ) => WorkbenchDockPreviewContent | null;
+  workspaceId: string;
+}) {
+  const { componentPreview, previewImageUrl } =
+    useWorkbenchMinimizedDockPreview({
+      capturePreview,
+      deferPreview,
+      dockPreviewCache,
+      node,
+      providePreview,
+      workspaceId
+    });
+
+  if (deferPreview) {
+    return renderMinimizedDockPreviewPlaceholder(className);
+  }
+
+  if (previewImageUrl) {
+    return renderMinimizedDockPreviewContent(
+      { kind: "image", src: previewImageUrl },
+      className
+    );
+  }
+
+  if (componentPreview) {
+    return renderMinimizedDockPreviewContent(componentPreview, className);
+  }
+
+  return renderMinimizedDockPreviewPlaceholder(className);
+}
+
+export function renderMinimizedDockPreviewPlaceholder(className?: string) {
+  return (
+    <span
+      className={["desktop-dock__minimized-preview", className]
+        .filter(Boolean)
+        .join(" ")}
+      aria-hidden="true"
+    >
+      <span className="desktop-dock__minimized-preview-line" />
+      <span className="desktop-dock__minimized-preview-line desktop-dock__minimized-preview-line--short" />
+      <span className="desktop-dock__minimized-preview-line desktop-dock__minimized-preview-line--accent" />
+    </span>
+  );
+}
+
+export function renderMinimizedDockPreviewContent(
+  preview: WorkbenchDockPreviewContent,
+  className?: string
+) {
+  if (preview.kind === "image") {
+    return (
+      <span
+        className={[
+          "desktop-dock__minimized-preview",
+          "desktop-dock__minimized-preview--snapshot",
+          className
+        ]
+          .filter(Boolean)
+          .join(" ")}
+        aria-hidden="true"
+      >
+        <img
+          alt=""
+          className="desktop-dock__minimized-preview-image"
+          draggable={false}
+          src={preview.src}
+        />
+      </span>
+    );
+  }
+
+  return (
+    <WorkbenchHostDockFrozenComponentPreview
+      className={className}
+      preview={preview}
+    />
+  );
+}
+
+function WorkbenchHostDockFrozenComponentPreview({
+  className,
+  preview
+}: {
+  className?: string;
+  preview: Extract<WorkbenchDockPreviewContent, { kind: "component" }>;
+}) {
+  const sourceRef = useRef<HTMLSpanElement | null>(null);
+  const [frozenMarkup, setFrozenMarkup] = useState<string | null>(null);
+
+  useLayoutEffect(() => {
+    if (frozenMarkup !== null) {
+      return;
+    }
+    setFrozenMarkup(sourceRef.current?.innerHTML ?? "");
+  }, [frozenMarkup]);
+
+  return (
+    <span
+      className={[
+        "desktop-dock__minimized-preview",
+        "desktop-dock__minimized-preview--component",
+        className
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      aria-hidden="true"
+    >
+      {frozenMarkup === null ? (
+        <span
+          ref={sourceRef}
+          className="desktop-dock__minimized-preview-freeze-source"
+        >
+          {preview.element}
+        </span>
+      ) : (
+        <span
+          className="desktop-dock__minimized-preview-frozen-content"
+          dangerouslySetInnerHTML={{ __html: frozenMarkup }}
+        />
+      )}
+    </span>
+  );
+}
+
+export function minimizedDockPreviewFreezeKey(
+  node: WorkbenchMinimizedDockNode
+): string {
+  return `${node.id}:${node.minimizedAtUnixMs ?? "pending"}`;
+}

--- a/packages/workbench/surface/src/host/useWorkbenchHostSurfaceRenderers.tsx
+++ b/packages/workbench/surface/src/host/useWorkbenchHostSurfaceRenderers.tsx
@@ -14,10 +14,8 @@ import type {
   WorkbenchDockPreviewCache,
   WorkbenchDockPreviewCacheKey
 } from "../react/dockPreviewCache.ts";
-import {
-  renderMinimizedDockPreviewContent,
-  WorkbenchHostDock
-} from "./WorkbenchHostDock.tsx";
+import { WorkbenchHostDock } from "./WorkbenchHostDock.tsx";
+import { renderMinimizedDockPreviewContent } from "./WorkbenchHostDockMinimizedPreview.tsx";
 import { MemoizedWorkbenchHostNodeBodyRenderer } from "./WorkbenchHostNodeBodyRenderer.tsx";
 import {
   createWorkbenchHostNodeBodyContext,


### PR DESCRIPTION
## Summary

- extract minimized Dock preview presentation from `WorkbenchHostDock.tsx` into the internal `WorkbenchHostDockMinimizedPreview.tsx` owner
- make both the Dock root and Genie capture renderer depend on that focused owner instead of making Genie import preview presentation from the Dock monolith
- preserve the existing `WorkbenchHostDock.tsx` file-level renderer export as a compatibility re-export while keeping package-root exports unchanged
- add characterization coverage for image, placeholder, component-freeze DOM contracts, freeze-key revisions, and compatibility export identity

## Ownership

Before:

```text
WorkbenchHostDock.tsx
├── Dock root composition
└── minimized preview presentation
    ↑ imported by Genie renderer
```

After:

```text
WorkbenchHostDock.tsx ─┐
                       ├─> WorkbenchHostDockMinimizedPreview.tsx
Genie renderer ────────┘
```

The Preview Runtime, capture/cache lifecycle, revision fencing, CSS classes, ARIA attributes, and public package API are unchanged.

## Compatibility and consumers

- no new package-root export or public type change
- no CSS, persistence, runtime, or host contract change
- retains the old file-level deep-import renderer path as the same function identity
- read-only TSH impact search found no references to the moved internal symbols, so no downstream change is required
- no architecture documentation change is required because ownership remains inside `@tutti-os/workbench-surface`

## Verification

- focused presentation tests: passed (5 tests)
- `pnpm --filter @tutti-os/workbench-surface test`: passed
- `pnpm --filter @tutti-os/workbench-surface typecheck`: passed
- `pnpm --filter @tutti-os/workbench-surface build`: passed
- `pnpm check:changed`: passed (9 lanes)
- pre-push `pnpm check:changed -- --push-ready`: passed (10 lanes)
- `pnpm release:pack:check`: passed, including `@tutti-os/workbench-surface`
- `git diff --check`: passed
- independent pre-commit review: PASS, no blocking findings

### Desktop runtime smoke

`make dev-gui` launched the real Electron renderer, Vite dev renderer, `tuttid`, and enabled workspace-app runtimes. `tutti-dev status` returned `status: ok`; the dedicated dev process was then stopped cleanly with no residual Tutti process.

Automated pointer interaction with the minimized Dock could not be performed because macOS denied Accessibility access to `osascript`; this limitation is recorded rather than treating process readiness as a visual interaction pass.

The untouched `WorkbenchHost.render.test.tsx` suite continues to emit its existing React `act(...)` environment warnings while passing.

Advances #1907.
