### PR TITLE
fix(mobile): standardize app bundle identifiers

### DIFF
--- a/apps/mobile/android/Makefile
+++ b/apps/mobile/android/Makefile
@@ -7,15 +7,15 @@ GOMOBILE_LDFLAGS ?= -checklinkname=0
 REPO_ROOT := $(abspath ../../..)
 DEVICE_LINK_DIR := $(REPO_ROOT)/packages/device-link
 AAR_OUTPUT ?= $(CURDIR)/app/libs/tutti-mobile-go.aar
-JAVA_PACKAGE := dev.tutti.mobile.bindings
+JAVA_PACKAGE := sh.tutti.mobile.bindings
 GOMOBILE_GO := env GOTOOLCHAIN=$(GOMOBILE_GO_TOOLCHAIN) go
 
 android-bindings-check:
 	@bind_tmp=$$(mktemp -d); \
 	trap 'rm -rf "$$bind_tmp"' EXIT; \
 	cd "$(DEVICE_LINK_DIR)" && $(GOMOBILE_GO) tool gobind -lang=java -javapkg=$(JAVA_PACKAGE) -outdir="$$bind_tmp" ./mobile ../agent/daemon/liveprotocol/mobile; \
-	test -f "$$bind_tmp/java/dev/tutti/mobile/bindings/mobile/Mobile.java"; \
-	test -f "$$bind_tmp/java/dev/tutti/mobile/bindings/liveprotocolmobile/Liveprotocolmobile.java"
+	test -f "$$bind_tmp/java/sh/tutti/mobile/bindings/mobile/Mobile.java"; \
+	test -f "$$bind_tmp/java/sh/tutti/mobile/bindings/liveprotocolmobile/Liveprotocolmobile.java"
 
 android-aar:
 	@test -n "$(ANDROID_HOME)" || (echo "ANDROID_HOME is required" >&2; exit 1)
@@ -39,8 +39,8 @@ android-aar-check:
 	@aar_tmp=$$(mktemp -d); \
 	trap 'rm -rf "$$aar_tmp"' EXIT; \
 	unzip -p "$(AAR_OUTPUT)" classes.jar > "$$aar_tmp/classes.jar"; \
-	"$(JAVA_HOME)/bin/jar" tf "$$aar_tmp/classes.jar" | grep -Fqx 'dev/tutti/mobile/bindings/mobile/Mobile.class'; \
-	"$(JAVA_HOME)/bin/jar" tf "$$aar_tmp/classes.jar" | grep -Fqx 'dev/tutti/mobile/bindings/liveprotocolmobile/Liveprotocolmobile.class'; \
+	"$(JAVA_HOME)/bin/jar" tf "$$aar_tmp/classes.jar" | grep -Fqx 'sh/tutti/mobile/bindings/mobile/Mobile.class'; \
+	"$(JAVA_HOME)/bin/jar" tf "$$aar_tmp/classes.jar" | grep -Fqx 'sh/tutti/mobile/bindings/liveprotocolmobile/Liveprotocolmobile.class'; \
 	for abi in armeabi-v7a arm64-v8a x86 x86_64; do \
 		unzip -p "$(AAR_OUTPUT)" "jni/$$abi/libgojni.so" > "$$aar_tmp/libgojni-$$abi.so"; \
 		$(GOMOBILE_GO) version -m "$$aar_tmp/libgojni-$$abi.so" | head -n 1 | grep -Fq ": $(GOMOBILE_GO_TOOLCHAIN)"; \

