### PR TITLE
feat(connectors): observe unexpected route exits

### DIFF
--- a/packages/connector/runtime/implementationhost/host.go
+++ b/packages/connector/runtime/implementationhost/host.go
@@ -51,20 +51,6 @@ type CredentialFile struct {
 	ExpiresAt time.Time
 }
 
-// AuthorizationObserver receives runtime-side credential binding outcomes.
-// The owning product may project them upstream; this Host does not become the
-// account authorization truth source.
-type AuthorizationObserver interface {
-	ObserveAuthorization(context.Context, AuthorizationObservation)
-}
-
-type AuthorizationObservation struct {
-	ConnectorKey string
-	ConnectionID string
-	State        market.AuthorizationState
-	ObservedAt   time.Time
-}
-
 type ReconcileRequest struct {
 	Runtime market.RuntimeReconcileRequest
 	// CredentialGrant is consumed by Reconcile and erased before it returns.
@@ -78,6 +64,7 @@ type Config struct {
 	Processes         agentruntime.ProcessTransport
 	Credentials       CredentialBroker
 	Authorization     AuthorizationObserver
+	Routes            RouteObserver
 	Commands          *CommandRegistry
 	StateRoot         string
 	MCPStartupTimeout time.Duration
@@ -89,6 +76,7 @@ type Host struct {
 	processes         agentruntime.ProcessTransport
 	credentials       CredentialBroker
 	authorization     AuthorizationObserver
+	routeObserver     RouteObserver
 	mcpStartupTimeout time.Duration
 	routes            *connectorruntime.RouteTable
 	snapshots         *connectorruntime.ExecutionSnapshotter
@@ -143,6 +131,7 @@ func New(config Config) (*Host, error) {
 	config.Commands.attach(routes)
 	return &Host{artifacts: config.Artifacts, planner: planner, processes: config.Processes, credentials: config.Credentials,
 		authorization:     config.Authorization,
+		routeObserver:     config.Routes,
 		mcpStartupTimeout: config.MCPStartupTimeout, routes: routes, snapshots: snapshots}, nil
 }
 
@@ -414,7 +403,14 @@ func listMCPTools(ctx context.Context, client *mcp.StdioClient) ([]mcpTool, erro
 
 func (host *Host) monitorMCPRoute(route *connectorRoute, client *mcp.StdioClient) {
 	<-client.Done()
+	unexpected := host.routes.IsCurrent(route)
 	_ = host.routes.RetireExact(route, time.Now().Add(3*time.Second))
+	if unexpected && host.routeObserver != nil {
+		host.routeObserver.ObserveRoute(context.Background(), RouteObservation{
+			ConnectorKey: route.connectorKey, ConnectionID: route.connectionID,
+			ReleaseDigest: route.releaseDigest, Generation: route.generation, ObservedAt: time.Now().UTC(),
+		})
+	}
 }
 
 func (host *Host) attachCLI(route *connectorRoute, managed *market.ManagedStdioImplementation,

--- a/packages/connector/runtime/implementationhost/observations.go
+++ b/packages/connector/runtime/implementationhost/observations.go
@@ -1,0 +1,37 @@
+package implementationhost
+
+import (
+	"context"
+	"time"
+
+	market "github.com/tutti-os/tutti/packages/connector/host"
+)
+
+// AuthorizationObserver receives runtime-side credential binding outcomes.
+// The owning product may project them upstream; this Host does not become the
+// account authorization truth source.
+type AuthorizationObserver interface {
+	ObserveAuthorization(context.Context, AuthorizationObservation)
+}
+
+type AuthorizationObservation struct {
+	ConnectorKey string
+	ConnectionID string
+	State        market.AuthorizationState
+	ObservedAt   time.Time
+}
+
+// RouteObserver receives unexpected long-lived runtime exits after the route
+// has been removed from publication. Intentional deactivate, replacement, and
+// Host shutdown do not emit an observation.
+type RouteObserver interface {
+	ObserveRoute(context.Context, RouteObservation)
+}
+
+type RouteObservation struct {
+	ConnectorKey  string
+	ConnectionID  string
+	ReleaseDigest string
+	Generation    market.HostGeneration
+	ObservedAt    time.Time
+}

--- a/packages/connector/runtime/implementationhost/route_observer_test.go
+++ b/packages/connector/runtime/implementationhost/route_observer_test.go
@@ -1,0 +1,99 @@
+package implementationhost
+
+import (
+	"context"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
+	market "github.com/tutti-os/tutti/packages/connector/host"
+	connectorruntime "github.com/tutti-os/tutti/packages/connector/runtime"
+	"github.com/tutti-os/tutti/packages/connector/runtime/mcp"
+)
+
+type routeObservationRecorder struct {
+	mu           sync.Mutex
+	observations []RouteObservation
+}
+
+func (recorder *routeObservationRecorder) ObserveRoute(_ context.Context, observation RouteObservation) {
+	recorder.mu.Lock()
+	recorder.observations = append(recorder.observations, observation)
+	recorder.mu.Unlock()
+}
+
+type exitedMCPConnection struct{ delivered bool }
+
+func (*exitedMCPConnection) Send([]byte) error { return nil }
+func (*exitedMCPConnection) Close() error      { return nil }
+func (*exitedMCPConnection) CloseInput() error { return nil }
+func (*exitedMCPConnection) Terminate() error  { return nil }
+func (*exitedMCPConnection) Kill() error       { return nil }
+func (connection *exitedMCPConnection) Recv() (agentruntime.ProcessFrame, error) {
+	if connection.delivered {
+		return agentruntime.ProcessFrame{}, io.EOF
+	}
+	connection.delivered = true
+	exitCode := 17
+	return agentruntime.ProcessFrame{ExitCode: &exitCode}, nil
+}
+
+func TestMonitorMCPRouteObservesOnlyUnexpectedCurrentRouteExit(t *testing.T) {
+	recorder := &routeObservationRecorder{}
+	routes := connectorruntime.NewRouteTable()
+	host := &Host{routes: routes, routeObserver: recorder}
+	generation := market.HostGeneration{BootEpoch: "boot-1", Generation: 4}
+	route := &connectorRoute{id: connectorRouteKey("connection-1", "calendar"), connectionID: "connection-1",
+		connectorKey: "calendar", releaseDigest: authorizationTestDigest, generation: generation,
+		processes: connectorruntime.NewProcessGroup()}
+	if err := routes.Commit(route); err != nil {
+		t.Fatal(err)
+	}
+	client, err := mcp.NewStdioClient(mcp.StdioClientConfig{Connection: &exitedMCPConnection{}, ProcessName: "calendar"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	host.monitorMCPRoute(route, client)
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	if len(recorder.observations) != 1 {
+		t.Fatalf("route observations = %+v", recorder.observations)
+	}
+	observation := recorder.observations[0]
+	if observation.ConnectorKey != "calendar" || observation.ConnectionID != "connection-1" ||
+		observation.ReleaseDigest != authorizationTestDigest || observation.Generation != generation ||
+		observation.ObservedAt.IsZero() {
+		t.Fatalf("route observation = %+v", observation)
+	}
+	if routes.IsCurrent(route) {
+		t.Fatal("exited MCP route remained current")
+	}
+}
+
+func TestMonitorMCPRouteDoesNotObserveIntentionalRemoval(t *testing.T) {
+	recorder := &routeObservationRecorder{}
+	routes := connectorruntime.NewRouteTable()
+	host := &Host{routes: routes, routeObserver: recorder}
+	generation := market.HostGeneration{BootEpoch: "boot-1", Generation: 1}
+	route := &connectorRoute{id: connectorRouteKey("connection-1", "calendar"), connectionID: "connection-1",
+		connectorKey: "calendar", releaseDigest: authorizationTestDigest, generation: generation,
+		processes: connectorruntime.NewProcessGroup()}
+	if err := routes.Commit(route); err != nil {
+		t.Fatal(err)
+	}
+	if err := routes.Remove(route.id, generation, authorizationTestDigest, time.Now().Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	client, err := mcp.NewStdioClient(mcp.StdioClientConfig{Connection: &exitedMCPConnection{}, ProcessName: "calendar"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	host.monitorMCPRoute(route, client)
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	if len(recorder.observations) != 0 {
+		t.Fatalf("intentional removal observations = %+v", recorder.observations)
+	}
+}


### PR DESCRIPTION
## Summary

- Why: the public Connector Host retires an MCP route when its long-lived process exits, but embedding products cannot currently observe that transition. TSH therefore cannot remove the matching route from its VM snapshot or emit the agreed runtime event.
- What changed: add a host-neutral `RouteObserver` port and emit a credential-free observation only when the exiting route was still current. Intentional deactivate, generation replacement, and Host shutdown remain silent.
- Risks: observers run after the route is unpublished and retired; a slow product observer could retain the monitor goroutine, but cannot keep the route callable.

## Verification

- `go test ./implementationhost ./mcp ./command` from `packages/connector/runtime` — passed.
- `pnpm check:changed -- --push-ready` — 6 lanes passed.

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter. (Not applicable.)
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed. (The exported API is documented in Go.)
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. (Not applicable.)
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
