### PR TITLE
fix(agent-host): preserve accepted goal readiness state

### DIFF
--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -93,7 +93,12 @@ same durable saga without opening a turn. `GoalControlResult.Goal` is always
 the durable desired projection after persistence; provider output is retained
 separately in `GoalState.Observed`. A provider may return no observation for
 pause or resume without erasing the visible Goal, and only a durable tombstone
-returns a nil Goal. `AdoptProviderGoal` is the narrow
+returns a nil Goal. `GoalControlResult.IntentAccepted` becomes true as soon as
+that durable operation exists, even when immediate runtime readiness or
+delivery returns an error; `GoalState` then distinguishes pending delivery
+from terminal failure. A provider-accepted or applied Goal is also canonical
+resume evidence for a turnless Goal session after the live runtime disappears.
+`AdoptProviderGoal` is the narrow
 reverse boundary for a Goal created by a provider tool during an already
 accepted Turn. It atomically records the active provider generation as a
 completed, applied operation and converged desired/observed state; it never

--- a/packages/agent/host/conformance/conformance.go
+++ b/packages/agent/host/conformance/conformance.go
@@ -100,6 +100,7 @@ type SendObservation struct {
 
 type GoalObservation struct {
 	Goal               map[string]any
+	IntentAccepted     bool
 	OperationID        string
 	Revision           int64
 	PendingOperationID string
@@ -163,6 +164,7 @@ type Metrics struct {
 // provider-neutral Host application surface rather than any transport API.
 type Driver interface {
 	Reset(context.Context, Fixture) error
+	DisconnectRuntimeSession(context.Context, agenthost.SessionRef) error
 	Create(context.Context, string, agenthost.CreateSessionInput) (SessionObservation, string, error)
 	EnsureSession(context.Context, agenthost.SessionRef) (SessionObservation, error)
 	SendInput(context.Context, agenthost.SessionRef, agenthost.SendInput) (SendObservation, error)

--- a/packages/agent/host/conformance/conformance_test.go
+++ b/packages/agent/host/conformance/conformance_test.go
@@ -20,7 +20,7 @@ func TestPublishedScenarioCatalogsHaveUniqueNames(t *testing.T) {
 		{name: "title policy", scenarios: TitlePolicyScenarios(), wantCount: 1},
 		{name: "deletion admission", scenarios: DeletionAdmissionScenarios(), wantCount: 3},
 		{name: "coordinator", scenarios: CoordinatorScenarios(), wantCount: 7},
-		{name: "goal", scenarios: GoalScenarios(), wantCount: 15},
+		{name: "goal", scenarios: GoalScenarios(), wantCount: 17},
 		{name: "commit observer", scenarios: CommitObserverScenarios(), wantCount: 2},
 	}
 	for _, catalog := range catalogs {

--- a/packages/agent/host/conformance/goal_scenarios.go
+++ b/packages/agent/host/conformance/goal_scenarios.go
@@ -515,6 +515,73 @@ func runAcceptedGoalControlWaitsWithoutReplay(ctx context.Context, driver Driver
 	return nil
 }
 
+func runTurnlessGoalSessionResumesAfterDisconnect(ctx context.Context, driver Driver) error {
+	if err := driver.Reset(ctx, Fixture{}); err != nil {
+		return err
+	}
+	ref := agenthost.SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-turnless-goal-resume"}
+	_, turnID, err := driver.Create(ctx, ref.WorkspaceID, agenthost.CreateSessionInput{
+		AgentSessionID: ref.AgentSessionID, AgentTargetID: "target-1", Provider: "codex",
+		ClientSubmitID: "turnless-goal-create-1",
+		InitialGoalControl: &agenthost.TypedGoalControl{
+			Action: "set", Objective: "survive provider reconnect",
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("create turnless Goal session: %w", err)
+	}
+	if turnID != "" {
+		return fmt.Errorf("turnless Goal session opened turn %q", turnID)
+	}
+	if err := driver.DisconnectRuntimeSession(ctx, ref); err != nil {
+		return fmt.Errorf("disconnect turnless Goal session: %w", err)
+	}
+	resumed, err := driver.EnsureSession(ctx, ref)
+	if err != nil {
+		return fmt.Errorf("resume turnless Goal session: %w", err)
+	}
+	if resumed.SessionID != ref.AgentSessionID || !resumed.Resumable {
+		return fmt.Errorf("resumed turnless Goal session=%#v", resumed)
+	}
+	metrics := driver.Metrics()
+	if metrics.StartCalls != 1 || metrics.ResumeCalls != 1 || metrics.GoalControlCalls != 1 {
+		return fmt.Errorf("turnless Goal resume metrics=%#v", metrics)
+	}
+	return nil
+}
+
+func runGoalIntentAcceptedBeforeRuntimeReadinessFailure(ctx context.Context, driver Driver) error {
+	fixture := Fixture{
+		Session: &SessionSeed{
+			WorkspaceID: "workspace-1", AgentSessionID: "session-goal-readiness-failure", Provider: "codex",
+			ProviderSessionID: "provider-session-goal-readiness-failure", Cwd: "/workspace",
+		},
+		Turn: &TurnSeed{
+			TurnID: "turn-canceled-before-provider-start", Phase: storesqlite.TurnPhaseSettled,
+			Outcome: storesqlite.TurnOutcomeCanceled,
+		},
+	}
+	if err := driver.Reset(ctx, fixture); err != nil {
+		return err
+	}
+	result, err := driver.GoalControl(ctx, agenthost.GoalControlInput{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-goal-readiness-failure",
+		Action: "set", Objective: "persist before delivery", ClientSubmitID: "goal-readiness-failure-1",
+	})
+	if !errors.Is(err, agenthost.ErrProviderSessionNotEstablished) {
+		return fmt.Errorf("goal readiness error=%v", err)
+	}
+	if !result.IntentAccepted || result.OperationID == "" ||
+		result.PendingOperationID != result.OperationID || result.SyncStatus != storesqlite.GoalSyncStatusPending ||
+		metadataString(result.Goal, "objective") != "persist before delivery" {
+		return fmt.Errorf("accepted Goal readiness result=%#v", result)
+	}
+	if metrics := driver.Metrics(); metrics.ResumeCalls != 0 || metrics.GoalControlCalls != 0 {
+		return fmt.Errorf("failed readiness reached runtime: metrics=%#v", metrics)
+	}
+	return nil
+}
+
 func runGoalInboxConsumerPreflight(ctx context.Context, driver Driver) error {
 	fixture := liveSessionFixture("session-goal-no-consumer", "")
 	fixture.DisableGoalInbox = true

--- a/packages/agent/host/conformance/scenarios.go
+++ b/packages/agent/host/conformance/scenarios.go
@@ -143,6 +143,8 @@ func GoalScenarios() []Scenario {
 		{Name: "goal generation fence preserves newer goal", run: runGoalGenerationFencePreservesNewerGoal},
 		{Name: "restart completes offline goal fence without replay", run: runRestartCompletesOfflineGoalFenceWithoutReplay},
 		{Name: "accepted goal control waits without replay", run: runAcceptedGoalControlWaitsWithoutReplay},
+		{Name: "turnless goal session resumes after disconnect", run: runTurnlessGoalSessionResumesAfterDisconnect},
+		{Name: "goal intent accepted before runtime readiness failure", run: runGoalIntentAcceptedBeforeRuntimeReadinessFailure},
 		{Name: "goal inbox consumer preflight", run: runGoalInboxConsumerPreflight},
 	}
 }

--- a/packages/agent/host/goal_control.go
+++ b/packages/agent/host/goal_control.go
@@ -65,6 +65,31 @@ func durableGoalForResponse(state storesqlite.SessionGoalState) map[string]any {
 	return clonePayload(state.Desired)
 }
 
+func acceptedGoalControlResult(operationID string, state *storesqlite.SessionGoalState) GoalControlResult {
+	result := GoalControlResult{OperationID: strings.TrimSpace(operationID)}
+	if result.OperationID == "" || state == nil {
+		return result
+	}
+	result.Goal = durableGoalForResponse(*state)
+	result.GoalState = state
+	result.IntentAccepted = true
+	return result
+}
+
+func goalControlResultPending(result GoalControlResult) bool {
+	if !result.IntentAccepted || result.GoalState == nil ||
+		strings.TrimSpace(result.OperationID) == "" ||
+		strings.TrimSpace(result.GoalState.PendingOperationID) != strings.TrimSpace(result.OperationID) {
+		return false
+	}
+	switch strings.TrimSpace(result.GoalState.SyncStatus) {
+	case storesqlite.GoalSyncStatusPending, storesqlite.GoalSyncStatusApplying:
+		return true
+	default:
+		return false
+	}
+}
+
 func goalControlOperationID(workspaceID, agentSessionID, clientSubmitID string) string {
 	clientSubmitID = strings.TrimSpace(clientSubmitID)
 	if clientSubmitID == "" {
@@ -109,36 +134,33 @@ func (h *Host) existingGoalControlResult(
 		operation.Objective != objective {
 		return GoalControlResult{}, true, storesqlite.ErrGoalOperationConflict
 	}
+	state, stateFound, stateErr := h.goals.GetSessionGoalState(ctx, workspaceID, agentSessionID)
+	if stateErr != nil {
+		return GoalControlResult{}, true, stateErr
+	}
+	if !stateFound {
+		return GoalControlResult{}, true, storesqlite.ErrGoalStateAbsent
+	}
+	accepted := acceptedGoalControlResult(operation.OperationID, &state)
 	switch operation.Status {
 	case storesqlite.GoalOperationStatusCompleted, storesqlite.GoalOperationStatusSuperseded:
-		state, stateFound, stateErr := h.goals.GetSessionGoalState(ctx, workspaceID, agentSessionID)
-		if stateErr != nil {
-			return GoalControlResult{}, true, stateErr
-		}
-		if !stateFound {
-			return GoalControlResult{}, true, storesqlite.ErrGoalStateAbsent
-		}
 		canonical, sessionFound, sessionErr := h.store.GetSession(ctx, workspaceID, agentSessionID)
 		if sessionErr != nil {
-			return GoalControlResult{}, true, sessionErr
+			return accepted, true, sessionErr
 		}
 		if !sessionFound {
-			return GoalControlResult{}, true, ErrSessionNotFound
+			return accepted, true, ErrSessionNotFound
 		}
-		return GoalControlResult{
-			Canonical:   canonical,
-			Goal:        durableGoalForResponse(state),
-			OperationID: operation.OperationID,
-			GoalState:   &state,
-		}, true, nil
+		accepted.Canonical = canonical
+		return accepted, true, nil
 	case storesqlite.GoalOperationStatusFailed:
-		return GoalControlResult{}, true, fmt.Errorf(
+		return accepted, true, fmt.Errorf(
 			"%w: %s",
 			ErrRuntimeOperationFailed,
 			strings.TrimSpace(operation.LastError),
 		)
 	default:
-		return GoalControlResult{}, true, ErrRuntimeOperationInProgress
+		return accepted, true, ErrRuntimeOperationInProgress
 	}
 }
 
@@ -284,7 +306,7 @@ func (h *Host) goalControlSerialized(
 			return nil
 		})
 		if err != nil {
-			return GoalControlResult{}, err
+			return acceptedGoalControlResult(operationID, persistedState), err
 		}
 	}
 	if replayed {
@@ -298,6 +320,7 @@ func (h *Host) goalControlSerialized(
 		return GoalControlResult{
 			Canonical: canonical, Goal: durableGoalForResponse(*persistedState),
 			OperationID: operationID, GoalState: persistedState,
+			IntentAccepted: true,
 		}, nil
 	}
 	if _, err := h.EnsureRuntimeSession(ctx, SessionRef{WorkspaceID: workspaceID, AgentSessionID: agentSessionID}); err != nil {
@@ -307,7 +330,7 @@ func (h *Host) goalControlSerialized(
 			"agentSessionId", agentSessionID,
 			"error", err.Error(),
 		)
-		return GoalControlResult{}, err
+		return acceptedGoalControlResult(operationID, persistedState), err
 	}
 	if h.goals != nil {
 		err := h.withGoalActor(ctx, workspaceID, agentSessionID, func(actorCtx context.Context) error {
@@ -333,7 +356,7 @@ func (h *Host) goalControlSerialized(
 			return err
 		})
 		if err != nil {
-			return GoalControlResult{}, err
+			return acceptedGoalControlResult(operationID, persistedState), err
 		}
 	}
 	controlResult, err := h.goalRuntime.GoalControl(ctx, RuntimeGoalControlInput{
@@ -370,9 +393,12 @@ func (h *Host) goalControlSerialized(
 				})
 				return releaseErr
 			})
+			if latest, found, stateErr := h.goals.GetSessionGoalState(persistCtx, workspaceID, agentSessionID); stateErr == nil && found {
+				persistedState = &latest
+			}
 			cancel()
 			if persistErr != nil {
-				return GoalControlResult{}, errors.Join(normalizedErr, persistErr)
+				return acceptedGoalControlResult(operationID, persistedState), errors.Join(normalizedErr, persistErr)
 			}
 		}
 		slog.Warn("workspace agent session goal control runtime request failed",
@@ -382,7 +408,7 @@ func (h *Host) goalControlSerialized(
 			"action", action,
 			"error", normalizedErr.Error(),
 		)
-		return GoalControlResult{}, normalizedErr
+		return acceptedGoalControlResult(operationID, persistedState), normalizedErr
 	}
 	responseGoal := clonePayload(controlResult.Goal)
 	if h.goals != nil && operationID != "" {
@@ -426,7 +452,7 @@ func (h *Host) goalControlSerialized(
 		})
 		cancel()
 		if persistErr != nil {
-			return GoalControlResult{}, persistErr
+			return acceptedGoalControlResult(operationID, persistedState), persistErr
 		}
 	}
 	if persistedState != nil {
@@ -444,10 +470,10 @@ func (h *Host) goalControlSerialized(
 			"agentSessionId", agentSessionID,
 			"error", err.Error(),
 		)
-		return GoalControlResult{}, err
+		return acceptedGoalControlResult(operationID, persistedState), err
 	}
 	if !found {
-		return GoalControlResult{}, ErrSessionNotFound
+		return acceptedGoalControlResult(operationID, persistedState), ErrSessionNotFound
 	}
 	slog.Info("workspace agent session goal control completed",
 		"event", "workspace_agent_session.goal_control.completed",
@@ -455,7 +481,10 @@ func (h *Host) goalControlSerialized(
 		"agentSessionId", agentSessionID,
 		"action", action,
 	)
-	return GoalControlResult{Canonical: canonical, Goal: responseGoal, OperationID: operationID, GoalState: persistedState}, nil
+	return GoalControlResult{
+		Canonical: canonical, Goal: responseGoal, OperationID: operationID,
+		GoalState: persistedState, IntentAccepted: operationID != "" && persistedState != nil,
+	}, nil
 }
 
 func goalControlSubmissionMetadata(clientSubmitID string) map[string]any {

--- a/packages/agent/host/goal_control_restart_test.go
+++ b/packages/agent/host/goal_control_restart_test.go
@@ -3,6 +3,7 @@ package agenthost_test
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -29,6 +30,7 @@ func (r liveGoalRuntime) RuntimeSessionLive(workspaceID, agentSessionID string) 
 type countingGoalRuntime struct {
 	mu    sync.Mutex
 	calls int
+	err   error
 }
 
 type createGoalRestartRuntime struct {
@@ -74,10 +76,65 @@ func (r *createGoalRestartRuntime) startCount() int {
 func (r *countingGoalRuntime) GoalControl(_ context.Context, input agenthost.RuntimeGoalControlInput) (agenthost.RuntimeGoalControlResult, error) {
 	r.mu.Lock()
 	r.calls++
+	err := r.err
 	r.mu.Unlock()
+	if err != nil {
+		return agenthost.RuntimeGoalControlResult{}, err
+	}
 	return agenthost.RuntimeGoalControlResult{
 		Goal: map[string]any{"objective": input.Objective, "status": "active"},
 	}, nil
+}
+
+func TestCreateWithInitialGoalPreservesAcceptedPendingIntent(t *testing.T) {
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "agent-host-create-goal-pending.db"))
+	if err != nil {
+		t.Fatalf("open SQLite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+	store := storesqlite.New(db, storesqlite.Options{})
+	if err := store.Migrate(t.Context()); err != nil {
+		t.Fatalf("migrate SQLite: %v", err)
+	}
+	hostRuntime := &createGoalRestartRuntime{}
+	goalRuntime := &countingGoalRuntime{err: context.DeadlineExceeded}
+	host := agenthost.New(agenthost.Config{
+		CanonicalStore: &agenthost.SQLiteWorkspaceStore{
+			StoreForWorkspace: func(string) *storesqlite.Store { return store },
+			CurrentUserID:     func() string { return "user-1" },
+		},
+		Runtime: hostRuntime, GoalStore: store, GoalRuntime: goalRuntime,
+	})
+	input := agenthost.CreateSessionInput{
+		AgentSessionID: "session-1", AgentTargetID: "target-1", Provider: "codex",
+		ClientSubmitID: "create-goal-pending-1",
+		InitialGoalControl: &agenthost.TypedGoalControl{
+			Action: "set", Objective: "ship after retry",
+		},
+	}
+	first, err := host.CreateSession(t.Context(), "workspace-1", input)
+	if !errors.Is(err, context.DeadlineExceeded) || first.GoalControl == nil ||
+		!first.GoalControl.IntentAccepted || !goalControlResultIsPending(first.GoalControl) ||
+		first.InitialGoalStatus != agenthost.CreateSessionInitialGoalStatusUnknown {
+		t.Fatalf("first pending create=%#v error=%v", first, err)
+	}
+	second, err := host.CreateSession(t.Context(), "workspace-1", input)
+	if !errors.Is(err, agenthost.ErrRuntimeOperationInProgress) || second.GoalControl == nil ||
+		!second.GoalControl.IntentAccepted || !goalControlResultIsPending(second.GoalControl) ||
+		second.GoalControl.OperationID != first.GoalControl.OperationID {
+		t.Fatalf("replayed pending create=%#v error=%v", second, err)
+	}
+	if hostRuntime.startCount() != 1 || goalRuntime.callCount() != 1 {
+		t.Fatalf("pending create calls start=%d goal=%d", hostRuntime.startCount(), goalRuntime.callCount())
+	}
+}
+
+func goalControlResultIsPending(result *agenthost.GoalControlResult) bool {
+	return result != nil && result.GoalState != nil && result.OperationID != "" &&
+		result.GoalState.PendingOperationID == result.OperationID &&
+		(result.GoalState.SyncStatus == storesqlite.GoalSyncStatusPending ||
+			result.GoalState.SyncStatus == storesqlite.GoalSyncStatusApplying)
 }
 
 func (r *countingGoalRuntime) callCount() int {

--- a/packages/agent/host/goal_resume_evidence.go
+++ b/packages/agent/host/goal_resume_evidence.go
@@ -1,0 +1,33 @@
+package agenthost
+
+import (
+	"context"
+	"strings"
+
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+// goalStateProvesProviderSessionEstablished covers legitimate turnless Goal
+// sessions. Provider acceptance or application of a durable Goal is the same
+// strength of resume evidence as a provider-root Turn: both can only happen
+// after the provider Session exists. A merely prepared or dispatched Goal is
+// intentionally insufficient because it may predate provider acceptance.
+func (h *Host) goalStateProvesProviderSessionEstablished(ctx context.Context, ref SessionRef) (bool, error) {
+	if h == nil || h.goals == nil {
+		return false, nil
+	}
+	state, found, err := h.goals.GetSessionGoalState(ctx, ref.WorkspaceID, ref.AgentSessionID)
+	if err != nil || !found {
+		return false, err
+	}
+	if strings.TrimSpace(metadataString(state.LastEvidence, "phase")) == storesqlite.GoalProviderPhaseAccepted ||
+		strings.TrimSpace(metadataString(state.LastEvidence, "confidence")) == "authoritative" {
+		return true, nil
+	}
+	switch strings.TrimSpace(state.SyncStatus) {
+	case storesqlite.GoalSyncStatusSynced, storesqlite.GoalSyncStatusDiverged:
+		return true, nil
+	default:
+		return false, nil
+	}
+}

--- a/packages/agent/host/initial_goal_create.go
+++ b/packages/agent/host/initial_goal_create.go
@@ -15,12 +15,23 @@ func (h *Host) replayInitialGoalCreate(
 	goalInput GoalControlInput,
 ) (CreateSessionResult, bool, error) {
 	replay, found, err := h.existingGoalControlResult(ctx, goalInput)
-	if err != nil || !found {
-		if err != nil {
-			result, resultErr := createSessionFailureResult(input, err)
-			return result, found, resultErr
-		}
+	if !found {
 		return CreateSessionResult{}, found, nil
+	}
+	if err != nil && !goalControlResultPending(replay) {
+		result, resultErr := createSessionFailureResult(input, err)
+		return result, true, resultErr
+	}
+	if strings.TrimSpace(replay.Canonical.ID) == "" {
+		canonical, sessionFound, readErr := h.store.GetSession(ctx, goalInput.WorkspaceID, goalInput.AgentSessionID)
+		if readErr != nil || !sessionFound {
+			if readErr == nil {
+				readErr = ErrSessionNotFound
+			}
+			result, resultErr := createSessionFailureResult(input, readErr)
+			return result, true, resultErr
+		}
+		replay.Canonical = canonical
 	}
 	if !railPlacementMatchesSession(input.RailPlacement, replay.Canonical) {
 		result, resultErr := createSessionFailureResult(input, ErrRailPlacementConflict)
@@ -30,12 +41,16 @@ func (h *Host) replayInitialGoalCreate(
 	if !live {
 		runtimeSession = providerRuntimeSessionIdentity(replay.Canonical)
 	}
+	initialGoalStatus := CreateSessionInitialGoalStatusSucceeded
+	if err != nil {
+		initialGoalStatus = CreateSessionInitialGoalStatusUnknown
+	}
 	return CreateSessionResult{
 		Session: runtimeSession, Canonical: replay.Canonical,
 		Kind: "goalControl", GoalControl: &replay,
 		SessionStatus:     CreateSessionStatusCreated,
-		InitialGoalStatus: CreateSessionInitialGoalStatusSucceeded,
-	}, true, nil
+		InitialGoalStatus: initialGoalStatus,
+	}, true, err
 }
 
 func providerRuntimeSessionIdentity(session storesqlite.Session) ProviderRuntimeSession {

--- a/packages/agent/host/lifecycle.go
+++ b/packages/agent/host/lifecycle.go
@@ -166,6 +166,15 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 		goalInput.AgentSessionID = session.ID
 		goalResult, goalErr := h.goalControl(ctx, goalInput)
 		if goalErr != nil {
+			if goalControlResultPending(goalResult) {
+				if refreshed, ok := h.runtime.Session(workspaceID, session.ID); ok {
+					session = refreshed
+				}
+				return CreateSessionResult{
+					Session: session, Canonical: canonicalSession, Kind: "goalControl", GoalControl: &goalResult,
+					SessionStatus: CreateSessionStatusCreated, InitialGoalStatus: CreateSessionInitialGoalStatusUnknown,
+				}, goalErr
+			}
 			// A typed goal starts from a non-provisional, already published
 			// session. Preserve that canonical session on command failure just as
 			// the legacy Service did; rolling it back would leave subscribers with
@@ -321,6 +330,12 @@ func (h *Host) ensureRuntimeSessionLocked(ctx context.Context, ref SessionRef) (
 		if err != nil {
 			return ProviderRuntimeSession{}, err
 		}
+		if !evidence.Established {
+			evidence.Established, err = h.goalStateProvesProviderSessionEstablished(ctx, ref)
+			if err != nil {
+				return ProviderRuntimeSession{}, err
+			}
+		}
 	}
 	if live, ok := h.runtime.Session(ref.WorkspaceID, ref.AgentSessionID); ok {
 		if !ExternalImportResumeSupported(live.RuntimeContext) {
@@ -394,12 +409,6 @@ func (h *Host) ensureRuntimeSessionLocked(ctx context.Context, ref SessionRef) (
 	}
 	h.goalFencesRestored.Store(ref.WorkspaceID+"\x00"+ref.AgentSessionID, struct{}{})
 	return result, nil
-}
-
-func runtimeSessionHasActiveTurn(session ProviderRuntimeSession) bool {
-	return session.TurnLifecycle != nil &&
-		session.TurnLifecycle.ActiveTurnID != nil &&
-		strings.TrimSpace(*session.TurnLifecycle.ActiveTurnID) != ""
 }
 
 func (h *Host) SendInput(ctx context.Context, ref SessionRef, input SendInput) (SendInputResult, error) {
@@ -819,12 +828,6 @@ func imageOnlyDisplayText(content []PromptContentBlock) string {
 	return ""
 }
 
-func persistedRuntimeStatus(activeTurnID string) string {
-	if strings.TrimSpace(activeTurnID) != "" {
-		return "working"
-	}
-	return "ready"
-}
 func value(input *string) string {
 	if input == nil {
 		return ""

--- a/packages/agent/host/resume_policy.go
+++ b/packages/agent/host/resume_policy.go
@@ -21,6 +21,19 @@ type ResumePolicy struct {
 	Mode ResumeMode
 }
 
+func runtimeSessionHasActiveTurn(session ProviderRuntimeSession) bool {
+	return session.TurnLifecycle != nil &&
+		session.TurnLifecycle.ActiveTurnID != nil &&
+		strings.TrimSpace(*session.TurnLifecycle.ActiveTurnID) != ""
+}
+
+func persistedRuntimeStatus(activeTurnID string) string {
+	if strings.TrimSpace(activeTurnID) != "" {
+		return "working"
+	}
+	return "ready"
+}
+
 func ResolveResumePolicy(session storesqlite.Session) ResumePolicy {
 	if strings.TrimSpace(session.Kind) == canonical.SessionKindChild {
 		return ResumePolicy{Mode: ResumeModeReject}

--- a/packages/agent/host/types.go
+++ b/packages/agent/host/types.go
@@ -947,10 +947,14 @@ type GoalControlInput struct {
 }
 
 type GoalControlResult struct {
-	Canonical   storesqlite.Session
-	Goal        map[string]any
-	OperationID string
-	GoalState   *storesqlite.SessionGoalState
+	Canonical storesqlite.Session
+	Goal      map[string]any
+	// IntentAccepted means the durable Goal operation exists and Host owns
+	// recovery. It does not claim immediate provider delivery or convergence;
+	// callers must inspect GoalState for pending, applying, or terminal state.
+	IntentAccepted bool
+	OperationID    string
+	GoalState      *storesqlite.SessionGoalState
 }
 
 // ProviderGoalAdoptionInput identifies one Goal generation that the provider

--- a/packages/agent/store-sqlite/provider_session_resume.go
+++ b/packages/agent/store-sqlite/provider_session_resume.go
@@ -16,8 +16,9 @@ type ProviderSessionResumeEvidence struct {
 }
 
 // GetProviderSessionResumeEvidence distinguishes an empty live session from a
-// session whose first canonical turn settled before the provider acknowledged
-// its own root turn.
+// session whose provider identity was established by either a root Turn or a
+// provider-accepted Goal. Goal evidence is historical and therefore remains
+// monotonic when a later local generation fence clears the current projection.
 func (s *Store) GetProviderSessionResumeEvidence(
 	ctx context.Context,
 	workspaceID string,
@@ -44,13 +45,26 @@ SELECT EXISTS(
          WHERE workspace_id = ? AND agent_session_id = ?
            AND phase = 'settled'
        ),
-       EXISTS(
-         SELECT 1
-         FROM workspace_agent_turns
-         WHERE workspace_id = ? AND agent_session_id = ?
-           AND TRIM(COALESCE(root_provider_turn_id, '')) <> ''
+       (
+         EXISTS(
+           SELECT 1
+           FROM workspace_agent_turns
+           WHERE workspace_id = ? AND agent_session_id = ?
+             AND TRIM(COALESCE(root_provider_turn_id, '')) <> ''
+         )
+         OR EXISTS(
+           SELECT 1
+           FROM workspace_agent_goal_control_operations
+           WHERE workspace_id = ? AND agent_session_id = ?
+             AND (
+               accepted_at_unix_ms > 0
+               OR provider_phase IN (?, ?)
+             )
+         )
        )
-`, workspaceID, agentSessionID, workspaceID, agentSessionID, workspaceID, agentSessionID).
+`, workspaceID, agentSessionID, workspaceID, agentSessionID,
+		workspaceID, agentSessionID, workspaceID, agentSessionID,
+		GoalProviderPhaseAccepted, GoalProviderPhaseApplied).
 		Scan(&hasTurns, &hasSettledTurn, &established); err != nil {
 		return ProviderSessionResumeEvidence{}, fmt.Errorf("get provider session resume evidence: %w", err)
 	}

--- a/packages/agent/store-sqlite/provider_session_resume_test.go
+++ b/packages/agent/store-sqlite/provider_session_resume_test.go
@@ -53,3 +53,43 @@ WHERE workspace_id = 'ws-1' AND agent_session_id = 'session-1' AND turn_id = 'tu
 		t.Fatalf("established evidence = %#v", evidence)
 	}
 }
+
+func TestGetProviderSessionResumeEvidenceRetainsHistoricalAcceptedGoal(t *testing.T) {
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	ctx := context.Background()
+	seedTurnTestSession(t, store, "ws-goal", "session-goal")
+
+	if _, _, _, err := store.PrepareGoalControlOperation(ctx, GoalControlOperationPrepare{
+		OperationID: "goal-set", WorkspaceID: "ws-goal", AgentSessionID: "session-goal",
+		Action: "set", Objective: "ship", OccurredAtUnixMS: 10,
+	}); err != nil {
+		t.Fatalf("prepare Goal: %v", err)
+	}
+	if _, _, _, err := store.CompleteGoalControlOperation(ctx, GoalControlOperationComplete{
+		WorkspaceID: "ws-goal", OperationID: "goal-set", Succeeded: true,
+		Observed: map[string]any{"objective": "ship", "status": "active"},
+		Evidence: map[string]any{"confidence": "authoritative"}, OccurredAtUnixMS: 20,
+	}); err != nil {
+		t.Fatalf("complete Goal: %v", err)
+	}
+	if _, _, _, err := store.PrepareGoalControlOperation(ctx, GoalControlOperationPrepare{
+		OperationID: "goal-local-stop", WorkspaceID: "ws-goal", AgentSessionID: "session-goal",
+		Action: "clear", OccurredAtUnixMS: 30,
+	}); err != nil {
+		t.Fatalf("prepare local stop: %v", err)
+	}
+	if _, _, _, err := store.CompleteGoalControlOperation(ctx, GoalControlOperationComplete{
+		WorkspaceID: "ws-goal", OperationID: "goal-local-stop",
+		Mode: GoalControlCompletionModeLocalStop, Succeeded: true, OccurredAtUnixMS: 40,
+	}); err != nil {
+		t.Fatalf("complete local stop: %v", err)
+	}
+
+	evidence, err := store.GetProviderSessionResumeEvidence(ctx, "ws-goal", "session-goal")
+	if err != nil {
+		t.Fatalf("Goal resume evidence: %v", err)
+	}
+	if evidence.HasTurns || evidence.HasSettledTurn || !evidence.Established {
+		t.Fatalf("historical Goal evidence=%#v", evidence)
+	}
+}

--- a/services/tuttid/service/agent/host_conformance_test.go
+++ b/services/tuttid/service/agent/host_conformance_test.go
@@ -625,6 +625,13 @@ func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconfo
 	return nil
 }
 
+func (d *legacyHostConformanceDriver) DisconnectRuntimeSession(ctx context.Context, ref agenthost.SessionRef) error {
+	return d.runtime.Close(ctx, RuntimeCloseInput{
+		WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
+		PreserveCanonicalState: true,
+	})
+}
+
 func (d *legacyHostConformanceDriver) Create(
 	ctx context.Context,
 	workspaceID string,
@@ -1088,16 +1095,16 @@ func (d *legacyHostConformanceDriver) GoalControl(ctx context.Context, input age
 		ClientSubmitID:     input.ClientSubmitID,
 		SubmissionMetadata: input.SubmissionMetadata,
 	})
-	if err != nil {
-		return hostconformance.GoalObservation{}, err
+	observation := hostconformance.GoalObservation{
+		Goal: clonePayload(result.Goal), IntentAccepted: result.IntentAccepted,
+		OperationID: result.OperationID, PendingOperationID: result.OperationID,
 	}
-	observation := hostconformance.GoalObservation{Goal: clonePayload(result.Goal), OperationID: result.OperationID, PendingOperationID: result.OperationID}
 	if result.GoalState != nil {
 		observation.Revision = result.GoalState.Revision
 		observation.PendingOperationID = result.GoalState.PendingOperationID
 		observation.SyncStatus = result.GoalState.SyncStatus
 	}
-	return observation, nil
+	return observation, err
 }
 
 func (d *legacyHostConformanceDriver) AdoptProviderGoal(ctx context.Context, input agenthost.ProviderGoalAdoptionInput) (hostconformance.GoalObservation, error) {
@@ -1160,7 +1167,10 @@ func (d *legacyHostConformanceDriver) StepGoalOperations(ctx context.Context, no
 }
 
 func hostGoalControlObservation(result agenthost.GoalControlResult) hostconformance.GoalObservation {
-	observation := hostconformance.GoalObservation{Goal: clonePayload(result.Goal), OperationID: result.OperationID, PendingOperationID: result.OperationID}
+	observation := hostconformance.GoalObservation{
+		Goal: clonePayload(result.Goal), IntentAccepted: result.IntentAccepted,
+		OperationID: result.OperationID, PendingOperationID: result.OperationID,
+	}
 	if result.GoalState != nil {
 		observation.Revision = result.GoalState.Revision
 		observation.PendingOperationID = result.GoalState.PendingOperationID

--- a/services/tuttid/service/agent/service_goal_control.go
+++ b/services/tuttid/service/agent/service_goal_control.go
@@ -13,10 +13,11 @@ type GoalStateStore = agenthost.GoalStateStore
 // GoalControlSessionResult preserves the daemon-facing session projection
 // while Host owns the durable goal saga.
 type GoalControlSessionResult struct {
-	Session     Session
-	Goal        map[string]any
-	OperationID string
-	GoalState   *agentactivitybiz.SessionGoalState
+	Session        Session
+	Goal           map[string]any
+	IntentAccepted bool
+	OperationID    string
+	GoalState      *agentactivitybiz.SessionGoalState
 }
 
 type GoalControlInput struct {
@@ -45,17 +46,17 @@ func (s *Service) GoalControl(ctx context.Context, input GoalControlInput) (Goal
 		ClientSubmitID:     strings.TrimSpace(input.ClientSubmitID),
 		SubmissionMetadata: clonePayload(input.SubmissionMetadata),
 	})
+	serviceResult := GoalControlSessionResult{
+		Goal: clonePayload(result.Goal), IntentAccepted: result.IntentAccepted,
+		OperationID: result.OperationID, GoalState: result.GoalState,
+	}
 	if err != nil {
-		return GoalControlSessionResult{}, normalizeRuntimeError(err)
+		return serviceResult, normalizeRuntimeError(err)
 	}
 	session, err := s.Get(ctx, input.WorkspaceID, input.AgentSessionID)
 	if err != nil {
-		return GoalControlSessionResult{}, err
+		return serviceResult, err
 	}
-	return GoalControlSessionResult{
-		Session:     session,
-		Goal:        clonePayload(result.Goal),
-		OperationID: result.OperationID,
-		GoalState:   result.GoalState,
-	}, nil
+	serviceResult.Session = session
+	return serviceResult, nil
 }


### PR DESCRIPTION
## Summary

- Preserve the durable Goal operation and expose IntentAccepted when runtime readiness or immediate provider delivery fails after persistence.
- Keep typed initial-Goal sessions alive with an unknown/pending initial Goal result so retry remains Host-owned and idempotent.
- Treat provider-accepted or applied Goal history as canonical, monotonic resume evidence for legitimate turnless sessions, including after a later local Goal fence clears the current projection.
- Propagate the result through tutt id and add Host conformance coverage for reconnect and accept-before-readiness failure.

The first shared Goal legitimately creates a Session without a Turn. Resume previously trusted only provider-root Turn evidence, so a reconnect could reject that Session as never established. The same flow could also persist the Goal operation and then drop the accepted result when runtime readiness failed, causing downstream Internal errors and misleading busy retries.

## Verification

- pnpm check:changed -- --dry-run
- pnpm check:changed (12/12 lanes passed on the final diff)
- go test ./packages/agent/store-sqlite -run ^TestGetProviderSessionResumeEvidence -count=1
- go test ./packages/agent/host/... -run Test(CreateWithInitialGoalPreservesAcceptedPendingIntent|CreateWithInitialGoalRetryAfterHostRestartDoesNotStartProviderSession|GoalControlRetryAfterHostRestartDoesNotReplayProviderMutation) -count=1
- go test ./services/tuttid/service/agent -run ^TestHostGoalConformance$ -count=1
- Downstream TSH Host conformance against this PR local Tutti source

## Fallback Three Questions

- Source: a provider Session can be established by an accepted Goal without ever creating a Turn, and runtime/transport failure can occur after the Goal operation is durably committed.
- Why can it not be fixed at that source? Session creation and provider Goal delivery are separate provider operations; Host must own the durable boundary and recovery semantics across runtime loss or response loss.
- Removal condition: remove the additional Goal resume evidence only if every provider offers one atomic create-and-Goal operation and canonical persistence records that atomic provider establishment directly.

## Checklist

- [x] Agent lifecycle semantics live in packages/agent/host and add packages/agent/host/conformance scenarios.
- [x] The change is focused on Goal readiness and recovery semantics.
- [x] Host behavior documentation is updated.
- [x] No multilingual root README or CONTRIBUTING source changed.
- [x] The lowest meaningful local and downstream checks passed.
- [x] The commit includes a DCO sign-off.