### PR TITLE
fix(agent-replay): expose transport failures

### DIFF
--- a/packages/agent/daemon/runtime/process_transport_replay.go
+++ b/packages/agent/daemon/runtime/process_transport_replay.go
@@ -206,6 +206,20 @@ func (t *ReplayProcessTransport) ReplayPlaybackState() ReplayPlaybackState {
 	return state
 }
 
+func (t *ReplayProcessTransport) ReplayFailure() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, connection := range t.started {
+		connection.mu.Lock()
+		failure := connection.failure
+		connection.mu.Unlock()
+		if failure != nil {
+			return failure
+		}
+	}
+	return nil
+}
+
 func (t *ReplayProcessTransport) SetReplayPlaybackSpeed(speed float64) error {
 	return t.playback.setSpeed(speed)
 }

--- a/packages/agent/daemon/runtime/process_transport_session_replay.go
+++ b/packages/agent/daemon/runtime/process_transport_session_replay.go
@@ -106,6 +106,14 @@ func (t *SessionReplayProcessTransport) ReplayPlaybackState(
 	return player.ReplayPlaybackState(), nil
 }
 
+func (t *SessionReplayProcessTransport) ReplayFailure(cassetteID string) error {
+	player, err := t.player(cassetteID)
+	if err != nil {
+		return err
+	}
+	return player.ReplayFailure()
+}
+
 func (t *SessionReplayProcessTransport) SetReplayPlaybackSpeed(
 	cassetteID string,
 	speed float64,

--- a/packages/agent/daemon/runtime/process_transport_session_replay_test.go
+++ b/packages/agent/daemon/runtime/process_transport_session_replay_test.go
@@ -145,6 +145,9 @@ func TestSessionReplayProcessTransportKeepsCassettePlaybackAndFailureIndependent
 	if stateB.Paused || stateB.Speed != 2 {
 		t.Fatalf("cassette B playback = %#v, want running at speed 2", stateB)
 	}
+	if err := transport.ReplayFailure("cassette-a"); err != nil {
+		t.Fatalf("unstarted cassette A failure = %v, want nil", err)
+	}
 
 	connectionA, err := transport.Start(context.Background(), ProcessSpec{
 		Provider:       ProviderCodex,
@@ -153,8 +156,17 @@ func TestSessionReplayProcessTransportKeepsCassettePlaybackAndFailureIndependent
 	if err != nil {
 		t.Fatal(err)
 	}
+	if err := transport.ReplayFailure("cassette-a"); err != nil {
+		t.Fatalf("undrained cassette A failure = %v, want nil", err)
+	}
 	if err := connectionA.Send([]byte(`{"wrong":true}`)); err == nil {
 		t.Fatal("cassette A outbound mismatch succeeded")
+	}
+	if err := transport.ReplayFailure("cassette-a"); err == nil {
+		t.Fatal("cassette A failure is nil after mismatch")
+	}
+	if err := transport.ReplayFailure("cassette-b"); err != nil {
+		t.Fatalf("cassette B failure after cassette A mismatch = %v, want nil", err)
 	}
 
 	connectionB, err := transport.Start(context.Background(), ProcessSpec{
@@ -175,6 +187,9 @@ func TestSessionReplayProcessTransportKeepsCassettePlaybackAndFailureIndependent
 	}
 	if _, err := transport.ReplayPlaybackState("missing"); err == nil {
 		t.Fatal("unknown replay cassette playback lookup succeeded")
+	}
+	if err := transport.ReplayFailure("missing"); err == nil {
+		t.Fatal("unknown replay cassette failure lookup succeeded")
 	}
 }
 


### PR DESCRIPTION
## Summary

- expose an existing replay connection failure without requiring cassette completion
- add cassette-scoped failure lookup for session replay orchestration
- keep unstarted and undrained cassettes healthy during readiness checks

## Validation

- `pnpm check:changed -- --push-ready` (8/8 lanes passed)

## Documentation

No documentation change. This adds an internal runtime health read and does not change cassette or wire formats.