### PR TITLE
fix(app-center): make active catalog channel authoritative

### DIFF
--- a/.github/workflows/publish-tutti-app-release.yml
+++ b/.github/workflows/publish-tutti-app-release.yml
@@ -206,23 +206,27 @@ jobs:
             return 0;
           }
 
-          function nextVersionFromSources(prefix, bump, manifestVersion) {
+          function latestVersionSeed(prefix, manifestVersion, requireStableManifest) {
             execFileSync("git", ["fetch", "--tags", "--force"], { stdio: "inherit" });
             const tags = execFileSync("git", ["tag", "--list"], { encoding: "utf8" })
               .split("\n")
               .map((tag) => tag.trim())
               .filter((tag) => tag.startsWith(prefix));
+            const stableManifestVersion = String(manifestVersion || "")
+              .split("+", 1)[0]
+              .split("-", 1)[0];
             const manifestSeed = parseStableVersion(
-              manifestVersion,
+              stableManifestVersion,
               "package manifest"
             );
-            if (!manifestSeed) {
+            if (requireStableManifest && !manifestSeed) {
               fail(`Package manifest version must be stable semver x.y.z when release_bump is used, got ${manifestVersion}.`);
             }
             const tagSeeds = tags
               .map((tag) => parseStableVersion(tag.slice(prefix.length), `tag ${tag}`))
               .filter(Boolean);
-            const latest = [manifestSeed, ...tagSeeds].sort(compareVersions).at(-1) ?? {
+            const seeds = [...(manifestSeed ? [manifestSeed] : []), ...tagSeeds];
+            const latest = seeds.sort(compareVersions).at(-1) ?? {
               source: "default",
               version: "0.0.0",
               major: 0,
@@ -230,6 +234,11 @@ jobs:
               patch: 0
             };
             console.log(`Resolved release version seed ${latest.version} from ${latest.source}.`);
+            return latest;
+          }
+
+          function nextVersionFromSources(prefix, bump, manifestVersion) {
+            const latest = latestVersionSeed(prefix, manifestVersion, true);
 
             if (bump === "major") {
               return `${latest.major + 1}.0.0`;
@@ -266,7 +275,11 @@ jobs:
             if (shouldCreateTag) {
               fail("create_release_tag requires release_bump.");
             }
-            releaseVersion = `${manifest.version}+${gitSha.slice(0, 12)}`;
+            // Staging publishes do not bump. Seed from max(manifest, release tags)
+            // so staging stays on the same product line as production tags.
+            const tagPrefix = defaultTagPrefix();
+            const seed = latestVersionSeed(tagPrefix, manifest.version, false);
+            releaseVersion = `${seed.version}+${gitSha.slice(0, 12)}`;
           }
 
           if (!semverPattern.test(releaseVersion)) {

--- a/docs/conventions/workspace-app-catalog.md
+++ b/docs/conventions/workspace-app-catalog.md
@@ -141,8 +141,15 @@ Packaged Desktop uses the Electron package version; `make dev-gui` resolves the
 same Git-derived version used by desktop packaging before launching Electron.
 The daemon applies compatibility selection consistently to list, refresh,
 install, and update workflows. Missing or invalid host versions use `apps[]`.
-An installed app is updateable only when the selected catalog version is
-greater; catalog selection never automatically downgrades an app.
+
+Desktop preferences choose the active app catalog channel (`production` or
+`staging`). That channel selects which remote catalog URL to load. Once a
+catalog entry is selected for the host, it is authoritative for App Center
+update and materialize decisions: when the installed builtin package version
+differs from the selected catalog version, Tutti offers or applies that catalog
+package even if the catalog version is lower than a package previously installed
+from the other channel. Equal version strings leave the installed package in
+place.
 
 When a package manifest declares `localizationInfo`, release tooling reads the
 referenced package-local manifest locale files and writes their `name`,
@@ -184,8 +191,12 @@ compatibility metadata fails before package upload; there is no permissive
 default.
 
 Staging app releases do not create release tags. When `release_bump` is empty,
-the reusable workflow publishes `manifest.version+<short git sha>` from the
-packaged manifest.
+the reusable workflow resolves a stable seed from the greater of the packaged
+manifest version and existing `<appId>-v*` release tags, then publishes
+`<seed>+<short git sha>`. Production tags therefore keep staging builds aligned
+with the current product line (for example `0.1.45+<sha>` after `ai-doc-v0.1.45`),
+instead of freezing on a stale source-manifest version that production never
+rewrites.
 
 Staging caller workflows should run automatically on `push` to `main`, which is
 the event produced after a pull request is merged. Push-triggered staging runs

--- a/services/tuttid/service/workspace/apps_remote_builtin.go
+++ b/services/tuttid/service/workspace/apps_remote_builtin.go
@@ -13,8 +13,6 @@ import (
 	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 	builtinapps "github.com/tutti-os/tutti/services/tuttid/builtin-apps"
-	tuttitypes "github.com/tutti-os/tutti/services/tuttid/types"
-	"golang.org/x/mod/semver"
 )
 
 func remoteBuiltinWorkspaceApp(builtin builtinapps.App) (workspacebiz.WorkspaceApp, error) {
@@ -53,37 +51,25 @@ func (s *AppCenterService) artifactFetcher() AppArtifactFetcher {
 func shouldUseRemoteBuiltin(appPackage workspacebiz.AppPackage, builtin builtinapps.App) bool {
 	return appPackage.Source == workspacebiz.AppPackageSourceBuiltin &&
 		builtin.Distribution.Kind == builtinapps.DistributionRemote &&
-		compareWorkspaceAppVersions(builtin.Manifest.Version, appPackage.Version) > 0
+		remoteCatalogVersionDiffers(builtin.Manifest.Version, appPackage.Version)
 }
 
 func (s *AppCenterService) shouldMaterializeRemoteBuiltin(appPackage workspacebiz.AppPackage, builtin builtinapps.App) bool {
 	if appPackage.Source != workspacebiz.AppPackageSourceBuiltin || builtin.Distribution.Kind != builtinapps.DistributionRemote {
 		return false
 	}
-	if compareWorkspaceAppVersions(builtin.Manifest.Version, appPackage.Version) > 0 {
+	if remoteCatalogVersionDiffers(builtin.Manifest.Version, appPackage.Version) {
 		return true
 	}
 	return validateExtractedAppPackage(s.ShellAdapter, appPackage.PackageDir, appPackage.Manifest) != nil
 }
 
-func compareWorkspaceAppVersions(left string, right string) int {
-	leftVersion, leftOK := tuttitypes.NormalizeSemver(left)
-	rightVersion, rightOK := tuttitypes.NormalizeSemver(right)
-	if !leftOK || !rightOK {
-		if strings.TrimSpace(left) == strings.TrimSpace(right) {
-			return 0
-		}
-		// Legacy non-SemVer packages have no safe ordering. Preserve the remote
-		// catalog's former authoritative-on-change behavior for those versions.
-		return 1
-	}
-	comparison := semver.Compare(leftVersion, rightVersion)
-	if comparison == 0 && strings.TrimSpace(left) != strings.TrimSpace(right) {
-		// Staging releases may differ only by SemVer build metadata. The remote
-		// catalog is authoritative for that equal-precedence build.
-		return 1
-	}
-	return comparison
+// remoteCatalogVersionDiffers reports whether the active catalog channel selected a
+// different package version than the locally installed builtin. App catalog channel
+// already chose production or staging; that selected catalog entry is authoritative,
+// including when its version is lower than a package installed from the other channel.
+func remoteCatalogVersionDiffers(catalogVersion string, packageVersion string) bool {
+	return strings.TrimSpace(catalogVersion) != strings.TrimSpace(packageVersion)
 }
 
 func (s *AppCenterService) materializeEmbeddedArchiveBuiltinPackage(ctx context.Context, builtin builtinapps.App) (workspacebiz.AppPackage, error) {

--- a/services/tuttid/service/workspace/apps_remote_builtin_catalog_test.go
+++ b/services/tuttid/service/workspace/apps_remote_builtin_catalog_test.go
@@ -284,7 +284,7 @@ func TestAppCenterServiceListsRemoteBuiltinWhenOlderLocalPackageExists(t *testin
 	}
 }
 
-func TestShouldUseRemoteBuiltinNeverDowngradesInstalledPackage(t *testing.T) {
+func TestShouldUseRemoteBuiltinFollowsActiveCatalogChannelVersion(t *testing.T) {
 	appPackage := workspacebiz.AppPackage{
 		AppID:   "design-app",
 		Version: "2.0.0",
@@ -297,12 +297,23 @@ func TestShouldUseRemoteBuiltinNeverDowngradesInstalledPackage(t *testing.T) {
 		},
 	}
 
-	if shouldUseRemoteBuiltin(appPackage, builtin) {
-		t.Fatal("older remote builtin must not replace installed package")
+	// Active channel catalog is authoritative even when its selected version is lower
+	// than a package previously installed from the other channel.
+	if !shouldUseRemoteBuiltin(appPackage, builtin) {
+		t.Fatal("active catalog version must replace a different installed package")
 	}
 	builtin.Manifest.Version = "3.0.0"
 	if !shouldUseRemoteBuiltin(appPackage, builtin) {
 		t.Fatal("newer remote builtin should replace installed package")
+	}
+	builtin.Manifest.Version = "2.0.0"
+	if shouldUseRemoteBuiltin(appPackage, builtin) {
+		t.Fatal("equal catalog version must not replace installed package")
+	}
+	appPackage.Version = "1.0.0+aaaa"
+	builtin.Manifest.Version = "1.0.0+bbbb"
+	if !shouldUseRemoteBuiltin(appPackage, builtin) {
+		t.Fatal("catalog build metadata change must replace installed package")
 	}
 	appPackage.Version = "legacy-a"
 	builtin.Manifest.Version = "legacy-b"

--- a/tools/scripts/build-tutti-app-release.test.mjs
+++ b/tools/scripts/build-tutti-app-release.test.mjs
@@ -794,6 +794,7 @@ test("Tutti app release workflow is reusable by external app repositories", asyn
   assert.match(workflow, /`\$\{process\.env\.APP_ID\}-v`/);
   assert.match(workflow, /git", \["fetch", "--tags", "--force"\]/);
   assert.match(workflow, /parseStableVersion/);
+  assert.match(workflow, /latestVersionSeed/);
   assert.match(workflow, /nextVersionFromSources/);
   assert.match(workflow, /manifest\.version/);
   assert.match(workflow, /Package manifest version must be stable semver/);
@@ -805,7 +806,11 @@ test("Tutti app release workflow is reusable by external app repositories", asyn
   assert.match(workflow, /create_release_tag requires release_bump/);
   assert.match(
     workflow,
-    /releaseVersion = `\$\{manifest\.version\}\+\$\{gitSha\.slice\(0, 12\)\}`/
+    /const seed = latestVersionSeed\(tagPrefix, manifest\.version, false\)/
+  );
+  assert.match(
+    workflow,
+    /releaseVersion = `\$\{seed\.version\}\+\$\{gitSha\.slice\(0, 12\)\}`/
   );
   assert.match(workflow, /name: Create release tag/);
   assert.match(workflow, /git tag -a "\$\{RELEASE_TAG_NAME\}"/);


### PR DESCRIPTION
## Summary
- Treat the active app catalog channel (`production` / `staging`) as authoritative: when the selected catalog version differs from the installed builtin package, offer/apply that catalog package even if it is a lower semver than a package installed from the other channel.
- Seed staging app releases as `max(manifest, <appId>-v* tags)+<sha>` so staging stays on the current product line (e.g. `0.1.45+sha`) instead of a stale source-manifest version that production never rewrites.
- Update workspace-app-catalog docs and unit/workflow coverage for the channel-authority and staging seed rules.

## Test plan
- [ ] `go test ./services/tuttid/service/workspace/ -run 'ShouldUseRemoteBuiltin|RemoteBuiltin|AppCatalogRemoteURL|ListExposesInstalledRemoteBuiltin'`
- [ ] `node --test tools/scripts/build-tutti-app-release.test.mjs`
- [ ] On Desktop with **测试应用**, keep a higher production ai-doc install, refresh App Center, confirm update/align to the staging catalog version is offered or applied
- [ ] Switch back to **正式应用**, confirm production catalog version is authoritative again
- [ ] After merge, publish an ai-doc staging release and confirm version is `0.1.45+<sha>` (or current latest tag seed), not a stale `0.1.27+<sha>`


Made with [Cursor](https://cursor.com)