### PR TITLE
perf(ci): scope Go checks to changed packages

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -284,6 +284,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
@@ -302,33 +304,20 @@ jobs:
           cache-dependency-path: |
             go.work
             go.work.sum
-            packages/agent/activity-replication/go.mod
-            packages/agent/daemon/go.mod
-            packages/agent/daemon/go.sum
-            packages/agent/host/go.mod
-            packages/agent/host/go.sum
-            packages/agent/runtimeprep/go.mod
-            packages/agent/store-sqlite/go.mod
-            packages/agent/store-sqlite/canonical/go.mod
-            packages/auth/bridge-go/go.mod
-            packages/appcli/core/go.mod
-            packages/clients/device-authority-go/go.mod
-            packages/events/stream-go/go.mod
-            packages/workbench/service/go.mod
-            packages/workspace/files/go.mod
-            packages/workspace/issues/go.mod
-            apps/cli/go.mod
-            services/tuttid/go.mod
-            services/tuttid/go.sum
+            **/go.mod
+            **/go.sum
 
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Generate builtin apps
-        run: pnpm generate:builtin-apps
-
-      - name: Run Go workspace tests
-        run: pnpm test:go:prepared -- --tail-lines 400
+      - name: Run changed Go tests
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: >-
+          node ./tools/scripts/run-changed-go-validation.mjs
+          --base "${BASE_SHA}"
+          --kind test
+          --tail-lines 400
 
   go-lint:
     name: Go Lint
@@ -339,6 +328,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
@@ -357,24 +348,11 @@ jobs:
           cache-dependency-path: |
             go.work
             go.work.sum
-            packages/agent/activity-replication/go.mod
-            packages/agent/host/go.mod
-            packages/agent/host/go.sum
-            packages/agent/runtimeprep/go.mod
-            packages/agent/store-sqlite/canonical/go.mod
-            packages/appcli/core/go.mod
-            packages/clients/device-authority-go/go.mod
-            packages/workbench/service/go.mod
-            packages/workspace/files/go.mod
-            packages/workspace/issues/go.mod
-            services/tuttid/go.mod
-            services/tuttid/go.sum
+            **/go.mod
+            **/go.sum
 
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Generate builtin apps
-        run: pnpm generate:builtin-apps
 
       - name: Install pinned golangci-lint
         run: |
@@ -396,5 +374,11 @@ jobs:
           test -x "${install_dir}/golangci-lint"
           echo "${install_dir}" >> "${GITHUB_PATH}"
 
-      - name: Run Go lint
-        run: node ./tools/scripts/run-golangci-lint.mjs
+      - name: Run changed Go lint
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: >-
+          node ./tools/scripts/run-changed-go-validation.mjs
+          --base "${BASE_SHA}"
+          --kind lint
+          --tail-lines 400

--- a/docs/conventions/local-git-hooks.md
+++ b/docs/conventions/local-git-hooks.md
@@ -129,13 +129,13 @@ Rules:
 - explicit full validation remains available for releases, broad migrations,
   manual confidence checks, and checked force-push workflows
 
-TypeScript package tests and Go workspace tests use discovery-based runners
-instead of root package/module whitelists. Successful runs print compact
-summaries with the slowest lanes; complete lane logs and a machine-readable
-`latest.json` are stored under `.tmp/test-runs`. Every `go.work` module,
-including `packages/agent/daemon`, participates in the blocking Go test gate.
-The focused agent daemon command and its stabilization expectations are
-documented in [Testing](./testing.md).
+TypeScript package tests and full Go workspace tests use discovery-based
+runners instead of root package/module whitelists. Successful runs print
+compact summaries with the slowest lanes; complete lane logs and a
+machine-readable `latest.json` are stored under `.tmp/test-runs`. Every
+`go.work` module participates in explicit full Go gates. The focused agent
+daemon command and its stabilization expectations are documented in
+[Testing](./testing.md).
 
 For PR branches that often need rebasing or force-pushing, use
 `pnpm push:checked` instead of running `pnpm check:full` and `git push`
@@ -159,6 +159,14 @@ concurrently, prints compact summaries, and stores full logs under
 `.tmp/check-runs`. Repository policy, tool contracts, generated contracts, and
 architecture boundaries come from `tools/scripts/repository-checks.mjs`; PR CI
 uses the same selectors.
+
+Go package selection is also shared by local changed-aware validation and PR
+CI. Test module roots come from `go.work` at runtime; lint uses the repository's
+established lint-enabled module set. Ordinary Go source changes run the owning
+package; module manifest changes run the owning module; changes to the
+workspace, selector, workflow, or shared lint configuration run every test
+module and lint-enabled module. Tutti daemon lanes validate existing builtin
+app assets and generate them only when missing or when their source changed.
 
 Lanes that write the same generated artifact are serialized while unrelated
 lanes remain parallel. In particular, Tutti daemon Go tests and `build:go`

--- a/docs/conventions/testing.md
+++ b/docs/conventions/testing.md
@@ -101,12 +101,18 @@ boundaries are selected from `tools/scripts/repository-checks.mjs`. Both PR CI
 and `check:changed` consume this registry; do not attach a repository-wide
 check to a TypeScript or Go lane based on its implementation language.
 
