### PR TITLE
refactor(desktop): isolate replay activity bridge

### DIFF
--- a/apps/desktop/src/renderer/src/features/agent-session-replay/services/agentSessionReplayActivityBridge.test.ts
+++ b/apps/desktop/src/renderer/src/features/agent-session-replay/services/agentSessionReplayActivityBridge.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type {
+  EngineExternalCommand,
+  EngineIntent
+} from "@tutti-os/agent-activity-core";
+import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
+import { AgentSessionReplayActivityBridge } from "./agentSessionReplayActivityBridge.ts";
+
+function queueRemovedIntent(): EngineIntent {
+  return {
+    agentSessionId: "session-1",
+    promptId: "prompt-1",
+    type: "queue/removed"
+  };
+}
+
+function queueRemovedCommand(): EngineExternalCommand {
+  return {
+    agentSessionId: "session-1",
+    commandId: "queue:removed:1",
+    promptId: "prompt-1",
+    type: "queue/removed"
+  } as unknown as EngineExternalCommand;
+}
+
+function createClient(
+  appended: { recordingId: string; types: string[] }[]
+): TuttidClient {
+  return {
+    appendAgentSessionRecordingActivityEvents: async (
+      _workspaceId: string,
+      recordingId: string,
+      body: { events: { type: string }[] }
+    ) => {
+      appended.push({
+        recordingId,
+        types: body.events.map((event) => event.type)
+      });
+    }
+  } as unknown as TuttidClient;
+}
+
+test("replay activity bridge fans Engine activity into recording and observers", async () => {
+  const appended: { recordingId: string; types: string[] }[] = [];
+  const observed: { commands: string[]; intents: string[] } = {
+    commands: [],
+    intents: []
+  };
+  const bridge = new AgentSessionReplayActivityBridge({
+    enabled: true,
+    tuttidClient: createClient(appended)
+  });
+  bridge.addSessionEngineActivityObserver("ws-1", {
+    observeCommand(command) {
+      observed.commands.push(command.type);
+    },
+    observeIntent(intent) {
+      observed.intents.push(intent.type);
+    }
+  });
+  bridge.startSessionActivityEventRecording("ws-1", "recording-1");
+
+  const activityObserver = bridge.createSessionEngineActivityObserver("ws-1");
+  const intent = queueRemovedIntent();
+  const command = queueRemovedCommand();
+  activityObserver.observeIntent(intent);
+  activityObserver.observeCommand(command);
+  await bridge.sealSessionActivityEventRecording("ws-1", "recording-1");
+
+  assert.deepEqual(observed, {
+    commands: ["queue/removed"],
+    intents: ["queue/removed"]
+  });
+  assert.deepEqual(appended, [
+    { recordingId: "recording-1", types: ["queue/removed"] }
+  ]);
+});
+
+test("disabled replay activity bridge fails closed without composing recording", () => {
+  const bridge = new AgentSessionReplayActivityBridge({
+    enabled: false,
+    tuttidClient: createClient([])
+  });
+
+  assert.throws(
+    () => bridge.startSessionActivityEventRecording("ws-1", "recording-1"),
+    /agent_session_replay_not_composed/
+  );
+  assert.throws(
+    () => bridge.createSessionEngineActivityObserver("ws-1"),
+    /agent_session_replay_not_composed/
+  );
+});

