### PR TITLE
fix(agent-gui): honor host rail refresh limits

### DIFF
--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -489,6 +489,10 @@ Hosts must pass those calls through to the daemon section endpoints so project
 sections come from current user projects and session membership comes from
 persisted `rail_section_key`, not frontend cwd grouping or project-root
 filters.
+Hosts whose first-page section endpoint accepts less than AgentGUI's default
+refresh limit declare the positive backend maximum through
+`conversationRailQueryLimits.sectionRefreshLimitMax`; AgentGUI clamps adaptive
+same-scope and scope-switch refreshes before calling `listSessionSections`.
 The published `@tutti-os/agent-gui/conversation-rail-runtime` entrypoint owns
 the host-neutral Rail query/mutation cohort. Its stable host surface is the
 typed `createAgentConversationRailRuntime` factory plus the runtime/source

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1104,6 +1104,12 @@ adapter-owned diagnostic context: the Desktop runtime adapter enriches
 diagnostic payloads instead of passing it into the headless controller
 interface.
 
+The full AgentGUI surface reads the optional
+`AgentGUIRuntime.conversationRailQueryLimits.sectionRefreshLimitMax` backend
+contract and passes it to that same controller. A host whose section endpoint
+accepts less than AgentGUI's default refresh limit must declare its positive
+maximum instead of relying on transport rejection or adapter-side truncation.
+
 Resolved query results may be reused from the workspace cache. In-flight
 first-page entity payloads are controller-generation scoped and must not be
 shared across mounted controllers: detach, pause, or a scope change must fence

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.search.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.search.spec.tsx
@@ -32,6 +32,84 @@ import type { AgentGUIViewLabels } from "../view/AgentGUINodeView.types";
 import { createDefaultWorkspaceUserProjectI18nRuntime } from "@tutti-os/workspace-user-project/i18n";
 
 describe("useAgentGUIConversationRailQuery search", () => {
+  it("respects the runtime first-page refresh limit across Rail scopes", async () => {
+    type ConversationFilter =
+      | { agentTargetId: string; kind: "agentTarget" }
+      | { kind: "all" };
+    const engine = createTestAgentSessionEngine("workspace-1");
+    const sessions = Array.from({ length: 21 }, (_, index) =>
+      normalizeAgentActivitySession({
+        activeTurnId: null,
+        agentSessionId: `session-${index + 1}`,
+        agentTargetId: "shared:one",
+        cwd: "/workspace",
+        latestTurnInteractions: [],
+        pendingInteractions: [],
+        provider: "codex",
+        railSectionKey: "conversations",
+        title: `Session ${index + 1}`,
+        updatedAtUnixMs: index + 1,
+        workspaceId: "workspace-1"
+      })
+    );
+    const listSessionSections = vi.fn(
+      async (input: { workspaceId: string }) => ({
+        sections: [
+          {
+            hasMore: true,
+            kind: "conversations" as const,
+            sectionKey: "conversations",
+            sessions,
+            totalCount: sessions.length + 1
+          }
+        ],
+        workspaceId: input.workspaceId
+      })
+    );
+    const runtime = {
+      conversationRailQueryLimits: { sectionRefreshLimitMax: 20 },
+      getSessionEngine: () => engine,
+      listSessionSectionPage: vi.fn(),
+      listSessionSections
+    } as unknown as AgentGUIRuntime;
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <AgentGUIRuntimeProvider runtime={runtime}>
+        {children}
+      </AgentGUIRuntimeProvider>
+    );
+
+    const { rerender, unmount } = renderHook(
+      ({ conversationFilter }: { conversationFilter: ConversationFilter }) =>
+        useAgentGUIConversationRailQuery({
+          activeConversationId: null,
+          conversationFilter,
+          conversationQuery: "",
+          userProjects: [],
+          workspaceId: "workspace-1"
+        }),
+      {
+        initialProps: {
+          conversationFilter: {
+            agentTargetId: "shared:one",
+            kind: "agentTarget"
+          }
+        },
+        wrapper
+      }
+    );
+
+    await waitFor(() => expect(listSessionSections).toHaveBeenCalledTimes(1));
+    rerender({ conversationFilter: { kind: "all" } });
+    await waitFor(() => expect(listSessionSections).toHaveBeenCalledTimes(2));
+
+    expect(listSessionSections).toHaveBeenLastCalledWith(
+      expect.objectContaining({ limitPerSection: 20 })
+    );
+
+    unmount();
+    engine.dispose();
+  });
+
   it("adds the Desktop node identity through the runtime diagnostic adapter", async () => {
     const engine = createTestAgentSessionEngine("workspace-1");
     const reportDiagnostic = vi.fn();

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts
@@ -55,6 +55,8 @@ export function useAgentGUIConversationRailQuery({
         engine,
         getActiveConversationId: () => activeConversationIdRef.current,
         runtime: railRuntime,
+        sectionRefreshLimitMax:
+          runtime.conversationRailQueryLimits?.sectionRefreshLimitMax,
         workspaceId
       }),
     [engine, railRuntime, workspaceId]

--- a/packages/agent/gui/agentActivityRuntime.tsx
+++ b/packages/agent/gui/agentActivityRuntime.tsx
@@ -315,6 +315,13 @@ export interface AgentGUIRuntime {
    */
   origin?: string;
   /**
+   * Host query limits for the Conversation Rail. Omit when the backend accepts
+   * AgentGUI's default limits.
+   */
+  conversationRailQueryLimits?: {
+    sectionRefreshLimitMax: number;
+  };
+  /**
    * The session cwd is not resolvable on the local filesystem (e.g. a
    * shared/cloud sandbox not mounted locally), so AgentGUI must not run its
    * local stat-based "working directory missing" existence check — it would


### PR DESCRIPTION
## Summary
- expose an optional host-declared Conversation Rail refresh ceiling through AgentGUIRuntime
- clamp adaptive first-page refreshes before calling the host section endpoint
- cover target-to-All scope switching and document the public host contract

## Tests
- pnpm check:changed -- --push-ready (12 lanes passed)

## Notes
- hosts that omit the capability keep AgentGUI's existing default limit
- TSH can declare its backend maximum of 20 without adapter-side truncation
