### PR TITLE
fix(workspace): support bundled React runtimes

### DIFF
--- a/.changeset/workspace-file-reference-react-runtime.md
+++ b/.changeset/workspace-file-reference-react-runtime.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/workspace-file-reference": patch
+---
+
+Keep the reference picker compatible with React runtimes bundled by supported hosts.

--- a/packages/workspace/file-reference/README.md
+++ b/packages/workspace/file-reference/README.md
@@ -11,6 +11,11 @@ product-specific integration stay in the consuming host adapter.
 The package uses logical workspace paths and keeps reference picking reusable
 across shared workspace features such as the agent GUI and issue manager.
 
+Published React entry points use APIs available across the repository's
+supported React 19 hosts. Avoid runtime imports that only exist in a newer
+React minor: frameworks such as Next.js may alias React to their bundled
+runtime even when dependency resolution installs a newer version.
+
 It also provides host-neutral provenance filter contracts, an external-store
 controller, and a controlled filter view. Hosts inject available Agent/member
 options; source implementations declare which dimensions they can enforce and

--- a/packages/workspace/file-reference/src/react/internal/reference/useWorkspaceFileReferencePickerView.ts
+++ b/packages/workspace/file-reference/src/react/internal/reference/useWorkspaceFileReferencePickerView.ts
@@ -1,10 +1,4 @@
-import {
-  useCallback,
-  useEffect,
-  useEffectEvent,
-  useMemo,
-  useState
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSnapshot } from "valtio";
 import type {
   WorkspaceFileReferenceAdapter,
@@ -71,11 +65,16 @@ export function useWorkspaceFileReferencePickerView({
   } = pickerSnapshot;
   const isLoading = mode === "search" ? isSearchLoading : isBrowseLoading;
 
-  const finalizeRequestedReferences = useEffectEvent(
+  const onCloseRef = useRef(onClose);
+  const onConfirmRef = useRef(onConfirm);
+  onCloseRef.current = onClose;
+  onConfirmRef.current = onConfirm;
+  const finalizeRequestedReferences = useCallback(
     (refs: WorkspaceFileReference[]) => {
-      onConfirm(uniqueWorkspaceFileReferences(refs));
-      onClose();
-    }
+      onConfirmRef.current(uniqueWorkspaceFileReferences(refs));
+      onCloseRef.current();
+    },
+    []
   );
 
   const setSearchQuery = useCallback(


### PR DESCRIPTION
## Summary
- replace the React 19.2-only useEffectEvent dependency in the workspace reference picker
- preserve stable callback behavior with latest-value refs
- document the supported-host runtime compatibility rule

## Validation
- pnpm --filter @tutti-os/workspace-file-reference typecheck
- pnpm --filter @tutti-os/workspace-file-reference test
- pnpm --filter @tutti-os/workspace-file-reference build
- verified the built package contains no useEffectEvent import
- pnpm check:changed
- pre-push pnpm check:changed -- --push-ready

## AI disclosure
Implemented with AI assistance and reviewed through targeted package and repository checks.