### PR TITLE
fix(release): 回移 Agent 就绪与通知身份修复

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAgentDecisionNotification.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAgentDecisionNotification.ts
@@ -5,6 +5,7 @@ import {
   managedAgentRoundedIconUrl,
   type WorkspaceAgentMessageCenterItem
 } from "@tutti-os/agent-gui/agent-message-center";
+import { resolveWorkspaceAgentDecisionIdentity } from "./workspaceAgentDecisionNotificationIdentity.ts";
 
 export interface WorkspaceAgentDecisionSubmitInput {
   action?: string;
@@ -41,9 +42,12 @@ export function buildWorkspaceAgentDecisionNotification(
   if (!prompt) {
     return null;
   }
-  const agentName =
-    formatWorkspaceAgentProviderName(item.provider) || labels.fallbackAgentName;
-  const agentIconUrl = managedAgentRoundedIconUrl(item.provider);
+  const { agentIconUrl, agentName } = resolveWorkspaceAgentDecisionIdentity({
+    agentAvatarUrl: item.agentAvatarUrl,
+    agentName: item.agentName,
+    fallbackAgentIconUrl: managedAgentRoundedIconUrl(undefined),
+    fallbackAgentName: labels.fallbackAgentName
+  });
   const conversationTitle = item.title.trim();
   switch (prompt.kind) {
     case "approval":
@@ -133,13 +137,4 @@ function approvalNotificationDescription(
     return labels.commandLabel;
   }
   return title;
-}
-
-function formatWorkspaceAgentProviderName(provider: string): string {
-  return provider
-    .trim()
-    .split(/[-_\s]+/)
-    .filter(Boolean)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
 }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAgentDecisionNotificationIdentity.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAgentDecisionNotificationIdentity.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveWorkspaceAgentDecisionIdentity } from "./workspaceAgentDecisionNotificationIdentity.ts";
+
+test("decision notification uses the exact Agent Directory name and icon", () => {
+  const identity = resolveWorkspaceAgentDecisionIdentity({
+    agentAvatarUrl: "agent-icon://kimi-code",
+    agentName: "Kimi Code",
+    fallbackAgentIconUrl: "agent-icon://generic",
+    fallbackAgentName: "Agent"
+  });
+
+  assert.deepEqual(identity, {
+    agentIconUrl: "agent-icon://kimi-code",
+    agentName: "Kimi Code"
+  });
+});
+
+test("decision notification does not expose provider metadata as fallback identity", () => {
+  const identity = resolveWorkspaceAgentDecisionIdentity({
+    agentAvatarUrl: null,
+    agentName: null,
+    fallbackAgentIconUrl: "agent-icon://generic",
+    fallbackAgentName: "Agent"
+  });
+
+  assert.deepEqual(identity, {
+    agentIconUrl: "agent-icon://generic",
+    agentName: "Agent"
+  });
+});

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAgentDecisionNotificationIdentity.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAgentDecisionNotificationIdentity.ts
@@ -1,0 +1,17 @@
+export interface WorkspaceAgentDecisionIdentity {
+  agentIconUrl: string;
+  agentName: string;
+}
+
+export function resolveWorkspaceAgentDecisionIdentity(input: {
+  agentAvatarUrl?: string | null;
+  agentName?: string | null;
+  fallbackAgentIconUrl: string;
+  fallbackAgentName: string;
+}): WorkspaceAgentDecisionIdentity {
+  return {
+    agentIconUrl:
+      input.agentAvatarUrl?.trim() || input.fallbackAgentIconUrl.trim(),
+    agentName: input.agentName?.trim() || input.fallbackAgentName.trim()
+  };
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentDecisionNotifications.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentDecisionNotifications.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, type ReactNode } from "react";
+import { useMemo, useRef, useSyncExternalStore, type ReactNode } from "react";
 import {
   buildWorkspaceAgentMessageCenterModelFromEngine,
   selectWorkspaceAgentMessageCenterPresentation,
@@ -9,6 +9,8 @@ import {
 } from "@tutti-os/agent-gui/agent-message-center";
 import type { I18nRuntime } from "@tutti-os/ui-i18n-runtime";
 import type { WorkspaceAgentActivityService } from "@renderer/features/workspace-agent";
+import { IAgentsService } from "@renderer/features/workspace-agent/services/agentsService.interface.ts";
+import { useService } from "@tutti-os/infra/di";
 import { useWorkspaceAgentDecisionNotifications } from "./useWorkspaceAgentDecisionNotifications.tsx";
 
 const MESSAGE_CENTER_VISIBLE_HISTORY_MS = 7 * 24 * 60 * 60 * 1000;
@@ -25,6 +27,12 @@ export function StandaloneAgentDecisionNotifications({
   messageCenterOpen: boolean;
   workspaceId: string;
 }): ReactNode {
+  const agentsService = useService(IAgentsService);
+  const agentDirectory = useSyncExternalStore(
+    (listener) => agentsService.subscribe(listener),
+    () => agentsService.getSnapshot(),
+    () => agentsService.getSnapshot()
+  );
   const sessionEngine = useMemo(
     () => activityService.getSessionEngine(workspaceId),
     [activityService, workspaceId]
@@ -52,6 +60,7 @@ export function StandaloneAgentDecisionNotifications({
         workspaceId
       },
       {
+        agentPresentations: agentDirectory.agents,
         itemCutoffUnixMs,
         promptFallbackLabels: {
           constraintHeader: i18n.t(
@@ -70,7 +79,13 @@ export function StandaloneAgentDecisionNotifications({
     );
     modelRef.current = stableModel;
     return stableModel;
-  }, [i18n, itemCutoffUnixMs, presentation, workspaceId]);
+  }, [
+    agentDirectory.agents,
+    i18n,
+    itemCutoffUnixMs,
+    presentation,
+    workspaceId
+  ]);
 
   useWorkspaceAgentDecisionNotifications({
     messageCenterOpen,

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -2255,3 +2255,34 @@ invalid_grant`. Search `tuttid.log` for
   [runtime-overrides.md](../runtime-overrides.md)
   [visible_error.go](../../../packages/agent/daemon/runtime/visible_error.go)
   [setup.go](../../../services/tuttid/service/agentextension/setup.go)
+
+### Terminal login succeeds but the setup terminal remains open
+
+- Symptom:
+  The provider's terminal login reports success and returns to its normal TUI,
+  but AgentGUI keeps the setup terminal open and continues polling the Target as
+  `auth_required`.
+- Quick checks:
+  Confirm the Desktop terminal diagnostic reports the startup action as
+  `submitted`, then inspect repeated Target setup probes. Compare the fresh ACP
+  `initialize` response with `session/new`: some runtimes keep advertising a
+  terminal login method even after authentication succeeds.
+- Root cause:
+  ACP `authMethods` is a catalog of available authentication methods, not the
+  current authentication state. Treating a terminal-only catalog as an
+  immediate `auth_required` verdict skips `session/new`, so a successfully
+  configured runtime can never become `ready` and the Host never closes its
+  login-terminal handle.
+- Fix:
+  Preserve the advertised methods for presentation, but verify readiness with
+  the bounded setup `session/new` probe. Continue mapping explicit
+  authentication, missing-model, missing-provider, and terminal-method timeout
+  outcomes to `auth_required`. Do not scrape terminal output or inject an exit
+  command to infer login completion.
+- Validation:
+  Cover a runtime that still advertises only a terminal login method while
+  `session/new` returns a usable model, plus unconfigured runtimes whose
+  `session/new` returns no usable model, a missing-provider error, or a timeout.
+- References:
+  [standard_acp_setup.go](../../../packages/agent/daemon/runtime/standard_acp_setup.go)
+  [desktopTerminalLoginReadinessMonitor.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopTerminalLoginReadinessMonitor.ts)

--- a/packages/agent/daemon/runtime/standard_acp_setup.go
+++ b/packages/agent/daemon/runtime/standard_acp_setup.go
@@ -37,13 +37,6 @@ var ErrACPAuthMethodTerminal = errors.New("ACP auth method requires an interacti
 // classifier so only the explicit errors.Is mapping classifies it.
 var ErrACPSetupNoUsableModel = errors.New("ACP agent created a session without any usable model")
 
-// errACPSetupInteractiveAuthRequired lets setup finish as auth_required when
-// an agent advertises only terminal authentication methods. Calling
-// session/new before the user completes that flow is both unnecessary and,
-// for some Python agents, can block while trying to resolve an unconfigured
-// model provider.
-var errACPSetupInteractiveAuthRequired = errors.New("ACP setup requires interactive terminal authentication")
-
 type StandardACPSetupStatus string
 
 const (
@@ -109,9 +102,6 @@ func RunStandardACPSetup(
 	adapter.config.beforeNewSession = func(ctx context.Context, client *acpClient, session Session, initializeResult json.RawMessage) error {
 		methods = parseStandardACPAuthMethods(initializeResult)
 		if methodID == "" {
-			if standardACPSetupRequiresInteractiveAuth(methods) {
-				return errACPSetupInteractiveAuthRequired
-			}
 			return nil
 		}
 		method := findStandardACPAuthMethod(methods, methodID)
@@ -148,9 +138,6 @@ func RunStandardACPSetup(
 		}
 	}
 	if _, err := adapter.Start(ctx, session); err != nil {
-		if errors.Is(err, errACPSetupInteractiveAuthRequired) {
-			return StandardACPSetupResult{Status: StandardACPSetupAuthRequired, AuthMethods: methods}, nil
-		}
 		if errors.Is(err, ErrACPAuthMethodTerminal) {
 			return StandardACPSetupResult{Status: StandardACPSetupAuthRequired, AuthMethods: methods}, err
 		}
@@ -182,18 +169,6 @@ func RunStandardACPSetup(
 		return StandardACPSetupResult{}, fmt.Errorf("close ACP setup session: %w", err)
 	}
 	return StandardACPSetupResult{Status: StandardACPSetupReady, AuthMethods: methods, Account: account}, nil
-}
-
-func standardACPSetupRequiresInteractiveAuth(methods []StandardACPAuthMethod) bool {
-	if len(methods) == 0 {
-		return false
-	}
-	for _, method := range methods {
-		if strings.TrimSpace(method.Type) != "terminal" {
-			return false
-		}
-	}
-	return true
 }
 
 func standardACPSetupHasInteractiveAuth(methods []StandardACPAuthMethod) bool {

--- a/packages/agent/daemon/runtime/standard_acp_setup_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_setup_test.go
@@ -200,6 +200,40 @@ func TestRunStandardACPSetupFlagsSessionWithoutUsableModel(t *testing.T) {
 	if method := result.AuthMethods[0]; method.Type != "terminal" || len(method.Args) != 1 || method.Args[0] != "login" {
 		t.Fatalf("terminal auth method = %#v", method)
 	}
+	if transport.conn.lastNewSessionParams == nil {
+		t.Fatal("probe must verify readiness through session/new")
+	}
+}
+
+func TestRunStandardACPSetupReadyWhenTerminalMethodRemainsAdvertised(t *testing.T) {
+	t.Parallel()
+
+	// Kimi Code continues advertising its terminal login method after setup.
+	// The method catalog is not an authentication verdict: a usable session/new
+	// result remains the authoritative ready signal.
+	transport := newStandardACPTransport("Example Agent", "setup-session")
+	transport.conn.authMethods = []map[string]any{{
+		"id": "login", "name": "Login with Example account",
+		"type": "terminal", "args": []any{"login"},
+	}}
+	transport.conn.models = map[string]any{
+		"availableModels": []any{map[string]any{"modelId": "example-model", "name": "Example Model"}},
+		"currentModelId":  "example-model",
+	}
+
+	result, err := runStandardACPSetupTest(t, transport, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != StandardACPSetupReady || len(result.AuthMethods) != 1 {
+		t.Fatalf("setup result = %#v", result)
+	}
+	if transport.conn.lastNewSessionParams == nil {
+		t.Fatal("probe must verify readiness through session/new")
+	}
+	if got := transport.conn.authenticatedMethodID(); got != "" {
+		t.Fatalf("authenticated method id = %q, want no ACP authenticate call", got)
+	}
 }
 
 func TestRunStandardACPSetupOffersTerminalConfigurationForMissingProvider(t *testing.T) {
@@ -226,6 +260,9 @@ func TestRunStandardACPSetupOffersTerminalConfigurationForMissingProvider(t *tes
 	if method := result.AuthMethods[0]; method.ID != "agent-setup" || method.Type != "terminal" ||
 		len(method.Args) != 1 || method.Args[0] != "--setup" {
 		t.Fatalf("terminal configuration method = %#v", method)
+	}
+	if transport.conn.lastNewSessionParams == nil {
+		t.Fatal("probe must inspect session/new before classifying missing configuration")
 	}
 }
 


### PR DESCRIPTION
## 背景

将已合入 `main` 的 #2045 和 #2047 回移到 `release/0805`，分别修复终端登录后的 Agent 就绪判定，以及请求通知中的 Agent 名称与头像展示。

## 修改

- 回移 #2045：`b89396a0378ed4928667f770b6dfa482842ed88e`
- 回移 #2047：`6e158a5c68da94bee3b8f19072f95095d5ef0570`
- 使用 `cherry-pick -x` 保留原提交来源
- 未带入 #2047 分支中同步 `main` 的 merge commit，避免引入无关主干历史

## 验证

- `pnpm check:changed -- --base upstream/release/0805 --push-ready`：17 个 lane 全部通过
- `git diff --check upstream/release/0805...HEAD`：通过
- 推送前再次刷新并确认 `upstream/release/0805` 无新增提交

额外执行 `pnpm push:checked` 时触发了全仓 `check:full`，其准备阶段与 21 项 preflight 通过，但被两个不在本次 7 个变更文件中的 release 基线问题阻断：

- `services/tuttid/service/mobileremote/relay_control_plane.go` 的既存 proxy-funnel lint
- `TestServiceRunActionReportsActiveActionForClaudeInstall` 的并发时序测试偶发提前完成

本次改动对应的 changed-aware push-ready gate 未出现失败。

## 范围说明

#2045 的原 PR 描述提到基础终端登录能力来自 #2023，但本次按指定范围仅回移 #2045 和 #2047，没有额外带入 #2023；当前 release 基线的 changed-aware 编译、测试与边界检查均已通过。

## 文档影响

#2045 自带 Agent Provider setup 排障文档更新；#2047 无额外持久文档影响。