### PR TITLE
fix(workspace-apps): preserve failure phase semantics

### DIFF
--- a/.changeset/workspace-app-failure-phases.md
+++ b/.changeset/workspace-app-failure-phases.md
@@ -1,0 +1,6 @@
+---
+"@tutti-os/workspace-app-center": patch
+---
+
+Preserve workspace app failure phases and show installation, startup, runtime,
+or neutral legacy failure copy on shared app cards.

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/adapters/desktopWorkspaceAppCenterGateway.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/adapters/desktopWorkspaceAppCenterGateway.test.ts
@@ -88,6 +88,7 @@ test("Workspace App Center gateway preserves app failure details", () => {
   const app = normalizeWorkspaceAppCenterApp(
     createWorkspaceApp({
       appId: "broken",
+      failurePhase: "installing",
       failureReason: "install script exited 1",
       installed: false,
       lastError: "npm install failed",
@@ -98,6 +99,7 @@ test("Workspace App Center gateway preserves app failure details", () => {
 
   assert.equal(app.runtimeStatus, "failed");
   assert.equal(app.failureReason, "install script exited 1");
+  assert.equal(app.failurePhase, "installing");
   assert.equal(app.lastError, "npm install failed");
 });
 

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/adapters/desktopWorkspaceAppCenterGateway.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/adapters/desktopWorkspaceAppCenterGateway.ts
@@ -16,6 +16,7 @@ import type {
   WorkspaceAppCenterCatalogStatus,
   WorkspaceAppCenterGateway,
   WorkspaceAppCenterLocalization,
+  WorkspaceAppFailurePhase,
   WorkspaceAppCenterSource,
   WorkspaceAppCenterRuntimeStatus,
   WorkspaceAppCenterSnapshot
@@ -60,6 +61,7 @@ export interface WorkspaceAppLike {
   readonly enabled: boolean;
   readonly exportable: boolean;
   readonly failureReason?: string | null;
+  readonly failurePhase?: WorkspaceAppFailurePhase | null;
   readonly iconUrl?: string | null;
   readonly installed: boolean;
   readonly installationId?: string | null;
@@ -342,6 +344,7 @@ export function normalizeWorkspaceAppCenterApp(
     enabled: app.enabled,
     exportable: app.exportable,
     failureReason: app.failureReason ?? null,
+    failurePhase: app.failurePhase ?? undefined,
     iconUrl: app.iconUrl,
     installProgress: normalizeWorkspaceAppInstallProgress(app.installProgress),
     installed: app.installed,

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterService.test.ts
@@ -520,6 +520,7 @@ test("WorkspaceAppCenterService tracks accepted runtime failure transitions once
   eventStream.publishWorkspaceAppUpdated(
     createProtocolApp({
       appId: "app-1",
+      failurePhase: "runtime",
       failureReason: "process exited",
       status: "failed",
       stateRevision: 3
@@ -528,6 +529,7 @@ test("WorkspaceAppCenterService tracks accepted runtime failure transitions once
   eventStream.publishWorkspaceAppUpdated(
     createProtocolApp({
       appId: "app-1",
+      failurePhase: "runtime",
       failureReason: "process exited",
       status: "failed",
       stateRevision: 3
@@ -535,6 +537,7 @@ test("WorkspaceAppCenterService tracks accepted runtime failure transitions once
   );
 
   assert.equal(service.store.apps[0]?.runtimeStatus, "failed");
+  assert.equal(service.store.apps[0]?.failurePhase, "runtime");
   assert.deepEqual(reporterCalls, [
     [
       {

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/ui/WorkspaceAppCenterPane.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/ui/WorkspaceAppCenterPane.tsx
@@ -605,6 +605,22 @@ function toWorkspaceAppRuntimeState(
     app.cli?.status === "warning" || app.cli?.status === "error"
       ? app.cli.issues[0]
       : null;
+  const failureMessage =
+    app.runtimeStatus === "failed"
+      ? app.failureReason?.trim() || app.lastError?.trim() || null
+      : null;
+  const runtimeError =
+    app.runtimeStatus === "failed" && (failureMessage || app.failurePhase)
+      ? {
+          message: failureMessage ?? "",
+          ...(app.failurePhase ? { failurePhase: app.failurePhase } : {})
+        }
+      : cliIssue
+        ? {
+            code: cliIssue.code,
+            message: cliIssue.message
+          }
+        : null;
   return {
     ...(app.runtimeId?.trim() ? { runtimeId: app.runtimeId.trim() } : {}),
     ...(app.installationId?.trim()
@@ -613,14 +629,7 @@ function toWorkspaceAppRuntimeState(
     appId: app.appId,
     launchUrl: app.launchUrl ?? null,
     ...(app.installProgress ? { installProgress: app.installProgress } : {}),
-    ...(cliIssue
-      ? {
-          error: {
-            code: cliIssue.code,
-            message: cliIssue.message
-          }
-        }
-      : {}),
+    ...(runtimeError ? { error: runtimeError } : {}),
     status:
       app.installProgress != null || app.runtimeStatus === "installing"
         ? "installing"

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -1402,6 +1402,7 @@ export type WorkspaceApp = {
   launchUrl: string | null;
   port: number | null;
   failureReason: string | null;
+  failurePhase?: "downloading" | "installing" | "starting" | "runtime";
   lastError: string | null;
   startedAtUnixMs: number | null;
   updatedAtUnixMs: number | null;

--- a/packages/events/protocol/schemas/topics/workspace/workspace-app.schema.json
+++ b/packages/events/protocol/schemas/topics/workspace/workspace-app.schema.json
@@ -119,6 +119,10 @@
     "failureReason": {
       "type": ["string", "null"]
     },
+    "failurePhase": {
+      "type": ["string", "null"],
+      "enum": ["downloading", "installing", "starting", "runtime", null]
+    },
     "lastError": {
       "type": ["string", "null"]
     },

--- a/packages/events/protocol/src/generated/contracts.ts
+++ b/packages/events/protocol/src/generated/contracts.ts
@@ -214,6 +214,7 @@ export interface WorkspaceWorkspaceAppV1 {
   launchUrl: string | null;
   port: number | null;
   failureReason: string | null;
+  failurePhase?: "downloading" | "installing" | "starting" | "runtime" | null;
   lastError: string | null;
   startedAtUnixMs: number | null;
   updatedAtUnixMs: number | null;

--- a/packages/events/protocol/src/generated/registry.ts
+++ b/packages/events/protocol/src/generated/registry.ts
@@ -55,7 +55,7 @@ export interface BusinessEventDefinition {
   scope: BusinessEventScopeName;
 }
 
-export const businessEventCatalogRevision = "sha256:4ad6cabfbf1a1951" as const;
+export const businessEventCatalogRevision = "sha256:d3cf3b4c5b26811b" as const;
 
 export const businessEventDefinitions = [
   {

--- a/packages/events/protocol/src/generated/schemas.ts
+++ b/packages/events/protocol/src/generated/schemas.ts
@@ -611,6 +611,10 @@ export const workspaceWorkspaceAppSchema = {
     failureReason: {
       type: ["string", "null"]
     },
+    failurePhase: {
+      type: ["string", "null"],
+      enum: ["downloading", "installing", "starting", "runtime", null]
+    },
     lastError: {
       type: ["string", "null"]
     },
@@ -2715,6 +2719,10 @@ export const workspaceAppUpdatedPayloadSchema = {
         },
         failureReason: {
           type: ["string", "null"]
+        },
+        failurePhase: {
+          type: ["string", "null"],
+          enum: ["downloading", "installing", "starting", "runtime", null]
         },
         lastError: {
           type: ["string", "null"]

--- a/packages/workspace/app-center/README.md
+++ b/packages/workspace/app-center/README.md
@@ -4,6 +4,19 @@ Host-neutral workspace app center contracts, validation, status mapping, view-mo
 
 The package does not construct daemon clients, access desktop preload APIs, resolve host paths, spawn processes, or register workbench or dock contributions.
 
+## Runtime Failure Semantics
+
+Runtime status remains a lifecycle status, so all terminal failures use
+`failed`. Hosts should attach `WorkspaceAppRuntimeError.failurePhase` to retain
+where the failure occurred: `downloading`, `installing`, `starting`, or
+`runtime`. Host adapters may carry the same phase on `WorkspaceAppCenterApp`
+before projecting the runtime state. The shared card uses that optional phase for accurate failure copy
+and falls back to a neutral runtime failure for older hosts.
+
+Do not add compound statuses such as `install_failed` or `start_failed`.
+Keeping outcome and failure phase orthogonal lets hosts preserve their existing
+install and runtime event hooks while sharing one compatible status machine.
+
 ## Runtime Refresh Policy
 
 `createWorkspaceAppCenterController` defaults to `refreshPolicy: "poll"` for

--- a/packages/workspace/app-center/src/contracts/host.ts
+++ b/packages/workspace/app-center/src/contracts/host.ts
@@ -1,4 +1,5 @@
 import type {
+  WorkspaceAppFailurePhase,
   WorkspaceAppInstallProgress,
   WorkspaceAppInstallUserPhase,
   WorkspaceAppRuntimeStatus
@@ -7,7 +8,11 @@ import type { WorkspaceAppFactoryJobStatus } from "./viewModel.ts";
 
 export type WorkspaceAppCenterRuntimeStatus = WorkspaceAppRuntimeStatus;
 
-export type { WorkspaceAppInstallProgress, WorkspaceAppInstallUserPhase };
+export type {
+  WorkspaceAppFailurePhase,
+  WorkspaceAppInstallProgress,
+  WorkspaceAppInstallUserPhase
+};
 
 export type WorkspaceAppCenterSource =
   | "builtin"
@@ -68,6 +73,7 @@ export interface WorkspaceAppCenterApp {
   createdAtUnixMs: number;
   enabled: boolean;
   exportable: boolean;
+  failurePhase?: WorkspaceAppFailurePhase;
   failureReason?: string | null;
   iconUrl?: string | null;
   installProgress?: WorkspaceAppInstallProgress | null;

--- a/packages/workspace/app-center/src/contracts/index.ts
+++ b/packages/workspace/app-center/src/contracts/index.ts
@@ -49,6 +49,9 @@ export {
 } from "./catalog.ts";
 export {
   workspaceAppRuntimeStatuses,
+  type WorkspaceAppFailurePhase,
+  type WorkspaceAppInstallProgress,
+  type WorkspaceAppInstallUserPhase,
   type WorkspaceAppRuntimeError,
   type WorkspaceAppRuntimeState,
   type WorkspaceAppRuntimeStatus

--- a/packages/workspace/app-center/src/contracts/runtime.ts
+++ b/packages/workspace/app-center/src/contracts/runtime.ts
@@ -15,6 +15,7 @@ export type WorkspaceAppRuntimeStatus =
 
 export interface WorkspaceAppRuntimeError {
   readonly code?: string;
+  readonly failurePhase?: WorkspaceAppFailurePhase;
   readonly message: string;
 }
 
@@ -22,6 +23,8 @@ export type WorkspaceAppInstallUserPhase =
   | "downloading"
   | "installing"
   | "starting";
+
+export type WorkspaceAppFailurePhase = WorkspaceAppInstallUserPhase | "runtime";
 
 export interface WorkspaceAppInstallProgress {
   readonly userPhase: WorkspaceAppInstallUserPhase;

--- a/packages/workspace/app-center/src/contracts/viewModel.ts
+++ b/packages/workspace/app-center/src/contracts/viewModel.ts
@@ -1,7 +1,10 @@
-import type { WorkspaceAppRuntimeStatus } from "./runtime.ts";
 import type { WorkspaceAppCatalogSourceKind } from "./catalog.ts";
-import type { WorkspaceAppInstallProgress } from "./runtime.ts";
 import type { WorkspaceAppCategoryId } from "./catalog.ts";
+import type {
+  WorkspaceAppFailurePhase,
+  WorkspaceAppInstallProgress,
+  WorkspaceAppRuntimeStatus
+} from "./runtime.ts";
 
 export type WorkspaceAppStatusTone =
   | "neutral"
@@ -76,6 +79,7 @@ export interface WorkspaceAppCardViewModel {
   readonly canUninstall: boolean;
   readonly canRetry: boolean;
   readonly canUpdate: boolean;
+  readonly failurePhase?: WorkspaceAppFailurePhase;
   readonly errorMessage?: string;
   readonly installProgress?: WorkspaceAppInstallProgress | null;
   readonly factoryEditAction?: WorkspaceAppFactoryEditAction | null;

--- a/packages/workspace/app-center/src/core/appCenterController.test.ts
+++ b/packages/workspace/app-center/src/core/appCenterController.test.ts
@@ -1451,6 +1451,312 @@ test("WorkspaceAppCenterController clears pending install when backend job disap
   );
 });
 
+test("WorkspaceAppCenterController reports a pending install failure only through the install hook", async () => {
+  const installFailures: unknown[] = [];
+  const runtimeFailures: unknown[] = [];
+  const controller = createWorkspaceAppCenterController({
+    formatError,
+    gateway: createGateway({
+      async installWorkspaceApp() {
+        return createSnapshot({
+          apps: [
+            createApp({
+              appId: "app-1",
+              installed: false,
+              runtimeStatus: "installing",
+              stateRevision: 2
+            })
+          ]
+        });
+      }
+    }),
+    hooks: {
+      onAppInstallFailed(input) {
+        installFailures.push(input);
+      },
+      onAppRuntimeFailed(input) {
+        runtimeFailures.push(input);
+      }
+    },
+    refreshPolicy: "event"
+  });
+  controller.applySnapshot(
+    "workspace-1",
+    createSnapshot({
+      apps: [createApp({ appId: "app-1", installed: false })]
+    })
+  );
+  controller.beginWorkspacePolling("workspace-1");
+  await controller.installApp({ appId: "app-1", workspaceId: "workspace-1" });
+
+  controller.applyAppUpdate({
+    app: createApp({
+      appId: "app-1",
+      failurePhase: "downloading",
+      failureReason: "network interrupted",
+      installed: false,
+      runtimeStatus: "failed",
+      stateRevision: 3
+    }),
+    failureReason: "network interrupted",
+    operationCursor: {
+      desiredGeneration: 1,
+      operationId: "operation-install-failed",
+      sequence: 1
+    },
+    workspaceId: "workspace-1"
+  });
+
+  assert.equal(installFailures.length, 1);
+  assert.equal(runtimeFailures.length, 0);
+  controller.endWorkspacePolling("workspace-1");
+});
+
+test("WorkspaceAppCenterController reports a pending starting failure through the runtime hook", async () => {
+  const installedApps: unknown[] = [];
+  const installFailures: unknown[] = [];
+  const runtimeFailures: unknown[] = [];
+  const controller = createWorkspaceAppCenterController({
+    formatError,
+    gateway: createGateway({
+      async installWorkspaceApp() {
+        return createSnapshot({
+          apps: [
+            createApp({
+              appId: "app-1",
+              installed: false,
+              runtimeStatus: "installing",
+              stateRevision: 2
+            })
+          ]
+        });
+      }
+    }),
+    hooks: {
+      onAppInstalled(app) {
+        installedApps.push(app);
+      },
+      onAppInstallFailed(input) {
+        installFailures.push(input);
+      },
+      onAppRuntimeFailed(input) {
+        runtimeFailures.push(input);
+      }
+    },
+    refreshPolicy: "event"
+  });
+  controller.applySnapshot(
+    "workspace-1",
+    createSnapshot({
+      apps: [createApp({ appId: "app-1", installed: false })]
+    })
+  );
+  controller.beginWorkspacePolling("workspace-1");
+  await controller.installApp({ appId: "app-1", workspaceId: "workspace-1" });
+
+  controller.applyAppUpdate({
+    app: createApp({
+      appId: "app-1",
+      failurePhase: "starting",
+      failureReason: "health check failed",
+      installed: true,
+      runtimeStatus: "failed",
+      stateRevision: 3
+    }),
+    failureReason: "health check failed",
+    operationCursor: {
+      desiredGeneration: 1,
+      operationId: "operation-start-failed",
+      sequence: 1
+    },
+    workspaceId: "workspace-1"
+  });
+
+  assert.equal(installedApps.length, 1);
+  assert.equal(installFailures.length, 0);
+  assert.equal(runtimeFailures.length, 1);
+  controller.endWorkspacePolling("workspace-1");
+});
+
+test("WorkspaceAppCenterController reports a legacy pending installed failure through the runtime hook", async () => {
+  const installedApps: unknown[] = [];
+  const installFailures: unknown[] = [];
+  const runtimeFailures: unknown[] = [];
+  const controller = createWorkspaceAppCenterController({
+    formatError,
+    gateway: createGateway({
+      async installWorkspaceApp() {
+        return createSnapshot({
+          apps: [
+            createApp({
+              appId: "app-1",
+              installed: false,
+              runtimeStatus: "installing",
+              stateRevision: 2
+            })
+          ]
+        });
+      }
+    }),
+    hooks: {
+      onAppInstalled(app) {
+        installedApps.push(app);
+      },
+      onAppInstallFailed(input) {
+        installFailures.push(input);
+      },
+      onAppRuntimeFailed(input) {
+        runtimeFailures.push(input);
+      }
+    },
+    refreshPolicy: "event"
+  });
+  controller.applySnapshot(
+    "workspace-1",
+    createSnapshot({
+      apps: [createApp({ appId: "app-1", installed: false })]
+    })
+  );
+  controller.beginWorkspacePolling("workspace-1");
+  await controller.installApp({ appId: "app-1", workspaceId: "workspace-1" });
+
+  controller.applyAppUpdate({
+    app: createApp({
+      appId: "app-1",
+      failureReason: "legacy startup failed",
+      installed: true,
+      runtimeStatus: "failed",
+      stateRevision: 3
+    }),
+    failureReason: "legacy startup failed",
+    operationCursor: {
+      desiredGeneration: 1,
+      operationId: "operation-legacy-start-failed",
+      sequence: 1
+    },
+    workspaceId: "workspace-1"
+  });
+
+  assert.equal(installedApps.length, 1);
+  assert.equal(installFailures.length, 0);
+  assert.equal(runtimeFailures.length, 1);
+  controller.endWorkspacePolling("workspace-1");
+});
+
+test("WorkspaceAppCenterController classifies an external installing failure as an install failure", () => {
+  const installFailures: unknown[] = [];
+  const runtimeFailures: unknown[] = [];
+  const controller = createWorkspaceAppCenterController({
+    formatError,
+    gateway: createGateway(),
+    hooks: {
+      onAppInstallFailed(input) {
+        installFailures.push(input);
+      },
+      onAppRuntimeFailed(input) {
+        runtimeFailures.push(input);
+      }
+    },
+    refreshPolicy: "event"
+  });
+  controller.applySnapshot(
+    "workspace-1",
+    createSnapshot({
+      apps: [createApp({ appId: "app-1", installed: false })]
+    })
+  );
+  controller.beginWorkspacePolling("workspace-1");
+
+  controller.applyAppUpdate({
+    app: createApp({
+      appId: "app-1",
+      failurePhase: "installing",
+      failureReason: "archive verification failed",
+      installed: false,
+      runtimeStatus: "failed",
+      stateRevision: 2
+    }),
+    failureReason: "archive verification failed",
+    operationCursor: {
+      desiredGeneration: 1,
+      operationId: "operation-external-install-failed",
+      sequence: 1
+    },
+    workspaceId: "workspace-1"
+  });
+
+  assert.equal(installFailures.length, 1);
+  assert.equal(runtimeFailures.length, 0);
+  controller.endWorkspacePolling("workspace-1");
+});
+
+test("WorkspaceAppCenterController reports an installed update artifact failure as install failure", async () => {
+  const installedApps: unknown[] = [];
+  const installFailures: unknown[] = [];
+  const controller = createWorkspaceAppCenterController({
+    formatError,
+    gateway: createGateway({
+      async installWorkspaceApp() {
+        return createSnapshot({
+          apps: [
+            createApp({
+              appId: "app-1",
+              installed: true,
+              runtimeStatus: "installing",
+              stateRevision: 2,
+              updateAvailable: false
+            })
+          ]
+        });
+      }
+    }),
+    hooks: {
+      onAppInstalled(app) {
+        installedApps.push(app);
+      },
+      onAppInstallFailed(input) {
+        installFailures.push(input);
+      }
+    },
+    refreshPolicy: "event"
+  });
+  controller.applySnapshot(
+    "workspace-1",
+    createSnapshot({
+      apps: [createApp({ appId: "app-1", updateAvailable: true })]
+    })
+  );
+  controller.beginWorkspacePolling("workspace-1");
+  await controller.updateApp({
+    appId: "app-1",
+    trigger: "primary_action",
+    workspaceId: "workspace-1"
+  });
+
+  controller.applyAppUpdate({
+    app: createApp({
+      appId: "app-1",
+      failurePhase: "downloading",
+      failureReason: "download exhausted retries",
+      installed: true,
+      runtimeStatus: "failed",
+      stateRevision: 3,
+      updateAvailable: false
+    }),
+    failureReason: "download exhausted retries",
+    operationCursor: {
+      desiredGeneration: 1,
+      operationId: "operation-update-download-failed",
+      sequence: 1
+    },
+    workspaceId: "workspace-1"
+  });
+
+  assert.equal(installedApps.length, 0);
+  assert.equal(installFailures.length, 1);
+  controller.endWorkspacePolling("workspace-1");
+});
+
 test("WorkspaceAppCenterController preserves pending install progress across catalog refresh", async () => {
   const controller = createWorkspaceAppCenterController({
     formatError: formatError,

--- a/packages/workspace/app-center/src/core/appCenterControllerState.ts
+++ b/packages/workspace/app-center/src/core/appCenterControllerState.ts
@@ -139,13 +139,39 @@ export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCent
     const acceptedRuntimeTransition =
       operationAdvance === true ||
       input.app.stateRevision > currentApp.stateRevision;
+    const installKey = appRuntimeKey(input.workspaceId, input.app.appId);
+    const installPending = this.pendingInstallKeys.has(installKey);
+    const pendingInstallReportsThroughSettlement =
+      this.pendingInstallReportKeys.has(installKey);
+    const failedDuringInstall =
+      input.app.failurePhase === "downloading" ||
+      input.app.failurePhase === "installing";
+    const failedDuringRuntime =
+      input.app.failurePhase === "starting" ||
+      input.app.failurePhase === "runtime";
     if (
       acceptedRuntimeTransition &&
       input.app.runtimeStatus === "failed" &&
-      currentApp.runtimeStatus !== "failed"
+      currentApp.runtimeStatus !== "failed" &&
+      (failedDuringRuntime ||
+        (input.app.failurePhase == null &&
+          (!installPending || input.app.installed)))
     ) {
       this.dependencies.hooks?.onAppRuntimeFailed?.({
         app: input.app,
+        failureReason: input.failureReason ?? null
+      });
+    }
+    if (
+      acceptedRuntimeTransition &&
+      input.app.runtimeStatus === "failed" &&
+      currentApp.runtimeStatus !== "failed" &&
+      failedDuringInstall &&
+      (!installPending || !pendingInstallReportsThroughSettlement)
+    ) {
+      this.dependencies.hooks?.onAppInstallFailed?.({
+        app: input.app,
+        appId: input.app.appId,
         failureReason: input.failureReason ?? null
       });
     }
@@ -482,6 +508,7 @@ export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCent
         currentApp.runtimeId !== snapshotApp.runtimeId ||
         currentApp.installationId !== snapshotApp.installationId ||
         currentApp.installProgress != null ||
+        currentApp.failurePhase != null ||
         currentApp.failureReason != null ||
         currentApp.lastError != null
       );
@@ -489,7 +516,9 @@ export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCent
     if (snapshotApp.runtimeStatus === "failed") {
       return (
         currentApp.runtimeStatus !== "failed" &&
-        (snapshotApp.failureReason != null || snapshotApp.lastError != null)
+        (snapshotApp.failurePhase != null ||
+          snapshotApp.failureReason != null ||
+          snapshotApp.lastError != null)
       );
     }
     if (
@@ -853,7 +882,11 @@ export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCent
     if (!this.pendingInstallReportKeys.delete(installKey)) {
       return;
     }
-    if (input.app.installed) {
+    const failedDuringInstall =
+      input.app.runtimeStatus === "failed" &&
+      (input.app.failurePhase === "downloading" ||
+        input.app.failurePhase === "installing");
+    if (input.app.installed && !failedDuringInstall) {
       this.dependencies.hooks?.onAppInstalled?.(input.app);
       return;
     }

--- a/packages/workspace/app-center/src/core/appCenterViewModel.test.ts
+++ b/packages/workspace/app-center/src/core/appCenterViewModel.test.ts
@@ -43,6 +43,7 @@ describe("createAppCenterViewModel", () => {
         {
           appId: "zeta",
           error: {
+            failurePhase: "starting",
             message: "Launch failed"
           },
           status: "failed"
@@ -66,6 +67,7 @@ describe("createAppCenterViewModel", () => {
     assert.equal(viewModel.apps[1]?.canOpenFolder, true);
     assert.equal(viewModel.apps[1]?.canOpenPackageFolder, false);
     assert.equal(viewModel.apps[1]?.errorMessage, "Launch failed");
+    assert.equal(viewModel.apps[1]?.failurePhase, "starting");
   });
 
   it("shows restart and open when an installed app is pending restart", () => {

--- a/packages/workspace/app-center/src/core/appCenterViewModel.ts
+++ b/packages/workspace/app-center/src/core/appCenterViewModel.ts
@@ -190,6 +190,9 @@ export function createAppCenterViewModel({
         ...(runtime?.error?.message
           ? { errorMessage: runtime.error.message }
           : {}),
+        ...(runtime?.error?.failurePhase
+          ? { failurePhase: runtime.error.failurePhase }
+          : {}),
         ...(runtime?.installProgress
           ? { installProgress: runtime.installProgress }
           : {}),

--- a/packages/workspace/app-center/src/core/appFailurePresentation.test.ts
+++ b/packages/workspace/app-center/src/core/appFailurePresentation.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { appCenterEn, appCenterZhCN } from "../i18n/appCenterI18n.ts";
+import { resolveWorkspaceAppFailureMessageKey } from "./appFailurePresentation.ts";
+
+describe("resolveWorkspaceAppFailureMessageKey", () => {
+  it("maps install, start, runtime, and legacy failures to distinct copy", () => {
+    assert.equal(
+      resolveWorkspaceAppFailureMessageKey("downloading"),
+      "messages.appInstallFailed"
+    );
+    assert.equal(
+      resolveWorkspaceAppFailureMessageKey("installing"),
+      "messages.appInstallFailed"
+    );
+    assert.equal(
+      resolveWorkspaceAppFailureMessageKey("starting"),
+      "messages.appStartFailed"
+    );
+    assert.equal(
+      resolveWorkspaceAppFailureMessageKey("runtime"),
+      "messages.appRuntimeFailed"
+    );
+    assert.equal(
+      resolveWorkspaceAppFailureMessageKey(undefined),
+      "messages.appUnknownFailure"
+    );
+    assert.equal(
+      resolveWorkspaceAppFailureMessageKey(null),
+      "messages.appUnknownFailure"
+    );
+
+    assert.deepEqual(
+      {
+        install: appCenterEn.messages.appInstallFailed,
+        runtime: appCenterEn.messages.appRuntimeFailed,
+        start: appCenterEn.messages.appStartFailed,
+        unknown: appCenterEn.messages.appUnknownFailure
+      },
+      {
+        install:
+          "The app failed to install. Retry or open the logs for details.",
+        runtime:
+          "The app stopped unexpectedly. Open its session or logs for details.",
+        start: "The app failed to start. Retry or open the logs for details.",
+        unknown: "The app failed to run. Retry or open the logs for details."
+      }
+    );
+    assert.deepEqual(
+      {
+        install: appCenterZhCN.messages.appInstallFailed,
+        runtime: appCenterZhCN.messages.appRuntimeFailed,
+        start: appCenterZhCN.messages.appStartFailed,
+        unknown: appCenterZhCN.messages.appUnknownFailure
+      },
+      {
+        install: "应用安装失败，请重试或查看日志",
+        runtime: "应用运行异常，请打开会话或日志查看详情",
+        start: "应用启动失败，请重试或查看日志",
+        unknown: "应用运行失败，请重试或查看日志"
+      }
+    );
+  });
+});

--- a/packages/workspace/app-center/src/core/appFailurePresentation.ts
+++ b/packages/workspace/app-center/src/core/appFailurePresentation.ts
@@ -1,0 +1,23 @@
+import type { WorkspaceAppFailurePhase } from "../contracts/runtime.ts";
+
+export type WorkspaceAppFailureMessageKey =
+  | "messages.appInstallFailed"
+  | "messages.appRuntimeFailed"
+  | "messages.appStartFailed"
+  | "messages.appUnknownFailure";
+
+export function resolveWorkspaceAppFailureMessageKey(
+  failurePhase: WorkspaceAppFailurePhase | null | undefined
+): WorkspaceAppFailureMessageKey {
+  switch (failurePhase) {
+    case "downloading":
+    case "installing":
+      return "messages.appInstallFailed";
+    case "starting":
+      return "messages.appStartFailed";
+    case "runtime":
+      return "messages.appRuntimeFailed";
+    default:
+      return "messages.appUnknownFailure";
+  }
+}

--- a/packages/workspace/app-center/src/i18n/appCenterI18n.ts
+++ b/packages/workspace/app-center/src/i18n/appCenterI18n.ts
@@ -272,8 +272,14 @@ export const appCenterEn = {
       'Load the skill https://github.com/tutti-os/tutti-agent-skills/tree/main/plugins/tutti/skills/tutti-workspace-app-factory and adapt project directory "{{cwd}}" into a Tutti local debug app. Generate .tutti/dev-app/; bootstrap.sh must read the host-injected TUTTI_APP_HOST and TUTTI_APP_PORT, and must not hard-code a port.'
   },
   messages: {
+    appInstallFailed:
+      "The app failed to install. Retry or open the logs for details.",
     appRuntimeFailed:
-      "The app failed to start. Open its session or logs for details.",
+      "The app stopped unexpectedly. Open its session or logs for details.",
+    appStartFailed:
+      "The app failed to start. Retry or open the logs for details.",
+    appUnknownFailure:
+      "The app failed to run. Retry or open the logs for details.",
     catalogFailed:
       "Remote app catalog is unavailable. Local apps are still available.",
     catalogLoading: "Loading remote app catalog...",
@@ -554,7 +560,10 @@ export const appCenterZhCN = {
       "加载 skill https://github.com/tutti-os/tutti-agent-skills/tree/main/plugins/tutti/skills/tutti-workspace-app-factory，将项目目录“{{cwd}}”适配成本地调试 Tutti 应用。生成 .tutti/dev-app/；bootstrap.sh 必须读取宿主注入的 TUTTI_APP_HOST 和 TUTTI_APP_PORT，不要硬编码端口。"
   },
   messages: {
-    appRuntimeFailed: "应用启动失败。请打开会话或日志查看详情。",
+    appInstallFailed: "应用安装失败，请重试或查看日志",
+    appRuntimeFailed: "应用运行异常，请打开会话或日志查看详情",
+    appStartFailed: "应用启动失败，请重试或查看日志",
+    appUnknownFailure: "应用运行失败，请重试或查看日志",
     catalogFailed: "无法加载远程应用目录，本地应用仍可用。",
     catalogLoading: "正在加载远程应用目录...",
     empty: "还没有安装应用",

--- a/packages/workspace/app-center/src/ui/AppCard.tsx
+++ b/packages/workspace/app-center/src/ui/AppCard.tsx
@@ -37,6 +37,7 @@ import type {
   WorkspaceAppLocalRepairRequest
 } from "../contracts/host.ts";
 import { isCommunityRecommendedApp } from "../core/appCenterAppOrdering.ts";
+import { resolveWorkspaceAppFailureMessageKey } from "../core/appFailurePresentation.ts";
 import {
   resolveFactoryPublishActionKey,
   type AppCenterFactoryPresentationMode
@@ -258,7 +259,6 @@ export const AppCard = memo(function AppCard({
 
   return (
     <article
-      aria-disabled={canOpenFromCard ? undefined : true}
       className={cn(
         "group flex h-full min-h-[168px] min-w-0 flex-col rounded-[12px] border border-[color:var(--line-2)] bg-[var(--background-fronted)] p-[12px] text-left text-[var(--text-primary)] transition-transform duration-200 ease-out hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color-mix(in_srgb,var(--border-focus)_70%,transparent)] motion-reduce:transition-none motion-reduce:hover:translate-y-0",
         canOpenFromCard ? "cursor-pointer" : "cursor-default",
@@ -362,13 +362,13 @@ export const AppCard = memo(function AppCard({
           ) : null}
         </div>
 
-        {app.errorMessage ? (
+        {app.status === "failed" ? (
           <div className="mt-auto flex min-w-0 flex-col gap-3 pt-3">
             <p
               className="min-w-0 rounded-[6px] bg-[color-mix(in_srgb,var(--state-danger)_10%,transparent)] px-2 py-1 text-[11px] leading-4 text-[var(--state-danger)]"
               title={app.errorMessage}
             >
-              {copy.t("messages.appRuntimeFailed")}
+              {copy.t(resolveWorkspaceAppFailureMessageKey(app.failurePhase))}
             </p>
           </div>
         ) : null}

--- a/services/tuttid/api/events/generated/protocol.gen.go
+++ b/services/tuttid/api/events/generated/protocol.gen.go
@@ -6,7 +6,7 @@ import "encoding/json"
 
 const (
 	BusinessEventProtocolVersion = 1
-	BusinessEventCatalogRevision = "sha256:4ad6cabfbf1a1951"
+	BusinessEventCatalogRevision = "sha256:d3cf3b4c5b26811b"
 )
 
 type Topic string
@@ -210,6 +210,7 @@ type WorkspaceWorkspaceApp struct {
 	LaunchUrl       *string  `json:"launchUrl"`
 	Port            *int     `json:"port"`
 	FailureReason   *string  `json:"failureReason"`
+	FailurePhase    *string  `json:"failurePhase,omitempty"`
 	LastError       *string  `json:"lastError"`
 	StartedAtUnixMs *int64   `json:"startedAtUnixMs"`
 	UpdatedAtUnixMs *int64   `json:"updatedAtUnixMs"`

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -3718,6 +3718,30 @@ func (e WorkspaceAgentTurnPhase) Valid() bool {
 	}
 }
 
+// Defines values for WorkspaceAppFailurePhase.
+const (
+	Downloading WorkspaceAppFailurePhase = "downloading"
+	Installing  WorkspaceAppFailurePhase = "installing"
+	Runtime     WorkspaceAppFailurePhase = "runtime"
+	Starting    WorkspaceAppFailurePhase = "starting"
+)
+
+// Valid indicates whether the value is a known member of the WorkspaceAppFailurePhase enum.
+func (e WorkspaceAppFailurePhase) Valid() bool {
+	switch e {
+	case Downloading:
+		return true
+	case Installing:
+		return true
+	case Runtime:
+		return true
+	case Starting:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for WorkspaceAppCatalogLoadStatus.
 const (
 	WorkspaceAppCatalogLoadStatusDisabled WorkspaceAppCatalogLoadStatus = "disabled"
@@ -8895,6 +8919,7 @@ type WorkspaceApp struct {
 	DisplayName      string                       `json:"displayName"`
 	Enabled          bool                         `json:"enabled"`
 	Exportable       bool                         `json:"exportable"`
+	FailurePhase     *WorkspaceAppFailurePhase    `json:"failurePhase,omitempty"`
 	FailureReason    *string                      `json:"failureReason"`
 	IconUrl          *string                      `json:"iconUrl"`
 	InstallProgress  *WorkspaceAppInstallProgress `json:"installProgress,omitempty"`
@@ -8920,6 +8945,9 @@ type WorkspaceApp struct {
 	WindowMinHeight  *int                         `json:"windowMinHeight"`
 	WindowMinWidth   *int                         `json:"windowMinWidth"`
 }
+
+// WorkspaceAppFailurePhase defines model for WorkspaceApp.FailurePhase.
+type WorkspaceAppFailurePhase string
 
 // WorkspaceAppAgentPreferencesResponse defines model for WorkspaceAppAgentPreferencesResponse.
 type WorkspaceAppAgentPreferencesResponse struct {

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -10092,6 +10092,14 @@ components:
         failureReason:
           type: string
           nullable: true
+        failurePhase:
+          type: string
+          nullable: true
+          enum:
+            - downloading
+            - installing
+            - starting
+            - runtime
         lastError:
           type: string
           nullable: true

--- a/services/tuttid/api/workspace/apps.go
+++ b/services/tuttid/api/workspace/apps.go
@@ -26,6 +26,7 @@ func GeneratedAppFromBiz(app workspacebiz.WorkspaceApp) tuttigenerated.Workspace
 		StateRevision:    app.StateRevision,
 		LaunchUrl:        app.Runtime.LaunchURL,
 		Port:             app.Runtime.Port,
+		FailurePhase:     generatedAppFailurePhase(app.Runtime.FailurePhase),
 		FailureReason:    app.Runtime.FailureReason,
 		LastError:        app.Runtime.LastError,
 		StartedAtUnixMs:  app.Runtime.StartedAtUnixMs,
@@ -42,6 +43,14 @@ func GeneratedAppFromBiz(app workspacebiz.WorkspaceApp) tuttigenerated.Workspace
 		References:       generatedAppReferencesStateFromBiz(app),
 		InstallProgress:  generatedAppInstallProgressFromBiz(app.InstallProgress),
 	}
+}
+
+func generatedAppFailurePhase(value *workspacebiz.AppFailurePhase) *tuttigenerated.WorkspaceAppFailurePhase {
+	if value == nil {
+		return nil
+	}
+	result := tuttigenerated.WorkspaceAppFailurePhase(*value)
+	return &result
 }
 
 func generatedAppAuthorsFromBiz(manifest workspacebiz.AppManifest) []tuttigenerated.WorkspaceAppAuthor {

--- a/services/tuttid/biz/workspace/apps.go
+++ b/services/tuttid/biz/workspace/apps.go
@@ -261,6 +261,7 @@ type AppRuntimeState struct {
 	Status          AppRuntimeStatus
 	LaunchURL       *string
 	Port            *int
+	FailurePhase    *AppFailurePhase
 	FailureReason   *string
 	LastError       *string
 	StartedAtUnixMs *int64
@@ -274,6 +275,15 @@ const (
 	AppInstallUserPhaseDownloading AppInstallUserPhase = "downloading"
 	AppInstallUserPhaseInstalling  AppInstallUserPhase = "installing"
 	AppInstallUserPhaseStarting    AppInstallUserPhase = "starting"
+)
+
+type AppFailurePhase string
+
+const (
+	AppFailurePhaseDownloading AppFailurePhase = "downloading"
+	AppFailurePhaseInstalling  AppFailurePhase = "installing"
+	AppFailurePhaseStarting    AppFailurePhase = "starting"
+	AppFailurePhaseRuntime     AppFailurePhase = "runtime"
 )
 
 type AppInstallProgress struct {
@@ -501,6 +511,7 @@ func ParseAppManifestJSON(data []byte) (AppManifest, string, error) {
 	if err := json.Unmarshal(data, &manifest); err != nil {
 		return AppManifest{}, "", fmt.Errorf("parse app manifest json: %w", err)
 	}
+	manifest = NormalizeAppManifestRuntimeProfile(manifest)
 	if err := ValidateAppManifest(manifest); err != nil {
 		return AppManifest{}, "", err
 	}
@@ -509,6 +520,16 @@ func ParseAppManifestJSON(data []byte) (AppManifest, string, error) {
 		return AppManifest{}, "", fmt.Errorf("serialize app manifest json: %w", err)
 	}
 	return manifest, string(normalized), nil
+}
+
+// NormalizeAppManifestRuntimeProfile keeps legacy catalog and package manifests
+// readable while ensuring downstream runtime resolution sees one canonical
+// profile name.
+func NormalizeAppManifestRuntimeProfile(manifest AppManifest) AppManifest {
+	if strings.TrimSpace(manifest.Runtime.Profile) == "node-static" {
+		manifest.Runtime.Profile = "connector-node-static"
+	}
+	return manifest
 }
 
 func validateAppManifestReferencesJSON(raw map[string]json.RawMessage) error {
@@ -566,7 +587,7 @@ func ValidateAppManifest(manifest AppManifest) error {
 		return errors.New("app manifest runtime.healthcheckPath must start with /")
 	}
 	if profile := strings.TrimSpace(manifest.Runtime.Profile); profile != "" && profile != "connector-node-static" && profile != "standalone" {
-		return errors.New("app manifest runtime.profile must be node-static or standalone when set")
+		return errors.New("app manifest runtime.profile must be connector-node-static or standalone when set")
 	}
 	if manifest.Window != nil {
 		minimizeBehavior := strings.TrimSpace(manifest.Window.MinimizeBehavior)

--- a/services/tuttid/biz/workspace/apps_test.go
+++ b/services/tuttid/biz/workspace/apps_test.go
@@ -269,7 +269,24 @@ func TestParseAppManifestJSONAcceptsRuntimeProfile(t *testing.T) {
 		t.Fatalf("ParseAppManifestJSON() error = %v, want nil for runtime.profile", err)
 	}
 	if manifest.Runtime.Profile != "connector-node-static" {
-		t.Fatalf("Runtime.Profile = %q, want node-static", manifest.Runtime.Profile)
+		t.Fatalf("Runtime.Profile = %q, want connector-node-static", manifest.Runtime.Profile)
+	}
+}
+
+func TestParseAppManifestJSONNormalizesLegacyRuntimeProfile(t *testing.T) {
+	t.Parallel()
+
+	manifest, normalized, err := ParseAppManifestJSON([]byte(
+		`{"schemaVersion":"tutti.app.manifest.v1","appId":"test-app","version":"0.1.0","name":"Test App","description":"Test app","icon":{"type":"asset","src":"icon.png"},"runtime":{"bootstrap":"bootstrap.sh","healthcheckPath":"/healthz","profile":"node-static"}}`,
+	))
+	if err != nil {
+		t.Fatalf("ParseAppManifestJSON() error = %v, want legacy runtime.profile accepted", err)
+	}
+	if manifest.Runtime.Profile != "connector-node-static" {
+		t.Fatalf("Runtime.Profile = %q, want connector-node-static", manifest.Runtime.Profile)
+	}
+	if !strings.Contains(normalized, `"profile":"connector-node-static"`) {
+		t.Fatalf("normalized manifest = %s, want canonical runtime.profile", normalized)
 	}
 }
 

--- a/services/tuttid/builtin-apps/catalog_compatibility.go
+++ b/services/tuttid/builtin-apps/catalog_compatibility.go
@@ -246,6 +246,7 @@ func isCanonicalCatalogCapability(value string) bool {
 }
 
 func parseRemoteCatalogApp(entry remoteCatalogApp) (App, error) {
+	entry.Manifest = workspacebiz.NormalizeAppManifestRuntimeProfile(entry.Manifest)
 	if err := workspacebiz.ValidateAppManifest(entry.Manifest); err != nil {
 		return App{}, fmt.Errorf("validate app catalog manifest: %w", err)
 	}

--- a/services/tuttid/builtin-apps/catalog_test.go
+++ b/services/tuttid/builtin-apps/catalog_test.go
@@ -353,6 +353,33 @@ func TestCatalogLoadsRemoteAutomationWhenProvidedByCatalog(t *testing.T) {
 	}
 }
 
+func TestCatalogNormalizesLegacyNodeStaticRuntimeProfile(t *testing.T) {
+	t.Setenv(remoteCatalogURLEnv, "")
+	manifest := remoteCatalogManifestForTest("legacy-node-static")
+	manifest.Runtime.Profile = "node-static"
+	setRemoteCatalogFileForTest(t, remoteCatalogDocumentForTest(remoteCatalogApp{
+		Manifest: manifest,
+		Distribution: remoteDistribution{
+			Kind:           string(DistributionRemote),
+			ArtifactURL:    "https://cdn.example.test/legacy-node-static.zip",
+			ArtifactSHA256: strings.Repeat("a", 64),
+			IconURL:        "https://cdn.example.test/legacy-node-static.png",
+		},
+	}))
+
+	apps, err := Catalog()
+	if err != nil {
+		t.Fatalf("Catalog() error = %v", err)
+	}
+	app := findCatalogAppForTest(apps, "legacy-node-static")
+	if app == nil {
+		t.Fatal("legacy-node-static app missing from catalog")
+	}
+	if app.Manifest.Runtime.Profile != "connector-node-static" {
+		t.Fatalf("runtime profile = %q, want connector-node-static", app.Manifest.Runtime.Profile)
+	}
+}
+
 func TestParseRemoteCatalogSelectsHighestCompatibleAppVersion(t *testing.T) {
 	legacy := remoteCatalogAppForVersionTest("versioned-app", "1.0.0")
 	compatible := remoteCatalogAppForVersionTest("versioned-app", "1.1.0")

--- a/services/tuttid/service/eventstream/service_test.go
+++ b/services/tuttid/service/eventstream/service_test.go
@@ -805,6 +805,7 @@ func TestWorkspaceAppPublisherIncludesReferencesState(t *testing.T) {
 	}
 
 	publisher := WorkspaceAppPublisher{Service: service}
+	failurePhase := workspacebiz.AppFailurePhaseRuntime
 	if err := publisher.PublishWorkspaceAppUpdated(context.Background(), "workspace-1", workspacebiz.WorkspaceApp{
 		Package: workspacebiz.AppPackage{
 			AppID:   "docs",
@@ -818,7 +819,8 @@ func TestWorkspaceAppPublisherIncludesReferencesState(t *testing.T) {
 			},
 		},
 		Runtime: workspacebiz.AppRuntimeState{
-			Status: workspacebiz.AppRuntimeStatusIdle,
+			Status:       workspacebiz.AppRuntimeStatusFailed,
+			FailurePhase: &failurePhase,
 		},
 	}); err != nil {
 		t.Fatalf("PublishWorkspaceAppUpdated() error = %v", err)
@@ -827,7 +829,8 @@ func TestWorkspaceAppPublisherIncludesReferencesState(t *testing.T) {
 	event := receiveEvent(t, session)
 	var payload struct {
 		App struct {
-			References struct {
+			FailurePhase *string `json:"failurePhase"`
+			References   struct {
 				ListSupported bool `json:"listSupported"`
 			} `json:"references"`
 		} `json:"app"`
@@ -837,6 +840,9 @@ func TestWorkspaceAppPublisherIncludesReferencesState(t *testing.T) {
 	}
 	if !payload.App.References.ListSupported {
 		t.Fatal("published references.listSupported = false, want true")
+	}
+	if payload.App.FailurePhase == nil || *payload.App.FailurePhase != "runtime" {
+		t.Fatalf("published failurePhase = %v, want runtime", payload.App.FailurePhase)
 	}
 }
 

--- a/services/tuttid/service/eventstream/workspace_apps.go
+++ b/services/tuttid/service/eventstream/workspace_apps.go
@@ -54,6 +54,7 @@ func (p WorkspaceAppPublisher) PublishWorkspaceAppUpdated(ctx context.Context, w
 			StateRevision:    app.StateRevision,
 			LaunchUrl:        app.Runtime.LaunchURL,
 			Port:             app.Runtime.Port,
+			FailurePhase:     workspaceAppFailurePhaseString(app.Runtime.FailurePhase),
 			FailureReason:    app.Runtime.FailureReason,
 			LastError:        app.Runtime.LastError,
 			StartedAtUnixMs:  app.Runtime.StartedAtUnixMs,
@@ -81,6 +82,14 @@ func (p WorkspaceAppPublisher) PublishWorkspaceAppUpdated(ctx context.Context, w
 	return p.Service.PublishFromServerScoped(ctx, TopicWorkspaceAppUpdated, payload, EventScope{
 		WorkspaceID: workspaceID,
 	})
+}
+
+func workspaceAppFailurePhaseString(value *workspacebiz.AppFailurePhase) *string {
+	if value == nil {
+		return nil
+	}
+	result := string(*value)
+	return &result
 }
 
 func generatedEventAppAuthors(manifest workspacebiz.AppManifest) []struct {

--- a/services/tuttid/service/workspace/app_projection_revision.go
+++ b/services/tuttid/service/workspace/app_projection_revision.go
@@ -17,6 +17,8 @@ type workspaceAppProjectionKey struct {
 	displayName          string
 	enabled              bool
 	failureReason        string
+	failurePhase         string
+	hasFailurePhase      bool
 	hasFailureReason     bool
 	hasIconURL           bool
 	hasLastError         bool
@@ -92,6 +94,10 @@ func projectionKeyFromWorkspaceApp(app workspacebiz.WorkspaceApp) workspaceAppPr
 	if app.Runtime.FailureReason != nil {
 		key.hasFailureReason = true
 		key.failureReason = *app.Runtime.FailureReason
+	}
+	if app.Runtime.FailurePhase != nil {
+		key.hasFailurePhase = true
+		key.failurePhase = string(*app.Runtime.FailurePhase)
 	}
 	if app.Runtime.LastError != nil {
 		key.hasLastError = true

--- a/services/tuttid/service/workspace/app_projection_revision_test.go
+++ b/services/tuttid/service/workspace/app_projection_revision_test.go
@@ -1,0 +1,38 @@
+package workspace
+
+import (
+	"testing"
+
+	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
+)
+
+func TestWorkspaceAppProjectionRejectsOlderRuntimeState(t *testing.T) {
+	service := &AppCenterService{}
+	newer := int64(2)
+	failurePhase := workspacebiz.AppFailurePhaseStarting
+	failureReason := "health check failed"
+	failed, changed := service.withChangedRevision(workspacebiz.WorkspaceApp{
+		Package: workspacebiz.AppPackage{AppID: "app-1"},
+		Runtime: workspacebiz.AppRuntimeState{
+			Status: workspacebiz.AppRuntimeStatusFailed, UpdatedAtUnixMs: &newer,
+			FailurePhase: &failurePhase, FailureReason: &failureReason, LastError: &failureReason,
+		},
+	}, "ws-1", "app-1")
+	if !changed || failed.StateRevision != 1 {
+		t.Fatalf("failed projection = (%#v, %v), want revision 1", failed, changed)
+	}
+
+	older := int64(1)
+	stale, changed := service.withChangedRevision(workspacebiz.WorkspaceApp{
+		Package: workspacebiz.AppPackage{AppID: "app-1"},
+		Runtime: workspacebiz.AppRuntimeState{
+			Status: workspacebiz.AppRuntimeStatusPreparing, UpdatedAtUnixMs: &older,
+		},
+		InstallProgress: &workspacebiz.AppInstallProgress{
+			UserPhase: workspacebiz.AppInstallUserPhaseStarting, OverallPercent: 100,
+		},
+	}, "ws-1", "app-1")
+	if changed || stale.StateRevision != failed.StateRevision {
+		t.Fatalf("stale projection = (%#v, %v), want rejected at revision %d", stale, changed, failed.StateRevision)
+	}
+}

--- a/services/tuttid/service/workspace/apps.go
+++ b/services/tuttid/service/workspace/apps.go
@@ -35,6 +35,8 @@ type AppCenterService struct {
 	ArtifactFetcher        AppArtifactFetcher
 	RemoteCatalogRefresher func(context.Context, string, builtinapps.CatalogHost) (builtinapps.CatalogSnapshot, error)
 
+	runnerMu sync.Mutex
+
 	mu                sync.Mutex
 	stateRevisions    map[string]int64
 	appProjectionKeys map[string]workspaceAppProjectionKey
@@ -42,6 +44,9 @@ type AppCenterService struct {
 	installMu             sync.Mutex
 	installJobs           map[string]workspaceAppInstallJob
 	activeInstallTrackers map[string]*installProgressTracker
+	installProgressSent   map[string]uint64
+	installGeneration     uint64
+	installPublishLocks   keyedOperationLocks
 
 	remoteBuiltinInstallLocks keyedOperationLocks
 
@@ -61,12 +66,17 @@ const (
 )
 
 type workspaceAppInstallJob struct {
-	WorkspaceID    string
-	AppID          string
-	Status         workspaceAppInstallJobStatus
-	FailureReason  string
-	RestartRunning bool
-	Progress       *workspacebiz.AppInstallProgress
+	Generation                     uint64
+	WorkspaceID                    string
+	AppID                          string
+	Status                         workspaceAppInstallJobStatus
+	FailureReason                  string
+	FailurePhase                   workspacebiz.AppFailurePhase
+	CurrentPhase                   workspacebiz.AppInstallUserPhase
+	RestartRunning                 bool
+	Progress                       *workspacebiz.AppInstallProgress
+	BaselineRuntimeStatus          workspacebiz.AppRuntimeStatus
+	BaselineRuntimeUpdatedAtUnixMs *int64
 }
 
 type WorkspaceRootResolver interface {
@@ -269,12 +279,17 @@ func (s *AppCenterService) runInstallJob(workspaceID string, appID string, runti
 	startedAt := time.Now()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	options := s.installJobOptions(workspaceID, appID)
+	job, ok := s.installJob(workspaceID, appID)
+	if !ok || job.Status != workspaceAppInstallJobInstalling {
+		return
+	}
+	generation := job.Generation
+	options := InstallOptions{RestartRunning: job.RestartRunning}
 	plan := s.buildInstallProgressPlan(ctx, appID)
-	tracker := s.newInstallProgressTracker(workspaceID, appID, plan)
+	tracker := s.newInstallProgressTracker(workspaceID, appID, generation, plan)
 	s.registerActiveInstallTracker(workspaceID, appID, tracker)
 	defer func() {
-		s.unregisterActiveInstallTracker(workspaceID, appID)
+		s.unregisterActiveInstallTracker(workspaceID, appID, tracker)
 		tracker.clear()
 	}()
 
@@ -323,31 +338,51 @@ func (s *AppCenterService) runInstallJob(workspaceID string, appID string, runti
 		if result.err != nil {
 			cancel()
 			wg.Wait()
-			s.handleInstallJobFailure(context.Background(), workspaceID, appID, appPackage, result.err, startedAt)
+			s.handleInstallJobFailure(context.Background(), workspaceID, appID, generation, appPackage, result.err, startedAt)
 			return
 		}
 	}
 	wg.Wait()
 	if err := ctx.Err(); err != nil {
-		s.handleInstallJobFailure(ctx, workspaceID, appID, appPackage, err, startedAt)
+		s.handleInstallJobFailure(ctx, workspaceID, appID, generation, appPackage, err, startedAt)
 		return
 	}
 
 	tracker.beginInstalling()
 	if _, err := s.installPackage(ctx, workspaceID, appPackage, options); err != nil {
-		s.handleInstallJobFailure(ctx, workspaceID, appID, appPackage, err, startedAt)
+		s.handleInstallJobFailure(ctx, workspaceID, appID, generation, appPackage, err, startedAt)
 		return
 	}
 	tracker.finishInstalling()
 	tracker.finishStarting()
 
-	s.finishInstallJob(workspaceID, appID)
+	s.completeInstallJob(workspaceID, appID, generation)
 	slog.Info("workspace_app_install_job_succeeded", "workspaceId", workspaceID, "appId", appID, "packageSource", appPackage.Source, "version", appPackage.Version, "packageDir", appPackage.PackageDir, "durationMs", time.Since(startedAt).Milliseconds())
 }
 
-func (s *AppCenterService) handleInstallJobFailure(ctx context.Context, workspaceID string, appID string, appPackage workspacebiz.AppPackage, err error, startedAt time.Time) {
+func (s *AppCenterService) completeInstallJob(workspaceID string, appID string, generation uint64) bool {
+	unlock := s.installPublishLocks.Lock(appRuntimeKey(workspaceID, appID))
+	defer unlock()
+	job, ok := s.installJob(workspaceID, appID)
+	if !ok || job.Generation != generation || job.Status != workspaceAppInstallJobInstalling {
+		return false
+	}
+	s.clearInstallProgressLocked(workspaceID, appID, generation)
+	return s.finishInstallJob(workspaceID, appID, generation)
+}
+
+func (s *AppCenterService) handleInstallJobFailure(ctx context.Context, workspaceID string, appID string, generation uint64, appPackage workspacebiz.AppPackage, err error, startedAt time.Time) {
+	unlock := s.installPublishLocks.Lock(appRuntimeKey(workspaceID, appID))
+	defer unlock()
+
 	slog.Warn("workspace_app_install_job_failed", "workspaceId", workspaceID, "appId", appID, "packageSource", appPackage.Source, "version", appPackage.Version, "packageDir", appPackage.PackageDir, "failureReason", err.Error(), "durationMs", time.Since(startedAt).Milliseconds(), "error", err)
-	s.failInstallJob(workspaceID, appID, err)
+	if !s.failInstallJob(workspaceID, appID, generation, err) {
+		return
+	}
+	// Stop accepting tracker callbacks and remove any transient progress before
+	// publishing the failure terminal. The deferred tracker cleanup must never
+	// be able to publish a newer idle/running projection over this failure.
+	s.clearInstallProgressLocked(workspaceID, appID, generation)
 	if failedApp, projectionErr := s.failedInstallAppProjection(ctx, workspaceID, appID, err); projectionErr == nil {
 		_ = s.publishAppIfChanged(ctx, workspaceID, appID, failedApp)
 	} else {
@@ -486,6 +521,8 @@ func (s *AppCenterService) workspaceSummary(ctx context.Context, workspaceID str
 }
 
 func (s *AppCenterService) runner() *AppRunner {
+	s.runnerMu.Lock()
+	defer s.runnerMu.Unlock()
 	if s.Runner == nil {
 		s.Runner = &AppRunner{}
 	}
@@ -556,9 +593,19 @@ func (s *AppCenterService) withChangedRevision(app workspacebiz.WorkspaceApp, wo
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.ensureRevisionStateLocked()
-	if previous, ok := s.appProjectionKeys[key]; ok && previous == projection {
-		app.StateRevision = s.stateRevisions[key]
-		return app, false
+	if previous, ok := s.appProjectionKeys[key]; ok {
+		staleInstallProgress := projection.hasInstallProgress &&
+			previous.hasUpdatedAt &&
+			(!projection.hasUpdatedAt || projection.updatedAtUnixMs < previous.updatedAtUnixMs) &&
+			(previous.status == workspacebiz.AppRuntimeStatusFailed ||
+				previous.status == workspacebiz.AppRuntimeStatusStopping ||
+				previous.status == workspacebiz.AppRuntimeStatusRunning ||
+				previous.status == workspacebiz.AppRuntimeStatusInstalledPendingRestart)
+		if previous == projection ||
+			staleInstallProgress {
+			app.StateRevision = s.stateRevisions[key]
+			return app, false
+		}
 	}
 	s.stateRevisions[key] += 1
 	s.appProjectionKeys[key] = projection

--- a/services/tuttid/service/workspace/apps_install_jobs.go
+++ b/services/tuttid/service/workspace/apps_install_jobs.go
@@ -8,48 +8,69 @@ import (
 
 func (s *AppCenterService) beginInstallJob(workspaceID string, appID string, options InstallOptions) bool {
 	key := appRuntimeKey(workspaceID, appID)
+	unlock := s.installPublishLocks.Lock(key)
+	defer unlock()
+	baselineRuntime := s.runner().State(workspaceID, appID)
 	s.installMu.Lock()
 	defer s.installMu.Unlock()
 	s.ensureInstallJobsLocked()
 	if job, ok := s.installJobs[key]; ok && job.Status == workspaceAppInstallJobInstalling {
 		return false
 	}
+	s.installGeneration += 1
 	s.installJobs[key] = workspaceAppInstallJob{
-		WorkspaceID:    workspaceID,
-		AppID:          appID,
-		Status:         workspaceAppInstallJobInstalling,
-		RestartRunning: options.RestartRunning,
+		Generation:                     s.installGeneration,
+		WorkspaceID:                    workspaceID,
+		AppID:                          appID,
+		Status:                         workspaceAppInstallJobInstalling,
+		CurrentPhase:                   workspacebiz.AppInstallUserPhaseDownloading,
+		RestartRunning:                 options.RestartRunning,
+		BaselineRuntimeStatus:          baselineRuntime.Status,
+		BaselineRuntimeUpdatedAtUnixMs: cloneInt64Ptr(baselineRuntime.UpdatedAtUnixMs),
 	}
 	return true
 }
 
-func (s *AppCenterService) finishInstallJob(workspaceID string, appID string) {
+func cloneInt64Ptr(value *int64) *int64 {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+func (s *AppCenterService) finishInstallJob(workspaceID string, appID string, generation uint64) bool {
 	key := appRuntimeKey(workspaceID, appID)
 	s.installMu.Lock()
 	defer s.installMu.Unlock()
 	s.ensureInstallJobsLocked()
+	job, ok := s.installJobs[key]
+	if !ok || job.Generation != generation {
+		return false
+	}
 	delete(s.installJobs, key)
+	return true
 }
 
-func (s *AppCenterService) failInstallJob(workspaceID string, appID string, err error) {
+func (s *AppCenterService) failInstallJob(workspaceID string, appID string, generation uint64, err error) bool {
 	key := appRuntimeKey(workspaceID, appID)
 	s.installMu.Lock()
 	defer s.installMu.Unlock()
 	s.ensureInstallJobsLocked()
-	s.installJobs[key] = workspaceAppInstallJob{
-		WorkspaceID:   workspaceID,
-		AppID:         appID,
-		Status:        workspaceAppInstallJobFailed,
-		FailureReason: err.Error(),
+	job, ok := s.installJobs[key]
+	if !ok || job.Generation != generation || job.Status != workspaceAppInstallJobInstalling {
+		return false
 	}
-}
-
-func (s *AppCenterService) installJobOptions(workspaceID string, appID string) InstallOptions {
-	job, ok := s.installJob(workspaceID, appID)
-	if !ok {
-		return InstallOptions{}
+	failurePhase := workspacebiz.AppFailurePhase(job.CurrentPhase)
+	if failurePhase == "" {
+		failurePhase = workspacebiz.AppFailurePhaseDownloading
 	}
-	return InstallOptions{RestartRunning: job.RestartRunning}
+	job.Status = workspaceAppInstallJobFailed
+	job.FailureReason = err.Error()
+	job.FailurePhase = failurePhase
+	job.Progress = nil
+	s.installJobs[key] = job
+	return true
 }
 
 func (s *AppCenterService) installJob(workspaceID string, appID string) (workspaceAppInstallJob, bool) {
@@ -67,31 +88,74 @@ func (s *AppCenterService) ensureInstallJobsLocked() {
 	}
 }
 
-func (s *AppCenterService) setInstallJobProgress(workspaceID string, appID string, progress workspacebiz.AppInstallProgress) {
+func (s *AppCenterService) setInstallJobProgress(workspaceID string, appID string, generation uint64, progress workspacebiz.AppInstallProgress) bool {
 	key := appRuntimeKey(workspaceID, appID)
 	s.installMu.Lock()
 	defer s.installMu.Unlock()
 	s.ensureInstallJobsLocked()
 	job, ok := s.installJobs[key]
-	if !ok || job.Status != workspaceAppInstallJobInstalling {
-		return
+	if !ok || job.Generation != generation || job.Status != workspaceAppInstallJobInstalling {
+		return false
 	}
 	progressCopy := progress
+	job.CurrentPhase = progress.UserPhase
 	job.Progress = &progressCopy
 	s.installJobs[key] = job
+	return true
 }
 
-func (s *AppCenterService) clearInstallJobProgress(workspaceID string, appID string) {
+func (s *AppCenterService) setInstallJobPhase(workspaceID string, appID string, generation uint64, phase workspacebiz.AppInstallUserPhase) bool {
 	key := appRuntimeKey(workspaceID, appID)
 	s.installMu.Lock()
 	defer s.installMu.Unlock()
 	s.ensureInstallJobsLocked()
 	job, ok := s.installJobs[key]
-	if !ok {
-		return
+	if !ok || job.Generation != generation || job.Status != workspaceAppInstallJobInstalling {
+		return false
+	}
+	job.CurrentPhase = phase
+	s.installJobs[key] = job
+	return true
+}
+
+func (s *AppCenterService) clearInstallJobProgress(workspaceID string, appID string, generation uint64) bool {
+	key := appRuntimeKey(workspaceID, appID)
+	s.installMu.Lock()
+	defer s.installMu.Unlock()
+	s.ensureInstallJobsLocked()
+	job, ok := s.installJobs[key]
+	if !ok || job.Generation != generation {
+		return false
 	}
 	job.Progress = nil
 	s.installJobs[key] = job
+	return true
+}
+
+func (s *AppCenterService) markInstallProgressSent(workspaceID string, appID string, generation uint64) {
+	key := appRuntimeKey(workspaceID, appID)
+	s.installMu.Lock()
+	defer s.installMu.Unlock()
+	if s.installProgressSent == nil {
+		s.installProgressSent = make(map[string]uint64)
+	}
+	s.installProgressSent[key] = generation
+}
+
+func (s *AppCenterService) installProgressWasSent(workspaceID string, appID string, generation uint64) bool {
+	key := appRuntimeKey(workspaceID, appID)
+	s.installMu.Lock()
+	defer s.installMu.Unlock()
+	return s.installProgressSent[key] == generation
+}
+
+func (s *AppCenterService) clearInstallProgressSent(workspaceID string, appID string, generation uint64) {
+	key := appRuntimeKey(workspaceID, appID)
+	s.installMu.Lock()
+	defer s.installMu.Unlock()
+	if s.installProgressSent[key] == generation {
+		delete(s.installProgressSent, key)
+	}
 }
 
 func (s *AppCenterService) withInstallJobProjections(apps []workspacebiz.WorkspaceApp, workspaceID string) []workspacebiz.WorkspaceApp {
@@ -104,10 +168,12 @@ func (s *AppCenterService) withInstallJobProjections(apps []workspacebiz.Workspa
 		}
 		if job.Status == workspaceAppInstallJobFailed {
 			failureReason := job.FailureReason
+			failurePhase := job.FailurePhase
 			app.Installation = nil
 			app.InstallProgress = nil
 			app.Runtime = workspacebiz.AppRuntimeState{
 				Status:        workspacebiz.AppRuntimeStatusFailed,
+				FailurePhase:  &failurePhase,
 				FailureReason: &failureReason,
 				LastError:     &failureReason,
 			}
@@ -129,10 +195,15 @@ func (s *AppCenterService) failedInstallAppProjection(ctx context.Context, works
 		return workspacebiz.WorkspaceApp{}, err
 	}
 	failureReason := installErr.Error()
+	failurePhase := workspacebiz.AppFailurePhaseDownloading
+	if job, ok := s.installJob(workspaceID, appID); ok && job.FailurePhase != "" {
+		failurePhase = job.FailurePhase
+	}
 	app.Installation = nil
 	app.InstallProgress = nil
 	app.Runtime = workspacebiz.AppRuntimeState{
 		Status:        workspacebiz.AppRuntimeStatusFailed,
+		FailurePhase:  &failurePhase,
 		FailureReason: &failureReason,
 		LastError:     &failureReason,
 	}

--- a/services/tuttid/service/workspace/apps_install_progress.go
+++ b/services/tuttid/service/workspace/apps_install_progress.go
@@ -39,6 +39,7 @@ type installProgressTracker struct {
 	service     *AppCenterService
 	workspaceID string
 	appID       string
+	generation  uint64
 	plan        installProgressPlan
 
 	mu              sync.Mutex
@@ -59,11 +60,12 @@ type streamDownloadProgress struct {
 	total int64
 }
 
-func (s *AppCenterService) newInstallProgressTracker(workspaceID string, appID string, plan installProgressPlan) *installProgressTracker {
+func (s *AppCenterService) newInstallProgressTracker(workspaceID string, appID string, generation uint64, plan installProgressPlan) *installProgressTracker {
 	tracker := &installProgressTracker{
 		service:     s,
 		workspaceID: workspaceID,
 		appID:       appID,
+		generation:  generation,
 		plan:        plan,
 		userPhase:   workspacebiz.AppInstallUserPhaseDownloading,
 	}
@@ -267,7 +269,7 @@ func (t *installProgressTracker) finishStarting() {
 }
 
 func (t *installProgressTracker) clear() {
-	t.service.clearInstallProgress(t.workspaceID, t.appID)
+	t.service.clearInstallProgress(t.workspaceID, t.appID, t.generation)
 }
 
 func (t *installProgressTracker) recalculateLocked() {
@@ -389,7 +391,7 @@ func (t *installProgressTracker) publishLocked(force bool) {
 	t.lastPublishTime = time.Now()
 	t.lastPublished = t.overallPercent
 	progress := t.snapshotLocked()
-	t.service.publishInstallProgress(context.Background(), t.workspaceID, t.appID, progress, force)
+	t.service.publishInstallProgress(context.Background(), t.workspaceID, t.appID, t.generation, progress, force)
 }
 
 func roundInstallProgressPercent(value float64) float64 {
@@ -409,13 +411,23 @@ func maxInt64(left int64, right int64) int64 {
 	return right
 }
 
-func (s *AppCenterService) publishInstallProgress(ctx context.Context, workspaceID string, appID string, progress workspacebiz.AppInstallProgress, checkpoint bool) {
+func (s *AppCenterService) publishInstallProgress(ctx context.Context, workspaceID string, appID string, generation uint64, progress workspacebiz.AppInstallProgress, checkpoint bool) {
+	unlock := s.installPublishLocks.Lock(appRuntimeKey(workspaceID, appID))
+	defer unlock()
+
+	job, ok := s.installJob(workspaceID, appID)
+	if !ok || job.Generation != generation || job.Status != workspaceAppInstallJobInstalling {
+		return
+	}
+	if !s.setInstallJobPhase(workspaceID, appID, generation, progress.UserPhase) {
+		return
+	}
 	app, err := s.workspaceAppProjectionForInstall(ctx, workspaceID, appID)
 	if err != nil {
 		return
 	}
-	if shouldSkipInstallProgressPublish(app.Runtime.Status, progress) {
-		s.clearInstallJobProgress(workspaceID, appID)
+	if shouldSkipInstallProgressPublish(app.Runtime, job) {
+		s.clearInstallProgressLocked(workspaceID, appID, generation)
 		slog.Info(
 			"workspace_app_install_progress_publish_skipped",
 			"workspaceId", workspaceID,
@@ -423,11 +435,14 @@ func (s *AppCenterService) publishInstallProgress(ctx context.Context, workspace
 			"runtimeStatus", app.Runtime.Status,
 			"userPhase", progress.UserPhase,
 			"overallPercent", progress.OverallPercent,
-			"reason", "runtime_already_running",
+			"reason", "runtime_terminal",
 		)
 		return
 	}
-	s.setInstallJobProgress(workspaceID, appID, progress)
+	if !s.setInstallJobProgress(workspaceID, appID, generation, progress) {
+		return
+	}
+	s.markInstallProgressSent(workspaceID, appID, generation)
 	progressCopy := progress
 	app.InstallProgress = &progressCopy
 	publishedApp := s.publishAppIfChanged(ctx, workspaceID, appID, app)
@@ -447,14 +462,24 @@ func (s *AppCenterService) publishInstallProgress(ctx context.Context, workspace
 	}
 }
 
-func (s *AppCenterService) clearInstallProgress(workspaceID string, appID string) {
-	s.clearInstallJobProgress(workspaceID, appID)
+func (s *AppCenterService) clearInstallProgress(workspaceID string, appID string, generation uint64) {
+	unlock := s.installPublishLocks.Lock(appRuntimeKey(workspaceID, appID))
+	defer unlock()
+	s.clearInstallProgressLocked(workspaceID, appID, generation)
+}
+
+func (s *AppCenterService) clearInstallProgressLocked(workspaceID string, appID string, generation uint64) {
+	wasSent := s.installProgressWasSent(workspaceID, appID, generation)
+	if !s.clearInstallJobProgress(workspaceID, appID, generation) {
+		return
+	}
+	defer s.clearInstallProgressSent(workspaceID, appID, generation)
 	ctx := context.Background()
 	app, err := s.workspaceAppProjectionForInstall(ctx, workspaceID, appID)
 	if err != nil {
 		return
 	}
-	if app.InstallProgress == nil {
+	if app.InstallProgress == nil && !wasSent {
 		slog.Info(
 			"workspace_app_install_progress_clear_skipped",
 			"workspaceId", workspaceID,
@@ -475,9 +500,37 @@ func (s *AppCenterService) clearInstallProgress(workspaceID string, appID string
 	)
 }
 
-func shouldSkipInstallProgressPublish(status workspacebiz.AppRuntimeStatus, progress workspacebiz.AppInstallProgress) bool {
-	return status == workspacebiz.AppRuntimeStatusRunning &&
-		progress.UserPhase == workspacebiz.AppInstallUserPhaseStarting
+func shouldSkipInstallProgressPublish(runtime workspacebiz.AppRuntimeState, job workspaceAppInstallJob) bool {
+	switch runtime.Status {
+	case workspacebiz.AppRuntimeStatusStopping:
+		return true
+	case workspacebiz.AppRuntimeStatusFailed,
+		workspacebiz.AppRuntimeStatusRunning,
+		workspacebiz.AppRuntimeStatusInstalledPendingRestart:
+		return !runtimeMatchesInstallBaseline(runtime, job)
+	default:
+		return false
+	}
+}
+
+func runtimeMatchesInstallBaseline(runtime workspacebiz.AppRuntimeState, job workspaceAppInstallJob) bool {
+	switch runtime.Status {
+	case workspacebiz.AppRuntimeStatusFailed,
+		workspacebiz.AppRuntimeStatusRunning,
+		workspacebiz.AppRuntimeStatusInstalledPendingRestart:
+	default:
+		return false
+	}
+	statusMatches := runtime.Status == job.BaselineRuntimeStatus ||
+		(runtime.Status == workspacebiz.AppRuntimeStatusInstalledPendingRestart &&
+			job.BaselineRuntimeStatus == workspacebiz.AppRuntimeStatusRunning)
+	if !statusMatches {
+		return false
+	}
+	if runtime.UpdatedAtUnixMs == nil || job.BaselineRuntimeUpdatedAtUnixMs == nil {
+		return runtime.UpdatedAtUnixMs == nil && job.BaselineRuntimeUpdatedAtUnixMs == nil
+	}
+	return *runtime.UpdatedAtUnixMs == *job.BaselineRuntimeUpdatedAtUnixMs
 }
 
 func (s *AppCenterService) registerActiveInstallTracker(workspaceID string, appID string, tracker *installProgressTracker) {
@@ -490,11 +543,13 @@ func (s *AppCenterService) registerActiveInstallTracker(workspaceID string, appI
 	s.activeInstallTrackers[key] = tracker
 }
 
-func (s *AppCenterService) unregisterActiveInstallTracker(workspaceID string, appID string) {
+func (s *AppCenterService) unregisterActiveInstallTracker(workspaceID string, appID string, tracker *installProgressTracker) {
 	key := appRuntimeKey(workspaceID, appID)
 	s.installMu.Lock()
 	defer s.installMu.Unlock()
-	delete(s.activeInstallTrackers, key)
+	if s.activeInstallTrackers[key] == tracker {
+		delete(s.activeInstallTrackers, key)
+	}
 }
 
 func (s *AppCenterService) activeInstallTracker(workspaceID string, appID string) *installProgressTracker {
@@ -529,7 +584,7 @@ func (s *AppCenterService) withActiveInstallJobProgress(app workspacebiz.Workspa
 	if !ok ||
 		job.Status != workspaceAppInstallJobInstalling ||
 		job.Progress == nil ||
-		!shouldAttachActiveInstallProgress(app.Runtime.Status) {
+		(!shouldAttachActiveInstallProgress(app.Runtime.Status) && !runtimeMatchesInstallBaseline(app.Runtime, job)) {
 		return app
 	}
 	progressCopy := *job.Progress

--- a/services/tuttid/service/workspace/apps_install_progress_test.go
+++ b/services/tuttid/service/workspace/apps_install_progress_test.go
@@ -1,7 +1,11 @@
 package workspace
 
 import (
+	"context"
+	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 )
@@ -97,8 +101,8 @@ func TestWithActiveInstallJobProgressOnlyAttachesToInstallRuntimeStates(t *testi
 		UserPhase:      workspacebiz.AppInstallUserPhaseStarting,
 		OverallPercent: 95,
 	}
-	service.beginInstallJob("ws-1", "app-1", InstallOptions{})
-	service.setInstallJobProgress("ws-1", "app-1", progress)
+	generation := beginInstallJobForTest(t, service, "ws-1", "app-1")
+	service.setInstallJobProgress("ws-1", "app-1", generation, progress)
 
 	for _, status := range []workspacebiz.AppRuntimeStatus{
 		workspacebiz.AppRuntimeStatusPreparing,
@@ -130,21 +134,378 @@ func TestWithActiveInstallJobProgressOnlyAttachesToInstallRuntimeStates(t *testi
 	}
 }
 
-func TestShouldSkipInstallProgressPublishForRunningStartingProgress(t *testing.T) {
+func TestShouldSkipInstallProgressPublishOnlyForNewTerminalRuntimeStates(t *testing.T) {
+	baselineUpdatedAt := int64(100)
+	newerUpdatedAt := int64(101)
+	job := workspaceAppInstallJob{
+		BaselineRuntimeStatus:          workspacebiz.AppRuntimeStatusRunning,
+		BaselineRuntimeUpdatedAtUnixMs: &baselineUpdatedAt,
+	}
+	tests := []struct {
+		name    string
+		runtime workspacebiz.AppRuntimeState
+		want    bool
+	}{
+		{name: "baseline running update remains visible", runtime: workspacebiz.AppRuntimeState{Status: workspacebiz.AppRuntimeStatusRunning, UpdatedAtUnixMs: &baselineUpdatedAt}},
+		{name: "baseline running projected as pending restart remains visible", runtime: workspacebiz.AppRuntimeState{Status: workspacebiz.AppRuntimeStatusInstalledPendingRestart, UpdatedAtUnixMs: &baselineUpdatedAt}},
+		{name: "new running terminal is skipped", runtime: workspacebiz.AppRuntimeState{Status: workspacebiz.AppRuntimeStatusRunning, UpdatedAtUnixMs: &newerUpdatedAt}, want: true},
+		{name: "new failure terminal is skipped", runtime: workspacebiz.AppRuntimeState{Status: workspacebiz.AppRuntimeStatusFailed, UpdatedAtUnixMs: &newerUpdatedAt}, want: true},
+		{name: "stopping is always skipped", runtime: workspacebiz.AppRuntimeState{Status: workspacebiz.AppRuntimeStatusStopping}, want: true},
+		{name: "starting remains visible", runtime: workspacebiz.AppRuntimeState{Status: workspacebiz.AppRuntimeStatusStarting}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := shouldSkipInstallProgressPublish(test.runtime, job); got != test.want {
+				t.Fatalf("shouldSkipInstallProgressPublish(%#v) = %v, want %v", test.runtime, got, test.want)
+			}
+		})
+	}
+
+	failedJob := workspaceAppInstallJob{
+		BaselineRuntimeStatus:          workspacebiz.AppRuntimeStatusFailed,
+		BaselineRuntimeUpdatedAtUnixMs: &baselineUpdatedAt,
+	}
+	if shouldSkipInstallProgressPublish(workspacebiz.AppRuntimeState{
+		Status: workspacebiz.AppRuntimeStatusFailed, UpdatedAtUnixMs: &baselineUpdatedAt,
+	}, failedJob) {
+		t.Fatal("baseline failed app update was skipped")
+	}
+}
+
+func TestInstallProgressCannotOverwriteRuntimeFailureTerminal(t *testing.T) {
+	ctx := context.Background()
+	packageDir := createWorkspaceAppPackageForTest(t, t.TempDir(), workspacebiz.AppManifest{
+		SchemaVersion: workspacebiz.AppManifestSchemaVersionV1,
+		AppID:         "app-1",
+		Version:       "0.1.0",
+		Name:          "App One",
+		Description:   "App One",
+		Runtime: workspacebiz.AppManifestRuntime{
+			Bootstrap:       "bootstrap.sh",
+			HealthcheckPath: "/ready",
+		},
+	})
+	appPackage := workspacebiz.AppPackage{
+		AppID: "app-1", Version: "0.1.0", PackageDir: packageDir,
+		Manifest: mustReadManifestForTest(t, packageDir), Source: workspacebiz.AppPackageSourceImported,
+	}
+	store := newAppStoreStub()
+	if err := store.PutAppPackage(ctx, appPackage); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutWorkspaceAppInstallation(ctx, workspacebiz.AppInstallation{
+		WorkspaceID: "ws-1", AppID: "app-1", Enabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	runner := &AppRunner{}
+	runner.ensure()
+	key := appRuntimeKey("ws-1", "app-1")
+	runner.mu.Lock()
+	runner.states[key] = workspacebiz.AppRuntimeState{Status: workspacebiz.AppRuntimeStatusPreparing}
+	runner.mu.Unlock()
+	publisher := &workspaceAppPublisherStub{}
+	service := &AppCenterService{Store: store, Runner: runner, Publisher: publisher}
+	generation := beginInstallJobForTest(t, service, "ws-1", "app-1")
 	progress := workspacebiz.AppInstallProgress{
-		UserPhase:      workspacebiz.AppInstallUserPhaseStarting,
-		OverallPercent: 100,
+		UserPhase: workspacebiz.AppInstallUserPhaseStarting, OverallPercent: 95,
 	}
-	if !shouldSkipInstallProgressPublish(workspacebiz.AppRuntimeStatusRunning, progress) {
-		t.Fatal("shouldSkipInstallProgressPublish(running, starting) = false, want true")
+	service.publishInstallProgress(ctx, "ws-1", "app-1", generation, progress, true)
+	if len(publisher.published) == 0 || publisher.published[len(publisher.published)-1].InstallProgress == nil {
+		t.Fatal("transient install progress was not published")
 	}
-	if shouldSkipInstallProgressPublish(workspacebiz.AppRuntimeStatusRunning, workspacebiz.AppInstallProgress{
-		UserPhase:      workspacebiz.AppInstallUserPhaseDownloading,
-		OverallPercent: 40,
-	}) {
-		t.Fatal("shouldSkipInstallProgressPublish(running, downloading) = true, want false")
+
+	failurePhase := workspacebiz.AppFailurePhaseStarting
+	failureReason := "health check failed"
+	runner.mu.Lock()
+	runner.states[key] = workspacebiz.AppRuntimeState{
+		Status: workspacebiz.AppRuntimeStatusFailed, FailurePhase: &failurePhase,
+		FailureReason: &failureReason, LastError: &failureReason,
 	}
-	if shouldSkipInstallProgressPublish(workspacebiz.AppRuntimeStatusStarting, progress) {
-		t.Fatal("shouldSkipInstallProgressPublish(starting, starting) = true, want false")
+	runner.mu.Unlock()
+	progress.OverallPercent = 100
+	service.publishInstallProgress(ctx, "ws-1", "app-1", generation, progress, true)
+
+	last := publisher.published[len(publisher.published)-1]
+	if last.Runtime.Status != workspacebiz.AppRuntimeStatusFailed || last.InstallProgress != nil {
+		t.Fatalf("late install progress replaced failure terminal: %#v", last)
 	}
+	if service.installProgressWasSent("ws-1", "app-1", generation) {
+		t.Fatal("published progress marker was not cleared")
+	}
+}
+
+func TestInstallFailureIsFinalAfterProgressCleanup(t *testing.T) {
+	ctx := context.Background()
+	packageDir := createWorkspaceAppPackageForTest(t, t.TempDir(), workspacebiz.AppManifest{
+		SchemaVersion: workspacebiz.AppManifestSchemaVersionV1,
+		AppID:         "app-1",
+		Version:       "0.1.0",
+		Name:          "App One",
+		Description:   "App One",
+		Runtime: workspacebiz.AppManifestRuntime{
+			Bootstrap:       "bootstrap.sh",
+			HealthcheckPath: "/ready",
+		},
+	})
+	appPackage := workspacebiz.AppPackage{
+		AppID: "app-1", Version: "0.1.0", PackageDir: packageDir,
+		Manifest: mustReadManifestForTest(t, packageDir), Source: workspacebiz.AppPackageSourceImported,
+	}
+	store := newAppStoreStub()
+	if err := store.PutAppPackage(ctx, appPackage); err != nil {
+		t.Fatal(err)
+	}
+	publisher := &workspaceAppPublisherStub{}
+	service := &AppCenterService{Store: store, Runner: &AppRunner{}, Publisher: publisher}
+	generation := beginInstallJobForTest(t, service, "ws-1", "app-1")
+	service.publishInstallProgress(ctx, "ws-1", "app-1", generation, workspacebiz.AppInstallProgress{
+		UserPhase: workspacebiz.AppInstallUserPhaseDownloading, OverallPercent: 25,
+	}, true)
+
+	installErr := errors.New("download interrupted")
+	service.handleInstallJobFailure(ctx, "ws-1", "app-1", generation, appPackage, installErr, time.Now())
+	publishedAfterFailure := len(publisher.published)
+	service.clearInstallProgress("ws-1", "app-1", generation) // Mirrors the deferred tracker cleanup.
+
+	if len(publisher.published) != publishedAfterFailure {
+		t.Fatalf("deferred cleanup published after failure: event count %d -> %d", publishedAfterFailure, len(publisher.published))
+	}
+	last := publisher.published[len(publisher.published)-1]
+	if last.Runtime.Status != workspacebiz.AppRuntimeStatusFailed || last.InstallProgress != nil {
+		t.Fatalf("last projection = %#v, want failed terminal without progress", last)
+	}
+	if last.Runtime.FailureReason == nil || *last.Runtime.FailureReason != installErr.Error() {
+		t.Fatalf("FailureReason = %v, want %q", last.Runtime.FailureReason, installErr)
+	}
+}
+
+func TestInstallFailureSerializesWithInFlightProgressPublish(t *testing.T) {
+	ctx := context.Background()
+	packageDir := createWorkspaceAppPackageForTest(t, t.TempDir(), workspacebiz.AppManifest{
+		SchemaVersion: workspacebiz.AppManifestSchemaVersionV1,
+		AppID:         "app-1",
+		Version:       "0.1.0",
+		Name:          "App One",
+		Description:   "App One",
+		Runtime: workspacebiz.AppManifestRuntime{
+			Bootstrap:       "bootstrap.sh",
+			HealthcheckPath: "/ready",
+		},
+	})
+	appPackage := workspacebiz.AppPackage{
+		AppID: "app-1", Version: "0.1.0", PackageDir: packageDir,
+		Manifest: mustReadManifestForTest(t, packageDir), Source: workspacebiz.AppPackageSourceImported,
+	}
+	store := newAppStoreStub()
+	if err := store.PutAppPackage(ctx, appPackage); err != nil {
+		t.Fatal(err)
+	}
+	publisher := newBlockingInstallProgressPublisher()
+	service := &AppCenterService{Store: store, Runner: &AppRunner{}, Publisher: publisher}
+	generation := beginInstallJobForTest(t, service, "ws-1", "app-1")
+
+	progressDone := make(chan struct{})
+	go func() {
+		defer close(progressDone)
+		service.publishInstallProgress(ctx, "ws-1", "app-1", generation, workspacebiz.AppInstallProgress{
+			UserPhase: workspacebiz.AppInstallUserPhaseDownloading, OverallPercent: 25,
+		}, true)
+	}()
+	select {
+	case <-publisher.progressEntered:
+	case <-time.After(time.Second):
+		t.Fatal("progress publish did not reach publisher")
+	}
+
+	failureDone := make(chan struct{})
+	go func() {
+		defer close(failureDone)
+		service.handleInstallJobFailure(ctx, "ws-1", "app-1", generation, appPackage, errors.New("download interrupted"), time.Now())
+	}()
+	close(publisher.releaseProgress)
+	for name, done := range map[string]<-chan struct{}{"progress": progressDone, "failure": failureDone} {
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatalf("%s publication did not finish", name)
+		}
+	}
+
+	published := publisher.snapshot()
+	last := published[len(published)-1]
+	if last.Runtime.Status != workspacebiz.AppRuntimeStatusFailed || last.InstallProgress != nil {
+		t.Fatalf("last projection = %#v, want failed terminal without progress", last)
+	}
+}
+
+func TestOldInstallGenerationCannotPublishOrClearNewInstallProgress(t *testing.T) {
+	service := &AppCenterService{}
+	oldGeneration := beginInstallJobForTest(t, service, "ws-1", "app-1")
+	if !service.failInstallJob("ws-1", "app-1", oldGeneration, errors.New("first install failed")) {
+		t.Fatal("failInstallJob() = false, want true")
+	}
+	newGeneration := beginInstallJobForTest(t, service, "ws-1", "app-1")
+	if newGeneration == oldGeneration {
+		t.Fatal("new install reused the previous generation")
+	}
+
+	service.publishInstallProgress(context.Background(), "ws-1", "app-1", oldGeneration, workspacebiz.AppInstallProgress{
+		UserPhase: workspacebiz.AppInstallUserPhaseDownloading, OverallPercent: 90,
+	}, true)
+	service.clearInstallProgress("ws-1", "app-1", oldGeneration)
+
+	job, ok := service.installJob("ws-1", "app-1")
+	if !ok || job.Generation != newGeneration || job.Status != workspaceAppInstallJobInstalling {
+		t.Fatalf("current install job was changed by stale generation: %#v", job)
+	}
+}
+
+func TestCompleteInstallJobClearsProgressBeforeRemovingGeneration(t *testing.T) {
+	ctx := context.Background()
+	packageDir := createWorkspaceAppPackageForTest(t, t.TempDir(), workspacebiz.AppManifest{
+		SchemaVersion: workspacebiz.AppManifestSchemaVersionV1,
+		AppID:         "app-1",
+		Version:       "0.1.0",
+		Name:          "App One",
+		Description:   "App One",
+		Runtime: workspacebiz.AppManifestRuntime{
+			Bootstrap:       "bootstrap.sh",
+			HealthcheckPath: "/ready",
+		},
+	})
+	store := newAppStoreStub()
+	if err := store.PutAppPackage(ctx, workspacebiz.AppPackage{
+		AppID: "app-1", Version: "0.1.0", PackageDir: packageDir,
+		Manifest: mustReadManifestForTest(t, packageDir), Source: workspacebiz.AppPackageSourceImported,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	publisher := &workspaceAppPublisherStub{}
+	service := &AppCenterService{Store: store, Runner: &AppRunner{}, Publisher: publisher}
+	generation := beginInstallJobForTest(t, service, "ws-1", "app-1")
+	service.publishInstallProgress(ctx, "ws-1", "app-1", generation, workspacebiz.AppInstallProgress{
+		UserPhase: workspacebiz.AppInstallUserPhaseInstalling, OverallPercent: 75,
+	}, true)
+
+	if !service.completeInstallJob("ws-1", "app-1", generation) {
+		t.Fatal("completeInstallJob() = false, want true")
+	}
+	if _, ok := service.installJob("ws-1", "app-1"); ok {
+		t.Fatal("completed install job was not removed")
+	}
+	last := publisher.published[len(publisher.published)-1]
+	if last.InstallProgress != nil {
+		t.Fatalf("last projection retained install progress: %#v", last.InstallProgress)
+	}
+}
+
+func TestInstallProgressIsVisibleWhileUpdatingBaselineTerminalApp(t *testing.T) {
+	ctx := context.Background()
+	packageDir := createWorkspaceAppPackageForTest(t, t.TempDir(), workspacebiz.AppManifest{
+		SchemaVersion: workspacebiz.AppManifestSchemaVersionV1,
+		AppID:         "app-1",
+		Version:       "0.1.0",
+		Name:          "App One",
+		Description:   "App One",
+		Runtime: workspacebiz.AppManifestRuntime{
+			Bootstrap:       "bootstrap.sh",
+			HealthcheckPath: "/ready",
+		},
+	})
+	appPackage := workspacebiz.AppPackage{
+		AppID: "app-1", Version: "0.1.0", PackageDir: packageDir,
+		Manifest: mustReadManifestForTest(t, packageDir), Source: workspacebiz.AppPackageSourceImported,
+	}
+
+	for _, status := range []workspacebiz.AppRuntimeStatus{
+		workspacebiz.AppRuntimeStatusRunning,
+		workspacebiz.AppRuntimeStatusFailed,
+	} {
+		t.Run(string(status), func(t *testing.T) {
+			store := newAppStoreStub()
+			if err := store.PutAppPackage(ctx, appPackage); err != nil {
+				t.Fatal(err)
+			}
+			if err := store.PutWorkspaceAppInstallation(ctx, workspacebiz.AppInstallation{
+				WorkspaceID: "ws-1", AppID: "app-1", Enabled: true,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			updatedAt := int64(100)
+			runner := &AppRunner{}
+			runner.ensure()
+			runner.states[appRuntimeKey("ws-1", "app-1")] = workspacebiz.AppRuntimeState{
+				Status: status, UpdatedAtUnixMs: &updatedAt,
+			}
+			publisher := &workspaceAppPublisherStub{}
+			service := &AppCenterService{Store: store, Runner: runner, Publisher: publisher}
+			generation := beginInstallJobForTest(t, service, "ws-1", "app-1")
+			service.publishInstallProgress(ctx, "ws-1", "app-1", generation, workspacebiz.AppInstallProgress{
+				UserPhase: workspacebiz.AppInstallUserPhaseDownloading, OverallPercent: 25,
+			}, true)
+
+			last := publisher.published[len(publisher.published)-1]
+			if last.InstallProgress == nil {
+				t.Fatalf("install progress missing while updating baseline %q app", status)
+			}
+		})
+	}
+}
+
+func TestInstallJobRetainsCurrentPhaseWhenPublishedProgressIsCleared(t *testing.T) {
+	service := &AppCenterService{}
+	generation := beginInstallJobForTest(t, service, "ws-1", "app-1")
+	service.setInstallJobPhase("ws-1", "app-1", generation, workspacebiz.AppInstallUserPhaseStarting)
+	service.clearInstallJobProgress("ws-1", "app-1", generation)
+	service.failInstallJob("ws-1", "app-1", generation, errors.New("activation failed"))
+
+	job, ok := service.installJob("ws-1", "app-1")
+	if !ok || job.FailurePhase != workspacebiz.AppFailurePhaseStarting {
+		t.Fatalf("failed install job = %#v, want starting failure phase", job)
+	}
+}
+
+func beginInstallJobForTest(t *testing.T, service *AppCenterService, workspaceID string, appID string) uint64 {
+	t.Helper()
+	if !service.beginInstallJob(workspaceID, appID, InstallOptions{}) {
+		t.Fatal("beginInstallJob() = false, want true")
+	}
+	job, ok := service.installJob(workspaceID, appID)
+	if !ok || job.Generation == 0 {
+		t.Fatalf("install job = %#v, want non-zero generation", job)
+	}
+	return job.Generation
+}
+
+type blockingInstallProgressPublisher struct {
+	progressEntered chan struct{}
+	releaseProgress chan struct{}
+	progressOnce    sync.Once
+	mu              sync.Mutex
+	published       []workspacebiz.WorkspaceApp
+}
+
+func newBlockingInstallProgressPublisher() *blockingInstallProgressPublisher {
+	return &blockingInstallProgressPublisher{
+		progressEntered: make(chan struct{}),
+		releaseProgress: make(chan struct{}),
+	}
+}
+
+func (p *blockingInstallProgressPublisher) PublishWorkspaceAppUpdated(_ context.Context, _ string, app workspacebiz.WorkspaceApp) error {
+	if app.InstallProgress != nil {
+		p.progressOnce.Do(func() { close(p.progressEntered) })
+		<-p.releaseProgress
+	}
+	p.mu.Lock()
+	p.published = append(p.published, app)
+	p.mu.Unlock()
+	return nil
+}
+
+func (p *blockingInstallProgressPublisher) snapshot() []workspacebiz.WorkspaceApp {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]workspacebiz.WorkspaceApp(nil), p.published...)
 }

--- a/services/tuttid/service/workspace/apps_install_test.go
+++ b/services/tuttid/service/workspace/apps_install_test.go
@@ -467,6 +467,9 @@ func TestAppCenterServiceInstallCancelsPackageDownloadAfterRuntimePreloadFailure
 			if !strings.Contains(job.FailureReason, runtimeErr.Error()) {
 				t.Fatalf("FailureReason = %q, want runtime preload error", job.FailureReason)
 			}
+			if job.FailurePhase != workspacebiz.AppFailurePhaseDownloading {
+				t.Fatalf("FailurePhase = %q, want downloading", job.FailurePhase)
+			}
 			return
 		}
 		select {

--- a/services/tuttid/service/workspace/apps_runner.go
+++ b/services/tuttid/service/workspace/apps_runner.go
@@ -33,6 +33,7 @@ type AppRunner struct {
 	OnStateChanged     AppRunnerStateChanged
 	RuntimeResolver    AppRuntimeResolver
 
+	initOnce  sync.Once
 	mu        sync.Mutex
 	processes map[string]*appProcess
 	states    map[string]workspacebiz.AppRuntimeState
@@ -104,20 +105,21 @@ func (r *AppRunner) Start(ctx context.Context, input AppStartInput) (workspacebi
 		start.cancel()
 		delete(r.starts, key)
 	}
-	r.mu.Unlock()
-	if running {
-		_, _ = r.Stop(ctx, input.WorkspaceID, input.AppID)
-	}
 	startCtx, cancel := context.WithCancel(context.Background())
 	start := &appStart{cancel: cancel}
-	r.mu.Lock()
 	r.starts[key] = start
 	r.mu.Unlock()
-
-	state := r.setState(key, workspacebiz.AppRuntimeState{
+	if running {
+		_, _ = r.stopProcess(ctx, key, existing)
+	}
+	state, committed := r.setStateForStart(key, start, workspacebiz.AppRuntimeState{
 		Status:     workspacebiz.AppRuntimeStatusPreparing,
 		PackageDir: input.PackageDir,
 	})
+	if !committed {
+		cancel()
+		return state, nil
+	}
 	go r.startQueued(startCtx, key, input, start)
 	return state, nil
 }
@@ -153,49 +155,49 @@ func (r *AppRunner) startQueued(ctx context.Context, key string, input AppStartI
 		r.finishStart(key, ctx, start)
 		return
 	}
-	r.startProcess(ctx, key, input)
+	r.startProcess(ctx, key, input, start)
 	r.finishStart(key, ctx, start)
 }
 
-func (r *AppRunner) startProcess(ctx context.Context, key string, input AppStartInput) {
+func (r *AppRunner) startProcess(ctx context.Context, key string, input AppStartInput, start *appStart) {
 	port, err := allocateLoopbackPort()
 	if err != nil {
 		logAppRuntimeControl("workspace_app_runtime_start_failed", input, 0, "startup", fmt.Errorf("allocate app port: %w", err))
-		r.setFailed(key, "startup", fmt.Errorf("allocate app port: %w", err))
+		r.setFailedForStart(key, start, "startup", fmt.Errorf("allocate app port: %w", err))
 		return
 	}
 
 	if err := os.MkdirAll(input.RuntimeDir, 0o755); err != nil {
 		logAppRuntimeControl("workspace_app_runtime_start_failed", input, port, "startup", fmt.Errorf("create app runtime dir: %w", err))
-		r.setFailed(key, "startup", fmt.Errorf("create app runtime dir: %w", err))
+		r.setFailedForStart(key, start, "startup", fmt.Errorf("create app runtime dir: %w", err))
 		return
 	}
 	if err := os.MkdirAll(input.DataDir, 0o755); err != nil {
 		logAppRuntimeControl("workspace_app_runtime_start_failed", input, port, "startup", fmt.Errorf("create app data dir: %w", err))
-		r.setFailed(key, "startup", fmt.Errorf("create app data dir: %w", err))
+		r.setFailedForStart(key, start, "startup", fmt.Errorf("create app data dir: %w", err))
 		return
 	}
 	if err := os.MkdirAll(input.DatabaseDir, 0o755); err != nil {
 		logAppRuntimeControl("workspace_app_runtime_start_failed", input, port, "startup", fmt.Errorf("create app database dir: %w", err))
-		r.setFailed(key, "startup", fmt.Errorf("create app database dir: %w", err))
+		r.setFailedForStart(key, start, "startup", fmt.Errorf("create app database dir: %w", err))
 		return
 	}
 	if err := os.MkdirAll(input.LogDir, 0o755); err != nil {
 		logAppRuntimeControl("workspace_app_runtime_start_failed", input, port, "startup", fmt.Errorf("create app log dir: %w", err))
-		r.setFailed(key, "startup", fmt.Errorf("create app log dir: %w", err))
+		r.setFailedForStart(key, start, "startup", fmt.Errorf("create app log dir: %w", err))
 		return
 	}
 	appRuntime, err := r.resolveRuntime(ctx, input.RuntimeProfile)
 	if err != nil {
 		logAppRuntimeControl("workspace_app_runtime_start_failed", input, port, "runtime_unavailable", err)
-		r.setFailed(key, "runtime_unavailable", err)
+		r.setFailedForStart(key, start, "runtime_unavailable", err)
 		return
 	}
 
 	logFile, err := os.OpenFile(filepath.Join(input.LogDir, "runtime.log"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
 	if err != nil {
 		logAppRuntimeControl("workspace_app_runtime_start_failed", input, port, "startup", fmt.Errorf("open app runtime log: %w", err))
-		r.setFailed(key, "startup", fmt.Errorf("open app runtime log: %w", err))
+		r.setFailedForStart(key, start, "startup", fmt.Errorf("open app runtime log: %w", err))
 		return
 	}
 
@@ -209,7 +211,7 @@ func (r *AppRunner) startProcess(ctx context.Context, key string, input AppStart
 	if err != nil {
 		_ = logFile.Close()
 		logAppRuntimeControl("workspace_app_runtime_start_failed", input, port, "bootstrap_unavailable", err)
-		r.setFailed(key, "bootstrap_unavailable", err)
+		r.setFailedForStart(key, start, "bootstrap_unavailable", err)
 		return
 	}
 	prepareAppProcessCommand(command)
@@ -251,13 +253,16 @@ func (r *AppRunner) startProcess(ctx context.Context, key string, input AppStart
 		done:    make(chan error, 1),
 		logFile: logFile,
 	}
-	r.setState(key, workspacebiz.AppRuntimeState{
+	if _, committed := r.setStateForStart(key, start, workspacebiz.AppRuntimeState{
 		Status:          workspacebiz.AppRuntimeStatusStarting,
 		LaunchURL:       &launchURL,
 		Port:            &port,
 		StartedAtUnixMs: &startedAt,
 		PackageDir:      input.PackageDir,
-	})
+	}); !committed {
+		_ = logFile.Close()
+		return
+	}
 
 	if err := ctx.Err(); err != nil {
 		_ = logFile.Close()
@@ -266,11 +271,20 @@ func (r *AppRunner) startProcess(ctx context.Context, key string, input AppStart
 	if err := command.Start(); err != nil {
 		_ = logFile.Close()
 		logAppRuntimeControl("workspace_app_runtime_start_failed", input, port, "startup", fmt.Errorf("start app process: %w", err))
-		r.setFailed(key, "startup", fmt.Errorf("start app process: %w", err))
+		r.setFailedForStart(key, start, "startup", fmt.Errorf("start app process: %w", err))
 		return
 	}
 
 	r.mu.Lock()
+	if r.starts[key] != start || ctx.Err() != nil {
+		process.stopRequested = true
+		r.mu.Unlock()
+		go waitForDetachedAppProcess(process)
+		if err := interruptAppProcess(process.command); err != nil {
+			_ = killAppProcess(process.command)
+		}
+		return
+	}
 	r.processes[key] = process
 	r.mu.Unlock()
 
@@ -284,18 +298,19 @@ func (r *AppRunner) startProcess(ctx context.Context, key string, input AppStart
 		}
 		_, _ = r.stopProcess(context.Background(), key, process)
 		logAppRuntimeControl("workspace_app_runtime_healthcheck_failed", input, port, "healthcheck", healthErr)
-		r.setFailed(key, "healthcheck", healthErr)
+		r.setFailedForStart(key, start, "healthcheck", healthErr)
 		return
 	}
 
-	logAppRuntimeControl("workspace_app_runtime_running", input, port, "", nil)
-	r.setState(key, workspacebiz.AppRuntimeState{
+	if r.setRunningIfProcessCurrent(key, start, process, workspacebiz.AppRuntimeState{
 		Status:          workspacebiz.AppRuntimeStatusRunning,
 		LaunchURL:       &launchURL,
 		Port:            &port,
 		StartedAtUnixMs: &startedAt,
 		PackageDir:      input.PackageDir,
-	})
+	}) {
+		logAppRuntimeControl("workspace_app_runtime_running", input, port, "", nil)
+	}
 }
 
 func tuttiAPIBaseURLFromEnv() string {
@@ -346,17 +361,22 @@ func (r *AppRunner) Stop(ctx context.Context, workspaceID string, appID string) 
 	}
 	process := r.processes[key]
 	existingState, hasExistingState := r.states[key]
-	r.mu.Unlock()
 	if process == nil {
 		if !hasExistingState || existingState.Status == workspacebiz.AppRuntimeStatusIdle {
+			r.mu.Unlock()
 			return workspacebiz.AppRuntimeState{
 				Status: workspacebiz.AppRuntimeStatusIdle,
 			}, nil
 		}
-		return r.setState(key, workspacebiz.AppRuntimeState{
+		state := withRuntimeUpdated(workspacebiz.AppRuntimeState{
 			Status: workspacebiz.AppRuntimeStatusIdle,
-		}), nil
+		})
+		r.states[key] = state
+		r.mu.Unlock()
+		r.notifyStateChanged(key, state)
+		return state, nil
 	}
+	r.mu.Unlock()
 
 	return r.stopProcess(ctx, key, process)
 }
@@ -506,8 +526,10 @@ func (r *AppRunner) setStoppedProcessIdle(key string, process *appProcess) works
 
 func (r *AppRunner) setStoppedProcessFailed(key string, process *appProcess, failureReason string, err error) workspacebiz.AppRuntimeState {
 	message := err.Error()
+	failurePhase := workspacebiz.AppFailurePhaseRuntime
 	return r.setStoppedProcessTerminalState(key, process, workspacebiz.AppRuntimeState{
 		Status:        workspacebiz.AppRuntimeStatusFailed,
+		FailurePhase:  &failurePhase,
 		FailureReason: &failureReason,
 		LastError:     &message,
 	})
@@ -568,44 +590,6 @@ func writeAppStartupDiagnostic(logFile *os.File, input AppStartInput, bootstrapP
 	_, _ = fmt.Fprintf(logFile, "  path=%s\n", appRuntimeEnvValue(env, "PATH"))
 }
 
-func (r *AppRunner) waitForProcess(key string, process *appProcess) {
-	err := process.command.Wait()
-	_ = process.logFile.Close()
-
-	r.mu.Lock()
-	if current := r.processes[key]; current != process {
-		r.mu.Unlock()
-		process.done <- err
-		return
-	}
-	delete(r.processes, key)
-	var nextState workspacebiz.AppRuntimeState
-	if process.stopRequested || err == nil {
-		nextState = withRuntimeUpdated(workspacebiz.AppRuntimeState{Status: workspacebiz.AppRuntimeStatusIdle})
-	} else {
-		message := err.Error()
-		nextState = withRuntimeUpdated(workspacebiz.AppRuntimeState{
-			Status:        workspacebiz.AppRuntimeStatusFailed,
-			FailureReason: stringPtr("process_exit"),
-			LastError:     &message,
-		})
-	}
-	if !process.stopRequested && err != nil {
-		slog.Warn(
-			"workspace_app_runtime_process_failed",
-			"workspaceId", appRuntimeWorkspaceIDFromKey(key),
-			"appId", appRuntimeAppIDFromKey(key),
-			"failureReason", "process_exit",
-			"lastError", err.Error(),
-			"error", err,
-		)
-	}
-	r.states[key] = nextState
-	r.mu.Unlock()
-	r.notifyStateChanged(key, nextState)
-	process.done <- err
-}
-
 func logAppRuntimeControl(event string, input AppStartInput, port int, failureReason string, err error) {
 	fields := []any{
 		"workspaceId", input.WorkspaceID,
@@ -629,30 +613,6 @@ func logAppRuntimeControl(event string, input AppStartInput, port int, failureRe
 		return
 	}
 	slog.Info(event, fields...)
-}
-
-func (r *AppRunner) finishStart(key string, ctx context.Context, start *appStart) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	currentStart := r.starts[key]
-	if currentStart == nil || currentStart != start {
-		return
-	}
-	delete(r.starts, key)
-	var nextState *workspacebiz.AppRuntimeState
-	if ctx.Err() != nil && r.processes[key] == nil {
-		current := r.states[key]
-		if current.Status == workspacebiz.AppRuntimeStatusPreparing || current.Status == workspacebiz.AppRuntimeStatusStarting {
-			state := withRuntimeUpdated(workspacebiz.AppRuntimeState{
-				Status: workspacebiz.AppRuntimeStatusIdle,
-			})
-			r.states[key] = state
-			nextState = &state
-		}
-	}
-	if nextState != nil {
-		go r.notifyStateChanged(key, *nextState)
-	}
 }
 
 func (r *AppRunner) waitForHealth(ctx context.Context, launchURL string, healthcheckPath string) error {
@@ -719,48 +679,21 @@ func (r *AppRunner) resolveRuntime(ctx context.Context, profile string) (Resolve
 	return resolver.Resolve(ctx)
 }
 
-func (r *AppRunner) setFailed(key string, reason string, err error) workspacebiz.AppRuntimeState {
-	message := ""
-	if err != nil {
-		message = err.Error()
-	}
-	return r.setState(key, workspacebiz.AppRuntimeState{
-		Status:        workspacebiz.AppRuntimeStatusFailed,
-		FailureReason: &reason,
-		LastError:     &message,
-	})
-}
-
-func (r *AppRunner) setState(key string, state workspacebiz.AppRuntimeState) workspacebiz.AppRuntimeState {
-	r.ensure()
-	r.mu.Lock()
-	updated := withRuntimeUpdated(state)
-	r.states[key] = updated
-	r.mu.Unlock()
-	r.notifyStateChanged(key, updated)
-	return updated
-}
-
-func (r *AppRunner) notifyStateChanged(key string, state workspacebiz.AppRuntimeState) {
-	if r.OnStateChanged == nil {
-		return
-	}
-	r.OnStateChanged(appRuntimeWorkspaceIDFromKey(key), appRuntimeAppIDFromKey(key), state)
-}
-
 func (r *AppRunner) ensure() {
-	if r.processes == nil {
-		r.processes = make(map[string]*appProcess)
-	}
-	if r.states == nil {
-		r.states = make(map[string]workspacebiz.AppRuntimeState)
-	}
-	if r.starts == nil {
-		r.starts = make(map[string]*appStart)
-	}
-	if r.queue == nil {
-		r.queue = make(chan struct{}, 2)
-	}
+	r.initOnce.Do(func() {
+		if r.processes == nil {
+			r.processes = make(map[string]*appProcess)
+		}
+		if r.states == nil {
+			r.states = make(map[string]workspacebiz.AppRuntimeState)
+		}
+		if r.starts == nil {
+			r.starts = make(map[string]*appStart)
+		}
+		if r.queue == nil {
+			r.queue = make(chan struct{}, 2)
+		}
+	})
 }
 
 func uniqueRuntimeKeys(keys []string) []string {
@@ -826,20 +759,6 @@ func tuttiCLIShimPathForPlatform(platform string) string {
 		commandName += ".cmd"
 	}
 	return filepath.Join(tuttitypes.DefaultStateDir(), "bin", commandName)
-}
-
-func withRuntimeUpdated(state workspacebiz.AppRuntimeState) workspacebiz.AppRuntimeState {
-	now := unixMsNow()
-	state.UpdatedAtUnixMs = &now
-	return state
-}
-
-func unixMsNow() int64 {
-	return time.Now().UTC().UnixNano() / int64(time.Millisecond)
-}
-
-func stringPtr(value string) *string {
-	return &value
 }
 
 func appRuntimeKey(workspaceID string, appID string) string {

--- a/services/tuttid/service/workspace/apps_runner_state.go
+++ b/services/tuttid/service/workspace/apps_runner_state.go
@@ -1,0 +1,175 @@
+package workspace
+
+import (
+	"context"
+	"log/slog"
+	"sync/atomic"
+	"time"
+
+	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
+)
+
+var appRuntimeUpdatedUnixMs atomic.Int64
+
+func (r *AppRunner) setRunningIfProcessCurrent(key string, start *appStart, process *appProcess, state workspacebiz.AppRuntimeState) bool {
+	r.mu.Lock()
+	current := r.states[key]
+	if r.starts[key] != start || r.processes[key] != process || process.stopRequested || current.Status != workspacebiz.AppRuntimeStatusStarting {
+		r.mu.Unlock()
+		return false
+	}
+	updated := withRuntimeUpdated(state)
+	r.states[key] = updated
+	r.mu.Unlock()
+	r.notifyStateChanged(key, updated)
+	return true
+}
+
+func (r *AppRunner) setFailedForStart(key string, start *appStart, reason string, err error) (workspacebiz.AppRuntimeState, bool) {
+	message := ""
+	if err != nil {
+		message = err.Error()
+	}
+	failurePhase := workspacebiz.AppFailurePhaseStarting
+	return r.setStateForStart(key, start, workspacebiz.AppRuntimeState{
+		Status:        workspacebiz.AppRuntimeStatusFailed,
+		FailurePhase:  &failurePhase,
+		FailureReason: &reason,
+		LastError:     &message,
+	})
+}
+
+func (r *AppRunner) setStateForStart(key string, start *appStart, state workspacebiz.AppRuntimeState) (workspacebiz.AppRuntimeState, bool) {
+	r.mu.Lock()
+	if r.starts[key] != start {
+		current := currentRuntimeStateOrIdle(r.states[key])
+		r.mu.Unlock()
+		return current, false
+	}
+	updated := withRuntimeUpdated(state)
+	r.states[key] = updated
+	r.mu.Unlock()
+	r.notifyStateChanged(key, updated)
+	return updated, true
+}
+
+func (r *AppRunner) setState(key string, state workspacebiz.AppRuntimeState) workspacebiz.AppRuntimeState {
+	r.ensure()
+	r.mu.Lock()
+	updated := withRuntimeUpdated(state)
+	r.states[key] = updated
+	r.mu.Unlock()
+	r.notifyStateChanged(key, updated)
+	return updated
+}
+
+func (r *AppRunner) notifyStateChanged(key string, state workspacebiz.AppRuntimeState) {
+	if r.OnStateChanged == nil {
+		return
+	}
+	r.OnStateChanged(appRuntimeWorkspaceIDFromKey(key), appRuntimeAppIDFromKey(key), state)
+}
+
+func (r *AppRunner) waitForProcess(key string, process *appProcess) {
+	err := process.command.Wait()
+	_ = process.logFile.Close()
+
+	r.mu.Lock()
+	if current := r.processes[key]; current != process {
+		r.mu.Unlock()
+		process.done <- err
+		return
+	}
+	delete(r.processes, key)
+	currentState := r.states[key]
+	var nextState workspacebiz.AppRuntimeState
+	if process.stopRequested {
+		nextState = withRuntimeUpdated(workspacebiz.AppRuntimeState{Status: workspacebiz.AppRuntimeStatusIdle})
+	} else {
+		message := "workspace app process exited unexpectedly with status 0"
+		if err != nil {
+			message = err.Error()
+		}
+		failurePhase := workspacebiz.AppFailurePhaseStarting
+		if currentState.Status == workspacebiz.AppRuntimeStatusRunning {
+			failurePhase = workspacebiz.AppFailurePhaseRuntime
+		}
+		nextState = withRuntimeUpdated(workspacebiz.AppRuntimeState{
+			Status:        workspacebiz.AppRuntimeStatusFailed,
+			FailurePhase:  &failurePhase,
+			FailureReason: stringPtr("process_exit"),
+			LastError:     &message,
+		})
+	}
+	if !process.stopRequested {
+		lastError := ""
+		if nextState.LastError != nil {
+			lastError = *nextState.LastError
+		}
+		slog.Warn(
+			"workspace_app_runtime_process_failed",
+			"workspaceId", appRuntimeWorkspaceIDFromKey(key),
+			"appId", appRuntimeAppIDFromKey(key),
+			"failureReason", "process_exit",
+			"lastError", lastError,
+			"error", err,
+		)
+	}
+	r.states[key] = nextState
+	r.mu.Unlock()
+	r.notifyStateChanged(key, nextState)
+	process.done <- err
+}
+
+func (r *AppRunner) finishStart(key string, ctx context.Context, start *appStart) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	currentStart := r.starts[key]
+	if currentStart == nil || currentStart != start {
+		return
+	}
+	delete(r.starts, key)
+	var nextState *workspacebiz.AppRuntimeState
+	if ctx.Err() != nil && r.processes[key] == nil {
+		current := r.states[key]
+		if current.Status == workspacebiz.AppRuntimeStatusPreparing || current.Status == workspacebiz.AppRuntimeStatusStarting {
+			state := withRuntimeUpdated(workspacebiz.AppRuntimeState{
+				Status: workspacebiz.AppRuntimeStatusIdle,
+			})
+			r.states[key] = state
+			nextState = &state
+		}
+	}
+	if nextState != nil {
+		go r.notifyStateChanged(key, *nextState)
+	}
+}
+
+func waitForDetachedAppProcess(process *appProcess) {
+	err := process.command.Wait()
+	_ = process.logFile.Close()
+	process.done <- err
+}
+
+func withRuntimeUpdated(state workspacebiz.AppRuntimeState) workspacebiz.AppRuntimeState {
+	now := unixMsNow()
+	for {
+		previous := appRuntimeUpdatedUnixMs.Load()
+		if now <= previous {
+			now = previous + 1
+		}
+		if appRuntimeUpdatedUnixMs.CompareAndSwap(previous, now) {
+			break
+		}
+	}
+	state.UpdatedAtUnixMs = &now
+	return state
+}
+
+func unixMsNow() int64 {
+	return time.Now().UTC().UnixNano() / int64(time.Millisecond)
+}
+
+func stringPtr(value string) *string {
+	return &value
+}

--- a/services/tuttid/service/workspace/apps_runner_test.go
+++ b/services/tuttid/service/workspace/apps_runner_test.go
@@ -553,6 +553,81 @@ func TestAppRunnerFinishStartIgnoresReplacedStart(t *testing.T) {
 	}
 }
 
+type barrierAppRuntimeResolver struct {
+	started  chan struct{}
+	release  chan error
+	finished chan struct{}
+}
+
+func (r *barrierAppRuntimeResolver) Resolve(context.Context) (ResolvedAppRuntime, error) {
+	close(r.started)
+	err := <-r.release
+	close(r.finished)
+	return ResolvedAppRuntime{}, err
+}
+
+func TestAppRunnerStoppedStartCannotPublishLateStartupFailure(t *testing.T) {
+	root := t.TempDir()
+	resolver := &barrierAppRuntimeResolver{
+		started: make(chan struct{}), release: make(chan error, 1), finished: make(chan struct{}),
+	}
+	runner := &AppRunner{RuntimeResolver: resolver}
+	input := AppStartInput{
+		WorkspaceID: "ws-runner", AppID: "stale-start", PackageDir: filepath.Join(root, "package"),
+		RuntimeDir: filepath.Join(root, "runtime"), DataDir: filepath.Join(root, "data"),
+		DatabaseDir: filepath.Join(root, "database"), LogDir: filepath.Join(root, "logs"),
+	}
+	if _, err := runner.Start(context.Background(), input); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-resolver.started:
+	case <-time.After(time.Second):
+		t.Fatal("runtime resolver did not start")
+	}
+	stopped, err := runner.Stop(context.Background(), input.WorkspaceID, input.AppID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stopped.Status != workspacebiz.AppRuntimeStatusIdle {
+		t.Fatalf("Stop() status = %q, want idle", stopped.Status)
+	}
+	resolver.release <- errors.New("late runtime resolution failure")
+	select {
+	case <-resolver.finished:
+	case <-time.After(time.Second):
+		t.Fatal("runtime resolver did not finish")
+	}
+	time.Sleep(20 * time.Millisecond)
+	state := runner.State(input.WorkspaceID, input.AppID)
+	if state.Status != workspacebiz.AppRuntimeStatusIdle || state.FailureReason != nil || state.LastError != nil {
+		t.Fatalf("late startup failure replaced stopped state: %#v", state)
+	}
+}
+
+func TestAppRunnerReplacedStartCannotCommitState(t *testing.T) {
+	runner := &AppRunner{}
+	runner.ensure()
+	key := appRuntimeKey("ws-runner", "restarted")
+	oldStart := &appStart{cancel: func() {}}
+	newStart := &appStart{cancel: func() {}}
+	runner.mu.Lock()
+	runner.starts[key] = newStart
+	runner.states[key] = workspacebiz.AppRuntimeState{Status: workspacebiz.AppRuntimeStatusPreparing}
+	runner.mu.Unlock()
+
+	if _, committed := runner.setStateForStart(key, oldStart, workspacebiz.AppRuntimeState{Status: workspacebiz.AppRuntimeStatusStarting}); committed {
+		t.Fatal("replaced start committed starting state")
+	}
+	if _, committed := runner.setFailedForStart(key, oldStart, "healthcheck", errors.New("late health failure")); committed {
+		t.Fatal("replaced start committed failure state")
+	}
+	state := runner.State("ws-runner", "restarted")
+	if state.Status != workspacebiz.AppRuntimeStatusPreparing || state.FailureReason != nil {
+		t.Fatalf("replacement state was overwritten: %#v", state)
+	}
+}
+
 func TestAppRunnerStartWithoutRestartReusesStartingProcess(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("bootstrap.sh runner test is POSIX-only")
@@ -704,6 +779,145 @@ sleep 30
 	state = waitForRunnerStatus(t, runner, "ws-runner", "slow", workspacebiz.AppRuntimeStatusFailed)
 	if state.FailureReason == nil || *state.FailureReason != "healthcheck" {
 		t.Fatalf("FailureReason = %v, want healthcheck", state.FailureReason)
+	}
+	if state.FailurePhase == nil || *state.FailurePhase != workspacebiz.AppFailurePhaseStarting {
+		t.Fatalf("FailurePhase = %v, want starting", state.FailurePhase)
+	}
+}
+
+func TestAppRunnerDoesNotReturnToRunningAfterStopStarts(t *testing.T) {
+	key := appRuntimeKey("ws-runner", "stopping")
+	start := &appStart{cancel: func() {}}
+	process := &appProcess{stopRequested: true}
+	runner := &AppRunner{
+		processes: map[string]*appProcess{key: process},
+		starts:    map[string]*appStart{key: start},
+		states: map[string]workspacebiz.AppRuntimeState{
+			key: {Status: workspacebiz.AppRuntimeStatusStopping},
+		},
+	}
+
+	if runner.setRunningIfProcessCurrent(key, start, process, workspacebiz.AppRuntimeState{Status: workspacebiz.AppRuntimeStatusRunning}) {
+		t.Fatal("stopping process was moved back to running")
+	}
+	if state := runner.State("ws-runner", "stopping"); state.Status != workspacebiz.AppRuntimeStatusStopping {
+		t.Fatalf("runner status = %q, want stopping", state.Status)
+	}
+}
+
+func TestAppRunnerMarksExitAfterRunningAsRuntimeFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bootstrap.sh runner test is POSIX-only")
+	}
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 is required for runner process exit test")
+	}
+
+	root := t.TempDir()
+	packageDir := filepath.Join(root, "package")
+	if err := os.MkdirAll(packageDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(packageDir, "bootstrap.sh"), []byte(`#!/bin/sh
+set -eu
+exec "$TUTTI_APP_PYTHON" "$TUTTI_APP_PACKAGE_DIR/server.py"
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(packageDir, "server.py"), []byte(`import os
+import socket
+import time
+
+server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+server.bind(("127.0.0.1", int(os.environ["TUTTI_APP_PORT"])))
+server.listen(1)
+connection, _ = server.accept()
+with connection:
+    connection.recv(4096)
+    connection.sendall(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
+time.sleep(0.2)
+raise SystemExit(17)
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv(tuttiAppRuntimeRootEnv, createManagedAppRuntimeFixture(t, root))
+	runner := &AppRunner{HealthcheckTimeout: 5 * time.Second}
+	_, err := runner.Start(context.Background(), AppStartInput{
+		WorkspaceID: "ws-runner", AppID: "exits", PackageDir: packageDir,
+		Bootstrap: "bootstrap.sh", HealthcheckPath: "/ready",
+		RuntimeDir: filepath.Join(root, "runtime"), DataDir: filepath.Join(root, "data"),
+		DatabaseDir: filepath.Join(root, "database"), LogDir: filepath.Join(root, "logs"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitForRunnerStatus(t, runner, "ws-runner", "exits", workspacebiz.AppRuntimeStatusRunning)
+	state := waitForRunnerStatus(t, runner, "ws-runner", "exits", workspacebiz.AppRuntimeStatusFailed)
+	if state.FailurePhase == nil || *state.FailurePhase != workspacebiz.AppFailurePhaseRuntime {
+		t.Fatalf("FailurePhase = %v, want runtime", state.FailurePhase)
+	}
+	if state.FailureReason == nil || *state.FailureReason != "process_exit" {
+		t.Fatalf("FailureReason = %v, want process_exit", state.FailureReason)
+	}
+}
+
+func TestAppRunnerMarksCleanExitAfterRunningAsRuntimeFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bootstrap.sh runner test is POSIX-only")
+	}
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 is required for runner process exit test")
+	}
+
+	root := t.TempDir()
+	packageDir := filepath.Join(root, "package")
+	if err := os.MkdirAll(packageDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(packageDir, "bootstrap.sh"), []byte(`#!/bin/sh
+set -eu
+exec "$TUTTI_APP_PYTHON" "$TUTTI_APP_PACKAGE_DIR/server.py"
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(packageDir, "server.py"), []byte(`import os
+import socket
+import time
+
+server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+server.bind(("127.0.0.1", int(os.environ["TUTTI_APP_PORT"])))
+server.listen(1)
+connection, _ = server.accept()
+with connection:
+    connection.recv(4096)
+    connection.sendall(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
+time.sleep(0.2)
+raise SystemExit(0)
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv(tuttiAppRuntimeRootEnv, createManagedAppRuntimeFixture(t, root))
+	runner := &AppRunner{HealthcheckTimeout: 5 * time.Second}
+	_, err := runner.Start(context.Background(), AppStartInput{
+		WorkspaceID: "ws-runner", AppID: "clean-exit", PackageDir: packageDir,
+		Bootstrap: "bootstrap.sh", HealthcheckPath: "/ready",
+		RuntimeDir: filepath.Join(root, "runtime"), DataDir: filepath.Join(root, "data"),
+		DatabaseDir: filepath.Join(root, "database"), LogDir: filepath.Join(root, "logs"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitForRunnerStatus(t, runner, "ws-runner", "clean-exit", workspacebiz.AppRuntimeStatusRunning)
+	state := waitForRunnerStatus(t, runner, "ws-runner", "clean-exit", workspacebiz.AppRuntimeStatusFailed)
+	if state.FailurePhase == nil || *state.FailurePhase != workspacebiz.AppFailurePhaseRuntime {
+		t.Fatalf("FailurePhase = %v, want runtime", state.FailurePhase)
+	}
+	if state.LastError == nil || !strings.Contains(*state.LastError, "status 0") {
+		t.Fatalf("LastError = %v, want unexpected clean exit", state.LastError)
 	}
 }
 


### PR DESCRIPTION
## Summary

- preserve the failure phase for workspace app install, startup, and runtime failures across daemon API, event stream, desktop adapter, and the shared App Center contract
- show phase-accurate App Center copy with a neutral fallback for older hosts, while keeping `failed` as the compatible terminal status
- harden pending install/runtime projection ordering so late progress or health events cannot overwrite a terminal failure
- remove inherited `aria-disabled` from actionable app cards and normalize legacy `node-static` catalog manifests to `connector-node-static`

## Verification

- `pnpm check:changed` — 21 lanes passed
- pre-push `pnpm check:changed -- --push-ready` — 24 lanes passed
- `pnpm --filter @tutti-os/desktop build`
- `cd services/tuttid && go build ./...`
- `make dev-gui` manual smoke:
  - artifact download retry exhaustion → `failurePhase=downloading` → install failure copy
  - bootstrap exit → `failurePhase=starting` → startup failure copy and retry
  - healthy runtime followed by process exit → `failurePhase=runtime` → runtime failure copy
  - staging catalog loaded 15 apps with the legacy profile compatibility path
  - install actions are exposed as enabled controls in the accessibility tree

## Fallback Three Questions

- Source: install progress, process exit, and health-check observations are emitted by separate asynchronous producers and may be observed after a terminal transition.
- Why can it not be fixed at that source? The producers represent independent process and transport boundaries; the daemon projection is the first boundary that can order them against the operation revision and retained terminal state.
- Removal condition: remove the reconciliation guards only when workspace app operations expose one atomic, totally ordered transition stream that subsumes progress, process, and health-check observations.

## Checklist

- [x] This does not change Agent session/turn/goal/runtime-operation lifecycle semantics.
- [x] I kept the change focused on workspace app failure semantics and the compatibility issues found while validating that flow.
- [x] I updated the workspace App Center contract documentation and added a changeset.
- [x] README/CONTRIBUTING language variants are not affected.
- [x] I ran the lowest meaningful local checks plus push-ready, Desktop build, daemon build, and manual Desktop smoke validation.
- [x] The commit is signed off with DCO.
