### PR TITLE
ci(mobile): deploy iOS builds through TestFlight

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -157,7 +157,7 @@ jobs:
           retention-days: 14
 
   ios:
-    name: Build internal iOS IPA
+    name: Build and upload iOS TestFlight
     if: inputs.platform == 'ios' || inputs.platform == 'all'
     runs-on: macos-26
     timeout-minutes: 60
@@ -221,139 +221,6 @@ jobs:
       - name: Build iOS framework and install pods
         run: pnpm --filter @tutti-os/mobile ios:pods
 
-      - name: Register internal iOS device
-        shell: bash
-        env:
-          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-          IOS_TEST_DEVICE_UDID: ${{ secrets.IOS_TEST_DEVICE_UDID }}
-        run: |
-          if [[ -z "${IOS_TEST_DEVICE_UDID}" ]]; then
-            echo "IOS_TEST_DEVICE_UDID is required for development signing." >&2
-            exit 1
-          fi
-
-          node <<'NODE'
-          const crypto = require("node:crypto");
-          const fs = require("node:fs");
-
-          function encode(value) {
-            return Buffer.from(value).toString("base64url");
-          }
-
-          function createToken() {
-            const issuedAt = Math.floor(Date.now() / 1000);
-            const header = encode(
-              JSON.stringify({
-                alg: "ES256",
-                kid: process.env.APPLE_API_KEY_ID,
-                typ: "JWT",
-              }),
-            );
-            const payload = encode(
-              JSON.stringify({
-                aud: "appstoreconnect-v1",
-                exp: issuedAt + 600,
-                iat: issuedAt - 30,
-                iss: process.env.APPLE_API_ISSUER,
-              }),
-            );
-            const signingInput = `${header}.${payload}`;
-            const key = fs.readFileSync(process.env.APPLE_API_KEY_PATH, "utf8");
-            const signature = crypto.sign(
-              "sha256",
-              Buffer.from(signingInput),
-              {
-                dsaEncoding: "ieee-p1363",
-                key,
-              },
-            );
-            return `${signingInput}.${signature.toString("base64url")}`;
-          }
-
-          async function request(path, options = {}) {
-            const response = await fetch(
-              `https://api.appstoreconnect.apple.com${path}`,
-              {
-                ...options,
-                headers: {
-                  Authorization: `Bearer ${createToken()}`,
-                  "Content-Type": "application/json",
-                  ...options.headers,
-                },
-              },
-            );
-            if (!response.ok) {
-              const error = new Error(
-                `Apple Developer API request failed with HTTP ${response.status}`,
-              );
-              error.status = response.status;
-              throw error;
-            }
-            return response.json();
-          }
-
-          async function findDevice(udid) {
-            const query = new URLSearchParams({
-              "filter[udid]": udid,
-              limit: "1",
-            });
-            const existing = await request(`/v1/devices?${query}`);
-            return existing.data[0];
-          }
-
-          function assertEnabled(device) {
-            if (device.attributes.status !== "ENABLED") {
-              throw new Error(
-                "The configured internal iOS device is disabled in Apple Developer",
-              );
-            }
-          }
-
-          async function main() {
-            const udid = process.env.IOS_TEST_DEVICE_UDID;
-            const device = await findDevice(udid);
-            if (device) {
-              assertEnabled(device);
-              console.log("Internal iOS device is already registered");
-              return;
-            }
-
-            try {
-              await request("/v1/devices", {
-                body: JSON.stringify({
-                  data: {
-                    attributes: {
-                      name: "Tutti Internal iPhone",
-                      platform: "IOS",
-                      udid,
-                    },
-                    type: "devices",
-                  },
-                }),
-                method: "POST",
-              });
-            } catch (error) {
-              if (error.status !== 409) {
-                throw error;
-              }
-              const concurrentDevice = await findDevice(udid);
-              if (!concurrentDevice) {
-                throw error;
-              }
-              assertEnabled(concurrentDevice);
-              console.log("Internal iOS device was registered concurrently");
-              return;
-            }
-            console.log("Registered internal iOS device");
-          }
-
-          main().catch((error) => {
-            console.error(error.message);
-            process.exitCode = 1;
-          });
-          NODE
-
       - name: Archive iOS app
         shell: bash
         env:
@@ -373,11 +240,12 @@ jobs:
             -authenticationKeyIssuerID "${APPLE_API_ISSUER}" \
             DEVELOPMENT_TEAM="${IOS_DEVELOPMENT_TEAM}" \
             CODE_SIGN_STYLE=Automatic \
+            CURRENT_PROJECT_VERSION="${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}" \
             clean archive
 
           echo "IOS_ARCHIVE_PATH=${archive_path}" >> "${GITHUB_ENV}"
 
-      - name: Export internal IPA
+      - name: Export App Store Connect IPA
         shell: bash
         env:
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
@@ -389,9 +257,11 @@ jobs:
 
           plutil -create xml1 "${export_options}"
           plutil -insert destination -string export "${export_options}"
-          plutil -insert method -string debugging "${export_options}"
+          plutil -insert method -string app-store-connect "${export_options}"
           plutil -insert signingStyle -string automatic "${export_options}"
           plutil -insert teamID -string "${IOS_DEVELOPMENT_TEAM}" "${export_options}"
+          plutil -insert manageAppVersionAndBuildNumber -bool false "${export_options}"
+          plutil -insert uploadSymbols -bool true "${export_options}"
 
           xcodebuild \
             -exportArchive \
@@ -406,30 +276,58 @@ jobs:
           ipa_path="$(find "${export_dir}" -maxdepth 1 -name '*.ipa' -print -quit)"
           test -n "${ipa_path}"
           mkdir -p "${artifact_dir}"
-          cp "${ipa_path}" "${artifact_dir}/tutti-mobile-internal.ipa"
+          cp "${ipa_path}" "${artifact_dir}/tutti-mobile-testflight.ipa"
 
-      - name: Verify internal IPA
+      - name: Verify TestFlight IPA
         shell: bash
         run: |
           artifact_dir="${RUNNER_TEMP}/tutti-ios-artifact"
           verification_dir="${RUNNER_TEMP}/tutti-ios-verification"
           mkdir -p "${verification_dir}"
-          unzip -q "${artifact_dir}/tutti-mobile-internal.ipa" -d "${verification_dir}"
+          unzip -q "${artifact_dir}/tutti-mobile-testflight.ipa" -d "${verification_dir}"
           app_path="$(find "${verification_dir}/Payload" -maxdepth 1 -name '*.app' -print -quit)"
           test -n "${app_path}"
           test -f "${app_path}/embedded.mobileprovision"
+          test -f "${app_path}/main.jsbundle"
           codesign --verify --deep --strict "${app_path}"
           (
             cd "${artifact_dir}"
-            shasum -a 256 tutti-mobile-internal.ipa > SHA256SUMS
+            shasum -a 256 tutti-mobile-testflight.ipa > SHA256SUMS
           )
 
-      - name: Upload internal iOS artifact
+      - name: Upload to TestFlight
+        shell: bash
+        env:
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+        run: |
+          upload_dir="${RUNNER_TEMP}/tutti-ios-upload"
+          upload_options="${RUNNER_TEMP}/tutti-ios-upload-options.plist"
+
+          plutil -create xml1 "${upload_options}"
+          plutil -insert destination -string upload "${upload_options}"
+          plutil -insert method -string app-store-connect "${upload_options}"
+          plutil -insert signingStyle -string automatic "${upload_options}"
+          plutil -insert teamID -string "${IOS_DEVELOPMENT_TEAM}" "${upload_options}"
+          plutil -insert manageAppVersionAndBuildNumber -bool false "${upload_options}"
+          plutil -insert uploadSymbols -bool true "${upload_options}"
+
+          xcodebuild \
+            -exportArchive \
+            -archivePath "${IOS_ARCHIVE_PATH}" \
+            -exportPath "${upload_dir}" \
+            -exportOptionsPlist "${upload_options}" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "${APPLE_API_KEY_PATH}" \
+            -authenticationKeyID "${APPLE_API_KEY_ID}" \
+            -authenticationKeyIssuerID "${APPLE_API_ISSUER}"
+
+      - name: Upload TestFlight IPA artifact
         uses: actions/upload-artifact@v4
         with:
-          name: tutti-mobile-ios-internal-${{ github.sha }}
+          name: tutti-mobile-ios-testflight-${{ github.sha }}
           path: |
-            ${{ runner.temp }}/tutti-ios-artifact/tutti-mobile-internal.ipa
+            ${{ runner.temp }}/tutti-ios-artifact/tutti-mobile-testflight.ipa
             ${{ runner.temp }}/tutti-ios-artifact/SHA256SUMS
           if-no-files-found: error
           retention-days: 14

--- a/docs/conventions/static-analysis.md
+++ b/docs/conventions/static-analysis.md
@@ -506,11 +506,14 @@ assembles the same Mobile
 binding surface as an XCFramework, archives the React Native app, and uses the
 repository App Store Connect API key plus the `IOS_DEVELOPMENT_TEAM` repository
 variable for Xcode-managed cloud signing. It loads the Mobile Podfile's pnpm
-path compatibility shim before generating the Pods project, then ensures the
-device configured by the `IOS_TEST_DEVICE_UDID` Actions secret is registered
-before exporting a development IPA as a 14-day private validation artifact
-rather than creating a GitHub Release. Both jobs remain manual so pull request
-code does not receive mobile signing credentials automatically.
+path compatibility shim before generating the Pods project, combines the GitHub
+Actions run number and attempt as the unique iOS build number, exports an App
+Store Connect IPA, verifies that the signed app contains its release
+`main.jsbundle`, and uploads the archive to TestFlight without registering test
+device UDIDs. The exported IPA and checksum remain available as a 14-day private
+validation artifact rather than creating a GitHub Release. Both jobs remain
+manual so pull request code does not receive mobile signing credentials
+automatically.
 
 Local runs resolve `golangci-lint` from `$(go env GOPATH)/bin` first and fall
 back to `PATH`. This matches the repository install command without requiring a

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -366,12 +366,14 @@ release keystore 必须在 GitHub 之外另做加密备份。GitHub Secret 的�
 
 在 iOS 真机上测试时，运行同一工作流并选择 `ios`。它使用仓库已有的 App Store
 Connect API Key 和 `IOS_DEVELOPMENT_TEAM` 仓库变量，让 Xcode 自动管理云签名并
-使用 `IOS_TEST_DEVICE_UDID` secret 幂等登记内部测试设备，再导出 development
-IPA。工作流上传保留 14 天的内部 artifact
-`tutti-mobile-ios-internal-<commit>`，其中包含 `tutti-mobile-internal.ipa` 和
-SHA-256 校验文件；不会创建 GitHub Release 或公开下载链接。IPA 只能安装到 Apple
-Developer 后台由该 secret 配置并包含在自动生成描述文件中的设备。选择 `all` 可
-同时构建两个平台。
+组合 GitHub Actions run number 和 attempt 作为唯一构建号，导出 App Store
+Connect IPA 并上传 TestFlight。工作流会确认签名后的 App 包含 release
+`main.jsbundle`，同时上传保留 14 天的私有 artifact
+`tutti-mobile-ios-testflight-<commit>`，其中包含
+`tutti-mobile-testflight.ipa` 和 SHA-256 校验文件；不会创建 GitHub Release 或公开
+下载链接。测试人员通过 TestFlight 安装，不需要预先登记设备 UDID；App Store
+Connect 仍需把处理完成的构建分配给对应的内部或外部测试组。选择 `all` 可同时构建
+两个平台。
 
 ## 6. 调试时先判断问题属于哪一层
 


### PR DESCRIPTION
## Summary
- replace the UDID-restricted development IPA flow with App Store Connect export and TestFlight upload
- assign a unique build number from the workflow run and attempt
- verify the Release IPA contains main.jsbundle before upload
- keep a private 14-day IPA/checksum artifact for validation

## Validation
- parsed the workflow as YAML
- ran targeted Prettier checks
- ran git diff --check
- confirmed the export option keys against Xcode 26 help