### PR TITLE
feat(device-authority): add shared Go client

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -312,6 +312,7 @@ jobs:
             packages/agent/store-sqlite/canonical/go.mod
             packages/auth/bridge-go/go.mod
             packages/appcli/core/go.mod
+            packages/clients/device-authority-go/go.mod
             packages/events/stream-go/go.mod
             packages/workbench/service/go.mod
             packages/workspace/files/go.mod
@@ -362,6 +363,7 @@ jobs:
             packages/agent/runtimeprep/go.mod
             packages/agent/store-sqlite/canonical/go.mod
             packages/appcli/core/go.mod
+            packages/clients/device-authority-go/go.mod
             packages/workbench/service/go.mod
             packages/workspace/files/go.mod
             packages/workspace/issues/go.mod

--- a/docs/architecture/project-structure.md
+++ b/docs/architecture/project-structure.md
@@ -202,6 +202,19 @@ Client packages provide domain-specific access helpers for consumers.
 
 They should remain focused, named by responsibility, and free of hidden business rules.
 
+`packages/clients/device-authority-go` is the shared Go client boundary for the
+Device Authority owner lifecycle across Tutti and TSH. The initial package is a
+staged cross-repository extraction from TSH: publish the stable module first,
+then refactor TSH to the released version without changing behavior, then wire
+the same client into Tutti. This ordering is required because cross-repository
+consumers must not use workspace replacements or pseudo-versions. The package
+owns the control-plane wire contract, canonical Ed25519 enrollment and
+owner-token signing, bounded HTTP response semantics, and credential-binding
+validation. Product adapters still own base-URL and API-prefix selection,
+account/session/device headers, durable identity storage, Relay demand and lease
+scheduling, logging, and retry policy. The client must not infer
+local-versus-remote deployment policy or import Relay transport lifecycle code.
+
 ### `packages/device-link`
 
 DeviceLink is the shared Go peer-transport boundary for Tutti Desktop, TSH

--- a/docs/conventions/static-analysis.md
+++ b/docs/conventions/static-analysis.md
@@ -453,6 +453,7 @@ The current root entrypoint runs the linter from:
 - `packages/agent/host`
 - `packages/agent/store-sqlite/canonical`
 - `packages/appcli/core`
+- `packages/clients/device-authority-go`
 - `packages/device-link`
 - `packages/agent/runtimeprep`
 - `packages/workspace/files`
@@ -472,7 +473,8 @@ Changed-aware Go validation includes the nested
 `packages/agent/activity-replication`, `packages/agent/daemon`,
 `packages/agent/host`,
 `packages/agent/runtimeprep`, `packages/agent/store-sqlite`, and
-`packages/agent/store-sqlite/canonical`, and `packages/device-link` modules.
+`packages/agent/store-sqlite/canonical`, `packages/clients/device-authority-go`,
+and `packages/device-link` modules.
 Codex app-server protocol changes should also run
 `pnpm check:codexproto-generated` when schema, generator, or generated protocol
 files are touched.

--- a/go.work
+++ b/go.work
@@ -6,6 +6,8 @@ use ./services/tuttid
 
 use ./packages/events/stream-go
 
+use ./packages/clients/device-authority-go
+
 use ./packages/analytics/reporter-go
 
 use ./packages/device-link

--- a/packages/clients/device-authority-go/README.md
+++ b/packages/clients/device-authority-go/README.md
@@ -1,0 +1,83 @@
+# Device Authority Go Client
+
+`device-authority-go` is the narrow, shared Device Authority owner-lifecycle
+client boundary for Tutti and TSH. It prevents the security-sensitive
+enrollment and owner-token signing protocol from drifting between products.
+
+This initial extraction is a staged cross-repository bootstrap from TSH's
+production implementation. The stable module is published first; TSH then
+switches to the released module without behavior changes; Tutti consumes the
+same boundary next. Cross-repository consumers must not bridge that ordering
+with a workspace replacement or pseudo-version. Update this section when those
+consumer cutovers land so it continues to describe current integration state.
+
+The module owns:
+
+- Device Authority ensure, gateway identity enrollment, owner-tunnel token,
+  and lease-renewal HTTP wire contracts;
+- the canonical `tsh.gateway.owner-session.v1` Ed25519 signing payload;
+- response-to-request credential binding checks;
+- bounded response and HTTP error metadata handling;
+- a reusable process-local Ed25519 identity source compatible with TSH's
+  current behavior.
+
+The module does not own account cookies, bearer tokens, user/device/lane
+headers, endpoint selection, identity persistence policy, Relay demand,
+reconnection, lease scheduling, logging, or product retry decisions. Consumers
+inject those concerns through `Config` and `IdentitySource`. Relay byte-stream
+mechanics remain in `packages/device-link/relaytransport`.
+
+## Usage
+
+```go
+identities := deviceauthority.NewMemoryIdentitySource()
+client, err := deviceauthority.NewClient(deviceauthority.Config{
+    BaseURL:   controlPlaneBaseURL,
+    APIPrefix: controlPlaneAPIPrefix,
+    HTTPClient: productHTTPClient,
+    Identities: identities,
+    PrepareRequest: func(req *http.Request, metadata deviceauthority.RequestMetadata) error {
+        addCurrentProductHeaders(req, metadata.OwnerUserID)
+        return nil
+    },
+})
+```
+
+`APIPrefix` is required because choosing `/v1` versus a product gateway path is
+deployment policy. The shared client never guesses from the host name.
+
+`MemoryIdentitySource` retains one key per runtime only for the current process.
+It is intended for consumers preserving an existing process-local identity
+contract. A product that requires restart-stable identity must implement
+`IdentitySource` with its durable credential store and must return the same
+signing identity for enrollment retries and token issuance.
+
+The owner sequence is:
+
+```text
+product demand
+  -> EnsureDeviceAuthority
+  -> RegisterDeviceGatewayIdentity
+  -> IssueDeviceGatewayOwnerTunnelToken
+  -> product starts relaytransport.OwnerHost
+  -> RenewDeviceAuthorityLease on the product schedule
+  -> product releases Relay demand
+```
+
+Do not log private keys, tokens, enrollment proofs, signatures, raw response
+bodies, or request headers. `HTTPError.Body` exists for adapter-owned protocol
+handling and is bounded to 4096 bytes; ordinary logs should use status and
+categorical reasons instead. The ordinary `error` string contains only the HTTP
+status and never includes `Body`.
+
+## Validation and releases
+
+Run:
+
+```sh
+go test -race ./...
+```
+
+The module participates in Tutti's shared stable `packages/**` Go release
+cohort. Cross-repository consumers must use the released module tag and must not
+add a workspace replacement or pseudo-version.

