### PR TITLE
fix(release): use canonical draft release URLs

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -552,7 +552,7 @@ jobs:
           (needs.build-windows.result == 'success' || needs.build-windows.result == 'skipped') }}
     runs-on: ubuntu-latest
     outputs:
-      release_url: ${{ steps.stage-release.outputs.url }}
+      release_url: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ needs.resolve.outputs.release_tag }}
     env:
       AWS_REGION: ${{ vars.AWS_REGION }}
       TUTTI_ARTIFACTS_AWS_ROLE_ARN: ${{ vars.TUTTI_ARTIFACTS_AWS_ROLE_ARN }}

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -224,7 +224,7 @@ test("desktop release workflow passes tsh-aligned Feishu card context", async ()
   );
   assert.match(
     workflow,
-    /outputs:\s*\n\s*release_url:\s*\${{\s*steps\.stage-release\.outputs\.url\s*}}/
+    /outputs:\s*\n\s*release_url:\s*\${{\s*github\.server_url\s*}}\/\${{\s*github\.repository\s*}}\/releases\/tag\/\${{\s*needs\.resolve\.outputs\.release_tag\s*}}/
   );
   assert.match(
     workflow,


### PR DESCRIPTION
## Summary
- use the canonical /releases/tag/<tag> URL for the stage release output
- keep Draft Feishu cards from receiving the transient untagged URL emitted during GitHub release creation

## Evidence
The main RC run completed successfully, but softprops/action-gh-release emitted an untagged URL that returned 404; gh release edit resolved the same draft by tag to the canonical URL. The canonical tag URL is reachable and is also the script's default release URL.

## Validation
- node --test tools/scripts/desktop-release-config.test.mjs (41/41)
- git diff --check