### PR TITLE
feat(workspace-file-reference): allow confirming the directory picker root

### DIFF
--- a/packages/workspace/file-reference/src/react/internal/reference/useReferenceSourcePickerView.ts
+++ b/packages/workspace/file-reference/src/react/internal/reference/useReferenceSourcePickerView.ts
@@ -640,8 +640,13 @@ export function useReferenceSourcePickerView({
       setBreadcrumbBySource((current) => ({ ...current, [sid]: [] }));
       controller.ensureSourceRoot(sid);
       setFocusedNode(null);
+      // Directory/"save here" pickers treat the source root as the current folder.
+      // Drop a stale nested selection so confirm maps to the root, not the old child.
+      if (selectionMode === "single") {
+        controller.clearSelection();
+      }
     },
-    [activeSourceId, controller]
+    [activeSourceId, controller, selectionMode]
   );
 
   const selectSourceRoot = useCallback(
@@ -651,8 +656,11 @@ export function useReferenceSourcePickerView({
       setBreadcrumbBySource((current) => ({ ...current, [sourceId]: [] }));
       controller.ensureSourceRoot(sourceId);
       setFocusedNode(null);
+      if (selectionMode === "single") {
+        controller.clearSelection();
+      }
     },
-    [controller]
+    [controller, selectionMode]
   );
 
   // 选中左栏二级分组:先切到该分组所属源(右侧内容随之切换),
@@ -761,61 +769,75 @@ export function useReferenceSourcePickerView({
     },
     [isOpeningReference]
   );
-  const confirm = useCallback(async () => {
-    if (confirmingRef.current) {
-      return;
-    }
-    if (selectableSelection.length === 0) {
-      controller.clearSelection();
-      return;
-    }
-    const confirmationGeneration = ++confirmationGenerationRef.current;
-    confirmingRef.current = true;
-    setIsConfirming(true);
-    setConfirmError(null);
-    try {
-      if (onConfirmBundles) {
-        const grouped = await controller.confirmGrouped(selectableSelection);
-        if (confirmationGeneration !== confirmationGenerationRef.current) {
-          return;
-        }
-        onConfirmBundles({
-          files: grouped.files.map(selectedReferenceToWorkspaceFileReference),
-          bundles: grouped.bundles.map((bundle) => ({
-            sourceId: bundle.root.ref.sourceId,
-            nodeId: bundle.root.ref.nodeId,
-            displayName: bundle.root.displayName,
-            iconUrl: bundle.root.iconUrl ?? null,
-            handle: bundle.handle,
-            // 展示用文件数:取节点 childCount(不再展开文件);缺省回退 0。
-            fileCount: bundle.root.childCount ?? 0
-          }))
-        });
-      } else {
-        const selected: SelectedReference[] =
-          await controller.confirm(selectableSelection);
-        if (confirmationGeneration !== confirmationGenerationRef.current) {
-          return;
-        }
-        onConfirm(selected.map(selectedReferenceToWorkspaceFileReference));
-      }
-      onClose();
-    } catch (error) {
-      if (confirmationGeneration !== confirmationGenerationRef.current) {
+  const confirm = useCallback(
+    async (overrideSelection?: readonly ReferenceNode[]) => {
+      if (confirmingRef.current) {
         return;
       }
-      setConfirmError(
-        error instanceof Error
-          ? error
-          : new Error("reference confirmation failed")
-      );
-    } finally {
-      if (confirmationGeneration === confirmationGenerationRef.current) {
-        confirmingRef.current = false;
-        setIsConfirming(false);
+      const selection =
+        overrideSelection && overrideSelection.length > 0
+          ? overrideSelection.filter((node) => isNodeSelectable?.(node) ?? true)
+          : selectableSelection;
+      if (selection.length === 0) {
+        controller.clearSelection();
+        return;
       }
-    }
-  }, [controller, onClose, onConfirm, onConfirmBundles, selectableSelection]);
+      const confirmationGeneration = ++confirmationGenerationRef.current;
+      confirmingRef.current = true;
+      setIsConfirming(true);
+      setConfirmError(null);
+      try {
+        if (onConfirmBundles) {
+          const grouped = await controller.confirmGrouped(selection);
+          if (confirmationGeneration !== confirmationGenerationRef.current) {
+            return;
+          }
+          onConfirmBundles({
+            files: grouped.files.map(selectedReferenceToWorkspaceFileReference),
+            bundles: grouped.bundles.map((bundle) => ({
+              sourceId: bundle.root.ref.sourceId,
+              nodeId: bundle.root.ref.nodeId,
+              displayName: bundle.root.displayName,
+              iconUrl: bundle.root.iconUrl ?? null,
+              handle: bundle.handle,
+              // 展示用文件数:取节点 childCount(不再展开文件);缺省回退 0。
+              fileCount: bundle.root.childCount ?? 0
+            }))
+          });
+        } else {
+          const selected: SelectedReference[] =
+            await controller.confirm(selection);
+          if (confirmationGeneration !== confirmationGenerationRef.current) {
+            return;
+          }
+          onConfirm(selected.map(selectedReferenceToWorkspaceFileReference));
+        }
+        onClose();
+      } catch (error) {
+        if (confirmationGeneration !== confirmationGenerationRef.current) {
+          return;
+        }
+        setConfirmError(
+          error instanceof Error
+            ? error
+            : new Error("reference confirmation failed")
+        );
+      } finally {
+        if (confirmationGeneration === confirmationGenerationRef.current) {
+          confirmingRef.current = false;
+          setIsConfirming(false);
+        }
+      }
+    },
+    [
+      controller,
+      isNodeSelectable,
+      onClose,
+      onConfirm,
+      onConfirmBundles,
+      selectableSelection
+    ]
+  );
 
   const previewController = useMemo(
     () =>

--- a/packages/workspace/file-reference/src/ui/internal/reference/ReferenceSourcePicker.render.test.ts
+++ b/packages/workspace/file-reference/src/ui/internal/reference/ReferenceSourcePicker.render.test.ts
@@ -208,6 +208,80 @@ test("reference source picker renders shared folder icons and content errors", a
       "directoryPicker.searchPlaceholder"
     );
 
+    const confirmedRoots: Array<
+      Array<{ path: string; kind: string; displayName: string }>
+    > = [];
+    let rootConfirmCloseCount = 0;
+    (
+      globalThis as { __referenceSourcePickerView?: unknown }
+    ).__referenceSourcePickerView = {
+      ...createFolderOnlyView(folderNode),
+      activeSourceId: "workspace",
+      activeTabLabel: "Workspace",
+      currentEntries: [],
+      currentNode: null,
+      focusedNode: null,
+      selection: [],
+      selectionCount: 0,
+      selectedGroupKey: null
+    };
+    await act(async () => {
+      root?.render(
+        createElement(ReferenceSourcePicker, {
+          aggregator: {},
+          confirmRootDirectoryPath: "/workspace",
+          copy: createCopy(),
+          fileManagerCopy: { t: (key: string) => key },
+          onClose() {
+            rootConfirmCloseCount += 1;
+          },
+          onConfirm(
+            refs: Array<{ path: string; kind: string; displayName: string }>
+          ) {
+            confirmedRoots.push(refs);
+          },
+          open: true,
+          purpose: "directory",
+          workspaceId: "workspace-directory-root-confirm-test"
+        } as unknown as ReferenceSourcePickerProps)
+      );
+    });
+    const rootConfirmBody = dom.window.document.body.textContent ?? "";
+    assert.match(rootConfirmBody, /Workspace/);
+    assert.match(rootConfirmBody, /\/workspace/);
+    assert.match(rootConfirmBody, /referencePicker\.previewFolder/);
+    assert.match(rootConfirmBody, /referencePicker\.emptyDirectory/);
+    assert.doesNotMatch(rootConfirmBody, /referencePicker\.selectGroupHint/);
+    assert.doesNotMatch(rootConfirmBody, /referencePicker\.emptyPreview/);
+    const rootConfirmButton = Array.from(
+      dom.window.document.querySelectorAll("button")
+    ).find((button) => button.textContent === "directoryPicker.confirm");
+    assert.ok(rootConfirmButton);
+    assert.equal(rootConfirmButton.disabled, false);
+    await act(async () => {
+      rootConfirmButton.dispatchEvent(
+        new dom.window.MouseEvent("click", { bubbles: true })
+      );
+    });
+    assert.deepEqual(confirmedRoots, [
+      [{ path: "/workspace", kind: "folder", displayName: "workspace" }]
+    ]);
+    assert.equal(rootConfirmCloseCount, 1);
+
+    (
+      globalThis as { __referenceSourcePickerView?: unknown }
+    ).__referenceSourcePickerView = {
+      ...createFolderOnlyView(folderNode),
+      canCreateDirectory: true,
+      capabilities: { directoryCreatable: true, filterable: true },
+      filterCategories: [
+        {
+          extensions: ["png"],
+          id: "image",
+          labelKey: "referencePicker.fileTypeImage"
+        }
+      ]
+    };
     let pickerCloseCount = 0;
     await act(async () => {
       root?.render(
@@ -752,6 +826,7 @@ function buildReferenceSourcePickerRenderModule(tempDir: string): string {
     tempDir,
     "core.mjs",
     `
+      export const SOURCE_ROOT_NODE_ID = "\\0source-root";
       export function base64UrlDecode(value) {
         return Buffer.from(value, "base64url").toString("utf8");
       }
@@ -774,7 +849,7 @@ function buildReferenceSourcePickerRenderModule(tempDir: string): string {
     "presentation.mjs",
     `
       export function formatReferenceNodePathText(node) {
-        return node.ref.nodeId;
+        return node.contextLabel || node.displayName || node.ref.nodeId;
       }
       export function formatReferencePreviewDateTime(value) {
         return String(value);
@@ -850,7 +925,7 @@ function buildReferenceSourcePickerRenderModule(tempDir: string): string {
       new RegExp(
         'import \\{\\s*base64UrlDecode[\\s\\S]*?\\} from "../../../core/index\\.ts";'
       ),
-      `import { base64UrlDecode, nodeRefKey } from "${coreUrl}";`
+      `import { base64UrlDecode, nodeRefKey, SOURCE_ROOT_NODE_ID } from "${coreUrl}";`
     )
     .replace(
       new RegExp(
@@ -928,6 +1003,8 @@ function createFolderOnlyView(node: ReferenceNode) {
     selectedGroupKey: "workspace:root",
     selection: [],
     selectionCount: 0,
+    activeSourceId: "workspace",
+    currentNode: null,
     setFilters: () => {},
     setFocusedNode: () => {},
     setSearchQuery: () => {},

--- a/packages/workspace/file-reference/src/ui/internal/reference/ReferenceSourcePicker.render.test.ts
+++ b/packages/workspace/file-reference/src/ui/internal/reference/ReferenceSourcePicker.render.test.ts
@@ -675,7 +675,14 @@ function buildReferenceSourcePickerRenderModule(tempDir: string): string {
     "file-preview.mjs",
     `
       import { createElement } from "react";
-      export function WorkspaceFilePreviewSurface({ emptyMessage }) {
+      export function WorkspaceFilePreviewSurface({
+        directoryMessage,
+        emptyMessage,
+        state
+      }) {
+        if (state?.status === "directory") {
+          return createElement("div", null, directoryMessage);
+        }
         return createElement("div", null, emptyMessage);
       }
     `

--- a/packages/workspace/file-reference/src/ui/internal/reference/ReferenceSourcePicker.tsx
+++ b/packages/workspace/file-reference/src/ui/internal/reference/ReferenceSourcePicker.tsx
@@ -66,6 +66,7 @@ import type { ReferenceSourceAggregator } from "../../../core/referenceSourceAgg
 import {
   base64UrlDecode,
   nodeRefKey,
+  SOURCE_ROOT_NODE_ID,
   type ReferenceFilterCategory
 } from "../../../core/index.ts";
 import {
@@ -111,6 +112,12 @@ export interface ReferenceSourcePickerProps {
   onConfirmBundles?: (result: ReferenceGroupedSelection) => void;
   open: boolean;
   purpose?: "directory" | "reference";
+  /**
+   * Directory purpose only. When the user is at the source root with nothing
+   * selected, confirm uses this path ("save/export here" = current location).
+   * Nested folders still confirm via the entered/selected folder.
+   */
+  confirmRootDirectoryPath?: string;
   workspaceId: string;
 }
 
@@ -187,6 +194,7 @@ export function ReferenceSourcePicker({
   onConfirmBundles,
   open,
   purpose = "reference",
+  confirmRootDirectoryPath,
   renderHeaderActions,
   resolveContentErrorAction,
   resolveEntryIconUrl,
@@ -211,6 +219,68 @@ export function ReferenceSourcePicker({
       onClose();
     }
   }, [onClose, view.isConfirming]);
+  const trimmedConfirmRootDirectoryPath =
+    confirmRootDirectoryPath?.trim() ?? "";
+  const atConfirmRootDirectory =
+    purpose === "directory" &&
+    Boolean(trimmedConfirmRootDirectoryPath) &&
+    !view.currentNode;
+  // When "confirm current location" is the workspace root, surface it in the
+  // preview pane so the enabled footer reads as a real selection.
+  const confirmRootDirectoryNode = useMemo((): ReferenceNode | null => {
+    if (!atConfirmRootDirectory || !view.activeSourceId) {
+      return null;
+    }
+    const segments = trimmedConfirmRootDirectoryPath.split("/").filter(Boolean);
+    return {
+      kind: "folder",
+      displayName:
+        view.activeTabLabel.trim() ||
+        segments.at(-1) ||
+        trimmedConfirmRootDirectoryPath,
+      hasChildren: true,
+      contextLabel: trimmedConfirmRootDirectoryPath,
+      ref: {
+        sourceId: view.activeSourceId,
+        nodeId: SOURCE_ROOT_NODE_ID
+      }
+    };
+  }, [
+    atConfirmRootDirectory,
+    trimmedConfirmRootDirectoryPath,
+    view.activeSourceId,
+    view.activeTabLabel
+  ]);
+  const previewNode = view.focusedNode ?? confirmRootDirectoryNode;
+  const canConfirmDirectory =
+    view.selectionCount > 0 ||
+    Boolean(view.currentNode) ||
+    Boolean(trimmedConfirmRootDirectoryPath);
+  const handleConfirm = useCallback(() => {
+    if (view.selectionCount > 0) {
+      void view.confirm();
+      return;
+    }
+    if (purpose !== "directory") {
+      return;
+    }
+    if (view.currentNode) {
+      void view.confirm([view.currentNode]);
+      return;
+    }
+    if (!trimmedConfirmRootDirectoryPath) {
+      return;
+    }
+    const segments = trimmedConfirmRootDirectoryPath.split("/").filter(Boolean);
+    onConfirm([
+      {
+        path: trimmedConfirmRootDirectoryPath,
+        kind: "folder",
+        displayName: segments.at(-1) || trimmedConfirmRootDirectoryPath
+      }
+    ]);
+    onClose();
+  }, [onClose, onConfirm, purpose, trimmedConfirmRootDirectoryPath, view]);
   const [createDirectoryDialog, setCreateDirectoryDialog] = useState<{
     errorMessage: string | null;
     name: string;
@@ -527,7 +597,8 @@ export function ReferenceSourcePicker({
     return null;
   }
 
-  const hasSelectedGroup = view.selectedGroupKey != null;
+  const hasSelectedGroup =
+    view.selectedGroupKey != null || atConfirmRootDirectory;
   const fitSidebar = () =>
     autoFitPanelWidth(
       layoutRef.current,
@@ -836,7 +907,7 @@ export function ReferenceSourcePicker({
                   copy={copy}
                   hierarchy={view.breadcrumb}
                   iconUrls={iconUrls}
-                  node={view.focusedNode}
+                  node={previewNode}
                   previewState={view.previewState}
                   sourceLabel={view.activeTabLabel}
                 />
@@ -853,9 +924,25 @@ export function ReferenceSourcePicker({
               : "referencePicker.confirm"
           )}
           countLabel={copy.t("referencePicker.selectedCount", {
-            count: view.selectionCount
+            count:
+              purpose === "directory" &&
+              view.selectionCount === 0 &&
+              canConfirmDirectory
+                ? 1
+                : view.selectionCount
           })}
-          disabled={view.selectionCount === 0}
+          selection={
+            view.selection.length > 0
+              ? view.selection
+              : confirmRootDirectoryNode
+                ? [confirmRootDirectoryNode]
+                : view.selection
+          }
+          disabled={
+            purpose === "directory"
+              ? !canConfirmDirectory
+              : view.selectionCount === 0
+          }
           errorMessage={
             view.confirmError
               ? (fileManagerCopy?.t("unknownErrorMessage") ??
@@ -863,9 +950,8 @@ export function ReferenceSourcePicker({
               : null
           }
           loading={view.isConfirming}
-          selection={view.selection}
           onClose={requestClose}
-          onConfirm={() => void view.confirm()}
+          onConfirm={handleConfirm}
         />
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- Add opt-in `confirmRootDirectoryPath` for `purpose="directory"` so hosts can confirm the current browse root (e.g. `/workspace`) without injecting a placeholder folder row.
- When that root is active, show it in the preview pane and footer selection so the enabled confirm action reads as a real selection.
- In single-selection directory mode, clear stale nested selection when navigating back to the source root so confirm cannot keep targeting the previous child folder.

## Compatibility
- Callers that omit `confirmRootDirectoryPath` keep prior confirm semantics (still require a selected folder).
- Agent GUI "Use existing project" does not pass the prop, so it cannot confirm the workspace root.
- `purpose="reference"` pickers are unaffected.

## Test plan
- [x] `pnpm test` in `packages/workspace/file-reference`
- [ ] Manual: directory picker with `confirmRootDirectoryPath` set — root shows in preview, confirm returns that path
- [ ] Manual: enter a child folder then confirm — still returns the child path
- [ ] Manual: Agent GUI use-existing-project — still requires selecting a child folder; cannot confirm workspace root


Made with [Cursor](https://cursor.com)