### PR TITLE
fix(agent): stop fenced goals during restart recovery

### DIFF
--- a/packages/agent/daemon/hostadapter/runtime.go
+++ b/packages/agent/daemon/hostadapter/runtime.go
@@ -589,6 +589,9 @@ func mapRuntimeError(err error) error {
 	if errors.Is(err, agentruntime.ErrSessionDisconnected) {
 		return errors.Join(host.ErrRuntimeSessionDisconnected, err)
 	}
+	if errors.Is(err, agentruntime.ErrSessionNotFound) {
+		return errors.Join(host.ErrSessionNotFound, err)
+	}
 	if errors.Is(err, agentruntime.ErrEffectiveHistoryUnsupported) {
 		return host.ErrRuntimeHistoryUnsupported
 	}
@@ -695,7 +698,8 @@ func runtimeResumeInput(input host.RuntimeResumeInput) agentruntime.ResumeInput 
 		RuntimeContext: cloneMap(input.RuntimeContext), ProviderTargetRef: cloneMap(input.ProviderTargetRef),
 		PermissionModeID: input.Settings.PermissionModeID, Settings: runtimeSettings(input.Settings),
 		CreatedAtUnixMS: input.CreatedAtUnixMS, UpdatedAtUnixMS: input.UpdatedAtUnixMS,
-		RecreateIfMissing: input.RecreateIfMissing,
+		GoalGenerationFences: runtimeGoalGenerationFences(input.GoalGenerationFences),
+		RecreateIfMissing:    input.RecreateIfMissing,
 	}
 }
 

--- a/packages/agent/daemon/hostadapter/runtime_goal_generation_fences.go
+++ b/packages/agent/daemon/hostadapter/runtime_goal_generation_fences.go
@@ -1,0 +1,17 @@
+package hostadapter
+
+import (
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
+	host "github.com/tutti-os/tutti/packages/agent/host"
+)
+
+func runtimeGoalGenerationFences(input []host.RuntimeGoalGenerationFenceInput) []agentruntime.GoalGenerationFenceInput {
+	result := make([]agentruntime.GoalGenerationFenceInput, 0, len(input))
+	for _, fence := range input {
+		result = append(result, agentruntime.GoalGenerationFenceInput{
+			OperationID: fence.TargetOperationID, Revision: fence.TargetRevision,
+			RepairEpoch: fence.TargetRepairEpoch, Reason: fence.Reason,
+		})
+	}
+	return result
+}

--- a/packages/agent/daemon/hostadapter/runtime_test.go
+++ b/packages/agent/daemon/hostadapter/runtime_test.go
@@ -56,6 +56,25 @@ func TestRuntimeControllerPreservesCanonicalStateWhenClosingRuntime(t *testing.T
 	}
 }
 
+func TestRuntimeResumeInputMapsDurableGoalGenerationFences(t *testing.T) {
+	t.Parallel()
+	mapped := runtimeResumeInput(host.RuntimeResumeInput{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1", Provider: "codex",
+		GoalGenerationFences: []host.RuntimeGoalGenerationFenceInput{{
+			TargetOperationID: "old-goal", TargetRevision: 3, TargetRepairEpoch: 2,
+			Reason: "binding_revoked", RequireLive: false,
+		}},
+	})
+	if len(mapped.GoalGenerationFences) != 1 {
+		t.Fatalf("mapped fences=%#v", mapped.GoalGenerationFences)
+	}
+	fence := mapped.GoalGenerationFences[0]
+	if fence.OperationID != "old-goal" || fence.Revision != 3 || fence.RepairEpoch != 2 ||
+		fence.Reason != "binding_revoked" {
+		t.Fatalf("mapped fence=%#v", fence)
+	}
+}
+
 func (b *goalLifecycleRuntimeBackend) SetGoalControlLifecycleObserver(observer agentruntime.GoalControlLifecycleObserver) {
 	b.observer = observer
 }
@@ -149,6 +168,17 @@ func TestMapRuntimeErrorMapsDisconnectedSessionAcrossHostBoundary(t *testing.T) 
 		t.Fatalf("mapped error = %v, want Host disconnected sentinel", mapped)
 	}
 	if !errors.Is(mapped, agentruntime.ErrSessionDisconnected) {
+		t.Fatalf("mapped error = %v, want source runtime sentinel preserved", mapped)
+	}
+}
+
+func TestMapRuntimeErrorMapsMissingSessionAcrossHostBoundary(t *testing.T) {
+	runtimeErr := fmt.Errorf("fence session disappeared: %w", agentruntime.ErrSessionNotFound)
+	mapped := mapRuntimeError(runtimeErr)
+	if !errors.Is(mapped, host.ErrSessionNotFound) {
+		t.Fatalf("mapped error = %v, want Host missing-session sentinel", mapped)
+	}
+	if !errors.Is(mapped, agentruntime.ErrSessionNotFound) {
 		t.Fatalf("mapped error = %v, want source runtime sentinel preserved", mapped)
 	}
 }

