### PR TITLE
fix(desktop): bundle Mutagen in Windows release

### DIFF
--- a/.github/workflows/windows-desktop-alpha.yml
+++ b/.github/workflows/windows-desktop-alpha.yml
@@ -113,6 +113,13 @@ jobs:
           $shellMetadata = Get-Content (Join-Path $shellRuntimeRoot 'runtime.json') -Raw | ConvertFrom-Json
           $shell = Resolve-Path (Join-Path $shellRuntimeRoot $shellMetadata.executable)
           $shellBin = Split-Path -Parent $shell
+          $mutagenRuntimeRoot = Resolve-Path 'apps/desktop/dist/win-unpacked/resources/bin/mutagen'
+          $mutagenMetadata = Get-Content (Join-Path $mutagenRuntimeRoot 'runtime.json') -Raw | ConvertFrom-Json
+          $mutagen = Resolve-Path (Join-Path $mutagenRuntimeRoot $mutagenMetadata.executable)
+          if (-not (Test-Path (Join-Path $mutagenRuntimeRoot 'LICENSE') -PathType Leaf)) { throw 'packaged Mutagen license is missing' }
+          if (-not (Test-Path (Join-Path $mutagenRuntimeRoot 'SSPL-LICENSE') -PathType Leaf)) { throw 'packaged Mutagen SSPL license is missing' }
+          & $mutagen version
+          if ($LASTEXITCODE -ne 0) { throw 'packaged Mutagen validation failed' }
           $package = Resolve-Path 'services/tuttid/builtin-apps/tutti-onboarding/build/package'
           $runtime = Join-Path $env:RUNNER_TEMP 'tutti-onboarding-runtime'
           $data = Join-Path $env:RUNNER_TEMP 'tutti-onboarding-data'

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -88,6 +88,13 @@
           "filter": [
             "**/*"
           ]
+        },
+        {
+          "from": "build/mutagen",
+          "to": "bin/mutagen",
+          "filter": [
+            "**/*"
+          ]
         }
       ]
     },

