### PR TITLE
perf(agent-replay): narrow validation gates

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -38,9 +38,11 @@ jobs:
         id: changed-files
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: >-
           node ./tools/scripts/change-classification.mjs
           --base "${BASE_SHA}"
+          --head "${HEAD_SHA}"
           --github-output "${GITHUB_OUTPUT}"
 
   tooling-consistency:
@@ -68,7 +70,8 @@ jobs:
       - name: Check changed-file whitespace
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: git diff --check "${BASE_SHA}...HEAD"
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: git diff --check "${BASE_SHA}...${HEAD_SHA}"
 
       - name: Check repository naming policy
         run: node ./tools/scripts/check-tutti-names.mjs
@@ -104,25 +107,28 @@ jobs:
         if: needs.changes.outputs.run_contracts == 'true'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: >-
           node ./tools/scripts/run-repository-checks.mjs
-          --group contracts --base "${BASE_SHA}"
+          --group contracts --base "${BASE_SHA}" --head "${HEAD_SHA}"
 
       - name: Run generated contract checks
         if: needs.changes.outputs.run_generated == 'true'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: >-
           node ./tools/scripts/run-repository-checks.mjs
-          --group generated --base "${BASE_SHA}"
+          --group generated --base "${BASE_SHA}" --head "${HEAD_SHA}"
 
       - name: Run repository boundary checks
         if: needs.changes.outputs.run_boundaries == 'true'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: >-
           node ./tools/scripts/run-repository-checks.mjs
-          --group boundaries --base "${BASE_SHA}"
+          --group boundaries --base "${BASE_SHA}" --head "${HEAD_SHA}"
 
   ts-lint:
     name: TypeScript Lint
@@ -313,9 +319,11 @@ jobs:
       - name: Run changed Go tests
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: >-
           node ./tools/scripts/run-changed-go-validation.mjs
           --base "${BASE_SHA}"
+          --head "${HEAD_SHA}"
           --kind test
           --tail-lines 400
 
@@ -377,8 +385,10 @@ jobs:
       - name: Run changed Go lint
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: >-
           node ./tools/scripts/run-changed-go-validation.mjs
           --base "${BASE_SHA}"
+          --head "${HEAD_SHA}"
           --kind lint
           --tail-lines 400

--- a/.github/workflows/windows-agent-adapters.yml
+++ b/.github/workflows/windows-agent-adapters.yml
@@ -1,0 +1,86 @@
+name: Windows Agent Adapters
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/windows-agent-adapters.yml"
+      - "packages/agent/daemon/**"
+      - "services/tuttid/**"
+  workflow_dispatch:
+
+concurrency:
+  group: windows-agent-adapters-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  test-adapters:
+    name: Test Windows agent adapters
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.24.5"
+          cache-dependency-path: |
+            go.work
+            go.work.sum
+            packages/agent/daemon/go.mod
+            packages/agent/daemon/go.sum
+            services/tuttid/go.mod
+            services/tuttid/go.sum
+
+      - name: Install dependencies
+        shell: pwsh
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Onboarding fat package
+        shell: pwsh
+        run: pnpm generate:builtin-apps
+
+      - name: Test Windows agent process adapters
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+          Push-Location packages/agent/daemon
+          go test ./runtime -run 'Test(RunVerifiedExecutableUsesVerifiedIdentity|PrepareProcessExecutableExecutesVerifiedDescriptorAfterPathReplacement)$'
+          go test ./runtimecmd -run 'Test(ResolverResolveAllReturnsEveryExecutableMatchInPathOrder|ResolverResolveAllNamesKeepsDirectoryOrderBeforeLauncherVariant|ResolveNPMGlobalLayoutUsesPrefixRootForWindowsShims|ResolverFindsWindowsNPMGlobalShim)$'
+          Pop-Location
+
+      - name: Test Windows daemon adapters
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+          Push-Location services/tuttid
+          go test ./data/workspace -run 'Test(SQLiteDSNPathUsesFileURLFormOnWindows|SQLiteStoreListEmptyDatabase)$'
+          go test ./service/managedruntime -run 'TestNodeReadyAcceptsOfficialWindowsCorepackLayout$'
+          go test ./service/agentstatus -run 'Test(NewInstallShellCommandUsesCmdInterpreter|PlatformExecutableFileAcceptsPlainWindowsFile|RunDefaultInstallCommandPreservesStructuredArguments)$'
+          go test ./service/browser -run 'TestStableChromeDevToolsActivePortPathUsesLocalAppDataOnWindows$'
+          go test ./service/workspace -run 'Test(PlatformAppShellAdapter|NormalizeWindowsTerminalInput|TerminalServiceCreatesLocalPTY|TerminalServiceAttachStream|AppCenterServiceInitializesBuiltinCatalogAndInstallState|WorkspaceAppCLI)'
+          go test ./integration -run 'TestTuttidBlackBoxWorkspaceTerminalWebSocketStreamsInputAndOutput$'
+          go test ./integration -run 'TestTuttidBlackBoxWorkspaceTerminalWebSocketExitFrameCarriesExitCode$'
+          Pop-Location

