### PR TITLE
fix(agent): classify canonical message visibility

### DIFF
--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -58,12 +58,13 @@ Daemon packages retain compatibility aliases, while runtime mechanics remain
 daemon-owned.
 
 New canonical messages always carry an explicit
-`userVisibleAssistantResponse` classification. Provider adapters classify the
-message before the runtime reporter writes it: user-facing assistant text and
-plans are `true`; user input, reasoning, tool calls, and system notices are
-`false`. Replication and read contracts continue to accept a missing value from
-older stored messages, so compatibility stays at the read boundary instead of
-being inferred by presentation code.
+`userVisibleAssistantResponse` classification. Runtime message producers
+classify the message before reporter and local-store projections write it:
+user-facing assistant text, plans, and visible failures are `true`; user input,
+reasoning, tool calls, and system notices are `false`. Every projection preserves
+that classification. Replication and read contracts continue to accept a
+missing value from older stored messages, so compatibility stays at the read
+boundary instead of being inferred by presentation code.
 
 ## Responsibilities
 

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -57,6 +57,14 @@ capability, and plan-decision vocabulary needed by canonical persistence.
 Daemon packages retain compatibility aliases, while runtime mechanics remain
 daemon-owned.
 
+New canonical messages always carry an explicit
+`userVisibleAssistantResponse` classification. Provider adapters classify the
+message before the runtime reporter writes it: user-facing assistant text and
+plans are `true`; user input, reasoning, tool calls, and system notices are
+`false`. Replication and read contracts continue to accept a missing value from
+older stored messages, so compatibility stays at the read boundary instead of
+being inferred by presentation code.
+
 ## Responsibilities
 
 ### `packages/agent/host`

--- a/packages/agent/daemon/activity/events/activity_types.go
+++ b/packages/agent/daemon/activity/events/activity_types.go
@@ -166,6 +166,12 @@ type InteractionTransition struct {
 	Metadata  map[string]any
 }
 
