### PR TITLE
fix(agent-gui): keep all shared-agent history visible

### DIFF
--- a/.changeset/shared-agent-all-session-history.md
+++ b/.changeset/shared-agent-all-session-history.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/agent-gui": major
+---
+
+Keep the AgentGUI All conversation filter unscoped so historical sessions from offline shared Agents remain visible alongside sessions from available Agents. Remove the obsolete `sectionAgentTargetFallbackId` host contract.

--- a/apps/mobile/src/services/workspaceConversationRailService.ts
+++ b/apps/mobile/src/services/workspaceConversationRailService.ts
@@ -102,7 +102,6 @@ export class WorkspaceConversationRailService extends ObservableService<Workspac
     });
     this.controller.configure({
       conversationFilter: { kind: "all" },
-      sectionAgentTargetFallbackId: null,
       userProjects: []
     });
     this.applyControllerSnapshot(this.controller.getSnapshot());

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -399,17 +399,6 @@ export function AgentGUINodeView({
     const label = providerAuthAccountLabels?.[provider]?.trim();
     return label || null;
   }, [effectiveRailConfigProvider, providerAuthAccountLabels]);
-  const enabledProviderTargets = viewModel.rail.agentTargets.filter(
-    (target) =>
-      target.disabled !== true &&
-      ((target.agentTargetId?.trim() ?? "") || (target.targetId?.trim() ?? ""))
-  );
-  const sectionAgentTargetFallbackId =
-    enabledProviderTargets.length <= 1
-      ? viewModel.rail.selectedAgentTarget.agentTargetId?.trim() ||
-        viewModel.rail.selectedAgentTarget.targetId?.trim() ||
-        null
-      : null;
   const {
     controller: targetSetupController,
     environmentSetupVisible,
@@ -472,7 +461,6 @@ export function AgentGUINodeView({
       agentTargets: viewModel.rail.agentTargets,
       agentTargetsLoading: viewModel.rail.agentTargetsLoading,
       conversationFilter: viewModel.rail.conversationFilter,
-      sectionAgentTargetFallbackId,
       onCreateConversation: requestCreateConversation,
       onUpdateConversationFilter: actions.updateConversationFilter,
       onSelectConversationFilterTarget: actions.selectConversationFilterTarget,
@@ -512,7 +500,6 @@ export function AgentGUINodeView({
       requestRenameConversation,
       selectConversation,
       effectiveSelectProjectDirectory,
-      sectionAgentTargetFallbackId,
       viewModel.rail.agentTargets,
       viewModel.rail.agentTargetsLoading,
       viewModel.rail.revealRequest,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailController.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailController.tsx
@@ -16,7 +16,6 @@ export const AgentGUIConversationRailController = memo(
       conversationQuery,
       nodeId: props.nodeId,
       registerInteractionLockProbe: props.registerInteractionLockProbe,
-      sectionAgentTargetFallbackId: props.sectionAgentTargetFallbackId,
       userProjects: props.userProjects,
       workspaceId: props.workspaceId
     });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.reattach.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.reattach.spec.ts
@@ -66,7 +66,6 @@ describe("AgentGUIConversationRailQueryController reattach", () => {
     });
     controller.configure({
       conversationFilter: { kind: "all" },
-      sectionAgentTargetFallbackId: null,
       userProjects: []
     });
     const detach = controller.attach();
@@ -187,7 +186,6 @@ describe("AgentGUIConversationRailQueryController reattach", () => {
     });
     controller.configure({
       conversationFilter: { kind: "all" },
-      sectionAgentTargetFallbackId: null,
       userProjects: []
     });
     const detach = controller.attach();

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
@@ -56,7 +56,6 @@ describe("AgentGUIConversationRailQueryController", () => {
     });
     controller.configure({
       conversationFilter: { kind: "all" },
-      sectionAgentTargetFallbackId: null,
       userProjects: []
     });
 
@@ -126,12 +125,10 @@ describe("AgentGUIConversationRailQueryController", () => {
     });
     const scopeA: ConversationRailQueryScope = {
       conversationFilter: { agentTargetId: "agent-a", kind: "agentTarget" },
-      sectionAgentTargetFallbackId: null,
       userProjects: []
     };
     const scopeB: ConversationRailQueryScope = {
       conversationFilter: { agentTargetId: "agent-b", kind: "agentTarget" },
-      sectionAgentTargetFallbackId: null,
       userProjects: []
     };
     const scopeAKey = resolveConversationRailQueryScope(
@@ -228,7 +225,6 @@ describe("AgentGUIConversationRailQueryController", () => {
     });
     controller.configure({
       conversationFilter: { kind: "all" },
-      sectionAgentTargetFallbackId: null,
       userProjects: []
     });
 
@@ -311,7 +307,6 @@ describe("AgentGUIConversationRailQueryController", () => {
     });
     const scope: ConversationRailQueryScope = {
       conversationFilter: { kind: "all" },
-      sectionAgentTargetFallbackId: null,
       userProjects: []
     };
     const scopeKey = resolveConversationRailQueryScope(
@@ -372,7 +367,6 @@ describe("AgentGUIConversationRailQueryController", () => {
       });
       controller.configure({
         conversationFilter: { kind: "all" },
-        sectionAgentTargetFallbackId: null,
         userProjects: []
       });
 
@@ -484,7 +478,6 @@ describe("AgentGUIConversationRailQueryController", () => {
     });
     const initialScope: ConversationRailQueryScope = {
       conversationFilter: { kind: "all" },
-      sectionAgentTargetFallbackId: null,
       userProjects: []
     };
     const initialScopeKey = resolveConversationRailQueryScope(
@@ -582,7 +575,6 @@ describe("AgentGUIConversationRailQueryController", () => {
         agentTargetId: "local:claude-code",
         kind: "agentTarget"
       },
-      sectionAgentTargetFallbackId: null,
       userProjects: []
     };
     controller.configure(nextScope);
@@ -624,7 +616,6 @@ describe("AgentGUIConversationRailQueryController", () => {
     });
     const regularScope = {
       conversationFilter: { kind: "all" } as const,
-      sectionAgentTargetFallbackId: null,
       userProjects: []
     };
 
@@ -685,7 +676,6 @@ describe("AgentGUIConversationRailQueryController", () => {
     };
     const scope = {
       conversationFilter: { kind: "all" } as const,
-      sectionAgentTargetFallbackId: null,
       userProjects: [alpha, beta]
     };
 
@@ -770,7 +760,6 @@ describe("AgentGUIConversationRailQueryController", () => {
     });
     controller.configure({
       conversationFilter: { kind: "all" },
-      sectionAgentTargetFallbackId: null,
       userProjects: []
     });
     const detach = controller.attach();
@@ -861,7 +850,6 @@ describe("AgentGUIConversationRailQueryController", () => {
     });
     controller.configure({
       conversationFilter: { kind: "all" },
-      sectionAgentTargetFallbackId: null,
       userProjects: []
     });
     const detach = controller.attach();
@@ -930,7 +918,6 @@ describe("AgentGUIConversationRailQueryController", () => {
     });
     controller.configure({
       conversationFilter: { kind: "all" },
-      sectionAgentTargetFallbackId: null,
       userProjects: []
     });
 
@@ -999,7 +986,6 @@ describe("AgentGUIConversationRailQueryController", () => {
     });
     controller.configure({
       conversationFilter: { kind: "all" },
-      sectionAgentTargetFallbackId: null,
       userProjects: []
     });
     const unsubscribeThrowingListener = controller.subscribe(() => {
@@ -1069,7 +1055,6 @@ describe("AgentGUIConversationRailQueryController", () => {
         kind: "agentTarget",
         agentTargetId: "local:codex"
       },
-      sectionAgentTargetFallbackId: null,
       userProjects: []
     });
 
@@ -1132,7 +1117,6 @@ describe("AgentGUIConversationRailQueryController", () => {
     });
     const scope = {
       conversationFilter: { kind: "all" } as const,
-      sectionAgentTargetFallbackId: null,
       userProjects: []
     };
     controller.configure(scope);
@@ -1205,7 +1189,6 @@ describe("AgentGUIConversationRailQueryController", () => {
         agentTargetId: "local:codex",
         kind: "agentTarget"
       } as const,
-      sectionAgentTargetFallbackId: null,
       userProjects: []
     };
     const first = new AgentGUIConversationRailQueryController({
@@ -1290,7 +1273,6 @@ describe("AgentGUIConversationRailQueryController", () => {
     });
     const scope = (agentTargetId: string) => ({
       conversationFilter: { agentTargetId, kind: "agentTarget" as const },
-      sectionAgentTargetFallbackId: null,
       userProjects: []
     });
     controller.configure(scope("local:codex"));
@@ -1412,7 +1394,6 @@ describe("AgentGUIConversationRailQueryController", () => {
         agentTargetId: "shared:one",
         kind: "agentTarget"
       },
-      sectionAgentTargetFallbackId: null,
       userProjects: []
     });
     const detach = controller.attach();
@@ -1423,9 +1404,12 @@ describe("AgentGUIConversationRailQueryController", () => {
 
     controller.configure({
       conversationFilter: { kind: "all" },
-      sectionAgentTargetFallbackId: "shared:one",
       userProjects: []
     });
+
+    expect(listSessionSections).toHaveBeenLastCalledWith(
+      expect.objectContaining({ agentTargetId: undefined })
+    );
 
     expect(controller.getSnapshot().runtimeRailSectionsPending).toBe(true);
     expect(controller.getSnapshot().runtimeRailMemberships).toEqual([
@@ -1443,7 +1427,7 @@ describe("AgentGUIConversationRailQueryController", () => {
         retainedPreviousSections: true,
         runtimeOrigin: AGENT_SESSION_ENGINE_LOCAL_ORIGIN,
         status: "pending",
-        toAgentTargetId: "shared:one",
+        toAgentTargetId: null,
         toFilterKind: "all"
       })
     );
@@ -1462,8 +1446,12 @@ describe("AgentGUIConversationRailQueryController", () => {
         status: "ready"
       })
     );
-    expect(diagnosticLogger).not.toHaveBeenCalledWith(
-      expect.objectContaining({ event: "agent_gui.provider_switch.completed" })
+    expect(diagnosticLogger).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "agent_gui.provider_switch.completed",
+        fromAgentTargetId: "shared:one",
+        toAgentTargetId: null
+      })
     );
 
     detach();

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailQueryTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailQueryTypes.ts
@@ -10,7 +10,6 @@ export interface ConversationRailQueryScope {
   conversationFilter:
     | { kind: "all" }
     | { agentTargetId: string; kind: "agentTarget" };
-  sectionAgentTargetFallbackId: string | null;
   userProjects: readonly { id: string }[];
 }
 
@@ -47,7 +46,7 @@ export function resolveConversationRailQueryScope(
   const agentTargetId =
     scope.conversationFilter.kind === "agentTarget"
       ? scope.conversationFilter.agentTargetId.trim()
-      : (scope.sectionAgentTargetFallbackId?.trim() ?? "");
+      : "";
   const projectCollectionKey = userProjectCollectionKey(scope.userProjects);
   return {
     agentTargetId,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.search.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.search.spec.tsx
@@ -58,7 +58,6 @@ describe("useAgentGUIConversationRailQuery search", () => {
           conversationFilter: { kind: "all" },
           conversationQuery: "",
           nodeId: "desktop-node-1",
-          sectionAgentTargetFallbackId: null,
           userProjects: [],
           workspaceId: "workspace-1"
         }),
@@ -100,7 +99,6 @@ describe("useAgentGUIConversationRailQuery search", () => {
           activeConversationId: null,
           conversationFilter: { kind: "all" },
           conversationQuery: "",
-          sectionAgentTargetFallbackId: null,
           userProjects: [],
           workspaceId: "workspace-1"
         }),
@@ -305,7 +303,6 @@ describe("useAgentGUIConversationRailQuery search", () => {
         activeConversationId: null,
         conversationFilter: { agentTargetId, kind: "agentTarget" },
         conversationQuery: "",
-        sectionAgentTargetFallbackId: null,
         userProjects: [],
         workspaceId: "workspace-1"
       });
@@ -379,7 +376,6 @@ describe("useAgentGUIConversationRailQuery search", () => {
             kind: "agentTarget"
           },
           conversationQuery: " backend ",
-          sectionAgentTargetFallbackId: null,
           userProjects: [],
           workspaceId: "workspace-1"
         }),
@@ -457,7 +453,6 @@ describe("useAgentGUIConversationRailQuery search", () => {
           activeConversationId: null,
           conversationFilter: { kind: "all" },
           conversationQuery: "backend",
-          sectionAgentTargetFallbackId: null,
           userProjects: [],
           workspaceId: "workspace-1"
         }),
@@ -507,7 +502,6 @@ describe("useAgentGUIConversationRailQuery search", () => {
           activeConversationId: "session-1",
           conversationFilter: { kind: "all" },
           conversationQuery: "",
-          sectionAgentTargetFallbackId: null,
           userProjects: [],
           workspaceId: "workspace-1"
         });
@@ -558,7 +552,6 @@ describe("useAgentGUIConversationRailQuery search", () => {
         activeConversationId: "session-1",
         conversationFilter: { kind: "all" },
         conversationQuery: "streaming",
-        sectionAgentTargetFallbackId: null,
         userProjects: [],
         workspaceId: "workspace-1"
       });
@@ -587,7 +580,6 @@ describe("useAgentGUIConversationRailQuery search", () => {
             labels={RAIL_LABELS}
             pendingDeleteConversationId={null}
             railQuery={railQuery}
-            sectionAgentTargetFallbackId={null}
             uiLanguage="en"
             userProjects={[]}
             workspaceId="workspace-1"
@@ -683,7 +675,6 @@ describe("useAgentGUIConversationRailQuery search", () => {
         activeConversationId: null,
         conversationFilter: { kind: "all" },
         conversationQuery: "does-not-match",
-        sectionAgentTargetFallbackId: null,
         userProjects,
         workspaceId: "workspace-1"
       });
@@ -705,7 +696,6 @@ describe("useAgentGUIConversationRailQuery search", () => {
           labels={RAIL_LABELS}
           pendingDeleteConversationId={null}
           railQuery={railQuery}
-          sectionAgentTargetFallbackId={null}
           uiLanguage="en"
           userProjects={userProjects}
           workspaceId="workspace-1"
@@ -812,7 +802,6 @@ describe("useAgentGUIConversationRailQuery search", () => {
         activeConversationId: null,
         conversationFilter: { kind: "all" },
         conversationQuery: "",
-        sectionAgentTargetFallbackId: null,
         userProjects,
         workspaceId: "workspace-1"
       });
@@ -835,7 +824,6 @@ describe("useAgentGUIConversationRailQuery search", () => {
           labels={RAIL_LABELS}
           pendingDeleteConversationId={null}
           railQuery={railQuery}
-          sectionAgentTargetFallbackId={null}
           uiLanguage="en"
           userProjects={userProjects}
           workspaceId="workspace-1"

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts
@@ -21,7 +21,6 @@ export interface AgentGUIConversationRailInput {
   conversationQuery: string;
   nodeId?: string | null;
   registerInteractionLockProbe?: (probe: (() => boolean) | null) => void;
-  sectionAgentTargetFallbackId: string | null;
   userProjects: AgentGUINodeViewModel["rail"]["userProjects"];
   workspaceId: string;
 }
@@ -32,7 +31,6 @@ export function useAgentGUIConversationRailQuery({
   conversationQuery,
   nodeId,
   registerInteractionLockProbe,
-  sectionAgentTargetFallbackId,
   userProjects,
   workspaceId
 }: AgentGUIConversationRailInput) {
@@ -86,17 +84,10 @@ export function useAgentGUIConversationRailQuery({
   useEffect(() => {
     controller.configure({
       conversationFilter,
-      sectionAgentTargetFallbackId,
       userProjects
     });
     controller.setSearchQuery(conversationQuery);
-  }, [
-    controller,
-    conversationFilter,
-    conversationQuery,
-    sectionAgentTargetFallbackId,
-    userProjects
-  ]);
+  }, [controller, conversationFilter, conversationQuery, userProjects]);
 
   const querySnapshot = useEngineSelector(
     controller,
@@ -130,15 +121,9 @@ export function useAgentGUIConversationRailQuery({
     () =>
       resolveConversationRailQueryScope(workspaceId, {
         conversationFilter,
-        sectionAgentTargetFallbackId,
         userProjects
       }).scopeKey,
-    [
-      conversationFilter,
-      sectionAgentTargetFallbackId,
-      userProjects,
-      workspaceId
-    ]
+    [conversationFilter, userProjects, workspaceId]
   );
   return useMemo(
     () => ({

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRailViewState.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRailViewState.spec.ts
@@ -14,17 +14,15 @@ describe("agent GUI conversation rail view state", () => {
           kind: "agentTarget",
           agentTargetId: " local:codex "
         },
-        sectionAgentTargetFallbackId: null,
         workspaceId: " workspace-1 "
       })
     ).toBe("workspace-1:agentTarget:local:codex");
     expect(
       agentGUIConversationRailViewScopeKey({
         conversationFilter: { kind: "all" },
-        sectionAgentTargetFallbackId: "local:claude-code",
         workspaceId: "workspace-1"
       })
-    ).toBe("workspace-1:all:local:claude-code");
+    ).toBe("workspace-1:all");
   });
 
   it("keeps collapsed sections and visible limits independent by scope", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRailViewState.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRailViewState.ts
@@ -36,13 +36,12 @@ const EMPTY_SCOPED_RAIL_VIEW_STATE: AgentGUIConversationRailScopedViewState = {
 
 export function agentGUIConversationRailViewScopeKey(input: {
   conversationFilter: AgentGUIConversationFilter;
-  sectionAgentTargetFallbackId: string | null;
   workspaceId: string;
 }): string {
   const filterScope =
     input.conversationFilter.kind === "agentTarget"
       ? `agentTarget:${input.conversationFilter.agentTargetId.trim()}`
-      : `all:${input.sectionAgentTargetFallbackId?.trim() ?? ""}`;
+      : "all";
   return `${input.workspaceId.trim()}:${filterScope}`;
 }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.tsx
@@ -81,7 +81,6 @@ export interface AgentGUIConversationRailControllerProps {
   agentTargets: AgentGUINodeViewModel["rail"]["agentTargets"];
   agentTargetsLoading: AgentGUINodeViewModel["rail"]["agentTargetsLoading"];
   conversationFilter: AgentGUINodeViewModel["rail"]["conversationFilter"];
-  sectionAgentTargetFallbackId: string | null;
   /**
    * Lets the host subtree observe the rail query controller's interaction
    * lock (e.g. so header-dispatched session actions honor the same lock).
@@ -176,7 +175,6 @@ export const AgentGUIConversationRailPane = memo(
     createConversationDisabled,
     isCollapsed,
     conversationFilter,
-    sectionAgentTargetFallbackId,
     conversationQuery,
     railQuery,
     onCreateConversation,
@@ -421,7 +419,6 @@ export const AgentGUIConversationRailPane = memo(
       );
     const railViewScopeKey = agentGUIConversationRailViewScopeKey({
       conversationFilter,
-      sectionAgentTargetFallbackId,
       workspaceId
     });
     const groupedConversationIdentityKey = useMemo(
@@ -437,7 +434,7 @@ export const AgentGUIConversationRailPane = memo(
     const sectionAgentTargetId =
       conversationFilter.kind === "agentTarget"
         ? conversationFilter.agentTargetId.trim()
-        : (sectionAgentTargetFallbackId?.trim() ?? "");
+        : "";
     const requestSectionBatchDeletion = useStableEventCallback(
       (section: ConversationSection) => {
         if (

--- a/packages/agent/gui/agentConversationRailController.spec.ts
+++ b/packages/agent/gui/agentConversationRailController.spec.ts
@@ -23,7 +23,6 @@ describe("createAgentGUIConversationRailQueryController", () => {
     };
     const scope = {
       conversationFilter: { kind: "all" as const },
-      sectionAgentTargetFallbackId: null,
       userProjects: []
     };
     const first = createAgentGUIConversationRailQueryController({


### PR DESCRIPTION
## Summary

- Keep the AgentGUI All conversation rail query unscoped.
- Keep historical sessions from offline shared Agents visible.
- Remove the obsolete sectionAgentTargetFallbackId host contract from AgentGUI and its two in-repo consumers.
- Add regression coverage for the unscoped All query.

## Tests

- pnpm check:changed --base origin/main --verbose
- Push hook check:changed -- --push-ready

## Notes

- This is a direct public-contract removal, so the changeset is major as requested.
- TSH should upgrade @tutti-os/agent-gui after this upstream patch is released; no TSH override is included.
- TSH PR: https://github.com/tutti-lab/tsh/pull/2333