--- a/.github/workflows/windows-agent-adapters.yml
+++ b/.github/workflows/windows-agent-adapters.yml
@@ -3,7 +3,6 @@ name: Windows Agent Adapters
 on:
   pull_request:
     paths:
-      - ".github/workflows/windows-agent-adapters.yml"
       - "packages/agent/daemon/**"
       - "services/tuttid/**"
   workflow_dispatch:

--- a/.github/workflows/windows-desktop-alpha.yml
+++ b/.github/workflows/windows-desktop-alpha.yml
@@ -3,7 +3,6 @@ name: Windows Desktop Alpha
 on:
   pull_request:
     paths:
-      - ".github/workflows/windows-desktop-alpha.yml"
       - "apps/desktop/**"
       - "services/tuttid/builtin-apps/**"
       - "package.json"

--- a/.github/workflows/windows-desktop-alpha.yml
+++ b/.github/workflows/windows-desktop-alpha.yml
@@ -5,8 +5,7 @@ on:
     paths:
       - ".github/workflows/windows-desktop-alpha.yml"
       - "apps/desktop/**"
-      - "packages/agent/daemon/**"
-      - "services/tuttid/**"
+      - "services/tuttid/builtin-apps/**"
       - "package.json"
       - "pnpm-lock.yaml"
   workflow_dispatch:

--- a/docs/conventions/static-analysis.md
+++ b/docs/conventions/static-analysis.md
@@ -51,10 +51,23 @@ conditions. Do not use workflow-level `paths-ignore` for this gate because
 missing required checks can leave documentation-only PRs waiting on branch
 protection.
 
+PR workflows execute on a synthetic merge ref so tests cover the result that
+would land on `main`. Their selectors must still calculate the changed set from
+the exact pull-request range, `${base.sha}...${head.sha}`, and read manifest
+comparisons from the pull-request head. Do not diff the merge ref against the
+original base SHA: if `main` advances while a PR is open, unrelated main-branch
+changes would select extra TypeScript, package, or repository checks.
+
 PR CI keeps the existing `Tooling Consistency` required context as the owner of
 repository policy, contract, generated, and boundary checks. This preserves
 branch-protection compatibility while keeping those checks out of language
 jobs.
+
+Windows validation separates adapter coverage from desktop packaging. Changes
+under the Agent daemon or `services/tuttid` run the Windows adapter tests;
+desktop and builtin-app changes run the full unsigned Windows package build.
+Use the desktop workflow's manual dispatch for a full package check when a
+daemon-only change needs release-package confidence.
 
 Agent Session Replay has an additional changed-file lane,
 `run_agent_session_replay`. Changes to its core, provider transport, daemon

