### PR TITLE
fix(agent): disable unsupported Tutti Agent features

### DIFF
--- a/docs/architecture/agent-runtime-preparation.md
+++ b/docs/architecture/agent-runtime-preparation.md
@@ -60,6 +60,15 @@ adapter-only contract: materialized bundle roots do not enter the Host public
 lifecycle types or user-visible runtime context. A failed RPC fails startup so
 the thread cannot silently run without its managed Skills.
 
+Runtimeprep also owns Tutti Agent's hosted-capability boundary. Every prepared
+session config disables Codex Apps, plugins, hosted search and image tools,
+memories, native multi-agent features, tool suggestions, orchestrator MCP and
+orchestrator Skills, and removes copied user MCP server tables. Those features
+depend on Codex-hosted services or namespace transports that Tutti Agent auth
+does not provide. The rewrite applies to the session-scoped config copy on
+every preparation, including resumed homes and explicitly sourced auth; it
+must never mutate the user's global `~/.tutti-agent/config.toml`.
+
 Tutti Agent installs its provider-owned embedded Skills beneath the run-scoped
 home during app-server initialization. Before the same extra-roots refresh,
 the Adapter content-addresses that installed tree under

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -1555,6 +1555,34 @@ invalid_grant`. Search `tuttid.log` for
   header, daemon visible-error classification, and rendered plans-page action as
   separate boundary tests.
 
+### Tutti Agent repeatedly reconnects after a Codex Apps HTTP 451
+
+- Symptom:
+  One Tutti Agent session repeatedly displays `Reconnecting...` while other
+  sessions continue normally. Provider logs contain a Codex Apps or MCP request
+  failing with HTTP 451 such as `no_biscuit_no_service`, followed by rejected
+  terminal-state transitions.
+- Root cause:
+  `tutti-agent login --with-tutti-llm-tokens` replaces authentication state but
+  does not write feature flags to `config.toml`. A run-scoped home created from
+  an explicit auth source may not copy the user's global config at all. Because
+  upstream Apps and Plugins default to enabled, that session can register a
+  Codex-hosted namespace that Tutti Agent auth cannot use.
+- Fix:
+  Runtimeprep must enforce the Tutti Agent hosted-capability policy in every
+  session-scoped config, replacing existing enabled values as well as filling
+  missing values. Disable Apps, plugins, other hosted or namespace features,
+  orchestrator MCP and Skills, hosted web search, and copied MCP server tables.
+  Do not rely on login and do not mutate `~/.tutti-agent/config.toml`.
+- Validation:
+  Start from a session config containing enabled feature values, orchestrator
+  tables, and nested MCP server tables. Prepare the home twice and assert the
+  unsupported sources are disabled exactly once, unrelated settings survive,
+  and the second preparation is byte-for-byte idempotent.
+- References:
+  [runtimeprep tutti_agent.go](../../../packages/agent/runtimeprep/tutti_agent.go)
+  [runtimeprep feature policy](../../../packages/agent/runtimeprep/tutti_agent_features.go)
+
 ### OpenCode effort changes fail with `effort not found`
 
 - Symptom:

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -43,6 +43,7 @@ Provider discovery, installation, authentication, models, configuration, and run
 - [Codex Model Plan turns fail or stay waiting against a Chat-only endpoint](./agent-provider-setup.md#codex-model-plan-turns-fail-or-stay-waiting-against-a-chat-only-endpoint)
 - [Claude Code sessions fail with `effectiveSource: "none"` when CC-Switch or similar proxy tools are used](./agent-provider-setup.md#claude-code-sessions-fail-with-effectivesource-none-when-cc-switch-or-similar-proxy-tools-are-used)
 - [Tutti Agent retries a 402 and shows generic provider setup](./agent-provider-setup.md#tutti-agent-retries-a-402-and-shows-generic-provider-setup)
+- [Tutti Agent repeatedly reconnects after a Codex Apps HTTP 451](./agent-provider-setup.md#tutti-agent-repeatedly-reconnects-after-a-codex-apps-http-451)
 - [OpenCode effort changes fail with `effort not found`](./agent-provider-setup.md#opencode-effort-changes-fail-with-effort-not-found)
 - [OpenCode model picker has fewer models than the terminal](./agent-provider-setup.md#opencode-model-picker-has-fewer-models-than-the-terminal)
 - [Provider setup notice flashes after switching to an already-connected agent](./agent-provider-setup.md#provider-setup-notice-flashes-after-switching-to-an-already-connected-agent)

--- a/packages/agent/runtimeprep/tutti_agent.go
+++ b/packages/agent/runtimeprep/tutti_agent.go
@@ -197,6 +197,10 @@ func ensureTuttiAgentSessionConfig(configPath string, input PrepareInput) error 
 		next = planNext
 		changed = true
 	}
+	if featureNext, featureChanged := tuttiAgentConfigWithUnsupportedFeaturesDisabled(next); featureChanged {
+		next = featureNext
+		changed = true
+	}
 	// Tutti Agent uses the same Codex-derived app-server sandbox runtime as
 	// Codex, but it is launched by Tutti's non-elevated desktop daemon. Keep
 	// the Windows implementation aligned with Codex session homes so an

--- a/packages/agent/runtimeprep/tutti_agent_features.go
+++ b/packages/agent/runtimeprep/tutti_agent_features.go
@@ -1,0 +1,116 @@
+package runtimeprep
+
+import (
+	"strconv"
+	"strings"
+)
+
+var tuttiAgentUnsupportedFeatures = []string{
+	"apps",
+	"current_time_reminder",
+	"image_generation",
+	"imagegenext",
+	"memories",
+	"multi_agent",
+	"multi_agent_v2",
+	"plugins",
+	"standalone_web_search",
+	"tool_suggest",
+}
+
+// tuttiAgentConfigWithUnsupportedFeaturesDisabled keeps provider-owned hosted
+// tools and namespace sources out of Tutti Agent sessions. These capabilities
+// depend on Codex services that Tutti Agent auth does not provide. Apply the
+// policy only to the run-scoped config copy; the user's global config remains
+// untouched.
+func tuttiAgentConfigWithUnsupportedFeaturesDisabled(content string) (string, bool) {
+	next := tuttiAgentConfigWithoutTablePrefix(content, "mcp_servers")
+	next = codexConfigWithTopLevelAssignment(next, "web_search", strconv.Quote("disabled"))
+	for _, feature := range tuttiAgentUnsupportedFeatures {
+		next = tuttiAgentConfigWithTableAssignment(next, "features", feature, "false")
+	}
+	for _, table := range []string{"orchestrator.mcp", "orchestrator.skills"} {
+		next = tuttiAgentConfigWithTableAssignment(next, table, "enabled", "false")
+	}
+	return next, next != content
+}
+
+func tuttiAgentConfigWithTableAssignment(content string, table string, key string, encodedValue string) string {
+	line := key + " = " + encodedValue
+	lines := strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n")
+	for tableStart, existingLine := range lines {
+		name, ok := tuttiAgentConfigTableName(existingLine)
+		if !ok || name != table {
+			continue
+		}
+		tableEnd := len(lines)
+		for index := tableStart + 1; index < len(lines); index++ {
+			if _, ok := tuttiAgentConfigTableName(lines[index]); ok {
+				tableEnd = index
+				break
+			}
+		}
+		for index := tableStart + 1; index < tableEnd; index++ {
+			trimmed := strings.TrimSpace(lines[index])
+			if trimmed == "" || strings.HasPrefix(trimmed, "#") || !codexConfigLineHasKey(trimmed, key) {
+				continue
+			}
+			if trimmed == line {
+				return content
+			}
+			nextLines := append([]string{}, lines...)
+			nextLines[index] = line
+			return strings.Join(nextLines, "\n")
+		}
+		nextLines := make([]string, 0, len(lines)+1)
+		nextLines = append(nextLines, lines[:tableEnd]...)
+		nextLines = append(nextLines, line)
+		nextLines = append(nextLines, lines[tableEnd:]...)
+		return strings.Join(nextLines, "\n")
+	}
+	block := "[" + table + "]\n" + line + "\n"
+	if strings.TrimSpace(content) == "" {
+		return block
+	}
+	return strings.TrimRight(content, "\r\n") + "\n\n" + block
+}
+
+func tuttiAgentConfigWithoutTablePrefix(content string, prefix string) string {
+	lines := strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n")
+	nextLines := make([]string, 0, len(lines))
+	removing := false
+	changed := false
+	for _, line := range lines {
+		if table, ok := tuttiAgentConfigTableName(line); ok {
+			removing = table == prefix || strings.HasPrefix(table, prefix+".")
+		}
+		if removing {
+			changed = true
+			continue
+		}
+		nextLines = append(nextLines, line)
+	}
+	if !changed {
+		return content
+	}
+	return strings.TrimRight(strings.Join(nextLines, "\n"), "\n") + "\n"
+}
+
+func tuttiAgentConfigTableName(line string) (string, bool) {
+	trimmed := strings.TrimSpace(line)
+	if !strings.HasPrefix(trimmed, "[") {
+		return "", false
+	}
+	if strings.HasPrefix(trimmed, "[[") {
+		end := strings.Index(trimmed[2:], "]]")
+		if end < 0 {
+			return "", false
+		}
+		return strings.TrimSpace(trimmed[2 : end+2]), true
+	}
+	end := strings.IndexByte(trimmed[1:], ']')
+	if end < 0 {
+		return "", false
+	}
+	return strings.TrimSpace(trimmed[1 : end+1]), true
+}

--- a/packages/agent/runtimeprep/tutti_agent_test.go
+++ b/packages/agent/runtimeprep/tutti_agent_test.go
@@ -176,6 +176,91 @@ func TestPrepareTuttiAgentHomeRemovesLegacyPinnedProvider(t *testing.T) {
 	}
 }
 
+func TestPrepareTuttiAgentHomeDisablesUnsupportedHostedFeatures(t *testing.T) {
+	home := t.TempDir()
+	configPath := filepath.Join(home, "config.toml")
+	config := strings.Join([]string{
+		`web_search = "live"`,
+		``,
+		`[mcp_servers.example]`,
+		`command = "example"`,
+		``,
+		`[mcp_servers.example.env]`,
+		`MODE = "test"`,
+		``,
+		`[features]`,
+		`apps = true`,
+		`plugins = true`,
+		`memories = true`,
+		`js_repl = false`,
+		``,
+		`[orchestrator.mcp]`,
+		`enabled = true`,
+		``,
+		`[orchestrator.skills]`,
+		`enabled = true`,
+		``,
+		`[projects."/tmp/work"]`,
+		`trust_level = "trusted"`,
+	}, "\n")
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	input := testResolvedInput(t, PrepareInput{Provider: "tutti-agent"})
+	if err := PrepareTuttiAgentHome(home, input); err != nil {
+		t.Fatalf("PrepareTuttiAgentHome() error = %v", err)
+	}
+	first, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared := string(first)
+	if strings.Contains(prepared, "[mcp_servers") || strings.Contains(prepared, `web_search = "live"`) {
+		t.Fatalf("prepared config retains unsupported hosted tools:\n%s", prepared)
+	}
+	if strings.Count(prepared, `web_search = "disabled"`) != 1 {
+		t.Fatalf("prepared config must disable web search exactly once:\n%s", prepared)
+	}
+	for _, feature := range []string{
+		"apps",
+		"current_time_reminder",
+		"image_generation",
+		"imagegenext",
+		"memories",
+		"multi_agent",
+		"multi_agent_v2",
+		"plugins",
+		"standalone_web_search",
+		"tool_suggest",
+	} {
+		if strings.Count(prepared, feature+" = false") != 1 || strings.Contains(prepared, feature+" = true") {
+			t.Fatalf("prepared config must disable %s exactly once:\n%s", feature, prepared)
+		}
+	}
+	for _, table := range []string{"orchestrator.mcp", "orchestrator.skills"} {
+		if !containsConfigBlock(prepared, "["+table+"]\nenabled = false") {
+			t.Fatalf("prepared config must disable %s:\n%s", table, prepared)
+		}
+	}
+	for _, preserved := range []string{`js_repl = false`, `[projects."/tmp/work"]`, `trust_level = "trusted"`} {
+		if !strings.Contains(prepared, preserved) {
+			t.Fatalf("prepared config lost %q:\n%s", preserved, prepared)
+		}
+	}
+
+	if err := PrepareTuttiAgentHome(home, input); err != nil {
+		t.Fatalf("second PrepareTuttiAgentHome() error = %v", err)
+	}
+	second, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(second) != prepared {
+		t.Fatalf("Tutti Agent feature policy is not idempotent:\nfirst:\n%s\nsecond:\n%s", prepared, second)
+	}
+}
+
 func TestPrepareTuttiAgentHomeWritesResponsesModelPlanEndpoint(t *testing.T) {
 	home := t.TempDir()
 	endpoint := &ModelEndpointConfig{


### PR DESCRIPTION
## Summary

- enforce the Tutti Agent hosted-capability policy in every run-scoped session config
- disable Codex Apps, plugins, hosted/namespace features, orchestrator MCP and Skills, hosted search, and copied MCP server tables
- preserve unrelated config, keep preparation idempotent, and leave the user's global config untouched
- document the HTTP 451 reconnecting failure mode and runtime ownership rule

This is runtime preparation policy, not a change to session/turn lifecycle semantics. The shared runtimeprep owner also keeps other Host consumers aligned.

## Verification

- `go test ./packages/agent/runtimeprep -run 'TestPrepareTuttiAgentHome(DisablesUnsupportedHostedFeatures|RemovesLegacyPinnedProvider|WritesResponsesModelPlanEndpoint)'`
- `pnpm check:changed` (6 lanes)
- pre-push `pnpm check:changed -- --push-ready` (7 lanes)

## Checklist

- [x] This does not change agent lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior changed.
- [x] README/CONTRIBUTING translations are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] The commit is signed off with DCO.