### PR TITLE
fix(ui): add image failure fallbacks for app and mention surfaces

### DIFF
--- a/packages/ui/rich-text/src/at-panel/MentionRow.render.test.tsx
+++ b/packages/ui/rich-text/src/at-panel/MentionRow.render.test.tsx
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { renderMentionRow } from "./MentionRow.tsx";
+
+afterEach(() => cleanup());
+
+describe("MentionRow image fallbacks", () => {
+  test("replaces a failed app icon with the kind glyph", () => {
+    const view = render(
+      renderMentionRow({
+        kind: "app",
+        name: "Weather",
+        iconUrl: "https://cdn.example.test/weather.png"
+      })
+    );
+
+    fireEvent.error(view.container.querySelector("img") as HTMLImageElement);
+
+    expect(view.container.querySelector("img")).toBeNull();
+    expect(
+      view.container.querySelector(".rich-text-at-mention-kind-icon--app")
+    ).not.toBeNull();
+  });
+
+  test("replaces a failed image thumbnail with the file glyph", () => {
+    const view = render(
+      renderMentionRow({
+        kind: "file",
+        name: "diagram.png",
+        visualKind: "image",
+        thumbnailUrl: "https://cdn.example.test/diagram.png"
+      })
+    );
+
+    fireEvent.error(view.container.querySelector("img") as HTMLImageElement);
+
+    expect(view.container.querySelector("img")).toBeNull();
+    expect(
+      view.container.querySelector(
+        '[data-rich-text-at-mention-file-visual-kind="image"]'
+      )
+    ).not.toBeNull();
+  });
+
+  test("replaces a failed user avatar and placeholder with a user glyph", async () => {
+    const view = render(
+      renderMentionRow({
+        kind: "session",
+        participant: "Agent",
+        userAvatarUrl: "https://cdn.example.test/user.png",
+        userAvatarPlaceholderUrl: "https://cdn.example.test/placeholder.png",
+        agentIconUrl: "https://cdn.example.test/agent.png"
+      })
+    );
+
+    const userAvatar = view.container.querySelector(
+      "[data-rich-text-at-mention-user-avatar] img"
+    ) as HTMLImageElement;
+    fireEvent.error(userAvatar);
+    await waitFor(() => {
+      expect(
+        view.container
+          .querySelector("[data-rich-text-at-mention-user-avatar] img")
+          ?.getAttribute("src")
+      ).toBe("https://cdn.example.test/placeholder.png");
+    });
+    fireEvent.error(
+      view.container.querySelector(
+        "[data-rich-text-at-mention-user-avatar] img"
+      ) as HTMLImageElement
+    );
+    await waitFor(() => {
+      expect(
+        view.container.querySelector(
+          "[data-rich-text-at-mention-user-avatar] img"
+        )
+      ).toBeNull();
+    });
+    expect(
+      view.container.querySelector(
+        "[data-rich-text-at-mention-user-avatar] svg"
+      )
+    ).not.toBeNull();
+  });
+});

--- a/packages/ui/rich-text/src/at-panel/MentionRow.tsx
+++ b/packages/ui/rich-text/src/at-panel/MentionRow.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowLeftIcon,
   ArrowRightIcon,
+  AgentSessionsIcon,
   Badge,
   FileCodeIcon,
   FileTextIcon,
@@ -8,11 +9,12 @@ import {
   ImageFileIcon,
   ProductIcon,
   StatusDot,
+  UserLinedIcon,
   VideoFileIcon,
   cn,
   type IconProps
 } from "@tutti-os/ui-system";
