### PR TITLE
fix(connector): bound durable lifecycle retention

### DIFF
--- a/docs/architecture/connector-market.md
+++ b/docs/architecture/connector-market.md
@@ -228,6 +228,29 @@ which stage to resume. Install and uninstall return verifiable results to the
 application; artifact helpers do not write the business repository or publish
 events directly.
 
+`accepted` and `running` rows have no age-based expiry. The SQLite repository
+protects them with one-active-operation constraints plus renewable,
+token-fenced leases, and daemon startup reschedules every recoverable row. The
+cleanup path is therefore intentionally unable to select an active operation.
+
+Terminal operation results are retained for 24 hours after `updatedAt`, with
+the cutoff inclusive. This is the supported `GET operation` result window and
+the `clientRequestId` idempotency window: repeating the same command identity
+inside the window returns the original operation; after the row expires the
+identity is treated as a new command and normal revision validation applies.
+The renderer polls non-terminal operations with a 250 ms to 2 second backoff. A
+permanent missing result, or a reconnect after the result window, converges
+from the authoritative connector/snapshot projection instead of relying on
+operation history.
+
+Installed release evidence is a current business fact, not operation history.
+The SQLite store records one complete release record per currently installed
+connector in `connector_market_installed_releases`; install completion updates
+it and uninstall completion removes it in the same transaction as the business
+transition. Runtime recovery therefore remains valid after the corresponding
+completed install operation has expired, including when the accepted catalog
+has advanced to a newer release.
+
 Authorization operations must follow the same recovery rule or remain fully
 synchronous without leaving a recoverable `running` operation. A provider uses
 the operation or client request identity to resume without creating duplicate
@@ -239,14 +262,32 @@ Business state and its invalidation event are written to a durable outbox in
 the same SQLite transaction. The host publisher delivers outbox entries through
 its existing event stream and records delivery progress.
 
-Events carry a monotonic revision or sequence and remain invalidation hints.
-Reconnect supports replay from a known sequence; a retention gap tells the
-renderer to reload a full daemon snapshot. The daemon snapshot, not the event,
-is always authoritative.
+Pending outbox entries never expire. Published entries are delivery receipts,
+not the replay or diagnostic authority, and are retained for one hour before
+becoming eligible for deletion. Publication failures and cleanup summaries are
+written as structured daemon logs; the business database is not an unbounded
+diagnostic archive.
 
-Until durable replay exists, a transitional host may publish best-effort events
-only if the renderer also refreshes on daemon reconnect, window resume, and
-command completion. Revision fencing remains required.
+Events carry a monotonic revision or sequence and remain invalidation hints.
+The current host does not use published outbox rows as a replay store, so the
+renderer refreshes on daemon reconnect, window resume, and command completion.
+A future durable replay transport may resume from a known sequence and must
+signal a retention gap so the renderer can reload a full daemon snapshot. The
+daemon snapshot, not the event, is always authoritative, and revision fencing
+remains required.
+
+Lifecycle cleanup runs once when the daemon host starts and then hourly. Each
+SQLite transaction deletes at most 500 eligible terminal operations and 500
+eligible published events, ordered by their indexed terminal/publication time
+and stable identity. A run repeats bounded transactions until neither category
+fills its batch, so an existing expired backlog drains without enlarging a
+transaction. The delete predicates are repeated outside the bounded subqueries
+so a row must still be terminal or published when the write occurs.
+The active-operation partial unique index, terminal-time cleanup index,
+pending-outbox index, and published-outbox cleanup index keep admission,
+delivery, and maintenance scans separate. Multiple daemon/store connections
+may race cleanup safely through SQLite write serialization and idempotent
+predicates.
 
 ## Renderer Boundary
 

--- a/packages/connector/daemon/README.md
+++ b/packages/connector/daemon/README.md
@@ -5,6 +5,12 @@ long-running desktop daemon. It owns bootstrap fencing, recovery ordering,
 operation scheduling, catalog refresh/reconcile scheduling, and durable outbox
 delivery.
 
+The host also starts lifecycle maintenance immediately and repeats it hourly.
+Defaults retain terminal operation lookup/idempotency results for 24 hours and
+published outbox receipts for one hour, with bounded SQLite cleanup batches;
+each run drains eligible backlog through repeated transactions. Active
+operations and pending events are outside the cleanup contract.
+
 The module provides the market catalog projection, while hosts inject their
 HTTP client/proxy policy, request authorization, event publication,
 persistence, and execution ports. Product account policy and generated HTTP

--- a/packages/connector/daemon/host.go
+++ b/packages/connector/daemon/host.go
@@ -22,6 +22,8 @@ type HostConfig struct {
 	Compatibility          market.CompatibilityEvaluator
 	ImplementationRegistry market.ImplementationRegistry
 	Outbox                 market.ChangedEventOutbox
+	Lifecycle              market.LifecycleCleanupStore
+	LifecyclePolicy        LifecycleCleanupPolicy
 	Publisher              ChangedEventPublisher
 }
 
@@ -31,6 +33,7 @@ type Host struct {
 	cancel               context.CancelFunc
 	scheduler            *OperationScheduler
 	outboxDone           chan struct{}
+	lifecycleDone        chan struct{}
 	closeOnce            sync.Once
 	bootstrapMu          sync.Mutex
 	bootstrapped         bool
@@ -122,8 +125,8 @@ func NewHost(parent context.Context, config HostConfig) (*Host, error) {
 	if parent == nil {
 		parent = context.Background()
 	}
-	if config.Outbox == nil || config.Publisher == nil {
-		return nil, errors.New("connector market outbox and publisher are required")
+	if config.Outbox == nil || config.Lifecycle == nil || config.Publisher == nil {
+		return nil, errors.New("connector market outbox, lifecycle cleanup, and publisher are required")
 	}
 	hostContext, cancel := context.WithCancel(parent)
 	scheduler := NewOperationScheduler(hostContext)
@@ -152,6 +155,7 @@ func NewHost(parent context.Context, config HostConfig) (*Host, error) {
 		cancel:             cancel,
 		scheduler:          scheduler,
 		outboxDone:         make(chan struct{}),
+		lifecycleDone:      make(chan struct{}),
 		repository:         config.Repository,
 		implementationHost: config.ImplementationHost,
 		activationGate:     activationGate,
@@ -164,6 +168,11 @@ func NewHost(parent context.Context, config HostConfig) (*Host, error) {
 	go func() {
 		defer close(host.outboxDone)
 		dispatcher.Run(hostContext)
+	}()
+	cleanupWorker := LifecycleCleanupWorker{Store: config.Lifecycle, Policy: config.LifecyclePolicy}
+	go func() {
+		defer close(host.lifecycleDone)
+		cleanupWorker.Run(hostContext)
 	}()
 	return host, nil
 }
@@ -370,6 +379,7 @@ func (host *Host) Close() {
 			_ = closer.Close()
 		}
 		<-host.outboxDone
+		<-host.lifecycleDone
 		host.scheduler.Wait()
 	})
 }

--- a/packages/connector/daemon/host_test.go
+++ b/packages/connector/daemon/host_test.go
@@ -146,6 +146,17 @@ func TestBootstrapRestoresInstalledRuntimeWithoutRefreshingCatalog(t *testing.T)
 	}); err != nil {
 		t.Fatal(err)
 	}
