### PR TITLE
fix(update-admission): preserve empty feature key arrays

### DIFF
--- a/packages/desktop/update-admission/README.md
+++ b/packages/desktop/update-admission/README.md
@@ -113,7 +113,8 @@ A valid `featureAvailability.keys` envelope replaces the daemon's
 exact-identity cache. Missing or invalid feature data retains the prior cache
 without changing a valid admission decision. The cache stores only identity,
 feature keys, policy revision, and fetch time; it never stores a minimum version
-or admission decision.
+or admission decision. The daemon always serializes `keys` as a JSON array,
+including `[]` when no feature keys are available.
 
 Electron keeps only an in-memory projection for trusted renderer IPC:
 

--- a/packages/desktop/update-admission/daemon/cache.go
+++ b/packages/desktop/update-admission/daemon/cache.go
@@ -75,7 +75,7 @@ func (cache FileFeatureCache) Save(identity Identity, snapshot FeatureAvailabili
 		Identity:       identity,
 		PolicyRevision: *snapshot.PolicyRevision,
 		FetchedAt:      snapshot.FetchedAt.UTC(),
-		Keys:           append([]string(nil), snapshot.Keys...),
+		Keys:           cloneFeatureKeys(snapshot.Keys),
 	}
 	raw, err := json.Marshal(document)
 	if err != nil {

--- a/packages/desktop/update-admission/daemon/service.go
+++ b/packages/desktop/update-admission/daemon/service.go
@@ -287,7 +287,7 @@ func (service *Service) refresh(ctx context.Context, trigger string) (RefreshRes
 		revision := parsed.Policy.PolicyRevision
 		fetchedAt := completedAt
 		service.snapshot.FeatureAvailability = FeatureAvailabilitySnapshot{
-			Keys:           append([]string(nil), parsed.Feature...),
+			Keys:           cloneFeatureKeys(parsed.Feature),
 			Source:         "remote",
 			PolicyRevision: &revision,
 			FetchedAt:      &fetchedAt,
@@ -354,7 +354,7 @@ func cloneSnapshot(snapshot Snapshot) Snapshot {
 
 func cloneFeatureSnapshot(snapshot FeatureAvailabilitySnapshot) FeatureAvailabilitySnapshot {
 	clone := snapshot
-	clone.Keys = append([]string(nil), snapshot.Keys...)
+	clone.Keys = cloneFeatureKeys(snapshot.Keys)
 	if snapshot.PolicyRevision != nil {
 		revision := *snapshot.PolicyRevision
 		clone.PolicyRevision = &revision
@@ -362,6 +362,15 @@ func cloneFeatureSnapshot(snapshot FeatureAvailabilitySnapshot) FeatureAvailabil
 	if snapshot.FetchedAt != nil {
 		clone.FetchedAt = pointerTime(*snapshot.FetchedAt)
 	}
+	return clone
+}
+
+// cloneFeatureKeys preserves the wire contract that an empty key set is an
+// empty JSON array, never null. append([]string(nil), values...) would turn an
+// empty slice into nil and break strict feature-availability consumers.
+func cloneFeatureKeys(keys []string) []string {
+	clone := make([]string, len(keys))
+	copy(clone, keys)
 	return clone
 }
 

--- a/packages/desktop/update-admission/daemon/service_test.go
+++ b/packages/desktop/update-admission/daemon/service_test.go
@@ -1,7 +1,9 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -53,6 +55,41 @@ func TestServiceStartsCheckBeforeLocalRead(t *testing.T) {
 	}
 	if snapshot.Policy.Status != "resolved" || snapshot.Policy.Response.Decision != "allowed" {
 		t.Fatalf("snapshot = %#v", snapshot)
+	}
+	assertEmptyFeatureKeysEncodeAsArray(t, snapshot)
+	assertEmptyFeatureKeysEncodeAsArray(t, service.Snapshot())
+}
+
+func TestServiceInitialSnapshotEncodesEmptyFeatureKeysAsArray(t *testing.T) {
+	service, err := New(Config{
+		Identity:      testIdentity(),
+		ChecksEnabled: false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertEmptyFeatureKeysEncodeAsArray(t, service.Snapshot())
+}
+
+func TestFeatureCacheEncodesEmptyFeatureKeysAsArray(t *testing.T) {
+	cachePath := filepath.Join(t.TempDir(), "feature-cache.json")
+	cache := FileFeatureCache{Path: cachePath}
+	now := time.Date(2026, 8, 3, 1, 2, 3, 0, time.UTC)
+	revision := "v1"
+	if err := cache.Save(testIdentity(), FeatureAvailabilitySnapshot{
+		Keys:           nil,
+		Source:         "remote",
+		PolicyRevision: &revision,
+		FetchedAt:      &now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(cachePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(raw, []byte(`"keys":[]`)) {
+		t.Fatalf("cache keys must encode as an array: %s", raw)
 	}
 }
 
@@ -337,6 +374,20 @@ func TestCloseCancelsActiveRefresh(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("active refresh was not canceled when the service closed")
+	}
+}
+
+func assertEmptyFeatureKeysEncodeAsArray(t *testing.T, snapshot Snapshot) {
+	t.Helper()
+	if snapshot.FeatureAvailability.Keys == nil {
+		t.Fatal("feature availability keys must be a non-nil empty slice")
+	}
+	raw, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(raw, []byte(`"keys":[]`)) {
+		t.Fatalf("snapshot keys must encode as an array: %s", raw)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Preserve non-nil empty feature key slices when cloning daemon snapshots and cache documents.
- Keep the strict wire contract: `featureAvailability.keys` always serializes as a JSON array, including `[]`.
- Add regression coverage for initial snapshots, remote empty responses, cloned snapshots, and persisted cache JSON.
- Document the empty-array contract.

## Verification

- `go test ./daemon`
- `pnpm --filter @tutti-os/desktop-update-admission test`
- `pnpm --filter @tutti-os/desktop-update-admission typecheck`
- `pnpm --filter @tutti-os/desktop-update-admission build`
- `pnpm check:changed`
- push-ready hook: `check:changed` passed 4 lanes

## Risk and rollout

The behavior change is limited to empty feature key serialization: `null` becomes `[]`. Non-empty key lists and admission policy decisions are unchanged. Consumers receive this fix after the next shared package release.

## Checklist

- [x] This change does not alter agent lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] I updated documentation for the wire behavior.
- [x] No multilingual README source was changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] The commit is signed off with DCO.