### PR TITLE
feat(connector): reconcile installed implementation state

### DIFF
--- a/docs/architecture/connector-market.md
+++ b/docs/architecture/connector-market.md
@@ -184,6 +184,19 @@ exactly and never derives a short name by splitting the ID. The selected
 connector remains a separate routing and policy boundary, and invocation fails
 when the canonical ID belongs to a different connector.
 
+Managed MCP and CLI interfaces may declare an `installationProbe` containing
+only bounded argv and `timeoutMs`. The host reuses the interface's verified
+entrypoint and managed runtime; manifests cannot select another executable or
+provide shell text. Exit code `0` means the release-scoped implementation is
+present, exit code `1` means it is absent, and timeout, transport failure, or
+any other exit code is indeterminate. Probe output is ignored and bounded.
+
+Installation probes run only for a release with durable prior-installation
+evidence. Catalog-only entries are never executed before the user accepts an
+installation. The daemon therefore does not silently adopt an arbitrary
+user-global CLI as a signed Connector release: artifact, runtime, and release
+identity must already have crossed the normal install boundary.
+
 Connector releases may declare optional `agentRouting.aliases` containing only
 stable product or brand names. Connector id and display name are included by
 the host automatically; authors use aliases for additional language and legacy
@@ -283,13 +296,25 @@ permanent missing result, or a reconnect after the result window, converges
 from the authoritative connector/snapshot projection instead of relying on
 operation history.
 
-Installed release evidence is a current business fact, not operation history.
-The SQLite store records one complete release record per currently installed
-connector in `connector_market_installed_releases`; install completion updates
-it and uninstall completion removes it in the same transaction as the business
-transition. Runtime recovery therefore remains valid after the corresponding
-completed install operation has expired, including when the accepted catalog
-has advanced to a newer release.
+Installed release evidence is durable recovery input, not operation history.
+The SQLite store records one complete release record per installed connector in
+`connector_market_installed_releases`; install completion updates it and
+uninstall completion removes it in the same transaction as the business
+transition. Probe-detected drift retains that evidence while the installation
+projection is failed so repair and uninstall still target the accepted release.
+Runtime recovery therefore remains valid after the corresponding completed
+install operation has expired, including when the accepted catalog has advanced
+to a newer release.
+
+Before bootstrap republishes installed routes, it compares each previously
+installed release that declares a probe with the actual MCP/CLI implementation.
+An explicit absent result changes the installation projection to `failed` with
+`connector_installation_probe_absent`, retains the installed release evidence
+needed for safe repair or uninstall, advances the revision, and publishes the
+normal changed event. A later present result for that same release clears the
+failure and restores `installed`. Indeterminate probes preserve SQLite truth;
+the ordinary fail-closed runtime reconcile still decides whether bootstrap can
+publish the route.
 
 Authorization operations must follow the same recovery rule or remain fully
 synchronous without leaving a recoverable `running` operation. A provider uses

--- a/packages/connector/daemon/README.md
+++ b/packages/connector/daemon/README.md
@@ -3,7 +3,9 @@
 `packages/connector/daemon` composes the Connector Host application inside a
 long-running desktop daemon. It owns bootstrap fencing, recovery ordering,
 operation scheduling, catalog refresh/reconcile scheduling, and durable outbox
-delivery.
+delivery. Bootstrap also calibrates releases with explicit MCP/CLI installation
+probes before opening capability publication; catalog-only connectors are not
+probed.
 
 The host also starts lifecycle maintenance immediately and repeats it hourly.
 Defaults retain terminal operation lookup/idempotency results for 24 hours and

--- a/packages/connector/daemon/catalog_source_test.go
+++ b/packages/connector/daemon/catalog_source_test.go
@@ -68,7 +68,10 @@ func TestCatalogSourceMapsPublishedConnectorItemsWithAdditiveFields(t *testing.T
           "extensionMetadata": {"revision": 2},
           "managedStdio": {
             "runtime": {"language": "node", "profile": "connector-node-static", "abi": "node20-darwin-arm64"},
-            "mcp": {"entrypoint": "bin/github.js"},
+            "mcp": {
+              "entrypoint": "bin/github.js",
+              "installationProbe": {"arguments": ["--version"], "timeoutMs": 3000}
+            },
             "observability": {"enabled": true}
           }
         }
