### PR TITLE
fix(windows): stabilize local agent startup and model catalog

### DIFF
--- a/packages/agent/runtimeprep/codex.go
+++ b/packages/agent/runtimeprep/codex.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 )
@@ -322,6 +323,17 @@ func ensureCodexSessionConfig(configPath string, input PrepareInput) error {
 		next = planNext
 		changed = true
 	}
+	// Tutti launches the Codex app-server from the non-elevated desktop daemon.
+	// On Windows, the elevated sandbox implementation invokes a separate setup
+	// helper through ShellExecuteExW, which requires an interactive UAC consent
+	// flow that is not owned by the app-server protocol. Use the restricted,
+	// non-elevated implementation for Tutti-owned session homes so a hidden or
+	// canceled UAC prompt cannot prevent every command from starting. The
+	// Codex/Tutti permission mode and approval policy remain unchanged.
+	if windowsSandboxNext, windowsSandboxChanged := codexConfigWithTuttiWindowsSandbox(next); windowsSandboxChanged {
+		next = windowsSandboxNext
+		changed = true
+	}
 	if !changed {
 		return nil
 	}
@@ -329,6 +341,59 @@ func ensureCodexSessionConfig(configPath string, input PrepareInput) error {
 		return fmt.Errorf("write codex config: %w", err)
 	}
 	return nil
+}
+
+// codexConfigWithTuttiWindowsSandbox pins Tutti-owned Codex session homes to
+// the unelevated Windows sandbox implementation. This is intentionally applied
+// only on Windows and only to the copied per-session config, never to the
+// user's global ~/.codex/config.toml.
+func codexConfigWithTuttiWindowsSandbox(content string) (string, bool) {
+	if runtime.GOOS != "windows" {
+		return content, false
+	}
+
+	normalized := strings.ReplaceAll(content, "\r\n", "\n")
+	lines := strings.Split(normalized, "\n")
+	for sectionStart, line := range lines {
+		if strings.TrimSpace(line) != "[windows]" {
+			continue
+		}
+		sectionEnd := len(lines)
+		for index := sectionStart + 1; index < len(lines); index++ {
+			trimmed := strings.TrimSpace(lines[index])
+			if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+				sectionEnd = index
+				break
+			}
+		}
+		for index := sectionStart + 1; index < sectionEnd; index++ {
+			trimmed := strings.TrimSpace(lines[index])
+			if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+				continue
+			}
+			if !codexConfigLineHasKey(trimmed, "sandbox") {
+				continue
+			}
+			if strings.TrimSpace(lines[index]) == `sandbox = "unelevated"` {
+				return content, false
+			}
+			next := append([]string{}, lines...)
+			next[index] = `sandbox = "unelevated"`
+			return strings.Join(next, "\n"), true
+		}
+		next := make([]string, 0, len(lines)+1)
+		next = append(next, lines[:sectionEnd]...)
+		next = append(next, `sandbox = "unelevated"`)
+		next = append(next, lines[sectionEnd:]...)
+		return strings.Join(next, "\n"), true
+	}
+
+	next := strings.TrimRight(normalized, "\n")
+	if next != "" {
+		next += "\n\n"
+	}
+	next += "[windows]\nsandbox = \"unelevated\"\n"
+	return next, true
 }
 
 func codexConfigWithTuttiConversationDetailMode(content string, conversationDetailMode string) (string, bool) {

--- a/packages/agent/runtimeprep/codex_windows_sandbox_test.go
+++ b/packages/agent/runtimeprep/codex_windows_sandbox_test.go
@@ -1,0 +1,73 @@
+package runtimeprep
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestCodexConfigWithTuttiWindowsSandboxPinsUnelevated(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows session config policy")
+	}
+
+	got, changed := codexConfigWithTuttiWindowsSandbox(`model = "gpt-5.6-luna"
+
+[windows]
+sandbox = "elevated"
+
+[tutti]
+conversationDetailMode = "coding"
+`)
+	if !changed {
+		t.Fatal("changed = false, want true")
+	}
+	if want := `sandbox = "unelevated"`; !containsConfigLine(got, want) {
+		t.Fatalf("config missing %q:\n%s", want, got)
+	}
+	if containsConfigLine(got, `sandbox = "elevated"`) {
+		t.Fatalf("config retained elevated sandbox:\n%s", got)
+	}
+}
+
+func TestCodexConfigWithTuttiWindowsSandboxAddsSection(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows session config policy")
+	}
+
+	got, changed := codexConfigWithTuttiWindowsSandbox("model = \"gpt-5.6-luna\"\n")
+	if !changed {
+		t.Fatal("changed = false, want true")
+	}
+	if want := "[windows]\nsandbox = \"unelevated\""; !containsConfigBlock(got, want) {
+		t.Fatalf("config missing Windows sandbox block %q:\n%s", want, got)
+	}
+}
+
+func TestCodexConfigWithTuttiWindowsSandboxIsIdempotent(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows session config policy")
+	}
+
+	content := "[windows]\nsandbox = \"unelevated\"\n"
+	got, changed := codexConfigWithTuttiWindowsSandbox(content)
+	if changed {
+		t.Fatal("changed = true, want false")
+	}
+	if got != content {
+		t.Fatalf("content changed:\ngot:\n%s\nwant:\n%s", got, content)
+	}
+}
+
+func containsConfigLine(content, line string) bool {
+	for _, candidate := range strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n") {
+		if candidate == line {
+			return true
+		}
+	}
+	return false
+}
+
+func containsConfigBlock(content, block string) bool {
+	return strings.Contains(content, block)
+}

