### PR TITLE
fix(release): add Windows RC download links

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -720,14 +720,20 @@ jobs:
           name: tutti-desktop-release-summary
           path: release-assets/release-summary.json
 
-      - name: Update release notes with summary
+      - name: Update release notes with summary and direct downloads
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          export RELEASE_TAG="${TUTTI_DESKTOP_RELEASE_TAG}"
+          export RELEASE_ASSET_BASE_URL="${TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL}"
           gh release view "${TUTTI_DESKTOP_RELEASE_TAG}" --json body --jq .body > release-body.md
           node apps/desktop/scripts/upsert-release-summary.mjs \
             release-body.md \
             release-assets/release-summary.json \
+            release-body-with-summary.md
+          node apps/desktop/scripts/upsert-release-download-links.mjs \
+            release-body-with-summary.md \
+            release-assets \
             updated-release-body.md
           gh release edit "${TUTTI_DESKTOP_RELEASE_TAG}" --notes-file updated-release-body.md
 

--- a/apps/desktop/scripts/send-release-feishu-card.mjs
+++ b/apps/desktop/scripts/send-release-feishu-card.mjs
@@ -177,7 +177,7 @@ function findPreferredAssetName(assetNames, pattern) {
 }
 
 function findAssetUrl(release, pattern, releaseAssetBaseUrl = "") {
-  const assets = Array.isArray(release.assets) ? release.assets : [];
+  const assets = Array.isArray(release?.assets) ? release.assets : [];
   const assetName = findPreferredAssetName(
     assets.map((candidate) => candidate.name ?? ""),
     pattern
@@ -280,6 +280,7 @@ function buildCardPayload({
   actor,
   branch,
   macUrl,
+  winUrl,
   publicationStatus = "published",
   releaseUrl,
   runUrl,
@@ -292,6 +293,7 @@ function buildCardPayload({
   const deployActor = resolveDisplayValue(actor);
   const actions = [
     { label: "下载 macOS", url: macUrl },
+    { label: "下载 Windows（未签名）", url: winUrl },
     { label: "打开 Release 页面", url: releaseUrl },
     { label: "查看流水线", url: runUrl }
   ]
@@ -450,6 +452,12 @@ async function main() {
     releaseAssetBaseUrl,
     tag
   );
+  const mirroredWinUrl = resolveMirroredAssetUrl(
+    mirroredAssetNames,
+    /-win-x64\.exe$/i,
+    releaseAssetBaseUrl,
+    tag
+  );
   const release = mirroredMacUrl
     ? null
     : await loadRelease(repository, tag, resolveGithubToken());
@@ -461,6 +469,9 @@ async function main() {
     branch,
     macUrl:
       mirroredMacUrl || findAssetUrl(release, /\.dmg$/i, releaseAssetBaseUrl),
+    winUrl:
+      mirroredWinUrl ||
+      findAssetUrl(release, /-win-x64\.exe$/i, releaseAssetBaseUrl),
     publicationStatus,
     releaseUrl,
     runUrl,

--- a/apps/desktop/scripts/upsert-release-download-links.mjs
+++ b/apps/desktop/scripts/upsert-release-download-links.mjs
@@ -25,7 +25,7 @@ function removeManagedSection(body) {
   return body.replace(managedSectionPattern, "\n").trimEnd();
 }
 
-function findMacDmgAssetName(assetNames, pattern) {
+function findAssetName(assetNames, pattern) {
   return assetNames.find((name) => {
     pattern.lastIndex = 0;
     return pattern.test(name);
@@ -49,13 +49,17 @@ function resolveDesktopDownloadLinks(
     {
       label: "macOS Universal",
       pattern: /-mac-universal\.dmg$/i
+    },
+    {
+      label: "Windows (x64, unsigned)",
+      pattern: /-win-x64\.exe$/i
     }
   ];
   const normalizedBaseUrl = normalizeBaseUrl(releaseAssetBaseUrl);
 
   return desktopAssets
     .map(({ label, pattern }) => {
-      const assetName = findMacDmgAssetName(assetNames, pattern);
+      const assetName = findAssetName(assetNames, pattern);
       if (!assetName) {
         return null;
       }
@@ -140,7 +144,7 @@ export {
   SECTION_END,
   SECTION_START,
   buildUpdatedReleaseBody,
-  findMacDmgAssetName,
+  findAssetName,
   removeManagedSection,
   resolveDesktopDownloadLinks
 };

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -350,7 +350,10 @@ test("desktop release workflow only publishes root latest metadata for stable re
   const workflow = await readFile(workflowPath, "utf8");
   const promoteWorkflow = await readFile(promoteWorkflowPath, "utf8");
 
-  assert.match(workflow, /publication_mode:[\s\S]*?- publish\n\s*- draft_only/);
+  assert.match(
+    workflow,
+    /publication_mode:[\s\S]*?- publish\r?\n\s*- draft_only/
+  );
   assert.match(
     workflow,
     /needs\.resolve\.outputs\.publication_mode\s*==\s*'publish'/
@@ -663,8 +666,8 @@ test("desktop release workflow keeps Windows packaging opt-in and stages unsigne
     /include_windows:[\s\S]*?type:\s+boolean[\s\S]*?default:\s+false/
   );
   assert.match(workflow, /id:\s+windows[\s\S]*?include_windows=false/);
-  assert.match(workflow, /\n\s{2}build-windows:\n/);
-  assert.doesNotMatch(workflow, /\n\s{2}build-linux:\n/);
+  assert.match(workflow, /\r?\n\s{2}build-windows:\r?\n/);
+  assert.doesNotMatch(workflow, /\r?\n\s{2}build-linux:\r?\n/);
   assert.match(
     workflow,
     /build-windows:[\s\S]*?if:\s+\$\{\{\s*needs\.resolve\.outputs\.include_windows\s*==\s*'true'\s*\}\}/
@@ -691,6 +694,14 @@ test("desktop release workflow keeps Windows packaging opt-in and stages unsigne
     /name:\s+tutti-desktop-release-assets-windows/
   );
   assert.match(stageJobMatch[0], /name:\s+Add Windows release artifacts/);
+  assert.match(
+    stageJobMatch[0],
+    /upsert-release-download-links\.mjs[\s\S]*?release-assets[\s\S]*?updated-release-body\.md/
+  );
+  assert.match(
+    stageJobMatch[0],
+    /export RELEASE_TAG="\$\{TUTTI_DESKTOP_RELEASE_TAG\}"/
+  );
   assert.match(stageJobMatch[0], /merge-multiple:\s+false/);
   assert.doesNotMatch(
     notifyJobMatch[0],

--- a/tools/scripts/desktop-release-download-links.test.mjs
+++ b/tools/scripts/desktop-release-download-links.test.mjs
@@ -11,7 +11,7 @@ import {
   buildUpdatedReleaseBody
 } from "../../apps/desktop/scripts/upsert-release-download-links.mjs";
 
-test("desktop release notes append all macOS direct download links for mirrored assets", () => {
+test("desktop release notes append macOS and Windows direct download links for mirrored assets", () => {
   const nextBody = buildUpdatedReleaseBody({
     assetNames: [
       "Tutti-0.1.0-rc.2-linux-x86_64.AppImage",
@@ -43,7 +43,10 @@ test("desktop release notes append all macOS direct download links for mirrored 
     nextBody,
     /\[macOS Universal\]\(https:\/\/d111111abcdef8\.cloudfront\.net\/desktop-release-assets\/v0\.1\.0-rc\.2\/Tutti-0\.1\.0-rc\.2-mac-universal\.dmg\)/
   );
-  assert.doesNotMatch(nextBody, /\[Windows\]/);
+  assert.match(
+    nextBody,
+    /\[Windows \(x64, unsigned\)\]\(https:\/\/d111111abcdef8\.cloudfront\.net\/desktop-release-assets\/v0\.1\.0-rc\.2\/Tutti-0\.1\.0-rc\.2-win-x64\.exe\)/
+  );
   assert.doesNotMatch(nextBody, /\[Linux\]/);
 });
 

--- a/tools/scripts/desktop-release-feishu-card.test.mjs
+++ b/tools/scripts/desktop-release-feishu-card.test.mjs
@@ -129,9 +129,32 @@ test("release Feishu card includes tsh-aligned release context fields", () => {
 
   assert.deepEqual(actionLabels, [
     "下载 macOS",
+    "下载 Windows（未签名）",
     "打开 Release 页面",
     "查看流水线"
   ]);
+});
+
+test("release Feishu card uses the mirrored Windows installer URL", () => {
+  const payload = buildCardPayload({
+    actor: "jomeswang",
+    branch: "main",
+    macUrl: "https://example.com/tutti.dmg",
+    releaseUrl: "https://github.com/tutti-os/tutti/releases/tag/v1.12.20-rc.0",
+    runUrl: "https://github.com/tutti-os/tutti/actions/runs/1",
+    tag: "v1.12.20-rc.0",
+    target: "4039186abcdef0",
+    winUrl: "https://downloads.example.com/v1.12.20-rc.0/Tutti-1.12.20-rc.0-win-x64.exe"
+  });
+
+  const windowsAction = payload.card.elements
+    .find((element) => element.tag === "action")
+    .actions.find((action) => action.text.content === "下载 Windows（未签名）");
+
+  assert.equal(
+    windowsAction?.url,
+    "https://downloads.example.com/v1.12.20-rc.0/Tutti-1.12.20-rc.0-win-x64.exe"
+  );
 });
 
 test("release Feishu card includes Chinese release summary when available", () => {
@@ -204,5 +227,19 @@ test("release Feishu card resolves mirrored macOS URLs from local artifact names
       "v0.1.0-rc.4"
     ),
     "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-desktop-release-assets/v0.1.0-rc.4/Tutti-0.1.0-rc.4-mac-universal.dmg"
+  );
+  assert.equal(
+    resolveMirroredAssetUrl(
+      [
+        "Tutti-0.1.0-rc.4-mac-arm64.dmg",
+        "Tutti-0.1.0-rc.4-mac-universal.dmg",
+        "Tutti-0.1.0-rc.4-mac-x64.dmg",
+        "Tutti-0.1.0-rc.4-win-x64.exe"
+      ],
+      /-win-x64\.exe$/i,
+      "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-desktop-release-assets",
+      "v0.1.0-rc.4"
+    ),
+    "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-desktop-release-assets/v0.1.0-rc.4/Tutti-0.1.0-rc.4-win-x64.exe"
   );
 });


### PR DESCRIPTION
## Summary
- include unsigned Windows x64 installers in managed GitHub Release Direct Downloads notes
- add Windows download action to Feishu release cards when the asset is available
- pass RELEASE_TAG when staging release notes so the direct-link updater runs in CI

## Validation
- node --test tools/scripts/desktop-release*.test.mjs (87/87)
- git diff --check

This keeps Windows opt-in and unsigned while making RC draft packaging and QA distribution complete.