### PR TITLE
fix(browser-node): restore agent browser page lifecycle

### DIFF
--- a/packages/agent/gui/workbench/tool-sidebar/AgentToolBrowserPanel.test.ts
+++ b/packages/agent/gui/workbench/tool-sidebar/AgentToolBrowserPanel.test.ts
@@ -6,6 +6,7 @@ import type {
 } from "@tutti-os/browser-node";
 import type { I18nRuntime } from "@tutti-os/ui-i18n-runtime";
 import { createAgentToolBrowserFeature } from "./AgentToolBrowserPanel.tsx";
+import { createAgentToolBrowserPage } from "./agentToolBrowserPage.ts";
 
 describe("AgentToolBrowserPanel", () => {
   it("scopes host events to its browser surface and child tabs", () => {
@@ -68,6 +69,31 @@ describe("AgentToolBrowserPanel", () => {
     });
 
     expect(feature.chromeCookieImport?.prompt).toBe(prompt);
+  });
+
+  it("materializes an automation-created about:blank page", () => {
+    const feature = createAgentToolBrowserFeature({
+      browserApi: createBrowserApi(() => undefined),
+      i18n: { t: (key) => key } as I18nRuntime<string>,
+      nodeId: "browser:agent-tool:one"
+    });
+
+    const nodeId = createAgentToolBrowserPage(
+      feature,
+      "browser:agent-tool:one",
+      "about:blank",
+      null
+    );
+
+    expect(nodeId).toBe("browser:agent-tool:one:tab:1");
+    expect(
+      feature.tabsStore.getSurfaceState("browser:agent-tool:one")?.tabs
+    ).toEqual([
+      expect.objectContaining({
+        materializeCold: true,
+        nodeId
+      })
+    ]);
   });
 });
 

--- a/packages/agent/gui/workbench/tool-sidebar/AgentToolBrowserPanel.tsx
+++ b/packages/agent/gui/workbench/tool-sidebar/AgentToolBrowserPanel.tsx
@@ -17,6 +17,7 @@ import {
   type BrowserNodeSessionMode
 } from "@tutti-os/browser-node";
 import type { I18nRuntime } from "@tutti-os/ui-i18n-runtime";
