### PR TITLE
feat(workspace-apps): add application artifact picker

### DIFF
--- a/.changeset/workspace-app-reference-selection.md
+++ b/.changeset/workspace-app-reference-selection.md
@@ -1,0 +1,10 @@
+---
+"@tutti-os/desktop": patch
+"@tutti-os/workspace-external-core": minor
+"@tutti-os/workspace-file-reference": minor
+---
+
+Expose a user-activated workspace-app reference picker for project files, local
+files, and application artifacts. Preserve application artifact groups as lazy
+workspace-reference handles and add a reusable composer plus control that can
+combine upload and reference actions.

--- a/apps/desktop/src/main/ipc/workspaceAppGuestContextRegistry.ts
+++ b/apps/desktop/src/main/ipc/workspaceAppGuestContextRegistry.ts
@@ -105,6 +105,7 @@ export function createWorkspaceAppContext(
       "files.open@1",
       "files.upload@1",
       "pdf.printHtmlToPdf@1",
+      "references.select@1",
       "userProjects@1",
       "workspace.openFeature@1"
     ],

--- a/apps/desktop/src/main/ipc/workspaceAppShellIpc.ts
+++ b/apps/desktop/src/main/ipc/workspaceAppShellIpc.ts
@@ -12,7 +12,8 @@ import {
 } from "@tutti-os/workspace-external-core/core";
 import type {
   TuttiExternalAtQueryResult,
-  TuttiExternalAtResolveResult
+  TuttiExternalAtResolveResult,
+  TuttiExternalReferenceSelectResult
 } from "@tutti-os/workspace-external-core/contracts";
 import type { DesktopHostPreferencesState } from "../desktopHostPreferences";
 import type { DesktopLogger } from "../logging";
@@ -125,6 +126,21 @@ export function registerWorkspaceAppShellIpc(input: {
         requestId: randomUUID(),
         workspaceId: context.workspaceID
       });
+    }
+  );
+  registerDesktopIpcHandler(
+    desktopIpcChannels.appExternal.referencesSelect,
+    async (event) => {
+      const context = requireWorkspaceAppGuestContext(event.sender);
+      return requestWorkspaceAppExternalRenderer<TuttiExternalReferenceSelectResult>(
+        context,
+        {
+          appId: context.appID,
+          operation: "references.select",
+          requestId: randomUUID(),
+          workspaceId: context.workspaceID
+        }
+      );
     }
   );
   ipcMain.on(

--- a/apps/desktop/src/preload/entries/workspaceAppExternalBridge.test.ts
+++ b/apps/desktop/src/preload/entries/workspaceAppExternalBridge.test.ts
@@ -609,6 +609,75 @@ test("workspace app external bridge invokes file open with activation", async ()
   ]);
 });
 