-import { Fragment } from "react";
+import { Fragment, useState } from "react";
 import type { MentionFileVisualKind } from "./mentionFileVisualKind.ts";
 import {
   mentionRowDataAttribute,
@@ -447,13 +449,17 @@ function MentionFileIcon({
         {...mentionRowDataAttribute(dataAttributeMode, "fileThumb", "true")}
         aria-hidden="true"
       >
-        <img
+        <MentionImageWithFallback
           src={thumbnailUrl}
           alt=""
           className="rich-text-at-mention-row__media"
-          decoding="async"
-          loading="lazy"
-          draggable={false}
+          fallback={
+            <MentionFileIcon
+              item={{ ...item, thumbnailUrl: null }}
+              classNames={classNames}
+              dataAttributeMode={dataAttributeMode}
+            />
+          }
         />
       </span>
     );
@@ -539,13 +545,18 @@ function MentionEntityIcon({
       aria-hidden="true"
     >
       {normalizedIconUrl ? (
-        <img
+        <MentionImageWithFallback
           src={normalizedIconUrl}
           alt=""
           className="rich-text-at-mention-row__media"
-          decoding="async"
-          loading="lazy"
-          draggable={false}
+          fallback={
+            <span
+              className={cn(
+                kindIconClassName,
+                "rich-text-at-mention-kind-icon--app"
+              )}
+            />
+          }
         />
       ) : (
         <span
@@ -559,6 +570,36 @@ function MentionEntityIcon({
   );
 }
 
+function MentionImageWithFallback({
+  src,
+  alt,
+  className,
+  fallback
+}: {
+  src: string;
+  alt: string;
+  className: string;
+  fallback: React.JSX.Element;
+}): React.JSX.Element {
+  const [failedSource, setFailedSource] = useState<string | null>(null);
+  if (failedSource === src) {
+    return fallback;
+  }
+  return (
+    <img
+      src={src}
+      alt={alt}
+      className={className}
+      decoding="async"
+      loading="lazy"
+      draggable={false}
+      onError={() => {
+        setFailedSource(src);
+      }}
+    />
+  );
+}
+
 function MentionSessionAvatarStack({
   item,
   classNames,
@@ -568,6 +609,9 @@ function MentionSessionAvatarStack({
   classNames: Required<MentionRowClassNames>;
   dataAttributeMode: MentionRowDataAttributeMode;
 }): React.JSX.Element {
+  const [failedUserAvatarUrls, setFailedUserAvatarUrls] = useState<
+    readonly string[]
+  >([]);
   const showUserAvatar = item.showUserAvatar !== false;
   if (!showUserAvatar) {
     return (
@@ -582,13 +626,16 @@ function MentionSessionAvatarStack({
           className="rich-text-at-mention-avatar rich-text-at-mention-avatar--agent"
           {...mentionRowDataAttribute(dataAttributeMode, "agentAvatar", "true")}
         >
-          <img
+          <MentionImageWithFallback
             src={item.agentIconUrl}
             alt=""
             className="rich-text-at-mention-row__media"
-            decoding="async"
-            loading="lazy"
-            draggable={false}
+            fallback={
+              <AgentSessionsIcon
+                aria-hidden="true"
+                className="size-4 text-[var(--rich-text-at-mention-text-secondary)]"
+              />
+            }
           />
         </span>
       </span>
@@ -596,48 +643,58 @@ function MentionSessionAvatarStack({
   }
 
   const userAvatarUrl = item.userAvatarUrl?.trim() ?? "";
-  const placeholderUrl = item.userAvatarPlaceholderUrl;
-  const userImageUrl = userAvatarUrl || placeholderUrl;
+  const placeholderUrl = item.userAvatarPlaceholderUrl.trim();
+  const userImageUrl = [userAvatarUrl, placeholderUrl].find(
+    (url) => url && !failedUserAvatarUrls.includes(url)
+  );
   return (
     <span className="rich-text-at-mention-avatar-stack" aria-hidden="true">
       <span
         className="rich-text-at-mention-avatar rich-text-at-mention-avatar--user"
         {...mentionRowDataAttribute(dataAttributeMode, "userAvatar", "true")}
       >
-        <img
-          src={userImageUrl}
-          alt=""
-          className={cn(
-            "rich-text-at-mention-row__media",
-            !userAvatarUrl && classNames.avatarImgUserPlaceholder
-          )}
-          decoding="async"
-          loading="lazy"
-          referrerPolicy="no-referrer"
-          draggable={false}
-          onError={(event) => {
-            if (event.currentTarget.dataset.fallbackAvatarApplied === "true") {
-              return;
-            }
-            event.currentTarget.dataset.fallbackAvatarApplied = "true";
-            event.currentTarget.src = placeholderUrl;
-            event.currentTarget.classList.add(
-              classNames.avatarImgUserPlaceholder
-            );
-          }}
-        />
+        {userImageUrl ? (
+          <img
+            src={userImageUrl}
+            alt=""
+            className={cn(
+              "rich-text-at-mention-row__media",
+              userImageUrl === placeholderUrl &&
+                classNames.avatarImgUserPlaceholder
+            )}
+            decoding="async"
+            loading="lazy"
+            referrerPolicy="no-referrer"
+            draggable={false}
+            onError={() => {
+              setFailedUserAvatarUrls((failedUrls) =>
+                failedUrls.includes(userImageUrl)
+                  ? failedUrls
+                  : [...failedUrls, userImageUrl]
+              );
+            }}
+          />
+        ) : (
+          <UserLinedIcon
+            aria-hidden="true"
+            className="size-3.5 text-[var(--rich-text-at-mention-text-secondary)]"
+          />
+        )}
       </span>
       <span
         className="rich-text-at-mention-avatar rich-text-at-mention-avatar--agent"
         {...mentionRowDataAttribute(dataAttributeMode, "agentAvatar", "true")}
       >
-        <img
+        <MentionImageWithFallback
           src={item.agentIconUrl}
           alt=""
           className="rich-text-at-mention-row__media"
-          decoding="async"
-          loading="lazy"
-          draggable={false}
+          fallback={
+            <AgentSessionsIcon
+              aria-hidden="true"
+              className="size-4 text-[var(--rich-text-at-mention-text-secondary)]"
+            />
+          }
         />
       </span>
     </span>

--- a/packages/ui/rich-text/src/editor/RichTextTriggerMenuItem.tsx
+++ b/packages/ui/rich-text/src/editor/RichTextTriggerMenuItem.tsx
@@ -1,4 +1,4 @@
-import type { JSX, MouseEvent } from "react";
+import { useState, type JSX, type MouseEvent } from "react";
 import { FileIcon, FolderFilledIcon } from "@tutti-os/ui-system/icons";
 
 type RichTextTriggerMenuItemProps = {
@@ -58,6 +58,7 @@ function RichTextTriggerMenuIcon({
   workspaceReferenceFileKind?: "file" | "folder";
 }): JSX.Element {
   const normalizedIconUrl = iconUrl?.trim() ?? "";
+  const [failedIconUrl, setFailedIconUrl] = useState<string | null>(null);
 
   if (workspaceReferenceFileKind) {
     const Icon =
@@ -79,7 +80,7 @@ function RichTextTriggerMenuIcon({
       className="inline-grid size-4 flex-none place-items-center overflow-hidden rounded bg-[var(--bg-block,var(--transparency-block))]"
       data-rich-text-trigger-icon="true"
     >
-      {normalizedIconUrl ? (
+      {normalizedIconUrl && failedIconUrl !== normalizedIconUrl ? (
         <img
           alt=""
           className="block size-full object-cover object-center"
@@ -87,6 +88,9 @@ function RichTextTriggerMenuIcon({
           draggable={false}
           loading="lazy"
           src={normalizedIconUrl}
+          onError={() => {
+            setFailedIconUrl(normalizedIconUrl);
+          }}
         />
       ) : (
         <span className="block size-3 rounded-[3px] bg-[var(--transparency-block)]" />

--- a/packages/workspace/app-center/src/ui/AppCard.tsx
+++ b/packages/workspace/app-center/src/ui/AppCard.tsx
@@ -662,23 +662,35 @@ function AuthorAvatar({
   readonly author: WorkspaceAppAuthorViewModel;
   readonly fallbackIconUrl?: string | null;
 }): ReactElement {
-  if (author.avatarUrl) {
+  const [failedImageUrl, setFailedImageUrl] = useState<string | null>(null);
+  const avatarUrl = author.avatarUrl?.trim() ?? "";
+  if (avatarUrl && failedImageUrl !== avatarUrl) {
     return (
       <img
         alt=""
         className="size-5 shrink-0 rounded-full border border-[var(--background-fronted)] object-cover"
         draggable={false}
-        src={author.avatarUrl}
+        src={avatarUrl}
+        onError={() => {
+          setFailedImageUrl(avatarUrl);
+        }}
       />
     );
   }
-  if (fallbackIconUrl) {
+  const normalizedFallbackIconUrl = fallbackIconUrl?.trim() ?? "";
+  if (
+    normalizedFallbackIconUrl &&
+    failedImageUrl !== normalizedFallbackIconUrl
+  ) {
     return (
       <img
         alt=""
         className="size-5 shrink-0 rounded-[5px] border border-[var(--background-fronted)] object-contain"
         draggable={false}
-        src={fallbackIconUrl}
+        src={normalizedFallbackIconUrl}
+        onError={() => {
+          setFailedImageUrl(normalizedFallbackIconUrl);
+        }}
       />
     );
   }
@@ -995,14 +1007,19 @@ function AppIcon({
   readonly onReplaceIcon: () => void;
   readonly replaceIconLabel: string;
 }): ReactElement {
+  const [failedIconUrl, setFailedIconUrl] = useState<string | null>(null);
+  const iconUrl = app.icon?.type === "asset" ? app.icon.src.trim() : "";
   const icon =
-    app.icon?.type === "asset" ? (
+    iconUrl && failedIconUrl !== iconUrl ? (
       <img
         alt=""
         className="size-11 flex-none rounded-[10px] object-contain object-center select-none"
         decoding="async"
         draggable={false}
-        src={app.icon.src}
+        src={iconUrl}
+        onError={() => {
+          setFailedIconUrl(iconUrl);
+        }}
       />
     ) : (
       <span className="flex size-11 flex-none items-center justify-center rounded-[10px] bg-[var(--transparency-block)] text-[var(--text-secondary)]">

--- a/packages/workspace/app-center/src/ui/AppCenterPanel.tsx
+++ b/packages/workspace/app-center/src/ui/AppCenterPanel.tsx
@@ -1412,7 +1412,14 @@ function AppCenterAgentProviderIcon({
   iconUrl?: string | null;
 }): ReactElement {
   const normalizedIconUrl = iconUrl?.trim();
+  const [failedIconUrl, setFailedIconUrl] = useState<string | null>(null);
   if (!normalizedIconUrl) {
+    return (
+      <span aria-hidden="true" className="size-4 shrink-0 rounded-[4px]" />
+    );
+  }
+
+  if (failedIconUrl === normalizedIconUrl) {
     return (
       <span aria-hidden="true" className="size-4 shrink-0 rounded-[4px]" />
     );
@@ -1426,6 +1433,9 @@ function AppCenterAgentProviderIcon({
       decoding="async"
       draggable={false}
       src={normalizedIconUrl}
+      onError={() => {
+        setFailedIconUrl(normalizedIconUrl);
+      }}
     />
   );
 }


### PR DESCRIPTION
## What changed
- Add bounded image failure fallbacks for application cards, author/provider icons, rich-text trigger icons, and @-panel thumbnails, app/issue icons, session avatars, and user avatars.
- Add regression coverage for failed app icons, thumbnails, and user-avatar plus placeholder failures.

## Why
Remote image failures currently leave broken image states visible. The fallback path keeps the row/card usable without changing the resource URL contract.

## Risks
- Existing public icon URLs and API fields are unchanged.
- Fallback icons affect only image load failures.
- The paired tsh-server PR adds immutable cache metadata for new application-icon uploads.

## Verification
- `pnpm --dir packages/ui/rich-text exec vitest run src/at-panel/MentionRow.render.test.tsx --environment jsdom`
- `pnpm --dir packages/ui/rich-text typecheck`
- `pnpm --dir packages/workspace/app-center typecheck`
- `pnpm --dir apps/tsh-desktop check`
- `pnpm check:changed -- --push-ready`

## Follow-up
Existing S3 objects with legacy cache metadata are intentionally not rewritten in this PR.