### PR TITLE
fix(release): retry transient package publishes

### DIFF
--- a/tools/scripts/publish-packages.mjs
+++ b/tools/scripts/publish-packages.mjs
@@ -60,12 +60,20 @@ async function main() {
       continue;
     }
 
-    console.log(
-      `Publishing ${packageConfig.name}@${releaseVersion} with latest tag`
-    );
-    execFileSync("pnpm", publishArguments, {
-      cwd: join(workspaceRoot, packageConfig.directory),
-      stdio: "inherit"
+    await publishPackageWithRetry({
+      packageName: packageConfig.name,
+      version: releaseVersion,
+      publish: () => {
+        console.log(
+          `Publishing ${packageConfig.name}@${releaseVersion} with latest tag`
+        );
+        execFileSync("pnpm", publishArguments, {
+          cwd: join(workspaceRoot, packageConfig.directory),
+          stdio: "inherit"
+        });
+      },
+      isPublished: () =>
+        isPackageVersionPublished(packageConfig.name, releaseVersion)
     });
   }
 
@@ -80,6 +88,46 @@ async function main() {
     env: createReleaseGitEnvironment(),
     stdio: "inherit"
   });
+}
+
+// npm provenance can fail after creating a transparency-log entry but before
+// the registry accepts the package. Re-checking the immutable version before
+// a bounded retry makes workflow re-runs and this individual publish step
+// idempotent without disabling provenance.
+export async function publishPackageWithRetry({
+  packageName,
+  version,
+  publish,
+  isPublished,
+  maxAttempts = 3,
+  wait = defaultPublishRetryWait
+}) {
+  let lastError;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      publish();
+      return;
+    } catch (error) {
+      lastError = error;
+      if (isPublished()) {
+        console.log(
+          `${packageName}@${version} became visible after publish returned an error; continuing`
+        );
+        return;
+      }
+      if (attempt < maxAttempts) {
+        console.warn(
+          `Publish attempt ${attempt}/${maxAttempts} failed for ${packageName}@${version}; retrying`
+        );
+        await wait(attempt);
+      }
+    }
+  }
+  throw lastError;
+}
+
+function defaultPublishRetryWait(attempt) {
+  return new Promise((resolve) => setTimeout(resolve, attempt * 2_000));
 }
 
 export function createReleaseCommit(releaseVersion, releasePaths) {

--- a/tools/scripts/publish-packages.test.mjs
+++ b/tools/scripts/publish-packages.test.mjs
@@ -7,6 +7,7 @@ import {
   formatPackageGoModuleReleaseTag,
   isPublishedVersionListed,
   normalizePublishedPackageVersions,
+  publishPackageWithRetry,
   resolveReleaseTagNames
 } from "./publish-packages.mjs";
 
@@ -80,4 +81,58 @@ test("normalizePublishedPackageVersions accepts npm string and array outputs", (
 test("isPublishedVersionListed detects already published versions", () => {
   assert.equal(isPublishedVersionListed(["0.0.1", "0.0.2"], "0.0.1"), true);
   assert.equal(isPublishedVersionListed(["0.0.1", "0.0.2"], "0.0.3"), false);
+});
+
+test("publishPackageWithRetry retries a failed unpublished version", async () => {
+  let attempts = 0;
+  const waits = [];
+  await publishPackageWithRetry({
+    packageName: "@tutti-os/example",
+    version: "0.0.1",
+    publish() {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new Error("transparency log conflict");
+      }
+    },
+    isPublished: () => false,
+    wait: async (attempt) => waits.push(attempt)
+  });
+  assert.equal(attempts, 2);
+  assert.deepEqual(waits, [1]);
+});
+
+test("publishPackageWithRetry accepts a version visible after an error", async () => {
+  let attempts = 0;
+  await publishPackageWithRetry({
+    packageName: "@tutti-os/example",
+    version: "0.0.1",
+    publish() {
+      attempts += 1;
+      throw new Error("registry response was lost");
+    },
+    isPublished: () => true,
+    wait: async () => assert.fail("published version must not be retried")
+  });
+  assert.equal(attempts, 1);
+});
+
+test("publishPackageWithRetry preserves the final publish error", async () => {
+  const expected = new Error("permanent publish failure");
+  let attempts = 0;
+  await assert.rejects(
+    publishPackageWithRetry({
+      packageName: "@tutti-os/example",
+      version: "0.0.1",
+      maxAttempts: 2,
+      publish() {
+        attempts += 1;
+        throw expected;
+      },
+      isPublished: () => false,
+      wait: async () => {}
+    }),
+    expected
+  );
+  assert.equal(attempts, 2);
 });


### PR DESCRIPTION
## Summary

- Why: the `npm Package Release` workflow aborts the entire immutable-version cohort when npm provenance transparency-log submission returns a transient 409. Run 31094271145 reproduced this on consecutive attempts, leaving `0.0.301` partially published and preventing the Go module tags from being created.
- What changed: retry each package publish up to three times, re-check the exact registry version after a failed attempt, and treat it as successful when the immutable version is already visible. Provenance remains enabled and version selection is unchanged.
- Risks: a persistent publish failure now takes two short backoffs before surfacing; the release path performs an additional registry query after publish errors.

## Verification

- `node --test tools/scripts/publish-packages.test.mjs` — 11 passed.
- `pnpm exec prettier --check tools/scripts/publish-packages.mjs tools/scripts/publish-packages.test.mjs` — passed.
- `pnpm check:changed -- --push-ready` — 5 lanes passed.

## Fallback Three Questions

- Source: transient npm provenance transparency-log failures can occur after the registry has accepted a package or before the package is accepted.
- Why can it not be fixed at that source? The transparency log and npm registry are external release dependencies; the repository can only make its immutable publish operation idempotent and bounded.
- Removal condition: remove the retry only when npm provides an atomic publish/provenance API with reliable idempotency or the release system centrally retries and verifies exact package versions.

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter. (Not applicable.)
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed. (No documentation change is needed for internal release retry behavior.)
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. (Not applicable.)
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
