### PR TITLE
feat(mobile): add Relay fallback transport

### DIFF
--- a/apps/mobile/android/app/src/main/java/dev/tutti/mobile/DeviceLinkModule.kt
+++ b/apps/mobile/android/app/src/main/java/dev/tutti/mobile/DeviceLinkModule.kt
@@ -42,6 +42,8 @@ class DeviceLinkModule(
     private var link: Link? = null
     @Volatile
     private var agentLiveStream: Stream? = null
+    @Volatile
+    private var relayConfig: RelayConfig? = null
     private var linkGeneration = 0L
     private var agentLiveGeneration = 0L
     private val backgroundClose = Runnable { closeCurrentLink() }
@@ -140,6 +142,34 @@ class DeviceLinkModule(
     }
 
     @ReactMethod
+    fun configureRelay(
+        endpoint: String,
+        queryJSON: String,
+        headersJSON: String,
+        subprotocol: String,
+        promise: Promise,
+    ) {
+        val normalizedEndpoint = endpoint.trim()
+        val normalizedSubprotocol = subprotocol.trim()
+        if (normalizedEndpoint.isEmpty() || normalizedSubprotocol.isEmpty()) {
+            promise.reject(
+                "DEVICE_LINK_RELAY_CONFIG_FAILED",
+                "Relay endpoint and subprotocol are required",
+            )
+            return
+        }
+        synchronized(this) {
+            relayConfig = RelayConfig(
+                endpoint = normalizedEndpoint,
+                queryJSON = queryJSON,
+                headersJSON = headersJSON,
+                subprotocol = normalizedSubprotocol,
+            )
+        }
+        promise.resolve(null)
+    }
+
+    @ReactMethod
     fun requestAgentHTTP(
         method: String,
         path: String,
@@ -148,7 +178,8 @@ class DeviceLinkModule(
         promise: Promise,
     ) {
         val selected = linkSnapshot()
-        if (selected == null) {
+        val relay = relaySnapshot()
+        if (selected == null && relay == null) {
             promise.reject(
                 "DEVICE_LINK_REQUEST_FAILED",
                 "DeviceLink is not prepared",
@@ -156,81 +187,43 @@ class DeviceLinkModule(
             return
         }
         runAsync(promise, "DEVICE_LINK_REQUEST_FAILED", "DeviceLink request failed") {
-            val timeout = timeoutMillis.toLong().coerceAtLeast(1)
-            val deadline = SystemClock.elapsedRealtime() + timeout
-            val stream = selected.openStream(timeout)
-            try {
-                stream.setDeadline(
-                    (deadline - SystemClock.elapsedRealtime()).coerceAtLeast(1),
-                )
-                val requestID = UUID.randomUUID().toString()
-                val bodyBytes = body.toByteArray(StandardCharsets.UTF_8)
-                require(bodyBytes.size <= MAX_REQUEST_BODY_BYTES) {
-                    "DeviceLink request body exceeds $MAX_REQUEST_BODY_BYTES bytes"
-                }
-                val request =
-                    JSONObject()
-                        .put("protocolEpoch", Mobile.protocolEpoch())
-                        .put("service", "agent_http")
-                        .put("requestId", requestID)
-                        .put("method", method)
-                        .put("path", path)
-                        .put(
-                            "headers",
-                            JSONObject()
-                                .put("Accept", JSONArray().put("application/json"))
-                                .put("Content-Type", JSONArray().put("application/json")),
-                        ).put(
-                            "body",
-                            Base64.encodeToString(
-                                bodyBytes,
-                                Base64.NO_WRAP,
-                            ),
-                        ).toString()
-                val payload = request.toByteArray(StandardCharsets.UTF_8)
-                require(payload.size <= MAX_REQUEST_FRAME_BYTES) {
-                    "DeviceLink request exceeds $MAX_REQUEST_FRAME_BYTES bytes"
-                }
-                val framed =
-                    ByteBuffer
-                        .allocate(Int.SIZE_BYTES + payload.size)
-                        .order(ByteOrder.BIG_ENDIAN)
-                        .putInt(payload.size)
-                        .put(payload)
-                        .array()
-                writeFully(stream, framed)
-                val header = readFully(stream, Int.SIZE_BYTES)
-                val responseSize = ByteBuffer.wrap(header).order(ByteOrder.BIG_ENDIAN).int
-                require(responseSize in 1..MAX_RESPONSE_FRAME_BYTES) {
-                    "DeviceLink response size is invalid"
-                }
-                val response =
-                    JSONObject(
-                        String(
-                            readFully(stream, responseSize),
-                            StandardCharsets.UTF_8,
-                        ),
+            var directFailure: Throwable? = null
+            if (selected != null) {
+                try {
+                    return@runAsync requestAgentHTTPWithStream(
+                        selected.openStream(timeoutMillis.toLong().coerceAtLeast(1)),
+                        method,
+                        path,
+                        body,
+                        timeoutMillis.toLong(),
                     )
-                require(response.optString("requestId") == requestID) {
-                    "DeviceLink response request id does not match"
+                } catch (error: Throwable) {
+                    directFailure = error
                 }
-                val responseBody =
-                    response
-                        .optString("body")
-                        .takeIf(String::isNotEmpty)
-                        ?.let { encoded ->
-                            String(Base64.decode(encoded, Base64.DEFAULT), StandardCharsets.UTF_8)
-                        }.orEmpty()
-                Arguments.createMap().apply {
-                    putInt("protocolEpoch", response.optInt("protocolEpoch"))
-                    putInt("status", response.optInt("status"))
-                    putString("body", responseBody)
-                    putString("errorCode", response.optString("errorCode"))
-                    putMap("headers", responseHeaders(response.optJSONObject("headers")))
-                }
-            } finally {
-                runCatching(stream::close)
             }
+            if (relay != null) {
+                try {
+                    return@runAsync requestAgentHTTPWithStream(
+                        Mobile.dialRelay(
+                            relay.endpoint,
+                            relay.queryJSON,
+                            relay.headersJSON,
+                            relay.subprotocol,
+                            timeoutMillis.toLong(),
+                        ),
+                        method,
+                        path,
+                        body,
+                        timeoutMillis.toLong(),
+                    )
+                } catch (error: Throwable) {
+                    if (directFailure != null) {
+                        throw IllegalStateException("direct and Relay Agent requests failed", error)
+                    }
+                    throw error
+                }
+            }
+            throw directFailure ?: IllegalStateException("DeviceLink request failed")
         }
     }
 
@@ -260,7 +253,8 @@ class DeviceLinkModule(
             return
         }
         val selected = linkSnapshot()
-        if (selected == null) {
+        val relay = relaySnapshot()
+        if (selected == null && relay == null) {
             promise.reject(
                 "AGENT_LIVE_SUBSCRIBE_FAILED",
                 "DeviceLink is not prepared",
@@ -273,7 +267,11 @@ class DeviceLinkModule(
                 var stream: Stream? = null
                 var promiseSettled = false
                 try {
-                    stream = selected.openStream(AGENT_LIVE_OPEN_TIMEOUT_MILLIS)
+                    stream = openAgentStream(
+                        selected,
+                        relay,
+                        AGENT_LIVE_OPEN_TIMEOUT_MILLIS,
+                    )
                     check(promoteAgentLiveStream(stream, generation)) {
                         "Agent live subscription was cancelled"
                     }
@@ -464,10 +462,14 @@ class DeviceLinkModule(
                 linkGeneration += 1
                 val detached = link
                 link = null
+                relayConfig = null
                 detached
             }
         closeDetachedLink(previous)
     }
+
+    @Synchronized
+    private fun relaySnapshot(): RelayConfig? = relayConfig
 
     private fun closeDetachedLink(detached: Link?) {
         if (detached == null) {
@@ -611,6 +613,115 @@ class DeviceLinkModule(
         return output.toByteArray()
     }
 
+    private fun requestAgentHTTPWithStream(
+        stream: Stream,
+        method: String,
+        path: String,
+        body: String,
+        timeoutMillis: Long,
+    ): Any {
+        val timeout = timeoutMillis.coerceAtLeast(1)
+        val deadline = SystemClock.elapsedRealtime() + timeout
+        try {
+            stream.setDeadline(
+                (deadline - SystemClock.elapsedRealtime()).coerceAtLeast(1),
+            )
+            val requestID = UUID.randomUUID().toString()
+            val bodyBytes = body.toByteArray(StandardCharsets.UTF_8)
+            require(bodyBytes.size <= MAX_REQUEST_BODY_BYTES) {
+                "DeviceLink request body exceeds $MAX_REQUEST_BODY_BYTES bytes"
+            }
+            val request =
+                JSONObject()
+                    .put("protocolEpoch", Mobile.protocolEpoch())
+                    .put("service", "agent_http")
+                    .put("requestId", requestID)
+                    .put("method", method)
+                    .put("path", path)
+                    .put(
+                        "headers",
+                        JSONObject()
+                            .put("Accept", JSONArray().put("application/json"))
+                            .put("Content-Type", JSONArray().put("application/json")),
+                    ).put(
+                        "body",
+                        Base64.encodeToString(bodyBytes, Base64.NO_WRAP),
+                    ).toString()
+            val payload = request.toByteArray(StandardCharsets.UTF_8)
+            require(payload.size <= MAX_REQUEST_FRAME_BYTES) {
+                "DeviceLink request exceeds $MAX_REQUEST_FRAME_BYTES bytes"
+            }
+            val framed =
+                ByteBuffer
+                    .allocate(Int.SIZE_BYTES + payload.size)
+                    .order(ByteOrder.BIG_ENDIAN)
+                    .putInt(payload.size)
+                    .put(payload)
+                    .array()
+            writeFully(stream, framed)
+            val header = readFully(stream, Int.SIZE_BYTES)
+            val responseSize = ByteBuffer.wrap(header).order(ByteOrder.BIG_ENDIAN).int
+            require(responseSize in 1..MAX_RESPONSE_FRAME_BYTES) {
+                "DeviceLink response size is invalid"
+            }
+            val response =
+                JSONObject(
+                    String(readFully(stream, responseSize), StandardCharsets.UTF_8),
+                )
+            require(response.optString("requestId") == requestID) {
+                "DeviceLink response request id does not match"
+            }
+            val responseBody =
+                response
+                    .optString("body")
+                    .takeIf(String::isNotEmpty)
+                    ?.let { encoded ->
+                        String(Base64.decode(encoded, Base64.DEFAULT), StandardCharsets.UTF_8)
+                    }.orEmpty()
+            return Arguments.createMap().apply {
+                putInt("protocolEpoch", response.optInt("protocolEpoch"))
+                putInt("status", response.optInt("status"))
+                putString("body", responseBody)
+                putString("errorCode", response.optString("errorCode"))
+                putMap("headers", responseHeaders(response.optJSONObject("headers")))
+            }
+        } finally {
+            runCatching(stream::close)
+        }
+    }
+
+    private fun openAgentStream(
+        selected: Link?,
+        relay: RelayConfig?,
+        timeoutMillis: Long,
+    ): Stream {
+        var directFailure: Throwable? = null
+        if (selected != null) {
+            try {
+                return selected.openStream(timeoutMillis)
+            } catch (error: Throwable) {
+                directFailure = error
+            }
+        }
+        if (relay != null) {
+            try {
+                return Mobile.dialRelay(
+                    relay.endpoint,
+                    relay.queryJSON,
+                    relay.headersJSON,
+                    relay.subprotocol,
+                    timeoutMillis,
+                )
+            } catch (error: Throwable) {
+                if (directFailure != null) {
+                    throw IllegalStateException("direct and Relay Agent live streams failed", error)
+                }
+                throw error
+            }
+        }
+        throw directFailure ?: IllegalStateException("DeviceLink Agent live stream is unavailable")
+    }
+
     private fun responseHeaders(headers: JSONObject?) =
         Arguments.createMap().apply {
             if (headers == null) {
@@ -658,4 +769,11 @@ class DeviceLinkModule(
         private const val MAX_RESPONSE_FRAME_BYTES =
             ((MAX_RESPONSE_BODY_BYTES + 2) / 3 * 4) + FRAME_ENVELOPE_BYTES
     }
+
+    private data class RelayConfig(
+        val endpoint: String,
+        val queryJSON: String,
+        val headersJSON: String,
+        val subprotocol: String,
+    )
 }

--- a/apps/mobile/ios/TuttiMobile/DeviceLinkModule.mm
+++ b/apps/mobile/ios/TuttiMobile/DeviceLinkModule.mm
@@ -120,6 +120,10 @@ static NSUInteger TUTReadFrameSize(TUTMobileStream *stream, NSUInteger maximum,
 @interface TuttiDeviceLink : RCTEventEmitter <RCTBridgeModule>
 @property(nonatomic, strong) TUTMobileLink *link;
 @property(nonatomic, strong) TUTMobileStream *agentLiveStream;
+@property(nonatomic, copy) NSString *relayEndpoint;
+@property(nonatomic, copy) NSString *relayQueryJSON;
+@property(nonatomic, copy) NSString *relayHeadersJSON;
+@property(nonatomic, copy) NSString *relaySubprotocol;
 @property(nonatomic, assign) int64_t linkGeneration;
 @property(nonatomic, assign) int64_t agentLiveGeneration;
 @property(nonatomic, strong) dispatch_queue_t operationQueue;
@@ -269,6 +273,33 @@ RCT_REMAP_METHOD(connectLink,
   });
 }
 
+RCT_REMAP_METHOD(configureRelay,
+                 configureRelay:(NSString *)endpoint
+                 queryJSON:(NSString *)queryJSON
+                 headersJSON:(NSString *)headersJSON
+                 subprotocol:(NSString *)subprotocol
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+  NSString *normalizedEndpoint =
+      [endpoint stringByTrimmingCharactersInSet:
+                    [NSCharacterSet whitespaceAndNewlineCharacterSet]];
+  NSString *normalizedSubprotocol =
+      [subprotocol stringByTrimmingCharactersInSet:
+                      [NSCharacterSet whitespaceAndNewlineCharacterSet]];
+  if (normalizedEndpoint.length == 0 || normalizedSubprotocol.length == 0) {
+    reject(@"DEVICE_LINK_RELAY_CONFIG_FAILED",
+           @"Relay endpoint and subprotocol are required", nil);
+    return;
+  }
+  @synchronized(self) {
+    self.relayEndpoint = normalizedEndpoint;
+    self.relayQueryJSON = queryJSON ?: @"";
+    self.relayHeadersJSON = headersJSON ?: @"";
+    self.relaySubprotocol = normalizedSubprotocol;
+  }
+  resolve(nil);
+}
+
 RCT_REMAP_METHOD(requestAgentHTTP,
                  requestAgentHTTP:(NSString *)method
                  path:(NSString *)path
@@ -277,19 +308,41 @@ RCT_REMAP_METHOD(requestAgentHTTP,
                  resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
   TUTMobileLink *selected = [self linkSnapshot];
-  if (selected == nil) {
+  NSDictionary *relay = [self relaySnapshot];
+  if (selected == nil && relay == nil) {
     reject(@"DEVICE_LINK_REQUEST_FAILED", @"DeviceLink is not prepared", nil);
     return;
   }
   dispatch_async(self.operationQueue, ^{
     NSError *error = nil;
-    NSDictionary *response =
-        [self requestAgentHTTPWithLink:selected
-                               method:method
-                                 path:path
-                                 body:body
-                        timeoutMillis:(int64_t)timeoutMillis
-                                error:&error];
+    NSDictionary *response = nil;
+    if (selected != nil) {
+      response = [self requestAgentHTTPWithLink:selected
+                                         method:method
+                                           path:path
+                                           body:body
+                                  timeoutMillis:(int64_t)timeoutMillis
+                                          error:&error];
+    }
+    if (response == nil && relay != nil) {
+      NSError *relayError = nil;
+      TUTMobileStream *stream = TUTMobileDialRelay(
+          relay[@"endpoint"], relay[@"queryJSON"], relay[@"headersJSON"],
+          relay[@"subprotocol"], (int64_t)timeoutMillis, &relayError);
+      if (stream != nil && relayError == nil) {
+        response = [self requestAgentHTTPWithStream:stream
+                                              method:method
+                                                path:path
+                                                body:body
+                                         timeoutMillis:(int64_t)timeoutMillis
+                                                 error:&relayError];
+      }
+      if (response != nil) {
+        error = nil;
+      } else if (error == nil) {
+        error = relayError;
+      }
+    }
     if (response == nil || error != nil) {
       reject(@"DEVICE_LINK_REQUEST_FAILED", @"DeviceLink request failed",
              error);
@@ -321,15 +374,18 @@ RCT_REMAP_METHOD(startAgentLive,
     return;
   }
   TUTMobileLink *selected = [self linkSnapshot];
-  if (selected == nil) {
+  NSDictionary *relay = [self relaySnapshot];
+  if (selected == nil && relay == nil) {
     reject(@"AGENT_LIVE_SUBSCRIBE_FAILED", @"DeviceLink is not prepared", nil);
     return;
   }
   int64_t generation = [self beginAgentLiveOperation];
   dispatch_async(self.agentLiveQueue, ^{
     NSError *error = nil;
-    TUTMobileStream *stream =
-        [selected openStream:TUTAgentLiveOpenTimeoutMillis error:&error];
+    TUTMobileStream *stream = [self openAgentStream:selected
+                                              relay:relay
+                                      timeoutMillis:TUTAgentLiveOpenTimeoutMillis
+                                              error:&error];
     if (stream == nil || error != nil) {
       reject(@"AGENT_LIVE_SUBSCRIBE_FAILED",
              @"Unable to start Agent live subscription", error);
@@ -444,15 +500,30 @@ RCT_REMAP_METHOD(closeLink,
 - (NSDictionary *)requestAgentHTTPWithLink:(TUTMobileLink *)link
                                     method:(NSString *)method
                                       path:(NSString *)path
-                                      body:(NSString *)body
-                             timeoutMillis:(int64_t)timeoutMillis
+                                     body:(NSString *)body
+                            timeoutMillis:(int64_t)timeoutMillis
                                      error:(NSError **)error {
   int64_t timeout = MAX(timeoutMillis, 1);
-  NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:timeout / 1000.0];
   TUTMobileStream *stream = [link openStream:timeout error:error];
   if (stream == nil) {
     return nil;
   }
+  return [self requestAgentHTTPWithStream:stream
+                                   method:method
+                                     path:path
+                                     body:body
+                            timeoutMillis:timeoutMillis
+                                    error:error];
+}
+
+- (NSDictionary *)requestAgentHTTPWithStream:(TUTMobileStream *)stream
+                                      method:(NSString *)method
+                                        path:(NSString *)path
+                                        body:(NSString *)body
+                               timeoutMillis:(int64_t)timeoutMillis
+                                       error:(NSError **)error {
+  int64_t timeout = MAX(timeoutMillis, 1);
+  NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:timeout / 1000.0];
   @try {
     int64_t remaining =
         MAX((int64_t)([deadline timeIntervalSinceNow] * 1000.0), 1);
@@ -532,6 +603,52 @@ RCT_REMAP_METHOD(closeLink,
   }
 }
 
+- (NSDictionary *)relaySnapshot {
+  @synchronized(self) {
+    if (self.relayEndpoint.length == 0 ||
+        self.relaySubprotocol.length == 0) {
+      return nil;
+    }
+    return @{
+      @"endpoint" : self.relayEndpoint,
+      @"queryJSON" : self.relayQueryJSON ?: @"",
+      @"headersJSON" : self.relayHeadersJSON ?: @"",
+      @"subprotocol" : self.relaySubprotocol,
+    };
+  }
+}
+
+- (TUTMobileStream *)openAgentStream:(TUTMobileLink *)link
+                               relay:(NSDictionary *)relay
+                       timeoutMillis:(int64_t)timeoutMillis
+                               error:(NSError **)error {
+  NSError *directError = nil;
+  if (link != nil) {
+    TUTMobileStream *stream = [link openStream:MAX(timeoutMillis, 1)
+                                         error:&directError];
+    if (stream != nil) {
+      return stream;
+    }
+  }
+  if (relay != nil) {
+    NSError *relayError = nil;
+    TUTMobileStream *stream = TUTMobileDialRelay(
+        relay[@"endpoint"], relay[@"queryJSON"], relay[@"headersJSON"],
+        relay[@"subprotocol"], MAX(timeoutMillis, 1), &relayError);
+    if (stream != nil) {
+      return stream;
+    }
+    if (error != NULL) {
+      *error = relayError ?: directError;
+    }
+    return nil;
+  }
+  if (error != NULL) {
+    *error = directError;
+  }
+  return nil;
+}
+
 - (NSDictionary *)objectFromJSONString:(NSString *)json {
   NSData *data = [json dataUsingEncoding:NSUTF8StringEncoding];
   return data == nil ? nil : TUTJSONObject(data, nil);
@@ -578,6 +695,10 @@ RCT_REMAP_METHOD(closeLink,
     self.linkGeneration += 1;
     previous = self.link;
     self.link = nil;
+    self.relayEndpoint = nil;
+    self.relayQueryJSON = nil;
+    self.relayHeadersJSON = nil;
+    self.relaySubprotocol = nil;
   }
   [self closeDetachedLink:previous];
 }

--- a/apps/mobile/src/native/mobileNative.ts
+++ b/apps/mobile/src/native/mobileNative.ts
@@ -41,6 +41,12 @@ interface MobilePreferencesNative {
 interface DeviceLinkNative {
   addListener(eventName: string): void;
   closeLink(): Promise<void>;
+  configureRelay?: (
+    endpoint: string,
+    queryJSON: string,
+    headersJSON: string,
+    subprotocol: string
+  ) => Promise<void>;
   connectLink(
     peerDescriptionJSON: string,
     caller: boolean,

--- a/apps/mobile/src/services/pairingClient.test.ts
+++ b/apps/mobile/src/services/pairingClient.test.ts
@@ -1,6 +1,8 @@
 jest.mock("../native/mobileNative", () => ({
   __esModule: true,
-  deviceLink: {},
+  deviceLink: {
+    configureRelay: jest.fn()
+  },
   mobileSecurity: {
     getOrCreateIdentity: jest.fn(),
     sign: jest.fn()
@@ -8,7 +10,11 @@ jest.mock("../native/mobileNative", () => ({
 }));
 
 import { mobileSecurity } from "../native/mobileNative";
-import { claimPairing, registerCurrentDevice } from "./pairingClient";
+import {
+  claimPairing,
+  issueAgentRelayDescriptor,
+  registerCurrentDevice
+} from "./pairingClient";
 import {
   deviceLinkProof,
   identityProof,
@@ -89,6 +95,72 @@ describe("control-plane authentication", () => {
 
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it("requests a scoped Agent Relay descriptor with the relay proof", async () => {
+    mockSign.mockResolvedValue("relay-signature");
+    const fetchMock = jest.fn().mockResolvedValue(
+      controlPlaneResponse({
+        authorityId: "authority-1",
+        relayDialEndpoint: "wss://relay.example.test/v1/tunnels/dial",
+        token: "target-token",
+        tokenExpiresAt: "2026-08-04T10:00:00Z"
+      })
+    );
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      issueAgentRelayDescriptor("session-1", "pairing-1", {
+        arch: "arm64",
+        deviceId: "device-1",
+        deviceName: "Alice's iPhone",
+        publicKey: "cHVibGljLWtleQ"
+      })
+    ).resolves.toEqual({
+      authorityId: "authority-1",
+      relayDialEndpoint: "wss://relay.example.test/v1/tunnels/dial",
+      token: "target-token",
+      tokenExpiresAt: "2026-08-04T10:00:00Z"
+    });
+
+    expect(mockSign).toHaveBeenCalledWith(
+      deviceLinkProof("relay", "pairing-1", "", "")
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://tutti.sh/api/desktop/v1/device-pairings/pairing-1/agent-relay-descriptor",
+      expect.objectContaining({
+        body: JSON.stringify({
+          deviceId: "device-1",
+          identitySignature: "relay-signature",
+          pairingId: "pairing-1"
+        }),
+        headers: expect.objectContaining({
+          Cookie: "session_id=session-1"
+        }),
+        method: "POST"
+      })
+    );
+  });
+
+  it("rejects a Relay descriptor that is not a websocket endpoint", async () => {
+    mockSign.mockResolvedValue("relay-signature");
+    globalThis.fetch = jest.fn().mockResolvedValue(
+      controlPlaneResponse({
+        authorityId: "authority-1",
+        relayDialEndpoint: "https://relay.example.test/not-websocket",
+        token: "target-token",
+        tokenExpiresAt: "2026-08-04T10:00:00Z"
+      })
+    );
+
+    await expect(
+      issueAgentRelayDescriptor("session-1", "pairing-1", {
+        arch: "arm64",
+        deviceId: "device-1",
+        deviceName: "Alice's iPhone",
+        publicKey: "cHVibGljLWtleQ"
+      })
+    ).rejects.toThrow("control-plane Relay descriptor is incomplete");
+  });
 });
 
 describe("parsePairingQR", () => {
@@ -132,6 +204,9 @@ describe("pairing proofs", () => {
     );
     expect(deviceLinkProof("get", "pairing-1", "attempt-1", "")).toBe(
       "tutti-device-link/1\nget\npairing-1\nattempt-1\n"
+    );
+    expect(deviceLinkProof("relay", "pairing-1", "", "")).toBe(
+      "tutti-device-link/1\nrelay\npairing-1\n\n"
     );
     expect(standardBase64ToURL("a+b/c==")).toBe("a-b_c");
   });

--- a/apps/mobile/src/services/pairingClient.ts
+++ b/apps/mobile/src/services/pairingClient.ts
@@ -49,6 +49,15 @@ interface DeviceLinkAttempt {
   stunEndpoints?: string[];
 }
 
+export interface AgentRelayDescriptor {
+  authorityId: string;
+  relayDialEndpoint: string;
+  token: string;
+  tokenExpiresAt: string;
+}
+
+const RELAY_STREAM_SUBPROTOCOL = "tsh.relay.stream.v1";
+
 export async function claimPairing(
   sessionId: string,
   payload: PairingQRPayload,
@@ -125,6 +134,30 @@ export async function connectPairedDevice(
   await requireCurrentConnection(isCurrent);
   await registerIdentity(sessionId, identity);
   await requireCurrentConnection(isCurrent);
+  const relayDescriptorTask = issueAgentRelayDescriptor(
+    sessionId,
+    pairingId,
+    identity
+  )
+    .then(async (descriptor) => {
+      if (!isCurrent() || typeof deviceLink.configureRelay !== "function") {
+        return null;
+      }
+      await deviceLink.configureRelay(
+        descriptor.relayDialEndpoint,
+        JSON.stringify({
+          authority_id: [descriptor.authorityId],
+          channel: ["agent"],
+          target: ["device-gateway"]
+        }),
+        JSON.stringify({
+          Authorization: [`Bearer ${descriptor.token}`]
+        }),
+        RELAY_STREAM_SUBPROTOCOL
+      );
+      return isCurrent() ? descriptor : null;
+    })
+    .catch(() => null);
   try {
     let prepared = await deviceLink.prepareLink("[]", 10_000);
     let local = parseDeviceLinkDescription(prepared.descriptionJSON);
@@ -189,6 +222,10 @@ export async function connectPairedDevice(
       );
       await requireCurrentConnection(isCurrent);
     }
+    if (await relayDescriptorTask) {
+      await requireCurrentConnection(isCurrent);
+      return "private_network";
+    }
     throw new Error("device-link attempt expired");
   } catch (error) {
     if (isCurrent()) {
@@ -196,6 +233,57 @@ export async function connectPairedDevice(
     }
     throw error;
   }
+}
+
+export async function issueAgentRelayDescriptor(
+  sessionId: string,
+  pairingId: string,
+  identity?: DeviceIdentity
+): Promise<AgentRelayDescriptor> {
+  const currentIdentity =
+    identity ?? (await mobileSecurity.getOrCreateIdentity());
+  const signature = await mobileSecurity.sign(
+    deviceLinkProof("relay", pairingId, "", "")
+  );
+  const response = await controlPlaneRequest<{
+    descriptor?: AgentRelayDescriptor;
+    relayDialEndpoint?: string;
+    authorityId?: string;
+    token?: string;
+    tokenExpiresAt?: string;
+  }>(
+    sessionId,
+    `/device-pairings/${encodeURIComponent(pairingId)}/agent-relay-descriptor`,
+    {
+      body: JSON.stringify({
+        deviceId: currentIdentity.deviceId,
+        identitySignature: signature,
+        pairingId
+      }),
+      method: "POST"
+    }
+  );
+  const descriptor = response.descriptor ?? response;
+  if (
+    !descriptor ||
+    typeof descriptor !== "object" ||
+    typeof descriptor.authorityId !== "string" ||
+    descriptor.authorityId.trim() === "" ||
+    typeof descriptor.relayDialEndpoint !== "string" ||
+    !/^wss?:\/\/[^\s/]+/i.test(descriptor.relayDialEndpoint.trim()) ||
+    typeof descriptor.token !== "string" ||
+    descriptor.token.trim() === "" ||
+    typeof descriptor.tokenExpiresAt !== "string" ||
+    Number.isNaN(Date.parse(descriptor.tokenExpiresAt))
+  ) {
+    throw new Error("control-plane Relay descriptor is incomplete");
+  }
+  return {
+    authorityId: descriptor.authorityId.trim(),
+    relayDialEndpoint: descriptor.relayDialEndpoint.trim(),
+    token: descriptor.token.trim(),
+    tokenExpiresAt: descriptor.tokenExpiresAt
+  };
 }
 
 function normalizeDeviceLinkPathScope(scope: string): DeviceLinkPathScope {

--- a/apps/mobile/src/services/pairingProtocol.ts
+++ b/apps/mobile/src/services/pairingProtocol.ts
@@ -31,7 +31,7 @@ export function pairingClaimProof(challengeID: string, secret: string): string {
 }
 
 export function deviceLinkProof(
-  action: "create" | "get" | "update",
+  action: "create" | "get" | "relay" | "update",
   pairingID: string,
   attemptID: string,
   fingerprint: string

--- a/docs/specs/2026-07-23-mobile-agentgui-device-link-design.md
+++ b/docs/specs/2026-07-23-mobile-agentgui-device-link-design.md
@@ -558,11 +558,24 @@ allowlist 和 Android fetch adapter，并直接复用生成的
 `@tutti-os/client-tuttid-ts`；workspace、Agent Target catalog、Session
 list/get/create/send/cancel/Interaction 均沿用现有 HTTP contract。owner host 会在
 caller 获得 response-only STUN endpoints 并二次发布 ICE 后再认领 attempt，避免
-连接旧 fingerprint。Relay 尚未实现。direct lane 的 `agent_live` event stream
-已经接入：delta、Turn、Interaction 和 session audit 通过 framed live protocol
-进入 Mobile；canonical-only 更新由 Personal 的 `mobileremote` adapter 转为
-scoped discontinuity，再触发权威 snapshot reconcile。Session/Message poller
-仅在 event stream 未就绪或断开时作为降级路径。
+连接旧 fingerprint。
+
+Relay Agent lane 已接入同一套应用帧协议：Desktop `mobileremote` 只在用户打开
+移动端连接开关后获取 Relay owner demand，按 Device Authority 完成 identity
+enrollment、owner token 和 lease renewal；Relay stream prelude 校验 authority、
+user、target、channel 及 paired-device scope 后复用现有 Agent HTTP/live handler。
+Mobile 在直连准备阶段并行请求短期 Relay descriptor，直连优先，直连无法建立时由
+Android/iOS native adapter 使用相同 framed HTTP/live 协议拨号 Relay。因此 UI、生成
+客户端和 Agent DTO 不变。pairing 的 active 快照仍由现有控制面轮询刷新，Relay stream
+在本地快照中找不到 pairing 时 fail closed；快照刷新间隔是当前 2 秒轮询周期。
+
+这里依赖的 Relay descriptor、Device Authority 和 `tsh-tunnel-relay` Agent channel
+是跨仓库的增量契约；服务端部署状态不在 Tutti 仓库内，须以对应 tsh-server/relay
+变更合入和线上配置为准。direct lane 的 `agent_live` event stream 已接入：delta、
+Turn、Interaction 和 session audit 通过 framed live protocol 进入 Mobile；
+canonical-only 更新由 Personal 的 `mobileremote` adapter 转为 scoped discontinuity，
+再触发权威 snapshot reconcile。Session/Message poller 仅在 event stream 未就绪或
+断开时作为降级路径。
 
 ### M4 — Mobile App shell（Android 首发）
 

--- a/packages/device-link/README.md
+++ b/packages/device-link/README.md
@@ -153,6 +153,15 @@ failures: gomobile cannot preserve final bytes returned together with `io.EOF`,
 and the generated pointer-bearing result may abort the Android process before
 Java receives it.
 
+`mobile.DialRelay` is the corresponding gomobile-safe byte-stream entry point for
+an already-authorized Relay caller. It accepts the endpoint, query values,
+headers, and WebSocket subprotocol as JSON `map[string][]string` values, then
+returns the same `Stream` abstraction used by the Agent framing adapter. The
+mobile package does not issue credentials, select a target, or decide when to
+fall back; those policies remain in the Mobile pairing service and native
+bridge. Relay streams must be closed by the caller after each HTTP request or
+when the live subscription ends.
+
 Account identity signatures, DeviceLink attempts, pairing scope, Agent HTTP
 framing, and foreground/background policy remain in the Android and tuttid
 product adapters. The mobile facade never accepts account cookies or Agent

--- a/packages/device-link/mobile/link.go
+++ b/packages/device-link/mobile/link.go
@@ -6,10 +6,14 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
+	"net/url"
+	"strings"
 	"sync"
 	"time"
 
 	authenticated "github.com/tutti-os/tutti/packages/device-link/authenticated"
+	"github.com/tutti-os/tutti/packages/device-link/relaytransport"
 )
 
 const (
@@ -53,6 +57,40 @@ func NewLoopbackLink() (*Link, error) {
 		return nil, err
 	}
 	return &Link{participant: participant}, nil
+}
+
+// DialRelay opens one product-configured Relay byte stream. The mobile
+// binding keeps the Relay endpoint, query, headers, and subprotocol opaque;
+// account, pairing, and target authorization remain owned by the caller.
+// queryJSON and headersJSON encode map[string][]string values so the API stays
+// safe for gomobile bindings.
+func DialRelay(
+	endpoint string,
+	queryJSON string,
+	headersJSON string,
+	subprotocol string,
+	timeoutMillis int64,
+) (*Stream, error) {
+	query, err := decodeRelayValues(queryJSON, "query")
+	if err != nil {
+		return nil, err
+	}
+	headers, err := decodeRelayValues(headersJSON, "headers")
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), linkTimeout(timeoutMillis))
+	defer cancel()
+	conn, err := relaytransport.Dial(ctx, relaytransport.DialRequest{
+		Endpoint:    endpoint,
+		Query:       query,
+		Header:      http.Header(headers),
+		Subprotocol: subprotocol,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &Stream{conn: conn}, nil
 }
 
 func (l *Link) LocalDescription(timeoutMillis int64) (string, error) {
@@ -217,4 +255,23 @@ func linkTimeout(timeoutMillis int64) time.Duration {
 		return defaultLinkTimeout
 	}
 	return time.Duration(timeoutMillis) * time.Millisecond
+}
+
+func decodeRelayValues(raw, name string) (url.Values, error) {
+	if strings.TrimSpace(raw) == "" {
+		return make(url.Values), nil
+	}
+	var values map[string][]string
+	if err := json.Unmarshal([]byte(raw), &values); err != nil {
+		return nil, fmt.Errorf("decode relay %s: %w", name, err)
+	}
+	result := make(url.Values, len(values))
+	for key, entries := range values {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return nil, fmt.Errorf("relay %s contains an empty key", name)
+		}
+		result[key] = append([]string(nil), entries...)
+	}
+	return result, nil
 }

--- a/packages/device-link/mobile/link_test.go
+++ b/packages/device-link/mobile/link_test.go
@@ -3,7 +3,12 @@ package mobile
 import (
 	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"github.com/gorilla/websocket"
 )
 
 func TestStreamReadPreservesFinalBytesReturnedWithEOF(t *testing.T) {
@@ -110,6 +115,87 @@ func TestProtocolEpochMatchesApplicationPrelude(t *testing.T) {
 	if ProtocolEpoch() != ApplicationProtocolEpoch {
 		t.Fatalf("ProtocolEpoch() = %d, want %d", ProtocolEpoch(), ApplicationProtocolEpoch)
 	}
+}
+
+func TestDialRelayOpensConfiguredByteStream(t *testing.T) {
+	t.Parallel()
+	upgrader := websocket.Upgrader{
+		CheckOrigin:  func(*http.Request) bool { return true },
+		Subprotocols: []string{"relay.test.v1"},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("authority_id") != "authority-1" {
+			http.Error(w, "authority missing", http.StatusBadRequest)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer target-token" {
+			http.Error(w, "authorization missing", http.StatusUnauthorized)
+			return
+		}
+		connection, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer connection.Close()
+		messageType, payload, err := connection.ReadMessage()
+		if err != nil {
+			return
+		}
+		_ = connection.WriteMessage(messageType, payload)
+	}))
+	defer server.Close()
+
+	endpoint := "ws" + strings.TrimPrefix(server.URL, "http")
+	stream, err := DialRelay(
+		endpoint,
+		`{"authority_id":["authority-1"]}`,
+		`{"Authorization":["Bearer target-token"]}`,
+		"relay.test.v1",
+		5_000,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stream.Close()
+	if err := stream.SetDeadline(5_000); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := stream.Write([]byte("relay-payload")); err != nil {
+		t.Fatal(err)
+	}
+	buffer := make([]byte, len("relay-payload"))
+	count := stream.ReadInto(buffer)
+	if count != len(buffer) || string(buffer[:count]) != "relay-payload" {
+		t.Fatalf("relay echo = %q (%d bytes)", buffer[:max(count, 0)], count)
+	}
+}
+
+func TestDialRelayRejectsMalformedValuesBeforeDial(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name    string
+		query   string
+		headers string
+		want    string
+	}{
+		{name: "query", query: "[", headers: "{}", want: "decode relay query"},
+		{name: "headers", query: "{}", headers: "[", want: "decode relay headers"},
+		{name: "empty key", query: `{" ":["value"]}`, headers: "{}", want: "empty key"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := DialRelay("ws://relay.invalid", test.query, test.headers, "relay.test.v1", 1)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("DialRelay() error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func max(left, right int) int {
+	if left > right {
+		return left
+	}
+	return right
 }
 
 type finalBytesConn struct {

--- a/services/tuttid/go.mod
+++ b/services/tuttid/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/tutti-os/tutti/packages/analytics/reporter-go v0.0.0
 	github.com/tutti-os/tutti/packages/appcli/core v0.0.0
 	github.com/tutti-os/tutti/packages/auth/bridge-go v0.0.0
+	github.com/tutti-os/tutti/packages/clients/device-authority-go v0.0.0
 	github.com/tutti-os/tutti/packages/commerce v0.0.0
 	github.com/tutti-os/tutti/packages/device-link v0.0.0
 	github.com/tutti-os/tutti/packages/desktop/update-admission v0.0.0
@@ -132,6 +133,8 @@ tool github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen
 replace github.com/tutti-os/tutti/packages/appcli/core => ../../packages/appcli/core
 
 replace github.com/tutti-os/tutti/packages/auth/bridge-go => ../../packages/auth/bridge-go
+
+replace github.com/tutti-os/tutti/packages/clients/device-authority-go => ../../packages/clients/device-authority-go
 
 replace github.com/tutti-os/tutti/packages/commerce => ../../packages/commerce
 

--- a/services/tuttid/service/mobileremote/relay_control_plane.go
+++ b/services/tuttid/service/mobileremote/relay_control_plane.go
@@ -1,0 +1,97 @@
+package mobileremote
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	deviceauthority "github.com/tutti-os/tutti/packages/clients/device-authority-go"
+)
+
+// NewDeviceAuthorityClient adapts the existing desktop account cookie and
+// mobile identity store to the shared Device Authority client. The returned
+// client never stores the cookie; every request resolves the current session.
+func NewDeviceAuthorityClient(
+	baseURL string,
+	account AccountSessionSource,
+	identities IdentityStore,
+) (*deviceauthority.Client, error) {
+	controlBase, apiPrefix, err := splitControlPlaneURL(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	if account == nil {
+		return nil, errors.New("mobile remote Device Authority account source is required")
+	}
+	if identities == nil {
+		return nil, errors.New("mobile remote Device Authority identity store is required")
+	}
+	return deviceauthority.NewClient(deviceauthority.Config{
+		BaseURL:    controlBase,
+		APIPrefix:  apiPrefix,
+		HTTPClient: &http.Client{Timeout: 15 * time.Second},
+		Identities: deviceAuthorityIdentitySource{store: identities},
+		PrepareRequest: func(req *http.Request, _ deviceauthority.RequestMetadata) error {
+			session, err := account.ReadSession()
+			if err != nil {
+				return err
+			}
+			if session == nil || strings.TrimSpace(session.Cookie) == "" {
+				return ErrAccountAuthenticationRequired
+			}
+			req.Header.Set("Cookie", strings.TrimSpace(session.Cookie))
+			return nil
+		},
+	})
+}
+
+type deviceAuthorityIdentitySource struct {
+	store IdentityStore
+}
+
+func (s deviceAuthorityIdentitySource) Identity(ctx context.Context, runtimeID string) (deviceauthority.SigningIdentity, error) {
+	if s.store == nil {
+		return deviceauthority.SigningIdentity{}, errors.New("mobile remote Device Authority identity store is unavailable")
+	}
+	identity, err := s.store.LoadOrCreate(ctx)
+	if err != nil {
+		return deviceauthority.SigningIdentity{}, err
+	}
+	if strings.TrimSpace(identity.DeviceID) != strings.TrimSpace(runtimeID) ||
+		len(identity.PrivateKey) != ed25519.PrivateKeySize || len(identity.PublicKey) != ed25519.PublicKeySize {
+		return deviceauthority.SigningIdentity{}, errors.New("mobile remote Device Authority identity is invalid")
+	}
+	privateKey := append(ed25519.PrivateKey(nil), identity.PrivateKey...)
+	if publicKey, ok := privateKey.Public().(ed25519.PublicKey); !ok || len(publicKey) != ed25519.PublicKeySize || !bytes.Equal(publicKey, identity.PublicKey) {
+		return deviceauthority.SigningIdentity{}, errors.New("mobile remote Device Authority identity public key is invalid")
+	}
+	return deviceauthority.SigningIdentity{
+		KeyID:  deviceauthority.GatewayIdentityKeyID(identity.PublicKey),
+		Signer: privateKey,
+	}, nil
+}
+
+func splitControlPlaneURL(raw string) (string, string, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		value = DefaultControlPlaneBaseURL
+	}
+	parsed, err := url.Parse(strings.TrimRight(value, "/"))
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", "", fmt.Errorf("mobile remote control-plane URL is invalid")
+	}
+	prefix := strings.TrimRight(parsed.EscapedPath(), "/")
+	if prefix == "" {
+		prefix = "/v1"
+	}
+	base := parsed.Scheme + "://" + parsed.Host
+	return base, prefix, nil
+}
+
+var _ deviceauthority.IdentitySource = deviceAuthorityIdentitySource{}

--- a/services/tuttid/service/mobileremote/relay_control_plane_test.go
+++ b/services/tuttid/service/mobileremote/relay_control_plane_test.go
@@ -1,0 +1,83 @@
+package mobileremote
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"testing"
+
+	mobileremotebiz "github.com/tutti-os/tutti/services/tuttid/biz/mobileremote"
+)
+
+func TestSplitControlPlaneURL(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name   string
+		raw    string
+		base   string
+		prefix string
+		valid  bool
+	}{
+		{
+			name:   "default",
+			raw:    "",
+			base:   "https://tutti.sh",
+			prefix: "/api/desktop/v1",
+			valid:  true,
+		},
+		{
+			name:   "explicit origin",
+			raw:    "https://control.example.test",
+			base:   "https://control.example.test",
+			prefix: "/v1",
+			valid:  true,
+		},
+		{
+			name:   "explicit api prefix",
+			raw:    "https://control.example.test/api/desktop/v1/",
+			base:   "https://control.example.test",
+			prefix: "/api/desktop/v1",
+			valid:  true,
+		},
+		{name: "query", raw: "https://control.example.test/v1?token=secret"},
+		{name: "userinfo", raw: "https://user:pass@control.example.test/v1"},
+		{name: "scheme", raw: "ftp://control.example.test/v1"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			base, prefix, err := splitControlPlaneURL(test.raw)
+			if !test.valid {
+				if err == nil {
+					t.Fatalf("splitControlPlaneURL(%q) unexpectedly succeeded", test.raw)
+				}
+				return
+			}
+			if err != nil || base != test.base || prefix != test.prefix {
+				t.Fatalf("splitControlPlaneURL(%q) = (%q, %q, %v), want (%q, %q)", test.raw, base, prefix, err, test.base, test.prefix)
+			}
+		})
+	}
+}
+
+func TestDeviceAuthorityIdentitySourceValidatesAndCopiesIdentity(t *testing.T) {
+	t.Parallel()
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := &stubIdentityStore{identity: mobileremotebiz.DeviceIdentity{
+		DeviceID: "runtime-1", PrivateKey: privateKey, PublicKey: publicKey,
+	}}
+	source := deviceAuthorityIdentitySource{store: store}
+	identity, err := source.Identity(context.Background(), "runtime-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if identity.KeyID == "" || !bytes.Equal(identity.Signer.Public().(ed25519.PublicKey), publicKey) {
+		t.Fatalf("identity = %#v, want matching public key and key id", identity)
+	}
+	identity.Signer.(ed25519.PrivateKey)[0] ^= 0xff
+	if privateKey[0] == identity.Signer.(ed25519.PrivateKey)[0] {
+		t.Fatal("identity source returned the store's private-key backing array")
+	}
+}

--- a/services/tuttid/service/mobileremote/relay_owner.go
+++ b/services/tuttid/service/mobileremote/relay_owner.go
@@ -1,0 +1,454 @@
+package mobileremote
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	deviceauthority "github.com/tutti-os/tutti/packages/clients/device-authority-go"
+	"github.com/tutti-os/tutti/packages/device-link/relaytransport"
+)
+
+const (
+	relayOwnerSubprotocol   = "tsh.relay.owner.v1"
+	deviceGatewayTarget     = "device-gateway"
+	relayStreamSubprotocol  = "tsh.relay.stream.v1"
+	maxRelayPreludeBytes    = 64 * 1024
+	defaultRelayLeaseRenew  = 30 * time.Second
+	defaultRelayLeaseWindow = 5 * time.Second
+	defaultRelayTokenTTL    = 10 * time.Minute
+)
+
+// NewRelayOwner creates the product adapter for the shared Relay owner host.
+// The host remains idle until StartRemoteHost acquires the mobile-remote
+// demand reference, so enabling the desktop feature is the only trigger for
+// control-plane polling and Relay credentials.
+func (s *Service) NewRelayOwner() (RelayOwnerHost, error) {
+	if s == nil || s.DeviceAuthority == nil {
+		return nil, errors.New("mobile remote device authority client is unavailable")
+	}
+	if strings.TrimSpace(s.RuntimeID) == "" {
+		return nil, errors.New("mobile remote Relay owner runtime id is required")
+	}
+	factory := &relayOwnerLifecycleFactory{service: s}
+	host, err := relaytransport.NewOwnerHost(relaytransport.OwnerHostConfig{
+		LifecycleFactory: factory,
+		Handler: relaytransport.StreamHandlerFunc(func(ctx context.Context, stream net.Conn) error {
+			return s.handleRelayStream(ctx, stream)
+		}),
+		StableSessionFor: 30 * time.Second,
+		PingInterval:     20 * time.Second,
+		PongTimeout:      60 * time.Second,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return host, nil
+}
+
+type relayOwnerLifecycleFactory struct {
+	service *Service
+	mu      sync.Mutex
+	nextID  uint64
+}
+
+func (f *relayOwnerLifecycleFactory) NewOwnerLifecycle() relaytransport.OwnerLifecycle {
+	f.mu.Lock()
+	f.nextID++
+	runID := f.nextID
+	f.mu.Unlock()
+	return &relayOwnerLifecycle{
+		runKey:  fmt.Sprintf("mobile-remote-owner-%d", runID),
+		service: f.service,
+	}
+}
+
+type relayOwnerLifecycle struct {
+	service *Service
+	runKey  string
+
+	mu               sync.Mutex
+	ownerUserID      string
+	authority        deviceauthority.DeviceAuthorityResult
+	identityEnrolled bool
+	token            deviceauthority.Token
+}
+
+func (l *relayOwnerLifecycle) Prepare(ctx context.Context) (relaytransport.OwnerSession, error) {
+	session := relaytransport.OwnerSession{Key: l.runKey, PingPayload: []byte("owner")}
+	ownerUserID, err := l.currentOwnerUserID()
+	if err != nil {
+		return session, err
+	}
+	runtimeID := strings.TrimSpace(l.service.RuntimeID)
+	l.mu.Lock()
+	if l.ownerUserID != ownerUserID {
+		l.ownerUserID = ownerUserID
+		l.authority = deviceauthority.DeviceAuthorityResult{}
+		l.identityEnrolled = false
+		l.token = deviceauthority.Token{}
+	}
+	l.mu.Unlock()
+
+	if err := l.ensureAuthority(ctx, ownerUserID, runtimeID); err != nil {
+		return session, err
+	}
+	if err := l.ensureIdentity(ctx, runtimeID); err != nil {
+		return session, err
+	}
+	if err := l.ensureToken(ctx, runtimeID); err != nil {
+		return session, err
+	}
+
+	l.mu.Lock()
+	authority := l.authority
+	token := l.token
+	l.mu.Unlock()
+	session.Dial = relaytransport.DialRequest{
+		Endpoint: strings.TrimSpace(authority.Relay.HostEndpoint),
+		Query: url.Values{
+			"authority_id": []string{strings.TrimSpace(authority.AuthorityID)},
+		},
+		Header: http.Header{
+			"Authorization": []string{"Bearer " + strings.TrimSpace(token.Value)},
+		},
+		Subprotocol: relayOwnerSubprotocol,
+	}
+	return session, nil
+}
+
+func (l *relayOwnerLifecycle) Activate(ctx context.Context, _ relaytransport.OwnerSession) (func(), error) {
+	l.mu.Lock()
+	authority := l.authority
+	ownerUserID := l.ownerUserID
+	l.mu.Unlock()
+	if strings.TrimSpace(authority.AuthorityID) == "" {
+		return nil, errors.New("mobile remote Relay authority is unavailable")
+	}
+	activationCtx, cancel := context.WithTimeout(ctx, defaultRelayLeaseWindow)
+	_, err := l.renewLease(activationCtx, authority, ownerUserID)
+	cancel()
+	if err != nil {
+		return nil, fmt.Errorf("activate mobile remote Relay lease: %w", err)
+	}
+	renewCtx, renewCancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		l.maintainLease(renewCtx, authority, ownerUserID)
+	}()
+	return func() {
+		renewCancel()
+		<-done
+	}, nil
+}
+
+func (l *relayOwnerLifecycle) SessionEnded(_ relaytransport.OwnerSession, err error) {
+	var dialErr *relaytransport.DialError
+	if !errors.As(err, &dialErr) {
+		return
+	}
+	if dialErr.HTTPStatusCode() != http.StatusUnauthorized && dialErr.HTTPStatusCode() != http.StatusForbidden {
+		return
+	}
+	l.mu.Lock()
+	l.token = deviceauthority.Token{}
+	l.mu.Unlock()
+}
+
+func (*relayOwnerLifecycle) Release(context.Context, relaytransport.OwnerSession) error {
+	return nil
+}
+
+func (l *relayOwnerLifecycle) currentOwnerUserID() (string, error) {
+	if l == nil || l.service == nil || l.service.Account == nil {
+		return "", ErrAccountAuthenticationRequired
+	}
+	session, err := l.service.Account.ReadSession()
+	if err != nil {
+		return "", err
+	}
+	if session == nil || strings.TrimSpace(session.Cookie) == "" || strings.TrimSpace(session.UserID) == "" {
+		return "", ErrAccountAuthenticationRequired
+	}
+	return strings.TrimSpace(session.UserID), nil
+}
+
+func (l *relayOwnerLifecycle) ensureAuthority(ctx context.Context, ownerUserID, runtimeID string) error {
+	l.mu.Lock()
+	ready := strings.TrimSpace(l.authority.AuthorityID) != ""
+	l.mu.Unlock()
+	if ready {
+		return nil
+	}
+	authority, err := l.service.DeviceAuthority.EnsureDeviceAuthority(ctx, deviceauthority.EnsureDeviceAuthorityRequest{
+		OwnerUserID: ownerUserID,
+		RuntimeID:   runtimeID,
+	})
+	if err != nil {
+		return fmt.Errorf("ensure mobile remote Relay authority: %w", err)
+	}
+	if err := validateRelayAuthority(authority, ownerUserID, runtimeID, l.service.now()); err != nil {
+		return err
+	}
+	l.mu.Lock()
+	l.authority = authority
+	l.mu.Unlock()
+	return nil
+}
+
+func (l *relayOwnerLifecycle) ensureIdentity(ctx context.Context, runtimeID string) error {
+	l.mu.Lock()
+	if l.identityEnrolled {
+		l.mu.Unlock()
+		return nil
+	}
+	authority := l.authority
+	l.mu.Unlock()
+	identity, err := l.service.DeviceAuthority.RegisterDeviceGatewayIdentity(ctx, deviceauthority.RegisterDeviceGatewayIdentityRequest{
+		AuthorityID:     authority.AuthorityID,
+		RuntimeID:       runtimeID,
+		EnrollmentProof: authority.GatewayEnrollment.Proof,
+	})
+	if err != nil {
+		// Enrollment proofs are single-use. A lost response must force a fresh
+		// authority projection instead of replaying the consumed proof.
+		l.mu.Lock()
+		l.authority = deviceauthority.DeviceAuthorityResult{}
+		l.identityEnrolled = false
+		l.token = deviceauthority.Token{}
+		l.mu.Unlock()
+		return fmt.Errorf("register mobile remote Relay identity: %w", err)
+	}
+	if identity.AuthorityID != authority.AuthorityID || identity.RuntimeID != runtimeID || strings.TrimSpace(identity.KeyID) == "" {
+		return errors.New("register mobile remote Relay identity returned an invalid binding")
+	}
+	l.mu.Lock()
+	l.identityEnrolled = true
+	l.authority.GatewayEnrollment = deviceauthority.GatewayEnrollment{}
+	l.mu.Unlock()
+	return nil
+}
+
+func (l *relayOwnerLifecycle) ensureToken(ctx context.Context, runtimeID string) error {
+	now := l.service.now()
+	l.mu.Lock()
+	authority := l.authority
+	identityEnrolled := l.identityEnrolled
+	token := l.token
+	l.mu.Unlock()
+	if !identityEnrolled {
+		return errors.New("mobile remote Relay identity is not enrolled")
+	}
+	if strings.TrimSpace(token.Value) != "" {
+		if expiresAt, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(token.ExpiresAt)); err == nil && expiresAt.After(now.Add(2*time.Minute)) {
+			return nil
+		}
+	}
+	issued, err := l.service.DeviceAuthority.IssueDeviceGatewayOwnerTunnelToken(ctx, deviceauthority.IssueDeviceGatewayOwnerTunnelTokenRequest{
+		AuthorityID:      authority.AuthorityID,
+		RuntimeID:        runtimeID,
+		SupportedTargets: []string{deviceGatewayTarget},
+		TTL:              defaultRelayTokenTTL,
+	})
+	if err != nil {
+		return fmt.Errorf("issue mobile remote Relay owner token: %w", err)
+	}
+	if issued.AuthorityID != authority.AuthorityID || strings.TrimSpace(issued.Token.Value) == "" {
+		return errors.New("issue mobile remote Relay owner token returned an invalid binding")
+	}
+	if _, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(issued.Token.ExpiresAt)); err != nil {
+		return fmt.Errorf("parse mobile remote Relay owner token expiry: %w", err)
+	}
+	l.mu.Lock()
+	l.token = issued.Token
+	l.mu.Unlock()
+	return nil
+}
+
+func (l *relayOwnerLifecycle) renewLease(
+	ctx context.Context,
+	authority deviceauthority.DeviceAuthorityResult,
+	ownerUserID string,
+) (deviceauthority.RenewDeviceAuthorityLeaseResult, error) {
+	ttl := authority.Lease.TTLSeconds
+	if ttl <= 0 {
+		ttl = int(defaultRelayLeaseRenew.Seconds())
+	}
+	lease, err := l.service.DeviceAuthority.RenewDeviceAuthorityLease(ctx, deviceauthority.RenewDeviceAuthorityLeaseRequest{
+		AuthorityID:       authority.AuthorityID,
+		OwnerUserID:       ownerUserID,
+		RuntimeID:         strings.TrimSpace(l.service.RuntimeID),
+		TTLSeconds:        ttl,
+		OwnerTunnelStatus: "connected",
+	})
+	if err != nil {
+		return deviceauthority.RenewDeviceAuthorityLeaseResult{}, err
+	}
+	if lease.AuthorityID != authority.AuthorityID || strings.TrimSpace(lease.State) != "online" {
+		return deviceauthority.RenewDeviceAuthorityLeaseResult{}, errors.New("mobile remote Relay lease is not online")
+	}
+	return lease, nil
+}
+
+func (l *relayOwnerLifecycle) maintainLease(ctx context.Context, authority deviceauthority.DeviceAuthorityResult, ownerUserID string) {
+	intervalSeconds := authority.Lease.RenewIntervalSeconds
+	if intervalSeconds <= 0 && authority.Lease.TTLSeconds > 0 {
+		intervalSeconds = authority.Lease.TTLSeconds / 2
+		if intervalSeconds <= 0 {
+			intervalSeconds = 1
+		}
+	}
+	interval := time.Duration(intervalSeconds) * time.Second
+	if interval <= 0 {
+		interval = defaultRelayLeaseRenew
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if _, err := l.renewLease(ctx, authority, ownerUserID); err != nil && !errors.Is(err, context.Canceled) {
+				// The owner tunnel remains transport-owned. Clear the cached token so
+				// the next reconnect cannot reuse credentials issued before a failed
+				// lease renewal.
+				l.mu.Lock()
+				l.token = deviceauthority.Token{}
+				l.mu.Unlock()
+			}
+		}
+	}
+}
+
+func validateRelayAuthority(authority deviceauthority.DeviceAuthorityResult, ownerUserID, runtimeID string, now time.Time) error {
+	if strings.TrimSpace(authority.AuthorityID) == "" || strings.TrimSpace(authority.OwnerUserID) != ownerUserID || strings.TrimSpace(authority.RuntimeID) != runtimeID {
+		return errors.New("mobile remote Relay authority returned an invalid owner binding")
+	}
+	if err := validateRelayEndpoint(authority.Relay.HostEndpoint); err != nil {
+		return fmt.Errorf("mobile remote Relay owner endpoint is invalid: %w", err)
+	}
+	if strings.TrimSpace(authority.GatewayEnrollment.Proof) == "" {
+		return errors.New("mobile remote Relay enrollment proof is missing")
+	}
+	expiresAt, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(authority.GatewayEnrollment.ExpiresAt))
+	if err != nil || !expiresAt.After(now) {
+		return errors.New("mobile remote Relay enrollment proof is expired")
+	}
+	return nil
+}
+
+func validateRelayEndpoint(value string) error {
+	parsed, err := url.Parse(strings.TrimSpace(value))
+	if err != nil {
+		return err
+	}
+	if parsed.Scheme != "ws" && parsed.Scheme != "wss" {
+		return fmt.Errorf("scheme %q is not ws or wss", parsed.Scheme)
+	}
+	if strings.TrimSpace(parsed.Host) == "" || parsed.User != nil {
+		return errors.New("relay endpoint host or userinfo is invalid")
+	}
+	return nil
+}
+
+type relayStreamPrelude struct {
+	Type            string `json:"type"`
+	ProtocolVersion string `json:"protocol_version"`
+	StreamID        string `json:"stream_id"`
+	AuthorityID     string `json:"authority_id"`
+	UserID          string `json:"user_id"`
+	Target          string `json:"target"`
+	Channel         string `json:"channel"`
+	RequestID       string `json:"request_id"`
+	TokenClaims     struct {
+		Scope struct {
+			Kind      string `json:"kind"`
+			PairingID string `json:"pairing_id"`
+		} `json:"scope"`
+	} `json:"token_claims"`
+}
+
+func readRelayStreamPrelude(reader io.Reader) (relayStreamPrelude, error) {
+	var header [4]byte
+	if _, err := io.ReadFull(reader, header[:]); err != nil {
+		return relayStreamPrelude{}, fmt.Errorf("read Relay stream prelude length: %w", err)
+	}
+	length := binary.BigEndian.Uint32(header[:])
+	if length == 0 || length > maxRelayPreludeBytes {
+		return relayStreamPrelude{}, fmt.Errorf("relay stream prelude size %d is invalid", length)
+	}
+	payload := make([]byte, length)
+	if _, err := io.ReadFull(reader, payload); err != nil {
+		return relayStreamPrelude{}, fmt.Errorf("read relay stream prelude: %w", err)
+	}
+	var prelude relayStreamPrelude
+	if err := json.Unmarshal(payload, &prelude); err != nil {
+		return relayStreamPrelude{}, fmt.Errorf("decode relay stream prelude: %w", err)
+	}
+	return prelude, nil
+}
+
+func (s *Service) handleRelayStream(ctx context.Context, stream net.Conn) error {
+	if stream == nil {
+		return errors.New("mobile remote Relay stream is missing")
+	}
+	prelude, err := readRelayStreamPrelude(stream)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(prelude.Type) != "open_stream" ||
+		strings.TrimSpace(prelude.ProtocolVersion) != relayStreamSubprotocol ||
+		strings.TrimSpace(prelude.AuthorityID) == "" ||
+		strings.TrimSpace(prelude.Target) != deviceGatewayTarget ||
+		strings.TrimSpace(prelude.Channel) != "agent" ||
+		strings.TrimSpace(prelude.StreamID) == "" || strings.TrimSpace(prelude.RequestID) == "" {
+		return errors.New("mobile remote Relay stream prelude is invalid")
+	}
+	pairingID := strings.TrimSpace(prelude.TokenClaims.Scope.PairingID)
+	if strings.TrimSpace(prelude.TokenClaims.Scope.Kind) != "paired_device" || pairingID == "" {
+		return errors.New("mobile remote Relay stream scope is invalid")
+	}
+	if err := s.authorizeRelayPairing(ctx, prelude.UserID, pairingID); err != nil {
+		return err
+	}
+	s.remoteHost.mu.Lock()
+	handler := s.remoteHost.handler
+	liveEvents := s.remoteHost.liveEvents
+	s.remoteHost.mu.Unlock()
+	if handler == nil {
+		return errors.New("mobile remote handler is unavailable")
+	}
+	return serveRemoteStreamWithAgentLive(ctx, stream, handler, pairingID, liveEvents)
+}
+
+func (s *Service) authorizeRelayPairing(_ context.Context, targetUserID, pairingID string) error {
+	session, err := s.accountSession()
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(session.UserID) != strings.TrimSpace(targetUserID) {
+		return errors.New("mobile remote Relay user scope is invalid")
+	}
+	s.remoteHost.mu.Lock()
+	registeredDeviceID := s.remoteHost.registeredDevice.UserDeviceID
+	_, active := s.remoteHost.activePairings[pairingID]
+	s.remoteHost.mu.Unlock()
+	if active && registeredDeviceID != "" {
+		return nil
+	}
+	return errors.New("mobile remote Relay pairing is no longer active")
+}
+
+var _ relaytransport.OwnerLifecycle = (*relayOwnerLifecycle)(nil)
+var _ DeviceAuthorityClient = (*deviceauthority.Client)(nil)

--- a/services/tuttid/service/mobileremote/relay_owner_test.go
+++ b/services/tuttid/service/mobileremote/relay_owner_test.go
@@ -1,0 +1,397 @@
+package mobileremote
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	authbridge "github.com/tutti-os/tutti/packages/auth/bridge-go"
+	deviceauthority "github.com/tutti-os/tutti/packages/clients/device-authority-go"
+	mobileremotebiz "github.com/tutti-os/tutti/services/tuttid/biz/mobileremote"
+)
+
+func TestRelayOwnerLifecyclePreparesAndActivatesBoundSession(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	account := &relayOwnerTestAccount{session: &authbridge.Session{
+		UserID: "user-1",
+		Cookie: "session_id=session-1",
+	}}
+	controlPlane := &relayOwnerTestAuthority{
+		authority: deviceauthority.DeviceAuthorityResult{
+			AuthorityID: "authority-1",
+			OwnerUserID: "user-1",
+			RuntimeID:   "runtime-1",
+			Relay: deviceauthority.RelayDescriptor{
+				HostEndpoint: "wss://relay.example.test/owner",
+				DialEndpoint: "wss://relay.example.test/dial",
+			},
+			Lease: deviceauthority.LeasePolicy{
+				TTLSeconds:           120,
+				RenewIntervalSeconds: 120,
+			},
+			GatewayEnrollment: deviceauthority.GatewayEnrollment{
+				Proof:     "enrollment-proof",
+				ExpiresAt: now.Add(time.Minute).Format(time.RFC3339Nano),
+			},
+		},
+		token: deviceauthority.Token{
+			Value:     "owner-token",
+			ExpiresAt: now.Add(9 * time.Minute).Format(time.RFC3339Nano),
+		},
+		lease: deviceauthority.RenewDeviceAuthorityLeaseResult{
+			AuthorityID: "authority-1",
+			State:       "online",
+			RenewedAt:   now.Format(time.RFC3339Nano),
+			ExpiresAt:   now.Add(2 * time.Minute).Format(time.RFC3339Nano),
+		},
+	}
+	service := &Service{
+		Account:         account,
+		ControlPlane:    &relayOwnerTestControlPlane{},
+		DeviceAuthority: controlPlane,
+		RuntimeID:       "runtime-1",
+	}
+	lifecycle := (&relayOwnerLifecycleFactory{service: service}).NewOwnerLifecycle()
+	session, err := lifecycle.Prepare(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.Key == "" || session.Dial.Endpoint != "wss://relay.example.test/owner" ||
+		session.Dial.Query.Get("authority_id") != "authority-1" ||
+		session.Dial.Header.Get("Authorization") != "Bearer owner-token" ||
+		session.Dial.Subprotocol != relayOwnerSubprotocol {
+		t.Fatalf("owner session = %#v, want bound Relay dial material", session)
+	}
+	if controlPlane.ensureCalls != 1 || controlPlane.registerCalls != 1 || controlPlane.tokenCalls != 1 {
+		t.Fatalf("authority calls = ensure=%d register=%d token=%d, want one each", controlPlane.ensureCalls, controlPlane.registerCalls, controlPlane.tokenCalls)
+	}
+	deactivate, err := lifecycle.Activate(context.Background(), session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if controlPlane.renewCalls != 1 {
+		t.Fatalf("lease renew calls = %d, want activation renewal", controlPlane.renewCalls)
+	}
+	deactivate()
+}
+
+func TestRelayOwnerLifecycleReusesAuthorityAndTokenAcrossReconnects(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	controlPlane := newRelayOwnerTestAuthority(now)
+	service := &Service{
+		Account:         &relayOwnerTestAccount{session: &authbridge.Session{UserID: "user-1", Cookie: "cookie"}},
+		ControlPlane:    &relayOwnerTestControlPlane{},
+		DeviceAuthority: controlPlane,
+		RuntimeID:       "runtime-1",
+	}
+	lifecycle := (&relayOwnerLifecycleFactory{service: service}).NewOwnerLifecycle()
+	if _, err := lifecycle.Prepare(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := lifecycle.Prepare(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if controlPlane.ensureCalls != 1 || controlPlane.registerCalls != 1 || controlPlane.tokenCalls != 1 {
+		t.Fatalf("reconnect calls = ensure=%d register=%d token=%d, want one each", controlPlane.ensureCalls, controlPlane.registerCalls, controlPlane.tokenCalls)
+	}
+}
+
+func TestRemoteHostOwnsRelayDemandOnlyWhileRunning(t *testing.T) {
+	t.Parallel()
+	demand := &relayOwnerDemandSpy{acquired: make(chan struct{}, 1)}
+	service := &Service{RelayOwner: demand}
+	service.StartRemoteHost(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	select {
+	case <-demand.acquired:
+	case <-time.After(time.Second):
+		t.Fatal("remote host did not acquire Relay demand")
+	}
+	service.StartRemoteHost(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	if got := demand.acquireCount(); got != 1 {
+		t.Fatalf("Relay acquire count after idempotent start = %d, want 1", got)
+	}
+	service.StopRemoteHost()
+	if got := demand.releaseCount(); got != 1 {
+		t.Fatalf("Relay release count after stop = %d, want 1", got)
+	}
+}
+
+func TestHandleRelayStreamValidatesPreludeAndUsesExistingAgentFraming(t *testing.T) {
+	t.Parallel()
+	service := &Service{
+		Account:      &relayOwnerTestAccount{session: &authbridge.Session{UserID: "user-1", Cookie: "cookie"}},
+		ControlPlane: &relayOwnerTestControlPlane{},
+		RuntimeID:    "runtime-1",
+	}
+	service.remoteHost.handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/workspaces" {
+			t.Errorf("handler path = %q, want /v1/workspaces", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+	service.remoteHost.registeredDevice = RegisteredDevice{UserDeviceID: "target-device"}
+	service.remoteHost.activePairings = map[string]struct{}{"pairing-1": {}}
+
+	owner, caller := net.Pipe()
+	defer caller.Close()
+	done := make(chan error, 1)
+	go func() {
+		done <- service.handleRelayStream(context.Background(), owner)
+	}()
+	writeRelayTestPrelude(t, caller)
+	if err := writeRemoteFrame(caller, RemoteRequest{
+		ProtocolEpoch: ApplicationProtocolEpoch,
+		Service:       AgentHTTPService,
+		RequestID:     "request-1",
+		Method:        http.MethodGet,
+		Path:          "/v1/workspaces",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var response RemoteResponse
+	if err := readRemoteFrame(caller, maxRemoteResponseFrameBytes, &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Status != http.StatusNoContent || response.RequestID != "request-1" {
+		t.Fatalf("Relay Agent response = %#v, want 204/request-1", response)
+	}
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeRelayTestPrelude(t *testing.T, writer io.Writer) {
+	writeRelayTestPreludeWith(t, writer, func(*relayStreamPrelude) {})
+}
+
+func writeRelayTestPreludeWith(t *testing.T, writer io.Writer, mutate func(*relayStreamPrelude)) {
+	t.Helper()
+	prelude := relayStreamPrelude{
+		Type:            "open_stream",
+		ProtocolVersion: relayStreamSubprotocol,
+		StreamID:        "stream-1",
+		AuthorityID:     "authority-1",
+		UserID:          "user-1",
+		Target:          deviceGatewayTarget,
+		Channel:         "agent",
+		RequestID:       "request-1",
+	}
+	prelude.TokenClaims.Scope.Kind = "paired_device"
+	prelude.TokenClaims.Scope.PairingID = "pairing-1"
+	mutate(&prelude)
+	payload, err := json.Marshal(prelude)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var header [4]byte
+	binary.BigEndian.PutUint32(header[:], uint32(len(payload)))
+	if _, err := writer.Write(header[:]); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writer.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestHandleRelayStreamRejectsInvalidPreludeScope(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name   string
+		mutate func(*relayStreamPrelude)
+		want   string
+	}{
+		{
+			name: "empty authority",
+			mutate: func(prelude *relayStreamPrelude) {
+				prelude.AuthorityID = " "
+			},
+			want: "prelude is invalid",
+		},
+		{
+			name: "wrong scope kind",
+			mutate: func(prelude *relayStreamPrelude) {
+				prelude.TokenClaims.Scope.Kind = "room"
+			},
+			want: "scope is invalid",
+		},
+		{
+			name: "wrong user",
+			mutate: func(prelude *relayStreamPrelude) {
+				prelude.UserID = "user-2"
+			},
+			want: "user scope is invalid",
+		},
+		{
+			name: "revoked pairing",
+			mutate: func(prelude *relayStreamPrelude) {
+				prelude.TokenClaims.Scope.PairingID = "pairing-revoked"
+			},
+			want: "pairing is no longer active",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			service := &Service{
+				Account:      &relayOwnerTestAccount{session: &authbridge.Session{UserID: "user-1", Cookie: "cookie"}},
+				ControlPlane: &relayOwnerTestControlPlane{},
+				RuntimeID:    "runtime-1",
+			}
+			service.remoteHost.registeredDevice = RegisteredDevice{UserDeviceID: "target-device"}
+			service.remoteHost.activePairings = map[string]struct{}{"pairing-1": {}}
+
+			owner, caller := net.Pipe()
+			done := make(chan error, 1)
+			go func() {
+				done <- service.handleRelayStream(context.Background(), owner)
+			}()
+			writeRelayTestPreludeWith(t, caller, test.mutate)
+			_ = caller.Close()
+			defer owner.Close()
+			if err := <-done; err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("handleRelayStream() error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func newRelayOwnerTestAuthority(now time.Time) *relayOwnerTestAuthority {
+	return &relayOwnerTestAuthority{
+		authority: deviceauthority.DeviceAuthorityResult{
+			AuthorityID: "authority-1",
+			OwnerUserID: "user-1",
+			RuntimeID:   "runtime-1",
+			Relay:       deviceauthority.RelayDescriptor{HostEndpoint: "wss://relay.example.test/owner"},
+			Lease:       deviceauthority.LeasePolicy{TTLSeconds: 60, RenewIntervalSeconds: 60},
+			GatewayEnrollment: deviceauthority.GatewayEnrollment{
+				Proof: "proof", ExpiresAt: now.Add(time.Minute).Format(time.RFC3339Nano),
+			},
+		},
+		token: deviceauthority.Token{
+			Value: "token", ExpiresAt: now.Add(9 * time.Minute).Format(time.RFC3339Nano),
+		},
+		lease: deviceauthority.RenewDeviceAuthorityLeaseResult{
+			AuthorityID: "authority-1", State: "online",
+			RenewedAt: now.Format(time.RFC3339Nano), ExpiresAt: now.Add(time.Minute).Format(time.RFC3339Nano),
+		},
+	}
+}
+
+type relayOwnerTestAccount struct {
+	session *authbridge.Session
+}
+
+func (a *relayOwnerTestAccount) ReadSession() (*authbridge.Session, error) {
+	return a.session, nil
+}
+
+type relayOwnerTestAuthority struct {
+	mu sync.Mutex
+
+	authority     deviceauthority.DeviceAuthorityResult
+	token         deviceauthority.Token
+	lease         deviceauthority.RenewDeviceAuthorityLeaseResult
+	ensureCalls   int
+	registerCalls int
+	tokenCalls    int
+	renewCalls    int
+}
+
+func (c *relayOwnerTestAuthority) EnsureDeviceAuthority(context.Context, deviceauthority.EnsureDeviceAuthorityRequest) (deviceauthority.DeviceAuthorityResult, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.ensureCalls++
+	return c.authority, nil
+}
+
+func (c *relayOwnerTestAuthority) RegisterDeviceGatewayIdentity(context.Context, deviceauthority.RegisterDeviceGatewayIdentityRequest) (deviceauthority.DeviceGatewayIdentityResult, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.registerCalls++
+	return deviceauthority.DeviceGatewayIdentityResult{AuthorityID: "authority-1", RuntimeID: "runtime-1", KeyID: "key-1"}, nil
+}
+
+func (c *relayOwnerTestAuthority) IssueDeviceGatewayOwnerTunnelToken(context.Context, deviceauthority.IssueDeviceGatewayOwnerTunnelTokenRequest) (deviceauthority.DeviceGatewayOwnerTunnelTokenResult, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.tokenCalls++
+	return deviceauthority.DeviceGatewayOwnerTunnelTokenResult{AuthorityID: "authority-1", Token: c.token}, nil
+}
+
+func (c *relayOwnerTestAuthority) RenewDeviceAuthorityLease(context.Context, deviceauthority.RenewDeviceAuthorityLeaseRequest) (deviceauthority.RenewDeviceAuthorityLeaseResult, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.renewCalls++
+	return c.lease, nil
+}
+
+type relayOwnerTestControlPlane struct{}
+
+func (*relayOwnerTestControlPlane) RegisterDevice(context.Context, string, RegisterDeviceInput) (RegisteredDevice, error) {
+	return RegisteredDevice{}, nil
+}
+func (*relayOwnerTestControlPlane) CreateChallenge(context.Context, string, string) (CreateChallengeResult, error) {
+	return CreateChallengeResult{}, nil
+}
+func (*relayOwnerTestControlPlane) GetChallenge(context.Context, string, string) (mobileremotebiz.PairingChallenge, error) {
+	return mobileremotebiz.PairingChallenge{}, nil
+}
+func (*relayOwnerTestControlPlane) ConfirmChallenge(context.Context, string, string, string, []byte) (ConfirmChallengeResult, error) {
+	return ConfirmChallengeResult{}, nil
+}
+func (*relayOwnerTestControlPlane) ListPairings(context.Context, string) ([]mobileremotebiz.DevicePairing, error) {
+	return nil, nil
+}
+func (*relayOwnerTestControlPlane) RevokePairing(context.Context, string, string) (mobileremotebiz.DevicePairing, error) {
+	return mobileremotebiz.DevicePairing{}, nil
+}
+func (*relayOwnerTestControlPlane) ListDeviceLinkAttempts(context.Context, string, string, string, []byte) ([]DeviceLinkAttempt, error) {
+	return nil, nil
+}
+func (*relayOwnerTestControlPlane) UpdateDeviceLinkParticipant(context.Context, string, string, string, string, DeviceLinkParticipantInput) (DeviceLinkAttempt, error) {
+	return DeviceLinkAttempt{}, nil
+}
+
+var _ DeviceAuthorityClient = (*relayOwnerTestAuthority)(nil)
+var _ ControlPlane = (*relayOwnerTestControlPlane)(nil)
+
+type relayOwnerDemandSpy struct {
+	mu       sync.Mutex
+	acquires int
+	releases int
+	acquired chan struct{}
+}
+
+func (s *relayOwnerDemandSpy) Acquire(context.Context, string) error {
+	s.mu.Lock()
+	s.acquires++
+	s.mu.Unlock()
+	s.acquired <- struct{}{}
+	return nil
+}
+
+func (s *relayOwnerDemandSpy) Release(string) error {
+	s.mu.Lock()
+	s.releases++
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *relayOwnerDemandSpy) acquireCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.acquires
+}
+
+func (s *relayOwnerDemandSpy) releaseCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.releases
+}

--- a/services/tuttid/service/mobileremote/remote_host.go
+++ b/services/tuttid/service/mobileremote/remote_host.go
@@ -18,6 +18,7 @@ const (
 	defaultRemotePollInterval = 2 * time.Second
 	remoteCallerSettleDelay   = 6 * time.Second
 	deviceLinkProtocolVersion = 2
+	mobileRemoteRelayDriver   = "mobile-remote"
 )
 
 type activeRemoteAttempt struct {
@@ -39,19 +40,22 @@ type remoteManagedLink struct {
 type remoteHostState struct {
 	mu sync.Mutex
 
-	cancel             context.CancelFunc
-	stopping           bool
-	stopDone           chan struct{}
-	handler            http.Handler
-	liveEvents         AgentLiveEventSource
-	attempts           map[string]activeRemoteAttempt
-	registeredSession  string
-	registeredDevice   RegisteredDevice
-	registerAfter      time.Time
-	nextGeneration     uint64
-	linkManager        *linkmanager.Manager[string, remoteLinkMetadata]
-	managedLinks       map[string]remoteManagedLink
-	observedLinkEvents map[string]uint64
+	cancel               context.CancelFunc
+	stopping             bool
+	stopDone             chan struct{}
+	handler              http.Handler
+	liveEvents           AgentLiveEventSource
+	attempts             map[string]activeRemoteAttempt
+	registeredSession    string
+	registeredDevice     RegisteredDevice
+	registerAfter        time.Time
+	nextGeneration       uint64
+	linkManager          *linkmanager.Manager[string, remoteLinkMetadata]
+	managedLinks         map[string]remoteManagedLink
+	observedLinkEvents   map[string]uint64
+	relayOwnerAcquired   bool
+	remoteHostGeneration uint64
+	activePairings       map[string]struct{}
 }
 
 func (s *Service) StartRemoteHost(handler http.Handler) {
@@ -80,8 +84,26 @@ func (s *Service) StartRemoteHost(handler http.Handler) {
 		s.remoteHost.attempts = make(map[string]activeRemoteAttempt)
 		s.remoteHost.managedLinks = make(map[string]remoteManagedLink)
 		s.remoteHost.observedLinkEvents = make(map[string]uint64)
+		s.remoteHost.activePairings = make(map[string]struct{})
 		s.remoteHost.linkManager = s.newRemoteLinkManager()
+		s.remoteHost.remoteHostGeneration++
+		remoteHostGeneration := s.remoteHost.remoteHostGeneration
+		relayOwner := s.RelayOwner
 		s.remoteHost.mu.Unlock()
+
+		if relayOwner != nil {
+			if err := relayOwner.Acquire(ctx, mobileRemoteRelayDriver); err == nil {
+				s.remoteHost.mu.Lock()
+				if s.remoteHost.remoteHostGeneration == remoteHostGeneration && !s.remoteHost.stopping {
+					s.remoteHost.relayOwnerAcquired = true
+					relayOwner = nil
+				}
+				s.remoteHost.mu.Unlock()
+				if relayOwner != nil {
+					_ = relayOwner.Release(mobileRemoteRelayDriver)
+				}
+			}
+		}
 
 		go func() {
 			defer s.remoteWG.Done()
@@ -115,6 +137,9 @@ func (s *Service) StopRemoteHost() {
 	done := make(chan struct{})
 	s.remoteHost.stopping = true
 	s.remoteHost.stopDone = done
+	relayOwner := s.RelayOwner
+	relayOwnerAcquired := s.remoteHost.relayOwnerAcquired
+	s.remoteHost.relayOwnerAcquired = false
 	for _, attempt := range s.remoteHost.attempts {
 		attempt.cancel()
 	}
@@ -129,12 +154,16 @@ func (s *Service) StopRemoteHost() {
 	if manager != nil {
 		_ = manager.WaitForQuiescence(context.Background())
 	}
+	if relayOwnerAcquired && relayOwner != nil {
+		_ = relayOwner.Release(mobileRemoteRelayDriver)
+	}
 	s.remoteHost.mu.Lock()
 	s.remoteHost.cancel = nil
 	s.remoteHost.linkManager = nil
 	s.remoteHost.attempts = nil
 	s.remoteHost.managedLinks = nil
 	s.remoteHost.observedLinkEvents = nil
+	s.remoteHost.activePairings = nil
 	s.remoteHost.stopping = false
 	s.remoteHost.stopDone = nil
 	close(done)
@@ -456,6 +485,14 @@ func (s *Service) stopRemoteAttempts(validPairings map[string]struct{}) {
 			}
 		}
 		invalidPairingSet[pairingID] = struct{}{}
+	}
+	if validPairings == nil {
+		s.remoteHost.activePairings = nil
+	} else {
+		s.remoteHost.activePairings = make(map[string]struct{}, len(validPairings))
+		for pairingID := range validPairings {
+			s.remoteHost.activePairings[pairingID] = struct{}{}
+		}
 	}
 	if validPairings == nil {
 		s.remoteHost.registeredSession = ""

--- a/services/tuttid/service/mobileremote/service.go
+++ b/services/tuttid/service/mobileremote/service.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	authbridge "github.com/tutti-os/tutti/packages/auth/bridge-go"
+	deviceauthority "github.com/tutti-os/tutti/packages/clients/device-authority-go"
 	mobileremotebiz "github.com/tutti-os/tutti/services/tuttid/biz/mobileremote"
 )
 
@@ -26,6 +27,24 @@ type AccountSessionSource interface {
 
 type IdentityStore interface {
 	LoadOrCreate(context.Context) (mobileremotebiz.DeviceIdentity, error)
+}
+
+// DeviceAuthorityClient is the narrow control-plane dependency used by the
+// Relay owner lifecycle. The shared client owns signing and wire validation;
+// the mobile-remote service owns demand, lease, and reconnect policy.
+type DeviceAuthorityClient interface {
+	EnsureDeviceAuthority(context.Context, deviceauthority.EnsureDeviceAuthorityRequest) (deviceauthority.DeviceAuthorityResult, error)
+	RegisterDeviceGatewayIdentity(context.Context, deviceauthority.RegisterDeviceGatewayIdentityRequest) (deviceauthority.DeviceGatewayIdentityResult, error)
+	IssueDeviceGatewayOwnerTunnelToken(context.Context, deviceauthority.IssueDeviceGatewayOwnerTunnelTokenRequest) (deviceauthority.DeviceGatewayOwnerTunnelTokenResult, error)
+	RenewDeviceAuthorityLease(context.Context, deviceauthority.RenewDeviceAuthorityLeaseRequest) (deviceauthority.RenewDeviceAuthorityLeaseResult, error)
+}
+
+// RelayOwnerHost is the demand-counted owner tunnel supplied by the shared
+// relay transport. Mobile Remote acquires it only while the user-enabled
+// connection feature is running.
+type RelayOwnerHost interface {
+	Acquire(context.Context, string) error
+	Release(string) error
 }
 
 // AgentLiveEventSource feeds already-validated agent.activity.updated
@@ -62,6 +81,9 @@ type Service struct {
 	Account         AccountSessionSource
 	Identities      IdentityStore
 	ControlPlane    ControlPlane
+	DeviceAuthority DeviceAuthorityClient
+	RuntimeID       string
+	RelayOwner      RelayOwnerHost
 	AgentLiveEvents AgentLiveEventSource
 	Metadata        DeviceMetadata
 	Now             func() time.Time

--- a/services/tuttid/wiring_mobile_remote.go
+++ b/services/tuttid/wiring_mobile_remote.go
@@ -27,13 +27,15 @@ func buildMobileRemoteService(
 	if err != nil {
 		reportedName = "Tutti Desktop"
 	}
-	return &mobileremoteservice.Service{
+	identities := deviceidentitydata.NewFileStore(
+		filepath.Join(stateDir, "mobile-remote", "device-identity.json"),
+		deviceID,
+	)
+	service := &mobileremoteservice.Service{
 		Account:         account,
 		AgentLiveEvents: mobileAgentLiveEventSource{events: events},
-		Identities: deviceidentitydata.NewFileStore(
-			filepath.Join(stateDir, "mobile-remote", "device-identity.json"),
-			deviceID,
-		),
+		Identities:      identities,
+		RuntimeID:       deviceID,
 		ControlPlane: &mobileremoteservice.HTTPControlPlane{
 			BaseURL: os.Getenv("TUTTI_MOBILE_CONTROL_PLANE_BASE_URL"),
 		},
@@ -43,7 +45,20 @@ func buildMobileRemoteService(
 			Arch:          runtime.GOARCH,
 			ClientVersion: tuttitypes.ResolveAppVersion(),
 		},
-	}, nil
+	}
+	deviceAuthority, err := mobileremoteservice.NewDeviceAuthorityClient(
+		os.Getenv("TUTTI_MOBILE_CONTROL_PLANE_BASE_URL"), account, identities,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("configure mobile remote Device Authority client: %w", err)
+	}
+	service.DeviceAuthority = deviceAuthority
+	relayOwner, err := service.NewRelayOwner()
+	if err != nil {
+		return nil, fmt.Errorf("configure mobile remote Relay owner: %w", err)
+	}
+	service.RelayOwner = relayOwner
+	return service, nil
 }
 
 type mobileAgentLiveEventSource struct {


### PR DESCRIPTION
## Summary
- add shared gomobile Relay byte-stream dialing with caller-provided query, headers, and subprotocol
- add tuttid mobile-remote Relay owner lifecycle with Device Authority enrollment, owner token, lease renewal, demand gating, and fail-closed paired-device scope checks
- add Mobile Android/iOS direct-first HTTP/live Relay fallback and parallel descriptor acquisition without changing Agent DTOs or UI ports
- update Relay design/package documentation and add protocol, lifecycle, authorization, native, and descriptor tests

## Compatibility
- existing direct DeviceLink and room framing remain unchanged
- Relay is only acquired when the existing mobile remote feature preference is enabled
- descriptor failure preserves the direct connection path
- server-side descriptor and tsh-tunnel-relay Agent channel are additive cross-repository contracts

## Validation
- `pnpm check:changed -- --push-ready`
- `pnpm --filter @tutti-os/mobile check`
- `go test -race ./mobile` (packages/device-link)
- `go test -race ./service/mobileremote` (services/tuttid)
- Android AAR build with local SDK/JDK
- iOS framework build

The repository-wide tuttid suite still reports the pre-existing missing `generated/tutti-onboarding/*.zip` fixture and cascading blackbox startup failures; changed-aware checks pass.