### PR TITLE
fix(agent-replay): fold modified file bodies and interaction toolCallIds

### DIFF
--- a/packages/agent/daemon/runtime/tool_file_changes.go
+++ b/packages/agent/daemon/runtime/tool_file_changes.go
@@ -180,7 +180,9 @@ func canonicalToolFileChange(value map[string]any, hint string) map[string]any {
 	if change == "" && hasContent {
 		change = "added"
 	}
-	if change == "added" && !hasNew && hasContent {
+	// Prefer newString over content for non-deleted bodies so obsolete cassette
+	// shapes match live projection and the shared store-sqlite/canonical contract.
+	if change != "deleted" && !hasNew && hasContent {
 		newString, hasNew = content, true
 		hasContent = false
 	}
@@ -191,7 +193,7 @@ func canonicalToolFileChange(value map[string]any, hint string) map[string]any {
 		case change == "deleted" && !hasOld:
 			oldString, hasOld = rawDiff, true
 		case !hasOld && !hasNew && !hasContent:
-			content, hasContent = rawDiff, true
+			newString, hasNew = rawDiff, true
 		}
 	}
 	if change == "" {

--- a/packages/agent/daemon/runtime/tool_file_changes_test.go
+++ b/packages/agent/daemon/runtime/tool_file_changes_test.go
@@ -139,11 +139,14 @@ func TestCanonicalFileChangesPreservesInvalidModifiedBodyWithoutDiff(t *testing.
 		},
 	})
 	file := payloadArray(got["files"])[0]
-	if file["content"] != body || file["change"] != "modified" {
-		t.Fatalf("canonical file = %#v, want modified body preserved as content", file)
+	if file["newString"] != body || file["change"] != "modified" {
+		t.Fatalf("canonical file = %#v, want modified body preserved as newString", file)
 	}
 	if _, exists := file["diff"]; exists {
 		t.Fatalf("canonical file retained invalid diff: %#v", file)
+	}
+	if _, exists := file["content"]; exists {
+		t.Fatalf("canonical file retained obsolete content field: %#v", file)
 	}
 }
 

--- a/packages/agent/session-replay/replay_state_compare.go
+++ b/packages/agent/session-replay/replay_state_compare.go
@@ -145,6 +145,24 @@ func registerReplayIDs(replacements map[string]string, value map[string]any) {
 		for interactionIndex, interactionItem := range interactions {
 			interaction, _ := interactionItem.(map[string]any)
 			registerReplayID(replacements, interaction["requestId"], fmt.Sprintf("session:%d/interaction:%d", sessionIndex, interactionIndex))
+			// Child-session approval / tool interactions remint toolCallId across
+			// record→replay. Pin the structural slot so final-state compare stays
+			// alpha-equivalent even when the id no longer equals a message callId.
+			if input, ok := interaction["input"].(map[string]any); ok {
+				if toolCall, ok := input["toolCall"].(map[string]any); ok {
+					toolCallReplacement := fmt.Sprintf(
+						"session:%d/interaction:%d/toolCall",
+						sessionIndex,
+						interactionIndex,
+					)
+					if toolCallID, ok := toolCall["toolCallId"].(string); ok {
+						if strings.TrimSpace(toolCallID) != "" {
+							registerReplayID(replacements, toolCallID, toolCallReplacement)
+						}
+						toolCall["toolCallId"] = toolCallReplacement
+					}
+				}
+			}
 		}
 	}
 	tuttiMode, _ := value["tuttiMode"].(map[string]any)

--- a/packages/agent/session-replay/replay_state_domain_test.go
+++ b/packages/agent/session-replay/replay_state_domain_test.go
@@ -831,6 +831,60 @@ func TestCompareTuttiReplayStateCanonicalizesAddedFileChangeBodies(
 	}
 }
 
