### PR TITLE
feat(connector): support account-scoped VM runtimes

### DIFF
--- a/docs/architecture/connector-market.md
+++ b/docs/architecture/connector-market.md
@@ -34,6 +34,14 @@ schema versions belong to different APIs and do not imply compatibility.
 The renderer never calls the remote market. The local daemon is authoritative
 for every state rendered by the desktop application.
 
+Installation is a device fact. Authorization is an account projection. A
+Connector may therefore be installed while inactive for the current account;
+authorization completion or expiry schedules a normal durable runtime
+reconcile without changing installed truth. Every durable lifecycle command
+freezes its `accountId` in `OperationScope`, while short-lived artifact and
+credential grants are passed only through execution ports and are never
+serialized into SQLite.
+
 Connector Manifest v3 keeps one signed release and adds an execution-target
 matrix keyed by canonical Go platform tuples such as `darwin-arm64` and
 `linux-arm64`. The catalog adapter selects the daemon's exact target and
@@ -87,15 +95,17 @@ application or renderer semantics.
 
 ## Artifact And Runtime Boundary
 
-Artifact preparation and runtime activation are different responsibilities:
+Artifact preparation and runtime activation are different responsibilities.
+They may also live on different machines:
 
 ```text
 durable operation
-    -> connector/runtime artifact resolver/downloader
+    -> host artifact port (direct download or account grant issuance)
+    -> connector/runtime artifact resolver/downloader, local or VM-owned
     -> bounded staging download
     -> size and digest verification
     -> safe extraction and packaged-manifest verification
-    -> prepared artifact
+    -> prepared artifact receipt (local path or opaque runtime reference)
     -> connector/runtime implementation adapter
     -> generation-fenced MCP/CLI routes and observed process state
     -> repository result commit
@@ -192,10 +202,14 @@ daemon resolves the artifact key against its configured artifact base URL. The
 production base URL is the public-assets CloudFront prefix
 `https://d27a59zdy4534h.cloudfront.net/tutti/connector-market/`; CloudFront
 serves immutable versioned objects from the private `tsh-public-assets` S3
-origin. The daemon never addresses S3 directly. Downloading is an ordinary
-direct GET without workspace identity. Operations persist the artifact key,
-release identity, digest, and size; the preparer verifies the downloaded bytes
-before installation. Staging and local integration may override the CDN prefix
+origin. The daemon never addresses S3 directly. The Tutti desktop host uses an
+ordinary direct GET without workspace identity. A split control-plane/runtime
+host may instead issue a short-lived presigned artifact grant under the frozen
+account scope and let its runtime machine download directly. The grant is not
+persisted or logged. Both modes verify the immutable object version, release
+digest, artifact digest, and size before installation. Operations persist the
+artifact key, release identity, object version, digest, and size. Staging and
+local integration may override the CDN prefix
 with `TUTTI_CONNECTOR_ARTIFACT_BASE_URL`; production should leave the public
 CloudFront default in place.
 
@@ -217,7 +231,7 @@ use at-least-once execution. Exactly-once execution is not assumed across
 SQLite, the filesystem, runtime activation, and process restarts.
 
 An installation request carries an immutable operation identity and release
