### PR TITLE
fix(connector-market): skip requests while signed out

### DIFF
--- a/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
+++ b/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
@@ -69,6 +69,7 @@ import type { IDesktopRichTextAtService } from "@renderer/features/rich-text-at/
 import type { IWorkspaceUserProjectService } from "@renderer/features/workspace-user-project/services/workspaceUserProjectService.interface.ts";
 import type { IWorkspaceAppCenterService } from "@renderer/features/workspace-app-center/services/workspaceAppCenterService.interface.ts";
 import type { AgentSessionReplayDesktopComposition } from "@renderer/features/agent-session-replay/services/agentSessionReplayDesktopComposition.ts";
+import { subscribe } from "valtio/vanilla";
 
 const workspaceRendererInstanceId =
   createWorkspaceWindowInstanceId("workspace-renderer");
@@ -156,24 +157,6 @@ export async function createWorkspaceWindowContainer(): Promise<WorkspaceWindowC
     reporterService
   });
   let disposeAgentOutcomeNotificationController: (() => void) | null = null;
-  const connectorMarketModule = registerConnectorMarketModule(registry, {
-    client: tuttidClient,
-    eventStreamClient: tuttidEventStreamClient,
-    openAuthorizationUrl: (url) => desktopApi.host.files.openExternal(url),
-    reportDiagnostic: (error) => {
-      void desktopApi.runtime
-        .logRendererDiagnostic({
-          details: {
-            message: error instanceof Error ? error.message : String(error)
-          },
-          event: "connector_market.service_error",
-          level: "warn",
-          source: "workspace-renderer"
-        })
-        .catch(() => undefined);
-    },
-    workspaceId: activeWorkspaceID
-  });
   registerAppUpdateServices(registry, desktopApi, {
     reporterService
   });
@@ -227,6 +210,25 @@ export async function createWorkspaceWindowContainer(): Promise<WorkspaceWindowC
   const accountService = registerWorkspaceAccountService(registry, {
     hostFilesApi: desktopApi.host.files,
     tuttidClient
+  });
+  const connectorMarketModule = registerConnectorMarketModule(registry, {
+    canRequest: () => accountService.store.user !== null,
+    client: tuttidClient,
+    eventStreamClient: tuttidEventStreamClient,
+    openAuthorizationUrl: (url) => desktopApi.host.files.openExternal(url),
+    reportDiagnostic: (error) => {
+      void desktopApi.runtime
+        .logRendererDiagnostic({
+          details: {
+            message: error instanceof Error ? error.message : String(error)
+          },
+          event: "connector_market.service_error",
+          level: "warn",
+          source: "workspace-renderer"
+        })
+        .catch(() => undefined);
+    },
+    workspaceId: activeWorkspaceID
   });
   const workspaceAgentServices = registerWorkspaceAgentServices(registry, {
     accountLogin: accountService,
@@ -335,6 +337,20 @@ export async function createWorkspaceWindowContainer(): Promise<WorkspaceWindowC
   });
   const container = new InstantiationService(registry.makeCollection());
   await connectorMarketModule.activate(container);
