### PR TITLE
fix(agent): preserve historical sessions after activation failure

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1274,6 +1274,9 @@ the ordinary Rail's transient `runtimeRailConversations` overlay; stale page
 projections therefore cannot leak into Activity View.
 Membership and recency are snapshotted when the view opens; subsequent Engine
 pushes reconcile incrementally, while deletion removes a member immediately.
+Selecting a historical Session that is temporarily injected into the visible
+summary list does not make an idle Session a newly discovered Activity task;
+only its live waiting, unread, or active facts can admit it to Priority.
 Search temporarily takes over the content area and clearing search restores the
 same activation. Closing the view discards the activation and its retained-idle
 markers. A retained-idle marker stores the exact unread recency and expires as

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1274,9 +1274,12 @@ the ordinary Rail's transient `runtimeRailConversations` overlay; stale page
 projections therefore cannot leak into Activity View.
 Membership and recency are snapshotted when the view opens; subsequent Engine
 pushes reconcile incrementally, while deletion removes a member immediately.
-Selecting a historical Session that is temporarily injected into the visible
-summary list does not make an idle Session a newly discovered Activity task;
-only its live waiting, unread, or active facts can admit it to Priority.
+Existing Priority member IDs and their relative order survive ordinary Rail
+refreshes that temporarily omit a summary; the controller uses the last known
+row summary until the next toggle or an explicit canonical tombstone. Selecting
+a historical Session that is temporarily injected into the visible summary
+list does not make an idle Session a newly discovered Activity task; only its
+live waiting, unread, or active facts can admit it to Priority.
 Search temporarily takes over the content area and clearing search restores the
 same activation. Closing the view discards the activation and its retained-idle
 markers. A retained-idle marker stores the exact unread recency and expires as

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -937,6 +937,13 @@ while canonical Turn state remains authoritative once it exists.
   those projections.
   Canonical monotonicity guards prevent a late activation response from
   regressing newer realtime state.
+  A failed new-Session activation is a rollback signal only when the Engine's
+  canonical Session selector confirms that no Session entity exists. If the
+  Session exists but runtime startup or the initial Goal failed, the Session
+  remains selectable and the failure is rendered as Session detail state.
+  An explicit historical-row selection has higher priority than stale
+  activation failure metadata; it first requests detail reconciliation and
+  only returns home after an authoritative not-found result.
   Surfaces clear a new-Session draft only after activation admission succeeds.
   If an admitted new-Session activation is canceled before canonical Session
   confirmation, the surface restores the submitted draft only while the
@@ -1014,7 +1021,10 @@ turnless controls remain intact.
   the same activity-core Session reconcile executor. The executor owns scope,
   cursor/window, pagination, double-detail race closure, cancellation/deletion
   fences, and atomic application; hosts own transport, DTO mapping, diagnostics,
-  polling, and presentation side effects
+  polling, and presentation side effects. A shared-agent detail open also
+  re-materializes a durable binding into the local Engine when its cached
+  binding exists but the local runtime projection is absent; this repairs local
+  state and does not mutate historical data.
 - every daemon Session response carries the required `messageVersion`
   high-water cursor. Daemon and renderer ship as one protocol unit, so the
   shared adapter rejects a missing or invalid cursor instead of fabricating
@@ -1274,17 +1284,23 @@ the ordinary Rail's transient `runtimeRailConversations` overlay; stale page
 projections therefore cannot leak into Activity View.
 Membership and recency are snapshotted when the view opens; subsequent Engine
 pushes reconcile incrementally, while deletion removes a member immediately.
+The Activity controller owns that activation and its retained row cache;
+React render only consumes the controller snapshot and projects live row facts.
 Existing Priority member IDs and their relative order survive ordinary Rail
 refreshes that temporarily omit a summary; the controller uses the last known
 row summary until the next toggle or an explicit canonical tombstone. Selecting
 a historical Session that is temporarily injected into the visible summary
 list does not make an idle Session a newly discovered Activity task; only its
 live waiting, unread, or active facts can admit it to Priority.
+The activation is scoped by the workspace, authenticated user, rail filter,
+AgentGUI node, and Engine identity, not by the currently selected Session's
+provider or target; selecting a row must not rebuild a cross-provider Activity
+queue.
 Search temporarily takes over the content area and clearing search restores the
-same activation. Closing the view discards the activation and its retained-idle
-markers. A retained-idle marker stores the exact unread recency and expires as
-soon as that recency changes. Existing workspace, authenticated-user, Agent
-target, and Engine identities fence the activation internally; no Activity
+same activation. Closing the view discards the activation and its retained row
+cache. Existing workspace, authenticated-user,
+rail-filter, AgentGUI-node, and Engine identities fence the activation
+internally; the selected Session's provider and target do not. No Activity
 filter or additional host scope contract is introduced. Disabled hosts use an
 empty Activity selector and do not scan root Sessions. Activity rows omit the
 minute-clock subscription together with their hidden timestamp. The full

--- a/docs/specs/2026-08-05-agent-conversation-activity-view-prd.md
+++ b/docs/specs/2026-08-05-agent-conversation-activity-view-prd.md
@@ -16,7 +16,7 @@ Status: implemented; pending code review
 该功能不是对当前屏幕中的 DOM 行临时排序，而是对 Agent GUI 当前内存态中的 canonical Session 摘要做稳定投影。它复刻 Codex.app 的实际展示行为：
 
 1. 开启时同步快照当前 Engine 已在内存中的可见**根会话摘要**；
-2. 立即按 `waiting → unread → active → retained idle` 的客户端 presentation policy 投影 Priority；
+2. 立即按 `waiting → unread → active` 的客户端 presentation policy 投影 Priority；
 3. 同一份摘要集合中其余最近 7 个自然日的会话直接放入 Today、Yesterday 或 weekday 日期段；
 4. 开启时快照 Priority 顺序与日期段 recency；开启期间监听 canonical 状态，但保留既有成员顺序，只按 Codex 规则增量合入新候选并更新行状态；
 5. 开启 Activity View 本身不发起历史查询、补页或 transcript hydration；Desktop daemon 新推送或更新的会话先进入 Engine，再按实时规则增量入队。
@@ -100,19 +100,19 @@ Activity View 的核心价值是把 Conversation Rail 从“目录”临时切�
 
 ## 4. 关键产品决策
 
-| 编号 | 决策                                                                    | 理由                                                              |
-| ---- | ----------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| D1   | 功能名称为 Activity View；Priority 是视图顶部的固定标题区段             | 不再把整个能力称为 Priority View                                  |
-| D2   | Desktop 默认关闭，由用户显式开启；Mobile 会话首页固定开启               | Desktop 保留既有项目目录心智；Mobile 直接采用已批准的新首页承载   |
-| D3   | 最近范围固定为最近 7 个自然日                                           | 覆盖一周工作上下文，避免无边界加载历史                            |
-| D4   | Priority 顺序复刻 Codex：`waiting`、`unread`、`active`、retained `idle` | 不按失败/成功再创造一套 Tutti 排序标准                            |
-| D5   | `waiting` 由 Tutti canonical `needsUserAction` 映射                     | UI 语义跟随 Codex，事实来源仍由 Tutti lifecycle 保证              |
-| D6   | 子 Session 不作为左栏独立行                                             | Codex 将子线程作为独立实体管理，但左栏由根线程代表                |
-| D7   | Priority 与近期日期段之间去重                                           | 一个 Session 只在最靠前的可见位置出现一次                         |
-| D8   | 搜索临时接管内容区，清空搜索后恢复 Activity View                        | 搜索是明确查找意图，避免搜索结果与工作队列结构混杂                |
-| D9   | Activity View 不新增或改造通用筛选器                                    | 当前 Engine 是完整输入边界，不增加 host context 契约              |
-| D10  | Activity View 开启本身仅投影当前 Engine 内存态，不因开启视图补页        | Desktop Activity View 聚焦当前工作；Mobile 的显式搜索另走分页查询 |
-| D11  | Activity View 不提供批量归档或批量删除入口                              | Archive chats 映射为 Tutti 删除，但首期不纳入标题菜单             |
+| 编号 | 决策                                                             | 理由                                                              |
+| ---- | ---------------------------------------------------------------- | ----------------------------------------------------------------- |
+| D1   | 功能名称为 Activity View；Priority 是视图顶部的固定标题区段      | 不再把整个能力称为 Priority View                                  |
+| D2   | Desktop 默认关闭，由用户显式开启；Mobile 会话首页固定开启        | Desktop 保留既有项目目录心智；Mobile 直接采用已批准的新首页承载   |
+| D3   | 最近范围固定为最近 7 个自然日                                    | 覆盖一周工作上下文，避免无边界加载历史                            |
+| D4   | Priority 顺序复刻 Codex：`waiting`、`unread`、`active`           | 不按失败/成功再创造一套 Tutti 排序标准                            |
+| D5   | `waiting` 由 Tutti canonical `needsUserAction` 映射              | UI 语义跟随 Codex，事实来源仍由 Tutti lifecycle 保证              |
+| D6   | 子 Session 不作为左栏独立行                                      | Codex 将子线程作为独立实体管理，但左栏由根线程代表                |
+| D7   | Priority 与近期日期段之间去重                                    | 一个 Session 只在最靠前的可见位置出现一次                         |
+| D8   | 搜索临时接管内容区，清空搜索后恢复 Activity View                 | 搜索是明确查找意图，避免搜索结果与工作队列结构混杂                |
+| D9   | Activity View 不新增或改造通用筛选器                             | 当前 Engine 是完整输入边界，不增加 host context 契约              |
+| D10  | Activity View 开启本身仅投影当前 Engine 内存态，不因开启视图补页 | Desktop Activity View 聚焦当前工作；Mobile 的显式搜索另走分页查询 |
+| D11  | Activity View 不提供批量归档或批量删除入口                       | Archive chats 映射为 Tutti 删除，但首期不纳入标题菜单             |
 
 ### 4.1 已识别的体验差异与数据映射
 
@@ -160,7 +160,7 @@ flowchart TD
 
 - **普通视图（Directory mode）**：现有 pinned、项目和 conversations 分区视图。
 - **Activity View（Activity mode）**：本 PRD 新增的跨项目工作队列视图；顶部显示 Priority，其余近期会话直接按日期标题排列。
-- **Priority**：Activity View 顶部的固定标题区段，只承载 waiting、unread、active 和 retained idle 根 Session；不是整个视图的名称。
+- **Priority**：Activity View 顶部的固定标题区段，只承载 waiting、unread 和 active 根 Session；不是整个视图的名称。开启后已经进入 Priority 的成员即使变为已读或 idle，也保留到下一次 toggle；这属于 activation snapshot retention，不是新的 idle admission 类型。
 - **近期日期段**：由 Today、Yesterday 或 weekday 标题及其会话组成；产品模型和界面均不存在名为 Recent 的固定分组。
 - **Desktop daemon**：host 向 Agent Engine 推送 canonical Session 变化的后台通道；Tutti 对应 `tuttid`，其他 Desktop host 可对应 `desktopd`。两者都必须先写入 Engine，再由 Activity View 投影消费。
 - **Engine identity**：现有 `AgentSessionEngine.identity`，由 `(workspaceId, runtime origin)` 定位 Engine；Activity View 不新增或复制该 identity。
@@ -228,14 +228,13 @@ Priority 内部不再增加多层可折叠标题，避免窄 Rail 产生过多 c
 
 每个根 Session 先映射为 Codex 同构的 attention state，再计算纯 presentation rank：
 
-| rank | Codex 同构状态  | Tutti canonical 映射                                       | 行内原因                         |
-| ---- | --------------- | ---------------------------------------------------------- | -------------------------------- |
-| 0    | `waiting`       | `needsUserAction=true`，通常来自 pending Interaction       | 需要处理                         |
-| 1    | `unread`        | 现有 attention/read state 表示存在未读结果                 | 未读；不再细分失败或成功的优先级 |
-| 2    | `active`        | 根 Session 或其子 Session 仍有 active lifecycle projection | 进行中                           |
-| 3    | retained `idle` | `priorityRetentionRecency === currentRecency`              | 已处理但保留                     |
+| rank | Codex 同构状态 | Tutti canonical 映射                                       | 行内原因                         |
+| ---- | -------------- | ---------------------------------------------------------- | -------------------------------- |
+| 0    | `waiting`      | `needsUserAction=true`，通常来自 pending Interaction       | 需要处理                         |
+| 1    | `unread`       | 现有 attention/read state 表示存在未读结果                 | 未读；不再细分失败或成功的优先级 |
+| 2    | `active`       | 根 Session 或其子 Session 仍有 active lifecycle projection | 进行中                           |
 
-普通 idle 不进入 Priority，由近期日期范围决定是否出现在某个日期段。retained idle 是 Codex 本地任务分支中的窄规则：会话被标记已读前，记录当时 recency；只要当前 recency 未变化，该行继续留在 Priority 的最后。Activity View 运行期间新发现的 idle 本地任务也用同一 marker 保留，避免刚创建的会话立即消失。仅因用户选择历史会话而临时注入的 idle summary 不属于“新发现任务”，不得创建 retained-idle marker；它仍按当前 recency 进入日期段或被 cutoff 排除。退出 Activity View 时 marker 清空。
+普通 idle 不进入 Priority，由近期日期范围决定是否出现在某个日期段。Activity View 运行期间晚到的 canonical idle summary 也不会被视为 activity，不会改变 Priority；它只可在下一次 toggle 的初始快照中按近期日期进入日期段。仅因用户选择历史会话而临时注入的 idle summary 同样不属于 Activity candidate。已经进入当前 Priority snapshot 的会话即使随后标记已读或变为 idle，也保留原成员和相对顺序，直到下一次 toggle；删除 tombstone 是唯一的即时移除例外。
 
 同 rank 内按现有 canonical recency 倒序。相同 recency 保留输入顺序；去重 identity 使用 exact `agentSessionId`。这与 Codex 的稳定排序策略一致，不额外用 Session ID 改变用户可见顺序。
 
@@ -311,12 +310,12 @@ Priority 区段始终存在。其成员为空时，在该区段内显示与 Code
 
 ### 8.4 实时变化
 
-- 开启时按当时 `waiting → unread → active → retained idle` 生成 Priority 初始顺序；
+- 开启时按当时 `waiting → unread → active` 生成 Priority 初始顺序；
 - 开启期间，既有 Priority 成员即使 attention state 改变也不做全量移组或重排；行上的 spinner、unread、状态与可执行操作读取 live canonical facts；普通 Rail refresh 暂时不返回某个已入队 ID 时，也不得把它当成删除，继续使用该行最近一次已知 summary，直到下一次 toggle 重建 activation；
-- Desktop daemon 新推送或更新的根 Session 先写入 Engine；满足 waiting/unread/active/retained-idle 的新候选再按当前 selector 顺序增量入队并按 exact ID 去重；
-- activation 打开后由 daemon 新发现的普通 idle 根 Session 按 Codex 本地任务的一次性 retained-idle 规则进入 Priority；打开时已存在的普通 idle Session 仍按时间进入日期段；
+- Desktop daemon 新推送或更新的根 Session 先写入 Engine；满足 waiting/unread/active 的新候选再按当前 selector 顺序增量入队并按 exact ID 去重；
+- activation 打开后由 daemon 新发现的普通 idle 根 Session 不进入 Priority，也不因为 canonical snapshot 到达而改变现有队列；打开时已存在的普通 idle Session 按时间进入日期段；
 - 用户选择一个尚未出现在 canonical snapshot 中的历史 Session 时，详情层可以临时注入该 Session 的 summary；若它当前 idle，则按普通近期会话处理，不因选择动作进入 Priority，只有真实 waiting/unread/active facts 才可进入 Priority；
-- 会话第一次进入本次 activation 的日期段时记录 recency，之后在本次视图中保持原日期段和相对顺序；
+- 会话第一次进入本次 activation 的日期段时记录 recency，之后在本次视图中保持原日期段和相对顺序；已经进入 Priority 的会话不因已读或 idle 状态变化移入日期段；
 - Session 被现有删除能力删除后，Activity View 按 canonical tombstone 立即移除对应行；pin/unpin 不触发 Activity View 专属区段变化；
 - Activity View 本身不提供批量删除或归档入口；现有单行删除行为不在本 PRD 中修改；
 - 关闭再开启、切换 sidebar context 或 activation 重建时，才基于最新 canonical facts 重新生成完整成员与顺序；
@@ -327,13 +326,12 @@ Priority 区段始终存在。其成员为空时，在该区段内显示与 Code
 Codex 使用两层机制避免当前会话突然消失：
 
 1. 已经位于本次 Priority snapshot 的条目在标记已读后仍保留原成员位置；不会在当前 activation 中立即移入日期段；
-2. 本地 Agent 根 Session 被标记已读前，另行记录 `priorityRetentionRecency = currentRecency`；这使一个当前为 idle、但 recency 尚未变化的本地任务在新建 Priority snapshot 时仍可进入 retained idle rank；
-3. recency marker 不是永久 pin；退出 Activity View 会同时清空 snapshot 与 marker；
-4. 下次重新开启时按最新事实重建：仍满足 waiting/unread/active/retained-idle 则进入 Priority，否则进入对应日期段或消失；
-5. 无论左栏是否仍显示，detail 保持当前 Session，不自动选择另一行；
-6. hover 和 keyboard focus 不产生另一套冻结规则；稳定性来自 activation snapshot 和 exact-recency marker。
+2. 新增的普通 idle canonical Session 不因晚到 snapshot 而进入 Priority；它只在下一次 toggle 的初始快照中按日期规则处理；
+3. 关闭再开启时只按当时最新 facts 重建，不继承上一次 activation 的 Priority 成员；
+4. 无论左栏是否仍显示，detail 保持当前 Session，不自动选择另一行；
+5. hover 和 keyboard focus 不产生另一套冻结规则；稳定性来自 activation snapshot 与 controller-owned row cache。
 
-Codex 的 ChatGPT 会话分支没有 local-task retained-idle marker，但已经进入当前 Priority snapshot 的条目同样不会因标记已读而立即重排。本 PRD 面向 Tutti Agent GUI，默认复刻本地 Agent 任务分支。
+该规则同时适用于所有 provider：Activity View 不创建 retained-idle admission 类型，也不把详情选择或已读后的 recency 变化解释为新的 activity。
 
 ## 9. 内存投影与实时入队
 
@@ -356,17 +354,15 @@ Codex 的本地 Activity View 是当前 store 上的客户端 presentation polic
 interface ActivityViewActivation {
   cutoffDayStartUnixMs: number;
   referenceDayStartUnixMs: number;
-  observedIds: readonly string[];
   priority: readonly ActivityMember[];
-  priorityRetentionRecencyById: ReadonlyMap<string, number>;
   recent: readonly ActivityMember[];
 }
 ```
 
 - activation object identity 区分每次开启；关闭后到达的旧渲染结果不能恢复已清理的 snapshot；
 - activation 绑定创建它的 Engine 实例；Engine 被替换、surface 卸载或视图关闭时立即取消订阅并清理；
-- sidebar 的 workspace、用户或 Agent context 变化时重建 activation；这是组件内部的 stale-state fence，不是新增筛选器或 host API；
-- Activity View state 只保存 activation、成员引用、Priority 顺序、日期段 recency snapshot 和 retained-idle marker，不把 Session 副本放进 activation 或分页 cursor；controller 可以在当前 activation 内短暂缓存已入队行的最近一次 summary，用于抵抗普通 Rail refresh 的临时缺席；该缓存随 toggle、context/Engine 重建或 canonical tombstone 清理；
+- sidebar 的 workspace、用户、Rail filter 或 AgentGUI context 变化时重建 activation；当前选中会话的 provider/target 变化不重建 activation，因为 Activity 队列跨 provider 展示；这是组件内部的 stale-state fence，不是新增筛选器或 host API；
+- Activity View state 只保存 activation、成员引用、Priority 顺序和日期段 recency snapshot，不把 Session 副本放进 activation 或分页 cursor；controller 可以在当前 activation 内短暂缓存已入队行的最近一次 summary，用于抵抗普通 Rail refresh 的临时缺席；该缓存随 toggle、context/Engine 重建或 canonical tombstone 清理；
 - cutoff 固定取本次 activation 的本地日期；持续打开跨午夜不自行刷新日期标题，关闭再开启时才使用新的 cutoff。
 
 ### 9.3 投影与事件算法
@@ -384,7 +380,7 @@ onEngineSessionUpsert(session)
   4. incrementally enqueue newly eligible root sessions by exact ID
 
 deactivate(activityView)
-  1. clear activation snapshot and retained-idle markers
+  1. clear activation snapshot and retained row cache
   2. keep canonical Engine sessions unchanged
 ```
 
