### PR TITLE
fix(browser-node): allow private network automation

### DIFF
--- a/docs/architecture/browser-node-package.md
+++ b/docs/architecture/browser-node-package.md
@@ -257,16 +257,10 @@ surfaces, while User Browser tabs remain under user lifecycle ownership.
 Network authorization runs before leasing or creating a tab. `new_page`
 creates only `about:blank`, attaches CDP request interception, and then loads
 the requested URL. The same policy therefore covers the initial document,
-main-frame redirects, subresources, and script-initiated requests. For an
-attached target, hostname checks use that target's Chromium Session resolver,
-keeping policy resolution in the browser network context that will make the
-request. The standard policy permits public HTTP/HTTPS destinations while
-rejecting private, link-local, metadata, multicast, and local-network targets.
-Loopback is denied by default; a virtualized host may permit an exact URL only
-through the trusted `isLoopbackUrlRouted` capability after its product-owned
-preview router maps the URL to the caller's sandbox instead of host localhost.
-`list_pages` remains metadata-only so an Agent can report a restricted page's
-title and URL without reading its contents.
+main-frame redirects, subresources, and script-initiated requests. The standard
+policy permits public, private, local-network, metadata, and loopback HTTP/HTTPS
+destinations alike, matching manual Browser navigation reachability. It still
+rejects invalid URLs and non-HTTP protocols.
 
 `BrowserNode` also accepts a `renderHome` slot. The package shows it only for
 an empty/`about:blank` tab and supplies a package-owned navigation callback.

--- a/packages/browser/workbench-node/README.md
+++ b/packages/browser/workbench-node/README.md
@@ -114,14 +114,9 @@ are disabled and retained Agent pages are closed, and later calls fail closed.
 
 `createBrowserNodeAutomationServer` publishes the registry on authenticated
 loopback and writes a private listener-info file for an explicitly configured
-daemon. `createBrowserNodeAutomationNetworkAuthorizer` provides the standard
-public HTTP/HTTPS policy and blocks private, link-local, metadata, multicast,
-and local-network pages from inspect/control calls. Loopback fails closed by
-default; hosts may permit a loopback URL only through the
-`isLoopbackUrlRouted` capability after sandbox-owned preview routing has
-accepted that exact URL. For registered targets, authorization resolves host
-names through the target's Chromium session rather than an unrelated process
-resolver. Hosts should also install the authorizer as the registry's
-`authorizeRequest` callback so the initial navigation, redirects,
-subresources, and script-initiated requests remain guarded for the lifetime of
-an automation lease.
+daemon. `createBrowserNodeAutomationNetworkAuthorizer` accepts public, private,
+local-network, metadata, and loopback HTTP/HTTPS targets alike, matching manual
+Browser navigation reachability. Hosts should also install the authorizer as
+the registry's `authorizeRequest` callback so the initial navigation,
+redirects, subresources, and script-initiated requests retain the HTTP/HTTPS
+protocol boundary for the lifetime of an automation lease.

--- a/packages/browser/workbench-node/src/electron-main/automationDebugger.test.ts
+++ b/packages/browser/workbench-node/src/electron-main/automationDebugger.test.ts
@@ -47,7 +47,7 @@ test("automation request guard intercepts redirects and subresources", async () 
       ? { allowed: true }
       : {
           allowed: false,
-          code: "private_network_blocked",
+          code: "blocked_by_policy",
           message: "blocked"
         }
   );

--- a/packages/browser/workbench-node/src/electron-main/automationNetworkPolicy.test.ts
+++ b/packages/browser/workbench-node/src/electron-main/automationNetworkPolicy.test.ts
@@ -26,53 +26,40 @@ function authorizationInput(
   };
 }
 
