### PR TITLE
fix(ui): retry remote images before fallback

### DIFF
--- a/apps/ui-storyboard/src/App.tsx
+++ b/apps/ui-storyboard/src/App.tsx
@@ -22,6 +22,7 @@ import {
   DrawerHeader,
   DrawerTitle,
   DrawerTrigger,
+  ImageWithFallback,
   Input,
   MenuSurface,
   MentionPill,
@@ -311,6 +312,11 @@ const buttonComponent = uiSystemMetadata.components.find(
 const sections = [
   ...foundationNavigationSections,
   ...componentSection("avatar", "Avatar", "身份图片、字母与加载回退"),
+  ...componentSection(
+    "image-with-fallback",
+    "ImageWithFallback",
+    "远程图片重试与稳定兜底"
+  ),
   ...componentSection("badge", "Badge", "状态标签与紧凑元信息"),
   ...componentSection("button", "Button", "按钮层级、尺寸与状态"),
   {
@@ -469,6 +475,10 @@ const sectionCopy: Record<
     colors: { label: "颜色", summary: colorsContent.description },
     typography: { label: "字体", summary: typographyContent.description },
     metrics: { label: "度量", summary: metricsContent.description },
+    "image-with-fallback": {
+      label: "ImageWithFallback",
+      summary: "远程图片重试与稳定兜底"
+    },
     badge: { label: "Badge", summary: "状态标签与紧凑元信息" },
     button: { label: "Button", summary: "按钮层级、尺寸与状态" },
     checkbox: { label: "Checkbox", summary: "多选项、文件选择与布尔配置" },
@@ -531,6 +541,10 @@ const sectionCopy: Record<
     metrics: {
       label: "Metrics",
       summary: "Spacing, radius, and motion values used across shared UI."
+    },
+    "image-with-fallback": {
+      label: "ImageWithFallback",
+      summary: "Bounded remote image retry and fallback."
     },
     badge: { label: "Badge", summary: "Status labels and compact metadata." },
     button: {
@@ -1661,6 +1675,78 @@ function AvatarStoryboard() {
               <code className="font-mono text-[11px] text-[var(--text-secondary)]">
                 {label}
               </code>
+            </div>
+          ))}
+        </div>
+      </ExampleCard>
+    </DocsSection>
+  );
+}
+
+function ImageWithFallbackStoryboard() {
+  if (!hasStoryboard("ImageWithFallback")) {
+    return null;
+  }
+
+  const fallback = (
+    <span className="grid size-12 place-items-center rounded-[10px] bg-[var(--transparency-block)] text-[var(--text-secondary)]">
+      <SystemIcons.ImageFileIcon className="size-5" />
+    </span>
+  );
+
+  const states = [
+    {
+      description: "Remote image delivered successfully",
+      label: "Loaded",
+      node: (
+        <ImageWithFallback
+          alt=""
+          className="size-12 rounded-[10px] object-contain"
+          src={avatarSampleImageUrl}
+          fallback={fallback}
+        />
+      )
+    },
+    {
+      description: "One same-URL retry, then the caller fallback",
+      label: "Retry then fallback",
+      node: (
+        <ImageWithFallback
+          alt=""
+          className="size-12 rounded-[10px] object-contain"
+          src="/__missing-image-with-fallback__.png"
+          fallback={fallback}
+        />
+      )
+    }
+  ];
+
+  return (
+    <DocsSection
+      id="image-with-fallback"
+      title="ImageWithFallback"
+      description="远程图片只做有限次同 URL 重试，失败后由调用方提供稳定兜底"
+      componentId={metadataFor("ImageWithFallback")?.id}
+    >
+      <ExampleCard
+        title="Delivery States"
+        description="同一个 URL 只重试一次，不通过追加 query 改写请求地址"
+      >
+        <div className="flex flex-wrap gap-5">
+          {states.map((state) => (
+            <div
+              className="grid min-w-32 justify-items-center gap-2 text-center"
+              key={state.label}
+            >
+              {state.node}
+              <div className="grid gap-0.5">
+                <span className="text-[13px] font-medium text-[var(--text-primary)]">
+                  {state.label}
+                </span>
+                <span className="text-[11px] text-[var(--text-secondary)]">
+                  {state.description}
+                </span>
+              </div>
             </div>
           ))}
         </div>
@@ -4059,6 +4145,7 @@ export function App() {
             />
           ) : null}
           <AvatarStoryboard />
+          <ImageWithFallbackStoryboard />
           <BadgeStoryboard />
           <ButtonStoryboard />
           <CheckboxStoryboard />

--- a/packages/ui/rich-text/src/at-panel/MentionRow.render.test.tsx
+++ b/packages/ui/rich-text/src/at-panel/MentionRow.render.test.tsx
@@ -5,7 +5,7 @@ import { renderMentionRow } from "./MentionRow.tsx";
 afterEach(() => cleanup());
 
 describe("MentionRow image fallbacks", () => {
-  test("replaces a failed app icon with the kind glyph", () => {
+  test("retries an app icon once before showing the kind glyph", async () => {
     const view = render(
       renderMentionRow({
         kind: "app",
@@ -14,15 +14,23 @@ describe("MentionRow image fallbacks", () => {
       })
     );
 
-    fireEvent.error(view.container.querySelector("img") as HTMLImageElement);
+    const firstImage = view.container.querySelector("img") as HTMLImageElement;
+    fireEvent.error(firstImage);
+    const retriedImage = await waitFor(() => {
+      const image = view.container.querySelector("img");
+      expect(image).not.toBeNull();
+      expect(image).not.toBe(firstImage);
+      return image as HTMLImageElement;
+    });
+    fireEvent.error(retriedImage);
 
-    expect(view.container.querySelector("img")).toBeNull();
+    await waitFor(() => expect(view.container.querySelector("img")).toBeNull());
     expect(
       view.container.querySelector(".rich-text-at-mention-kind-icon--app")
     ).not.toBeNull();
   });
 
-  test("replaces a failed image thumbnail with the file glyph", () => {
+  test("retries an image thumbnail once before showing the file glyph", async () => {
     const view = render(
       renderMentionRow({
         kind: "file",
@@ -32,9 +40,17 @@ describe("MentionRow image fallbacks", () => {
       })
     );
 
-    fireEvent.error(view.container.querySelector("img") as HTMLImageElement);
+    const firstImage = view.container.querySelector("img") as HTMLImageElement;
+    fireEvent.error(firstImage);
+    const retriedImage = await waitFor(() => {
+      const image = view.container.querySelector("img");
+      expect(image).not.toBeNull();
+      expect(image).not.toBe(firstImage);
+      return image as HTMLImageElement;
+    });
+    fireEvent.error(retriedImage);
 
-    expect(view.container.querySelector("img")).toBeNull();
+    await waitFor(() => expect(view.container.querySelector("img")).toBeNull());
     expect(
       view.container.querySelector(
         '[data-rich-text-at-mention-file-visual-kind="image"]'
@@ -57,6 +73,17 @@ describe("MentionRow image fallbacks", () => {
       "[data-rich-text-at-mention-user-avatar] img"
     ) as HTMLImageElement;
     fireEvent.error(userAvatar);
+    const retriedUserAvatar = await waitFor(() => {
+      const image = view.container.querySelector(
+        "[data-rich-text-at-mention-user-avatar] img"
+      );
+      expect(image).not.toBe(userAvatar);
+      expect(image?.getAttribute("src")).toBe(
+        "https://cdn.example.test/user.png"
+      );
+      return image as HTMLImageElement;
+    });
+    fireEvent.error(retriedUserAvatar);
     await waitFor(() => {
       expect(
         view.container
@@ -64,11 +91,21 @@ describe("MentionRow image fallbacks", () => {
           ?.getAttribute("src")
       ).toBe("https://cdn.example.test/placeholder.png");
     });
-    fireEvent.error(
-      view.container.querySelector(
+    const firstPlaceholder = view.container.querySelector(
+      "[data-rich-text-at-mention-user-avatar] img"
+    ) as HTMLImageElement;
+    fireEvent.error(firstPlaceholder);
+    const retriedPlaceholder = await waitFor(() => {
+      const image = view.container.querySelector(
         "[data-rich-text-at-mention-user-avatar] img"
-      ) as HTMLImageElement
-    );
+      );
+      expect(image).not.toBe(firstPlaceholder);
+      expect(image?.getAttribute("src")).toBe(
+        "https://cdn.example.test/placeholder.png"
+      );
+      return image as HTMLImageElement;
+    });
+    fireEvent.error(retriedPlaceholder);
     await waitFor(() => {
       expect(
         view.container.querySelector(

--- a/packages/ui/rich-text/src/at-panel/MentionRow.tsx
+++ b/packages/ui/rich-text/src/at-panel/MentionRow.tsx
@@ -6,6 +6,7 @@ import {
   FileCodeIcon,
   FileTextIcon,
   FolderIcon,
+  ImageWithFallback,
   ImageFileIcon,
   ProductIcon,
   StatusDot,
@@ -14,7 +15,7 @@ import {
   cn,
   type IconProps
 } from "@tutti-os/ui-system";
-import { Fragment, useState } from "react";
+import { Fragment } from "react";
 import type { MentionFileVisualKind } from "./mentionFileVisualKind.ts";
 import {
   mentionRowDataAttribute,
@@ -449,7 +450,7 @@ function MentionFileIcon({
         {...mentionRowDataAttribute(dataAttributeMode, "fileThumb", "true")}
         aria-hidden="true"
       >
-        <MentionImageWithFallback
+        <ImageWithFallback
           src={thumbnailUrl}
           alt=""
           className="rich-text-at-mention-row__media"
@@ -545,7 +546,7 @@ function MentionEntityIcon({
       aria-hidden="true"
     >
       {normalizedIconUrl ? (
-        <MentionImageWithFallback
+        <ImageWithFallback
           src={normalizedIconUrl}
           alt=""
           className="rich-text-at-mention-row__media"
@@ -570,36 +571,6 @@ function MentionEntityIcon({
   );
 }
 
-function MentionImageWithFallback({
-  src,
-  alt,
-  className,
-  fallback
-}: {
-  src: string;
-  alt: string;
-  className: string;
-  fallback: React.JSX.Element;
-}): React.JSX.Element {
-  const [failedSource, setFailedSource] = useState<string | null>(null);
-  if (failedSource === src) {
-    return fallback;
-  }
-  return (
-    <img
-      src={src}
-      alt={alt}
-      className={className}
-      decoding="async"
-      loading="lazy"
-      draggable={false}
-      onError={() => {
-        setFailedSource(src);
-      }}
-    />
-  );
-}
-
 function MentionSessionAvatarStack({
   item,
   classNames,
@@ -609,9 +580,6 @@ function MentionSessionAvatarStack({
   classNames: Required<MentionRowClassNames>;
   dataAttributeMode: MentionRowDataAttributeMode;
 }): React.JSX.Element {
-  const [failedUserAvatarUrls, setFailedUserAvatarUrls] = useState<
-    readonly string[]
-  >([]);
   const showUserAvatar = item.showUserAvatar !== false;
   if (!showUserAvatar) {
     return (
@@ -626,7 +594,7 @@ function MentionSessionAvatarStack({
           className="rich-text-at-mention-avatar rich-text-at-mention-avatar--agent"
           {...mentionRowDataAttribute(dataAttributeMode, "agentAvatar", "true")}
         >
-          <MentionImageWithFallback
+          <ImageWithFallback
             src={item.agentIconUrl}
             alt=""
             className="rich-text-at-mention-row__media"
@@ -644,48 +612,67 @@ function MentionSessionAvatarStack({
 
   const userAvatarUrl = item.userAvatarUrl?.trim() ?? "";
   const placeholderUrl = item.userAvatarPlaceholderUrl.trim();
-  const userImageUrl = [userAvatarUrl, placeholderUrl].find(
-    (url) => url && !failedUserAvatarUrls.includes(url)
-  );
+  const userAvatarFallback =
+    placeholderUrl && placeholderUrl !== userAvatarUrl ? (
+      <ImageWithFallback
+        src={placeholderUrl}
+        alt=""
+        className={cn(
+          "rich-text-at-mention-row__media",
+          classNames.avatarImgUserPlaceholder
+        )}
+        decoding="async"
+        loading="lazy"
+        referrerPolicy="no-referrer"
+        draggable={false}
+        fallback={
+          <UserLinedIcon
+            aria-hidden="true"
+            className="size-3.5 text-[var(--rich-text-at-mention-text-secondary)]"
+          />
+        }
+      />
+    ) : (
+      <UserLinedIcon
+        aria-hidden="true"
+        className="size-3.5 text-[var(--rich-text-at-mention-text-secondary)]"
+      />
+    );
+  const userImageUrl = userAvatarUrl || placeholderUrl;
   return (
     <span className="rich-text-at-mention-avatar-stack" aria-hidden="true">
       <span
         className="rich-text-at-mention-avatar rich-text-at-mention-avatar--user"
         {...mentionRowDataAttribute(dataAttributeMode, "userAvatar", "true")}
       >
-        {userImageUrl ? (
-          <img
-            src={userImageUrl}
-            alt=""
-            className={cn(
-              "rich-text-at-mention-row__media",
-              userImageUrl === placeholderUrl &&
-                classNames.avatarImgUserPlaceholder
-            )}
-            decoding="async"
-            loading="lazy"
-            referrerPolicy="no-referrer"
-            draggable={false}
-            onError={() => {
-              setFailedUserAvatarUrls((failedUrls) =>
-                failedUrls.includes(userImageUrl)
-                  ? failedUrls
-                  : [...failedUrls, userImageUrl]
-              );
-            }}
-          />
-        ) : (
-          <UserLinedIcon
-            aria-hidden="true"
-            className="size-3.5 text-[var(--rich-text-at-mention-text-secondary)]"
-          />
-        )}
+        <ImageWithFallback
+          src={userImageUrl}
+          alt=""
+          className={cn(
+            "rich-text-at-mention-row__media",
+            !userAvatarUrl && classNames.avatarImgUserPlaceholder
+          )}
+          decoding="async"
+          loading="lazy"
+          referrerPolicy="no-referrer"
+          draggable={false}
+          fallback={
+            userAvatarUrl ? (
+              userAvatarFallback
+            ) : (
+              <UserLinedIcon
+                aria-hidden="true"
+                className="size-3.5 text-[var(--rich-text-at-mention-text-secondary)]"
+              />
+            )
+          }
+        />
       </span>
       <span
         className="rich-text-at-mention-avatar rich-text-at-mention-avatar--agent"
         {...mentionRowDataAttribute(dataAttributeMode, "agentAvatar", "true")}
       >
-        <MentionImageWithFallback
+        <ImageWithFallback
           src={item.agentIconUrl}
           alt=""
           className="rich-text-at-mention-row__media"

--- a/packages/ui/rich-text/src/editor/RichTextTriggerMenuItem.tsx
+++ b/packages/ui/rich-text/src/editor/RichTextTriggerMenuItem.tsx
@@ -1,4 +1,5 @@
-import { useState, type JSX, type MouseEvent } from "react";
+import type { JSX, MouseEvent } from "react";
+import { ImageWithFallback } from "@tutti-os/ui-system";
 import { FileIcon, FolderFilledIcon } from "@tutti-os/ui-system/icons";
 
 type RichTextTriggerMenuItemProps = {
@@ -58,7 +59,6 @@ function RichTextTriggerMenuIcon({
   workspaceReferenceFileKind?: "file" | "folder";
 }): JSX.Element {
   const normalizedIconUrl = iconUrl?.trim() ?? "";
-  const [failedIconUrl, setFailedIconUrl] = useState<string | null>(null);
 
   if (workspaceReferenceFileKind) {
     const Icon =
@@ -80,17 +80,17 @@ function RichTextTriggerMenuIcon({
       className="inline-grid size-4 flex-none place-items-center overflow-hidden rounded bg-[var(--bg-block,var(--transparency-block))]"
       data-rich-text-trigger-icon="true"
     >
-      {normalizedIconUrl && failedIconUrl !== normalizedIconUrl ? (
-        <img
+      {normalizedIconUrl ? (
+        <ImageWithFallback
           alt=""
           className="block size-full object-cover object-center"
           decoding="async"
           draggable={false}
           loading="lazy"
           src={normalizedIconUrl}
-          onError={() => {
-            setFailedIconUrl(normalizedIconUrl);
-          }}
+          fallback={
+            <span className="block size-3 rounded-[3px] bg-[var(--transparency-block)]" />
+          }
         />
       ) : (
         <span className="block size-3 rounded-[3px] bg-[var(--transparency-block)]" />

--- a/packages/ui/system/src/components/image-with-fallback/image-with-fallback.spec.tsx
+++ b/packages/ui/system/src/components/image-with-fallback/image-with-fallback.spec.tsx
@@ -1,0 +1,52 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor
+} from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ImageWithFallback } from "./image-with-fallback";
+
+afterEach(() => cleanup());
+
+describe("ImageWithFallback", () => {
+  it("retries the same source once before showing fallback", async () => {
+    const view = render(
+      <ImageWithFallback
+        src="https://cdn.example.test/icon.png"
+        retryDelayMs={0}
+        fallback={<span data-testid="fallback">fallback</span>}
+      />
+    );
+    const firstImage = view.container.querySelector("img") as HTMLImageElement;
+
+    fireEvent.error(firstImage);
+    const retriedImage = await waitFor(() => {
+      const image = view.container.querySelector("img");
+      expect(image).not.toBe(firstImage);
+      expect(image?.getAttribute("src")).toBe(
+        "https://cdn.example.test/icon.png"
+      );
+      return image as HTMLImageElement;
+    });
+
+    fireEvent.error(retriedImage);
+    await waitFor(() => {
+      expect(view.container.querySelector("img")).toBeNull();
+      expect(screen.getByTestId("fallback")).not.toBeNull();
+    });
+  });
+
+  it("renders fallback without requesting an empty source", () => {
+    const view = render(
+      <ImageWithFallback
+        src=" "
+        fallback={<span data-testid="fallback">fallback</span>}
+      />
+    );
+
+    expect(view.container.querySelector("img")).toBeNull();
+    expect(screen.getByTestId("fallback")).not.toBeNull();
+  });
+});

--- a/packages/ui/system/src/components/image-with-fallback/image-with-fallback.tsx
+++ b/packages/ui/system/src/components/image-with-fallback/image-with-fallback.tsx
@@ -1,0 +1,136 @@
+import {
+  useEffect,
+  useRef,
+  useState,
+  type ImgHTMLAttributes,
+  type ReactNode
+} from "react";
+
+const DEFAULT_RETRY_COUNT = 1;
+const DEFAULT_RETRY_DELAY_MS = 150;
+const MAX_RETRY_COUNT = 3;
+
+interface ImageDeliveryState {
+  attempt: number;
+  phase: "ready" | "retrying" | "failed";
+  src: string;
+}
+
+export interface ImageWithFallbackProps extends Omit<
+  ImgHTMLAttributes<HTMLImageElement>,
+  "src"
+> {
+  /** Content shown while retrying and after the retry budget is exhausted. */
+  fallback?: ReactNode;
+  /** Number of additional requests allowed after the first load failure. */
+  retryCount?: number;
+  /** Delay between bounded image requests. */
+  retryDelayMs?: number;
+  src?: string | null;
+}
+
+function normalizeRetryCount(value: number): number {
+  if (!Number.isFinite(value)) {
+    return DEFAULT_RETRY_COUNT;
+  }
+  return Math.min(MAX_RETRY_COUNT, Math.max(0, Math.floor(value)));
+}
+
+function normalizeRetryDelay(value: number): number {
+  if (!Number.isFinite(value)) {
+    return DEFAULT_RETRY_DELAY_MS;
+  }
+  return Math.max(0, Math.floor(value));
+}
+
+/**
+ * Decorative remote image with a bounded same-URL retry and caller-owned
+ * fallback. Retrying remounts the image without mutating the URL, so signed
+ * URLs remain valid and content-addressed URLs keep their cache identity.
+ */
+export function ImageWithFallback({
+  fallback = null,
+  onError,
+  retryCount = DEFAULT_RETRY_COUNT,
+  retryDelayMs = DEFAULT_RETRY_DELAY_MS,
+  src,
+  ...imageProps
+}: ImageWithFallbackProps): React.JSX.Element | null {
+  const normalizedSrc = src?.trim() ?? "";
+  const maxRetries = normalizeRetryCount(retryCount);
+  const delayMs = normalizeRetryDelay(retryDelayMs);
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [deliveryState, setDeliveryState] = useState<ImageDeliveryState>({
+    attempt: 0,
+    phase: "ready",
+    src: normalizedSrc
+  });
+
+  useEffect(() => {
+    if (deliveryState.src !== normalizedSrc) {
+      setDeliveryState({ attempt: 0, phase: "ready", src: normalizedSrc });
+    }
+    if (retryTimerRef.current !== null) {
+      clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
+    }
+  }, [deliveryState.src, normalizedSrc]);
+
+  useEffect(
+    () => () => {
+      if (retryTimerRef.current !== null) {
+        clearTimeout(retryTimerRef.current);
+      }
+    },
+    []
+  );
+
+  const currentState =
+    deliveryState.src === normalizedSrc
+      ? deliveryState
+      : { attempt: 0, phase: "ready" as const, src: normalizedSrc };
+
+  if (
+    normalizedSrc.length === 0 ||
+    currentState.phase === "failed" ||
+    currentState.phase === "retrying"
+  ) {
+    return <>{fallback}</>;
+  }
+
+  return (
+    <img
+      {...imageProps}
+      key={`${normalizedSrc}:${currentState.attempt}`}
+      src={normalizedSrc}
+      onError={(event) => {
+        onError?.(event);
+        if (currentState.attempt >= maxRetries) {
+          setDeliveryState((previous) =>
+            previous.src === normalizedSrc
+              ? { ...previous, phase: "failed" }
+              : previous
+          );
+          return;
+        }
+
+        const nextAttempt = currentState.attempt + 1;
+        setDeliveryState((previous) =>
+          previous.src === normalizedSrc
+            ? { attempt: nextAttempt, phase: "retrying", src: normalizedSrc }
+            : previous
+        );
+        retryTimerRef.current = setTimeout(() => {
+          retryTimerRef.current = null;
+          setDeliveryState((previous) =>
+            previous.src === normalizedSrc &&
+            previous.attempt === nextAttempt &&
+            previous.phase === "retrying"
+              ? { ...previous, phase: "ready" }
+              : previous
+          );
+        }, delayMs);
+      }}
+    />
+  );
+}

--- a/packages/ui/system/src/components/image-with-fallback/index.tsx
+++ b/packages/ui/system/src/components/image-with-fallback/index.tsx
@@ -1,0 +1,4 @@
+export {
+  ImageWithFallback,
+  type ImageWithFallbackProps
+} from "./image-with-fallback";

--- a/packages/ui/system/src/components/index.ts
+++ b/packages/ui/system/src/components/index.ts
@@ -12,6 +12,7 @@ export * from "./dialog";
 export * from "./drawer";
 export * from "./dropdown-menu";
 export * from "./input";
+export * from "./image-with-fallback";
 export * from "./mention-pill";
 export * from "./menu-surface";
 export * from "./popover";

--- a/packages/ui/system/src/metadata/components.json
+++ b/packages/ui/system/src/metadata/components.json
@@ -133,6 +133,29 @@
       "storyboard": true
     },
     {
+      "id": "image-with-fallback",
+      "layer": "base",
+      "name": "ImageWithFallback",
+      "export": "ImageWithFallback",
+      "from": "@tutti-os/ui-system/components",
+      "category": "primitive",
+      "status": "stable",
+      "source": "src/components/image-with-fallback/index.tsx",
+      "description": "Decorative remote image primitive with a bounded same-URL retry and caller-owned fallback.",
+      "propsType": "ImageWithFallbackProps",
+      "useCases": [
+        "Remote application icons",
+        "Image thumbnails",
+        "Decorative remote media"
+      ],
+      "migrationHints": [
+        "Keep retryCount small and bounded; the default retries once.",
+        "Do not mutate the URL to force a retry because signed URLs may become invalid.",
+        "Provide a stable fallback for any image that is decorative or essential to row layout."
+      ],
+      "storyboard": true
+    },
+    {
       "id": "badge",
       "layer": "base",
       "name": "Badge",

--- a/packages/workspace/app-center/src/ui/AppCard.tsx
+++ b/packages/workspace/app-center/src/ui/AppCard.tsx
@@ -12,6 +12,7 @@ import {
   DropdownMenuTrigger,
   FolderIcon,
   GitHubBrandIcon,
+  ImageWithFallback,
   MoreHorizontalIcon,
   NavApplicationsFilledIcon,
   Popover,
@@ -662,43 +663,36 @@ function AuthorAvatar({
   readonly author: WorkspaceAppAuthorViewModel;
   readonly fallbackIconUrl?: string | null;
 }): ReactElement {
-  const [failedImageUrl, setFailedImageUrl] = useState<string | null>(null);
   const avatarUrl = author.avatarUrl?.trim() ?? "";
-  if (avatarUrl && failedImageUrl !== avatarUrl) {
-    return (
-      <img
-        alt=""
-        className="size-5 shrink-0 rounded-full border border-[var(--background-fronted)] object-cover"
-        draggable={false}
-        src={avatarUrl}
-        onError={() => {
-          setFailedImageUrl(avatarUrl);
-        }}
-      />
-    );
-  }
   const normalizedFallbackIconUrl = fallbackIconUrl?.trim() ?? "";
-  if (
-    normalizedFallbackIconUrl &&
-    failedImageUrl !== normalizedFallbackIconUrl
-  ) {
-    return (
-      <img
-        alt=""
-        className="size-5 shrink-0 rounded-[5px] border border-[var(--background-fronted)] object-contain"
-        draggable={false}
-        src={normalizedFallbackIconUrl}
-        onError={() => {
-          setFailedImageUrl(normalizedFallbackIconUrl);
-        }}
-      />
-    );
-  }
-  return (
+  const initialsFallback = (
     <span className="flex size-5 shrink-0 items-center justify-center rounded-full border border-[var(--background-fronted)] bg-[var(--transparency-block)] text-[10px] font-semibold uppercase text-[var(--text-secondary)]">
       {author.name.slice(0, 1)}
     </span>
   );
+  const fallback = normalizedFallbackIconUrl ? (
+    <ImageWithFallback
+      alt=""
+      className="size-5 shrink-0 rounded-[5px] border border-[var(--background-fronted)] object-contain"
+      draggable={false}
+      src={normalizedFallbackIconUrl}
+      fallback={initialsFallback}
+    />
+  ) : (
+    initialsFallback
+  );
+  if (avatarUrl) {
+    return (
+      <ImageWithFallback
+        alt=""
+        className="size-5 shrink-0 rounded-full border border-[var(--background-fronted)] object-cover"
+        draggable={false}
+        src={avatarUrl}
+        fallback={fallback}
+      />
+    );
+  }
+  return fallback;
 }
 
 function isOfficialAuthor(name: string | null | undefined): boolean {
@@ -1007,25 +1001,25 @@ function AppIcon({
   readonly onReplaceIcon: () => void;
   readonly replaceIconLabel: string;
 }): ReactElement {
-  const [failedIconUrl, setFailedIconUrl] = useState<string | null>(null);
   const iconUrl = app.icon?.type === "asset" ? app.icon.src.trim() : "";
-  const icon =
-    iconUrl && failedIconUrl !== iconUrl ? (
-      <img
-        alt=""
-        className="size-11 flex-none rounded-[10px] object-contain object-center select-none"
-        decoding="async"
-        draggable={false}
-        src={iconUrl}
-        onError={() => {
-          setFailedIconUrl(iconUrl);
-        }}
-      />
-    ) : (
-      <span className="flex size-11 flex-none items-center justify-center rounded-[10px] bg-[var(--transparency-block)] text-[var(--text-secondary)]">
-        <NavApplicationsFilledIcon className="size-[22px]" />
-      </span>
-    );
+  const icon = iconUrl ? (
+    <ImageWithFallback
+      alt=""
+      className="size-11 flex-none rounded-[10px] object-contain object-center select-none"
+      decoding="async"
+      draggable={false}
+      src={iconUrl}
+      fallback={
+        <span className="flex size-11 flex-none items-center justify-center rounded-[10px] bg-[var(--transparency-block)] text-[var(--text-secondary)]">
+          <NavApplicationsFilledIcon className="size-[22px]" />
+        </span>
+      }
+    />
+  ) : (
+    <span className="flex size-11 flex-none items-center justify-center rounded-[10px] bg-[var(--transparency-block)] text-[var(--text-secondary)]">
+      <NavApplicationsFilledIcon className="size-[22px]" />
+    </span>
+  );
 
   return (
     <span className="group/app-icon relative block size-11 flex-none">

--- a/packages/workspace/app-center/src/ui/AppCenterPanel.tsx
+++ b/packages/workspace/app-center/src/ui/AppCenterPanel.tsx
@@ -20,6 +20,7 @@ import {
   DialogHeader,
   DialogTitle,
   FileCreateIcon,
+  ImageWithFallback,
   ImportLinedIcon as ImportIcon,
   Input,
   OpenSessionsIcon as OpenSessionsFilledIcon,
@@ -1412,30 +1413,23 @@ function AppCenterAgentProviderIcon({
   iconUrl?: string | null;
 }): ReactElement {
   const normalizedIconUrl = iconUrl?.trim();
-  const [failedIconUrl, setFailedIconUrl] = useState<string | null>(null);
   if (!normalizedIconUrl) {
     return (
       <span aria-hidden="true" className="size-4 shrink-0 rounded-[4px]" />
     );
   }
 
-  if (failedIconUrl === normalizedIconUrl) {
-    return (
-      <span aria-hidden="true" className="size-4 shrink-0 rounded-[4px]" />
-    );
-  }
-
   return (
-    <img
+    <ImageWithFallback
       alt=""
       aria-hidden="true"
       className="size-4 shrink-0 rounded-[4px] object-contain"
       decoding="async"
       draggable={false}
       src={normalizedIconUrl}
-      onError={() => {
-        setFailedIconUrl(normalizedIconUrl);
-      }}
+      fallback={
+        <span aria-hidden="true" className="size-4 shrink-0 rounded-[4px]" />
+      }
     />
   );
 }


### PR DESCRIPTION
## What changed
- Add the shared `ImageWithFallback` UI-system primitive for remote decorative images.
- Retry the same URL once with a bounded delay, then render a caller-provided fallback; the URL is never mutated.
- Use it for app icons, provider/author avatars, `@`-panel thumbnails and entity/session icons, and rich-text trigger icons.
- Preserve the session-avatar fallback chain: user avatar -> placeholder avatar -> user glyph.
- Add UI metadata, storyboard coverage, regression tests, and package-level verification.

## Why
The previous fix only rendered a fallback after the first load error. This follow-up adds one bounded retry for transient image delivery failures while keeping layout and semantic fallbacks stable.

## URL expiry boundary
This is not a URL re-signing mechanism. If a signed URL is expired, retrying the same URL cannot repair it; the owning data/query layer must resolve a fresh URL. Current application icon URLs observed in production are public CloudFront URLs rather than signed `X-Amz-*` URLs.

## Risks
- Failed image loads may briefly show the supplied fallback during the bounded retry delay.
- No URL query parameter is appended, preserving signed-URL validity and cache identity.
- The paired tsh-server PR adds immutable cache metadata for new application-icon uploads; existing objects are not rewritten.

## Verification
- `pnpm --dir packages/ui/system test`
- `pnpm --dir packages/ui/system typecheck`
- `pnpm --dir packages/ui/rich-text test -- --run`
- `pnpm --dir packages/ui/rich-text typecheck`
- `pnpm --dir packages/workspace/app-center test -- --run`
- `pnpm --dir packages/workspace/app-center typecheck`
- `pnpm --dir apps/ui-storyboard typecheck`
- `pnpm --dir apps/tsh-desktop check`
- `pnpm check:changed -- --push-ready`
- `pnpm check:ui-boundaries`

## Follow-up
The root cause of the reported production failures remains unconfirmed because client image-error telemetry and CloudFront access logs are not currently available in this investigation.