### PR TITLE
fix(agent-gui): preserve shared Agent owner in rich-text mentions

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -538,9 +538,14 @@ export function AgentGUINodeView({
     () =>
       projectAgentTargetPresentations({
         agentTargets: viewModel.rail.agentTargets,
+        ownerSeparator: labels.sharedAgentOwnerSeparator,
         workspaceId: viewModel.shell.workspaceId
       }),
-    [targetPresentationKey, viewModel.shell.workspaceId]
+    [
+      labels.sharedAgentOwnerSeparator,
+      targetPresentationKey,
+      viewModel.shell.workspaceId
+    ]
   );
 
   const content = (

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiTargetName.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiTargetName.ts
@@ -1,0 +1,28 @@
+import type { AgentGUIAgentTarget } from "../../../types";
+
+export interface AgentGUIAgentTargetNamePresentation {
+  agentLabel: string;
+  fullLabel: string;
+  ownerLabel: string | null;
+  ownerSeparator: string;
+}
+
+export function projectAgentGUIAgentTargetName(input: {
+  ownerSeparator: string;
+  target: AgentGUIAgentTarget;
+}): AgentGUIAgentTargetNamePresentation {
+  const agentLabel = input.target.label.trim();
+  const ownerLabel =
+    input.target.ownership === "shared"
+      ? input.target.ownerLabel?.trim() || null
+      : null;
+  const ownerSeparator = ownerLabel ? input.ownerSeparator : "";
+  return {
+    agentLabel,
+    fullLabel: ownerLabel
+      ? `${ownerLabel}${ownerSeparator}${agentLabel}`
+      : agentLabel,
+    ownerLabel,
+    ownerSeparator
+  };
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiTargetPresentation.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiTargetPresentation.spec.ts
@@ -23,6 +23,7 @@ describe("Agent GUI target presentation projection", () => {
     expect(
       projectAgentTargetPresentations({
         agentTargets: [TARGET],
+        ownerSeparator: "'s ",
         workspaceId: "workspace-1"
       })
     ).toEqual([
@@ -43,6 +44,35 @@ describe("Agent GUI target presentation projection", () => {
         {
           ...TARGET,
           maskIconUrl: "data:image/svg+xml;base64,kilo-mask-next"
+        }
+      ])
+    );
+  });
+
+  it("uses the localized owner-qualified label for shared Agent mentions", () => {
+    expect(
+      projectAgentTargetPresentations({
+        agentTargets: [
+          {
+            ...TARGET,
+            label: "Codex",
+            ownerLabel: "Lin",
+            ownership: "shared"
+          }
+        ],
+        ownerSeparator: " 的 ",
+        workspaceId: "workspace-1"
+      })
+    ).toMatchObject([{ name: "Lin 的 Codex" }]);
+  });
+
+  it("invalidates presentation memoization when shared ownership changes", () => {
+    expect(agentTargetPresentationKey([TARGET])).not.toBe(
+      agentTargetPresentationKey([
+        {
+          ...TARGET,
+          ownerLabel: "Lin",
+          ownership: "shared"
         }
       ])
     );

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiTargetPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiTargetPresentation.ts
@@ -1,5 +1,6 @@
 import type { AgentGUIAgentTarget } from "../../../types";
 import type { AgentMessageMarkdownAgentTarget } from "../../../shared/AgentTargetPresentationContext";
+import { projectAgentGUIAgentTargetName } from "./agentGuiTargetName";
 
 export function agentTargetPresentationKey(
   agentTargets: readonly AgentGUIAgentTarget[]
@@ -10,6 +11,8 @@ export function agentTargetPresentationKey(
       target.iconUrl ?? null,
       target.maskIconUrl ?? null,
       target.label,
+      target.ownerLabel ?? null,
+      target.ownership ?? null,
       target.provider
     ])
   );
@@ -17,6 +20,7 @@ export function agentTargetPresentationKey(
 
 export function projectAgentTargetPresentations(input: {
   agentTargets: readonly AgentGUIAgentTarget[];
+  ownerSeparator: string;
   workspaceId: string;
 }): readonly AgentMessageMarkdownAgentTarget[] {
   return input.agentTargets.flatMap((target) =>
@@ -26,7 +30,10 @@ export function projectAgentTargetPresentations(input: {
             agentTargetId: target.agentTargetId,
             iconUrl: target.iconUrl ?? null,
             maskIconUrl: target.maskIconUrl ?? null,
-            name: target.label,
+            name: projectAgentGUIAgentTargetName({
+              ownerSeparator: input.ownerSeparator,
+              target
+            }).fullLabel,
             provider: target.provider,
             workspaceId: input.workspaceId
           }

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAgentTargetName.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIAgentTargetName.tsx
@@ -1,32 +1,6 @@
 import { cn } from "@tutti-os/ui-system";
 import type { AgentGUIAgentTarget } from "../../../types";
-
-export interface AgentGUIAgentTargetNamePresentation {
-  agentLabel: string;
-  fullLabel: string;
-  ownerLabel: string | null;
-  ownerSeparator: string;
-}
-
-export function projectAgentGUIAgentTargetName(input: {
-  ownerSeparator: string;
-  target: AgentGUIAgentTarget;
-}): AgentGUIAgentTargetNamePresentation {
-  const agentLabel = input.target.label.trim();
-  const ownerLabel =
-    input.target.ownership === "shared"
-      ? input.target.ownerLabel?.trim() || null
-      : null;
-  const ownerSeparator = ownerLabel ? input.ownerSeparator : "";
-  return {
-    agentLabel,
-    fullLabel: ownerLabel
-      ? `${ownerLabel}${ownerSeparator}${agentLabel}`
-      : agentLabel,
-    ownerLabel,
-    ownerSeparator
-  };
-}
+import { projectAgentGUIAgentTargetName } from "../model/agentGuiTargetName";
 
 export function AgentGUIAgentTargetName({
   className,

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyState.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIEmptyState.tsx
@@ -45,10 +45,8 @@ import type {
 import type { ChromeLabels } from "./AgentGUINodeView.types";
 import { AgentGUIEmptyHeroCarouselStage } from "./AgentGUIEmptyHeroCarouselStage";
 import { AgentTargetSetupGate } from "./AgentTargetSetupGate.tsx";
-import {
-  AgentGUIAgentTargetName,
-  projectAgentGUIAgentTargetName
-} from "./AgentGUIAgentTargetName";
+import { projectAgentGUIAgentTargetName } from "../model/agentGuiTargetName";
+import { AgentGUIAgentTargetName } from "./AgentGUIAgentTargetName";
 import styles from "../AgentGUINode.styles";
 import { AgentGUIOwnerAvatar } from "../AgentGUIOwnerAvatar";
 


### PR DESCRIPTION
## Summary

- Extract the localized owner-qualified Agent label projection into a shared AgentGUI model helper.
- Reuse that helper when projecting Agent targets into rich-text mention presentation metadata.
- Include shared ownership fields in the presentation memoization key and add regression coverage.

## Root cause

The Agent rail/header rendered a shared Agent owner and Agent name separately, but the rich-text presentation projection only copied the raw Agent label. Read-only rich-text hydration then replaced the serialized mention label with that raw name, so a shared Agent mention displayed only `Codex` instead of the localized owner-qualified label such as `Lin 的 Codex`.

## Validation

- `pnpm --filter @tutti-os/agent-gui exec vitest run agent-gui/agentGuiNode/model/agentGuiTargetPresentation.spec.ts`
- `pnpm exec oxfmt --check ...`
- `pnpm exec oxlint --deny-warnings ...`
- Staged repository checks passed.
- `pnpm check:changed -- --push-ready` passed 12 lanes.