### PR TITLE
fix(agent-replay): make cassettes portable across consumers

### DIFF
--- a/.codex/skills/tutti-record-agent-session-replay/SKILL.md
+++ b/.codex/skills/tutti-record-agent-session-replay/SKILL.md
@@ -1,145 +1,199 @@
 ---
 name: tutti-record-agent-session-replay
-description: Record, inspect, and replay deterministic Tutti AgentGUI Session Replay cassettes. Use when Codex must turn a repository-owned test case into a real Provider-backed cassette, add or run an external named `--scenario`, diagnose recording or replay mismatches, verify Provider frames and portable semantic state, or capture AgentGUI evidence.
+description: Record, audit, replay, publish, or diagnose deterministic Tutti AgentGUI Session Replay cassettes from a Tutti checkout while keeping the external case repository as the Case and artifact source of truth. Use for Tutti Session Replay Case scenarios, real Provider recordings, cassette transport or semantic-state mismatches, fresh replay qualification, and AgentGUI replay evidence. Do not use for cases whose case.json declares executionKind "ui".
 ---
 
 # Record Tutti Agent Session Replay
 
-Produce evidence in this order:
+Work from the Tutti checkout. Keep product implementation and the generic
+runner in Tutti; keep Case metadata, scenarios, fixtures, qualified Cassettes,
+and evidence in the external case repository.
 
-`case -> deterministic scenario -> real record -> cassette audit -> real replay -> case artifact update`
+Prove work in this order:
 
-Do not report a cassette as recorded before both the recording and a fresh
-Replay succeed.
+`Case -> scenario -> real Record -> structural audit -> fresh Replay -> optional publication`
 
-## Prepare
+Never call a Cassette qualified until Record, audit, and a fresh isolated
+Replay have all passed.
 
-1. Read the root and closest `AGENTS.md`.
+## Establish scope
+
+1. Read the Tutti root and closest `AGENTS.md` files.
 2. Read `docs/architecture/agent-session-replay.md`.
-3. For AgentGUI interactions, read `docs/architecture/agent-gui-node.md` and
+3. For AgentGUI behavior, also read `docs/architecture/agent-gui-node.md` and
    `packages/agent/gui/AGENTS.md`.
-4. For lifecycle semantics, read `packages/agent/host/README.md` and keep those
-   semantics in Host.
-5. Inspect `git status --short`. Preserve pre-existing work.
-6. Read the case repository's `case.json`, `scenario.mjs`, fixtures, current
-   Cassette, and evidence. The repository is the case source of truth.
+4. For Session, Turn, Goal, or runtime-operation lifecycle behavior, read
+   `packages/agent/host/README.md`; lifecycle semantics remain in Host.
+5. Inspect `git status --short` in both repositories and preserve pre-existing
+   work.
+6. Resolve the case repository from the user-provided path, the configured
+   cases path, or the sibling `../tutti-agent-session-replay-cases` checkout.
+   Do not guess another location if none exists.
 
-Use CDP through the repository runner. Do not use Computer Use unless the user
-explicitly requests it.
+Read the selected Case before planning:
 
-## Design the scenario
+- `cases/<case-id>/case.json`
+- every `cases/<case-id>/scenarios/*.mjs` except `*.impl.mjs`
+- referenced shared scenario helpers and `runtime-fixtures/`
+- existing `cassettes/`, `evidence/`, and relevant Run artifacts
+- the case repository's `README.md` and `CONTEXT.md` when publication or Case
+  lifecycle is involved
 
-Add or update `cases/<scenario-id>/scenario.mjs` in the QA case repository.
-Do not add a case registry or case-specific scenario to the Tutti repository.
+If `case.json` declares `executionKind: "ui"`, stop this workflow. It is a
+UI-drive Case, not a Session Replay recording Case.
 
-Make the scenario deterministic:
+Use CDP through Tutti's repository runner. Do not use Computer Use unless the
+user explicitly requests it.
 
-- Use one exact prompt with stable markers.
-- Use an exact final token when the case expects an assistant reply.
-- Use a harmless, reversible command for approval cases.
-- Set every behavior-affecting composer default explicitly: permission mode,
-  plan mode, model, and reasoning effort as applicable.
-- Match the real accessible label, test ID, or semantic DOM state. Do not
-  depend on layout coordinates.
-- Wait for the interaction to exist before acting.
-- Submit each approval, answer, or plan decision once.
-- Require the expected terminal state and absence of enabled stale controls.
-- Cassette directory name is `{scenarioId}_{provider}` (for example
-  `c01_codex`), derived by `defineRecordScenario`.
+## Maintain the ownership boundary
 
-For question cards, trigger the Provider's real user-input request. For Codex
-plan cases, enable Plan Mode, wait for the completed plan and implementation
-card, then drive the real plan decision or feedback action.
+- Add or update Case scenarios only under
+  `cases/<case-id>/scenarios/*.mjs` in the case repository.
+- Put reusable scenario helpers in that repository's `scenario-runtime/`.
+- Do not add Case registries, Case-specific scenarios, fixtures, or qualified
+  Cassettes to Tutti.
+- Change Tutti only for generic product, runner, protocol, or Replay defects.
+- Fix root causes. Do not relax transport matching, semantic verification,
+  terminal assertions, or checkpoint requirements to accept a broken Case.
 
-## Record
+## Design a deterministic scenario
 
-Run:
+Use the case repository's existing scenario factory and provider profile
+patterns. A scenario must export `prepare`, `drive`, and `assert`, set its
+Provider explicitly or through the repository helper, and set every
+behavior-affecting composer default explicitly.
+
+Require all of the following:
+
+- one stable prompt per intended Turn, with exact markers;
+- an exact final token when an assistant reply is expected;
+- harmless and reversible commands for approval Cases;
+- accessible labels, test IDs, or semantic DOM state instead of coordinates;
+- waits for each interaction before acting;
+- exactly one response to each approval, question, or plan decision;
+- an asserted terminal state and no enabled stale controls;
+- a declared expected recording mode when continuing an existing Session;
+- provider-derived scenario and Cassette identity rather than a hard-coded
+  Codex target.
+
+For question cards, trigger the Provider's real user-input request. For plan
+Cases, wait for the completed plan and implementation decision before driving
+the real action.
+
+## Record with the Tutti runner
+
+Run one real Provider recording per scenario from the Tutti root. Derive the
+scenario ID, Cassette name, and Agent Target from the loaded scenario. For
+example:
 
 ```bash
 pnpm e2e:agent-gui -- \
-  --record .tmp/cassettes/<scenario-id>_codex \
+  --record .tmp/cassettes/<cassette-name> \
   --scenario <scenario-id> \
-  --scenario-file ../tutti-agent-session-replay-cases/cases/<scenario-id>/scenario.mjs \
-  --agent-target-id local:codex \
+  --scenario-file <case-repository>/cases/<case-id>/scenarios/<scenario-id>.mjs \
+  --agent-target-id <agent-target-id> \
   --keep-runtime \
-  --timeout-ms 300000
+  --timeout-ms 300000 \
+  --stall-timeout-ms 60000
 ```
 
-Omit `--headless` to show the Electron window while debugging; add it for
-unattended runs. Keep `--keep-runtime` while developing. Inspect:
+Omit `--headless` while debugging; add it for unattended execution. Keep the
+runtime only long enough to inspect or collect its artifacts.
 
-- `artifacts/record-agent-gui.png`
-- `logs/desktop.log`
-- `state/logs/tuttid.log`
-- `state/tuttid.db`
-- the incomplete cassette and Provider frames
+Inspect failures from the smallest relevant evidence set:
 
-Fix root causes. Do not weaken transport matching, semantic validation, or
-terminal-state assertions to make a cassette pass.
+- record screenshots and checkpoint screenshots;
+- `logs/desktop.log`;
+- `state/logs/tuttid.log`;
+- `state/tuttid.db` through targeted queries;
+- the incomplete Cassette and a small decoded Provider-frame window.
 
-## Audit
+Do not dump an entire Provider stream or expose account data.
 
-Run the bundled deterministic audit:
+## Audit each Cassette
+
+Run the bundled structural audit from the Tutti root:
 
 ```bash
 node .codex/skills/tutti-record-agent-session-replay/scripts/audit-cassette.mjs \
-  .tmp/cassettes/<scenario-id>_codex
+  .tmp/cassettes/<cassette-name>
 ```
 
 Require:
 
-- cassette inventory and hashes verify;
-- Provider manifest is `complete`;
+- Cassette inventory, hashes, and size policy verify;
+- the Provider manifest is complete;
 - global and per-connection frame sequences are continuous;
-- the expected interaction or plan decision appears once;
-- tool execution count and exit status match the case;
-- all expected Turns are terminal;
-- activity sequences are contiguous and intent→effect causality satisfies
-  `packages/agent/session-replay/activity-contract.json`: every effect
-  references an earlier intent with a compatible correlationId and a declared
-  effect type, every `requiresEffect` intent is answered, and direct-stimulus
-  events carry no cause;
-- the final assistant token or expected no-text state matches the case.
+- Activity sequences are continuous;
+- intent-to-effect causality satisfies
+  `packages/agent/session-replay/activity-contract.json`;
+- expected interactions, plan decisions, tools, exits, terminal Turns, and
+  final response state match `case.json` and the scenario assertions.
 
-Inspect a small decoded Provider-frame window around the interaction. Do not
-dump the entire Provider stream or expose account data.
+The bundled audit proves structural invariants and emits a semantic summary.
+It does not replace Case-specific assertions or a fresh Replay.
 
-## Replay
+## Run a fresh Replay
 
-Run a fresh isolated Replay:
+Replay from a fresh isolated Tutti runtime and pass the scenario so screenshot
+settling and terminal assertions run:
 
 ```bash
 pnpm e2e:agent-gui -- \
-  --replay .tmp/cassettes/<scenario-id>_codex \
+  --replay .tmp/cassettes/<cassette-name> \
+  --scenario <scenario-id> \
+  --scenario-file <case-repository>/cases/<case-id>/scenarios/<scenario-id>.mjs \
+  --screenshot-checkpoints \
   --keep-runtime \
-  --timeout-ms 300000
+  --timeout-ms 300000 \
+  --stall-timeout-ms 60000
 ```
 
