### PR TITLE
feat(workspace-apps): add file mention directory browsing

### DIFF
--- a/apps/desktop/src/main/ipc/workspaceAppAtQueryDirectoryRequest.test.ts
+++ b/apps/desktop/src/main/ipc/workspaceAppAtQueryDirectoryRequest.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createWorkspaceAppAtQueryDirectoryRequest } from "./workspaceAppAtQueryDirectoryRequest.ts";
+
+test("workspace app directory request uses registered guest identity", () => {
+  assert.deepEqual(
+    createWorkspaceAppAtQueryDirectoryRequest({
+      context: { appID: "docs", workspaceID: "workspace-1" },
+      query: { directoryPath: "/workspace/docs", providerId: "file" },
+      requestId: "request-1"
+    }),
+    {
+      appId: "docs",
+      input: { directoryPath: "/workspace/docs", providerId: "file" },
+      operation: "at.queryDirectory",
+      requestId: "request-1",
+      workspaceId: "workspace-1"
+    }
+  );
+});

--- a/apps/desktop/src/main/ipc/workspaceAppAtQueryDirectoryRequest.ts
+++ b/apps/desktop/src/main/ipc/workspaceAppAtQueryDirectoryRequest.ts
@@ -1,0 +1,22 @@
+import type { DesktopWorkspaceAppExternalRendererRequest } from "../../shared/contracts/ipc.ts";
+import type { TuttiExternalAtQueryDirectoryInput } from "@tutti-os/workspace-external-core/contracts";
+import type { WorkspaceAppGuestContext } from "./workspaceAppContextTypes.ts";
+
+type WorkspaceAppAtQueryDirectoryRequest = Extract<
+  DesktopWorkspaceAppExternalRendererRequest,
+  { operation: "at.queryDirectory" }
+>;
+
+export function createWorkspaceAppAtQueryDirectoryRequest(input: {
+  context: Pick<WorkspaceAppGuestContext, "appID" | "workspaceID">;
+  query: TuttiExternalAtQueryDirectoryInput;
+  requestId: string;
+}): WorkspaceAppAtQueryDirectoryRequest {
+  return {
+    appId: input.context.appID,
+    input: input.query,
+    operation: "at.queryDirectory",
+    requestId: input.requestId,
+    workspaceId: input.context.workspaceID
+  };
+}

