### PR TITLE
feat(agent): 展示扩展声明的模型消耗倍率

### DIFF
--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -896,6 +896,9 @@ future mutations; `effectiveModel` is presentation-only runtime evidence for
 describing what Default currently resolves to. Activity adapters and AgentGUI
 must not replace the selection with that resolved value or infer it from the
 catalog's Default entry.
+Optional model `consumptionMultiplier` metadata is likewise typed before it
+reaches activity-core. AgentGUI may render that field but must not reconstruct
+quota or cost semantics from provider-owned model descriptions.
 An omitted pre-session descriptor means the connected daemon predates the
 typed composer capability contract and must remain an unknown/loading state.
 Core capability booleans must not be reconstructed from private

--- a/docs/architecture/agent-extensions.md
+++ b/docs/architecture/agent-extensions.md
@@ -284,6 +284,18 @@ retaining the original runtime id for ACP writes. Unknown provider-native
 options remain intact in the opaque runtime context; this does not imply a
 generic AgentGUI control for every unknown option.
 
+Model consumption metadata follows the same adapter-first rule without making
+provider prose globally meaningful. A verified Extension may opt its model
+config reference into the closed
+`descriptionMetadataFormat: "credit-consumption-multiplier-v1"` declaration.
+Only then does the standard ACP adapter remove a standalone `xN credits`
+description segment and project its numeric token as the typed
+`consumptionMultiplier` model field. Unknown formats fail package validation
+and adapter construction; profiles without the declaration preserve the full
+description. The daemon API and activity adapter preserve the typed field, and
+AgentGUI renders it without parsing provider prose or branching on a provider
+name.
+
 Signed composer profiles may narrow the provider-advertised slash-command
 catalog and attach shared command effects such as submit-immediate, show-status,
 activate-goal-mode, and toggle-plan-mode. `tuttid` applies that declarative