--- a/apps/desktop/scripts/vendor-mutagen.mjs
+++ b/apps/desktop/scripts/vendor-mutagen.mjs
@@ -1,0 +1,215 @@
+import { createHash, randomUUID } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import {
+  access,
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, "../../..");
+const lock = JSON.parse(
+  await readFile(join(repoRoot, "config/tutti.mutagen.lock.json"), "utf8")
+);
+if (lock.schemaVersion !== "tutti.mutagen-lock.v1") {
+  throw new Error(`unsupported Mutagen lock schema: ${lock.schemaVersion}`);
+}
+
+const platform = parsePlatformArgument(process.argv.slice(2));
+const config = lock.platforms?.[platform];
+if (!config) throw new Error(`Mutagen lock does not contain ${platform}`);
+const outputRoot = resolve(
+  process.env.TUTTI_MUTAGEN_STAGING_DIR?.trim() ||
+    join(repoRoot, "apps/desktop/build/mutagen")
+);
+const archivePath = await resolveArchive(config);
+const extractRoot = await mkdtemp(join(tmpdir(), "tutti-mutagen-"));
+
+try {
+  const archiveExecutable = listArchiveExecutable(
+    archivePath,
+    config.executable
+  );
+  extractArchiveEntry(archivePath, extractRoot, archiveExecutable);
+  const extractedExecutable = join(
+    extractRoot,
+    ...archiveExecutable.split("/")
+  );
+  await access(extractedExecutable);
+
+  await rm(outputRoot, { recursive: true, force: true });
+  await mkdir(outputRoot, { recursive: true });
+  const executable = join(outputRoot, config.executable);
+  await copyFile(extractedExecutable, executable);
+  for (const license of config.licenseFiles) {
+    await downloadVerifiedFile(
+      license.url,
+      license.sha256,
+      join(outputRoot, license.name)
+    );
+  }
+  await writeFile(
+    join(outputRoot, "runtime.json"),
+    `${JSON.stringify(
+      {
+        schemaVersion: "tutti.mutagen.v1",
+        platform,
+        version: config.version,
+        executable: config.executable,
+        sourceArchive: basename(config.archiveUrl),
+        sourceArchiveSha256: config.archiveSha256,
+        executableSha256: await sha256File(executable),
+        executableSizeBytes: (await stat(executable)).size
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+  await writeFile(
+    join(outputRoot, "THIRD_PARTY_NOTICES.md"),
+    `# Mutagen third-party notices
+
+Tutti includes an unmodified Mutagen ${config.version} executable from the
+official release archive below for Windows auth-file synchronization.
+
+- Source and release: https://github.com/mutagen-io/mutagen/tree/v${config.version}
+- Release archive: ${config.archiveUrl}
+- Release archive SHA-256: ${config.archiveSha256}
+
+The upstream LICENSE states that official Mutagen release builds from v0.17
+onward include SSPL-licensed code. The complete upstream LICENSE and SSPL text
+are distributed beside this notice.
+`,
+    "utf8"
+  );
+} finally {
+  await rm(extractRoot, { recursive: true, force: true });
+}
+
+function parsePlatformArgument(args) {
+  const value = args.find((argument) => argument.startsWith("--platform="));
+  if (!value) throw new Error("Mutagen platform is required");
+  const platform = value.slice("--platform=".length).trim();
+  if (!platform || args.length !== 1) {
+    throw new Error(`invalid Mutagen arguments: ${args.join(" ")}`);
+  }
+  return platform;
+}
+
+async function resolveArchive(config) {
+  const override = process.env.TUTTI_MUTAGEN_ARCHIVE?.trim();
+  if (override) {
+    const path = resolve(override);
+    await verifyFile(path, config.archiveSha256, "Mutagen archive");
+    return path;
+  }
+  const cacheRoot = join(tmpdir(), "tutti-build-cache", "mutagen");
+  const path = join(cacheRoot, basename(config.archiveUrl));
+  await mkdir(cacheRoot, { recursive: true });
+  try {
+    await verifyFile(path, config.archiveSha256, "Mutagen archive");
+    return path;
+  } catch {
+    await rm(path, { force: true });
+  }
+  await downloadVerifiedFile(config.archiveUrl, config.archiveSha256, path);
+  return path;
+}
+
+async function downloadVerifiedFile(url, expectedSha256, target) {
+  const response = await fetch(url, { redirect: "follow" });
+  if (!response.ok) throw new Error(`download ${url}: HTTP ${response.status}`);
+  const bytes = Buffer.from(await response.arrayBuffer());
+  const actualSha256 = createHash("sha256").update(bytes).digest("hex");
+  if (actualSha256 !== expectedSha256) {
+    throw new Error(
+      `download checksum mismatch for ${url}: got ${actualSha256}, want ${expectedSha256}`
+    );
+  }
+  await mkdir(dirname(target), { recursive: true });
+  const temporary = `${target}.${randomUUID()}.tmp`;
+  await writeFile(temporary, bytes, { flag: "wx" });
+  try {
+    await rm(target, { force: true });
+    await rename(temporary, target);
+  } finally {
+    await rm(temporary, { force: true });
+  }
+}
+
+async function verifyFile(path, expectedSha256, label) {
+  await access(path);
+  const actualSha256 = await sha256File(path);
+  if (actualSha256 !== expectedSha256) {
+    throw new Error(
+      `${label} checksum mismatch: got ${actualSha256}, want ${expectedSha256}`
+    );
+  }
+}
+
+async function sha256File(path) {
+  return createHash("sha256")
+    .update(await readFile(path))
+    .digest("hex");
+}
+
+function listArchiveExecutable(archivePath, executable) {
+  const result = spawnSync(resolveTarCommand(), ["-tzf", archivePath], {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `list Mutagen archive: ${result.stderr || result.stdout || result.error}`
+    );
+  }
+  const matches = result.stdout
+    .split(/\r?\n/u)
+    .map((entry) => entry.replace(/^\.\//u, ""))
+    .filter((entry) => entry && basename(entry) === executable);
+  if (matches.length !== 1) {
+    throw new Error(
+      `Mutagen archive must contain exactly one ${executable}, found ${matches.length}`
+    );
+  }
+  const entry = matches[0];
+  if (
+    isAbsolute(entry) ||
+    entry.split("/").some((part) => part === "" || part === "..")
+  ) {
+    throw new Error(`unsafe Mutagen archive entry: ${entry}`);
+  }
+  return entry;
+}
+
+function extractArchiveEntry(archivePath, targetRoot, entry) {
+  const result = spawnSync(
+    resolveTarCommand(),
+    ["-xzf", archivePath, "-C", targetRoot, entry],
+    { encoding: "utf8" }
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      `extract Mutagen archive: ${result.stderr || result.stdout || result.error}`
+    );
+  }
+}
+
+function resolveTarCommand() {
+  if (process.platform !== "win32") return "tar";
+  const systemRoot = process.env.SystemRoot?.trim();
+  if (!systemRoot) {
+    throw new Error("extract Mutagen archive: SystemRoot is unavailable");
+  }
+  return join(systemRoot, "System32", "tar.exe");
+}

--- a/apps/desktop/src/main/daemon/tuttidManager.test.ts
+++ b/apps/desktop/src/main/daemon/tuttidManager.test.ts
@@ -25,7 +25,8 @@ import {
   resolveClaudeSDKSidecarDaemonEnv,
   resolveLaunchSpec,
   resolveManagedDaemonProcessEnv,
-  resolveManagedPosixShellDaemonEnv
+  resolveManagedPosixShellDaemonEnv,
+  resolveMutagenDaemonEnv
 } from "./tuttidManager.ts";
 
 const repoRoot = resolve(
@@ -312,6 +313,64 @@ test("resolveManagedPosixShellDaemonEnv points the daemon at the packaged shell"
     assert.deepEqual(got, {
       TUTTI_MANAGED_POSIX_SHELL: shell
     });
+  } finally {
+    restoreEnv(previousEnv);
+  }
+});
+
+test("resolveMutagenDaemonEnv respects an explicit operator override", () => {
+  const previousEnv = { ...process.env };
+  try {
+    process.env.TUTTI_MUTAGEN_BIN = "C:\\custom\\mutagen.exe";
+    const got = resolveMutagenDaemonEnv({
+      isPackaged: true,
+      resourcesPath: join(tmpdir(), "tutti-resources")
+    });
+    assert.deepEqual(got, {});
+  } finally {
+    restoreEnv(previousEnv);
+  }
+});
+
+test("resolveMutagenDaemonEnv respects a shell environment override", () => {
+  const previousEnv = { ...process.env };
+  try {
+    delete process.env.TUTTI_MUTAGEN_BIN;
+    const got = resolveMutagenDaemonEnv(
+      {
+        isPackaged: true,
+        resourcesPath: join(tmpdir(), "tutti-resources")
+      },
+      { inheritedEnv: { TUTTI_MUTAGEN_BIN: "C:\\custom\\mutagen.exe" } }
+    );
+    assert.deepEqual(got, {});
+  } finally {
+    restoreEnv(previousEnv);
+  }
+});
+
+test("resolveMutagenDaemonEnv points the daemon at packaged Mutagen", async () => {
+  const previousEnv = { ...process.env };
+  try {
+    delete process.env.TUTTI_MUTAGEN_BIN;
+    const resourcesPath = await mkdtemp(join(tmpdir(), "tutti-resources-"));
+    const runtimeRoot = join(resourcesPath, "bin", "mutagen");
+    const executable = join(runtimeRoot, "mutagen.exe");
+    await mkdir(runtimeRoot, { recursive: true });
+    await writeFile(executable, "stub\n");
+    await writeFile(
+      join(runtimeRoot, "runtime.json"),
+      JSON.stringify({
+        schemaVersion: "tutti.mutagen.v1",
+        executable: "mutagen.exe"
+      })
+    );
+
+    const got = resolveMutagenDaemonEnv({
+      isPackaged: true,
+      resourcesPath
+    });
+    assert.deepEqual(got, { TUTTI_MUTAGEN_BIN: executable });
   } finally {
     restoreEnv(previousEnv);
   }

--- a/apps/desktop/src/main/daemon/tuttidManager.ts
+++ b/apps/desktop/src/main/daemon/tuttidManager.ts
@@ -342,6 +342,7 @@ const vendoredClaudeSDKSidecarRelPath = join(
   "main.ts"
 );
 const vendoredManagedPosixShellRootRelPath = join("bin", "managed-posix-shell");
+const vendoredMutagenRootRelPath = join("bin", "mutagen");
 
 // resolveBrowserMcpDaemonEnv points the daemon at a vendored chrome-devtools-mcp
 // in packaged builds so browser use never has to fetch it over the network at
@@ -491,6 +492,59 @@ export function resolveManagedPosixShellDaemonEnv(
   };
 }
 
+export function resolveMutagenDaemonEnv(
+  runtime?: DesktopElectronAppRuntime,
+  options: ResolveLaunchSpecOptions & {
+    inheritedEnv?: Record<string, string>;
+  } = {}
+): Record<string, string> {
+  if (
+    process.env.TUTTI_MUTAGEN_BIN?.trim() ||
+    options.inheritedEnv?.TUTTI_MUTAGEN_BIN?.trim()
+  ) {
+    return {};
+  }
+  let appRuntime: DesktopElectronAppRuntime;
+  try {
+    appRuntime = runtime ?? resolveElectronAppRuntime();
+  } catch {
+    return {};
+  }
+  const runtimeRoot = appRuntime.isPackaged
+    ? resolve(appRuntime.resourcesPath, vendoredMutagenRootRelPath)
+    : resolve(
+        options.repoRoot ?? resolveRepoRoot(),
+        "apps/desktop/build/mutagen"
+      );
+  let executable: unknown;
+  try {
+    const metadata = JSON.parse(
+      readFileSync(join(runtimeRoot, "runtime.json"), "utf8")
+    ) as { schemaVersion?: unknown; executable?: unknown };
+    if (metadata.schemaVersion !== "tutti.mutagen.v1") {
+      return {};
+    }
+    executable = metadata.executable;
+  } catch {
+    return {};
+  }
+  if (typeof executable !== "string" || executable.trim() !== executable) {
+    return {};
+  }
+  const entry = resolve(runtimeRoot, executable);
+  const relativeEntry = relative(runtimeRoot, entry);
+  if (
+    executable === "" ||
+    relativeEntry === ".." ||
+    relativeEntry.startsWith(`..${sep}`) ||
+    isAbsolute(relativeEntry) ||
+    !existsSync(entry)
+  ) {
+    return {};
+  }
+  return { TUTTI_MUTAGEN_BIN: entry };
+}
+
 function resolveManagedRuntimeDaemonEnv(
   userShellEnv?: Record<string, string>
 ): Record<string, string> {
@@ -524,6 +578,7 @@ export function resolveManagedDaemonProcessEnv(
     ...resolveComputerMcpDaemonEnv(),
     ...resolveClaudeSDKSidecarDaemonEnv(),
     ...resolveManagedPosixShellDaemonEnv(),
+    ...resolveMutagenDaemonEnv(undefined, { inheritedEnv: input.userShellEnv }),
     TUTTI_APP_VERSION: process.env.TUTTI_APP_VERSION?.trim() ?? "",
     TUTTI_DESKTOP_UPDATE_ADMISSION_ARCHITECTURE:
       desktopUpdateAdmission?.architecture ?? "",

--- a/config/tutti.mutagen.lock.json
+++ b/config/tutti.mutagen.lock.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "tutti.mutagen-lock.v1",
+  "platforms": {
+    "windows-amd64": {
+      "version": "0.18.1",
+      "archiveUrl": "https://github.com/mutagen-io/mutagen/releases/download/v0.18.1/mutagen_windows_amd64_v0.18.1.tar.gz",
+      "archiveSha256": "3e237e77f69959ed520a0f877330a431507bb0a85d9da7919764ba0c87b702c7",
+      "executable": "mutagen.exe",
+      "licenseFiles": [
+        {
+          "name": "LICENSE",
+          "url": "https://raw.githubusercontent.com/mutagen-io/mutagen/v0.18.1/LICENSE",
+          "sha256": "886ee5c61fb4b87bfe80499a667e1b0e4ab0216d133b0c7ec9f0859f73127d55"
+        },
+        {
+          "name": "SSPL-LICENSE",
+          "url": "https://raw.githubusercontent.com/mutagen-io/mutagen/v0.18.1/sspl/LICENSE",
+          "sha256": "34e94c5087ba6e9fb34f35ae71df5e6533c5fc7cbbf6c44186a71e82806b69e1"
+        }
+      ]
+    }
+  }
+}

--- a/docs/architecture/windows-platform-support.md
+++ b/docs/architecture/windows-platform-support.md
@@ -146,6 +146,15 @@ command resolution, executable verification, npm launcher layout, and process
 creation stay in the runtime command/process boundary. Do not make provider
 installers assemble shell command strings to handle Windows.
 
+The Windows Desktop package also vendors the pinned Mutagen executable used
+when file-symlink creation is unavailable. Electron resolves the packaged
+resource and injects `TUTTI_MUTAGEN_BIN` into `tuttid`; Workspace Apps inherit
+that same absolute path. Release staging downloads the official archive and
+license texts, verifies their pinned SHA-256 digests, and packages only the
+Windows amd64 executable and notices. Runtime execution therefore has no
+Mutagen download dependency, while an explicit `TUTTI_MUTAGEN_BIN` remains an
+operator override.
+
 ### Browser and Files
 
 Browser and Files do not require broad platform interfaces by default. Keep API,

--- a/packages/agent/runtimeprep/README.md
+++ b/packages/agent/runtimeprep/README.md
@@ -71,9 +71,11 @@ the default real-time watcher. Cleanup flushes the session and refuses to
 delete the run home if Mutagen reports a conflict; otherwise it terminates the
 session before runtime deletion. `.refresh.lock` is always a symlink or hard
 link to the stable lock so both homes coordinate through one OS file object.
-Mutagen resolution prefers `TUTTI_MUTAGEN_BIN`, then `PATH`; Windows amd64 can
-download the pinned v0.18.1 archive into `<state>/bin` after SHA-256
-verification. Other automatic-download platforms remain to be confirmed.
+Mutagen resolution prefers `TUTTI_MUTAGEN_BIN`, then `PATH`. Packaged Windows
+amd64 Desktop builds inject the verified v0.18.1 executable bundled at build
+time, so production Agent and Workspace App runs do not download it. The
+daemon's SHA-256-verified downloader remains only as a compatibility fallback
+for unpackaged or older hosts. Other bundled platforms remain to be confirmed.
 
 When `TuttiAgentPreparer.StableSkillBundleRoot` is configured, Tutti-managed
 Skills are content-addressed under

--- a/tools/scripts/build-desktop-package.sh
+++ b/tools/scripts/build-desktop-package.sh
@@ -212,6 +212,13 @@ prepare_managed_posix_shell() {
   node "${ROOT_DIR}/apps/desktop/scripts/vendor-managed-posix-shell.mjs" --platform=windows-amd64
 }
 
+prepare_mutagen() {
+  if [[ "${VARIANT}" != "win" && "${VARIANT}" != "win-store" ]]; then
+    return
+  fi
+  node "${ROOT_DIR}/apps/desktop/scripts/vendor-mutagen.mjs" --platform=windows-amd64
+}
+
 run_pnpm_build() {
   pnpm build
 }
@@ -339,6 +346,7 @@ case "${VARIANT}" in
     run_timed_phase "prepare_browser_mcp" prepare_browser_mcp
     run_timed_phase "prepare_claude_sdk_sidecar" prepare_claude_sdk_sidecar
     run_timed_phase "prepare_managed_posix_shell" prepare_managed_posix_shell
+    run_timed_phase "prepare_mutagen" prepare_mutagen
     (
       cd "${APP_DIR}"
       run_timed_phase "resolve_desktop_build_version" resolve_desktop_build_version

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -35,6 +35,14 @@ const managedPosixShellLockPath = new URL(
   "../../config/tutti.managed-posix-shell.lock.json",
   import.meta.url
 );
+const mutagenVendorScriptPath = new URL(
+  "../../apps/desktop/scripts/vendor-mutagen.mjs",
+  import.meta.url
+);
+const mutagenLockPath = new URL(
+  "../../config/tutti.mutagen.lock.json",
+  import.meta.url
+);
 const tuttidManagerPath = new URL(
   "../../apps/desktop/src/main/daemon/tuttidManager.ts",
   import.meta.url
@@ -1146,6 +1154,11 @@ test("desktop Windows package and daemon agree on the managed POSIX shell resour
       from: "build/managed-posix-shell",
       to: "bin/managed-posix-shell",
       filter: ["**/*"]
+    },
+    {
+      from: "build/mutagen",
+      to: "bin/mutagen",
+      filter: ["**/*"]
     }
   ]);
   assert.match(buildScript, /vendor-managed-posix-shell\.mjs/);
@@ -1159,4 +1172,27 @@ test("desktop Windows package and daemon agree on the managed POSIX shell resour
   assert.equal(lock.schemaVersion, "tutti.managed-posix-shell-lock.v1");
   assert.equal(lock.platforms["windows-amd64"].executable, "usr/bin/bash.exe");
   assert.doesNotMatch(alphaWorkflow, /\n\s+push:/);
+});
+
+test("desktop Windows package and daemon agree on the bundled Mutagen resource", async () => {
+  const packageJson = JSON.parse(await readFile(desktopPackagePath, "utf8"));
+  const buildScript = await readFile(buildScriptPath, "utf8");
+  const alphaWorkflow = await readFile(windowsAlphaWorkflowPath, "utf8");
+  const tuttidManager = await readFile(tuttidManagerPath, "utf8");
+  const lock = JSON.parse(await readFile(mutagenLockPath, "utf8"));
+
+  await access(mutagenVendorScriptPath);
+  assert.deepEqual(packageJson.build.win.extraResources[1], {
+    from: "build/mutagen",
+    to: "bin/mutagen",
+    filter: ["**/*"]
+  });
+  assert.match(buildScript, /vendor-mutagen\.mjs/);
+  assert.match(alphaWorkflow, /bin\/mutagen/);
+  assert.match(alphaWorkflow, /mutagenMetadata\.executable/);
+  assert.match(tuttidManager, /"mutagen"/);
+  assert.match(tuttidManager, /TUTTI_MUTAGEN_BIN/);
+  assert.match(tuttidManager, /tutti\.mutagen\.v1/);
+  assert.equal(lock.schemaVersion, "tutti.mutagen-lock.v1");
+  assert.equal(lock.platforms["windows-amd64"].executable, "mutagen.exe");
 });


### PR DESCRIPTION
## 背景

Windows 无符号链接不可用时，`agent-acp-kit` 会依赖 Mutagen 同步 session home 与全局 `auth.json`。当前桌面包未携带 Mutagen，运行时下载在网络较慢时会超时，导致 Agent 直接启动失败。

## 改动

- 在 Windows 桌面构建阶段按锁文件下载并校验 Mutagen 0.18.1。
- 只从官方归档提取 `mutagen.exe`（约 13.2 MiB），不把约 97.6 MiB 的完整归档打进安装包。
- 将可执行文件与 LICENSE/SSPL-LICENSE 作为 Electron `extraResources` 打包。
- 桌面启动 tuttid 时自动注入 `TUTTI_MUTAGEN_BIN`；显式环境变量仍优先，便于运维覆盖和回滚。
- Windows release smoke test 校验文件、元数据和 `mutagen version`。

## 验证

- daemon 单测：26 passed / 1 skipped / 0 failed。
- desktop release config：47 passed / 0 failed。
- `@tutti-os/desktop` typecheck 通过。
- 改动文件 oxlint 通过，`git diff --check` 通过。
- 使用官方 Mutagen 0.18.1 Windows amd64 归档验证 SHA256、提取和 `mutagen version`（输出 `0.18.1`）。
- 使用打包产物完成本机 local-to-local two-way-safe 实测：session `auth.json` 原子替换后，全局 `auth.json` 成功同步为刷新后的内容。

## 风险与回滚

- Windows 安装目录增加约 13.2 MiB 可执行文件及许可证文本；实际安装包压缩增量由 release 构建确认。
- 构建依赖固定 GitHub Release URL，但支持本地归档覆盖和缓存，且强制 SHA256 校验。
- 回滚时可撤销本 PR；运行时原有查找/下载逻辑仍保留。也可通过显式 `TUTTI_MUTAGEN_BIN` 覆盖内置版本。

## 已知基线问题

仓库 pre-commit 的 `check:ui-boundaries:staged` 因 `release/0807` 基线中的 renderer token 生成物过期而失败，与本次文件无关；未在热修中扩大范围修复。
