### PR TITLE
fix(desktop): 对齐请求通知的 Agent 身份

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAgentDecisionNotification.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAgentDecisionNotification.ts
@@ -5,6 +5,7 @@ import {
   managedAgentRoundedIconUrl,
   type WorkspaceAgentMessageCenterItem
 } from "@tutti-os/agent-gui/agent-message-center";
+import { resolveWorkspaceAgentDecisionIdentity } from "./workspaceAgentDecisionNotificationIdentity.ts";
 
 export interface WorkspaceAgentDecisionSubmitInput {
   action?: string;
@@ -41,9 +42,12 @@ export function buildWorkspaceAgentDecisionNotification(
   if (!prompt) {
     return null;
   }
-  const agentName =
-    formatWorkspaceAgentProviderName(item.provider) || labels.fallbackAgentName;
-  const agentIconUrl = managedAgentRoundedIconUrl(item.provider);
+  const { agentIconUrl, agentName } = resolveWorkspaceAgentDecisionIdentity({
+    agentAvatarUrl: item.agentAvatarUrl,
+    agentName: item.agentName,
+    fallbackAgentIconUrl: managedAgentRoundedIconUrl(undefined),
+    fallbackAgentName: labels.fallbackAgentName
+  });
   const conversationTitle = item.title.trim();
   switch (prompt.kind) {
     case "approval":
@@ -133,13 +137,4 @@ function approvalNotificationDescription(
     return labels.commandLabel;
   }
   return title;
-}
-
-function formatWorkspaceAgentProviderName(provider: string): string {
-  return provider
-    .trim()
-    .split(/[-_\s]+/)
-    .filter(Boolean)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
 }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAgentDecisionNotificationIdentity.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAgentDecisionNotificationIdentity.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveWorkspaceAgentDecisionIdentity } from "./workspaceAgentDecisionNotificationIdentity.ts";
+
+test("decision notification uses the exact Agent Directory name and icon", () => {
+  const identity = resolveWorkspaceAgentDecisionIdentity({
+    agentAvatarUrl: "agent-icon://kimi-code",
+    agentName: "Kimi Code",
+    fallbackAgentIconUrl: "agent-icon://generic",
+    fallbackAgentName: "Agent"
+  });
+
+  assert.deepEqual(identity, {
+    agentIconUrl: "agent-icon://kimi-code",
+    agentName: "Kimi Code"
+  });
+});
+
+test("decision notification does not expose provider metadata as fallback identity", () => {
+  const identity = resolveWorkspaceAgentDecisionIdentity({
+    agentAvatarUrl: null,
+    agentName: null,
+    fallbackAgentIconUrl: "agent-icon://generic",
+    fallbackAgentName: "Agent"
+  });
+
+  assert.deepEqual(identity, {
+    agentIconUrl: "agent-icon://generic",
+    agentName: "Agent"
+  });
+});

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAgentDecisionNotificationIdentity.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAgentDecisionNotificationIdentity.ts
@@ -1,0 +1,17 @@
+export interface WorkspaceAgentDecisionIdentity {
+  agentIconUrl: string;
+  agentName: string;
+}
+
+export function resolveWorkspaceAgentDecisionIdentity(input: {
+  agentAvatarUrl?: string | null;
+  agentName?: string | null;
+  fallbackAgentIconUrl: string;
+  fallbackAgentName: string;
+}): WorkspaceAgentDecisionIdentity {
+  return {
+    agentIconUrl:
+      input.agentAvatarUrl?.trim() || input.fallbackAgentIconUrl.trim(),
+    agentName: input.agentName?.trim() || input.fallbackAgentName.trim()
+  };
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentDecisionNotifications.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentDecisionNotifications.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, type ReactNode } from "react";
+import { useMemo, useRef, useSyncExternalStore, type ReactNode } from "react";
 import {
   buildWorkspaceAgentMessageCenterModelFromEngine,
   selectWorkspaceAgentMessageCenterPresentation,
@@ -9,6 +9,8 @@ import {
 } from "@tutti-os/agent-gui/agent-message-center";
 import type { I18nRuntime } from "@tutti-os/ui-i18n-runtime";
 import type { WorkspaceAgentActivityService } from "@renderer/features/workspace-agent";
+import { IAgentsService } from "@renderer/features/workspace-agent/services/agentsService.interface.ts";
+import { useService } from "@tutti-os/infra/di";
 import { useWorkspaceAgentDecisionNotifications } from "./useWorkspaceAgentDecisionNotifications.tsx";
 
 const MESSAGE_CENTER_VISIBLE_HISTORY_MS = 7 * 24 * 60 * 60 * 1000;
@@ -25,6 +27,12 @@ export function StandaloneAgentDecisionNotifications({
   messageCenterOpen: boolean;
   workspaceId: string;
 }): ReactNode {
+  const agentsService = useService(IAgentsService);
+  const agentDirectory = useSyncExternalStore(
+    (listener) => agentsService.subscribe(listener),
+    () => agentsService.getSnapshot(),
+    () => agentsService.getSnapshot()
+  );
   const sessionEngine = useMemo(
     () => activityService.getSessionEngine(workspaceId),
     [activityService, workspaceId]
@@ -52,6 +60,7 @@ export function StandaloneAgentDecisionNotifications({
         workspaceId
       },
       {
+        agentPresentations: agentDirectory.agents,
         itemCutoffUnixMs,
         promptFallbackLabels: {
           constraintHeader: i18n.t(
@@ -70,7 +79,13 @@ export function StandaloneAgentDecisionNotifications({
     );
     modelRef.current = stableModel;
     return stableModel;
-  }, [i18n, itemCutoffUnixMs, presentation, workspaceId]);
+  }, [
+    agentDirectory.agents,
+    i18n,
+    itemCutoffUnixMs,
+    presentation,
+    workspaceId
+  ]);
 
   useWorkspaceAgentDecisionNotifications({
     messageCenterOpen,


### PR DESCRIPTION
## 背景

Agent 请求授权或回答问题时，右上角通知使用 Provider ID 推导展示名称，并回退到通用默认图标。对于 Kimi Code，这会显示为 `Acp:kimi Code`，且与会话完成通知中的 Agent Directory 身份不一致。

## 根因

请求通知没有读取 Agent Directory 中的权威 Agent 名称与头像，而是直接格式化 `providerId` 作为用户可见名称；独立通知窗口也没有接收 Agent Directory 的展示数据。

## 修改

- 请求通知统一读取 Agent Directory 中的 `agentName` 和 `agentAvatarUrl`
- 独立 Agent 通知窗口补充 Agent Directory 展示数据
- 仅在目录身份缺失时回退到通用 Agent 名称和图标
- 新增身份解析回归测试，覆盖目录身份与回退路径

## 用户影响

Kimi Code 的请求式通知将与会话完成通知保持一致，显示 `Kimi Code` 及对应图标，不再显示 `Acp:kimi Code` 和默认图标。

## 验证

- `pnpm check:changed -- --base upstream/main`：11 条 lane 通过
- `pnpm check:changed -- --base upstream/main --push-ready`：12 条 lane 通过

## 文档影响

无持久文档影响。本次修改仅对齐现有通知身份展示规则，并由回归测试覆盖。
