### PR TITLE
refactor(agent-gui): remove legacy host sessions contract

### DIFF
--- a/.changeset/remove-agent-host-legacy-sessions.md
+++ b/.changeset/remove-agent-host-legacy-sessions.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/agent-gui": major
+---
+
+Remove the obsolete `AgentHostInputApi.agentSessions` activity lifecycle surface and its unused `AgentHostAgentSessionsApi` type. Agent session lifecycle remains owned by the canonical AgentSessionEngine rather than the host capability contract.

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
@@ -302,7 +302,7 @@ test("desktop agent GUI workbench host input creates the default agent host api"
   });
 
   assert.equal(hostInput.agentHostApi.meta?.workspaceId, workspaceId);
-  assert.equal(hostInput.agentHostApi.agentSessions, undefined);
+  assert.equal("agentSessions" in hostInput.agentHostApi, false);
   assert.equal("workspaceAgents" in hostInput.agentHostApi, false);
   assert.deepEqual(
     await hostInput.workspaceFileReferenceAdapter.listDirectory?.({

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentHostApi.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentHostApi.test.ts
@@ -184,7 +184,7 @@ test("desktop agent host api writes images through the host clipboard", async ()
 test("desktop agent host api does not inject legacy agent data host apis", () => {
   const api = createAgentHostApi();
 
-  assert.equal(api.agentSessions, undefined);
+  assert.equal("agentSessions" in api, false);
   assert.equal("workspaceAgents" in api, false);
 });
 

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -441,9 +441,10 @@ intents. The runtime has no duplicate activation, submit, Goal, Interaction,
 settings, Tutti Mode, or unactivation callbacks. The effective `AgentHostApi`
 is limited to host
 capabilities such as files, clipboard, runtime metadata, account/project
-lookup, diagnostics, setup, and OS/Workbench helpers. Its input type still
-accepts a legacy `agentSessions` shape, but `toAgentHostRuntimeApi` strips that
-shape; production AgentGUI must not use it as an activity source.
+lookup, diagnostics, setup, and OS/Workbench helpers. The public
+`AgentHostInputApi` no longer exposes the legacy `agentSessions` activity
+lifecycle shape; production AgentGUI must not use the host capability contract
+as an activity source.
 Large pasted text is a separate runtime capability rather than an inference
 from generic file upload. `stagePastedText` returns one provider-readable
 locator: a local archive `path`, or an ordinary prepared remote-file `url`

--- a/packages/agent/gui/host/agentHostApi.ts
+++ b/packages/agent/gui/host/agentHostApi.ts
@@ -211,7 +211,6 @@ export type AgentHostWorkspaceApi = AgentHostRecord & {
 
 export interface AgentHostInputApi {
   account?: AgentHostAccountApi;
-  agentSessions?: AgentHostAgentSessionsApi;
   agentTargetSetup?: AgentHostAgentTargetSetupApi;
   clipboard: AgentHostClipboardApi;
   debug?: AgentHostDebugApi;
@@ -394,19 +393,6 @@ export type AgentHostUserProjectsApi = AgentHostRecord & {
     path: string | null;
   }) => AgentHostAsyncResult<void>;
   use: (input: { path: string }) => AgentHostAsyncResult<AgentHostUserProject>;
-};
-
-export type AgentHostAgentSessionsApi = AgentHostRecord & {
-  activate: (input: any) => AgentHostAsyncResult<any>;
-  getComposerOptions?: (input: any) => AgentHostAsyncResult<any>;
-  getState: (input: any) => AgentHostAsyncResult<any>;
-  onEvent?: (listener: (event: any) => void) => AgentHostUnsubscribe;
-  subscribeEvents: (
-    input: any,
-    listener: (event: any) => void
-  ) => AgentHostUnsubscribe;
-  unactivate: (input: any) => AgentHostAsyncResult<any>;
-  updateSettings: (input: any) => AgentHostAsyncResult<any>;
 };
 
 export interface AgentHostRuntimeApi {


### PR DESCRIPTION
## Summary

- Remove the obsolete `AgentHostInputApi.agentSessions` activity lifecycle field and unused `AgentHostAgentSessionsApi` type.
- Keep Agent session lifecycle ownership in the canonical `AgentSessionEngine` boundary.
- Update the two existing Desktop host tests to assert the runtime shape without depending on the removed type surface.
- Update the durable Agent Activity architecture documentation.
- Add a major changeset for `@tutti-os/agent-gui`.

## Verification

- `corepack pnpm --filter @tutti-os/agent-gui exec vitest run --reporter=dot` — 300 files, 2595 passed.
- `corepack pnpm --filter @tutti-os/agent-gui typecheck` — passed.
- `corepack pnpm --filter @tutti-os/agent-gui build` — passed.
- `corepack pnpm --filter @tutti-os/desktop typecheck` — passed.
- Desktop full test — 1764 total, 1762 passed, 2 skipped, 0 failed.
- `corepack pnpm check:changed` — 15 lanes passed; push-ready check — 16 lanes passed.
- `make dev-gui` — Electron/tuttid runtime launched; onboarding `/healthz` returned HTTP 204 and canvas `/home` returned HTTP 200; process tree and ports were cleaned up.
- TSH consumer source audit found no use of `agentSessions`; no TSH changes are required.

## Scope

No runtime behavior, AgentHostApi runtime capability, tuttid API, OpenAPI, event, persistence, or TSH contract implementation was changed.