### PR TITLE
feat(agent): execute native plugin turns on current runtime

### DIFF
--- a/packages/agent/daemon/hostadapter/turn_capability.go
+++ b/packages/agent/daemon/hostadapter/turn_capability.go
@@ -1,0 +1,35 @@
+package hostadapter
+
+import (
+	"context"
+
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
+	host "github.com/tutti-os/tutti/packages/agent/host"
+)
+
+var _ host.RuntimeTurnCapabilityPort = (*RuntimeController)(nil)
+
+type codexTurnCapabilityBackend interface {
+	EnsureCodexTurnCapability(context.Context, agentruntime.CodexTurnCapabilityInput) (agentruntime.PromptContentBlock, error)
+}
+
+func (a *RuntimeController) EnsureTurnCapability(ctx context.Context, input host.RuntimeTurnCapabilityInput) (host.RuntimeTurnCapabilityResult, error) {
+	if err := a.requireBackend(); err != nil {
+		return host.RuntimeTurnCapabilityResult{}, err
+	}
+	backend, ok := a.Backend.(codexTurnCapabilityBackend)
+	if !ok {
+		return host.RuntimeTurnCapabilityResult{}, host.ErrTurnCapabilityUnsupported
+	}
+	block, err := backend.EnsureCodexTurnCapability(ctx, agentruntime.CodexTurnCapabilityInput{
+		RoomID: input.WorkspaceID, AgentSessionID: input.AgentSessionID,
+		TurnID: input.TurnID, ClientSubmitID: input.ClientSubmitID,
+		Semantic: input.Invocation.Semantic,
+	})
+	if err != nil {
+		return host.RuntimeTurnCapabilityResult{}, mapRuntimeError(err)
+	}
+	return host.RuntimeTurnCapabilityResult{PromptAugmentation: []host.PromptContentBlock{{
+		Type: block.Type, Name: block.Name, Path: block.Path,
+	}}}, nil
+}

