### PR TITLE
fix(agent-gui): preserve images and retry failed loads

### DIFF
--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
@@ -12,6 +12,8 @@ import { enAgentGuiUsageStatus } from "./en.agentGuiUsageStatus.ts";
 
 export const enAgentGui = {
   imageDownloaded: "Image downloaded",
+  imageLoadFailed: "Image failed to load",
+  retryImage: "Retry",
   initialPlaceholder: "Type @ to reference sessions, files, tasks, and apps",
   followupPlaceholder: "Request follow-up changes from {{provider}}",
   installRequiredPlaceholder: "Connect {{provider}} to send messages",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
@@ -11,6 +11,8 @@ import { zhCNTuttiModePlan } from "./zh-CN.tuttiModePlan.ts";
 
 export const zhCNAgentGui = {
   imageDownloaded: "图片已下载",
+  imageLoadFailed: "图片加载失败",
+  retryImage: "重试",
   codexSaverModeLabel: "Codex 省额度模式",
   codexSaverModeDescription:
     "主模型保持不变；合适的独立子任务改用 Luna Max，按当前额度口径约为 Sol High 的 1/10。实际效果与速度因任务而异。",

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageImages.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageImages.tsx
@@ -1,12 +1,29 @@
-import { useEffect, useMemo, useState, type JSX } from "react";
-import { LoaderCircle } from "lucide-react";
-import { useOptionalAgentGUIRuntime } from "../../../agentActivityRuntime";
+import { Button } from "@tutti-os/ui-system";
+import {
+  AlertCircle,
+  LoaderCircle,
+  RotateCcw,
+  type LucideIcon
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useState, type JSX } from "react";
+import {
+  useOptionalAgentGUIRuntime,
+  type AgentGUIRuntime
+} from "../../../agentActivityRuntime";
 import { ZoomableImage } from "../../../app/renderer/components/ZoomableImage";
+import { useTranslation } from "../../../i18n/index";
 import styles from "../../../agent-gui/agentGuiNode/AgentGUIConversation.styles";
 import type {
   AgentMessageContentVM,
   AgentMessageImageVM
 } from "../contracts/agentMessageRowVM";
+
+type ImageFailureKind = "load" | "read" | "unavailable";
+type ImageFailureReporter = (
+  image: AgentMessageImageVM,
+  kind: ImageFailureKind,
+  attempt: number
+) => void;
 
 export function AgentUserImageGrid({
   message
@@ -15,7 +32,16 @@ export function AgentUserImageGrid({
 }): JSX.Element {
   "use memo";
   const images = message.images ?? [];
-  const { loadingIds, sources } = useAgentMessageImageSources(images);
+  const runtime = useOptionalAgentGUIRuntime();
+  const reportFailure = useCallback(
+    (image: AgentMessageImageVM, kind: ImageFailureKind, attempt: number) => {
+      reportImageLoadFailure(runtime, image, kind, attempt);
+    },
+    [runtime]
+  );
+  const { failedIds, loadingIds, retryCounts, sources, markFailed, retry } =
+    useAgentMessageImageSources(images, reportFailure);
+  const { t } = useTranslation();
   const columnCount = Math.min(Math.max(images.length, 1), 4);
   const thumbnailWidth = images.length === 1 ? "160px" : "80px";
   return (
@@ -27,16 +53,30 @@ export function AgentUserImageGrid({
     >
       {images.map((image) => {
         const src = sources.get(image.id) ?? imageSourceUrl(image);
+        const failed = failedIds.has(image.id);
         const loading = !src && loadingIds.has(image.id);
+        const attempt = retryCounts.get(image.id) ?? 0;
         return (
           <div key={image.id} className={styles.userImageThumbnail}>
-            {src ? (
+            {failed ? (
+              <ImageLoadFailurePlaceholder
+                label={t("agentHost.agentGui.imageLoadFailed")}
+                retryLabel={t("agentHost.agentGui.retryImage")}
+                icon={AlertCircle}
+                onRetry={() => retry(image.id)}
+              />
+            ) : src ? (
               <ZoomableImage
+                key={`${image.id}:${attempt}:${src}`}
                 src={src}
                 alt={image.name?.trim() || "image"}
                 className="block max-h-20 w-full rounded-[7px] object-contain"
                 draggable={false}
                 downloadName={image.name?.trim() || "image.png"}
+                onError={() => {
+                  markFailed(image.id);
+                  reportFailure(image, "load", attempt);
+                }}
               />
             ) : loading ? (
               <div
@@ -50,7 +90,12 @@ export function AgentUserImageGrid({
                 />
               </div>
             ) : (
-              <div className="h-20 w-full animate-pulse bg-[color-mix(in_srgb,var(--text-primary)_8%,transparent)]" />
+              <ImageLoadFailurePlaceholder
+                label={t("agentHost.agentGui.imageLoadFailed")}
+                retryLabel={t("agentHost.agentGui.retryImage")}
+                icon={AlertCircle}
+                onRetry={() => retry(image.id)}
+              />
             )}
           </div>
         );
@@ -59,78 +104,242 @@ export function AgentUserImageGrid({
   );
 }
 
-function useAgentMessageImageSources(images: readonly AgentMessageImageVM[]): {
+function useAgentMessageImageSources(
+  images: readonly AgentMessageImageVM[],
+  reportFailure: ImageFailureReporter
+): {
+  failedIds: ReadonlySet<string>;
   loadingIds: ReadonlySet<string>;
+  retryCounts: ReadonlyMap<string, number>;
   sources: ReadonlyMap<string, string>;
+  markFailed: (imageId: string) => void;
+  retry: (imageId: string) => void;
 } {
   const runtime = useOptionalAgentGUIRuntime();
+  const [failedIds, setFailedIds] = useState<Set<string>>(() => new Set());
   const [sources, setSources] = useState<Map<string, string>>(() => new Map());
   const [loadingIds, setLoadingIds] = useState<Set<string>>(() => new Set());
+  const [retryCounts, setRetryCounts] = useState<Map<string, number>>(
+    () => new Map()
+  );
+  const markFailed = useCallback((imageId: string): void => {
+    setFailedIds((current) => {
+      if (current.has(imageId)) return current;
+      const next = new Set(current);
+      next.add(imageId);
+      return next;
+    });
+    setLoadingIds((current) => {
+      if (!current.has(imageId)) return current;
+      const next = new Set(current);
+      next.delete(imageId);
+      return next;
+    });
+  }, []);
+  const retry = useCallback((imageId: string): void => {
+    setFailedIds((current) => {
+      if (!current.has(imageId)) return current;
+      const next = new Set(current);
+      next.delete(imageId);
+      return next;
+    });
+    setRetryCounts((current) => {
+      const next = new Map(current);
+      next.set(imageId, (next.get(imageId) ?? 0) + 1);
+      return next;
+    });
+  }, []);
   const missingImages = useMemo(
     () =>
       images.filter(
         (image) =>
           !imageSourceUrl(image) &&
           !sources.has(image.id) &&
+          !failedIds.has(image.id) &&
           image.workspaceId &&
           image.agentSessionId &&
+          (image.attachmentId
+            ? runtime?.readSessionAttachment
+            : runtime?.readPromptAsset) &&
           (image.attachmentId || image.path)
       ),
-    [images, sources]
+    [failedIds, images, runtime, sources]
+  );
+  const unavailableImages = useMemo(
+    () =>
+      images.filter(
+        (image) =>
+          !imageSourceUrl(image) &&
+          !sources.has(image.id) &&
+          !failedIds.has(image.id) &&
+          (!image.workspaceId ||
+            !image.agentSessionId ||
+            !(image.attachmentId || image.path) ||
+            (image.attachmentId
+              ? !runtime?.readSessionAttachment
+              : !runtime?.readPromptAsset))
+      ),
+    [failedIds, images, runtime, sources]
   );
 
   useEffect(() => {
-    if (
-      (!runtime?.readSessionAttachment && !runtime?.readPromptAsset) ||
-      missingImages.length === 0
-    ) {
-      return;
-    }
     let canceled = false;
-    for (const image of missingImages) {
-      const readImage = image.attachmentId
-        ? runtime.readSessionAttachment?.({
-            workspaceId: image.workspaceId ?? "",
-            agentSessionId: image.agentSessionId,
-            attachmentId: image.attachmentId ?? ""
+    if (
+      runtime &&
+      (runtime.readSessionAttachment || runtime.readPromptAsset) &&
+      missingImages.length > 0
+    ) {
+      for (const image of missingImages) {
+        const readImage = image.attachmentId
+          ? runtime.readSessionAttachment?.({
+              workspaceId: image.workspaceId ?? "",
+              agentSessionId: image.agentSessionId,
+              attachmentId: image.attachmentId ?? ""
+            })
+          : runtime.readPromptAsset?.({
+              workspaceId: image.workspaceId ?? "",
+              agentSessionId: image.agentSessionId,
+              mimeType: image.mimeType,
+              name: image.name,
+              path: image.path
+            });
+        if (!readImage) continue;
+        setLoadingIds((current) => new Set(current).add(image.id));
+        const attempt = retryCounts.get(image.id) ?? 0;
+        void readImage
+          .then((attachment) => {
+            if (canceled) return;
+            setSources((current) => {
+              const next = new Map(current);
+              next.set(
+                image.id,
+                `data:${attachment.mimeType};base64,${attachment.data}`
+              );
+              return next;
+            });
           })
-        : runtime.readPromptAsset?.({
-            workspaceId: image.workspaceId ?? "",
-            agentSessionId: image.agentSessionId,
-            mimeType: image.mimeType,
-            name: image.name,
-            path: image.path
+          .catch(() => {
+            if (canceled) return;
+            markFailed(image.id);
+            reportFailure(image, "read", attempt);
+          })
+          .finally(() => {
+            if (canceled) return;
+            setLoadingIds((current) => {
+              const next = new Set(current);
+              next.delete(image.id);
+              return next;
+            });
           });
-      if (!readImage) continue;
-      setLoadingIds((current) => new Set(current).add(image.id));
-      void readImage
-        .then((attachment) => {
-          if (canceled) return;
-          setSources((current) => {
-            const next = new Map(current);
-            next.set(
-              image.id,
-              `data:${attachment.mimeType};base64,${attachment.data}`
-            );
-            return next;
-          });
-        })
-        .catch(() => {})
-        .finally(() => {
-          if (canceled) return;
-          setLoadingIds((current) => {
-            const next = new Set(current);
-            next.delete(image.id);
-            return next;
-          });
-        });
+      }
+    }
+    for (const image of unavailableImages) {
+      const attempt = retryCounts.get(image.id) ?? 0;
+      markFailed(image.id);
+      reportFailure(image, "unavailable", attempt);
     }
     return () => {
       canceled = true;
     };
-  }, [missingImages, runtime]);
+  }, [
+    markFailed,
+    missingImages,
+    reportFailure,
+    retryCounts,
+    runtime,
+    unavailableImages
+  ]);
 
-  return { loadingIds, sources };
+  return {
+    failedIds,
+    loadingIds,
+    retryCounts,
+    sources,
+    markFailed,
+    retry
+  };
+}
+
+function ImageLoadFailurePlaceholder({
+  icon: Icon,
+  label,
+  onRetry,
+  retryLabel
+}: {
+  icon: LucideIcon;
+  label: string;
+  onRetry: () => void;
+  retryLabel: string;
+}): JSX.Element {
+  return (
+    <div
+      className="flex h-20 w-full flex-col items-center justify-center gap-1 bg-[var(--transparency-block)] px-1 text-[var(--text-secondary)]"
+      data-testid="agent-gui-message-image-failed"
+      role="status"
+      aria-label={label}
+    >
+      <Icon aria-hidden="true" className="size-4" />
+      <span className="max-w-full truncate text-xs" title={label}>
+        {label}
+      </span>
+      <Button type="button" variant="ghost" size="xs" onClick={onRetry}>
+        <RotateCcw aria-hidden="true" />
+        {retryLabel}
+      </Button>
+    </div>
+  );
+}
+
+function reportImageLoadFailure(
+  runtime: AgentGUIRuntime | null,
+  image: AgentMessageImageVM,
+  kind: ImageFailureKind,
+  attempt: number
+): void {
+  const reportDiagnostic = runtime?.reportDiagnostic;
+  if (!reportDiagnostic) return;
+  try {
+    void Promise.resolve(
+      reportDiagnostic.call(runtime, {
+        event: "agent.gui.conversation.image_load_failed",
+        level: "warn",
+        source: "agent-gui",
+        workspaceId: image.workspaceId ?? null,
+        details: {
+          imageId: image.id,
+          attempt,
+          failureKind: kind,
+          hasUrl: Boolean(image.url?.trim()),
+          hasData: Boolean(image.data?.trim()),
+          hasAttachmentId: Boolean(image.attachmentId?.trim()),
+          hasPath: Boolean(image.path?.trim())
+        }
+      })
+    ).catch((error: unknown) => {
+      reportImageLoadDiagnosticFailure(image, error);
+    });
+  } catch (error) {
+    reportImageLoadDiagnosticFailure(image, error);
+  }
+}
+
+function reportImageLoadDiagnosticFailure(
+  image: AgentMessageImageVM,
+  error: unknown
+): void {
+  console.warn(
+    "[agent-gui]",
+    JSON.stringify({
+      event: "agent.gui.conversation.image_diagnostic_failed",
+      level: "warn",
+      source: "agent-gui",
+      workspaceId: image.workspaceId ?? null,
+      details: {
+        diagnosticEvent: "agent.gui.conversation.image_load_failed",
+        error: error instanceof Error ? error.message : String(error)
+      }
+    })
+  );
 }
 
 function imageDataUrl(image: AgentMessageImageVM): string | null {

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
@@ -735,6 +735,58 @@ describe("AgentTranscriptItemView render stability", () => {
     delete (window as { agentGUIRuntime?: unknown }).agentGUIRuntime;
   });
 
+  it("shows a failure placeholder and retries a remote image with the same URL", async () => {
+    const signedUrl = "https://objects.example.test/signed/screen.png";
+
+    render(
+      <AgentMessageBlock
+        workspaceRoot="/workspace/demo"
+        basePath="/workspace/demo"
+        row={userMessageRow({
+          kind: "message-content",
+          id: "user-images-url-failed",
+          turnId: "turn-1",
+          body: "",
+          contentKind: "image-grid",
+          images: [
+            {
+              id: "remote-image-failed",
+              workspaceId: "room-1",
+              agentSessionId: "session-1",
+              mimeType: "image/png",
+              name: "screen.png",
+              url: signedUrl
+            }
+          ],
+          occurredAtUnixMs: 1
+        })}
+        thinkingLabel="Thought process"
+      />
+    );
+
+    const image = screen.getByRole("img", { name: "screen.png" });
+    fireEvent.error(image);
+
+    expect(
+      await screen.findByTestId("agent-gui-message-image-failed")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "agentHost.agentGui.retryImage" })
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "agentHost.agentGui.retryImage" })
+    );
+    const retriedImage = await screen.findByRole("img", {
+      name: "screen.png"
+    });
+    expect(retriedImage).not.toBe(image);
+    expect(retriedImage).toHaveAttribute("src", signedUrl);
+    fireEvent.load(retriedImage);
+
+    expect(screen.queryByTestId("agent-gui-message-image-failed")).toBeNull();
+  });
+
   it("shows a loading spinner while a user prompt image is being read", async () => {
     const readController: {
       resolve: (value: {

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts
@@ -2000,6 +2000,71 @@ describe("projectAgentConversationVM", () => {
     });
   });
 
+  it("keeps a signed image URL when its MIME type is absent", () => {
+    const conversation = projectAgentConversationVM(
+      detailViewModel({
+        session: {
+          ...detailViewModel().session,
+          workspaceId: "room-1"
+        },
+        turns: [
+          {
+            id: "turn-1",
+            userMessage: null,
+            userMessages: [
+              {
+                id: "user-1",
+                body: "",
+                sourceTimelineItems: [
+                  {
+                    id: 1,
+                    agentSessionId: "session-1",
+                    eventId: "event-1",
+                    actorType: "user",
+                    actorId: "user",
+                    itemType: "message",
+                    role: "user",
+                    payload: {
+                      content: [
+                        {
+                          type: "image",
+                          url: "https://objects.example.test/signed/screen.png"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            agentMessages: [],
+            toolCalls: [],
+            toolCallCount: 0,
+            hasFailedToolCall: false,
+            agentItems: []
+          }
+        ],
+        showProcessingIndicator: false
+      })
+    );
+
+    const userRow = conversation.rows.find(
+      (
+        row
+      ): row is Extract<
+        (typeof conversation.rows)[number],
+        { kind: "message" }
+      > => row.kind === "message" && row.speaker === "user"
+    );
+
+    expect(userRow?.messages.map((message) => message.contentKind)).toEqual([
+      "image-grid"
+    ]);
+    expect(userRow?.messages[0]?.images?.[0]).toMatchObject({
+      url: "https://objects.example.test/signed/screen.png",
+      mimeType: ""
+    });
+  });
+
   it("replaces rich user prompt text blocks with displayPrompt while preserving images", () => {
     const conversation = projectAgentConversationVM(
       detailViewModel({

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationUserProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationUserProjection.ts
@@ -212,7 +212,6 @@ function userPromptContentBlocks(
     if (block.type !== "image") return [];
     const mimeType =
       typeof block.mimeType === "string" ? block.mimeType.trim() : "";
-    if (!mimeType) return [];
     return [
       {
         type: "image",

--- a/packages/agent/gui/shared/workspaceAgentTimelineMessageHelpers.ts
+++ b/packages/agent/gui/shared/workspaceAgentTimelineMessageHelpers.ts
@@ -124,7 +124,7 @@ export function userMessageProjectionKey(
   if (normalizedBody) {
     return `text:${normalizedBody}`;
   }
-  if (!hasRenderableUserPromptContent(item.payload?.content)) {
+  if (!hasUserPromptContent(item.payload?.content)) {
     return null;
   }
   const clientSubmitId = stringRecordValue(item.payload, "clientSubmitId");
@@ -165,7 +165,7 @@ export function isRecentDuplicateUserMessage(
   return false;
 }
 
-function hasRenderableUserPromptContent(content: unknown): boolean {
+function hasUserPromptContent(content: unknown): boolean {
   if (!Array.isArray(content)) {
     return false;
   }
@@ -181,11 +181,10 @@ function hasRenderableUserPromptContent(content: unknown): boolean {
     if (block.type === "text") {
       return typeof block.text === "string" && block.text.trim().length > 0;
     }
-    return (
-      block.type === "image" &&
-      typeof block.mimeType === "string" &&
-      block.mimeType.trim().length > 0
-    );
+    // Keep the image block even when MIME/source metadata is incomplete. The
+    // renderer owns load failure presentation and must be able to show a
+    // retryable placeholder for an expired or malformed external URL.
+    return block.type === "image";
   });
 }
 


### PR DESCRIPTION
## Summary

- Preserve user image content when MIME metadata is missing, including image-only prompts.
- Show a localized load-failure placeholder and retry direct signed URLs.
- Record only safe image failure metadata; URLs, data, asset IDs, and attachment contents are not changed or logged.

## Why

A signed URL can expire or fail intermittently. Previously, image blocks without MIME metadata could be dropped before rendering, so the UI had no image element and could only show a blank/empty state.

## Scope

This keeps the existing signedURL-as-external-link decision. It does not introduce assetID lookup or URL refresh logic. The retry remounts the same source URL.

## Verification

- `pnpm exec vitest run shared/agentConversation/projection/agentConversationProjection.spec.ts shared/agentConversation/components/AgentTranscriptItemView.spec.tsx` — 2 files, 73 tests passed
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm check:i18n`
- staged AgentGUI boundary/degradation/runtime-image checks
- `pnpm check:changed -- --push-ready` — 13 lanes passed