+type MessageSemantics struct {
+	// UserVisibleAssistantResponse is a producer-owned classification. It is
+	// true only when this message may represent a user-facing assistant reply.
+	UserVisibleAssistantResponse bool
+}
+
 type EventPayload struct {
 	PresenceStatus          string
 	LifecycleStatus         string
@@ -179,6 +185,7 @@ type EventPayload struct {
 	CWD                     string
 	Role                    MessageRole
 	Content                 string
+	Semantics               MessageSemantics
 	CallID                  string
 	CallType                string
 	Name                    string
@@ -437,17 +444,19 @@ func cloneMap(value map[string]any) map[string]any {
 	return cloned
 }
 
-func NewMessageAppended(ctx EventContext, role MessageRole, content string) Event {
+func NewMessageAppended(ctx EventContext, role MessageRole, content string, userVisibleAssistantResponse bool) Event {
 	return eventFromContext(ctx, EventMessageAppended, EventPayload{
-		Role:    role,
-		Content: content,
+		Role:      role,
+		Content:   content,
+		Semantics: MessageSemantics{UserVisibleAssistantResponse: userVisibleAssistantResponse},
 	})
 }
 
-func NewContextMessage(ctx EventContext, role MessageRole, content string) Event {
+func NewContextMessage(ctx EventContext, role MessageRole, content string, userVisibleAssistantResponse bool) Event {
 	return eventFromContext(ctx, EventMessageCreated, EventPayload{
-		Role:    role,
-		Content: content,
+		Role:      role,
+		Content:   content,
+		Semantics: MessageSemantics{UserVisibleAssistantResponse: userVisibleAssistantResponse},
 	})
 }
 

--- a/packages/agent/daemon/activity/events/activity_types_test.go
+++ b/packages/agent/daemon/activity/events/activity_types_test.go
@@ -143,7 +143,7 @@ func TestMessageEventRequiresStableEventIDAndRole(t *testing.T) {
 		Provider:          ProviderClaudeCode,
 		ProviderSessionID: "claude-session",
 		OccurredAtUnixMS:  1710000000456,
-	}, MessageRoleAssistant, "done")
+	}, MessageRoleAssistant, "done", true)
 
 	if event.EventID != "event-1" {
 		t.Fatalf("event id = %q", event.EventID)
@@ -156,6 +156,9 @@ func TestMessageEventRequiresStableEventIDAndRole(t *testing.T) {
 	}
 	if event.Payload.Content != "done" {
 		t.Fatalf("content = %q", event.Payload.Content)
+	}
+	if !event.Payload.Semantics.UserVisibleAssistantResponse {
+		t.Fatal("user-visible assistant response classification was not preserved")
 	}
 }
 
@@ -172,11 +175,11 @@ func TestContextEventBuildersCreateMessagesAndCompactCalls(t *testing.T) {
 		OccurredAtUnixMS:  1710000000123,
 	}
 
-	message := NewContextMessage(ctx, MessageRoleAssistant, "done")
+	message := NewContextMessage(ctx, MessageRoleAssistant, "done", true)
 	if message.Type != EventMessageCreated || message.EventID != "event-1" {
 		t.Fatalf("message event = %#v", message)
 	}
-	if message.Payload.Role != MessageRoleAssistant || message.Payload.Content != "done" || message.Payload.TurnID != "turn-1" {
+	if message.Payload.Role != MessageRoleAssistant || message.Payload.Content != "done" || message.Payload.TurnID != "turn-1" || !message.Payload.Semantics.UserVisibleAssistantResponse {
 		t.Fatalf("message payload = %#v", message.Payload)
 	}
 

--- a/packages/agent/daemon/activity/service_helpers.go
+++ b/packages/agent/daemon/activity/service_helpers.go
@@ -233,6 +233,7 @@ func cloneSessionMessages(items []WorkspaceAgentSessionMessage) []WorkspaceAgent
 }
 
 func cloneSessionMessage(item WorkspaceAgentSessionMessage) WorkspaceAgentSessionMessage {
+	item.Semantics = cloneMessageSemantics(item.Semantics)
 	item.Payload = clonePayloadMap(item.Payload)
 	return item
 }
@@ -253,6 +254,7 @@ func sessionMessageFromLegacyUpdate(
 		Role:              strings.TrimSpace(update.Role),
 		Kind:              strings.TrimSpace(update.Kind),
 		Status:            strings.TrimSpace(update.Status),
+		Semantics:         cloneMessageSemantics(update.Semantics),
 		Payload:           payload,
 		OccurredAtUnixMS:  firstNonZeroInt64(update.OccurredAtUnixMS, update.StartedAtUnixMS, update.CompletedAtUnixMS),
 		StartedAtUnixMS:   update.StartedAtUnixMS,
@@ -286,6 +288,7 @@ func messageUpdateFromSessionMessage(
 		Role:              strings.TrimSpace(message.Role),
 		Kind:              strings.TrimSpace(message.Kind),
 		Status:            strings.TrimSpace(message.Status),
+		Semantics:         cloneMessageSemantics(message.Semantics),
 		CallID:            payloadFirstStringValue(payload, "callId", "call_id"),
 		ParentCallID:      payloadFirstStringValue(payload, "parentCallId", "parent_call_id"),
 		RootCallID:        payloadFirstStringValue(payload, "rootCallId", "root_call_id"),
@@ -322,6 +325,9 @@ func mergeSessionMessage(
 	}
 	if merged.Status == "" {
 		merged.Status = existing.Status
+	}
+	if merged.Semantics == nil {
+		merged.Semantics = cloneMessageSemantics(existing.Semantics)
 	}
 	if merged.Payload == nil {
 		merged.Payload = clonePayloadMap(existing.Payload)

--- a/packages/agent/daemon/activity/service_projection.go
+++ b/packages/agent/daemon/activity/service_projection.go
@@ -139,12 +139,15 @@ func sessionMessageUpdateFromActivityEvent(
 			payload["text"] = event.Payload.Content
 		}
 		return WorkspaceAgentMessageUpdate{
-			AgentSessionID:   sessionID,
-			MessageID:        messageID,
-			TurnID:           strings.TrimSpace(event.Payload.TurnID),
-			Role:             role,
-			Kind:             kind,
-			Status:           firstNonEmptyString(payloadFirstStringValue(event.Payload.Metadata, "streamState"), event.Payload.Status),
+			AgentSessionID: sessionID,
+			MessageID:      messageID,
+			TurnID:         strings.TrimSpace(event.Payload.TurnID),
+			Role:           role,
+			Kind:           kind,
+			Status:         firstNonEmptyString(payloadFirstStringValue(event.Payload.Metadata, "streamState"), event.Payload.Status),
+			Semantics: &WorkspaceAgentMessageSemantics{
+				UserVisibleAssistantResponse: event.Payload.Semantics.UserVisibleAssistantResponse,
+			},
 			Payload:          payload,
 			OccurredAtUnixMS: timestamp,
 		}, true
@@ -183,6 +186,7 @@ func sessionMessageUpdateFromActivityEvent(
 			Role:             string(activityshared.MessageRoleAssistant),
 			Kind:             "tool_call",
 			Status:           status,
+			Semantics:        &WorkspaceAgentMessageSemantics{UserVisibleAssistantResponse: false},
 			CallID:           callID,
 			Title:            strings.TrimSpace(event.Payload.Name),
 			Payload:          payload,

--- a/packages/agent/daemon/activity/service_test.go
+++ b/packages/agent/daemon/activity/service_test.go
@@ -442,9 +442,10 @@ func TestStoreSnapshotCarriesTurnStateAndMessagesFromActivityEvents(t *testing.T
 		AgentSessionID:    "agent-1",
 		OccurredAtUnixMS:  1002,
 		Payload: activityshared.EventPayload{
-			TurnID:  "turn-1",
-			Role:    activityshared.MessageRoleAssistant,
-			Content: "working",
+			TurnID:    "turn-1",
+			Role:      activityshared.MessageRoleAssistant,
+			Content:   "working",
+			Semantics: activityshared.MessageSemantics{UserVisibleAssistantResponse: true},
 			Metadata: map[string]any{
 				"messageId": "assistant:turn-1:1",
 			},
@@ -462,6 +463,35 @@ func TestStoreSnapshotCarriesTurnStateAndMessagesFromActivityEvents(t *testing.T
 	messages := snapshot.SessionMessagesByID["agent-1"]
 	if len(messages) != 1 || messages[0].MessageID != "assistant:turn-1:1" || messages[0].Version != 1 {
 		t.Fatalf("snapshot messages = %#v, want one versioned message", snapshot.SessionMessagesByID)
+	}
+	if messages[0].Semantics == nil || !messages[0].Semantics.UserVisibleAssistantResponse {
+		t.Fatalf("snapshot message semantics = %#v, want explicit visible assistant response", messages[0].Semantics)
+	}
+}
+
+func TestSessionMessageUpdateFromActivityEventCarriesExplicitSemantics(t *testing.T) {
+	t.Parallel()
+
+	ctx := activityshared.EventContext{
+		EventID:        "event-1",
+		AgentSessionID: "agent-1",
+		TurnID:         "turn-1",
+	}
+	message := activityshared.NewMessageAppended(
+		ctx,
+		activityshared.MessageRoleAssistant,
+		"done",
+		true,
+	)
+	messageUpdate, ok := sessionMessageUpdateFromActivityEvent("agent-1", message, 1_000)
+	if !ok || messageUpdate.Semantics == nil || !messageUpdate.Semantics.UserVisibleAssistantResponse {
+		t.Fatalf("message update = %#v, want explicit visible assistant response", messageUpdate)
+	}
+
+	call := activityshared.NewCallStarted(ctx, "call-1", "tool", "Read", map[string]any{"path": "README.md"})
+	callUpdate, ok := sessionMessageUpdateFromActivityEvent("agent-1", call, 1_001)
+	if !ok || callUpdate.Semantics == nil || callUpdate.Semantics.UserVisibleAssistantResponse {
+		t.Fatalf("call update = %#v, want explicit non-visible assistant response", callUpdate)
 	}
 }
 
@@ -1267,6 +1297,7 @@ func TestStoreStoresMessageUpdatesForLocalReads(t *testing.T) {
 		Role:             "assistant",
 		Kind:             "text",
 		Status:           "streaming",
+		Semantics:        &WorkspaceAgentMessageSemantics{UserVisibleAssistantResponse: true},
 		Payload:          map[string]any{"text": "working"},
 		OccurredAtUnixMS: 1710000000002,
 	}, {
@@ -1304,6 +1335,9 @@ func TestStoreStoresMessageUpdatesForLocalReads(t *testing.T) {
 	}
 	if messages.Messages[1].Payload["text"] != "done" || messages.Messages[1].CompletedAtUnixMS != 1710000000003 {
 		t.Fatalf("merged message = %#v", messages.Messages[1])
+	}
+	if messages.Messages[1].Semantics == nil || !messages.Messages[1].Semantics.UserVisibleAssistantResponse {
+		t.Fatalf("merged message semantics = %#v, want original explicit visibility preserved", messages.Messages[1].Semantics)
 	}
 	messages.Messages[1].Payload["text"] = "mutated"
 

--- a/packages/agent/daemon/runtime/activity_projection_test.go
+++ b/packages/agent/daemon/runtime/activity_projection_test.go
@@ -1000,6 +1000,9 @@ func TestProjectActivityEventsToStreamEventsAddsVisibleTurnFailureMessage(t *tes
 	if item.Kind != "text" || item.Status != messageStreamStateFailed {
 		t.Fatalf("visible failure item = %#v", item)
 	}
+	if item.Semantics == nil || !item.Semantics.UserVisibleAssistantResponse {
+		t.Fatalf("visible failure semantics = %#v, want explicit user-visible assistant response", item.Semantics)
+	}
 	if item.Payload["kind"] != visibleErrorKind ||
 		item.Payload["phase"] != "turn" ||
 		item.Payload["code"] != "quota_or_rate_limit" ||

--- a/packages/agent/daemon/runtime/interactive_projection.go
+++ b/packages/agent/daemon/runtime/interactive_projection.go
@@ -610,7 +610,12 @@ func newTurnActivityEventWithIDAt(
 		if status == "" && messageRole == activityshared.MessageRoleUser {
 			status = messageStreamStateCompleted
 		}
-		event := activityshared.NewMessageAppended(ctx, messageRole, content)
+		event := activityshared.NewMessageAppended(
+			ctx,
+			messageRole,
+			content,
+			messageRole == activityshared.MessageRoleAssistant && payloadString(payload, "kind") != "agent_system_notice",
+		)
 		event.Payload.Metadata = clonePayload(payload)
 		if event.Payload.Metadata == nil {
 			event.Payload.Metadata = map[string]any{}

--- a/packages/agent/daemon/runtime/provider_input_unit_observations_test.go
+++ b/packages/agent/daemon/runtime/provider_input_unit_observations_test.go
@@ -128,6 +128,7 @@ func TestCompletedPlanMessageProjectsProviderNeutralObservation(t *testing.T) {
 		},
 		activityshared.MessageRoleAssistant,
 		"# Plan",
+		true,
 	)
 	event.Payload.Metadata = map[string]any{
 		"messageId": "plan-message-1", "messageKind": "plan",
@@ -208,6 +209,7 @@ func TestCompactionAndAttachmentProjectProviderNeutralObservations(
 				},
 				activityshared.MessageRoleUser,
 				"look",
+				false,
 			)
 			event.Payload.Metadata = test.metadata
 			event.ProviderInputUnit = &activityshared.ProviderInputUnitContext{

--- a/packages/agent/daemon/runtime/reporter_message.go
+++ b/packages/agent/daemon/runtime/reporter_message.go
@@ -78,30 +78,21 @@ func textMessageUpdateFromSessionEvent(
 	if messageKind := stringFromPayload(event.Payload.Metadata, "messageKind"); messageKind != "" {
 		update.Payload["messageKind"] = messageKind
 	}
-	update.Semantics = messageSemanticsFromMetadata(event.Payload.Metadata)
+	update.Semantics = messageSemanticsFromEventPayload(event.Payload)
 	forwardSystemNoticeMessageMetadata(update.Payload, event.Payload.Metadata)
 	return update, true
 }
 
-func messageSemanticsFromMetadata(metadata map[string]any) *canonical.WorkspaceAgentMessageSemantics {
-	if len(metadata) == 0 {
-		return nil
-	}
-	semantics := canonical.WorkspaceAgentMessageSemantics{}
-	if value, ok := metadata["userVisibleAssistantResponse"].(bool); ok {
-		semantics.UserVisibleAssistantResponse = value
+func messageSemanticsFromEventPayload(payload activityshared.EventPayload) *canonical.WorkspaceAgentMessageSemantics {
+	metadata := payload.Metadata
+	semantics := canonical.WorkspaceAgentMessageSemantics{
+		UserVisibleAssistantResponse: payload.Semantics.UserVisibleAssistantResponse,
 	}
 	if value, ok := metadata["turnSettling"].(bool); ok {
 		semantics.TurnSettling = value
 	}
 	semantics.NoticeCommand = stringFromPayload(metadata, "noticeCommand")
 	semantics.NoticeCommandStatus = stringFromPayload(metadata, "noticeCommandStatus")
-	if !semantics.UserVisibleAssistantResponse &&
-		!semantics.TurnSettling &&
-		semantics.NoticeCommand == "" &&
-		semantics.NoticeCommandStatus == "" {
-		return nil
-	}
 	return &semantics
 }
 
@@ -236,6 +227,7 @@ func callMessageUpdateFromSessionEvent(
 		Role:             string(activityshared.MessageRoleAssistant),
 		Kind:             "tool_call",
 		Status:           status,
+		Semantics:        &canonical.WorkspaceAgentMessageSemantics{UserVisibleAssistantResponse: false},
 		CallID:           callID,
 		Title:            name,
 		Payload:          payload,

--- a/packages/agent/daemon/runtime/reporter_test.go
+++ b/packages/agent/daemon/runtime/reporter_test.go
@@ -1451,6 +1451,9 @@ func TestReporterProjectsTurnFailureErrorToStatePatch(t *testing.T) {
 	if item.Payload["detail"] != "API Error: 403 Key limit exceeded (total limit)" {
 		t.Fatalf("visible failure detail = %#v", item.Payload["detail"])
 	}
+	if item.Semantics == nil || !item.Semantics.UserVisibleAssistantResponse {
+		t.Fatalf("visible failure semantics = %#v, want explicit user-visible assistant response", item.Semantics)
+	}
 }
 
 func TestReporterDoesNotSendEmptyOrUnreportableBatches(t *testing.T) {

--- a/packages/agent/daemon/runtime/reporter_test.go
+++ b/packages/agent/daemon/runtime/reporter_test.go
@@ -365,6 +365,9 @@ func TestReportActivityInputProjectsRuntimeMessagesToMessageUpdates(t *testing.T
 		user.Payload["clientSubmitId"] != "submit-1" {
 		t.Fatalf("user message update = %#v", user)
 	}
+	if user.Semantics == nil || user.Semantics.UserVisibleAssistantResponse {
+		t.Fatalf("user message semantics = %#v, want explicit userVisibleAssistantResponse=false", user.Semantics)
+	}
 	assistant := report.MessageUpdates[1]
 	if assistant.MessageID != "assistant-event-1" ||
 		assistant.Seq != uint64(assistantEvent.OccurredAtUnixMS) ||
@@ -373,6 +376,9 @@ func TestReportActivityInputProjectsRuntimeMessagesToMessageUpdates(t *testing.T
 		assistant.Payload["content"] != "found README" ||
 		assistant.Payload["source"] != "runtime" {
 		t.Fatalf("assistant message update = %#v", assistant)
+	}
+	if assistant.Semantics == nil || !assistant.Semantics.UserVisibleAssistantResponse {
+		t.Fatalf("assistant message semantics = %#v, want userVisibleAssistantResponse=true", assistant.Semantics)
 	}
 	if _, ok := assistant.Payload["adapterExtra"]; ok {
 		t.Fatalf("assistant message update payload = %#v, want compact UI payload", assistant.Payload)
@@ -385,6 +391,9 @@ func TestReportActivityInputProjectsRuntimeMessagesToMessageUpdates(t *testing.T
 		thinking.Payload["content"] != "checking files" ||
 		thinking.Payload["source"] != "runtime" {
 		t.Fatalf("thinking message update = %#v", thinking)
+	}
+	if thinking.Semantics == nil || thinking.Semantics.UserVisibleAssistantResponse {
+		t.Fatalf("thinking message semantics = %#v, want explicit userVisibleAssistantResponse=false", thinking.Semantics)
 	}
 }
 
@@ -466,6 +475,9 @@ func TestReportActivityInputForwardsMessageKindToPayload(t *testing.T) {
 	if plan.Payload["messageKind"] != "plan" {
 		t.Fatalf("plan message payload = %#v, want messageKind=plan forwarded to the GUI", plan.Payload)
 	}
+	if plan.Semantics == nil || !plan.Semantics.UserVisibleAssistantResponse {
+		t.Fatalf("plan message semantics = %#v, want userVisibleAssistantResponse=true", plan.Semantics)
+	}
 }
 
 func TestReportActivityInputDoesNotProjectLegacySubAgentMarkers(t *testing.T) {
@@ -526,6 +538,9 @@ func TestReportActivityInputForwardsSystemNoticeMetadataToPayload(t *testing.T) 
 		notice.Payload["code"] != "CODEX_VERSION_TOO_OLD" ||
 		notice.Payload["retryable"] != false {
 		t.Fatalf("notice message payload = %#v, want system notice metadata forwarded to the GUI", notice.Payload)
+	}
+	if notice.Semantics == nil || notice.Semantics.UserVisibleAssistantResponse {
+		t.Fatalf("notice message semantics = %#v, want explicit userVisibleAssistantResponse=false", notice.Semantics)
 	}
 }
 
@@ -702,6 +717,9 @@ func TestReportActivityInputPreservesToolInputFromTerminalMetadata(t *testing.T)
 
 	if len(report.MessageUpdates) != 1 {
 		t.Fatalf("message updates = %#v, want one", report.MessageUpdates)
+	}
+	if semantics := report.MessageUpdates[0].Semantics; semantics == nil || semantics.UserVisibleAssistantResponse {
+		t.Fatalf("tool message semantics = %#v, want explicit userVisibleAssistantResponse=false", semantics)
 	}
 	update := report.MessageUpdates[0]
 	input, _ := update.Payload["input"].(map[string]any)

--- a/packages/agent/daemon/runtime/visible_error.go
+++ b/packages/agent/daemon/runtime/visible_error.go
@@ -120,13 +120,16 @@ func visibleFailureMessageUpdate(
 	payload := clonePayload(projection.payload)
 	payload["source"] = "runtime"
 	return agentsessionstore.WorkspaceAgentMessageUpdate{
-		AgentSessionID:   strings.TrimSpace(sessionID),
-		MessageID:        "visible-error:" + projection.eventID,
-		Seq:              uint64(timestamp),
-		TurnID:           turnID,
-		Role:             string(activityshared.MessageRoleAssistant),
-		Kind:             "text",
-		Status:           messageStreamStateFailed,
+		AgentSessionID: strings.TrimSpace(sessionID),
+		MessageID:      "visible-error:" + projection.eventID,
+		Seq:            uint64(timestamp),
+		TurnID:         turnID,
+		Role:           string(activityshared.MessageRoleAssistant),
+		Kind:           "text",
+		Status:         messageStreamStateFailed,
+		Semantics: &canonical.WorkspaceAgentMessageSemantics{
+			UserVisibleAssistantResponse: true,
+		},
 		Payload:          payload,
 		OccurredAtUnixMS: timestamp,
 	}, true

--- a/packages/agent/store-sqlite/canonical/activity_reports.go
+++ b/packages/agent/store-sqlite/canonical/activity_reports.go
@@ -238,7 +238,7 @@ type WorkspaceAgentSessionMessageUpdate struct {
 }
 
 type WorkspaceAgentMessageSemantics struct {
-	UserVisibleAssistantResponse bool   `json:"userVisibleAssistantResponse,omitempty"`
+	UserVisibleAssistantResponse bool   `json:"userVisibleAssistantResponse"`
 	TurnSettling                 bool   `json:"turnSettling,omitempty"`
 	NoticeCommand                string `json:"noticeCommand,omitempty"`
 	NoticeCommandStatus          string `json:"noticeCommandStatus,omitempty"`

--- a/packages/agent/store-sqlite/canonical/activity_reports_test.go
+++ b/packages/agent/store-sqlite/canonical/activity_reports_test.go
@@ -1,0 +1,16 @@
+package canonical
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestWorkspaceAgentMessageSemanticsEncodesExplicitFalseVisibility(t *testing.T) {
+	raw, err := json.Marshal(WorkspaceAgentMessageSemantics{UserVisibleAssistantResponse: false})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if got, want := string(raw), `{"userVisibleAssistantResponse":false}`; got != want {
+		t.Fatalf("semantics JSON = %s, want %s", got, want)
+	}
+}

--- a/packages/agent/store-sqlite/repository.go
+++ b/packages/agent/store-sqlite/repository.go
@@ -695,7 +695,7 @@ type Message struct {
 }
 
 type MessageSemantics struct {
-	UserVisibleAssistantResponse bool   `json:"userVisibleAssistantResponse,omitempty"`
+	UserVisibleAssistantResponse bool   `json:"userVisibleAssistantResponse"`
 	TurnSettling                 bool   `json:"turnSettling,omitempty"`
 	NoticeCommand                string `json:"noticeCommand,omitempty"`
 	NoticeCommandStatus          string `json:"noticeCommandStatus,omitempty"`


### PR DESCRIPTION
## Summary

- require runtime message producers to classify user-visible assistant responses explicitly
- persist both `true` and `false` through reporter, stream, local-store, and legacy-read projections
- classify visible failures explicitly and preserve existing semantics across partial message updates
- keep legacy read and replication contracts permissive when older messages omit the field

## Tests

- focused daemon activity/runtime regression tests covering explicit message, tool, visible-failure, local-store, and legacy-read semantics
- `pnpm check:changed -- --failed-only` (11 lanes passed; 7 run, 4 reused)

## Notes

- user-facing assistant text, plans, and visible failures are visible
- user input, reasoning, tool calls, and system notices are not assistant-response candidates
- no historical data migration or replication schema version change
- downstream package cohort upgrades remain separate from this producer fix
