### PR TITLE
feat(connector-market): add shared domain foundation

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,6 +11,7 @@
       "@tutti-os/analytics",
       "@tutti-os/analytics-debug",
       "@tutti-os/event-stream-core",
+      "@tutti-os/connector-market",
       "@tutti-os/workspace-file-manager",
       "@tutti-os/workspace-file-reference",
       "@tutti-os/workspace-issue-manager",

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -30,6 +30,7 @@ Stable change rules live in [Conventions](../conventions/README.md).
 
 ## Desktop And Transport
 
+- [Connector Market](./connector-market.md)
 - [Desktop Backend Access](./desktop-backend-access.md)
 - [Desktop Update Admission](./desktop-update-admission.md)
 - [Desktop Transport](./desktop-transport.md)

--- a/docs/architecture/connector-market.md
+++ b/docs/architecture/connector-market.md
@@ -1,0 +1,84 @@
+# Connector Market
+
+The connector market is a shared desktop-daemon domain owned by
+`packages/connector/market`. Tutti is the source repository and first host;
+other hosts consume exact released Go and npm package versions.
+
+## Ownership
+
+The public package owns:
+
+- connector, catalog, installation, authorization, compatibility, workspace
+  binding, durable operation, revision, and error contracts
+- Go state transitions, manifest validation, host ports, and the application
+  service boundary
+- the reusable OpenAPI fragment under
+  `openapi/connector-market.v1.yaml`
+- the renderer `ConnectorMarketBackend` contract and Valtio-backed domain
+  service
+
+Each host daemon owns:
+
+- local persistence and transactions
+- accepted catalog snapshots and upstream authentication
+- artifact download, verification, installation, activation, and recovery
+- secure credential storage and authorization callbacks
+- transport DTO mapping, event publication, product compatibility policy,
+  logging, and diagnostics
+
+Each renderer host owns the generated daemon client and the adapter that maps
+wire DTOs into `@tutti-os/connector-market` domain types. The public renderer
+package never constructs a daemon client and never reads preload or window
+globals.
+
+The renderer domain follows the same service boundary as TSH Room Chat:
+
+- `IConnectorMarketService` is the typed DI contract and
+  `ConnectorMarketService` is the constructor-injected class implementation
+- `readonly dataStore = proxy(...)` is the only writable renderer state source;
+  only the owning service mutates it
+- `start()` owns long-lived event subscription setup, while host startup jobs
+  decide when to call it and when to perform the initial load
+- asynchronous responses are fenced by request sequence, workspace generation,
+  and daemon revision; `dispose()` is idempotent and terminal
+- React subscribes at the rendering leaf and does not own transport, startup, or
+  disposal
+
+## Data flow
+
+```text
+upstream catalog
+    -> host daemon CatalogSource
+    -> accepted daemon snapshot and durable operations
+    -> host aggregate OpenAPI
+    -> generated host client
+    -> host ConnectorMarketBackend adapter
+    -> shared Valtio service
+    -> host UI
+```
+
+The local daemon is authoritative. Business events carry connector key,
+operation id, and revision only as invalidation hints. Renderers re-read the
+daemon before applying newer state.
+
+## OpenAPI reuse
+
+Host aggregate documents compose the same fragment instead of copying paths or
+schemas. Tutti may reference the repository path. External hosts resolve the
+fragment exported by an exact installed `@tutti-os/connector-market` version.
+The OpenAPI generator rejects malformed references and merge conflicts.
+
+The aggregate document continues to own server URLs, security, and
+product-only routes. The fragment owns common connector-market paths, DTOs,
+enums, revisions, operations, and error codes.
+
+## State boundaries
+
+Installation, authorization, compatibility, and catalog freshness are
+independent state machines. A connector can therefore be installed but
+disconnected, supported but stale, or visible but blocked by an unsupported
+implementation without overloading one ambiguous status field.
+
+Credentials and sensitive implementation configuration are never part of the
+renderer projection. Unknown implementation kinds remain visible as
+`unsupported_implementation` but cannot be installed.

--- a/docs/architecture/project-structure.md
+++ b/docs/architecture/project-structure.md
@@ -185,6 +185,20 @@ Product policy transport, normal update preferences, release feeds, download
 URLs, window assets, logging sinks, and business-window enumeration remain in
 the consuming desktop app.
 
+### `packages/connector/*`
+
+Connector packages own host-neutral connector domain boundaries shared across
+desktop daemons.
+
+Current packages:
+
+- `packages/connector/market`: connector catalog, installation,
+  authorization, compatibility, workspace-binding, operation, OpenAPI, and
+  renderer state contracts shared by Tutti and external hosts
+
+Catalog endpoints, local persistence, credentials, installation directories,
+generated daemon clients, and product integration remain in host adapters.
+
 ### `services/tuttid`
 
 `services/tuttid` is the primary business core.

--- a/docs/conventions/npm-package-release.md
+++ b/docs/conventions/npm-package-release.md
@@ -19,6 +19,7 @@ The current fixed release group is:
 @tutti-os/analytics
 @tutti-os/analytics-debug
 @tutti-os/event-stream-core
+@tutti-os/connector-market
 @tutti-os/workspace-file-manager
 @tutti-os/workspace-file-reference
 @tutti-os/workspace-issue-manager
@@ -164,6 +165,7 @@ pnpm add @tutti-os/workspace-file-reference@beta
 pnpm add @tutti-os/workspace-file-preview@beta
 pnpm add @tutti-os/workspace-file-manager@beta
 pnpm add @tutti-os/workspace-issue-manager@beta
+pnpm add @tutti-os/connector-market@beta
 pnpm add @tutti-os/workspace-app-center@beta
 pnpm add @tutti-os/workspace-terminal@beta
 pnpm add @tutti-os/workbench-electron@beta
@@ -323,6 +325,11 @@ The stable package entrypoints are:
 @tutti-os/ui-rich-text/plugins
 @tutti-os/ui-rich-text/types
 @tutti-os/ui-react-hooks
+@tutti-os/connector-market
+@tutti-os/connector-market/contracts
+@tutti-os/connector-market/openapi/connector-market.v1.yaml
+@tutti-os/connector-market/react
+@tutti-os/connector-market/services
 @tutti-os/workspace-app-center
 @tutti-os/workspace-app-center/contracts
 @tutti-os/workspace-app-center/core

--- a/docs/specs/2026-08-03-connector-market-shared-domain.md
+++ b/docs/specs/2026-08-03-connector-market-shared-domain.md
@@ -1,0 +1,57 @@
+# Connector Market Shared Domain
+
+Status: accepted architecture, implementation in progress.
+
+## Goal
+
+Make Tutti the source repository for one connector-market capability that runs
+inside both tuttidd and the TSH desktop daemon. Both hosts share domain
+semantics and HTTP contracts while keeping independent local state and
+product-specific adapters.
+
+## Target shape
+
+`packages/connector/market` publishes a Go module and npm package in the shared
+package release cohort. It owns the OpenAPI fragment, Go domain boundary, and
+Valtio renderer domain service. Each host composes the fragment, generates its
+own transport, implements daemon ports, and injects a renderer backend adapter.
+
+The renderer never reaches an upstream catalog and the public package never
+constructs a host HTTP client. The local daemon is the authoritative source for
+accepted catalog data, installation state, authorization state, workspace
+bindings, and durable operations.
+
+## Delivery sequence
+
+1. Establish and validate the public Go, OpenAPI, and TypeScript contracts.
+2. Implement the Go application service and conformance suite.
+3. Implement tuttidd persistence, catalog, installer, authorization, event,
+   transport, and generated-client adapters.
+4. Integrate the Tutti renderer and UI through the generated client adapter.
+5. Publish one exact package release cohort.
+6. Install the exact Go and npm versions in TSH, compose the same OpenAPI
+   fragment, and implement TSH host adapters.
+7. Retire the legacy market route after compatibility validation.
+
+TSH may temporarily adapt its existing `tsh-server -> zk-admin-server` market
+chain behind `CatalogSource`. That compatibility adapter must not leak into the
+shared renderer contract or become the target architecture.
+
+## Current implementation checkpoint
+
+The first checkpoint includes:
+
+- public package and release registration
+- shared domain types, state transitions, manifest validation, ports, and an
+  application service that owns revision fencing, request idempotency,
+  per-connector operation exclusion, durable operation execution, and recovery
+- shared OpenAPI fragment
+- package-resolved OpenAPI fragment support for cross-repository hosts
+- Valtio service with invalidation re-reads, stale-response fencing,
+  single-flight refresh, per-connector mutation locks, workspace switching, and
+  the class/interface/dataStore/start/dispose renderer-service convention used
+  by TSH Room Chat
+
+The fragment is not added to the tuttidd aggregate until the daemon service,
+persistence, and handlers exist. This avoids publishing generated routes that
+return placeholder responses.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -9,7 +9,7 @@ Specs are not the source of truth for behavior that has already landed. When a
 spec completes, update the current document that owns the result and delete the
 dated plan.
 
-There are currently seven active specs:
+There are currently eight active specs:
 
 - [Agent Provider Status Read/Detect Split](./2026-06-28-agent-status-read-detect-split-design.md): pending review.
 - [Agent Extension Package Design](./2026-07-14-agent-extension-package-design.md): pending architecture and implementation approval.
@@ -18,3 +18,4 @@ There are currently seven active specs:
 - [Mobile AgentGUI And DeviceLink Design](./2026-07-23-mobile-agentgui-device-link-design.md): accepted architecture; Android M0 transport slice passed, physical-network validation and M1+ remain active.
 - [Agent Session Fork Design](./2026-07-27-agent-session-fork-design.md): throughTurn implemented; supersedes the 2026-07-01 draft and implementation plan.
 - [Tutti Agent `skills/list` Integration](./2026-07-30-tutti-agent-skills-list-integration.md): implemented; local Desktop end-to-end validation passed, pending cross-platform artifact validation.
+- [Connector Market Shared Domain](./2026-08-03-connector-market-shared-domain.md): accepted architecture; public contract foundation is in progress before tuttidd and TSH host-adapter rollout.

--- a/go.work
+++ b/go.work
@@ -14,6 +14,8 @@ use ./packages/device-link
 
 use ./packages/desktop/update-admission
 