--- a/packages/agent/runtimeprep/tutti_agent.go
+++ b/packages/agent/runtimeprep/tutti_agent.go
@@ -197,6 +197,14 @@ func ensureTuttiAgentSessionConfig(configPath string, input PrepareInput) error 
 		next = planNext
 		changed = true
 	}
+	// Tutti Agent uses the same Codex-derived app-server sandbox runtime as
+	// Codex, but it is launched by Tutti's non-elevated desktop daemon. Keep
+	// the Windows implementation aligned with Codex session homes so an
+	// interactive UAC setup helper cannot block app-server startup.
+	if windowsSandboxNext, windowsSandboxChanged := codexConfigWithTuttiWindowsSandbox(next); windowsSandboxChanged {
+		next = windowsSandboxNext
+		changed = true
+	}
 	if !changed {
 		return nil
 	}

--- a/packages/agent/runtimeprep/tutti_agent_test.go
+++ b/packages/agent/runtimeprep/tutti_agent_test.go
@@ -79,6 +79,9 @@ func TestTuttiAgentPreparerUsesExplicitAuthSourceAndInstallsSkills(t *testing.T)
 			t.Fatalf("managed config unexpectedly pinned %q: %s", unexpected, config)
 		}
 	}
+	if runtime.GOOS == "windows" && !containsConfigBlock(string(config), "[windows]\nsandbox = \"unelevated\"") {
+		t.Fatalf("Tutti Agent session config missing Windows sandbox fallback: %s", config)
+	}
 	if len(result.Env) == 0 || result.Env[0] != "TUTTI_AGENT_HOME="+home {
 		t.Fatalf("Prepare() env = %#v", result.Env)
 	}

