### PR TITLE
fix(agent): preserve provider model selection integrity

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -208,9 +208,11 @@ composer descriptor rather than provider-name checks in shared UI code.
 Extension-owned model catalogs can change independently of target-scoped
 remembered defaults. On Create, the daemon treats such a default as a fallback
 preference and resolves an obsolete value to the extension runtime's current
-model; a model explicitly supplied by the caller remains strict. If the runtime
-rejects that explicit selection, startup fails rather than continuing with an
-undisclosed provider default.
+model. Non-explicit model-dependent settings, such as reasoning effort, resolve
+against that effective model rather than remaining bound to the obsolete
+preference. A model or dependent setting explicitly supplied by the caller
+remains strict. If the runtime rejects an explicit model selection, startup
+fails rather than continuing with an undisclosed provider default.
 
 Settings that affect provider preparation are immutable after launch. The
 daemon validates them against current product policy and resolved provider

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -205,6 +205,12 @@ entry capability may additionally hide or disable an experimental control; the
 activation boundary must fail closed as well, so a remembered `true` value
 cannot outlive a disabled host entry. Provider support comes from the resolved
 composer descriptor rather than provider-name checks in shared UI code.
+Extension-owned model catalogs can change independently of target-scoped
+remembered defaults. On Create, the daemon treats such a default as a fallback
+preference and resolves an obsolete value to the extension runtime's current
+model; a model explicitly supplied by the caller remains strict. If the runtime
+rejects that explicit selection, startup fails rather than continuing with an
+undisclosed provider default.
 
 Settings that affect provider preparation are immutable after launch. The
 daemon validates them against current product policy and resolved provider

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -1589,7 +1589,9 @@ invalid_grant`. Search `tuttid.log` for
 - Symptom:
   `opencode models --verbose` lists more models in a local terminal than the
   OpenCode model picker in Agent GUI. Custom provider ids or recently published
-  model variants are commonly absent.
+  model variants are commonly absent. A related presentation symptom shows a
+  provider-qualified recent item such as `newapi/deepseek-v4-pro`, while the
+  searchable catalog shows only the ambiguous model name `DeepSeek V4 Pro`.
 - Quick checks:
   Run `opencode models --verbose` from the same workspace cwd passed to the
   composer. Count exact `provider/model` lines and compare them with the
@@ -1601,18 +1603,25 @@ invalid_grant`. Search `tuttid.log` for
   daemon previously ran model discovery in its own inherited cwd and stored the
   resulting provider-wide list for six hours. A smaller result from the wrong
   project context therefore remained visible even after the terminal catalog
-  changed.
+  changed. Separately, verbose catalog normalization previously used only the
+  model metadata `name` as the display label even though the exact launch
+  identity remained the provider-qualified `provider/model` id.
 - Fix:
   Pass the composer workspace cwd through the daemon model-catalog request and
   set it as the `opencode models --verbose` process directory. Do not cache
   OpenCode model-list successes or failures. Keep one request-scoped catalog
   projection so a composer-options request starts the CLI only once. Preserve
   the auth/config invalidation event so an already-open composer refreshes when
-  global OpenCode credentials or config files change.
+  global OpenCode credentials or config files change. Append a non-built-in
+  provider id to verbose model labels while preserving the exact
+  provider-qualified id as the selection value. Keep the built-in `opencode`
+  provider suffix hidden so ordinary catalog entries stay concise, and avoid
+  renderer-side provider branches.
 - Validation:
   Cover cwd propagation, repeated uncached OpenCode lookups, all provider/model
   prefixes from verbose output, one catalog lookup per composer-options request,
