### PR TITLE
feat(connector): support multi-platform execution targets

### DIFF
--- a/docs/architecture/connector-market.md
+++ b/docs/architecture/connector-market.md
@@ -34,6 +34,15 @@ schema versions belong to different APIs and do not imply compatibility.
 The renderer never calls the remote market. The local daemon is authoritative
 for every state rendered by the desktop application.
 
+Connector Manifest v3 keeps one signed release and adds an execution-target
+matrix keyed by canonical Go platform tuples such as `darwin-arm64` and
+`linux-arm64`. The catalog adapter selects the daemon's exact target and
+projects it into the existing single-implementation host contract before
+validation or installation. Target selection never falls back across OS or
+architecture boundaries because runtime ABIs and native executable checksums
+are target-specific release facts. Manifest v1 and market-neutral v2 remain
+read-compatible at this boundary.
+
 ## Ownership
 
 The shared Connector modules own:

--- a/docs/specs/2026-08-03-connector-market-shared-domain.md
+++ b/docs/specs/2026-08-03-connector-market-shared-domain.md
@@ -29,9 +29,11 @@ The Connector Market service owns the authoritative, versioned schema and
 publishes a generated Go client. It exposes published market items with
 immutable artifact keys, digests, and sizes.
 
-This is the first production connector release contract. The existing
-unreleased connector publish and read shape is replaced directly by the
-market-neutral connector `schemaVersion: "2"`; there is no dual-read period.
+Market-neutral connector `schemaVersion: "2"` declares one implementation.
+Connector `schemaVersion: "3"` keeps the same release identity and listing
+model while declaring an implementation matrix keyed by execution target.
+Hosts retain v1/v2 read compatibility and normalize the selected v3 target into
+the existing single-implementation runtime contract.
 
 A release descriptor must bind at least:
 

