### PR TITLE
fix(agent): deduplicate compaction advisory warning

### DIFF
--- a/packages/agent/daemon/runtime/acp_turn_normalizer.go
+++ b/packages/agent/daemon/runtime/acp_turn_normalizer.go
@@ -55,6 +55,15 @@ func (n *acpTurnNormalizer) StartCompactionNotice(messageID string) (string, boo
 	return messageID, true
 }
 
+func (n *acpTurnNormalizer) HasCompactionNotice() bool {
+	if n == nil {
+		return false
+	}
+	n.compactionMu.Lock()
+	defer n.compactionMu.Unlock()
+	return n.compactionMessageID != ""
+}
+
 // CompleteCompactionNotice selects the provider-reported completed terminal.
 // Terminal selection is first-write-wins: a late completion after a locally
 // synthesized failed/canceled terminal is ignored.

--- a/packages/agent/daemon/runtime/codex_appserver_events.go
+++ b/packages/agent/daemon/runtime/codex_appserver_events.go
@@ -71,7 +71,7 @@ func appServerNotificationUsesNormalizer(method string) bool {
 	switch method {
 	case appServerNotifyAgentMessageDelta, appServerNotifyReasoningDelta, appServerNotifyReasoningSummary,
 		appServerNotifyItemStarted, appServerNotifyItemCompleted, appServerNotifyCommandOutputDelta,
-		appServerNotifyPlanUpdated:
+		appServerNotifyPlanUpdated, appServerNotifyWarning:
 		return true
 	default:
 		return false
@@ -107,6 +107,7 @@ const (
 	appServerCompactingContextTitle     = "Compacting context."
 	appServerContextCompactedTitle      = "Context compacted."
 	appServerCompactionInterruptedTitle = "Context compaction interrupted."
+	appServerCompactionAdvisoryMessage  = "Heads up: Long threads and multiple compactions can cause the model to be less accurate. Start a new thread when possible to keep threads small and targeted."
 )
 
 // appServerCompactionNoticeEvent emits the compaction banner for both item

--- a/packages/agent/daemon/runtime/codex_appserver_events_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_events_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -68,6 +69,92 @@ func mustJSONRawMessage(t *testing.T, value any) json.RawMessage {
 		t.Fatalf("json.Marshal: %v", err)
 	}
 	return raw
+}
+
+func TestCodexAppServerCompactionAdvisoryWarningIsScopedToCompaction(t *testing.T) {
+	t.Parallel()
+
+	session := reportTestSession()
+	session.ProviderSessionID = "thread-1"
+	reducer := newCodexAppServerReducer(&CodexAppServerAdapter{})
+	warning := acpMessage{
+		Method: appServerNotifyWarning,
+		Params: mustJSONRawMessage(t, map[string]any{
+			"threadId": "thread-1",
+			"turnId":   "provider-turn-1",
+			"message":  appServerCompactionAdvisoryMessage,
+		}),
+	}
+
+	withoutCompaction := reducer.ReduceNotification(
+		nil,
+		session,
+		"turn-1",
+		warning,
+		newACPTurnNormalizer(),
+		nil,
+	)
+	if len(withoutCompaction.Events) != 1 {
+		t.Fatalf("unscoped advisory events = %#v, want one warning notice", withoutCompaction.Events)
+	}
+
+	compaction := newACPTurnNormalizer()
+	compaction.StartCompactionNotice("compaction:turn-1")
+	duringCompaction := reducer.ReduceNotification(
+		nil,
+		session,
+		"turn-1",
+		warning,
+		compaction,
+		nil,
+	)
+	if len(duringCompaction.Events) != 0 {
+		t.Fatalf("compaction advisory events = %#v, want no duplicate transcript warning", duringCompaction.Events)
+	}
+	warning.Params = mustJSONRawMessage(t, map[string]any{
+		"threadId": "thread-1",
+		"turnId":   "provider-turn-1",
+		"message":  appServerCompactionAdvisoryMessage + "\n",
+	})
+	nearMatch := reducer.ReduceNotification(nil, session, "turn-1", warning, compaction, nil)
+	if len(nearMatch.Events) != 1 {
+		t.Fatalf("near-match advisory events = %#v, want warning preserved", nearMatch.Events)
+	}
+}
+
+func TestCodexAppServerCompactionKeepsUnrelatedWarnings(t *testing.T) {
+	t.Parallel()
+
+	session := reportTestSession()
+	session.ProviderSessionID = "thread-1"
+	normalizer := newACPTurnNormalizer()
+	normalizer.StartCompactionNotice("compaction:turn-1")
+
+	warning := "  Model fell back to a smaller context window.\n"
+	reduction := newCodexAppServerReducer(&CodexAppServerAdapter{}).ReduceNotification(
+		nil,
+		session,
+		"turn-1",
+		acpMessage{
+			Method: appServerNotifyWarning,
+			Params: mustJSONRawMessage(t, map[string]any{
+				"threadId": "thread-1",
+				"turnId":   "provider-turn-1",
+				"message":  warning,
+			}),
+		},
+		normalizer,
+		nil,
+	)
+	if len(reduction.Events) != 1 {
+		t.Fatalf("unrelated warning events = %#v, want one warning notice", reduction.Events)
+	}
+	if detail := asString(reduction.Events[0].Payload.Metadata["detail"]); detail != strings.TrimSpace(warning) {
+		t.Fatalf("unrelated warning detail = %q, want normalized event detail %q", detail, strings.TrimSpace(warning))
+	}
+	if !appServerNotificationUsesNormalizer(appServerNotifyWarning) {
+		t.Fatal("warning notifications must serialize with compaction lifecycle updates")
+	}
 }
 
 func TestCodexAppServerCommandOutputDeltaUsesToolOutputFastLane(t *testing.T) {

--- a/packages/agent/daemon/runtime/codex_appserver_reducer.go
+++ b/packages/agent/daemon/runtime/codex_appserver_reducer.go
@@ -263,7 +263,14 @@ func (r codexAppServerReducer) reduceNotification(
 		a.failActiveTurnFromAppServerError(session.AgentSessionID, params)
 		return codexAppServerReduction{}
 	case appServerNotifyWarning:
-		return emit([]activityshared.Event{appServerSystemNoticeEvent(session, turnID, "warning", "", asString(params["message"]))})
+		message := asStringRaw(params["message"])
+		// The app-server currently sends this untyped advisory after a successful
+		// compaction. Suppress only the exact duplicate while this turn owns a
+		// compaction notice; keep every other warning visible.
+		if normalizer.HasCompactionNotice() && message == appServerCompactionAdvisoryMessage {
+			return emit(nil)
+		}
+		return emit([]activityshared.Event{appServerSystemNoticeEvent(session, turnID, "warning", "", message)})
 	case appServerNotifyDeprecation:
 		return emit([]activityshared.Event{appServerSystemNoticeEvent(session, turnID, "warning",
 			asString(params["summary"]), asString(params["details"]))})


### PR DESCRIPTION
## What

- suppress the exact long-thread advisory warning only when the same normalized turn already owns a compaction notice
- serialize warning handling with compaction lifecycle notifications
- preserve unrelated and near-match warnings, along with routed prefix events
- add reducer coverage for scoped suppression and warning preservation

## Why

Tutti Agent emits a generic app-server warning after successful `/compact`. The daemon already projects the structured compaction lifecycle as `Context compacted.`, so projecting the advisory again creates a misleading red warning card for a successful operation.

## Verification

- `go test ./runtime -run 'TestCodexAppServerCompaction(AdvisoryWarningIsScopedToCompaction|KeepsUnrelatedWarnings)|TestCodexAppServerAdapterWarningNotificationsBecomeSystemNotices|TestCodexAppServerAdapterCompactionBannersShareMessageID' -count=1`\n- `pnpm test:go:agent-daemon`\n- `pnpm check:changed` (7 lanes)\n- push-ready hook: `pnpm check:changed -- --push-ready` (8 lanes)\n- TSH desktop E2E via `make dev-gui` and a temporary local Go workspace: Tutti Agent `/compact` invoked `thread/compact/start`, settled successfully, persisted `Context compacted.` with `noticeCommandStatus=completed`, and produced `advisoryCount=0`, `warningCount=0`\n\n## Risk\n\nThe compatibility match intentionally uses the exact current advisory text because the app-server notification has no structured advisory code. Text drift will make the duplicate visible again rather than suppress an unknown warning.\n\nNo public API or durable documentation changes.