### PR TITLE
feat(mobile): race direct and Relay streams with peer handshake

### DIFF
--- a/apps/mobile/android/app/src/main/java/dev/tutti/mobile/DeviceLinkModule.kt
+++ b/apps/mobile/android/app/src/main/java/dev/tutti/mobile/DeviceLinkModule.kt
@@ -187,43 +187,48 @@ class DeviceLinkModule(
             return
         }
         runAsync(promise, "DEVICE_LINK_REQUEST_FAILED", "DeviceLink request failed") {
-            var directFailure: Throwable? = null
+            if (selected != null && relay != null) {
+                val stream = selected.openStreamWithRelay(
+                    relay.endpoint,
+                    relay.queryJSON,
+                    relay.headersJSON,
+                    relay.subprotocol,
+                    timeoutMillis.toLong().coerceAtLeast(1),
+                )
+                return@runAsync requestAgentHTTPWithStream(
+                    stream,
+                    method,
+                    path,
+                    body,
+                    timeoutMillis.toLong(),
+                )
+            }
             if (selected != null) {
-                try {
-                    return@runAsync requestAgentHTTPWithStream(
-                        selected.openStream(timeoutMillis.toLong().coerceAtLeast(1)),
-                        method,
-                        path,
-                        body,
-                        timeoutMillis.toLong(),
-                    )
-                } catch (error: Throwable) {
-                    directFailure = error
-                }
+                val stream = selected.openStream(timeoutMillis.toLong().coerceAtLeast(1))
+                return@runAsync requestAgentHTTPWithStream(
+                    stream,
+                    method,
+                    path,
+                    body,
+                    timeoutMillis.toLong(),
+                )
             }
             if (relay != null) {
-                try {
-                    return@runAsync requestAgentHTTPWithStream(
-                        Mobile.dialRelay(
-                            relay.endpoint,
-                            relay.queryJSON,
-                            relay.headersJSON,
-                            relay.subprotocol,
-                            timeoutMillis.toLong(),
-                        ),
-                        method,
-                        path,
-                        body,
+                return@runAsync requestAgentHTTPWithStream(
+                    Mobile.dialRelay(
+                        relay.endpoint,
+                        relay.queryJSON,
+                        relay.headersJSON,
+                        relay.subprotocol,
                         timeoutMillis.toLong(),
-                    )
-                } catch (error: Throwable) {
-                    if (directFailure != null) {
-                        throw IllegalStateException("direct and Relay Agent requests failed", error)
-                    }
-                    throw error
-                }
+                    ),
+                    method,
+                    path,
+                    body,
+                    timeoutMillis.toLong(),
+                )
             }
-            throw directFailure ?: IllegalStateException("DeviceLink request failed")
+            throw IllegalStateException("DeviceLink request is not configured")
         }
     }
 
@@ -695,6 +700,15 @@ class DeviceLinkModule(
         relay: RelayConfig?,
         timeoutMillis: Long,
     ): Stream {
+        if (selected != null && relay != null) {
+            return selected.openStreamWithRelay(
+                relay.endpoint,
+                relay.queryJSON,
+                relay.headersJSON,
+                relay.subprotocol,
+                timeoutMillis,
+            )
+        }
         var directFailure: Throwable? = null
         if (selected != null) {
             try {

--- a/apps/mobile/android/app/src/main/java/dev/tutti/mobile/DeviceLinkModule.kt
+++ b/apps/mobile/android/app/src/main/java/dev/tutti/mobile/DeviceLinkModule.kt
@@ -14,6 +14,7 @@ import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.modules.core.DeviceEventManagerModule
 import dev.tutti.mobile.bindings.liveprotocolmobile.Liveprotocolmobile
@@ -167,6 +168,48 @@ class DeviceLinkModule(
             )
         }
         promise.resolve(null)
+    }
+
+    @ReactMethod
+    fun probeRelay(timeoutMillis: Double, promise: Promise) {
+        val relay = relaySnapshot()
+        if (relay == null) {
+            promise.reject(
+                "DEVICE_LINK_RELAY_PROBE_FAILED",
+                "DeviceLink Relay is not configured",
+            )
+            return
+        }
+        val timeout = timeoutMillis.toLong().coerceAtLeast(1)
+        runAsync(
+            promise,
+            "DEVICE_LINK_RELAY_PROBE_FAILED",
+            "Relay peer handshake failed",
+        ) {
+            val response =
+                requestAgentHTTPWithStream(
+                    Mobile.dialRelay(
+                        relay.endpoint,
+                        relay.queryJSON,
+                        relay.headersJSON,
+                        relay.subprotocol,
+                        timeout,
+                    ),
+                    "GET",
+                    "/v1/preferences/desktop",
+                    "",
+                    timeout,
+                )
+            val protocolEpoch = response.getInt("protocolEpoch")
+            require(protocolEpoch.toLong() == Mobile.protocolEpoch()) {
+                "Relay peer uses an unsupported DeviceLink protocol epoch"
+            }
+            val status = response.getInt("status")
+            require(status in 200..299) {
+                "Relay peer control request returned HTTP $status"
+            }
+            null
+        }
     }
 
     @ReactMethod
@@ -624,7 +667,7 @@ class DeviceLinkModule(
         path: String,
         body: String,
         timeoutMillis: Long,
-    ): Any {
+    ): ReadableMap {
         val timeout = timeoutMillis.coerceAtLeast(1)
         val deadline = SystemClock.elapsedRealtime() + timeout
         try {

--- a/apps/mobile/ios/TuttiMobile.xcodeproj/project.pbxproj
+++ b/apps/mobile/ios/TuttiMobile.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		A10000000000000000000009 /* AppLifecycleModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000010 /* AppLifecycleModule.swift */; };
 		A10000000000000000000010 /* MobileWebAuthenticationSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000011 /* MobileWebAuthenticationSession.swift */; };
 		A10000000000000000000011 /* MobilePreferencesModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000012 /* MobilePreferencesModule.swift */; };
+		A10000000000000000000012 /* DeviceLinkRelayProbe.mm in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000013 /* DeviceLinkRelayProbe.mm */; settings = {COMPILER_FLAGS = "-fcxx-modules"; }; };
+		A10000000000000000000013 /* DeviceLinkFraming.mm in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000015 /* DeviceLinkFraming.mm */; settings = {COMPILER_FLAGS = "-fcxx-modules"; }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -46,6 +48,10 @@
 		A20000000000000000000010 /* AppLifecycleModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppLifecycleModule.swift; path = TuttiMobile/AppLifecycleModule.swift; sourceTree = "<group>"; };
 		A20000000000000000000011 /* MobileWebAuthenticationSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MobileWebAuthenticationSession.swift; path = TuttiMobile/MobileWebAuthenticationSession.swift; sourceTree = "<group>"; };
 		A20000000000000000000012 /* MobilePreferencesModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MobilePreferencesModule.swift; path = TuttiMobile/MobilePreferencesModule.swift; sourceTree = "<group>"; };
+		A20000000000000000000013 /* DeviceLinkRelayProbe.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = DeviceLinkRelayProbe.mm; path = TuttiMobile/DeviceLinkRelayProbe.mm; sourceTree = "<group>"; };
+		A20000000000000000000014 /* DeviceLinkRelayProbe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DeviceLinkRelayProbe.h; path = TuttiMobile/DeviceLinkRelayProbe.h; sourceTree = "<group>"; };
+		A20000000000000000000015 /* DeviceLinkFraming.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = DeviceLinkFraming.mm; path = TuttiMobile/DeviceLinkFraming.mm; sourceTree = "<group>"; };
+		A20000000000000000000016 /* DeviceLinkFraming.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DeviceLinkFraming.h; path = TuttiMobile/DeviceLinkFraming.h; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -68,6 +74,10 @@
 				761780EC2CA45674006654EE /* AppDelegate.swift */,
 				A20000000000000000000010 /* AppLifecycleModule.swift */,
 				A20000000000000000000005 /* DeviceLinkModule.mm */,
+				A20000000000000000000013 /* DeviceLinkRelayProbe.mm */,
+				A20000000000000000000014 /* DeviceLinkRelayProbe.h */,
+				A20000000000000000000015 /* DeviceLinkFraming.mm */,
+				A20000000000000000000016 /* DeviceLinkFraming.h */,
 				A20000000000000000000002 /* MobileBrowserAuthBridge.swift */,
 				A20000000000000000000011 /* MobileWebAuthenticationSession.swift */,
 				A20000000000000000000012 /* MobilePreferencesModule.swift */,
@@ -286,6 +296,8 @@
 				A10000000000000000000004 /* MobileNativeModules.m in Sources */,
 				A10000000000000000000009 /* AppLifecycleModule.swift in Sources */,
 				A10000000000000000000005 /* DeviceLinkModule.mm in Sources */,