@@ -401,11 +397,7 @@ Desktop daemon push 可能重复、乱序或在 surface 切换后迟到，因此
 建议在 `@tutti-os/agent-gui` 内定义纯投影，而不是在 JSX 中拼装：
 
 ```ts
-type AgentConversationPriorityReason =
-  | "waiting"
-  | "unread"
-  | "active"
-  | "retained_idle";
+type AgentConversationPriorityReason = "waiting" | "unread" | "active";
 
 interface AgentConversationActivityViewModel {
   sections: Array<{
@@ -437,7 +429,7 @@ interface AgentConversationActivityViewModel {
 | Desktop host adapter               | 显式启用 capability，并接入既有 daemon → Engine 事件通道                  | 复制 controller 或业务排序      |
 | 外部 host adapter                  | 传入可选 capability；关闭或缺失时保持普通 Rail                            | 被要求实现 Activity View 能力   |
 
-本功能不新增 OpenAPI endpoint、SQLite 查询或 Activity View 专用 query controller。普通 Rail 已经加载进 Engine 的会话与 Desktop daemon 后续实时推送，是 Activity View 投影的全部数据来源。
+本功能不新增 OpenAPI endpoint、SQLite 查询或独立的 Activity View query controller。Activity activation state 挂在既有 Conversation Rail query controller 的生命周期上；普通 Rail 已经加载进 Engine 的会话与 Desktop daemon 后续实时推送，是 Activity View 投影的全部数据来源。
 
 ## 12. 功能需求清单
 
@@ -446,9 +438,9 @@ interface AgentConversationActivityViewModel {
 | FR-01 | Rail 提供可发现、可访问的 Activity View 切换入口                      | P0     |
 | FR-02 | 首帧基于 Engine 已知会话立即投影                                      | P0     |
 | FR-03 | 只展示根 Session；子 Session activity 投影到根行                      | P0     |
-| FR-04 | waiting/unread/active 事实及 retained-idle marker 可投影              | P0     |
+| FR-04 | waiting/unread/active 事实可投影                                      | P0     |
 | FR-05 | 近期日期段只使用当前 Engine 内存态，不触发补页                        | P0     |
-| FR-06 | Priority 按 waiting/unread/active/retained-idle 和 recency 排序       | P0     |
+| FR-06 | Priority 按 waiting/unread/active 和 recency 排序                     | P0     |
 | FR-07 | Priority 与近期日期段全局去重                                         | P0     |
 | FR-08 | 不新增筛选入口、筛选条件、组合状态或通用 filter API                   | P0     |
 | FR-09 | 搜索接管与恢复行为逐项沿用 Codex                                      | P0     |
@@ -534,7 +526,7 @@ interface AgentConversationActivityViewModel {
 2. Activity View 不要求 host 提供额外 context/scope identity API；内部仅复用页面已有 workspace、用户和 Agent context 作为 activation stale-state fence。页面不存在本功能新增的 target/workspace/provider 筛选入口或组合状态。
 3. 搜索开始、结果展示和清空恢复均与 Codex 当前行为一致，不增加独立 Priority 搜索状态。
 4. 打开 Priority 中的 Session 沿用现有 selection/detail hydration；选择一个历史 Session 只允许产生详情层 transient summary，不得因此改变 Activity View 的 Priority 顺序；其他行不因 Activity View 触发后台 hydration。
-5. 当前本地 Agent Session 被标记已读后在本次 snapshot 中保留原位置；退出并重新开启时才按最新 facts 与 retained-idle marker 重建，detail 始终保持打开且不自动选中其他会话。
+5. 当前 Agent Session 被标记已读后在本次 snapshot 中保留原位置；退出并重新开启时才按最新 facts 重建，detail 始终保持打开且不自动选中其他会话。
 6. 项目折叠和显示条数不被修改；滚动复用现有 Rail mode 状态，不创建 Activity View 专用 scroll key。
 
 ### 15.3 实时与异常
@@ -563,7 +555,7 @@ interface AgentConversationActivityViewModel {
 
 - rank 判定矩阵；
 - Tutti `needsUserAction` 到 waiting、普通运行到 active 的映射；
-- waiting/unread/active/retained-idle 的排序与 marker 失效；
+- waiting/unread/active 的排序，以及已读后既有 Priority 成员的 snapshot retention；
 - child Session 过滤与 child activity 到 root 的投影；
 - Priority 与日期段去重；
 - 7 日 cutoff 和本地午夜边界；
@@ -601,7 +593,7 @@ interface AgentConversationActivityViewModel {
 - 普通视图与 Activity View 复用同一 Rail mode scroll state；
 - 实时 pending → answered → completed → read 全链路；
 - Desktop daemon 推送当前未在 Engine 中的新会话后，符合条件的根 Session 实时入队；
-- 未读本地 Session 标记已读后在当前 snapshot 保持原位置；重建时按 retained-idle marker 判定，recency 改变后 marker 失效；
+- 已读或变为 idle 的既有 Priority Session 在当前 snapshot 保持原位置；重建时不继承旧 Priority，普通 idle 按最新日期规则处理；
 - Priority 空但日期段非空时只在 Priority 区段显示 `Nothing needs attention` 同构空状态；
 - Workbench AgentGUI 与独立 Agent window；
 - 外部 host 在 capability 为 `false` 和缺失两种情况下均保持原普通 Rail，且没有 Activity View 查询副作用；
@@ -675,8 +667,8 @@ interface AgentConversationActivityViewModel {
 - Codex 本地任务模式不会因为开启 Activity View 再调用 `thread/list` 补 Priority；Tutti 只参考该本地模式，不实现 ChatGPT 近期会话补页分支；
 - 普通侧边栏的无限滚动是独立逻辑，约每批 10 条；
 - Activity View 本身不提供“加载更多”；开启时快照 Priority 顺序与日期段 recency，期间保留既有顺序并增量合入新候选；
-- Codex 本地任务在标记已读前保存 exact recency，并允许匹配该 recency 的 idle 行继续留在 Priority 最后；recency 变化或退出模式后该保留失效；
-- ChatGPT 会话分支没有上述 retained-idle marker；当前 snapshot 仍保持，下一次重建时通常进入对应日期段；
+- Codex 某些本地任务分支会保存 exact recency，并允许 idle 行留在 Priority；Tutti 本实现不采用这个独立 admission marker，只保留当前 activation 中已入队成员直到下一次 toggle；
+- 已进入当前 Priority snapshot 的会话在标记已读后仍保持原位置；下一次重建时普通 idle 按最新事实进入对应日期段或被 cutoff 排除；
 - 子线程通过 `parentThreadId`/sub-agent source 建模；左栏过滤子线程，父线程承担导航表示；
 - Priority 区段不会加载完整 transcript；Tutti 进一步约束为不因该视图执行任何 Turn hydration；
 - Activity View 本地任务行使用两层布局：第一行只显示标题和标题行对齐的尾部状态栏，不显示时间戳；第二行只显示项目/source 信息，不展示会话 prompt 或 Agent 回复；

--- a/docs/specs/2026-08-05-agent-conversation-activity-view-prd.md
+++ b/docs/specs/2026-08-05-agent-conversation-activity-view-prd.md
@@ -312,7 +312,7 @@ Priority 区段始终存在。其成员为空时，在该区段内显示与 Code
 ### 8.4 实时变化
 
 - 开启时按当时 `waiting → unread → active → retained idle` 生成 Priority 初始顺序；
-- 开启期间，既有 Priority 成员即使 attention state 改变也不做全量移组或重排；行上的 spinner、unread、状态与可执行操作读取 live canonical facts；
+- 开启期间，既有 Priority 成员即使 attention state 改变也不做全量移组或重排；行上的 spinner、unread、状态与可执行操作读取 live canonical facts；普通 Rail refresh 暂时不返回某个已入队 ID 时，也不得把它当成删除，继续使用该行最近一次已知 summary，直到下一次 toggle 重建 activation；
 - Desktop daemon 新推送或更新的根 Session 先写入 Engine；满足 waiting/unread/active/retained-idle 的新候选再按当前 selector 顺序增量入队并按 exact ID 去重；
 - activation 打开后由 daemon 新发现的普通 idle 根 Session 按 Codex 本地任务的一次性 retained-idle 规则进入 Priority；打开时已存在的普通 idle Session 仍按时间进入日期段；
 - 用户选择一个尚未出现在 canonical snapshot 中的历史 Session 时，详情层可以临时注入该 Session 的 summary；若它当前 idle，则按普通近期会话处理，不因选择动作进入 Priority，只有真实 waiting/unread/active facts 才可进入 Priority；
@@ -366,7 +366,7 @@ interface ActivityViewActivation {
 - activation object identity 区分每次开启；关闭后到达的旧渲染结果不能恢复已清理的 snapshot；
 - activation 绑定创建它的 Engine 实例；Engine 被替换、surface 卸载或视图关闭时立即取消订阅并清理；
 - sidebar 的 workspace、用户或 Agent context 变化时重建 activation；这是组件内部的 stale-state fence，不是新增筛选器或 host API；
-- Activity View state 只保存 activation、成员引用、Priority 顺序、日期段 recency snapshot 和 retained-idle marker，不保存 Session 副本或分页 cursor；
+- Activity View state 只保存 activation、成员引用、Priority 顺序、日期段 recency snapshot 和 retained-idle marker，不把 Session 副本放进 activation 或分页 cursor；controller 可以在当前 activation 内短暂缓存已入队行的最近一次 summary，用于抵抗普通 Rail refresh 的临时缺席；该缓存随 toggle、context/Engine 重建或 canonical tombstone 清理；
 - cutoff 固定取本次 activation 的本地日期；持续打开跨午夜不自行刷新日期标题，关闭再开启时才使用新的 cutoff。
 
 ### 9.3 投影与事件算法

--- a/docs/specs/2026-08-05-agent-conversation-activity-view-prd.md
+++ b/docs/specs/2026-08-05-agent-conversation-activity-view-prd.md
@@ -235,7 +235,7 @@ Priority 内部不再增加多层可折叠标题，避免窄 Rail 产生过多 c
 | 2    | `active`        | 根 Session 或其子 Session 仍有 active lifecycle projection | 进行中                           |
 | 3    | retained `idle` | `priorityRetentionRecency === currentRecency`              | 已处理但保留                     |
 
-普通 idle 不进入 Priority，由近期日期范围决定是否出现在某个日期段。retained idle 是 Codex 本地任务分支中的窄规则：会话被标记已读前，记录当时 recency；只要当前 recency 未变化，该行继续留在 Priority 的最后。Activity View 运行期间新发现的 idle 本地任务也用同一 marker 保留，避免刚创建的会话立即消失。退出 Activity View 时 marker 清空。
+普通 idle 不进入 Priority，由近期日期范围决定是否出现在某个日期段。retained idle 是 Codex 本地任务分支中的窄规则：会话被标记已读前，记录当时 recency；只要当前 recency 未变化，该行继续留在 Priority 的最后。Activity View 运行期间新发现的 idle 本地任务也用同一 marker 保留，避免刚创建的会话立即消失。仅因用户选择历史会话而临时注入的 idle summary 不属于“新发现任务”，不得创建 retained-idle marker；它仍按当前 recency 进入日期段或被 cutoff 排除。退出 Activity View 时 marker 清空。
 
 同 rank 内按现有 canonical recency 倒序。相同 recency 保留输入顺序；去重 identity 使用 exact `agentSessionId`。这与 Codex 的稳定排序策略一致，不额外用 Session ID 改变用户可见顺序。
 
@@ -315,6 +315,7 @@ Priority 区段始终存在。其成员为空时，在该区段内显示与 Code
 - 开启期间，既有 Priority 成员即使 attention state 改变也不做全量移组或重排；行上的 spinner、unread、状态与可执行操作读取 live canonical facts；
 - Desktop daemon 新推送或更新的根 Session 先写入 Engine；满足 waiting/unread/active/retained-idle 的新候选再按当前 selector 顺序增量入队并按 exact ID 去重；
 - activation 打开后由 daemon 新发现的普通 idle 根 Session 按 Codex 本地任务的一次性 retained-idle 规则进入 Priority；打开时已存在的普通 idle Session 仍按时间进入日期段；
+- 用户选择一个尚未出现在 canonical snapshot 中的历史 Session 时，详情层可以临时注入该 Session 的 summary；若它当前 idle，则按普通近期会话处理，不因选择动作进入 Priority，只有真实 waiting/unread/active facts 才可进入 Priority；
 - 会话第一次进入本次 activation 的日期段时记录 recency，之后在本次视图中保持原日期段和相对顺序；
 - Session 被现有删除能力删除后，Activity View 按 canonical tombstone 立即移除对应行；pin/unpin 不触发 Activity View 专属区段变化；
 - Activity View 本身不提供批量删除或归档入口；现有单行删除行为不在本 PRD 中修改；
@@ -532,7 +533,7 @@ interface AgentConversationActivityViewModel {
 1. Engine 实例替换或 surface 卸载时清理旧 activation；旧 Engine 的后续更新不能污染新列表。
 2. Activity View 不要求 host 提供额外 context/scope identity API；内部仅复用页面已有 workspace、用户和 Agent context 作为 activation stale-state fence。页面不存在本功能新增的 target/workspace/provider 筛选入口或组合状态。
 3. 搜索开始、结果展示和清空恢复均与 Codex 当前行为一致，不增加独立 Priority 搜索状态。
-4. 打开 Priority 中的 Session 沿用现有 selection/detail hydration；其他行不因 Activity View 触发后台 hydration。
+4. 打开 Priority 中的 Session 沿用现有 selection/detail hydration；选择一个历史 Session 只允许产生详情层 transient summary，不得因此改变 Activity View 的 Priority 顺序；其他行不因 Activity View 触发后台 hydration。
 5. 当前本地 Agent Session 被标记已读后在本次 snapshot 中保留原位置；退出并重新开启时才按最新 facts 与 retained-idle marker 重建，detail 始终保持打开且不自动选中其他会话。
 6. 项目折叠和显示条数不被修改；滚动复用现有 Rail mode 状态，不创建 Activity View 专用 scroll key。
 

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   selectEngineSessionOperationError,
   selectEngineSubmitAvailability,
+  selectFailedNewActivationResolution,
   selectEngineSessionDeleted,
   selectRootAgentSessionIdsWithPendingInteractions,
   selectWorkspaceAgentConsumerCounts,
@@ -63,6 +64,61 @@ test("deleted session selector normalizes ids and hides tombstone storage", () =
   assert.equal(selectEngineSessionDeleted(state, " session-1 "), true);
   assert.equal(selectEngineSessionDeleted(state, "missing"), false);
   assert.equal(selectEngineSessionDeleted(state, null), false);
+});
+
+test("failed new activation preserves a canonical session after runtime failure", () => {
+  let state = createInitialAgentSessionEngineState();
+  assert.equal(
+    selectFailedNewActivationResolution(state, "session-1"),
+    "not-applicable"
+  );
+
+  state = rootEngineReducer(state, {
+    agentSessionId: "session-1",
+    agentTargetId: "target-1",
+    clientSubmitId: "submit-1",
+    content: [{ type: "text", text: "hello" }],
+    cwd: "/workspace",
+    expiresAtUnixMs: 45_001,
+    mode: "new",
+    requestedAtUnixMs: 1,
+    requestId: "activation-1",
+    type: "activation/requested",
+    workspaceId: "workspace-1"
+  }).state;
+  state = rootEngineReducer(state, {
+    commandId: "activate:activation-1",
+    commandType: "session/activate",
+    correlationId: "activation-1",
+    errorMessage: "Initial goal failed.",
+    outcome: "failed",
+    type: "engine/commandResult"
+  }).state;
+  assert.equal(
+    selectFailedNewActivationResolution(state, "session-1"),
+    "rollback"
+  );
+
+  state = rootEngineReducer(state, {
+    sessions: [
+      {
+        activeTurnId: null,
+        agentSessionId: "session-1",
+        cwd: "/workspace",
+        latestTurnInteractions: [],
+        pendingInteractions: [],
+        provider: "codex",
+        title: "Persisted session",
+        workspaceId: "workspace-1"
+      }
+    ],
+    type: "session/snapshotReceived"
+  }).state;
+
+  assert.equal(
+    selectFailedNewActivationResolution(state, " session-1 "),
+    "preserve"
+  );
 });
 
 test("consumer collections hide presentation-invisible sessions without removing exact lookup", () => {

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.ts
@@ -43,6 +43,30 @@ export interface EngineSubmitAvailability {
   state: "available" | "blocked";
 }
 
+/**
+ * A failed new-session activation is only a missing session when the
+ * canonical session entity is absent. The runtime may be unavailable while
+ * the session remains a durable, selectable conversation.
+ */
+export type FailedNewActivationResolution =
+  | "not-applicable"
+  | "preserve"
+  | "rollback";
+
+export function selectFailedNewActivationResolution(
+  state: AgentSessionEngineStateBase,
+  agentSessionId: string | null | undefined
+): FailedNewActivationResolution {
+  const activation = selectLatestActivationForSession(state, agentSessionId);
+  if (activation?.mode !== "new" || isPendingActivationViable(activation)) {
+    return "not-applicable";
+  }
+  return state.sessionLifecycle?.sessionsById &&
+    selectEngineSession(state, agentSessionId)
+    ? "preserve"
+    : "rollback";
+}
+
 export function selectEngineSessionRuntimeAvailability(
   state: AgentSessionEngineStateBase,
   agentSessionId: string | null | undefined

--- a/packages/agent/activity-core/src/index.ts
+++ b/packages/agent/activity-core/src/index.ts
@@ -224,6 +224,7 @@ export {
   selectEngineLatestTurn,
   selectEnginePendingInteractions,
   selectEngineSession,
+  selectFailedNewActivationResolution,
   selectEngineSessionDeleted,
   selectEngineSessionIsRespondingToInteraction,
   selectEngineSessionRuntimeAvailability,
@@ -253,6 +254,7 @@ export {
   canonicalTurnKey
 } from "./engine/sessionEntityKeys.ts";
 export type {
+  FailedNewActivationResolution,
   WorkspaceAgentConsumerCounts,
   WorkspaceAgentConsumerSession
 } from "./engine/sessionLifecycle.selectors.ts";

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -638,16 +638,16 @@ export function AgentGUINodeView({
             inert={conversationRailCollapsed ? true : undefined}
           >
             <AgentConversationClockProvider isVisible={isVisible}>
+              {/* Activity is an all-provider rail snapshot. Selecting a row
+                  changes the active provider/target, but must not rebuild it. */}
               <AgentGUIConversationRailController
                 {...conversationRailStoreState}
                 activityContextKey={[
                   viewModel.shell.currentUserId?.trim() ?? "",
-                  viewModel.shell.data.provider?.trim() ?? "",
-                  viewModel.rail.selectedAgentTarget.agentTargetId?.trim() ??
-                    "",
                   viewModel.shell.nodeId?.trim() ?? ""
                 ].join("\u0000")}
                 conversations={viewModel.rail.conversations}
+                currentUserId={viewModel.shell.currentUserId}
                 nodeId={viewModel.shell.nodeId}
                 registerInteractionLockProbe={registerRailInteractionLockProbe}
                 userProjects={viewModel.rail.userProjects}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailController.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailController.tsx
@@ -12,8 +12,10 @@ export const AgentGUIConversationRailController = memo(
     const [conversationQuery, setConversationQuery] = useState("");
     const railQuery = useAgentGUIConversationRailQuery({
       activeConversationId: props.activeConversationId,
+      activityContextKey: props.activityContextKey,
       conversationFilter: props.conversationFilter,
       conversationQuery,
+      currentUserId: props.currentUserId,
       nodeId: props.nodeId,
       registerInteractionLockProbe: props.registerInteractionLockProbe,
       userProjects: props.userProjects,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
@@ -46,6 +46,10 @@ import type {
 import { resolveConversationRailQueryScope } from "./agentGuiConversationRailQueryTypes";
 import { AgentGUIConversationRailTargetedPageRefresher } from "./AgentGUIConversationRailTargetedPageRefresher";
 import { AgentGUIConversationRailSearchController } from "./AgentGUIConversationRailSearchController";
+import {
+  createAgentGUIConversationActivityController,
+  type AgentGUIConversationActivityController
+} from "./agentGUIConversationActivityController";
 export type { AgentGUIConversationRailQuerySnapshot } from "./agentConversationRailQuerySnapshot";
 export type {
   ConversationRailQueryRuntime,
@@ -57,6 +61,8 @@ const SECTION_REFRESH_LIMIT_MAX = 100;
 type Listener = (snapshot: AgentGUIConversationRailQuerySnapshot) => void;
 type PublicationRefreshState = "idle" | "pending" | "failed";
 export class AgentGUIConversationRailQueryController {
+  readonly activityController: AgentGUIConversationActivityController =
+    createAgentGUIConversationActivityController();
   readonly getSnapshot = (): AgentGUIConversationRailQuerySnapshot =>
     this.snapshot;
   readonly isInteractionLocked = (): boolean =>

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGUIConversationActivityController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGUIConversationActivityController.ts
@@ -1,0 +1,178 @@
+import {
+  createAgentGUIConversationActivityActivation,
+  reconcileAgentGUIConversationActivityActivation,
+  type AgentGUIConversationActivityActivation
+} from "../model/agentGuiConversationActivityView";
+import type { AgentGUIConversationSummary } from "../model/agentGuiConversationTypes";
+
+const EMPTY_DELETED_SESSION_IDS: Readonly<Record<string, true>> = {};
+
+export interface AgentGUIConversationActivityControllerInput {
+  available: boolean;
+  conversations: readonly AgentGUIConversationSummary[];
+  deletedSessionIds?: Readonly<Record<string, true>>;
+  identityKey: string;
+  scopeKey: string;
+}
+
+export interface AgentGUIConversationActivityControllerSnapshot {
+  available: boolean;
+  activation: AgentGUIConversationActivityActivation | null;
+  conversationCache: ReadonlyMap<string, AgentGUIConversationSummary>;
+  enabled: boolean;
+  identityKey: string | null;
+  scopeKey: string | null;
+}
+
+export interface AgentGUIConversationActivityController {
+  getSnapshot: () => AgentGUIConversationActivityControllerSnapshot;
+  subscribe: (listener: () => void) => () => void;
+  configure: (input: AgentGUIConversationActivityControllerInput) => void;
+  toggle: () => void;
+}
+
+const DISABLED_SNAPSHOT: AgentGUIConversationActivityControllerSnapshot = {
+  available: false,
+  activation: null,
+  conversationCache: new Map(),
+  enabled: false,
+  identityKey: null,
+  scopeKey: null
+};
+const AVAILABLE_OFF_SNAPSHOT: AgentGUIConversationActivityControllerSnapshot = {
+  ...DISABLED_SNAPSHOT,
+  available: true
+};
+
+export function createAgentGUIConversationActivityController(): AgentGUIConversationActivityController {
+  let snapshot = DISABLED_SNAPSHOT;
+  let latestInput: AgentGUIConversationActivityControllerInput | null = null;
+  const listeners = new Set<() => void>();
+
+  const publish = (
+    next: AgentGUIConversationActivityControllerSnapshot
+  ): void => {
+    if (next === snapshot) return;
+    snapshot = next;
+    for (const listener of listeners) listener();
+  };
+
+  const configure = (
+    input: AgentGUIConversationActivityControllerInput
+  ): void => {
+    latestInput = input;
+    if (!input.available) {
+      if (snapshot !== DISABLED_SNAPSHOT) publish(DISABLED_SNAPSHOT);
+      return;
+    }
+    if (!snapshot.enabled) {
+      if (snapshot !== AVAILABLE_OFF_SNAPSHOT) {
+        publish(AVAILABLE_OFF_SNAPSHOT);
+      }
+      return;
+    }
+
+    const sameContext =
+      snapshot.identityKey === input.identityKey &&
+      snapshot.scopeKey === input.scopeKey;
+    const deletedSessionIds =
+      input.deletedSessionIds ?? EMPTY_DELETED_SESSION_IDS;
+    const candidates = input.conversations.filter(
+      (conversation) => !deletedSessionIds[conversation.id]
+    );
+    const activation =
+      sameContext && snapshot.activation
+        ? reconcileAgentGUIConversationActivityActivation(
+            snapshot.activation,
+            candidates,
+            deletedSessionIds
+          )
+        : createAgentGUIConversationActivityActivation(candidates, Date.now());
+    const conversationCache = mergeConversationCache(
+      sameContext ? snapshot.conversationCache : new Map(),
+      candidates,
+      deletedSessionIds
+    );
+    if (
+      sameContext &&
+      activation === snapshot.activation &&
+      conversationCache === snapshot.conversationCache
+    ) {
+      return;
+    }
+    publish({
+      available: true,
+      activation,
+      conversationCache,
+      enabled: true,
+      identityKey: input.identityKey,
+      scopeKey: input.scopeKey
+    });
+  };
+
+  const toggle = (): void => {
+    const input = latestInput;
+    if (!input) return;
+    if (!input.available) return;
+    if (snapshot.enabled) {
+      publish(AVAILABLE_OFF_SNAPSHOT);
+      return;
+    }
+    const deletedSessionIds =
+      input.deletedSessionIds ?? EMPTY_DELETED_SESSION_IDS;
+    const candidates = input.conversations.filter(
+      (conversation) => !deletedSessionIds[conversation.id]
+    );
+    publish({
+      available: true,
+      activation: createAgentGUIConversationActivityActivation(
+        candidates,
+        Date.now()
+      ),
+      conversationCache: mergeConversationCache(
+        new Map(),
+        candidates,
+        deletedSessionIds
+      ),
+      enabled: true,
+      identityKey: input.identityKey,
+      scopeKey: input.scopeKey
+    });
+  };
+
+  return {
+    getSnapshot: () => snapshot,
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    configure,
+    toggle
+  };
+}
+
+function mergeConversationCache(
+  previous: ReadonlyMap<string, AgentGUIConversationSummary>,
+  conversations: readonly AgentGUIConversationSummary[],
+  deletedSessionIds: Readonly<Record<string, true>>
+): ReadonlyMap<string, AgentGUIConversationSummary> {
+  const next = new Map(previous);
+  for (const deletedId of Object.keys(deletedSessionIds)) {
+    next.delete(deletedId);
+  }
+  for (const conversation of conversations) {
+    next.set(conversation.id, conversation);
+  }
+  if (conversationMapsEqual(previous, next)) return previous;
+  return next;
+}
+
+function conversationMapsEqual(
+  left: ReadonlyMap<string, AgentGUIConversationSummary>,
+  right: ReadonlyMap<string, AgentGUIConversationSummary>
+): boolean {
+  return (
+    left.size === right.size &&
+    [...left].every(([id, conversation]) => right.get(id) === conversation)
+  );
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.stableHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.stableHelpers.ts
@@ -241,6 +241,7 @@ export function conversationSummariesRenderEqual(
     left.pinnedAtUnixMs === right.pinnedAtUnixMs &&
     left.sortTimeUnixMs === right.sortTimeUnixMs &&
     left.updatedAtUnixMs === right.updatedAtUnixMs &&
+    left.isTransient === right.isTransient &&
     left.projectionSource === right.projectionSource &&
     left.isImported === right.isImported &&
     left.hasUnreadCompletion === right.hasUnreadCompletion &&

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailQuerySnapshot.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailQuerySnapshot.ts
@@ -100,6 +100,7 @@ function conversationSummariesRenderEqual(
     left.pinnedAtUnixMs === right.pinnedAtUnixMs &&
     left.sortTimeUnixMs === right.sortTimeUnixMs &&
     left.updatedAtUnixMs === right.updatedAtUnixMs &&
+    left.isTransient === right.isTransient &&
     left.projectionSource === right.projectionSource &&
     left.isImported === right.isImported &&
     left.hasUnreadCompletion === right.hasUnreadCompletion &&

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentConversationSelection.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentConversationSelection.spec.tsx
@@ -226,7 +226,8 @@ describe("useAgentConversationSelection", () => {
     expect(active.current).toBe("session-a");
     expect(setIntent).toHaveBeenCalledWith({
       tag: "active",
-      id: "session-a"
+      id: "session-a",
+      source: "user-selection"
     });
     expect(setLoading).toHaveBeenCalledWith(false);
     expect(ensureHydrated).not.toHaveBeenCalled();

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentConversationSelection.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentConversationSelection.ts
@@ -7,7 +7,11 @@ import { rememberAgentGUIActiveConversation } from "../model/agentGuiSessionNavi
 export type ConversationIntent =
   | { tag: "home" }
   | { tag: "requested"; id: string }
-  | { tag: "active"; id: string };
+  | {
+      tag: "active";
+      id: string;
+      source?: "activation" | "user-selection";
+    };
 
 export interface AgentGUIConversationSelectionOptions {
   reloadConversations?: boolean;
@@ -132,7 +136,11 @@ export function useAgentConversationSelection(
       const reloadConversations =
         options?.reloadConversations !== false &&
         current.conversations.contains(normalized);
-      current.selection.setIntent({ tag: "active", id: normalized });
+      current.selection.setIntent({
+        id: normalized,
+        source: "user-selection",
+        tag: "active"
+      });
       current.selection.setActiveSessionId(normalized);
       current.selection.clearDetailError();
       if (options?.reveal) {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationActivityView.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationActivityView.spec.tsx
@@ -1,92 +1,73 @@
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import {
-  AgentGUIRuntimeProvider,
-  type AgentGUIRuntime
-} from "../../../agentActivityRuntime";
 import type { AgentGUIConversationSummary } from "../model/agentGuiConversationTypes";
-import type { AgentGUIConversationActivityRootFact } from "./useAgentGUIConversationRailQuery";
+import { createAgentGUIConversationActivityController } from "./agentGUIConversationActivityController";
 import { useAgentGUIConversationActivityView } from "./useAgentGUIConversationActivityView";
 
 describe("useAgentGUIConversationActivityView", () => {
   it("clears an active view when the host capability fails closed", () => {
-    let capability = true;
-    const runtime = {
-      get conversationActivityViewEnabled() {
-        return capability;
-      },
-      origin: "local"
-    } as unknown as AgentGUIRuntime;
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <AgentGUIRuntimeProvider runtime={runtime}>
-        {children}
-      </AgentGUIRuntimeProvider>
-    );
-    const rendered = renderHook(
-      () =>
-        useAgentGUIConversationActivityView({
-          conversations: [CONVERSATION],
-          hasConversationQuery: false,
-          rootFacts: new Map(),
-          scopeKey: "workspace-1"
-        }),
-      { wrapper }
+    const activityController = createAgentGUIConversationActivityController();
+    const rendered = renderHook(() =>
+      useAgentGUIConversationActivityView({
+        activityController,
+        conversations: [CONVERSATION],
+        hasConversationQuery: false
+      })
     );
 
-    act(() => rendered.result.current.toggle());
+    act(() => {
+      configure(activityController, [CONVERSATION]);
+      rendered.result.current.toggle();
+    });
     expect(rendered.result.current.enabled).toBe(true);
 
-    capability = false;
-    rendered.rerender();
+    act(() => configure(activityController, [], { available: false }));
     expect(rendered.result.current.enabled).toBe(false);
     expect(rendered.result.current.projection).toBeNull();
 
-    capability = true;
-    rendered.rerender();
+    act(() => configure(activityController, [CONVERSATION]));
     expect(rendered.result.current.enabled).toBe(false);
   });
 
   it("rebuilds instead of incrementally retaining idle sessions across identity changes", () => {
-    const runtime = {
-      conversationActivityViewEnabled: true,
-      origin: "local"
-    } as unknown as AgentGUIRuntime;
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <AgentGUIRuntimeProvider runtime={runtime}>
-        {children}
-      </AgentGUIRuntimeProvider>
-    );
+    const activityController = createAgentGUIConversationActivityController();
     const rendered = renderHook(
-      ({ conversation, identityKey }) =>
+      ({ conversation }) =>
         useAgentGUIConversationActivityView({
+          activityController,
           conversations: [conversation],
-          hasConversationQuery: false,
-          identityKey,
-          rootFacts: new Map(),
-          scopeKey: "workspace-1"
+          hasConversationQuery: false
         }),
       {
         initialProps: {
-          conversation: CONVERSATION,
-          identityKey: "user-1:codex"
-        },
-        wrapper
+          conversation: CONVERSATION
+        }
       }
     );
 
-    act(() => rendered.result.current.toggle());
+    act(() => {
+      configure(activityController, [CONVERSATION], {
+        identityKey: "user-1:codex"
+      });
+      rendered.result.current.toggle();
+    });
     expect(rendered.result.current.projection?.priorityIds).toEqual([
       "session-1"
     ]);
 
+    const nextConversation = {
+      ...CONVERSATION,
+      id: "session-2",
+      status: "ready" as const,
+      title: "Session 2"
+    };
+    act(() =>
+      configure(activityController, [nextConversation], {
+        identityKey: "user-2:codex"
+      })
+    );
     rendered.rerender({
-      conversation: {
-        ...CONVERSATION,
-        id: "session-2",
-        status: "ready",
-        title: "Session 2"
-      },
-      identityKey: "user-2:codex"
+      conversation: nextConversation
     });
     expect(rendered.result.current.projection?.priorityIds).toEqual([]);
     expect(rendered.result.current.projection?.recentSections[0]?.ids).toEqual([
@@ -95,30 +76,31 @@ describe("useAgentGUIConversationActivityView", () => {
   });
 
   it("keeps an existing Priority row while a rail refresh omits its summary", () => {
-    const runtime = {
-      conversationActivityViewEnabled: true,
-      origin: "local"
-    } as unknown as AgentGUIRuntime;
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <AgentGUIRuntimeProvider runtime={runtime}>
-        {children}
-      </AgentGUIRuntimeProvider>
-    );
+    const activityController = createAgentGUIConversationActivityController();
     const rendered = renderHook(
       ({ conversations }) =>
         useAgentGUIConversationActivityView({
+          activityController,
           conversations,
-          hasConversationQuery: false,
-          rootFacts: new Map(),
-          scopeKey: "workspace-1"
+          hasConversationQuery: false
         }),
       {
-        initialProps: { conversations: [CONVERSATION] },
-        wrapper
+        initialProps: { conversations: [CONVERSATION] }
       }
     );
 
-    act(() => rendered.result.current.toggle());
+    act(() => {
+      configure(activityController, [CONVERSATION]);
+      rendered.result.current.toggle();
+    });
+    expect(activityController.getSnapshot().enabled).toBe(true);
+    expect(
+      activityController.getSnapshot().conversationCache.get("session-1")
+    ).toBe(CONVERSATION);
+    act(() => configure(activityController, []));
+    expect(
+      activityController.getSnapshot().conversationCache.get("session-1")
+    ).toBe(CONVERSATION);
     rendered.rerender({ conversations: [] });
 
     expect(rendered.result.current.projection?.priorityIds).toEqual([
@@ -130,34 +112,32 @@ describe("useAgentGUIConversationActivityView", () => {
   });
 
   it("does not render a cached Priority row after an Engine tombstone", () => {
-    const runtime = {
-      conversationActivityViewEnabled: true,
-      origin: "local"
-    } as unknown as AgentGUIRuntime;
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <AgentGUIRuntimeProvider runtime={runtime}>
-        {children}
-      </AgentGUIRuntimeProvider>
-    );
+    const activityController = createAgentGUIConversationActivityController();
     const rendered = renderHook(
       ({ conversations, deletedSessionIds }) =>
         useAgentGUIConversationActivityView({
+          activityController,
           conversations,
           deletedSessionIds,
-          hasConversationQuery: false,
-          rootFacts: new Map(),
-          scopeKey: "workspace-1"
+          hasConversationQuery: false
         }),
       {
         initialProps: {
           conversations: [CONVERSATION],
           deletedSessionIds: {}
-        },
-        wrapper
+        }
       }
     );
 
-    act(() => rendered.result.current.toggle());
+    act(() => {
+      configure(activityController, [CONVERSATION]);
+      rendered.result.current.toggle();
+    });
+    act(() =>
+      configure(activityController, [], {
+        deletedSessionIds: { "session-1": true }
+      })
+    );
     rendered.rerender({
       conversations: [],
       deletedSessionIds: { "session-1": true }
@@ -170,16 +150,7 @@ describe("useAgentGUIConversationActivityView", () => {
   });
 
   it("preserves unchanged conversation objects when one root activity fact changes", () => {
-    const runtime = {
-      conversationActivityViewEnabled: true,
-      origin: "local"
-    } as unknown as AgentGUIRuntime;
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <AgentGUIRuntimeProvider runtime={runtime}>
-        {children}
-      </AgentGUIRuntimeProvider>
-    );
-    const conversations = [
+    const conversations: AgentGUIConversationSummary[] = [
       {
         ...CONVERSATION,
         id: "changed",
@@ -193,36 +164,37 @@ describe("useAgentGUIConversationActivityView", () => {
         title: "Unchanged"
       }
     ];
-    const initialRootFacts: ReadonlyMap<
-      string,
-      AgentGUIConversationActivityRootFact
-    > = new Map([
-      ["changed", { needsUserAction: false, status: "ready" }],
-      ["unchanged", { needsUserAction: false, status: "ready" }]
-    ]);
+    const activityController = createAgentGUIConversationActivityController();
     const rendered = renderHook(
-      ({ rootFacts }) =>
+      ({ currentConversations }) =>
         useAgentGUIConversationActivityView({
-          conversations,
-          hasConversationQuery: false,
-          rootFacts,
-          scopeKey: "workspace-1"
+          activityController,
+          conversations: currentConversations,
+          hasConversationQuery: false
         }),
       {
-        initialProps: { rootFacts: initialRootFacts },
-        wrapper
+        initialProps: { currentConversations: conversations }
       }
     );
+    act(() => configure(activityController, conversations));
+    rendered.rerender({ currentConversations: conversations });
     const changedBefore =
       rendered.result.current.conversationsById.get("changed");
     const unchangedBefore =
       rendered.result.current.conversationsById.get("unchanged");
+    const changedConversation = conversations[0];
+    const unchangedConversation = conversations[1];
+    if (!changedConversation || !unchangedConversation) {
+      throw new Error("conversation fixture is incomplete");
+    }
 
+    const nextConversations: AgentGUIConversationSummary[] = [
+      { ...changedConversation, status: "working" as const },
+      unchangedConversation
+    ];
+    act(() => configure(activityController, nextConversations));
     rendered.rerender({
-      rootFacts: new Map<string, AgentGUIConversationActivityRootFact>([
-        ["changed", { needsUserAction: false, status: "working" }],
-        ["unchanged", { needsUserAction: false, status: "ready" }]
-      ])
+      currentConversations: nextConversations
     });
 
     expect(rendered.result.current.conversationsById.get("changed")).not.toBe(
@@ -233,6 +205,25 @@ describe("useAgentGUIConversationActivityView", () => {
     );
   });
 });
+
+function configure(
+  controller: ReturnType<typeof createAgentGUIConversationActivityController>,
+  conversations: readonly AgentGUIConversationSummary[],
+  overrides: Partial<{
+    available: boolean;
+    deletedSessionIds: Readonly<Record<string, true>>;
+    identityKey: string;
+    scopeKey: string;
+  }> = {}
+): void {
+  controller.configure({
+    available: overrides.available ?? true,
+    conversations,
+    deletedSessionIds: overrides.deletedSessionIds,
+    identityKey: overrides.identityKey ?? "workspace-1",
+    scopeKey: overrides.scopeKey ?? "workspace-1"
+  });
+}
 
 const CONVERSATION: AgentGUIConversationSummary = {
   cwd: "/workspace",

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationActivityView.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationActivityView.spec.tsx
@@ -94,6 +94,81 @@ describe("useAgentGUIConversationActivityView", () => {
     ]);
   });
 
+  it("keeps an existing Priority row while a rail refresh omits its summary", () => {
+    const runtime = {
+      conversationActivityViewEnabled: true,
+      origin: "local"
+    } as unknown as AgentGUIRuntime;
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AgentGUIRuntimeProvider runtime={runtime}>
+        {children}
+      </AgentGUIRuntimeProvider>
+    );
+    const rendered = renderHook(
+      ({ conversations }) =>
+        useAgentGUIConversationActivityView({
+          conversations,
+          hasConversationQuery: false,
+          rootFacts: new Map(),
+          scopeKey: "workspace-1"
+        }),
+      {
+        initialProps: { conversations: [CONVERSATION] },
+        wrapper
+      }
+    );
+
+    act(() => rendered.result.current.toggle());
+    rendered.rerender({ conversations: [] });
+
+    expect(rendered.result.current.projection?.priorityIds).toEqual([
+      "session-1"
+    ]);
+    expect(rendered.result.current.conversationsById.get("session-1")).toBe(
+      CONVERSATION
+    );
+  });
+
+  it("does not render a cached Priority row after an Engine tombstone", () => {
+    const runtime = {
+      conversationActivityViewEnabled: true,
+      origin: "local"
+    } as unknown as AgentGUIRuntime;
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AgentGUIRuntimeProvider runtime={runtime}>
+        {children}
+      </AgentGUIRuntimeProvider>
+    );
+    const rendered = renderHook(
+      ({ conversations, deletedSessionIds }) =>
+        useAgentGUIConversationActivityView({
+          conversations,
+          deletedSessionIds,
+          hasConversationQuery: false,
+          rootFacts: new Map(),
+          scopeKey: "workspace-1"
+        }),
+      {
+        initialProps: {
+          conversations: [CONVERSATION],
+          deletedSessionIds: {}
+        },
+        wrapper
+      }
+    );
+
+    act(() => rendered.result.current.toggle());
+    rendered.rerender({
+      conversations: [],
+      deletedSessionIds: { "session-1": true }
+    });
+
+    expect(rendered.result.current.projection?.priorityIds).toEqual([]);
+    expect(rendered.result.current.conversationsById.has("session-1")).toBe(
+      false
+    );
+  });
+
   it("preserves unchanged conversation objects when one root activity fact changes", () => {
     const runtime = {
       conversationActivityViewEnabled: true,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationActivityView.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationActivityView.ts
@@ -1,39 +1,8 @@
-import { useCallback, useMemo, useState } from "react";
-import {
-  useAgentGUIRuntime,
-  type AgentGUIRuntime
-} from "../../../agentActivityRuntime";
+import { useCallback, useMemo } from "react";
+import { useEngineSelector } from "../../../shared/engine/useEngineSelector";
+import type { AgentGUIConversationActivityController } from "./agentGUIConversationActivityController";
 import type { AgentGUIConversationSummary } from "../model/agentGuiConversationTypes";
-import {
-  createAgentGUIConversationActivityActivation,
-  projectAgentGUIConversationActivity,
-  reconcileAgentGUIConversationActivityActivation,
-  type AgentGUIConversationActivityActivation
-} from "../model/agentGuiConversationActivityView";
-import type { AgentGUIConversationActivityRootFact } from "./useAgentGUIConversationRailQuery";
-
-interface AgentGUIConversationActivityViewState {
-  activation: AgentGUIConversationActivityActivation | null;
-  enabled: boolean;
-  identityKey: string | null;
-  runtime: AgentGUIRuntime | null;
-  scopeKey: string | null;
-  conversationCache: ReadonlyMap<string, AgentGUIConversationSummary>;
-}
-
-const EMPTY_ACTIVITY_CONVERSATION_CACHE: ReadonlyMap<
-  string,
-  AgentGUIConversationSummary
-> = new Map();
-
-const DISABLED_ACTIVITY_VIEW_STATE: AgentGUIConversationActivityViewState = {
-  activation: null,
-  conversationCache: EMPTY_ACTIVITY_CONVERSATION_CACHE,
-  enabled: false,
-  identityKey: null,
-  runtime: null,
-  scopeKey: null
-};
+import { projectAgentGUIConversationActivity } from "../model/agentGuiConversationActivityView";
 
 export interface AgentGUIConversationActivityViewController {
   available: boolean;
@@ -45,7 +14,6 @@ export interface AgentGUIConversationActivityViewController {
   toggle: () => void;
 }
 
-const EMPTY_ACTIVITY_CONVERSATIONS: readonly AgentGUIConversationSummary[] = [];
 const EMPTY_ACTIVITY_CONVERSATIONS_BY_ID: ReadonlyMap<
   string,
   AgentGUIConversationSummary
@@ -53,134 +21,36 @@ const EMPTY_ACTIVITY_CONVERSATIONS_BY_ID: ReadonlyMap<
 const EMPTY_DELETED_SESSION_IDS: Readonly<Record<string, true>> = {};
 
 export function useAgentGUIConversationActivityView({
+  activityController,
   conversations,
   hasConversationQuery,
-  identityKey = "",
-  deletedSessionIds = EMPTY_DELETED_SESSION_IDS,
-  rootFacts,
-  scopeKey
+  deletedSessionIds = EMPTY_DELETED_SESSION_IDS
 }: {
+  activityController: AgentGUIConversationActivityController;
   conversations: readonly AgentGUIConversationSummary[];
   hasConversationQuery: boolean;
-  identityKey?: string;
   deletedSessionIds?: Readonly<Record<string, true>>;
-  rootFacts: ReadonlyMap<string, AgentGUIConversationActivityRootFact>;
-  scopeKey: string;
 }): AgentGUIConversationActivityViewController {
-  const runtime = useAgentGUIRuntime();
-  const available = runtime.conversationActivityViewEnabled === true;
-  const activityConversations = useMemo(
-    () =>
-      available
-        ? conversations.map((conversation) => {
-            const fact = rootFacts.get(conversation.id);
-            if (
-              !fact ||
-              (fact.needsUserAction === Boolean(conversation.needsUserAction) &&
-                fact.status === conversation.status)
-            ) {
-              return conversation;
-            }
-            return {
-              ...conversation,
-              needsUserAction: fact.needsUserAction,
-              status: fact.status
-            };
-          })
-        : EMPTY_ACTIVITY_CONVERSATIONS,
-    [available, conversations, rootFacts]
+  const state = useEngineSelector(
+    activityController,
+    (snapshot) => snapshot,
+    Object.is
   );
-  const [storedState, setStoredState] =
-    useState<AgentGUIConversationActivityViewState>(
-      DISABLED_ACTIVITY_VIEW_STATE
-    );
 
-  let state = storedState;
-  let shouldStoreState = false;
-  let conversationCache = state.conversationCache;
-  const activityContextChanged =
-    state.enabled &&
-    (state.identityKey !== identityKey ||
-      state.runtime !== runtime ||
-      state.scopeKey !== scopeKey);
-  if (!available || !state.enabled || activityContextChanged) {
-    conversationCache = EMPTY_ACTIVITY_CONVERSATION_CACHE;
-  }
-  if (!available && state !== DISABLED_ACTIVITY_VIEW_STATE) {
-    state = DISABLED_ACTIVITY_VIEW_STATE;
-    shouldStoreState = true;
-  } else if (available && state.enabled) {
-    const sameIdentity =
-      state.identityKey === identityKey && state.runtime === runtime;
-    const activation =
-      sameIdentity && state.scopeKey === scopeKey && state.activation
-        ? reconcileAgentGUIConversationActivityActivation(
-            state.activation,
-            activityConversations,
-            deletedSessionIds
-          )
-        : createAgentGUIConversationActivityActivation(
-            activityConversations,
-            Date.now(),
-            sameIdentity
-              ? state.activation?.priorityRetentionRecencyById
-              : undefined
-          );
-    if (
-      activation !== state.activation ||
-      state.identityKey !== identityKey ||
-      state.runtime !== runtime ||
-      state.scopeKey !== scopeKey
-    ) {
-      state = {
-        activation,
-        conversationCache,
-        enabled: true,
-        identityKey,
-        runtime,
-        scopeKey
-      };
-      shouldStoreState = true;
-    }
-  }
-
-  const enabled = available && state.enabled;
-  if (enabled) {
-    const nextConversationCache = new Map(conversationCache);
-    for (const deletedId of Object.keys(deletedSessionIds)) {
-      nextConversationCache.delete(deletedId);
-    }
-    for (const conversation of activityConversations) {
-      if (deletedSessionIds[conversation.id]) continue;
-      nextConversationCache.set(conversation.id, conversation);
-    }
-    if (
-      !activityConversationMapsEqual(conversationCache, nextConversationCache)
-    ) {
-      conversationCache = nextConversationCache;
-    }
-  } else {
-    conversationCache = EMPTY_ACTIVITY_CONVERSATION_CACHE;
-  }
-  if (conversationCache !== state.conversationCache) {
-    state = { ...state, conversationCache };
-    shouldStoreState = true;
-  }
-  if (shouldStoreState) {
-    setStoredState(state);
-  }
+  const available = state.available;
+  const enabled = state.enabled;
   const currentConversationsById = useMemo(
     () =>
       available
         ? new Map(
-            activityConversations.flatMap((conversation) =>
+            conversations.flatMap((conversation) =>
               deletedSessionIds[conversation.id]
                 ? []
                 : [[conversation.id, conversation]]
             )
           )
         : EMPTY_ACTIVITY_CONVERSATIONS_BY_ID,
-    [activityConversations, available, deletedSessionIds]
+    [available, conversations, deletedSessionIds]
   );
   const conversationsById = useMemo(() => {
     if (!available) return EMPTY_ACTIVITY_CONVERSATIONS_BY_ID;
@@ -191,60 +61,37 @@ export function useAgentGUIConversationActivityView({
       ...state.activation.recent
     ]) {
       if (result.has(member.id)) continue;
-      const cached = conversationCache.get(member.id);
+      const cached = state.conversationCache.get(member.id);
       if (cached) result.set(member.id, cached);
     }
     return result;
   }, [
     available,
-    conversationCache,
     currentConversationsById,
     enabled,
-    state.activation
+    state.activation,
+    state.conversationCache
   ]);
   const needsAttention = useMemo(
     () =>
       available &&
-      activityConversations.some(
+      conversations.some(
         (conversation) =>
           !deletedSessionIds[conversation.id] &&
           (conversation.needsUserAction || conversation.hasUnreadCompletion)
       ),
-    [activityConversations, available, deletedSessionIds]
+    [available, conversations, deletedSessionIds]
   );
   const projection = useMemo(
     () =>
-      state.activation
+      enabled && state.activation
         ? projectAgentGUIConversationActivity(state.activation)
         : null,
-    [state.activation]
+    [enabled, state.activation]
   );
   const toggle = useCallback(() => {
-    if (enabled) {
-      setStoredState(DISABLED_ACTIVITY_VIEW_STATE);
-      return;
-    }
-    setStoredState({
-      activation: createAgentGUIConversationActivityActivation(
-        activityConversations.filter(
-          (conversation) => !deletedSessionIds[conversation.id]
-        ),
-        Date.now()
-      ),
-      conversationCache: EMPTY_ACTIVITY_CONVERSATION_CACHE,
-      enabled: true,
-      identityKey,
-      runtime,
-      scopeKey
-    });
-  }, [
-    activityConversations,
-    deletedSessionIds,
-    enabled,
-    identityKey,
-    runtime,
-    scopeKey
-  ]);
+    activityController.toggle();
+  }, [activityController]);
   return useMemo(
     () => ({
       available,
@@ -264,17 +111,5 @@ export function useAgentGUIConversationActivityView({
       projection,
       toggle
     ]
-  );
-}
-
-function activityConversationMapsEqual(
-  left: ReadonlyMap<string, AgentGUIConversationSummary>,
-  right: ReadonlyMap<string, AgentGUIConversationSummary>
-): boolean {
-  return (
-    left.size === right.size &&
-    [...left].every(([id, conversation]) => {
-      return right.get(id) === conversation;
-    })
   );
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationActivityView.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationActivityView.ts
@@ -18,10 +18,17 @@ interface AgentGUIConversationActivityViewState {
   identityKey: string | null;
   runtime: AgentGUIRuntime | null;
   scopeKey: string | null;
+  conversationCache: ReadonlyMap<string, AgentGUIConversationSummary>;
 }
+
+const EMPTY_ACTIVITY_CONVERSATION_CACHE: ReadonlyMap<
+  string,
+  AgentGUIConversationSummary
+> = new Map();
 
 const DISABLED_ACTIVITY_VIEW_STATE: AgentGUIConversationActivityViewState = {
   activation: null,
+  conversationCache: EMPTY_ACTIVITY_CONVERSATION_CACHE,
   enabled: false,
   identityKey: null,
   runtime: null,
@@ -43,17 +50,20 @@ const EMPTY_ACTIVITY_CONVERSATIONS_BY_ID: ReadonlyMap<
   string,
   AgentGUIConversationSummary
 > = new Map();
+const EMPTY_DELETED_SESSION_IDS: Readonly<Record<string, true>> = {};
 
 export function useAgentGUIConversationActivityView({
   conversations,
   hasConversationQuery,
   identityKey = "",
+  deletedSessionIds = EMPTY_DELETED_SESSION_IDS,
   rootFacts,
   scopeKey
 }: {
   conversations: readonly AgentGUIConversationSummary[];
   hasConversationQuery: boolean;
   identityKey?: string;
+  deletedSessionIds?: Readonly<Record<string, true>>;
   rootFacts: ReadonlyMap<string, AgentGUIConversationActivityRootFact>;
   scopeKey: string;
 }): AgentGUIConversationActivityViewController {
@@ -86,9 +96,19 @@ export function useAgentGUIConversationActivityView({
     );
 
   let state = storedState;
+  let shouldStoreState = false;
+  let conversationCache = state.conversationCache;
+  const activityContextChanged =
+    state.enabled &&
+    (state.identityKey !== identityKey ||
+      state.runtime !== runtime ||
+      state.scopeKey !== scopeKey);
+  if (!available || !state.enabled || activityContextChanged) {
+    conversationCache = EMPTY_ACTIVITY_CONVERSATION_CACHE;
+  }
   if (!available && state !== DISABLED_ACTIVITY_VIEW_STATE) {
     state = DISABLED_ACTIVITY_VIEW_STATE;
-    setStoredState(state);
+    shouldStoreState = true;
   } else if (available && state.enabled) {
     const sameIdentity =
       state.identityKey === identityKey && state.runtime === runtime;
@@ -96,7 +116,8 @@ export function useAgentGUIConversationActivityView({
       sameIdentity && state.scopeKey === scopeKey && state.activation
         ? reconcileAgentGUIConversationActivityActivation(
             state.activation,
-            activityConversations
+            activityConversations,
+            deletedSessionIds
           )
         : createAgentGUIConversationActivityActivation(
             activityConversations,
@@ -113,36 +134,83 @@ export function useAgentGUIConversationActivityView({
     ) {
       state = {
         activation,
+        conversationCache,
         enabled: true,
         identityKey,
         runtime,
         scopeKey
       };
-      setStoredState(state);
+      shouldStoreState = true;
     }
   }
 
   const enabled = available && state.enabled;
-  const conversationsById = useMemo(
+  if (enabled) {
+    const nextConversationCache = new Map(conversationCache);
+    for (const deletedId of Object.keys(deletedSessionIds)) {
+      nextConversationCache.delete(deletedId);
+    }
+    for (const conversation of activityConversations) {
+      if (deletedSessionIds[conversation.id]) continue;
+      nextConversationCache.set(conversation.id, conversation);
+    }
+    if (
+      !activityConversationMapsEqual(conversationCache, nextConversationCache)
+    ) {
+      conversationCache = nextConversationCache;
+    }
+  } else {
+    conversationCache = EMPTY_ACTIVITY_CONVERSATION_CACHE;
+  }
+  if (conversationCache !== state.conversationCache) {
+    state = { ...state, conversationCache };
+    shouldStoreState = true;
+  }
+  if (shouldStoreState) {
+    setStoredState(state);
+  }
+  const currentConversationsById = useMemo(
     () =>
       available
         ? new Map(
-            activityConversations.map((conversation) => [
-              conversation.id,
-              conversation
-            ])
+            activityConversations.flatMap((conversation) =>
+              deletedSessionIds[conversation.id]
+                ? []
+                : [[conversation.id, conversation]]
+            )
           )
         : EMPTY_ACTIVITY_CONVERSATIONS_BY_ID,
-    [activityConversations, available]
+    [activityConversations, available, deletedSessionIds]
   );
+  const conversationsById = useMemo(() => {
+    if (!available) return EMPTY_ACTIVITY_CONVERSATIONS_BY_ID;
+    if (!enabled || !state.activation) return currentConversationsById;
+    const result = new Map(currentConversationsById);
+    for (const member of [
+      ...state.activation.priority,
+      ...state.activation.recent
+    ]) {
+      if (result.has(member.id)) continue;
+      const cached = conversationCache.get(member.id);
+      if (cached) result.set(member.id, cached);
+    }
+    return result;
+  }, [
+    available,
+    conversationCache,
+    currentConversationsById,
+    enabled,
+    state.activation
+  ]);
   const needsAttention = useMemo(
     () =>
       available &&
       activityConversations.some(
         (conversation) =>
-          conversation.needsUserAction || conversation.hasUnreadCompletion
+          !deletedSessionIds[conversation.id] &&
+          (conversation.needsUserAction || conversation.hasUnreadCompletion)
       ),
-    [activityConversations, available]
+    [activityConversations, available, deletedSessionIds]
   );
   const projection = useMemo(
     () =>
@@ -158,15 +226,25 @@ export function useAgentGUIConversationActivityView({
     }
     setStoredState({
       activation: createAgentGUIConversationActivityActivation(
-        activityConversations,
+        activityConversations.filter(
+          (conversation) => !deletedSessionIds[conversation.id]
+        ),
         Date.now()
       ),
+      conversationCache: EMPTY_ACTIVITY_CONVERSATION_CACHE,
       enabled: true,
       identityKey,
       runtime,
       scopeKey
     });
-  }, [activityConversations, enabled, identityKey, runtime, scopeKey]);
+  }, [
+    activityConversations,
+    deletedSessionIds,
+    enabled,
+    identityKey,
+    runtime,
+    scopeKey
+  ]);
   return useMemo(
     () => ({
       available,
@@ -186,5 +264,17 @@ export function useAgentGUIConversationActivityView({
       projection,
       toggle
     ]
+  );
+}
+
+function activityConversationMapsEqual(
+  left: ReadonlyMap<string, AgentGUIConversationSummary>,
+  right: ReadonlyMap<string, AgentGUIConversationSummary>
+): boolean {
+  return (
+    left.size === right.size &&
+    [...left].every(([id, conversation]) => {
+      return right.get(id) === conversation;
+    })
   );
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.activity.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.activity.spec.tsx
@@ -75,6 +75,11 @@ describe("useAgentGUIConversationRailQuery Activity facts", () => {
       })
     );
     expect(rendered.result.current.activityRootFacts.has("child")).toBe(false);
+    expect(
+      rendered.result.current.activityConversations.map(
+        (conversation) => conversation.id
+      )
+    ).toEqual(["root"]);
 
     act(() => {
       engine.dispatch({

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts
@@ -1,5 +1,9 @@
 import { useEffect, useMemo, useRef } from "react";
-import { selectWorkspaceAgentRootConversationSessions } from "@tutti-os/agent-activity-core";
+import {
+  selectAttentionReadState,
+  selectWorkspaceAgentConsumerSessions,
+  selectWorkspaceAgentRootConversationSessions
+} from "@tutti-os/agent-activity-core";
 import {
   useAgentGUIRuntime,
   type AgentGUIRuntime
@@ -12,34 +16,48 @@ import {
 import { inspectAgentConversationBatchDeletionCapability } from "./agentConversationBatchDeletionCapability";
 import { useEngineSelector } from "../../../shared/engine/useEngineSelector";
 import type { AgentGUINodeViewModel } from "../model/agentGuiNodeTypes";
+import {
+  applyAgentGUIConversationProjects,
+  type AgentGUIConversationSummary
+} from "../model/agentGuiConversationModel";
+import type { AgentGUIConversationActivityRootFact } from "../model/agentGuiConversationActivityView";
+import {
+  filterAgentGUIConversationSummaries,
+  type AgentGUIConversationFilter
+} from "../model/agentGuiConversationFilter";
+import { createAgentGUIConversationRailTitlePromptSelector } from "../../../shared/agentConversationRailTitlePromptSelector";
+import { projectCanonicalAgentGUIConversationSummaries } from "../../../shared/agentGUIConversationSummaryProjection";
+import { conversationSummariesRenderEqual } from "./agentGuiController.stableHelpers";
 import { createConversationRailConversationsSelector } from "./agentGuiConversationRailQuerySnapshot";
 import { resolveConversationRailQueryScope } from "./agentGuiConversationRailQueryTypes";
+import { agentGUIConversationRailViewScopeKey } from "../model/agentGuiConversationRailViewState";
 import { reportAgentGUIConversationBatchDeletionCapabilityIncomplete } from "./agentGuiController.reporting";
 
 export interface AgentGUIConversationRailInput {
   activeConversationId: string | null;
+  activityContextKey?: string;
   conversationFilter: AgentGUINodeViewModel["rail"]["conversationFilter"];
   conversationQuery: string;
+  currentUserId?: string | null;
   nodeId?: string | null;
   registerInteractionLockProbe?: (probe: (() => boolean) | null) => void;
   userProjects: AgentGUINodeViewModel["rail"]["userProjects"];
   workspaceId: string;
 }
 
-export interface AgentGUIConversationActivityRootFact {
-  needsUserAction: boolean;
-  status: AgentGUINodeViewModel["rail"]["conversations"][number]["status"];
-}
-
 const EMPTY_AGENT_GUI_CONVERSATION_ACTIVITY_ROOT_FACTS: ReadonlyMap<
   string,
   AgentGUIConversationActivityRootFact
 > = new Map();
+const EMPTY_AGENT_GUI_CONVERSATION_ACTIVITY_CONVERSATIONS: readonly AgentGUIConversationSummary[] =
+  [];
 
 export function useAgentGUIConversationRailQuery({
   activeConversationId,
   conversationFilter,
   conversationQuery,
+  activityContextKey = "",
+  currentUserId,
   nodeId,
   registerInteractionLockProbe,
   userProjects,
@@ -54,6 +72,7 @@ export function useAgentGUIConversationRailQuery({
     () => runtime.getSessionEngine(workspaceId),
     [runtime, workspaceId]
   );
+  const activityEnabled = runtime.conversationActivityViewEnabled === true;
   const activeConversationIdRef = useRef(activeConversationId);
   activeConversationIdRef.current = activeConversationId;
   const railRuntime = useMemo(
@@ -94,14 +113,6 @@ export function useAgentGUIConversationRailQuery({
     runtime,
     workspaceId
   ]);
-  useEffect(() => {
-    controller.configure({
-      conversationFilter,
-      userProjects
-    });
-    controller.setSearchQuery(conversationQuery);
-  }, [controller, conversationFilter, conversationQuery, userProjects]);
-
   const querySnapshot = useEngineSelector(
     controller,
     identitySnapshot,
@@ -142,10 +153,68 @@ export function useAgentGUIConversationRailQuery({
     selectActivityRootFacts,
     activityRootFactsEqual
   );
+  const selectActivityTitlePrompts = useMemo(
+    () => createAgentGUIConversationRailTitlePromptSelector(),
+    [engine]
+  );
+  const activityTitlePrompts = useEngineSelector(
+    engine,
+    selectActivityTitlePrompts,
+    Object.is
+  );
+  const selectActivityConversations = useMemo(
+    () => (state: Parameters<typeof selectWorkspaceAgentConsumerSessions>[0]) =>
+      selectCanonicalActivityConversations(state, {
+        activityEnabled,
+        conversationFilter,
+        currentUserId,
+        firstUserDisplayPromptsBySessionId: activityTitlePrompts,
+        userProjects
+      }),
+    [
+      activityEnabled,
+      activityTitlePrompts,
+      conversationFilter,
+      currentUserId,
+      userProjects
+    ]
+  );
+  const activityConversations = useEngineSelector(
+    engine,
+    selectActivityConversations,
+    activityConversationArraysEqual
+  );
   const deletedSessionIds = useEngineSelector(
     engine,
     (state) => state.sessionLifecycle.deletedSessionIds
   );
+  useEffect(() => {
+    controller.configure({
+      conversationFilter,
+      userProjects
+    });
+    controller.setSearchQuery(conversationQuery);
+    controller.activityController.configure({
+      available: activityEnabled,
+      conversations: activityConversations,
+      deletedSessionIds,
+      identityKey: `${workspaceId}\u0000${activityContextKey}`,
+      scopeKey: agentGUIConversationRailViewScopeKey({
+        conversationFilter,
+        workspaceId
+      })
+    });
+  }, [
+    activityContextKey,
+    activityConversations,
+    activityEnabled,
+    controller,
+    conversationFilter,
+    conversationQuery,
+    deletedSessionIds,
+    userProjects,
+    workspaceId
+  ]);
   const requestedRailScopeKey = useMemo(
     () =>
       resolveConversationRailQueryScope(workspaceId, {
@@ -157,8 +226,10 @@ export function useAgentGUIConversationRailQuery({
   return useMemo(
     () => ({
       ...querySnapshot,
+      activityController: controller.activityController,
       batchDeletionAvailable: batchDeletionCapability.available,
       activityRootFacts,
+      activityConversations,
       deletedSessionIds,
       isInteractionLocked: controller.isInteractionLocked,
       loadMoreSectionConversations: controller.loadMoreSectionConversations,
@@ -175,6 +246,7 @@ export function useAgentGUIConversationRailQuery({
     [
       batchDeletionCapability.available,
       activityRootFacts,
+      activityConversations,
       controller,
       deletedSessionIds,
       querySnapshot,
@@ -204,6 +276,56 @@ function selectAgentGUIConversationActivityRootFacts(
           status: item.displayStatus === "idle" ? "ready" : item.displayStatus
         }
       ])
+  );
+}
+
+function selectCanonicalActivityConversations(
+  state: Parameters<typeof selectWorkspaceAgentConsumerSessions>[0],
+  input: {
+    activityEnabled: boolean;
+    conversationFilter: AgentGUIConversationFilter;
+    currentUserId?: string | null;
+    firstUserDisplayPromptsBySessionId: Record<string, string>;
+    userProjects: AgentGUINodeViewModel["rail"]["userProjects"];
+  }
+): readonly AgentGUIConversationSummary[] {
+  if (!input.activityEnabled) {
+    return EMPTY_AGENT_GUI_CONVERSATION_ACTIVITY_CONVERSATIONS;
+  }
+  const rootFacts = selectAgentGUIConversationActivityRootFacts(state);
+  const attention = selectAttentionReadState(state, input.currentUserId);
+  const summaries = projectCanonicalAgentGUIConversationSummaries(
+    selectWorkspaceAgentConsumerSessions(state),
+    input.firstUserDisplayPromptsBySessionId
+  ).map((conversation): AgentGUIConversationSummary => {
+    const fact = rootFacts.get(conversation.id);
+    const attentionRecord = attention.recordsBySessionId[conversation.id];
+    return {
+      ...conversation,
+      hasUnreadCompletion: attentionRecord?.isUnread ?? false,
+      needsUserAction: fact?.needsUserAction ?? conversation.needsUserAction,
+      status: fact?.status ?? conversation.status
+    };
+  });
+  return filterAgentGUIConversationSummaries(
+    applyAgentGUIConversationProjects(summaries, input.userProjects),
+    input.conversationFilter
+  );
+}
+
+function activityConversationArraysEqual(
+  left: readonly AgentGUIConversationSummary[],
+  right: readonly AgentGUIConversationSummary[]
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((conversation, index) => {
+      const other = right[index];
+      return (
+        other !== undefined &&
+        conversationSummariesRenderEqual(conversation, other)
+      );
+    })
   );
 }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts
@@ -142,6 +142,10 @@ export function useAgentGUIConversationRailQuery({
     selectActivityRootFacts,
     activityRootFactsEqual
   );
+  const deletedSessionIds = useEngineSelector(
+    engine,
+    (state) => state.sessionLifecycle.deletedSessionIds
+  );
   const requestedRailScopeKey = useMemo(
     () =>
       resolveConversationRailQueryScope(workspaceId, {
@@ -155,6 +159,7 @@ export function useAgentGUIConversationRailQuery({
       ...querySnapshot,
       batchDeletionAvailable: batchDeletionCapability.available,
       activityRootFacts,
+      deletedSessionIds,
       isInteractionLocked: controller.isInteractionLocked,
       loadMoreSectionConversations: controller.loadMoreSectionConversations,
       railSearch: {
@@ -171,6 +176,7 @@ export function useAgentGUIConversationRailQuery({
       batchDeletionCapability.available,
       activityRootFacts,
       controller,
+      deletedSessionIds,
       querySnapshot,
       requestedRailScopeKey,
       runtimeRailConversations

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRouting.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRouting.spec.tsx
@@ -153,4 +153,132 @@ describe("useAgentGUIConversationRouting", () => {
       ).toBeNull();
     }
   );
+
+  it("keeps a failed activation open when canonical session state exists", () => {
+    const sessionEngine = createAgentSessionEngine({
+      clock: { nowUnixMs: () => 1 },
+      commandPort: createTestEngineCommandPort({
+        execute: () => new Promise(() => {})
+      }),
+      identity: { origin: "test", workspaceId: "workspace-1" },
+      scheduler: { schedule: () => ({ cancel() {} }) }
+    });
+    sessionEngine.dispatch({
+      agentSessionId: "failed-session",
+      agentTargetId: "target-1",
+      clientSubmitId: "submit-1",
+      content: [{ type: "text", text: "hello" }],
+      cwd: "/workspace",
+      expiresAtUnixMs: 45_001,
+      mode: "new",
+      requestedAtUnixMs: 1,
+      requestId: "activation-1",
+      type: "activation/requested",
+      workspaceId: "workspace-1"
+    });
+    sessionEngine.dispatch({
+      commandId: "activate:activation-1",
+      commandType: "session/activate",
+      correlationId: "activation-1",
+      errorMessage: "Initial goal failed.",
+      outcome: "failed",
+      type: "engine/commandResult"
+    });
+    sessionEngine.dispatch({
+      sessions: [
+        {
+          activeTurnId: null,
+          agentSessionId: "failed-session",
+          createdAtUnixMs: 2,
+          cwd: "/workspace",
+          latestTurnInteractions: [],
+          pendingInteractions: [],
+          provider: "codex",
+          title: "Historical session",
+          workspaceId: "workspace-1"
+        }
+      ],
+      type: "session/snapshotReceived"
+    });
+    const setIntent = vi.fn();
+
+    renderHook(() =>
+      useAgentGUIConversationRouting({
+        activeConversationIdRef: { current: "failed-session" },
+        conversationListQuery: {},
+        conversations: [],
+        conversationsRef: { current: [] },
+        handledOpenSessionSequenceRef: { current: null },
+        hasLoadedConversations: true,
+        intent: { id: "failed-session", source: "activation", tag: "active" },
+        openSessionRequest: null,
+        pendingOpenSessionRequestRef: { current: null },
+        selectConversation: vi.fn(),
+        sessionEngine,
+        setIntent,
+        transientConversation: null,
+        workspaceId: "workspace-1"
+      })
+    );
+
+    expect(setIntent).not.toHaveBeenCalledWith({ tag: "home" });
+  });
+
+  it("does not let a failed activation override an explicit history selection", () => {
+    const sessionEngine = createAgentSessionEngine({
+      clock: { nowUnixMs: () => 1 },
+      commandPort: createTestEngineCommandPort({
+        execute: () => new Promise(() => {})
+      }),
+      identity: { origin: "test", workspaceId: "workspace-1" },
+      scheduler: { schedule: () => ({ cancel() {} }) }
+    });
+    sessionEngine.dispatch({
+      agentSessionId: "historical-session",
+      agentTargetId: "target-1",
+      clientSubmitId: "submit-1",
+      content: [{ type: "text", text: "hello" }],
+      cwd: "/workspace",
+      expiresAtUnixMs: 45_001,
+      mode: "new",
+      requestedAtUnixMs: 1,
+      requestId: "activation-1",
+      type: "activation/requested",
+      workspaceId: "workspace-1"
+    });
+    sessionEngine.dispatch({
+      commandId: "activate:activation-1",
+      commandType: "session/activate",
+      correlationId: "activation-1",
+      errorMessage: "Initial goal failed.",
+      outcome: "failed",
+      type: "engine/commandResult"
+    });
+    const setIntent = vi.fn();
+
+    renderHook(() =>
+      useAgentGUIConversationRouting({
+        activeConversationIdRef: { current: "historical-session" },
+        conversationListQuery: {},
+        conversations: [],
+        conversationsRef: { current: [] },
+        handledOpenSessionSequenceRef: { current: null },
+        hasLoadedConversations: true,
+        intent: {
+          id: "historical-session",
+          source: "user-selection",
+          tag: "active"
+        },
+        openSessionRequest: null,
+        pendingOpenSessionRequestRef: { current: null },
+        selectConversation: vi.fn(),
+        sessionEngine,
+        setIntent,
+        transientConversation: null,
+        workspaceId: "workspace-1"
+      })
+    );
+
+    expect(setIntent).not.toHaveBeenCalledWith({ tag: "home" });
+  });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRouting.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRouting.ts
@@ -1,7 +1,6 @@
 import {
-  isPendingActivationViable,
+  selectFailedNewActivationResolution,
   selectEngineSessionReconcile,
-  selectLatestActivationForSession,
   selectWorkspaceAgentConsumerSession,
   type AgentSessionEngine
 } from "@tutti-os/agent-activity-core";
@@ -135,13 +134,12 @@ export function useAgentGUIConversationRouting(
     }
 
     if (intent.tag !== "home") {
-      const activation = selectLatestActivationForSession(
-        sessionEngine.getSnapshot(),
-        intent.id
-      );
       if (
-        activation?.mode === "new" &&
-        !isPendingActivationViable(activation)
+        !(intent.tag === "active" && intent.source === "user-selection") &&
+        selectFailedNewActivationResolution(
+          sessionEngine.getSnapshot(),
+          intent.id
+        ) === "rollback"
       ) {
         // Terminal activation settlement clears the optimistic selection in an
         // earlier effect. Do not let this effect's stale active/requested intent

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.spec.ts
@@ -265,6 +265,31 @@ describe("clearRolledBackAgentGUISelection", () => {
     const transientConversation = {
       id: failedAgentSessionId
     } as AgentGUIConversationSummary;
+    const failedActivationSnapshot = {
+      pendingIntents: {
+        activationsByRequestId: {
+          "activation-1": {
+            agentSessionId: failedAgentSessionId,
+            agentTargetId: "target-1",
+            clientSubmitId: "submit-1",
+            content: [],
+            cwd: "/workspace",
+            errorCode: null,
+            errorMessage: "create failed",
+            expiresAtUnixMs: 45_001,
+            initialPromptRetracted: false,
+            initialTurnExpected: false,
+            mode: "new",
+            requestId: "activation-1",
+            requestedAtUnixMs: 1,
+            status: "failed",
+            title: null,
+            workspaceId: "workspace-1"
+          }
+        }
+      },
+      sessionLifecycle: { sessionsById: {} }
+    };
 
     const { result } = renderHook(() => {
       const [activeConversationId, setActiveConversationId] = useState<
@@ -318,9 +343,7 @@ describe("clearRolledBackAgentGUISelection", () => {
         onDataChangeRef: { current: onDataChange },
         sessionEngine: {
           dispatch: vi.fn(),
-          getSnapshot: vi.fn(() => ({
-            pendingIntents: { activationsByRequestId: {} }
-          }))
+          getSnapshot: vi.fn(() => failedActivationSnapshot)
         } as unknown as AgentSessionEngine,
         setActiveConversationId,
         setDetailError: vi.fn(),
@@ -353,9 +376,7 @@ describe("clearRolledBackAgentGUISelection", () => {
         },
         sessionEngine: {
           dispatch: vi.fn(),
-          getSnapshot: vi.fn(() => ({
-            pendingIntents: { activationsByRequestId: {} }
-          }))
+          getSnapshot: vi.fn(() => failedActivationSnapshot)
         } as unknown as AgentSessionEngine,
         setIntent,
         transientConversation,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.ts
@@ -1,5 +1,5 @@
 import {
-  isPendingActivationViable,
+  selectFailedNewActivationResolution,
   selectEngineSession,
   selectEngineSessionDetailHydrated,
   selectEngineSessionStateHydrated,
@@ -218,9 +218,13 @@ export function useAgentGUIConversationSelectionController(
     };
 
     if (
-      activePendingActivation?.mode === "new" &&
-      !isPendingActivationViable(activePendingActivation) &&
-      activeConversationIdRef.current === activePendingActivation.agentSessionId
+      activeConversationIdRef.current ===
+        activePendingActivation?.agentSessionId &&
+      !(intent.tag === "active" && intent.source === "user-selection") &&
+      selectFailedNewActivationResolution(
+        sessionEngine.getSnapshot(),
+        activePendingActivation.agentSessionId
+      ) === "rollback"
     ) {
       rollbackSelection(
         activePendingActivation.agentSessionId,
@@ -374,12 +378,7 @@ export function useAgentGUIConversationSelectionController(
             sessionEngine.getSnapshot(),
             agentSessionId
           )?.status ?? null;
-        return (
-          status !== "failed" &&
-          status !== "canceled" &&
-          status !== "requested" &&
-          status !== "uncertain"
-        );
+        return status !== "requested" && status !== "uncertain";
       },
       forget: activation.clearFailure,
       isPending: (agentSessionId) =>

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.ts
@@ -311,7 +311,11 @@ export function useAgentGUINewConversationActivation(
       requestRailReveal(agentSessionId, "created");
       isComposerHomeRef.current = false;
       setIsComposerHome(false);
-      setIntent({ tag: "active", id: agentSessionId });
+      setIntent({
+        id: agentSessionId,
+        source: "activation",
+        tag: "active"
+      });
       setIsLoadingMessages(false);
       return { agentSessionId, requestId };
     },

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -378,11 +378,14 @@ export function useAgentGUINodeController({
       ) {
         return null;
       }
-      return conversationSummaryFromAgentSession(session, {
-        isNoProjectPath,
-        needsUserAction: activeRelatedPendingInteractions.length > 0,
-        userProjects
-      });
+      return {
+        ...conversationSummaryFromAgentSession(session, {
+          isNoProjectPath,
+          needsUserAction: activeRelatedPendingInteractions.length > 0,
+          userProjects
+        }),
+        isTransient: true
+      };
     }, [
       activeEngineSession,
       activeRelatedPendingInteractions.length,

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationActivityView.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationActivityView.spec.ts
@@ -130,35 +130,7 @@ test("activity reconciliation does not move existing members when they become re
   ]);
 });
 
-test("activity reconciliation accumulates observed IDs across missing snapshots", () => {
-  const initial = createAgentGUIConversationActivityActivation(
-    [conversation("existing", { time: NOW - 2 * HOUR_MS })],
-    NOW
-  );
-  const withTransient = reconcileAgentGUIConversationActivityActivation(
-    initial,
-    [
-      conversation("existing", { time: NOW - 2 * HOUR_MS }),
-      conversation("selected-history", {
-        isTransient: true,
-        time: NOW - HOUR_MS
-      })
-    ]
-  );
-  const missing = reconcileAgentGUIConversationActivityActivation(
-    withTransient,
-    [conversation("existing", { time: NOW - 2 * HOUR_MS })]
-  );
-  const restored = reconcileAgentGUIConversationActivityActivation(missing, [
-    conversation("existing", { time: NOW - 2 * HOUR_MS }),
-    conversation("selected-history", { time: NOW - HOUR_MS })
-  ]);
-
-  expect(restored.priority).toEqual([]);
-  expect(restored.observedIds).toContain("selected-history");
-});
-
-test("activity reconciliation incrementally enqueues pushes and retains existing Priority members", () => {
+test("activity reconciliation admits only live late sessions and retains Priority members", () => {
   const initial = createAgentGUIConversationActivityActivation(
     [
       conversation("keep", { status: "working", time: NOW - HOUR_MS }),
@@ -179,12 +151,11 @@ test("activity reconciliation incrementally enqueues pushes and retains existing
   ]);
 
   expect(projectAgentGUIConversationActivity(reconciled)).toEqual({
-    priorityIds: ["promote", "pushed-active", "keep", "pushed-idle"],
+    priorityIds: ["promote", "pushed-active", "keep"],
     priorityReasonsById: new Map([
       ["promote", "unread"],
       ["pushed-active", "active"],
-      ["keep", "active"],
-      ["pushed-idle", "retained-idle"]
+      ["keep", "active"]
     ]),
     recentSections: [],
     referenceDayStartUnixMs: localDayStartUnixMs(NOW)
@@ -210,53 +181,6 @@ test("activity reconciliation removes a deleted Priority member immediately", ()
   );
 });
 
-test("activity reconciliation keeps a selected idle transient conversation recent", () => {
-  const initial = createAgentGUIConversationActivityActivation(
-    [conversation("existing", { time: NOW - 2 * HOUR_MS })],
-    NOW
-  );
-  const reconciled = reconcileAgentGUIConversationActivityActivation(initial, [
-    conversation("existing", { time: NOW - 2 * HOUR_MS }),
-    conversation("selected-history", {
-      isTransient: true,
-      time: NOW - HOUR_MS
-    })
-  ]);
-
-  expect(projectAgentGUIConversationActivity(reconciled)).toEqual({
-    priorityIds: [],
-    priorityReasonsById: new Map(),
-    recentSections: [
-      {
-        dayStartUnixMs: localDayStartUnixMs(NOW),
-        ids: ["selected-history", "existing"]
-      }
-    ],
-    referenceDayStartUnixMs: localDayStartUnixMs(NOW)
-  });
-  expect(reconciled.priorityRetentionRecencyById.has("selected-history")).toBe(
-    false
-  );
-});
-
-test("activity reconciliation still prioritizes a transient conversation with live work", () => {
-  const initial = createAgentGUIConversationActivityActivation([], NOW);
-  const reconciled = reconcileAgentGUIConversationActivityActivation(initial, [
-    conversation("active-selected", {
-      isTransient: true,
-      status: "working",
-      time: NOW
-    })
-  ]);
-
-  expect(projectAgentGUIConversationActivity(reconciled)).toEqual({
-    priorityIds: ["active-selected"],
-    priorityReasonsById: new Map([["active-selected", "active"]]),
-    recentSections: [],
-    referenceDayStartUnixMs: localDayStartUnixMs(NOW)
-  });
-});
-
 test("activity reconciliation preserves activation identity when nothing changes", () => {
   const conversations = [conversation("recent", { time: NOW - HOUR_MS })];
   const initial = createAgentGUIConversationActivityActivation(
@@ -266,43 +190,6 @@ test("activity reconciliation preserves activation identity when nothing changes
   expect(
     reconcileAgentGUIConversationActivityActivation(initial, conversations)
   ).toBe(initial);
-});
-
-test("activity retention records exact unread recency and expires after recency changes", () => {
-  const unread = conversation("unread", {
-    hasUnreadCompletion: true,
-    time: NOW - HOUR_MS
-  });
-  const initial = createAgentGUIConversationActivityActivation([unread], NOW);
-  const read = conversation("unread", { time: NOW - HOUR_MS });
-  const retained = reconcileAgentGUIConversationActivityActivation(initial, [
-    read
-  ]);
-
-  expect(retained.priorityRetentionRecencyById.get("unread")).toBe(
-    NOW - HOUR_MS
-  );
-  expect(
-    projectAgentGUIConversationActivity(
-      createAgentGUIConversationActivityActivation(
-        [read],
-        NOW,
-        retained.priorityRetentionRecencyById
-      )
-    ).priorityReasonsById.get("unread")
-  ).toBe("retained-idle");
-
-  const recencyChanged = conversation("unread", { time: NOW });
-  const expired = reconcileAgentGUIConversationActivityActivation(retained, [
-    recencyChanged
-  ]);
-  expect(expired.priorityRetentionRecencyById.has("unread")).toBe(false);
-  const rebuilt = createAgentGUIConversationActivityActivation(
-    [recencyChanged],
-    NOW,
-    expired.priorityRetentionRecencyById
-  );
-  expect(projectAgentGUIConversationActivity(rebuilt).priorityIds).toEqual([]);
 });
 
 test("activity activation preserves source order for equal rank and recency", () => {
@@ -366,7 +253,6 @@ function conversation(
   id: string,
   overrides: {
     hasUnreadCompletion?: boolean;
-    isTransient?: boolean;
     needsUserAction?: boolean;
     status?: AgentGUIConversationSummary["status"];
     time: number;
@@ -376,7 +262,6 @@ function conversation(
     cwd: "/workspace",
     hasUnreadCompletion: overrides.hasUnreadCompletion,
     id,
-    isTransient: overrides.isTransient,
     needsUserAction: overrides.needsUserAction,
     provider: "codex",
     status: overrides.status ?? "ready",

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationActivityView.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationActivityView.spec.ts
@@ -107,6 +107,53 @@ test("activity reconciliation incrementally enqueues pushes, promotes attention,
   );
 });
 
+test("activity reconciliation keeps a selected idle transient conversation recent", () => {
+  const initial = createAgentGUIConversationActivityActivation(
+    [conversation("existing", { time: NOW - 2 * HOUR_MS })],
+    NOW
+  );
+  const reconciled = reconcileAgentGUIConversationActivityActivation(initial, [
+    conversation("existing", { time: NOW - 2 * HOUR_MS }),
+    conversation("selected-history", {
+      isTransient: true,
+      time: NOW - HOUR_MS
+    })
+  ]);
+
+  expect(projectAgentGUIConversationActivity(reconciled)).toEqual({
+    priorityIds: [],
+    priorityReasonsById: new Map(),
+    recentSections: [
+      {
+        dayStartUnixMs: localDayStartUnixMs(NOW),
+        ids: ["selected-history", "existing"]
+      }
+    ],
+    referenceDayStartUnixMs: localDayStartUnixMs(NOW)
+  });
+  expect(reconciled.priorityRetentionRecencyById.has("selected-history")).toBe(
+    false
+  );
+});
+
+test("activity reconciliation still prioritizes a transient conversation with live work", () => {
+  const initial = createAgentGUIConversationActivityActivation([], NOW);
+  const reconciled = reconcileAgentGUIConversationActivityActivation(initial, [
+    conversation("active-selected", {
+      isTransient: true,
+      status: "working",
+      time: NOW
+    })
+  ]);
+
+  expect(projectAgentGUIConversationActivity(reconciled)).toEqual({
+    priorityIds: ["active-selected"],
+    priorityReasonsById: new Map([["active-selected", "active"]]),
+    recentSections: [],
+    referenceDayStartUnixMs: localDayStartUnixMs(NOW)
+  });
+});
+
 test("activity reconciliation preserves activation identity when nothing changes", () => {
   const conversations = [conversation("recent", { time: NOW - HOUR_MS })];
   const initial = createAgentGUIConversationActivityActivation(
@@ -216,6 +263,7 @@ function conversation(
   id: string,
   overrides: {
     hasUnreadCompletion?: boolean;
+    isTransient?: boolean;
     needsUserAction?: boolean;
     status?: AgentGUIConversationSummary["status"];
     time: number;
@@ -225,6 +273,7 @@ function conversation(
     cwd: "/workspace",
     hasUnreadCompletion: overrides.hasUnreadCompletion,
     id,
+    isTransient: overrides.isTransient,
     needsUserAction: overrides.needsUserAction,
     provider: "codex",
     status: overrides.status ?? "ready",

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationActivityView.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationActivityView.spec.ts
@@ -72,7 +72,93 @@ test("activity reconciliation retains members and frozen recency after live fact
   });
 });
 
-test("activity reconciliation incrementally enqueues pushes, promotes attention, and removes deletes", () => {
+test("activity reconciliation keeps existing Priority members through a list refresh", () => {
+  const initial = createAgentGUIConversationActivityActivation(
+    [
+      conversation("waiting", {
+        needsUserAction: true,
+        time: NOW - HOUR_MS
+      }),
+      conversation("unread", {
+        hasUnreadCompletion: true,
+        time: NOW - 2 * HOUR_MS
+      })
+    ],
+    NOW
+  );
+  const refreshed = reconcileAgentGUIConversationActivityActivation(initial, [
+    conversation("new-active", {
+      status: "working",
+      time: NOW + HOUR_MS
+    })
+  ]);
+
+  expect(projectAgentGUIConversationActivity(refreshed).priorityIds).toEqual([
+    "waiting",
+    "unread",
+    "new-active"
+  ]);
+  expect(refreshed.priority.slice(0, 2)).toEqual(initial.priority);
+});
+
+test("activity reconciliation does not move existing members when they become read", () => {
+  const initial = createAgentGUIConversationActivityActivation(
+    [
+      conversation("waiting", {
+        needsUserAction: true,
+        time: NOW - HOUR_MS
+      }),
+      conversation("unread", {
+        hasUnreadCompletion: true,
+        time: NOW - 2 * HOUR_MS
+      })
+    ],
+    NOW
+  );
+  const read = reconcileAgentGUIConversationActivityActivation(initial, [
+    conversation("unread", { time: NOW + 2 * DAY_MS }),
+    conversation("waiting", { time: NOW + DAY_MS })
+  ]);
+
+  expect(projectAgentGUIConversationActivity(read).priorityIds).toEqual([
+    "waiting",
+    "unread"
+  ]);
+  expect(read.priority.map((member) => member.priorityReason)).toEqual([
+    "waiting",
+    "unread"
+  ]);
+});
+
+test("activity reconciliation accumulates observed IDs across missing snapshots", () => {
+  const initial = createAgentGUIConversationActivityActivation(
+    [conversation("existing", { time: NOW - 2 * HOUR_MS })],
+    NOW
+  );
+  const withTransient = reconcileAgentGUIConversationActivityActivation(
+    initial,
+    [
+      conversation("existing", { time: NOW - 2 * HOUR_MS }),
+      conversation("selected-history", {
+        isTransient: true,
+        time: NOW - HOUR_MS
+      })
+    ]
+  );
+  const missing = reconcileAgentGUIConversationActivityActivation(
+    withTransient,
+    [conversation("existing", { time: NOW - 2 * HOUR_MS })]
+  );
+  const restored = reconcileAgentGUIConversationActivityActivation(missing, [
+    conversation("existing", { time: NOW - 2 * HOUR_MS }),
+    conversation("selected-history", { time: NOW - HOUR_MS })
+  ]);
+
+  expect(restored.priority).toEqual([]);
+  expect(restored.observedIds).toContain("selected-history");
+});
+
+test("activity reconciliation incrementally enqueues pushes and retains existing Priority members", () => {
   const initial = createAgentGUIConversationActivityActivation(
     [
       conversation("keep", { status: "working", time: NOW - HOUR_MS }),
@@ -93,10 +179,11 @@ test("activity reconciliation incrementally enqueues pushes, promotes attention,
   ]);
 
   expect(projectAgentGUIConversationActivity(reconciled)).toEqual({
-    priorityIds: ["promote", "pushed-active", "pushed-idle"],
+    priorityIds: ["promote", "pushed-active", "keep", "pushed-idle"],
     priorityReasonsById: new Map([
       ["promote", "unread"],
       ["pushed-active", "active"],
+      ["keep", "active"],
       ["pushed-idle", "retained-idle"]
     ]),
     recentSections: [],
@@ -104,6 +191,22 @@ test("activity reconciliation incrementally enqueues pushes, promotes attention,
   });
   expect(new Set(reconciled.priority.map((member) => member.id)).size).toBe(
     reconciled.priority.length
+  );
+});
+
+test("activity reconciliation removes a deleted Priority member immediately", () => {
+  const initial = createAgentGUIConversationActivityActivation(
+    [conversation("deleted", { status: "working", time: NOW })],
+    NOW
+  );
+  const reconciled = reconcileAgentGUIConversationActivityActivation(
+    initial,
+    [],
+    { deleted: true }
+  );
+
+  expect(projectAgentGUIConversationActivity(reconciled).priorityIds).toEqual(
+    []
   );
 });
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationActivityView.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationActivityView.ts
@@ -13,6 +13,7 @@ export type AgentGUIConversationActivityCandidate = Pick<
   AgentGUIConversationSummary,
   | "hasUnreadCompletion"
   | "id"
+  | "isTransient"
   | "needsUserAction"
   | "sortTimeUnixMs"
   | "status"
@@ -166,7 +167,7 @@ export function reconcileAgentGUIConversationActivityActivation(
       recentIds.delete(conversation.id);
     }
 
-    if (liveReason || !wasObserved) {
+    if (liveReason || (!conversation.isTransient && !wasObserved)) {
       if (!liveReason) {
         priorityRetentionRecencyById.set(conversation.id, currentRecency);
       }
@@ -178,6 +179,24 @@ export function reconcileAgentGUIConversationActivityActivation(
         recentDayStartUnixMs: null
       });
       priorityIds.add(conversation.id);
+      continue;
+    }
+
+    // A selected historical session can be injected into the visible rail
+    // before the canonical session snapshot catches up. It is a normal idle
+    // recent conversation, not a newly discovered task to retain in Priority.
+    if (conversation.isTransient && !wasObserved) {
+      const recentDayStartUnixMs = localDayStartUnixMs(currentRecency);
+      if (recentDayStartUnixMs >= activation.cutoffDayStartUnixMs) {
+        retainedRecent.push({
+          admissionOrder: ++admissionOrder,
+          admittedAtUnixMs: currentRecency,
+          id: conversation.id,
+          priorityReason: null,
+          recentDayStartUnixMs
+        });
+        recentIds.add(conversation.id);
+      }
     }
   }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationActivityView.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationActivityView.ts
@@ -2,6 +2,7 @@ import { resolveAgentGUIConversationSortTimeUnixMs } from "./agentGuiConversatio
 import type { AgentGUIConversationSummary } from "./agentGuiConversationTypes";
 
 const ACTIVITY_RECENT_DAY_COUNT = 7;
+const EMPTY_DELETED_SESSION_IDS: Readonly<Record<string, true>> = {};
 
 export type AgentGUIConversationActivityPriorityReason =
   | "waiting"
@@ -111,16 +112,17 @@ export function createAgentGUIConversationActivityActivation(
 
 export function reconcileAgentGUIConversationActivityActivation(
   activation: AgentGUIConversationActivityActivation,
-  conversations: readonly AgentGUIConversationActivityCandidate[]
+  conversations: readonly AgentGUIConversationActivityCandidate[],
+  deletedSessionIds: Readonly<Record<string, true>> = EMPTY_DELETED_SESSION_IDS
 ): AgentGUIConversationActivityActivation {
-  const conversationsById = new Map(
-    conversations.map((conversation) => [conversation.id, conversation])
+  // Activity membership is an activation snapshot. Keep the member refs even
+  // when a rail refresh temporarily omits their canonical summary; the view
+  // layer can render the last known row until the next toggle rebuilds it.
+  const retainedPriority = activation.priority.filter(
+    (member) => !deletedSessionIds[member.id]
   );
-  const retainedPriority = activation.priority.filter((member) =>
-    conversationsById.has(member.id)
-  );
-  const retainedRecent = activation.recent.filter((member) =>
-    conversationsById.has(member.id)
+  const retainedRecent = activation.recent.filter(
+    (member) => !deletedSessionIds[member.id]
   );
   const priorityIds = new Set(retainedPriority.map((member) => member.id));
   const retainedPriorityById = new Map(
@@ -128,8 +130,15 @@ export function reconcileAgentGUIConversationActivityActivation(
   );
   const recentIds = new Set(retainedRecent.map((member) => member.id));
   const previouslyObservedIds = new Set(activation.observedIds);
-  const observedIds = new Set<string>();
-  const priorityRetentionRecencyById = new Map<string, number>();
+  const observedIds = new Set(
+    activation.observedIds.filter((id) => !deletedSessionIds[id])
+  );
+  const currentIds = new Set<string>();
+  const priorityRetentionRecencyById = new Map(
+    [...activation.priorityRetentionRecencyById].filter(
+      ([id]) => !deletedSessionIds[id]
+    )
+  );
   let admissionOrder = Math.max(
     -1,
     ...activation.priority.map((member) => member.admissionOrder),
@@ -137,7 +146,9 @@ export function reconcileAgentGUIConversationActivityActivation(
   );
 
   for (const conversation of conversations) {
-    if (observedIds.has(conversation.id)) continue;
+    if (currentIds.has(conversation.id)) continue;
+    if (deletedSessionIds[conversation.id]) continue;
+    currentIds.add(conversation.id);
     observedIds.add(conversation.id);
     const currentRecency =
       resolveAgentGUIConversationSortTimeUnixMs(conversation);
@@ -147,8 +158,9 @@ export function reconcileAgentGUIConversationActivityActivation(
       activation.priorityRetentionRecencyById.get(conversation.id);
     if (previousRetentionRecency === currentRecency) {
       priorityRetentionRecencyById.set(conversation.id, currentRecency);
+    } else if (previousRetentionRecency !== undefined) {
+      priorityRetentionRecencyById.delete(conversation.id);
     } else if (
-      previousRetentionRecency === undefined &&
       !liveReason &&
       retainedPriorityMember?.priorityReason === "unread"
     ) {

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationActivityView.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationActivityView.ts
@@ -1,5 +1,8 @@
 import { resolveAgentGUIConversationSortTimeUnixMs } from "./agentGuiConversationTypes";
-import type { AgentGUIConversationSummary } from "./agentGuiConversationTypes";
+import type {
+  AgentGUIConversationStatus,
+  AgentGUIConversationSummary
+} from "./agentGuiConversationTypes";
 
 const ACTIVITY_RECENT_DAY_COUNT = 7;
 const EMPTY_DELETED_SESSION_IDS: Readonly<Record<string, true>> = {};
@@ -7,14 +10,17 @@ const EMPTY_DELETED_SESSION_IDS: Readonly<Record<string, true>> = {};
 export type AgentGUIConversationActivityPriorityReason =
   | "waiting"
   | "unread"
-  | "active"
-  | "retained-idle";
+  | "active";
+
+export interface AgentGUIConversationActivityRootFact {
+  needsUserAction: boolean;
+  status: AgentGUIConversationStatus;
+}
 
 export type AgentGUIConversationActivityCandidate = Pick<
   AgentGUIConversationSummary,
   | "hasUnreadCompletion"
   | "id"
-  | "isTransient"
   | "needsUserAction"
   | "sortTimeUnixMs"
   | "status"
@@ -32,9 +38,7 @@ export interface AgentGUIConversationActivityMember {
 export interface AgentGUIConversationActivityActivation {
   cutoffDayStartUnixMs: number;
   referenceDayStartUnixMs: number;
-  observedIds: readonly string[];
   priority: readonly AgentGUIConversationActivityMember[];
-  priorityRetentionRecencyById: ReadonlyMap<string, number>;
   recent: readonly AgentGUIConversationActivityMember[];
 }
 
@@ -55,29 +59,22 @@ export interface AgentGUIConversationActivityProjection {
 
 export function createAgentGUIConversationActivityActivation(
   conversations: readonly AgentGUIConversationActivityCandidate[],
-  openedAtUnixMs: number,
-  priorityRetentionRecencyById: ReadonlyMap<string, number> = new Map()
+  openedAtUnixMs: number
 ): AgentGUIConversationActivityActivation {
   const cutoffDate = new Date(localDayStartUnixMs(openedAtUnixMs));
   cutoffDate.setDate(cutoffDate.getDate() - (ACTIVITY_RECENT_DAY_COUNT - 1));
   const cutoffDayStartUnixMs = cutoffDate.getTime();
   const priority: AgentGUIConversationActivityMember[] = [];
   const recent: AgentGUIConversationActivityMember[] = [];
-  const retainedRecency = new Map<string, number>();
-  const observedIds = new Set<string>();
+  const seenIds = new Set<string>();
   let admissionOrder = 0;
 
   for (const conversation of conversations) {
-    if (observedIds.has(conversation.id)) continue;
-    observedIds.add(conversation.id);
+    if (seenIds.has(conversation.id)) continue;
+    seenIds.add(conversation.id);
     const admittedAtUnixMs =
       resolveAgentGUIConversationSortTimeUnixMs(conversation);
-    const retainedIdle =
-      priorityRetentionRecencyById.get(conversation.id) === admittedAtUnixMs;
-    if (retainedIdle) retainedRecency.set(conversation.id, admittedAtUnixMs);
-    const priorityReason =
-      livePriorityReason(conversation) ??
-      (retainedIdle ? "retained-idle" : null);
+    const priorityReason = livePriorityReason(conversation);
     if (priorityReason) {
       priority.push({
         admissionOrder: admissionOrder++,
@@ -103,9 +100,7 @@ export function createAgentGUIConversationActivityActivation(
   return {
     cutoffDayStartUnixMs,
     referenceDayStartUnixMs: localDayStartUnixMs(openedAtUnixMs),
-    observedIds: [...observedIds].sort(),
     priority: priority.sort(compareActivityMembers),
-    priorityRetentionRecencyById: retainedRecency,
     recent: recent.sort(compareActivityMembers)
   };
 }
@@ -125,20 +120,8 @@ export function reconcileAgentGUIConversationActivityActivation(
     (member) => !deletedSessionIds[member.id]
   );
   const priorityIds = new Set(retainedPriority.map((member) => member.id));
-  const retainedPriorityById = new Map(
-    retainedPriority.map((member) => [member.id, member])
-  );
   const recentIds = new Set(retainedRecent.map((member) => member.id));
-  const previouslyObservedIds = new Set(activation.observedIds);
-  const observedIds = new Set(
-    activation.observedIds.filter((id) => !deletedSessionIds[id])
-  );
   const currentIds = new Set<string>();
-  const priorityRetentionRecencyById = new Map(
-    [...activation.priorityRetentionRecencyById].filter(
-      ([id]) => !deletedSessionIds[id]
-    )
-  );
   let admissionOrder = Math.max(
     -1,
     ...activation.priority.map((member) => member.admissionOrder),
@@ -149,26 +132,11 @@ export function reconcileAgentGUIConversationActivityActivation(
     if (currentIds.has(conversation.id)) continue;
     if (deletedSessionIds[conversation.id]) continue;
     currentIds.add(conversation.id);
-    observedIds.add(conversation.id);
     const currentRecency =
       resolveAgentGUIConversationSortTimeUnixMs(conversation);
     const liveReason = livePriorityReason(conversation);
-    const retainedPriorityMember = retainedPriorityById.get(conversation.id);
-    const previousRetentionRecency =
-      activation.priorityRetentionRecencyById.get(conversation.id);
-    if (previousRetentionRecency === currentRecency) {
-      priorityRetentionRecencyById.set(conversation.id, currentRecency);
-    } else if (previousRetentionRecency !== undefined) {
-      priorityRetentionRecencyById.delete(conversation.id);
-    } else if (
-      !liveReason &&
-      retainedPriorityMember?.priorityReason === "unread"
-    ) {
-      priorityRetentionRecencyById.set(conversation.id, currentRecency);
-    }
     if (priorityIds.has(conversation.id)) continue;
 
-    const wasObserved = previouslyObservedIds.has(conversation.id);
     if (recentIds.has(conversation.id) && !liveReason) continue;
 
     if (recentIds.has(conversation.id)) {
@@ -179,59 +147,34 @@ export function reconcileAgentGUIConversationActivityActivation(
       recentIds.delete(conversation.id);
     }
 
-    if (liveReason || (!conversation.isTransient && !wasObserved)) {
-      if (!liveReason) {
-        priorityRetentionRecencyById.set(conversation.id, currentRecency);
-      }
+    // A late canonical snapshot is not an activity signal. It can be a
+    // selected historical session or a page that arrived after activation;
+    // only live facts may admit a previously unseen session to Priority.
+    if (liveReason) {
       retainedPriority.push({
         admissionOrder: ++admissionOrder,
         admittedAtUnixMs: currentRecency,
         id: conversation.id,
-        priorityReason: liveReason ?? "retained-idle",
+        priorityReason: liveReason,
         recentDayStartUnixMs: null
       });
       priorityIds.add(conversation.id);
       continue;
     }
-
-    // A selected historical session can be injected into the visible rail
-    // before the canonical session snapshot catches up. It is a normal idle
-    // recent conversation, not a newly discovered task to retain in Priority.
-    if (conversation.isTransient && !wasObserved) {
-      const recentDayStartUnixMs = localDayStartUnixMs(currentRecency);
-      if (recentDayStartUnixMs >= activation.cutoffDayStartUnixMs) {
-        retainedRecent.push({
-          admissionOrder: ++admissionOrder,
-          admittedAtUnixMs: currentRecency,
-          id: conversation.id,
-          priorityReason: null,
-          recentDayStartUnixMs
-        });
-        recentIds.add(conversation.id);
-      }
-    }
   }
 
-  const nextObservedIds = [...observedIds].sort();
   const nextPriority = retainedPriority.sort(compareActivityMembers);
   const nextRecent = retainedRecent.sort(compareActivityMembers);
   if (
-    stringArraysEqual(activation.observedIds, nextObservedIds) &&
     activityMemberArraysEqual(activation.priority, nextPriority) &&
-    activityMemberArraysEqual(activation.recent, nextRecent) &&
-    numberMapsEqual(
-      activation.priorityRetentionRecencyById,
-      priorityRetentionRecencyById
-    )
+    activityMemberArraysEqual(activation.recent, nextRecent)
   ) {
     return activation;
   }
   return {
     cutoffDayStartUnixMs: activation.cutoffDayStartUnixMs,
     referenceDayStartUnixMs: activation.referenceDayStartUnixMs,
-    observedIds: nextObservedIds,
     priority: nextPriority,
-    priorityRetentionRecencyById,
     recent: nextRecent
   };
 }
@@ -273,7 +216,7 @@ export function localDayStartUnixMs(value: number): number {
 
 function livePriorityReason(
   conversation: AgentGUIConversationActivityCandidate
-): Exclude<AgentGUIConversationActivityPriorityReason, "retained-idle"> | null {
+): AgentGUIConversationActivityPriorityReason | null {
   if (conversation.needsUserAction || conversation.status === "waiting") {
     return "waiting";
   }
@@ -306,10 +249,8 @@ function priorityRank(
       return 1;
     case "active":
       return 2;
-    case "retained-idle":
-      return 3;
     default:
-      return 4;
+      return 3;
   }
 }
 
@@ -320,25 +261,5 @@ function activityMemberArraysEqual(
   return (
     left.length === right.length &&
     left.every((member, index) => member === right[index])
-  );
-}
-
-function stringArraysEqual(
-  left: readonly string[],
-  right: readonly string[]
-): boolean {
-  return (
-    left.length === right.length &&
-    left.every((value, index) => value === right[index])
-  );
-}
-
-function numberMapsEqual(
-  left: ReadonlyMap<string, number>,
-  right: ReadonlyMap<string, number>
-): boolean {
-  return (
-    left.size === right.size &&
-    [...left].every(([key, value]) => right.get(key) === value)
   );
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.ts
@@ -655,6 +655,7 @@ export function conversationSummariesRenderEqual(
     left.pinnedAtUnixMs === right.pinnedAtUnixMs &&
     left.sortTimeUnixMs === right.sortTimeUnixMs &&
     left.updatedAtUnixMs === right.updatedAtUnixMs &&
+    left.isTransient === right.isTransient &&
     left.projectionSource === right.projectionSource &&
     left.isImported === right.isImported &&
     left.hasUnreadCompletion === right.hasUnreadCompletion &&

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationTypes.ts
@@ -56,6 +56,10 @@ export interface AgentGUIConversationSummary {
   // still exists so an explicitly opened session presents its real identity,
   // but it must never be rendered as a conversation rail row.
   hiddenFromRail?: boolean;
+  // The summary was injected only because its session was explicitly selected
+  // while it was absent from the canonical conversation snapshot. Activity
+  // View must not treat an idle summary with this marker as a new task.
+  isTransient?: boolean;
   projectionSource?: "pending_activation";
   isImported?: boolean;
   activeTurn?: AgentActivitySession["activeTurn"];

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationTypes.ts
@@ -57,8 +57,9 @@ export interface AgentGUIConversationSummary {
   // but it must never be rendered as a conversation rail row.
   hiddenFromRail?: boolean;
   // The summary was injected only because its session was explicitly selected
-  // while it was absent from the canonical conversation snapshot. Activity
-  // View must not treat an idle summary with this marker as a new task.
+  // while it was absent from the canonical conversation snapshot. The
+  // presentation layer may use it for the ordinary Rail/detail overlay, but
+  // it is excluded before Activity candidates are built.
   isTransient?: boolean;
   projectionSource?: "pending_activation";
   isImported?: boolean;

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.activity.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.activity.spec.tsx
@@ -11,6 +11,7 @@ import type { AgentGUIConversationSummary } from "../model/agentGuiConversationT
 import type { useAgentGUIConversationRailQuery } from "../controller/useAgentGUIConversationRailQuery";
 import type { AgentGUIConversationRailLabels } from "./agentGUIConversationRailLabels";
 import { AgentGUIConversationRailPane } from "./AgentGUIConversationRailPane";
+import { createAgentGUIConversationActivityController } from "../controller/agentGUIConversationActivityController";
 
 describe("AgentGUIConversationRailPane Activity capability", () => {
   it("fails closed when the host does not opt in", () => {
@@ -94,29 +95,54 @@ describe("AgentGUIConversationRailPane Activity capability", () => {
       screen.getByTestId("agent-gui-conversation-item-session-1")
     ).toBeTruthy();
   });
+
+  it("does not admit a detail-only transient rail overlay", () => {
+    const transient = {
+      ...conversationFixture(),
+      id: "selected-history",
+      isTransient: true,
+      status: "ready" as const,
+      title: "Selected history"
+    };
+    renderPane({
+      capability: true,
+      activityConversations: [conversationFixture()],
+      conversations: [conversationFixture(), transient]
+    });
+
+    fireEvent.click(screen.getByTestId("agent-gui-activity-view-toggle"));
+
+    expect(screen.queryByText("Selected history")).toBeNull();
+  });
 });
 
 function renderPane({
   capability,
   hasUnreadCompletion = false,
   listPage = vi.fn(),
-  runtimeRailConversations = []
+  runtimeRailConversations = [],
+  activityConversations: requestedActivityConversations,
+  conversations: requestedConversations
 }: {
   capability: boolean;
   hasUnreadCompletion?: boolean;
   listPage?: ReturnType<typeof vi.fn>;
   runtimeRailConversations?: AgentGUIConversationSummary[];
+  activityConversations?: AgentGUIConversationSummary[];
+  conversations?: AgentGUIConversationSummary[];
 }) {
-  const conversation: AgentGUIConversationSummary = {
-    cwd: "/workspace",
-    hasUnreadCompletion,
-    id: "session-1",
-    provider: "codex",
-    sortTimeUnixMs: Date.now(),
-    status: "ready",
-    title: "Session 1",
-    updatedAtUnixMs: Date.now()
-  };
+  const conversation = conversationFixture({ hasUnreadCompletion });
+  const activityConversations = requestedActivityConversations ?? [
+    conversation
+  ];
+  const conversations = requestedConversations ?? activityConversations;
+  const activityController = createAgentGUIConversationActivityController();
+  activityController.configure({
+    available: capability,
+    conversations: activityConversations,
+    identityKey: "workspace-1",
+    scopeKey: "workspace-1"
+  });
   const snapshot = {
     sessionMessagesById: {}
   } as unknown as AgentActivitySnapshot;
@@ -136,7 +162,7 @@ function renderPane({
         agentTargetsLoading={false}
         conversationFilter={{ kind: "all" }}
         conversationQuery={conversationQuery}
-        conversations={[conversation]}
+        conversations={conversations}
         createConversationDisabled={false}
         isCollapsed={false}
         isDeletingConversation={false}
@@ -144,7 +170,12 @@ function renderPane({
         isLoadingConversations={false}
         labels={LABELS}
         pendingDeleteConversationId={null}
-        railQuery={{ ...RAIL_QUERY, runtimeRailConversations }}
+        railQuery={{
+          ...RAIL_QUERY,
+          activityController,
+          activityConversations,
+          runtimeRailConversations
+        }}
         revealRequest={null}
         uiLanguage="en"
         userProjects={[]}
@@ -178,7 +209,23 @@ function renderPane({
   );
 }
 
+function conversationFixture(
+  overrides: Pick<AgentGUIConversationSummary, "hasUnreadCompletion"> = {}
+): AgentGUIConversationSummary {
+  return {
+    cwd: "/workspace",
+    hasUnreadCompletion: overrides.hasUnreadCompletion,
+    id: "session-1",
+    provider: "codex",
+    sortTimeUnixMs: Date.now(),
+    status: "ready",
+    title: "Session 1",
+    updatedAtUnixMs: Date.now()
+  };
+}
+
 const RAIL_QUERY = {
+  activityConversations: [conversationFixture()],
   activityRootFacts: new Map(),
   batchDeletionAvailable: false,
   isInteractionLocked: () => false,

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.tsx
@@ -7,7 +7,6 @@ import type { WorkspaceUserProjectI18nRuntime } from "@tutti-os/workspace-user-p
 import { AgentConversationListSkeleton } from "../AgentConversationListSkeleton";
 import type { AgentGUINodeViewModel } from "../model/agentGuiNodeTypes";
 import { matchesAgentGUIConversationSummaryFilter } from "../model/agentGuiConversationFilter";
-import type { AgentGUINodeViewProps } from "../AgentGUINodeView";
 import type { ConversationSection } from "../agentGuiNodeViewConversation";
 import {
   isConversationRailInitialLoadPending,
@@ -45,10 +44,11 @@ import { useAgentGUIConversationRailViewState } from "./useAgentGUIConversationR
 import { useAgentGUIProjectMenuState } from "./useAgentGUIProjectMenuState";
 import { useAgentGUIConversationActivityView } from "../controller/useAgentGUIConversationActivityView";
 import { useDelayedBoolean } from "../controller/useDelayedBoolean";
-
+import type { AgentGUIConversationFilterTargetSelection } from "./agentGUIConversationRailTypes";
 export interface AgentGUIConversationRailControllerProps {
   activityContextKey?: string;
   conversations: AgentGUINodeViewModel["rail"]["conversations"];
+  currentUserId?: string | null;
   nodeId?: string | null;
   footer?: React.ReactNode;
   workspaceId: string;
@@ -77,7 +77,7 @@ export interface AgentGUIConversationRailControllerProps {
   onUpdateConversationFilter: (
     filter: AgentGUINodeViewModel["rail"]["conversationFilter"]
   ) => void;
-  onSelectConversationFilterTarget: AgentGUINodeViewProps["actions"]["selectConversationFilterTarget"];
+  onSelectConversationFilterTarget: AgentGUIConversationFilterTargetSelection;
   onCreateConversation: (options?: {
     projectPath?: string | null;
     source?: string;
@@ -145,7 +145,6 @@ export type AgentGUIConversationRailState = Omit<
 
 export const AgentGUIConversationRailPane = memo(
   function AgentGUIConversationRailPane({
-    activityContextKey = "",
     conversations,
     footer,
     workspaceId,
@@ -230,12 +229,10 @@ export const AgentGUIConversationRailPane = memo(
       workspaceId
     });
     const activityView = useAgentGUIConversationActivityView({
-      conversations,
+      activityController: railQuery.activityController,
+      conversations: railQuery.activityConversations,
       deletedSessionIds,
-      hasConversationQuery,
-      identityKey: `${workspaceId}\u0000${activityContextKey}`,
-      rootFacts: railQuery.activityRootFacts,
-      scopeKey: railViewScopeKey
+      hasConversationQuery
     });
     const backendSearchActive = hasConversationQuery && railSearch.enabled;
     const railInteractionsLocked = isInteractionLocked();

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.tsx
@@ -197,6 +197,7 @@ export const AgentGUIConversationRailPane = memo(
     const groupedConversationsRef = useRef<ConversationSection[] | null>(null);
     const {
       batchDeletionAvailable,
+      deletedSessionIds,
       loadMoreSectionConversations,
       isInteractionLocked,
       runtimeSectionsEnabled,
@@ -213,7 +214,6 @@ export const AgentGUIConversationRailPane = memo(
         isUserProjectMutationPending
       );
     const projectActionLocked = isProjectActionLocked();
-
     const railConversationEntitiesById = new Map(
       runtimeRailConversations.map((conversation) => [
         conversation.id,
@@ -231,6 +231,7 @@ export const AgentGUIConversationRailPane = memo(
     });
     const activityView = useAgentGUIConversationActivityView({
       conversations,
+      deletedSessionIds,
       hasConversationQuery,
       identityKey: `${workspaceId}\u0000${activityContextKey}`,
       rootFacts: railQuery.activityRootFacts,

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIConversationRailTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIConversationRailTypes.ts
@@ -1,0 +1,10 @@
+import type { AgentGUIProvider } from "../../../types";
+
+export interface AgentGUIConversationFilterTargetInput {
+  provider: AgentGUIProvider;
+  agentTargetId: string;
+}
+
+export type AgentGUIConversationFilterTargetSelection = (
+  input: AgentGUIConversationFilterTargetInput
+) => void;

--- a/packages/agent/gui/agentConversationRailController.ts
+++ b/packages/agent/gui/agentConversationRailController.ts
@@ -4,6 +4,7 @@ import type { CachedConversationRailQuery } from "./agent-gui/agentGuiNode/contr
 import type { AgentGUIConversationRailQuerySnapshot } from "./agent-gui/agentGuiNode/controller/agentConversationRailQuerySnapshot.ts";
 import type { ConversationRailQueryScope } from "./agent-gui/agentGuiNode/controller/agentGuiConversationRailQueryTypes.ts";
 import type { AgentConversationRailRuntimePort } from "./agentConversationRailContracts.ts";
+import type { AgentGUIConversationActivityController } from "./agent-gui/agentGuiNode/controller/agentGUIConversationActivityController.ts";
 import {
   createWorkspaceQueryCache,
   type WorkspaceQueryCache
@@ -41,6 +42,7 @@ export interface AgentGUIConversationRailQueryControllerInput {
 }
 
 export interface AgentGUIConversationRailQueryController {
+  activityController: AgentGUIConversationActivityController;
   attach(): () => void;
   configure(scope: ConversationRailQueryScope): void;
   getSnapshot(): AgentGUIConversationRailQuerySnapshot;

--- a/packages/agent/host/create_result.go
+++ b/packages/agent/host/create_result.go
@@ -1,0 +1,44 @@
+package agenthost
+
+import (
+	"errors"
+
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+func createSessionFailureResult(input CreateSessionInput, err error) (CreateSessionResult, error) {
+	initialGoalStatus := CreateSessionInitialGoalStatusNotRequested
+	if input.InitialGoalControl != nil {
+		initialGoalStatus = CreateSessionInitialGoalStatusUnknown
+	} else if _, typedGoal := ParseTypedGoalControl(input.InitialContent, false); typedGoal {
+		initialGoalStatus = CreateSessionInitialGoalStatusUnknown
+	}
+	sessionStatus := CreateSessionStatusNotCreated
+	if errors.Is(err, ErrSubmitDeliveryUnknown) {
+		sessionStatus = CreateSessionStatusUnknown
+	}
+	return CreateSessionResult{
+		SessionStatus:     sessionStatus,
+		InitialGoalStatus: initialGoalStatus,
+	}, err
+}
+
+func createSessionCreatedErrorResult(
+	input CreateSessionInput,
+	session ProviderRuntimeSession,
+	canonical storesqlite.Session,
+	err error,
+) (CreateSessionResult, error) {
+	initialGoalStatus := CreateSessionInitialGoalStatusNotRequested
+	if input.InitialGoalControl != nil {
+		initialGoalStatus = CreateSessionInitialGoalStatusUnknown
+	} else if _, typedGoal := ParseTypedGoalControl(input.InitialContent, false); typedGoal {
+		initialGoalStatus = CreateSessionInitialGoalStatusUnknown
+	}
+	return CreateSessionResult{
+		Session:           session,
+		Canonical:         canonical,
+		SessionStatus:     CreateSessionStatusCreated,
+		InitialGoalStatus: initialGoalStatus,
+	}, err
+}

--- a/packages/agent/host/initial_goal_create.go
+++ b/packages/agent/host/initial_goal_create.go
@@ -16,10 +16,15 @@ func (h *Host) replayInitialGoalCreate(
 ) (CreateSessionResult, bool, error) {
 	replay, found, err := h.existingGoalControlResult(ctx, goalInput)
 	if err != nil || !found {
-		return CreateSessionResult{}, found, err
+		if err != nil {
+			result, resultErr := createSessionFailureResult(input, err)
+			return result, found, resultErr
+		}
+		return CreateSessionResult{}, found, nil
 	}
 	if !railPlacementMatchesSession(input.RailPlacement, replay.Canonical) {
-		return CreateSessionResult{}, true, ErrRailPlacementConflict
+		result, resultErr := createSessionFailureResult(input, ErrRailPlacementConflict)
+		return result, true, resultErr
 	}
 	runtimeSession, live := h.runtime.Session(goalInput.WorkspaceID, input.AgentSessionID)
 	if !live {
@@ -28,6 +33,8 @@ func (h *Host) replayInitialGoalCreate(
 	return CreateSessionResult{
 		Session: runtimeSession, Canonical: replay.Canonical,
 		Kind: "goalControl", GoalControl: &replay,
+		SessionStatus:     CreateSessionStatusCreated,
+		InitialGoalStatus: CreateSessionInitialGoalStatusSucceeded,
 	}, true, nil
 }
 

--- a/packages/agent/host/lifecycle.go
+++ b/packages/agent/host/lifecycle.go
@@ -17,26 +17,26 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 	workspaceID, input.AgentSessionID = strings.TrimSpace(workspaceID), strings.TrimSpace(input.AgentSessionID)
 	input.Provider, input.AgentTargetID = strings.TrimSpace(input.Provider), strings.TrimSpace(input.AgentTargetID)
 	if h == nil || h.runtime == nil || h.store == nil || workspaceID == "" || input.AgentSessionID == "" || input.Provider == "" {
-		return CreateSessionResult{}, ErrInvalidArgument
+		return createSessionFailureResult(input, ErrInvalidArgument)
 	}
 	var err error
 	input.RailPlacement, err = normalizeRailPlacement(input.RailPlacement)
 	if err != nil {
-		return CreateSessionResult{}, err
+		return createSessionFailureResult(input, err)
 	}
 	ref := SessionRef{WorkspaceID: workspaceID, AgentSessionID: input.AgentSessionID}
 	normalized, promptText, err := normalizeOptionalPromptContent(input.InitialContent)
 	if err != nil {
-		return CreateSessionResult{}, err
+		return createSessionFailureResult(input, err)
 	}
 	typedGoal, isTypedGoal := ParseTypedGoalControl(normalized, false)
 	if input.InitialGoalControl != nil {
 		if len(normalized) != 0 {
-			return CreateSessionResult{}, ErrInvalidArgument
+			return createSessionFailureResult(input, ErrInvalidArgument)
 		}
 		typedGoal, err = normalizeTypedGoalControl(*input.InitialGoalControl)
 		if err != nil {
-			return CreateSessionResult{}, err
+			return createSessionFailureResult(input, err)
 		}
 		isTypedGoal = true
 	}
@@ -63,23 +63,23 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 	claim, claimPending, err := h.prepareSubmitClaim(ctx, ref, claimMetadata, input.TurnID)
 	if err != nil {
 		if errors.Is(err, storesqlite.ErrSubmitClaimTurnConflict) {
-			return CreateSessionResult{}, errors.Join(ErrSubmitDeliveryUnknown, err)
+			return createSessionFailureResult(input, errors.Join(ErrSubmitDeliveryUnknown, err))
 		}
-		return CreateSessionResult{}, err
+		return createSessionFailureResult(input, err)
 	}
 	if claim.ClientSubmitID != "" && !claimPending {
 		if claim.Status != "accepted" && claim.Status != "rejected" {
-			return CreateSessionResult{}, ErrSubmitDeliveryUnknown
+			return createSessionFailureResult(input, ErrSubmitDeliveryUnknown)
 		}
 		canonicalSession, _, readErr := h.store.GetSession(ctx, workspaceID, input.AgentSessionID)
 		if readErr != nil {
-			return CreateSessionResult{}, readErr
+			return createSessionFailureResult(input, readErr)
 		}
 		if !railPlacementMatchesSession(input.RailPlacement, canonicalSession) {
-			return CreateSessionResult{}, ErrRailPlacementConflict
+			return createSessionFailureResult(input, ErrRailPlacementConflict)
 		}
 		runtimeSession, _ := h.runtime.Session(workspaceID, input.AgentSessionID)
-		return CreateSessionResult{Session: runtimeSession, Canonical: canonicalSession, TurnID: claim.TurnID}, nil
+		return CreateSessionResult{Session: runtimeSession, Canonical: canonicalSession, TurnID: claim.TurnID, SessionStatus: CreateSessionStatusCreated, InitialGoalStatus: CreateSessionInitialGoalStatusNotRequested}, nil
 	}
 	defer func() {
 		if claimPending {
@@ -91,7 +91,7 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 	if h.preparation != nil {
 		prepared, err = h.preparation.Prepare(ctx, createPreparationInput(workspaceID, input))
 		if err != nil {
-			return CreateSessionResult{}, err
+			return createSessionFailureResult(input, err)
 		}
 	}
 	cleanup := func(cause error, started bool, canonicalCreated bool) error {
@@ -117,7 +117,7 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 	release, err := h.acquireStartup(ctx, input.Provider)
 	if err != nil {
 		h.observeStep(ctx, "session_create", "runtime_started", input.AgentSessionID, input.Provider, startedAt, err)
-		return CreateSessionResult{}, cleanup(err, false, false)
+		return createSessionFailureResult(input, cleanup(err, false, false))
 	}
 	session, err := func() (ProviderRuntimeSession, error) {
 		defer release()
@@ -136,7 +136,7 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 	}()
 	if err != nil {
 		h.observeStep(ctx, "session_create", "runtime_started", input.AgentSessionID, input.Provider, startedAt, err)
-		return CreateSessionResult{}, cleanup(err, false, false)
+		return createSessionFailureResult(input, cleanup(err, false, false))
 	}
 	h.observeStep(ctx, "session_create", "runtime_started", session.ID, session.Provider, startedAt, nil)
 	startedAt = h.now()
@@ -146,21 +146,21 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 	})
 	if err != nil {
 		h.observeStep(ctx, "session_create", "session_persisted", session.ID, session.Provider, startedAt, err)
-		return CreateSessionResult{}, cleanup(err, true, false)
+		return createSessionFailureResult(input, cleanup(err, true, false))
 	}
 	if strings.TrimSpace(canonicalSession.ID) != strings.TrimSpace(session.ID) || strings.TrimSpace(canonicalSession.WorkspaceID) != workspaceID || strings.TrimSpace(canonicalSession.RailSectionKey) == "" {
 		identityErr := fmt.Errorf("initialize workspace agent session: persisted session identity mismatch")
 		h.observeStep(ctx, "session_create", "session_persisted", session.ID, session.Provider, startedAt, identityErr)
-		return CreateSessionResult{}, cleanup(identityErr, true, true)
+		return createSessionFailureResult(input, cleanup(identityErr, true, true))
 	}
 	if !railPlacementMatchesSession(input.RailPlacement, canonicalSession) {
 		placementErr := ErrRailPlacementConflict
 		h.observeStep(ctx, "session_create", "session_persisted", session.ID, session.Provider, startedAt, placementErr)
-		return CreateSessionResult{}, cleanup(placementErr, true, true)
+		return createSessionFailureResult(input, cleanup(placementErr, true, true))
 	}
 	h.observeStep(ctx, "session_create", "session_persisted", session.ID, session.Provider, startedAt, nil)
 	if len(normalized) == 0 && !isTypedGoal {
-		return CreateSessionResult{Session: session, Canonical: canonicalSession}, nil
+		return CreateSessionResult{Session: session, Canonical: canonicalSession, SessionStatus: CreateSessionStatusCreated, InitialGoalStatus: CreateSessionInitialGoalStatusNotRequested}, nil
 	}
 	if isTypedGoal {
 		goalInput.AgentSessionID = session.ID
@@ -170,27 +170,24 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 			// session. Preserve that canonical session on command failure just as
 			// the legacy Service did; rolling it back would leave subscribers with
 			// an unpaired session-created event.
-			return CreateSessionResult{}, cleanup(goalErr, true, false)
+			return CreateSessionResult{Session: session, Canonical: canonicalSession, Kind: "goalControl", SessionStatus: CreateSessionStatusCreated, InitialGoalStatus: CreateSessionInitialGoalStatusFailed}, cleanup(goalErr, true, false)
 		}
 		if refreshed, ok := h.runtime.Session(workspaceID, session.ID); ok {
 			session = refreshed
 		}
-		return CreateSessionResult{
-			Session: session, Canonical: goalResult.Canonical,
-			Kind: "goalControl", GoalControl: &goalResult,
-		}, nil
+		return CreateSessionResult{Session: session, Canonical: goalResult.Canonical, Kind: "goalControl", GoalControl: &goalResult, SessionStatus: CreateSessionStatusCreated, InitialGoalStatus: CreateSessionInitialGoalStatusSucceeded}, nil
 	}
 	startedAt = h.now()
 	if err := h.runtime.ValidatePromptContent(ctx, RuntimeExecInput{WorkspaceID: workspaceID, AgentSessionID: session.ID, Content: normalized}); err != nil {
 		h.observeStep(ctx, "session_create", "prompt_validated", session.ID, session.Provider, startedAt, err)
-		return CreateSessionResult{}, cleanup(err, true, true)
+		return createSessionFailureResult(input, cleanup(err, true, true))
 	}
 	h.observeStep(ctx, "session_create", "prompt_validated", session.ID, session.Provider, startedAt, nil)
 	startedAt = h.now()
 	preparedContent, err := h.prepareContent(workspaceID, session.ID, normalized)
 	if err != nil {
 		h.observeStep(ctx, "session_create", "prompt_prepared", session.ID, session.Provider, startedAt, err)
-		return CreateSessionResult{}, cleanup(err, true, true)
+		return createSessionFailureResult(input, cleanup(err, true, true))
 	}
 	h.observeStep(ctx, "session_create", "prompt_prepared", session.ID, session.Provider, startedAt, nil)
 	displayPrompt := strings.TrimSpace(input.InitialDisplayPrompt)
@@ -224,7 +221,7 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 				input.TuttiModeSnapshot,
 			); persistErr != nil {
 				claimPending = false
-				return CreateSessionResult{}, errors.Join(ErrSubmitDeliveryUnknown, err, persistErr)
+				return createSessionCreatedErrorResult(input, session, canonicalSession, errors.Join(ErrSubmitDeliveryUnknown, err, persistErr))
 			}
 			if disposition == RuntimeDispatchDispositionRejected {
 				// A definitive rejection keeps the visible Session/failed Turn. The
@@ -235,24 +232,24 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 				if strings.TrimSpace(execResult.TurnID) != "" {
 					claimPending = false
 					if rejectErr := h.finalizeRejectedSubmitClaim(ref, firstNonEmpty(claim.ClientSubmitID, input.ClientSubmitID, legacyClientSubmitID(metadata)), execResult.TurnID); rejectErr != nil {
-						return CreateSessionResult{}, errors.Join(ErrSubmitDeliveryUnknown, err, rejectErr)
+						return createSessionCreatedErrorResult(input, session, canonicalSession, errors.Join(ErrSubmitDeliveryUnknown, err, rejectErr))
 					}
 				}
-				return CreateSessionResult{}, h.discardRejectedPreparedRuntime(ctx, err, workspaceID, session.ID, session.Provider)
+				return createSessionCreatedErrorResult(input, session, canonicalSession, h.discardRejectedPreparedRuntime(ctx, err, workspaceID, session.ID, session.Provider))
 			}
 			claimPending = false
-			return CreateSessionResult{}, errors.Join(ErrSubmitDeliveryUnknown, err)
+			return createSessionCreatedErrorResult(input, session, canonicalSession, errors.Join(ErrSubmitDeliveryUnknown, err))
 		}
-		return CreateSessionResult{}, cleanup(err, true, true)
+		return createSessionFailureResult(input, cleanup(err, true, true))
 	}
 	turnID = strings.TrimSpace(execResult.TurnID)
 	if turnID == "" {
 		h.observeStep(ctx, "session_create", "runtime_exec", session.ID, session.Provider, startedAt, ErrSubmitDeliveryUnknown)
-		return CreateSessionResult{}, cleanup(ErrSubmitDeliveryUnknown, true, true)
+		return createSessionFailureResult(input, cleanup(ErrSubmitDeliveryUnknown, true, true))
 	}
 	if expectedTurnID := strings.TrimSpace(input.TurnID); expectedTurnID != "" && turnID != expectedTurnID {
 		claimPending = false
-		return CreateSessionResult{}, ErrSubmitDeliveryUnknown
+		return createSessionCreatedErrorResult(input, session, canonicalSession, ErrSubmitDeliveryUnknown)
 	}
 	if reporter, ok := h.runtime.(RuntimeSubmitProvenanceReporter); ok {
 		if err := reporter.DurablyReportSubmitProvenance(ctx, RuntimeSubmitProvenanceInput{
@@ -263,7 +260,7 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 			// Provider acceptance is already possible. Keep the runtime, canonical
 			// session, and prepared claim intact so a retry cannot dispatch twice.
 			claimPending = false
-			return CreateSessionResult{}, errors.Join(ErrSubmitDeliveryUnknown, err)
+			return createSessionCreatedErrorResult(input, session, canonicalSession, errors.Join(ErrSubmitDeliveryUnknown, err))
 		}
 	}
 	if err := h.recordTurnSubmission(
@@ -271,12 +268,12 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 		displayPrompt, input.CapabilityRefs, input.TuttiModeSnapshot,
 	); err != nil {
 		claimPending = false
-		return CreateSessionResult{}, errors.Join(ErrSubmitDeliveryUnknown, err)
+		return createSessionCreatedErrorResult(input, session, canonicalSession, errors.Join(ErrSubmitDeliveryUnknown, err))
 	}
 	if claim.ClientSubmitID != "" {
 		claimPending = false
 		if err := h.acceptSubmitClaim(ref, claim.ClientSubmitID, turnID); err != nil {
-			return CreateSessionResult{}, errors.Join(ErrSubmitDeliveryUnknown, err)
+			return createSessionCreatedErrorResult(input, session, canonicalSession, errors.Join(ErrSubmitDeliveryUnknown, err))
 		}
 	}
 	if refreshed, ok := h.runtime.Session(workspaceID, session.ID); ok {
@@ -286,7 +283,7 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 		canonicalSession = refreshed
 	}
 	h.observeStep(ctx, "session_create", "runtime_exec", session.ID, session.Provider, startedAt, nil)
-	return CreateSessionResult{Session: session, Canonical: canonicalSession, TurnID: turnID}, nil
+	return CreateSessionResult{Session: session, Canonical: canonicalSession, TurnID: turnID, SessionStatus: CreateSessionStatusCreated, InitialGoalStatus: CreateSessionInitialGoalStatusNotRequested}, nil
 }
 
 func (h *Host) EnsureRuntimeSession(ctx context.Context, ref SessionRef) (ProviderRuntimeSession, error) {

--- a/packages/agent/host/types.go
+++ b/packages/agent/host/types.go
@@ -756,12 +756,31 @@ type UpdatePinInput struct {
 }
 
 type CreateSessionResult struct {
-	Session     ProviderRuntimeSession
-	Canonical   storesqlite.Session
-	TurnID      string
-	Kind        string
-	GoalControl *GoalControlResult
+	Session           ProviderRuntimeSession
+	Canonical         storesqlite.Session
+	TurnID            string
+	Kind              string
+	GoalControl       *GoalControlResult
+	SessionStatus     CreateSessionStatus
+	InitialGoalStatus CreateSessionInitialGoalStatus
 }
+
+type CreateSessionStatus string
+
+const (
+	CreateSessionStatusUnknown    CreateSessionStatus = "unknown"
+	CreateSessionStatusCreated    CreateSessionStatus = "created"
+	CreateSessionStatusNotCreated CreateSessionStatus = "not_created"
+)
+
+type CreateSessionInitialGoalStatus string
+
+const (
+	CreateSessionInitialGoalStatusNotRequested CreateSessionInitialGoalStatus = "not_requested"
+	CreateSessionInitialGoalStatusSucceeded    CreateSessionInitialGoalStatus = "succeeded"
+	CreateSessionInitialGoalStatusFailed       CreateSessionInitialGoalStatus = "failed"
+	CreateSessionInitialGoalStatusUnknown      CreateSessionInitialGoalStatus = "unknown"
+)
 
 type SendInputResult struct {
 	Session            ProviderRuntimeSession

--- a/services/tuttid/service/agent/service_create.go
+++ b/services/tuttid/service/agent/service_create.go
@@ -29,29 +29,29 @@ func (s *Service) CreateWithResult(ctx context.Context, workspaceID string, inpu
 	input.AgentTargetID = strings.TrimSpace(input.AgentTargetID)
 	launch, err := s.resolveCreateSessionLaunch(ctx, workspaceID, &input)
 	if err != nil {
-		return CreateSessionResult{}, err
+		return createSessionFailureResult(input, err)
 	}
 	provider := launch.Provider
 	if workspaceID == "" || provider == "" {
-		return CreateSessionResult{}, ErrInvalidArgument
+		return createSessionFailureResult(input, ErrInvalidArgument)
 	}
 	input.Provider = provider
 	input.ProviderTargetRef = launch.ProviderTargetRef
 	if valueBool(input.CodexSaverMode) && (!input.CodexSaverModeAllowed || !composerProviderSupportsSaverSubagentMode(provider)) {
-		return CreateSessionResult{}, fmt.Errorf("%w: Codex saver mode is unavailable", ErrInvalidArgument)
+		return createSessionFailureResult(input, fmt.Errorf("%w: Codex saver mode is unavailable", ErrInvalidArgument))
 	}
 	if !input.CodexSaverModeAllowed || !composerProviderSupportsSaverSubagentMode(provider) {
 		input.CodexSaverMode = nil
 	}
 	permissionModeExplicit := strings.TrimSpace(value(input.PermissionModeID)) != ""
 	if err := s.applyCreateSessionComposerDefaults(ctx, &input); err != nil {
-		return CreateSessionResult{}, err
+		return createSessionFailureResult(input, err)
 	}
 	input.ConversationDetailMode = preferencesbiz.NormalizeDesktopAgentConversationDetailMode(input.ConversationDetailMode)
 	requestedPermissionModeID := strings.TrimSpace(value(input.PermissionModeID))
 	if input.StrictPermissionMode && requestedPermissionModeID != "" &&
 		!permissionModeConfigHasModeID(permissionConfigForProvider(provider), requestedPermissionModeID) {
-		return CreateSessionResult{}, fmt.Errorf("%w: permission mode is unsupported by the workspace agent harness", ErrInvalidArgument)
+		return createSessionFailureResult(input, fmt.Errorf("%w: permission mode is unsupported by the workspace agent harness", ErrInvalidArgument))
 	}
 	normalizedPermissionModeID := normalizePermissionModeIDForLaunch(provider, input.ProviderTargetRef, value(input.PermissionModeID))
 	if normalizedPermissionModeID != "" {
@@ -79,11 +79,11 @@ func (s *Service) CreateWithResult(ctx context.Context, workspaceID string, inpu
 		normalizedContent, _, err = normalizePromptContent(input.InitialContent)
 		if err != nil {
 			s.reportAgentServiceNodeFailure(ctx, input.AgentSessionID, "session_create", "content_normalized", provider, nodeStartedAt, err)
-			return CreateSessionResult{}, err
+			return createSessionFailureResult(input, err)
 		}
 		if err := s.validatePromptConnectors(ctx, normalizedContent); err != nil {
 			s.reportAgentServiceNodeFailure(ctx, input.AgentSessionID, "session_create", "connectors_validated", provider, nodeStartedAt, err)
-			return CreateSessionResult{}, err
+			return createSessionFailureResult(input, err)
 		}
 		s.reportAgentServiceNodeSuccess(ctx, input.AgentSessionID, "session_create", "content_normalized", provider, nodeStartedAt)
 	}
@@ -93,7 +93,7 @@ func (s *Service) CreateWithResult(ctx context.Context, workspaceID string, inpu
 	planResolution, err := s.resolveCreateSessionModelForPlanOrProvider(ctx, workspaceID, provider, requestedModel, &input)
 	if err != nil {
 		s.reportAgentServiceNodeFailure(ctx, input.AgentSessionID, "session_create", "model_validated", provider, nodeStartedAt, err)
-		return CreateSessionResult{}, err
+		return createSessionFailureResult(input, err)
 	}
 	s.reportAgentServiceNodeSuccess(ctx, input.AgentSessionID, "session_create", "model_validated", provider, nodeStartedAt)
 	input.RuntimeContext = runtimeContextWithSessionRuntimeSnapshot(input.RuntimeContext, input, provider, planResolution)
@@ -101,7 +101,7 @@ func (s *Service) CreateWithResult(ctx context.Context, workspaceID string, inpu
 		"model": value(input.Model),
 	})
 	if err := s.applyCreateSessionReasoningIntensity(ctx, provider, value(input.Model), &input); err != nil {
-		return CreateSessionResult{}, err
+		return createSessionFailureResult(input, err)
 	}
 	input.ReasoningEffort = s.clampReasoningEffortPointerForLaunch(
 		ctx,
@@ -112,7 +112,7 @@ func (s *Service) CreateWithResult(ctx context.Context, workspaceID string, inpu
 	)
 	isolationMode := strings.TrimSpace(input.Isolation)
 	if isolationMode != "" && isolationMode != WorktreeIsolationMode {
-		return CreateSessionResult{}, fmt.Errorf("%w: unsupported session isolation mode %q", ErrInvalidArgument, isolationMode)
+		return createSessionFailureResult(input, fmt.Errorf("%w: unsupported session isolation mode %q", ErrInvalidArgument, isolationMode))
 	}
 	worktreeLock := s.worktreeLock()
 	worktreeLock.RLock()
@@ -121,12 +121,12 @@ func (s *Service) CreateWithResult(ctx context.Context, workspaceID string, inpu
 	if isolationMode == WorktreeIsolationMode && strings.TrimSpace(value(input.Cwd)) == "" {
 		err := &WorktreeIsolationError{Kind: ErrNotAGitRepo}
 		s.reportAgentServiceNodeFailure(ctx, input.AgentSessionID, "session_create", "cwd_resolved", provider, nodeStartedAt, err)
-		return CreateSessionResult{}, err
+		return createSessionFailureResult(input, err)
 	}
 	cwd, err := s.resolveCwd(ctx, input.Cwd)
 	if err != nil {
 		s.reportAgentServiceNodeFailure(ctx, input.AgentSessionID, "session_create", "cwd_resolved", provider, nodeStartedAt, err)
-		return CreateSessionResult{}, err
+		return createSessionFailureResult(input, err)
 	}
 	s.reportAgentServiceNodeSuccess(ctx, input.AgentSessionID, "session_create", "cwd_resolved", provider, nodeStartedAt)
 	logAgentSubmitTrace("service.create.cwd_resolved", workspaceID, input.AgentSessionID, input.ClientSubmitID, input.Metadata, map[string]any{
@@ -138,7 +138,7 @@ func (s *Service) CreateWithResult(ctx context.Context, workspaceID string, inpu
 	if isolationMode == WorktreeIsolationMode {
 		created, warnings, createErr := s.createSessionWorktree(ctx, workspaceID, cwd, input.AgentSessionID)
 		if createErr != nil {
-			return CreateSessionResult{}, createErr
+			return createSessionFailureResult(input, createErr)
 		}
 		isolation = &created
 		isolationWarnings = warnings
@@ -161,7 +161,7 @@ func (s *Service) CreateWithResult(ctx context.Context, workspaceID string, inpu
 			permissionModeExplicit,
 		); err != nil {
 			s.reportAgentServiceNodeFailure(ctx, input.AgentSessionID, "session_create", "settings_validated", provider, nodeStartedAt, err)
-			return CreateSessionResult{}, err
+			return createSessionFailureResult(input, err)
 		}
 		s.reportAgentServiceNodeSuccess(ctx, input.AgentSessionID, "session_create", "settings_validated", provider, nodeStartedAt)
 	}
@@ -169,7 +169,7 @@ func (s *Service) CreateWithResult(ctx context.Context, workspaceID string, inpu
 	prepared, err := s.prepareRuntime(ctx, workspaceID, cwd, input, planResolution.Endpoint)
 	if err != nil {
 		s.reportAgentServiceNodeFailure(ctx, input.AgentSessionID, "session_create", "runtime_prepared", provider, nodeStartedAt, err)
-		return CreateSessionResult{}, err
+		return createSessionFailureResult(input, err)
 	}
 	if isolation != nil {
 		prepared.Cwd = isolation.WorktreePath
@@ -204,7 +204,7 @@ func (s *Service) CreateWithResult(ctx context.Context, workspaceID string, inpu
 		RailPlacement: input.RailPlacement,
 	}
 	if err := s.applyInitialTuttiModeActivation(ctx, workspaceID, input.AgentSessionID, input.InitialTuttiModeActivation); err != nil {
-		return CreateSessionResult{}, err
+		return createSessionFailureResult(input, err)
 	}
 	var preparedTuttiModeTurnID string
 	_, textGoal := agenthost.ParseTypedGoalControl(normalizedContent, false)
@@ -212,7 +212,7 @@ func (s *Service) CreateWithResult(ctx context.Context, workspaceID string, inpu
 	if len(normalizedContent) > 0 && !typedGoal {
 		canonicalTurnID, claimErr := s.existingSubmitCanonicalTurnID(ctx, workspaceID, input.AgentSessionID, input.ClientSubmitID, input.Metadata)
 		if claimErr != nil {
-			return CreateSessionResult{}, claimErr
+			return createSessionFailureResult(input, claimErr)
 		}
 		if canonicalTurnID != "" {
 			// A durable claim already owns this submit: reuse its canonical
@@ -227,7 +227,7 @@ func (s *Service) CreateWithResult(ctx context.Context, workspaceID string, inpu
 					activationErr := s.deleteTuttiModeActivationSessionState(context.WithoutCancel(ctx), workspaceID, input.AgentSessionID)
 					snapshotErr = errors.Join(snapshotErr, activationErr)
 				}
-				return CreateSessionResult{}, snapshotErr
+				return createSessionFailureResult(input, snapshotErr)
 			}
 			preparedTuttiModeTurnID = turnID
 			hostInput.TurnID = turnID
@@ -237,13 +237,45 @@ func (s *Service) CreateWithResult(ctx context.Context, workspaceID string, inpu
 	logAgentSubmitTrace("service.create.runtime_start_requested", workspaceID, input.AgentSessionID, input.ClientSubmitID, input.Metadata, nil)
 	hostResult, err := s.ApplicationHost().CreateSession(ctx, workspaceID, hostInput)
 	if err != nil {
+		// Host can durably create the Session before the typed initial Goal
+		// fails. Preserve that result (and its worktree) so callers can render a
+		// selectable historical Session with a failed Goal instead of treating the
+		// whole creation as absent.
+		if hostResult.SessionStatus == agenthost.CreateSessionStatusCreated {
+			keepWorktree = true
+			created, getErr := s.Get(ctx, workspaceID, input.AgentSessionID)
+			if getErr == nil {
+				return CreateSessionResult{
+					Session:           decorateIsolatedSession(created, isolation, isolationWarnings),
+					SessionStatus:     hostResult.SessionStatus,
+					InitialGoalStatus: hostResult.InitialGoalStatus,
+				}, err
+			}
+			// Get may fail after Host has already persisted the Session (for
+			// example while the runtime is being torn down). Return the Host
+			// projection anyway; the original Goal error remains the operation
+			// error, but the Session-created fact must not be lost.
+			fallback := serviceSessionWithPersistedFreshness(
+				hostResult.Session,
+				persistedSessionFromHost(hostResult.Canonical),
+				s.controller().CanResume(runtimeResumeInputFromRuntimeSession(hostResult.Session)),
+			)
+			if projected, projectErr := s.projectSessionForResponse(ctx, workspaceID, fallback); projectErr == nil {
+				fallback = projected
+			}
+			return CreateSessionResult{
+				Session:           decorateIsolatedSession(fallback, isolation, isolationWarnings),
+				SessionStatus:     hostResult.SessionStatus,
+				InitialGoalStatus: hostResult.InitialGoalStatus,
+			}, err
+		}
 		// Delivery-unknown means provider acceptance is already possible:
 		// keep the prepared claim, bound snapshot, and activation so a retry
 		// reconciles instead of double-dispatching.
 		if !errors.Is(err, ErrSubmitDeliveryUnknown) {
 			_ = s.deleteTuttiModeActivationSessionState(context.WithoutCancel(ctx), workspaceID, input.AgentSessionID)
 		}
-		return CreateSessionResult{}, err
+		return createSessionFailureResult(input, err)
 	}
 	keepWorktree = true
 	session := hostResult.Session
@@ -252,19 +284,23 @@ func (s *Service) CreateWithResult(ctx context.Context, workspaceID string, inpu
 	if strings.TrimSpace(session.ID) == "" && strings.TrimSpace(hostResult.TurnID) != "" {
 		result, getErr := s.Get(ctx, workspaceID, input.AgentSessionID)
 		return CreateSessionResult{
-			Session: decorateIsolatedSession(result, isolation, isolationWarnings),
-			TurnID:  strings.TrimSpace(hostResult.TurnID),
+			Session:           decorateIsolatedSession(result, isolation, isolationWarnings),
+			TurnID:            strings.TrimSpace(hostResult.TurnID),
+			SessionStatus:     hostResult.SessionStatus,
+			InitialGoalStatus: hostResult.InitialGoalStatus,
 		}, getErr
 	}
 	if hostResult.Kind == "goalControl" {
 		result, getErr := s.Get(ctx, workspaceID, session.ID)
 		return CreateSessionResult{
-			Session: decorateIsolatedSession(result, isolation, isolationWarnings),
-			TurnID:  strings.TrimSpace(hostResult.TurnID),
+			Session:           decorateIsolatedSession(result, isolation, isolationWarnings),
+			TurnID:            strings.TrimSpace(hostResult.TurnID),
+			SessionStatus:     hostResult.SessionStatus,
+			InitialGoalStatus: hostResult.InitialGoalStatus,
 		}, getErr
 	}
 	if preparedTuttiModeTurnID != "" && strings.TrimSpace(hostResult.TurnID) != preparedTuttiModeTurnID {
-		return CreateSessionResult{}, ErrSubmitDeliveryUnknown
+		return createSessionFailureResult(input, ErrSubmitDeliveryUnknown)
 	}
 	if len(normalizedContent) == 0 {
 		created, err := s.projectSessionForResponse(ctx, workspaceID, serviceSessionWithPersistedFreshness(
@@ -273,8 +309,10 @@ func (s *Service) CreateWithResult(ctx context.Context, workspaceID string, inpu
 			s.controller().CanResume(runtimeResumeInputFromRuntimeSession(session)),
 		))
 		return CreateSessionResult{
-			Session: decorateIsolatedSession(created, isolation, isolationWarnings),
-			TurnID:  strings.TrimSpace(hostResult.TurnID),
+			Session:           decorateIsolatedSession(created, isolation, isolationWarnings),
+			TurnID:            strings.TrimSpace(hostResult.TurnID),
+			SessionStatus:     hostResult.SessionStatus,
+			InitialGoalStatus: hostResult.InitialGoalStatus,
 		}, err
 	}
 	logAgentSubmitTrace("service.create.prompt_validated", workspaceID, session.ID, input.ClientSubmitID, input.Metadata, nil)
@@ -286,8 +324,26 @@ func (s *Service) CreateWithResult(ctx context.Context, workspaceID string, inpu
 		s.controller().CanResume(runtimeResumeInputFromRuntimeSession(session)),
 	))
 	return CreateSessionResult{
-		Session: decorateIsolatedSession(created, isolation, isolationWarnings),
-		TurnID:  strings.TrimSpace(hostResult.TurnID),
+		Session:           decorateIsolatedSession(created, isolation, isolationWarnings),
+		TurnID:            strings.TrimSpace(hostResult.TurnID),
+		SessionStatus:     hostResult.SessionStatus,
+		InitialGoalStatus: hostResult.InitialGoalStatus,
+	}, err
+}
+
+func createSessionFailureResult(input CreateSessionInput, err error) (CreateSessionResult, error) {
+	initialGoalStatus := agenthost.CreateSessionInitialGoalStatusNotRequested
+	_, typedGoal := agenthost.ParseTypedGoalControl(input.InitialContent, false)
+	if input.InitialGoalControl != nil || typedGoal {
+		initialGoalStatus = agenthost.CreateSessionInitialGoalStatusUnknown
+	}
+	sessionStatus := agenthost.CreateSessionStatusNotCreated
+	if errors.Is(err, ErrSubmitDeliveryUnknown) {
+		sessionStatus = agenthost.CreateSessionStatusUnknown
+	}
+	return CreateSessionResult{
+		SessionStatus:     sessionStatus,
+		InitialGoalStatus: initialGoalStatus,
 	}, err
 }
 

--- a/services/tuttid/service/agent/service_host_create_rollback_test.go
+++ b/services/tuttid/service/agent/service_host_create_rollback_test.go
@@ -13,6 +13,22 @@ import (
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 )
 
+type unavailableSessionReader struct {
+	delegate SessionReader
+}
+
+func (unavailableSessionReader) GetSession(string, string) (PersistedSession, bool) {
+	return PersistedSession{}, false
+}
+
+func (r unavailableSessionReader) ListSessions(workspaceID string) ([]PersistedSession, bool) {
+	return r.delegate.ListSessions(workspaceID)
+}
+
+func (r unavailableSessionReader) SessionDeleted(ctx context.Context, workspaceID, agentSessionID string) (bool, error) {
+	return r.delegate.SessionDeleted(ctx, workspaceID, agentSessionID)
+}
+
 func TestHostCreateWithInitialInputRollsBackTurnlessCanonicalShell(t *testing.T) {
 	execErr := errors.New("provider rejected initial input")
 	runtime := newFakeRuntime()
@@ -28,12 +44,20 @@ func TestHostCreateWithInitialInputRollsBackTurnlessCanonicalShell(t *testing.T)
 	service.SessionReader = projection
 	service.SessionInitializer = projection
 
-	_, err := service.Create(context.Background(), "ws-1", CreateSessionInput{
+	created, err := service.CreateWithResult(context.Background(), "ws-1", CreateSessionInput{
 		AgentSessionID: "session-no-turnless-shell", AgentTargetID: agenttargetbiz.IDLocalCodex,
 		InitialContent: TextPromptContent("start atomically"),
 	})
 	if !errors.Is(err, execErr) {
 		t.Fatalf("Create() error=%v, want %v", err, execErr)
+	}
+	if created.SessionStatus != agenthost.CreateSessionStatusNotCreated ||
+		created.InitialGoalStatus != agenthost.CreateSessionInitialGoalStatusNotRequested {
+		t.Fatalf(
+			"create outcome session=%q goal=%q, want not_created/not_requested",
+			created.SessionStatus,
+			created.InitialGoalStatus,
+		)
 	}
 	if _, ok, err := store.GetSession(context.Background(), "ws-1", "session-no-turnless-shell"); err != nil || ok {
 		t.Fatalf("canonical shell after failed initial input ok=%v error=%v", ok, err)
@@ -191,16 +215,27 @@ func TestHostCreateWithInvalidTypedGoalPreservesPublishedSession(t *testing.T) {
 	publisher := &activityUpdatePublisherStub{}
 	projection.SetPublisher(publisher)
 	service := newTestService(runtime)
-	service.SessionReader = projection
+	service.SessionReader = unavailableSessionReader{delegate: projection}
 	service.SessionInitializer = projection
 	service.GoalStateStore = store
 
-	_, err := service.Create(ctx, "ws-goal", CreateSessionInput{
+	created, err := service.CreateWithResult(ctx, "ws-goal", CreateSessionInput{
 		AgentSessionID: "session-invalid-goal", AgentTargetID: agenttargetbiz.IDLocalCodex,
 		InitialContent: TextPromptContent("/goal pause"),
 	})
 	if !errors.Is(err, storesqlite.ErrGoalStateAbsent) {
 		t.Fatalf("Create() error=%v, want %v", err, storesqlite.ErrGoalStateAbsent)
+	}
+	if created.Session.ID != "session-invalid-goal" {
+		t.Fatalf("created Session ID=%q, want preserved canonical Session", created.Session.ID)
+	}
+	if created.SessionStatus != agenthost.CreateSessionStatusCreated ||
+		created.InitialGoalStatus != agenthost.CreateSessionInitialGoalStatusFailed {
+		t.Fatalf(
+			"create outcome session=%q goal=%q, want created/failed",
+			created.SessionStatus,
+			created.InitialGoalStatus,
+		)
 	}
 	if _, found, getErr := store.GetSession(ctx, "ws-goal", "session-invalid-goal"); getErr != nil || !found {
 		t.Fatalf("published canonical session found=%v error=%v", found, getErr)

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -685,8 +685,10 @@ type CreateSessionInput struct {
 // for callers that need to correlate the initial submission. Create remains
 // the compatibility surface for consumers that only need the Session.
 type CreateSessionResult struct {
-	Session Session
-	TurnID  string
+	Session           Session
+	TurnID            string
+	SessionStatus     agenthost.CreateSessionStatus
+	InitialGoalStatus agenthost.CreateSessionInitialGoalStatus
 }
 
 type TuttiModeActivationIntent struct {


### PR DESCRIPTION
## Summary

- Centralize failed-new-activation resolution in Activity Core: roll back only when no canonical Session exists; preserve and open when the Session already exists.
- Keep user-selected historical conversations higher priority than transient activation failure routing.
- Reconcile/materialize a shared Agent Session from its durable binding when the local runtime projection is missing.
- Separate Session creation status from initial Goal status, including the created/failed case and explicit not-created/unknown outcomes.

## Root cause

AgentGUI treated any failed activation as proof that the selected Session did not exist. For historical shared-Agent rows, the durable binding could exist remotely while the local runtime projection was absent, so the failure path cleared the selected conversation and rendered the empty state.

## Main risks / affected surfaces

- Activity Core activation/session lifecycle selectors
- AgentGUI conversation routing, selection, Activity View, and shared-Agent reconciliation
- Host and tuttid create-result semantics

The change is read-time reconciliation only; it does not migrate or rewrite historical database records. A genuinely missing canonical Session still returns to the home state.

## Verification

- `go test ./packages/agent/host ./services/tuttid/service/agent`
- `pnpm check:changed`
- `pnpm check:changed -- --push-ready` (24 lanes)
- Agent Activity Core tests and typecheck
- AgentGUI tests/typecheck
- TSH shared-Agent targeted tests: 5 passed
- TSH typecheck

## Follow-up

TSH local reconciliation changes are kept separate and should be upgraded after this Tutti change is released.