### PR TITLE
fix(agent-gui): support remote pasted text display

### DIFF
--- a/.changeset/agent-gui-shared-pasted-text.md
+++ b/.changeset/agent-gui-shared-pasted-text.md
@@ -1,0 +1,9 @@
+---
+"@tutti-os/agent-gui": patch
+---
+
+Allow AgentGUI long-paste staging to return a prepared remote file URL as well
+as a local archive path. Shared hosts can now pass text/plain pasted content
+through their existing attachment upload pipeline without treating a remote
+asset as a local file, while conversation lists receive only a safe pasted-text
+preview rather than the remote locator.

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -444,6 +444,16 @@ capabilities such as files, clipboard, runtime metadata, account/project
 lookup, diagnostics, setup, and OS/Workbench helpers. Its input type still
 accepts a legacy `agentSessions` shape, but `toAgentHostRuntimeApi` strips that
 shape; production AgentGUI must not use it as an activity source.
+Large pasted text is a separate runtime capability rather than an inference
+from generic file upload. `stagePastedText` returns one provider-readable
+locator: a local archive `path`, or an ordinary prepared remote-file `url`
+with optional object-store identity metadata. AgentGUI keeps the local path
+behavior as a read-file instruction, while a remote locator is emitted as an
+ordinary prepared file so shared hosts use their existing attachment transport;
+it must never be disguised as a local path. The conversation `displayPrompt`
+for a remote pasted-text asset carries only its safe preview mention; short-
+lived URLs and object-store locators remain in structured prompt content and
+must not enter caller-visible transcript projections.
 Device-global quick prompts are also an optional host capability rather than
 activity data. The desktop adapter combines the developer-gated preference,
 the generated `tuttid` client, and global invalidation events behind

--- a/packages/agent/gui/README.md
+++ b/packages/agent/gui/README.md
@@ -59,7 +59,12 @@ AgentGUI classifies plain-text clipboard content before delegating structured
 mention HTML. A trimmed payload of at least 5,000 characters is never inserted
 into the prompt automatically. It becomes a pasted-text draft attachment and
 is passed as raw text to `AgentGUIRuntime.stagePastedText`; the host owns
