### PR TITLE
fix(agent): align file change diff statistics

### DIFF
--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -82,6 +82,7 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 - [Agent session restore breaks when durable snapshot ownership is split](./agent-session-lifecycle.md#agent-session-restore-breaks-when-durable-snapshot-ownership-is-split)
 - [Agent activity live updates fail after event schema changes](./agent-session-lifecycle.md#agent-activity-live-updates-fail-after-event-schema-changes)
 - [AgentGUI file-change undo reports a generic failure](./agent-session-lifecycle.md#agentgui-file-change-undo-reports-a-generic-failure)
+- [AgentGUI changed-files summary shows negative lines for a new file](./agent-session-lifecycle.md#agentgui-changed-files-summary-shows-negative-lines-for-a-new-file)
 - [Cursor deleted files appear as created or modified](./agent-session-lifecycle.md#cursor-deleted-files-appear-as-created-or-modified)
 - [AgentGUI compaction timer keeps running after compaction completed](./agent-session-lifecycle.md#agentgui-compaction-timer-keeps-running-after-compaction-completed)
 - [AgentActivity replication repeatedly rejects message batches as invalid](./agent-session-lifecycle.md#agentactivity-replication-repeatedly-rejects-message-batches-as-invalid)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -2463,6 +2463,38 @@ inline data URL instead`. Claude or standard ACP may instead receive no
   [agentPatchMetadata.ts](../../../packages/agent/gui/shared/agentConversation/rules/agentPatchMetadata.ts)
   [git_patch.go](../../../services/tuttid/service/agent/git_patch.go)
 
+### AgentGUI changed-files summary shows negative lines for a new file
+
+- Symptom:
+  The file-edit row reports additions, but the settled changed-files summary
+  reports deletions, often matching the number of Markdown list items that
+  begin with `-`. The worktree file itself is present and complete.
+- Quick checks:
+  Compare the final file's line count with the tool row, then inspect the
+  canonical `turn.fileChanges.files[]` entry. A real unified diff has a hunk
+  header such as `@@ -0,0 +1,13 @@`; a file body stored in `unifiedDiff` is
+  malformed metadata, not a diff.
+- Root cause:
+  The summary projection used any non-empty `unifiedDiff` as a valid patch and
+  counted every line beginning with `-` as a removal. Its content fallback also
+  discarded blank lines, so the summary and tool row could use different line
+  totals for the same write.
+- Fix:
+  Normalize `fileChanges` at the runtime and durable-payload boundaries: a
+  created file's raw body becomes `newString`, while `unifiedDiff` is retained
+  only when it has a real hunk. AgentGUI also requires a hunk before parsing
+  historical payloads and shares the line-count helper with tool render data,
+  so blank lines are counted consistently.
+- Validation:
+  Cover a created Markdown body containing list items and blank lines at both
+  canonicalization boundaries, then run the Agent runtime and AgentGUI tests
+  and typechecks.
+- References:
+  [tool_file_changes.go](../../../packages/agent/daemon/runtime/tool_file_changes.go)
+  [tool_payload.go](../../../packages/agent/store-sqlite/canonical/tool_payload.go)
+  [agentUnifiedDiff.ts](../../../packages/agent/gui/shared/agentConversation/components/tool-renderers/file-diff/agentUnifiedDiff.ts)
+  [AgentTurnSummaryRow.tsx](../../../packages/agent/gui/shared/agentConversation/components/AgentTurnSummaryRow.tsx)
+
 ### Cursor deleted files appear as created or modified
 
 - Symptom:

--- a/packages/agent/daemon/runtime/process_transport.go
+++ b/packages/agent/daemon/runtime/process_transport.go
@@ -385,14 +385,8 @@ func (w processFrameWriter) Write(data []byte) (int, error) {
 	} else {
 		frame.Stderr = chunk
 	}
-	select {
-	case w.conn.frames <- frame:
-		return len(data), nil
-	case <-w.conn.closing:
-		// Closing intentionally discards unread diagnostics. Report the write as
-		// consumed so an orderly shutdown is not rewritten as a copy failure.
-		return len(data), nil
-	}
+	w.conn.sendFrame(frame)
+	return len(data), nil
 }
 
 func (c *localProcessConnection) wait() {
@@ -409,10 +403,31 @@ func (c *localProcessConnection) wait() {
 			exitCode = exitErr.ExitCode()
 		}
 	}
-	select {
-	case c.frames <- ProcessFrame{ExitCode: &exitCode}:
-	case <-c.closing:
-	}
+	c.sendFrame(ProcessFrame{ExitCode: &exitCode})
 	close(c.frames)
 	close(c.done)
+}
+
+// sendFrame preserves the output ordering guarantee even when Close has
+// started. Once closing is signaled, a send and the close signal are both
+// ready; choosing between them directly would make final stdout/stderr
+// diagnostics disappear nondeterministically. Prefer an available queue slot
+// before observing closing, and make one last non-blocking attempt after the
+// connection starts closing.
+func (c *localProcessConnection) sendFrame(frame ProcessFrame) {
+	select {
+	case c.frames <- frame:
+		return
+	default:
+	}
+
+	select {
+	case c.frames <- frame:
+		return
+	case <-c.closing:
+		select {
+		case c.frames <- frame:
+		default:
+		}
+	}
 }

--- a/packages/agent/daemon/runtime/process_transport_test.go
+++ b/packages/agent/daemon/runtime/process_transport_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -198,6 +199,45 @@ func TestLocalProcessTransportDeliversFinalStdoutBeforeExit(t *testing.T) {
 	}
 	if stdout != "final-output" {
 		t.Fatalf("stdout before exit = %q, want final-output", stdout)
+	}
+}
+
+func TestLocalProcessTransportPreservesFinalStderrBeforeClose(t *testing.T) {
+	shPath, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("sh is unavailable")
+	}
+
+	conn, err := NewLocalProcessTransport().Start(context.Background(), ProcessSpec{
+		Command: []string{shPath, "-c", "printf 'final-stderr\\n' >&2; exit 1"},
+	})
+	if err != nil {
+		t.Fatalf("start transport: %v", err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatalf("close transport: %v", err)
+	}
+
+	var stderr string
+	var exitCode *int
+	for {
+		frame, err := conn.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("recv frame: %v", err)
+		}
+		stderr += string(frame.Stderr)
+		if frame.ExitCode != nil {
+			exitCode = frame.ExitCode
+		}
+	}
+	if stderr != "final-stderr\n" {
+		t.Fatalf("stderr before close = %q, want final-stderr", stderr)
+	}
+	if exitCode == nil || *exitCode != 1 {
+		t.Fatalf("exit code = %v, want 1", exitCode)
 	}
 }
 

--- a/packages/agent/daemon/runtime/tool_file_changes.go
+++ b/packages/agent/daemon/runtime/tool_file_changes.go
@@ -1,10 +1,14 @@
 package agentruntime
 
 import (
+	"regexp"
+	"strconv"
 	"strings"
 
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
+
+var unifiedDiffHunkPattern = regexp.MustCompile(`^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(?:.*)$`)
 
 // fileChangesFromActivityEvent projects provider tool payloads into the one
 // canonical shape persisted on WorkspaceAgentTurn. Provider-specific metadata
@@ -17,12 +21,14 @@ func canonicalFileChangesFromToolPayload(payload map[string]any) map[string]any 
 	if len(payload) == 0 {
 		return nil
 	}
+	hint := toolFileChangeKind(payload)
 	if fileChanges := payloadMap(payload, "fileChanges"); len(fileChanges) > 0 {
-		return clonePayload(fileChanges)
+		if canonical := canonicalizeFileChanges(fileChanges, hint); canonical != nil {
+			return canonical
+		}
 	}
 	input := payloadMap(payload, "input")
 	output := payloadMap(payload, "output")
-	hint := toolFileChangeKind(payload)
 	for _, candidate := range []map[string]any{
 		fileChangesFromChangeEntries(output["changes"], hint),
 		fileChangesFromChangeEntries(input["changes"], hint),
@@ -39,6 +45,27 @@ func canonicalFileChangesFromToolPayload(payload map[string]any) map[string]any 
 		}
 	}
 	return nil
+}
+
+func canonicalizeFileChanges(value map[string]any, hint string) map[string]any {
+	entries := fileChangeEntryMaps(value["files"])
+	if len(entries) == 0 {
+		return nil
+	}
+	files := make([]any, 0, len(entries))
+	for _, entry := range entries {
+		if file := canonicalToolFileChange(entry, hint); file != nil {
+			files = append(files, file)
+		}
+	}
+	canonical := canonicalFileChanges(files)
+	if canonical == nil {
+		return nil
+	}
+	if coverage := strings.TrimSpace(asString(value["coverage"])); coverage != "" {
+		canonical["coverage"] = coverage
+	}
+	return canonical
 }
 
 func fileChangesFromChangeEntries(value any, hint string) map[string]any {
@@ -128,18 +155,21 @@ func canonicalToolFileChange(value map[string]any, hint string) map[string]any {
 	if path == "" {
 		return nil
 	}
-	diff := firstNonEmpty(
-		asStringRaw(value["diff"]),
-		asStringRaw(value["patch"]),
-		asStringRaw(value["unifiedDiff"]),
-		asStringRaw(value["unified_diff"]),
+	validDiff, hasValidDiff, rawDiff, hasRawDiff := selectToolFileDiff(
+		value["diff"],
+		value["patch"],
+		value["unifiedDiff"],
+		value["unified_diff"],
 	)
+	diff := validDiff
+	hasDiff := hasValidDiff
 	oldString, hasOld := firstPresentToolFileString(
 		value["oldString"], value["old_string"], value["oldText"],
 	)
 	newString, hasNew := firstPresentToolFileString(
-		value["newString"], value["new_string"], value["newText"], value["content"],
+		value["newString"], value["new_string"], value["newText"],
 	)
+	content, hasContent := firstPresentToolFileString(value["content"])
 	change := firstNonEmpty(
 		normalizeToolFileChangeKind(value["change"]),
 		normalizeToolFileChangeKind(value["status"]),
@@ -147,14 +177,34 @@ func canonicalToolFileChange(value map[string]any, hint string) map[string]any {
 		normalizeToolFileChangeKind(value["type"]),
 		hint,
 	)
+	if change == "" && hasContent {
+		change = "added"
+	}
+	if change == "added" && !hasNew && hasContent {
+		newString, hasNew = content, true
+		hasContent = false
+	}
+	if !hasValidDiff && hasRawDiff {
+		switch {
+		case change == "added" && !hasNew:
+			newString, hasNew = rawDiff, true
+		case change == "deleted" && !hasOld:
+			oldString, hasOld = rawDiff, true
+		case !hasOld && !hasNew && !hasContent:
+			content, hasContent = rawDiff, true
+		}
+	}
 	if change == "" {
 		change = inferToolFileChangeKind(hasOld, oldString, hasNew, newString, diff)
+		if change == "" && hasContent {
+			change = "modified"
+		}
 	}
 	if change == "" {
 		return nil
 	}
 	file := map[string]any{"path": path, "change": change}
-	if diff != "" {
+	if hasDiff {
 		file["diff"] = diff
 		file["unifiedDiff"] = diff
 	}
@@ -163,6 +213,9 @@ func canonicalToolFileChange(value map[string]any, hint string) map[string]any {
 	}
 	if hasNew {
 		file["newString"] = newString
+	}
+	if hasContent {
+		file["content"] = content
 	}
 	return file
 }
@@ -268,7 +321,31 @@ func canonicalFileChanges(files []any) map[string]any {
 	if len(files) == 0 {
 		return nil
 	}
-	return map[string]any{"files": files}
+	byPath := make(map[string]map[string]any, len(files))
+	order := make([]string, 0, len(files))
+	for _, raw := range files {
+		file := payloadObject(raw)
+		path := strings.TrimSpace(asString(file["path"]))
+		if path == "" {
+			continue
+		}
+		if current, exists := byPath[path]; exists {
+			byPath[path] = mergeCanonicalFileChange(current, file)
+			continue
+		}
+		order = append(order, path)
+		byPath[path] = clonePayload(file)
+	}
+	result := make([]any, 0, len(order))
+	for _, path := range order {
+		if file := byPath[path]; file != nil {
+			result = append(result, file)
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return map[string]any{"files": result}
 }
 
 func firstPresentToolFileString(values ...any) (string, bool) {
@@ -278,6 +355,22 @@ func firstPresentToolFileString(values ...any) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+func selectToolFileDiff(values ...any) (valid string, hasValid bool, raw string, hasRaw bool) {
+	for _, value := range values {
+		text, ok := value.(string)
+		if !ok {
+			continue
+		}
+		if !hasRaw {
+			raw, hasRaw = text, true
+		}
+		if !hasValid && looksLikeUnifiedDiff(text) {
+			valid, hasValid = text, true
+		}
+	}
+	return
 }
 
 func toolFileChangeKind(payload map[string]any) string {
@@ -326,17 +419,143 @@ func inferToolFileChangeKind(hasOld bool, oldString string, hasNew bool, newStri
 	return ""
 }
 
+func looksLikeUnifiedDiff(value string) bool {
+	normalized := strings.TrimSpace(strings.ReplaceAll(strings.ReplaceAll(value, "\r\n", "\n"), "\r", "\n"))
+	if normalized == "" {
+		return false
+	}
+	lines := strings.Split(normalized, "\n")
+	isApplyPatch := strings.Contains(normalized, "*** Begin Patch") &&
+		(strings.Contains(normalized, "*** Add File:") || strings.Contains(normalized, "*** Delete File:") || strings.Contains(normalized, "*** Update File:"))
+	hasHunk := false
+	hunkHasChange := false
+	oldCount := 0
+	newCount := 0
+	expectedOld := 0
+	expectedNew := 0
+	hunkActive := false
+	hunkHasCounts := false
+	finishHunk := func() bool {
+		if !hunkActive {
+			return true
+		}
+		if !hunkHasCounts {
+			return isApplyPatch && hunkHasChange
+		}
+		return oldCount == expectedOld && newCount == expectedNew && hunkHasChange
+	}
+	for _, line := range lines {
+		if match := unifiedDiffHunkPattern.FindStringSubmatch(line); match != nil {
+			if !finishHunk() {
+				return false
+			}
+			hasHunk = true
+			hunkActive = true
+			hunkHasCounts = true
+			oldCount = 0
+			newCount = 0
+			hunkHasChange = false
+			expectedOld = unifiedDiffHunkCount(match[2])
+			expectedNew = unifiedDiffHunkCount(match[4])
+			continue
+		}
+		if line == "@@" && isApplyPatch {
+			if !finishHunk() {
+				return false
+			}
+			hasHunk = true
+			hunkActive = true
+			hunkHasCounts = false
+			hunkHasChange = false
+			continue
+		}
+		if hunkActive && strings.HasPrefix(line, "diff --git ") {
+			if !finishHunk() {
+				return false
+			}
+			hunkActive = false
+			continue
+		}
+		if !hunkActive && (strings.HasPrefix(line, "diff --git ") || strings.HasPrefix(line, "index ") ||
+			strings.HasPrefix(line, "--- ") || strings.HasPrefix(line, "+++ ") ||
+			strings.HasPrefix(line, "new file mode ") || strings.HasPrefix(line, "deleted file mode ") ||
+			strings.HasPrefix(line, "old mode ") || strings.HasPrefix(line, "new mode ") ||
+			strings.HasPrefix(line, "similarity index ") || strings.HasPrefix(line, "rename from ") ||
+			strings.HasPrefix(line, "rename to ") || strings.HasPrefix(line, "*** ")) {
+			continue
+		}
+		if hunkActive && isApplyPatch && strings.HasPrefix(line, "*** ") {
+			continue
+		}
+		if line == "\\ No newline at end of file" {
+			continue
+		}
+		if !hasHunk {
+			continue
+		}
+		if !hunkHasCounts && isApplyPatch {
+			switch {
+			case strings.HasPrefix(line, "+"):
+				hunkHasChange = true
+			case strings.HasPrefix(line, "-"):
+				hunkHasChange = true
+			case strings.HasPrefix(line, " "):
+			default:
+				return false
+			}
+			continue
+		}
+		switch {
+		case strings.HasPrefix(line, "+"):
+			newCount++
+			hunkHasChange = true
+		case strings.HasPrefix(line, "-"):
+			oldCount++
+			hunkHasChange = true
+		case strings.HasPrefix(line, " "):
+			oldCount++
+			newCount++
+		default:
+			return false
+		}
+	}
+	return hasHunk && finishHunk()
+}
+
+func unifiedDiffHunkCount(value string) int {
+	if value == "" {
+		return 1
+	}
+	count, err := strconv.Atoi(value)
+	if err != nil {
+		return -1
+	}
+	return count
+}
+
 func mergeCanonicalFileChanges(current map[string]any, incoming map[string]any) map[string]any {
 	files := payloadArray(current["files"])
 	order := make([]string, 0, len(files))
 	byPath := make(map[string]map[string]any, len(files))
+	seenPaths := make(map[string]struct{}, len(files))
+	appendPath := func(path string) {
+		if _, seen := seenPaths[path]; seen {
+			return
+		}
+		seenPaths[path] = struct{}{}
+		order = append(order, path)
+	}
 	for _, file := range files {
 		path := strings.TrimSpace(asString(file["path"]))
 		if path == "" {
 			continue
 		}
-		order = append(order, path)
-		byPath[path] = file
+		appendPath(path)
+		if existing := byPath[path]; existing != nil {
+			byPath[path] = mergeCanonicalFileChange(existing, file)
+			continue
+		}
+		byPath[path] = clonePayload(file)
 	}
 	for _, next := range payloadArray(incoming["files"]) {
 		path := strings.TrimSpace(asString(next["path"]))
@@ -345,8 +564,8 @@ func mergeCanonicalFileChanges(current map[string]any, incoming map[string]any) 
 		}
 		existing := byPath[path]
 		if existing == nil {
-			order = append(order, path)
-			byPath[path] = next
+			appendPath(path)
+			byPath[path] = clonePayload(next)
 			continue
 		}
 		byPath[path] = mergeCanonicalFileChange(existing, next)
@@ -361,6 +580,12 @@ func mergeCanonicalFileChanges(current map[string]any, incoming map[string]any) 
 }
 
 func mergeCanonicalFileChange(existing map[string]any, next map[string]any) map[string]any {
+	if existing == nil {
+		return clonePayload(next)
+	}
+	if next == nil {
+		return clonePayload(existing)
+	}
 	merged := clonePayload(existing)
 	for key, value := range next {
 		if key != "path" && key != "change" && key != "oldString" {
@@ -375,10 +600,14 @@ func mergeCanonicalFileChange(existing map[string]any, next map[string]any) map[
 	previousKind := normalizeToolFileChangeKind(existing["change"])
 	nextKind := normalizeToolFileChangeKind(next["change"])
 	switch {
+	case previousKind == "added" && nextKind == "deleted":
+		return nil
 	case previousKind == "added" && nextKind == "modified":
 		merged["change"] = "added"
 	case previousKind == "deleted" && nextKind == "added":
 		merged["change"] = "modified"
+	case previousKind == "modified" && nextKind == "deleted":
+		merged["change"] = "deleted"
 	case nextKind != "":
 		merged["change"] = nextKind
 	}

--- a/packages/agent/daemon/runtime/tool_file_changes_test.go
+++ b/packages/agent/daemon/runtime/tool_file_changes_test.go
@@ -56,6 +56,108 @@ func TestCanonicalFileChangesNormalizeProviderShapes(t *testing.T) {
 	}
 }
 
+func TestCanonicalFileChangesMovesRawCreatedBodyOutOfUnifiedDiff(t *testing.T) {
+	t.Parallel()
+
+	content := "# Liying\n\n- 自我介绍\n- 欢迎来到我的 README\n"
+	got := canonicalFileChangesFromToolPayload(map[string]any{
+		"fileChanges": map[string]any{
+			"files": []any{map[string]any{
+				"path":        "/workspace/README.md",
+				"change":      "created",
+				"unifiedDiff": content,
+			}},
+		},
+	})
+	files := payloadArray(got["files"])
+	if len(files) != 1 {
+		t.Fatalf("canonical files = %#v, want one file", files)
+	}
+	file := files[0]
+	if file["change"] != "added" || file["newString"] != content {
+		t.Fatalf("canonical file = %#v, want added file with its body in newString", file)
+	}
+	if _, exists := file["diff"]; exists {
+		t.Fatalf("canonical file retained invalid diff: %#v", file)
+	}
+	if _, exists := file["unifiedDiff"]; exists {
+		t.Fatalf("canonical file retained invalid unifiedDiff: %#v", file)
+	}
+}
+
+func TestCanonicalFileChangesKeepsValidUnifiedDiff(t *testing.T) {
+	t.Parallel()
+
+	diff := "@@ -1 +1 @@\n-old\n+new"
+	got := canonicalFileChangesFromToolPayload(map[string]any{
+		"fileChanges": map[string]any{
+			"files": []any{map[string]any{
+				"path":        "/workspace/app.ts",
+				"change":      "modified",
+				"unifiedDiff": diff,
+			}},
+		},
+	})
+	file := payloadArray(got["files"])[0]
+	if file["unifiedDiff"] != diff || file["diff"] != diff {
+		t.Fatalf("canonical file = %#v, want valid unified diff preserved", file)
+	}
+}
+
+func TestCanonicalFileChangesChoosesFirstValidDiffAlias(t *testing.T) {
+	t.Parallel()
+
+	valid := "@@ -1 +1 @@\n-old\n+new"
+	rawBody := "README\n- bullet\n"
+	got := canonicalFileChangesFromToolPayload(map[string]any{
+		"fileChanges": map[string]any{
+			"files": []any{map[string]any{
+				"path":        "/workspace/app.ts",
+				"change":      "modified",
+				"diff":        rawBody,
+				"unifiedDiff": valid,
+			}},
+		},
+	})
+	file := payloadArray(got["files"])[0]
+	if file["diff"] != valid || file["unifiedDiff"] != valid {
+		t.Fatalf("canonical file = %#v, want the valid later alias", file)
+	}
+}
+
+func TestCanonicalFileChangesPreservesInvalidModifiedBodyWithoutDiff(t *testing.T) {
+	t.Parallel()
+
+	body := "README\n- bullet\n"
+	got := canonicalFileChangesFromToolPayload(map[string]any{
+		"fileChanges": map[string]any{
+			"files": []any{map[string]any{
+				"path":   "/workspace/README.md",
+				"change": "modified",
+				"diff":   body,
+			}},
+		},
+	})
+	file := payloadArray(got["files"])[0]
+	if file["content"] != body || file["change"] != "modified" {
+		t.Fatalf("canonical file = %#v, want modified body preserved as content", file)
+	}
+	if _, exists := file["diff"]; exists {
+		t.Fatalf("canonical file retained invalid diff: %#v", file)
+	}
+}
+
+func TestLooksLikeUnifiedDiffRejectsPseudoHunks(t *testing.T) {
+	t.Parallel()
+
+	if looksLikeUnifiedDiff("@@ notes\n- bullet") {
+		t.Fatal("pseudo hunk was accepted as a unified diff")
+	}
+	if !looksLikeUnifiedDiff("@@ -1 +1 @@\n-old\n+new") {
+		t.Fatal("valid unified diff was rejected")
+	}
+}
+
 func TestMergeCanonicalFileChangesKeepsTurnLevelSemantics(t *testing.T) {
 	t.Parallel()
 
@@ -77,5 +179,23 @@ func TestMergeCanonicalFileChangesKeepsTurnLevelSemantics(t *testing.T) {
 	}
 	if files[1]["change"] != "deleted" || files[1]["oldString"] != "before" || files[1]["newString"] != "" {
 		t.Fatalf("edited-then-deleted file = %#v, want deleted with original content", files[1])
+	}
+}
+
+func TestMergeCanonicalFileChangesDeduplicatesAndCancelsCreatedFiles(t *testing.T) {
+	t.Parallel()
+
+	current := map[string]any{"files": []any{
+		map[string]any{"path": "/workspace/a.txt", "change": "added", "newString": "first"},
+		map[string]any{"path": "/workspace/a.txt", "change": "modified", "newString": "final"},
+	}}
+	incoming := map[string]any{"files": []any{
+		map[string]any{"path": "/workspace/a.txt", "change": "deleted"},
+		map[string]any{"path": "/workspace/b.txt", "change": "added", "newString": "b"},
+	}}
+
+	files := payloadArray(mergeCanonicalFileChanges(current, incoming)["files"])
+	if len(files) != 1 || files[0]["path"] != "/workspace/b.txt" {
+		t.Fatalf("merged files = %#v, want only the surviving file", files)
 	}
 }

--- a/packages/agent/gui/shared/agentConversation/components/AgentTurnSummaryRow.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTurnSummaryRow.spec.tsx
@@ -1219,4 +1219,54 @@ describe("AgentTurnSummaryRow", () => {
       screen.queryByText("agentHost.agentTool.details.loadingDiff")
     ).toBeNull();
   });
+
+  it("counts raw created content as additions instead of deletions", () => {
+    const content = [
+      "# 你好，我是 Liying 👋",
+      "",
+      "欢迎来到我的个人主页！",
+      "",
+      "我是 **Liying**，一名对学习、探索和创造充满热情的人。很高兴认识你！",
+      "",
+      "## 关于我",
+      "",
+      "- 👤 名字：Liying",
+      "- 🌱 正在持续学习与成长",
+      "- ✨ 喜欢尝试新事物、记录想法",
+      "",
+      "感谢你的访问！"
+    ].join("\n");
+
+    render(
+      <AgentTurnSummaryRow
+        row={{
+          kind: "turn-summary",
+          id: "turn-summary:raw-created-content",
+          turnId: "turn-raw-created-content",
+          fileCount: 1,
+          modifiedCount: 0,
+          createdCount: 1,
+          occurredAtUnixMs: 40,
+          files: [
+            {
+              label: "README.md",
+              path: "/workspace/README.md",
+              fileName: "README.md",
+              directory: "/workspace",
+              changeType: "created",
+              toolName: "Edit",
+              messageId: "call:raw-created-content",
+              unifiedDiff: content,
+              occurredAtUnixMs: 40
+            }
+          ]
+        }}
+        workspaceRoot="/workspace"
+        label="Changed files"
+      />
+    );
+
+    expect(screen.getAllByText("+13")).toHaveLength(2);
+    expect(screen.queryByText("-3")).toBeNull();
+  });
 });

--- a/packages/agent/gui/shared/agentConversation/components/AgentTurnSummaryRow.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTurnSummaryRow.tsx
@@ -34,7 +34,10 @@ import {
 import { AgentCodeBlock } from "./tool-renderers/code/AgentCodeBlock";
 import { CollapsibleReveal } from "./CollapsibleReveal";
 import { AgentMonacoDiffViewer } from "./tool-renderers/file-diff/AgentMonacoDiffViewer";
-import { parseAgentUnifiedDiffStats } from "./tool-renderers/file-diff/agentUnifiedDiff";
+import {
+  agentFileChangeStats,
+  isAgentUnifiedDiff
+} from "./tool-renderers/file-diff/agentUnifiedDiff";
 import { AgentUnifiedPatchViewer } from "./tool-renderers/file-diff/AgentUnifiedPatchViewer";
 
 interface AgentTurnSummaryRowProps {
@@ -512,7 +515,11 @@ function TurnSummaryFileCard({
 }
 
 function filePreview(file: AgentTurnSummaryFileVM): JSX.Element | null {
-  if (file.changeType === "created" && file.content?.trim()) {
+  if (
+    file.changeType === "created" &&
+    file.content !== null &&
+    file.content !== undefined
+  ) {
     return (
       <AgentCodeBlock
         path={file.path}
@@ -524,7 +531,7 @@ function filePreview(file: AgentTurnSummaryFileVM): JSX.Element | null {
     );
   }
 
-  if (file.unifiedDiff?.trim()) {
+  if (file.unifiedDiff && isAgentUnifiedDiff(file.unifiedDiff)) {
     return (
       <AgentUnifiedPatchViewer
         path={file.path}
@@ -535,7 +542,11 @@ function filePreview(file: AgentTurnSummaryFileVM): JSX.Element | null {
     );
   }
 
-  if (file.changeType === "created" && file.newString?.trim()) {
+  if (
+    file.changeType === "created" &&
+    file.newString !== null &&
+    file.newString !== undefined
+  ) {
     return (
       <AgentCodeBlock
         path={file.path}
@@ -547,7 +558,10 @@ function filePreview(file: AgentTurnSummaryFileVM): JSX.Element | null {
     );
   }
 
-  if (file.oldString?.trim() || file.newString?.trim()) {
+  if (
+    (file.oldString !== null && file.oldString !== undefined) ||
+    (file.newString !== null && file.newString !== undefined)
+  ) {
     return (
       <AgentMonacoDiffViewer
         path={file.path}
@@ -559,11 +573,43 @@ function filePreview(file: AgentTurnSummaryFileVM): JSX.Element | null {
     );
   }
 
-  if (file.content?.trim()) {
+  if (
+    file.changeType === "deleted" &&
+    ((file.content !== null && file.content !== undefined) ||
+      (file.unifiedDiff !== null && file.unifiedDiff !== undefined))
+  ) {
+    return (
+      <AgentMonacoDiffViewer
+        path={file.path}
+        oldValue={file.oldString ?? file.content ?? file.unifiedDiff ?? ""}
+        newValue=""
+        flat
+        showHeader={false}
+      />
+    );
+  }
+
+  if (file.content !== null && file.content !== undefined) {
     return (
       <AgentCodeBlock
         path={file.path}
         content={file.content}
+        showHeader={false}
+        collapsible
+        flat
+      />
+    );
+  }
+
+  if (
+    file.unifiedDiff !== null &&
+    file.unifiedDiff !== undefined &&
+    file.changeType !== "deleted"
+  ) {
+    return (
+      <AgentCodeBlock
+        path={file.path}
+        content={file.content ?? file.newString ?? file.unifiedDiff}
         showHeader={false}
         collapsible
         flat
@@ -647,26 +693,11 @@ function summarizeFileDiff(file: AgentTurnSummaryFileVM): {
   added: number;
   removed: number;
 } {
-  if (file.unifiedDiff?.trim()) {
-    return parseAgentUnifiedDiffStats(file.unifiedDiff);
-  }
-  if (file.content?.trim()) {
-    return {
-      added: file.content.split("\n").filter(Boolean).length || 1,
-      removed: 0
-    };
-  }
-  if (file.changeType === "created" && file.newString?.trim()) {
-    return {
-      added: file.newString.split("\n").filter(Boolean).length || 1,
-      removed: 0
-    };
-  }
-  if (file.changeType === "deleted" && file.oldString?.trim()) {
-    return {
-      added: 0,
-      removed: file.oldString.split("\n").filter(Boolean).length || 1
-    };
-  }
-  return { added: 0, removed: 0 };
+  return agentFileChangeStats({
+    changeType: file.changeType,
+    unifiedDiff: file.unifiedDiff,
+    content: file.content,
+    oldString: file.oldString,
+    newString: file.newString
+  });
 }

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentEditContent.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentEditContent.tsx
@@ -22,18 +22,20 @@ export function AgentEditContent({
     stringValue(call.input?.file_path) ??
     stringValue(call.input?.filePath) ??
     null;
-  const patchFiles = files.filter((candidate) => candidate.unifiedDiff);
+  const patchFiles = files.filter(
+    (candidate) => candidate.unifiedDiff !== null
+  );
   const diffFiles = files.filter(
     (candidate) =>
-      !candidate.unifiedDiff &&
+      candidate.unifiedDiff === null &&
       candidate.oldString !== null &&
       candidate.newString !== null
   );
   const contentFiles = files.filter(
     (candidate) =>
-      !candidate.unifiedDiff &&
+      candidate.unifiedDiff === null &&
       !(candidate.oldString !== null && candidate.newString !== null) &&
-      candidate.content
+      candidate.content !== null
   );
   const hasRenderableContent =
     Boolean(path && files.length === 0) ||

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentWriteContent.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentWriteContent.tsx
@@ -21,10 +21,11 @@ export function AgentWriteContent({
     stringValue(call.input?.file_path) ??
     stringValue(call.input?.filePath) ??
     null;
-  const contentFiles = files.filter((candidate) => candidate.content);
+  const contentFiles = files.filter((candidate) => candidate.content !== null);
   const contentPaths = new Set(contentFiles.map((candidate) => candidate.path));
   const patchFiles = files.filter(
-    (candidate) => candidate.unifiedDiff && !contentPaths.has(candidate.path)
+    (candidate) =>
+      candidate.unifiedDiff !== null && !contentPaths.has(candidate.path)
   );
   const fallbackContent =
     files.length === 0 ? call.summary.trim() || null : null;

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/agentToolContentShared.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/agentToolContentShared.tsx
@@ -250,7 +250,7 @@ function hasReadContent(call: AgentToolCallVM): boolean {
 function hasWriteContent(call: AgentToolCallVM): boolean {
   const files = getFileChangeRenderData(call);
   return Boolean(
-    files.some((file) => file.content || file.unifiedDiff) ||
+    files.some((file) => file.content !== null || file.unifiedDiff !== null) ||
     (files.length === 0 &&
       (call.summary.trim() ||
         stringValue(call.input?.path) ||
@@ -264,9 +264,9 @@ function hasEditContent(call: AgentToolCallVM): boolean {
   return Boolean(
     files.some(
       (file) =>
-        file.unifiedDiff ||
+        file.unifiedDiff !== null ||
         (file.oldString !== null && file.newString !== null) ||
-        file.content
+        file.content !== null
     ) ||
     (files.length === 0 &&
       (stringValue(call.input?.path) ||

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/file-diff/agentUnifiedDiff.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/file-diff/agentUnifiedDiff.spec.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  agentFileChangeStats,
+  countAgentTextLines,
+  isAgentUnifiedDiff,
   parseAgentUnifiedDiff,
   parseAgentUnifiedDiffLines,
   parseAgentUnifiedDiffStats
@@ -29,6 +32,73 @@ describe("agentUnifiedDiff", () => {
       added: 1,
       removed: 1
     });
+  });
+
+  it("does not treat file content as a unified diff", () => {
+    const content = [
+      "# 你好，我是 Liying 👋",
+      "",
+      "欢迎来到我的个人主页！",
+      "",
+      "我是 Liying。",
+      "",
+      "- 👤 名字：Liying",
+      "- 🌱 正在持续学习与成长",
+      "- ✨ 喜欢尝试新事物、记录想法"
+    ].join("\n");
+
+    expect(isAgentUnifiedDiff(content)).toBe(false);
+    expect(parseAgentUnifiedDiffStats(content)).toEqual({
+      added: 0,
+      removed: 0
+    });
+    expect(
+      agentFileChangeStats({
+        changeType: "created",
+        unifiedDiff: content,
+        content: null,
+        oldString: null,
+        newString: null
+      })
+    ).toEqual({ added: 9, removed: 0 });
+  });
+
+  it("rejects pseudo hunk headers", () => {
+    expect(isAgentUnifiedDiff("@@ notes\n- bullet")).toBe(false);
+    expect(parseAgentUnifiedDiffStats("@@ notes\n- bullet")).toEqual({
+      added: 0,
+      removed: 0
+    });
+  });
+
+  it("counts blank lines consistently with file content", () => {
+    expect(countAgentTextLines("first\n\nthird\n")).toBe(3);
+    expect(countAgentTextLines("\n")).toBe(1);
+    expect(countAgentTextLines("   ")).toBe(1);
+  });
+
+  it("does not count an invalid modified body as additions", () => {
+    expect(
+      agentFileChangeStats({
+        changeType: "modified",
+        unifiedDiff: "README\n- bullet\n",
+        content: null,
+        oldString: null,
+        newString: null
+      })
+    ).toEqual({ added: 0, removed: 0 });
+  });
+
+  it("computes conservative stats for modified text bodies", () => {
+    expect(
+      agentFileChangeStats({
+        changeType: "modified",
+        unifiedDiff: null,
+        content: null,
+        oldString: "one\ntwo\n",
+        newString: "one\nthree\n"
+      })
+    ).toEqual({ added: 1, removed: 1 });
   });
 
   it("parses unified diff into numbered display lines", () => {

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/file-diff/agentUnifiedDiff.ts
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/file-diff/agentUnifiedDiff.ts
@@ -4,6 +4,7 @@ import {
   normalizeAgentPatchText,
   type AgentPatchChangeType
 } from "../../../rules/agentPatchMetadata";
+import { isAgentUnifiedDiffText } from "../../../rules/agentUnifiedDiffValidation";
 
 export { extractAgentPatchPath, inferAgentPatchChangeType };
 export type AgentUnifiedDiffChangeType = AgentPatchChangeType;
@@ -20,6 +21,12 @@ export interface ParsedAgentUnifiedDiffLine {
   text: string;
 }
 
+export type AgentFileChangeType =
+  | "created"
+  | "modified"
+  | "deleted"
+  | "unknown";
+
 const DIFF_META_PREFIXES = [
   "diff --git ",
   "index ",
@@ -31,7 +38,7 @@ const DIFF_META_PREFIXES = [
 export function parseAgentUnifiedDiff(
   diffText: string
 ): ParsedAgentUnifiedDiff | null {
-  if (!diffText.trim()) {
+  if (!isAgentUnifiedDiff(diffText)) {
     return null;
   }
 
@@ -40,17 +47,36 @@ export function parseAgentUnifiedDiff(
   const newLines: string[] = [];
   let sawChangeLine = false;
   let sawHunkHeader = false;
+  let hunkActive = false;
 
   for (const line of normalizedText.replace(/\r\n/g, "\n").split("\n")) {
-    if (line.startsWith("@@")) {
+    if (/^@@(?: -\d|$)/.test(line)) {
       if (sawHunkHeader && (oldLines.length > 0 || newLines.length > 0)) {
         oldLines.push("");
         newLines.push("");
       }
       sawHunkHeader = true;
+      hunkActive = true;
       continue;
     }
-    if (DIFF_META_PREFIXES.some((prefix) => line.startsWith(prefix))) {
+    if (line === "@@" && isApplyPatch(normalizedText)) {
+      if (sawHunkHeader && (oldLines.length > 0 || newLines.length > 0)) {
+        oldLines.push("");
+        newLines.push("");
+      }
+      sawHunkHeader = true;
+      hunkActive = true;
+      continue;
+    }
+    if (hunkActive && line.startsWith("diff --git ")) {
+      hunkActive = false;
+      continue;
+    }
+    if (
+      (!hunkActive &&
+        DIFF_META_PREFIXES.some((prefix) => line.startsWith(prefix))) ||
+      (hunkActive && isApplyPatch(normalizedText) && line.startsWith("*** "))
+    ) {
       continue;
     }
     if (line === "\\ No newline at end of file") {
@@ -86,6 +112,9 @@ export function parseAgentUnifiedDiff(
 export function parseAgentUnifiedDiffLines(
   diffText: string
 ): ParsedAgentUnifiedDiffLine[] {
+  if (!isAgentUnifiedDiff(diffText)) {
+    return [];
+  }
   const normalized = normalizeAgentPatchText(diffText);
   if (!normalized.trim()) {
     return [];
@@ -94,18 +123,29 @@ export function parseAgentUnifiedDiffLines(
   const lines: ParsedAgentUnifiedDiffLine[] = [];
   let oldLineNumber = 0;
   let newLineNumber = 0;
+  let hunkActive = false;
 
   for (const line of normalized.replace(/\r\n/g, "\n").split("\n")) {
-    if (line.startsWith("@@")) {
-      const match = line.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
-      if (!match) {
-        continue;
-      }
+    const match = line.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+    if (match) {
       oldLineNumber = Number.parseInt(match[1] ?? "0", 10);
       newLineNumber = Number.parseInt(match[2] ?? "0", 10);
+      hunkActive = true;
       continue;
     }
-    if (DIFF_META_PREFIXES.some((prefix) => line.startsWith(prefix))) {
+    if (line === "@@" && isApplyPatch(normalized)) {
+      hunkActive = true;
+      continue;
+    }
+    if (hunkActive && line.startsWith("diff --git ")) {
+      hunkActive = false;
+      continue;
+    }
+    if (
+      (!hunkActive &&
+        DIFF_META_PREFIXES.some((prefix) => line.startsWith(prefix))) ||
+      (hunkActive && isApplyPatch(normalized) && line.startsWith("*** "))
+    ) {
       continue;
     }
     if (line === "\\ No newline at end of file") {
@@ -146,25 +186,149 @@ export function parseAgentUnifiedDiffLines(
   return lines;
 }
 
+export function isAgentUnifiedDiff(diffText: string): boolean {
+  return isAgentUnifiedDiffText(diffText);
+}
+
+export function countAgentTextLines(value: string | null | undefined): number {
+  if (typeof value !== "string" || value.length === 0) {
+    return 0;
+  }
+  const lines = value.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+  if (lines.at(-1) === "") {
+    lines.pop();
+  }
+  return lines.length;
+}
+
+export function agentFileChangeStats({
+  changeType,
+  unifiedDiff,
+  content,
+  oldString,
+  newString
+}: {
+  changeType: AgentFileChangeType;
+  unifiedDiff: string | null | undefined;
+  content: string | null | undefined;
+  oldString: string | null | undefined;
+  newString: string | null | undefined;
+}): { added: number; removed: number } {
+  const diff = typeof unifiedDiff === "string" ? unifiedDiff : null;
+  if (diff && isAgentUnifiedDiff(diff)) {
+    return parseAgentUnifiedDiffStats(diff);
+  }
+
+  if (changeType === "deleted") {
+    return {
+      added: 0,
+      removed: countAgentTextLines(oldString ?? content ?? diff)
+    };
+  }
+  if (changeType === "created") {
+    return {
+      added: countAgentTextLines(content ?? newString ?? diff),
+      removed: 0
+    };
+  }
+  if (typeof oldString === "string" && typeof newString === "string") {
+    return agentTextDiffStats(oldString, newString);
+  }
+  return { added: 0, removed: 0 };
+}
+
 export function parseAgentUnifiedDiffStats(diffText: string): {
   added: number;
   removed: number;
 } {
+  if (!isAgentUnifiedDiff(diffText)) {
+    return { added: 0, removed: 0 };
+  }
+
   let added = 0;
   let removed = 0;
-  for (const line of normalizeAgentPatchText(diffText)
-    .replace(/\r\n/g, "\n")
-    .split("\n")) {
-    if (line.startsWith("+++") || line.startsWith("---")) {
+  let hunkActive = false;
+  const normalized = normalizeAgentPatchText(diffText);
+  for (const line of normalized.replace(/\r\n/g, "\n").split("\n")) {
+    if (/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/.test(line)) {
+      hunkActive = true;
+      continue;
+    }
+    if (line === "@@" && isApplyPatch(normalized)) {
+      hunkActive = true;
+      continue;
+    }
+    if (hunkActive && line.startsWith("diff --git ")) {
+      hunkActive = false;
+      continue;
+    }
+    if (
+      (!hunkActive &&
+        DIFF_META_PREFIXES.some((prefix) => line.startsWith(prefix))) ||
+      (hunkActive && isApplyPatch(normalized) && line.startsWith("*** "))
+    ) {
+      continue;
+    }
+    if (line === "\\ No newline at end of file" || !hunkActive) {
       continue;
     }
     if (line.startsWith("+")) {
       added += 1;
-      continue;
-    }
-    if (line.startsWith("-")) {
+    } else if (line.startsWith("-")) {
       removed += 1;
     }
   }
   return { added, removed };
+}
+
+function agentTextDiffStats(
+  oldString: string,
+  newString: string
+): { added: number; removed: number } {
+  const oldLines = splitAgentTextLines(oldString);
+  const newLines = splitAgentTextLines(newString);
+  if (oldLines.length === 0 && newLines.length === 0) {
+    return { added: 0, removed: 0 };
+  }
+  if (oldLines.length * newLines.length > 2_000_000) {
+    return { added: 0, removed: 0 };
+  }
+
+  let previous = Array.from({ length: newLines.length + 1 }, () => 0);
+  for (const oldLine of oldLines) {
+    const current = Array.from({ length: newLines.length + 1 }, () => 0);
+    for (let newIndex = 1; newIndex <= newLines.length; newIndex += 1) {
+      current[newIndex] =
+        oldLine === newLines[newIndex - 1]
+          ? previous[newIndex - 1]! + 1
+          : Math.max(previous[newIndex]!, current[newIndex - 1]!);
+    }
+    previous = current;
+  }
+
+  const commonLines = previous[newLines.length] ?? 0;
+  return {
+    added: newLines.length - commonLines,
+    removed: oldLines.length - commonLines
+  };
+}
+
+function splitAgentTextLines(value: string): string[] {
+  if (value.length === 0) {
+    return [];
+  }
+  const lines = value.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+  if (lines.at(-1) === "") {
+    lines.pop();
+  }
+  return lines;
+}
+
+function isApplyPatch(value: string): boolean {
+  return (
+    value.includes("*** Begin Patch") &&
+    (value.includes("*** Add File:") ||
+      value.includes("*** Delete File:") ||
+      value.includes("*** Update File:"))
+  );
 }

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/render-data/agentToolFileChangeRenderData.ts
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/render-data/agentToolFileChangeRenderData.ts
@@ -4,6 +4,10 @@ import {
   inferAgentPatchChangeType
 } from "../../../rules/agentPatchMetadata";
 import {
+  agentFileChangeStats,
+  isAgentUnifiedDiff
+} from "../file-diff/agentUnifiedDiff";
+import {
   fileChangeEntriesFromChanges,
   fileChangeTypeValue
 } from "../../../../workspaceAgentFileChangePayload";
@@ -77,72 +81,48 @@ export function getFileChangeRenderData(
     stringValue(payloadInput?.path),
     firstLocationPath(inputLocations)
   );
-  const unifiedDiff = firstString(
-    stringValue(call.output?.patch),
-    stringValue(payloadOutput?.patch),
-    stringValue(call.output?.diff),
-    stringValue(payloadOutput?.diff)
-  );
+  const diffValues = [
+    call.output?.patch,
+    payloadOutput?.patch,
+    call.output?.diff,
+    payloadOutput?.diff
+  ];
+  const rawDiff = firstRawString(...diffValues);
   const path = firstString(
     inputPath,
-    unifiedDiff ? extractAgentPatchPath(unifiedDiff) : null
+    rawDiff ? extractAgentPatchPath(rawDiff) : null
   );
   if (!path) {
     return [];
   }
 
-  const content = firstString(
-    stringValue(call.input?.content),
-    stringValue(payloadInput?.content)
+  const content = firstFileString(call.input?.content, payloadInput?.content);
+  const oldString = firstFileString(
+    call.input?.old_string,
+    call.input?.oldString,
+    payloadInput?.old_string,
+    payloadInput?.oldString,
+    call.output?.oldString,
+    payloadOutput?.oldString
   );
-  const oldString = firstString(
-    stringValue(call.input?.old_string),
-    stringValue(call.input?.oldString),
-    stringValue(payloadInput?.old_string),
-    stringValue(payloadInput?.oldString),
-    stringValue(call.output?.oldString),
-    stringValue(payloadOutput?.oldString)
+  const newString = firstFileString(
+    call.input?.new_string,
+    call.input?.newString,
+    payloadInput?.new_string,
+    payloadInput?.newString,
+    call.output?.newString,
+    payloadOutput?.newString
   );
-  const newString = firstString(
-    stringValue(call.input?.new_string),
-    stringValue(call.input?.newString),
-    stringValue(payloadInput?.new_string),
-    stringValue(payloadInput?.newString),
-    stringValue(call.output?.newString),
-    stringValue(payloadOutput?.newString)
-  );
-  const changeType = inferFileChangeType(
-    call.toolName,
-    unifiedDiff,
+  const rendered = normalizeFileChangeRenderData({
+    path,
+    toolName: call.toolName,
+    allowSyntheticDiff: true,
+    diffValues,
     content,
     oldString,
     newString
-  );
-  const normalizedUnifiedDiff =
-    !unifiedDiff && oldString !== null && newString !== null
-      ? syntheticUnifiedDiff(path, changeType, oldString, newString)
-      : unifiedDiff;
-  const lineStats = fileChangeStats(
-    changeType,
-    normalizedUnifiedDiff,
-    content,
-    oldString,
-    newString
-  );
-
-  return [
-    {
-      path,
-      changeType,
-      language: languageForPath(path),
-      content,
-      oldString,
-      newString,
-      unifiedDiff: normalizedUnifiedDiff,
-      added: lineStats.added,
-      removed: lineStats.removed
-    }
-  ];
+  });
+  return rendered ? [rendered] : [];
 }
 
 function structuredPatchFiles(value: unknown): AgentFileChangeRenderData[] {
@@ -156,77 +136,39 @@ function structuredPatchFiles(value: unknown): AgentFileChangeRenderData[] {
       stringValue(patch?.filePath),
       stringValue(patch?.path)
     );
-    const diff = firstString(
-      stringValue(patch?.diff),
-      stringValue(patch?.patch)
-    );
     if (!path) {
       return [];
     }
-    const oldString = firstString(
-      stringValue(patch?.oldString),
-      stringValue(patch?.old_string)
-    );
-    const newString = firstString(
-      stringValue(patch?.newString),
-      stringValue(patch?.new_string)
-    );
-    const content = firstString(stringValue(patch?.content), newString);
-    if (!diff && !oldString && !newString && !content) {
-      return [];
-    }
-    const changeType = firstKnownChangeType(
-      normalizeChangeType(stringValue(patch?.kind)),
-      normalizeChangeType(stringValue(patch?.change)),
-      inferFileChangeType(null, diff, content, oldString, newString)
-    );
-    const stats = fileChangeStats(
-      changeType,
-      diff,
-      content,
-      oldString,
-      newString
-    );
-    return [
-      {
-        path,
-        changeType,
-        language: languageForPath(path),
-        content,
-        oldString,
-        newString,
-        unifiedDiff: diff,
-        added: stats.added,
-        removed: stats.removed
-      }
-    ];
+    const rendered = normalizeFileChangeRenderData({
+      path,
+      explicitChangeType: normalizeChangeType(fileChangeTypeValue(patch ?? {})),
+      allowSyntheticDiff: false,
+      diffValues: [patch?.diff, patch?.patch],
+      content: firstFileString(patch?.content),
+      oldString: firstFileString(patch?.oldString, patch?.old_string),
+      newString: firstFileString(patch?.newString, patch?.new_string)
+    });
+    return rendered ? [rendered] : [];
   });
 }
 
 function detailedDiffFiles(value: unknown): AgentFileChangeRenderData[] {
-  const diff = stringValue(value);
-  if (!diff) {
+  const diff = firstRawString(value);
+  if (diff === null) {
     return [];
   }
   const path = diffPath(diff);
   if (!path) {
     return [];
   }
-  const stats = diffLineStats(diff);
-  const changeType = inferFileChangeType(null, diff, null, null, null);
-  return [
-    {
-      path,
-      changeType,
-      language: languageForPath(path),
-      content: null,
-      oldString: null,
-      newString: null,
-      unifiedDiff: diff,
-      added: stats.added,
-      removed: stats.removed
-    }
-  ];
+  const rendered = normalizeFileChangeRenderData({
+    path,
+    diffValues: [diff],
+    content: null,
+    oldString: null,
+    newString: null
+  });
+  return rendered ? [rendered] : [];
 }
 
 function fileChangesFiles(value: unknown): AgentFileChangeRenderData[] {
@@ -238,50 +180,120 @@ function fileChangesFiles(value: unknown): AgentFileChangeRenderData[] {
   return files.flatMap((item) => {
     const file = recordValue(item);
     const path = stringValue(file?.path);
-    if (!path) {
+    if (!file || !path) {
       return [];
     }
-    const unifiedDiff = firstString(
-      stringValue(file?.diff),
-      stringValue(file?.patch),
-      stringValue(file?.unifiedDiff),
-      stringValue(file?.unified_diff)
-    );
-    const oldString = firstString(
-      stringValue(file?.oldString),
-      stringValue(file?.old_string)
-    );
-    const newString = firstString(
-      stringValue(file?.newString),
-      stringValue(file?.new_string)
-    );
-    const content = firstString(stringValue(file?.content), newString);
-    const changeType = firstKnownChangeType(
-      normalizeChangeType(stringValue(file?.change)),
-      normalizeChangeType(stringValue(file?.kind)),
-      inferFileChangeType(null, unifiedDiff, content, oldString, newString)
-    );
-    const stats = fileChangeStats(
-      changeType,
-      unifiedDiff,
-      content,
-      oldString,
-      newString
-    );
-    return [
-      {
-        path,
-        changeType,
-        language: languageForPath(path),
-        content,
-        oldString,
-        newString,
-        unifiedDiff,
-        added: stats.added,
-        removed: stats.removed
-      }
-    ];
+    const rendered = normalizeFileChangeRenderData({
+      path,
+      explicitChangeType: normalizeChangeType(fileChangeTypeValue(file)),
+      diffValues: [
+        file?.diff,
+        file?.patch,
+        file?.unifiedDiff,
+        file?.unified_diff
+      ],
+      content: firstFileString(file?.content),
+      oldString: firstFileString(file?.oldString, file?.old_string),
+      newString: firstFileString(file?.newString, file?.new_string)
+    });
+    return rendered ? [rendered] : [];
   });
+}
+
+function normalizeFileChangeRenderData({
+  path,
+  toolName = null,
+  explicitChangeType = "unknown",
+  allowSyntheticDiff = false,
+  diffValues,
+  content: initialContent,
+  oldString: initialOldString,
+  newString: initialNewString
+}: {
+  path: string;
+  toolName?: string | null;
+  explicitChangeType?: AgentFileChangeRenderData["changeType"];
+  allowSyntheticDiff?: boolean;
+  diffValues: unknown[];
+  content: string | null;
+  oldString: string | null;
+  newString: string | null;
+}): AgentFileChangeRenderData | null {
+  const rawDiff = firstRawString(...diffValues);
+  const unifiedDiff = firstValidUnifiedDiff(...diffValues);
+  let content = initialContent;
+  let oldString = initialOldString;
+  let newString = initialNewString;
+  let changeType = firstKnownChangeType(
+    explicitChangeType,
+    inferFileChangeType(toolName, unifiedDiff, content, oldString, newString)
+  );
+
+  if (unifiedDiff === null && rawDiff !== null) {
+    switch (changeType) {
+      case "created":
+        if (newString === null && content === null) {
+          newString = fileTextValue(rawDiff);
+        }
+        content ??= newString;
+        break;
+      case "deleted":
+        if (oldString === null && content === null) {
+          oldString = fileTextValue(rawDiff);
+        }
+        if (oldString !== null && newString === null) {
+          newString = "";
+        }
+        content = null;
+        break;
+      default:
+        if (oldString === null && newString === null && content === null) {
+          content = fileTextValue(rawDiff);
+        }
+        break;
+    }
+    if (changeType === "unknown" && content !== null) {
+      changeType = "modified";
+    }
+  }
+  if (changeType === "created" && content === null && newString !== null) {
+    content = newString;
+  }
+
+  const normalizedUnifiedDiff =
+    allowSyntheticDiff &&
+    unifiedDiff === null &&
+    oldString !== null &&
+    newString !== null
+      ? syntheticUnifiedDiff(path, changeType, oldString, newString)
+      : unifiedDiff;
+  if (
+    normalizedUnifiedDiff === null &&
+    content === null &&
+    oldString === null &&
+    newString === null &&
+    changeType === "unknown"
+  ) {
+    return null;
+  }
+  const stats = fileChangeStats(
+    changeType,
+    normalizedUnifiedDiff,
+    content,
+    oldString,
+    newString
+  );
+  return {
+    path,
+    changeType,
+    language: languageForPath(path),
+    content,
+    oldString,
+    newString,
+    unifiedDiff: normalizedUnifiedDiff,
+    added: stats.added,
+    removed: stats.removed
+  };
 }
 
 function changeMapFiles(value: unknown): AgentFileChangeRenderData[] {
@@ -291,21 +303,12 @@ function changeMapFiles(value: unknown): AgentFileChangeRenderData[] {
     if (!normalizedPath) {
       return [];
     }
-    const unifiedDiff = firstString(
-      stringValue(change.unified_diff),
-      stringValue(change.unifiedDiff),
-      stringValue(change.diff),
-      stringValue(change.patch)
-    );
-    const explicitContent = stringValue(change.content);
     const normalizedType = normalizeChangeType(fileChangeTypeValue(change));
-    let oldString = firstString(
-      stringValue(change.old_string),
-      stringValue(change.oldString)
-    );
-    let newString = firstString(
-      stringValue(change.new_string),
-      stringValue(change.newString),
+    const explicitContent = firstFileString(change.content);
+    let oldString = firstFileString(change.old_string, change.oldString);
+    let newString = firstFileString(
+      change.new_string,
+      change.newString,
       explicitContent
     );
     if (
@@ -330,46 +333,25 @@ function changeMapFiles(value: unknown): AgentFileChangeRenderData[] {
     ) {
       newString = "";
     }
-    const content = firstString(
+    const content = firstFileString(
       normalizedType === "deleted" ? null : explicitContent,
       normalizedType === "created" ? newString : null
     );
-    if (
-      !unifiedDiff &&
-      oldString === null &&
-      newString === null &&
-      content === null
-    ) {
-      return [];
-    }
-    const changeType = firstKnownChangeType(
-      normalizedType,
-      inferFileChangeType(null, unifiedDiff, content, oldString, newString)
-    );
-    const normalizedUnifiedDiff =
-      !unifiedDiff && oldString !== null && newString !== null
-        ? syntheticUnifiedDiff(normalizedPath, changeType, oldString, newString)
-        : unifiedDiff;
-    const stats = fileChangeStats(
-      changeType,
-      normalizedUnifiedDiff,
+    const rendered = normalizeFileChangeRenderData({
+      path: normalizedPath,
+      explicitChangeType: normalizedType ?? "unknown",
+      allowSyntheticDiff: true,
+      diffValues: [
+        change.unified_diff,
+        change.unifiedDiff,
+        change.diff,
+        change.patch
+      ],
       content,
       oldString,
       newString
-    );
-    return [
-      {
-        path: normalizedPath,
-        changeType,
-        language: languageForPath(normalizedPath),
-        content,
-        oldString,
-        newString,
-        unifiedDiff: normalizedUnifiedDiff,
-        added: stats.added,
-        removed: stats.removed
-      }
-    ];
+    });
+    return rendered ? [rendered] : [];
   });
 }
 
@@ -380,14 +362,21 @@ function inferFileChangeType(
   oldString: string | null,
   newString: string | null
 ): AgentFileChangeRenderData["changeType"] {
-  if (unifiedDiff) {
+  if (unifiedDiff && isAgentUnifiedDiff(unifiedDiff)) {
     return inferAgentPatchChangeType(unifiedDiff);
   }
   const normalizedToolName = normalizeToolName(toolName);
-  if (normalizedToolName === "write" && (content || newString)) {
+  if (
+    normalizedToolName === "write" &&
+    (content !== null || newString !== null)
+  ) {
     return "created";
   }
-  if (normalizedToolName === "edit" || oldString || newString) {
+  if (
+    normalizedToolName === "edit" ||
+    oldString !== null ||
+    newString !== null
+  ) {
     return "modified";
   }
   return "unknown";
@@ -436,30 +425,6 @@ function diffPath(value: string): string | null {
   return match?.[2]?.trim() ?? match?.[1]?.trim() ?? null;
 }
 
-function diffLineStats(value: string | null): {
-  added: number;
-  removed: number;
-} {
-  if (!value) {
-    return { added: 0, removed: 0 };
-  }
-  let added = 0;
-  let removed = 0;
-  value.split("\n").forEach((line) => {
-    if (line.startsWith("+++") || line.startsWith("---")) {
-      return;
-    }
-    if (line.startsWith("+")) {
-      added += 1;
-      return;
-    }
-    if (line.startsWith("-")) {
-      removed += 1;
-    }
-  });
-  return { added, removed };
-}
-
 function fileChangeStats(
   changeType: AgentFileChangeRenderData["changeType"],
   unifiedDiff: string | null,
@@ -467,24 +432,13 @@ function fileChangeStats(
   oldString: string | null,
   newString: string | null
 ): { added: number; removed: number } {
-  if (unifiedDiff) {
-    return diffLineStats(unifiedDiff);
-  }
-  if (changeType === "created") {
-    return { added: countTextLines(content ?? newString), removed: 0 };
-  }
-  if (changeType === "deleted") {
-    return { added: 0, removed: countTextLines(oldString) };
-  }
-  return { added: 0, removed: 0 };
-}
-
-function countTextLines(value: string | null): number {
-  if (!value) {
-    return 0;
-  }
-  const normalized = value.trimEnd();
-  return normalized ? normalized.split("\n").length : 0;
+  return agentFileChangeStats({
+    changeType,
+    unifiedDiff,
+    content,
+    oldString,
+    newString
+  });
 }
 
 function syntheticUnifiedDiff(
@@ -570,6 +524,38 @@ function firstString(
     }
   }
   return null;
+}
+
+function firstRawString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+  return null;
+}
+
+function firstValidUnifiedDiff(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === "string" && isAgentUnifiedDiff(value)) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function firstFileString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === "string") {
+      return fileTextValue(value);
+    }
+  }
+  return null;
+}
+
+function fileTextValue(value: string): string {
+  const trimmed = value.trim();
+  return trimmed ? trimmed : value;
 }
 
 function recordValue(value: unknown): Record<string, unknown> | null {

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/render-data/agentToolRenderData.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/render-data/agentToolRenderData.spec.ts
@@ -356,6 +356,59 @@ describe("agentToolRenderData", () => {
     ]);
   });
 
+  it("chooses a valid later diff alias over an invalid body", () => {
+    const validDiff = "@@ -1 +1 @@\n-old\n+new";
+    const changes = getFileChangeRenderData(
+      makeCall({
+        payload: {
+          fileChanges: {
+            files: [
+              {
+                path: "src/a.ts",
+                change: "modified",
+                diff: "README\n- bullet\n",
+                unifiedDiff: validDiff
+              }
+            ]
+          }
+        }
+      })
+    );
+
+    expect(changes).toEqual([
+      expect.objectContaining({
+        path: "src/a.ts",
+        unifiedDiff: validDiff,
+        added: 1,
+        removed: 1
+      })
+    ]);
+  });
+
+  it("keeps an invalid created body as content instead of a patch", () => {
+    const body = "# README\n\n- bullet\n- another bullet\n";
+    const changes = getFileChangeRenderData(
+      makeCall({
+        payload: {
+          fileChanges: {
+            files: [{ path: "README.md", change: "created", diff: body }]
+          }
+        }
+      })
+    );
+
+    expect(changes).toEqual([
+      expect.objectContaining({
+        path: "README.md",
+        changeType: "created",
+        unifiedDiff: null,
+        content: "# README\n\n- bullet\n- another bullet",
+        added: 4,
+        removed: 0
+      })
+    ]);
+  });
+
   it("extracts file changes from structured patch output", () => {
     const changes = getFileChangeRenderData(
       makeCall({

--- a/packages/agent/gui/shared/agentConversation/projection/agentTurnSummaryProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentTurnSummaryProjection.spec.ts
@@ -70,6 +70,42 @@ describe("agent turn summary canonical projection", () => {
     ]);
   });
 
+  it("does not expose invalid file bodies as unified diffs", () => {
+    const body = "# README\n\n- bullet\n";
+    const rows = projectAgentTurnSummaryRowForTurn(
+      turn("turn-invalid-diff"),
+      {
+        files: [
+          {
+            path: "/workspace/README.md",
+            change: "created",
+            diff: body
+          },
+          {
+            path: "/workspace/obsolete.md",
+            change: "deleted",
+            unifiedDiff: body
+          }
+        ]
+      },
+      { workspaceRoot: "/workspace" }
+    );
+
+    expect(rows[0]?.files).toEqual([
+      expect.objectContaining({
+        path: "/workspace/README.md",
+        unifiedDiff: null,
+        content: body
+      }),
+      expect.objectContaining({
+        path: "/workspace/obsolete.md",
+        unifiedDiff: null,
+        oldString: body,
+        newString: ""
+      })
+    ]);
+  });
+
   it("keeps executable patch batches separate from canonical presentation", () => {
     const sourceTurn = turn("turn-patch", [
       {

--- a/packages/agent/gui/shared/agentConversation/projection/agentTurnSummaryProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentTurnSummaryProjection.ts
@@ -10,6 +10,7 @@ import type {
   AgentTurnSummaryRowVM
 } from "../contracts/agentTurnSummaryRowVM";
 import { inferAgentPatchChangeType } from "../rules/agentPatchMetadata";
+import { isAgentUnifiedDiffText } from "../rules/agentUnifiedDiffValidation";
 import {
   fileChangeEntriesFromChanges,
   fileChangeTypeValue
@@ -140,37 +141,55 @@ function canonicalTurnFiles(
       continue;
     }
     const parts = splitFilePath(path);
+    const rawDiff = firstRawString(
+      file?.diff,
+      file?.patch,
+      file?.unifiedDiff,
+      file?.unified_diff
+    );
+    const unifiedDiff = firstValidUnifiedDiff(
+      file?.diff,
+      file?.patch,
+      file?.unifiedDiff,
+      file?.unified_diff
+    );
+    const explicitChangeType = normalizeChangeType(fileChangeTypeValue(file));
+    let oldString = firstPresentString(
+      literalStringValue(file.oldString),
+      literalStringValue(file.old_string)
+    );
+    let newString = firstPresentString(
+      literalStringValue(file.newString),
+      literalStringValue(file.new_string)
+    );
+    let content = literalStringValue(file.content);
+    const changeType =
+      explicitChangeType ??
+      (unifiedDiff ? inferAgentPatchChangeType(unifiedDiff) : "modified");
+    if (unifiedDiff === null && rawDiff !== null) {
+      if (changeType === "created") {
+        content ??= rawDiff;
+        newString ??= rawDiff;
+      } else if (changeType === "deleted") {
+        oldString ??= rawDiff;
+        newString ??= "";
+        content = null;
+      } else if (oldString === null && newString === null && content === null) {
+        content = rawDiff;
+      }
+    }
     byPath.set(path, {
       label: path,
       path,
       fileName: parts.fileName,
       directory: parts.directory,
-      changeType:
-        normalizeChangeType(
-          firstNonEmptyString(
-            stringValue(file.change),
-            stringValue(file.type),
-            stringValue(file.status)
-          )
-        ) ?? "modified",
+      changeType,
       toolName: null,
       messageId: `turn-summary:${turnId}:file:${index + 1}`,
-      unifiedDiff:
-        firstNonEmptyString(
-          stringValue(file.unifiedDiff),
-          stringValue(file.unified_diff),
-          stringValue(file.diff),
-          stringValue(file.patch)
-        ) ?? null,
-      oldString: firstPresentString(
-        literalStringValue(file.oldString),
-        literalStringValue(file.old_string)
-      ),
-      newString: firstPresentString(
-        literalStringValue(file.newString),
-        literalStringValue(file.new_string)
-      ),
-      content: literalStringValue(file.content),
+      unifiedDiff,
+      oldString,
+      newString,
+      content,
       occurredAtUnixMs: options.occurredAtUnixMs ?? null
     });
   }
@@ -286,13 +305,19 @@ function patchChangesFromChangeMap(
       return [];
     }
     const changeType = normalizeChangeType(fileChangeTypeValue(change));
+    const rawDiff = firstRawString(
+      change.unified_diff,
+      change.unifiedDiff,
+      change.diff,
+      change.patch
+    );
     const unifiedDiff =
-      firstNonEmptyString(
-        stringValue(change.unified_diff),
-        stringValue(change.unifiedDiff),
-        stringValue(change.diff),
-        stringValue(change.patch)
-      ) ?? null;
+      firstValidUnifiedDiff(
+        change.unified_diff,
+        change.unifiedDiff,
+        change.diff,
+        change.patch
+      ) ?? rawDiff;
     let oldString = firstPresentString(
       literalStringValue(change.old_string),
       literalStringValue(change.oldString)
@@ -336,4 +361,22 @@ function patchChangesFromChangeMap(
       }
     ];
   });
+}
+
+function firstRawString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+  return null;
+}
+
+function firstValidUnifiedDiff(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === "string" && isAgentUnifiedDiffText(value)) {
+      return value;
+    }
+  }
+  return null;
 }

--- a/packages/agent/gui/shared/agentConversation/rules/agentTurnSummaryPatchDiff.ts
+++ b/packages/agent/gui/shared/agentConversation/rules/agentTurnSummaryPatchDiff.ts
@@ -3,6 +3,7 @@ import type {
   AgentTurnSummaryPatchChangeVM
 } from "../contracts/agentTurnSummaryRowVM";
 import { normalizeAgentPatchText } from "./agentPatchMetadata";
+import { isAgentUnifiedDiffText } from "./agentUnifiedDiffValidation";
 
 export function buildAgentTurnSummaryPatchDiff(
   batch: AgentTurnSummaryPatchBatchVM
@@ -19,7 +20,7 @@ function patchChangeToUnifiedDiff(
 ): string {
   const path = patchPathRelativeToCwd(change.path, cwd);
   const rawDiff = normalizeAgentPatchText(change.unifiedDiff ?? "").trim();
-  if (rawDiff && looksLikeUnifiedDiff(rawDiff)) {
+  if (rawDiff && isAgentUnifiedDiffText(rawDiff)) {
     return ensureTrailingNewline(
       wrapUnifiedDiff(path, change.changeType, rawDiff)
     );
@@ -132,15 +133,6 @@ function patchPathRelativeToCwd(path: string, cwd: string | null): string {
 
 function normalizePathForPatch(path: string): string {
   return path.trim().replaceAll("\\", "/").replace(/\/+$/, "");
-}
-
-function looksLikeUnifiedDiff(value: string): boolean {
-  return (
-    value.startsWith("diff --git ") ||
-    value.startsWith("@@ ") ||
-    value.startsWith("--- ") ||
-    value.includes("\n@@ ")
-  );
 }
 
 function splitPatchContentLines(content: string): string[] {

--- a/packages/agent/gui/shared/agentConversation/rules/agentUnifiedDiffValidation.ts
+++ b/packages/agent/gui/shared/agentConversation/rules/agentUnifiedDiffValidation.ts
@@ -1,0 +1,135 @@
+import { normalizeAgentPatchText } from "./agentPatchMetadata";
+
+const UNIFIED_DIFF_HUNK_PATTERN =
+  /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(?:.*)$/;
+
+export function isAgentUnifiedDiffText(value: string): boolean {
+  const normalized = normalizeAgentPatchText(value).replace(/\r/g, "\n").trim();
+  if (!normalized) {
+    return false;
+  }
+
+  const lines = normalized.split("\n");
+  const isApplyPatch =
+    normalized.includes("*** Begin Patch") &&
+    (normalized.includes("*** Add File:") ||
+      normalized.includes("*** Delete File:") ||
+      normalized.includes("*** Update File:"));
+  let hasHunk = false;
+  let hunkActive = false;
+  let hunkHasCounts = false;
+  let hunkHasChange = false;
+  let oldCount = 0;
+  let newCount = 0;
+  let expectedOld = 0;
+  let expectedNew = 0;
+
+  const finishHunk = (): boolean => {
+    if (!hunkActive) {
+      return true;
+    }
+    if (!hunkHasCounts) {
+      return isApplyPatch && hunkHasChange;
+    }
+    return (
+      oldCount === expectedOld && newCount === expectedNew && hunkHasChange
+    );
+  };
+
+  for (const line of lines) {
+    const hunkMatch = line.match(UNIFIED_DIFF_HUNK_PATTERN);
+    if (hunkMatch) {
+      if (!finishHunk()) {
+        return false;
+      }
+      hasHunk = true;
+      hunkActive = true;
+      hunkHasCounts = true;
+      hunkHasChange = false;
+      oldCount = 0;
+      newCount = 0;
+      expectedOld = hunkCount(hunkMatch[2]);
+      expectedNew = hunkCount(hunkMatch[4]);
+      continue;
+    }
+
+    if (line === "@@" && isApplyPatch) {
+      if (!finishHunk()) {
+        return false;
+      }
+      hasHunk = true;
+      hunkActive = true;
+      hunkHasCounts = false;
+      hunkHasChange = false;
+      continue;
+    }
+
+    if (hunkActive && line.startsWith("diff --git ")) {
+      if (!finishHunk()) {
+        return false;
+      }
+      hunkActive = false;
+      continue;
+    }
+
+    if (
+      !hunkActive &&
+      (line.startsWith("diff --git ") ||
+        line.startsWith("index ") ||
+        line.startsWith("--- ") ||
+        line.startsWith("+++ ") ||
+        line.startsWith("new file mode ") ||
+        line.startsWith("deleted file mode ") ||
+        line.startsWith("old mode ") ||
+        line.startsWith("new mode ") ||
+        line.startsWith("similarity index ") ||
+        line.startsWith("rename from ") ||
+        line.startsWith("rename to ") ||
+        line.startsWith("*** "))
+    ) {
+      continue;
+    }
+    if (hunkActive && isApplyPatch && line.startsWith("*** ")) {
+      continue;
+    }
+    if (line === "\\ No newline at end of file") {
+      continue;
+    }
+    if (!hasHunk) {
+      continue;
+    }
+
+    if (!hunkHasCounts && isApplyPatch) {
+      if (line.startsWith("+") || line.startsWith("-")) {
+        hunkHasChange = true;
+        continue;
+      }
+      if (line.startsWith(" ")) {
+        continue;
+      }
+      return false;
+    }
+
+    if (line.startsWith("+")) {
+      newCount += 1;
+      hunkHasChange = true;
+    } else if (line.startsWith("-")) {
+      oldCount += 1;
+      hunkHasChange = true;
+    } else if (line.startsWith(" ")) {
+      oldCount += 1;
+      newCount += 1;
+    } else {
+      return false;
+    }
+  }
+
+  return hasHunk && finishHunk();
+}
+
+function hunkCount(value: string | undefined): number {
+  if (!value) {
+    return 1;
+  }
+  return Number.parseInt(value, 10);
+}

--- a/packages/agent/store-sqlite/canonical/tool_file_changes.go
+++ b/packages/agent/store-sqlite/canonical/tool_file_changes.go
@@ -1,0 +1,319 @@
+package canonical
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var toolUnifiedDiffHunkPattern = regexp.MustCompile(`^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(?:.*)$`)
+
+func normalizeToolFileChanges(value any) map[string]any {
+	body := toolMap(value)
+	if body == nil {
+		return nil
+	}
+	filesByPath := make(map[string]map[string]any)
+	order := make([]string, 0)
+	for _, raw := range toolFileChangeMaps(body["files"]) {
+		file := normalizeToolFileChange(raw)
+		if file == nil {
+			continue
+		}
+		path := toolString(file["path"])
+		if current, exists := filesByPath[path]; exists {
+			filesByPath[path] = mergeToolFileChangeValues(current, file)
+			continue
+		}
+		order = append(order, path)
+		filesByPath[path] = file
+	}
+	files := make([]any, 0, len(order))
+	for _, path := range order {
+		if file := filesByPath[path]; file != nil {
+			files = append(files, file)
+		}
+	}
+	if len(files) == 0 {
+		return nil
+	}
+	result := map[string]any{"files": files}
+	if coverage := toolString(body["coverage"]); coverage != "" {
+		result["coverage"] = coverage
+	}
+	return result
+}
+
+func toolFileChangeMaps(value any) []map[string]any {
+	result := make([]map[string]any, 0)
+	switch typed := value.(type) {
+	case []any:
+		for _, raw := range typed {
+			if file := toolMap(raw); file != nil {
+				result = append(result, file)
+			}
+		}
+	case []map[string]any:
+		for _, raw := range typed {
+			if file := toolMap(raw); file != nil {
+				result = append(result, file)
+			}
+		}
+	}
+	return result
+}
+
+func normalizeToolFileChange(value map[string]any) map[string]any {
+	if value == nil {
+		return nil
+	}
+	path := firstToolString(value["path"], value["filePath"], value["file_path"], value["relativePath"])
+	if path == "" {
+		return nil
+	}
+	validDiff, hasValidDiff, rawDiff, hasRawDiff := selectToolFileDiff(value["diff"], value["patch"], value["unifiedDiff"], value["unified_diff"])
+	diff := validDiff
+	hasDiff := hasValidDiff
+	oldString, hasOld := firstPresentToolString(value["oldString"], value["old_string"], value["oldText"])
+	newString, hasNew := firstPresentToolString(value["newString"], value["new_string"], value["newText"])
+	content, hasContent := firstPresentToolString(value["content"])
+	change := firstToolChange(value["change"], value["status"], value["kind"], value["type"])
+	if change == "" && hasContent {
+		change = "added"
+	}
+	if change == "added" && !hasNew && hasContent {
+		newString, hasNew = content, true
+		hasContent = false
+	}
+	if !hasValidDiff && hasRawDiff {
+		switch {
+		case change == "added" && !hasNew:
+			newString, hasNew = rawDiff, true
+		case change == "deleted" && !hasOld:
+			oldString, hasOld = rawDiff, true
+		case !hasOld && !hasNew && !hasContent:
+			content, hasContent = rawDiff, true
+		}
+	}
+	if change == "" {
+		switch {
+		case hasOld && !hasNew:
+			change = "deleted"
+		case hasNew && !hasOld:
+			change = "added"
+		case hasOld || hasNew || hasDiff:
+			change = "modified"
+		case hasContent:
+			change = "modified"
+		}
+	}
+	if change == "" {
+		return nil
+	}
+	file := map[string]any{"path": path, "change": change}
+	if hasOld {
+		file["oldString"] = oldString
+	}
+	if hasNew {
+		file["newString"] = newString
+	}
+	if hasDiff {
+		file["diff"] = diff
+		file["unifiedDiff"] = diff
+	}
+	if hasContent {
+		file["content"] = content
+	}
+	return file
+}
+
+func looksLikeUnifiedDiff(value string) bool {
+	normalized := strings.TrimSpace(strings.ReplaceAll(strings.ReplaceAll(value, "\r\n", "\n"), "\r", "\n"))
+	if normalized == "" {
+		return false
+	}
+	lines := strings.Split(normalized, "\n")
+	isApplyPatch := strings.Contains(normalized, "*** Begin Patch") &&
+		(strings.Contains(normalized, "*** Add File:") || strings.Contains(normalized, "*** Delete File:") || strings.Contains(normalized, "*** Update File:"))
+	hasHunk := false
+	hunkHasChange := false
+	oldCount := 0
+	newCount := 0
+	expectedOld := 0
+	expectedNew := 0
+	hunkActive := false
+	hunkHasCounts := false
+	finishHunk := func() bool {
+		if !hunkActive {
+			return true
+		}
+		if !hunkHasCounts {
+			return isApplyPatch && hunkHasChange
+		}
+		return oldCount == expectedOld && newCount == expectedNew && hunkHasChange
+	}
+	for _, line := range lines {
+		if match := toolUnifiedDiffHunkPattern.FindStringSubmatch(line); match != nil {
+			if !finishHunk() {
+				return false
+			}
+			hasHunk = true
+			hunkActive = true
+			hunkHasCounts = true
+			oldCount = 0
+			newCount = 0
+			hunkHasChange = false
+			expectedOld = toolUnifiedDiffHunkCount(match[2])
+			expectedNew = toolUnifiedDiffHunkCount(match[4])
+			continue
+		}
+		if line == "@@" && isApplyPatch {
+			if !finishHunk() {
+				return false
+			}
+			hasHunk = true
+			hunkActive = true
+			hunkHasCounts = false
+			hunkHasChange = false
+			continue
+		}
+		if hunkActive && strings.HasPrefix(line, "diff --git ") {
+			if !finishHunk() {
+				return false
+			}
+			hunkActive = false
+			continue
+		}
+		if !hunkActive && (strings.HasPrefix(line, "diff --git ") || strings.HasPrefix(line, "index ") ||
+			strings.HasPrefix(line, "--- ") || strings.HasPrefix(line, "+++ ") ||
+			strings.HasPrefix(line, "new file mode ") || strings.HasPrefix(line, "deleted file mode ") ||
+			strings.HasPrefix(line, "old mode ") || strings.HasPrefix(line, "new mode ") ||
+			strings.HasPrefix(line, "similarity index ") || strings.HasPrefix(line, "rename from ") ||
+			strings.HasPrefix(line, "rename to ") || strings.HasPrefix(line, "*** ")) {
+			continue
+		}
+		if hunkActive && isApplyPatch && strings.HasPrefix(line, "*** ") {
+			continue
+		}
+		if line == "\\ No newline at end of file" {
+			continue
+		}
+		if !hasHunk {
+			continue
+		}
+		if !hunkHasCounts && isApplyPatch {
+			switch {
+			case strings.HasPrefix(line, "+"), strings.HasPrefix(line, "-"):
+				hunkHasChange = true
+			case strings.HasPrefix(line, " "):
+			default:
+				return false
+			}
+			continue
+		}
+		switch {
+		case strings.HasPrefix(line, "+"):
+			newCount++
+			hunkHasChange = true
+		case strings.HasPrefix(line, "-"):
+			oldCount++
+			hunkHasChange = true
+		case strings.HasPrefix(line, " "):
+			oldCount++
+			newCount++
+		default:
+			return false
+		}
+	}
+	return hasHunk && finishHunk()
+}
+
+func toolUnifiedDiffHunkCount(value string) int {
+	if value == "" {
+		return 1
+	}
+	count, err := strconv.Atoi(value)
+	if err != nil {
+		return -1
+	}
+	return count
+}
+
+func selectToolFileDiff(values ...any) (valid string, hasValid bool, raw string, hasRaw bool) {
+	for _, value := range values {
+		text, ok := value.(string)
+		if !ok {
+			continue
+		}
+		if !hasRaw {
+			raw, hasRaw = text, true
+		}
+		if !hasValid && looksLikeUnifiedDiff(text) {
+			valid, hasValid = text, true
+		}
+	}
+	return
+}
+
+func firstToolChange(values ...any) string {
+	for _, value := range values {
+		if change := normalizeToolChangeValue(value); change != "" {
+			return change
+		}
+	}
+	return ""
+}
+
+func normalizeToolChangeValue(value any) string {
+	if text, ok := value.(string); ok {
+		return normalizeToolChange(text)
+	}
+	if nested, ok := value.(map[string]any); ok {
+		for _, key := range []string{"type", "change", "status", "kind"} {
+			if change := normalizeToolChangeValue(nested[key]); change != "" {
+				return change
+			}
+		}
+	}
+	return ""
+}
+
+func mergeToolFileChangeValues(existing map[string]any, next map[string]any) map[string]any {
+	if existing == nil {
+		return cloneToolMap(next)
+	}
+	if next == nil {
+		return cloneToolMap(existing)
+	}
+	previousKind := normalizeToolChangeValue(existing["change"])
+	nextKind := normalizeToolChangeValue(next["change"])
+	if previousKind == "added" && nextKind == "deleted" {
+		return nil
+	}
+
+	merged := cloneToolMap(existing)
+	for key, value := range next {
+		if key == "path" || key == "change" || key == "oldString" {
+			continue
+		}
+		merged[key] = cloneToolValue(value)
+	}
+	if _, exists := merged["oldString"]; !exists {
+		if value, present := next["oldString"]; present {
+			merged["oldString"] = cloneToolValue(value)
+		}
+	}
+	switch {
+	case previousKind == "added" && nextKind == "modified":
+		merged["change"] = "added"
+	case previousKind == "deleted" && nextKind == "added":
+		merged["change"] = "modified"
+	case previousKind == "modified" && nextKind == "deleted":
+		merged["change"] = "deleted"
+	case nextKind != "":
+		merged["change"] = nextKind
+	case previousKind != "":
+		merged["change"] = previousKind
+	}
+	return merged
+}

--- a/packages/agent/store-sqlite/canonical/tool_payload.go
+++ b/packages/agent/store-sqlite/canonical/tool_payload.go
@@ -186,6 +186,11 @@ func CompactToolCallPayload(status string, payload map[string]any) map[string]an
 	if len(projection.fileChanges) > 0 {
 		result["fileChanges"] = mergeToolFileChanges(result["fileChanges"], projection.fileChanges)
 	}
+	if fileChanges := normalizeToolFileChanges(result["fileChanges"]); fileChanges != nil {
+		result["fileChanges"] = fileChanges
+	} else {
+		delete(result, "fileChanges")
+	}
 
 	if output != nil {
 		delete(output, "content")
@@ -293,8 +298,8 @@ func compactToolSteps(value any) []any {
 		if len(metadata) > 0 {
 			step["metadata"] = metadata
 		}
-		if fileChanges := firstToolValue(rawStep["fileChanges"], payload["fileChanges"]); fileChanges != nil {
-			step["fileChanges"] = cloneToolValue(fileChanges)
+		if fileChanges := normalizeToolFileChanges(firstToolValue(rawStep["fileChanges"], payload["fileChanges"])); fileChanges != nil {
+			step["fileChanges"] = fileChanges
 		}
 		if len(step) > 0 {
 			steps = append(steps, step)
@@ -357,6 +362,11 @@ func compactToolBody(value any) map[string]any {
 	}
 	if len(projection.fileChanges) > 0 {
 		body["fileChanges"] = mergeToolFileChanges(body["fileChanges"], projection.fileChanges)
+	}
+	if fileChanges := normalizeToolFileChanges(body["fileChanges"]); fileChanges != nil {
+		body["fileChanges"] = fileChanges
+	} else {
+		delete(body, "fileChanges")
 	}
 
 	if value, exists := body["exit_code"]; exists {
@@ -491,13 +501,15 @@ func toolFileChangesFromContent(value map[string]any) []map[string]any {
 
 	oldString, hasOld := firstPresentToolString(value["oldString"], value["old_string"], value["oldText"])
 	newString, hasNew := firstPresentToolString(value["newString"], value["new_string"], value["newText"])
-	diff := firstToolString(value["diff"], value["patch"], value["unifiedDiff"], value["unified_diff"])
-	change := normalizeToolChange(firstToolString(value["change"], value["status"], value["kind"]))
+	content, hasContent := firstPresentToolString(value["content"])
+	change := firstToolChange(value["change"], value["status"], value["kind"], value["type"])
 	if change == "" {
 		switch {
 		case hasOld && !hasNew:
 			change = "deleted"
-		case hasNew && (!hasOld || oldString == "") && newString != "":
+		case hasNew && (!hasOld || oldString == ""):
+			change = "added"
+		case hasContent:
 			change = "added"
 		default:
 			change = "modified"
@@ -513,9 +525,13 @@ func toolFileChangesFromContent(value map[string]any) []map[string]any {
 		if hasNew {
 			file["newString"] = newString
 		}
-		if diff != "" {
-			file["diff"] = diff
-			file["unifiedDiff"] = diff
+		if hasContent {
+			file["content"] = content
+		}
+		for _, key := range []string{"diff", "patch", "unifiedDiff", "unified_diff"} {
+			if text, ok := value[key].(string); ok {
+				file[key] = text
+			}
 		}
 		files = append(files, file)
 	}
@@ -525,26 +541,27 @@ func toolFileChangesFromContent(value map[string]any) []map[string]any {
 func mergeToolFileChanges(existing any, incoming []map[string]any) map[string]any {
 	filesByPath := map[string]map[string]any{}
 	order := make([]string, 0)
-	if existingMap := toolMap(existing); existingMap != nil {
-		if files, ok := existingMap["files"].([]any); ok {
-			for _, raw := range files {
-				file := toolMap(raw)
-				path := toolString(file["path"])
-				if path == "" {
-					continue
-				}
-				order = append(order, path)
-				filesByPath[path] = file
+	if existingMap := normalizeToolFileChanges(existing); existingMap != nil {
+		for _, raw := range toolFileChangeMaps(existingMap["files"]) {
+			path := toolString(raw["path"])
+			if path == "" {
+				continue
 			}
+			order = append(order, path)
+			filesByPath[path] = raw
 		}
 	}
-	for _, file := range incoming {
+	for _, raw := range incoming {
+		file := normalizeToolFileChange(raw)
+		if file == nil {
+			continue
+		}
 		path := toolString(file["path"])
 		if path == "" {
 			continue
 		}
 		if current, exists := filesByPath[path]; exists {
-			filesByPath[path] = mergeMissingToolValues(current, file)
+			filesByPath[path] = mergeToolFileChangeValues(current, file)
 			continue
 		}
 		order = append(order, path)
@@ -738,11 +755,11 @@ func stringsToAny(values []string) []any {
 
 func normalizeToolChange(value string) string {
 	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "add", "added", "create", "created", "new":
+	case "add", "added", "create", "created", "new", "write_file":
 		return "added"
-	case "delete", "deleted", "remove", "removed":
+	case "delete", "deleted", "remove", "removed", "delete_file":
 		return "deleted"
-	case "modify", "modified", "update", "updated", "edit", "edited", "change", "changed":
+	case "modify", "modified", "update", "updated", "edit", "edited", "change", "changed", "edit_file":
 		return "modified"
 	default:
 		return ""

--- a/packages/agent/store-sqlite/canonical/tool_payload_test.go
+++ b/packages/agent/store-sqlite/canonical/tool_payload_test.go
@@ -159,6 +159,93 @@ func TestCompactToolCallPayloadKeepsBusinessProjectionWithoutProviderEnvelopes(t
 	}
 }
 
+func TestCompactToolCallPayloadNormalizesRawCreatedBody(t *testing.T) {
+	content := "# Liying\n\n- 自我介绍\n- 欢迎来到我的 README\n"
+	got := CompactToolCallPayload("completed", map[string]any{
+		"fileChanges": map[string]any{
+			"files": []any{map[string]any{
+				"path":        "/workspace/README.md",
+				"change":      "created",
+				"unifiedDiff": content,
+			}},
+		},
+	})
+	fileChanges, ok := got["fileChanges"].(map[string]any)
+	if !ok {
+		t.Fatalf("fileChanges = %#v, want canonical fileChanges", got["fileChanges"])
+	}
+	files, ok := fileChanges["files"].([]any)
+	if !ok || len(files) != 1 {
+		t.Fatalf("files = %#v, want one file", fileChanges["files"])
+	}
+	file, ok := files[0].(map[string]any)
+	if !ok {
+		t.Fatalf("file = %#v, want object", files[0])
+	}
+	if file["change"] != "added" || file["newString"] != content {
+		t.Fatalf("file = %#v, want added file with body in newString", file)
+	}
+	if _, exists := file["diff"]; exists {
+		t.Fatalf("file retained invalid diff: %#v", file)
+	}
+	if _, exists := file["unifiedDiff"]; exists {
+		t.Fatalf("file retained invalid unifiedDiff: %#v", file)
+	}
+}
+
+func TestCompactToolCallPayloadNormalizesNestedKindAndValidDiffAlias(t *testing.T) {
+	valid := "@@ -1 +1 @@\n-old\n+new"
+	got := CompactToolCallPayload("completed", map[string]any{
+		"fileChanges": map[string]any{
+			"files": []any{map[string]any{
+				"path":        "/workspace/app.ts",
+				"kind":        map[string]any{"type": "update"},
+				"diff":        "README\n- bullet\n",
+				"unifiedDiff": valid,
+			}},
+		},
+	})
+	files := got["fileChanges"].(map[string]any)["files"].([]any)
+	file := files[0].(map[string]any)
+	if file["change"] != "modified" || file["unifiedDiff"] != valid {
+		t.Fatalf("file = %#v, want nested kind and valid diff alias normalized", file)
+	}
+}
+
+func TestNormalizeToolFileChangesDeduplicatesAndCancelsCreatedFiles(t *testing.T) {
+	got := normalizeToolFileChanges(map[string]any{
+		"files": []any{
+			map[string]any{"path": "/workspace/a.txt", "change": "added", "newString": "a"},
+			map[string]any{"path": "/workspace/a.txt", "change": "deleted"},
+			map[string]any{"path": "/workspace/b.txt", "change": "added", "newString": "b"},
+		},
+	})
+	files := got["files"].([]any)
+	if len(files) != 1 || files[0].(map[string]any)["path"] != "/workspace/b.txt" {
+		t.Fatalf("normalized files = %#v, want only the surviving file", files)
+	}
+}
+
+func TestCompactToolCallPayloadPreservesInvalidModifiedBodyWithoutDiff(t *testing.T) {
+	body := "README\n- bullet\n"
+	got := CompactToolCallPayload("completed", map[string]any{
+		"fileChanges": map[string]any{
+			"files": []any{map[string]any{
+				"path":   "/workspace/README.md",
+				"change": "modified",
+				"diff":   body,
+			}},
+		},
+	})
+	file := got["fileChanges"].(map[string]any)["files"].([]any)[0].(map[string]any)
+	if file["content"] != body || file["change"] != "modified" {
+		t.Fatalf("file = %#v, want invalid body preserved as content", file)
+	}
+	if _, exists := file["diff"]; exists {
+		t.Fatalf("file retained invalid diff: %#v", file)
+	}
+}
+
 func TestCompactToolCallPayloadCompactsNestedTaskSteps(t *testing.T) {
 	got := CompactToolCallPayload("completed", map[string]any{
 		"callId":   "call-parent",


### PR DESCRIPTION
## Summary\n\n- Normalize provider file-change payloads before UI inference.\n- Validate unified diffs and keep raw created/deleted/modified bodies in the correct fields.\n- Make aggregation and AgentGUI stats/rendering consistent, including empty files and same-path merges.\n- Add regression coverage and troubleshooting documentation for the negative-line summary case.\n\n## Tests\n\n- go test ./... (packages/agent/daemon)\n- go test ./... (packages/agent/store-sqlite/canonical)\n- pnpm --filter @tutti-os/agent-gui typecheck\n- pnpm --filter @tutti-os/agent-gui test -- --run\n- pnpm check:changed\n- pnpm --dir apps/tsh-desktop check (TSH integration check with the local Tutti packages)\n