### PR TITLE
fix(workbench): bound window interaction renders

### DIFF
--- a/docs/conventions/troubleshooting/workbench-renderer.md
+++ b/docs/conventions/troubleshooting/workbench-renderer.md
@@ -928,6 +928,43 @@
   [hostNodeContext.ts](../../../packages/workbench/surface/src/host/hostNodeContext.ts)
   [dockWallpaperSampling.ts](../../../packages/workbench/surface/src/host/dockWallpaperSampling.ts)
 
+### Translated Workbench window still commits on every pointer sample
+
+- Symptom:
+  Dragging or resizing a Workbench window stutters even though the shell uses
+  CSS `translate`, and a trace shows nearly one React commit per raw
+  `pointermove`.
+- Quick checks:
+  Confirm the shell already uses `left: 0`, `top: 0`, and `translate`. Then
+  compare pointer-event, Workbench store notification, `WorkbenchNodeLayerItem`,
+  and React commit counts over the same drag interval. Check whether system
+  traffic-light controls rerender for position-only node changes.
+- Root cause:
+  Compositor-friendly positioning removes `left`/`top` layout work, but it does
+  not reduce JavaScript input frequency. Dispatching every raw pointer sample
+  immediately still creates a new Workbench frame, notifies subscribers, and
+  commits the shell. System window actions can also rebuild Tooltip-backed
+  button trees even when their real inputs did not change.
+- Fix:
+  Keep only the latest pointer sample until the next animation frame and flush
+  any pending sample before `pointerup` or `pointercancel`. Cancel the scheduled
+  callback during cleanup so no frame lands after the interaction ends. Memoize
+  system window actions by their actual command inputs, not the complete node
+  object. Preserve live store updates for snapping, locked layouts, and
+  responsive resize behavior.
+- Validation:
+  Unit-test latest-wins coalescing, final-frame flush, and the absence of a late
+  dispatch. Verify system traffic lights skip position-only renders but update
+  for capability or display-mode changes. Run
+  `pnpm perf:agent-gui -- --scenario workbench-window-drag` and confirm final
+  pointer following, drag cleanup, tile-memory warnings, and renderer-task
+  limits.
+- References:
+  [useWorkbenchDrag.ts](../../../packages/workbench/surface/src/react/hooks/useWorkbenchDrag.ts)
+  [useWorkbenchResize.ts](../../../packages/workbench/surface/src/react/hooks/useWorkbenchResize.ts)
+  [WorkbenchHostWindowActions.tsx](../../../packages/workbench/surface/src/host/WorkbenchHostWindowActions.tsx)
+  [WorkbenchWindowFullscreenToggle.tsx](../../../packages/workbench/surface/src/react/WorkbenchWindowFullscreenToggle.tsx)
+
 ### Adjacent sidebar animation repeatedly reflows its content and message flow
 
 - Symptom:

--- a/packages/workbench/surface/README.md
+++ b/packages/workbench/surface/README.md
@@ -45,7 +45,12 @@ When a node body or header needs host-owned business state, pass an
 
 Node body and header contexts expose `isDragging` and `isResizing`. The Workbench
 shell continues applying live frame geometry during direct manipulation. Window
-position is shell-owned: changing only `frame.x` or `frame.y` does not render a
+pointer samples are latest-wins coalesced to one frame update per animation
+frame; a pending sample is flushed before the interaction ends. This keeps the
+live store contract while bounding shell and responsive-body updates to the
+display cadence.
+
+Window position is shell-owned: changing only `frame.x` or `frame.y` does not render a
 body during drag or resize. Width and height changes remain live, as do changes
 to node data, external state, focus, visibility, or interaction state. The body
 always renders after the interaction settles so the final committed frame

