### PR TITLE
fix(connector-market): show pending installation state

### DIFF
--- a/docs/architecture/connector-market.md
+++ b/docs/architecture/connector-market.md
@@ -264,6 +264,11 @@ synchronizing -> materializing -> ready`; failure is terminal and disposes
   state source, and only its owning service mutates it
 - asynchronous responses are fenced by request sequence, service generation,
   and daemon revision; `dispose()` is idempotent and terminal
+- installation intent is projected into the reactive Market store before the
+  host request starts, so cards and dialogs become busy immediately even when a
+  host keeps the mutation request open until runtime work completes; the local
+  projection is cleared on both success and failure and never replaces daemon
+  installation truth
 - event refreshes are coalesced, daemon reconnect performs a full reload, and
   accepted commands are followed through the operation endpoint or events
 - hosts gate connector-market transport through `canRequest`; Tutti binds it to

--- a/packages/connector/market/src/services/connectorMarketService.interface.ts
+++ b/packages/connector/market/src/services/connectorMarketService.interface.ts
@@ -25,6 +25,7 @@ export interface ConnectorMarketStoreState {
   catalogSections: ConnectorMarketSectionState[];
   connectorsByKey: Record<string, Connector>;
   connectorKeys: string[];
+  pendingInstallationsByConnectorKey: Record<string, true>;
   operationsByConnectorKey: Record<string, ConnectorOperation>;
   authorizingConnectorKeys: Record<string, boolean>;
   lastError: ConnectorMarketErrorShape | null;

--- a/packages/connector/market/src/services/connectorMarketService.test.ts
+++ b/packages/connector/market/src/services/connectorMarketService.test.ts
@@ -216,6 +216,10 @@ test("rejects overlapping mutations for one connector", async () => {
     createRequestId: () => "request-1"
   });
   const first = service.install("github");
+  assert.equal(
+    service.dataStore.pendingInstallationsByConnectorKey.github,
+    true
+  );
   await assert.rejects(service.install("github"), ConnectorMarketBusyError);
   install.resolve({
     connector: connector("github", 1),
@@ -234,8 +238,33 @@ test("rejects overlapping mutations for one connector", async () => {
   await first;
 
   assert.equal(
+    service.dataStore.pendingInstallationsByConnectorKey.github,
+    undefined
+  );
+  assert.equal(
     service.dataStore.operationsByConnectorKey.github?.operationId,
     "operation-1"
+  );
+  service.dispose();
+});
+
+test("clears the projected pending installation when install fails", async () => {
+  const install = deferred<never>();
+  const service = new ConnectorMarketService({
+    backend: backendWith({ installConnector: async () => install.promise })
+  });
+
+  const pending = service.install("github");
+  assert.equal(
+    service.dataStore.pendingInstallationsByConnectorKey.github,
+    true
+  );
+  install.reject(new Error("install failed"));
+  await assert.rejects(pending, /install failed/);
+
+  assert.equal(
+    service.dataStore.pendingInstallationsByConnectorKey.github,
+    undefined
   );
   service.dispose();
 });

--- a/packages/connector/market/src/services/connectorMarketService.ts
+++ b/packages/connector/market/src/services/connectorMarketService.ts
@@ -180,12 +180,15 @@ export class ConnectorMarketService implements IConnectorMarketService {
   }
 
   install(connectorKey: string): Promise<void> {
-    return this.runConnectorMutation(connectorKey, () =>
-      this.dependencies.backend.installConnector({
-        connectorKey,
-        clientRequestId: this.createRequestId(),
-        expectedRevision: this.dataStore.revision
-      })
+    return this.runConnectorMutation(
+      connectorKey,
+      () =>
+        this.dependencies.backend.installConnector({
+          connectorKey,
+          clientRequestId: this.createRequestId(),
+          expectedRevision: this.dataStore.revision
+        }),
+      true
     );
   }
 
@@ -494,13 +497,17 @@ export class ConnectorMarketService implements IConnectorMarketService {
 
   private async runConnectorMutation(
     connectorKey: string,
-    operation: () => Promise<ConnectorMutationResult>
+    operation: () => Promise<ConnectorMutationResult>,
+    projectPendingInstallation = false
   ): Promise<void> {
     if (this.disposed || !this.canRequest()) {
       return;
     }
     const token = this.acquireConnectorMutation(connectorKey);
     const generation = this.dataGeneration;
+    if (projectPendingInstallation) {
+      this.dataStore.pendingInstallationsByConnectorKey[connectorKey] = true;
+    }
     try {
       let result: ConnectorMutationResult;
       try {
@@ -530,6 +537,12 @@ export class ConnectorMarketService implements IConnectorMarketService {
       }
       throw error;
     } finally {
+      if (
+        projectPendingInstallation &&
+        this.connectorMutations.get(connectorKey) === token
+      ) {
+        delete this.dataStore.pendingInstallationsByConnectorKey[connectorKey];
+      }
       this.releaseConnectorMutation(connectorKey, token);
     }
   }

--- a/packages/connector/market/src/services/connectorMarketState.ts
+++ b/packages/connector/market/src/services/connectorMarketState.ts
@@ -17,6 +17,7 @@ export function createConnectorMarketStoreState(): ConnectorMarketStoreState {
     catalogSections: [],
     connectorsByKey: {},
     connectorKeys: [],
+    pendingInstallationsByConnectorKey: {},
     operationsByConnectorKey: {},
     authorizingConnectorKeys: {},
     lastError: null,
@@ -34,6 +35,8 @@ export function clearConnectorMarketStoreState(
   state.catalogSections = initial.catalogSections;
   state.connectorsByKey = initial.connectorsByKey;
   state.connectorKeys = initial.connectorKeys;
+  state.pendingInstallationsByConnectorKey =
+    initial.pendingInstallationsByConnectorKey;
   state.operationsByConnectorKey = initial.operationsByConnectorKey;
   state.authorizingConnectorKeys = initial.authorizingConnectorKeys;
   state.lastError = initial.lastError;

--- a/packages/connector/market/src/services/view/connectorMarketViewBuilder.test.ts
+++ b/packages/connector/market/src/services/view/connectorMarketViewBuilder.test.ts
@@ -65,6 +65,21 @@ test("keeps connector details open through installation and advances to authoriz
     beforeInstall?.description,
     "Manage repositories and pull requests"
   );
+  assert.equal(
+    beforeInstall?.kind === "installation" && beforeInstall.installing,
+    false
+  );
+
+  market.pendingInstallationsByConnectorKey[connector.key] = true;
+  const pendingInstall = buildConnectorMarketView(market, dialogState);
+  assert.equal(pendingInstall.cardsByKey[connector.key]?.action, "busy");
+  assert.equal(pendingInstall.cardsByKey[connector.key]?.status, "installing");
+  assert.equal(
+    pendingInstall.dialog?.kind === "installation" &&
+      pendingInstall.dialog.installing,
+    true
+  );
+  delete market.pendingInstallationsByConnectorKey[connector.key];
 
   connector.installation = { state: "installing" };
   market.connectorsByKey[connector.key] = connector;

--- a/packages/connector/market/src/services/view/connectorMarketViewBuilder.ts
+++ b/packages/connector/market/src/services/view/connectorMarketViewBuilder.ts
@@ -68,7 +68,8 @@ export function buildConnectorMarketView(
       connector.key,
       buildConnectorCardView(
         connector,
-        market.operationsByConnectorKey[connector.key]?.stage ?? null
+        market.operationsByConnectorKey[connector.key]?.stage ?? null,
+        market.pendingInstallationsByConnectorKey[connector.key] === true
       )
     ])
   );
@@ -83,6 +84,11 @@ export function buildConnectorMarketView(
         : undefined,
       uiState.dialog
         ? Boolean(market.authorizingConnectorKeys[uiState.dialog.connectorKey])
+        : false,
+      uiState.dialog
+        ? market.pendingInstallationsByConnectorKey[
+            uiState.dialog.connectorKey
+          ] === true
         : false
     ),
     installedCount,
@@ -125,9 +131,11 @@ function buildCatalogErrorView(
 
 function buildConnectorCardView(
   connector: Connector,
-  operationStage: ConnectorCardView["operationStage"]
+  operationStage: ConnectorCardView["operationStage"],
+  pendingInstallation: boolean
 ): ConnectorCardView {
   const busy =
+    pendingInstallation ||
     ["installing", "updating", "uninstalling"].includes(
       connector.installation.state
     ) ||
@@ -182,7 +190,8 @@ function buildConnectorCardView(
 
 function buildConnectorDialogView(
   connector: Connector | undefined,
-  authorizing: boolean
+  authorizing: boolean,
+  pendingInstallation: boolean
 ): ConnectorDialogView | null {
   if (!connector) {
     return null;
@@ -210,9 +219,9 @@ function buildConnectorDialogView(
   if (!installed || !currentReleaseInstalled) {
     return {
       ...base,
-      installing: ["installing", "updating"].includes(
-        connector.installation.state
-      ),
+      installing:
+        pendingInstallation ||
+        ["installing", "updating"].includes(connector.installation.state),
       kind: "installation",
       updating: installed
     };

--- a/packages/connector/market/src/ui/dialogs/ConnectorInstallationDialog.tsx
+++ b/packages/connector/market/src/ui/dialogs/ConnectorInstallationDialog.tsx
@@ -31,7 +31,11 @@ export function ConnectorInstallationDialog({
   onInstall: () => void;
 }) {
   return (
-    <DialogContent className="max-h-[min(720px,calc(100vh-32px))] overflow-y-auto sm:max-w-[500px]">
+    <DialogContent
+      aria-busy={installing}
+      className="max-h-[min(720px,calc(100vh-32px))] overflow-y-auto sm:max-w-[500px]"
+      showCloseButton={!installing}
+    >
       <DialogHeader className="items-center gap-3 px-6 pt-4 text-center">
         <ConnectorIcon displayName={displayName} iconUrl={iconUrl} size="lg" />
         <DialogTitle>
@@ -49,6 +53,7 @@ export function ConnectorInstallationDialog({
 
       <DialogFooter className="gap-2.5 pt-2 sm:justify-center">
         <Button
+          disabled={installing}
           size="dialog"
           type="button"
           variant="secondary"

--- a/packages/connector/market/src/ui/dialogs/ConnectorMarketDialogs.tsx
+++ b/packages/connector/market/src/ui/dialogs/ConnectorMarketDialogs.tsx
@@ -16,7 +16,14 @@ export function ConnectorMarketDialogs() {
   }
 
   return (
-    <Dialog open onOpenChange={(open) => !open && uiState.closeDialog()}>
+    <Dialog
+      open
+      onOpenChange={(open) =>
+        !open &&
+        !(dialog.kind === "installation" && dialog.installing) &&
+        uiState.closeDialog()
+      }
+    >
       {dialog.kind === "installation" ? (
         <ConnectorInstallationDialog
           description={dialog.description}


### PR DESCRIPTION
## Summary

Connector installation is synchronous from the renderer's point of view, so the authoritative daemon snapshot cannot expose `installing` until after the request returns. Project the accepted local install intent into the observable connector-market store immediately, and clear it on both success and failure.

The installation dialog and connector card now render a busy state immediately, disable duplicate/cancel/close interactions while the operation is pending, and continue to reconcile against daemon-owned state after completion. The public backend protocol and daemon authority remain unchanged.

## Verification

- `pnpm --filter @tutti-os/connector-market test` — 32 tests passed, including immediate pending state and failure cleanup coverage.
- `pnpm --filter @tutti-os/connector-market typecheck`
- `pnpm --filter @tutti-os/connector-market build`
- `pnpm check:changed` — 9 lanes passed before commit; push-ready hook passed 10 lanes.

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter. (N/A: connector market UI state only.)
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. (N/A: no README/CONTRIBUTING changes.)
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
