### PR TITLE
feat(connectors): gate connector entries behind Lab

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -1450,6 +1450,10 @@ test("WorkspaceAgentActivityService starts session-event streams and forwards ca
     {
       scope: null,
       topic: "connector.market.changed"
+    },
+    {
+      scope: null,
+      topic: "preferences.desktop.updated"
     }
   ]);
   assert.equal(connectCalls, 1);
@@ -1939,7 +1943,7 @@ test("WorkspaceAgentActivityService dispose releases every event stream subscrip
   });
 
   service.onSessionEvent("ws-1", () => {});
-  assert.equal(activeSubscriptions.size, 6);
+  assert.equal(activeSubscriptions.size, 7);
 
   service.dispose();
   service.dispose();

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentComposerOptionsInvalidationCoordinator.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentComposerOptionsInvalidationCoordinator.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { TuttidEventStreamClient } from "@tutti-os/client-tuttid-ts";
+import type { WorkspaceAgentSessionEngineHost } from "./workspaceAgentSessionEngineHost.ts";
+import { WorkspaceAgentComposerOptionsInvalidationCoordinator } from "./workspaceAgentComposerOptionsInvalidationCoordinator.ts";
+
+test("connector Lab visibility changes invalidate cached Composer Options", () => {
+  const dispatched: unknown[] = [];
+  const host = {
+    engine: {
+      dispatch(intent: unknown) {
+        dispatched.push(intent);
+      }
+    }
+  } as unknown as WorkspaceAgentSessionEngineHost;
+  type PreferencesUpdatedEvent = {
+    payload: { preferences: { featureFlags: Record<string, boolean> } };
+  };
+  const listeners = new Map<string, (event: PreferencesUpdatedEvent) => void>();
+  const events = {
+    subscribe(topic: string, listener: unknown) {
+      listeners.set(
+        topic,
+        listener as (event: PreferencesUpdatedEvent) => void
+      );
+      return () => listeners.delete(topic);
+    }
+  } as unknown as TuttidEventStreamClient;
+  const coordinator = new WorkspaceAgentComposerOptionsInvalidationCoordinator(
+    () => [host]
+  );
+  const catalogInvalidations: unknown[] = [];
+  coordinator.onConnectorCatalogInvalidated((event) => {
+    catalogInvalidations.push(event);
+  });
+  coordinator.subscribe(events);
+
+  const publishVisibility = (enabled: boolean) => {
+    listeners.get("preferences.desktop.updated")?.({
+      payload: {
+        preferences: { featureFlags: { "lab.connectors": enabled } }
+      }
+    });
+  };
+
+  publishVisibility(false);
+  publishVisibility(false);
+  publishVisibility(true);
+
+  assert.deepEqual(dispatched, [
+    { type: "composerOptions/invalidated" },
+    { type: "composerOptions/invalidated" }
+  ]);
+  assert.deepEqual(catalogInvalidations, [{ revision: 1 }, { revision: 2 }]);
+});

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentComposerOptionsInvalidationCoordinator.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentComposerOptionsInvalidationCoordinator.ts
@@ -5,6 +5,10 @@ import type {
   WorkspaceAgentModelCatalogInvalidatedEvent
 } from "../workspaceAgentActivityService.interface.ts";
 import type { WorkspaceAgentSessionEngineHost } from "./workspaceAgentSessionEngineHost.ts";
+import {
+  isFeatureEnabled,
+  LAB_CONNECTORS_FLAG
+} from "../../../../../../shared/featureFlags/catalog.ts";
 
 export class WorkspaceAgentComposerOptionsInvalidationCoordinator {
   private readonly hosts: () => Iterable<WorkspaceAgentSessionEngineHost>;
@@ -17,8 +21,10 @@ export class WorkspaceAgentComposerOptionsInvalidationCoordinator {
   private readonly connectorCatalogListeners = new Set<
     (event: WorkspaceAgentConnectorCatalogInvalidatedEvent) => void
   >();
-  private connectorCatalogRevision = 0;
+  private connectorCatalogEventRevision = 0;
+  private connectorMarketRevision = 0;
   private disposed = false;
+  private connectorsVisible: boolean | null = null;
 
   constructor(hosts: () => Iterable<WorkspaceAgentSessionEngineHost>) {
     this.hosts = hosts;
@@ -68,6 +74,11 @@ export class WorkspaceAgentComposerOptionsInvalidationCoordinator {
             : {}),
           revision: event.payload.revision
         })
+      ),
+      eventStreamClient.subscribe("preferences.desktop.updated", (event) =>
+        this.handleDesktopPreferencesUpdated(
+          event.payload.preferences.featureFlags
+        )
       )
     ];
   }