--- a/docs/conventions/static-analysis.md
+++ b/docs/conventions/static-analysis.md
@@ -67,7 +67,15 @@ Windows validation separates adapter coverage from desktop packaging. Changes
 under the Agent daemon or `services/tuttid` run the Windows adapter tests;
 desktop and builtin-app changes run the full unsigned Windows package build.
 Use the desktop workflow's manual dispatch for a full package check when a
-daemon-only change needs release-package confidence.
+daemon-only change needs release-package confidence. Workflow definition files
+are validated by repository tool contracts and do not trigger either runtime
+workflow themselves; this prevents a selector-only PR from starting a full
+Windows package build.
+
+Changes to shared Go selector scripts are covered by the repository tool
+contract suite and continue to select only the affected Go modules. Go
+workspace, module, or lint configuration changes still select all relevant Go
+modules because they can change the validity of every target.
 
 Agent Session Replay has an additional changed-file lane,
 `run_agent_session_replay`. Changes to its core, provider transport, daemon

--- a/packages/agent/session-replay/replay_semantic_profile.go
+++ b/packages/agent/session-replay/replay_semantic_profile.go
@@ -97,7 +97,7 @@ func MergeTuttiReplayStatesForProfile(
 		}
 		profileStates[index] = projectTuttiReplayStateForProfile(state, profile)
 	}