-Omit `--headless` to show the Electron window; add it for unattended runs.
-Require the runner's `replay passed` result. Inspect
-`artifacts/replay-agent-gui.png` and confirm the case's UI terminal state.
+Require the runner's `replay passed` result, all planned checkpoints, the
+expected AgentGUI terminal state, and a fully drained Provider transport.
+Provider transport remains fail-closed; only repository-declared observer-only
+probes may yield to causal traffic.
 
-Provider transport remains fail-closed. Only repository-declared
-observer-only probes may be absent or yield to causal traffic.
+When one Case owns multiple scenarios, Record and audit every resulting
+Cassette, then qualify them together through one Replay Workspace. Let the
+case repository workflow generate the workspace manifest; do not invent a
+second Case registry in Tutti.
 
-## Update the case artifacts
+## Publish only qualified artifacts
 
-Only after record and Replay pass, replace the case repository's
-`cases/<scenario-id>/cassette` and `evidence` directories and update its
-`case.json` status when required. Do not read or write a remote catalog.
+Prefer the case repository's publication workflow because it records the Run,
+archives prior artifacts, and publishes `cassettes/` plus `evidence/` only
+after qualification.
+
+If the user explicitly requests manual publication:
+
+1. Stage all new Cassettes and evidence without touching the qualified copies.
+2. Verify every staged Cassette completed Record, audit, and fresh Replay.
+3. Replace `cases/<case-id>/cassettes/` and `evidence/` as one Case operation,
+   preserving the previous qualified artifacts in the case repository's
+   archive convention.
+4. Re-read every published manifest and evidence directory.
+
+Do not infer Case lifecycle from a successful command. Run status, manual
+acceptance, and `case.json` lifecycle status are distinct. Do not set
+`status: "confirmed"` or `acceptedAt` unless the case repository's acceptance
+requirements have been satisfied.
 
 ## Finish
 
-Run the repository validation selection policy from
-`docs/conventions/testing.md`.
+- If Tutti implementation changed, run the validation selected by
+  `docs/conventions/testing.md` plus any closest-area checks.
+- If case metadata or scenarios changed, run the case repository's metadata,
+  scenario, and type checks.
+- Recheck both worktrees and separate pre-existing changes from this task.
+- Perform the Tutti documentation-impact check.
 
 Report:
 
-- cassette names and artifact links;
-- record and Replay evidence per case;
-- Provider frame, interaction, tool, Turn, and final-response summaries;
-- case repository artifacts changed;
-- implementation changes and why they changed;
-- changed-line distribution, separating pre-existing dirty work;
+- Case and Cassette names;
+- Record, audit, and fresh Replay results;
+- Provider-frame, Activity, interaction, tool, Turn, and final-state summaries;
+- Tutti implementation changes and case repository artifact changes;
+- changed-line distribution by functional area, excluding pre-existing work;
 - documentation impact;
-- remaining failed gates or unimplemented scope.
+- failed gates and unimplemented scope.

--- a/.codex/skills/tutti-record-agent-session-replay/agents/openai.yaml
+++ b/.codex/skills/tutti-record-agent-session-replay/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Tutti Session Replay"
-  short_description: "Record and verify Tutti Agent Session Replay cassettes"
-  default_prompt: "Use $tutti-record-agent-session-replay to record and replay a deterministic AgentGUI cassette."
+  short_description: "Record and qualify Tutti Session Replay cassettes"
+  default_prompt: "Use $tutti-record-agent-session-replay to record, audit, and freshly replay a Case cassette from this Tutti checkout."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ Read the closest `AGENTS.md` before editing:
 - `apps/desktop/*` -> `apps/desktop/AGENTS.md`
 - `services/tuttid/*` -> `services/tuttid/AGENTS.md`
 - `packages/agent/gui/*` -> `packages/agent/gui/AGENTS.md`
+- `packages/agent/session-replay/*` -> `packages/agent/session-replay/AGENTS.md`
 - `packages/ui/*` -> `packages/ui/AGENTS.md`
 - `packages/*` -> `packages/AGENTS.md`
 

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -14,6 +14,12 @@ If you are editing Agent session, Turn, Goal, runtime-operation, or recovery
 lifecycle under `packages/agent/*`, read the root `Agent Host Boundary` and
 [packages/agent/host/README.md](agent/host/README.md) first.
 
+If you are editing Cassette projection, checkpoint readiness, or final-state
+replay compare under `packages/agent/session-replay/*`, read
+[packages/agent/session-replay/AGENTS.md](agent/session-replay/AGENTS.md) and
+[packages/agent/session-replay/README.md](agent/session-replay/README.md)
+first.
+
 If the task mentions AgentGUI, AgentGuiNode, Agent GUI, the agent conversation
 module, agent composer, workspace agent timeline, agent approvals, or
 interactive agent prompts, read

--- a/packages/agent/daemon/runtime/process_cassette_projection.go
+++ b/packages/agent/daemon/runtime/process_cassette_projection.go
@@ -13,8 +13,10 @@ import (
 )
 
 const (
-	portableProcessCassetteAccountEmail = "replay-user@example.invalid"
-	portableProcessCassetteHomeToken    = replay.PortableReplayHomeToken
+	portableProcessCassetteAccountEmail     = "replay-user@example.invalid"
+	portableProcessCassetteHomeToken        = replay.PortableReplayHomeToken
+	portableProcessCassetteCLIVersionToken  = "<runtime-cli-version>"
+	portableProcessCassetteClientTitleToken = "<runtime-client-title>"
 )
 
 type processCassetteProjection struct {
@@ -366,6 +368,36 @@ func projectProcessCassetteRuntimeGeneratedFields(
 				current != field.PortableValue {
 				params[field.Parameter] = field.PortableValue
 			}
+		}
+	}
+}
+
+// projectProcessCassetteVolatileClientInfo normalizes product-owned initialize
+// clientInfo fields for request matching. The served CLI version and host title
+// may drift across cassette lifetime and consumer product; name remains the
+// protocol client identity and part of the semantic match.
+func projectProcessCassetteVolatileClientInfo(values []any) {
+	for _, value := range values {
+		message, ok := value.(map[string]any)
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(payloadString(message, "method")) != "initialize" {
+			continue
+		}
+		params, _ := message["params"].(map[string]any)
+		if params == nil {
+			continue
+		}
+		clientInfo, _ := params["clientInfo"].(map[string]any)
+		if clientInfo == nil {
+			continue
+		}
+		if _, ok := clientInfo["version"]; ok {
+			clientInfo["version"] = portableProcessCassetteCLIVersionToken
+		}
+		if _, ok := clientInfo["title"]; ok {
+			clientInfo["title"] = portableProcessCassetteClientTitleToken
 		}
 	}
 }

--- a/packages/agent/daemon/runtime/process_transport_cassette_test.go
+++ b/packages/agent/daemon/runtime/process_transport_cassette_test.go
@@ -942,23 +942,81 @@ func TestRecordingAndReplayProcessTransportProjectsPlanDecisionClientUserMessage
 	}
 }
 
-func TestReplayProcessTransportKeepsOrdinaryClientUserMessageIDStrict(t *testing.T) {
+func TestReplayProcessTransportRemapsOrdinaryClientUserMessageIDConsistently(t *testing.T) {
 	expected := []byte(
 		`{"id":9,"method":"turn/start","params":{"clientUserMessageId":"user-submit-1"}}` + "\n",
 	)
 	actual := []byte(
 		`{"id":10,"method":"turn/start","params":{"clientUserMessageId":"user-submit-2"}}` + "\n",
 	)
-	if _, _, matches := processCassetteJSONMatch(
-		codexReplayDescriptorForCassetteTest(t),
+	descriptor := codexReplayDescriptorForCassetteTest(t)
+	_, learned, matches := processCassetteJSONMatch(
+		descriptor,
 		expected,
 		actual,
 		"",
 		"",
 		"",
 		nil,
+	)
+	if !matches {
+		t.Fatal("ordinary clientUserMessageId runtime identity did not match")
+	}
+	if got := learned["user-submit-1"]; got != "user-submit-2" {
+		t.Fatalf("learned clientUserMessageId = %q, want user-submit-2", got)
+	}
+
+	followupExpected := []byte(
+		`{"id":11,"method":"turn/start","params":{"clientUserMessageId":"user-submit-1"}}` + "\n",
+	)
+	followupActual := []byte(
+		`{"id":12,"method":"turn/start","params":{"clientUserMessageId":"user-submit-2"}}` + "\n",
+	)
+	if _, _, matches := processCassetteJSONMatch(
+		descriptor,
+		followupExpected,
+		followupActual,
+		"",
+		"",
+		"",
+		learned,
+	); !matches {
+		t.Fatal("consistent clientUserMessageId mapping did not match")
+	}
+
+	conflictingActual := bytes.Replace(
+		followupActual,
+		[]byte("user-submit-2"),
+		[]byte("user-submit-3"),
+		1,
+	)
+	if _, _, matches := processCassetteJSONMatch(
+		descriptor,
+		followupExpected,
+		conflictingActual,
+		"",
+		"",
+		"",
+		learned,
 	); matches {
-		t.Fatal("ordinary clientUserMessageId mismatch matched")
+		t.Fatal("conflicting clientUserMessageId mapping matched")
+	}
+
+	mappedInbound := mapProcessCassetteFrameJSON(
+		[]byte(`{"method":"turn/completed","params":{"clientUserMessageId":"user-submit-1"}}`+"\n"),
+		"",
+		"",
+		"",
+		descriptor,
+		learned,
+	)
+	var inboundMessage map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(mappedInbound), &inboundMessage); err != nil {
+		t.Fatal(err)
+	}
+	inboundParams, _ := inboundMessage["params"].(map[string]any)
+	if got := payloadString(inboundParams, "clientUserMessageId"); got != "user-submit-2" {
+		t.Fatalf("mapped inbound clientUserMessageId = %q, want user-submit-2", got)
 	}
 }
 

--- a/packages/agent/daemon/runtime/process_transport_cassette_test.go
+++ b/packages/agent/daemon/runtime/process_transport_cassette_test.go
@@ -686,6 +686,45 @@ func TestReplayProcessTransportMatchesJSONRPCRequestSemanticsAndMapsResponseID(t
 	}
 }
 