+func TestCompareTuttiReplayStateCanonicalizesModifiedFileChangeBodies(
+	t *testing.T,
+) {
+	buildState := func(fileChanges map[string]any) TuttiReplayState {
+		return TuttiReplayState{
+			SchemaVersion: SchemaVersion,
+			Agent: TuttiReplayAgent{
+				RootSessionID: "session-1",
+				Sessions: []agenthost.HistoricalSession{{
+					ID:                "session-1",
+					Kind:              "root",
+					AgentTargetID:     "local:codex",
+					Provider:          "codex",
+					ProviderSessionID: "provider-session-1",
+					Turns: []agenthost.HistoricalTurn{{
+						ID:          "turn-1",
+						Phase:       "settled",
+						Outcome:     "completed",
+						Origin:      "user_prompt",
+						FileChanges: fileChanges,
+					}},
+				}},
+			},
+			TuttiMode: TuttiReplayTuttiMode{
+				Activations:   []TuttiReplayActivation{},
+				TurnSnapshots: []TuttiReplayTurnSnapshot{},
+			},
+			Workflows: []TuttiReplayWorkflow{},
+			Issues:    []TuttiReplayIssue{},
+		}
+	}
+	recorded := buildState(map[string]any{
+		"files": []any{map[string]any{
+			"path":        "${REPLAY_CWD}/one.txt",
+			"change":      "modified",
+			"diff":        "R14_ONE_UPDATED",
+			"unifiedDiff": "R14_ONE_UPDATED",
+		}},
+	})
+	live := buildState(map[string]any{
+		"files": []any{map[string]any{
+			"path":      "${REPLAY_CWD}/one.txt",
+			"change":    "modified",
+			"newString": "R14_ONE_UPDATED\n",
+		}},
+	})
+	if err := CompareTuttiReplayState(recorded, live); err != nil {
+		t.Fatalf(
+			"modified-file bodies under obsolete diff must match live newString, got %v",
+			err,
+		)
+	}
+}
+
 func TestCompareTuttiReplayStateTreatsToolCallIDsAsAlphaEquivalent(
 	t *testing.T,
 ) {
@@ -872,5 +926,65 @@ func TestCompareTuttiReplayStateTreatsToolCallIDsAsAlphaEquivalent(
 		buildState("approval:replayed-call"),
 	); err != nil {
 		t.Fatalf("tool_call callId must be alpha-equivalent, got %v", err)
+	}
+}
+
+func TestCompareTuttiReplayStateTreatsInteractionToolCallIDsAsAlphaEquivalent(
+	t *testing.T,
+) {
+	buildState := func(requestID, toolCallID string) TuttiReplayState {
+		return TuttiReplayState{
+			SchemaVersion: SchemaVersion,
+			Agent: TuttiReplayAgent{
+				RootSessionID: "session-0",
+				Sessions: []agenthost.HistoricalSession{{
+					ID:                "session-0",
+					Kind:              "root",
+					AgentTargetID:     "local:claude-code",
+					Provider:          "claude-code",
+					ProviderSessionID: "provider-session-0",
+				}, {
+					ID:                "session-1",
+					Kind:              "child",
+					RootSessionID:     "session-0",
+					ParentSessionID:   "session-0",
+					AgentTargetID:     "local:claude-code",
+					Provider:          "claude-code",
+					ProviderSessionID: "provider-session-1",
+					Interactions: []agenthost.HistoricalInteraction{{
+						RequestID: requestID,
+						TurnID:    "turn-1",
+						Kind:      "approval",
+						Status:    "answered",
+						ToolName:  "Bash",
+						Input: map[string]any{
+							"toolCall": map[string]any{
+								"name":       "Bash",
+								"toolName":   "Bash",
+								"toolCallId": toolCallID,
+								"title":      "echo hi",
+							},
+						},
+						Output:   map[string]any{},
+						Metadata: map[string]any{},
+					}},
+				}},
+			},
+			TuttiMode: TuttiReplayTuttiMode{
+				Activations:   []TuttiReplayActivation{},
+				TurnSnapshots: []TuttiReplayTurnSnapshot{},
+			},
+			Workflows: []TuttiReplayWorkflow{},
+			Issues:    []TuttiReplayIssue{},
+		}
+	}
+	if err := CompareTuttiReplayState(
+		buildState("req-recorded", "call_recorded"),
+		buildState("req-replayed", "call_replayed"),
+	); err != nil {
+		t.Fatalf(
+			"interaction toolCallId must be alpha-equivalent, got %v",
+			err,
+		)
 	}
 }

