### PR TITLE
fix(agent): preserve session rename through turn completion

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -488,6 +488,16 @@ reloading the page.
 
 A Session holds identity, target, provider metadata, cwd, title, settings, resume information, a Goal reference, and the current active Turn reference.
 
+Session title has an explicit ownership rule in the runtime. A user title
+(explicit rename) is immutable from the turn-execution path: a running turn may
+fold provider/event titles as candidates, but the controller's current Session
+is the only accepted state, and the turn-completion commit merges only the
+turn-owned lifecycle/status fields back. A title the user set is never
+overwritten by a late provider title or by a stale turn-completion snapshot,
+and neither the stream projection nor the durable report may carry a stale
+provider title over an established user title. On resume the runtime fails
+closed and treats a persisted title as user-established.
+
 A Session does not copy Turn phase/outcome, own pending Interactions, or persist lifecycle inferred from transcript.
 
 Provider-native subagents use child Sessions:

--- a/packages/agent/daemon/runtime/controller_report_projection_test.go
+++ b/packages/agent/daemon/runtime/controller_report_projection_test.go
@@ -231,6 +231,60 @@ func TestEnrichStreamStateEventsWithSessionSnapshotFillsRuntimeContext(t *testin
 	}
 }
 
+func TestSessionTitleEnrichmentDoesNotCrossSessionBoundaries(t *testing.T) {
+	t.Parallel()
+
+	controller := NewController(nil, nil)
+	session := Session{
+		RoomID:         "room-1",
+		AgentSessionID: "root-session",
+		Provider:       ProviderCodex,
+		Title:          "Root title",
+		UserTitleSet:   true,
+	}
+	controller.store(session)
+
+	report := &agentsessionstore.ReportActivityInput{
+		StatePatches: []agentsessionstore.WorkspaceAgentStatePatch{
+			{AgentSessionID: "root-session", Title: "Stale root title"},
+			{AgentSessionID: "child-session", Title: "Child title"},
+		},
+	}
+	controller.enrichReportStatePatchesWithSessionMetadata(session, report)
+	if got := report.StatePatches[0].Title; got != "Root title" {
+		t.Fatalf("root report title = %q, want Root title", got)
+	}
+	if got := report.StatePatches[1].Title; got != "Child title" {
+		t.Fatalf("child report title = %q, want Child title", got)
+	}
+
+	stream := []StreamEvent{
+		{
+			EventType: StreamEventStatePatch,
+			Data: agentsessionstore.WorkspaceAgentStatePatch{
+				AgentSessionID: "root-session",
+				Title:          "Stale root title",
+			},
+		},
+		{
+			EventType: StreamEventStatePatch,
+			Data: agentsessionstore.WorkspaceAgentStatePatch{
+				AgentSessionID: "child-session",
+				Title:          "Child title",
+			},
+		},
+	}
+	controller.enrichStreamStateEventsWithSessionSnapshot(session, stream)
+	rootPatch := stream[0].Data.(agentsessionstore.WorkspaceAgentStatePatch)
+	childPatch := stream[1].Data.(agentsessionstore.WorkspaceAgentStatePatch)
+	if rootPatch.Title != "Root title" {
+		t.Fatalf("root stream title = %q, want Root title", rootPatch.Title)
+	}
+	if childPatch.Title != "Child title" {
+		t.Fatalf("child stream title = %q, want Child title", childPatch.Title)
+	}
+}
+
 func TestDeriveSessionStatusFromEvents(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/controller_report_worker.go
+++ b/packages/agent/daemon/runtime/controller_report_worker.go
@@ -333,7 +333,17 @@ func (c *Controller) enrichReportStatePatchesWithSessionMetadata(
 	if snapshot.AgentSessionID == "" {
 		return
 	}
-	enrichReportStatePatchesWithSessionMetadata(report, statePatchFromSessionStateSnapshot(snapshot))
+	snapshotPatch := statePatchFromSessionStateSnapshot(snapshot)
+	enrichReportStatePatchesWithSessionMetadata(report, snapshotPatch)
+	if session.UserTitleSet {
+		// A user-established title is the authoritative title source. Never let
+		// a stale provider title carried by an event payload override it here;
+		// the session's accepted title always wins in the persisted report.
+		title := strings.TrimSpace(snapshotPatch.Title)
+		for index := range report.StatePatches {
+			report.StatePatches[index].Title = title
+		}
+	}
 }
 
 func (c *Controller) enrichStreamStateEventsWithSessionSnapshot(
@@ -362,6 +372,11 @@ func (c *Controller) enrichStreamStateEventsWithSessionSnapshot(
 		enrichReportStatePatchesWithSessionMetadata(&tmp, snapshotPatch)
 		tmp.StatePatches[0].TurnLifecycle = cloneTurnLifecycle(snapshotPatch.TurnLifecycle)
 		tmp.StatePatches[0].SubmitAvailability = cloneSubmitAvailability(snapshotPatch.SubmitAvailability)
+		if session.UserTitleSet {
+			// Same ownership rule as the report enrichment: a user-established
+			// title is the authoritative title source for the stream projection.
+			tmp.StatePatches[0].Title = strings.TrimSpace(snapshotPatch.Title)
+		}
 		events[index].Data = tmp.StatePatches[0]
 	}
 }

--- a/packages/agent/daemon/runtime/controller_report_worker.go
+++ b/packages/agent/daemon/runtime/controller_report_worker.go
@@ -341,6 +341,9 @@ func (c *Controller) enrichReportStatePatchesWithSessionMetadata(
 		// the session's accepted title always wins in the persisted report.
 		title := strings.TrimSpace(snapshotPatch.Title)
 		for index := range report.StatePatches {
+			if !statePatchMatchesSession(report.StatePatches[index], snapshotPatch.AgentSessionID) {
+				continue
+			}
 			report.StatePatches[index].Title = title
 		}
 	}
@@ -372,13 +375,21 @@ func (c *Controller) enrichStreamStateEventsWithSessionSnapshot(
 		enrichReportStatePatchesWithSessionMetadata(&tmp, snapshotPatch)
 		tmp.StatePatches[0].TurnLifecycle = cloneTurnLifecycle(snapshotPatch.TurnLifecycle)
 		tmp.StatePatches[0].SubmitAvailability = cloneSubmitAvailability(snapshotPatch.SubmitAvailability)
-		if session.UserTitleSet {
+		if session.UserTitleSet && statePatchMatchesSession(patch, snapshotPatch.AgentSessionID) {
 			// Same ownership rule as the report enrichment: a user-established
 			// title is the authoritative title source for the stream projection.
 			tmp.StatePatches[0].Title = strings.TrimSpace(snapshotPatch.Title)
 		}
 		events[index].Data = tmp.StatePatches[0]
 	}
+}
+
+func statePatchMatchesSession(
+	patch agentsessionstore.WorkspaceAgentStatePatch,
+	sessionID string,
+) bool {
+	sessionID = strings.TrimSpace(sessionID)
+	return sessionID != "" && strings.TrimSpace(patch.AgentSessionID) == sessionID
 }
 
 // enrichReportStatePatchesWithSessionMetadata fills stable session metadata on

--- a/packages/agent/daemon/runtime/controller_session_commit.go
+++ b/packages/agent/daemon/runtime/controller_session_commit.go
@@ -1,0 +1,129 @@
+package agentruntime
+
+import "strings"
+
+// Session commit boundary
+// -----------------------
+//
+// A turn-execution goroutine captures a Session snapshot when its turn begins
+// and folds provider events onto that local value while the provider runs.
+// Meanwhile the controller's live session may be mutated concurrently by other
+// lifecycle commands (SetTitle, SetVisible, UpdateSettings), so the exec-path
+// snapshot is never the accepted state. commitTurnExecSessionLocked is the
+// single boundary through which those goroutines write back, and it merges only
+// the fields turn execution owns. Callers must publish and report using the
+// returned accepted session, never the exec-path snapshot.
+
+// mergeTurnExecSession produces the accepted session for a turn-execution
+// commit. `current` is the controller's current session (the only accepted
+// state); `update` is the turn goroutine's local snapshot. Only
+// turn-execution-owned fields are taken from `update`; user-mutated fields
+// (Title, Visible, Settings, PermissionModeID) and identity fields are always
+// preserved from `current`, so a concurrent SetTitle/SetVisible/UpdateSettings
+// can never be lost to a stale exec copy.
+func mergeTurnExecSession(current, update Session) (Session, bool) {
+	// A stale adapter lifecycle snapshot (already superseded by a newer one
+	// applied through the session-event sink) must never regress the accepted
+	// session. This lost-update guard previously lived only in storeTurnSession;
+	// finishTurn now applies the same rule so settlement cannot resurrect an
+	// older lifecycle.
+	if current.LifecycleAuthority && current.LifecycleSeq > update.LifecycleSeq {
+		return Session{}, false
+	}
+	accepted := current
+
+	// Turn-execution-owned fields: lifecycle, status, availability, and the
+	// event-derived facts only turn execution observes.
+	accepted.Status = update.Status
+	accepted.TurnLifecycle = cloneRuntimeTurnLifecycle(update.TurnLifecycle)
+	accepted.SubmitAvailability = cloneRuntimeSubmitAvailability(update.SubmitAvailability)
+	accepted.LastError = update.LastError
+	accepted.Resumable = current.Resumable || update.Resumable
+	if providerSessionID := strings.TrimSpace(update.ProviderSessionID); providerSessionID != "" {
+		accepted.ProviderSessionID = providerSessionID
+	}
+	if update.UpdatedAtUnixMS > current.UpdatedAtUnixMS {
+		accepted.UpdatedAtUnixMS = update.UpdatedAtUnixMS
+	}
+	if update.LifecycleAuthority {
+		accepted.LifecycleAuthority = true
+		if update.LifecycleSeq > accepted.LifecycleSeq {
+			accepted.LifecycleSeq = update.LifecycleSeq
+		}
+	}
+
+	// Title ownership: a title the user set explicitly is immutable from the
+	// exec path's perspective. A provider/event title is only a candidate while
+	// no user title exists; once accepted it is carried into the accepted
+	// session without changing the established-title state.
+	if current.UserTitleSet {
+		accepted.Title = current.Title
+	} else if strings.TrimSpace(update.Title) != "" {
+		accepted.Title = strings.TrimSpace(update.Title)
+	}
+	accepted.UserTitleSet = current.UserTitleSet
+
+	accepted.RuntimeContext = mergeTurnExecRuntimeContext(
+		current.RuntimeContext,
+		update.RuntimeContext,
+		accepted.SettingsValue(),
+		accepted.InitialTitleEstablished,
+	)
+	return accepted, true
+}
+
+// mergeTurnExecRuntimeContext preserves the accepted runtime context while
+// merging event-derived keys from the exec snapshot, then re-asserts the
+// settings-derived keys and the initial-title marker from the accepted session
+// so a stale exec copy can never clobber concurrent settings or title state.
+func mergeTurnExecRuntimeContext(
+	current, update map[string]any,
+	settings SessionSettings,
+	established bool,
+) map[string]any {
+	merged := clonePayload(current)
+	if merged == nil {
+		merged = map[string]any{}
+	}
+	if len(update) > 0 {
+		merged = mergeRuntimeContextPatch(merged, update)
+	}
+	merged = runtimeContextWithSessionSettings(merged, settings)
+	return runtimeContextWithInitialTitleEstablished(merged, established)
+}
+
+// commitTurnExecSessionLocked validates the turn fence, applies the merge onto
+// the controller's current session, optionally settles the turn, and persists
+// the accepted session. When settle is true the matched turn fence is always
+// removed — even if the merge rejects the write (different live turn, newer
+// adapter lifecycle, closed session) — because a stale exec snapshot must not
+// keep the fence open.
+func (c *Controller) commitTurnExecSessionLocked(key, turnID string, update Session, settle bool) (Session, bool) {
+	active, ok := c.turns[key]
+	if !ok || strings.TrimSpace(active.turnID) != strings.TrimSpace(turnID) {
+		return Session{}, false
+	}
+	if settle {
+		delete(c.turns, key)
+	}
+	current, ok := c.sessions[key]
+	if !ok {
+		return Session{}, false
+	}
+	if settle && sessionHasDifferentLiveTurn(current, turnID) {
+		return Session{}, false
+	}
+	accepted, ok := mergeTurnExecSession(current, update)
+	if !ok {
+		return Session{}, false
+	}
+	if settle && !accepted.LifecycleAuthority {
+		// ADR 0008: snapshot-authority sessions already settle through their own
+		// copied lifecycle; legacy sessions get the controller-origin settle and
+		// a pure status reconcile.
+		accepted = settleFinishedTurnLifecycle(accepted, turnID)
+		accepted = c.reconcileSessionStatusLocked(key, accepted)
+	}
+	c.sessions[key] = accepted
+	return accepted, true
+}

--- a/packages/agent/daemon/runtime/controller_session_lifecycle.go
+++ b/packages/agent/daemon/runtime/controller_session_lifecycle.go
@@ -174,7 +174,11 @@ func (c *Controller) Resume(ctx context.Context, input ResumeInput) (Session, er
 		Status:                  firstNonEmpty(normalizeSessionStatus(input.Status), SessionStatusReady),
 		Title:                   strings.TrimSpace(input.Title),
 		InitialTitleEstablished: initialTitleEstablished,
-		Visible:                 sessionVisible(input.Visible),
+		// UserTitleSet fails closed on resume: the persisted title (or a legacy
+		// fail-closed marker) is treated as user-established so a late provider
+		// title cannot clobber a title the user set before restart.
+		UserTitleSet: initialTitleEstablished,
+		Visible:      sessionVisible(input.Visible),
 		RuntimeContext: runtimeContextWithInitialTitleEstablished(
 			input.RuntimeContext,
 			initialTitleEstablished,
@@ -320,6 +324,7 @@ func (c *Controller) SetTitle(ctx context.Context, roomID, agentSessionID string
 	if session.Title == title {
 		if !session.InitialTitleEstablished {
 			session = markInitialTitleEstablished(session)
+			session.UserTitleSet = true
 			session.UpdatedAtUnixMS = unixMS(now())
 			c.store(session)
 			c.enqueueSessionReport(ctx, session, []activityshared.Event{
@@ -335,6 +340,7 @@ func (c *Controller) SetTitle(ctx context.Context, roomID, agentSessionID string
 	}
 	session.Title = title
 	session = markInitialTitleEstablished(session)
+	session.UserTitleSet = true
 	session.UpdatedAtUnixMS = unixMS(now())
 	c.store(session)
 	events := []activityshared.Event{newSessionTitleActivityEvent(session, title)}
@@ -432,12 +438,15 @@ func cloneSessionSettings(settings SessionSettings) *SessionSettings {
 // provider session id, title, runtime context, and last error. It is the
 // shared core of the legacy applySessionEvents fold and the ADR 0008
 // authority path (which derives status purely from the lifecycle instead).
+//
+// A provider/event title is a candidate, not the owner: once the user set the
+// title explicitly (UserTitleSet) it is never overwritten by an event title.
 func applySessionEventsBase(session Session, events []activityshared.Event) Session {
 	for _, event := range events {
 		if strings.TrimSpace(event.ProviderSessionID) != "" {
 			session.ProviderSessionID = strings.TrimSpace(event.ProviderSessionID)
 		}
-		if title := strings.TrimSpace(event.Payload.Title); title != "" {
+		if title := strings.TrimSpace(event.Payload.Title); title != "" && !session.UserTitleSet {
 			session.Title = title
 		}
 		if runtimeContext := payloadMap(event.Payload.Metadata, "runtimeContext"); len(runtimeContext) > 0 {
@@ -458,7 +467,7 @@ func applySessionEvents(session Session, events []activityshared.Event) Session 
 		if strings.TrimSpace(event.ProviderSessionID) != "" {
 			session.ProviderSessionID = strings.TrimSpace(event.ProviderSessionID)
 		}
-		if title := strings.TrimSpace(event.Payload.Title); title != "" {
+		if title := strings.TrimSpace(event.Payload.Title); title != "" && !session.UserTitleSet {
 			session.Title = title
 		}
 		if runtimeContext := payloadMap(event.Payload.Metadata, "runtimeContext"); len(runtimeContext) > 0 {

--- a/packages/agent/daemon/runtime/controller_session_rename_race_test.go
+++ b/packages/agent/daemon/runtime/controller_session_rename_race_test.go
@@ -1,0 +1,386 @@
+package agentruntime
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+)
+
+// These tests lock in the title-ownership rule under concurrency: the
+// controller's current Session is the only accepted state, a turn-execution
+// goroutine merges only its owned fields back, and a user title (SetTitle) is
+// never overwritten by a late provider title or by the turn-completion write.
+
+// recordingStreamObserver captures every published stream projection in order.
+// The observer is synchronous with publish, so the recorded order is the exact
+// order consumers would observe.
+type recordingStreamObserver struct {
+	mu     sync.Mutex
+	events []StreamEvent
+}
+
+func (o *recordingStreamObserver) ObserveRuntimeStreamEvents(_ context.Context, _, _ string, events []StreamEvent) error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.events = append(o.events, events...)
+	return nil
+}
+
+func (o *recordingStreamObserver) statePatches() []agentsessionstore.WorkspaceAgentStatePatch {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	var patches []agentsessionstore.WorkspaceAgentStatePatch
+	for _, event := range o.events {
+		if event.EventType != StreamEventStatePatch {
+			continue
+		}
+		patch, ok := event.Data.(agentsessionstore.WorkspaceAgentStatePatch)
+		if !ok {
+			continue
+		}
+		patches = append(patches, patch)
+	}
+	return patches
+}
+
+func (o *recordingStreamObserver) waitForCompletionPatch(t *testing.T, turnID string) agentsessionstore.WorkspaceAgentStatePatch {
+	t.Helper()
+	timer := time.NewTimer(10 * time.Second)
+	defer timer.Stop()
+	for {
+		for _, patch := range o.statePatches() {
+			if patch.Turn != nil &&
+				strings.TrimSpace(patch.Turn.TurnID) == strings.TrimSpace(turnID) &&
+				patch.Turn.CompletedAtUnixMS > 0 {
+				return patch
+			}
+		}
+		select {
+		case <-time.After(10 * time.Millisecond):
+		case <-timer.C:
+			t.Fatalf("timed out waiting for stream completion patch for turn %q; patches=%#v", turnID, o.statePatches())
+		}
+	}
+}
+
+// lateProviderTitleAdapter blocks Exec until the test signals a provider title
+// to emit and then until the test releases the turn to complete.
+type lateProviderTitleAdapter struct {
+	started      chan struct{}
+	emitTitle    chan string
+	titleEmitted chan struct{}
+	releases     chan struct{}
+}
+
+func newLateProviderTitleAdapter() *lateProviderTitleAdapter {
+	return &lateProviderTitleAdapter{
+		started:      make(chan struct{}),
+		emitTitle:    make(chan string),
+		titleEmitted: make(chan struct{}),
+		releases:     make(chan struct{}),
+	}
+}
+
+func (*lateProviderTitleAdapter) Provider() string { return ProviderCodex }
+
+func (*lateProviderTitleAdapter) Start(context.Context, Session) ([]activityshared.Event, error) {
+	return nil, nil
+}
+
+func (*lateProviderTitleAdapter) Resume(context.Context, Session) error { return nil }
+
+func (*lateProviderTitleAdapter) Close(context.Context, Session) error { return nil }
+
+func (*lateProviderTitleAdapter) Cancel(context.Context, Session, string) ([]activityshared.Event, error) {
+	return nil, nil
+}
+
+func (a *lateProviderTitleAdapter) Exec(
+	ctx context.Context,
+	session Session,
+	_ []PromptContentBlock,
+	_ string,
+	turnID string,
+	emit EventSink,
+	_ CommandSnapshotSink,
+) ([]activityshared.Event, error) {
+	emit([]activityshared.Event{newTurnActivityEvent(session, EventTurnStarted, turnID, SessionStatusWorking, "", "", nil)})
+	close(a.started)
+	select {
+	case title := <-a.emitTitle:
+		emit([]activityshared.Event{newSessionTitleActivityEvent(session, title)})
+		close(a.titleEmitted)
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	select {
+	case <-a.releases:
+		return []activityshared.Event{newTurnActivityEvent(session, EventTurnCompleted, turnID, SessionStatusReady, "", "", nil)}, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// waitForUserTitle asserts the stream never reverts to the pre-rename title
+// after the user title first appears.
+func assertStreamKeepsUserTitle(t *testing.T, patches []agentsessionstore.WorkspaceAgentStatePatch, userTitle, oldTitle string) {
+	t.Helper()
+	seen := false
+	for _, patch := range patches {
+		title := strings.TrimSpace(patch.Title)
+		if !seen && title == userTitle {
+			seen = true
+			continue
+		}
+		if seen && title == oldTitle {
+			t.Fatalf("stale title %q reappeared after user title %q in stream patches %v", oldTitle, userTitle, streamPatchTitles(patches))
+		}
+	}
+	if !seen {
+		t.Fatalf("user title %q never appeared in stream patches %v", userTitle, streamPatchTitles(patches))
+	}
+}
+
+func streamPatchTitles(patches []agentsessionstore.WorkspaceAgentStatePatch) []string {
+	titles := make([]string, 0, len(patches))
+	for _, patch := range patches {
+		titles = append(titles, strings.TrimSpace(patch.Title))
+	}
+	return titles
+}
+
+func completionReport(reports []reportCall, turnID string) (agentsessionstore.ReportActivityInput, bool) {
+	for _, call := range reports {
+		if hasTurnCompletionPatch(call.report, turnID) {
+			return call.report, true
+		}
+	}
+	return agentsessionstore.ReportActivityInput{}, false
+}
+
+func reportStatePatchTitles(report agentsessionstore.ReportActivityInput) []string {
+	titles := make([]string, 0, len(report.StatePatches))
+	for _, patch := range report.StatePatches {
+		titles = append(titles, strings.TrimSpace(patch.Title))
+	}
+	return titles
+}
+
+// SetTitle during an active turn must survive turn completion: the Session, the
+// stream projection, and the durable report must all keep the new title, and no
+// terminal event may carry the pre-rename title.
+func TestControllerSetTitleDuringActiveTurnSurvivesCompletion(t *testing.T) {
+	t.Parallel()
+
+	adapter := newBlockingExecAdapter()
+	reporter := &recordingReporter{}
+	observer := &recordingStreamObserver{}
+	controller := NewController([]Adapter{adapter}, reporter)
+	controller.SetStreamEventObserver(observer)
+
+	started, err := controller.Start(context.Background(), StartInput{
+		RoomID:         "room-1",
+		AgentSessionID: "agent-session-1",
+		Provider:       ProviderCodex,
+		Title:          "Initial title",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	execResult, err := controller.Exec(context.Background(), ExecInput{
+		RoomID:         "room-1",
+		AgentSessionID: started.Session.AgentSessionID,
+		Content:        textPrompt("hello"),
+	})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	adapter.waitForPrompt(t, "hello")
+
+	// The user renames while the turn is still running.
+	if _, err := controller.SetTitle(context.Background(), "room-1", started.Session.AgentSessionID, "User title"); err != nil {
+		t.Fatalf("SetTitle: %v", err)
+	}
+	adapter.releaseNext()
+
+	// The turn completes; the accepted session must keep the user title.
+	waitForCondition(t, func() bool {
+		session, ok := controller.get("room-1", started.Session.AgentSessionID)
+		return ok && session.Status == SessionStatusReady && session.Title == "User title"
+	})
+
+	completionPatch := observer.waitForCompletionPatch(t, execResult.TurnID)
+	if strings.TrimSpace(completionPatch.Title) != "User title" {
+		t.Fatalf("stream completion patch title = %q, want user title", completionPatch.Title)
+	}
+	assertStreamKeepsUserTitle(t, observer.statePatches(), "User title", "Initial title")
+
+	reports := reporter.waitForReports(t, "turn completion report", func(calls []reportCall) bool {
+		_, ok := completionReport(calls, execResult.TurnID)
+		return ok
+	})
+	completion, ok := completionReport(reports, execResult.TurnID)
+	if !ok {
+		t.Fatalf("completion report missing; reports=%#v", reports)
+	}
+	if titles := reportStatePatchTitles(completion); len(titles) == 0 {
+		t.Fatalf("completion report has no state patches")
+	} else if titles[len(titles)-1] != "User title" {
+		t.Fatalf("completion report titles = %v, want final user title", titles)
+	}
+}
+
+// A provider title that arrives late must not overwrite a user rename. The
+// session keeps the user title and the late provider title never reaches the
+// stream or the report.
+func TestControllerLateProviderTitleCannotOverwriteUserRename(t *testing.T) {
+	t.Parallel()
+
+	adapter := newLateProviderTitleAdapter()
+	reporter := &recordingReporter{}
+	observer := &recordingStreamObserver{}
+	controller := NewController([]Adapter{adapter}, reporter)
+	controller.SetStreamEventObserver(observer)
+
+	started, err := controller.Start(context.Background(), StartInput{
+		RoomID:         "room-1",
+		AgentSessionID: "agent-session-1",
+		Provider:       ProviderCodex,
+		Title:          "Initial title",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	execResult, err := controller.Exec(context.Background(), ExecInput{
+		RoomID:         "room-1",
+		AgentSessionID: started.Session.AgentSessionID,
+		Content:        textPrompt("hello"),
+	})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	<-adapter.started
+
+	if _, err := controller.SetTitle(context.Background(), "room-1", started.Session.AgentSessionID, "User title"); err != nil {
+		t.Fatalf("SetTitle: %v", err)
+	}
+	adapter.emitTitle <- "Provider old title"
+	<-adapter.titleEmitted
+
+	if session, ok := controller.get("room-1", started.Session.AgentSessionID); !ok || session.Title != "User title" {
+		t.Fatalf("session title after late provider title = %q, want user title", session.Title)
+	}
+	// The late provider title must never surface in the stream projection.
+	assertStreamKeepsUserTitle(t, observer.statePatches(), "User title", "Initial title")
+
+	adapter.releases <- struct{}{}
+	waitForCondition(t, func() bool {
+		session, ok := controller.get("room-1", started.Session.AgentSessionID)
+		return ok && session.Status == SessionStatusReady && session.Title == "User title"
+	})
+
+	completionPatch := observer.waitForCompletionPatch(t, execResult.TurnID)
+	if strings.TrimSpace(completionPatch.Title) != "User title" {
+		t.Fatalf("stream completion patch title = %q, want user title", completionPatch.Title)
+	}
+	reports := reporter.waitForReports(t, "turn completion report", func(calls []reportCall) bool {
+		_, ok := completionReport(calls, execResult.TurnID)
+		return ok
+	})
+	if completion, ok := completionReport(reports, execResult.TurnID); ok {
+		if titles := reportStatePatchTitles(completion); len(titles) == 0 || titles[len(titles)-1] != "User title" {
+			t.Fatalf("completion report titles = %v, want final user title", titles)
+		}
+	} else {
+		t.Fatalf("completion report missing; reports=%#v", reports)
+	}
+}
+
+// The async turn-execution path applies the same merge boundary: a SetTitle
+// during an active async turn survives the async completion write-back.
+func TestControllerSetTitleDuringActiveAsyncTurnSurvivesCompletion(t *testing.T) {
+	t.Parallel()
+
+	adapter := newAsyncExecTestAdapter()
+	reporter := &recordingReporter{}
+	controller := NewController([]Adapter{adapter}, reporter)
+
+	started, err := controller.Start(context.Background(), StartInput{
+		RoomID:         "room-1",
+		AgentSessionID: "agent-session-1",
+		Provider:       ProviderCodex,
+		Title:          "Initial title",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if _, err := controller.Exec(context.Background(), ExecInput{
+		RoomID:         "room-1",
+		AgentSessionID: started.Session.AgentSessionID,
+		Content:        textPrompt("hello"),
+	}); err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	<-adapter.started
+
+	if _, err := controller.SetTitle(context.Background(), "room-1", started.Session.AgentSessionID, "User title"); err != nil {
+		t.Fatalf("SetTitle: %v", err)
+	}
+	adapter.release <- struct{}{}
+
+	waitForCondition(t, func() bool {
+		session, ok := controller.get("room-1", started.Session.AgentSessionID)
+		return ok && session.Status == SessionStatusReady && session.Title == "User title"
+	})
+}
+
+// The session-event sink (the adapter channel used by snapshot providers) must
+// respect a user-established title: a provider title event folded through the
+// general projection neither changes the session title nor leaks its stale
+// title into the report.
+func TestControllerSessionEventSinkTitleEventRespectsUserRename(t *testing.T) {
+	t.Parallel()
+
+	reporter := &recordingReporter{}
+	controller := NewController(nil, reporter)
+	initial := Session{
+		RoomID:         "room-1",
+		AgentSessionID: "agent-session-1",
+		Provider:       ProviderClaudeCode,
+		Status:         SessionStatusReady,
+		Title:          "Initial title",
+	}
+	controller.store(initial)
+
+	if _, err := controller.SetTitle(context.Background(), "room-1", "agent-session-1", "User title"); err != nil {
+		t.Fatalf("SetTitle: %v", err)
+	}
+	controller.applySessionEventsByAgentSessionID("agent-session-1", []activityshared.Event{
+		newSessionTitleActivityEvent(initial, "Provider old title"),
+	})
+
+	stored, ok := controller.get("room-1", "agent-session-1")
+	if !ok {
+		t.Fatal("stored session missing")
+	}
+	if stored.Title != "User title" {
+		t.Fatalf("session title = %q, want user title", stored.Title)
+	}
+	if !stored.UserTitleSet {
+		t.Fatal("session user-title marker lost")
+	}
+
+	reports := reporter.waitForCalls(t, 2)
+	for _, call := range reports {
+		for _, patch := range call.report.StatePatches {
+			if strings.TrimSpace(patch.Title) == "Provider old title" {
+				t.Fatalf("stale provider title leaked into report: %#v", call.report.StatePatches)
+			}
+		}
+	}
+}

--- a/packages/agent/daemon/runtime/controller_turn_exec.go
+++ b/packages/agent/daemon/runtime/controller_turn_exec.go
@@ -217,9 +217,13 @@ func (c *Controller) runBlockingExecTurn(
 			session.UpdatedAtUnixMS = unixMS(now())
 		}
 		session = c.preserveCurrentSessionSettings(session)
-		if !c.storeTurnSession(session, turnID) {
+		accepted, ok := c.storeTurnSession(session, turnID)
+		if !ok {
 			return
 		}
+		// Publish and report the accepted snapshot, never the stale exec copy:
+		// the controller's current session is the only accepted state.
+		session = accepted
 		emitted = append(emitted, events...)
 		if !c.isProvisionalSession(session) {
 			c.publish(session, events)
@@ -282,16 +286,16 @@ func (c *Controller) runBlockingExecTurn(
 			// Turn for the durable aggregation path to settle. The direct Turn
 			// failure is authoritative, so release the in-memory active-turn fence
 			// immediately after its event has been reported.
-			c.finishTurn(session, turnID)
+			_, _ = c.finishTurn(session, turnID)
 			return
 		}
 		// Exec returning closes only the provider invocation. The controller's
 		// active root turn remains addressable for guidance/cancel until the
 		// daemon commits and reconciles canonical root settlement.
-		c.storeTurnSession(session, turnID)
+		_, _ = c.storeTurnSession(session, turnID)
 		return
 	}
-	c.finishTurn(session, turnID)
+	_, _ = c.finishTurn(session, turnID)
 }
 
 func (c *Controller) isProvisionalSession(session Session) bool {
@@ -314,16 +318,17 @@ func (c *Controller) runAsyncExecTurn(ctx context.Context, session Session, adap
 	var mu sync.Mutex
 	finished := false
 	var emittedSummary agentSubmitRuntimeEventSummary
-	finish := func(next Session) bool {
+	finish := func(next Session) (Session, bool) {
 		if finished {
-			return false
+			return Session{}, false
 		}
 		finished = true
-		if !c.finishTurn(next, turnID) {
-			return false
+		accepted, ok := c.finishTurn(next, turnID)
+		if !ok {
+			return Session{}, false
 		}
-		emittedSummary.log("runtime.async_events_emitted.summary", next, turnID, metadata)
-		return true
+		emittedSummary.log("runtime.async_events_emitted.summary", accepted, turnID, metadata)
+		return accepted, true
 	}
 	emit := func(events []activityshared.Event) {
 		if len(events) == 0 {
@@ -343,18 +348,24 @@ func (c *Controller) runAsyncExecTurn(ctx context.Context, session Session, adap
 		terminal := turnHasTerminalEvent(events, turnID) ||
 			turnLifecycleSnapshotSettledTurn(events, turnID) ||
 			turnSteeredIntoActiveTurn(events, turnID)
+		var accepted Session
+		var ok bool
 		if terminal {
 			// Remove the controller's active-turn record before publishing a
 			// terminal/ready session. Consumers must never observe a ready session
 			// while HasActiveTurn still reports the finished turn.
 			emittedSummary.observe(events, session)
-			if !finish(session) {
-				return
-			}
+			accepted, ok = finish(session)
 		} else {
-			if !c.storeTurnSession(session, turnID) {
-				return
-			}
+			accepted, ok = c.storeTurnSession(session, turnID)
+		}
+		if !ok {
+			return
+		}
+		// Publish and report the accepted snapshot, never the stale exec copy:
+		// the controller's current session is the only accepted state.
+		session = accepted
+		if !terminal {
 			emittedSummary.observe(events, session)
 		}
 		c.publish(session, events)

--- a/packages/agent/daemon/runtime/controller_turn_finish.go
+++ b/packages/agent/daemon/runtime/controller_turn_finish.go
@@ -6,75 +6,56 @@ import (
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
-func (c *Controller) storeTurnSession(session Session, turnID string) bool {
+// storeTurnSession commits a mid-turn lifecycle snapshot produced by a turn
+// execution goroutine through the unified commit boundary. The controller's
+// current session is the only accepted state, so a concurrent user mutation
+// (SetTitle/SetVisible/UpdateSettings) is never overwritten by the stale exec
+// copy. It returns the accepted session; callers must publish and report with
+// that value, never the exec-path snapshot.
+func (c *Controller) storeTurnSession(session Session, turnID string) (Session, bool) {
 	if c == nil {
-		return false
+		return Session{}, false
 	}
 	key := sessionKey(session.RoomID, session.AgentSessionID)
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	active, ok := c.turns[key]
-	if !ok || strings.TrimSpace(active.turnID) != strings.TrimSpace(turnID) {
-		return false
-	}
-	current, ok := c.sessions[key]
-	if !ok {
-		return false
-	}
-	// A blocking Exec owns a local Session snapshot while the adapter's
-	// session-event sink can advance lifecycle concurrently. Never let the
-	// older local snapshot erase a newer synthetic continuation.
-	if current.LifecycleAuthority && current.LifecycleSeq > session.LifecycleSeq {
-		return false
-	}
-	c.sessions[key] = session
-	return true
+	return c.commitTurnExecSessionLocked(key, turnID, session, false)
 }
 
-func (c *Controller) finishTurn(session Session, turnID string) bool {
+// finishTurn settles the turn owned by an execution goroutine through the
+// unified commit boundary and returns the accepted session. Like
+// storeTurnSession it merges only turn-execution-owned fields, so settlement
+// never reverts a concurrent user title, visibility, or settings change.
+func (c *Controller) finishTurn(session Session, turnID string) (Session, bool) {
 	if c == nil {
-		return false
+		return Session{}, false
 	}
 	key := sessionKey(session.RoomID, session.AgentSessionID)
+	needsFallback := session.LifecycleAuthority &&
+		lifecycleStillActiveForTurn(session.TurnLifecycle, turnID)
 	c.mu.Lock()
-	active, ok := c.turns[key]
-	if !ok || strings.TrimSpace(active.turnID) != strings.TrimSpace(turnID) {
-		c.mu.Unlock()
-		return false
-	}
-	delete(c.turns, key)
-	current, ok := c.sessions[key]
-	if !ok {
-		c.mu.Unlock()
-		return false
-	}
-	if sessionHasDifferentLiveTurn(current, turnID) {
-		c.mu.Unlock()
-		return false
-	}
-	session = c.preserveCurrentSessionSettingsLocked(key, session)
-	if session.LifecycleAuthority {
-		// ADR 0008: no silent record mutation. If the adapter already settled
-		// this turn via its snapshot, nothing is left to do; otherwise (steer
-		// absorption, adapter death before settle) publish a controller-origin
-		// settled snapshot so even the fallback flows through the single copy
-		// pipeline — and reaches reporter/GUI, unlike the old silent write.
-		needsFallback := session.TurnLifecycle != nil &&
-			session.TurnLifecycle.ActiveTurnID != nil &&
-			strings.TrimSpace(*session.TurnLifecycle.ActiveTurnID) == strings.TrimSpace(turnID) &&
-			runtimeTurnLifecyclePhaseIsLive(session.TurnLifecycle.Phase)
-		c.sessions[key] = session
-		c.mu.Unlock()
-		if needsFallback {
-			c.applySessionEventsByAgentSessionID(session.AgentSessionID, settledFallbackTurnEvents(session, turnID))
-		}
-		return true
-	}
-	session = settleFinishedTurnLifecycle(session, turnID)
-	session = c.reconcileSessionStatusLocked(key, session)
-	c.sessions[key] = session
+	accepted, ok := c.commitTurnExecSessionLocked(key, turnID, session, true)
 	c.mu.Unlock()
-	return true
+	if !ok {
+		return Session{}, false
+	}
+	if needsFallback {
+		c.applySessionEventsByAgentSessionID(accepted.AgentSessionID, settledFallbackTurnEvents(accepted, turnID))
+	}
+	return accepted, true
+}
+
+// lifecycleStillActiveForTurn reports that the exec-path lifecycle still marks
+// the given turn live after Exec returned. For snapshot-authority sessions that
+// means the adapter never settled the turn it owns (for example a submission
+// absorbed by steering), so the controller publishes its own settled snapshot
+// to reach reporter/GUI.
+func lifecycleStillActiveForTurn(lifecycle *TurnLifecycle, turnID string) bool {
+	if lifecycle == nil || lifecycle.ActiveTurnID == nil {
+		return false
+	}
+	return strings.TrimSpace(*lifecycle.ActiveTurnID) == strings.TrimSpace(turnID) &&
+		runtimeTurnLifecyclePhaseIsLive(lifecycle.Phase)
 }
 
 // settledFallbackTurnEvents builds the controller-origin settled snapshot the

--- a/packages/agent/daemon/runtime/controller_turn_lifecycle_test.go
+++ b/packages/agent/daemon/runtime/controller_turn_lifecycle_test.go
@@ -185,7 +185,7 @@ func TestControllerStoreTurnSessionRejectsOlderAdapterLifecycle(t *testing.T) {
 	}
 	stale.SubmitAvailability = availableSubmitAvailability()
 
-	if controller.storeTurnSession(stale, turnID) {
+	if _, ok := controller.storeTurnSession(stale, turnID); ok {
 		t.Fatal("older adapter lifecycle overwrote current session")
 	}
 	stored, ok := controller.get("room-1", "agent-session-1")
@@ -287,7 +287,7 @@ func TestControllerFinishTurnDoesNotOverwriteRestartedSession(t *testing.T) {
 
 	// The canceled turn can unwind after a same-ID session has restarted. Its
 	// stale snapshot must not replace the fresh controller session.
-	if controller.storeTurnSession(staleTurnSession, turnID) {
+	if _, ok := controller.storeTurnSession(staleTurnSession, turnID); ok {
 		t.Fatal("late turn event stored stale session after restart")
 	}
 	controller.finishTurn(staleTurnSession, turnID)

--- a/packages/agent/daemon/runtime/types.go
+++ b/packages/agent/daemon/runtime/types.go
@@ -399,6 +399,13 @@ type Session struct {
 	// InitialTitleEstablished prevents a first-submit title candidate from
 	// overwriting a title established concurrently in this runtime.
 	InitialTitleEstablished bool `json:"-"`
+	// UserTitleSet records that the title was explicitly set by the user through
+	// SetTitle. It is runtime-only (never persisted): once set, provider/event
+	// title candidates are no longer applied, so a late provider title cannot
+	// revert a user rename. On resume the value fails closed to the established
+	// title so a restarted runtime never lets a provider title clobber a
+	// persisted user title.
+	UserTitleSet bool `json:"-"`
 }
 
 type SessionInteractivePrompt struct {


### PR DESCRIPTION
## Summary

- preserve user-renamed session titles when an active turn completes
- route blocking and async turn write-back through one accepted Session commit boundary
- prevent late provider title events from overwriting an explicit user title
- add deterministic blocking, async, provider-event-sink, stream, and report regressions
- document the Session title ownership rule

## Root cause

Turn execution retained a start-of-turn Session value copy and later wrote the whole copy over the controller's current Session. A concurrent rename was therefore lost in the runtime projection even though canonical persistence remained correct.

## Design

The controller's current Session is now the only accepted state. Turn completion merges only turn-owned fields and returns the accepted snapshot for stream/report publication. User title ownership is runtime-only and requires no database schema or migration.

## Validation

- `pnpm check:changed`
- `pnpm check:changed -- --push-ready`
- `go test ./runtime -skip SidecarTestDriver`
- targeted title-race tests with `-race -count=3`
- `go test ./service/agent/`

The SidecarTestDriver cases require an external Claude Code SDK binary and were excluded from the runtime suite; unrelated to this change.