+func TestReplayProcessTransportIgnoresVolatileInitializeClientInfo(t *testing.T) {
+	expected := []byte(
+		`{"id":1,"method":"initialize","params":{"clientInfo":{"name":"codex-cli","title":"Codex","version":"0.146.0"},"capabilities":{"experimentalApi":true}}}` + "\n",
+	)
+	actual := []byte(
+		`{"id":7,"method":"initialize","params":{"capabilities":{"experimentalApi":true},"clientInfo":{"name":"codex-cli","title":"TSH","version":"0.146.1"}}}` + "\n",
+	)
+
+	descriptor := codexReplayDescriptorForCassetteTest(t)
+	responseIDs, _, matches := processCassetteJSONMatch(
+		descriptor,
+		expected,
+		actual,
+		"",
+		"",
+		"",
+		nil,
+	)
+	if !matches {
+		t.Fatal("initialize clientInfo version/title drift did not match")
+	}
+	if got := responseIDs["1"]; got != json.Number("7") {
+		t.Fatalf("mapped response id = %#v, want 7", got)
+	}
+
+	changedName := bytes.Replace(actual, []byte(`"name":"codex-cli"`), []byte(`"name":"other-cli"`), 1)
+	if _, _, matches := processCassetteJSONMatch(
+		descriptor,
+		expected,
+		changedName,
+		"",
+		"",
+		"",
+		nil,
+	); matches {
+		t.Fatal("initialize clientInfo.name mismatch matched")
+	}
+}
+
 func TestClaudeSidecarRecordingAndReplayProjectsEnvironmentAndGeneratedIdentities(t *testing.T) {
 	directory := t.TempDir()
 	base := &cassetteTestConnection{received: []ProcessFrame{

--- a/packages/agent/daemon/runtime/process_transport_replay_json.go
+++ b/packages/agent/daemon/runtime/process_transport_replay_json.go
@@ -46,6 +46,8 @@ func processCassetteJSONMatch(
 	}
 	projectProcessCassetteRuntimeGeneratedFields(expectedValues, descriptor)
 	projectProcessCassetteRuntimeGeneratedFields(actualValues, descriptor)
+	projectProcessCassetteVolatileClientInfo(expectedValues)
+	projectProcessCassetteVolatileClientInfo(actualValues)
 	projectProcessCassetteEnvironment(expectedValues, descriptor)
 	projectProcessCassetteEnvironment(actualValues, descriptor)
 	responseIDs := map[string]any{}

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -257,8 +257,11 @@ Interaction, Goal, hierarchy, stable settings state, and the narrow portable
 `providerResumeCheckpoint` required to resume an already-initialized protocol
 boundary. The checkpoint is opaque to Host; full provider runtime context is
 not exported. Restore is for a fresh isolated Workspace before normal Host
-recovery. It is idempotent for identical content, rejects conflicts, and never
-starts or resumes a Provider.
+recovery. `HistoricalSessionGraphRestoreInput` carries the target Workspace and
+required current User outside the portable graph; restore binds every imported Session
+to that runtime-owned identity without serializing it into a Cassette. It is
+idempotent only for identical content and the same target User, rejects graph
+or ownership conflicts, and never starts or resumes a Provider.
 
 Runtime adapters preserve explicit downstream failures as `ProviderError` so
 Host consumers can distinguish provider-owned rejection from preparation,

--- a/packages/agent/host/conformance/historical_state_scenarios.go
+++ b/packages/agent/host/conformance/historical_state_scenarios.go
@@ -22,13 +22,13 @@ type HistoricalStateDriver interface {
 	ResetHistoricalState(context.Context) error
 	RestoreHistoricalSessionGraph(
 		context.Context,
-		string,
-		agenthost.HistoricalSessionGraph,
+		agenthost.HistoricalSessionGraphRestoreInput,
 	) error
 	CaptureHistoricalSessionGraph(
 		context.Context,
 		agenthost.SessionRef,
 	) (agenthost.HistoricalSessionGraph, error)
+	HistoricalSessionUserID(context.Context, agenthost.SessionRef) (string, error)
 	EnsureHistoricalSession(
 		context.Context,
 		agenthost.SessionRef,
@@ -76,7 +76,21 @@ func runRestoreHistoricalSessionGraph(
 	}
 	graph := historicalStateScenarioGraph()
 	const workspaceID = "historical-state-workspace"
-	if err := driver.RestoreHistoricalSessionGraph(ctx, workspaceID, graph); err != nil {
+	const userID = "historical-state-user"
+	restoreInput := agenthost.HistoricalSessionGraphRestoreInput{
+		WorkspaceID: workspaceID,
+		UserID:      userID,
+		Graph:       graph,
+	}
+	missingOwner := restoreInput
+	missingOwner.UserID = ""
+	if err := driver.RestoreHistoricalSessionGraph(
+		ctx,
+		missingOwner,
+	); !errors.Is(err, agenthost.ErrInvalidArgument) {
+		return fmt.Errorf("missing historical owner restore error = %v", err)
+	}
+	if err := driver.RestoreHistoricalSessionGraph(ctx, restoreInput); err != nil {
 		return fmt.Errorf("restore historical graph: %w", err)
 	}
 	if metrics := driver.HistoricalStateMetrics(); metrics.ProviderStartCalls != 0 ||
@@ -92,16 +106,36 @@ func runRestoreHistoricalSessionGraph(
 	if !reflect.DeepEqual(captured, graph) {
 		return fmt.Errorf("restored historical graph differs: %#v", captured)
 	}
-	if err := driver.RestoreHistoricalSessionGraph(ctx, workspaceID, graph); err != nil {
+	boundUserID, err := driver.HistoricalSessionUserID(ctx, agenthost.SessionRef{
+		WorkspaceID: workspaceID, AgentSessionID: graph.RootSessionID,
+	})
+	if err != nil {
+		return fmt.Errorf("read restored historical Session ownership: %w", err)
+	}
+	if boundUserID != userID {
+		return fmt.Errorf("restored historical Session user = %q, want %q", boundUserID, userID)
+	}
+	if err := driver.RestoreHistoricalSessionGraph(ctx, restoreInput); err != nil {
 		return fmt.Errorf("idempotent historical restore: %w", err)
+	}
+	conflictingOwner := restoreInput
+	conflictingOwner.UserID = "different-user"
+	if err := driver.RestoreHistoricalSessionGraph(
+		ctx,
+		conflictingOwner,
+	); !errors.Is(err, agenthost.ErrHistoricalStateConflict) {
+		return fmt.Errorf("conflicting historical owner restore error = %v", err)
 	}
 	conflicting := graph
 	conflicting.Sessions = append([]agenthost.HistoricalSession(nil), graph.Sessions...)
 	conflicting.Sessions[0].Title = "conflicting title"
 	if err := driver.RestoreHistoricalSessionGraph(
 		ctx,
-		workspaceID,
-		conflicting,
+		agenthost.HistoricalSessionGraphRestoreInput{
+			WorkspaceID: workspaceID,
+			UserID:      userID,
+			Graph:       conflicting,
+		},
 	); !errors.Is(err, agenthost.ErrHistoricalStateConflict) {
 		return fmt.Errorf("conflicting historical restore error = %v", err)
 	}

--- a/packages/agent/host/historical_state.go
+++ b/packages/agent/host/historical_state.go
@@ -15,6 +15,7 @@ var (
 )
 
 type HistoricalSessionGraph = storesqlite.HistoricalSessionGraph
+type HistoricalSessionGraphRestoreInput = storesqlite.HistoricalSessionGraphRestoreInput
 type HistoricalSession = storesqlite.HistoricalSession
 type HistoricalTurn = storesqlite.HistoricalTurn
 type HistoricalMessage = storesqlite.HistoricalMessage
@@ -51,20 +52,20 @@ func (h *Host) CaptureHistoricalSessionGraph(
 // Replay Workspace before Host recovery.
 func (h *Host) RestoreHistoricalSessionGraph(
 	ctx context.Context,
-	workspaceID string,
-	graph HistoricalSessionGraph,
+	input HistoricalSessionGraphRestoreInput,
 ) error {
 	if h == nil || h.historicalState == nil {
 		return ErrHistoricalStateUnavailable
 	}
-	workspaceID = strings.TrimSpace(workspaceID)
-	if workspaceID == "" {
+	input.WorkspaceID = strings.TrimSpace(input.WorkspaceID)
+	input.UserID = strings.TrimSpace(input.UserID)
+	if input.WorkspaceID == "" || input.UserID == "" {
 		return ErrInvalidArgument
 	}
-	if err := ValidateHistoricalSessionGraph(graph); err != nil {
+	if err := ValidateHistoricalSessionGraph(input.Graph); err != nil {
 		return err
 	}
-	return h.historicalState.RestoreHistoricalSessionGraph(ctx, workspaceID, graph)
+	return h.historicalState.RestoreHistoricalSessionGraph(ctx, input)
 }
 
 func ValidateHistoricalSessionGraph(graph HistoricalSessionGraph) error {

--- a/packages/agent/host/ports.go
+++ b/packages/agent/host/ports.go
@@ -233,8 +233,7 @@ type HistoricalSessionStateStore interface {
 	) (HistoricalSessionGraph, error)
 	RestoreHistoricalSessionGraph(
 		context.Context,
-		string,
-		HistoricalSessionGraph,
+		HistoricalSessionGraphRestoreInput,
 	) error
 }
 

--- a/packages/agent/session-replay/AGENTS.md
+++ b/packages/agent/session-replay/AGENTS.md
@@ -1,0 +1,37 @@
+# Agent Session Replay
+
+Owns portable Cassette contracts, checkpoint readiness, and final-state
+transport verification for Agent Session Replay.
+
+Read [README.md](README.md) before changing projection, compare, or cassette
+schema rules.
+
+## Composer settings contract
+
+`settings.equal` checkpoint readiness and final-state
+`CompareTuttiReplayState` must share one composer-settings contract:
+
+- require every **recorded** key
+- treat empty defaults (`false`, `""`, `null`) as equivalent to absent
+- ignore live-only extras that current product materializes
+
+Do **not** add per-field `delete(settings, "…")` special cases in compare
+code when Tutti introduces a new default composer setting. Extend the shared
+`composerSettingsEqual` helpers / empty-default rules, or update the portable
+projection if the field is not part of the semantic contract at all.
+
+Explicit non-default recorded values (for example `codexSaverMode: true`)
+remain fail-closed.
+
+## Cassette reuse
+
+| Change                                                                                                  | Action                                                            |
+| ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| New live-only default / omitempty field                                                                 | Fix shared settings contract or projection; keep old cassettes    |
+| Runtime id / wall-clock rematerialization                                                               | Alpha-equivalence or strip volatile fields; keep old cassettes    |
+| Path / cwd / provider-home portability                                                                  | Project to `${REPLAY_CWD}` / `${REPLAY_HOME}`; keep old cassettes |
+| Semantic contract change (turn shape, tool protocol, permission/model meaning, checkpoint schema major) | Re-record affected cassettes                                      |
+
+Default response to `agent_session_replay_transport_mismatch` on settings is
+to align compare/projection with the contract above, not to mass-rewrite
+Cases Console cassettes.

--- a/packages/agent/session-replay/README.md
+++ b/packages/agent/session-replay/README.md
@@ -182,8 +182,9 @@ checkout. A caller may supply an absolute
 run-scoped Git project under the operating-system temporary directory and
 removes it on exit. `--keep-runtime` retains that project for diagnosis.
 Semantic settings readiness compares every recorded composer setting with the
-live canonical value but ignores live-only default fields. A Replay recorded
-before a provider began materializing a new default such as `speed` therefore
-remains valid, while a missing or changed recorded model, reasoning,
-permission, plan, or speed value that is not equivalent to an omitted default
-still fails closed.
+live canonical value but ignores live-only default fields. Final-state
+transport verification uses the same composer-settings contract for
+`Session.settings`, so a Replay recorded before a provider began materializing
+a new default such as `speed` or `codexSaverMode:false` remains valid, while a
+missing or changed recorded model, reasoning, permission, plan, or non-default
+speed / saver value still fails closed.

--- a/packages/agent/session-replay/README.md
+++ b/packages/agent/session-replay/README.md
@@ -166,8 +166,16 @@ published Cassette. Active recordings must be canceled before deletion.
 The daemon creates a fresh Tutti `WorkspaceID` for every Replay Workspace,
 validates and merges all semantic initial states before mutation, restores
 canonical Agent history through Host before normal recovery, and verifies the
-semantic expected state. The JavaScript runner injects the transient identity
-only into product Activity Event envelopes.
+semantic expected state. Runtime registrations carry the current `UserID`
+beside the Workspace target; Host binds it during restore, while the portable
+Agent graph remains user-independent. Every batch declares one semantic
+profile. Tutti uses the full Agent, Tutti Mode, Workflow, and Issue profile;
+consumers that implement only Agent semantics use the Agent profile. A
+Cassette that contains state from an unsupported domain fails before restore,
+and actual state is checked against the same profile during verification.
+Product composition supplies a non-empty target User through runtime registration; the
+JavaScript runner injects the replay-created Workspace identity only into
+product Activity Event envelopes.
 The runner also binds every scenario to one user-project root outside the Tutti
 checkout. A caller may supply an absolute
 `TUTTI_AGENT_SESSION_REPLAY_PROJECT_ROOT`; otherwise the direct CLI creates a

--- a/packages/agent/session-replay/provider_descriptor.go
+++ b/packages/agent/session-replay/provider_descriptor.go
@@ -97,6 +97,9 @@ var providerReplayDescriptors = []ProviderReplayDescriptor{
 				ValuePrefix:   "plan-decision:",
 				PortableValue: "plan-decision:<runtime-operation>",
 			}},
+			GeneratedIdentityFields: []string{
+				"clientUserMessageId",
+			},
 		},
 		PortableRuntime: ProviderPortableRuntimeDescriptor{
 			HomeEnvVars:          []string{"CODEX_HOME"},

--- a/packages/agent/session-replay/provider_descriptor_test.go
+++ b/packages/agent/session-replay/provider_descriptor_test.go
@@ -19,6 +19,7 @@ func TestCodexProviderReplayDescriptorDeclaresCompleteAdapter(t *testing.T) {
 		) ||
 		!descriptor.MethodCarriesCredentials("account/login/start") ||
 		!descriptor.IsOptionalProbeMethod("thread/read") ||
+		!descriptor.IsGeneratedIdentityField("clientUserMessageId") ||
 		!descriptor.IsHomeEnvVar("codex_home") ||
 		descriptor.PortableRuntime.SessionHomeDirectory != "codex-home" {
 		t.Fatalf("Codex replay descriptor = %#v", descriptor)

--- a/packages/agent/session-replay/replay_semantic_profile.go
+++ b/packages/agent/session-replay/replay_semantic_profile.go
@@ -1,0 +1,159 @@
+package sessionreplay
+
+import (
+	"errors"
+	"fmt"
+)
+
+var ErrUnsupportedReplaySemanticDomain = errors.New(
+	"replay state requires an unsupported semantic domain",
+)
+
+type SemanticProfile struct {
+	Agent     bool
+	TuttiMode bool
+	Workflows bool
+	Issues    bool
+}
+
+func TuttiSemanticProfile() SemanticProfile {
+	return SemanticProfile{
+		Agent: true, TuttiMode: true, Workflows: true, Issues: true,
+	}
+}
+
+func AgentSemanticProfile() SemanticProfile {
+	return SemanticProfile{Agent: true}
+}
+
+type UnsupportedReplaySemanticDomainError struct {
+	Domain string
+	Path   string
+}
+
+func (e *UnsupportedReplaySemanticDomainError) Error() string {
+	return fmt.Sprintf(
+		"%s: %s at %s",
+		ErrUnsupportedReplaySemanticDomain,
+		e.Domain,
+		e.Path,
+	)
+}
+
+func (*UnsupportedReplaySemanticDomainError) Unwrap() error {
+	return ErrUnsupportedReplaySemanticDomain
+}
+
+func ValidateTuttiReplayStateForProfile(
+	state TuttiReplayState,
+	profile SemanticProfile,
+) error {
+	if err := validateSemanticProfile(profile); err != nil {
+		return err
+	}
+	if err := ValidateTuttiReplayState(state); err != nil {
+		return err
+	}
+	if !profile.TuttiMode {
+		if len(state.TuttiMode.Activations) != 0 {
+			return unsupportedReplaySemanticDomain("tuttiMode", "$.tuttiMode.activations")
+		}
+		for _, snapshot := range state.TuttiMode.TurnSnapshots {
+			if !isUnconfiguredTuttiModeTurnSnapshot(snapshot) {
+				return unsupportedReplaySemanticDomain("tuttiMode", "$.tuttiMode.turnSnapshots")
+			}
+		}
+	}
+	if !profile.Workflows && len(state.Workflows) != 0 {
+		return unsupportedReplaySemanticDomain("workflows", "$.workflows")
+	}
+	if !profile.Issues {
+		if len(state.Issues) != 0 {
+			return unsupportedReplaySemanticDomain("issues", "$.issues")
+		}
+		for index, workflow := range state.Workflows {
+			if len(workflow.IssueIDs) != 0 {
+				return unsupportedReplaySemanticDomain(
+					"issues",
+					fmt.Sprintf("$.workflows[%d].issueIds", index),
+				)
+			}
+		}
+	}
+	return nil
+}
+
+func MergeTuttiReplayStatesForProfile(
+	states []TuttiReplayState,
+	profile SemanticProfile,
+) (TuttiReplayMergedState, error) {
+	if err := validateSemanticProfile(profile); err != nil {
+		return TuttiReplayMergedState{}, err
+	}
+	profileStates := make([]TuttiReplayState, len(states))
+	for index, state := range states {
+		if err := ValidateTuttiReplayStateForProfile(state, profile); err != nil {
+			return TuttiReplayMergedState{}, err
+		}
+		profileStates[index] = projectTuttiReplayStateForProfile(state, profile)
+	}
+	return MergeTuttiReplayStates(profileStates)
+}
+
+func CompareTuttiReplayStateForProfile(
+	expected TuttiReplayState,
+	actual TuttiReplayState,
+	profile SemanticProfile,
+) error {
+	if err := ValidateTuttiReplayStateForProfile(expected, profile); err != nil {
+		return fmt.Errorf("invalid expected Tutti Replay State: %w", err)
+	}
+	if err := ValidateTuttiReplayStateForProfile(actual, profile); err != nil {
+		return fmt.Errorf("invalid actual Tutti Replay State: %w", err)
+	}
+	return CompareTuttiReplayState(
+		projectTuttiReplayStateForProfile(expected, profile),
+		projectTuttiReplayStateForProfile(actual, profile),
+	)
+}
+
+func projectTuttiReplayStateForProfile(
+	state TuttiReplayState,
+	profile SemanticProfile,
+) TuttiReplayState {
+	if profile.TuttiMode {
+		return state
+	}
+	state.TuttiMode.TurnSnapshots = []TuttiReplayTurnSnapshot{}
+	return state
+}
+
+// Tutti records one turn snapshot before dispatch even when Tutti Mode is not
+// configured for the Session. That row only proves the absence of Tutti Mode;
+// it does not require a consumer to own Tutti Mode product state.
+func isUnconfiguredTuttiModeTurnSnapshot(
+	snapshot TuttiReplayTurnSnapshot,
+) bool {
+	return snapshot.ActivationID == "" &&
+		snapshot.RevisionID == "" &&
+		snapshot.Revision == 0 &&
+		snapshot.State == "inactive" &&
+		snapshot.Source == "" &&
+		snapshot.PreferenceVersion == 0 &&
+		snapshot.Effect == 0 &&
+		snapshot.Speed == 0
+}
+
+func validateSemanticProfile(profile SemanticProfile) error {
+	if !profile.Agent {
+		return errors.New("replay semantic profile must support the Agent domain")
+	}
+	return nil
+}
+
+func unsupportedReplaySemanticDomain(
+	domain string,
+	path string,
+) error {
+	return &UnsupportedReplaySemanticDomainError{Domain: domain, Path: path}
+}

--- a/packages/agent/session-replay/replay_semantic_profile_test.go
+++ b/packages/agent/session-replay/replay_semantic_profile_test.go
@@ -1,0 +1,143 @@
+package sessionreplay
+
+import (
+	"errors"
+	"testing"
+
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
+)
+
+func TestAgentSemanticProfileRejectsUnsupportedProductDomains(t *testing.T) {
+	state := agentOnlyReplayState()
+	if err := ValidateTuttiReplayStateForProfile(state, AgentSemanticProfile()); err != nil {
+		t.Fatalf("Agent-only state error = %v", err)
+	}
+
+	withInactiveTuttiMode := state
+	withInactiveTuttiMode.TuttiMode.TurnSnapshots = []TuttiReplayTurnSnapshot{{
+		SessionID: "session-root", TurnID: "turn-1", State: "inactive",
+		DispatchState: "accepted",
+	}}
+	if err := ValidateTuttiReplayStateForProfile(
+		withInactiveTuttiMode,
+		AgentSemanticProfile(),
+	); err != nil {
+		t.Fatalf("inactive Tutti Mode snapshot error = %v", err)
+	}
+
+	withConfiguredTuttiMode := state
+	withConfiguredTuttiMode.TuttiMode.TurnSnapshots = []TuttiReplayTurnSnapshot{{
+		SessionID: "session-root", TurnID: "turn-1",
+		ActivationID: "activation-1", RevisionID: "revision-1", Revision: 1,
+		State: "inactive", Source: "badge_remove", PreferenceVersion: 1,
+		DispatchState: "accepted",
+	}}
+	if err := ValidateTuttiReplayStateForProfile(
+		withConfiguredTuttiMode,
+		AgentSemanticProfile(),
+	); !errors.Is(err, ErrUnsupportedReplaySemanticDomain) {
+		t.Fatalf("configured Tutti Mode dependency error = %v", err)
+	}
+
+	withWorkflow := state
+	withWorkflow.Workflows = []TuttiReplayWorkflow{{
+		ID: "workflow-1", IssueIDs: []string{},
+	}}
+	if err := ValidateTuttiReplayStateForProfile(
+		withWorkflow,
+		AgentSemanticProfile(),
+	); !errors.Is(err, ErrUnsupportedReplaySemanticDomain) {
+		t.Fatalf("Workflow dependency error = %v", err)
+	}
+	if err := ValidateTuttiReplayStateForProfile(
+		withWorkflow,
+		TuttiSemanticProfile(),
+	); err != nil {
+		t.Fatalf("Tutti profile rejected Workflow state: %v", err)
+	}
+}
+
+func TestAgentSemanticProfileIgnoresInactiveTuttiModeSnapshots(t *testing.T) {
+	withInactiveSnapshot := agentOnlyReplayState()
+	withInactiveSnapshot.TuttiMode.TurnSnapshots = []TuttiReplayTurnSnapshot{{
+		SessionID: "session-root", TurnID: "turn-1", State: "inactive",
+		DispatchState: "accepted",
+	}}
+
+	merged, err := MergeTuttiReplayStatesForProfile(
+		[]TuttiReplayState{withInactiveSnapshot},
+		AgentSemanticProfile(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(merged.TuttiMode.TurnSnapshots) != 0 {
+		t.Fatalf("merged inactive Tutti Mode snapshots = %#v", merged.TuttiMode.TurnSnapshots)
+	}
+
+	if err := CompareTuttiReplayStateForProfile(
+		withInactiveSnapshot,
+		agentOnlyReplayState(),
+		AgentSemanticProfile(),
+	); err != nil {
+		t.Fatalf("compare inactive Tutti Mode snapshot error = %v", err)
+	}
+
+	tuttiMerged, err := MergeTuttiReplayStatesForProfile(
+		[]TuttiReplayState{withInactiveSnapshot},
+		TuttiSemanticProfile(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tuttiMerged.TuttiMode.TurnSnapshots) != 1 {
+		t.Fatalf("Tutti profile snapshots = %#v", tuttiMerged.TuttiMode.TurnSnapshots)
+	}
+	if err := CompareTuttiReplayStateForProfile(
+		withInactiveSnapshot,
+		agentOnlyReplayState(),
+		TuttiSemanticProfile(),
+	); !errors.Is(err, ErrTuttiReplayStateConflict) {
+		t.Fatalf("Tutti profile snapshot mismatch error = %v", err)
+	}
+}
+
+func TestSemanticProfileFailsFastOnIndirectIssueDependency(t *testing.T) {
+	state := agentOnlyReplayState()
+	state.Workflows = []TuttiReplayWorkflow{{
+		ID: "workflow-1", IssueIDs: []string{"issue-1"},
+	}}
+	profile := SemanticProfile{Agent: true, Workflows: true}
+	err := ValidateTuttiReplayStateForProfile(state, profile)
+	if !errors.Is(err, ErrUnsupportedReplaySemanticDomain) {
+		t.Fatalf("indirect Issue dependency error = %v", err)
+	}
+	var unsupported *UnsupportedReplaySemanticDomainError
+	if !errors.As(err, &unsupported) || unsupported.Domain != "issues" {
+		t.Fatalf("unsupported domain error = %#v", err)
+	}
+}
+
+func agentOnlyReplayState() TuttiReplayState {
+	return TuttiReplayState{
+		SchemaVersion: SchemaVersion,
+		Agent: agenthost.HistoricalSessionGraph{
+			RootSessionID: "session-root",
+			Sessions: []agenthost.HistoricalSession{{
+				ID: "session-root", Kind: "root",
+				AgentTargetID: "local:codex", Provider: "codex",
+				ProviderSessionID: "provider-session-root",
+				Settings:          map[string]any{},
+				Turns:             []agenthost.HistoricalTurn{},
+				Messages:          []agenthost.HistoricalMessage{},
+				Interactions:      []agenthost.HistoricalInteraction{},
+			}},
+		},
+		TuttiMode: TuttiReplayTuttiMode{
+			Activations:   []TuttiReplayActivation{},
+			TurnSnapshots: []TuttiReplayTurnSnapshot{},
+		},
+		Workflows: []TuttiReplayWorkflow{},
+		Issues:    []TuttiReplayIssue{},
+	}
+}

--- a/packages/agent/session-replay/replay_semantic_readiness.go
+++ b/packages/agent/session-replay/replay_semantic_readiness.go
@@ -301,6 +301,9 @@ func projectBindingMatches(
 }
 
 func composerSettingsEqual(actual, expected map[string]any) bool {
+	// Shared by settings.equal readiness and final-state transport compare:
+	// require every recorded key, treat empty defaults as absent, and ignore
+	// live-only extras so older cassettes survive new default composer fields.
 	if len(expected) == 0 {
 		return true
 	}

--- a/packages/agent/session-replay/replay_semantic_readiness_settings_test.go
+++ b/packages/agent/session-replay/replay_semantic_readiness_settings_test.go
@@ -12,6 +12,7 @@ func TestComposerSettingsEqualIgnoresLiveOnlyDefaults(t *testing.T) {
 	}
 	actual := map[string]any{
 		"codexSaverMode":   false,
+		"futureDefaultOff": false,
 		"model":            "haiku",
 		"permissionModeId": "default",
 		"planMode":         false,
@@ -19,7 +20,7 @@ func TestComposerSettingsEqualIgnoresLiveOnlyDefaults(t *testing.T) {
 		"speed":            "standard",
 	}
 	if !composerSettingsEqual(actual, expected) {
-		t.Fatal("live-only speed default must not fail settings.equal")
+		t.Fatal("live-only defaults must not fail settings.equal")
 	}
 	actual["reasoningEffort"] = "medium"
 	if composerSettingsEqual(actual, expected) {

--- a/packages/agent/session-replay/replay_semantic_runtime.go
+++ b/packages/agent/session-replay/replay_semantic_runtime.go
@@ -14,9 +14,13 @@ import (
 )
 
 type SemanticRegistration struct {
-	CassetteID          string
-	RootSessionID       string
-	WorkspaceID         string
+	CassetteID    string
+	RootSessionID string
+	WorkspaceID   string
+	// UserID is a runtime-owned authorization binding. It is never read from or
+	// written to a portable Cassette.
+	UserID              string
+	Profile             SemanticProfile
 	AgentTargetRewrites map[string]string
 }
 
@@ -47,6 +51,7 @@ type SemanticRuntime struct {
 	host          *agenthost.Host
 	store         SemanticWorkspaceStore
 	workspaceID   string
+	profile       SemanticProfile
 	registrations map[string]SemanticRegistration
 	plans         map[string]CheckpointPlan
 	expected      map[string]TuttiReplayState
@@ -87,6 +92,10 @@ func PrepareSemanticRuntime(
 		map[string]*semanticObservationState,
 		len(registrations),
 	)
+	workspaceID, runtimeUserID, profile, err := resolveSemanticRuntimeTarget(registrations)
+	if err != nil {
+		return nil, err
+	}
 	// The replay runner resolves portable `${REPLAY_CWD}` activity payloads
 	// against the repository workspace root and passes the same anchor through
 	// TUTTI_AGENT_SESSION_REPLAY_CWD. The daemon process cwd is only a
@@ -103,11 +112,11 @@ func PrepareSemanticRuntime(
 		}
 	}
 	initialStates := make([]TuttiReplayState, 0, len(registrations))
-	workspaceID := ""
 	for _, registration := range registrations {
 		registration.CassetteID = strings.TrimSpace(registration.CassetteID)
 		registration.RootSessionID = strings.TrimSpace(registration.RootSessionID)
 		registration.WorkspaceID = strings.TrimSpace(registration.WorkspaceID)
+		registration.UserID = strings.TrimSpace(registration.UserID)
 		if registration.CassetteID == "" || registration.RootSessionID == "" ||
 			registration.WorkspaceID == "" {
 			return nil, errors.New(
@@ -125,11 +134,6 @@ func PrepareSemanticRuntime(
 			)
 		}
 		registration.AgentTargetRewrites = normalizedTargetRewrites
-		if workspaceID == "" {
-			workspaceID = registration.WorkspaceID
-		} else if workspaceID != registration.WorkspaceID {
-			return nil, errors.New("agent session replay registrations must share one Workspace")
-		}
 		if _, duplicate := byID[registration.CassetteID]; duplicate {
 			return nil, fmt.Errorf("duplicate Agent Session Replay cassette %q", registration.CassetteID)
 		}
@@ -138,6 +142,22 @@ func PrepareSemanticRuntime(
 			return nil, fmt.Errorf("load Replay Cassette %q: %w", registration.CassetteID, err)
 		}
 		manifest := artifact.Manifest
+		if artifact.InitialState != nil {
+			if err := ValidateTuttiReplayStateForProfile(*artifact.InitialState, profile); err != nil {
+				return nil, fmt.Errorf(
+					"Replay Cassette %q initial state profile: %w",
+					registration.CassetteID,
+					err,
+				)
+			}
+		}
+		if err := ValidateTuttiReplayStateForProfile(artifact.ExpectedState, profile); err != nil {
+			return nil, fmt.Errorf(
+				"Replay Cassette %q expected state profile: %w",
+				registration.CassetteID,
+				err,
+			)
+		}
 		if manifest.ID != registration.CassetteID ||
 			manifest.RootSessionID != registration.RootSessionID {
 			return nil, fmt.Errorf(
@@ -214,7 +234,7 @@ func PrepareSemanticRuntime(
 		}
 		observationStates[registration.CassetteID] = observationState
 	}
-	merged, err := MergeTuttiReplayStates(initialStates)
+	merged, err := MergeTuttiReplayStatesForProfile(initialStates, profile)
 	if err != nil {
 		return nil, fmt.Errorf("merge Agent Session Replay initial states: %w", err)
 	}
@@ -249,7 +269,14 @@ func PrepareSemanticRuntime(
 		return nil, fmt.Errorf("initialize Agent Session Replay Workbench: %w", err)
 	}
 	for _, graph := range merged.Agents {
-		if err := host.RestoreHistoricalSessionGraph(ctx, workspaceID, graph); err != nil {
+		if err := host.RestoreHistoricalSessionGraph(
+			ctx,
+			agenthost.HistoricalSessionGraphRestoreInput{
+				WorkspaceID: workspaceID,
+				UserID:      runtimeUserID,
+				Graph:       graph,
+			},
+		); err != nil {
 			return nil, fmt.Errorf(
 				"restore Agent Session Replay root %q: %w",
 				graph.RootSessionID,
@@ -261,10 +288,58 @@ func PrepareSemanticRuntime(
 		return nil, err
 	}
 	return &SemanticRuntime{
-		host: host, store: store, workspaceID: workspaceID, registrations: byID,
-		plans: plans, expected: expectedStates,
+		host: host, store: store, workspaceID: workspaceID, profile: profile,
+		registrations: byID,
+		plans:         plans, expected: expectedStates,
 		expectedBindings: expectedBindings, observations: observationStates,
 	}, nil
+}
+
+func resolveSemanticRuntimeTarget(
+	registrations []SemanticRegistration,
+) (string, string, SemanticProfile, error) {
+	workspaceID := ""
+	userID := ""
+	profile := SemanticProfile{}
+	for index, registration := range registrations {
+		registrationWorkspaceID := strings.TrimSpace(registration.WorkspaceID)
+		registrationUserID := strings.TrimSpace(registration.UserID)
+		if registrationWorkspaceID == "" {
+			return "", "", SemanticProfile{}, errors.New(
+				"agent session replay registration requires a Workspace",
+			)
+		}
+		if registrationUserID == "" {
+			return "", "", SemanticProfile{}, errors.New(
+				"agent session replay registration requires a runtime user",
+			)
+		}
+		if err := validateSemanticProfile(registration.Profile); err != nil {
+			return "", "", SemanticProfile{}, err
+		}
+		if index == 0 {
+			workspaceID = registrationWorkspaceID
+			userID = registrationUserID
+			profile = registration.Profile
+			continue
+		}
+		if workspaceID != registrationWorkspaceID {
+			return "", "", SemanticProfile{}, errors.New(
+				"agent session replay registrations must share one Workspace",
+			)
+		}
+		if userID != registrationUserID {
+			return "", "", SemanticProfile{}, errors.New(
+				"agent session replay registrations must share one runtime user",
+			)
+		}
+		if profile != registration.Profile {
+			return "", "", SemanticProfile{}, errors.New(
+				"agent session replay registrations must share one semantic profile",
+			)
+		}
+	}
+	return workspaceID, userID, profile, nil
 }
 
 func replayWorkbenchSnapshot(
@@ -327,5 +402,5 @@ func (r *SemanticRuntime) Verify(
 	if err != nil {
 		return err
 	}
-	return CompareTuttiReplayState(expected, actual)
+	return CompareTuttiReplayStateForProfile(expected, actual, r.profile)
 }

--- a/packages/agent/session-replay/replay_semantic_runtime_target_test.go
+++ b/packages/agent/session-replay/replay_semantic_runtime_target_test.go
@@ -1,0 +1,29 @@
+package sessionreplay
+
+import "testing"
+
+func TestResolveSemanticRuntimeTargetBindsOneTransientUserPerWorkspace(t *testing.T) {
+	profile := AgentSemanticProfile()
+	workspaceID, userID, resolvedProfile, err := resolveSemanticRuntimeTarget([]SemanticRegistration{
+		{WorkspaceID: " workspace-1 ", UserID: " user-1 ", Profile: profile},
+		{WorkspaceID: "workspace-1", UserID: "user-1", Profile: profile},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if workspaceID != "workspace-1" || userID != "user-1" || resolvedProfile != profile {
+		t.Fatalf("runtime target = (%q, %q, %#v)", workspaceID, userID, resolvedProfile)
+	}
+	if _, _, _, err := resolveSemanticRuntimeTarget([]SemanticRegistration{
+		{WorkspaceID: "workspace-1", UserID: "user-1", Profile: profile},
+		{WorkspaceID: "workspace-1", UserID: "user-2", Profile: profile},
+	}); err == nil {
+		t.Fatal("mixed runtime users were accepted")
+	}
+	if _, _, _, err := resolveSemanticRuntimeTarget([]SemanticRegistration{{
+		WorkspaceID: "workspace-1",
+		Profile:     profile,
+	}}); err == nil {
+		t.Fatal("missing runtime user was accepted")
+	}
+}

--- a/packages/agent/session-replay/replay_state_compare.go
+++ b/packages/agent/session-replay/replay_state_compare.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strings"
 )
 
 // normalizeReplayStateForComparison preserves relationships while replacing
@@ -147,6 +148,20 @@ func replaceReplayIDs(value any, replacements map[string]string) {
 func firstReplayStateMismatch(path string, expected, actual any) string {
 	expectedValue := replayComparableValue(expected)
 	actualValue := replayComparableValue(actual)
+	if isComposerSettingsPath(path) {
+		expectedSettings, expectedOK := expectedValue.(map[string]any)
+		actualSettings, actualOK := actualValue.(map[string]any)
+		if !expectedOK {
+			expectedSettings = nil
+		}
+		if !actualOK {
+			actualSettings = nil
+		}
+		if composerSettingsEqual(actualSettings, expectedSettings) {
+			return ""
+		}
+		return firstComposerSettingsMismatch(path, expectedSettings, actualSettings)
+	}
 	if expectedValue == nil || actualValue == nil {
 		if expectedValue == nil && actualValue == nil {
 			return ""
@@ -197,6 +212,40 @@ func firstReplayStateMismatch(path string, expected, actual any) string {
 		}
 	}
 	return ""
+}
+
+// isComposerSettingsPath detects Session.settings objects so final-state
+// compare can share settings.equal semantics instead of strict key equality.
+func isComposerSettingsPath(path string) bool {
+	return strings.HasSuffix(path, ".settings") &&
+		strings.Contains(path, ".sessions[")
+}
+
+// firstComposerSettingsMismatch reports the first recorded composer setting
+// that fails the shared empty-default / live-extra contract.
+func firstComposerSettingsMismatch(
+	path string,
+	expected, actual map[string]any,
+) string {
+	keys := make([]string, 0, len(expected))
+	for key := range expected {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		expectedValue := expected[key]
+		actualValue, ok := actual[key]
+		if !ok {
+			if composerSettingsValueEmpty(expectedValue) {
+				continue
+			}
+			return path + "." + key
+		}
+		if !composerSettingsValueEqual(actualValue, expectedValue) {
+			return path + "." + key
+		}
+	}
+	return path
 }
 
 func replayComparableValue(value any) any {

--- a/packages/agent/session-replay/replay_state_domain_test.go
+++ b/packages/agent/session-replay/replay_state_domain_test.go
@@ -627,6 +627,79 @@ func TestCompareTuttiReplayStateTreatsAttachmentIDsAsAlphaEquivalent(
 	}
 }
 
+func TestCompareTuttiReplayStateIgnoresLiveOnlyComposerSettingsDefaults(
+	t *testing.T,
+) {
+	buildState := func(settings map[string]any) TuttiReplayState {
+		return TuttiReplayState{
+			SchemaVersion: SchemaVersion,
+			Agent: TuttiReplayAgent{
+				RootSessionID: "session-1",
+				Sessions: []agenthost.HistoricalSession{{
+					ID:                "session-1",
+					Kind:              "root",
+					AgentTargetID:     "local:codex",
+					Provider:          "codex",
+					ProviderSessionID: "provider-session-1",
+					Settings:          settings,
+				}},
+			},
+			TuttiMode: TuttiReplayTuttiMode{
+				Activations:   []TuttiReplayActivation{},
+				TurnSnapshots: []TuttiReplayTurnSnapshot{},
+			},
+			Workflows: []TuttiReplayWorkflow{},
+			Issues:    []TuttiReplayIssue{},
+		}
+	}
+
+	expected := buildState(map[string]any{
+		"model":            "gpt-5.3-codex-spark",
+		"permissionModeId": "read-only",
+		"planMode":         false,
+		"reasoningEffort":  "medium",
+	})
+	actual := buildState(map[string]any{
+		"codexSaverMode":   false,
+		"futureDefaultOff": false,
+		"model":            "gpt-5.3-codex-spark",
+		"permissionModeId": "read-only",
+		"planMode":         false,
+		"reasoningEffort":  "medium",
+		"speed":            "standard",
+	})
+	if err := CompareTuttiReplayState(expected, actual); err != nil {
+		t.Fatalf(
+			"live-only composer defaults must match recorded settings, got %v",
+			err,
+		)
+	}
+	if !composerSettingsEqual(actual.Agent.Sessions[0].Settings, expected.Agent.Sessions[0].Settings) {
+		t.Fatal("final compare and settings.equal must share composer contract")
+	}
+
+	err := CompareTuttiReplayState(
+		buildState(map[string]any{
+			"codexSaverMode": true,
+			"model":          "gpt-5.3-codex-spark",
+		}),
+		buildState(map[string]any{
+			"codexSaverMode": false,
+			"model":          "gpt-5.3-codex-spark",
+		}),
+	)
+	if err == nil {
+		t.Fatal("explicit non-default composer setting must still fail compare")
+	}
+	var conflict *TuttiReplayStateConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("expected TuttiReplayStateConflictError, got %v", err)
+	}
+	if conflict.Path != "$.agent.sessions[0].settings.codexSaverMode" {
+		t.Fatalf("conflict path = %q", conflict.Path)
+	}
+}
+
 func TestCompareTuttiReplayStateIgnoresVolatileGoalTimingFields(
 	t *testing.T,
 ) {

--- a/packages/agent/store-sqlite/child_sessions_test.go
+++ b/packages/agent/store-sqlite/child_sessions_test.go
@@ -133,7 +133,11 @@ func TestChildSessionReportReturnsCanonicalRelations(t *testing.T) {
 	if len(graph.Sessions) != 5 {
 		t.Fatalf("captured Sessions=%#v", graph.Sessions)
 	}
-	if err := store.RestoreHistoricalSessionGraph(ctx, "ws-restore", graph); err != nil {
+	if err := store.RestoreHistoricalSessionGraph(ctx, HistoricalSessionGraphRestoreInput{
+		WorkspaceID: "ws-restore",
+		UserID:      "user-restore",
+		Graph:       graph,
+	}); err != nil {
 		t.Fatal(err)
 	}
 	restored, err := store.ListChildSessions(ctx, "ws-restore", "root")

--- a/packages/agent/store-sqlite/historical_state.go
+++ b/packages/agent/store-sqlite/historical_state.go
@@ -11,6 +11,16 @@ type HistoricalSessionGraph struct {
 	Sessions      []HistoricalSession `json:"sessions"`
 }
 
+// HistoricalSessionGraphRestoreInput binds portable historical state to one
+// runtime-owned Workspace and user. WorkspaceID and UserID are deliberately
+// outside HistoricalSessionGraph so cassette artifacts remain product-neutral
+// and do not persist the identity of the user that recorded them.
+type HistoricalSessionGraphRestoreInput struct {
+	WorkspaceID string
+	UserID      string
+	Graph       HistoricalSessionGraph
+}
+
 type HistoricalSession struct {
 	ID                       string                  `json:"id"`
 	Kind                     string                  `json:"kind,omitempty"`

--- a/packages/agent/store-sqlite/historical_state_restore.go
+++ b/packages/agent/store-sqlite/historical_state_restore.go
@@ -19,21 +19,34 @@ import (
 // semantic content.
 func (s *Store) RestoreHistoricalSessionGraph(
 	ctx context.Context,
-	workspaceID string,
-	graph HistoricalSessionGraph,
+	input HistoricalSessionGraphRestoreInput,
 ) error {
 	if s == nil || s.db == nil {
 		return errors.New("workspace database is not initialized")
 	}
-	workspaceID = strings.TrimSpace(workspaceID)
-	if workspaceID == "" {
-		return errors.New("workspace and root Agent Session ids are required")
+	workspaceID := strings.TrimSpace(input.WorkspaceID)
+	userID := strings.TrimSpace(input.UserID)
+	graph := input.Graph
+	if workspaceID == "" || userID == "" {
+		return errors.New("workspace, user, and root Agent Session ids are required")
 	}
 	existing, err := s.historicalReplayGraphExists(ctx, workspaceID, graph)
 	if err != nil {
 		return err
 	}
 	if existing {
+		matches, err := s.historicalReplayUserBindingMatches(
+			ctx,
+			workspaceID,
+			graph,
+			userID,
+		)
+		if err != nil {
+			return err
+		}
+		if !matches {
+			return ErrHistoricalStateConflict
+		}
 		captured, err := s.CaptureHistoricalSessionGraph(ctx, workspaceID, graph.RootSessionID)
 		if err != nil {
 			return err
@@ -59,7 +72,7 @@ func (s *Store) RestoreHistoricalSessionGraph(
 		return err
 	}
 	for _, session := range ordered {
-		if err := restoreHistoricalSession(ctx, tx, workspaceID, session, now); err != nil {
+		if err := restoreHistoricalSession(ctx, tx, workspaceID, userID, session, now); err != nil {
 			return err
 		}
 	}
@@ -90,6 +103,30 @@ WHERE workspace_id = ? AND agent_session_id = ?
 		return fmt.Errorf("commit historical Agent state restore: %w", err)
 	}
 	return nil
+}
+
+func (s *Store) historicalReplayUserBindingMatches(
+	ctx context.Context,
+	workspaceID string,
+	graph HistoricalSessionGraph,
+	userID string,
+) (bool, error) {
+	ids := make([]string, 0, len(graph.Sessions))
+	for _, session := range graph.Sessions {
+		ids = append(ids, session.ID)
+	}
+	placeholders, args := historicalIdentityArgs(workspaceID, ids)
+	args = append(args, userID)
+	var mismatches int
+	if err := s.db.QueryRowContext(ctx, `
+SELECT COUNT(*)
+FROM workspace_agent_sessions
+WHERE workspace_id = ? AND agent_session_id IN (`+placeholders+`)
+  AND user_id <> ?
+`, args...).Scan(&mismatches); err != nil {
+		return false, err
+	}
+	return mismatches == 0, nil
 }
 
 func (s *Store) historicalReplayGraphExists(
@@ -179,6 +216,7 @@ func restoreHistoricalSession(
 	ctx context.Context,
 	tx *sql.Tx,
 	workspaceID string,
+	userID string,
 	session HistoricalSession,
 	now int64,
 ) error {
@@ -226,11 +264,11 @@ INSERT INTO workspace_agent_sessions (
   pinned_at_unix_ms, deleted_at_unix_ms, created_at_unix_ms, updated_at_unix_ms,
   active_turn_id
 ) VALUES (?, ?, ?, NULLIF(?, ''), NULLIF(?, ''), NULLIF(?, ''),
-          NULLIF(?, ''), NULLIF(?, ''), ?, '', ?, ?, ?, ?, ?, ?, ?, ?,
+          NULLIF(?, ''), NULLIF(?, ''), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
           ?, ?, ?, ?, 0, ?, 0, 0, ?, 0, ?, ?, NULL)
 `, workspaceID, session.ID, session.Kind, session.RootSessionID,
 		session.RootTurnID, session.ParentSessionID, session.ParentTurnID,
-		session.ParentToolCallID, session.Origin, session.AgentTargetID,
+		session.ParentToolCallID, session.Origin, userID, session.AgentTargetID,
 		session.Provider, session.ProviderSessionID, session.Model, string(settingsJSON),
 		metadataJSON, internalRuntimeContextJSON, session.Cwd,
 		railSectionKind, railProjectPath, railSectionKey,

--- a/packages/agent/store-sqlite/historical_state_restore_test.go
+++ b/packages/agent/store-sqlite/historical_state_restore_test.go
@@ -1,0 +1,63 @@
+package storesqlite
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRestoreHistoricalSessionGraphBindsRuntimeUserOutsidePortableGraph(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	ctx := context.Background()
+	graph := HistoricalSessionGraph{
+		RootSessionID: "session-root",
+		Sessions: []HistoricalSession{{
+			ID: "session-root", Kind: SessionKindRoot,
+			AgentTargetID: "local:codex", Provider: "codex",
+			ProviderSessionID: "provider-session-root",
+			Settings:          map[string]any{},
+			RailSectionKind:   RailSectionKindConversations,
+			RailSectionKey:    RailSectionKeyConversations,
+			Turns:             []HistoricalTurn{},
+			Messages:          []HistoricalMessage{},
+			Interactions:      []HistoricalInteraction{},
+		}},
+	}
+	input := HistoricalSessionGraphRestoreInput{
+		WorkspaceID: " workspace-replay ",
+		UserID:      " user-current ",
+		Graph:       graph,
+	}
+	missingOwner := input
+	missingOwner.UserID = ""
+	if err := store.RestoreHistoricalSessionGraph(ctx, missingOwner); err == nil {
+		t.Fatal("historical restore without a runtime user was accepted")
+	}
+	if err := store.RestoreHistoricalSessionGraph(ctx, input); err != nil {
+		t.Fatal(err)
+	}
+	session, found, err := store.GetSession(ctx, "workspace-replay", graph.RootSessionID)
+	if err != nil || !found {
+		t.Fatalf("GetSession() found=%v err=%v", found, err)
+	}
+	if session.UserID != "user-current" {
+		t.Fatalf("restored Session user = %q, want user-current", session.UserID)
+	}
+	raw, err := json.Marshal(graph)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "user-current") || strings.Contains(string(raw), "userId") {
+		t.Fatalf("portable historical graph contains runtime user binding: %s", raw)
+	}
+	if err := store.RestoreHistoricalSessionGraph(ctx, input); err != nil {
+		t.Fatalf("idempotent restore error = %v", err)
+	}
+	input.UserID = "different-user"
+	if err := store.RestoreHistoricalSessionGraph(ctx, input); !errors.Is(err, ErrHistoricalStateConflict) {
+		t.Fatalf("different runtime user restore error = %v", err)
+	}
+}

--- a/services/tuttid/data/workspace/agent_session_fixture_test.go
+++ b/services/tuttid/data/workspace/agent_session_fixture_test.go
@@ -151,8 +151,11 @@ func TestCaptureReplayStateExcludesUnrelatedSentinelSession(t *testing.T) {
 	}
 	if err := store.AgentCanonicalStore().RestoreHistoricalSessionGraph(
 		ctx,
-		replayWorkspaceID,
-		state.Agent,
+		agenthost.HistoricalSessionGraphRestoreInput{
+			WorkspaceID: replayWorkspaceID,
+			UserID:      "user-replay",
+			Graph:       state.Agent,
+		},
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -196,7 +199,14 @@ func TestCaptureReplayStateExcludesUnrelatedSentinelSession(t *testing.T) {
 	)) {
 		t.Fatalf("restored provider resume checkpoint = %#v", checkpoint)
 	}
-	if err := store.AgentCanonicalStore().RestoreHistoricalSessionGraph(ctx, replayWorkspaceID, state.Agent); err != nil {
+	if err := store.AgentCanonicalStore().RestoreHistoricalSessionGraph(
+		ctx,
+		agenthost.HistoricalSessionGraphRestoreInput{
+			WorkspaceID: replayWorkspaceID,
+			UserID:      "user-replay",
+			Graph:       state.Agent,
+		},
+	); err != nil {
 		t.Fatalf("idempotent restore error = %v", err)
 	}
 	conflicting := state.Agent
@@ -204,8 +214,11 @@ func TestCaptureReplayStateExcludesUnrelatedSentinelSession(t *testing.T) {
 	conflicting.Sessions[0].Title = "conflicting title"
 	if err := store.AgentCanonicalStore().RestoreHistoricalSessionGraph(
 		ctx,
-		replayWorkspaceID,
-		conflicting,
+		agenthost.HistoricalSessionGraphRestoreInput{
+			WorkspaceID: replayWorkspaceID,
+			UserID:      "user-replay",
+			Graph:       conflicting,
+		},
 	); !errors.Is(err, agenthost.ErrHistoricalStateConflict) {
 		t.Fatalf("conflicting restore error = %v", err)
 	}

--- a/services/tuttid/data/workspace/agent_session_replay_semantics_test.go
+++ b/services/tuttid/data/workspace/agent_session_replay_semantics_test.go
@@ -212,7 +212,14 @@ func TestRestoreTuttiReplayProductStateRoundTripsSemanticRelationships(t *testin
 			Priority: "medium", Position: 0,
 		}},
 	}}
-	if err := store.AgentCanonicalStore().RestoreHistoricalSessionGraph(ctx, workspaceID, state.Agent); err != nil {
+	if err := store.AgentCanonicalStore().RestoreHistoricalSessionGraph(
+		ctx,
+		agenthost.HistoricalSessionGraphRestoreInput{
+			WorkspaceID: workspaceID,
+			UserID:      "user-replay",
+			Graph:       state.Agent,
+		},
+	); err != nil {
 		t.Fatal(err)
 	}
 	merged, err := replaybiz.MergeTuttiReplayStates([]TuttiReplayState{state})
@@ -253,8 +260,11 @@ func TestHistoricalSessionGraphRoundTripsCanonicalProjectBinding(t *testing.T) {
 	canonicalStore := store.AgentCanonicalStore()
 	if err := canonicalStore.RestoreHistoricalSessionGraph(
 		ctx,
-		workspaceID,
-		graph,
+		agenthost.HistoricalSessionGraphRestoreInput{
+			WorkspaceID: workspaceID,
+			UserID:      "user-replay",
+			Graph:       graph,
+		},
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/services/tuttid/service/agent/host_conformance_test.go
+++ b/services/tuttid/service/agent/host_conformance_test.go
@@ -727,13 +727,11 @@ func (d *legacyHostConformanceDriver) ResetHistoricalState(ctx context.Context) 
 
 func (d *legacyHostConformanceDriver) RestoreHistoricalSessionGraph(
 	ctx context.Context,
-	workspaceID string,
-	graph agenthost.HistoricalSessionGraph,
+	input agenthost.HistoricalSessionGraphRestoreInput,
 ) error {
 	return d.service.ApplicationHost().RestoreHistoricalSessionGraph(
 		ctx,
-		workspaceID,
-		graph,
+		input,
 	)
 }
 
@@ -742,6 +740,17 @@ func (d *legacyHostConformanceDriver) CaptureHistoricalSessionGraph(
 	ref agenthost.SessionRef,
 ) (agenthost.HistoricalSessionGraph, error) {
 	return d.service.ApplicationHost().CaptureHistoricalSessionGraph(ctx, ref)
+}
+
+func (d *legacyHostConformanceDriver) HistoricalSessionUserID(
+	ctx context.Context,
+	ref agenthost.SessionRef,
+) (string, error) {
+	result, err := d.service.ApplicationHost().GetSession(ctx, ref)
+	if err != nil {
+		return "", err
+	}
+	return result.Canonical.UserID, nil
 }
 
 func (d *legacyHostConformanceDriver) EnsureHistoricalSession(
@@ -778,22 +787,26 @@ func (d *legacyHostConformanceDriver) HistoricalStateMetrics() hostconformance.H
 type conformanceHistoricalStateStore struct {
 	driver      *legacyHostConformanceDriver
 	workspaceID string
+	userID      string
 	graph       *agenthost.HistoricalSessionGraph
 }
 
 func (s *conformanceHistoricalStateStore) RestoreHistoricalSessionGraph(
 	_ context.Context,
-	workspaceID string,
-	graph agenthost.HistoricalSessionGraph,
+	input agenthost.HistoricalSessionGraphRestoreInput,
 ) error {
+	workspaceID := input.WorkspaceID
+	graph := input.Graph
 	if s.graph != nil {
-		if s.workspaceID == workspaceID && reflect.DeepEqual(*s.graph, graph) {
+		if s.workspaceID == workspaceID && s.userID == input.UserID &&
+			reflect.DeepEqual(*s.graph, graph) {
 			return nil
 		}
 		return agenthost.ErrHistoricalStateConflict
 	}
 	copied := graph
 	s.workspaceID = workspaceID
+	s.userID = input.UserID
 	s.graph = &copied
 	for _, historical := range graph.Sessions {
 		settingsRaw, err := json.Marshal(historical.Settings)
@@ -807,7 +820,7 @@ func (s *conformanceHistoricalStateStore) RestoreHistoricalSessionGraph(
 		key := workspaceID + ":" + historical.ID
 		s.driver.sessions.sessions[key] = PersistedSession{
 			ID: historical.ID, WorkspaceID: workspaceID, Kind: historical.Kind,
-			Origin: historical.Origin, Provider: historical.Provider,
+			Origin: historical.Origin, UserID: input.UserID, Provider: historical.Provider,
 			AgentTargetID:     historical.AgentTargetID,
 			ProviderSessionID: historical.ProviderSessionID,
 			RailSectionKind:   "conversations", RailSectionKey: "conversations",

--- a/services/tuttid/service/agentsessionreplay/facade.go
+++ b/services/tuttid/service/agentsessionreplay/facade.go
@@ -41,8 +41,17 @@ type ImportResult = replay.ImportResult
 type ActivityEvent = replay.RecordingActivityEvent
 type Service = replay.Service
 type SemanticRegistration = replay.SemanticRegistration
+type SemanticProfile = replay.SemanticProfile
 type SemanticCassetteReader = replay.SemanticCassetteSource
 type SemanticRuntime = replay.SemanticRuntime
+
+func TuttiSemanticProfile() SemanticProfile {
+	return replay.TuttiSemanticProfile()
+}
+
+func AgentSemanticProfile() SemanticProfile {
+	return replay.AgentSemanticProfile()
+}
 
 // SemanticWorkspaceStore keeps Tutti's product-facing workspace types at the
 // Tutti boundary. The shared replay runtime consumes its neutral equivalents

--- a/services/tuttid/service/agentstatus/claude_binary_test.go
+++ b/services/tuttid/service/agentstatus/claude_binary_test.go
@@ -84,6 +84,8 @@ func newClaudeBinaryFixture(t *testing.T, extraEnv ...string) claudeBinaryFixtur
 	}, extraEnv...)
 	service := Service{
 		Environ:              func() []string { return env },
+		HomeDir:              func() (string, error) { return stateDir, nil },
+		LookPath:             func(string) (string, error) { return "", os.ErrNotExist },
 		ClaudeCodeStateDir:   stateDir,
 		ClaudeCodeRuntimeDir: runtimeRoot,
 	}

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -1720,6 +1720,7 @@ func TestServiceRunActionReportsActiveActionForClaudeInstall(t *testing.T) {
 	}
 	runtimeRoot := fakeManagedRuntimeRoot(t)
 	service := probeTestService(home)
+	service.ClaudeCodeStateDir = t.TempDir()
 	service.FileExists = fileExistsForTest
 	service.Environ = func() []string {
 		return []string{"PATH=" + binDir, claudeSDKSidecarEntryPathEnv + "=" + entry}

--- a/services/tuttid/wiring_agent_session_replay.go
+++ b/services/tuttid/wiring_agent_session_replay.go
@@ -13,6 +13,8 @@ import (
 	replayservice "github.com/tutti-os/tutti/services/tuttid/service/agentsessionreplay"
 )
 
+const agentSessionReplayLocalUserID = "tutti-local-user"
+
 func resolveAgentSessionRecordingEnabled(
 	ctx context.Context,
 	preferences interface {
@@ -93,6 +95,8 @@ func prepareReplaySemanticRuntime(
 				CassetteID:    registration.CassetteID,
 				RootSessionID: registration.RootAgentSessionID,
 				WorkspaceID:   registration.WorkspaceID,
+				UserID:        agentSessionReplayLocalUserID,
+				Profile:       replayservice.TuttiSemanticProfile(),
 			},
 		)
 	}


### PR DESCRIPTION
## Summary
- normalize volatile provider initialize client version and title fields so cassettes remain portable across runtime and consumer updates
- bind restored historical Session graphs to the replay runtime user and enforce consumer semantic profiles without rejecting ordinary inactive Tutti Mode snapshots
- isolate Claude agent-status tests from machine-local runtime state and executable discovery

## Tests
- `go test ./packages/agent/session-replay`
- `go test ./services/tuttid/service/agentstatus -run '^(TestResolveProviderRuntimeUsesManagedClaudeCodePointer|TestServiceRunActionReportsActiveActionForClaudeInstall)$' -count=1`
- `pnpm check:changed -- --push-ready` (pre-push hook)

## Notes
- updated Agent Host and Session Replay durable documentation for the runtime-user binding and semantic-profile contract
- repository-local Session Replay skill edits are intentionally excluded
