### PR TITLE
fix(desktop): align Claude SDK sidecar smoke protocol

### DIFF
--- a/apps/desktop/scripts/smoke-claude-sdk-sidecar.mjs
+++ b/apps/desktop/scripts/smoke-claude-sdk-sidecar.mjs
@@ -36,7 +36,7 @@ export async function smokeClaudeSDKSidecar({
   });
 
   const send = (request) => {
-    child.stdin.write(`${JSON.stringify({ version: 7, ...request })}\n`);
+    child.stdin.write(`${JSON.stringify({ version: 8, ...request })}\n`);
   };
   const waitForEvent = async (predicate, label) => {
     while (true) {


### PR DESCRIPTION
## Summary

- Align the desktop release smoke driver with Claude SDK sidecar protocol v8
- Reuse the existing cross-runtime protocol consistency test as the verification contract

## Root cause

The TypeScript sidecar and Go daemon had already advanced to protocol v8, but `apps/desktop/scripts/smoke-claude-sdk-sidecar.mjs` still serialized every request with `version: 7`. The smoke driver therefore failed the authoritative tooling consistency check and would be rejected by a v8 sidecar.

## Impact

Release smoke validation now sends protocol v8 requests, matching the TypeScript sidecar and Go daemon. No public API, runtime configuration, or user-facing behavior changes.

## Checks

- `node --test tools/scripts/claude-sdk-sidecar-protocol.test.mjs`
- `pnpm check:changed -- --failed-only` (9/9 lanes passed after worktree dependency setup)
- `pnpm check:changed -- --push-ready` (9/9 lanes passed on retry)
- Commit hooks: formatting, lint, and staged repository boundary checks passed
- `git diff --check`

The first changed-aware run only exposed missing dependencies in the new worktree. Two later push-ready attempts encountered unrelated flaky assertions in `tools/scripts/run-agent-session-replay.test.mjs`; the repository-selected lanes passed on the prescribed failed-only retries.

No documentation impact was found: this is a one-line internal release-smoke protocol alignment and does not alter public contracts, module ownership, configuration, or validation conventions.