+test("workspace app external bridge invokes reference select with activation", async () => {
+  const calls: Array<{ channel: string; payload?: unknown }> = [];
+  const bridge = createWorkspaceAppExternalBridge({
+    appContext: {
+      async get() {
+        return { locale: "en" };
+      },
+      subscribe() {
+        throw new Error("unexpected subscribe");
+      }
+    },
+    isUserActivationActive: () => true,
+    send: unexpectedSend,
+    async invoke<TResult>(channel: string, payload?: unknown) {
+      calls.push({ channel, payload });
+      return [
+        {
+          displayName: "Canvas outputs",
+          id: "canvas",
+          selectionKind: "workspace-reference",
+          source: "app",
+          workspaceId: "workspace-1"
+        }
+      ] as TResult;
+    }
+  });
+
+  assert.ok(bridge.references.select);
+  assert.deepEqual(await bridge.references.select(), [
+    {
+      displayName: "Canvas outputs",
+      id: "canvas",
+      selectionKind: "workspace-reference",
+      source: "app",
+      workspaceId: "workspace-1"
+    }
+  ]);
+  assert.deepEqual(calls, [
+    {
+      channel: workspaceAppExternalChannels.referencesSelect,
+      payload: undefined
+    }
+  ]);
+});
+
+test("workspace app external bridge requires activation for reference select", () => {
+  const bridge = createWorkspaceAppExternalBridge({
+    appContext: {
+      async get() {
+        return { locale: "en" };
+      },
+      subscribe() {
+        throw new Error("unexpected subscribe");
+      }
+    },
+    isUserActivationActive: () => false,
+    send: unexpectedSend,
+    async invoke() {
+      throw new Error("unexpected invoke");
+    }
+  });
+
+  assert.ok(bridge.references.select);
+  assert.throws(
+    () => bridge.references.select?.(),
+    /references\.select requires a user action/
+  );
+});
+
 test("workspace app external bridge uploads files without user activation", async () => {
   const calls: Array<{ channel: string; payload?: unknown }> = [];
   let fetchUrl = "";

--- a/apps/desktop/src/preload/entries/workspaceAppExternalBridge.ts
+++ b/apps/desktop/src/preload/entries/workspaceAppExternalBridge.ts
@@ -34,6 +34,7 @@ import type {
   TuttiExternalPdfPrintHtmlInput,
   TuttiExternalPdfPrintHtmlResult,
   TuttiExternalReferenceOpenInput,
+  TuttiExternalReferenceSelectResult,
   TuttiExternalSettingsOpenInput,
   TuttiExternalUserProjectCreateInput,
   TuttiExternalUserProjectPathInput,
@@ -119,6 +120,7 @@ export const workspaceAppExternalChannels = {
   permissionsRequest: "workspace-app-permissions:request",
   pdfPrintHtml: "workspace-app-pdf:print-html",
   referencesOpen: "workspace-app-references:open",
+  referencesSelect: "workspace-app-references:select",
   settingsOpen: "workspace-app-settings:open",
   userProjectsCheckPath: "workspace-app-user-projects:check-path",
   userProjectsCreate: "workspace-app-user-projects:create",
@@ -317,6 +319,15 @@ export function createWorkspaceAppExternalBridge(
       }
     },
     references: {
+      select() {
+        requireUserActivation(
+          dependencies.isUserActivationActive(),
+          "references.select"
+        );
+        return dependencies.invoke<TuttiExternalReferenceSelectResult>(
+          workspaceAppExternalChannels.referencesSelect
+        );
+      },
       open(input: TuttiExternalReferenceOpenInput) {
         requireUserActivation(
           dependencies.isUserActivationActive(),

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
@@ -84,6 +84,11 @@ import type {
   TuttiExternalAtResolveResult
 } from "@tutti-os/workspace-external-core/contracts";
 import type { WorkspaceFileReferenceAdapter } from "@tutti-os/workspace-file-reference/contracts";
+import {
+  createReferenceSourceAggregator,
+  createStaticReferenceSourceRegistry,
+  type ReferenceSourceAggregator
+} from "@tutti-os/workspace-file-reference/core";
 import type { WorkspaceUserProjectApi } from "@tutti-os/workspace-user-project/contracts";
 import { serializeWorkspaceAppExternalAtMatch } from "./workspaceAppExternalAtSerialization.ts";
 import { requestWorkspaceWorkbenchNodeLaunch } from "../workspaceWorkbenchNodeLaunchCoordinator.ts";
@@ -109,6 +114,11 @@ import {
   type WorkspaceWorkbenchHostInputResolverDependencies
 } from "./workspaceWorkbenchHostInputResolver.ts";
 import { createWorkspaceDockRetentionController } from "./workspaceDockRetentionController.ts";
+import {
+  createAppArtifactReferenceSource,
+  createWorkspaceFileLocationReferenceSources
+} from "../../../agent-reference-sources/index.ts";
+import { loadDesktopWorkspaceFileLocationSections } from "../../../workspace-file-manager/services/desktopWorkspaceFileLocations.ts";
 
 export interface WorkspaceWorkbenchHostServiceDependencies extends WorkspaceWorkbenchHostInputResolverDependencies {
   hostNotificationsApi: Pick<DesktopHostNotificationsApi, "onNavigate">;
@@ -287,6 +297,40 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
       tuttidClient: this.dependencies.tuttidClient,
       workspaceId
     });
+  }
+
+  createWorkspaceAppExternalReferenceSourceAggregator(input: {
+    appSourceLabel: string;
+    localSourceLabel: string;
+    projectSourceLabel: string;
+    workspaceId: string;
+  }): ReferenceSourceAggregator {
+    const adapter = this.createWorkspaceAppExternalFileReferenceAdapter(
+      input.workspaceId
+    );
+    return createReferenceSourceAggregator(
+      createStaticReferenceSourceRegistry([
+        ...createWorkspaceFileLocationReferenceSources({
+          adapter,
+          getLocationSections: () =>
+            loadDesktopWorkspaceFileLocationSections({
+              homeDirectory: this.dependencies.platformApi.homeDirectory,
+              workspaceUserProjectService:
+                this.dependencies.workspaceUserProjectService
+            }),
+          localLabel: input.localSourceLabel,
+          localOrder: 0,
+          projectLabel: input.projectSourceLabel,
+          projectOrder: -1
+        }),
+        createAppArtifactReferenceSource({
+          adapter,
+          label: input.appSourceLabel,
+          order: 1,
+          tuttidClient: this.dependencies.tuttidClient
+        })
+      ])
+    );
   }
 
   createWorkspaceAppExternalUserProjectApi(): WorkspaceUserProjectApi {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAppExternalReferenceSerialization.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAppExternalReferenceSerialization.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { serializeWorkspaceAppExternalReferenceSelection } from "./workspaceAppExternalReferenceSerialization.ts";
+
+test("serializes paths and lazy application artifact bundles", () => {
+  assert.deepEqual(
+    serializeWorkspaceAppExternalReferenceSelection("workspace-1", {
+      files: [{ displayName: "notes.md", kind: "file", path: "/notes.md" }],
+      bundles: [
+        {
+          displayName: "Canvas outputs",
+          fileCount: 3,
+          handle: { groupId: "outputs", id: "ai-canvas", source: "app" },
+          nodeId: "opaque-node",
+          sourceId: "app-artifact"
+        },
+        {
+          displayName: "Issue files",
+          fileCount: 2,
+          handle: { id: "topic-1", source: "task" },
+          nodeId: "opaque-issue",
+          sourceId: "issue"
+        }
+      ]
+    }),
+    [
+      {
+        selectionKind: "path",
+        reference: {
+          displayName: "notes.md",
+          kind: "file",
+          path: "/notes.md"
+        }
+      },
+      {
+        selectionKind: "workspace-reference",
+        displayName: "Canvas outputs",
+        fileCount: 3,
+        groupId: "outputs",
+        id: "ai-canvas",
+        source: "app",
+        workspaceId: "workspace-1"
+      }
+    ]
+  );
+});

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAppExternalReferenceSerialization.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAppExternalReferenceSerialization.ts
@@ -1,0 +1,31 @@
+import type { TuttiExternalReferenceSelectResult } from "@tutti-os/workspace-external-core/contracts";
+import type { ReferenceGroupedSelection } from "@tutti-os/workspace-file-reference/ui";
+
+export function serializeWorkspaceAppExternalReferenceSelection(
+  workspaceId: string,
+  selection: ReferenceGroupedSelection
+): TuttiExternalReferenceSelectResult {
+  return [
+    ...selection.files.map((reference) => ({
+      selectionKind: "path" as const,
+      reference
+    })),
+    ...selection.bundles.flatMap((bundle) => {
+      const handle = bundle.handle;
+      if (!handle || handle.source !== "app") {
+        return [];
+      }
+      return [
+        {
+          selectionKind: "workspace-reference" as const,
+          displayName: bundle.displayName,
+          ...(bundle.fileCount > 0 ? { fileCount: bundle.fileCount } : {}),
+          ...(handle.groupId ? { groupId: handle.groupId } : {}),
+          id: handle.id,
+          source: "app" as const,
+          workspaceId
+        }
+      ];
+    })
+  ];
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchHostService.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchHostService.interface.ts
@@ -46,6 +46,7 @@ import type {
   TuttiExternalAtResolveResult
 } from "@tutti-os/workspace-external-core/contracts";
 import type { WorkspaceFileReferenceAdapter } from "@tutti-os/workspace-file-reference/contracts";
+import type { ReferenceSourceAggregator } from "@tutti-os/workspace-file-reference/core";
 import type { WorkspaceUserProjectApi } from "@tutti-os/workspace-user-project/contracts";
 import type { DesktopWorkspaceAppOpenFileResolvedPayload } from "@shared/contracts/ipc";
 
@@ -167,6 +168,12 @@ export interface IWorkspaceWorkbenchHostService {
   createWorkspaceAppExternalFileReferenceAdapter(
     workspaceId: string
   ): WorkspaceFileReferenceAdapter;
+  createWorkspaceAppExternalReferenceSourceAggregator(input: {
+    appSourceLabel: string;
+    localSourceLabel: string;
+    projectSourceLabel: string;
+    workspaceId: string;
+  }): ReferenceSourceAggregator;
   createWorkspaceAppExternalUserProjectApi(): WorkspaceUserProjectApi;
   openExternal(url: string): Promise<void>;
   queryWorkspaceAppExternalAt(input: {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAppExternalBridge.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAppExternalBridge.tsx
@@ -6,7 +6,11 @@ import {
   useState,
   type ReactElement
 } from "react";
-import { WorkspaceFileReferencePicker } from "@tutti-os/workspace-file-reference/ui";
+import {
+  ReferenceSourcePicker,
+  WorkspaceFileReferencePicker,
+  type ReferenceGroupedSelection
+} from "@tutti-os/workspace-file-reference/ui";
 import type {
   WorkspaceFileReference,
   WorkspaceFileReferenceCopy
@@ -22,7 +26,8 @@ import type {
 import type {
   TuttiExternalAgentActivityComposerOptions,
   TuttiExternalAgentTargetCatalog,
-  TuttiExternalFileOpenInput
+  TuttiExternalFileOpenInput,
+  TuttiExternalReferenceSelectResult
 } from "@tutti-os/workspace-external-core/contracts";
 import { resolveWorkspaceMentionLinkAction } from "@contexts/workspace/presentation/renderer/actions/workspaceLinkActions";
 import { runDesktopAgentGUILinkAction } from "@renderer/features/workspace-agent/services/desktopAgentGUILinkActions.ts";
@@ -39,6 +44,7 @@ import { useWorkspaceSettingsService } from "./useWorkspaceSettingsService";
 import { requestWorkspaceIssueManagerLaunch } from "../services/workspaceIssueManagerLaunchCoordinator";
 import { serializeWorkspaceAppExternalAgentIconUrl } from "../services/workspaceAppExternalAgentIconSerialization.ts";
 import { dispatchWorkspaceAppExternalAtRequest } from "../services/workspaceAppExternalAtRequest.ts";
+import { serializeWorkspaceAppExternalReferenceSelection } from "../services/workspaceAppExternalReferenceSerialization.ts";
 
 const workspaceFileReferenceLocaleKeyByPickerKey: Record<string, string> = {
   "actions.cancel": "common.cancel",
@@ -114,6 +120,10 @@ interface PendingFileSelect {
   resolve: (refs: WorkspaceFileReference[]) => void;
 }
 
+interface PendingReferenceSelect {
+  resolve: (refs: TuttiExternalReferenceSelectResult) => void;
+}
+
 export function WorkspaceAppExternalBridge({
   api,
   openFile,
@@ -131,6 +141,9 @@ export function WorkspaceAppExternalBridge({
   const [pendingFileSelect, setPendingFileSelect] =
     useState<PendingFileSelect | null>(null);
   const pendingFileSelectRef = useRef<PendingFileSelect | null>(null);
+  const [pendingReferenceSelect, setPendingReferenceSelect] =
+    useState<PendingReferenceSelect | null>(null);
+  const pendingReferenceSelectRef = useRef<PendingReferenceSelect | null>(null);
   const fileAdapter = useMemo(
     () =>
       hostService.createWorkspaceAppExternalFileReferenceAdapter(workspaceId),
@@ -140,11 +153,24 @@ export function WorkspaceAppExternalBridge({
     () => hostService.createWorkspaceAppExternalUserProjectApi(),
     [hostService]
   );
+  const referenceSourceAggregator = useMemo(
+    () =>
+      hostService.createWorkspaceAppExternalReferenceSourceAggregator({
+        appSourceLabel: t("workspace.referenceSources.appSourceLabel"),
+        localSourceLabel: t("workspace.referenceSources.localSourceLabel"),
+        projectSourceLabel: t("workspace.referenceSources.projectSourceLabel"),
+        workspaceId
+      }),
+    [hostService, t, workspaceId]
+  );
   const copy = useMemo<WorkspaceFileReferenceCopy>(
     () => ({
       t(key, values) {
         const localeKey =
-          workspaceFileReferenceLocaleKeyByPickerKey[key] ?? key;
+          workspaceFileReferenceLocaleKeyByPickerKey[key] ??
+          (key.startsWith("referencePicker.")
+            ? `agentHost.agentGui.${key}`
+            : key);
         return t(localeKey as Parameters<typeof t>[0], values);
       }
     }),
@@ -248,10 +274,49 @@ export function WorkspaceAppExternalBridge({
       new Promise<WorkspaceFileReference[]>((resolve) => {
         const pending: PendingFileSelect = { multiple, resolve };
         pendingFileSelectRef.current?.resolve([]);
+        pendingReferenceSelectRef.current?.resolve([]);
+        pendingReferenceSelectRef.current = null;
+        setPendingReferenceSelect(null);
         pendingFileSelectRef.current = pending;
         setPendingFileSelect(pending);
       }),
     []
+  );
+
+  const resolvePendingReferenceSelect = useCallback(
+    (refs: TuttiExternalReferenceSelectResult) => {
+      const pending = pendingReferenceSelectRef.current;
+      if (!pending) {
+        return;
+      }
+      pendingReferenceSelectRef.current = null;
+      setPendingReferenceSelect(null);
+      pending.resolve(refs);
+    },
+    []
+  );
+
+  const openReferenceSelect = useCallback(
+    () =>
+      new Promise<TuttiExternalReferenceSelectResult>((resolve) => {
+        const pending: PendingReferenceSelect = { resolve };
+        pendingReferenceSelectRef.current?.resolve([]);
+        pendingFileSelectRef.current?.resolve([]);
+        pendingFileSelectRef.current = null;
+        setPendingFileSelect(null);
+        pendingReferenceSelectRef.current = pending;
+        setPendingReferenceSelect(pending);
+      }),
+    []
+  );
+
+  const confirmReferenceSelect = useCallback(
+    (selection: ReferenceGroupedSelection) => {
+      resolvePendingReferenceSelect(
+        serializeWorkspaceAppExternalReferenceSelection(workspaceId, selection)
+      );
+    },
+    [resolvePendingReferenceSelect, workspaceId]
   );
 
   const handleRequest = useCallback(
@@ -389,6 +454,8 @@ export function WorkspaceAppExternalBridge({
           }
           return undefined;
         }
+        case "references.select":
+          return openReferenceSelect();
         case "userProjects.checkPath":
           return userProjectsApi.checkPath?.(request.input);
         case "userProjects.create":
@@ -423,6 +490,7 @@ export function WorkspaceAppExternalBridge({
       hostService,
       openFile,
       openFileSelect,
+      openReferenceSelect,
       settingsService,
       userProjectsApi,
       workspaceAgentActivityService,
@@ -441,17 +509,32 @@ export function WorkspaceAppExternalBridge({
     return () => {
       pendingFileSelectRef.current?.resolve([]);
       pendingFileSelectRef.current = null;
+      pendingReferenceSelectRef.current?.resolve([]);
+      pendingReferenceSelectRef.current = null;
     };
   }, []);
 
   return (
-    <WorkspaceFileReferencePicker
-      copy={copy}
-      fileAdapter={fileAdapter}
-      open={pendingFileSelect !== null}
-      workspaceId={workspaceId}
-      onClose={() => resolvePendingFileSelect([])}
-      onConfirm={resolvePendingFileSelect}
-    />
+    <>
+      <WorkspaceFileReferencePicker
+        copy={copy}
+        fileAdapter={fileAdapter}
+        open={pendingFileSelect !== null}
+        workspaceId={workspaceId}
+        onClose={() => resolvePendingFileSelect([])}
+        onConfirm={resolvePendingFileSelect}
+      />
+      <ReferenceSourcePicker
+        aggregator={referenceSourceAggregator}
+        copy={copy}
+        open={pendingReferenceSelect !== null}
+        workspaceId={workspaceId}
+        onClose={() => resolvePendingReferenceSelect([])}
+        onConfirm={(references) =>
+          confirmReferenceSelect({ bundles: [], files: references })
+        }
+        onConfirmBundles={confirmReferenceSelect}
+      />
+    </>
   );
 }

--- a/apps/desktop/src/shared/contracts/ipc.ts
+++ b/apps/desktop/src/shared/contracts/ipc.ts
@@ -58,6 +58,7 @@ import type {
   TuttiExternalPdfPrintHtmlInput,
   TuttiExternalPdfPrintHtmlResult,
   TuttiExternalReferenceOpenInput,
+  TuttiExternalReferenceSelectResult,
   TuttiExternalRendererRequest,
   TuttiExternalAtResolveResult,
   TuttiExternalAtResolveInput,
@@ -131,6 +132,7 @@ export const desktopIpcChannels = {
     permissionsRequest: "workspace-app-permissions:request",
     pdfPrintHtml: "workspace-app-pdf:print-html",
     referencesOpen: "workspace-app-references:open",
+    referencesSelect: "workspace-app-references:select",
     guestEvent: "workspace-app-external:guest-event",
     rendererEvent: "workspace-app-external:renderer-event",
     rendererRequest: "workspace-app-external:renderer-request",
@@ -799,6 +801,7 @@ export type DesktopWorkspaceAppExternalRendererResult =
   | TuttiExternalAtQueryResult[]
   | TuttiExternalAtResolveResult
   | TuttiExternalFileSelectResult
+  | TuttiExternalReferenceSelectResult
   | WorkspaceUserProject
   | WorkspaceUserProjectDefaultSelection
   | WorkspaceUserProjectPathCheck
@@ -1083,6 +1086,7 @@ export interface DesktopInvokePayloadByChannel {
   [desktopIpcChannels.appExternal.pdfPrintHtml]: TuttiExternalPdfPrintHtmlInput;
   [desktopIpcChannels.appExternal
     .referencesOpen]: TuttiExternalReferenceOpenInput;
+  [desktopIpcChannels.appExternal.referencesSelect]: undefined;
   [desktopIpcChannels.appExternal.settingsOpen]: TuttiExternalSettingsOpenInput;
   [desktopIpcChannels.appExternal
     .userProjectsCheckPath]: TuttiExternalUserProjectPathInput;
@@ -1280,6 +1284,8 @@ export interface DesktopInvokeResultByChannel {
   [desktopIpcChannels.appExternal
     .pdfPrintHtml]: TuttiExternalPdfPrintHtmlResult;
   [desktopIpcChannels.appExternal.referencesOpen]: void;
+  [desktopIpcChannels.appExternal
+    .referencesSelect]: TuttiExternalReferenceSelectResult;
   [desktopIpcChannels.appExternal.settingsOpen]: void;
   [desktopIpcChannels.appExternal
     .userProjectsCheckPath]: WorkspaceUserProjectPathCheck;

--- a/docs/architecture/agent-reference-sources.md
+++ b/docs/architecture/agent-reference-sources.md
@@ -15,6 +15,9 @@ resolution after selection are documented in
   desktop sources and transport adapters.
 - AgentGUI consumes injected picker capabilities. It does not fetch daemon
   references or interpret source-specific node ids.
+- External workspace apps request the host-owned picker through
+  `tuttiExternal.references.select()` and receive only serialized selections;
+  they do not construct a desktop source registry or query artifact APIs.
 - Daemon and workspace-app APIs own artifact listing and search; desktop maps
   those responses into the shared source contract.
 
@@ -53,6 +56,20 @@ desktop source registry
   -> composer mention
   -> workspace-reference runtime resolution when required
 ```
+
+Tutti Desktop composes a restricted registry for external workspace apps:
+`user-project`, `workspace-file`, and `app-artifact`. `issue-file` remains
+available to owning Desktop surfaces but is deliberately excluded from this
+external picker. A selected file or folder crosses the bridge as a concrete
+`WorkspaceFileReference`; a selected application group crosses as a lazy
+`workspace-reference` handle with app/group identity and workspace scope.
+External apps append those values to the prompt through the shared rich-text
+helper and must not enumerate a whole application artifact group eagerly.
+
+The standard external-app composer plus control is also host-neutral. With an
+app-owned upload callback it presents Upload and Browse actions; without one it
+opens Browse directly. The control owns only this interaction shape and icons.
+Apps continue to own localized labels, their upload pipeline, and prompt state.
 
 List-style app and issue sources adapt their backend responses through the
 shared `ReferenceListBackend` / `createReferenceListSource` protocol. Local

--- a/packages/workspace/external-core/README.md
+++ b/packages/workspace/external-core/README.md
@@ -20,6 +20,13 @@ trusted app APIs may read or update host workspace state directly.
   `at.resolve()` and `at.subscribe()` for exact mention hydration and dirty
   invalidation.
 - `files.select()` for user-activated workspace file picking.
+- `references.select()` for the user-activated multi-source reference picker.
+  Tutti Desktop currently offers project files, local files, and application
+  artifacts on this workspace-app surface. The result contains concrete paths
+  for files/folders and lazy `workspace-reference` handles for whole
+  application artifact groups; issue artifacts are not part of this surface.
+- `references.open()` for user-activated navigation from a serialized
+  `mention://` reference back to its owning workspace surface.
 - `files.open()` for user-activated host opening/revealing of a known workspace file path.
 - `files.upload()` for trusted app upload of a browser `File`/`Blob` into the
   app's managed durable data path, with optional progress and `AbortSignal`
@@ -136,3 +143,17 @@ invalidation.
 
 See `@tutti-os/ui-rich-text` for the generic trigger-provider and at-panel
 contracts.
+
+## Composer Reference Selection
+
+Workspace apps should feature-detect `window.tuttiExternal.references.select`
+before exposing a reference action. The host owns the available source set and
+the picker interaction. Apps append the returned references to their serialized
+rich-text prompt with `appendTuttiExternalReferenceSelections`; they must not
+expand an application artifact group into every child path.
+
+For a standard composer entry, use `WorkspaceReferenceAddControl` from
+`@tutti-os/workspace-file-reference/ui`. Apps with an upload workflow pass
+`onUploadFile` and receive an Upload / Browse menu. Apps without upload support
+omit it and the plus button opens the reference picker directly. All visible
+labels remain app-owned i18n input.

--- a/packages/workspace/external-core/src/contracts/index.ts
+++ b/packages/workspace/external-core/src/contracts/index.ts
@@ -240,6 +240,24 @@ export interface TuttiExternalReferenceOpenInput {
   href: string;
 }
 
+export type TuttiExternalReferenceSelection =
+  | {
+      selectionKind: "path";
+      reference: WorkspaceFileReference;
+    }
+  | {
+      selectionKind: "workspace-reference";
+      displayName: string;
+      fileCount?: number;
+      groupId?: string;
+      id: string;
+      source: "app";
+      workspaceId: string;
+    };
+
+export type TuttiExternalReferenceSelectResult =
+  TuttiExternalReferenceSelection[];
+
 export type TuttiExternalAgentAvailabilityStatus =
   | "ready"
   | "checking"
@@ -435,6 +453,7 @@ export interface TuttiExternalBridge {
     openFeature(input: TuttiExternalWorkspaceOpenFeatureInput): Promise<void>;
   };
   references: {
+    select?(): Promise<TuttiExternalReferenceSelectResult>;
     open(input: TuttiExternalReferenceOpenInput): Promise<void>;
   };
   pdf: {
@@ -565,6 +584,12 @@ export type TuttiExternalRendererRequest =
       appId: string;
       input: TuttiExternalReferenceOpenInput;
       operation: "references.open";
+      requestId: string;
+      workspaceId: string;
+    }
+  | {
+      appId: string;
+      operation: "references.select";
       requestId: string;
       workspaceId: string;
     }

--- a/packages/workspace/external-core/src/rich-text/index.test.ts
+++ b/packages/workspace/external-core/src/rich-text/index.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  appendTuttiExternalReferenceSelections,
   createTuttiExternalAtRichTextTriggerProvider,
   createTuttiExternalAtRichTextTriggerProviders,
   createTuttiExternalRichTextMentionService,
@@ -10,6 +11,66 @@ import type {
   TuttiExternalAtQueryInput,
   TuttiExternalAtQueryResult
 } from "../contracts/index.ts";
+
+test("appends selected paths and application reference bundles", () => {
+  assert.equal(
+    appendTuttiExternalReferenceSelections("Create a summary", [
+      {
+        selectionKind: "path",
+        reference: {
+          displayName: "notes.md",
+          kind: "file",
+          path: "/workspace/notes.md"
+        }
+      },
+      {
+        selectionKind: "path",
+        reference: {
+          displayName: "Sources",
+          kind: "folder",
+          path: "/workspace/sources"
+        }
+      },
+      {
+        selectionKind: "workspace-reference",
+        displayName: "Canvas outputs",
+        fileCount: 3,
+        groupId: "outputs",
+        id: "ai-canvas",
+        source: "app",
+        workspaceId: "workspace-1"
+      }
+    ]),
+    "Create a summary [notes.md](/workspace/notes.md) [Sources](/workspace/sources/) [@Canvas outputs](mention://workspace-reference/ai-canvas?count=3&groupId=outputs&source=app&workspaceId=workspace-1)"
+  );
+});
+
+test("deduplicates existing selected paths and application reference bundles", () => {
+  const content =
+    "Use [notes.md](/workspace/notes.md) [@Canvas outputs](mention://workspace-reference/ai-canvas?count=2&groupId=outputs&source=app&workspaceId=workspace-1)";
+  assert.equal(
+    appendTuttiExternalReferenceSelections(content, [
+      {
+        selectionKind: "path",
+        reference: {
+          displayName: "notes.md",
+          kind: "file",
+          path: "/workspace/notes.md"
+        }
+      },
+      {
+        selectionKind: "workspace-reference",
+        displayName: "Canvas outputs",
+        fileCount: 3,
+        groupId: "outputs",
+        id: "ai-canvas",
+        source: "app",
+        workspaceId: "workspace-1"
+      }
+    ]),
+    content
+  );
+});
 
 test("creates one rich text provider per requested external at provider", () => {
   const providers = createTuttiExternalAtRichTextTriggerProviders({

--- a/packages/workspace/external-core/src/rich-text/index.ts
+++ b/packages/workspace/external-core/src/rich-text/index.ts
@@ -5,6 +5,7 @@ import {
   type TuttiExternalAtProviderId,
   type TuttiExternalAtQueryInput,
   type TuttiExternalAtQueryResult,
+  type TuttiExternalReferenceSelection,
   type TuttiExternalAtResolveInput,
   type TuttiExternalAtResolveResult
 } from "../contracts/index.ts";
@@ -13,6 +14,12 @@ import type {
   RichTextTriggerInsertResult,
   RichTextTriggerProvider
 } from "@tutti-os/ui-rich-text/types";
+import {
+  appendRichTextLinksToContent,
+  createRichTextMentionMarkdown,
+  extractRichTextMentionsFromContent,
+  normalizeRichTextContent
+} from "@tutti-os/ui-rich-text/core";
 import {
   createRichTextMentionService,
   canonicalizeRichTextMentionScope,
@@ -70,6 +77,93 @@ export interface CreateTuttiExternalRichTextMentionServiceInput {
   providerIds?: readonly TuttiExternalAtProviderId[];
   appLocalProviders?: readonly RichTextTriggerProvider[];
   maxResults?: number;
+}
+
+function workspaceReferenceIdentityKey(input: {
+  entityId: string;
+  providerId: string;
+  scope?: Readonly<Record<string, string>>;
+}): string | null {
+  if (input.providerId !== "workspace-reference") {
+    return null;
+  }
+  const entityId = input.entityId.trim();
+  const source = input.scope?.source?.trim() ?? "";
+  const workspaceId = input.scope?.workspaceId?.trim() ?? "";
+  if (!entityId || source !== "app" || !workspaceId) {
+    return null;
+  }
+  return JSON.stringify([
+    entityId,
+    source,
+    workspaceId,
+    input.scope?.groupId?.trim() ?? ""
+  ]);
+}
+
+/**
+ * Appends Host-selected paths and lazy workspace-reference handles to the
+ * serialized rich-text prompt. Selection order is stable within each kind,
+ * duplicate paths or handles are omitted, and existing prompt text is kept.
+ */
+export function appendTuttiExternalReferenceSelections(
+  value: string | null | undefined,
+  selections: readonly TuttiExternalReferenceSelection[]
+): string {
+  const pathSelections = selections.filter(
+    (
+      selection
+    ): selection is Extract<
+      TuttiExternalReferenceSelection,
+      { selectionKind: "path" }
+    > => selection.selectionKind === "path"
+  );
+  let content = appendRichTextLinksToContent(
+    value,
+    pathSelections.map(({ reference }) => ({
+      kind: reference.kind === "folder" ? "folder" : "file",
+      name: reference.displayName,
+      path: reference.path
+    }))
+  );
+  const existingWorkspaceReferenceKeys = new Set(
+    extractRichTextMentionsFromContent(content).flatMap((mention) => {
+      const key = workspaceReferenceIdentityKey(mention);
+      return key ? [key] : [];
+    })
+  );
+  const mentionMarkdown = selections.flatMap((selection) => {
+    if (selection.selectionKind !== "workspace-reference") {
+      return [];
+    }
+    const mention = {
+      providerId: "workspace-reference",
+      entityId: selection.id,
+      label: selection.displayName,
+      scope: {
+        workspaceId: selection.workspaceId,
+        source: selection.source,
+        ...(selection.groupId ? { groupId: selection.groupId } : {}),
+        ...(selection.fileCount && selection.fileCount > 0
+          ? { count: String(selection.fileCount) }
+          : {})
+      }
+    };
+    const key = workspaceReferenceIdentityKey(mention);
+    if (!key || existingWorkspaceReferenceKeys.has(key)) {
+      return [];
+    }
+    existingWorkspaceReferenceKeys.add(key);
+    const markdown = createRichTextMentionMarkdown(mention);
+    return markdown ? [markdown] : [];
+  });
+  if (mentionMarkdown.length === 0) {
+    return content;
+  }
+  content = normalizeRichTextContent(content);
+  return content
+    ? `${content} ${mentionMarkdown.join(" ")}`
+    : mentionMarkdown.join(" ");
 }
 
 export async function queryTuttiExternalAtRichTextTriggerItems(

--- a/packages/workspace/file-reference/src/ui/index.ts
+++ b/packages/workspace/file-reference/src/ui/index.ts
@@ -18,3 +18,8 @@ export {
   type ReferenceProvenanceFilterControlProps,
   type ReferenceProvenanceFilterLabels
 } from "./internal/reference/ReferenceProvenanceFilterControl.tsx";
+export {
+  WorkspaceReferenceAddControl,
+  type WorkspaceReferenceAddControlLabels,
+  type WorkspaceReferenceAddControlProps
+} from "./internal/reference/WorkspaceReferenceAddControl.tsx";

--- a/packages/workspace/file-reference/src/ui/internal/reference/WorkspaceReferenceAddControl.tsx
+++ b/packages/workspace/file-reference/src/ui/internal/reference/WorkspaceReferenceAddControl.tsx
@@ -1,0 +1,97 @@
+import {
+  AddLinedIcon,
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  FolderOpenLinedIcon,
+  UploadIcon
+} from "@tutti-os/ui-system";
+import { forwardRef } from "react";
+
+export interface WorkspaceReferenceAddControlLabels {
+  addContent: string;
+  browseReferences: string;
+  uploadFile?: string;
+}
+
+export interface WorkspaceReferenceAddControlProps {
+  className?: string;
+  disabled?: boolean;
+  labels: WorkspaceReferenceAddControlLabels;
+  onBrowseReferences: () => void;
+  onUploadFile?: () => void;
+}
+
+const AddButton = forwardRef<
+  HTMLButtonElement,
+  {
+    className?: string;
+    disabled?: boolean;
+    label: string;
+    onClick?: () => void;
+  }
+>(function AddButton({ className, disabled, label, onClick }, ref) {
+  return (
+    <Button
+      ref={ref}
+      aria-label={label}
+      className={className}
+      disabled={disabled}
+      size="icon-sm"
+      title={label}
+      type="button"
+      variant="ghost"
+      onClick={onClick}
+    >
+      <AddLinedIcon aria-hidden="true" className="size-4" />
+    </Button>
+  );
+});
+
+/**
+ * Standard workspace-app composer entry for adding referenced content.
+ * Upload-capable apps get a two-action menu; other apps open the reference
+ * picker directly.
+ */
+export function WorkspaceReferenceAddControl({
+  className,
+  disabled,
+  labels,
+  onBrowseReferences,
+  onUploadFile
+}: WorkspaceReferenceAddControlProps) {
+  if (!onUploadFile) {
+    return (
+      <AddButton
+        className={className}
+        disabled={disabled}
+        label={labels.addContent}
+        onClick={onBrowseReferences}
+      />
+    );
+  }
+
+  return (
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild>
+        <AddButton
+          className={className}
+          disabled={disabled}
+          label={labels.addContent}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="nodrag min-w-40">
+        <DropdownMenuItem onSelect={onUploadFile}>
+          <UploadIcon aria-hidden="true" className="size-4" />
+          {labels.uploadFile ?? labels.addContent}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={onBrowseReferences}>
+          <FolderOpenLinedIcon aria-hidden="true" className="size-4" />
+          {labels.browseReferences}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}


### PR DESCRIPTION
## Summary

- expose a user-activated `tuttiExternal.references.select()` bridge backed by the shared multi-source picker
- include project files, local files, and application artifacts while intentionally excluding issue artifacts
- preserve artifact groups as lazy `workspace-reference` handles and add shared prompt-append/reference-plus helpers for workspace apps
- keep upload-capable app composers compatible through a reusable Upload / Browse plus menu

## Verification

- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready`
- `pnpm release:pack:check -- --packages-json '["@tutti-os/workspace-file-reference","@tutti-os/workspace-external-core"]'`\n\n## Checklist\n\n- [x] Agent lifecycle semantics are unchanged; this is a host bridge and presentation capability.\n- [x] I kept the change focused on one concern.\n- [x] I updated documentation when behavior, setup, or contributor workflow changed.\n- [x] No multilingual README/CONTRIBUTING source changed.\n- [x] I ran the lowest meaningful local checks for the changed surface.\n- [x] My commits are signed off with DCO when required: `git commit -s`.\n