+	cleanup, err := store.CleanupLifecycle(ctx, market.LifecycleCleanupRequest{
+		TerminalOperationsUpdatedThrough: time.Now().UTC(),
+		PublishedEventsPublishedThrough:  time.Now().UTC(),
+		BatchSize:                        10,
+	})
+	if err != nil || cleanup.TerminalOperationsDeleted != 1 {
+		t.Fatalf("pre-restart lifecycle cleanup = %#v, error = %v", cleanup, err)
+	}
+	if _, err := store.Operation(ctx, operation.OperationID); !errors.Is(err, market.ErrNotFound) {
+		t.Fatalf("terminal operation survived cleanup: %v", err)
+	}
 
 	source := &countingCatalogSource{release: release, refreshErr: errors.New("catalog returned 403")}
 	runtime := &activationGateDelegate{reconcileFailures: 1}
@@ -158,6 +169,7 @@ func TestBootstrapRestoresInstalledRuntimeWithoutRefreshingCatalog(t *testing.T)
 		Compatibility:          rejectingCompatibility{},
 		ImplementationRegistry: market.NewImplementationRegistry(nil),
 		Outbox:                 store,
+		Lifecycle:              store,
 		Publisher:              discardChangedEventPublisher{},
 	})
 	if err != nil {

--- a/packages/connector/daemon/workers.go
+++ b/packages/connector/daemon/workers.go
@@ -81,6 +81,102 @@ type ChangedEventPublisher interface {
 	PublishConnectorMarketChanged(context.Context, market.ChangedEvent) error
 }
 
+const (
+	DefaultTerminalOperationRetention = 24 * time.Hour
+	DefaultPublishedEventRetention    = time.Hour
+	DefaultLifecycleCleanupInterval   = time.Hour
+	DefaultLifecycleCleanupBatchSize  = 500
+)
+
+type LifecycleCleanupPolicy struct {
+	TerminalOperationRetention time.Duration
+	PublishedEventRetention    time.Duration
+	Interval                   time.Duration
+	BatchSize                  int
+}
+
+type LifecycleCleanupWorker struct {
+	Store  market.LifecycleCleanupStore
+	Now    func() time.Time
+	Policy LifecycleCleanupPolicy
+}
+
+func (worker LifecycleCleanupWorker) Run(ctx context.Context) {
+	policy := normalizedLifecycleCleanupPolicy(worker.Policy)
+	worker.Policy = policy
+	if err := worker.Cleanup(ctx); err != nil && !errors.Is(err, context.Canceled) {
+		slog.Warn("connector market lifecycle cleanup failed", "error", err)
+	}
+	ticker := time.NewTicker(policy.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := worker.Cleanup(ctx); err != nil && !errors.Is(err, context.Canceled) {
+				slog.Warn("connector market lifecycle cleanup failed", "error", err)
+			}
+		}
+	}
+}
+
+func (worker LifecycleCleanupWorker) Cleanup(ctx context.Context) error {
+	if worker.Store == nil {
+		return errors.New("connector market lifecycle cleanup store is required")
+	}
+	policy := normalizedLifecycleCleanupPolicy(worker.Policy)
+	now := time.Now().UTC()
+	if worker.Now != nil {
+		now = worker.Now().UTC()
+	}
+	request := market.LifecycleCleanupRequest{
+		TerminalOperationsUpdatedThrough: now.Add(-policy.TerminalOperationRetention),
+		PublishedEventsPublishedThrough:  now.Add(-policy.PublishedEventRetention),
+		BatchSize:                        policy.BatchSize,
+	}
+	var total market.LifecycleCleanupResult
+	for {
+		result, err := worker.Store.CleanupLifecycle(ctx, request)
+		if err != nil {
+			return err
+		}
+		total.TerminalOperationsDeleted += result.TerminalOperationsDeleted
+		total.PublishedEventsDeleted += result.PublishedEventsDeleted
+		if result.TerminalOperationsDeleted < int64(policy.BatchSize) &&
+			result.PublishedEventsDeleted < int64(policy.BatchSize) {
+			break
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
+	if total.TerminalOperationsDeleted > 0 || total.PublishedEventsDeleted > 0 {
+		slog.Info("connector market lifecycle cleanup completed",
+			"terminalOperationsDeleted", total.TerminalOperationsDeleted,
+			"publishedEventsDeleted", total.PublishedEventsDeleted,
+			"terminalOperationRetention", policy.TerminalOperationRetention,
+			"publishedEventRetention", policy.PublishedEventRetention)
+	}
+	return nil
+}
+
+func normalizedLifecycleCleanupPolicy(policy LifecycleCleanupPolicy) LifecycleCleanupPolicy {
+	if policy.TerminalOperationRetention <= 0 {
+		policy.TerminalOperationRetention = DefaultTerminalOperationRetention
+	}
+	if policy.PublishedEventRetention <= 0 {
+		policy.PublishedEventRetention = DefaultPublishedEventRetention
+	}
+	if policy.Interval <= 0 {
+		policy.Interval = DefaultLifecycleCleanupInterval
+	}
+	if policy.BatchSize <= 0 || policy.BatchSize > DefaultLifecycleCleanupBatchSize {
+		policy.BatchSize = DefaultLifecycleCleanupBatchSize
+	}
+	return policy
+}
+
 type OutboxDispatcher struct {
 	Outbox    market.ChangedEventOutbox
 	Publisher ChangedEventPublisher

--- a/packages/connector/daemon/workers_test.go
+++ b/packages/connector/daemon/workers_test.go
@@ -57,6 +57,107 @@ func TestOutboxDispatcherMarksOnlyPublishedEvents(t *testing.T) {
 	}
 }
 
+func TestLifecycleCleanupWorkerUsesFiniteRetentionCutoffs(t *testing.T) {
+	now := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+	store := &memoryLifecycleCleanupStore{}
+	worker := LifecycleCleanupWorker{
+		Store: store,
+		Now:   func() time.Time { return now },
+		Policy: LifecycleCleanupPolicy{
+			TerminalOperationRetention: 24 * time.Hour,
+			PublishedEventRetention:    time.Hour,
+			BatchSize:                  37,
+		},
+	}
+	if err := worker.Cleanup(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	requests := store.snapshot()
+	if len(requests) != 1 || !requests[0].TerminalOperationsUpdatedThrough.Equal(now.Add(-24*time.Hour)) ||
+		!requests[0].PublishedEventsPublishedThrough.Equal(now.Add(-time.Hour)) || requests[0].BatchSize != 37 {
+		t.Fatalf("cleanup requests = %#v", requests)
+	}
+}
+
+func TestLifecycleCleanupWorkerRunsAtStartupAndPeriodically(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	store := &memoryLifecycleCleanupStore{called: make(chan struct{}, 3)}
+	worker := LifecycleCleanupWorker{
+		Store:  store,
+		Policy: LifecycleCleanupPolicy{Interval: 5 * time.Millisecond},
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		worker.Run(ctx)
+	}()
+	for range 2 {
+		select {
+		case <-store.called:
+		case <-time.After(time.Second):
+			t.Fatal("lifecycle cleanup worker did not run")
+		}
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("lifecycle cleanup worker did not stop")
+	}
+	if len(store.snapshot()) < 2 {
+		t.Fatalf("cleanup calls = %d, want startup and periodic calls", len(store.snapshot()))
+	}
+}
+
+func TestLifecycleCleanupWorkerDrainsBacklogInBoundedTransactions(t *testing.T) {
+	store := &memoryLifecycleCleanupStore{results: []market.LifecycleCleanupResult{
+		{TerminalOperationsDeleted: 5, PublishedEventsDeleted: 5},
+		{TerminalOperationsDeleted: 5},
+		{TerminalOperationsDeleted: 1},
+	}}
+	worker := LifecycleCleanupWorker{Store: store, Policy: LifecycleCleanupPolicy{BatchSize: 5}}
+	if err := worker.Cleanup(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	requests := store.snapshot()
+	if len(requests) != 3 {
+		t.Fatalf("cleanup calls = %d, want 3 bounded transactions", len(requests))
+	}
+	for _, request := range requests {
+		if request.BatchSize != 5 {
+			t.Fatalf("cleanup batch size = %d, want 5", request.BatchSize)
+		}
+	}
+}
+
+type memoryLifecycleCleanupStore struct {
+	mu       sync.Mutex
+	requests []market.LifecycleCleanupRequest
+	results  []market.LifecycleCleanupResult
+	called   chan struct{}
+}
+
+func (store *memoryLifecycleCleanupStore) CleanupLifecycle(_ context.Context, request market.LifecycleCleanupRequest) (market.LifecycleCleanupResult, error) {
+	store.mu.Lock()
+	store.requests = append(store.requests, request)
+	var result market.LifecycleCleanupResult
+	if len(store.results) > 0 {
+		result = store.results[0]
+		store.results = store.results[1:]
+	}
+	store.mu.Unlock()
+	if store.called != nil {
+		store.called <- struct{}{}
+	}
+	return result, nil
+}
+
+func (store *memoryLifecycleCleanupStore) snapshot() []market.LifecycleCleanupRequest {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	return append([]market.LifecycleCleanupRequest(nil), store.requests...)
+}
+
 type memoryOutbox struct {
 	entries []market.ChangedEventRecord
 	marked  []int64

--- a/packages/connector/host/application_test.go
+++ b/packages/connector/host/application_test.go
@@ -46,6 +46,40 @@ func TestApplicationInstallIsDurableAndIdempotent(t *testing.T) {
 	}
 }
 
+func TestApplicationClientRequestIDIsReusableOnlyAfterTerminalRetention(t *testing.T) {
+	repository := newMemoryRepository(testConnector("github"))
+	scheduler := &memoryScheduler{}
+	application := newTestApplication(t, repository, scheduler, &memoryInstallRuntime{}, CatalogSnapshot{})
+	command := ConnectorMutation{Mutation: Mutation{ClientRequestID: "request-retained", ExpectedRevision: 0}, ConnectorKey: "github"}
+	accepted, err := application.Install(context.Background(), command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := application.ExecuteOperation(context.Background(), accepted.Operation.OperationID); err != nil {
+		t.Fatal(err)
+	}
+	retried, err := application.Install(context.Background(), command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retried.Operation.OperationID != accepted.Operation.OperationID || retried.Operation.State != OperationStateCompleted {
+		t.Fatalf("retained retry = %#v, want completed operation %q", retried.Operation, accepted.Operation.OperationID)
+	}
+
+	// Lifecycle cleanup removes the idempotency key with its terminal result.
+	// A caller reusing that key after the documented window starts a new
+	// operation and must provide the current revision like any fresh command.
+	delete(repository.operations, accepted.Operation.OperationID)
+	command.ExpectedRevision = repository.revision
+	afterRetention, err := application.Install(context.Background(), command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterRetention.Operation.OperationID == accepted.Operation.OperationID || afterRetention.Operation.State != OperationStateAccepted {
+		t.Fatalf("post-retention operation = %#v", afterRetention.Operation)
+	}
+}
+
 func TestApplicationExecutesAcceptedInstall(t *testing.T) {
 	repository := newMemoryRepository(testConnector("github"))
 	scheduler := &memoryScheduler{}

--- a/packages/connector/host/ports.go
+++ b/packages/connector/host/ports.go
@@ -205,3 +205,22 @@ type ChangedEventOutbox interface {
 	PendingChangedEvents(ctx context.Context, limit int) ([]ChangedEventRecord, error)
 	MarkChangedEventPublished(ctx context.Context, sequence int64, publishedAt time.Time) error
 }
+
+// LifecycleCleanupStore removes only terminal operation results and events
+// whose publication has already been recorded. Active operations and pending
+// events are deliberately outside this contract so cleanup cannot weaken
+// crash recovery or at-least-once event delivery.
+type LifecycleCleanupStore interface {
+	CleanupLifecycle(ctx context.Context, request LifecycleCleanupRequest) (LifecycleCleanupResult, error)
+}
+
+type LifecycleCleanupRequest struct {
+	TerminalOperationsUpdatedThrough time.Time
+	PublishedEventsPublishedThrough  time.Time
+	BatchSize                        int
+}
+
+type LifecycleCleanupResult struct {
+	TerminalOperationsDeleted int64
+	PublishedEventsDeleted    int64
+}

--- a/packages/connector/store-sqlite/README.md
+++ b/packages/connector/store-sqlite/README.md
@@ -4,3 +4,9 @@
 of the Connector Host repository and changed-event outbox contracts. Hosts own
 the selected database path and process lifecycle; the module owns schema,
 migration, transactions, revisions, leases, and operation persistence.
+
+Active operations and pending outbox events are durable and never age-pruned.
+The lifecycle cleanup contract removes bounded batches of expired terminal
+operations and already-published events. Installed release evidence is stored
+separately from operation history so runtime recovery does not depend on an
+expired operation row.

--- a/packages/connector/store-sqlite/lifecycle.go
+++ b/packages/connector/store-sqlite/lifecycle.go
@@ -1,0 +1,256 @@
+package storesqlite
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	market "github.com/tutti-os/tutti/packages/connector/host"
+)
+
+const maxLifecycleCleanupBatchSize = 500
+
+func (store *Store) migrateLifecycle(ctx context.Context) error {
+	if _, err := store.db.ExecContext(ctx, `ALTER TABLE connector_market_operations ADD COLUMN updated_at_unix_ms INTEGER NOT NULL DEFAULT 0`); err != nil &&
+		!isDuplicateColumnError(err) {
+		return fmt.Errorf("migrate connector market operation update timestamp: %w", err)
+	}
+	if err := store.backfillLifecycleColumns(ctx); err != nil {
+		return err
+	}
+	statements := []string{
+		`CREATE INDEX IF NOT EXISTS connector_market_operations_terminal_cleanup
+ON connector_market_operations(updated_at_unix_ms, operation_id)
+WHERE state IN ('completed', 'failed')`,
+		`CREATE INDEX IF NOT EXISTS connector_market_outbox_published_cleanup
+ON connector_market_outbox(published_at_unix_ms, sequence)
+WHERE published_at_unix_ms IS NOT NULL`,
+	}
+	for _, statement := range statements {
+		if _, err := store.db.ExecContext(ctx, statement); err != nil {
+			return fmt.Errorf("migrate connector market lifecycle index: %w", err)
+		}
+	}
+	return nil
+}
+
+func isDuplicateColumnError(err error) bool {
+	return err != nil && strings.Contains(strings.ToLower(err.Error()), "duplicate column")
+}
+
+func (store *Store) backfillLifecycleColumns(ctx context.Context) error {
+	tx, err := store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	rows, err := tx.QueryContext(ctx, `
+SELECT operation_id, operation_json FROM connector_market_operations
+WHERE updated_at_unix_ms = 0`)
+	if err != nil {
+		return err
+	}
+	type timestampBackfill struct {
+		operationID string
+		updatedAtMS int64
+	}
+	var updates []timestampBackfill
+	for rows.Next() {
+		var operationID, payload string
+		if err := rows.Scan(&operationID, &payload); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		operation, err := decodeOperation(payload)
+		if err != nil {
+			_ = rows.Close()
+			return err
+		}
+		updates = append(updates, timestampBackfill{operationID: operationID, updatedAtMS: operation.UpdatedAt.UTC().UnixMilli()})
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for _, update := range updates {
+		if _, err := tx.ExecContext(ctx, `UPDATE connector_market_operations SET updated_at_unix_ms = ? WHERE operation_id = ? AND updated_at_unix_ms = 0`,
+			update.updatedAtMS, update.operationID); err != nil {
+			return err
+		}
+	}
+	if err := backfillInstalledReleaseEvidence(ctx, tx); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func backfillInstalledReleaseEvidence(ctx context.Context, tx *sql.Tx) error {
+	rows, err := tx.QueryContext(ctx, `SELECT connector_json FROM connector_market_connectors`)
+	if err != nil {
+		return err
+	}
+	var connectors []market.Connector
+	for rows.Next() {
+		var payload string
+		if err := rows.Scan(&payload); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		connector, err := decodeConnector(payload)
+		if err != nil {
+			_ = rows.Close()
+			return err
+		}
+		connectors = append(connectors, connector)
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for _, connector := range connectors {
+		digest := connector.Installation.InstalledReleaseDigest
+		if digest == "" {
+			continue
+		}
+		var storedDigest string
+		err := tx.QueryRowContext(ctx, `SELECT release_digest FROM connector_market_installed_releases WHERE connector_key = ?`, connector.Key).Scan(&storedDigest)
+		if err == nil && storedDigest == digest {
+			continue
+		}
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		release, found, err := legacyInstalledReleaseEvidence(ctx, tx, connector, digest)
+		if err != nil {
+			return err
+		}
+		if !found {
+			return fmt.Errorf("backfill installed connector release %q for %q: %w", digest, connector.Key, market.ErrNotFound)
+		}
+		if err := saveInstalledReleaseOn(ctx, tx, release); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func legacyInstalledReleaseEvidence(ctx context.Context, tx *sql.Tx, connector market.Connector, digest string) (market.Release, bool, error) {
+	if connector.Release.ReleaseDigest == digest {
+		return connector.Release, true, nil
+	}
+	rows, err := tx.QueryContext(ctx, `SELECT operation_json FROM connector_market_operations
+WHERE connector_key = ? AND kind = ? AND state = ? ORDER BY updated_at_unix_ms DESC`,
+		connector.Key, market.OperationKindInstall, market.OperationStateCompleted)
+	if err != nil {
+		return market.Release{}, false, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var payload string
+		if err := rows.Scan(&payload); err != nil {
+			return market.Release{}, false, err
+		}
+		operation, err := decodeOperation(payload)
+		if err != nil {
+			return market.Release{}, false, err
+		}
+		if operation.Target != nil && operation.Target.Release != nil && operation.Target.ReleaseDigest == digest {
+			return *operation.Target.Release, true, nil
+		}
+	}
+	return market.Release{}, false, rows.Err()
+}
+
+func saveInstalledReleaseEvidenceOn(ctx context.Context, tx *sql.Tx, operation market.Operation) error {
+	if operation.State != market.OperationStateCompleted {
+		return nil
+	}
+	switch operation.Kind {
+	case market.OperationKindInstall:
+		if operation.Target == nil || operation.Target.Release == nil || operation.Target.ReleaseDigest == "" {
+			return errors.New("completed connector install is missing release evidence")
+		}
+		return saveInstalledReleaseOn(ctx, tx, *operation.Target.Release)
+	case market.OperationKindUninstall:
+		_, err := tx.ExecContext(ctx, `DELETE FROM connector_market_installed_releases WHERE connector_key = ?`, operation.ConnectorKey)
+		return err
+	default:
+		return nil
+	}
+}
+
+func saveInstalledReleaseOn(ctx context.Context, tx *sql.Tx, release market.Release) error {
+	payload, err := json.Marshal(release)
+	if err != nil {
+		return err
+	}
+	_, err = tx.ExecContext(ctx, `
+INSERT INTO connector_market_installed_releases (connector_key, release_digest, release_json)
+VALUES (?, ?, ?)
+ON CONFLICT(connector_key) DO UPDATE SET
+  release_digest = excluded.release_digest,
+  release_json = excluded.release_json`, release.ConnectorKey, release.ReleaseDigest, string(payload))
+	return err
+}
+
+func (store *Store) CleanupLifecycle(ctx context.Context, request market.LifecycleCleanupRequest) (market.LifecycleCleanupResult, error) {
+	if request.BatchSize <= 0 || request.BatchSize > maxLifecycleCleanupBatchSize {
+		return market.LifecycleCleanupResult{}, fmt.Errorf("connector market lifecycle cleanup batch size must be between 1 and %d", maxLifecycleCleanupBatchSize)
+	}
+	if request.TerminalOperationsUpdatedThrough.IsZero() || request.PublishedEventsPublishedThrough.IsZero() {
+		return market.LifecycleCleanupResult{}, errors.New("connector market lifecycle cleanup cutoffs are required")
+	}
+	tx, err := store.db.BeginTx(ctx, nil)
+	if err != nil {
+		return market.LifecycleCleanupResult{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	operationResult, err := tx.ExecContext(ctx, `
+DELETE FROM connector_market_operations
+WHERE operation_id IN (
+  SELECT operation_id FROM connector_market_operations
+  WHERE state IN ('completed', 'failed') AND updated_at_unix_ms <= ?
+  ORDER BY updated_at_unix_ms, operation_id LIMIT ?
+)
+AND state IN ('completed', 'failed') AND updated_at_unix_ms <= ?`,
+		request.TerminalOperationsUpdatedThrough.UTC().UnixMilli(), request.BatchSize,
+		request.TerminalOperationsUpdatedThrough.UTC().UnixMilli())
+	if err != nil {
+		return market.LifecycleCleanupResult{}, err
+	}
+	outboxResult, err := tx.ExecContext(ctx, `
+DELETE FROM connector_market_outbox
+WHERE sequence IN (
+  SELECT sequence FROM connector_market_outbox
+  WHERE published_at_unix_ms IS NOT NULL AND published_at_unix_ms <= ?
+  ORDER BY published_at_unix_ms, sequence LIMIT ?
+)
+AND published_at_unix_ms IS NOT NULL AND published_at_unix_ms <= ?`,
+		request.PublishedEventsPublishedThrough.UTC().UnixMilli(), request.BatchSize,
+		request.PublishedEventsPublishedThrough.UTC().UnixMilli())
+	if err != nil {
+		return market.LifecycleCleanupResult{}, err
+	}
+	operationsDeleted, err := operationResult.RowsAffected()
+	if err != nil {
+		return market.LifecycleCleanupResult{}, err
+	}
+	eventsDeleted, err := outboxResult.RowsAffected()
+	if err != nil {
+		return market.LifecycleCleanupResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return market.LifecycleCleanupResult{}, err
+	}
+	return market.LifecycleCleanupResult{
+		TerminalOperationsDeleted: operationsDeleted,
+		PublishedEventsDeleted:    eventsDeleted,
+	}, nil
+}

--- a/packages/connector/store-sqlite/lifecycle_test.go
+++ b/packages/connector/store-sqlite/lifecycle_test.go
@@ -1,0 +1,414 @@
+package storesqlite
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	market "github.com/tutti-os/tutti/packages/connector/host"
+)
+
+func TestStoreCleanupLifecycleHonorsCutoffsBatchesAndProtectedRows(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(ctx, filepath.Join(t.TempDir(), "tuttid.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	cutoff := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+	operations := []market.Operation{
+		lifecycleTestOperation("completed-before", "connector-completed", market.OperationStateCompleted, cutoff.Add(-time.Millisecond)),
+		lifecycleTestOperation("failed-at", "connector-failed", market.OperationStateFailed, cutoff),
+		lifecycleTestOperation("completed-after", "connector-newer", market.OperationStateCompleted, cutoff.Add(time.Millisecond)),
+		lifecycleTestOperation("accepted-old", "connector-accepted", market.OperationStateAccepted, cutoff.Add(-time.Hour)),
+		lifecycleTestOperation("running-old", "connector-running", market.OperationStateRunning, cutoff.Add(-time.Hour)),
+	}
+	if err := store.Transaction(ctx, func(tx market.Transaction) error {
+		for index, operation := range operations {
+			if err := tx.SaveOperation(operation); err != nil {
+				return err
+			}
+			if err := tx.EnqueueConnectorMarketChanged(market.ChangedEvent{OperationID: operation.OperationID, Revision: uint64(index + 1)}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for sequence, publishedAt := range map[int64]time.Time{
+		1: cutoff.Add(-time.Millisecond),
+		2: cutoff,
+		3: cutoff.Add(time.Millisecond),
+		5: cutoff.Add(2 * time.Millisecond),
+	} {
+		if err := store.MarkChangedEventPublished(ctx, sequence, publishedAt); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	request := market.LifecycleCleanupRequest{
+		TerminalOperationsUpdatedThrough: cutoff,
+		PublishedEventsPublishedThrough:  cutoff,
+		BatchSize:                        1,
+	}
+	first, err := store.CleanupLifecycle(ctx, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := store.CleanupLifecycle(ctx, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	third, err := store.CleanupLifecycle(ctx, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.TerminalOperationsDeleted != 1 || first.PublishedEventsDeleted != 1 ||
+		second.TerminalOperationsDeleted != 1 || second.PublishedEventsDeleted != 1 ||
+		third.TerminalOperationsDeleted != 0 || third.PublishedEventsDeleted != 0 {
+		t.Fatalf("cleanup results = %#v, %#v, %#v", first, second, third)
+	}
+	for _, operationID := range []string{"completed-before", "failed-at"} {
+		if _, err := store.Operation(ctx, operationID); !errors.Is(err, market.ErrNotFound) {
+			t.Fatalf("operation %q error = %v, want not found", operationID, err)
+		}
+	}
+	for _, operationID := range []string{"completed-after", "accepted-old", "running-old"} {
+		if _, err := store.Operation(ctx, operationID); err != nil {
+			t.Fatalf("protected operation %q error = %v", operationID, err)
+		}
+	}
+	reusedRequest := lifecycleTestOperation("accepted-reused-request", "connector-reused-request", market.OperationStateAccepted, cutoff.Add(time.Minute))
+	reusedRequest.ClientRequestID = operations[0].ClientRequestID
+	if err := store.Transaction(ctx, func(tx market.Transaction) error {
+		return tx.SaveOperation(reusedRequest)
+	}); err != nil {
+		t.Fatalf("reuse expired client request ID: %v", err)
+	}
+	pending, err := store.PendingChangedEvents(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 1 || pending[0].Sequence != 4 {
+		t.Fatalf("pending events = %#v, want only sequence 4", pending)
+	}
+	var publishedRows int
+	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM connector_market_outbox WHERE published_at_unix_ms IS NOT NULL`).Scan(&publishedRows); err != nil {
+		t.Fatal(err)
+	}
+	if publishedRows != 2 {
+		t.Fatalf("published outbox rows = %d, want 2 protected newer rows", publishedRows)
+	}
+	if _, err := store.CleanupLifecycle(ctx, market.LifecycleCleanupRequest{
+		TerminalOperationsUpdatedThrough: cutoff,
+		PublishedEventsPublishedThrough:  cutoff,
+		BatchSize:                        maxLifecycleCleanupBatchSize + 1,
+	}); err == nil {
+		t.Fatal("oversized lifecycle cleanup batch was accepted")
+	}
+}
+
+func TestStoreCleanupLifecycleIsSafeAcrossConnections(t *testing.T) {
+	ctx := context.Background()
+	databasePath := filepath.Join(t.TempDir(), "tuttid.db")
+	first, err := Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer first.Close()
+	second, err := Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer second.Close()
+	cutoff := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+	if err := first.Transaction(ctx, func(tx market.Transaction) error {
+		for index := range 20 {
+			operation := lifecycleTestOperation(
+				fmt.Sprintf("terminal-%02d", index),
+				fmt.Sprintf("connector-%02d", index),
+				market.OperationStateCompleted,
+				cutoff.Add(-time.Hour),
+			)
+			if err := tx.SaveOperation(operation); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	request := market.LifecycleCleanupRequest{
+		TerminalOperationsUpdatedThrough: cutoff,
+		PublishedEventsPublishedThrough:  cutoff,
+		BatchSize:                        7,
+	}
+	start := make(chan struct{})
+	results := make(chan market.LifecycleCleanupResult, 2)
+	errorsFound := make(chan error, 2)
+	var wait sync.WaitGroup
+	for _, candidate := range []*Store{first, second} {
+		wait.Add(1)
+		go func(store *Store) {
+			defer wait.Done()
+			<-start
+			result, cleanupErr := store.CleanupLifecycle(ctx, request)
+			if cleanupErr != nil {
+				errorsFound <- cleanupErr
+				return
+			}
+			results <- result
+		}(candidate)
+	}
+	close(start)
+	wait.Wait()
+	close(results)
+	close(errorsFound)
+	for cleanupErr := range errorsFound {
+		t.Fatal(cleanupErr)
+	}
+	var deleted int64
+	for result := range results {
+		if result.TerminalOperationsDeleted > int64(request.BatchSize) {
+			t.Fatalf("one cleanup deleted %d operations, batch size %d", result.TerminalOperationsDeleted, request.BatchSize)
+		}
+		deleted += result.TerminalOperationsDeleted
+	}
+	if deleted != 14 {
+		t.Fatalf("concurrent cleanup deleted %d operations, want 14", deleted)
+	}
+	var remaining int
+	if err := first.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM connector_market_operations`).Scan(&remaining); err != nil {
+		t.Fatal(err)
+	}
+	if remaining != 6 {
+		t.Fatalf("remaining operations = %d, want 6", remaining)
+	}
+}
+
+func TestStoreCleanupPreservesRecoverableWorkAcrossReopen(t *testing.T) {
+	ctx := context.Background()
+	databasePath := filepath.Join(t.TempDir(), "tuttid.db")
+	store, err := Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	operation := lifecycleTestOperation(
+		"accepted-restart",
+		"connector-restart",
+		market.OperationStateAccepted,
+		time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC),
+	)
+	if err := store.Transaction(ctx, func(tx market.Transaction) error {
+		if err := tx.SaveOperation(operation); err != nil {
+			return err
+		}
+		return tx.EnqueueConnectorMarketChanged(market.ChangedEvent{
+			ConnectorKey: operation.ConnectorKey,
+			OperationID:  operation.OperationID,
+			Revision:     1,
+		})
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cutoff := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+	if _, err := store.CleanupLifecycle(ctx, market.LifecycleCleanupRequest{
+		TerminalOperationsUpdatedThrough: cutoff,
+		PublishedEventsPublishedThrough:  cutoff,
+		BatchSize:                        10,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	recoverable, err := reopened.RecoverableOperations(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recoverable) != 1 || recoverable[0].OperationID != operation.OperationID {
+		t.Fatalf("recoverable operations = %#v", recoverable)
+	}
+	pending, err := reopened.PendingChangedEvents(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 1 || pending[0].Event.OperationID != operation.OperationID {
+		t.Fatalf("pending events = %#v", pending)
+	}
+}
+
+func TestStoreInstalledReleaseEvidenceSurvivesTerminalCleanupAndReopen(t *testing.T) {
+	ctx := context.Background()
+	databasePath := filepath.Join(t.TempDir(), "tuttid.db")
+	store, err := Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	release := testConnector().Release
+	connector := testConnector()
+	connector.Installation = market.Installation{
+		State:                  market.InstallationStateInstalled,
+		InstalledVersion:       release.Version,
+		InstalledReleaseID:     release.ReleaseID,
+		InstalledReleaseDigest: release.ReleaseDigest,
+	}
+	completedAt := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	operation := lifecycleTestOperation("install-evidence", connector.Key, market.OperationStateCompleted, completedAt)
+	operation.Kind = market.OperationKindInstall
+	operation.Target = &market.OperationTarget{
+		ConnectorKey: connector.Key, Version: release.Version, ReleaseID: release.ReleaseID,
+		ReleaseDigest: release.ReleaseDigest, ArtifactSHA256: release.Artifact.SHA256, Release: &release,
+	}
+	if err := store.Transaction(ctx, func(tx market.Transaction) error {
+		connector.Revision = tx.AdvanceRevision()
+		if err := tx.SaveConnector(connector); err != nil {
+			return err
+		}
+		return tx.SaveOperation(operation)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	connector.Release.Version = "2.0.0"
+	connector.Release.ReleaseID = "43"
+	connector.Release.ReleaseDigest = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+	connector.Release.ManifestDigest = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+	if err := store.Transaction(ctx, func(tx market.Transaction) error {
+		connector.Revision = tx.AdvanceRevision()
+		return tx.SaveConnector(connector)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	result, err := store.CleanupLifecycle(ctx, market.LifecycleCleanupRequest{
+		TerminalOperationsUpdatedThrough: completedAt,
+		PublishedEventsPublishedThrough:  completedAt,
+		BatchSize:                        10,
+	})
+	if err != nil || result.TerminalOperationsDeleted != 1 {
+		t.Fatalf("cleanup result = %#v, error = %v", result, err)
+	}
+	if _, err := store.Operation(ctx, operation.OperationID); !errors.Is(err, market.ErrNotFound) {
+		t.Fatalf("cleaned operation error = %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	got, err := reopened.InstalledRelease(ctx, connector.Key, release.ReleaseDigest)
+	if err != nil || got.ReleaseDigest != release.ReleaseDigest || got.ManifestDigest != release.ManifestDigest {
+		t.Fatalf("installed release = %#v, error = %v", got, err)
+	}
+}
+
+func TestStoreMigrationBackfillsLifecycleTimestampAndInstalledReleaseEvidence(t *testing.T) {
+	ctx := context.Background()
+	databasePath := filepath.Join(t.TempDir(), "tuttid.db")
+	legacy, err := sql.Open("sqlite", databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, statement := range []string{
+		`CREATE TABLE connector_market_connectors (connector_key TEXT PRIMARY KEY, connector_json TEXT NOT NULL)`,
+		`CREATE TABLE connector_market_operations (
+  operation_id TEXT PRIMARY KEY,
+  client_request_id TEXT NOT NULL UNIQUE,
+  connector_key TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  state TEXT NOT NULL,
+  lease_owner TEXT NOT NULL,
+  lease_token INTEGER NOT NULL DEFAULT 0,
+  lease_expires_at_unix_ms INTEGER,
+  operation_json TEXT NOT NULL
+)`,
+	} {
+		if _, err := legacy.ExecContext(ctx, statement); err != nil {
+			_ = legacy.Close()
+			t.Fatal(err)
+		}
+	}
+	installedRelease := testConnector().Release
+	connector := testConnector()
+	connector.Installation = market.Installation{
+		State:                  market.InstallationStateInstalled,
+		InstalledVersion:       installedRelease.Version,
+		InstalledReleaseID:     installedRelease.ReleaseID,
+		InstalledReleaseDigest: installedRelease.ReleaseDigest,
+	}
+	connector.Release.Version = "2.0.0"
+	connector.Release.ReleaseDigest = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+	operation := lifecycleTestOperation(
+		"legacy-install",
+		connector.Key,
+		market.OperationStateCompleted,
+		time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC),
+	)
+	operation.Kind = market.OperationKindInstall
+	operation.Target = &market.OperationTarget{
+		ConnectorKey: connector.Key, Version: installedRelease.Version, ReleaseID: installedRelease.ReleaseID,
+		ReleaseDigest: installedRelease.ReleaseDigest, ArtifactSHA256: installedRelease.Artifact.SHA256, Release: &installedRelease,
+	}
+	connectorPayload, err := json.Marshal(connector)
+	if err != nil {
+		t.Fatal(err)
+	}
+	operationPayload, err := json.Marshal(operation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := legacy.ExecContext(ctx, `INSERT INTO connector_market_connectors (connector_key, connector_json) VALUES (?, ?)`,
+		connector.Key, string(connectorPayload)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := legacy.ExecContext(ctx, `INSERT INTO connector_market_operations (
+operation_id, client_request_id, connector_key, kind, state, lease_owner, lease_token, lease_expires_at_unix_ms, operation_json
+) VALUES (?, ?, ?, ?, ?, '', 0, NULL, ?)`, operation.OperationID, operation.ClientRequestID, operation.ConnectorKey,
+		operation.Kind, operation.State, string(operationPayload)); err != nil {
+		t.Fatal(err)
+	}
+	if err := legacy.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := Open(ctx, databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	var updatedAtMS int64
+	if err := store.db.QueryRowContext(ctx, `SELECT updated_at_unix_ms FROM connector_market_operations WHERE operation_id = ?`, operation.OperationID).Scan(&updatedAtMS); err != nil {
+		t.Fatal(err)
+	}
+	if updatedAtMS != operation.UpdatedAt.UnixMilli() {
+		t.Fatalf("migrated updated timestamp = %d, want %d", updatedAtMS, operation.UpdatedAt.UnixMilli())
+	}
+	release, err := store.InstalledRelease(ctx, connector.Key, installedRelease.ReleaseDigest)
+	if err != nil || release.ReleaseDigest != installedRelease.ReleaseDigest {
+		t.Fatalf("migrated installed release = %#v, error = %v", release, err)
+	}
+}
+
+func lifecycleTestOperation(operationID, connectorKey string, state market.OperationState, updatedAt time.Time) market.Operation {
+	return market.Operation{
+		OperationID: operationID, ClientRequestID: "request-" + operationID, ConnectorKey: connectorKey,
+		Kind: market.OperationKindRefreshCatalog, State: state, Stage: market.OperationStageCompleted,
+		CreatedAt: updatedAt.Add(-time.Minute), UpdatedAt: updatedAt,
+	}
+}

--- a/packages/connector/store-sqlite/store.go
+++ b/packages/connector/store-sqlite/store.go
@@ -25,6 +25,7 @@ type Store struct {
 
 var _ market.Repository = (*Store)(nil)
 var _ market.ChangedEventOutbox = (*Store)(nil)
+var _ market.LifecycleCleanupStore = (*Store)(nil)
 
 func Open(ctx context.Context, dbPath string) (*Store, error) {
 	dbPath = strings.TrimSpace(dbPath)
@@ -92,6 +93,11 @@ VALUES (1, 0, 'stale', '') ON CONFLICT(id) DO NOTHING`,
   connector_key TEXT PRIMARY KEY,
   connector_json TEXT NOT NULL
 )`,
+		`CREATE TABLE IF NOT EXISTS connector_market_installed_releases (
+  connector_key TEXT PRIMARY KEY,
+  release_digest TEXT NOT NULL,
+  release_json TEXT NOT NULL
+)`,
 		`CREATE TABLE IF NOT EXISTS connector_market_operations (
   operation_id TEXT PRIMARY KEY,
   client_request_id TEXT NOT NULL UNIQUE,
@@ -101,6 +107,7 @@ VALUES (1, 0, 'stale', '') ON CONFLICT(id) DO NOTHING`,
   lease_owner TEXT NOT NULL,
 	lease_token INTEGER NOT NULL DEFAULT 0,
   lease_expires_at_unix_ms INTEGER,
+	updated_at_unix_ms INTEGER NOT NULL DEFAULT 0,
   operation_json TEXT NOT NULL
 )`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS connector_market_one_active_operation
@@ -124,7 +131,7 @@ ON connector_market_outbox(published_at_unix_ms, sequence)`,
 		!strings.Contains(strings.ToLower(err.Error()), "duplicate column") {
 		return fmt.Errorf("migrate connector market operation lease token: %w", err)
 	}
-	return nil
+	return store.migrateLifecycle(ctx)
 }
 
 func (store *Store) Snapshot(ctx context.Context) (market.Snapshot, error) {
@@ -299,29 +306,18 @@ WHERE operation_id = ? AND lease_owner = ? AND lease_token = ?`, operationID, ow
 }
 
 func (store *Store) InstalledRelease(ctx context.Context, connectorKey, releaseDigest string) (market.Release, error) {
-	rows, err := store.db.QueryContext(ctx, `SELECT operation_json FROM connector_market_operations WHERE connector_key = ? AND kind = ? AND state = ? ORDER BY operation_id DESC`,
-		connectorKey, market.OperationKindInstall, market.OperationStateCompleted)
+	var payload string
+	err := store.db.QueryRowContext(ctx, `
+SELECT release_json FROM connector_market_installed_releases
+WHERE connector_key = ? AND release_digest = ?`, connectorKey, releaseDigest).Scan(&payload)
 	if err != nil {
-		return market.Release{}, err
+		return market.Release{}, mapNotFound(err)
 	}
-	defer rows.Close()
-	for rows.Next() {
-		var payload string
-		if err := rows.Scan(&payload); err != nil {
-			return market.Release{}, err
-		}
-		operation, err := decodeOperation(payload)
-		if err != nil {
-			return market.Release{}, err
-		}
-		if operation.Target != nil && operation.Target.Release != nil && operation.Target.ReleaseDigest == releaseDigest {
-			return *operation.Target.Release, nil
-		}
+	var release market.Release
+	if err := json.Unmarshal([]byte(payload), &release); err != nil {
+		return market.Release{}, fmt.Errorf("decode installed connector release: %w", err)
 	}
-	if err := rows.Err(); err != nil {
-		return market.Release{}, err
-	}
-	return market.Release{}, market.ErrNotFound
+	return release, nil
 }
 
 func (store *Store) RecoverableOperations(ctx context.Context) ([]market.Operation, error) {
@@ -614,20 +610,22 @@ func saveOperationOn(ctx context.Context, tx *sql.Tx, operation market.Operation
 	result, err := tx.ExecContext(ctx, `
 INSERT INTO connector_market_operations (
   operation_id, client_request_id, connector_key, kind, state,
-  lease_owner, lease_token, lease_expires_at_unix_ms, operation_json
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  lease_owner, lease_token, lease_expires_at_unix_ms, updated_at_unix_ms, operation_json
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(operation_id) DO UPDATE SET
   state = excluded.state,
   lease_owner = excluded.lease_owner,
 	lease_token = excluded.lease_token,
   lease_expires_at_unix_ms = excluded.lease_expires_at_unix_ms,
+	updated_at_unix_ms = excluded.updated_at_unix_ms,
 	operation_json = excluded.operation_json
 WHERE excluded.lease_token = 0 OR (
   connector_market_operations.lease_owner = excluded.lease_owner AND
   connector_market_operations.lease_token = excluded.lease_token
 )`,
 		operation.OperationID, operation.ClientRequestID, operation.ConnectorKey,
-		operation.Kind, operation.State, operation.LeaseOwner, operation.LeaseToken, leaseExpiresAt, string(payload))
+		operation.Kind, operation.State, operation.LeaseOwner, operation.LeaseToken, leaseExpiresAt,
+		operation.UpdatedAt.UTC().UnixMilli(), string(payload))
 	if err != nil {
 		return err
 	}
@@ -638,7 +636,7 @@ WHERE excluded.lease_token = 0 OR (
 	if operation.LeaseToken > 0 && changed != 1 {
 		return market.ErrOperationLeaseLost
 	}
-	return nil
+	return saveInstalledReleaseEvidenceOn(ctx, tx, operation)
 }
 
 func decodeConnector(payload string) (market.Connector, error) {

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -312,7 +312,7 @@ func (w *tuttiWiring) buildWorkspaceModule(ctx context.Context) error {
 		Repository: connectorMarketStore, CatalogSource: connectorCatalog,
 		ArtifactPreparer: artifactPreparer, CLIInstallations: nodePackageInstaller, ImplementationHost: connectorRuntime,
 		Authorization: connectorAuthorization, Compatibility: compatibility,
-		ImplementationRegistry: implementations, Outbox: connectorMarketStore,
+		ImplementationRegistry: implementations, Outbox: connectorMarketStore, Lifecycle: connectorMarketStore,
 		Publisher: eventstreamservice.ConnectorMarketPublisher{Service: events},
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

- retain terminal Connector Market operations for a bounded 24-hour polling/idempotency window
- retain published outbox receipts for one hour while preserving active operations and pending events indefinitely
- persist installed release evidence independently from operation history so runtime recovery survives cleanup
- run indexed, bounded cleanup transactions at daemon startup and hourly, with structured summaries and errors

## Compatibility

This is rebased on the generic market contract from #2088. It does not restore the removed connector-specific trust/grant protocol.

## Validation

- `go test ./...` in connector host, store-sqlite, and daemon modules
- `go test ./service/connectormarket ./api` in services/tuttid
- `go vet ./...` in connector host, store-sqlite, and daemon modules
- `go build ./...` in services/tuttid
- `pnpm check:changed -- --failed-only` (12/12 lanes passed)
- push-ready hook: 13/13 lanes passed