### PR TITLE
[release/0805] fix(agent): filter oversized model gateway metadata

### DIFF
--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -15,8 +15,9 @@ recur and the repository now has implementation or debugging evidence for it.
 Use the focused runtime index or open one area directly:
 
 - [Agent Providers And Setup](./agent-provider-setup.md): Provider discovery, installation, authentication, models, configuration, and runtime reachability.
-  Includes Codex Model Plan Responses-to-Chat routing and extension
-  command/Skill palette hydration failures.
+  Includes Codex Model Plan Responses-to-Chat routing, oversized request
+  metadata compatibility, and extension command/Skill palette hydration
+  failures.
   Also covers uv-managed Extension installs that accidentally select an
   incompatible system Python.
   Also covers Kimi Code ACP sessions that advertise no model or hide provider

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -2122,13 +2122,19 @@ invalid_grant`. Search `tuttid.log` for
   A Codex session bound to an OpenAI-protocol Model Plan fails immediately,
   stays working without output, or loses tool-call messages. The Plan's
   connection check can still pass because detection calls
-  `/v1/chat/completions` directly.
+  `/v1/chat/completions` directly. Another immediate-failure shape is a
+  terminal provider error such as `metadata value too long: ... (578 > 512)`
+  after a short prompt that produced no assistant content.
 - Quick checks:
   Inspect the session-scoped Codex `config.toml`. The
   `tutti-model-plan` provider must use a loopback `base_url`, a temporary
   `TUTTI_MODEL_PLAN_API_KEY`, and `wire_api = "responses"`. Verify the upstream
   server receives `/v1/chat/completions`, not `/v1/responses`. A direct
-  Chat-only Base URL paired with `wire_api = "responses"` is incomplete.
+  Chat-only Base URL paired with `wire_api = "responses"` is incomplete. For
+  the metadata failure, inspect the exported Session's terminal Turn error and
+  compare the reported value length with 512. Codex workspace diagnostics can
+  grow with Git remotes and usage-attribution fields. Adjacent model-list 404s
+  are not the terminal cause when the thread and Turn both start successfully.
 - Root cause:
   Current Codex emits Responses-shaped requests and requires terminal
   Responses SSE events. A Chat-only provider neither owns `/v1/responses` nor
@@ -2139,7 +2145,11 @@ invalid_grant`. Search `tuttid.log` for
   tools that Chat Completions cannot execute. Codex also sends Responses
   `developer` messages; Chat-compatible providers that only recognize
   `system`/`user`/`assistant`/`tool` can reject the otherwise valid request
-  during tokenization.
+  during tokenization. The gateway also used to forward Responses
+  `metadata`/`client_metadata` unchanged. Codex can encode its workspace
+  diagnostics as one optional metadata value larger than the 512-byte limit
+  enforced by common Chat-compatible endpoints, so the upstream rejects the
+  request before model execution.
 - Fix:
   Keep Codex on `wire_api = "responses"` and route the session through
   tuttid's loopback Model Gateway. The gateway authenticates the temporary
@@ -2157,6 +2167,11 @@ invalid_grant`. Search `tuttid.log` for
   index zero. This preserves instruction precedence without requiring newer
   OpenAI-only roles or mid-conversation system roles from the upstream
   tokenizer. OpenCode continues to use the Plan endpoint directly.
+  Before sending the converted Chat request, omit only metadata values larger
+  than 512 bytes. Do not truncate them, because a truncated diagnostic JSON
+  value is misleading and may be invalid. Keep the original Responses
+  metadata for local response reconstruction; metadata at or below the limit
+  and Responses-over-client key precedence remain unchanged.
 - Validation:
   Cover request/tool conversion, interleaved parallel tool arguments, UTF-8
   and arbitrary SSE byte boundaries, large arguments, usage, upstream errors,
@@ -2166,10 +2181,13 @@ invalid_grant`. Search `tuttid.log` for
   internal-role normalization and system-message collapse. A real smoke test
   must complete two Codex turns and one tool call while the upstream records
   `/v1/chat/completions` without any upstream `developer` role or `system`
-  message after index zero.
+  message after index zero. Cover the metadata boundary explicitly: a 512-byte
+  value is forwarded, a 513-byte value is omitted, and an omitted Responses
+  value is not replaced by lower-priority client metadata with the same key.
 - References:
   [model-access-plans.md](../../architecture/model-access-plans.md)
   [gateway.go](../../../services/tuttid/service/modelgateway/gateway.go)
+  [responses_request.go](../../../services/tuttid/service/modelgateway/responses_request.go)
   [stream_converter.go](../../../services/tuttid/service/modelgateway/stream_converter.go)
   [model_endpoint.go](../../../packages/agent/runtimeprep/model_endpoint.go)
 

--- a/services/tuttid/service/modelgateway/responses_request.go
+++ b/services/tuttid/service/modelgateway/responses_request.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 )
 