--- a/apps/desktop/src/main/ipc/workspaceAppGuestContextRegistry.test.ts
+++ b/apps/desktop/src/main/ipc/workspaceAppGuestContextRegistry.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { parseWorkspaceAppGuestPartition } from "./workspaceAppGuestContextRegistry.ts";
+import {
+  parseWorkspaceAppGuestPartition,
+  requireWorkspaceAppGuestContext
+} from "./workspaceAppGuestContextRegistry.ts";
 
 test("workspace app guest partitions decode workspace and app identifiers", () => {
   assert.deepEqual(
@@ -21,5 +24,16 @@ test("workspace app guest partitions reject missing scoped identifiers", () => {
   assert.equal(
     parseWorkspaceAppGuestPartition("persist:tutti-app:workspace:"),
     null
+  );
+});
+
+test("workspace app guest context rejects unregistered senders", () => {
+  assert.throws(
+    () =>
+      requireWorkspaceAppGuestContext({
+        id: 987_654,
+        isDestroyed: () => false
+      } as never),
+    /context is unavailable/
   );
 });

--- a/apps/desktop/src/main/ipc/workspaceAppShellIpc.ts
+++ b/apps/desktop/src/main/ipc/workspaceAppShellIpc.ts
@@ -3,6 +3,7 @@ import { ipcMain } from "electron";
 import { desktopIpcChannels } from "../../shared/contracts/ipc.ts";
 import {
   normalizeTuttiExternalAtQueryInput,
+  normalizeTuttiExternalAtQueryDirectoryInput,
   normalizeTuttiExternalAtResolveInput,
   normalizeTuttiExternalLogInput,
   normalizeTuttiExternalReferenceOpenInput,
@@ -33,6 +34,7 @@ import {
 import { dispatchWorkspaceAppOpenUrl } from "./workspaceAppWindowOpen.ts";
 import { isRecord } from "./workspaceAppPayloadValidation.ts";
 import { requestWorkspaceAppExternalRenderer } from "./workspaceAppRendererBridge.ts";
+import { createWorkspaceAppAtQueryDirectoryRequest } from "./workspaceAppAtQueryDirectoryRequest.ts";
 
 export function registerWorkspaceAppShellIpc(input: {
   endpoint: DesktopDaemonEndpoint;
@@ -62,6 +64,21 @@ export function registerWorkspaceAppShellIpc(input: {
           requestId: randomUUID(),
           workspaceId: context.workspaceID
         }
+      );
+    }
+  );
+  registerDesktopIpcHandler(
+    desktopIpcChannels.appExternal.atQueryDirectory,
+    async (event, payload) => {
+      const context = requireWorkspaceAppGuestContext(event.sender);
+      const input = normalizeTuttiExternalAtQueryDirectoryInput(payload);
+      return requestWorkspaceAppExternalRenderer<TuttiExternalAtQueryResult[]>(
+        context,
+        createWorkspaceAppAtQueryDirectoryRequest({
+          context,
+          query: input,
+          requestId: randomUUID()
+        })
       );
     }
   );

--- a/apps/desktop/src/preload/entries/workspaceAppExternalBridge.test.ts
+++ b/apps/desktop/src/preload/entries/workspaceAppExternalBridge.test.ts
@@ -282,6 +282,40 @@ test("workspace app external bridge resolves mentions without user activation", 
   ]);
 });
 
+test("workspace app external bridge queries direct directory children without user activation", async () => {
+  const calls: Array<{ channel: string; payload?: unknown }> = [];
+  const bridge = createWorkspaceAppExternalBridge({
+    appContext: {
+      async get() {
+        return { locale: "en" };
+      },
+      subscribe() {
+        throw new Error("unexpected subscribe");
+      }
+    },
+    isUserActivationActive: () => false,
+    send: unexpectedSend,
+    async invoke<TResult>(channel: string, payload?: unknown) {
+      calls.push({ channel, payload });
+      return [] as TResult;
+    }
+  });
+
+  assert.deepEqual(
+    await bridge.at.queryDirectory?.({
+      directoryPath: "/workspace/docs",
+      providerId: "file"
+    }),
+    []
+  );
+  assert.deepEqual(calls, [
+    {
+      channel: workspaceAppExternalChannels.atQueryDirectory,
+      payload: { directoryPath: "/workspace/docs", providerId: "file" }
+    }
+  ]);
+});
+
 test("workspace app external bridge subscribes to mention invalidation", () => {
   let publish:
     | ((event: { providerIds?: readonly ["workspace-app"] }) => void)

--- a/apps/desktop/src/preload/entries/workspaceAppExternalBridge.ts
+++ b/apps/desktop/src/preload/entries/workspaceAppExternalBridge.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../shared/contracts/ipc";
 import type {
   TuttiExternalAtQueryInput,
+  TuttiExternalAtQueryDirectoryInput,
   TuttiExternalAtQueryResult,
   TuttiExternalAtInvalidation,
   TuttiExternalAtResolveInput,
@@ -106,6 +107,7 @@ export const workspaceAppExternalChannels = {
   agentActivityListTargets: "workspace-app-agent-activity:list-targets",
   agentActivitySendInput: "workspace-app-agent-activity:send-input",
   atQuery: "workspace-app-at:query",
+  atQueryDirectory: "workspace-app-at:query-directory",
   atResolve: "workspace-app-at:resolve",
   browserOpenUrl: "workspace-app:open-url",
   filesOpen: "workspace-app-files:open",
@@ -209,6 +211,12 @@ export function createWorkspaceAppExternalBridge(
       query(input: TuttiExternalAtQueryInput) {
         return dependencies.invoke<TuttiExternalAtQueryResult[]>(
           workspaceAppExternalChannels.atQuery,
+          input
+        );
+      },
+      queryDirectory(input: TuttiExternalAtQueryDirectoryInput) {
+        return dependencies.invoke<TuttiExternalAtQueryResult[]>(
+          workspaceAppExternalChannels.atQueryDirectory,
           input
         );
       },

--- a/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.test.ts
+++ b/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.test.ts
@@ -1581,6 +1581,189 @@ test("desktop rich text @ service honors abort before provider search starts", a
   assert.equal(searchCallCount, 0);
 });
 
+test("desktop file mention provider lists direct file and folder children", async () => {
+  const calls: Array<{ workspaceId: string; path?: string }> = [];
+  const service = new DesktopRichTextAtService({
+    tuttidClient: createTuttidClient({
+      async listWorkspaceFileDirectory(
+        workspaceId: string,
+        request?: { includeHidden?: boolean; path?: string }
+      ) {
+        calls.push({ workspaceId, path: request?.path });
+        return {
+          directoryPath: request?.path ?? "/workspace",
+          entries: [
+            { kind: "directory", name: "docs", path: "/workspace/docs" },
+            {
+              kind: "file",
+              name: "README.md",
+              path: "/workspace/README.md"
+            }
+          ],
+          root: "/workspace",
+          workspaceID: workspaceId
+        };
+      }
+    })
+  });
+  const [provider] = service.getProviders({
+    capabilities: ["file"],
+    surface: "workspace-app-external",
+    target: "workspace-app",
+    workspaceId: "workspace-1"
+  });
+  assert.ok(provider?.queryDirectory);
+
+  const rootItems = await provider.queryDirectory({
+    context: {},
+    directoryPath: "",
+    keyword: "",
+    trigger: "@"
+  });
+  const childItems = await provider.queryDirectory({
+    context: {},
+    directoryPath: "/workspace/docs",
+    keyword: "",
+    trigger: "@"
+  });
+
+  assert.deepEqual(calls, [
+    { workspaceId: "workspace-1", path: undefined },
+    { workspaceId: "workspace-1", path: "/workspace/docs" }
+  ]);
+  assert.deepEqual(rootItems, childItems);
+  assert.deepEqual(provider.getItemDirectory?.(rootItems[0]), {
+    path: "/workspace/docs"
+  });
+  assert.equal(provider.getItemDirectory?.(rootItems[1]), null);
+  assert.deepEqual(provider.toInsertResult(rootItems[0]), {
+    href: "/workspace/docs/",
+    kind: "markdown-link",
+    label: "docs"
+  });
+});
+
+test("workspace app file mention provider rejects directories outside its root", async () => {
+  const calls: Array<{ workspaceId: string; path?: string }> = [];
+  const service = new DesktopRichTextAtService({
+    tuttidClient: createTuttidClient({
+      async listWorkspaceFileDirectory(
+        workspaceId: string,
+        request?: { includeHidden?: boolean; path?: string }
+      ) {
+        calls.push({ workspaceId, path: request?.path });
+        return {
+          directoryPath: "/workspace",
+          entries: [],
+          root: "/workspace",
+          workspaceID: workspaceId
+        };
+      }
+    })
+  });
+  const [provider] = service.getProviders({
+    capabilities: ["file"],
+    surface: "workspace-app-external",
+    target: "workspace-app",
+    workspaceId: "workspace-1"
+  });
+  assert.ok(provider?.queryDirectory);
+
+  await assert.rejects(
+    Promise.resolve(
+      provider.queryDirectory({
+        context: {},
+        directoryPath: "/etc",
+        keyword: "",
+        trigger: "@"
+      })
+    ),
+    /escapes the provider root/
+  );
+  assert.deepEqual(calls, [{ workspaceId: "workspace-1", path: undefined }]);
+});
+
+test("workspace app file mention provider rejects directories resolved under another root", async () => {
+  const service = new DesktopRichTextAtService({
+    tuttidClient: createTuttidClient({
+      async listWorkspaceFileDirectory(
+        workspaceId: string,
+        request?: { includeHidden?: boolean; path?: string }
+      ) {
+        return request?.path
+          ? {
+              directoryPath: request.path,
+              entries: [],
+              root: "/",
+              workspaceID: workspaceId
+            }
+          : {
+              directoryPath: "/workspace",
+              entries: [],
+              root: "/workspace",
+              workspaceID: workspaceId
+            };
+      }
+    })
+  });
+  const [provider] = service.getProviders({
+    capabilities: ["file"],
+    surface: "workspace-app-external",
+    target: "workspace-app",
+    workspaceId: "workspace-1"
+  });
+  assert.ok(provider?.queryDirectory);
+
+  await assert.rejects(
+    Promise.resolve(
+      provider.queryDirectory({
+        context: {},
+        directoryPath: "/workspace/external-link",
+        keyword: "",
+        trigger: "@"
+      })
+    ),
+    /resolved outside the provider root/
+  );
+});
+
+test("desktop agent file mention provider keeps external absolute directory access", async () => {
+  const calls: Array<{ workspaceId: string; path?: string }> = [];
+  const service = new DesktopRichTextAtService({
+    tuttidClient: createTuttidClient({
+      async listWorkspaceFileDirectory(
+        workspaceId: string,
+        request?: { includeHidden?: boolean; path?: string }
+      ) {
+        calls.push({ workspaceId, path: request?.path });
+        return {
+          directoryPath: request?.path ?? "/workspace",
+          entries: [{ kind: "file", name: "hosts", path: "/etc/hosts" }],
+          root: request?.path ? "/" : "/workspace",
+          workspaceID: workspaceId
+        };
+      }
+    })
+  });
+  const [provider] = service.getProviders({
+    capabilities: ["file"],
+    surface: "desktop-agent-composer",
+    target: "agent-gui",
+    workspaceId: "workspace-1"
+  });
+  assert.ok(provider?.queryDirectory);
+
+  const items = await provider.queryDirectory({
+    context: {},
+    directoryPath: "/etc",
+    keyword: "",
+    trigger: "@"
+  });
+
+  assert.equal((items[0] as { path?: string } | undefined)?.path, "/etc/hosts");
+  assert.deepEqual(calls, [{ workspaceId: "workspace-1", path: "/etc" }]);
+});
+
 test("desktop rich text @ service passes abort signals through to tuttid search", async () => {
   let receivedSignal: AbortSignal | undefined;
   const service = new DesktopRichTextAtService({

--- a/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.ts
+++ b/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.ts
@@ -536,12 +536,68 @@ function isIssueWorkspaceRuntimePath(path: string, root: string): boolean {
   return trimmed === issueRoot || trimmed.startsWith(`${issueRoot}/`);
 }
 
+function normalizeWorkspaceFileBoundaryPath(
+  value: string,
+  rootPath?: string
+): string {
+  const raw = value.trim().replaceAll("\\", "/");
+  const root = rootPath
+    ? normalizeWorkspaceFileBoundaryPath(rootPath)
+    : "/workspace";
+  const rooted = raw
+    ? /^(?:\/?[A-Za-z]:|\/)/.test(raw)
+      ? raw
+      : `${root}/${raw}`
+    : root;
+  const driveMatch = /^\/?([A-Za-z]:)(?:\/|$)/.exec(rooted);
+  const drive = driveMatch?.[1] ?? "";
+  const body = drive
+    ? rooted.slice(driveMatch?.[0].length ?? 0)
+    : rooted.replace(/^\/+/, "");
+  const segments: string[] = [];
+  for (const segment of body.split("/").filter(Boolean)) {
+    if (segment === ".") continue;
+    if (segment === "..") {
+      segments.pop();
+      continue;
+    }
+    segments.push(segment);
+  }
+  if (drive) {
+    return segments.length === 0
+      ? `${drive}/`
+      : `${drive}/${segments.join("/")}`;
+  }
+  return `/${segments.join("/")}`.replace(/\/$/, "") || "/";
+}
+
+function isWorkspaceFilePathWithinProviderRoot(
+  path: string,
+  rootPath: string
+): boolean {
+  const root = normalizeWorkspaceFileBoundaryPath(rootPath);
+  const candidate = normalizeWorkspaceFileBoundaryPath(path, root);
+  const usesWindowsDrive = /^\/?[A-Za-z]:/.test(root);
+  const comparableRoot = usesWindowsDrive ? root.toLowerCase() : root;
+  const comparableCandidate = usesWindowsDrive
+    ? candidate.toLowerCase()
+    : candidate;
+  return (
+    comparableRoot === "/" ||
+    comparableCandidate === comparableRoot ||
+    comparableCandidate.startsWith(`${comparableRoot}/`)
+  );
+}
+
 function createWorkspaceFileAtContributor(
   tuttidClient: TuttidClient
 ): DesktopRichTextAtContributor {
   return {
     capability: "file",
     getProviders(input) {
+      const restrictDirectoryToProviderRoot =
+        input.surface === "workspace-app-external";
+      let providerRootPath: string | null = null;
       return [
         createRichTextTriggerProvider<WorkspaceFileAtItem>({
           id: FILE_PROVIDER_ID,
@@ -574,6 +630,78 @@ function createWorkspaceFileAtContributor(
                 path: entry.path
               }));
           },
+          async queryDirectory(directoryInput) {
+            if (directoryInput.abortSignal?.aborted) {
+              return [];
+            }
+            const directoryPath = directoryInput.directoryPath.trim();
+            let rootResponse: Awaited<
+              ReturnType<TuttidClient["listWorkspaceFileDirectory"]>
+            > | null = null;
+            if (restrictDirectoryToProviderRoot && providerRootPath === null) {
+              rootResponse = await tuttidClient.listWorkspaceFileDirectory(
+                input.workspaceId
+              );
+              providerRootPath = rootResponse.root.trim();
+            }
+            if (
+              restrictDirectoryToProviderRoot &&
+              directoryPath &&
+              (!providerRootPath ||
+                !isWorkspaceFilePathWithinProviderRoot(
+                  directoryPath,
+                  providerRootPath
+                ))
+            ) {
+              throw new Error(
+                "Workspace app file mention directory escapes the provider root."
+              );
+            }
+            const normalizedDirectoryPath = directoryPath
+              ? normalizeWorkspaceFileBoundaryPath(
+                  directoryPath,
+                  providerRootPath ?? undefined
+                )
+              : "";
+            const response =
+              rootResponse &&
+              (!normalizedDirectoryPath ||
+                normalizedDirectoryPath ===
+                  normalizeWorkspaceFileBoundaryPath(rootResponse.root))
+                ? rootResponse
+                : await tuttidClient.listWorkspaceFileDirectory(
+                    input.workspaceId,
+                    directoryPath ? { path: directoryPath } : undefined
+                  );
+            if (
+              restrictDirectoryToProviderRoot &&
+              providerRootPath &&
+              normalizeWorkspaceFileBoundaryPath(response.root) !==
+                normalizeWorkspaceFileBoundaryPath(providerRootPath)
+            ) {
+              throw new Error(
+                "Workspace app file mention directory resolved outside the provider root."
+              );
+            }
+            if (directoryInput.abortSignal?.aborted) {
+              return [];
+            }
+            const entries = response.entries
+              .filter(
+                (entry) =>
+                  !isIssueWorkspaceRuntimePath(entry.path, response.root)
+              )
+              .map((entry) => ({
+                displayName: entry.name,
+                kind: entry.kind,
+                path: entry.path
+              }));
+            return directoryInput.maxResults === undefined
+              ? entries
+              : entries.slice(0, Math.max(0, directoryInput.maxResults));
+          },
+          getItemDirectory: (item) =>
+            item.kind === "directory" ? { path: item.path.trim() } : null,
           getItemKey: (item) => item.path,
           getItemLabel: resolveWorkspaceFileLabel,
           getItemSubtitle: (item) => item.path.trim(),

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAppExternalAtSerialization.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAppExternalAtSerialization.test.ts
@@ -202,6 +202,20 @@ test("serializes rich text at matches without exposing raw item", () => {
   });
 });
 
+test("serializes provider-owned directory metadata for external apps", () => {
+  const match = createMatch({
+    directory: {
+      childCount: 3,
+      path: "/workspace/docs"
+    }
+  });
+
+  assert.deepEqual(serializeWorkspaceAppExternalAtMatch(match)?.directory, {
+    childCount: 3,
+    path: "/workspace/docs"
+  });
+});
+
 test("serializes mention item id from insert identity for external restore", () => {
   const match: RichTextTriggerQueryMatch = {
     providerId: "workspace-app",

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAppExternalAtSerialization.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAppExternalAtSerialization.ts
@@ -65,6 +65,7 @@ export function serializeWorkspaceAppExternalAtMatch(
     label: match.label,
     ...(match.subtitle ? { subtitle: match.subtitle } : {}),
     ...(thumbnailUrl ? { thumbnailUrl } : {}),
+    ...(match.directory ? { directory: { ...match.directory } } : {}),
     insert
   };
 }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
@@ -78,6 +78,7 @@ import type { RichTextTriggerProvider } from "@tutti-os/ui-rich-text/types";
 import { tuttiExternalAtProviderIds } from "@tutti-os/workspace-external-core/core";
 import type {
   TuttiExternalAtQueryInput,
+  TuttiExternalAtQueryDirectoryInput,
   TuttiExternalAtQueryResult,
   TuttiExternalAtResolveInput,
   TuttiExternalAtResolveResult
@@ -321,6 +322,29 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
           workspaceId: input.workspaceId
         }
       }
+    });
+    return matches
+      .map(serializeWorkspaceAppExternalAtMatch)
+      .filter(
+        (result): result is TuttiExternalAtQueryResult => result !== null
+      );
+  }
+
+  async queryWorkspaceAppExternalAtDirectory(input: {
+    query: TuttiExternalAtQueryDirectoryInput;
+    workspaceId: string;
+  }): Promise<TuttiExternalAtQueryResult[]> {
+    const providers = this.createWorkspaceAppExternalAtProviders(
+      new Set([input.query.providerId]),
+      input.workspaceId
+    );
+    const registry = createRichTextTriggerRegistry(providers);
+    const matches = await registry.queryDirectory(input.query.providerId, {
+      context: { metadata: { workspaceId: input.workspaceId } },
+      directoryPath: input.query.directoryPath,
+      keyword: "",
+      maxResults: input.query.maxResults,
+      trigger: "@"
     });
     return matches
       .map(serializeWorkspaceAppExternalAtMatch)

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAppExternalAtRequest.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAppExternalAtRequest.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { dispatchWorkspaceAppExternalAtRequest } from "./workspaceAppExternalAtRequest.ts";
+
+test("workspace app external at directory requests dispatch with host workspace context", async () => {
+  const calls: unknown[] = [];
+  const result = await dispatchWorkspaceAppExternalAtRequest({
+    hostService: {
+      async queryWorkspaceAppExternalAt() {
+        throw new Error("unexpected at.query");
+      },
+      async queryWorkspaceAppExternalAtDirectory(input) {
+        calls.push(input);
+        return [];
+      },
+      async resolveWorkspaceAppExternalAt() {
+        throw new Error("unexpected at.resolve");
+      }
+    },
+    request: {
+      appId: "docs",
+      input: {
+        directoryPath: "/workspace/docs",
+        providerId: "file"
+      },
+      operation: "at.queryDirectory",
+      requestId: "request-1",
+      workspaceId: "untrusted-request-workspace"
+    },
+    workspaceId: "workspace-1"
+  });
+
+  assert.deepEqual(result, []);
+  assert.deepEqual(calls, [
+    {
+      query: {
+        directoryPath: "/workspace/docs",
+        providerId: "file"
+      },
+      workspaceId: "workspace-1"
+    }
+  ]);
+});

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAppExternalAtRequest.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAppExternalAtRequest.ts
@@ -1,0 +1,36 @@
+import type { DesktopWorkspaceAppExternalRendererRequest } from "@shared/contracts/ipc";
+import type { IWorkspaceWorkbenchHostService } from "./workspaceWorkbenchHostService.interface.ts";
+
+type WorkspaceAppExternalAtRequest = Extract<
+  DesktopWorkspaceAppExternalRendererRequest,
+  { operation: "at.query" | "at.queryDirectory" | "at.resolve" }
+>;
+
+export function dispatchWorkspaceAppExternalAtRequest(input: {
+  hostService: Pick<
+    IWorkspaceWorkbenchHostService,
+    | "queryWorkspaceAppExternalAt"
+    | "queryWorkspaceAppExternalAtDirectory"
+    | "resolveWorkspaceAppExternalAt"
+  >;
+  request: WorkspaceAppExternalAtRequest;
+  workspaceId: string;
+}) {
+  switch (input.request.operation) {
+    case "at.query":
+      return input.hostService.queryWorkspaceAppExternalAt({
+        query: input.request.input,
+        workspaceId: input.workspaceId
+      });
+    case "at.queryDirectory":
+      return input.hostService.queryWorkspaceAppExternalAtDirectory({
+        query: input.request.input,
+        workspaceId: input.workspaceId
+      });
+    case "at.resolve":
+      return input.hostService.resolveWorkspaceAppExternalAt({
+        mention: input.request.input,
+        workspaceId: input.workspaceId
+      });
+  }
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchHostService.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchHostService.interface.ts
@@ -39,6 +39,7 @@ import type {
   DesktopWorkspaceOpenFeatureRequest
 } from "@shared/contracts/ipc";
 import type {
+  TuttiExternalAtQueryDirectoryInput,
   TuttiExternalAtQueryInput,
   TuttiExternalAtQueryResult,
   TuttiExternalAtResolveInput,
@@ -170,6 +171,10 @@ export interface IWorkspaceWorkbenchHostService {
   openExternal(url: string): Promise<void>;
   queryWorkspaceAppExternalAt(input: {
     query: TuttiExternalAtQueryInput;
+    workspaceId: string;
+  }): Promise<TuttiExternalAtQueryResult[]>;
+  queryWorkspaceAppExternalAtDirectory(input: {
+    query: TuttiExternalAtQueryDirectoryInput;
     workspaceId: string;
   }): Promise<TuttiExternalAtQueryResult[]>;
   resolveWorkspaceAppExternalAt(input: {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAppExternalBridge.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAppExternalBridge.tsx
@@ -38,6 +38,7 @@ import { useWorkspaceWorkbenchHostService } from "./useWorkspaceWorkbenchHostSer
 import { useWorkspaceSettingsService } from "./useWorkspaceSettingsService";
 import { requestWorkspaceIssueManagerLaunch } from "../services/workspaceIssueManagerLaunchCoordinator";
 import { serializeWorkspaceAppExternalAgentIconUrl } from "../services/workspaceAppExternalAgentIconSerialization.ts";
+import { dispatchWorkspaceAppExternalAtRequest } from "../services/workspaceAppExternalAtRequest.ts";
 
 const workspaceFileReferenceLocaleKeyByPickerKey: Record<string, string> = {
   "actions.cancel": "common.cancel",
@@ -333,13 +334,11 @@ export function WorkspaceAppExternalBridge({
         case "agentActivity.getSnapshot":
           return workspaceAgentActivityService.load(workspaceId);
         case "at.query":
-          return hostService.queryWorkspaceAppExternalAt({
-            query: request.input,
-            workspaceId
-          });
+        case "at.queryDirectory":
         case "at.resolve":
-          return hostService.resolveWorkspaceAppExternalAt({
-            mention: request.input,
+          return dispatchWorkspaceAppExternalAtRequest({
+            hostService,
+            request,
             workspaceId
           });
         case "files.select":

--- a/apps/desktop/src/shared/contracts/ipc.ts
+++ b/apps/desktop/src/shared/contracts/ipc.ts
@@ -45,6 +45,7 @@ import type {
   BrowserNodeUpdateAutomationTargetInput
 } from "@tutti-os/browser-node";
 import type {
+  TuttiExternalAtQueryDirectoryInput,
   TuttiExternalAtQueryInput,
   TuttiExternalAtQueryResult,
   TuttiExternalFileOpenInput,
@@ -119,6 +120,7 @@ export const desktopIpcChannels = {
     agentActivityListTargets: "workspace-app-agent-activity:list-targets",
     agentActivitySendInput: "workspace-app-agent-activity:send-input",
     atQuery: "workspace-app-at:query",
+    atQueryDirectory: "workspace-app-at:query-directory",
     atResolve: "workspace-app-at:resolve",
     filesOpen: "workspace-app-files:open",
     filesSelect: "workspace-app-files:select",
@@ -1065,6 +1067,8 @@ export interface DesktopInvokePayloadByChannel {
   [desktopIpcChannels.appExternal
     .agentActivitySendInput]: TuttiExternalAgentActivitySendInput;
   [desktopIpcChannels.appExternal.atQuery]: TuttiExternalAtQueryInput;
+  [desktopIpcChannels.appExternal
+    .atQueryDirectory]: TuttiExternalAtQueryDirectoryInput;
   [desktopIpcChannels.appExternal.atResolve]: TuttiExternalAtResolveInput;
   [desktopIpcChannels.appExternal.filesOpen]: TuttiExternalFileOpenInput;
   [desktopIpcChannels.appExternal.filesSelect]: TuttiExternalFileSelectInput;
@@ -1260,6 +1264,8 @@ export interface DesktopInvokeResultByChannel {
   [desktopIpcChannels.appExternal
     .agentActivitySendInput]: TuttiExternalAgentActivitySendResult;
   [desktopIpcChannels.appExternal.atQuery]: TuttiExternalAtQueryResult[];
+  [desktopIpcChannels.appExternal
+    .atQueryDirectory]: TuttiExternalAtQueryResult[];
   [desktopIpcChannels.appExternal
     .atResolve]: TuttiExternalAtResolveResult | null;
   [desktopIpcChannels.appExternal.filesOpen]: void;

--- a/docs/architecture/agent-reference-sources.md
+++ b/docs/architecture/agent-reference-sources.md
@@ -141,12 +141,25 @@ create copy from the `workspaceFileManager` namespace.
 
 ### Composer Mention Directory Navigation
 
-The compact AgentGUI `@` palette uses `AgentContextMentionProvider` instead of
-the full reference picker, but it preserves the same ownership boundary. A file
+The generic hierarchy contract belongs to `@tutti-os/ui-rich-text`. A file
 provider that supports directory browsing exposes both `getItemDirectory()`
 and `queryDirectory()`. The descriptor supplies the provider-owned canonical
 directory path and, when known, its direct-child count; `queryDirectory()`
 lists that directory's direct children without overloading keyword search.
+The shared `RichTextTriggerEditor` owns an optional browse stack when a consumer
+enables `palette.directoryNavigation`; consumers that omit the option retain
+the ordinary flat trigger behavior.
+
+The compact AgentGUI `@` palette uses `AgentContextMentionProvider` instead of
+the full reference picker and consumes the same shared provider contract, but
+keeps its existing controller-owned browse lifecycle. External workspace apps
+receive the optional contract through `tuttiExternal.at.queryDirectory()` and
+enable it on their shared editor. The bridge transports provider results and
+canonical paths; it does not infer hierarchy or own an app-side browse stack.
+For workspace apps, the empty path addresses the host file-provider root and
+subsequent directory paths must remain inside that root. AgentGUI continues to
+use its separately composed host provider when it needs explicitly supported
+external absolute paths.
 
 AgentGUI owns only the ephemeral browse stack and turns those provider results
 into enter/back navigation rows. The palette renders the supplied count and
@@ -154,6 +167,14 @@ navigation affordance, but does not infer hierarchy from a path, a trailing
 separator, cached tree depth, or already loaded rows. Search results remain
 ordinary insertable mentions unless the provider explicitly marks them as
 navigable directories.
+
+Across both AgentGUI and shared-editor consumers, selection and hierarchy are
+separate actions: selecting a folder row inserts its folder path, while the
+dedicated row affordance or ArrowRight enters it. ArrowLeft and the header back
+action return to the parent. Non-empty input always uses the existing ranked
+keyword query and clears the ephemeral browse stack; clearing back to the bare
+trigger resumes browse from the provider root. Closing the query, pressing
+Escape, or changing the configured directory provider also clears that stack.
 
 Directory navigation owns a request lifecycle that is independent from
 keyword-search and root-browse provider queries. Entering another directory,
@@ -166,8 +187,9 @@ Directory reads do not inherit the short provider-search timeout or its
 partial-result fallback. They remain loading until the provider completes or
 the directory lifecycle explicitly cancels them. A successful authoritative
 empty result is the only state presented as an empty directory; provider
-failure remains an error, and a file provider without `queryDirectory()` fails
-closed instead of falling back to keyword search.
+failure remains an error. A file provider without `queryDirectory()` exposes no
+hierarchy controls and retains the ordinary flat keyword-search behavior for
+compatibility with older hosts.
 
 The compact palette browse cache is presentation-only. Every user-opened `@`
 browse paints a matching cached entry synchronously when one exists and always

--- a/packages/ui/rich-text/README.md
+++ b/packages/ui/rich-text/README.md
@@ -104,6 +104,12 @@ interface RichTextTriggerProvider<TItem = unknown> {
   ) =>
     | Promise<RichTextTriggerQueryGroup<TItem>>
     | RichTextTriggerQueryGroup<TItem>;
+  getItemDirectory?: (
+    item: TItem
+  ) => RichTextTriggerDirectoryDescriptor | null | undefined;
+  queryDirectory?: (
+    input: RichTextTriggerDirectoryQueryInput
+  ) => Promise<readonly TItem[]> | readonly TItem[];
   getItemKey: (item: TItem) => string;
   getItemLabel: (item: TItem) => string;
   getItemSubtitle?: (item: TItem) => string | null | undefined;
@@ -124,6 +130,9 @@ Interpretation:
 - `queryGroups` optionally returns provider-owned groups with stable ids,
   labels, query-scoped totals, and independent cursors; `queryGroupPage`
   appends one cursor page without re-querying sibling groups
+- `getItemDirectory` and `queryDirectory` are an optional hierarchy contract:
+  the descriptor exposes a provider-owned canonical path and optional direct
+  child count, while the query lists only that directory's direct children
 - `getItemLabel` and `getItemSubtitle` decide the suggestion copy
 - `toInsertResult` maps a chosen item into a mention, markdown-link, or text
   insertion
@@ -135,6 +144,45 @@ Interpretation:
   limited to durable identity and scope
 - group ids, labels, totals, and cursors are candidate-panel metadata only;
   they must not be copied into mention identity, href, or persisted scope
+
+Directory navigation is opt-in at the editor boundary. Omitting
+`palette.directoryNavigation` preserves the ordinary ranked mention palette,
+even when a registered provider supports hierarchy. When enabled, an empty
+trigger browses the provider root, the row body still inserts a folder
+reference, and the row's hierarchy action or ArrowRight enters it. ArrowLeft
+and the header back action return to the parent. Non-empty queries continue to
+use ranked `query()` results.
+
+The editor only renders hierarchy hints and actions when the configured
+provider actually implements `queryDirectory`; older hosts therefore keep a
+clean flat-search fallback. Starting a keyword search, changing the directory
+provider, closing the query, or pressing Escape clears the browse stack.
+Directory failures remain an explicit localized error state rather than being
+presented as an authoritative empty directory.
+
+```tsx
+<RichTextTriggerEditor
+  value={draft}
+  onChange={setDraft}
+  palette={{
+    categories: [{ id: "file", label: labels.file, providerIds: ["file"] }],
+    defaultCategoryId: "file",
+    labels: {
+      tabHint: labels.tabHint,
+      cycleFilter: labels.cycleFilter,
+      moveSelection: labels.moveSelection
+    },
+    directoryNavigation: {
+      providerId: "file",
+      labels: {
+        back: labels.back,
+        enter: labels.enter,
+        navigateHierarchy: labels.navigateHierarchy
+      }
+    }
+  }}
+/>
+```
 
 Mention data:
 

--- a/packages/ui/rich-text/package.json
+++ b/packages/ui/rich-text/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "build": "tsup --config tsup.config.ts",
-    "test": "node --test --experimental-strip-types \"./src/**/*.test.ts\"",
+    "test": "node --test --experimental-strip-types \"./src/**/*.test.ts\" && vitest run RichTextTriggerEditor.directoryNavigation.render.test --environment jsdom",
     "typecheck": "node ../../../tools/scripts/run-tsgo-typecheck.mjs"
   },
   "dependencies": {
@@ -34,6 +34,7 @@
     "@tutti-os/ui-system": "workspace:*"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.3.0",
     "@tiptap/core": "^3.23.6",
     "@tiptap/extension-document": "^3.23.6",
     "@tiptap/extension-hard-break": "^3.23.6",
@@ -44,9 +45,11 @@
     "@types/node": "^24.0.1",
     "@types/react": "^19.1.6",
     "@types/react-dom": "^19.1.5",
+    "jsdom": "^27.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^4.0.13"
   },
   "peerDependencies": {
     "@tiptap/core": "^3.23.6",

--- a/packages/ui/rich-text/src/editor/RichTextTriggerEditor.directoryNavigation.render.test.tsx
+++ b/packages/ui/rich-text/src/editor/RichTextTriggerEditor.directoryNavigation.render.test.tsx
@@ -1,0 +1,263 @@
+import { afterEach, beforeAll, describe, expect, test } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor
+} from "@testing-library/react";
+import { createRichTextMentionService } from "../service/RichTextMentionService.ts";
+import { createRichTextMarkdownLinkInsertResult } from "../plugins/trigger.ts";
+import type { RichTextTriggerProvider } from "../types/trigger.ts";
+import { TooltipProvider } from "@tutti-os/ui-system/components";
+import { RichTextTriggerEditor } from "./RichTextTriggerEditor.tsx";
+
+const palette = {
+  categories: [{ id: "files", label: "Files", providerIds: ["file"] }],
+  defaultCategoryId: "files",
+  directoryNavigation: {
+    providerId: "file",
+    labels: {
+      back: "Back",
+      enter: "Enter folder",
+      navigateHierarchy: "Navigate folders"
+    }
+  },
+  labels: {
+    cycleFilter: "Cycle filter",
+    moveSelection: "Move selection",
+    tabHint: "Filter"
+  }
+} as const;
+
+beforeAll(() => {
+  const rect = {
+    bottom: 20,
+    height: 20,
+    left: 0,
+    right: 100,
+    top: 0,
+    width: 100,
+    x: 0,
+    y: 0,
+    toJSON: () => ({})
+  } satisfies DOMRect;
+  Range.prototype.getBoundingClientRect = () => rect;
+  Range.prototype.getClientRects = () =>
+    Object.assign([rect], { item: (index: number) => [rect][index] ?? null });
+  window.scrollBy = () => undefined;
+});
+
+afterEach(() => cleanup());
+
+describe("RichTextTriggerEditor directory navigation", () => {
+  test("enters and returns from provider directories", async () => {
+    const directoryPaths: string[] = [];
+    const mentionService = createRichTextMentionService({
+      providers: [
+        createFileProvider({
+          queryDirectory(input) {
+            directoryPaths.push(input.directoryPath);
+            return input.directoryPath
+              ? [{ kind: "file", path: "/workspace/docs/readme.md" }]
+              : [{ kind: "directory", path: "/workspace/docs" }];
+          }
+        })
+      ]
+    });
+
+    const view = render(
+      <RichTextTriggerEditor
+        focusSignal={0}
+        mentionService={mentionService}
+        onChange={() => undefined}
+        palette={palette}
+        value="@"
+      />
+    );
+    view.rerender(
+      <RichTextTriggerEditor
+        focusSignal={1}
+        mentionService={mentionService}
+        onChange={() => undefined}
+        palette={palette}
+        value="@"
+      />
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Enter folder" })
+    );
+    await waitFor(() => expect(directoryPaths.at(-1)).toBe("/workspace/docs"));
+    const callCountBeforeBack = directoryPaths.length;
+    fireEvent.click(await screen.findByRole("button", { name: "Back" }));
+    await waitFor(() => {
+      expect(directoryPaths.length).toBeGreaterThan(callCountBeforeBack);
+      expect(directoryPaths.at(-1)).toBe("");
+    });
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Enter folder" })
+    );
+    await waitFor(() => expect(directoryPaths.at(-1)).toBe("/workspace/docs"));
+    view.rerender(
+      <RichTextTriggerEditor
+        focusSignal={2}
+        mentionService={mentionService}
+        onChange={() => undefined}
+        palette={palette}
+        value="@read"
+      />
+    );
+    await waitFor(() => expect(screen.queryByText("docs")).toBeNull());
+    const callCountBeforeClearingSearch = directoryPaths.length;
+    view.rerender(
+      <RichTextTriggerEditor
+        focusSignal={3}
+        mentionService={mentionService}
+        onChange={() => undefined}
+        palette={palette}
+        value="@"
+      />
+    );
+    await waitFor(() => {
+      expect(directoryPaths.length).toBeGreaterThan(
+        callCountBeforeClearingSearch
+      );
+      expect(directoryPaths.at(-1)).toBe("");
+    });
+  });
+
+  test("inserts a directory path from the row body", async () => {
+    const changes: string[] = [];
+    const mentionService = createRichTextMentionService({
+      providers: [
+        createFileProvider({
+          queryDirectory: () => [{ kind: "directory", path: "/workspace/docs" }]
+        })
+      ]
+    });
+
+    const view = render(
+      <TooltipProvider>
+        <RichTextTriggerEditor
+          focusSignal={0}
+          mentionService={mentionService}
+          onChange={(value) => changes.push(value)}
+          palette={palette}
+          value="@"
+        />
+      </TooltipProvider>
+    );
+    view.rerender(
+      <TooltipProvider>
+        <RichTextTriggerEditor
+          focusSignal={1}
+          mentionService={mentionService}
+          onChange={(value) => changes.push(value)}
+          palette={palette}
+          value="@"
+        />
+      </TooltipProvider>
+    );
+
+    const label = await screen.findByText("docs");
+    const option = label.closest('[role="option"]');
+    expect(option).not.toBeNull();
+    fireEvent.click(option as Element);
+    await waitFor(() =>
+      expect(changes.at(-1)).toBe("[docs](/workspace/docs/)")
+    );
+  });
+
+  test("hides hierarchy controls when the provider lacks the capability", async () => {
+    const mentionService = createRichTextMentionService({
+      providers: [
+        createFileProvider({
+          query: () => [{ kind: "directory", path: "/workspace/docs" }]
+        })
+      ]
+    });
+
+    const view = render(
+      <RichTextTriggerEditor
+        focusSignal={0}
+        mentionService={mentionService}
+        onChange={() => undefined}
+        palette={palette}
+        value="@"
+      />
+    );
+    view.rerender(
+      <RichTextTriggerEditor
+        focusSignal={1}
+        mentionService={mentionService}
+        onChange={() => undefined}
+        palette={palette}
+        value="@"
+      />
+    );
+
+    await screen.findByText("docs");
+    expect(screen.queryByRole("button", { name: "Enter folder" })).toBeNull();
+    expect(screen.queryByText("Navigate folders")).toBeNull();
+  });
+
+  test("renders a localized error when directory loading fails", async () => {
+    const mentionService = createRichTextMentionService({
+      providers: [
+        createFileProvider({
+          queryDirectory: async () => {
+            throw new Error("directory unavailable");
+          }
+        })
+      ]
+    });
+
+    const view = render(
+      <RichTextTriggerEditor
+        focusSignal={0}
+        mentionService={mentionService}
+        onChange={() => undefined}
+        palette={palette}
+        value="@"
+      />
+    );
+    view.rerender(
+      <RichTextTriggerEditor
+        focusSignal={1}
+        mentionService={mentionService}
+        onChange={() => undefined}
+        palette={palette}
+        value="@"
+      />
+    );
+
+    expect(await screen.findByText("Unable to load references")).toBeTruthy();
+  });
+});
+
+function createFileProvider(
+  overrides: Partial<RichTextTriggerProvider<FileItem>>
+): RichTextTriggerProvider<FileItem> {
+  return {
+    id: "file",
+    trigger: "@",
+    query: () => [],
+    getItemDirectory: (item) =>
+      item.kind === "directory" ? { path: item.path } : null,
+    getItemKey: (item) => item.path,
+    getItemLabel: (item) => item.path.split("/").at(-1) ?? item.path,
+    toInsertResult: (item) =>
+      createRichTextMarkdownLinkInsertResult(
+        item.path.split("/").at(-1) ?? item.path,
+        item.kind === "directory" ? `${item.path}/` : item.path
+      ),
+    ...overrides
+  };
+}
+
+interface FileItem {
+  kind: "directory" | "file";
+  path: string;
+}

--- a/packages/ui/rich-text/src/editor/RichTextTriggerEditor.directoryNavigation.test.ts
+++ b/packages/ui/rich-text/src/editor/RichTextTriggerEditor.directoryNavigation.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createRichTextTriggerRegistry } from "../plugins/triggerRegistry.ts";
+import { createRichTextMarkdownLinkInsertResult } from "../plugins/trigger.ts";
+import type {
+  RichTextTriggerProvider,
+  RichTextTriggerQueryMatch,
+  RichTextTriggerRegistry
+} from "../types/trigger.ts";
+import {
+  enterRichTextTriggerDirectory,
+  exitRichTextTriggerDirectory,
+  resolveRichTextTriggerDirectoryItemAction
+} from "./richTextTriggerDirectoryNavigation.ts";
+import { queryRichTextTriggerDirectoryMatches } from "./richTextTriggerQuery.ts";
+
+function directoryMatch(): RichTextTriggerQueryMatch {
+  return {
+    directory: { path: "/workspace/docs" },
+    insertResult: createRichTextMarkdownLinkInsertResult(
+      "docs",
+      "/workspace/docs/"
+    ),
+    item: {},
+    key: "/workspace/docs",
+    label: "docs",
+    providerId: "file",
+    trigger: "@"
+  };
+}
+
+test("legacy rich text trigger registries can omit directory browsing", () => {
+  const registry: RichTextTriggerRegistry = {
+    getProvider: () => undefined,
+    listProviders: () => [],
+    listTriggerConfigs: () => [],
+    query: async () => []
+  };
+
+  assert.equal(registry.queryDirectory, undefined);
+});
+
+test("RichTextTriggerEditor keeps directory body selection insertable", () => {
+  assert.equal(
+    resolveRichTextTriggerDirectoryItemAction({
+      interaction: "select",
+      match: directoryMatch(),
+      providerId: "file"
+    }),
+    "insert"
+  );
+});
+
+test("RichTextTriggerEditor enters folders only through hierarchy navigation", () => {
+  assert.equal(
+    resolveRichTextTriggerDirectoryItemAction({
+      interaction: "navigate",
+      match: directoryMatch(),
+      providerId: "file"
+    }),
+    "enter"
+  );
+  assert.deepEqual(enterRichTextTriggerDirectory([], "/workspace/docs"), [
+    "/workspace/docs"
+  ]);
+  assert.deepEqual(
+    exitRichTextTriggerDirectory(["/workspace/docs", "/workspace/docs/api"]),
+    ["/workspace/docs"]
+  );
+});
+
+test("RichTextTriggerEditor directory request respects abort fencing", async () => {
+  let release: (() => void) | undefined;
+  const provider = {
+    id: "file",
+    trigger: "@",
+    query: () => [],
+    queryDirectory: async () => {
+      await new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      return [{ kind: "file", path: "/workspace/docs/readme.md" }];
+    },
+    getItemKey: (item) => item.path,
+    getItemLabel: (item) => item.path,
+    toInsertResult: (item) =>
+      createRichTextMarkdownLinkInsertResult(item.path, item.path)
+  } satisfies RichTextTriggerProvider<{ kind: string; path: string }>;
+  const registry = createRichTextTriggerRegistry([provider]);
+  const abortController = new AbortController();
+  const pending = queryRichTextTriggerDirectoryMatches(registry, "file", {
+    abortSignal: abortController.signal,
+    context: {},
+    directoryPath: "/workspace/docs",
+    keyword: "",
+    trigger: "@"
+  });
+  abortController.abort();
+  release?.();
+  assert.deepEqual(await pending, []);
+});
+
+test("RichTextTriggerEditor directory request preserves provider errors", async () => {
+  const registry = createRichTextTriggerRegistry([
+    {
+      id: "file",
+      trigger: "@",
+      query: () => [],
+      queryDirectory: async () => {
+        throw new Error("directory unavailable");
+      },
+      getItemKey: () => "unused",
+      getItemLabel: () => "unused",
+      toInsertResult: () =>
+        createRichTextMarkdownLinkInsertResult("unused", "/unused")
+    }
+  ]);
+
+  await assert.rejects(
+    queryRichTextTriggerDirectoryMatches(registry, "file", {
+      context: {},
+      directoryPath: "",
+      keyword: "",
+      trigger: "@"
+    }),
+    /directory unavailable/
+  );
+});
+
+test("directory registry discards results aborted during async item mapping", async () => {
+  let releaseIcon: (() => void) | undefined;
+  const provider = {
+    id: "file",
+    trigger: "@",
+    query: () => [],
+    queryDirectory: () => [{ kind: "file", path: "/workspace/readme.md" }],
+    getItemKey: (item) => item.path,
+    getItemLabel: (item) => item.path,
+    getItemIconUrl: async () => {
+      await new Promise<void>((resolve) => {
+        releaseIcon = resolve;
+      });
+      return "file:///icon.png";
+    },
+    toInsertResult: (item) =>
+      createRichTextMarkdownLinkInsertResult(item.path, item.path)
+  } satisfies RichTextTriggerProvider<{ kind: string; path: string }>;
+  const registry = createRichTextTriggerRegistry([provider]);
+  const abortController = new AbortController();
+
+  const pending = registry.queryDirectory("file", {
+    abortSignal: abortController.signal,
+    context: {},
+    directoryPath: "",
+    keyword: "",
+    trigger: "@"
+  });
+  abortController.abort();
+  releaseIcon?.();
+
+  assert.deepEqual(await pending, []);
+});

--- a/packages/ui/rich-text/src/editor/RichTextTriggerEditor.tsx
+++ b/packages/ui/rich-text/src/editor/RichTextTriggerEditor.tsx
@@ -17,7 +17,8 @@ import Paragraph from "@tiptap/extension-paragraph";
 import Text from "@tiptap/extension-text";
 import type { Editor as TiptapEditor } from "@tiptap/react";
 import { EditorContent, useEditor } from "@tiptap/react";
-import { ViewportMenuSurface } from "@tutti-os/ui-system/components";
+import { Button, ViewportMenuSurface } from "@tutti-os/ui-system/components";
+import { ArrowLeftIcon } from "@tutti-os/ui-system/icons";
 import { cn } from "@tutti-os/ui-system/utils";
 import {
   MentionPaletteFromState,
@@ -52,9 +53,15 @@ import {
 } from "../core/richTextDocument.ts";
 import {
   findRichTextTriggerQuery,
+  queryRichTextTriggerDirectoryMatches,
   queryRichTextTriggerMatches
 } from "./richTextTriggerQuery.ts";
 import { isRichTextImeComposing } from "./richTextIme.ts";
+import {
+  enterRichTextTriggerDirectory,
+  exitRichTextTriggerDirectory,
+  resolveRichTextTriggerDirectoryItemAction
+} from "./richTextTriggerDirectoryNavigation.ts";
 import {
   resolveRichTextTriggerText,
   type RichTextTriggerTextOverrides
@@ -111,6 +118,15 @@ export interface RichTextTriggerEditorPaletteOptions {
     listbox?: string;
   };
   maxHeightPx?: number;
+  /** Optional, provider-owned directory navigation. Disabled when omitted. */
+  directoryNavigation?: {
+    providerId: string;
+    labels: {
+      back: string;
+      enter: string;
+      navigateHierarchy: string;
+    };
+  };
 }
 
 type RichTextEditorTriggerQueryState = {
@@ -193,10 +209,25 @@ export function RichTextTriggerEditor({
     resolveDefaultPaletteCategoryId(palette)
   );
   const [isLoading, setIsLoading] = useState(false);
+  const [hasQueryError, setHasQueryError] = useState(false);
+  const [directoryBrowsePaths, setDirectoryBrowsePaths] = useState<
+    readonly string[]
+  >([]);
   const [resolvedMenuAnchor, setResolvedMenuAnchor] =
     useState<RichTextTriggerResolvedMenuPlacement | null>(null);
 
   latestOnChangeRef.current = onChange;
+
+  const directoryNavigationProviderId =
+    palette?.directoryNavigation?.providerId.trim() ?? "";
+  const directoryNavigationProvider = directoryNavigationProviderId
+    ? registry.getProvider(directoryNavigationProviderId)
+    : undefined;
+  const hasDirectoryNavigationCapability = Boolean(
+    directoryNavigationProviderId &&
+    registry.queryDirectory &&
+    directoryNavigationProvider?.queryDirectory
+  );
 
   const resetMenuPlacement = useCallback(() => {
     setResolvedMenuAnchor(null);
@@ -371,6 +402,7 @@ export function RichTextTriggerEditor({
       setMatches([]);
       setActiveIndex(0);
       setIsLoading(false);
+      setHasQueryError(false);
       return;
     }
 
@@ -378,13 +410,19 @@ export function RichTextTriggerEditor({
       setMatches([]);
       setActiveIndex(0);
       setIsLoading(false);
+      setHasQueryError(false);
       return;
     }
 
     const abortController = new AbortController();
     setIsLoading(true);
+    setHasQueryError(false);
 
-    void queryRichTextTriggerMatches(registry, {
+    const shouldBrowseDirectory =
+      query.trigger === "@" &&
+      query.keyword.length === 0 &&
+      hasDirectoryNavigationCapability;
+    const queryInput = {
       abortSignal: abortController.signal,
       keyword: query.keyword,
       maxResults,
@@ -398,7 +436,19 @@ export function RichTextTriggerEditor({
         ),
         documentText: serializeRichTextDocumentToContent(editor.getJSON())
       }
-    })
+    } as const;
+    const matchesPromise = shouldBrowseDirectory
+      ? queryRichTextTriggerDirectoryMatches(
+          registry,
+          directoryNavigationProviderId,
+          {
+            ...queryInput,
+            directoryPath: directoryBrowsePaths.at(-1) ?? ""
+          }
+        )
+      : queryRichTextTriggerMatches(registry, queryInput);
+
+    void matchesPromise
       .then((nextMatches) => {
         if (abortController.signal.aborted) {
           return;
@@ -409,6 +459,14 @@ export function RichTextTriggerEditor({
             ? 0
             : Math.max(0, Math.min(current, nextMatches.length - 1))
         );
+      })
+      .catch(() => {
+        if (abortController.signal.aborted) {
+          return;
+        }
+        setMatches([]);
+        setActiveIndex(0);
+        setHasQueryError(true);
       })
       .finally(() => {
         if (!abortController.signal.aborted) {
@@ -425,27 +483,62 @@ export function RichTextTriggerEditor({
     minQueryLength,
     activeTriggerConfigs.length,
     query,
-    registry
+    registry,
+    directoryNavigationProviderId,
+    hasDirectoryNavigationCapability,
+    directoryBrowsePaths
   ]);
+
+  useEffect(() => {
+    setDirectoryBrowsePaths((current) => (current.length === 0 ? current : []));
+  }, [directoryNavigationProviderId]);
+
+  useEffect(() => {
+    if (query !== null && query.trigger === "@" && query.keyword.length === 0) {
+      return;
+    }
+    setDirectoryBrowsePaths((current) => (current.length === 0 ? current : []));
+  }, [query?.keyword, query?.trigger]);
 
   const resolvedPaletteCategoryId = resolveActivePaletteCategoryId(
     palette,
     activePaletteCategoryId
   );
-  const paletteState = useMemo(
-    () =>
-      palette
-        ? buildMentionPaletteModelFromTriggerMatches({
-            activeCategoryId: resolvedPaletteCategoryId,
-            categories: palette.categories,
-            matches,
-            loading: isLoading,
-            query: query?.keyword ?? "",
-            mode: "results"
-          })
-        : null,
-    [isLoading, matches, palette, query?.keyword, resolvedPaletteCategoryId]
+  const isDirectoryBrowseMode = Boolean(
+    hasDirectoryNavigationCapability &&
+    query?.trigger === "@" &&
+    query.keyword.length === 0
   );
+  const paletteState = useMemo(() => {
+    if (!palette) {
+      return null;
+    }
+    const nextState = buildMentionPaletteModelFromTriggerMatches({
+      activeCategoryId: resolvedPaletteCategoryId,
+      categories: palette.categories,
+      matches,
+      loading: isLoading,
+      query: query?.keyword ?? "",
+      mode: isDirectoryBrowseMode ? "browse" : "results"
+    });
+    if (!hasQueryError) {
+      return nextState;
+    }
+    return {
+      ...nextState,
+      status: "error",
+      error: text.loadFailedLabel
+    } satisfies MentionPaletteState<RichTextTriggerQueryMatch>;
+  }, [
+    hasQueryError,
+    isDirectoryBrowseMode,
+    isLoading,
+    matches,
+    palette,
+    query?.keyword,
+    resolvedPaletteCategoryId,
+    text.loadFailedLabel
+  ]);
 
   useEffect(() => {
     const defaultCategoryId = resolveDefaultPaletteCategoryId(palette);
@@ -535,6 +628,17 @@ export function RichTextTriggerEditor({
     if (!editor || !query) {
       return;
     }
+    const directoryProviderId = palette?.directoryNavigation?.providerId;
+    if (
+      directoryProviderId &&
+      resolveRichTextTriggerDirectoryItemAction({
+        interaction: "select",
+        match,
+        providerId: directoryProviderId
+      }) !== "insert"
+    ) {
+      return;
+    }
 
     const content = renderInsertResultAsEditorContent(
       match.providerId,
@@ -553,7 +657,44 @@ export function RichTextTriggerEditor({
     setActiveIndex(0);
     setHighlightedPaletteKey(null);
     setIsLoading(false);
+    setHasQueryError(false);
     resetMenuPlacement();
+  };
+
+  const navigateIntoDirectory = (match: RichTextTriggerQueryMatch): boolean => {
+    const directory = match.directory;
+    if (
+      !editor ||
+      !query ||
+      !directory ||
+      !hasDirectoryNavigationCapability ||
+      resolveRichTextTriggerDirectoryItemAction({
+        interaction: "navigate",
+        match,
+        providerId: palette?.directoryNavigation?.providerId ?? ""
+      }) !== "enter"
+    ) {
+      return false;
+    }
+    if (query.keyword.length > 0) {
+      editor
+        .chain()
+        .focus()
+        .insertContentAt({ from: query.from, to: query.to }, query.trigger)
+        .run();
+    }
+    setDirectoryBrowsePaths((current) =>
+      enterRichTextTriggerDirectory(current, directory.path)
+    );
+    return true;
+  };
+
+  const navigateBackDirectory = (): boolean => {
+    if (query?.keyword || directoryBrowsePaths.length === 0) {
+      return false;
+    }
+    setDirectoryBrowsePaths(exitRichTextTriggerDirectory);
+    return true;
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
@@ -571,6 +712,8 @@ export function RichTextTriggerEditor({
       setActiveIndex(0);
       setHighlightedPaletteKey(null);
       setIsLoading(false);
+      setHasQueryError(false);
+      setDirectoryBrowsePaths([]);
       resetMenuPlacement();
       return;
     }
@@ -627,6 +770,21 @@ export function RichTextTriggerEditor({
         if (match) {
           event.preventDefault();
           applyMatch(match);
+        }
+        return;
+      }
+
+      if (event.key === "ArrowLeft") {
+        if (navigateBackDirectory()) {
+          event.preventDefault();
+        }
+        return;
+      }
+
+      if (event.key === "ArrowRight") {
+        const match = selectedPaletteMatch(paletteState, highlightedPaletteKey);
+        if (match && navigateIntoDirectory(match)) {
+          event.preventDefault();
         }
         return;
       }
@@ -713,19 +871,74 @@ export function RichTextTriggerEditor({
               labels={{
                 loading: text.loadingLabel,
                 empty: palette.labels.empty ?? text.noMatchesLabel,
-                error: palette.labels.empty ?? text.noMatchesLabel,
+                error: text.loadFailedLabel,
                 tabHint: palette.labels.tabHint,
                 listbox: palette.labels.listbox
               }}
               hintLabels={{
                 cycleFilter: palette.labels.cycleFilter,
-                moveSelection: palette.labels.moveSelection
+                moveSelection: palette.labels.moveSelection,
+                navigateHierarchy: hasDirectoryNavigationCapability
+                  ? palette.directoryNavigation?.labels.navigateHierarchy
+                  : undefined
               }}
               maxHeightPx={palette.maxHeightPx ?? 320}
-              renderItem={(match) =>
-                renderMentionRow(
-                  richTextTriggerQueryMatchToMentionRowItem(match)
-                )
+              renderItem={(match) => {
+                const directory = match.directory;
+                return renderMentionRow(
+                  richTextTriggerQueryMatchToMentionRowItem(match, {
+                    getChildCountLabel: () =>
+                      directory?.childCount == null
+                        ? null
+                        : String(directory.childCount),
+                    getFileEntryKind: () =>
+                      directory ? "directory" : undefined
+                  }),
+                  directory &&
+                    hasDirectoryNavigationCapability &&
+                    match.providerId === palette.directoryNavigation?.providerId
+                    ? {
+                        navigateIntoLabel:
+                          palette.directoryNavigation.labels.enter,
+                        onNavigateInto: () => navigateIntoDirectory(match)
+                      }
+                    : undefined
+                );
+              }}
+              headerActions={
+                directoryBrowsePaths.length > 0 &&
+                hasDirectoryNavigationCapability &&
+                palette.directoryNavigation ? (
+                  <Button
+                    type="button"
+                    aria-label={palette.directoryNavigation.labels.back}
+                    title={palette.directoryNavigation.labels.back}
+                    size="sm"
+                    variant="ghost"
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={() => navigateBackDirectory()}
+                  >
+                    <ArrowLeftIcon size={14} />
+                    <span>{palette.directoryNavigation.labels.back}</span>
+                  </Button>
+                ) : undefined
+              }
+              onNavigateHierarchy={
+                hasDirectoryNavigationCapability && palette.directoryNavigation
+                  ? (delta) => {
+                      if (delta === -1) {
+                        navigateBackDirectory();
+                        return;
+                      }
+                      const match = selectedPaletteMatch(
+                        paletteState,
+                        highlightedPaletteKey
+                      );
+                      if (match) {
+                        navigateIntoDirectory(match);
+                      }
+                    }
+                  : undefined
               }
               callbacks={{
                 onHighlightChange: setHighlightedPaletteKey,
@@ -810,6 +1023,27 @@ function firstPaletteItemKey(
     }
   }
   return state.categories[0] ? `category:${state.categories[0].id}` : null;
+}
+
+function selectedPaletteMatch(
+  state: MentionPaletteState<RichTextTriggerQueryMatch>,
+  highlightedKey: string | null
+): RichTextTriggerQueryMatch | null {
+  const entry = findMentionPaletteEntry({
+    state,
+    key: highlightedKey,
+    getItemKey: getPaletteMatchKey
+  });
+  if (entry?.type !== "item" || !entry.groupId) {
+    return null;
+  }
+  const group = state.groups.find(
+    (candidate) => candidate.id === entry.groupId
+  );
+  return (
+    group?.items[typeof entry.itemIndex === "number" ? entry.itemIndex : -1] ??
+    null
+  );
 }
 
 function nextPaletteCategoryId(

--- a/packages/ui/rich-text/src/editor/index.ts
+++ b/packages/ui/rich-text/src/editor/index.ts
@@ -1,5 +1,6 @@
 export {
   RichTextTriggerEditor,
+  type RichTextTriggerEditorPaletteOptions,
   type RichTextTriggerEditorProps
 } from "./RichTextTriggerEditor.tsx";
 export {

--- a/packages/ui/rich-text/src/editor/richTextTriggerDirectoryNavigation.ts
+++ b/packages/ui/rich-text/src/editor/richTextTriggerDirectoryNavigation.ts
@@ -1,0 +1,30 @@
+import type { RichTextTriggerQueryMatch } from "../types/trigger.ts";
+
+export type RichTextTriggerDirectoryItemAction = "insert" | "enter" | "none";
+
+export function resolveRichTextTriggerDirectoryItemAction(input: {
+  interaction: "select" | "navigate";
+  match: RichTextTriggerQueryMatch;
+  providerId: string;
+}): RichTextTriggerDirectoryItemAction {
+  if (input.interaction === "select") {
+    return "insert";
+  }
+  return input.match.providerId === input.providerId && input.match.directory
+    ? "enter"
+    : "none";
+}
+
+export function enterRichTextTriggerDirectory(
+  paths: readonly string[],
+  path: string
+): readonly string[] {
+  const canonicalPath = path.trim();
+  return canonicalPath ? [...paths, canonicalPath] : paths;
+}
+
+export function exitRichTextTriggerDirectory(
+  paths: readonly string[]
+): readonly string[] {
+  return paths.length === 0 ? paths : paths.slice(0, -1);
+}

--- a/packages/ui/rich-text/src/editor/richTextTriggerQuery.ts
+++ b/packages/ui/rich-text/src/editor/richTextTriggerQuery.ts
@@ -78,7 +78,7 @@ export function findRichTextTriggerQuery(
 }
 
 export async function queryRichTextTriggerMatches(
-  registry: RichTextTriggerRegistry,
+  registry: Pick<RichTextTriggerRegistry, "query">,
   input: RichTextTriggerQueryInput
 ): Promise<readonly RichTextTriggerQueryMatch[]> {
   try {
@@ -86,4 +86,14 @@ export async function queryRichTextTriggerMatches(
   } catch {
     return [];
   }
+}
+
+export async function queryRichTextTriggerDirectoryMatches(
+  registry: {
+    queryDirectory?: RichTextTriggerRegistry["queryDirectory"];
+  },
+  providerId: string,
+  input: RichTextTriggerQueryInput & { directoryPath: string }
+): Promise<readonly RichTextTriggerQueryMatch[]> {
+  return (await registry.queryDirectory?.(providerId, input)) ?? [];
 }

--- a/packages/ui/rich-text/src/editor/richTextTriggerText.ts
+++ b/packages/ui/rich-text/src/editor/richTextTriggerText.ts
@@ -4,12 +4,14 @@ import {
 } from "../i18n/richTextI18n.ts";
 
 export interface RichTextTriggerTextOverrides {
+  loadFailedLabel?: string;
   loadingLabel?: string;
   noMatchesLabel?: string;
   removeReferenceActionLabel?: string;
 }
 
 export interface ResolvedRichTextTriggerText {
+  loadFailedLabel: string;
   loadingLabel: string;
   noMatchesLabel: string;
   removeReferenceActionLabel: string;
@@ -23,6 +25,8 @@ export function resolveRichTextTriggerText(
   i18n: RichTextI18nRuntime = defaultRichTextI18n
 ): ResolvedRichTextTriggerText {
   return {
+    loadFailedLabel:
+      overrides?.loadFailedLabel?.trim() || i18n.t("richTextAt.loadFailed"),
     loadingLabel:
       overrides?.loadingLabel?.trim() || i18n.t("richTextAt.loading"),
     noMatchesLabel:

--- a/packages/ui/rich-text/src/i18n/richTextI18n.test.ts
+++ b/packages/ui/rich-text/src/i18n/richTextI18n.test.ts
@@ -10,6 +10,7 @@ import { resolveRichTextTriggerText } from "../editor/richTextTriggerText.ts";
 test("rich text i18n runtime resolves package-local defaults", () => {
   const i18n = createRichTextI18nRuntime();
 
+  assert.equal(i18n.t("richTextAt.loadFailed"), "Unable to load references");
   assert.equal(i18n.t("richTextAt.loading"), "Loading...");
   assert.equal(i18n.t("richTextAt.noMatches"), "No matches");
   assert.equal(
@@ -24,6 +25,7 @@ test("rich text i18n runtime follows merged host locale resources", () => {
   });
   const i18n = createRichTextI18nRuntime(runtime);
 
+  assert.equal(i18n.t("richTextAt.loadFailed"), "无法加载引用");
   assert.equal(i18n.t("richTextAt.loading"), "正在加载...");
   assert.equal(i18n.t("richTextAt.noMatches"), "没有匹配项");
 });
@@ -43,6 +45,7 @@ test("resolveRichTextTriggerText prefers overrides over i18n defaults", () => {
       i18n
     ),
     {
+      loadFailedLabel: "无法加载引用",
       loadingLabel: "正在加载...",
       noMatchesLabel: "Nothing here",
       removeReferenceActionLabel: "移除引用"

--- a/packages/ui/rich-text/src/i18n/richTextI18n.ts
+++ b/packages/ui/rich-text/src/i18n/richTextI18n.ts
@@ -21,6 +21,7 @@ export const richTextI18nModule = createScopedLocaleObjectsI18nModuleManifest({
 
 const richTextEn = {
   richTextAt: {
+    loadFailed: "Unable to load references",
     loading: "Loading...",
     noMatches: "No matches",
     removeReferenceActionLabel: "Remove reference"
@@ -29,6 +30,7 @@ const richTextEn = {
 
 const richTextZhCN = {
   richTextAt: {
+    loadFailed: "无法加载引用",
     loading: "正在加载...",
     noMatches: "没有匹配项",
     removeReferenceActionLabel: "移除引用"
@@ -36,6 +38,7 @@ const richTextZhCN = {
 } as const satisfies I18nDictionary;
 
 export type RichTextI18nKey =
+  | "richTextAt.loadFailed"
   | "richTextAt.loading"
   | "richTextAt.noMatches"
   | "richTextAt.removeReferenceActionLabel";

--- a/packages/ui/rich-text/src/plugins/triggerRegistry.ts
+++ b/packages/ui/rich-text/src/plugins/triggerRegistry.ts
@@ -2,6 +2,7 @@ import type {
   RichTextTrigger,
   RichTextTriggerBoundary,
   RichTextTriggerConfig,
+  RichTextTriggerDirectoryQueryInput,
   RichTextTriggerInsertResult,
   RichTextTriggerProvider,
   RichTextTriggerQueryInput,
@@ -70,9 +71,35 @@ async function resolveItemIconUrl<TItem>(
   return resolveInsertResultIconUrl(insertResult);
 }
 
+async function mapProviderItems<TItem>(
+  provider: RichTextTriggerProvider<TItem>,
+  trigger: RichTextTrigger,
+  items: readonly TItem[]
+): Promise<RichTextTriggerQueryMatch<TItem>[]> {
+  return Promise.all(
+    items.map(async (item) => {
+      const insertResult = provider.toInsertResult(item);
+      return {
+        providerId: provider.id,
+        trigger,
+        key: provider.getItemKey(item),
+        label: provider.getItemLabel(item),
+        subtitle: provider.getItemSubtitle?.(item) || undefined,
+        iconUrl: await resolveItemIconUrl(provider, item, insertResult),
+        keywords: provider.getItemKeywords?.(item),
+        item,
+        insertResult,
+        directory: provider.getItemDirectory?.(item) ?? undefined
+      };
+    })
+  );
+}
+
 export function createRichTextTriggerRegistry(
   providers: readonly RichTextTriggerProvider[]
-): RichTextTriggerRegistry {
+): RichTextTriggerRegistry & {
+  queryDirectory: NonNullable<RichTextTriggerRegistry["queryDirectory"]>;
+} {
   const providerMap = new Map<string, RichTextTriggerProvider>();
   const triggerConfigKeys = new Set<string>();
   const triggerConfigs: RichTextTriggerConfig[] = [];
@@ -114,22 +141,7 @@ export function createRichTextTriggerRegistry(
           if (input.abortSignal?.aborted) {
             return [];
           }
-          return Promise.all(
-            items.map(async (item) => {
-              const insertResult = provider.toInsertResult(item);
-              return {
-                providerId: provider.id,
-                trigger: input.trigger,
-                key: provider.getItemKey(item),
-                label: provider.getItemLabel(item),
-                subtitle: provider.getItemSubtitle?.(item) || undefined,
-                iconUrl: await resolveItemIconUrl(provider, item, insertResult),
-                keywords: provider.getItemKeywords?.(item),
-                item,
-                insertResult
-              };
-            })
-          );
+          return mapProviderItems(provider, input.trigger, items);
         })
     );
 
@@ -141,11 +153,39 @@ export function createRichTextTriggerRegistry(
     return flatMatches;
   }
 
+  async function queryDirectory(
+    providerId: string,
+    input: RichTextTriggerDirectoryQueryInput
+  ): Promise<readonly RichTextTriggerQueryMatch[]> {
+    if (input.abortSignal?.aborted) {
+      return [];
+    }
+    const provider = providerMap.get(normalizeProviderId(providerId));
+    if (!provider?.queryDirectory || provider.trigger !== input.trigger) {
+      throw new Error(
+        `Rich text trigger provider does not support directory browsing: ${providerId}`
+      );
+    }
+    const items = await provider.queryDirectory(input);
+    if (input.abortSignal?.aborted) {
+      return [];
+    }
+    const matches = await mapProviderItems(provider, input.trigger, items);
+    if (input.abortSignal?.aborted) {
+      return [];
+    }
+    const limit = input.maxResults;
+    return typeof limit === "number" && limit >= 0
+      ? matches.slice(0, limit)
+      : matches;
+  }
+
   return {
     listProviders: () => [...providerMap.values()],
     getProvider: (providerId: string) =>
       providerMap.get(normalizeProviderId(providerId)),
     listTriggerConfigs: () => [...triggerConfigs],
-    query
+    query,
+    queryDirectory
   };
 }

--- a/packages/ui/rich-text/src/service/RichTextMentionService.ts
+++ b/packages/ui/rich-text/src/service/RichTextMentionService.ts
@@ -5,6 +5,7 @@ import type {
 } from "../types/mention.ts";
 import type {
   RichTextTriggerConfig,
+  RichTextTriggerDirectoryQueryInput,
   RichTextTriggerProvider,
   RichTextTriggerQueryInput,
   RichTextTriggerQueryMatch
@@ -64,6 +65,10 @@ export interface RichTextMentionService {
   listTriggerConfigs(): readonly RichTextTriggerConfig[];
   query(
     input: RichTextTriggerQueryInput
+  ): Promise<readonly RichTextTriggerQueryMatch[]>;
+  queryDirectory?(
+    providerId: string,
+    input: RichTextTriggerDirectoryQueryInput
   ): Promise<readonly RichTextTriggerQueryMatch[]>;
   resolve(identity: RichTextMentionIdentity): Promise<RichTextMentionSnapshot>;
   getSnapshot(identity: RichTextMentionIdentity): RichTextMentionSnapshot;
@@ -278,6 +283,29 @@ export function createRichTextMentionService(
         emit({
           name: "mention_query_completed",
           providerId: "*",
+          outcome: "error",
+          cacheStatus: "miss",
+          durationMs: Math.max(0, now() - startedAt)
+        });
+        throw error;
+      }
+    },
+    async queryDirectory(providerId, queryInput) {
+      const startedAt = now();
+      try {
+        const matches = await registry.queryDirectory(providerId, queryInput);
+        emit({
+          name: "mention_query_completed",
+          providerId,
+          outcome: "success",
+          cacheStatus: "miss",
+          durationMs: Math.max(0, now() - startedAt)
+        });
+        return matches;
+      } catch (error) {
+        emit({
+          name: "mention_query_completed",
+          providerId,
           outcome: "error",
           cacheStatus: "miss",
           durationMs: Math.max(0, now() - startedAt)

--- a/packages/ui/rich-text/src/types/index.ts
+++ b/packages/ui/rich-text/src/types/index.ts
@@ -5,6 +5,8 @@ export type {
   RichTextTrigger,
   RichTextTriggerBoundary,
   RichTextTriggerConfig,
+  RichTextTriggerDirectoryDescriptor,
+  RichTextTriggerDirectoryQueryInput,
   RichTextTriggerGroupedQueryResult,
   RichTextTriggerGroupPageQueryInput,
   RichTextTriggerInsertResult,

--- a/packages/ui/rich-text/src/types/trigger.ts
+++ b/packages/ui/rich-text/src/types/trigger.ts
@@ -47,6 +47,18 @@ export interface RichTextTriggerGroupPageQueryInput extends RichTextTriggerQuery
   pageSize: number;
 }
 
+export interface RichTextTriggerDirectoryDescriptor {
+  /** Canonical provider-owned directory path used for direct-child queries. */
+  path: string;
+  /** Number of direct children when the provider can determine it. */
+  childCount?: number | null;
+}
+
+export interface RichTextTriggerDirectoryQueryInput extends RichTextTriggerQueryInput {
+  /** Empty string addresses the provider-owned root directory. */
+  directoryPath: string;
+}
+
 export interface RichTextMentionTriggerInsertResult {
   kind: "mention";
   mention: RichTextMentionInsert;
@@ -87,6 +99,14 @@ export interface RichTextTriggerProvider<TItem = unknown> {
   ):
     | Promise<RichTextTriggerQueryGroup<TItem>>
     | RichTextTriggerQueryGroup<TItem>;
+  /** Optional hierarchy contract for providers that expose directories. */
+  getItemDirectory?(
+    item: TItem
+  ): RichTextTriggerDirectoryDescriptor | null | undefined;
+  /** Lists direct children without overloading ranked keyword search. */
+  queryDirectory?(
+    input: RichTextTriggerDirectoryQueryInput
+  ): Promise<readonly TItem[]> | readonly TItem[];
   getItemKey(item: TItem): string;
   getItemLabel(item: TItem): string;
   getItemSubtitle?(item: TItem): string | null | undefined;
@@ -110,6 +130,7 @@ export interface RichTextTriggerQueryMatch<TItem = unknown> {
   keywords?: readonly string[];
   item: TItem;
   insertResult: RichTextTriggerInsertResult;
+  directory?: RichTextTriggerDirectoryDescriptor;
 }
 
 export interface RichTextTriggerRegistry {
@@ -118,5 +139,9 @@ export interface RichTextTriggerRegistry {
   listTriggerConfigs: () => readonly RichTextTriggerConfig[];
   query: (
     input: RichTextTriggerQueryInput
+  ) => Promise<readonly RichTextTriggerQueryMatch[]>;
+  queryDirectory?: (
+    providerId: string,
+    input: RichTextTriggerDirectoryQueryInput
   ) => Promise<readonly RichTextTriggerQueryMatch[]>;
 }

--- a/packages/workspace/external-core/README.md
+++ b/packages/workspace/external-core/README.md
@@ -16,6 +16,7 @@ trusted app APIs may read or update host workspace state directly.
   runtime and state used by Agent GUI; workspace apps must not create a second
   Activity engine or provider adapter around this surface.
 - `at.query()` for host-provided mention candidates, plus optional
+  `at.queryDirectory()` for provider-owned direct-child browsing and optional
   `at.resolve()` and `at.subscribe()` for exact mention hydration and dirty
   invalidation.
 - `files.select()` for user-activated workspace file picking.
@@ -66,7 +67,7 @@ import { createTuttiExternalRichTextMentionService } from "@tutti-os/workspace-e
 
 const mentionService = createTuttiExternalRichTextMentionService({
   getBridge: () => window.tuttiExternal,
-  providerIds: ["workspace-app", "agent-session", "agent-generated-file"]
+  providerIds: ["file"]
 });
 ```
 
@@ -75,12 +76,58 @@ app root. App-local providers can be supplied once through
 `appLocalProviders`; leaf inputs and message lists should not recreate adapters.
 
 The adapter feature-detects optional bridge methods. New hosts use exact
-`at.resolve()` and `at.subscribe()`. On an older query-only host, resolution
-first queries by the persisted fallback label, then uses a bounded empty-keyword
-query and exact provider/entity/scope match. The service TTL supplies eventual
-refresh for hosts or provider sources without a real-time dirty event. The existing
+`at.queryDirectory()`, `at.resolve()`, and `at.subscribe()`. A file provider
+only advertises its hierarchy methods when the current bridge supports
+`at.queryDirectory()`, so an older host keeps the existing flat ranked search.
+On an older query-only host, resolution first queries by the persisted fallback
+label, then uses a bounded empty-keyword query and exact
+provider/entity/scope match. The service TTL supplies eventual refresh for
+hosts or provider sources without a real-time dirty event. The existing
 `createTuttiExternalAtRichTextTriggerProviders` factory remains available for
 older bundles.
+
+For a file-only external composer, register only the file provider and one file
+category, then opt the shared editor into that provider's hierarchy:
+
+```tsx
+const mentionService = createTuttiExternalRichTextMentionService({
+  getBridge: () => window.tuttiExternal,
+  providerIds: ["file"]
+});
+
+<RichTextMentionServiceProvider service={mentionService}>
+  <RichTextTriggerEditor
+    value={draft}
+    onChange={setDraft}
+    palette={{
+      categories: [{ id: "file", label: labels.file, providerIds: ["file"] }],
+      defaultCategoryId: "file",
+      labels: {
+        tabHint: labels.tabHint,
+        cycleFilter: labels.cycleFilter,
+        moveSelection: labels.moveSelection
+      },
+      directoryNavigation: {
+        providerId: "file",
+        labels: {
+          back: labels.back,
+          enter: labels.enter,
+          navigateHierarchy: labels.navigateHierarchy
+        }
+      }
+    }}
+  />
+</RichTextMentionServiceProvider>;
+```
+
+The inserted value remains the host-provided file or folder path. The external
+app does not recursively enumerate a folder or create a second path protocol;
+the local Agent receives the serialized path in its prompt and owns execution.
+An empty directory path addresses the file provider root. Desktop constrains
+workspace-app directory traversal to that root and its descendants; arbitrary
+absolute paths outside the provider root are not part of this bridge contract.
+This workspace-app policy does not narrow AgentGUI's host-owned local-path
+provider.
 
 Provider ids and palette sections stay aligned with the host contract. The app
 still owns local-only mention sources, i18n labels, palette categories, row

--- a/packages/workspace/external-core/src/contracts/index.ts
+++ b/packages/workspace/external-core/src/contracts/index.ts
@@ -47,6 +47,20 @@ export interface TuttiExternalAtQueryInput {
   providers?: readonly TuttiExternalAtProviderId[];
 }
 
+export interface TuttiExternalAtQueryDirectoryInput {
+  /** Empty string addresses the provider-owned root directory. */
+  directoryPath: string;
+  maxResults?: number;
+  providerId: TuttiExternalAtProviderId;
+}
+
+export interface TuttiExternalAtDirectoryDescriptor {
+  /** Canonical provider-owned directory path used for direct-child queries. */
+  path: string;
+  /** Number of direct children when the provider can determine it. */
+  childCount?: number | null;
+}
+
 export interface TuttiExternalAtQueryResult {
   providerId: TuttiExternalAtProviderId;
   itemId: string;
@@ -54,6 +68,7 @@ export interface TuttiExternalAtQueryResult {
   subtitle?: string;
   thumbnailUrl?: string | null;
   insert: TuttiExternalAtInsertResult;
+  directory?: TuttiExternalAtDirectoryDescriptor;
 }
 
 export interface TuttiExternalAtResolveInput {
@@ -385,6 +400,9 @@ export interface TuttiExternalBridge {
     query(
       input: TuttiExternalAtQueryInput
     ): Promise<TuttiExternalAtQueryResult[]>;
+    queryDirectory?(
+      input: TuttiExternalAtQueryDirectoryInput
+    ): Promise<TuttiExternalAtQueryResult[]>;
     resolve?(
       input: TuttiExternalAtResolveInput
     ): Promise<TuttiExternalAtResolveResult | null>;
@@ -512,6 +530,13 @@ export type TuttiExternalRendererRequest =
       appId: string;
       input: TuttiExternalAtQueryInput;
       operation: "at.query";
+      requestId: string;
+      workspaceId: string;
+    }
+  | {
+      appId: string;
+      input: TuttiExternalAtQueryDirectoryInput;
+      operation: "at.queryDirectory";
       requestId: string;
       workspaceId: string;
     }

--- a/packages/workspace/external-core/src/core/index.test.ts
+++ b/packages/workspace/external-core/src/core/index.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   normalizeTuttiExternalAtQueryInput,
+  normalizeTuttiExternalAtQueryDirectoryInput,
   normalizeTuttiExternalAtResolveInput,
   normalizeTuttiExternalAtInvalidation,
   normalizeTuttiExternalAgentActivityActivateSessionInput,
@@ -47,6 +48,29 @@ test("caps at query max results and deduplicates providers", () => {
       maxResults: tuttiExternalAtMaxResultsLimit,
       providers: ["file", "agent-session"]
     }
+  );
+});
+
+test("normalizes external at directory queries including the provider root", () => {
+  assert.deepEqual(
+    normalizeTuttiExternalAtQueryDirectoryInput({
+      directoryPath: "  ",
+      maxResults: tuttiExternalAtMaxResultsLimit + 10,
+      providerId: "file"
+    }),
+    {
+      directoryPath: "",
+      maxResults: tuttiExternalAtMaxResultsLimit,
+      providerId: "file"
+    }
+  );
+  assert.throws(
+    () =>
+      normalizeTuttiExternalAtQueryDirectoryInput({
+        directoryPath: "",
+        providerId: "unknown"
+      }),
+    /providerId is unsupported/
   );
 });
 

--- a/packages/workspace/external-core/src/core/index.ts
+++ b/packages/workspace/external-core/src/core/index.ts
@@ -8,6 +8,7 @@ import {
   type TuttiExternalAgentActivityComposerOptionsInput,
   type TuttiExternalAgentActivitySendInput,
   type TuttiExternalAtQueryInput,
+  type TuttiExternalAtQueryDirectoryInput,
   type TuttiExternalAtResolveInput,
   type TuttiExternalAtInvalidation,
   type TuttiExternalBrowserOpenUrlInput,
@@ -105,6 +106,25 @@ export function normalizeTuttiExternalAtQueryInput(
     keyword: keywordValue,
     maxResults: normalizeMaxResults(input.maxResults),
     providers: normalizeProviders(input.providers)
+  };
+}
+
+export function normalizeTuttiExternalAtQueryDirectoryInput(
+  input: unknown
+): TuttiExternalAtQueryDirectoryInput {
+  if (!isRecord(input)) {
+    throw new Error("at.queryDirectory input must be an object.");
+  }
+  if (!isTuttiExternalAtProviderId(input.providerId)) {
+    throw new Error("at.queryDirectory providerId is unsupported.");
+  }
+  if (typeof input.directoryPath !== "string") {
+    throw new Error("at.queryDirectory directoryPath is required.");
+  }
+  return {
+    directoryPath: input.directoryPath.trim(),
+    maxResults: normalizeMaxResults(input.maxResults),
+    providerId: input.providerId
   };
 }
 

--- a/packages/workspace/external-core/src/rich-text/index.test.ts
+++ b/packages/workspace/external-core/src/rich-text/index.test.ts
@@ -64,6 +64,58 @@ test("queries the external bridge with the provider filter", async () => {
   );
 });
 
+test("file provider exposes external directory browsing when the host supports it", async () => {
+  const calls: unknown[] = [];
+  const directory = createQueryResult("file", "/workspace/docs", "docs", {
+    directory: { childCount: 2, path: "/workspace/docs" },
+    insert: {
+      href: "/workspace/docs/",
+      kind: "markdown-link",
+      label: "docs"
+    }
+  });
+  const provider = createTuttiExternalAtRichTextTriggerProvider({
+    providerId: "file",
+    bridge: {
+      at: {
+        query: () => [],
+        queryDirectory(input) {
+          calls.push(input);
+          return [directory];
+        }
+      }
+    }
+  });
+
+  assert.deepEqual(provider.getItemDirectory?.(directory), directory.directory);
+  assert.deepEqual(
+    await provider.queryDirectory?.({
+      context: {},
+      directoryPath: "/workspace",
+      keyword: "",
+      maxResults: 12,
+      trigger: "@"
+    }),
+    [directory]
+  );
+  assert.deepEqual(calls, [
+    {
+      directoryPath: "/workspace",
+      maxResults: 12,
+      providerId: "file"
+    }
+  ]);
+});
+
+test("file provider keeps directory browsing absent on an older bridge", () => {
+  const provider = createTuttiExternalAtRichTextTriggerProvider({
+    providerId: "file",
+    bridge: { at: { query: () => [] } }
+  });
+  assert.equal(provider.queryDirectory, undefined);
+  assert.equal(provider.getItemDirectory, undefined);
+});
+
 test("defaults external at rich text providers to include agent targets", () => {
   const providers = createTuttiExternalAtRichTextTriggerProviders({
     bridge: null

--- a/packages/workspace/external-core/src/rich-text/index.ts
+++ b/packages/workspace/external-core/src/rich-text/index.ts
@@ -1,6 +1,7 @@
 import {
   tuttiExternalAtProviderIds,
   type TuttiExternalAtInvalidation,
+  type TuttiExternalAtQueryDirectoryInput,
   type TuttiExternalAtProviderId,
   type TuttiExternalAtQueryInput,
   type TuttiExternalAtQueryResult,
@@ -22,6 +23,11 @@ export interface TuttiExternalAtRichTextBridge {
   at?: {
     query(
       input: TuttiExternalAtQueryInput
+    ):
+      | Promise<readonly TuttiExternalAtQueryResult[]>
+      | readonly TuttiExternalAtQueryResult[];
+    queryDirectory?(
+      input: TuttiExternalAtQueryDirectoryInput
     ):
       | Promise<readonly TuttiExternalAtQueryResult[]>
       | readonly TuttiExternalAtQueryResult[];
@@ -100,6 +106,27 @@ export function createTuttiExternalAtRichTextTriggerProvider(
         providerIds: [input.providerId]
       });
     },
+    ...(input.providerId === "file" &&
+    (input.getBridge?.() ?? input.bridge)?.at?.queryDirectory
+      ? {
+          getItemDirectory(item: TuttiExternalAtQueryResult) {
+            return item.directory;
+          },
+          async queryDirectory(queryInput) {
+            const bridge = (input.getBridge?.() ?? input.bridge)?.at;
+            if (!bridge?.queryDirectory) {
+              throw new Error(
+                "Tutti external @ bridge does not support directory browsing."
+              );
+            }
+            return bridge.queryDirectory({
+              directoryPath: queryInput.directoryPath,
+              maxResults: queryInput.maxResults ?? input.maxResults,
+              providerId: input.providerId
+            });
+          }
+        }
+      : {}),
     async resolveMention(identity) {
       const bridge = (input.getBridge?.() ?? input.bridge)?.at;
       if (!bridge) return null;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -958,6 +958,9 @@ importers:
         specifier: workspace:*
         version: link:../system
     devDependencies:
+      "@testing-library/react":
+        specifier: ^16.3.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@tiptap/core":
         specifier: ^3.23.6
         version: 3.23.6(@tiptap/pm@3.23.6)
@@ -988,6 +991,9 @@ importers:
       "@types/react-dom":
         specifier: ^19.1.5
         version: 19.2.3(@types/react@19.2.15)
+      jsdom:
+        specifier: ^27.2.0
+        version: 27.4.0
       react:
         specifier: ^19.1.0
         version: 19.2.6
@@ -997,6 +1003,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.0.13
+        version: 4.1.7(@types/node@24.12.4)(jsdom@27.4.0)(vite@6.4.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/ui/system:
     dependencies:


### PR DESCRIPTION
## Summary
- add provider-owned file and folder directory browsing to the shared rich-text mention contract
- expose optional workspace-app at.queryDirectory through Desktop IPC, preload, and renderer seams
- keep folder selection insertable as a local path while providing enter/back keyboard navigation
- restrict workspace-app directory traversal to the provider root without changing AgentGUI external absolute-path capability
- preserve flat-search compatibility for older Desktop bridges and surface localized directory errors

## Scope
This is the Tutti foundation change only. It does not change AgentGUI or Issue Manager behavior. External app dependency upgrades for ai-office, vibe-design, and ai-media-canvas follow after the shared package release.

## Validation
- pnpm check:changed
- pnpm check:changed -- --push-ready
- pnpm lint:ts
- pnpm typecheck
- pnpm release:pack:check
- pnpm --filter @tutti-os/desktop test (1770 passed, 3 skipped)
- pnpm --filter @tutti-os/desktop build
- pnpm --filter @tutti-os/ui-rich-text test
- pnpm --filter @tutti-os/workspace-external-core test

## Release order
After merge, dispatch the stable npm package release workflow on main, then ship a Desktop build containing the new bridge before upgrading the external applications.