--- a/apps/mobile/android/app/build.gradle
+++ b/apps/mobile/android/app/build.gradle
@@ -55,9 +55,9 @@ android {
     buildToolsVersion rootProject.ext.buildToolsVersion
     compileSdk rootProject.ext.compileSdkVersion
 
-    namespace "dev.tutti.mobile"
+    namespace "sh.tutti.mobile"
     defaultConfig {
-        applicationId "dev.tutti.mobile"
+        applicationId "sh.tutti.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode androidVersionCode

--- a/apps/mobile/android/app/proguard-rules.pro
+++ b/apps/mobile/android/app/proguard-rules.pro
@@ -1,2 +1,2 @@
--keep class dev.tutti.mobile.bindings.** { *; }
+-keep class sh.tutti.mobile.bindings.** { *; }
 -keep class go.** { *; }

--- a/apps/mobile/android/app/src/main/java/sh/tutti/mobile/AppLifecycleModule.kt
+++ b/apps/mobile/android/app/src/main/java/sh/tutti/mobile/AppLifecycleModule.kt
@@ -1,4 +1,4 @@
-package dev.tutti.mobile
+package sh.tutti.mobile
 
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle

--- a/apps/mobile/android/app/src/main/java/sh/tutti/mobile/DeviceLinkModule.kt
+++ b/apps/mobile/android/app/src/main/java/sh/tutti/mobile/DeviceLinkModule.kt
@@ -1,4 +1,4 @@
-package dev.tutti.mobile
+package sh.tutti.mobile
 
 import android.os.Handler
 import android.os.Looper
@@ -17,10 +17,10 @@ import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.modules.core.DeviceEventManagerModule
-import dev.tutti.mobile.bindings.liveprotocolmobile.Liveprotocolmobile
-import dev.tutti.mobile.bindings.mobile.Link
-import dev.tutti.mobile.bindings.mobile.Mobile
-import dev.tutti.mobile.bindings.mobile.Stream
+import sh.tutti.mobile.bindings.liveprotocolmobile.Liveprotocolmobile
+import sh.tutti.mobile.bindings.mobile.Link
+import sh.tutti.mobile.bindings.mobile.Mobile
+import sh.tutti.mobile.bindings.mobile.Stream
 import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 import java.nio.ByteOrder

--- a/apps/mobile/android/app/src/main/java/sh/tutti/mobile/MainActivity.kt
+++ b/apps/mobile/android/app/src/main/java/sh/tutti/mobile/MainActivity.kt
@@ -1,4 +1,4 @@
-package dev.tutti.mobile
+package sh.tutti.mobile
 
 import android.net.Uri
 import android.os.Bundle

--- a/apps/mobile/android/app/src/main/java/sh/tutti/mobile/MainApplication.kt
+++ b/apps/mobile/android/app/src/main/java/sh/tutti/mobile/MainApplication.kt
@@ -1,4 +1,4 @@
-package dev.tutti.mobile
+package sh.tutti.mobile
 
 import android.app.Application
 import com.facebook.react.PackageList

--- a/apps/mobile/android/app/src/main/java/sh/tutti/mobile/MobileBrowserAuthBridge.kt
+++ b/apps/mobile/android/app/src/main/java/sh/tutti/mobile/MobileBrowserAuthBridge.kt
@@ -1,4 +1,4 @@
-package dev.tutti.mobile
+package sh.tutti.mobile
 
 import android.content.Intent
 import android.net.Uri

--- a/apps/mobile/android/app/src/main/java/sh/tutti/mobile/MobileNativePackage.kt
+++ b/apps/mobile/android/app/src/main/java/sh/tutti/mobile/MobileNativePackage.kt
@@ -1,4 +1,4 @@
-package dev.tutti.mobile
+package sh.tutti.mobile
 
 import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.NativeModule

--- a/apps/mobile/android/app/src/main/java/sh/tutti/mobile/MobilePreferencesModule.kt
+++ b/apps/mobile/android/app/src/main/java/sh/tutti/mobile/MobilePreferencesModule.kt
@@ -1,4 +1,4 @@
-package dev.tutti.mobile
+package sh.tutti.mobile
 
 import android.content.Context
 import com.facebook.react.bridge.Promise

--- a/apps/mobile/android/app/src/main/java/sh/tutti/mobile/MobileSecurityModule.kt
+++ b/apps/mobile/android/app/src/main/java/sh/tutti/mobile/MobileSecurityModule.kt
@@ -1,4 +1,4 @@
-package dev.tutti.mobile
+package sh.tutti.mobile
 
 import android.app.Activity
 import android.content.Intent

--- a/apps/mobile/android/app/src/main/java/sh/tutti/mobile/PairingCaptureActivity.kt
+++ b/apps/mobile/android/app/src/main/java/sh/tutti/mobile/PairingCaptureActivity.kt
@@ -1,4 +1,4 @@
-package dev.tutti.mobile
+package sh.tutti.mobile
 
 import android.app.Activity
 import android.content.Intent

--- a/apps/mobile/ios/TuttiMobile.xcodeproj/project.pbxproj
+++ b/apps/mobile/ios/TuttiMobile.xcodeproj/project.pbxproj
@@ -345,7 +345,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = dev.tutti.mobile;
+				PRODUCT_BUNDLE_IDENTIFIER = sh.tutti.mobile;
 				PRODUCT_NAME = TuttiMobile;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -374,7 +374,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = dev.tutti.mobile;
+				PRODUCT_BUNDLE_IDENTIFIER = sh.tutti.mobile;
 				PRODUCT_NAME = TuttiMobile;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SWIFT_VERSION = 5.0;

--- a/apps/mobile/ios/TuttiMobile/DeviceLinkFraming.mm
+++ b/apps/mobile/ios/TuttiMobile/DeviceLinkFraming.mm
@@ -3,7 +3,7 @@
 static const NSUInteger TUTDeviceLinkFramingMaxReadChunk = 1 << 20;
 
 static NSError *TUTDeviceLinkFramingError(NSString *code, NSString *message) {
-  return [NSError errorWithDomain:@"dev.tutti.mobile.device-link"
+  return [NSError errorWithDomain:@"sh.tutti.mobile.device-link"
                              code:1
                          userInfo:@{
                            NSLocalizedDescriptionKey : message,

--- a/apps/mobile/ios/TuttiMobile/DeviceLinkModule.mm
+++ b/apps/mobile/ios/TuttiMobile/DeviceLinkModule.mm
@@ -22,7 +22,7 @@ static const NSUInteger TUTMaxResponseFrameBytes =
     ((TUTMaxResponseBodyBytes + 2) / 3 * 4) + TUTFrameEnvelopeBytes;
 
 static NSError *TUTDeviceLinkError(NSString *code, NSString *message) {
-  return [NSError errorWithDomain:@"dev.tutti.mobile.device-link"
+  return [NSError errorWithDomain:@"sh.tutti.mobile.device-link"
                              code:1
                          userInfo:@{
                            NSLocalizedDescriptionKey : message,
@@ -74,11 +74,11 @@ RCT_EXPORT_MODULE(TuttiDeviceLink)
   self = [super init];
   if (self != nil) {
     _operationQueue = dispatch_queue_create(
-        "dev.tutti.mobile.device-link.operations", DISPATCH_QUEUE_CONCURRENT);
-    _closeQueue = dispatch_queue_create("dev.tutti.mobile.device-link.close",
+        "sh.tutti.mobile.device-link.operations", DISPATCH_QUEUE_CONCURRENT);
+    _closeQueue = dispatch_queue_create("sh.tutti.mobile.device-link.close",
                                         DISPATCH_QUEUE_SERIAL);
     _agentLiveQueue = dispatch_queue_create(
-        "dev.tutti.mobile.device-link.agent-live", DISPATCH_QUEUE_SERIAL);
+        "sh.tutti.mobile.device-link.agent-live", DISPATCH_QUEUE_SERIAL);
     [[NSNotificationCenter defaultCenter]
         addObserver:self
            selector:@selector(applicationDidEnterBackground)

--- a/apps/mobile/ios/TuttiMobile/DeviceLinkRelayProbe.mm
+++ b/apps/mobile/ios/TuttiMobile/DeviceLinkRelayProbe.mm
@@ -1,7 +1,7 @@
 #import "DeviceLinkRelayProbe.h"
 
 static NSError *TUTRelayProbeError(NSString *message) {
-  return [NSError errorWithDomain:@"dev.tutti.mobile.device-link.relay-probe"
+  return [NSError errorWithDomain:@"sh.tutti.mobile.device-link.relay-probe"
                              code:1
                          userInfo:@{NSLocalizedDescriptionKey : message}];
 }

--- a/apps/mobile/ios/TuttiMobile/Info.plist
+++ b/apps/mobile/ios/TuttiMobile/Info.plist
@@ -24,7 +24,7 @@
 	<array>
 		<dict>
 			<key>CFBundleURLName</key>
-			<string>dev.tutti.mobile.auth</string>
+			<string>sh.tutti.mobile.auth</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>tutti</string>

--- a/apps/mobile/ios/TuttiMobile/MobileBrowserAuthBridge.swift
+++ b/apps/mobile/ios/TuttiMobile/MobileBrowserAuthBridge.swift
@@ -10,7 +10,7 @@ struct MobileBrowserAuthError: LocalizedError {
 
 final class MobileBrowserAuthBridge {
   private let queue = DispatchQueue(
-    label: "dev.tutti.mobile.browser-auth",
+    label: "sh.tutti.mobile.browser-auth",
     qos: .userInitiated
   )
   private let lock = NSLock()

--- a/apps/mobile/ios/TuttiMobile/MobileSecurityModule.swift
+++ b/apps/mobile/ios/TuttiMobile/MobileSecurityModule.swift
@@ -368,7 +368,7 @@ private final class MobileSecureStore {
 
 private final class MobileKeychain {
   private let service =
-    (Bundle.main.bundleIdentifier ?? "dev.tutti.mobile") + ".secure-state"
+    (Bundle.main.bundleIdentifier ?? "sh.tutti.mobile") + ".secure-state"
 
   func read(account: String) throws -> Data? {
     var query = baseQuery(account: account)

--- a/apps/mobile/ios/TuttiMobile/QRCodeScannerViewController.swift
+++ b/apps/mobile/ios/TuttiMobile/QRCodeScannerViewController.swift
@@ -20,7 +20,7 @@ final class QRCodeScannerViewController: UIViewController,
 
   private let captureSession = AVCaptureSession()
   private let captureQueue = DispatchQueue(
-    label: "dev.tutti.mobile.qr-capture",
+    label: "sh.tutti.mobile.qr-capture",
     qos: .userInitiated
   )
   private let previewLayer = AVCaptureVideoPreviewLayer()

--- a/docs/conventions/troubleshooting/mobile.md
+++ b/docs/conventions/troubleshooting/mobile.md
@@ -31,7 +31,7 @@
   confirm no background event is emitted during the
   `MainActivity -> CaptureActivity -> MainActivity` sequence.
 - **References:**
-  `apps/mobile/android/app/src/main/java/dev/tutti/mobile/AppLifecycleModule.kt`,
+  `apps/mobile/android/app/src/main/java/sh/tutti/mobile/AppLifecycleModule.kt`,
   `apps/mobile/ios/TuttiMobile/AppLifecycleModule.swift`,
   `apps/mobile/src/native/appLifecyclePort.ts`
 
@@ -184,8 +184,8 @@
   Tab support, and verify the transfer code is redeemed no more than once.
 - **References:** `apps/mobile/ios/TuttiMobile/MobileWebAuthenticationSession.swift`,
   `apps/mobile/ios/TuttiMobile/MobileBrowserAuthBridge.swift`,
-  `apps/mobile/android/app/src/main/java/dev/tutti/mobile/MainActivity.kt`,
-  `apps/mobile/android/app/src/main/java/dev/tutti/mobile/MobileBrowserAuthBridge.kt`
+  `apps/mobile/android/app/src/main/java/sh/tutti/mobile/MainActivity.kt`,
+  `apps/mobile/android/app/src/main/java/sh/tutti/mobile/MobileBrowserAuthBridge.kt`
 
 ## Browser login returns to the App but remains signed out
 
@@ -212,7 +212,7 @@
   device page, restart the App, and verify the same account session still
   authorizes device-list requests.
 - **References:** `apps/mobile/src/services/accountClient.ts`,
-  `apps/mobile/android/app/src/main/java/dev/tutti/mobile/MobileSecurityModule.kt`
+  `apps/mobile/android/app/src/main/java/sh/tutti/mobile/MobileSecurityModule.kt`
 
 ## Android DeviceLink opens a session and then repeatedly restarts
 
@@ -222,7 +222,7 @@
   `fatal error: bulkBarrierPreWrite: unaligned arguments` instead of a Java or
   React Native exception.
 - **Quick checks:** Run `adb shell dumpsys activity exit-info
-dev.tutti.mobile` and inspect a narrow logcat window for the Go fatal message.
+sh.tutti.mobile` and inspect a narrow logcat window for the Go fatal message.
   This distinguishes a Go runtime abort from an Android lifecycle transition or
   a React Native development reload.
 - **Root cause:** A gomobile-exported Go method returned a pointer-bearing value,
@@ -247,7 +247,7 @@ dev.tutti.mobile` and inspect a narrow logcat window for the Go fatal message.
   connect on an ARM64 Android device, receive Agent Live frames, and observe
   beyond the previous crash window with no new Go fatal message.
 - **References:** `packages/device-link/mobile/link.go`,
-  `apps/mobile/android/app/src/main/java/dev/tutti/mobile/DeviceLinkModule.kt`
+  `apps/mobile/android/app/src/main/java/sh/tutti/mobile/DeviceLinkModule.kt`
 
 ## Mobile shows output from a completed Session after foreground resume
 
@@ -281,7 +281,7 @@ dev.tutti.mobile` and inspect a narrow logcat window for the Go fatal message.
 - **References:**
   `apps/mobile/src/native/createMobileServicePorts.ts`,
   `apps/mobile/src/services/workspaceAgentLiveLane.ts`,
-  `apps/mobile/android/app/src/main/java/dev/tutti/mobile/DeviceLinkModule.kt`,
+  `apps/mobile/android/app/src/main/java/sh/tutti/mobile/DeviceLinkModule.kt`,
   `apps/mobile/ios/TuttiMobile/DeviceLinkModule.mm`
 
 ## Mobile stays connected after a long lock-screen interval but sends fail
@@ -312,7 +312,7 @@ dev.tutti.mobile` and inspect a narrow logcat window for the Go fatal message.
   send from the original conversation without revisiting the computer list.
 - **References:**
   `apps/mobile/src/services/mobileApplicationService.ts`,
-  `apps/mobile/android/app/src/main/java/dev/tutti/mobile/DeviceLinkModule.kt`
+  `apps/mobile/android/app/src/main/java/sh/tutti/mobile/DeviceLinkModule.kt`
 
 ## iOS App crashes after loading the JavaScript bundle
 

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -400,7 +400,7 @@ Connect 仍需把处理完成的构建分配给对应的内部或外部测试组
 ```sh
 adb devices
 adb shell pm list packages | grep tutti
-adb shell am force-stop dev.tutti.mobile
+adb shell am force-stop sh.tutti.mobile
 adb logcat
 adb logcat -c
 adb logcat -s 'TuttiMobileSecurity:E' 'ReactNativeJS:V' '*:S'


### PR DESCRIPTION
## Summary

- Standardize Android and iOS mobile identity on `sh.tutti.mobile`
- Rename Android source packages and gomobile binding package references
- Update iOS URL, Keychain, queue, and error identifiers
- Update mobile documentation

## Validation

- `make -C apps/mobile/android android-bindings-check`
- `pnpm --filter @tutti-os/mobile android:aar`
- `./gradlew app:compileDebugKotlin`
- `pnpm --filter @tutti-os/mobile ios:pods`
- Full iOS simulator build with `CODE_SIGNING_ALLOWED=NO`
- `pnpm check:changed -- --push-ready` in a clean worktree