### PR TITLE
fix(workbench): stop the dock from truncating icons too early

### DIFF
--- a/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
@@ -51,6 +51,7 @@ import {
   resolveWorkbenchHostDockScrollState,
   type WorkbenchHostDockScrollState
 } from "./dockScrollState.ts";
+import { resolveWorkbenchHostDockItemsWidth } from "./dockItemsWidth.ts";
 import {
   createWorkbenchHostExternalStateLookupInput,
   readWorkbenchHostExternalState
@@ -344,9 +345,20 @@ export function WorkbenchHostDock({
     }
 
     let frameId: number | null = null;
+    let retryId: number | null = null;
     const updateDockFrameSize = () => {
       frameId = null;
       if (isDockVisualMutationActive(dockMeasureRef.current)) {
+        // Presence and magnification animations mutate the dock size while
+        // they run and fire no further resize events once they settle.
+        // Retry instead of dropping the measurement so the plate does not
+        // get stuck at a stale (usually narrower) frame size.
+        if (retryId === null) {
+          retryId = window.setTimeout(() => {
+            retryId = null;
+            scheduleUpdate();
+          }, dockVisualMutationRetryMs);
+        }
         return;
       }
       const rect = element.getBoundingClientRect();
@@ -377,6 +389,9 @@ export function WorkbenchHostDock({
     return () => {
       if (frameId !== null) {
         window.cancelAnimationFrame(frameId);
+      }
+      if (retryId !== null) {
+        window.clearTimeout(retryId);
       }
       resizeObserver?.disconnect();
       window.removeEventListener("resize", scheduleUpdate);
@@ -1059,15 +1074,25 @@ export function WorkbenchHostDock({
     }
 
     let frameId: number | null = null;
+    let retryId: number | null = null;
     const scheduleUpdate = () => {
-      if (isDockVisualMutationActive(dockMeasureRef.current)) {
-        return;
-      }
       if (frameId !== null) {
         return;
       }
       frameId = window.requestAnimationFrame(() => {
         frameId = null;
+        if (isDockVisualMutationActive(dockMeasureRef.current)) {
+          // Keep retrying while presence/magnification animations run;
+          // dropping the update leaves a stale scroll state (and fade mask)
+          // after the animation settles.
+          if (retryId === null) {
+            retryId = window.setTimeout(() => {
+              retryId = null;
+              scheduleUpdate();
+            }, dockVisualMutationRetryMs);
+          }
+          return;
+        }
         updateDockScrollState();
       });
     };
@@ -1085,6 +1110,9 @@ export function WorkbenchHostDock({
     return () => {
       if (frameId !== null) {
         window.cancelAnimationFrame(frameId);
+      }
+      if (retryId !== null) {
+        window.clearTimeout(retryId);
       }
       resizeObserver?.disconnect();
       window.removeEventListener("resize", scheduleUpdate);
@@ -3432,23 +3460,6 @@ function useDockBounce(slotRefs: RefObject<Map<string, HTMLElement>>) {
   return { triggerDockBounce };
 }
 
-function resolveWorkbenchHostDockItemsWidth(
-  items: readonly WorkbenchHostDockItem[]
-): number {
-  if (items.length === 0) {
-    return dockItemsHorizontalPaddingPx;
-  }
-
-  const itemWidth = items.reduce(
-    (sum, item) =>
-      sum +
-      (item.kind === "separator" ? dockSeparatorOuterWidthPx : dockSlotWidthPx),
-    0
-  );
-  const gapWidth = Math.max(0, items.length - 1) * dockItemsGapPx;
-  return itemWidth + gapWidth + dockItemsHorizontalPaddingPx;
-}
-
 const dockHoverPanelOpenDelayMs = 120;
 const dockHoverPanelCloseDelayMs = 160;
 const dockHoverPanelHitSlopPx = 12;
@@ -3487,11 +3498,8 @@ function createHoverPanelBridgeRect(anchor: DOMRect, panel: DOMRect): DOMRect {
 }
 const dockPresenceAnimationMs = 300;
 const minimizedDockSlotLayoutAnimationMs = 720;
-const dockItemsGapPx = 10.8;
-const dockItemsHorizontalPaddingPx = 12.6;
-const dockSeparatorOuterWidthPx = 8.1;
-const dockSlotWidthPx = 43.2;
 const desktopDockPlateChromeWidth = 15.3;
+const dockVisualMutationRetryMs = 120;
 
 interface WorkbenchHostDockPlateStyle extends CSSProperties {
   "--desktop-dock-frame-size"?: string;

--- a/packages/workbench/surface/src/host/dockItemsWidth.test.ts
+++ b/packages/workbench/surface/src/host/dockItemsWidth.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  dockItemsGapPx,
+  dockItemsHorizontalPaddingPx,
+  dockSeparatorOuterWidthPx,
+  dockSlotWidthPx,
+  resolveWorkbenchHostDockItemsWidth
+} from "./dockItemsWidth.ts";
+
+// The width model must match workbench.css exactly: --desktop-dock-gap,
+// --desktop-dock-items-padding, the separator outer width (1px + 4px margins
+// per side), and --desktop-dock-size. If these drift apart the dock frame
+// sizes itself narrower than its icons and truncates them too early.
+test("dock layout constants match workbench.css", () => {
+  assert.equal(dockItemsGapPx, 16);
+  assert.equal(dockItemsHorizontalPaddingPx, 12.6);
+  assert.equal(dockSeparatorOuterWidthPx, 9);
+  assert.equal(dockSlotWidthPx, 43.2);
+});
+
+test("empty dock collapses to its horizontal padding", () => {
+  assert.equal(resolveWorkbenchHostDockItemsWidth([]), 12.6);
+});
+
+test("a single slot spans slot width plus padding without gaps", () => {
+  assert.equal(
+    resolveWorkbenchHostDockItemsWidth([{ kind: "entry" }]),
+    43.2 + 12.6
+  );
+});
+
+test("slots, separators, gaps, and padding all contribute to the width", () => {
+  const width = resolveWorkbenchHostDockItemsWidth([
+    { kind: "entry" },
+    { kind: "entry" },
+    { kind: "separator" },
+    { kind: "entry" }
+  ]);
+  // 3 slots + 1 separator + 3 gaps + padding.
+  assert.equal(width, 3 * 43.2 + 9 + 3 * 16 + 12.6);
+});

--- a/packages/workbench/surface/src/host/dockItemsWidth.ts
+++ b/packages/workbench/surface/src/host/dockItemsWidth.ts
@@ -1,0 +1,31 @@
+// Keep these layout constants in sync with workbench.css: --desktop-dock-gap
+// (16px), --desktop-dock-items-padding (6.3px per side), the 1px separator
+// with 4px margins per side (9px outer), and --desktop-dock-size (43.2px).
+// A mismatch makes the dock frame narrower than its icons, so the dock
+// truncates icons (or enters scroll mode) before its content actually
+// overflows.
+export const dockItemsGapPx = 16;
+export const dockItemsHorizontalPaddingPx = 12.6;
+export const dockSeparatorOuterWidthPx = 9;
+export const dockSlotWidthPx = 43.2;
+
+export interface WorkbenchDockItemsWidthInput {
+  kind: string;
+}
+
+export function resolveWorkbenchHostDockItemsWidth(
+  items: readonly WorkbenchDockItemsWidthInput[]
+): number {
+  if (items.length === 0) {
+    return dockItemsHorizontalPaddingPx;
+  }
+
+  const itemWidth = items.reduce(
+    (sum, item) =>
+      sum +
+      (item.kind === "separator" ? dockSeparatorOuterWidthPx : dockSlotWidthPx),
+    0
+  );
+  const gapWidth = Math.max(0, items.length - 1) * dockItemsGapPx;
+  return itemWidth + gapWidth + dockItemsHorizontalPaddingPx;
+}


### PR DESCRIPTION
## Problem

The dock frame sized itself narrower than its icons, so the right-most icons visually extended past the dock bounds / got clipped by the scroll fade mask earlier than they should.

Measured live in TSH (14 slots + 4 separators):

| metric | before | after |
| --- | --- | --- |
| dock inline width | 833.4px | 925.4px |
| items scroll width | 873px (overflow) | 925px (fits) |
| plate frame size | 722px (stale) | 941px |

## Root cause

1. **Stale layout constants** — `resolveWorkbenchHostDockItemsWidth` used `dockItemsGapPx = 10.8` and `dockSeparatorOuterWidthPx = 8.1`, while workbench.css renders `--desktop-dock-gap: 16px` and separators at 9px outer (1px + 4px margins per side). The dock therefore computed a content size ~11% smaller than reality and never entered scroll mode when it should / clipped content against a too-narrow frame.

2. **Dropped measurements during animations** — the frame-size and scroll-state observers skip updates while `isDockVisualMutationActive` (presence/magnification animations), with no retry. Since no further resize events fire after the animation settles, the dock plate stayed stuck at an older, narrower size.

## Fix

- Sync the constants with workbench.css (gap 16, separator outer 9) and extract the width model into `dockItemsWidth.ts` with unit tests pinning it to the stylesheet.
- Retry deferred frame-size / scroll-state measurements (120ms) until the visual mutation settles instead of dropping them.

## Tests

- `node --test`: 276 passed (4 new for the width model)
- `vitest run` render suites: 43 passed
- typecheck + build: clean
- Verified live in TSH Desktop via linked local package: all dock icons now render inside the dock frame, no premature truncation.