--- a/apps/desktop/src/renderer/src/features/agent-session-replay/services/agentSessionReplayActivityBridge.ts
+++ b/apps/desktop/src/renderer/src/features/agent-session-replay/services/agentSessionReplayActivityBridge.ts
@@ -1,0 +1,202 @@
+import type {
+  EngineExternalCommand,
+  EngineIntent
+} from "@tutti-os/agent-activity-core";
+import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
+import { AgentSessionRecordingBinding } from "./agentSessionRecordingBinding.ts";
+import {
+  AgentSessionActivityEventRecorder,
+  createTuttidAgentSessionActivityEventAppender
+} from "./agentSessionActivityEventRecorder.ts";
+
+function normalizeReplayWorkspaceId(workspaceId: string): string {
+  return workspaceId.trim() || "__default__";
+}
+
+export interface AgentSessionEngineActivityObserver {
+  observeCommand(command: EngineExternalCommand): void;
+  observeIntent(intent: EngineIntent): void;
+}
+
+export class AgentSessionReplayActivityBridge {
+  private readonly enabled: boolean;
+  private readonly tuttidClient: TuttidClient;
+  private sessionRecordingBinding: AgentSessionRecordingBinding | null = null;
+  private sessionActivityEventRecorders: Map<
+    string,
+    AgentSessionActivityEventRecorder
+  > | null = null;
+  private sessionEngineActivityObservers: Map<
+    string,
+    Set<AgentSessionEngineActivityObserver>
+  > | null = null;
+
+  constructor(input: { enabled?: boolean; tuttidClient: TuttidClient }) {
+    this.enabled = input.enabled === true;
+    this.tuttidClient = input.tuttidClient;
+  }
+
+  armNextSessionRecording(workspaceId: string, recordingId: string): void {
+    this.assertEnabled();
+    (this.sessionRecordingBinding ??= new AgentSessionRecordingBinding()).arm(
+      workspaceId,
+      recordingId
+    );
+  }
+
+  clearNextSessionRecording(workspaceId: string, recordingId?: string): void {
+    this.sessionRecordingBinding?.clear(workspaceId, recordingId);
+  }
+
+  startSessionActivityEventRecording(
+    workspaceId: string,
+    recordingId: string
+  ): void {
+    const normalizedWorkspaceId = normalizeReplayWorkspaceId(workspaceId);
+    this.assertEnabled();
+    const recorders = (this.sessionActivityEventRecorders ??= new Map());
+    const existing = recorders.get(normalizedWorkspaceId);
+    const recorder =
+      existing ??
+      new AgentSessionActivityEventRecorder({
+        appender: createTuttidAgentSessionActivityEventAppender({
+          tuttidClient: this.tuttidClient,
+          workspaceId: normalizedWorkspaceId
+        })
+      });
+    recorder.start({
+      recordingId,
+      scopeId: normalizedWorkspaceId
+    });
+    if (!existing) {
+      recorders.set(normalizedWorkspaceId, recorder);
+    }
+  }
+
+  async sealSessionActivityEventRecording(
+    workspaceId: string,
+    recordingId: string
+  ): Promise<void> {
+    const normalizedWorkspaceId = normalizeReplayWorkspaceId(workspaceId);
+    const recorders = this.sessionActivityEventRecorders;
+    const recorder = recorders?.get(normalizedWorkspaceId);
+    if (!recorder) return;
+    await recorder.seal(recordingId);
+    if (recorders?.get(normalizedWorkspaceId) === recorder) {
+      recorders.delete(normalizedWorkspaceId);
+      if (recorders.size === 0) this.sessionActivityEventRecorders = null;
+    }
+  }
+
+  discardSessionActivityEventRecording(
+    workspaceId: string,
+    recordingId: string
+  ): void {
+    const normalizedWorkspaceId = normalizeReplayWorkspaceId(workspaceId);
+    const recorders = this.sessionActivityEventRecorders;
+    if (!recorders) return;
+    const recorder = recorders.get(normalizedWorkspaceId);
+    if (!recorder) return;
+    recorder.discard(recordingId);
+    recorders.delete(normalizedWorkspaceId);
+    if (recorders.size === 0) this.sessionActivityEventRecorders = null;
+  }
+
+  addSessionEngineActivityObserver(
+    workspaceId: string,
+    observer: AgentSessionEngineActivityObserver
+  ): () => void {
+    const normalizedWorkspaceId = normalizeReplayWorkspaceId(workspaceId);
+    this.assertEnabled();
+    const observerMap = (this.sessionEngineActivityObservers ??= new Map());
+    let observers = observerMap.get(normalizedWorkspaceId);
+    if (!observers) {
+      observers = new Set();
+      observerMap.set(normalizedWorkspaceId, observers);
+    }
+    observers.add(observer);
+    return () => {
+      observers?.delete(observer);
+      if (observers?.size === 0) {
+        observerMap.delete(normalizedWorkspaceId);
+        if (observerMap.size === 0) this.sessionEngineActivityObservers = null;
+      }
+    };
+  }
+
+  createSessionEngineActivityObserver(
+    workspaceId: string
+  ): AgentSessionEngineActivityObserver {
+    const normalizedWorkspaceId = normalizeReplayWorkspaceId(workspaceId);
+    this.assertEnabled();
+    return {
+      observeCommand: (command) => {
+        this.sessionActivityEventRecorders
+          ?.get(normalizedWorkspaceId)
+          ?.observeCommand(command);
+        this.notifySessionEngineActivityObservers(
+          normalizedWorkspaceId,
+          "observeCommand",
+          command
+        );
+      },
+      observeIntent: (intent) => {
+        this.sessionActivityEventRecorders
+          ?.get(normalizedWorkspaceId)
+          ?.observeIntent(intent);
+        this.notifySessionEngineActivityObservers(
+          normalizedWorkspaceId,
+          "observeIntent",
+          intent
+        );
+      }
+    };
+  }
+
+  takePendingSessionRecording(workspaceId: string): string | null {
+    return this.sessionRecordingBinding?.take(workspaceId) ?? null;
+  }
+
+  restorePendingSessionRecording(
+    workspaceId: string,
+    recordingId: string
+  ): void {
+    this.sessionRecordingBinding?.restore(workspaceId, recordingId);
+  }
+
+  private assertEnabled(): void {
+    if (!this.enabled) {
+      throw new Error("agent_session_replay_not_composed");
+    }
+  }
+
+  private notifySessionEngineActivityObservers(
+    workspaceId: string,
+    method: "observeCommand",
+    value: EngineExternalCommand
+  ): void;
+  private notifySessionEngineActivityObservers(
+    workspaceId: string,
+    method: "observeIntent",
+    value: EngineIntent
+  ): void;
+  private notifySessionEngineActivityObservers(
+    workspaceId: string,
+    method: "observeCommand" | "observeIntent",
+    value: EngineExternalCommand | EngineIntent
+  ): void {
+    const observers = this.sessionEngineActivityObservers?.get(workspaceId);
+    if (!observers) return;
+    for (const observer of observers) {
+      try {
+        if (method === "observeCommand") {
+          observer.observeCommand(value as EngineExternalCommand);
+        } else {
+          observer.observeIntent(value as EngineIntent);
+        }
+      } catch {
+        // Replay instrumentation cannot block the product command path.
+      }
+    }
+  }
+}

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -4314,13 +4314,7 @@ function activityRecorderHarness() {
     runtimeApi: { logTerminalDiagnostic: async () => {} },
     sessionReplayEnabled: true
   });
