### PR TITLE
fix(agent): reconcile historical sessions after activation failure

### DIFF
--- a/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.test.ts
@@ -6,6 +6,7 @@ import {
 } from "./rootReducer.ts";
 import {
   selectEngineSessionOperationError,
+  selectEngineSessionCanReload,
   selectEngineSubmitAvailability,
   selectFailedNewActivationResolution,
   selectEngineSessionDeleted,
@@ -119,6 +120,13 @@ test("failed new activation preserves a canonical session after runtime failure"
     selectFailedNewActivationResolution(state, " session-1 "),
     "preserve"
   );
+  assert.equal(
+    selectFailedNewActivationResolution(state, "session-1", {
+      selectionSource: "user-selection"
+    }),
+    "not-applicable"
+  );
+  assert.equal(selectEngineSessionCanReload(state, "session-1"), true);
 });
 
 test("consumer collections hide presentation-invisible sessions without removing exact lookup", () => {

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.selectors.ts
@@ -55,8 +55,12 @@ export type FailedNewActivationResolution =
 
 export function selectFailedNewActivationResolution(
   state: AgentSessionEngineStateBase,
-  agentSessionId: string | null | undefined
+  agentSessionId: string | null | undefined,
+  options?: { selectionSource?: "activation" | "user-selection" }
 ): FailedNewActivationResolution {
+  if (options?.selectionSource === "user-selection") {
+    return "not-applicable";
+  }
   const activation = selectLatestActivationForSession(state, agentSessionId);
   if (activation?.mode !== "new" || isPendingActivationViable(activation)) {
     return "not-applicable";
@@ -65,6 +69,21 @@ export function selectFailedNewActivationResolution(
     selectEngineSession(state, agentSessionId)
     ? "preserve"
     : "rollback";
+}
+
+/**
+ * Session selection may reload after a failed or canceled activation. Only an
+ * activation whose delivery is still pending/uncertain must wait for an
+ * authoritative result before starting detail hydration.
+ */
+export function selectEngineSessionCanReload(
+  state: AgentSessionEngineStateBase,
+  agentSessionId: string | null | undefined
+): boolean {
+  const activation = selectLatestActivationForSession(state, agentSessionId);
+  return (
+    activation?.status !== "requested" && activation?.status !== "uncertain"
+  );
 }
 
 export function selectEngineSessionRuntimeAvailability(

--- a/packages/agent/activity-core/src/index.ts
+++ b/packages/agent/activity-core/src/index.ts
@@ -224,6 +224,7 @@ export {
   selectEngineLatestTurn,
   selectEnginePendingInteractions,
   selectEngineSession,
+  selectEngineSessionCanReload,
   selectFailedNewActivationResolution,
   selectEngineSessionDeleted,
   selectEngineSessionIsRespondingToInteraction,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentConversationSelection.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentConversationSelection.spec.tsx
@@ -1,6 +1,11 @@
 import { act, renderHook } from "@testing-library/react";
+import {
+  createAgentSessionEngine,
+  selectEngineSessionCanReload
+} from "@tutti-os/agent-activity-core";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentGUINodeData } from "../../../types";
+import { createTestEngineCommandPort } from "../../../shared/testing/createTestAgentSessionEngine";
 import { useAgentConversationSelection } from "./useAgentConversationSelection";
 
 describe("useAgentConversationSelection", () => {
@@ -280,5 +285,90 @@ describe("useAgentConversationSelection", () => {
 
     expect(hasConversationListQuery).not.toHaveBeenCalled();
     expect(ensureHydrated).not.toHaveBeenCalled();
+  });
+
+  it("hydrates a historical session after its new activation failed", () => {
+    const agentSessionId = "historical-session";
+    const engine = createAgentSessionEngine({
+      clock: { nowUnixMs: () => 1 },
+      commandPort: createTestEngineCommandPort({
+        execute: async () => undefined
+      }),
+      identity: { origin: "test", workspaceId: "workspace-1" },
+      scheduler: { schedule: () => ({ cancel() {} }) }
+    });
+    engine.dispatch({
+      agentSessionId,
+      agentTargetId: "target-1",
+      clientSubmitId: "submit-1",
+      content: [{ type: "text", text: "hello" }],
+      cwd: "/workspace",
+      expiresAtUnixMs: 45_001,
+      mode: "new",
+      requestedAtUnixMs: 1,
+      requestId: "activation-1",
+      type: "activation/requested",
+      workspaceId: "workspace-1"
+    });
+    engine.dispatch({
+      commandId: "activate:activation-1",
+      commandType: "session/activate",
+      correlationId: "activation-1",
+      errorMessage: "Initial goal failed.",
+      outcome: "failed",
+      type: "engine/commandResult"
+    });
+
+    const active = { current: null as string | null };
+    const ensureHydrated = vi.fn();
+    const setIntent = vi.fn();
+    const { result } = renderHook(() =>
+      useAgentConversationSelection({
+        activation: {
+          canReload: (sessionId) =>
+            selectEngineSessionCanReload(engine.getSnapshot(), sessionId),
+          forget: vi.fn(),
+          isPending: () => false
+        },
+        conversations: {
+          agentTargetIdFor: () => "local:codex",
+          contains: () => true
+        },
+        detail: {
+          ensureHydrated,
+          ensureStateHydrated: vi.fn(),
+          isHydrated: () => false,
+          isStateHydrated: () => false,
+          markPending: vi.fn(),
+          setLoading: vi.fn()
+        },
+        hasConversationListQuery: () => true,
+        isMounted: () => true,
+        onMissingConversationListQuery: vi.fn(),
+        persistence: { update: vi.fn() },
+        rail: {
+          clearRevealRequest: vi.fn(),
+          requestReveal: vi.fn()
+        },
+        selection: {
+          clearDetailError: vi.fn(),
+          getActiveSessionId: () => active.current,
+          setActiveSessionId: (sessionId) => {
+            active.current = sessionId;
+          },
+          setComposerHome: vi.fn(),
+          setIntent
+        }
+      })
+    );
+
+    act(() => result.current.selectConversation(agentSessionId));
+
+    expect(setIntent).toHaveBeenCalledWith({
+      id: agentSessionId,
+      source: "user-selection",
+      tag: "active"
+    });
+    expect(ensureHydrated).toHaveBeenCalledWith(agentSessionId);
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRouting.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRouting.ts
@@ -135,10 +135,12 @@ export function useAgentGUIConversationRouting(
 
     if (intent.tag !== "home") {
       if (
-        !(intent.tag === "active" && intent.source === "user-selection") &&
         selectFailedNewActivationResolution(
           sessionEngine.getSnapshot(),
-          intent.id
+          intent.id,
+          intent.tag === "active"
+            ? { selectionSource: intent.source }
+            : undefined
         ) === "rollback"
       ) {
         // Terminal activation settlement clears the optimistic selection in an

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.ts
@@ -1,6 +1,7 @@
 import {
   selectFailedNewActivationResolution,
   selectEngineSession,
+  selectEngineSessionCanReload,
   selectEngineSessionDetailHydrated,
   selectEngineSessionStateHydrated,
   selectLatestActivationForSession,
@@ -220,10 +221,10 @@ export function useAgentGUIConversationSelectionController(
     if (
       activeConversationIdRef.current ===
         activePendingActivation?.agentSessionId &&
-      !(intent.tag === "active" && intent.source === "user-selection") &&
       selectFailedNewActivationResolution(
         sessionEngine.getSnapshot(),
-        activePendingActivation.agentSessionId
+        activePendingActivation.agentSessionId,
+        intent.tag === "active" ? { selectionSource: intent.source } : undefined
       ) === "rollback"
     ) {
       rollbackSelection(
@@ -373,12 +374,10 @@ export function useAgentGUIConversationSelectionController(
   const selection = useAgentConversationSelection({
     activation: {
       canReload: (agentSessionId) => {
-        const status =
-          selectLatestActivationForSession(
-            sessionEngine.getSnapshot(),
-            agentSessionId
-          )?.status ?? null;
-        return status !== "requested" && status !== "uncertain";
+        return selectEngineSessionCanReload(
+          sessionEngine.getSnapshot(),
+          agentSessionId
+        );
       },
       forget: activation.clearFailure,
       isPending: (agentSessionId) =>

--- a/services/tuttid/service/agent/service_create.go
+++ b/services/tuttid/service/agent/service_create.go
@@ -292,6 +292,25 @@ func (s *Service) CreateWithResult(ctx context.Context, workspaceID string, inpu
 	}
 	if hostResult.Kind == "goalControl" {
 		result, getErr := s.Get(ctx, workspaceID, session.ID)
+		if getErr != nil {
+			// Host has already created and published the Session. A follow-up
+			// projection read may be unavailable while the runtime is settling,
+			// but that read failure must not erase the Session-created result.
+			fallback := serviceSessionWithPersistedFreshness(
+				session,
+				persistedSession,
+				s.controller().CanResume(runtimeResumeInputFromRuntimeSession(session)),
+			)
+			if projected, projectErr := s.projectSessionForResponse(ctx, workspaceID, fallback); projectErr == nil {
+				fallback = projected
+			}
+			return CreateSessionResult{
+				Session:           decorateIsolatedSession(fallback, isolation, isolationWarnings),
+				TurnID:            strings.TrimSpace(hostResult.TurnID),
+				SessionStatus:     hostResult.SessionStatus,
+				InitialGoalStatus: hostResult.InitialGoalStatus,
+			}, getErr
+		}
 		return CreateSessionResult{
 			Session:           decorateIsolatedSession(result, isolation, isolationWarnings),
 			TurnID:            strings.TrimSpace(hostResult.TurnID),

--- a/services/tuttid/service/agent/service_host_create_rollback_test.go
+++ b/services/tuttid/service/agent/service_host_create_rollback_test.go
@@ -29,6 +29,28 @@ func (r unavailableSessionReader) SessionDeleted(ctx context.Context, workspaceI
 	return r.delegate.SessionDeleted(ctx, workspaceID, agentSessionID)
 }
 
+type failAfterSessionReads struct {
+	delegate     SessionReader
+	allowedReads int
+	reads        int
+}
+
+func (r *failAfterSessionReads) GetSession(workspaceID, agentSessionID string) (PersistedSession, bool) {
+	if r.reads >= r.allowedReads {
+		return PersistedSession{}, false
+	}
+	r.reads++
+	return r.delegate.GetSession(workspaceID, agentSessionID)
+}
+
+func (r *failAfterSessionReads) ListSessions(workspaceID string) ([]PersistedSession, bool) {
+	return r.delegate.ListSessions(workspaceID)
+}
+
+func (r *failAfterSessionReads) SessionDeleted(ctx context.Context, workspaceID, agentSessionID string) (bool, error) {
+	return r.delegate.SessionDeleted(ctx, workspaceID, agentSessionID)
+}
+
 func TestHostCreateWithInitialInputRollsBackTurnlessCanonicalShell(t *testing.T) {
 	execErr := errors.New("provider rejected initial input")
 	runtime := newFakeRuntime()
@@ -242,6 +264,52 @@ func TestHostCreateWithInvalidTypedGoalPreservesPublishedSession(t *testing.T) {
 	}
 	if len(publisher.events) != 1 {
 		t.Fatalf("published session event count=%d, want 1", len(publisher.events))
+	}
+}
+
+func TestHostCreateWithSuccessfulTypedGoalPreservesSessionWhenResponseReadFails(t *testing.T) {
+	ctx := context.Background()
+	runtime := newFakeRuntime()
+	runtime.goalControlHook = func(_ context.Context, input RuntimeGoalControlInput) (RuntimeGoalControlResult, error) {
+		return RuntimeGoalControlResult{
+			Goal:          map[string]any{"objective": input.Objective, "status": "active"},
+			ProviderPhase: "accepted",
+			Evidence:      map[string]any{"phase": "accepted"},
+		}, nil
+	}
+	store := openAgentServiceSQLiteStore(t)
+	if err := store.Create(ctx, workspacebiz.Summary{ID: "ws-goal-success", Name: "Goal workspace"}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	projection := NewActivityProjection(store)
+	goalStore := &recordingGoalStateStore{}
+	service := newTestService(runtime)
+	service.SessionReader = &failAfterSessionReads{delegate: projection, allowedReads: 2}
+	service.SessionInitializer = projection
+	service.GoalStateStore = goalStore
+
+	created, err := service.CreateWithResult(ctx, "ws-goal-success", CreateSessionInput{
+		AgentSessionID: "session-goal-success",
+		AgentTargetID:  agenttargetbiz.IDLocalCodex,
+		InitialContent: TextPromptContent("/goal ship it"),
+		Metadata:       map[string]any{"clientSubmitId": "submit-goal-success"},
+	})
+	if err == nil {
+		t.Fatal("CreateWithResult() error=nil, want response projection failure")
+	}
+	if created.Session.ID != "session-goal-success" {
+		t.Fatalf("created Session ID=%q, want preserved Host Session", created.Session.ID)
+	}
+	if created.SessionStatus != agenthost.CreateSessionStatusCreated ||
+		created.InitialGoalStatus != agenthost.CreateSessionInitialGoalStatusSucceeded {
+		t.Fatalf(
+			"create outcome session=%q goal=%q, want created/succeeded",
+			created.SessionStatus,
+			created.InitialGoalStatus,
+		)
+	}
+	if _, found, getErr := store.GetSession(ctx, "ws-goal-success", "session-goal-success"); getErr != nil || !found {
+		t.Fatalf("published canonical session found=%v error=%v", found, getErr)
 	}
 }
 


### PR DESCRIPTION
## What changed\n\n- Move failed new-activation resolution into Activity Core, distinguishing canonical Session presence from activation failure.\n- Keep explicit historical selection as the highest-priority intent and make AgentGUI consume Core decisions.\n- Preserve the created Session and split Session/initial Goal lifecycle status when GoalControl succeeds but the follow-up projection read fails.\n- Add Core, AgentGUI, and Service regression coverage.\n\n## Why\n\nA failed initial activation/Goal could incorrectly erase a durable historical Session and send AgentGUI to the empty home state. The fix treats activation delivery and Session existence as separate facts.\n\n## Verification\n\n- AgentGUI tests: 2,666 passed.\n- Activity Core tests: 448 passed.\n- Tutti agent service package: passed.\n- Targeted Go regression tests: passed.\n- Tutti and TSH type checks, boundary checks, and diff checks passed.\n- Manual make dev-gui smoke test confirmed existing local and shared-agent history sessions load details instead of showing empty state.\n\n## Risk and scope\n\nNo schema migration or bulk repair is introduced. Truly missing canonical sessions remain unavailable. TSH shared-agent materialization is submitted in the companion TSH PR.