### PR TITLE
fix(agent-gui): decode markdown media paths

### DIFF
--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -572,6 +572,42 @@ describe("AgentMessageMarkdown", () => {
     });
   });
 
+  it("decodes percent-encoded workspace markdown image paths before reading files", async () => {
+    const readFile = vi.fn().mockResolvedValue({
+      bytes: new Uint8Array([137, 80, 78, 71])
+    });
+    window.agentHostApi = {
+      ...(window.agentHostApi ?? {}),
+      workspace: {
+        ...(window.agentHostApi?.workspace ?? {}),
+        readFile
+      }
+    } as typeof window.agentHostApi;
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: vi.fn(() => "blob:tsh-markdown-image")
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: vi.fn()
+    });
+
+    render(
+      <AgentMessageMarkdown
+        content={"![generated image](/workspace/可爱小狗.png)"}
+      />
+    );
+
+    expect(
+      await screen.findByRole("img", {
+        name: "generated image"
+      })
+    ).toHaveAttribute("src", "blob:tsh-markdown-image");
+    expect(readFile).toHaveBeenCalledWith({
+      path: "/workspace/可爱小狗.png"
+    });
+  });
+
   it("renders workspace markdown videos from workspace file bytes", async () => {
     const readFile = vi.fn().mockResolvedValue({
       bytes: new Uint8Array([0, 0, 0, 24])

--- a/packages/agent/gui/shared/AgentMessageMarkdownMedia.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdownMedia.tsx
@@ -17,9 +17,9 @@ import {
   resetCachedMarkdownMediaForTests,
   resolveMarkdownMediaKind,
   resolveMarkdownMediaType,
+  resolveMarkdownWorkspaceMediaPath,
   resolveRenderableMarkdownMediaSrc,
   retainCachedMarkdownMedia,
-  isLocalAbsolutePath,
   type MarkdownMediaState
 } from "./agentMessageMarkdownLinks";
 
@@ -43,7 +43,7 @@ export function MarkdownMedia({
   const isInsideLink = useContext(MarkdownLinkContext);
   const agentHostApi = useOptionalAgentHostApi() ?? getOptionalAgentHostApi();
   const workspacePath =
-    typeof src === "string" && isLocalAbsolutePath(src) ? src.trim() : null;
+    typeof src === "string" ? resolveMarkdownWorkspaceMediaPath(src) : null;
   const readWorkspaceImage = workspacePath
     ? agentHostApi?.workspace?.readFile
     : undefined;

--- a/packages/agent/gui/shared/agentMessageMarkdownLinks.ts
+++ b/packages/agent/gui/shared/agentMessageMarkdownLinks.ts
@@ -69,6 +69,25 @@ export function isLocalAbsolutePath(path: string): boolean {
   );
 }
 
+export function resolveMarkdownWorkspaceMediaPath(src: string): string | null {
+  const candidate = src.trim();
+  if (!isLocalAbsolutePath(candidate)) {
+    return null;
+  }
+
+  try {
+    const decodedPath = decodeURIComponent(candidate);
+    return decodedPath.length > 1 &&
+      decodedPath.startsWith("/") &&
+      !decodedPath.startsWith("//") &&
+      !decodedPath.includes("\0")
+      ? decodedPath
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 export function isHomeRelativePath(path: string): boolean {
   const candidate = path.trim();
   return (


### PR DESCRIPTION
## Summary

- Decode URI-encoded absolute Markdown media paths before calling the workspace file API.
- Keep path validation at the AgentGUI presentation boundary and reject malformed encoded paths.
- Add a regression test for a generated image whose workspace filename contains Chinese characters.

React Markdown percent-encodes non-ASCII image destinations. AgentGUI previously forwarded that encoded URI pathname to `workspace.readFile`, so hosts looked for a literal `%E5...` filename and rendered a failed preview even though image generation succeeded.

## Verification

- `pnpm --dir packages/agent/gui exec vitest run shared/AgentMessageMarkdown.spec.tsx` — 94 tests passed.
- `pnpm check:changed` — 11 lanes passed.
- Push-ready hook `pnpm check:changed -- --push-ready` — 12 lanes passed.

## AgentGUI Review

| Lane | Trigger | Result | Evidence | Affected consumers |
| --- | --- | --- | --- | --- |
| Architecture | Workspace Host file input is normalized before dispatch | pass | The existing `MarkdownMedia -> AgentHostApi.workspace.readFile` direction is unchanged; only URI decoding is added before the capability call, with no new public export or state owner | Desktop AgentGUI, standalone Agent windows, external AgentGUI hosts |
| Performance | Rich-text rendering and the retained media cache are touched | pass | Decoding occurs once per media `src`; cache lookup, ref-counting, object URL lifetime, and render state transitions remain keyed by the resolved filesystem path; `check:agent-gui-degradation` passed | Transcript media rendering |
| Consumers | Runtime host input path changes from URI form to filesystem form | pass | Existing ASCII-path test remains green and the Unicode regression asserts the exact `readFile` input; capability shape and absence behavior are unchanged | TSH and other AgentGUI hosts |

Unresolved risks: none identified.

Documentation impact: no durable architecture or contributor documentation change is required because ownership, data flow, and the public Host API contract are unchanged; this corrects conversion into the existing filesystem-path contract.

## Checklist

- [x] If this PR changes agent lifecycle semantics: the change lives in the Agent Host conformance surface. This PR does not change lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed. No durable documentation change is needed for this contract-preserving bug fix.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. No README or CONTRIBUTING source changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
