### PR TITLE
fix(workspace-files): normalize Windows logical paths

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.test.ts
@@ -219,6 +219,44 @@ test("workspace file manager service treats missing or unreadable entries as abs
   );
 });
 
+test("workspace file manager service compares native Windows paths with daemon logical paths", async () => {
+  const dependencies = createDependenciesStub();
+  let requestedPath: string | undefined;
+  dependencies.tuttidClient.listWorkspaceFileDirectory = async (
+    workspaceId,
+    input
+  ) => {
+    requestedPath = input?.path;
+    return {
+      directoryPath: "/C:/",
+      entries: [
+        {
+          createdTimeMs: null,
+          hasChildren: false,
+          kind: "file",
+          lastOpenedMs: null,
+          mtimeMs: null,
+          name: "README.md",
+          path: "/C:/README.md",
+          sizeBytes: 12
+        }
+      ],
+      root: "/C:/",
+      workspaceId
+    };
+  };
+  const service = new WorkspaceFileManagerService(dependencies);
+
+  assert.equal(
+    await service.entryExists({
+      path: "C:\\README.md",
+      workspaceID: "workspace-1"
+    }),
+    true
+  );
+  assert.equal(requestedPath, "/C:/");
+});
+
 test("workspace file manager service restores snapshot state without localStorage", () => {
   const restoreStorage = installForbiddenLocalStorage();
   try {

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.ts
@@ -460,11 +460,16 @@ function dirnameForWorkspaceFilePath(path: string): string {
   if (index <= 0) {
     return path.startsWith("/") ? "/" : path;
   }
-  return path.slice(0, index);
+  const directory = path.slice(0, index);
+  return /^\/[A-Za-z]:$/.test(directory) ? `${directory}/` : directory;
 }
 
 function normalizeComparableWorkspaceFilePath(path: string): string {
-  const normalized = path.trim().replaceAll("\\", "/").replace(/\/+/g, "/");
+  const normalized = path
+    .trim()
+    .replaceAll("\\", "/")
+    .replace(/\/+/g, "/")
+    .replace(/^\/?([A-Za-z]:)(?=\/|$)/, "/$1");
   if (!normalized) {
     return "";
   }

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -125,6 +125,7 @@ App Center, workspace-app lifecycle, App Factory, file references, and File Mana
 - [Agent GUI app mentions show unavailable workspace apps](./workspace-apps-files.md#agent-gui-app-mentions-show-unavailable-workspace-apps)
 - [Agent generated files under system temp do not open](./workspace-apps-files.md#agent-generated-files-under-system-temp-do-not-open)
 - [FileManager home-relative paths break only the list pane](./workspace-apps-files.md#filemanager-home-relative-paths-break-only-the-list-pane)
+- [Windows FileManager paths exist but fail validation or selection](./workspace-apps-files.md#windows-filemanager-paths-exist-but-fail-validation-or-selection)
 
 ## [Toolchain, Browser, And Terminal](./toolchain-browser-terminal.md)
 

--- a/docs/conventions/troubleshooting/workspace-apps-files.md
+++ b/docs/conventions/troubleshooting/workspace-apps-files.md
@@ -343,3 +343,26 @@
   Run the workspace files launch coordinator test and the AgentGUI workspace
   link action test, then `pnpm check:changed` for mixed desktop and AgentGUI
   changes.
+
+### Windows FileManager paths exist but fail validation or selection
+
+- Symptom:
+  A Windows path opens through direct preview, but FileManager reports it as
+  missing, fails to select the revealed entry, loses the matching sidebar
+  location, or adds a duplicate back-navigation entry.
+- Quick checks:
+  Compare the desktop launch path with `tuttid`'s directory response. Native
+  input commonly arrives as `C:\\Users\\...` or `C:/Users/...`, while the
+  workspace API intentionally transports the same path as `/C:/Users/...`.
+- Root cause:
+  Workspace file paths are logical API paths. Normalizing separators without
+  also adding the logical leading slash leaves native Windows input unequal to
+  daemon roots, directory paths, and entry paths.
+- Fix:
+  Canonicalize drive-qualified paths to `/C:/...` at the shared FileManager
+  path-model boundary. Strip that transport slash only at a native Electron or
+  operating-system file API boundary.
+- Validation:
+  Cover native Windows inputs against daemon-shaped `/C:/...` responses in
+  existence, directory navigation, and reveal-selection tests. Then run
+  `pnpm check:changed`.

--- a/packages/workspace/file-manager/src/services/internal/model/paths.ts
+++ b/packages/workspace/file-manager/src/services/internal/model/paths.ts
@@ -33,7 +33,7 @@ function normalizeWorkspaceFileAbsolutePath(value?: string | null): string {
   const drive = readWindowsDrive(raw);
   const startsWithSlash = raw.startsWith("/");
   const body = drive
-    ? raw.slice(drive.length).replace(/^\/+/, "")
+    ? stripWindowsDrivePrefix(raw, drive)
     : startsWithSlash
       ? raw.slice(1)
       : raw;
@@ -51,10 +51,10 @@ function normalizeWorkspaceFileAbsolutePath(value?: string | null): string {
   }
 
   if (result.length === 0) {
-    return drive ? `${drive}/` : workspaceFileManagerLogicalRoot;
+    return drive ? `/${drive}/` : workspaceFileManagerLogicalRoot;
   }
   if (drive) {
-    return `${drive}/${result.join("/")}`;
+    return `/${drive}/${result.join("/")}`;
   }
   return `/${result.join("/")}`;
 }
@@ -80,13 +80,13 @@ export function workspaceFileDirectory(
   }
 
   const drive = readWindowsDrive(normalized);
-  const body = drive ? normalized.slice(drive.length) : normalized;
+  const body = drive ? stripWindowsDrivePrefix(normalized, drive) : normalized;
   const parts = body.split("/").filter(Boolean);
   parts.pop();
   const directory = drive
     ? parts.length === 0
-      ? `${drive}/`
-      : `${drive}/${parts.join("/")}`
+      ? `/${drive}/`
+      : `/${drive}/${parts.join("/")}`
     : parts.length === 0
       ? workspaceFileManagerLogicalRoot
       : `/${parts.join("/")}`;
@@ -184,5 +184,10 @@ function isWorkspaceFileAbsolutePath(path: string): boolean {
 }
 
 function readWindowsDrive(path: string): string {
-  return /^[A-Za-z]:/.exec(path)?.[0] ?? "";
+  return /^\/?([A-Za-z]:)(?=\/|$)/.exec(path)?.[1] ?? "";
+}
+
+function stripWindowsDrivePrefix(path: string, drive: string): string {
+  const prefixLength = drive.length + (path.startsWith("/") ? 1 : 0);
+  return path.slice(prefixLength).replace(/^\/+/, "");
 }

--- a/packages/workspace/file-manager/src/services/internal/workspaceFileManagerNavigationController.test.ts
+++ b/packages/workspace/file-manager/src/services/internal/workspaceFileManagerNavigationController.test.ts
@@ -205,16 +205,16 @@ test("revealPath loads external absolute parent directories outside the current 
 
 test("revealPath handles Windows drive paths outside the current root", async () => {
   const store = createTestStore();
-  store.root = "C:/Users/demo";
-  store.currentDirectoryPath = "C:/Users/demo";
+  store.root = "/C:/Users/demo";
+  store.currentDirectoryPath = "/C:/Users/demo";
   const controller = new WorkspaceFileManagerNavigationController({
     host: {
       async listDirectory(input) {
-        assert.equal(input.path, "C:/tmp");
+        assert.equal(input.path, "/C:/tmp");
         return {
-          directoryPath: input.path,
-          entries: [createFileEntry("C:/tmp/hello_world.md")],
-          root: "C:/",
+          directoryPath: "/C:/tmp",
+          entries: [createFileEntry("/C:/tmp/hello_world.md")],
+          root: "/C:/",
           workspaceID: input.workspaceID
         };
       }
@@ -225,10 +225,37 @@ test("revealPath handles Windows drive paths outside the current root", async ()
 
   await controller.revealPath("C:\\tmp\\hello_world.md");
 
-  assert.equal(store.root, "C:/");
-  assert.equal(store.currentDirectoryPath, "C:/tmp");
-  assert.equal(store.selectedPath, "C:/tmp/hello_world.md");
+  assert.equal(store.root, "/C:/");
+  assert.equal(store.currentDirectoryPath, "/C:/tmp");
+  assert.equal(store.selectedPath, "/C:/tmp/hello_world.md");
+  assert.equal(store.selectedPath, store.entries[0]?.path);
   assert.equal(store.isLoading, false);
+});
+
+test("loading a native Windows path does not add the daemon path as duplicate history", async () => {
+  const store = createTestStore();
+  store.root = "/C:/Users/demo";
+  store.currentDirectoryPath = "/C:/Users/demo";
+  const controller = new WorkspaceFileManagerNavigationController({
+    host: {
+      async listDirectory(input) {
+        assert.equal(input.path, "/C:/Users/demo");
+        return {
+          directoryPath: "/C:/Users/demo",
+          entries: [],
+          root: "/C:/Users/demo",
+          workspaceID: input.workspaceID
+        };
+      }
+    },
+    resolveErrorMessage: defaultResolveErrorMessage,
+    store
+  });
+
+  await controller.loadDirectory("C:\\Users\\demo");
+
+  assert.deepEqual(store.navigationBackStack, []);
+  assert.equal(store.currentDirectoryPath, "/C:/Users/demo");
 });
 
 test("revealPath includes hidden entries when parent path contains a hidden segment", async () => {

--- a/packages/workspace/file-manager/src/services/workspaceFileManagerModel.test.ts
+++ b/packages/workspace/file-manager/src/services/workspaceFileManagerModel.test.ts
@@ -27,14 +27,18 @@ test("normalizes paths under the logical workspace root", () => {
 test("normalizes Windows drive paths without treating them as relative", () => {
   assert.equal(
     normalizeWorkspaceFilePath("src\\main.ts", "C:\\Users\\demo\\project"),
-    "C:/Users/demo/project/src/main.ts"
+    "/C:/Users/demo/project/src/main.ts"
   );
   assert.equal(
     normalizeWorkspaceFilePath(
       "C:\\tmp\\report.txt",
       "C:\\Users\\demo\\project"
     ),
-    "C:/tmp/report.txt"
+    "/C:/tmp/report.txt"
+  );
+  assert.equal(
+    normalizeWorkspaceFilePath("/C:/tmp/report.txt"),
+    "/C:/tmp/report.txt"
   );
 });
 
@@ -92,11 +96,11 @@ test("derives external absolute parent directories outside the current root", ()
 test("derives Windows drive parent directories outside the current root", () => {
   assert.equal(
     workspaceFileDirectory("C:\\tmp\\hello_world.md", "C:\\Users\\demo"),
-    "C:/tmp"
+    "/C:/tmp"
   );
   assert.equal(
     workspaceFileDirectory("C:\\hello_world.md", "C:\\Users\\demo"),
-    "C:/"
+    "/C:/"
   );
 });
 


### PR DESCRIPTION
## Summary

- canonicalize Windows drive-qualified FileManager paths to the daemon logical form `/C:/...`
- make desktop entry existence checks compare native input with daemon logical paths, including drive-root parents
- add regression coverage for AgentGUI folder validation, reveal selection, and duplicate navigation history
- document the recurring Windows FileManager path mismatch troubleshooting pattern

## Root cause

Desktop/AgentGUI launch inputs use native Windows paths such as `C:\Users\...`, while `tuttid` intentionally returns POSIX-shaped logical workspace paths such as `/C:/Users/...`. The FileManager normalized separators but did not normalize the leading logical slash, so strict comparisons incorrectly treated the same path as missing or different.

## User impact

AgentGUI's project-menu "Open folder" action can now validate and open Windows project directories. File reveals retain selection/highlighting, matching sidebar locations remain selected, and equivalent native/daemon paths no longer create duplicate navigation history.

## Validation

Passed:
- workspace-file-manager focused path/navigation tests: 23/23
- workspace-file-manager package Node tests: 137/137
- workspace-file-manager JSDOM tests: 22/22 (single worker)
- desktop workspaceFileManagerService tests: 20/20
- workspace files launch/reveal intent tests: 12/12
- changed-aware lint, naming, backdrop-filter, Electron boundary, renderer boundary, agent-provider boundary, i18n boundary
- workspace-file-manager typecheck
- desktop typecheck
- desktop production build and renderer CSS contracts

The changed-aware aggregate completed 10/13 lanes. Three unrelated baseline/environment failures remain:
- diff lane cannot spawn `bash` on this Windows host; `git diff --check` passes directly
- UI boundary reports pre-existing stale generated renderer theme outputs on `origin/main`
- desktop aggregate tests include existing Windows failures caused by POSIX `/tmp` expectations and a `C:\C:\...` fixture path; the directly changed desktop test file passes 20/20

## Documentation

Added the Windows logical-path mismatch symptom, root cause, fix boundary, and validation guidance to the Workspace Apps and Files troubleshooting guide.
