### PR TITLE
fix(agent-session-replay): preserve replay identity and screenshot evidence

### DIFF
--- a/apps/desktop/src/renderer/src/features/agent-session-replay/services/agentSessionReplayInteractionContract.ts
+++ b/apps/desktop/src/renderer/src/features/agent-session-replay/services/agentSessionReplayInteractionContract.ts
@@ -4,6 +4,7 @@ import {
   selectEngineInteraction,
   selectEngineSession,
   selectEngineSessionRuntimeAvailability,
+  selectEngineSubmitWouldBeVisibleInQueue,
   selectEngineTurn,
   type AgentSessionEngineState,
   type EngineExternalCommand,
@@ -270,6 +271,20 @@ const agentSessionReplayIntentContracts = {
     },
     replayEffectCommandIdFromPayload: (payload) =>
       submitSendNowCancelCommandId(payload),
+    // Busy-queue submits were recorded while submit was unavailable. Wait until
+    // the engine again admits a visible queue row before replaying them; otherwise
+    // admission recomputes available→immediate send and the composer blue bar
+    // never appears (and later provider outbound order mismatches).
+    isReady: (snapshot, { agentSessionId, payload }) => {
+      const diagnostics = payload.submitDiagnostics;
+      const queued =
+        diagnostics !== null &&
+        typeof diagnostics === "object" &&
+        "queued" in diagnostics &&
+        (diagnostics as { queued?: unknown }).queued === true;
+      if (!queued) return true;
+      return selectEngineSubmitWouldBeVisibleInQueue(snapshot, agentSessionId);
+    },
     replayMaterializesCommandId: false,
     requiresEffect: false,
     timestampRebase: "requestExpiryWindow"

--- a/docs/architecture/agent-session-replay.md
+++ b/docs/architecture/agent-session-replay.md
@@ -686,7 +686,9 @@ child-Session or Message ordinal columns in the product database. The recorder
 waits for the matching canonical commit before confirming a Provider
 observation. Replay rebuilds the same address bindings from the Cassette start
 and uses exact Host queries plus the recorded observation fingerprint before a
-checkpoint can become ready.
+checkpoint can become ready. When a turn's terminal observation is the first
+observation available to a replay binding, its address still uses the turn's
+recorded birth observation so started and terminal fingerprints remain stable.
 
 Compaction notices normalize to provider-neutral `compaction.updated`
 observations using the canonical system-notice command and status. Attachment

--- a/packages/agent/store-sqlite/historical_state_restore.go
+++ b/packages/agent/store-sqlite/historical_state_restore.go
@@ -188,10 +188,15 @@ func restoreHistoricalSession(
 	}
 	railSectionKind := strings.TrimSpace(session.RailSectionKind)
 	railProjectPath := NormalizeProjectPath(session.RailProjectPath)
-	railSectionKey := strings.TrimSpace(session.RailSectionKey)
+	railSectionKey := NormalizeRailSectionKey(session.RailSectionKey)
 	if railSectionKind == "" && railProjectPath == "" && railSectionKey == "" {
 		railSectionKind = RailSectionKindConversations
 		railSectionKey = RailSectionKeyConversations
+	}
+	if railSectionKind == RailSectionKindProject && railProjectPath != "" {
+		// Keep restored membership aligned with live classification and with
+		// user-project SectionKeyFromPath (both use RailSectionKeyForProject).
+		railSectionKey = RailSectionKeyForProject(railProjectPath)
 	}
 	metadataJSON := `{"visible":true,"imported":true,"capabilities":[]}`
 	internalRuntimeContext := map[string]any{

--- a/packages/agent/store-sqlite/rail.go
+++ b/packages/agent/store-sqlite/rail.go
@@ -361,6 +361,21 @@ func RailSectionKeyForProject(projectPath string) string {
 	return "project:" + projectPath
 }
 
+// NormalizeRailSectionKey canonicalizes a rail section key so project keys
+// that differ only by symlink path forms (for example /var vs /private/var
+// on macOS) compare equal.
+func NormalizeRailSectionKey(sectionKey string) string {
+	sectionKey = strings.TrimSpace(sectionKey)
+	if sectionKey == "" || sectionKey == RailSectionKeyConversations {
+		return sectionKey
+	}
+	const prefix = "project:"
+	if strings.HasPrefix(sectionKey, prefix) {
+		return RailSectionKeyForProject(strings.TrimPrefix(sectionKey, prefix))
+	}
+	return sectionKey
+}
+
 func normalizeAgentSessionRailSection(section RailSection) RailSection {
 	section.Kind = strings.TrimSpace(section.Kind)
 	section.ProjectPath = NormalizeProjectPath(section.ProjectPath)

--- a/services/tuttid/biz/agentsessionreplay/state.go
+++ b/services/tuttid/biz/agentsessionreplay/state.go
@@ -136,7 +136,7 @@ func ProjectPortableAgentState(
 			rootCWD,
 		)
 		if session.RailSectionKind == storesqlite.RailSectionKindProject &&
-			strings.TrimSpace(session.RailSectionKey) ==
+			storesqlite.NormalizeRailSectionKey(session.RailSectionKey) ==
 				storesqlite.RailSectionKeyForProject(sourceSession.RailProjectPath) {
 			session.RailSectionKey = "project:" + session.RailProjectPath
 		}
@@ -407,7 +407,14 @@ func portableReplayPath(path, root string) string {
 	if path == "" || root == "" {
 		return path
 	}
-	relative, err := filepath.Rel(root, path)
+	// Normalize before Rel so macOS /var vs /private/var forms of the same
+	// directory project to ${REPLAY_CWD} instead of leaking absolute paths.
+	normalizedPath := storesqlite.NormalizeProjectPath(path)
+	normalizedRoot := storesqlite.NormalizeProjectPath(root)
+	if normalizedPath == "" || normalizedRoot == "" {
+		return path
+	}
+	relative, err := filepath.Rel(normalizedRoot, normalizedPath)
 	if err != nil || relative == ".." ||
 		strings.HasPrefix(relative, ".."+string(filepath.Separator)) ||
 		filepath.IsAbs(relative) {

--- a/services/tuttid/biz/agentsessionreplay/state_test.go
+++ b/services/tuttid/biz/agentsessionreplay/state_test.go
@@ -7,6 +7,7 @@ import (
 
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	sessionreplay "github.com/tutti-os/tutti/packages/agent/session-replay"
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 )
 
 func TestProjectAndResolvePortableAgentSessionBinding(t *testing.T) {
@@ -54,6 +55,53 @@ func TestProjectAndResolvePortableAgentSessionBinding(t *testing.T) {
 		session.RailSectionKey !=
 			"project:"+filepath.Join(replayRoot, "packages", "agent") {
 		t.Fatalf("resolved binding = %#v", session)
+	}
+}
+
+func TestProjectPortableAgentStateNormalizesSymlinkEquivalentPaths(t *testing.T) {
+	rawDir := t.TempDir()
+	canonicalDir := storesqlite.NormalizeProjectPath(rawDir)
+	if canonicalDir == "" || canonicalDir == rawDir {
+		t.Skip("temp dir has no symlink path form to exercise")
+	}
+	agent := TuttiReplayAgent{
+		RootSessionID: "session-1",
+		Sessions: []agenthost.HistoricalSession{{
+			ID:              "session-1",
+			Cwd:             rawDir,
+			RailSectionKind: storesqlite.RailSectionKindProject,
+			RailProjectPath: canonicalDir,
+			RailSectionKey:  "project:" + rawDir,
+		}},
+	}
+
+	portable := ProjectPortableAgentState(agent, t.TempDir())
+	session := portable.Sessions[0]
+	if session.Cwd != sessionreplay.PortableReplayCWDToken {
+		t.Fatalf("portable cwd = %q", session.Cwd)
+	}
+	if session.RailProjectPath != sessionreplay.PortableReplayCWDToken {
+		t.Fatalf("portable railProjectPath = %q", session.RailProjectPath)
+	}
+	if session.RailSectionKey !=
+		"project:"+sessionreplay.PortableReplayCWDToken {
+		t.Fatalf("portable railSectionKey = %q", session.RailSectionKey)
+	}
+	if filepath.IsAbs(session.RailProjectPath) || filepath.IsAbs(session.Cwd) {
+		t.Fatalf("portable paths must not stay absolute: %#v", session)
+	}
+	if err := validateReplayPortableValue("$", "", map[string]any{
+		"agent": map[string]any{
+			"sessions": []any{
+				map[string]any{
+					"cwd":             session.Cwd,
+					"railProjectPath": session.RailProjectPath,
+					"railSectionKey":  session.RailSectionKey,
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("portable binding failed path validation: %v", err)
 	}
 }
 

--- a/services/tuttid/biz/userproject/model.go
+++ b/services/tuttid/biz/userproject/model.go
@@ -1,6 +1,10 @@
 package userproject
 
-import "strings"
+import (
+	"strings"
+
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
 
 type Project struct {
 	ID               string
@@ -14,12 +18,16 @@ type Project struct {
 	SortOrder        int
 }
 
+// SectionKeyFromPath returns the conversation-rail section key for a user
+// project path. It must match storesqlite.RailSectionKeyForProject so list
+// queries find sessions whose keys were classified with path normalization
+// (for example macOS /var vs /private/var).
 func SectionKeyFromPath(path string) string {
 	path = strings.TrimSpace(path)
 	if path == "" {
 		return ""
 	}
-	return "project:" + path
+	return storesqlite.RailSectionKeyForProject(path)
 }
 
 func LabelFromPath(path string) string {

--- a/services/tuttid/biz/userproject/model_test.go
+++ b/services/tuttid/biz/userproject/model_test.go
@@ -1,0 +1,39 @@
+package userproject
+
+import (
+	"path/filepath"
+	"testing"
+
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+func TestSectionKeyFromPathMatchesRailClassification(t *testing.T) {
+	rawDir := t.TempDir()
+	canonicalDir := storesqlite.NormalizeProjectPath(rawDir)
+	if canonicalDir == "" {
+		t.Fatal("normalized temp dir is empty")
+	}
+
+	gotRaw := SectionKeyFromPath(rawDir)
+	gotCanonical := SectionKeyFromPath(canonicalDir)
+	want := storesqlite.RailSectionKeyForProject(rawDir)
+	if gotRaw != want {
+		t.Fatalf("SectionKeyFromPath(raw) = %q, want %q", gotRaw, want)
+	}
+	if gotCanonical != want {
+		t.Fatalf("SectionKeyFromPath(canonical) = %q, want %q", gotCanonical, want)
+	}
+	if canonicalDir != rawDir && gotRaw == "project:"+rawDir {
+		t.Fatalf("SectionKeyFromPath must normalize symlink forms, got %q", gotRaw)
+	}
+	if gotRaw != "project:"+filepath.Clean(canonicalDir) &&
+		gotRaw != storesqlite.RailSectionKeyForProject(canonicalDir) {
+		t.Fatalf("unexpected section key %q for %q", gotRaw, rawDir)
+	}
+}
+
+func TestSectionKeyFromPathEmpty(t *testing.T) {
+	if got := SectionKeyFromPath("  "); got != "" {
+		t.Fatalf("empty path section key = %q, want empty", got)
+	}
+}

--- a/services/tuttid/data/agentsessionreplay/artifact_blobs.go
+++ b/services/tuttid/data/agentsessionreplay/artifact_blobs.go
@@ -512,7 +512,17 @@ func portableReplayPath(path, root string) (string, bool) {
 	if path == "" || root == "" {
 		return path, false
 	}
-	relative, err := filepath.Rel(root, path)
+	normalizedPath := path
+	normalizedRoot := root
+	if evaluated, err := filepath.EvalSymlinks(path); err == nil {
+		normalizedPath = evaluated
+	}
+	if evaluated, err := filepath.EvalSymlinks(root); err == nil {
+		normalizedRoot = evaluated
+	}
+	normalizedPath = filepath.Clean(normalizedPath)
+	normalizedRoot = filepath.Clean(normalizedRoot)
+	relative, err := filepath.Rel(normalizedRoot, normalizedPath)
 	if err != nil || relative == ".." ||
 		strings.HasPrefix(relative, ".."+string(filepath.Separator)) ||
 		filepath.IsAbs(relative) {

--- a/services/tuttid/service/agentsessionreplay/checkpoint_activity_boundaries.go
+++ b/services/tuttid/service/agentsessionreplay/checkpoint_activity_boundaries.go
@@ -167,6 +167,11 @@ func activityIntentRequiresEffect(eventType string) bool {
 		"interaction/responseRequested", "plan/decisionRequested",
 		"plan/feedbackRequested", "session/cancelRequested",
 		"session/settingsUpdateRequested", "submit/requested":
+		// Keep submit/requested requiring an effect for checkpoint boundaries:
+		// busy-queue admits have no immediate effect, but the same intent later
+		// causes queue/sendPrompt on drain — cutting submission.accepted on the
+		// bare intent fails checkpoint_plan validation (splits intent/effects).
+		// Mid-queue UI evidence stays on record-time captureEvidence.
 		return true
 	default:
 		return false

--- a/services/tuttid/service/agentsessionreplay/checkpoint_commit_correlations.go
+++ b/services/tuttid/service/agentsessionreplay/checkpoint_commit_correlations.go
@@ -74,9 +74,10 @@ func (s *Service) ObserveReplayCommitted(
 					EventIndex:   event.EventIndex,
 				}
 				addresses, found :=
-					s.checkpoints.entities.providerAddresses(
+					s.checkpoints.entities.providerAddressesForPlan(
 						eventPosition,
 						event,
+						s.checkpoints.plan,
 					)
 				if !found || len(addresses) == 0 {
 					continue

--- a/services/tuttid/service/agentsessionreplay/checkpoint_provider_candidates.go
+++ b/services/tuttid/service/agentsessionreplay/checkpoint_provider_candidates.go
@@ -175,9 +175,10 @@ func (r *checkpointRecorder) buildCandidate(
 			UnitIndex:    position.UnitIndex,
 			EventIndex:   event.EventIndex,
 		}
-		addresses, ok := r.entities.providerAddresses(
+		addresses, ok := r.entities.providerAddressesForPlan(
 			observationPosition,
 			event,
+			r.plan,
 		)
 		if !ok || len(addresses) == 0 {
 			continue

--- a/services/tuttid/service/agentsessionreplay/checkpoint_recorder_test.go
+++ b/services/tuttid/service/agentsessionreplay/checkpoint_recorder_test.go
@@ -498,3 +498,109 @@ func TestLateStartInitializationDoesNotOverwriteEarlyProviderState(
 		)
 	}
 }
+
+func TestCompletedFirstTurnBindsBirthAddressFromPlan(t *testing.T) {
+	startedPos := replay.ProviderObservationPosition{
+		ConnectionID: "connection-1",
+		ChunkSeq:     21,
+		UnitIndex:    1,
+		EventIndex:   1,
+	}
+	completedPos := replay.ProviderObservationPosition{
+		ConnectionID: "connection-1",
+		ChunkSeq:     30,
+		UnitIndex:    1,
+		EventIndex:   1,
+	}
+	plan := replay.NewCheckpointPlan([]replay.ReplayCheckpoint{
+		{
+			ID:    "checkpoint-0001",
+			Index: 0,
+			Kind:  "turn.working",
+			Trigger: replay.CheckpointTrigger{
+				Source:   replay.CheckpointTriggerProviderObservation,
+				Position: &startedPos,
+				UnitKind: replay.ProviderInputUnitProtocolMessage,
+				Type:     "root_provider_turn.started",
+			},
+			Subjects: []replay.EntityAddress{{
+				Kind: replay.EntityKindTurn,
+				Origin: replay.EntityOrigin{
+					Source:              replay.EntityOriginProviderObservation,
+					ProviderObservation: &startedPos,
+				},
+			}},
+		},
+		{
+			ID:    "checkpoint-0003",
+			Index: 1,
+			Kind:  "turn.terminal",
+			Trigger: replay.CheckpointTrigger{
+				Source:   replay.CheckpointTriggerProviderObservation,
+				Position: &completedPos,
+				UnitKind: replay.ProviderInputUnitProtocolMessage,
+				Type:     "root_provider_turn.completed",
+			},
+			Subjects: []replay.EntityAddress{{
+				Kind: replay.EntityKindTurn,
+				Origin: replay.EntityOrigin{
+					Source:              replay.EntityOriginProviderObservation,
+					ProviderObservation: &startedPos,
+				},
+			}},
+		},
+	})
+
+	registry := newReplayEntityRegistry("session-1")
+	completedAddresses, ok := registry.providerAddressesForPlan(
+		completedPos,
+		replay.ProviderObservationEvent{
+			EventIndex:     1,
+			Type:           "root_provider_turn.completed",
+			AgentSessionID: "session-1",
+			TurnID:         "turn-1",
+			TurnPhase:      "settled",
+			TurnOutcome:    "canceled",
+		},
+		plan,
+	)
+	if !ok || len(completedAddresses) != 1 {
+		t.Fatalf("completed bind failed: %#v ok=%v", completedAddresses, ok)
+	}
+	wantAddress := providerAddress(replay.EntityKindTurn, startedPos, "")
+	if !replay.EntityAddressesEqual(completedAddresses[0], wantAddress) {
+		t.Fatalf(
+			"completed-first address=%#v want birth %#v",
+			completedAddresses[0],
+			wantAddress,
+		)
+	}
+
+	startedFP, err := replay.ObservationFingerprint(replay.ProviderObservation{
+		SchemaVersion: replay.ObservationSchemaVersion,
+		Type:          "root_provider_turn.completed",
+		Address:       wantAddress,
+		Stable: map[string]any{
+			"turnOutcome": "canceled",
+			"turnPhase":   "settled",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	actualFP, err := replay.ObservationFingerprint(replay.ProviderObservation{
+		SchemaVersion: replay.ObservationSchemaVersion,
+		Type:          "root_provider_turn.completed",
+		Address:       completedAddresses[0],
+		Stable: map[string]any{
+			"turnOutcome": "canceled",
+			"turnPhase":   "settled",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if actualFP != startedFP {
+		t.Fatalf("fingerprint diverged: got %s want %s", actualFP, startedFP)
+	}
+}

--- a/services/tuttid/service/agentsessionreplay/checkpoint_recorder_test.go
+++ b/services/tuttid/service/agentsessionreplay/checkpoint_recorder_test.go
@@ -604,3 +604,36 @@ func TestCompletedFirstTurnBindsBirthAddressFromPlan(t *testing.T) {
 		t.Fatalf("fingerprint diverged: got %s want %s", actualFP, startedFP)
 	}
 }
+
+func TestQueuedSubmitActivityBoundaryWaitsForDrainEffect(t *testing.T) {
+	if !activityIntentRequiresEffect("submit/requested") {
+		t.Fatal("submit/requested must require an effect for checkpoint boundaries")
+	}
+	if !activityIntentRequiresEffect("activation/requested") {
+		t.Fatal("activation/requested still requires an effect")
+	}
+	var recorder checkpointRecorder
+	queued := replay.ActivityEvent{
+		Kind:           replay.ActivityEventKindIntent,
+		Type:           "submit/requested",
+		EventID:        "submit-queued",
+		AgentSessionID: "session-1",
+		Payload: map[string]any{
+			"submitDiagnostics": map[string]any{"queued": true},
+		},
+	}
+	if got := recorder.completeActivityBoundary([]replay.ActivityEvent{queued}); got != nil {
+		t.Fatalf("queued submit without drain effect must suppress boundary: %#v", got)
+	}
+	drain := replay.ActivityEvent{
+		Kind:            replay.ActivityEventKindEffect,
+		Type:            "queue/sendPrompt",
+		EventID:         "send-1",
+		CausedByEventID: "submit-queued",
+		AgentSessionID:  "session-1",
+	}
+	got := recorder.completeActivityBoundary([]replay.ActivityEvent{drain})
+	if len(got) != 2 {
+		t.Fatalf("drain should complete queued submit boundary: %#v", got)
+	}
+}

--- a/services/tuttid/service/agentsessionreplay/entity_registry.go
+++ b/services/tuttid/service/agentsessionreplay/entity_registry.go
@@ -436,6 +436,18 @@ func (r *replayEntityRegistry) providerAddresses(
 	position replay.ProviderObservationPosition,
 	event replay.ProviderObservationEvent,
 ) ([]replay.EntityAddress, bool) {
+	return r.providerAddressesForPlan(position, event, replay.CheckpointPlan{})
+}
+
+// providerAddressesForPlan binds portable entity addresses for a Provider
+// observation. Turn addresses use the plan's birth observation (started /
+// subject origin) when available so completed-first replay still fingerprints
+// against the same Address recorded at started.
+func (r *replayEntityRegistry) providerAddressesForPlan(
+	position replay.ProviderObservationPosition,
+	event replay.ProviderObservationEvent,
+	plan replay.CheckpointPlan,
+) ([]replay.EntityAddress, bool) {
 	sessionID := strings.TrimSpace(event.AgentSessionID)
 	if sessionID == "" {
 		sessionID = r.rootSessionID
@@ -483,9 +495,10 @@ func (r *replayEntityRegistry) providerAddresses(
 		if turnID == "" {
 			return nil, false
 		}
+		birth := turnBirthPositionFromPlan(plan, position, event.Type)
 		address, ok := r.bindFirst(
 			turnRuntimeKey(sessionID, turnID),
-			providerAddress(replay.EntityKindTurn, position, ""),
+			providerAddress(replay.EntityKindTurn, birth, ""),
 			replayEntityBinding{
 				SessionID: sessionID,
 				TurnID:    turnID,
@@ -593,6 +606,90 @@ func runtimeKey(parts ...string) string {
 		result.WriteString(part)
 	}
 	return result.String()
+}
+
+// turnBirthPositionFromPlan picks the portable Address origin for a turn
+// observation. Fingerprints embed that Address; using the current event
+// position for completed-first replay would diverge from the Address recorded
+// when started bound first. Prefer:
+//  1. started/turn.started events → current position
+//  2. matching checkpoint subject origin at this event position
+//  3. latest started trigger on the same connection before this event
+//  4. current position (degraded)
+func turnBirthPositionFromPlan(
+	plan replay.CheckpointPlan,
+	eventPosition replay.ProviderObservationPosition,
+	eventType string,
+) replay.ProviderObservationPosition {
+	switch eventType {
+	case "turn.started", "root_provider_turn.started":
+		return eventPosition
+	}
+	for _, checkpoint := range plan.Checkpoints {
+		trigger := checkpoint.Trigger
+		if trigger.Source !=
+			replay.CheckpointTriggerProviderObservation ||
+			trigger.Position == nil ||
+			*trigger.Position != eventPosition {
+			continue
+		}
+		for _, subject := range checkpoint.Subjects {
+			if subject.Kind != replay.EntityKindTurn ||
+				subject.Origin.Source !=
+					replay.EntityOriginProviderObservation ||
+				subject.Origin.ProviderObservation == nil {
+				continue
+			}
+			return *subject.Origin.ProviderObservation
+		}
+	}
+	var best *replay.ProviderObservationPosition
+	for _, checkpoint := range plan.Checkpoints {
+		trigger := checkpoint.Trigger
+		if trigger.Source !=
+			replay.CheckpointTriggerProviderObservation ||
+			trigger.Position == nil {
+			continue
+		}
+		if trigger.Type != "turn.started" &&
+			trigger.Type != "root_provider_turn.started" {
+			continue
+		}
+		started := *trigger.Position
+		if started.ConnectionID != eventPosition.ConnectionID {
+			continue
+		}
+		if !providerObservationPositionBeforeOrEqual(
+			started,
+			eventPosition,
+		) {
+			continue
+		}
+		if best == nil ||
+			providerObservationPositionBeforeOrEqual(*best, started) {
+			copy := started
+			best = &copy
+		}
+	}
+	if best != nil {
+		return *best
+	}
+	return eventPosition
+}
+
+func providerObservationPositionBeforeOrEqual(
+	left, right replay.ProviderObservationPosition,
+) bool {
+	if left.ConnectionID != right.ConnectionID {
+		return false
+	}
+	if left.ChunkSeq != right.ChunkSeq {
+		return left.ChunkSeq < right.ChunkSeq
+	}
+	if left.UnitIndex != right.UnitIndex {
+		return left.UnitIndex < right.UnitIndex
+	}
+	return left.EventIndex <= right.EventIndex
 }
 
 func sessionRuntimeKey(sessionID string) string {

--- a/services/tuttid/service/agentsessionreplay/semantic_checkpoints_test.go
+++ b/services/tuttid/service/agentsessionreplay/semantic_checkpoints_test.go
@@ -298,6 +298,37 @@ func TestProjectBindingMatchesCanonicalCWDAndRailPlacement(t *testing.T) {
 	}
 }
 
+func TestProjectBindingMatchesNormalizesRailSectionKeySymlinks(t *testing.T) {
+	rawDir := t.TempDir()
+	canonicalDir := storesqlite.NormalizeProjectPath(rawDir)
+	if canonicalDir == "" || canonicalDir == rawDir {
+		t.Skip("temp dir has no symlink path form to exercise")
+	}
+	actual := storesqlite.Session{
+		AgentTargetID:   "local:codex",
+		Provider:        "codex",
+		Cwd:             rawDir,
+		RailSectionKind: storesqlite.RailSectionKindProject,
+		RailProjectPath: rawDir,
+		RailSectionKey:  "project:" + rawDir,
+	}
+	expected := agenthost.HistoricalSession{
+		AgentTargetID:   actual.AgentTargetID,
+		Provider:        actual.Provider,
+		Cwd:             canonicalDir,
+		RailSectionKind: actual.RailSectionKind,
+		RailProjectPath: canonicalDir,
+		RailSectionKey:  storesqlite.RailSectionKeyForProject(canonicalDir),
+	}
+	if !projectBindingMatches(actual, expected) {
+		t.Fatalf(
+			"symlink-equivalent rail section keys should match: actual=%q expected=%q",
+			actual.RailSectionKey,
+			expected.RailSectionKey,
+		)
+	}
+}
+
 func TestProjectBindingReadinessResolvesPortableExpectedState(t *testing.T) {
 	replayCWD, err := filepath.EvalSymlinks(t.TempDir())
 	if err != nil {

--- a/services/tuttid/service/agentsessionreplay/semantic_observations.go
+++ b/services/tuttid/service/agentsessionreplay/semantic_observations.go
@@ -83,9 +83,10 @@ func (s *semanticObservationState) observeBatch(
 			UnitIndex:    position.UnitIndex,
 			EventIndex:   event.EventIndex,
 		}
-		addresses, ok := s.projector.entities.providerAddresses(
+		addresses, ok := s.projector.entities.providerAddressesForPlan(
 			eventPosition,
 			event,
+			plan,
 		)
 		if !ok || len(addresses) == 0 {
 			continue

--- a/services/tuttid/service/agentsessionreplay/semantic_readiness.go
+++ b/services/tuttid/service/agentsessionreplay/semantic_readiness.go
@@ -288,8 +288,8 @@ func projectBindingMatches(
 			strings.TrimSpace(expected.RailSectionKind) &&
 		storesqlite.NormalizeProjectPath(actual.RailProjectPath) ==
 			storesqlite.NormalizeProjectPath(expected.RailProjectPath) &&
-		strings.TrimSpace(actual.RailSectionKey) ==
-			strings.TrimSpace(expected.RailSectionKey)
+		storesqlite.NormalizeRailSectionKey(actual.RailSectionKey) ==
+			storesqlite.NormalizeRailSectionKey(expected.RailSectionKey)
 }
 
 func semanticGoalStatus(state storesqlite.SessionGoalState) string {

--- a/tools/scripts/README.md
+++ b/tools/scripts/README.md
@@ -41,7 +41,9 @@ Current examples include:
 - `run-agent-gui-performance.mjs` for starting an isolated Desktop from a
   consistent backup of the developer database, running a selected AgentGUI or
   window interaction, capturing its exact trace window, and generating
-  report-only JSON and Markdown summaries
+  report-only JSON and Markdown summaries. It reuses a fresh production
+  Desktop bundle when available, so each run starts the isolated Electron
+  process directly instead of starting a new Vite renderer dev server.
 - `lark-log-tool.mjs` for fetching Feishu/Lark message file attachments or Base bug-record attachments with `lark-cli`, extracting Tutti log bundles, summarizing repeated log failures around an anchor time, and optionally watching appended warn/error lines in real time
 
   ```bash

--- a/tools/scripts/agent-session-replay-runner/ui-drive.mjs
+++ b/tools/scripts/agent-session-replay-runner/ui-drive.mjs
@@ -144,9 +144,15 @@ export async function uiDriveScenario(options) {
   let disposeDesktopShutdown = () => {};
   const checkpoints = [];
   try {
+    const scenarioStallTimeoutMs = options.stallTimeoutMs ?? 60_000;
+    // Scenario modules live in the replay-cases checkout and import their own
+    // wait helper. Pass the runner's stall policy across that module boundary.
+    process.env.TUTTI_AGENT_SESSION_REPLAY_STALL_TIMEOUT_MS = String(
+      scenarioStallTimeoutMs
+    );
     configureWaitDiagnostics({
       log,
-      stallTimeoutMs: options.stallTimeoutMs ?? 60_000
+      stallTimeoutMs: scenarioStallTimeoutMs
     });
     const scenario = await loadUiScenario(options);
     const workspaceId = "11111111-1111-4111-8111-111111111111";

--- a/tools/scripts/prepared-desktop-launch.mjs
+++ b/tools/scripts/prepared-desktop-launch.mjs
@@ -1,0 +1,125 @@
+import { spawn } from "node:child_process";
+import { access, readdir, stat } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+
+const ignoredDirectories = new Set([
+  ".git",
+  "build",
+  "dist",
+  "node_modules",
+  "out"
+]);
+
+export function isDesktopBundleFresh({ outputMtimeMs, sourceMtimeMs }) {
+  return (
+    Number.isFinite(outputMtimeMs) &&
+    Number.isFinite(sourceMtimeMs) &&
+    outputMtimeMs >= sourceMtimeMs
+  );
+}
+
+export async function ensurePreparedDesktopLaunch({ workspaceRoot, log }) {
+  const desktopRoot = join(workspaceRoot, "apps", "desktop");
+  const outputFiles = [
+    join(desktopRoot, "out", "main", "index.js"),
+    join(desktopRoot, "out", "preload", "index.cjs"),
+    join(desktopRoot, "out", "renderer", "index.html")
+  ];
+  const sourceMtimeMs = await latestSourceMtimeMs(workspaceRoot);
+  const outputMtimeMs = await oldestMtimeMs(outputFiles);
+
+  if (!isDesktopBundleFresh({ outputMtimeMs, sourceMtimeMs })) {
+    log("building prepared Desktop bundle");
+    await runCommand(
+      "pnpm",
+      ["--filter", "@tutti-os/desktop", "build"],
+      workspaceRoot
+    );
+  } else {
+    log("reusing prepared Desktop bundle");
+  }
+
+  const electronExecutable = createRequire(join(desktopRoot, "package.json"))(
+    "electron"
+  );
+  return {
+    args: [desktopRoot],
+    command: electronExecutable,
+    launchMode: "prebuilt"
+  };
+}
+
+async function latestSourceMtimeMs(workspaceRoot) {
+  const sourceRoots = [
+    join(workspaceRoot, "apps", "desktop"),
+    join(workspaceRoot, "packages"),
+    join(workspaceRoot, "config"),
+    join(workspaceRoot, "package.json"),
+    join(workspaceRoot, "pnpm-lock.yaml")
+  ];
+  let latest = 0;
+  for (const sourceRoot of sourceRoots) {
+    latest = Math.max(latest, await treeMtimeMs(sourceRoot));
+  }
+  return latest;
+}
+
+async function treeMtimeMs(path) {
+  let entry;
+  try {
+    entry = await stat(path);
+  } catch (error) {
+    if (error?.code === "ENOENT") return 0;
+    throw error;
+  }
+  if (!entry.isDirectory()) return entry.mtimeMs;
+
+  let latest = entry.mtimeMs;
+  for (const child of await readdir(path, { withFileTypes: true })) {
+    if (child.isDirectory() && ignoredDirectories.has(child.name)) continue;
+    latest = Math.max(latest, await treeMtimeMs(join(path, child.name)));
+  }
+  return latest;
+}
+
+async function oldestMtimeMs(paths) {
+  let oldest = Number.POSITIVE_INFINITY;
+  for (const path of paths) {
+    try {
+      await access(path);
+      oldest = Math.min(oldest, (await stat(path)).mtimeMs);
+    } catch (error) {
+      if (error?.code === "ENOENT") return 0;
+      throw error;
+    }
+  }
+  return oldest;
+}
+
+function runCommand(command, args, cwd) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+    child.stdout.resume();
+    let stderr = "";
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(
+        new Error(
+          `${command} ${args.join(" ")} failed (${code ?? signal ?? "unknown"})${stderr.trim() ? `: ${stderr.trim()}` : ""}`
+        )
+      );
+    });
+  });
+}

--- a/tools/scripts/run-agent-gui-performance.mjs
+++ b/tools/scripts/run-agent-gui-performance.mjs
@@ -25,6 +25,7 @@ import {
   analyzeElectronTrace,
   renderElectronTraceMarkdown
 } from "./analyze-electron-trace.mjs";
+import { ensurePreparedDesktopLaunch } from "./prepared-desktop-launch.mjs";
 import {
   agentGuiPerformanceScenarios,
   resolveAgentGuiPerformanceScenario
@@ -110,7 +111,12 @@ export async function main(argv) {
 
     await buildDaemon(daemonPath);
     const cdpPort = await reservePort();
+    const desktopLaunch = await ensurePreparedDesktopLaunch({
+      log,
+      workspaceRoot
+    });
     desktopProcess = startDesktop({
+      ...desktopLaunch,
       cdpPort,
       daemonPath,
       desktopLogPath,
@@ -476,15 +482,22 @@ export function startDesktop(input) {
   const headless = input.headless !== false;
   const command = input.command ?? "pnpm";
   const args = input.args ?? ["dev:desktop"];
+  const launchMode = input.launchMode ? `${input.launchMode} ` : "";
   log(
-    `starting ${headless ? "headless " : ""}isolated Desktop on CDP ${input.cdpPort}`
+    `starting ${headless ? "headless " : ""}${launchMode}isolated Desktop on CDP ${input.cdpPort}`
   );
   const logStream = createWriteStream(input.desktopLogPath, { flags: "w" });
+  const environment = { ...process.env };
+  if (input.launchMode === "prebuilt") {
+    delete environment.ELECTRON_ENTRY;
+    delete environment.ELECTRON_RENDERER_URL;
+    delete environment.NODE_ENV_ELECTRON_VITE;
+  }
   const child = spawn(command, args, {
     cwd: workspaceRoot,
     detached: process.platform !== "win32",
     env: {
-      ...process.env,
+      ...environment,
       ...input.environment,
       TUTTI_ANALYTICS_DISABLED: "1",
       TUTTI_DESKTOP_LOG_OUTPUT: "tee",

--- a/tools/scripts/run-agent-gui-performance.test.mjs
+++ b/tools/scripts/run-agent-gui-performance.test.mjs
@@ -18,6 +18,7 @@ import {
 import { summarizeProviderStatusFocusRefresh } from "./agent-provider-status-performance-scenario.mjs";
 import { buildAllProcessTimeProfileArgs } from "./all-process-time-profile.mjs";
 import { prepareConcurrentAgentStreamingWorkbenchSnapshot } from "./agent-gui-concurrent-streaming-performance-scenario.mjs";
+import { isDesktopBundleFresh } from "./prepared-desktop-launch.mjs";
 import {
   applyScenarioAssessment,
   findUnknownAgentTargetMigrationIDs,
@@ -42,6 +43,21 @@ test("parses the structured Desktop startup failure from process output", () => 
       },
       message: "tuttid exited"
     }
+  );
+});
+
+test("reuses a prepared Desktop bundle until source output is newer", () => {
+  assert.equal(
+    isDesktopBundleFresh({ outputMtimeMs: 20, sourceMtimeMs: 20 }),
+    true
+  );
+  assert.equal(
+    isDesktopBundleFresh({ outputMtimeMs: 19, sourceMtimeMs: 20 }),
+    false
+  );
+  assert.equal(
+    isDesktopBundleFresh({ outputMtimeMs: Number.NaN, sourceMtimeMs: 20 }),
+    false
   );
 });
 

--- a/tools/scripts/run-agent-session-replay.mjs
+++ b/tools/scripts/run-agent-session-replay.mjs
@@ -403,6 +403,7 @@ async function replayCassette(options) {
             logPath: desktopLogPath,
             mode: "replay",
             cassetteId: replayCassetteId,
+            screenshotLabel: screenshotEvidenceLabel(options.scenario),
             settleScenario,
             replayRegistrations: [
               {
@@ -601,8 +602,9 @@ async function runReplayWorkspaceOrchestration(bootstrap, options) {
       bootstrap.cassettes,
       options.timeoutMs
     );
-    const reportSurfaceReady = createReplayWorkspaceSurfaceReadyQueue(
-      async (cassette) => {
+    const runDesktopUi = createSerialAsyncQueue();
+    const reportSurfaceReady = (cassette) =>
+      runDesktopUi(async () => {
         await activateRendererReplayWorkspaceCassette(
           client,
           cassette.cassetteId,
@@ -614,8 +616,7 @@ async function runReplayWorkspaceOrchestration(bootstrap, options) {
             runtimeDirectory: bootstrap.runtime.directory
           })}\n`
         );
-      }
-    );
+      });
     const workspaceArtifactDirectory = join(
       bootstrap.runtime.directory,
       "artifacts"
@@ -631,6 +632,10 @@ async function runReplayWorkspaceOrchestration(bootstrap, options) {
           surfaceReadyReported = true;
           await reportSurfaceReady(cassette);
         };
+        const settleAgentSessionId =
+          cassette.rootAgentSessionId ||
+          cassette.action?.agentSessionId ||
+          null;
         try {
           await replayStimuli(
             bootstrap.runtime.stateDirectory,
@@ -646,18 +651,31 @@ async function runReplayWorkspaceOrchestration(bootstrap, options) {
               async onCheckpoint(checkpoint) {
                 if (options.screenshotCheckpoints) {
                   const checkpointPlan = cassette.checkpoints[checkpoint];
-                  await maybeSettleForScreenshot(
-                    cassette.settleScenario,
-                    client,
-                    options.timeoutMs,
-                    checkpointPlan
-                  );
-                  await captureCheckpointScreenshot({
-                    artifactDirectory: workspaceArtifactDirectory,
-                    cassetteId: cassette.cassetteId,
-                    checkpointIndex: checkpoint,
-                    checkpoints: cassette.checkpoints,
-                    client
+                  await runDesktopUi(async () => {
+                    await activateRendererReplayWorkspaceCassette(
+                      client,
+                      cassette.cassetteId,
+                      options.timeoutMs
+                    );
+                    await maybeSettleForScreenshot(
+                      cassette.settleScenario,
+                      client,
+                      options.timeoutMs,
+                      checkpointPlan,
+                      settleAgentSessionId
+                    );
+                    await captureCheckpointScreenshot({
+                      agentSessionId: settleAgentSessionId,
+                      artifactDirectory: workspaceArtifactDirectory,
+                      cassetteId: cassette.cassetteId,
+                      checkpointIndex: checkpoint,
+                      checkpoints: cassette.checkpoints,
+                      client,
+                      label: screenshotEvidenceLabel(cassette),
+                      prepareToolEvidence:
+                        scenarioPreparesToolEvidence(cassette.settleScenario) &&
+                        checkpointNeedsToolSettle(checkpointPlan)
+                    });
                   });
                 }
                 process.stdout.write(
@@ -696,10 +714,12 @@ async function runReplayWorkspaceOrchestration(bootstrap, options) {
                 ) {
                   return;
                 }
-                await activateRendererReplayWorkspaceCassette(
-                  client,
-                  cassette.cassetteId,
-                  options.timeoutMs
+                await runDesktopUi(() =>
+                  activateRendererReplayWorkspaceCassette(
+                    client,
+                    cassette.cassetteId,
+                    options.timeoutMs
+                  )
                 );
               }
             }
@@ -742,13 +762,18 @@ async function runReplayWorkspaceOrchestration(bootstrap, options) {
   }
 }
 
-export function createReplayWorkspaceSurfaceReadyQueue(activate) {
+export function createSerialAsyncQueue() {
   let tail = Promise.resolve();
-  return (cassette) => {
-    const current = tail.then(() => activate(cassette));
+  return (task) => {
+    const current = tail.then(() => task());
     tail = current.catch(() => undefined);
     return current;
   };
+}
+
+export function createReplayWorkspaceSurfaceReadyQueue(activate) {
+  const enqueue = createSerialAsyncQueue();
+  return (cassette) => enqueue(() => activate(cassette));
 }
 
 export function assertReplayWorkspaceSucceeded(results, managed) {
@@ -947,6 +972,8 @@ export function validateReplayWorkspaceManifest(value) {
       );
     }
     const normalized = {
+      caseId:
+        typeof cassette?.caseId === "string" ? cassette.caseId.trim() : "",
       cassetteId:
         typeof cassette?.cassetteId === "string"
           ? cassette.cassetteId.trim()
@@ -1331,9 +1358,9 @@ async function runDesktopAction(input) {
           paused: false,
           timingMode:
             process.env.TUTTI_AGENT_SESSION_REPLAY_TIMING_MODE?.trim() ===
-            "fast-forward"
-              ? "fast-forward"
-              : "realtime",
+            "realtime"
+              ? "realtime"
+              : "fast-forward",
           targetCheckpoint: null
         }
       : {})
@@ -1465,13 +1492,19 @@ async function runDesktopAction(input) {
                 input.settleScenario,
                 pageClient,
                 input.timeoutMs,
-                checkpointPlan
+                checkpointPlan,
+                input.action.agentSessionId
               );
               await captureCheckpointScreenshot({
+                agentSessionId: input.action.agentSessionId,
                 artifactDirectory: input.artifactDirectory,
                 checkpointIndex: checkpoint,
                 checkpoints: input.checkpoints,
-                client: pageClient
+                client: pageClient,
+                label: input.screenshotLabel,
+                prepareToolEvidence:
+                  scenarioPreparesToolEvidence(input.settleScenario) &&
+                  checkpointNeedsToolSettle(checkpointPlan)
               });
             }
             await input.onCheckpoint?.(checkpoint);
@@ -1574,7 +1607,8 @@ async function runDesktopAction(input) {
       settleScenario,
       pageClient,
       input.timeoutMs,
-      null
+      null,
+      input.action.agentSessionId
     );
     await captureScreenshot(
       pageClient,
@@ -2554,10 +2588,15 @@ export function createReplayPlaybackController(input) {
     : input.targetCheckpoint;
   let targetDeadline = null;
   let activityEventSequence = 0;
-  const preferFastForward =
-    process.env.TUTTI_AGENT_SESSION_REPLAY_TIMING_MODE?.trim() ===
-    "fast-forward";
-  let timingMode = preferFastForward ? "fast-forward" : "realtime";
+  const timingModeEnv =
+    process.env.TUTTI_AGENT_SESSION_REPLAY_TIMING_MODE?.trim() || "";
+  // preferFastForward: opt-in batch mode that keeps FF even after landing a
+  // checkpoint (env === "fast-forward"). Default seeking still uses FF via
+  // setFastForward, then setRealtime restores realtime on land — unless the
+  // operator explicitly requested realtime seeking for busy-queue visuals.
+  const preferFastForward = timingModeEnv === "fast-forward";
+  const forceRealtimeSeek = timingModeEnv === "realtime";
+  let timingMode = "realtime";
   const transportPlaybackPath = `/v1/agent-session-replay/cassettes/${encodeURIComponent(cassetteId)}/transport/playback`;
   const checkpointVerificationPath = (checkpointIndex) =>
     `/v1/agent-session-replay/cassettes/${encodeURIComponent(cassetteId)}/checkpoints/${checkpointIndex}/verify`;
@@ -2630,6 +2669,13 @@ export function createReplayPlaybackController(input) {
   };
 
   const setFastForward = async () => {
+    // Explicit realtime keeps seeking in realtime. Forcing FF here lets the
+    // provider finish a long busy turn before queued submit/requested intents
+    // are dispatched, so the composer queue never becomes visible.
+    if (forceRealtimeSeek) {
+      await setRealtime();
+      return;
+    }
     if (timingMode === "fast-forward") return;
     await setTransport({
       command: "set-timing-mode",
@@ -3637,16 +3683,467 @@ async function ensureReplayConversationRailExpanded(client, timeoutMs) {
   );
 }
 
-async function captureScreenshot(client, outputPath) {
-  const result = await client.send("Page.captureScreenshot", {
-    format: "png",
-    fromSurface: true
-  });
-  if (!result.data) {
-    throw new Error("CDP screenshot returned no data");
+export function normalizeScreenshotClip(rect) {
+  if (!rect || typeof rect !== "object") return null;
+  const x = Math.max(0, Math.floor(Number(rect.x)));
+  const y = Math.max(0, Math.floor(Number(rect.y)));
+  const width = Math.floor(Number(rect.width));
+  const height = Math.floor(Number(rect.height));
+  if (
+    !Number.isFinite(x) ||
+    !Number.isFinite(y) ||
+    !Number.isFinite(width) ||
+    !Number.isFinite(height) ||
+    width < 8 ||
+    height < 8
+  ) {
+    return null;
   }
-  await mkdir(dirname(outputPath), { recursive: true });
-  await writeFile(outputPath, Buffer.from(result.data, "base64"));
+  return { x, y, width, height, scale: 1 };
+}
+
+export function screenshotEvidenceLabel(source) {
+  if (typeof source === "string") {
+    return source.trim();
+  }
+  if (!source || typeof source !== "object") return "";
+  for (const key of ["caseId", "screenshotLabel", "scenario", "label"]) {
+    const value = source[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return "";
+}
+
+export async function resolveAgentSessionScreenshotClip(
+  client,
+  agentSessionId
+) {
+  const pinned =
+    typeof agentSessionId === "string" ? agentSessionId.trim() : "";
+  if (!pinned) return null;
+  const rect = await evaluate(
+    client,
+    `(() => {
+      const id = ${JSON.stringify(pinned)};
+      const detail = [...document.querySelectorAll('main[data-agent-session-id]')].find(
+        (candidate) => candidate.getAttribute('data-agent-session-id') === id
+      );
+      if (!(detail instanceof HTMLElement)) return null;
+      const shell =
+        detail.closest('[data-workbench-window-id]') instanceof HTMLElement
+          ? detail.closest('[data-workbench-window-id]')
+          : detail;
+      const box = shell.getBoundingClientRect();
+      const x = Math.max(0, box.left);
+      const y = Math.max(0, box.top);
+      const right = Math.min(window.innerWidth, box.right);
+      const bottom = Math.min(window.innerHeight, box.bottom);
+      return {
+        x,
+        y,
+        width: right - x,
+        height: bottom - y
+      };
+    })()`
+  );
+  return normalizeScreenshotClip(rect);
+}
+
+async function installEvidenceBadge(client, { agentSessionId, label }) {
+  const text = screenshotEvidenceLabel(label);
+  if (!text) return false;
+  const pinned =
+    typeof agentSessionId === "string" ? agentSessionId.trim() : "";
+  await evaluate(
+    client,
+    `(() => {
+      const text = ${JSON.stringify(text)};
+      const id = ${JSON.stringify(pinned)};
+      document
+        .querySelectorAll('[data-tutti-replay-evidence-badge="true"]')
+        .forEach((node) => node.remove());
+      const detail = id
+        ? [...document.querySelectorAll('main[data-agent-session-id]')].find(
+            (candidate) => candidate.getAttribute('data-agent-session-id') === id
+          )
+        : null;
+      const host =
+        (detail instanceof HTMLElement &&
+          detail.closest('[data-workbench-window-id]')) ||
+        detail ||
+        document.documentElement;
+      if (!(host instanceof HTMLElement)) return false;
+      if (getComputedStyle(host).position === 'static') {
+        host.style.position = 'relative';
+      }
+      const badge = document.createElement('div');
+      badge.setAttribute('data-tutti-replay-evidence-badge', 'true');
+      badge.textContent = text;
+      badge.style.cssText = [
+        'position:absolute',
+        'top:8px',
+        'left:8px',
+        'z-index:2147483647',
+        'pointer-events:none',
+        'box-sizing:border-box',
+        'padding:4px 10px',
+        'border-radius:4px',
+        'background:#111827',
+        'color:#f8fafc',
+        'font:700 14px/1.2 ui-monospace,SFMono-Regular,Menlo,monospace',
+        'letter-spacing:0.02em',
+        'box-shadow:0 1px 4px rgba(0,0,0,.45)'
+      ].join(';');
+      host.appendChild(badge);
+      return true;
+    })()`
+  );
+  return true;
+}
+
+async function removeEvidenceBadge(client) {
+  try {
+    await evaluate(
+      client,
+      `(() => {
+        document
+          .querySelectorAll('[data-tutti-replay-evidence-badge="true"]')
+          .forEach((node) => node.remove());
+        return true;
+      })()`
+    );
+  } catch {
+    // Best-effort cleanup; capture already completed or page is gone.
+  }
+}
+
+const PINNED_PAINTED_DETAIL_EXPRESSION = `(function resolvePinnedPaintedDetail(sessionId) {
+  const isPaintedAtCenter = (candidate) => {
+    if (!(candidate instanceof HTMLElement) || candidate.offsetParent === null) {
+      return false;
+    }
+    const rect = candidate.getBoundingClientRect();
+    if (
+      rect.width <= 0 ||
+      rect.height <= 0 ||
+      rect.right <= 0 ||
+      rect.bottom <= 0 ||
+      rect.left >= window.innerWidth ||
+      rect.top >= window.innerHeight
+    ) {
+      return false;
+    }
+    const x = Math.min(window.innerWidth - 1, Math.max(0, rect.left + rect.width / 2));
+    const y = Math.min(window.innerHeight - 1, Math.max(0, rect.top + rect.height / 2));
+    return document.elementsFromPoint(x, y).some(
+      (element) => element === candidate || candidate.contains(element)
+    );
+  };
+  const matches = [...document.querySelectorAll('main[data-agent-session-id]')].filter(
+    (candidate) => candidate.getAttribute('data-agent-session-id') === sessionId
+  );
+  return (
+    matches.find((candidate) => isPaintedAtCenter(candidate)) ||
+    matches.find((candidate) => {
+      if (!(candidate instanceof HTMLElement) || candidate.offsetParent === null) {
+        return false;
+      }
+      const rect = candidate.getBoundingClientRect();
+      return rect.width > 0 && rect.height > 0;
+    }) ||
+    null
+  );
+})`;
+
+async function startToolEvidenceExpandKeepAlive(client, agentSessionId) {
+  const pinned =
+    typeof agentSessionId === "string" ? agentSessionId.trim() : "";
+  if (!pinned) return false;
+  // Runner-injected only: keep re-clicking collapsed chrome every frame so
+  // virtualizer remounts cannot leave a collapsed frame for the PNG.
+  return evaluate(
+    client,
+    `(() => {
+      const id = ${JSON.stringify(pinned)};
+      const resolvePinnedPaintedDetail = ${PINNED_PAINTED_DETAIL_EXPRESSION};
+      globalThis.__tuttiToolEvidenceExpandKeepAlive = true;
+      globalThis.__tuttiToolEvidenceExpandSessionId = id;
+      if (globalThis.__tuttiToolEvidenceExpandRaf != null) {
+        return true;
+      }
+      const clickCollapsed = (nodes) => {
+        for (const node of nodes) {
+          if (!(node instanceof HTMLButtonElement)) continue;
+          if (node.getAttribute('aria-expanded') === 'true') continue;
+          node.click();
+        }
+      };
+      const tick = () => {
+        if (globalThis.__tuttiToolEvidenceExpandKeepAlive !== true) {
+          globalThis.__tuttiToolEvidenceExpandRaf = null;
+          return;
+        }
+        const detail = resolvePinnedPaintedDetail(
+          globalThis.__tuttiToolEvidenceExpandSessionId
+        );
+        if (detail instanceof HTMLElement) {
+          clickCollapsed([
+            ...detail.querySelectorAll(
+              '[data-agent-turn-work-header] button[aria-expanded]'
+            )
+          ]);
+          clickCollapsed([
+            ...detail.querySelectorAll(
+              'button.workspace-agents-status-panel__detail-tool-count[aria-expanded]'
+            )
+          ]);
+          clickCollapsed([
+            ...detail.querySelectorAll(
+              'button.workspace-agents-status-panel__detail-tool-row-head--button'
+            )
+          ]);
+        }
+        globalThis.__tuttiToolEvidenceExpandRaf = requestAnimationFrame(tick);
+      };
+      globalThis.__tuttiToolEvidenceExpandRaf = requestAnimationFrame(tick);
+      return true;
+    })()`
+  );
+}
+
+async function stopToolEvidenceExpandKeepAlive(client) {
+  try {
+    await evaluate(
+      client,
+      `(() => {
+        globalThis.__tuttiToolEvidenceExpandKeepAlive = false;
+        if (globalThis.__tuttiToolEvidenceExpandRaf != null) {
+          cancelAnimationFrame(globalThis.__tuttiToolEvidenceExpandRaf);
+          globalThis.__tuttiToolEvidenceExpandRaf = null;
+        }
+        delete globalThis.__tuttiToolEvidenceExpandSessionId;
+        return true;
+      })()`
+    );
+  } catch {
+    // Best-effort cleanup after capture.
+  }
+}
+
+export async function captureScreenshot(client, outputPath, options = {}) {
+  const agentSessionId =
+    typeof options.agentSessionId === "string"
+      ? options.agentSessionId.trim()
+      : "";
+  const label = screenshotEvidenceLabel(options.label ?? options);
+  const expandToolEvidence = Boolean(
+    options.expandToolEvidence && agentSessionId
+  );
+  const captureOnce = async (clip) => {
+    const result = await client.send("Page.captureScreenshot", {
+      format: "png",
+      fromSurface: true,
+      ...(clip ? { clip } : {})
+    });
+    if (!result.data) {
+      throw new Error("CDP screenshot returned no data");
+    }
+    return { clip, data: result.data };
+  };
+
+  if (!expandToolEvidence) {
+    const badgeInstalled = await installEvidenceBadge(client, {
+      agentSessionId,
+      label
+    });
+    try {
+      const clip = agentSessionId
+        ? await resolveAgentSessionScreenshotClip(client, agentSessionId)
+        : null;
+      const { data } = await captureOnce(clip);
+      await mkdir(dirname(outputPath), { recursive: true });
+      await writeFile(outputPath, Buffer.from(data, "base64"));
+      return { clip, outputPath };
+    } finally {
+      if (badgeInstalled) {
+        await removeEvidenceBadge(client);
+      }
+    }
+  }
+
+  // Expand → capture → verify. Remounts can collapse between settle and PNG;
+  // a runner-side rAF keep-alive re-opens chrome without touching AGUI source.
+  await startToolEvidenceExpandKeepAlive(client, agentSessionId);
+  try {
+    await prepareToolEvidenceForScreenshot(client, agentSessionId);
+    const badgeInstalled = await installEvidenceBadge(client, {
+      agentSessionId,
+      label
+    });
+    try {
+      const clip = await resolveAgentSessionScreenshotClip(
+        client,
+        agentSessionId
+      );
+      const deadline = Date.now() + 5_000;
+      let lastInspect = null;
+      while (Date.now() < deadline) {
+        // Expand + paint-check in one evaluate, then capture with no other awaits.
+        lastInspect = await evaluate(
+          client,
+          `(() => {
+            const id = ${JSON.stringify(agentSessionId)};
+            const resolvePinnedPaintedDetail = ${PINNED_PAINTED_DETAIL_EXPRESSION};
+            const detail = resolvePinnedPaintedDetail(id);
+            if (!(detail instanceof HTMLElement)) {
+              return { ready: false, reason: 'pinned-detail-missing' };
+            }
+            const clickCollapsed = (nodes) => {
+              for (const node of nodes) {
+                if (!(node instanceof HTMLElement)) continue;
+                if (node.getAttribute('aria-expanded') === 'true') continue;
+                if (typeof node.click === 'function') node.click();
+              }
+            };
+            clickCollapsed([
+              ...detail.querySelectorAll(
+                '[data-agent-turn-work-header] button[aria-expanded], [data-agent-turn-work-header] [aria-expanded]'
+              )
+            ]);
+            clickCollapsed([
+              ...detail.querySelectorAll(
+                'button.workspace-agents-status-panel__detail-tool-count[aria-expanded]'
+              )
+            ]);
+            clickCollapsed([
+              ...detail.querySelectorAll(
+                'button.workspace-agents-status-panel__detail-tool-row-head--button'
+              )
+            ]);
+            const groups = [
+              ...detail.querySelectorAll(
+                'button.workspace-agents-status-panel__detail-tool-count[aria-expanded]'
+              )
+            ];
+            const heads = [
+              ...detail.querySelectorAll(
+                'button.workspace-agents-status-panel__detail-tool-row-head--button'
+              )
+            ];
+            // No tool chrome yet (or this turn has none): do not block capture.
+            if (groups.length === 0 && heads.length === 0) {
+              return {
+                ready: true,
+                reason: 'no-tool-chrome',
+                commandVisible: false,
+                commandText: '',
+                commandRect: null,
+                toolDetailTextVisible: false,
+                openToolRevealCount: 0,
+                groupExpanded: [],
+                headExpanded: [],
+                dpr: window.devicePixelRatio,
+                viewport: { width: window.innerWidth, height: window.innerHeight }
+              };
+            }
+            const isPaintedElement = (element) => {
+              if (!(element instanceof HTMLElement) || element.offsetParent === null) {
+                return false;
+              }
+              const rect = element.getBoundingClientRect();
+              if (rect.height < 8 || rect.width < 8) return false;
+              if (
+                rect.bottom <= 0 ||
+                rect.top >= window.innerHeight ||
+                rect.right <= 0 ||
+                rect.left >= window.innerWidth
+              ) {
+                return false;
+              }
+              const x = Math.min(
+                window.innerWidth - 1,
+                Math.max(0, rect.left + rect.width / 2)
+              );
+              const y = Math.min(
+                window.innerHeight - 1,
+                Math.max(0, rect.top + rect.height / 2)
+              );
+              return document.elementsFromPoint(x, y).some(
+                (node) =>
+                  node === element ||
+                  element.contains(node) ||
+                  node.contains?.(element)
+              );
+            };
+            const openRowReveals = [
+              ...detail.querySelectorAll(
+                '.workspace-agents-status-panel__detail-tool-row .agent-collapsible-reveal[data-expanded="true"]'
+              )
+            ].filter((reveal) => isPaintedElement(reveal));
+            const commands = [
+              ...detail.querySelectorAll('[data-agent-terminal-command="true"]')
+            ];
+            const visibleCommand = commands.find((element) => {
+              if (!isPaintedElement(element)) return false;
+              return (element.textContent ?? '').trim().length > 0;
+            });
+            const commandVisible = Boolean(visibleCommand);
+            const toolDetailTextVisible = openRowReveals.some((reveal) => {
+              const text = (reveal.textContent ?? '').trim();
+              return text.length > 12;
+            });
+            return {
+              ready: commandVisible || toolDetailTextVisible,
+              reason:
+                commandVisible || toolDetailTextVisible
+                  ? 'tool-body-painted'
+                  : 'tool-body-not-painted',
+              commandVisible,
+              commandText: (visibleCommand?.textContent ?? '').trim().slice(0, 80),
+              commandRect: visibleCommand
+                ? (() => {
+                    const rect = visibleCommand.getBoundingClientRect();
+                    return {
+                      x: rect.x,
+                      y: rect.y,
+                      width: rect.width,
+                      height: rect.height
+                    };
+                  })()
+                : null,
+              toolDetailTextVisible,
+              openToolRevealCount: openRowReveals.length,
+              groupExpanded: groups.map((group) =>
+                group.getAttribute('aria-expanded')
+              ),
+              headExpanded: heads.map((head) =>
+                head.getAttribute('aria-expanded')
+              ),
+              dpr: window.devicePixelRatio,
+              viewport: { width: window.innerWidth, height: window.innerHeight }
+            };
+          })()`
+        );
+        if (!lastInspect?.ready) {
+          await delay(25);
+          continue;
+        }
+        const { data } = await captureOnce(clip);
+        await mkdir(dirname(outputPath), { recursive: true });
+        await writeFile(outputPath, Buffer.from(data, "base64"));
+        return { clip, outputPath };
+      }
+      throw new Error(
+        `timed out capturing expanded tool evidence: ${JSON.stringify(lastInspect)}`
+      );
+    } finally {
+      if (badgeInstalled) {
+        await removeEvidenceBadge(client);
+      }
+    }
+  } finally {
+    await stopToolEvidenceExpandKeepAlive(client);
+  }
 }
 
 export function replayCheckpointScreenshotPath({
@@ -3682,12 +4179,15 @@ export function replayCheckpointScreenshotPath({
     : join(artifactDirectory, `${id}.png`);
 }
 
-async function captureCheckpointScreenshot({
+export async function captureCheckpointScreenshot({
+  agentSessionId,
   artifactDirectory,
   cassetteId,
   checkpointIndex,
   checkpoints,
-  client
+  client,
+  label,
+  prepareToolEvidence = false
 }) {
   const outputPath = replayCheckpointScreenshotPath({
     artifactDirectory,
@@ -3695,7 +4195,12 @@ async function captureCheckpointScreenshot({
     checkpointIndex,
     checkpoints
   });
-  await captureScreenshot(client, outputPath);
+  const expandToolEvidence = Boolean(prepareToolEvidence && agentSessionId);
+  await captureScreenshot(client, outputPath, {
+    agentSessionId,
+    expandToolEvidence,
+    label
+  });
   log(`checkpoint screenshot: ${outputPath}`);
   return outputPath;
 }
@@ -3913,33 +4418,252 @@ export async function loadRecordScenario(options) {
 }
 
 export function checkpointNeedsToolSettle(checkpoint) {
+  if (!checkpoint) return false;
+  const kind = String(checkpoint.kind ?? "");
+  const tags = Array.isArray(checkpoint.tags) ? checkpoint.tags : [];
+  // Forced expanded-tool PNG capture is only meaningful once a tool has
+  // completed. tool.started often has no painted body yet (I10/L06 Agent
+  // tool); requiring it hard-fails replay with tool-body-not-painted.
+  return [kind, ...tags].some((token) =>
+    /(?:^|[.])tool\.completed$/u.test(String(token))
+  );
+}
+
+export function checkpointNeedsScreenshotSettle(checkpoint) {
   if (!checkpoint) return true;
   const kind = String(checkpoint.kind ?? "");
   const tags = Array.isArray(checkpoint.tags) ? checkpoint.tags : [];
   return [kind, ...tags].some((token) =>
-    /(?:^|[.])(?:tool\.completed|turn\.terminal|turn\.completed)$/u.test(
+    /(?:^|[.])(?:tool\.completed|tool\.started|turn\.terminal|turn\.completed)$/u.test(
       String(token)
     )
   );
+}
+
+export function checkpointAllowsOptionalScreenshotSettle(checkpoint) {
+  if (!checkpoint) return false;
+  const kind = String(checkpoint.kind ?? "");
+  const tags = Array.isArray(checkpoint.tags) ? checkpoint.tags : [];
+  // Queue cases soft-wait for the composer blue bar on busy-queue submits.
+  // Do not fold this into checkpointNeedsScreenshotSettle: tool-evidence
+  // settlers (I10/L06/R*) would hang for the full timeout when no tool chrome
+  // exists yet at submission.accepted.
+  return [kind, ...tags].some((token) =>
+    /(?:^|[.])submission\.accepted$/u.test(String(token))
+  );
+}
+
+export function scenarioPreparesToolEvidence(scenario) {
+  return typeof scenario?.settleForScreenshot === "function";
 }
 
 export async function maybeSettleForScreenshot(
   scenario,
   client,
   timeoutMs,
-  checkpoint = null
+  checkpoint = null,
+  agentSessionId = null
 ) {
   if (!scenario || typeof scenario.settleForScreenshot !== "function") {
     return;
   }
-  if (checkpoint && !checkpointNeedsToolSettle(checkpoint)) {
+  if (
+    checkpoint &&
+    !checkpointNeedsScreenshotSettle(checkpoint) &&
+    !checkpointAllowsOptionalScreenshotSettle(checkpoint)
+  ) {
     return;
   }
-  await scenario.settleForScreenshot({
+  const pinned =
+    typeof agentSessionId === "string" && agentSessionId.trim()
+      ? agentSessionId.trim()
+      : null;
+  if (pinned) {
+    await evaluate(
+      client,
+      `globalThis.__tuttiSettleAgentSessionId = ${JSON.stringify(pinned)}; true`
+    );
+  }
+  try {
+    await scenario.settleForScreenshot({
+      agentSessionId: pinned,
+      client,
+      timeoutMs,
+      checkpoint
+    });
+  } finally {
+    if (pinned) {
+      await evaluate(
+        client,
+        "delete globalThis.__tuttiSettleAgentSessionId; true"
+      );
+    }
+  }
+}
+
+export async function prepareToolEvidenceForScreenshot(
+  client,
+  agentSessionId,
+  timeoutMs = 5_000
+) {
+  const pinned =
+    typeof agentSessionId === "string" && agentSessionId.trim()
+      ? agentSessionId.trim()
+      : null;
+  if (!pinned) return null;
+  await evaluate(
     client,
-    timeoutMs,
-    checkpoint
-  });
+    `globalThis.__tuttiSettleAgentSessionId = ${JSON.stringify(pinned)}; true`
+  );
+  try {
+    await waitForEvaluation(
+      client,
+      `(() => {
+        const resolvePinnedPaintedDetail = ${PINNED_PAINTED_DETAIL_EXPRESSION};
+        const detail = resolvePinnedPaintedDetail(
+          globalThis.__tuttiSettleAgentSessionId
+        );
+        if (!(detail instanceof HTMLElement)) {
+          return { ready: false, reason: 'pinned-detail-missing' };
+        }
+        const clickCollapsed = (nodes) => {
+          for (const node of nodes) {
+            if (!(node instanceof HTMLElement)) continue;
+            if (node.getAttribute('aria-expanded') === 'true') continue;
+            if (typeof node.click === 'function') node.click();
+          }
+        };
+        const workToggles = [
+          ...detail.querySelectorAll(
+            '[data-agent-turn-work-header] button[aria-expanded], [data-agent-turn-work-header] [aria-expanded]'
+          )
+        ];
+        const workCollapsed = workToggles.some(
+          (toggle) => toggle.getAttribute('aria-expanded') !== 'true'
+        );
+        clickCollapsed(workToggles);
+        // Collapsed turn-work unmounts tool rows; wait a poll after expanding.
+        if (workCollapsed) {
+          return { ready: false, reason: 'expanding-work' };
+        }
+        const groups = [
+          ...detail.querySelectorAll(
+            'button.workspace-agents-status-panel__detail-tool-count[aria-expanded]'
+          )
+        ];
+        const heads = [
+          ...detail.querySelectorAll(
+            'button.workspace-agents-status-panel__detail-tool-row-head--button'
+          )
+        ];
+        const groupsCollapsed = groups.some(
+          (group) => group.getAttribute('aria-expanded') !== 'true'
+        );
+        clickCollapsed(groups);
+        if (groupsCollapsed) {
+          return { ready: false, reason: 'expanding-groups' };
+        }
+        // Heads may mount only after the group reveal opens.
+        const headsNow = [
+          ...detail.querySelectorAll(
+            'button.workspace-agents-status-panel__detail-tool-row-head--button'
+          )
+        ];
+        const headsCollapsed = headsNow.some(
+          (head) => head.getAttribute('aria-expanded') !== 'true'
+        );
+        clickCollapsed(headsNow);
+        if (headsCollapsed) {
+          return { ready: false, reason: 'expanding-heads' };
+        }
+        const hasToolChrome = groups.length > 0 || headsNow.length > 0;
+        // Text/queue turns never mount tool chrome. Do not wait forever here —
+        // that breaks C04 and other non-tool terminal screenshots.
+        if (!hasToolChrome) {
+          return { ready: true, reason: 'no-tool-chrome', hasToolChrome: false };
+        }
+        const openRowReveals = [
+          ...detail.querySelectorAll(
+            '.workspace-agents-status-panel__detail-tool-row .agent-collapsible-reveal[data-expanded="true"]'
+          )
+        ].filter((reveal) => {
+          if (!(reveal instanceof HTMLElement) || reveal.offsetParent === null) {
+            return false;
+          }
+          const rect = reveal.getBoundingClientRect();
+          if (rect.height < 8 || rect.width < 8) return false;
+          const x = Math.min(
+            window.innerWidth - 1,
+            Math.max(0, rect.left + rect.width / 2)
+          );
+          const y = Math.min(
+            window.innerHeight - 1,
+            Math.max(0, rect.top + rect.height / 2)
+          );
+          return document.elementsFromPoint(x, y).some(
+            (node) =>
+              node === reveal || reveal.contains(node) || node.contains?.(reveal)
+          );
+        });
+        const commands = [
+          ...detail.querySelectorAll('[data-agent-terminal-command="true"]')
+        ];
+        const commandVisible = commands.some((element) => {
+          if (!(element instanceof HTMLElement) || element.offsetParent === null) {
+            return false;
+          }
+          const rect = element.getBoundingClientRect();
+          if (rect.height < 8 || rect.width < 8) return false;
+          if (
+            rect.bottom <= 0 ||
+            rect.top >= window.innerHeight ||
+            rect.right <= 0 ||
+            rect.left >= window.innerWidth
+          ) {
+            return false;
+          }
+          const x = Math.min(
+            window.innerWidth - 1,
+            Math.max(0, rect.left + rect.width / 2)
+          );
+          const y = Math.min(
+            window.innerHeight - 1,
+            Math.max(0, rect.top + rect.height / 2)
+          );
+          const painted = document.elementsFromPoint(x, y).some(
+            (node) =>
+              node === element ||
+              element.contains(node) ||
+              node.contains?.(element)
+          );
+          if (!painted) return false;
+          return (element.textContent ?? '').trim().length > 0;
+        });
+        const toolDetailTextVisible = openRowReveals.some((reveal) => {
+          const text = (reveal.textContent ?? '').trim();
+          return text.length > 12;
+        });
+        return {
+          ready: commandVisible || toolDetailTextVisible,
+          openToolRevealCount: openRowReveals.length,
+          commandVisible,
+          toolDetailTextVisible,
+          hasToolChrome,
+          groupExpanded: groups.map((group) => group.getAttribute('aria-expanded')),
+          headExpanded: headsNow.map((head) => head.getAttribute('aria-expanded'))
+        };
+      })()`,
+      timeoutMs,
+      "pre-screenshot tool evidence",
+      25
+    );
+  } finally {
+    await evaluate(
+      client,
+      "delete globalThis.__tuttiSettleAgentSessionId; true"
+    );
+  }
+  return null;
 }
 
 function setMode(options, mode, directory) {

--- a/tools/scripts/run-agent-session-replay.test.mjs
+++ b/tools/scripts/run-agent-session-replay.test.mjs
@@ -37,11 +37,18 @@ import {
   createReplayActivityClock,
   createReplayPlaybackController,
   createReplayWorkspaceSurfaceReadyQueue,
+  createSerialAsyncQueue,
+  maybeSettleForScreenshot,
   validateReplayCheckpointPlan,
   assertReplayWorkspaceSucceeded,
   checkpointNeedsToolSettle,
+  checkpointNeedsScreenshotSettle,
+  captureCheckpointScreenshot,
+  captureScreenshot,
+  normalizeScreenshotClip,
   parseArgs,
   resolveDesktopHeadless,
+  resolveAgentSessionScreenshotClip,
   replayCheckpointScreenshotPath,
   replayControlRouter,
   replayPendingInteraction,
@@ -56,6 +63,7 @@ import {
   replayWorkspaceInitialTargetCheckpoint,
   managedReplayFailure,
   loadRecordScenario,
+  screenshotEvidenceLabel,
   submitRequestedRequiresSessionIdle,
   validateAction,
   validateReplayWorkspaceManifest,
@@ -254,6 +262,65 @@ test("Replay Workspace continues Surface readiness after one failure", async () 
   await assert.rejects(first, /first Surface failed/u);
   await second;
   assert.deepEqual(events, ["cassette-1", "cassette-2"]);
+});
+
+test("createSerialAsyncQueue runs Desktop UI tasks one at a time", async () => {
+  const events = [];
+  let releaseFirst;
+  const firstGate = new Promise((resolve) => {
+    releaseFirst = resolve;
+  });
+  const enqueue = createSerialAsyncQueue();
+  const first = enqueue(async () => {
+    events.push("start:a");
+    await firstGate;
+    events.push("end:a");
+  });
+  const second = enqueue(async () => {
+    events.push("start:b");
+    events.push("end:b");
+  });
+  await Promise.resolve();
+  assert.deepEqual(events, ["start:a"]);
+  releaseFirst();
+  await Promise.all([first, second]);
+  assert.deepEqual(events, ["start:a", "end:a", "start:b", "end:b"]);
+});
+
+test("maybeSettleForScreenshot pins and clears settle agent session id", async () => {
+  const expressions = [];
+  const client = {
+    async send(method, params) {
+      assert.equal(method, "Runtime.evaluate");
+      expressions.push(params.expression);
+      return { result: { value: true } };
+    }
+  };
+  let settleSawPin = false;
+  await maybeSettleForScreenshot(
+    {
+      async settleForScreenshot() {
+        settleSawPin = expressions.some((expression) =>
+          expression.includes("__tuttiSettleAgentSessionId = ")
+        );
+      }
+    },
+    client,
+    1_000,
+    { kind: "tool.completed", tags: ["tool.completed"] },
+    "session-r03"
+  );
+  assert.equal(settleSawPin, true);
+  assert.ok(
+    expressions.some((expression) =>
+      expression.includes('__tuttiSettleAgentSessionId = "session-r03"')
+    )
+  );
+  assert.ok(
+    expressions.some((expression) =>
+      expression.includes("delete globalThis.__tuttiSettleAgentSessionId")
+    )
+  );
 });
 
 test("replay rebases recorded Turn identities before Engine intents", async () => {
@@ -1978,6 +2045,173 @@ test("checkpoint screenshot paths stay Cassette-scoped in a Replay Workspace", (
   );
 });
 
+test("normalizeScreenshotClip rejects tiny or invalid rects", () => {
+  assert.equal(normalizeScreenshotClip(null), null);
+  assert.equal(
+    normalizeScreenshotClip({ x: 0, y: 0, width: 4, height: 100 }),
+    null
+  );
+  assert.deepEqual(
+    normalizeScreenshotClip({ x: 10.9, y: 20.1, width: 300.7, height: 400.2 }),
+    { x: 10, y: 20, width: 300, height: 400, scale: 1 }
+  );
+});
+
+test("screenshotEvidenceLabel prefers caseId over scenario", () => {
+  assert.equal(screenshotEvidenceLabel(" C03 "), "C03");
+  assert.equal(
+    screenshotEvidenceLabel({ caseId: "C03", scenario: "c03" }),
+    "C03"
+  );
+  assert.equal(screenshotEvidenceLabel({ scenario: "c03" }), "c03");
+  assert.equal(screenshotEvidenceLabel({}), "");
+});
+
+test("captureScreenshot clips to the pinned Agent Session and stamps a case badge", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "asr-clip-shot-"));
+  const outputPath = join(directory, "checkpoint.png");
+  const evaluations = [];
+  const captures = [];
+  const client = {
+    async send(method, params) {
+      if (method === "Runtime.evaluate") {
+        evaluations.push(params.expression);
+        if (params.expression.includes("getBoundingClientRect")) {
+          return {
+            result: {
+              value: { x: 120.4, y: 40.6, width: 640.8, height: 800.2 }
+            }
+          };
+        }
+        return { result: { value: true } };
+      }
+      if (method === "Page.captureScreenshot") {
+        captures.push(params);
+        // 1x1 PNG
+        return {
+          data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+        };
+      }
+      throw new Error(`unexpected CDP method: ${method}`);
+    }
+  };
+
+  const result = await captureScreenshot(client, outputPath, {
+    agentSessionId: "session-left",
+    label: "C03"
+  });
+  assert.deepEqual(result.clip, {
+    x: 120,
+    y: 40,
+    width: 640,
+    height: 800,
+    scale: 1
+  });
+  assert.equal(captures.length, 1);
+  assert.deepEqual(captures[0].clip, result.clip);
+  assert.ok(
+    evaluations.some((expression) =>
+      expression.includes('data-tutti-replay-evidence-badge="true"')
+    )
+  );
+  assert.ok(evaluations.some((expression) => expression.includes('"C03"')));
+  assert.ok(
+    evaluations.some((expression) =>
+      expression.includes(
+        "querySelectorAll('[data-tutti-replay-evidence-badge="
+      )
+    )
+  );
+  assert.equal((await readFile(outputPath)).length > 0, true);
+});
+
+test("captureScreenshot falls back to a full-page shot when the session rect is missing", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "asr-full-shot-"));
+  const outputPath = join(directory, "checkpoint.png");
+  const captures = [];
+  const client = {
+    async send(method, params) {
+      if (method === "Runtime.evaluate") {
+        if (params.expression.includes("getBoundingClientRect")) {
+          return { result: { value: null } };
+        }
+        return { result: { value: true } };
+      }
+      if (method === "Page.captureScreenshot") {
+        captures.push(params);
+        return {
+          data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+        };
+      }
+      throw new Error(`unexpected CDP method: ${method}`);
+    }
+  };
+
+  const result = await captureScreenshot(client, outputPath, {
+    agentSessionId: "missing-session",
+    label: "C05"
+  });
+  assert.equal(result.clip, null);
+  assert.equal(captures.length, 1);
+  assert.equal(captures[0].clip, undefined);
+});
+
+test("captureCheckpointScreenshot keeps Cassette path and forwards clip identity", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "asr-checkpoint-shot-"));
+  const captures = [];
+  const client = {
+    async send(method, params) {
+      if (method === "Runtime.evaluate") {
+        if (params.expression.includes("getBoundingClientRect")) {
+          return {
+            result: { value: { x: 0, y: 0, width: 200, height: 300 } }
+          };
+        }
+        return { result: { value: true } };
+      }
+      if (method === "Page.captureScreenshot") {
+        captures.push(params);
+        return {
+          data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+        };
+      }
+      throw new Error(`unexpected CDP method: ${method}`);
+    }
+  };
+
+  const outputPath = await captureCheckpointScreenshot({
+    agentSessionId: "session-a",
+    artifactDirectory: directory,
+    cassetteId: "cassette-a",
+    checkpointIndex: 0,
+    checkpoints: [{ id: "checkpoint-0007" }],
+    client,
+    label: "R12"
+  });
+  assert.equal(
+    outputPath,
+    join(directory, "cassette-a", "checkpoint-0007.png")
+  );
+  assert.deepEqual(captures[0]?.clip, {
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 300,
+    scale: 1
+  });
+});
+
+test("resolveAgentSessionScreenshotClip returns null without a session id", async () => {
+  assert.equal(
+    await resolveAgentSessionScreenshotClip({ send() {} }, ""),
+    null
+  );
+  assert.equal(
+    await resolveAgentSessionScreenshotClip({ send() {} }, null),
+    null
+  );
+});
+
 test("record arguments accept an external scenario file", () => {
   const options = parseArgs([
     "--record",
@@ -2008,7 +2242,36 @@ test("replay arguments accept an optional scenario file for screenshot settle", 
 });
 
 test("checkpoint settle targets completed tool and terminal turn checkpoints", () => {
-  assert.equal(checkpointNeedsToolSettle(null), true);
+  assert.equal(checkpointNeedsScreenshotSettle(null), true);
+  assert.equal(
+    checkpointNeedsScreenshotSettle({
+      kind: "tool.completed",
+      tags: ["tool.completed"]
+    }),
+    true
+  );
+  assert.equal(
+    checkpointNeedsScreenshotSettle({
+      kind: "turn.terminal",
+      tags: ["turn.terminal"]
+    }),
+    true
+  );
+  assert.equal(
+    checkpointNeedsScreenshotSettle({
+      kind: "submission.accepted",
+      tags: ["submission.accepted"]
+    }),
+    false
+  );
+  assert.equal(
+    checkpointNeedsScreenshotSettle({
+      kind: "turn.working",
+      tags: ["turn.working"]
+    }),
+    false
+  );
+  assert.equal(checkpointNeedsToolSettle(null), false);
   assert.equal(
     checkpointNeedsToolSettle({
       kind: "tool.completed",
@@ -2018,13 +2281,16 @@ test("checkpoint settle targets completed tool and terminal turn checkpoints", (
   );
   assert.equal(
     checkpointNeedsToolSettle({
+      kind: "tool.started",
+      tags: ["tool.started"]
+    }),
+    false
+  );
+  assert.equal(
+    checkpointNeedsToolSettle({
       kind: "turn.terminal",
       tags: ["turn.terminal"]
     }),
-    true
-  );
-  assert.equal(
-    checkpointNeedsToolSettle({ kind: "tool.started", tags: ["tool.started"] }),
     false
   );
   assert.equal(
@@ -2172,6 +2438,7 @@ test("Replay Workspace manifest rejects duplicate cassette and root Session", ()
     {
       cassettes: [
         {
+          caseId: "",
           cassetteDirectory: join(process.cwd(), ".tmp", "portable-cassette"),
           cassetteId: "",
           rootAgentSessionId: "",
@@ -2182,6 +2449,18 @@ test("Replay Workspace manifest rejects duplicate cassette and root Session", ()
       playbackMode: "manual",
       workspaceId: null
     }
+  );
+  assert.equal(
+    validateReplayWorkspaceManifest({
+      playbackMode: "automatic",
+      cassettes: [
+        {
+          caseId: "C03",
+          cassetteDirectory: ".tmp/c03"
+        }
+      ]
+    }).cassettes[0]?.caseId,
+    "C03"
   );
 });
 


### PR DESCRIPTION
## Summary
- preserve provider turn birth identity across replay observations and checkpoint correlations
- normalize symlink-equivalent project paths and rail keys during restore and semantic readiness
- stabilize queued-submit replay timing, serialized Desktop UI capture, and Agent Session screenshot evidence

## Tests
- `pnpm check:changed`
- `pnpm test:tools`
- `go test ./...` in `packages/agent/store-sqlite`
- targeted `go test` in `services/tuttid`
- `pnpm --filter @tutti-os/desktop test`

## Notes
- The final branch is based on `origin/main` and contains the two local Agent Session Replay fixes required by the current workspace.
- No additional durable documentation impact was found beyond the updated Agent Session Replay architecture and tools README.