### PR TITLE
fix(agent-replay): align fileChanges and callId compare

### DIFF
--- a/packages/agent/session-replay/go.mod
+++ b/packages/agent/session-replay/go.mod
@@ -8,8 +8,11 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/tutti-os/tutti/packages/agent/host v0.0.0
 	github.com/tutti-os/tutti/packages/agent/store-sqlite v0.0.0
+	github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical v0.0.0
 )
 
 replace github.com/tutti-os/tutti/packages/agent/host => ../host
 
 replace github.com/tutti-os/tutti/packages/agent/store-sqlite => ../store-sqlite
+
+replace github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical => ../store-sqlite/canonical

--- a/packages/agent/session-replay/replay_state_compare.go
+++ b/packages/agent/session-replay/replay_state_compare.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+
+	"github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
 )
 
 // normalizeReplayStateForComparison preserves relationships while replacing
@@ -21,11 +23,62 @@ func normalizeReplayStateForComparison(state TuttiReplayState) TuttiReplayState 
 	registerReplayIDs(replacements, value)
 	replaceReplayIDs(value, replacements)
 	stripVolatileGoalTimingFields(value)
+	canonicalizeTurnFileChanges(value)
 
 	normalized, _ := json.Marshal(value)
 	var result TuttiReplayState
 	_ = json.Unmarshal(normalized, &result)
 	return result
+}
+
+// canonicalizeTurnFileChanges folds recorded and live turn.fileChanges into the
+// shared tool fileChanges contract so older cassettes that still store raw
+// created-file bodies under diff/unifiedDiff compare equal to live newString.
+// Trailing EOLs on text bodies are stripped: apply_patch rematerialization often
+// adds a final newline that older expected-state tokens omitted.
+func canonicalizeTurnFileChanges(value map[string]any) {
+	agent, _ := value["agent"].(map[string]any)
+	sessions, _ := agent["sessions"].([]any)
+	for _, item := range sessions {
+		session, _ := item.(map[string]any)
+		turns, _ := session["turns"].([]any)
+		for _, turnItem := range turns {
+			turn, _ := turnItem.(map[string]any)
+			if turn == nil {
+				continue
+			}
+			normalized := canonical.NormalizeToolFileChanges(turn["fileChanges"])
+			if normalized == nil {
+				delete(turn, "fileChanges")
+				continue
+			}
+			normalizeFileChangeTextFields(normalized)
+			turn["fileChanges"] = normalized
+		}
+	}
+}
+
+func normalizeFileChangeTextFields(fileChanges map[string]any) {
+	files, _ := fileChanges["files"].([]any)
+	for _, item := range files {
+		file, _ := item.(map[string]any)
+		if file == nil {
+			continue
+		}
+		for _, key := range []string{
+			"content",
+			"diff",
+			"newString",
+			"oldString",
+			"unifiedDiff",
+		} {
+			text, ok := file[key].(string)
+			if !ok {
+				continue
+			}
+			file[key] = strings.TrimRight(text, "\r\n")
+		}
+	}
 }
 
 // stripVolatileGoalTimingFields drops Goal wall-clock / duration fields that