--- a/services/tuttid/service/agent/model_catalog.go
+++ b/services/tuttid/service/agent/model_catalog.go
@@ -1,8 +1,10 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -280,6 +282,9 @@ func prepareTuttiAgentModelListEnv(ctx context.Context, env []string) ([]string,
 	env = withoutEnvKeys(env, "TUTTI_AGENT_HOME", "CODEX_HOME")
 	tuttiAgentHome := filepath.Join(tuttitypes.DefaultStateDir(), "agent-model-catalog", "tutti-agent-home")
 	tuttiagentservice.BootstrapTuttiAgentUserAuth(ctx)
+	if err := refreshTuttiAgentModelCatalogAuth(tuttiAgentHome); err != nil {
+		return nil, err
+	}
 	if err := tuttiagentservice.PrepareHome(tuttiAgentHome); err != nil {
 		return nil, err
 	}
@@ -288,6 +293,38 @@ func prepareTuttiAgentModelListEnv(ctx context.Context, env []string) ([]string,
 	// model cache when tuttid itself runs inside a Codex-hosted environment.
 	env = append(env, "CODEX_HOME=")
 	return env, nil
+}
+
+// refreshTuttiAgentModelCatalogAuth drops only a stale materialized auth view
+// in the dedicated model-catalog home. PrepareHome will then recreate the
+// view from the freshly bootstrapped user auth (symlink/hard-link when
+// possible). This matters on Windows, where a first-run copy can otherwise
+// remain frozen after the host auth is refreshed.
+func refreshTuttiAgentModelCatalogAuth(home string) error {
+	userHome, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(userHome) == "" {
+		return nil
+	}
+	source := filepath.Join(userHome, ".tutti-agent", "auth.json")
+	sourceBytes, err := os.ReadFile(source)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read tutti-agent user auth: %w", err)
+	}
+	target := filepath.Join(home, "auth.json")
+	targetBytes, err := os.ReadFile(target)
+	if err == nil && bytes.Equal(sourceBytes, targetBytes) {
+		return nil
+	}
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read tutti-agent model catalog auth: %w", err)
+	}
+	if err := os.Remove(target); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove stale tutti-agent model catalog auth: %w", err)
+	}
+	return nil
 }
 
 func withoutEnvKeys(env []string, keys ...string) []string {

--- a/services/tuttid/service/agent/model_catalog_test.go
+++ b/services/tuttid/service/agent/model_catalog_test.go
@@ -361,6 +361,7 @@ func TestAgentModelCatalogListsTuttiAgentModelsFromLiveLister(t *testing.T) {
 func TestDefaultTuttiAgentModelListerUsesTuttiHomeAndClearsCodexHome(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	stateDir := filepath.Join(home, "state")
 	t.Setenv("TUTTI_STATE_DIR", stateDir)
 	userAgentHome := filepath.Join(home, ".tutti-agent")
@@ -511,6 +512,43 @@ func TestDefaultTuttiAgentModelListerBootstrapsExpiredTuttiAgentAuth(t *testing.
 	}
 	if !strings.Contains(string(loginJSON), `"access_token":"lat_new"`) {
 		t.Fatalf("login payload = %s, want issued access token", string(loginJSON))
+	}
+}
+
+func TestPrepareTuttiAgentModelListEnvRefreshesStaleCatalogAuth(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	stateDir := filepath.Join(home, "state")
+	t.Setenv("TUTTI_STATE_DIR", stateDir)
+
+	userAgentHome := filepath.Join(home, ".tutti-agent")
+	if err := os.MkdirAll(userAgentHome, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	accessExpiresAt := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+	currentAuth := `{"tutti_llm":{"access_token":"lat_new","access_token_expires_at":` + strconv.Quote(accessExpiresAt) + `,"refresh_token":"lrt_new"}}`
+	if err := os.WriteFile(filepath.Join(userAgentHome, "auth.json"), []byte(currentAuth), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	catalogHome := filepath.Join(stateDir, "agent-model-catalog", "tutti-agent-home")
+	if err := os.MkdirAll(catalogHome, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(catalogHome, "auth.json"), []byte(`{"tutti_llm":{"access_token":"lat_old","refresh_token":"lrt_old"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := prepareTuttiAgentModelListEnv(t.Context(), nil); err != nil {
+		t.Fatalf("prepareTuttiAgentModelListEnv() error = %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(catalogHome, "auth.json"))
+	if err != nil {
+		t.Fatalf("read catalog auth: %v", err)
+	}
+	if string(got) != currentAuth {
+		t.Fatal("catalog auth did not refresh from user auth")
 	}
 }
 


### PR DESCRIPTION
## What changed
- Pin Tutti-owned Codex and Tutti Agent session homes to the Windows `unelevated` sandbox implementation.
- Add coverage for replacing, adding, and preserving the Windows sandbox setting, including Tutti Agent preparation.
- Refresh a stale materialized Tutti Agent auth view before model catalog listing.

## Why
The elevated Windows sandbox setup launches an interactive helper through `ShellExecuteExW`. In Tutti's non-elevated app-server path, a hidden, canceled, or unavailable UAC flow caused command startup to fail with Windows error 1223. Tutti Agent uses the same Codex-derived app-server runtime and needed the same session-scoped fallback. Separately, the dedicated model-catalog home could retain an old copied auth file after host auth refresh, causing model discovery to use stale credentials.

## Scope and safety
- Only per-session `CODEX_HOME/config.toml` and `TUTTI_AGENT_HOME/config.toml` are changed.
- User-global Codex/Tutti Agent configuration and permission/approval policy are not modified.
- Claude Code, Cursor, OpenCode, and other ACP/SDK providers are not given Codex-specific Windows config.

## Validation
- `go test ./packages/agent/runtimeprep -run 'Test(TuttiAgentPreparer|PrepareTuttiAgentHome|CodexConfigWithTuttiWindowsSandbox)' -count=1`
- `go test ./service/agent -run '^TestPrepareTuttiAgentModelListEnvRefreshesStaleCatalogAuth$' -count=1 -v`
- `go build -o apps\\desktop\\build\\tuttid\\tuttid.exe ./services\\tuttid`
- Direct `tutti-agent -c 'windows.sandbox="unelevated"' sandbox ...` smoke test succeeded.