### PR TITLE
fix(agent): 修复终端登录后的就绪判定

### DIFF
--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -2289,3 +2289,34 @@ invalid_grant`. Search `tuttid.log` for
   [runtime-overrides.md](../runtime-overrides.md)
   [visible_error.go](../../../packages/agent/daemon/runtime/visible_error.go)
   [setup.go](../../../services/tuttid/service/agentextension/setup.go)
+
+### Terminal login succeeds but the setup terminal remains open
+
+- Symptom:
+  The provider's terminal login reports success and returns to its normal TUI,
+  but AgentGUI keeps the setup terminal open and continues polling the Target as
+  `auth_required`.
+- Quick checks:
+  Confirm the Desktop terminal diagnostic reports the startup action as
+  `submitted`, then inspect repeated Target setup probes. Compare the fresh ACP
+  `initialize` response with `session/new`: some runtimes keep advertising a
+  terminal login method even after authentication succeeds.
+- Root cause:
+  ACP `authMethods` is a catalog of available authentication methods, not the
+  current authentication state. Treating a terminal-only catalog as an
+  immediate `auth_required` verdict skips `session/new`, so a successfully
+  configured runtime can never become `ready` and the Host never closes its
+  login-terminal handle.
+- Fix:
+  Preserve the advertised methods for presentation, but verify readiness with
+  the bounded setup `session/new` probe. Continue mapping explicit
+  authentication, missing-model, missing-provider, and terminal-method timeout
+  outcomes to `auth_required`. Do not scrape terminal output or inject an exit
+  command to infer login completion.
+- Validation:
+  Cover a runtime that still advertises only a terminal login method while
+  `session/new` returns a usable model, plus unconfigured runtimes whose
+  `session/new` returns no usable model, a missing-provider error, or a timeout.
+- References:
+  [standard_acp_setup.go](../../../packages/agent/daemon/runtime/standard_acp_setup.go)
+  [desktopTerminalLoginReadinessMonitor.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopTerminalLoginReadinessMonitor.ts)

--- a/packages/agent/daemon/runtime/standard_acp_setup.go
+++ b/packages/agent/daemon/runtime/standard_acp_setup.go
@@ -37,13 +37,6 @@ var ErrACPAuthMethodTerminal = errors.New("ACP auth method requires an interacti
 // classifier so only the explicit errors.Is mapping classifies it.
 var ErrACPSetupNoUsableModel = errors.New("ACP agent created a session without any usable model")
 
-// errACPSetupInteractiveAuthRequired lets setup finish as auth_required when
-// an agent advertises only terminal authentication methods. Calling
-// session/new before the user completes that flow is both unnecessary and,
-// for some Python agents, can block while trying to resolve an unconfigured
-// model provider.
-var errACPSetupInteractiveAuthRequired = errors.New("ACP setup requires interactive terminal authentication")
-
 type StandardACPSetupStatus string
 
 const (
@@ -109,9 +102,6 @@ func RunStandardACPSetup(
 	adapter.config.beforeNewSession = func(ctx context.Context, client *acpClient, session Session, initializeResult json.RawMessage) error {
 		methods = parseStandardACPAuthMethods(initializeResult)
 		if methodID == "" {
-			if standardACPSetupRequiresInteractiveAuth(methods) {
-				return errACPSetupInteractiveAuthRequired
-			}
 			return nil
 		}
 		method := findStandardACPAuthMethod(methods, methodID)
@@ -148,9 +138,6 @@ func RunStandardACPSetup(
 		}
 	}
 	if _, err := adapter.Start(ctx, session); err != nil {
-		if errors.Is(err, errACPSetupInteractiveAuthRequired) {
-			return StandardACPSetupResult{Status: StandardACPSetupAuthRequired, AuthMethods: methods}, nil
-		}
 		if errors.Is(err, ErrACPAuthMethodTerminal) {
 			return StandardACPSetupResult{Status: StandardACPSetupAuthRequired, AuthMethods: methods}, err
 		}
@@ -182,18 +169,6 @@ func RunStandardACPSetup(
 		return StandardACPSetupResult{}, fmt.Errorf("close ACP setup session: %w", err)
 	}
 	return StandardACPSetupResult{Status: StandardACPSetupReady, AuthMethods: methods, Account: account}, nil
-}
-
-func standardACPSetupRequiresInteractiveAuth(methods []StandardACPAuthMethod) bool {
-	if len(methods) == 0 {
-		return false
-	}
-	for _, method := range methods {
-		if strings.TrimSpace(method.Type) != "terminal" {
-			return false
-		}
-	}
-	return true
 }
 
 func standardACPSetupHasInteractiveAuth(methods []StandardACPAuthMethod) bool {

--- a/packages/agent/daemon/runtime/standard_acp_setup_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_setup_test.go
@@ -200,6 +200,40 @@ func TestRunStandardACPSetupFlagsSessionWithoutUsableModel(t *testing.T) {
 	if method := result.AuthMethods[0]; method.Type != "terminal" || len(method.Args) != 1 || method.Args[0] != "login" {
 		t.Fatalf("terminal auth method = %#v", method)
 	}
+	if transport.conn.lastNewSessionParams == nil {
+		t.Fatal("probe must verify readiness through session/new")
+	}
+}
+
+func TestRunStandardACPSetupReadyWhenTerminalMethodRemainsAdvertised(t *testing.T) {
+	t.Parallel()
+
+	// Kimi Code continues advertising its terminal login method after setup.
+	// The method catalog is not an authentication verdict: a usable session/new
+	// result remains the authoritative ready signal.
+	transport := newStandardACPTransport("Example Agent", "setup-session")
+	transport.conn.authMethods = []map[string]any{{
+		"id": "login", "name": "Login with Example account",
+		"type": "terminal", "args": []any{"login"},
+	}}
+	transport.conn.models = map[string]any{
+		"availableModels": []any{map[string]any{"modelId": "example-model", "name": "Example Model"}},
+		"currentModelId":  "example-model",
+	}
+
+	result, err := runStandardACPSetupTest(t, transport, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != StandardACPSetupReady || len(result.AuthMethods) != 1 {
+		t.Fatalf("setup result = %#v", result)
+	}
+	if transport.conn.lastNewSessionParams == nil {
+		t.Fatal("probe must verify readiness through session/new")
+	}
+	if got := transport.conn.authenticatedMethodID(); got != "" {
+		t.Fatalf("authenticated method id = %q, want no ACP authenticate call", got)
+	}
 }
 
 func TestRunStandardACPSetupOffersTerminalConfigurationForMissingProvider(t *testing.T) {
@@ -226,6 +260,9 @@ func TestRunStandardACPSetupOffersTerminalConfigurationForMissingProvider(t *tes
 	if method := result.AuthMethods[0]; method.ID != "agent-setup" || method.Type != "terminal" ||
 		len(method.Args) != 1 || method.Args[0] != "--setup" {
 		t.Fatalf("terminal configuration method = %#v", method)
+	}
+	if transport.conn.lastNewSessionParams == nil {
+		t.Fatal("probe must inspect session/new before classifying missing configuration")
 	}
 }
 


### PR DESCRIPTION
## 背景

#2023 已支持从 Kimi TUI 自动提交 `/login`，并在 Agent Target 变为 `ready` 后关闭登录终端。但 Kimi Code 0.30.0 登录成功后仍会在 ACP `initialize` 中持续声明 terminal 类型的 `login` 方法。

## 根因

`authMethods` 是运行时提供的认证方式目录，不代表当前认证状态。Standard ACP setup probe 之前看到“全部是 terminal 方法”就直接返回 `auth_required`，跳过了 `session/new`；因此登录后的轮询永远得不到 `ready`，现有终端关闭句柄也不会执行。

## 修改

- 移除 terminal-only `authMethods` 的提前 `auth_required` 判定
- 保留认证方式用于 UI 展示，并通过有界的 `session/new` 探测真实 readiness
- 继续把显式认证失败、无可用模型、缺失 Provider 和 terminal 方法超时映射为 `auth_required`
- 增加“登录后仍声明 terminal 方法但 session 可用”的回归测试
- 补充 Agent Provider setup 排障文档

## 用户影响

Kimi 登录成功并返回正常 TUI 后，Agent Target 可以正确转为 `ready`，Tutti 随即关闭登录专用终端。未完成配置或认证失败的运行时仍保持 `auth_required`。

## 验证

- `go test ./packages/agent/daemon/runtime ./services/tuttid/service/agentextension`
- `pnpm check:changed -- --push-ready --base upstream/main`（8 lanes）
- `git diff --check`
- `gofmt -d packages/agent/daemon/runtime/standard_acp_setup.go packages/agent/daemon/runtime/standard_acp_setup_test.go`
- 本地 Prettier 检查通过

## 依赖

- 基础终端登录能力来自已合入的 #2023