-  and unchanged cache policies for Codex and Tutti Agent. Run
+  duplicate model names under different provider ids, and unchanged cache
+  policies for Codex and Tutti Agent. Run
   `cd services/tuttid && go test ./service/agent` and `pnpm check:changed`.
 - References:
   [opencode_model_catalog.go](../../../services/tuttid/service/agent/opencode_model_catalog.go)

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -69,6 +69,7 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 - [Queued AgentGUI prompt stalls after no-active-turn failure](./agent-session-lifecycle.md#queued-agentgui-prompt-stalls-after-no-active-turn-failure)
 - [Agent session stays loading after a completed turn](./agent-session-lifecycle.md#agent-session-stays-loading-after-a-completed-turn)
 - [AgentGUI model switch changes defaults but not the active session](./agent-session-lifecycle.md#agentgui-model-switch-changes-defaults-but-not-the-active-session)
+- [New Agent conversation rejects a model that is no longer offered](./agent-session-lifecycle.md#new-agent-conversation-rejects-a-model-that-is-no-longer-offered)
 - [AgentGUI shows the selected settings but a new session does not inherit them](./agent-session-lifecycle.md#agentgui-shows-the-selected-settings-but-a-new-session-does-not-inherit-them)
 - [Historical AgentGUI permission changes time out or stop responding](./agent-session-lifecycle.md#historical-agentgui-permission-changes-time-out-or-stop-responding)
 - [AgentGUI pin or unpin appears stuck for a live session](./agent-session-lifecycle.md#agentgui-pin-or-unpin-appears-stuck-for-a-live-session)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -4684,3 +4684,29 @@ permanently ambiguous`. Provider status may already be `active` while the
 - References:
   [checkpoint_provider_candidates.go](../../../services/tuttid/service/agentsessionreplay/checkpoint_provider_candidates.go)
   [checkpoint_activity_boundaries.go](../../../services/tuttid/service/agentsessionreplay/checkpoint_activity_boundaries.go)
+
+### New Agent conversation rejects a model that is no longer offered
+
+- Symptom:
+  A newly submitted conversation fails with `model value is not supported by
+agent target`, although the current model picker does not offer that model.
+  Alternatively, the selected model appears to start but the provider actually
+  continues on its own default.
+- Root cause:
+  A target-scoped remembered composer default outlived a changed model catalog,
+  or the ACP runtime treated a rejected startup model selection as a
+  best-effort setting and silently retained the provider default. Reapplying a
+  model that `session/new` already selected can also trigger an unnecessary
+  provider-side reconfiguration failure.
+- Fix:
+  At Create, distinguish a target-scoped persisted default from a model
+  explicitly supplied by the caller. For an Agent Extension, resolve an
+  obsolete persisted default to the current model reported by that same
+  extension; never use a different provider. Treat an explicit ACP model
+  selection as identity-bearing: leave an already-selected model unchanged,
+  and if a real model change is rejected, abort startup rather than falling
+  back.
+- Validation:
+  Cover an obsolete persisted default and an unsupported explicit selection
+  separately with generic extension fixtures, and inject a `session/set_model`
+  rejection into the standard ACP transport test.

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -4694,6 +4694,8 @@ agent target`, although the current model picker does not offer that model.
   continues on its own default.
 - Root cause:
   A target-scoped remembered composer default outlived a changed model catalog,
+  or a dependent reasoning default remained bound to the retired model after
+  model fallback,
   or the ACP runtime treated a rejected startup model selection as a
   best-effort setting and silently retained the provider default. Reapplying a
   model that `session/new` already selected can also trigger an unnecessary
@@ -4702,11 +4704,13 @@ agent target`, although the current model picker does not offer that model.
   At Create, distinguish a target-scoped persisted default from a model
   explicitly supplied by the caller. For an Agent Extension, resolve an
   obsolete persisted default to the current model reported by that same
-  extension; never use a different provider. Treat an explicit ACP model
-  selection as identity-bearing: leave an already-selected model unchanged,
-  and if a real model change is rejected, abort startup rather than falling
-  back.
+  extension; never use a different provider. Resolve non-explicit per-model
+  reasoning against that effective model while keeping explicit caller values
+  strict. Treat an explicit ACP model selection as identity-bearing: leave an
+  already-selected model unchanged, and if a real model change is rejected,
+  abort startup rather than falling back.
 - Validation:
-  Cover an obsolete persisted default and an unsupported explicit selection
-  separately with generic extension fixtures, and inject a `session/set_model`
-  rejection into the standard ACP transport test.
+  Cover an obsolete persisted default with a multi-model catalog whose reported
+  current model is not first, a stale dependent reasoning default, and an
+  unsupported explicit selection separately with generic extension fixtures.
+  Inject a `session/set_model` rejection into the standard ACP transport test.

--- a/packages/agent/daemon/runtime/standard_acp_launch_settings_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_launch_settings_test.go
@@ -2,8 +2,10 @@ package agentruntime
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -541,5 +543,66 @@ func TestStandardACPSetModelCarriesAdvertisedPerModelReasoningMetadata(t *testin
 	}
 	if calls := transport.conn.setConfigOptionCalls(); len(calls) != 0 {
 		t.Fatalf("config option calls = %#v, want standard session/set_model only", calls)
+	}
+}
+
+func TestStandardACPStartupFailsWhenRequestedModelIsRejected(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Model ACP", "model-rejected-session")
+	transport.conn.models = map[string]any{
+		"currentModelId": "provider-default",
+		"availableModels": []any{
+			map[string]any{"modelId": "requested-model", "name": "Requested Model"},
+		},
+	}
+	transport.conn.setModelError = &acpError{
+		Code:    -32603,
+		Message: "Internal error",
+		Data:    json.RawMessage(`{"details":"requested model is unavailable"}`),
+	}
+	adapterRaw, err := NewStandardACPAdapter(StandardACPAdapterConfig{
+		Provider: "acp:model-rejected", Name: "model-rejected-acp", DisplayName: "Model ACP", Command: []string{"model-acp", "stdio"},
+	}, transport, LegacyHostMetadata())
+	if err != nil {
+		t.Fatalf("NewStandardACPAdapter: %v", err)
+	}
+	session := standardTestSession("acp:model-rejected")
+	session.Settings = &SessionSettings{Model: "requested-model"}
+
+	if _, err := adapterRaw.Start(context.Background(), session); err == nil {
+		t.Fatal("Start error = nil, want rejected requested model to abort startup")
+	} else if !strings.Contains(err.Error(), "model configuration failed") {
+		t.Fatalf("Start error = %v, want model configuration failure", err)
+	}
+}
+
+func TestStandardACPStartupDoesNotReapplyCurrentRequestedModel(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Model ACP", "model-current-session")
+	transport.conn.models = map[string]any{
+		"currentModelId": "requested-model",
+		"availableModels": []any{
+			map[string]any{"modelId": "requested-model", "name": "Requested Model"},
+		},
+	}
+	transport.conn.setModelError = &acpError{
+		Code: -32603, Message: "duplicate model application rejected",
+	}
+	adapterRaw, err := NewStandardACPAdapter(StandardACPAdapterConfig{
+		Provider: "acp:model-current", Name: "model-current-acp", DisplayName: "Model ACP", Command: []string{"model-acp", "stdio"},
+	}, transport, LegacyHostMetadata())
+	if err != nil {
+		t.Fatalf("NewStandardACPAdapter: %v", err)
+	}
+	session := standardTestSession("acp:model-current")
+	session.Settings = &SessionSettings{Model: "requested-model"}
+
+	if _, err := adapterRaw.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if calls := transport.conn.setModelCalls(); len(calls) != 0 {
+		t.Fatalf("set_model calls = %#v, want current model left unchanged", calls)
 	}
 }

--- a/packages/agent/daemon/runtime/standard_acp_settings.go
+++ b/packages/agent/daemon/runtime/standard_acp_settings.go
@@ -125,26 +125,28 @@ func (a *standardACPAdapter) applySessionConfigOptions(
 		"model_requested":      strings.TrimSpace(settings.Model) != "",
 		"effort_requested":     strings.TrimSpace(settings.ReasoningEffort) != "",
 	})
-	// Startup config options are applied best-effort: a value the agent
-	// rejects (e.g. a model alias the signed-in account cannot access) must
-	// not abort the whole session. The session stays usable on the agent's
-	// default, and the user can pick a supported value from the live list.
+	// A requested model is identity-bearing launch intent. If the agent rejects
+	// it, continuing on its default would make the visible selection disagree
+	// with the provider request. Other non-identity settings remain best-effort.
 	modelConfigID := a.effectiveModelConfigOptionID()
 	modelSet := false
 	if model := strings.TrimSpace(settings.Model); model != "" && modelConfigID != "" &&
 		(supported[modelConfigID] || (modelConfigID == "model" && modelsAPI)) {
-		var err error
-		if modelsAPI && modelConfigID == "model" {
-			err = a.setSessionModel(ctx, client, session, model)
-		} else {
-			err = a.setSessionConfigOption(ctx, client, session, modelConfigID, model)
-		}
-		if err != nil {
-			a.logStartupConfigOptionRejected(session, modelConfigID, model, err)
-		} else {
+		modelAlreadySelected := modelsAPI && modelConfigID == "model" &&
+			strings.TrimSpace(a.sessionCurrentModelID(session.AgentSessionID)) == model
+		if !modelAlreadySelected {
+			var err error
+			if modelsAPI && modelConfigID == "model" {
+				err = a.setSessionModel(ctx, client, session, model)
+			} else {
+				err = a.setSessionConfigOption(ctx, client, session, modelConfigID, model)
+			}
+			if err != nil {
+				return fmt.Errorf("agent session ACP model configuration failed: %w", err)
+			}
 			modelSet = modelsAPI && modelConfigID == "model"
-			a.updateSessionConfigOption(session.AgentSessionID, modelConfigID, model)
 		}
+		a.updateSessionConfigOption(session.AgentSessionID, modelConfigID, model)
 	}
 	if reasoning := strings.TrimSpace(settings.ReasoningEffort); reasoning != "" {
 		if a.config.setModelReasoningEffortMeta {

--- a/packages/agent/daemon/runtime/standard_acp_test_connection_rpc_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_test_connection_rpc_test.go
@@ -221,7 +221,16 @@ func (c *standardACPConnection) Send(data []byte) error {
 			if c.models != nil {
 				result["models"] = clonePayload(c.models)
 			}
+			setModelError := c.setModelError
 			c.mu.Unlock()
+			if setModelError != nil {
+				c.sendJSON(map[string]any{
+					"jsonrpc": "2.0",
+					"id":      message.ID,
+					"error":   setModelError,
+				})
+				return nil
+			}
 			c.sendJSON(map[string]any{
 				"jsonrpc": "2.0",
 				"id":      message.ID,

--- a/packages/agent/daemon/runtime/standard_acp_test_transport_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_test_transport_test.go
@@ -91,6 +91,7 @@ type standardACPConnection struct {
 	lastSetModeParamsSnapshot     map[string]any
 	lastAuthenticatedMethodID     string
 	setModeError                  *acpError
+	setModelError                 *acpError
 	loadSessionError              *acpError
 	closeSessionError             *acpError
 	rejectModelValue              string

--- a/services/tuttid/service/agent/composer_defaults_validation.go
+++ b/services/tuttid/service/agent/composer_defaults_validation.go
@@ -130,6 +130,7 @@ func (s *Service) validateExtensionComposerSettingsForCreate(
 	input *CreateSessionInput,
 	modelExplicit bool,
 	permissionModeExplicit bool,
+	reasoningEffortExplicit bool,
 ) error {
 	if input == nil || providerTargetRefKind(input.ProviderTargetRef) != "agent_extension" {
 		return nil
@@ -177,6 +178,15 @@ func (s *Service) validateExtensionComposerSettingsForCreate(
 			input.PermissionModeID = nil
 		} else {
 			input.PermissionModeID = stringPointer(resolved)
+		}
+	}
+	if !reasoningEffortExplicit {
+		resolved := strings.TrimSpace(options.EffectiveSettings.ReasoningEffort)
+		settings.ReasoningEffort = resolved
+		if resolved == "" {
+			input.ReasoningEffort = nil
+		} else {
+			input.ReasoningEffort = stringPointer(resolved)
 		}
 	}
 	if err := validateExtensionComposerOption(

--- a/services/tuttid/service/agent/composer_defaults_validation.go
+++ b/services/tuttid/service/agent/composer_defaults_validation.go
@@ -128,6 +128,7 @@ func (s *Service) validateExtensionComposerSettingsForCreate(
 	workspaceID string,
 	cwd string,
 	input *CreateSessionInput,
+	modelExplicit bool,
 	permissionModeExplicit bool,
 ) error {
 	if input == nil || providerTargetRefKind(input.ProviderTargetRef) != "agent_extension" {
@@ -138,6 +139,12 @@ func (s *Service) validateExtensionComposerSettingsForCreate(
 		PermissionModeID: strings.TrimSpace(value(input.PermissionModeID)),
 		ReasoningEffort:  strings.TrimSpace(value(input.ReasoningEffort)),
 		Speed:            strings.TrimSpace(value(input.Speed)),
+	}
+	if !modelExplicit {
+		// Persisted defaults may outlive an extension-owned model catalog. Let
+		// Composer Options resolve the runtime's current model rather than
+		// validating the retired preference as an explicit caller selection.
+		settings.Model = ""
 	}
 	if !permissionModeExplicit {
 		// Persisted defaults are fallback preferences, not caller selections.
@@ -155,6 +162,14 @@ func (s *Service) validateExtensionComposerSettingsForCreate(
 	})
 	if err != nil {
 		return err
+	}
+	if !modelExplicit {
+		resolved := strings.TrimSpace(options.EffectiveSettings.Model)
+		if resolved == "" {
+			input.Model = nil
+		} else {
+			input.Model = stringPointer(resolved)
+		}
 	}
 	if !permissionModeExplicit {
 		resolved := strings.TrimSpace(options.EffectiveSettings.PermissionModeID)

--- a/services/tuttid/service/agent/composer_defaults_validation_test.go
+++ b/services/tuttid/service/agent/composer_defaults_validation_test.go
@@ -82,7 +82,7 @@ func TestValidateAgentComposerDefaultsPatchRetainsExtensionTargetCatalogAfterDis
 	}
 }
 
-func TestServiceCreateRevalidatesObservedExtensionDefaultForActualCwd(t *testing.T) {
+func TestServiceCreateResolvesObservedExtensionDefaultForActualCwd(t *testing.T) {
 	ctx := context.Background()
 	runtime, service := newExtensionComposerValidationService(t)
 	cwdA := resolvedComposerValidationCwd(t, service, t.TempDir())
@@ -105,15 +105,31 @@ func TestServiceCreateRevalidatesObservedExtensionDefaultForActualCwd(t *testing
 	service.AgentComposerDefaultsReader = fakeAgentComposerDefaultsReader{
 		extensionComposerValidationTargetID: {Model: "gemini-project-a"},
 	}
-	_, err := service.Create(ctx, "workspace-create-b", CreateSessionInput{
+	created, err := service.Create(ctx, "workspace-create-b", CreateSessionInput{
 		AgentTargetID: extensionComposerValidationTargetID,
 		Cwd:           &cwdB,
 	})
-	if !errors.Is(err, ErrInvalidArgument) {
-		t.Fatalf("Create() error = %v, want ErrInvalidArgument", err)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
 	}
-	if starts := visibleRuntimeStarts(runtime.startCalls); len(starts) != 0 {
-		t.Fatalf("visible starts = %#v, want none", starts)
+	if created.Settings == nil || created.Settings.Model != "gemini-project-b" {
+		t.Fatalf("created settings = %#v, want current-cwd model", created.Settings)
+	}
+	if starts := visibleRuntimeStarts(runtime.startCalls); len(starts) != 1 || starts[0].Model != "gemini-project-b" {
+		t.Fatalf("visible starts = %#v, want current-cwd model", starts)
+	}
+
+	explicitModel := "gemini-project-a"
+	_, err = service.Create(ctx, "workspace-create-b-explicit", CreateSessionInput{
+		AgentTargetID: extensionComposerValidationTargetID,
+		Cwd:           &cwdB,
+		Model:         &explicitModel,
+	})
+	if !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("Create() explicit model error = %v, want ErrInvalidArgument", err)
+	}
+	if starts := visibleRuntimeStarts(runtime.startCalls); len(starts) != 1 {
+		t.Fatalf("visible starts after rejected explicit model = %#v, want original start only", starts)
 	}
 }
 

--- a/services/tuttid/service/agent/composer_live_model_discovery.go
+++ b/services/tuttid/service/agent/composer_live_model_discovery.go
@@ -134,10 +134,9 @@ func (s *Service) liveModelOptionsFromRunningSessionForScope(scope composerLiveM
 	return nil, hasProviderSession
 }
 
-func (s *Service) effectiveModelFromRunningSessionForScope(
+func (s *Service) modelValuesFromRunningSessionForScope(
 	scope composerLiveModelScope,
-) string {
-	effectiveModel := ""
+) (effectiveModel string, currentModel string) {
 	selectedUnixMS := int64(-1)
 	selectedSessionID := ""
 	selectedSession := false
@@ -168,21 +167,23 @@ func (s *Service) effectiveModelFromRunningSessionForScope(
 			session.RuntimeContext,
 			scope.modelConfigOptionID,
 		)
+		currentModel = extractCurrentModelFromRuntimeContext(
+			session.RuntimeContext,
+			scope.modelConfigOptionID,
+		)
 		selectedUnixMS = sessionUnixMS
 		selectedSessionID = session.ID
 		selectedSession = true
 	}
 	if selectedSession {
-		return effectiveModel
+		return effectiveModel, currentModel
 	}
 	runtimeContext, ok := s.getComposerRuntimeContextForScope(scope, time.Now().UTC())
 	if !ok {
-		return ""
+		return "", ""
 	}
-	return extractEffectiveModelFromRuntimeContext(
-		runtimeContext,
-		scope.modelConfigOptionID,
-	)
+	return extractEffectiveModelFromRuntimeContext(runtimeContext, scope.modelConfigOptionID),
+		extractCurrentModelFromRuntimeContext(runtimeContext, scope.modelConfigOptionID)
 }
 
 func (s *Service) liveModelInvalidatedAtUnixMSForProvider(provider string) int64 {
@@ -578,7 +579,7 @@ func (s *Service) mergeLiveComposerModelsForComposerOptions(
 	}
 	if len(liveModels) > 0 {
 		liveModels = s.enrichModelCapabilityOptions(ctx, provider, liveModels)
-		effectiveModel := s.effectiveModelFromRunningSessionForScope(scope)
+		effectiveModel, currentModel := s.modelValuesFromRunningSessionForScope(scope)
 		logClaudeModelCatalogInvalidationDebug("composer_options_model_source_selected", map[string]any{
 			"workspaceId":       input.WorkspaceID,
 			"cwd":               input.Cwd,
@@ -591,6 +592,7 @@ func (s *Service) mergeLiveComposerModelsForComposerOptions(
 			liveModels,
 			modelSource,
 			effectiveModel,
+			currentModel,
 		), nil
 	}
 	if !isClaudeSDKLiveModelProvider(provider) {
@@ -608,7 +610,7 @@ func (s *Service) mergeLiveComposerModelsForComposerOptions(
 			"modelOptionCount":  len(staticModels),
 			"modelOptionValues": composerConfigOptionValuesDebugValues(staticModels),
 		})
-		return mergeComposerModelsIntoComposerOptions(options, staticModels, modelSource, ""), nil
+		return mergeComposerModelsIntoComposerOptions(options, staticModels, modelSource, "", ""), nil
 	}
 	return clearUnverifiedLiveComposerModel(options), nil
 }
@@ -629,7 +631,7 @@ func composerConfigOptionValuesDebugValues(options []ComposerConfigOptionValue) 
 }
 
 func mergeLiveModelsIntoComposerOptions(options ComposerOptions, liveModels []ComposerConfigOptionValue) ComposerOptions {
-	return mergeComposerModelsIntoComposerOptions(options, liveModels, runtimeLiveModelCatalogSource, "")
+	return mergeComposerModelsIntoComposerOptions(options, liveModels, runtimeLiveModelCatalogSource, "", "")
 }
 
 func mergeComposerModelsIntoComposerOptions(
@@ -637,12 +639,18 @@ func mergeComposerModelsIntoComposerOptions(
 	liveModels []ComposerConfigOptionValue,
 	modelSource string,
 	effectiveModel string,
+	currentModel string,
 ) ComposerOptions {
 	normalized := normalizeLiveComposerModelOptions(liveModels)
 	if len(normalized) == 0 {
 		return options
 	}
-	selected := liveComposerSelectedModel(options.EffectiveSettings.Model, normalized)
+	selected := liveComposerSelectedModel(
+		options.EffectiveSettings.Model,
+		currentModel,
+		effectiveModel,
+		normalized,
+	)
 	options.EffectiveSettings.Model = selected
 	options.ModelConfig = ComposerConfigOption{
 		Configurable:   true,
@@ -723,12 +731,33 @@ func normalizeLiveComposerModelOptions(options []ComposerConfigOptionValue) []Co
 	return normalized
 }
 
-func liveComposerSelectedModel(selectedModel string, liveModels []ComposerConfigOptionValue) string {
+func liveComposerSelectedModel(
+	selectedModel string,
+	currentModel string,
+	effectiveModel string,
+	liveModels []ComposerConfigOptionValue,
+) string {
 	selectedModel = strings.TrimSpace(selectedModel)
 	if selectedModel != "" {
 		for _, option := range liveModels {
 			if strings.TrimSpace(option.Value) == selectedModel {
 				return selectedModel
+			}
+		}
+	}
+	currentModel = strings.TrimSpace(currentModel)
+	if currentModel != "" {
+		for _, option := range liveModels {
+			if strings.TrimSpace(option.Value) == currentModel {
+				return currentModel
+			}
+		}
+	}
+	effectiveModel = strings.TrimSpace(effectiveModel)
+	if effectiveModel != "" {
+		for _, option := range liveModels {
+			if strings.TrimSpace(option.Value) == effectiveModel {
+				return effectiveModel
 			}
 		}
 	}

--- a/services/tuttid/service/agent/composer_runtime_model_options.go
+++ b/services/tuttid/service/agent/composer_runtime_model_options.go
@@ -90,6 +90,25 @@ func extractEffectiveModelFromRuntimeContext(
 	return ""
 }
 
+func extractCurrentModelFromRuntimeContext(
+	runtimeContext map[string]any,
+	optionIDs ...string,
+) string {
+	if len(runtimeContext) == 0 {
+		return ""
+	}
+	modelOptionID := "model"
+	if len(optionIDs) > 0 && strings.TrimSpace(optionIDs[0]) != "" {
+		modelOptionID = strings.TrimSpace(optionIDs[0])
+	}
+	for _, option := range runtimeConfigOptionsAsMapSlice(runtimeContext["configOptions"]) {
+		if strings.TrimSpace(stringFromAny(option["id"])) == modelOptionID {
+			return strings.TrimSpace(stringFromAny(option["currentValue"]))
+		}
+	}
+	return ""
+}
+
 func composerModelOptionsFromCanonicalCatalog(models []modelcatalog.ModelOption) []ComposerConfigOptionValue {
 	options := make([]ComposerConfigOptionValue, 0, len(models))
 	for _, model := range models {

--- a/services/tuttid/service/agent/composer_runtime_model_options_test.go
+++ b/services/tuttid/service/agent/composer_runtime_model_options_test.go
@@ -17,3 +17,21 @@ func TestComposerModelOptionsFromCanonicalCatalogDeduplicatesModelIDs(t *testing
 		t.Fatalf("composer model options = %#v, want first canonical model only", options)
 	}
 }
+
+func TestExtractRuntimeModelValues(t *testing.T) {
+	t.Parallel()
+
+	runtimeContext := map[string]any{
+		"configOptions": []map[string]any{{
+			"id":             "model",
+			"currentValue":   "provider-current",
+			"effectiveValue": "resolved-alias",
+		}},
+	}
+	if got := extractEffectiveModelFromRuntimeContext(runtimeContext); got != "resolved-alias" {
+		t.Fatalf("effective model = %q, want resolved-alias", got)
+	}
+	if got := extractCurrentModelFromRuntimeContext(runtimeContext); got != "provider-current" {
+		t.Fatalf("current model = %q, want provider-current", got)
+	}
+}

--- a/services/tuttid/service/agent/extension_composer_create_validation_test.go
+++ b/services/tuttid/service/agent/extension_composer_create_validation_test.go
@@ -234,8 +234,10 @@ func TestServiceCreateRejectsExtensionSettingsOutsideDescriptor(t *testing.T) {
 		input    CreateSessionInput
 	}{
 		{
-			name:     "default model",
-			defaults: preferencesbiz.AgentComposerDefaults{Model: "unknown-model"},
+			name: "model override",
+			input: CreateSessionInput{
+				Model: stringPointer("unknown-model"),
+			},
 		},
 		{
 			name: "permission override",
@@ -276,6 +278,28 @@ func TestServiceCreateRejectsExtensionSettingsOutsideDescriptor(t *testing.T) {
 				t.Fatalf("visible starts = %#v, want none", starts)
 			}
 		})
+	}
+}
+
+func TestServiceCreateIgnoresRetiredExtensionModelDefault(t *testing.T) {
+	runtime, service := newExtensionComposerValidationService(t)
+	service.AgentComposerDefaultsReader = fakeAgentComposerDefaultsReader{
+		extensionComposerValidationTargetID: {Model: "retired-model"},
+	}
+
+	created, err := service.Create(context.Background(), "workspace-extension", CreateSessionInput{
+		AgentTargetID: extensionComposerValidationTargetID,
+		Cwd:           stringPointer(t.TempDir()),
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if created.Settings == nil || created.Settings.Model != "gemini-pro" {
+		t.Fatalf("created settings = %#v, want runtime current model", created.Settings)
+	}
+	visibleStarts := visibleRuntimeStarts(runtime.startCalls)
+	if len(visibleStarts) != 1 || visibleStarts[0].Model != "gemini-pro" {
+		t.Fatalf("visible starts = %#v, want runtime current model", visibleStarts)
 	}
 }
 

--- a/services/tuttid/service/agent/extension_composer_create_validation_test.go
+++ b/services/tuttid/service/agent/extension_composer_create_validation_test.go
@@ -283,6 +283,21 @@ func TestServiceCreateRejectsExtensionSettingsOutsideDescriptor(t *testing.T) {
 
 func TestServiceCreateIgnoresRetiredExtensionModelDefault(t *testing.T) {
 	runtime, service := newExtensionComposerValidationService(t)
+	runtime.startHook = func(input RuntimeStartInput, session ProviderRuntimeSession) ProviderRuntimeSession {
+		if input.Visible != nil && !*input.Visible {
+			session.RuntimeContext = map[string]any{
+				"configOptions": []any{map[string]any{
+					"id":           "model",
+					"currentValue": "gemini-fast",
+					"options": []any{
+						map[string]any{"value": "gemini-pro", "name": "Gemini Pro"},
+						map[string]any{"value": "gemini-fast", "name": "Gemini Fast"},
+					},
+				}},
+			}
+		}
+		return session
+	}
 	service.AgentComposerDefaultsReader = fakeAgentComposerDefaultsReader{
 		extensionComposerValidationTargetID: {Model: "retired-model"},
 	}
@@ -294,12 +309,64 @@ func TestServiceCreateIgnoresRetiredExtensionModelDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create() error = %v", err)
 	}
-	if created.Settings == nil || created.Settings.Model != "gemini-pro" {
+	if created.Settings == nil || created.Settings.Model != "gemini-fast" {
 		t.Fatalf("created settings = %#v, want runtime current model", created.Settings)
 	}
 	visibleStarts := visibleRuntimeStarts(runtime.startCalls)
-	if len(visibleStarts) != 1 || visibleStarts[0].Model != "gemini-pro" {
+	if len(visibleStarts) != 1 || visibleStarts[0].Model != "gemini-fast" {
 		t.Fatalf("visible starts = %#v, want runtime current model", visibleStarts)
+	}
+}
+
+func TestServiceCreateResolvesReasoningDefaultAfterRetiredExtensionModel(t *testing.T) {
+	runtime, service := newExtensionComposerValidationService(t)
+	runtime.startHook = func(input RuntimeStartInput, session ProviderRuntimeSession) ProviderRuntimeSession {
+		if input.Visible != nil && !*input.Visible {
+			session.RuntimeContext = map[string]any{
+				"configOptions": []any{map[string]any{
+					"id":           "model",
+					"currentValue": "gemini-fast",
+					"options": []any{
+						map[string]any{"value": "gemini-pro", "name": "Gemini Pro"},
+						map[string]any{
+							"value":                   "gemini-fast",
+							"name":                    "Gemini Fast",
+							"reasoningEffort":         "low",
+							"supportsReasoningEffort": true,
+							"reasoningEfforts": []any{
+								map[string]any{"value": "low", "name": "Low", "default": true},
+							},
+						},
+					},
+				}},
+			}
+		}
+		return session
+	}
+	service.AgentComposerDefaultsReader = fakeAgentComposerDefaultsReader{
+		extensionComposerValidationTargetID: {
+			Model:           "retired-model",
+			ReasoningEffort: "high",
+		},
+	}
+
+	created, err := service.Create(context.Background(), "workspace-extension", CreateSessionInput{
+		AgentTargetID: extensionComposerValidationTargetID,
+		Cwd:           stringPointer(t.TempDir()),
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if created.Settings == nil ||
+		created.Settings.Model != "gemini-fast" ||
+		created.Settings.ReasoningEffort != "low" {
+		t.Fatalf("created settings = %#v, want runtime model reasoning default", created.Settings)
+	}
+	visibleStarts := visibleRuntimeStarts(runtime.startCalls)
+	if len(visibleStarts) != 1 ||
+		visibleStarts[0].Model != "gemini-fast" ||
+		visibleStarts[0].ReasoningEffort != "low" {
+		t.Fatalf("visible starts = %#v, want resolved runtime model settings", visibleStarts)
 	}
 }
 

--- a/services/tuttid/service/agent/opencode_model_catalog.go
+++ b/services/tuttid/service/agent/opencode_model_catalog.go
@@ -134,9 +134,7 @@ func parseVerboseOpenCodeModelsOutput(output []byte) []AgentModelOption {
 
 func normalizeVerboseOpenCodeModel(modelID string, metadata map[string]any) AgentModelOption {
 	name := strings.TrimSpace(stringFromAny(metadata["name"]))
-	if name == "" {
-		name = modelID
-	}
+	displayName := openCodeModelDisplayName(modelID, name)
 	variants, variantsAdvertised := metadata["variants"].(map[string]any)
 	reasoningEfforts := make([]AgentModelReasoningEffortOption, 0, len(variants))
 	for value := range variants {
@@ -158,12 +156,32 @@ func normalizeVerboseOpenCodeModel(modelID string, metadata map[string]any) Agen
 	}
 	return AgentModelOption{
 		ID:                         modelID,
-		DisplayName:                name,
+		DisplayName:                displayName,
 		Description:                "OpenCode model",
 		ReasoningEffortsAdvertised: variantsAdvertised,
 		SupportedReasoningEfforts:  reasoningEfforts,
 		SupportsImageInput:         supportsImageInput,
 	}
+}
+
+func openCodeModelDisplayName(modelID string, name string) string {
+	modelID = strings.TrimSpace(modelID)
+	name = strings.TrimSpace(name)
+	providerID, modelName, qualified := strings.Cut(modelID, "/")
+	providerID = strings.TrimSpace(providerID)
+	if name == "" && qualified {
+		name = strings.TrimSpace(modelName)
+	}
+	if name == "" {
+		return modelID
+	}
+	if !qualified || providerID == "" {
+		return name
+	}
+	if strings.EqualFold(providerID, "opencode") {
+		return name
+	}
+	return name + " / " + providerID
 }
 
 func openCodeReasoningEffortOrder(value string) string {

--- a/services/tuttid/service/agent/opencode_model_catalog_test.go
+++ b/services/tuttid/service/agent/opencode_model_catalog_test.go
@@ -60,6 +60,10 @@ opencode/deepseek-v4-flash-free
 	if models[0].SupportsImageInput == nil || *models[0].SupportsImageInput {
 		t.Fatalf("Big Pickle image support = %#v", models[0].SupportsImageInput)
 	}
+	if models[0].DisplayName != "Big Pickle" ||
+		models[1].DisplayName != "DeepSeek V4 Flash Free" {
+		t.Fatalf("model display names = %#v, want built-in provider omitted", models)
+	}
 	wantEfforts := []string{"low", "medium", "high", "max"}
 	for index, want := range wantEfforts {
 		if models[1].SupportedReasoningEfforts[index].Value != want {
@@ -97,6 +101,24 @@ tutti/glm-5
 		if models[index].ID != modelID {
 			t.Fatalf("models[%d].ID = %q, want %q", index, models[index].ID, modelID)
 		}
+	}
+}
+
+func TestParseVerboseOpenCodeModelsOutputDistinguishesSameModelAcrossProviders(t *testing.T) {
+	t.Parallel()
+
+	models := parseOpenCodeModelsOutput([]byte(`newapi/deepseek-v4-pro
+{"name":"DeepSeek V4 Pro","providerID":"newapi","variants":{}}
+opencode/deepseek-v4-pro
+{"name":"DeepSeek V4 Pro","providerID":"opencode","variants":{}}
+`))
+
+	if len(models) != 2 {
+		t.Fatalf("len(models) = %d, want 2: %#v", len(models), models)
+	}
+	if models[0].DisplayName != "DeepSeek V4 Pro / newapi" ||
+		models[1].DisplayName != "DeepSeek V4 Pro" {
+		t.Fatalf("model display names = %#v, want custom provider suffix only", models)
 	}
 }
 

--- a/services/tuttid/service/agent/service_create.go
+++ b/services/tuttid/service/agent/service_create.go
@@ -45,6 +45,7 @@ func (s *Service) CreateWithResult(ctx context.Context, workspaceID string, inpu
 	}
 	modelExplicit := strings.TrimSpace(value(input.Model)) != ""
 	permissionModeExplicit := strings.TrimSpace(value(input.PermissionModeID)) != ""
+	reasoningEffortExplicit := strings.TrimSpace(value(input.ReasoningEffort)) != ""
 	if err := s.applyCreateSessionComposerDefaults(ctx, &input); err != nil {
 		return CreateSessionResult{}, err
 	}
@@ -168,6 +169,7 @@ func (s *Service) CreateWithResult(ctx context.Context, workspaceID string, inpu
 			&input,
 			modelExplicit,
 			permissionModeExplicit,
+			reasoningEffortExplicit,
 		); err != nil {
 			s.reportAgentServiceNodeFailure(ctx, input.AgentSessionID, "session_create", "settings_validated", provider, nodeStartedAt, err)
 			return CreateSessionResult{}, err

--- a/services/tuttid/service/agent/service_create.go
+++ b/services/tuttid/service/agent/service_create.go
@@ -43,9 +43,17 @@ func (s *Service) CreateWithResult(ctx context.Context, workspaceID string, inpu
 	if !input.CodexSaverModeAllowed || !composerProviderSupportsSaverSubagentMode(provider) {
 		input.CodexSaverMode = nil
 	}
+	modelExplicit := strings.TrimSpace(value(input.Model)) != ""
 	permissionModeExplicit := strings.TrimSpace(value(input.PermissionModeID)) != ""
 	if err := s.applyCreateSessionComposerDefaults(ctx, &input); err != nil {
 		return CreateSessionResult{}, err
+	}
+	if providerTargetRefKind(input.ProviderTargetRef) == "agent_extension" && !modelExplicit {
+		// Extension defaults are fallback preferences, not caller selections.
+		// Their model catalog is runtime-owned and can change independently of
+		// persisted preferences, so defer the effective model to the live
+		// extension validation below.
+		input.Model = nil
 	}
 	input.ConversationDetailMode = preferencesbiz.NormalizeDesktopAgentConversationDetailMode(input.ConversationDetailMode)
 	requestedPermissionModeID := strings.TrimSpace(value(input.PermissionModeID))
@@ -158,11 +166,13 @@ func (s *Service) CreateWithResult(ctx context.Context, workspaceID string, inpu
 			workspaceID,
 			cwd,
 			&input,
+			modelExplicit,
 			permissionModeExplicit,
 		); err != nil {
 			s.reportAgentServiceNodeFailure(ctx, input.AgentSessionID, "session_create", "settings_validated", provider, nodeStartedAt, err)
 			return CreateSessionResult{}, err
 		}
+		input.RuntimeContext = runtimeContextWithSessionRuntimeSnapshot(input.RuntimeContext, input, provider, planResolution)
 		s.reportAgentServiceNodeSuccess(ctx, input.AgentSessionID, "session_create", "settings_validated", provider, nodeStartedAt)
 	}
 	nodeStartedAt = time.Now()


### PR DESCRIPTION
## 背景

Agent Extension 的模型目录可能独立于已保存的 Composer 默认值发生变化。此前创建会话时可能继续校验过期默认模型，或者在 ACP 拒绝显式模型切换后静默使用提供商默认模型，导致界面选择与实际运行模型不一致。同时，OpenCode 自定义提供商的同名模型在模型列表中缺少可区分的展示信息。

## 修改内容

- 将显式 ACP 模型选择作为具有身份语义的启动参数：运行时拒绝切换时终止启动，已由 `session/new` 选中的模型不重复设置
- 区分调用方显式设置与持久化默认值；过期的 Extension 模型默认值回退到运行时报告的当前模型
- 模型回退时同步解析非显式的 per-model reasoning 默认值，显式 reasoning 继续严格校验
- 分离 ACP `currentValue` 与 `effectiveValue`，避免破坏 Claude 等现有展示语义
- OpenCode 自定义提供商显示为 `Model / Provider`，内置 `opencode` 提供商保持简洁
- 补充多模型目录、过期默认值、reasoning 回退、ACP 拒绝以及 OpenCode 同名模型回归测试
- 更新 AgentGUI 架构和相关故障排查文档

## 架构说明

这些改动属于 tuttid 的 Composer、Target 和提供商准备策略，不改变 Session、Turn、Goal 或 runtime-operation 的生命周期语义，因此不需要 tsh 或其他 Host consumer 共享该行为，也不引入新的 Host 生命周期能力。

## 验证

- `pnpm check:changed -- --push-ready`
- `cd services/tuttid && go test ./service/agent -run 'Test(GetComposerOptionsDoesNotReuseOlderEffectiveModel|ExtractRuntimeModelValues|ServiceCreateIgnoresRetiredExtensionModelDefault|ServiceCreateResolvesReasoningDefaultAfterRetiredExtensionModel)'`
- `cd packages && go test ./agent/daemon/runtime`
