### PR TITLE
修复 Browser 同源新窗口链接无响应

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserContribution.ts
@@ -43,6 +43,7 @@ export function createWorkspaceBrowserContribution(input: {
   const browserApi = input.browserService.createFeatureHostApi({
     acceptsEvent: isWorkspaceBrowserEvent,
     observeEvent: (event) => analyticsTracker.observeEvent(event),
+    source: "browser",
     workspaceId: input.workspaceId
   });
   const feature = createBrowserNodeFeature({

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserService.test.ts
@@ -95,7 +95,7 @@ test("workspace browser service routes multiple features through one desktop sub
   );
 });
 
-test("workspace browser service launches open-url once from the owning route", async () => {
+test("workspace browser service opens Browser popups in tabs and launches app URLs", async () => {
   const requests: WorkspaceBrowserLaunchRequest[] = [];
   let emitDesktopBrowserEvent = (_event: BrowserNodeEvent): void => undefined;
   const service = createWorkspaceBrowserService({
@@ -111,15 +111,22 @@ test("workspace browser service launches open-url once from the owning route", a
   const browserFeature = createBrowserNodeFeature({
     hostApi: service.createFeatureHostApi({
       acceptsEvent: (event) => browserNodeOwnsEvent(event),
+      source: "browser",
       workspaceId: "workspace-browser-open-url"
     })
   });
   const appFeature = createBrowserNodeFeature({
     hostApi: service.createFeatureHostApi({
       acceptsEvent: (event) => workspaceAppOwnsEvent(event),
+      source: "workspace_app",
       workspaceId: "workspace-browser-open-url"
     })
   });
+  const surfaceNodeId = "browser:surface-1";
+  const initial = browserFeature.tabsStore.ensureSurface(
+    surfaceNodeId,
+    "https://www.baidu.com/"
+  );
   const disposeLaunchHandler = registerWorkspaceBrowserLaunchHandler(
     "workspace-browser-open-url",
     (request) => {
@@ -131,10 +138,10 @@ test("workspace browser service launches open-url once from the owning route", a
   service.ensureFeatureConnected(browserFeature);
   service.ensureFeatureConnected(appFeature);
   emitDesktopBrowserEvent({
-    reuseIfOpen: false,
-    sourceNodeId: "browser:node-1",
+    reuseIfOpen: true,
+    sourceNodeId: initial.tabs[0]!.nodeId,
     type: "open-url",
-    url: "https://example.com/browser-popup"
+    url: "https://www.baidu.com/s?wd=tutti"
   });
   emitDesktopBrowserEvent({
     reuseIfOpen: false,
@@ -145,16 +152,18 @@ test("workspace browser service launches open-url once from the owning route", a
   await Promise.resolve();
 
   disposeLaunchHandler();
+  const browserTabs = browserFeature.tabsStore.getSurfaceState(surfaceNodeId);
+  assert.equal(browserTabs?.tabs.length, 2);
+  assert.equal(
+    browserTabs?.tabs.find((tab) => tab.id === browserTabs.activeTabId)
+      ?.defaultUrl,
+    "https://www.baidu.com/s?wd=tutti"
+  );
   assert.deepEqual(requests, [
     {
       kind: "open",
       reuseIfOpen: false,
-      url: "https://example.com/browser-popup",
-      workspaceId: "workspace-browser-open-url"
-    },
-    {
-      kind: "open",
-      reuseIfOpen: false,
+      source: "workspace_app",
       url: "https://example.com/app-popup",
       workspaceId: "workspace-browser-open-url"
     }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserService.test.ts
@@ -170,6 +170,125 @@ test("workspace browser service opens Browser popups in tabs and launches app UR
   ]);
 });
 
+test("workspace browser service replaces stale feature routes before handling popups", () => {
+  let emitDesktopBrowserEvent = (_event: BrowserNodeEvent): void => undefined;
+  const service = createWorkspaceBrowserService({
+    browserApi: createBrowserNodeHostApi({
+      onEvent(listener) {
+        emitDesktopBrowserEvent = listener;
+        return () => {
+          emitDesktopBrowserEvent = () => undefined;
+        };
+      }
+    })
+  });
+  const createFeature = () => {
+    const feature = createBrowserNodeFeature({
+      hostApi: service.createFeatureHostApi({
+        acceptsEvent: (event) => browserNodeOwnsEvent(event),
+        source: "browser",
+        workspaceId: "workspace-browser-replacement"
+      })
+    });
+    feature.tabsStore.ensureSurface(
+      "browser:surface-replacement",
+      "https://www.baidu.com/"
+    );
+    service.ensureFeatureConnected(feature);
+    return feature;
+  };
+  const staleFeature = createFeature();
+  const currentFeature = createFeature();
+
+  emitDesktopBrowserEvent({
+    reuseIfOpen: true,
+    sourceNodeId: "browser:surface-replacement:tab:1",
+    type: "open-url",
+    url: "https://www.baidu.com/s?wd=tutti"
+  });
+
+  assert.equal(
+    staleFeature.tabsStore.getSurfaceState("browser:surface-replacement")?.tabs
+      .length,
+    1
+  );
+  assert.equal(
+    currentFeature.tabsStore.getSurfaceState("browser:surface-replacement")
+      ?.tabs.length,
+    2
+  );
+});
+
+test("workspace browser service disposes routes with their workspace session", () => {
+  let desktopDisconnectCount = 0;
+  let emitDesktopBrowserEvent = (_event: BrowserNodeEvent): void => undefined;
+  const service = createWorkspaceBrowserService({
+    browserApi: createBrowserNodeHostApi({
+      onEvent(listener) {
+        emitDesktopBrowserEvent = listener;
+        return () => {
+          desktopDisconnectCount += 1;
+          emitDesktopBrowserEvent = () => undefined;
+        };
+      }
+    })
+  });
+  const createFeature = (workspaceId: string, nodeIdPrefix: string) => {
+    const feature = createBrowserNodeFeature({
+      hostApi: service.createFeatureHostApi({
+        acceptsEvent: (event) => {
+          const nodeId =
+            event.type === "open-url" ? event.sourceNodeId : event.nodeId;
+          return nodeId.startsWith(nodeIdPrefix);
+        },
+        source: "browser",
+        workspaceId
+      })
+    });
+    service.ensureFeatureConnected(feature);
+    return feature;
+  };
+  const disposedFeature = createFeature("workspace-disposed", "browser-old:");
+  const activeFeature = createFeature("workspace-active", "browser-active:");
+
+  service.disposeWorkspace("workspace-disposed");
+  emitDesktopBrowserEvent({
+    canGoBack: false,
+    canGoForward: false,
+    isLoading: false,
+    isOccluded: false,
+    lifecycle: "active",
+    nodeId: "browser-old:tab:1",
+    title: "Disposed",
+    type: "state",
+    url: "https://disposed.example/"
+  });
+  emitDesktopBrowserEvent({
+    canGoBack: false,
+    canGoForward: false,
+    isLoading: false,
+    isOccluded: false,
+    lifecycle: "active",
+    nodeId: "browser-active:tab:1",
+    title: "Active",
+    type: "state",
+    url: "https://active.example/"
+  });
+
+  assert.equal(
+    disposedFeature.runtimeStore.getNodeState("browser-old:tab:1").url,
+    null
+  );
+  assert.equal(
+    activeFeature.runtimeStore.getNodeState("browser-active:tab:1").url,
+    "https://active.example/"
+  );
+  assert.equal(desktopDisconnectCount, 0);
+
+  service.disposeWorkspace("workspace-active");
+  assert.equal(desktopDisconnectCount, 1);
+});
+
 test("workspace app Browser features do not inherit Chrome Cookie import", () => {
   const browserApi = createBrowserNodeHostApi({
     cancelChromeCookieImport: async () => undefined,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserService.ts
@@ -24,6 +24,7 @@ export interface WorkspaceBrowserService {
   createFeatureHostApi(
     input: WorkspaceBrowserFeatureHostApiInput
   ): BrowserNodeHostApi;
+  disposeWorkspace(workspaceId: string): void;
   ensureFeatureConnected(feature: BrowserNodeFeature): void;
   setUserAutomationSurface(input: {
     feature: BrowserNodeFeature;
@@ -44,12 +45,16 @@ export function createWorkspaceBrowserService(
       >;
   } = {}
 ): WorkspaceBrowserService {
-  const connectedFeatures = new WeakSet<BrowserNodeFeature>();
-  const featuresByHostApi = new WeakMap<
-    BrowserNodeHostApi,
-    BrowserNodeFeature
-  >();
   const routes = new Set<WorkspaceBrowserEventRoute>();
+  const routesByHostApi = new WeakMap<
+    BrowserNodeHostApi,
+    WorkspaceBrowserEventRoute
+  >();
+  const featureReleases = new WeakMap<BrowserNodeFeature, () => void>();
+  const activeRoutesByWorkspace = new Map<
+    string,
+    Map<WorkspaceBrowserFeatureSource, WorkspaceBrowserEventRoute>
+  >();
   let disconnectBrowserEvents: (() => void) | null = null;
   let disconnectUserAutomation: (() => void) | null = null;
 
@@ -79,7 +84,7 @@ export function createWorkspaceBrowserService(
             event.reuseIfOpen !== false &&
             !openUrlHandled
           ) {
-            const feature = featuresByHostApi.get(route.hostApi);
+            const feature = route.feature;
             openUrlHandled = feature
               ? openBrowserUrlInNewTab(feature, event)
               : false;
@@ -113,6 +118,45 @@ export function createWorkspaceBrowserService(
     disconnectBrowserEvents = null;
   };
 
+  const disposeRoute = (route: WorkspaceBrowserEventRoute): void => {
+    const feature = route.feature;
+    route.releaseFeature?.();
+    if (feature) {
+      featureReleases.delete(feature);
+    }
+    route.releaseFeature = null;
+    route.feature = null;
+    routes.delete(route);
+    routesByHostApi.delete(route.hostApi);
+    if (route.source) {
+      const activeRoutes = activeRoutesByWorkspace.get(route.workspaceId);
+      if (activeRoutes?.get(route.source) === route) {
+        activeRoutes.delete(route.source);
+        if (activeRoutes.size === 0) {
+          activeRoutesByWorkspace.delete(route.workspaceId);
+        }
+      }
+    }
+    maybeDisconnectBrowserEvents();
+  };
+
+  const replaceActiveRoute = (route: WorkspaceBrowserEventRoute): void => {
+    if (!route.source) {
+      return;
+    }
+    const previousRoute = activeRoutesByWorkspace
+      .get(route.workspaceId)
+      ?.get(route.source);
+    if (previousRoute && previousRoute !== route) {
+      disposeRoute(previousRoute);
+    }
+    const activeRoutes =
+      activeRoutesByWorkspace.get(route.workspaceId) ??
+      new Map<WorkspaceBrowserFeatureSource, WorkspaceBrowserEventRoute>();
+    activeRoutes.set(route.source, route);
+    activeRoutesByWorkspace.set(route.workspaceId, activeRoutes);
+  };
+
   return {
     createFeatureHostApi({ acceptsEvent, observeEvent, source, workspaceId }) {
       if (!input.browserApi) {
@@ -136,24 +180,40 @@ export function createWorkspaceBrowserService(
           };
         }
       };
-      routes.add({
+      const route: WorkspaceBrowserEventRoute = {
         acceptsEvent,
+        feature: null,
         hostApi,
         listeners,
         observeEvent,
+        releaseFeature: null,
         source,
         workspaceId
-      });
+      };
+      routes.add(route);
+      routesByHostApi.set(hostApi, route);
       return hostApi;
     },
+    disposeWorkspace(workspaceId) {
+      for (const route of Array.from(routes)) {
+        if (route.workspaceId === workspaceId) {
+          disposeRoute(route);
+        }
+      }
+    },
     ensureFeatureConnected(feature) {
-      featuresByHostApi.set(feature.hostApi, feature);
-      if (connectedFeatures.has(feature)) {
+      if (featureReleases.has(feature)) {
         return;
       }
-
-      feature.connect();
-      connectedFeatures.add(feature);
+      const route = routesByHostApi.get(feature.hostApi);
+      const releaseFeature = feature.connect();
+      featureReleases.set(feature, releaseFeature);
+      if (!route) {
+        return;
+      }
+      route.feature = feature;
+      route.releaseFeature = releaseFeature;
+      replaceActiveRoute(route);
     },
     setUserAutomationSurface({ feature, workspaceId }) {
       disconnectUserAutomation?.();
@@ -249,12 +309,18 @@ function resolveBrowserSurfaceNodeId(nodeId: string): string | null {
 
 interface WorkspaceBrowserEventRoute {
   acceptsEvent: WorkspaceBrowserEventMatcher;
+  feature: BrowserNodeFeature | null;
   hostApi: BrowserNodeHostApi;
   listeners: Set<(event: BrowserNodeEvent) => void>;
   observeEvent?: (event: BrowserNodeEvent) => void;
+  releaseFeature: (() => void) | null;
   source?: "browser" | "workspace_app";
   workspaceId: string;
 }
+
+type WorkspaceBrowserFeatureSource = NonNullable<
+  WorkspaceBrowserEventRoute["source"]
+>;
 
 function openBrowserUrlInNewTab(
   feature: BrowserNodeFeature,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserService.ts
@@ -45,6 +45,10 @@ export function createWorkspaceBrowserService(
   } = {}
 ): WorkspaceBrowserService {
   const connectedFeatures = new WeakSet<BrowserNodeFeature>();
+  const featuresByHostApi = new WeakMap<
+    BrowserNodeHostApi,
+    BrowserNodeFeature
+  >();
   const routes = new Set<WorkspaceBrowserEventRoute>();
   let disconnectBrowserEvents: (() => void) | null = null;
   let disconnectUserAutomation: (() => void) | null = null;
@@ -61,6 +65,7 @@ export function createWorkspaceBrowserService(
     disconnectBrowserEvents = input.browserApi.onEvent((event) => {
       let launchWorkspaceId: string | null = null;
       let launchSource: "browser" | "workspace_app" | undefined;
+      let openUrlHandled = false;
       for (const route of routes) {
         if (route.listeners.size === 0) {
           continue;
@@ -68,16 +73,28 @@ export function createWorkspaceBrowserService(
         if (!route.acceptsEvent(event)) {
           continue;
         }
-        if (event.type === "open-url" && launchWorkspaceId === null) {
-          launchWorkspaceId = route.workspaceId;
-          launchSource = route.source;
+        if (event.type === "open-url") {
+          if (
+            route.source === "browser" &&
+            event.reuseIfOpen !== false &&
+            !openUrlHandled
+          ) {
+            const feature = featuresByHostApi.get(route.hostApi);
+            openUrlHandled = feature
+              ? openBrowserUrlInNewTab(feature, event)
+              : false;
+          }
+          if (!openUrlHandled && launchWorkspaceId === null) {
+            launchWorkspaceId = route.workspaceId;
+            launchSource = route.source;
+          }
         }
         route.observeEvent?.(event);
         for (const listener of route.listeners) {
           listener(event);
         }
       }
-      if (launchWorkspaceId && event.type === "open-url") {
+      if (launchWorkspaceId && event.type === "open-url" && !openUrlHandled) {
         launchOpenUrl(event, launchWorkspaceId, launchSource);
       }
     });
@@ -101,33 +118,36 @@ export function createWorkspaceBrowserService(
       if (!input.browserApi) {
         throw new Error("Workspace browser service requires a browser API");
       }
-      const route: WorkspaceBrowserEventRoute = {
-        acceptsEvent,
-        listeners: new Set(),
-        observeEvent,
-        source,
-        workspaceId
-      };
-      routes.add(route);
+      const listeners = new Set<(event: BrowserNodeEvent) => void>();
       const featureApi = { ...input.browserApi };
       if (source === "workspace_app") {
         delete featureApi.discoverChromeCookieProfiles;
         delete featureApi.importChromeCookies;
         delete featureApi.cancelChromeCookieImport;
       }
-      return {
+      const hostApi: BrowserNodeHostApi = {
         ...featureApi,
         onEvent(listener) {
-          route.listeners.add(listener);
+          listeners.add(listener);
           ensureBrowserEventsConnected();
           return () => {
-            route.listeners.delete(listener);
+            listeners.delete(listener);
             maybeDisconnectBrowserEvents();
           };
         }
       };
+      routes.add({
+        acceptsEvent,
+        hostApi,
+        listeners,
+        observeEvent,
+        source,
+        workspaceId
+      });
+      return hostApi;
     },
     ensureFeatureConnected(feature) {
+      featuresByHostApi.set(feature.hostApi, feature);
       if (connectedFeatures.has(feature)) {
         return;
       }
@@ -229,10 +249,30 @@ function resolveBrowserSurfaceNodeId(nodeId: string): string | null {
 
 interface WorkspaceBrowserEventRoute {
   acceptsEvent: WorkspaceBrowserEventMatcher;
+  hostApi: BrowserNodeHostApi;
   listeners: Set<(event: BrowserNodeEvent) => void>;
   observeEvent?: (event: BrowserNodeEvent) => void;
   source?: "browser" | "workspace_app";
   workspaceId: string;
+}
+
+function openBrowserUrlInNewTab(
+  feature: BrowserNodeFeature,
+  event: BrowserNodeOpenUrlEvent
+): boolean {
+  const surfaceNodeId = resolveBrowserSurfaceNodeId(event.sourceNodeId);
+  const state = surfaceNodeId
+    ? feature.tabsStore.getSurfaceState(surfaceNodeId)
+    : null;
+  if (
+    !surfaceNodeId ||
+    !state?.tabs.some((tab) => tab.nodeId === event.sourceNodeId)
+  ) {
+    return false;
+  }
+
+  feature.tabsStore.addTab(surfaceNodeId, event.url);
+  return true;
 }
 
 function launchOpenUrl(

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
@@ -227,8 +227,8 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
       this.dependencies
     );
     this.hostSessionConfiguration = createWorkbenchHostSessionConfiguration({
-      createSession: (partition) =>
-        new WorkbenchHostSession<
+      createSession: (partition) => {
+        const session = new WorkbenchHostSession<
           WorkspaceWorkbenchHostSessionUpdate,
           WorkspaceWorkbenchHostInput,
           CachedWorkspaceWorkbenchHostInput
@@ -240,7 +240,12 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
           partition,
           resolve: (update, current) =>
             this.hostInputResolver.resolve(update, current)
-        })
+        });
+        session.registerDisposable(() => {
+          this.dependencies.browserService.disposeWorkspace(partition.scope.id);
+        });
+        return session;
+      }
     });
     this.dependencies.repository.subscribe(() => {
       this.notifyWallpaperListeners();

--- a/docs/architecture/browser-node-package.md
+++ b/docs/architecture/browser-node-package.md
@@ -86,6 +86,13 @@ It must not translate this explicit popup intent into a passive Workbench
 same-origin URL differences so normal in-page and authentication redirects are
 not reset by stale host state.
 
+The workspace host keeps one active Browser feature route per workspace and
+source. Rebuilding a Workbench contribution replaces and disconnects the prior
+route before it can handle another event, and disposing the Workbench session
+releases every Browser route for that workspace. A weak lookup does not replace
+this lifecycle: a route that still strongly owns its lookup key would also keep
+the obsolete feature and tab store alive.
+
 ## Package Entry Points
 
 The package uses multiple exports from one package rather than several small

--- a/docs/architecture/browser-node-package.md
+++ b/docs/architecture/browser-node-package.md
@@ -78,6 +78,14 @@ one surface must use the package-owned surface-event predicate so both the
 parent ID and its `:tab:*` child IDs are accepted without admitting events from
 other Browser surfaces.
 
+Ordinary guest `target="_blank"` links and `window.open` calls emit an
+`open-url` event with the exact source child ID. The full workspace Browser host
+uses that identity to create and select a new tab in the same Browser surface.
+It must not translate this explicit popup intent into a passive Workbench
+`defaultUrl` update: controller synchronization deliberately ignores
+same-origin URL differences so normal in-page and authentication redirects are
+not reset by stale host state.
+
 ## Package Entry Points
 
 The package uses multiple exports from one package rather than several small

--- a/docs/conventions/troubleshooting/toolchain-browser-terminal.md
+++ b/docs/conventions/troubleshooting/toolchain-browser-terminal.md
@@ -386,6 +386,41 @@ delimited by ---`, and the composer skill picker may show partial or
   [workspaceBrowserService.ts](../../../apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserService.ts)
   [BrowserNode.tsx](../../../packages/browser/workbench-node/src/react/BrowserNode.tsx)
 
+### Browser Node same-origin target-blank link does nothing
+
+- Symptom:
+  Clicking a `target="_blank"` link in the full workspace Browser leaves the
+  current page unchanged and opens no tab. Desktop logs show the guest preload
+  reporting `action=open-url` with `defaultPrevented=true`, followed by both
+  `Browser Node guest open-url IPC received` and the guest `open-url` emission,
+  but no navigation to the requested URL. Cross-origin popup links may still
+  appear to work.
+- Quick checks:
+  Compare the current and requested origins. Confirm the event's
+  `sourceNodeId` names an existing `:tab:*` child and that the workspace Browser
+  route is registered with source `browser`.
+- Root cause:
+  The guest preload correctly suppresses Chromium's native popup and delegates
+  the URL to the host. Reusing the Browser surface through Workbench activation
+  then changed only the active tab's `defaultUrl`. Browser Node's passive host
+  synchronization intentionally ignores same-origin differences to avoid
+  fighting in-page and authentication redirects, so the explicit popup URL was
+  never loaded.
+- Fix:
+  Keep the same-origin synchronization guard. Route Browser-owned `open-url`
+  events by their exact source child ID, create and select a new tab on that
+  Browser surface, and retain the existing Workbench launch fallback for URLs
+  emitted by Workspace Apps or unavailable Browser surfaces.
+- Validation:
+  Cover a same-origin popup from an existing Browser child and assert that a
+  second selected tab owns the requested URL while no Workbench launch occurs.
+  Also retain coverage that Workspace App URLs still launch through the
+  workspace Browser coordinator.
+- References:
+  [workspaceBrowserService.ts](../../../apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserService.ts)
+  [tabsStore.ts](../../../packages/browser/workbench-node/src/core/tabsStore.ts)
+  [nodeController.ts](../../../packages/browser/workbench-node/src/core/nodeController.ts)
+
 ### Standalone Agent Browser Node is blank and never attaches a guest
 
 - Symptom:

--- a/docs/conventions/troubleshooting/toolchain-browser-terminal.md
+++ b/docs/conventions/troubleshooting/toolchain-browser-terminal.md
@@ -410,12 +410,17 @@ delimited by ---`, and the composer skill picker may show partial or
   Keep the same-origin synchronization guard. Route Browser-owned `open-url`
   events by their exact source child ID, create and select a new tab on that
   Browser surface, and retain the existing Workbench launch fallback for URLs
-  emitted by Workspace Apps or unavailable Browser surfaces.
+  emitted by Workspace Apps or unavailable Browser surfaces. Treat the route
+  registration as a Workbench-session resource: replace an earlier route for
+  the same workspace/source generation and dispose all workspace routes when
+  its session closes.
 - Validation:
   Cover a same-origin popup from an existing Browser child and assert that a
   second selected tab owns the requested URL while no Workbench launch occurs.
-  Also retain coverage that Workspace App URLs still launch through the
-  workspace Browser coordinator.
+  Rebuild the Browser contribution and assert only the latest feature receives
+  the popup, then dispose the workspace and assert its feature no longer
+  receives events. Also retain coverage that Workspace App URLs still launch
+  through the workspace Browser coordinator.
 - References:
   [workspaceBrowserService.ts](../../../apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserService.ts)
   [tabsStore.ts](../../../packages/browser/workbench-node/src/core/tabsStore.ts)


### PR DESCRIPTION
## 问题

Browser guest 会拦截 `target="_blank"` 和 `window.open`，并向宿主发出 `open-url`。原有 Workbench 复用路径只更新活动标签的 `defaultUrl`；当目标 URL 与当前页面同源时，同源同步保护会把它视为被动状态同步而忽略，导致百度首页到百度搜索等链接点击后没有反应。

初版修复还暴露了一个生命周期问题：Workbench contribution 会在语言、主题、Dock 样式等输入变化时重建，但 Browser route 只增不减。旧 route 因而可能先消费 popup，并长期保留过期 feature 和 tabs store。

## 修改

- 使用 `open-url.sourceNodeId` 定位事件所属的 Browser surface
- 在同一 Browser surface 中新建并选中标签，承载显式 popup URL
- 每个 workspace/source 只保留当前 Browser feature route；新一代连接后释放并移除旧 route
- 将 Browser route 注册到 Workbench session 生命周期，session 释放时清理该 workspace 的全部 route
- 保留 Workspace App 和失效来源的 Workbench 启动兜底
- 保留用于保护页面内跳转和认证重定向的同源同步逻辑
- 补充同源 popup、feature 替换和 workspace disposal 回归测试
- 更新 Browser Node 架构说明和对应排障条目

## 验证

- Browser Service 目标测试：7/7 通过
- Desktop 类型检查通过
- `pnpm check:changed -- --base upstream/main --push-ready`：12/12 通过
- `GOMAXPROCS=2 pnpm push:checked`：`check:full` 27/27 通过