### PR TITLE
fix(agent): harden session replay lifecycle

### DIFF
--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -85,6 +85,7 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 - [AgentGUI changed-files summary shows negative lines for a new file](./agent-session-lifecycle.md#agentgui-changed-files-summary-shows-negative-lines-for-a-new-file)
 - [Cursor deleted files appear as created or modified](./agent-session-lifecycle.md#cursor-deleted-files-appear-as-created-or-modified)
 - [AgentGUI compaction timer keeps running after compaction completed](./agent-session-lifecycle.md#agentgui-compaction-timer-keeps-running-after-compaction-completed)
+- [Claude `/compact` finishes without a compaction divider](./agent-session-lifecycle.md#claude-compact-finishes-without-a-compaction-divider)
 - [AgentActivity replication repeatedly rejects message batches as invalid](./agent-session-lifecycle.md#agentactivity-replication-repeatedly-rejects-message-batches-as-invalid)
 - [Remote agent cancel does not stop the local turn](./agent-session-lifecycle.md#remote-agent-cancel-does-not-stop-the-local-turn)
 - [Claude Code cancel leaves Write/tool cards stuck in progress](./agent-session-lifecycle.md#claude-code-cancel-leaves-writetool-cards-stuck-in-progress)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -115,6 +115,30 @@ incomplete`, while a newly created session can still launch.
 - **Validation:** Launch a managed Replay Workspace and prove its isolated
   daemon becomes discoverable without waiting for the startup timeout.
 
+### Replay fails because Desktop and tuttid use different event catalogs
+
+- **Symptom:** Replay stops during Desktop startup with
+  `desktop/tuttid event stream catalog mismatch (fail-fast)`, or the isolated
+  Desktop log contains `Event stream catalog revision mismatch`.
+- **Quick checks:** Compare the revisions reported by the runner for the
+  prepared `apps/desktop/out` bundle, the event-protocol source, and the
+  `tuttid` binary. A prepared Electron bundle can be stale even when the
+  current source checkout and daemon build match.
+- **Root cause:** The Desktop renderer and daemon perform a strict event-stream
+  catalog handshake. Reusing a prepared renderer or daemon from a different
+  generated-protocol revision makes the handshake fail before Replay can drive
+  a Session.
+- **Fix:** For an unmanaged launch, the runner falls back to
+  `pnpm-dev-desktop` when the current event-protocol source matches `tuttid`.
+  For a managed launch, rebuild `apps/desktop/out` and `tuttid` from the same
+  checkout, or clear the prepared Electron environment before retrying.
+- **Validation:** Confirm the runner reports matching revisions before launch,
+  then run the Replay scenario and require the first checkpoint to become
+  ready without a catalog mismatch in `desktop.log`.
+- **References:**
+  [event-stream-catalog.mjs](../../../tools/scripts/agent-session-replay-runner/event-stream-catalog.mjs),
+  [agent-session-replay.md](../../../docs/architecture/agent-session-replay.md)
+
 ### Replay starts but the first Turn never becomes idle
 
 - **Symptom:** The isolated Replay Workspace is ready, but playback waits on the
@@ -3564,6 +3588,55 @@ inline data URL instead`. Claude or standard ACP may instead receive no
   [compaction.ts](../../../packages/agent/claude-sdk-sidecar/src/compaction.ts)
   [messageRouter.ts](../../../packages/agent/claude-sdk-sidecar/src/messageRouter.ts)
   [sessionRuntime.session.test.ts](../../../packages/agent/claude-sdk-sidecar/src/sessionRuntime.session.test.ts)
+
+### Claude `/compact` finishes without a compaction divider
+
+- Symptom:
+  After Claude Code `/compact`, AgentGUI shows only the turn duration footer
+  (for example `总用时 22 秒`) and never renders the
+  `Compacting context` / `Context compacted.` divider. Context usage may still
+  drop correctly.
+- Quick checks:
+  Confirm the provider is Claude Code SDK. Inspect the Claude transcript under
+  `~/.claude/projects/.../<provider-session-id>.jsonl` for `compact_boundary`
+  or `<local-command-stdout>Compacted`. Check tuttíd for a
+  `claude-sdk:compact:<turnId>` system notice; if tokens fell but that notice is
+  missing, the sidecar never published `compact_started`.
+- Root cause:
+  Claude Code 2.1.x often completes manual compaction without streaming
+  `status:compacting` or `compact_boundary` to the query iterator (the boundary
+  may exist only on disk, or arrive as `local_command` /
+  camelCase `compactMetadata`). Compaction banners were driven only by those
+  signals, so a silent success left no notice for AgentGUI to project. Even when
+  the sidecar emits `compact_started` immediately on `/compact`, that assistant
+  system notice arrives before provider-turn acceptance; the Claude acceptance
+  gate previously treated it as premature provider output and dropped it. The
+  daemon already settles an active compact notice when the turn closes; it needs
+  a held `compact_started` (or an adapter-emitted running notice) first.
+- Fix:
+  Emit a running compact notice from the Claude adapter when `/compact` is
+  selected, allow compact system notices to precede provider-turn acceptance,
+  accept `local_command` / `local_command_output` and camelCase boundary
+  metadata in the sidecar, and map known failure copy to `compact_failed`
+  before a successful result can settle the banner as completed. When the
+  acceptance barrier later flushes those held events, restamp their
+  `ProviderInputUnit` onto the acceptance unit so Session Replay does not
+  observe an earlier chunk after the durable `turn.working` checkpoint (that
+  regression fails recording with
+  `provider cursor moved backward`).
+- Validation:
+  Add daemon coverage that `/compact` banners stay held until durable
+  acceptance, then flush on the acceptance unit; add sidecar coverage for
+  silent `/compact` (result only), local_command failure, and camelCase
+  `compactMetadata`. Re-run L04-CLAUDE recording and confirm the progress
+  divider appears, then becomes `Context compacted.` (or the interrupted
+  divider with the failure detail), and that recording status stays
+  `recording` through compact.
+- References:
+  [compaction.ts](../../../packages/agent/claude-sdk-sidecar/src/compaction.ts)
+  [claude_sdk_execution.go](../../../packages/agent/daemon/runtime/claude_sdk_execution.go)
+  [claude_sdk_turn.go](../../../packages/agent/daemon/runtime/claude_sdk_turn.go)
+  [AgentMessageBlock.tsx](../../../packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx)
 
 ### AgentGUI compaction timer keeps running after compaction completed
 

--- a/go.work.sum
+++ b/go.work.sum
@@ -7,6 +7,7 @@ cel.dev/expr v0.19.1/go.mod h1:MrpN08Q+lEBs+bGYdLxxHkZoUSsCp0nSKTs0nTymJgw=
 cel.dev/expr v0.19.2/go.mod h1:MrpN08Q+lEBs+bGYdLxxHkZoUSsCp0nSKTs0nTymJgw=
 cel.dev/expr v0.20.0/go.mod h1:MrpN08Q+lEBs+bGYdLxxHkZoUSsCp0nSKTs0nTymJgw=
 cel.dev/expr v0.23.0/go.mod h1:hLPLo1W4QUmuYdA72RBX06QTs6MXw941piREPl3Yfiw=
+cel.dev/expr v0.24.0 h1:56OvJKSH3hDGL0ml5uSxZmz3/3Pq4tJ+fb1unVLAFcY=
 cel.dev/expr v0.24.0/go.mod h1:hLPLo1W4QUmuYdA72RBX06QTs6MXw941piREPl3Yfiw=
 cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
 cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
@@ -517,6 +518,7 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.24.2
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.25.0/go.mod h1:obipzmGjfSjam60XLwGfqUkJsfiheAl+TUjG+4yzyPM=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.26.0/go.mod h1:2bIszWvQRlJVmJLiuLhukLImRjKPcYdzzsx6darK02A=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.27.0/go.mod h1:yAZHSGnqScoU556rBOVkwLze6WP5N+U11RHuWaGVxwY=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.29.0 h1:UQUsRi8WTzhZntp5313l+CHIAT95ojUI2lpP/ExlZa4=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.29.0/go.mod h1:Cz6ft6Dkn3Et6l2v2a9/RpN7epQ1GtDlO6lj8bEcOvw=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 h1:DHa2U07rk8syqvCge0QIGMCE1WxGj9njT44GH7zNJLQ=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0/go.mod h1:P4WPRUkOhJC13W//jWpyfJNDAIpvRbAUIYLX/4jtlE0=
@@ -652,6 +654,7 @@ github.com/census-instrumentation/opencensus-proto v0.4.1/go.mod h1:4T9NM4+4Vw91
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.2.0 h1:+eqR0HfOetur4tgnC8ftU5imRnhi4te+BadWS95c5AM=
@@ -695,6 +698,7 @@ github.com/cncf/xds/go v0.0.0-20240905190251-b4127c9b8d78/go.mod h1:W+zGtBO5Y1Ig
 github.com/cncf/xds/go v0.0.0-20241223141626-cff3c89139a3/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
 github.com/cncf/xds/go v0.0.0-20250121191232-2f005788dc42/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
 github.com/cncf/xds/go v0.0.0-20250326154945-ae57f3c0d45f/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
+github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443 h1:aQ3y1lwWyqYPiWZThqv1aFbZMiM9vblcSArJRf2Irls=
 github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
@@ -736,11 +740,13 @@ github.com/envoyproxy/go-control-plane v0.12.0/go.mod h1:ZBTaoJ23lqITozF0M6G4/Ir
 github.com/envoyproxy/go-control-plane v0.12.1-0.20240621013728-1eb8caab5155/go.mod h1:5Wkq+JduFtdAXihLmeTJf+tRYIT4KBc2vPXDhwVo1pA=
 github.com/envoyproxy/go-control-plane v0.13.0/go.mod h1:GRaKG3dwvFoTg4nj7aXdZnvMg4d7nvT/wl9WgVXn3Q8=
 github.com/envoyproxy/go-control-plane v0.13.1/go.mod h1:X45hY0mufo6Fd0KW3rqsGvQMw58jvjymeCzBU3mWyHw=
+github.com/envoyproxy/go-control-plane v0.13.4 h1:zEqyPVyku6IvWCFwux4x9RxkLOMUL+1vC9xUFv5l2/M=
 github.com/envoyproxy/go-control-plane v0.13.4/go.mod h1:kDfuBlDVsSj2MjrLEtRWtHlsWIFcGyB2RMO44Dc5GZA=
 github.com/envoyproxy/go-control-plane v0.14.0 h1:hbG2kr4RuFj222B6+7T83thSPqLjwBIfQawTkC++2HA=
 github.com/envoyproxy/go-control-plane v0.14.0/go.mod h1:NcS5X47pLl/hfqxU70yPwL9ZMkUlwlKxtAohpi2wBEU=
 github.com/envoyproxy/go-control-plane/envoy v1.32.2/go.mod h1:eR2SOX2IedqlPvmiKjUH7Wu//S602JKI7HPC/L3SRq8=
 github.com/envoyproxy/go-control-plane/envoy v1.32.3/go.mod h1:F6hWupPfh75TBXGKA++MCT/CZHFq5r9/uwt/kQYkZfE=
+github.com/envoyproxy/go-control-plane/envoy v1.32.4 h1:jb83lalDRZSpPWW2Z7Mck/8kXZ5CQAFYVjQcdVIr83A=
 github.com/envoyproxy/go-control-plane/envoy v1.32.4/go.mod h1:Gzjc5k8JcJswLjAx1Zm+wSYE20UrLtt7JZMWiWQXQEw=
 github.com/envoyproxy/go-control-plane/envoy v1.36.0 h1:yg/JjO5E7ubRyKX3m07GF3reDNEnfOboJ0QySbH736g=
 github.com/envoyproxy/go-control-plane/envoy v1.36.0/go.mod h1:ty89S1YCCVruQAm9OtKeEkQLTb+Lkz0k8v9W0Oxsv98=
@@ -754,6 +760,7 @@ github.com/envoyproxy/protoc-gen-validate v1.0.1/go.mod h1:0vj8bNkYbSTNS2PIyH87K
 github.com/envoyproxy/protoc-gen-validate v1.0.2/go.mod h1:GpiZQP3dDbg4JouG/NNS7QWXpgx6x8QiMKdmN72jogE=
 github.com/envoyproxy/protoc-gen-validate v1.0.4/go.mod h1:qys6tmnRsYrQqIhm2bvKZH4Blx/1gTIZ2UKVY1M+Yew=
 github.com/envoyproxy/protoc-gen-validate v1.1.0/go.mod h1:sXRDRVmzEbkM7CVcM06s9shE/m23dg3wzjl0UWqJ2q4=
+github.com/envoyproxy/protoc-gen-validate v1.2.1 h1:DEo3O99U8j4hBFwbJfrz9VtgcDfUKS7KJ7spH3d86P8=
 github.com/envoyproxy/protoc-gen-validate v1.2.1/go.mod h1:d/C80l/jxXLdfEIhX1W2TmLfsJ31lvEjwamM4DxlWXU=
 github.com/envoyproxy/protoc-gen-validate v1.3.0 h1:TvGH1wof4H33rezVKWSpqKz5NXWg5VPuZ0uONDT6eb4=
 github.com/envoyproxy/protoc-gen-validate v1.3.0/go.mod h1:HvYl7zwPa5mffgyeTUHA9zHIH36nmrm7oCbo4YKoSWA=
@@ -813,6 +820,7 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20231223183121-56fa3ac82ce7/go.mod h1:tQ2
 github.com/go-jose/go-jose/v4 v4.0.4/go.mod h1:NKb5HO1EZccyMpiZNbdUw/14tiXNyUJh188dfnMCAfc=
 github.com/go-jose/go-jose/v4 v4.0.5/go.mod h1:s3P1lRrkT8igV8D9OjyL4WRyHvjB6a4JSllnOrmmBOA=
 github.com/go-jose/go-jose/v4 v4.1.1/go.mod h1:BdsZGqgdO3b6tTc6LSE56wcDbMMLuPsw5d4ZD5f94kA=
+github.com/go-jose/go-jose/v4 v4.1.2 h1:TK/7NqRQZfgAh+Td8AlsrvtPoUyiHh0LqVvokh+1vHI=
 github.com/go-jose/go-jose/v4 v4.1.2/go.mod h1:22cg9HWM1pOlnRiY+9cQYJ9XHmya1bYW8OeDM6Ku6Oo=
 github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
 github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
@@ -831,7 +839,9 @@ github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbV
 github.com/go-logr/logr v1.3.0/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
@@ -903,6 +913,7 @@ github.com/golang/mock v1.7.0-rc.1/go.mod h1:s42URUywIqd+OcERslBJvOjepvNymP31m3q
 github.com/golang/protobuf v1.5.1/go.mod h1:DopwsBzvsk0Fs44TXzsVbJyPhcCPeIwnvohx4u74HPM=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -1342,6 +1353,7 @@ github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spiffe/go-spiffe/v2 v2.5.0 h1:N2I01KCUkv1FAjZXJMwh95KK1ZIQLYbPfhaxw8WS0hE=
 github.com/spiffe/go-spiffe/v2 v2.5.0/go.mod h1:P+NxobPc6wXhVtINNtFjNWGBTreew1GBUCwT2wPmb7g=
 github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMpsbLuo=
 github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
@@ -1431,6 +1443,7 @@ go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
+go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/detectors/gcp v1.28.0/go.mod h1:9BIqH22qyHWAiZxQh0whuJygro59z+nbMVuc7ciiGug=
 go.opentelemetry.io/contrib/detectors/gcp v1.29.0/go.mod h1:GW2aWZNwR2ZxDLdv8OyC2G8zkRoQBuURgV7RPQgcPoU=
@@ -1439,6 +1452,7 @@ go.opentelemetry.io/contrib/detectors/gcp v1.32.0/go.mod h1:TVqo0Sda4Cv8gCIixd7L
 go.opentelemetry.io/contrib/detectors/gcp v1.33.0/go.mod h1:ZHrLmr4ikK2AwRj9QL+c9s2SOlgoSRyMpNVzUj2fZqI=
 go.opentelemetry.io/contrib/detectors/gcp v1.34.0/go.mod h1:cV4BMFcscUR/ckqLkbfQmF0PRsq8w/lMGzdbCSveBHo=
 go.opentelemetry.io/contrib/detectors/gcp v1.35.0/go.mod h1:qGWP8/+ILwMRIUf9uIVLloR1uo5ZYAslM4O6OqUi1DA=
+go.opentelemetry.io/contrib/detectors/gcp v1.36.0 h1:F7q2tNlCaHY9nMKHR6XH9/qkp8FktLnIcy6jJNyOCQw=
 go.opentelemetry.io/contrib/detectors/gcp v1.36.0/go.mod h1:IbBN8uAIIx734PTonTPxAxnjc2pQTxWNkwfstZ+6H2k=
 go.opentelemetry.io/contrib/detectors/gcp v1.39.0 h1:kWRNZMsfBHZ+uHjiH4y7Etn2FK26LAGkNFw7RHv1DhE=
 go.opentelemetry.io/contrib/detectors/gcp v1.39.0/go.mod h1:t/OGqzHBa5v6RHZwrDBJ2OirWc+4q/w2fTbLZwAKjTk=
@@ -1481,6 +1495,7 @@ go.opentelemetry.io/otel v1.34.0/go.mod h1:OWFPOQ+h4G8xpyjgqo4SxJYdDQ/qmRH+wivy7
 go.opentelemetry.io/otel v1.35.0/go.mod h1:UEqy8Zp11hpkUrL73gSlELM0DupHoiq72dR+Zqel/+Y=
 go.opentelemetry.io/otel v1.36.0/go.mod h1:/TcFMXYjyRNh8khOAO9ybYkqaDBb/70aVwkNML4pP8E=
 go.opentelemetry.io/otel v1.37.0/go.mod h1:ehE/umFRLnuLa/vSccNq9oS1ErUlkkK71gMcN34UG8I=
+go.opentelemetry.io/otel v1.38.0 h1:RkfdswUDRimDg0m2Az18RKOsnI8UDzppJAtj01/Ymk8=
 go.opentelemetry.io/otel v1.38.0/go.mod h1:zcmtmQ1+YmQM9wrNsTGV/q/uyusom3P8RxwExxkZhjM=
 go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.29.0/go.mod h1:BLbf7zbNIONBLPwvFnwNHGj4zge8uTCM/UPIVW1Mq2I=
 go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.35.0/go.mod h1:U2R3XyVPzn0WX7wOIypPuptulsMcPDPs/oiSVOMVnHY=
@@ -1502,6 +1517,7 @@ go.opentelemetry.io/otel/metric v1.34.0/go.mod h1:CEDrp0fy2D0MvkXE+dPV7cMi8tWZwX
 go.opentelemetry.io/otel/metric v1.35.0/go.mod h1:nKVFgxBZ2fReX6IlyW28MgZojkoAkJGaE8CpgeAU3oE=
 go.opentelemetry.io/otel/metric v1.36.0/go.mod h1:zC7Ks+yeyJt4xig9DEw9kuUFe5C3zLbVjV2PzT6qzbs=
 go.opentelemetry.io/otel/metric v1.37.0/go.mod h1:04wGrZurHYKOc+RKeye86GwKiTb9FKm1WHtO+4EVr2E=
+go.opentelemetry.io/otel/metric v1.38.0 h1:Kl6lzIYGAh5M159u9NgiRkmoMKjvbsKtYRwgfrA6WpA=
 go.opentelemetry.io/otel/metric v1.38.0/go.mod h1:kB5n/QoRM8YwmUahxvI3bO34eVtQf2i4utNVLr9gEmI=
 go.opentelemetry.io/otel/oteltest v0.20.0 h1:HiITxCawalo5vQzdHfKeZurV8x7ljcqAgiWzF6Vaeaw=
 go.opentelemetry.io/otel/oteltest v0.20.0/go.mod h1:L7bgKf9ZB7qCwT9Up7i9/pn0PWIa9FqQ2IQ8LoxiGnw=
@@ -1519,6 +1535,7 @@ go.opentelemetry.io/otel/sdk v1.34.0/go.mod h1:0e/pNiaMAqaykJGKbi+tSjWfNNHMTxoC9
 go.opentelemetry.io/otel/sdk v1.35.0/go.mod h1:+ga1bZliga3DxJ3CQGg3updiaAJoNECOgJREo9KHGQg=
 go.opentelemetry.io/otel/sdk v1.36.0/go.mod h1:+lC+mTgD+MUWfjJubi2vvXWcVxyr9rmlshZni72pXeY=
 go.opentelemetry.io/otel/sdk v1.37.0/go.mod h1:VredYzxUvuo2q3WRcDnKDjbdvmO0sCzOvVAiY+yUkAg=
+go.opentelemetry.io/otel/sdk v1.38.0 h1:l48sr5YbNf2hpCUj/FoGhW9yDkl+Ma+LrVl8qaM5b+E=
 go.opentelemetry.io/otel/sdk v1.38.0/go.mod h1:ghmNdGlVemJI3+ZB5iDEuk4bWA3GkTpW+DOoZMYBVVg=
 go.opentelemetry.io/otel/sdk/metric v1.28.0/go.mod h1:cWPjykihLAPvXKi4iZc1dpER3Jdq2Z0YLse3moQUCpg=
 go.opentelemetry.io/otel/sdk/metric v1.29.0/go.mod h1:6zZLdCl2fkauYoZIOn/soQIDSWFmNSRcICarHfuhNJQ=
@@ -1529,6 +1546,7 @@ go.opentelemetry.io/otel/sdk/metric v1.34.0/go.mod h1:jQ/r8Ze28zRKoNRdkjCZxfs6Yv
 go.opentelemetry.io/otel/sdk/metric v1.35.0/go.mod h1:is6XYCUMpcKi+ZsOvfluY5YstFnhW0BidkR+gL+qN+w=
 go.opentelemetry.io/otel/sdk/metric v1.36.0/go.mod h1:qTNOhFDfKRwX0yXOqJYegL5WRaW376QbB7P4Pb0qva4=
 go.opentelemetry.io/otel/sdk/metric v1.37.0/go.mod h1:cNen4ZWfiD37l5NhS+Keb5RXVWZWpRE+9WyVCpbo5ps=
+go.opentelemetry.io/otel/sdk/metric v1.38.0 h1:aSH66iL0aZqo//xXzQLYozmWrXxyFkBJ6qT5wthqPoM=
 go.opentelemetry.io/otel/sdk/metric v1.38.0/go.mod h1:dg9PBnW9XdQ1Hd6ZnRz689CbtrUp0wMMs9iPcgT9EZA=
 go.opentelemetry.io/otel/trace v0.20.0/go.mod h1:6GjCW8zgDjwGHGa6GkyeB8+/5vjT16gUEi0Nf1iBdgw=
 go.opentelemetry.io/otel/trace v1.21.0/go.mod h1:LGbsEB0f9LGjN+OZaQQ26sohbOmiMR+BaslueVtS/qQ=
@@ -1546,6 +1564,7 @@ go.opentelemetry.io/otel/trace v1.34.0/go.mod h1:Svm7lSjQD7kG7KJ/MUHPVXSDGz2OX4h
 go.opentelemetry.io/otel/trace v1.35.0/go.mod h1:WUk7DtFp1Aw2MkvqGdwiXYDZZNvA/1J8o6xRXLrIkyc=
 go.opentelemetry.io/otel/trace v1.36.0/go.mod h1:gQ+OnDZzrybY4k4seLzPAWNwVBBVlF2szhehOBB/tGA=
 go.opentelemetry.io/otel/trace v1.37.0/go.mod h1:TlgrlQ+PtQO5XFerSPUYG0JSgGyryXewPGyayAWSBS0=
+go.opentelemetry.io/otel/trace v1.38.0 h1:Fxk5bKrDZJUH+AMyyIXGcFAPah0oRcT+LuNtJrmcNLE=
 go.opentelemetry.io/otel/trace v1.38.0/go.mod h1:j1P9ivuFsTceSWe1oY+EeW3sc+Pp42sO++GHkg4wwhs=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.opentelemetry.io/proto/otlp v0.15.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
@@ -1558,6 +1577,7 @@ go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
+go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee h1:0mgffUl7nfd+FpvXMVz4IDEaUSmT1ysygQC7qYo7sG4=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.13.0/go.mod h1:zwrFLgMcdUuIBviXEYEH1YKNaOBnKXsx2IPda5bBwHM=
 golang.org/x/arch v0.8.0 h1:3wRIsP3pM4yUptoR96otTUOXI367OS0+c9eeRi9doIc=
@@ -1806,6 +1826,7 @@ golang.org/x/oauth2 v0.28.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT
 golang.org/x/oauth2 v0.29.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
 golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=
 golang.org/x/oauth2 v0.31.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
+golang.org/x/oauth2 v0.33.0 h1:4Q+qn+E5z8gPRJfmRy7C2gGG3T4jIprK6aSYgTXGRpo=
 golang.org/x/oauth2 v0.33.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
 golang.org/x/oauth2 v0.34.0 h1:hqK/t4AKgbqWkdkcAeI8XLmbK+4m4G5YeQRrmiotGlw=
 golang.org/x/oauth2 v0.34.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
@@ -2064,6 +2085,7 @@ gonum.org/v1/gonum v0.9.3/go.mod h1:TZumC3NeyVQskjXqmyWt4S3bINhy7B4eYwW69EbyX+0=
 gonum.org/v1/gonum v0.12.0/go.mod h1:73TDxJfAAHeA8Mk9mf8NlIppyhQNo5GLTcYeqgo2lvY=
 gonum.org/v1/gonum v0.14.0/go.mod h1:AoWeoz0becf9QMWtE8iWXNXc27fK4fNeHNf/oMejGfU=
 gonum.org/v1/gonum v0.15.1/go.mod h1:eZTZuRFrzu5pcyjN5wJhcIhnUdNijYxX1T2IcrOGY0o=
+gonum.org/v1/gonum v0.16.0 h1:5+ul4Swaf3ESvrOnidPp4GZbzf0mxVQpDCYUQE7OJfk=
 gonum.org/v1/gonum v0.16.0/go.mod h1:fef3am4MQ93R2HHpKnLk4/Tbh/s0+wqD5nfa6Pnwy4E=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0 h1:OE9mWmgKkjJyEmDAAtGMPjXu+YNeGvK9VTSHY6+Qihc=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
@@ -2245,6 +2267,7 @@ google.golang.org/genproto/googleapis/api v0.0.0-20250804133106-a7a43d27e69b/go.
 google.golang.org/genproto/googleapis/api v0.0.0-20250818200422-3122310a409c/go.mod h1:ea2MjsO70ssTfCjiwHgI0ZFqcw45Ksuk2ckf9G468GA=
 google.golang.org/genproto/googleapis/api v0.0.0-20250922171735-9219d122eba9/go.mod h1:LmwNphe5Afor5V3R5BppOULHOnt2mCIf+NxMd4XiygE=
 google.golang.org/genproto/googleapis/api v0.0.0-20251111163417-95abcf5c77ba/go.mod h1:G5IanEx8/PgI9w6CFcYQf7jMtHQhZruvfM1i3qOqk5U=
+google.golang.org/genproto/googleapis/api v0.0.0-20260120174246-409b4a993575 h1:FWSX7MpEdo8+769wkFCFqNMjLV8mDyS8EI1nIG4ysCc=
 google.golang.org/genproto/googleapis/api v0.0.0-20260120174246-409b4a993575/go.mod h1:dd646eSK+Dk9kxVBl1nChEOhJPtMXriCcVb4x3o6J+E=
 google.golang.org/genproto/googleapis/api v0.0.0-20260120221211-b8f7ae30c516 h1:vmC/ws+pLzWjj/gzApyoZuSVrDtF1aod4u/+bbj8hgM=
 google.golang.org/genproto/googleapis/api v0.0.0-20260120221211-b8f7ae30c516/go.mod h1:p3MLuOwURrGBRoEyFHBT3GjUwaCQVKeNqqWxlcISGdw=
@@ -2392,6 +2415,7 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20250922171735-9219d122eba9/go.
 google.golang.org/genproto/googleapis/rpc v0.0.0-20251103181224-f26f9409b101/go.mod h1:7i2o+ce6H/6BluujYR+kqX3GKH+dChPTQU19wjRPiGk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20251111163417-95abcf5c77ba/go.mod h1:7i2o+ce6H/6BluujYR+kqX3GKH+dChPTQU19wjRPiGk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20251222181119-0a764e51fe1b/go.mod h1:j9x/tPzZkyxcgEFkiKEEGxfvyumM01BEtsW8xzOahRQ=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260120174246-409b4a993575 h1:vzOYHDZEHIsPYYnaSYo60AqHkJronSu0rzTz/s4quL0=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260120174246-409b4a993575/go.mod h1:j9x/tPzZkyxcgEFkiKEEGxfvyumM01BEtsW8xzOahRQ=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.20.0/go.mod h1:chYK+tFQF0nDUGJgXMSgLCQk3phJEuONr2DCgLDdAQM=
@@ -2466,6 +2490,7 @@ google.golang.org/grpc v1.73.0/go.mod h1:50sbHOUqWoCQGI8V2HQLJM0B+LMlIUjNSZmow7E
 google.golang.org/grpc v1.74.2/go.mod h1:CtQ+BGjaAIXHs/5YS3i473GqwBBa1zGQNevxdeBEXrM=
 google.golang.org/grpc v1.75.0/go.mod h1:JtPAzKiq4v1xcAB2hydNlWI2RnF85XXcV0mhKXr2ecQ=
 google.golang.org/grpc v1.75.1/go.mod h1:JtPAzKiq4v1xcAB2hydNlWI2RnF85XXcV0mhKXr2ecQ=
+google.golang.org/grpc v1.76.0 h1:UnVkv1+uMLYXoIz6o7chp59WfQUYA2ex/BXQ9rHZu7A=
 google.golang.org/grpc v1.76.0/go.mod h1:Ju12QI8M6iQJtbcsV+awF5a4hfJMLi4X0JLo94ULZ6c=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0 h1:rNBFJjBCOgVr9pWD7rs/knKL4FRTKgpZmsRfV214zcA=

--- a/packages/agent/claude-sdk-sidecar/src/compaction.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/compaction.test.ts
@@ -3,16 +3,23 @@ import test from "node:test";
 import { CompactionTracker } from "./compaction.ts";
 import type { ClaudeSDKSidecarEvent } from "./protocol.ts";
 
-test("compaction failure collapses a duplicated provider reason", () => {
-  const events: ClaudeSDKSidecarEvent[] = [];
-  const tracker = new CompactionTracker({
-    activeTurnId: () => "turn-1",
+function createTracker(
+  events: ClaudeSDKSidecarEvent[],
+  activeTurnId = () => "turn-1"
+): CompactionTracker {
+  return new CompactionTracker({
+    activeTurnId,
     ensureActive: () => {},
     clearPendingOrphans: () => {},
     getQuery: () => undefined,
     getModel: () => "sonnet",
     emit: (event) => events.push(event as ClaudeSDKSidecarEvent)
   });
+}
+
+test("compaction failure collapses a duplicated provider reason", () => {
+  const events: ClaudeSDKSidecarEvent[] = [];
+  const tracker = createTracker(events);
 
   tracker.handleSystemMessage("status", { status: "compacting" });
   tracker.handleSystemMessage("status", {
@@ -24,6 +31,96 @@ test("compaction failure collapses a duplicated provider reason", () => {
   assert.equal(
     events[1]?.payload?.content,
     "Compacting failed: Not enough messages to compact."
+  );
+});
+
+test("slash compact starts a progress banner before provider signals", () => {
+  const events: ClaudeSDKSidecarEvent[] = [];
+  const tracker = createTracker(events, () => "");
+
+  tracker.selectCommand("turn-compact", true);
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0]?.type, "compact_started");
+  assert.equal(events[0]?.payload?.turnId, "turn-compact");
+});
+
+test("slash compact start is idempotent with later status compacting", () => {
+  const events: ClaudeSDKSidecarEvent[] = [];
+  const tracker = createTracker(events);
+
+  tracker.selectCommand("turn-1", true);
+  tracker.handleSystemMessage("status", { status: "compacting" });
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0]?.type, "compact_started");
+});
+
+test("camelCase compactMetadata still publishes boundary usage", () => {
+  const events: ClaudeSDKSidecarEvent[] = [];
+  const tracker = createTracker(events);
+  tracker.selectCommand("turn-1", true);
+
+  tracker.handleSystemMessage("compact_boundary", {
+    compactMetadata: {
+      trigger: "manual",
+      preTokens: 48000,
+      postTokens: 1990
+    }
+  });
+
+  assert.equal(
+    events.some((event) => event.type === "compact_completed"),
+    true
+  );
+  const usage = events.find((event) => event.type === "usage_updated");
+  assert.deepEqual(usage?.payload?.contextWindow, {
+    usedTokens: 1990,
+    lastUsedTokens: 48000
+  });
+});
+
+test("local_command stdout marks compact failure before turn settle", () => {
+  const events: ClaudeSDKSidecarEvent[] = [];
+  const tracker = createTracker(events);
+  tracker.selectCommand("turn-1", true);
+
+  tracker.handleSystemMessage("local_command", {
+    content:
+      "<local-command-stdout>Not enough messages to compact.</local-command-stdout>"
+  });
+
+  assert.equal(
+    events.find((event) => event.type === "compact_failed")?.payload?.reason,
+    "Not enough messages to compact."
+  );
+});
+
+test("local_command_output Compacted completes the slash compact banner", () => {
+  const events: ClaudeSDKSidecarEvent[] = [];
+  const tracker = createTracker(events);
+  tracker.selectCommand("turn-1", true);
+
+  tracker.handleSystemMessage("local_command_output", {
+    content: "Compacted "
+  });
+
+  assert.equal(
+    events.some((event) => event.type === "compact_completed"),
+    true
+  );
+});
+
+test("assistant failure copy during slash compact emits compact_failed", () => {
+  const events: ClaudeSDKSidecarEvent[] = [];
+  const tracker = createTracker(events);
+  tracker.selectCommand("turn-1", true);
+
+  tracker.noteAssistantText("Not enough messages to compact.");
+
+  assert.equal(
+    events.find((event) => event.type === "compact_failed")?.payload?.reason,
+    "Not enough messages to compact."
   );
 });
 

--- a/packages/agent/claude-sdk-sidecar/src/compaction.ts
+++ b/packages/agent/claude-sdk-sidecar/src/compaction.ts
@@ -10,9 +10,15 @@ type ContextUsageQuery = {
 
 export type ContextUsageSnapshotResult = "emitted" | "unavailable" | "stale";
 
+const LOCAL_COMMAND_STDOUT_PATTERN =
+  /<local-command-stdout>([\s\S]*?)<\/local-command-stdout>/iu;
+const COMPACT_FAILURE_PATTERN = /not enough|fail|error/iu;
+const COMPACT_SUCCESS_PATTERN = /^compacted\b/iu;
+
 export class CompactionTracker {
   private inProgress = false;
   private commandTurnId = "";
+  private readonly startedTurnIds = new Set<string>();
   private readonly completedTurnIds = new Set<string>();
   private readonly activeTurnId: () => string;
   private readonly ensureActive: (messageType: string) => void;
@@ -39,7 +45,17 @@ export class CompactionTracker {
   }
 
   selectCommand(turnId: string, isCompact: boolean): void {
-    this.commandTurnId = isCompact ? turnId : "";
+    if (!isCompact) {
+      this.commandTurnId = "";
+      return;
+    }
+    // Claude Code 2.1.x frequently finishes /compact without streaming
+    // status:compacting or compact_boundary to the query iterator (the
+    // boundary may exist only in the on-disk transcript). Emit the progress
+    // banner immediately so the daemon can settle it when the turn closes,
+    // matching the Codex silent-compact path.
+    this.commandTurnId = turnId;
+    this.emitStarted(turnId);
   }
 
   handleSystemMessage(
@@ -49,6 +65,9 @@ export class CompactionTracker {
     if (subtype === "status") {
       return this.handleStatus(message);
     }
+    if (subtype === "local_command" || subtype === "local_command_output") {
+      return this.handleLocalCommandOutput(message);
+    }
     if (subtype !== "compact_boundary") {
       return false;
     }
@@ -57,6 +76,24 @@ export class CompactionTracker {
     this.emitBoundaryUsage(message, turnId);
     this.emitBoundaryCompletion();
     return true;
+  }
+
+  /**
+   * Claude 2.1.x may surface compact failures as assistant-style text (or as
+   * a result fallback) instead of status/compact_result. When a slash
+   * /compact turn is live, treat known failure copy as compact_failed so the
+   * daemon does not settle the progress banner as "completed" on a successful
+   * result subtype.
+   */
+  noteAssistantText(content: string): void {
+    const text = collapseRepeatedText(content);
+    if (!text || !this.isLiveCommandTurn()) {
+      return;
+    }
+    if (!COMPACT_FAILURE_PATTERN.test(text)) {
+      return;
+    }
+    this.emitFailed(this.eventTurnId(), text);
   }
 
   async emitContextUsageSnapshot(
@@ -109,38 +146,43 @@ export class CompactionTracker {
     if (message.status === "compacting") {
       this.ensureActive("compact_status");
       this.clearPendingOrphans();
-      this.inProgress = true;
-      this.emit({
-        type: "compact_started",
-        payload: {
-          turnId: this.activeTurnId(),
-          content: "Compacting..."
-        }
-      });
+      this.emitStarted(this.activeTurnId() || this.commandTurnId);
       return true;
     }
     const compactResult = stringValue(message.compact_result);
     if (compactResult === "success" && this.inProgress) {
-      this.inProgress = false;
       const turnId = this.eventTurnId();
       this.emitCompleted(turnId, "Compacting completed.");
       void this.emitContextUsageSnapshot(turnId);
       return true;
     }
     if (compactResult === "failed" && this.inProgress) {
-      this.inProgress = false;
-      const turnId = this.activeTurnId();
+      const turnId = this.activeTurnId() || this.commandTurnId;
       const reason = collapseRepeatedText(stringValue(message.compact_error));
-      this.emit({
-        type: "compact_failed",
-        payload: {
-          turnId,
-          reason,
-          content: reason
-            ? `Compacting failed: ${reason}`
-            : "Compacting failed."
-        }
-      });
+      this.emitFailed(turnId, reason);
+      return true;
+    }
+    return false;
+  }
+
+  private handleLocalCommandOutput(message: Record<string, unknown>): boolean {
+    if (!this.isLiveCommandTurn()) {
+      return false;
+    }
+    const stdout = localCommandStdout(message);
+    if (!stdout) {
+      return false;
+    }
+    const turnId = this.eventTurnId();
+    if (COMPACT_FAILURE_PATTERN.test(stdout)) {
+      this.ensureActive("compact_local_command");
+      this.emitFailed(turnId, stdout);
+      return true;
+    }
+    if (COMPACT_SUCCESS_PATTERN.test(stdout)) {
+      this.ensureActive("compact_local_command");
+      this.emitCompleted(turnId, "Compacting completed.");
+      void this.emitContextUsageSnapshot(turnId);
       return true;
     }
     return false;
@@ -150,9 +192,11 @@ export class CompactionTracker {
     message: Record<string, unknown>,
     turnId: string
   ): void {
-    const metadata = recordValue(message.compact_metadata);
-    const postTokens = numberValue(metadata?.post_tokens);
-    const preTokens = numberValue(metadata?.pre_tokens);
+    const metadata = compactBoundaryMetadata(message);
+    const postTokens = numberValue(
+      metadata?.post_tokens ?? metadata?.postTokens
+    );
+    const preTokens = numberValue(metadata?.pre_tokens ?? metadata?.preTokens);
     if (postTokens > 0 && turnId) {
       emitUsageUpdated(this.emit, turnId, {
         contextWindow: {
@@ -172,21 +216,91 @@ export class CompactionTracker {
     if (!this.inProgress && turnId !== this.commandTurnId) {
       return;
     }
-    this.inProgress = false;
     this.emitCompleted(turnId, "Compacting completed.");
   }
 
-  private emitCompleted(turnId: string, content: string): void {
-    if (!turnId || this.completedTurnIds.has(turnId)) {
+  private emitStarted(turnId: string): void {
+    const normalized = turnId.trim();
+    if (
+      !normalized ||
+      this.startedTurnIds.has(normalized) ||
+      this.completedTurnIds.has(normalized)
+    ) {
       return;
     }
-    this.completedTurnIds.add(turnId);
-    this.emit({ type: "compact_completed", payload: { turnId, content } });
+    this.startedTurnIds.add(normalized);
+    this.inProgress = true;
+    this.emit({
+      type: "compact_started",
+      payload: {
+        turnId: normalized,
+        content: "Compacting..."
+      }
+    });
+  }
+
+  private emitCompleted(turnId: string, content: string): void {
+    const normalized = turnId.trim();
+    if (!normalized || this.completedTurnIds.has(normalized)) {
+      return;
+    }
+    this.completedTurnIds.add(normalized);
+    this.inProgress = false;
+    if (normalized === this.commandTurnId) {
+      this.commandTurnId = "";
+    }
+    this.emit({
+      type: "compact_completed",
+      payload: { turnId: normalized, content }
+    });
+  }
+
+  private emitFailed(turnId: string, reason: string): void {
+    const normalized = turnId.trim();
+    if (!normalized || this.completedTurnIds.has(normalized)) {
+      return;
+    }
+    this.completedTurnIds.add(normalized);
+    this.inProgress = false;
+    if (normalized === this.commandTurnId) {
+      this.commandTurnId = "";
+    }
+    this.emit({
+      type: "compact_failed",
+      payload: {
+        turnId: normalized,
+        reason,
+        content: reason ? `Compacting failed: ${reason}` : "Compacting failed."
+      }
+    });
+  }
+
+  private isLiveCommandTurn(): boolean {
+    if (!this.commandTurnId || this.completedTurnIds.has(this.commandTurnId)) {
+      return false;
+    }
+    return this.inProgress || this.startedTurnIds.has(this.commandTurnId);
   }
 
   private eventTurnId(): string {
     return this.activeTurnId() || this.commandTurnId;
   }
+}
+
+function compactBoundaryMetadata(
+  message: Record<string, unknown>
+): Record<string, unknown> | null {
+  return (
+    recordValue(message.compact_metadata) ||
+    recordValue(message.compactMetadata) ||
+    null
+  );
+}
+
+function localCommandStdout(message: Record<string, unknown>): string {
+  const content = stringValue(message.content);
+  const match = LOCAL_COMMAND_STDOUT_PATTERN.exec(content);
+  return collapseRepeatedText((match?.[1] ?? content).trim());
 }
 
 export function collapseRepeatedText(value: string): string {

--- a/packages/agent/claude-sdk-sidecar/src/interactive.ts
+++ b/packages/agent/claude-sdk-sidecar/src/interactive.ts
@@ -5,7 +5,10 @@ import type {
   PermissionUpdate
 } from "@anthropic-ai/claude-agent-sdk";
 import { isDeepStrictEqual } from "node:util";
-import { answersFromInteractivePayload } from "./normalizer.ts";
+import {
+  answersFromInteractivePayload,
+  stampAskUserQuestionInput
+} from "./normalizer.ts";
 import type { ClaudeSDKSidecarEventEmitter } from "./protocol.ts";
 import type { ProviderTurnPhase } from "./providerTurnAcceptance.ts";
 import { stringValue } from "./runtimeValues.ts";
@@ -198,10 +201,11 @@ export class InteractiveCoordinator {
     toolInput: Record<string, unknown>,
     callbackOptions: ToolPermissionOptions
   ): Promise<PermissionResult> {
+    const stampedInput = stampAskUserQuestionInput(toolInput);
     const submission = await this.request(
       "user_input_requested",
       "AskUserQuestion",
-      toolInput,
+      stampedInput,
       [],
       callbackOptions
     );
@@ -209,8 +213,8 @@ export class InteractiveCoordinator {
     return {
       behavior: "allow",
       updatedInput: {
-        questions: toolInput.questions,
-        answers: answersFromInteractivePayload(submission.payload, toolInput)
+        questions: stampedInput.questions,
+        answers: answersFromInteractivePayload(submission.payload, stampedInput)
       }
     };
   }

--- a/packages/agent/claude-sdk-sidecar/src/messageProjection.ts
+++ b/packages/agent/claude-sdk-sidecar/src/messageProjection.ts
@@ -143,6 +143,7 @@ export class MessageProjection {
     if (block.type === "text") {
       if (!parentToolUseID) {
         const content = stringValue(block.text);
+        this.compaction.noteAssistantText(content);
         if (failed) {
           this.assistant.failContent(
             "assistant",

--- a/packages/agent/claude-sdk-sidecar/src/normalizer.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/normalizer.test.ts
@@ -5,6 +5,7 @@ import {
   commandEntries,
   sdkContentFromPromptBlocks,
   speedFromFastModeState,
+  stampAskUserQuestionInput,
   toolPayload
 } from "./normalizer.ts";
 
@@ -353,7 +354,7 @@ test("answersFromInteractivePayload keys answers by question text for Claude SDK
         answers: ["React", "UI, daemon"],
         answersByQuestionId: {
           "framework-id": "React",
-          "question-2": ["UI", "daemon"]
+          "contract-question-x5nn4u": ["UI", "daemon"]
         }
       },
       {
@@ -374,6 +375,81 @@ test("answersFromInteractivePayload keys answers by question text for Claude SDK
     {
       "Which framework?": "React",
       "Which areas?": "UI, daemon"
+    }
+  );
+});
+
+test("stampAskUserQuestionInput fills missing question ids at Tutti ingress", () => {
+  assert.deepEqual(
+    stampAskUserQuestionInput({
+      questions: [
+        {
+          header: "I05 Choice",
+          multiSelect: false,
+          options: [
+            { description: "First preset option", label: "Preset one" },
+            { description: "Second preset option", label: "Preset two" }
+          ],
+          question: "What custom deterministic answer should I record?"
+        },
+        {
+          id: "kept-id",
+          question: "Already identified?"
+        }
+      ]
+    }),
+    {
+      questions: [
+        {
+          header: "I05 Choice",
+          multiSelect: false,
+          options: [
+            { description: "First preset option", label: "Preset one" },
+            { description: "Second preset option", label: "Preset two" }
+          ],
+          question: "What custom deterministic answer should I record?",
+          id: "contract-question-weuao6"
+        },
+        {
+          id: "kept-id",
+          question: "Already identified?"
+        }
+      ]
+    }
+  );
+});
+
+test("answersFromInteractivePayload maps answers after ingress question ids are stamped", () => {
+  const stamped = stampAskUserQuestionInput({
+    questions: [
+      {
+        header: "I05 Choice",
+        multiSelect: false,
+        options: [
+          { description: "First preset option", label: "Preset one" },
+          { description: "Second preset option", label: "Preset two" }
+        ],
+        question: "What custom deterministic answer should I record?"
+      }
+    ]
+  });
+  assert.equal(
+    (stamped.questions as Array<Record<string, unknown>>)[0]?.id,
+    "contract-question-weuao6"
+  );
+  assert.deepEqual(
+    answersFromInteractivePayload(
+      {
+        answers: ["Tutti I05 custom answer"],
+        answersByQuestionId: {
+          "contract-question-weuao6": "Tutti I05 custom answer"
+        }
+      },
+      stamped
+    ),
+    {
+      "What custom deterministic answer should I record?":
+        "Tutti I05 custom answer"
     }
   );
 });

--- a/packages/agent/claude-sdk-sidecar/src/normalizer.ts
+++ b/packages/agent/claude-sdk-sidecar/src/normalizer.ts
@@ -289,6 +289,39 @@ export function answersFromInteractivePayload(
   return answers ?? {};
 }
 
+/**
+ * Claude AskUserQuestion has no question.id in its schema. Stamp Tutti-owned
+ * `contract-question-<hash>` ids at ingress (same algorithm as
+ * askUserQuestions.ts) so GUI answer keys and sidecar lookup share one
+ * contract instead of the renderer hashing while lookup expects `question-N`.
+ */
+export function stampAskUserQuestionInput(
+  toolInput: Record<string, unknown>
+): Record<string, unknown> {
+  const questions = Array.isArray(toolInput.questions)
+    ? toolInput.questions
+    : null;
+  if (!questions) {
+    return toolInput;
+  }
+  return {
+    ...toolInput,
+    questions: questions.map((value) => {
+      const question = recordValue(value);
+      if (!question) {
+        return value;
+      }
+      if (stringValue(question.id)) {
+        return question;
+      }
+      return {
+        ...question,
+        id: askUserContractId("question", question)
+      };
+    })
+  };
+}
+
 function answersByQuestionText(
   answersByQuestionId: Record<string, unknown>,
   toolInput?: Record<string, unknown>
@@ -300,22 +333,37 @@ function answersByQuestionText(
     return answersByQuestionId;
   }
   const answers: Record<string, unknown> = {};
-  questions.forEach((value, index) => {
+  questions.forEach((value) => {
     const question = recordValue(value);
     const questionText = stringValue(question?.question);
     if (!questionText) {
       return;
     }
-    const key = firstNonEmptyString(
-      stringValue(question?.id),
-      `question-${index + 1}`
-    );
+    const key =
+      stringValue(question?.id) || askUserContractId("question", question);
     if (!Object.hasOwn(answersByQuestionId, key)) {
       return;
     }
     answers[questionText] = sdkAnswerValue(answersByQuestionId[key]);
   });
   return answers;
+}
+
+/**
+ * Must stay byte-compatible with
+ * packages/agent/gui/shared/agentConversation/askUserQuestions.ts
+ * `askUserContractId` so ingress stamps match renderer-synthesized ids.
+ */
+function askUserContractId(
+  scope: "question" | "option",
+  value: unknown
+): string {
+  let hash = 0x811c9dc5;
+  for (const character of JSON.stringify(value)) {
+    hash ^= character.codePointAt(0) ?? 0;
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return `contract-${scope}-${(hash >>> 0).toString(36)}`;
 }
 
 function sdkAnswerValue(value: unknown): unknown {
@@ -326,15 +374,6 @@ function sdkAnswerValue(value: unknown): unknown {
       .join(", ");
   }
   return value;
-}
-
-function firstNonEmptyString(...values: Array<string | undefined>): string {
-  for (const value of values) {
-    if (value) {
-      return value;
-    }
-  }
-  return "";
 }
 
 function toolDisplayName(toolName: string): string {

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.session.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.session.test.ts
@@ -18,7 +18,9 @@ import {
   fakeDeferredContextUsageQuery,
   fakeFailedCompactQuery,
   fakeGuidancePromptQuery,
+  fakeLocalCommandFailedCompactQuery,
   fakePermissionCheckQuery,
+  fakeSilentCompactQuery,
   fakeStatusOnlyCompactQuery
 } from "./sessionRuntimeTestQueries.session.ts";
 import { waitForEvent } from "./sessionRuntimeTestQueries.nested.ts";
@@ -2091,6 +2093,100 @@ test("compact failure preserves the status reason and assistant response", async
   }
 });
 
+test("silent slash compact still emits a progress banner before result", async () => {
+  // Real Claude Code 2.1.x can finish /compact with only result + getContextUsage
+  // and never stream status:compacting or compact_boundary to the query
+  // iterator. Without an immediate compact_started, AgentGUI shows only the
+  // turn duration footer and no compaction divider.
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) => fakeSilentCompactQuery(prompt)
+    );
+
+    await session.start();
+    session.exec("turn-silent-compact", "/compact");
+    await waitForEvent(events, "compact_started");
+    await waitForEvent(events, "turn_completed");
+
+    assert.equal(
+      events.find((event) => event.type === "compact_started")?.payload?.turnId,
+      "turn-silent-compact"
+    );
+    const usage = events.find(
+      (event) =>
+        event.type === "usage_updated" && isRecord(event.payload?.contextWindow)
+    );
+    assert.equal(usage?.payload?.turnId, "turn-silent-compact");
+    assert.equal(
+      (usage?.payload?.contextWindow as { usedTokens?: number } | undefined)
+        ?.usedTokens,
+      1_990
+    );
+  } finally {
+    restoreSink();
+  }
+});
+
+test("local_command compact failure still emits compact_failed", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) => fakeLocalCommandFailedCompactQuery(prompt)
+    );
+
+    await session.start();
+    session.exec("turn-local-command-failed", "/compact");
+    await waitForEvent(events, "compact_failed");
+    await waitForEvent(events, "turn_completed");
+
+    assert.equal(
+      events.find((event) => event.type === "compact_failed")?.payload?.reason,
+      "Not enough messages to compact."
+    );
+    assert.equal(
+      events.find((event) => event.type === "compact_started")?.payload?.turnId,
+      "turn-local-command-failed"
+    );
+  } finally {
+    restoreSink();
+  }
+});
+
 test("bypass permission mode allows ordinary tools without approval", async () => {
   const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
   const restoreSink = withSidecarEventSinkForTest((event) =>
@@ -2193,6 +2289,10 @@ test("bypass permission mode still surfaces AskUserQuestion", async () => {
     const request = events.find(
       (event) => event.type === "user_input_requested"
     );
+    const requestQuestions = (
+      request?.payload?.input as { questions?: Array<Record<string, unknown>> }
+    )?.questions;
+    assert.equal(requestQuestions?.[0]?.id, "contract-question-1412lhw");
     session.submitInteractive(
       "turn-1",
       String(request?.payload?.requestId ?? ""),
@@ -2200,7 +2300,7 @@ test("bypass permission mode still surfaces AskUserQuestion", async () => {
       "Yes",
       {
         answers: ["Yes"],
-        answersByQuestionId: { "question-1": "Yes" }
+        answersByQuestionId: { "contract-question-1412lhw": "Yes" }
       }
     );
     await waitForEvent(events, "turn_completed");
@@ -2216,7 +2316,8 @@ test("bypass permission mode still surfaces AskUserQuestion", async () => {
           {
             header: "Confirm",
             question: "Delete everything?",
-            options: [{ label: "Yes", description: "Delete files" }]
+            options: [{ label: "Yes", description: "Delete files" }],
+            id: "contract-question-1412lhw"
           }
         ],
         answers: { "Delete everything?": "Yes" }

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntimeTestQueries.session.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntimeTestQueries.session.ts
@@ -265,6 +265,81 @@ export function fakeFailedCompactQuery(
   } as AsyncIterable<SDKMessage>;
 }
 
+// Claude Code 2.1.x often finishes a successful manual /compact with only a
+// result (plus an on-disk compact_boundary that never reaches the query
+// iterator). The progress banner must come from selectCommand, and the daemon
+// settles it when turn_completed arrives.
+export function fakeSilentCompactQuery(
+  prompt: AsyncIterable<SDKUserMessage>
+): AsyncIterable<SDKMessage> & {
+  getContextUsage: () => Promise<unknown>;
+  close: () => void;
+} {
+  return {
+    async *[Symbol.asyncIterator]() {
+      const firstPrompt = await prompt[Symbol.asyncIterator]().next();
+      const promptMessage = firstPrompt.value as SDKUserMessage & {
+        uuid?: string;
+      };
+      yield {
+        ...promptMessage,
+        uuid: promptMessage.uuid,
+        type: "user",
+        parent_tool_use_id: null,
+        session_id: "provider-session-1"
+      } as SDKMessage;
+      yield {
+        type: "result",
+        subtype: "success"
+      } as unknown as SDKMessage;
+    },
+    async getContextUsage() {
+      return {
+        totalTokens: 1_990,
+        maxTokens: 200_000,
+        rawMaxTokens: 200_000
+      };
+    },
+    close() {}
+  };
+}
+
+// Mirrors Claude Code 2.1.x compact failure: local_command stdout instead of
+// status/compact_result, with a successful result subtype.
+export function fakeLocalCommandFailedCompactQuery(
+  prompt: AsyncIterable<SDKUserMessage>
+): AsyncIterable<SDKMessage> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      const firstPrompt = await prompt[Symbol.asyncIterator]().next();
+      const promptMessage = firstPrompt.value as SDKUserMessage & {
+        uuid?: string;
+      };
+      yield {
+        ...promptMessage,
+        uuid: promptMessage.uuid,
+        type: "user",
+        parent_tool_use_id: null,
+        session_id: "provider-session-1"
+      } as SDKMessage;
+      yield {
+        type: "system",
+        subtype: "local_command",
+        content:
+          "<local-command-stdout>Not enough messages to compact.</local-command-stdout>"
+      } as unknown as SDKMessage;
+      yield consolidatedAssistant("assistant-compact-failed", "msg-compact", [
+        { type: "text", text: "Not enough messages to compact." }
+      ]);
+      yield {
+        type: "result",
+        subtype: "success"
+      } as unknown as SDKMessage;
+    },
+    close() {}
+  } as AsyncIterable<SDKMessage>;
+}
+
 export function fakePermissionCheckQuery(
   prompt: AsyncIterable<SDKUserMessage>,
   options: ClaudeQueryOptions,

--- a/packages/agent/daemon/runtime/claude_sdk_acceptance_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_acceptance_test.go
@@ -3,11 +3,211 @@ package agentruntime
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
+
+func TestClaudeSDKProviderAcceptanceHoldsCompactBannerUntilIdentity(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	conn := newBlockingClaudeSDKConnection()
+	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, conn)
+	adapterSession.providerSessionID = session.ProviderSessionID
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	emitted := make(chan activityshared.Event, 32)
+	barrierEntered := make(chan ProviderAcceptanceReceipt, 1)
+	execDone := make(chan error, 1)
+	go func() {
+		_, err := adapter.ExecWithProviderAcceptance(
+			ctx,
+			session,
+			[]PromptContentBlock{{Type: "text", Text: "/compact"}},
+			"/compact",
+			"turn-compact",
+			func(events []activityshared.Event) {
+				for _, event := range events {
+					emitted <- event
+				}
+			},
+			nil,
+			func(ProviderDispatchResult) {},
+			func(receipt ProviderAcceptanceReceipt) error {
+				barrierEntered <- receipt
+				return nil
+			},
+		)
+		execDone <- err
+	}()
+
+	waitForClaudeSDKSentRequest(t, conn, "exec")
+	select {
+	case event := <-emitted:
+		t.Fatalf("event %q escaped before durable acceptance", event.Type)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	conn.pushEvent(claudeSDKSidecarEvent{
+		Type: "compact_started",
+		Payload: map[string]any{
+			"turnId":  "turn-compact",
+			"content": "Compacting...",
+		},
+	})
+	select {
+	case event := <-emitted:
+		t.Fatalf("compact banner %q escaped before durable acceptance", event.Type)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	conn.pushEvent(claudeSDKSidecarEvent{
+		Type: "provider_turn_identity_resolved",
+		Payload: map[string]any{
+			"turnId":         "turn-compact",
+			"providerTurnId": "provider-compact",
+		},
+	})
+	select {
+	case <-barrierEntered:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for acceptance barrier")
+	}
+
+	var sawCompactRunning bool
+	var compactUnit *activityshared.ProviderInputUnitContext
+	var identityUnit *activityshared.ProviderInputUnitContext
+	deadline := time.After(2 * time.Second)
+	for !sawCompactRunning {
+		select {
+		case event := <-emitted:
+			if event.Type == activityshared.EventRootProviderTurnStarted &&
+				strings.TrimSpace(event.Payload.TurnID) == "turn-compact" {
+				identityUnit = event.ProviderInputUnit
+			}
+			if event.Type == activityshared.EventMessageAppended &&
+				payloadString(event.Payload.Metadata, "noticeCommand") == "compact" &&
+				payloadString(event.Payload.Metadata, "noticeCommandStatus") == "running" {
+				sawCompactRunning = true
+				compactUnit = event.ProviderInputUnit
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for held compact banner after acceptance")
+		}
+	}
+	if identityUnit != nil && compactUnit != nil && *identityUnit != *compactUnit {
+		t.Fatalf(
+			"flushed compact ProviderInputUnit=%#v, want acceptance unit %#v",
+			compactUnit,
+			identityUnit,
+		)
+	}
+
+	conn.pushEvent(claudeSDKSidecarEvent{
+		Type: "turn_completed",
+		Payload: map[string]any{
+			"turnId":         "turn-compact",
+			"providerTurnId": "provider-compact",
+			"stopReason":     "end_turn",
+		},
+	})
+	select {
+	case err := <-execDone:
+		if err != nil {
+			t.Fatalf("ExecWithProviderAcceptance: %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for turn completion")
+	}
+}
+
+func TestClaudeSDKEventMayPrecedeProviderAcceptanceAllowsCompactNotice(t *testing.T) {
+	t.Parallel()
+
+	session := standardTestSession(ProviderClaudeCode)
+	compact := claudeSDKCompactMessageEvent(
+		session,
+		"turn-compact",
+		"claude-sdk:compact:turn-compact",
+		messageStreamStateStreaming,
+		"running",
+		"",
+	)
+	if !claudeSDKEventMayPrecedeProviderAcceptance(compact) {
+		t.Fatalf("compact notice must be holdable before provider acceptance: %#v", compact)
+	}
+	if !claudeSDKEventsMayPrecedeProviderAcceptance([]activityshared.Event{compact}) {
+		t.Fatal("compact-only batch must precede provider acceptance")
+	}
+	if !isClaudeSDKCompactPrompt(
+		[]PromptContentBlock{{Type: "text", Text: "/compact"}},
+		"/compact",
+	) {
+		t.Fatal("expected /compact prompt detection")
+	}
+}
+
+func TestRestampClaudeSDKHeldEventsOntoAcceptanceUnit(t *testing.T) {
+	t.Parallel()
+
+	acceptance := &activityshared.ProviderInputUnitContext{
+		ConnectionID: "connection-1",
+		ChunkSeq:     62,
+		UnitIndex:    1,
+		EventIndex:   1,
+		UnitKind:     "protocol-message",
+	}
+	early := &activityshared.ProviderInputUnitContext{
+		ConnectionID: "connection-1",
+		ChunkSeq:     53,
+		UnitIndex:    1,
+		EventIndex:   1,
+		UnitKind:     "protocol-message",
+	}
+	held := []activityshared.Event{
+		{
+			Type:              activityshared.EventMessageAppended,
+			ProviderInputUnit: early,
+		},
+		{
+			Type: activityshared.EventTurnStarted,
+		},
+	}
+	restamped := restampClaudeSDKHeldEventsOntoAcceptanceUnit(held, acceptance)
+	if len(restamped) != 2 {
+		t.Fatalf("restamped=%#v", restamped)
+	}
+	for index, event := range restamped {
+		if event.ProviderInputUnit == nil ||
+			*event.ProviderInputUnit != *acceptance {
+			t.Fatalf(
+				"event[%d] ProviderInputUnit=%#v, want acceptance unit %#v",
+				index,
+				event.ProviderInputUnit,
+				acceptance,
+			)
+		}
+	}
+	if held[0].ProviderInputUnit == nil || *held[0].ProviderInputUnit != *early {
+		t.Fatalf("restamp mutated the held slice: %#v", held[0].ProviderInputUnit)
+	}
+	identity := []activityshared.Event{{
+		Type: activityshared.EventRootProviderTurnStarted,
+		Payload: activityshared.EventPayload{
+			TurnID:         "turn-compact",
+			ProviderTurnID: "provider-compact",
+		},
+		ProviderInputUnit: acceptance,
+	}}
+	if got := claudeSDKAcceptanceProviderInputUnit(identity, "turn-compact"); got == nil ||
+		*got != *acceptance {
+		t.Fatalf("acceptance unit=%#v, want %#v", got, acceptance)
+	}
+}
 
 func TestClaudeSDKProviderAcceptanceReportsPreDispatchFailures(t *testing.T) {
 	t.Parallel()

--- a/packages/agent/daemon/runtime/claude_sdk_execution.go
+++ b/packages/agent/daemon/runtime/claude_sdk_execution.go
@@ -84,6 +84,22 @@ func (a *ClaudeCodeSDKAdapter) exec(
 	if event, ok := adapterSession.mirrorGoalSlashPrompt(session, visibleText); ok {
 		startEvents = append(startEvents, event)
 	}
+	// Emit the compacting banner up front (same rationale as Codex silent
+	// compact): Claude frequently finishes /compact without streaming
+	// status/boundary to the query iterator, and even when the sidecar emits
+	// compact_started immediately it arrives before provider-turn acceptance.
+	if isClaudeSDKCompactPrompt(content, visibleText) {
+		if compact, ok := a.compactMessageEvent(
+			adapterSession,
+			session,
+			turnID,
+			messageStreamStateStreaming,
+			"running",
+			"",
+		); ok {
+			startEvents = append(startEvents, compact)
+		}
+	}
 	emitEvents(a.stampTurnLifecycleSnapshots(adapterSession, startEvents))
 
 	providerContent, err := materializeProviderPromptImagesAtBoundary(ctx, content, a.promptImageMaterializer)
@@ -240,8 +256,21 @@ func (a *ClaudeCodeSDKAdapter) ExecWithProviderAcceptance(
 		}
 		if emit != nil {
 			if len(pendingEvents) > 0 {
+				// acceptProviderTurn already recorded Replay observations at the
+				// acceptance ProviderInputUnit (turn.working). Held pre-acceptance
+				// events still carry their earlier frame units (e.g. compact_started
+				// before identity). Emitting them unchanged regresses the provider
+				// cursor and fails checkpoint plan writes. Reanchor onto the
+				// acceptance unit so they coalesce with that checkpoint.
+				acceptanceUnit := claudeSDKAcceptanceProviderInputUnit(events, turnID)
 				published := make([]activityshared.Event, 0, len(pendingEvents)+len(events))
-				published = append(published, pendingEvents...)
+				published = append(
+					published,
+					restampClaudeSDKHeldEventsOntoAcceptanceUnit(
+						pendingEvents,
+						acceptanceUnit,
+					)...,
+				)
 				published = append(published, events...)
 				pendingEvents = nil
 				emit(published)
@@ -305,6 +334,40 @@ func (a *ClaudeCodeSDKAdapter) ExecWithProviderAcceptance(
 	return events, err
 }
 
+func claudeSDKAcceptanceProviderInputUnit(
+	events []activityshared.Event,
+	turnID string,
+) *activityshared.ProviderInputUnitContext {
+	turnID = strings.TrimSpace(turnID)
+	for index := range events {
+		event := events[index]
+		if event.Type != activityshared.EventRootProviderTurnStarted ||
+			strings.TrimSpace(event.Payload.TurnID) != turnID ||
+			event.ProviderInputUnit == nil {
+			continue
+		}
+		unit := *event.ProviderInputUnit
+		return &unit
+	}
+	return nil
+}
+
+func restampClaudeSDKHeldEventsOntoAcceptanceUnit(
+	events []activityshared.Event,
+	acceptanceUnit *activityshared.ProviderInputUnitContext,
+) []activityshared.Event {
+	if len(events) == 0 || acceptanceUnit == nil {
+		return events
+	}
+	restamped := make([]activityshared.Event, len(events))
+	copy(restamped, events)
+	for index := range restamped {
+		unit := *acceptanceUnit
+		restamped[index].ProviderInputUnit = &unit
+	}
+	return restamped
+}
+
 func claudeSDKEventsMayPrecedeProviderAcceptance(
 	events []activityshared.Event,
 ) bool {
@@ -312,19 +375,37 @@ func claudeSDKEventsMayPrecedeProviderAcceptance(
 		return true
 	}
 	for _, event := range events {
-		if event.Type == EventTurnStarted {
-			continue
+		if !claudeSDKEventMayPrecedeProviderAcceptance(event) {
+			return false
 		}
-		if event.Type == activityshared.EventMessageAppended &&
-			strings.EqualFold(
-				strings.TrimSpace(string(event.Payload.Role)),
-				"user",
-			) {
-			continue
-		}
-		return false
 	}
 	return true
+}
+
+func claudeSDKEventMayPrecedeProviderAcceptance(event activityshared.Event) bool {
+	if event.Type == EventTurnStarted {
+		return true
+	}
+	if event.Type != activityshared.EventMessageAppended {
+		return false
+	}
+	if strings.EqualFold(
+		strings.TrimSpace(string(event.Payload.Role)),
+		"user",
+	) {
+		return true
+	}
+	// Slash /compact progress banners are emitted as soon as exec is selected,
+	// often before Claude persists a provider Turn identity. Hold them like the
+	// local user prompt instead of treating them as premature provider output.
+	command := strings.TrimSpace(payloadString(event.Payload.Metadata, "noticeCommand"))
+	source := strings.TrimSpace(payloadString(event.Payload.Metadata, "source"))
+	return command == "compact" || source == "compact"
+}
+
+func isClaudeSDKCompactPrompt(content []PromptContentBlock, visibleText string) bool {
+	prompt := strings.ToLower(strings.TrimSpace(promptTextForClaudeSDK(content, visibleText)))
+	return prompt == "/compact" || strings.HasPrefix(prompt, "/compact ")
 }
 
 func claudeSDKEventsContainTurnFailed(events []activityshared.Event) bool {

--- a/packages/agent/daemon/runtime/report_coalescer.go
+++ b/packages/agent/daemon/runtime/report_coalescer.go
@@ -152,7 +152,16 @@ func (c *streamingReportCoalescer) stopTimer() {
 }
 
 func isCoalescibleStreamingReport(report agentsessionstore.ReportActivityInput) bool {
-	if len(report.TimelineItems) > 0 || len(report.StatePatches) > 0 || len(report.SessionAudits) > 0 || len(report.GoalReconcileRequests) > 0 || len(report.MessageUpdates) == 0 {
+	// ProviderObservations mint checkpoint candidates before enqueue. Coalescing
+	// only merges MessageUpdates, so a later observation-bearing report would
+	// drop its batches and leave checkpoint_commit_unconfirmed on publish
+	// (I10 child Bash tool.started after pending assistant streaming).
+	if len(report.TimelineItems) > 0 ||
+		len(report.StatePatches) > 0 ||
+		len(report.SessionAudits) > 0 ||
+		len(report.GoalReconcileRequests) > 0 ||
+		len(report.ProviderObservations) > 0 ||
+		len(report.MessageUpdates) == 0 {
 		return false
 	}
 	for _, update := range report.MessageUpdates {

--- a/packages/agent/daemon/runtime/report_coalescer_test.go
+++ b/packages/agent/daemon/runtime/report_coalescer_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+	replay "github.com/tutti-os/tutti/packages/agent/session-replay"
 	"github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
 )
 
@@ -120,6 +121,61 @@ func TestStreamingReportCoalescerNeverCoalescesSessionAudit(t *testing.T) {
 	flushed := coalescer.add(request)
 	if len(flushed) != 1 || len(flushed[0].report.SessionAudits) != 1 {
 		t.Fatalf("flushed = %#v", flushed)
+	}
+}
+
+func TestStreamingReportCoalescerFlushesBeforeProviderObservationReport(t *testing.T) {
+	t.Parallel()
+
+	coalescer := newStreamingReportCoalescer(time.Hour)
+	defer coalescer.stop()
+
+	if flushed := coalescer.add(reportRequest{
+		ctx:    context.Background(),
+		report: streamingReport("assistant-message-1", 1, "hello"),
+	}); len(flushed) != 0 {
+		t.Fatalf("streaming add flushed %#v, want pending", flushed)
+	}
+
+	observed := toolCallStreamingReport(2, map[string]any{
+		"input": map[string]any{"command": "touch /tmp/marker"},
+	})
+	observed.ProviderObservations = []agentsessionstore.ProviderObservationBatch{{
+		RecordingID:  "recording-1",
+		ConnectionID: "connection-1",
+		ChunkSeq:     317,
+		UnitIndex:    1,
+		UnitKind:     "protocol-message",
+		Events: []replay.ProviderObservationEvent{{
+			EventIndex: 1,
+			Type:       "call.started",
+			TurnID:     "turn-1",
+			CallID:     "call-1",
+			Status:     "streaming",
+		}},
+	}}
+
+	flushed := coalescer.add(reportRequest{
+		ctx:    context.Background(),
+		report: observed,
+	})
+	if len(flushed) != 2 {
+		t.Fatalf("flushed reports = %d, want pending streaming plus observation report", len(flushed))
+	}
+	if flushed[0].report.MessageUpdates[0].Status != messageStreamStateStreaming {
+		t.Fatalf("first flushed report = %#v, want streaming", flushed[0].report)
+	}
+	if len(flushed[1].report.ProviderObservations) != 1 ||
+		flushed[1].report.ProviderObservations[0].ChunkSeq != 317 ||
+		len(flushed[1].report.ProviderObservations[0].Events) != 1 ||
+		flushed[1].report.ProviderObservations[0].Events[0].Type != "call.started" {
+		t.Fatalf(
+			"observation report = %#v, want preserved ProviderObservations",
+			flushed[1].report.ProviderObservations,
+		)
+	}
+	if pending := coalescer.flushAll(); len(pending) != 0 {
+		t.Fatalf("remaining pending reports = %#v, want none", pending)
 	}
 }
 

--- a/packages/agent/host/conformance/session_lifecycle_scenarios.go
+++ b/packages/agent/host/conformance/session_lifecycle_scenarios.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 	"github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
 )
 
@@ -154,7 +155,7 @@ func runCreateWithRailPlacement(ctx context.Context, driver Driver) error {
 			Version:     1,
 			Kind:        agenthost.RailPlacementKindProject,
 			ProjectPath: "/workspace/project",
-			SectionKey:  "project:workspace-1:/workspace/project",
+			SectionKey:  "project:/workspace/project",
 		},
 	}
 	session, turnID, err := driver.Create(ctx, "workspace-1", input)
@@ -164,11 +165,12 @@ func runCreateWithRailPlacement(ctx context.Context, driver Driver) error {
 	if turnID == "" {
 		return fmt.Errorf("create with explicit rail placement turn is empty")
 	}
-	if session.RailSectionKey != input.RailPlacement.SectionKey {
+	wantKey := storesqlite.RailSectionKeyForProject("/workspace/project")
+	if session.RailSectionKey != wantKey {
 		return fmt.Errorf(
 			"create with explicit rail placement key=%q, want %q",
 			session.RailSectionKey,
-			input.RailPlacement.SectionKey,
+			wantKey,
 		)
 	}
 	if err := verifyRetriedInitialCreate(ctx, driver, input, session, turnID); err != nil {

--- a/packages/agent/host/rail_placement.go
+++ b/packages/agent/host/rail_placement.go
@@ -24,15 +24,22 @@ func normalizeRailPlacement(placement *RailPlacement) (*RailPlacement, error) {
 	}
 	switch normalized.Kind {
 	case RailPlacementKindConversations:
-		if normalized.ProjectPath != "" || normalized.SectionKey != storesqlite.RailSectionKeyConversations {
-			return nil, fmt.Errorf("%w: invalid conversations rail placement", ErrInvalidArgument)
-		}
+		normalized.ProjectPath = ""
+		normalized.SectionKey = storesqlite.RailSectionKeyConversations
 	case RailPlacementKindProject:
-		if normalized.ProjectPath == "" ||
-			normalized.SectionKey == "" ||
-			normalized.SectionKey == storesqlite.RailSectionKeyConversations {
+		normalized.ProjectPath = storesqlite.NormalizeProjectPath(normalized.ProjectPath)
+		if normalized.ProjectPath == "" {
+			key := storesqlite.NormalizeRailSectionKey(normalized.SectionKey)
+			if strings.HasPrefix(key, "project:") {
+				normalized.ProjectPath = storesqlite.NormalizeProjectPath(
+					strings.TrimPrefix(key, "project:"),
+				)
+			}
+		}
+		if normalized.ProjectPath == "" {
 			return nil, fmt.Errorf("%w: invalid project rail placement", ErrInvalidArgument)
 		}
+		normalized.SectionKey = storesqlite.RailSectionKeyForProject(normalized.ProjectPath)
 	default:
 		return nil, fmt.Errorf("%w: invalid rail placement kind", ErrInvalidArgument)
 	}
@@ -46,5 +53,6 @@ func railPlacementMatchesSession(placement *RailPlacement, session storesqlite.S
 	return strings.TrimSpace(session.RailSectionKind) == string(placement.Kind) &&
 		storesqlite.NormalizeProjectPath(session.RailProjectPath) ==
 			storesqlite.NormalizeProjectPath(placement.ProjectPath) &&
-		strings.TrimSpace(session.RailSectionKey) == placement.SectionKey
+		storesqlite.NormalizeRailSectionKey(session.RailSectionKey) ==
+			storesqlite.NormalizeRailSectionKey(placement.SectionKey)
 }

--- a/packages/agent/host/rail_placement_test.go
+++ b/packages/agent/host/rail_placement_test.go
@@ -1,0 +1,61 @@
+package agenthost
+
+import (
+	"runtime"
+	"testing"
+
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+func TestNormalizeRailPlacementDerivesCanonicalSectionKey(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	placement, err := normalizeRailPlacement(&RailPlacement{
+		Version:     1,
+		Kind:        RailPlacementKindProject,
+		ProjectPath: root,
+		SectionKey:  "project:/unrelated",
+	})
+	if err != nil {
+		t.Fatalf("normalizeRailPlacement() error = %v", err)
+	}
+	wantPath := storesqlite.NormalizeProjectPath(root)
+	wantKey := storesqlite.RailSectionKeyForProject(wantPath)
+	if placement.ProjectPath != wantPath {
+		t.Fatalf("ProjectPath = %q, want %q", placement.ProjectPath, wantPath)
+	}
+	if placement.SectionKey != wantKey {
+		t.Fatalf("SectionKey = %q, want %q", placement.SectionKey, wantKey)
+	}
+}
+
+func TestRailPlacementMatchesSessionAcrossSymlinkForms(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS != "darwin" {
+		t.Skip("macOS /var vs /private/var alias")
+	}
+
+	root := t.TempDir()
+	canonical := storesqlite.NormalizeProjectPath(root)
+	if canonical == root {
+		t.Skip("temp dir has no symlink alias")
+	}
+	placement, err := normalizeRailPlacement(&RailPlacement{
+		Version:     1,
+		Kind:        RailPlacementKindProject,
+		ProjectPath: canonical,
+		SectionKey:  storesqlite.RailSectionKeyForProject(canonical),
+	})
+	if err != nil {
+		t.Fatalf("normalizeRailPlacement() error = %v", err)
+	}
+	session := storesqlite.Session{
+		RailSectionKind: string(RailPlacementKindProject),
+		RailProjectPath: root,
+		RailSectionKey:  "project:" + root,
+	}
+	if !railPlacementMatchesSession(placement, session) {
+		t.Fatalf("expected alias forms to match: placement=%#v session=%#v", placement, session)
+	}
+}

--- a/packages/agent/host/sqlite_workspace_store_test.go
+++ b/packages/agent/host/sqlite_workspace_store_test.go
@@ -115,7 +115,7 @@ func TestSQLiteWorkspaceStoreInitializesCanonicalRuntimeSession(t *testing.T) {
 			Version:     1,
 			Kind:        agenthost.RailPlacementKindProject,
 			ProjectPath: "/workspace/app",
-			SectionKey:  "project:workspace-1:/workspace/app",
+			SectionKey:  "project:/workspace/app",
 		},
 	})
 	if err != nil {
@@ -127,8 +127,9 @@ func TestSQLiteWorkspaceStoreInitializesCanonicalRuntimeSession(t *testing.T) {
 	if persisted.LastEventUnixMS != 1234 || persisted.Settings["reasoningEffort"] != "ultra" || persisted.Settings["speed"] != "standard" {
 		t.Fatalf("persisted canonical fields = %#v", persisted)
 	}
-	if persisted.RailSectionKey != "project:workspace-1:/workspace/app" {
-		t.Fatalf("persisted rail section key = %q", persisted.RailSectionKey)
+	wantRailKey := storesqlite.RailSectionKeyForProject("/workspace/app")
+	if persisted.RailSectionKey != wantRailKey {
+		t.Fatalf("persisted rail section key = %q, want %q", persisted.RailSectionKey, wantRailKey)
 	}
 	if persisted.Metadata.Visible {
 		t.Fatalf("provisional session visibility = true, want false")

--- a/packages/agent/host/types.go
+++ b/packages/agent/host/types.go
@@ -562,10 +562,11 @@ const (
 	RailPlacementKindProject       RailPlacementKind = "project"
 )
 
-// RailPlacement is the caller-selected canonical conversation-rail identity
-// for a newly created session. SectionKey is opaque to Host and is persisted
-// exactly; ProjectPath is the caller's logical project path, not a prepared
-// runtime or owner-host path.
+// RailPlacement is the caller-selected conversation-rail identity for a newly
+// created session. Host canonicalizes project paths and derives project
+// SectionKey values from them; conversation placement uses the canonical
+// conversations key. ProjectPath is the caller's logical project path, not a
+// prepared runtime or owner-host path.
 type RailPlacement struct {
 	Version     int               `json:"version"`
 	Kind        RailPlacementKind `json:"kind"`

--- a/packages/agent/session-replay/replay_state.go
+++ b/packages/agent/session-replay/replay_state.go
@@ -187,6 +187,12 @@ func replayProviderHome(
 		session.AgentTargetID,
 		session.Provider,
 	)
+	if !ok {
+		// Shared Agent Sessions use a runtime-specific shared-agent:<id> target
+		// while retaining the provider identity in the canonical Session. The
+		// provider descriptor still owns portable runtime paths for that Session.
+		descriptor, ok = FindProviderReplayByProvider(session.Provider)
+	}
 	directory := strings.TrimSpace(
 		descriptor.PortableRuntime.SessionHomeDirectory,
 	)

--- a/packages/agent/store-sqlite/activity_sections.go
+++ b/packages/agent/store-sqlite/activity_sections.go
@@ -17,7 +17,7 @@ func (s *Store) ListSessionSection(
 		return SessionSectionPage{}, false, errors.New("workspace database is not initialized")
 	}
 	workspaceID := strings.TrimSpace(input.WorkspaceID)
-	sectionKey := strings.TrimSpace(input.SectionKey)
+	sectionKey := NormalizeRailSectionKey(strings.TrimSpace(input.SectionKey))
 	agentTargetID := strings.TrimSpace(input.AgentTargetID)
 	if workspaceID == "" || sectionKey == "" {
 		return SessionSectionPage{}, false, nil
@@ -416,7 +416,7 @@ func normalizeSessionSectionKeys(values []string) []string {
 	result := make([]string, 0, len(values))
 	seen := make(map[string]struct{}, len(values))
 	for _, value := range values {
-		sectionKey := strings.TrimSpace(value)
+		sectionKey := NormalizeRailSectionKey(strings.TrimSpace(value))
 		if sectionKey == "" {
 			continue
 		}
@@ -437,7 +437,7 @@ func (s *Store) ListSessionSectionDeletionCandidates(
 		return SessionSectionDeletionCandidates{}, false, errors.New("workspace database is not initialized")
 	}
 	workspaceID := strings.TrimSpace(input.WorkspaceID)
-	sectionKey := strings.TrimSpace(input.SectionKey)
+	sectionKey := NormalizeRailSectionKey(strings.TrimSpace(input.SectionKey))
 	agentTargetID := strings.TrimSpace(input.AgentTargetID)
 	if workspaceID == "" || sectionKey == "" || sectionKey == PinnedSessionPageKey {
 		return SessionSectionDeletionCandidates{}, false, nil

--- a/packages/agent/store-sqlite/generated_files.go
+++ b/packages/agent/store-sqlite/generated_files.go
@@ -27,7 +27,7 @@ func (s *Store) ListWorkspaceGeneratedFileTurns(
 		return GeneratedFileTurnList{}, false, fmt.Errorf("workspace database is not initialized")
 	}
 	workspaceID := strings.TrimSpace(input.WorkspaceID)
-	sectionKey := strings.TrimSpace(input.SectionKey)
+	sectionKey := NormalizeRailSectionKey(strings.TrimSpace(input.SectionKey))
 	if workspaceID == "" || sectionKey == "" || sectionKey == PinnedSessionPageKey {
 		return GeneratedFileTurnList{}, false, nil
 	}

--- a/packages/agent/store-sqlite/rail.go
+++ b/packages/agent/store-sqlite/rail.go
@@ -378,10 +378,29 @@ func NormalizeRailSectionKey(sectionKey string) string {
 
 func normalizeAgentSessionRailSection(section RailSection) RailSection {
 	section.Kind = strings.TrimSpace(section.Kind)
-	section.ProjectPath = NormalizeProjectPath(section.ProjectPath)
-	section.Key = strings.TrimSpace(section.Key)
-	if section.Kind == RailSectionKindConversations {
+	switch section.Kind {
+	case RailSectionKindConversations:
 		section.ProjectPath = ""
+		section.Key = RailSectionKeyConversations
+	case RailSectionKindProject:
+		section.ProjectPath = NormalizeProjectPath(section.ProjectPath)
+		if section.ProjectPath == "" {
+			key := NormalizeRailSectionKey(strings.TrimSpace(section.Key))
+			if strings.HasPrefix(key, "project:") {
+				section.ProjectPath = NormalizeProjectPath(strings.TrimPrefix(key, "project:"))
+			}
+		}
+		if section.ProjectPath != "" {
+			// Key is derived from the project path so symlink path forms
+			// (for example macOS /var vs /private/var) cannot diverge from
+			// the path used for user-project section matching.
+			section.Key = RailSectionKeyForProject(section.ProjectPath)
+		} else {
+			section.Key = strings.TrimSpace(section.Key)
+		}
+	default:
+		section.ProjectPath = NormalizeProjectPath(section.ProjectPath)
+		section.Key = strings.TrimSpace(section.Key)
 	}
 	return section
 }
@@ -392,8 +411,7 @@ func isValidAgentSessionRailSection(section RailSection) bool {
 		return section.ProjectPath == "" && section.Key == RailSectionKeyConversations
 	case RailSectionKindProject:
 		return section.ProjectPath != "" &&
-			section.Key != "" &&
-			section.Key != RailSectionKeyConversations
+			section.Key == RailSectionKeyForProject(section.ProjectPath)
 	default:
 		return false
 	}

--- a/packages/agent/store-sqlite/rail_normalize_test.go
+++ b/packages/agent/store-sqlite/rail_normalize_test.go
@@ -1,0 +1,98 @@
+package storesqlite
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestNormalizeAgentSessionRailSectionDerivesKeyFromPath(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	canonical := NormalizeProjectPath(root)
+	aliased := root
+	if runtime.GOOS == "darwin" {
+		// On macOS TempDir is often under /var which is a symlink to /private/var.
+		if evaluated, err := filepath.EvalSymlinks(root); err == nil && evaluated != root {
+			aliased = root
+			canonical = evaluated
+		}
+	}
+
+	section := normalizeAgentSessionRailSection(RailSection{
+		Kind:        RailSectionKindProject,
+		ProjectPath: aliased,
+		Key:         "project:" + aliased,
+	})
+	if section.ProjectPath != canonical {
+		t.Fatalf("ProjectPath = %q, want %q", section.ProjectPath, canonical)
+	}
+	wantKey := RailSectionKeyForProject(canonical)
+	if section.Key != wantKey {
+		t.Fatalf("Key = %q, want %q", section.Key, wantKey)
+	}
+	if !isValidAgentSessionRailSection(section) {
+		t.Fatalf("normalized section should be valid: %#v", section)
+	}
+}
+
+func TestNormalizeAgentSessionRailSectionRepairsMismatchedKey(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	canonical := NormalizeProjectPath(root)
+	section := normalizeAgentSessionRailSection(RailSection{
+		Kind:        RailSectionKindProject,
+		ProjectPath: canonical,
+		Key:         "project:/unrelated/path",
+	})
+	if section.Key != RailSectionKeyForProject(canonical) {
+		t.Fatalf("Key = %q, want derived from path", section.Key)
+	}
+}
+
+func TestNormalizeRailSectionKeyAliasesCompareEqual(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	canonical := NormalizeProjectPath(root)
+	if canonical == root {
+		t.Skip("temp dir path is already canonical; no symlink alias to assert")
+	}
+	if NormalizeRailSectionKey("project:"+root) != NormalizeRailSectionKey("project:"+canonical) {
+		t.Fatalf(
+			"NormalizeRailSectionKey(%q) != NormalizeRailSectionKey(%q)",
+			root,
+			canonical,
+		)
+	}
+}
+
+func TestNormalizeAgentSessionRailSectionClearsConversationProjectBinding(t *testing.T) {
+	t.Parallel()
+
+	section := normalizeAgentSessionRailSection(RailSection{
+		Kind:        RailSectionKindConversations,
+		ProjectPath: t.TempDir(),
+		Key:         "project:/tmp/x",
+	})
+	if section.ProjectPath != "" || section.Key != RailSectionKeyConversations {
+		t.Fatalf("conversations section = %#v", section)
+	}
+}
+
+func TestClassifyRailSectionUsesCanonicalProjectKey(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "pkg"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	section := ClassifyRailSection(filepath.Join(root, "pkg"), nil, []string{root})
+	want := RailSectionKeyForProject(root)
+	if section.Key != want {
+		t.Fatalf("ClassifyRailSection key = %q, want %q", section.Key, want)
+	}
+}

--- a/services/tuttid/api/daemon_user_projects.go
+++ b/services/tuttid/api/daemon_user_projects.go
@@ -3,7 +3,9 @@ package api
 import (
 	"context"
 	"errors"
+	"strings"
 
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 	tuttigenerated "github.com/tutti-os/tutti/services/tuttid/api/generated"
 	"github.com/tutti-os/tutti/services/tuttid/apierrors"
 	userprojectbiz "github.com/tutti-os/tutti/services/tuttid/biz/userproject"
@@ -214,14 +216,18 @@ func generatedUserProjects(projects []userprojectbiz.Project) []tuttigenerated.U
 }
 
 func generatedUserProject(project userprojectbiz.Project) tuttigenerated.UserProject {
+	normalizedPath := storesqlite.NormalizeProjectPath(project.Path)
+	if normalizedPath == "" {
+		normalizedPath = strings.TrimSpace(project.Path)
+	}
 	return tuttigenerated.UserProject{
 		CreatedAtUnixMs:  project.CreatedAtUnixMS,
 		Id:               project.ID,
 		Label:            project.Label,
 		LastUsedAtUnixMs: project.LastUsedAtUnixMS,
-		Path:             project.Path,
+		Path:             normalizedPath,
 		PinnedAtUnixMs:   project.PinnedAtUnixMS,
-		SectionKey:       userprojectbiz.SectionKeyFromPath(project.Path),
+		SectionKey:       userprojectbiz.SectionKeyFromPath(normalizedPath),
 		UpdatedAtUnixMs:  project.UpdatedAtUnixMS,
 	}
 }

--- a/services/tuttid/service/agent/messages.go
+++ b/services/tuttid/service/agent/messages.go
@@ -131,7 +131,7 @@ func (s *Service) ListGeneratedFiles(
 	input ListGeneratedFilesInput,
 ) (GeneratedFileList, error) {
 	workspaceID = strings.TrimSpace(workspaceID)
-	sectionKey := strings.TrimSpace(input.SectionKey)
+	sectionKey := agentactivitybiz.NormalizeRailSectionKey(strings.TrimSpace(input.SectionKey))
 	if workspaceID == "" || sectionKey == "" || sectionKey == agentactivitybiz.PinnedSessionPageKey || input.Limit < 0 {
 		return GeneratedFileList{}, ErrInvalidArgument
 	}

--- a/services/tuttid/service/agent/service_session_sections.go
+++ b/services/tuttid/service/agent/service_session_sections.go
@@ -284,10 +284,23 @@ func (s *Service) ListSessionSectionPage(
 	if err != nil {
 		return SessionSection{}, err
 	}
+	canonicalSectionKey := agentactivitybiz.NormalizeRailSectionKey(sectionKey)
 	for _, project := range projects {
 		project = userProjectWithSectionKey(project)
-		if project.SectionKey == sectionKey {
-			return s.sessionSectionPage(ctx, workspaceID, sessionSectionKindProject, sectionKey, &project, input.Cursor, input.Limit, agentTargetID)
+		if agentactivitybiz.NormalizeRailSectionKey(project.SectionKey) == canonicalSectionKey {
+			// Always list by the project-derived canonical key so sessions
+			// classified with NormalizeProjectPath are found even when the
+			// caller still has a symlink-aliased section key.
+			return s.sessionSectionPage(
+				ctx,
+				workspaceID,
+				sessionSectionKindProject,
+				project.SectionKey,
+				&project,
+				input.Cursor,
+				input.Limit,
+				agentTargetID,
+			)
 		}
 	}
 	return SessionSection{}, ErrInvalidArgument
@@ -474,9 +487,10 @@ func (s *Service) resolveSessionSectionScope(
 	if err != nil {
 		return "", nil, err
 	}
+	canonicalSectionKey := agentactivitybiz.NormalizeRailSectionKey(sectionKey)
 	for _, project := range projects {
 		project = userProjectWithSectionKey(project)
-		if project.SectionKey == sectionKey {
+		if agentactivitybiz.NormalizeRailSectionKey(project.SectionKey) == canonicalSectionKey {
 			return sessionSectionKindProject, &project, nil
 		}
 	}
@@ -541,8 +555,7 @@ func (s *Service) sessionsFromActivity(ctx context.Context, workspaceID string, 
 }
 
 func userProjectWithSectionKey(project userprojectbiz.Project) userprojectbiz.Project {
-	if strings.TrimSpace(project.SectionKey) == "" {
-		project.SectionKey = userprojectbiz.SectionKeyFromPath(project.Path)
-	}
+	project.Path = agentactivitybiz.NormalizeProjectPath(project.Path)
+	project.SectionKey = userprojectbiz.SectionKeyFromPath(project.Path)
 	return project
 }

--- a/services/tuttid/service/userproject/service.go
+++ b/services/tuttid/service/userproject/service.go
@@ -7,10 +7,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 	userprojectbiz "github.com/tutti-os/tutti/services/tuttid/biz/userproject"
 	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
 )
@@ -70,23 +70,19 @@ func (s Service) List(ctx context.Context) ([]userprojectbiz.Project, error) {
 }
 
 func (Service) CheckPath(_ context.Context, input CheckPathInput) (PathCheck, error) {
-	path := strings.TrimSpace(input.Path)
+	path := storesqlite.NormalizeProjectPath(input.Path)
 	if path == "" {
 		return PathCheck{}, ErrInvalidArgument
 	}
-	absolute, err := filepath.Abs(path)
-	if err != nil {
-		return PathCheck{}, fmt.Errorf("%w: %w", ErrInvalidArgument, err)
-	}
-	info, err := os.Stat(absolute)
+	info, err := os.Stat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return PathCheck{Path: absolute}, nil
+			return PathCheck{Path: path}, nil
 		}
 		return PathCheck{}, fmt.Errorf("check user project path: %w", err)
 	}
 	return PathCheck{
-		Path:        absolute,
+		Path:        path,
 		Exists:      true,
 		IsDirectory: info.IsDir(),
 	}, nil
@@ -97,9 +93,9 @@ func (s Service) Use(ctx context.Context, input UseInput) (userprojectbiz.Projec
 		return userprojectbiz.Project{}, errors.New("user project store is not configured")
 	}
 
-	projectPath, err := normalizeDirectoryPath(input.Path)
-	if err != nil {
-		return userprojectbiz.Project{}, err
+	projectPath := storesqlite.NormalizeProjectPath(input.Path)
+	if projectPath == "" {
+		return userprojectbiz.Project{}, ErrInvalidArgument
 	}
 	info, err := os.Stat(projectPath)
 	if err != nil {
@@ -222,19 +218,11 @@ func (s Service) publishCurrentProjects(ctx context.Context) {
 }
 
 func normalizeDirectoryPath(path string) (string, error) {
-	path = strings.TrimSpace(path)
-	if path == "" {
+	normalized := storesqlite.NormalizeProjectPath(path)
+	if normalized == "" {
 		return "", ErrInvalidArgument
 	}
-	absolute, err := filepath.Abs(path)
-	if err != nil {
-		return "", ErrInvalidArgument
-	}
-	evaluated, err := filepath.EvalSymlinks(absolute)
-	if err == nil {
-		absolute = evaluated
-	}
-	return absolute, nil
+	return normalized, nil
 }
 
 func projectID(path string) string {

--- a/services/tuttid/service/userproject/service_test.go
+++ b/services/tuttid/service/userproject/service_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 	userprojectbiz "github.com/tutti-os/tutti/services/tuttid/biz/userproject"
 	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
 )
@@ -325,24 +326,27 @@ func TestServiceCheckPathReportsDirectoryStatusWithoutStore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CheckPath(validDir) error = %v", err)
 	}
-	if !directory.Exists || !directory.IsDirectory || directory.Path != validDir {
-		t.Fatalf("CheckPath(validDir) = %#v, want existing directory", directory)
+	wantDir := storesqlite.NormalizeProjectPath(validDir)
+	if !directory.Exists || !directory.IsDirectory || directory.Path != wantDir {
+		t.Fatalf("CheckPath(validDir) = %#v, want existing directory %q", directory, wantDir)
 	}
 
 	file, err := service.CheckPath(ctx, CheckPathInput{Path: filePath})
 	if err != nil {
 		t.Fatalf("CheckPath(filePath) error = %v", err)
 	}
-	if !file.Exists || file.IsDirectory {
-		t.Fatalf("CheckPath(filePath) = %#v, want existing non-directory", file)
+	wantFile := storesqlite.NormalizeProjectPath(filePath)
+	if !file.Exists || file.IsDirectory || file.Path != wantFile {
+		t.Fatalf("CheckPath(filePath) = %#v, want existing non-directory %q", file, wantFile)
 	}
 
 	missing, err := service.CheckPath(ctx, CheckPathInput{Path: missingPath})
 	if err != nil {
 		t.Fatalf("CheckPath(missingPath) error = %v", err)
 	}
-	if missing.Exists || missing.IsDirectory || missing.Path != missingPath {
-		t.Fatalf("CheckPath(missingPath) = %#v, want missing path", missing)
+	wantMissing := storesqlite.NormalizeProjectPath(missingPath)
+	if missing.Exists || missing.IsDirectory || missing.Path != wantMissing {
+		t.Fatalf("CheckPath(missingPath) = %#v, want missing path %q", missing, wantMissing)
 	}
 }
 

--- a/tools/scripts/agent-session-replay-runner/cassette.mjs
+++ b/tools/scripts/agent-session-replay-runner/cassette.mjs
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { createReadStream } from "node:fs";
+import { createReadStream, realpathSync } from "node:fs";
 import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -323,6 +323,34 @@ function resolvePortableRailSectionKey(value, replayCWD) {
   );
 }
 
+function resolvePortableReplayPath(value, replayCWD) {
+  if (typeof value !== "string") return value;
+  let resolved = value;
+  let fromPortableToken = false;
+  if (value === portableReplayCWDToken) {
+    resolved = replayCWD;
+    fromPortableToken = true;
+  } else if (value.startsWith(`${portableReplayCWDToken}/`)) {
+    resolved = join(
+      replayCWD,
+      ...value.slice(portableReplayCWDToken.length + 1).split("/")
+    );
+    fromPortableToken = true;
+  }
+  if (
+    typeof resolved !== "string" ||
+    !resolved ||
+    (!fromPortableToken && !resolved.startsWith("/"))
+  ) {
+    return resolved;
+  }
+  try {
+    return realpathSync(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
 export function parseActivityEvents(contents) {
   const events = parseJSONLines(contents);
   const eventKinds = new Map();
@@ -499,18 +527,6 @@ function promptImageExtension(mimeType) {
     default:
       return "";
   }
-}
-
-function resolvePortableReplayPath(value, replayCWD) {
-  if (typeof value !== "string") return value;
-  if (value === portableReplayCWDToken) return replayCWD;
-  if (value.startsWith(`${portableReplayCWDToken}/`)) {
-    return join(
-      replayCWD,
-      ...value.slice(portableReplayCWDToken.length + 1).split("/")
-    );
-  }
-  return value;
 }
 
 function stimulusPrompt(payload) {

--- a/tools/scripts/agent-session-replay-runner/event-stream-catalog.mjs
+++ b/tools/scripts/agent-session-replay-runner/event-stream-catalog.mjs
@@ -1,0 +1,361 @@
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+
+const CATALOG_REVISION_RE = /sha256:[0-9a-f]{8,}/g;
+const BUSINESS_CATALOG_ASSIGNMENT_RE =
+  /businessEventCatalogRevision\s*=\s*"(sha256:[0-9a-f]+)"/;
+const GO_CATALOG_ASSIGNMENT_RE =
+  /BusinessEventCatalogRevision\s*=\s*"(sha256:[0-9a-f]+)"/;
+const MISMATCH_LOG_RE =
+  /Event stream catalog revision mismatch\.\s*Expected\s+(sha256:[0-9a-f]+),\s*received\s+(sha256:[0-9a-f]+)/;
+
+/**
+ * Extract a business-event catalog revision from source, bundle, or binary text.
+ * Prefers explicit assignment forms, then falls back to the first sha256 token.
+ */
+export function extractCatalogRevision(text) {
+  if (typeof text !== "string" || text.length === 0) return null;
+  const assigned =
+    text.match(BUSINESS_CATALOG_ASSIGNMENT_RE)?.[1] ??
+    text.match(GO_CATALOG_ASSIGNMENT_RE)?.[1] ??
+    null;
+  if (assigned) return assigned;
+  const matches = text.match(CATALOG_REVISION_RE);
+  return matches?.[0] ?? null;
+}
+
+export function formatCatalogMismatchError(input) {
+  const desktop = input.desktopRevision ?? "unknown";
+  const daemon = input.daemonRevision ?? "unknown";
+  const desktopSource = input.desktopSource ?? "desktop";
+  const daemonSource = input.daemonSource ?? "tuttid";
+  const guidance =
+    input.guidance ??
+    "Rebuild desktop (apps/desktop/out) and tuttids from the same commit, " +
+      "or clear stale prepared Electron/out artifacts before recording.";
+  return (
+    `desktop/tuttid event stream catalog mismatch (fail-fast): ` +
+    `${desktopSource}=${desktop}, ${daemonSource}=${daemon}. ` +
+    guidance
+  );
+}
+
+export async function readCatalogRevisionFromFile(path) {
+  try {
+    return extractCatalogRevision(await readFile(path, "utf8"));
+  } catch (error) {
+    if (error && error.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+export async function readCatalogRevisionFromBinary(path) {
+  try {
+    const buffer = await readFile(path);
+    // Binary may contain multiple sha256 tokens; prefer the business-event one
+    // by scanning latin1 and matching assignment-like nearby text first.
+    const latin1 = buffer.toString("latin1");
+    const assigned = extractCatalogRevisionFromBinaryAssignment(latin1);
+    if (assigned) return assigned;
+    // Fall back: tuttidd embeds the revision as a naked string constant.
+    const matches = latin1.match(CATALOG_REVISION_RE) ?? [];
+    // Prefer 16-hex-nibble revisions used by generate-event-protocol.
+    const short = matches.find((value) => /^sha256:[0-9a-f]{16}$/.test(value));
+    return short ?? matches[0] ?? null;
+  } catch (error) {
+    if (error && error.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function extractCatalogRevisionFromBinaryAssignment(text) {
+  const marker = "BusinessEventCatalogRevision";
+  const markerIndex = text.indexOf(marker);
+  if (markerIndex < 0) return null;
+
+  const assignmentIndex = text.indexOf("=", markerIndex + marker.length);
+  if (assignmentIndex < 0 || assignmentIndex - markerIndex > 128) {
+    return null;
+  }
+
+  const quoteIndex = text.indexOf('"', assignmentIndex + 1);
+  if (quoteIndex < 0 || quoteIndex - assignmentIndex > 128) {
+    return null;
+  }
+
+  return text.slice(quoteIndex + 1).match(/^sha256:[0-9a-f]+/)?.[0] ?? null;
+}
+
+export async function readCatalogRevisionFromDesktopRendererOut(workspaceRoot) {
+  const assetsDirectory = join(
+    workspaceRoot,
+    "apps",
+    "desktop",
+    "out",
+    "renderer",
+    "assets"
+  );
+  let entries = [];
+  try {
+    entries = await readdir(assetsDirectory);
+  } catch (error) {
+    if (error && error.code === "ENOENT") return null;
+    throw error;
+  }
+  for (const name of entries) {
+    if (!name.endsWith(".js")) continue;
+    const revision = await readCatalogRevisionFromFile(
+      join(assetsDirectory, name)
+    );
+    if (revision) return revision;
+  }
+  return null;
+}
+
+export async function readCatalogRevisionFromEventProtocolSource(
+  workspaceRoot
+) {
+  return readCatalogRevisionFromFile(
+    join(
+      workspaceRoot,
+      "packages",
+      "events",
+      "protocol",
+      "src",
+      "generated",
+      "registry.ts"
+    )
+  );
+}
+
+/**
+ * @param {'out' | 'source' | 'out-then-source' | 'source-then-out'} [prefer]
+ */
+export async function resolveDesktopEventStreamCatalogRevision(
+  workspaceRoot,
+  prefer = "out-then-source"
+) {
+  const readOut = async () => {
+    const renderer =
+      await readCatalogRevisionFromDesktopRendererOut(workspaceRoot);
+    if (renderer) {
+      return { revision: renderer, source: "desktop-out-renderer" };
+    }
+    const main = await readCatalogRevisionFromFile(
+      join(workspaceRoot, "apps", "desktop", "out", "main", "index.js")
+    );
+    if (main) {
+      return { revision: main, source: "desktop-out-main" };
+    }
+    return null;
+  };
+  const readSource = async () => {
+    const protocol =
+      await readCatalogRevisionFromEventProtocolSource(workspaceRoot);
+    if (protocol) {
+      return { revision: protocol, source: "event-protocol-source" };
+    }
+    return null;
+  };
+
+  if (prefer === "out") return readOut();
+  if (prefer === "source") return readSource();
+  if (prefer === "source-then-out") {
+    return (await readSource()) ?? (await readOut());
+  }
+  return (await readOut()) ?? (await readSource());
+}
+
+export async function resolveDaemonEventStreamCatalogRevision(input) {
+  const daemonPath = input.daemonPath?.trim?.() || input.daemonPath || "";
+  if (daemonPath) {
+    const fromBinary = await readCatalogRevisionFromBinary(daemonPath);
+    if (fromBinary) {
+      return { revision: fromBinary, source: "daemon-binary" };
+    }
+  }
+  const fromGo = await readCatalogRevisionFromFile(
+    join(
+      input.workspaceRoot,
+      "services",
+      "tuttid",
+      "api",
+      "events",
+      "generated",
+      "protocol.gen.go"
+    )
+  );
+  if (fromGo) {
+    return { revision: fromGo, source: "tuttid-protocol-source" };
+  }
+  return null;
+}
+
+/**
+ * Fail when desktop/tuttid catalogs diverge.
+ * No-ops when either side cannot be resolved (e.g. cold pnpm-dev without out/).
+ *
+ * @param {{ daemonPath?: string, workspaceRoot: string, desktopPrefer?: string }} input
+ */
+export async function assertEventStreamCatalogAligned(input) {
+  const desktopPrefer = input.desktopPrefer ?? "out-then-source";
+  const desktop = await resolveDesktopEventStreamCatalogRevision(
+    input.workspaceRoot,
+    desktopPrefer
+  );
+  const daemon = await resolveDaemonEventStreamCatalogRevision({
+    daemonPath: input.daemonPath,
+    workspaceRoot: input.workspaceRoot
+  });
+  if (!desktop || !daemon) return { checked: false, desktop, daemon };
+  if (desktop.revision !== daemon.revision) {
+    throw new Error(
+      formatCatalogMismatchError({
+        daemonRevision: daemon.revision,
+        daemonSource: daemon.source,
+        desktopRevision: desktop.revision,
+        desktopSource: desktop.source
+      })
+    );
+  }
+  return { checked: true, desktop, daemon };
+}
+
+/**
+ * Align catalogs for a launch. Stale prepared `apps/desktop/out` automatically
+ * falls back to pnpm-dev-desktop when event-protocol source matches tuttidd.
+ *
+ * Managed launches (must use a fixed Electron binary) cannot fall back — they
+ * still fail fast so the operator rebuilds out/.
+ */
+export async function reconcileEventStreamCatalogForLaunch(input) {
+  const preparedElectron = Boolean(input.preparedElectron);
+  const managed = Boolean(input.managed);
+  const daemon = await resolveDaemonEventStreamCatalogRevision({
+    daemonPath: input.daemonPath,
+    workspaceRoot: input.workspaceRoot
+  });
+  if (!daemon) {
+    return {
+      checked: false,
+      fallbackToPnpmDev: false,
+      daemon: null,
+      desktop: null
+    };
+  }
+
+  if (!preparedElectron) {
+    // Vite/dev uses protocol source; ignore stale out/ so we do not false-fail.
+    const result = await assertEventStreamCatalogAligned({
+      daemonPath: input.daemonPath,
+      desktopPrefer: "source-then-out",
+      workspaceRoot: input.workspaceRoot
+    });
+    return { ...result, fallbackToPnpmDev: false };
+  }
+
+  const out = await resolveDesktopEventStreamCatalogRevision(
+    input.workspaceRoot,
+    "out"
+  );
+  if (out && out.revision === daemon.revision) {
+    return {
+      checked: true,
+      desktop: out,
+      daemon,
+      fallbackToPnpmDev: false
+    };
+  }
+
+  const source = await resolveDesktopEventStreamCatalogRevision(
+    input.workspaceRoot,
+    "source"
+  );
+  if (source && source.revision === daemon.revision) {
+    if (managed) {
+      throw new Error(
+        formatCatalogMismatchError({
+          daemonRevision: daemon.revision,
+          daemonSource: daemon.source,
+          desktopRevision: out?.revision ?? "missing",
+          desktopSource: out?.source ?? "desktop-out",
+          guidance:
+            "Managed replay cannot auto-fall back to pnpm-dev-desktop. " +
+            "Rebuild apps/desktop/out (or clear managed Electron env) so " +
+            "renderer matches tuttidd."
+        })
+      );
+    }
+    return {
+      checked: true,
+      desktop: source,
+      daemon,
+      fallbackToPnpmDev: true,
+      message:
+        `stale prepared desktop out catalog ` +
+        `(${out?.source ?? "desktop-out"}=${out?.revision ?? "missing"} vs ` +
+        `${daemon.source}=${daemon.revision}); ` +
+        `auto-falling back to pnpm-dev-desktop (event-protocol source matches)`
+    };
+  }
+
+  throw new Error(
+    formatCatalogMismatchError({
+      daemonRevision: daemon.revision,
+      daemonSource: daemon.source,
+      desktopRevision: out?.revision ?? source?.revision ?? "unknown",
+      desktopSource: out?.source ?? source?.source ?? "desktop",
+      guidance:
+        "Neither prepared out/ nor event-protocol source match tuttidd. " +
+        "Run pnpm generate:event-protocol and rebuild desktop + tuttids " +
+        "from the same commit."
+    })
+  );
+}
+
+export function clearPreparedElectronEnv(env = process.env) {
+  delete env.TUTTI_AGENT_SESSION_REPLAY_ELECTRON_EXECUTABLE;
+  delete env.TUTTI_AGENT_SESSION_REPLAY_ELECTRON_ENTRY;
+}
+
+/**
+ * Check the live Desktop log once after CDP is ready. The source/artifact
+ * reconciliation above is the authoritative preflight; this snapshot only
+ * turns an already-emitted handshake failure into a useful error. Polling here
+ * has no success signal and used to delay every healthy replay by 8 seconds.
+ */
+export async function assertDesktopLogHasNoCatalogMismatch(logPath) {
+  let lastText;
+  try {
+    lastText = await readFile(logPath, "utf8");
+  } catch (error) {
+    if (error && error.code === "ENOENT") return { checked: false };
+    throw error;
+  }
+
+  const match = lastText.match(MISMATCH_LOG_RE);
+  if (match) {
+    throw new Error(
+      formatCatalogMismatchError({
+        daemonRevision: match[2],
+        daemonSource: "tuttid-ready-frame",
+        desktopRevision: match[1],
+        desktopSource: "desktop-event-stream-client"
+      })
+    );
+  }
+  if (
+    lastText.includes("catalog revision mismatch") ||
+    lastText.includes("event_stream.connect_failed")
+  ) {
+    throw new Error(
+      formatCatalogMismatchError({
+        daemonRevision: "see desktop.log",
+        daemonSource: "tuttid",
+        desktopRevision: "see desktop.log",
+        desktopSource: "desktop"
+      })
+    );
+  }
+  return { checked: true };
+}

--- a/tools/scripts/agent-session-replay-runner/event-stream-catalog.test.mjs
+++ b/tools/scripts/agent-session-replay-runner/event-stream-catalog.test.mjs
@@ -1,0 +1,218 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  assertDesktopLogHasNoCatalogMismatch,
+  assertEventStreamCatalogAligned,
+  clearPreparedElectronEnv,
+  extractCatalogRevision,
+  formatCatalogMismatchError,
+  readCatalogRevisionFromBinary,
+  readCatalogRevisionFromDesktopRendererOut,
+  readCatalogRevisionFromFile,
+  reconcileEventStreamCatalogForLaunch
+} from "./event-stream-catalog.mjs";
+
+test("extractCatalogRevision prefers businessEventCatalogRevision assignment", () => {
+  const text = `
+    const other = "sha256:deadbeefdeadbeef";
+    const businessEventCatalogRevision = "sha256:0413e48c4012324e";
+  `;
+  assert.equal(extractCatalogRevision(text), "sha256:0413e48c4012324e");
+});
+
+test("extractCatalogRevision reads Go BusinessEventCatalogRevision", () => {
+  const text = `\tBusinessEventCatalogRevision = "sha256:0413e48c4012324e"\n`;
+  assert.equal(extractCatalogRevision(text), "sha256:0413e48c4012324e");
+});
+
+test("assertEventStreamCatalogAligned fails when renderer out and daemon diverge", async () => {
+  const root = await mkdtemp(join(tmpdir(), "catalog-align-"));
+  const assets = join(root, "apps", "desktop", "out", "renderer", "assets");
+  const daemonDir = join(root, "daemon");
+  await mkdir(assets, { recursive: true });
+  await mkdir(daemonDir, { recursive: true });
+  await writeFile(
+    join(assets, "browserNodeWebviewContext-test.js"),
+    `const businessEventCatalogRevision = "sha256:2e36dcc0d1c65637";\n`
+  );
+  const daemonPath = join(daemonDir, "tuttid");
+  await writeFile(
+    daemonPath,
+    Buffer.from(`xxBusinessEventCatalogRevision="sha256:0413e48c4012324e"yy`)
+  );
+
+  await assert.rejects(
+    () =>
+      assertEventStreamCatalogAligned({
+        daemonPath,
+        workspaceRoot: root
+      }),
+    /event stream catalog mismatch \(fail-fast\)/
+  );
+});
+
+test("assertEventStreamCatalogAligned passes when revisions match", async () => {
+  const root = await mkdtemp(join(tmpdir(), "catalog-align-ok-"));
+  const assets = join(root, "apps", "desktop", "out", "renderer", "assets");
+  const daemonDir = join(root, "daemon");
+  await mkdir(assets, { recursive: true });
+  await mkdir(daemonDir, { recursive: true });
+  await writeFile(
+    join(assets, "browserNodeWebviewContext-test.js"),
+    `const businessEventCatalogRevision = "sha256:0413e48c4012324e";\n`
+  );
+  const daemonPath = join(daemonDir, "tuttid");
+  await writeFile(
+    daemonPath,
+    Buffer.from(`BusinessEventCatalogRevision="sha256:0413e48c4012324e"`)
+  );
+  const result = await assertEventStreamCatalogAligned({
+    daemonPath,
+    workspaceRoot: root
+  });
+  assert.equal(result.checked, true);
+  assert.equal(result.desktop.revision, "sha256:0413e48c4012324e");
+  assert.equal(result.daemon.revision, "sha256:0413e48c4012324e");
+});
+
+test("reconcile falls back to pnpm-dev when out is stale but source matches", async () => {
+  const root = await mkdtemp(join(tmpdir(), "catalog-fallback-"));
+  const assets = join(root, "apps", "desktop", "out", "renderer", "assets");
+  const protocolDir = join(
+    root,
+    "packages",
+    "events",
+    "protocol",
+    "src",
+    "generated"
+  );
+  const daemonDir = join(root, "daemon");
+  await mkdir(assets, { recursive: true });
+  await mkdir(protocolDir, { recursive: true });
+  await mkdir(daemonDir, { recursive: true });
+  await writeFile(
+    join(assets, "browserNodeWebviewContext-test.js"),
+    `const businessEventCatalogRevision = "sha256:2e36dcc0d1c65637";\n`
+  );
+  await writeFile(
+    join(protocolDir, "registry.ts"),
+    `export const businessEventCatalogRevision = "sha256:0413e48c4012324e";\n`
+  );
+  const daemonPath = join(daemonDir, "tuttid");
+  await writeFile(
+    daemonPath,
+    Buffer.from(`BusinessEventCatalogRevision="sha256:0413e48c4012324e"`)
+  );
+
+  const result = await reconcileEventStreamCatalogForLaunch({
+    daemonPath,
+    preparedElectron: true,
+    workspaceRoot: root
+  });
+  assert.equal(result.fallbackToPnpmDev, true);
+  assert.equal(result.desktop.revision, "sha256:0413e48c4012324e");
+  assert.match(result.message, /auto-falling back to pnpm-dev-desktop/);
+});
+
+test("reconcile does not fall back for managed launches", async () => {
+  const root = await mkdtemp(join(tmpdir(), "catalog-managed-"));
+  const assets = join(root, "apps", "desktop", "out", "renderer", "assets");
+  const protocolDir = join(
+    root,
+    "packages",
+    "events",
+    "protocol",
+    "src",
+    "generated"
+  );
+  const daemonDir = join(root, "daemon");
+  await mkdir(assets, { recursive: true });
+  await mkdir(protocolDir, { recursive: true });
+  await mkdir(daemonDir, { recursive: true });
+  await writeFile(
+    join(assets, "browserNodeWebviewContext-test.js"),
+    `const businessEventCatalogRevision = "sha256:2e36dcc0d1c65637";\n`
+  );
+  await writeFile(
+    join(protocolDir, "registry.ts"),
+    `export const businessEventCatalogRevision = "sha256:0413e48c4012324e";\n`
+  );
+  const daemonPath = join(daemonDir, "tuttid");
+  await writeFile(
+    daemonPath,
+    Buffer.from(`BusinessEventCatalogRevision="sha256:0413e48c4012324e"`)
+  );
+
+  await assert.rejects(
+    () =>
+      reconcileEventStreamCatalogForLaunch({
+        daemonPath,
+        managed: true,
+        preparedElectron: true,
+        workspaceRoot: root
+      }),
+    /Managed replay cannot auto-fall back/
+  );
+});
+
+test("clearPreparedElectronEnv removes launch env", () => {
+  const env = {
+    TUTTI_AGENT_SESSION_REPLAY_ELECTRON_EXECUTABLE: "/bin/Electron",
+    TUTTI_AGENT_SESSION_REPLAY_ELECTRON_ENTRY: "/apps/desktop",
+    KEEP: "1"
+  };
+  clearPreparedElectronEnv(env);
+  assert.equal(env.TUTTI_AGENT_SESSION_REPLAY_ELECTRON_EXECUTABLE, undefined);
+  assert.equal(env.TUTTI_AGENT_SESSION_REPLAY_ELECTRON_ENTRY, undefined);
+  assert.equal(env.KEEP, "1");
+});
+
+test("assertDesktopLogHasNoCatalogMismatch fails fast on handshake error", async () => {
+  const root = await mkdtemp(join(tmpdir(), "catalog-log-"));
+  const logPath = join(root, "desktop.log");
+  await writeFile(
+    logPath,
+    `time=... msg="terminal diagnostic" details={"error":"Event stream catalog revision mismatch. Expected sha256:2e36dcc0d1c65637, received sha256:0413e48c4012324e."}\n`
+  );
+  await assert.rejects(
+    () => assertDesktopLogHasNoCatalogMismatch(logPath),
+    /fail-fast/
+  );
+});
+
+test("assertDesktopLogHasNoCatalogMismatch accepts a clean desktop snapshot", async () => {
+  const root = await mkdtemp(join(tmpdir(), "catalog-log-clean-"));
+  const logPath = join(root, "desktop.log");
+  await writeFile(logPath, 'time=... msg="desktop app ready"\n');
+  assert.deepEqual(await assertDesktopLogHasNoCatalogMismatch(logPath), {
+    checked: true
+  });
+});
+
+test("read helpers tolerate missing artifacts", async () => {
+  const root = await mkdtemp(join(tmpdir(), "catalog-missing-"));
+  assert.equal(await readCatalogRevisionFromFile(join(root, "nope.ts")), null);
+  assert.equal(await readCatalogRevisionFromBinary(join(root, "nope")), null);
+  assert.equal(await readCatalogRevisionFromDesktopRendererOut(root), null);
+  const result = await assertEventStreamCatalogAligned({
+    daemonPath: join(root, "missing-daemon"),
+    workspaceRoot: root
+  });
+  assert.equal(result.checked, false);
+});
+
+test("formatCatalogMismatchError mentions rebuild guidance", () => {
+  const message = formatCatalogMismatchError({
+    daemonRevision: "sha256:aaaa",
+    daemonSource: "daemon-binary",
+    desktopRevision: "sha256:bbbb",
+    desktopSource: "desktop-out-renderer"
+  });
+  assert.match(message, /desktop-out-renderer=sha256:bbbb/);
+  assert.match(message, /daemon-binary=sha256:aaaa/);
+  assert.match(message, /Rebuild desktop/);
+});

--- a/tools/scripts/agent-session-replay-runner/recording.mjs
+++ b/tools/scripts/agent-session-replay-runner/recording.mjs
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
+import { realpathSync } from "node:fs";
 import { access, readFile, rm } from "node:fs/promises";
 import { basename, join, relative, resolve } from "node:path";
 import {
@@ -16,9 +17,19 @@ const checkpointPlanName = cassettePolicy.files.checkpointPlan.path;
 const expectedStateName = cassettePolicy.files.expectedState.path;
 const initialStateName = cassettePolicy.files.initialState.path;
 
+function canonicalizeProjectPath(path) {
+  const absolute = resolve(String(path ?? "").trim());
+  if (!absolute) return absolute;
+  try {
+    return realpathSync(absolute);
+  } catch {
+    return absolute;
+  }
+}
+
 export function resolveRecordScenarioProject(project, replayCWD) {
-  const root = resolve(replayCWD);
-  const path = resolve(root, project.relativePath);
+  const root = canonicalizeProjectPath(replayCWD);
+  const path = canonicalizeProjectPath(resolve(root, project.relativePath));
   const relativePath = relative(root, path);
   if (
     relativePath === ".." ||
@@ -45,6 +56,7 @@ export function resolveRecordScenarioProject(project, replayCWD) {
 
 export async function seedRecordingUserProject(databasePath, project) {
   const now = Date.now();
+  const path = canonicalizeProjectPath(project.path);
   await runCommand("sqlite3", [
     databasePath,
     `
@@ -53,7 +65,7 @@ INSERT INTO user_projects (
   last_used_at_unix_ms, sort_order, pinned_at_unix_ms
 ) VALUES (
   '${sqlString(project.id)}',
-  '${sqlString(project.path)}',
+  '${sqlString(path)}',
   '${sqlString(project.label)}',
   ${now}, ${now}, ${now}, 0, 0
 )

--- a/tools/scripts/run-agent-session-replay.mjs
+++ b/tools/scripts/run-agent-session-replay.mjs
@@ -52,6 +52,11 @@ import {
   setAgentComposerDefaults
 } from "./agent-session-replay-runner/runtime.mjs";
 import {
+  assertDesktopLogHasNoCatalogMismatch,
+  clearPreparedElectronEnv,
+  reconcileEventStreamCatalogForLaunch
+} from "./agent-session-replay-runner/event-stream-catalog.mjs";
+import {
   assertForbiddenPathAbsent,
   resolveAgentSessionReplayProjectRoot,
   resolveRecordScenarioProject,
@@ -584,10 +589,25 @@ async function runReplayWorkspaceOrchestration(bootstrap, options) {
       )
     ])
   );
+  const catalogLaunch = await reconcileEventStreamCatalogForLaunch({
+    daemonPath: bootstrap.runtime.daemonPath,
+    managed: Boolean(options.managed),
+    preparedElectron: Boolean(desktopLaunch),
+    workspaceRoot
+  });
+  let effectiveDesktopLaunch = desktopLaunch;
+  if (catalogLaunch.fallbackToPnpmDev) {
+    log(
+      catalogLaunch.message ??
+        "stale prepared desktop out; falling back to pnpm-dev-desktop"
+    );
+    clearPreparedElectronEnv();
+    effectiveDesktopLaunch = undefined;
+  }
   const desktop = startDesktop({
-    args: desktopLaunch?.args,
+    args: effectiveDesktopLaunch?.args,
     cdpPort,
-    command: desktopLaunch?.command,
+    command: effectiveDesktopLaunch?.command,
     daemonPath: bootstrap.runtime.daemonPath,
     desktopLogPath: logPath,
     environment: {
@@ -613,6 +633,7 @@ async function runReplayWorkspaceOrchestration(bootstrap, options) {
       desktop,
       options.timeoutMs
     );
+    await assertDesktopLogHasNoCatalogMismatch(logPath);
     client = await CdpClient.connect(pageWebSocket);
     await client.send("Runtime.enable");
     await bootstrapRendererReplayWorkspace(
@@ -1427,10 +1448,25 @@ async function runDesktopAction(input) {
     input.mode === "replay"
       ? requiredReplayRegistrations(input.replayRegistrations)
       : null;
+  const catalogLaunch = await reconcileEventStreamCatalogForLaunch({
+    daemonPath: input.daemonPath,
+    managed: Boolean(input.keepDesktopOpen && input.desktopLaunch),
+    preparedElectron: Boolean(input.desktopLaunch),
+    workspaceRoot
+  });
+  let desktopLaunch = input.desktopLaunch;
+  if (catalogLaunch.fallbackToPnpmDev) {
+    log(
+      catalogLaunch.message ??
+        "stale prepared desktop out; falling back to pnpm-dev-desktop"
+    );
+    clearPreparedElectronEnv();
+    desktopLaunch = undefined;
+  }
   const desktop = startDesktop({
-    args: input.desktopLaunch?.args,
+    args: desktopLaunch?.args,
     cdpPort,
-    command: input.desktopLaunch?.command,
+    command: desktopLaunch?.command,
     daemonPath: input.daemonPath,
     desktopLogPath: input.logPath,
     environment:
@@ -1471,6 +1507,9 @@ async function runDesktopAction(input) {
       desktop,
       input.timeoutMs
     );
+    // Catalog mismatch is logged as soon as the renderer handshake runs.
+    // Fail here instead of waiting for scenario assistantText timeouts.
+    await assertDesktopLogHasNoCatalogMismatch(input.logPath);
     pageClient = await CdpClient.connect(pageWebSocket);
     await pageClient.send("Runtime.enable");
     await pageClient.send("Page.enable");

--- a/tools/scripts/run-agent-session-replay.test.mjs
+++ b/tools/scripts/run-agent-session-replay.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
 import { EventEmitter } from "node:events";
+import { realpathSync } from "node:fs";
 import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
@@ -3734,12 +3735,13 @@ test("PROJECT_ROOT remaps portable REPLAY_CWD outside Tutti checkout", () => {
 
 test("P01 selects an in-cwd project and requires portable binding artifacts", async () => {
   const root = await mkdtemp(join(tmpdir(), "agent-replay-project-binding-"));
+  const canonicalRoot = realpathSync(root);
   const project = resolveRecordScenarioProject(
-    { label: basename(root), relativePath: "." },
+    { label: basename(canonicalRoot), relativePath: "." },
     root
   );
-  assert.equal(project.path, root);
-  assert.equal(project.label, basename(root));
+  assert.equal(project.path, canonicalRoot);
+  assert.equal(project.label, basename(canonicalRoot));
   assert.equal(project.portablePath, "${REPLAY_CWD}");
   assert.throws(
     () =>
@@ -3768,7 +3770,10 @@ test("P01 selects an in-cwd project and requires portable binding artifacts", as
     databasePath,
     "SELECT path || '|' || label FROM user_projects;"
   ]);
-  assert.equal(seeded.stdout.trim(), `${root}|${basename(root)}`);
+  assert.equal(
+    seeded.stdout.trim(),
+    `${canonicalRoot}|${basename(canonicalRoot)}`
+  );
 
   await writeFile(
     join(root, cassettePolicy.files.activityEvents.path),


### PR DESCRIPTION
## Summary

- Make Claude `/compact` progress, failure, and acceptance ordering deterministic across the sidecar and daemon.
- Stabilize AskUserQuestion identity mapping, project rail/path canonicalization, and provider-observation coalescing.
- Make session replay portable and fail fast on Desktop/tuttid event-catalog mismatches, with troubleshooting coverage.

## Validation

- `GOTOOLCHAIN=go1.24.5 pnpm check:changed -- --push-ready`
- 23 validation lanes passed locally.