--- a/packages/agent/daemon/providerregistry/codex.go
+++ b/packages/agent/daemon/providerregistry/codex.go
@@ -13,12 +13,13 @@ func codexDescriptor() ProviderDescriptor {
 	return ProviderDescriptor{
 		Identity: canonicalProviderIdentity(CodexProviderID),
 		Runtime: RuntimeDescriptor{
-			Kind:                RuntimeKindCodexAppServer,
-			Name:                "codex-app-server",
-			Command:             []string{"codex", "app-server"},
-			ClientInfoName:      "codex_cli_rs",
-			AuthRequiredMessage: "Codex requires authentication. Run `codex login` on the host (or sync Codex credentials), then retry this session.",
-			NativeSessionFork:   true,
+			Kind:                   RuntimeKindCodexAppServer,
+			Name:                   "codex-app-server",
+			Command:                []string{"codex", "app-server"},
+			ClientInfoName:         "codex_cli_rs",
+			AuthRequiredMessage:    "Codex requires authentication. Run `codex login` on the host (or sync Codex credentials), then retry this session.",
+			TurnCapabilityStrategy: TurnCapabilityStrategyNativePlugin,
+			NativeSessionFork:      true,
 			AppServerFork: AppServerForkDescriptor{
 				UserAgentBrand:        "codex",
 				ThroughTurnMinVersion: CodexThroughTurnForkMinVersion,

--- a/packages/agent/daemon/providerregistry/turn_capability.go
+++ b/packages/agent/daemon/providerregistry/turn_capability.go
@@ -1,0 +1,8 @@
+package providerregistry
+
+// SupportsNativePluginTurn reports whether a provider descriptor supports
+// attaching a native plugin capability to the current Turn.
+func SupportsNativePluginTurn(provider string) bool {
+	descriptor, ok := Find(provider)
+	return ok && descriptor.Runtime.TurnCapabilityStrategy == TurnCapabilityStrategyNativePlugin
+}

--- a/packages/agent/daemon/providerregistry/turn_capability_test.go
+++ b/packages/agent/daemon/providerregistry/turn_capability_test.go
@@ -1,0 +1,25 @@
+package providerregistry
+
+import "testing"
+
+func TestSupportsNativePluginTurn(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		want     bool
+	}{
+		{name: "codex", provider: CodexProviderID, want: true},
+		{name: "tutti agent", provider: TuttiAgentProviderID, want: false},
+		{name: "claude", provider: ClaudeCodeProviderID, want: false},
+		{name: "cursor", provider: CursorProviderID, want: false},
+		{name: "unknown", provider: "unknown", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SupportsNativePluginTurn(tt.provider); got != tt.want {
+				t.Fatalf("SupportsNativePluginTurn(%q) = %v, want %v", tt.provider, got, tt.want)
+			}
+		})
+	}
+}

--- a/packages/agent/daemon/providerregistry/types.go
+++ b/packages/agent/daemon/providerregistry/types.go
@@ -16,6 +16,16 @@ const (
 	RuntimeKindClaudeSDK      RuntimeKind = "claude_sdk"
 )
 
+// TurnCapabilityStrategy identifies provider-owned capabilities that may be
+// attached to the current Turn. Consumers dispatch on this strategy rather
+// than comparing provider identities in lifecycle or adapter code.
+type TurnCapabilityStrategy string
+
+const (
+	TurnCapabilityStrategyNone         TurnCapabilityStrategy = ""
+	TurnCapabilityStrategyNativePlugin TurnCapabilityStrategy = "native_plugin_turn"
+)
+
 type StandardACPAdapterStrategy string
 
 const (
@@ -167,12 +177,13 @@ const (
 type IdentityDescriptor = canonical.ProviderIdentity
 
 type RuntimeDescriptor struct {
-	Kind                RuntimeKind
-	Name                string
-	Command             []string
-	ClientInfoName      string
-	AuthRequiredMessage string
-	AppServerSkillRoots AppServerSkillRootsStrategy
+	Kind                   RuntimeKind
+	Name                   string
+	Command                []string
+	ClientInfoName         string
+	AuthRequiredMessage    string
+	TurnCapabilityStrategy TurnCapabilityStrategy
+	AppServerSkillRoots    AppServerSkillRootsStrategy
 	// NativeSessionFork marks runtimes whose provider strategy may expose a
 	// native session-fork primitive. The live adapter must still attest the
 	// exact protocol/version before advertising any fork capability.

--- a/packages/agent/daemon/runtime/codex_turn_capability.go
+++ b/packages/agent/daemon/runtime/codex_turn_capability.go
@@ -3,6 +3,8 @@ package agentruntime
 import (
 	"context"
 	"strings"
+
+	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
 )
 
 type CodexTurnCapabilityInput struct {
@@ -29,7 +31,7 @@ func (c *Controller) EnsureCodexTurnCapability(ctx context.Context, input CodexT
 	}
 	defer release()
 	session, adapter, err := c.sessionAndAdapter(roomID, agentSessionID)
-	if err != nil || strings.TrimSpace(session.Provider) != "codex" {
+	if err != nil || !providerregistry.SupportsNativePluginTurn(session.Provider) {
 		return PromptContentBlock{}, ErrSessionNotFound
 	}
 	codex, ok := adapter.(*CodexAppServerAdapter)

--- a/packages/agent/daemon/runtime/codex_turn_capability.go
+++ b/packages/agent/daemon/runtime/codex_turn_capability.go
@@ -1,0 +1,69 @@
+package agentruntime
+
+import (
+	"context"
+	"strings"
+)
+
+type CodexTurnCapabilityInput struct {
+	RoomID         string
+	AgentSessionID string
+	TurnID         string
+	ClientSubmitID string
+	Semantic       string
+}
+
+// EnsureCodexTurnCapability proves that a capability will be attached to the
+// current live Codex runtime. It neither starts/resumes a thread nor performs
+// plugin discovery; the resulting mention is consumed by the normal turn/start
+// request owned by Host.
+func (c *Controller) EnsureCodexTurnCapability(ctx context.Context, input CodexTurnCapabilityInput) (PromptContentBlock, error) {
+	roomID := strings.TrimSpace(input.RoomID)
+	agentSessionID := strings.TrimSpace(input.AgentSessionID)
+	if roomID == "" || agentSessionID == "" || strings.TrimSpace(input.TurnID) == "" || strings.TrimSpace(input.ClientSubmitID) == "" {
+		return PromptContentBlock{}, ErrSessionNotFound
+	}
+	release, err := c.acquireLifecycleLockContext(ctx, roomID, agentSessionID)
+	if err != nil {
+		return PromptContentBlock{}, err
+	}
+	defer release()
+	session, adapter, err := c.sessionAndAdapter(roomID, agentSessionID)
+	if err != nil || strings.TrimSpace(session.Provider) != "codex" {
+		return PromptContentBlock{}, ErrSessionNotFound
+	}
+	codex, ok := adapter.(*CodexAppServerAdapter)
+	if !ok || codex == nil {
+		return PromptContentBlock{}, ErrSessionNotFound
+	}
+	return codex.ensureLiveTurnCapability(session, input.Semantic)
+}
+
+func (a *CodexAppServerAdapter) ensureLiveTurnCapability(session Session, semantic string) (PromptContentBlock, error) {
+	semantic = strings.TrimSpace(semantic)
+	a.mu.Lock()
+	live := a.sessions[strings.TrimSpace(session.AgentSessionID)]
+	ready := live != nil && live.client != nil && strings.TrimSpace(live.threadID) == strings.TrimSpace(session.ProviderSessionID)
+	a.mu.Unlock()
+	if !ready {
+		return PromptContentBlock{}, ErrSessionNotFound
+	}
+	pluginID, ok := codexNativeTurnPluginID(semantic)
+	if !ok {
+		return PromptContentBlock{}, ErrSessionNotFound
+	}
+	return PromptContentBlock{Type: "mention", Name: pluginID, Path: "plugin://" + pluginID}, nil
+}
+
+func codexNativeTurnPluginID(semantic string) (string, bool) {
+	switch strings.TrimSpace(semantic) {
+	case "browser":
+		return "browser@openai-bundled", true
+	case "computer":
+		return "computer-use@openai-bundled", true
+	case "sites":
+		return "sites@openai-bundled", true
+	default:
+		return "", false
+	}
+}

--- a/packages/agent/daemon/runtime/codex_turn_capability_test.go
+++ b/packages/agent/daemon/runtime/codex_turn_capability_test.go
@@ -1,0 +1,45 @@
+package agentruntime
+
+import "testing"
+
+func TestCodexNativeTurnPluginID(t *testing.T) {
+	t.Parallel()
+	for semantic, want := range map[string]string{
+		"browser":  "browser@openai-bundled",
+		"computer": "computer-use@openai-bundled",
+		"sites":    "sites@openai-bundled",
+	} {
+		got, ok := codexNativeTurnPluginID(semantic)
+		if !ok || got != want {
+			t.Fatalf("plugin id for %q = %q, %v; want %q, true", semantic, got, ok, want)
+		}
+	}
+}
+
+func TestCodexNativeTurnPluginIDRejectsUnknownSemantic(t *testing.T) {
+	t.Parallel()
+	if _, ok := codexNativeTurnPluginID("not-a-plugin"); ok {
+		t.Fatal("unknown semantic was accepted")
+	}
+}
+
+func TestCodexAppServerAdapterEnsureLiveTurnCapability(t *testing.T) {
+	t.Parallel()
+	adapter := &CodexAppServerAdapter{sessions: map[string]*codexAppServerSession{
+		"session-1": {client: &codexAppServerClient{}, threadID: "thread-1"},
+	}}
+	session := Session{AgentSessionID: "session-1", ProviderSessionID: "thread-1"}
+	mention, err := adapter.ensureLiveTurnCapability(session, "browser")
+	if err != nil {
+		t.Fatalf("ensure browser capability: %v", err)
+	}
+	if mention.Path != "plugin://browser@openai-bundled" {
+		t.Fatalf("mention = %#v", mention)
+	}
+	if mention, err := adapter.ensureLiveTurnCapability(session, "computer"); err != nil || mention.Path != "plugin://computer-use@openai-bundled" {
+		t.Fatalf("computer capability = %#v, error = %v", mention, err)
+	}
+	if _, err := adapter.ensureLiveTurnCapability(Session{AgentSessionID: "session-1", ProviderSessionID: "other-thread"}, "sites"); err == nil {
+		t.Fatalf("stale runtime error = %v, want session not found", err)
+	}
+}

--- a/packages/agent/host/errors.go
+++ b/packages/agent/host/errors.go
@@ -33,6 +33,8 @@ var (
 	ErrEditRetryInProgress               = errors.New("agent history edit is still being confirmed")
 	ErrEditRetryResendPending            = errors.New("agent history was rolled back but the edited turn still needs to be resent")
 	ErrEditRetryRecoveryRequired         = errors.New("agent provider history diverged and requires explicit recovery")
+	ErrTurnCapabilityUnsupported         = errors.New("agent runtime does not support turn capabilities")
+	ErrTurnCapabilityUnavailable         = errors.New("requested turn capability is unavailable")
 )
 
 // ProviderError preserves a provider-owned failure across the runtime adapter

--- a/packages/agent/host/host.go
+++ b/packages/agent/host/host.go
@@ -23,6 +23,7 @@ type Config struct {
 	SessionForkState       SessionForkProviderStateBinder
 	SessionForkAttachments SessionForkAttachmentStager
 	Runtime                RuntimeController
+	TurnCapabilities       RuntimeTurnCapabilityPort
 	HistoryRuntime         RuntimeHistoryController
 	RuntimePreparation     RuntimePreparationPort
 	SettingsPolicy         SettingsPolicy
@@ -77,6 +78,7 @@ type Host struct {
 	sessionForkState       SessionForkProviderStateBinder
 	sessionForkAttachments SessionForkAttachmentStager
 	runtime                RuntimeController
+	turnCapabilities       RuntimeTurnCapabilityPort
 	historyRuntime         RuntimeHistoryController
 	preparation            RuntimePreparationPort
 	settingsPolicy         SettingsPolicy
@@ -126,6 +128,7 @@ func New(config Config) *Host {
 		sessionForkContext: config.SessionForkContext, sessionForkState: config.SessionForkState,
 		sessionForkAttachments: config.SessionForkAttachments,
 		runtime:                config.Runtime,
+		turnCapabilities:       config.TurnCapabilities,
 		historyRuntime:         config.HistoryRuntime,
 		sessionForkRecovery:    config.SessionForkRecovery,
 		preparation:            config.RuntimePreparation, settingsPolicy: config.SettingsPolicy, attachments: config.Attachments,

--- a/packages/agent/host/lifecycle.go
+++ b/packages/agent/host/lifecycle.go
@@ -54,6 +54,9 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 	}
 	claimMetadata := metadata
 	if isTypedGoal || len(normalized) == 0 {
+		if input.TurnCapabilityInvocation != nil {
+			return CreateSessionResult{}, ErrInvalidArgument
+		}
 		normalized = nil
 		claimMetadata = nil
 	}
@@ -179,6 +182,21 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 			Session: session, Canonical: goalResult.Canonical,
 			Kind: "goalControl", GoalControl: &goalResult,
 		}, nil
+	}
+	augmentation, err := h.ensureTurnCapability(
+		ctx,
+		ref,
+		session,
+		claim.TurnID,
+		claim.ClientSubmitID,
+		input.TurnCapabilityInvocation,
+	)
+	if err != nil {
+		return CreateSessionResult{}, cleanup(err, true, true)
+	}
+	normalized, promptText, err = mergeTurnCapabilityPromptContent(normalized, augmentation)
+	if err != nil {
+		return CreateSessionResult{}, cleanup(err, true, true)
 	}
 	startedAt = h.now()
 	if err := h.runtime.ValidatePromptContent(ctx, RuntimeExecInput{WorkspaceID: workspaceID, AgentSessionID: session.ID, Content: normalized}); err != nil {
@@ -486,6 +504,21 @@ func (h *Host) sendInputSerialized(
 		return SendInputResult{}, err
 	}
 	h.observeStep(ctx, "message_send", "runtime_session_ready", ref.AgentSessionID, session.Provider, startedAt, nil)
+	augmentation, err := h.ensureTurnCapability(
+		ctx,
+		ref,
+		session,
+		claim.TurnID,
+		claim.ClientSubmitID,
+		input.TurnCapabilityInvocation,
+	)
+	if err != nil {
+		return SendInputResult{}, err
+	}
+	normalized, promptText, err = mergeTurnCapabilityPromptContent(normalized, augmentation)
+	if err != nil {
+		return SendInputResult{}, err
+	}
 	startedAt = h.now()
 	if err := h.runtime.ValidatePromptContent(ctx, RuntimeExecInput{WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID, Content: normalized}); err != nil {
 		h.observeStep(ctx, "message_send", "prompt_validated", ref.AgentSessionID, session.Provider, startedAt, err)

--- a/packages/agent/host/lifecycle.go
+++ b/packages/agent/host/lifecycle.go
@@ -25,7 +25,7 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 		return CreateSessionResult{}, err
 	}
 	ref := SessionRef{WorkspaceID: workspaceID, AgentSessionID: input.AgentSessionID}
-	normalized, promptText, err := normalizeOptionalPromptContent(input.InitialContent)
+	normalized, _, err := normalizeOptionalPromptContent(input.InitialContent)
 	if err != nil {
 		return CreateSessionResult{}, err
 	}
@@ -183,6 +183,7 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 			Kind: "goalControl", GoalControl: &goalResult,
 		}, nil
 	}
+	var promptText string
 	augmentation, err := h.ensureTurnCapability(
 		ctx,
 		ref,
@@ -429,7 +430,7 @@ func (h *Host) SendInput(ctx context.Context, ref SessionRef, input SendInput) (
 	if input.Guidance && strings.TrimSpace(input.TurnID) == "" {
 		return SendInputResult{}, ErrActiveTurnTargetRequired
 	}
-	normalized, promptText, err := normalizePromptContent(input.Content)
+	normalized, _, err := normalizePromptContent(input.Content)
 	if err != nil {
 		return SendInputResult{}, err
 	}
@@ -453,205 +454,10 @@ func (h *Host) SendInput(ctx context.Context, ref SessionRef, input SendInput) (
 	var result SendInputResult
 	err = h.withSessionMutationActor(ctx, ref.WorkspaceID, ref.AgentSessionID, func(actorCtx context.Context) error {
 		var sendErr error
-		result, sendErr = h.sendInputSerialized(actorCtx, ref, input, normalized, promptText, metadata)
+		result, sendErr = h.sendInputSerialized(actorCtx, ref, input, normalized, metadata)
 		return sendErr
 	})
 	return result, err
-}
-
-func (h *Host) sendInputSerialized(
-	ctx context.Context,
-	ref SessionRef,
-	input SendInput,
-	normalized []PromptContentBlock,
-	promptText string,
-	metadata map[string]any,
-) (SendInputResult, error) {
-	var err error
-	if err := h.requireSendAllowedByEffectiveHistory(ctx, ref); err != nil {
-		return SendInputResult{}, err
-	}
-	if !input.Guidance && strings.TrimSpace(input.TurnID) == "" {
-		input.TurnID = uuid.NewString()
-	}
-	claim, claimPending, err := h.prepareSubmitClaim(ctx, ref, metadata, input.TurnID)
-	if err != nil {
-		if errors.Is(err, storesqlite.ErrSubmitClaimTurnConflict) {
-			return SendInputResult{}, errors.Join(ErrSubmitDeliveryUnknown, err)
-		}
-		return SendInputResult{}, err
-	}
-	if claim.ClientSubmitID != "" && !claimPending {
-		if claim.Status != "accepted" && claim.Status != "rejected" {
-			return SendInputResult{}, ErrSubmitDeliveryUnknown
-		}
-		return h.replayedSubmitResult(ctx, ref, claim)
-	}
-	defer func() {
-		if claimPending {
-			h.abandonSubmitClaim(ref, claim.ClientSubmitID)
-		}
-	}()
-	release, err := h.acquireSession(ctx, ref)
-	if err != nil {
-		return SendInputResult{}, err
-	}
-	defer release()
-	startedAt := h.now()
-	session, err := h.ensureRuntimeSessionLocked(ctx, ref)
-	if err != nil {
-		h.observeStep(ctx, "message_send", "runtime_session_ready", ref.AgentSessionID, "", startedAt, err)
-		return SendInputResult{}, err
-	}
-	h.observeStep(ctx, "message_send", "runtime_session_ready", ref.AgentSessionID, session.Provider, startedAt, nil)
-	augmentation, err := h.ensureTurnCapability(
-		ctx,
-		ref,
-		session,
-		claim.TurnID,
-		claim.ClientSubmitID,
-		input.TurnCapabilityInvocation,
-	)
-	if err != nil {
-		return SendInputResult{}, err
-	}
-	normalized, promptText, err = mergeTurnCapabilityPromptContent(normalized, augmentation)
-	if err != nil {
-		return SendInputResult{}, err
-	}
-	startedAt = h.now()
-	if err := h.runtime.ValidatePromptContent(ctx, RuntimeExecInput{WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID, Content: normalized}); err != nil {
-		h.observeStep(ctx, "message_send", "prompt_validated", ref.AgentSessionID, session.Provider, startedAt, err)
-		return SendInputResult{}, err
-	}
-	h.observeStep(ctx, "message_send", "prompt_validated", ref.AgentSessionID, session.Provider, startedAt, nil)
-	startedAt = h.now()
-	preparedContent, err := h.prepareContent(ref.WorkspaceID, ref.AgentSessionID, normalized)
-	if err != nil {
-		h.observeStep(ctx, "message_send", "prompt_prepared", ref.AgentSessionID, session.Provider, startedAt, err)
-		return SendInputResult{}, err
-	}
-	h.observeStep(ctx, "message_send", "prompt_prepared", ref.AgentSessionID, session.Provider, startedAt, nil)
-	displayPrompt, initialTitle := strings.TrimSpace(input.DisplayPrompt), ""
-	if !input.Guidance && !session.InitialTitleEstablished {
-		initialTitle = DeriveInitialTitle(session.Title, firstNonEmpty(displayPrompt, promptText, preparedContent.DisplayText))
-	}
-	startedAt = h.now()
-	releaseStartup, err := h.acquireStartup(ctx, session.Provider)
-	if err != nil {
-		h.observeStep(ctx, "message_send", "runtime_exec", ref.AgentSessionID, session.Provider, startedAt, err)
-		return SendInputResult{}, err
-	}
-	execResult, err := func() (RuntimeExecResult, error) {
-		defer releaseStartup()
-		turnID := strings.TrimSpace(input.TurnID)
-		if turnID == "" && !input.Guidance {
-			turnID = uuid.NewString()
-		}
-		return h.runtime.Exec(ctx, RuntimeExecInput{
-			WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
-			TurnID: turnID, ClientSubmitID: claim.ClientSubmitID,
-			CanonicalSubmitOccurredAtUnixMS: claim.CreatedAtUnixMS,
-			CapabilityRefs:                  append([]CapabilityReference(nil), input.CapabilityRefs...), Content: preparedContent.Hydrated,
-			DisplayPrompt: displayPrompt, InitialTitle: initialTitle, InitialTitleBase: session.Title,
-			Guidance: input.Guidance, Metadata: cloneMap(metadata), TuttiModeSnapshot: input.TuttiModeSnapshot,
-			RequireProviderAcceptance: !input.Guidance,
-		})
-	}()
-	if err != nil {
-		h.observeStep(ctx, "message_send", "runtime_exec", ref.AgentSessionID, session.Provider, startedAt, err)
-		if !input.Guidance && strings.TrimSpace(execResult.TurnID) != "" {
-			if persistErr := h.persistRuntimeSubmitOutcome(
-				ctx, ref, execResult,
-				firstNonEmpty(claim.ClientSubmitID, input.ClientSubmitID, legacyClientSubmitID(metadata)),
-				claim.CreatedAtUnixMS, preparedContent, displayPrompt, input.CapabilityRefs,
-				input.TuttiModeSnapshot,
-			); persistErr != nil {
-				claimPending = false
-				return SendInputResult{}, errors.Join(ErrSubmitDeliveryUnknown, err, persistErr)
-			}
-		}
-		if !input.Guidance &&
-			execResult.ProviderDispatch.Disposition == RuntimeDispatchDispositionRejected {
-			// The failed Turn and prompt are already durable. Resolve the claim to
-			// a terminal rejected state before the deferred cleanup can run.
-			if strings.TrimSpace(execResult.TurnID) != "" {
-				claimPending = false
-				if rejectErr := h.finalizeRejectedSubmitClaim(ref, firstNonEmpty(claim.ClientSubmitID, input.ClientSubmitID, legacyClientSubmitID(metadata)), execResult.TurnID); rejectErr != nil {
-					return SendInputResult{}, errors.Join(ErrSubmitDeliveryUnknown, err, rejectErr)
-				}
-				return SendInputResult{}, err
-			}
-		}
-		if input.Guidance && execResult.ProviderDispatch.Disposition == RuntimeDispatchDispositionNotDispatched {
-			// The runtime rejected the exact target before provider admission. Keep
-			// claimPending true so the deferred cleanup removes the prepared claim;
-			// this is a known rejection, not an outcome-unknown delivery.
-			return SendInputResult{}, err
-		}
-		if input.Guidance ||
-			execResult.ProviderDispatch.Disposition == RuntimeDispatchDispositionApplied ||
-			execResult.ProviderDispatch.Disposition == RuntimeDispatchDispositionOutcomeUnknown {
-			// Guidance targets an already-live turn and transport failure cannot
-			// prove rejection. A positive/unknown provider dispatch likewise
-			// preserves the claim as a recovery fence.
-			claimPending = false
-			return SendInputResult{}, errors.Join(ErrSubmitDeliveryUnknown, err)
-		}
-		return SendInputResult{}, err
-	}
-	turnID := strings.TrimSpace(execResult.TurnID)
-	if turnID == "" {
-		h.observeStep(ctx, "message_send", "runtime_exec", ref.AgentSessionID, session.Provider, startedAt, ErrSubmitDeliveryUnknown)
-		return SendInputResult{}, ErrSubmitDeliveryUnknown
-	}
-	if expectedTurnID := strings.TrimSpace(input.TurnID); !input.Guidance && expectedTurnID != "" && turnID != expectedTurnID {
-		claimPending = false
-		return SendInputResult{}, ErrSubmitDeliveryUnknown
-	}
-	if reporter, ok := h.runtime.(RuntimeSubmitProvenanceReporter); ok {
-		if err := reporter.DurablyReportSubmitProvenance(ctx, RuntimeSubmitProvenanceInput{
-			WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID, TurnID: turnID,
-			ClientSubmitID: claim.ClientSubmitID, CanonicalSubmitOccurredAtUnixMS: claim.CreatedAtUnixMS,
-			Content: preparedContent.Hydrated, DisplayPrompt: displayPrompt, Guidance: input.Guidance,
-		}); err != nil {
-			claimPending = false
-			return SendInputResult{}, errors.Join(ErrSubmitDeliveryUnknown, err)
-		}
-	}
-	if !input.Guidance {
-		if err := h.recordTurnSubmission(
-			ctx, ref, turnID, input.ClientSubmitID, preparedContent.Persisted,
-			displayPrompt, input.CapabilityRefs, input.TuttiModeSnapshot,
-		); err != nil {
-			claimPending = false
-			return SendInputResult{}, errors.Join(ErrSubmitDeliveryUnknown, err)
-		}
-	}
-	if claim.ClientSubmitID != "" {
-		claimPending = false
-		if err := h.acceptSubmitClaim(ref, claim.ClientSubmitID, turnID); err != nil {
-			return SendInputResult{}, errors.Join(ErrSubmitDeliveryUnknown, err)
-		}
-	}
-	h.observeStep(ctx, "message_send", "runtime_exec", ref.AgentSessionID, session.Provider, startedAt, nil)
-	canonicalSession, ok, err := h.store.GetSession(ctx, ref.WorkspaceID, ref.AgentSessionID)
-	if err != nil {
-		return SendInputResult{}, err
-	}
-	_ = ok
-	turn, ok, err := h.store.GetTurn(ctx, ref.WorkspaceID, ref.AgentSessionID, turnID)
-	if err != nil {
-		return SendInputResult{}, err
-	}
-	var turnPtr *storesqlite.Turn
-	if ok {
-		turnPtr = &turn
-	}
-	return SendInputResult{
-		Session: session, Canonical: canonicalSession, Turn: turnPtr, TurnID: turnID,
-		TurnLifecycle: execResult.TurnLifecycle, SubmitAvailability: execResult.SubmitAvailability,
-	}, nil
 }
 
 func (h *Host) UpdateTitle(ctx context.Context, input UpdateTitleInput) (UpdateTitleResult, error) {

--- a/packages/agent/host/ports.go
+++ b/packages/agent/host/ports.go
@@ -257,6 +257,12 @@ type RuntimeController interface {
 	Close(context.Context, RuntimeCloseInput) error
 }
 
+// RuntimeTurnCapabilityPort performs provider-owned capability readiness for
+// one already claimed Turn. Host owns the claim, lock, and ordinary Exec call.
+type RuntimeTurnCapabilityPort interface {
+	EnsureTurnCapability(context.Context, RuntimeTurnCapabilityInput) (RuntimeTurnCapabilityResult, error)
+}
+
 // RuntimeSessionLiveness distinguishes a registered runtime Session from a
 // live provider connection. It is required when Goal generation fencing is
 // configured: background recovery must never guess liveness and reconnect an

--- a/packages/agent/host/send_input_serialized.go
+++ b/packages/agent/host/send_input_serialized.go
@@ -1,0 +1,205 @@
+package agenthost
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/google/uuid"
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+func (h *Host) sendInputSerialized(
+	ctx context.Context,
+	ref SessionRef,
+	input SendInput,
+	normalized []PromptContentBlock,
+	metadata map[string]any,
+) (SendInputResult, error) {
+	var err error
+	if err := h.requireSendAllowedByEffectiveHistory(ctx, ref); err != nil {
+		return SendInputResult{}, err
+	}
+	if !input.Guidance && strings.TrimSpace(input.TurnID) == "" {
+		input.TurnID = uuid.NewString()
+	}
+	claim, claimPending, err := h.prepareSubmitClaim(ctx, ref, metadata, input.TurnID)
+	if err != nil {
+		if errors.Is(err, storesqlite.ErrSubmitClaimTurnConflict) {
+			return SendInputResult{}, errors.Join(ErrSubmitDeliveryUnknown, err)
+		}
+		return SendInputResult{}, err
+	}
+	if claim.ClientSubmitID != "" && !claimPending {
+		if claim.Status != "accepted" && claim.Status != "rejected" {
+			return SendInputResult{}, ErrSubmitDeliveryUnknown
+		}
+		return h.replayedSubmitResult(ctx, ref, claim)
+	}
+	defer func() {
+		if claimPending {
+			h.abandonSubmitClaim(ref, claim.ClientSubmitID)
+		}
+	}()
+	release, err := h.acquireSession(ctx, ref)
+	if err != nil {
+		return SendInputResult{}, err
+	}
+	defer release()
+	startedAt := h.now()
+	session, err := h.ensureRuntimeSessionLocked(ctx, ref)
+	if err != nil {
+		h.observeStep(ctx, "message_send", "runtime_session_ready", ref.AgentSessionID, "", startedAt, err)
+		return SendInputResult{}, err
+	}
+	h.observeStep(ctx, "message_send", "runtime_session_ready", ref.AgentSessionID, session.Provider, startedAt, nil)
+	augmentation, err := h.ensureTurnCapability(
+		ctx,
+		ref,
+		session,
+		claim.TurnID,
+		claim.ClientSubmitID,
+		input.TurnCapabilityInvocation,
+	)
+	if err != nil {
+		return SendInputResult{}, err
+	}
+	var promptText string
+	normalized, promptText, err = mergeTurnCapabilityPromptContent(normalized, augmentation)
+	if err != nil {
+		return SendInputResult{}, err
+	}
+	startedAt = h.now()
+	if err := h.runtime.ValidatePromptContent(ctx, RuntimeExecInput{WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID, Content: normalized}); err != nil {
+		h.observeStep(ctx, "message_send", "prompt_validated", ref.AgentSessionID, session.Provider, startedAt, err)
+		return SendInputResult{}, err
+	}
+	h.observeStep(ctx, "message_send", "prompt_validated", ref.AgentSessionID, session.Provider, startedAt, nil)
+	startedAt = h.now()
+	preparedContent, err := h.prepareContent(ref.WorkspaceID, ref.AgentSessionID, normalized)
+	if err != nil {
+		h.observeStep(ctx, "message_send", "prompt_prepared", ref.AgentSessionID, session.Provider, startedAt, err)
+		return SendInputResult{}, err
+	}
+	h.observeStep(ctx, "message_send", "prompt_prepared", ref.AgentSessionID, session.Provider, startedAt, nil)
+	displayPrompt, initialTitle := strings.TrimSpace(input.DisplayPrompt), ""
+	if !input.Guidance && !session.InitialTitleEstablished {
+		initialTitle = DeriveInitialTitle(session.Title, firstNonEmpty(displayPrompt, promptText, preparedContent.DisplayText))
+	}
+	startedAt = h.now()
+	releaseStartup, err := h.acquireStartup(ctx, session.Provider)
+	if err != nil {
+		h.observeStep(ctx, "message_send", "runtime_exec", ref.AgentSessionID, session.Provider, startedAt, err)
+		return SendInputResult{}, err
+	}
+	execResult, err := func() (RuntimeExecResult, error) {
+		defer releaseStartup()
+		turnID := strings.TrimSpace(input.TurnID)
+		if turnID == "" && !input.Guidance {
+			turnID = uuid.NewString()
+		}
+		return h.runtime.Exec(ctx, RuntimeExecInput{
+			WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
+			TurnID: turnID, ClientSubmitID: claim.ClientSubmitID,
+			CanonicalSubmitOccurredAtUnixMS: claim.CreatedAtUnixMS,
+			CapabilityRefs:                  append([]CapabilityReference(nil), input.CapabilityRefs...), Content: preparedContent.Hydrated,
+			DisplayPrompt: displayPrompt, InitialTitle: initialTitle, InitialTitleBase: session.Title,
+			Guidance: input.Guidance, Metadata: cloneMap(metadata), TuttiModeSnapshot: input.TuttiModeSnapshot,
+			RequireProviderAcceptance: !input.Guidance,
+		})
+	}()
+	if err != nil {
+		h.observeStep(ctx, "message_send", "runtime_exec", ref.AgentSessionID, session.Provider, startedAt, err)
+		if !input.Guidance && strings.TrimSpace(execResult.TurnID) != "" {
+			if persistErr := h.persistRuntimeSubmitOutcome(
+				ctx, ref, execResult,
+				firstNonEmpty(claim.ClientSubmitID, input.ClientSubmitID, legacyClientSubmitID(metadata)),
+				claim.CreatedAtUnixMS, preparedContent, displayPrompt, input.CapabilityRefs,
+				input.TuttiModeSnapshot,
+			); persistErr != nil {
+				claimPending = false
+				return SendInputResult{}, errors.Join(ErrSubmitDeliveryUnknown, err, persistErr)
+			}
+		}
+		if !input.Guidance &&
+			execResult.ProviderDispatch.Disposition == RuntimeDispatchDispositionRejected {
+			// The failed Turn and prompt are already durable. Resolve the claim to
+			// a terminal rejected state before the deferred cleanup can run.
+			if strings.TrimSpace(execResult.TurnID) != "" {
+				claimPending = false
+				if rejectErr := h.finalizeRejectedSubmitClaim(ref, firstNonEmpty(claim.ClientSubmitID, input.ClientSubmitID, legacyClientSubmitID(metadata)), execResult.TurnID); rejectErr != nil {
+					return SendInputResult{}, errors.Join(ErrSubmitDeliveryUnknown, err, rejectErr)
+				}
+				return SendInputResult{}, err
+			}
+		}
+		if input.Guidance && execResult.ProviderDispatch.Disposition == RuntimeDispatchDispositionNotDispatched {
+			// The runtime rejected the exact target before provider admission. Keep
+			// claimPending true so the deferred cleanup removes the prepared claim;
+			// this is a known rejection, not an outcome-unknown delivery.
+			return SendInputResult{}, err
+		}
+		if input.Guidance ||
+			execResult.ProviderDispatch.Disposition == RuntimeDispatchDispositionApplied ||
+			execResult.ProviderDispatch.Disposition == RuntimeDispatchDispositionOutcomeUnknown {
+			// Guidance targets an already-live turn and transport failure cannot
+			// prove rejection. A positive/unknown provider dispatch likewise
+			// preserves the claim as a recovery fence.
+			claimPending = false
+			return SendInputResult{}, errors.Join(ErrSubmitDeliveryUnknown, err)
+		}
+		return SendInputResult{}, err
+	}
+	turnID := strings.TrimSpace(execResult.TurnID)
+	if turnID == "" {
+		h.observeStep(ctx, "message_send", "runtime_exec", ref.AgentSessionID, session.Provider, startedAt, ErrSubmitDeliveryUnknown)
+		return SendInputResult{}, ErrSubmitDeliveryUnknown
+	}
+	if expectedTurnID := strings.TrimSpace(input.TurnID); !input.Guidance && expectedTurnID != "" && turnID != expectedTurnID {
+		claimPending = false
+		return SendInputResult{}, ErrSubmitDeliveryUnknown
+	}
+	if reporter, ok := h.runtime.(RuntimeSubmitProvenanceReporter); ok {
+		if err := reporter.DurablyReportSubmitProvenance(ctx, RuntimeSubmitProvenanceInput{
+			WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID, TurnID: turnID,
+			ClientSubmitID: claim.ClientSubmitID, CanonicalSubmitOccurredAtUnixMS: claim.CreatedAtUnixMS,
+			Content: preparedContent.Hydrated, DisplayPrompt: displayPrompt, Guidance: input.Guidance,
+		}); err != nil {
+			claimPending = false
+			return SendInputResult{}, errors.Join(ErrSubmitDeliveryUnknown, err)
+		}
+	}
+	if !input.Guidance {
+		if err := h.recordTurnSubmission(
+			ctx, ref, turnID, input.ClientSubmitID, preparedContent.Persisted,
+			displayPrompt, input.CapabilityRefs, input.TuttiModeSnapshot,
+		); err != nil {
+			claimPending = false
+			return SendInputResult{}, errors.Join(ErrSubmitDeliveryUnknown, err)
+		}
+	}
+	if claim.ClientSubmitID != "" {
+		claimPending = false
+		if err := h.acceptSubmitClaim(ref, claim.ClientSubmitID, turnID); err != nil {
+			return SendInputResult{}, errors.Join(ErrSubmitDeliveryUnknown, err)
+		}
+	}
+	h.observeStep(ctx, "message_send", "runtime_exec", ref.AgentSessionID, session.Provider, startedAt, nil)
+	canonicalSession, ok, err := h.store.GetSession(ctx, ref.WorkspaceID, ref.AgentSessionID)
+	if err != nil {
+		return SendInputResult{}, err
+	}
+	_ = ok
+	turn, ok, err := h.store.GetTurn(ctx, ref.WorkspaceID, ref.AgentSessionID, turnID)
+	if err != nil {
+		return SendInputResult{}, err
+	}
+	var turnPtr *storesqlite.Turn
+	if ok {
+		turnPtr = &turn
+	}
+	return SendInputResult{
+		Session: session, Canonical: canonicalSession, Turn: turnPtr, TurnID: turnID,
+		TurnLifecycle: execResult.TurnLifecycle, SubmitAvailability: execResult.SubmitAvailability,
+	}, nil
+}

--- a/packages/agent/host/turn_capability.go
+++ b/packages/agent/host/turn_capability.go
@@ -1,0 +1,80 @@
+package agenthost
+
+import (
+	"context"
+	"strings"
+)
+
+// TurnCapabilityInvocation is a provider-neutral request to prepare exactly
+// one capability for the Turn being submitted. It is separate from
+// CapabilityRefs, which only record provenance after submission.
+type TurnCapabilityInvocation struct {
+	Semantic string
+}
+
+// RuntimeTurnCapabilityInput binds capability preparation to the Host-owned
+// submit identity. The runtime must not infer an active Turn from process
+// state, and it must never dispatch a provider turn itself.
+type RuntimeTurnCapabilityInput struct {
+	WorkspaceID    string
+	AgentSessionID string
+	TurnID         string
+	ClientSubmitID string
+	Session        ProviderRuntimeSession
+	Invocation     TurnCapabilityInvocation
+}
+
+// RuntimeTurnCapabilityResult may contribute exactly one structured mention
+// to the ordinary Turn. Empty content is never a successful capability result.
+type RuntimeTurnCapabilityResult struct {
+	PromptAugmentation []PromptContentBlock
+}
+
+func (h *Host) ensureTurnCapability(
+	ctx context.Context,
+	ref SessionRef,
+	session ProviderRuntimeSession,
+	turnID, clientSubmitID string,
+	invocation *TurnCapabilityInvocation,
+) ([]PromptContentBlock, error) {
+	if invocation == nil {
+		return nil, nil
+	}
+	if h == nil || h.turnCapabilities == nil || strings.TrimSpace(turnID) == "" || strings.TrimSpace(clientSubmitID) == "" {
+		return nil, ErrTurnCapabilityUnsupported
+	}
+	semantic := strings.TrimSpace(invocation.Semantic)
+	if semantic == "" {
+		return nil, ErrInvalidArgument
+	}
+	result, err := h.turnCapabilities.EnsureTurnCapability(ctx, RuntimeTurnCapabilityInput{
+		WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
+		TurnID: turnID, ClientSubmitID: clientSubmitID, Session: session,
+		Invocation: TurnCapabilityInvocation{Semantic: semantic},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(result.PromptAugmentation) != 1 {
+		return nil, ErrTurnCapabilityUnavailable
+	}
+	block := result.PromptAugmentation[0]
+	if strings.TrimSpace(block.Type) != "mention" || strings.TrimSpace(block.Name) == "" || strings.TrimSpace(block.Path) == "" {
+		return nil, ErrTurnCapabilityUnavailable
+	}
+	return []PromptContentBlock{{Type: "mention", Name: strings.TrimSpace(block.Name), Path: strings.TrimSpace(block.Path)}}, nil
+}
+
+func mergeTurnCapabilityPromptContent(base, augmentation []PromptContentBlock) ([]PromptContentBlock, string, error) {
+	if len(augmentation) == 0 {
+		return normalizePromptContent(base)
+	}
+	if len(augmentation) != 1 || strings.TrimSpace(augmentation[0].Type) != "mention" ||
+		strings.TrimSpace(augmentation[0].Name) == "" || strings.TrimSpace(augmentation[0].Path) == "" {
+		return nil, "", ErrTurnCapabilityUnavailable
+	}
+	merged := make([]PromptContentBlock, 0, len(base)+1)
+	merged = append(merged, base...)
+	merged = append(merged, augmentation...)
+	return normalizePromptContent(merged)
+}

--- a/packages/agent/host/turn_capability_test.go
+++ b/packages/agent/host/turn_capability_test.go
@@ -1,0 +1,28 @@
+package agenthost
+
+import "testing"
+
+func TestMergeTurnCapabilityPromptContent(t *testing.T) {
+	t.Parallel()
+	content, text, err := mergeTurnCapabilityPromptContent(
+		[]PromptContentBlock{{Type: "text", Text: "open tutti.dev"}},
+		[]PromptContentBlock{{Type: "mention", Name: "browser@openai-bundled", Path: "plugin://browser@openai-bundled"}},
+	)
+	if err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+	if text != "open tutti.dev" || len(content) != 2 {
+		t.Fatalf("content = %#v, text = %q", content, text)
+	}
+}
+
+func TestMergeTurnCapabilityPromptContentRejectsInvalidMention(t *testing.T) {
+	t.Parallel()
+	_, _, err := mergeTurnCapabilityPromptContent(
+		[]PromptContentBlock{{Type: "text", Text: "task"}},
+		[]PromptContentBlock{{Type: "skill", Name: "unexpected", Path: "skill://unexpected"}},
+	)
+	if err == nil {
+		t.Fatal("merge succeeded for an invalid capability augmentation")
+	}
+}

--- a/packages/agent/host/types.go
+++ b/packages/agent/host/types.go
@@ -578,10 +578,11 @@ type RailPlacement struct {
 // import paths, workspace resolution, identity, and transport state are not
 // part of this type.
 type CreateSessionInput struct {
-	AgentSessionID string
-	AgentTargetID  string
-	Provider       string
-	InitialContent []PromptContentBlock
+	AgentSessionID           string
+	AgentTargetID            string
+	Provider                 string
+	InitialContent           []PromptContentBlock
+	TurnCapabilityInvocation *TurnCapabilityInvocation
 	// InitialGoalControl applies a Goal mutation after creating the Session
 	// without opening an initial Turn. It is mutually exclusive with
 	// InitialContent; ClientSubmitID is the durable mutation identity.
@@ -612,12 +613,13 @@ type CreateSessionInput struct {
 }
 
 type SendInput struct {
-	CapabilityRefs    []CapabilityReference
-	TurnID            string
-	TuttiModeSnapshot *TuttiModeTurnSnapshot
-	Content           []PromptContentBlock
-	DisplayPrompt     string
-	Metadata          map[string]any
+	CapabilityRefs           []CapabilityReference
+	TurnCapabilityInvocation *TurnCapabilityInvocation
+	TurnID                   string
+	TuttiModeSnapshot        *TuttiModeTurnSnapshot
+	Content                  []PromptContentBlock
+	DisplayPrompt            string
+	Metadata                 map[string]any
 	// ClientSubmitID is the caller-owned idempotency identity. When present it
 	// overrides any legacy clientSubmitId value carried in Metadata.
 	ClientSubmitID string

--- a/services/tuttid/service/agent/codex_native_turn_capability.go
+++ b/services/tuttid/service/agent/codex_native_turn_capability.go
@@ -1,0 +1,85 @@
+package agent
+
+import (
+	"strings"
+
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
+)
+
+const (
+	legacyBrowserUsePromptPrefix  = "Use the injected browser-use skill and only the tutti browser CLI. Do not use any other browser skill, CDP scripts, or direct browser automation."
+	legacyComputerUsePromptPrefix = "Use the injected computer-use skill and only the tutti computer CLI. Do not use any other computer-use skill, accessibility script, or direct desktop automation."
+)
+
+// codexNativeTurnCapability is a narrow product-policy translation. It runs
+// only after the service has selected Codex, and hands the Host a semantic
+// request rather than a plugin path. The runtime owns the final current-thread
+// check and the official App Server mention.
+func codexNativeTurnCapability(provider string, content []PromptContentBlock) ([]PromptContentBlock, *agenthost.TurnCapabilityInvocation) {
+	if strings.TrimSpace(provider) != "codex" || len(content) == 0 {
+		return content, nil
+	}
+	for index, block := range content {
+		if strings.TrimSpace(block.Type) != "text" {
+			continue
+		}
+		semantic, task, ok := parseCodexNativeCapabilityInvocation(block.Text)
+		if !ok {
+			return content, nil
+		}
+		translated := append([]PromptContentBlock(nil), content...)
+		translated[index].Text = task
+		return translated, &agenthost.TurnCapabilityInvocation{Semantic: semantic}
+	}
+	return content, nil
+}
+
+func parseCodexNativeCapabilityInvocation(text string) (semantic, task string, ok bool) {
+	if semantic, task, ok = parseCodexNativeCapabilitySlash(text); ok {
+		return semantic, task, true
+	}
+	return parseLegacyTuttiCapabilityPrompt(text)
+}
+
+func parseCodexNativeCapabilitySlash(text string) (semantic, task string, ok bool) {
+	text = strings.TrimSpace(text)
+	if !strings.HasPrefix(text, "/") {
+		return "", "", false
+	}
+	separator := strings.IndexAny(text, " \t\r\n")
+	if separator < 0 {
+		return "", "", false
+	}
+	semantic = strings.TrimPrefix(text[:separator], "/")
+	task = strings.TrimSpace(text[separator:])
+	if task == "" {
+		return "", "", false
+	}
+	switch semantic {
+	case "browser", "computer", "sites":
+		return semantic, task, true
+	default:
+		return "", "", false
+	}
+}
+
+func parseLegacyTuttiCapabilityPrompt(text string) (semantic, task string, ok bool) {
+	text = strings.TrimSpace(text)
+	for _, candidate := range []struct {
+		prefix   string
+		semantic string
+	}{
+		{prefix: legacyBrowserUsePromptPrefix, semantic: "browser"},
+		{prefix: legacyComputerUsePromptPrefix, semantic: "computer"},
+	} {
+		if !strings.HasPrefix(text, candidate.prefix) {
+			continue
+		}
+		task = strings.TrimSpace(strings.TrimPrefix(text, candidate.prefix))
+		if task == "" {
+			return "", "", false
+		}
+		return candidate.semantic, task, true
+	}
+	return "", "", false
+}

--- a/services/tuttid/service/agent/codex_native_turn_capability.go
+++ b/services/tuttid/service/agent/codex_native_turn_capability.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"strings"
 
+	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 )
 
@@ -16,7 +17,7 @@ const (
 // request rather than a plugin path. The runtime owns the final current-thread
 // check and the official App Server mention.
 func codexNativeTurnCapability(provider string, content []PromptContentBlock) ([]PromptContentBlock, *agenthost.TurnCapabilityInvocation) {
-	if strings.TrimSpace(provider) != "codex" || len(content) == 0 {
+	if !providerregistry.SupportsNativePluginTurn(provider) || len(content) == 0 {
 		return content, nil
 	}
 	for index, block := range content {

--- a/services/tuttid/service/agent/codex_native_turn_capability_test.go
+++ b/services/tuttid/service/agent/codex_native_turn_capability_test.go
@@ -1,0 +1,40 @@
+package agent
+
+import "testing"
+
+func TestCodexNativeTurnCapability(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		provider     string
+		prompt       string
+		wantSemantic string
+		wantPrompt   string
+	}{
+		{name: "browser on Codex", provider: "codex", prompt: "/browser open tutti.dev", wantSemantic: "browser", wantPrompt: "open tutti.dev"},
+		{name: "computer on Codex", provider: "codex", prompt: "/computer open Notes", wantSemantic: "computer", wantPrompt: "open Notes"},
+		{name: "sites on Codex", provider: "codex", prompt: "/sites\ncreate a landing page", wantSemantic: "sites", wantPrompt: "create a landing page"},
+		{name: "legacy browser palette prompt on Codex", provider: "codex", prompt: legacyBrowserUsePromptPrefix + "\n\nopen tutti.dev", wantSemantic: "browser", wantPrompt: "open tutti.dev"},
+		{name: "other provider unchanged", provider: "claude-code", prompt: "/browser open tutti.dev", wantPrompt: "/browser open tutti.dev"},
+		{name: "bare command unchanged", provider: "codex", prompt: "/browser", wantPrompt: "/browser"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			content, invocation := codexNativeTurnCapability(test.provider, TextPromptContent(test.prompt))
+			if content[0].Text != test.wantPrompt {
+				t.Fatalf("text = %q, want %q", content[0].Text, test.wantPrompt)
+			}
+			if test.wantSemantic == "" {
+				if invocation != nil {
+					t.Fatalf("invocation = %#v, want nil", invocation)
+				}
+				return
+			}
+			if invocation == nil || invocation.Semantic != test.wantSemantic {
+				t.Fatalf("invocation = %#v, want semantic %q", invocation, test.wantSemantic)
+			}
+		})
+	}
+}

--- a/services/tuttid/service/agent/host_composition.go
+++ b/services/tuttid/service/agent/host_composition.go
@@ -183,6 +183,7 @@ func composeApplicationHost(
 	turnSubmissions, _ := canonical.(agenthost.TurnSubmissionStore)
 	effectiveHistory, _ := canonical.(agenthost.EffectiveHistoryStore)
 	historyRuntime, _ := runtime.(agenthost.RuntimeHistoryController)
+	turnCapabilities, _ := runtime.(agenthost.RuntimeTurnCapabilityPort)
 	return agenthost.New(agenthost.Config{
 		CanonicalStore: canonical, SessionManagement: sessionManagement,
 		SessionBatchManagement: sessionBatchManagement, SessionPurge: support.SessionPurge,
@@ -196,6 +197,7 @@ func composeApplicationHost(
 		TurnSubmissions:        turnSubmissions,
 		EffectiveHistory:       effectiveHistory,
 		Runtime:                runtime,
+		TurnCapabilities:       turnCapabilities,
 		HistoryRuntime:         historyRuntime,
 		RuntimePreparation:     support.RuntimePreparation, Attachments: support.Attachments,
 		SettingsPolicy: support.SettingsPolicy,

--- a/services/tuttid/service/agent/service_create.go
+++ b/services/tuttid/service/agent/service_create.go
@@ -83,6 +83,7 @@ func (s *Service) CreateWithResult(ctx context.Context, workspaceID string, inpu
 		}
 		s.reportAgentServiceNodeSuccess(ctx, input.AgentSessionID, "session_create", "content_normalized", provider, nodeStartedAt)
 	}
+	normalizedContent, turnCapability := codexNativeTurnCapability(provider, normalizedContent)
 	logAgentSubmitTrace("service.create.content_normalized", workspaceID, input.AgentSessionID, input.ClientSubmitID, input.Metadata, map[string]any{"content_block_count": len(normalizedContent)})
 	requestedModel := value(input.Model)
 	nodeStartedAt := time.Now()
@@ -186,7 +187,8 @@ func (s *Service) CreateWithResult(ctx context.Context, workspaceID string, inpu
 	hostInput := agenthost.CreateSessionInput{
 		AgentSessionID: input.AgentSessionID, AgentTargetID: input.AgentTargetID, Provider: input.Provider,
 		InitialContent: normalizedContent, InitialGoalControl: input.InitialGoalControl, InitialDisplayPrompt: input.InitialDisplayPrompt,
-		Metadata: input.Metadata, ClientSubmitID: input.ClientSubmitID,
+		TurnCapabilityInvocation: turnCapability,
+		Metadata:                 input.Metadata, ClientSubmitID: input.ClientSubmitID,
 		CapabilityRefs: append([]CapabilityReference(nil), input.CapabilityRefs...), Title: input.Title, Cwd: stringPointer(prepared.Cwd),
 		PermissionModeID: input.PermissionModeID,
 		Model:            stringPointer(runtimeSettings.Model),

--- a/services/tuttid/service/agent/service_send_input.go
+++ b/services/tuttid/service/agent/service_send_input.go
@@ -37,6 +37,17 @@ func (s *Service) SendInput(ctx context.Context, workspaceID string, agentSessio
 		s.reportAgentServiceNodeFailure(ctx, agentSessionID, "message_send", "content_normalized", "", nodeStartedAt, err)
 		return SendInputResult{}, err
 	}
+	runtimeSession, _ := s.controller().Session(workspaceID, agentSessionID)
+	provider := runtimeSession.Provider
+	if strings.TrimSpace(provider) == "" {
+		if persistedSession, getErr := s.Get(ctx, workspaceID, agentSessionID); getErr == nil {
+			provider = persistedSession.Provider
+		}
+	}
+	var turnCapability *agenthost.TurnCapabilityInvocation
+	if !input.Guidance {
+		normalizedContent, turnCapability = codexNativeTurnCapability(provider, normalizedContent)
+	}
 	s.reportAgentServiceNodeSuccess(ctx, agentSessionID, "message_send", "content_normalized", "", nodeStartedAt)
 	logAgentSubmitTrace("service.send.content_normalized", workspaceID, agentSessionID, input.ClientSubmitID, input.Metadata, map[string]any{
 		"content_block_count": len(normalizedContent),
@@ -45,12 +56,11 @@ func (s *Service) SendInput(ctx context.Context, workspaceID string, agentSessio
 		CapabilityRefs: append([]CapabilityReference(nil), input.CapabilityRefs...),
 		Content:        normalizedContent, DisplayPrompt: input.DisplayPrompt,
 		Metadata: cloneMetadata(input.Metadata), ClientSubmitID: input.ClientSubmitID, Guidance: input.Guidance,
-		TurnID: input.TurnID,
+		TurnID: input.TurnID, TurnCapabilityInvocation: turnCapability,
 	}
 	var preparedTurnID string
 	var preparedSnapshot tuttimodeactivationbiz.TurnSnapshot
 	if _, typedGoal := agenthost.ParseTypedGoalControl(normalizedContent, input.Guidance); !typedGoal {
-		runtimeSession, _ := s.controller().Session(workspaceID, agentSessionID)
 		existingCanonicalTurnID, claimErr := s.existingSubmitCanonicalTurnID(ctx, workspaceID, agentSessionID, input.ClientSubmitID, input.Metadata)
 		if claimErr != nil {
 			return SendInputResult{}, claimErr
@@ -100,7 +110,7 @@ func (s *Service) SendInput(ctx context.Context, workspaceID string, agentSessio
 		return SendInputResult{}, ErrSubmitDeliveryUnknown
 	}
 	turnID := hostResult.TurnID
-	provider := strings.TrimSpace(hostResult.Session.Provider)
+	provider = strings.TrimSpace(hostResult.Session.Provider)
 	logAgentSubmitTrace("service.send.runtime_session_ready", workspaceID, agentSessionID, input.ClientSubmitID, input.Metadata, nil)
 	logAgentSubmitTrace("service.send.prompt_validated", workspaceID, agentSessionID, input.ClientSubmitID, input.Metadata, nil)
 	logAgentSubmitTrace("service.send.prompt_prepared", workspaceID, agentSessionID, input.ClientSubmitID, input.Metadata, map[string]any{"content_block_count": len(normalizedContent)})


### PR DESCRIPTION
## Summary

Add Codex Native Plugin execution for the current Turn on the existing Codex runtime. This PR is intentionally independent of PR1977 and does not modify the Skills catalog, slash-palette hiding, or cold-load/cache behavior.

## Execution flow

- Parse Codex-only `/browser`, `/computer`, and `/sites` intents into provider-neutral Turn capability invocations.
- Bind the invocation to the Host-owned Session/Turn and existing `TurnID`/`ClientSubmitID` claim.
- Verify the live Codex runtime and current thread before normal `turn/start`.
- Add exactly one official plugin mention:
  - `plugin://browser@openai-bundled`
  - `plugin://computer-use@openai-bundled`
  - `plugin://sites@openai-bundled`
- Delegate plugin availability/authorization decisions to the existing Codex App Server path.
- On preparation failure, do not dispatch or silently fall back to Tutti.

## Compatibility

The existing legacy Tutti Browser/Computer prompt prefixes are retained as an explicitly scoped compatibility parser. They are only recognized for Codex input and do not change non-Codex Agent behavior.

## Out of scope

- PR1977 Skills hiding, slash palette, plugin-to-Skill mapping, and cold-load/cache changes
- `plugin/list`, `plugin/read`, plugin installation, or a new authorization system
- Tutti Mode routing/fallback behavior
- Non-Codex providers

## Validation

- Targeted Host, daemon runtime, Host adapter, and Tuttid service tests pass.
- `git diff --cached --check` passed before commit.
- The full daemon runtime package still has three pre-existing Claude sidecar environment test failures; no Codex plugin test failed.

Commit: `cf23eb498ed89b17337570ecdf3021a447ddb3ab`