### PR TITLE
fix(mobile): accept HTTPS Android update URLs

### DIFF
--- a/apps/mobile/android/app/build.gradle
+++ b/apps/mobile/android/app/build.gradle
@@ -104,4 +104,5 @@ dependencies {
     implementation("com.facebook.react:hermes-android")
     implementation("com.journeyapps:zxing-android-embedded:4.3.0")
     implementation(files(mobileGoAar))
+    testImplementation("junit:junit:4.13.2")
 }

--- a/apps/mobile/android/app/src/main/java/sh/tutti/mobile/MobileUpdateDownloader.kt
+++ b/apps/mobile/android/app/src/main/java/sh/tutti/mobile/MobileUpdateDownloader.kt
@@ -22,7 +22,7 @@ internal class MobileUpdateDownloader(
                 cause,
             )
         }
-        if (url.protocol != "https:") {
+        if (!isHTTPSUpdateURL(url)) {
             throw MobileUpdateDownloadFailure(
                 "UPDATE_URL_INVALID",
                 "Update URL must use HTTPS",
@@ -161,6 +161,8 @@ internal class MobileUpdateDownloader(
             bytes.joinToString("") { byte -> "%02x".format(byte.toInt() and 0xff) }
     }
 }
+
+internal fun isHTTPSUpdateURL(url: URL): Boolean = url.protocol == "https"
 
 internal class MobileUpdateDownloadFailure(
     val code: String,

--- a/apps/mobile/android/app/src/test/java/sh/tutti/mobile/MobileUpdateDownloaderTest.kt
+++ b/apps/mobile/android/app/src/test/java/sh/tutti/mobile/MobileUpdateDownloaderTest.kt
@@ -1,0 +1,18 @@
+package sh.tutti.mobile
+
+import java.net.URL
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MobileUpdateDownloaderTest {
+    @Test
+    fun `accepts HTTPS update URLs`() {
+        assertTrue(isHTTPSUpdateURL(URL("https://updates.example.test/app.apk")))
+    }
+
+    @Test
+    fun `rejects HTTP update URLs`() {
+        assertFalse(isHTTPSUpdateURL(URL("http://updates.example.test/app.apk")))
+    }
+}

--- a/docs/conventions/troubleshooting/mobile.md
+++ b/docs/conventions/troubleshooting/mobile.md
@@ -98,16 +98,20 @@ activity started`: package-installer launch failure.
 - **Root cause:** The manual updater downloads and verifies the APK before
   passing a `content://` URI from the Tutti FileProvider to Android's package
   installer. Failures at any pre-installer stage previously collapsed into the
-  same user-facing error. Unknown-source permission is checked before the
-  download and opens the app-specific Android settings page when required.
-- **Fix:** If the permission settings page opens, enable **Allow from this
-  source** for Tutti, return to the App, and tap **Software update** and
-  **Download and install** again. If permission is already allowed, capture
-  the first failing `TuttiMobileSecurity` log stage and its error code rather
-  than rechecking only the feed URL or APK HTTP status. Compare the logged
-  `expectedSHA256` and `actualSHA256` with the published `latest.json` before
-  investigating PackageInstaller.
-- **Validation:** Run `pnpm --filter @tutti-os/mobile check` and
+  same user-facing error. Java's `URL.protocol` value is `"https"` without a
+  trailing colon; comparing it with `"https:"` rejects every valid HTTPS APK
+  URL before the download starts. Unknown-source permission is checked before
+  the download and opens the app-specific Android settings page when required.
+- **Fix:** Keep the native URL allowlist check against Java's protocol value
+  (`"https"`, without a colon). If the permission settings page opens, enable
+  **Allow from this source** for Tutti, return to the App, and tap **Software
+  update** and **Download and install** again. If permission is already
+  allowed, capture the first failing `TuttiMobileSecurity` log stage and its
+  error code rather than rechecking only the feed URL or APK HTTP status.
+  Compare the logged `expectedSHA256` and `actualSHA256` with the published
+  `latest.json` before investigating PackageInstaller.
+- **Validation:** Run `pnpm --filter @tutti-os/mobile check`,
+  `./gradlew app:testDebugUnitTest`, and
   `./gradlew app:compileDebugKotlin` from `apps/mobile/android`. On a physical
   device, reproduce from Settings, confirm the log reaches APK finalization
   and URI creation, then confirm `Android package installer activity started`


### PR DESCRIPTION
## Summary

- fix Android update URL validation to match Java `URL.protocol`, which returns `https` without a trailing colon
- add Kotlin regression coverage for accepted HTTPS and rejected HTTP update URLs
- document the protocol-validation failure mode in the Android update troubleshooting guide

The device log showed `UPDATE_URL_INVALID` before any APK download or PackageInstaller activity. The previous `url.protocol != "https:"` check rejected every valid HTTPS update URL.

## Validation

- `pnpm --filter @tutti-os/mobile check`
- `./gradlew app:testDebugUnitTest`
- `./gradlew app:compileDebugKotlin`
- `pnpm check:changed`