+				A10000000000000000000012 /* DeviceLinkRelayProbe.mm in Sources */,
+				A10000000000000000000013 /* DeviceLinkFraming.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/mobile/ios/TuttiMobile/DeviceLinkFraming.h
+++ b/apps/mobile/ios/TuttiMobile/DeviceLinkFraming.h
@@ -1,0 +1,16 @@
+#import <Foundation/Foundation.h>
+#import <TuttiMobileGo/TUTMobile.objc.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+FOUNDATION_EXPORT BOOL TUTDeviceLinkWriteFully(TUTMobileStream *stream,
+                                               NSData *payload,
+                                               NSError **error);
+FOUNDATION_EXPORT NSData *_Nullable
+TUTDeviceLinkReadFully(TUTMobileStream *stream, NSUInteger size,
+                       NSError **error);
+FOUNDATION_EXPORT NSData *TUTDeviceLinkFrame(NSData *payload);
+FOUNDATION_EXPORT NSUInteger TUTDeviceLinkReadFrameSize(
+    TUTMobileStream *stream, NSUInteger maximum, NSError **error);
+
+NS_ASSUME_NONNULL_END

--- a/apps/mobile/ios/TuttiMobile/DeviceLinkFraming.mm
+++ b/apps/mobile/ios/TuttiMobile/DeviceLinkFraming.mm
@@ -1,0 +1,85 @@
+#import "DeviceLinkFraming.h"
+
+static const NSUInteger TUTDeviceLinkFramingMaxReadChunk = 1 << 20;
+
+static NSError *TUTDeviceLinkFramingError(NSString *code, NSString *message) {
+  return [NSError errorWithDomain:@"dev.tutti.mobile.device-link"
+                             code:1
+                         userInfo:@{
+                           NSLocalizedDescriptionKey : message,
+                           @"code" : code,
+                         }];
+}
+
+BOOL TUTDeviceLinkWriteFully(TUTMobileStream *stream, NSData *payload,
+                             NSError **error) {
+  NSUInteger offset = 0;
+  while (offset < payload.length) {
+    NSData *chunk = offset == 0
+                        ? payload
+                        : [payload subdataWithRange:NSMakeRange(
+                              offset, payload.length - offset)];
+    long written = 0;
+    if (![stream write:chunk ret0_:&written error:error]) {
+      return NO;
+    }
+    if (written <= 0 || (NSUInteger)written > chunk.length) {
+      if (error != NULL) {
+        *error = TUTDeviceLinkFramingError(
+            @"INVALID_WRITE",
+            @"DeviceLink stream returned an invalid write count");
+      }
+      return NO;
+    }
+    offset += (NSUInteger)written;
+  }
+  return YES;
+}
+
+NSData *TUTDeviceLinkReadFully(TUTMobileStream *stream, NSUInteger size,
+                               NSError **error) {
+  NSMutableData *output = [NSMutableData dataWithCapacity:size];
+  while (output.length < size) {
+    NSUInteger remaining = size - output.length;
+    NSMutableData *chunk = [NSMutableData
+        dataWithLength:MIN(remaining, TUTDeviceLinkFramingMaxReadChunk)];
+    long count = [stream readInto:chunk];
+    if (count <= 0 || (NSUInteger)count > chunk.length) {
+      if (error != NULL) {
+        *error = TUTDeviceLinkFramingError(
+            @"INCOMPLETE_FRAME",
+            @"DeviceLink stream closed before the response completed");
+      }
+      return nil;
+    }
+    [output appendBytes:chunk.bytes length:(NSUInteger)count];
+  }
+  return output;
+}
+
+NSData *TUTDeviceLinkFrame(NSData *payload) {
+  uint32_t size = CFSwapInt32HostToBig((uint32_t)payload.length);
+  NSMutableData *framed =
+      [NSMutableData dataWithBytes:&size length:sizeof(size)];
+  [framed appendData:payload];
+  return framed;
+}
+
+NSUInteger TUTDeviceLinkReadFrameSize(TUTMobileStream *stream,
+                                      NSUInteger maximum, NSError **error) {
+  NSData *header = TUTDeviceLinkReadFully(stream, sizeof(uint32_t), error);
+  if (header == nil) {
+    return 0;
+  }
+  uint32_t encoded = 0;
+  [header getBytes:&encoded length:sizeof(encoded)];
+  NSUInteger size = (NSUInteger)CFSwapInt32BigToHost(encoded);
+  if (size == 0 || size > maximum) {
+    if (error != NULL) {
+      *error = TUTDeviceLinkFramingError(
+          @"INVALID_FRAME", @"DeviceLink frame size is invalid");
+    }
+    return 0;
+  }
+  return size;
+}

--- a/apps/mobile/ios/TuttiMobile/DeviceLinkModule.mm
+++ b/apps/mobile/ios/TuttiMobile/DeviceLinkModule.mm
@@ -5,6 +5,8 @@
 #import <TuttiMobileGo/TUTLiveprotocolmobile.objc.h>
 #import <TuttiMobileGo/TUTMobile.objc.h>
 #import <UIKit/UIKit.h>
+#import "DeviceLinkFraming.h"
+#import "DeviceLinkRelayProbe.h"
 
 static NSString *const TUTAgentLiveEventName = @"TuttiDeviceLinkAgentLive";
 static const int64_t TUTAgentLiveOpenTimeoutMillis = 10000;
@@ -42,79 +44,6 @@ static NSDictionary *TUTJSONObject(NSData *data, NSError **error) {
     return nil;
   }
   return value;
-}
-
-static BOOL TUTWriteFully(TUTMobileStream *stream, NSData *payload,
-                          NSError **error) {
-  NSUInteger offset = 0;
-  while (offset < payload.length) {
-    NSData *chunk = offset == 0
-                        ? payload
-                        : [payload subdataWithRange:NSMakeRange(
-                              offset, payload.length - offset)];
-    long written = 0;
-    if (![stream write:chunk ret0_:&written error:error]) {
-      return NO;
-    }
-    if (written <= 0 || (NSUInteger)written > chunk.length) {
-      if (error != NULL) {
-        *error = TUTDeviceLinkError(
-            @"INVALID_WRITE",
-            @"DeviceLink stream returned an invalid write count");
-      }
-      return NO;
-    }
-    offset += (NSUInteger)written;
-  }
-  return YES;
-}
-
-static NSData *TUTReadFully(TUTMobileStream *stream, NSUInteger size,
-                            NSError **error) {
-  NSMutableData *output = [NSMutableData dataWithCapacity:size];
-  while (output.length < size) {
-    NSUInteger remaining = size - output.length;
-    NSMutableData *chunk =
-        [NSMutableData dataWithLength:MIN(remaining, TUTMaxReadChunk)];
-    long count = [stream readInto:chunk];
-    if (count <= 0 || (NSUInteger)count > chunk.length) {
-      if (error != NULL) {
-        *error = TUTDeviceLinkError(
-            @"INCOMPLETE_FRAME",
-            @"DeviceLink stream closed before the response completed");
-      }
-      return nil;
-    }
-    [output appendBytes:chunk.bytes length:(NSUInteger)count];
-  }
-  return output;
-}
-
-static NSData *TUTFrame(NSData *payload) {
-  uint32_t size = CFSwapInt32HostToBig((uint32_t)payload.length);
-  NSMutableData *framed =
-      [NSMutableData dataWithBytes:&size length:sizeof(size)];
-  [framed appendData:payload];
-  return framed;
-}
-
-static NSUInteger TUTReadFrameSize(TUTMobileStream *stream, NSUInteger maximum,
-                                   NSError **error) {
-  NSData *header = TUTReadFully(stream, sizeof(uint32_t), error);
-  if (header == nil) {
-    return 0;
-  }
-  uint32_t encoded = 0;
-  [header getBytes:&encoded length:sizeof(encoded)];
-  NSUInteger size = (NSUInteger)CFSwapInt32BigToHost(encoded);
-  if (size == 0 || size > maximum) {
-    if (error != NULL) {
-      *error = TUTDeviceLinkError(@"INVALID_FRAME",
-                                  @"DeviceLink frame size is invalid");
-    }
-    return 0;
-  }
-  return size;
 }
 
 @interface TuttiDeviceLink : RCTEventEmitter <RCTBridgeModule>
@@ -300,6 +229,38 @@ RCT_REMAP_METHOD(configureRelay,
   resolve(nil);
 }
 
+RCT_REMAP_METHOD(probeRelay,
+                 probeRelay:(double)timeoutMillis
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+  NSDictionary *relay = [self relaySnapshot];
+  if (relay == nil) {
+    reject(@"DEVICE_LINK_RELAY_PROBE_FAILED",
+           @"DeviceLink Relay is not configured", nil);
+    return;
+  }
+  int64_t timeout = MAX((int64_t)timeoutMillis, 1);
+  TUTDeviceLinkProbeRelay(
+      relay, timeout, self.operationQueue,
+      ^NSDictionary *(TUTMobileStream *stream, int64_t requestTimeout,
+                       NSError **error) {
+        return [self requestAgentHTTPWithStream:stream
+                                          method:@"GET"
+                                            path:@"/v1/preferences/desktop"
+                                            body:@""
+                                     timeoutMillis:requestTimeout
+                                             error:error];
+      },
+      ^(NSError *error) {
+        if (error != nil) {
+          reject(@"DEVICE_LINK_RELAY_PROBE_FAILED", @"Relay peer handshake failed",
+                 error);
+          return;
+        }
+        resolve(nil);
+      });
+}
+
 RCT_REMAP_METHOD(requestAgentHTTP,
                  requestAgentHTTP:(NSString *)method
                  path:(NSString *)path
@@ -431,7 +392,8 @@ RCT_REMAP_METHOD(startAgentLive,
     };
     NSData *requestData = TUTJSONData(request, &error);
     if (requestData == nil || requestData.length > TUTMaxRequestFrameBytes ||
-        !TUTWriteFully(stream, TUTFrame(requestData), &error)) {
+        !TUTDeviceLinkWriteFully(stream, TUTDeviceLinkFrame(requestData),
+                                 &error)) {
       [self clearAgentLiveStream:stream generation:generation];
       [self closeDetachedStream:stream];
       reject(@"AGENT_LIVE_SUBSCRIBE_FAILED",
@@ -442,11 +404,12 @@ RCT_REMAP_METHOD(startAgentLive,
     resolve(nil);
     while ([self isAgentLiveCurrent:stream generation:generation]) {
       NSUInteger size =
-          TUTReadFrameSize(stream, TUTMaxAgentLiveFrameBytes, &error);
+          TUTDeviceLinkReadFrameSize(stream, TUTMaxAgentLiveFrameBytes,
+                                     &error);
       if (size == 0) {
         break;
       }
-      NSData *frame = TUTReadFully(stream, size, &error);
+      NSData *frame = TUTDeviceLinkReadFully(stream, size, &error);
       NSString *result =
           frame == nil ? nil
                        : [subscriber apply:frame error:&error];
@@ -567,15 +530,16 @@ RCT_REMAP_METHOD(closeLink,
     if (payload == nil || payload.length > TUTMaxRequestFrameBytes) {
       return nil;
     }
-    if (!TUTWriteFully(stream, TUTFrame(payload), error)) {
+    if (!TUTDeviceLinkWriteFully(stream, TUTDeviceLinkFrame(payload), error)) {
       return nil;
     }
     NSUInteger responseSize =
-        TUTReadFrameSize(stream, TUTMaxResponseFrameBytes, error);
+        TUTDeviceLinkReadFrameSize(stream, TUTMaxResponseFrameBytes, error);
     if (responseSize == 0) {
       return nil;
     }
-    NSData *responseData = TUTReadFully(stream, responseSize, error);
+    NSData *responseData =
+        TUTDeviceLinkReadFully(stream, responseSize, error);
     if (responseData == nil) {
       return nil;
     }

--- a/apps/mobile/ios/TuttiMobile/DeviceLinkModule.mm
+++ b/apps/mobile/ios/TuttiMobile/DeviceLinkModule.mm
@@ -318,13 +318,13 @@ RCT_REMAP_METHOD(requestAgentHTTP,
     NSDictionary *response = nil;
     if (selected != nil) {
       response = [self requestAgentHTTPWithLink:selected
+                                          relay:relay
                                          method:method
                                            path:path
                                            body:body
-                                  timeoutMillis:(int64_t)timeoutMillis
+                                          timeoutMillis:(int64_t)timeoutMillis
                                           error:&error];
-    }
-    if (response == nil && relay != nil) {
+    } else if (relay != nil) {
       NSError *relayError = nil;
       TUTMobileStream *stream = TUTMobileDialRelay(
           relay[@"endpoint"], relay[@"queryJSON"], relay[@"headersJSON"],
@@ -339,7 +339,7 @@ RCT_REMAP_METHOD(requestAgentHTTP,
       }
       if (response != nil) {
         error = nil;
-      } else if (error == nil) {
+      } else {
         error = relayError;
       }
     }
@@ -498,13 +498,24 @@ RCT_REMAP_METHOD(closeLink,
 }
 
 - (NSDictionary *)requestAgentHTTPWithLink:(TUTMobileLink *)link
+                                     relay:(NSDictionary *)relay
                                     method:(NSString *)method
                                       path:(NSString *)path
                                      body:(NSString *)body
                             timeoutMillis:(int64_t)timeoutMillis
                                      error:(NSError **)error {
   int64_t timeout = MAX(timeoutMillis, 1);
-  TUTMobileStream *stream = [link openStream:timeout error:error];
+  TUTMobileStream *stream = nil;
+  if (relay != nil) {
+    stream = [link openStreamWithRelay:relay[@"endpoint"]
+                              queryJSON:relay[@"queryJSON"]
+                            headersJSON:relay[@"headersJSON"]
+                            subprotocol:relay[@"subprotocol"]
+                          timeoutMillis:timeout
+                                  error:error];
+  } else {
+    stream = [link openStream:timeout error:error];
+  }
   if (stream == nil) {
     return nil;
   }
@@ -620,14 +631,28 @@ RCT_REMAP_METHOD(closeLink,
 
 - (TUTMobileStream *)openAgentStream:(TUTMobileLink *)link
                                relay:(NSDictionary *)relay
-                       timeoutMillis:(int64_t)timeoutMillis
+                               timeoutMillis:(int64_t)timeoutMillis
                                error:(NSError **)error {
   NSError *directError = nil;
   if (link != nil) {
-    TUTMobileStream *stream = [link openStream:MAX(timeoutMillis, 1)
-                                         error:&directError];
+    TUTMobileStream *stream = relay != nil
+                                  ? [link openStreamWithRelay:
+                                           relay[@"endpoint"]
+                                             queryJSON:relay[@"queryJSON"]
+                                           headersJSON:relay[@"headersJSON"]
+                                           subprotocol:relay[@"subprotocol"]
+                                         timeoutMillis:MAX(timeoutMillis, 1)
+                                                 error:&directError]
+                                  : [link openStream:MAX(timeoutMillis, 1)
+                                               error:&directError];
     if (stream != nil) {
       return stream;
+    }
+    if (relay != nil) {
+      if (error != NULL) {
+        *error = directError;
+      }
+      return nil;
     }
   }
   if (relay != nil) {

--- a/apps/mobile/ios/TuttiMobile/DeviceLinkRelayProbe.h
+++ b/apps/mobile/ios/TuttiMobile/DeviceLinkRelayProbe.h
@@ -1,0 +1,15 @@
+#import <Foundation/Foundation.h>
+#import <TuttiMobileGo/TUTMobile.objc.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NSDictionary *_Nullable (^TUTDeviceLinkRelayRequest)(
+    TUTMobileStream *stream, int64_t timeoutMillis, NSError **error);
+typedef void (^TUTDeviceLinkRelayProbeCompletion)(NSError *_Nullable error);
+
+FOUNDATION_EXPORT void TUTDeviceLinkProbeRelay(
+    NSDictionary *relay, int64_t timeoutMillis, dispatch_queue_t queue,
+    TUTDeviceLinkRelayRequest request,
+    TUTDeviceLinkRelayProbeCompletion completion);
+
+NS_ASSUME_NONNULL_END

--- a/apps/mobile/ios/TuttiMobile/DeviceLinkRelayProbe.mm
+++ b/apps/mobile/ios/TuttiMobile/DeviceLinkRelayProbe.mm
@@ -1,0 +1,42 @@
+#import "DeviceLinkRelayProbe.h"
+
+static NSError *TUTRelayProbeError(NSString *message) {
+  return [NSError errorWithDomain:@"dev.tutti.mobile.device-link.relay-probe"
+                             code:1
+                         userInfo:@{NSLocalizedDescriptionKey : message}];
+}
+
+void TUTDeviceLinkProbeRelay(
+    NSDictionary *relay, int64_t timeoutMillis, dispatch_queue_t queue,
+    TUTDeviceLinkRelayRequest request,
+    TUTDeviceLinkRelayProbeCompletion completion) {
+  dispatch_async(queue, ^{
+    NSError *error = nil;
+    TUTMobileStream *stream = TUTMobileDialRelay(
+        relay[@"endpoint"], relay[@"queryJSON"], relay[@"headersJSON"],
+        relay[@"subprotocol"], timeoutMillis, &error);
+    NSDictionary *response = nil;
+    if (stream != nil && error == nil) {
+      response = request(stream, timeoutMillis, &error);
+    }
+    if (response == nil || error != nil) {
+      completion(error ?: TUTRelayProbeError(@"Relay peer handshake failed"));
+      return;
+    }
+    NSNumber *protocolEpoch = response[@"protocolEpoch"];
+    if (![protocolEpoch isKindOfClass:[NSNumber class]] ||
+        protocolEpoch.longLongValue != TUTMobileProtocolEpoch()) {
+      completion(TUTRelayProbeError(
+          @"Relay peer uses an unsupported DeviceLink protocol epoch"));
+      return;
+    }
+    NSInteger status = [response[@"status"] integerValue];
+    if (status < 200 || status > 299) {
+      completion(TUTRelayProbeError([NSString stringWithFormat:
+                                                  @"Relay peer control request returned HTTP %ld",
+                                                  (long)status]));
+      return;
+    }
+    completion(nil);
+  });
+}

--- a/apps/mobile/src/native/mobileNative.ts
+++ b/apps/mobile/src/native/mobileNative.ts
@@ -47,6 +47,7 @@ interface DeviceLinkNative {
     headersJSON: string,
     subprotocol: string
   ) => Promise<void>;
+  probeRelay(timeoutMillis: number): Promise<void>;
   connectLink(
     peerDescriptionJSON: string,
     caller: boolean,

--- a/apps/mobile/src/services/pairingClient.test.ts
+++ b/apps/mobile/src/services/pairingClient.test.ts
@@ -1,7 +1,10 @@
 jest.mock("../native/mobileNative", () => ({
   __esModule: true,
   deviceLink: {
-    configureRelay: jest.fn()
+    closeLink: jest.fn(),
+    configureRelay: jest.fn(),
+    connectLink: jest.fn(),
+    prepareLink: jest.fn()
   },
   mobileSecurity: {
     getOrCreateIdentity: jest.fn(),
@@ -9,9 +12,10 @@ jest.mock("../native/mobileNative", () => ({
   }
 }));
 
-import { mobileSecurity } from "../native/mobileNative";
+import { deviceLink, mobileSecurity } from "../native/mobileNative";
 import {
   claimPairing,
+  connectPairedDevice,
   issueAgentRelayDescriptor,
   registerCurrentDevice
 } from "./pairingClient";
@@ -26,6 +30,10 @@ import { PAIRING_OPERATION_SUSPENDED } from "./servicePorts";
 
 const mockGetOrCreateIdentity = jest.mocked(mobileSecurity.getOrCreateIdentity);
 const mockSign = jest.mocked(mobileSecurity.sign);
+const mockCloseLink = jest.mocked(deviceLink.closeLink);
+const mockConfigureRelay = jest.mocked(deviceLink.configureRelay!);
+const mockConnectLink = jest.mocked(deviceLink.connectLink);
+const mockPrepareLink = jest.mocked(deviceLink.prepareLink);
 
 function controlPlaneResponse(data: unknown): Response {
   return {
@@ -160,6 +168,88 @@ describe("control-plane authentication", () => {
         publicKey: "cHVibGljLWtleQ"
       })
     ).rejects.toThrow("control-plane Relay descriptor is incomplete");
+  });
+
+  it("returns the existing path scope while Relay is ready first", async () => {
+    mockGetOrCreateIdentity.mockResolvedValue({
+      arch: "arm64",
+      deviceId: "device-1",
+      deviceName: "Alice's iPhone",
+      publicKey: "cHVibGljLWtleQ"
+    });
+    mockSign.mockResolvedValue("signature");
+    let resolvePrepareLink!: (value: {
+      descriptionJSON: string;
+      token: number;
+    }) => void;
+    mockPrepareLink.mockReturnValue(
+      new Promise((resolve) => {
+        resolvePrepareLink = resolve;
+      })
+    );
+    mockConfigureRelay.mockResolvedValue(undefined);
+    mockConnectLink.mockResolvedValue("local_subnet");
+    globalThis.fetch = jest.fn().mockImplementation((input: RequestInfo) => {
+      const url = String(input);
+      if (url.endsWith("/devices/current")) {
+        return Promise.resolve(
+          controlPlaneResponse({ device: { userDeviceId: "user-device-1" } })
+        );
+      }
+      if (url.includes("/agent-relay-descriptor")) {
+        return Promise.resolve(
+          controlPlaneResponse({
+            authorityId: "authority-1",
+            relayDialEndpoint: "wss://relay.example.test/v1/tunnels/dial",
+            token: "target-token",
+            tokenExpiresAt: "2026-08-04T10:00:00Z"
+          })
+        );
+      }
+      if (url.includes("/device-link-attempts")) {
+        return Promise.resolve(
+          controlPlaneResponse({
+            attempt: {
+              attemptId: "attempt-1",
+              callerFingerprint: "fingerprint-1",
+              callerIce: {
+                candidates: ["candidate:local"],
+                pwd: "password",
+                ufrag: "username"
+              },
+              expiresAt: "2026-08-04T10:00:30Z",
+              ownerFingerprint: "owner-fingerprint-1",
+              ownerIce: {
+                candidates: ["candidate:owner"],
+                pwd: "owner-password",
+                ufrag: "owner-username"
+              },
+              state: "ready"
+            }
+          })
+        );
+      }
+      throw new Error(`unexpected control-plane request: ${url}`);
+    });
+
+    await expect(connectPairedDevice("session-1", "pairing-1")).resolves.toBe(
+      "private_network"
+    );
+    expect(mockConfigureRelay).toHaveBeenCalledTimes(1);
+    expect(mockConnectLink).not.toHaveBeenCalled();
+    expect(mockCloseLink).not.toHaveBeenCalled();
+
+    resolvePrepareLink({
+      descriptionJSON: JSON.stringify({
+        candidates: ["candidate:local"],
+        fingerprint: "fingerprint-1",
+        pwd: "password",
+        ufrag: "username"
+      }),
+      token: 1
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mockConnectLink).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/mobile/src/services/pairingClient.test.ts
+++ b/apps/mobile/src/services/pairingClient.test.ts
@@ -4,7 +4,8 @@ jest.mock("../native/mobileNative", () => ({
     closeLink: jest.fn(),
     configureRelay: jest.fn(),
     connectLink: jest.fn(),
-    prepareLink: jest.fn()
+    prepareLink: jest.fn(),
+    probeRelay: jest.fn()
   },
   mobileSecurity: {
     getOrCreateIdentity: jest.fn(),
@@ -34,6 +35,7 @@ const mockCloseLink = jest.mocked(deviceLink.closeLink);
 const mockConfigureRelay = jest.mocked(deviceLink.configureRelay!);
 const mockConnectLink = jest.mocked(deviceLink.connectLink);
 const mockPrepareLink = jest.mocked(deviceLink.prepareLink);
+const mockProbeRelay = jest.mocked(deviceLink.probeRelay);
 
 function controlPlaneResponse(data: unknown): Response {
   return {
@@ -188,6 +190,12 @@ describe("control-plane authentication", () => {
       })
     );
     mockConfigureRelay.mockResolvedValue(undefined);
+    let resolveProbeRelay!: () => void;
+    mockProbeRelay.mockReturnValue(
+      new Promise((resolve) => {
+        resolveProbeRelay = resolve;
+      })
+    );
     mockConnectLink.mockResolvedValue("local_subnet");
     globalThis.fetch = jest.fn().mockImplementation((input: RequestInfo) => {
       const url = String(input);
@@ -217,7 +225,7 @@ describe("control-plane authentication", () => {
                 pwd: "password",
                 ufrag: "username"
               },
-              expiresAt: "2026-08-04T10:00:30Z",
+              expiresAt: new Date(Date.now() + 30_000).toISOString(),
               ownerFingerprint: "owner-fingerprint-1",
               ownerIce: {
                 candidates: ["candidate:owner"],
@@ -232,12 +240,22 @@ describe("control-plane authentication", () => {
       throw new Error(`unexpected control-plane request: ${url}`);
     });
 
-    await expect(connectPairedDevice("session-1", "pairing-1")).resolves.toBe(
-      "private_network"
+    let settled = false;
+    const connection = connectPairedDevice("session-1", "pairing-1").then(
+      (scope) => {
+        settled = true;
+        return scope;
+      }
     );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(settled).toBe(false);
     expect(mockConfigureRelay).toHaveBeenCalledTimes(1);
+    expect(mockProbeRelay).toHaveBeenCalledWith(10_000);
     expect(mockConnectLink).not.toHaveBeenCalled();
     expect(mockCloseLink).not.toHaveBeenCalled();
+
+    resolveProbeRelay();
+    await expect(connection).resolves.toBe("private_network");
 
     resolvePrepareLink({
       descriptionJSON: JSON.stringify({
@@ -248,7 +266,13 @@ describe("control-plane authentication", () => {
       }),
       token: 1
     });
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    for (
+      let attempt = 0;
+      attempt < 20 && !mockConnectLink.mock.calls.length;
+      attempt += 1
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
     expect(mockConnectLink).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/mobile/src/services/pairingClient.ts
+++ b/apps/mobile/src/services/pairingClient.ts
@@ -19,6 +19,7 @@ import {
   type PairingQRPayload
 } from "./pairingProtocol";
 import { PAIRING_OPERATION_SUSPENDED } from "./servicePorts";
+import { raceSuccessful } from "./pairingTransportRace";
 
 interface RegisteredDevice {
   userDeviceId: string;
@@ -131,103 +132,55 @@ export async function connectPairedDevice(
   isCurrent: () => boolean = () => true
 ): Promise<DeviceLinkPathScope> {
   const identity = await mobileSecurity.getOrCreateIdentity();
-  await requireCurrentConnection(isCurrent);
+  requireCurrentConnection(isCurrent);
   await registerIdentity(sessionId, identity);
-  await requireCurrentConnection(isCurrent);
-  const relayDescriptorTask = issueAgentRelayDescriptor(
+  requireCurrentConnection(isCurrent);
+  const relayController = new AbortController();
+  const directController = new AbortController();
+  const directTask = connectDirectDevice(
     sessionId,
     pairingId,
-    identity
-  )
-    .then(async (descriptor) => {
-      if (!isCurrent() || typeof deviceLink.configureRelay !== "function") {
-        return null;
-      }
-      await deviceLink.configureRelay(
-        descriptor.relayDialEndpoint,
-        JSON.stringify({
-          authority_id: [descriptor.authorityId],
-          channel: ["agent"],
-          target: ["device-gateway"]
-        }),
-        JSON.stringify({
-          Authorization: [`Bearer ${descriptor.token}`]
-        }),
-        RELAY_STREAM_SUBPROTOCOL
-      );
-      return isCurrent() ? descriptor : null;
-    })
-    .catch(() => null);
+    identity,
+    isCurrent,
+    directController.signal
+  );
+  const relayTask = configureRelayTransport(
+    sessionId,
+    pairingId,
+    identity,
+    isCurrent,
+    relayController.signal
+  );
   try {
-    let prepared = await deviceLink.prepareLink("[]", 10_000);
-    let local = parseDeviceLinkDescription(prepared.descriptionJSON);
-    await requireCurrentConnection(isCurrent);
-    let attempt = await createDeviceLinkAttempt(
-      sessionId,
-      identity.deviceId,
-      pairingId,
-      local
-    );
-    await requireCurrentConnection(isCurrent);
-    if ((attempt.stunEndpoints?.length ?? 0) > 0) {
-      prepared = await deviceLink.prepareLink(
-        JSON.stringify(attempt.stunEndpoints),
-        10_000
-      );
-      local = parseDeviceLinkDescription(prepared.descriptionJSON);
-      await requireCurrentConnection(isCurrent);
-      attempt = await updateDeviceLinkParticipant(
-        sessionId,
-        identity.deviceId,
-        pairingId,
-        attempt.attemptId,
-        local
-      );
-      await requireCurrentConnection(isCurrent);
-    }
-    const getSignature = standardBase64ToURL(
-      await mobileSecurity.sign(
-        deviceLinkProof("get", pairingId, attempt.attemptId, "")
-      )
-    );
-    const deadline = Date.parse(attempt.expiresAt);
-    while (Date.now() < deadline) {
-      if (
-        attempt.state === "ready" &&
-        attempt.ownerIce &&
-        attempt.ownerFingerprint
-      ) {
-        const scope = await deviceLink.connectLink(
-          JSON.stringify({
-            candidates: attempt.ownerIce.candidates,
-            fingerprint: attempt.ownerFingerprint,
-            pwd: attempt.ownerIce.pwd,
-            ufrag: attempt.ownerIce.ufrag
-          }),
-          true,
-          prepared.token,
-          30_000
-        );
-        await requireCurrentConnection(isCurrent);
-        return normalizeDeviceLinkPathScope(scope);
+    const winner = await raceSuccessful<
+      DeviceLinkPathScope | AgentRelayDescriptor
+    >([
+      {
+        name: "direct",
+        run: () => directTask
+      },
+      {
+        name: "relay",
+        run: async () => (await relayTask) ?? null
       }
-      await delay(500);
-      await requireCurrentConnection(isCurrent);
-      attempt = await getDeviceLinkAttempt(
-        sessionId,
-        identity.deviceId,
-        pairingId,
-        attempt.attemptId,
-        getSignature
-      );
-      await requireCurrentConnection(isCurrent);
-    }
-    if (await relayDescriptorTask) {
-      await requireCurrentConnection(isCurrent);
+    ]);
+    requireCurrentConnection(isCurrent);
+    if (winner.name === "relay") {
+      // A Relay descriptor only makes the fallback dialable; it does not prove
+      // that the Relay stream is usable. Keep direct rendezvous running so a
+      // later data-stream race still has a direct candidate if Relay fails.
+      // Relay is an internal transport fallback. Keep the existing path scope
+      // contract consumed by the UI and workspace services unchanged.
       return "private_network";
     }
-    throw new Error("device-link attempt expired");
+    // Direct is already usable. Do not leave a control-plane descriptor
+    // request running after the connection lifecycle has returned; a later
+    // reconnect will request a fresh Relay descriptor if it needs one.
+    relayController.abort();
+    return winner.value as DeviceLinkPathScope;
   } catch (error) {
+    relayController.abort();
+    directController.abort();
     if (isCurrent()) {
       await deviceLink.closeLink().catch(() => undefined);
     }
@@ -235,10 +188,120 @@ export async function connectPairedDevice(
   }
 }
 
+async function connectDirectDevice(
+  sessionId: string,
+  pairingId: string,
+  identity: DeviceIdentity,
+  isCurrent: () => boolean,
+  signal: AbortSignal
+): Promise<DeviceLinkPathScope> {
+  let prepared = await deviceLink.prepareLink("[]", 10_000);
+  let local = parseDeviceLinkDescription(prepared.descriptionJSON);
+  requireCurrentConnection(isCurrent, signal);
+  let attempt = await createDeviceLinkAttempt(
+    sessionId,
+    identity.deviceId,
+    pairingId,
+    local,
+    signal
+  );
+  requireCurrentConnection(isCurrent, signal);
+  if ((attempt.stunEndpoints?.length ?? 0) > 0) {
+    prepared = await deviceLink.prepareLink(
+      JSON.stringify(attempt.stunEndpoints),
+      10_000
+    );
+    local = parseDeviceLinkDescription(prepared.descriptionJSON);
+    requireCurrentConnection(isCurrent, signal);
+    attempt = await updateDeviceLinkParticipant(
+      sessionId,
+      identity.deviceId,
+      pairingId,
+      attempt.attemptId,
+      local,
+      signal
+    );
+    requireCurrentConnection(isCurrent, signal);
+  }
+  const getSignature = standardBase64ToURL(
+    await mobileSecurity.sign(
+      deviceLinkProof("get", pairingId, attempt.attemptId, "")
+    )
+  );
+  const deadline = Date.parse(attempt.expiresAt);
+  while (Date.now() < deadline) {
+    requireCurrentConnection(isCurrent, signal);
+    if (
+      attempt.state === "ready" &&
+      attempt.ownerIce &&
+      attempt.ownerFingerprint
+    ) {
+      const scope = await deviceLink.connectLink(
+        JSON.stringify({
+          candidates: attempt.ownerIce.candidates,
+          fingerprint: attempt.ownerFingerprint,
+          pwd: attempt.ownerIce.pwd,
+          ufrag: attempt.ownerIce.ufrag
+        }),
+        true,
+        prepared.token,
+        30_000
+      );
+      requireCurrentConnection(isCurrent, signal);
+      return normalizeDeviceLinkPathScope(scope);
+    }
+    await delay(500, signal);
+    requireCurrentConnection(isCurrent, signal);
+    attempt = await getDeviceLinkAttempt(
+      sessionId,
+      identity.deviceId,
+      pairingId,
+      attempt.attemptId,
+      getSignature,
+      signal
+    );
+  }
+  throw new Error("device-link attempt expired");
+}
+
+async function configureRelayTransport(
+  sessionId: string,
+  pairingId: string,
+  identity: DeviceIdentity,
+  isCurrent: () => boolean,
+  signal: AbortSignal
+): Promise<AgentRelayDescriptor | null> {
+  if (typeof deviceLink.configureRelay !== "function") {
+    return null;
+  }
+  const descriptor = await issueAgentRelayDescriptor(
+    sessionId,
+    pairingId,
+    identity,
+    signal
+  );
+  requireCurrentConnection(isCurrent, signal);
+  await deviceLink.configureRelay(
+    descriptor.relayDialEndpoint,
+    JSON.stringify({
+      authority_id: [descriptor.authorityId],
+      channel: ["agent"],
+      target: ["device-gateway"]
+    }),
+    JSON.stringify({
+      Authorization: [`Bearer ${descriptor.token}`]
+    }),
+    RELAY_STREAM_SUBPROTOCOL
+  );
+  requireCurrentConnection(isCurrent, signal);
+  return descriptor;
+}
+
 export async function issueAgentRelayDescriptor(
   sessionId: string,
   pairingId: string,
-  identity?: DeviceIdentity
+  identity?: DeviceIdentity,
+  signal?: AbortSignal
 ): Promise<AgentRelayDescriptor> {
   const currentIdentity =
     identity ?? (await mobileSecurity.getOrCreateIdentity());
@@ -261,7 +324,8 @@ export async function issueAgentRelayDescriptor(
         pairingId
       }),
       method: "POST"
-    }
+    },
+    signal
   );
   const descriptor = response.descriptor ?? response;
   if (
@@ -303,7 +367,8 @@ async function createDeviceLinkAttempt(
   sessionId: string,
   deviceId: string,
   pairingId: string,
-  local: DeviceLinkDescription
+  local: DeviceLinkDescription,
+  signal?: AbortSignal
 ): Promise<DeviceLinkAttempt> {
   const signature = await mobileSecurity.sign(
     deviceLinkProof("create", pairingId, "", local.fingerprint)
@@ -324,7 +389,8 @@ async function createDeviceLinkAttempt(
         protocolVersion: 2
       }),
       method: "POST"
-    }
+    },
+    signal
   );
   return response.attempt;
 }
@@ -334,7 +400,8 @@ async function updateDeviceLinkParticipant(
   deviceId: string,
   pairingId: string,
   attemptId: string,
-  local: DeviceLinkDescription
+  local: DeviceLinkDescription,
+  signal?: AbortSignal
 ): Promise<DeviceLinkAttempt> {
   const signature = await mobileSecurity.sign(
     deviceLinkProof("update", pairingId, attemptId, local.fingerprint)
@@ -355,7 +422,8 @@ async function updateDeviceLinkParticipant(
         protocolVersion: 2
       }),
       method: "POST"
-    }
+    },
+    signal
   );
   return response.attempt;
 }
@@ -365,12 +433,14 @@ async function getDeviceLinkAttempt(
   deviceId: string,
   pairingId: string,
   attemptId: string,
-  identitySignature: string
+  identitySignature: string,
+  signal?: AbortSignal
 ): Promise<DeviceLinkAttempt> {
   const response = await controlPlaneRequest<{ attempt: DeviceLinkAttempt }>(
     sessionId,
     `/device-pairings/${encodeURIComponent(pairingId)}/device-link-attempts/${encodeURIComponent(attemptId)}?deviceId=${encodeURIComponent(deviceId)}&identitySignature=${encodeURIComponent(identitySignature)}`,
-    { method: "GET" }
+    { method: "GET" },
+    signal
   );
   return response.attempt;
 }
@@ -426,26 +496,52 @@ async function registerIdentity(
   return response.device;
 }
 
-async function requireCurrentConnection(
-  isCurrent: () => boolean
-): Promise<void> {
+function requireCurrentConnection(
+  isCurrent: () => boolean,
+  signal?: AbortSignal
+): void {
+  if (signal?.aborted) {
+    throw new Error("device-link connection race was cancelled");
+  }
   if (isCurrent()) {
     return;
   }
   throw new Error("device-link connection was cancelled");
 }
 
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new Error("device-link connection race was cancelled"));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+      reject(new Error("device-link connection race was cancelled"));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 async function controlPlaneRequest<T>(
   sessionId: string,
   path: string,
-  init: RequestInit
+  init: RequestInit,
+  externalSignal?: AbortSignal
 ): Promise<T> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 15_000);
+  const abortExternal = () => controller.abort();
+  if (externalSignal?.aborted) {
+    controller.abort();
+  } else {
+    externalSignal?.addEventListener("abort", abortExternal, { once: true });
+  }
   try {
     const response = await fetch(`${controlPlaneBaseURL}${path}`, {
       ...init,
@@ -460,5 +556,6 @@ async function controlPlaneRequest<T>(
     return readJSON<T>(response);
   } finally {
     clearTimeout(timer);
+    externalSignal?.removeEventListener("abort", abortExternal);
   }
 }

--- a/apps/mobile/src/services/pairingClient.ts
+++ b/apps/mobile/src/services/pairingClient.ts
@@ -150,7 +150,16 @@ export async function connectPairedDevice(
     identity,
     isCurrent,
     relayController.signal
-  );
+  ).then(async (descriptor) => {
+    if (descriptor === null) return null;
+    // A descriptor only makes Relay dialable. The native probe opens a Relay
+    // stream and waits for the paired desktop Agent endpoint to acknowledge a
+    // authenticated Agent request before this path can win the connection race.
+    requireCurrentConnection(isCurrent, relayController.signal);
+    await deviceLink.probeRelay(10_000);
+    requireCurrentConnection(isCurrent, relayController.signal);
+    return descriptor;
+  });
   try {
     const winner = await raceSuccessful<
       DeviceLinkPathScope | AgentRelayDescriptor
@@ -166,11 +175,9 @@ export async function connectPairedDevice(
     ]);
     requireCurrentConnection(isCurrent);
     if (winner.name === "relay") {
-      // A Relay descriptor only makes the fallback dialable; it does not prove
-      // that the Relay stream is usable. Keep direct rendezvous running so a
-      // later data-stream race still has a direct candidate if Relay fails.
-      // Relay is an internal transport fallback. Keep the existing path scope
-      // contract consumed by the UI and workspace services unchanged.
+      // The Relay task completes only after the native Agent probe has
+      // received a response from the paired desktop. Keep direct rendezvous
+      // running so later data-stream races retain a direct candidate.
       return "private_network";
     }
     // Direct is already usable. Do not leave a control-plane descriptor

--- a/apps/mobile/src/services/pairingTransportRace.test.ts
+++ b/apps/mobile/src/services/pairingTransportRace.test.ts
@@ -1,0 +1,61 @@
+import { raceSuccessful } from "./pairingTransportRace";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, reject, resolve };
+}
+
+describe("raceSuccessful", () => {
+  it("returns the first successful path instead of the first settled path", async () => {
+    const direct = deferred<string>();
+    const relay = deferred<string | null>();
+    const result = raceSuccessful([
+      { name: "direct", run: () => direct.promise },
+      { name: "relay", run: () => relay.promise }
+    ]);
+
+    direct.reject(new Error("direct unavailable"));
+    relay.resolve("relay-ready");
+
+    await expect(result).resolves.toEqual({
+      name: "relay",
+      value: "relay-ready"
+    });
+  });
+
+  it("does not reject when a losing path fails after the winner", async () => {
+    const direct = deferred<string>();
+    const relay = deferred<string>();
+    const result = raceSuccessful([
+      { name: "direct", run: () => direct.promise },
+      { name: "relay", run: () => relay.promise }
+    ]);
+
+    relay.resolve("relay-ready");
+    await expect(result).resolves.toEqual({
+      name: "relay",
+      value: "relay-ready"
+    });
+    direct.reject(new Error("late direct failure"));
+    await Promise.resolve();
+  });
+
+  it("rejects only after every path fails or returns null", async () => {
+    const result = raceSuccessful([
+      { name: "direct", run: async () => null },
+      {
+        name: "relay",
+        run: async () => {
+          throw new Error("relay unavailable");
+        }
+      }
+    ]);
+
+    await expect(result).rejects.toThrow("relay unavailable");
+  });
+});

--- a/apps/mobile/src/services/pairingTransportRace.ts
+++ b/apps/mobile/src/services/pairingTransportRace.ts
@@ -1,0 +1,61 @@
+export interface SuccessfulRaceTask<T> {
+  name: string;
+  run: () => Promise<T | null>;
+}
+
+export interface SuccessfulRaceResult<T> {
+  name: string;
+  value: T;
+}
+
+/**
+ * Resolves with the first non-null task result while treating individual
+ * failures as losing paths. Every task receives a rejection handler, so a
+ * loser that finishes after the winner cannot create an unhandled rejection.
+ */
+export function raceSuccessful<T>(
+  tasks: readonly SuccessfulRaceTask<T>[]
+): Promise<SuccessfulRaceResult<T>> {
+  if (tasks.length === 0) {
+    return Promise.reject(
+      new Error("connection race requires at least one path")
+    );
+  }
+  return new Promise((resolve, reject) => {
+    let remaining = tasks.length;
+    let settled = false;
+    let lastError: Error | null = null;
+    for (const task of tasks) {
+      Promise.resolve()
+        .then(task.run)
+        .then(
+          (value) => {
+            if (settled) return;
+            if (value !== null) {
+              settled = true;
+              resolve({ name: task.name, value });
+              return;
+            }
+            remaining -= 1;
+            if (remaining === 0) {
+              settled = true;
+              reject(lastError ?? new Error("all connection paths failed"));
+            }
+          },
+          (error: unknown) => {
+            if (settled) return;
+            lastError = toError(error);
+            remaining -= 1;
+            if (remaining === 0) {
+              settled = true;
+              reject(lastError);
+            }
+          }
+        );
+    }
+  });
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -214,6 +214,21 @@ transport、Agent live Subscriber 和产品 adapter 的现有所有权，不把 
 `cocoapods_pathname_workaround.rb`；GitHub macOS runner 和本机 pnpm workspace
 都可能在 CocoaPods 生成工程时触发该符号链接解析缺陷。
 
+### 4.1 移动端连接竞速边界
+
+移动端连接分成两个边界，不能把控制面轮询和数据面建流混为一谈：
+
+| 边界                                       | 当前策略                                                                         | 所有者                                      |
+| ------------------------------------------ | -------------------------------------------------------------------------------- | ------------------------------------------- |
+| DeviceLink attempt / Relay descriptor 准备 | direct attempt 与 Relay descriptor 并行；direct attempt 仍按 500ms 轮询状态      | `apps/mobile/src/services/pairingClient.ts` |
+| Agent HTTP / live 数据流                   | direct authenticated stream 与已授权 Relay stream 立即并行，首个成功 stream 胜出 | `packages/device-link/mobile` + 原生 bridge |
+
+移动端目前没有已确认的 `device_link.attempt.changed` 控制面 WebSocket 契约，因此不
+凭空增加推送协议；控制面仍保留轮询作为事实来源。Relay descriptor 先准备好时，
+移动端可以先通过 Relay 工作，同时让 direct attempt 在后台完成；direct stream 等待
+正在进行的 `Connect`，Relay stream 不等待它。TSH Desktop 的默认 3 秒 Relay 兜底策略
+属于另一套已上线产品策略，本改动不改变它。
+
 ### 账号浏览器认证边界
 
 Mobile 继续复用 Desktop 使用的托管 Web 登录页、localhost callback bridge 和账号
@@ -482,6 +497,10 @@ Google Play 账号。以下事项等正式分发前再处理：
 - Android caller 已接入 create/get/update attempt、STUN 二次 gathering、真实
   DeviceLink request stream、端到端请求 deadline、prepare/connect generation
   fencing 和 Native 15 秒后台 grace period；
+- Android/iOS caller 已将 direct 与 Relay 的 Agent 数据流接入同一条即时竞速；控制面
+  Relay descriptor 先就绪时不再等待 direct attempt 的 TTL，但 direct attempt 会在
+  后台继续完成，作为后续数据流竞速的 direct 候选；UI 和现有 DeviceLink path scope
+  保持不变；
 - 移动端已直接复用 `@tutti-os/client-tuttid-ts`，并从
   `@tutti-os/agent-gui` 复用安全的 Interaction answer model、无 DOM 的会话摘要和
   canonical 对话流 projection，完成 Personal 单 workspace 校验、按置顶/项目/最近分组的
@@ -489,8 +508,9 @@ Google Play 账号。以下事项等正式分发前再处理：
   消息读取、新建/切换、发送、停止和结构化 Interaction 提交；Native 对话流遵循同一份
   消息合并、思考、工具活动、处理态和 Turn summary 语义，并复用 AgentGUI 的
   `following` / `detached` 末尾跟随状态机；Mobile 只负责原生手势、滚动执行与展开状态。
-  会话列表标题显示当前电脑和连接状态；连接详情仅展示 Native ICE 分类后的路径范围、
-  端到端 P2P 通道和即时健康探测耗时，不暴露 candidate 或地址信息。
+  会话列表标题显示当前电脑和连接状态；连接详情继续复用现有路径、传输通道和即时
+  健康探测字段，不暴露 candidate 或地址信息；Relay 竞速属于 native transport
+  内部行为，不新增 UI 分支；
   切换会话会定位最新内容，流式更新只在 `following` 时跟随；主动上滑会在首个滚动帧前
   进入 `detached` 并提供回到底部入口，内容增长和近底部几何不能自行恢复跟随；加载历史
   消息时保持当前阅读锚点；
@@ -610,8 +630,8 @@ Mobile 也点击“使用 GitHub 登录”并在平台浏览器认证会话中�
 按顺序验证，每一步成功后再继续：
 
 1. Mobile 只显示当前手机 identity 拥有的同账号配对设备。
-2. 点击 Desktop 后成功建立 direct DeviceLink，并且仅在返回恰好一个 Personal
-   workspace 时进入会话列表；零个或多个 workspace 都明确失败。
+2. 点击 Desktop 后成功建立可用 DeviceLink，并且仅在返回恰好一个 Personal workspace
+   时进入会话列表；零个或多个 workspace 都明确失败。
 3. 会话列表可新建、切换会话，选择后进入独立详情页并正确显示历史对话流。
 4. 发送一条普通消息，Desktop 和 Mobile 最终显示同一个结果且没有重复消息。
 5. 在 Agent 运行时点击停止，两个端最终收敛到同一个 Turn 状态。
@@ -619,8 +639,8 @@ Mobile 也点击“使用 GitHub 登录”并在平台浏览器认证会话中�
 7. 将 App 切到后台少于 15 秒再返回，当前连接保持；切到后台超过 15 秒再返回，
    App 回到设备列表并可手动重连。
 8. 在 Desktop 移除手机配对，Mobile 刷新后不再显示该 Desktop，旧连接不可继续使用。
-9. 至少分别测试同一 Wi-Fi 和手机蜂窝网络。记录 direct P2P 是否成功；蜂窝或严格
-   NAT 失败但同一 Wi-Fi 成功时，将结果归入 Relay fallback 后续项，不改 Agent 协议。
+9. 至少分别测试同一 Wi-Fi 和手机蜂窝网络，确认 Agent HTTP/live 请求均可用；Relay
+   仅作为内部传输，不改变现有 UI 和 Agent DTO。
 
 验收失败时保留三个终端：Desktop、Metro、`adb logcat`。先记录失败发生在哪一层、
 操作步骤和用户可见错误，不要复制网络 candidate、IP、Agent 正文或任何账号材料。

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -218,15 +218,15 @@ transport、Agent live Subscriber 和产品 adapter 的现有所有权，不把 
 
 移动端连接分成两个边界，不能把控制面轮询和数据面建流混为一谈：
 
-| 边界                                       | 当前策略                                                                         | 所有者                                      |
-| ------------------------------------------ | -------------------------------------------------------------------------------- | ------------------------------------------- |
-| DeviceLink attempt / Relay descriptor 准备 | direct attempt 与 Relay descriptor 并行；direct attempt 仍按 500ms 轮询状态      | `apps/mobile/src/services/pairingClient.ts` |
-| Agent HTTP / live 数据流                   | direct authenticated stream 与已授权 Relay stream 立即并行，首个成功 stream 胜出 | `packages/device-link/mobile` + 原生 bridge |
+| 边界                                       | 当前策略                                                                                                                              | 所有者                                                    |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| DeviceLink attempt / Relay descriptor 准备 | direct attempt 与 Relay descriptor 并行；Relay 只有完成一次对端 Agent 请求/响应后才可成为可用路径；direct attempt 仍按 500ms 轮询状态 | `apps/mobile/src/services/pairingClient.ts` + 原生 bridge |
+| Agent HTTP / live 数据流                   | direct 与 Relay 的底层拨号仍可并行；应用帧得到对端响应前不把 Relay 的 WebSocket 101 当成成功                                          | `packages/device-link/mobile` + 原生 bridge               |
 
 移动端目前没有已确认的 `device_link.attempt.changed` 控制面 WebSocket 契约，因此不
 凭空增加推送协议；控制面仍保留轮询作为事实来源。Relay descriptor 先准备好时，
-移动端可以先通过 Relay 工作，同时让 direct attempt 在后台完成；direct stream 等待
-正在进行的 `Connect`，Relay stream 不等待它。TSH Desktop 的默认 3 秒 Relay 兜底策略
+原生层先通过一次带应用帧的 Agent 请求确认对端 tunnel 和 handler，再让 Relay 参与
+连接结果竞速；direct attempt 仍在后台完成。TSH Desktop 的默认 3 秒 Relay 兜底策略
 属于另一套已上线产品策略，本改动不改变它。
 
 ### 账号浏览器认证边界
@@ -498,9 +498,9 @@ Google Play 账号。以下事项等正式分发前再处理：
   DeviceLink request stream、端到端请求 deadline、prepare/connect generation
   fencing 和 Native 15 秒后台 grace period；
 - Android/iOS caller 已将 direct 与 Relay 的 Agent 数据流接入同一条即时竞速；控制面
-  Relay descriptor 先就绪时不再等待 direct attempt 的 TTL，但 direct attempt 会在
-  后台继续完成，作为后续数据流竞速的 direct 候选；UI 和现有 DeviceLink path scope
-  保持不变；
+  Relay descriptor 先就绪时先做一次端到端 Agent 请求确认，不再把 WebSocket 101
+  当成成功，同时不等待 direct attempt 的 TTL；direct attempt 会在后台继续完成，
+  作为后续数据流竞速的 direct 候选；UI 和现有 DeviceLink path scope 保持不变；
 - 移动端已直接复用 `@tutti-os/client-tuttid-ts`，并从
   `@tutti-os/agent-gui` 复用安全的 Interaction answer model、无 DOM 的会话摘要和
   canonical 对话流 projection，完成 Personal 单 workspace 校验、按置顶/项目/最近分组的

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -218,16 +218,16 @@ transport、Agent live Subscriber 和产品 adapter 的现有所有权，不把 
 
 移动端连接分成两个边界，不能把控制面轮询和数据面建流混为一谈：
 
-| 边界                                       | 当前策略                                                                                                                              | 所有者                                                    |
-| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
-| DeviceLink attempt / Relay descriptor 准备 | direct attempt 与 Relay descriptor 并行；Relay 只有完成一次对端 Agent 请求/响应后才可成为可用路径；direct attempt 仍按 500ms 轮询状态 | `apps/mobile/src/services/pairingClient.ts` + 原生 bridge |
-| Agent HTTP / live 数据流                   | direct 与 Relay 的底层拨号仍可并行；应用帧得到对端响应前不把 Relay 的 WebSocket 101 当成成功                                          | `packages/device-link/mobile` + 原生 bridge               |
+| 边界                                       | 当前策略                                                                                                                              | 所有者                                                                 |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| DeviceLink attempt / Relay descriptor 准备 | direct attempt 与 Relay descriptor 并行；Relay 只有完成一次对端 Agent 请求/响应后才可成为可用路径；direct attempt 仍按 500ms 轮询状态 | `apps/mobile/src/services/pairingClient.ts` + 原生 bridge              |
+| Agent HTTP / live 数据流                   | direct 与 Relay 的底层拨号仍可并行；两条路径先完成 DeviceLink transport probe，收到对端 ACK 后才选中，应用帧仍由原生 bridge 处理      | `packages/device-link/mobile` + `services/tuttid/service/mobileremote` |
 
 移动端目前没有已确认的 `device_link.attempt.changed` 控制面 WebSocket 契约，因此不
 凭空增加推送协议；控制面仍保留轮询作为事实来源。Relay descriptor 先准备好时，
-原生层先通过一次带应用帧的 Agent 请求确认对端 tunnel 和 handler，再让 Relay 参与
-连接结果竞速；direct attempt 仍在后台完成。TSH Desktop 的默认 3 秒 Relay 兜底策略
-属于另一套已上线产品策略，本改动不改变它。
+原生层先通过 DeviceLink transport probe 确认对端 tunnel，再让 Relay 参与连接结果
+竞速；具体 Agent 请求仍在探测成功后发送，direct attempt 仍在后台完成。TSH Desktop
+的默认 3 秒 Relay 兜底策略属于另一套已上线产品策略，本改动不改变它。
 
 ### 账号浏览器认证边界
 

--- a/docs/specs/2026-07-23-mobile-agentgui-device-link-design.md
+++ b/docs/specs/2026-07-23-mobile-agentgui-device-link-design.md
@@ -14,8 +14,9 @@ fallback policy. Personal Desktop and Android consume the same authenticated
 facade; the direct lane includes paired-device rendezvous, framed Agent HTTP,
 request deadlines, event streaming and foreground/background close behavior.
 Android 15 ARM64 emulator build/install/start and authenticated loopback
-integration pass. Real-account physical-device network transitions and Relay
-fallback remain hardening work that does not expand the transport API. A stable
+integration pass. Mobile's Relay stream race and native consumer integration are
+now implemented; real-account physical-device network transitions and end-to-end
+Relay verification remain hardening work. A stable
 tag still requires the authenticated lifecycle checks and reproducible Mobile
 AAR consumer build to pass at the release head. TSH cutover to the shared
 manager remains a consumer-side rollout step.
@@ -222,9 +223,12 @@ TypeScript 侧继续使用：
 ### 7.4 P2P 与 Relay
 
 - P2P 与 Relay 同时受同一设备身份和配对授权约束。
-- Direct 立即开始；Relay 在现有竞速窗口后启动，快速失败时立即启动。
+- Mobile 的 Agent HTTP/live 数据流 direct 与 Relay 同时立即开始，首个成功的
+  authenticated stream 获胜；TSH Desktop 的默认 3 秒 Relay 兜底窗口由其产品策略
+  保持不变。
 - 第一条完成认证的可用链路获胜，晚到链路关闭。
-- 主界面不展示 P2P/Relay 区别，只展示连接中、已连接、重连中和设备离线。
+- 主界面和连接详情继续复用现有状态与 path scope，不新增 P2P/Relay 展示分支；选路
+  只在 native transport 内部生效。
 - 具体选路、耗时和 fallback reason 只进入清洗后的诊断与指标，不记录 candidate、IP、token 或 Agent payload。
 
 ## 8. 账号、配对和设备身份
@@ -564,9 +568,10 @@ Relay Agent lane 已接入同一套应用帧协议：Desktop `mobileremote` 只�
 移动端连接开关后获取 Relay owner demand，按 Device Authority 完成 identity
 enrollment、owner token 和 lease renewal；Relay stream prelude 校验 authority、
 user、target、channel 及 paired-device scope 后复用现有 Agent HTTP/live handler。
-Mobile 在直连准备阶段并行请求短期 Relay descriptor，直连优先，直连无法建立时由
-Android/iOS native adapter 使用相同 framed HTTP/live 协议拨号 Relay。因此 UI、生成
-客户端和 Agent DTO 不变。pairing 的 active 快照仍由现有控制面轮询刷新，Relay stream
+Mobile 在直连准备阶段并行请求短期 Relay descriptor；如果 descriptor 先就绪，只提前
+返回可用的 Relay 配置，不取消 direct attempt，后者继续到成功或当前连接代际失效。
+Android/iOS native adapter 对每个 framed HTTP/live stream 同时拨号 direct 与 Relay，首个
+成功路径获胜。因此 UI、生成客户端和 Agent DTO 不变。pairing 的 active 快照仍由现有控制面轮询刷新，Relay stream
 在本地快照中找不到 pairing 时 fail closed；快照刷新间隔是当前 2 秒轮询周期。
 
 这里依赖的 Relay descriptor、Device Authority 和 `tsh-tunnel-relay` Agent channel

--- a/docs/specs/2026-07-23-mobile-agentgui-device-link-design.md
+++ b/docs/specs/2026-07-23-mobile-agentgui-device-link-design.md
@@ -568,12 +568,12 @@ Relay Agent lane 已接入同一套应用帧协议：Desktop `mobileremote` 只�
 移动端连接开关后获取 Relay owner demand，按 Device Authority 完成 identity
 enrollment、owner token 和 lease renewal；Relay stream prelude 校验 authority、
 user、target、channel 及 paired-device scope 后复用现有 Agent HTTP/live handler。
-Mobile 在直连准备阶段并行请求短期 Relay descriptor；如果 descriptor 先就绪，原生层
-先通过一条 Relay stream 完成带应用帧的 Agent 请求/响应，确认对端 tunnel 和 Agent
-handler 已接受后才把 Relay 标记为可用；不会取消 direct attempt，后者继续到成功或
-当前连接代际失效。Android/iOS native adapter 对每个 framed HTTP/live stream 同时
-拨号 direct 与 Relay，不能把 WebSocket 101 单独当作成功路径。因此 UI、生成客户端和
-Agent DTO 不变。pairing 的 active 快照仍由现有控制面轮询刷新，Relay stream
+Mobile 在直连准备阶段并行请求短期 Relay descriptor；原生层对每条 direct/Relay
+数据流先完成共享 DeviceLink transport probe，收到对端 ACK 后才让该路径赢得竞速，
+再发送应用帧；不会取消 direct attempt，后者继续到成功或当前连接代际失效。
+Android/iOS native adapter 不能把 WebSocket 101 或本地 QUIC stream allocation 单独
+当作成功路径。因此 UI、生成客户端和 Agent DTO 不变。pairing 的 active 快照仍由现有
+控制面轮询刷新，Relay stream
 在本地快照中找不到 pairing 时 fail closed；快照刷新间隔是当前 2 秒轮询周期。
 
 这里依赖的 Relay descriptor、Device Authority 和 `tsh-tunnel-relay` Agent channel

--- a/docs/specs/2026-07-23-mobile-agentgui-device-link-design.md
+++ b/docs/specs/2026-07-23-mobile-agentgui-device-link-design.md
@@ -568,10 +568,12 @@ Relay Agent lane 已接入同一套应用帧协议：Desktop `mobileremote` 只�
 移动端连接开关后获取 Relay owner demand，按 Device Authority 完成 identity
 enrollment、owner token 和 lease renewal；Relay stream prelude 校验 authority、
 user、target、channel 及 paired-device scope 后复用现有 Agent HTTP/live handler。
-Mobile 在直连准备阶段并行请求短期 Relay descriptor；如果 descriptor 先就绪，只提前
-返回可用的 Relay 配置，不取消 direct attempt，后者继续到成功或当前连接代际失效。
-Android/iOS native adapter 对每个 framed HTTP/live stream 同时拨号 direct 与 Relay，首个
-成功路径获胜。因此 UI、生成客户端和 Agent DTO 不变。pairing 的 active 快照仍由现有控制面轮询刷新，Relay stream
+Mobile 在直连准备阶段并行请求短期 Relay descriptor；如果 descriptor 先就绪，原生层
+先通过一条 Relay stream 完成带应用帧的 Agent 请求/响应，确认对端 tunnel 和 Agent
+handler 已接受后才把 Relay 标记为可用；不会取消 direct attempt，后者继续到成功或
+当前连接代际失效。Android/iOS native adapter 对每个 framed HTTP/live stream 同时
+拨号 direct 与 Relay，不能把 WebSocket 101 单独当作成功路径。因此 UI、生成客户端和
+Agent DTO 不变。pairing 的 active 快照仍由现有控制面轮询刷新，Relay stream
 在本地快照中找不到 pairing 时 fail closed；快照刷新间隔是当前 2 秒轮询周期。
 
 这里依赖的 Relay descriptor、Device Authority 和 `tsh-tunnel-relay` Agent channel

--- a/packages/device-link/README.md
+++ b/packages/device-link/README.md
@@ -144,6 +144,8 @@ link facade:
   material;
 - caller/owner connection using the peer description;
 - authenticated bidirectional stream open/accept/read/write/deadline/close;
+- `OpenStreamWithRelay`, which races a direct authenticated stream and an
+  already-authorized Relay stream concurrently and closes the losing stream;
 - the loopback integration probe used by the Android build gate.
 
 The mobile read boundary intentionally fills a caller-owned byte buffer and
@@ -159,8 +161,10 @@ headers, and WebSocket subprotocol as JSON `map[string][]string` values, then
 returns the same `Stream` abstraction used by the Agent framing adapter. The
 mobile package does not issue credentials, select a target, or decide when to
 fall back; those policies remain in the Mobile pairing service and native
-bridge. Relay streams must be closed by the caller after each HTTP request or
-when the live subscription ends.
+bridge. `Link.OpenStreamWithRelay` uses the same stream abstraction to start
+direct and Relay together; a direct stream may wait for an in-progress
+`Link.Connect`, while Relay starts immediately. Relay streams must be closed by
+the caller after each HTTP request or when the live subscription ends.
 
 Account identity signatures, DeviceLink attempts, pairing scope, Agent HTTP
 framing, and foreground/background policy remain in the Android and tuttid

--- a/packages/device-link/README.md
+++ b/packages/device-link/README.md
@@ -31,7 +31,8 @@ an authenticated link:
 - one in-flight establishment per opaque peer key;
 - authenticated link reuse, stream reference counting, idle retirement, and
   deterministic collision resolution;
-- a delayed two-path race that closes every losing late connection;
+- a delayed two-path race that verifies each candidate with a transport-owned
+  stream probe before selecting it and closes every losing late connection;
 - an annealed direct-probe cache with bounded peer state and explicit
   environment invalidation.
 
@@ -109,6 +110,17 @@ handshake response body available for adapter-owned wire-reason parsing, but
 does not include that body in its error string; adapters must not persist the
 raw value in ordinary logs or metrics.
 
+### Stream readiness probe
+
+`ProbeStream` and `ServeStreamProbe` form the product-neutral readiness barrier
+for a newly opened authenticated stream. The caller writes a fresh nonce and
+selects the path only after the peer echoes that nonce. This matters for stale
+QUIC sessions: `OpenStreamSync` can succeed locally after a network transition
+even though the peer is no longer reachable. The probe is deliberately
+separate from Agent framing and leaves the verified stream open for the
+consumer's application protocol. Owners must run `ServeStreamProbe` before
+dispatching the stream to their handler.
+
 ## Trickle ICE and protocol migration
 
 Consumers that exchange candidates incrementally call
@@ -145,10 +157,10 @@ link facade:
 - caller/owner connection using the peer description;
 - authenticated bidirectional stream open/accept/read/write/deadline/close;
 - `OpenStreamWithRelay`, which races a direct stream dial and an authorized
-  Relay stream dial concurrently and closes the losing stream. The returned
-  byte stream is only a transport candidate: callers that carry an application
-  protocol must complete that protocol's request/response handshake before
-  recording the path as usable;
+  Relay stream dial concurrently, requires the shared stream probe on both
+  candidates, and closes the losing stream. The returned byte stream has
+  crossed the transport readiness barrier; callers still own their application
+  protocol handshake and request semantics;
 - the loopback integration probe used by the Android build gate.
 
 The mobile read boundary intentionally fills a caller-owned byte buffer and
@@ -161,9 +173,10 @@ Java receives it.
 `mobile.DialRelay` is the corresponding gomobile-safe byte-stream entry point for
 an already-authorized Relay caller. It accepts the endpoint, query values,
 headers, and WebSocket subprotocol as JSON `map[string][]string` values, then
-returns the same `Stream` abstraction used by the Agent framing adapter. A
-successful WebSocket upgrade is not proof that the owner tunnel or Agent
-handler accepted the stream. The mobile package does not issue credentials,
+runs the shared stream probe before returning the same `Stream` abstraction used
+by the Agent framing adapter. A successful WebSocket upgrade alone is not proof
+that the owner tunnel or Agent handler accepted the stream; the probe confirms
+only that the transport owner is responsive. The mobile package does not issue credentials,
 select a target, or decide when to fall back; those policies remain in the
 Mobile pairing service and native bridge. `Link.OpenStreamWithRelay` uses the
 same stream abstraction to start direct and Relay together; a direct stream may

--- a/packages/device-link/README.md
+++ b/packages/device-link/README.md
@@ -144,8 +144,11 @@ link facade:
   material;
 - caller/owner connection using the peer description;
 - authenticated bidirectional stream open/accept/read/write/deadline/close;
-- `OpenStreamWithRelay`, which races a direct authenticated stream and an
-  already-authorized Relay stream concurrently and closes the losing stream;
+- `OpenStreamWithRelay`, which races a direct stream dial and an authorized
+  Relay stream dial concurrently and closes the losing stream. The returned
+  byte stream is only a transport candidate: callers that carry an application
+  protocol must complete that protocol's request/response handshake before
+  recording the path as usable;
 - the loopback integration probe used by the Android build gate.
 
 The mobile read boundary intentionally fills a caller-owned byte buffer and
@@ -158,13 +161,15 @@ Java receives it.
 `mobile.DialRelay` is the corresponding gomobile-safe byte-stream entry point for
 an already-authorized Relay caller. It accepts the endpoint, query values,
 headers, and WebSocket subprotocol as JSON `map[string][]string` values, then
-returns the same `Stream` abstraction used by the Agent framing adapter. The
-mobile package does not issue credentials, select a target, or decide when to
-fall back; those policies remain in the Mobile pairing service and native
-bridge. `Link.OpenStreamWithRelay` uses the same stream abstraction to start
-direct and Relay together; a direct stream may wait for an in-progress
-`Link.Connect`, while Relay starts immediately. Relay streams must be closed by
-the caller after each HTTP request or when the live subscription ends.
+returns the same `Stream` abstraction used by the Agent framing adapter. A
+successful WebSocket upgrade is not proof that the owner tunnel or Agent
+handler accepted the stream. The mobile package does not issue credentials,
+select a target, or decide when to fall back; those policies remain in the
+Mobile pairing service and native bridge. `Link.OpenStreamWithRelay` uses the
+same stream abstraction to start direct and Relay together; a direct stream may
+wait for an in-progress `Link.Connect`, while Relay starts immediately. Relay
+streams must be closed by the caller after each HTTP request or when the live
+subscription ends.
 
 Account identity signatures, DeviceLink attempts, pairing scope, Agent HTTP
 framing, and foreground/background policy remain in the Android and tuttid

--- a/packages/device-link/mobile/link.go
+++ b/packages/device-link/mobile/link.go
@@ -168,9 +168,10 @@ func (l *Link) OpenStream(timeoutMillis int64) (*Stream, error) {
 }
 
 // OpenStreamWithRelay starts the direct and Relay stream dials together. The
-// first authenticated stream wins; the losing dial is canceled by the shared
-// race context. A Link may still be completing Connect, so the direct dial
-// waits for that operation while Relay starts immediately.
+// first dialable byte stream wins; callers must complete their application
+// protocol handshake before treating that path as usable. The losing dial is
+// canceled by the shared race context. A Link may still be completing Connect,
+// so the direct dial waits for that operation while Relay starts immediately.
 func (l *Link) OpenStreamWithRelay(
 	endpoint string,
 	queryJSON string,

--- a/packages/device-link/mobile/link.go
+++ b/packages/device-link/mobile/link.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	authenticated "github.com/tutti-os/tutti/packages/device-link/authenticated"
+	"github.com/tutti-os/tutti/packages/device-link/linkmanager"
 	"github.com/tutti-os/tutti/packages/device-link/relaytransport"
 )
 
@@ -20,14 +21,19 @@ const (
 	ApplicationProtocolEpoch = 1
 	defaultLinkTimeout       = 30 * time.Second
 	maxMobileStreamRead      = 1 << 20
+	transportDirect          = "direct"
+	transportRelay           = "relay"
 )
 
 type Link struct {
 	participant *authenticated.Participant
 
-	mu        sync.Mutex
-	connected *authenticated.Link
-	closed    bool
+	mu          sync.Mutex
+	connected   *authenticated.Link
+	connectDone chan struct{}
+	connectOnce sync.Once
+	connectErr  error
+	closed      bool
 }
 
 func ProtocolEpoch() int { return ApplicationProtocolEpoch }
@@ -46,7 +52,7 @@ func NewLink(stunEndpointsJSON string) (*Link, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Link{participant: participant}, nil
+	return newLink(participant), nil
 }
 
 func NewLoopbackLink() (*Link, error) {
@@ -56,7 +62,14 @@ func NewLoopbackLink() (*Link, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Link{participant: participant}, nil
+	return newLink(participant), nil
+}
+
+func newLink(participant *authenticated.Participant) *Link {
+	return &Link{
+		participant: participant,
+		connectDone: make(chan struct{}),
+	}
 }
 
 // DialRelay opens one product-configured Relay byte stream. The mobile
@@ -90,7 +103,7 @@ func DialRelay(
 	if err != nil {
 		return nil, err
 	}
-	return &Stream{conn: conn}, nil
+	return &Stream{conn: conn, transport: transportRelay}, nil
 }
 
 func (l *Link) LocalDescription(timeoutMillis int64) (string, error) {
@@ -116,7 +129,9 @@ func (l *Link) Connect(peerDescriptionJSON string, caller bool, timeoutMillis in
 	}
 	var peer authenticated.Description
 	if err := json.Unmarshal([]byte(peerDescriptionJSON), &peer); err != nil {
-		return "", fmt.Errorf("decode device-link peer description: %w", err)
+		connectErr := fmt.Errorf("decode device-link peer description: %w", err)
+		l.recordConnectError(connectErr)
+		return "", connectErr
 	}
 	role := authenticated.RoleOwner
 	if caller {
@@ -126,45 +141,91 @@ func (l *Link) Connect(peerDescriptionJSON string, caller bool, timeoutMillis in
 	defer cancel()
 	connected, err := l.participant.Connect(ctx, peer, role)
 	if err != nil {
+		l.recordConnectError(err)
 		return "", err
 	}
 	l.mu.Lock()
 	if l.closed {
 		l.mu.Unlock()
 		_ = connected.Close()
+		l.signalConnectDone()
 		return "", errors.New("device-link mobile participant closed while connecting")
 	}
 	l.connected = connected
 	l.mu.Unlock()
+	l.signalConnectDone()
 	return connected.SelectedScope(), nil
 }
 
 func (l *Link) OpenStream(timeoutMillis int64) (*Stream, error) {
-	connected, err := l.activeLink()
+	ctx, cancel := context.WithTimeout(context.Background(), linkTimeout(timeoutMillis))
+	defer cancel()
+	stream, err := l.openStreamContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &Stream{conn: stream, transport: transportDirect}, nil
+}
+
+// OpenStreamWithRelay starts the direct and Relay stream dials together. The
+// first authenticated stream wins; the losing dial is canceled by the shared
+// race context. A Link may still be completing Connect, so the direct dial
+// waits for that operation while Relay starts immediately.
+func (l *Link) OpenStreamWithRelay(
+	endpoint string,
+	queryJSON string,
+	headersJSON string,
+	subprotocol string,
+	timeoutMillis int64,
+) (*Stream, error) {
+	query, err := decodeRelayValues(queryJSON, "query")
+	if err != nil {
+		return nil, err
+	}
+	headers, err := decodeRelayValues(headersJSON, "headers")
 	if err != nil {
 		return nil, err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), linkTimeout(timeoutMillis))
 	defer cancel()
-	stream, err := connected.OpenStream(ctx)
+	result, err := linkmanager.Race(ctx, linkmanager.RaceConfig{
+		Primary: linkmanager.DialPath{
+			Name: transportDirect,
+			Dial: func(dialCtx context.Context) (net.Conn, error) {
+				return l.openStreamContext(dialCtx)
+			},
+		},
+		Fallback: linkmanager.DialPath{
+			Name: transportRelay,
+			Dial: func(dialCtx context.Context) (net.Conn, error) {
+				return relaytransport.Dial(dialCtx, relaytransport.DialRequest{
+					Endpoint:    endpoint,
+					Query:       query,
+					Header:      http.Header(headers),
+					Subprotocol: subprotocol,
+				})
+			},
+		},
+		FallbackDelay: 0,
+	})
 	if err != nil {
 		return nil, err
 	}
-	return &Stream{conn: stream}, nil
+	return &Stream{conn: result.Conn, transport: result.Path}, nil
 }
 
 func (l *Link) AcceptStream(timeoutMillis int64) (*Stream, error) {
-	connected, err := l.activeLink()
+	ctx, cancel := context.WithTimeout(context.Background(), linkTimeout(timeoutMillis))
+	defer cancel()
+	connected, err := l.waitConnected(ctx)
 	if err != nil {
 		return nil, err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), linkTimeout(timeoutMillis))
-	defer cancel()
 	stream, err := connected.AcceptStream(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return &Stream{conn: stream}, nil
+	return &Stream{conn: stream, transport: transportDirect}, nil
 }
 
 func (l *Link) Close() error {
@@ -180,6 +241,7 @@ func (l *Link) Close() error {
 	connected := l.connected
 	participant := l.participant
 	l.mu.Unlock()
+	l.signalConnectDone()
 	if connected != nil {
 		return connected.Close()
 	}
@@ -189,18 +251,80 @@ func (l *Link) Close() error {
 	return nil
 }
 
-func (l *Link) activeLink() (*authenticated.Link, error) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	if l.closed || l.connected == nil {
-		return nil, errors.New("device-link mobile session is not connected")
+func (l *Link) signalConnectDone() {
+	if l == nil {
+		return
 	}
-	return l.connected, nil
+	l.connectOnce.Do(func() {
+		if l.connectDone != nil {
+			close(l.connectDone)
+		}
+	})
+}
+
+func (l *Link) recordConnectError(err error) {
+	l.mu.Lock()
+	l.connectErr = err
+	l.mu.Unlock()
+	l.signalConnectDone()
+}
+
+func (l *Link) openStreamContext(ctx context.Context) (net.Conn, error) {
+	connected, err := l.waitConnected(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return connected.OpenStream(ctx)
+}
+
+func (l *Link) waitConnected(ctx context.Context) (*authenticated.Link, error) {
+	if l == nil {
+		return nil, errors.New("device-link mobile participant is unavailable")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	l.mu.Lock()
+	connected := l.connected
+	closed := l.closed
+	connectDone := l.connectDone
+	connectErr := l.connectErr
+	l.mu.Unlock()
+	if closed {
+		return nil, errors.New("device-link mobile session is closed")
+	}
+	if connected != nil {
+		return connected, nil
+	}
+	if connectErr != nil {
+		return nil, connectErr
+	}
+	select {
+	case <-connectDone:
+		l.mu.Lock()
+		connected = l.connected
+		connectErr = l.connectErr
+		closed = l.closed
+		l.mu.Unlock()
+		if connected != nil {
+			return connected, nil
+		}
+		if connectErr != nil {
+			return nil, connectErr
+		}
+		if closed {
+			return nil, errors.New("device-link mobile session is closed")
+		}
+		return nil, errors.New("device-link mobile session is not connected")
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 type Stream struct {
-	conn net.Conn
-	once sync.Once
+	conn      net.Conn
+	transport string
+	once      sync.Once
 }
 
 func (s *Stream) ReadInto(buffer []byte) int {

--- a/packages/device-link/mobile/link.go
+++ b/packages/device-link/mobile/link.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	devicelink "github.com/tutti-os/tutti/packages/device-link"
 	authenticated "github.com/tutti-os/tutti/packages/device-link/authenticated"
 	"github.com/tutti-os/tutti/packages/device-link/linkmanager"
 	"github.com/tutti-os/tutti/packages/device-link/relaytransport"
@@ -103,6 +104,10 @@ func DialRelay(
 	if err != nil {
 		return nil, err
 	}
+	if err := devicelink.ProbeStream(ctx, conn); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("probe Relay stream: %w", err)
+	}
 	return &Stream{conn: conn, transport: transportRelay}, nil
 }
 
@@ -167,11 +172,12 @@ func (l *Link) OpenStream(timeoutMillis int64) (*Stream, error) {
 	return &Stream{conn: stream, transport: transportDirect}, nil
 }
 
-// OpenStreamWithRelay starts the direct and Relay stream dials together. The
-// first dialable byte stream wins; callers must complete their application
-// protocol handshake before treating that path as usable. The losing dial is
-// canceled by the shared race context. A Link may still be completing Connect,
-// so the direct dial waits for that operation while Relay starts immediately.
+// OpenStreamWithRelay starts the direct and Relay stream dials together. Each
+// candidate must complete the shared DeviceLink stream probe before it can win;
+// a QUIC stream that only allocated locally is not considered usable. The
+// losing dial is canceled by the shared race context. A Link may still be
+// completing Connect, so the direct dial waits for that operation while Relay
+// starts immediately.
 func (l *Link) OpenStreamWithRelay(
 	endpoint string,
 	queryJSON string,
@@ -275,7 +281,15 @@ func (l *Link) openStreamContext(ctx context.Context) (net.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	return connected.OpenStream(ctx)
+	stream, err := connected.OpenStream(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := devicelink.ProbeStream(ctx, stream); err != nil {
+		_ = stream.Close()
+		return nil, fmt.Errorf("probe direct stream: %w", err)
+	}
+	return stream, nil
 }
 
 func (l *Link) waitConnected(ctx context.Context) (*authenticated.Link, error) {

--- a/packages/device-link/mobile/link_test.go
+++ b/packages/device-link/mobile/link_test.go
@@ -1,14 +1,18 @@
 package mobile
 
 import (
+	"context"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/gorilla/websocket"
+	devicelink "github.com/tutti-os/tutti/packages/device-link"
 )
 
 func TestStreamReadPreservesFinalBytesReturnedWithEOF(t *testing.T) {
@@ -70,18 +74,23 @@ func TestLoopbackLinksExchangeDescriptionsAndStreams(t *testing.T) {
 			return
 		}
 		defer stream.Close()
-		buffer := make([]byte, 1024)
-		for {
-			count := stream.ReadInto(buffer)
-			if count <= 0 {
-				serveDone <- io.EOF
-				return
+		serveDone <- devicelink.ServeStreamProbe(context.Background(), &mobileStreamConn{stream: stream}, func(
+			_ context.Context,
+			conn net.Conn,
+		) error {
+			buffer := make([]byte, 1024)
+			for {
+				count, readErr := conn.Read(buffer)
+				if count > 0 {
+					if _, writeErr := conn.Write(buffer[:count]); writeErr != nil {
+						return writeErr
+					}
+				}
+				if readErr != nil {
+					return readErr
+				}
 			}
-			if _, writeErr := stream.Write(buffer[:count]); writeErr != nil {
-				serveDone <- writeErr
-				return
-			}
-		}
+		})
 	}()
 	stream, err := caller.OpenStream(20_000)
 	if err != nil {
@@ -138,6 +147,72 @@ func TestOpenStreamWithRelayStartsBeforeConnect(t *testing.T) {
 	}
 }
 
+func TestOpenStreamWithRelayDoesNotSelectUnresponsiveDirectStream(t *testing.T) {
+	t.Parallel()
+	caller, err := NewLoopbackLink()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer caller.Close()
+	owner, err := NewLoopbackLink()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer owner.Close()
+
+	callerDescription, err := caller.LocalDescription(20_000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ownerDescription, err := owner.LocalDescription(20_000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ownerResult := make(chan error, 1)
+	go func() {
+		_, connectErr := owner.Connect(callerDescription, false, 20_000)
+		ownerResult <- connectErr
+	}()
+	if _, err := caller.Connect(ownerDescription, true, 20_000); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-ownerResult; err != nil {
+		t.Fatal(err)
+	}
+
+	unresponsiveDirect := make(chan *Stream, 1)
+	go func() {
+		stream, acceptErr := owner.AcceptStream(5_000)
+		if acceptErr != nil {
+			return
+		}
+		unresponsiveDirect <- stream
+	}()
+	relay := newRelayEchoServer(t)
+	defer relay.Close()
+
+	stream, err := caller.OpenStreamWithRelay(
+		relay.endpoint,
+		`{"authority_id":["authority-1"]}`,
+		`{"Authorization":["Bearer target-token"]}`,
+		"relay.test.v1",
+		5_000,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stream.Close()
+	if got := stream.transport; got != transportRelay {
+		t.Fatalf("transport = %q, want Relay after direct probe timeout", got)
+	}
+	select {
+	case direct := <-unresponsiveDirect:
+		_ = direct.Close()
+	case <-time.After(time.Second):
+		t.Fatal("direct stream was not accepted")
+	}
+}
+
 func TestOpenStreamCanStartBeforeConnect(t *testing.T) {
 	t.Parallel()
 	caller, err := NewLoopbackLink()
@@ -188,6 +263,15 @@ func TestOpenStreamCanStartBeforeConnect(t *testing.T) {
 	}, 1)
 	go func() {
 		stream, acceptErr := owner.AcceptStream(5_000)
+		if acceptErr == nil {
+			probeErr := devicelink.ServeStreamProbe(context.Background(), &mobileStreamConn{stream: stream}, func(
+				_ context.Context,
+				_ net.Conn,
+			) error {
+				return nil
+			})
+			acceptErr = probeErr
+		}
 		acceptResult <- struct {
 			stream *Stream
 			err    error
@@ -298,16 +382,102 @@ func newRelayEchoServer(t *testing.T) *relayTestServer {
 			return
 		}
 		defer connection.Close()
-		messageType, payload, err := connection.ReadMessage()
-		if err != nil {
-			return
-		}
-		_ = connection.WriteMessage(messageType, payload)
+		stream := &relayMessageConn{ws: connection}
+		_ = devicelink.ServeStreamProbe(context.Background(), stream, func(
+			_ context.Context,
+			stream net.Conn,
+		) error {
+			payload := make([]byte, len("relay-payload"))
+			if _, err := io.ReadFull(stream, payload); err != nil {
+				return err
+			}
+			_, err := stream.Write(payload)
+			return err
+		})
 	}))
 	return &relayTestServer{
 		endpoint: "ws" + strings.TrimPrefix(server.URL, "http"),
 		server:   server,
 	}
+}
+
+type relayMessageConn struct {
+	ws *websocket.Conn
+
+	readMu  sync.Mutex
+	readBuf []byte
+	writeMu sync.Mutex
+}
+
+func (c *relayMessageConn) Read(buffer []byte) (int, error) {
+	c.readMu.Lock()
+	defer c.readMu.Unlock()
+	for len(c.readBuf) == 0 {
+		messageType, payload, err := c.ws.ReadMessage()
+		if err != nil {
+			return 0, err
+		}
+		if messageType == websocket.BinaryMessage {
+			c.readBuf = payload
+		}
+	}
+	count := copy(buffer, c.readBuf)
+	c.readBuf = c.readBuf[count:]
+	return count, nil
+}
+
+func (c *relayMessageConn) Write(payload []byte) (int, error) {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	if err := c.ws.WriteMessage(websocket.BinaryMessage, payload); err != nil {
+		return 0, err
+	}
+	return len(payload), nil
+}
+
+func (c *relayMessageConn) Close() error         { return c.ws.Close() }
+func (c *relayMessageConn) LocalAddr() net.Addr  { return c.ws.LocalAddr() }
+func (c *relayMessageConn) RemoteAddr() net.Addr { return c.ws.RemoteAddr() }
+func (c *relayMessageConn) SetDeadline(value time.Time) error {
+	if err := c.ws.SetReadDeadline(value); err != nil {
+		return err
+	}
+	return c.ws.SetWriteDeadline(value)
+}
+func (c *relayMessageConn) SetReadDeadline(value time.Time) error {
+	return c.ws.SetReadDeadline(value)
+}
+func (c *relayMessageConn) SetWriteDeadline(value time.Time) error {
+	return c.ws.SetWriteDeadline(value)
+}
+
+type mobileStreamConn struct {
+	stream *Stream
+}
+
+func (c *mobileStreamConn) Read(buffer []byte) (int, error) {
+	count := c.stream.ReadInto(buffer)
+	if count < 0 {
+		return 0, io.EOF
+	}
+	return count, nil
+}
+
+func (c *mobileStreamConn) Write(payload []byte) (int, error) {
+	return c.stream.Write(payload)
+}
+
+func (c *mobileStreamConn) Close() error         { return c.stream.Close() }
+func (c *mobileStreamConn) LocalAddr() net.Addr  { return c.stream.conn.LocalAddr() }
+func (c *mobileStreamConn) RemoteAddr() net.Addr { return c.stream.conn.RemoteAddr() }
+func (c *mobileStreamConn) SetDeadline(value time.Time) error {
+	return c.stream.conn.SetDeadline(value)
+}
+func (c *mobileStreamConn) SetReadDeadline(value time.Time) error {
+	return c.stream.conn.SetReadDeadline(value)
+}
+func (c *mobileStreamConn) SetWriteDeadline(value time.Time) error {
+	return c.stream.conn.SetWriteDeadline(value)
 }
 
 func (s *relayTestServer) Close() {

--- a/packages/device-link/mobile/link_test.go
+++ b/packages/device-link/mobile/link_test.go
@@ -111,6 +111,113 @@ func TestLoopbackLinksExchangeDescriptionsAndStreams(t *testing.T) {
 	}
 }
 
+func TestOpenStreamWithRelayStartsBeforeConnect(t *testing.T) {
+	t.Parallel()
+	server := newRelayEchoServer(t)
+	defer server.Close()
+
+	link, err := NewLoopbackLink()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer link.Close()
+
+	stream, err := link.OpenStreamWithRelay(
+		server.endpoint,
+		`{"authority_id":["authority-1"]}`,
+		`{"Authorization":["Bearer target-token"]}`,
+		"relay.test.v1",
+		5_000,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stream.Close()
+	if got := stream.transport; got != "relay" {
+		t.Fatalf("transport = %q, want relay", got)
+	}
+}
+
+func TestOpenStreamCanStartBeforeConnect(t *testing.T) {
+	t.Parallel()
+	caller, err := NewLoopbackLink()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer caller.Close()
+	owner, err := NewLoopbackLink()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer owner.Close()
+
+	callerDescription, err := caller.LocalDescription(20_000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ownerDescription, err := owner.LocalDescription(20_000)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	streamResult := make(chan struct {
+		stream *Stream
+		err    error
+	}, 1)
+	go func() {
+		stream, openErr := caller.OpenStream(5_000)
+		streamResult <- struct {
+			stream *Stream
+			err    error
+		}{stream: stream, err: openErr}
+	}()
+	ownerResult := make(chan error, 1)
+	go func() {
+		_, connectErr := owner.Connect(callerDescription, false, 20_000)
+		ownerResult <- connectErr
+	}()
+	if _, err := caller.Connect(ownerDescription, true, 20_000); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-ownerResult; err != nil {
+		t.Fatal(err)
+	}
+	acceptResult := make(chan struct {
+		stream *Stream
+		err    error
+	}, 1)
+	go func() {
+		stream, acceptErr := owner.AcceptStream(5_000)
+		acceptResult <- struct {
+			stream *Stream
+			err    error
+		}{stream: stream, err: acceptErr}
+	}()
+	result := <-streamResult
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	if result.stream == nil {
+		t.Fatal("OpenStream returned a nil stream")
+	}
+	defer result.stream.Close()
+	if result.stream.transport != "direct" {
+		t.Fatalf("transport = %q, want direct", result.stream.transport)
+	}
+	if _, err := result.stream.Write([]byte("pending-stream")); err != nil {
+		t.Fatal(err)
+	}
+	acceptedResult := <-acceptResult
+	if acceptedResult.err != nil {
+		t.Fatal(acceptedResult.err)
+	}
+	accepted := acceptedResult.stream
+	if accepted == nil {
+		t.Fatal("AcceptStream returned a nil stream")
+	}
+	defer accepted.Close()
+}
+
 func TestProtocolEpochMatchesApplicationPrelude(t *testing.T) {
 	if ProtocolEpoch() != ApplicationProtocolEpoch {
 		t.Fatalf("ProtocolEpoch() = %d, want %d", ProtocolEpoch(), ApplicationProtocolEpoch)
@@ -119,35 +226,10 @@ func TestProtocolEpochMatchesApplicationPrelude(t *testing.T) {
 
 func TestDialRelayOpensConfiguredByteStream(t *testing.T) {
 	t.Parallel()
-	upgrader := websocket.Upgrader{
-		CheckOrigin:  func(*http.Request) bool { return true },
-		Subprotocols: []string{"relay.test.v1"},
-	}
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Query().Get("authority_id") != "authority-1" {
-			http.Error(w, "authority missing", http.StatusBadRequest)
-			return
-		}
-		if r.Header.Get("Authorization") != "Bearer target-token" {
-			http.Error(w, "authorization missing", http.StatusUnauthorized)
-			return
-		}
-		connection, err := upgrader.Upgrade(w, r, nil)
-		if err != nil {
-			return
-		}
-		defer connection.Close()
-		messageType, payload, err := connection.ReadMessage()
-		if err != nil {
-			return
-		}
-		_ = connection.WriteMessage(messageType, payload)
-	}))
+	server := newRelayEchoServer(t)
 	defer server.Close()
-
-	endpoint := "ws" + strings.TrimPrefix(server.URL, "http")
 	stream, err := DialRelay(
-		endpoint,
+		server.endpoint,
 		`{"authority_id":["authority-1"]}`,
 		`{"Authorization":["Bearer target-token"]}`,
 		"relay.test.v1",
@@ -189,6 +271,47 @@ func TestDialRelayRejectsMalformedValuesBeforeDial(t *testing.T) {
 			}
 		})
 	}
+}
+
+type relayTestServer struct {
+	endpoint string
+	server   *httptest.Server
+}
+
+func newRelayEchoServer(t *testing.T) *relayTestServer {
+	t.Helper()
+	upgrader := websocket.Upgrader{
+		CheckOrigin:  func(*http.Request) bool { return true },
+		Subprotocols: []string{"relay.test.v1"},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("authority_id") != "authority-1" {
+			http.Error(w, "authority missing", http.StatusBadRequest)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer target-token" {
+			http.Error(w, "authorization missing", http.StatusUnauthorized)
+			return
+		}
+		connection, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer connection.Close()
+		messageType, payload, err := connection.ReadMessage()
+		if err != nil {
+			return
+		}
+		_ = connection.WriteMessage(messageType, payload)
+	}))
+	return &relayTestServer{
+		endpoint: "ws" + strings.TrimPrefix(server.URL, "http"),
+		server:   server,
+	}
+}
+
+func (s *relayTestServer) Close() {
+	s.server.Close()
 }
 
 func max(left, right int) int {

--- a/packages/device-link/stream_probe.go
+++ b/packages/device-link/stream_probe.go
@@ -1,0 +1,190 @@
+package devicelink
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+)
+
+const (
+	streamProbeRequest = "tutti-device-link/stream-probe/1"
+	streamProbeAck     = "tutti-device-link/stream-probe-ack/1"
+	streamProbeNonce   = 16
+	streamProbeLimit   = 5 * time.Second
+)
+
+var (
+	ErrStreamProbeRejected = errors.New("device-link stream probe rejected")
+	ErrStreamProbeMismatch = errors.New("device-link stream probe acknowledgement mismatch")
+)
+
+// ProbeStream verifies that the authenticated peer can receive and answer a
+// fresh stream before the caller commits a direct/Relay race winner. QUIC
+// stream allocation alone is not a liveness signal: a stale session may still
+// allocate a local stream after its network path has become unusable.
+//
+// The probe is transport-owned and carries no Agent or product payload. The
+// peer must run ServeStreamProbe before handing the stream to its application
+// protocol handler. The same stream is left open after the acknowledgement so
+// callers can immediately write their application prelude without a second
+// race or an ambiguous request retry.
+func ProbeStream(ctx context.Context, stream net.Conn) error {
+	if stream == nil {
+		return errors.New("device-link stream probe requires a stream")
+	}
+	probeCtx, cancel := streamProbeContext(ctx)
+	defer cancel()
+	stopClose := closeStreamOnContext(probeCtx, stream)
+	defer stopClose()
+	if err := setProbeDeadline(probeCtx, stream); err != nil {
+		return fmt.Errorf("set device-link stream probe deadline: %w", err)
+	}
+	defer func() { _ = stream.SetDeadline(time.Time{}) }()
+
+	nonce := make([]byte, streamProbeNonce)
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return fmt.Errorf("generate device-link stream probe nonce: %w", err)
+	}
+	if err := writeProbeMessage(stream, streamProbeRequest, nonce); err != nil {
+		return fmt.Errorf("write device-link stream probe: %w", err)
+	}
+	ack, err := readProbeMessage(stream, streamProbeAck)
+	if err != nil {
+		return err
+	}
+	if !equalBytes(ack, nonce) {
+		return ErrStreamProbeMismatch
+	}
+	stopClose()
+	cancel()
+	_ = stream.SetDeadline(time.Time{})
+	return nil
+}
+
+// ServeStreamProbe acknowledges one ProbeStream call and then invokes next
+// with the same stream. A failed probe never reaches the product handler.
+// This keeps application framing and request semantics out of the shared
+// transport handshake while still proving that the remote endpoint is alive.
+func ServeStreamProbe(
+	ctx context.Context,
+	stream net.Conn,
+	next func(context.Context, net.Conn) error,
+) error {
+	if stream == nil {
+		return errors.New("device-link stream probe requires a stream")
+	}
+	if next == nil {
+		return errors.New("device-link stream probe handler is required")
+	}
+	probeCtx, cancel := streamProbeContext(ctx)
+	defer cancel()
+	stopClose := closeStreamOnContext(probeCtx, stream)
+	defer stopClose()
+	if err := setProbeDeadline(probeCtx, stream); err != nil {
+		return fmt.Errorf("set device-link stream probe deadline: %w", err)
+	}
+	defer func() { _ = stream.SetDeadline(time.Time{}) }()
+
+	nonce, err := readProbeMessage(stream, streamProbeRequest)
+	if err != nil {
+		return err
+	}
+	if err := writeProbeMessage(stream, streamProbeAck, nonce); err != nil {
+		return fmt.Errorf("write device-link stream probe acknowledgement: %w", err)
+	}
+	stopClose()
+	cancel()
+	_ = stream.SetDeadline(time.Time{})
+	return next(ctx, stream)
+}
+
+func streamProbeContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, ok := ctx.Deadline(); ok {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, streamProbeLimit)
+}
+
+func closeStreamOnContext(ctx context.Context, stream net.Conn) func() {
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+	var once sync.Once
+	go func() {
+		defer close(stopped)
+		select {
+		case <-ctx.Done():
+			_ = stream.Close()
+		case <-done:
+		}
+	}()
+	return func() {
+		once.Do(func() {
+			close(done)
+			<-stopped
+		})
+	}
+}
+
+func setProbeDeadline(ctx context.Context, stream net.Conn) error {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return nil
+	}
+	return stream.SetDeadline(deadline)
+}
+
+func writeProbeMessage(writer io.Writer, kind string, nonce []byte) error {
+	if err := writeProbeBytes(writer, []byte(kind)); err != nil {
+		return err
+	}
+	return writeProbeBytes(writer, nonce)
+}
+
+func readProbeMessage(reader io.Reader, kind string) ([]byte, error) {
+	header := make([]byte, len(kind))
+	if _, err := io.ReadFull(reader, header); err != nil {
+		return nil, fmt.Errorf("read device-link stream probe header: %w", err)
+	}
+	if string(header) != kind {
+		return nil, ErrStreamProbeRejected
+	}
+	nonce := make([]byte, streamProbeNonce)
+	if _, err := io.ReadFull(reader, nonce); err != nil {
+		return nil, fmt.Errorf("read device-link stream probe nonce: %w", err)
+	}
+	return nonce, nil
+}
+
+func writeProbeBytes(writer io.Writer, payload []byte) error {
+	for len(payload) > 0 {
+		written, err := writer.Write(payload)
+		if err != nil {
+			return err
+		}
+		if written <= 0 || written > len(payload) {
+			return io.ErrShortWrite
+		}
+		payload = payload[written:]
+	}
+	return nil
+}
+
+func equalBytes(left, right []byte) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}

--- a/packages/device-link/stream_probe_test.go
+++ b/packages/device-link/stream_probe_test.go
@@ -1,0 +1,99 @@
+package devicelink
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestStreamProbeLeavesVerifiedStreamForApplicationPayload(t *testing.T) {
+	t.Parallel()
+	server, client := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	serverDone := make(chan error, 1)
+	go func() {
+		serverDone <- ServeStreamProbe(context.Background(), server, func(_ context.Context, stream net.Conn) error {
+			payload := make([]byte, len("application-payload"))
+			if _, err := io.ReadFull(stream, payload); err != nil {
+				return err
+			}
+			if string(payload) != "application-payload" {
+				return errors.New("unexpected application payload")
+			}
+			_, err := stream.Write([]byte("application-ack"))
+			return err
+		})
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := ProbeStream(ctx, client); err != nil {
+		t.Fatalf("ProbeStream() error = %v", err)
+	}
+	if _, err := client.Write([]byte("application-payload")); err != nil {
+		t.Fatalf("write application payload: %v", err)
+	}
+	ack := make([]byte, len("application-ack"))
+	if _, err := io.ReadFull(client, ack); err != nil {
+		t.Fatalf("read application acknowledgement: %v", err)
+	}
+	if string(ack) != "application-ack" {
+		t.Fatalf("application acknowledgement = %q", ack)
+	}
+	if err := <-serverDone; err != nil {
+		t.Fatalf("ServeStreamProbe() error = %v", err)
+	}
+}
+
+func TestStreamProbeCancellationClosesBlockedStream(t *testing.T) {
+	t.Parallel()
+	server, client := net.Pipe()
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() { result <- ProbeStream(ctx, client) }()
+	cancel()
+
+	select {
+	case err := <-result:
+		if err == nil {
+			t.Fatal("ProbeStream() succeeded after cancellation")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ProbeStream() did not observe cancellation")
+	}
+	_ = client.Close()
+}
+
+func TestStreamProbeRejectsUnexpectedRequest(t *testing.T) {
+	t.Parallel()
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	result := make(chan error, 1)
+	go func() {
+		result <- ServeStreamProbe(context.Background(), server, func(context.Context, net.Conn) error {
+			return nil
+		})
+	}()
+	payload := make([]byte, len(streamProbeRequest))
+	copy(payload, "unexpected")
+	if _, err := client.Write(payload); err != nil {
+		t.Fatalf("write unexpected probe: %v", err)
+	}
+	select {
+	case err := <-result:
+		if !errors.Is(err, ErrStreamProbeRejected) {
+			t.Fatalf("ServeStreamProbe() error = %v, want rejection", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ServeStreamProbe() did not reject unexpected request")
+	}
+}

--- a/services/tuttid/service/mobileremote/relay_owner.go
+++ b/services/tuttid/service/mobileremote/relay_owner.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	deviceauthority "github.com/tutti-os/tutti/packages/clients/device-authority-go"
+	devicelink "github.com/tutti-os/tutti/packages/device-link"
 	"github.com/tutti-os/tutti/packages/device-link/relaytransport"
 )
 
@@ -429,7 +430,12 @@ func (s *Service) handleRelayStream(ctx context.Context, stream net.Conn) error 
 	if handler == nil {
 		return errors.New("mobile remote handler is unavailable")
 	}
-	return serveRemoteStreamWithAgentLive(ctx, stream, handler, pairingID, liveEvents)
+	return devicelink.ServeStreamProbe(ctx, stream, func(
+		ctx context.Context,
+		stream net.Conn,
+	) error {
+		return serveRemoteStreamWithAgentLive(ctx, stream, handler, pairingID, liveEvents)
+	})
 }
 
 func (s *Service) authorizeRelayPairing(_ context.Context, targetUserID, pairingID string) error {

--- a/services/tuttid/service/mobileremote/relay_owner_test.go
+++ b/services/tuttid/service/mobileremote/relay_owner_test.go
@@ -14,6 +14,7 @@ import (
 
 	authbridge "github.com/tutti-os/tutti/packages/auth/bridge-go"
 	deviceauthority "github.com/tutti-os/tutti/packages/clients/device-authority-go"
+	devicelink "github.com/tutti-os/tutti/packages/device-link"
 	mobileremotebiz "github.com/tutti-os/tutti/services/tuttid/biz/mobileremote"
 )
 
@@ -148,6 +149,9 @@ func TestHandleRelayStreamValidatesPreludeAndUsesExistingAgentFraming(t *testing
 		done <- service.handleRelayStream(context.Background(), owner)
 	}()
 	writeRelayTestPrelude(t, caller)
+	if err := devicelink.ProbeStream(context.Background(), caller); err != nil {
+		t.Fatalf("probe Relay stream: %v", err)
+	}
 	if err := writeRemoteFrame(caller, RemoteRequest{
 		ProtocolEpoch: ApplicationProtocolEpoch,
 		Service:       AgentHTTPService,

--- a/services/tuttid/service/mobileremote/remote_host.go
+++ b/services/tuttid/service/mobileremote/remote_host.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"crypto/ed25519"
 	"errors"
+	"net"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
 
+	devicelink "github.com/tutti-os/tutti/packages/device-link"
 	authenticatedlink "github.com/tutti-os/tutti/packages/device-link/authenticated"
 	"github.com/tutti-os/tutti/packages/device-link/linkmanager"
 	mobileremotebiz "github.com/tutti-os/tutti/services/tuttid/biz/mobileremote"
@@ -554,13 +556,18 @@ func serveManagedRemoteStream(
 	incoming linkmanager.IncomingStream[string, remoteLinkMetadata],
 ) error {
 	metadata := incoming.Metadata
-	return serveRemoteStreamWithAgentLive(
-		ctx,
-		incoming.Stream,
-		metadata.handler,
-		metadata.pairingID,
-		metadata.liveEvents,
-	)
+	return devicelink.ServeStreamProbe(ctx, incoming.Stream, func(
+		ctx context.Context,
+		stream net.Conn,
+	) error {
+		return serveRemoteStreamWithAgentLive(
+			ctx,
+			stream,
+			metadata.handler,
+			metadata.pairingID,
+			metadata.liveEvents,
+		)
+	})
 }
 
 func deviceLinkProof(action, pairingID, attemptID, fingerprint string) []byte {

--- a/services/tuttid/service/mobileremote/remote_host_test.go
+++ b/services/tuttid/service/mobileremote/remote_host_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	authbridge "github.com/tutti-os/tutti/packages/auth/bridge-go"
+	devicelink "github.com/tutti-os/tutti/packages/device-link"
 	authenticatedlink "github.com/tutti-os/tutti/packages/device-link/authenticated"
 	"github.com/tutti-os/tutti/packages/device-link/linkmanager"
 	mobileremotebiz "github.com/tutti-os/tutti/services/tuttid/biz/mobileremote"
@@ -196,6 +197,9 @@ func TestRemoteHostConnectsAuthenticatedLinkAndServesAgentHTTP(t *testing.T) {
 	stream, err := link.OpenStream(ctx)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if err := devicelink.ProbeStream(ctx, stream); err != nil {
+		t.Fatalf("probe DeviceLink stream: %v", err)
 	}
 	if err := writeRemoteFrame(stream, RemoteRequest{
 		ProtocolEpoch: ApplicationProtocolEpoch, Service: AgentHTTPService,


### PR DESCRIPTION
## Summary

- Race the mobile direct DeviceLink attempt and Relay descriptor preparation in parallel.
- Race direct and Relay Agent HTTP/live data streams at the native transport boundary.
- Require every direct/Relay stream candidate to complete the shared DeviceLink transport probe (fresh nonce/ACK) before it can win; the verified stream is then reused for application framing.
- Keep the existing direct path, UI/path-scope contract, Agent DTOs, and service ports unchanged.
- Add focused Go/TypeScript/native-boundary tests and update the mobile transport documentation.

## Why

A Relay WebSocket upgrade only proves that the tunnel is dialable. A stale authenticated direct QUIC session can have the same problem in the opposite direction: `OpenStreamSync` can allocate a local stream after a network transition even though the peer is unreachable. The race could therefore select direct, cancel a working Relay stream, and only fail when the later Agent request was written. The shared transport probe now requires a peer ACK before either candidate is selected, without retrying an ambiguous application request.

## Scope

This PR contains the direct/Relay race and its transport/application handshake gates. It does not change the direct ICE/rendezvous strategy or the current connection-establishment latency. The approximately 18-second direct connection path observed on a real Android device is a separate follow-up performance item.

## Validation

- `pnpm --filter @tutti-os/mobile test -- src/services/pairingClient.test.ts src/services/pairingTransportRace.test.ts` — 14 tests passed
- `pnpm --filter @tutti-os/mobile typecheck`
- `go test ./packages/device-link/... ./services/tuttid/service/mobileremote`
- `go test -race ./packages/device-link/... ./services/tuttid/service/mobileremote`
- `go vet ./packages/device-link/... ./services/tuttid/service/mobileremote`
- `pnpm check:changed -- --push-ready`
- Real Android device smoke test: paired-device connection, workspace/session loading, live Agent request, and the Relay handshake guard path exercised

## Follow-up

Investigate and reduce the direct connection setup latency separately; do not treat the current 18-second path as an acceptance target.