### PR TITLE
ci(desktop): require Windows release artifacts

### DIFF
--- a/.github/workflows/desktop-release-promote.yml
+++ b/.github/workflows/desktop-release-promote.yml
@@ -212,16 +212,35 @@ jobs:
 
       - name: Verify staged release assets
         run: |
+          shopt -s nullglob
           test -f release-assets/SHA256SUMS.txt
           test -f release-assets/release-summary.json
           if ! grep -Eq "  .+\.(dmg|zip|exe|AppImage)$" release-assets/SHA256SUMS.txt; then
             echo "SHA256SUMS.txt does not contain an installable desktop artifact." >&2
             exit 1
           fi
+          windows_metadata="${TUTTI_DESKTOP_RELEASE_CHANNEL}.yml"
+          if [[ "${TUTTI_DESKTOP_RELEASE_CHANNEL}" == "stable" ]]; then
+            windows_metadata=latest.yml
+          fi
+          windows_installers=(release-assets/*-win-x64.exe)
+          windows_blockmaps=(release-assets/*-win-x64.exe.blockmap)
+          if (( ${#windows_installers[@]} != 1 )); then
+            echo "Expected exactly one Windows x64 installer, found ${#windows_installers[@]}." >&2
+            exit 1
+          fi
+          if (( ${#windows_blockmaps[@]} != 1 )); then
+            echo "Expected exactly one Windows x64 blockmap, found ${#windows_blockmaps[@]}." >&2
+            exit 1
+          fi
+          test -f "release-assets/${windows_metadata}"
           (
             cd release-assets
             sha256sum --check SHA256SUMS.txt
           )
+
+      - name: Validate Windows updater metadata
+        run: node apps/desktop/scripts/validate-windows-release-artifacts.mjs release-assets "${TUTTI_DESKTOP_RELEASE_CHANNEL}" "${TUTTI_DESKTOP_RELEASE_TAG}"
 
       - name: Validate staged release summary
         env:
@@ -314,6 +333,41 @@ jobs:
           aws s3 sync release-assets "${remote_dir}" \
             --size-only \
             --cache-control "public, max-age=31536000, immutable"
+
+      - name: Verify mirrored Windows release assets
+        shell: bash
+        run: |
+          windows_metadata="${TUTTI_DESKTOP_RELEASE_CHANNEL}.yml"
+          if [[ "${TUTTI_DESKTOP_RELEASE_CHANNEL}" == "stable" ]]; then
+            windows_metadata=latest.yml
+          fi
+          windows_files=(
+            release-assets/*-win-x64.exe
+            release-assets/*-win-x64.exe.blockmap
+            "release-assets/${windows_metadata}"
+          )
+          prefix="${TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX%/}/${TUTTI_DESKTOP_RELEASE_TAG}"
+          for file in "${windows_files[@]}"; do
+            asset_name="$(basename "${file}")"
+            local_size="$(stat -c %s "${file}")"
+            remote_size="$(aws s3api head-object \
+              --bucket "${TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET}" \
+              --key "${prefix}/${asset_name}" \
+              --query ContentLength \
+              --output text)"
+            if [[ "${remote_size}" != "${local_size}" ]]; then
+              echo "Mirrored asset size mismatch for ${asset_name}: local ${local_size}, remote ${remote_size}." >&2
+              exit 1
+            fi
+            local_sha256="$(sha256sum "${file}" | cut -d ' ' -f 1)"
+            remote_url="${TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL%/}/${TUTTI_DESKTOP_RELEASE_TAG}/${asset_name}"
+            remote_sha256="$(curl --fail --silent --show-error --location \
+              --retry 5 --retry-all-errors "${remote_url}" | sha256sum | cut -d ' ' -f 1)"
+            if [[ "${remote_sha256}" != "${local_sha256}" ]]; then
+              echo "Mirrored asset checksum mismatch for ${asset_name}: local ${local_sha256}, remote ${remote_sha256}." >&2
+              exit 1
+            fi
+          done
 
       - name: Upload desktop release summary artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -42,11 +42,6 @@ on:
         options:
           - publish
           - draft_only
-      include_windows:
-        description: Include an unsigned Windows NSIS package in the release assets
-        required: false
-        type: boolean
-        default: false
       notify_feishu:
         description: Send a Feishu card after publishing
         required: false
@@ -73,7 +68,6 @@ jobs:
       release_version: ${{ steps.release.outputs.release_version }}
       release_channel: ${{ steps.release.outputs.release_channel }}
       publication_mode: ${{ steps.publication.outputs.publication_mode }}
-      include_windows: ${{ steps.windows.outputs.include_windows }}
       notify_feishu: ${{ steps.notify.outputs.notify_feishu }}
 
     steps:
@@ -286,19 +280,6 @@ jobs:
           esac
           echo "publication_mode=${publication_mode}" >> "$GITHUB_OUTPUT"
 
-      - name: Resolve Windows packaging opt-in
-        id: windows
-        shell: bash
-        env:
-          RELEASE_EVENT_NAME: ${{ github.event_name }}
-          INPUT_INCLUDE_WINDOWS: ${{ inputs.include_windows }}
-        run: |
-          include_windows=false
-          if [[ "${RELEASE_EVENT_NAME}" == "workflow_dispatch" && "${INPUT_INCLUDE_WINDOWS}" == "true" ]]; then
-            include_windows=true
-          fi
-          echo "include_windows=${include_windows}" >> "$GITHUB_OUTPUT"
-
   build-macos:
     name: Build macOS (${{ matrix.arch }})
     needs: resolve
@@ -460,7 +441,6 @@ jobs:
   build-windows:
     name: Build Windows (unsigned)
     needs: resolve
-    if: ${{ needs.resolve.outputs.include_windows == 'true' }}
     runs-on: windows-latest
     timeout-minutes: 60
     env:
@@ -520,15 +500,7 @@ jobs:
 
       - name: Verify Windows release metadata
         shell: pwsh
-        run: |
-          $metadataName = if ($env:TUTTI_DESKTOP_RELEASE_CHANNEL -eq 'stable') { 'latest.yml' } else { "$env:TUTTI_DESKTOP_RELEASE_CHANNEL.yml" }
-          $metadataPath = Join-Path 'apps/desktop/dist' $metadataName
-          if (-not (Test-Path $metadataPath)) {
-            throw "Expected Windows updater metadata at $metadataPath"
-          }
-          if (-not (Get-ChildItem 'apps/desktop/dist' -Filter '*.exe' -File)) {
-            throw 'Windows build did not produce an NSIS installer'
-          }
+        run: node apps/desktop/scripts/validate-windows-release-artifacts.mjs apps/desktop/dist "$env:TUTTI_DESKTOP_RELEASE_CHANNEL" "$env:TUTTI_DESKTOP_RELEASE_TAG"
 
       - name: Upload Windows release artifacts
         uses: actions/upload-artifact@v7
@@ -565,7 +537,7 @@ jobs:
       ${{ always() && needs.resolve.result == 'success' &&
           (github.event_name == 'push' || needs.resolve.outputs.release_dry_run != 'true') &&
           needs.build-macos.result == 'success' &&
-          (needs.build-windows.result == 'success' || needs.build-windows.result == 'skipped') }}
+          needs.build-windows.result == 'success' }}
     runs-on: ubuntu-latest
     outputs:
       release_url: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ needs.resolve.outputs.release_tag }}
@@ -600,7 +572,6 @@ jobs:
           path: release-assets-input/macos
 
       - name: Download Windows built artifacts
-        if: ${{ needs.resolve.outputs.include_windows == 'true' }}
         uses: actions/download-artifact@v4
         with:
           name: tutti-desktop-release-assets-windows
@@ -616,7 +587,6 @@ jobs:
             release-assets
 
       - name: Add Windows release artifacts
-        if: ${{ needs.resolve.outputs.include_windows == 'true' }}
         shell: bash
         run: |
           shopt -s nullglob globstar
@@ -636,6 +606,9 @@ jobs:
             echo "No Windows release artifacts were downloaded" >&2
             exit 1
           fi
+
+      - name: Validate Windows release artifacts
+        run: node apps/desktop/scripts/validate-windows-release-artifacts.mjs release-assets "${TUTTI_DESKTOP_RELEASE_CHANNEL}" "${TUTTI_DESKTOP_RELEASE_TAG}"
 
       - name: Generate desktop release summary
         env:

--- a/apps/desktop/scripts/build-release-latest.mjs
+++ b/apps/desktop/scripts/build-release-latest.mjs
@@ -89,6 +89,14 @@ function isMacosUniversalDmg(asset) {
   );
 }
 
+function isWindowsX64Exe(asset) {
+  return (
+    asset.platform === "windows" &&
+    asset.arch === "x64" &&
+    asset.format === "exe"
+  );
+}
+
 function normalizePlatform(value) {
   const normalized = value.toLowerCase();
   if (
@@ -184,6 +192,7 @@ async function buildDesktopReleaseLatest(options) {
   }
 
   const macosUniversalDmg = assets.find(isMacosUniversalDmg)?.url ?? null;
+  const windowsX64Exe = assets.find(isWindowsX64Exe)?.url ?? null;
 
   return {
     schemaVersion,
@@ -196,7 +205,8 @@ async function buildDesktopReleaseLatest(options) {
     sourceRef: sourceRef || null,
     baseUrl,
     preferredDownloads: {
-      macosUniversalDmg
+      macosUniversalDmg,
+      windowsX64Exe
     },
     assets
   };

--- a/apps/desktop/scripts/send-release-feishu-card.mjs
+++ b/apps/desktop/scripts/send-release-feishu-card.mjs
@@ -458,9 +458,10 @@ async function main() {
     releaseAssetBaseUrl,
     tag
   );
-  const release = mirroredMacUrl
-    ? null
-    : await loadRelease(repository, tag, resolveGithubToken());
+  const release =
+    mirroredMacUrl && mirroredWinUrl
+      ? null
+      : await loadRelease(repository, tag, resolveGithubToken());
   const summary = await loadReleaseSummary(
     readOption(args, "summary", "RELEASE_SUMMARY_PATH")
   );

--- a/apps/desktop/scripts/validate-windows-release-artifacts.mjs
+++ b/apps/desktop/scripts/validate-windows-release-artifacts.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+function parseScalar(rawValue) {
+  const value = rawValue.trim();
+  if (value.startsWith('"')) {
+    return JSON.parse(value);
+  }
+  if (value.startsWith("'") && value.endsWith("'")) {
+    return value.slice(1, -1).replaceAll("''", "'");
+  }
+  return value;
+}
+
+function parseUpdaterMetadata(source) {
+  const metadata = { files: [] };
+  let inFiles = false;
+  let currentFile;
+
+  for (const line of source.split(/\r?\n/u)) {
+    const topLevel = /^(\S[^:]*):(?:\s*(.*))?$/u.exec(line);
+    if (topLevel) {
+      inFiles = topLevel[1] === "files";
+      currentFile = undefined;
+      if (["path", "sha512", "version"].includes(topLevel[1])) {
+        metadata[topLevel[1]] = parseScalar(topLevel[2] ?? "");
+      }
+      continue;
+    }
+
+    if (!inFiles) continue;
+    const fileStart = /^\s+-\s+url:\s*(.+)$/u.exec(line);
+    if (fileStart) {
+      currentFile = { url: parseScalar(fileStart[1]) };
+      metadata.files.push(currentFile);
+      continue;
+    }
+    const fileSha = /^\s+sha512:\s*(.+)$/u.exec(line);
+    if (fileSha && currentFile) {
+      currentFile.sha512 = parseScalar(fileSha[1]);
+    }
+  }
+
+  return metadata;
+}
+
+async function sha512(filePath) {
+  const hash = createHash("sha512");
+  for await (const chunk of createReadStream(filePath)) hash.update(chunk);
+  return hash.digest("base64");
+}
+
+async function validateWindowsReleaseArtifacts(directory, channel, releaseTag) {
+  if (!new Set(["stable", "rc", "beta"]).has(channel)) {
+    throw new Error(`Unsupported Windows release channel: ${channel}`);
+  }
+  const versionMatch =
+    /^v(?<version>\d+\.\d+\.\d+(?:-(?:rc|beta)\.\d+)?)$/u.exec(releaseTag);
+  if (!versionMatch?.groups) {
+    throw new Error(`Unsupported Windows release tag: ${releaseTag}`);
+  }
+
+  const names = await readdir(directory);
+  const installers = names.filter((name) => name.endsWith("-win-x64.exe"));
+  if (installers.length !== 1) {
+    throw new Error(
+      `Expected exactly one Windows x64 installer, found ${installers.length}`
+    );
+  }
+  const installerName = installers[0];
+  const blockmapName = `${installerName}.blockmap`;
+  if (!names.includes(blockmapName)) {
+    throw new Error(`Missing Windows blockmap: ${blockmapName}`);
+  }
+
+  const metadataName = channel === "stable" ? "latest.yml" : `${channel}.yml`;
+  if (!names.includes(metadataName)) {
+    throw new Error(`Missing Windows updater metadata: ${metadataName}`);
+  }
+  const metadata = parseUpdaterMetadata(
+    await readFile(path.join(directory, metadataName), "utf8")
+  );
+  const expectedVersion = versionMatch.groups.version;
+  if (metadata.version !== expectedVersion) {
+    throw new Error(
+      `Windows updater version mismatch: expected ${expectedVersion}, found ${metadata.version}`
+    );
+  }
+  if (metadata.path !== installerName) {
+    throw new Error(
+      `Windows updater path mismatch: expected ${installerName}, found ${metadata.path}`
+    );
+  }
+
+  const installerSha512 = await sha512(path.join(directory, installerName));
+  if (metadata.sha512 !== installerSha512) {
+    throw new Error(
+      "Windows updater top-level SHA-512 does not match installer"
+    );
+  }
+  if (metadata.files.length !== 1) {
+    throw new Error(
+      `Expected exactly one Windows updater file entry, found ${metadata.files.length}`
+    );
+  }
+  const [file] = metadata.files;
+  if (file.url !== installerName) {
+    throw new Error(
+      `Windows updater file URL mismatch: expected ${installerName}, found ${file.url}`
+    );
+  }
+  if (file.sha512 !== installerSha512) {
+    throw new Error("Windows updater file SHA-512 does not match installer");
+  }
+
+  return {
+    blockmapName,
+    installerName,
+    metadataName,
+    version: expectedVersion
+  };
+}
+
+async function main() {
+  const [directory, channel, releaseTag] = process.argv.slice(2);
+  if (!directory || !channel || !releaseTag) {
+    throw new Error(
+      "Usage: validate-windows-release-artifacts.mjs <directory> <stable|rc|beta> <release-tag>"
+    );
+  }
+  await validateWindowsReleaseArtifacts(directory, channel, releaseTag);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  void main().catch((error) => {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : String(error)}\n`
+    );
+    process.exit(1);
+  });
+}
+
+export { parseUpdaterMetadata, validateWindowsReleaseArtifacts };

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -14,7 +14,7 @@ The formal desktop release flow currently includes:
 
 - GitHub Release publishing
 - macOS desktop artifacts
-- opt-in unsigned Windows RC/stable artifacts
+- default unsigned Windows RC/stable artifacts
 - Electron auto-update metadata
 - release candidate (`rc`) prereleases
 - beta prereleases for development-branch packaging
@@ -29,17 +29,17 @@ The current release flow intentionally excludes:
 
 Windows packaging remains available through
 `.github/workflows/windows-desktop-alpha.yml` for smoke validation. The formal
-`.github/workflows/desktop-release.yml` workflow also accepts the manual
-`include_windows=true` switch. That switch builds an unsigned Windows NSIS
+`.github/workflows/desktop-release.yml` workflow always builds Windows. It
+builds an unsigned Windows NSIS
 installer and stages its `.exe`, `.blockmap`, and updater `.yml` beside the
-macOS draft assets. It defaults to false, so formal releases remain macOS-only
-until an operator explicitly enables it. See
+macOS draft assets. Scheduled RC builds, pushed RC/stable tags, and manual
+RC/stable releases therefore all require Windows to succeed. See
 [Windows Platform Support](../architecture/windows-platform-support.md) for the
 promotion gates.
 
 ## Workflow Status
 
-The desktop release workflow is currently soft-disabled.
+The desktop release workflow has a repository-level soft-enable guard.
 
 `.github/workflows/desktop-release.yml` only runs release jobs when this repository variable is set:
 
@@ -76,11 +76,10 @@ Manual runs also expose `publication_mode`:
 - `publish` keeps the existing end-to-end behavior. The workflow stages a GitHub Draft Release, uploads immutable assets, then calls the promotion workflow to update public channel metadata and publish the stable GitHub Release.
 - `draft_only` builds the same signed and notarized artifacts, keeps the GitHub Release as a draft, uploads immutable assets under the versioned S3/CloudFront `<tag>/` directory, and stops before changing any public channel pointer, changelog, stable alias, or GitHub visibility.
 
-For an RC draft that includes Windows, dispatch `patch_rc_release` from
-`main` or `release/*`, select `draft_only`, and set `include_windows=true`.
-Windows is intentionally unsigned for now; stable releases keep the same
-opt-in switch so signing and promotion can be enabled later without redesigning
-the release graph.
+For an RC draft, dispatch `patch_rc_release` from `main` or `release/*` and
+select `draft_only`; Windows is included by default. Windows is intentionally
+unsigned for now. A Windows build or artifact validation failure blocks staging
+so an RC or stable release cannot silently publish only macOS assets.
 
 Draft-only assets are unlisted, not private. Anyone who knows the immutable CloudFront URL can download them. This is intentional so internal release notifications can carry working QA download links. Do not use the desktop release asset prefix for confidential artifacts.
 
@@ -156,11 +155,14 @@ The formal release workflow currently produces:
 - macOS update metadata such as `.yml` and `.blockmap`
 - `SHA256SUMS.txt`
 
-Windows `.exe`/`.blockmap`/`.yml` are included only when the formal workflow's
-`include_windows` switch is enabled. Linux `.AppImage` remains a target
+Windows `.exe`/`.blockmap`/`.yml` are required formal-release artifacts. Linux
+`.AppImage` remains a target
 artifact shape, not a formal-release output. Windows assets are staged on the
-GitHub Release and mirror, but stable/public channel promotion remains
-controlled by the existing release promotion gates.
+GitHub Release and mirror. Promotion verifies the staged installer, blockmap,
+channel updater metadata (version, installer path, and SHA-512), and the size
+and checksum of each mirrored S3/CloudFront object before moving the public
+channel pointer. Stable/public channel promotion remains controlled by the
+existing release promotion gates.
 
 The Store build is deliberately separate from the Direct artifact set. It uses
 `build:win:store` to produce one x64 AppX whose identity, publisher, and display
@@ -335,7 +337,8 @@ public GitHub Releases page. Publish the immutable assets and updater YAML
 first, then mutate the relevant pointer; the current pointer cache is 60
 seconds. Before announcing a release, verify HTTP 200 for the channel pointer,
 its `<tag>/latest-mac.yml` or `<tag>/rc-mac.yml`, and the ZIP referenced by that
-YAML.
+YAML, plus the Windows `.exe`, `.exe.blockmap`, and matching `latest.yml` or
+`rc.yml`.
 
 The `latest.json` metadata must include stable-identifying fields:
 
@@ -344,6 +347,7 @@ The `latest.json` metadata must include stable-identifying fields:
 - a plain semver `version`, without `-rc` or `-beta`
 - a stable `tag`, such as `v1.12.20`
 - `preferredDownloads.macosUniversalDmg`
+- `preferredDownloads.windowsX64Exe`
 
 External download workers should treat these fields as a fail-closed contract. If the metadata is missing, malformed, or points at an RC or beta tag, the worker must not return that package as the public download.
 

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -768,7 +768,7 @@ test("desktop release workflow refreshes the stable alias without taking Latest"
   assert.ok(releaseDeleteIndex < releaseCreateIndex);
 });
 
-test("desktop release workflow keeps Windows packaging opt-in and stages unsigned assets", async () => {
+test("desktop release workflow always builds Windows and stages unsigned assets", async () => {
   const workflow = await readFile(workflowPath, "utf8");
   const stageJobMatch = workflow.match(
     /stage:[\s\S]*?(?=\n\s{2}[a-z][a-z0-9_-]+:\n|$)/
@@ -779,17 +779,9 @@ test("desktop release workflow keeps Windows packaging opt-in and stages unsigne
 
   assert.ok(stageJobMatch, "stage job should exist");
   assert.ok(notifyJobMatch, "draft notify job should exist");
-  assert.match(
-    workflow,
-    /include_windows:[\s\S]*?type:\s+boolean[\s\S]*?default:\s+false/
-  );
-  assert.match(workflow, /id:\s+windows[\s\S]*?include_windows=false/);
+  assert.doesNotMatch(workflow, /include_windows/);
   assert.match(workflow, /\r?\n\s{2}build-windows:\r?\n/);
   assert.doesNotMatch(workflow, /\r?\n\s{2}build-linux:\r?\n/);
-  assert.match(
-    workflow,
-    /build-windows:[\s\S]*?if:\s+\$\{\{\s*needs\.resolve\.outputs\.include_windows\s*==\s*'true'\s*\}\}/
-  );
   assert.match(
     workflow,
     /build-windows:[\s\S]*?CSC_IDENTITY_AUTO_DISCOVERY:\s+"false"[\s\S]*?build:win/
@@ -800,6 +792,10 @@ test("desktop release workflow keeps Windows packaging opt-in and stages unsigne
   );
   assert.match(stageJobMatch[0], /always\(\)/);
   assert.match(
+    stageJobMatch[0],
+    /needs\.build-windows\.result\s*==\s*'success'/
+  );
+  assert.doesNotMatch(
     stageJobMatch[0],
     /needs\.build-windows\.result\s*==\s*'skipped'/
   );
@@ -814,6 +810,10 @@ test("desktop release workflow keeps Windows packaging opt-in and stages unsigne
   assert.match(stageJobMatch[0], /name:\s+Add Windows release artifacts/);
   assert.match(
     stageJobMatch[0],
+    /validate-windows-release-artifacts\.mjs release-assets/
+  );
+  assert.match(
+    stageJobMatch[0],
     /upsert-release-download-links\.mjs[\s\S]*?release-assets[\s\S]*?updated-release-body\.md/
   );
   assert.match(
@@ -825,6 +825,28 @@ test("desktop release workflow keeps Windows packaging opt-in and stages unsigne
     notifyJobMatch[0],
     /pattern:\s+tutti-desktop-release-assets-macos/
   );
+});
+
+test("desktop promotion verifies Windows artifacts in the release and S3 mirror", async () => {
+  const promoteWorkflow = await readFile(promoteWorkflowPath, "utf8");
+
+  assert.match(
+    promoteWorkflow,
+    /Verify staged release assets[\s\S]*?\*-win-x64\.exe[\s\S]*?\*-win-x64\.exe\.blockmap[\s\S]*?windows_metadata/
+  );
+  assert.match(
+    promoteWorkflow,
+    /name:\s+Validate Windows updater metadata[\s\S]*?validate-windows-release-artifacts\.mjs/
+  );
+  assert.match(
+    promoteWorkflow,
+    /name:\s+Verify mirrored Windows release assets/
+  );
+  assert.match(promoteWorkflow, /aws s3api head-object/);
+  assert.match(promoteWorkflow, /--query ContentLength/);
+  assert.match(promoteWorkflow, /Mirrored asset size mismatch/);
+  assert.match(promoteWorkflow, /curl --fail --silent --show-error --location/);
+  assert.match(promoteWorkflow, /Mirrored asset checksum mismatch/);
 });
 
 test("desktop release workflow materializes macOS signing certificate before packaging", async () => {

--- a/tools/scripts/desktop-release-latest.test.mjs
+++ b/tools/scripts/desktop-release-latest.test.mjs
@@ -70,7 +70,9 @@ test("desktop release latest metadata exposes CloudFront URLs for every asset", 
     );
     assert.deepEqual(latest.preferredDownloads, {
       macosUniversalDmg:
-        "https://d111111abcdef8.cloudfront.net/desktop-release-assets/v1.2.3/Tutti-1.2.3-mac-universal.dmg"
+        "https://d111111abcdef8.cloudfront.net/desktop-release-assets/v1.2.3/Tutti-1.2.3-mac-universal.dmg",
+      windowsX64Exe:
+        "https://d111111abcdef8.cloudfront.net/desktop-release-assets/v1.2.3/Tutti-1.2.3-win-x64.exe"
     });
     assert.ok(latest.assets.every((asset) => !("cdnUrl" in asset)));
     assert.equal(latest.downloads, undefined);
@@ -109,6 +111,7 @@ test("desktop release latest metadata supports rc channel tags", async () => {
       path.join(dir, "Tutti-1.2.3-rc.1-mac-universal.dmg"),
       "uni"
     );
+    await writeFile(path.join(dir, "Tutti-1.2.3-rc.1-win-x64.exe"), "win");
 
     const latest = await buildDesktopReleaseLatest({
       assetDirPath: dir,
@@ -123,6 +126,12 @@ test("desktop release latest metadata supports rc channel tags", async () => {
     assert.equal(latest.version, "1.2.3-rc.1");
     assert.equal(
       latest.preferredDownloads.macosUniversalDmg?.includes("v1.2.3-rc.1"),
+      true
+    );
+    assert.equal(
+      latest.preferredDownloads.windowsX64Exe?.includes(
+        "Tutti-1.2.3-rc.1-win-x64.exe"
+      ),
       true
     );
   } finally {

--- a/tools/scripts/desktop-release-windows-artifacts.test.mjs
+++ b/tools/scripts/desktop-release-windows-artifacts.test.mjs
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { validateWindowsReleaseArtifacts } from "../../apps/desktop/scripts/validate-windows-release-artifacts.mjs";
+
+async function createArtifacts({
+  channel = "stable",
+  metadataSha,
+  metadataVersion = "1.2.3",
+  metadataUrl = "Tutti-1.2.3-win-x64.exe"
+} = {}) {
+  const directory = await mkdtemp(path.join(tmpdir(), "tutti-win-release-"));
+  const installerName = "Tutti-1.2.3-win-x64.exe";
+  const installer = Buffer.from("test Windows installer");
+  const sha = createHash("sha512").update(installer).digest("base64");
+  const metadataName = channel === "stable" ? "latest.yml" : `${channel}.yml`;
+  await writeFile(path.join(directory, installerName), installer);
+  await writeFile(
+    path.join(directory, `${installerName}.blockmap`),
+    "blockmap"
+  );
+  await writeFile(
+    path.join(directory, metadataName),
+    [
+      `version: ${metadataVersion}`,
+      "files:",
+      `  - url: ${metadataUrl}`,
+      `    sha512: ${metadataSha ?? sha}`,
+      "    size: 22",
+      `path: ${metadataUrl}`,
+      `sha512: ${metadataSha ?? sha}`,
+      "releaseDate: '2026-08-07T00:00:00.000Z'",
+      ""
+    ].join("\n")
+  );
+  return { directory, installerName, metadataName };
+}
+
+test("validates stable Windows installer, blockmap, and updater metadata", async () => {
+  const fixture = await createArtifacts();
+  try {
+    assert.deepEqual(
+      await validateWindowsReleaseArtifacts(
+        fixture.directory,
+        "stable",
+        "v1.2.3"
+      ),
+      {
+        blockmapName: `${fixture.installerName}.blockmap`,
+        installerName: fixture.installerName,
+        metadataName: fixture.metadataName,
+        version: "1.2.3"
+      }
+    );
+  } finally {
+    await rm(fixture.directory, { force: true, recursive: true });
+  }
+});
+
+test("accepts RC channel metadata with the matching prerelease version", async () => {
+  const fixture = await createArtifacts({
+    channel: "rc",
+    metadataVersion: "1.2.3-rc.4"
+  });
+  try {
+    await validateWindowsReleaseArtifacts(
+      fixture.directory,
+      "rc",
+      "v1.2.3-rc.4"
+    );
+  } finally {
+    await rm(fixture.directory, { force: true, recursive: true });
+  }
+});
+
+test("rejects updater metadata for a different release version", async () => {
+  const fixture = await createArtifacts({ metadataVersion: "1.2.2" });
+  try {
+    await assert.rejects(
+      validateWindowsReleaseArtifacts(fixture.directory, "stable", "v1.2.3"),
+      /version mismatch/
+    );
+  } finally {
+    await rm(fixture.directory, { force: true, recursive: true });
+  }
+});
+
+test("rejects updater metadata whose installer digest is stale", async () => {
+  const fixture = await createArtifacts({ metadataSha: "stale-sha512" });
+  try {
+    await assert.rejects(
+      validateWindowsReleaseArtifacts(fixture.directory, "stable", "v1.2.3"),
+      /SHA-512 does not match installer/
+    );
+  } finally {
+    await rm(fixture.directory, { force: true, recursive: true });
+  }
+});
+
+test("rejects updater metadata that points at another installer", async () => {
+  const fixture = await createArtifacts({
+    metadataUrl: "Tutti-1.2.2-win-x64.exe"
+  });
+  try {
+    await assert.rejects(
+      validateWindowsReleaseArtifacts(fixture.directory, "stable", "v1.2.3"),
+      /path mismatch/
+    );
+  } finally {
+    await rm(fixture.directory, { force: true, recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

- always build and stage unsigned Windows NSIS artifacts for desktop releases
- validate Windows updater metadata and the S3/CloudFront mirror before promotion
- expose the Windows installer in release metadata and Feishu download actions

## Validation

- `node --test tools/scripts/*release*.test.mjs` (159 passed)
- `pnpm run check:changed -- --push-ready` passed
- workflow YAML parse passed
- `git diff --check` passed
- independent subagent review: no findings

## Notes

Windows direct-download artifacts remain unsigned until the Store distribution path is used; this change makes them mandatory for RC/stable direct releases and prevents channel promotion when the updater metadata or mirror is inconsistent.