--- a/packages/clients/device-authority-go/client.go
+++ b/packages/clients/device-authority-go/client.go
@@ -1,0 +1,432 @@
+package deviceauthority
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/ed25519"
+	cryptorand "crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	defaultHTTPTimeout           = 30 * time.Second
+	defaultOwnerTunnelTokenTTL   = 10 * time.Minute
+	maxOwnerTunnelTokenTTL       = 10 * time.Minute
+	maxHTTPResponseBodyBytes     = 1 << 20
+	deviceIdentityAlgorithm      = "ed25519"
+	ensureDeviceAuthorityPath    = "/device-authorities/ensure"
+	renewDeviceAuthorityPathFmt  = "/device-authorities/%s/lease/renew"
+	enrollGatewayIdentityPathFmt = "/gateway/device-authorities/%s/identity/enroll"
+	issueOwnerTunnelTokenPathFmt = "/gateway/device-authorities/%s/owner-tunnel-token"
+)
+
+// HTTPDoer is the narrow HTTP dependency used by Client.
+type HTTPDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// RequestMetadata lets a product adapter add its current account, device, or
+// lane headers without moving those policies into this package.
+type RequestMetadata struct {
+	OwnerUserID string
+}
+
+// PrepareRequestFunc adds product-owned authentication and device headers.
+// Implementations must not retain or mutate the request after returning.
+type PrepareRequestFunc func(req *http.Request, metadata RequestMetadata) error
+
+// Config supplies the deployment and product dependencies for a Client.
+type Config struct {
+	BaseURL        string
+	APIPrefix      string
+	HTTPClient     HTTPDoer
+	PrepareRequest PrepareRequestFunc
+	Identities     IdentitySource
+	Now            func() time.Time
+	Nonce          func() (string, error)
+}
+
+// Client executes the Device Authority owner lifecycle wire protocol.
+type Client struct {
+	baseURL        string
+	apiPrefix      string
+	httpClient     HTTPDoer
+	prepareRequest PrepareRequestFunc
+	identities     IdentitySource
+	now            func() time.Time
+	nonce          func() (string, error)
+}
+
+// NewClient validates cfg and constructs an immutable client.
+func NewClient(cfg Config) (*Client, error) {
+	baseURL, err := normalizeBaseURL(cfg.BaseURL)
+	if err != nil {
+		return nil, err
+	}
+	apiPrefix, err := normalizeAPIPrefix(cfg.APIPrefix)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.Identities == nil {
+		return nil, fmt.Errorf("device authority client requires identity source")
+	}
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: defaultHTTPTimeout}
+	}
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
+	nonce := cfg.Nonce
+	if nonce == nil {
+		nonce = randomNonce
+	}
+	return &Client{
+		baseURL:        baseURL,
+		apiPrefix:      apiPrefix,
+		httpClient:     httpClient,
+		prepareRequest: cfg.PrepareRequest,
+		identities:     cfg.Identities,
+		now:            now,
+		nonce:          nonce,
+	}, nil
+}
+
+// EnsureDeviceAuthority resolves or creates the authority for one owner and
+// runtime.
+func (c *Client) EnsureDeviceAuthority(ctx context.Context, req EnsureDeviceAuthorityRequest) (DeviceAuthorityResult, error) {
+	ownerUserID := strings.TrimSpace(req.OwnerUserID)
+	runtimeID := strings.TrimSpace(req.RuntimeID)
+	if ownerUserID == "" || runtimeID == "" {
+		return DeviceAuthorityResult{}, fmt.Errorf("ensure device authority requires owner user id and runtime id")
+	}
+	var raw ensureDeviceAuthorityWireResponse
+	if err := c.doJSON(ctx, http.MethodPost, ensureDeviceAuthorityPath, map[string]string{
+		"ownerUserId": ownerUserID,
+		"runtimeId":   runtimeID,
+	}, &raw, RequestMetadata{OwnerUserID: ownerUserID}); err != nil {
+		return DeviceAuthorityResult{}, err
+	}
+	authorityID := strings.TrimSpace(raw.AuthorityID)
+	if authorityID == "" {
+		return DeviceAuthorityResult{}, fmt.Errorf("ensure device authority response missing authorityId")
+	}
+	relay := raw.Relay.descriptor()
+	if relay.HostEndpoint == "" || relay.DialEndpoint == "" {
+		return DeviceAuthorityResult{}, fmt.Errorf("ensure device authority response missing relay endpoints")
+	}
+	return DeviceAuthorityResult{
+		AuthorityID: authorityID,
+		State:       strings.TrimSpace(raw.State),
+		OwnerUserID: ownerUserID,
+		RuntimeID:   runtimeID,
+		Relay:       relay,
+		Lease:       raw.Lease.policy(),
+		GatewayEnrollment: GatewayEnrollment{
+			Proof:     strings.TrimSpace(raw.GatewayEnrollment.Proof),
+			ExpiresAt: strings.TrimSpace(raw.GatewayEnrollment.ExpiresAt),
+		},
+	}, nil
+}
+
+// RegisterDeviceGatewayIdentity enrolls the runtime identity selected by the
+// configured IdentitySource.
+func (c *Client) RegisterDeviceGatewayIdentity(ctx context.Context, req RegisterDeviceGatewayIdentityRequest) (DeviceGatewayIdentityResult, error) {
+	authorityID := strings.TrimSpace(req.AuthorityID)
+	runtimeID := strings.TrimSpace(req.RuntimeID)
+	proof := strings.TrimSpace(req.EnrollmentProof)
+	if authorityID == "" || runtimeID == "" || proof == "" {
+		return DeviceGatewayIdentityResult{}, fmt.Errorf("register device gateway identity requires authority id, runtime id, and enrollment proof")
+	}
+	identity, publicKey, err := c.identity(ctx, runtimeID)
+	if err != nil {
+		return DeviceGatewayIdentityResult{}, err
+	}
+	path := fmt.Sprintf(enrollGatewayIdentityPathFmt, url.PathEscape(authorityID))
+	var raw enrollDeviceGatewayIdentityWireResponse
+	if err := c.doJSON(ctx, http.MethodPost, path, map[string]any{
+		"authorityId":     authorityID,
+		"runtimeId":       runtimeID,
+		"enrollmentProof": proof,
+		"keyId":           strings.TrimSpace(identity.KeyID),
+		"algorithm":       deviceIdentityAlgorithm,
+		"publicKey":       base64.RawURLEncoding.EncodeToString(publicKey),
+	}, &raw, RequestMetadata{}); err != nil {
+		return DeviceGatewayIdentityResult{}, err
+	}
+	keyID := firstNonEmpty(raw.Identity.KeyID, identity.KeyID)
+	if keyID != strings.TrimSpace(identity.KeyID) {
+		return DeviceGatewayIdentityResult{}, fmt.Errorf("register device gateway identity response key id %q does not match local key %q", keyID, identity.KeyID)
+	}
+	responseAuthorityID := firstNonEmpty(raw.Identity.AuthorityID, authorityID)
+	if responseAuthorityID != authorityID {
+		return DeviceGatewayIdentityResult{}, fmt.Errorf("register device gateway identity response authority id %q does not match request %q", responseAuthorityID, authorityID)
+	}
+	return DeviceGatewayIdentityResult{
+		AuthorityID: responseAuthorityID,
+		RuntimeID:   runtimeID,
+		IdentityID:  strings.TrimSpace(raw.Identity.IdentityID),
+		KeyID:       keyID,
+	}, nil
+}
+
+// IssueDeviceGatewayOwnerTunnelToken signs and requests a Relay owner-tunnel
+// token bound to the runtime's enrolled gateway identity.
+func (c *Client) IssueDeviceGatewayOwnerTunnelToken(ctx context.Context, req IssueDeviceGatewayOwnerTunnelTokenRequest) (DeviceGatewayOwnerTunnelTokenResult, error) {
+	authorityID := strings.TrimSpace(req.AuthorityID)
+	runtimeID := strings.TrimSpace(req.RuntimeID)
+	if authorityID == "" || runtimeID == "" {
+		return DeviceGatewayOwnerTunnelTokenResult{}, fmt.Errorf("issue device gateway owner tunnel token requires authority id and runtime id")
+	}
+	identity, _, err := c.identity(ctx, runtimeID)
+	if err != nil {
+		return DeviceGatewayOwnerTunnelTokenResult{}, err
+	}
+	ttlSeconds, err := ownerTunnelTTLSeconds(req.TTL)
+	if err != nil {
+		return DeviceGatewayOwnerTunnelTokenResult{}, err
+	}
+	nonce, err := c.nonce()
+	if err != nil {
+		return DeviceGatewayOwnerTunnelTokenResult{}, fmt.Errorf("generate device gateway owner tunnel token nonce: %w", err)
+	}
+	nonce = strings.TrimSpace(nonce)
+	if nonce == "" {
+		return DeviceGatewayOwnerTunnelTokenResult{}, fmt.Errorf("generate device gateway owner tunnel token nonce: empty value")
+	}
+	now := c.now()
+	if now.IsZero() {
+		return DeviceGatewayOwnerTunnelTokenResult{}, fmt.Errorf("issue device gateway owner tunnel token requires a non-zero clock value")
+	}
+	timestamp := now.UTC().Format(time.RFC3339Nano)
+	targets := append([]string(nil), req.SupportedTargets...)
+	payload, err := gatewayOwnerSessionSigningPayload(authorityID, runtimeID, identity.KeyID, nonce, timestamp, ttlSeconds, targets)
+	if err != nil {
+		return DeviceGatewayOwnerTunnelTokenResult{}, err
+	}
+	signature, err := identity.Signer.Sign(cryptorand.Reader, []byte(payload), crypto.Hash(0))
+	if err != nil {
+		return DeviceGatewayOwnerTunnelTokenResult{}, fmt.Errorf("sign device gateway owner tunnel token: %w", err)
+	}
+	if len(signature) != ed25519.SignatureSize {
+		return DeviceGatewayOwnerTunnelTokenResult{}, fmt.Errorf("sign device gateway owner tunnel token: invalid Ed25519 signature length")
+	}
+	path := fmt.Sprintf(issueOwnerTunnelTokenPathFmt, url.PathEscape(authorityID))
+	var raw issueOwnerTunnelTokenWireResponse
+	if err := c.doJSON(ctx, http.MethodPost, path, map[string]any{
+		"authorityId":      authorityID,
+		"runtimeId":        runtimeID,
+		"keyId":            strings.TrimSpace(identity.KeyID),
+		"nonce":            nonce,
+		"timestamp":        timestamp,
+		"signature":        base64.RawURLEncoding.EncodeToString(signature),
+		"supportedTargets": targets,
+		"ttlSeconds":       ttlSeconds,
+	}, &raw, RequestMetadata{}); err != nil {
+		return DeviceGatewayOwnerTunnelTokenResult{}, err
+	}
+	token := raw.OwnerTunnelToken
+	if strings.TrimSpace(token.Token) == "" {
+		return DeviceGatewayOwnerTunnelTokenResult{}, fmt.Errorf("issue device gateway owner tunnel token response missing token")
+	}
+	responseAuthorityID := firstNonEmpty(raw.AuthorityID, authorityID)
+	if responseAuthorityID != authorityID {
+		return DeviceGatewayOwnerTunnelTokenResult{}, fmt.Errorf("issue device gateway owner tunnel token response authority id %q does not match request %q", responseAuthorityID, authorityID)
+	}
+	identityID := strings.TrimSpace(raw.GatewayIdentityID)
+	if identityID == "" {
+		return DeviceGatewayOwnerTunnelTokenResult{}, fmt.Errorf("issue device gateway owner tunnel token response missing gateway identity id")
+	}
+	if identityID != strings.TrimSpace(identity.KeyID) {
+		return DeviceGatewayOwnerTunnelTokenResult{}, fmt.Errorf("issue device gateway owner tunnel token response gateway identity id %q does not match local key %q", identityID, identity.KeyID)
+	}
+	return DeviceGatewayOwnerTunnelTokenResult{
+		AuthorityID: responseAuthorityID,
+		State:       strings.TrimSpace(raw.State),
+		Token: Token{
+			Value:     strings.TrimSpace(token.Token),
+			ExpiresAt: strings.TrimSpace(token.ExpiresAt),
+		},
+		Relay:      raw.Relay.descriptor(),
+		Lease:      raw.Lease.policy(),
+		IdentityID: identityID,
+	}, nil
+}
+
+// RenewDeviceAuthorityLease reports the product-owned VM and owner-tunnel
+// status while extending the authority lease.
+func (c *Client) RenewDeviceAuthorityLease(ctx context.Context, req RenewDeviceAuthorityLeaseRequest) (RenewDeviceAuthorityLeaseResult, error) {
+	authorityID := strings.TrimSpace(req.AuthorityID)
+	ownerUserID := strings.TrimSpace(req.OwnerUserID)
+	runtimeID := strings.TrimSpace(req.RuntimeID)
+	if authorityID == "" || ownerUserID == "" || runtimeID == "" {
+		return RenewDeviceAuthorityLeaseResult{}, fmt.Errorf("renew device authority lease requires authority id, owner user id, and runtime id")
+	}
+	path := fmt.Sprintf(renewDeviceAuthorityPathFmt, url.PathEscape(authorityID))
+	var raw renewLeaseWireResponse
+	if err := c.doJSON(ctx, http.MethodPost, path, map[string]any{
+		"authorityId":       authorityID,
+		"ownerUserId":       ownerUserID,
+		"runtimeId":         runtimeID,
+		"ttlSeconds":        req.TTLSeconds,
+		"vmStatus":          strings.TrimSpace(req.VMStatus),
+		"ownerTunnelStatus": strings.TrimSpace(req.OwnerTunnelStatus),
+	}, &raw, RequestMetadata{OwnerUserID: ownerUserID}); err != nil {
+		return RenewDeviceAuthorityLeaseResult{}, err
+	}
+	responseAuthorityID := strings.TrimSpace(raw.AuthorityID)
+	if responseAuthorityID != "" && responseAuthorityID != authorityID {
+		return RenewDeviceAuthorityLeaseResult{}, fmt.Errorf("renew device authority lease response authority id %q does not match request %q", responseAuthorityID, authorityID)
+	}
+	return RenewDeviceAuthorityLeaseResult{
+		AuthorityID: responseAuthorityID,
+		State:       strings.TrimSpace(raw.State),
+		RenewedAt:   strings.TrimSpace(raw.RenewedAt),
+		ExpiresAt:   strings.TrimSpace(raw.ExpiresAt),
+	}, nil
+}
+
+func (c *Client) identity(ctx context.Context, runtimeID string) (SigningIdentity, []byte, error) {
+	if err := contextError(ctx); err != nil {
+		return SigningIdentity{}, nil, err
+	}
+	identity, err := c.identities.Identity(ctx, runtimeID)
+	if err != nil {
+		return SigningIdentity{}, nil, fmt.Errorf("resolve device gateway identity: %w", err)
+	}
+	publicKey, err := validateSigningIdentity(identity)
+	if err != nil {
+		return SigningIdentity{}, nil, err
+	}
+	identity.KeyID = strings.TrimSpace(identity.KeyID)
+	return identity, publicKey, nil
+}
+
+func (c *Client) doJSON(ctx context.Context, method, path string, requestBody, responseBody any, metadata RequestMetadata) error {
+	if err := contextError(ctx); err != nil {
+		return err
+	}
+	rawRequest, err := json.Marshal(requestBody)
+	if err != nil {
+		return fmt.Errorf("marshal device authority request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.endpoint(path), bytes.NewReader(rawRequest))
+	if err != nil {
+		return fmt.Errorf("create device authority request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	if c.prepareRequest != nil {
+		if err := c.prepareRequest(req, metadata); err != nil {
+			return fmt.Errorf("prepare device authority request: %w", err)
+		}
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("device authority request failed: %w", err)
+	}
+	if resp == nil || resp.Body == nil {
+		return fmt.Errorf("device authority request failed: HTTP client returned an empty response")
+	}
+	defer func() { _ = resp.Body.Close() }()
+	responseLimit := int64(maxHTTPResponseBodyBytes + 1)
+	if resp.StatusCode >= http.StatusMultipleChoices {
+		responseLimit = int64(maxHTTPErrorBodyBytes + 1)
+	}
+	rawResponse, err := io.ReadAll(io.LimitReader(resp.Body, responseLimit))
+	if err != nil {
+		return fmt.Errorf("read device authority response: %w", err)
+	}
+	if resp.StatusCode >= http.StatusMultipleChoices {
+		return newHTTPError(resp.StatusCode, rawResponse, resp.Header.Get("Retry-After"))
+	}
+	if len(rawResponse) > maxHTTPResponseBodyBytes {
+		return fmt.Errorf("device authority response exceeds %d bytes", maxHTTPResponseBodyBytes)
+	}
+	if responseBody == nil || len(bytes.TrimSpace(rawResponse)) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(rawResponse, responseBody); err != nil {
+		return fmt.Errorf("parse device authority response: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) endpoint(path string) string {
+	return c.baseURL + c.apiPrefix + path
+}
+
+func ownerTunnelTTLSeconds(ttl time.Duration) (int, error) {
+	if ttl <= 0 {
+		ttl = defaultOwnerTunnelTokenTTL
+	}
+	seconds := int64(ttl / time.Second)
+	if seconds <= 0 {
+		seconds = int64(defaultOwnerTunnelTokenTTL / time.Second)
+	}
+	if seconds > int64(maxOwnerTunnelTokenTTL/time.Second) {
+		return 0, fmt.Errorf("device gateway owner tunnel token ttl exceeds 10 minute protocol maximum")
+	}
+	return int(seconds), nil
+}
+
+func normalizeBaseURL(value string) (string, error) {
+	value = strings.TrimRight(strings.TrimSpace(value), "/")
+	if value == "" {
+		return "", fmt.Errorf("device authority client requires base URL")
+	}
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return "", fmt.Errorf("parse device authority base URL: %w", err)
+	}
+	if (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
+		return "", fmt.Errorf("device authority base URL must use http or https with a host")
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", fmt.Errorf("device authority base URL must not contain user info, query, or fragment")
+	}
+	return value, nil
+}
+
+func normalizeAPIPrefix(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("device authority client requires API prefix")
+	}
+	if !strings.HasPrefix(value, "/") {
+		value = "/" + value
+	}
+	value = strings.TrimRight(value, "/")
+	if value == "" || strings.Contains(value, "?") || strings.Contains(value, "#") {
+		return "", fmt.Errorf("device authority API prefix must be an absolute URL path")
+	}
+	return value, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func contextError(ctx context.Context) error {
+	if ctx == nil {
+		return fmt.Errorf("device authority request requires context")
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("device authority request context: %w", err)
+	}
+	return nil
+}

--- a/packages/clients/device-authority-go/client_integration_test.go
+++ b/packages/clients/device-authority-go/client_integration_test.go
@@ -1,0 +1,357 @@
+package deviceauthority
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestClientDeviceAuthorityOwnerLifecycle(t *testing.T) {
+	t.Parallel()
+
+	fixedTime := time.Date(2026, time.August, 2, 9, 10, 11, 123, time.UTC)
+	privateKey := ed25519.NewKeyFromSeed(bytesOf(7, ed25519.SeedSize))
+	publicKey := privateKey.Public().(ed25519.PublicKey)
+	keyID := GatewayIdentityKeyID(publicKey)
+	identitySource := staticIdentitySource{identity: SigningIdentity{KeyID: keyID, Signer: privateKey}}
+	seen := make(map[string]bool)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", got)
+		}
+		if got := r.Header.Get("Accept"); got != "application/json" {
+			t.Errorf("Accept = %q, want application/json", got)
+		}
+		if got := r.Header.Get("X-Product-Auth"); got != "current-account" {
+			t.Errorf("X-Product-Auth = %q, want current-account", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/control/v1/device-authorities/ensure":
+			seen["ensure"] = true
+			if got := r.Header.Get("X-Owner-User-ID"); got != "owner-1" {
+				t.Errorf("ensure X-Owner-User-ID = %q, want owner-1", got)
+			}
+			var body struct {
+				OwnerUserID string `json:"ownerUserId"`
+				RuntimeID   string `json:"runtimeId"`
+			}
+			decodeJSONRequest(t, r, &body)
+			if body.OwnerUserID != "owner-1" || body.RuntimeID != "runtime-1" {
+				t.Errorf("ensure body = %+v", body)
+			}
+			writeJSONResponse(t, w, map[string]any{
+				"authorityId": "deva_123",
+				"state":       "online",
+				"relay": map[string]any{
+					"hostEndpoint": "wss://relay.example/host",
+					"dialEndpoint": "wss://relay.example/dial",
+					"relayNodeId":  "relay-1",
+				},
+				"lease": map[string]any{"ttlSeconds": 120, "renewIntervalSeconds": 30},
+				"gatewayEnrollment": map[string]any{
+					"proof":     "proof-1",
+					"expiresAt": "2026-08-02T09:11:11Z",
+				},
+			})
+		case "/control/v1/gateway/device-authorities/deva_123/identity/enroll":
+			seen["enroll"] = true
+			if got := r.Header.Get("X-Owner-User-ID"); got != "" {
+				t.Errorf("enroll X-Owner-User-ID = %q, want empty", got)
+			}
+			var body struct {
+				AuthorityID     string `json:"authorityId"`
+				RuntimeID       string `json:"runtimeId"`
+				EnrollmentProof string `json:"enrollmentProof"`
+				KeyID           string `json:"keyId"`
+				Algorithm       string `json:"algorithm"`
+				PublicKey       string `json:"publicKey"`
+			}
+			decodeJSONRequest(t, r, &body)
+			decodedPublicKey, err := base64.RawURLEncoding.DecodeString(body.PublicKey)
+			if err != nil {
+				t.Errorf("decode enrollment public key: %v", err)
+			}
+			if body.AuthorityID != "deva_123" || body.RuntimeID != "runtime-1" ||
+				body.EnrollmentProof != "proof-1" || body.KeyID != keyID ||
+				body.Algorithm != "ed25519" || !reflect.DeepEqual(decodedPublicKey, []byte(publicKey)) {
+				t.Errorf("enrollment body = %+v", body)
+			}
+			writeJSONResponse(t, w, map[string]any{
+				"identity": map[string]any{
+					"authorityId": "deva_123",
+					"identityId":  "identity-1",
+					"keyId":       keyID,
+				},
+			})
+		case "/control/v1/gateway/device-authorities/deva_123/owner-tunnel-token":
+			seen["issue"] = true
+			var body struct {
+				AuthorityID      string   `json:"authorityId"`
+				RuntimeID        string   `json:"runtimeId"`
+				KeyID            string   `json:"keyId"`
+				Nonce            string   `json:"nonce"`
+				Timestamp        string   `json:"timestamp"`
+				Signature        string   `json:"signature"`
+				SupportedTargets []string `json:"supportedTargets"`
+				TTLSeconds       int      `json:"ttlSeconds"`
+			}
+			decodeJSONRequest(t, r, &body)
+			// Build the verifier-side fixture independently from the client
+			// helper so a simultaneous bug in signing and test setup cannot pass.
+			payload := strings.Join([]string{
+				"tsh.gateway.owner-session.v1",
+				"authority_id=" + body.AuthorityID,
+				"runtime_id=" + body.RuntimeID,
+				"key_id=" + body.KeyID,
+				"nonce=" + body.Nonce,
+				"timestamp=" + body.Timestamp,
+				"ttl_seconds=600",
+				"supported_targets=device-gateway",
+			}, "\n")
+			signature, err := base64.RawURLEncoding.DecodeString(body.Signature)
+			if err != nil || !ed25519.Verify(publicKey, []byte(payload), signature) {
+				t.Errorf("owner token signature is invalid: decode error = %v", err)
+			}
+			if body.Nonce != "fixed-nonce" || body.Timestamp != fixedTime.Format(time.RFC3339Nano) ||
+				body.TTLSeconds != 600 || !reflect.DeepEqual(body.SupportedTargets, []string{" DEVICE-GATEWAY ", "device-gateway"}) {
+				t.Errorf("owner token body = %+v", body)
+			}
+			writeJSONResponse(t, w, map[string]any{
+				"authorityId": "deva_123",
+				"state":       "online",
+				"ownerTunnelToken": map[string]any{
+					"token":     "owner-token",
+					"expiresAt": "2026-08-02T09:20:11Z",
+				},
+				"relay": map[string]any{
+					"hostEndpoint": "wss://relay.example/host",
+					"dialEndpoint": "wss://relay.example/dial",
+					"relayNodeId":  "relay-1",
+				},
+				"lease":             map[string]any{"ttlSeconds": 120, "renewIntervalSeconds": 30},
+				"gatewayIdentityId": keyID,
+			})
+		case "/control/v1/device-authorities/deva_123/lease/renew":
+			seen["renew"] = true
+			if got := r.Header.Get("X-Owner-User-ID"); got != "owner-1" {
+				t.Errorf("renew X-Owner-User-ID = %q, want owner-1", got)
+			}
+			var body struct {
+				AuthorityID       string `json:"authorityId"`
+				OwnerUserID       string `json:"ownerUserId"`
+				RuntimeID         string `json:"runtimeId"`
+				TTLSeconds        int    `json:"ttlSeconds"`
+				VMStatus          string `json:"vmStatus"`
+				OwnerTunnelStatus string `json:"ownerTunnelStatus"`
+			}
+			decodeJSONRequest(t, r, &body)
+			if body.AuthorityID != "deva_123" || body.OwnerUserID != "owner-1" ||
+				body.RuntimeID != "runtime-1" || body.TTLSeconds != 120 ||
+				body.VMStatus != "ready" || body.OwnerTunnelStatus != "connected" {
+				t.Errorf("renew body = %+v", body)
+			}
+			writeJSONResponse(t, w, map[string]any{
+				"authorityId": "deva_123",
+				"state":       "online",
+				"renewedAt":   "2026-08-02T09:12:11Z",
+				"expiresAt":   "2026-08-02T09:14:11Z",
+			})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.String())
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Config{
+		BaseURL:    server.URL + "/control/",
+		APIPrefix:  "v1/",
+		HTTPClient: server.Client(),
+		PrepareRequest: func(req *http.Request, metadata RequestMetadata) error {
+			req.Header.Set("X-Product-Auth", "current-account")
+			if metadata.OwnerUserID != "" {
+				req.Header.Set("X-Owner-User-ID", metadata.OwnerUserID)
+			}
+			return nil
+		},
+		Identities: identitySource,
+		Now:        func() time.Time { return fixedTime },
+		Nonce:      func() (string, error) { return "fixed-nonce", nil },
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	authority, err := client.EnsureDeviceAuthority(context.Background(), EnsureDeviceAuthorityRequest{
+		OwnerUserID: " owner-1 ",
+		RuntimeID:   " runtime-1 ",
+	})
+	if err != nil {
+		t.Fatalf("EnsureDeviceAuthority() error = %v", err)
+	}
+	if authority.AuthorityID != "deva_123" || authority.Relay.RelayNodeID != "relay-1" ||
+		authority.Lease.RenewIntervalSeconds != 30 || authority.GatewayEnrollment.Proof != "proof-1" {
+		t.Fatalf("authority = %+v", authority)
+	}
+
+	identity, err := client.RegisterDeviceGatewayIdentity(context.Background(), RegisterDeviceGatewayIdentityRequest{
+		AuthorityID:     authority.AuthorityID,
+		RuntimeID:       authority.RuntimeID,
+		EnrollmentProof: authority.GatewayEnrollment.Proof,
+	})
+	if err != nil {
+		t.Fatalf("RegisterDeviceGatewayIdentity() error = %v", err)
+	}
+	if identity.KeyID != keyID || identity.IdentityID != "identity-1" {
+		t.Fatalf("identity = %+v", identity)
+	}
+
+	token, err := client.IssueDeviceGatewayOwnerTunnelToken(context.Background(), IssueDeviceGatewayOwnerTunnelTokenRequest{
+		AuthorityID:      authority.AuthorityID,
+		RuntimeID:        authority.RuntimeID,
+		SupportedTargets: []string{" DEVICE-GATEWAY ", "device-gateway"},
+	})
+	if err != nil {
+		t.Fatalf("IssueDeviceGatewayOwnerTunnelToken() error = %v", err)
+	}
+	if token.Token.Value != "owner-token" || token.IdentityID != identity.KeyID || token.Relay.HostEndpoint == "" {
+		t.Fatalf("token = %+v", token)
+	}
+
+	renewed, err := client.RenewDeviceAuthorityLease(context.Background(), RenewDeviceAuthorityLeaseRequest{
+		AuthorityID:       authority.AuthorityID,
+		OwnerUserID:       authority.OwnerUserID,
+		RuntimeID:         authority.RuntimeID,
+		TTLSeconds:        authority.Lease.TTLSeconds,
+		OwnerTunnelStatus: " connected ",
+		VMStatus:          " ready ",
+	})
+	if err != nil {
+		t.Fatalf("RenewDeviceAuthorityLease() error = %v", err)
+	}
+	if renewed.AuthorityID != authority.AuthorityID || renewed.State != "online" {
+		t.Fatalf("renewed = %+v", renewed)
+	}
+
+	for _, operation := range []string{"ensure", "enroll", "issue", "renew"} {
+		if !seen[operation] {
+			t.Errorf("did not observe %s request", operation)
+		}
+	}
+}
+
+func TestClientEnrollmentRetryReusesIdentityAfterLostResponse(t *testing.T) {
+	t.Parallel()
+
+	var keyIDs []string
+	var publicKeys []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			AuthorityID     string `json:"authorityId"`
+			RuntimeID       string `json:"runtimeId"`
+			EnrollmentProof string `json:"enrollmentProof"`
+			KeyID           string `json:"keyId"`
+			Algorithm       string `json:"algorithm"`
+			PublicKey       string `json:"publicKey"`
+		}
+		decodeJSONRequest(t, r, &body)
+		if body.AuthorityID != "deva_123" || body.RuntimeID != "runtime-1" || body.Algorithm != "ed25519" {
+			t.Errorf("enrollment retry body = %+v", body)
+		}
+		keyIDs = append(keyIDs, body.KeyID)
+		publicKeys = append(publicKeys, body.PublicKey)
+		if len(keyIDs) == 1 {
+			hijacker, ok := w.(http.Hijacker)
+			if !ok {
+				t.Error("test server does not support connection hijacking")
+				return
+			}
+			conn, _, err := hijacker.Hijack()
+			if err != nil {
+				t.Errorf("hijack first enrollment response: %v", err)
+				return
+			}
+			_ = conn.Close()
+			return
+		}
+		writeJSONResponse(t, w, map[string]any{
+			"identity": map[string]any{
+				"authorityId": "deva_123",
+				"keyId":       body.KeyID,
+			},
+		})
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Config{
+		BaseURL:    server.URL,
+		APIPrefix:  "/v1",
+		HTTPClient: server.Client(),
+		Identities: NewMemoryIdentitySource(),
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	firstRequest := RegisterDeviceGatewayIdentityRequest{
+		AuthorityID:     "deva_123",
+		RuntimeID:       "runtime-1",
+		EnrollmentProof: "proof-consumed-with-lost-response",
+	}
+	if _, err := client.RegisterDeviceGatewayIdentity(context.Background(), firstRequest); err == nil {
+		t.Fatal("first RegisterDeviceGatewayIdentity() error = nil, want ambiguous response loss")
+	}
+	secondRequest := firstRequest
+	secondRequest.EnrollmentProof = "fresh-proof"
+	if _, err := client.RegisterDeviceGatewayIdentity(context.Background(), secondRequest); err != nil {
+		t.Fatalf("second RegisterDeviceGatewayIdentity() error = %v", err)
+	}
+	if len(keyIDs) != 2 || keyIDs[0] == "" || keyIDs[0] != keyIDs[1] {
+		t.Fatalf("enrollment key ids = %v, want same non-empty key", keyIDs)
+	}
+	if len(publicKeys) != 2 || publicKeys[0] == "" || publicKeys[0] != publicKeys[1] {
+		t.Fatalf("enrollment public keys differ across retry")
+	}
+}
+
+func decodeJSONRequest(t *testing.T, r *http.Request, target any) {
+	t.Helper()
+	if r.Method != http.MethodPost {
+		t.Errorf("method = %s, want POST", r.Method)
+	}
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		t.Errorf("decode request: %v", err)
+	}
+}
+
+func writeJSONResponse(t *testing.T, w http.ResponseWriter, body any) {
+	t.Helper()
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		t.Errorf("encode response: %v", err)
+	}
+}
+
+func bytesOf(value byte, count int) []byte {
+	return bytes.Repeat([]byte{value}, count)
+}
+
+type staticIdentitySource struct {
+	identity SigningIdentity
+	err      error
+}
+
+func (s staticIdentitySource) Identity(context.Context, string) (SigningIdentity, error) {
+	return s.identity, s.err
+}

--- a/packages/clients/device-authority-go/client_validation_test.go
+++ b/packages/clients/device-authority-go/client_validation_test.go
@@ -1,0 +1,391 @@
+package deviceauthority
+
+import (
+	"context"
+	"crypto"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestNewClientValidatesEndpointAndDependencies(t *testing.T) {
+	t.Parallel()
+
+	identitySource := testIdentitySource(t)
+	tests := []struct {
+		name string
+		cfg  Config
+	}{
+		{name: "missing base URL", cfg: Config{APIPrefix: "/v1", Identities: identitySource}},
+		{name: "unsupported scheme", cfg: Config{BaseURL: "file:///tmp/socket", APIPrefix: "/v1", Identities: identitySource}},
+		{name: "missing host", cfg: Config{BaseURL: "https:///v1", APIPrefix: "/v1", Identities: identitySource}},
+		{name: "URL credentials", cfg: Config{BaseURL: "https://user:secret@example.test", APIPrefix: "/v1", Identities: identitySource}},
+		{name: "URL query", cfg: Config{BaseURL: "https://example.test?lane=ppe", APIPrefix: "/v1", Identities: identitySource}},
+		{name: "URL fragment", cfg: Config{BaseURL: "https://example.test#fragment", APIPrefix: "/v1", Identities: identitySource}},
+		{name: "missing API prefix", cfg: Config{BaseURL: "https://example.test", Identities: identitySource}},
+		{name: "root API prefix", cfg: Config{BaseURL: "https://example.test", APIPrefix: "/", Identities: identitySource}},
+		{name: "API prefix query", cfg: Config{BaseURL: "https://example.test", APIPrefix: "/v1?lane=ppe", Identities: identitySource}},
+		{name: "missing identity source", cfg: Config{BaseURL: "https://example.test", APIPrefix: "/v1"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := NewClient(tt.cfg); err == nil {
+				t.Fatal("NewClient() error = nil")
+			}
+		})
+	}
+
+	client, err := NewClient(Config{
+		BaseURL:    " https://example.test/base/ ",
+		APIPrefix:  " desktop/v1/ ",
+		Identities: identitySource,
+	})
+	if err != nil {
+		t.Fatalf("NewClient(valid config) error = %v", err)
+	}
+	if got := client.endpoint("/resource"); got != "https://example.test/base/desktop/v1/resource" {
+		t.Fatalf("endpoint = %q", got)
+	}
+	defaultClient, ok := client.httpClient.(*http.Client)
+	if !ok || defaultClient.Timeout != defaultHTTPTimeout {
+		t.Fatalf("default HTTP client = %#v, want timeout %s", client.httpClient, defaultHTTPTimeout)
+	}
+}
+
+func TestClientHTTPErrorIsBoundedAndPreservesRetryMetadata(t *testing.T) {
+	t.Parallel()
+
+	client := mustClientWithDoer(t, httpDoerFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Header:     http.Header{"Retry-After": []string{" 17 "}},
+			Body:       io.NopCloser(strings.NewReader(strings.Repeat("x", maxHTTPResponseBodyBytes+100))),
+		}, nil
+	}))
+
+	err := client.doJSON(context.Background(), http.MethodPost, "/test", map[string]string{"ok": "yes"}, nil, RequestMetadata{})
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("error = %T %v, want *HTTPError", err, err)
+	}
+	if httpErr.StatusCode != http.StatusServiceUnavailable || httpErr.HTTPStatusCode() != http.StatusServiceUnavailable ||
+		httpErr.RetryAfter != "17" || httpErr.HTTPRetryAfter() != "17" || len(httpErr.Body) != maxHTTPErrorBodyBytes {
+		t.Fatalf("HTTPError = %+v, body length = %d", httpErr, len(httpErr.Body))
+	}
+	if httpErr.Error() != "control-plane request failed (503)" {
+		t.Fatalf("HTTPError.Error() = %q", httpErr.Error())
+	}
+	if strings.Contains(httpErr.Error(), httpErr.Body) {
+		t.Fatal("HTTPError.Error() exposes the upstream response body")
+	}
+}
+
+func TestClientRejectsOversizedOrMalformedSuccessfulResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "oversized", body: strings.Repeat("x", maxHTTPResponseBodyBytes+1)},
+		{name: "malformed JSON", body: "{"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := mustClientWithDoer(t, httpDoerFunc(func(*http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader(tt.body)),
+				}, nil
+			}))
+			var response map[string]any
+			if err := client.doJSON(context.Background(), http.MethodPost, "/test", map[string]string{}, &response, RequestMetadata{}); err == nil {
+				t.Fatal("doJSON() error = nil")
+			}
+		})
+	}
+}
+
+func TestClientStopsBeforeTransportForCanceledContextOrHeaderFailure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		context func() context.Context
+		prepare PrepareRequestFunc
+	}{
+		{
+			name: "canceled context",
+			context: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+		},
+		{
+			name:    "product header failure",
+			context: context.Background,
+			prepare: func(*http.Request, RequestMetadata) error { return errors.New("account unavailable") },
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls atomic.Int32
+			client, err := NewClient(Config{
+				BaseURL:   "https://example.test",
+				APIPrefix: "/v1",
+				HTTPClient: httpDoerFunc(func(*http.Request) (*http.Response, error) {
+					calls.Add(1)
+					return nil, errors.New("unexpected transport call")
+				}),
+				PrepareRequest: tt.prepare,
+				Identities:     testIdentitySource(t),
+			})
+			if err != nil {
+				t.Fatalf("NewClient() error = %v", err)
+			}
+			if err := client.doJSON(tt.context(), http.MethodPost, "/test", map[string]string{}, nil, RequestMetadata{}); err == nil {
+				t.Fatal("doJSON() error = nil")
+			}
+			if calls.Load() != 0 {
+				t.Fatalf("transport calls = %d, want 0", calls.Load())
+			}
+		})
+	}
+}
+
+func TestClientRejectsEmptyHTTPResponse(t *testing.T) {
+	t.Parallel()
+
+	client := mustClientWithDoer(t, httpDoerFunc(func(*http.Request) (*http.Response, error) {
+		return nil, nil
+	}))
+	if err := client.doJSON(context.Background(), http.MethodPost, "/test", map[string]string{}, nil, RequestMetadata{}); err == nil {
+		t.Fatal("doJSON() error = nil")
+	}
+}
+
+func TestClientRejectsCredentialBindingMismatches(t *testing.T) {
+	t.Parallel()
+
+	identitySource := testIdentitySource(t)
+	keyID := identitySource.identity.KeyID
+	tests := []struct {
+		name     string
+		response func(request map[string]any) string
+		call     func(context.Context, *Client) error
+	}{
+		{
+			name: "enrollment key id",
+			response: func(map[string]any) string {
+				return `{"identity":{"authorityId":"deva_123","keyId":"unexpected-key"}}`
+			},
+			call: enrollTestCall,
+		},
+		{
+			name: "enrollment authority id",
+			response: func(map[string]any) string {
+				return fmt.Sprintf(`{"identity":{"authorityId":"deva_other","keyId":%q}}`, keyID)
+			},
+			call: enrollTestCall,
+		},
+		{
+			name: "owner token key id",
+			response: func(map[string]any) string {
+				return `{"authorityId":"deva_123","ownerTunnelToken":{"token":"token"},"gatewayIdentityId":"unexpected-key"}`
+			},
+			call: issueTestCall,
+		},
+		{
+			name: "owner token authority id",
+			response: func(map[string]any) string {
+				return fmt.Sprintf(`{"authorityId":"deva_other","ownerTunnelToken":{"token":"token"},"gatewayIdentityId":%q}`, keyID)
+			},
+			call: issueTestCall,
+		},
+		{
+			name: "renewed authority id",
+			response: func(map[string]any) string {
+				return `{"authorityId":"deva_other","state":"online"}`
+			},
+			call: renewTestCall,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := mustClientWithIdentityAndDoer(t, identitySource, httpDoerFunc(func(req *http.Request) (*http.Response, error) {
+				var request map[string]any
+				if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+					return nil, err
+				}
+				return jsonHTTPResponse(http.StatusOK, tt.response(request)), nil
+			}))
+			if err := tt.call(context.Background(), client); err == nil {
+				t.Fatal("call error = nil, want binding mismatch")
+			}
+		})
+	}
+}
+
+func TestClientPropagatesIdentityAndSigningFailuresWithoutHTTP(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	doer := httpDoerFunc(func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return nil, errors.New("unexpected transport call")
+	})
+	client := mustClientWithIdentityAndDoer(t, staticIdentitySource{err: errors.New("keychain locked")}, doer)
+	if err := enrollTestCall(context.Background(), client); err == nil || !strings.Contains(err.Error(), "keychain locked") {
+		t.Fatalf("enrollment error = %v", err)
+	}
+
+	publicKey, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	client = mustClientWithIdentityAndDoer(t, staticIdentitySource{identity: SigningIdentity{
+		KeyID:  GatewayIdentityKeyID(publicKey),
+		Signer: failingEd25519Signer{publicKey: publicKey},
+	}}, doer)
+	if err := issueTestCall(context.Background(), client); err == nil || !strings.Contains(err.Error(), "signing unavailable") {
+		t.Fatalf("owner token error = %v", err)
+	}
+	client = mustClientWithIdentityAndDoer(t, staticIdentitySource{identity: SigningIdentity{
+		KeyID:  GatewayIdentityKeyID(publicKey),
+		Signer: shortSignatureSigner{publicKey: publicKey},
+	}}, doer)
+	if err := issueTestCall(context.Background(), client); err == nil || !strings.Contains(err.Error(), "signature length") {
+		t.Fatalf("short signature error = %v", err)
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("transport calls = %d, want 0", calls.Load())
+	}
+}
+
+func TestClientRejectsZeroClockBeforeSigning(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	client, err := NewClient(Config{
+		BaseURL:   "https://example.test",
+		APIPrefix: "/v1",
+		HTTPClient: httpDoerFunc(func(*http.Request) (*http.Response, error) {
+			calls.Add(1)
+			return nil, errors.New("unexpected transport call")
+		}),
+		Identities: testIdentitySource(t),
+		Now:        func() time.Time { return time.Time{} },
+		Nonce:      func() (string, error) { return "nonce-1", nil },
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	if err := issueTestCall(context.Background(), client); err == nil || !strings.Contains(err.Error(), "non-zero clock") {
+		t.Fatalf("owner token error = %v", err)
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("transport calls = %d, want 0", calls.Load())
+	}
+}
+
+func mustClientWithDoer(t *testing.T, doer HTTPDoer) *Client {
+	t.Helper()
+	return mustClientWithIdentityAndDoer(t, testIdentitySource(t), doer)
+}
+
+func mustClientWithIdentityAndDoer(t *testing.T, identities IdentitySource, doer HTTPDoer) *Client {
+	t.Helper()
+	client, err := NewClient(Config{
+		BaseURL:    "https://example.test",
+		APIPrefix:  "/v1",
+		HTTPClient: doer,
+		Identities: identities,
+		Now:        func() time.Time { return time.Date(2026, 8, 2, 9, 10, 11, 0, time.UTC) },
+		Nonce:      func() (string, error) { return "nonce-1", nil },
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	return client
+}
+
+func testIdentitySource(t *testing.T) staticIdentitySource {
+	t.Helper()
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	return staticIdentitySource{identity: SigningIdentity{
+		KeyID:  GatewayIdentityKeyID(publicKey),
+		Signer: privateKey,
+	}}
+}
+
+func enrollTestCall(ctx context.Context, client *Client) error {
+	_, err := client.RegisterDeviceGatewayIdentity(ctx, RegisterDeviceGatewayIdentityRequest{
+		AuthorityID:     "deva_123",
+		RuntimeID:       "runtime-1",
+		EnrollmentProof: "proof-1",
+	})
+	return err
+}
+
+func issueTestCall(ctx context.Context, client *Client) error {
+	_, err := client.IssueDeviceGatewayOwnerTunnelToken(ctx, IssueDeviceGatewayOwnerTunnelTokenRequest{
+		AuthorityID:      "deva_123",
+		RuntimeID:        "runtime-1",
+		SupportedTargets: []string{"device-gateway"},
+	})
+	return err
+}
+
+func renewTestCall(ctx context.Context, client *Client) error {
+	_, err := client.RenewDeviceAuthorityLease(ctx, RenewDeviceAuthorityLeaseRequest{
+		AuthorityID: "deva_123",
+		OwnerUserID: "owner-1",
+		RuntimeID:   "runtime-1",
+	})
+	return err
+}
+
+type httpDoerFunc func(*http.Request) (*http.Response, error)
+
+func (f httpDoerFunc) Do(req *http.Request) (*http.Response, error) { return f(req) }
+
+func jsonHTTPResponse(statusCode int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+type failingEd25519Signer struct {
+	publicKey ed25519.PublicKey
+}
+
+func (s failingEd25519Signer) Public() crypto.PublicKey { return s.publicKey }
+
+func (failingEd25519Signer) Sign(io.Reader, []byte, crypto.SignerOpts) ([]byte, error) {
+	return nil, errors.New("signing unavailable")
+}
+
+type shortSignatureSigner struct {
+	publicKey ed25519.PublicKey
+}
+
+func (s shortSignatureSigner) Public() crypto.PublicKey { return s.publicKey }
+
+func (shortSignatureSigner) Sign(io.Reader, []byte, crypto.SignerOpts) ([]byte, error) {
+	return []byte("short"), nil
+}

--- a/packages/clients/device-authority-go/doc.go
+++ b/packages/clients/device-authority-go/doc.go
@@ -1,0 +1,5 @@
+// Package deviceauthority implements the shared Device Authority owner
+// lifecycle wire client and its canonical Ed25519 gateway signing contract.
+// Product adapters supply authentication headers, endpoint policy, identity
+// persistence, Relay lifecycle, and retry decisions.
+package deviceauthority

--- a/packages/clients/device-authority-go/go.mod
+++ b/packages/clients/device-authority-go/go.mod
@@ -1,0 +1,5 @@
+module github.com/tutti-os/tutti/packages/clients/device-authority-go
+
+go 1.24.3
+
+toolchain go1.24.5

--- a/packages/clients/device-authority-go/http_error.go
+++ b/packages/clients/device-authority-go/http_error.go
@@ -1,0 +1,41 @@
+package deviceauthority
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+const maxHTTPErrorBodyBytes = 4096
+
+// HTTPError preserves bounded control-plane status metadata for adapter-owned
+// retry policy. Callers should avoid logging Body because upstream responses
+// are product data and may contain sensitive details.
+type HTTPError struct {
+	StatusCode int
+	Body       string
+	RetryAfter string
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("control-plane request failed (%d)", e.StatusCode)
+}
+
+func (e *HTTPError) HTTPStatusCode() int { return e.StatusCode }
+
+func (e *HTTPError) HTTPRetryAfter() string { return e.RetryAfter }
+
+func newHTTPError(statusCode int, body []byte, retryAfter string) *HTTPError {
+	if len(body) > maxHTTPErrorBodyBytes {
+		body = body[:maxHTTPErrorBodyBytes]
+	}
+	message := strings.TrimSpace(string(body))
+	if message == "" {
+		message = http.StatusText(statusCode)
+	}
+	return &HTTPError{
+		StatusCode: statusCode,
+		Body:       message,
+		RetryAfter: strings.TrimSpace(retryAfter),
+	}
+}

--- a/packages/clients/device-authority-go/identity.go
+++ b/packages/clients/device-authority-go/identity.go
@@ -1,0 +1,90 @@
+package deviceauthority
+
+import (
+	"context"
+	"crypto"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+const gatewayIdentityKeyIDPrefix = "device-gateway-"
+
+// SigningIdentity binds a stable key identifier to its signer. Signer.Public
+// must return the Ed25519 public key enrolled with the Device Authority.
+type SigningIdentity struct {
+	KeyID  string
+	Signer crypto.Signer
+}
+
+// IdentitySource resolves the gateway identity for a runtime. Implementations
+// must return the same identity across enrollment retries and token requests.
+// Desktop products that need restart stability should back this interface with
+// their durable credential store.
+type IdentitySource interface {
+	Identity(ctx context.Context, runtimeID string) (SigningIdentity, error)
+}
+
+// MemoryIdentitySource creates one Ed25519 identity per runtime and retains it
+// for the life of the process. It preserves TSH's existing process-local
+// identity semantics; durable hosts should provide their own IdentitySource.
+type MemoryIdentitySource struct {
+	mu        sync.Mutex
+	byRuntime map[string]SigningIdentity
+}
+
+func NewMemoryIdentitySource() *MemoryIdentitySource {
+	return &MemoryIdentitySource{byRuntime: make(map[string]SigningIdentity)}
+}
+
+func (s *MemoryIdentitySource) Identity(ctx context.Context, runtimeID string) (SigningIdentity, error) {
+	if s == nil {
+		return SigningIdentity{}, fmt.Errorf("device gateway identity source is nil")
+	}
+	if err := contextError(ctx); err != nil {
+		return SigningIdentity{}, err
+	}
+	runtimeID = strings.TrimSpace(runtimeID)
+	if runtimeID == "" {
+		return SigningIdentity{}, fmt.Errorf("device gateway identity requires runtime id")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if identity, ok := s.byRuntime[runtimeID]; ok {
+		return identity, nil
+	}
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return SigningIdentity{}, fmt.Errorf("generate device gateway identity: %w", err)
+	}
+	identity := SigningIdentity{
+		KeyID:  GatewayIdentityKeyID(publicKey),
+		Signer: privateKey,
+	}
+	s.byRuntime[runtimeID] = identity
+	return identity, nil
+}
+
+// GatewayIdentityKeyID derives the canonical key identifier used by the
+// Device Authority gateway enrollment protocol.
+func GatewayIdentityKeyID(publicKey ed25519.PublicKey) string {
+	sum := sha256.Sum256(publicKey)
+	return gatewayIdentityKeyIDPrefix + hex.EncodeToString(sum[:8])
+}
+
+func validateSigningIdentity(identity SigningIdentity) (ed25519.PublicKey, error) {
+	keyID := strings.TrimSpace(identity.KeyID)
+	if keyID == "" || identity.Signer == nil {
+		return nil, fmt.Errorf("device gateway identity requires key id and signer")
+	}
+	publicKey, ok := identity.Signer.Public().(ed25519.PublicKey)
+	if !ok || len(publicKey) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("device gateway identity signer must use Ed25519")
+	}
+	return append(ed25519.PublicKey(nil), publicKey...), nil
+}

--- a/packages/clients/device-authority-go/identity_test.go
+++ b/packages/clients/device-authority-go/identity_test.go
@@ -1,0 +1,107 @@
+package deviceauthority
+
+import (
+	"context"
+	"crypto"
+	"crypto/ed25519"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"sync"
+	"testing"
+)
+
+func TestMemoryIdentitySourceReusesIdentityPerRuntimeConcurrently(t *testing.T) {
+	t.Parallel()
+
+	source := NewMemoryIdentitySource()
+	const callers = 32
+	identities := make(chan SigningIdentity, callers)
+	errors := make(chan error, callers)
+	var group sync.WaitGroup
+	for range callers {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			identity, err := source.Identity(context.Background(), " runtime-1 ")
+			if err != nil {
+				errors <- err
+				return
+			}
+			identities <- identity
+		}()
+	}
+	group.Wait()
+	close(identities)
+	close(errors)
+	for err := range errors {
+		t.Errorf("Identity() error = %v", err)
+	}
+
+	var first SigningIdentity
+	for identity := range identities {
+		if first.Signer == nil {
+			first = identity
+			continue
+		}
+		if identity.KeyID != first.KeyID || !identity.Signer.Public().(ed25519.PublicKey).Equal(first.Signer.Public()) {
+			t.Fatalf("identity changed across concurrent calls: first=%q current=%q", first.KeyID, identity.KeyID)
+		}
+	}
+	if first.KeyID != GatewayIdentityKeyID(first.Signer.Public().(ed25519.PublicKey)) {
+		t.Fatalf("key id = %q, does not match canonical derivation", first.KeyID)
+	}
+
+	other, err := source.Identity(context.Background(), "runtime-2")
+	if err != nil {
+		t.Fatalf("Identity(runtime-2) error = %v", err)
+	}
+	if other.KeyID == first.KeyID {
+		t.Fatal("different runtimes received the same generated identity")
+	}
+}
+
+func TestGatewayIdentityKeyIDMatchesTSHCompatibilityVector(t *testing.T) {
+	t.Parallel()
+
+	publicKey := make(ed25519.PublicKey, ed25519.PublicKeySize)
+	for index := range publicKey {
+		publicKey[index] = byte(index)
+	}
+	const want = "device-gateway-630dcd2966c43366"
+	if got := GatewayIdentityKeyID(publicKey); got != want {
+		t.Fatalf("GatewayIdentityKeyID() = %q, want %q", got, want)
+	}
+}
+
+func TestValidateSigningIdentityRejectsInvalidSignerContract(t *testing.T) {
+	t.Parallel()
+
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	tests := []struct {
+		name     string
+		identity SigningIdentity
+	}{
+		{name: "missing key id", identity: SigningIdentity{Signer: privateKey}},
+		{name: "missing signer", identity: SigningIdentity{KeyID: "key-1"}},
+		{name: "wrong algorithm", identity: SigningIdentity{KeyID: "key-1", Signer: fakeSigner{}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := validateSigningIdentity(tt.identity); err == nil {
+				t.Fatal("validateSigningIdentity() error = nil")
+			}
+		})
+	}
+}
+
+type fakeSigner struct{}
+
+func (fakeSigner) Public() crypto.PublicKey { return []byte("not-ed25519") }
+
+func (fakeSigner) Sign(io.Reader, []byte, crypto.SignerOpts) ([]byte, error) {
+	return nil, fmt.Errorf("not implemented")
+}

--- a/packages/clients/device-authority-go/signing.go
+++ b/packages/clients/device-authority-go/signing.go
@@ -1,0 +1,61 @@
+package deviceauthority
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const gatewayOwnerSessionPayloadVersion = "tsh.gateway.owner-session.v1"
+
+func randomNonce() (string, error) {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", fmt.Errorf("generate device gateway nonce: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(raw[:]), nil
+}
+
+func gatewayOwnerSessionSigningPayload(authorityID, runtimeID, keyID, nonce, timestamp string, ttlSeconds int, targets []string) (string, error) {
+	authorityID = strings.TrimSpace(authorityID)
+	runtimeID = strings.TrimSpace(runtimeID)
+	keyID = strings.TrimSpace(keyID)
+	nonce = strings.TrimSpace(nonce)
+	timestamp = strings.TrimSpace(timestamp)
+	if authorityID == "" || runtimeID == "" || keyID == "" || nonce == "" || timestamp == "" {
+		return "", fmt.Errorf("device gateway owner session signing payload requires non-empty fields")
+	}
+
+	normalized := make([]string, 0, len(targets))
+	seen := make(map[string]struct{}, len(targets))
+	for _, target := range targets {
+		// Must match tsh-server normalizeRuntimeTarget before signature
+		// verification. The request body intentionally retains the caller's
+		// original values; only the canonical signing payload is normalized.
+		target = strings.ToLower(strings.TrimSpace(target))
+		if target == "" {
+			return "", fmt.Errorf("device gateway owner session signing payload target is empty")
+		}
+		if _, exists := seen[target]; exists {
+			continue
+		}
+		seen[target] = struct{}{}
+		normalized = append(normalized, target)
+	}
+	sort.Strings(normalized)
+
+	// This canonical form is verified by tsh-server. Field order, spelling,
+	// whitespace, sorting, and newline separators are wire compatibility.
+	return strings.Join([]string{
+		gatewayOwnerSessionPayloadVersion,
+		"authority_id=" + authorityID,
+		"runtime_id=" + runtimeID,
+		"key_id=" + keyID,
+		"nonce=" + nonce,
+		"timestamp=" + timestamp,
+		fmt.Sprintf("ttl_seconds=%d", ttlSeconds),
+		"supported_targets=" + strings.Join(normalized, ","),
+	}, "\n"), nil
+}

--- a/packages/clients/device-authority-go/signing_test.go
+++ b/packages/clients/device-authority-go/signing_test.go
@@ -1,0 +1,85 @@
+package deviceauthority
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGatewayOwnerSessionSigningPayloadMatchesTSHServerCanonicalForm(t *testing.T) {
+	t.Parallel()
+
+	payload, err := gatewayOwnerSessionSigningPayload(
+		" deva_123 ",
+		" runtime-1 ",
+		" key-1 ",
+		" nonce-1 ",
+		" 2026-08-02T09:10:11.000000123Z ",
+		600,
+		[]string{" Z-TARGET ", "DEVICE-GATEWAY", "device-gateway", "a-target"},
+	)
+	if err != nil {
+		t.Fatalf("gatewayOwnerSessionSigningPayload() error = %v", err)
+	}
+	want := strings.Join([]string{
+		"tsh.gateway.owner-session.v1",
+		"authority_id=deva_123",
+		"runtime_id=runtime-1",
+		"key_id=key-1",
+		"nonce=nonce-1",
+		"timestamp=2026-08-02T09:10:11.000000123Z",
+		"ttl_seconds=600",
+		"supported_targets=a-target,device-gateway,z-target",
+	}, "\n")
+	if payload != want {
+		t.Fatalf("payload =\n%s\nwant =\n%s", payload, want)
+	}
+}
+
+func TestGatewayOwnerSessionSigningPayloadRejectsMissingFieldsAndEmptyTargets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		authority string
+		targets   []string
+	}{
+		{name: "missing authority", targets: []string{"device-gateway"}},
+		{name: "empty target", authority: "deva_123", targets: []string{"device-gateway", " "}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := gatewayOwnerSessionSigningPayload(tt.authority, "runtime-1", "key-1", "nonce-1", "timestamp", 600, tt.targets)
+			if err == nil {
+				t.Fatal("gatewayOwnerSessionSigningPayload() error = nil")
+			}
+		})
+	}
+}
+
+func TestOwnerTunnelTTLSecondsPreservesExistingDefaultsAndProtocolBounds(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		ttl     time.Duration
+		want    int
+		wantErr bool
+	}{
+		{name: "zero defaults", want: 600},
+		{name: "negative defaults", ttl: -time.Second, want: 600},
+		{name: "sub-second defaults", ttl: 500 * time.Millisecond, want: 600},
+		{name: "whole seconds", ttl: 42*time.Second + 900*time.Millisecond, want: 42},
+		{name: "server maximum", ttl: 10 * time.Minute, want: 600},
+		{name: "server maximum truncates fractional second", ttl: 10*time.Minute + 900*time.Millisecond, want: 600},
+		{name: "above server maximum", ttl: 10*time.Minute + time.Second, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ownerTunnelTTLSeconds(tt.ttl)
+			if (err != nil) != tt.wantErr || got != tt.want {
+				t.Fatalf("ownerTunnelTTLSeconds(%s) = (%d, %v), want (%d, error=%v)", tt.ttl, got, err, tt.want, tt.wantErr)
+			}
+		})
+	}
+}