+const maxChatMetadataValueBytes = 512
+
 type responsesRequest struct {
 	Model              string                     `json:"model"`
 	Instructions       json.RawMessage            `json:"instructions"`
@@ -179,17 +181,7 @@ func convertResponsesRequest(request responsesRequest) (chatRequest, responseToo
 	if err != nil {
 		return chatRequest{}, nil, err
 	}
-	metadata := request.Metadata
-	if len(request.ClientMetadata) > 0 {
-		if metadata == nil {
-			metadata = make(map[string]string, len(request.ClientMetadata))
-		}
-		for key, value := range request.ClientMetadata {
-			if _, exists := metadata[key]; !exists {
-				metadata[key] = value
-			}
-		}
-	}
+	metadata := chatCompatibleMetadata(request.Metadata, request.ClientMetadata)
 	result := chatRequest{
 		Model:             request.Model,
 		Messages:          messages,
@@ -220,6 +212,31 @@ func convertResponsesRequest(request responsesRequest) (chatRequest, responseToo
 		result.ReasoningEffort = strings.TrimSpace(request.Reasoning.Effort)
 	}
 	return result, toolNamespaces, nil
+}
+
+// chatCompatibleMetadata keeps optional request metadata from blocking model
+// execution. Codex can encode workspace diagnostics as one value larger than
+// the limit enforced by common Chat-compatible endpoints. Dropping that value
+// preserves the model request without forwarding truncated diagnostic JSON.
+func chatCompatibleMetadata(metadata map[string]string, clientMetadata map[string]string) map[string]string {
+	result := make(map[string]string, len(metadata)+len(clientMetadata))
+	for key, value := range metadata {
+		if len(value) <= maxChatMetadataValueBytes {
+			result[key] = value
+		}
+	}
+	for key, value := range clientMetadata {
+		if _, exists := metadata[key]; exists {
+			continue
+		}
+		if len(value) <= maxChatMetadataValueBytes {
+			result[key] = value
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
 }
 
 type responseInputItem struct {

--- a/services/tuttid/service/modelgateway/responses_request_test.go
+++ b/services/tuttid/service/modelgateway/responses_request_test.go
@@ -1,0 +1,56 @@
+package modelgateway
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestConvertResponsesRequestDropsOversizedChatMetadataValues(t *testing.T) {
+	t.Parallel()
+
+	exactLimit := strings.Repeat("a", maxChatMetadataValueBytes)
+	overLimit := exactLimit + "a"
+	request := responsesRequest{
+		Model: "model-a",
+		Input: json.RawMessage(`"hello"`),
+		Metadata: map[string]string{
+			"responses_exact_limit":               exactLimit,
+			"responses_over_limit":                overLimit,
+			"responses_over_limit_shadows_client": overLimit,
+			"shared":                              "responses",
+		},
+		ClientMetadata: map[string]string{
+			"client_exact_limit":                  exactLimit,
+			"client_over_limit":                   overLimit,
+			"responses_over_limit_shadows_client": "client",
+			"shared":                              "client",
+		},
+	}
+
+	converted, _, err := convertResponsesRequest(request)
+	if err != nil {
+		t.Fatalf("convertResponsesRequest() error = %v", err)
+	}
+	if len(converted.Metadata) != 3 {
+		t.Fatalf("metadata = %#v, want three compatible values", converted.Metadata)
+	}
+	if converted.Metadata["responses_exact_limit"] != exactLimit {
+		t.Fatal("Responses metadata at the Chat limit was dropped")
+	}
+	if converted.Metadata["client_exact_limit"] != exactLimit {
+		t.Fatal("client metadata at the Chat limit was dropped")
+	}
+	if converted.Metadata["shared"] != "responses" {
+		t.Fatalf("shared metadata = %q, want Responses value", converted.Metadata["shared"])
+	}
+	if _, exists := converted.Metadata["responses_over_limit"]; exists {
+		t.Fatal("oversized Responses metadata was forwarded")
+	}
+	if _, exists := converted.Metadata["client_over_limit"]; exists {
+		t.Fatal("oversized client metadata was forwarded")
+	}
+	if _, exists := converted.Metadata["responses_over_limit_shadows_client"]; exists {
+		t.Fatal("lower-priority client metadata replaced dropped Responses metadata")
+	}
+}


### PR DESCRIPTION
## Summary

Backport #2066 to `release/0805`.

- omit optional Responses metadata values larger than 512 bytes before forwarding Model Gateway requests to Chat-compatible upstreams
- preserve compatible metadata, Responses-over-client precedence, and original Responses metadata used for local response reconstruction
- add regression coverage for the 512/513-byte boundary and document the failure signature

## Backport details

- based on `release/0805` at `7865412c0`
- cherry-picked `96deb390e` as `a7d558fc9`
- applied without conflicts and retains the DCO sign-off
- contains only the same four files as #2066

## Root cause and user impact

Codex can encode workspace diagnostics, Git remotes, and usage attribution into one metadata value. The Responses-to-Chat bridge forwarded that value unchanged, so upstreams enforcing a 512-byte metadata limit rejected custom Agent sessions before model execution.

## Validation

- `go test ./service/modelgateway -count=1`
- `pnpm check:changed` — 17/17 lanes passed
- `go build ./...` from `services/tuttid`
- pre-push `pnpm check:changed -- --push-ready` — 19/19 lanes passed