-Go tests are discovered from the modules declared in `go.work`. The blocking
-lane includes every module, so additions to `go.work` join the root test gate
-without a second registry.
+Go modules are discovered directly from `go.work`; do not maintain a second
+module-root registry. The explicit root commands (`pnpm test:go`,
+`pnpm test:go:prepared`, and `pnpm lint:go`) remain full-workspace gates.
 
-Changed-aware validation must recognize every current `go.work` module so a Go
-file change selects the matching package lint and test lanes.
+Changed-aware local validation and pull-request CI share package selection. An
+ordinary `.go` change runs tests for the owning package and, when the module is
+part of the established Go lint gate, lints that package. A module's `go.mod`
+or `go.sum` change expands those checks to the owning module. Changes to
+`go.work`, Go validation scripts, the Go PR workflow, or shared golangci-lint
+configuration fall back to every test module and every lint-enabled module.
+This keeps selection infrastructure self-testing while avoiding full-workspace
+Go runs for isolated package changes.
 
 ## Local Performance Reports
 

--- a/tools/scripts/change-classification.mjs
+++ b/tools/scripts/change-classification.mjs
@@ -5,6 +5,7 @@ import { execFileSync } from "node:child_process";
 
 import { createIsolatedGitEnvironment } from "./git-environment.mjs";
 import { selectedRepositoryCheckGroups } from "./repository-checks.mjs";
+import { isGoValidationRelevant } from "./run-check-changed-targets.mjs";
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const workspaceRoot = resolve(scriptDirectory, "../..");
@@ -39,7 +40,7 @@ export function classifyChangedFiles(
     runBoundaries: groups.has("boundaries"),
     runContracts: groups.has("contracts"),
     runGenerated: groups.has("generated"),
-    runGo: normalizedFiles.some(isGoRelevant),
+    runGo: normalizedFiles.some(isGoValidationRelevant),
     runPack: packSelection.packAll || packSelection.packageNames.length > 0,
     runTs: normalizedFiles.some(isTypeScriptRelevant),
     runTsTests: testSelection.testAll || testSelection.packageNames.length > 0,
@@ -182,15 +183,6 @@ export function isAgentSessionReplayRelevant(file) {
     /services\/tuttid\/data\/workspace\/\S*agent_session_(?:fixture|replay)\S*\.go$/u.test(
       file
     )
-  );
-}
-
-function isGoRelevant(file) {
-  return (
-    file.endsWith(".go") ||
-    /(?:^|\/)go\.(?:mod|sum)$/u.test(file) ||
-    ["go.work", "go.work.sum"].includes(file) ||
-    file.startsWith("services/tuttid/.golangci")
   );
 }
 

--- a/tools/scripts/change-classification.test.mjs
+++ b/tools/scripts/change-classification.test.mjs
@@ -87,6 +87,19 @@ test("workflow and hook changes select repository tool contracts", () => {
   }
 });
 
