### PR TITLE
feat(agent-gui): add unavailable image fallback

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1490,6 +1490,18 @@ text, but they are not an additional transcript text block when the canonical
 structured content already renders the same image. Explicit display prompts
 remain transcript content and continue to replace expanded rich prompt text.
 
+Standalone conversation hosts may supply
+`AgentConversationFlow.renderUnavailableImage` to own the presentation for an
+image that AgentGUI cannot render. The same renderer covers structured user
+message images, assistant Markdown images, and image-generation tool artifacts.
+AgentGUI retains loading state and invokes the renderer only after the source is
+known to be unavailable, a host read fails, or the browser image load fails. The
+renderer receives only the image-source category, stable failure reason, and
+alternative text; local paths and raw errors do not cross this presentation
+slot. Omitting the renderer uses AgentGUI's neutral unavailable-image fallback;
+a host renderer replaces that fallback, and a host that intentionally wants no
+failure presentation may return `null` from its renderer.
+
 Standalone hosts may opt a transcript into participant avatars through the
 `agent-conversation` entrypoint's explicit presentation contract. Omitted or
 disabled presentation preserves the existing transcript DOM. Enabled

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1498,9 +1498,10 @@ AgentGUI retains loading state and invokes the renderer only after the source is
 known to be unavailable, a host read fails, or the browser image load fails. The
 renderer receives only the image-source category, stable failure reason, and
 alternative text; local paths and raw errors do not cross this presentation
-slot. Omitting the renderer uses AgentGUI's neutral unavailable-image fallback;
-a host renderer replaces that fallback, and a host that intentionally wants no
-failure presentation may return `null` from its renderer.
+slot. Omitting the renderer uses AgentGUI's neutral, icon-only broken-image
+fallback with an accessible label; a host renderer replaces that fallback, and
+a host that intentionally wants no failure presentation may return `null` from
+its renderer.
 
 Standalone hosts may opt a transcript into participant avatars through the
 `agent-conversation` entrypoint's explicit presentation contract. Omitted or

--- a/packages/agent/gui/agent-conversation/index.ts
+++ b/packages/agent/gui/agent-conversation/index.ts
@@ -38,6 +38,12 @@ export type {
 } from "../shared/agentConversation/contracts/agentConversationParticipantPresentation";
 export type { AgentConversationFlowProps } from "../shared/agentConversation/components/AgentConversationFlow";
 export type { AgentTranscriptViewProps } from "../shared/agentConversation/components/AgentTranscriptView";