--- a/packages/clients/device-authority-go/types.go
+++ b/packages/clients/device-authority-go/types.go
@@ -1,0 +1,102 @@
+package deviceauthority
+
+import "time"
+
+// EnsureDeviceAuthorityRequest identifies the product owner and local runtime
+// that should own the Device Authority.
+type EnsureDeviceAuthorityRequest struct {
+	OwnerUserID string
+	RuntimeID   string
+}
+
+// DeviceAuthorityResult describes the ensured authority and its current Relay
+// and lease parameters.
+type DeviceAuthorityResult struct {
+	AuthorityID       string
+	State             string
+	OwnerUserID       string
+	RuntimeID         string
+	Relay             RelayDescriptor
+	Lease             LeasePolicy
+	GatewayEnrollment GatewayEnrollment
+}
+
+// RegisterDeviceGatewayIdentityRequest carries the one-time enrollment proof
+// for a runtime identity.
+type RegisterDeviceGatewayIdentityRequest struct {
+	AuthorityID     string
+	RuntimeID       string
+	EnrollmentProof string
+}
+
+// DeviceGatewayIdentityResult identifies the enrolled local key.
+type DeviceGatewayIdentityResult struct {
+	AuthorityID string
+	RuntimeID   string
+	IdentityID  string
+	KeyID       string
+}
+
+// IssueDeviceGatewayOwnerTunnelTokenRequest selects the authority targets and
+// requested token lifetime.
+type IssueDeviceGatewayOwnerTunnelTokenRequest struct {
+	AuthorityID      string
+	RuntimeID        string
+	SupportedTargets []string
+	TTL              time.Duration
+}
+
+// DeviceGatewayOwnerTunnelTokenResult carries the signed owner credential and
+// current Relay/lease descriptors.
+type DeviceGatewayOwnerTunnelTokenResult struct {
+	AuthorityID string
+	State       string
+	Token       Token
+	Relay       RelayDescriptor
+	Lease       LeasePolicy
+	IdentityID  string
+}
+
+// RenewDeviceAuthorityLeaseRequest reports product-owned runtime readiness.
+type RenewDeviceAuthorityLeaseRequest struct {
+	AuthorityID       string
+	OwnerUserID       string
+	RuntimeID         string
+	TTLSeconds        int
+	OwnerTunnelStatus string
+	VMStatus          string
+}
+
+// RenewDeviceAuthorityLeaseResult reports the renewed server lease window.
+type RenewDeviceAuthorityLeaseResult struct {
+	AuthorityID string
+	State       string
+	RenewedAt   string
+	ExpiresAt   string
+}
+
+// RelayDescriptor contains the endpoints and node selected by the control
+// plane. The client does not interpret or dial these values.
+type RelayDescriptor struct {
+	HostEndpoint string
+	DialEndpoint string
+	RelayNodeID  string
+}
+
+// LeasePolicy carries server-selected lease and renewal durations in seconds.
+type LeasePolicy struct {
+	TTLSeconds           int
+	RenewIntervalSeconds int
+}
+
+// GatewayEnrollment is the short-lived proof used to enroll a gateway key.
+type GatewayEnrollment struct {
+	Proof     string
+	ExpiresAt string
+}
+
+// Token is an opaque owner-tunnel credential and its server timestamp.
+type Token struct {
+	Value     string
+	ExpiresAt string
+}