+test("Go CI and shared selector changes select Go validation", () => {
+  for (const file of [
+    ".github/workflows/pr-checks.yml",
+    "tools/scripts/run-changed-go-validation.mjs",
+    "tools/scripts/run-check-changed-targets.mjs"
+  ]) {
+    const classification = classifyChangedFiles([file], {
+      releasePackages
+    });
+    assert.equal(classification.runGo, true, file);
+  }
+});
+
 test("Agent Session Replay changes select the current-build closed loop", () => {
   for (const file of [
     "packages/agent/session-replay/cassette.go",

--- a/tools/scripts/run-changed-go-validation.mjs
+++ b/tools/scripts/run-changed-go-validation.mjs
@@ -1,0 +1,160 @@
+import { execFileSync } from "node:child_process";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { createIsolatedGitEnvironment } from "./git-environment.mjs";
+import {
+  buildGoLintLane,
+  buildGoTestLane,
+  discoverGoModuleRoots,
+  isBuiltinGenerateRequired,
+  resolveGoValidationTargets,
+  selectGoLintModuleRoots
+} from "./run-check-changed-targets.mjs";
+import { runValidationLanes } from "./run-validation-lanes.mjs";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = join(scriptDirectory, "..", "..");
+
+export function buildChangedGoValidationLanes({
+  changedFiles,
+  kind,
+  moduleRoots,
+  pathExists,
+  pnpmCommand = "pnpm",
+  root = workspaceRoot
+}) {
+  if (kind !== "lint" && kind !== "test") {
+    throw new Error("kind requires lint or test");
+  }
+  const resolved = resolveGoValidationTargets(changedFiles, {
+    lintModuleRoots: selectGoLintModuleRoots(moduleRoots),
+    moduleRoots,
+    ...(pathExists ? { pathExists } : {})
+  });
+  if (!resolved) {
+    return [];
+  }
+  const targetsByModule =
+    kind === "lint" ? resolved.lintByModule : resolved.testByModule;
+  const forceBuiltinGenerate = isBuiltinGenerateRequired(changedFiles);
+  return Array.from(targetsByModule, ([moduleRoot, targets]) =>
+    kind === "lint"
+      ? buildGoLintLane({
+          forceBuiltinGenerate,
+          moduleRoot,
+          pnpmCommand,
+          shellQuote,
+          targets,
+          workspaceRoot: root
+        })
+      : buildGoTestLane({
+          forceBuiltinGenerate,
+          moduleRoot,
+          pnpmCommand,
+          shellQuote,
+          targets
+        })
+  );
+}
+
+export function parseChangedGoValidationArgs(inputArgs) {
+  const args = inputArgs.filter((arg) => arg !== "--");
+  const options = { baseRef: null, kind: null, maxParallel: 3, tailLines: 80 };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--base":
+        options.baseRef = readValue(args, ++index, arg);
+        break;
+      case "--kind": {
+        const kind = readValue(args, ++index, arg);
+        if (kind !== "lint" && kind !== "test") {
+          throw new Error("--kind requires lint or test");
+        }
+        options.kind = kind;
+        break;
+      }
+      case "--max-parallel":
+        options.maxParallel = readPositiveInteger(args, ++index, arg);
+        break;
+      case "--tail-lines":
+        options.tailLines = readPositiveInteger(args, ++index, arg);
+        break;
+      default:
+        throw new Error(`unknown option: ${arg}`);
+    }
+  }
+  if (!options.baseRef) {
+    throw new Error("--base is required");
+  }
+  if (!options.kind) {
+    throw new Error("--kind is required");
+  }
+  return options;
+}
+
+async function main() {
+  const options = parseChangedGoValidationArgs(process.argv.slice(2));
+  const changedFiles = execFileSync(
+    "git",
+    ["diff", "--name-only", `${options.baseRef}...HEAD`],
+    {
+      cwd: workspaceRoot,
+      encoding: "utf8",
+      env: createIsolatedGitEnvironment(workspaceRoot)
+    }
+  )
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const moduleRoots = discoverGoModuleRoots({ root: workspaceRoot });
+  const lanes = buildChangedGoValidationLanes({
+    changedFiles,
+    kind: options.kind,
+    moduleRoots
+  });
+  const label =
+    options.kind === "lint" ? "Changed Go lint" : "Changed Go tests";
+  const result = await runValidationLanes({
+    lanes,
+    maxParallel: options.maxParallel,
+    summaryLabel: label,
+    tailLines: options.tailLines,
+    tmpDirectoryName:
+      options.kind === "lint" ? "lint-runs/go-changed" : "test-runs/go-changed",
+    workspaceRoot
+  });
+  process.exitCode = result.exitCode;
+}
+
+function readValue(args, index, option) {
+  const value = args[index];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${option} requires a value`);
+  }
+  return value;
+}
+
+function readPositiveInteger(args, index, option) {
+  const value = readValue(args, index, option);
+  if (!/^[1-9]\d*$/u.test(value)) {
+    throw new Error(`${option} requires a positive integer`);
+  }
+  return Number.parseInt(value, 10);
+}
+
+function shellQuote(value) {
+  if (/^[A-Za-z0-9_./:=@+-]+$/u.test(value)) {
+    return value;
+  }
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+const currentPath = fileURLToPath(import.meta.url);
+if (process.argv[1] && resolve(process.argv[1]) === currentPath) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/tools/scripts/run-changed-go-validation.test.mjs
+++ b/tools/scripts/run-changed-go-validation.test.mjs
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  buildChangedGoValidationLanes,
+  parseChangedGoValidationArgs
+} from "./run-changed-go-validation.mjs";
+
+const moduleRoots = [
+  "packages/agent/daemon",
+  "packages/agent/session-replay",
+  "services/tuttid"
+];
+
+describe("parseChangedGoValidationArgs", () => {
+  it("parses the CI selection options", () => {
+    assert.deepEqual(
+      parseChangedGoValidationArgs([
+        "--base",
+        "base-sha",
+        "--kind",
+        "test",
+        "--max-parallel",
+        "2",
+        "--tail-lines",
+        "400"
+      ]),
+      {
+        baseRef: "base-sha",
+        kind: "test",
+        maxParallel: 2,
+        tailLines: 400
+      }
+    );
+  });
+
+  it("rejects an incomplete selector", () => {
+    assert.throws(
+      () => parseChangedGoValidationArgs(["--kind", "test"]),
+      /--base is required/
+    );
+    assert.throws(
+      () =>
+        parseChangedGoValidationArgs(["--base", "base-sha", "--kind", "all"]),
+      /--kind requires lint or test/
+    );
+  });
+});
+
+describe("buildChangedGoValidationLanes", () => {
+  it("runs only the changed package for an ordinary Go change", () => {
+    const lanes = buildChangedGoValidationLanes({
+      changedFiles: ["packages/agent/daemon/runtime/session.go"],
+      kind: "test",
+      moduleRoots,
+      pathExists: () => true,
+      root: "/repo"
+    });
+
+    assert.equal(lanes.length, 1);
+    assert.equal(lanes[0].label, "test:go (packages/agent/daemon)");
+    assert.match(
+      lanes[0].command[2],
+      /cd packages\/agent\/daemon && go test \.\/runtime\/\.\.\./
+    );
+  });
+
+  it("uses the same package scope for lint", () => {
+    const lanes = buildChangedGoValidationLanes({
+      changedFiles: ["packages/agent/daemon/runtime/session.go"],
+      kind: "lint",
+      moduleRoots,
+      pathExists: () => true,
+      root: "/repo"
+    });
+
+    assert.equal(lanes.length, 1);
+    assert.equal(lanes[0].label, "lint:go (packages/agent/daemon)");
+    assert.match(lanes[0].command[2], /golangci-lint run/);
+    assert.match(lanes[0].command[2], / \.\/runtime$/);
+    assert.doesNotMatch(lanes[0].command[2], /generate:builtin-apps/);
+  });
+
+  it("does not expand lint beyond the established lint module set", () => {
+    const lanes = buildChangedGoValidationLanes({
+      changedFiles: ["packages/agent/session-replay/replay.go"],
+      kind: "lint",
+      moduleRoots,
+      pathExists: () => true,
+      root: "/repo"
+    });
+
+    assert.deepEqual(lanes, []);
+  });
+
+  it("falls back to every module when shared selection code changes", () => {
+    const lanes = buildChangedGoValidationLanes({
+      changedFiles: ["tools/scripts/run-changed-go-validation.mjs"],
+      kind: "test",
+      moduleRoots,
+      pathExists: () => true,
+      root: "/repo"
+    });
+
+    assert.deepEqual(
+      lanes.map((lane) => lane.label),
+      moduleRoots.map((moduleRoot) => `test:go (${moduleRoot})`)
+    );
+    for (const lane of lanes) {
+      assert.match(lane.command[2], /go test \.\/\.\.\./);
+    }
+  });
+
+  it("ensures builtin assets only for the selected tuttid lane", () => {
+    const lanes = buildChangedGoValidationLanes({
+      changedFiles: ["services/tuttid/service/workspace/apps.go"],
+      kind: "test",
+      moduleRoots,
+      pathExists: () => true,
+      root: "/repo"
+    });
+
+    assert.equal(lanes.length, 1);
+    assert.match(lanes[0].command[2], /package:builtin:check/);
+    assert.match(lanes[0].command[2], /go test \.\/service\/workspace\/\.\.\./);
+  });
+});

--- a/tools/scripts/run-check-changed-targets.mjs
+++ b/tools/scripts/run-check-changed-targets.mjs
@@ -1,7 +1,20 @@
+import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { dirname, join, relative } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 
-const GO_MODULE_ROOTS = [
+const GLOBAL_GO_VALIDATION_FILES = new Set([
+  ".github/workflows/pr-checks.yml",
+  "go.work",
+  "go.work.sum",
+  "tools/scripts/change-classification.mjs",
+  "tools/scripts/run-changed-go-validation.mjs",
+  "tools/scripts/run-check-changed-targets.mjs",
+  "tools/scripts/run-golangci-lint.mjs",
+  "tools/scripts/run-go-tests.mjs",
+  "tools/scripts/run-validation-lanes.mjs"
+]);
+
+const GO_LINT_MODULE_ROOTS = new Set([
   "apps/cli",
   "packages/agent/activity-replication",
   "packages/agent/daemon",
@@ -18,7 +31,7 @@ const GO_MODULE_ROOTS = [
   "packages/workspace/files",
   "packages/workspace/issues",
   "services/tuttid"
-].sort((left, right) => right.length - left.length);
+]);
 
 const GOLANGCI_CONFIG_RELATIVE_PATH = join(
   "services",
@@ -26,14 +39,46 @@ const GOLANGCI_CONFIG_RELATIVE_PATH = join(
   ".golangci.yml"
 );
 
-export function resolveGoModuleRoot(file) {
+export function discoverGoModuleRoots({
+  root = process.cwd(),
+  spawnSyncImpl = spawnSync
+} = {}) {
+  const result = spawnSyncImpl("go", ["work", "edit", "-json"], {
+    cwd: root,
+    encoding: "utf8"
+  });
+  if (result.error || result.status !== 0) {
+    throw new Error(
+      String(result.stderr ?? "").trim() ||
+        result.error?.message ||
+        "go work edit -json failed"
+    );
+  }
+  const workspace = JSON.parse(result.stdout);
+  return (workspace.Use ?? [])
+    .map((entry) =>
+      relative(root, resolve(root, entry.DiskPath)).replaceAll("\\", "/")
+    )
+    .sort();
+}
+
+export function resolveGoModuleRoot(file, moduleRoots) {
   const normalized = file.replaceAll("\\", "/");
-  for (const moduleRoot of GO_MODULE_ROOTS) {
+  const orderedRoots = [...moduleRoots].sort(
+    (left, right) => right.length - left.length
+  );
+  for (const moduleRoot of orderedRoots) {
     if (normalized === moduleRoot || normalized.startsWith(`${moduleRoot}/`)) {
       return moduleRoot;
     }
   }
   return null;
+}
+
+export function selectGoLintModuleRoots(moduleRoots) {
+  return moduleRoots.filter((moduleRoot) =>
+    GO_LINT_MODULE_ROOTS.has(moduleRoot)
+  );
 }
 
 export function isBuiltinGenerateRequired(changedFiles) {
@@ -48,7 +93,7 @@ export function isBuiltinGenerateRequired(changedFiles) {
 
 export function resolveGoValidationTargets(
   changedFiles,
-  { pathExists = existsSync } = {}
+  { moduleRoots, lintModuleRoots = moduleRoots, pathExists = existsSync }
 ) {
   const goFiles = changedFiles.filter(isGoValidationRelevant);
   if (goFiles.length === 0) {
@@ -57,9 +102,22 @@ export function resolveGoValidationTargets(
 
   const lintByModule = new Map();
   const testByModule = new Map();
+  const lintModuleRootSet = new Set(lintModuleRoots);
+
+  if (goFiles.some(isGlobalGoValidationRelevant)) {
+    for (const moduleRoot of moduleRoots) {
+      if (!pathExists(moduleRoot)) {
+        continue;
+      }
+      if (lintModuleRootSet.has(moduleRoot)) {
+        addGoTarget(lintByModule, moduleRoot, "./...");
+      }
+      addGoTarget(testByModule, moduleRoot, "./...");
+    }
+  }
 
   for (const file of goFiles) {
-    const moduleRoot = resolveGoModuleRoot(file);
+    const moduleRoot = resolveGoModuleRoot(file, moduleRoots);
     if (!moduleRoot) {
       continue;
     }
@@ -68,7 +126,9 @@ export function resolveGoValidationTargets(
       if (!pathExists(moduleRoot)) {
         continue;
       }
-      addGoTarget(lintByModule, moduleRoot, "./...");
+      if (lintModuleRootSet.has(moduleRoot)) {
+        addGoTarget(lintByModule, moduleRoot, "./...");
+      }
       addGoTarget(testByModule, moduleRoot, "./...");
       continue;
     }
@@ -81,7 +141,9 @@ export function resolveGoValidationTargets(
     if (!pathExists(join(moduleRoot, packagePattern.slice(2)))) {
       continue;
     }
-    addGoTarget(lintByModule, moduleRoot, packagePattern);
+    if (lintModuleRootSet.has(moduleRoot)) {
+      addGoTarget(lintByModule, moduleRoot, packagePattern);
+    }
     addGoTarget(testByModule, moduleRoot, `${packagePattern}/...`);
   }
 
@@ -93,21 +155,31 @@ export function resolveGoValidationTargets(
 }
 
 export function buildGoLintLane({
+  forceBuiltinGenerate,
   golangciLintBinary = "golangci-lint",
   moduleRoot,
+  pnpmCommand,
   targets,
   workspaceRoot,
   shellQuote
 }) {
   const golangciConfigPath = join(workspaceRoot, GOLANGCI_CONFIG_RELATIVE_PATH);
   const targetList = Array.from(targets).sort().join(" ");
+  const builtinEnsure =
+    moduleRoot === "services/tuttid"
+      ? `${buildTuttidBuiltinEnsureCommand(pnpmCommand, {
+          forceGenerate: forceBuiltinGenerate
+        })} `
+      : "";
   return {
     key: `lint:go:${sanitizeLaneKey(moduleRoot)}`,
     label: `lint:go (${moduleRoot})`,
+    serialGroup:
+      moduleRoot === "services/tuttid" ? "tuttid-builtin-assets" : undefined,
     command: [
       "bash",
       "-lc",
-      `cd ${shellQuote(moduleRoot)} && ${shellQuote(golangciLintBinary)} run --allow-parallel-runners --config ${shellQuote(golangciConfigPath)} ${targetList}`
+      `${builtinEnsure}cd ${shellQuote(moduleRoot)} && ${shellQuote(golangciLintBinary)} run --allow-parallel-runners --config ${shellQuote(golangciConfigPath)} ${targetList}`
     ]
   };
 }
@@ -269,7 +341,13 @@ function addGoTarget(targetsByModule, moduleRoot, pattern) {
   if (!targetsByModule.has(moduleRoot)) {
     targetsByModule.set(moduleRoot, new Set());
   }
-  targetsByModule.get(moduleRoot).add(pattern);
+  const targets = targetsByModule.get(moduleRoot);
+  if (pattern === "./...") {
+    targets.clear();
+    targets.add(pattern);
+  } else if (!targets.has("./...")) {
+    targets.add(pattern);
+  }
 }
 
 function sanitizeLaneKey(value) {
@@ -284,6 +362,19 @@ function isTestFile(file) {
   return /\.(?:test|spec)\.(?:ts|tsx|mts|cts|js|jsx|mjs|cjs)$/u.test(file);
 }
 
-function isGoValidationRelevant(file) {
-  return file.endsWith(".go") || /(?:^|\/)go\.(?:mod|sum)$/u.test(file);
+export function isGlobalGoValidationRelevant(file) {
+  const normalized = file.replaceAll("\\", "/");
+  return (
+    GLOBAL_GO_VALIDATION_FILES.has(normalized) ||
+    normalized.startsWith("services/tuttid/.golangci")
+  );
+}
+
+export function isGoValidationRelevant(file) {
+  const normalized = file.replaceAll("\\", "/");
+  return (
+    normalized.endsWith(".go") ||
+    /(?:^|\/)go\.(?:mod|sum)$/u.test(normalized) ||
+    isGlobalGoValidationRelevant(normalized)
+  );
 }

--- a/tools/scripts/run-check-changed-targets.test.mjs
+++ b/tools/scripts/run-check-changed-targets.test.mjs
@@ -4,65 +4,107 @@ import {
   buildGoLintLane,
   buildGoTestLane,
   buildPackageTestCommand,
+  discoverGoModuleRoots,
   isBuiltinGenerateRequired,
   resolveGoModuleRoot,
-  resolveGoValidationTargets
+  resolveGoValidationTargets,
+  selectGoLintModuleRoots
 } from "./run-check-changed-targets.mjs";
+
+const goModuleRoots = [
+  "apps/cli",
+  "packages/agent/daemon",
+  "packages/agent/session-replay",
+  "packages/agent/store-sqlite",
+  "packages/agent/store-sqlite/canonical",
+  "packages/connector/market",
+  "packages/device-link",
+  "packages/events/stream-go",
+  "packages/workspace/issues",
+  "services/tuttid"
+];
+
+describe("discoverGoModuleRoots", () => {
+  it("reads every module from go.work instead of a maintained whitelist", () => {
+    const roots = discoverGoModuleRoots({
+      root: "/repo",
+      spawnSyncImpl: () => ({
+        status: 0,
+        stdout: JSON.stringify({
+          Use: [
+            { DiskPath: "./packages/connector/market" },
+            { DiskPath: "./packages/agent/session-replay" },
+            { DiskPath: "./services/tuttid" }
+          ]
+        })
+      })
+    });
+
+    assert.deepEqual(roots, [
+      "packages/agent/session-replay",
+      "packages/connector/market",
+      "services/tuttid"
+    ]);
+  });
+});
 
 describe("resolveGoModuleRoot", () => {
   it("maps changed files to their Go module root", () => {
     assert.equal(
       resolveGoModuleRoot(
-        "services/tuttid/service/workspace/apps_install_progress.go"
+        "services/tuttid/service/workspace/apps_install_progress.go",
+        goModuleRoots
       ),
       "services/tuttid"
     );
     assert.equal(
-      resolveGoModuleRoot("apps/cli/internal/app/foo.go"),
+      resolveGoModuleRoot("apps/cli/internal/app/foo.go", goModuleRoots),
       "apps/cli"
     );
     assert.equal(
       resolveGoModuleRoot(
-        "packages/agent/activity-replication/conformance/fixtures.go"
+        "packages/agent/session-replay/replay.go",
+        goModuleRoots
       ),
-      "packages/agent/activity-replication"
+      "packages/agent/session-replay"
     );
     assert.equal(
-      resolveGoModuleRoot("packages/agent/host/conformance/conformance.go"),
-      "packages/agent/host"
+      resolveGoModuleRoot(
+        "packages/connector/market/daemon/application.go",
+        goModuleRoots
+      ),
+      "packages/connector/market"
     );
     assert.equal(
-      resolveGoModuleRoot("packages/agent/runtimeprep/preparer.go"),
-      "packages/agent/runtimeprep"
-    );
-    assert.equal(
-      resolveGoModuleRoot("packages/agent/store-sqlite/store.go"),
+      resolveGoModuleRoot(
+        "packages/agent/store-sqlite/store.go",
+        goModuleRoots
+      ),
       "packages/agent/store-sqlite"
     );
     assert.equal(
       resolveGoModuleRoot(
-        "packages/agent/store-sqlite/canonical/vocabulary.go"
+        "packages/agent/store-sqlite/canonical/vocabulary.go",
+        goModuleRoots
       ),
       "packages/agent/store-sqlite/canonical"
     );
     assert.equal(
-      resolveGoModuleRoot("packages/auth/bridge-go/bridge.go"),
-      "packages/auth/bridge-go"
-    );
-    assert.equal(
-      resolveGoModuleRoot("packages/clients/device-authority-go/client.go"),
-      "packages/clients/device-authority-go"
-    );
-    assert.equal(
-      resolveGoModuleRoot("packages/device-link/mobile/probe.go"),
+      resolveGoModuleRoot(
+        "packages/device-link/mobile/probe.go",
+        goModuleRoots
+      ),
       "packages/device-link"
     );
     assert.equal(
-      resolveGoModuleRoot("packages/events/stream-go/stream.go"),
+      resolveGoModuleRoot("packages/events/stream-go/stream.go", goModuleRoots),
       "packages/events/stream-go"
     );
     assert.equal(
-      resolveGoModuleRoot("packages/workspace/issues/service.go"),
+      resolveGoModuleRoot(
+        "packages/workspace/issues/service.go",
+        goModuleRoots
+      ),
       "packages/workspace/issues"
     );
   });
@@ -70,10 +112,13 @@ describe("resolveGoModuleRoot", () => {
 
 describe("resolveGoValidationTargets", () => {
   it("scopes lint and test targets to changed Go packages", () => {
-    const targets = resolveGoValidationTargets([
-      "services/tuttid/service/workspace/apps_install_progress.go",
-      "services/tuttid/service/workspace/apps_install_progress_test.go"
-    ]);
+    const targets = resolveGoValidationTargets(
+      [
+        "services/tuttid/service/workspace/apps_install_progress.go",
+        "services/tuttid/service/workspace/apps_install_progress_test.go"
+      ],
+      { moduleRoots: goModuleRoots }
+    );
 
     assert.deepEqual(Array.from(targets.lintByModule.get("services/tuttid")), [
       "./service/workspace"
@@ -84,7 +129,9 @@ describe("resolveGoValidationTargets", () => {
   });
 
   it("runs the full module when go.mod changes", () => {
-    const targets = resolveGoValidationTargets(["services/tuttid/go.mod"]);
+    const targets = resolveGoValidationTargets(["services/tuttid/go.mod"], {
+      moduleRoots: goModuleRoots
+    });
 
     assert.deepEqual(Array.from(targets.testByModule.get("services/tuttid")), [
       "./..."
@@ -98,7 +145,7 @@ describe("resolveGoValidationTargets", () => {
         "packages/agent/daemon/activity/ingress/service.go",
         "packages/agent/daemon/internal/guestdesktoprelay/v1/types.go"
       ],
-      { pathExists: () => false }
+      { moduleRoots: goModuleRoots, pathExists: () => false }
     );
 
     assert.equal(targets, null);
@@ -107,7 +154,7 @@ describe("resolveGoValidationTargets", () => {
   it("keeps Go lanes for deleted files inside existing packages", () => {
     const targets = resolveGoValidationTargets(
       ["services/tuttid/service/workspace/deleted_file.go"],
-      { pathExists: () => true }
+      { moduleRoots: goModuleRoots, pathExists: () => true }
     );
 
     assert.deepEqual(Array.from(targets.lintByModule.get("services/tuttid")), [
@@ -116,6 +163,29 @@ describe("resolveGoValidationTargets", () => {
     assert.deepEqual(Array.from(targets.testByModule.get("services/tuttid")), [
       "./service/workspace/..."
     ]);
+  });
+
+  it("runs every go.work module when shared validation ownership changes", () => {
+    const targets = resolveGoValidationTargets(
+      ["tools/scripts/run-changed-go-validation.mjs"],
+      {
+        lintModuleRoots: selectGoLintModuleRoots(goModuleRoots),
+        moduleRoots: goModuleRoots,
+        pathExists: () => true
+      }
+    );
+
+    assert.deepEqual(
+      Array.from(targets.testByModule),
+      goModuleRoots.map((moduleRoot) => [moduleRoot, new Set(["./..."])])
+    );
+    assert.deepEqual(
+      Array.from(targets.lintByModule),
+      selectGoLintModuleRoots(goModuleRoots).map((moduleRoot) => [
+        moduleRoot,
+        new Set(["./..."])
+      ])
+    );
   });
 });
 
@@ -294,16 +364,19 @@ describe("builtin onboarding ensure", () => {
 });
 
 describe("buildGoLintLane", () => {
-  it("does not run generate:builtin-apps", () => {
+  it("ensures builtin assets before linting tuttid", () => {
     const lane = buildGoLintLane({
+      forceBuiltinGenerate: false,
       golangciLintBinary: "/tmp/go/bin/golangci-lint",
       moduleRoot: "services/tuttid",
+      pnpmCommand: "pnpm",
       targets: new Set(["./service/workspace/..."]),
       workspaceRoot: "/repo",
       shellQuote: (value) => value
     });
 
-    assert.doesNotMatch(lane.command[2], /generate:builtin-apps/);
+    assert.match(lane.command[2], /package:builtin:check/);
+    assert.match(lane.command[2], /generate:builtin-apps\) && cd/);
     assert.match(lane.command[2], /\/tmp\/go\/bin\/golangci-lint run/);
     assert.match(lane.command[2], /--allow-parallel-runners/);
   });

--- a/tools/scripts/run-check-changed.mjs
+++ b/tools/scripts/run-check-changed.mjs
@@ -19,10 +19,14 @@ import {
 import {
   buildGoLintLane,
   buildGoTestLane,
+  discoverGoModuleRoots,
   buildPackageTestCommand,
   isBuiltinGenerateRequired,
+  isGlobalGoValidationRelevant,
+  isGoValidationRelevant,
   resolveGoModuleRoot,
-  resolveGoValidationTargets
+  resolveGoValidationTargets,
+  selectGoLintModuleRoots
 } from "./run-check-changed-targets.mjs";
 import {
   classifyChangedFiles,
@@ -222,8 +226,14 @@ function buildChangedLanes() {
     });
   }
 
+  const goModuleRoots = classification.runGo
+    ? discoverGoModuleRoots({ root: workspaceRoot })
+    : [];
   const goValidationTargets = classification.runGo
-    ? resolveGoValidationTargets(changedFiles)
+    ? resolveGoValidationTargets(changedFiles, {
+        lintModuleRoots: selectGoLintModuleRoots(goModuleRoots),
+        moduleRoots: goModuleRoots
+      })
     : null;
   const forceBuiltinGenerate = isBuiltinGenerateRequired(changedFiles);
   if (goValidationTargets) {
@@ -231,12 +241,15 @@ function buildChangedLanes() {
       const inputFiles = selectGoLaneInputs(
         changedFiles,
         moduleRoot,
-        forceBuiltinGenerate
+        forceBuiltinGenerate,
+        goModuleRoots
       );
       addLane({
         ...buildGoLintLane({
+          forceBuiltinGenerate,
           golangciLintBinary,
           moduleRoot,
+          pnpmCommand: pnpmShellCommand,
           targets,
           shellQuote,
           workspaceRoot
@@ -248,7 +261,8 @@ function buildChangedLanes() {
       const inputFiles = selectGoLaneInputs(
         changedFiles,
         moduleRoot,
-        forceBuiltinGenerate
+        forceBuiltinGenerate,
+        goModuleRoots
       );
       addLane({
         ...buildGoTestLane({
@@ -268,7 +282,7 @@ function buildChangedLanes() {
         label: "build:go",
         serialGroup: "tuttid-builtin-assets",
         command: [...pnpmCommand, "run", "build:go"],
-        inputFiles: changedFiles.filter(isGoValidationInput)
+        inputFiles: changedFiles.filter(isGoValidationRelevant)
       });
     }
   }
@@ -718,19 +732,17 @@ function isTypeScriptValidationInput(file) {
   );
 }
 
-function isGoValidationInput(file) {
-  return (
-    file.endsWith(".go") ||
-    /(?:^|\/)go\.(?:mod|sum)$/u.test(file) ||
-    ["go.work", "go.work.sum"].includes(file) ||
-    file.startsWith("services/tuttid/.golangci")
-  );
-}
-
-function selectGoLaneInputs(changedFiles, moduleRoot, forceBuiltinGenerate) {
+function selectGoLaneInputs(
+  changedFiles,
+  moduleRoot,
+  forceBuiltinGenerate,
+  moduleRoots
+) {
   return changedFiles.filter(
     (file) =>
-      (isGoValidationInput(file) && resolveGoModuleRoot(file) === moduleRoot) ||
+      (isGoValidationRelevant(file) &&
+        (isGlobalGoValidationRelevant(file) ||
+          resolveGoModuleRoot(file, moduleRoots) === moduleRoot)) ||
       (forceBuiltinGenerate &&
         moduleRoot === "services/tuttid" &&
         file.startsWith("services/tuttid/builtin-apps/tutti-onboarding/"))

--- a/tools/scripts/run-go-tests.mjs
+++ b/tools/scripts/run-go-tests.mjs
@@ -1,6 +1,6 @@
-import { spawnSync } from "node:child_process";
-import { dirname, join, relative } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { discoverGoModuleRoots } from "./run-check-changed-targets.mjs";
 import {
   readPositiveIntegerOption,
   runValidationLanes
@@ -10,7 +10,7 @@ const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const workspaceRoot = join(scriptDirectory, "..", "..");
 const agentDaemonModule = "packages/agent/daemon";
 const agentDaemonOnly = process.argv.includes("--agent-daemon-only");
-const moduleRoots = loadGoWorkspaceModuleRoots().filter(
+const moduleRoots = discoverGoModuleRoots({ root: workspaceRoot }).filter(
   (moduleRoot) => !agentDaemonOnly || moduleRoot === agentDaemonModule
 );
 
@@ -35,22 +35,3 @@ const result = await runValidationLanes({
   workspaceRoot
 });
 process.exit(result.exitCode);
-
-function loadGoWorkspaceModuleRoots() {
-  const result = spawnSync("go", ["work", "edit", "-json"], {
-    cwd: workspaceRoot,
-    encoding: "utf8"
-  });
-  if (result.status !== 0) {
-    throw new Error(result.stderr.trim() || "go work edit -json failed");
-  }
-  const workspace = JSON.parse(result.stdout);
-  return (workspace.Use ?? [])
-    .map((entry) =>
-      relative(workspaceRoot, join(workspaceRoot, entry.DiskPath)).replaceAll(
-        "\\",
-        "/"
-      )
-    )
-    .sort();
-}

--- a/tools/scripts/run-golangci-lint.mjs
+++ b/tools/scripts/run-golangci-lint.mjs
@@ -2,6 +2,10 @@ import { spawnSync } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveGolangciLintBinary } from "./golangci-lint-tool.mjs";
+import {
+  discoverGoModuleRoots,
+  selectGoLintModuleRoots
+} from "./run-check-changed-targets.mjs";
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const workspaceRoot = join(scriptDirectory, "..", "..");
@@ -11,18 +15,9 @@ const sharedConfigPath = join(
   "tuttid",
   ".golangci.yml"
 );
-const goModuleRoots = [
-  join(workspaceRoot, "packages", "agent", "activity-replication"),
-  join(workspaceRoot, "packages", "agent", "host"),
-  join(workspaceRoot, "packages", "agent", "store-sqlite", "canonical"),
-  join(workspaceRoot, "packages", "agent", "runtimeprep"),
-  join(workspaceRoot, "packages", "appcli", "core"),
-  join(workspaceRoot, "packages", "clients", "device-authority-go"),
-  join(workspaceRoot, "packages", "device-link"),
-  join(workspaceRoot, "packages", "workbench", "service"),
-  join(workspaceRoot, "packages", "workspace", "files"),
-  join(workspaceRoot, "services", "tuttid")
-];
+const goModuleRoots = selectGoLintModuleRoots(
+  discoverGoModuleRoots({ root: workspaceRoot })
+).map((moduleRoot) => join(workspaceRoot, moduleRoot));
 const args = [
   "run",
   "--config",


### PR DESCRIPTION
## Summary
- discover Go modules from `go.work` and scope ordinary Go changes to their owning packages
- share the changed-Go selector between local validation and PR CI, with full-module fallbacks for workflow and tooling changes
- document the changed-aware Go validation policy and builtin-app generation behavior

## Tests
- `pnpm check:changed -- --push-ready` — 60/61 lanes passed; the unchanged `TestServiceRunActionReportsActiveActionForClaudeInstall` failed locally before its mocked installer started
- `go test ./service/agentstatus -run '^TestServiceRunActionReportsActiveActionForClaudeInstall$' -count=1` — reproduced the same local environment-dependent failure\n\n## Notes\n- GitHub CI remains the clean-runner verification for the unrelated local agentstatus failure.