-local persistence and returns `{ path, name, sizeBytes }`.
+persistence and returns either a local `{ path, name, sizeBytes }` locator or
+a remote `{ url, name, sizeBytes, assetId?, uri?, uploadStatus? }` prepared
+attachment. Local text is sent as a read-file instruction; a remote locator is
+sent as an ordinary prepared file, so shared hosts reuse their attachment path.
+Its conversation display mention contains only the pasted-text preview, never
+the remote URL or storage locator.
 
 If the method is absent or staging fails, the attachment remains in an explicit
 failed state and retains its in-memory text. AgentGUI must not silently put the

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerDraftAttachments.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerDraftAttachments.ts
@@ -18,6 +18,7 @@ import type {
   AgentComposerDraftLargeText
 } from "../model/agentGuiNodeTypes";
 import {
+  applyPastedTextStagingResult,
   agentComposerDraftFiles,
   agentComposerDraftImages,
   agentComposerDraftLargeTexts,
@@ -673,22 +674,12 @@ export function useComposerDraftAttachments({
         name
       })
         .then((result) => {
-          const uploadedPath = result.path.trim();
-          if (!uploadedPath) {
-            throw new Error("Pasted text staging completed without path.");
-          }
           updateScopedDraft(draftScopeKey, (currentDraft) =>
             updateAgentComposerDraft(currentDraft, {
               largeTexts: agentComposerDraftLargeTexts(currentDraft).map(
                 (item) =>
                   item.id === id
-                    ? {
-                        ...item,
-                        path: uploadedPath,
-                        name: result.name || item.name,
-                        sizeBytes: result.sizeBytes,
-                        uploading: false
-                      }
+                    ? applyPastedTextStagingResult(item, result)
                     : item
               )
             })

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  applyPastedTextStagingResult,
   agentComposerDraftDisplayPrompt,
   agentComposerDraftFiles,
   agentComposerDraftHasContent,
@@ -371,6 +372,58 @@ describe("agentComposerDraft", () => {
     });
   });
 
+  it("projects remote pasted text as a safe display-only mention", () => {
+    const signedUrl =
+      "https://assets.example/shared/pasted.txt?signature=short-lived";
+    const staged = applyPastedTextStagingResult(
+      {
+        id: "22222222-2222-4222-8222-222222222222",
+        name: "pasted-text.txt",
+        text: "first line shared",
+        sizeBytes: 22,
+        uploading: true
+      },
+      {
+        name: "pasted-text.txt",
+        sizeBytes: 22,
+        assetId: "asset-1",
+        uri: "object://shared/pasted.txt",
+        uploadStatus: "uploaded",
+        url: signedUrl
+      }
+    );
+    const draft = buildAgentComposerDraft({
+      prompt: "",
+      largeTexts: [staged]
+    });
+
+    const submission = projectAgentComposerDraftSubmission({
+      draft,
+      skills: []
+    });
+
+    expect(submission).toEqual({
+      content: [
+        {
+          type: "file",
+          kind: "pasted-text",
+          mimeType: undefined,
+          name: "first line…",
+          sizeBytes: 22,
+          assetId: "asset-1",
+          uri: "object://shared/pasted.txt",
+          uploadStatus: "uploaded",
+          url: signedUrl
+        }
+      ],
+      displayPrompt:
+        "[@first line…](mention://pasted-text/22222222-2222-4222-8222-222222222222?presentation=remote)"
+    });
+    expect(submission.displayPrompt).not.toContain(signedUrl);
+    expect(submission.displayPrompt).not.toContain("asset-1");
+    expect(submission.displayPrompt).not.toContain("object://");
+  });
+
   it("submits a landed pasted-text draft as a structured file block", () => {
     const draft = buildAgentComposerDraft({
       prompt: "Summarize this",
@@ -525,6 +578,59 @@ describe("agentComposerDraft", () => {
         line: (_preview, path) => path
       })
     ).toEqual([{ type: "text", text: "hi" }]);
+  });
+
+  it("keeps remote pasted text on the prepared-file attachment path", async () => {
+    const { materializePastedTextInstructions } =
+      await import("./agentComposerDraft");
+    const content = [
+      { type: "text" as const, text: "Summarize this" },
+      {
+        type: "file" as const,
+        kind: "pasted-text",
+        mimeType: "text/plain;charset=utf-8",
+        name: "first line",
+        sizeBytes: 22,
+        assetId: "asset-1",
+        uri: "object://shared/pasted.txt",
+        uploadStatus: "uploaded",
+        url: "https://assets.example/shared/pasted.txt?signature=short-lived"
+      }
+    ];
+
+    expect(
+      materializePastedTextInstructions(content, {
+        header: () => "Referenced pasted text files:",
+        line: (preview, path) => `${preview}: ${path}`
+      })
+    ).toEqual([
+      { type: "text", text: "Summarize this" },
+      {
+        type: "file",
+        kind: "file",
+        mimeType: "text/plain;charset=utf-8",
+        name: "first line",
+        sizeBytes: 22,
+        assetId: "asset-1",
+        uri: "object://shared/pasted.txt",
+        uploadStatus: "uploaded",
+        url: "https://assets.example/shared/pasted.txt?signature=short-lived"
+      }
+    ]);
+
+    const restored = agentPromptContentToComposerDraft(
+      content,
+      "remote-restore"
+    );
+    expect(agentComposerDraftHasContent(restored)).toBe(true);
+    expect(agentComposerDraftLargeTexts(restored)).toEqual([
+      expect.objectContaining({
+        url: "https://assets.example/shared/pasted.txt?signature=short-lived",
+        assetId: "asset-1",
+        uri: "object://shared/pasted.txt",
+        uploadStatus: "uploaded"
+      })
+    ]);
   });
 
   it("adds codex app-server prompt items for referenced skills and connectors", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.ts
@@ -1,4 +1,5 @@
 import { createRichTextMentionMarkdown } from "@tutti-os/ui-rich-text/core";
+import type { AgentActivityRuntimeStagePastedTextResult } from "../../../agentActivityRuntime";
 import type { AgentPromptContentBlock } from "../../../shared/contracts/dto";
 import type {
   AgentComposerDraft,
@@ -66,30 +67,69 @@ function pastedTextPreviewLabel(
 
 /**
  * Encodes a landed pasted-text item as a canonical mention link for the
- * conversation-flow display prompt. The href (a `mention://pasted-text/...`
- * URL) losslessly carries the archive `path` and byte size so the host can
- * render a chip and open a preview on click — the persisted, reload-safe
- * "custom protocol" for pasted text. Returns "" when the item has not landed.
+ * conversation-flow display prompt. A local href carries the archive `path`
+ * and byte size so the host can render a chip and open a preview on click.
+ * A remote href deliberately carries only the draft identity and preview
+ * label: signed object URLs and attachment locators must stay in structured
+ * prompt content, never in display-only text that may be projected to a
+ * shared caller transcript. Returns "" when the item has not landed.
  */
 export function pastedTextMentionMarkdown(
   item: AgentComposerDraftLargeText,
   index: number
 ): string {
   const path = item.path?.trim();
-  if (!path) {
+  const remoteUrl = item.url?.trim();
+  if (!path && !remoteUrl) {
     return "";
   }
   return createRichTextMentionMarkdown({
     providerId: AGENT_PASTED_TEXT_MENTION_KIND,
     entityId: item.id,
     label: pastedTextPreviewLabel(item, index),
-    scope: {
-      path,
-      ...(typeof item.sizeBytes === "number" && Number.isFinite(item.sizeBytes)
-        ? { size: String(item.sizeBytes) }
-        : {})
-    }
+    ...(path
+      ? {
+          scope: {
+            path,
+            ...(typeof item.sizeBytes === "number" &&
+            Number.isFinite(item.sizeBytes)
+              ? { size: String(item.sizeBytes) }
+              : {})
+          }
+        }
+      : { scope: { presentation: "remote" } })
   });
+}
+
+/**
+ * Applies the provider-readable locator returned by the host staging boundary
+ * to one draft item. Keeping this mapping in the model lets the composer hook
+ * remain a transport caller rather than a second attachment-state owner.
+ */
+export function applyPastedTextStagingResult(
+  item: AgentComposerDraftLargeText,
+  result: AgentActivityRuntimeStagePastedTextResult
+): AgentComposerDraftLargeText {
+  const path = result.path?.trim();
+  const url = result.url?.trim();
+  if (!path && !url) {
+    throw new Error(
+      "Pasted text staging completed without a provider-readable locator."
+    );
+  }
+  return {
+    ...item,
+    ...(path ? { path } : { url: url! }),
+    ...(result.mimeType?.trim() ? { mimeType: result.mimeType.trim() } : {}),
+    ...(result.assetId?.trim() ? { assetId: result.assetId.trim() } : {}),
+    ...(result.uri?.trim() ? { uri: result.uri.trim() } : {}),
+    ...(result.uploadStatus?.trim()
+      ? { uploadStatus: result.uploadStatus.trim() }
+      : {}),
+    name: result.name || item.name,
+    sizeBytes: result.sizeBytes,
+    uploading: false
+  };
 }
 import {
   promptForProviderSkills,
@@ -265,7 +305,7 @@ export function agentComposerDraftHasContent(
     if (block.type === "image") return true;
     return block.kind === "file"
       ? false
-      : block.text.trim() !== "" || Boolean(block.path);
+      : block.text.trim() !== "" || Boolean(block.path || block.url);
   });
 }
 
@@ -438,6 +478,11 @@ function agentPromptPastedTextBlockToDraftLargeText(
     name: block.name?.trim() || "pasted-text.txt",
     text: "",
     ...(block.path ? { path: block.path } : {}),
+    ...(block.url ? { url: block.url } : {}),
+    ...(block.mimeType ? { mimeType: block.mimeType } : {}),
+    ...(block.uri ? { uri: block.uri } : {}),
+    ...(block.assetId ? { assetId: block.assetId } : {}),
+    ...(block.uploadStatus ? { uploadStatus: block.uploadStatus } : {}),
     ...(typeof block.sizeBytes === "number"
       ? { sizeBytes: block.sizeBytes }
       : {})
@@ -496,7 +541,8 @@ export function agentComposerDraftDisplayPrompt(
 ): string | undefined {
   const prompt = agentComposerDraftPrompt(draft).trim();
   const largeTexts = agentComposerDraftLargeTexts(draft).filter(
-    (item) => Boolean(item.path) && !item.uploading && !item.uploadError
+    (item) =>
+      Boolean(item.path || item.url) && !item.uploading && !item.uploadError
   );
   if (!largeTexts.length) {
     return prompt.includes("](mention://") ? prompt : undefined;
@@ -571,14 +617,14 @@ export function textPromptContent(prompt: string): AgentPromptContentBlock[] {
 }
 
 /**
- * Pasted long text submits as a structured `file` block (content-addressed
- * archive path) tagged with {@link AGENT_PASTED_TEXT_BLOCK_KIND}. Only landed
- * items are emitted — same rule as images: still-uploading or errored items are
- * dropped from submit (a visible error chip remains for the user to retry or
- * remove). The codex-style "read this file" instruction is NOT added here; it
- * is materialized in the controller at send time via
- * {@link materializePastedTextInstructions} so translations never enter the
- * model layer or the persisted/queued draft.
+ * Pasted long text submits as a structured `file` block tagged with
+ * {@link AGENT_PASTED_TEXT_BLOCK_KIND}. A landed item has either a local
+ * archive path or a remote prepared-file URL. Still-uploading or errored items
+ * are dropped from submit (a visible error chip remains for the user to retry
+ * or remove). The local codex-style "read this file" instruction, and the
+ * remote conversion to an ordinary prepared file, are materialized in the
+ * controller at send time via {@link materializePastedTextInstructions} so
+ * translations never enter the model layer or the persisted/queued draft.
  */
 function largeTextPromptContent(
   largeTexts: readonly AgentComposerDraftLargeText[]
@@ -586,15 +632,24 @@ function largeTextPromptContent(
   return largeTexts
     .filter((item) => {
       const path = item.path?.trim();
-      return Boolean(path) && !item.uploading && !item.uploadError;
+      const url = item.url?.trim();
+      return Boolean(path || url) && !item.uploading && !item.uploadError;
     })
     .map((item, index) => ({
       type: "file" as const,
       kind: AGENT_PASTED_TEXT_BLOCK_KIND,
-      path: item.path,
+      ...(item.path?.trim()
+        ? { path: item.path.trim() }
+        : { url: item.url!.trim() }),
+      ...(item.mimeType?.trim() ? { mimeType: item.mimeType.trim() } : {}),
       // The preview (first chars of the pasted body) is the chip label; carry it
       // as the block name so the send-time instruction persists it in content.
       name: pastedTextPreviewLabel(item, index),
+      ...(item.uri?.trim() ? { uri: item.uri.trim() } : {}),
+      ...(item.assetId?.trim() ? { assetId: item.assetId.trim() } : {}),
+      ...(item.uploadStatus?.trim()
+        ? { uploadStatus: item.uploadStatus.trim() }
+        : {}),
       ...(typeof item.sizeBytes === "number"
         ? { sizeBytes: item.sizeBytes }
         : {})
@@ -612,15 +667,12 @@ export function isPastedTextPromptBlock(
 }
 
 /**
- * Rewrites `content` for send: the structured pasted-text `file` blocks
- * (kept in the draft/queue so the composer can show a chip and restore it on
- * edit) are replaced by a single codex-style instruction text block at the tail
- * that references each landed file by path — mirroring the Codex desktop app,
- * which references pasted text as a plain "read this file" line rather than a
- * structured attachment. This also keeps the sent content free of `file` blocks,
- * which the desktop tuttid pipeline rejects. The instruction copy is passed in
- * already-translated so the model layer stays free of any i18n dependency. When
- * there are no pasted-text blocks the input is returned unchanged.
+ * Rewrites `content` for send. Local pasted-text blocks are replaced by one
+ * codex-style instruction text block at the tail that references each local
+ * archive path. Remote pasted-text blocks become ordinary prepared `file`
+ * blocks, preserving their object-store locator and metadata so the shared host
+ * can use its normal attachment pipeline. The instruction copy is passed in
+ * already-translated so the model layer stays free of any i18n dependency.
  */
 export function materializePastedTextInstructions(
   content: readonly AgentPromptContentBlock[],
@@ -636,17 +688,27 @@ export function materializePastedTextInstructions(
       path: block.path?.trim() ?? ""
     }))
     .filter((ref) => ref.path !== "");
+  const withoutLocalPastedText = content.flatMap((block) => {
+    if (!isPastedTextPromptBlock(block)) {
+      return [block];
+    }
+    if (block.path?.trim()) {
+      return [];
+    }
+    const url = block.url?.trim();
+    if (!url) {
+      return [];
+    }
+    return [{ ...block, kind: "file", url }];
+  });
   if (pastedRefs.length === 0) {
-    return [...content];
+    return withoutLocalPastedText;
   }
-  const withoutPastedText = content.filter(
-    (block) => !isPastedTextPromptBlock(block)
-  );
   const instruction = [
     format.header(),
     ...pastedRefs.map((ref) => format.line(ref.preview, ref.path))
   ].join("\n");
-  return [...withoutPastedText, { type: "text", text: instruction }];
+  return [...withoutLocalPastedText, { type: "text", text: instruction }];
 }
 
 // The preview is embedded quoted in the persisted instruction line

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentExternalPromptFiles.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentExternalPromptFiles.ts
@@ -205,7 +205,7 @@ export function agentPromptPastedTextBlocks(
     (block): block is AgentPromptContentBlock & { type: "file" } =>
       block.type === "file" &&
       block.kind === AGENT_PASTED_TEXT_BLOCK_KIND &&
-      typeof block.path === "string"
+      (typeof block.path === "string" || typeof block.url === "string")
   );
 }
 

--- a/packages/agent/gui/agentActivityRuntime.tsx
+++ b/packages/agent/gui/agentActivityRuntime.tsx
@@ -232,9 +232,10 @@ export interface AgentActivityRuntimeUploadPromptContentResult {
 }
 
 /**
- * Dedicated host boundary for turning an in-memory text paste into a local
- * prompt asset. The runtime owns persistence and returns a sendable host path;
- * AgentGUI must not infer this capability from generic file-upload support.
+ * Dedicated host boundary for turning an in-memory text paste into a prepared
+ * prompt asset. The runtime owns persistence and returns one provider-readable
+ * locator; AgentGUI must not infer this capability from generic file-upload
+ * support.
  */
 export interface AgentActivityRuntimeStagePastedTextInput {
   name: string;
@@ -242,11 +243,32 @@ export interface AgentActivityRuntimeStagePastedTextInput {
   workspaceId: string;
 }
 
-export interface AgentActivityRuntimeStagePastedTextResult {
-  name: string;
-  path: string;
-  sizeBytes: number;
-}
+/**
+ * A prepared long-text asset. Local hosts return a path; remote/shared hosts
+ * return the same URL-backed attachment metadata used by ordinary prompt-file
+ * upload. Exactly one of `path` and `url` must be present.
+ */
+export type AgentActivityRuntimeStagePastedTextResult =
+  | {
+      name: string;
+      path: string;
+      url?: never;
+      assetId?: never;
+      mimeType?: string;
+      sizeBytes: number;
+      uploadStatus?: never;
+      uri?: never;
+    }
+  | {
+      name: string;
+      path?: never;
+      url: string;
+      assetId?: string;
+      mimeType?: string;
+      sizeBytes: number;
+      uploadStatus?: string;
+      uri?: string;
+    };
 
 export type AgentActivityRuntimeSessionSectionScopeInput =
   AgentConversationRailSessionSectionScopeInput;


### PR DESCRIPTION
## What changed

- Let AgentGUI stage long pasted text to either a local archive path or a prepared remote file URL with attachment metadata.
- Preserve remote pasted text through the shared-host prepared-file pipeline.
- Add a safe display-only pasted-text mention so the conversation list renders a preview chip without exposing signed URLs or storage locators.
- Add focused coverage, runtime documentation, and an `@tutti-os/agent-gui` patch changeset.

## Why

Shared-agent staging already uploads pasted text through the normal prompt-file path, which returns a URL rather than a local path. AgentGUI previously treated only paths as landed pasted text, so the user-message projection received a generic file with no display prompt and rendered nothing in the conversation list.

## Impact and risk

Shared-agent long pasted text now appears in the message list as a safe preview and is sent as a prepared attachment. Local path-backed pasted text retains its existing read-file behavior. The display-only mention intentionally excludes signed URLs, asset IDs, and object-store URIs.

## Validation

- `pnpm exec vitest run agent-gui/agentGuiNode/model/agentComposerDraft.spec.ts shared/agentConversation/projection/workspaceAgentMessageProjection.spec.ts --project node`
- `pnpm typecheck` in `packages/agent/gui`
- `corepack pnpm@10.11.0 exec oxlint --deny-warnings …` on the modified AgentGUI TypeScript sources
- `pnpm check:agent-activity-runtime-boundaries`
- TSH focused integration tests for prompt staging, shared-runtime isolation, and remote pasted-text mentions
- `pnpm --dir apps/tsh-desktop check`

## Follow-up

The TSH host integration remains local until this AgentGUI patch is released. TSH will then upgrade the full Tutti dependency cohort through the package manager and open its follow-up PR.