--- a/packages/clients/device-authority-go/wire.go
+++ b/packages/clients/device-authority-go/wire.go
@@ -1,0 +1,70 @@
+package deviceauthority
+
+import "strings"
+
+type ensureDeviceAuthorityWireResponse struct {
+	AuthorityID       string                `json:"authorityId"`
+	State             string                `json:"state"`
+	Relay             relayWire             `json:"relay"`
+	Lease             leaseWire             `json:"lease"`
+	GatewayEnrollment gatewayEnrollmentWire `json:"gatewayEnrollment"`
+}
+
+type deviceGatewayIdentityWire struct {
+	AuthorityID string `json:"authorityId"`
+	IdentityID  string `json:"identityId"`
+	KeyID       string `json:"keyId"`
+}
+
+type enrollDeviceGatewayIdentityWireResponse struct {
+	Identity deviceGatewayIdentityWire `json:"identity"`
+}
+
+type ownerTunnelTokenWire struct {
+	Token     string `json:"token"`
+	ExpiresAt string `json:"expiresAt"`
+}
+
+type issueOwnerTunnelTokenWireResponse struct {
+	AuthorityID       string               `json:"authorityId"`
+	State             string               `json:"state"`
+	Relay             relayWire            `json:"relay"`
+	OwnerTunnelToken  ownerTunnelTokenWire `json:"ownerTunnelToken"`
+	Lease             leaseWire            `json:"lease"`
+	GatewayIdentityID string               `json:"gatewayIdentityId"`
+}
+
+type renewLeaseWireResponse struct {
+	AuthorityID string `json:"authorityId"`
+	State       string `json:"state"`
+	RenewedAt   string `json:"renewedAt"`
+	ExpiresAt   string `json:"expiresAt"`
+}
+
+type relayWire struct {
+	HostEndpoint string `json:"hostEndpoint"`
+	DialEndpoint string `json:"dialEndpoint"`
+	RelayNodeID  string `json:"relayNodeId"`
+}
+
+func (r relayWire) descriptor() RelayDescriptor {
+	return RelayDescriptor{
+		HostEndpoint: strings.TrimSpace(r.HostEndpoint),
+		DialEndpoint: strings.TrimSpace(r.DialEndpoint),
+		RelayNodeID:  strings.TrimSpace(r.RelayNodeID),
+	}
+}
+
+type leaseWire struct {
+	TTLSeconds           int `json:"ttlSeconds"`
+	RenewIntervalSeconds int `json:"renewIntervalSeconds"`
+}
+
+func (l leaseWire) policy() LeasePolicy {
+	return LeasePolicy(l)
+}
+
+type gatewayEnrollmentWire struct {
+	Proof     string `json:"proof"`
+	ExpiresAt string `json:"expiresAt"`
+}

