### PR TITLE
fix(desktop): contain managed tuttid spawn errors

### DIFF
--- a/apps/desktop/src/main/daemon/tuttidManager.test.ts
+++ b/apps/desktop/src/main/daemon/tuttidManager.test.ts
@@ -4,6 +4,7 @@ import {
   chmod,
   mkdir,
   mkdtemp,
+  rm,
   stat,
   utimes,
   writeFile
@@ -13,7 +14,10 @@ import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
+import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
+import type { DesktopDaemonEndpoint } from "../transport/paths.ts";
 import {
+  createTuttidManager,
   isLikelyTuttidProcess,
   managedTuttidStartupError,
   resolveBrowserMcpDaemonEnv,
@@ -26,6 +30,35 @@ import {
 const repoRoot = resolve(
   fileURLToPath(new URL("../../../../..", import.meta.url))
 );
+
+test("rejects startup when the managed tuttid binary cannot be spawned", async () => {
+  const previousEnv = { ...process.env };
+  const runtimeDirectory = await mkdtemp(join(tmpdir(), "tutti-tuttid-spawn-"));
+  const endpoint: DesktopDaemonEndpoint = {
+    accessToken: "test-token",
+    boundAddr: null,
+    listenerInfoPath: join(runtimeDirectory, "listener.json"),
+    pidPath: join(runtimeDirectory, "tuttid.pid"),
+    requestedAddr: "127.0.0.1:0"
+  };
+  const tuttidClient = {
+    async getHealth() {
+      throw new Error("health must not run when spawn fails");
+    }
+  } as unknown as TuttidClient;
+
+  try {
+    process.env.TUTTID_BIN = join(runtimeDirectory, "missing-tuttid");
+    const manager = createTuttidManager(endpoint, tuttidClient);
+
+    await assert.rejects(manager.start(), { code: "ENOENT" });
+    assert.equal(endpoint.boundAddr, null);
+    await manager.stop();
+  } finally {
+    restoreEnv(previousEnv);
+    await rm(runtimeDirectory, { force: true, recursive: true });
+  }
+});
 
 test("preserves managed tuttid stderr as a structured startup cause", () => {
   const failure = managedTuttidStartupError(

--- a/apps/desktop/src/main/daemon/tuttidManager.ts
+++ b/apps/desktop/src/main/daemon/tuttidManager.ts
@@ -155,13 +155,11 @@ class ManagedTuttid implements TuttidManager {
       env: processEnv,
       stdio: ["ignore", forwardStdout ? "pipe" : "ignore", "pipe"]
     });
+    const spawned = waitForChildSpawn(child);
 
     this.process = child;
     this.stopRequested = false;
     let startupDiagnostic = "";
-    logger.info("managed tuttid spawned", {
-      pid: child.pid ?? null
-    });
 
     if (forwardStdout) {
       child.stdout?.on("data", (chunk: Buffer | string) => {
@@ -177,6 +175,13 @@ class ManagedTuttid implements TuttidManager {
       getDesktopLogger().error("managed tuttid stderr", {
         chunk: chunk.toString().trim(),
         error_code: desktopErrorCodes.managedProcessStderr
+      });
+    });
+
+    child.on("error", (error) => {
+      getDesktopLogger().error("managed tuttid process error", {
+        error: formatErrorMessage(error),
+        error_code: desktopErrorCodes.managedProcessError
       });
     });
 
@@ -196,6 +201,10 @@ class ManagedTuttid implements TuttidManager {
     });
 
     try {
+      await spawned;
+      logger.info("managed tuttid spawned", {
+        pid: child.pid ?? null
+      });
       this.endpoint.boundAddr = await waitForListenerInfo(
         this.endpoint.listenerInfoPath,
         () => this.isProcessAlive()
@@ -249,6 +258,21 @@ class ManagedTuttid implements TuttidManager {
 
     return this.process.exitCode === null && this.process.signalCode === null;
   }
+}
+
+function waitForChildSpawn(child: ChildProcess): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onSpawn = () => {
+      child.off("error", onError);
+      resolve();
+    };
+    const onError = (error: Error) => {
+      child.off("spawn", onSpawn);
+      reject(error);
+    };
+    child.once("spawn", onSpawn);
+    child.once("error", onError);
+  });
 }
 
 export function managedTuttidStartupError(

--- a/apps/desktop/src/shared/errors/desktopErrors.ts
+++ b/apps/desktop/src/shared/errors/desktopErrors.ts
@@ -10,6 +10,7 @@ export const desktopErrorCodes = {
   daemonUnavailable: "daemon_unavailable",
   electronDebugRequired: "electron_debug_required",
   loggerFallback: "logger_file_unavailable",
+  managedProcessError: "managed_process_error",
   managedProcessExited: "managed_process_exited",
   managedProcessStderr: "managed_process_stderr",
   nodeRuntimeBroken: "node_runtime_broken",


### PR DESCRIPTION
## Summary

- contain managed `tuttid` child-process spawn failures inside the Desktop startup promise
- wait for Node's `spawn`/`error` handshake before reporting a successful daemon spawn
- keep a lifecycle-level child-process error listener and structured `managed_process_error` diagnostics
- add a real missing-binary regression test that verifies startup rejects and cleanup remains safe

## Problem

`child_process.spawn()` can return a `ChildProcess` and then asynchronously emit an `error` event when the executable cannot be started (for example `ENOENT`). `ManagedTuttid` listened to `stderr` and `exit`, but not `error`.

A missing, quarantined, or otherwise unlaunchable managed `tuttid` binary could therefore produce an unhandled EventEmitter error and escape the existing Desktop startup rejection/analytics path. The code also logged `managed tuttid spawned` before Node had confirmed that the process actually spawned.

## Solution

`ManagedTuttid.start()` now creates a child spawn handshake immediately after `spawn()`:

- `spawn` resolves the handshake and only then emits the success log
- `error` rejects the handshake, so the existing startup catch/cleanup path owns the failure
- handshake listeners remove their counterpart on settlement
- a lifecycle-level `error` listener keeps later child-process errors handled and records a structured diagnostic

No daemon protocol, published package, renderer API, or restart policy changes.

## Verification

- RED reproduction: missing executable caused an unhandled `spawn ... ENOENT` test failure
- focused `tuttidManager.test.ts`: 20 passed, 2 skipped
- Desktop full unit suite: 1,749 passed, 3 skipped
- Desktop typecheck
- Desktop production build and renderer CSS contracts
- Electron runtime boundary check
- `pnpm check:changed`: 10/10 lanes
- `pnpm check:changed -- --push-ready`: 11/11 lanes
- `make dev-gui` runtime smoke:
  - Electron main/preload/renderer started
  - `tutti-dev status` reported `service: tuttid`, `status: ok`
  - current Desktop session logged `managed tuttid spawned` followed by `desktop app ready`
  - current Desktop session had no `managed_process_error` or error-level Desktop logs
  - the smoke-test process tree was terminated and verified clean

## Downstream impact

This change is internal to Tutti's Electron main-process daemon owner. TSH does not reference `ManagedTuttid`, `tuttidManager`, or the new internal log code, and no consumed `@tutti-os/*` package or API changed. No TSH update is required.