+  let connectorMarketAccountAuthenticated = accountService.store.user !== null;
+  const disposeConnectorMarketAccountRefresh = subscribe(
+    accountService.store,
+    () => {
+      const authenticated = accountService.store.user !== null;
+      if (authenticated === connectorMarketAccountAuthenticated) {
+        return;
+      }
+      connectorMarketAccountAuthenticated = authenticated;
+      if (authenticated) {
+        void connectorMarketModule.root.market.reload().catch(() => undefined);
+      }
+    }
+  );
   let connectorMarketResumeRefresh: Promise<void> | null = null;
   const disposeConnectorMarketResumeRefresh = windowLifecycle.subscribe(
     (event) => {
@@ -375,6 +391,7 @@ export async function createWorkspaceWindowContainer(): Promise<WorkspaceWindowC
     disposeAgentOutcomeNotificationController = null;
     agentAvailabilitySnapshotAnalytics?.dispose();
     predefinePageviewAnalytics?.dispose();
+    disposeConnectorMarketAccountRefresh();
     disposeConnectorMarketResumeRefresh();
     workspaceAgentServices.dispose();
     windowLifecycle.dispose();

--- a/apps/desktop/src/renderer/src/features/connector-market/services/registerConnectorMarketModule.ts
+++ b/apps/desktop/src/renderer/src/features/connector-market/services/registerConnectorMarketModule.ts
@@ -13,6 +13,7 @@ import { createDesktopConnectorMarketBackend } from "./internal/desktopConnector
 import { createDesktopConnectorMarketEvents } from "./internal/desktopConnectorMarketEvents.ts";
 
 export interface ConnectorMarketModuleRegistrationInput {
+  canRequest?: () => boolean;
   client: ConnectorMarketClient;
   eventStreamClient: TuttidEventStreamClient;
   openAuthorizationUrl?: (url: string) => Promise<void>;
@@ -28,6 +29,7 @@ export function registerConnectorMarketModule(
   const module = new ConnectorMarketModule({
     market: {
       backend: createDesktopConnectorMarketBackend(input.client),
+      canRequest: input.canRequest,
       events: createDesktopConnectorMarketEvents(input.eventStreamClient),
       openAuthorizationUrl: input.openAuthorizationUrl,
       reportDiagnostic: input.reportDiagnostic

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.test.ts
@@ -28,7 +28,7 @@ test("workspace settings gives Model an independent Plan-only section", () => {
   assert.doesNotMatch(panelSource, /WorkspaceAgentModelBindingSection/);
 });
 
-test("workspace settings places Connectors between Agent Runtime and Custom Agents", () => {
+test("workspace settings places signed-in Connectors between Agent Runtime and Custom Agents", () => {
   const general = panelSource.indexOf('value: "general" as const');
   const runtimes = panelSource.indexOf('value: "agents" as const');
   const connectors = panelSource.indexOf('value: "connectors" as const');
@@ -47,6 +47,14 @@ test("workspace settings places Connectors between Agent Runtime and Custom Agen
   assert.match(
     panelSource,
     /agentTab === "connectors"[\s\S]{0,260}<ConnectorMarketPanel/
+  );
+  assert.match(
+    panelSource,
+    /accountState\.user[\s\S]{0,220}value: "connectors" as const/
+  );
+  assert.match(
+    panelSource,
+    /!accountState\.user[\s\S]{0,120}agentTab === "connectors"[\s\S]{0,120}selectAgentTab\("general"\)/
   );
   assert.doesNotMatch(runtimeTabSource, /WorkspaceAgentsSection/);
 });

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
@@ -135,6 +135,7 @@ import {
 } from "../services/workspaceWallpaper";
 import { WorkspaceModelPlansSection } from "./WorkspaceModelPlansSection";
 import { WorkspaceConnectionSettingsSection } from "./WorkspaceConnectionSettingsSection";
+import { useAccountService } from "./useAccountService";
 import {
   workspaceSettingsInputClass,
   workspaceSettingsSelectContentClass,
@@ -187,6 +188,7 @@ export function WorkspaceSettingsPanel({
     useDesktopPreferencesService();
   const { service: settingsService, state: settingsState } =
     useWorkspaceSettingsService();
+  const { state: accountState } = useAccountService();
   const versionTapCountRef = useRef(0);
   const pendingFeatureFlags =
     desktopPreferencesState.changingFeatureFlags ??
@@ -241,6 +243,12 @@ export function WorkspaceSettingsPanel({
       settingsService.selectAgentTab("general");
     }
   }, [automationRulesEnabled, settingsService, settingsState.agentTab]);
+
+  useEffect(() => {
+    if (!accountState.user && settingsState.agentTab === "connectors") {
+      settingsService.selectAgentTab("general");
+    }
+  }, [accountState.user, settingsService, settingsState.agentTab]);
 
   const handleVersionTap = () => {
     if (settingsState.developerPanelVisible) {
@@ -424,10 +432,14 @@ export function WorkspaceSettingsPanel({
                       value: "agents" as const,
                       label: t("workspace.settings.agent.tabs.agents")
                     },
-                    {
-                      value: "connectors" as const,
-                      label: translateConnectorMarket("title")
-                    },
+                    ...(accountState.user
+                      ? [
+                          {
+                            value: "connectors" as const,
+                            label: translateConnectorMarket("title")
+                          }
+                        ]
+                      : []),
                     {
                       value: "customAgents" as const,
                       label: t("workspace.settings.agent.tabs.customAgents")
@@ -493,7 +505,8 @@ export function WorkspaceSettingsPanel({
                       agentEnvService.open({ focus: "detect", provider })
                     }
                   />
-                ) : settingsState.agentTab === "connectors" ? (
+                ) : settingsState.agentTab === "connectors" &&
+                  accountState.user ? (
                   <ConnectorMarketPanel
                     i18n={connectorMarketI18n}
                     root={connectorMarketModule.root}

--- a/docs/architecture/connector-market.md
+++ b/docs/architecture/connector-market.md
@@ -172,6 +172,10 @@ synchronizing -> materializing -> ready`; failure is terminal and disposes
   and daemon revision; `dispose()` is idempotent and terminal
 - event refreshes are coalesced, daemon reconnect performs a full reload, and
   accepted commands are followed through the operation endpoint or events
+- hosts gate connector-market transport through `canRequest`; Tutti binds it to
+  account authentication, activates the module without network access while
+  signed out, reloads after login, and keeps reconnect/resume paths silent
+  after logout
 - the shared renderer subscribes at leaf components through a stable context,
   uses `@tutti-os/ui-system`, and owns no transport, startup, disposal, or
   business-state reconciliation

--- a/packages/connector/market/README.md
+++ b/packages/connector/market/README.md
@@ -31,6 +31,7 @@ import {
 const connectorMarketModule = new ConnectorMarketModule({
   market: {
     backend: hostConnectorMarketBackend,
+    canRequest: () => hostAccountState.authenticated,
     events: hostConnectorMarketEvents
   },
   scope: { workspaceId }
@@ -51,6 +52,10 @@ await connectorMarketModule.activate(workspaceServices);
 The backend adapter wraps the host's generated daemon client and maps transport
 DTOs into package domain types. Daemon events are invalidation hints; the
 service re-reads the authoritative daemon snapshot before publishing new state.
+Hosts whose market requires authentication must provide `canRequest`. A false
+result keeps startup, reconnect, resume, and command paths transport-silent
+while still allowing the module lifecycle to reach `ready`; after the host
+observes an authenticated transition it calls `root.market.reload()`.
 Starting an event subscription and every observed `connected` state trigger an
 authoritative reconciliation, including the first connection. Snapshot reads
 are coalesced per workspace generation and a connection/event arriving during

--- a/packages/connector/market/src/services/connectorMarketService.interface.ts
+++ b/packages/connector/market/src/services/connectorMarketService.interface.ts
@@ -33,6 +33,8 @@ export interface ConnectorMarketStoreState {
 
 export interface ConnectorMarketServiceDependencies {
   backend: ConnectorMarketBackend;
+  /** Host-owned admission check for transport requests. */
+  canRequest?: () => boolean;
   events?: ConnectorMarketEventSource;
   workspaceId?: string;
   createRequestId?: () => string;

--- a/packages/connector/market/src/services/connectorMarketService.ts
+++ b/packages/connector/market/src/services/connectorMarketService.ts
@@ -81,21 +81,25 @@ export class ConnectorMarketService implements IConnectorMarketService {
   }
 
   ensureLoaded(): Promise<void> {
-    if (this.disposed || this.dataStore.loadState !== "idle") {
+    if (
+      this.disposed ||
+      !this.canRequest() ||
+      this.dataStore.loadState !== "idle"
+    ) {
       return Promise.resolve();
     }
     return this.load(true);
   }
 
   reload(): Promise<void> {
-    if (this.disposed) {
+    if (this.disposed || !this.canRequest()) {
       return Promise.resolve();
     }
     return this.load(this.dataStore.loadState === "idle");
   }
 
   refreshCatalog(): Promise<void> {
-    if (this.disposed) {
+    if (this.disposed || !this.canRequest()) {
       return Promise.resolve();
     }
     if (this.refreshInFlight) {
@@ -130,7 +134,7 @@ export class ConnectorMarketService implements IConnectorMarketService {
   }
 
   loadMore(sectionId: string): Promise<void> {
-    if (this.disposed) {
+    if (this.disposed || !this.canRequest()) {
       return Promise.resolve();
     }
     const existing = this.sectionLoads.get(sectionId);
@@ -185,7 +189,7 @@ export class ConnectorMarketService implements IConnectorMarketService {
   }
 
   async beginAuthorization(connectorKey: string): Promise<void> {
-    if (this.disposed) {
+    if (this.disposed || !this.canRequest()) {
       return;
     }
     const workspaceId = this.dataStore.workspaceId;
@@ -232,7 +236,7 @@ export class ConnectorMarketService implements IConnectorMarketService {
     connectorKey: string,
     enabled: boolean
   ): Promise<void> {
-    if (this.disposed) {
+    if (this.disposed || !this.canRequest()) {
       return;
     }
     const workspaceId = this.dataStore.workspaceId;
@@ -300,6 +304,9 @@ export class ConnectorMarketService implements IConnectorMarketService {
   }
 
   private async load(showLoading: boolean): Promise<void> {
+    if (!this.canRequest()) {
+      return;
+    }
     const generation = this.workspaceGeneration;
     const workspaceId = this.dataStore.workspaceId;
     if (this.loadInFlight?.generation === generation) {
@@ -424,7 +431,7 @@ export class ConnectorMarketService implements IConnectorMarketService {
     connectorKey: string,
     operation: () => Promise<ConnectorMutationResult>
   ): Promise<void> {
-    if (this.disposed) {
+    if (this.disposed || !this.canRequest()) {
       return;
     }
     const token = this.acquireConnectorMutation(connectorKey);
@@ -461,6 +468,10 @@ export class ConnectorMarketService implements IConnectorMarketService {
 
   private isCurrent(generation: number): boolean {
     return !this.disposed && generation === this.workspaceGeneration;
+  }
+
+  private canRequest(): boolean {
+    return this.dependencies.canRequest?.() ?? true;
   }
 
   private isCurrentMutation(

--- a/packages/connector/market/src/services/core/connectorMarketRuntime.test.ts
+++ b/packages/connector/market/src/services/core/connectorMarketRuntime.test.ts
@@ -69,6 +69,43 @@ test("module activation runs all service startup jobs before ready", async () =>
   assert.equal(unsubscriptions, 1);
 });
 
+test("module activation skips market requests until the host admits them", async () => {
+  let requestAllowed = false;
+  let snapshotLoads = 0;
+  let categoryLoads = 0;
+  const module = new ConnectorMarketModule({
+    market: {
+      backend: backendWith({
+        getSnapshot: async () => {
+          snapshotLoads += 1;
+          return snapshot(1, []);
+        },
+        listCategories: async () => {
+          categoryLoads += 1;
+          return [];
+        }
+      }),
+      canRequest: () => requestAllowed,
+      events: eventSource({})
+    },
+    scope: { workspaceId: "workspace-1" }
+  });
+
+  await module.activate(new InstantiationService());
+
+  assert.equal(module.lifecycle.phase, "ready");
+  assert.equal(snapshotLoads, 0);
+  assert.equal(categoryLoads, 0);
+
+  requestAllowed = true;
+  await module.root.market.reload();
+
+  assert.equal(snapshotLoads, 1);
+  assert.equal(categoryLoads, 1);
+  assert.equal(module.root.view.dataStore.status, "empty");
+  module.dispose();
+});
+
 test("module activation rejects and releases started services when synchronization fails", async () => {
   let unsubscriptions = 0;
   const failure = new Error("catalog unavailable");


### PR DESCRIPTION
## Summary

Opening a workspace while signed out could leave the desktop on a white screen. The workspace container awaited connector-market activation before React mounted, while the initial market category load requires an authenticated account and rejected the startup barrier.

This change adds a host-owned connector-market request admission check and binds it to the desktop account state. Signed-out startup, reconnect, resume, and command paths stay transport-silent while the module can still reach `ready`. A transition to an authenticated account reloads the market, logout blocks later refreshes, and the Connectors settings tab is hidden while signed out.

## Verification

- Added a runtime regression test that activates the module with requests denied, verifies zero snapshot/category backend calls, then admits requests and verifies reload succeeds
- `pnpm check:changed` passed 14 lanes
- pre-push `pnpm check:changed -- --push-ready` passed 16 lanes
- `pnpm --filter @tutti-os/desktop build` passed, including renderer CSS contracts

## Fallback Three Questions

- Source: a valid signed-out workspace starts before an authenticated connector-market session exists
- Why can it not be fixed at that source? Signed-out desktop use is supported, while the market transport is intentionally account-authenticated; startup must admit that state without weakening market authentication
- Removal condition: remove the gate only if connector-market reads become valid for anonymous users or the workspace no longer composes the market module before authentication

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter. (Not applicable; connector-market renderer lifecycle only.)
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. (No translated variant exists for the package README.)
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
