### PR TITLE
fix(device-link): prefer private ICE hosts on system policy

### DIFF
--- a/docs/specs/2026-07-23-mobile-agentgui-device-link-design.md
+++ b/docs/specs/2026-07-23-mobile-agentgui-device-link-design.md
@@ -706,7 +706,7 @@ P2P 成功率不是单独的发布门槛。发布目标是 direct 优先且 Rela
 | 风险                                                  | 影响                         | 缓解                                                                      |
 | ----------------------------------------------------- | ---------------------------- | ------------------------------------------------------------------------- |
 | gomobile、Pion ICE 与 quic-go 在 Android 真机行为不同 | 核心链路不可用或不稳定       | M0 先做 vertical slice；在 UI 投入前完成跨网络真机测试                    |
-| Android 网络/VPN 路由与 macOS 物理接口策略不同        | candidate 不可达或错误选路   | Android 初期使用系统路由，保留分类诊断；VPN/TUN 单独验收                  |
+| Android 网络/VPN 路由与 macOS 物理接口策略不同        | candidate 不可达或错误选路   | Android 默认使用 `system` 的共享 LAN-first host priority，并保留 server-reflexive 公网 fallback；Android Network 绑定与 VPN/TUN 单独验收                  |
 | 直接导入 AgentGUI 带入 DOM/Monaco                     | Metro 构建失败或 bundle 膨胀 | 平台无关 subpath 建立严格 import boundary 和检查                          |
 | Relay 当前 channel 只覆盖既有 query lane              | 写操作被错误复用或授权过宽   | 增加明确 paired-device Agent channel，复用身份校验但不复用业务含义        |
 | App 与 Desktop 快速迭代产生协议漂移                   | 无法连接                     | 单一 `protocolEpoch` fail-fast，并协调开发期发布，不维护兼容分支          |

--- a/packages/device-link/README.md
+++ b/packages/device-link/README.md
@@ -131,6 +131,19 @@ candidates may arrive before or after `Connect` through
 `AddRemoteCandidates`. A `Participant` represents one connection attempt and
 must not be reused after completion or cancellation.
 
+### Network path policy
+
+The default empty `NetworkPolicy` is `system`. It keeps the operating system's
+network view, but applies a shared LAN-first candidate preference: private
+IPv4/ULA host candidates receive the normal host priority, global-unicast host
+candidates receive a lower host priority, and server-reflexive candidates
+remain available as the public-network fallback.
+
+`system` includes active TUN interfaces for fallback, while `direct` additionally
+binds sockets to physical interfaces where the platform supports it. Product
+consumers should use `system` unless they expose an explicit advanced routing
+setting.
+
 `ALPN` remains the canonical protocol name. During a rolling migration, a
 consumer may add a bounded list of `CompatibleProtocols`; the canonical value
 is always offered first. After connection, `Link.NegotiatedProtocol` lets the

