### PR TITLE
fix(connector): avoid runtime admission during fencing

### DIFF
--- a/packages/connector/daemon/README.md
+++ b/packages/connector/daemon/README.md
@@ -27,4 +27,6 @@ the synchronous implementation-host publication gate.
 
 Account logout and switching use `Host.FenceForScope` to close remote
 publication, fail-close all processes, and force a later bootstrap even when
-the same account logs in again.
+the same account logs in again. The account-boundary fence never admits or
+starts a runtime with retired authority; per-Connector deactivation remains a
+normal uninstall/reconcile concern.

--- a/packages/connector/daemon/host.go
+++ b/packages/connector/daemon/host.go
@@ -275,8 +275,7 @@ func (host *Host) FenceForScope(ctx context.Context, scope market.OperationScope
 	host.bootstrapScope = scope
 	publicationErr := host.applyCapabilityPublication(ctx, scope, false)
 	fenceErr := host.activationGate.FailClosed(ctx, time.Now().Add(10*time.Second))
-	projectionErr := host.Application.FenceInstalledRuntimesForScope(ctx, scope)
-	return errors.Join(publicationErr, fenceErr, projectionErr)
+	return errors.Join(publicationErr, fenceErr)
 }
 
 func (host *Host) applyCapabilityPublication(ctx context.Context, scope market.OperationScope, enabled bool) error {


### PR DESCRIPTION
## Summary\n- keep account-boundary fencing global and fail-closed\n- avoid per-Connector deactivation that could admit a VM with retired authority\n- leave per-Connector deactivation to uninstall and reconcile operations\n\n## Validation\n- go test ./... (packages/connector/daemon)