@@ -78,6 +131,9 @@ func registerReplayIDs(replacements map[string]string, value map[string]any) {
 			if payload, ok := message["payload"].(map[string]any); ok {
 				delete(payload, "seq")
 				registerReplayID(replacements, payload["operationId"], fmt.Sprintf("session:%d/message:%d/operation", sessionIndex, messageIndex))
+				// tool_call / approval callId remints across record→replay while
+				// the structural message slot stays the same.
+				registerReplayID(replacements, payload["callId"], fmt.Sprintf("session:%d/message:%d/call", sessionIndex, messageIndex))
 				content, _ := payload["content"].([]any)
 				for contentIndex, contentItem := range content {
 					block, _ := contentItem.(map[string]any)

--- a/packages/agent/session-replay/replay_state_domain_test.go
+++ b/packages/agent/session-replay/replay_state_domain_test.go
@@ -776,3 +776,101 @@ func TestCompareTuttiReplayStateIgnoresVolatileGoalTimingFields(
 		t.Fatalf("conflict path = %q", conflict.Path)
 	}
 }
+
+func TestCompareTuttiReplayStateCanonicalizesAddedFileChangeBodies(
+	t *testing.T,
+) {
+	buildState := func(fileChanges map[string]any) TuttiReplayState {
+		return TuttiReplayState{
+			SchemaVersion: SchemaVersion,
+			Agent: TuttiReplayAgent{
+				RootSessionID: "session-1",
+				Sessions: []agenthost.HistoricalSession{{
+					ID:                "session-1",
+					Kind:              "root",
+					AgentTargetID:     "local:codex",
+					Provider:          "codex",
+					ProviderSessionID: "provider-session-1",
+					Turns: []agenthost.HistoricalTurn{{
+						ID:          "turn-1",
+						Phase:       "settled",
+						Outcome:     "completed",
+						Origin:      "user_prompt",
+						FileChanges: fileChanges,
+					}},
+				}},
+			},
+			TuttiMode: TuttiReplayTuttiMode{
+				Activations:   []TuttiReplayActivation{},
+				TurnSnapshots: []TuttiReplayTurnSnapshot{},
+			},
+			Workflows: []TuttiReplayWorkflow{},
+			Issues:    []TuttiReplayIssue{},
+		}
+	}
+	recorded := buildState(map[string]any{
+		"files": []any{map[string]any{
+			"path":        "${REPLAY_CWD}/notes.md",
+			"change":      "added",
+			"diff":        "R36_NOTES_BODY",
+			"unifiedDiff": "R36_NOTES_BODY",
+		}},
+	})
+	live := buildState(map[string]any{
+		"files": []any{map[string]any{
+			"path":      "${REPLAY_CWD}/notes.md",
+			"change":    "added",
+			"newString": "R36_NOTES_BODY\n",
+		}},
+	})
+	if err := CompareTuttiReplayState(recorded, live); err != nil {
+		t.Fatalf(
+			"added-file bodies under obsolete diff must match live newString, got %v",
+			err,
+		)
+	}
+}
+
+func TestCompareTuttiReplayStateTreatsToolCallIDsAsAlphaEquivalent(
+	t *testing.T,
+) {
+	buildState := func(callID string) TuttiReplayState {
+		return TuttiReplayState{
+			SchemaVersion: SchemaVersion,
+			Agent: TuttiReplayAgent{
+				RootSessionID: "session-1",
+				Sessions: []agenthost.HistoricalSession{{
+					ID:                "session-1",
+					Kind:              "root",
+					AgentTargetID:     "local:claude-code",
+					Provider:          "claude-code",
+					ProviderSessionID: "provider-session-1",
+					Messages: []agenthost.HistoricalMessage{{
+						ID:     "toolcall:" + callID,
+						Role:   "assistant",
+						Kind:   "tool_call",
+						Status: "completed",
+						Payload: map[string]any{
+							"callId":   callID,
+							"callType": "function",
+							"name":     "Bash",
+							"provider": "claude-code",
+						},
+					}},
+				}},
+			},
+			TuttiMode: TuttiReplayTuttiMode{
+				Activations:   []TuttiReplayActivation{},
+				TurnSnapshots: []TuttiReplayTurnSnapshot{},
+			},
+			Workflows: []TuttiReplayWorkflow{},
+			Issues:    []TuttiReplayIssue{},
+		}
+	}
+	if err := CompareTuttiReplayState(
+		buildState("approval:recorded-call"),
+		buildState("approval:replayed-call"),
+	); err != nil {
+		t.Fatalf("tool_call callId must be alpha-equivalent, got %v", err)
+	}
+}

--- a/packages/agent/store-sqlite/canonical/tool_file_changes.go
+++ b/packages/agent/store-sqlite/canonical/tool_file_changes.go
@@ -8,6 +8,15 @@ import (
 
 var toolUnifiedDiffHunkPattern = regexp.MustCompile(`^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(?:.*)$`)
 
+// NormalizeToolFileChanges is the shared fileChanges contract used by tool
+// payloads and Agent Session Replay final-state compare. Invalid unified-diff
+// bodies on added files become newString; only real unified diffs keep diff /
+// unifiedDiff. Callers should run both recorded and live graphs through this
+// before equality checks so older cassettes stay portable.
+func NormalizeToolFileChanges(value any) map[string]any {
+	return normalizeToolFileChanges(value)
+}
+
 func normalizeToolFileChanges(value any) map[string]any {
 	body := toolMap(value)
 	if body == nil {


### PR DESCRIPTION
## Summary
- Make Agent Session Replay final-state compare canonicalize `turn.fileChanges` through the shared tool contract (`diff` body → `newString`) and ignore trailing EOLs so older cassettes stay portable.
- Treat tool_call / approval `payload.callId` as alpha-equivalent runtime IDs across record→replay.

## Tests
- `pnpm check:changed -- --push-ready` (pre-push)
- `go test` session-replay compare cases for fileChanges + callId
- Local `pnpm e2e:agent-gui` replay: R36, I03-CLAUDE, C06-CLAUDE → EXIT:0

## Notes
- No cassette re-records; compare/projection only.
- Fixes Cases Console transport_mismatch on `fileChanges.files[*].diff` / `newString` and `messages[*].payload.callId`.