-identity. Each stage is idempotent for at least:
+identity plus an explicit account execution scope. Each stage is idempotent for at least:
 
 ```text
 operationId + connectorKey + version + releaseDigest
@@ -264,6 +278,13 @@ Authorization operations must follow the same recovery rule or remain fully
 synchronous without leaving a recoverable `running` operation. A provider uses
 the operation or client request identity to resume without creating duplicate
 external authorization sessions.
+
+For account-scoped runtimes, `AccountRuntimeBindingResolver` maps `none`
+authorization to an always-active device connection. OAuth/API-key connectors
+remain inactive until the current account projection is `connected`; only then
+does the resolver request a one-shot credential-broker grant. `expired`,
+`disconnected`, and missing projections reconcile inactive. Daemon or guest
+restart uses `BootstrapForScope` to rebuild the same projection explicitly.
 
 ## Event Consistency
 

--- a/packages/connector/daemon/README.md
+++ b/packages/connector/daemon/README.md
@@ -15,3 +15,8 @@ The module provides the market catalog projection, while hosts inject their
 HTTP client/proxy policy, request authorization, event publication,
 persistence, and execution ports. Product account policy and generated HTTP
 handlers remain in the consuming daemon.
+
+Hosts with an account-scoped runtime call `BootstrapForScope`; the daemon
+reuses that explicit scope for recovery retries. The legacy `Bootstrap` method
+retains Tutti's device-global behavior through the default runtime-binding
+resolver.

--- a/packages/connector/daemon/README.md
+++ b/packages/connector/daemon/README.md
@@ -20,3 +20,7 @@ Hosts with an account-scoped runtime call `BootstrapForScope`; the daemon
 reuses that explicit scope for recovery retries. The legacy `Bootstrap` method
 retains Tutti's device-global behavior through the default runtime-binding
 resolver.
+
+Remote runtimes inject `CapabilityPublicationController`; bootstrap awaits its
+fail-closed/open commands. Same-process Tutti runtimes remain compatible with
+the synchronous implementation-host publication gate.

--- a/packages/connector/daemon/host.go
+++ b/packages/connector/daemon/host.go
@@ -27,6 +27,13 @@ type HostConfig struct {
 	Lifecycle                market.LifecycleCleanupStore
 	LifecyclePolicy          LifecycleCleanupPolicy
 	Publisher                ChangedEventPublisher
+	Publication              CapabilityPublicationController
+}
+
+// CapabilityPublicationController is the daemon-level publication boundary
+// for runtimes owned by another process or machine.
+type CapabilityPublicationController interface {
+	ApplyCapabilityPublication(context.Context, market.OperationScope, bool) error
 }
 
 type Host struct {
@@ -45,6 +52,7 @@ type Host struct {
 	implementationHost   market.ImplementationHost
 	activationGate       *activationGateHost
 	publicationGate      capabilityPublicationGate
+	publication          CapabilityPublicationController
 }
 
 type capabilityPublicationGate interface {
@@ -160,10 +168,13 @@ func NewHost(parent context.Context, config HostConfig) (*Host, error) {
 		repository:         config.Repository,
 		implementationHost: config.ImplementationHost,
 		activationGate:     activationGate,
+		publication:        config.Publication,
 	}
 	if publicationGate, ok := config.ImplementationHost.(capabilityPublicationGate); ok {
 		host.publicationGate = publicationGate
-		publicationGate.SetCapabilityPublication(false)
+		if host.publication == nil {
+			publicationGate.SetCapabilityPublication(false)
+		}
 	}
 	dispatcher := OutboxDispatcher{Outbox: config.Outbox, Publisher: config.Publisher}
 	go func() {
@@ -205,8 +216,8 @@ func (host *Host) BootstrapForScope(ctx context.Context, scope market.OperationS
 		go host.runCatalogRefreshWorker()
 	}
 	host.activationGate.setOpen(false)
-	if host.publicationGate != nil {
-		host.publicationGate.SetCapabilityPublication(false)
+	if err := host.applyCapabilityPublication(ctx, scope, false); err != nil {
+		return err
 	}
 	committed := false
 	defer func() {
@@ -214,9 +225,7 @@ func (host *Host) BootstrapForScope(ctx context.Context, scope market.OperationS
 			return
 		}
 		host.activationGate.setOpen(false)
-		if host.publicationGate != nil {
-			host.publicationGate.SetCapabilityPublication(false)
-		}
+		_ = host.applyCapabilityPublication(context.Background(), scope, false)
 		fenceContext, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 		if err := host.implementationHost.FailClosed(fenceContext, time.Now().Add(10*time.Second)); err != nil {
@@ -242,12 +251,22 @@ func (host *Host) BootstrapForScope(ctx context.Context, scope market.OperationS
 	if err := host.Application.ReconcileInstalledRuntimesForScope(ctx, scope); err != nil {
 		return err
 	}
-	if host.publicationGate != nil {
-		host.publicationGate.SetCapabilityPublication(true)
+	if err := host.applyCapabilityPublication(ctx, scope, true); err != nil {
+		return err
 	}
 	host.activationGate.markRecovered()
 	host.bootstrapped = true
 	committed = true
+	return nil
+}
+
+func (host *Host) applyCapabilityPublication(ctx context.Context, scope market.OperationScope, enabled bool) error {
+	if host.publication != nil {
+		return host.publication.ApplyCapabilityPublication(ctx, scope, enabled)
+	}
+	if host.publicationGate != nil {
+		host.publicationGate.SetCapabilityPublication(enabled)
+	}
 	return nil
 }
 

--- a/packages/connector/daemon/host.go
+++ b/packages/connector/daemon/host.go
@@ -13,18 +13,20 @@ import (
 )
 
 type HostConfig struct {
-	Repository             market.Repository
-	CatalogSource          market.CatalogSource
-	ArtifactPreparer       market.ArtifactPreparer
-	CLIInstallations       market.CLIInstallationManager
-	ImplementationHost     market.ImplementationHost
-	Authorization          market.AuthorizationProvider
-	Compatibility          market.CompatibilityEvaluator
-	ImplementationRegistry market.ImplementationRegistry
-	Outbox                 market.ChangedEventOutbox
-	Lifecycle              market.LifecycleCleanupStore
-	LifecyclePolicy        LifecycleCleanupPolicy
-	Publisher              ChangedEventPublisher
+	Repository               market.Repository
+	CatalogSource            market.CatalogSource
+	ArtifactPreparer         market.ArtifactPreparer
+	CLIInstallations         market.CLIInstallationManager
+	ImplementationHost       market.ImplementationHost
+	Authorization            market.AuthorizationProvider
+	AuthorizationProjections market.AuthorizationProjectionStore
+	RuntimeBindings          market.RuntimeBindingResolver
+	Compatibility            market.CompatibilityEvaluator
+	ImplementationRegistry   market.ImplementationRegistry
+	Outbox                   market.ChangedEventOutbox
+	Lifecycle                market.LifecycleCleanupStore
+	LifecyclePolicy          LifecycleCleanupPolicy
+	Publisher                ChangedEventPublisher
 }
 
 type Host struct {
@@ -37,6 +39,7 @@ type Host struct {
 	closeOnce            sync.Once
 	bootstrapMu          sync.Mutex
 	bootstrapped         bool
+	bootstrapScope       market.OperationScope
 	refreshWorkerStarted bool
 	repository           market.Repository
 	implementationHost   market.ImplementationHost
@@ -46,10 +49,6 @@ type Host struct {
 
 type capabilityPublicationGate interface {
 	SetCapabilityPublication(bool)
-}
-
-type runtimeProjectionFencer interface {
-	FenceAll(context.Context, time.Time) error
 }
 
 type activationGateHost struct {
@@ -132,15 +131,17 @@ func NewHost(parent context.Context, config HostConfig) (*Host, error) {
 	scheduler := NewOperationScheduler(hostContext)
 	activationGate := newActivationGateHost(config.ImplementationHost)
 	application, err := market.NewApplication(market.ApplicationConfig{
-		Repository:             config.Repository,
-		CatalogSource:          config.CatalogSource,
-		ArtifactPreparer:       config.ArtifactPreparer,
-		CLIInstallations:       config.CLIInstallations,
-		Host:                   activationGate,
-		Authorization:          config.Authorization,
-		Compatibility:          config.Compatibility,
-		Scheduler:              scheduler,
-		ImplementationRegistry: config.ImplementationRegistry,
+		Repository:               config.Repository,
+		CatalogSource:            config.CatalogSource,
+		ArtifactPreparer:         config.ArtifactPreparer,
+		CLIInstallations:         config.CLIInstallations,
+		Host:                     activationGate,
+		Authorization:            config.Authorization,
+		AuthorizationProjections: config.AuthorizationProjections,
+		RuntimeBindings:          config.RuntimeBindings,
+		Compatibility:            config.Compatibility,
+		Scheduler:                scheduler,
+		ImplementationRegistry:   config.ImplementationRegistry,
 	})
 	if err != nil {
 		cancel()
@@ -181,14 +182,23 @@ func NewHost(parent context.Context, config HostConfig) (*Host, error) {
 // remote catalog. Catalog refresh has its own retry loop: a network, auth, or
 // presentation-policy failure must never keep installed MCP/CLI routes fenced.
 func (host *Host) Bootstrap(ctx context.Context) error {
+	return host.BootstrapForScope(ctx, market.OperationScope{})
+}
+
+// BootstrapForScope restores device-installed runtimes for the explicitly
+// active account authority. The scope is retained for retry workers but no
+// short-lived grant is retained by the daemon.
+func (host *Host) BootstrapForScope(ctx context.Context, scope market.OperationScope) error {
 	if host == nil || host.Application == nil {
 		return errors.New("connector market host is unavailable")
 	}
 	host.bootstrapMu.Lock()
 	defer host.bootstrapMu.Unlock()
-	if host.bootstrapped && !host.activationGate.requiresRecovery() {
+	sameScope := host.bootstrapScope == scope
+	if host.bootstrapped && sameScope && !host.activationGate.requiresRecovery() {
 		return nil
 	}
+	host.bootstrapScope = scope
 	host.bootstrapped = false
 	if !host.refreshWorkerStarted {
 		host.refreshWorkerStarted = true
@@ -209,31 +219,27 @@ func (host *Host) Bootstrap(ctx context.Context) error {
 		}
 		fenceContext, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		if fencer, ok := host.implementationHost.(runtimeProjectionFencer); ok {
-			if err := fencer.FenceAll(fenceContext, time.Now().Add(10*time.Second)); err != nil {
-				slog.Error("connector market bootstrap rollback runtime fence failed", "error", err)
-			}
+		if err := host.implementationHost.FailClosed(fenceContext, time.Now().Add(10*time.Second)); err != nil {
+			slog.Error("connector market bootstrap rollback runtime fence failed", "error", err)
 		}
-		if err := host.Application.FenceInstalledRuntimes(fenceContext); err != nil {
+		if err := host.Application.FenceInstalledRuntimesForScope(fenceContext, scope); err != nil {
 			slog.Error("connector market bootstrap rollback fence failed", "error", err)
 		}
 	}()
 	// Fence any route left by an interrupted previous bootstrap before recovery
 	// can replay host-touching operations. Reconcile calls remain staged behind
 	// activationGate until durable local recovery has completed.
-	if fencer, ok := host.implementationHost.(runtimeProjectionFencer); ok {
-		if err := fencer.FenceAll(ctx, time.Now().Add(10*time.Second)); err != nil {
-			return err
-		}
+	if err := host.implementationHost.FailClosed(ctx, time.Now().Add(10*time.Second)); err != nil {
+		return err
 	}
-	if err := host.Application.FenceInstalledRuntimes(ctx); err != nil {
+	if err := host.Application.FenceInstalledRuntimesForScope(ctx, scope); err != nil {
 		return err
 	}
 	if err := host.recoverAndWait(ctx); err != nil {
 		return err
 	}
 	host.activationGate.setOpen(true)
-	if err := host.Application.ReconcileInstalledRuntimes(ctx); err != nil {
+	if err := host.Application.ReconcileInstalledRuntimesForScope(ctx, scope); err != nil {
 		return err
 	}
 	if host.publicationGate != nil {
@@ -264,7 +270,8 @@ func (host *Host) recoverAndWait(ctx context.Context) error {
 			// Remote refresh and authorization operations may legitimately wait on
 			// the network. Recover them, but do not make local route restoration
 			// wait for their terminal state.
-			if candidate.Kind != market.OperationKindInstall && candidate.Kind != market.OperationKindUninstall {
+			if candidate.Kind != market.OperationKindInstall && candidate.Kind != market.OperationKindUninstall &&
+				candidate.Kind != market.OperationKindReconcileRuntime {
 				continue
 			}
 			operation, err := host.Application.GetOperation(ctx, candidate.OperationID)
@@ -324,6 +331,7 @@ func (host *Host) runCatalogRefreshWorker() {
 	for {
 		host.bootstrapMu.Lock()
 		bootstrapped := host.bootstrapped
+		scope := host.bootstrapScope
 		host.bootstrapMu.Unlock()
 		if !bootstrapped {
 			timer := time.NewTimer(bootstrapRetry)
@@ -334,7 +342,7 @@ func (host *Host) runCatalogRefreshWorker() {
 			case <-timer.C:
 			}
 			bootstrapContext, cancel := context.WithTimeout(host.scheduler.ctx, 45*time.Second)
-			err := host.Bootstrap(bootstrapContext)
+			err := host.BootstrapForScope(bootstrapContext, scope)
 			cancel()
 			if err != nil && !errors.Is(err, context.Canceled) {
 				slog.Warn("connector market bootstrap retry failed", "error", err)

--- a/packages/connector/daemon/host_test.go
+++ b/packages/connector/daemon/host_test.go
@@ -16,16 +16,24 @@ type activationGateDelegate struct {
 	reconciles        int
 	reconcileFailures int
 	deactivations     int
+	lastReconcile     market.RuntimeReconcileRequest
 }
 
 func (delegate *activationGateDelegate) Reconcile(_ context.Context, request market.RuntimeReconcileRequest) (market.RuntimeReceipt, error) {
 	delegate.reconciles++
+	delegate.lastReconcile = request
 	if delegate.reconcileFailures > 0 {
 		delegate.reconcileFailures--
 		return market.RuntimeReceipt{}, errors.New("simulated runtime reconcile failure")
 	}
 	return market.RuntimeReceipt{OperationID: request.OperationID, ConnectionID: request.ConnectionID,
 		ConnectorKey: request.Connector.Key, ReleaseDigest: request.Connector.Release.ReleaseDigest, Generation: request.Generation}, nil
+}
+
+type runtimeBindingResolverFunc func(context.Context, market.RuntimeBindingRequest) (market.RuntimeBinding, error)
+
+func (resolve runtimeBindingResolverFunc) ResolveRuntimeBinding(ctx context.Context, request market.RuntimeBindingRequest) (market.RuntimeBinding, error) {
+	return resolve(ctx, request)
 }
 func (delegate *activationGateDelegate) DeactivateRuntime(context.Context, market.RuntimeDeactivationRequest) error {
 	delegate.deactivations++
@@ -160,11 +168,19 @@ func TestBootstrapRestoresInstalledRuntimeWithoutRefreshingCatalog(t *testing.T)
 
 	source := &countingCatalogSource{release: release, refreshErr: errors.New("catalog returned 403")}
 	runtime := &activationGateDelegate{reconcileFailures: 1}
+	bindings := runtimeBindingResolverFunc(func(_ context.Context, request market.RuntimeBindingRequest) (market.RuntimeBinding, error) {
+		connectionID := "device-github"
+		if request.Scope.AccountID != "" {
+			connectionID = "account-" + request.Scope.AccountID
+		}
+		return market.RuntimeBinding{ConnectionID: connectionID, Enabled: true}, nil
+	})
 	host, err := NewHost(ctx, HostConfig{
 		Repository:             store,
 		CatalogSource:          source,
 		ArtifactPreparer:       unavailableArtifactPreparer{},
 		ImplementationHost:     runtime,
+		RuntimeBindings:        bindings,
 		Authorization:          unavailableAuthorization{},
 		Compatibility:          rejectingCompatibility{},
 		ImplementationRegistry: market.NewImplementationRegistry(nil),
@@ -187,11 +203,23 @@ func TestBootstrapRestoresInstalledRuntimeWithoutRefreshingCatalog(t *testing.T)
 	if source.refreshes != 0 || runtime.reconciles != 2 {
 		t.Fatalf("bootstrap refreshes=%d reconciles=%d, want 0 and 2", source.refreshes, runtime.reconciles)
 	}
+	if err := host.BootstrapForScope(ctx, market.OperationScope{AccountID: "account-1"}); err != nil {
+		t.Fatalf("account bootstrap failed: %v", err)
+	}
+	if runtime.reconciles != 3 || runtime.lastReconcile.ConnectionID != "account-account-1" {
+		t.Fatalf("account reconcile = %#v, count = %d", runtime.lastReconcile, runtime.reconciles)
+	}
+	if err := host.BootstrapForScope(ctx, market.OperationScope{AccountID: "account-1"}); err != nil {
+		t.Fatalf("idempotent account bootstrap failed: %v", err)
+	}
+	if runtime.reconciles != 3 {
+		t.Fatalf("unchanged account scope reconciled %d times", runtime.reconciles)
+	}
 
 	if err := host.refreshAndWait(ctx); err == nil || !strings.Contains(err.Error(), "refresh failed") {
 		t.Fatalf("refresh error = %v, want catalog failure", err)
 	}
-	if source.refreshes != 1 || runtime.reconciles != 2 {
+	if source.refreshes != 1 || runtime.reconciles != 3 {
 		t.Fatalf("refreshes=%d reconciles=%d, want catalog retry isolated from runtime", source.refreshes, runtime.reconciles)
 	}
 }

--- a/packages/connector/daemon/host_test.go
+++ b/packages/connector/daemon/host_test.go
@@ -102,6 +102,15 @@ func (discardChangedEventPublisher) PublishConnectorMarketChanged(context.Contex
 	return nil
 }
 
+type recordingPublicationController struct {
+	values []bool
+}
+
+func (controller *recordingPublicationController) ApplyCapabilityPublication(_ context.Context, _ market.OperationScope, enabled bool) error {
+	controller.values = append(controller.values, enabled)
+	return nil
+}
+
 func TestBootstrapRestoresInstalledRuntimeWithoutRefreshingCatalog(t *testing.T) {
 	ctx := context.Background()
 	store, err := marketdata.Open(ctx, filepath.Join(t.TempDir(), "tuttid.db"))
@@ -168,6 +177,7 @@ func TestBootstrapRestoresInstalledRuntimeWithoutRefreshingCatalog(t *testing.T)
 
 	source := &countingCatalogSource{release: release, refreshErr: errors.New("catalog returned 403")}
 	runtime := &activationGateDelegate{reconcileFailures: 1}
+	publication := &recordingPublicationController{}
 	bindings := runtimeBindingResolverFunc(func(_ context.Context, request market.RuntimeBindingRequest) (market.RuntimeBinding, error) {
 		connectionID := "device-github"
 		if request.Scope.AccountID != "" {
@@ -187,6 +197,7 @@ func TestBootstrapRestoresInstalledRuntimeWithoutRefreshingCatalog(t *testing.T)
 		Outbox:                 store,
 		Lifecycle:              store,
 		Publisher:              discardChangedEventPublisher{},
+		Publication:            publication,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -214,6 +225,9 @@ func TestBootstrapRestoresInstalledRuntimeWithoutRefreshingCatalog(t *testing.T)
 	}
 	if runtime.reconciles != 3 {
 		t.Fatalf("unchanged account scope reconciled %d times", runtime.reconciles)
+	}
+	if len(publication.values) == 0 || !publication.values[len(publication.values)-1] {
+		t.Fatalf("publication transitions = %#v, want final open", publication.values)
 	}
 
 	if err := host.refreshAndWait(ctx); err == nil || !strings.Contains(err.Error(), "refresh failed") {

--- a/packages/connector/host/README.md
+++ b/packages/connector/host/README.md
@@ -1,7 +1,7 @@
 # Connector Host
 
 `packages/connector/host` is the host-neutral Connector application core. It
-owns catalog acceptance, installation and authorization state, durable
+owns catalog acceptance, device installation and account authorization projections, durable
 operation transitions, compatibility evaluation, recovery, reconcile intent,
 manifest validation, and the ports implemented by daemon and runtime hosts.
 
@@ -9,3 +9,10 @@ The package contains no HTTP client, SQLite driver, product account state,
 Electron API, absolute state root, or operating-system process policy.
 Lifecycle behavior belongs here when Tutti and another daemon host must observe
 the same result.
+
+`OperationScope` freezes the account authority used by a durable command.
+`RuntimeBindingResolver` derives the connection ID, active/inactive intent and
+one-shot credential grant from that scope. Grants are passed directly to the
+implementation host and cleared after the call; they are never operation
+state. Artifact and CLI ports may return opaque references when execution is
+owned by another machine, while same-machine runtimes may use local paths.

--- a/packages/connector/host/account_runtime_binding.go
+++ b/packages/connector/host/account_runtime_binding.go
@@ -1,0 +1,87 @@
+package host
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var runtimeConnectionIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,190}$`)
+
+// AccountRuntimeBindingResolver derives runtime intent from device-scoped
+// installation plus account-scoped authorization. It never caches grants.
+type AccountRuntimeBindingResolver struct {
+	Projections AuthorizationProjectionStore
+	Credentials CredentialBrokerGrantIssuer
+}
+
+func (resolver AccountRuntimeBindingResolver) ResolveRuntimeBinding(
+	ctx context.Context,
+	request RuntimeBindingRequest,
+) (RuntimeBinding, error) {
+	connectorKey := strings.TrimSpace(request.Connector.Key)
+	if connectorKey == "" {
+		connectorKey = strings.TrimSpace(request.Release.ConnectorKey)
+	}
+	if connectorKey == "" {
+		return RuntimeBinding{}, invalidRequest("connectorKey is required for runtime binding")
+	}
+	if request.Release.Manifest.AuthorizationKind == "none" {
+		return RuntimeBinding{ConnectionID: DeviceRuntimeConnectionID(connectorKey), Enabled: true}, nil
+	}
+	accountID := strings.TrimSpace(request.Scope.AccountID)
+	if accountID == "" {
+		return RuntimeBinding{}, invalidRequest("accountId is required for an authorized connector runtime")
+	}
+	connectionID := AccountRuntimeConnectionID(accountID, connectorKey)
+	if resolver.Projections == nil {
+		return RuntimeBinding{ConnectionID: connectionID, Enabled: false}, nil
+	}
+	projection, err := resolver.Projections.AuthorizationProjection(ctx, accountID, connectorKey)
+	if errors.Is(err, ErrNotFound) {
+		return RuntimeBinding{ConnectionID: connectionID, Enabled: false}, nil
+	}
+	if err != nil {
+		return RuntimeBinding{}, fmt.Errorf("load connector authorization projection: %w", err)
+	}
+	if projection.AccountID != accountID || projection.ConnectorKey != connectorKey {
+		return RuntimeBinding{}, invalidOperationReceipt("authorization projection identity does not match runtime scope")
+	}
+	if projectedConnectionID := strings.TrimSpace(projection.ConnectionID); projectedConnectionID != "" {
+		connectionID = projectedConnectionID
+	}
+	if !runtimeConnectionIDPattern.MatchString(connectionID) {
+		return RuntimeBinding{}, invalidOperationReceipt("authorization projection connection id is invalid")
+	}
+	if projection.State != AuthorizationStateConnected {
+		return RuntimeBinding{ConnectionID: connectionID, Enabled: false}, nil
+	}
+	if request.Purpose == RuntimeBindingPurposeDeactivate {
+		return RuntimeBinding{ConnectionID: connectionID, Enabled: true}, nil
+	}
+	if resolver.Credentials == nil {
+		return RuntimeBinding{}, NewDomainError(ErrorCodeUnavailable, "credential broker grant issuer is not registered", true, nil)
+	}
+	grant, err := resolver.Credentials.IssueCredentialBrokerGrant(ctx, accountID, connectorKey, connectionID)
+	if err != nil {
+		clear(grant)
+		return RuntimeBinding{}, fmt.Errorf("issue connector credential broker grant: %w", err)
+	}
+	if len(grant) == 0 {
+		return RuntimeBinding{}, invalidOperationReceipt("credential broker grant issuer returned an empty grant")
+	}
+	return RuntimeBinding{ConnectionID: connectionID, Enabled: true, CredentialBrokerGrant: grant}, nil
+}
+
+func DeviceRuntimeConnectionID(connectorKey string) string {
+	return "device-" + strings.TrimSpace(connectorKey)
+}
+
+func AccountRuntimeConnectionID(accountID, connectorKey string) string {
+	digest := sha256.Sum256([]byte(strings.TrimSpace(accountID) + "\x00" + strings.TrimSpace(connectorKey)))
+	return "account-" + hex.EncodeToString(digest[:16])
+}

