### PR TITLE
fix(agent): preserve host path for managed installs

### DIFF
--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -482,6 +482,43 @@ file or directory`. A failed `codex app-server` probe is diagnostic evidence,
   [runtimeprep tutti_agent.go](../../../packages/agent/runtimeprep/tutti_agent.go)
   [tuttid tuttiagent service.go](../../../services/tuttid/service/tuttiagent/service.go)
 
+### Managed npm install fails before reaching every registry
+
+- Symptom:
+  A Codex or Tutti Agent managed npm install fails immediately with exit code
+  `126`. On macOS or another Unix host, stderr contains
+  `dirname: command not found` followed by a malformed `node` path. Switching
+  npm registries produces the same failure without meaningful network delay.
+- Quick checks:
+  Inspect the prepared npm path and the install process `PATH`. Run the managed
+  npm launcher once with that exact environment. If adding `/usr/bin:/bin`
+  makes it work, the failure is local process setup rather than registry or
+  package availability. On Windows, confirm the structured runner uses
+  `cmd.exe /D /S /C call` for `npm.cmd` and retains the inherited `System32`
+  path.
+- Root cause:
+  Managed runtime overrides put the bundled Node directory first, but an
+  already-installed runtime fast path can accidentally build the override from
+  an empty base environment. Direct structured execution then exposes the
+  truncated `PATH`: the Unix npm launcher cannot resolve tools such as
+  `dirname`, while Windows batch launchers can lose commands supplied by the
+  host environment. A login shell can hide this defect by rebuilding `PATH`.
+- Fix:
+  Keep structured argv execution and the platform process adapters. When no
+  environment provider is injected, inherit the daemon process environment
+  before prepending managed runtime directories. Do not switch back to shell
+  command strings or hardcode a Unix path into shared installer policy.
+- Validation:
+  Execute a real POSIX npm-style launcher that calls `dirname` with the
+  production managed-runtime composition, test Windows `.cmd` argument
+  preservation, build the daemon natively, and cross-compile the Windows
+  agentstatus tests.
+- References:
+  [installer_codex_cli.go](../../../services/tuttid/service/agentstatus/installer_codex_cli.go)
+  [provider_resolution.go](../../../services/tuttid/service/agentstatus/provider_resolution.go)
+  [service_helpers.go](../../../services/tuttid/service/agentstatus/service_helpers.go)
+  [install_command_windows.go](../../../services/tuttid/service/agentstatus/install_command_windows.go)
+
 ### Tutti Agent unexpectedly loses login after a host auth read failure
 
 - Symptom:

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -16,6 +16,7 @@ Provider discovery, installation, authentication, models, configuration, and run
 - [Claude SDK context window shows 200k for 1M models](./agent-provider-setup.md#claude-sdk-context-window-shows-200k-for-1m-models)
 - [Codex npm install misses the platform package](./agent-provider-setup.md#codex-npm-install-misses-the-platform-package)
 - [Tutti Agent npm install misses the platform package](./agent-provider-setup.md#tutti-agent-npm-install-misses-the-platform-package)
+- [Managed npm install fails before reaching every registry](./agent-provider-setup.md#managed-npm-install-fails-before-reaching-every-registry)
 - [Tutti Agent unexpectedly loses login after a host auth read failure](./agent-provider-setup.md#tutti-agent-unexpectedly-loses-login-after-a-host-auth-read-failure)
 - [Agent sandbox cannot reach local daemon](./agent-provider-setup.md#agent-sandbox-cannot-reach-local-daemon)
 - [Codex provider install fails with missing npm](./agent-provider-setup.md#codex-provider-install-fails-with-missing-npm)

--- a/services/tuttid/service/agentstatus/install_command_other.go
+++ b/services/tuttid/service/agentstatus/install_command_other.go
@@ -28,6 +28,6 @@ func platformExecutableFile(info os.FileInfo) bool {
 	return info.Mode().Perm()&0o111 != 0
 }
 
-func managedNPMInstallRunner() string {
-	return "shell -lc"
+func structuredInstallRunner() string {
+	return "direct exec"
 }

--- a/services/tuttid/service/agentstatus/install_command_windows.go
+++ b/services/tuttid/service/agentstatus/install_command_windows.go
@@ -49,6 +49,6 @@ func installCommandInterpreter() string {
 	return resolveInstallerShell()
 }
 
-func managedNPMInstallRunner() string {
+func structuredInstallRunner() string {
 	return "cmd.exe /D /S /C call"
 }

--- a/services/tuttid/service/agentstatus/installer.go
+++ b/services/tuttid/service/agentstatus/installer.go
@@ -574,7 +574,7 @@ func (s Service) runExternalAgentRegistryNPMInstaller(ctx context.Context, provi
 		"provider", provider,
 		"npmPath", appRuntime.NPM,
 		"installPrefix", npmSpec.PrefixDir,
-		"runner", managedNPMInstallRunner(),
+		"runner", structuredInstallRunner(),
 	)
 	baseEnv := managedruntime.ProcessEnv(append(appRuntime.EnvOverrides, envMapToList(npmSpec.Env)...)...)
 	// Use a dedicated, tutti-owned npm cache inside the install prefix rather than

--- a/services/tuttid/service/agentstatus/installer_codex_cli.go
+++ b/services/tuttid/service/agentstatus/installer_codex_cli.go
@@ -128,7 +128,7 @@ func (s Service) runManagedNPMPackageAction(
 		"npmPath", npmPath,
 		"installPrefix", installPrefix,
 		"nodeTarget", nodeTarget,
-		"runner", managedNPMInstallRunner(),
+		"runner", structuredInstallRunner(),
 	)
 	// Pin a dedicated, tutti-owned npm cache instead of the user's global ~/.npm,
 	// which on some machines holds root-owned files that make every user-mode npm

--- a/services/tuttid/service/agentstatus/installer_managed_npm_unix_test.go
+++ b/services/tuttid/service/agentstatus/installer_managed_npm_unix_test.go
@@ -1,0 +1,52 @@
+//go:build !windows
+
+package agentstatus
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tutti-os/tutti/services/tuttid/service/managedruntime"
+)
+
+func TestManagedNPMInstallerExecutesPOSIXLauncherWithInheritedPath(t *testing.T) {
+	home := t.TempDir()
+	runtimeRoot := fakeManagedRuntimeRoot(t)
+	npmPath := filepath.Join(runtimeRoot, "node", "bin", npmBinaryNameForTest())
+	writeExecutable(t, npmPath, `#!/bin/sh
+script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+printf 'npm-dir=%s' "$script_dir"
+`)
+
+	service := probeTestService(home)
+	service.Environ = nil
+	service.ManagedRuntime = managedruntime.DefaultResolver{RuntimeRoot: runtimeRoot}
+	service.HTTPClient = agentNPMRegistryProbeHTTPClient(nil)
+
+	result, err := service.runManagedNPMPackageInstaller(
+		context.Background(),
+		"tutti-agent",
+		ManagedNPMPackageInstallerSpec{
+			PackageName:     "@tutti-os/tutti-agent",
+			BinaryName:      "tutti-agent",
+			IncludeOptional: true,
+		},
+		"",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("exit code = %d, stderr = %q", result.ExitCode, result.Stderr)
+	}
+	wantDir := filepath.Join(runtimeRoot, "node", "bin")
+	if !strings.Contains(result.Stdout, "npm-dir="+wantDir) {
+		t.Fatalf("stdout = %q, want launcher directory %q", result.Stdout, wantDir)
+	}
+	if _, err := os.Stat(npmPath); err != nil {
+		t.Fatalf("npm launcher missing after install: %v", err)
+	}
+}

--- a/services/tuttid/service/agentstatus/provider_resolution.go
+++ b/services/tuttid/service/agentstatus/provider_resolution.go
@@ -414,7 +414,7 @@ func resolvedExistingManagedNodeRuntime(root string, environ func() []string) (m
 	if !managedruntime.NodeReady(root) {
 		return managedruntime.ResolvedRuntime{}, false
 	}
-	baseEnv := []string(nil)
+	baseEnv := os.Environ()
 	if environ != nil {
 		baseEnv = environ()
 	}

--- a/services/tuttid/service/agentstatus/provider_resolution_managed_runtime_test.go
+++ b/services/tuttid/service/agentstatus/provider_resolution_managed_runtime_test.go
@@ -2,7 +2,9 @@ package agentstatus
 
 import (
 	"context"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/tutti-os/tutti/services/tuttid/service/managedruntime"
@@ -54,5 +56,20 @@ func TestResolvedExistingManagedNodeRuntimeAcceptsCompatibleCorepack(t *testing.
 	wantNode := filepath.Join(root, "node", "bin", nodeBinaryNameForTest())
 	if runtime.Node != wantNode {
 		t.Fatalf("Node = %q, want %q", runtime.Node, wantNode)
+	}
+}
+
+func TestResolvedExistingManagedNodeRuntimeInheritsProcessPath(t *testing.T) {
+	root := fakeManagedRuntimeRoot(t)
+	inheritedPath := strings.Join([]string{t.TempDir(), t.TempDir()}, string(os.PathListSeparator))
+	t.Setenv("PATH", inheritedPath)
+
+	resolved, ok := resolvedExistingManagedNodeRuntime(root, nil)
+	if !ok {
+		t.Fatal("resolvedExistingManagedNodeRuntime() rejected compatible cache")
+	}
+	wantPath := filepath.Join(root, "node", "bin") + string(os.PathListSeparator) + inheritedPath
+	if got := managedruntime.EnvValue(resolved.EnvOverrides, "PATH"); got != wantPath {
+		t.Fatalf("PATH = %q, want %q", got, wantPath)
 	}
 }


### PR DESCRIPTION
## Summary

- inherit the daemon process environment when resolving an already-installed managed Node runtime, then prepend managed runtime bins
- preserve structured installer execution on both platforms: direct exec on macOS/Unix and `cmd.exe /D /S /C call` for Windows batch launchers
- report the real structured runner for managed and external-registry npm installs
- add a real POSIX npm-launcher regression test and durable troubleshooting guidance

## Root cause

The installed-runtime fast path built `PATH` from an empty environment when no `Environ` dependency was injected. The Windows compatibility change correctly moved managed npm installs to structured argv execution, but that exposed the truncated environment on macOS: the bundled npm shell launcher could not find `dirname` and exited 126 before contacting any registry.

## Provider installer review

- Codex and Tutti Agent use the shared managed npm action and are fixed by this change
- external Agent Registry npm installers already use structured argv and a resolver-owned managed runtime; their misleading runner log is corrected
- OpenClaw npm shell setup receives the corrected managed-runtime PATH (the provider remains temporarily unsupported)
- Cursor and OpenCode official scripts use the command resolver environment, including platform fallback paths
- Claude Code uses the official installer on Unix and verified managed binary provisioning on Windows, so it does not depend on the affected npm launcher path

## Validation

- `go test ./services/tuttid/service/agentstatus -run <installer-focused tests> -count=1` — 11 passed
- `pnpm build:go` — passed
- Windows amd64 cross-compile: `GOOS=windows GOARCH=amd64 go test -c ./services/tuttid/service/agentstatus` — passed
- pre-push `check:changed` — 5/6 lanes passed; the Go test lane hit the existing non-hermetic `TestServiceRunActionReportsActiveActionForClaudeInstall`, which resolves the host-installed Claude binary and completes before its mocked install starts

## Documentation

Adds the recurring `dirname: command not found` / exit 126 diagnosis to the Agent provider troubleshooting guide.