### PR TITLE
feat(agent-gui): graduate session input history

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -86,7 +86,6 @@ import {
   AGENT_SESSION_RECORDING_FLAG,
   AGENT_REFERENCE_PROVENANCE_FILTER_FLAG,
   isFeatureEnabled,
-  LAB_AGENT_INPUT_HISTORY_FLAG,
   LAB_AGENT_SESSION_FORK_FLAG,
   LAB_CODEX_SAVER_MODE_FLAG
 } from "../../../../../shared/featureFlags/catalog.ts";
@@ -538,10 +537,7 @@ function DesktopAgentGUISurfaceImpl({
     desktopPreferencesState.featureFlags,
     AGENT_REFERENCE_PROVENANCE_FILTER_FLAG
   );
-  const sessionInputHistoryEnabled = isFeatureEnabled(
-    desktopPreferencesState.featureFlags,
-    LAB_AGENT_INPUT_HISTORY_FLAG
-  );
+  const sessionInputHistoryEnabled = true;
   const sessionForkEnabled = isFeatureEnabled(
     desktopPreferencesState.featureFlags,
     LAB_AGENT_SESSION_FORK_FLAG

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceLabFeatureGateRows.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceLabFeatureGateRows.tsx
@@ -2,7 +2,6 @@ import { Switch } from "@tutti-os/ui-system";
 import { useTranslation } from "@renderer/i18n";
 import {
   EARLY_ACCESS_AGENT_INTEGRATIONS_FLAG,
-  LAB_AGENT_INPUT_HISTORY_FLAG,
   LAB_AUTOMATION_RULES_FLAG,
   LAB_WORKBENCH_SHORTCUTS_FLAG,
   isFeatureEnabled
@@ -20,12 +19,6 @@ const featureGateRows = [
     labelKey: "workspace.settings.lab.workbenchShortcutsLabel" as const,
     descriptionKey:
       "workspace.settings.lab.workbenchShortcutsDescription" as const
-  },
-  {
-    key: LAB_AGENT_INPUT_HISTORY_FLAG,
-    labelKey: "workspace.settings.lab.agentInputHistoryLabel" as const,
-    descriptionKey:
-      "workspace.settings.lab.agentInputHistoryDescription" as const
   },
   {
     key: EARLY_ACCESS_AGENT_INTEGRATIONS_FLAG,

--- a/apps/desktop/src/shared/featureFlags/catalog.test.ts
+++ b/apps/desktop/src/shared/featureFlags/catalog.test.ts
@@ -14,7 +14,6 @@ import {
   isFeatureEnabled,
   labFeatureDefinitions,
   LAB_ENABLED_FLAG,
-  LAB_AGENT_INPUT_HISTORY_FLAG,
   LAB_AGENT_SESSION_FORK_FLAG,
   LAB_AUTOMATION_RULES_FLAG,
   MOBILE_REMOTE_ACCESS_SETTINGS_FLAG,
@@ -104,7 +103,7 @@ test("labFeatureDefinitions excludes the master switch", () => {
 });
 
 test("experimental Agent features require independent Lab opt-ins", () => {
-  const flags = [LAB_AGENT_INPUT_HISTORY_FLAG, LAB_AUTOMATION_RULES_FLAG];
+  const flags = [LAB_AUTOMATION_RULES_FLAG];
 
   for (const flag of flags) {
     assert.equal(isFeatureEnabled({}, flag), false);
@@ -132,6 +131,7 @@ test("session Fork keeps its durable flag without appearing in Lab settings", ()
 test("graduated Agent features are not registered as Lab flags", () => {
   const definitions = labFeatureDefinitions();
   for (const retiredKey of [
+    "lab.agentInputHistory",
     "lab.tuttiMode",
     "lab.modelPlans",
     "lab.workspaceAgents"

--- a/apps/desktop/src/shared/featureFlags/catalog.ts
+++ b/apps/desktop/src/shared/featureFlags/catalog.ts
@@ -8,7 +8,6 @@ export const LAB_ENABLED_FLAG = "lab.enabled";
 export const BROWSER_CHROME_COOKIE_IMPORT_FLAG = "browser.chromeCookieImport";
 export const LAB_AUTOMATION_RULES_FLAG = "lab.automationRules";
 export const LAB_WORKBENCH_SHORTCUTS_FLAG = "lab.workbenchShortcuts";
-export const LAB_AGENT_INPUT_HISTORY_FLAG = "lab.agentInputHistory";
 export const LAB_AGENT_SESSION_FORK_FLAG = "lab.agentSessionFork";
 export const LAB_CODEX_SAVER_MODE_FLAG = "lab.codexSaverMode";
 // Keep the durable key for existing profiles while naming the product concept
@@ -168,13 +167,6 @@ export const FEATURE_FLAG_DEFINITIONS: readonly FeatureFlagDefinition[] = [
     group: "lab",
     labelKey: "workspace.settings.lab.workbenchShortcutsLabel",
     descriptionKey: "workspace.settings.lab.workbenchShortcutsDescription"
-  },
-  {
-    key: LAB_AGENT_INPUT_HISTORY_FLAG,
-    default: false,
-    group: "lab",
-    labelKey: "workspace.settings.lab.agentInputHistoryLabel",
-    descriptionKey: "workspace.settings.lab.agentInputHistoryDescription"
   },
   {
     key: LAB_AGENT_SESSION_FORK_FLAG,

--- a/apps/desktop/src/shared/i18n/locales/en.ts
+++ b/apps/desktop/src/shared/i18n/locales/en.ts
@@ -1292,9 +1292,6 @@ export const en = {
         visibilityLabel: "Show developer panel"
       },
       lab: {
-        agentInputHistoryDescription:
-          "Use Up and Down in Agent input to recall earlier prompts from the current session.",
-        agentInputHistoryLabel: "Agent input history",
         backLabel: "Back",
         automationRulesDescription:
           "Shows Automation Rule configuration and session overrides.",

--- a/apps/desktop/src/shared/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/shared/i18n/locales/zh-CN.ts
@@ -1211,9 +1211,6 @@ export const zhCN = {
         visibilityLabel: "显示开发者面板"
       },
       lab: {
-        agentInputHistoryDescription:
-          "在 Agent 输入框中使用上下键切换当前会话的历史输入",
-        agentInputHistoryLabel: "Agent 输入历史",
         backLabel: "返回",
         automationRulesDescription: "显示自动化规则配置与会话覆盖选项",
         automationRulesLabel: "自动化规则",

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1729,9 +1729,13 @@ projection cannot overwrite newer local input; a value not emitted locally
 remains an authoritative external replacement.
 
 An existing-Session composer derives input history from that Session's
-canonical user-message projection; it does not persist a second history store.
-The host must opt in explicitly; Desktop maps the default-off
-`lab.agentInputHistory` Lab preference to that capability.
+canonical user-message projection and its turnless Goal-control audit entries;
+it does not persist a second history store. These sources are merged by their
+timeline timestamps so Goal commands participate in the same Up/Down sequence
+as ordinary prompts.
+The host capability remains explicit so unsupported hosts can fail closed, but
+Tutti Desktop always supplies `sessionInputHistoryEnabled: true`; historical
+`lab.agentInputHistory` preference values do not hide or disable the feature.
 Bare Up/Down recalls older/newer structured drafts only from an empty composer
 or an unchanged recalled entry, and only when the collapsed caret is at a
 whole-document boundary. Palette handling and IME composition take precedence,

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerInputHistory.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerInputHistory.spec.ts
@@ -75,6 +75,52 @@ describe("agent composer input history", () => {
     ]);
   });
 
+  it("includes Goal controls in chronological input history", () => {
+    const conversation = conversationWithUserMessages([
+      {
+        id: "message-1",
+        body: "first prompt",
+        occurredAtUnixMs: 100
+      },
+      {
+        id: "message-2",
+        body: "second prompt",
+        occurredAtUnixMs: 300
+      }
+    ]);
+    conversation.sourceDetail.goalControls = [
+      {
+        id: "goal-control-1",
+        action: "set",
+        body: "/goal ship it",
+        occurredAtUnixMs: 200
+      }
+    ];
+
+    const history = projectAgentComposerInputHistory(conversation);
+
+    expect(
+      history.map((entry) => agentComposerDraftPrompt(entry.draft))
+    ).toEqual(["first prompt", "/goal ship it", "second prompt"]);
+
+    const latest = navigateAgentComposerInputHistory({
+      currentDraft: emptyAgentComposerDraft(),
+      direction: "older",
+      entries: history,
+      hasOlderPage: false,
+      state: EMPTY_AGENT_COMPOSER_INPUT_HISTORY_STATE
+    });
+    const goal = navigateAgentComposerInputHistory({
+      currentDraft: latest.draft!,
+      direction: "older",
+      entries: history,
+      hasOlderPage: false,
+      state: latest.state
+    });
+
+    expect(agentComposerDraftPrompt(goal.draft!)).toBe("/goal ship it");
+  });
+
   it("does not restore a synthetic image-only display prompt as text", () => {
     const history = projectAgentComposerInputHistory(
       conversationWithUserMessages([
@@ -361,6 +407,7 @@ function conversationWithUserMessages(
   messages: Array<{
     id: string;
     body: string;
+    occurredAtUnixMs?: number | null;
     sourceTimelineItems?: Array<{
       payload: Record<string, unknown>;
     }>;

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerInputHistory.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerInputHistory.ts
@@ -1,5 +1,6 @@
 import type { AgentPromptContentBlock } from "../../../shared/contracts/dto";
 import type { AgentConversationVM } from "../../../shared/agentConversation/contracts/agentConversationVM";
+import type { WorkspaceAgentSessionDetailGoalControl } from "../../../shared/workspaceAgentSessionDetailViewModel";
 import type { AgentComposerDraft } from "./agentGuiNodeTypes";
 import {
   agentComposerDraftHasContent,
@@ -36,6 +37,12 @@ const inputHistoryByConversation = new WeakMap<
   AgentComposerInputHistoryEntry[]
 >();
 
+interface ProjectedHistoryEntry {
+  entry: AgentComposerInputHistoryEntry;
+  occurredAtUnixMs: number | null;
+  sequence: number;
+}
+
 export function projectAgentComposerInputHistory(
   conversation: AgentConversationVM | null
 ): AgentComposerInputHistoryEntry[] {
@@ -46,24 +53,44 @@ export function projectAgentComposerInputHistory(
   if (cached) {
     return cached;
   }
+  const projectedEntries: ProjectedHistoryEntry[] = [];
+  let sequence = 0;
+  const append = (
+    entry: AgentComposerInputHistoryEntry | null,
+    occurredAtUnixMs?: number | null
+  ): void => {
+    if (!entry) {
+      return;
+    }
+    projectedEntries.push({
+      entry,
+      occurredAtUnixMs: occurredAtUnixMs ?? null,
+      sequence: sequence++
+    });
+  };
+
   const entries: AgentComposerInputHistoryEntry[] = [];
   for (const turn of conversation.sourceDetail.turns) {
     for (const message of turn.userMessages) {
-      const entry = projectHistoryEntry(message, turn.id);
-      if (!entry) {
-        continue;
-      }
-      const previous = entries.at(-1);
-      if (
-        previous &&
-        historyEntryDuplicateKey(previous) === historyEntryDuplicateKey(entry)
-      ) {
-        // Keep the newest duplicate id. Prepending an older page then cannot
-        // invalidate a cursor that already points at the loaded copy.
-        entries[entries.length - 1] = entry;
-      } else {
-        entries.push(entry);
-      }
+      append(projectHistoryEntry(message, turn.id), message.occurredAtUnixMs);
+    }
+  }
+  for (const control of conversation.sourceDetail.goalControls ?? []) {
+    append(projectGoalControlHistoryEntry(control), control.occurredAtUnixMs);
+  }
+
+  projectedEntries.sort(compareProjectedHistoryEntries);
+  for (const { entry } of projectedEntries) {
+    const previous = entries.at(-1);
+    if (
+      previous &&
+      historyEntryDuplicateKey(previous) === historyEntryDuplicateKey(entry)
+    ) {
+      // Keep the newest duplicate id. Prepending an older page then cannot
+      // invalidate a cursor that already points at the loaded copy.
+      entries[entries.length - 1] = entry;
+    } else {
+      entries.push(entry);
     }
   }
   inputHistoryByConversation.set(conversation, entries);
@@ -226,6 +253,33 @@ function projectHistoryEntry(
     })
   );
   return entry;
+}
+
+function projectGoalControlHistoryEntry(
+  control: WorkspaceAgentSessionDetailGoalControl
+): AgentComposerInputHistoryEntry | null {
+  const draft = buildAgentComposerDraft({ prompt: control.body });
+  if (!agentComposerDraftHasContent(draft)) {
+    return null;
+  }
+  return {
+    id: `goal-control:${control.id}`,
+    draft
+  };
+}
+
+function compareProjectedHistoryEntries(
+  left: ProjectedHistoryEntry,
+  right: ProjectedHistoryEntry
+): number {
+  if (
+    left.occurredAtUnixMs !== null &&
+    right.occurredAtUnixMs !== null &&
+    left.occurredAtUnixMs !== right.occurredAtUnixMs
+  ) {
+    return left.occurredAtUnixMs - right.occurredAtUnixMs;
+  }
+  return left.sequence - right.sequence;
 }
 
 const historyDuplicateKeyByEntry = new WeakMap<


### PR DESCRIPTION
## Summary
- Graduate session input history from Labs and enable it by default in Tutti Desktop.
- Include turnless Goal-control audit entries in chronological Up/Down history.
- Keep unsupported hosts fail-closed and document the ownership/data flow.

## Tests
- `pnpm check:changed -- --push-ready` (17 lanes)
- `pnpm --filter @tutti-os/agent-gui test -- agent-gui/agentGuiNode/model/agentComposerInputHistory.spec.ts`

## Notes
- Two unrelated untracked screenshots were intentionally excluded.
- The branch is six commits behind `main`; it was not rebased per repository PR workflow.