### PR TITLE
fix(connector): restore invalid prepared artifacts

### DIFF
--- a/packages/connector/runtime/artifact/preparer.go
+++ b/packages/connector/runtime/artifact/preparer.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	market "github.com/tutti-os/tutti/packages/connector/host"
 )
@@ -70,7 +71,8 @@ var _ market.ArtifactPreparer = (*Preparer)(nil)
 
 // ResolvePrepared revalidates the content-addressed receipt, packaged
 // manifest, and full inventory before a durable connector runtime is restored.
-// A receipt is never treated as an authenticity root by itself.
+// An invalid prepared tree is rebuilt from the verified artifact blob; a
+// receipt is never treated as an authenticity root by itself.
 func (preparer *Preparer) ResolvePrepared(ctx context.Context, release market.Release) (market.PreparedArtifactReceipt, error) {
 	if err := ctx.Err(); err != nil {
 		return market.PreparedArtifactReceipt{}, err
@@ -83,10 +85,18 @@ func (preparer *Preparer) ResolvePrepared(ctx context.Context, release market.Re
 		return market.PreparedArtifactReceipt{}, err
 	}
 	receipt, ok := readExistingReceipt(target, market.PrepareArtifactRequest{Release: release})
-	if !ok {
-		return market.PreparedArtifactReceipt{}, errors.New("prepared connector artifact receipt or inventory is invalid")
+	if ok {
+		return receipt, nil
 	}
-	return receipt, nil
+	// Prepared trees are verified on every restore and remain fail-closed while
+	// in use. If the durable tree was changed between runs, rebuild it from the
+	// content-addressed artifact blob instead of permanently fencing an otherwise
+	// installed connector. Prepare still verifies the blob, packaged manifest,
+	// and complete extracted inventory before atomically replacing the tree.
+	return preparer.prepare(ctx, market.PrepareArtifactRequest{
+		OperationID: fmt.Sprintf("restore-%d-%d", os.Getpid(), time.Now().UnixNano()),
+		Release:     release,
+	}, validateRuntimePrepareRequest)
 }
 
 func NewPreparer(config Config) (*Preparer, error) {
@@ -113,7 +123,15 @@ func (preparer *Preparer) Prepare(
 	ctx context.Context,
 	request market.PrepareArtifactRequest,
 ) (market.PreparedArtifactReceipt, error) {
-	if err := validatePrepareRequest(request); err != nil {
+	return preparer.prepare(ctx, request, validatePrepareRequest)
+}
+
+func (preparer *Preparer) prepare(
+	ctx context.Context,
+	request market.PrepareArtifactRequest,
+	validate func(market.PrepareArtifactRequest) error,
+) (market.PreparedArtifactReceipt, error) {
+	if err := validate(request); err != nil {
 		return market.PreparedArtifactReceipt{}, err
 	}
 	target, err := preparer.preparedPath(request.Release)
@@ -425,6 +443,13 @@ func validatePrepareRequest(request market.PrepareArtifactRequest) error {
 		return errors.New("connector artifact operation id is invalid")
 	}
 	return market.ValidateReleaseShape(request.Release)
+}
+
+func validateRuntimePrepareRequest(request market.PrepareArtifactRequest) error {
+	if strings.TrimSpace(request.OperationID) == "" || !safeSegment(request.OperationID) {
+		return errors.New("connector artifact operation id is invalid")
+	}
+	return market.ValidateRuntimeReleaseShape(request.Release)
 }
 
 func validateLimits(limits Limits) error {

--- a/packages/connector/runtime/artifact/preparer_test.go
+++ b/packages/connector/runtime/artifact/preparer_test.go
@@ -87,6 +87,9 @@ func TestResolvePreparedAllowsLegacyReleaseWithoutIcon(t *testing.T) {
 
 	legacyRelease := release
 	legacyRelease.Manifest.IconURL = ""
+	if err := os.WriteFile(filepath.Join(prepared.PreparedPath, ".DS_Store"), []byte("finder metadata"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	resolved, err := preparer.ResolvePrepared(context.Background(), legacyRelease)
 	if err != nil {
 		t.Fatalf("ResolvePrepared() rejected legacy presentation metadata: %v", err)
@@ -99,6 +102,90 @@ func TestResolvePreparedAllowsLegacyReleaseWithoutIcon(t *testing.T) {
 		Release:     legacyRelease,
 	}); err == nil || !strings.Contains(err.Error(), "iconUrl") {
 		t.Fatalf("Prepare() error = %v, want full icon validation", err)
+	}
+}
+
+func TestResolvePreparedRepairsInvalidInventoryFromVerifiedBlob(t *testing.T) {
+	manifest := []byte(`{"schemaVersion":"1","connectorKey":"github"}`)
+	archive := testZIP(t, map[string][]byte{
+		packagedManifestPath: manifest,
+		"bin/connector":      []byte("executable"),
+	})
+	release := testRelease(archive, manifest)
+	fetcher := &memoryFetcher{body: archive, mediaType: release.Artifact.MediaType}
+	preparer, err := NewPreparer(Config{RootDir: t.TempDir(), Fetcher: fetcher})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := preparer.Prepare(context.Background(), market.PrepareArtifactRequest{
+		OperationID: "operation-1",
+		Release:     release,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(prepared.PreparedPath, ".DS_Store"), []byte("finder metadata"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	resolved, err := preparer.ResolvePrepared(context.Background(), release)
+	if err != nil {
+		t.Fatalf("ResolvePrepared() failed to repair invalid inventory: %v", err)
+	}
+	if fetcher.calls != 1 {
+		t.Fatalf("fetch calls = %d, want 1 verified blob download", fetcher.calls)
+	}
+	if resolved.PreparedPath != prepared.PreparedPath || resolved.InventoryDigest != prepared.InventoryDigest {
+		t.Fatalf("resolved receipt = %#v, want repaired %#v", resolved, prepared)
+	}
+	if _, err := os.Stat(filepath.Join(resolved.PreparedPath, ".DS_Store")); !os.IsNotExist(err) {
+		t.Fatalf("unexpected metadata survived repair: %v", err)
+	}
+	content, err := os.ReadFile(filepath.Join(resolved.PreparedPath, "bin", "connector"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "executable" {
+		t.Fatalf("repaired content = %q", content)
+	}
+}
+
+func TestResolvePreparedRepairsModifiedContentFromVerifiedBlob(t *testing.T) {
+	manifest := []byte(`{"schemaVersion":"1","connectorKey":"github"}`)
+	archive := testZIP(t, map[string][]byte{
+		packagedManifestPath: manifest,
+		"bin/connector":      []byte("executable"),
+	})
+	release := testRelease(archive, manifest)
+	fetcher := &memoryFetcher{body: archive, mediaType: release.Artifact.MediaType}
+	preparer, err := NewPreparer(Config{RootDir: t.TempDir(), Fetcher: fetcher})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := preparer.Prepare(context.Background(), market.PrepareArtifactRequest{
+		OperationID: "operation-1",
+		Release:     release,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	connectorPath := filepath.Join(prepared.PreparedPath, "bin", "connector")
+	if err := os.WriteFile(connectorPath, []byte("tampered"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := preparer.ResolvePrepared(context.Background(), release); err != nil {
+		t.Fatalf("ResolvePrepared() failed to repair modified content: %v", err)
+	}
+	content, err := os.ReadFile(connectorPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "executable" {
+		t.Fatalf("repaired content = %q", content)
+	}
+	if fetcher.calls != 1 {
+		t.Fatalf("fetch calls = %d, want 1 verified blob download", fetcher.calls)
 	}
 }
 


### PR DESCRIPTION
## Summary

Installed connectors could disappear from `connector available` after a restart even though their durable installation records remained in SQLite. Startup revalidates the prepared artifact tree and fails closed when its inventory differs from the receipt. On macOS, Finder can add `.DS_Store` to that writable tree, causing bootstrap to fence all connector routes with `prepared connector artifact receipt or inventory is invalid`.

This change keeps the strict inventory check and changes recovery behavior:

- If the prepared tree is valid, restore behavior is unchanged.
- If it is invalid or missing, rebuild it from the content-addressed artifact blob.
- Re-verify the blob SHA-256, packaged manifest, and full extracted inventory before atomically replacing the prepared tree.
- Continue to fail closed if trusted artifact bytes cannot be obtained and verified.
- Preserve runtime compatibility validation for previously installed connector manifests.

## Verification

- Reproduced from local logs: the install row remained present while connector bootstrap repeatedly failed inventory validation and kept routes fenced.
- Added coverage for Finder `.DS_Store` contamination and modified connector content.
- Confirmed repair reuses the already verified local blob without another download.
- `go test -race ./packages/connector/runtime/artifact`
- `go test ./packages/connector/runtime ./packages/connector/runtime/implementationhost ./services/tuttid/service/connectormarket`
- `pnpm check:changed`
- `pnpm check:changed -- --push-ready`
- `git diff --check`

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter. (Not applicable; artifact recovery only.)
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed. (Not applicable; internal recovery behavior.)
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. (Not applicable.)
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
