### PR TITLE
feat(mobile-remote): add realtime DeviceLink attempt wakeups

### DIFF
--- a/apps/mobile/src/native/createMobileServicePorts.ts
+++ b/apps/mobile/src/native/createMobileServicePorts.ts
@@ -4,7 +4,7 @@ import { appLifecycle, deviceLink, mobileSecurity } from "./mobileNative";
 import { signInWithBrowser } from "../services/accountClient";
 import {
   claimPairing,
-  connectPairedDevice,
+  connectPairedDevice as connectPairedDeviceRequest,
   getPairingChallenge,
   listDevices,
   listPairings,
@@ -12,6 +12,7 @@ import {
 } from "../services/pairingClient";
 import { createRemoteTuttidClient } from "../services/remoteTuttidClient";
 import type { MobileServicePorts } from "../services/servicePorts";
+import { DeviceLinkAttemptEvents } from "../services/deviceLinkAttemptEvents";
 import { parseAgentLiveDeliveries } from "./agentLiveNativeBridge";
 import { accountBaseURL } from "../config";
 
@@ -20,6 +21,12 @@ const appLifecycleEvents = new NativeEventEmitter(appLifecycle);
 
 export function createMobileServicePorts(): MobileServicePorts {
   let nextAgentLiveSubscriptionGeneration = 0;
+  const diagnostics = {
+    record(event: Parameters<MobileServicePorts["diagnostics"]["record"]>[0]) {
+      console.info("[TuttiMobile]", JSON.stringify(event));
+    }
+  };
+  const attemptEvents = new DeviceLinkAttemptEvents();
   return {
     account: {
       signInWithBrowser
@@ -73,17 +80,17 @@ export function createMobileServicePorts(): MobileServicePorts {
         };
       }
     },
-    diagnostics: {
-      record(event) {
-        console.info("[TuttiMobile]", JSON.stringify(event));
-      }
-    },
+    diagnostics,
     legacySessionCookie: {
       clear: () => mobileSecurity.clearLegacySessionCookie(accountBaseURL)
     },
     pairing: {
       claimPairing,
-      connectPairedDevice,
+      connectPairedDevice: (sessionId, pairingId, isCurrent) =>
+        connectPairedDeviceRequest(sessionId, pairingId, isCurrent, {
+          attemptEvents,
+          diagnostics
+        }),
       getPairingChallenge,
       listDevices,
       listPairings,

--- a/apps/mobile/src/services/deviceLinkAttemptEvents.test.ts
+++ b/apps/mobile/src/services/deviceLinkAttemptEvents.test.ts
@@ -1,0 +1,98 @@
+import {
+  DeviceLinkAttemptEvents,
+  deviceLinkAttemptEventsForTests
+} from "./deviceLinkAttemptEvents";
+
+class FakeSocket {
+  static instances: FakeSocket[] = [];
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: ((event: { data?: unknown }) => void) | null = null;
+  onopen: (() => void) | null = null;
+  readonly sent: string[] = [];
+
+  constructor(readonly url: string) {
+    FakeSocket.instances.push(this);
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.onclose?.();
+  }
+
+  emitOpen(): void {
+    this.onopen?.();
+  }
+
+  emitMessage(data: string): void {
+    this.onmessage?.({ data });
+  }
+}
+
+describe("DeviceLinkAttemptEvents", () => {
+  beforeEach(() => {
+    FakeSocket.instances = [];
+  });
+
+  it("routes a V2 business wake frame to the attempt listener", () => {
+    const listener = jest.fn();
+    const source = new DeviceLinkAttemptEvents({
+      realtimeURL: "wss://ws.example.test/realtime?lane=test",
+      socketConstructor: FakeSocket
+    });
+    const subscription = source.start("session-1", "device-1", listener);
+    const socket = FakeSocket.instances[0]!;
+    expect(socket.url).toContain("deviceId=device-1");
+    socket.emitOpen();
+    expect(JSON.parse(socket.sent[0]!)).toEqual({
+      action: "connection.initialize",
+      data: { protocolVersion: 2 }
+    });
+    expect(JSON.parse(socket.sent[1]!)).toEqual({
+      action: "init",
+      data: { deviceId: "device-1" }
+    });
+    socket.emitMessage(
+      JSON.stringify({
+        content_type: "PAYLOAD_CONTENT_TYPE_JSON",
+        delivery: { device_id: "device-1", scope: "user_device" },
+        dispatch_id: "dispatch-1",
+        event_id: "event-1",
+        event_type: "device_link.attempt.changed",
+        occurred_at: new Date().toISOString(),
+        payload: btoa(JSON.stringify({ attemptId: "attempt-1" })),
+        protocol_version: 2,
+        schema_version: 1
+      })
+    );
+    expect(listener).toHaveBeenCalledWith("attempt-1");
+    subscription.close();
+  });
+
+  it("ignores malformed or non-attempt frames", () => {
+    expect(
+      deviceLinkAttemptEventsForTests.parseAttemptChangedPayload("not-json")
+    ).toBeNull();
+    expect(
+      deviceLinkAttemptEventsForTests.parseAttemptChangedPayload(
+        JSON.stringify({
+          payload: { attemptId: "attempt-1" },
+          protocol_version: 2,
+          type: "room.message"
+        })
+      )
+    ).toBeNull();
+  });
+
+  it("rejects a non-websocket endpoint before dialing", () => {
+    expect(() =>
+      deviceLinkAttemptEventsForTests.appendDeviceID(
+        "https://ws.example.test/realtime",
+        "device-1"
+      )
+    ).toThrow("ws or wss");
+  });
+});

--- a/apps/mobile/src/services/deviceLinkAttemptEvents.ts
+++ b/apps/mobile/src/services/deviceLinkAttemptEvents.ts
@@ -1,0 +1,216 @@
+import { accountCookie } from "./http";
+
+const DEFAULT_REALTIME_URL = "wss://ws.tutti.sh/";
+const ATTEMPT_CHANGED_EVENT = "device_link.attempt.changed";
+const PROTOCOL_VERSION = 2;
+const HEARTBEAT_INTERVAL_MS = 180_000;
+const INITIAL_RECONNECT_DELAY_MS = 1_000;
+const MAX_RECONNECT_DELAY_MS = 15_000;
+
+type SocketEvent = { data?: unknown };
+
+export interface DeviceLinkAttemptSocket {
+  close(code?: number, reason?: string): void;
+  onclose: (() => void) | null;
+  onerror: (() => void) | null;
+  onmessage: ((event: SocketEvent) => void) | null;
+  onopen: (() => void) | null;
+  send(data: string): void;
+}
+
+export interface DeviceLinkAttemptSocketOptions {
+  headers?: Record<string, string>;
+}
+
+export type DeviceLinkAttemptSocketConstructor = new (
+  url: string,
+  protocols?: string | string[],
+  options?: DeviceLinkAttemptSocketOptions
+) => DeviceLinkAttemptSocket;
+
+export interface DeviceLinkAttemptEventSource {
+  start(
+    sessionId: string,
+    deviceId: string,
+    listener: (attemptId: string) => void
+  ): { close(): void };
+}
+
+export interface DeviceLinkAttemptEventSourceOptions {
+  realtimeURL?: string;
+  socketConstructor?: DeviceLinkAttemptSocketConstructor;
+}
+
+/**
+ * Subscribes to the account/device WebSocket only as a wake lane. Every wake
+ * is reconciled through the signed HTTP attempt endpoint, so reconnects,
+ * dropped frames, and stale payloads cannot change connection authority.
+ */
+export class DeviceLinkAttemptEvents implements DeviceLinkAttemptEventSource {
+  private readonly realtimeURL: string;
+  private readonly socketConstructor: DeviceLinkAttemptSocketConstructor | null;
+
+  constructor(options: DeviceLinkAttemptEventSourceOptions = {}) {
+    this.realtimeURL = options.realtimeURL?.trim() || DEFAULT_REALTIME_URL;
+    this.socketConstructor =
+      options.socketConstructor ?? resolveSocketConstructor();
+  }
+
+  start(
+    sessionId: string,
+    deviceId: string,
+    listener: (attemptId: string) => void
+  ): { close(): void } {
+    if (!this.socketConstructor || !sessionId.trim() || !deviceId.trim()) {
+      return { close() {} };
+    }
+    let closed = false;
+    let socket: DeviceLinkAttemptSocket | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+    let reconnectDelay = INITIAL_RECONNECT_DELAY_MS;
+
+    const clearTimers = () => {
+      if (reconnectTimer !== null) clearTimeout(reconnectTimer);
+      if (heartbeatTimer !== null) clearInterval(heartbeatTimer);
+      reconnectTimer = null;
+      heartbeatTimer = null;
+    };
+
+    const scheduleReconnect = () => {
+      if (closed || reconnectTimer !== null) return;
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = null;
+        connect();
+      }, reconnectDelay);
+      reconnectDelay = Math.min(
+        MAX_RECONNECT_DELAY_MS,
+        Math.max(INITIAL_RECONNECT_DELAY_MS, reconnectDelay * 1.5)
+      );
+    };
+
+    const handleMessage = (event: SocketEvent) => {
+      const payload = parseAttemptChangedPayload(event.data);
+      if (payload) listener(payload);
+    };
+
+    const connect = () => {
+      if (closed) return;
+      try {
+        clearTimers();
+        const endpoint = appendDeviceID(this.realtimeURL, deviceId);
+        socket = new this.socketConstructor!(endpoint, [], {
+          headers: { Cookie: accountCookie(sessionId) }
+        });
+      } catch {
+        scheduleReconnect();
+        return;
+      }
+      const current = socket;
+      current.onopen = () => {
+        if (closed || current !== socket) return;
+        reconnectDelay = INITIAL_RECONNECT_DELAY_MS;
+        current.send(
+          JSON.stringify({
+            action: "connection.initialize",
+            data: { protocolVersion: PROTOCOL_VERSION }
+          })
+        );
+        current.send(
+          JSON.stringify({
+            action: "init",
+            data: { deviceId: deviceId.trim() }
+          })
+        );
+        heartbeatTimer = setInterval(() => {
+          if (current !== socket || closed) return;
+          current.send(
+            JSON.stringify({ action: "ping", data: { ts: Date.now() } })
+          );
+        }, HEARTBEAT_INTERVAL_MS);
+      };
+      current.onmessage = handleMessage;
+      current.onerror = () => {
+        if (current === socket) current.close();
+      };
+      current.onclose = () => {
+        if (current !== socket) return;
+        clearTimers();
+        socket = null;
+        scheduleReconnect();
+      };
+    };
+
+    connect();
+    return {
+      close() {
+        if (closed) return;
+        closed = true;
+        clearTimers();
+        const current = socket;
+        socket = null;
+        current?.close(1000, "device-link connection stopped");
+      }
+    };
+  }
+}
+
+function resolveSocketConstructor(): DeviceLinkAttemptSocketConstructor | null {
+  const constructor = (globalThis as { WebSocket?: unknown }).WebSocket;
+  return typeof constructor === "function"
+    ? (constructor as DeviceLinkAttemptSocketConstructor)
+    : null;
+}
+
+function appendDeviceID(rawURL: string, deviceId: string): string {
+  const url = new URL(rawURL);
+  if (url.protocol !== "ws:" && url.protocol !== "wss:") {
+    throw new Error("mobile remote realtime URL must use ws or wss");
+  }
+  url.searchParams.set("deviceId", deviceId.trim());
+  return url.toString();
+}
+
+function parseAttemptChangedPayload(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  let envelope: Record<string, unknown>;
+  try {
+    envelope = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+  if (envelope.protocol_version !== PROTOCOL_VERSION) return null;
+  let type = typeof envelope.type === "string" ? envelope.type : "";
+  let payload: unknown = envelope.payload;
+  if (typeof envelope.event_type === "string") {
+    type = envelope.event_type;
+    payload = decodeBusinessPayload(envelope.payload);
+  }
+  if (type !== ATTEMPT_CHANGED_EVENT || !isRecord(payload)) return null;
+  const attemptId = payload.attemptId;
+  return typeof attemptId === "string" && attemptId.trim()
+    ? attemptId.trim()
+    : null;
+}
+
+function decodeBusinessPayload(raw: unknown): unknown {
+  if (typeof raw !== "string") return null;
+  try {
+    const encoded = globalThis.atob(raw);
+    // The attempt wake payload is ASCII-only (IDs, state, and version). JSON
+    // parsing the decoded bytes avoids adding a native text-decoder shim to
+    // the MVP bridge.
+    return JSON.parse(encoded);
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export const deviceLinkAttemptEventsForTests = {
+  appendDeviceID,
+  parseAttemptChangedPayload
+};

--- a/apps/mobile/src/services/deviceLinkAttemptWake.test.ts
+++ b/apps/mobile/src/services/deviceLinkAttemptWake.test.ts
@@ -1,0 +1,19 @@
+import { DeviceLinkAttemptWake } from "./deviceLinkAttemptWake";
+
+describe("DeviceLinkAttemptWake", () => {
+  it("observes notifications that arrive before waiting", async () => {
+    const wake = new DeviceLinkAttemptWake();
+    wake.notify("attempt-1");
+    await expect(
+      wake.wait("attempt-1", 0, new AbortController().signal)
+    ).resolves.toBe(true);
+  });
+
+  it("cancels a pending wait", async () => {
+    const wake = new DeviceLinkAttemptWake();
+    const controller = new AbortController();
+    const waiting = wake.wait("attempt-1", 0, controller.signal);
+    controller.abort();
+    await expect(waiting).resolves.toBe(false);
+  });
+});

--- a/apps/mobile/src/services/deviceLinkAttemptWake.ts
+++ b/apps/mobile/src/services/deviceLinkAttemptWake.ts
@@ -1,0 +1,43 @@
+export class DeviceLinkAttemptWake {
+  private readonly versions = new Map<string, number>();
+  private readonly waiters = new Map<string, Set<() => void>>();
+
+  version(attemptId: string): number {
+    return this.versions.get(attemptId) ?? 0;
+  }
+
+  notify(attemptId: string): void {
+    if (!attemptId.trim()) return;
+    this.versions.set(attemptId, this.version(attemptId) + 1);
+    for (const resolve of this.waiters.get(attemptId) ?? []) resolve();
+    this.waiters.delete(attemptId);
+  }
+
+  wait(
+    attemptId: string,
+    afterVersion: number,
+    signal: AbortSignal
+  ): Promise<boolean> {
+    if (this.version(attemptId) > afterVersion) return Promise.resolve(true);
+    return new Promise((resolve) => {
+      if (signal.aborted) {
+        resolve(false);
+        return;
+      }
+      const finish = (notified: boolean) => {
+        signal.removeEventListener("abort", onAbort);
+        const waiters = this.waiters.get(attemptId);
+        waiters?.delete(finishResolve);
+        if (waiters && waiters.size === 0) this.waiters.delete(attemptId);
+        resolve(notified);
+      };
+      const finishResolve = () => finish(true);
+      const onAbort = () => finish(false);
+      const waiters = this.waiters.get(attemptId) ?? new Set<() => void>();
+      waiters.add(finishResolve);
+      this.waiters.set(attemptId, waiters);
+      signal.addEventListener("abort", onAbort, { once: true });
+      if (this.version(attemptId) > afterVersion) finish(true);
+    });
+  }
+}

--- a/apps/mobile/src/services/pairingClient.ts
+++ b/apps/mobile/src/services/pairingClient.ts
@@ -19,6 +19,9 @@ import {
   type PairingQRPayload
 } from "./pairingProtocol";
 import { PAIRING_OPERATION_SUSPENDED } from "./servicePorts";
+import type { MobileDiagnosticsPort } from "./servicePorts";
+import { DeviceLinkAttemptWake } from "./deviceLinkAttemptWake";
+import type { DeviceLinkAttemptEventSource } from "./deviceLinkAttemptEvents";
 import { raceSuccessful } from "./pairingTransportRace";
 
 interface RegisteredDevice {
@@ -58,6 +61,11 @@ export interface AgentRelayDescriptor {
 }
 
 const RELAY_STREAM_SUBPROTOCOL = "tsh.relay.stream.v1";
+
+export interface PairedDeviceConnectionOptions {
+  attemptEvents?: DeviceLinkAttemptEventSource;
+  diagnostics?: MobileDiagnosticsPort;
+}
 
 export async function claimPairing(
   sessionId: string,
@@ -129,7 +137,8 @@ export async function listDevices(sessionId: string): Promise<UserDevice[]> {
 export async function connectPairedDevice(
   sessionId: string,
   pairingId: string,
-  isCurrent: () => boolean = () => true
+  isCurrent: () => boolean = () => true,
+  options: PairedDeviceConnectionOptions = {}
 ): Promise<DeviceLinkPathScope> {
   const identity = await mobileSecurity.getOrCreateIdentity();
   requireCurrentConnection(isCurrent);
@@ -137,13 +146,22 @@ export async function connectPairedDevice(
   requireCurrentConnection(isCurrent);
   const relayController = new AbortController();
   const directController = new AbortController();
+  const raceStartedAt = Date.now();
+  const attemptWake = new DeviceLinkAttemptWake();
+  const attemptEvents = options.attemptEvents?.start(
+    sessionId,
+    identity.deviceId,
+    (attemptId) => attemptWake.notify(attemptId)
+  );
   const directTask = connectDirectDevice(
     sessionId,
     pairingId,
     identity,
     isCurrent,
-    directController.signal
-  );
+    directController.signal,
+    attemptWake,
+    options.diagnostics
+  ).finally(() => attemptEvents?.close());
   const relayTask = configureRelayTransport(
     sessionId,
     pairingId,
@@ -152,12 +170,22 @@ export async function connectPairedDevice(
     relayController.signal
   ).then(async (descriptor) => {
     if (descriptor === null) return null;
+    recordDeviceLinkStage(
+      options.diagnostics,
+      "relay_descriptor_ready",
+      raceStartedAt
+    );
     // A descriptor only makes Relay dialable. The native probe opens a Relay
     // stream and waits for the paired desktop Agent endpoint to acknowledge a
     // authenticated Agent request before this path can win the connection race.
     requireCurrentConnection(isCurrent, relayController.signal);
     await deviceLink.probeRelay(10_000);
     requireCurrentConnection(isCurrent, relayController.signal);
+    recordDeviceLinkStage(
+      options.diagnostics,
+      "relay_probe_ready",
+      raceStartedAt
+    );
     return descriptor;
   });
   try {
@@ -200,7 +228,9 @@ async function connectDirectDevice(
   pairingId: string,
   identity: DeviceIdentity,
   isCurrent: () => boolean,
-  signal: AbortSignal
+  signal: AbortSignal,
+  wake: DeviceLinkAttemptWake,
+  diagnostics?: MobileDiagnosticsPort
 ): Promise<DeviceLinkPathScope> {
   let prepared = await deviceLink.prepareLink("[]", 10_000);
   let local = parseDeviceLinkDescription(prepared.descriptionJSON);
@@ -213,6 +243,8 @@ async function connectDirectDevice(
     signal
   );
   requireCurrentConnection(isCurrent, signal);
+  const startedAt = Date.now();
+  recordDeviceLinkStage(diagnostics, "direct_attempt_created", startedAt);
   if ((attempt.stunEndpoints?.length ?? 0) > 0) {
     prepared = await deviceLink.prepareLink(
       JSON.stringify(attempt.stunEndpoints),
@@ -236,6 +268,7 @@ async function connectDirectDevice(
     )
   );
   const deadline = Date.parse(attempt.expiresAt);
+  let wakeVersion = wake.version(attempt.attemptId);
   while (Date.now() < deadline) {
     requireCurrentConnection(isCurrent, signal);
     if (
@@ -255,9 +288,10 @@ async function connectDirectDevice(
         30_000
       );
       requireCurrentConnection(isCurrent, signal);
+      recordDeviceLinkStage(diagnostics, "direct_connected", startedAt);
       return normalizeDeviceLinkPathScope(scope);
     }
-    await delay(500, signal);
+    await waitForAttemptChange(wake, attempt.attemptId, wakeVersion, signal);
     requireCurrentConnection(isCurrent, signal);
     attempt = await getDeviceLinkAttempt(
       sessionId,
@@ -267,6 +301,14 @@ async function connectDirectDevice(
       getSignature,
       signal
     );
+    wakeVersion = wake.version(attempt.attemptId);
+    if (
+      attempt.state === "ready" &&
+      attempt.ownerIce &&
+      attempt.ownerFingerprint
+    ) {
+      recordDeviceLinkStage(diagnostics, "direct_attempt_ready", startedAt);
+    }
   }
   throw new Error("device-link attempt expired");
 }
@@ -532,6 +574,43 @@ function delay(ms: number, signal?: AbortSignal): Promise<void> {
       reject(new Error("device-link connection race was cancelled"));
     };
     signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+async function waitForAttemptChange(
+  wake: DeviceLinkAttemptWake,
+  attemptId: string,
+  version: number,
+  signal: AbortSignal
+): Promise<void> {
+  const waitController = new AbortController();
+  const abortWait = () => waitController.abort();
+  signal.addEventListener("abort", abortWait, { once: true });
+  try {
+    await Promise.race([
+      wake.wait(attemptId, version, waitController.signal),
+      delay(500, signal)
+    ]);
+  } finally {
+    signal.removeEventListener("abort", abortWait);
+    waitController.abort();
+  }
+}
+
+function recordDeviceLinkStage(
+  diagnostics: MobileDiagnosticsPort | undefined,
+  stage:
+    | "direct_attempt_created"
+    | "direct_attempt_ready"
+    | "direct_connected"
+    | "relay_descriptor_ready"
+    | "relay_probe_ready",
+  startedAt: number
+): void {
+  diagnostics?.record({
+    elapsedMs: Math.max(0, Date.now() - startedAt),
+    name: "device_link.stage",
+    stage
   });
 }
 

--- a/apps/mobile/src/services/servicePorts.ts
+++ b/apps/mobile/src/services/servicePorts.ts
@@ -149,6 +149,16 @@ export type MobileDiagnosticEvent =
         | "transport_lost";
     }
   | {
+      elapsedMs: number;
+      name: "device_link.stage";
+      stage:
+        | "direct_attempt_created"
+        | "direct_attempt_ready"
+        | "direct_connected"
+        | "relay_descriptor_ready"
+        | "relay_probe_ready";
+    }
+  | {
       name: "device_pairing.phase_changed";
       phase: DevicePairingPhase;
       source?: "manual" | "scanner";

--- a/docs/conventions/runtime-overrides.md
+++ b/docs/conventions/runtime-overrides.md
@@ -55,14 +55,15 @@ Use the owner documents linked below for detailed behavior. This file exists to 
 
 ## Account Remote Services
 
-| Variable                              | Owner document                                                                                     | Purpose                                                                                           |
-| ------------------------------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `TUTTI_ACCOUNT_BASE_URL`              | [Agent Account And Commerce](../architecture/agent-account-and-commerce.md)                        | Overrides the daemon account auth/user-info API base URL.                                         |
-| `TUTTI_AGENT_LLM_APP_ID`              | [Tutti Agent Readiness Bootstrap](../architecture/tutti-agent-readiness-bootstrap.md)              | Overrides the Tutti LLM application id used when issuing provider auth tokens.                    |
-| `TUTTI_AUTH_LOGIN_URL`                | [Agent Account And Commerce](../architecture/agent-account-and-commerce.md)                        | Overrides the desktop account login URL used by the auth bridge.                                  |
-| `TUTTI_COMMERCE_BASE_URL`             | [Agent Account And Commerce](../architecture/agent-account-and-commerce.md)                        | Overrides the Tutti commerce gateway base URL for session-cookie membership and credits fetches.  |
-| `TUTTI_MOBILE_CONTROL_PLANE_BASE_URL` | [Mobile AgentGUI And DeviceLink Design](../specs/2026-07-23-mobile-agentgui-device-link-design.md) | Overrides the tsh-server desktop control-plane base URL used by Personal device pairing.          |
-| `TUTTI_WEB_BASE_URL`                  | [Agent Account And Commerce](../architecture/agent-account-and-commerce.md)                        | Overrides the Tutti web origin used by tuttid when returning account profile links to desktop UI. |
+| Variable                              | Owner document                                                                                     | Purpose                                                                                                                     |
+| ------------------------------------- | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `TUTTI_ACCOUNT_BASE_URL`              | [Agent Account And Commerce](../architecture/agent-account-and-commerce.md)                        | Overrides the daemon account auth/user-info API base URL.                                                                   |
+| `TUTTI_AGENT_LLM_APP_ID`              | [Tutti Agent Readiness Bootstrap](../architecture/tutti-agent-readiness-bootstrap.md)              | Overrides the Tutti LLM application id used when issuing provider auth tokens.                                              |
+| `TUTTI_AUTH_LOGIN_URL`                | [Agent Account And Commerce](../architecture/agent-account-and-commerce.md)                        | Overrides the desktop account login URL used by the auth bridge.                                                            |
+| `TUTTI_COMMERCE_BASE_URL`             | [Agent Account And Commerce](../architecture/agent-account-and-commerce.md)                        | Overrides the Tutti commerce gateway base URL for session-cookie membership and credits fetches.                            |
+| `TUTTI_MOBILE_CONTROL_PLANE_BASE_URL` | [Mobile AgentGUI And DeviceLink Design](../specs/2026-07-23-mobile-agentgui-device-link-design.md) | Overrides the tsh-server desktop control-plane base URL used by Personal device pairing.                                    |
+| `TUTTI_MOBILE_REALTIME_URL`           | [Mobile AgentGUI And DeviceLink Design](../specs/2026-07-23-mobile-agentgui-device-link-design.md) | Overrides the device-level V2 WebSocket used to wake Personal paired-device attempt reads; unset uses `wss://ws.tutti.sh/`. |
+| `TUTTI_WEB_BASE_URL`                  | [Agent Account And Commerce](../architecture/agent-account-and-commerce.md)                        | Overrides the Tutti web origin used by tuttid when returning account profile links to desktop UI.                           |
 
 ## Desktop Update Admission Development
 

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -218,16 +218,19 @@ transport、Agent live Subscriber 和产品 adapter 的现有所有权，不把 
 
 移动端连接分成两个边界，不能把控制面轮询和数据面建流混为一谈：
 
-| 边界                                       | 当前策略                                                                                                                              | 所有者                                                                 |
-| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| DeviceLink attempt / Relay descriptor 准备 | direct attempt 与 Relay descriptor 并行；Relay 只有完成一次对端 Agent 请求/响应后才可成为可用路径；direct attempt 仍按 500ms 轮询状态 | `apps/mobile/src/services/pairingClient.ts` + 原生 bridge              |
-| Agent HTTP / live 数据流                   | direct 与 Relay 的底层拨号仍可并行；两条路径先完成 DeviceLink transport probe，收到对端 ACK 后才选中，应用帧仍由原生 bridge 处理      | `packages/device-link/mobile` + `services/tuttid/service/mobileremote` |
+| 边界                                       | 当前策略                                                                                                                                                            | 所有者                                                                 |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| DeviceLink attempt / Relay descriptor 准备 | direct attempt 与 Relay descriptor 并行；Relay 只有完成一次对端 Agent 请求/响应后才可成为可用路径；WebSocket 事件优先唤醒 direct attempt，丢失时仍按 500ms 轮询状态 | `apps/mobile/src/services/pairingClient.ts` + 原生 bridge              |
+| Agent HTTP / live 数据流                   | direct 与 Relay 的底层拨号仍可并行；两条路径先完成 DeviceLink transport probe，收到对端 ACK 后才选中，应用帧仍由原生 bridge 处理                                    | `packages/device-link/mobile` + `services/tuttid/service/mobileremote` |
 
-移动端目前没有已确认的 `device_link.attempt.changed` 控制面 WebSocket 契约，因此不
-凭空增加推送协议；控制面仍保留轮询作为事实来源。Relay descriptor 先准备好时，
-原生层先通过 DeviceLink transport probe 确认对端 tunnel，再让 Relay 参与连接结果
-竞速；具体 Agent 请求仍在探测成功后发送，direct attempt 仍在后台完成。TSH Desktop
-的默认 3 秒 Relay 兜底策略属于另一套已上线产品策略，本改动不改变它。
+控制面 WebSocket 复用已上线的设备级 V2 长连接：握手携带当前 session cookie 和
+`deviceId`，只接收 `device_link.attempt.changed` 作为唤醒提示；HTTP attempt API
+仍是唯一事实来源，推送丢失、重连或乱序都由重读和 500ms 轮询兜底。paired-device
+attempt 不绑定 room，服务端按 `userId + deviceId` 精确投递，因此连接功能未开启时
+不会建立这条长连接。Relay descriptor 先准备好时，原生层先通过 DeviceLink
+transport probe 确认对端 tunnel，再让 Relay 参与连接结果竞速；具体 Agent 请求仍在
+探测成功后发送，direct attempt 仍在后台完成。TSH Desktop 的默认 3 秒 Relay 兜底策略
+属于另一套已上线产品策略，本改动不改变它。
 
 ### 账号浏览器认证边界
 

--- a/docs/specs/2026-07-23-mobile-agentgui-device-link-design.md
+++ b/docs/specs/2026-07-23-mobile-agentgui-device-link-design.md
@@ -572,9 +572,13 @@ Mobile 在直连准备阶段并行请求短期 Relay descriptor；原生层对�
 数据流先完成共享 DeviceLink transport probe，收到对端 ACK 后才让该路径赢得竞速，
 再发送应用帧；不会取消 direct attempt，后者继续到成功或当前连接代际失效。
 Android/iOS native adapter 不能把 WebSocket 101 或本地 QUIC stream allocation 单独
-当作成功路径。因此 UI、生成客户端和 Agent DTO 不变。pairing 的 active 快照仍由现有
-控制面轮询刷新，Relay stream
-在本地快照中找不到 pairing 时 fail closed；快照刷新间隔是当前 2 秒轮询周期。
+当作成功路径。因此 UI、生成客户端和 Agent DTO 不变。paired-device attempt 的
+`device_link.attempt.changed` 通过已上线的设备级 V2 WebSocket 作为唤醒提示，连接
+建立时携带 session cookie 与 `deviceId`；客户端收到提示后仍通过 HTTP attempt API
+读取权威状态，推送丢失、重连或乱序时回退到 500ms 状态轮询。服务端对没有 room 的
+paired-device attempt 使用 `userId + deviceId` 精确投递；未开启连接功能的 Desktop
+不会建立这条长连接。pairing 的 active 快照仍在本地使用当前 2 秒周期轮询，Relay
+stream 在本地快照中找不到 pairing 时 fail closed。
 
 这里依赖的 Relay descriptor、Device Authority 和 `tsh-tunnel-relay` Agent channel
 是跨仓库的增量契约；服务端部署状态不在 Tutti 仓库内，须以对应 tsh-server/relay

--- a/packages/device-link/mobile/link.go
+++ b/packages/device-link/mobile/link.go
@@ -205,12 +205,20 @@ func (l *Link) OpenStreamWithRelay(
 		Fallback: linkmanager.DialPath{
 			Name: transportRelay,
 			Dial: func(dialCtx context.Context) (net.Conn, error) {
-				return relaytransport.Dial(dialCtx, relaytransport.DialRequest{
+				conn, dialErr := relaytransport.Dial(dialCtx, relaytransport.DialRequest{
 					Endpoint:    endpoint,
 					Query:       query,
 					Header:      http.Header(headers),
 					Subprotocol: subprotocol,
 				})
+				if dialErr != nil {
+					return nil, dialErr
+				}
+				if probeErr := devicelink.ProbeStream(dialCtx, conn); probeErr != nil {
+					_ = conn.Close()
+					return nil, fmt.Errorf("probe Relay stream: %w", probeErr)
+				}
+				return conn, nil
 			},
 		},
 		FallbackDelay: 0,

--- a/packages/device-link/mobile/link_test.go
+++ b/packages/device-link/mobile/link_test.go
@@ -145,6 +145,17 @@ func TestOpenStreamWithRelayStartsBeforeConnect(t *testing.T) {
 	if got := stream.transport; got != "relay" {
 		t.Fatalf("transport = %q, want relay", got)
 	}
+	if err := stream.SetDeadline(5_000); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := stream.Write([]byte("relay-payload")); err != nil {
+		t.Fatal(err)
+	}
+	buffer := make([]byte, len("relay-payload"))
+	count := stream.ReadInto(buffer)
+	if count != len(buffer) || string(buffer[:count]) != "relay-payload" {
+		t.Fatalf("relay echo = %q (%d bytes)", buffer[:max(count, 0)], count)
+	}
 }
 
 func TestOpenStreamWithRelayDoesNotSelectUnresponsiveDirectStream(t *testing.T) {

--- a/services/tuttid/service/mobileremote/attempt_wake.go
+++ b/services/tuttid/service/mobileremote/attempt_wake.go
@@ -1,0 +1,100 @@
+package mobileremote
+
+import (
+	"context"
+	"sync"
+)
+
+// AttemptWake is the local rendezvous between the WebSocket hint lane and the
+// authoritative HTTP attempt reader. Notifications are deliberately
+// coalesced: a hint only says that the attempt should be fetched again.
+type AttemptWake struct {
+	mu      sync.Mutex
+	version map[string]uint64
+	waiters map[string]map[uint64]chan struct{}
+	nextID  uint64
+}
+
+func NewAttemptWake() *AttemptWake {
+	return &AttemptWake{
+		version: make(map[string]uint64),
+		waiters: make(map[string]map[uint64]chan struct{}),
+	}
+}
+
+func (w *AttemptWake) Version(attemptID string) uint64 {
+	if w == nil {
+		return 0
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.version[attemptID]
+}
+
+func (w *AttemptWake) Notify(attemptID string) {
+	if w == nil || attemptID == "" {
+		return
+	}
+	w.mu.Lock()
+	w.version[attemptID]++
+	for _, waiter := range w.waiters[attemptID] {
+		select {
+		case waiter <- struct{}{}:
+		default:
+		}
+	}
+	w.mu.Unlock()
+}
+
+// Forget releases the version retained for an attempt after its worker has
+// finished. Notifications are intentionally retained until then so a push
+// racing worker creation cannot be lost between discovery and Wait.
+func (w *AttemptWake) Forget(attemptID string) {
+	if w == nil || attemptID == "" {
+		return
+	}
+	w.mu.Lock()
+	delete(w.version, attemptID)
+	if len(w.waiters[attemptID]) == 0 {
+		delete(w.waiters, attemptID)
+	}
+	w.mu.Unlock()
+}
+
+func (w *AttemptWake) Wait(ctx context.Context, attemptID string, after uint64) bool {
+	if w == nil {
+		return false
+	}
+	w.mu.Lock()
+	if w.version[attemptID] > after {
+		w.mu.Unlock()
+		return true
+	}
+	w.nextID++
+	waiterID := w.nextID
+	waiter := make(chan struct{}, 1)
+	if w.waiters[attemptID] == nil {
+		w.waiters[attemptID] = make(map[uint64]chan struct{})
+	}
+	w.waiters[attemptID][waiterID] = waiter
+	w.mu.Unlock()
+
+	select {
+	case <-waiter:
+		w.removeWaiter(attemptID, waiterID)
+		return true
+	case <-ctx.Done():
+		w.removeWaiter(attemptID, waiterID)
+		return false
+	}
+}
+
+func (w *AttemptWake) removeWaiter(attemptID string, waiterID uint64) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	waiters := w.waiters[attemptID]
+	delete(waiters, waiterID)
+	if len(waiters) == 0 {
+		delete(w.waiters, attemptID)
+	}
+}

--- a/services/tuttid/service/mobileremote/attempt_wake_test.go
+++ b/services/tuttid/service/mobileremote/attempt_wake_test.go
@@ -1,0 +1,50 @@
+package mobileremote
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestAttemptWakeDeliversOnlyAfterTheObservedVersion(t *testing.T) {
+	wake := NewAttemptWake()
+	version := wake.Version("attempt-1")
+	result := make(chan bool, 1)
+	go func() { result <- wake.Wait(context.Background(), "attempt-1", version) }()
+
+	wake.Notify("attempt-1")
+	select {
+	case notified := <-result:
+		if !notified {
+			t.Fatal("Wait returned false after a notification")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Wait did not receive the notification")
+	}
+}
+
+func TestAttemptWakeDoesNotBlockWhenNotificationPrecedesWait(t *testing.T) {
+	wake := NewAttemptWake()
+	wake.Notify("attempt-1")
+	if !wake.Wait(context.Background(), "attempt-1", 0) {
+		t.Fatal("Wait missed an already-recorded notification")
+	}
+}
+
+func TestAttemptWakeForgetRemovesRetainedVersion(t *testing.T) {
+	wake := NewAttemptWake()
+	wake.Notify("attempt-1")
+	wake.Forget("attempt-1")
+	if got := wake.Version("attempt-1"); got != 0 {
+		t.Fatalf("forgotten attempt version = %d, want 0", got)
+	}
+}
+
+func TestAttemptWakeCanBeCancelled(t *testing.T) {
+	wake := NewAttemptWake()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	if wake.Wait(ctx, "attempt-1", 0) {
+		t.Fatal("Wait returned true without a notification")
+	}
+}

--- a/services/tuttid/service/mobileremote/remote_host.go
+++ b/services/tuttid/service/mobileremote/remote_host.go
@@ -17,10 +17,10 @@ import (
 )
 
 const (
-	defaultRemotePollInterval = 2 * time.Second
-	remoteCallerSettleDelay   = 6 * time.Second
-	deviceLinkProtocolVersion = 2
-	mobileRemoteRelayDriver   = "mobile-remote"
+	defaultRemotePollInterval  = 2 * time.Second
+	remoteCallerSettleFallback = 1 * time.Second
+	deviceLinkProtocolVersion  = 2
+	mobileRemoteRelayDriver    = "mobile-remote"
 )
 
 type activeRemoteAttempt struct {
@@ -58,6 +58,8 @@ type remoteHostState struct {
 	relayOwnerAcquired   bool
 	remoteHostGeneration uint64
 	activePairings       map[string]struct{}
+	attemptWake          *AttemptWake
+	pollWake             chan struct{}
 }
 
 func (s *Service) StartRemoteHost(handler http.Handler) {
@@ -87,6 +89,8 @@ func (s *Service) StartRemoteHost(handler http.Handler) {
 		s.remoteHost.managedLinks = make(map[string]remoteManagedLink)
 		s.remoteHost.observedLinkEvents = make(map[string]uint64)
 		s.remoteHost.activePairings = make(map[string]struct{})
+		s.remoteHost.attemptWake = NewAttemptWake()
+		s.remoteHost.pollWake = make(chan struct{}, 1)
 		s.remoteHost.linkManager = s.newRemoteLinkManager()
 		s.remoteHost.remoteHostGeneration++
 		remoteHostGeneration := s.remoteHost.remoteHostGeneration
@@ -107,6 +111,13 @@ func (s *Service) StartRemoteHost(handler http.Handler) {
 			}
 		}
 
+		if s.AttemptEvents != nil {
+			s.remoteWG.Add(1)
+			go func() {
+				defer s.remoteWG.Done()
+				s.runRemoteAttemptEvents(ctx)
+			}()
+		}
 		go func() {
 			defer s.remoteWG.Done()
 			s.runRemoteHost(ctx)
@@ -166,6 +177,8 @@ func (s *Service) StopRemoteHost() {
 	s.remoteHost.managedLinks = nil
 	s.remoteHost.observedLinkEvents = nil
 	s.remoteHost.activePairings = nil
+	s.remoteHost.attemptWake = nil
+	s.remoteHost.pollWake = nil
 	s.remoteHost.stopping = false
 	s.remoteHost.stopDone = nil
 	close(done)
@@ -180,13 +193,102 @@ func (s *Service) runRemoteHost(ctx context.Context) {
 	timer := time.NewTimer(0)
 	defer timer.Stop()
 	for {
+		s.remoteHost.mu.Lock()
+		pollWake := s.remoteHost.pollWake
+		s.remoteHost.mu.Unlock()
 		select {
 		case <-ctx.Done():
 			return
 		case <-timer.C:
-			s.pollRemoteHost(ctx)
-			timer.Reset(interval)
+		case <-pollWake:
 		}
+		if ctx.Err() != nil {
+			return
+		}
+		s.pollRemoteHost(ctx)
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+		timer.Reset(interval)
+	}
+}
+
+func (s *Service) runRemoteAttemptEvents(ctx context.Context) {
+	backoff := time.Second
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		session, identity, err := s.readyIdentity(ctx)
+		if err == nil {
+			s.remoteHost.mu.Lock()
+			wake := s.remoteHost.attemptWake
+			s.remoteHost.mu.Unlock()
+			if wake != nil {
+				runErr := s.AttemptEvents.Run(
+					ctx, session.Cookie, identity.DeviceID, s.notifyRemoteAttemptChanged,
+				)
+				if ctx.Err() != nil {
+					return
+				}
+				if runErr == nil {
+					backoff = time.Second
+				} else {
+					backoff = nextAttemptEventBackoff(backoff)
+				}
+			}
+		}
+		if !waitRemoteAttemptEventRetry(ctx, backoff) {
+			return
+		}
+	}
+}
+
+// notifyRemoteAttemptChanged treats realtime messages as a best-effort wake
+// for both stages of owner rendezvous: an attempt may not have a worker yet,
+// so the discovery loop must run immediately before the worker can refetch it.
+// The HTTP attempt API remains authoritative when either wake is lost.
+func (s *Service) notifyRemoteAttemptChanged(attemptID string) {
+	s.remoteHost.mu.Lock()
+	wake := s.remoteHost.attemptWake
+	pollWake := s.remoteHost.pollWake
+	s.remoteHost.mu.Unlock()
+	if wake != nil {
+		wake.Notify(attemptID)
+	}
+	if pollWake != nil {
+		select {
+		case pollWake <- struct{}{}:
+		default:
+		}
+	}
+}
+
+func nextAttemptEventBackoff(current time.Duration) time.Duration {
+	if current <= 0 {
+		return time.Second
+	}
+	if current >= 15*time.Second {
+		return 15 * time.Second
+	}
+	next := current + current/2
+	if next > 15*time.Second {
+		return 15 * time.Second
+	}
+	return next
+}
+
+func waitRemoteAttemptEventRetry(ctx context.Context, delay time.Duration) bool {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
 	}
 }
 
@@ -311,25 +413,39 @@ func (s *Service) startRemoteAttempt(
 
 func (s *Service) finishRemoteAttempt(attemptID string, generation uint64) {
 	s.remoteHost.mu.Lock()
-	defer s.remoteHost.mu.Unlock()
+	wake := s.remoteHost.attemptWake
+	finished := false
 	if current, exists := s.remoteHost.attempts[attemptID]; exists &&
 		current.generation == generation {
 		delete(s.remoteHost.attempts, attemptID)
+		finished = true
+	}
+	s.remoteHost.mu.Unlock()
+	if finished && wake != nil {
+		wake.Forget(attemptID)
 	}
 }
 
 func (s *Service) stopRemotePairing(pairingID string) {
 	pairingID = strings.TrimSpace(pairingID)
 	s.remoteHost.mu.Lock()
+	finishedAttemptIDs := make([]string, 0)
 	for attemptID, attempt := range s.remoteHost.attempts {
 		if attempt.pairingID != pairingID {
 			continue
 		}
 		attempt.cancel()
 		delete(s.remoteHost.attempts, attemptID)
+		finishedAttemptIDs = append(finishedAttemptIDs, attemptID)
 	}
 	manager := s.remoteHost.linkManager
+	wake := s.remoteHost.attemptWake
 	s.remoteHost.mu.Unlock()
+	if wake != nil {
+		for _, attemptID := range finishedAttemptIDs {
+			wake.Forget(attemptID)
+		}
+	}
 	if manager != nil {
 		manager.Invalidate(pairingID)
 	}
@@ -349,29 +465,65 @@ func (s *Service) settledRemoteAttempt(
 	pairingID string,
 	attempt DeviceLinkAttempt,
 ) (DeviceLinkAttempt, bool) {
+	startedAt := time.Now()
 	if len(attempt.STUNEndpoints) == 0 {
+		s.recordRemoteAttempt(RemoteAttemptEvent{
+			AttemptID: attempt.AttemptID, PairingID: pairingID,
+			Stage: "rendezvous_wait", Outcome: "skipped",
+			ElapsedMS: time.Since(startedAt).Milliseconds(),
+		})
 		return attempt, true
 	}
-	timer := time.NewTimer(remoteCallerSettleDelay)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
+	s.remoteHost.mu.Lock()
+	wake := s.remoteHost.attemptWake
+	var wakeVersion uint64
+	if wake != nil {
+		wakeVersion = wake.Version(attempt.AttemptID)
+	}
+	s.remoteHost.mu.Unlock()
+	if wake != nil {
+		settleCtx, cancel := context.WithTimeout(ctx, remoteCallerSettleFallback)
+		wake.Wait(settleCtx, attempt.AttemptID, wakeVersion)
+		cancel()
+	} else if !waitRemoteAttemptEventRetry(ctx, remoteCallerSettleFallback) {
 		return DeviceLinkAttempt{}, false
-	case <-timer.C:
+	}
+	if ctx.Err() != nil {
+		s.recordRemoteAttempt(RemoteAttemptEvent{
+			AttemptID: attempt.AttemptID, PairingID: pairingID,
+			Stage: "rendezvous_wait", Outcome: "cancelled",
+			ElapsedMS: time.Since(startedAt).Milliseconds(),
+		})
+		return DeviceLinkAttempt{}, false
 	}
 	signature := ed25519.Sign(identity.PrivateKey, deviceLinkProof("list", pairingID, "", ""))
 	attempts, err := s.ControlPlane.ListDeviceLinkAttempts(
 		ctx, cookie, pairingID, identity.DeviceID, signature,
 	)
 	if err != nil {
+		s.recordRemoteAttempt(RemoteAttemptEvent{
+			AttemptID: attempt.AttemptID, PairingID: pairingID,
+			Stage: "rendezvous_refetch", Outcome: "failed",
+			ElapsedMS: time.Since(startedAt).Milliseconds(), Error: err.Error(),
+		})
 		return DeviceLinkAttempt{}, false
 	}
 	for _, latest := range attempts {
 		if latest.AttemptID == attempt.AttemptID && latest.State == "awaiting_owner" &&
 			latest.OwnerFingerprint == "" && latest.OwnerICE == nil {
+			s.recordRemoteAttempt(RemoteAttemptEvent{
+				AttemptID: attempt.AttemptID, PairingID: pairingID,
+				Stage: "rendezvous_wait", Outcome: "succeeded",
+				ElapsedMS: time.Since(startedAt).Milliseconds(),
+			})
 			return latest, true
 		}
 	}
+	s.recordRemoteAttempt(RemoteAttemptEvent{
+		AttemptID: attempt.AttemptID, PairingID: pairingID,
+		Stage: "rendezvous_wait", Outcome: "superseded",
+		ElapsedMS: time.Since(startedAt).Milliseconds(),
+	})
 	return DeviceLinkAttempt{}, false
 }
 
@@ -422,6 +574,7 @@ func (s *Service) serveRemoteAttempt(
 		identity.PrivateKey,
 		deviceLinkProof("update", pairingID, attempt.AttemptID, description.Fingerprint),
 	)
+	participantStartedAt := time.Now()
 	updated, err := s.ControlPlane.UpdateDeviceLinkParticipant(
 		handshakeCtx, cookie, pairingID, attempt.AttemptID, identity.DeviceID,
 		DeviceLinkParticipantInput{
@@ -435,12 +588,23 @@ func (s *Service) serveRemoteAttempt(
 		},
 	)
 	if err != nil || updated.State != "ready" {
+		s.recordRemoteAttempt(RemoteAttemptEvent{
+			AttemptID: attempt.AttemptID, PairingID: pairingID,
+			Stage: "owner_participant", Outcome: "failed",
+			ElapsedMS: time.Since(participantStartedAt).Milliseconds(),
+		})
 		return
 	}
+	s.recordRemoteAttempt(RemoteAttemptEvent{
+		AttemptID: attempt.AttemptID, PairingID: pairingID,
+		Stage: "owner_participant", Outcome: "succeeded",
+		ElapsedMS: time.Since(participantStartedAt).Milliseconds(),
+	})
 	peer := updated.CallerICE
 	if peer == nil {
 		return
 	}
+	connectStartedAt := time.Now()
 	link, err := participant.Connect(handshakeCtx, authenticatedlink.Description{
 		Fingerprint: updated.CallerFingerprint,
 		Ufrag:       peer.Ufrag,
@@ -448,8 +612,18 @@ func (s *Service) serveRemoteAttempt(
 		Candidates:  append([]string(nil), peer.Candidates...),
 	}, authenticatedlink.RoleOwner)
 	if err != nil {
+		s.recordRemoteAttempt(RemoteAttemptEvent{
+			AttemptID: attempt.AttemptID, PairingID: pairingID,
+			Stage: "direct_connect", Outcome: "failed",
+			ElapsedMS: time.Since(connectStartedAt).Milliseconds(), Error: err.Error(),
+		})
 		return
 	}
+	s.recordRemoteAttempt(RemoteAttemptEvent{
+		AttemptID: attempt.AttemptID, PairingID: pairingID,
+		Stage: "direct_connect", Outcome: "succeeded",
+		ElapsedMS: time.Since(connectStartedAt).Milliseconds(),
+	})
 	_, err = manager.Register(admission, linkmanager.Registration[string, remoteLinkMetadata]{
 		Key:          pairingID,
 		ConnectionID: attempt.AttemptID,
@@ -469,6 +643,7 @@ func (s *Service) serveRemoteAttempt(
 func (s *Service) stopRemoteAttempts(validPairings map[string]struct{}) {
 	s.remoteHost.mu.Lock()
 	invalidPairingSet := make(map[string]struct{})
+	finishedAttemptIDs := make([]string, 0)
 	for attemptID, attempt := range s.remoteHost.attempts {
 		if validPairings != nil {
 			if _, valid := validPairings[attempt.pairingID]; valid {
@@ -478,8 +653,10 @@ func (s *Service) stopRemoteAttempts(validPairings map[string]struct{}) {
 		attempt.cancel()
 		delete(s.remoteHost.attempts, attemptID)
 		invalidPairingSet[attempt.pairingID] = struct{}{}
+		finishedAttemptIDs = append(finishedAttemptIDs, attemptID)
 	}
 	manager := s.remoteHost.linkManager
+	wake := s.remoteHost.attemptWake
 	for pairingID := range s.remoteHost.managedLinks {
 		if validPairings != nil {
 			if _, valid := validPairings[pairingID]; valid {
@@ -502,6 +679,11 @@ func (s *Service) stopRemoteAttempts(validPairings map[string]struct{}) {
 		s.remoteHost.registerAfter = time.Time{}
 	}
 	s.remoteHost.mu.Unlock()
+	if wake != nil {
+		for _, attemptID := range finishedAttemptIDs {
+			wake.Forget(attemptID)
+		}
+	}
 	if manager == nil {
 		return
 	}
@@ -574,4 +756,10 @@ func deviceLinkProof(action, pairingID, attemptID, fingerprint string) []byte {
 	return []byte("tutti-device-link/1\n" + strings.TrimSpace(action) + "\n" +
 		strings.TrimSpace(pairingID) + "\n" + strings.TrimSpace(attemptID) + "\n" +
 		strings.TrimSpace(fingerprint))
+}
+
+func (s *Service) recordRemoteAttempt(event RemoteAttemptEvent) {
+	if s != nil && s.Diagnostics != nil {
+		s.Diagnostics.Record(event)
+	}
 }

--- a/services/tuttid/service/mobileremote/remote_host_test.go
+++ b/services/tuttid/service/mobileremote/remote_host_test.go
@@ -221,16 +221,41 @@ func TestRemoteHostConnectsAuthenticatedLinkAndServesAgentHTTP(t *testing.T) {
 func TestRemoteHostAttemptCleanupDoesNotDeleteNewGeneration(t *testing.T) {
 	t.Parallel()
 	service := &Service{}
+	service.remoteHost.attemptWake = NewAttemptWake()
 	service.remoteHost.attempts = map[string]activeRemoteAttempt{
 		"attempt-1": {generation: 2},
 	}
+	service.remoteHost.attemptWake.Notify("attempt-1")
 	service.finishRemoteAttempt("attempt-1", 1)
 	if _, exists := service.remoteHost.attempts["attempt-1"]; !exists {
 		t.Fatal("old worker cleanup deleted the newer attempt generation")
 	}
+	if got := service.remoteHost.attemptWake.Version("attempt-1"); got != 1 {
+		t.Fatalf("old worker cleanup forgot current wake version: %d", got)
+	}
 	service.finishRemoteAttempt("attempt-1", 2)
 	if _, exists := service.remoteHost.attempts["attempt-1"]; exists {
 		t.Fatal("current worker cleanup did not delete its attempt")
+	}
+	if got := service.remoteHost.attemptWake.Version("attempt-1"); got != 0 {
+		t.Fatalf("current worker cleanup retained wake version: %d", got)
+	}
+}
+
+func TestRemoteHostAttemptChangeWakesDiscoveryAndRendezvous(t *testing.T) {
+	service := &Service{}
+	service.remoteHost.attemptWake = NewAttemptWake()
+	service.remoteHost.pollWake = make(chan struct{}, 1)
+
+	service.notifyRemoteAttemptChanged("attempt-1")
+
+	if got := service.remoteHost.attemptWake.Version("attempt-1"); got != 1 {
+		t.Fatalf("attempt wake version = %d, want 1", got)
+	}
+	select {
+	case <-service.remoteHost.pollWake:
+	default:
+		t.Fatal("attempt change did not wake owner discovery")
 	}
 }
 

--- a/services/tuttid/service/mobileremote/service.go
+++ b/services/tuttid/service/mobileremote/service.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 	"time"
@@ -60,6 +61,51 @@ type AgentLiveEventSource interface {
 	) error
 }
 
+// AttemptEventSource is a best-effort control-plane hint stream. The HTTP
+// attempt API remains authoritative; implementations only wake a caller to
+// refetch an attempt after a committed mutation.
+type AttemptEventSource interface {
+	Run(context.Context, string, string, func(string)) error
+}
+
+type RemoteAttemptDiagnostics interface {
+	Record(RemoteAttemptEvent)
+}
+
+type RemoteAttemptEvent struct {
+	AttemptID string
+	PairingID string
+	Stage     string
+	Outcome   string
+	ElapsedMS int64
+	Error     string
+}
+
+// SlogRemoteAttemptDiagnostics keeps timing details in the daemon's existing
+// structured log stream without coupling the service to a logging backend.
+type SlogRemoteAttemptDiagnostics struct {
+	Logger *slog.Logger
+}
+
+func (d SlogRemoteAttemptDiagnostics) Record(event RemoteAttemptEvent) {
+	logger := d.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	args := []any{
+		"event", "mobile_remote.device_link_stage",
+		"attempt_id", event.AttemptID,
+		"pairing_id", event.PairingID,
+		"stage", event.Stage,
+		"outcome", event.Outcome,
+		"elapsed_ms", event.ElapsedMS,
+	}
+	if event.Error != "" {
+		args = append(args, "error", event.Error)
+	}
+	logger.Info("mobile remote DeviceLink stage", args...)
+}
+
 type DeviceMetadata struct {
 	ReportedName  string
 	Platform      string
@@ -85,6 +131,8 @@ type Service struct {
 	RuntimeID       string
 	RelayOwner      RelayOwnerHost
 	AgentLiveEvents AgentLiveEventSource
+	AttemptEvents   AttemptEventSource
+	Diagnostics     RemoteAttemptDiagnostics
 	Metadata        DeviceMetadata
 	Now             func() time.Time
 	// RemotePollInterval is test-only tuning; zero uses the production default.

--- a/services/tuttid/service/mobileremote/websocket_attempt_events.go
+++ b/services/tuttid/service/mobileremote/websocket_attempt_events.go
@@ -1,0 +1,160 @@
+package mobileremote
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+const (
+	DefaultRealtimeBaseURL       = "wss://ws.tutti.sh/"
+	deviceLinkAttemptChangedType = "device_link.attempt.changed"
+	websocketProtocolVersion     = 2
+	websocketHeartbeatInterval   = 3 * time.Minute
+)
+
+// WebSocketAttemptEvents consumes the account/device-scoped realtime lane.
+// It intentionally exposes one connection attempt per Run call; the remote
+// host owns reconnect backoff so credentials are refreshed between attempts.
+type WebSocketAttemptEvents struct {
+	URL string
+}
+
+func (s WebSocketAttemptEvents) Run(ctx context.Context, cookie, deviceID string, notify func(string)) error {
+	if notify == nil {
+		return errors.New("device-link attempt event listener is required")
+	}
+	endpoint, err := realtimeEndpoint(s.URL, deviceID)
+	if err != nil {
+		return err
+	}
+	connectionCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	conn, _, err := websocket.Dial(connectionCtx, endpoint, &websocket.DialOptions{
+		HTTPHeader: http.Header{"Cookie": []string{strings.TrimSpace(cookie)}},
+	})
+	if err != nil {
+		return err
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "device-link attempt listener stopped")
+	conn.SetReadLimit(16 * 1024)
+	if err := writeRealtimeAction(connectionCtx, conn, "connection.initialize", map[string]any{
+		"protocolVersion": websocketProtocolVersion,
+	}); err != nil {
+		return err
+	}
+	if err := writeRealtimeAction(connectionCtx, conn, "init", map[string]any{
+		"deviceId": deviceID,
+	}); err != nil {
+		return err
+	}
+
+	heartbeat := time.NewTicker(websocketHeartbeatInterval)
+	defer heartbeat.Stop()
+	go func() {
+		for {
+			select {
+			case <-connectionCtx.Done():
+				return
+			case now := <-heartbeat.C:
+				_ = writeRealtimeAction(connectionCtx, conn, "ping", map[string]any{
+					"ts": now.UnixMilli(),
+				})
+			}
+		}
+	}()
+
+	for {
+		_, raw, err := conn.Read(connectionCtx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return err
+		}
+		if attemptID, ok := parseDeviceLinkAttemptEvent(raw); ok {
+			notify(attemptID)
+		}
+	}
+}
+
+type realtimeEnvelope struct {
+	ProtocolVersion int             `json:"protocol_version"`
+	Type            string          `json:"type"`
+	EventType       string          `json:"event_type"`
+	Payload         json.RawMessage `json:"payload"`
+}
+
+type deviceLinkAttemptChangedPayload struct {
+	AttemptID string `json:"attemptId"`
+}
+
+func parseDeviceLinkAttemptEvent(raw []byte) (string, bool) {
+	var envelope realtimeEnvelope
+	if err := json.Unmarshal(raw, &envelope); err != nil ||
+		envelope.ProtocolVersion != websocketProtocolVersion {
+		return "", false
+	}
+	eventType := strings.TrimSpace(envelope.EventType)
+	if eventType == "" {
+		eventType = strings.TrimSpace(envelope.Type)
+	}
+	if eventType != deviceLinkAttemptChangedType {
+		return "", false
+	}
+	payload := envelope.Payload
+	if len(payload) > 0 && payload[0] == '"' {
+		var encoded string
+		if err := json.Unmarshal(payload, &encoded); err != nil {
+			return "", false
+		}
+		decoded, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			return "", false
+		}
+		payload = decoded
+	}
+	var attempt deviceLinkAttemptChangedPayload
+	if err := json.Unmarshal(payload, &attempt); err != nil {
+		return "", false
+	}
+	attemptID := strings.TrimSpace(attempt.AttemptID)
+	return attemptID, attemptID != ""
+}
+
+func writeRealtimeAction(ctx context.Context, conn *websocket.Conn, action string, data map[string]any) error {
+	payload, err := json.Marshal(struct {
+		Action string         `json:"action"`
+		Data   map[string]any `json:"data"`
+	}{Action: action, Data: data})
+	if err != nil {
+		return err
+	}
+	return conn.Write(ctx, websocket.MessageText, payload)
+}
+
+func realtimeEndpoint(rawURL, deviceID string) (string, error) {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		rawURL = DefaultRealtimeBaseURL
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Host == "" || (parsed.Scheme != "ws" && parsed.Scheme != "wss") {
+		return "", errors.New("mobile remote realtime URL is invalid")
+	}
+	deviceID = strings.TrimSpace(deviceID)
+	if deviceID == "" {
+		return "", errors.New("mobile remote realtime device identity is required")
+	}
+	query := parsed.Query()
+	query.Set("deviceId", deviceID)
+	parsed.RawQuery = query.Encode()
+	return parsed.String(), nil
+}

--- a/services/tuttid/service/mobileremote/websocket_attempt_events_test.go
+++ b/services/tuttid/service/mobileremote/websocket_attempt_events_test.go
@@ -1,0 +1,151 @@
+package mobileremote
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+func TestRealtimeEndpointRequiresDeviceIdentity(t *testing.T) {
+	if _, err := realtimeEndpoint("ws://localhost:8080/realtime", ""); err == nil {
+		t.Fatal("expected missing device identity to fail")
+	}
+	if _, err := realtimeEndpoint("https://ws.example.test/realtime", "device-1"); err == nil {
+		t.Fatal("expected non-websocket scheme to fail")
+	}
+	endpoint, err := realtimeEndpoint("ws://localhost:8080/realtime?lane=mobile", "device/1")
+	if err != nil {
+		t.Fatalf("realtime endpoint: %v", err)
+	}
+	if !strings.Contains(endpoint, "lane=mobile") || !strings.Contains(endpoint, "deviceId=device%2F1") {
+		t.Fatalf("endpoint does not preserve query and encode device id: %s", endpoint)
+	}
+}
+
+func TestParseDeviceLinkAttemptEvent(t *testing.T) {
+	payload, err := json.Marshal(deviceLinkAttemptChangedPayload{AttemptID: "attempt-1"})
+	if err != nil {
+		t.Fatalf("encode payload: %v", err)
+	}
+	raw, err := json.Marshal(map[string]any{
+		"event_type":       deviceLinkAttemptChangedType,
+		"payload":          base64.StdEncoding.EncodeToString(payload),
+		"protocol_version": websocketProtocolVersion,
+	})
+	if err != nil {
+		t.Fatalf("encode envelope: %v", err)
+	}
+	attemptID, ok := parseDeviceLinkAttemptEvent(raw)
+	if !ok || attemptID != "attempt-1" {
+		t.Fatalf("parse event = %q, %v", attemptID, ok)
+	}
+	if _, ok := parseDeviceLinkAttemptEvent([]byte(`{"event_type":"room.message","protocol_version":2}`)); ok {
+		t.Fatal("non-attempt event should be ignored")
+	}
+}
+
+func TestWebSocketAttemptEventsReadsV2BusinessFrame(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("deviceId"); got != "device-1" {
+			t.Errorf("device id = %q", got)
+		}
+		if got := r.Header.Get("Cookie"); got != "session-cookie" {
+			t.Errorf("cookie = %q", got)
+		}
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept websocket: %v", err)
+			return
+		}
+		defer conn.Close(websocket.StatusNormalClosure, "test finished")
+		readCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_, raw, err := conn.Read(readCtx)
+		if err != nil {
+			t.Errorf("read initialize: %v", err)
+			return
+		}
+		var initialize struct {
+			Action string `json:"action"`
+		}
+		if err := json.Unmarshal(raw, &initialize); err != nil {
+			t.Errorf("decode initialize: %v", err)
+			return
+		}
+		if initialize.Action != "connection.initialize" {
+			t.Errorf("initialize action = %q", initialize.Action)
+			return
+		}
+		_, raw, err = conn.Read(readCtx)
+		if err != nil {
+			t.Errorf("read device init: %v", err)
+			return
+		}
+		var deviceInit struct {
+			Action string         `json:"action"`
+			Data   map[string]any `json:"data"`
+		}
+		if err := json.Unmarshal(raw, &deviceInit); err != nil {
+			t.Errorf("decode device init: %v", err)
+			return
+		}
+		if deviceInit.Action != "init" || deviceInit.Data["deviceId"] != "device-1" {
+			t.Errorf("device init = %#v", deviceInit)
+			return
+		}
+		payload, _ := json.Marshal(deviceLinkAttemptChangedPayload{AttemptID: "attempt-1"})
+		envelope, _ := json.Marshal(map[string]any{
+			"content_type":     "PAYLOAD_CONTENT_TYPE_JSON",
+			"delivery":         map[string]any{"device_id": "device-1", "scope": "user_device"},
+			"dispatch_id":      "dispatch-1",
+			"event_id":         "event-1",
+			"event_type":       deviceLinkAttemptChangedType,
+			"payload":          base64.StdEncoding.EncodeToString(payload),
+			"protocol_version": websocketProtocolVersion,
+			"schema_version":   1,
+			"occurred_at":      time.Now().UTC().Format(time.RFC3339Nano),
+		})
+		if err := conn.Write(context.Background(), websocket.MessageText, envelope); err != nil {
+			t.Errorf("write attempt event: %v", err)
+			return
+		}
+		_, _, _ = conn.Read(context.Background())
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	events := WebSocketAttemptEvents{URL: strings.Replace(server.URL, "http://", "ws://", 1)}
+	received := make(chan string, 1)
+	result := make(chan error, 1)
+	go func() {
+		result <- events.Run(ctx, "session-cookie", "device-1", func(attemptID string) {
+			received <- attemptID
+		})
+	}()
+
+	select {
+	case attemptID := <-received:
+		if attemptID != "attempt-1" {
+			t.Fatalf("attempt id = %q", attemptID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for attempt event")
+	}
+	cancel()
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("event source returned error after cancellation: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("event source did not stop after cancellation")
+	}
+}

--- a/services/tuttid/wiring_mobile_remote.go
+++ b/services/tuttid/wiring_mobile_remote.go
@@ -34,8 +34,12 @@ func buildMobileRemoteService(
 	service := &mobileremoteservice.Service{
 		Account:         account,
 		AgentLiveEvents: mobileAgentLiveEventSource{events: events},
-		Identities:      identities,
-		RuntimeID:       deviceID,
+		AttemptEvents: mobileremoteservice.WebSocketAttemptEvents{
+			URL: os.Getenv("TUTTI_MOBILE_REALTIME_URL"),
+		},
+		Diagnostics: mobileremoteservice.SlogRemoteAttemptDiagnostics{},
+		Identities:  identities,
+		RuntimeID:   deviceID,
 		ControlPlane: &mobileremoteservice.HTTPControlPlane{
 			BaseURL: os.Getenv("TUTTI_MOBILE_CONTROL_PLANE_BASE_URL"),
 		},


### PR DESCRIPTION
## Summary

- Consume the existing device-scoped tsh-websocket V2 lane on Desktop and Mobile, using it only as a wake hint for DeviceLink attempt reconciliation.
- Wake Desktop owner discovery immediately when an attempt event arrives; keep HTTP as the authority and retain 2s/500ms polling fallbacks.
- Replace the fixed Desktop caller-settle delay with event-or-1s fallback waiting and add stage timings for rendezvous, owner ICE publication, direct connect, and Relay probe.
- Keep the mobile connection feature gate unchanged: the long-lived Desktop subscription starts only while the user-enabled connection host is running.
- Document the new runtime override and event/polling boundary.

## Validation

- `go test ./service/mobileremote -count=1`
- `go test -race ./service/mobileremote -run 'TestAttemptWake|TestWebSocketAttemptEvents|TestRemoteHostAttemptChange' -count=1`\n- `go build ./...` (services/tuttid)\n- Mobile Jest: 16 tests passed\n- Oxlint changed files passed\n- `pnpm check:changed` selected 10 lanes; 8 passed. The builtin-app test lane cannot build because this worktree lacks the generated onboarding archive and its local Vite dependency, and mobile typecheck is blocked by pre-existing missing workspace package build outputs. No errors referenced the changed files.\n\nThe paired-device audience correction is in the companion tsh-server PR.