+export type {
+  AgentConversationUnavailableImageContext,
+  AgentConversationUnavailableImageReason,
+  AgentConversationUnavailableImageRenderer,
+  AgentConversationUnavailableImageSource
+} from "../shared/agentConversation/contracts/agentConversationUnavailableImage";
 export type { WorkspaceAgentSessionDetailProps } from "../shared/WorkspaceAgentSessionDetail";
 export type { WorkspaceAgentActivityTimelineItem } from "../shared/workspaceAgentTimelineTypes";
 export type { WorkspaceAgentActivityCard } from "../shared/workspaceAgentActivityListViewModel";

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
@@ -12,6 +12,7 @@ import { enAgentGuiUsageStatus } from "./en.agentGuiUsageStatus.ts";
 
 export const enAgentGui = {
   imageDownloaded: "Image downloaded",
+  imagePreviewUnavailable: "Image preview is temporarily unavailable",
   initialPlaceholder: "Type @ to reference sessions, files, tasks, and apps",
   followupPlaceholder: "Request follow-up changes from {{provider}}",
   installRequiredPlaceholder: "Connect {{provider}} to send messages",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
@@ -11,6 +11,7 @@ import { zhCNTuttiModePlan } from "./zh-CN.tuttiModePlan.ts";
 
 export const zhCNAgentGui = {
   imageDownloaded: "图片已下载",
+  imagePreviewUnavailable: "图片暂时无法预览",
   codexSaverModeLabel: "Codex 省额度模式",
   codexSaverModeDescription:
     "主模型保持不变；合适的独立子任务改用 Luna Max，按当前额度口径约为 Sol High 的 1/10。实际效果与速度因任务而异。",

--- a/packages/agent/gui/shared/AgentMessageMarkdown.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.tsx
@@ -65,6 +65,7 @@ import {
   textFromReactNode
 } from "./AgentMessageMarkdownRenderers";
 import { MarkdownMedia } from "./AgentMessageMarkdownMedia";
+import type { AgentConversationUnavailableImageRenderer } from "./agentConversation/contracts/agentConversationUnavailableImage";
 import { remarkLiteralAutolinkBoundary } from "./remarkLiteralAutolinkBoundary";
 import { cachedMarkdownParser } from "./cachedMarkdownParser";
 export { resetCachedMarkdownImagesForTests } from "./AgentMessageMarkdownMedia";
@@ -121,6 +122,7 @@ interface AgentMessageMarkdownProps {
   inline?: boolean;
   normalizePlainIssueMentionTitle?: boolean;
   enableImageZoom?: boolean;
+  renderUnavailableImage?: AgentConversationUnavailableImageRenderer;
   streaming?: boolean;
 }
 
@@ -160,6 +162,7 @@ export function AgentMessageMarkdown({
   inline = false,
   normalizePlainIssueMentionTitle = false,
   enableImageZoom = false,
+  renderUnavailableImage,
   streaming = false
 }: AgentMessageMarkdownProps): JSX.Element {
   "use memo";
@@ -261,7 +264,11 @@ export function AgentMessageMarkdown({
       ),
       code: (props: MarkdownDomProps<"code">) => <MarkdownCode {...props} />,
       img: (props: MarkdownDomProps<"img">) => (
-        <MarkdownMedia {...props} enableZoom={enableImageZoom} />
+        <MarkdownMedia
+          {...props}
+          enableZoom={enableImageZoom}
+          renderUnavailableImage={renderUnavailableImage}
+        />
       ),
       p: (props: MarkdownDomProps<"p">) => (
         <MarkdownParagraph {...props} inline={inline} />
@@ -283,6 +290,7 @@ export function AgentMessageMarkdown({
       handleLinkClick,
       inline,
       mermaidStreaming,
+      renderUnavailableImage,
       workspaceAppIcons
     ]
   );

--- a/packages/agent/gui/shared/AgentMessageMarkdownMedia.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdownMedia.tsx
@@ -1,4 +1,10 @@
-import { useContext, useEffect, useState, type JSX } from "react";
+import {
+  useContext,
+  useEffect,
+  useState,
+  type JSX,
+  type SyntheticEvent
+} from "react";
 import { ZoomableImage } from "../app/renderer/components/ZoomableImage";
 import { cn } from "../app/renderer/lib/utils";
 import { useTranslation } from "../i18n/index";
@@ -22,6 +28,8 @@ import {
   retainCachedMarkdownMedia,
   type MarkdownMediaState
 } from "./agentMessageMarkdownLinks";
+import type { AgentConversationUnavailableImageRenderer } from "./agentConversation/contracts/agentConversationUnavailableImage";
+import { resolveAgentConversationUnavailableImageRenderer } from "./agentConversation/components/AgentConversationUnavailableImageFallback";
 
 export function resetCachedMarkdownImagesForTests(): void {
   resetCachedMarkdownMediaForTests();
@@ -34,12 +42,16 @@ export function MarkdownMedia({
   className,
   title,
   enableZoom = false,
+  renderUnavailableImage,
   ...props
 }: MarkdownDomProps<"img"> & {
   enableZoom?: boolean;
+  renderUnavailableImage?: AgentConversationUnavailableImageRenderer;
 }): JSX.Element {
   "use memo";
   const { t } = useTranslation();
+  const unavailableImageRenderer =
+    resolveAgentConversationUnavailableImageRenderer(renderUnavailableImage);
   const isInsideLink = useContext(MarkdownLinkContext);
   const agentHostApi = useOptionalAgentHostApi() ?? getOptionalAgentHostApi();
   const workspacePath =
@@ -58,6 +70,30 @@ export function MarkdownMedia({
       ? (peekCachedMarkdownMediaState(workspacePath) ?? { status: "loading" })
       : null
   );
+  const [failedRenderableSrc, setFailedRenderableSrc] = useState<string | null>(
+    null
+  );
+  const normalizedAlt = typeof alt === "string" ? alt : "";
+  const mediaKind = workspacePath
+    ? resolveMarkdownMediaKind(workspacePath)
+    : fallbackMediaKind;
+  const renderUnavailable = (
+    reason: "unavailable" | "read-failed" | "load-failed"
+  ): JSX.Element => (
+    <>
+      {unavailableImageRenderer({
+        source: "assistant-markdown",
+        reason,
+        alt: normalizedAlt
+      })}
+    </>
+  );
+  const handleImageError = (event: SyntheticEvent<HTMLImageElement>): void => {
+    props.onError?.(event);
+    setFailedRenderableSrc(
+      event.currentTarget.getAttribute("src") || event.currentTarget.src
+    );
+  };
 
   useEffect(() => {
     if (!workspacePath || !readWorkspaceImage) {
@@ -154,6 +190,19 @@ export function MarkdownMedia({
       );
     }
 
+    if (renderUnavailableImage && (workspacePath || !resolvedSrc)) {
+      return renderUnavailable("unavailable");
+    }
+    if (!resolvedSrc) {
+      return renderUnavailable("unavailable");
+    }
+    if (
+      typeof resolvedSrc === "string" &&
+      failedRenderableSrc === resolvedSrc
+    ) {
+      return renderUnavailable("load-failed");
+    }
+
     if (!shouldEnableZoom) {
       return (
         <img
@@ -162,6 +211,7 @@ export function MarkdownMedia({
           alt={alt}
           title={title}
           className={className}
+          onError={handleImageError}
         />
       );
     }
@@ -175,6 +225,7 @@ export function MarkdownMedia({
         downloadName={resolveMarkdownImageDownloadName(src, alt)}
         className={className}
         wrapElement="span"
+        onError={handleImageError}
       />
     );
   }
@@ -197,6 +248,10 @@ export function MarkdownMedia({
       );
     }
 
+    if (failedRenderableSrc === state.src) {
+      return renderUnavailable("load-failed");
+    }
+
     if (!shouldEnableZoom) {
       return (
         <img
@@ -208,6 +263,7 @@ export function MarkdownMedia({
             "mt-2 block max-h-[360px] max-w-full rounded-[8px] bg-[var(--transparency-block)] object-contain",
             className
           )}
+          onError={handleImageError}
         />
       );
     }
@@ -224,7 +280,14 @@ export function MarkdownMedia({
           className
         )}
         wrapElement="span"
+        onError={handleImageError}
       />
+    );
+  }
+
+  if (state?.status === "error" && mediaKind !== "video") {
+    return renderUnavailable(
+      state.reason === "read-failed" ? "read-failed" : "unavailable"
     );
   }
 

--- a/packages/agent/gui/shared/agentConversation/components/AgentConversationFlow.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentConversationFlow.tsx
@@ -3,6 +3,7 @@ import type { WorkspaceLinkAction } from "../../../contexts/workspace/presentati
 import type { AgentMessageMarkdownWorkspaceAppIcon } from "../../AgentMessageMarkdown";
 import type { AgentConversationVM } from "../contracts/agentConversationVM";
 import type { AgentConversationParticipantPresentation } from "../contracts/agentConversationParticipantPresentation";
+import type { AgentConversationUnavailableImageRenderer } from "../contracts/agentConversationUnavailableImage";
 import type { AgentConversationFollowEndMode } from "../agentConversationFollowEndController";
 import { AgentTranscriptSkeleton } from "./AgentTranscriptSkeleton";
 import {
@@ -36,6 +37,8 @@ export interface AgentConversationFlowProps {
   workspaceAppIcons?: readonly AgentMessageMarkdownWorkspaceAppIcon[];
   showRawTimelineJson?: boolean;
   participantPresentation?: AgentConversationParticipantPresentation;
+  /** Host-owned presentation for transcript images that cannot be rendered. */
+  renderUnavailableImage?: AgentConversationUnavailableImageRenderer;
   followEndMode?: AgentConversationFollowEndMode;
   forkThroughTurnPendingTurnIds?: readonly string[];
   virtualListLayoutRevision?: number;
@@ -68,6 +71,7 @@ export const AgentConversationFlow = memo(function AgentConversationFlow({
   workspaceAppIcons,
   showRawTimelineJson = false,
   participantPresentation,
+  renderUnavailableImage,
   followEndMode,
   forkThroughTurnPendingTurnIds,
   virtualListLayoutRevision,
@@ -105,6 +109,7 @@ export const AgentConversationFlow = memo(function AgentConversationFlow({
         showRawTimelineJson={showRawTimelineJson}
         followEndMode={followEndMode}
         participantPresentation={participantPresentation}
+        renderUnavailableImage={renderUnavailableImage}
         virtualListLayoutRevision={virtualListLayoutRevision}
         virtualScrollControllerRef={virtualScrollControllerRef}
       />

--- a/packages/agent/gui/shared/agentConversation/components/AgentConversationUnavailableImage.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentConversationUnavailableImage.spec.tsx
@@ -18,13 +18,13 @@ describe("Agent conversation unavailable-image renderer", () => {
     } as unknown as typeof window.agentHostApi;
   });
 
-  it("renders the default fallback for a path-only user image", () => {
+  it("renders the default broken-image fallback for a path-only user image", () => {
     render(<AgentUserImageGrid message={userImageMessage()} />);
 
     expectDefaultFallback("user-message", "unavailable");
   });
 
-  it("renders the default fallback when a local Markdown image read fails", async () => {
+  it("renders the default broken-image fallback when a local Markdown image read fails", async () => {
     render(
       <AgentMessageMarkdown content="![generated image](/workspace/output/imagegen/dance.png)" />
     );
@@ -33,14 +33,14 @@ describe("Agent conversation unavailable-image renderer", () => {
     expectDefaultFallback("assistant-markdown", "read-failed");
   });
 
-  it("renders the default fallback when an image-generation artifact read fails", async () => {
+  it("renders the default broken-image fallback when an image-generation artifact read fails", async () => {
     render(<AgentGeneratedImageRow row={generatedImageRow()} />);
 
     await screen.findByTestId("agent-conversation-unavailable-image");
     expectDefaultFallback("image-generation-tool", "read-failed");
   });
 
-  it("renders the default fallback after a browser image load failure", async () => {
+  it("renders the default broken-image fallback after a browser image load failure", async () => {
     render(<AgentGeneratedImageRow row={remoteGeneratedImageRow()} />);
 
     fireEvent.error(screen.getByRole("img"));
@@ -122,9 +122,13 @@ describe("Agent conversation unavailable-image renderer", () => {
 
 function expectDefaultFallback(source: string, reason: string): void {
   const fallback = screen.getByTestId("agent-conversation-unavailable-image");
-  expect(fallback).toHaveTextContent(
+  expect(fallback).not.toHaveTextContent(
     "Image preview is temporarily unavailable"
   );
+  expect(fallback).toHaveAccessibleName(
+    "Image preview is temporarily unavailable"
+  );
+  expect(fallback.querySelector("svg")).not.toBeNull();
   expect(fallback).toHaveAttribute(
     "data-agent-conversation-unavailable-image-source",
     source

--- a/packages/agent/gui/shared/agentConversation/components/AgentConversationUnavailableImage.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentConversationUnavailableImage.spec.tsx
@@ -1,0 +1,193 @@
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentMessageMarkdown } from "../../AgentMessageMarkdown";
+import type { AgentMessageContentVM } from "../contracts/agentMessageRowVM";
+import type { AgentConversationUnavailableImageRenderer } from "../contracts/agentConversationUnavailableImage";
+import { AgentGeneratedImageRow } from "./AgentGeneratedImageRow";
+import { AgentUserImageGrid } from "./AgentMessageImages";
+
+describe("Agent conversation unavailable-image renderer", () => {
+  beforeEach(() => {
+    delete (window as { agentGUIRuntime?: unknown }).agentGUIRuntime;
+    window.agentHostApi = {
+      filesystem: {},
+      workspace: {
+        readFile: vi.fn().mockRejectedValue(new Error("not shared"))
+      }
+    } as unknown as typeof window.agentHostApi;
+  });
+
+  it("renders the default fallback for a path-only user image", () => {
+    render(<AgentUserImageGrid message={userImageMessage()} />);
+
+    expectDefaultFallback("user-message", "unavailable");
+  });
+
+  it("renders the default fallback when a local Markdown image read fails", async () => {
+    render(
+      <AgentMessageMarkdown content="![generated image](/workspace/output/imagegen/dance.png)" />
+    );
+
+    await screen.findByTestId("agent-conversation-unavailable-image");
+    expectDefaultFallback("assistant-markdown", "read-failed");
+  });
+
+  it("renders the default fallback when an image-generation artifact read fails", async () => {
+    render(<AgentGeneratedImageRow row={generatedImageRow()} />);
+
+    await screen.findByTestId("agent-conversation-unavailable-image");
+    expectDefaultFallback("image-generation-tool", "read-failed");
+  });
+
+  it("renders the default fallback after a browser image load failure", async () => {
+    render(<AgentGeneratedImageRow row={remoteGeneratedImageRow()} />);
+
+    fireEvent.error(screen.getByRole("img"));
+
+    await waitFor(() => {
+      expectDefaultFallback("image-generation-tool", "load-failed");
+    });
+  });
+
+  it("renders the host slot for a path-only user image", () => {
+    const renderUnavailableImage = unavailableImageRenderer();
+
+    render(
+      <AgentUserImageGrid
+        message={userImageMessage()}
+        renderUnavailableImage={renderUnavailableImage}
+      />
+    );
+
+    expect(screen.getByTestId("unavailable-image")).toHaveTextContent(
+      "user-message:unavailable:screen.png"
+    );
+    expect(renderUnavailableImage).toHaveBeenCalledWith({
+      source: "user-message",
+      reason: "unavailable",
+      alt: "screen.png"
+    });
+  });
+
+  it("renders the host slot when a local Markdown image read fails", async () => {
+    const renderUnavailableImage = unavailableImageRenderer();
+
+    render(
+      <AgentMessageMarkdown
+        content="![generated image](/workspace/output/imagegen/dance.png)"
+        renderUnavailableImage={renderUnavailableImage}
+      />
+    );
+
+    expect(await screen.findByTestId("unavailable-image")).toHaveTextContent(
+      "assistant-markdown:read-failed:generated image"
+    );
+  });
+
+  it("renders the host slot when an image-generation artifact read fails", async () => {
+    const renderUnavailableImage = unavailableImageRenderer();
+
+    render(
+      <AgentGeneratedImageRow
+        row={generatedImageRow()}
+        renderUnavailableImage={renderUnavailableImage}
+      />
+    );
+
+    expect(await screen.findByTestId("unavailable-image")).toHaveTextContent(
+      "image-generation-tool:read-failed:Image generation preview"
+    );
+  });
+
+  it("renders the host slot after a browser image load failure", async () => {
+    const renderUnavailableImage = unavailableImageRenderer();
+
+    render(
+      <AgentGeneratedImageRow
+        row={remoteGeneratedImageRow()}
+        renderUnavailableImage={renderUnavailableImage}
+      />
+    );
+
+    fireEvent.error(screen.getByRole("img"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("unavailable-image")).toHaveTextContent(
+        "image-generation-tool:load-failed:Image generation preview"
+      );
+    });
+  });
+});
+
+function expectDefaultFallback(source: string, reason: string): void {
+  const fallback = screen.getByTestId("agent-conversation-unavailable-image");
+  expect(fallback).toHaveTextContent(
+    "Image preview is temporarily unavailable"
+  );
+  expect(fallback).toHaveAttribute(
+    "data-agent-conversation-unavailable-image-source",
+    source
+  );
+  expect(fallback).toHaveAttribute(
+    "data-agent-conversation-unavailable-image-reason",
+    reason
+  );
+}
+
+function unavailableImageRenderer() {
+  const renderer: AgentConversationUnavailableImageRenderer = (context) => (
+    <div data-testid="unavailable-image">
+      {context.source}:{context.reason}:{context.alt}
+    </div>
+  );
+  return vi.fn(renderer);
+}
+
+function userImageMessage(): AgentMessageContentVM {
+  return {
+    kind: "message-content",
+    id: "user-images-1",
+    turnId: "turn-1",
+    body: "",
+    presentationKind: "content",
+    contentKind: "image-grid",
+    images: [
+      {
+        id: "image-1",
+        workspaceId: "room-1",
+        agentSessionId: "session-1",
+        mimeType: "image/png",
+        name: "screen.png",
+        path: "/workspace/prompt-assets/screen.png"
+      }
+    ],
+    occurredAtUnixMs: 1
+  };
+}
+
+function generatedImageRow() {
+  return {
+    kind: "generated-image" as const,
+    id: "generated-image:call-1",
+    turnId: "turn-1",
+    sourceCallId: "call-1",
+    uri: "/workspace/output/imagegen/dance.png",
+    mimeType: "image/png",
+    prompt: "A dancer",
+    occurredAtUnixMs: 1
+  };
+}
+
+function remoteGeneratedImageRow() {
+  return {
+    kind: "generated-image" as const,
+    id: "generated-image:call-remote",
+    turnId: "turn-1",
+    sourceCallId: "call-remote",
+    uri: "https://assets.example.test/image.png",
+    mimeType: "image/png",
+    prompt: null,
+    occurredAtUnixMs: 1
+  };
+}

--- a/packages/agent/gui/shared/agentConversation/components/AgentConversationUnavailableImageFallback.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentConversationUnavailableImageFallback.tsx
@@ -1,0 +1,37 @@
+import type { JSX } from "react";
+import { useTranslation } from "../../../i18n/index";
+import type {
+  AgentConversationUnavailableImageContext,
+  AgentConversationUnavailableImageRenderer
+} from "../contracts/agentConversationUnavailableImage";
+
+export const renderDefaultAgentConversationUnavailableImage: AgentConversationUnavailableImageRenderer =
+  (context) => <AgentConversationUnavailableImageFallback context={context} />;
+
+export function resolveAgentConversationUnavailableImageRenderer(
+  renderer: AgentConversationUnavailableImageRenderer | undefined
+): AgentConversationUnavailableImageRenderer {
+  return renderer ?? renderDefaultAgentConversationUnavailableImage;
+}
+
+function AgentConversationUnavailableImageFallback({
+  context
+}: {
+  context: AgentConversationUnavailableImageContext;
+}): JSX.Element {
+  const { t } = useTranslation();
+  const label = t("agentHost.agentGui.imagePreviewUnavailable");
+
+  return (
+    <span
+      aria-label={label}
+      className="flex min-h-20 w-full items-center justify-center rounded-[8px] bg-[var(--transparency-block)] px-3 py-2 text-center text-[12px] leading-5 text-[var(--text-tertiary)]"
+      data-agent-conversation-unavailable-image-reason={context.reason}
+      data-agent-conversation-unavailable-image-source={context.source}
+      data-testid="agent-conversation-unavailable-image"
+      role="img"
+    >
+      {label}
+    </span>
+  );
+}

--- a/packages/agent/gui/shared/agentConversation/components/AgentConversationUnavailableImageFallback.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentConversationUnavailableImageFallback.tsx
@@ -1,4 +1,5 @@
 import type { JSX } from "react";
+import { ImageOff } from "lucide-react";
 import { useTranslation } from "../../../i18n/index";
 import type {
   AgentConversationUnavailableImageContext,
@@ -25,13 +26,13 @@ function AgentConversationUnavailableImageFallback({
   return (
     <span
       aria-label={label}
-      className="flex min-h-20 w-full items-center justify-center rounded-[8px] bg-[var(--transparency-block)] px-3 py-2 text-center text-[12px] leading-5 text-[var(--text-tertiary)]"
+      className="flex min-h-20 w-full items-center justify-center rounded-[8px] bg-[var(--transparency-block)] px-3 py-2 text-[var(--text-tertiary)]"
       data-agent-conversation-unavailable-image-reason={context.reason}
       data-agent-conversation-unavailable-image-source={context.source}
       data-testid="agent-conversation-unavailable-image"
       role="img"
     >
-      {label}
+      <ImageOff aria-hidden="true" className="size-5" strokeWidth={1.5} />
     </span>
   );
 }

--- a/packages/agent/gui/shared/agentConversation/components/AgentGeneratedImagePreview.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentGeneratedImagePreview.tsx
@@ -6,33 +6,62 @@ import {
   isLocalImagePath,
   resolveImageGenerationPreviewSrc
 } from "../../imageGenerationTool";
+import type {
+  AgentConversationUnavailableImageReason,
+  AgentConversationUnavailableImageRenderer
+} from "../contracts/agentConversationUnavailableImage";
+import { resolveAgentConversationUnavailableImageRenderer } from "./AgentConversationUnavailableImageFallback";
+
+type AgentGeneratedImagePreviewState =
+  | { status: "loading" }
+  | { status: "ready"; src: string }
+  | {
+      status: "error";
+      reason: AgentConversationUnavailableImageReason;
+    };
 
 interface AgentGeneratedImagePreviewProps {
   uri: string;
   mimeType: string | null;
   alt: string;
   className: string;
+  renderUnavailableImage?: AgentConversationUnavailableImageRenderer;
 }
 
 export function AgentGeneratedImagePreview({
   uri,
   mimeType,
   alt,
-  className
+  className,
+  renderUnavailableImage
 }: AgentGeneratedImagePreviewProps): JSX.Element | null {
   "use memo";
+  const unavailableImageRenderer =
+    resolveAgentConversationUnavailableImageRenderer(renderUnavailableImage);
   const agentHostApi = useOptionalAgentHostApi();
   const localPath = isLocalImagePath(uri) ? uri.trim() : null;
   const readWorkspaceImage = localPath
     ? agentHostApi?.workspace?.readFile
     : undefined;
-  const [src, setSrc] = useState<string | null>(() =>
-    !localPath ? resolveImageGenerationPreviewSrc(uri) : null
-  );
+  const [state, setState] = useState<AgentGeneratedImagePreviewState>(() => {
+    const src = resolveImageGenerationPreviewSrc(uri);
+    if (localPath && readWorkspaceImage) {
+      return { status: "loading" };
+    }
+    if (src) {
+      return { status: "ready", src };
+    }
+    return { status: "error", reason: "unavailable" };
+  });
 
   useEffect(() => {
     if (!localPath || !readWorkspaceImage) {
-      setSrc(resolveImageGenerationPreviewSrc(uri));
+      const src = resolveImageGenerationPreviewSrc(uri);
+      setState(
+        src
+          ? { status: "ready", src }
+          : { status: "error", reason: "unavailable" }
+      );
       return;
     }
 
@@ -64,15 +93,15 @@ export function AgentGeneratedImagePreview({
         objectUrl = URL.createObjectURL(
           new Blob([arrayBuffer], { type: resolvedMimeType })
         );
-        setSrc(objectUrl);
+        setState({ status: "ready", src: objectUrl });
       } catch {
         if (!canceled) {
-          setSrc(null);
+          setState({ status: "error", reason: "read-failed" });
         }
       }
     }
 
-    setSrc(null);
+    setState({ status: "loading" });
     void loadWorkspaceImage();
 
     return () => {
@@ -83,8 +112,32 @@ export function AgentGeneratedImagePreview({
     };
   }, [localPath, mimeType, readWorkspaceImage, uri]);
 
-  if (!src) {
+  if (localPath && !readWorkspaceImage && renderUnavailableImage) {
+    return (
+      <>
+        {unavailableImageRenderer({
+          source: "image-generation-tool",
+          reason: "unavailable",
+          alt
+        })}
+      </>
+    );
+  }
+
+  if (state.status === "loading") {
     return null;
+  }
+
+  if (state.status === "error") {
+    return (
+      <>
+        {unavailableImageRenderer({
+          source: "image-generation-tool",
+          reason: state.reason,
+          alt
+        })}
+      </>
+    );
   }
 
   return (
@@ -92,8 +145,9 @@ export function AgentGeneratedImagePreview({
       alt={alt}
       className={className}
       downloadName={localPath ? localPath.split(/[\\/]/).pop() : "image.png"}
-      src={src}
+      src={state.src}
       wrapElement="span"
+      onError={() => setState({ status: "error", reason: "load-failed" })}
     />
   );
 }

--- a/packages/agent/gui/shared/agentConversation/components/AgentGeneratedImageRow.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentGeneratedImageRow.tsx
@@ -1,12 +1,15 @@
 import type { JSX } from "react";
 import { translate } from "../../../i18n/index";
 import type { AgentGeneratedImageRowVM } from "../contracts/agentGeneratedImageRowVM";
+import type { AgentConversationUnavailableImageRenderer } from "../contracts/agentConversationUnavailableImage";
 import { AgentGeneratedImagePreview } from "./AgentGeneratedImagePreview";
 
 export function AgentGeneratedImageRow({
-  row
+  row,
+  renderUnavailableImage
 }: {
   row: AgentGeneratedImageRowVM;
+  renderUnavailableImage?: AgentConversationUnavailableImageRenderer;
 }): JSX.Element {
   "use memo";
   return (
@@ -19,6 +22,7 @@ export function AgentGeneratedImageRow({
         mimeType={row.mimeType}
         alt={translate("agentHost.agentTool.details.imagePreviewAlt")}
         className="block max-h-[560px] max-w-full rounded-[10px] border border-[var(--line-2)] bg-[var(--background-panel)] object-contain"
+        renderUnavailableImage={renderUnavailableImage}
       />
     </div>
   );

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
@@ -23,6 +23,7 @@ import type {
   AgentConversationParticipantIdentity,
   AgentConversationParticipantPresentation
 } from "../contracts/agentConversationParticipantPresentation";
+import type { AgentConversationUnavailableImageRenderer } from "../contracts/agentConversationUnavailableImage";
 import { AgentMessageDetailsDisclosure } from "./AgentMessageDetailsDisclosure";
 import { AgentToolGroupRow } from "./AgentToolGroupRow";
 import {
@@ -70,6 +71,7 @@ interface AgentMessageBlockProps {
   showRawTimelineJson?: boolean;
   rawTimelineJsonLabel?: string;
   participantPresentation?: AgentConversationParticipantPresentation;
+  renderUnavailableImage?: AgentConversationUnavailableImageRenderer;
   showParticipantHeader?: boolean;
   isActiveTurn?: boolean;
   footerAction?: ReactNode;
@@ -90,6 +92,7 @@ export function AgentMessageBlock({
   showRawTimelineJson = false,
   rawTimelineJsonLabel = "",
   participantPresentation,
+  renderUnavailableImage,
   showParticipantHeader = true,
   isActiveTurn = false,
   footerAction
@@ -214,7 +217,10 @@ export function AgentMessageBlock({
         : null;
     const renderedContent =
       isUser && message.contentKind === "image-grid" ? (
-        <AgentUserImageGrid message={message} />
+        <AgentUserImageGrid
+          message={message}
+          renderUnavailableImage={renderUnavailableImage}
+        />
       ) : isUser &&
         message.contentKind === "tutti-checkpoint-wake" &&
         message.checkpointWake ? (
@@ -284,6 +290,7 @@ export function AgentMessageBlock({
           }}
           workspaceAppIcons={workspaceAppIcons}
           enableImageZoom
+          renderUnavailableImage={renderUnavailableImage}
           streaming={
             isActiveTurn ||
             message.statusKind === "working" ||

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageImages.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageImages.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type JSX } from "react";
+import { useCallback, useEffect, useMemo, useState, type JSX } from "react";
 import { LoaderCircle } from "lucide-react";
 import { useOptionalAgentGUIRuntime } from "../../../agentActivityRuntime";
 import { ZoomableImage } from "../../../app/renderer/components/ZoomableImage";
@@ -7,15 +7,30 @@ import type {
   AgentMessageContentVM,
   AgentMessageImageVM
 } from "../contracts/agentMessageRowVM";
+import type {
+  AgentConversationUnavailableImageReason,
+  AgentConversationUnavailableImageRenderer
+} from "../contracts/agentConversationUnavailableImage";
+import { resolveAgentConversationUnavailableImageRenderer } from "./AgentConversationUnavailableImageFallback";
+
+interface AgentMessageImageFailure {
+  identity: string;
+  reason: AgentConversationUnavailableImageReason;
+}
 
 export function AgentUserImageGrid({
-  message
+  message,
+  renderUnavailableImage
 }: {
   message: AgentMessageContentVM;
+  renderUnavailableImage?: AgentConversationUnavailableImageRenderer;
 }): JSX.Element {
   "use memo";
   const images = message.images ?? [];
-  const { loadingIds, sources } = useAgentMessageImageSources(images);
+  const unavailableImageRenderer =
+    resolveAgentConversationUnavailableImageRenderer(renderUnavailableImage);
+  const { failures, loadingIds, markLoadFailed, sources } =
+    useAgentMessageImageSources(images);
   const columnCount = Math.min(Math.max(images.length, 1), 4);
   const thumbnailWidth = images.length === 1 ? "160px" : "80px";
   return (
@@ -28,15 +43,30 @@ export function AgentUserImageGrid({
       {images.map((image) => {
         const src = sources.get(image.id) ?? imageSourceUrl(image);
         const loading = !src && loadingIds.has(image.id);
+        const failure = failures.get(image.id);
+        const failureReason =
+          failure?.identity === imageIdentity(image) ? failure.reason : null;
+        const alt = image.name?.trim() || "image";
+        const unavailable =
+          !loading && (!src || failureReason)
+            ? unavailableImageRenderer({
+                source: "user-message",
+                reason: failureReason ?? "unavailable",
+                alt
+              })
+            : null;
         return (
           <div key={image.id} className={styles.userImageThumbnail}>
-            {src ? (
+            {!loading && (!src || failureReason) ? (
+              <>{unavailable}</>
+            ) : src ? (
               <ZoomableImage
                 src={src}
-                alt={image.name?.trim() || "image"}
+                alt={alt}
                 className="block max-h-20 w-full rounded-[7px] object-contain"
                 draggable={false}
                 downloadName={image.name?.trim() || "image.png"}
+                onError={() => markLoadFailed(image)}
               />
             ) : loading ? (
               <div
@@ -60,24 +90,41 @@ export function AgentUserImageGrid({
 }
 
 function useAgentMessageImageSources(images: readonly AgentMessageImageVM[]): {
+  failures: ReadonlyMap<string, AgentMessageImageFailure>;
   loadingIds: ReadonlySet<string>;
+  markLoadFailed: (image: AgentMessageImageVM) => void;
   sources: ReadonlyMap<string, string>;
 } {
   const runtime = useOptionalAgentGUIRuntime();
   const [sources, setSources] = useState<Map<string, string>>(() => new Map());
   const [loadingIds, setLoadingIds] = useState<Set<string>>(() => new Set());
+  const [failures, setFailures] = useState<
+    Map<string, AgentMessageImageFailure>
+  >(() => new Map());
   const missingImages = useMemo(
     () =>
       images.filter(
         (image) =>
           !imageSourceUrl(image) &&
           !sources.has(image.id) &&
+          failures.get(image.id)?.identity !== imageIdentity(image) &&
           image.workspaceId &&
           image.agentSessionId &&
           (image.attachmentId || image.path)
       ),
-    [images, sources]
+    [failures, images, sources]
   );
+
+  const markLoadFailed = useCallback((image: AgentMessageImageVM): void => {
+    setFailures((current) => {
+      const next = new Map(current);
+      next.set(image.id, {
+        identity: imageIdentity(image),
+        reason: "load-failed"
+      });
+      return next;
+    });
+  }, []);
 
   useEffect(() => {
     if (
@@ -114,8 +161,26 @@ function useAgentMessageImageSources(images: readonly AgentMessageImageVM[]): {
             );
             return next;
           });
+          setFailures((current) => {
+            if (!current.has(image.id)) {
+              return current;
+            }
+            const next = new Map(current);
+            next.delete(image.id);
+            return next;
+          });
         })
-        .catch(() => {})
+        .catch(() => {
+          if (canceled) return;
+          setFailures((current) => {
+            const next = new Map(current);
+            next.set(image.id, {
+              identity: imageIdentity(image),
+              reason: "read-failed"
+            });
+            return next;
+          });
+        })
         .finally(() => {
           if (canceled) return;
           setLoadingIds((current) => {
@@ -130,7 +195,18 @@ function useAgentMessageImageSources(images: readonly AgentMessageImageVM[]): {
     };
   }, [missingImages, runtime]);
 
-  return { loadingIds, sources };
+  return { failures, loadingIds, markLoadFailed, sources };
+}
+
+function imageIdentity(image: AgentMessageImageVM): string {
+  const data = image.data?.trim() ?? "";
+  return [
+    image.id,
+    image.attachmentId?.trim() ?? "",
+    image.path?.trim() ?? "",
+    image.url?.trim() ?? "",
+    data ? `${data.length}:${data.slice(0, 24)}` : ""
+  ].join("\u0000");
 }
 
 function imageDataUrl(image: AgentMessageImageVM): string | null {

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.tsx
@@ -5,6 +5,7 @@ import type { AgentGUIProviderSkillOption } from "../../../agent-gui/agentGuiNod
 import { resolveAgentConversationLinkAction } from "../actions/agentConversationLinkActions";
 import type { AgentTranscriptRowVM } from "../contracts/agentTranscriptRowVM";
 import type { AgentConversationParticipantPresentation } from "../contracts/agentConversationParticipantPresentation";
+import type { AgentConversationUnavailableImageRenderer } from "../contracts/agentConversationUnavailableImage";
 import { AgentGeneratedImageRow } from "./AgentGeneratedImageRow";
 import { AgentGoalControlRow } from "./AgentGoalControlRow";
 import { AgentMessageBlock } from "./AgentMessageBlock";
@@ -32,6 +33,7 @@ interface AgentTranscriptItemViewProps {
   workspaceAppIcons?: readonly AgentMessageMarkdownWorkspaceAppIcon[];
   showRawTimelineJson?: boolean;
   participantPresentation?: AgentConversationParticipantPresentation;
+  renderUnavailableImage?: AgentConversationUnavailableImageRenderer;
   showParticipantHeader?: boolean;
   isActiveTurn?: boolean;
   processingPaused?: boolean;
@@ -54,6 +56,7 @@ export const AgentTranscriptItemView = memo(function AgentTranscriptItemView({
   workspaceAppIcons,
   showRawTimelineJson = false,
   participantPresentation,
+  renderUnavailableImage,
   showParticipantHeader,
   isActiveTurn = false,
   processingPaused = false,
@@ -80,7 +83,12 @@ export const AgentTranscriptItemView = memo(function AgentTranscriptItemView({
   );
   switch (row.kind) {
     case "generated-image":
-      return <AgentGeneratedImageRow row={row} />;
+      return (
+        <AgentGeneratedImageRow
+          row={row}
+          renderUnavailableImage={renderUnavailableImage}
+        />
+      );
     case "goal-control":
       return (
         <AgentGoalControlRow
@@ -106,6 +114,7 @@ export const AgentTranscriptItemView = memo(function AgentTranscriptItemView({
           showRawTimelineJson={showRawTimelineJson}
           rawTimelineJsonLabel={labels.rawTimelineJson}
           participantPresentation={participantPresentation}
+          renderUnavailableImage={renderUnavailableImage}
           showParticipantHeader={showParticipantHeader}
           isActiveTurn={isActiveTurn}
           footerAction={footerAction}

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx
@@ -15,6 +15,7 @@ import type { AgentMessageMarkdownWorkspaceAppIcon } from "../../AgentMessageMar
 import type { AgentGUIProviderSkillOption } from "../../../agent-gui/agentGuiNode/model/agentGuiNodeTypes";
 import type { AgentConversationVM } from "../contracts/agentConversationVM";
 import type { AgentConversationParticipantPresentation } from "../contracts/agentConversationParticipantPresentation";
+import type { AgentConversationUnavailableImageRenderer } from "../contracts/agentConversationUnavailableImage";
 import type { AgentConversationFollowEndMode } from "../agentConversationFollowEndController";
 import { AgentTranscriptItemView } from "./AgentTranscriptItemView";
 import {
@@ -68,7 +69,6 @@ import { useAgentObservationGap } from "../AgentObservationGapContext";
 const AGENT_TRANSCRIPT_DISCLOSURE_TURN_GAP_PX = 24;
 const AGENT_TRANSCRIPT_LEGACY_TURN_GAP_PX = 12;
 const AGENT_TRANSCRIPT_FALLBACK_TURN_COUNT = 3;
-
 export type {
   AgentTranscriptAttachmentLocator,
   AgentTranscriptTurnAttachment
@@ -91,6 +91,7 @@ export interface AgentTranscriptViewProps {
   workspaceAppIcons?: readonly AgentMessageMarkdownWorkspaceAppIcon[];
   showRawTimelineJson?: boolean;
   participantPresentation?: AgentConversationParticipantPresentation;
+  renderUnavailableImage?: AgentConversationUnavailableImageRenderer;
   followEndMode?: AgentConversationFollowEndMode;
   forkThroughTurnPendingTurnIds?: readonly string[];
   virtualListLayoutRevision?: number;
@@ -243,6 +244,7 @@ export function areAgentTranscriptViewPropsEqual(
     previous.followEndMode === next.followEndMode &&
     previous.virtualListLayoutRevision === next.virtualListLayoutRevision &&
     previous.virtualScrollControllerRef === next.virtualScrollControllerRef &&
+    previous.renderUnavailableImage === next.renderUnavailableImage &&
     participantPresentationEqual(
       previous.participantPresentation,
       next.participantPresentation
@@ -265,6 +267,7 @@ export const AgentTranscriptView = memo(function AgentTranscriptView({
   workspaceAppIcons,
   showRawTimelineJson = false,
   participantPresentation,
+  renderUnavailableImage,
   followEndMode,
   forkThroughTurnPendingTurnIds = [],
   virtualListLayoutRevision = 0,
@@ -554,6 +557,7 @@ export const AgentTranscriptView = memo(function AgentTranscriptView({
           workspaceAppIcons={workspaceAppIcons}
           showRawTimelineJson={showRawTimelineJson}
           participantPresentation={participantPresentation}
+          renderUnavailableImage={renderUnavailableImage}
           showParticipantHeader={showParticipantHeader}
           isActiveTurn={isActiveTurn}
           processingPaused={

--- a/packages/agent/gui/shared/agentConversation/contracts/agentConversationUnavailableImage.ts
+++ b/packages/agent/gui/shared/agentConversation/contracts/agentConversationUnavailableImage.ts
@@ -1,0 +1,21 @@
+import type { ReactNode } from "react";
+
+export type AgentConversationUnavailableImageSource =
+  | "user-message"
+  | "assistant-markdown"
+  | "image-generation-tool";
+
+export type AgentConversationUnavailableImageReason =
+  | "unavailable"
+  | "read-failed"
+  | "load-failed";
+
+export interface AgentConversationUnavailableImageContext {
+  source: AgentConversationUnavailableImageSource;
+  reason: AgentConversationUnavailableImageReason;
+  alt: string;
+}
+
+export type AgentConversationUnavailableImageRenderer = (
+  context: AgentConversationUnavailableImageContext
+) => ReactNode;


### PR DESCRIPTION
- 增加 `renderUnavailableImage` 宿主渲染接口。
- 不传 renderer 时使用 Agent GUI 默认提示。
- 覆盖用户图片、Markdown 图片和图片生成工具结果。
- 外部 renderer 仍然优先。
- 309 个测试文件、2677 个测试通过。
- `check:changed` 和 Agent GUI build 通过。