### PR TITLE
fix(workspace-file-reference): refine add menu presentation

### DIFF
--- a/packages/workspace/file-reference/src/ui/internal/reference/WorkspaceReferenceAddControl.render.test.ts
+++ b/packages/workspace/file-reference/src/ui/internal/reference/WorkspaceReferenceAddControl.render.test.ts
@@ -86,6 +86,8 @@ test("reference add control forwards dropdown trigger interactions", async () =>
 
     const menu = dom.window.document.querySelector('[role="menu"]');
     assert.ok(menu);
+    assert.match(menu.className, /w-max/);
+    assert.match(menu.className, /whitespace-nowrap/);
     assert.match(menu.textContent ?? "", /Upload file/);
     assert.match(menu.textContent ?? "", /Browse files/);
   } finally {
@@ -144,9 +146,11 @@ function buildReferenceAddControlRenderModule(tempDir: string): string {
         }
         return h("button", null, children);
       }
-      export function DropdownMenuContent({ children }) {
+      export function DropdownMenuContent({ children, className }) {
         const menu = useContext(MenuContext);
-        return menu.open ? h("div", { role: "menu" }, children) : null;
+        return menu.open
+          ? h("div", { className, role: "menu" }, children)
+          : null;
       }
       export function DropdownMenuItem({ children, onSelect }) {
         return h("button", { role: "menuitem", onClick: onSelect }, children);

--- a/packages/workspace/file-reference/src/ui/internal/reference/WorkspaceReferenceAddControl.tsx
+++ b/packages/workspace/file-reference/src/ui/internal/reference/WorkspaceReferenceAddControl.tsx
@@ -80,7 +80,10 @@ export function WorkspaceReferenceAddControl({
           label={labels.addContent}
         />
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="nodrag min-w-40">
+      <DropdownMenuContent
+        align="start"
+        className="nodrag w-max min-w-40 whitespace-nowrap"
+      >
         <DropdownMenuItem onSelect={onUploadFile}>
           <UploadIcon aria-hidden="true" className="size-4" />
           {labels.uploadFile ?? labels.addContent}


### PR DESCRIPTION
## Summary

- size the shared add-content menu to its contents
- prevent action labels from wrapping
- cover the menu presentation classes in the existing interaction regression test

## Validation

- repository pre-commit hooks
- `pnpm check:changed -- --push-ready`

## Documentation impact

No durable documentation update is needed; this is a presentation-only refinement of the existing shared control.