### PR TITLE
fix(agent-gui): track draft project changes

### DIFF
--- a/apps/desktop/src/renderer/src/features/analytics/reporters/agent-settings-project-changed/types.ts
+++ b/apps/desktop/src/renderer/src/features/analytics/reporters/agent-settings-project-changed/types.ts
@@ -2,6 +2,6 @@ import type { AnalyticsReporterParams } from "../baseReporter.ts";
 
 export interface AgentSettingsProjectChangedParams extends AnalyticsReporterParams {
   action: string;
-  agentSessionId: string;
+  agentSessionId: string | null;
   provider: string;
 }

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
@@ -866,7 +866,7 @@ test("desktop agent GUI workbench host input tracks runtime session pin changes"
   ]);
 });
 
-test("desktop agent GUI workbench host input tracks runtime project setting changes", async () => {
+test("desktop agent GUI workbench host input tracks draft project setting changes", async () => {
   const reporterCalls: ReporterEventInput[][] = [];
   const hostInput = createDesktopAgentGUIWorkbenchHostInput({
     agentHostApi: {
@@ -885,7 +885,7 @@ test("desktop agent GUI workbench host input tracks runtime project setting chan
 
   await hostInput.agentActivityRuntime.trackSettingsProjectChange?.({
     workspaceId,
-    agentSessionId: "session-runtime-project-1",
+    agentSessionId: null,
     action: "select_existing",
     provider: "codex"
   });
@@ -897,7 +897,7 @@ test("desktop agent GUI workbench host input tracks runtime project setting chan
         name: "agent.settings.project_changed",
         params: {
           action: "select_existing",
-          agent_session_id: "session-runtime-project-1",
+          agent_session_id: null,
           provider: "codex"
         }
       }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiProjectAnalytics.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiProjectAnalytics.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AgentGUIRuntime } from "../../../agentActivityRuntime";
+import { trackAgentGUISettingsProjectChange } from "./agentGuiProjectAnalytics";
+
+describe("trackAgentGUISettingsProjectChange", () => {
+  it.each(["clear", "create_new", "select_existing"] as const)(
+    "tracks draft %s project changes with a null session id",
+    (action) => {
+      const trackSettingsProjectChange = vi.fn(async () => undefined);
+
+      trackAgentGUISettingsProjectChange({
+        agentActivityRuntime: {
+          trackSettingsProjectChange
+        } as unknown as AgentGUIRuntime,
+        agentSessionId: null,
+        metadata: { action },
+        provider: "codex",
+        workspaceId: "room-1"
+      });
+
+      expect(trackSettingsProjectChange).toHaveBeenCalledWith({
+        action,
+        agentSessionId: null,
+        provider: "codex",
+        workspaceId: "room-1"
+      });
+    }
+  );
+
+  it("does not track state synchronization without interaction metadata", () => {
+    const trackSettingsProjectChange = vi.fn(async () => undefined);
+
+    trackAgentGUISettingsProjectChange({
+      agentActivityRuntime: {
+        trackSettingsProjectChange
+      } as unknown as AgentGUIRuntime,
+      agentSessionId: null,
+      provider: "codex",
+      workspaceId: "room-1"
+    });
+
+    expect(trackSettingsProjectChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiProjectAnalytics.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiProjectAnalytics.ts
@@ -1,0 +1,24 @@
+import type { AgentGUIRuntime } from "../../../agentActivityRuntime";
+
+export interface AgentGUIProjectChangeMetadata {
+  action: "clear" | "create_new" | "select_existing";
+}
+
+export function trackAgentGUISettingsProjectChange(input: {
+  agentActivityRuntime: AgentGUIRuntime;
+  agentSessionId: string | null;
+  metadata?: AgentGUIProjectChangeMetadata;
+  provider?: string | null;
+  workspaceId: string;
+}): void {
+  if (!input.metadata) {
+    return;
+  }
+  const tracking = input.agentActivityRuntime.trackSettingsProjectChange?.({
+    action: input.metadata.action,
+    agentSessionId: input.agentSessionId,
+    provider: input.provider,
+    workspaceId: input.workspaceId
+  });
+  void tracking?.catch(() => {});
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -61,6 +61,7 @@ export {
   permissionModeLabel,
   permissionModeOptions
 } from "./agentGuiController.composerHelpers";
+import { trackAgentGUISettingsProjectChange } from "./agentGuiProjectAnalytics";
 export * from "./agentGuiController.conversationHelpers";
 export {
   agentGUIConversationDiagnosticDetails,
@@ -536,17 +537,13 @@ export function useAgentGUINodeController({
       }
       selectedProjectPathRef.current = normalizedPath;
       setSelectedProjectPath(normalizedPath);
-      const agentSessionId = activeConversationIdRef.current;
-      if (!agentSessionId || !metadata) {
-        return;
-      }
-      const tracking = agentActivityRuntime.trackSettingsProjectChange?.({
-        action: metadata.action,
-        agentSessionId,
+      trackAgentGUISettingsProjectChange({
+        agentActivityRuntime,
+        agentSessionId: activeConversationIdRef.current,
+        metadata,
         provider: dataRef.current.provider,
         workspaceId
       });
-      void tracking?.catch(() => {});
     },
     [agentActivityRuntime, workspaceId]
   );

--- a/packages/agent/gui/agentActivityRuntime.tsx
+++ b/packages/agent/gui/agentActivityRuntime.tsx
@@ -120,7 +120,7 @@ export interface AgentActivityRuntimeSetSessionPinnedInput {
 
 export interface AgentActivityRuntimeTrackSettingsProjectChangeInput {
   action: "clear" | "create_new" | "select_existing";
-  agentSessionId: string;
+  agentSessionId: string | null;
   provider?: string | null;
   workspaceId: string;
 }


### PR DESCRIPTION
## Summary
- report project selection changes while the composer is still in draft mode
- allow the public analytics hook to receive a null agent session id for draft interactions
- preserve metadata-free synchronization without analytics

## Validation
- pnpm exec vitest run agent-gui/agentGuiNode/controller/agentGuiProjectAnalytics.spec.ts
- pnpm --filter @tutti-os/agent-gui typecheck
- full @tutti-os/agent-gui test suite: 299 files / 2561 tests passed
- Computer Use: select existing project -> action=select_existing, agent_session_id=null
- Computer Use: clear project -> action=clear, agent_session_id=null