--- a/packages/connector/host/account_runtime_binding_test.go
+++ b/packages/connector/host/account_runtime_binding_test.go
@@ -1,0 +1,96 @@
+package host
+
+import (
+	"context"
+	"testing"
+)
+
+func TestAccountRuntimeBindingResolverKeepsAuthorizedConnectorInactiveWithoutProjection(t *testing.T) {
+	release := testReleaseWithImplementation("github", "1.0.0", ImplementationKindManagedStdio)
+	release.Manifest.AuthorizationKind = "oauth2"
+	resolver := AccountRuntimeBindingResolver{}
+	binding, err := resolver.ResolveRuntimeBinding(context.Background(), RuntimeBindingRequest{
+		Scope: OperationScope{AccountID: "account-1"}, Connector: Connector{Key: "github"}, Release: release,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if binding.Enabled || binding.ConnectionID != AccountRuntimeConnectionID("account-1", "github") {
+		t.Fatalf("binding = %#v", binding)
+	}
+}
+
+func TestAccountRuntimeBindingResolverIssuesGrantOnlyForConnectedProjection(t *testing.T) {
+	release := testReleaseWithImplementation("github", "1.0.0", ImplementationKindManagedStdio)
+	release.Manifest.AuthorizationKind = "oauth2"
+	projections := &authorizationProjectionStoreStub{projection: AuthorizationProjection{
+		AccountID: "account-1", ConnectorKey: "github", ConnectionID: "server-connection", State: AuthorizationStateConnected,
+	}}
+	credentials := &credentialGrantIssuerStub{grant: []byte("grant")}
+	resolver := AccountRuntimeBindingResolver{Projections: projections, Credentials: credentials}
+	binding, err := resolver.ResolveRuntimeBinding(context.Background(), RuntimeBindingRequest{
+		Scope: OperationScope{AccountID: "account-1"}, Connector: Connector{Key: "github"}, Release: release,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !binding.Enabled || binding.ConnectionID != "server-connection" || string(binding.CredentialBrokerGrant) != "grant" || credentials.calls != 1 {
+		t.Fatalf("binding = %#v, credential calls = %d", binding, credentials.calls)
+	}
+	projections.projection.State = AuthorizationStateExpired
+	binding, err = resolver.ResolveRuntimeBinding(context.Background(), RuntimeBindingRequest{
+		Scope: OperationScope{AccountID: "account-1"}, Connector: Connector{Key: "github"}, Release: release,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if binding.Enabled || len(binding.CredentialBrokerGrant) != 0 || credentials.calls != 1 {
+		t.Fatalf("expired binding = %#v, credential calls = %d", binding, credentials.calls)
+	}
+	projections.projection.State = AuthorizationStateConnected
+	binding, err = resolver.ResolveRuntimeBinding(context.Background(), RuntimeBindingRequest{
+		Scope: OperationScope{AccountID: "account-1"}, Purpose: RuntimeBindingPurposeDeactivate,
+		Connector: Connector{Key: "github"}, Release: release,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !binding.Enabled || len(binding.CredentialBrokerGrant) != 0 || credentials.calls != 1 {
+		t.Fatalf("deactivation binding = %#v, credential calls = %d", binding, credentials.calls)
+	}
+}
+
+func TestAccountRuntimeBindingResolverUsesDeviceBindingForNoAuthConnector(t *testing.T) {
+	release := testReleaseWithImplementation("github", "1.0.0", ImplementationKindManagedStdio)
+	binding, err := (AccountRuntimeBindingResolver{}).ResolveRuntimeBinding(context.Background(), RuntimeBindingRequest{
+		Connector: Connector{Key: "github"}, Release: release,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !binding.Enabled || binding.ConnectionID != "device-github" {
+		t.Fatalf("binding = %#v", binding)
+	}
+}
+
+type authorizationProjectionStoreStub struct {
+	projection AuthorizationProjection
+}
+
+func (store *authorizationProjectionStoreStub) AuthorizationProjection(context.Context, string, string) (AuthorizationProjection, error) {
+	return store.projection, nil
+}
+
+func (*authorizationProjectionStoreStub) SaveAuthorizationProjection(context.Context, AuthorizationProjection) error {
+	return nil
+}
+
+type credentialGrantIssuerStub struct {
+	grant []byte
+	calls int
+}
+
+func (issuer *credentialGrantIssuerStub) IssueCredentialBrokerGrant(context.Context, string, string, string) ([]byte, error) {
+	issuer.calls++
+	return issuer.grant, nil
+}

--- a/packages/connector/host/application.go
+++ b/packages/connector/host/application.go
@@ -15,20 +15,22 @@ import (
 )
 
 type ApplicationConfig struct {
-	Repository             Repository
-	CatalogSource          CatalogSource
-	ArtifactPreparer       ArtifactPreparer
-	CLIInstallations       CLIInstallationManager
-	Host                   ImplementationHost
-	Authorization          AuthorizationProvider
-	Compatibility          CompatibilityEvaluator
-	Scheduler              OperationScheduler
-	ImplementationRegistry ImplementationRegistry
-	WorkerID               string
-	BootEpoch              string
-	LeaseDuration          time.Duration
-	Now                    func() time.Time
-	NewID                  func() (string, error)
+	Repository               Repository
+	CatalogSource            CatalogSource
+	ArtifactPreparer         ArtifactPreparer
+	CLIInstallations         CLIInstallationManager
+	Host                     ImplementationHost
+	Authorization            AuthorizationProvider
+	AuthorizationProjections AuthorizationProjectionStore
+	RuntimeBindings          RuntimeBindingResolver
+	Compatibility            CompatibilityEvaluator
+	Scheduler                OperationScheduler
+	ImplementationRegistry   ImplementationRegistry
+	WorkerID                 string
+	BootEpoch                string
+	LeaseDuration            time.Duration
+	Now                      func() time.Time
+	NewID                    func() (string, error)
 }
 
 type Application struct {
@@ -62,6 +64,9 @@ func NewApplication(config ApplicationConfig) (*Application, error) {
 	}
 	if config.Authorization == nil {
 		return nil, errors.New("connector market authorization provider is required")
+	}
+	if config.RuntimeBindings == nil {
+		config.RuntimeBindings = defaultRuntimeBindingResolver{}
 	}
 	if config.Compatibility == nil {
 		return nil, errors.New("connector market compatibility evaluator is required")
@@ -453,6 +458,8 @@ func (application *Application) executeOperation(ctx context.Context, operationI
 		executeErr = application.executeInstall(executionContext, operation)
 	case OperationKindUninstall:
 		executeErr = application.executeUninstall(executionContext, operation)
+	case OperationKindReconcileRuntime:
+		executeErr = application.executeRuntimeReconcile(executionContext, operation)
 	case OperationKindDisconnectAuthorization:
 		executeErr = application.executeDisconnectAuthorization(executionContext, operation)
 	case OperationKindStartAuthorization:
@@ -540,7 +547,7 @@ func (application *Application) Recover(ctx context.Context) error {
 
 func operationTouchesImplementationHost(kind OperationKind) bool {
 	switch kind {
-	case OperationKindInstall, OperationKindUninstall:
+	case OperationKindInstall, OperationKindUninstall, OperationKindReconcileRuntime:
 		return true
 	default:
 		return false
@@ -573,79 +580,6 @@ func (application *Application) adoptRuntimeOperation(ctx context.Context, opera
 	return adopted, err
 }
 
-// ReconcileInstalledRuntimes rebuilds one global runtime projection for every
-// installed connector.
-func (application *Application) ReconcileInstalledRuntimes(ctx context.Context) error {
-	if application == nil {
-		return NewDomainError(ErrorCodeUnavailable, "connector application is unavailable", false, nil)
-	}
-	snapshot, err := application.config.Repository.Snapshot(ctx)
-	if err != nil {
-		return err
-	}
-	for _, connector := range snapshot.Connectors {
-		if connector.Installation.State != InstallationStateInstalled {
-			continue
-		}
-		installedRelease, evidenceErr := application.installedReleaseEvidence(ctx, connector)
-		if evidenceErr != nil {
-			return NewDomainError(ErrorCodeUnavailable, "installed connector release evidence is unavailable", false, nil)
-		}
-		if validationErr := ValidateRuntimeReleaseShape(installedRelease); validationErr != nil {
-			return NewDomainError(ErrorCodeUnavailable, "installed connector release evidence is invalid", false, validationErr)
-		}
-		installedConnector := connector
-		installedConnector.Release = installedRelease
-		generation := maxGeneration(connector.Revision)
-		operationID := "reconcile/" + application.config.BootEpoch + "/" + connector.Key
-		receipt, err := application.config.Host.Reconcile(ctx, RuntimeReconcileRequest{
-			OperationID: operationID, ConnectionID: defaultConnectorConnectionID,
-			Connector: installedConnector, Enabled: true,
-			Generation: HostGeneration{BootEpoch: application.config.BootEpoch, Generation: generation},
-		})
-		if err != nil {
-			return NewDomainError(ErrorCodeUnavailable, "connector runtime could not be reconciled", true, err)
-		}
-		if err := validateRuntimeReceipt(receipt, operationID, defaultConnectorConnectionID, connector.Key,
-			installedRelease.ReleaseDigest, HostGeneration{BootEpoch: application.config.BootEpoch, Generation: generation}); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// FenceInstalledRuntimes removes runtime projections without deleting install
-// facts.
-func (application *Application) FenceInstalledRuntimes(ctx context.Context) error {
-	if application == nil {
-		return NewDomainError(ErrorCodeUnavailable, "connector application is unavailable", false, nil)
-	}
-	snapshot, err := application.config.Repository.Snapshot(ctx)
-	if err != nil {
-		return err
-	}
-	var fenceErrors []error
-	for _, connector := range snapshot.Connectors {
-		if connector.Installation.State != InstallationStateInstalled {
-			continue
-		}
-		fenceErrors = append(fenceErrors, application.config.Host.DeactivateRuntime(ctx, RuntimeDeactivationRequest{
-			ConnectionID: defaultConnectorConnectionID, ConnectorKey: connector.Key,
-			ReleaseDigest: connector.Installation.InstalledReleaseDigest,
-			Generation:    HostGeneration{BootEpoch: application.config.BootEpoch, Generation: maxGeneration(connector.Revision)},
-			Deadline:      application.config.Now().UTC().Add(5 * time.Second),
-		}))
-	}
-	return errors.Join(fenceErrors...)
-}
-
-func maxGeneration(generation uint64) uint64 {
-	if generation == 0 {
-		return 1
-	}
-	return generation
-}
-
 func (application *Application) acceptConnectorOperation(
 	ctx context.Context,
 	mutation ConnectorMutation,
@@ -662,7 +596,7 @@ func (application *Application) acceptConnectorOperation(
 			return err
 		}
 		if existing != nil {
-			if err := verifyIdempotentOperation(*existing, kind, mutation.ConnectorKey); err != nil {
+			if err := verifyIdempotentOperation(*existing, kind, mutation.ConnectorKey, mutation.AccountID); err != nil {
 				return err
 			}
 			connector, err := tx.Connector(mutation.ConnectorKey)
@@ -698,13 +632,14 @@ func (application *Application) acceptConnectorOperation(
 			ClientRequestID: mutation.ClientRequestID,
 			ConnectorKey:    mutation.ConnectorKey,
 			Kind:            kind,
+			Scope:           OperationScope{AccountID: strings.TrimSpace(mutation.AccountID)},
 			State:           OperationStateAccepted,
 			Stage:           OperationStageAccepted,
 			Target:          operationTarget(kind, connector),
 			CreatedAt:       now,
 			UpdatedAt:       now,
 		}
-		if kind == OperationKindInstall || kind == OperationKindUninstall {
+		if kind == OperationKindInstall || kind == OperationKindUninstall || kind == OperationKindReconcileRuntime {
 			operation.HostGeneration = HostGeneration{BootEpoch: application.config.BootEpoch, Generation: revision}
 		}
 		if err := tx.SaveConnector(connector); err != nil {
@@ -751,7 +686,7 @@ func (application *Application) acceptOperation(
 			return err
 		}
 		if existing != nil {
-			if err := verifyIdempotentOperation(*existing, kind, connectorKey); err != nil {
+			if err := verifyIdempotentOperation(*existing, kind, connectorKey, ""); err != nil {
 				return err
 			}
 			result = MutationResult{Operation: *existing, Revision: tx.Revision()}
@@ -837,8 +772,9 @@ func verifyRevision(tx Transaction, expected uint64) error {
 	)
 }
 
-func verifyIdempotentOperation(operation Operation, kind OperationKind, connectorKey string) error {
-	if operation.Kind != kind || operation.ConnectorKey != connectorKey {
+func verifyIdempotentOperation(operation Operation, kind OperationKind, connectorKey, accountID string) error {
+	if operation.Kind != kind || operation.ConnectorKey != connectorKey ||
+		operation.Scope.AccountID != strings.TrimSpace(accountID) {
 		return invalidRequest("clientRequestId was already used for a different connector-market command")
 	}
 	return nil
@@ -894,7 +830,7 @@ func operationTarget(kind OperationKind, connector Connector) *OperationTarget {
 			Release:        &release,
 		}
 	}
-	if kind == OperationKindUninstall {
+	if kind == OperationKindUninstall || kind == OperationKindReconcileRuntime {
 		return &OperationTarget{
 			ConnectorKey:  connector.Key,
 			Version:       connector.Installation.InstalledVersion,

--- a/packages/connector/host/application_execution.go
+++ b/packages/connector/host/application_execution.go
@@ -114,6 +114,8 @@ func (application *Application) executeInstall(ctx context.Context, operation Op
 	}
 	prepared, prepareErr := application.config.ArtifactPreparer.Prepare(ctx, PrepareArtifactRequest{
 		OperationID: operation.OperationID,
+		Scope:       operation.Scope,
+		Generation:  operation.HostGeneration,
 		Release:     release,
 	})
 	if prepareErr != nil {
@@ -141,6 +143,8 @@ func (application *Application) executeInstall(ctx context.Context, operation Op
 		}
 		installed, installErr := application.config.CLIInstallations.InstallCLI(ctx, InstallCLIRequest{
 			OperationID: operation.OperationID,
+			Scope:       operation.Scope,
+			Generation:  operation.HostGeneration,
 			Release:     release,
 		})
 		if installErr != nil {
@@ -200,10 +204,15 @@ func (application *Application) rolloutInstalledBindings(ctx context.Context, op
 	if strings.TrimSpace(generation.BootEpoch) == "" || generation.Generation == 0 {
 		return rollout, invalidOperationReceipt("install rollout generation is missing")
 	}
-	for _, connectionID := range []string{defaultConnectorConnectionID} {
+	binding, err := application.resolveRuntimeBinding(ctx, operation, connector, release, RuntimeBindingPurposeReconcile)
+	if err != nil {
+		return rollout, err
+	}
+	for _, connectionID := range []string{binding.ConnectionID} {
 		operationID := operation.OperationID + "/rollout/" + connectionID
-		receipt, reconcileErr := application.config.Host.Reconcile(ctx, RuntimeReconcileRequest{
-			OperationID: operationID, ConnectionID: connectionID, Connector: connector, Enabled: true, Generation: generation,
+		receipt, reconcileErr := application.reconcileRuntime(ctx, RuntimeReconcileRequest{
+			OperationID: operationID, Scope: operation.Scope, ConnectionID: connectionID, Connector: connector,
+			Enabled: binding.Enabled, Generation: generation, CredentialBrokerGrant: binding.CredentialBrokerGrant,
 		})
 		if reconcileErr == nil {
 			reconcileErr = validateRuntimeReceipt(receipt, operationID, connectionID,
@@ -227,7 +236,7 @@ func (application *Application) rollbackInstalledBindings(ctx context.Context, o
 		connectionID := rollout.applied[index]
 		if rollout.previous == nil {
 			rollbackErrors = append(rollbackErrors, application.config.Host.DeactivateRuntime(ctx, RuntimeDeactivationRequest{
-				ConnectionID: connectionID, ConnectorKey: operation.ConnectorKey,
+				Scope: operation.Scope, ConnectionID: connectionID, ConnectorKey: operation.ConnectorKey,
 				ReleaseDigest: operation.Target.ReleaseDigest, Generation: operation.HostGeneration,
 				Deadline: application.config.Now().UTC().Add(5 * time.Second),
 			}))
@@ -241,11 +250,17 @@ func (application *Application) rollbackInstalledBindings(ctx context.Context, o
 		previousConnector.Release = *rollout.previous
 		previousConnector.Installation = Installation{State: InstallationStateInstalled, InstalledVersion: rollout.previous.Version,
 			InstalledReleaseID: rollout.previous.ReleaseID, InstalledReleaseDigest: rollout.previous.ReleaseDigest}
+		binding, bindingErr := application.resolveRuntimeBinding(ctx, operation, previousConnector, *rollout.previous, RuntimeBindingPurposeReconcile)
+		if bindingErr != nil {
+			rollbackErrors = append(rollbackErrors, bindingErr)
+			continue
+		}
 		rollbackOperationID := operation.OperationID + "/rollback/" + connectionID
-		receipt, err := application.config.Host.Reconcile(ctx, RuntimeReconcileRequest{OperationID: rollbackOperationID,
-			ConnectionID: connectionID, Connector: previousConnector, Enabled: true, Generation: operation.HostGeneration})
+		receipt, err := application.reconcileRuntime(ctx, RuntimeReconcileRequest{OperationID: rollbackOperationID,
+			Scope: operation.Scope, ConnectionID: binding.ConnectionID, Connector: previousConnector,
+			Enabled: binding.Enabled, Generation: operation.HostGeneration, CredentialBrokerGrant: binding.CredentialBrokerGrant})
 		if err == nil {
-			err = validateRuntimeReceipt(receipt, rollbackOperationID, connectionID,
+			err = validateRuntimeReceipt(receipt, rollbackOperationID, binding.ConnectionID,
 				operation.ConnectorKey, rollout.previous.ReleaseDigest, operation.HostGeneration)
 		}
 		rollbackErrors = append(rollbackErrors, err)
@@ -272,8 +287,21 @@ func (application *Application) executeUninstall(ctx context.Context, operation 
 	if err != nil {
 		return err
 	}
+	connector, err := application.config.Repository.Connector(ctx, operation.ConnectorKey)
+	if err != nil {
+		return err
+	}
+	release, err := application.installedReleaseEvidence(ctx, connector)
+	if err != nil {
+		return err
+	}
+	binding, err := application.resolveRuntimeBinding(ctx, operation, connector, release, RuntimeBindingPurposeDeactivate)
+	if err != nil {
+		return err
+	}
+	clear(binding.CredentialBrokerGrant)
 	if err := application.config.Host.DeactivateRuntime(ctx, RuntimeDeactivationRequest{
-		ConnectionID: defaultConnectorConnectionID, ConnectorKey: operation.Target.ConnectorKey, ReleaseDigest: operation.Target.ReleaseDigest,
+		Scope: operation.Scope, ConnectionID: binding.ConnectionID, ConnectorKey: operation.Target.ConnectorKey, ReleaseDigest: operation.Target.ReleaseDigest,
 		Generation: operation.HostGeneration,
 		Deadline:   application.config.Now().UTC().Add(5 * time.Second),
 	}); err != nil {
@@ -284,7 +312,8 @@ func (application *Application) executeUninstall(ctx context.Context, operation 
 			return NewDomainError(ErrorCodeInstallFailed, "connector CLI installation is not registered", false, nil)
 		}
 		if err := application.config.CLIInstallations.RemoveCLI(ctx, RemoveCLIRequest{
-			OperationID: operation.OperationID, ConnectorKey: operation.Target.ConnectorKey,
+			OperationID: operation.OperationID, Scope: operation.Scope, ConnectorKey: operation.Target.ConnectorKey,
+			Generation:    operation.HostGeneration,
 			ReleaseDigest: operation.Target.ReleaseDigest,
 		}); err != nil {
 			return NewDomainError(ErrorCodeInstallFailed, "connector CLI installation cleanup failed", true, err)
@@ -292,6 +321,8 @@ func (application *Application) executeUninstall(ctx context.Context, operation 
 	}
 	if err := application.config.ArtifactPreparer.Remove(ctx, RemoveArtifactRequest{
 		OperationID:   operation.OperationID,
+		Scope:         operation.Scope,
+		Generation:    operation.HostGeneration,
 		ConnectorKey:  operation.Target.ConnectorKey,
 		Version:       operation.Target.Version,
 		ReleaseDigest: operation.Target.ReleaseDigest,
@@ -368,6 +399,7 @@ func (application *Application) beginAuthorizationSession(
 	session, err := application.config.Authorization.Begin(ctx, AuthorizationStartRequest{
 		OperationID:     operation.OperationID,
 		ClientRequestID: operation.ClientRequestID,
+		Scope:           operation.Scope,
 		Connector:       connector,
 		Release:         release,
 	})
@@ -402,6 +434,7 @@ func (application *Application) executeDisconnectAuthorization(ctx context.Conte
 	}
 	if err := application.config.Authorization.Disconnect(ctx, AuthorizationDisconnectRequest{
 		OperationID: operation.OperationID,
+		Scope:       operation.Scope,
 		Connector:   connector,
 	}); err != nil {
 		return NewDomainError(ErrorCodeAuthorizationFailed, "connector authorization disconnect failed", true, err)
@@ -704,7 +737,7 @@ func validatePreparedArtifact(
 		receipt.ReleaseDigest != release.ReleaseDigest ||
 		receipt.ArtifactSHA256 != release.Artifact.SHA256 ||
 		!artifactSHA256Pattern.MatchString(receipt.InventoryDigest) ||
-		strings.TrimSpace(receipt.PreparedPath) == "" {
+		(strings.TrimSpace(receipt.PreparedPath) == "" && strings.TrimSpace(receipt.OpaqueArtifactRef) == "") {
 		return invalidOperationReceipt("artifact preparer returned a mismatched receipt")
 	}
 	return nil
@@ -726,10 +759,14 @@ func validateCLIInstallationReceipt(operation Operation, release Release, instal
 		receipt.LaunchKind != install.Launch.Kind || receipt.EntrypointSize <= 0 ||
 		!artifactSHA256Pattern.MatchString(receipt.NodeSHA256) ||
 		!artifactSHA256Pattern.MatchString(receipt.EntrypointSHA256) ||
-		!artifactSHA256Pattern.MatchString(receipt.LockSHA256) ||
 		strings.TrimSpace(receipt.RuntimeProfile) == "" || strings.TrimSpace(receipt.RuntimeABI) == "" ||
-		strings.TrimSpace(receipt.NodeVersion) == "" || !filepath.IsAbs(receipt.InstallRoot) ||
-		!filepath.IsAbs(receipt.StoreRoot) || !safeRelativeEntrypoint(receipt.Entrypoint) {
+		strings.TrimSpace(receipt.NodeVersion) == "" || !safeRelativeEntrypoint(receipt.Entrypoint) {
+		return invalidOperationReceipt("CLI installer returned a mismatched receipt")
+	}
+	localReceipt := filepath.IsAbs(receipt.InstallRoot) && filepath.IsAbs(receipt.StoreRoot) &&
+		artifactSHA256Pattern.MatchString(receipt.LockSHA256)
+	remoteReceipt := strings.TrimSpace(receipt.OpaqueInstallationRef) != ""
+	if !localReceipt && !remoteReceipt {
 		return invalidOperationReceipt("CLI installer returned a mismatched receipt")
 	}
 	return nil

--- a/packages/connector/host/application_runtime_execution.go
+++ b/packages/connector/host/application_runtime_execution.go
@@ -1,0 +1,68 @@
+package host
+
+import (
+	"context"
+	"strings"
+)
+
+func (application *Application) executeRuntimeReconcile(ctx context.Context, operation Operation) error {
+	connector, err := application.config.Repository.Connector(ctx, operation.ConnectorKey)
+	if err != nil {
+		return err
+	}
+	release, err := application.installedReleaseEvidence(ctx, connector)
+	if err != nil {
+		return err
+	}
+	connector.Release = release
+	binding, err := application.resolveRuntimeBinding(ctx, operation, connector, release, RuntimeBindingPurposeReconcile)
+	if err != nil {
+		return err
+	}
+	receipt, err := application.reconcileRuntime(ctx, RuntimeReconcileRequest{
+		OperationID: operation.OperationID, Scope: operation.Scope, ConnectionID: binding.ConnectionID,
+		Connector: connector, Enabled: binding.Enabled, Generation: operation.HostGeneration,
+		CredentialBrokerGrant: binding.CredentialBrokerGrant,
+	})
+	if err != nil {
+		return NewDomainError(ErrorCodeInstallFailed, "connector runtime could not be reconciled", true, err)
+	}
+	if err := validateRuntimeReceipt(receipt, operation.OperationID, binding.ConnectionID, connector.Key,
+		release.ReleaseDigest, operation.HostGeneration); err != nil {
+		return err
+	}
+	return application.completeConnectorOperation(ctx, operation.OperationID, func(current Connector) Connector { return current })
+}
+
+func (application *Application) resolveRuntimeBinding(
+	ctx context.Context,
+	operation Operation,
+	connector Connector,
+	release Release,
+	purpose RuntimeBindingPurpose,
+) (RuntimeBinding, error) {
+	binding, err := application.config.RuntimeBindings.ResolveRuntimeBinding(ctx, RuntimeBindingRequest{
+		OperationID: operation.OperationID, Scope: operation.Scope, Purpose: purpose, Connector: connector, Release: release,
+	})
+	if err != nil {
+		clear(binding.CredentialBrokerGrant)
+		return RuntimeBinding{}, err
+	}
+	binding.ConnectionID = strings.TrimSpace(binding.ConnectionID)
+	if binding.ConnectionID == "" || (!binding.Enabled && len(binding.CredentialBrokerGrant) != 0) {
+		clear(binding.CredentialBrokerGrant)
+		return RuntimeBinding{}, invalidOperationReceipt("runtime binding resolver returned invalid intent")
+	}
+	return binding, nil
+}
+
+func (application *Application) reconcileRuntime(ctx context.Context, request RuntimeReconcileRequest) (RuntimeReceipt, error) {
+	defer clear(request.CredentialBrokerGrant)
+	return application.config.Host.Reconcile(ctx, request)
+}
+
+type defaultRuntimeBindingResolver struct{}
+
+func (defaultRuntimeBindingResolver) ResolveRuntimeBinding(context.Context, RuntimeBindingRequest) (RuntimeBinding, error) {
+	return RuntimeBinding{ConnectionID: defaultConnectorConnectionID, Enabled: true}, nil
+}

--- a/packages/connector/host/application_scoped_runtime.go
+++ b/packages/connector/host/application_scoped_runtime.go
@@ -1,0 +1,169 @@
+package host
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+)
+
+// ReconcileRuntime reapplies device-installed truth for the mutation's
+// explicit account scope. It does not mutate installation state.
+func (application *Application) ReconcileRuntime(ctx context.Context, mutation ConnectorMutation) (MutationResult, error) {
+	return application.acceptConnectorOperation(ctx, mutation, OperationKindReconcileRuntime, func(connector Connector) (Connector, error) {
+		if connector.Installation.State != InstallationStateInstalled ||
+			strings.TrimSpace(connector.Installation.InstalledReleaseDigest) == "" {
+			return Connector{}, invalidTransition("runtime", string(connector.Installation.State), string(InstallationStateInstalled))
+		}
+		return connector, nil
+	})
+}
+
+func (application *Application) GetAuthorizationProjection(
+	ctx context.Context,
+	accountID, connectorKey string,
+) (AuthorizationProjection, error) {
+	if application.config.AuthorizationProjections == nil {
+		return AuthorizationProjection{}, NewDomainError(ErrorCodeUnavailable, "account authorization projections are not registered", false, nil)
+	}
+	if strings.TrimSpace(accountID) == "" || strings.TrimSpace(connectorKey) == "" {
+		return AuthorizationProjection{}, invalidRequest("accountId and connectorKey are required")
+	}
+	return application.config.AuthorizationProjections.AuthorizationProjection(ctx, accountID, connectorKey)
+}
+
+// ObserveAuthorization persists server-observed account authorization and
+// schedules a durable runtime reconcile for an installed connector.
+func (application *Application) ObserveAuthorization(
+	ctx context.Context,
+	mutation ConnectorMutation,
+	projection AuthorizationProjection,
+) (MutationResult, error) {
+	if application.config.AuthorizationProjections == nil {
+		return MutationResult{}, NewDomainError(ErrorCodeUnavailable, "account authorization projections are not registered", false, nil)
+	}
+	projection.AccountID = strings.TrimSpace(projection.AccountID)
+	projection.ConnectorKey = strings.TrimSpace(projection.ConnectorKey)
+	projection.ConnectionID = strings.TrimSpace(projection.ConnectionID)
+	if projection.AccountID == "" || projection.ConnectorKey == "" ||
+		projection.AccountID != strings.TrimSpace(mutation.AccountID) ||
+		projection.ConnectorKey != strings.TrimSpace(mutation.ConnectorKey) {
+		return MutationResult{}, invalidRequest("authorization projection does not match the mutation scope")
+	}
+	if projection.ConnectionID != "" && !runtimeConnectionIDPattern.MatchString(projection.ConnectionID) {
+		return MutationResult{}, invalidRequest("authorization projection connectionId is invalid")
+	}
+	switch projection.State {
+	case AuthorizationStateNotRequired, AuthorizationStateDisconnected, AuthorizationStatePending,
+		AuthorizationStateConnected, AuthorizationStateExpired, AuthorizationStateFailed:
+	default:
+		return MutationResult{}, invalidRequest("authorization projection state is invalid")
+	}
+	if projection.UpdatedAt.IsZero() {
+		projection.UpdatedAt = application.config.Now().UTC()
+	}
+	if err := application.config.AuthorizationProjections.SaveAuthorizationProjection(ctx, projection); err != nil {
+		return MutationResult{}, err
+	}
+	return application.ReconcileRuntime(ctx, mutation)
+}
+
+func (application *Application) ReconcileInstalledRuntimes(ctx context.Context) error {
+	return application.ReconcileInstalledRuntimesForScope(ctx, OperationScope{})
+}
+
+// ReconcileInstalledRuntimesForScope rebuilds runtime intent for an explicit
+// account authority after daemon or guest restart.
+func (application *Application) ReconcileInstalledRuntimesForScope(ctx context.Context, scope OperationScope) error {
+	if application == nil {
+		return NewDomainError(ErrorCodeUnavailable, "connector application is unavailable", false, nil)
+	}
+	snapshot, err := application.config.Repository.Snapshot(ctx)
+	if err != nil {
+		return err
+	}
+	for _, connector := range snapshot.Connectors {
+		if connector.Installation.State != InstallationStateInstalled {
+			continue
+		}
+		installedRelease, evidenceErr := application.installedReleaseEvidence(ctx, connector)
+		if evidenceErr != nil {
+			return NewDomainError(ErrorCodeUnavailable, "installed connector release evidence is unavailable", false, nil)
+		}
+		if validationErr := ValidateRuntimeReleaseShape(installedRelease); validationErr != nil {
+			return NewDomainError(ErrorCodeUnavailable, "installed connector release evidence is invalid", false, validationErr)
+		}
+		installedConnector := connector
+		installedConnector.Release = installedRelease
+		generation := maxGeneration(connector.Revision)
+		operationID := "reconcile/" + application.config.BootEpoch + "/" + connector.Key
+		operation := Operation{OperationID: operationID, ConnectorKey: connector.Key, Scope: scope}
+		binding, err := application.resolveRuntimeBinding(ctx, operation, installedConnector, installedRelease, RuntimeBindingPurposeReconcile)
+		if err != nil {
+			return NewDomainError(ErrorCodeUnavailable, "connector runtime binding could not be resolved", true, err)
+		}
+		receipt, err := application.reconcileRuntime(ctx, RuntimeReconcileRequest{
+			OperationID: operationID, Scope: scope, ConnectionID: binding.ConnectionID,
+			Connector: installedConnector, Enabled: binding.Enabled, CredentialBrokerGrant: binding.CredentialBrokerGrant,
+			Generation: HostGeneration{BootEpoch: application.config.BootEpoch, Generation: generation},
+		})
+		if err != nil {
+			return NewDomainError(ErrorCodeUnavailable, "connector runtime could not be reconciled", true, err)
+		}
+		if err := validateRuntimeReceipt(receipt, operationID, binding.ConnectionID, connector.Key,
+			installedRelease.ReleaseDigest, HostGeneration{BootEpoch: application.config.BootEpoch, Generation: generation}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (application *Application) FenceInstalledRuntimes(ctx context.Context) error {
+	return application.FenceInstalledRuntimesForScope(ctx, OperationScope{})
+}
+
+// FenceInstalledRuntimesForScope removes runtime projections without deleting
+// device installation facts.
+func (application *Application) FenceInstalledRuntimesForScope(ctx context.Context, scope OperationScope) error {
+	if application == nil {
+		return NewDomainError(ErrorCodeUnavailable, "connector application is unavailable", false, nil)
+	}
+	snapshot, err := application.config.Repository.Snapshot(ctx)
+	if err != nil {
+		return err
+	}
+	var fenceErrors []error
+	for _, connector := range snapshot.Connectors {
+		if connector.Installation.State != InstallationStateInstalled {
+			continue
+		}
+		installedRelease, evidenceErr := application.installedReleaseEvidence(ctx, connector)
+		if evidenceErr != nil {
+			fenceErrors = append(fenceErrors, evidenceErr)
+			continue
+		}
+		connector.Release = installedRelease
+		operation := Operation{OperationID: "fence/" + application.config.BootEpoch + "/" + connector.Key,
+			ConnectorKey: connector.Key, Scope: scope}
+		binding, bindingErr := application.resolveRuntimeBinding(ctx, operation, connector, installedRelease, RuntimeBindingPurposeDeactivate)
+		if bindingErr != nil {
+			fenceErrors = append(fenceErrors, bindingErr)
+			continue
+		}
+		clear(binding.CredentialBrokerGrant)
+		fenceErrors = append(fenceErrors, application.config.Host.DeactivateRuntime(ctx, RuntimeDeactivationRequest{
+			Scope: scope, ConnectionID: binding.ConnectionID, ConnectorKey: connector.Key,
+			ReleaseDigest: connector.Installation.InstalledReleaseDigest,
+			Generation:    HostGeneration{BootEpoch: application.config.BootEpoch, Generation: maxGeneration(connector.Revision)},
+			Deadline:      application.config.Now().UTC().Add(5 * time.Second),
+		}))
+	}
+	return errors.Join(fenceErrors...)
+}
+
+func maxGeneration(generation uint64) uint64 {
+	if generation == 0 {
+		return 1
+	}
+	return generation
+}

--- a/packages/connector/host/application_test.go
+++ b/packages/connector/host/application_test.go
@@ -141,6 +141,33 @@ func TestApplicationExecutesTypedCLIInstallationBeforeCompletion(t *testing.T) {
 	}
 }
 
+func TestCrossMachineReceiptsUseOpaqueReferences(t *testing.T) {
+	release := testReleaseWithImplementation("lark", "1.0.0", ImplementationKindManagedStdio)
+	release.Manifest.Implementation.ManagedStdio.MCP = nil
+	release.Manifest.Implementation.ManagedStdio.CLI = &ManagedCLIInterface{Entrypoint: "lark-cli", Install: &CLIInstallation{
+		Kind: "node_package", NodePackage: &NodePackageInstallation{Package: "@larksuite/cli", Version: "1.0.83",
+			Integrity: "sha512-qbJYoJtNch6dV8RvYBO2wpcKO9+6Io3Cuf5alYFzvLbtkSntOKqoc+xHI7p6wRq4oH4F9fydgNJbTGy79ibPdg==",
+			Launch:    NodePackageLaunch{Kind: "native", Entrypoint: "bin/lark-cli", SHA256: strings.Repeat("c", 64)}},
+	}}
+	operation := Operation{OperationID: "operation-1", ConnectorKey: "lark"}
+	prepared := PreparedArtifactReceipt{OperationID: operation.OperationID, ConnectorKey: "lark", Version: release.Version,
+		ReleaseDigest: release.ReleaseDigest, ArtifactSHA256: release.Artifact.SHA256,
+		InventoryDigest: strings.Repeat("e", 64), OpaqueArtifactRef: "guest-artifact-1"}
+	if err := validatePreparedArtifact(operation, release, prepared); err != nil {
+		t.Fatal(err)
+	}
+	install := releaseCLIInstallation(release)
+	installed := CLIInstallationReceipt{SchemaVersion: "tutti.connector.cli-installation.v1", OperationID: operation.OperationID,
+		ConnectorKey: "lark", ReleaseDigest: release.ReleaseDigest, RuntimeProfile: "connector-node-static",
+		RuntimeABI: "node24-linux-arm64", NodeVersion: "24.18.0", NodeSHA256: strings.Repeat("1", 64),
+		Package: install.Package, PackageVersion: install.Version, PackageIntegrity: install.Integrity,
+		LaunchKind: install.Launch.Kind, Entrypoint: "node_modules/@larksuite/cli/bin/lark-cli",
+		EntrypointSHA256: strings.Repeat("2", 64), EntrypointSize: 7, OpaqueInstallationRef: "guest-install-1"}
+	if err := validateCLIInstallationReceipt(operation, release, *install, installed); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestApplicationReconcilesInstalledRuntimeAtStartup(t *testing.T) {
 	connector := testConnector("github")
 	connector.Revision = 7
@@ -158,6 +185,134 @@ func TestApplicationReconcilesInstalledRuntimeAtStartup(t *testing.T) {
 	if host.reconciles != 1 || host.lastReconcile.ConnectionID != defaultConnectorConnectionID ||
 		host.lastReconcile.Generation.Generation != 7 || host.lastReconcile.Generation.BootEpoch == "" {
 		t.Fatalf("startup reconcile = %#v, count=%d", host.lastReconcile, host.reconciles)
+	}
+}
+
+func TestApplicationInstallUsesAccountScopedInactiveRuntimeBinding(t *testing.T) {
+	repository := newMemoryRepository(testConnector("github"))
+	host := &memoryInstallRuntime{}
+	resolver := &runtimeBindingResolverStub{binding: RuntimeBinding{ConnectionID: "account-connection", Enabled: false}}
+	application := newTestApplication(t, repository, &memoryScheduler{}, host, CatalogSnapshot{})
+	application.config.RuntimeBindings = resolver
+
+	accepted, err := application.Install(context.Background(), ConnectorMutation{
+		Mutation:     Mutation{ClientRequestID: "install-account", ExpectedRevision: 0},
+		ConnectorKey: "github", AccountID: "account-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := application.ExecuteOperation(context.Background(), accepted.Operation.OperationID); err != nil {
+		t.Fatal(err)
+	}
+	operation := repository.operations[accepted.Operation.OperationID]
+	if operation.Scope.AccountID != "account-1" || host.lastPrepare.Scope.AccountID != "account-1" ||
+		host.lastPrepare.Generation != operation.HostGeneration ||
+		host.lastReconcile.Scope.AccountID != "account-1" || host.lastReconcile.ConnectionID != "account-connection" ||
+		host.lastReconcile.Enabled {
+		t.Fatalf("operation=%#v prepare=%#v reconcile=%#v", operation, host.lastPrepare, host.lastReconcile)
+	}
+	if repository.connectors["github"].Installation.State != InstallationStateInstalled {
+		t.Fatalf("installation = %#v", repository.connectors["github"].Installation)
+	}
+}
+
+func TestApplicationCredentialGrantIsNotPersistedAndIsCleared(t *testing.T) {
+	repository := newMemoryRepository(testConnector("github"))
+	host := &memoryInstallRuntime{}
+	grant := []byte("one-shot-grant")
+	application := newTestApplication(t, repository, &memoryScheduler{}, host, CatalogSnapshot{})
+	application.config.RuntimeBindings = &runtimeBindingResolverStub{binding: RuntimeBinding{
+		ConnectionID: "account-connection", Enabled: true, CredentialBrokerGrant: grant,
+	}}
+	accepted, err := application.Install(context.Background(), ConnectorMutation{
+		Mutation: Mutation{ClientRequestID: "install-grant"}, ConnectorKey: "github", AccountID: "account-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := application.ExecuteOperation(context.Background(), accepted.Operation.OperationID); err != nil {
+		t.Fatal(err)
+	}
+	if host.lastCredentialGrant != "one-shot-grant" {
+		t.Fatalf("runtime grant = %q", host.lastCredentialGrant)
+	}
+	if string(grant) != strings.Repeat("\x00", len(grant)) {
+		t.Fatalf("credential grant was not cleared: %v", grant)
+	}
+	payload := fmt.Sprintf("%#v", repository.operations[accepted.Operation.OperationID])
+	if strings.Contains(payload, "one-shot-grant") {
+		t.Fatalf("operation persisted credential authority: %s", payload)
+	}
+}
+
+func TestApplicationReconcileRuntimeKeepsDeviceInstallationTruth(t *testing.T) {
+	connector := testConnector("github")
+	connector.Installation = Installation{State: InstallationStateInstalled, InstalledVersion: connector.Release.Version,
+		InstalledReleaseID: connector.Release.ReleaseID, InstalledReleaseDigest: connector.Release.ReleaseDigest}
+	repository := newMemoryRepository(connector)
+	host := &memoryInstallRuntime{}
+	application := newTestApplication(t, repository, &memoryScheduler{}, host, CatalogSnapshot{})
+	application.config.RuntimeBindings = &runtimeBindingResolverStub{binding: RuntimeBinding{ConnectionID: "account-connection", Enabled: false}}
+	accepted, err := application.ReconcileRuntime(context.Background(), ConnectorMutation{
+		Mutation: Mutation{ClientRequestID: "reconcile-account"}, ConnectorKey: "github", AccountID: "account-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := application.ExecuteOperation(context.Background(), accepted.Operation.OperationID); err != nil {
+		t.Fatal(err)
+	}
+	stored := repository.connectors["github"]
+	if stored.Installation.State != InstallationStateInstalled || stored.Installation.InstalledReleaseDigest != connector.Release.ReleaseDigest ||
+		host.lastReconcile.Enabled {
+		t.Fatalf("connector=%#v reconcile=%#v", stored, host.lastReconcile)
+	}
+}
+
+func TestApplicationAuthorizationObservationReconcilesWithoutChangingInstallation(t *testing.T) {
+	connector := testConnector("github")
+	connector.Release.Manifest.AuthorizationKind = "oauth2"
+	connector.Authorization = Authorization{State: AuthorizationStateDisconnected}
+	connector.Installation = Installation{State: InstallationStateInstalled, InstalledVersion: connector.Release.Version,
+		InstalledReleaseID: connector.Release.ReleaseID, InstalledReleaseDigest: connector.Release.ReleaseDigest}
+	repository := newMemoryRepository(connector)
+	host := &memoryInstallRuntime{}
+	projections := &recordingAuthorizationProjectionStore{}
+	application := newTestApplication(t, repository, &memoryScheduler{}, host, CatalogSnapshot{})
+	application.config.AuthorizationProjections = projections
+	application.config.RuntimeBindings = AccountRuntimeBindingResolver{
+		Projections: projections, Credentials: &credentialGrantIssuerStub{grant: []byte("credential-grant")},
+	}
+	connected := AuthorizationProjection{AccountID: "account-1", ConnectorKey: "github",
+		ConnectionID: "server-connection", State: AuthorizationStateConnected}
+	accepted, err := application.ObserveAuthorization(context.Background(), ConnectorMutation{
+		Mutation: Mutation{ClientRequestID: "authorization-connected"}, ConnectorKey: "github", AccountID: "account-1",
+	}, connected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := application.ExecuteOperation(context.Background(), accepted.Operation.OperationID); err != nil {
+		t.Fatal(err)
+	}
+	if !host.lastReconcile.Enabled || host.lastReconcile.ConnectionID != "server-connection" ||
+		host.lastCredentialGrant != "credential-grant" {
+		t.Fatalf("connected reconcile = %#v", host.lastReconcile)
+	}
+	expired := connected
+	expired.State = AuthorizationStateExpired
+	accepted, err = application.ObserveAuthorization(context.Background(), ConnectorMutation{
+		Mutation:     Mutation{ClientRequestID: "authorization-expired", ExpectedRevision: repository.revision},
+		ConnectorKey: "github", AccountID: "account-1",
+	}, expired)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := application.ExecuteOperation(context.Background(), accepted.Operation.OperationID); err != nil {
+		t.Fatal(err)
+	}
+	if host.lastReconcile.Enabled || repository.connectors["github"].Installation.State != InstallationStateInstalled {
+		t.Fatalf("expired reconcile = %#v connector = %#v", host.lastReconcile, repository.connectors["github"])
 	}
 }
 
@@ -750,22 +905,25 @@ func (scheduler *memoryScheduler) Schedule(_ context.Context, operationID string
 }
 
 type memoryInstallRuntime struct {
-	prepares        int
-	removes         int
-	activations     int
-	deactivations   int
-	activeDigest    string
-	reconciles      int
-	lastReconcile   RuntimeReconcileRequest
-	deactivationErr error
-	failClosed      int
-	cliInstalls     int
-	cliRemoves      int
+	prepares            int
+	removes             int
+	activations         int
+	deactivations       int
+	activeDigest        string
+	reconciles          int
+	lastReconcile       RuntimeReconcileRequest
+	lastPrepare         PrepareArtifactRequest
+	lastCredentialGrant string
+	deactivationErr     error
+	failClosed          int
+	cliInstalls         int
+	cliRemoves          int
 }
 
 func (host *memoryInstallRuntime) Reconcile(_ context.Context, request RuntimeReconcileRequest) (RuntimeReceipt, error) {
 	host.reconciles++
 	host.lastReconcile = request
+	host.lastCredentialGrant = string(request.CredentialBrokerGrant)
 	return RuntimeReceipt{OperationID: request.OperationID, ConnectionID: request.ConnectionID,
 		ConnectorKey: request.Connector.Key, ReleaseDigest: request.Connector.Release.ReleaseDigest, Generation: request.Generation}, nil
 }
@@ -786,6 +944,7 @@ func (host *memoryInstallRuntime) FailClosed(context.Context, time.Time) error {
 
 func (host *memoryInstallRuntime) Prepare(_ context.Context, request PrepareArtifactRequest) (PreparedArtifactReceipt, error) {
 	host.prepares++
+	host.lastPrepare = request
 	return PreparedArtifactReceipt{
 		OperationID:     request.OperationID,
 		ConnectorKey:    request.Release.ConnectorKey,
@@ -795,6 +954,30 @@ func (host *memoryInstallRuntime) Prepare(_ context.Context, request PrepareArti
 		InventoryDigest: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
 		PreparedPath:    "/prepared/" + request.Release.ReleaseDigest,
 	}, nil
+}
+
+type runtimeBindingResolverStub struct {
+	binding RuntimeBinding
+}
+
+type recordingAuthorizationProjectionStore struct {
+	projection AuthorizationProjection
+}
+
+func (store *recordingAuthorizationProjectionStore) AuthorizationProjection(context.Context, string, string) (AuthorizationProjection, error) {
+	if store.projection.AccountID == "" {
+		return AuthorizationProjection{}, ErrNotFound
+	}
+	return store.projection, nil
+}
+
+func (store *recordingAuthorizationProjectionStore) SaveAuthorizationProjection(_ context.Context, projection AuthorizationProjection) error {
+	store.projection = projection
+	return nil
+}
+
+func (resolver *runtimeBindingResolverStub) ResolveRuntimeBinding(context.Context, RuntimeBindingRequest) (RuntimeBinding, error) {
+	return resolver.binding, nil
 }
 
 func (host *memoryInstallRuntime) Remove(context.Context, RemoveArtifactRequest) error {

--- a/packages/connector/host/ports.go
+++ b/packages/connector/host/ports.go
@@ -104,22 +104,30 @@ type CLIInstallationManager interface {
 
 type InstallCLIRequest struct {
 	OperationID string
+	Scope       OperationScope
+	Generation  HostGeneration
 	Release     Release
 }
 
 type RemoveCLIRequest struct {
 	OperationID   string
+	Scope         OperationScope
+	Generation    HostGeneration
 	ConnectorKey  string
 	ReleaseDigest string
 }
 
 type PrepareArtifactRequest struct {
 	OperationID string
+	Scope       OperationScope
+	Generation  HostGeneration
 	Release     Release
 }
 
 type RemoveArtifactRequest struct {
 	OperationID   string
+	Scope         OperationScope
+	Generation    HostGeneration
 	ConnectorKey  string
 	Version       string
 	ReleaseDigest string
@@ -149,18 +157,63 @@ type ImplementationHost interface {
 
 type RuntimeReconcileRequest struct {
 	OperationID  string
+	Scope        OperationScope
 	ConnectionID string
 	Connector    Connector
 	Enabled      bool
 	Generation   HostGeneration
+	// CredentialBrokerGrant is a one-shot authority passed directly to the
+	// runtime adapter. Implementations must not log or persist it.
+	CredentialBrokerGrant []byte
 }
 
 type RuntimeDeactivationRequest struct {
+	Scope         OperationScope
 	ConnectionID  string
 	ConnectorKey  string
 	ReleaseDigest string
 	Generation    HostGeneration
 	Deadline      time.Time
+}
+
+// RuntimeBindingResolver converts device installation plus an explicit
+// operation scope into account-aware runtime intent. It is the only port that
+// may obtain a short-lived credential grant; the Application clears the grant
+// after the ImplementationHost call returns.
+type RuntimeBindingResolver interface {
+	ResolveRuntimeBinding(context.Context, RuntimeBindingRequest) (RuntimeBinding, error)
+}
+
+type RuntimeBindingRequest struct {
+	OperationID string
+	Scope       OperationScope
+	Purpose     RuntimeBindingPurpose
+	Connector   Connector
+	Release     Release
+}
+
+type RuntimeBindingPurpose string
+
+const (
+	RuntimeBindingPurposeReconcile  RuntimeBindingPurpose = "reconcile"
+	RuntimeBindingPurposeDeactivate RuntimeBindingPurpose = "deactivate"
+)
+
+type RuntimeBinding struct {
+	ConnectionID          string
+	Enabled               bool
+	CredentialBrokerGrant []byte
+}
+
+// AuthorizationProjectionStore keeps account authorization separate from the
+// device-scoped Connector installation fact.
+type AuthorizationProjectionStore interface {
+	AuthorizationProjection(ctx context.Context, accountID, connectorKey string) (AuthorizationProjection, error)
+	SaveAuthorizationProjection(ctx context.Context, projection AuthorizationProjection) error
+}
+
+type CredentialBrokerGrantIssuer interface {
+	IssueCredentialBrokerGrant(ctx context.Context, accountID, connectorKey, connectionID string) ([]byte, error)
 }
 
 type AuthorizationProvider interface {
@@ -171,12 +224,14 @@ type AuthorizationProvider interface {
 type AuthorizationStartRequest struct {
 	OperationID     string
 	ClientRequestID string
+	Scope           OperationScope
 	Connector       Connector
 	Release         Release
 }
 
 type AuthorizationDisconnectRequest struct {
 	OperationID string
+	Scope       OperationScope
 	Connector   Connector
 }
 

--- a/packages/connector/host/service.go
+++ b/packages/connector/host/service.go
@@ -20,6 +20,9 @@ type Service interface {
 	RefreshCatalog(ctx context.Context, mutation Mutation) (MutationResult, error)
 	Install(ctx context.Context, mutation ConnectorMutation) (MutationResult, error)
 	Uninstall(ctx context.Context, mutation ConnectorMutation) (MutationResult, error)
+	ReconcileRuntime(ctx context.Context, mutation ConnectorMutation) (MutationResult, error)
+	GetAuthorizationProjection(ctx context.Context, accountID, connectorKey string) (AuthorizationProjection, error)
+	ObserveAuthorization(ctx context.Context, mutation ConnectorMutation, projection AuthorizationProjection) (MutationResult, error)
 	BeginAuthorization(ctx context.Context, mutation ConnectorMutation) (AuthorizationResult, error)
 	DisconnectAuthorization(ctx context.Context, mutation ConnectorMutation) (MutationResult, error)
 	ExecuteOperation(ctx context.Context, operationID string) error

--- a/packages/connector/host/types.go
+++ b/packages/connector/host/types.go
@@ -56,6 +56,7 @@ const (
 	OperationKindRefreshCatalog          OperationKind = "refresh_catalog"
 	OperationKindInstall                 OperationKind = "install"
 	OperationKindUninstall               OperationKind = "uninstall"
+	OperationKindReconcileRuntime        OperationKind = "reconcile_runtime"
 	OperationKindStartAuthorization      OperationKind = "start_authorization"
 	OperationKindDisconnectAuthorization OperationKind = "disconnect_authorization"
 )
@@ -111,10 +112,11 @@ type Manifest struct {
 }
 
 type Artifact struct {
-	Key       string `json:"key"`
-	SHA256    string `json:"sha256"`
-	SizeBytes int64  `json:"sizeBytes"`
-	MediaType string `json:"mediaType"`
+	Key           string `json:"key"`
+	SHA256        string `json:"sha256"`
+	SizeBytes     int64  `json:"sizeBytes"`
+	MediaType     string `json:"mediaType"`
+	ObjectVersion string `json:"objectVersion,omitempty"`
 }
 
 type CompatibilityRequirements struct {
@@ -248,6 +250,7 @@ type Operation struct {
 	ClientRequestID string             `json:"clientRequestId"`
 	ConnectorKey    string             `json:"connectorKey,omitempty"`
 	Kind            OperationKind      `json:"kind"`
+	Scope           OperationScope     `json:"scope,omitempty"`
 	State           OperationState     `json:"state"`
 	Stage           OperationStage     `json:"stage,omitempty"`
 	Target          *OperationTarget   `json:"target,omitempty"`
@@ -260,6 +263,14 @@ type Operation struct {
 	FailureCode     string             `json:"failureCode,omitempty"`
 	CreatedAt       time.Time          `json:"createdAt"`
 	UpdatedAt       time.Time          `json:"updatedAt"`
+}
+
+// OperationScope freezes the external authority under which a durable
+// operation was accepted. AccountID is intentionally the only persisted
+// authority fact: short-lived artifact and credential grants belong to ports
+// and must never be serialized into an operation.
+type OperationScope struct {
+	AccountID string `json:"accountId,omitempty"`
 }
 
 // OperationTarget freezes the exact release identity at command acceptance so
@@ -299,6 +310,10 @@ type CLIInstallationReceipt struct {
 	EntrypointSHA256 string `json:"entrypointSha256"`
 	EntrypointSize   int64  `json:"entrypointSizeBytes"`
 	LockSHA256       string `json:"lockSha256"`
+	// OpaqueInstallationRef identifies an installation owned by a remote or
+	// isolated runtime. Cross-machine hosts persist this value instead of guest
+	// filesystem paths.
+	OpaqueInstallationRef string `json:"opaqueInstallationRef,omitempty"`
 }
 
 type PreparedArtifactReceipt struct {
@@ -309,6 +324,9 @@ type PreparedArtifactReceipt struct {
 	ArtifactSHA256  string `json:"artifactSha256"`
 	InventoryDigest string `json:"inventoryDigest"`
 	PreparedPath    string `json:"preparedPath"`
+	// OpaqueArtifactRef identifies a prepared artifact owned by a remote or
+	// isolated runtime. It is deliberately meaningless to the control plane.
+	OpaqueArtifactRef string `json:"opaqueArtifactRef,omitempty"`
 }
 
 type RuntimeActivationReceipt struct {
@@ -359,6 +377,19 @@ type Mutation struct {
 type ConnectorMutation struct {
 	Mutation
 	ConnectorKey string `json:"connectorKey"`
+	AccountID    string `json:"accountId,omitempty"`
+}
+
+// AuthorizationProjection is account-scoped runtime intent. Installation is
+// still device-scoped on Connector; switching accounts changes only this
+// projection and the runtime binding derived from it.
+type AuthorizationProjection struct {
+	AccountID    string             `json:"accountId"`
+	ConnectorKey string             `json:"connectorKey"`
+	ConnectionID string             `json:"connectionId,omitempty"`
+	State        AuthorizationState `json:"state"`
+	FailureCode  string             `json:"failureCode,omitempty"`
+	UpdatedAt    time.Time          `json:"updatedAt"`
 }
 
 type MutationResult struct {

--- a/packages/connector/store-sqlite/README.md
+++ b/packages/connector/store-sqlite/README.md
@@ -5,6 +5,11 @@ of the Connector Host repository and changed-event outbox contracts. Hosts own
 the selected database path and process lifecycle; the module owns schema,
 migration, transactions, revisions, leases, and operation persistence.
 
+Device installation remains on the Connector row. Account authorization is
+stored independently in `connector_market_authorization_projections`, keyed by
+`account_id + connector_key`, so account switching cannot overwrite installed
+truth.
+
 Active operations and pending outbox events are durable and never age-pruned.
 The lifecycle cleanup contract removes bounded batches of expired terminal
 operations and already-published events. Installed release evidence is stored

--- a/packages/connector/store-sqlite/store.go
+++ b/packages/connector/store-sqlite/store.go
@@ -26,6 +26,7 @@ type Store struct {
 var _ market.Repository = (*Store)(nil)
 var _ market.ChangedEventOutbox = (*Store)(nil)
 var _ market.LifecycleCleanupStore = (*Store)(nil)
+var _ market.AuthorizationProjectionStore = (*Store)(nil)
 
 func Open(ctx context.Context, dbPath string) (*Store, error) {
 	dbPath = strings.TrimSpace(dbPath)
@@ -97,6 +98,12 @@ VALUES (1, 0, 'stale', '') ON CONFLICT(id) DO NOTHING`,
   connector_key TEXT PRIMARY KEY,
   release_digest TEXT NOT NULL,
   release_json TEXT NOT NULL
+)`,
+		`CREATE TABLE IF NOT EXISTS connector_market_authorization_projections (
+  account_id TEXT NOT NULL,
+  connector_key TEXT NOT NULL,
+  projection_json TEXT NOT NULL,
+  PRIMARY KEY (account_id, connector_key)
 )`,
 		`CREATE TABLE IF NOT EXISTS connector_market_operations (
   operation_id TEXT PRIMARY KEY,
@@ -183,6 +190,39 @@ SELECT operation_json FROM connector_market_operations WHERE operation_id = ?`, 
 		return market.Operation{}, mapNotFound(err)
 	}
 	return decodeOperation(payload)
+}
+
+func (store *Store) AuthorizationProjection(
+	ctx context.Context,
+	accountID, connectorKey string,
+) (market.AuthorizationProjection, error) {
+	var payload string
+	if err := store.db.QueryRowContext(ctx, `
+SELECT projection_json FROM connector_market_authorization_projections
+WHERE account_id = ? AND connector_key = ?`, accountID, connectorKey).Scan(&payload); err != nil {
+		return market.AuthorizationProjection{}, mapNotFound(err)
+	}
+	var projection market.AuthorizationProjection
+	if err := json.Unmarshal([]byte(payload), &projection); err != nil {
+		return market.AuthorizationProjection{}, fmt.Errorf("decode connector authorization projection: %w", err)
+	}
+	return projection, nil
+}
+
+func (store *Store) SaveAuthorizationProjection(
+	ctx context.Context,
+	projection market.AuthorizationProjection,
+) error {
+	payload, err := json.Marshal(projection)
+	if err != nil {
+		return fmt.Errorf("encode connector authorization projection: %w", err)
+	}
+	_, err = store.db.ExecContext(ctx, `
+INSERT INTO connector_market_authorization_projections (account_id, connector_key, projection_json)
+VALUES (?, ?, ?)
+ON CONFLICT(account_id, connector_key) DO UPDATE SET projection_json = excluded.projection_json`,
+		projection.AccountID, projection.ConnectorKey, string(payload))
+	return err
 }
 
 func (store *Store) ClaimOperation(

--- a/packages/connector/store-sqlite/store_test.go
+++ b/packages/connector/store-sqlite/store_test.go
@@ -121,6 +121,38 @@ func TestStorePersistsRevisionOperationBindingAndOutboxAtomically(t *testing.T) 
 	}
 }
 
+func TestStorePersistsAuthorizationProjectionByAccount(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(ctx, filepath.Join(t.TempDir(), "tuttid.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	first := market.AuthorizationProjection{AccountID: "account-1", ConnectorKey: "github",
+		ConnectionID: "connection-1", State: market.AuthorizationStateConnected, UpdatedAt: time.Unix(1, 0).UTC()}
+	second := market.AuthorizationProjection{AccountID: "account-2", ConnectorKey: "github",
+		ConnectionID: "connection-2", State: market.AuthorizationStateExpired, UpdatedAt: time.Unix(2, 0).UTC()}
+	for _, projection := range []market.AuthorizationProjection{first, second} {
+		if err := store.SaveAuthorizationProjection(ctx, projection); err != nil {
+			t.Fatal(err)
+		}
+	}
+	loaded, err := store.AuthorizationProjection(ctx, first.AccountID, first.ConnectorKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded != first {
+		t.Fatalf("projection = %#v, want %#v", loaded, first)
+	}
+	loaded, err = store.AuthorizationProjection(ctx, second.AccountID, second.ConnectorKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded != second {
+		t.Fatalf("projection = %#v, want %#v", loaded, second)
+	}
+}
+
 func TestStoreOperationLeaseFencesOtherWorkersAndExpires(t *testing.T) {
 	ctx := context.Background()
 	store, err := Open(ctx, filepath.Join(t.TempDir(), "tuttid.db"))


### PR DESCRIPTION
## Summary
- separate device installation from account-scoped authorization projections
- add explicit operation scope and runtime binding policy for inactive/active VM runtimes
- support opaque cross-machine artifact/CLI receipts and artifact object versions
- make daemon bootstrap re-fence and rebuild runtime state on account changes

## Verification
- `pnpm check:changed`
- Connector host/daemon/store/runtime module tests
- `go test ./service/connectormarket` in `services/tuttid`

## Notes
- legacy Tutti behavior remains the default (`default` connection, enabled) when no account binding resolver is supplied
- one-shot credential grants are never persisted and are cleared after runtime reconciliation
- full `services/tuttid go test ./...` was also sampled; Connector tests passed, but the suite has an unrelated missing generated `tutti-onboarding-0.1.0.zip` fixture in `builtin-apps`.