+use ./packages/connector/market
+
 use ./apps/cli
 
 use ./packages/workbench/service

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -26,6 +26,7 @@ If you are editing `packages/ui/*`, also read [packages/ui/AGENTS.md](ui/AGENTS.
 ## Package groups
 
 - `clients/*`: shared domain-specific clients
+- `connector/*`: reusable connector-domain contracts and application cores shared by daemon hosts
 - `device-link`: shared ICE/QUIC peer transport, product-neutral Relay stream mechanics, and gomobile boundary
 - `events/*`: shared schema-first business event protocol contracts and generated transport metadata
 - `agent/*`: Agent lifecycle Host, canonical store, frontend activity engine, replication contract, and GUI boundaries
@@ -41,6 +42,7 @@ If you are editing `packages/ui/*`, also read [packages/ui/AGENTS.md](ui/AGENTS.
 - name packages by responsibility, not by audience
 - avoid vague names such as `shared`, `common`, `utils`, or `client-sdk`
 - keep `clients/*` focused on domain-specific access patterns
+- keep `connector/*` focused on host-neutral connector semantics, contracts, and state; concrete catalog endpoints, persistence, credentials, installation directories, and generated daemon clients stay in host adapters
 - keep `device-link` transport-only: it may own candidate selection, authenticated peer streams, generation-fenced admission, product-neutral pooling/racing/probe mechanics, WebSocket/yamux Relay byte-stream mechanics, and platform build boundaries, but not account, pairing, rendezvous, path-specific authentication, Relay authorization or product policy, or Agent/Workspace DTOs
 - keep `events/*` focused on repository-owned business event protocol contracts, topic catalogs, generated validators, and transport metadata rather than socket lifecycle or daemon business workflows
 - keep `browser/*` focused on browser mechanics, workbench node integration, bridge shape, Electron webview guest management, and package-local i18n defaults; host product globals, backend-token access, preview proxy behavior, and business bridge methods stay in host adapters

--- a/packages/connector/market/README.md
+++ b/packages/connector/market/README.md
@@ -1,0 +1,80 @@
+# @tutti-os/connector-market
+
+`@tutti-os/connector-market` is the host-neutral connector-market boundary
+shared by Tutti and other approved desktop daemon hosts such as TSH.
+
+The package deliberately owns three matching contracts:
+
+- `daemon`: Go domain types, state transitions, manifest validation, ports, and
+  the application service boundary
+- `openapi/connector-market.v1.yaml`: the HTTP fragment composed by each host
+  daemon's aggregate OpenAPI document
+- `services`: a Valtio-backed renderer domain service driven by an injected
+  `ConnectorMarketBackend`
+
+The package does not construct an HTTP client, read Electron globals, choose a
+catalog endpoint, persist credentials, select install directories, or own a
+host database. Those responsibilities remain in the consuming daemon and
+renderer adapters.
+
+## Renderer usage
+
+```ts
+import { ConnectorMarketService } from "@tutti-os/connector-market/services";
+
+const connectorMarket = new ConnectorMarketService({
+  backend: hostConnectorMarketBackend,
+  events: hostConnectorMarketEvents,
+  workspaceId
+});
+
+connectorMarket.start();
+await connectorMarket.ensureLoaded();
+```
+
+The backend adapter wraps the host's generated daemon client and maps transport
+DTOs into package domain types. Daemon events are invalidation hints; the
+service re-reads the authoritative daemon snapshot before publishing new state.
+The service follows the shared renderer-domain convention: it is a constructor-
+injected class, exposes its only writable state source as `readonly dataStore`,
+owns asynchronous commands directly, and has explicit idempotent `start()` and
+`dispose()` lifecycle methods. React consumers subscribe to `dataStore`; they do
+not start transports or data loads.
+
+## OpenAPI composition
+
+Inside this repository, the aggregate document may use a repository path:
+
+```yaml
+x-tutti-openapi-fragments:
+  - packages/connector/market/openapi/connector-market.v1.yaml
+```
+
+External hosts install an exact released package version and resolve the
+exported fragment through package exports:
+
+```yaml
+x-tutti-openapi-fragments:
+  - package: "@tutti-os/connector-market"
+    path: "openapi/connector-market.v1.yaml"
+```
+
+Do not copy the fragment into another repository or reference a Tutti worktree.
+
+## Go host boundary
+
+The Go module path is:
+
+```text
+github.com/tutti-os/tutti/packages/connector/market
+```
+
+Host daemons implement repository, catalog, artifact installation,
+authorization, scheduling, and event ports. The public package owns shared
+state semantics; host adapters own storage and product integration.
+
+`Repository.Transaction` must be atomic and advance the daemon-wide market
+revision monotonically. `ArtifactInstaller`, `AuthorizationProvider`, and
+`OperationScheduler` must be idempotent for the operation or client request id
+they receive because daemon recovery can replay accepted or running work after
+a crash.

--- a/packages/connector/market/daemon/application.go
+++ b/packages/connector/market/daemon/application.go
@@ -1,0 +1,637 @@
+package daemon
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type ApplicationConfig struct {
+	Repository             Repository
+	CatalogSource          CatalogSource
+	Installer              ArtifactInstaller
+	Authorization          AuthorizationProvider
+	Compatibility          CompatibilityEvaluator
+	Scheduler              OperationScheduler
+	Events                 EventPublisher
+	ImplementationRegistry ImplementationRegistry
+	Now                    func() time.Time
+	NewID                  func() (string, error)
+}
+
+type Application struct {
+	config ApplicationConfig
+}
+
+var _ Service = (*Application)(nil)
+
+func NewApplication(config ApplicationConfig) (*Application, error) {
+	if config.Repository == nil {
+		return nil, errors.New("connector market repository is required")
+	}
+	if config.CatalogSource == nil {
+		return nil, errors.New("connector market catalog source is required")
+	}
+	if config.Installer == nil {
+		return nil, errors.New("connector market artifact installer is required")
+	}
+	if config.Authorization == nil {
+		return nil, errors.New("connector market authorization provider is required")
+	}
+	if config.Compatibility == nil {
+		return nil, errors.New("connector market compatibility evaluator is required")
+	}
+	if config.Scheduler == nil {
+		return nil, errors.New("connector market operation scheduler is required")
+	}
+	if config.Events == nil {
+		return nil, errors.New("connector market event publisher is required")
+	}
+	if config.Now == nil {
+		config.Now = time.Now
+	}
+	if config.NewID == nil {
+		config.NewID = randomID
+	}
+	return &Application{config: config}, nil
+}
+
+func (application *Application) Snapshot(ctx context.Context, workspaceID string) (Snapshot, error) {
+	return application.config.Repository.Snapshot(ctx, workspaceID)
+}
+
+func (application *Application) GetConnector(
+	ctx context.Context,
+	connectorKey string,
+	workspaceID string,
+) (Connector, error) {
+	if strings.TrimSpace(connectorKey) == "" {
+		return Connector{}, invalidRequest("connectorKey is required")
+	}
+	return application.config.Repository.Connector(ctx, connectorKey, workspaceID)
+}
+
+func (application *Application) GetOperation(ctx context.Context, operationID string) (Operation, error) {
+	if strings.TrimSpace(operationID) == "" {
+		return Operation{}, invalidRequest("operationID is required")
+	}
+	return application.config.Repository.Operation(ctx, operationID)
+}
+
+func (application *Application) RefreshCatalog(
+	ctx context.Context,
+	mutation Mutation,
+) (MutationResult, error) {
+	return application.acceptOperation(ctx, mutation, OperationKindRefreshCatalog, "")
+}
+
+func (application *Application) Install(
+	ctx context.Context,
+	mutation ConnectorMutation,
+) (MutationResult, error) {
+	var target InstallationState
+	result, err := application.acceptConnectorOperation(
+		ctx,
+		mutation,
+		OperationKindInstall,
+		func(connector Connector) (Connector, error) {
+			if connector.Compatibility.State != CompatibilityStateSupported {
+				return Connector{}, NewDomainError(
+					ErrorCodeIncompatible,
+					"connector is not compatible with this host",
+					false,
+					nil,
+				)
+			}
+			if connector.Installation.State == InstallationStateInstalled {
+				target = InstallationStateUpdating
+			} else {
+				target = InstallationStateInstalling
+			}
+			if !CanTransitionInstallation(connector.Installation.State, target) {
+				return Connector{}, invalidTransition("installation", string(connector.Installation.State), string(target))
+			}
+			connector.Installation.State = target
+			connector.Installation.FailureCode = ""
+			return connector, nil
+		},
+	)
+	return result, err
+}
+
+func (application *Application) Uninstall(
+	ctx context.Context,
+	mutation ConnectorMutation,
+) (MutationResult, error) {
+	return application.acceptConnectorOperation(
+		ctx,
+		mutation,
+		OperationKindUninstall,
+		func(connector Connector) (Connector, error) {
+			if !CanTransitionInstallation(connector.Installation.State, InstallationStateUninstalling) {
+				return Connector{}, invalidTransition(
+					"installation",
+					string(connector.Installation.State),
+					string(InstallationStateUninstalling),
+				)
+			}
+			connector.Installation.State = InstallationStateUninstalling
+			connector.Installation.FailureCode = ""
+			return connector, nil
+		},
+	)
+}
+
+func (application *Application) BeginAuthorization(
+	ctx context.Context,
+	mutation ConnectorMutation,
+) (AuthorizationResult, error) {
+	if err := validateConnectorMutation(mutation); err != nil {
+		return AuthorizationResult{}, err
+	}
+	var result AuthorizationResult
+	shouldBegin := false
+	shouldComplete := false
+	err := application.config.Repository.Transaction(ctx, func(tx Transaction) error {
+		existing, err := tx.OperationByClientRequestID(mutation.ClientRequestID)
+		if err != nil {
+			return err
+		}
+		if existing != nil {
+			if err := verifyIdempotentOperation(*existing, OperationKindStartAuthorization, mutation.ConnectorKey); err != nil {
+				return err
+			}
+			connector, err := tx.Connector(mutation.ConnectorKey)
+			if err != nil {
+				return err
+			}
+			result = AuthorizationResult{Connector: connector, Operation: *existing, Revision: tx.Revision()}
+			if existing.State == OperationStateFailed {
+				return NewDomainError(
+					ErrorCodeAuthorizationFailed,
+					"connector authorization attempt previously failed",
+					true,
+					nil,
+				)
+			}
+			shouldBegin = true
+			shouldComplete = existing.State != OperationStateCompleted
+			return nil
+		}
+		if err := verifyRevision(tx, mutation.ExpectedRevision); err != nil {
+			return err
+		}
+		if err := rejectActiveOperation(tx, mutation.ConnectorKey); err != nil {
+			return err
+		}
+
+		connector, err := tx.Connector(mutation.ConnectorKey)
+		if err != nil {
+			return err
+		}
+		if !CanTransitionAuthorization(connector.Authorization.State, AuthorizationStatePending) {
+			return invalidTransition(
+				"authorization",
+				string(connector.Authorization.State),
+				string(AuthorizationStatePending),
+			)
+		}
+		now := application.config.Now().UTC()
+		revision := tx.AdvanceRevision()
+		operationID, err := application.config.NewID()
+		if err != nil {
+			return NewDomainError(ErrorCodeUnavailable, "connector operation id could not be generated", true, err)
+		}
+		connector.Authorization = Authorization{State: AuthorizationStatePending}
+		connector.Revision = revision
+		operation := Operation{
+			OperationID:     operationID,
+			ClientRequestID: mutation.ClientRequestID,
+			ConnectorKey:    mutation.ConnectorKey,
+			Kind:            OperationKindStartAuthorization,
+			State:           OperationStateRunning,
+			Stage:           "starting",
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		}
+		if err := tx.SaveConnector(connector); err != nil {
+			return err
+		}
+		if err := tx.SaveOperation(operation); err != nil {
+			return err
+		}
+		result = AuthorizationResult{Connector: connector, Operation: operation, Revision: revision}
+		shouldBegin = true
+		shouldComplete = true
+		return nil
+	})
+	if err != nil {
+		return AuthorizationResult{}, err
+	}
+	if !shouldBegin {
+		return result, nil
+	}
+
+	url, beginErr := application.config.Authorization.Begin(
+		ctx,
+		result.Connector,
+		mutation.ClientRequestID,
+	)
+	if beginErr != nil {
+		if shouldComplete {
+			_ = application.failOperation(ctx, result.Operation.OperationID, ErrorCodeAuthorizationFailed)
+		}
+		return AuthorizationResult{}, NewDomainError(
+			ErrorCodeAuthorizationFailed,
+			"connector authorization could not be started",
+			true,
+			beginErr,
+		)
+	}
+	if !shouldComplete {
+		result.AuthorizationURL = url
+		return result, nil
+	}
+	completed, err := application.completeSynchronousOperation(ctx, result.Operation.OperationID, "pending_external_authorization")
+	if err != nil {
+		return AuthorizationResult{}, err
+	}
+	completed.AuthorizationURL = url
+	return completed, nil
+}
+
+func (application *Application) DisconnectAuthorization(
+	ctx context.Context,
+	mutation ConnectorMutation,
+) (MutationResult, error) {
+	return application.acceptConnectorOperation(
+		ctx,
+		mutation,
+		OperationKindDisconnectAuthorization,
+		func(connector Connector) (Connector, error) {
+			if connector.Authorization.State == AuthorizationStateNotRequired {
+				return Connector{}, invalidTransition(
+					"authorization",
+					string(connector.Authorization.State),
+					string(AuthorizationStateDisconnected),
+				)
+			}
+			return connector, nil
+		},
+	)
+}
+
+func (application *Application) SetWorkspaceEnabled(
+	ctx context.Context,
+	command SetWorkspaceEnabledCommand,
+) (WorkspaceBindingResult, error) {
+	if err := validateConnectorMutation(command.ConnectorMutation); err != nil {
+		return WorkspaceBindingResult{}, err
+	}
+	if strings.TrimSpace(command.WorkspaceID) == "" {
+		return WorkspaceBindingResult{}, invalidRequest("workspaceId is required")
+	}
+	var result WorkspaceBindingResult
+	err := application.config.Repository.Transaction(ctx, func(tx Transaction) error {
+		existing, err := tx.OperationByClientRequestID(command.ClientRequestID)
+		if err != nil {
+			return err
+		}
+		if existing != nil {
+			if err := verifyIdempotentOperation(*existing, OperationKindSetWorkspaceEnabled, command.ConnectorKey); err != nil {
+				return err
+			}
+			connector, err := tx.Connector(command.ConnectorKey)
+			if err != nil {
+				return err
+			}
+			result = WorkspaceBindingResult{Connector: connector, Operation: *existing, Revision: tx.Revision()}
+			return nil
+		}
+		if err := verifyRevision(tx, command.ExpectedRevision); err != nil {
+			return err
+		}
+		if err := rejectActiveOperation(tx, command.ConnectorKey); err != nil {
+			return err
+		}
+		now := application.config.Now().UTC()
+		revision := tx.AdvanceRevision()
+		operationID, err := application.config.NewID()
+		if err != nil {
+			return NewDomainError(ErrorCodeUnavailable, "connector operation id could not be generated", true, err)
+		}
+		connector, err := tx.SetWorkspaceBinding(command.ConnectorKey, WorkspaceBinding{
+			WorkspaceID: command.WorkspaceID,
+			Enabled:     command.Enabled,
+		})
+		if err != nil {
+			return err
+		}
+		connector.Revision = revision
+		operation := Operation{
+			OperationID:     operationID,
+			ClientRequestID: command.ClientRequestID,
+			ConnectorKey:    command.ConnectorKey,
+			Kind:            OperationKindSetWorkspaceEnabled,
+			State:           OperationStateCompleted,
+			Stage:           "completed",
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		}
+		if err := tx.SaveConnector(connector); err != nil {
+			return err
+		}
+		if err := tx.SaveOperation(operation); err != nil {
+			return err
+		}
+		result = WorkspaceBindingResult{Connector: connector, Operation: operation, Revision: revision}
+		return nil
+	})
+	if err != nil {
+		return WorkspaceBindingResult{}, err
+	}
+	application.publishChanged(ctx, result.Connector.Key, result.Operation.OperationID, result.Revision)
+	return result, nil
+}
+
+func (application *Application) ExecuteOperation(ctx context.Context, operationID string) error {
+	operation, err := application.config.Repository.Operation(ctx, operationID)
+	if err != nil {
+		return err
+	}
+	if operation.State == OperationStateCompleted || operation.State == OperationStateFailed {
+		return nil
+	}
+	if err := application.markOperationRunning(ctx, operation.OperationID); err != nil {
+		return err
+	}
+
+	var executeErr error
+	switch operation.Kind {
+	case OperationKindRefreshCatalog:
+		executeErr = application.executeRefresh(ctx, operation)
+	case OperationKindInstall:
+		executeErr = application.executeInstall(ctx, operation)
+	case OperationKindUninstall:
+		executeErr = application.executeUninstall(ctx, operation)
+	case OperationKindDisconnectAuthorization:
+		executeErr = application.executeDisconnectAuthorization(ctx, operation)
+	default:
+		executeErr = invalidRequest(fmt.Sprintf("operation kind %q is not executable", operation.Kind))
+	}
+	if executeErr != nil {
+		code := ErrorCodeInstallFailed
+		if operation.Kind == OperationKindRefreshCatalog {
+			code = ErrorCodeUpstreamUnavailable
+		}
+		if operation.Kind == OperationKindDisconnectAuthorization {
+			code = ErrorCodeAuthorizationFailed
+		}
+		_ = application.failOperation(ctx, operation.OperationID, code)
+		return executeErr
+	}
+	return nil
+}
+
+func (application *Application) Recover(ctx context.Context) error {
+	operations, err := application.config.Repository.RecoverableOperations(ctx)
+	if err != nil {
+		return err
+	}
+	for _, operation := range operations {
+		if err := application.config.Scheduler.Schedule(ctx, operation.OperationID); err != nil {
+			return NewDomainError(ErrorCodeUnavailable, "connector operation recovery could not be scheduled", true, err)
+		}
+	}
+	return nil
+}
+
+func (application *Application) acceptConnectorOperation(
+	ctx context.Context,
+	mutation ConnectorMutation,
+	kind OperationKind,
+	transition func(Connector) (Connector, error),
+) (MutationResult, error) {
+	if err := validateConnectorMutation(mutation); err != nil {
+		return MutationResult{}, err
+	}
+	var result MutationResult
+	err := application.config.Repository.Transaction(ctx, func(tx Transaction) error {
+		existing, err := tx.OperationByClientRequestID(mutation.ClientRequestID)
+		if err != nil {
+			return err
+		}
+		if existing != nil {
+			if err := verifyIdempotentOperation(*existing, kind, mutation.ConnectorKey); err != nil {
+				return err
+			}
+			connector, err := tx.Connector(mutation.ConnectorKey)
+			if err != nil {
+				return err
+			}
+			result = MutationResult{Connector: &connector, Operation: *existing, Revision: tx.Revision()}
+			return nil
+		}
+		if err := verifyRevision(tx, mutation.ExpectedRevision); err != nil {
+			return err
+		}
+		if err := rejectActiveOperation(tx, mutation.ConnectorKey); err != nil {
+			return err
+		}
+		connector, err := tx.Connector(mutation.ConnectorKey)
+		if err != nil {
+			return err
+		}
+		connector, err = transition(connector)
+		if err != nil {
+			return err
+		}
+		now := application.config.Now().UTC()
+		revision := tx.AdvanceRevision()
+		operationID, err := application.config.NewID()
+		if err != nil {
+			return NewDomainError(ErrorCodeUnavailable, "connector operation id could not be generated", true, err)
+		}
+		connector.Revision = revision
+		operation := Operation{
+			OperationID:     operationID,
+			ClientRequestID: mutation.ClientRequestID,
+			ConnectorKey:    mutation.ConnectorKey,
+			Kind:            kind,
+			State:           OperationStateAccepted,
+			Stage:           "accepted",
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		}
+		if err := tx.SaveConnector(connector); err != nil {
+			return err
+		}
+		if err := tx.SaveOperation(operation); err != nil {
+			return err
+		}
+		result = MutationResult{Connector: &connector, Operation: operation, Revision: revision}
+		return nil
+	})
+	if err != nil {
+		return MutationResult{}, err
+	}
+	if result.Operation.State == OperationStateAccepted || result.Operation.State == OperationStateRunning {
+		if err := application.config.Scheduler.Schedule(ctx, result.Operation.OperationID); err != nil {
+			return MutationResult{}, NewDomainError(ErrorCodeUnavailable, "connector operation could not be scheduled", true, err)
+		}
+	}
+	application.publishChanged(ctx, mutation.ConnectorKey, result.Operation.OperationID, result.Revision)
+	return result, nil
+}
+
+func (application *Application) acceptOperation(
+	ctx context.Context,
+	mutation Mutation,
+	kind OperationKind,
+	connectorKey string,
+) (MutationResult, error) {
+	if err := validateMutation(mutation); err != nil {
+		return MutationResult{}, err
+	}
+	var result MutationResult
+	err := application.config.Repository.Transaction(ctx, func(tx Transaction) error {
+		existing, err := tx.OperationByClientRequestID(mutation.ClientRequestID)
+		if err != nil {
+			return err
+		}
+		if existing != nil {
+			if err := verifyIdempotentOperation(*existing, kind, connectorKey); err != nil {
+				return err
+			}
+			result = MutationResult{Operation: *existing, Revision: tx.Revision()}
+			return nil
+		}
+		if err := verifyRevision(tx, mutation.ExpectedRevision); err != nil {
+			return err
+		}
+		if err := rejectActiveOperation(tx, connectorKey); err != nil {
+			return err
+		}
+		now := application.config.Now().UTC()
+		revision := tx.AdvanceRevision()
+		operationID, err := application.config.NewID()
+		if err != nil {
+			return NewDomainError(ErrorCodeUnavailable, "connector operation id could not be generated", true, err)
+		}
+		operation := Operation{
+			OperationID:     operationID,
+			ClientRequestID: mutation.ClientRequestID,
+			ConnectorKey:    connectorKey,
+			Kind:            kind,
+			State:           OperationStateAccepted,
+			Stage:           "accepted",
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		}
+		if kind == OperationKindRefreshCatalog {
+			if err := tx.SetCatalogState(CatalogStateRefreshing); err != nil {
+				return err
+			}
+		}
+		if err := tx.SaveOperation(operation); err != nil {
+			return err
+		}
+		result = MutationResult{Operation: operation, Revision: revision}
+		return nil
+	})
+	if err != nil {
+		return MutationResult{}, err
+	}
+	if result.Operation.State == OperationStateAccepted || result.Operation.State == OperationStateRunning {
+		if err := application.config.Scheduler.Schedule(ctx, result.Operation.OperationID); err != nil {
+			return MutationResult{}, NewDomainError(ErrorCodeUnavailable, "connector operation could not be scheduled", true, err)
+		}
+	}
+	application.publishChanged(ctx, connectorKey, result.Operation.OperationID, result.Revision)
+	return result, nil
+}
+
+func validateMutation(mutation Mutation) error {
+	if strings.TrimSpace(mutation.ClientRequestID) == "" {
+		return invalidRequest("clientRequestId is required")
+	}
+	return nil
+}
+
+func validateConnectorMutation(mutation ConnectorMutation) error {
+	if err := validateMutation(mutation.Mutation); err != nil {
+		return err
+	}
+	if strings.TrimSpace(mutation.ConnectorKey) == "" {
+		return invalidRequest("connectorKey is required")
+	}
+	return nil
+}
+
+func verifyRevision(tx Transaction, expected uint64) error {
+	if tx.Revision() == expected {
+		return nil
+	}
+	return NewDomainError(
+		ErrorCodeRevisionConflict,
+		fmt.Sprintf("expected revision %d but current revision is %d", expected, tx.Revision()),
+		true,
+		nil,
+	)
+}
+
+func verifyIdempotentOperation(operation Operation, kind OperationKind, connectorKey string) error {
+	if operation.Kind == kind && operation.ConnectorKey == connectorKey {
+		return nil
+	}
+	return invalidRequest("clientRequestId was already used for a different connector-market command")
+}
+
+func rejectActiveOperation(tx Transaction, connectorKey string) error {
+	active, err := tx.ActiveOperation(connectorKey)
+	if err != nil {
+		return err
+	}
+	if active == nil {
+		return nil
+	}
+	return NewDomainError(
+		ErrorCodeOperationInProgress,
+		fmt.Sprintf("operation %s is already in progress", active.OperationID),
+		true,
+		nil,
+	)
+}
+
+func invalidRequest(message string) error {
+	return NewDomainError(ErrorCodeInvalidRequest, message, false, nil)
+}
+
+func invalidTransition(kind, from, to string) error {
+	return NewDomainError(
+		ErrorCodeOperationInProgress,
+		fmt.Sprintf("%s cannot transition from %s to %s", kind, from, to),
+		true,
+		nil,
+	)
+}
+
+func randomID() (string, error) {
+	raw := make([]byte, 16)
+	if _, err := rand.Read(raw); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(raw), nil
+}
+
+func (application *Application) publishChanged(ctx context.Context, connectorKey, operationID string, revision uint64) {
+	_ = application.config.Events.ConnectorMarketChanged(ctx, ChangedEvent{
+		ConnectorKey: connectorKey,
+		OperationID:  operationID,
+		Revision:     revision,
+	})
+}

--- a/packages/connector/market/daemon/application_execution.go
+++ b/packages/connector/market/daemon/application_execution.go
@@ -1,0 +1,331 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+)
+
+func (application *Application) executeRefresh(ctx context.Context, operation Operation) error {
+	catalog, err := application.config.CatalogSource.Refresh(ctx)
+	if err != nil {
+		return NewDomainError(
+			ErrorCodeUpstreamUnavailable,
+			"connector catalog refresh failed",
+			true,
+			err,
+		)
+	}
+	for _, manifest := range catalog.Manifests {
+		if err := ValidateManifestShape(manifest); err != nil {
+			return err
+		}
+	}
+
+	var revision uint64
+	err = application.config.Repository.Transaction(ctx, func(tx Transaction) error {
+		storedOperation, err := tx.Operation(operation.OperationID)
+		if err != nil {
+			return err
+		}
+		existing, err := tx.Connectors()
+		if err != nil {
+			return err
+		}
+		byKey := make(map[string]Connector, len(existing))
+		for _, connector := range existing {
+			byKey[connector.Key] = connector
+		}
+		revision = tx.AdvanceRevision()
+		accepted := make(map[string]bool, len(catalog.Manifests))
+		for _, manifest := range catalog.Manifests {
+			accepted[manifest.Key] = true
+			connector, ok := byKey[manifest.Key]
+			if !ok {
+				connector = newCatalogConnector(manifest)
+			}
+			connector.Manifest = manifest
+			compatibility, err := application.compatibilityFor(manifest)
+			if err != nil {
+				return err
+			}
+			connector.Compatibility = compatibility
+			connector.Revision = revision
+			if err := tx.SaveConnector(connector); err != nil {
+				return err
+			}
+		}
+		for _, connector := range existing {
+			if accepted[connector.Key] {
+				continue
+			}
+			if connector.Installation.State == InstallationStateNotInstalled {
+				if err := tx.DeleteConnector(connector.Key); err != nil {
+					return err
+				}
+				continue
+			}
+			connector.Compatibility = Compatibility{
+				State:  CompatibilityStateUnsupportedVersion,
+				Reason: "removed_from_catalog",
+			}
+			connector.Revision = revision
+			if err := tx.SaveConnector(connector); err != nil {
+				return err
+			}
+		}
+		storedOperation.State = OperationStateCompleted
+		storedOperation.Stage = "completed"
+		storedOperation.UpdatedAt = application.config.Now().UTC()
+		if err := tx.SaveOperation(storedOperation); err != nil {
+			return err
+		}
+		if err := tx.SaveCatalogRevision(catalog.SourceRevision); err != nil {
+			return err
+		}
+		return tx.SetCatalogState(CatalogStateReady)
+	})
+	if err != nil {
+		return err
+	}
+	application.publishChanged(ctx, "", operation.OperationID, revision)
+	return nil
+}
+
+func (application *Application) executeInstall(ctx context.Context, operation Operation) error {
+	connector, err := application.config.Repository.Connector(ctx, operation.ConnectorKey, "")
+	if err != nil {
+		return err
+	}
+	if err := application.config.ImplementationRegistry.Validate(connector.Manifest); err != nil {
+		return err
+	}
+	if err := application.config.Installer.Install(ctx, connector.Manifest); err != nil {
+		return NewDomainError(ErrorCodeInstallFailed, "connector installation failed", true, err)
+	}
+	return application.completeConnectorOperation(ctx, operation.OperationID, func(connector Connector) Connector {
+		connector.Installation = Installation{
+			State:            InstallationStateInstalled,
+			InstalledVersion: connector.Manifest.Version,
+		}
+		return connector
+	})
+}
+
+func (application *Application) executeUninstall(ctx context.Context, operation Operation) error {
+	connector, err := application.config.Repository.Connector(ctx, operation.ConnectorKey, "")
+	if err != nil {
+		return err
+	}
+	if err := application.config.Installer.Uninstall(ctx, connector); err != nil {
+		return NewDomainError(ErrorCodeInstallFailed, "connector uninstall failed", true, err)
+	}
+	return application.completeConnectorOperation(ctx, operation.OperationID, func(connector Connector) Connector {
+		connector.Installation = Installation{State: InstallationStateNotInstalled}
+		connector.Authorization = initialAuthorization(connector.Manifest.AuthorizationKind)
+		return connector
+	})
+}
+
+func (application *Application) executeDisconnectAuthorization(ctx context.Context, operation Operation) error {
+	connector, err := application.config.Repository.Connector(ctx, operation.ConnectorKey, "")
+	if err != nil {
+		return err
+	}
+	if err := application.config.Authorization.Disconnect(ctx, connector); err != nil {
+		return NewDomainError(ErrorCodeAuthorizationFailed, "connector authorization disconnect failed", true, err)
+	}
+	return application.completeConnectorOperation(ctx, operation.OperationID, func(connector Connector) Connector {
+		connector.Authorization = Authorization{State: AuthorizationStateDisconnected}
+		return connector
+	})
+}
+
+func (application *Application) markOperationRunning(ctx context.Context, operationID string) error {
+	var event ChangedEvent
+	err := application.config.Repository.Transaction(ctx, func(tx Transaction) error {
+		operation, err := tx.Operation(operationID)
+		if err != nil {
+			return err
+		}
+		if operation.State == OperationStateRunning {
+			return nil
+		}
+		revision := tx.AdvanceRevision()
+		operation.State = OperationStateRunning
+		operation.Stage = "running"
+		operation.UpdatedAt = application.config.Now().UTC()
+		if err := tx.SaveOperation(operation); err != nil {
+			return err
+		}
+		event = ChangedEvent{ConnectorKey: operation.ConnectorKey, OperationID: operation.OperationID, Revision: revision}
+		return nil
+	})
+	if err == nil && event.Revision > 0 {
+		application.publishChanged(ctx, event.ConnectorKey, event.OperationID, event.Revision)
+	}
+	return err
+}
+
+func (application *Application) completeConnectorOperation(
+	ctx context.Context,
+	operationID string,
+	update func(Connector) Connector,
+) error {
+	var event ChangedEvent
+	err := application.config.Repository.Transaction(ctx, func(tx Transaction) error {
+		operation, err := tx.Operation(operationID)
+		if err != nil {
+			return err
+		}
+		connector, err := tx.Connector(operation.ConnectorKey)
+		if err != nil {
+			return err
+		}
+		revision := tx.AdvanceRevision()
+		connector = update(connector)
+		connector.Revision = revision
+		operation.State = OperationStateCompleted
+		operation.Stage = "completed"
+		operation.FailureCode = ""
+		operation.UpdatedAt = application.config.Now().UTC()
+		if err := tx.SaveConnector(connector); err != nil {
+			return err
+		}
+		if err := tx.SaveOperation(operation); err != nil {
+			return err
+		}
+		event = ChangedEvent{ConnectorKey: connector.Key, OperationID: operation.OperationID, Revision: revision}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	application.publishChanged(ctx, event.ConnectorKey, event.OperationID, event.Revision)
+	return nil
+}
+
+func (application *Application) completeSynchronousOperation(
+	ctx context.Context,
+	operationID string,
+	stage string,
+) (AuthorizationResult, error) {
+	var result AuthorizationResult
+	err := application.config.Repository.Transaction(ctx, func(tx Transaction) error {
+		operation, err := tx.Operation(operationID)
+		if err != nil {
+			return err
+		}
+		connector, err := tx.Connector(operation.ConnectorKey)
+		if err != nil {
+			return err
+		}
+		revision := tx.AdvanceRevision()
+		connector.Revision = revision
+		operation.State = OperationStateCompleted
+		operation.Stage = stage
+		operation.UpdatedAt = application.config.Now().UTC()
+		if err := tx.SaveConnector(connector); err != nil {
+			return err
+		}
+		if err := tx.SaveOperation(operation); err != nil {
+			return err
+		}
+		result = AuthorizationResult{Connector: connector, Operation: operation, Revision: revision}
+		return nil
+	})
+	if err != nil {
+		return AuthorizationResult{}, err
+	}
+	application.publishChanged(ctx, result.Connector.Key, result.Operation.OperationID, result.Revision)
+	return result, nil
+}
+
+func (application *Application) failOperation(ctx context.Context, operationID string, code ErrorCode) error {
+	var event ChangedEvent
+	err := application.config.Repository.Transaction(ctx, func(tx Transaction) error {
+		operation, err := tx.Operation(operationID)
+		if err != nil {
+			return err
+		}
+		revision := tx.AdvanceRevision()
+		operation.State = OperationStateFailed
+		operation.Stage = "failed"
+		operation.FailureCode = string(code)
+		operation.UpdatedAt = application.config.Now().UTC()
+		if operation.Kind == OperationKindRefreshCatalog {
+			if err := tx.SetCatalogState(CatalogStateFailed); err != nil {
+				return err
+			}
+		} else if operation.ConnectorKey != "" {
+			connector, err := tx.Connector(operation.ConnectorKey)
+			if err != nil && !errors.Is(err, ErrNotFound) {
+				return err
+			}
+			if err == nil {
+				switch operation.Kind {
+				case OperationKindInstall, OperationKindUninstall:
+					connector.Installation.State = InstallationStateFailed
+					connector.Installation.FailureCode = string(code)
+				case OperationKindStartAuthorization, OperationKindDisconnectAuthorization:
+					connector.Authorization.State = AuthorizationStateFailed
+					connector.Authorization.FailureCode = string(code)
+				}
+				connector.Revision = revision
+				if err := tx.SaveConnector(connector); err != nil {
+					return err
+				}
+			}
+		}
+		if err := tx.SaveOperation(operation); err != nil {
+			return err
+		}
+		event = ChangedEvent{ConnectorKey: operation.ConnectorKey, OperationID: operation.OperationID, Revision: revision}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	application.publishChanged(ctx, event.ConnectorKey, event.OperationID, event.Revision)
+	return nil
+}
+
+func (application *Application) compatibilityFor(manifest Manifest) (Compatibility, error) {
+	if !application.config.ImplementationRegistry.Supports(manifest.Implementation.Kind) {
+		return Compatibility{
+			State:  CompatibilityStateUnsupportedImplementation,
+			Reason: "unsupported_implementation",
+		}, nil
+	}
+	compatibility := application.config.Compatibility.Evaluate(manifest)
+	switch compatibility.State {
+	case CompatibilityStateSupported,
+		CompatibilityStateUnsupportedProduct,
+		CompatibilityStateUnsupportedPlatform,
+		CompatibilityStateUnsupportedVersion:
+		return compatibility, nil
+	default:
+		return Compatibility{}, NewDomainError(
+			ErrorCodeUnavailable,
+			"connector compatibility evaluator returned an invalid state",
+			false,
+			nil,
+		)
+	}
+}
+
+func newCatalogConnector(manifest Manifest) Connector {
+	return Connector{
+		Key:           manifest.Key,
+		Manifest:      manifest,
+		Installation:  Installation{State: InstallationStateNotInstalled},
+		Authorization: initialAuthorization(manifest.AuthorizationKind),
+		Compatibility: Compatibility{State: CompatibilityStateSupported},
+	}
+}
+
+func initialAuthorization(kind string) Authorization {
+	if kind == "none" {
+		return Authorization{State: AuthorizationStateNotRequired}
+	}
+	return Authorization{State: AuthorizationStateDisconnected}
+}

--- a/packages/connector/market/daemon/application_test.go
+++ b/packages/connector/market/daemon/application_test.go
@@ -1,0 +1,447 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+)
+
+func TestApplicationInstallIsDurableAndIdempotent(t *testing.T) {
+	repository := newMemoryRepository(testConnector("github"))
+	scheduler := &memoryScheduler{}
+	application := newTestApplication(t, repository, scheduler, &memoryInstaller{}, CatalogSnapshot{})
+	command := ConnectorMutation{
+		Mutation:     Mutation{ClientRequestID: "request-1", ExpectedRevision: 0},
+		ConnectorKey: "github",
+	}
+
+	accepted, err := application.Install(context.Background(), command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if accepted.Connector == nil || accepted.Connector.Installation.State != InstallationStateInstalling {
+		t.Fatalf("connector = %#v", accepted.Connector)
+	}
+	if accepted.Operation.State != OperationStateAccepted || accepted.Revision != 1 {
+		t.Fatalf("result = %#v", accepted)
+	}
+
+	retried, err := application.Install(context.Background(), command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retried.Operation.OperationID != accepted.Operation.OperationID {
+		t.Fatalf("retry operation = %q, want %q", retried.Operation.OperationID, accepted.Operation.OperationID)
+	}
+	if repository.revision != 1 {
+		t.Fatalf("revision = %d, want 1", repository.revision)
+	}
+	if len(scheduler.operationIDs) != 2 {
+		t.Fatalf("scheduled operations = %#v", scheduler.operationIDs)
+	}
+}
+
+func TestApplicationExecutesAcceptedInstall(t *testing.T) {
+	repository := newMemoryRepository(testConnector("github"))
+	scheduler := &memoryScheduler{}
+	installer := &memoryInstaller{}
+	application := newTestApplication(t, repository, scheduler, installer, CatalogSnapshot{})
+	accepted, err := application.Install(context.Background(), ConnectorMutation{
+		Mutation:     Mutation{ClientRequestID: "request-1", ExpectedRevision: 0},
+		ConnectorKey: "github",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := application.ExecuteOperation(context.Background(), accepted.Operation.OperationID); err != nil {
+		t.Fatal(err)
+	}
+	installed, err := repository.Connector(context.Background(), "github", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	operation, err := repository.Operation(context.Background(), accepted.Operation.OperationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if installed.Installation.State != InstallationStateInstalled || installed.Installation.InstalledVersion != "1.0.0" {
+		t.Fatalf("installation = %#v", installed.Installation)
+	}
+	if operation.State != OperationStateCompleted || installer.installs != 1 {
+		t.Fatalf("operation = %#v, installs = %d", operation, installer.installs)
+	}
+}
+
+func TestApplicationRejectsConcurrentConnectorOperation(t *testing.T) {
+	repository := newMemoryRepository(testConnector("github"))
+	application := newTestApplication(t, repository, &memoryScheduler{}, &memoryInstaller{}, CatalogSnapshot{})
+	if _, err := application.Install(context.Background(), ConnectorMutation{
+		Mutation:     Mutation{ClientRequestID: "install-1", ExpectedRevision: 0},
+		ConnectorKey: "github",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_, err := application.Uninstall(context.Background(), ConnectorMutation{
+		Mutation:     Mutation{ClientRequestID: "uninstall-1", ExpectedRevision: 1},
+		ConnectorKey: "github",
+	})
+	var domainError *DomainError
+	if !errors.As(err, &domainError) || domainError.Code != ErrorCodeOperationInProgress {
+		t.Fatalf("error = %#v", err)
+	}
+}
+
+func TestApplicationRefreshKeepsUnknownImplementationVisible(t *testing.T) {
+	repository := newMemoryRepository()
+	scheduler := &memoryScheduler{}
+	application := newTestApplication(t, repository, scheduler, &memoryInstaller{}, CatalogSnapshot{
+		SourceRevision: "catalog-2",
+		Manifests: []Manifest{{
+			SchemaVersion:     "1",
+			Key:               "future-connector",
+			Version:           "2.0.0",
+			DisplayName:       "Future Connector",
+			Artifact:          testArtifact(),
+			Implementation:    Implementation{Kind: "future_runtime"},
+			AuthorizationKind: "none",
+		}},
+	})
+	accepted, err := application.RefreshCatalog(context.Background(), Mutation{
+		ClientRequestID:  "refresh-1",
+		ExpectedRevision: 0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := application.ExecuteOperation(context.Background(), accepted.Operation.OperationID); err != nil {
+		t.Fatal(err)
+	}
+	connector, err := repository.Connector(context.Background(), "future-connector", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if connector.Compatibility.State != CompatibilityStateUnsupportedImplementation {
+		t.Fatalf("compatibility = %#v", connector.Compatibility)
+	}
+	if repository.catalogState != CatalogStateReady || repository.sourceRevision != "catalog-2" {
+		t.Fatalf("catalog state = %q, source revision = %q", repository.catalogState, repository.sourceRevision)
+	}
+}
+
+func TestApplicationRejectsStaleRevisionBeforeMutation(t *testing.T) {
+	repository := newMemoryRepository(testConnector("github"))
+	repository.revision = 4
+	application := newTestApplication(t, repository, &memoryScheduler{}, &memoryInstaller{}, CatalogSnapshot{})
+	_, err := application.Install(context.Background(), ConnectorMutation{
+		Mutation:     Mutation{ClientRequestID: "request-1", ExpectedRevision: 3},
+		ConnectorKey: "github",
+	})
+	var domainError *DomainError
+	if !errors.As(err, &domainError) || domainError.Code != ErrorCodeRevisionConflict {
+		t.Fatalf("error = %#v", err)
+	}
+	if len(repository.operations) != 0 {
+		t.Fatalf("operations = %#v", repository.operations)
+	}
+}
+
+func newTestApplication(
+	t *testing.T,
+	repository *memoryRepository,
+	scheduler *memoryScheduler,
+	installer *memoryInstaller,
+	catalog CatalogSnapshot,
+) *Application {
+	t.Helper()
+	nextID := 0
+	application, err := NewApplication(ApplicationConfig{
+		Repository:             repository,
+		CatalogSource:          catalogSourceFunc(func(context.Context) (CatalogSnapshot, error) { return catalog, nil }),
+		Installer:              installer,
+		Authorization:          authorizationProviderStub{},
+		Compatibility:          compatibilityEvaluatorStub{},
+		Scheduler:              scheduler,
+		Events:                 eventPublisherStub{},
+		ImplementationRegistry: NewImplementationRegistry(map[string]ImplementationValidator{"mcp_stdio": nil}),
+		Now:                    func() time.Time { return time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC) },
+		NewID: func() (string, error) {
+			nextID++
+			return fmt.Sprintf("operation-%d", nextID), nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return application
+}
+
+func testConnector(key string) Connector {
+	return Connector{
+		Key: key,
+		Manifest: Manifest{
+			SchemaVersion:     "1",
+			Key:               key,
+			Version:           "1.0.0",
+			DisplayName:       key,
+			Artifact:          testArtifact(),
+			Implementation:    Implementation{Kind: "mcp_stdio"},
+			AuthorizationKind: "none",
+		},
+		Installation:  Installation{State: InstallationStateNotInstalled},
+		Authorization: Authorization{State: AuthorizationStateNotRequired},
+		Compatibility: Compatibility{State: CompatibilityStateSupported},
+	}
+}
+
+type catalogSourceFunc func(context.Context) (CatalogSnapshot, error)
+
+func (source catalogSourceFunc) Refresh(ctx context.Context) (CatalogSnapshot, error) {
+	return source(ctx)
+}
+
+type memoryScheduler struct {
+	operationIDs []string
+}
+
+func (scheduler *memoryScheduler) Schedule(_ context.Context, operationID string) error {
+	scheduler.operationIDs = append(scheduler.operationIDs, operationID)
+	return nil
+}
+
+type memoryInstaller struct {
+	installs   int
+	uninstalls int
+}
+
+func (installer *memoryInstaller) Install(context.Context, Manifest) error {
+	installer.installs++
+	return nil
+}
+
+func (installer *memoryInstaller) Uninstall(context.Context, Connector) error {
+	installer.uninstalls++
+	return nil
+}
+
+type authorizationProviderStub struct{}
+
+func (authorizationProviderStub) Begin(context.Context, Connector, string) (string, error) {
+	return "https://example.test/authorize", nil
+}
+
+func (authorizationProviderStub) Disconnect(context.Context, Connector) error {
+	return nil
+}
+
+type compatibilityEvaluatorStub struct{}
+
+func (compatibilityEvaluatorStub) Evaluate(Manifest) Compatibility {
+	return Compatibility{State: CompatibilityStateSupported}
+}
+
+type eventPublisherStub struct{}
+
+func (eventPublisherStub) ConnectorMarketChanged(context.Context, ChangedEvent) error {
+	return nil
+}
+
+type memoryRepository struct {
+	revision       uint64
+	catalogState   CatalogState
+	sourceRevision string
+	connectors     map[string]Connector
+	operations     map[string]Operation
+}
+
+func newMemoryRepository(connectors ...Connector) *memoryRepository {
+	repository := &memoryRepository{
+		catalogState: CatalogStateStale,
+		connectors:   map[string]Connector{},
+		operations:   map[string]Operation{},
+	}
+	for _, connector := range connectors {
+		repository.connectors[connector.Key] = connector
+	}
+	return repository
+}
+
+func (repository *memoryRepository) Snapshot(_ context.Context, _ string) (Snapshot, error) {
+	connectors := make([]Connector, 0, len(repository.connectors))
+	for _, connector := range repository.connectors {
+		connectors = append(connectors, connector)
+	}
+	sort.Slice(connectors, func(left, right int) bool { return connectors[left].Key < connectors[right].Key })
+	operations := make([]Operation, 0, len(repository.operations))
+	for _, operation := range repository.operations {
+		operations = append(operations, operation)
+	}
+	return Snapshot{
+		CatalogState:   repository.catalogState,
+		Connectors:     connectors,
+		Operations:     operations,
+		Revision:       repository.revision,
+		SourceRevision: repository.sourceRevision,
+	}, nil
+}
+
+func (repository *memoryRepository) Connector(_ context.Context, connectorKey, _ string) (Connector, error) {
+	connector, ok := repository.connectors[connectorKey]
+	if !ok {
+		return Connector{}, ErrNotFound
+	}
+	return connector, nil
+}
+
+func (repository *memoryRepository) Operation(_ context.Context, operationID string) (Operation, error) {
+	operation, ok := repository.operations[operationID]
+	if !ok {
+		return Operation{}, ErrNotFound
+	}
+	return operation, nil
+}
+
+func (repository *memoryRepository) Transaction(_ context.Context, fn func(Transaction) error) error {
+	transaction := &memoryTransaction{
+		revision:       repository.revision,
+		catalogState:   repository.catalogState,
+		sourceRevision: repository.sourceRevision,
+		connectors:     cloneConnectors(repository.connectors),
+		operations:     cloneOperations(repository.operations),
+	}
+	if err := fn(transaction); err != nil {
+		return err
+	}
+	repository.revision = transaction.revision
+	repository.catalogState = transaction.catalogState
+	repository.sourceRevision = transaction.sourceRevision
+	repository.connectors = transaction.connectors
+	repository.operations = transaction.operations
+	return nil
+}
+
+func (repository *memoryRepository) RecoverableOperations(context.Context) ([]Operation, error) {
+	var operations []Operation
+	for _, operation := range repository.operations {
+		if operation.State == OperationStateAccepted || operation.State == OperationStateRunning {
+			operations = append(operations, operation)
+		}
+	}
+	return operations, nil
+}
+
+type memoryTransaction struct {
+	revision       uint64
+	catalogState   CatalogState
+	sourceRevision string
+	connectors     map[string]Connector
+	operations     map[string]Operation
+}
+
+func (transaction *memoryTransaction) Revision() uint64 { return transaction.revision }
+
+func (transaction *memoryTransaction) AdvanceRevision() uint64 {
+	transaction.revision++
+	return transaction.revision
+}
+
+func (transaction *memoryTransaction) Connectors() ([]Connector, error) {
+	connectors := make([]Connector, 0, len(transaction.connectors))
+	for _, connector := range transaction.connectors {
+		connectors = append(connectors, connector)
+	}
+	return connectors, nil
+}
+
+func (transaction *memoryTransaction) Connector(connectorKey string) (Connector, error) {
+	connector, ok := transaction.connectors[connectorKey]
+	if !ok {
+		return Connector{}, ErrNotFound
+	}
+	return connector, nil
+}
+
+func (transaction *memoryTransaction) Operation(operationID string) (Operation, error) {
+	operation, ok := transaction.operations[operationID]
+	if !ok {
+		return Operation{}, ErrNotFound
+	}
+	return operation, nil
+}
+
+func (transaction *memoryTransaction) OperationByClientRequestID(clientRequestID string) (*Operation, error) {
+	for _, operation := range transaction.operations {
+		if operation.ClientRequestID == clientRequestID {
+			copy := operation
+			return &copy, nil
+		}
+	}
+	return nil, nil
+}
+
+func (transaction *memoryTransaction) ActiveOperation(connectorKey string) (*Operation, error) {
+	for _, operation := range transaction.operations {
+		if operation.ConnectorKey == connectorKey &&
+			(operation.State == OperationStateAccepted || operation.State == OperationStateRunning) {
+			copy := operation
+			return &copy, nil
+		}
+	}
+	return nil, nil
+}
+
+func (transaction *memoryTransaction) SaveCatalogRevision(sourceRevision string) error {
+	transaction.sourceRevision = sourceRevision
+	return nil
+}
+
+func (transaction *memoryTransaction) SetCatalogState(state CatalogState) error {
+	transaction.catalogState = state
+	return nil
+}
+
+func (transaction *memoryTransaction) SaveConnector(connector Connector) error {
+	transaction.connectors[connector.Key] = connector
+	return nil
+}
+
+func (transaction *memoryTransaction) DeleteConnector(connectorKey string) error {
+	delete(transaction.connectors, connectorKey)
+	return nil
+}
+
+func (transaction *memoryTransaction) SaveOperation(operation Operation) error {
+	transaction.operations[operation.OperationID] = operation
+	return nil
+}
+
+func (transaction *memoryTransaction) SetWorkspaceBinding(
+	connectorKey string,
+	binding WorkspaceBinding,
+) (Connector, error) {
+	connector, ok := transaction.connectors[connectorKey]
+	if !ok {
+		return Connector{}, ErrNotFound
+	}
+	connector.WorkspaceBinding = &binding
+	return connector, nil
+}
+
+func cloneConnectors(source map[string]Connector) map[string]Connector {
+	cloned := make(map[string]Connector, len(source))
+	for key, connector := range source {
+		cloned[key] = connector
+	}
+	return cloned
+}
+
+func cloneOperations(source map[string]Operation) map[string]Operation {
+	cloned := make(map[string]Operation, len(source))
+	for key, operation := range source {
+		cloned[key] = operation
+	}
+	return cloned
+}

--- a/packages/connector/market/daemon/errors.go
+++ b/packages/connector/market/daemon/errors.go
@@ -1,0 +1,51 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+)
+
+var ErrNotFound = errors.New("connector market resource not found")
+
+type ErrorCode string
+
+const (
+	ErrorCodeInvalidRequest            ErrorCode = "connector_market_invalid_request"
+	ErrorCodeNotFound                  ErrorCode = "connector_not_found"
+	ErrorCodeRevisionConflict          ErrorCode = "connector_market_revision_conflict"
+	ErrorCodeOperationInProgress       ErrorCode = "connector_operation_in_progress"
+	ErrorCodeIncompatible              ErrorCode = "connector_incompatible"
+	ErrorCodeInvalidManifest           ErrorCode = "connector_manifest_invalid"
+	ErrorCodeUnsupportedImplementation ErrorCode = "connector_implementation_unsupported"
+	ErrorCodeUpstreamUnavailable       ErrorCode = "connector_market_upstream_unavailable"
+	ErrorCodeInstallFailed             ErrorCode = "connector_install_failed"
+	ErrorCodeAuthorizationFailed       ErrorCode = "connector_authorization_failed"
+	ErrorCodeUnavailable               ErrorCode = "connector_market_unavailable"
+)
+
+type DomainError struct {
+	Code      ErrorCode
+	Message   string
+	Retryable bool
+	Cause     error
+}
+
+func (domainError *DomainError) Error() string {
+	if domainError.Cause == nil {
+		return domainError.Message
+	}
+	return fmt.Sprintf("%s: %v", domainError.Message, domainError.Cause)
+}
+
+func (domainError *DomainError) Unwrap() error {
+	return domainError.Cause
+}
+
+func NewDomainError(code ErrorCode, message string, retryable bool, cause error) error {
+	return &DomainError{
+		Code:      code,
+		Message:   message,
+		Retryable: retryable,
+		Cause:     cause,
+	}
+}

--- a/packages/connector/market/daemon/manifest.go
+++ b/packages/connector/market/daemon/manifest.go
@@ -1,0 +1,81 @@
+package daemon
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var connectorKeyPattern = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9._-]{0,126}[a-z0-9])?$`)
+var artifactSHA256Pattern = regexp.MustCompile(`^[a-f0-9]{64}$`)
+
+type ImplementationValidator func(config map[string]any) error
+
+type ImplementationRegistry struct {
+	validators map[string]ImplementationValidator
+}
+
+func NewImplementationRegistry(validators map[string]ImplementationValidator) ImplementationRegistry {
+	cloned := make(map[string]ImplementationValidator, len(validators))
+	for kind, validator := range validators {
+		cloned[kind] = validator
+	}
+	return ImplementationRegistry{validators: cloned}
+}
+
+func (registry ImplementationRegistry) Supports(kind string) bool {
+	_, ok := registry.validators[kind]
+	return ok
+}
+
+func (registry ImplementationRegistry) Validate(manifest Manifest) error {
+	if err := ValidateManifestShape(manifest); err != nil {
+		return err
+	}
+	validator, ok := registry.validators[manifest.Implementation.Kind]
+	if !ok {
+		return NewDomainError(
+			ErrorCodeUnsupportedImplementation,
+			fmt.Sprintf("implementation %q is not supported", manifest.Implementation.Kind),
+			false,
+			nil,
+		)
+	}
+	if validator != nil {
+		if err := validator(manifest.Implementation.Config); err != nil {
+			return invalidManifest("implementation config is invalid", err)
+		}
+	}
+	return nil
+}
+
+func ValidateManifestShape(manifest Manifest) error {
+	if manifest.SchemaVersion != "1" {
+		return invalidManifest("schemaVersion must be 1", nil)
+	}
+	if !connectorKeyPattern.MatchString(manifest.Key) {
+		return invalidManifest("key must be a stable lowercase connector identifier", nil)
+	}
+	if strings.TrimSpace(manifest.Version) == "" {
+		return invalidManifest("version is required", nil)
+	}
+	if strings.TrimSpace(manifest.DisplayName) == "" {
+		return invalidManifest("displayName is required", nil)
+	}
+	if strings.TrimSpace(manifest.Artifact.Key) == "" ||
+		!artifactSHA256Pattern.MatchString(manifest.Artifact.SHA256) ||
+		manifest.Artifact.SizeBytes <= 0 {
+		return invalidManifest("artifact key, lowercase SHA-256, and positive sizeBytes are required", nil)
+	}
+	if strings.TrimSpace(manifest.Implementation.Kind) == "" {
+		return invalidManifest("implementation.kind is required", nil)
+	}
+	if strings.TrimSpace(manifest.AuthorizationKind) == "" {
+		return invalidManifest("authorizationKind is required", nil)
+	}
+	return nil
+}
+
+func invalidManifest(message string, cause error) error {
+	return NewDomainError(ErrorCodeInvalidManifest, message, false, cause)
+}

--- a/packages/connector/market/daemon/manifest_test.go
+++ b/packages/connector/market/daemon/manifest_test.go
@@ -1,0 +1,77 @@
+package daemon
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestImplementationRegistryValidatesSupportedManifest(t *testing.T) {
+	registry := NewImplementationRegistry(map[string]ImplementationValidator{
+		"mcp_stdio": func(config map[string]any) error {
+			if config["command"] == "" {
+				return errors.New("command is required")
+			}
+			return nil
+		},
+	})
+
+	err := registry.Validate(Manifest{
+		SchemaVersion:     "1",
+		Key:               "github",
+		Version:           "1.0.0",
+		DisplayName:       "GitHub",
+		Permissions:       []string{"repository.read"},
+		Artifact:          testArtifact(),
+		Implementation:    Implementation{Kind: "mcp_stdio", Config: map[string]any{"command": "github-mcp"}},
+		AuthorizationKind: "oauth2",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestImplementationRegistryRejectsUnknownImplementation(t *testing.T) {
+	registry := NewImplementationRegistry(nil)
+	err := registry.Validate(Manifest{
+		SchemaVersion:     "1",
+		Key:               "github",
+		Version:           "1.0.0",
+		DisplayName:       "GitHub",
+		Artifact:          testArtifact(),
+		Implementation:    Implementation{Kind: "unknown"},
+		AuthorizationKind: "none",
+	})
+	var domainError *DomainError
+	if !errors.As(err, &domainError) {
+		t.Fatalf("error = %v, want DomainError", err)
+	}
+	if domainError.Code != ErrorCodeUnsupportedImplementation {
+		t.Fatalf("code = %q", domainError.Code)
+	}
+}
+
+func testArtifact() Artifact {
+	return Artifact{
+		Key:       "connectors/github/1.0.0.tgz",
+		SHA256:    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		SizeBytes: 1024,
+	}
+}
+
+func TestInstallationTransitionsRejectSkippedActivation(t *testing.T) {
+	if !CanTransitionInstallation(InstallationStateInstalling, InstallationStateInstalled) {
+		t.Fatal("installing -> installed should be allowed")
+	}
+	if CanTransitionInstallation(InstallationStateNotInstalled, InstallationStateInstalled) {
+		t.Fatal("not_installed -> installed should be rejected")
+	}
+}
+
+func TestAuthorizationTransitionsKeepNotRequiredTerminal(t *testing.T) {
+	if CanTransitionAuthorization(AuthorizationStateNotRequired, AuthorizationStatePending) {
+		t.Fatal("not_required -> pending should be rejected")
+	}
+	if !CanTransitionAuthorization(AuthorizationStateExpired, AuthorizationStatePending) {
+		t.Fatal("expired -> pending should be allowed")
+	}
+}

--- a/packages/connector/market/daemon/ports.go
+++ b/packages/connector/market/daemon/ports.go
@@ -1,0 +1,64 @@
+package daemon
+
+import "context"
+
+type CatalogSource interface {
+	Refresh(context.Context) (CatalogSnapshot, error)
+}
+
+type CatalogSnapshot struct {
+	SourceRevision string
+	Manifests      []Manifest
+}
+
+type Repository interface {
+	Snapshot(ctx context.Context, workspaceID string) (Snapshot, error)
+	Connector(ctx context.Context, connectorKey, workspaceID string) (Connector, error)
+	Operation(ctx context.Context, operationID string) (Operation, error)
+	Transaction(ctx context.Context, fn func(Transaction) error) error
+	RecoverableOperations(ctx context.Context) ([]Operation, error)
+}
+
+type Transaction interface {
+	Revision() uint64
+	AdvanceRevision() uint64
+	Connectors() ([]Connector, error)
+	Connector(connectorKey string) (Connector, error)
+	Operation(operationID string) (Operation, error)
+	OperationByClientRequestID(clientRequestID string) (*Operation, error)
+	ActiveOperation(connectorKey string) (*Operation, error)
+	SaveCatalogRevision(sourceRevision string) error
+	SetCatalogState(state CatalogState) error
+	SaveConnector(Connector) error
+	DeleteConnector(connectorKey string) error
+	SaveOperation(Operation) error
+	SetWorkspaceBinding(connectorKey string, binding WorkspaceBinding) (Connector, error)
+}
+
+type ArtifactInstaller interface {
+	Install(ctx context.Context, manifest Manifest) error
+	Uninstall(ctx context.Context, connector Connector) error
+}
+
+type AuthorizationProvider interface {
+	Begin(ctx context.Context, connector Connector, clientRequestID string) (authorizationURL string, err error)
+	Disconnect(ctx context.Context, connector Connector) error
+}
+
+type CompatibilityEvaluator interface {
+	Evaluate(manifest Manifest) Compatibility
+}
+
+type OperationScheduler interface {
+	Schedule(ctx context.Context, operationID string) error
+}
+
+type EventPublisher interface {
+	ConnectorMarketChanged(ctx context.Context, event ChangedEvent) error
+}
+
+type ChangedEvent struct {
+	ConnectorKey string `json:"connectorKey,omitempty"`
+	OperationID  string `json:"operationId,omitempty"`
+	Revision     uint64 `json:"revision"`
+}

--- a/packages/connector/market/daemon/service.go
+++ b/packages/connector/market/daemon/service.go
@@ -1,0 +1,20 @@
+package daemon
+
+import "context"
+
+// Service is the host-neutral connector-market application boundary. Host
+// daemons provide ports for persistence, artifacts, authorization, scheduling,
+// and events; transports adapt their generated OpenAPI DTOs to this interface.
+type Service interface {
+	Snapshot(ctx context.Context, workspaceID string) (Snapshot, error)
+	GetConnector(ctx context.Context, connectorKey, workspaceID string) (Connector, error)
+	GetOperation(ctx context.Context, operationID string) (Operation, error)
+	RefreshCatalog(ctx context.Context, mutation Mutation) (MutationResult, error)
+	Install(ctx context.Context, mutation ConnectorMutation) (MutationResult, error)
+	Uninstall(ctx context.Context, mutation ConnectorMutation) (MutationResult, error)
+	BeginAuthorization(ctx context.Context, mutation ConnectorMutation) (AuthorizationResult, error)
+	DisconnectAuthorization(ctx context.Context, mutation ConnectorMutation) (MutationResult, error)
+	SetWorkspaceEnabled(ctx context.Context, command SetWorkspaceEnabledCommand) (WorkspaceBindingResult, error)
+	ExecuteOperation(ctx context.Context, operationID string) error
+	Recover(ctx context.Context) error
+}

--- a/packages/connector/market/daemon/transitions.go
+++ b/packages/connector/market/daemon/transitions.go
@@ -1,0 +1,59 @@
+package daemon
+
+func CanTransitionInstallation(from, to InstallationState) bool {
+	allowed := map[InstallationState]map[InstallationState]bool{
+		InstallationStateNotInstalled: {
+			InstallationStateInstalling: true,
+		},
+		InstallationStateInstalling: {
+			InstallationStateInstalled: true,
+			InstallationStateFailed:    true,
+		},
+		InstallationStateInstalled: {
+			InstallationStateUpdating:     true,
+			InstallationStateUninstalling: true,
+		},
+		InstallationStateUpdating: {
+			InstallationStateInstalled: true,
+			InstallationStateFailed:    true,
+		},
+		InstallationStateUninstalling: {
+			InstallationStateNotInstalled: true,
+			InstallationStateFailed:       true,
+		},
+		InstallationStateFailed: {
+			InstallationStateInstalling:   true,
+			InstallationStateUpdating:     true,
+			InstallationStateUninstalling: true,
+		},
+	}
+	return allowed[from][to]
+}
+
+func CanTransitionAuthorization(from, to AuthorizationState) bool {
+	allowed := map[AuthorizationState]map[AuthorizationState]bool{
+		AuthorizationStateNotRequired: {},
+		AuthorizationStateDisconnected: {
+			AuthorizationStatePending: true,
+		},
+		AuthorizationStatePending: {
+			AuthorizationStateConnected:    true,
+			AuthorizationStateDisconnected: true,
+			AuthorizationStateFailed:       true,
+		},
+		AuthorizationStateConnected: {
+			AuthorizationStateDisconnected: true,
+			AuthorizationStateExpired:      true,
+			AuthorizationStateFailed:       true,
+		},
+		AuthorizationStateExpired: {
+			AuthorizationStatePending:      true,
+			AuthorizationStateDisconnected: true,
+		},
+		AuthorizationStateFailed: {
+			AuthorizationStatePending:      true,
+			AuthorizationStateDisconnected: true,
+		},
+	}
+	return allowed[from][to]
+}

--- a/packages/connector/market/daemon/types.go
+++ b/packages/connector/market/daemon/types.go
@@ -1,0 +1,180 @@
+package daemon
+
+import "time"
+
+type InstallationState string
+
+const (
+	InstallationStateNotInstalled InstallationState = "not_installed"
+	InstallationStateInstalling   InstallationState = "installing"
+	InstallationStateInstalled    InstallationState = "installed"
+	InstallationStateUpdating     InstallationState = "updating"
+	InstallationStateUninstalling InstallationState = "uninstalling"
+	InstallationStateFailed       InstallationState = "failed"
+)
+
+type AuthorizationState string
+
+const (
+	AuthorizationStateNotRequired  AuthorizationState = "not_required"
+	AuthorizationStateDisconnected AuthorizationState = "disconnected"
+	AuthorizationStatePending      AuthorizationState = "pending"
+	AuthorizationStateConnected    AuthorizationState = "connected"
+	AuthorizationStateExpired      AuthorizationState = "expired"
+	AuthorizationStateFailed       AuthorizationState = "failed"
+)
+
+type CompatibilityState string
+
+const (
+	CompatibilityStateSupported                 CompatibilityState = "supported"
+	CompatibilityStateUnsupportedProduct        CompatibilityState = "unsupported_product"
+	CompatibilityStateUnsupportedPlatform       CompatibilityState = "unsupported_platform"
+	CompatibilityStateUnsupportedVersion        CompatibilityState = "unsupported_version"
+	CompatibilityStateUnsupportedImplementation CompatibilityState = "unsupported_implementation"
+)
+
+type CatalogState string
+
+const (
+	CatalogStateReady      CatalogState = "ready"
+	CatalogStateRefreshing CatalogState = "refreshing"
+	CatalogStateStale      CatalogState = "stale"
+	CatalogStateFailed     CatalogState = "failed"
+)
+
+type OperationKind string
+
+const (
+	OperationKindRefreshCatalog          OperationKind = "refresh_catalog"
+	OperationKindInstall                 OperationKind = "install"
+	OperationKindUninstall               OperationKind = "uninstall"
+	OperationKindStartAuthorization      OperationKind = "start_authorization"
+	OperationKindSetWorkspaceEnabled     OperationKind = "set_workspace_enabled"
+	OperationKindDisconnectAuthorization OperationKind = "disconnect_authorization"
+)
+
+type OperationState string
+
+const (
+	OperationStateAccepted  OperationState = "accepted"
+	OperationStateRunning   OperationState = "running"
+	OperationStateCompleted OperationState = "completed"
+	OperationStateFailed    OperationState = "failed"
+)
+
+type Manifest struct {
+	SchemaVersion     string                    `json:"schemaVersion"`
+	Key               string                    `json:"key"`
+	Version           string                    `json:"version"`
+	DisplayName       string                    `json:"displayName"`
+	Description       string                    `json:"description,omitempty"`
+	Permissions       []string                  `json:"permissions"`
+	Artifact          Artifact                  `json:"artifact"`
+	Implementation    Implementation            `json:"implementation"`
+	AuthorizationKind string                    `json:"authorizationKind"`
+	Compatibility     CompatibilityRequirements `json:"compatibility,omitempty"`
+}
+
+type Artifact struct {
+	Key       string `json:"key"`
+	SHA256    string `json:"sha256"`
+	SizeBytes int64  `json:"sizeBytes"`
+}
+
+type CompatibilityRequirements struct {
+	Products           []string `json:"products,omitempty"`
+	Platforms          []string `json:"platforms,omitempty"`
+	MinimumHostVersion string   `json:"minimumHostVersion,omitempty"`
+}
+
+type Implementation struct {
+	Kind   string         `json:"kind"`
+	Config map[string]any `json:"config,omitempty"`
+}
+
+type Installation struct {
+	State            InstallationState `json:"state"`
+	InstalledVersion string            `json:"installedVersion,omitempty"`
+	FailureCode      string            `json:"failureCode,omitempty"`
+}
+
+type Authorization struct {
+	State       AuthorizationState `json:"state"`
+	FailureCode string             `json:"failureCode,omitempty"`
+}
+
+type Compatibility struct {
+	State  CompatibilityState `json:"state"`
+	Reason string             `json:"reason,omitempty"`
+}
+
+type WorkspaceBinding struct {
+	WorkspaceID string `json:"workspaceId"`
+	Enabled     bool   `json:"enabled"`
+}
+
+type Connector struct {
+	Key              string            `json:"key"`
+	Manifest         Manifest          `json:"manifest"`
+	Installation     Installation      `json:"installation"`
+	Authorization    Authorization     `json:"authorization"`
+	Compatibility    Compatibility     `json:"compatibility"`
+	WorkspaceBinding *WorkspaceBinding `json:"workspaceBinding,omitempty"`
+	Revision         uint64            `json:"revision"`
+}
+
+type Operation struct {
+	OperationID     string         `json:"operationId"`
+	ClientRequestID string         `json:"clientRequestId"`
+	ConnectorKey    string         `json:"connectorKey,omitempty"`
+	Kind            OperationKind  `json:"kind"`
+	State           OperationState `json:"state"`
+	Stage           string         `json:"stage,omitempty"`
+	FailureCode     string         `json:"failureCode,omitempty"`
+	CreatedAt       time.Time      `json:"createdAt"`
+	UpdatedAt       time.Time      `json:"updatedAt"`
+}
+
+type Snapshot struct {
+	CatalogState   CatalogState `json:"catalogState"`
+	Connectors     []Connector  `json:"connectors"`
+	Operations     []Operation  `json:"operations"`
+	Revision       uint64       `json:"revision"`
+	SourceRevision string       `json:"sourceRevision,omitempty"`
+}
+
+type Mutation struct {
+	ClientRequestID  string `json:"clientRequestId"`
+	ExpectedRevision uint64 `json:"expectedRevision"`
+}
+
+type ConnectorMutation struct {
+	Mutation
+	ConnectorKey string `json:"connectorKey"`
+}
+
+type SetWorkspaceEnabledCommand struct {
+	ConnectorMutation
+	WorkspaceID string `json:"workspaceId"`
+	Enabled     bool   `json:"enabled"`
+}
+
+type MutationResult struct {
+	Connector *Connector `json:"connector,omitempty"`
+	Operation Operation  `json:"operation"`
+	Revision  uint64     `json:"revision"`
+}
+
+type AuthorizationResult struct {
+	Connector        Connector `json:"connector"`
+	Operation        Operation `json:"operation"`
+	AuthorizationURL string    `json:"authorizationUrl,omitempty"`
+	Revision         uint64    `json:"revision"`
+}
+
+type WorkspaceBindingResult struct {
+	Connector Connector `json:"connector"`
+	Operation Operation `json:"operation"`
+	Revision  uint64    `json:"revision"`
+}

--- a/packages/connector/market/go.mod
+++ b/packages/connector/market/go.mod
@@ -1,0 +1,5 @@
+module github.com/tutti-os/tutti/packages/connector/market
+
+go 1.24.3
+
+toolchain go1.24.5

--- a/packages/connector/market/openapi/connector-market.v1.yaml
+++ b/packages/connector/market/openapi/connector-market.v1.yaml
@@ -1,0 +1,627 @@
+openapi: 3.0.3
+info:
+  title: Connector Market API Fragment
+  version: 1.0.0
+  description: Host-neutral connector catalog, installation, authorization, and workspace-binding contract.
+tags:
+  - name: connector-market
+paths:
+  /v1/connector-market:
+    get:
+      operationId: getConnectorMarket
+      tags: [connector-market]
+      summary: Get the authoritative connector-market snapshot
+      parameters:
+        - $ref: "#/components/parameters/ConnectorMarketWorkspaceID"
+      responses:
+        "200":
+          description: Connector-market snapshot
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectorMarketSnapshot"
+        "400":
+          $ref: "#/components/responses/ConnectorMarketInvalidRequestError"
+        "401":
+          $ref: "#/components/responses/ConnectorMarketUnauthorizedError"
+        "503":
+          $ref: "#/components/responses/ConnectorMarketUnavailableError"
+  /v1/connector-market/connectors/{connectorKey}:
+    parameters:
+      - $ref: "#/components/parameters/ConnectorMarketConnectorKey"
+    get:
+      operationId: getConnectorMarketConnector
+      tags: [connector-market]
+      summary: Get one connector projection
+      parameters:
+        - $ref: "#/components/parameters/ConnectorMarketWorkspaceID"
+      responses:
+        "200":
+          description: Connector projection
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectorMarketConnector"
+        "400":
+          $ref: "#/components/responses/ConnectorMarketInvalidRequestError"
+        "401":
+          $ref: "#/components/responses/ConnectorMarketUnauthorizedError"
+        "404":
+          $ref: "#/components/responses/ConnectorMarketNotFoundError"
+        "503":
+          $ref: "#/components/responses/ConnectorMarketUnavailableError"
+  /v1/connector-market:refresh:
+    post:
+      operationId: refreshConnectorMarket
+      tags: [connector-market]
+      summary: Refresh and accept the upstream connector catalog
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConnectorMarketMutationRequest"
+      responses:
+        "202":
+          description: Refresh operation accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectorMarketMutationResponse"
+        "400":
+          $ref: "#/components/responses/ConnectorMarketInvalidRequestError"
+        "401":
+          $ref: "#/components/responses/ConnectorMarketUnauthorizedError"
+        "409":
+          $ref: "#/components/responses/ConnectorMarketConflictError"
+        "503":
+          $ref: "#/components/responses/ConnectorMarketUnavailableError"
+  /v1/connector-market/connectors/{connectorKey}:install:
+    parameters:
+      - $ref: "#/components/parameters/ConnectorMarketConnectorKey"
+    post:
+      operationId: installConnectorMarketConnector
+      tags: [connector-market]
+      summary: Install or update one connector
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConnectorMarketMutationRequest"
+      responses:
+        "202":
+          description: Installation operation accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectorMarketMutationResponse"
+        "400":
+          $ref: "#/components/responses/ConnectorMarketInvalidRequestError"
+        "401":
+          $ref: "#/components/responses/ConnectorMarketUnauthorizedError"
+        "404":
+          $ref: "#/components/responses/ConnectorMarketNotFoundError"
+        "409":
+          $ref: "#/components/responses/ConnectorMarketConflictError"
+        "422":
+          $ref: "#/components/responses/ConnectorMarketUnprocessableError"
+        "503":
+          $ref: "#/components/responses/ConnectorMarketUnavailableError"
+  /v1/connector-market/connectors/{connectorKey}:uninstall:
+    parameters:
+      - $ref: "#/components/parameters/ConnectorMarketConnectorKey"
+    post:
+      operationId: uninstallConnectorMarketConnector
+      tags: [connector-market]
+      summary: Uninstall one connector
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConnectorMarketMutationRequest"
+      responses:
+        "202":
+          description: Uninstallation operation accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectorMarketMutationResponse"
+        "400":
+          $ref: "#/components/responses/ConnectorMarketInvalidRequestError"
+        "401":
+          $ref: "#/components/responses/ConnectorMarketUnauthorizedError"
+        "404":
+          $ref: "#/components/responses/ConnectorMarketNotFoundError"
+        "409":
+          $ref: "#/components/responses/ConnectorMarketConflictError"
+        "503":
+          $ref: "#/components/responses/ConnectorMarketUnavailableError"
+  /v1/connector-market/connectors/{connectorKey}/authorization:start:
+    parameters:
+      - $ref: "#/components/parameters/ConnectorMarketConnectorKey"
+    post:
+      operationId: startConnectorMarketAuthorization
+      tags: [connector-market]
+      summary: Start connector authorization
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConnectorMarketMutationRequest"
+      responses:
+        "200":
+          description: Authorization attempt started
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectorMarketAuthorizationResponse"
+        "400":
+          $ref: "#/components/responses/ConnectorMarketInvalidRequestError"
+        "401":
+          $ref: "#/components/responses/ConnectorMarketUnauthorizedError"
+        "404":
+          $ref: "#/components/responses/ConnectorMarketNotFoundError"
+        "409":
+          $ref: "#/components/responses/ConnectorMarketConflictError"
+        "503":
+          $ref: "#/components/responses/ConnectorMarketUnavailableError"
+  /v1/connector-market/connectors/{connectorKey}/authorization:disconnect:
+    parameters:
+      - $ref: "#/components/parameters/ConnectorMarketConnectorKey"
+    post:
+      operationId: disconnectConnectorMarketAuthorization
+      tags: [connector-market]
+      summary: Disconnect connector authorization
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConnectorMarketMutationRequest"
+      responses:
+        "202":
+          description: Authorization disconnection accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectorMarketMutationResponse"
+        "400":
+          $ref: "#/components/responses/ConnectorMarketInvalidRequestError"
+        "401":
+          $ref: "#/components/responses/ConnectorMarketUnauthorizedError"
+        "404":
+          $ref: "#/components/responses/ConnectorMarketNotFoundError"
+        "409":
+          $ref: "#/components/responses/ConnectorMarketConflictError"
+        "503":
+          $ref: "#/components/responses/ConnectorMarketUnavailableError"
+  /v1/connector-market/connectors/{connectorKey}/workspace-binding:set:
+    parameters:
+      - $ref: "#/components/parameters/ConnectorMarketConnectorKey"
+    post:
+      operationId: setConnectorMarketWorkspaceBinding
+      tags: [connector-market]
+      summary: Enable or disable a connector for one workspace
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SetConnectorMarketWorkspaceBindingRequest"
+      responses:
+        "200":
+          description: Updated connector projection
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectorMarketConnectorResponse"
+        "400":
+          $ref: "#/components/responses/ConnectorMarketInvalidRequestError"
+        "401":
+          $ref: "#/components/responses/ConnectorMarketUnauthorizedError"
+        "404":
+          $ref: "#/components/responses/ConnectorMarketNotFoundError"
+        "409":
+          $ref: "#/components/responses/ConnectorMarketConflictError"
+        "503":
+          $ref: "#/components/responses/ConnectorMarketUnavailableError"
+  /v1/connector-market/operations/{operationID}:
+    parameters:
+      - $ref: "#/components/parameters/ConnectorMarketOperationID"
+    get:
+      operationId: getConnectorMarketOperation
+      tags: [connector-market]
+      summary: Get one durable connector-market operation
+      responses:
+        "200":
+          description: Connector-market operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectorMarketOperation"
+        "400":
+          $ref: "#/components/responses/ConnectorMarketInvalidRequestError"
+        "401":
+          $ref: "#/components/responses/ConnectorMarketUnauthorizedError"
+        "404":
+          $ref: "#/components/responses/ConnectorMarketNotFoundError"
+        "503":
+          $ref: "#/components/responses/ConnectorMarketUnavailableError"
+components:
+  parameters:
+    ConnectorMarketConnectorKey:
+      name: connectorKey
+      in: path
+      required: true
+      schema:
+        type: string
+        pattern: "^[a-z0-9](?:[a-z0-9._-]{0,126}[a-z0-9])?$"
+    ConnectorMarketOperationID:
+      name: operationID
+      in: path
+      required: true
+      schema:
+        type: string
+        minLength: 1
+    ConnectorMarketWorkspaceID:
+      name: workspaceId
+      in: query
+      required: false
+      schema:
+        type: string
+        minLength: 1
+  responses:
+    ConnectorMarketInvalidRequestError:
+      description: Invalid connector-market request
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ConnectorMarketError"
+    ConnectorMarketUnauthorizedError:
+      description: Daemon authorization is required
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ConnectorMarketError"
+    ConnectorMarketNotFoundError:
+      description: Connector or operation was not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ConnectorMarketError"
+    ConnectorMarketConflictError:
+      description: Revision conflict or operation already in progress
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ConnectorMarketError"
+    ConnectorMarketUnprocessableError:
+      description: Connector is incompatible or its manifest cannot be installed
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ConnectorMarketError"
+    ConnectorMarketUnavailableError:
+      description: Connector-market capability is temporarily unavailable
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ConnectorMarketError"
+  schemas:
+    ConnectorMarketSnapshot:
+      type: object
+      additionalProperties: false
+      required: [catalogState, connectors, operations, revision]
+      properties:
+        catalogState:
+          $ref: "#/components/schemas/ConnectorMarketCatalogState"
+        connectors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ConnectorMarketConnector"
+        operations:
+          type: array
+          items:
+            $ref: "#/components/schemas/ConnectorMarketOperation"
+        revision:
+          type: integer
+          format: int64
+          minimum: 0
+        sourceRevision:
+          type: string
+    ConnectorMarketConnector:
+      type: object
+      additionalProperties: false
+      required:
+        [key, manifest, installation, authorization, compatibility, revision]
+      properties:
+        key:
+          type: string
+        manifest:
+          $ref: "#/components/schemas/ConnectorMarketManifest"
+        installation:
+          $ref: "#/components/schemas/ConnectorMarketInstallation"
+        authorization:
+          $ref: "#/components/schemas/ConnectorMarketAuthorization"
+        compatibility:
+          $ref: "#/components/schemas/ConnectorMarketCompatibility"
+        workspaceBinding:
+          $ref: "#/components/schemas/ConnectorMarketWorkspaceBinding"
+        revision:
+          type: integer
+          format: int64
+          minimum: 0
+    ConnectorMarketManifest:
+      type: object
+      additionalProperties: false
+      required:
+        [
+          schemaVersion,
+          key,
+          version,
+          displayName,
+          permissions,
+          artifact,
+          implementation,
+          authorizationKind
+        ]
+      properties:
+        schemaVersion:
+          type: string
+          enum: ["1"]
+        key:
+          type: string
+        version:
+          type: string
+        displayName:
+          type: string
+        description:
+          type: string
+        permissions:
+          type: array
+          items:
+            type: string
+        artifact:
+          $ref: "#/components/schemas/ConnectorMarketArtifact"
+        implementation:
+          $ref: "#/components/schemas/ConnectorMarketImplementation"
+        authorizationKind:
+          type: string
+        compatibility:
+          $ref: "#/components/schemas/ConnectorMarketCompatibilityRequirements"
+    ConnectorMarketArtifact:
+      type: object
+      additionalProperties: false
+      required: [key, sha256, sizeBytes]
+      properties:
+        key:
+          type: string
+          minLength: 1
+        sha256:
+          type: string
+          pattern: "^[a-f0-9]{64}$"
+        sizeBytes:
+          type: integer
+          format: int64
+          minimum: 1
+    ConnectorMarketCompatibilityRequirements:
+      type: object
+      additionalProperties: false
+      properties:
+        products:
+          type: array
+          items:
+            type: string
+        platforms:
+          type: array
+          items:
+            type: string
+        minimumHostVersion:
+          type: string
+    ConnectorMarketImplementation:
+      type: object
+      description: Public implementation discriminator; sensitive host configuration is never returned.
+      additionalProperties: false
+      required: [kind]
+      properties:
+        kind:
+          type: string
+    ConnectorMarketInstallation:
+      type: object
+      additionalProperties: false
+      required: [state]
+      properties:
+        state:
+          $ref: "#/components/schemas/ConnectorMarketInstallationState"
+        installedVersion:
+          type: string
+        failureCode:
+          type: string
+    ConnectorMarketAuthorization:
+      type: object
+      additionalProperties: false
+      required: [state]
+      properties:
+        state:
+          $ref: "#/components/schemas/ConnectorMarketAuthorizationState"
+        failureCode:
+          type: string
+    ConnectorMarketCompatibility:
+      type: object
+      additionalProperties: false
+      required: [state]
+      properties:
+        state:
+          $ref: "#/components/schemas/ConnectorMarketCompatibilityState"
+        reason:
+          type: string
+    ConnectorMarketWorkspaceBinding:
+      type: object
+      additionalProperties: false
+      required: [workspaceId, enabled]
+      properties:
+        workspaceId:
+          type: string
+        enabled:
+          type: boolean
+    ConnectorMarketOperation:
+      type: object
+      additionalProperties: false
+      required:
+        [operationId, clientRequestId, kind, state, createdAt, updatedAt]
+      properties:
+        operationId:
+          type: string
+        clientRequestId:
+          type: string
+        connectorKey:
+          type: string
+        kind:
+          $ref: "#/components/schemas/ConnectorMarketOperationKind"
+        state:
+          $ref: "#/components/schemas/ConnectorMarketOperationState"
+        stage:
+          type: string
+        failureCode:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    ConnectorMarketMutationRequest:
+      type: object
+      additionalProperties: false
+      required: [clientRequestId, expectedRevision]
+      properties:
+        clientRequestId:
+          type: string
+          minLength: 1
+        expectedRevision:
+          type: integer
+          format: int64
+          minimum: 0
+    SetConnectorMarketWorkspaceBindingRequest:
+      type: object
+      additionalProperties: false
+      required: [clientRequestId, expectedRevision, workspaceId, enabled]
+      properties:
+        clientRequestId:
+          type: string
+          minLength: 1
+        expectedRevision:
+          type: integer
+          format: int64
+          minimum: 0
+        workspaceId:
+          type: string
+          minLength: 1
+        enabled:
+          type: boolean
+    ConnectorMarketMutationResponse:
+      type: object
+      additionalProperties: false
+      required: [operation, revision]
+      properties:
+        connector:
+          $ref: "#/components/schemas/ConnectorMarketConnector"
+        operation:
+          $ref: "#/components/schemas/ConnectorMarketOperation"
+        revision:
+          type: integer
+          format: int64
+          minimum: 0
+    ConnectorMarketAuthorizationResponse:
+      type: object
+      additionalProperties: false
+      required: [connector, operation, revision]
+      properties:
+        connector:
+          $ref: "#/components/schemas/ConnectorMarketConnector"
+        operation:
+          $ref: "#/components/schemas/ConnectorMarketOperation"
+        authorizationUrl:
+          type: string
+          format: uri
+        revision:
+          type: integer
+          format: int64
+          minimum: 0
+    ConnectorMarketConnectorResponse:
+      type: object
+      additionalProperties: false
+      required: [connector, operation, revision]
+      properties:
+        connector:
+          $ref: "#/components/schemas/ConnectorMarketConnector"
+        operation:
+          $ref: "#/components/schemas/ConnectorMarketOperation"
+        revision:
+          type: integer
+          format: int64
+          minimum: 0
+    ConnectorMarketError:
+      type: object
+      additionalProperties: false
+      required: [code, message, retryable]
+      properties:
+        code:
+          $ref: "#/components/schemas/ConnectorMarketErrorCode"
+        message:
+          type: string
+        retryable:
+          type: boolean
+        revision:
+          type: integer
+          format: int64
+          minimum: 0
+    ConnectorMarketCatalogState:
+      type: string
+      enum: [ready, refreshing, stale, failed]
+    ConnectorMarketInstallationState:
+      type: string
+      enum:
+        [not_installed, installing, installed, updating, uninstalling, failed]
+    ConnectorMarketAuthorizationState:
+      type: string
+      enum: [not_required, disconnected, pending, connected, expired, failed]
+    ConnectorMarketCompatibilityState:
+      type: string
+      enum:
+        [
+          supported,
+          unsupported_product,
+          unsupported_platform,
+          unsupported_version,
+          unsupported_implementation
+        ]
+    ConnectorMarketOperationKind:
+      type: string
+      enum:
+        - refresh_catalog
+        - install
+        - uninstall
+        - start_authorization
+        - set_workspace_enabled
+        - disconnect_authorization
+    ConnectorMarketOperationState:
+      type: string
+      enum: [accepted, running, completed, failed]
+    ConnectorMarketErrorCode:
+      type: string
+      enum:
+        - connector_market_invalid_request
+        - connector_not_found
+        - connector_market_revision_conflict
+        - connector_operation_in_progress
+        - connector_incompatible
+        - connector_manifest_invalid
+        - connector_implementation_unsupported
+        - connector_market_upstream_unavailable
+        - connector_install_failed
+        - connector_authorization_failed
+        - connector_market_unavailable

--- a/packages/connector/market/package.json
+++ b/packages/connector/market/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@tutti-os/connector-market",
+  "version": "0.1.0",
+  "private": false,
+  "type": "module",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./contracts": "./src/contracts/index.ts",
+    "./openapi/connector-market.v1.yaml": "./openapi/connector-market.v1.yaml",
+    "./react": "./src/react/index.ts",
+    "./services": "./src/services/index.ts"
+  },
+  "files": [
+    "dist",
+    "openapi",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tutti-os/tutti.git",
+    "directory": "packages/connector/market"
+  },
+  "scripts": {
+    "build": "tsup --config tsup.config.ts",
+    "test": "tsx --test \"./src/**/*.test.ts\"",
+    "typecheck": "node ../../../tools/scripts/run-tsgo-typecheck.mjs"
+  },
+  "dependencies": {
+    "@tutti-os/infra": "0.1.0",
+    "valtio": "^2.3.2"
+  },
+  "devDependencies": {
+    "@tutti-os/config-tsconfig": "workspace:*",
+    "@types/node": "^24.0.1",
+    "@types/react": "^19.1.6",
+    "react": "^19.1.0",
+    "tsx": "^4.22.3",
+    "typescript": "^5.8.3",
+    "valtio": "^2.3.2"
+  },
+  "peerDependencies": {
+    "react": "^19.1.0",
+    "valtio": "^2.3.2"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./contracts": {
+        "types": "./dist/contracts/index.d.ts",
+        "import": "./dist/contracts/index.js"
+      },
+      "./openapi/connector-market.v1.yaml": "./openapi/connector-market.v1.yaml",
+      "./react": {
+        "types": "./dist/react/index.d.ts",
+        "import": "./dist/react/index.js"
+      },
+      "./services": {
+        "types": "./dist/services/index.d.ts",
+        "import": "./dist/services/index.js"
+      }
+    },
+    "types": "./dist/index.d.ts"
+  }
+}

--- a/packages/connector/market/src/contracts/backend.ts
+++ b/packages/connector/market/src/contracts/backend.ts
@@ -1,0 +1,40 @@
+import type {
+  Connector,
+  ConnectorAuthorizationResult,
+  ConnectorMarketMutationInput,
+  ConnectorMarketSnapshot,
+  ConnectorMutationInput,
+  ConnectorMutationResult,
+  ConnectorOperation,
+  ConnectorWorkspaceBindingResult,
+  SetConnectorWorkspaceEnabledInput
+} from "./domain.ts";
+
+export interface ConnectorMarketBackend {
+  getSnapshot(input: {
+    workspaceId?: string;
+  }): Promise<ConnectorMarketSnapshot>;
+  getConnector(input: {
+    connectorKey: string;
+    workspaceId?: string;
+  }): Promise<Connector>;
+  getOperation(input: { operationId: string }): Promise<ConnectorOperation>;
+  refreshCatalog(
+    input: ConnectorMarketMutationInput
+  ): Promise<ConnectorMutationResult>;
+  installConnector(
+    input: ConnectorMutationInput
+  ): Promise<ConnectorMutationResult>;
+  uninstallConnector(
+    input: ConnectorMutationInput
+  ): Promise<ConnectorMutationResult>;
+  beginAuthorization(
+    input: ConnectorMutationInput
+  ): Promise<ConnectorAuthorizationResult>;
+  disconnectAuthorization(
+    input: ConnectorMutationInput
+  ): Promise<ConnectorMutationResult>;
+  setWorkspaceEnabled(
+    input: SetConnectorWorkspaceEnabledInput
+  ): Promise<ConnectorWorkspaceBindingResult>;
+}

--- a/packages/connector/market/src/contracts/domain.ts
+++ b/packages/connector/market/src/contracts/domain.ts
@@ -1,0 +1,164 @@
+export type ConnectorInstallationState =
+  | "not_installed"
+  | "installing"
+  | "installed"
+  | "updating"
+  | "uninstalling"
+  | "failed";
+
+export type ConnectorAuthorizationState =
+  | "not_required"
+  | "disconnected"
+  | "pending"
+  | "connected"
+  | "expired"
+  | "failed";
+
+export type ConnectorCompatibilityState =
+  | "supported"
+  | "unsupported_product"
+  | "unsupported_platform"
+  | "unsupported_version"
+  | "unsupported_implementation";
+
+export type ConnectorCatalogState = "ready" | "refreshing" | "stale" | "failed";
+
+export type ConnectorOperationKind =
+  | "refresh_catalog"
+  | "install"
+  | "uninstall"
+  | "start_authorization"
+  | "set_workspace_enabled"
+  | "disconnect_authorization";
+
+export type ConnectorOperationState =
+  | "accepted"
+  | "running"
+  | "completed"
+  | "failed";
+
+export interface ConnectorManifestImplementation {
+  kind: string;
+}
+
+export interface ConnectorManifestArtifact {
+  key: string;
+  sha256: string;
+  sizeBytes: number;
+}
+
+export interface ConnectorCompatibilityRequirements {
+  products?: string[];
+  platforms?: string[];
+  minimumHostVersion?: string;
+}
+
+export interface ConnectorManifest {
+  schemaVersion: "1";
+  key: string;
+  version: string;
+  displayName: string;
+  description?: string;
+  permissions: string[];
+  artifact: ConnectorManifestArtifact;
+  implementation: ConnectorManifestImplementation;
+  authorizationKind: string;
+  compatibility?: ConnectorCompatibilityRequirements;
+}
+
+export interface ConnectorInstallation {
+  state: ConnectorInstallationState;
+  installedVersion?: string;
+  failureCode?: string;
+}
+
+export interface ConnectorAuthorization {
+  state: ConnectorAuthorizationState;
+  failureCode?: string;
+}
+
+export interface ConnectorCompatibility {
+  state: ConnectorCompatibilityState;
+  reason?: string;
+}
+
+export interface ConnectorWorkspaceBinding {
+  workspaceId: string;
+  enabled: boolean;
+}
+
+export interface Connector {
+  key: string;
+  manifest: ConnectorManifest;
+  installation: ConnectorInstallation;
+  authorization: ConnectorAuthorization;
+  compatibility: ConnectorCompatibility;
+  workspaceBinding?: ConnectorWorkspaceBinding;
+  revision: number;
+}
+
+export interface ConnectorOperation {
+  operationId: string;
+  clientRequestId: string;
+  connectorKey?: string;
+  kind: ConnectorOperationKind;
+  state: ConnectorOperationState;
+  stage?: string;
+  failureCode?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ConnectorMarketSnapshot {
+  catalogState: ConnectorCatalogState;
+  connectors: Connector[];
+  operations: ConnectorOperation[];
+  revision: number;
+  sourceRevision?: string;
+}
+
+export interface ConnectorMarketMutationInput {
+  clientRequestId: string;
+  expectedRevision: number;
+}
+
+export interface ConnectorMutationInput extends ConnectorMarketMutationInput {
+  connectorKey: string;
+}
+
+export interface SetConnectorWorkspaceEnabledInput extends ConnectorMutationInput {
+  workspaceId: string;
+  enabled: boolean;
+}
+
+export interface ConnectorMutationResult {
+  connector?: Connector;
+  operation: ConnectorOperation;
+  revision: number;
+}
+
+export interface ConnectorAuthorizationResult {
+  connector: Connector;
+  operation: ConnectorOperation;
+  authorizationUrl?: string;
+  revision: number;
+}
+
+export interface ConnectorWorkspaceBindingResult {
+  connector: Connector;
+  operation: ConnectorOperation;
+  revision: number;
+}
+
+export interface ConnectorMarketChangedEvent {
+  type: "connector.market.changed";
+  revision: number;
+  connectorKey?: string;
+  operationId?: string;
+}
+
+export interface ConnectorMarketErrorShape {
+  code: string;
+  message: string;
+  retryable: boolean;
+}

--- a/packages/connector/market/src/contracts/events.ts
+++ b/packages/connector/market/src/contracts/events.ts
@@ -1,0 +1,5 @@
+import type { ConnectorMarketChangedEvent } from "./domain.ts";
+
+export interface ConnectorMarketEventSource {
+  subscribe(listener: (event: ConnectorMarketChangedEvent) => void): () => void;
+}

--- a/packages/connector/market/src/contracts/index.ts
+++ b/packages/connector/market/src/contracts/index.ts
@@ -1,0 +1,3 @@
+export type { ConnectorMarketBackend } from "./backend.ts";
+export type { ConnectorMarketEventSource } from "./events.ts";
+export type * from "./domain.ts";

--- a/packages/connector/market/src/index.ts
+++ b/packages/connector/market/src/index.ts
@@ -1,0 +1,2 @@
+export type * from "./contracts/index.ts";
+export * from "./services/index.ts";

--- a/packages/connector/market/src/react/index.ts
+++ b/packages/connector/market/src/react/index.ts
@@ -1,0 +1,9 @@
+import { useSnapshot } from "valtio";
+
+import type { IConnectorMarketService } from "../services/index.ts";
+
+export function useConnectorMarketSnapshot(
+  service: Pick<IConnectorMarketService, "dataStore">
+) {
+  return useSnapshot(service.dataStore);
+}

--- a/packages/connector/market/src/services/connectorMarketService.interface.ts
+++ b/packages/connector/market/src/services/connectorMarketService.interface.ts
@@ -1,0 +1,61 @@
+import { createDecorator } from "@tutti-os/infra/di";
+
+import type {
+  Connector,
+  ConnectorCatalogState,
+  ConnectorMarketBackend,
+  ConnectorMarketErrorShape,
+  ConnectorMarketEventSource,
+  ConnectorOperation
+} from "../contracts/index.ts";
+
+export type ConnectorMarketLoadState = "idle" | "loading" | "ready" | "error";
+
+export interface ConnectorMarketStoreState {
+  loadState: ConnectorMarketLoadState;
+  catalogState: ConnectorCatalogState;
+  catalogOperation: ConnectorOperation | null;
+  connectorsByKey: Record<string, Connector>;
+  connectorKeys: string[];
+  operationsByConnectorKey: Record<string, ConnectorOperation>;
+  lastError: ConnectorMarketErrorShape | null;
+  revision: number;
+  workspaceId?: string;
+}
+
+export interface ConnectorMarketServiceDependencies {
+  backend: ConnectorMarketBackend;
+  events?: ConnectorMarketEventSource;
+  workspaceId?: string;
+  createRequestId?: () => string;
+  openAuthorizationUrl?: (url: string) => Promise<void>;
+  reportDiagnostic?: (error: unknown) => void;
+}
+
+/**
+ * Host-neutral renderer domain service. The host owns transport construction and
+ * injects it through `ConnectorMarketServiceDependencies`.
+ */
+export interface IConnectorMarketService {
+  readonly _serviceBrand: undefined;
+  readonly dataStore: ConnectorMarketStoreState;
+
+  /** Connects long-lived event sources. Repeated calls are idempotent. */
+  start(): void;
+  ensureLoaded(): Promise<void>;
+  reload(): Promise<void>;
+  refreshCatalog(): Promise<void>;
+  install(connectorKey: string): Promise<void>;
+  uninstall(connectorKey: string): Promise<void>;
+  beginAuthorization(connectorKey: string): Promise<void>;
+  disconnectAuthorization(connectorKey: string): Promise<void>;
+  setWorkspaceEnabled(connectorKey: string, enabled: boolean): Promise<void>;
+  setWorkspace(workspaceId?: string): Promise<void>;
+
+  /** Releases subscriptions and makes the service terminal. */
+  dispose(): void;
+}
+
+export const IConnectorMarketService = createDecorator<IConnectorMarketService>(
+  "connector-market-service"
+);

--- a/packages/connector/market/src/services/connectorMarketService.test.ts
+++ b/packages/connector/market/src/services/connectorMarketService.test.ts
@@ -1,0 +1,301 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type {
+  Connector,
+  ConnectorMarketBackend,
+  ConnectorMarketChangedEvent,
+  ConnectorMarketEventSource,
+  ConnectorMarketSnapshot
+} from "../contracts/index.ts";
+import {
+  ConnectorMarketBusyError,
+  ConnectorMarketService
+} from "./connectorMarketService.ts";
+
+function connector(
+  key: string,
+  revision: number,
+  workspaceId = "workspace-1"
+): Connector {
+  return {
+    key,
+    manifest: {
+      schemaVersion: "1",
+      key,
+      version: "1.0.0",
+      displayName: key,
+      permissions: [],
+      artifact: {
+        key: `connectors/${key}/1.0.0.tgz`,
+        sha256:
+          "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        sizeBytes: 1024
+      },
+      implementation: { kind: "mcp_stdio" },
+      authorizationKind: "none"
+    },
+    installation: { state: "not_installed" },
+    authorization: { state: "not_required" },
+    compatibility: { state: "supported" },
+    workspaceBinding: { workspaceId, enabled: false },
+    revision
+  };
+}
+
+function snapshot(
+  revision: number,
+  connectors: Connector[]
+): ConnectorMarketSnapshot {
+  return {
+    catalogState: "ready",
+    connectors,
+    operations: [],
+    revision
+  };
+}
+
+function backendWith(
+  overrides: Partial<ConnectorMarketBackend>
+): ConnectorMarketBackend {
+  const unsupported = async (): Promise<never> => {
+    throw new Error("not implemented in test");
+  };
+  return {
+    getSnapshot: async () => snapshot(0, []),
+    getConnector: unsupported,
+    getOperation: unsupported,
+    refreshCatalog: unsupported,
+    installConnector: unsupported,
+    uninstallConnector: unsupported,
+    beginAuthorization: unsupported,
+    disconnectAuthorization: unsupported,
+    setWorkspaceEnabled: unsupported,
+    ...overrides
+  };
+}
+
+test("exposes commands directly on a class service and state through dataStore", async () => {
+  const service = new ConnectorMarketService({
+    backend: backendWith({
+      getSnapshot: async () => snapshot(1, [connector("github", 1)])
+    })
+  });
+
+  await service.ensureLoaded();
+
+  assert.deepEqual(service.dataStore.connectorKeys, ["github"]);
+  assert.equal(service.dataStore.loadState, "ready");
+  service.dispose();
+});
+
+test("ignores a stale workspace response after switching workspaces", async () => {
+  const first = deferred<ConnectorMarketSnapshot>();
+  const second = deferred<ConnectorMarketSnapshot>();
+  const backend = backendWith({
+    getSnapshot: async ({ workspaceId }) =>
+      workspaceId === "workspace-1" ? first.promise : second.promise
+  });
+  const service = new ConnectorMarketService({
+    backend,
+    workspaceId: "workspace-1"
+  });
+
+  const initialLoad = service.ensureLoaded();
+  const switchWorkspace = service.setWorkspace("workspace-2");
+  second.resolve(snapshot(2, [connector("linear", 2, "workspace-2")]));
+  await switchWorkspace;
+  first.resolve(snapshot(1, [connector("github", 1)]));
+  await initialLoad;
+
+  assert.deepEqual(service.dataStore.connectorKeys, ["linear"]);
+  assert.equal(service.dataStore.workspaceId, "workspace-2");
+  service.dispose();
+});
+
+test("coalesces concurrent catalog refreshes", async () => {
+  const refresh =
+    deferred<Awaited<ReturnType<ConnectorMarketBackend["refreshCatalog"]>>>();
+  let calls = 0;
+  const service = new ConnectorMarketService({
+    backend: backendWith({
+      refreshCatalog: async () => {
+        calls += 1;
+        return refresh.promise;
+      }
+    }),
+    createRequestId: () => "request-1"
+  });
+
+  const first = service.refreshCatalog();
+  const second = service.refreshCatalog();
+  assert.equal(calls, 1);
+  refresh.resolve({
+    operation: {
+      operationId: "operation-1",
+      clientRequestId: "request-1",
+      kind: "refresh_catalog",
+      state: "accepted",
+      createdAt: "2026-08-03T00:00:00Z",
+      updatedAt: "2026-08-03T00:00:00Z"
+    },
+    revision: 1
+  });
+  await Promise.all([first, second]);
+
+  assert.equal(service.dataStore.revision, 1);
+  assert.equal(service.dataStore.catalogOperation?.operationId, "operation-1");
+  service.dispose();
+});
+
+test("rejects overlapping mutations for one connector", async () => {
+  const install =
+    deferred<Awaited<ReturnType<ConnectorMarketBackend["installConnector"]>>>();
+  const service = new ConnectorMarketService({
+    backend: backendWith({ installConnector: async () => install.promise }),
+    createRequestId: () => "request-1"
+  });
+
+  const first = service.install("github");
+  await assert.rejects(service.install("github"), ConnectorMarketBusyError);
+  install.resolve({
+    connector: connector("github", 1),
+    operation: {
+      operationId: "operation-1",
+      clientRequestId: "request-1",
+      connectorKey: "github",
+      kind: "install",
+      state: "accepted",
+      createdAt: "2026-08-03T00:00:00Z",
+      updatedAt: "2026-08-03T00:00:00Z"
+    },
+    revision: 1
+  });
+  await first;
+
+  assert.equal(
+    service.dataStore.operationsByConnectorKey.github?.operationId,
+    "operation-1"
+  );
+  service.dispose();
+});
+
+test("rolls back optimistic workspace enablement when the daemon rejects it", async () => {
+  const update =
+    deferred<
+      Awaited<ReturnType<ConnectorMarketBackend["setWorkspaceEnabled"]>>
+    >();
+  const service = new ConnectorMarketService({
+    backend: backendWith({
+      getSnapshot: async () => snapshot(1, [connector("github", 1)]),
+      setWorkspaceEnabled: async () => update.promise
+    }),
+    workspaceId: "workspace-1"
+  });
+  await service.ensureLoaded();
+
+  const mutation = service.setWorkspaceEnabled("github", true);
+  assert.equal(
+    service.dataStore.connectorsByKey.github?.workspaceBinding?.enabled,
+    true
+  );
+  update.reject(new Error("daemon rejected mutation"));
+  await assert.rejects(mutation, /daemon rejected mutation/);
+
+  assert.equal(
+    service.dataStore.connectorsByKey.github?.workspaceBinding?.enabled,
+    false
+  );
+  service.dispose();
+});
+
+test("connects events only during start and disposes the subscription once", async () => {
+  const events = new TestEventSource();
+  let revision = 1;
+  let loads = 0;
+  const service = new ConnectorMarketService({
+    backend: backendWith({
+      getSnapshot: async () => {
+        loads += 1;
+        return snapshot(revision, [connector("github", revision)]);
+      }
+    }),
+    events
+  });
+  await service.ensureLoaded();
+
+  revision = 2;
+  events.emit({ type: "connector.market.changed", revision: 2 });
+  await Promise.resolve();
+  assert.equal(loads, 1);
+
+  service.start();
+  service.start();
+  events.emit({ type: "connector.market.changed", revision: 2 });
+  await waitFor(() => service.dataStore.revision === 2);
+  assert.equal(loads, 2);
+  assert.equal(events.subscribeCalls, 1);
+
+  service.dispose();
+  service.dispose();
+  assert.equal(events.unsubscribeCalls, 1);
+  revision = 3;
+  events.emit({ type: "connector.market.changed", revision: 3 });
+  await Promise.resolve();
+  assert.equal(loads, 2);
+});
+
+test("does not publish an in-flight response after disposal", async () => {
+  const pending = deferred<ConnectorMarketSnapshot>();
+  const service = new ConnectorMarketService({
+    backend: backendWith({ getSnapshot: async () => pending.promise })
+  });
+
+  const load = service.ensureLoaded();
+  service.dispose();
+  pending.resolve(snapshot(1, [connector("github", 1)]));
+  await load;
+
+  assert.deepEqual(service.dataStore.connectorKeys, []);
+  assert.equal(service.dataStore.loadState, "idle");
+  assert.equal(service.dataStore.workspaceId, undefined);
+});
+
+class TestEventSource implements ConnectorMarketEventSource {
+  subscribeCalls = 0;
+  unsubscribeCalls = 0;
+  private listener?: (event: ConnectorMarketChangedEvent) => void;
+
+  subscribe(listener: (event: ConnectorMarketChangedEvent) => void) {
+    this.subscribeCalls += 1;
+    this.listener = listener;
+    return () => {
+      this.unsubscribeCalls += 1;
+      this.listener = undefined;
+    };
+  }
+
+  emit(event: ConnectorMarketChangedEvent) {
+    this.listener?.(event);
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  assert.fail("condition was not met");
+}

--- a/packages/connector/market/src/services/connectorMarketService.ts
+++ b/packages/connector/market/src/services/connectorMarketService.ts
@@ -1,0 +1,351 @@
+import { proxy } from "valtio/vanilla";
+
+import type {
+  ConnectorMarketEventSource,
+  ConnectorMutationResult
+} from "../contracts/index.ts";
+import type {
+  ConnectorMarketServiceDependencies,
+  ConnectorMarketStoreState,
+  IConnectorMarketService
+} from "./connectorMarketService.interface.ts";
+import {
+  applyConnector,
+  applyConnectorMarketSnapshot,
+  applyConnectorMutationResult,
+  clearConnectorMarketStoreState,
+  createConnectorMarketStoreState,
+  normalizeConnectorMarketError,
+  resetConnectorMarketWorkspaceState
+} from "./connectorMarketState.ts";
+
+export class ConnectorMarketBusyError extends Error {
+  readonly code = "connector_operation_in_progress";
+
+  constructor(readonly connectorKey: string) {
+    super(`A connector operation is already in progress for ${connectorKey}`);
+    this.name = "ConnectorMarketBusyError";
+  }
+}
+
+/**
+ * Owns connector-market renderer state and behavior. HTTP clients and desktop
+ * capabilities are host adapters supplied through the constructor.
+ */
+export class ConnectorMarketService implements IConnectorMarketService {
+  declare readonly _serviceBrand: undefined;
+  readonly dataStore: ConnectorMarketStoreState;
+
+  private readonly createRequestId: () => string;
+  private readonly reportDiagnostic: (error: unknown) => void;
+  private readonly connectorMutations = new Map<string, symbol>();
+  private eventUnsubscribe: (() => void) | null = null;
+  private refreshInFlight: Promise<void> | null = null;
+  private loadSequence = 0;
+  private workspaceGeneration = 0;
+  private started = false;
+  private disposed = false;
+
+  constructor(
+    private readonly dependencies: ConnectorMarketServiceDependencies
+  ) {
+    this.dataStore = proxy<ConnectorMarketStoreState>(
+      createConnectorMarketStoreState(dependencies.workspaceId)
+    );
+    this.createRequestId =
+      dependencies.createRequestId ?? (() => crypto.randomUUID());
+    this.reportDiagnostic = dependencies.reportDiagnostic ?? (() => undefined);
+  }
+
+  start(): void {
+    if (this.started || this.disposed) {
+      return;
+    }
+    this.started = true;
+    this.eventUnsubscribe = this.subscribeToEvents(this.dependencies.events);
+  }
+
+  ensureLoaded(): Promise<void> {
+    if (this.disposed || this.dataStore.loadState !== "idle") {
+      return Promise.resolve();
+    }
+    return this.load(true);
+  }
+
+  reload(): Promise<void> {
+    if (this.disposed) {
+      return Promise.resolve();
+    }
+    return this.load(this.dataStore.loadState === "idle");
+  }
+
+  refreshCatalog(): Promise<void> {
+    if (this.disposed) {
+      return Promise.resolve();
+    }
+    if (this.refreshInFlight) {
+      return this.refreshInFlight;
+    }
+    const generation = this.workspaceGeneration;
+    this.dataStore.catalogState = "refreshing";
+    const promise = this.dependencies.backend
+      .refreshCatalog({
+        clientRequestId: this.createRequestId(),
+        expectedRevision: this.dataStore.revision
+      })
+      .then((result) => {
+        if (this.isCurrent(generation)) {
+          applyConnectorMutationResult(this.dataStore, result);
+        }
+      })
+      .catch((error) => {
+        if (this.isCurrent(generation)) {
+          this.dataStore.catalogState = "failed";
+          this.recordError(error);
+        }
+        throw error;
+      })
+      .finally(() => {
+        if (this.refreshInFlight === promise) {
+          this.refreshInFlight = null;
+        }
+      });
+    this.refreshInFlight = promise;
+    return promise;
+  }
+
+  install(connectorKey: string): Promise<void> {
+    return this.runConnectorMutation(connectorKey, () =>
+      this.dependencies.backend.installConnector({
+        connectorKey,
+        clientRequestId: this.createRequestId(),
+        expectedRevision: this.dataStore.revision
+      })
+    );
+  }
+
+  uninstall(connectorKey: string): Promise<void> {
+    return this.runConnectorMutation(connectorKey, () =>
+      this.dependencies.backend.uninstallConnector({
+        connectorKey,
+        clientRequestId: this.createRequestId(),
+        expectedRevision: this.dataStore.revision
+      })
+    );
+  }
+
+  async beginAuthorization(connectorKey: string): Promise<void> {
+    if (this.disposed) {
+      return;
+    }
+    const token = this.acquireConnectorMutation(connectorKey);
+    const generation = this.workspaceGeneration;
+    try {
+      const result = await this.dependencies.backend.beginAuthorization({
+        connectorKey,
+        clientRequestId: this.createRequestId(),
+        expectedRevision: this.dataStore.revision
+      });
+      if (!this.isCurrentMutation(connectorKey, token, generation)) {
+        return;
+      }
+      applyConnector(this.dataStore, result.connector);
+      this.dataStore.operationsByConnectorKey[connectorKey] = result.operation;
+      this.dataStore.revision = Math.max(
+        this.dataStore.revision,
+        result.revision
+      );
+      this.dataStore.lastError = null;
+      if (result.authorizationUrl && this.dependencies.openAuthorizationUrl) {
+        await this.dependencies.openAuthorizationUrl(result.authorizationUrl);
+      }
+    } catch (error) {
+      if (this.isCurrentMutation(connectorKey, token, generation)) {
+        this.recordError(error);
+      }
+      throw error;
+    } finally {
+      this.releaseConnectorMutation(connectorKey, token);
+    }
+  }
+
+  disconnectAuthorization(connectorKey: string): Promise<void> {
+    return this.runConnectorMutation(connectorKey, () =>
+      this.dependencies.backend.disconnectAuthorization({
+        connectorKey,
+        clientRequestId: this.createRequestId(),
+        expectedRevision: this.dataStore.revision
+      })
+    );
+  }
+
+  async setWorkspaceEnabled(
+    connectorKey: string,
+    enabled: boolean
+  ): Promise<void> {
+    if (this.disposed) {
+      return;
+    }
+    const workspaceId = this.dataStore.workspaceId;
+    if (!workspaceId) {
+      throw new Error("A workspace is required to change connector enablement");
+    }
+    const token = this.acquireConnectorMutation(connectorKey);
+    const generation = this.workspaceGeneration;
+    const connector = this.dataStore.connectorsByKey[connectorKey];
+    const previous = connector?.workspaceBinding;
+    if (connector) {
+      connector.workspaceBinding = { workspaceId, enabled };
+    }
+    try {
+      const result = await this.dependencies.backend.setWorkspaceEnabled({
+        connectorKey,
+        workspaceId,
+        enabled,
+        clientRequestId: this.createRequestId(),
+        expectedRevision: this.dataStore.revision
+      });
+      if (!this.isCurrentMutation(connectorKey, token, generation)) {
+        return;
+      }
+      applyConnector(this.dataStore, result.connector);
+      this.dataStore.operationsByConnectorKey[connectorKey] = result.operation;
+      this.dataStore.revision = Math.max(
+        this.dataStore.revision,
+        result.revision
+      );
+      this.dataStore.lastError = null;
+    } catch (error) {
+      if (this.isCurrentMutation(connectorKey, token, generation)) {
+        if (connector) {
+          connector.workspaceBinding = previous;
+        }
+        this.recordError(error);
+      }
+      throw error;
+    } finally {
+      this.releaseConnectorMutation(connectorKey, token);
+    }
+  }
+
+  async setWorkspace(workspaceId?: string): Promise<void> {
+    if (this.disposed || this.dataStore.workspaceId === workspaceId) {
+      return;
+    }
+    this.workspaceGeneration += 1;
+    this.loadSequence += 1;
+    this.connectorMutations.clear();
+    this.refreshInFlight = null;
+    resetConnectorMarketWorkspaceState(this.dataStore, workspaceId);
+    await this.load(false);
+  }
+
+  dispose(): void {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    this.workspaceGeneration += 1;
+    this.loadSequence += 1;
+    this.connectorMutations.clear();
+    this.refreshInFlight = null;
+    this.eventUnsubscribe?.();
+    this.eventUnsubscribe = null;
+    clearConnectorMarketStoreState(this.dataStore);
+  }
+
+  private async load(showLoading: boolean): Promise<void> {
+    const sequence = ++this.loadSequence;
+    const generation = this.workspaceGeneration;
+    const workspaceId = this.dataStore.workspaceId;
+    if (showLoading && this.dataStore.loadState === "idle") {
+      this.dataStore.loadState = "loading";
+    }
+    try {
+      const next = await this.dependencies.backend.getSnapshot({ workspaceId });
+      if (!this.isCurrent(generation) || sequence !== this.loadSequence) {
+        return;
+      }
+      applyConnectorMarketSnapshot(this.dataStore, next);
+    } catch (error) {
+      if (!this.isCurrent(generation) || sequence !== this.loadSequence) {
+        return;
+      }
+      this.dataStore.loadState = "error";
+      this.recordError(error);
+      throw error;
+    }
+  }
+
+  private async runConnectorMutation(
+    connectorKey: string,
+    operation: () => Promise<ConnectorMutationResult>
+  ): Promise<void> {
+    if (this.disposed) {
+      return;
+    }
+    const token = this.acquireConnectorMutation(connectorKey);
+    const generation = this.workspaceGeneration;
+    try {
+      const result = await operation();
+      if (this.isCurrentMutation(connectorKey, token, generation)) {
+        applyConnectorMutationResult(this.dataStore, result);
+      }
+    } catch (error) {
+      if (this.isCurrentMutation(connectorKey, token, generation)) {
+        this.recordError(error);
+      }
+      throw error;
+    } finally {
+      this.releaseConnectorMutation(connectorKey, token);
+    }
+  }
+
+  private acquireConnectorMutation(connectorKey: string): symbol {
+    if (this.connectorMutations.has(connectorKey)) {
+      throw new ConnectorMarketBusyError(connectorKey);
+    }
+    const token = Symbol(connectorKey);
+    this.connectorMutations.set(connectorKey, token);
+    return token;
+  }
+
+  private releaseConnectorMutation(connectorKey: string, token: symbol): void {
+    if (this.connectorMutations.get(connectorKey) === token) {
+      this.connectorMutations.delete(connectorKey);
+    }
+  }
+
+  private isCurrent(generation: number): boolean {
+    return !this.disposed && generation === this.workspaceGeneration;
+  }
+
+  private isCurrentMutation(
+    connectorKey: string,
+    token: symbol,
+    generation: number
+  ): boolean {
+    return (
+      this.isCurrent(generation) &&
+      this.connectorMutations.get(connectorKey) === token
+    );
+  }
+
+  private recordError(error: unknown): void {
+    this.dataStore.lastError = normalizeConnectorMarketError(error);
+    this.reportDiagnostic(error);
+  }
+
+  private subscribeToEvents(
+    events: ConnectorMarketEventSource | undefined
+  ): (() => void) | null {
+    return (
+      events?.subscribe((event) => {
+        if (this.disposed || event.revision <= this.dataStore.revision) {
+          return;
+        }
+        void this.load(false).catch(() => undefined);
+      }) ?? null
+    );
+  }
+}

--- a/packages/connector/market/src/services/connectorMarketState.ts
+++ b/packages/connector/market/src/services/connectorMarketState.ts
@@ -1,0 +1,150 @@
+import type {
+  Connector,
+  ConnectorMarketErrorShape,
+  ConnectorMarketSnapshot,
+  ConnectorMutationResult,
+  ConnectorOperation
+} from "../contracts/index.ts";
+import type { ConnectorMarketStoreState } from "./connectorMarketService.interface.ts";
+
+export function createConnectorMarketStoreState(
+  workspaceId?: string
+): ConnectorMarketStoreState {
+  return {
+    loadState: "idle",
+    catalogState: "stale",
+    catalogOperation: null,
+    connectorsByKey: {},
+    connectorKeys: [],
+    operationsByConnectorKey: {},
+    lastError: null,
+    revision: 0,
+    workspaceId
+  };
+}
+
+export function resetConnectorMarketWorkspaceState(
+  state: ConnectorMarketStoreState,
+  workspaceId?: string
+): void {
+  state.workspaceId = workspaceId;
+  state.loadState = "loading";
+  state.connectorsByKey = {};
+  state.connectorKeys = [];
+  state.operationsByConnectorKey = {};
+  state.catalogOperation = null;
+  state.lastError = null;
+}
+
+export function clearConnectorMarketStoreState(
+  state: ConnectorMarketStoreState
+): void {
+  const initial = createConnectorMarketStoreState();
+  state.loadState = initial.loadState;
+  state.catalogState = initial.catalogState;
+  state.catalogOperation = initial.catalogOperation;
+  state.connectorsByKey = initial.connectorsByKey;
+  state.connectorKeys = initial.connectorKeys;
+  state.operationsByConnectorKey = initial.operationsByConnectorKey;
+  state.lastError = initial.lastError;
+  state.revision = initial.revision;
+  state.workspaceId = initial.workspaceId;
+}
+
+export function applyConnectorMarketSnapshot(
+  state: ConnectorMarketStoreState,
+  next: ConnectorMarketSnapshot
+): void {
+  if (next.revision < state.revision) {
+    return;
+  }
+  state.connectorsByKey = Object.fromEntries(
+    next.connectors.map((connector) => [connector.key, connector])
+  );
+  state.connectorKeys = next.connectors.map((connector) => connector.key);
+  state.operationsByConnectorKey = {};
+  state.catalogOperation = null;
+  for (const operation of next.operations) {
+    if (operation.connectorKey) {
+      const current = state.operationsByConnectorKey[operation.connectorKey];
+      if (!current || isNewerConnectorOperation(operation, current)) {
+        state.operationsByConnectorKey[operation.connectorKey] = operation;
+      }
+    } else if (
+      operation.kind === "refresh_catalog" &&
+      (!state.catalogOperation ||
+        isNewerConnectorOperation(operation, state.catalogOperation))
+    ) {
+      state.catalogOperation = operation;
+    }
+  }
+  state.catalogState = next.catalogState;
+  state.revision = next.revision;
+  state.loadState = "ready";
+  state.lastError = null;
+}
+
+export function applyConnectorMutationResult(
+  state: ConnectorMarketStoreState,
+  result: ConnectorMutationResult
+): void {
+  if (result.revision < state.revision) {
+    return;
+  }
+  if (result.connector) {
+    applyConnector(state, result.connector);
+  }
+  if (result.operation.connectorKey) {
+    state.operationsByConnectorKey[result.operation.connectorKey] =
+      result.operation;
+  } else if (result.operation.kind === "refresh_catalog") {
+    state.catalogOperation = result.operation;
+  }
+  state.revision = result.revision;
+  state.lastError = null;
+}
+
+export function applyConnector(
+  state: ConnectorMarketStoreState,
+  connector: Connector
+): void {
+  state.connectorsByKey[connector.key] = connector;
+  if (!state.connectorKeys.includes(connector.key)) {
+    state.connectorKeys.push(connector.key);
+  }
+}
+
+export function normalizeConnectorMarketError(
+  error: unknown
+): ConnectorMarketErrorShape {
+  if (isConnectorMarketError(error)) {
+    return error;
+  }
+  return {
+    code: "connector_market_unknown",
+    message:
+      error instanceof Error ? error.message : "Unknown connector market error",
+    retryable: false
+  };
+}
+
+function isNewerConnectorOperation(
+  candidate: ConnectorOperation,
+  current: ConnectorOperation
+): boolean {
+  return candidate.updatedAt.localeCompare(current.updatedAt) > 0;
+}
+
+function isConnectorMarketError(
+  error: unknown
+): error is ConnectorMarketErrorShape {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  const candidate = error as Partial<ConnectorMarketErrorShape>;
+  return (
+    typeof candidate.code === "string" &&
+    typeof candidate.message === "string" &&
+    typeof candidate.retryable === "boolean"
+  );
+}

--- a/packages/connector/market/src/services/index.ts
+++ b/packages/connector/market/src/services/index.ts
@@ -1,0 +1,10 @@
+export {
+  ConnectorMarketBusyError,
+  ConnectorMarketService
+} from "./connectorMarketService.ts";
+export {
+  IConnectorMarketService,
+  type ConnectorMarketLoadState,
+  type ConnectorMarketServiceDependencies,
+  type ConnectorMarketStoreState
+} from "./connectorMarketService.interface.ts";

--- a/packages/connector/market/tsconfig.json
+++ b/packages/connector/market/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../packages/configs/tsconfig/base.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "jsx": "react-jsx",
+    "types": ["node", "react"]
+  },
+  "include": ["src/**/*", "tsup.config.ts"]
+}

--- a/packages/connector/market/tsup.config.ts
+++ b/packages/connector/market/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  clean: true,
+  dts: true,
+  entry: {
+    index: "src/index.ts",
+    "contracts/index": "src/contracts/index.ts",
+    "react/index": "src/react/index.ts",
+    "services/index": "src/services/index.ts"
+  },
+  external: ["react", "valtio", "valtio/react", "valtio/vanilla"],
+  format: ["esm"],
+  sourcemap: true
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -783,6 +783,34 @@ importers:
 
   packages/configs/tsconfig: {}
 
+  packages/connector/market:
+    dependencies:
+      "@tutti-os/infra":
+        specifier: 0.1.0
+        version: 0.1.0(lodash-es@4.18.1)(react@19.2.6)
+      valtio:
+        specifier: ^2.3.2
+        version: 2.3.2(@types/react@19.2.15)(react@19.2.6)
+    devDependencies:
+      "@tutti-os/config-tsconfig":
+        specifier: workspace:*
+        version: link:../../configs/tsconfig
+      "@types/node":
+        specifier: ^24.0.1
+        version: 24.12.4
+      "@types/react":
+        specifier: ^19.1.6
+        version: 19.2.15
+      react:
+        specifier: ^19.1.0
+        version: 19.2.6
+      tsx:
+        specifier: ^4.22.3
+        version: 4.22.3
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+
   packages/desktop/update-admission:
     dependencies:
       "@tutti-os/ui-i18n-runtime":

--- a/tools/scripts/generate-openapi.mjs
+++ b/tools/scripts/generate-openapi.mjs
@@ -15,6 +15,11 @@ import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import YAML from "yaml";
 
+import {
+  normalizeOpenApiFragmentRefs,
+  resolveOpenApiFragmentPath as resolveFragmentPath
+} from "./openapi-fragments.mjs";
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, "../..");
 const specPath = resolve(
@@ -101,7 +106,10 @@ function generateGo(configPath, outputPath, inputPath) {
 
 function writeComposedOpenAPISpec(outputPath) {
   const document = YAML.parse(readFileSync(specPath, "utf8"));
-  const fragmentRefs = normalizeFragmentRefs(document?.[fragmentExtensionKey]);
+  const fragmentRefs = normalizeOpenApiFragmentRefs(
+    document?.[fragmentExtensionKey],
+    fragmentExtensionKey
+  );
   delete document[fragmentExtensionKey];
 
   for (const fragmentRef of fragmentRefs) {
@@ -114,27 +122,14 @@ function writeComposedOpenAPISpec(outputPath) {
   writeFileSync(outputPath, YAML.stringify(document), "utf8");
 }
 
-function normalizeFragmentRefs(value) {
-  if (value == null) {
-    return [];
-  }
-  if (!Array.isArray(value)) {
-    throw new Error(`${fragmentExtensionKey} must be an array`);
-  }
-  return value.map((entry) => {
-    const fragmentRef = String(entry ?? "").trim();
-    if (fragmentRef === "") {
-      throw new Error(`${fragmentExtensionKey} cannot contain empty entries`);
-    }
-    return fragmentRef;
-  });
-}
-
 function resolveOpenApiFragmentPath(fragmentRef) {
-  if (fragmentRef.startsWith(".")) {
-    return resolve(dirname(specPath), fragmentRef);
-  }
-  return resolve(repoRoot, fragmentRef);
+  return resolveFragmentPath(fragmentRef, {
+    repoRoot,
+    specPath,
+    resolvePackageSpecifier(specifier) {
+      return fileURLToPath(import.meta.resolve(specifier));
+    }
+  });
 }
 
 function mergeOpenApiFragment(document, fragment, fragmentPath) {

--- a/tools/scripts/openapi-fragments.mjs
+++ b/tools/scripts/openapi-fragments.mjs
@@ -1,0 +1,68 @@
+import { dirname, resolve } from "node:path";
+
+export function normalizeOpenApiFragmentRefs(value, extensionKey) {
+  if (value == null) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    throw new Error(`${extensionKey} must be an array`);
+  }
+  return value.map((entry) => normalizeOpenApiFragmentRef(entry, extensionKey));
+}
+
+export function resolveOpenApiFragmentPath(
+  fragmentRef,
+  { repoRoot, specPath, resolvePackageSpecifier }
+) {
+  if (typeof fragmentRef === "string") {
+    if (fragmentRef.startsWith(".")) {
+      return resolve(dirname(specPath), fragmentRef);
+    }
+    return resolve(repoRoot, fragmentRef);
+  }
+
+  const specifier = `${fragmentRef.package}/${fragmentRef.path}`;
+  try {
+    return resolvePackageSpecifier(specifier);
+  } catch (error) {
+    throw new Error(
+      `Cannot resolve OpenAPI fragment ${specifier}; install an exact released package version before generation`,
+      { cause: error }
+    );
+  }
+}
+
+function normalizeOpenApiFragmentRef(entry, extensionKey) {
+  if (typeof entry === "string") {
+    const value = entry.trim();
+    if (value === "") {
+      throw new Error(`${extensionKey} cannot contain empty entries`);
+    }
+    return value;
+  }
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    throw new Error(
+      `${extensionKey} entries must be paths or package/path objects`
+    );
+  }
+  const packageName = String(entry.package ?? "").trim();
+  const packagePath = String(entry.path ?? "").trim();
+  const keys = Object.keys(entry);
+  if (
+    packageName === "" ||
+    packagePath === "" ||
+    keys.some((key) => key !== "package" && key !== "path")
+  ) {
+    throw new Error(
+      `${extensionKey} package entries require only non-empty package and path fields`
+    );
+  }
+  const packagePathSegments = packagePath.split(/[\\/]/u);
+  if (
+    packagePath.startsWith("/") ||
+    packagePathSegments.some((segment) => segment === "." || segment === "..")
+  ) {
+    throw new Error(`${extensionKey} package paths must be package-relative`);
+  }
+  return { package: packageName, path: packagePath };
+}

--- a/tools/scripts/openapi-fragments.test.mjs
+++ b/tools/scripts/openapi-fragments.test.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  normalizeOpenApiFragmentRefs,
+  resolveOpenApiFragmentPath
+} from "./openapi-fragments.mjs";
+
+const extensionKey = "x-tutti-openapi-fragments";
+
+test("normalizes repository and package fragment references", () => {
+  assert.deepEqual(
+    normalizeOpenApiFragmentRefs(
+      [
+        "packages/workspace/issue-manager/openapi/issue-manager.v1.yaml",
+        {
+          package: "@tutti-os/connector-market",
+          path: "openapi/connector-market.v1.yaml"
+        }
+      ],
+      extensionKey
+    ),
+    [
+      "packages/workspace/issue-manager/openapi/issue-manager.v1.yaml",
+      {
+        package: "@tutti-os/connector-market",
+        path: "openapi/connector-market.v1.yaml"
+      }
+    ]
+  );
+});
+
+test("resolves package fragments through package exports", () => {
+  const resolved = resolveOpenApiFragmentPath(
+    {
+      package: "@tutti-os/connector-market",
+      path: "openapi/connector-market.v1.yaml"
+    },
+    {
+      repoRoot: "/repo",
+      specPath: "/repo/services/daemon/openapi.yaml",
+      resolvePackageSpecifier(specifier) {
+        assert.equal(
+          specifier,
+          "@tutti-os/connector-market/openapi/connector-market.v1.yaml"
+        );
+        return "/node_modules/@tutti-os/connector-market/openapi/connector-market.v1.yaml";
+      }
+    }
+  );
+  assert.equal(
+    resolved,
+    "/node_modules/@tutti-os/connector-market/openapi/connector-market.v1.yaml"
+  );
+});
+
+test("rejects package paths that escape the package export boundary", () => {
+  assert.throws(
+    () =>
+      normalizeOpenApiFragmentRefs(
+        [{ package: "@tutti-os/connector-market", path: "../private.yaml" }],
+        extensionKey
+      ),
+    /package-relative/
+  );
+});


### PR DESCRIPTION
## Summary

Tutti and TSH need to consume one connector-market domain without duplicating daemon semantics, OpenAPI paths, or renderer state logic. The local daemon must remain authoritative, while each product retains ownership of persistence, catalog access, installation, authorization, generated transport, and desktop integration.

This PR establishes that shared foundation in `packages/connector/market`:

- adds a host-neutral Go application core for manifest validation, revision fencing, request idempotency, durable operations, recovery, compatibility, installation, authorization, and workspace bindings
- publishes one reusable OpenAPI fragment that host daemon aggregates can resolve from an exact package release instead of copying YAML
- adds shared TypeScript contracts and a Valtio renderer domain service following the TSH Room Chat service convention: typed DI contract, constructor-injected class, `readonly dataStore`, direct domain commands, explicit `start()`/`dispose()`, stale-response fencing, and host-injected backend adapters
- extends the OpenAPI composition tooling to resolve both repository-relative and package-exported fragments with traversal protection
- registers the package in the release cohort and documents ownership, data flow, compatibility boundaries, and the staged host-integration sequence

This is the shared SDK and application-core checkpoint only. It intentionally does not add tuttidd persistence or handlers, generated host clients, Tutti UI integration, or TSH/zk host adapters.

## Verification

- `go test ./...` in `packages/connector/market`: validates manifest rules, revision/idempotency behavior, operation exclusion, execution, and recovery
- `pnpm --dir packages/connector/market test`: 7 renderer service scenarios passed, including workspace stale-response fencing, refresh singleflight, mutation exclusion, optimistic rollback, event lifecycle, and disposal
- `node --test tools/scripts/openapi-fragments.test.mjs`: 3 fragment-resolution scenarios passed
- `pnpm release:pack:check -- --packages-json '["@tutti-os/connector-market"]'`: published entrypoints and OpenAPI asset passed
- pre-push `pnpm check:changed -- --push-ready`: 12 selected lanes passed

## Fallback Three Questions

- Source: asynchronous daemon commands, invalidation events, workspace switches, process recovery, and network retries can duplicate requests or deliver responses out of order.
- Why can it not be fixed at that source? These races cross renderer, transport, daemon transaction, scheduler, and process-restart boundaries; no single upstream source can guarantee synchronous delivery or exactly-once execution.
- Removal condition: the defensive revision, generation, and idempotency branches can be removed only if every host provides one transactional, ordered, exactly-once stream spanning command acceptance, durable execution, recovery, and renderer projection.

## Checklist

- [x] Agent lifecycle semantics are unchanged; the `packages/agent/host` requirement is not applicable.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source; no existing multilingual source was changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