--- a/packages/workbench/surface/package.json
+++ b/packages/workbench/surface/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "build": "tsup --config tsup.config.ts && node ../../../tools/scripts/copy-package-assets.mjs src/styles dist/styles",
-    "test": "node --test --experimental-strip-types ./src/**/*.test.ts && vitest run ./src/host/WorkbenchHostDock.render.test.tsx ./src/host/WorkbenchHostDockMinimizedPreview.test.tsx ./src/host/WorkbenchHost.render.test.tsx ./src/host/useWorkbenchMinimizedDockPreview.test.tsx ./src/preview/createWorkbenchNodePreviewCaptureAdapter.test.tsx ./src/react/genieTextureCapture.test.tsx --environment jsdom",
+    "test": "node --test --experimental-strip-types ./src/**/*.test.ts && vitest run ./src/host/WorkbenchHostDock.render.test.tsx ./src/host/WorkbenchHostDockMinimizedPreview.test.tsx ./src/host/WorkbenchHost.render.test.tsx ./src/host/WorkbenchWindowChrome.render.test.tsx ./src/host/useWorkbenchMinimizedDockPreview.test.tsx ./src/preview/createWorkbenchNodePreviewCaptureAdapter.test.tsx ./src/react/genieTextureCapture.test.tsx ./src/react/hooks/useWorkbenchPointerFrameScheduling.test.tsx --environment jsdom",
     "typecheck": "node ../../../tools/scripts/run-tsgo-typecheck.mjs"
   },
   "devDependencies": {

--- a/packages/workbench/surface/src/host/WorkbenchHostWindowActions.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostWindowActions.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import type { WorkbenchWindowActionContext } from "../react/types.ts";
 import { WorkbenchWindowTrafficLights } from "../react/WorkbenchWindowTrafficLights.tsx";
 import type {
@@ -7,17 +8,19 @@ import type {
 } from "./types.ts";
 import type { WorkbenchHostI18nRuntime } from "./workbenchHostI18n.ts";
 
-export function WorkbenchHostWindowActions({
-  context,
-  host,
-  i18n,
-  nodeDefinitions
-}: {
+interface WorkbenchHostWindowActionsProps {
   context: WorkbenchWindowActionContext<WorkbenchHostNodeData>;
   host: WorkbenchHostHandle;
   i18n: WorkbenchHostI18nRuntime;
   nodeDefinitions: Map<string, WorkbenchHostNodeDefinition>;
-}) {
+}
+
+function WorkbenchHostWindowActionsComponent({
+  context,
+  host,
+  i18n,
+  nodeDefinitions
+}: WorkbenchHostWindowActionsProps) {
   const definition = nodeDefinitions.get(context.node.data.typeId);
   if (!definition) {
     return null;
@@ -53,3 +56,23 @@ export function WorkbenchHostWindowActions({
     />
   );
 }
+
+function areWorkbenchHostWindowActionsPropsEqual(
+  previous: WorkbenchHostWindowActionsProps,
+  next: WorkbenchHostWindowActionsProps
+): boolean {
+  return (
+    previous.host === next.host &&
+    previous.i18n === next.i18n &&
+    previous.nodeDefinitions === next.nodeDefinitions &&
+    previous.context.controller === next.context.controller &&
+    previous.context.genie === next.context.genie &&
+    previous.context.node.id === next.context.node.id &&
+    previous.context.node.data.typeId === next.context.node.data.typeId
+  );
+}
+
+export const WorkbenchHostWindowActions = memo(
+  WorkbenchHostWindowActionsComponent,
+  areWorkbenchHostWindowActionsPropsEqual
+);

--- a/packages/workbench/surface/src/host/WorkbenchWindowChrome.render.test.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchWindowChrome.render.test.tsx
@@ -1,0 +1,167 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorkbenchNode } from "../core/types.ts";
+import { createWorkbenchWindowChromeI18nRuntime } from "../react/workbenchWindowI18n.ts";
+import { WorkbenchWindowFullscreenToggle } from "../react/WorkbenchWindowFullscreenToggle.tsx";
+import { createWorkbenchController } from "../store/createWorkbenchController.ts";
+import type { WorkbenchWindowActionContext } from "../react/types.ts";
+import type {
+  WorkbenchHostHandle,
+  WorkbenchHostNodeData,
+  WorkbenchHostNodeDefinition
+} from "./types.ts";
+import { createWorkbenchHostI18nRuntime } from "./workbenchHostI18n.ts";
+import { WorkbenchHostWindowActions } from "./WorkbenchHostWindowActions.tsx";
+
+const trafficLightsRender = vi.hoisted(() => vi.fn());
+
+vi.mock("../react/WorkbenchWindowTrafficLights.tsx", () => ({
+  WorkbenchWindowTrafficLights: (props: unknown) => {
+    trafficLightsRender(props);
+    return null;
+  }
+}));
+
+const node: WorkbenchNode<WorkbenchHostNodeData> = {
+  data: {
+    instanceId: "test-1",
+    typeId: "test"
+  },
+  displayMode: "floating",
+  frame: { x: 100, y: 100, width: 320, height: 240 },
+  id: "test:test-1",
+  isMinimized: false,
+  kind: "test",
+  restoreFrame: null,
+  title: "Test"
+};
+
+const movedNode: WorkbenchNode<WorkbenchHostNodeData> = {
+  ...node,
+  frame: { ...node.frame, x: 180, y: 160 }
+};
+
+beforeEach(() => {
+  trafficLightsRender.mockClear();
+});
+
+describe("Workbench system window chrome", () => {
+  it("does not render host actions again for a position-only node update", async () => {
+    const controller = createWorkbenchController({
+      nodes: [node],
+      nodeStack: [node.id]
+    });
+    const genie = { minimizeNodeToAnchor: vi.fn() };
+    const context: WorkbenchWindowActionContext<WorkbenchHostNodeData> = {
+      controller,
+      genie,
+      node
+    };
+    const definition: WorkbenchHostNodeDefinition = {
+      frame: node.frame,
+      renderBody: () => null,
+      title: node.title,
+      typeId: node.data.typeId,
+      window: { defaultOpen: true }
+    };
+    const nodeDefinitions = new Map([[definition.typeId, definition]]);
+    const host = {
+      requestNodeClose: vi.fn()
+    } as unknown as WorkbenchHostHandle;
+    const i18n = createWorkbenchHostI18nRuntime(undefined);
+    const container = document.createElement("div");
+    const root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          <WorkbenchHostWindowActions
+            context={context}
+            host={host}
+            i18n={i18n}
+            nodeDefinitions={nodeDefinitions}
+          />
+        );
+      });
+      expect(trafficLightsRender).toHaveBeenCalledOnce();
+
+      await act(async () => {
+        root.render(
+          <WorkbenchHostWindowActions
+            context={{ ...context, node: movedNode }}
+            host={host}
+            i18n={i18n}
+            nodeDefinitions={nodeDefinitions}
+          />
+        );
+      });
+      expect(trafficLightsRender).toHaveBeenCalledOnce();
+
+      await act(async () => {
+        root.render(
+          <WorkbenchHostWindowActions
+            context={{ ...context, node: movedNode }}
+            host={host}
+            i18n={i18n}
+            nodeDefinitions={new Map(nodeDefinitions)}
+          />
+        );
+      });
+      expect(trafficLightsRender).toHaveBeenCalledTimes(2);
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+    }
+  });
+
+  it("does not render the fullscreen action again for a position-only node update", async () => {
+    const controller = createWorkbenchController({
+      nodes: [node],
+      nodeStack: [node.id]
+    });
+    const i18n = createWorkbenchWindowChromeI18nRuntime(undefined);
+    const container = document.createElement("div");
+    const root = createRoot(container);
+
+    try {
+      await act(async () => {
+        root.render(
+          <WorkbenchWindowFullscreenToggle
+            controller={controller}
+            i18n={i18n}
+            node={node}
+          />
+        );
+      });
+      expect(trafficLightsRender).toHaveBeenCalledOnce();
+
+      await act(async () => {
+        root.render(
+          <WorkbenchWindowFullscreenToggle
+            controller={controller}
+            i18n={i18n}
+            node={movedNode}
+          />
+        );
+      });
+      expect(trafficLightsRender).toHaveBeenCalledOnce();
+
+      await act(async () => {
+        root.render(
+          <WorkbenchWindowFullscreenToggle
+            controller={controller}
+            i18n={i18n}
+            node={{ ...movedNode, displayMode: "fullscreen" }}
+          />
+        );
+      });
+      expect(trafficLightsRender).toHaveBeenCalledTimes(2);
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+    }
+  });
+});