--- a/packages/agent/daemon/runtime/controller_goal_generation_fence.go
+++ b/packages/agent/daemon/runtime/controller_goal_generation_fence.go
@@ -61,6 +61,15 @@ func (c *Controller) FenceGoalGeneration(ctx context.Context, input GoalGenerati
 }
 
 func normalizeGoalGenerationFenceInput(input GoalGenerationFenceRequest) (GoalGenerationFenceInput, error) {
+	return normalizeRetainedGoalGenerationFenceInput(GoalGenerationFenceInput{
+		OperationID: strings.TrimSpace(input.OperationID),
+		Revision:    input.Revision,
+		RepairEpoch: input.RepairEpoch,
+		Reason:      strings.TrimSpace(input.Reason),
+	})
+}
+
+func normalizeRetainedGoalGenerationFenceInput(input GoalGenerationFenceInput) (GoalGenerationFenceInput, error) {
 	fence := GoalGenerationFenceInput{
 		OperationID: strings.TrimSpace(input.OperationID),
 		Revision:    input.Revision,

--- a/packages/agent/daemon/runtime/controller_goal_test.go
+++ b/packages/agent/daemon/runtime/controller_goal_test.go
@@ -109,6 +109,36 @@ func TestBackgroundGoalControlsRequireExistingLiveProvider(t *testing.T) {
 	}
 }
 
+func TestResumeInstallsPreloadedGoalFencesBeforePublishingSession(t *testing.T) {
+	adapter := &requireLiveGoalAdapter{recordingStartAdapter: recordingStartAdapter{provider: "resume-goal-fences"}}
+	controller := NewController([]Adapter{adapter}, nil)
+	adapter.onFence = func(session Session) {
+		if published, found := controller.Session(session.RoomID, session.AgentSessionID); found {
+			t.Fatalf("session published before durable fences were installed: %#v", published)
+		}
+	}
+	inputFence := GoalGenerationFenceInput{
+		OperationID: "old-goal", Revision: 4, RepairEpoch: 2, Reason: "binding_revoked",
+	}
+	session, err := controller.Resume(context.Background(), ResumeInput{
+		RoomID: "room-resume-fences", AgentSessionID: "session-resume-fences", Provider: adapter.Provider(),
+		ProviderSessionID:    "provider-session-resume-fences",
+		GoalGenerationFences: []GoalGenerationFenceInput{inputFence},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := strings.Join(adapter.calls, ","), "resume,fence"; got != want {
+		t.Fatalf("resume fence order=%q want=%q", got, want)
+	}
+	if adapter.lastFence != inputFence {
+		t.Fatalf("installed fence=%#v want=%#v", adapter.lastFence, inputFence)
+	}
+	if published, found := controller.Session(session.RoomID, session.AgentSessionID); !found || published.AgentSessionID != session.AgentSessionID {
+		t.Fatalf("resumed session was not published after fence installation: %#v found=%v", published, found)
+	}
+}
+
 type requireLiveGoalAdapter struct {
 	recordingStartAdapter
 	live        bool
@@ -118,6 +148,8 @@ type requireLiveGoalAdapter struct {
 	closeCalls  int
 	calls       []string
 	fenceErr    error
+	lastFence   GoalGenerationFenceInput
+	onFence     func(Session)
 }
 
 func (a *requireLiveGoalAdapter) Start(ctx context.Context, session Session) ([]activityshared.Event, error) {
@@ -161,9 +193,13 @@ func (*requireLiveGoalAdapter) ExecGoalControl(context.Context, Session, []Promp
 	return nil, false, nil
 }
 
-func (a *requireLiveGoalAdapter) FenceGoalGeneration(context.Context, Session, GoalGenerationFenceInput) error {
+func (a *requireLiveGoalAdapter) FenceGoalGeneration(_ context.Context, session Session, input GoalGenerationFenceInput) error {
 	a.fenceCalls++
 	a.calls = append(a.calls, "fence")
+	a.lastFence = input
+	if a.onFence != nil {
+		a.onFence(session)
+	}
 	return a.fenceErr
 }
 

--- a/packages/agent/daemon/runtime/controller_session_lifecycle.go
+++ b/packages/agent/daemon/runtime/controller_session_lifecycle.go
@@ -192,6 +192,17 @@ func (c *Controller) Resume(ctx context.Context, input ResumeInput) (Session, er
 	if session.Settings != nil {
 		session.PermissionModeID = session.Settings.PermissionModeID
 	}
+	normalizedFences := make([]GoalGenerationFenceInput, 0, len(input.GoalGenerationFences))
+	for _, inputFence := range input.GoalGenerationFences {
+		fence, fenceErr := normalizeRetainedGoalGenerationFenceInput(inputFence)
+		if fenceErr != nil {
+			return Session{}, fenceErr
+		}
+		normalizedFences = append(normalizedFences, fence)
+	}
+	for _, fence := range normalizedFences {
+		c.retainGoalGenerationFence(session, fence)
+	}
 	c.invalidateAppliedGoalGenerationFences(session)
 	if err := adapter.Resume(ctx, session); err != nil {
 		if !input.RecreateIfMissing || !isResumeRecreatableError(err) {

--- a/packages/agent/daemon/runtime/types.go
+++ b/packages/agent/daemon/runtime/types.go
@@ -97,6 +97,10 @@ type ResumeInput struct {
 	Settings          *SessionSettings
 	CreatedAtUnixMS   int64
 	UpdatedAtUnixMS   int64
+	// GoalGenerationFences must be retained before this Session becomes
+	// available for Goal or Turn submission. Adapter installation follows
+	// Resume connection establishment and precedes Controller publication.
+	GoalGenerationFences []GoalGenerationFenceInput
 	// RecreateIfMissing creates a fresh provider session in place when the
 	// existing provider session can no longer be restored locally (e.g. an
 	// imported conversation), instead of returning a restore error.

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -126,14 +126,21 @@ persists `(operationId, revision, repairEpoch)` in
 `IntentAccepted` means Host owns later retries even when the provider is
 offline. Accepting or recovering a fence never resumes an offline provider
 Session. Host immediately prepares a revision-conditional local clear so the
-revoked target cannot replay; provider delivery waits until the Session is
-already live or a user action resumes it. A fence is an admission rule, not
-session deletion: completed rows remain durable and are restored to the
-runtime after restart or resume so a delayed provider generation cannot become
-canonical. The runtime Controller retains the exact fence set independently
-of an adapter connection and installs it into every replacement connection
-before dispatching a user operation; failed installation closes the
-unprotected connection. Host cancels a live Turn only when its
+revoked target cannot replay. During startup recovery, an absent Runtime
+Session completes that clear and the fence locally without resuming a provider;
+the operation remains explicit that provider application is unknown. Provider
+delivery waits until the Session is already live or a user action resumes it.
+A pre-crash live revocation may already have prepared its exact-Turn cancel;
+startup completes that internal operation locally with an interrupted outcome
+instead of retrying a missing Runtime or letting the operation shield a stale
+Turn from restart settlement.
+A fence is an admission rule, not session deletion: completed rows remain
+durable and are loaded into Runtime resume before the Session can accept Goal
+or Turn work, so a delayed provider generation cannot become canonical. The
+runtime Controller retains the exact fence set independently of an adapter
+connection and installs it into every replacement connection before dispatching
+a user operation; failed installation closes the unprotected connection. Host
+cancels a live Turn only when its
 immutable Goal provenance exactly matches the fenced identity; that internal
 cancel is require-live and never reconnects an offline provider. The fence
 remains unsettled until the Turn reaches an authoritative terminal state. It

--- a/packages/agent/host/conformance/conformance.go
+++ b/packages/agent/host/conformance/conformance.go
@@ -63,8 +63,12 @@ type Fixture struct {
 	AcceptGoalControlsOnly bool
 	CompleteGoalOnSet      bool
 	EmptyPauseResumeGoal   bool
-	FailCommitObserver     bool
-	RejectInitialExec      bool
+	// DisconnectGoalFenceDelivery drops the live Runtime Session during the
+	// first fence delivery, modeling a Host restart with accepted durable intent
+	// but no in-memory provider Session.
+	DisconnectGoalFenceDelivery bool
+	FailCommitObserver          bool
+	RejectInitialExec           bool
 	// GuidanceTargetMismatch makes the test runtime reject guidance whose
 	// explicit TurnID is not the Session.ActiveTurnID. It models the runtime
 	// target race without exposing a runtime/provider API to scenarios.
@@ -146,6 +150,7 @@ type Metrics struct {
 	LastExecRequiresProviderAcceptance bool
 	LastClosePreservedCanonicalState   bool
 	LastResumeRecreate                 bool
+	LastResumeGoalGenerationFences     []agenthost.RuntimeGoalGenerationFenceInput
 	RecoverySteps                      []string
 	DeleteAdmissionPlans               []agenthost.DeleteSessionsPlan
 	DeleteReports                      []agenthost.DeleteSessionsReport

--- a/packages/agent/host/conformance/conformance_test.go
+++ b/packages/agent/host/conformance/conformance_test.go
@@ -20,7 +20,7 @@ func TestPublishedScenarioCatalogsHaveUniqueNames(t *testing.T) {
 		{name: "title policy", scenarios: TitlePolicyScenarios(), wantCount: 1},
 		{name: "deletion admission", scenarios: DeletionAdmissionScenarios(), wantCount: 3},
 		{name: "coordinator", scenarios: CoordinatorScenarios(), wantCount: 7},
-		{name: "goal", scenarios: GoalScenarios(), wantCount: 14},
+		{name: "goal", scenarios: GoalScenarios(), wantCount: 15},
 		{name: "commit observer", scenarios: CommitObserverScenarios(), wantCount: 2},
 	}
 	for _, catalog := range catalogs {

--- a/packages/agent/host/conformance/goal_scenarios.go
+++ b/packages/agent/host/conformance/goal_scenarios.go
@@ -396,6 +396,90 @@ func runGoalGenerationFencePreservesNewerGoal(ctx context.Context, driver Driver
 	return nil
 }
 
+func runRestartCompletesOfflineGoalFenceWithoutReplay(ctx context.Context, driver Driver) error {
+	const sessionID = "session-goal-fence-restart-stop"
+	fixture := liveSessionFixture(sessionID, "")
+	fixture.DisconnectGoalFenceDelivery = true
+	if err := driver.Reset(ctx, fixture); err != nil {
+		return err
+	}
+	target, err := driver.GoalControl(ctx, agenthost.GoalControlInput{
+		WorkspaceID: "workspace-1", AgentSessionID: sessionID,
+		Action: "set", Objective: "must not replay", ClientSubmitID: "old-goal",
+	})
+	if err != nil || target.OperationID == "" {
+		return fmt.Errorf("prepare old Goal: result=%#v error=%w", target, err)
+	}
+	fenceInput := agenthost.FenceGoalGenerationInput{
+		WorkspaceID: "workspace-1", AgentSessionID: sessionID,
+		TargetOperationID: target.OperationID, ClientSubmitID: "restart-stop-fence",
+		Reason: "binding_revoked",
+	}
+	fenced, err := driver.FenceGoalGeneration(ctx, fenceInput)
+	if err == nil || !fenced.IntentAccepted || fenced.Settled {
+		return fmt.Errorf("disconnected fence result=%#v error=%v", fenced, err)
+	}
+	beforeRecovery := driver.Metrics()
+	if beforeRecovery.ResumeCalls != 0 || beforeRecovery.GoalControlCalls != 1 {
+		return fmt.Errorf("fence failure resumed or replayed provider work: %#v", beforeRecovery)
+	}
+	if err := driver.Recover(ctx); err != nil {
+		return fmt.Errorf("recover offline Goal fence: %w", err)
+	}
+	state, err := driver.GetGoalState(ctx, agenthost.SessionRef{WorkspaceID: "workspace-1", AgentSessionID: sessionID})
+	if err != nil {
+		return err
+	}
+	if state.Revision != 2 || state.Goal != nil || state.PendingOperationID != "" ||
+		state.SyncStatus != storesqlite.GoalSyncStatusUnknown {
+		return fmt.Errorf("offline recovery state=%#v", state)
+	}
+	afterRecovery := driver.Metrics()
+	if afterRecovery.ResumeCalls != 0 || afterRecovery.GoalControlCalls != 1 || afterRecovery.CancelCalls != 0 {
+		return fmt.Errorf("offline recovery reached provider: %#v", afterRecovery)
+	}
+	replayedFence, err := driver.FenceGoalGeneration(ctx, fenceInput)
+	if err != nil || !replayedFence.IntentAccepted || !replayedFence.Settled {
+		return fmt.Errorf("completed fence replay result=%#v error=%w", replayedFence, err)
+	}
+	if err := driver.Recover(ctx); err != nil {
+		return fmt.Errorf("second restart recovery: %w", err)
+	}
+	afterSecondRecovery := driver.Metrics()
+	if afterSecondRecovery.ResumeCalls != 0 || afterSecondRecovery.GoalControlCalls != 1 ||
+		afterSecondRecovery.CancelCalls != 0 {
+		return fmt.Errorf("second recovery retried stopped Goal: %#v", afterSecondRecovery)
+	}
+	if _, err := driver.EnsureSession(ctx, agenthost.SessionRef{
+		WorkspaceID: "workspace-1", AgentSessionID: sessionID,
+	}); err != nil {
+		return fmt.Errorf("manual Session resume: %w", err)
+	}
+	resumed := driver.Metrics()
+	if resumed.ResumeCalls != 1 || len(resumed.LastResumeGoalGenerationFences) != 1 {
+		return fmt.Errorf("manual resume did not preload durable fence: %#v", resumed)
+	}
+	preloaded := resumed.LastResumeGoalGenerationFences[0]
+	if preloaded.TargetOperationID != target.OperationID || preloaded.TargetRevision != 1 || preloaded.RequireLive {
+		return fmt.Errorf("preloaded fence=%#v", preloaded)
+	}
+	if _, err := driver.GoalControl(ctx, agenthost.GoalControlInput{
+		WorkspaceID: "workspace-1", AgentSessionID: sessionID,
+		Action: "set", Objective: "new generation", ClientSubmitID: "new-goal",
+	}); err != nil {
+		return fmt.Errorf("submit new Goal generation: %w", err)
+	}
+	finalState, err := driver.GetGoalState(ctx, agenthost.SessionRef{WorkspaceID: "workspace-1", AgentSessionID: sessionID})
+	if err != nil {
+		return err
+	}
+	if finalState.Revision != 3 || metadataString(finalState.Goal, "objective") != "new generation" ||
+		driver.Metrics().GoalControlCalls != 2 {
+		return fmt.Errorf("new Goal state=%#v metrics=%#v", finalState, driver.Metrics())
+	}
+	return nil
+}
+
 func runAcceptedGoalControlWaitsWithoutReplay(ctx context.Context, driver Driver) error {
 	fixture := liveSessionFixture("session-goal-accepted", "")
 	fixture.AcceptGoalControlsOnly = true

--- a/packages/agent/host/conformance/scenarios.go
+++ b/packages/agent/host/conformance/scenarios.go
@@ -141,6 +141,7 @@ func GoalScenarios() []Scenario {
 		{Name: "goal reconcile observation", run: runGoalReconcileObservation},
 		{Name: "goal revision actor fence", run: runGoalRevisionActorFence},
 		{Name: "goal generation fence preserves newer goal", run: runGoalGenerationFencePreservesNewerGoal},
+		{Name: "restart completes offline goal fence without replay", run: runRestartCompletesOfflineGoalFenceWithoutReplay},
 		{Name: "accepted goal control waits without replay", run: runAcceptedGoalControlWaitsWithoutReplay},
 		{Name: "goal inbox consumer preflight", run: runGoalInboxConsumerPreflight},
 	}

--- a/packages/agent/host/goal_generation_fence.go
+++ b/packages/agent/host/goal_generation_fence.go
@@ -84,7 +84,7 @@ func (h *Host) FenceGoalGeneration(ctx context.Context, input FenceGoalGeneratio
 	if result.Settled {
 		return result, nil
 	}
-	processed, processErr := h.processGoalGenerationFenceSerialized(ctx, fence)
+	processed, processErr := h.processGoalGenerationFenceSerialized(ctx, fence, false)
 	if processed.FenceID != "" {
 		result.Fence = processed
 		result.Settled = processed.Status == storesqlite.GoalGenerationFenceStatusCompleted
@@ -93,6 +93,10 @@ func (h *Host) FenceGoalGeneration(ctx context.Context, input FenceGoalGeneratio
 }
 
 func (h *Host) StepGoalGenerationFenceWorker(ctx context.Context) error {
+	return h.stepGoalGenerationFenceWorker(ctx, false)
+}
+
+func (h *Host) stepGoalGenerationFenceWorker(ctx context.Context, recovering bool) error {
 	if h == nil || h.goalFences == nil {
 		return nil
 	}
@@ -107,7 +111,7 @@ func (h *Host) StepGoalGenerationFenceWorker(ctx context.Context) error {
 		if ctx.Err() != nil {
 			break
 		}
-		if _, processErr := h.processGoalGenerationFenceSerialized(ctx, fence); processErr != nil &&
+		if _, processErr := h.processGoalGenerationFenceSerialized(ctx, fence, recovering); processErr != nil &&
 			!errors.Is(processErr, ErrRuntimeOperationInProgress) {
 			errs = append(errs, fmt.Errorf("process goal generation fence %s: %w", fence.FenceID, processErr))
 		}
@@ -118,19 +122,24 @@ func (h *Host) StepGoalGenerationFenceWorker(ctx context.Context) error {
 func (h *Host) processGoalGenerationFenceSerialized(
 	ctx context.Context,
 	fence storesqlite.GoalGenerationFence,
+	recovering bool,
 ) (storesqlite.GoalGenerationFence, error) {
 	var result storesqlite.GoalGenerationFence
 	err := h.withSessionMutationActor(ctx, fence.WorkspaceID, fence.AgentSessionID, func(commandCtx context.Context) error {
 		return h.withGoalActor(commandCtx, fence.WorkspaceID, fence.AgentSessionID, func(actorCtx context.Context) error {
 			var processErr error
-			result, processErr = h.processGoalGenerationFence(actorCtx, fence)
+			result, processErr = h.processGoalGenerationFence(actorCtx, fence, recovering)
 			return processErr
 		})
 	})
 	return result, err
 }
 
-func (h *Host) processGoalGenerationFence(ctx context.Context, candidate storesqlite.GoalGenerationFence) (storesqlite.GoalGenerationFence, error) {
+func (h *Host) processGoalGenerationFence(
+	ctx context.Context,
+	candidate storesqlite.GoalGenerationFence,
+	recovering bool,
+) (storesqlite.GoalGenerationFence, error) {
 	clearOperationID, err := h.ensureGoalGenerationFenceClear(ctx, candidate)
 	if err != nil {
 		return candidate, err
@@ -167,8 +176,26 @@ func (h *Host) processGoalGenerationFence(ctx context.Context, candidate storesq
 		})
 		return released, releaseErr
 	}
+	completeLocally := func() (storesqlite.GoalGenerationFence, error) {
+		if err := h.completeGoalGenerationFenceClearLocally(ctx, fence, clearOperationID); err != nil {
+			return retry(err)
+		}
+		return h.completeClaimedGoalGenerationFence(ctx, fence, clearOperationID)
+	}
+
+	// Startup recovery has no local provider process to quiesce. The durable
+	// conditional clear above is the restart-time source of truth, so finish it
+	// locally instead of reconnecting a provider merely to stop work that is no
+	// longer running.
+	if recovering && !h.runtimeSessionLive(fence.WorkspaceID, fence.AgentSessionID) {
+		return completeLocally()
+	}
 
 	if err = h.applyGoalGenerationFence(ctx, fence); err != nil {
+		if recovering && !h.runtimeSessionLive(fence.WorkspaceID, fence.AgentSessionID) &&
+			(errors.Is(err, ErrRuntimeSessionDisconnected) || errors.Is(err, ErrSessionNotFound)) {
+			return completeLocally()
+		}
 		if errors.Is(err, ErrRuntimeSessionDisconnected) {
 			return deferPending("waiting for a live provider session")
 		}
@@ -176,9 +203,16 @@ func (h *Host) processGoalGenerationFence(ctx context.Context, candidate storesq
 	}
 	turnSettled, err := h.cancelActiveTurnForGoalFence(ctx, fence)
 	if err != nil {
+		if recovering && !h.runtimeSessionLive(fence.WorkspaceID, fence.AgentSessionID) &&
+			(errors.Is(err, ErrRuntimeSessionDisconnected) || errors.Is(err, ErrSessionNotFound)) {
+			return completeLocally()
+		}
 		return retry(err)
 	}
 	if !turnSettled {
+		if recovering && !h.runtimeSessionLive(fence.WorkspaceID, fence.AgentSessionID) {
+			return completeLocally()
+		}
 		return deferPending("waiting for the exact fenced Turn to settle")
 	}
 	if clearOperationID != "" {
@@ -208,11 +242,69 @@ func (h *Host) processGoalGenerationFence(ctx context.Context, candidate storesq
 			}
 		}
 	}
-	completed, _, err := h.goalFences.CompleteGoalGenerationFence(ctx, storesqlite.CompleteGoalGenerationFenceInput{
+	return h.completeClaimedGoalGenerationFence(ctx, fence, clearOperationID)
+}
+
+func (h *Host) completeClaimedGoalGenerationFence(
+	ctx context.Context,
+	fence storesqlite.GoalGenerationFence,
+	clearOperationID string,
+) (storesqlite.GoalGenerationFence, error) {
+	completed, changed, err := h.goalFences.CompleteGoalGenerationFence(ctx, storesqlite.CompleteGoalGenerationFenceInput{
 		FenceID: fence.FenceID, LeaseOwner: h.goalOperationOwner(),
 		ClearOperationID: clearOperationID, OccurredAtUnixMS: h.goalOperationNow().UnixMilli(),
 	})
-	return completed, err
+	if err != nil || changed {
+		return completed, err
+	}
+	current, found, readErr := h.goalFences.GetGoalGenerationFence(ctx, fence.WorkspaceID, fence.FenceID)
+	if readErr != nil {
+		return current, readErr
+	}
+	if found && current.Status == storesqlite.GoalGenerationFenceStatusCompleted {
+		return current, nil
+	}
+	return current, ErrRuntimeOperationInProgress
+}
+
+func (h *Host) completeGoalGenerationFenceClearLocally(
+	ctx context.Context,
+	fence storesqlite.GoalGenerationFence,
+	clearOperationID string,
+) error {
+	if clearOperationID == "" {
+		return nil
+	}
+	clearOperation, found, err := h.goals.GetGoalControlOperation(ctx, fence.WorkspaceID, clearOperationID)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return errors.New("goal generation fence clear operation is missing")
+	}
+	if clearOperation.Status == storesqlite.GoalOperationStatusCompleted ||
+		clearOperation.Status == storesqlite.GoalOperationStatusSuperseded {
+		return nil
+	}
+	completed, _, _, err := h.goals.CompleteGoalControlOperation(ctx, storesqlite.GoalControlOperationComplete{
+		WorkspaceID: fence.WorkspaceID, OperationID: clearOperation.OperationID,
+		Mode: storesqlite.GoalControlCompletionModeLocalStop, Succeeded: true,
+		Evidence: map[string]any{
+			"source":            "goal_generation_fence_recovery",
+			"fenceId":           fence.FenceID,
+			"targetOperationId": fence.TargetOperationID,
+			"reason":            fence.Reason,
+		},
+		OccurredAtUnixMS: h.goalOperationNow().UnixMilli(),
+	})
+	if err != nil {
+		return err
+	}
+	if completed.Status != storesqlite.GoalOperationStatusCompleted &&
+		completed.Status != storesqlite.GoalOperationStatusSuperseded {
+		return errors.New("goal generation fence clear did not complete locally")
+	}
+	return nil
 }
 
 func (h *Host) ensureGoalGenerationFenceClear(
@@ -286,16 +378,34 @@ func (h *Host) restoreGoalGenerationFences(ctx context.Context, ref SessionRef) 
 	if !ok {
 		return ErrGoalGenerationFenceUnavailable
 	}
-	fences, err := h.goalFences.ListGoalGenerationFencesForSession(ctx, ref.WorkspaceID, ref.AgentSessionID)
+	fences, err := h.listRuntimeGoalGenerationFences(ctx, ref)
 	if err != nil {
 		return err
 	}
 	for _, fence := range fences {
-		if err := applyGoalGenerationFenceWithRuntime(ctx, fencer, fence, false); err != nil {
+		if err := fencer.FenceGoalGeneration(ctx, fence); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func (h *Host) listRuntimeGoalGenerationFences(
+	ctx context.Context,
+	ref SessionRef,
+) ([]RuntimeGoalGenerationFenceInput, error) {
+	if h == nil || h.goalFences == nil {
+		return nil, nil
+	}
+	fences, err := h.goalFences.ListGoalGenerationFencesForSession(ctx, ref.WorkspaceID, ref.AgentSessionID)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]RuntimeGoalGenerationFenceInput, 0, len(fences))
+	for _, fence := range fences {
+		result = append(result, runtimeGoalGenerationFenceInput(fence, false))
+	}
+	return result, nil
 }
 
 func (h *Host) restoreGoalGenerationFencesOnce(ctx context.Context, ref SessionRef) error {
@@ -324,9 +434,16 @@ func applyGoalGenerationFenceWithRuntime(
 	fence storesqlite.GoalGenerationFence,
 	requireLive bool,
 ) error {
-	return fencer.FenceGoalGeneration(ctx, RuntimeGoalGenerationFenceInput{
+	return fencer.FenceGoalGeneration(ctx, runtimeGoalGenerationFenceInput(fence, requireLive))
+}
+
+func runtimeGoalGenerationFenceInput(
+	fence storesqlite.GoalGenerationFence,
+	requireLive bool,
+) RuntimeGoalGenerationFenceInput {
+	return RuntimeGoalGenerationFenceInput{
 		WorkspaceID: fence.WorkspaceID, AgentSessionID: fence.AgentSessionID,
 		TargetOperationID: fence.TargetOperationID, TargetRevision: fence.TargetRevision,
 		TargetRepairEpoch: fence.TargetRepairEpoch, Reason: fence.Reason, RequireLive: requireLive,
-	})
+	}
 }

--- a/packages/agent/host/goal_generation_fence_sqlite_test.go
+++ b/packages/agent/host/goal_generation_fence_sqlite_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
@@ -21,12 +22,16 @@ type goalFenceRuntime struct {
 	onFence    func()
 }
 
+type goalFenceTestClock struct{ at time.Time }
+
+func (c goalFenceTestClock) Now() time.Time { return c.at }
+
 type offlineGoalFenceSessionRuntime struct {
 	agenthost.RuntimeController
-	mu          sync.Mutex
-	session     agenthost.ProviderRuntimeSession
-	live        bool
-	resumeCalls int
+	mu           sync.Mutex
+	session      agenthost.ProviderRuntimeSession
+	live         bool
+	resumeInputs []agenthost.RuntimeResumeInput
 }
 
 type pendingCancelGoalFenceRuntime struct {
@@ -34,12 +39,15 @@ type pendingCancelGoalFenceRuntime struct {
 	mu          sync.Mutex
 	session     agenthost.ProviderRuntimeSession
 	live        bool
+	missing     bool
 	resumeCalls int
 	cancelCalls int
 }
 
 func (r *pendingCancelGoalFenceRuntime) Session(workspaceID, agentSessionID string) (agenthost.ProviderRuntimeSession, bool) {
-	return r.session, workspaceID == r.session.WorkspaceID && agentSessionID == r.session.ID
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.session, !r.missing && workspaceID == r.session.WorkspaceID && agentSessionID == r.session.ID
 }
 
 func (r *pendingCancelGoalFenceRuntime) RuntimeSessionLive(workspaceID, agentSessionID string) bool {
@@ -72,6 +80,15 @@ func (r *pendingCancelGoalFenceRuntime) setLive(live bool) {
 	r.mu.Unlock()
 }
 
+func (r *pendingCancelGoalFenceRuntime) setMissing(missing bool) {
+	r.mu.Lock()
+	r.missing = missing
+	if missing {
+		r.live = false
+	}
+	r.mu.Unlock()
+}
+
 func (r *pendingCancelGoalFenceRuntime) counts() (int, int) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -92,7 +109,7 @@ func (r *offlineGoalFenceSessionRuntime) RuntimeSessionLive(workspaceID, agentSe
 func (r *offlineGoalFenceSessionRuntime) Resume(_ context.Context, input agenthost.RuntimeResumeInput) (agenthost.ProviderRuntimeSession, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.resumeCalls++
+	r.resumeInputs = append(r.resumeInputs, input)
 	r.live = true
 	r.session.ID = input.AgentSessionID
 	r.session.WorkspaceID = input.WorkspaceID
@@ -104,7 +121,16 @@ func (r *offlineGoalFenceSessionRuntime) Resume(_ context.Context, input agentho
 func (r *offlineGoalFenceSessionRuntime) resumeCount() int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return r.resumeCalls
+	return len(r.resumeInputs)
+}
+
+func (r *offlineGoalFenceSessionRuntime) lastResumeInput() agenthost.RuntimeResumeInput {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.resumeInputs) == 0 {
+		return agenthost.RuntimeResumeInput{}
+	}
+	return r.resumeInputs[len(r.resumeInputs)-1]
 }
 
 func (r *goalFenceRuntime) GoalControl(_ context.Context, input agenthost.RuntimeGoalControlInput) (agenthost.RuntimeGoalControlResult, error) {
@@ -383,14 +409,18 @@ func TestGoalFenceRecoveryDoesNotResumeOfflineSession(t *testing.T) {
 	if err != nil || !result.IntentAccepted || result.Settled {
 		t.Fatalf("fence result=%#v error=%v", result, err)
 	}
-	if err := host.RecoverGoalOperations(t.Context()); err != nil {
+	recoveryHost := agenthost.New(agenthost.Config{
+		CanonicalStore: sqliteCanonicalStore{Store: store}, Runtime: sessionRuntime,
+		GoalStore: store, GoalFences: store, GoalRuntime: goalRuntime,
+	})
+	if err := recoveryHost.RecoverGoalOperations(t.Context()); err != nil {
 		t.Fatal(err)
 	}
 	if sessionRuntime.resumeCount() != 0 {
 		t.Fatalf("background fence recovery resumed provider %d times", sessionRuntime.resumeCount())
 	}
 	controls, fences := goalRuntime.snapshot()
-	if len(controls) != 0 || len(fences) == 0 {
+	if len(controls) != 0 || len(fences) != 1 {
 		t.Fatalf("offline recovery controls=%#v fence registry calls=%#v", controls, fences)
 	}
 	for _, fence := range fences {
@@ -399,19 +429,40 @@ func TestGoalFenceRecoveryDoesNotResumeOfflineSession(t *testing.T) {
 		}
 	}
 	state, found, err := store.GetSessionGoalState(t.Context(), "workspace", "session")
-	if err != nil || !found || !state.Tombstoned || state.Revision != 2 {
+	if err != nil || !found || !state.Tombstoned || state.Revision != 2 ||
+		state.PendingOperationID != "" || state.SyncStatus != storesqlite.GoalSyncStatusUnknown {
 		t.Fatalf("local conditional clear state=%#v found=%v error=%v", state, found, err)
 	}
 	persistedTarget, found, err := store.GetGoalControlOperation(t.Context(), "workspace", target.OperationID)
 	if err != nil || !found || persistedTarget.Status != storesqlite.GoalOperationStatusSuperseded {
 		t.Fatalf("target=%#v found=%v error=%v", persistedTarget, found, err)
 	}
+	persistedFence, found, err := store.GetGoalGenerationFence(t.Context(), "workspace", result.Fence.FenceID)
+	if err != nil || !found || persistedFence.Status != storesqlite.GoalGenerationFenceStatusCompleted {
+		t.Fatalf("fence=%#v found=%v error=%v", persistedFence, found, err)
+	}
+	clearOperation, found, err := store.GetGoalControlOperation(t.Context(), "workspace", persistedFence.ClearOperationID)
+	if err != nil || !found || clearOperation.Status != storesqlite.GoalOperationStatusCompleted ||
+		clearOperation.ProviderPhase != storesqlite.GoalProviderPhaseUnknown {
+		t.Fatalf("clear operation=%#v found=%v error=%v", clearOperation, found, err)
+	}
+	secondRestart := agenthost.New(agenthost.Config{
+		CanonicalStore: sqliteCanonicalStore{Store: store}, Runtime: sessionRuntime,
+		GoalStore: store, GoalFences: store, GoalRuntime: goalRuntime,
+	})
+	if err := secondRestart.RecoverGoalOperations(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	_, fencesAfterSecondRecovery := goalRuntime.snapshot()
+	if len(fencesAfterSecondRecovery) != len(fences) || sessionRuntime.resumeCount() != 0 {
+		t.Fatalf("second startup retried offline fence: fences=%#v resumes=%d", fencesAfterSecondRecovery, sessionRuntime.resumeCount())
+	}
 
 	fencesBeforeEnsure := len(fences)
 	goalRuntime.mu.Lock()
 	goalRuntime.fenceError = nil
 	goalRuntime.mu.Unlock()
-	if _, err := host.EnsureRuntimeSession(t.Context(), agenthost.SessionRef{
+	if _, err := secondRestart.EnsureRuntimeSession(t.Context(), agenthost.SessionRef{
 		WorkspaceID: "workspace", AgentSessionID: "session",
 	}); err != nil {
 		t.Fatal(err)
@@ -419,11 +470,27 @@ func TestGoalFenceRecoveryDoesNotResumeOfflineSession(t *testing.T) {
 	if sessionRuntime.resumeCount() != 1 {
 		t.Fatalf("user-triggered Ensure resumed provider %d times", sessionRuntime.resumeCount())
 	}
+	resumeInput := sessionRuntime.lastResumeInput()
+	if len(resumeInput.GoalGenerationFences) != 1 ||
+		resumeInput.GoalGenerationFences[0].TargetOperationID != target.OperationID ||
+		resumeInput.GoalGenerationFences[0].RequireLive {
+		t.Fatalf("user resume did not preload durable fence: %#v", resumeInput.GoalGenerationFences)
+	}
 	_, fences = goalRuntime.snapshot()
 	if len(fences) != fencesBeforeEnsure+1 ||
 		fences[len(fences)-1].TargetOperationID != target.OperationID ||
 		fences[len(fences)-1].RequireLive {
 		t.Fatalf("Ensure returned before restoring exact fence: %#v", fences)
+	}
+	if _, err := secondRestart.GoalControl(t.Context(), agenthost.GoalControlInput{
+		WorkspaceID: "workspace", AgentSessionID: "session", Action: "set",
+		Objective: "new work", ClientSubmitID: "new-goal-after-restart",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	controls, _ = goalRuntime.snapshot()
+	if len(controls) != 1 || controls[0].Objective != "new work" {
+		t.Fatalf("new Goal did not execute after manual resume: %#v", controls)
 	}
 }
 
@@ -465,6 +532,7 @@ func TestGoalFenceWaitsForAuthoritativeTurnTerminalAfterCancelDeliveryFailure(t 
 	host := agenthost.New(agenthost.Config{
 		CanonicalStore: sqliteCanonicalStore{Store: store}, Runtime: sessionRuntime,
 		RuntimeOperations: store, GoalStore: store, GoalFences: store, GoalRuntime: goalRuntime,
+		Clock: goalFenceTestClock{at: time.UnixMilli(1_000)},
 	})
 	result, err := host.FenceGoalGeneration(t.Context(), agenthost.FenceGoalGenerationInput{
 		WorkspaceID: "workspace", AgentSessionID: "session",
@@ -485,6 +553,36 @@ func TestGoalFenceWaitsForAuthoritativeTurnTerminalAfterCancelDeliveryFailure(t 
 	turn, found, err := store.GetTurn(t.Context(), "workspace", "session", "goal-turn")
 	if err != nil || !found || turn.Phase != storesqlite.TurnPhaseRunning {
 		t.Fatalf("turn=%#v found=%v error=%v", turn, found, err)
+	}
+
+	// A crash can leave the fence's durable cancel operation pending. Runtime
+	// recovery must not retry that internal cancel against a provider process
+	// that restart already removed, or the operation would protect this stale
+	// Turn from normal startup settlement forever.
+	sessionRuntime.setMissing(true)
+	recoveryHost := agenthost.New(agenthost.Config{
+		CanonicalStore: sqliteCanonicalStore{Store: store}, Runtime: sessionRuntime,
+		RuntimeOperations: store, GoalStore: store, GoalFences: store, GoalRuntime: goalRuntime,
+		Clock: goalFenceTestClock{at: time.UnixMilli(3_000)},
+	})
+	if err := recoveryHost.RecoverRuntimeOperations(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	turn, found, err = store.GetTurn(t.Context(), "workspace", "session", "goal-turn")
+	if err != nil || !found || turn.Phase != storesqlite.TurnPhaseSettled ||
+		turn.Outcome != storesqlite.TurnOutcomeInterrupted {
+		t.Fatalf("locally settled fence cancel turn=%#v found=%v error=%v", turn, found, err)
+	}
+	if err := recoveryHost.RecoverGoalOperations(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	persistedFence, found, err = store.GetGoalGenerationFence(t.Context(), "workspace", result.Fence.FenceID)
+	if err != nil || !found || persistedFence.Status != storesqlite.GoalGenerationFenceStatusCompleted {
+		t.Fatalf("recovered fence=%#v found=%v error=%v", persistedFence, found, err)
+	}
+	resumeCalls, cancelCalls := sessionRuntime.counts()
+	if resumeCalls != 0 || cancelCalls != 1 {
+		t.Fatalf("startup recovery resumed or retried provider cancel: resume=%d cancel=%d", resumeCalls, cancelCalls)
 	}
 }
 
@@ -547,5 +645,29 @@ func TestGoalFenceDoesNotReconnectWhenConnectionDropsBeforeCancel(t *testing.T) 
 	turn, found, err := store.GetTurn(t.Context(), "workspace", "session", "goal-turn")
 	if err != nil || !found || turn.Phase != storesqlite.TurnPhaseRunning {
 		t.Fatalf("turn=%#v found=%v error=%v", turn, found, err)
+	}
+
+	// If the retained Session disappears after startup recovery's liveness
+	// probe and runtime-fence install, exact-Turn lookup returns not-found. That
+	// race is still an offline local stop and must not fail startup.
+	sessionRuntime.setMissing(false)
+	sessionRuntime.setLive(true)
+	goalRuntime.mu.Lock()
+	goalRuntime.onFence = func() { sessionRuntime.setMissing(true) }
+	goalRuntime.mu.Unlock()
+	recoveryHost := agenthost.New(agenthost.Config{
+		CanonicalStore: sqliteCanonicalStore{Store: store}, Runtime: sessionRuntime,
+		RuntimeOperations: store, GoalStore: store, GoalFences: store, GoalRuntime: goalRuntime,
+	})
+	if err := recoveryHost.RecoverGoalOperations(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	persistedFence, found, err = store.GetGoalGenerationFence(t.Context(), "workspace", result.Fence.FenceID)
+	if err != nil || !found || persistedFence.Status != storesqlite.GoalGenerationFenceStatusCompleted {
+		t.Fatalf("recovered race fence=%#v found=%v error=%v", persistedFence, found, err)
+	}
+	resumeCalls, cancelCalls = sessionRuntime.counts()
+	if resumeCalls != 0 || cancelCalls != 0 {
+		t.Fatalf("startup liveness race resumed or canceled provider: resume=%d cancel=%d", resumeCalls, cancelCalls)
 	}
 }

--- a/packages/agent/host/goal_operation_worker.go
+++ b/packages/agent/host/goal_operation_worker.go
@@ -319,7 +319,7 @@ func (h *Host) RecoverGoalOperations(ctx context.Context) error {
 			}
 			return nil
 		}
-		if err := h.StepGoalGenerationFenceWorker(recoveryCtx); err != nil {
+		if err := h.stepGoalGenerationFenceWorker(recoveryCtx, true); err != nil {
 			if recoveryCtx.Err() != nil && ctx.Err() == nil {
 				return nil
 			}

--- a/packages/agent/host/lifecycle.go
+++ b/packages/agent/host/lifecycle.go
@@ -369,6 +369,10 @@ func (h *Host) ensureRuntimeSessionLocked(ctx context.Context, ref SessionRef) (
 		return ProviderRuntimeSession{}, err
 	}
 	defer release()
+	goalGenerationFences, err := h.listRuntimeGoalGenerationFences(ctx, ref)
+	if err != nil {
+		return ProviderRuntimeSession{}, err
+	}
 	result, err := h.runtime.Resume(ctx, RuntimeResumeInput{
 		WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
 		AgentTargetID: strings.TrimSpace(canonicalSession.AgentTargetID), Provider: strings.TrimSpace(canonicalSession.Provider),
@@ -378,7 +382,9 @@ func (h *Host) ensureRuntimeSessionLocked(ctx context.Context, ref SessionRef) (
 		CreatedAtUnixMS: canonicalSession.CreatedAtUnixMS, UpdatedAtUnixMS: canonicalSession.UpdatedAtUnixMS,
 		Visible: boolPointer(canonicalSession.Metadata.Visible), RuntimeContext: cloneMap(firstMap(prepared.RuntimeContext, canonicalSession.InternalRuntimeContext)),
 		ProviderTargetRef: cloneMap(prepared.ProviderTargetRef), Metadata: canonicalSession.Metadata,
-		InternalRuntimeContext: cloneMap(canonicalSession.InternalRuntimeContext), RecreateIfMissing: policy.Mode == ResumeModeRecreate,
+		InternalRuntimeContext: cloneMap(canonicalSession.InternalRuntimeContext),
+		GoalGenerationFences:   append([]RuntimeGoalGenerationFenceInput(nil), goalGenerationFences...),
+		RecreateIfMissing:      policy.Mode == ResumeModeRecreate,
 	})
 	if err != nil {
 		return ProviderRuntimeSession{}, err

--- a/packages/agent/host/runtime_operations.go
+++ b/packages/agent/host/runtime_operations.go
@@ -176,7 +176,7 @@ func (h *Host) processRuntimeOperation(ctx context.Context, operation storesqlit
 	case storesqlite.RuntimeOperationKindInteractiveResponse:
 		return h.executeInteractiveRuntimeOperation(ctx, leased, owner, recovering)
 	case storesqlite.RuntimeOperationKindCancelTurn:
-		return h.executeCancelRuntimeOperation(ctx, leased, owner)
+		return h.executeCancelRuntimeOperation(ctx, leased, owner, recovering)
 	case storesqlite.RuntimeOperationKindPlanDecision:
 		return h.executePlanDecisionRuntimeOperation(ctx, leased, owner)
 	case storesqlite.RuntimeOperationKindEditRetry:
@@ -266,7 +266,21 @@ func (h *Host) executeInteractiveRuntimeOperation(ctx context.Context, operation
 	return completion.Operation, nil
 }
 
-func (h *Host) executeCancelRuntimeOperation(ctx context.Context, operation storesqlite.RuntimeOperation, owner string) (storesqlite.RuntimeOperation, error) {
+func (h *Host) executeCancelRuntimeOperation(
+	ctx context.Context,
+	operation storesqlite.RuntimeOperation,
+	owner string,
+	recovering bool,
+) (storesqlite.RuntimeOperation, error) {
+	if recovering {
+		locallyStopped, err := h.goalGenerationFenceStopsRuntimeCancel(ctx, operation)
+		if err != nil {
+			return h.releaseRuntimeOperation(ctx, operation, owner, err, false)
+		}
+		if locallyStopped {
+			return h.completeInterruptedCancelRuntimeOperation(ctx, operation, owner)
+		}
+	}
 	targets := runtimeCancelTargetsFromPayload(operation.Payload)
 	result, err := h.runtime.Cancel(ctx, RuntimeCancelInput{
 		WorkspaceID: operation.WorkspaceID, RootAgentSessionID: runtimeOperationPayloadText(operation.Payload, "rootAgentSessionId"),
@@ -287,6 +301,69 @@ func (h *Host) executeCancelRuntimeOperation(ctx context.Context, operation stor
 	completion.Operation.Payload["providerConfirmed"] = len(result.ConfirmedTargets) > 0
 	if err := h.publishRuntimeOperationEvents(ctx, operation.WorkspaceID); err != nil {
 		logRuntimeOperationFailure(completion.Operation, fmt.Errorf("publish completed cancel runtime operation: %w", err))
+	}
+	return completion.Operation, nil
+}
+
+// A live Goal revocation may crash after preparing its exact-Turn cancel but
+// before that runtime operation settles. On restart the durable Goal fence is
+// already the admission fact and no provider process exists to cancel. Finish
+// the orphaned cancel locally as interrupted so it cannot protect the stale
+// Turn from startup settlement or retry a missing Runtime forever.
+func (h *Host) goalGenerationFenceStopsRuntimeCancel(
+	ctx context.Context,
+	operation storesqlite.RuntimeOperation,
+) (bool, error) {
+	if h == nil || h.goalFences == nil || h.store == nil {
+		return false, nil
+	}
+	if _, ok := h.runtime.(RuntimeSessionLiveness); !ok {
+		return false, ErrRuntimeSessionLivenessUnavailable
+	}
+	if h.runtimeSessionLive(operation.WorkspaceID, operation.AgentSessionID) {
+		return false, nil
+	}
+	turn, found, err := h.store.GetTurn(ctx, operation.WorkspaceID, operation.AgentSessionID, operation.TurnID)
+	if err != nil || !found {
+		return false, err
+	}
+	fences, err := h.goalFences.ListGoalGenerationFencesForSession(ctx, operation.WorkspaceID, operation.AgentSessionID)
+	if err != nil {
+		return false, err
+	}
+	for _, fence := range fences {
+		if turn.SourceGoalOperationID == fence.TargetOperationID &&
+			turn.SourceGoalRevision == fence.TargetRevision &&
+			turn.SourceGoalRepairEpoch == fence.TargetRepairEpoch {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (h *Host) completeInterruptedCancelRuntimeOperation(
+	ctx context.Context,
+	operation storesqlite.RuntimeOperation,
+	owner string,
+) (storesqlite.RuntimeOperation, error) {
+	targets := runtimeCancelTargetsFromPayload(operation.Payload)
+	outcomes := make([]storesqlite.CancelRuntimeOperationTargetOutcome, 0, len(targets))
+	for _, target := range targets {
+		outcomes = append(outcomes, storesqlite.CancelRuntimeOperationTargetOutcome{
+			AgentSessionID: target.AgentSessionID,
+			TurnID:         target.TurnID,
+			Outcome:        storesqlite.TurnOutcomeInterrupted,
+		})
+	}
+	completion, _, err := h.operations.CompleteCancelRuntimeOperation(ctx, storesqlite.CompleteCancelRuntimeOperationInput{
+		WorkspaceID: operation.WorkspaceID, OperationID: operation.OperationID, LeaseOwner: owner,
+		TargetOutcomes: outcomes, NowUnixMS: h.now().UnixMilli(),
+	})
+	if err != nil {
+		return operation, err
+	}
+	if err := h.publishRuntimeOperationEvents(ctx, operation.WorkspaceID); err != nil {
+		logRuntimeOperationFailure(completion.Operation, fmt.Errorf("publish locally stopped cancel runtime operation: %w", err))
 	}
 	return completion.Operation, nil
 }

--- a/packages/agent/host/types.go
+++ b/packages/agent/host/types.go
@@ -308,6 +308,9 @@ type RuntimeResumeInput struct {
 	ProviderTargetRef      map[string]any
 	Metadata               storesqlite.SessionMetadata
 	InternalRuntimeContext map[string]any
+	// GoalGenerationFences are loaded from durable Host state and retained by
+	// the Runtime before the resumed Session is exposed for Goal/Turn work.
+	GoalGenerationFences []RuntimeGoalGenerationFenceInput
 	// RecreateIfMissing lets the runtime start a fresh provider session in place
 	// when the existing one can't be restored locally (imported conversations),
 	// instead of surfacing a non-recoverable restore error.

--- a/packages/agent/store-sqlite/goal_state.go
+++ b/packages/agent/store-sqlite/goal_state.go
@@ -364,6 +364,12 @@ func (s *Store) CompleteGoalControlOperation(ctx context.Context, input GoalCont
 	if input.WorkspaceID == "" || input.OperationID == "" || input.OccurredAtUnixMS <= 0 {
 		return GoalControlOperation{}, SessionGoalState{}, false, errors.New("goal completion identity and occurred time are required")
 	}
+	if input.Mode == "" {
+		input.Mode = GoalControlCompletionModeProvider
+	}
+	if input.Mode != GoalControlCompletionModeProvider && input.Mode != GoalControlCompletionModeLocalStop {
+		return GoalControlOperation{}, SessionGoalState{}, false, errors.New("unsupported goal completion mode")
+	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return GoalControlOperation{}, SessionGoalState{}, false, err
@@ -377,36 +383,67 @@ func (s *Store) CompleteGoalControlOperation(ctx context.Context, input GoalCont
 	if err != nil || !stateFound {
 		return GoalControlOperation{}, SessionGoalState{}, false, err
 	}
-	if op.Status == GoalOperationStatusCompleted || op.Status == GoalOperationStatusFailed || op.Status == GoalOperationStatusSuperseded {
+	localStop := input.Mode == GoalControlCompletionModeLocalStop
+	if localStop && (!input.Succeeded || op.Action != "clear") {
+		return GoalControlOperation{}, SessionGoalState{}, false, errors.New("local stop completion requires a successful clear operation")
+	}
+	if localStop && state.Revision < op.GoalRevision {
+		return GoalControlOperation{}, SessionGoalState{}, false, errors.New("local stop clear revision exceeds current goal state")
+	}
+	if op.Status == GoalOperationStatusCompleted || op.Status == GoalOperationStatusSuperseded ||
+		(op.Status == GoalOperationStatusFailed && !localStop) {
 		if _, err := s.commitTransaction(ctx, tx, input.WorkspaceID, nil); err != nil {
 			return GoalControlOperation{}, SessionGoalState{}, false, err
 		}
 		return op, state, false, nil
 	}
-	if op.RepairRequired && input.RepairEpoch != op.RepairEpoch {
+	if op.RepairRequired && input.RepairEpoch != op.RepairEpoch && !localStop {
 		if _, err := s.commitTransaction(ctx, tx, input.WorkspaceID, nil); err != nil {
 			return GoalControlOperation{}, SessionGoalState{}, false, err
 		}
 		return op, state, false, nil
 	}
-	input.Observed = normalizeObservedGoalTiming(input.Observed, state, input.OccurredAtUnixMS)
-	terminalFence, err := goalRevisionTerminalFenceTx(ctx, tx, state.WorkspaceID, state.AgentSessionID, state.Revision)
-	if err != nil {
-		return GoalControlOperation{}, SessionGoalState{}, false, err
+	if localStop {
+		input.Observed = cloneJSONMap(state.Observed)
+	} else {
+		input.Observed = normalizeObservedGoalTiming(input.Observed, state, input.OccurredAtUnixMS)
+	}
+	supersededLocalStop := localStop && state.Revision > op.GoalRevision
+	terminalFence := false
+	if !supersededLocalStop {
+		terminalFence, err = goalRevisionTerminalFenceTx(ctx, tx, state.WorkspaceID, state.AgentSessionID, state.Revision)
+		if err != nil {
+			return GoalControlOperation{}, SessionGoalState{}, false, err
+		}
 	}
 	status := GoalOperationStatusFailed
 	syncStatus := GoalSyncStatusFailed
-	if input.Succeeded {
+	if supersededLocalStop {
+		status = GoalOperationStatusSuperseded
+		syncStatus = state.SyncStatus
+	} else if input.Succeeded {
 		status = GoalOperationStatusCompleted
-		if goalStateConverged(state.Desired, input.Observed, state.Tombstoned) {
+		if localStop {
+			syncStatus = GoalSyncStatusUnknown
+		} else if goalStateConverged(state.Desired, input.Observed, state.Tombstoned) {
 			syncStatus = GoalSyncStatusSynced
 		} else {
 			syncStatus = GoalSyncStatusDiverged
 		}
 	}
 	stateLastError := strings.TrimSpace(input.LastError)
-	syncStatus, stateLastError = terminalGoalSyncState(state, syncStatus, stateLastError, terminalFence)
+	if supersededLocalStop {
+		stateLastError = state.LastError
+	} else {
+		syncStatus, stateLastError = terminalGoalSyncState(state, syncStatus, stateLastError, terminalFence)
+	}
 	evidenceJSON := marshalJSONMapOrEmpty(input.Evidence)
+	providerPhase := providerPhaseForCompletion(input.Succeeded)
+	observedAtUnixMS := input.OccurredAtUnixMS
+	if localStop {
+		providerPhase = GoalProviderPhaseUnknown
+		observedAtUnixMS = state.ObservedAtUnixMS
+	}
 	if _, err := tx.ExecContext(ctx, `
 UPDATE workspace_agent_goal_control_operations
 SET status = ?, evidence_json = ?, last_error = ?, provider_phase = ?,
@@ -414,17 +451,15 @@ SET status = ?, evidence_json = ?, last_error = ?, provider_phase = ?,
     repair_required = 0,
     updated_at_unix_ms = ?, completed_at_unix_ms = ?
 WHERE workspace_id = ? AND operation_id = ?
-`, status, evidenceJSON, strings.TrimSpace(input.LastError), providerPhaseForCompletion(input.Succeeded), input.OccurredAtUnixMS,
+`, status, evidenceJSON, strings.TrimSpace(input.LastError), providerPhase, input.OccurredAtUnixMS,
 		input.OccurredAtUnixMS, input.WorkspaceID, input.OperationID); err != nil {
 		return GoalControlOperation{}, SessionGoalState{}, false, err
 	}
-	if _, err := tx.ExecContext(ctx, `
-UPDATE workspace_agent_session_goals
-SET observed_json = ?, sync_status = ?, pending_operation_id = NULL,
-    last_evidence_json = ?, last_error = ?, observed_at_unix_ms = ?, updated_at_unix_ms = ?
-WHERE workspace_id = ? AND agent_session_id = ? AND pending_operation_id = ?
-`, nullableJSONMap(input.Observed), syncStatus, evidenceJSON, stateLastError,
-		input.OccurredAtUnixMS, input.OccurredAtUnixMS, input.WorkspaceID, op.AgentSessionID, input.OperationID); err != nil {
+	stateChanged, err := updateGoalStateForOperationCompletionTx(
+		ctx, tx, input, op, syncStatus, evidenceJSON, stateLastError,
+		observedAtUnixMS, localStop, supersededLocalStop,
+	)
+	if err != nil {
 		return GoalControlOperation{}, SessionGoalState{}, false, err
 	}
 	op, _, err = getGoalControlOperationTx(ctx, tx, input.WorkspaceID, input.OperationID)
@@ -435,10 +470,19 @@ WHERE workspace_id = ? AND agent_session_id = ? AND pending_operation_id = ?
 	if err != nil {
 		return GoalControlOperation{}, SessionGoalState{}, false, err
 	}
-	delta, err := s.commitTransaction(ctx, tx, input.WorkspaceID, []TransactionMutation{
-		transactionMutation(input.WorkspaceID, op.AgentSessionID, MutationEntityGoalOperation, op.OperationID, "complete", op.UpdatedAtUnixMS),
-		transactionMutation(input.WorkspaceID, op.AgentSessionID, MutationEntityGoalState, op.AgentSessionID, "upsert", state.Revision),
-	})
+	operationMutationAction := "complete"
+	if supersededLocalStop {
+		operationMutationAction = "supersede"
+	}
+	mutations := []TransactionMutation{
+		transactionMutation(input.WorkspaceID, op.AgentSessionID, MutationEntityGoalOperation, op.OperationID, operationMutationAction, op.UpdatedAtUnixMS),
+	}
+	if stateChanged {
+		mutations = append(mutations,
+			transactionMutation(input.WorkspaceID, op.AgentSessionID, MutationEntityGoalState, op.AgentSessionID, "upsert", state.Revision),
+		)
+	}
+	delta, err := s.commitTransaction(ctx, tx, input.WorkspaceID, mutations)
 	if err != nil {
 		return GoalControlOperation{}, SessionGoalState{}, false, err
 	}

--- a/packages/agent/store-sqlite/goal_state_completion.go
+++ b/packages/agent/store-sqlite/goal_state_completion.go
@@ -1,0 +1,62 @@
+package storesqlite
+
+import (
+	"context"
+	"database/sql"
+)
+
+func updateGoalStateForOperationCompletionTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	input GoalControlOperationComplete,
+	op GoalControlOperation,
+	syncStatus string,
+	evidenceJSON string,
+	stateLastError string,
+	observedAtUnixMS int64,
+	localStop bool,
+	supersededLocalStop bool,
+) (bool, error) {
+	if supersededLocalStop {
+		return false, nil
+	}
+	query := `
+UPDATE workspace_agent_session_goals
+SET observed_json = ?, sync_status = ?, pending_operation_id = NULL,
+    last_evidence_json = ?, last_error = ?, observed_at_unix_ms = ?, updated_at_unix_ms = ?
+WHERE workspace_id = ? AND agent_session_id = ? AND pending_operation_id = ?
+	`
+	args := []any{
+		nullableJSONMap(input.Observed), syncStatus, evidenceJSON, stateLastError,
+		observedAtUnixMS, input.OccurredAtUnixMS, input.WorkspaceID, op.AgentSessionID, input.OperationID,
+	}
+	if localStop {
+		query = `
+UPDATE workspace_agent_session_goals
+SET observed_json = ?, sync_status = ?, pending_operation_id = NULL,
+    last_evidence_json = ?, last_error = ?, observed_at_unix_ms = ?, updated_at_unix_ms = ?
+WHERE workspace_id = ? AND agent_session_id = ? AND revision = ?
+  AND (pending_operation_id = ? OR pending_operation_id IS NULL)
+		`
+		args = []any{
+			nullableJSONMap(input.Observed), syncStatus, evidenceJSON, stateLastError,
+			observedAtUnixMS, input.OccurredAtUnixMS, input.WorkspaceID, op.AgentSessionID,
+			op.GoalRevision, input.OperationID,
+		}
+	}
+	result, err := tx.ExecContext(ctx, query, args...)
+	if err != nil {
+		return false, err
+	}
+	if !localStop {
+		return true, nil
+	}
+	updated, err := rowsWereAffected(result, "complete local stop goal state CAS")
+	if err != nil {
+		return false, err
+	}
+	if !updated {
+		return false, ErrGoalOperationConflict
+	}
+	return true, nil
+}

--- a/packages/agent/store-sqlite/goal_state_test.go
+++ b/packages/agent/store-sqlite/goal_state_test.go
@@ -293,6 +293,130 @@ func TestGoalControlOperationPersistsWithoutTurn(t *testing.T) {
 	}
 }
 
+func TestGoalControlLocalStopCompletesClearWithoutClaimingProviderApplication(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	ctx := context.Background()
+	if _, err := store.ReportSessionState(ctx, SessionStateReport{
+		WorkspaceID: "ws-local-stop", AgentSessionID: "session-local-stop", Provider: "codex",
+		OccurredAtUnixMS: 10,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := store.PrepareGoalControlOperation(ctx, GoalControlOperationPrepare{
+		OperationID: "goal-set", WorkspaceID: "ws-local-stop", AgentSessionID: "session-local-stop",
+		Action: "set", Objective: "must remain stopped", OccurredAtUnixMS: 20,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := store.CompleteGoalControlOperation(ctx, GoalControlOperationComplete{
+		WorkspaceID: "ws-local-stop", OperationID: "goal-set", Succeeded: true,
+		Observed: map[string]any{"objective": "must remain stopped", "status": "active"}, OccurredAtUnixMS: 30,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := store.PrepareGoalControlOperation(ctx, GoalControlOperationPrepare{
+		OperationID: "goal-clear", WorkspaceID: "ws-local-stop", AgentSessionID: "session-local-stop",
+		Action: "clear", ExpectedRevision: 1, OccurredAtUnixMS: 40,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	op, state, changed, err := store.CompleteGoalControlOperation(ctx, GoalControlOperationComplete{
+		WorkspaceID: "ws-local-stop", OperationID: "goal-clear", Succeeded: true,
+		Mode:     GoalControlCompletionModeLocalStop,
+		Evidence: map[string]any{"source": "goal_generation_fence_recovery"}, OccurredAtUnixMS: 50,
+	})
+	if err != nil || !changed {
+		t.Fatalf("local stop operation=%#v state=%#v changed=%v error=%v", op, state, changed, err)
+	}
+	if op.Status != GoalOperationStatusCompleted || op.ProviderPhase != GoalProviderPhaseUnknown ||
+		state.Revision != 2 || !state.Tombstoned || state.Desired != nil ||
+		state.PendingOperationID != "" || state.SyncStatus != GoalSyncStatusUnknown {
+		t.Fatalf("local stop operation=%#v state=%#v", op, state)
+	}
+	if state.Observed["objective"] != "must remain stopped" || state.ObservedAtUnixMS != 30 {
+		t.Fatalf("local stop overwrote provider observation: %#v", state)
+	}
+}
+
+func TestGoalControlLocalStopConvergesPreviouslyFailedClear(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	ctx := context.Background()
+	if _, err := store.ReportSessionState(ctx, SessionStateReport{
+		WorkspaceID: "ws-local-stop-failed", AgentSessionID: "session-local-stop-failed", Provider: "codex",
+		OccurredAtUnixMS: 10,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := store.PrepareGoalControlOperation(ctx, GoalControlOperationPrepare{
+		OperationID: "goal-clear-failed", WorkspaceID: "ws-local-stop-failed",
+		AgentSessionID: "session-local-stop-failed", Action: "clear", OccurredAtUnixMS: 20,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, failed, changed, err := store.CompleteGoalControlOperation(ctx, GoalControlOperationComplete{
+		WorkspaceID: "ws-local-stop-failed", OperationID: "goal-clear-failed",
+		LastError: "provider unavailable", OccurredAtUnixMS: 30,
+	}); err != nil || !changed || failed.SyncStatus != GoalSyncStatusFailed {
+		t.Fatalf("failed clear state=%#v changed=%v error=%v", failed, changed, err)
+	}
+	op, state, changed, err := store.CompleteGoalControlOperation(ctx, GoalControlOperationComplete{
+		WorkspaceID: "ws-local-stop-failed", OperationID: "goal-clear-failed", Succeeded: true,
+		Mode: GoalControlCompletionModeLocalStop, OccurredAtUnixMS: 40,
+	})
+	if err != nil || !changed || op.Status != GoalOperationStatusCompleted ||
+		op.ProviderPhase != GoalProviderPhaseUnknown || state.SyncStatus != GoalSyncStatusUnknown ||
+		state.PendingOperationID != "" || !state.Tombstoned {
+		t.Fatalf("local stop operation=%#v state=%#v changed=%v error=%v", op, state, changed, err)
+	}
+}
+
+func TestGoalControlLocalStopSupersedesFailedClearAfterNewerGoal(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	ctx := context.Background()
+	if _, err := store.ReportSessionState(ctx, SessionStateReport{
+		WorkspaceID: "ws-local-stop-newer", AgentSessionID: "session-local-stop-newer", Provider: "codex",
+		OccurredAtUnixMS: 10,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := store.PrepareGoalControlOperation(ctx, GoalControlOperationPrepare{
+		OperationID: "old-clear", WorkspaceID: "ws-local-stop-newer",
+		AgentSessionID: "session-local-stop-newer", Action: "clear", OccurredAtUnixMS: 20,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := store.CompleteGoalControlOperation(ctx, GoalControlOperationComplete{
+		WorkspaceID: "ws-local-stop-newer", OperationID: "old-clear",
+		LastError: "provider unavailable", OccurredAtUnixMS: 30,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	newGoal, expectedState, _, err := store.PrepareGoalControlOperation(ctx, GoalControlOperationPrepare{
+		OperationID: "new-goal", WorkspaceID: "ws-local-stop-newer",
+		AgentSessionID: "session-local-stop-newer", Action: "set", Objective: "new generation",
+		OccurredAtUnixMS: 40,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	op, state, changed, err := store.CompleteGoalControlOperation(ctx, GoalControlOperationComplete{
+		WorkspaceID: "ws-local-stop-newer", OperationID: "old-clear", Succeeded: true,
+		Mode: GoalControlCompletionModeLocalStop, OccurredAtUnixMS: 50,
+	})
+	if err != nil || !changed || op.Status != GoalOperationStatusSuperseded ||
+		op.ProviderPhase != GoalProviderPhaseUnknown {
+		t.Fatalf("superseded local stop operation=%#v changed=%v error=%v", op, changed, err)
+	}
+	if state.Revision != expectedState.Revision || state.PendingOperationID != newGoal.OperationID ||
+		state.Tombstoned || state.SyncStatus != GoalSyncStatusPending ||
+		state.Desired["objective"] != "new generation" {
+		t.Fatalf("newer Goal was changed by old local stop: %#v", state)
+	}
+}
+
 func TestGoalAcceptedIgnoresSessionMetadataUntilHostCompletesOperation(t *testing.T) {
 	t.Parallel()
 	store := openTestStore(t, testOptions(&staticProjectPaths{}))

--- a/packages/agent/store-sqlite/goal_state_types.go
+++ b/packages/agent/store-sqlite/goal_state_types.go
@@ -21,7 +21,15 @@ const (
 	GoalProviderPhaseAccepted   = "accepted"
 	GoalProviderPhaseApplied    = "applied"
 	GoalProviderPhaseUnknown    = "unknown"
+
+	GoalControlCompletionModeProvider  GoalControlCompletionMode = "provider"
+	GoalControlCompletionModeLocalStop GoalControlCompletionMode = "local_stop"
 )
+
+// GoalControlCompletionMode distinguishes provider-confirmed completion from
+// restart recovery that only finalizes the durable local stop. The zero value
+// preserves the provider-confirmed behavior for existing callers.
+type GoalControlCompletionMode string
 
 var (
 	ErrGoalOperationConflict       = errors.New("goal control operation identity conflicts with existing state")
@@ -113,6 +121,7 @@ type ProviderGoalAdoption struct {
 type GoalControlOperationComplete struct {
 	OperationID      string
 	WorkspaceID      string
+	Mode             GoalControlCompletionMode
 	Observed         map[string]any
 	Evidence         map[string]any
 	LastError        string

--- a/services/tuttid/service/agent/host_conformance_test.go
+++ b/services/tuttid/service/agent/host_conformance_test.go
@@ -435,6 +435,22 @@ func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconfo
 			Evidence: map[string]any{"confidence": "authoritative"},
 		}, nil
 	}
+	if fixture.DisconnectGoalFenceDelivery {
+		var disconnectOnce sync.Once
+		d.runtime.goalGenerationFenceHook = func(_ context.Context, input RuntimeGoalGenerationFenceInput) error {
+			disconnected := false
+			disconnectOnce.Do(func() {
+				d.runtime.mu.Lock()
+				delete(d.runtime.sessions, input.WorkspaceID+":"+input.AgentSessionID)
+				d.runtime.mu.Unlock()
+				disconnected = true
+			})
+			if disconnected {
+				return ErrSessionNotFound
+			}
+			return nil
+		}
+	}
 	if fixture.LiveOnlySession != nil {
 		seed := *fixture.LiveOnlySession
 		settings := seed.Settings
@@ -1207,7 +1223,11 @@ func (d *legacyHostConformanceDriver) Metrics() hostconformance.Metrics {
 			last.RequireProviderAcceptance
 	}
 	if len(d.runtime.resumeCalls) > 0 {
-		metrics.LastResumeRecreate = d.runtime.resumeCalls[len(d.runtime.resumeCalls)-1].RecreateIfMissing
+		lastResume := d.runtime.resumeCalls[len(d.runtime.resumeCalls)-1]
+		metrics.LastResumeRecreate = lastResume.RecreateIfMissing
+		metrics.LastResumeGoalGenerationFences = append(
+			[]agenthost.RuntimeGoalGenerationFenceInput(nil), lastResume.GoalGenerationFences...,
+		)
 	}
 	return metrics
 }

--- a/services/tuttid/service/agent/service_test_runtime_test.go
+++ b/services/tuttid/service/agent/service_test_runtime_test.go
@@ -24,42 +24,43 @@ import (
 )
 
 type fakeRuntime struct {
-	mu                     sync.Mutex
-	nextID                 int
-	canResumeCalls         []RuntimeResumeInput
-	canResumeHook          func(RuntimeResumeInput) bool
-	cancelCalls            []RuntimeCancelInput
-	cancelResult           RuntimeCancelResult
-	cancelResultSet        bool
-	closeErr               error
-	closeCalls             []RuntimeCloseInput
-	execErr                error
-	execHook               func(RuntimeExecInput) (RuntimeExecResult, error)
-	execCalls              []RuntimeExecInput
-	guidanceTargetMismatch bool
-	guidanceTarget         string
-	guidanceProviderCalls  int
-	provenanceErr          error
-	provenanceHook         func(RuntimeSubmitProvenanceInput) error
-	provenanceCalls        []RuntimeSubmitProvenanceInput
-	goalControlCalls       []RuntimeGoalControlInput
-	goalControlHook        func(context.Context, RuntimeGoalControlInput) (RuntimeGoalControlResult, error)
-	goalReconcileCalls     []RuntimeGoalControlInput
-	goalReconcileHook      func(context.Context, RuntimeGoalControlInput) (RuntimeGoalReconcileResult, error)
-	goalRecoveryPolicyHook func(context.Context, RuntimeGoalControlInput) (RuntimeGoalRecoveryPolicy, error)
-	goalGenerationFences   []RuntimeGoalGenerationFenceInput
-	resumeCalls            []RuntimeResumeInput
-	sessions               map[string]ProviderRuntimeSession
-	submitInteractiveCalls []RuntimeSubmitInteractiveInput
-	submitInteractiveErr   error
-	interactiveDisposition RuntimeInteractiveDisposition
-	startErr               error
-	startCalls             []RuntimeStartInput
-	startHook              func(RuntimeStartInput, ProviderRuntimeSession) ProviderRuntimeSession
-	updateSettingsCalls    []RuntimeUpdateSettingsInput
-	closeHook              func(RuntimeCloseInput)
-	validateErr            error
-	validateCalls          []RuntimeExecInput
+	mu                      sync.Mutex
+	nextID                  int
+	canResumeCalls          []RuntimeResumeInput
+	canResumeHook           func(RuntimeResumeInput) bool
+	cancelCalls             []RuntimeCancelInput
+	cancelResult            RuntimeCancelResult
+	cancelResultSet         bool
+	closeErr                error
+	closeCalls              []RuntimeCloseInput
+	execErr                 error
+	execHook                func(RuntimeExecInput) (RuntimeExecResult, error)
+	execCalls               []RuntimeExecInput
+	guidanceTargetMismatch  bool
+	guidanceTarget          string
+	guidanceProviderCalls   int
+	provenanceErr           error
+	provenanceHook          func(RuntimeSubmitProvenanceInput) error
+	provenanceCalls         []RuntimeSubmitProvenanceInput
+	goalControlCalls        []RuntimeGoalControlInput
+	goalControlHook         func(context.Context, RuntimeGoalControlInput) (RuntimeGoalControlResult, error)
+	goalReconcileCalls      []RuntimeGoalControlInput
+	goalReconcileHook       func(context.Context, RuntimeGoalControlInput) (RuntimeGoalReconcileResult, error)
+	goalRecoveryPolicyHook  func(context.Context, RuntimeGoalControlInput) (RuntimeGoalRecoveryPolicy, error)
+	goalGenerationFences    []RuntimeGoalGenerationFenceInput
+	goalGenerationFenceHook func(context.Context, RuntimeGoalGenerationFenceInput) error
+	resumeCalls             []RuntimeResumeInput
+	sessions                map[string]ProviderRuntimeSession
+	submitInteractiveCalls  []RuntimeSubmitInteractiveInput
+	submitInteractiveErr    error
+	interactiveDisposition  RuntimeInteractiveDisposition
+	startErr                error
+	startCalls              []RuntimeStartInput
+	startHook               func(RuntimeStartInput, ProviderRuntimeSession) ProviderRuntimeSession
+	updateSettingsCalls     []RuntimeUpdateSettingsInput
+	closeHook               func(RuntimeCloseInput)
+	validateErr             error
+	validateCalls           []RuntimeExecInput
 }
 
 type fakeAgentTargetStore struct {
@@ -521,10 +522,14 @@ func (f *fakeRuntime) GoalRecoveryPolicy(ctx context.Context, input RuntimeGoalC
 	return RuntimeGoalRecoveryPolicy{QuerySupported: true, ReplaySetAfterRestart: true}, nil
 }
 
-func (f *fakeRuntime) FenceGoalGeneration(_ context.Context, input RuntimeGoalGenerationFenceInput) error {
+func (f *fakeRuntime) FenceGoalGeneration(ctx context.Context, input RuntimeGoalGenerationFenceInput) error {
 	f.mu.Lock()
-	defer f.mu.Unlock()
 	f.goalGenerationFences = append(f.goalGenerationFences, input)
+	hook := f.goalGenerationFenceHook
+	f.mu.Unlock()
+	if hook != nil {
+		return hook(ctx, input)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- converge pending Goal generation fences locally during startup recovery when no Runtime Session is live, without resuming the Provider or issuing a live cancel
- preserve truthful durable state by completing restart-only clears with unknown Provider application and superseding stale clears when a newer Goal generation exists
- preload durable fences into Runtime resume and install them before the resumed Session is published for Goal or Turn work
- locally settle exact Goal-fence cancel operations left by a crash as interrupted, while preserving runtime fence + exact active-Turn cancel for live revocation
- add shared Host conformance and focused SQLite, Host, Runtime Controller, adapter, restart, race, and crash-window coverage

Does tsh (or another Host consumer) also need this behavior? Yes. The lifecycle semantics and conformance scenario live in `packages/agent/host`; Runtime resume gains the shared fence input contract. No tuttid- or TSH-only lifecycle fallback is introduced.

## Verification

- `pnpm check:changed` — 14/14 lanes passed after rebasing onto latest `origin/main`
- pre-push `pnpm check:changed -- --push-ready` — 15/15 lanes passed
- commit hooks and `git diff --check` passed

## Fallback Three Questions

- Source: a Host crash can preserve an accepted Goal fence, conditional clear, or exact-Turn cancel while the in-memory Runtime/Provider Session disappears.
- Why can it not be fixed at that source? The durable lifecycle intent must survive the process boundary, while the provider connection is intentionally ephemeral and cannot be canceled after restart.
- Removal condition: remove the restart-local branches only if fence, clear, cancel settlement, and provider admission become one atomic durable boundary that is installed before any resumed provider can replay work.

## Checklist

- [x] Agent lifecycle semantics live in `packages/agent/host` and include a shared conformance scenario.
- [x] I kept the change focused on restart recovery of fenced Goal generations.
- [x] I updated the Host lifecycle documentation.
- [x] No top-level multilingual README or CONTRIBUTING source changed.
- [x] I ran the lowest meaningful focused checks and the repository changed-aware checks.
- [x] The commit is signed off with DCO.