--- a/tools/scripts/run-check-changed-targets.mjs
+++ b/tools/scripts/run-check-changed-targets.mjs
@@ -11,6 +11,7 @@ const GO_MODULE_ROOTS = [
   "packages/agent/store-sqlite/canonical",
   "packages/appcli/core",
   "packages/auth/bridge-go",
+  "packages/clients/device-authority-go",
   "packages/device-link",
   "packages/events/stream-go",
   "packages/workbench/service",

--- a/tools/scripts/run-check-changed-targets.test.mjs
+++ b/tools/scripts/run-check-changed-targets.test.mjs
@@ -50,6 +50,10 @@ describe("resolveGoModuleRoot", () => {
       "packages/auth/bridge-go"
     );
     assert.equal(
+      resolveGoModuleRoot("packages/clients/device-authority-go/client.go"),
+      "packages/clients/device-authority-go"
+    );
+    assert.equal(
       resolveGoModuleRoot("packages/device-link/mobile/probe.go"),
       "packages/device-link"
     );

--- a/tools/scripts/run-golangci-lint.mjs
+++ b/tools/scripts/run-golangci-lint.mjs
@@ -17,6 +17,7 @@ const goModuleRoots = [
   join(workspaceRoot, "packages", "agent", "store-sqlite", "canonical"),
   join(workspaceRoot, "packages", "agent", "runtimeprep"),
   join(workspaceRoot, "packages", "appcli", "core"),
+  join(workspaceRoot, "packages", "clients", "device-authority-go"),
   join(workspaceRoot, "packages", "device-link"),
   join(workspaceRoot, "packages", "workbench", "service"),
   join(workspaceRoot, "packages", "workspace", "files"),


### PR DESCRIPTION
## What changed

- add `packages/clients/device-authority-go` for Device Authority ensure, Ed25519 gateway enrollment, owner-tunnel token issuance, and lease renewal
- preserve the TSH/tsh-server wire contract, canonical signing payload, key identity reuse, bounded HTTP metadata, and response credential binding
- keep product authentication headers, endpoint policy, durable identity storage, Relay lifecycle, retry, and lease scheduling in consumer adapters
- register the module with `go.work`, changed-aware Go validation, root Go lint, PR cache inputs, and durable architecture/static-analysis documentation

## Why

TSH already implements this security-sensitive control-plane protocol and Tutti needs the same Relay owner lifecycle. Extracting one narrow Go client prevents signing and wire behavior from drifting. This PR is the staged release bootstrap: publish the stable module first, then refactor TSH to the released cohort without behavior changes, then integrate Tutti.

## Impact

No current Tutti or TSH runtime is switched by this PR. It adds the published shared boundary and tests only. The ordinary `HTTPError` string is redacted; bounded response body, status, and Retry-After metadata remain available for explicit adapter handling.

## Validation

- `go test -count=10 ./packages/clients/device-authority-go/...`
- `go test -count=1 -race ./packages/clients/device-authority-go/...`
- `GOWORK=off go test -count=1 -race ./...`
- pinned `golangci-lint v2.12.0` on the new module
- `node --test tools/scripts/run-check-changed-targets.test.mjs`
- Prettier, Oxfmt, and `git diff --check`
- two independent architecture/security/compatibility reviews; all findings resolved

`pnpm check:changed --base origin/main` passes 7 of 8 lanes. The remaining repository tool-contract lane fails on an existing `origin/main` mismatch: `packages/agent/claude-sdk-sidecar/src/protocol.ts` and the Go daemon use protocol v8, while `apps/desktop/scripts/smoke-claude-sdk-sidecar.mjs` still sends v7. This PR does not modify those files.