### PR TITLE
fix(agent): confirm Claude root_provider_turn.started checkpoints

### DIFF
--- a/packages/agent/daemon/runtime/claude_sdk_execution.go
+++ b/packages/agent/daemon/runtime/claude_sdk_execution.go
@@ -200,6 +200,7 @@ func (a *ClaudeCodeSDKAdapter) ExecWithProviderAcceptance(
 				Source:            AcceptanceSourceTurnStartResponse,
 				ProviderSessionID: strings.TrimSpace(adapterSession.providerSessionID),
 				ProviderTurnID:    providerTurnID,
+				ProviderInputUnit: event.ProviderInputUnit,
 			}
 			acceptanceOnce.Do(func() {
 				if acceptProviderTurn == nil {

--- a/packages/agent/daemon/runtime/controller_dispatch.go
+++ b/packages/agent/daemon/runtime/controller_dispatch.go
@@ -89,6 +89,11 @@ func (c *Controller) confirmProviderDispatchDurable(
 	accepted.Payload.Metadata = map[string]any{
 		"acceptanceSource": string(receipt.Source),
 	}
+	// Preserve the stamped ProviderInputUnit from the live provider event so the
+	// acceptance commit carries Replay batches. Without it, Claude Code's later
+	// re-emit is often an empty-mutation no-op (no TransactionID) and
+	// checkpoint_commit_unconfirmed fails for turn.working.
+	accepted.ProviderInputUnit = receipt.ProviderInputUnit
 	reported, err := c.reportProviderAcceptanceDurable(ctx, session, []activityshared.Event{accepted})
 	if err != nil {
 		return ProviderDispatchResult{

--- a/packages/agent/daemon/runtime/controller_report_worker.go
+++ b/packages/agent/daemon/runtime/controller_report_worker.go
@@ -191,6 +191,9 @@ func (c *Controller) reportProviderAcceptanceDurable(
 	}
 	report := reportActivityInput(session, events)
 	c.enrichReportStatePatchesWithSessionMetadata(session, &report)
+	// Mirror enqueueSessionReport: observe batches before the durable commit so
+	// checkpoint candidates exist when ObserveReplayCommitted runs.
+	c.observeProviderObservations(ctx, session, report.ProviderObservations)
 	reportCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 	defer cancel()
 	request := reportRequest{

--- a/packages/agent/daemon/runtime/types.go
+++ b/packages/agent/daemon/runtime/types.go
@@ -508,6 +508,11 @@ type ProviderAcceptanceReceipt struct {
 	Source            AcceptanceSource `json:"source"`
 	ProviderSessionID string           `json:"providerSessionId"`
 	ProviderTurnID    string           `json:"providerTurnId"`
+	// ProviderInputUnit is process-local Replay metadata from the stamped
+	// acceptance event. It must travel with the durable acceptance report so
+	// commit correlation can confirm against the same transaction that writes
+	// RootProviderTurn (Claude Code otherwise re-emits a later no-op report).
+	ProviderInputUnit *activityshared.ProviderInputUnitContext `json:"-"`
 }
 
 type ProviderDispatchResult struct {

--- a/packages/agent/store-sqlite/activity.go
+++ b/packages/agent/store-sqlite/activity.go
@@ -110,7 +110,11 @@ func (s *Store) ReportActivityState(
 			return ActivityStateReportResult{}, errors.New("workspace agent activity turn transition was rejected")
 		}
 	}
-	if accepted && input.RootProviderTurn != nil {
+	// RootProviderTurn may arrive on an exact-replay session envelope after Exec
+	// already set CurrentPhase (Claude Code identity_resolved). Apply whenever the
+	// session row is addressable so Replay commit correlation still gets a
+	// durable turn mutation / RootProviderTurnAccepted flag.
+	if input.RootProviderTurn != nil && strings.TrimSpace(session.ID) != "" {
 		result.RootTurn, result.RootTurnAccepted, result.RootProviderTurnAccepted, err = s.applyRootProviderTurnTransitionTx(ctx, tx, *input.RootProviderTurn, now)
 		if err != nil {
 			return ActivityStateReportResult{}, err

--- a/services/tuttid/service/agentsessionreplay/checkpoint_commit_correlations.go
+++ b/services/tuttid/service/agentsessionreplay/checkpoint_commit_correlations.go
@@ -443,7 +443,45 @@ func committedObservationMatches(
 						event.TurnOutcome,
 					))
 		}
-		return stateMatches && hasCommittedMutation(delta, "turn", event.TurnID)
+		if !stateMatches {
+			return false
+		}
+		if hasCommittedMutation(delta, "turn", event.TurnID) {
+			return true
+		}
+		// RootProviderTurnAccepted still means a durable turn-row write even when
+		// ProjectionDirty was omitted (exact-replay session + already-running
+		// canonical phase). Prefer the Result flag over inventing a dirty hint.
+		result := delta.ActivityState.Result
+		if (result.RootProviderTurnAccepted || result.RootTurnAccepted) &&
+			strings.TrimSpace(result.RootTurn.TurnID) == event.TurnID {
+			return true
+		}
+		// Claude Code acceptance may persist RootProviderTurn first; the
+		// observation-bearing follow-up can then return the already-running
+		// RootTurn with Accepted=false (no ProjectionDirty). Still confirm when
+		// Result already shows the expected running turn.
+		if event.Type == "root_provider_turn.started" {
+			if strings.TrimSpace(result.RootTurn.TurnID) == event.TurnID &&
+				semanticTurnStateMatches(
+					result.RootTurn.Phase,
+					result.RootTurn.Outcome,
+					event.TurnPhase,
+					event.TurnOutcome,
+				) {
+				return true
+			}
+			if strings.TrimSpace(result.Turn.TurnID) == event.TurnID &&
+				semanticTurnStateMatches(
+					result.Turn.Phase,
+					result.Turn.Outcome,
+					event.TurnPhase,
+					event.TurnOutcome,
+				) {
+				return true
+			}
+		}
+		return false
 	case "call":
 		if delta.SessionMessages == nil {
 			return false


### PR DESCRIPTION
## Summary
- Carry `ProviderInputUnit` on Claude Code's durable provider-acceptance commit so Replay observation batches share the same `RootProviderTurn` write that creates `turn.working` checkpoint anchors.
- Observe provider batches before the acceptance report commits, matching the normal session-report path.
- Allow `RootProviderTurn` apply on exact-replay session envelopes, and tighten commit-correlation fallbacks so `checkpoint_commit_unconfirmed` no longer blocks Claude Code Session Replay recording.

## Test plan
- [x] `go test` for `packages/agent/daemon/runtime`, `packages/agent/store-sqlite`, `services/tuttid/service/agentsessionreplay`
- [x] C01-CLAUDE record + replay passed on local agent-session-replay plan (`530845ed`)
- [ ] CI push-ready / PR checks green


Made with [Cursor](https://cursor.com)