+import { createAgentToolBrowserPage } from "./agentToolBrowserPage.ts";
 
 const LazyBrowserNode = lazy(() =>
   import("@tutti-os/browser-node/react").then(({ BrowserNode }) => ({
@@ -96,23 +97,7 @@ export function AgentToolBrowserPanel({
         return "closed";
       },
       createPage(url) {
-        const resolvedUrl = url?.trim() || "about:blank";
-        const state = feature.tabsStore.ensureSurface(nodeId, defaultUrl);
-        const activeTab = state.tabs.find(
-          (tab) => tab.id === state.activeTabId
-        );
-        const activeRuntime = activeTab
-          ? feature.runtimeStore.getNodeState(activeTab.nodeId)
-          : null;
-        if (
-          state.tabs.length === 1 &&
-          activeTab?.defaultUrl === "about:blank" &&
-          !activeRuntime?.url
-        ) {
-          feature.tabsStore.syncDefaultUrl(nodeId, resolvedUrl);
-          return activeTab.nodeId;
-        }
-        return feature.tabsStore.addTab(nodeId, resolvedUrl).nodeId;
+        return createAgentToolBrowserPage(feature, nodeId, defaultUrl, url);
       },
       ownsPage: (pageNodeId) => getPage(pageNodeId) !== null,
       selectPage(pageNodeId) {

--- a/packages/agent/gui/workbench/tool-sidebar/AgentToolBrowserPanel.tsx
+++ b/packages/agent/gui/workbench/tool-sidebar/AgentToolBrowserPanel.tsx
@@ -40,6 +40,7 @@ export interface AgentToolBrowserPanelProps {
   loadingFallback?: ReactNode;
   navigationActions?: ReactNode;
   nodeIdPrefix?: string;
+  onCloseRequest?: () => void;
   onControllerReady?: (controller: AgentToolBrowserController | null) => void;
   profileId?: string | null;
   sessionMode?: BrowserNodeSessionMode;
@@ -64,6 +65,7 @@ export function AgentToolBrowserPanel({
   loadingFallback = null,
   navigationActions,
   nodeIdPrefix = "browser:agent-tool",
+  onCloseRequest,
   onControllerReady,
   profileId = null,
   sessionMode = "shared",
@@ -133,6 +135,7 @@ export function AgentToolBrowserPanel({
           hidden={hidden}
           navigationActions={navigationActions}
           nodeId={nodeId}
+          onCloseRequest={onCloseRequest}
           profileId={profileId}
           sessionMode={sessionMode}
           sessionPartition={sessionPartition}

--- a/packages/agent/gui/workbench/tool-sidebar/agentToolBrowserPage.ts
+++ b/packages/agent/gui/workbench/tool-sidebar/agentToolBrowserPage.ts
@@ -1,0 +1,28 @@
+import type { BrowserNodeFeature } from "@tutti-os/browser-node";
+
+export function createAgentToolBrowserPage(
+  feature: BrowserNodeFeature,
+  surfaceNodeId: string,
+  defaultUrl: string,
+  url?: string | null
+): string {
+  const resolvedUrl = url?.trim() || "about:blank";
+  const state = feature.tabsStore.ensureSurface(surfaceNodeId, defaultUrl, {
+    materializeCold: true
+  });
+  const activeTab = state.tabs.find((tab) => tab.id === state.activeTabId);
+  const activeRuntime = activeTab
+    ? feature.runtimeStore.getNodeState(activeTab.nodeId)
+    : null;
+  if (
+    state.tabs.length === 1 &&
+    activeTab?.defaultUrl === "about:blank" &&
+    !activeRuntime?.url
+  ) {
+    feature.tabsStore.syncDefaultUrl(surfaceNodeId, resolvedUrl);
+    return activeTab.nodeId;
+  }
+  return feature.tabsStore.addTab(surfaceNodeId, resolvedUrl, {
+    materializeCold: true
+  }).nodeId;
+}

--- a/packages/browser/workbench-node/src/core/tabsStore.test.ts
+++ b/packages/browser/workbench-node/src/core/tabsStore.test.ts
@@ -58,3 +58,16 @@ test("browser tabs can create an automation page at a requested URL", () => {
   const tab = store.addTab("browser:one", "https://example.com/");
   assert.equal(tab.defaultUrl, "https://example.com/");
 });
+
+test("browser tabs materialize an existing cold surface for automation", () => {
+  const store = createBrowserNodeTabsStore();
+  const initial = store.ensureSurface("browser:one", "about:blank");
+
+  assert.equal(initial.tabs[0]?.materializeCold, undefined);
+
+  const materialized = store.ensureSurface("browser:one", "about:blank", {
+    materializeCold: true
+  });
+
+  assert.equal(materialized.tabs[0]?.materializeCold, true);
+});

--- a/packages/browser/workbench-node/src/core/tabsStore.ts
+++ b/packages/browser/workbench-node/src/core/tabsStore.ts
@@ -64,6 +64,23 @@ export function createBrowserNodeTabsStore(): BrowserNodeTabsStore {
   ): BrowserNodeTabsState => {
     const existing = states.get(surfaceNodeId);
     if (existing) {
+      if (
+        options?.materializeCold &&
+        !existing.tabs.find((tab) => tab.id === existing.activeTabId)
+          ?.materializeCold
+      ) {
+        const state = {
+          ...existing,
+          tabs: existing.tabs.map((tab) =>
+            tab.id === existing.activeTabId
+              ? { ...tab, materializeCold: true }
+              : tab
+          )
+        };
+        states.set(surfaceNodeId, state);
+        emit();
+        return state;
+      }
       return existing;
     }
 

--- a/packages/browser/workbench-node/src/react/BrowserNode.tsx
+++ b/packages/browser/workbench-node/src/react/BrowserNode.tsx
@@ -87,6 +87,7 @@ export interface BrowserNodeProps {
   navigationPolicy?: BrowserNodeNavigationPolicy | null;
   navigationActions?: ReactNode;
   nodeId: string;
+  onCloseRequest?: () => void;
   onFocusRequest?: () => void;
   onNavigated?: (url: string) => void;
   profileId?: string | null;
@@ -112,6 +113,7 @@ export function BrowserNode({
   navigationPolicy = null,
   navigationActions,
   nodeId,
+  onCloseRequest,
   onFocusRequest,
   onNavigated,
   profileId = null,
@@ -132,6 +134,7 @@ export function BrowserNode({
         navigationPolicy={navigationPolicy}
         navigationActions={navigationActions}
         nodeId={nodeId}
+        onCloseRequest={onCloseRequest}
         onFocusRequest={onFocusRequest}
         onNavigated={onNavigated}
         profileId={profileId}
@@ -183,6 +186,7 @@ function TabbedBrowserNode({
   navigationPolicy,
   navigationActions,
   nodeId,
+  onCloseRequest,
   onFocusRequest,
   onNavigated,
   profileId,
@@ -228,6 +232,7 @@ function TabbedBrowserNode({
             defaultUrl={defaultUrl}
             feature={feature}
             navigationActions={navigationActions}
+            onCloseRequest={onCloseRequest}
             onFocusRequest={onFocusRequest}
             surfaceNodeId={nodeId}
           />

--- a/packages/browser/workbench-node/src/react/BrowserNodeChrome.tsx
+++ b/packages/browser/workbench-node/src/react/BrowserNodeChrome.tsx
@@ -34,6 +34,7 @@ import {
   openBrowserNodeExternal,
   resolveBrowserNodeOpenExternalUrl
 } from "./browserNodeOperations.ts";
+import { resolveBrowserNodeTabCloseIntent } from "./browserNodeTabClose.ts";
 import { useBrowserNodeController } from "./useBrowserNodeController.ts";
 
 export interface BrowserNodeChromeProps {
@@ -184,21 +185,31 @@ export function BrowserNodeChrome({
           className="nodrag flex min-w-0 max-w-[70%] items-center gap-1 overflow-x-auto"
           role="tablist"
         >
-          {tabsState.tabs.map((tab) => (
-            <BrowserNodeTabButton
-              active={tab.id === tabsState.activeTabId}
-              canClose={tabsState.tabs.length > 1}
-              feature={feature}
-              key={tab.id}
-              tab={tab}
-              onClose={() =>
-                closeBrowserNodeTab(feature, surfaceNodeId, tab.id)
-              }
-              onSelect={() =>
-                feature.tabsStore.selectTab(surfaceNodeId, tab.id)
-              }
-            />
-          ))}
+          {tabsState.tabs.map((tab) => {
+            const closeIntent = resolveBrowserNodeTabCloseIntent({
+              hasSurfaceCloseRequest: Boolean(onCloseRequest),
+              tabCount: tabsState.tabs.length
+            });
+            return (
+              <BrowserNodeTabButton
+                active={tab.id === tabsState.activeTabId}
+                canClose={closeIntent !== null}
+                feature={feature}
+                key={tab.id}
+                tab={tab}
+                onClose={() => {
+                  if (closeIntent === "surface") {
+                    onCloseRequest?.();
+                    return;
+                  }
+                  closeBrowserNodeTab(feature, surfaceNodeId, tab.id);
+                }}
+                onSelect={() =>
+                  feature.tabsStore.selectTab(surfaceNodeId, tab.id)
+                }
+              />
+            );
+          })}
         </div>
         <Button
           aria-label={feature.i18n.t("tabs.new")}

--- a/packages/browser/workbench-node/src/react/browserNodeTabClose.test.ts
+++ b/packages/browser/workbench-node/src/react/browserNodeTabClose.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveBrowserNodeTabCloseIntent } from "./browserNodeTabClose.ts";
+
+test("Browser Node closes one of multiple tabs", () => {
+  assert.equal(
+    resolveBrowserNodeTabCloseIntent({
+      hasSurfaceCloseRequest: true,
+      tabCount: 2
+    }),
+    "tab"
+  );
+});
+
+test("Browser Node delegates its last tab to the surface close request", () => {
+  assert.equal(
+    resolveBrowserNodeTabCloseIntent({
+      hasSurfaceCloseRequest: true,
+      tabCount: 1
+    }),
+    "surface"
+  );
+});
+
+test("Browser Node keeps its last tab without a surface close request", () => {
+  assert.equal(
+    resolveBrowserNodeTabCloseIntent({
+      hasSurfaceCloseRequest: false,
+      tabCount: 1
+    }),
+    null
+  );
+});

--- a/packages/browser/workbench-node/src/react/browserNodeTabClose.ts
+++ b/packages/browser/workbench-node/src/react/browserNodeTabClose.ts
@@ -1,0 +1,13 @@
+export type BrowserNodeTabCloseIntent = "surface" | "tab";
+
+export function resolveBrowserNodeTabCloseIntent(input: {
+  hasSurfaceCloseRequest: boolean;
+  tabCount: number;
+}): BrowserNodeTabCloseIntent | null {
+  if (input.tabCount > 1) {
+    return "tab";
+  }
+  return input.tabCount === 1 && input.hasSurfaceCloseRequest
+    ? "surface"
+    : null;
+}


### PR DESCRIPTION
## Summary

- Materialize automation-created Browser pages even when the Agent Browser surface already owns a cold tab, so the Electron guest can attach before automation proceeds.
- Let a host-owned Agent Browser close its surface from the final tab while preserving the at-least-one-tab invariant for embedded tool sidebars without a surface close capability.
- Keep exact Agent Session, workspace, surface, and tab identity unchanged across Browser automation routing.

## Verification

- `pnpm --filter @tutti-os/browser-node test` (158 tests passed)
- `pnpm --filter @tutti-os/agent-gui test -- --run workbench/tool-sidebar/AgentToolBrowserPanel.test.ts` (299 files / 2606 tests passed)
- `pnpm check:changed` (13 lanes passed)
- pre-push `pnpm check:changed -- --push-ready` (14 lanes passed)
- Linked `@tutti-os/agent-gui` and `@tutti-os/browser-node` into the downstream desktop host; its focused Agent Browser test and Desktop check passed.

## AgentGUI Review

| Lane | Result | Evidence | Affected consumers |
| --- | --- | --- | --- |
| Architecture | pass | Browser page creation remains a Workbench presentation/controller action; exact session/workspace/surface/tab identities and Browser guest ownership are unchanged. | AgentGUI Workbench Browser, standalone Agent Browser |
| Performance | pass | The change runs only on explicit page creation or tab close; no subscriptions, streaming projections, layout measurement, timers, caches, or logging hot paths changed. The degradation gate passed in changed checks. | BrowserNode and AgentGUI renderers |
| Consumers | pass | New close capability is optional and fails closed when absent; existing embedded sidebars keep their last tab. BrowserNode, AgentGUI, and the downstream desktop host all passed focused validation. | Tutti Desktop, TSH and other AgentGUI hosts |

Unresolved risks: visual placement still requires host-side manual inspection after restarting the Electron/Vite process.

## Documentation impact

No durable documentation update is required: ownership, data flow, public package entry points, and runtime configuration are unchanged; this restores the existing Browser surface lifecycle contract.

## Checklist

- [x] This PR does not change agent lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] I reviewed documentation impact.
- [x] README/CONTRIBUTING language variants are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required.