### PR TITLE
fix(agent-activity): preserve exact submit cancellation targets

### DIFF
--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -267,7 +267,12 @@ display text.
 Desktop AgentGUI and Mobile call `stopSession` instead of constructing
 `session/stopRequested` protocol fields. The same method stops an active Turn
 or records a bounded request that cancels the first Turn produced by an
-in-flight activation.
+in-flight activation. When an implicit stop observes a submit admission without
+an active Turn, it retains only a submit that may still produce an unsettled
+Turn: definitive admission failure and a known settled canonical Turn are not
+stop targets. Missing or out-of-order canonical evidence remains eligible, and
+late activity messages correlate the exact submit identity before issuing the
+Turn cancel.
 Desktop AgentGUI and Mobile call `submitPrompt` for an existing Session instead
 of constructing `submit/requested` protocol fields or reading multiple Engine
 selectors to infer whether the submission was admitted. The Engine fixes the

--- a/packages/agent/activity-core/src/engine/createAgentSessionEngine.ts
+++ b/packages/agent/activity-core/src/engine/createAgentSessionEngine.ts
@@ -16,7 +16,7 @@ import {
   selectEngineSessionSettingsUpdate
 } from "./sessionLifecycle.selectors.ts";
 import {
-  selectLatestPendingSubmitForSession,
+  selectLatestStopTargetSubmitForSession,
   selectPendingSubmitsForSession
 } from "./pendingIntents.selectors.ts";
 import {
@@ -468,7 +468,7 @@ export function createAgentSessionEngine({
     const clientSubmitId =
       requestedClientSubmitId ??
       (!activeTurn
-        ? selectLatestPendingSubmitForSession(publicSnapshot, agentSessionId)
+        ? selectLatestStopTargetSubmitForSession(publicSnapshot, agentSessionId)
             ?.clientSubmitId
         : undefined);
     const requestedAtUnixMs = clock.nowUnixMs();

--- a/packages/agent/activity-core/src/engine/createAgentSessionEngine.ts
+++ b/packages/agent/activity-core/src/engine/createAgentSessionEngine.ts
@@ -15,7 +15,10 @@ import {
   selectEngineSession,
   selectEngineSessionSettingsUpdate
 } from "./sessionLifecycle.selectors.ts";
-import { selectPendingSubmitsForSession } from "./pendingIntents.selectors.ts";
+import {
+  selectLatestPendingSubmitForSession,
+  selectPendingSubmitsForSession
+} from "./pendingIntents.selectors.ts";
 import {
   selectEngineHasVisibleQueuedSubmit,
   selectEngineSubmitWouldBeVisibleInQueue
@@ -460,12 +463,21 @@ export function createAgentSessionEngine({
     if (!agentSessionId) {
       return;
     }
+    const activeTurn = selectEngineActiveTurn(publicSnapshot, agentSessionId);
+    const requestedClientSubmitId = input.clientSubmitId?.trim() || null;
+    const clientSubmitId =
+      requestedClientSubmitId ??
+      (!activeTurn
+        ? selectLatestPendingSubmitForSession(publicSnapshot, agentSessionId)
+            ?.clientSubmitId
+        : undefined);
     const requestedAtUnixMs = clock.nowUnixMs();
     const sequence = sessionStopCommandSequence++;
     dispatch({
       agentSessionId,
       awaitingTurnExpiresAtUnixMs: requestedAtUnixMs + SESSION_STOP_TIMEOUT_MS,
       commandId: `stop:${requestedAtUnixMs}:${sequence}`,
+      ...(clientSubmitId ? { clientSubmitId } : {}),
       timeoutMs: SESSION_STOP_TIMEOUT_MS,
       type: "session/stopRequested",
       workspaceId: engineIdentity.workspaceId

--- a/packages/agent/activity-core/src/engine/pendingIntents.selectors.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.selectors.ts
@@ -142,6 +142,48 @@ export function selectLatestPendingSubmitForSession(
   return latest;
 }
 
+/**
+ * Select the implicit stop target without changing the broader pending-submit
+ * presentation semantics used by GUI consumers.
+ *
+ * A failed submit is proven not to produce a Turn. A submit with a known
+ * settled canonical Turn is likewise complete. Missing canonical state is not
+ * proof of completion because admission and activity events can arrive out of
+ * order.
+ */
+export function selectLatestStopTargetSubmitForSession(
+  state: AgentSessionEngineStateBase,
+  agentSessionId: string | null | undefined
+): PendingSubmitIntentRecord | null {
+  let latest: PendingSubmitIntentRecord | null = null;
+  for (const pending of selectPendingSubmitsForSession(state, agentSessionId)) {
+    if (!stopTargetMayStillProduceUnsettledTurn(state, pending)) continue;
+    if (
+      !latest ||
+      pending.requestedAtUnixMs > latest.requestedAtUnixMs ||
+      (pending.requestedAtUnixMs === latest.requestedAtUnixMs &&
+        pending.clientSubmitId.localeCompare(latest.clientSubmitId) > 0)
+    ) {
+      latest = pending;
+    }
+  }
+  return latest;
+}
+
+function stopTargetMayStillProduceUnsettledTurn(
+  state: AgentSessionEngineStateBase,
+  pending: PendingSubmitIntentRecord
+): boolean {
+  if (pending.status === "failed") return false;
+  const turnId = pending.turnId?.trim() ?? "";
+  if (!turnId) return true;
+  const turn =
+    state.sessionLifecycle.turnsById[
+      canonicalTurnKey(pending.agentSessionId, turnId)
+    ];
+  return turn?.phase !== "settled";
+}
+
 export function selectLatestActivationForSession(
   state: AgentSessionEngineStateBase,
   agentSessionId: string | null | undefined

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.cancel.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.cancel.ts
@@ -1,0 +1,216 @@
+import type { AgentActivityMessage, AgentActivityTurn } from "../types.ts";
+import { reconcileSettingsUpdates } from "./sessionSettings.reducer.ts";
+import type { EngineCommand, EngineReducerResult } from "./types.ts";
+import type { SessionLifecycleState } from "./sessionLifecycle.types.ts";
+import { canonicalTurnKey } from "./sessionEntityKeys.ts";
+import {
+  initialCancel,
+  setCancel,
+  setOperation
+} from "./sessionLifecycle.state.ts";
+
+const NO_COMMANDS: readonly EngineCommand[] = [];
+const TURN_CANCEL_TIMEOUT_MS = 30_000;
+
+export function reconcilePendingCancels(
+  previous: SessionLifecycleState,
+  next: SessionLifecycleState
+): EngineReducerResult<SessionLifecycleState> {
+  const settings = reconcileSettingsUpdates(previous, next);
+  const commands: EngineCommand[] = [...settings.commands];
+  let state = settings.state;
+  for (const [id, operation] of Object.entries(state.operationBySessionId)) {
+    const session = state.sessionsById[id];
+    const activeTurn = session?.activeTurnId
+      ? state.turnsById[canonicalTurnKey(id, session.activeTurnId)]
+      : null;
+    const reconciledOperation = state.operationBySessionId[id] ?? operation;
+    const targetedTurn = reconciledOperation.cancel.turnId
+      ? state.turnsById[canonicalTurnKey(id, reconciledOperation.cancel.turnId)]
+      : null;
+    const turn = targetedTurn ?? activeTurn;
+    if (
+      reconciledOperation.cancel.status === "awaitingTurn" &&
+      session &&
+      turn &&
+      turn.phase !== "settled" &&
+      reconciledOperation.cancel.commandId &&
+      (!reconciledOperation.cancel.requestedWorkspaceId ||
+        session.workspaceId ===
+          reconciledOperation.cancel.requestedWorkspaceId) &&
+      (!reconciledOperation.cancel.targetClientSubmitId ||
+        reconciledOperation.cancel.turnId === turn.turnId)
+    ) {
+      if (reconciledOperation.cancel.expiryId)
+        commands.push({
+          type: "engine/cancelExpiry",
+          expiryId: reconciledOperation.cancel.expiryId
+        });
+      commands.push(
+        cancelCommand(
+          session.workspaceId,
+          id,
+          turn,
+          reconciledOperation.cancel.commandId
+        )
+      );
+      state = setCancel(state, id, {
+        ...reconciledOperation.cancel,
+        expiryId: null,
+        status: "requested",
+        turnId: turn.turnId
+      });
+    } else if (
+      reconciledOperation.cancel.status !== "idle" &&
+      reconciledOperation.cancel.status !== "awaitingTurn" &&
+      (!activeTurn || activeTurn.phase === "settled")
+    ) {
+      state = setOperation(state, id, {
+        ...reconciledOperation,
+        cancel: initialCancel(),
+        operationError: null
+      });
+    }
+  }
+  return state === previous && commands.length === 0
+    ? unchanged(previous)
+    : { commands, state };
+}
+
+export function reconcilePendingCancelFromMessages(
+  state: SessionLifecycleState,
+  messages: readonly AgentActivityMessage[]
+): EngineReducerResult<SessionLifecycleState> {
+  let next = state;
+  for (const message of messages) {
+    const clientSubmitId = message.payload?.clientSubmitId;
+    const turnId = message.turnId?.trim() ?? "";
+    if (
+      typeof clientSubmitId !== "string" ||
+      !clientSubmitId.trim() ||
+      !turnId
+    ) {
+      continue;
+    }
+    const agentSessionId = message.agentSessionId.trim();
+    const operation = next.operationBySessionId[agentSessionId];
+    const messageWorkspaceId = message.workspaceId?.trim() ?? "";
+    if (
+      !operation ||
+      operation.cancel.status !== "awaitingTurn" ||
+      operation.cancel.targetClientSubmitId !== clientSubmitId.trim() ||
+      (operation.cancel.turnId && operation.cancel.turnId !== turnId) ||
+      (messageWorkspaceId &&
+        messageWorkspaceId !== operation.cancel.requestedWorkspaceId)
+    ) {
+      continue;
+    }
+    next = setCancel(next, agentSessionId, {
+      ...operation.cancel,
+      turnId
+    });
+  }
+  return next === state
+    ? unchanged(state)
+    : reconcilePendingCancels(state, next);
+}
+
+export function reconcilePendingCancelForSubmit(
+  previous: SessionLifecycleState,
+  next: SessionLifecycleState,
+  clientSubmitId: string,
+  turn: AgentActivityTurn
+): EngineReducerResult<SessionLifecycleState> {
+  const targetClientSubmitId = clientSubmitId.trim();
+  if (!targetClientSubmitId || turn.phase === "settled") {
+    return result(next);
+  }
+  const operation = next.operationBySessionId[turn.agentSessionId];
+  if (
+    !operation ||
+    operation.cancel.status !== "awaitingTurn" ||
+    operation.cancel.targetClientSubmitId !== targetClientSubmitId ||
+    !operation.cancel.commandId
+  ) {
+    return result(next);
+  }
+  const session = next.sessionsById[turn.agentSessionId];
+  if (
+    !session ||
+    session.workspaceId.trim() === "" ||
+    (operation.cancel.requestedWorkspaceId !== null &&
+      session.workspaceId !== operation.cancel.requestedWorkspaceId)
+  ) {
+    return result(next);
+  }
+  const commands: EngineCommand[] = [];
+  if (operation.cancel.expiryId) {
+    commands.push({
+      type: "engine/cancelExpiry",
+      expiryId: operation.cancel.expiryId
+    });
+  }
+  commands.push(
+    cancelCommand(
+      session.workspaceId,
+      turn.agentSessionId,
+      turn,
+      operation.cancel.commandId
+    )
+  );
+  const state = setCancel(next, turn.agentSessionId, {
+    ...operation.cancel,
+    expiryId: null,
+    status: "requested",
+    turnId: turn.turnId
+  });
+  return previous === state && commands.length === 0
+    ? unchanged(previous)
+    : { commands, state };
+}
+
+export function cancelCommand(
+  workspaceId: string,
+  agentSessionId: string,
+  turn: AgentActivityTurn,
+  commandId: string,
+  timeoutMs = TURN_CANCEL_TIMEOUT_MS
+): EngineCommand {
+  return {
+    type: "turn/cancel",
+    workspaceId,
+    agentSessionId,
+    turnId: turn.turnId,
+    commandId,
+    timeoutMs
+  };
+}
+
+export function sessionVersion(session: {
+  updatedAtUnixMs?: number;
+  lastEventUnixMs?: number;
+  messageVersion?: number;
+  createdAtUnixMs?: number;
+  startedAtUnixMs?: number;
+}): number | null {
+  return (
+    session.updatedAtUnixMs ??
+    session.lastEventUnixMs ??
+    session.messageVersion ??
+    session.createdAtUnixMs ??
+    session.startedAtUnixMs ??
+    null
+  );
+}
+
+function result(
+  state: SessionLifecycleState
+): EngineReducerResult<SessionLifecycleState> {
+  return { commands: NO_COMMANDS, state };
+}
+
+function unchanged(
+  state: SessionLifecycleState
+): EngineReducerResult<SessionLifecycleState> {
+  return { commands: NO_COMMANDS, state };
+}

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.test.ts
@@ -1162,6 +1162,118 @@ test("cancel requested before turn creation waits for a v2 turn entity", () => {
   assert.ok(started.commands.some((command) => command.type === "turn/cancel"));
 });
 
+test("stop for a pending submit waits for that submit instead of the next unrelated turn", () => {
+  let state = reduce(createInitialSessionLifecycleState(), {
+    type: "session/snapshotReceived",
+    sessions: [session(null, 1)]
+  }).state;
+  const waiting = reduce(state, {
+    type: "session/stopRequested",
+    agentSessionId: "session-1",
+    awaitingTurnExpiresAtUnixMs: 30_000,
+    clientSubmitId: "submit-1",
+    commandId: "stop-1",
+    workspaceId: "workspace-1"
+  });
+  assert.equal(
+    waiting.state.operationBySessionId["session-1"]?.cancel
+      .targetClientSubmitId,
+    "submit-1"
+  );
+
+  const unrelated = reduce(waiting.state, {
+    type: "session/upserted",
+    session: session(activeTurn(2), 2)
+  });
+  assert.equal(unrelated.commands.length, 0);
+  assert.equal(
+    unrelated.state.operationBySessionId["session-1"]?.cancel.status,
+    "awaitingTurn"
+  );
+
+  const turn = { ...activeTurn(4), turnId: "turn-2" };
+  const matched = reduce(waiting.state, {
+    commandId: "send-1",
+    commandType: "queue/sendPrompt",
+    correlationId: "submit-1",
+    outcome: "succeeded",
+    type: "engine/commandResult",
+    value: { session: session(turn, 4), turn, turnId: turn.turnId }
+  });
+  assert.deepEqual(matched.commands.at(-1), {
+    agentSessionId: "session-1",
+    commandId: "stop-1",
+    timeoutMs: 30_000,
+    turnId: "turn-2",
+    type: "turn/cancel",
+    workspaceId: "workspace-1"
+  });
+  assert.equal(
+    matched.state.operationBySessionId["session-1"]?.cancel.turnId,
+    "turn-2"
+  );
+});
+
+test("stop for a submit still resolves after send admission times out", () => {
+  let state = reduce(createInitialSessionLifecycleState(), {
+    type: "session/snapshotReceived",
+    sessions: [session(null, 1)]
+  }).state;
+  state = reduce(state, {
+    type: "session/stopRequested",
+    agentSessionId: "session-1",
+    awaitingTurnExpiresAtUnixMs: 30_000,
+    clientSubmitId: "submit-1",
+    commandId: "stop-1",
+    workspaceId: "workspace-1"
+  }).state;
+
+  state = reduce(state, {
+    commandId: "send-1",
+    commandType: "queue/sendPrompt",
+    correlationId: "submit-1",
+    errorCode: "aborted",
+    errorMessage: "admission timed out",
+    outcome: "timedOut",
+    type: "engine/commandResult"
+  }).state;
+
+  const message = reduce(state, {
+    messages: [
+      {
+        agentSessionId: "session-1",
+        kind: "user_prompt",
+        messageId: "message-1",
+        occurredAtUnixMs: 2,
+        payload: { clientSubmitId: "submit-1" },
+        role: "user",
+        turnId: "turn-2",
+        version: 1
+      }
+    ],
+    type: "message/snapshotReceived"
+  });
+  assert.equal(
+    message.state.operationBySessionId["session-1"]?.cancel.turnId,
+    "turn-2"
+  );
+  assert.equal(message.commands.length, 0);
+
+  const turn = { ...activeTurn(4), turnId: "turn-2" };
+  const matched = reduce(message.state, {
+    type: "turn/upserted",
+    turn
+  });
+  assert.deepEqual(matched.commands.at(-1), {
+    agentSessionId: "session-1",
+    commandId: "stop-1",
+    timeoutMs: 30_000,
+    turnId: "turn-2",
+    type: "turn/cancel",
+    workspaceId: "workspace-1"
+  });
+});
+
 for (const provider of ["cursor", "codex", "claude-code"]) {
   test(`stop requested before ${provider} activation survives snapshots and cancels the first turn`, () => {
     const waiting = reduce(createInitialSessionLifecycleState(), {

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.test.ts
@@ -1274,6 +1274,49 @@ test("stop for a submit still resolves after send admission times out", () => {
   });
 });
 
+test("stop target correlation ignores a message from another workspace", () => {
+  let state = reduce(createInitialSessionLifecycleState(), {
+    type: "session/snapshotReceived",
+    sessions: [session(null, 1)]
+  }).state;
+  state = reduce(state, {
+    type: "session/stopRequested",
+    agentSessionId: "session-1",
+    awaitingTurnExpiresAtUnixMs: 30_000,
+    clientSubmitId: "submit-1",
+    commandId: "stop-1",
+    workspaceId: "workspace-1"
+  }).state;
+
+  const message = {
+    agentSessionId: "session-1",
+    kind: "user_prompt",
+    messageId: "message-1",
+    occurredAtUnixMs: 2,
+    payload: { clientSubmitId: "submit-1" },
+    role: "user",
+    turnId: "turn-2",
+    version: 1
+  };
+  const ignored = reduce(state, {
+    messages: [{ ...message, workspaceId: "workspace-other" }],
+    type: "message/snapshotReceived"
+  });
+  assert.equal(
+    ignored.state.operationBySessionId["session-1"]?.cancel.turnId,
+    null
+  );
+
+  const matched = reduce(ignored.state, {
+    messages: [{ ...message, workspaceId: "workspace-1" }],
+    type: "message/snapshotReceived"
+  });
+  assert.equal(
+    matched.state.operationBySessionId["session-1"]?.cancel.turnId,
+    "turn-2"
+  );
+});
+
 for (const provider of ["cursor", "codex", "claude-code"]) {
   test(`stop requested before ${provider} activation survives snapshots and cancels the first turn`, () => {
     const waiting = reduce(createInitialSessionLifecycleState(), {

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.ts
@@ -1,9 +1,8 @@
-import type { AgentActivityInteraction, AgentActivityTurn } from "../types.ts";
+import type { AgentActivityInteraction } from "../types.ts";
 import type { SendInputResultValidation } from "./commandResult.validation.ts";
 import type { ScopedSessionResultValidation } from "./commandResult.validation.ts";
 import type { CancelResultValidation } from "./commandResult.validation.ts";
 import {
-  reconcileSettingsUpdates,
   requestSettingsUpdate,
   resumeSettingsQueueAfterPrompt,
   resumeSettingsUpdateWhenRuntimeAvailable,
@@ -15,7 +14,6 @@ import type {
   EngineReducerResult
 } from "./types.ts";
 import {
-  type SessionCancelState,
   type SessionLifecycleState,
   type SessionOperationState
 } from "./sessionLifecycle.types.ts";
@@ -37,8 +35,17 @@ import {
   cancelPending,
   initialCancel,
   initialOperation,
-  requestedCancel
+  requestedCancel,
+  setCancel,
+  setOperation
 } from "./sessionLifecycle.state.ts";
+import {
+  cancelCommand,
+  reconcilePendingCancelForSubmit,
+  reconcilePendingCancelFromMessages,
+  reconcilePendingCancels,
+  sessionVersion
+} from "./sessionLifecycle.cancel.ts";
 const NO_COMMANDS: readonly EngineCommand[] = [];
 const TURN_CANCEL_TIMEOUT_MS = 30_000;
 
@@ -512,151 +519,6 @@ function requestCancel(
   };
 }
 
-function reconcilePendingCancels(
-  previous: SessionLifecycleState,
-  next: SessionLifecycleState
-): EngineReducerResult<SessionLifecycleState> {
-  const settings = reconcileSettingsUpdates(previous, next);
-  const commands: EngineCommand[] = [...settings.commands];
-  let state = settings.state;
-  for (const [id, operation] of Object.entries(state.operationBySessionId)) {
-    const session = state.sessionsById[id];
-    const activeTurn = session?.activeTurnId
-      ? state.turnsById[canonicalTurnKey(id, session.activeTurnId)]
-      : null;
-    const reconciledOperation = state.operationBySessionId[id] ?? operation;
-    const targetedTurn = reconciledOperation.cancel.turnId
-      ? state.turnsById[canonicalTurnKey(id, reconciledOperation.cancel.turnId)]
-      : null;
-    const turn = targetedTurn ?? activeTurn;
-    if (
-      reconciledOperation.cancel.status === "awaitingTurn" &&
-      session &&
-      turn &&
-      turn.phase !== "settled" &&
-      reconciledOperation.cancel.commandId &&
-      (!reconciledOperation.cancel.targetClientSubmitId ||
-        reconciledOperation.cancel.turnId === turn.turnId)
-    ) {
-      if (reconciledOperation.cancel.expiryId)
-        commands.push({
-          type: "engine/cancelExpiry",
-          expiryId: reconciledOperation.cancel.expiryId
-        });
-      commands.push(
-        cancelCommand(
-          session.workspaceId,
-          id,
-          turn,
-          reconciledOperation.cancel.commandId
-        )
-      );
-      state = setCancel(state, id, {
-        ...reconciledOperation.cancel,
-        expiryId: null,
-        status: "requested",
-        turnId: turn.turnId
-      });
-    } else if (
-      reconciledOperation.cancel.status !== "idle" &&
-      reconciledOperation.cancel.status !== "awaitingTurn" &&
-      (!activeTurn || activeTurn.phase === "settled")
-    ) {
-      state = setOperation(state, id, {
-        ...reconciledOperation,
-        cancel: initialCancel(),
-        operationError: null
-      });
-    }
-  }
-  return state === previous && commands.length === 0
-    ? unchanged(previous)
-    : { commands, state };
-}
-
-function reconcilePendingCancelFromMessages(
-  state: SessionLifecycleState,
-  messages: readonly import("../types.ts").AgentActivityMessage[]
-): EngineReducerResult<SessionLifecycleState> {
-  let next = state;
-  for (const message of messages) {
-    const clientSubmitId = message.payload?.clientSubmitId;
-    const turnId = message.turnId?.trim() ?? "";
-    if (
-      typeof clientSubmitId !== "string" ||
-      !clientSubmitId.trim() ||
-      !turnId
-    ) {
-      continue;
-    }
-    const agentSessionId = message.agentSessionId.trim();
-    const operation = next.operationBySessionId[agentSessionId];
-    if (
-      !operation ||
-      operation.cancel.status !== "awaitingTurn" ||
-      operation.cancel.targetClientSubmitId !== clientSubmitId.trim() ||
-      (operation.cancel.turnId && operation.cancel.turnId !== turnId)
-    ) {
-      continue;
-    }
-    next = setCancel(next, agentSessionId, {
-      ...operation.cancel,
-      turnId
-    });
-  }
-  return next === state
-    ? unchanged(state)
-    : reconcilePendingCancels(state, next);
-}
-
-function reconcilePendingCancelForSubmit(
-  previous: SessionLifecycleState,
-  next: SessionLifecycleState,
-  clientSubmitId: string,
-  turn: AgentActivityTurn
-): EngineReducerResult<SessionLifecycleState> {
-  if (!clientSubmitId || turn.phase === "settled") {
-    return result(next);
-  }
-  const operation = next.operationBySessionId[turn.agentSessionId];
-  if (
-    !operation ||
-    operation.cancel.status !== "awaitingTurn" ||
-    operation.cancel.targetClientSubmitId !== clientSubmitId ||
-    !operation.cancel.commandId
-  ) {
-    return result(next);
-  }
-  const session = next.sessionsById[turn.agentSessionId];
-  if (!session || session.workspaceId.trim() === "") {
-    return result(next);
-  }
-  const commands: EngineCommand[] = [];
-  if (operation.cancel.expiryId) {
-    commands.push({
-      type: "engine/cancelExpiry",
-      expiryId: operation.cancel.expiryId
-    });
-  }
-  commands.push(
-    cancelCommand(
-      session.workspaceId,
-      turn.agentSessionId,
-      turn,
-      operation.cancel.commandId
-    )
-  );
-  const state = setCancel(next, turn.agentSessionId, {
-    ...operation.cancel,
-    expiryId: null,
-    status: "requested",
-    turnId: turn.turnId
-  });
-  return previous === state && commands.length === 0
-    ? unchanged(previous)
-    : { commands, state };
-}
-
 function settleCancel(
   state: SessionLifecycleState,
   intent: Extract<EngineIntent, { type: "engine/commandResult" }>,
@@ -821,56 +683,6 @@ function updateOperation(
   return current
     ? result(setOperation(state, id.trim(), update(current)))
     : unchanged(state);
-}
-function setCancel(
-  state: SessionLifecycleState,
-  id: string,
-  cancel: SessionCancelState
-): SessionLifecycleState {
-  const operation = state.operationBySessionId[id];
-  return operation ? setOperation(state, id, { ...operation, cancel }) : state;
-}
-function setOperation(
-  state: SessionLifecycleState,
-  id: string,
-  operation: SessionOperationState
-): SessionLifecycleState {
-  return {
-    ...state,
-    operationBySessionId: { ...state.operationBySessionId, [id]: operation }
-  };
-}
-function cancelCommand(
-  workspaceId: string,
-  agentSessionId: string,
-  turn: AgentActivityTurn,
-  commandId: string,
-  timeoutMs = TURN_CANCEL_TIMEOUT_MS
-): EngineCommand {
-  return {
-    type: "turn/cancel",
-    workspaceId,
-    agentSessionId,
-    turnId: turn.turnId,
-    commandId,
-    timeoutMs
-  };
-}
-function sessionVersion(session: {
-  updatedAtUnixMs?: number;
-  lastEventUnixMs?: number;
-  messageVersion?: number;
-  createdAtUnixMs?: number;
-  startedAtUnixMs?: number;
-}): number | null {
-  return (
-    session.updatedAtUnixMs ??
-    session.lastEventUnixMs ??
-    session.messageVersion ??
-    session.createdAtUnixMs ??
-    session.startedAtUnixMs ??
-    null
-  );
 }
 function result(
   state: SessionLifecycleState

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.ts
@@ -69,6 +69,8 @@ export function sessionLifecycleReducer(
   }
 ): EngineReducerResult<SessionLifecycleState> {
   switch (intent.type) {
+    case "message/snapshotReceived":
+      return reconcilePendingCancelFromMessages(state, intent.messages);
     case "session/snapshotReceived":
       return reconcilePendingCancels(
         state,
@@ -232,11 +234,15 @@ export function sessionLifecycleReducer(
           );
         }
         const { session, turn } = sendResult;
-        return result(
-          upsertCanonicalTurn(
-            upsertCanonicalSession(state, session, initialOperation),
-            turn
-          )
+        const projected = upsertCanonicalTurn(
+          upsertCanonicalSession(state, session, initialOperation),
+          turn
+        );
+        return reconcilePendingCancelForSubmit(
+          state,
+          projected,
+          intent.correlationId?.trim() ?? "",
+          turn
         );
       }
       return unchanged(state);
@@ -464,11 +470,12 @@ function requestCancel(
     nextState = setOperation(state, id, operation);
   }
   if (cancelPending(operation.cancel)) return unchanged(nextState);
+  const targetClientSubmitId = intent.clientSubmitId?.trim() || null;
   const activeTurnId = session?.activeTurnId ?? null;
   const turn = activeTurnId
     ? state.turnsById[canonicalTurnKey(id, activeTurnId)]
     : null;
-  if (turn && turn.phase !== "settled") {
+  if (turn && turn.phase !== "settled" && !targetClientSubmitId) {
     const next = setCancel(
       nextState,
       id,
@@ -483,7 +490,12 @@ function requestCancel(
   }
   const expiryId = `cancel:awaiting-turn:${intent.commandId}`;
   const next = setCancel(nextState, id, {
-    ...requestedCancel(intent.commandId, null, workspaceId),
+    ...requestedCancel(
+      intent.commandId,
+      null,
+      workspaceId,
+      targetClientSubmitId
+    ),
     expiryId,
     requestedSessionVersion: session ? sessionVersion(session) : null,
     status: "awaitingTurn"
@@ -509,16 +521,22 @@ function reconcilePendingCancels(
   let state = settings.state;
   for (const [id, operation] of Object.entries(state.operationBySessionId)) {
     const session = state.sessionsById[id];
-    const turn = session?.activeTurnId
+    const activeTurn = session?.activeTurnId
       ? state.turnsById[canonicalTurnKey(id, session.activeTurnId)]
       : null;
     const reconciledOperation = state.operationBySessionId[id] ?? operation;
+    const targetedTurn = reconciledOperation.cancel.turnId
+      ? state.turnsById[canonicalTurnKey(id, reconciledOperation.cancel.turnId)]
+      : null;
+    const turn = targetedTurn ?? activeTurn;
     if (
       reconciledOperation.cancel.status === "awaitingTurn" &&
       session &&
       turn &&
       turn.phase !== "settled" &&
-      reconciledOperation.cancel.commandId
+      reconciledOperation.cancel.commandId &&
+      (!reconciledOperation.cancel.targetClientSubmitId ||
+        reconciledOperation.cancel.turnId === turn.turnId)
     ) {
       if (reconciledOperation.cancel.expiryId)
         commands.push({
@@ -542,7 +560,7 @@ function reconcilePendingCancels(
     } else if (
       reconciledOperation.cancel.status !== "idle" &&
       reconciledOperation.cancel.status !== "awaitingTurn" &&
-      (!turn || turn.phase === "settled")
+      (!activeTurn || activeTurn.phase === "settled")
     ) {
       state = setOperation(state, id, {
         ...reconciledOperation,
@@ -552,6 +570,89 @@ function reconcilePendingCancels(
     }
   }
   return state === previous && commands.length === 0
+    ? unchanged(previous)
+    : { commands, state };
+}
+
+function reconcilePendingCancelFromMessages(
+  state: SessionLifecycleState,
+  messages: readonly import("../types.ts").AgentActivityMessage[]
+): EngineReducerResult<SessionLifecycleState> {
+  let next = state;
+  for (const message of messages) {
+    const clientSubmitId = message.payload?.clientSubmitId;
+    const turnId = message.turnId?.trim() ?? "";
+    if (
+      typeof clientSubmitId !== "string" ||
+      !clientSubmitId.trim() ||
+      !turnId
+    ) {
+      continue;
+    }
+    const agentSessionId = message.agentSessionId.trim();
+    const operation = next.operationBySessionId[agentSessionId];
+    if (
+      !operation ||
+      operation.cancel.status !== "awaitingTurn" ||
+      operation.cancel.targetClientSubmitId !== clientSubmitId.trim() ||
+      (operation.cancel.turnId && operation.cancel.turnId !== turnId)
+    ) {
+      continue;
+    }
+    next = setCancel(next, agentSessionId, {
+      ...operation.cancel,
+      turnId
+    });
+  }
+  return next === state
+    ? unchanged(state)
+    : reconcilePendingCancels(state, next);
+}
+
+function reconcilePendingCancelForSubmit(
+  previous: SessionLifecycleState,
+  next: SessionLifecycleState,
+  clientSubmitId: string,
+  turn: AgentActivityTurn
+): EngineReducerResult<SessionLifecycleState> {
+  if (!clientSubmitId || turn.phase === "settled") {
+    return result(next);
+  }
+  const operation = next.operationBySessionId[turn.agentSessionId];
+  if (
+    !operation ||
+    operation.cancel.status !== "awaitingTurn" ||
+    operation.cancel.targetClientSubmitId !== clientSubmitId ||
+    !operation.cancel.commandId
+  ) {
+    return result(next);
+  }
+  const session = next.sessionsById[turn.agentSessionId];
+  if (!session || session.workspaceId.trim() === "") {
+    return result(next);
+  }
+  const commands: EngineCommand[] = [];
+  if (operation.cancel.expiryId) {
+    commands.push({
+      type: "engine/cancelExpiry",
+      expiryId: operation.cancel.expiryId
+    });
+  }
+  commands.push(
+    cancelCommand(
+      session.workspaceId,
+      turn.agentSessionId,
+      turn,
+      operation.cancel.commandId
+    )
+  );
+  const state = setCancel(next, turn.agentSessionId, {
+    ...operation.cancel,
+    expiryId: null,
+    status: "requested",
+    turnId: turn.turnId
+  });
+  return previous === state && commands.length === 0
     ? unchanged(previous)
     : { commands, state };
 }

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.state.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.state.ts
@@ -21,6 +21,7 @@ export function initialCancel(): SessionCancelState {
     expiryId: null,
     requestedSessionVersion: null,
     requestedWorkspaceId: null,
+    targetClientSubmitId: null,
     status: "idle",
     turnId: null
   };
@@ -29,13 +30,15 @@ export function initialCancel(): SessionCancelState {
 export function requestedCancel(
   commandId: string,
   turnId: string | null,
-  requestedWorkspaceId: string
+  requestedWorkspaceId: string,
+  targetClientSubmitId: string | null = null
 ): SessionCancelState {
   return {
     ...initialCancel(),
     commandId,
     requestedWorkspaceId,
     status: "requested",
+    targetClientSubmitId,
     turnId
   };
 }

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.state.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.state.ts
@@ -1,6 +1,7 @@
 import { createInitialSettingsUpdate } from "./sessionSettings.reducer.ts";
 import type {
   SessionCancelState,
+  SessionLifecycleState,
   SessionOperationState
 } from "./sessionLifecycle.types.ts";
 
@@ -45,4 +46,24 @@ export function requestedCancel(
 
 export function cancelPending(cancel: SessionCancelState): boolean {
   return cancel.status === "requested" || cancel.status === "awaitingTurn";
+}
+
+export function setCancel(
+  state: SessionLifecycleState,
+  id: string,
+  cancel: SessionCancelState
+): SessionLifecycleState {
+  const operation = state.operationBySessionId[id];
+  return operation ? setOperation(state, id, { ...operation, cancel }) : state;
+}
+
+export function setOperation(
+  state: SessionLifecycleState,
+  id: string,
+  operation: SessionOperationState
+): SessionLifecycleState {
+  return {
+    ...state,
+    operationBySessionId: { ...state.operationBySessionId, [id]: operation }
+  };
 }

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.types.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.types.ts
@@ -24,6 +24,7 @@ export interface SessionCancelState {
   expiryId: string | null;
   requestedSessionVersion: number | null;
   requestedWorkspaceId: string | null;
+  targetClientSubmitId: string | null;
   turnId: string | null;
   status: SessionCancelStatus;
 }
@@ -216,6 +217,7 @@ export interface SessionCancelRequestedIntent {
   agentSessionId: string;
   commandId: string;
   awaitingTurnExpiresAtUnixMs: number;
+  clientSubmitId?: string;
   timeoutMs?: number;
   workspaceId: string;
 }
@@ -225,6 +227,7 @@ export interface SessionStopRequestedIntent {
   agentSessionId: string;
   commandId: string;
   awaitingTurnExpiresAtUnixMs: number;
+  clientSubmitId?: string;
   timeoutMs?: number;
   workspaceId: string;
 }

--- a/packages/agent/activity-core/src/engine/sessionStop.semantic.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionStop.semantic.test.ts
@@ -107,6 +107,44 @@ test("semantic session stop waits 30 seconds for a first Turn and deduplicates r
   assert.equal(harness.scheduled[0]?.canceled, true);
 });
 
+test("semantic session stop targets the latest pending prompt admission", () => {
+  const harness = createHarness(false);
+
+  assert.deepEqual(
+    harness.engine.submitPrompt({
+      agentSessionId: "session-1",
+      clientSubmitId: "submit-1",
+      content: [{ text: "hello", type: "text" }]
+    }),
+    { accepted: true, queued: false }
+  );
+
+  harness.engine.stopSession({ agentSessionId: "session-1" });
+
+  assert.equal(
+    selectEngineCancelState(harness.engine.getSnapshot(), "session-1")
+      ?.targetClientSubmitId,
+    "submit-1"
+  );
+  assert.equal(harness.commands.at(-1)?.type, "queue/sendPrompt");
+});
+
+test("semantic session stop preserves an explicit submit target with an active turn", () => {
+  const harness = createHarness(true);
+
+  harness.engine.stopSession({
+    agentSessionId: "session-1",
+    clientSubmitId: "submit-explicit"
+  });
+
+  assert.deepEqual(harness.commands, []);
+  assert.equal(
+    selectEngineCancelState(harness.engine.getSnapshot(), "session-1")
+      ?.targetClientSubmitId,
+    "submit-explicit"
+  );
+});
+
 function activeTurn(): AgentActivityTurn {
   return {
     agentSessionId: "session-1",

--- a/packages/agent/activity-core/src/engine/sessionStop.semantic.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionStop.semantic.test.ts
@@ -3,6 +3,7 @@ import { test } from "node:test";
 import { normalizeAgentActivitySession } from "../sessionNormalization.ts";
 import type { AgentActivityTurn } from "../types.ts";
 import { createAgentSessionEngine } from "./createAgentSessionEngine.ts";
+import { selectLatestStopTargetSubmitForSession } from "./pendingIntents.selectors.ts";
 import { selectEngineCancelState } from "./sessionLifecycle.selectors.ts";
 import { createTestEngineCommandPort } from "./testEngineCommandPort.ts";
 import type { EngineExternalCommand, EngineScheduler } from "./types.ts";
@@ -129,6 +130,90 @@ test("semantic session stop targets the latest pending prompt admission", () => 
   assert.equal(harness.commands.at(-1)?.type, "queue/sendPrompt");
 });
 
+test("semantic session stop does not target a failed submit admission", () => {
+  const harness = createHarness(false);
+
+  harness.engine.submitPrompt({
+    agentSessionId: "session-1",
+    clientSubmitId: "submit-1",
+    content: [{ text: "hello", type: "text" }]
+  });
+  harness.engine.dispatch({
+    commandId: "send-1",
+    commandType: "queue/sendPrompt",
+    correlationId: "submit-1",
+    errorCode: "send_failed",
+    errorMessage: "send failed",
+    outcome: "failed",
+    type: "engine/commandResult"
+  });
+
+  harness.engine.stopSession({ agentSessionId: "session-1" });
+
+  assert.equal(
+    selectEngineCancelState(harness.engine.getSnapshot(), "session-1")
+      ?.targetClientSubmitId,
+    null
+  );
+  assert.equal(
+    selectEngineCancelState(harness.engine.getSnapshot(), "session-1")?.status,
+    "awaitingTurn"
+  );
+});
+
+test("semantic session stop keeps a delivery-unknown submit as its target", () => {
+  const harness = createHarness(false);
+
+  harness.engine.submitPrompt({
+    agentSessionId: "session-1",
+    clientSubmitId: "submit-1",
+    content: [{ text: "hello", type: "text" }]
+  });
+  harness.engine.dispatch({
+    commandId: "send-1",
+    commandType: "queue/sendPrompt",
+    correlationId: "submit-1",
+    errorCode: "timeout",
+    outcome: "timedOut",
+    type: "engine/commandResult"
+  });
+
+  harness.engine.stopSession({ agentSessionId: "session-1" });
+
+  assert.equal(
+    selectEngineCancelState(harness.engine.getSnapshot(), "session-1")
+      ?.targetClientSubmitId,
+    "submit-1"
+  );
+});
+
+test("stop target selection ignores a submit whose canonical Turn is settled", () => {
+  const harness = createHarness(false);
+  const turn = settledTurn();
+
+  harness.engine.submitPrompt({
+    agentSessionId: "session-1",
+    clientSubmitId: "submit-1",
+    content: [{ text: "hello", type: "text" }]
+  });
+  harness.engine.dispatch({
+    commandId: "send-1",
+    commandType: "queue/sendPrompt",
+    correlationId: "submit-1",
+    outcome: "succeeded",
+    type: "engine/commandResult",
+    value: { session: session(turn), turn, turnId: turn.turnId }
+  });
+
+  assert.equal(
+    selectLatestStopTargetSubmitForSession(
+      harness.engine.getSnapshot(),
+      "session-1"
+    ),
+    null
+  );
+});
+
 test("semantic session stop preserves an explicit submit target with an active turn", () => {
   const harness = createHarness(true);
 
@@ -153,6 +238,15 @@ function activeTurn(): AgentActivityTurn {
     startedAtUnixMs: 1,
     turnId: "turn-1",
     updatedAtUnixMs: 2
+  };
+}
+
+function settledTurn(): AgentActivityTurn {
+  return {
+    ...activeTurn(),
+    outcome: "completed",
+    phase: "settled",
+    settledAtUnixMs: 3
   };
 }
 

--- a/packages/agent/activity-core/src/engine/types.ts
+++ b/packages/agent/activity-core/src/engine/types.ts
@@ -531,6 +531,8 @@ export interface AgentSessionSubmitPromptResult {
 
 export interface AgentSessionStopInput {
   agentSessionId: string;
+  /** Identity of the pending submit to stop while its Turn is being admitted. */
+  clientSubmitId?: string;
 }
 
 export interface AgentSessionEngine {


### PR DESCRIPTION
## What changed

- Preserve an explicit `clientSubmitId` when stopping a session, even if another Turn is currently active.
- Keep a targeted stop waiting for the exact submit admission instead of canceling an unrelated active Turn.
- Correlate a delayed activity message's `clientSubmitId` to its `turnId`, so a later Turn can be canceled even when prompt admission returned failed or timed out.
- Add regression coverage for active-turn targeting and failed/timeout admission races.

## Why

The cancellation state machine had two race windows. An explicit submit target was dropped when an active Turn existed, and targeted cancellations were ignored by generic reconciliation after an uncertain send result. In both cases, a stop could either cancel the wrong Turn or fail to cancel a prompt that Host had actually admitted.

## Risk and affected surfaces

This changes only the agent activity lifecycle engine and its semantic session-stop behavior. Targeted cancellation remains exact: unrelated Turns are ignored, and the message correlation is accepted only when both the session and `clientSubmitId` match. The main affected surface is prompt admission and stop/cancel ordering in agent GUI consumers.

## Verification

- activity-core full test suite: 433 passed
- targeted lifecycle and semantic stop tests: 70 passed
- `pnpm --filter @tutti-os/agent-activity-core typecheck`
- `oxfmt --check` on all changed files

## Follow-up / out of scope

The companion desktopd owner-loop change is in [tsh#2328](https://github.com/tutti-lab/tsh/pull/2328). Existing unrelated GUI/Workbench changes in the source worktree were intentionally excluded.
