### PR TITLE
fix(release): preserve notification after optional job skip

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -740,7 +740,7 @@ jobs:
   promote:
     name: Promote Release
     needs: [resolve, stage]
-    if: ${{ needs.stage.result == 'success' && needs.resolve.outputs.publication_mode == 'publish' }}
+    if: ${{ always() && needs.stage.result == 'success' && needs.resolve.outputs.publication_mode == 'publish' }}
     uses: ./.github/workflows/desktop-release-promote.yml
     with:
       release_tag: ${{ needs.resolve.outputs.release_tag }}
@@ -754,7 +754,7 @@ jobs:
   notify-draft-feishu:
     name: Notify Draft Release
     needs: [resolve, stage]
-    if: ${{ needs.stage.result == 'success' && needs.resolve.outputs.publication_mode == 'draft_only' && needs.resolve.outputs.notify_feishu == 'true' }}
+    if: ${{ always() && needs.stage.result == 'success' && needs.resolve.outputs.publication_mode == 'draft_only' && needs.resolve.outputs.notify_feishu == 'true' }}
     runs-on: ubuntu-latest
     env:
       FEISHU_WEBHOOK_URL: ${{ secrets.FEISHU_RELEASE_WEBHOOK_URL }}

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -277,6 +277,23 @@ test("desktop release workflow defaults Feishu notifications on outside manual d
   );
 });
 
+test("desktop release post-stage jobs tolerate skipped optional dependencies", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
+  const promoteJob = workflow.match(
+    /promote:[\s\S]*?(?=\n\s{2}[a-z][a-z0-9_-]+:\n|$)/
+  )?.[0];
+  const notifyJob = workflow.match(
+    /notify-draft-feishu:[\s\S]*?(?=\n\s{2}[a-z][a-z0-9_-]+:\n|$)/
+  )?.[0];
+
+  assert.ok(promoteJob, "promote job should exist");
+  assert.ok(notifyJob, "draft notify job should exist");
+  assert.match(promoteJob, /if:\s+\${{\s*always\(\)\s*&&/);
+  assert.match(promoteJob, /needs\.stage\.result\s*==\s*'success'/);
+  assert.match(notifyJob, /if:\s+\${{\s*always\(\)\s*&&/);
+  assert.match(notifyJob, /needs\.stage\.result\s*==\s*'success'/);
+});
+
 test("desktop release workflow does not redownload release assets for Feishu", async () => {
   const workflow = await readFile(workflowPath, "utf8");
   const notifyJobMatch = workflow.match(


### PR DESCRIPTION
## Summary

- allow release promotion to continue after the optional Windows build is skipped
- allow draft Feishu notification to continue through the same dependency shape
- add regression coverage for explicit post-stage status handling

## Root cause

The optional Windows build is skipped unless `include_windows=true`. Although the stage job accepts that result with `always()`, the downstream promotion and draft-notification jobs had no status-check function, so GitHub propagated the skipped ancestor through the dependency chain.

## Validation

- `node --test tools/scripts/desktop-release-config.test.mjs` (42 passed)
- `pnpm check:changed` (5 lanes passed)
- pre-push `pnpm check:changed -- --push-ready` (5 lanes passed)

## Risk

Low. The existing `needs.stage.result == 'success'` and publication-mode checks remain intact; this only prevents an accepted optional-job skip from implicitly suppressing downstream jobs.