-  const getRecorders = () =>
-    (
-      service as unknown as {
-        sessionActivityEventRecorders: Map<string, unknown> | null;
-      }
-    ).sessionActivityEventRecorders;
-  return { appended, getRecorders, service };
+  return { appended, service };
 }
 
 test("WorkspaceAgentActivityService disabled composition creates no replay state", async () => {
@@ -4342,23 +4336,23 @@ test("WorkspaceAgentActivityService disabled composition creates no replay state
     type: "queue/removed"
   });
 
-  const replayState = service as unknown as {
-    sessionActivityEventRecorders: Map<string, unknown> | null;
-    sessionEngineActivityObservers: Map<string, unknown> | null;
-    sessionRecordingBinding: unknown | null;
-  };
-  assert.equal(replayState.sessionActivityEventRecorders, null);
-  assert.equal(replayState.sessionEngineActivityObservers, null);
-  assert.equal(replayState.sessionRecordingBinding, null);
   assert.throws(
     () => service.startSessionActivityEventRecording("ws-1", "recording-1"),
+    /agent_session_replay_not_composed/
+  );
+  assert.throws(
+    () =>
+      service.addSessionEngineActivityObserver("ws-1", {
+        observeCommand() {},
+        observeIntent() {}
+      }),
     /agent_session_replay_not_composed/
   );
   service.dispose();
 });
 
 test("WorkspaceAgentActivityService keeps enabled observer state lazy without a recording", async () => {
-  const { appended, getRecorders, service } = activityRecorderHarness();
+  const { appended, service } = activityRecorderHarness();
   const observedIntentTypes: string[] = [];
   const removeObserver = service.addSessionEngineActivityObserver("ws-1", {
     observeCommand: () => {},
@@ -4375,7 +4369,6 @@ test("WorkspaceAgentActivityService keeps enabled observer state lazy without a 
     type: "queue/removed"
   });
 
-  assert.equal(getRecorders(), null);
   assert.equal(observedIntentTypes.includes("queue/removed"), true);
   assert.deepEqual(appended, []);
   removeObserver();
@@ -4383,7 +4376,7 @@ test("WorkspaceAgentActivityService keeps enabled observer state lazy without a 
 });
 
 test("WorkspaceAgentActivityService constructs the recorder at start and drops it after seal or discard", async () => {
-  const { appended, getRecorders, service } = activityRecorderHarness();
+  const { appended, service } = activityRecorderHarness();
   const engine = service.getSessionEngine("ws-1");
   await service.load("ws-1");
 
@@ -4392,10 +4385,8 @@ test("WorkspaceAgentActivityService constructs the recorder at start and drops i
     promptId: "prompt-before",
     type: "queue/removed"
   });
-  assert.equal(getRecorders(), null);
 
   service.startSessionActivityEventRecording("ws-1", "recording-1");
-  assert.equal(getRecorders()?.size, 1);
   engine.dispatch({
     agentSessionId: "session-1",
     promptId: "prompt-recorded",
@@ -4403,7 +4394,6 @@ test("WorkspaceAgentActivityService constructs the recorder at start and drops i
   });
   await service.sealSessionActivityEventRecording("ws-1", "recording-1");
 
-  assert.equal(getRecorders(), null);
   assert.deepEqual(
     appended.flatMap((batch) => batch.types),
     ["queue/removed"]
@@ -4414,16 +4404,13 @@ test("WorkspaceAgentActivityService constructs the recorder at start and drops i
   );
 
   service.startSessionActivityEventRecording("ws-1", "recording-2");
-  assert.equal(getRecorders()?.size, 1);
   service.discardSessionActivityEventRecording("ws-1", "recording-2");
-  assert.equal(getRecorders(), null);
 
   engine.dispatch({
     agentSessionId: "session-1",
     promptId: "prompt-after",
     type: "queue/removed"
   });
-  assert.equal(getRecorders(), null);
   assert.equal(appended.length, 1);
   service.dispose();
 });

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -50,11 +50,7 @@ import {
   reportAgentSubmitTraceDiagnostic
 } from "../desktopAgentRuntimeSubmitDiagnostics.ts";
 import { reportAgentSessionSettingsChanges } from "./agentSessionSettingsAnalytics.ts";
-import { AgentSessionRecordingBinding } from "../../../agent-session-replay/services/agentSessionRecordingBinding.ts";
-import {
-  AgentSessionActivityEventRecorder,
-  createTuttidAgentSessionActivityEventAppender
-} from "../../../agent-session-replay/services/agentSessionActivityEventRecorder.ts";
+import { AgentSessionReplayActivityBridge } from "../../../agent-session-replay/services/agentSessionReplayActivityBridge.ts";
 
 function waitForPromiseWithSignal<T>(
   promise: Promise<T>,
@@ -121,21 +117,14 @@ export class WorkspaceAgentActivityService
     string,
     Promise<AgentActivitySnapshot>
   >();
-  private sessionRecordingBinding: AgentSessionRecordingBinding | null = null;
-  private sessionActivityEventRecorders: Map<
-    string,
-    AgentSessionActivityEventRecorder
-  > | null = null;
-  private sessionEngineActivityObservers: Map<
-    string,
-    Set<{
-      observeCommand(command: EngineExternalCommand): void;
-      observeIntent(intent: EngineIntent): void;
-    }>
-  > | null = null;
+  private readonly sessionReplayActivityBridge: AgentSessionReplayActivityBridge;
   constructor(dependencies: WorkspaceAgentActivityServiceDependencies) {
     super(dependencies);
     this.dependencies = dependencies;
+    this.sessionReplayActivityBridge = new AgentSessionReplayActivityBridge({
+      enabled: dependencies.sessionReplayEnabled,
+      tuttidClient: dependencies.tuttidClient
+    });
     this.analytics = new WorkspaceAgentActivityAnalytics({
       forceRefreshAgentProviderStatuses:
         dependencies.forceRefreshAgentProviderStatuses,
@@ -166,77 +155,47 @@ export class WorkspaceAgentActivityService
   }
 
   armNextSessionRecording(workspaceId: string, recordingId: string): void {
-    this.assertSessionReplayEnabled();
-    (this.sessionRecordingBinding ??= new AgentSessionRecordingBinding()).arm(
+    this.sessionReplayActivityBridge.armNextSessionRecording(
       workspaceId,
       recordingId
     );
   }
 
   clearNextSessionRecording(workspaceId: string, recordingId?: string): void {
-    this.sessionRecordingBinding?.clear(workspaceId, recordingId);
+    this.sessionReplayActivityBridge.clearNextSessionRecording(
+      workspaceId,
+      recordingId
+    );
   }
 
-  // Recorder lifecycle: an AgentSessionActivityEventRecorder exists only
-  // between a successful start and the matching seal/discard. Outside that
-  // window the per-workspace map stays empty so the engine hot path reduces
-  // to a null check.
   startSessionActivityEventRecording(
     workspaceId: string,
     recordingId: string
   ): void {
-    const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
-    this.assertSessionReplayEnabled();
-    const recorders = (this.sessionActivityEventRecorders ??= new Map());
-    const existing = recorders.get(normalizedWorkspaceId);
-    const recorder =
-      existing ??
-      new AgentSessionActivityEventRecorder({
-        appender: createTuttidAgentSessionActivityEventAppender({
-          tuttidClient: this.dependencies.tuttidClient,
-          workspaceId: normalizedWorkspaceId
-        })
-      });
-    // Retain the recorder only after start accepts the recording, so a
-    // rejected start leaves no idle recorder on the hot path.
-    recorder.start({
-      recordingId,
-      scopeId: normalizedWorkspaceId
-    });
-    if (!existing) {
-      recorders.set(normalizedWorkspaceId, recorder);
-    }
+    this.sessionReplayActivityBridge.startSessionActivityEventRecording(
+      workspaceId,
+      recordingId
+    );
   }
 
-  async sealSessionActivityEventRecording(
+  sealSessionActivityEventRecording(
     workspaceId: string,
     recordingId: string
   ): Promise<void> {
-    const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
-    const recorders = this.sessionActivityEventRecorders;
-    const recorder = recorders?.get(normalizedWorkspaceId);
-    if (!recorder) return;
-    // On seal failure the recorder keeps its pending batch so the caller can
-    // retry seal; drop the instance only after the flush succeeded.
-    await recorder.seal(recordingId);
-    if (recorders?.get(normalizedWorkspaceId) === recorder) {
-      recorders.delete(normalizedWorkspaceId);
-      if (recorders.size === 0) this.sessionActivityEventRecorders = null;
-    }
+    return this.sessionReplayActivityBridge.sealSessionActivityEventRecording(
+      workspaceId,
+      recordingId
+    );
   }
 
   discardSessionActivityEventRecording(
     workspaceId: string,
     recordingId: string
   ): void {
-    const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
-    const recorders = this.sessionActivityEventRecorders;
-    if (!recorders) return;
-    const recorder = recorders.get(normalizedWorkspaceId);
-    if (!recorder) return;
-    recorder.discard(recordingId);
-    recorders.delete(normalizedWorkspaceId);
-    if (recorders.size === 0) this.sessionActivityEventRecorders = null;
+    this.sessionReplayActivityBridge.discardSessionActivityEventRecording(
+      workspaceId,
+      recordingId
+    );
   }
 
   addSessionEngineActivityObserver(
@@ -246,33 +205,26 @@ export class WorkspaceAgentActivityService
       observeIntent(intent: EngineIntent): void;
     }
   ): () => void {
-    const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
-    this.assertSessionReplayEnabled();
-    const observerMap = (this.sessionEngineActivityObservers ??= new Map());
-    let observers = observerMap.get(normalizedWorkspaceId);
-    if (!observers) {
-      observers = new Set();
-      observerMap.set(normalizedWorkspaceId, observers);
-    }
-    observers.add(observer);
-    return () => {
-      observers?.delete(observer);
-      if (observers?.size === 0) {
-        observerMap.delete(normalizedWorkspaceId);
-        if (observerMap.size === 0) this.sessionEngineActivityObservers = null;
-      }
-    };
+    return this.sessionReplayActivityBridge.addSessionEngineActivityObserver(
+      workspaceId,
+      observer
+    );
   }
 
   private takeNextSessionRecording(workspaceId: string): string | null {
-    return this.sessionRecordingBinding?.take(workspaceId) ?? null;
+    return this.sessionReplayActivityBridge.takePendingSessionRecording(
+      workspaceId
+    );
   }
 
   private restoreNextSessionRecording(
     workspaceId: string,
     recordingId: string
   ): void {
-    this.sessionRecordingBinding?.restore(workspaceId, recordingId);
+    this.sessionReplayActivityBridge.restorePendingSessionRecording(
+      workspaceId,
+      recordingId
+    );
   }
 
   getSnapshot(workspaceId: string): AgentActivitySnapshot {
@@ -1083,28 +1035,10 @@ export class WorkspaceAgentActivityService
     return createWorkspaceAgentSessionEngineHost({
       ...(this.dependencies.sessionReplayEnabled
         ? {
-            activityEventObserver: {
-              observeCommand: (command: EngineExternalCommand) => {
-                this.sessionActivityEventRecorders
-                  ?.get(workspaceId)
-                  ?.observeCommand(command);
-                this.notifySessionEngineActivityObservers(
-                  workspaceId,
-                  "observeCommand",
-                  command
-                );
-              },
-              observeIntent: (intent: EngineIntent) => {
-                this.sessionActivityEventRecorders
-                  ?.get(workspaceId)
-                  ?.observeIntent(intent);
-                this.notifySessionEngineActivityObservers(
-                  workspaceId,
-                  "observeIntent",
-                  intent
-                );
-              }
-            },
+            activityEventObserver:
+              this.sessionReplayActivityBridge.createSessionEngineActivityObserver(
+                workspaceId
+              ),
             takePendingSessionRecording: (entryWorkspaceId: string) =>
               this.takeNextSessionRecording(entryWorkspaceId),
             restorePendingSessionRecording: (
@@ -1157,42 +1091,6 @@ export class WorkspaceAgentActivityService
         this.updateTuttiModeActivation(input),
       workspaceId
     });
-  }
-
-  private notifySessionEngineActivityObservers(
-    workspaceId: string,
-    method: "observeCommand",
-    value: EngineExternalCommand
-  ): void;
-  private notifySessionEngineActivityObservers(
-    workspaceId: string,
-    method: "observeIntent",
-    value: EngineIntent
-  ): void;
-  private notifySessionEngineActivityObservers(
-    workspaceId: string,
-    method: "observeCommand" | "observeIntent",
-    value: EngineExternalCommand | EngineIntent
-  ): void {
-    const observers = this.sessionEngineActivityObservers?.get(workspaceId);
-    if (!observers) return;
-    for (const observer of observers) {
-      try {
-        if (method === "observeCommand") {
-          observer.observeCommand(value as EngineExternalCommand);
-        } else {
-          observer.observeIntent(value as EngineIntent);
-        }
-      } catch {
-        // Replay instrumentation cannot block the product command path.
-      }
-    }
-  }
-
-  private assertSessionReplayEnabled(): void {
-    if (!this.dependencies.sessionReplayEnabled) {
-      throw new Error("agent_session_replay_not_composed");
-    }
   }
 }
 

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -354,13 +354,16 @@ consumer of the hydrated feature flag and does not add a parallel event center.
 The main-process Replay composition module owns manager/access/control creation
 and all Replay IPC bindings; general runtime IPC supplies only Electron and
 daemon adapters. When disabled, Desktop main does not create the Replay process
-manager, access adapters, control writer, or Replay IPC handlers. The renderer does not create
-the Replay service, recording binding, recorder/observer maps, or Engine
-intent/command observer. Enabled composition creates the renderer recorder only
-for the lifetime of an active Recording and mounts isolated Replay observers
-only inside the Replay runtime. Changing the preference does not claim to
-recompose a running daemon or renderer; the next process composition applies
-the new value.
+manager, access adapters, control writer, or Replay IPC handlers, and the
+renderer keeps the replay activity bridge inert: it creates no recording
+binding, recorder map, or Engine observer. When enabled, the
+`agent-session-replay` feature-local activity bridge owns the recording binding,
+recorder map, and Engine observer fan-out; `WorkspaceAgentActivityService`
+remains the Activity Engine/reconcile facade and delegates that replay boundary
+to the bridge. The renderer creates recorder state only for the lifetime of an
+active Recording and mounts isolated Replay observers only inside the Replay
+runtime. Changing the preference does not claim to recompose a running daemon
+or renderer; the next process composition applies the new value.
 
 A Recording captures a time window over the root SessionGraph. Root Turn
 settlement, child creation, and Goal continuation do not complete it. Explicit

--- a/docs/conventions/desktop-layering.md
+++ b/docs/conventions/desktop-layering.md
@@ -349,7 +349,9 @@ Rules:
   container
 - pass that service into AgentGUI, MessageCenter, and other workspace workbench
   contributions that need agent activity
-- keep controller/cache ownership inside `WorkspaceAgentActivityService`
+- keep controller/cache ownership inside `WorkspaceAgentActivityService` for
+  activity engine and reconcile state; the Agent Session Replay feature owns
+  its recording binding, recorder state, and Engine observer bridge
 - keep daemon session-directory query projection and external-import refresh
   workflows in focused internal operation collaborators; the public service
   remains the facade and the only owner of engine/reconcile coordination


### PR DESCRIPTION
## Summary
- Move Agent Session Replay recording binding, recorder state, observer fan-out, and pending-recording lifecycle into a Desktop feature-local activity bridge.
- Keep `WorkspaceAgentActivityService` as the Activity Engine/reconcile facade and preserve its existing external replay port.
- Replace tests that inspected private replay maps with behavior-focused coverage.
- Document the updated Replay ownership boundary.

## Scope
- Desktop renderer and architecture documentation only.
- No HTTP/OpenAPI, database, generated client, published package, or TSH changes.

## Validation
- `pnpm setup:worktree`
- Desktop typecheck
- Focused bridge + WorkspaceAgentActivityService tests: 61/61 passed
- Desktop full test suite: 1753 passed, 2 skipped, 0 failed
- `pnpm check:changed -- --push-ready`: 12 lanes passed
- Renderer and Agent Activity runtime boundary checks
- Real `make dev-gui` renderer/daemon/Agent ACP startup smoke completed; processes cleaned up afterward

Independent read-only review: PASS.