@@ -118,19 +129,44 @@ export class WorkspaceAgentComposerOptionsInvalidationCoordinator {
     if (
       this.disposed ||
       !Number.isSafeInteger(event.revision) ||
-      event.revision <= this.connectorCatalogRevision
+      event.revision <= this.connectorMarketRevision
     ) {
       return;
     }
-    this.connectorCatalogRevision = event.revision;
+    this.connectorMarketRevision = event.revision;
+    this.notifyConnectorCatalogInvalidated(event.connectorKey, event.revision);
+  }
+
+  private notifyConnectorCatalogInvalidated(
+    connectorKey?: string,
+    requestedRevision?: number
+  ): void {
+    const revision = Math.max(
+      this.connectorCatalogEventRevision + 1,
+      requestedRevision ?? 0
+    );
+    this.connectorCatalogEventRevision = revision;
     for (const host of this.hosts()) {
       host.engine.dispatch({ type: "composerOptions/invalidated" });
     }
     for (const listener of this.connectorCatalogListeners) {
       listener({
-        ...(event.connectorKey ? { connectorKey: event.connectorKey } : {}),
-        revision: event.revision
+        ...(connectorKey ? { connectorKey } : {}),
+        revision
       });
     }
+  }
+
+  private handleDesktopPreferencesUpdated(
+    featureFlags: Readonly<Record<string, boolean>>
+  ): void {
+    if (this.disposed) return;
+    const connectorsVisible = isFeatureEnabled(
+      featureFlags,
+      LAB_CONNECTORS_FLAG
+    );
+    if (connectorsVisible === this.connectorsVisible) return;
+    this.connectorsVisible = connectorsVisible;
+    this.notifyConnectorCatalogInvalidated();
   }
 }

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -88,7 +88,8 @@ import {
   LAB_CONVERSATION_ACTIVITY_VIEW_FLAG,
   isFeatureEnabled,
   LAB_AGENT_SESSION_FORK_FLAG,
-  LAB_CODEX_SAVER_MODE_FLAG
+  LAB_CODEX_SAVER_MODE_FLAG,
+  LAB_CONNECTORS_FLAG
 } from "../../../../../shared/featureFlags/catalog.ts";
 
 const AgentSessionReplayNodeReadiness = lazy(() =>
@@ -536,8 +537,11 @@ function DesktopAgentGUISurfaceImpl({
       : (prefillPromptRequest?.sequence ?? null));
   const capabilityMenuState = useMemo<
     AgentGUIProps["hostCapabilities"]["capabilityMenuState"]
-  >(
-    () => ({
+  >(() => {
+    const featureFlags =
+      desktopPreferencesState.changingFeatureFlags ??
+      desktopPreferencesState.featureFlags;
+    return {
       browserUse: {
         connectionMode: desktopPreferencesState.browserUseConnectionMode
       },
@@ -545,12 +549,19 @@ function DesktopAgentGUISurfaceImpl({
         authorization: resolveComputerUseAuthorizationState(computerUseStatus),
         installed: computerUseStatus?.installed ?? null
       },
+      connectors: {
+        enabled: isFeatureEnabled(featureFlags, LAB_CONNECTORS_FLAG)
+      },
       tuttiMode: {
         enabled: true
       }
-    }),
-    [computerUseStatus, desktopPreferencesState.browserUseConnectionMode]
-  );
+    };
+  }, [
+    computerUseStatus,
+    desktopPreferencesState.browserUseConnectionMode,
+    desktopPreferencesState.changingFeatureFlags,
+    desktopPreferencesState.featureFlags
+  ]);
   const handleAgentEnvPanelOpen = useCallback<
     NonNullable<AgentGUIProps["hostActions"]["onAgentEnvPanelOpen"]>
   >((input) => agentEnvService.open(input), [agentEnvService]);

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceSettingsService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceSettingsService.test.ts
@@ -10,6 +10,7 @@ import {
   AGENT_EXTENSION_ACTIVATION_FLAGS,
   AGENT_EXTENSION_GEMINI_FLAG,
   AGENT_QUICK_PROMPT_LIBRARY_FLAG,
+  LAB_CONNECTORS_FLAG,
   LAB_ENABLED_FLAG,
   MOBILE_REMOTE_ACCESS_SETTINGS_FLAG
 } from "../../../../../../shared/featureFlags/catalog.ts";
@@ -1342,16 +1343,29 @@ test("WorkspaceSettingsService Agents deep-link works without a provider (blank 
   assert.equal(service.store.agentFocusProvider, null);
 });
 
-test("WorkspaceSettingsService deep-links to the connector market panel", () => {
-  const service = new WorkspaceSettingsService({
-    client: createWorkspaceSettingsClient({})
-  });
+test("WorkspaceSettingsService gates the Connectors deep-link with its Lab flag", () => {
+  const disabled = new WorkspaceSettingsService(
+    { client: createWorkspaceSettingsClient({}) },
+    createDesktopPreferencesService({
+      state: createPreferencesState({ featureFlags: {} })
+    })
+  );
+  disabled.openPanel({ id: "workspace-1" }, { pane: "connectors" });
+  assert.equal(disabled.store.activeSection, "agent");
+  assert.equal(disabled.store.agentTab, "general");
 
-  service.openPanel({ id: "workspace-1" }, { pane: "connectors" });
-
-  assert.equal(service.store.open, true);
-  assert.equal(service.store.activeSection, "agent");
-  assert.equal(service.store.agentTab, "connectors");
+  const enabled = new WorkspaceSettingsService(
+    { client: createWorkspaceSettingsClient({}) },
+    createDesktopPreferencesService({
+      state: createPreferencesState({
+        featureFlags: { [LAB_CONNECTORS_FLAG]: true }
+      })
+    })
+  );
+  enabled.openPanel({ id: "workspace-1" }, { pane: "connectors" });
+  assert.equal(enabled.store.open, true);
+  assert.equal(enabled.store.activeSection, "agent");
+  assert.equal(enabled.store.agentTab, "connectors");
 });
 
 test("WorkspaceSettingsService deep-links to Custom Agents and Automation", () => {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceSettingsService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceSettingsService.ts
@@ -30,6 +30,8 @@ import {
   desktopWorkbenchWindowSnappingEqual
 } from "../../../../../../shared/preferences/index.ts";
 import {
+  isFeatureEnabled,
+  LAB_CONNECTORS_FLAG,
   resolveDesktopWorkspaceUiMode,
   withDesktopWorkspaceUiMode
 } from "../../../../../../shared/featureFlags/catalog.ts";
@@ -187,7 +189,12 @@ export class WorkspaceSettingsService implements IWorkspaceSettingsService {
       this.store.agentFocusRequestID += 1;
     } else if (options?.pane === "connectors") {
       this.store.activeSection = "agent";
-      this.store.agentTab = "connectors";
+      const flags =
+        this.desktopPreferences.store.changingFeatureFlags ??
+        this.desktopPreferences.store.featureFlags;
+      this.store.agentTab = isFeatureEnabled(flags, LAB_CONNECTORS_FLAG)
+        ? "connectors"
+        : "general";
     } else if (
       options?.pane === "custom-agents" ||
       options?.pane === "workspace-agents"

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
@@ -70,6 +70,11 @@ import { createAgentGuiWorkbenchInstanceId } from "@tutti-os/agent-gui/workbench
 import { DesktopAgentGUISurface } from "@renderer/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx";
 import type { DesktopAgentGUISurfaceContext } from "@renderer/features/workspace-agent/ui/desktopAgentGUIWorkbenchModel.ts";
 import { useTranslation } from "@renderer/i18n";
+import { useDesktopPreferencesService } from "@renderer/features/desktop-preferences/ui/useDesktopPreferencesService";
+import {
+  isFeatureEnabled,
+  LAB_CONNECTORS_FLAG
+} from "../../../../../shared/featureFlags/catalog.ts";
 import { AppUpdateStatus } from "@renderer/features/app-update";
 import { StandaloneAgentToolSidebar } from "./StandaloneAgentToolSidebar";
 import type { StandaloneAgentFileOpenRequest } from "./StandaloneAgentToolSidebar";
@@ -178,6 +183,7 @@ export function StandaloneAgentWindow({
   );
   const workspaceFileManagerService = useService(IWorkspaceFileManagerService);
   const { service: workspaceSettingsService } = useWorkspaceSettingsService();
+  const { state: desktopPreferencesState } = useDesktopPreferencesService();
   const connectorMarketModule = useService(IConnectorMarketModule);
   const workspaceId = workspace.id;
   const mentionService = useMemo(
@@ -678,6 +684,12 @@ export function StandaloneAgentWindow({
   const handleCapabilitySettingsRequest = useCallback(
     (target: WorkspaceWorkbenchCapabilitySettingsTarget) => {
       if (typeof target !== "string") {
+        const featureFlags =
+          desktopPreferencesState.changingFeatureFlags ??
+          desktopPreferencesState.featureFlags;
+        if (!isFeatureEnabled(featureFlags, LAB_CONNECTORS_FLAG)) {
+          return;
+        }
         if (target.action === "open") {
           void openConnectorDialogFromComposer(
             connectorMarketModule.root,
@@ -700,7 +712,13 @@ export function StandaloneAgentWindow({
         }
       );
     },
-    [connectorMarketModule, workspaceId, workspaceSettingsService]
+    [
+      connectorMarketModule,
+      desktopPreferencesState.changingFeatureFlags,
+      desktopPreferencesState.featureFlags,
+      workspaceId,
+      workspaceSettingsService
+    ]
   );
   const handleDuplicateStandaloneWindow = useCallback(() => {
     void hostWindowApi.openAgentWindow({

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceLabFeatureGateRows.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceLabFeatureGateRows.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "@renderer/i18n";
 import {
   EARLY_ACCESS_AGENT_INTEGRATIONS_FLAG,
   LAB_AUTOMATION_RULES_FLAG,
+  LAB_CONNECTORS_FLAG,
   LAB_CONVERSATION_ACTIVITY_VIEW_FLAG,
   LAB_WORKBENCH_SHORTCUTS_FLAG,
   isFeatureEnabled
@@ -20,6 +21,11 @@ const featureGateRows = [
     labelKey: "workspace.settings.lab.workbenchShortcutsLabel" as const,
     descriptionKey:
       "workspace.settings.lab.workbenchShortcutsDescription" as const
+  },
+  {
+    key: LAB_CONNECTORS_FLAG,
+    labelKey: "workspace.settings.lab.connectorsLabel" as const,
+    descriptionKey: "workspace.settings.lab.connectorsDescription" as const
   },
   {
     key: LAB_CONVERSATION_ACTIVITY_VIEW_FLAG,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.test.ts
@@ -28,7 +28,7 @@ test("workspace settings gives Model an independent Plan-only section", () => {
   assert.doesNotMatch(panelSource, /WorkspaceAgentModelBindingSection/);
 });
 
-test("workspace settings places signed-in Connectors between Agent Runtime and Custom Agents", () => {
+test("workspace settings places enabled signed-in Connectors between Agent Runtime and Custom Agents", () => {
   const general = panelSource.indexOf('value: "general" as const');
   const runtimes = panelSource.indexOf('value: "agents" as const');
   const connectors = panelSource.indexOf('value: "connectors" as const');
@@ -58,11 +58,15 @@ test("workspace settings places signed-in Connectors between Agent Runtime and C
   );
   assert.match(
     panelSource,
-    /accountState\.user[\s\S]{0,220}value: "connectors" as const/
+    /connectorsVisible[\s\S]{0,220}value: "connectors" as const/
   );
   assert.match(
     panelSource,
-    /!accountState\.user[\s\S]{0,120}agentTab === "connectors"[\s\S]{0,120}selectAgentTab\("general"\)/
+    /!connectorsVisible[\s\S]{0,120}agentTab === "connectors"[\s\S]{0,120}selectAgentTab\("general"\)/
+  );
+  assert.match(
+    panelSource,
+    /accountState\.user !== null[\s\S]{0,120}LAB_CONNECTORS_FLAG/
   );
   assert.doesNotMatch(runtimeTabSource, /WorkspaceAgentsSection/);
 });

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
@@ -93,6 +93,7 @@ import {
   EARLY_ACCESS_AGENT_INTEGRATIONS_FLAG,
   isFeatureEnabled,
   LAB_ENABLED_FLAG,
+  LAB_CONNECTORS_FLAG,
   LAB_WORKBENCH_SHORTCUTS_FLAG,
   LAB_AUTOMATION_RULES_FLAG,
   MOBILE_REMOTE_ACCESS_SETTINGS_FLAG,
@@ -208,6 +209,9 @@ export function WorkspaceSettingsPanel({
   const agentProviderStatusService = useService(IAgentProviderStatusService);
   const agentEnvService = useService(IAgentEnvService);
   const connectorMarketModule = useService(IConnectorMarketModule);
+  const connectorsVisible =
+    accountState.user !== null &&
+    isFeatureEnabled(pendingFeatureFlags, LAB_CONNECTORS_FLAG);
   const automationRulesEnabled = isFeatureEnabled(
     pendingFeatureFlags,
     LAB_AUTOMATION_RULES_FLAG
@@ -249,10 +253,10 @@ export function WorkspaceSettingsPanel({
   }, [automationRulesEnabled, settingsService, settingsState.agentTab]);
 
   useEffect(() => {
-    if (!accountState.user && settingsState.agentTab === "connectors") {
+    if (!connectorsVisible && settingsState.agentTab === "connectors") {
       settingsService.selectAgentTab("general");
     }
-  }, [accountState.user, settingsService, settingsState.agentTab]);
+  }, [connectorsVisible, settingsService, settingsState.agentTab]);
 
   const handleVersionTap = () => {
     if (settingsState.developerPanelVisible) {
@@ -436,7 +440,7 @@ export function WorkspaceSettingsPanel({
                       value: "agents" as const,
                       label: t("workspace.settings.agent.tabs.agents")
                     },
-                    ...(accountState.user
+                    ...(connectorsVisible
                       ? [
                           {
                             value: "connectors" as const,
@@ -510,7 +514,7 @@ export function WorkspaceSettingsPanel({
                     }
                   />
                 ) : settingsState.agentTab === "connectors" &&
-                  accountState.user ? (
+                  connectorsVisible ? (
                   <ConnectorMarketPanel
                     i18n={connectorMarketI18n}
                     onError={handleConnectorMarketError}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceWorkbenchShellRuntime.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceWorkbenchShellRuntime.tsx
@@ -37,6 +37,10 @@ import { useWorkspaceFileManagerService } from "@renderer/features/workspace-fil
 import { IWorkspaceFilePreviewSurfaceHost } from "@renderer/features/workspace-file-preview";
 import { useTranslation } from "@renderer/i18n";
 import { createWorkspaceWorkbenchDesktopI18nRuntime } from "@shared/i18n";
+import {
+  isFeatureEnabled,
+  LAB_CONNECTORS_FLAG
+} from "../../../../../shared/featureFlags/catalog.ts";
 import type {
   DesktopDockIconStyle,
   DesktopFeatureFlags,
@@ -180,6 +184,12 @@ export function useWorkspaceWorkbenchShellRuntime({
   const handleCapabilitySettingsRequest = useCallback(
     (target: WorkspaceWorkbenchCapabilitySettingsTarget) => {
       if (typeof target !== "string") {
+        const featureFlags =
+          desktopPreferencesState.changingFeatureFlags ??
+          desktopPreferencesState.featureFlags;
+        if (!isFeatureEnabled(featureFlags, LAB_CONNECTORS_FLAG)) {
+          return;
+        }
         if (target.action === "open") {
           void openConnectorDialogFromComposer(
             connectorMarketModule.root,
@@ -202,7 +212,13 @@ export function useWorkspaceWorkbenchShellRuntime({
         }
       );
     },
-    [connectorMarketModule, state.workspace.id, workspaceSettingsService]
+    [
+      connectorMarketModule,
+      desktopPreferencesState.changingFeatureFlags,
+      desktopPreferencesState.featureFlags,
+      state.workspace.id,
+      workspaceSettingsService
+    ]
   );
   const shellRuntimeControllerRef =
     useRef<WorkspaceWorkbenchShellRuntimeController | null>(null);

--- a/apps/desktop/src/shared/featureFlags/catalog.test.ts
+++ b/apps/desktop/src/shared/featureFlags/catalog.test.ts
@@ -16,6 +16,7 @@ import {
   LAB_ENABLED_FLAG,
   LAB_AGENT_SESSION_FORK_FLAG,
   LAB_AUTOMATION_RULES_FLAG,
+  LAB_CONNECTORS_FLAG,
   LAB_CONVERSATION_ACTIVITY_VIEW_FLAG,
   MOBILE_REMOTE_ACCESS_SETTINGS_FLAG,
   isStableAgentExtensionTarget,
@@ -106,6 +107,7 @@ test("labFeatureDefinitions excludes the master switch", () => {
 test("experimental Agent features require independent Lab opt-ins", () => {
   const flags = [
     LAB_AUTOMATION_RULES_FLAG,
+    LAB_CONNECTORS_FLAG,
     LAB_CONVERSATION_ACTIVITY_VIEW_FLAG
   ];
 

--- a/apps/desktop/src/shared/featureFlags/catalog.ts
+++ b/apps/desktop/src/shared/featureFlags/catalog.ts
@@ -7,6 +7,7 @@ import {
 export const LAB_ENABLED_FLAG = "lab.enabled";
 export const BROWSER_CHROME_COOKIE_IMPORT_FLAG = "browser.chromeCookieImport";
 export const LAB_AUTOMATION_RULES_FLAG = "lab.automationRules";
+export const LAB_CONNECTORS_FLAG = "lab.connectors";
 export const LAB_WORKBENCH_SHORTCUTS_FLAG = "lab.workbenchShortcuts";
 export const LAB_CONVERSATION_ACTIVITY_VIEW_FLAG =
   "lab.conversationActivityView";
@@ -162,6 +163,13 @@ export const FEATURE_FLAG_DEFINITIONS: readonly FeatureFlagDefinition[] = [
     group: "lab",
     labelKey: "workspace.settings.lab.automationRulesLabel",
     descriptionKey: "workspace.settings.lab.automationRulesDescription"
+  },
+  {
+    key: LAB_CONNECTORS_FLAG,
+    default: false,
+    group: "lab",
+    labelKey: "workspace.settings.lab.connectorsLabel",
+    descriptionKey: "workspace.settings.lab.connectorsDescription"
   },
   {
     key: LAB_WORKBENCH_SHORTCUTS_FLAG,

--- a/apps/desktop/src/shared/i18n/locales/en.ts
+++ b/apps/desktop/src/shared/i18n/locales/en.ts
@@ -1299,6 +1299,9 @@ export const en = {
         conversationActivityViewDescription:
           "Shows the Activity View for conversations in the Agent sidebar.",
         conversationActivityViewLabel: "Conversation Activity View",
+        connectorsDescription:
+          "Shows Connectors in Agent settings and the Agent composer.",
+        connectorsLabel: "Connectors",
         clearShortcutLabel: "Clear {{label}}",
         newAgentConversationShortcutLabel: "New Agent conversation",
         newSameTypeWindowShortcutLabel: "New same-type window",

--- a/apps/desktop/src/shared/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/shared/i18n/locales/zh-CN.ts
@@ -1217,6 +1217,8 @@ export const zhCN = {
         conversationActivityViewDescription:
           "在 Agent 侧边栏中显示会话 Activity View",
         conversationActivityViewLabel: "会话 Activity View",
+        connectorsDescription: "在 Agent 设置和输入框中显示连接器",
+        connectorsLabel: "连接器",
         clearShortcutLabel: "清除 {{label}}",
         newAgentConversationShortcutLabel: "新建 Agent 对话",
         newSameTypeWindowShortcutLabel: "新建同类型窗口",

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1583,6 +1583,23 @@ ensuring that only installed and authorized connectors can be invoked. AgentGUI
 does not scan external MCP, plugin, or package-manager configuration and does not
 infer installation from a remote market response.
 
+The device-global `lab.connectors` UI-preference flag controls whether that
+projection is returned. The daemon fails closed when the preference is absent
+or unreadable and removes Provider-reported connector entries as well as local
+ones. Desktop invalidates cached Composer Options when the preference changes,
+publishes the same invalidation through the AgentGUI host event bus, and
+projects the host capability into the palette so stale cached connector rows
+are hidden immediately. Workspace and standalone AgentGUI surfaces therefore
+converge on the next canonical read without exposing stale entries. The flag
+does not uninstall connectors, stop their runtimes, or reject an already
+structured connector prompt.
+
+Desktop also projects the flag through AgentGUI's existing host-owned
+capability-menu state. The primary footer capability slot is mutually
+exclusive: when `lab.connectors` is off it renders Tutti Mode, and when the
+flag is on it renders only the Connectors menu. The same footer serves both the
+home hero and existing-session dock, so the two AgentGUI contexts cannot drift.
+
 ### 5.3 Agent Directory and setup
 
 The host provides a complete, ordered Agent Directory with this load lifecycle:

--- a/docs/conventions/feature-flags.md
+++ b/docs/conventions/feature-flags.md
@@ -18,6 +18,15 @@ means; that logic never belongs to the flag infrastructure.
 A flag can start as UI-preference and gain daemon enforcement later; keep the
 same key when that happens.
 
+`lab.connectors` is a UI-preference flag whose owning surfaces span renderer
+settings and daemon-projected Composer Options. Off removes the Connectors
+settings entry, connector setup deep links, and connector entries from the
+Agent composer, and the AgentGUI footer uses Tutti Mode as that slot's fallback.
+On replaces the fallback with the Connectors control. The flag deliberately
+leaves installed state, active runtimes, and direct capability validation
+unchanged. Renderer projections must also filter cached connector palette rows
+while the daemon-backed Composer Options reread is in flight.
+
 ## Key contract
 
 The daemon registry is the key contract:

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
@@ -456,6 +456,13 @@ export interface AgentComposerCapabilityMenuState {
     authorization?: AgentComposerComputerUseAuthorizationState | null;
     installed?: boolean | null;
   };
+  /**
+   * Host-owned connector visibility override. Missing preserves the existing
+   * catalog behavior for hosts that have not adopted this optional field.
+   */
+  connectors?: {
+    enabled?: boolean | null;
+  };
   tuttiMode?: {
     enabled?: boolean | null;
   };

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerView.tsx
@@ -635,6 +635,15 @@ export function AgentComposerView(input: Props): React.JSX.Element {
             isHeroLayout={isHeroLayout}
             isGoalModeActive={input.isGoalModeActive}
             isPlanModeActive={input.isPlanModeActive}
+            isTuttiModeActive={input.isTuttiModeActive}
+            isTuttiModeUpdating={input.isTuttiModeUpdating}
+            tuttiModeSupported={
+              input.props.capabilityMenuState?.tuttiMode?.enabled === true
+            }
+            connectorsVisible={
+              input.props.capabilityMenuState?.connectors?.enabled !== false
+            }
+            onTuttiModeChange={input.props.onTuttiModeChange}
             onClearPlanMode={input.onClearPlanMode}
             composerActionButton={composerActionButton}
             quickPromptControl={

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerFooter.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerFooter.tsx
@@ -14,7 +14,6 @@ import {
 import { cn } from "../../../app/renderer/lib/utils";
 import atLinedIconUrl from "../../../app/renderer/assets/icons/@-lined.svg";
 import addLinedIconUrl from "../../../app/renderer/assets/icons/add-lined.svg";
-import { openWorkspaceSettingsPanel } from "../../../shared/workspaceSettingsPanel/workspaceSettingsPanelStore";
 import styles from "../AgentGUINode.styles";
 import {
   AgentModelReasoningDropdown,
@@ -33,7 +32,7 @@ import {
   resolveComposerProviderTargetIconUrl
 } from "./AgentComposerChrome";
 import { AgentHandoffMenu } from "./AgentHandoffMenu";
-import { ComposerConnectorsMenu } from "./ComposerConnectorsMenu";
+import { ComposerPrimaryCapabilityControl } from "./ComposerPrimaryCapabilityControl";
 
 interface Props {
   workspaceId: string;
@@ -52,6 +51,11 @@ interface Props {
   isHeroLayout: boolean;
   isGoalModeActive: boolean;
   isPlanModeActive: boolean;
+  isTuttiModeActive: boolean;
+  isTuttiModeUpdating: boolean;
+  tuttiModeSupported: boolean;
+  connectorsVisible: boolean;
+  onTuttiModeChange?: (active: boolean) => void;
   composerActionButton: ReactNode;
   quickPromptControl?: ReactNode;
   footerAccessory?: ReactNode;
@@ -99,6 +103,11 @@ export function ComposerFooter({
   isHeroLayout,
   isGoalModeActive,
   isPlanModeActive,
+  isTuttiModeActive,
+  isTuttiModeUpdating,
+  tuttiModeSupported,
+  connectorsVisible,
+  onTuttiModeChange,
   composerActionButton,
   quickPromptControl,
   footerAccessory,
@@ -202,32 +211,16 @@ export function ComposerFooter({
               </Tooltip>
             </TooltipProvider>
           </div>
-          <ComposerConnectorsMenu
-            connectors={availableSkills ?? []}
-            disabled={
-              composerControlsHardDisabled || !onCapabilitySettingsRequest
-            }
-            labels={{
-              connectors: labels.addContentConnectors,
-              connectorConnected: labels.addContentConnectorConnected,
-              connectorConnect: labels.addContentConnectorConnect,
-              connectorAuthorize: labels.addContentConnectorAuthorize,
-              connectorEmpty: labels.addContentConnectorEmpty,
-              connectorMore: labels.addContentConnectorMore
-            }}
-            onOpenConnector={(connectorKey) =>
-              onCapabilitySettingsRequest?.({
-                kind: "connector",
-                connectorKey,
-                action: "open"
-              })
-            }
-            onOpenConnectors={() =>
-              openWorkspaceSettingsPanel({
-                section: "agent",
-                pane: "connectors"
-              })
-            }
+          <ComposerPrimaryCapabilityControl
+            availableSkills={availableSkills}
+            connectorsVisible={connectorsVisible}
+            disabled={composerControlsHardDisabled}
+            isTuttiModeActive={isTuttiModeActive}
+            isTuttiModeUpdating={isTuttiModeUpdating}
+            labels={labels}
+            onCapabilitySettingsRequest={onCapabilitySettingsRequest}
+            onTuttiModeChange={onTuttiModeChange}
+            tuttiModeSupported={tuttiModeSupported}
           />
           {showHandoffSelect ? (
             <AgentHandoffMenu

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerPrimaryCapabilityControl.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerPrimaryCapabilityControl.spec.tsx
@@ -1,0 +1,64 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentComposerProps } from "./AgentComposer.types";
+import { ComposerPrimaryCapabilityControl } from "./ComposerPrimaryCapabilityControl";
+
+const labels = {
+  addContentConnectors: "Connectors",
+  addContentConnectorConnected: "Connected",
+  addContentConnectorConnect: "Connect",
+  addContentConnectorAuthorize: "Authorize",
+  addContentConnectorEmpty: "No connectors available",
+  addContentConnectorMore: "View more connectors",
+  tuttiModeDescription: "Coordinate work",
+  tuttiModeLabel: "Tutti Mode"
+} as AgentComposerProps["labels"];
+
+describe("ComposerPrimaryCapabilityControl", () => {
+  it("shows Tutti Mode when connectors are disabled", () => {
+    render(
+      <ComposerPrimaryCapabilityControl
+        availableSkills={[]}
+        connectorsVisible={false}
+        disabled={false}
+        isTuttiModeActive={false}
+        isTuttiModeUpdating={false}
+        labels={labels}
+        onCapabilitySettingsRequest={vi.fn()}
+        onTuttiModeChange={vi.fn()}
+        tuttiModeSupported={true}
+      />
+    );
+
+    expect(
+      screen.getByTestId("agent-gui-composer-tutti-mode-toggle")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("agent-gui-composer-connectors-trigger")
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows only connectors when connectors are enabled", () => {
+    render(
+      <ComposerPrimaryCapabilityControl
+        availableSkills={[]}
+        connectorsVisible
+        disabled={false}
+        isTuttiModeActive={false}
+        isTuttiModeUpdating={false}
+        labels={labels}
+        onCapabilitySettingsRequest={vi.fn()}
+        onTuttiModeChange={vi.fn()}
+        tuttiModeSupported={true}
+      />
+    );
+
+    expect(
+      screen.getByTestId("agent-gui-composer-connectors-trigger")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("agent-gui-composer-tutti-mode-toggle")
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerPrimaryCapabilityControl.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerPrimaryCapabilityControl.tsx
@@ -1,0 +1,74 @@
+import { openWorkspaceSettingsPanel } from "../../../shared/workspaceSettingsPanel/workspaceSettingsPanelStore";
+import type { AgentComposerProps } from "./AgentComposer.types";
+import { ComposerConnectorsMenu } from "./ComposerConnectorsMenu";
+import { ComposerTuttiModeChip } from "./ComposerTuttiModeChip";
+
+interface Props {
+  availableSkills: AgentComposerProps["availableSkills"];
+  connectorsVisible: boolean;
+  disabled: boolean;
+  isTuttiModeActive: boolean;
+  isTuttiModeUpdating: boolean;
+  labels: AgentComposerProps["labels"];
+  onCapabilitySettingsRequest: AgentComposerProps["onCapabilitySettingsRequest"];
+  onTuttiModeChange?: (active: boolean) => void;
+  tuttiModeSupported: boolean;
+}
+
+/**
+ * Owns the single primary capability slot between the mention and handoff
+ * controls. Connector visibility is host-owned; when it is off, the slot
+ * falls back to Tutti Mode instead of leaving an empty connector catalog.
+ */
+export function ComposerPrimaryCapabilityControl({
+  availableSkills,
+  connectorsVisible,
+  disabled,
+  isTuttiModeActive,
+  isTuttiModeUpdating,
+  labels,
+  onCapabilitySettingsRequest,
+  onTuttiModeChange,
+  tuttiModeSupported
+}: Props): React.JSX.Element | null {
+  if (!connectorsVisible) {
+    return (
+      <ComposerTuttiModeChip
+        active={isTuttiModeActive}
+        updating={isTuttiModeUpdating}
+        label={labels.tuttiModeLabel}
+        description={labels.tuttiModeDescription}
+        tuttiModeSupported={tuttiModeSupported}
+        onTuttiModeChange={onTuttiModeChange}
+      />
+    );
+  }
+
+  return (
+    <ComposerConnectorsMenu
+      connectors={availableSkills ?? []}
+      disabled={disabled || !onCapabilitySettingsRequest}
+      labels={{
+        connectors: labels.addContentConnectors,
+        connectorConnected: labels.addContentConnectorConnected,
+        connectorConnect: labels.addContentConnectorConnect,
+        connectorAuthorize: labels.addContentConnectorAuthorize,
+        connectorEmpty: labels.addContentConnectorEmpty,
+        connectorMore: labels.addContentConnectorMore
+      }}
+      onOpenConnector={(connectorKey) =>
+        onCapabilitySettingsRequest?.({
+          kind: "connector",
+          connectorKey,
+          action: "open"
+        })
+      }
+      onOpenConnectors={() =>
+        openWorkspaceSettingsPanel({
+          section: "agent",
+          pane: "connectors"
+        })
+      }
+    />
+  );
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerPaletteCatalog.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerPaletteCatalog.spec.tsx
@@ -55,4 +55,55 @@ describe("useComposerPaletteCatalog", () => {
         .map((entry) => entry.label)
     ).toEqual(["github", "review"]);
   });
+
+  it("removes connector entries immediately when the host disables them", () => {
+    const { result } = renderHook(() =>
+      useComposerPaletteCatalog({
+        provider: "codex",
+        isGoalModeActive: false,
+        goalSupported: false,
+        paletteDraftPrompt: "/",
+        availableCommands: [],
+        availableSkills: [
+          {
+            name: "review",
+            trigger: "$review",
+            sourceKind: "project",
+            kind: "skill"
+          },
+          {
+            name: "GitHub",
+            connectorKey: "github",
+            trigger: "/github",
+            sourceKind: "connector",
+            kind: "connector",
+            status: "available"
+          }
+        ],
+        hasCompactableContext: false,
+        compactSupported: false,
+        composerSettings: {
+          supportsPlanMode: false,
+          supportsBrowser: false,
+          supportsComputerUse: false,
+          slashCommandPolicy: {
+            fallbackCommands: [],
+            commandEffects: [],
+            commandCatalogAuthoritative: true
+          }
+        } as unknown as AgentGUIComposerSettingsVM,
+        capabilityMenuState: { connectors: { enabled: false } },
+        capabilityControlsReadOnly: false,
+        labels: {} as AgentComposerProps["labels"],
+        uiLanguage: "en",
+        editorHandleRef: { current: null }
+      })
+    );
+
+    expect(
+      result.current.slashPaletteEntries
+        .filter((entry) => entry.type === "skill")
+        .map((entry) => entry.label)
+    ).toEqual(["review"]);
+  });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerPaletteCatalog.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerPaletteCatalog.ts
@@ -83,6 +83,16 @@ export function useComposerPaletteCatalog({
     editorHandleRef.current?.getPromptTextBeforeSelection() ?? "";
   const skillQueryDraft = promptBeforeSelection || paletteDraftPrompt;
   const skillQueryMatch = getAgentComposerTriggerQueryMatch(skillQueryDraft);
+  const presentationSkills = useMemo(
+    () =>
+      capabilityMenuState?.connectors?.enabled === false
+        ? availableSkills.filter(
+            (skill) =>
+              skill.sourceKind !== "connector" && skill.kind !== "connector"
+          )
+        : availableSkills,
+    [availableSkills, capabilityMenuState?.connectors?.enabled]
+  );
   const resolvedSlashCommands = useMemo(
     () =>
       resolveSlashCommandsForProvider({
@@ -124,11 +134,11 @@ export function useComposerPaletteCatalog({
       skillQueryMatch === null
         ? []
         : filterProviderSkillsForTrigger({
-            skills: availableSkills,
+            skills: presentationSkills,
             query: skillQueryMatch.query,
             triggerPrefix: skillQueryMatch.prefix
           }),
-    [availableSkills, skillQueryMatch]
+    [presentationSkills, skillQueryMatch]
   );
   const availableCapabilities = useMemo<AgentCapabilityTokenOption[]>(() => {
     if (capabilityControlsReadOnly) {

--- a/services/tuttid/biz/preferences/lab_flags.go
+++ b/services/tuttid/biz/preferences/lab_flags.go
@@ -9,6 +9,7 @@ const (
 	LabFlagAutomationRules  = "lab.automationRules"
 	LabFlagAgentSessionFork = "lab.agentSessionFork"
 	LabFlagCodexSaverMode   = "lab.codexSaverMode"
+	LabFlagConnectors       = "lab.connectors"
 	// Durable key for Early Access agent-integration visibility (Agents directory).
 	LabFlagPreviewAgents = "lab.previewAgents"
 )
@@ -18,6 +19,7 @@ var labFlagDefaults = map[string]bool{
 	LabFlagAutomationRules:  false,
 	LabFlagAgentSessionFork: false,
 	LabFlagCodexSaverMode:   false,
+	LabFlagConnectors:       false,
 	LabFlagPreviewAgents:    false,
 }
 

--- a/services/tuttid/biz/preferences/lab_flags_test.go
+++ b/services/tuttid/biz/preferences/lab_flags_test.go
@@ -7,6 +7,7 @@ func TestLabFlagRegistryKeysAndDefaults(t *testing.T) {
 		LabFlagAutomationRules,
 		LabFlagAgentSessionFork,
 		LabFlagCodexSaverMode,
+		LabFlagConnectors,
 		LabFlagPreviewAgents,
 	}
 	if len(labFlagDefaults) != len(keys) {
@@ -39,6 +40,7 @@ func TestIsLabFlagEnabledFailsClosed(t *testing.T) {
 		LabFlagAutomationRules,
 		LabFlagAgentSessionFork,
 		LabFlagCodexSaverMode,
+		LabFlagConnectors,
 		LabFlagPreviewAgents,
 	} {
 		if IsLabFlagEnabled(nil, key) {

--- a/services/tuttid/service/agent/composer_options.go
+++ b/services/tuttid/service/agent/composer_options.go
@@ -275,7 +275,13 @@ func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsI
 	capabilityErrors := []string(nil)
 	if composerOptionsIncludeCapabilityCatalog(input) {
 		capabilityCatalog, capabilityErrors = s.listComposerCapabilityOptions(ctx, provider, input.Cwd, skills)
-		if s.ConnectorMarketSnapshots != nil {
+		connectorsVisible, err := s.connectorCatalogVisible(ctx)
+		if err != nil {
+			capabilityErrors = append(capabilityErrors, "load connector visibility: "+err.Error())
+		}
+		if !connectorsVisible {
+			capabilityCatalog = replaceComposerConnectorCapabilities(capabilityCatalog, nil)
+		} else if s.ConnectorMarketSnapshots != nil {
 			localConnectors, err := localConnectorCapabilityOptions(ctx, s.ConnectorMarketSnapshots)
 			if err != nil {
 				capabilityErrors = append(capabilityErrors, "load local connectors: "+err.Error())

--- a/services/tuttid/service/agent/local_connector_capabilities.go
+++ b/services/tuttid/service/agent/local_connector_capabilities.go
@@ -6,7 +6,22 @@ import (
 	"strings"
 
 	market "github.com/tutti-os/tutti/packages/connector/host"
+	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
 )
+
+func (s *Service) connectorCatalogVisible(ctx context.Context) (bool, error) {
+	if s == nil || s.DesktopPreferencesReader == nil {
+		return false, nil
+	}
+	preferences, err := s.DesktopPreferencesReader.Get(ctx)
+	if err != nil {
+		return false, err
+	}
+	return preferencesbiz.IsLabFlagEnabled(
+		preferences.FeatureFlags,
+		preferencesbiz.LabFlagConnectors,
+	), nil
+}
 
 func (s *Service) validatePromptConnectors(ctx context.Context, content []PromptContentBlock) error {
 	requested := make(map[string]struct{})

--- a/services/tuttid/service/agent/service_composer_options_test.go
+++ b/services/tuttid/service/agent/service_composer_options_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"slices"
@@ -10,6 +11,7 @@ import (
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
 	market "github.com/tutti-os/tutti/packages/connector/host"
 	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
+	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
 )
 
 func TestServiceGetsComposerOptionsWithoutStartingRuntime(t *testing.T) {
@@ -335,11 +337,12 @@ func TestServiceGetComposerOptionsSkipsCapabilityCatalogWhenDisabled(t *testing.
 	}
 }
 
-func TestServiceGetComposerOptionsIncludesCapabilityCatalogByDefault(t *testing.T) {
+func TestServiceGetComposerOptionsIncludesConnectorCatalogWhenLabFlagEnabled(t *testing.T) {
 	runtime := newFakeRuntime()
 	lister := &recordingComposerCapabilityLister{}
 	service := newIsolatedAgentService(runtime)
 	service.CapabilityLister = lister
+	service.DesktopPreferencesReader = connectorCatalogPreferencesReader(true)
 
 	options, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
 		Provider: "codex",
@@ -355,11 +358,56 @@ func TestServiceGetComposerOptionsIncludesCapabilityCatalogByDefault(t *testing.
 	}
 }
 
+func TestServiceGetComposerOptionsHidesConnectorCatalogByDefault(t *testing.T) {
+	runtime := newFakeRuntime()
+	lister := &recordingComposerCapabilityLister{}
+	service := newIsolatedAgentService(runtime)
+	service.CapabilityLister = lister
+
+	options, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
+		Provider: "codex",
+	})
+	if err != nil {
+		t.Fatalf("GetComposerOptions returned error: %v", err)
+	}
+	if lister.callCount != 1 {
+		t.Fatalf("capability lister calls = %d, want 1", lister.callCount)
+	}
+	if len(options.CapabilityCatalog) != 0 {
+		t.Fatalf("capability catalog = %#v, want connectors hidden", options.CapabilityCatalog)
+	}
+}
+
+func TestServiceGetComposerOptionsHidesConnectorCatalogWhenPreferencesAreUnavailable(t *testing.T) {
+	runtime := newFakeRuntime()
+	lister := &recordingComposerCapabilityLister{}
+	service := newIsolatedAgentService(runtime)
+	service.CapabilityLister = lister
+	service.DesktopPreferencesReader = fakeDesktopPreferencesReader{
+		err: errors.New("preferences unavailable"),
+	}
+
+	options, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
+		Provider: "codex",
+	})
+	if err != nil {
+		t.Fatalf("GetComposerOptions returned error: %v", err)
+	}
+	if len(options.CapabilityCatalog) != 0 {
+		t.Fatalf("capability catalog = %#v, want connectors hidden", options.CapabilityCatalog)
+	}
+	errors, ok := options.RuntimeContext["capabilityCatalogErrors"].([]string)
+	if !ok || len(errors) != 1 || errors[0] != "load connector visibility: preferences unavailable" {
+		t.Fatalf("capability catalog errors = %#v", options.RuntimeContext["capabilityCatalogErrors"])
+	}
+}
+
 func TestServiceGetComposerOptionsUsesLocalInstalledConnectorCatalog(t *testing.T) {
 	runtime := newFakeRuntime()
 	lister := &recordingComposerCapabilityLister{}
 	service := newIsolatedAgentService(runtime)
 	service.CapabilityLister = lister
+	service.DesktopPreferencesReader = connectorCatalogPreferencesReader(true)
 	service.ConnectorMarketSnapshots = connectorMarketSnapshotStub{
 		snapshot: market.Snapshot{Connectors: []market.Connector{
 			localConnectorFixture(
@@ -391,6 +439,7 @@ func TestServiceGetComposerOptionsCachesCapabilityCatalog(t *testing.T) {
 	lister := &recordingComposerCapabilityLister{}
 	service := newIsolatedAgentService(runtime)
 	service.CapabilityLister = lister
+	service.DesktopPreferencesReader = connectorCatalogPreferencesReader(true)
 
 	first, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
 		Provider: "codex",
@@ -410,6 +459,16 @@ func TestServiceGetComposerOptionsCachesCapabilityCatalog(t *testing.T) {
 	}
 	if len(second.CapabilityCatalog) != 1 || second.CapabilityCatalog[0].ID != "connector:github" {
 		t.Fatalf("cached capability catalog = %#v, want unmutated github connector", second.CapabilityCatalog)
+	}
+}
+
+func connectorCatalogPreferencesReader(enabled bool) fakeDesktopPreferencesReader {
+	return fakeDesktopPreferencesReader{
+		preferences: preferencesbiz.DesktopPreferences{
+			FeatureFlags: map[string]bool{
+				preferencesbiz.LabFlagConnectors: enabled,
+			},
+		},
 	}
 }
 

--- a/services/tuttid/service/agent/service_config.go
+++ b/services/tuttid/service/agent/service_config.go
@@ -75,6 +75,7 @@ type ServiceComposerConfig struct {
 	AgentTargetStore              AgentTargetStore
 	WorkspaceAgentResolver        WorkspaceAgentResolver
 	AgentComposerDefaultsReader   AgentComposerDefaultsReader
+	DesktopPreferencesReader      DesktopPreferencesReader
 	CapabilityLister              ComposerCapabilityLister
 	ConnectorMarketSnapshots      market.SnapshotReader
 	ExtensionComposerProfiles     ExtensionComposerProfileResolver
@@ -155,6 +156,7 @@ func (s *Service) applyConfig(config ServiceConfig) {
 	s.ConnectorMarketSnapshots = config.Composer.ConnectorMarketSnapshots
 	s.ExtensionComposerProfiles = config.Composer.ExtensionComposerProfiles
 	s.AgentComposerDefaultsReader = config.Composer.AgentComposerDefaultsReader
+	s.DesktopPreferencesReader = config.Composer.DesktopPreferencesReader
 	s.ProviderAvailabilityCacheTTL = config.Composer.ProviderAvailabilityCacheTTL
 	s.CapabilityCatalogCacheTTL = config.Composer.CapabilityCatalogCacheTTL
 	s.LiveModelCacheTTL = config.Composer.LiveModelCacheTTL

--- a/services/tuttid/service/agent/service_test_runtime_test.go
+++ b/services/tuttid/service/agent/service_test_runtime_test.go
@@ -73,6 +73,15 @@ func (f fakeAgentComposerDefaultsReader) GetAgentComposerDefaultsForTarget(_ con
 	return f[strings.TrimSpace(agentTargetID)], nil
 }
 
+type fakeDesktopPreferencesReader struct {
+	preferences preferencesbiz.DesktopPreferences
+	err         error
+}
+
+func (f fakeDesktopPreferencesReader) Get(context.Context) (preferencesbiz.DesktopPreferences, error) {
+	return f.preferences, f.err
+}
+
 func (f fakeAgentTargetStore) GetAgentTarget(_ context.Context, id string) (agenttargetbiz.Target, error) {
 	if f.err != nil {
 		return agenttargetbiz.Target{}, f.err

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -75,6 +75,7 @@ type Service struct {
 	ConnectorMarketSnapshots       market.SnapshotReader
 	ExtensionComposerProfiles      ExtensionComposerProfileResolver
 	AgentComposerDefaultsReader    AgentComposerDefaultsReader
+	DesktopPreferencesReader       DesktopPreferencesReader
 	ProviderAvailabilityCacheTTL   time.Duration
 	CapabilityCatalogCacheTTL      time.Duration
 	LiveModelCacheTTL              time.Duration
@@ -179,6 +180,10 @@ type AgentTargetStore interface {
 
 type AgentComposerDefaultsReader interface {
 	GetAgentComposerDefaultsForTarget(context.Context, string) (preferencesbiz.AgentComposerDefaults, error)
+}
+
+type DesktopPreferencesReader interface {
+	Get(context.Context) (preferencesbiz.DesktopPreferences, error)
 }
 
 type WorkspaceAgentResolver interface {

--- a/services/tuttid/wiring_daemon_api.go
+++ b/services/tuttid/wiring_daemon_api.go
@@ -381,6 +381,7 @@ func buildDaemonAPI(
 			AgentTargetStore:            agentTargetStore,
 			WorkspaceAgentResolver:      workspaceAgents,
 			AgentComposerDefaultsReader: preferences,
+			DesktopPreferencesReader:    preferences,
 			ExtensionComposerProfiles: agentExtensionComposerProfileResolver{
 				manager: agentExtensionManager,
 			},


### PR DESCRIPTION
## Summary

- Add a default-off `lab.connectors` flag, mirrored in desktop and daemon, because connector entry points are still experimental.
- Gate connector settings, deep links, daemon composer projections, and AgentGUI surfaces with the same flag.
- Make the AgentGUI primary capability slot mutually exclusive: show Tutti Mode when connectors are disabled, otherwise show Connectors only.
- Invalidate and immediately filter cached AgentGUI connector catalog entries when Lab visibility changes, preventing stale connector rows from remaining in the slash palette.

## Verification

- `pnpm check:changed -- --push-ready` — passed 21 lanes.
- `pnpm --filter @tutti-os/agent-gui exec vitest run agent-gui/agentGuiNode/composer/ComposerPrimaryCapabilityControl.spec.tsx agent-gui/agentGuiNode/composer/useComposerPaletteCatalog.spec.tsx`
- `pnpm --filter @tutti-os/desktop exec vitest run src/renderer/src/features/workspace-agent/services/internal/workspaceAgentComposerOptionsInvalidationCoordinator.test.ts`
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `go test ./biz/preferences ./service/agent`
- Manual Tutti Dev verification with `lab.connectors=false`: AgentGUI footer shows Tutti Mode, connector footer control and slash-palette connector rows are hidden, and daemon composer options contain no connector skills/capabilities.

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter. (Not applicable: no lifecycle semantics changed.)
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. (Not applicable: no README/CONTRIBUTING changes.)
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
