### PR TITLE
fix(connector): fence account runtime state

### DIFF
--- a/packages/connector/daemon/README.md
+++ b/packages/connector/daemon/README.md
@@ -24,3 +24,7 @@ resolver.
 Remote runtimes inject `CapabilityPublicationController`; bootstrap awaits its
 fail-closed/open commands. Same-process Tutti runtimes remain compatible with
 the synchronous implementation-host publication gate.
+
+Account logout and switching use `Host.FenceForScope` to close remote
+publication, fail-close all processes, and force a later bootstrap even when
+the same account logs in again.

--- a/packages/connector/daemon/host.go
+++ b/packages/connector/daemon/host.go
@@ -260,6 +260,25 @@ func (host *Host) BootstrapForScope(ctx context.Context, scope market.OperationS
 	return nil
 }
 
+// FenceForScope closes publication and runtime authority for an account
+// boundary without deleting device installation truth. A later bootstrap,
+// including one for the same account, must perform full recovery before routes
+// can be published again.
+func (host *Host) FenceForScope(ctx context.Context, scope market.OperationScope) error {
+	if host == nil || host.Application == nil {
+		return errors.New("connector market host is unavailable")
+	}
+	host.bootstrapMu.Lock()
+	defer host.bootstrapMu.Unlock()
+	host.activationGate.setOpen(false)
+	host.bootstrapped = false
+	host.bootstrapScope = scope
+	publicationErr := host.applyCapabilityPublication(ctx, scope, false)
+	fenceErr := host.activationGate.FailClosed(ctx, time.Now().Add(10*time.Second))
+	projectionErr := host.Application.FenceInstalledRuntimesForScope(ctx, scope)
+	return errors.Join(publicationErr, fenceErr, projectionErr)
+}
+
 func (host *Host) applyCapabilityPublication(ctx context.Context, scope market.OperationScope, enabled bool) error {
 	if host.publication != nil {
 		return host.publication.ApplyCapabilityPublication(ctx, scope, enabled)

--- a/packages/connector/daemon/host_test.go
+++ b/packages/connector/daemon/host_test.go
@@ -16,6 +16,7 @@ type activationGateDelegate struct {
 	reconciles        int
 	reconcileFailures int
 	deactivations     int
+	failClosed        int
 	lastReconcile     market.RuntimeReconcileRequest
 }
 
@@ -39,7 +40,10 @@ func (delegate *activationGateDelegate) DeactivateRuntime(context.Context, marke
 	delegate.deactivations++
 	return nil
 }
-func (*activationGateDelegate) FailClosed(context.Context, time.Time) error { return nil }
+func (delegate *activationGateDelegate) FailClosed(context.Context, time.Time) error {
+	delegate.failClosed++
+	return nil
+}
 
 func TestActivationGateStagesRecoveryUntilInitialCatalogRefresh(t *testing.T) {
 	delegate := &activationGateDelegate{}
@@ -235,6 +239,20 @@ func TestBootstrapRestoresInstalledRuntimeWithoutRefreshingCatalog(t *testing.T)
 	}
 	if source.refreshes != 1 || runtime.reconciles != 3 {
 		t.Fatalf("refreshes=%d reconciles=%d, want catalog retry isolated from runtime", source.refreshes, runtime.reconciles)
+	}
+
+	accountScope := market.OperationScope{AccountID: "account-1"}
+	if err := host.FenceForScope(ctx, accountScope); err != nil {
+		t.Fatalf("account fence failed: %v", err)
+	}
+	if len(publication.values) == 0 || publication.values[len(publication.values)-1] || runtime.failClosed == 0 {
+		t.Fatalf("fence publication=%#v failClosed=%d", publication.values, runtime.failClosed)
+	}
+	if err := host.BootstrapForScope(ctx, accountScope); err != nil {
+		t.Fatalf("same-account bootstrap after fence failed: %v", err)
+	}
+	if runtime.reconciles != 4 || !publication.values[len(publication.values)-1] {
+		t.Fatalf("same-account recovery reconciles=%d publication=%#v", runtime.reconciles, publication.values)
 	}
 }
 


### PR DESCRIPTION
## Summary\n- add a daemon-owned account-scope fence operation\n- close capability publication and activation before fencing runtime projections\n- force same-account re-login through full bootstrap recovery\n\n## Validation\n- go test ./... (packages/connector/daemon)