### PR TITLE
fix(mobile): diagnose Android update installation failures

### DIFF
--- a/apps/mobile/android/app/src/main/java/sh/tutti/mobile/MobileSecurityModule.kt
+++ b/apps/mobile/android/app/src/main/java/sh/tutti/mobile/MobileSecurityModule.kt
@@ -21,17 +21,11 @@ import com.facebook.react.modules.network.ForwardingCookieHandler
 import com.google.zxing.client.android.Intents
 import com.journeyapps.barcodescanner.ScanContract
 import com.journeyapps.barcodescanner.ScanOptions
-import java.io.BufferedInputStream
-import java.io.File
-import java.io.FileOutputStream
-import java.net.HttpURLConnection
 import java.net.URI
-import java.net.URL
 import java.nio.charset.StandardCharsets
 import java.security.KeyPair
 import java.security.KeyPairGenerator
 import java.security.KeyStore
-import java.security.MessageDigest
 import java.security.PrivateKey
 import java.security.Signature
 import java.security.spec.ECGenParameterSpec
@@ -50,6 +44,7 @@ class MobileSecurityModule(
     private val browserAuthBridge = MobileBrowserAuthBridge(reactContext)
     private val store = SecureStore(reactContext)
     private val updateExecutor = Executors.newSingleThreadExecutor()
+    private val updateDownloader = MobileUpdateDownloader(reactContext.cacheDir)
     private var scanPromise: Promise? = null
     private var scanCancellationPromise: Promise? = null
     private var scanActivity: Activity? = null
@@ -149,40 +144,96 @@ class MobileSecurityModule(
         promise: Promise,
     ) {
         UiThreadUtil.runOnUiThread {
-            try {
-                val activity = reactContext.currentActivity
-                require(activity != null) { "No active Android activity" }
-                if (
-                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
-                    !reactContext.packageManager.canRequestPackageInstalls()
-                ) {
+            val activity = reactContext.currentActivity
+            if (activity == null) {
+                val cause = IllegalStateException("No active Android activity")
+                Log.e(LOG_TAG, "Unable to start update: no active activity", cause)
+                promise.reject(
+                    "UPDATE_INSTALL_FAILED",
+                    "No active Android activity",
+                    cause,
+                )
+                return@runOnUiThread
+            }
+            if (
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
+                !reactContext.packageManager.canRequestPackageInstalls()
+            ) {
+                try {
+                    Log.i(LOG_TAG, "Update install permission is missing; opening settings")
                     activity.startActivity(
                         Intent(
                             Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
                             Uri.parse("package:${reactContext.packageName}"),
                         ),
                     )
+                } catch (cause: Throwable) {
+                    Log.e(LOG_TAG, "Unable to open Android install permission settings", cause)
                     promise.reject(
-                        "UPDATE_INSTALL_PERMISSION_REQUIRED",
-                        "Allow Tutti to install unknown apps, then try again",
+                        "UPDATE_PERMISSION_SETTINGS_FAILED",
+                        "Unable to open Android install permission settings",
+                        cause,
                     )
                     return@runOnUiThread
                 }
+                Log.i(LOG_TAG, "Android install permission settings opened")
+                promise.reject(
+                    "UPDATE_INSTALL_PERMISSION_REQUIRED",
+                    "Allow Tutti to install unknown apps, then try again",
+                )
+                return@runOnUiThread
+            }
+            Log.i(LOG_TAG, "Android install permission is available; starting update download")
 
+            try {
                 updateExecutor.execute {
                     try {
-                        val apkFile = downloadUpdate(apkURL, expectedSHA256)
+                        val apkFile = updateDownloader.download(apkURL, expectedSHA256)
+                        Log.i(
+                            LOG_TAG,
+                            "Update APK download completed: path=${apkFile.absolutePath}, " +
+                                "exists=${apkFile.exists()}, canRead=${apkFile.canRead()}, " +
+                                "bytes=${apkFile.length()}",
+                        )
                         UiThreadUtil.runOnUiThread {
-                            try {
-                                val installerActivity = reactContext.currentActivity
-                                require(installerActivity != null) {
-                                    "No active Android activity"
-                                }
-                                val uri = FileProvider.getUriForFile(
+                            val installerActivity = reactContext.currentActivity
+                            if (installerActivity == null) {
+                                val cause =
+                                    IllegalStateException("No active Android activity")
+                                Log.e(
+                                    LOG_TAG,
+                                    "Unable to launch package installer: no active activity",
+                                    cause,
+                                )
+                                promise.reject(
+                                    "UPDATE_INSTALL_FAILED",
+                                    "No active Android activity",
+                                    cause,
+                                )
+                                return@runOnUiThread
+                            }
+                            val uri = try {
+                                FileProvider.getUriForFile(
                                     reactContext,
                                     "${BuildConfig.APPLICATION_ID}.fileprovider",
                                     apkFile,
                                 )
+                            } catch (cause: Throwable) {
+                                Log.e(
+                                    LOG_TAG,
+                                    "Unable to create update FileProvider URI for " +
+                                        apkFile.absolutePath,
+                                    cause,
+                                )
+                                promise.reject(
+                                    "UPDATE_URI_FAILED",
+                                    "Unable to prepare the Android update file",
+                                    cause,
+                                )
+                                return@runOnUiThread
+                            }
+                            Log.i(LOG_TAG, "Update FileProvider URI created: $uri")
+                            try {
                                 installerActivity.startActivity(
                                     Intent(Intent.ACTION_VIEW).apply {
                                         addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
@@ -193,16 +244,27 @@ class MobileSecurityModule(
                                         )
                                     },
                                 )
+                                Log.i(LOG_TAG, "Android package installer activity started")
                                 promise.resolve(null)
                             } catch (cause: Throwable) {
+                                Log.e(LOG_TAG, "Unable to launch Android package installer", cause)
                                 promise.reject(
-                                    "UPDATE_INSTALL_FAILED",
+                                    "UPDATE_INSTALLER_LAUNCH_FAILED",
                                     "Unable to open the Android package installer",
                                     cause,
                                 )
                             }
                         }
+                    } catch (cause: MobileUpdateDownloadFailure) {
+                        Log.e(
+                            LOG_TAG,
+                            "Update download failed: code=${cause.code}, " +
+                                "message=${cause.message}",
+                            cause,
+                        )
+                        promise.reject(cause.code, cause.message, cause)
                     } catch (cause: Throwable) {
+                        Log.e(LOG_TAG, "Unexpected update download failure", cause)
                         promise.reject(
                             "UPDATE_DOWNLOAD_FAILED",
                             cause.message ?: "Unable to download the Android update",
@@ -211,9 +273,10 @@ class MobileSecurityModule(
                     }
                 }
             } catch (cause: Throwable) {
+                Log.e(LOG_TAG, "Unable to schedule Android update download", cause)
                 promise.reject(
-                    "UPDATE_INSTALL_FAILED",
-                    "Unable to open Android install settings",
+                    "UPDATE_EXECUTOR_FAILED",
+                    "Unable to start the Android update download",
                     cause,
                 )
             }
@@ -451,67 +514,8 @@ class MobileSecurityModule(
         super.invalidate()
     }
 
-    private fun downloadUpdate(apkURL: String, expectedSHA256: String): File {
-        val url = URL(apkURL.trim())
-        require(url.protocol == "https:") { "Update URL must use HTTPS" }
-        val expected = expectedSHA256.trim().lowercase(Locale.ROOT)
-        require(expected.matches(Regex("[a-f0-9]{64}"))) {
-            "Update SHA-256 is invalid"
-        }
-
-        val connection = url.openConnection() as HttpURLConnection
-        connection.connectTimeout = UPDATE_CONNECT_TIMEOUT_MS
-        connection.readTimeout = UPDATE_READ_TIMEOUT_MS
-        connection.requestMethod = "GET"
-        connection.setRequestProperty(
-            "Accept",
-            "application/vnd.android.package-archive",
-        )
-        try {
-            val responseCode = connection.responseCode
-            require(responseCode in 200..299) {
-                "Update download failed with HTTP $responseCode"
-            }
-
-            val updateDirectory = File(reactContext.cacheDir, "updates")
-            require(updateDirectory.mkdirs() || updateDirectory.isDirectory) {
-                "Unable to create update cache directory"
-            }
-            val temporaryFile = File(updateDirectory, "tutti-update.apk.part")
-            val apkFile = File(updateDirectory, "tutti-update.apk")
-            val digest = MessageDigest.getInstance("SHA-256")
-            BufferedInputStream(connection.inputStream).use { input ->
-                FileOutputStream(temporaryFile).use { output ->
-                    val buffer = ByteArray(UPDATE_BUFFER_SIZE)
-                    while (true) {
-                        val count = input.read(buffer)
-                        if (count < 0) break
-                        digest.update(buffer, 0, count)
-                        output.write(buffer, 0, count)
-                    }
-                }
-            }
-
-            require(toHex(digest.digest()) == expected) {
-                temporaryFile.delete()
-                "Downloaded update checksum does not match"
-            }
-            require(!apkFile.exists() || apkFile.delete()) {
-                "Unable to replace the cached Android update"
-            }
-            require(temporaryFile.renameTo(apkFile)) {
-                "Unable to finalize the downloaded Android update"
-            }
-            return apkFile
-        } finally {
-            connection.disconnect()
-        }
-    }
-
     companion object {
-        private const val UPDATE_BUFFER_SIZE = 32 * 1024
-        private const val UPDATE_CONNECT_TIMEOUT_MS = 15_000
-        private const val UPDATE_READ_TIMEOUT_MS = 60_000
+        private const val LOG_TAG = "TuttiMobileSecurity"
         private const val QR_SCAN_REQUEST_CODE_MIN = 51731
         private const val QR_SCAN_REQUEST_CODE_MAX = 60000
 

--- a/apps/mobile/android/app/src/main/java/sh/tutti/mobile/MobileSecurityModule.kt
+++ b/apps/mobile/android/app/src/main/java/sh/tutti/mobile/MobileSecurityModule.kt
@@ -2,7 +2,9 @@ package sh.tutti.mobile
 
 import android.app.Activity
 import android.content.Intent
+import android.net.Uri
 import android.os.Build
+import android.provider.Settings
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
 import android.util.Base64
@@ -146,41 +148,72 @@ class MobileSecurityModule(
         expectedSHA256: String,
         promise: Promise,
     ) {
-        updateExecutor.execute {
+        UiThreadUtil.runOnUiThread {
             try {
-                val apkFile = downloadUpdate(apkURL, expectedSHA256)
-                UiThreadUtil.runOnUiThread {
+                val activity = reactContext.currentActivity
+                require(activity != null) { "No active Android activity" }
+                if (
+                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
+                    !reactContext.packageManager.canRequestPackageInstalls()
+                ) {
+                    activity.startActivity(
+                        Intent(
+                            Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
+                            Uri.parse("package:${reactContext.packageName}"),
+                        ),
+                    )
+                    promise.reject(
+                        "UPDATE_INSTALL_PERMISSION_REQUIRED",
+                        "Allow Tutti to install unknown apps, then try again",
+                    )
+                    return@runOnUiThread
+                }
+
+                updateExecutor.execute {
                     try {
-                        val activity = reactContext.currentActivity
-                        require(activity != null) { "No active Android activity" }
-                        val uri = FileProvider.getUriForFile(
-                            reactContext,
-                            "${BuildConfig.APPLICATION_ID}.fileprovider",
-                            apkFile,
-                        )
-                        activity.startActivity(
-                            Intent(Intent.ACTION_VIEW).apply {
-                                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                                setDataAndType(
-                                    uri,
-                                    "application/vnd.android.package-archive",
+                        val apkFile = downloadUpdate(apkURL, expectedSHA256)
+                        UiThreadUtil.runOnUiThread {
+                            try {
+                                val installerActivity = reactContext.currentActivity
+                                require(installerActivity != null) {
+                                    "No active Android activity"
+                                }
+                                val uri = FileProvider.getUriForFile(
+                                    reactContext,
+                                    "${BuildConfig.APPLICATION_ID}.fileprovider",
+                                    apkFile,
                                 )
-                            },
-                        )
-                        promise.resolve(null)
+                                installerActivity.startActivity(
+                                    Intent(Intent.ACTION_VIEW).apply {
+                                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                                        setDataAndType(
+                                            uri,
+                                            "application/vnd.android.package-archive",
+                                        )
+                                    },
+                                )
+                                promise.resolve(null)
+                            } catch (cause: Throwable) {
+                                promise.reject(
+                                    "UPDATE_INSTALL_FAILED",
+                                    "Unable to open the Android package installer",
+                                    cause,
+                                )
+                            }
+                        }
                     } catch (cause: Throwable) {
                         promise.reject(
-                            "UPDATE_INSTALL_FAILED",
-                            "Unable to open the Android package installer",
+                            "UPDATE_DOWNLOAD_FAILED",
+                            cause.message ?: "Unable to download the Android update",
                             cause,
                         )
                     }
                 }
             } catch (cause: Throwable) {
                 promise.reject(
-                    "UPDATE_DOWNLOAD_FAILED",
-                    cause.message ?: "Unable to download the Android update",
+                    "UPDATE_INSTALL_FAILED",
+                    "Unable to open Android install settings",
                     cause,
                 )
             }

--- a/apps/mobile/android/app/src/main/java/sh/tutti/mobile/MobileUpdateDownloader.kt
+++ b/apps/mobile/android/app/src/main/java/sh/tutti/mobile/MobileUpdateDownloader.kt
@@ -1,0 +1,169 @@
+package sh.tutti.mobile
+
+import android.util.Log
+import java.io.BufferedInputStream
+import java.io.File
+import java.io.FileOutputStream
+import java.net.HttpURLConnection
+import java.net.URL
+import java.security.MessageDigest
+import java.util.Locale
+
+internal class MobileUpdateDownloader(
+    private val cacheDir: File,
+) {
+    fun download(apkURL: String, expectedSHA256: String): File {
+        val url = try {
+            URL(apkURL.trim())
+        } catch (cause: Throwable) {
+            throw MobileUpdateDownloadFailure(
+                "UPDATE_URL_INVALID",
+                "Update URL is invalid",
+                cause,
+            )
+        }
+        if (url.protocol != "https:") {
+            throw MobileUpdateDownloadFailure(
+                "UPDATE_URL_INVALID",
+                "Update URL must use HTTPS",
+            )
+        }
+        val expected = expectedSHA256.trim().lowercase(Locale.ROOT)
+        if (!expected.matches(Regex("[a-f0-9]{64}"))) {
+            throw MobileUpdateDownloadFailure(
+                "UPDATE_CHECKSUM_INVALID",
+                "Update SHA-256 is invalid",
+            )
+        }
+        Log.i(
+            LOG_TAG,
+            "Starting update download: host=${url.host}, path=${url.path}, " +
+                "expectedSHA256=$expected",
+        )
+
+        val connection = try {
+            url.openConnection() as HttpURLConnection
+        } catch (cause: Throwable) {
+            throw MobileUpdateDownloadFailure(
+                "UPDATE_CONNECTION_FAILED",
+                "Unable to open update connection",
+                cause,
+            )
+        }
+        connection.connectTimeout = UPDATE_CONNECT_TIMEOUT_MS
+        connection.readTimeout = UPDATE_READ_TIMEOUT_MS
+        connection.requestMethod = "GET"
+        connection.setRequestProperty(
+            "Accept",
+            "application/vnd.android.package-archive",
+        )
+        try {
+            val responseCode = try {
+                connection.responseCode
+            } catch (cause: Throwable) {
+                throw MobileUpdateDownloadFailure(
+                    "UPDATE_HTTP_FAILED",
+                    "Unable to read update HTTP response",
+                    cause,
+                )
+            }
+            Log.i(
+                LOG_TAG,
+                "Update HTTP response: status=$responseCode, " +
+                    "contentLength=${connection.contentLengthLong}",
+            )
+            if (responseCode !in 200..299) {
+                throw MobileUpdateDownloadFailure(
+                    "UPDATE_HTTP_FAILED",
+                    "Update download failed with HTTP $responseCode",
+                )
+            }
+
+            val updateDirectory = File(cacheDir, "updates")
+            if (!updateDirectory.mkdirs() && !updateDirectory.isDirectory) {
+                throw MobileUpdateDownloadFailure(
+                    "UPDATE_CACHE_FAILED",
+                    "Unable to create update cache directory",
+                )
+            }
+            val temporaryFile = File(updateDirectory, "tutti-update.apk.part")
+            val apkFile = File(updateDirectory, "tutti-update.apk")
+            Log.i(
+                LOG_TAG,
+                "Writing update APK to temporary file: ${temporaryFile.absolutePath}",
+            )
+            val digest = MessageDigest.getInstance("SHA-256")
+            var downloadedBytes = 0L
+            try {
+                BufferedInputStream(connection.inputStream).use { input ->
+                    FileOutputStream(temporaryFile).use { output ->
+                        val buffer = ByteArray(UPDATE_BUFFER_SIZE)
+                        while (true) {
+                            val count = input.read(buffer)
+                            if (count < 0) break
+                            digest.update(buffer, 0, count)
+                            output.write(buffer, 0, count)
+                            downloadedBytes += count
+                        }
+                    }
+                }
+            } catch (cause: Throwable) {
+                temporaryFile.delete()
+                throw MobileUpdateDownloadFailure(
+                    "UPDATE_DOWNLOAD_FAILED",
+                    "Unable to write the downloaded Android update",
+                    cause,
+                )
+            }
+
+            val actual = toHex(digest.digest())
+            Log.i(
+                LOG_TAG,
+                "Update download bytes received: $downloadedBytes, actualSHA256=$actual",
+            )
+            if (actual != expected) {
+                temporaryFile.delete()
+                throw MobileUpdateDownloadFailure(
+                    "UPDATE_CHECKSUM_FAILED",
+                    "Downloaded update checksum does not match: " +
+                        "expected=$expected actual=$actual",
+                )
+            }
+            if (apkFile.exists() && !apkFile.delete()) {
+                throw MobileUpdateDownloadFailure(
+                    "UPDATE_CACHE_REPLACE_FAILED",
+                    "Unable to replace the cached Android update",
+                )
+            }
+            if (!temporaryFile.renameTo(apkFile)) {
+                throw MobileUpdateDownloadFailure(
+                    "UPDATE_FILE_FINALIZE_FAILED",
+                    "Unable to finalize the downloaded Android update",
+                )
+            }
+            Log.i(
+                LOG_TAG,
+                "Update APK finalized: ${apkFile.absolutePath}, bytes=${apkFile.length()}",
+            )
+            return apkFile
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    companion object {
+        private const val LOG_TAG = "TuttiMobileSecurity"
+        private const val UPDATE_BUFFER_SIZE = 32 * 1024
+        private const val UPDATE_CONNECT_TIMEOUT_MS = 15_000
+        private const val UPDATE_READ_TIMEOUT_MS = 60_000
+
+        private fun toHex(bytes: ByteArray): String =
+            bytes.joinToString("") { byte -> "%02x".format(byte.toInt() and 0xff) }
+    }
+}
+
+internal class MobileUpdateDownloadFailure(
+    val code: String,
+    message: String,
+    cause: Throwable? = null,
+) : Exception(message, cause)

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -9,6 +9,7 @@ import {
 import { mobileSecurity } from "../native/mobileNative";
 import type { MobileRootStackParamList } from "../navigation/mobileNavigation";
 import type { MobileApplicationService } from "../services/mobileApplicationService";
+import { isMobileUpdateInstallPermissionRequired } from "../services/mobileUpdateService";
 import { SettingsScreenView } from "./SettingsScreenView";
 
 type Props = NativeStackScreenProps<MobileRootStackParamList, "Settings"> & {
@@ -65,8 +66,10 @@ export function SettingsScreen({ application, navigation }: Props) {
             { style: "cancel", text: t("cancel") },
             {
               onPress: () => {
-                void mobileUpdateService.installUpdate().catch(() => {
-                  Alert.alert(t("updateInstallFailed"));
+                void mobileUpdateService.installUpdate().catch((error) => {
+                  if (!isMobileUpdateInstallPermissionRequired(error)) {
+                    Alert.alert(t("updateInstallFailed"));
+                  }
                 });
               },
               text: t("downloadAndInstall")

--- a/apps/mobile/src/services/mobileUpdateService.test.ts
+++ b/apps/mobile/src/services/mobileUpdateService.test.ts
@@ -1,4 +1,5 @@
 import {
+  MOBILE_UPDATE_INSTALL_PERMISSION_REQUIRED,
   MOBILE_UPDATE_SCHEMA_VERSION,
   MobileUpdateService,
   parseMobileUpdateRelease
@@ -52,6 +53,20 @@ test("passes the verified release to the native installer", async () => {
 
   expect(install).toHaveBeenCalledWith(releaseFeed.apkUrl, "a".repeat(64));
   expect(snapshot.status).toBe("installing");
+});
+
+test("keeps the release available when Android install permission is required", async () => {
+  const install = jest.fn<Promise<void>, [string, string]>(async () => {
+    throw { code: MOBILE_UPDATE_INSTALL_PERMISSION_REQUIRED };
+  });
+  const service = createService(releaseFeed, install);
+
+  await service.checkForUpdates();
+  await expect(service.installUpdate()).rejects.toMatchObject({
+    code: MOBILE_UPDATE_INSTALL_PERMISSION_REQUIRED
+  });
+
+  expect(service.getSnapshot().status).toBe("available");
 });
 
 test("rejects a feed for a different package or schema", () => {

--- a/apps/mobile/src/services/mobileUpdateService.ts
+++ b/apps/mobile/src/services/mobileUpdateService.ts
@@ -2,6 +2,8 @@ import { ObservableService } from "./observableService";
 
 export const MOBILE_UPDATE_SCHEMA_VERSION = "tutti.android.mobile.latest.v1";
 export const MOBILE_PACKAGE_NAME = "sh.tutti.mobile";
+export const MOBILE_UPDATE_INSTALL_PERMISSION_REQUIRED =
+  "UPDATE_INSTALL_PERMISSION_REQUIRED";
 
 export type MobileUpdateStatus =
   | "available"
@@ -100,7 +102,11 @@ export class MobileUpdateService extends ObservableService<MobileUpdateSnapshot>
       await this.installer.install(release.apkURL, release.sha256);
       return this.snapshot;
     } catch (error) {
-      this.setSnapshot({ status: "error" });
+      this.setSnapshot({
+        status: isMobileUpdateInstallPermissionRequired(error)
+          ? "available"
+          : "error"
+      });
       throw error;
     }
   }
@@ -220,4 +226,12 @@ function positiveInteger(value: unknown, key: string): number {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isMobileUpdateInstallPermissionRequired(
+  value: unknown
+): boolean {
+  return (
+    isRecord(value) && value.code === MOBILE_UPDATE_INSTALL_PERMISSION_REQUIRED
+  );
 }


### PR DESCRIPTION
## Summary

- guide Android users to the app-specific "install unknown apps" settings before downloading an update
- keep the update available for retry after the permission flow
- add staged Android update logs and distinct native error codes for URL/HTTP, download, checksum, cache finalization, FileProvider URI creation, and package-installer launch failures
- extract APK download and verification into `MobileUpdateDownloader` to keep `MobileSecurityModule` within the repository file-length limit

## Validation

- `pnpm --filter @tutti-os/mobile check`
- `./gradlew app:compileDebugKotlin`
- `pnpm check:changed -- --push-ready`

Logcat can be filtered with:

```sh
adb logcat -v threadtime TuttiMobileSecurity:I '*:S'
```