--- a/packages/device-link/icequic/agent.go
+++ b/packages/device-link/icequic/agent.go
@@ -21,11 +21,12 @@ import (
 // core devicelink PathScope / devicelinkdiag NetworkScope strings so callers
 // can cast directly; classification is categorical and carries no address.
 const (
-	ScopeLocalSubnet    = "local_subnet"
-	ScopePrivateNetwork = "private_network"
-	ScopePublicInternet = "public_internet"
-	maxSTUNEndpoints    = 8
-	maxSTUNEndpointSize = 128
+	ScopeLocalSubnet            = "local_subnet"
+	ScopePrivateNetwork         = "private_network"
+	ScopePublicInternet         = "public_internet"
+	maxSTUNEndpoints            = 8
+	maxSTUNEndpointSize         = 128
+	systemHostAcceptanceMinWait = 200 * time.Millisecond
 )
 
 // redactingLoggerFactory disables pion's logging entirely. Pion's default
@@ -57,7 +58,8 @@ func (discardLogger) Errorf(string, ...any) {}
 // gathering, which is also the graceful degradation when STUN is unavailable.
 type AgentConfig struct {
 	STUNEndpoints []string
-	// NetworkPolicySystem follows OS routing, including TUN interfaces.
+	// NetworkPolicySystem follows OS routing, including TUN interfaces, while
+	// applying the shared LAN-first candidate preference.
 	// NetworkPolicyDirect pins UDP sockets to eligible physical interfaces and
 	// is supported on macOS only. Empty defaults to system.
 	NetworkPolicy NetworkPolicy
@@ -104,6 +106,7 @@ type Agent struct {
 	closeOnce        sync.Once
 	startOnce        sync.Once
 	startErr         error
+	prioritizeHosts  bool
 }
 
 // NewAgent builds an ICE agent under the device-link razor. TURN and mDNS are
@@ -167,7 +170,10 @@ func NewAgent(cfg AgentConfig) (*Agent, error) {
 	if len(stunURLs) > 0 {
 		agentOptions = append(agentOptions, ice.WithUrls(stunURLs))
 	}
-	if networkPolicy == NetworkPolicyDirect {
+	switch networkPolicy {
+	case NetworkPolicySystem:
+		agentOptions = append(agentOptions, ice.WithHostAcceptanceMinWait(systemHostAcceptanceMinWait))
+	case NetworkPolicyDirect:
 		netTransport, err := newInterfaceBoundNet(cfg.IncludeLoopback)
 		if err != nil {
 			return nil, err
@@ -189,7 +195,7 @@ func NewAgent(cfg AgentConfig) (*Agent, error) {
 	}
 	a := &Agent{
 		agent: underlying, gathered: make(chan struct{}), changed: make(chan struct{}, 1), done: make(chan struct{}),
-		remoteCandidates: make(map[string]struct{}),
+		remoteCandidates: make(map[string]struct{}), prioritizeHosts: networkPolicy == NetworkPolicySystem,
 	}
 	if err := underlying.OnCandidate(a.onCandidate); err != nil {
 		_ = underlying.Close()
@@ -208,6 +214,9 @@ func (a *Agent) onCandidate(candidate ice.Candidate) {
 	// Re-marshal through the exact wire round-trip the peer will perform, so a
 	// candidate that cannot survive serialization is never advertised.
 	marshalled := candidate.Marshal()
+	if a.prioritizeHosts {
+		marshalled = prioritizeHostCandidate(marshalled)
+	}
 	if _, err := ice.UnmarshalCandidate(marshalled); err != nil {
 		return
 	}

--- a/packages/device-link/icequic/agent_test.go
+++ b/packages/device-link/icequic/agent_test.go
@@ -240,6 +240,16 @@ func TestNewAgentRejectsUnknownNetworkPolicy(t *testing.T) {
 	}
 }
 
+func TestEmptyNetworkPolicyDefaultsToSystem(t *testing.T) {
+	got, err := normalizeNetworkPolicy("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != NetworkPolicySystem {
+		t.Fatalf("empty network policy = %q, want %q", got, NetworkPolicySystem)
+	}
+}
+
 func TestAgentExcludeHostCandidatesThreadsToGathering(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/packages/device-link/icequic/candidate_policy.go
+++ b/packages/device-link/icequic/candidate_policy.go
@@ -1,6 +1,46 @@
 package icequic
 
-import "github.com/pion/ice/v4"
+import (
+	"net/netip"
+	"strconv"
+	"strings"
+
+	"github.com/pion/ice/v4"
+)
+
+const publicHostLocalPreference = 16384
+
+// prioritizeHostCandidate lowers the local preference of global-unicast host
+// candidates while keeping private/ULA hosts at Pion's default maximum. The
+// candidate type remains host, so a public host is still preferred over srflx
+// when it is the only direct path; it simply loses to a usable private host.
+// Candidate signaling carries this priority to the peer, which is the only
+// safe place available without forking Pion's local candidate gatherer.
+func prioritizeHostCandidate(raw string) string {
+	candidate, err := ice.UnmarshalCandidate(raw)
+	if err != nil || candidate.Type() != ice.CandidateTypeHost {
+		return raw
+	}
+	address, err := netip.ParseAddr(candidate.Address())
+	if err != nil || address.IsPrivate() || address.IsLoopback() || !address.IsGlobalUnicast() {
+		return raw
+	}
+	fields := strings.Fields(raw)
+	if len(fields) < 6 {
+		return raw
+	}
+	fields[3] = strconv.FormatUint(uint64(candidatePriority(candidate, publicHostLocalPreference)), 10)
+	return strings.Join(fields, " ")
+}
+
+func candidatePriority(candidate ice.Candidate, localPreference uint16) uint32 {
+	componentPreference := uint32(0)
+	if candidate.Component() < 256 {
+		componentPreference = 256 - uint32(candidate.Component())
+	}
+	return (1<<24)*uint32(candidate.Type().Preference()) +
+		(1<<8)*uint32(localPreference) + componentPreference
+}
 
 // ICECandidateTypes returns the pion candidate types the device-link ICE agent
 // should gather for the shared host-candidate policy.

--- a/packages/device-link/icequic/candidate_policy_test.go
+++ b/packages/device-link/icequic/candidate_policy_test.go
@@ -6,6 +6,34 @@ import (
 	"github.com/pion/ice/v4"
 )
 
+func TestPrioritizeHostCandidatePrefersPrivateAddresses(t *testing.T) {
+	privateRaw := "1 1 udp 2130706431 192.168.1.83 41000 typ host"
+	publicRaw := "2 1 udp 2130706431 2001:4860:4860::8888 41000 typ host"
+
+	private, err := ice.UnmarshalCandidate(prioritizeHostCandidate(privateRaw))
+	if err != nil {
+		t.Fatalf("unmarshal private candidate: %v", err)
+	}
+	public, err := ice.UnmarshalCandidate(prioritizeHostCandidate(publicRaw))
+	if err != nil {
+		t.Fatalf("unmarshal public candidate: %v", err)
+	}
+	if private.Priority() <= public.Priority() {
+		t.Fatalf("private host priority = %d, public host priority = %d; want private first", private.Priority(), public.Priority())
+	}
+	if got, want := public.Priority(), candidatePriority(public, publicHostLocalPreference); got != want {
+		t.Fatalf("public host priority = %d, want %d", got, want)
+	}
+}
+
+func TestPrioritizeHostCandidateLeavesSrflxUnchanged(t *testing.T) {
+	const raw = "3 1 udp 16777215 203.0.113.1 41000 typ srflx raddr 192.168.1.83 rport 41000"
+	got := prioritizeHostCandidate(raw)
+	if got != raw {
+		t.Fatalf("srflx candidate changed from %q to %q", raw, got)
+	}
+}
+
 func TestICECandidateTypesExcludesHostButKeepsSrflx(t *testing.T) {
 	types := ICECandidateTypes(true)
 	if len(types) != 1 || types[0] != ice.CandidateTypeServerReflexive {

--- a/packages/device-link/icequic/network_policy.go
+++ b/packages/device-link/icequic/network_policy.go
@@ -2,9 +2,10 @@ package icequic
 
 import "fmt"
 
-// NetworkPolicy controls which OS path owns ICE UDP sockets. System leaves
-// routing to the OS (including any active TUN); Direct binds every socket to a
-// physical interface and is currently implemented on macOS only.
+// NetworkPolicy controls which OS path owns ICE UDP sockets. System follows
+// OS routing while applying the shared LAN-first candidate preference. Direct
+// binds every socket to a physical interface and is currently implemented on
+// macOS only.
 type NetworkPolicy string
 
 const (


### PR DESCRIPTION
## Summary

- Keep `system` as the default device-link network policy.
- Prefer private IPv4/ULA host candidates over global-unicast host candidates by lowering the advertised ICE host priority for public addresses.
- Keep server-reflexive candidates as the public-network fallback and add a short host acceptance wait for trickled LAN candidates.
- Document the shared policy and cover the priority behavior with tests.

## Validation

- `make test` in `packages/device-link`
- `make android-crosscompile`
- `make android-bindings-check`
- `git diff --check`

`pnpm check:changed` was attempted in the isolated worktree but its Electron boundary lane could not locate the TypeScript runtime because that worktree has no `node_modules`; the Go and Android validations above pass.