--- a/packages/workbench/surface/src/react/WorkbenchWindowFullscreenToggle.tsx
+++ b/packages/workbench/surface/src/react/WorkbenchWindowFullscreenToggle.tsx
@@ -1,19 +1,22 @@
+import { memo } from "react";
 import type { WorkbenchNode } from "../core/types.ts";
 import type { WorkbenchController } from "../store/types.ts";
 import type { WorkbenchWindowChromeI18nRuntime } from "./workbenchWindowI18n.ts";
 import { WorkbenchWindowTrafficLights } from "./WorkbenchWindowTrafficLights.tsx";
 
-export function WorkbenchWindowFullscreenToggle<TData>({
-  controller,
-  disabled = false,
-  i18n,
-  node
-}: {
+interface WorkbenchWindowFullscreenToggleProps<TData> {
   controller: WorkbenchController<TData>;
   disabled?: boolean;
   i18n: WorkbenchWindowChromeI18nRuntime;
   node: WorkbenchNode<TData>;
-}) {
+}
+
+function WorkbenchWindowFullscreenToggleComponent<TData>({
+  controller,
+  disabled = false,
+  i18n,
+  node
+}: WorkbenchWindowFullscreenToggleProps<TData>) {
   const isFullscreen = node.displayMode === "fullscreen";
   const label = i18n.t(isFullscreen ? "exitFullscreen" : "enterFullscreen");
 
@@ -38,3 +41,21 @@ export function WorkbenchWindowFullscreenToggle<TData>({
     />
   );
 }
+
+function areWorkbenchWindowFullscreenTogglePropsEqual<TData>(
+  previous: WorkbenchWindowFullscreenToggleProps<TData>,
+  next: WorkbenchWindowFullscreenToggleProps<TData>
+): boolean {
+  return (
+    previous.controller === next.controller &&
+    previous.disabled === next.disabled &&
+    previous.i18n === next.i18n &&
+    previous.node.id === next.node.id &&
+    previous.node.displayMode === next.node.displayMode
+  );
+}
+
+export const WorkbenchWindowFullscreenToggle = memo(
+  WorkbenchWindowFullscreenToggleComponent,
+  areWorkbenchWindowFullscreenTogglePropsEqual
+) as typeof WorkbenchWindowFullscreenToggleComponent;

--- a/packages/workbench/surface/src/react/hooks/pointerFrameScheduler.ts
+++ b/packages/workbench/surface/src/react/hooks/pointerFrameScheduler.ts
@@ -1,0 +1,47 @@
+interface PointerFrameScheduler {
+  cancel(): void;
+  flush(): void;
+  schedule(event: PointerEvent): void;
+}
+
+export function createPointerFrameScheduler(
+  onFrame: (event: PointerEvent) => void
+): PointerFrameScheduler {
+  let animationFrameID: number | null = null;
+  let pendingEvent: PointerEvent | null = null;
+
+  const dispatchPendingEvent = () => {
+    const event = pendingEvent;
+    pendingEvent = null;
+    if (event) {
+      onFrame(event);
+    }
+  };
+
+  return {
+    cancel() {
+      if (animationFrameID !== null) {
+        window.cancelAnimationFrame(animationFrameID);
+        animationFrameID = null;
+      }
+      pendingEvent = null;
+    },
+    flush() {
+      if (animationFrameID !== null) {
+        window.cancelAnimationFrame(animationFrameID);
+        animationFrameID = null;
+      }
+      dispatchPendingEvent();
+    },
+    schedule(event) {
+      pendingEvent = event;
+      if (animationFrameID !== null) {
+        return;
+      }
+      animationFrameID = window.requestAnimationFrame(() => {
+        animationFrameID = null;
+        dispatchPendingEvent();
+      });
+    }
+  };
+}

--- a/packages/workbench/surface/src/react/hooks/useWorkbenchDrag.ts
+++ b/packages/workbench/surface/src/react/hooks/useWorkbenchDrag.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import type { PointerEvent as ReactPointerEvent } from "react";
 import type { WorkbenchNode } from "../../core/types.ts";
 import { useWorkbenchController } from "../WorkbenchProvider.tsx";
+import { createPointerFrameScheduler } from "./pointerFrameScheduler.ts";
 import { useWorkbenchSnap } from "./useWorkbenchSnap.ts";
 
 export function useWorkbenchDrag<TData>(
@@ -33,7 +34,7 @@ export function useWorkbenchDrag<TData>(
         return lockedLayout !== null && lockedLayout.nodeIDs.includes(node.id);
       };
 
-      const onPointerMove = (moveEvent: PointerEvent) => {
+      const pointerFrames = createPointerFrameScheduler((moveEvent) => {
         const nextFrame = {
           ...initialFrame,
           x: initialFrame.x + moveEvent.clientX - origin.x,
@@ -46,9 +47,14 @@ export function useWorkbenchDrag<TData>(
           );
         }
         controller.commands.dragNode(node.id, nextFrame);
+      });
+
+      const onPointerMove = (moveEvent: PointerEvent) => {
+        pointerFrames.schedule(moveEvent);
       };
 
       const clearListeners = () => {
+        pointerFrames.cancel();
         controller.commands.setActiveDragNode(null);
         controller.commands.setActiveSnapTarget(null);
         window.removeEventListener("pointermove", onPointerMove);
@@ -57,6 +63,7 @@ export function useWorkbenchDrag<TData>(
       };
 
       const finishDrag = (upEvent: PointerEvent) => {
+        pointerFrames.flush();
         if (isLockedLayoutDrag()) {
           controller.commands.settleLockedDrag(node.id);
         } else if (
@@ -71,6 +78,7 @@ export function useWorkbenchDrag<TData>(
       };
 
       const cancelDrag = () => {
+        pointerFrames.flush();
         if (isLockedLayoutDrag()) {
           // Snap the node back into its slot instead of leaving it mid-air.
           controller.commands.settleLockedDrag(node.id);

--- a/packages/workbench/surface/src/react/hooks/useWorkbenchPointerFrameScheduling.test.tsx
+++ b/packages/workbench/surface/src/react/hooks/useWorkbenchPointerFrameScheduling.test.tsx
@@ -1,0 +1,447 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getWorkbenchSnapRect } from "../../core/geometry.ts";
+import type { WorkbenchNode } from "../../core/types.ts";
+import { createWorkbenchController } from "../../store/createWorkbenchController.ts";
+import { WorkbenchProvider } from "../WorkbenchProvider.tsx";
+import { useWorkbenchDrag } from "./useWorkbenchDrag.ts";
+import { useWorkbenchResize } from "./useWorkbenchResize.ts";
+
+interface AnimationFrameQueue {
+  flushNext(): void;
+  pendingCount(): number;
+  restore(): void;
+}
+
+function installAnimationFrameQueue(): AnimationFrameQueue {
+  let nextID = 1;
+  const callbacks = new Map<number, FrameRequestCallback>();
+  const requestSpy = vi
+    .spyOn(window, "requestAnimationFrame")
+    .mockImplementation((callback) => {
+      const id = nextID++;
+      callbacks.set(id, callback);
+      return id;
+    });
+  const cancelSpy = vi
+    .spyOn(window, "cancelAnimationFrame")
+    .mockImplementation((id) => {
+      callbacks.delete(id);
+    });
+
+  return {
+    flushNext() {
+      const next = callbacks.entries().next().value as
+        | [number, FrameRequestCallback]
+        | undefined;
+      if (!next) {
+        throw new Error("Expected a pending animation frame");
+      }
+      callbacks.delete(next[0]);
+      next[1](performance.now());
+    },
+    pendingCount() {
+      return callbacks.size;
+    },
+    restore() {
+      callbacks.clear();
+      requestSpy.mockRestore();
+      cancelSpy.mockRestore();
+    }
+  };
+}
+
+function createPointerEvent(
+  type: "pointercancel" | "pointerdown" | "pointermove" | "pointerup",
+  input: {
+    button?: number;
+    clientX: number;
+    clientY: number;
+    pointerId?: number;
+  }
+): Event {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperties(event, {
+    button: { value: input.button ?? 0 },
+    clientX: { value: input.clientX },
+    clientY: { value: input.clientY },
+    pointerId: { value: input.pointerId ?? 1 }
+  });
+  return event;
+}
+
+const initialNode: WorkbenchNode = {
+  data: null,
+  displayMode: "floating",
+  frame: { x: 100, y: 100, width: 320, height: 240 },
+  id: "node-1",
+  isMinimized: false,
+  kind: "test",
+  restoreFrame: null,
+  title: "Test"
+};
+
+function readNodeFrame(
+  controller: ReturnType<typeof createWorkbenchController>
+) {
+  const frame = controller.getSnapshot().nodes[0]?.frame;
+  if (!frame) {
+    throw new Error("Expected a workbench node frame");
+  }
+  return frame;
+}
+
+function countFrameMutations(
+  controller: ReturnType<typeof createWorkbenchController>
+) {
+  let count = 0;
+  let previousFrame = readNodeFrame(controller);
+  const unsubscribe = controller.subscribe(() => {
+    const nextFrame = readNodeFrame(controller);
+    if (nextFrame !== previousFrame) {
+      count += 1;
+      previousFrame = nextFrame;
+    }
+  });
+  return { count: () => count, unsubscribe };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("workbench pointer frame scheduling", () => {
+  it("coalesces drag moves and flushes the latest frame before pointerup", async () => {
+    const animationFrames = installAnimationFrameQueue();
+    const controller = createWorkbenchController({
+      nodes: [initialNode],
+      nodeStack: [initialNode.id]
+    });
+    const frameMutations = countFrameMutations(controller);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    function DragProbe() {
+      const onPointerDown = useWorkbenchDrag(initialNode);
+      return <button data-drag-handle onPointerDown={onPointerDown} />;
+    }
+
+    try {
+      await act(async () => {
+        root.render(
+          <WorkbenchProvider controller={controller}>
+            <DragProbe />
+          </WorkbenchProvider>
+        );
+      });
+      const handle = container.querySelector(
+        "[data-drag-handle]"
+      ) as HTMLButtonElement | null;
+      if (!handle) {
+        throw new Error("Expected a drag handle");
+      }
+      handle.setPointerCapture = vi.fn();
+
+      await act(async () => {
+        handle.dispatchEvent(
+          createPointerEvent("pointerdown", { clientX: 200, clientY: 200 })
+        );
+        window.dispatchEvent(
+          createPointerEvent("pointermove", { clientX: 210, clientY: 210 })
+        );
+        window.dispatchEvent(
+          createPointerEvent("pointermove", { clientX: 220, clientY: 225 })
+        );
+        window.dispatchEvent(
+          createPointerEvent("pointermove", { clientX: 230, clientY: 235 })
+        );
+      });
+
+      expect(animationFrames.pendingCount()).toBe(1);
+      expect(frameMutations.count()).toBe(0);
+      expect(readNodeFrame(controller)).toEqual(initialNode.frame);
+
+      await act(async () => {
+        animationFrames.flushNext();
+      });
+      expect(frameMutations.count()).toBe(1);
+      expect(readNodeFrame(controller)).toEqual({
+        ...initialNode.frame,
+        x: 130,
+        y: 135
+      });
+
+      await act(async () => {
+        window.dispatchEvent(
+          createPointerEvent("pointermove", { clientX: 245, clientY: 250 })
+        );
+        window.dispatchEvent(
+          createPointerEvent("pointerup", { clientX: 245, clientY: 250 })
+        );
+      });
+      expect(animationFrames.pendingCount()).toBe(0);
+      expect(frameMutations.count()).toBe(2);
+      expect(readNodeFrame(controller)).toEqual({
+        ...initialNode.frame,
+        x: 145,
+        y: 150
+      });
+      expect(controller.getSnapshot().activeDragNodeId).toBeNull();
+    } finally {
+      frameMutations.unsubscribe();
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      animationFrames.restore();
+    }
+  });
+
+  it("coalesces resize moves and flushes the latest frame before pointercancel", async () => {
+    const animationFrames = installAnimationFrameQueue();
+    const controller = createWorkbenchController({
+      nodes: [initialNode],
+      nodeStack: [initialNode.id]
+    });
+    const frameMutations = countFrameMutations(controller);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    function ResizeProbe() {
+      const onPointerDown = useWorkbenchResize(initialNode, "south-east");
+      return <button data-resize-handle onPointerDown={onPointerDown} />;
+    }
+
+    try {
+      await act(async () => {
+        root.render(
+          <WorkbenchProvider controller={controller}>
+            <ResizeProbe />
+          </WorkbenchProvider>
+        );
+      });
+      const handle = container.querySelector(
+        "[data-resize-handle]"
+      ) as HTMLButtonElement | null;
+      if (!handle) {
+        throw new Error("Expected a resize handle");
+      }
+      handle.setPointerCapture = vi.fn();
+
+      await act(async () => {
+        handle.dispatchEvent(
+          createPointerEvent("pointerdown", { clientX: 300, clientY: 300 })
+        );
+        window.dispatchEvent(
+          createPointerEvent("pointermove", { clientX: 310, clientY: 315 })
+        );
+        window.dispatchEvent(
+          createPointerEvent("pointermove", { clientX: 320, clientY: 325 })
+        );
+      });
+
+      expect(animationFrames.pendingCount()).toBe(1);
+      expect(frameMutations.count()).toBe(0);
+
+      await act(async () => {
+        animationFrames.flushNext();
+      });
+      expect(frameMutations.count()).toBe(1);
+      expect(readNodeFrame(controller)).toEqual({
+        ...initialNode.frame,
+        width: 340,
+        height: 265
+      });
+
+      await act(async () => {
+        window.dispatchEvent(
+          createPointerEvent("pointermove", { clientX: 335, clientY: 345 })
+        );
+        window.dispatchEvent(
+          createPointerEvent("pointercancel", { clientX: 335, clientY: 345 })
+        );
+      });
+      expect(animationFrames.pendingCount()).toBe(0);
+      expect(frameMutations.count()).toBe(2);
+      expect(readNodeFrame(controller)).toEqual({
+        ...initialNode.frame,
+        width: 355,
+        height: 285
+      });
+      expect(controller.getSnapshot().activeResizeNodeId).toBeNull();
+    } finally {
+      frameMutations.unsubscribe();
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      animationFrames.restore();
+    }
+  });
+
+  it("flushes the latest locked drag frame before settling the layout", async () => {
+    const animationFrames = installAnimationFrameQueue();
+    const siblingNode: WorkbenchNode = {
+      ...initialNode,
+      id: "node-2",
+      title: "Sibling"
+    };
+    const controller = createWorkbenchController({
+      nodes: [initialNode, siblingNode],
+      nodeStack: [initialNode.id, siblingNode.id],
+      surfaceSize: { width: 1024, height: 720 }
+    });
+    controller.commands.applyLayoutPreset(
+      [initialNode.id, siblingNode.id],
+      { kind: "row" },
+      true
+    );
+    const draggedNode = controller
+      .getSnapshot()
+      .nodes.find((candidate) => candidate.id === initialNode.id);
+    const siblingFrame = controller
+      .getSnapshot()
+      .nodes.find((candidate) => candidate.id === siblingNode.id)?.frame;
+    if (!draggedNode || !siblingFrame) {
+      throw new Error("Expected locked layout nodes");
+    }
+    const lockedDraggedNode = draggedNode;
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    function DragProbe() {
+      const onPointerDown = useWorkbenchDrag(lockedDraggedNode);
+      return <button data-locked-drag-handle onPointerDown={onPointerDown} />;
+    }
+
+    try {
+      await act(async () => {
+        root.render(
+          <WorkbenchProvider controller={controller}>
+            <DragProbe />
+          </WorkbenchProvider>
+        );
+      });
+      const handle = container.querySelector(
+        "[data-locked-drag-handle]"
+      ) as HTMLButtonElement | null;
+      if (!handle) {
+        throw new Error("Expected a locked drag handle");
+      }
+      handle.setPointerCapture = vi.fn();
+      const origin = { x: 200, y: 200 };
+      const target = {
+        x: origin.x + siblingFrame.x + 10 - lockedDraggedNode.frame.x,
+        y: origin.y + siblingFrame.y + 10 - lockedDraggedNode.frame.y
+      };
+
+      await act(async () => {
+        handle.dispatchEvent(
+          createPointerEvent("pointerdown", {
+            clientX: origin.x,
+            clientY: origin.y
+          })
+        );
+        window.dispatchEvent(
+          createPointerEvent("pointermove", {
+            clientX: target.x,
+            clientY: target.y
+          })
+        );
+        window.dispatchEvent(
+          createPointerEvent("pointerup", {
+            clientX: target.x,
+            clientY: target.y
+          })
+        );
+      });
+
+      expect(animationFrames.pendingCount()).toBe(0);
+      expect(
+        controller
+          .getSnapshot()
+          .nodes.find((candidate) => candidate.id === initialNode.id)?.frame
+      ).toEqual(siblingFrame);
+      expect(controller.getSnapshot().lockedLayout?.nodeIDs).toEqual([
+        siblingNode.id,
+        initialNode.id
+      ]);
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      animationFrames.restore();
+    }
+  });
+
+  it("flushes the latest drag frame before applying the final snap target", async () => {
+    const animationFrames = installAnimationFrameQueue();
+    const controller = createWorkbenchController({
+      nodes: [initialNode],
+      nodeStack: [initialNode.id],
+      surfaceSize: { width: 1024, height: 720 }
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    function DragProbe() {
+      const onPointerDown = useWorkbenchDrag(initialNode, {
+        edgeSnapEnabled: true
+      });
+      return <button data-snap-drag-handle onPointerDown={onPointerDown} />;
+    }
+
+    try {
+      await act(async () => {
+        root.render(
+          <WorkbenchProvider controller={controller}>
+            <DragProbe />
+          </WorkbenchProvider>
+        );
+      });
+      const handle = container.querySelector(
+        "[data-snap-drag-handle]"
+      ) as HTMLButtonElement | null;
+      if (!handle) {
+        throw new Error("Expected a snap drag handle");
+      }
+      handle.setPointerCapture = vi.fn();
+
+      await act(async () => {
+        handle.dispatchEvent(
+          createPointerEvent("pointerdown", { clientX: 300, clientY: 300 })
+        );
+        window.dispatchEvent(
+          createPointerEvent("pointermove", { clientX: 0, clientY: 300 })
+        );
+        window.dispatchEvent(
+          createPointerEvent("pointerup", { clientX: 0, clientY: 300 })
+        );
+      });
+
+      const snapshot = controller.getSnapshot();
+      expect(animationFrames.pendingCount()).toBe(0);
+      expect(readNodeFrame(controller)).toEqual(
+        getWorkbenchSnapRect(
+          "left",
+          snapshot.surfaceSize,
+          snapshot.layoutConstraints
+        )
+      );
+      expect(snapshot.activeDragNodeId).toBeNull();
+      expect(snapshot.activeSnapTarget).toBeNull();
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      animationFrames.restore();
+    }
+  });
+});

--- a/packages/workbench/surface/src/react/hooks/useWorkbenchResize.ts
+++ b/packages/workbench/surface/src/react/hooks/useWorkbenchResize.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import type { PointerEvent as ReactPointerEvent } from "react";
 import type { WorkbenchNode, WorkbenchResizeHandle } from "../../core/types.ts";
 import { useWorkbenchController } from "../WorkbenchProvider.tsx";
+import { createPointerFrameScheduler } from "./pointerFrameScheduler.ts";
 
 export function useWorkbenchResize<TData>(
   node: WorkbenchNode<TData>,
@@ -24,25 +25,35 @@ export function useWorkbenchResize<TData>(
       const origin = { x: event.clientX, y: event.clientY };
       const initialFrame = node.frame;
 
-      const onPointerMove = (moveEvent: PointerEvent) => {
+      const pointerFrames = createPointerFrameScheduler((moveEvent) => {
         const deltaX = moveEvent.clientX - origin.x;
         const deltaY = moveEvent.clientY - origin.y;
         controller.commands.resizeNode(
           node.id,
           resizeFrame(initialFrame, handle, deltaX, deltaY)
         );
+      });
+
+      const onPointerMove = (moveEvent: PointerEvent) => {
+        pointerFrames.schedule(moveEvent);
       };
 
       const cleanup = () => {
+        pointerFrames.cancel();
         controller.commands.setActiveResizeNode(null);
         window.removeEventListener("pointermove", onPointerMove);
-        window.removeEventListener("pointerup", cleanup);
-        window.removeEventListener("pointercancel", cleanup);
+        window.removeEventListener("pointerup", finishResize);
+        window.removeEventListener("pointercancel", finishResize);
+      };
+
+      const finishResize = () => {
+        pointerFrames.flush();
+        cleanup();
       };
 
       window.addEventListener("pointermove", onPointerMove);
-      window.addEventListener("pointerup", cleanup);
-      window.addEventListener("pointercancel", cleanup);
+      window.addEventListener("pointerup", finishResize);
+      window.addEventListener("pointercancel", finishResize);
     },
     [controller, handle, node.frame, node.id]
   );


### PR DESCRIPTION
## Summary
- coalesce drag and resize pointer samples to one latest-wins update per animation frame
- flush pending geometry before pointerup/cancel and memoize system traffic-light chrome across position-only updates
- cover free drag, resize, locked layout, edge snap, final cleanup, and chrome invalidation; document the trace diagnostic

## Tests
- `pnpm --filter @tutti-os/workbench-surface test`
- `pnpm check:changed -- --push-ready`

## Notes
- `pnpm perf:agent-gui -- --scenario workbench-window-drag` was attempted, but the isolated source snapshot exposed only one mounted AgentGUI window while the scenario requires at least three, so it exited during preparation before recording the drag