--- a/docs/specs/2026-07-14-agent-extension-package-design.md
+++ b/docs/specs/2026-07-14-agent-extension-package-design.md
@@ -726,7 +726,8 @@ Manifest 声明不能覆盖实际 ACP handshake，也不能开启当前 host 不
   "schemaVersion": "tutti.agent.composer.v1",
   "configOptions": {
     "model": {
-      "acpOptionId": "model"
+      "acpOptionId": "model",
+      "descriptionMetadataFormat": "credit-consumption-multiplier-v1"
     },
     "permission": {
       "acpOptionId": "approval-mode"
@@ -786,6 +787,14 @@ objects. These declarations identify or constrain ACP fields. Model, reasoning,
 and command catalogs still require runtime facts; the signed `permissionModes`
 list is the independent launch-permission contract and does not depend on model
 catalog discovery.
+
+`configOptions.model.descriptionMetadataFormat` is an optional closed
+normalization declaration, not an extension-code hook. The supported
+`credit-consumption-multiplier-v1` format allows the standard ACP adapter to
+extract a standalone `xN credits` description segment into typed
+`consumptionMultiplier` metadata. Without the declaration, the description is
+preserved verbatim. Unknown formats are rejected, and profiles cannot provide
+scripts, regular expressions, or provider-specific executable normalization.
 
 Known permission semantics are `ask-before-write`, `accept-edits`, `auto`,
 `locked-down`, `full-access`, and the plan-only `read-only` mapping. The composer

--- a/packages/agent/activity-core/src/composerOptions.types.ts
+++ b/packages/agent/activity-core/src/composerOptions.types.ts
@@ -5,6 +5,7 @@ export interface AgentActivityComposerSettingOption {
   value: string;
   label: string;
   description?: string;
+  consumptionMultiplier?: string;
   supportsImageInput?: boolean;
   /** True when the entry mirrors the requested/current selection, not the provider catalog. */
   requested?: boolean;

--- a/packages/agent/activity-tuttid-adapter/src/composerOptions.test.ts
+++ b/packages/agent/activity-tuttid-adapter/src/composerOptions.test.ts
@@ -17,7 +17,14 @@ test("maps daemon composer options into the canonical activity contract", () => 
     modelConfig: {
       configurable: true,
       effectiveValue: "claude-haiku-4-5-20251001",
-      options: [{ id: "gpt-5", label: "GPT-5", value: "gpt-5" }]
+      options: [
+        {
+          id: "gpt-5",
+          label: "GPT-5",
+          value: "gpt-5",
+          consumptionMultiplier: "0.71"
+        }
+      ]
     },
     permissionConfig: { configurable: false, modes: [] },
     reasoningConfig: { configurable: false, options: [] },
@@ -34,7 +41,13 @@ test("maps daemon composer options into the canonical activity contract", () => 
   assert.equal(options.effectiveSettings?.codexSaverMode, true);
   assert.equal(options.modelConfigurable, true);
   assert.equal(options.effectiveModel, "claude-haiku-4-5-20251001");
-  assert.deepEqual(options.models, [{ label: "GPT-5", value: "gpt-5" }]);
+  assert.deepEqual(options.models, [
+    {
+      label: "GPT-5",
+      value: "gpt-5",
+      consumptionMultiplier: "0.71"
+    }
+  ]);
   assert.equal(options.effectiveSettings?.model, "gpt-5");
 });
 

--- a/packages/agent/activity-tuttid-adapter/src/composerOptions.ts
+++ b/packages/agent/activity-tuttid-adapter/src/composerOptions.ts
@@ -292,6 +292,7 @@ function settingOptionsFromRawOptions(
     seen.add(optionValue);
     const label = firstTextValue(record, keys.labelKeys) ?? optionValue;
     const description = normalizeText(record.description);
+    const consumptionMultiplier = normalizeText(record.consumptionMultiplier);
     const supportsImageInput =
       typeof record.supportsImageInput === "boolean"
         ? record.supportsImageInput
@@ -300,6 +301,7 @@ function settingOptionsFromRawOptions(
       value: optionValue,
       label,
       ...(description ? { description } : {}),
+      ...(consumptionMultiplier ? { consumptionMultiplier } : {}),
       ...(supportsImageInput !== undefined ? { supportsImageInput } : {}),
       // Daemon provenance: the entry mirrors the requested selection (warm
       // catalog append / bootstrap echo) and is not catalog testimony.

--- a/packages/agent/daemon/modelcatalog/runtime_config_options.go
+++ b/packages/agent/daemon/modelcatalog/runtime_config_options.go
@@ -80,6 +80,7 @@ func NormalizeRuntimeConfigOptionModel(raw json.RawMessage) (ModelOption, bool) 
 		ID:                         id,
 		DisplayName:                displayName,
 		Description:                stringMapValue(object, "description"),
+		ConsumptionMultiplier:      stringMapValue(object, "consumptionMultiplier"),
 		DefaultReasoningEffort:     validReasoningDefault(reasoningOptions, defaultReasoning),
 		DefaultSpeed:               validSpeedDefault(speeds, canonicalCodexSpeed(defaultSpeed)),
 		IsDefault:                  id == "default" || boolMapValue(object, "default") || boolMapValue(object, "isDefault") || boolMapValue(object, "is_default"),
@@ -99,6 +100,9 @@ func ProjectRuntimeConfigOptionModel(model ModelOption) map[string]any {
 		"name":        firstNonBlank(model.DisplayName, model.ID),
 		"description": strings.TrimSpace(model.Description),
 		"default":     model.IsDefault,
+	}
+	if consumptionMultiplier := strings.TrimSpace(model.ConsumptionMultiplier); consumptionMultiplier != "" {
+		option["consumptionMultiplier"] = consumptionMultiplier
 	}
 	if model.SupportsImageInput != nil {
 		option["supportsImageInput"] = *model.SupportsImageInput

--- a/packages/agent/daemon/modelcatalog/runtime_config_options_test.go
+++ b/packages/agent/daemon/modelcatalog/runtime_config_options_test.go
@@ -13,6 +13,7 @@ func TestRuntimeConfigOptionModelRoundTripPreservesCapabilities(t *testing.T) {
 		ID:                         "gpt-5.6-sol",
 		DisplayName:                "GPT-5.6-Sol",
 		Description:                "Frontier coding model",
+		ConsumptionMultiplier:      "0.71",
 		DefaultReasoningEffort:     "low",
 		DefaultSpeed:               "standard",
 		IsDefault:                  true,
@@ -45,7 +46,7 @@ func TestRuntimeConfigOptionModelRoundTripPreservesCapabilities(t *testing.T) {
 		t.Fatalf("ParseRuntimeConfigOptionModels() = (%#v, %t), want one advertised model", models, advertised)
 	}
 	got := models[0]
-	if got.ID != model.ID || got.DisplayName != model.DisplayName || got.Description != model.Description || !got.IsDefault {
+	if got.ID != model.ID || got.DisplayName != model.DisplayName || got.Description != model.Description || got.ConsumptionMultiplier != model.ConsumptionMultiplier || !got.IsDefault {
 		t.Fatalf("round-trip identity = %#v, want %#v", got, model)
 	}
 	if !got.ReasoningEffortsAdvertised || got.DefaultReasoningEffort != "low" {

--- a/packages/agent/daemon/modelcatalog/types.go
+++ b/packages/agent/daemon/modelcatalog/types.go
@@ -19,6 +19,7 @@ type ModelOption struct {
 	ID                         string
 	DisplayName                string
 	Description                string
+	ConsumptionMultiplier      string
 	DefaultReasoningEffort     string
 	DefaultSpeed               string
 	IsDefault                  bool

--- a/packages/agent/daemon/runtime/acp_live_state.go
+++ b/packages/agent/daemon/runtime/acp_live_state.go
@@ -115,6 +115,8 @@ func applyACPUpdateToLiveState(
 	state *acpLiveState,
 	agentSessionID string,
 	raw json.RawMessage,
+	modelConfigOptionID string,
+	modelDescriptionFormat string,
 ) *AgentSessionCommandSnapshot {
 	if state == nil {
 		return nil
@@ -141,6 +143,7 @@ func applyACPUpdateToLiveState(
 		}
 	case "config_option_update":
 		if descriptors := acpConfigOptionDescriptorsFromUpdate(params.Update); len(descriptors) > 0 {
+			normalizeACPModelConfigOptionDescriptions(descriptors, modelConfigOptionID, modelDescriptionFormat)
 			applyACPConfigOptionDescriptors(state, descriptors)
 		}
 		for key, value := range acpConfigValues(params.Update) {
@@ -345,7 +348,12 @@ func acpConfigOptionsUpdateKey(raw json.RawMessage) (string, bool) {
 	return strings.TrimSpace(asString(params.Update["key"])), true
 }
 
-func applyACPConfigOptionsResult(state *acpLiveState, raw json.RawMessage) {
+func applyACPConfigOptionsResult(
+	state *acpLiveState,
+	raw json.RawMessage,
+	modelConfigOptionID string,
+	modelDescriptionFormat string,
+) {
 	if state == nil || len(raw) == 0 {
 		return
 	}
@@ -355,6 +363,7 @@ func applyACPConfigOptionsResult(state *acpLiveState, raw json.RawMessage) {
 	if err := json.Unmarshal(raw, &payload); err != nil || len(payload.ConfigOptions) == 0 {
 		return
 	}
+	normalizeACPModelConfigOptionDescriptions(payload.ConfigOptions, modelConfigOptionID, modelDescriptionFormat)
 	applyACPConfigOptionDescriptors(state, payload.ConfigOptions)
 }
 

--- a/packages/agent/daemon/runtime/acp_model_state.go
+++ b/packages/agent/daemon/runtime/acp_model_state.go
@@ -2,8 +2,15 @@ package agentruntime
 
 import (
 	"encoding/json"
+	"regexp"
 	"strings"
 )
+
+var acpModelConsumptionDescriptionPattern = regexp.MustCompile(
+	`(?i)^\s*(?:x\s*([0-9]+(?:\.[0-9]+)?)|([0-9]+(?:\.[0-9]+)?)\s*x)\s*credits?\s*$`,
+)
+
+const StandardACPModelDescriptionMetadataFormatCreditConsumptionMultiplierV1 = "credit-consumption-multiplier-v1"
 
 type acpModelInfo struct {
 	Description             string          `json:"description"`
@@ -16,7 +23,7 @@ type acpModelInfo struct {
 	Meta                    json.RawMessage `json:"_meta"`
 }
 
-func applyACPModelsResult(state *acpLiveState, raw json.RawMessage) {
+func applyACPModelsResult(state *acpLiveState, raw json.RawMessage, descriptionMetadataFormat string) {
 	if state == nil || len(raw) == 0 {
 		return
 	}
@@ -41,8 +48,12 @@ func applyACPModelsResult(state *acpLiveState, raw json.RawMessage) {
 			label = modelID
 		}
 		option := map[string]any{"value": modelID, "label": label}
-		if description := strings.TrimSpace(model.Description); description != "" {
+		description, consumptionMultiplier := normalizeACPModelDescription(model.Description, descriptionMetadataFormat)
+		if description != "" {
 			option["description"] = description
+		}
+		if consumptionMultiplier != "" {
+			option["consumptionMultiplier"] = consumptionMultiplier
 		}
 		applyACPModelMetadata(option, model)
 		options = append(options, option)
@@ -69,6 +80,80 @@ func applyACPModelsResult(state *acpLiveState, raw json.RawMessage) {
 		descriptors = append(descriptors, descriptor)
 	}
 	applyACPConfigOptionDescriptors(state, descriptors)
+}
+
+// normalizeACPModelDescription converts the standalone credit multiplier into
+// typed model metadata only when a verified Extension explicitly declares the
+// closed format. Shared catalog and GUI layers must not infer this semantic
+// from provider-owned presentation text.
+func normalizeACPModelDescription(description string, metadataFormat string) (string, string) {
+	original := strings.TrimSpace(description)
+	if strings.TrimSpace(metadataFormat) != StandardACPModelDescriptionMetadataFormatCreditConsumptionMultiplierV1 {
+		return original, ""
+	}
+	parts := strings.FieldsFunc(description, func(value rune) bool {
+		return value == '·' || value == '•' || value == '\n' || value == '\r'
+	})
+	kept := make([]string, 0, len(parts))
+	consumptionMultiplier := ""
+	foundConsumption := false
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		if matches := acpModelConsumptionDescriptionPattern.FindStringSubmatch(part); len(matches) > 0 {
+			foundConsumption = true
+			if consumptionMultiplier == "" {
+				consumptionMultiplier = firstNonEmptyString(matches[1], matches[2])
+			}
+			continue
+		}
+		kept = append(kept, part)
+	}
+	if !foundConsumption {
+		return original, ""
+	}
+	return strings.Join(kept, " · "), consumptionMultiplier
+}
+
+func normalizeACPModelConfigOptionDescriptions(
+	descriptors []map[string]any,
+	modelConfigOptionID string,
+	metadataFormat string,
+) {
+	modelConfigOptionID = strings.TrimSpace(modelConfigOptionID)
+	if modelConfigOptionID == "" || strings.TrimSpace(metadataFormat) == "" {
+		return
+	}
+	for _, descriptor := range descriptors {
+		if strings.TrimSpace(asString(descriptor["id"])) != modelConfigOptionID {
+			continue
+		}
+		options, ok := descriptor["options"].([]any)
+		if !ok {
+			return
+		}
+		for _, rawOption := range options {
+			option, ok := rawOption.(map[string]any)
+			if !ok {
+				continue
+			}
+			description, consumptionMultiplier := normalizeACPModelDescription(
+				asString(option["description"]),
+				metadataFormat,
+			)
+			if description == "" {
+				delete(option, "description")
+			} else {
+				option["description"] = description
+			}
+			if consumptionMultiplier != "" {
+				option["consumptionMultiplier"] = consumptionMultiplier
+			}
+		}
+		return
+	}
 }
 
 func applyACPModelMetadata(option map[string]any, model acpModelInfo) {

--- a/packages/agent/daemon/runtime/acp_models_test.go
+++ b/packages/agent/daemon/runtime/acp_models_test.go
@@ -10,25 +10,117 @@ func TestApplyACPModelsResultProjectsModelConfigOption(t *testing.T) {
 	applyACPModelsResult(&state, json.RawMessage(`{
 		"models": {
 			"availableModels": [
-				{"modelId":"auto-gemini-3","name":"Auto (Gemini 3)","description":"Routes automatically"},
-				{"modelId":"gemini-3-pro-preview","name":"Gemini 3 Pro"}
+				{"modelId":"auto-gemini-3","name":"Auto (Gemini 3)","description":"Routes automatically\nwithout rewriting"},
+				{"modelId":"gemini-3-pro-preview","name":"Gemini 3 Pro","description":"Frontier model · x0.71 credits"},
+				{"modelId":"hy3","name":"Hy3","description":"0.00x Credits"}
 			],
 			"currentModelId":"auto-gemini-3"
 		}
-	}`))
+	}`), StandardACPModelDescriptionMetadataFormatCreditConsumptionMultiplierV1)
 
 	if !state.modelsAPI {
 		t.Fatal("modelsAPI = false, want true")
 	}
 	options := extractModelOptionsFromRuntimeDescriptorsForTest(state.configOptionDescriptors)
-	if len(options) != 2 {
-		t.Fatalf("model options = %#v, want two", options)
+	if len(options) != 3 {
+		t.Fatalf("model options = %#v, want three", options)
 	}
 	if options[0]["value"] != "auto-gemini-3" || options[0]["label"] != "Auto (Gemini 3)" {
 		t.Fatalf("first model option = %#v", options[0])
 	}
+	if options[0]["description"] != "Routes automatically\nwithout rewriting" {
+		t.Fatalf("ordinary model description = %#v, want verbatim text", options[0]["description"])
+	}
+	if options[1]["description"] != "Frontier model" || options[1]["consumptionMultiplier"] != "0.71" {
+		t.Fatalf("model consumption metadata = %#v", options[1])
+	}
+	if _, present := options[2]["description"]; present || options[2]["consumptionMultiplier"] != "0.00" {
+		t.Fatalf("credit-only model metadata = %#v", options[2])
+	}
 	if state.configOptions["model"] != "auto-gemini-3" {
 		t.Fatalf("current model = %#v, want auto-gemini-3", state.configOptions["model"])
+	}
+}
+
+func TestApplyACPModelsResultPreservesDescriptionWithoutDeclaredMetadataFormat(t *testing.T) {
+	state := newACPLiveState()
+	applyACPModelsResult(&state, json.RawMessage(`{
+		"models": {
+			"availableModels": [
+				{"modelId":"ordinary-provider","name":"Ordinary Provider","description":"Frontier model · x0.71 credits"}
+			],
+			"currentModelId":"ordinary-provider"
+		}
+	}`), "")
+
+	options := extractModelOptionsFromRuntimeDescriptorsForTest(state.configOptionDescriptors)
+	if len(options) != 1 || options[0]["description"] != "Frontier model · x0.71 credits" {
+		t.Fatalf("model options = %#v, want provider description preserved", options)
+	}
+	if _, present := options[0]["consumptionMultiplier"]; present {
+		t.Fatalf("undeclared consumption metadata should not be inferred: %#v", options[0])
+	}
+}
+
+func TestApplyACPConfigOptionsResultProjectsDeclaredModelConsumptionMetadata(t *testing.T) {
+	state := newACPLiveState()
+	applyACPConfigOptionsResult(&state, json.RawMessage(`{
+		"configOptions": [
+			{
+				"type":"select",
+				"id":"model",
+				"currentValue":"hy3",
+				"options":[
+					{"value":"hy3","name":"Hy3","description":"x0.00 credits"},
+					{"value":"glm-5.3","name":"GLM-5.3","description":"Frontier model · x0.79 credits"}
+				]
+			}
+		]
+	}`), "model", StandardACPModelDescriptionMetadataFormatCreditConsumptionMultiplierV1)
+
+	options := extractModelOptionsFromRuntimeDescriptorsForTest(state.configOptionDescriptors)
+	if len(options) != 2 {
+		t.Fatalf("model options = %#v, want two", options)
+	}
+	if _, present := options[0]["description"]; present || options[0]["consumptionMultiplier"] != "0.00" {
+		t.Fatalf("credit-only config option metadata = %#v", options[0])
+	}
+	if options[1]["description"] != "Frontier model" || options[1]["consumptionMultiplier"] != "0.79" {
+		t.Fatalf("mixed config option metadata = %#v", options[1])
+	}
+}
+
+func TestApplyACPConfigOptionsResultPreservesDescriptionWithoutDeclaredMetadataFormat(t *testing.T) {
+	state := newACPLiveState()
+	applyACPConfigOptionsResult(&state, json.RawMessage(`{
+		"configOptions": [{
+			"id":"model",
+			"currentValue":"ordinary-provider",
+			"options":[{
+				"value":"ordinary-provider",
+				"name":"Ordinary Provider",
+				"description":"Frontier model · x0.71 credits"
+			}]
+		}]
+	}`), "model", "")
+
+	options := extractModelOptionsFromRuntimeDescriptorsForTest(state.configOptionDescriptors)
+	if len(options) != 1 || options[0]["description"] != "Frontier model · x0.71 credits" {
+		t.Fatalf("model options = %#v, want provider description preserved", options)
+	}
+	if _, present := options[0]["consumptionMultiplier"]; present {
+		t.Fatalf("undeclared config option consumption metadata should not be inferred: %#v", options[0])
+	}
+}
+
+func TestNewStandardACPAdapterRejectsUnknownModelDescriptionMetadataFormat(t *testing.T) {
+	_, err := NewStandardACPAdapter(StandardACPAdapterConfig{
+		Provider:               "acp:example",
+		Command:                []string{"example", "--acp"},
+		ModelDescriptionFormat: "extension-supplied-parser",
+	}, nil, LegacyHostMetadata())
+	if err == nil {
+		t.Fatal("NewStandardACPAdapter() error = nil, want unsupported metadata format rejection")
 	}
 }
 
@@ -60,7 +152,7 @@ func TestApplyACPModelsResultPreservesDynamicModelMetadata(t *testing.T) {
 			],
 			"currentModelId":"reasoning-model"
 		}
-	}`))
+	}`), "")
 
 	options := extractModelOptionsFromRuntimeDescriptorsForTest(state.configOptionDescriptors)
 	if len(options) != 2 {
@@ -112,7 +204,7 @@ func TestApplyACPModelsResultToleratesAlternateMetadataShapes(t *testing.T) {
 			],
 			"currentModelId":"string-efforts"
 		}
-	}`))
+	}`), "")
 
 	if !state.modelsAPI {
 		t.Fatal("modelsAPI = false, want true")

--- a/packages/agent/daemon/runtime/acp_update_normalizer_test.go
+++ b/packages/agent/daemon/runtime/acp_update_normalizer_test.go
@@ -38,8 +38,50 @@ func TestApplyACPUpdateToLiveStateCapturesCurrentModeID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	applyACPUpdateToLiveState(&state, "agent-session-1", raw)
+	applyACPUpdateToLiveState(&state, "agent-session-1", raw, "", "")
 	if state.currentMode != "auto" {
 		t.Fatalf("state.currentMode = %q, want auto", state.currentMode)
+	}
+}
+
+func TestApplyACPUpdateToLiveStateProjectsDeclaredModelConsumptionMetadata(t *testing.T) {
+	t.Parallel()
+
+	state := newACPLiveState()
+	raw, err := json.Marshal(map[string]any{
+		"update": map[string]any{
+			"sessionUpdate": "config_option_update",
+			"configOptions": []any{
+				map[string]any{
+					"id":           "model",
+					"currentValue": "glm-5.3",
+					"options": []any{
+						map[string]any{
+							"value":       "glm-5.3",
+							"name":        "GLM-5.3",
+							"description": "x0.79 credits",
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	applyACPUpdateToLiveState(
+		&state,
+		"agent-session-1",
+		raw,
+		"model",
+		StandardACPModelDescriptionMetadataFormatCreditConsumptionMultiplierV1,
+	)
+
+	options := extractModelOptionsFromRuntimeDescriptorsForTest(state.configOptionDescriptors)
+	if len(options) != 1 || options[0]["consumptionMultiplier"] != "0.79" {
+		t.Fatalf("model options = %#v, want typed multiplier", options)
+	}
+	if _, present := options[0]["description"]; present {
+		t.Fatalf("credit-only description should be consumed: %#v", options[0])
 	}
 }

--- a/packages/agent/daemon/runtime/provider_descriptors.go
+++ b/packages/agent/daemon/runtime/provider_descriptors.go
@@ -160,6 +160,7 @@ type StandardACPAdapterConfig struct {
 	AuthMessage                  string
 	ToolAliases                  map[string]string
 	ModelConfigOptionID          string
+	ModelDescriptionFormat       string
 	PermissionConfigOptionID     string
 	ReasoningConfigOptionID      string
 	RestrictConfigOptions        bool
@@ -187,6 +188,10 @@ func NewStandardACPAdapter(config StandardACPAdapterConfig, transport ProcessTra
 	provider := strings.TrimSpace(config.Provider)
 	if provider == "" || len(config.Command) == 0 || strings.TrimSpace(config.Command[0]) == "" {
 		return nil, fmt.Errorf("standard ACP provider and command are required")
+	}
+	modelDescriptionFormat := strings.TrimSpace(config.ModelDescriptionFormat)
+	if modelDescriptionFormat != "" && modelDescriptionFormat != StandardACPModelDescriptionMetadataFormatCreditConsumptionMultiplierV1 {
+		return nil, errors.New("standard ACP model description metadata format is unsupported")
 	}
 	launchPermission, err := validateStandardACPLaunchPermissionSetting(config.Command, config.LaunchPermission)
 	if err != nil {
@@ -219,6 +224,7 @@ func NewStandardACPAdapter(config StandardACPAdapterConfig, transport ProcessTra
 			authRequiredMessage:          strings.TrimSpace(config.AuthMessage),
 			toolAliases:                  cloneStandardACPToolAliases(config.ToolAliases),
 			modelConfigOptionID:          strings.TrimSpace(config.ModelConfigOptionID),
+			modelDescriptionFormat:       modelDescriptionFormat,
 			permissionConfigOptionID:     strings.TrimSpace(config.PermissionConfigOptionID),
 			reasoningConfigOptionID:      strings.TrimSpace(config.ReasoningConfigOptionID),
 			restrictConfigOptions:        config.RestrictConfigOptions,

--- a/packages/agent/daemon/runtime/standard_acp_adapter.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter.go
@@ -97,6 +97,7 @@ type standardACPConfig struct {
 	startupDiagnostics             bool
 	toolAliases                    map[string]string
 	modelConfigOptionID            string
+	modelDescriptionFormat         string
 	permissionConfigOptionID       string
 	reasoningConfigOptionID        string
 	restrictConfigOptions          bool

--- a/packages/agent/daemon/runtime/standard_acp_session.go
+++ b/packages/agent/daemon/runtime/standard_acp_session.go
@@ -136,8 +136,13 @@ func (a *standardACPAdapter) Start(ctx context.Context, session Session) ([]acti
 	})
 	session.ProviderSessionID = providerSessionID
 	acpSession.providerSessionID = providerSessionID
-	applyACPConfigOptionsResult(&acpSession.acpLiveState, newSessionResult)
-	applyACPModelsResult(&acpSession.acpLiveState, newSessionResult)
+	applyACPConfigOptionsResult(
+		&acpSession.acpLiveState,
+		newSessionResult,
+		a.config.modelConfigOptionID,
+		a.config.modelDescriptionFormat,
+	)
+	applyACPModelsResult(&acpSession.acpLiveState, newSessionResult, a.config.modelDescriptionFormat)
 	applyACPModesResult(&acpSession.acpLiveState, newSessionResult)
 	if a.config.validateNewSessionResult != nil {
 		if err := a.config.validateNewSessionResult(newSessionResult); err != nil {
@@ -299,8 +304,13 @@ func (a *standardACPAdapter) resumeLocked(ctx context.Context, session Session) 
 	if err != nil {
 		return classifyACPResumeError(session, method, err)
 	}
-	applyACPConfigOptionsResult(&acpSession.acpLiveState, loadSessionResult)
-	applyACPModelsResult(&acpSession.acpLiveState, loadSessionResult)
+	applyACPConfigOptionsResult(
+		&acpSession.acpLiveState,
+		loadSessionResult,
+		a.config.modelConfigOptionID,
+		a.config.modelDescriptionFormat,
+	)
+	applyACPModelsResult(&acpSession.acpLiveState, loadSessionResult, a.config.modelDescriptionFormat)
 	applyACPModesResult(&acpSession.acpLiveState, loadSessionResult)
 	if err := a.applySessionConfigOptions(ctx, client, session, loadSessionResult); err != nil {
 		return err

--- a/packages/agent/daemon/runtime/standard_acp_settings.go
+++ b/packages/agent/daemon/runtime/standard_acp_settings.go
@@ -302,8 +302,13 @@ func (a *standardACPAdapter) updateSessionConfigOptionsResult(agentSessionID str
 	if session == nil {
 		return
 	}
-	applyACPConfigOptionsResult(&session.acpLiveState, raw)
-	applyACPModelsResult(&session.acpLiveState, raw)
+	applyACPConfigOptionsResult(
+		&session.acpLiveState,
+		raw,
+		a.config.modelConfigOptionID,
+		a.config.modelDescriptionFormat,
+	)
+	applyACPModelsResult(&session.acpLiveState, raw, a.config.modelDescriptionFormat)
 	applyACPModesResult(&session.acpLiveState, raw)
 }
 

--- a/packages/agent/daemon/runtime/standard_acp_stream.go
+++ b/packages/agent/daemon/runtime/standard_acp_stream.go
@@ -458,7 +458,13 @@ func (a *standardACPAdapter) applyACPUpdate(agentSessionID string, raw json.RawM
 	if session == nil {
 		return nil
 	}
-	return applyACPUpdateToLiveState(&session.acpLiveState, agentSessionID, raw)
+	return applyACPUpdateToLiveState(
+		&session.acpLiveState,
+		agentSessionID,
+		raw,
+		a.config.modelConfigOptionID,
+		a.config.modelDescriptionFormat,
+	)
 }
 
 func (a *standardACPAdapter) storePendingApproval(pending *pendingACPApproval) {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerModelReasoningDropdown.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerModelReasoningDropdown.tsx
@@ -717,6 +717,17 @@ function ComposerModelOptionTooltip({
             {option.tooltip.description}
           </span>
         ) : null}
+        {option.tooltip.consumptionMultiplier ? (
+          <span className="mt-3 flex w-full items-center justify-between gap-6 border-t border-[var(--line-2)] pt-3">
+            <span>
+              {translate("agentHost.agentGui.modelConsumptionSpeedLabel")}
+            </span>
+            <span className="shrink-0 tabular-nums">
+              {option.tooltip.consumptionMultiplier}{" "}
+              {translate("agentHost.agentGui.modelConsumptionMultiplierSuffix")}
+            </span>
+          </span>
+        ) : null}
         {option.tooltip.contextWindow ? (
           <span className="mt-4 block">{option.tooltip.contextWindow}</span>
         ) : null}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
@@ -2,6 +2,7 @@ import "@testing-library/jest-dom/vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { useState } from "react";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@tutti-os/ui-system";
 import {
   AgentModelReasoningDropdown,
   AgentPermissionModeDropdown
@@ -129,6 +130,45 @@ describe("AgentModelReasoningDropdown", () => {
     expect(
       screen.queryByRole("button", { name: "Add to favorites" })
     ).not.toBeInTheDocument();
+  });
+
+  it("shows the typed model consumption multiplier", async () => {
+    render(
+      <TooltipProvider delayDuration={0}>
+        <AgentModelReasoningDropdown
+          composerSettings={{
+            ...composerModelSettings(),
+            availableModels: [
+              {
+                label: "Hy3",
+                value: "hy3",
+                consumptionMultiplier: "0.71"
+              }
+            ],
+            draftSettings: {
+              ...composerModelSettings().draftSettings,
+              model: "hy3"
+            },
+            selectedModelValue: "hy3"
+          }}
+          labels={modelSettingsLabels}
+          onSettingsChange={vi.fn()}
+        />
+      </TooltipProvider>
+    );
+
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Model / Reasoning" }),
+      { button: 0, ctrlKey: false, pointerType: "mouse" }
+    );
+    fireEvent.pointerMove(await screen.findByTestId("agent-gui-model-option"), {
+      pointerType: "mouse"
+    });
+
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toHaveTextContent("Hy3");
+    expect(tooltip).toHaveTextContent("Consumption rate");
+    expect(tooltip).toHaveTextContent("0.71x multiplier");
   });
 
   it("retries composer options from the compact error state", async () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
@@ -99,6 +99,7 @@ export interface AgentGUIComposerSettingOption {
   value: string;
   label: string;
   description?: string;
+  consumptionMultiplier?: string;
   supportsImageInput?: boolean;
   /** Bound plan identity for options aggregated from model access plans. */
   modelPlanId?: string | null;

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/composerSettingsMenuModel.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/composerSettingsMenuModel.spec.ts
@@ -186,6 +186,31 @@ describe("buildComposerModelMenuModel", () => {
     });
   });
 
+  it("presents the typed model consumption multiplier", () => {
+    const menu = buildComposerModelMenuModel(
+      vm({
+        availableModels: [
+          {
+            value: "hy3",
+            label: "Hy3",
+            consumptionMultiplier: "0.71"
+          }
+        ],
+        selectedModelValue: "hy3"
+      }),
+      labels
+    );
+
+    expect(menu.model.options[0]).toMatchObject({
+      label: "Hy3",
+      tooltip: {
+        consumptionMultiplier: "0.71x",
+        title: "Hy3"
+      }
+    });
+    expect(menu.model.options[0]?.tooltip?.description).toBeUndefined();
+  });
+
   it("marks the trigger as fast and localizes model descriptions", () => {
     const menu = buildComposerModelMenuModel(
       vm({

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/composerSettingsMenuModel.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/composerSettingsMenuModel.ts
@@ -61,6 +61,7 @@ export interface ComposerMenuOption {
 export interface ComposerModelOptionTooltip {
   title: string;
   description?: string;
+  consumptionMultiplier?: string;
   contextWindow?: string;
   version?: string;
 }
@@ -338,7 +339,12 @@ function modelMenuOptionFromSettingOption(
       : option.description,
     labels
   );
+  const consumptionMultiplier =
+    option.value === "default"
+      ? resolvedOption?.consumptionMultiplier
+      : option.consumptionMultiplier;
   const presentation = modelOptionPresentation({
+    consumptionMultiplier,
     description,
     label: displayLabel,
     labels
@@ -355,6 +361,7 @@ function modelMenuOptionFromSettingOption(
 }
 
 function modelOptionPresentation(input: {
+  consumptionMultiplier: string | undefined;
   description: string | undefined;
   label: string;
   labels: Pick<
@@ -378,6 +385,7 @@ function modelOptionPresentation(input: {
 } {
   const description = input.description?.trim() || "";
   const parsed = parseModelDescription(description);
+  const consumptionMultiplier = input.consumptionMultiplier?.trim() || "";
   const label = shortModelDisplayLabel(input.label);
   const summary = uniqueNonEmpty([
     parsed.contextWindow?.summary,
@@ -389,10 +397,13 @@ function modelOptionPresentation(input: {
   const tooltipDescription =
     parsed.body || (description && !parsed.title ? description : "");
   const tooltip =
-    description || summary.length > 0
+    description || summary.length > 0 || consumptionMultiplier
       ? {
           title: parsed.title ?? label,
           ...(tooltipDescription ? { description: tooltipDescription } : {}),
+          ...(consumptionMultiplier
+            ? { consumptionMultiplier: `${consumptionMultiplier}x` }
+            : {}),
           ...(parsed.contextWindow
             ? {
                 contextWindow: `${parsed.contextWindow.summary} ${input.labels.modelContextWindowSuffix}`

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGuiComposer.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGuiComposer.ts
@@ -5,5 +5,7 @@ export const enAgentGuiComposer = {
   composerOptionsRetryTooltip:
     "Unable to load shared Agent information. Click to retry",
   sendFailed: "The message could not be sent.",
-  inheritedUnavailable: "Inherited / unavailable"
+  inheritedUnavailable: "Inherited / unavailable",
+  modelConsumptionSpeedLabel: "Consumption rate",
+  modelConsumptionMultiplierSuffix: "multiplier"
 };

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGuiComposer.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGuiComposer.ts
@@ -4,5 +4,7 @@ export const zhCNAgentGuiComposer = {
   composerOptionsRetry: "重试",
   composerOptionsRetryTooltip: "共享 Agent 信息加载失败，点击重试",
   sendFailed: "消息未能发送",
-  inheritedUnavailable: "继承 / 不可用"
+  inheritedUnavailable: "继承 / 不可用",
+  modelConsumptionSpeedLabel: "消耗速度",
+  modelConsumptionMultiplierSuffix: "倍率"
 };

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -1983,6 +1983,10 @@ export type AgentProviderComposerConfigOptionValue = {
   value: string;
   label: string;
   description?: string;
+  /**
+   * Provider-reported credit consumption multiplier without the display suffix. Runtime adapters normalize provider wire data into this typed field; clients must not infer it from description.
+   */
+  consumptionMultiplier?: string;
   supportsImageInput?: boolean;
   /**
    * True when the entry mirrors the requested/current selection instead of the provider catalog (warm-catalog append of the requested model, selected-model bootstrap echo). Clients keep such entries selectable but must not treat them as proof the provider can run the model; create validation runs against the raw catalog only.

--- a/services/tuttid/api/daemon_agent_composer_options.go
+++ b/services/tuttid/api/daemon_agent_composer_options.go
@@ -174,6 +174,9 @@ func generatedComposerConfigOption(config agentservice.ComposerConfigOption) tut
 		if strings.TrimSpace(option.Description) != "" {
 			resultOption.Description = optionalStringPointer(option.Description)
 		}
+		if strings.TrimSpace(option.ConsumptionMultiplier) != "" {
+			resultOption.ConsumptionMultiplier = optionalStringPointer(option.ConsumptionMultiplier)
+		}
 		if option.SupportsImageInput != nil {
 			resultOption.SupportsImageInput = option.SupportsImageInput
 		}

--- a/services/tuttid/api/daemon_agent_composer_options_test.go
+++ b/services/tuttid/api/daemon_agent_composer_options_test.go
@@ -22,7 +22,7 @@ func TestGeneratedComposerConfigOptionKeepsRequestedProvenance(t *testing.T) {
 		CurrentValue:   "default",
 		EffectiveValue: "claude-haiku-4-5-20251001",
 		Options: []agentservice.ComposerConfigOptionValue{
-			{ID: "gpt-5.6-sol", Label: "GPT-5.6 Sol", Value: "gpt-5.6-sol"},
+			{ID: "gpt-5.6-sol", Label: "GPT-5.6 Sol", Value: "gpt-5.6-sol", ConsumptionMultiplier: "0.71"},
 			{ID: "x-ai/grok-4.5", Label: "x-ai/grok-4.5", Value: "x-ai/grok-4.5", Requested: true},
 		},
 	})
@@ -31,6 +31,9 @@ func TestGeneratedComposerConfigOptionKeepsRequestedProvenance(t *testing.T) {
 	}
 	if generated.Options[0].Requested != nil {
 		t.Fatal("catalog entry must omit the requested field")
+	}
+	if generated.Options[0].ConsumptionMultiplier == nil || *generated.Options[0].ConsumptionMultiplier != "0.71" {
+		t.Fatalf("consumption multiplier = %#v, want 0.71", generated.Options[0].ConsumptionMultiplier)
 	}
 	if generated.Options[1].Requested == nil || !*generated.Options[1].Requested {
 		t.Fatal("requested-origin entry must project requested=true")

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -5505,9 +5505,11 @@ type AgentProviderComposerConfig struct {
 
 // AgentProviderComposerConfigOptionValue defines model for AgentProviderComposerConfigOptionValue.
 type AgentProviderComposerConfigOptionValue struct {
-	Description *string `json:"description,omitempty"`
-	Id          string  `json:"id"`
-	Label       string  `json:"label"`
+	// ConsumptionMultiplier Provider-reported credit consumption multiplier without the display suffix. Runtime adapters normalize provider wire data into this typed field; clients must not infer it from description.
+	ConsumptionMultiplier *string `json:"consumptionMultiplier,omitempty"`
+	Description           *string `json:"description,omitempty"`
+	Id                    string  `json:"id"`
+	Label                 string  `json:"label"`
 
 	// Requested True when the entry mirrors the requested/current selection instead of the provider catalog (warm-catalog append of the requested model, selected-model bootstrap echo). Clients keep such entries selectable but must not treat them as proof the provider can run the model; create validation runs against the raw catalog only.
 	Requested          *bool  `json:"requested,omitempty"`

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -11946,6 +11946,12 @@ components:
           minLength: 1
         description:
           type: string
+        consumptionMultiplier:
+          type: string
+          description: >-
+            Provider-reported credit consumption multiplier without the
+            display suffix. Runtime adapters normalize provider wire data into
+            this typed field; clients must not infer it from description.
         supportsImageInput:
           type: boolean
         requested:

--- a/services/tuttid/service/agent/composer_config_option_values.go
+++ b/services/tuttid/service/agent/composer_config_option_values.go
@@ -32,6 +32,9 @@ func composerConfigOptionValuesToRuntimeModelOptions(options []ComposerConfigOpt
 		if description := strings.TrimSpace(option.Description); description != "" {
 			entry["description"] = description
 		}
+		if consumptionMultiplier := strings.TrimSpace(option.ConsumptionMultiplier); consumptionMultiplier != "" {
+			entry["consumptionMultiplier"] = consumptionMultiplier
+		}
 		if option.SupportsImageInput != nil {
 			entry["supportsImageInput"] = *option.SupportsImageInput
 		}

--- a/services/tuttid/service/agent/composer_live_model_discovery.go
+++ b/services/tuttid/service/agent/composer_live_model_discovery.go
@@ -727,6 +727,7 @@ func normalizeLiveComposerModelOptions(options []ComposerConfigOptionValue) []Co
 			Label:                      label,
 			Value:                      value,
 			Description:                strings.TrimSpace(option.Description),
+			ConsumptionMultiplier:      strings.TrimSpace(option.ConsumptionMultiplier),
 			SupportsImageInput:         option.SupportsImageInput,
 			SupportsReasoningEffort:    option.SupportsReasoningEffort,
 			ReasoningEffort:            strings.TrimSpace(option.ReasoningEffort),

--- a/services/tuttid/service/agent/composer_live_model_discovery_test.go
+++ b/services/tuttid/service/agent/composer_live_model_discovery_test.go
@@ -464,6 +464,28 @@ func TestMergeLiveModelsIntoComposerOptionsKeepsModelDescriptionInRuntimeContext
 	}
 }
 
+func TestMergeLiveModelsIntoComposerOptionsKeepsConsumptionMultiplierInRuntimeContext(t *testing.T) {
+	merged := mergeLiveModelsIntoComposerOptions(ComposerOptions{
+		Provider:          "acp:codebuddy",
+		EffectiveSettings: ComposerSettings{Model: "glm-5.2"},
+		RuntimeContext:    map[string]any{},
+	}, []ComposerConfigOptionValue{
+		{ID: "glm-5.2", Label: "GLM-5.2", Value: "glm-5.2", ConsumptionMultiplier: "0.79"},
+	})
+
+	configOptions, ok := merged.RuntimeContext["configOptions"].([]map[string]any)
+	if !ok || len(configOptions) == 0 || configOptions[0]["id"] != "model" {
+		t.Fatalf("configOptions = %#v, want model option", merged.RuntimeContext["configOptions"])
+	}
+	options, ok := configOptions[0]["options"].([]map[string]any)
+	if !ok || len(options) != 1 {
+		t.Fatalf("model options = %#v, want 1 entry", configOptions[0]["options"])
+	}
+	if got := options[0]["consumptionMultiplier"]; got != "0.79" {
+		t.Fatalf("consumptionMultiplier = %#v, want 0.79", got)
+	}
+}
+
 func TestMergeLiveModelsIntoComposerOptionsKeepsSupportsImageInput(t *testing.T) {
 	imageSupported := true
 	imageUnsupported := false

--- a/services/tuttid/service/agent/composer_options.go
+++ b/services/tuttid/service/agent/composer_options.go
@@ -48,6 +48,7 @@ type ComposerConfigOption struct {
 
 type ComposerConfigOptionValue struct {
 	Description                string
+	ConsumptionMultiplier      string
 	ID                         string
 	Label                      string
 	Value                      string

--- a/services/tuttid/service/agent/composer_runtime_model_options.go
+++ b/services/tuttid/service/agent/composer_runtime_model_options.go
@@ -133,6 +133,7 @@ func composerModelOptionsFromCanonicalCatalog(models []modelcatalog.ModelOption)
 			Label:                      label,
 			Value:                      value,
 			Description:                strings.TrimSpace(model.Description),
+			ConsumptionMultiplier:      strings.TrimSpace(model.ConsumptionMultiplier),
 			SupportsImageInput:         model.SupportsImageInput,
 			SupportsReasoningEffort:    supportsReasoningEffort,
 			ReasoningEffort:            strings.TrimSpace(model.DefaultReasoningEffort),
@@ -167,10 +168,11 @@ func composerConfigOptionValuesFromAny(input any) []ComposerConfigOptionValue {
 			id = value
 		}
 		options = append(options, ComposerConfigOptionValue{
-			ID:          id,
-			Label:       label,
-			Value:       value,
-			Description: strings.TrimSpace(stringFromAny(optionMap["description"])),
+			ID:                    id,
+			Label:                 label,
+			Value:                 value,
+			Description:           strings.TrimSpace(stringFromAny(optionMap["description"])),
+			ConsumptionMultiplier: strings.TrimSpace(stringFromAny(optionMap["consumptionMultiplier"])),
 		})
 	}
 	return options

--- a/services/tuttid/service/agentextension/manager.go
+++ b/services/tuttid/service/agentextension/manager.go
@@ -344,6 +344,7 @@ func (m *Manager) runtimeBinding(installation Installation, command []string, ve
 	return RuntimeBinding{
 		Installation: installation, Command: command, Version: version, Source: source,
 		ToolAliases: aliases, AuthenticationMethods: authenticationMethods, ModelConfigOptionID: modelConfigOptionID,
+		ModelDescriptionFormat:   composerProfile.ModelDescriptionMetadataFormat(),
 		PermissionConfigOptionID: permissionConfigOptionID, ReasoningConfigOptionID: reasoningConfigOptionID,
 		PermissionModes: permissionModes, AutomaticPermissionDecisions: composerProfile.AutomaticPermissionDecisions(),
 		PlanModeRuntimeID:            planModeRuntimeID,

--- a/services/tuttid/service/agentextension/manager_test.go
+++ b/services/tuttid/service/agentextension/manager_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
 	"github.com/tutti-os/tutti/packages/agent/daemon/runtimecmd"
 	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
@@ -1031,17 +1032,23 @@ func TestComposerProfileACPConfigOptionIDs(t *testing.T) {
 	t.Run("canonical", func(t *testing.T) {
 		profile := ComposerProfile{SchemaVersion: "tutti.agent.composer.v1"}
 		profile.ConfigOptions = &struct {
-			Model      ComposerConfigOptionReference `json:"model"`
-			Permission ComposerConfigOptionReference `json:"permission"`
-			Reasoning  ComposerConfigOptionReference `json:"reasoning"`
+			Model      ComposerModelConfigOptionReference `json:"model"`
+			Permission ComposerConfigOptionReference      `json:"permission"`
+			Reasoning  ComposerConfigOptionReference      `json:"reasoning"`
 		}{
-			Model:      ComposerConfigOptionReference{ACPOptionID: "model-choice"},
+			Model: ComposerModelConfigOptionReference{
+				ACPOptionID:               "model-choice",
+				DescriptionMetadataFormat: agentruntime.StandardACPModelDescriptionMetadataFormatCreditConsumptionMultiplierV1,
+			},
 			Permission: ComposerConfigOptionReference{ACPOptionID: "approval-mode"},
 			Reasoning:  ComposerConfigOptionReference{ACPOptionID: "thought-level"},
 		}
 		model, permission, reasoning := profile.ACPConfigOptionIDs()
 		if model != "model-choice" || permission != "approval-mode" || reasoning != "thought-level" {
 			t.Fatalf("config option ids = %q, %q, %q", model, permission, reasoning)
+		}
+		if format := profile.ModelDescriptionMetadataFormat(); format != agentruntime.StandardACPModelDescriptionMetadataFormatCreditConsumptionMultiplierV1 {
+			t.Fatalf("model description metadata format = %q", format)
 		}
 	})
 
@@ -1153,6 +1160,14 @@ func TestValidateComposerProfileRejectsInvalidSignedCommandDeclarations(t *testi
 		{
 			name: "unsupported effect",
 			raw:  `{"schemaVersion":"tutti.agent.composer.v1","slashCommands":{"commands":[{"name":"status","effect":"runArbitraryCode"}]}}`,
+		},
+		{
+			name: "unsupported model description metadata format",
+			raw:  `{"schemaVersion":"tutti.agent.composer.v1","configOptions":{"model":{"acpOptionId":"model","descriptionMetadataFormat":"extension-supplied-parser"}}}`,
+		},
+		{
+			name: "model description metadata format without model option",
+			raw:  `{"schemaVersion":"tutti.agent.composer.v1","configOptions":{"model":{"descriptionMetadataFormat":"credit-consumption-multiplier-v1"}}}`,
 		},
 		{
 			name: "unknown launch placeholder",

--- a/services/tuttid/service/agentextension/profiles.go
+++ b/services/tuttid/service/agentextension/profiles.go
@@ -12,6 +12,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
 	runtimeprep "github.com/tutti-os/tutti/packages/agent/runtimeprep"
 )
 
@@ -20,9 +21,9 @@ type ComposerProfile struct {
 	Model         json.RawMessage `json:"model"`
 	Permission    json.RawMessage `json:"permission"`
 	ConfigOptions *struct {
-		Model      ComposerConfigOptionReference `json:"model"`
-		Permission ComposerConfigOptionReference `json:"permission"`
-		Reasoning  ComposerConfigOptionReference `json:"reasoning"`
+		Model      ComposerModelConfigOptionReference `json:"model"`
+		Permission ComposerConfigOptionReference      `json:"permission"`
+		Reasoning  ComposerConfigOptionReference      `json:"reasoning"`
 	} `json:"configOptions,omitempty"`
 	PermissionModes []ComposerPermissionMode `json:"permissionModes"`
 	LaunchSettings  *struct {
@@ -128,6 +129,11 @@ type ComposerConfigOptionReference struct {
 	ACPOptionID string `json:"acpOptionId"`
 }
 
+type ComposerModelConfigOptionReference struct {
+	ACPOptionID               string `json:"acpOptionId"`
+	DescriptionMetadataFormat string `json:"descriptionMetadataFormat,omitempty"`
+}
+
 func (profile ComposerProfile) ACPConfigOptionIDs() (model string, permission string, reasoning string) {
 	if strings.TrimSpace(profile.SchemaVersion) == "" {
 		return "", "", ""
@@ -147,6 +153,13 @@ func (profile ComposerProfile) ACPConfigOptionIDs() (model string, permission st
 		permission = "mode"
 	}
 	return model, permission, "reasoning_effort"
+}
+
+func (profile ComposerProfile) ModelDescriptionMetadataFormat() string {
+	if profile.ConfigOptions == nil {
+		return ""
+	}
+	return strings.TrimSpace(profile.ConfigOptions.Model.DescriptionMetadataFormat)
 }
 
 type CapabilitiesProfile struct {
@@ -383,14 +396,19 @@ func validateComposerProfile(profile ComposerProfile) error {
 		}
 	}
 	if profile.ConfigOptions != nil {
-		for _, option := range []ComposerConfigOptionReference{
-			profile.ConfigOptions.Model,
-			profile.ConfigOptions.Permission,
-			profile.ConfigOptions.Reasoning,
+		for _, id := range []string{
+			profile.ConfigOptions.Model.ACPOptionID,
+			profile.ConfigOptions.Permission.ACPOptionID,
+			profile.ConfigOptions.Reasoning.ACPOptionID,
 		} {
-			if id := strings.TrimSpace(option.ACPOptionID); id != "" && !composerConfigOptionID.MatchString(id) {
+			if optionID := strings.TrimSpace(id); optionID != "" && !composerConfigOptionID.MatchString(optionID) {
 				return errors.New("composer ACP config option id is unsupported")
 			}
+		}
+		if metadataFormat := profile.ModelDescriptionMetadataFormat(); metadataFormat != "" && metadataFormat != agentruntime.StandardACPModelDescriptionMetadataFormatCreditConsumptionMultiplierV1 {
+			return errors.New("composer model description metadata format is unsupported")
+		} else if metadataFormat != "" && strings.TrimSpace(profile.ConfigOptions.Model.ACPOptionID) == "" {
+			return errors.New("composer model description metadata format requires a model ACP config option")
 		}
 	}
 	for _, mode := range profile.PermissionModes {

--- a/services/tuttid/service/agentextension/runtime_resolver.go
+++ b/services/tuttid/service/agentextension/runtime_resolver.go
@@ -26,6 +26,7 @@ type RuntimeBinding struct {
 	ToolAliases                  map[string]string
 	AuthenticationMethods        map[string]AuthenticationMethodProfile
 	ModelConfigOptionID          string
+	ModelDescriptionFormat       string
 	PermissionConfigOptionID     string
 	ReasoningConfigOptionID      string
 	PermissionModes              map[string]string
@@ -84,6 +85,7 @@ func runtimeAdapterConfig(binding RuntimeBinding, agentTargetID string) agentrun
 		AuthMessage:                  binding.Installation.AuthMessage,
 		ToolAliases:                  binding.ToolAliases,
 		ModelConfigOptionID:          binding.ModelConfigOptionID,
+		ModelDescriptionFormat:       binding.ModelDescriptionFormat,
 		PermissionConfigOptionID:     binding.PermissionConfigOptionID,
 		ReasoningConfigOptionID:      binding.ReasoningConfigOptionID,
 		RestrictConfigOptions:        true,

--- a/services/tuttid/service/agentextension/setup_test.go
+++ b/services/tuttid/service/agentextension/setup_test.go
@@ -1054,6 +1054,16 @@ func TestProbeRuntimeAppliesSignedTerminalSetupPresentation(t *testing.T) {
 	}
 }
 
+func TestRuntimeAdapterConfigProjectsModelDescriptionMetadataFormat(t *testing.T) {
+	binding := RuntimeBinding{
+		ModelDescriptionFormat: agentruntime.StandardACPModelDescriptionMetadataFormatCreditConsumptionMultiplierV1,
+	}
+	config := runtimeAdapterConfig(binding, "")
+	if config.ModelDescriptionFormat != agentruntime.StandardACPModelDescriptionMetadataFormatCreditConsumptionMultiplierV1 {
+		t.Fatalf("model description metadata format = %q", config.ModelDescriptionFormat)
+	}
+}
+
 func TestAgentTargetSetupFeedsRuntimeAuthFailureBackIntoDetectionAndAllowsRelogin(t *testing.T) {
 	binDir := t.TempDir()
 	writeVersionExecutable(t, filepath.Join(binDir, "gemini"), "0.50.0")


### PR DESCRIPTION
## 背景

CodeBuddy 的 ACP 模型说明会返回类似 `x0.79 credits` 的消耗倍率。旧实现虽然在 AgentGUI 前已经转成 typed 字段，但仍由 Tutti 无条件解释 Provider 文案，语义所有权不正确。

本次修正把“这种描述代表消耗倍率”的声明移回 CodeBuddy 扩展；Tutti 只在扩展明确声明受支持格式时执行通用标准 ACP 规范化。

配套扩展 PR：[tutti-os/agent-extension-codebuddy#10](https://github.com/tutti-os/agent-extension-codebuddy/pull/10)

## 改动

- 扩展 Composer Profile 支持封闭声明 `descriptionMetadataFormat: "credit-consumption-multiplier-v1"`
- Agent Extension 安装、加载和运行时解析链验证并传递该声明，未知格式失败关闭
- 标准 ACP adapter 仅在声明存在时提取独立的 `xN credits` / `Nx credits` 描述片段，规范化为 typed `consumptionMultiplier`
- profiles 未声明时完整保留模型描述，不按 Provider 名称分支
- typed 字段贯穿模型目录、tuttid OpenAPI/生成客户端、activity adapter 和 AgentGUI
- AgentGUI 在模型悬浮提示中展示消耗倍率，不解析 Provider 文案
- 修复 live model 去重重建时遗漏 `consumptionMultiplier` 的问题，并增加回归覆盖

## 架构边界

- CodeBuddy 扩展拥有 Provider 私有描述语义和版本化声明
- Tutti 的 Agent Extension 层只验证受支持的封闭格式，不接受脚本、正则或扩展可执行归一化逻辑
- 标准 ACP adapter 负责 Provider wire 到 Provider-neutral typed contract 的转换
- AgentGUI 只消费 typed 字段，不感知 CodeBuddy、Credits 文案或成本解析规则
- 本改动不改变 Session、Turn、Goal 或 runtime-operation 生命周期，因此不进入 Agent Host lifecycle core

## AgentGUI 审查通道

| 通道 | 结论 | 证据 |
| --- | --- | --- |
| 架构 | 通过 | 扩展声明 → 标准 ACP adapter → model catalog/OpenAPI → activity adapter → AgentGUI；Tutti 生产代码无 CodeBuddy/provider 分支 |
| 性能 | 不适用 | 仅为已存在的模型菜单行增加静态可选元数据和按需 Tooltip 文案，无轮询、滚动、时间线或高频 Engine 订阅 |
| 消费者 | 通过 | OpenAPI 先行并重新生成 Go/TS contract；字段为可选 additive contract，Desktop/AgentGUI 和 activity adapter 已覆盖，旧 daemon/外部消费者可继续省略 |

## 验证

- `pnpm check:changed -- --base upstream/main`：25/25 lane 通过（提交格式化后最终重跑）
- `pnpm check:changed -- --base upstream/main --push-ready`：71/72 lane 通过
  - 唯一失败的聚合 Go lane 包含主线既有 `TestResolveProviderRuntimeUsesManagedClaudeCodePointer`，本机会固定发现 `/opt/homebrew/bin/claude`
  - 本 PR 对 `services/tuttid/service/agentstatus` 和 `services/tuttid/service/workspace` 相对 `upstream/main` 均无差异
  - 同 lane 的 Workspace App 临时端口测试单独重跑通过
- `services/tuttid/service/agent` 全量 Go 测试通过
- AgentGUI 定向测试 34/34 通过
- CodeBuddy 扩展 `pnpm check` 通过：Release 6/6、Account Usage Helper 9/9
- 隔离本地 E2E 验证 GLM-5.2 在 runtime-context 和 ModelConfig 投影中均返回 `consumptionMultiplier: "0.79"`，原描述不再泄漏到 UI contract

## 发布门禁

本 PR 依赖 CodeBuddy 扩展 PR #10 合并并按现有流程发布、签名 `2.0.5`。Tutti 源码合并只提供通用消费能力，不代表普通安装路径已经拿到声明该格式的新扩展包。

## 文档影响

已更新 Agent Extension、Agent Activity 和扩展包设计文档，记录语义所有权、数据流、失败关闭策略和兼容边界；未发现额外 troubleshooting 文档需求。
