### PR TITLE
fix(connector-market): single-flight operation execution

### DIFF
--- a/packages/connector/market/README.md
+++ b/packages/connector/market/README.md
@@ -78,3 +78,11 @@ revision monotonically. `ArtifactInstaller`, `AuthorizationProvider`, and
 `OperationScheduler` must be idempotent for the operation or client request id
 they receive because daemon recovery can replay accepted or running work after
 a crash.
+
+`Application.ExecuteOperation` also provides process-local single-flight
+semantics: concurrent dispatches for the same operation ID share one execution
+and its final result, while different operation IDs remain independently
+schedulable. This in-memory ownership is intentionally limited to one
+`Application` instance; after a process restart, durable accepted/running
+operations are replayed through `Recover`, so adapters must still tolerate
+uncertain external side effects from a crash.

--- a/packages/connector/market/daemon/application.go
+++ b/packages/connector/market/daemon/application.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -25,6 +26,16 @@ type ApplicationConfig struct {
 
 type Application struct {
 	config ApplicationConfig
+
+	// executionMu and inFlight provide process-local ownership for operation
+	// execution. Durable recovery remains the repository and adapter contract.
+	executionMu sync.Mutex
+	inFlight    map[string]*operationExecution
+}
+
+type operationExecution struct {
+	done chan struct{}
+	err  error
 }
 
 var _ Service = (*Application)(nil)
@@ -57,7 +68,7 @@ func NewApplication(config ApplicationConfig) (*Application, error) {
 	if config.NewID == nil {
 		config.NewID = randomID
 	}
-	return &Application{config: config}, nil
+	return &Application{config: config, inFlight: make(map[string]*operationExecution)}, nil
 }
 
 func (application *Application) Snapshot(ctx context.Context, workspaceID string) (Snapshot, error) {
@@ -359,6 +370,48 @@ func (application *Application) SetWorkspaceEnabled(
 }
 
 func (application *Application) ExecuteOperation(ctx context.Context, operationID string) error {
+	execution, owner := application.beginOperationExecution(operationID)
+	if !owner {
+		select {
+		case <-execution.done:
+			return execution.err
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	var executeErr error
+	defer func() {
+		application.finishOperationExecution(operationID, execution, executeErr)
+	}()
+	executeErr = application.executeOperation(ctx, operationID)
+	return executeErr
+}
+
+func (application *Application) beginOperationExecution(operationID string) (*operationExecution, bool) {
+	application.executionMu.Lock()
+	defer application.executionMu.Unlock()
+	if execution, ok := application.inFlight[operationID]; ok {
+		return execution, false
+	}
+	execution := &operationExecution{done: make(chan struct{})}
+	application.inFlight[operationID] = execution
+	return execution, true
+}
+
+func (application *Application) finishOperationExecution(
+	operationID string,
+	execution *operationExecution,
+	err error,
+) {
+	application.executionMu.Lock()
+	defer application.executionMu.Unlock()
+	execution.err = err
+	delete(application.inFlight, operationID)
+	close(execution.done)
+}
+
+func (application *Application) executeOperation(ctx context.Context, operationID string) error {
 	operation, err := application.config.Repository.Operation(ctx, operationID)
 	if err != nil {
 		return err

--- a/packages/connector/market/daemon/application_test.go
+++ b/packages/connector/market/daemon/application_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -73,6 +75,110 @@ func TestApplicationExecutesAcceptedInstall(t *testing.T) {
 	}
 	if operation.State != OperationStateCompleted || installer.installs != 1 {
 		t.Fatalf("operation = %#v, installs = %d", operation, installer.installs)
+	}
+}
+
+func TestApplicationSingleFlightsConcurrentOperationExecution(t *testing.T) {
+	repository := newMemoryRepository(testConnector("github"))
+	scheduler := &memoryScheduler{}
+	installer := newBlockingInstaller()
+	application := newTestApplication(t, repository, scheduler, installer, CatalogSnapshot{})
+	accepted, err := application.Install(context.Background(), ConnectorMutation{
+		Mutation:     Mutation{ClientRequestID: "request-1", ExpectedRevision: 0},
+		ConnectorKey: "github",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- application.ExecuteOperation(context.Background(), accepted.Operation.OperationID)
+	}()
+	select {
+	case <-installer.started:
+	case <-time.After(time.Second):
+		t.Fatal("first operation did not reach installer")
+	}
+
+	secondDone := make(chan error, 1)
+	go func() {
+		secondDone <- application.ExecuteOperation(context.Background(), accepted.Operation.OperationID)
+	}()
+	select {
+	case err := <-secondDone:
+		t.Fatalf("second execution returned before the first completed: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(installer.release)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first execution error = %v", err)
+	}
+	if err := <-secondDone; err != nil {
+		t.Fatalf("second execution error = %v", err)
+	}
+	if installs := installer.installs.Load(); installs != 1 {
+		t.Fatalf("installer calls = %d, want 1", installs)
+	}
+}
+
+func TestApplicationSharesConcurrentOperationFailureAndClearsFlight(t *testing.T) {
+	repository := newMemoryRepository(testConnector("github"))
+	scheduler := &memoryScheduler{}
+	cause := errors.New("installer unavailable")
+	installer := newBlockingInstallerWithError(cause)
+	application := newTestApplication(t, repository, scheduler, installer, CatalogSnapshot{})
+	accepted, err := application.Install(context.Background(), ConnectorMutation{
+		Mutation:     Mutation{ClientRequestID: "request-1", ExpectedRevision: 0},
+		ConnectorKey: "github",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- application.ExecuteOperation(context.Background(), accepted.Operation.OperationID)
+	}()
+	select {
+	case <-installer.started:
+	case <-time.After(time.Second):
+		t.Fatal("first operation did not reach installer")
+	}
+
+	secondDone := make(chan error, 1)
+	go func() {
+		secondDone <- application.ExecuteOperation(context.Background(), accepted.Operation.OperationID)
+	}()
+	select {
+	case err := <-secondDone:
+		t.Fatalf("second execution returned before the first completed: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(installer.release)
+	firstErr := <-firstDone
+	secondErr := <-secondDone
+	for name, err := range map[string]error{"first": firstErr, "second": secondErr} {
+		var domainError *DomainError
+		if !errors.As(err, &domainError) || !errors.Is(err, cause) {
+			t.Errorf("%s error = %#v, want install domain error caused by %v", name, err, cause)
+		}
+	}
+	if installs := installer.installs.Load(); installs != 1 {
+		t.Fatalf("installer calls = %d, want 1", installs)
+	}
+
+	operation, err := repository.Operation(context.Background(), accepted.Operation.OperationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if operation.State != OperationStateFailed {
+		t.Fatalf("operation state = %q, want failed", operation.State)
+	}
+	if err := application.ExecuteOperation(context.Background(), accepted.Operation.OperationID); err != nil {
+		t.Fatalf("terminal operation after flight cleanup = %v", err)
 	}
 }
 
@@ -153,7 +259,7 @@ func newTestApplication(
 	t *testing.T,
 	repository *memoryRepository,
 	scheduler *memoryScheduler,
-	installer *memoryInstaller,
+	installer ArtifactInstaller,
 	catalog CatalogSnapshot,
 ) *Application {
 	t.Helper()
@@ -224,6 +330,41 @@ func (installer *memoryInstaller) Install(context.Context, Manifest) error {
 
 func (installer *memoryInstaller) Uninstall(context.Context, Connector) error {
 	installer.uninstalls++
+	return nil
+}
+
+type blockingInstaller struct {
+	started  chan struct{}
+	release  chan struct{}
+	once     sync.Once
+	installs atomic.Int32
+	err      error
+}
+
+func newBlockingInstaller() *blockingInstaller {
+	return newBlockingInstallerWithError(nil)
+}
+
+func newBlockingInstallerWithError(err error) *blockingInstaller {
+	return &blockingInstaller{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+		err:     err,
+	}
+}
+
+func (installer *blockingInstaller) Install(ctx context.Context, _ Manifest) error {
+	installer.installs.Add(1)
+	installer.once.Do(func() { close(installer.started) })
+	select {
+	case <-installer.release:
+		return installer.err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (installer *blockingInstaller) Uninstall(context.Context, Connector) error {
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- add process-local single-flight ownership for `Application.ExecuteOperation`
- make concurrent dispatches of one operation share one real side effect and final result
- document the boundary between in-process deduplication and durable crash recovery

## Problem

`ExecuteOperation` treated an already-`running` operation as a successful no-op. If the scheduler, retry path, or recovery path dispatched the same operation concurrently, multiple goroutines could therefore call `ArtifactInstaller.Install`, `Uninstall`, or authorization disconnect for the same durable operation.

That can duplicate external side effects and allowed a later caller to return before the original execution had completed.

## Fix

`Application` now keeps an operation-ID keyed in-flight registry:

- the first caller becomes the owner and performs the existing execution state machine;
- concurrent callers wait for that owner and receive the same result/error;
- different operation IDs do not share an execution entry or long-held lock;
- the entry is removed after completion or failure;
- waiter context cancellation does not cancel the owner;
- persisted `accepted`/`running` recovery semantics remain unchanged after process restart.

This is intentionally process-local. Adapter idempotency remains required because a crash can leave an external side effect uncertain before the durable operation reaches a terminal state.

## Tests

- added a real barrier regression test proving concurrent install dispatch calls the installer once;
- added shared-failure and in-flight cleanup coverage;
- `go test -race ./packages/connector/market/daemon`
- `go test ./packages/connector/market/...`
- `go vet ./packages/connector/market/...`
- `go test ./packages/connector/market/... ./services/tuttid/...`
- `corepack pnpm lint:go` (Node 24.18.1)
- `corepack pnpm build:go` (Node 24.18.1)

The broader Tutti daemon test command also exposed two existing failures in `services/tuttid/service/agentstatus`, both unrelated to this diff and reproducible when run alone:

- `TestResolveProviderRuntimeUsesManagedClaudeCodePointer`
- `TestServiceRunActionReportsActiveActionForClaudeInstall`

## Downstream impact

The TSH source tree currently has no `connector-market` consumer, so no TSH source change is required. The shared package README documents the new execution contract for future approved hosts.