-test("automation network policy permits public pages and only routed loopback", async () => {
-  const authorize = createBrowserNodeAutomationNetworkAuthorizer({
-    isLoopbackUrlRouted: async (url) => url === "http://127.0.0.1:3000/",
-    resolveHost: async () => ["93.184.216.34"]
-  });
-  assert.deepEqual(await authorize(authorizationInput("https://example.com")), {
-    allowed: true
-  });
+test("automation network policy permits every HTTP and HTTPS target", async () => {
+  const authorize = createBrowserNodeAutomationNetworkAuthorizer();
+  for (const url of [
+    "https://example.com",
+    "http://127.0.0.1:3000",
+    "http://10.0.0.2",
+    "http://169.254.169.254/latest/meta-data",
+    "http://router.local",
+    "https://198.18.0.178"
+  ]) {
+    assert.deepEqual(await authorize(authorizationInput(url)), {
+      allowed: true
+    });
+  }
+});
+
+test("automation network policy retains URL and protocol validation", async () => {
+  const authorize = createBrowserNodeAutomationNetworkAuthorizer();
   assert.deepEqual(
-    await authorize(authorizationInput("http://127.0.0.1:3000")),
-    { allowed: true }
-  );
-  assert.equal(
-    (await authorize(authorizationInput("http://127.0.0.1:4000"))).allowed,
-    false
-  );
-});
-
-test("automation request policy uses the target Chromium session resolver", async () => {
-  let nodeResolverCalled = false;
-  const authorize = createBrowserNodeAutomationNetworkAuthorizer({
-    resolveHost: async () => {
-      nodeResolverCalled = true;
-      return ["10.0.0.2"];
+    await authorize(authorizationInput("https://example.com", "not a url")),
+    {
+      allowed: false,
+      code: "invalid_url",
+      message: "The browser URL is invalid"
     }
-  });
-  const input = authorizationInput("https://example.com");
-  input.resolveHost = async () => ["93.184.216.34"];
-
-  assert.deepEqual(await authorize(input), { allowed: true });
-  assert.equal(nodeResolverCalled, false);
-});
-
-test("automation network policy blocks private current pages and navigation", async () => {
-  const authorize = createBrowserNodeAutomationNetworkAuthorizer({
-    resolveHost: async () => ["10.0.0.2"]
-  });
-  assert.equal(
-    (await authorize(authorizationInput("https://internal.example"))).allowed,
-    false
   );
-  assert.equal(
-    (
-      await authorize(
-        authorizationInput("https://example.com", "http://169.254.169.254")
-      )
-    ).allowed,
-    false
+  assert.deepEqual(
+    await authorize(
+      authorizationInput("https://example.com", "file:///etc/hosts")
+    ),
+    {
+      allowed: false,
+      code: "unsupported_protocol",
+      message: "Browser automation only supports HTTP and HTTPS pages"
+    }
   );
 });

--- a/packages/browser/workbench-node/src/electron-main/automationNetworkPolicy.ts
+++ b/packages/browser/workbench-node/src/electron-main/automationNetworkPolicy.ts
@@ -1,18 +1,9 @@
-import { lookup } from "node:dns/promises";
-import { isIP } from "node:net";
 import type {
   BrowserNodeAutomationAuthorizationInput,
   BrowserNodeAutomationAuthorizationResult
 } from "./automationTypes.ts";
 
-export interface BrowserNodeAutomationNetworkPolicyOptions {
-  isLoopbackUrlRouted?: (url: string) => boolean | Promise<boolean>;
-  resolveHost?: (hostname: string) => Promise<readonly string[]>;
-}
-
-export function createBrowserNodeAutomationNetworkAuthorizer(
-  options: BrowserNodeAutomationNetworkPolicyOptions = {}
-): (
+export function createBrowserNodeAutomationNetworkAuthorizer(): (
   input: BrowserNodeAutomationAuthorizationInput
 ) => Promise<BrowserNodeAutomationAuthorizationResult> {
   return async (input) => {
@@ -34,40 +25,6 @@ export function createBrowserNodeAutomationNetworkAuthorizer(
       );
     }
 
-    const hostname = normalizeHostname(url.hostname);
-    if (isLoopbackHostname(hostname)) {
-      const routed = await options.isLoopbackUrlRouted?.(url.toString());
-      return routed === true
-        ? { allowed: true }
-        : blocked("private_network_blocked", "Loopback pages are not allowed");
-    }
-    if (hostname.endsWith(".local")) {
-      return blocked(
-        "private_network_blocked",
-        "Local-network pages are not available to browser automation"
-      );
-    }
-
-    let addresses: readonly string[];
-    try {
-      const resolveHost =
-        input.resolveHost ?? options.resolveHost ?? resolveHostnameAddresses;
-      addresses = isIP(hostname) ? [hostname] : await resolveHost(hostname);
-    } catch {
-      return blocked(
-        "host_resolution_failed",
-        "The browser host could not be resolved safely"
-      );
-    }
-    if (
-      addresses.length === 0 ||
-      addresses.some((address) => !isAllowedAddress(address))
-    ) {
-      return blocked(
-        "private_network_blocked",
-        "Private, link-local, and metadata-network pages are not available to browser automation"
-      );
-    }
     return { allowed: true };
   };
 }
@@ -80,62 +37,6 @@ function resolveAuthorizationUrl(
     return typeof candidate === "string" ? candidate.trim() : "";
   }
   return input.target?.url.trim() || "about:blank";
-}
-
-async function resolveHostnameAddresses(hostname: string): Promise<string[]> {
-  return (await lookup(hostname, { all: true, verbatim: true })).map(
-    ({ address }) => address
-  );
-}
-
-function normalizeHostname(hostname: string): string {
-  return hostname.replace(/^\[|\]$/gu, "").toLowerCase();
-}
-
-function isLoopbackHostname(hostname: string): boolean {
-  if (hostname === "localhost" || hostname === "::1") return true;
-  if (!hostname.includes(".")) return false;
-  const octets = hostname.split(".").map(Number);
-  return octets.length === 4 && octets[0] === 127;
-}
-
-function isAllowedAddress(address: string): boolean {
-  const normalized = normalizeHostname(address);
-  if (normalized.includes(":")) {
-    return isAllowedIPv6(normalized);
-  }
-  return isAllowedIPv4(normalized);
-}
-
-function isAllowedIPv4(address: string): boolean {
-  const octets = address.split(".").map(Number);
-  if (octets.length !== 4 || octets.some((value) => !Number.isInteger(value))) {
-    return false;
-  }
-  const a = octets[0]!;
-  const b = octets[1]!;
-  return !(
-    a === 0 ||
-    a === 127 ||
-    a === 10 ||
-    (a === 100 && b >= 64 && b <= 127) ||
-    (a === 169 && b === 254) ||
-    (a === 172 && b >= 16 && b <= 31) ||
-    (a === 192 && b === 168) ||
-    (a === 198 && (b === 18 || b === 19)) ||
-    a >= 224
-  );
-}
-
-function isAllowedIPv6(address: string): boolean {
-  if (address === "::" || address === "::1" || address.startsWith("ff")) {
-    return false;
-  }
-  if (address.startsWith("::ffff:")) {
-    return isAllowedIPv4(address.slice("::ffff:".length));
-  }
-  const first = Number.parseInt(address.split(":", 1)[0] || "0", 16);
-  return !((first & 0xfe00) === 0xfc00 || (first & 0xffc0) === 0xfe80);
 }
 
 function blocked(

--- a/packages/browser/workbench-node/src/electron-main/automationRegistry.test.ts
+++ b/packages/browser/workbench-node/src/electron-main/automationRegistry.test.ts
@@ -61,10 +61,6 @@ function guardedContents(events: string[]): BrowserGuestWebContents {
       },
       on() {
         return this;
-      },
-      async resolveHost() {
-        events.push("session.resolveHost");
-        return { endpoints: [{ address: "93.184.216.34" }] };
       }
     },
     async loadURL(url) {
@@ -226,13 +222,7 @@ test("new page creates about:blank and enables the request guard before navigati
   let registry: ReturnType<typeof createBrowserNodeAutomationRegistry>;
   registry = createBrowserNodeAutomationRegistry({
     authorize: async () => ({ allowed: true }),
-    authorizeRequest: async (input) => {
-      assert.ok(input.resolveHost);
-      assert.deepEqual(await input.resolveHost("public.example"), [
-        "93.184.216.34"
-      ]);
-      return { allowed: true };
-    },
+    authorizeRequest: async () => ({ allowed: true }),
     closeTarget: async () => undefined,
     requestTarget: async (input) => {
       assert.equal(input.url, "about:blank");

--- a/packages/browser/workbench-node/src/electron-main/automationRegistry.ts
+++ b/packages/browser/workbench-node/src/electron-main/automationRegistry.ts
@@ -121,11 +121,9 @@ export function createBrowserNodeAutomationRegistry(
     args: Record<string, unknown>,
     target: RegisteredTarget
   ): Promise<void> => {
-    const resolveHost = resolveTargetHost(target);
     const result = await options.authorize?.({
       agentSessionId: normalizeOptional(input.agentSessionId),
       args,
-      ...(resolveHost ? { resolveHost } : {}),
       target: toSummary(target),
       tool: input.tool,
       workspaceId: input.workspaceId
@@ -240,12 +238,10 @@ export function createBrowserNodeAutomationRegistry(
               if (!options.authorizeRequest) {
                 throw new Error("Browser request authorization is unavailable");
               }
-              const resolveHost = resolveTargetHost(target);
               await target.driver.enableRequestGuard(async (url) =>
                 options.authorizeRequest!({
                   agentSessionId,
                   args: { url },
-                  ...(resolveHost ? { resolveHost } : {}),
                   target: toSummary(target),
                   tool: "navigate_page",
                   workspaceId
@@ -273,12 +269,10 @@ export function createBrowserNodeAutomationRegistry(
         const acquired = acquireLease(normalizedInput, target);
         try {
           if (options.authorizeRequest) {
-            const resolveHost = resolveTargetHost(target);
             await target.driver.enableRequestGuard(async (url) =>
               options.authorizeRequest!({
                 agentSessionId: normalizeOptional(input.agentSessionId),
                 args: { url },
-                ...(resolveHost ? { resolveHost } : {}),
                 target: toSummary(target),
                 tool: "navigate_page",
                 workspaceId
@@ -470,20 +464,6 @@ function assertAgentActive(
       "agent_session_released: Browser automation session is closed"
     );
   }
-}
-
-function resolveTargetHost(
-  target: RegisteredTarget
-): ((hostname: string) => Promise<readonly string[]>) | null {
-  const browserSession = target.contents.session;
-  const resolveHost = browserSession?.resolveHost;
-  if (!browserSession || !resolveHost) return null;
-  return async (hostname) => {
-    const result = await resolveHost.call(browserSession, hostname, {
-      cacheUsage: "allowed"
-    });
-    return result.endpoints.map((endpoint) => endpoint.address);
-  };
 }
 
 async function loadTargetUrl(

--- a/packages/browser/workbench-node/src/electron-main/automationTypes.ts
+++ b/packages/browser/workbench-node/src/electron-main/automationTypes.ts
@@ -35,7 +35,6 @@ export interface BrowserNodeAutomationTargetSummary extends BrowserNodeAutomatio
 export interface BrowserNodeAutomationAuthorizationInput {
   agentSessionId: string | null;
   args: Record<string, unknown>;
-  resolveHost?: (hostname: string) => Promise<readonly string[]>;
   target: BrowserNodeAutomationTargetSummary | null;
   tool: BrowserNodeAutomationTool;
   workspaceId: string;

--- a/packages/browser/workbench-node/src/electron-main/index.ts
+++ b/packages/browser/workbench-node/src/electron-main/index.ts
@@ -23,10 +23,7 @@ export {
   type BrowserNodeAutomationListenerInfo,
   type BrowserNodeAutomationServer
 } from "./automationServer.ts";
-export {
-  createBrowserNodeAutomationNetworkAuthorizer,
-  type BrowserNodeAutomationNetworkPolicyOptions
-} from "./automationNetworkPolicy.ts";
+export { createBrowserNodeAutomationNetworkAuthorizer } from "./automationNetworkPolicy.ts";
 export type {
   BrowserNodeAutomationAuthorizationInput,
   BrowserNodeAutomationAuthorizationResult,

--- a/packages/browser/workbench-node/src/electron-main/types.ts
+++ b/packages/browser/workbench-node/src/electron-main/types.ts
@@ -197,10 +197,6 @@ export interface BrowserGuestElectronSession {
   cookies?: BrowserGuestCookieStore;
   off(event: "will-download", listener: BrowserGuestWillDownloadListener): this;
   on(event: "will-download", listener: BrowserGuestWillDownloadListener): this;
-  resolveHost?(
-    hostname: string,
-    options?: { cacheUsage?: "allowed" | "disallowed" | "staleAllowed" }
-  ): Promise<{ endpoints: readonly { address: string }[] }>;
   setDownloadPath?(path: string): void;
 }
 


### PR DESCRIPTION
## Summary

- remove Browser automation blocking for private, loopback, link-local, metadata, multicast, local-network, and benchmark-range HTTP/HTTPS targets
- remove obsolete DNS resolution and host-provided loopback authorization contracts
- retain invalid URL and non-HTTP/HTTPS protocol validation
- update Browser Node architecture and package documentation

## Verification

- `pnpm --dir packages/browser/workbench-node test`
- `pnpm --dir packages/browser/workbench-node typecheck`
- `pnpm --dir packages/browser/workbench-node build`
- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready`

## Checklist

- [x] Agent lifecycle semantics are unchanged.
- [x] I kept the change focused on one concern.
- [x] I updated documentation for the changed network policy.
- [x] No root multilingual README or CONTRIBUTING source changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] The commit is signed off with DCO.