-	return MergeTuttiReplayStates(profileStates)
+	return mergeTuttiReplayStatesValidated(profileStates)
 }
 
 func CompareTuttiReplayStateForProfile(
@@ -111,7 +111,7 @@ func CompareTuttiReplayStateForProfile(
 	if err := ValidateTuttiReplayStateForProfile(actual, profile); err != nil {
 		return fmt.Errorf("invalid actual Tutti Replay State: %w", err)
 	}
-	return CompareTuttiReplayState(
+	return compareTuttiReplayStateValidated(
 		projectTuttiReplayStateForProfile(expected, profile),
 		projectTuttiReplayStateForProfile(actual, profile),
 	)

--- a/packages/agent/session-replay/replay_state.go
+++ b/packages/agent/session-replay/replay_state.go
@@ -691,6 +691,17 @@ func validateReplayPortableValue(path, key string, value any) error {
 func MergeTuttiReplayStates(
 	states []TuttiReplayState,
 ) (TuttiReplayMergedState, error) {
+	for _, state := range states {
+		if err := ValidateTuttiReplayState(state); err != nil {
+			return TuttiReplayMergedState{}, err
+		}
+	}
+	return mergeTuttiReplayStatesValidated(states)
+}
+
+func mergeTuttiReplayStatesValidated(
+	states []TuttiReplayState,
+) (TuttiReplayMergedState, error) {
 	merged := TuttiReplayMergedState{
 		Agents: []agenthost.HistoricalSessionGraph{},
 		TuttiMode: TuttiReplayTuttiMode{
@@ -706,9 +717,6 @@ func MergeTuttiReplayStates(
 	workflowObjects := map[string]any{}
 	issueObjects := map[string]any{}
 	for _, state := range states {
-		if err := ValidateTuttiReplayState(state); err != nil {
-			return TuttiReplayMergedState{}, err
-		}
 		for _, session := range state.Agent.Sessions {
 			if err := mergeReplayObject(
 				"$.agent.sessions["+session.ID+"]",
@@ -808,6 +816,12 @@ func CompareTuttiReplayState(expected, actual TuttiReplayState) error {
 	if err := ValidateTuttiReplayState(actual); err != nil {
 		return fmt.Errorf("invalid actual Tutti Replay State: %w", err)
 	}
+	return compareTuttiReplayStateValidated(expected, actual)
+}
+
+func compareTuttiReplayStateValidated(
+	expected, actual TuttiReplayState,
+) error {
 	expected = normalizeReplayStateForComparison(expected)
 	actual = normalizeReplayStateForComparison(actual)
 	if mismatch := firstReplayStateMismatch("$", expected, actual); mismatch != "" {

--- a/packages/agent/session-replay/replay_state_compare.go
+++ b/packages/agent/session-replay/replay_state_compare.go
@@ -146,8 +146,17 @@ func replaceReplayIDs(value any, replacements map[string]string) {
 }
 
 func firstReplayStateMismatch(path string, expected, actual any) string {
-	expectedValue := replayComparableValue(expected)
-	actualValue := replayComparableValue(actual)
+	return firstReplayStateMismatchComparable(
+		path,
+		replayComparableValue(expected),
+		replayComparableValue(actual),
+	)
+}
+
+func firstReplayStateMismatchComparable(
+	path string,
+	expectedValue, actualValue any,
+) string {
 	if isComposerSettingsPath(path) {
 		expectedSettings, expectedOK := expectedValue.(map[string]any)
 		actualSettings, actualOK := actualValue.(map[string]any)
@@ -192,7 +201,11 @@ func firstReplayStateMismatch(path string, expected, actual any) string {
 			if !expectedOK || !actualOK {
 				return path + "." + key
 			}
-			if mismatch := firstReplayStateMismatch(path+"."+key, expectedChild, actualChild); mismatch != "" {
+			if mismatch := firstReplayStateMismatchComparable(
+				path+"."+key,
+				expectedChild,
+				actualChild,
+			); mismatch != "" {
 				return mismatch
 			}
 		}
@@ -202,7 +215,11 @@ func firstReplayStateMismatch(path string, expected, actual any) string {
 			return path
 		}
 		for index := range expectedValue {
-			if mismatch := firstReplayStateMismatch(fmt.Sprintf("%s[%d]", path, index), expectedValue[index], actualValue[index]); mismatch != "" {
+			if mismatch := firstReplayStateMismatchComparable(
+				fmt.Sprintf("%s[%d]", path, index),
+				expectedValue[index],
+				actualValue[index],
+			); mismatch != "" {
 				return mismatch
 			}
 		}

--- a/packages/auth/bridge-go/authbridge.go
+++ b/packages/auth/bridge-go/authbridge.go
@@ -162,7 +162,7 @@ func NewClient(config Config) (*Client, error) {
 	if httpClient == nil {
 		// This package is a standalone module and intentionally preserves the
 		// caller's process-wide default client customizations.
-		httpClient = http.DefaultClient //nolint:forbidigo
+		httpClient = http.DefaultClient //nolint:forbidigo // standalone module preserves caller's process-wide client
 	}
 	return &Client{config: normalized, http: httpClient}, nil
 }

--- a/tools/scripts/change-classification.mjs
+++ b/tools/scripts/change-classification.mjs
@@ -346,13 +346,17 @@ export function isPackagePackRelevantPath(file) {
 
 export function createPackageManifestPackRelevance({
   baseRef,
+  headRef = "HEAD",
   root = workspaceRoot
 }) {
   const cache = new Map();
 
   return (file) => {
     if (!cache.has(file)) {
-      cache.set(file, isPackageManifestPackRelevant(baseRef, file, root));
+      cache.set(
+        file,
+        isPackageManifestPackRelevant(baseRef, headRef, file, root)
+      );
     }
     return cache.get(file);
   };
@@ -360,6 +364,7 @@ export function createPackageManifestPackRelevance({
 
 export function createRootManifestTestRelevance({
   baseRef,
+  headRef = "HEAD",
   root = workspaceRoot
 }) {
   return () => {
@@ -372,17 +377,21 @@ export function createRootManifestTestRelevance({
       );
       const candidates = [
         normalizedManifestAtRef(
-          "HEAD",
+          headRef,
           "package.json",
           root,
           testRelevantRootManifest
-        ),
-        JSON.stringify(
-          testRelevantRootManifest(
-            JSON.parse(readFileSync(join(root, "package.json"), "utf8"))
-          )
         )
       ];
+      if (headRef === "HEAD") {
+        candidates.push(
+          JSON.stringify(
+            testRelevantRootManifest(
+              JSON.parse(readFileSync(join(root, "package.json"), "utf8"))
+            )
+          )
+        );
+      }
       return candidates.some((candidate) => candidate !== before);
     } catch {
       return true;
@@ -390,15 +399,17 @@ export function createRootManifestTestRelevance({
   };
 }
 
-function isPackageManifestPackRelevant(baseRef, file, root) {
+function isPackageManifestPackRelevant(baseRef, headRef, file, root) {
   try {
     const before = normalizedManifestAtRef(baseRef, file, root);
-    const candidates = [
-      normalizedManifestAtRef("HEAD", file, root),
-      JSON.stringify(
-        withoutTestScripts(JSON.parse(readFileSync(join(root, file), "utf8")))
-      )
-    ];
+    const candidates = [normalizedManifestAtRef(headRef, file, root)];
+    if (headRef === "HEAD") {
+      candidates.push(
+        JSON.stringify(
+          withoutTestScripts(JSON.parse(readFileSync(join(root, file), "utf8")))
+        )
+      );
+    }
     return candidates.some((candidate) => candidate !== before);
   } catch {
     return true;
@@ -505,9 +516,10 @@ if (isMainModule()) {
   if (!base) {
     throw new Error("--base is required");
   }
+  const head = readOption("--head") ?? "HEAD";
   const changedFiles = execFileSync(
     "git",
-    ["diff", "--name-only", `${base}...HEAD`],
+    ["diff", "--name-only", `${base}...${head}`],
     { cwd: workspaceRoot, encoding: "utf8" }
   )
     .split("\n")
@@ -516,10 +528,12 @@ if (isMainModule()) {
   const output = formatClassificationOutputs(
     classifyChangedFiles(changedFiles, {
       isPackageManifestPackRelevant: createPackageManifestPackRelevance({
-        baseRef: base
+        baseRef: base,
+        headRef: head
       }),
       isRootManifestTestRelevant: createRootManifestTestRelevance({
-        baseRef: base
+        baseRef: base,
+        headRef: head
       })
     })
   );

--- a/tools/scripts/change-classification.test.mjs
+++ b/tools/scripts/change-classification.test.mjs
@@ -87,7 +87,7 @@ test("workflow and hook changes select repository tool contracts", () => {
   }
 });
 
-test("Go CI and shared selector changes select Go validation", () => {
+test("Go CI and shared selector changes use tool contracts instead of all Go lanes", () => {
   for (const file of [
     ".github/workflows/pr-checks.yml",
     "tools/scripts/run-changed-go-validation.mjs",
@@ -96,7 +96,8 @@ test("Go CI and shared selector changes select Go validation", () => {
     const classification = classifyChangedFiles([file], {
       releasePackages
     });
-    assert.equal(classification.runGo, true, file);
+    assert.equal(classification.runGo, false, file);
+    assert.equal(classification.runContracts, true, file);
   }
 });
 

--- a/tools/scripts/change-classification.test.mjs
+++ b/tools/scripts/change-classification.test.mjs
@@ -281,6 +281,37 @@ test("package manifest comparison ignores only test scripts", () => {
       committedBuildChangeIsRelevant("packages/agent/gui/package.json"),
       true
     );
+
+    const headRef = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: root,
+      encoding: "utf8",
+      env: gitEnv
+    }).trim();
+    writeFileSync(
+      manifestPath,
+      `${JSON.stringify({
+        name: "@tutti-os/agent-gui",
+        scripts: {
+          build: "tsup --working-copy",
+          test: "vitest run --working-copy"
+        }
+      })}\n`
+    );
+    assert.equal(
+      createPackageManifestPackRelevance({
+        baseRef: "HEAD",
+        headRef,
+        root
+      })("packages/agent/gui/package.json"),
+      false
+    );
+    assert.equal(
+      createPackageManifestPackRelevance({
+        baseRef: "HEAD",
+        root
+      })("packages/agent/gui/package.json"),
+      true
+    );
   } finally {
     rmSync(root, { force: true, recursive: true });
   }

--- a/tools/scripts/pr-checks-workflow.test.mjs
+++ b/tools/scripts/pr-checks-workflow.test.mjs
@@ -11,6 +11,21 @@ const workflow = YAML.parse(
   readFileSync(join(workspaceRoot, ".github/workflows/pr-checks.yml"), "utf8")
 );
 
+const windowsWorkflows = [
+  [
+    ".github/workflows/windows-desktop-alpha.yml",
+    ["apps/desktop/**", "services/tuttid/builtin-apps/**"]
+  ],
+  [
+    ".github/workflows/windows-agent-adapters.yml",
+    ["packages/agent/daemon/**", "services/tuttid/**"]
+  ]
+].map(([path, expectedPaths]) => ({
+  expectedPaths,
+  path,
+  workflow: YAML.parse(readFileSync(join(workspaceRoot, path), "utf8"))
+}));
+
 test("PR checks route repository groups through shared scripts", () => {
   const changes = workflow.jobs.changes;
   const classificationStep = changes.steps.find(
@@ -100,6 +115,17 @@ test("TypeScript Tests preserves its required context across package shards", ()
     requireShardsStep.env.SHARDS_RESULT,
     "${{ needs.ts-test-shards.result }}"
   );
+});
+
+test("Windows workflows route source changes without self-triggering", () => {
+  for (const { expectedPaths, path, workflow } of windowsWorkflows) {
+    const paths = workflow.on?.pull_request?.paths ?? [];
+    assert.ok(paths.length > 0, path);
+    assert.ok(!paths.includes(path), `${path} must not trigger itself`);
+    for (const expectedPath of expectedPaths) {
+      assert.ok(paths.includes(expectedPath), `${path}: ${expectedPath}`);
+    }
+  }
 });
 
 function stepScripts(job) {

--- a/tools/scripts/pr-checks-workflow.test.mjs
+++ b/tools/scripts/pr-checks-workflow.test.mjs
@@ -22,9 +22,12 @@ test("PR checks route repository groups through shared scripts", () => {
     classificationStep.run,
     /tools\/scripts\/change-classification\.mjs/u
   );
+  assert.match(classificationStep.run, /--base/u);
+  assert.match(classificationStep.run, /--head/u);
   for (const group of ["contracts", "generated", "boundaries"]) {
     assert.match(toolingScripts, new RegExp(`--group ${group}`, "u"));
   }
+  assert.match(toolingScripts, /--head/u);
 });
 
 test("language jobs do not own repository checks", () => {

--- a/tools/scripts/run-changed-go-validation.mjs
+++ b/tools/scripts/run-changed-go-validation.mjs
@@ -60,12 +60,21 @@ export function buildChangedGoValidationLanes({
 
 export function parseChangedGoValidationArgs(inputArgs) {
   const args = inputArgs.filter((arg) => arg !== "--");
-  const options = { baseRef: null, kind: null, maxParallel: 3, tailLines: 80 };
+  const options = {
+    baseRef: null,
+    headRef: "HEAD",
+    kind: null,
+    maxParallel: 3,
+    tailLines: 80
+  };
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
     switch (arg) {
       case "--base":
         options.baseRef = readValue(args, ++index, arg);
+        break;
+      case "--head":
+        options.headRef = readValue(args, ++index, arg);
         break;
       case "--kind": {
         const kind = readValue(args, ++index, arg);
@@ -98,7 +107,7 @@ async function main() {
   const options = parseChangedGoValidationArgs(process.argv.slice(2));
   const changedFiles = execFileSync(
     "git",
-    ["diff", "--name-only", `${options.baseRef}...HEAD`],
+    ["diff", "--name-only", `${options.baseRef}...${options.headRef}`],
     {
       cwd: workspaceRoot,
       encoding: "utf8",

--- a/tools/scripts/run-changed-go-validation.test.mjs
+++ b/tools/scripts/run-changed-go-validation.test.mjs
@@ -110,7 +110,7 @@ describe("buildChangedGoValidationLanes", () => {
     assert.deepEqual(lanes, []);
   });
 
-  it("falls back to every module when shared selection code changes", () => {
+  it("does not create Go lanes for shared selection code changes", () => {
     const lanes = buildChangedGoValidationLanes({
       changedFiles: ["tools/scripts/run-changed-go-validation.mjs"],
       kind: "test",
@@ -119,13 +119,7 @@ describe("buildChangedGoValidationLanes", () => {
       root: "/repo"
     });
 
-    assert.deepEqual(
-      lanes.map((lane) => lane.label),
-      moduleRoots.map((moduleRoot) => `test:go (${moduleRoot})`)
-    );
-    for (const lane of lanes) {
-      assert.match(lane.command[2], /go test \.\/\.\.\./);
-    }
+    assert.deepEqual(lanes, []);
   });
 
   it("ensures builtin assets only for the selected tuttid lane", () => {

--- a/tools/scripts/run-changed-go-validation.test.mjs
+++ b/tools/scripts/run-changed-go-validation.test.mjs
@@ -18,6 +18,8 @@ describe("parseChangedGoValidationArgs", () => {
       parseChangedGoValidationArgs([
         "--base",
         "base-sha",
+        "--head",
+        "head-sha",
         "--kind",
         "test",
         "--max-parallel",
@@ -27,6 +29,7 @@ describe("parseChangedGoValidationArgs", () => {
       ]),
       {
         baseRef: "base-sha",
+        headRef: "head-sha",
         kind: "test",
         maxParallel: 2,
         tailLines: 400
@@ -79,6 +82,20 @@ describe("buildChangedGoValidationLanes", () => {
     assert.match(lanes[0].command[2], /golangci-lint run/);
     assert.match(lanes[0].command[2], / \.\/runtime$/);
     assert.doesNotMatch(lanes[0].command[2], /generate:builtin-apps/);
+  });
+
+  it("keeps a changed module-root package scoped to the module root", () => {
+    const lanes = buildChangedGoValidationLanes({
+      changedFiles: ["services/tuttid/wiring.go"],
+      kind: "test",
+      moduleRoots,
+      pathExists: () => true,
+      root: "/repo"
+    });
+
+    assert.equal(lanes.length, 1);
+    assert.match(lanes[0].command[2], /cd services\/tuttid && .*go test \.$/u);
+    assert.doesNotMatch(lanes[0].command[2], /go test \.\/\.\.\./u);
   });
 
   it("does not expand lint beyond the established lint module set", () => {

--- a/tools/scripts/run-check-changed-targets.mjs
+++ b/tools/scripts/run-check-changed-targets.mjs
@@ -148,7 +148,11 @@ export function resolveGoValidationTargets(
     if (lintModuleRootSet.has(moduleRoot)) {
       addGoTarget(lintByModule, moduleRoot, packagePattern);
     }
-    addGoTarget(testByModule, moduleRoot, `${packagePattern}/...`);
+    addGoTarget(
+      testByModule,
+      moduleRoot,
+      packagePattern === "." ? "." : `${packagePattern}/...`
+    );
   }
 
   if (lintByModule.size === 0 && testByModule.size === 0) {

--- a/tools/scripts/run-check-changed-targets.mjs
+++ b/tools/scripts/run-check-changed-targets.mjs
@@ -2,17 +2,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 
-const GLOBAL_GO_VALIDATION_FILES = new Set([
-  ".github/workflows/pr-checks.yml",
-  "go.work",
-  "go.work.sum",
-  "tools/scripts/change-classification.mjs",
-  "tools/scripts/run-changed-go-validation.mjs",
-  "tools/scripts/run-check-changed-targets.mjs",
-  "tools/scripts/run-golangci-lint.mjs",
-  "tools/scripts/run-go-tests.mjs",
-  "tools/scripts/run-validation-lanes.mjs"
-]);
+const GLOBAL_GO_VALIDATION_FILES = new Set(["go.work", "go.work.sum"]);
 
 const GO_LINT_MODULE_ROOTS = new Set([
   "apps/cli",

--- a/tools/scripts/run-check-changed-targets.test.mjs
+++ b/tools/scripts/run-check-changed-targets.test.mjs
@@ -7,8 +7,7 @@ import {
   discoverGoModuleRoots,
   isBuiltinGenerateRequired,
   resolveGoModuleRoot,
-  resolveGoValidationTargets,
-  selectGoLintModuleRoots
+  resolveGoValidationTargets
 } from "./run-check-changed-targets.mjs";
 
 const goModuleRoots = [
@@ -168,27 +167,16 @@ describe("resolveGoValidationTargets", () => {
     ]);
   });
 
-  it("runs every go.work module when shared validation ownership changes", () => {
+  it("does not create Go lanes for shared selector scripts", () => {
     const targets = resolveGoValidationTargets(
       ["tools/scripts/run-changed-go-validation.mjs"],
       {
-        lintModuleRoots: selectGoLintModuleRoots(goModuleRoots),
         moduleRoots: goModuleRoots,
         pathExists: () => true
       }
     );
 
-    assert.deepEqual(
-      Array.from(targets.testByModule),
-      goModuleRoots.map((moduleRoot) => [moduleRoot, new Set(["./..."])])
-    );
-    assert.deepEqual(
-      Array.from(targets.lintByModule),
-      selectGoLintModuleRoots(goModuleRoots).map((moduleRoot) => [
-        moduleRoot,
-        new Set(["./..."])
-      ])
-    );
+    assert.equal(targets, null);
   });
 });
 

--- a/tools/scripts/run-repository-checks.mjs
+++ b/tools/scripts/run-repository-checks.mjs
@@ -10,6 +10,7 @@ const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const workspaceRoot = resolve(scriptDirectory, "../..");
 const group = readOption("--group");
 const base = readOption("--base");
+const head = readOption("--head") ?? "HEAD";
 
 if (!group || !base) {
   throw new Error("--group and --base are required");
@@ -17,7 +18,7 @@ if (!group || !base) {
 
 const changedFiles = execFileSync(
   "git",
-  ["diff", "--name-only", `${base}...HEAD`],
+  ["diff", "--name-only", `${base}...${head}`],
   { cwd: workspaceRoot, encoding: "utf8" }
 )
   .split("\n")


### PR DESCRIPTION
## Summary
- Classify PR checks against the exact PR head instead of the synthetic merge ref, avoiding unrelated main-branch drift from expanding the validation matrix.
- Split Windows agent-adapter checks from the Electron packaging workflow. Workflow definition changes are validated by tool contracts and do not self-trigger either runtime Windows workflow.
- Shared Go selector scripts use repository tool contracts and affected-module Go validation instead of forcing every Go module. Go workspace, module, and lint configuration changes remain full-scope.
- Avoid redundant replay-state validation and repeated JSON marshaling in semantic comparison.
- Keep the existing auth-bridge lint suppression explicit for the pinned linter.

## Tests
- `node --test tools/scripts/change-classification.test.mjs tools/scripts/run-changed-go-validation.test.mjs tools/scripts/run-check-changed-targets.test.mjs tools/scripts/pr-checks-workflow.test.mjs` (56 passed)
- `go test ./...` in `packages/agent/session-replay`
- `pnpm check:changed -- --push-ready` (27 lanes passed)

## Notes
- Desktop packaging still runs for `apps/desktop/**` and builtin-app changes. Agent adapter coverage still runs for daemon and `services/tuttid` changes.