--- a/packages/connector/daemon/catalog_source.go
+++ b/packages/connector/daemon/catalog_source.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -30,6 +31,9 @@ type CatalogSourceConfig struct {
 	ExpectedMarketType string
 	HTTPClient         *http.Client
 	AuthorizeRequest   RequestAuthorizer
+	// ExecutionTarget selects a Connector v3 target. Empty defaults to the
+	// daemon process GOOS/GOARCH, which is the correct target for desktop Tutti.
+	ExecutionTarget string
 }
 
 type CatalogSource struct {
@@ -37,6 +41,7 @@ type CatalogSource struct {
 	expectedMarketType string
 	httpClient         *http.Client
 	authorizeRequest   RequestAuthorizer
+	executionTarget    string
 }
 
 var _ market.CatalogSource = (*CatalogSource)(nil)
@@ -57,8 +62,18 @@ func NewCatalogSource(config CatalogSourceConfig) (*CatalogSource, error) {
 	if client == nil {
 		return nil, errors.New("connector market HTTP client is required")
 	}
+	executionTarget := strings.TrimSpace(config.ExecutionTarget)
+	var executionTargetErr error
+	if executionTarget == "" {
+		executionTarget, executionTargetErr = market.ExecutionTarget(runtime.GOOS, runtime.GOARCH)
+	} else {
+		executionTarget, executionTargetErr = market.NormalizeExecutionTarget(executionTarget)
+	}
+	if executionTargetErr != nil {
+		return nil, executionTargetErr
+	}
 	return &CatalogSource{baseURL: baseURL, expectedMarketType: expectedMarketType,
-		httpClient: client, authorizeRequest: config.AuthorizeRequest}, nil
+		httpClient: client, authorizeRequest: config.AuthorizeRequest, executionTarget: executionTarget}, nil
 }
 
 func (source *CatalogSource) Refresh(ctx context.Context) (market.CatalogSnapshot, error) {
@@ -152,7 +167,7 @@ func (source *CatalogSource) ListPage(ctx context.Context, input market.CatalogS
 	}
 	entries := make([]market.CatalogEntry, 0, len(payload.Items))
 	for _, item := range payload.Items {
-		release, err := mapItem(item)
+		release, err := source.mapItem(item)
 		if err != nil {
 			return market.CatalogSourcePage{}, err
 		}
@@ -213,7 +228,7 @@ func (source *CatalogSource) getJSON(ctx context.Context, requestPath string, qu
 	return payloadBytes, nil
 }
 
-func mapItem(item wireMarketItem) (market.Release, error) {
+func (source *CatalogSource) mapItem(item wireMarketItem) (market.Release, error) {
 	if item.ItemType != "connector" || item.ItemKey == "" || item.Version == "" || item.Artifact == nil || !safeArtifactKey(item.Artifact.Key) {
 		return market.Release{}, errors.New("connector market item identity is incomplete")
 	}
@@ -222,22 +237,21 @@ func mapItem(item wireMarketItem) (market.Release, error) {
 		return market.Release{}, err
 	}
 	var connectorManifest wireConnectorMarketManifest
-	// Connector manifest v2 is extensible. Unknown fields cannot alter the
-	// semantics of fields already defined by v2; a breaking semantic change
-	// requires a new schemaVersion, which is rejected explicitly below.
+	// Connector market manifests are extensible. Unknown fields cannot alter
+	// the semantics of known fields; breaking changes require a new major.
 	decoder := json.NewDecoder(bytes.NewReader(manifestBytes))
 	if err := decoder.Decode(&connectorManifest); err != nil {
 		return market.Release{}, fmt.Errorf("decode connector market manifest: %w", err)
 	}
-	if connectorManifest.SchemaVersion != "2" || connectorManifest.ItemType != "connector" ||
-		connectorManifest.ItemKey != item.ItemKey || connectorManifest.Version != item.Version {
+	if connectorManifest.ItemType != "connector" || connectorManifest.ItemKey != item.ItemKey || connectorManifest.Version != item.Version {
 		return market.Release{}, errors.New("connector manifest identity does not match item")
 	}
 	if !isSHA256Hex(connectorManifest.Payload.PackageManifestSHA256) {
 		return market.Release{}, errors.New("connector manifest package digest is invalid")
 	}
-	if connectorManifest.Payload.Implementation == nil {
-		return market.Release{}, errors.New("connector manifest does not provide an implementation")
+	implementation, err := source.resolveManifestImplementation(connectorManifest)
+	if err != nil {
+		return market.Release{}, err
 	}
 	releaseDigest := sha256.Sum256([]byte(item.ItemKey + "\x00" + item.Version + "\x00" + item.Artifact.SHA256))
 	iconURL := connectorManifest.Display.IconURL
@@ -245,11 +259,11 @@ func mapItem(item wireMarketItem) (market.Release, error) {
 		iconURL = legacyConnectorIconURL
 	}
 	// The server's v2 envelope is the generic, market-neutral publication
-	// contract. The daemon projects it into the stable host manifest contract;
-	// the two schema versions intentionally describe different boundaries.
+	// contract. V3 selects one target first. Both project into the stable host
+	// manifest contract; these schema versions describe different boundaries.
 	manifest := market.Manifest{SchemaVersion: "1", DisplayName: connectorManifest.Display.Name, IconURL: iconURL,
 		Description: connectorManifest.Display.Description, Permissions: connectorManifest.Payload.Permissions,
-		Implementation: *connectorManifest.Payload.Implementation, AuthorizationKind: connectorManifest.Payload.Authorization.Kind,
+		Implementation: implementation, AuthorizationKind: connectorManifest.Payload.Authorization.Kind,
 		Compatibility: connectorManifest.Payload.Compatibility}
 	release := market.Release{SchemaVersion: "1", ReleaseID: item.ItemKey + "@" + item.Version,
 		ConnectorKey: item.ItemKey, Version: item.Version,
@@ -261,6 +275,24 @@ func mapItem(item wireMarketItem) (market.Release, error) {
 		return market.Release{}, err
 	}
 	return release, nil
+}
+
+func (source *CatalogSource) resolveManifestImplementation(manifest wireConnectorMarketManifest) (market.Implementation, error) {
+	payload := manifest.Payload
+	switch manifest.SchemaVersion {
+	case "2":
+		if payload.Implementation == nil || len(payload.TargetImplementations) != 0 {
+			return market.Implementation{}, errors.New("connector v2 manifest must provide one market-neutral implementation")
+		}
+		return *payload.Implementation, nil
+	case "3":
+		if payload.Implementation != nil || len(payload.TargetImplementations) == 0 {
+			return market.Implementation{}, errors.New("connector v3 manifest must provide targetImplementations")
+		}
+		return market.ResolveTargetImplementation(source.executionTarget, payload.TargetImplementations)
+	default:
+		return market.Implementation{}, fmt.Errorf("connector manifest schemaVersion %q is unsupported", manifest.SchemaVersion)
+	}
 }
 
 type wireMarketResponse struct {
@@ -336,7 +368,8 @@ type wireConnectorManifestPayload struct {
 	PackageManifestSHA256 string                           `json:"packageManifestSha256"`
 	Authorization         wireConnectorAuthorization       `json:"authorization"`
 	Compatibility         market.CompatibilityRequirements `json:"compatibility"`
-	Implementation        *market.Implementation           `json:"implementation"`
+	Implementation        *market.Implementation           `json:"implementation,omitempty"`
+	TargetImplementations map[string]market.Implementation `json:"targetImplementations,omitempty"`
 }
 
 type wireConnectorAuthorization struct {

--- a/packages/connector/daemon/catalog_source_test.go
+++ b/packages/connector/daemon/catalog_source_test.go
@@ -136,13 +136,51 @@ func TestCatalogSourceRejectsLegacyConnectorManifestV1(t *testing.T) {
 }`), &manifest); err != nil {
 		t.Fatal(err)
 	}
-	_, err := mapItem(wireMarketItem{
+	source := &CatalogSource{executionTarget: "darwin-arm64"}
+	_, err := source.mapItem(wireMarketItem{
 		ItemType: "connector", ItemKey: "github", Version: "1.0.0", Manifest: manifest,
 		Artifact:      &wireArtifact{Key: "connectors/github/1.0.0.zip", SHA256: strings.Repeat("c", 64), SizeBytes: 123},
 		PublishedAtMS: 1785801600000,
 	})
 	if err == nil {
 		t.Fatal("legacy connector manifest v1 was accepted")
+	}
+}
+
+func TestCatalogSourceSelectsExactV3ExecutionTarget(t *testing.T) {
+	source := &CatalogSource{expectedMarketType: "overseas", executionTarget: "linux-arm64"}
+	manifest := wireConnectorMarketManifest{
+		SchemaVersion: "3",
+		Payload: wireConnectorManifestPayload{TargetImplementations: map[string]market.Implementation{
+			"darwin-arm64": {Kind: market.ImplementationKindManagedStdio},
+			"linux-arm64":  {Kind: market.ImplementationKindBuiltin},
+		}},
+	}
+	implementation, err := source.resolveManifestImplementation(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if implementation.Kind != market.ImplementationKindBuiltin {
+		t.Fatalf("implementation = %#v", implementation)
+	}
+	delete(manifest.Payload.TargetImplementations, "linux-arm64")
+	if _, err := source.resolveManifestImplementation(manifest); err == nil || !strings.Contains(err.Error(), "linux-arm64") {
+		t.Fatalf("resolveManifestImplementation() error = %v, want missing exact target", err)
+	}
+}
+
+func TestCatalogSourceKeepsV2MarketNeutralImplementation(t *testing.T) {
+	implementation := market.Implementation{Kind: market.ImplementationKindManagedStdio}
+	source := &CatalogSource{expectedMarketType: "domestic", executionTarget: "darwin-arm64"}
+	got, err := source.resolveManifestImplementation(wireConnectorMarketManifest{
+		SchemaVersion: "2",
+		Payload:       wireConnectorManifestPayload{Implementation: &implementation},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Kind != implementation.Kind {
+		t.Fatalf("implementation = %#v", got)
 	}
 }
 
@@ -155,6 +193,9 @@ func TestCatalogSourceRejectsInvalidConfiguration(t *testing.T) {
 	}
 	if _, err := NewCatalogSource(CatalogSourceConfig{BaseURL: "https://example.test", ExpectedMarketType: "overseas"}); err == nil || !strings.Contains(err.Error(), "HTTP client") {
 		t.Fatalf("expected missing HTTP client error, got %v", err)
+	}
+	if _, err := NewCatalogSource(CatalogSourceConfig{BaseURL: "https://example.test", ExpectedMarketType: "overseas", HTTPClient: http.DefaultClient, ExecutionTarget: "linux-aarch64"}); err == nil || !strings.Contains(err.Error(), "execution target") {
+		t.Fatalf("expected invalid execution target error, got %v", err)
 	}
 }
 

--- a/packages/connector/host/execution_target.go
+++ b/packages/connector/host/execution_target.go
@@ -1,0 +1,44 @@
+package host
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var executionTargetPattern = regexp.MustCompile(`^(darwin|linux|windows)-(arm64|amd64)$`)
+
+// ExecutionTarget returns the canonical Connector target key for a Go runtime
+// tuple. Connector manifests use Go's OS and architecture names deliberately,
+// so target selection does not depend on npm, OCI, or vendor-specific aliases.
+func ExecutionTarget(goos, goarch string) (string, error) {
+	return NormalizeExecutionTarget(strings.TrimSpace(goos) + "-" + strings.TrimSpace(goarch))
+}
+
+// NormalizeExecutionTarget validates and canonicalizes an explicit target key.
+func NormalizeExecutionTarget(target string) (string, error) {
+	target = strings.ToLower(strings.TrimSpace(target))
+	if !executionTargetPattern.MatchString(target) {
+		return "", fmt.Errorf("connector execution target %q is unsupported", target)
+	}
+	return target, nil
+}
+
+// ResolveTargetImplementation selects one exact implementation. It never
+// falls back across operating systems or architectures because runtime ABI and
+// native launch checksums are target-specific security properties.
+func ResolveTargetImplementation(target string, implementations map[string]Implementation) (Implementation, error) {
+	var err error
+	target, err = NormalizeExecutionTarget(target)
+	if err != nil {
+		return Implementation{}, err
+	}
+	implementation, ok := implementations[target]
+	if !ok {
+		return Implementation{}, fmt.Errorf("connector does not provide the %s execution target", target)
+	}
+	if implementation.ManagedStdio != nil && !strings.HasSuffix(strings.TrimSpace(implementation.ManagedStdio.Runtime.ABI), "-"+target) {
+		return Implementation{}, fmt.Errorf("connector %s runtime ABI does not match its execution target", target)
+	}
+	return implementation, nil
+}

--- a/packages/connector/host/execution_target_test.go
+++ b/packages/connector/host/execution_target_test.go
@@ -1,0 +1,36 @@
+package host
+
+import "testing"
+
+func TestExecutionTargetUsesCanonicalGoTuple(t *testing.T) {
+	target, err := ExecutionTarget(" Linux ", "ARM64")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target != "linux-arm64" {
+		t.Fatalf("ExecutionTarget() = %q, want linux-arm64", target)
+	}
+	if _, err := ExecutionTarget("linux", "aarch64"); err == nil {
+		t.Fatal("ExecutionTarget() accepted a non-canonical architecture")
+	}
+}
+
+func TestResolveTargetImplementationRequiresExactTarget(t *testing.T) {
+	darwin := Implementation{Kind: ImplementationKindManagedStdio, ManagedStdio: &ManagedStdioImplementation{Runtime: RuntimeRequirement{ABI: "node22-darwin-arm64"}}}
+	linux := Implementation{Kind: ImplementationKindBuiltin}
+	implementations := map[string]Implementation{"darwin-arm64": darwin, "linux-arm64": linux}
+	got, err := ResolveTargetImplementation("linux-arm64", implementations)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Kind != ImplementationKindBuiltin {
+		t.Fatalf("ResolveTargetImplementation() = %#v", got)
+	}
+	if _, err := ResolveTargetImplementation("windows-arm64", implementations); err == nil {
+		t.Fatal("ResolveTargetImplementation() fell back to another target")
+	}
+	implementations["linux-arm64"] = Implementation{Kind: ImplementationKindManagedStdio, ManagedStdio: &ManagedStdioImplementation{Runtime: RuntimeRequirement{ABI: "node22-darwin-arm64"}}}
+	if _, err := ResolveTargetImplementation("linux-arm64", implementations); err == nil {
+		t.Fatal("ResolveTargetImplementation() accepted a mismatched runtime ABI")
+	}
+}


### PR DESCRIPTION
## Summary
- add a host-neutral exact execution-target selector for Connector implementations
- accept legacy v1, market-neutral v2, and target-matrix v3 manifests in the shared catalog adapter
- select the desktop daemon's GOOS/GOARCH target before projecting into the existing runtime contract
- fail closed on missing targets and runtime ABI/target mismatches
- document the v3 target-selection boundary

## Verification
- `go test ./packages/connector/host ./packages/connector/daemon`
- `pnpm check:changed`