--- a/packages/agent/store-sqlite/canonical/tool_file_changes.go
+++ b/packages/agent/store-sqlite/canonical/tool_file_changes.go
@@ -10,9 +10,9 @@ var toolUnifiedDiffHunkPattern = regexp.MustCompile(`^@@ -(\d+)(?:,(\d+))? \+(\d
 
 // NormalizeToolFileChanges is the shared fileChanges contract used by tool
 // payloads and Agent Session Replay final-state compare. Invalid unified-diff
-// bodies on added files become newString; only real unified diffs keep diff /
-// unifiedDiff. Callers should run both recorded and live graphs through this
-// before equality checks so older cassettes stay portable.
+// bodies on added or modified files become newString; only real unified diffs
+// keep diff / unifiedDiff. Callers should run both recorded and live graphs
+// through this before equality checks so older cassettes stay portable.
 func NormalizeToolFileChanges(value any) map[string]any {
 	return normalizeToolFileChanges(value)
 }
@@ -90,7 +90,9 @@ func normalizeToolFileChange(value map[string]any) map[string]any {
 	if change == "" && hasContent {
 		change = "added"
 	}
-	if change == "added" && !hasNew && hasContent {
+	// Prefer newString over content for non-deleted bodies so obsolete cassette
+	// shapes (bare content, or invalid diff folded below) match live projection.
+	if change != "deleted" && !hasNew && hasContent {
 		newString, hasNew = content, true
 		hasContent = false
 	}
@@ -101,7 +103,9 @@ func normalizeToolFileChange(value map[string]any) map[string]any {
 		case change == "deleted" && !hasOld:
 			oldString, hasOld = rawDiff, true
 		case !hasOld && !hasNew && !hasContent:
-			content, hasContent = rawDiff, true
+			// modified / unspecified: fold invalid diff bodies into newString,
+			// not content — live rematerialization already uses newString.
+			newString, hasNew = rawDiff, true
 		}
 	}
 	if change == "" {

--- a/packages/agent/store-sqlite/canonical/tool_payload_test.go
+++ b/packages/agent/store-sqlite/canonical/tool_payload_test.go
@@ -238,11 +238,14 @@ func TestCompactToolCallPayloadPreservesInvalidModifiedBodyWithoutDiff(t *testin
 		},
 	})
 	file := got["fileChanges"].(map[string]any)["files"].([]any)[0].(map[string]any)
-	if file["content"] != body || file["change"] != "modified" {
-		t.Fatalf("file = %#v, want invalid body preserved as content", file)
+	if file["newString"] != body || file["change"] != "modified" {
+		t.Fatalf("file = %#v, want invalid body preserved as newString", file)
 	}
 	if _, exists := file["diff"]; exists {
 		t.Fatalf("file retained invalid diff: %#v", file)
+	}
+	if _, exists := file["content"]; exists {
+		t.Fatalf("file retained obsolete content field: %#v", file)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fold obsolete `modified` fileChange bodies (invalid `diff` / bare `content`) into `newString` so older cassettes match live projection (R14/R22/R24).
- Treat reminted interaction `toolCallId` values as alpha-equivalent by structural slot (I10).

## Tests
- `go test ./packages/agent/store-sqlite/canonical ./packages/agent/daemon/runtime ./packages/agent/session-replay -run 'InvalidModified|Canonicalizes(Added|Modified)FileChange|Treats(ToolCall|InteractionToolCall)IDs|CanonicalFileChangesPreservesInvalid'`
- Offline compare of R24 `expected-state.json` vs live `newString` shape
- `pnpm check:changed -- --push-ready`

## Notes
- Does not re-record cassettes; extends the shared `NormalizeToolFileChanges` contract and final-state compare.
- R15 UI settle-evidence timeout is out of scope.
- Full Electron replay was not run locally because Cases Console batches were already active.


Made with [Cursor](https://cursor.com)