@@ -106,7 +109,9 @@ func TestCatalogSourceMapsPublishedConnectorItemsWithAdditiveFields(t *testing.T
 	if got.ConnectorKey != "github" || got.ReleaseID != "github@1.0.0" || got.Manifest.SchemaVersion != "1" ||
 		got.ManifestDigest != strings.Repeat("b", 64) || got.Artifact.SizeBytes != 123 || got.Artifact.MediaType != "application/zip" ||
 		got.Manifest.Implementation.ManagedStdio == nil || len(got.Manifest.Permissions) != 1 || got.Manifest.Permissions[0] != "network:*" ||
-		got.Manifest.AgentRouting == nil || len(got.Manifest.AgentRouting.Aliases) != 2 || got.Manifest.AgentRouting.Aliases[1] != "代码托管" {
+		got.Manifest.AgentRouting == nil || len(got.Manifest.AgentRouting.Aliases) != 2 || got.Manifest.AgentRouting.Aliases[1] != "代码托管" ||
+		got.Manifest.Implementation.ManagedStdio.MCP.InstallationProbe == nil ||
+		got.Manifest.Implementation.ManagedStdio.MCP.InstallationProbe.TimeoutMS != 3_000 {
 		t.Fatalf("release = %#v", got)
 	}
 	page, err := source.ListPage(context.Background(), market.CatalogSourcePageQuery{SectionID: "development", PageSize: 100})

--- a/packages/connector/daemon/host.go
+++ b/packages/connector/daemon/host.go
@@ -17,6 +17,7 @@ type HostConfig struct {
 	CatalogSource            market.CatalogSource
 	ArtifactPreparer         market.ArtifactPreparer
 	CLIInstallations         market.CLIInstallationManager
+	InstallationChecker      market.InstallationChecker
 	ImplementationHost       market.ImplementationHost
 	Authorization            market.AuthorizationProvider
 	AuthorizationProjections market.AuthorizationProjectionStore
@@ -138,11 +139,16 @@ func NewHost(parent context.Context, config HostConfig) (*Host, error) {
 	hostContext, cancel := context.WithCancel(parent)
 	scheduler := NewOperationScheduler(hostContext)
 	activationGate := newActivationGateHost(config.ImplementationHost)
+	installationChecker := config.InstallationChecker
+	if installationChecker == nil {
+		installationChecker, _ = config.ImplementationHost.(market.InstallationChecker)
+	}
 	application, err := market.NewApplication(market.ApplicationConfig{
 		Repository:               config.Repository,
 		CatalogSource:            config.CatalogSource,
 		ArtifactPreparer:         config.ArtifactPreparer,
 		CLIInstallations:         config.CLIInstallations,
+		InstallationChecker:      installationChecker,
 		Host:                     activationGate,
 		Authorization:            config.Authorization,
 		AuthorizationProjections: config.AuthorizationProjections,
@@ -246,6 +252,11 @@ func (host *Host) BootstrapForScope(ctx context.Context, scope market.OperationS
 	}
 	if err := host.recoverAndWait(ctx); err != nil {
 		return err
+	}
+	if err := host.Application.CalibrateInstalledConnectorsForScope(ctx, scope); err != nil {
+		// A timeout or other indeterminate probe must preserve durable truth. The
+		// following runtime reconcile remains authoritative and may still recover.
+		slog.Warn("connector installation calibration was indeterminate", "error", err)
 	}
 	host.activationGate.setOpen(true)
 	if err := host.Application.ReconcileInstalledRuntimesForScope(ctx, scope); err != nil {

--- a/packages/connector/daemon/host_test.go
+++ b/packages/connector/daemon/host_test.go
@@ -13,11 +13,26 @@ import (
 )
 
 type activationGateDelegate struct {
-	reconciles        int
-	reconcileFailures int
-	deactivations     int
-	failClosed        int
-	lastReconcile     market.RuntimeReconcileRequest
+	reconciles         int
+	reconcileFailures  int
+	installationChecks int
+	installationState  market.InstallationObservationState
+	deactivations      int
+	failClosed         int
+	lastReconcile      market.RuntimeReconcileRequest
+}
+
+func (delegate *activationGateDelegate) CheckInstallation(
+	_ context.Context,
+	request market.InstallationCheckRequest,
+) (market.InstallationObservation, error) {
+	delegate.installationChecks++
+	state := delegate.installationState
+	if state == "" {
+		state = market.InstallationObservationPresent
+	}
+	return market.InstallationObservation{State: state, ConnectorKey: request.Connector.Key,
+		ReleaseDigest: request.Connector.Release.ReleaseDigest}, nil
 }
 
 func (delegate *activationGateDelegate) Reconcile(_ context.Context, request market.RuntimeReconcileRequest) (market.RuntimeReceipt, error) {
@@ -254,6 +269,25 @@ func TestBootstrapRestoresInstalledRuntimeWithoutRefreshingCatalog(t *testing.T)
 	if runtime.reconciles != 4 || !publication.values[len(publication.values)-1] {
 		t.Fatalf("same-account recovery reconciles=%d publication=%#v", runtime.reconciles, publication.values)
 	}
+	if runtime.installationChecks != 4 {
+		t.Fatalf("installation checks = %d, want one per non-idempotent bootstrap", runtime.installationChecks)
+	}
+
+	if err := host.FenceForScope(ctx, accountScope); err != nil {
+		t.Fatal(err)
+	}
+	runtime.installationState = market.InstallationObservationAbsent
+	if err := host.BootstrapForScope(ctx, accountScope); err != nil {
+		t.Fatalf("bootstrap with explicitly absent installation failed: %v", err)
+	}
+	calibrated, err := store.Connector(ctx, connector.Key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calibrated.Installation.State != market.InstallationStateFailed ||
+		calibrated.Installation.FailureCode != market.InstallationFailureCodeProbeAbsent || runtime.reconciles != 4 {
+		t.Fatalf("calibrated connector=%#v reconciles=%d", calibrated, runtime.reconciles)
+	}
 }
 
 func hostTestRelease() market.Release {
@@ -269,10 +303,12 @@ func hostTestRelease() market.Release {
 			DisplayName:       "GitHub",
 			IconURL:           "data:image/png;base64,iVBORw0KGgo=",
 			AuthorizationKind: "none",
-			Implementation: market.Implementation{
-				Kind:    market.ImplementationKindBuiltin,
-				Builtin: &market.BuiltinImplementation{ProviderID: "github", MCP: true},
-			},
+			Implementation: market.Implementation{Kind: market.ImplementationKindManagedStdio,
+				ManagedStdio: &market.ManagedStdioImplementation{
+					Runtime: market.RuntimeRequirement{Language: "node", Profile: "connector-node-static", ABI: "node22-darwin-arm64"},
+					MCP: &market.ManagedMCPInterface{Entrypoint: "bin/github.mjs",
+						InstallationProbe: &market.InstallationProbe{Arguments: []string{"--version"}, TimeoutMS: 1_000}},
+				}},
 		},
 		Artifact: market.Artifact{
 			Key:       "connectors/github/1.0.0.tgz",

--- a/packages/connector/host/README.md
+++ b/packages/connector/host/README.md
@@ -3,7 +3,10 @@
 `packages/connector/host` is the host-neutral Connector application core. It
 owns catalog acceptance, device installation and account authorization projections, durable
 operation transitions, compatibility evaluation, recovery, reconcile intent,
-manifest validation, and the ports implemented by daemon and runtime hosts.
+manifest validation, installation calibration, and the ports implemented by
+daemon and runtime hosts. Calibration executes only an already-installed
+release's bounded MCP/CLI probe and preserves durable state on indeterminate
+results.
 
 The package contains no HTTP client, SQLite driver, product account state,
 Electron API, absolute state root, or operating-system process policy.

--- a/packages/connector/host/account_runtime_binding.go
+++ b/packages/connector/host/account_runtime_binding.go
@@ -60,7 +60,7 @@ func (resolver AccountRuntimeBindingResolver) ResolveRuntimeBinding(
 	if projection.State != AuthorizationStateConnected {
 		return RuntimeBinding{ConnectionID: connectionID, Enabled: false}, nil
 	}
-	if request.Purpose == RuntimeBindingPurposeDeactivate {
+	if request.Purpose == RuntimeBindingPurposeDeactivate || request.Purpose == RuntimeBindingPurposeInstallationProbe {
 		return RuntimeBinding{ConnectionID: connectionID, Enabled: true}, nil
 	}
 	if resolver.Credentials == nil {

--- a/packages/connector/host/account_runtime_binding_test.go
+++ b/packages/connector/host/account_runtime_binding_test.go
@@ -58,6 +58,16 @@ func TestAccountRuntimeBindingResolverIssuesGrantOnlyForConnectedProjection(t *t
 	if !binding.Enabled || len(binding.CredentialBrokerGrant) != 0 || credentials.calls != 1 {
 		t.Fatalf("deactivation binding = %#v, credential calls = %d", binding, credentials.calls)
 	}
+	binding, err = resolver.ResolveRuntimeBinding(context.Background(), RuntimeBindingRequest{
+		Scope: OperationScope{AccountID: "account-1"}, Purpose: RuntimeBindingPurposeInstallationProbe,
+		Connector: Connector{Key: "github"}, Release: release,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !binding.Enabled || len(binding.CredentialBrokerGrant) != 0 || credentials.calls != 1 {
+		t.Fatalf("installation probe binding = %#v, credential calls = %d", binding, credentials.calls)
+	}
 }
 
 func TestAccountRuntimeBindingResolverUsesDeviceBindingForNoAuthConnector(t *testing.T) {

--- a/packages/connector/host/application.go
+++ b/packages/connector/host/application.go
@@ -19,6 +19,7 @@ type ApplicationConfig struct {
 	CatalogSource            CatalogSource
 	ArtifactPreparer         ArtifactPreparer
 	CLIInstallations         CLIInstallationManager
+	InstallationChecker      InstallationChecker
 	Host                     ImplementationHost
 	Authorization            AuthorizationProvider
 	AuthorizationProjections AuthorizationProjectionStore

--- a/packages/connector/host/application_installation_calibration.go
+++ b/packages/connector/host/application_installation_calibration.go
@@ -1,0 +1,123 @@
+package host
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const InstallationFailureCodeProbeAbsent = "connector_installation_probe_absent"
+
+// CalibrateInstalledConnectorsForScope compares durable installation truth
+// with explicit probes from releases that the user previously installed. A
+// probe is never executed for a catalog-only connector. Indeterminate checks
+// preserve SQLite state and are returned for diagnostics.
+func (application *Application) CalibrateInstalledConnectorsForScope(
+	ctx context.Context,
+	scope OperationScope,
+) error {
+	if application == nil || application.config.InstallationChecker == nil {
+		return nil
+	}
+	snapshot, err := application.config.Repository.Snapshot(ctx)
+	if err != nil {
+		return err
+	}
+	var calibrationErrors []error
+	for _, connector := range snapshot.Connectors {
+		if !installationCalibrationCandidate(connector) {
+			continue
+		}
+		release, evidenceErr := application.installedReleaseEvidence(ctx, connector)
+		if evidenceErr != nil {
+			calibrationErrors = append(calibrationErrors, fmt.Errorf("calibrate connector %s: %w", connector.Key, evidenceErr))
+			continue
+		}
+		if !releaseHasInstallationProbe(release) {
+			continue
+		}
+		installedConnector := connector
+		installedConnector.Release = release
+		operationID := "calibrate/" + application.config.BootEpoch + "/" + connector.Key
+		operation := Operation{OperationID: operationID, ConnectorKey: connector.Key, Scope: scope}
+		binding, bindingErr := application.resolveRuntimeBinding(ctx, operation, installedConnector, release, RuntimeBindingPurposeInstallationProbe)
+		if bindingErr != nil {
+			calibrationErrors = append(calibrationErrors, fmt.Errorf("calibrate connector %s binding: %w", connector.Key, bindingErr))
+			continue
+		}
+		clear(binding.CredentialBrokerGrant)
+		generation := HostGeneration{BootEpoch: application.config.BootEpoch, Generation: nextGeneration(connector.Revision)}
+		observation, checkErr := application.config.InstallationChecker.CheckInstallation(ctx, InstallationCheckRequest{
+			OperationID: operationID, Scope: scope, ConnectionID: binding.ConnectionID,
+			Connector: installedConnector, Generation: generation,
+		})
+		if checkErr != nil {
+			calibrationErrors = append(calibrationErrors, fmt.Errorf("calibrate connector %s installation: %w", connector.Key, checkErr))
+			continue
+		}
+		if observation.ConnectorKey != connector.Key || observation.ReleaseDigest != release.ReleaseDigest ||
+			(observation.State != InstallationObservationPresent && observation.State != InstallationObservationAbsent) {
+			calibrationErrors = append(calibrationErrors, fmt.Errorf("calibrate connector %s: installation checker returned a mismatched observation", connector.Key))
+			continue
+		}
+		if err := application.applyInstallationObservation(ctx, connector.Key, operationID, release.ReleaseDigest, observation.State); err != nil {
+			calibrationErrors = append(calibrationErrors, fmt.Errorf("calibrate connector %s projection: %w", connector.Key, err))
+		}
+	}
+	return errors.Join(calibrationErrors...)
+}
+
+func installationCalibrationCandidate(connector Connector) bool {
+	if strings.TrimSpace(connector.Installation.InstalledReleaseDigest) == "" {
+		return false
+	}
+	return connector.Installation.State == InstallationStateInstalled ||
+		(connector.Installation.State == InstallationStateFailed &&
+			connector.Installation.FailureCode == InstallationFailureCodeProbeAbsent)
+}
+
+func releaseHasInstallationProbe(release Release) bool {
+	managed := release.Manifest.Implementation.ManagedStdio
+	return managed != nil && ((managed.MCP != nil && managed.MCP.InstallationProbe != nil) ||
+		(managed.CLI != nil && managed.CLI.InstallationProbe != nil))
+}
+
+func (application *Application) applyInstallationObservation(
+	ctx context.Context,
+	connectorKey, operationID, releaseDigest string,
+	state InstallationObservationState,
+) error {
+	return application.config.Repository.Transaction(ctx, func(tx Transaction) error {
+		connector, err := tx.Connector(connectorKey)
+		if err != nil {
+			return err
+		}
+		if connector.Installation.InstalledReleaseDigest != releaseDigest || !installationCalibrationCandidate(connector) {
+			return nil
+		}
+		next := connector.Installation
+		switch state {
+		case InstallationObservationPresent:
+			if next.State == InstallationStateInstalled {
+				return nil
+			}
+			next.State, next.FailureCode = InstallationStateInstalled, ""
+		case InstallationObservationAbsent:
+			if next.State == InstallationStateFailed && next.FailureCode == InstallationFailureCodeProbeAbsent {
+				return nil
+			}
+			next.State, next.FailureCode = InstallationStateFailed, InstallationFailureCodeProbeAbsent
+		default:
+			return errors.New("installation observation state is invalid")
+		}
+		revision := tx.AdvanceRevision()
+		connector.Installation = next
+		connector.Revision = revision
+		if err := tx.SaveConnector(connector); err != nil {
+			return err
+		}
+		return tx.EnqueueConnectorMarketChanged(ChangedEvent{ConnectorKey: connector.Key,
+			OperationID: operationID, Revision: revision})
+	})
+}

--- a/packages/connector/host/application_installation_calibration_test.go
+++ b/packages/connector/host/application_installation_calibration_test.go
@@ -1,0 +1,73 @@
+package host
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestApplicationCalibrationMarksExplicitlyMissingInstallationAndRestoresIt(t *testing.T) {
+	connector := testConnector("github")
+	connector.Release.Manifest.Implementation.ManagedStdio.MCP.InstallationProbe =
+		&InstallationProbe{Arguments: []string{"--version"}, TimeoutMS: 1_000}
+	connector.Installation = Installation{State: InstallationStateInstalled,
+		InstalledVersion: connector.Release.Version, InstalledReleaseID: connector.Release.ReleaseID,
+		InstalledReleaseDigest: connector.Release.ReleaseDigest}
+	connector.Revision = 4
+	repository := newMemoryRepository(connector)
+	repository.revision = connector.Revision
+	runtime := &memoryInstallRuntime{installationResult: InstallationObservation{State: InstallationObservationAbsent}}
+	application := newTestApplication(t, repository, &memoryScheduler{}, runtime, CatalogSnapshot{})
+
+	if err := application.CalibrateInstalledConnectorsForScope(context.Background(), OperationScope{}); err != nil {
+		t.Fatal(err)
+	}
+	missing := repository.connectors[connector.Key]
+	if missing.Installation.State != InstallationStateFailed ||
+		missing.Installation.FailureCode != InstallationFailureCodeProbeAbsent ||
+		missing.Installation.InstalledReleaseDigest != connector.Release.ReleaseDigest || missing.Revision != 5 {
+		t.Fatalf("missing calibration = %#v", missing)
+	}
+	if runtime.installationChecks != 1 || len(repository.events) != 1 ||
+		repository.events[0].OperationID != "calibrate/operation-2/github" {
+		t.Fatalf("checks=%d events=%#v", runtime.installationChecks, repository.events)
+	}
+
+	runtime.installationResult.State = InstallationObservationPresent
+	if err := application.CalibrateInstalledConnectorsForScope(context.Background(), OperationScope{}); err != nil {
+		t.Fatal(err)
+	}
+	restored := repository.connectors[connector.Key]
+	if restored.Installation.State != InstallationStateInstalled || restored.Installation.FailureCode != "" || restored.Revision != 6 {
+		t.Fatalf("restored calibration = %#v", restored)
+	}
+}
+
+func TestApplicationCalibrationPreservesStateForIndeterminateOrUndeclaredProbe(t *testing.T) {
+	connector := testConnector("github")
+	connector.Installation = Installation{State: InstallationStateInstalled,
+		InstalledVersion: connector.Release.Version, InstalledReleaseID: connector.Release.ReleaseID,
+		InstalledReleaseDigest: connector.Release.ReleaseDigest}
+	repository := newMemoryRepository(connector)
+	runtime := &memoryInstallRuntime{installationCheckErr: errors.New("probe timed out")}
+	application := newTestApplication(t, repository, &memoryScheduler{}, runtime, CatalogSnapshot{})
+
+	if err := application.CalibrateInstalledConnectorsForScope(context.Background(), OperationScope{}); err != nil {
+		t.Fatalf("legacy connector without probe returned error: %v", err)
+	}
+	if runtime.installationChecks != 0 {
+		t.Fatalf("undeclared probe checks = %d", runtime.installationChecks)
+	}
+
+	connector = repository.connectors[connector.Key]
+	connector.Release.Manifest.Implementation.ManagedStdio.MCP.InstallationProbe =
+		&InstallationProbe{Arguments: []string{"--version"}, TimeoutMS: 1_000}
+	repository.connectors[connector.Key] = connector
+	if err := application.CalibrateInstalledConnectorsForScope(context.Background(), OperationScope{}); err == nil {
+		t.Fatal("indeterminate probe error was discarded")
+	}
+	preserved := repository.connectors[connector.Key]
+	if preserved.Installation.State != InstallationStateInstalled || preserved.Installation.FailureCode != "" || len(repository.events) != 0 {
+		t.Fatalf("indeterminate probe changed projection: %#v events=%#v", preserved, repository.events)
+	}
+}

--- a/packages/connector/host/application_test.go
+++ b/packages/connector/host/application_test.go
@@ -808,10 +808,14 @@ func newTestApplicationWithCatalogSource(
 	t.Helper()
 	nextID := 0
 	application, err := NewApplication(ApplicationConfig{
-		Repository:             repository,
-		CatalogSource:          catalogSource,
-		ArtifactPreparer:       installationHost,
-		CLIInstallations:       installationHost,
+		Repository:       repository,
+		CatalogSource:    catalogSource,
+		ArtifactPreparer: installationHost,
+		CLIInstallations: installationHost,
+		InstallationChecker: func() InstallationChecker {
+			checker, _ := any(installationHost).(InstallationChecker)
+			return checker
+		}(),
 		Host:                   installationHost,
 		Authorization:          authorizationProviderStub{},
 		Compatibility:          compatibilityEvaluatorStub{},
@@ -927,20 +931,23 @@ func (scheduler *memoryScheduler) Schedule(_ context.Context, operationID string
 }
 
 type memoryInstallRuntime struct {
-	prepares            int
-	removes             int
-	activations         int
-	deactivations       int
-	activeDigest        string
-	reconciles          int
-	lastReconcile       RuntimeReconcileRequest
-	lastDeactivation    RuntimeDeactivationRequest
-	lastPrepare         PrepareArtifactRequest
-	lastCredentialGrant string
-	deactivationErr     error
-	failClosed          int
-	cliInstalls         int
-	cliRemoves          int
+	prepares             int
+	removes              int
+	activations          int
+	deactivations        int
+	activeDigest         string
+	reconciles           int
+	lastReconcile        RuntimeReconcileRequest
+	lastDeactivation     RuntimeDeactivationRequest
+	lastPrepare          PrepareArtifactRequest
+	lastCredentialGrant  string
+	deactivationErr      error
+	failClosed           int
+	cliInstalls          int
+	cliRemoves           int
+	installationChecks   int
+	installationResult   InstallationObservation
+	installationCheckErr error
 }
 
 func (host *memoryInstallRuntime) Reconcile(_ context.Context, request RuntimeReconcileRequest) (RuntimeReceipt, error) {
@@ -949,6 +956,24 @@ func (host *memoryInstallRuntime) Reconcile(_ context.Context, request RuntimeRe
 	host.lastCredentialGrant = string(request.CredentialBrokerGrant)
 	return RuntimeReceipt{OperationID: request.OperationID, ConnectionID: request.ConnectionID,
 		ConnectorKey: request.Connector.Key, ReleaseDigest: request.Connector.Release.ReleaseDigest, Generation: request.Generation}, nil
+}
+
+func (host *memoryInstallRuntime) CheckInstallation(_ context.Context, request InstallationCheckRequest) (InstallationObservation, error) {
+	host.installationChecks++
+	if host.installationCheckErr != nil {
+		return InstallationObservation{}, host.installationCheckErr
+	}
+	result := host.installationResult
+	if result.State == "" {
+		result.State = InstallationObservationPresent
+	}
+	if result.ConnectorKey == "" {
+		result.ConnectorKey = request.Connector.Key
+	}
+	if result.ReleaseDigest == "" {
+		result.ReleaseDigest = request.Connector.Release.ReleaseDigest
+	}
+	return result, nil
 }
 
 func (host *memoryInstallRuntime) DeactivateRuntime(_ context.Context, request RuntimeDeactivationRequest) error {

--- a/packages/connector/host/manifest.go
+++ b/packages/connector/host/manifest.go
@@ -246,8 +246,13 @@ func validateManagedStdio(managed ManagedStdioImplementation, authorizationKind 
 	if managed.MCP == nil && managed.CLI == nil {
 		return invalidManifest("managed_stdio requires an MCP or CLI interface", nil)
 	}
-	if managed.MCP != nil && !safeRelativeEntrypoint(managed.MCP.Entrypoint) {
-		return invalidManifest("managed MCP entrypoint must be a safe relative path", nil)
+	if managed.MCP != nil {
+		if !safeRelativeEntrypoint(managed.MCP.Entrypoint) {
+			return invalidManifest("managed MCP entrypoint must be a safe relative path", nil)
+		}
+		if err := validateInstallationProbe(managed.MCP.InstallationProbe); err != nil {
+			return err
+		}
 	}
 	if managed.CLI != nil {
 		if managed.Runtime.Language != "node" || managed.Runtime.Profile != "connector-node-static" {
@@ -263,6 +268,9 @@ func validateManagedStdio(managed ManagedStdioImplementation, authorizationKind 
 			if strings.ContainsRune(argument, '\x00') {
 				return invalidManifest("managed CLI arguments must not contain NUL", nil)
 			}
+		}
+		if err := validateInstallationProbe(managed.CLI.InstallationProbe); err != nil {
+			return err
 		}
 		if managed.CLI.Install != nil {
 			if err := validateCLIInstallation(*managed.CLI.Install, managed.Runtime, managed.CLI.Entrypoint); err != nil {
@@ -297,6 +305,23 @@ func validateManagedStdio(managed ManagedStdioImplementation, authorizationKind 
 	}
 	if authorizationKind == "none" && managed.CredentialBroker != nil {
 		return invalidManifest("credential broker must not be declared when authorization is none", nil)
+	}
+	return nil
+}
+
+func validateInstallationProbe(probe *InstallationProbe) error {
+	if probe == nil {
+		return nil
+	}
+	if len(probe.Arguments) == 0 || len(probe.Arguments) > 32 || probe.TimeoutMS < 100 || probe.TimeoutMS > 30_000 {
+		return invalidManifest("installationProbe requires between 1 and 32 arguments and timeoutMs between 100 and 30000", nil)
+	}
+	totalBytes := 0
+	for _, argument := range probe.Arguments {
+		totalBytes += len(argument)
+		if strings.ContainsRune(argument, '\x00') || totalBytes > 16*1024 {
+			return invalidManifest("installationProbe arguments are invalid", nil)
+		}
 	}
 	return nil
 }

--- a/packages/connector/host/manifest_test.go
+++ b/packages/connector/host/manifest_test.go
@@ -172,6 +172,32 @@ func TestManagedCLIAllowsTypedNodePackageWithoutActionMappings(t *testing.T) {
 	}
 }
 
+func TestManagedInterfacesValidateBoundedInstallationProbes(t *testing.T) {
+	manifest := Manifest{SchemaVersion: "1", DisplayName: "Probe", IconURL: testConnectorIconURL, AuthorizationKind: "none",
+		Implementation: Implementation{Kind: ImplementationKindManagedStdio, ManagedStdio: &ManagedStdioImplementation{
+			Runtime: RuntimeRequirement{Language: "node", Profile: "connector-node-static", ABI: "node22-darwin-arm64",
+				VersionRange: ">=22.0.0 <23.0.0"},
+			MCP: &ManagedMCPInterface{Entrypoint: "bin/server.mjs",
+				InstallationProbe: &InstallationProbe{Arguments: []string{"--version"}, TimeoutMS: 3_000}},
+			CLI: &ManagedCLIInterface{Entrypoint: "bin/cli.mjs", TimeoutMS: 30_000,
+				InstallationProbe: &InstallationProbe{Arguments: []string{"doctor", "--quiet"}, TimeoutMS: 5_000},
+				Commands:          []CLICommand{{Name: "run", InputSchema: map[string]any{"type": "object"}, TimeoutMS: 30_000}}},
+		}}}
+	if err := ValidateManifestShape(manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest.Implementation.ManagedStdio.MCP.InstallationProbe.Arguments = nil
+	if err := ValidateManifestShape(manifest); err == nil || !strings.Contains(err.Error(), "installationProbe") {
+		t.Fatalf("empty installation probe error = %v", err)
+	}
+	manifest.Implementation.ManagedStdio.MCP.InstallationProbe.Arguments = []string{"--version"}
+	manifest.Implementation.ManagedStdio.CLI.InstallationProbe.TimeoutMS = 30_001
+	if err := ValidateManifestShape(manifest); err == nil || !strings.Contains(err.Error(), "installationProbe") {
+		t.Fatalf("unbounded installation probe error = %v", err)
+	}
+}
+
 func TestManagedCLIRequiresExplicitNodeVersionAndExactIntegrity(t *testing.T) {
 	manifest := Manifest{
 		SchemaVersion: "1", DisplayName: "Lark", IconURL: testConnectorIconURL, AuthorizationKind: "none",

--- a/packages/connector/host/ports.go
+++ b/packages/connector/host/ports.go
@@ -146,6 +146,34 @@ type RuntimeObservation struct {
 	ReleaseDigest string
 }
 
+type InstallationObservationState string
+
+const (
+	InstallationObservationPresent InstallationObservationState = "present"
+	InstallationObservationAbsent  InstallationObservationState = "absent"
+)
+
+type InstallationObservation struct {
+	State         InstallationObservationState
+	ConnectorKey  string
+	ReleaseDigest string
+}
+
+// InstallationChecker executes only signed, bounded probes declared by a
+// release that was previously installed. It must not probe unaccepted catalog
+// entries or turn transient execution errors into an absent observation.
+type InstallationChecker interface {
+	CheckInstallation(context.Context, InstallationCheckRequest) (InstallationObservation, error)
+}
+
+type InstallationCheckRequest struct {
+	OperationID  string
+	Scope        OperationScope
+	ConnectionID string
+	Connector    Connector
+	Generation   HostGeneration
+}
+
 // ImplementationHost reconciles installed connector releases into global MCP
 // routes and CLI registrations.
 type ImplementationHost interface {
@@ -195,8 +223,9 @@ type RuntimeBindingRequest struct {
 type RuntimeBindingPurpose string
 
 const (
-	RuntimeBindingPurposeReconcile  RuntimeBindingPurpose = "reconcile"
-	RuntimeBindingPurposeDeactivate RuntimeBindingPurpose = "deactivate"
+	RuntimeBindingPurposeReconcile         RuntimeBindingPurpose = "reconcile"
+	RuntimeBindingPurposeDeactivate        RuntimeBindingPurpose = "deactivate"
+	RuntimeBindingPurposeInstallationProbe RuntimeBindingPurpose = "installation_probe"
 )
 
 type RuntimeBinding struct {

--- a/packages/connector/host/types.go
+++ b/packages/connector/host/types.go
@@ -171,16 +171,26 @@ type ManagedCredentialBroker struct {
 }
 
 type ManagedMCPInterface struct {
-	Entrypoint string   `json:"entrypoint"`
-	Arguments  []string `json:"arguments,omitempty"`
+	Entrypoint        string             `json:"entrypoint"`
+	Arguments         []string           `json:"arguments,omitempty"`
+	InstallationProbe *InstallationProbe `json:"installationProbe,omitempty"`
 }
 
 type ManagedCLIInterface struct {
-	Entrypoint string           `json:"entrypoint"`
-	Arguments  []string         `json:"arguments,omitempty"`
-	TimeoutMS  int              `json:"timeoutMs,omitempty"`
-	Install    *CLIInstallation `json:"install,omitempty"`
-	Commands   []CLICommand     `json:"commands,omitempty"`
+	Entrypoint        string             `json:"entrypoint"`
+	Arguments         []string           `json:"arguments,omitempty"`
+	TimeoutMS         int                `json:"timeoutMs,omitempty"`
+	InstallationProbe *InstallationProbe `json:"installationProbe,omitempty"`
+	Install           *CLIInstallation   `json:"install,omitempty"`
+	Commands          []CLICommand       `json:"commands,omitempty"`
+}
+
+// InstallationProbe is a bounded, direct-argv check executed through the
+// interface's already verified entrypoint. Exit code 0 reports present and
+// exit code 1 reports absent; every other outcome is indeterminate.
+type InstallationProbe struct {
+	Arguments []string `json:"arguments"`
+	TimeoutMS int      `json:"timeoutMs"`
 }
 
 // CLIInstallation is a typed installation command. The daemon compiles this

--- a/packages/connector/market/src/services/view/connectorMarketViewBuilder.test.ts
+++ b/packages/connector/market/src/services/view/connectorMarketViewBuilder.test.ts
@@ -199,6 +199,34 @@ test("keeps authorization-free connectors on the management action", () => {
   assert.equal(view.cardsByKey[connector.key]?.action, "manage");
 });
 
+test("offers repair when calibration finds the installed implementation absent", () => {
+  const market = createConnectorMarketStoreState();
+  const connector = connectorFixture();
+  connector.installation = {
+    failureCode: "connector_installation_probe_absent",
+    installedReleaseDigest: connector.release.releaseDigest,
+    installedReleaseId: connector.release.releaseId,
+    installedVersion: connector.release.version,
+    state: "failed"
+  };
+  market.connectorKeys = [connector.key];
+  market.connectorsByKey[connector.key] = connector;
+
+  const view = buildConnectorMarketView(market, {
+    ...uiState,
+    dialog: { connectorKey: connector.key },
+    segment: "installed"
+  });
+
+  assert.equal(view.cardsByKey[connector.key]?.action, "install");
+  assert.equal(view.cardsByKey[connector.key]?.status, "not_installed");
+  assert.equal(view.dialog?.kind, "installation");
+  assert.equal(
+    view.dialog?.kind === "installation" && view.dialog.updating,
+    false
+  );
+});
+
 function connectorFixture(): Connector {
   return {
     authorization: { state: "disconnected" },

--- a/packages/connector/market/src/services/view/connectorMarketViewBuilder.ts
+++ b/packages/connector/market/src/services/view/connectorMarketViewBuilder.ts
@@ -244,6 +244,12 @@ function buildConnectorDialogView(
 
 function connectorHasInstalledArtifact(connector: Connector): boolean {
   if (
+    connector.installation.state === "failed" &&
+    connector.installation.failureCode === "connector_installation_probe_absent"
+  ) {
+    return false;
+  }
+  if (
     connector.installation.installedReleaseDigest ||
     connector.installation.installedReleaseId ||
     connector.installation.installedVersion

--- a/packages/connector/runtime/README.md
+++ b/packages/connector/runtime/README.md
@@ -12,6 +12,12 @@ transport, HTTP client/proxy policy, state roots, and product-facing command
 transport. Runtime code must not import `services/tuttid` or expose host
 filesystem paths as a cross-machine protocol.
 
+Managed MCP and CLI releases may provide a bounded `installationProbe` argv.
+The runtime launches it through the interface's verified entrypoint and runtime
+without a shell; only exit codes 0 (present) and 1 (absent) are observations.
+Timeouts, transport failures, and other exit codes remain indeterminate so they
+cannot erase durable installation truth.
+
 Authorized `managed_stdio` Connectors declare a connector-owned
 credential broker entrypoint. The broker translates its provider-specific
 flow into the `tutti.connector.credentials.v1` event protocol. Tutti validates

--- a/packages/connector/runtime/implementationhost/installation_probe.go
+++ b/packages/connector/runtime/implementationhost/installation_probe.go
@@ -1,0 +1,170 @@
+package implementationhost
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
+	market "github.com/tutti-os/tutti/packages/connector/host"
+	connectorruntime "github.com/tutti-os/tutti/packages/connector/runtime"
+)
+
+const maxInstallationProbeOutput = 64 << 10
+
+// CheckInstallation runs the signed release's explicit MCP/CLI probes without
+// publishing a route. It never infers absence from a timeout, transport error,
+// or an unexpected exit code.
+func (host *Host) CheckInstallation(
+	ctx context.Context,
+	request market.InstallationCheckRequest,
+) (market.InstallationObservation, error) {
+	if host == nil || host.artifacts == nil || host.planner == nil || host.processes == nil ||
+		!hostIdentityPattern.MatchString(request.ConnectionID) ||
+		!hostIdentityPattern.MatchString(request.Connector.Key) ||
+		strings.TrimSpace(request.OperationID) == "" ||
+		strings.TrimSpace(request.Generation.BootEpoch) == "" || request.Generation.Generation == 0 {
+		return market.InstallationObservation{}, errors.New("connector installation probe identity is invalid")
+	}
+	release := request.Connector.Release
+	if err := market.ValidateRuntimeReleaseShape(release); err != nil {
+		return market.InstallationObservation{}, err
+	}
+	managed := release.Manifest.Implementation.ManagedStdio
+	if release.Manifest.Implementation.Kind != market.ImplementationKindManagedStdio || managed == nil ||
+		!hasInstallationProbe(managed) {
+		return market.InstallationObservation{}, errors.New("connector installation probe is not declared")
+	}
+	prepared, err := host.artifacts.ResolvePrepared(ctx, release)
+	if err != nil {
+		return market.InstallationObservation{}, fmt.Errorf("resolve prepared connector artifact for installation probe: %w", err)
+	}
+	plan, err := host.planner.Build(ctx, market.RuntimeReconcileRequest{
+		OperationID: request.OperationID, Scope: request.Scope, ConnectionID: request.ConnectionID,
+		Connector: request.Connector, Generation: request.Generation,
+	}, prepared)
+	if err != nil {
+		if errors.Is(err, connectorruntime.ErrCLIInstallationUnavailable) &&
+			managed.CLI != nil && managed.CLI.InstallationProbe != nil {
+			return installationObservation(request, market.InstallationObservationAbsent), nil
+		}
+		return market.InstallationObservation{}, err
+	}
+	if managed.MCP != nil && managed.MCP.InstallationProbe != nil {
+		present, probeErr := host.runManagedInstallationProbe(ctx, request, plan, prepared,
+			managed.MCP.Entrypoint, managed.MCP.Arguments, managed.MCP.InstallationProbe, nil)
+		if probeErr != nil {
+			return market.InstallationObservation{}, fmt.Errorf("probe connector MCP installation: %w", probeErr)
+		}
+		if !present {
+			return installationObservation(request, market.InstallationObservationAbsent), nil
+		}
+	}
+	if managed.CLI != nil && managed.CLI.InstallationProbe != nil {
+		present, probeErr := host.runManagedInstallationProbe(ctx, request, plan, prepared,
+			managed.CLI.Entrypoint, managed.CLI.Arguments, managed.CLI.InstallationProbe, plan.InstalledCLI)
+		if probeErr != nil {
+			return market.InstallationObservation{}, fmt.Errorf("probe connector CLI installation: %w", probeErr)
+		}
+		if !present {
+			return installationObservation(request, market.InstallationObservationAbsent), nil
+		}
+	}
+	return installationObservation(request, market.InstallationObservationPresent), nil
+}
+
+func hasInstallationProbe(managed *market.ManagedStdioImplementation) bool {
+	return managed != nil && ((managed.MCP != nil && managed.MCP.InstallationProbe != nil) ||
+		(managed.CLI != nil && managed.CLI.InstallationProbe != nil))
+}
+
+func installationObservation(
+	request market.InstallationCheckRequest,
+	state market.InstallationObservationState,
+) market.InstallationObservation {
+	return market.InstallationObservation{State: state, ConnectorKey: request.Connector.Key,
+		ReleaseDigest: request.Connector.Release.ReleaseDigest}
+}
+
+func (host *Host) runManagedInstallationProbe(
+	ctx context.Context,
+	request market.InstallationCheckRequest,
+	plan connectorruntime.ManagedRoutePlan,
+	prepared market.PreparedArtifactReceipt,
+	entrypointRelative string,
+	interfaceArguments []string,
+	probe *market.InstallationProbe,
+	installed *market.CLIInstallationReceipt,
+) (bool, error) {
+	entrypointRoot := prepared.PreparedPath
+	if installed != nil {
+		entrypointRoot, entrypointRelative = installed.InstallRoot, installed.Entrypoint
+	}
+	entrypoint, err := connectorruntime.PreparedEntrypoint(entrypointRoot, entrypointRelative)
+	if err != nil {
+		return false, err
+	}
+	launchExecutable := plan.Executable
+	arguments := []string{entrypoint}
+	if installed != nil && installed.LaunchKind == "native" {
+		launchExecutable = connectorruntime.ConnectorExecutable{Path: entrypoint,
+			SHA256: installed.EntrypointSHA256, SizeBytes: installed.EntrypointSize}
+		arguments = nil
+	}
+	arguments = append(arguments, interfaceArguments...)
+	arguments = append(arguments, probe.Arguments...)
+	probeCtx, cancel := context.WithTimeout(ctx, time.Duration(probe.TimeoutMS)*time.Millisecond)
+	defer cancel()
+	spec := connectorruntime.ConnectorProcessSpec(request.ConnectionID, request.Connector.Key,
+		plan.Managed.Runtime.Language, launchExecutable, prepared.PreparedPath, arguments,
+		plan.StateDir, plan.UserHome, plan.ArtifactTrees)
+	connection, err := host.processes.Start(probeCtx, spec)
+	if err != nil {
+		return false, err
+	}
+	defer connection.Close()
+	if graceful, ok := connection.(agentruntime.GracefulProcessConnection); ok {
+		_ = graceful.CloseInput()
+	}
+	return waitInstallationProbe(probeCtx, connection)
+}
+
+func waitInstallationProbe(ctx context.Context, connection agentruntime.ProcessConnection) (bool, error) {
+	outputBytes := 0
+	for {
+		var frame agentruntime.ProcessFrame
+		var err error
+		if contextual, ok := connection.(agentruntime.ContextProcessConnection); ok {
+			frame, err = contextual.RecvContext(ctx)
+		} else {
+			frame, err = connection.Recv()
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return false, errors.New("installation probe exited without an exit code")
+			}
+			return false, err
+		}
+		outputBytes += len(frame.Stdout) + len(frame.Stderr)
+		if outputBytes > maxInstallationProbeOutput {
+			if graceful, ok := connection.(agentruntime.GracefulProcessConnection); ok {
+				_ = graceful.Kill()
+			}
+			return false, errors.New("installation probe output exceeded its limit")
+		}
+		if frame.ExitCode == nil {
+			continue
+		}
+		switch *frame.ExitCode {
+		case 0:
+			return true, nil
+		case 1:
+			return false, nil
+		default:
+			return false, fmt.Errorf("installation probe exited with indeterminate code %d", *frame.ExitCode)
+		}
+	}
+}

--- a/packages/connector/runtime/implementationhost/installation_probe_test.go
+++ b/packages/connector/runtime/implementationhost/installation_probe_test.go
@@ -1,0 +1,57 @@
+package implementationhost
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
+)
+
+type installationProbeConnection struct {
+	frames []agentruntime.ProcessFrame
+	index  int
+}
+
+func (*installationProbeConnection) Send([]byte) error { return nil }
+func (*installationProbeConnection) Close() error      { return nil }
+func (connection *installationProbeConnection) Recv() (agentruntime.ProcessFrame, error) {
+	if connection.index >= len(connection.frames) {
+		return agentruntime.ProcessFrame{}, io.EOF
+	}
+	frame := connection.frames[connection.index]
+	connection.index++
+	return frame, nil
+}
+
+func TestWaitInstallationProbeUsesOnlyDeclaredExitCodes(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		exit    int
+		present bool
+		wantErr bool
+	}{
+		{name: "present", exit: 0, present: true},
+		{name: "absent", exit: 1},
+		{name: "indeterminate", exit: 2, wantErr: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			connection := &installationProbeConnection{frames: []agentruntime.ProcessFrame{{Stdout: []byte("probe\n")}, {ExitCode: &test.exit}}}
+			present, err := waitInstallationProbe(context.Background(), connection)
+			if present != test.present || (err != nil) != test.wantErr {
+				t.Fatalf("present=%v error=%v", present, err)
+			}
+		})
+	}
+}
+
+func TestWaitInstallationProbeRejectsMissingExitAndOversizedOutput(t *testing.T) {
+	if _, err := waitInstallationProbe(context.Background(), &installationProbeConnection{}); err == nil {
+		t.Fatal("EOF without exit code was accepted")
+	}
+	connection := &installationProbeConnection{frames: []agentruntime.ProcessFrame{{Stdout: make([]byte, maxInstallationProbeOutput+1)}}}
+	if _, err := waitInstallationProbe(context.Background(), connection); err == nil || errors.Is(err, io.EOF) {
+		t.Fatalf("oversized output error = %v", err)
+	}
+}

--- a/packages/connector/runtime/managed_route_plan.go
+++ b/packages/connector/runtime/managed_route_plan.go
@@ -15,6 +15,13 @@ import (
 
 var runtimeIdentityPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,190}$`)
 
+// ErrCLIInstallationUnavailable reports that the release-scoped CLI files or
+// their verified receipt no longer match the signed installation contract.
+// Callers may treat this as explicit installation drift; runtime/profile
+// failures remain ordinary errors and must not rewrite durable installation
+// truth.
+var ErrCLIInstallationUnavailable = errors.New("connector CLI installation is unavailable")
+
 type ManagedRoutePlannerConfig struct {
 	StateRoot        string
 	UserHome         string
@@ -79,7 +86,7 @@ func (planner *ManagedRoutePlanner) Build(ctx context.Context, request market.Ru
 		}
 		receipt, resolveErr := planner.cliInstallations.ResolveCLI(ctx, request.Connector.Release)
 		if resolveErr != nil {
-			return ManagedRoutePlan{}, fmt.Errorf("resolve connector CLI installation: %w", resolveErr)
+			return ManagedRoutePlan{}, fmt.Errorf("%w: %v", ErrCLIInstallationUnavailable, resolveErr)
 		}
 		installed = &receipt
 	}

--- a/packages/connector/store-sqlite/README.md
+++ b/packages/connector/store-sqlite/README.md
@@ -14,4 +14,6 @@ Active operations and pending outbox events are durable and never age-pruned.
 The lifecycle cleanup contract removes bounded batches of expired terminal
 operations and already-published events. Installed release evidence is stored
 separately from operation history so runtime recovery does not depend on an
-expired operation row.
+expired operation row. A probe-detected missing implementation retains that
+evidence while installation is failed, allowing repair or uninstall to keep
+targeting the accepted release.

--- a/services/tuttid/service/connectormarket/implementation_host.go
+++ b/services/tuttid/service/connectormarket/implementation_host.go
@@ -108,6 +108,16 @@ func (host *ImplementationHost) Reconcile(ctx context.Context, request market.Ru
 	return host.runtime.Reconcile(ctx, implementationhost.ReconcileRequest{Runtime: request})
 }
 
+func (host *ImplementationHost) CheckInstallation(
+	ctx context.Context,
+	request market.InstallationCheckRequest,
+) (market.InstallationObservation, error) {
+	if host == nil || host.runtime == nil {
+		return market.InstallationObservation{}, errors.New("connector implementation host is unavailable")
+	}
+	return host.runtime.CheckInstallation(ctx, request)
+}
+
 func (host *ImplementationHost) Begin(ctx context.Context, request market.AuthorizationStartRequest) (market.AuthorizationSession, error) {
 	if host == nil || host.runtime == nil {
 		return market.AuthorizationSession{}, errors.New("connector authorization provider is unavailable")

--- a/services/tuttid/service/connectormarket/implementation_host_test.go
+++ b/services/tuttid/service/connectormarket/implementation_host_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -202,11 +203,14 @@ func (stub connectorRuntimeStub) VerifyLaunch(string, string) (connectorruntime.
 	return stub.executable, nil
 }
 
-type connectorProcessStub struct{ starts int }
+type connectorProcessStub struct {
+	starts   int
+	exitCode int
+}
 
 func (stub *connectorProcessStub) Start(context.Context, agentruntime.ProcessSpec) (agentruntime.ProcessConnection, error) {
 	stub.starts++
-	exit := 0
+	exit := stub.exitCode
 	return &connectorConnectionStub{frames: []agentruntime.ProcessFrame{{Stdout: []byte(`{"ok":true}`)}, {ExitCode: &exit}}}, nil
 }
 
@@ -254,6 +258,37 @@ func TestContainsPermissionScopeAcceptsScopedPermission(t *testing.T) {
 	}
 	if connectorruntime.ContainsPermissionScope([]string{"filesystem:workspace"}, "network") {
 		t.Fatal("unrelated scoped permission enabled connector network access")
+	}
+}
+
+func TestImplementationHostChecksCLIInstallationWithDeclaredProbeArguments(t *testing.T) {
+	processes := &recordingConnectorProcessStub{}
+	host, _, connector, generation := testCLIHost(t, processes)
+	cli := connector.Release.Manifest.Implementation.ManagedStdio.CLI
+	cli.Arguments = []string{"--non-interactive"}
+	cli.InstallationProbe = &market.InstallationProbe{Arguments: []string{"doctor", "--quiet"}, TimeoutMS: 1_000}
+	request := market.InstallationCheckRequest{OperationID: "probe-1", ConnectionID: "workspace-1",
+		Connector: connector, Generation: generation}
+
+	observation, err := host.CheckInstallation(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if observation.State != market.InstallationObservationPresent || observation.ConnectorKey != connector.Key ||
+		observation.ReleaseDigest != implementationHostTestReleaseDigest {
+		t.Fatalf("observation = %#v", observation)
+	}
+	entrypoint := filepath.Join(processes.spec.CWD, "connector.js")
+	wantSuffix := []string{entrypoint, "--non-interactive", "doctor", "--quiet"}
+	if len(processes.spec.Command) < len(wantSuffix)+1 ||
+		!slices.Equal(processes.spec.Command[len(processes.spec.Command)-len(wantSuffix):], wantSuffix) {
+		t.Fatalf("probe command = %#v, want suffix %#v", processes.spec.Command, wantSuffix)
+	}
+
+	processes.exitCode = 1
+	observation, err = host.CheckInstallation(context.Background(), request)
+	if err != nil || observation.State != market.InstallationObservationAbsent {
+		t.Fatalf("absent observation = %#v, error = %v", observation, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add bounded MCP/CLI `installationProbe` declarations to managed connector manifests
- calibrate previously installed connector releases against their verified runtime and CLI receipt during daemon bootstrap
- preserve durable release evidence while marking explicitly missing implementations failed, and restore installed state after recovery
- project probe-detected absence as a repair/install action in Connector Market

## Probe semantics

- exit `0`: implementation present
- exit `1`: implementation absent
- timeout, launch failure, or any other exit: indeterminate; durable installation state is preserved
- probes run only for releases with prior installation evidence and never receive account credential grants

## Connector integration

The Lark CLI declaration and connector protocol support were merged separately in tutti-lab/tutti-connectors#24.

## Validation

- `pnpm check:changed` — 18 lanes passed
- push-ready `pnpm check:changed` — 20 lanes passed
- `cd services/tuttid && go build ./...`
- focused host/runtime/daemon/service tests are included in the changed-aware plan