### PR TITLE
feat(agent-gui): allow hosts to resolve pasted absolute paths

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1908,6 +1908,14 @@ identity without a host DOM event interceptor.
 
 External OS file paste and drop enter one host-injected classification boundary before draft attachment creation. The synchronous `resolveExternalPromptEntries` port classifies each source index as a live `WorkspaceFileReference` or a snapshot requiring preparation. AgentGUI owns ordered mention insertion and draft reconciliation: references become ordinary file/folder mentions and never consume prompt-asset slots, while only `prepare` entries create pending attachment state and enter `prepareExternalPromptFiles`. A host without the resolver prepares every external entry. The preparer owns native-path or byte lookup, size enforcement, persistence, and remote transport; each prepared input has one `sourceIndex` result, one failure must not fail siblings, successful results include a provider-readable `path` or `url`, and failures carry typed error codes. Hosts that classify path-backed entries as references must reject any such entry that unexpectedly reaches preparation, so classification failure cannot silently create a duplicate snapshot.
 
+Plain-text absolute path paste may enter an optional host-owned
+`workspace.resolvePastedPath` boundary. AgentGUI applies only a strict sync
+candidate gate (one trimmed absolute path with no whitespace or quotes). The
+host returns a `WorkspaceFileReference` to insert as a file/folder mention, or
+`null`/rejection to fall back to plain text. Hosts that omit the callback keep
+the previous plain-text paste path; existence checks, host-namespace
+projection, and Shared-Agent policy remain host-owned.
+
 Workspace picker results and internal workspace-reference drags remain live references. They enter the rich-text document as mentions and never pass through external-file preparation. A picker source whose selected locator is not yet consumer-readable may perform source-owned confirmation preparation before the mention is inserted; the picker waits in a loading state, publishes no partial result on failure, and remains open for retry. This confirmation transaction belongs to the reference source contract and is distinct from the external OS file preparation pipeline. Removing an inline external-file mention removes its draft intent; a later async result must not revive it or lose its error reason when the draft is in another scope.
 
 A host may map a reference-source content error to a labeled recovery action

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -63,6 +63,7 @@ export const AgentGUINode = memo(function AgentGUINode({
     selectProjectDirectory,
     resolveExternalPromptEntries = null,
     prepareExternalPromptFiles = null,
+    resolvePastedPath = null,
     promptAssetLimit = null,
     projectDirectorySourceAggregator = null,
     referenceSourceAggregator = null,
@@ -541,6 +542,7 @@ export const AgentGUINode = memo(function AgentGUINode({
               }
               resolveExternalPromptEntries={resolveExternalPromptEntries}
               prepareExternalPromptFiles={prepareExternalPromptFiles}
+              resolvePastedPath={resolvePastedPath}
               promptAssetLimit={promptAssetLimit}
               onConversationRailWidthChanged={
                 handleConversationRailWidthChanged

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.types.ts
@@ -69,6 +69,7 @@ export interface AgentGUINodeWorkspace {
   selectProjectDirectory?: () => Promise<{ path: string } | null>;
   resolveExternalPromptEntries?: AgentComposerProps["resolveExternalPromptEntries"];
   prepareExternalPromptFiles?: AgentComposerProps["prepareExternalPromptFiles"];
+  resolvePastedPath?: AgentComposerProps["resolvePastedPath"];
   promptAssetLimit?: number | null;
   projectDirectorySourceAggregator?: ReferenceSourceAggregator | null;
   referenceSourceAggregator?: ReferenceSourceAggregator | null;
@@ -388,6 +389,7 @@ export function areAgentGUINodePropsEqual(
     pw.selectProjectDirectory === nw.selectProjectDirectory &&
     pw.resolveExternalPromptEntries === nw.resolveExternalPromptEntries &&
     pw.prepareExternalPromptFiles === nw.prepareExternalPromptFiles &&
+    pw.resolvePastedPath === nw.resolvePastedPath &&
     pw.promptAssetLimit === nw.promptAssetLimit &&
     pw.projectDirectorySourceAggregator ===
       nw.projectDirectorySourceAggregator &&

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -136,6 +136,7 @@ export function AgentGUINodeView({
   onWorkspaceFileReferencesAdded,
   resolveExternalPromptEntries = null,
   prepareExternalPromptFiles = null,
+  resolvePastedPath = null,
   promptAssetLimit = null,
   onConversationRailWidthChanged,
   onConversationRailLayoutChange,
@@ -727,6 +728,7 @@ export function AgentGUINodeView({
                 onRequestWorkspaceReferences={requestWorkspaceReferences}
                 resolveExternalPromptEntries={resolveExternalPromptEntries}
                 prepareExternalPromptFiles={prepareExternalPromptFiles}
+                resolvePastedPath={resolvePastedPath}
                 promptAssetLimit={promptAssetLimit}
                 selectProjectDirectory={effectiveSelectProjectDirectory}
                 onRequestGitBranches={onRequestGitBranches}

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
@@ -7,6 +7,35 @@ import {
 } from "../../../shared/agentCustomMentionKinds";
 import { AgentRichTextEditor } from "./AgentRichTextEditor";
 import type { AgentRichTextEditorHandle } from "./AgentRichTextEditor.types";
+import { isAgentRichTextAbsolutePathPasteCandidate } from "./agentRichTextEditorSupport";
+
+describe("isAgentRichTextAbsolutePathPasteCandidate", () => {
+  it("accepts a single absolute path", () => {
+    expect(isAgentRichTextAbsolutePathPasteCandidate("/workspace/a.txt")).toBe(
+      true
+    );
+    expect(
+      isAgentRichTextAbsolutePathPasteCandidate(" /Users/me/a.txt\n")
+    ).toBe(true);
+  });
+
+  it("rejects quoted, spaced, relative, and multi-path pastes", () => {
+    expect(
+      isAgentRichTextAbsolutePathPasteCandidate('" /workspace/a.txt"')
+    ).toBe(false);
+    expect(
+      isAgentRichTextAbsolutePathPasteCandidate("/workspace/my file.txt")
+    ).toBe(false);
+    expect(isAgentRichTextAbsolutePathPasteCandidate("workspace/a.txt")).toBe(
+      false
+    );
+    expect(
+      isAgentRichTextAbsolutePathPasteCandidate(
+        "/workspace/a.txt\n/workspace/b.txt"
+      )
+    ).toBe(false);
+  });
+});
 
 describe("AgentRichTextEditor file paste", () => {
   it("dispatches images and regular files from one paste", async () => {
@@ -47,6 +76,125 @@ describe("AgentRichTextEditor file paste", () => {
       expect(onPasteImages).toHaveBeenCalledWith([
         expect.objectContaining({ name: "screen.png", mimeType: "image/png" })
       ])
+    );
+  });
+
+  it("inserts a resolved absolute path as a file mention", async () => {
+    const onResolvePastedPath = vi.fn().mockResolvedValue({
+      kind: "file",
+      path: "/host/Users/me/demo.txt",
+      displayName: "demo.txt"
+    });
+    const onChange = vi.fn();
+    const rendered = render(
+      <AgentRichTextEditor
+        value=""
+        disabled={false}
+        placeholder="Prompt"
+        onChange={onChange}
+        onSubmit={vi.fn()}
+        onResolvePastedPath={onResolvePastedPath}
+      />
+    );
+
+    const editor = await waitFor(() => {
+      const element = rendered.container.querySelector<HTMLElement>(
+        '[contenteditable="true"]'
+      );
+      expect(element).not.toBeNull();
+      return element!;
+    });
+    fireEvent.paste(editor, {
+      clipboardData: {
+        files: [],
+        getData: (type: string) =>
+          type === "text/plain" ? "/Users/me/demo.txt" : ""
+      }
+    });
+
+    await waitFor(() =>
+      expect(onResolvePastedPath).toHaveBeenCalledWith("/Users/me/demo.txt")
+    );
+    await waitFor(() =>
+      expect(onChange.mock.calls.at(-1)?.[0]).toContain(
+        "[@demo.txt](/host/Users/me/demo.txt)"
+      )
+    );
+  });
+
+  it("falls back to plain text when absolute path resolution returns null", async () => {
+    const onResolvePastedPath = vi.fn().mockResolvedValue(null);
+    const onChange = vi.fn();
+    const rendered = render(
+      <AgentRichTextEditor
+        value=""
+        disabled={false}
+        placeholder="Prompt"
+        onChange={onChange}
+        onSubmit={vi.fn()}
+        onResolvePastedPath={onResolvePastedPath}
+      />
+    );
+
+    const editor = await waitFor(() => {
+      const element = rendered.container.querySelector<HTMLElement>(
+        '[contenteditable="true"]'
+      );
+      expect(element).not.toBeNull();
+      return element!;
+    });
+    fireEvent.paste(editor, {
+      clipboardData: {
+        files: [],
+        getData: (type: string) =>
+          type === "text/plain" ? "/missing/path.txt" : ""
+      }
+    });
+
+    await waitFor(() =>
+      expect(onResolvePastedPath).toHaveBeenCalledWith("/missing/path.txt")
+    );
+    await waitFor(() =>
+      expect(onChange.mock.calls.at(-1)?.[0]).toBe("/missing/path.txt")
+    );
+  });
+
+  it("falls back to plain text when absolute path resolution rejects", async () => {
+    const onResolvePastedPath = vi
+      .fn()
+      .mockRejectedValue(new Error("host unavailable"));
+    const onChange = vi.fn();
+    const rendered = render(
+      <AgentRichTextEditor
+        value=""
+        disabled={false}
+        placeholder="Prompt"
+        onChange={onChange}
+        onSubmit={vi.fn()}
+        onResolvePastedPath={onResolvePastedPath}
+      />
+    );
+
+    const editor = await waitFor(() => {
+      const element = rendered.container.querySelector<HTMLElement>(
+        '[contenteditable="true"]'
+      );
+      expect(element).not.toBeNull();
+      return element!;
+    });
+    fireEvent.paste(editor, {
+      clipboardData: {
+        files: [],
+        getData: (type: string) =>
+          type === "text/plain" ? "/Users/me/demo.txt" : ""
+      }
+    });
+
+    await waitFor(() =>
+      expect(onResolvePastedPath).toHaveBeenCalledWith("/Users/me/demo.txt")
+    );
+    await waitFor(() =>
+      expect(onChange.mock.calls.at(-1)?.[0]).toBe("/Users/me/demo.txt")
     );
   });
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
@@ -35,11 +35,8 @@ import type {
 } from "./AgentRichTextEditor.types";
 import {
   buildWorkspaceFileMentionDropContent,
-  classifyAgentRichTextTextPaste,
   createAgentRichTextCaretAnchorExtension,
   createAgentRichTextPlaceholderExtension,
-  insertAgentRichTextClipboardHtml,
-  isAgentRichTextAbsolutePathPasteCandidate,
   isAgentRichTextLargeTextPaste,
   isPromptVisualLineStart,
   readEditorDomSelectionRange,
@@ -51,11 +48,8 @@ import {
   scrollEditorSelectionIntoView,
   writePlainTextToClipboard
 } from "./agentRichTextEditorSupport";
-export {
-  isAgentRichTextAbsolutePathPasteCandidate,
-  isAgentRichTextLargeTextPaste
-} from "./agentRichTextEditorSupport";
-import { createAgentFileMentionContent } from "./agentWorkspaceFileReferences";
+export { isAgentRichTextLargeTextPaste } from "./agentRichTextEditorSupport";
+import { routeAgentRichTextTextPaste } from "./routeAgentRichTextTextPaste";
 import { useAgentRichTextEditorHandle } from "./useAgentRichTextEditorHandle";
 import { AgentRichTextEditorSurface } from "./AgentRichTextEditorSurface";
 import { handleAgentRichTextKeyDownCapture } from "./agentRichTextKeyboard";
@@ -441,105 +435,20 @@ export const AgentRichTextEditor = forwardRef<
           }
           const html = event.clipboardData?.getData("text/html") ?? "";
           const text = event.clipboardData?.getData("text/plain") ?? "";
-          const textPasteKind = classifyAgentRichTextTextPaste(
-            text,
+          const handled = routeAgentRichTextTextPaste({
+            availableCapabilities: availableCapabilitiesRef.current,
+            availableSkills: availableSkillsRef.current,
+            editorRef,
             html,
-            Boolean(onPasteLargeTextRef.current)
-          );
-          if (textPasteKind === "empty") {
-            return false;
-          }
-          if (textPasteKind === "large-text") {
+            mentionSuggestionSuppression,
+            onPasteLargeText: onPasteLargeTextRef.current,
+            resolvePastedPath: onResolvePastedPathRef.current,
+            text
+          });
+          if (handled) {
             event.preventDefault();
-            onPasteLargeTextRef.current?.(text);
-            return true;
           }
-          if (textPasteKind === "structured-mention") {
-            event.preventDefault();
-            const currentEditor = editorRef.current;
-            if (!currentEditor) {
-              return true;
-            }
-            if (insertAgentRichTextClipboardHtml(currentEditor, html)) {
-              mentionSuggestionSuppression.suppressTextInsertion(text);
-            }
-            return true;
-          }
-          const pathCandidate = text.trim();
-          const resolvePastedPath = onResolvePastedPathRef.current;
-          if (
-            resolvePastedPath &&
-            isAgentRichTextAbsolutePathPasteCandidate(pathCandidate)
-          ) {
-            event.preventDefault();
-            const insertPlainPasteText = (): void => {
-              const currentEditor = editorRef.current;
-              if (!currentEditor || currentEditor.isDestroyed) {
-                return;
-              }
-              if (!currentEditor.isFocused) {
-                currentEditor.commands.setTextSelection(
-                  currentEditor.state.doc.content.size
-                );
-              }
-              mentionSuggestionSuppression.suppressTextInsertion(text);
-              currentEditor.commands.insertContent(
-                plainTextToAgentRichTextInlineContent(text, {
-                  capabilities: availableCapabilitiesRef.current,
-                  skills: availableSkillsRef.current
-                })
-              );
-            };
-            void resolvePastedPath(pathCandidate)
-              .then((reference) => {
-                const currentEditor = editorRef.current;
-                if (!currentEditor || currentEditor.isDestroyed) {
-                  return;
-                }
-                if (!reference) {
-                  insertPlainPasteText();
-                  return;
-                }
-                if (!currentEditor.isFocused) {
-                  currentEditor.commands.setTextSelection(
-                    currentEditor.state.doc.content.size
-                  );
-                }
-                mentionSuggestionSuppression.suppressTextInsertion(
-                  pathCandidate
-                );
-                currentEditor.commands.insertContent(
-                  createAgentFileMentionContent([reference], {
-                    prefixCaretAnchor: isPromptVisualLineStart(
-                      currentEditor,
-                      currentEditor.state.selection.from
-                    )
-                  })
-                );
-              })
-              .catch(() => {
-                insertPlainPasteText();
-              });
-            return true;
-          }
-          event.preventDefault();
-          const currentEditor = editorRef.current;
-          if (!currentEditor) {
-            return true;
-          }
-          if (!currentEditor.isFocused) {
-            currentEditor.commands.setTextSelection(
-              currentEditor.state.doc.content.size
-            );
-          }
-          mentionSuggestionSuppression.suppressTextInsertion(text);
-          currentEditor.commands.insertContent(
-            plainTextToAgentRichTextInlineContent(text, {
-              capabilities: availableCapabilitiesRef.current,
-              skills: availableSkillsRef.current
-            })
-          );
-          return true;
+          return handled;
         },
         keydown: (_view, event) => {
           if (isAgentRichTextImeComposing(event)) {

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
@@ -39,6 +39,7 @@ import {
   createAgentRichTextCaretAnchorExtension,
   createAgentRichTextPlaceholderExtension,
   insertAgentRichTextClipboardHtml,
+  isAgentRichTextAbsolutePathPasteCandidate,
   isAgentRichTextLargeTextPaste,
   isPromptVisualLineStart,
   readEditorDomSelectionRange,
@@ -50,7 +51,11 @@ import {
   scrollEditorSelectionIntoView,
   writePlainTextToClipboard
 } from "./agentRichTextEditorSupport";
-export { isAgentRichTextLargeTextPaste } from "./agentRichTextEditorSupport";
+export {
+  isAgentRichTextAbsolutePathPasteCandidate,
+  isAgentRichTextLargeTextPaste
+} from "./agentRichTextEditorSupport";
+import { createAgentFileMentionContent } from "./agentWorkspaceFileReferences";
 import { useAgentRichTextEditorHandle } from "./useAgentRichTextEditorHandle";
 import { AgentRichTextEditorSurface } from "./AgentRichTextEditorSurface";
 import { handleAgentRichTextKeyDownCapture } from "./agentRichTextKeyboard";
@@ -103,7 +108,8 @@ export const AgentRichTextEditor = forwardRef<
     onPasteImages,
     onPasteLargeText,
     onPasteFiles,
-    onDropFiles
+    onDropFiles,
+    onResolvePastedPath
   },
   ref
 ): React.JSX.Element {
@@ -136,6 +142,7 @@ export const AgentRichTextEditor = forwardRef<
   const onPasteLargeTextRef = useRef(onPasteLargeText);
   const onPasteFilesRef = useRef(onPasteFiles);
   const onDropFilesRef = useRef(onDropFiles);
+  const onResolvePastedPathRef = useRef(onResolvePastedPath);
   const promptImagesSupportedRef = useRef(promptImagesSupported);
   const placeholderRef = useRef(placeholder);
   const removeMentionLabelRef = useRef(removeMentionLabel);
@@ -290,6 +297,7 @@ export const AgentRichTextEditor = forwardRef<
   onPasteLargeTextRef.current = onPasteLargeText;
   onPasteFilesRef.current = onPasteFiles;
   onDropFilesRef.current = onDropFiles;
+  onResolvePastedPathRef.current = onResolvePastedPath;
   promptImagesSupportedRef.current = promptImagesSupported;
   placeholderRef.current = placeholder;
   removeMentionLabelRef.current = removeMentionLabel;
@@ -455,6 +463,63 @@ export const AgentRichTextEditor = forwardRef<
             if (insertAgentRichTextClipboardHtml(currentEditor, html)) {
               mentionSuggestionSuppression.suppressTextInsertion(text);
             }
+            return true;
+          }
+          const pathCandidate = text.trim();
+          const resolvePastedPath = onResolvePastedPathRef.current;
+          if (
+            resolvePastedPath &&
+            isAgentRichTextAbsolutePathPasteCandidate(pathCandidate)
+          ) {
+            event.preventDefault();
+            const insertPlainPasteText = (): void => {
+              const currentEditor = editorRef.current;
+              if (!currentEditor || currentEditor.isDestroyed) {
+                return;
+              }
+              if (!currentEditor.isFocused) {
+                currentEditor.commands.setTextSelection(
+                  currentEditor.state.doc.content.size
+                );
+              }
+              mentionSuggestionSuppression.suppressTextInsertion(text);
+              currentEditor.commands.insertContent(
+                plainTextToAgentRichTextInlineContent(text, {
+                  capabilities: availableCapabilitiesRef.current,
+                  skills: availableSkillsRef.current
+                })
+              );
+            };
+            void resolvePastedPath(pathCandidate)
+              .then((reference) => {
+                const currentEditor = editorRef.current;
+                if (!currentEditor || currentEditor.isDestroyed) {
+                  return;
+                }
+                if (!reference) {
+                  insertPlainPasteText();
+                  return;
+                }
+                if (!currentEditor.isFocused) {
+                  currentEditor.commands.setTextSelection(
+                    currentEditor.state.doc.content.size
+                  );
+                }
+                mentionSuggestionSuppression.suppressTextInsertion(
+                  pathCandidate
+                );
+                currentEditor.commands.insertContent(
+                  createAgentFileMentionContent([reference], {
+                    prefixCaretAnchor: isPromptVisualLineStart(
+                      currentEditor,
+                      currentEditor.state.selection.from
+                    )
+                  })
+                );
+              })
+              .catch(() => {
+                insertPlainPasteText();
+              });
             return true;
           }
           event.preventDefault();

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.types.ts
@@ -41,6 +41,13 @@ export interface AgentRichTextEditorProps {
   onPasteLargeText?: (text: string) => void;
   onPasteFiles?: (files: readonly File[]) => void;
   onDropFiles?: (files: readonly File[]) => void;
+  /**
+   * Host-owned absolute-path paste resolution. Returning a reference inserts a
+   * file/directory mention; returning null falls back to plain text.
+   */
+  onResolvePastedPath?: (
+    text: string
+  ) => Promise<WorkspaceFileReference | null>;
 }
 
 export interface AgentRichTextEditorHandle {

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentRichTextEditorSupport.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentRichTextEditorSupport.ts
@@ -95,6 +95,25 @@ export function classifyAgentRichTextTextPaste(
     : "plain-text";
 }
 
+/**
+ * Hosts may resolve a single absolute path paste into a file/directory mention.
+ * Keep the sync gate strict so quoted paths, spaces, and multi-path pastes stay
+ * plain text until a host explicitly resolves them.
+ */
+export function isAgentRichTextAbsolutePathPasteCandidate(
+  text: string
+): boolean {
+  const candidate = text.trim();
+  if (!candidate || candidate[0] !== "/") {
+    return false;
+  }
+  // Reject multi-line and whitespace/quotes inside the path.
+  if (/[\s"'`]/.test(candidate)) {
+    return false;
+  }
+  return true;
+}
+
 export function buildWorkspaceFileMentionDropContent(
   entries: ReadonlyArray<{
     path: string;

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/handleAgentRichTextAbsolutePathPaste.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/handleAgentRichTextAbsolutePathPaste.ts
@@ -1,0 +1,83 @@
+import type { Editor } from "@tiptap/core";
+import type { WorkspaceFileReference } from "@tutti-os/workspace-file-reference/contracts";
+import type { AgentGUIProviderSkillOption } from "../model/agentGuiNodeTypes";
+import type { AgentCapabilityTokenOption } from "./agentCapabilityTokenExtension";
+import { plainTextToAgentRichTextInlineContent } from "./agentRichTextDocument";
+import {
+  isAgentRichTextAbsolutePathPasteCandidate,
+  isPromptVisualLineStart
+} from "./agentRichTextEditorSupport";
+import { createAgentFileMentionContent } from "./agentWorkspaceFileReferences";
+
+type MentionSuggestionSuppression = {
+  suppressTextInsertion: (text: string) => void;
+};
+
+export function handleAgentRichTextAbsolutePathPaste(input: {
+  availableCapabilities: readonly AgentCapabilityTokenOption[];
+  availableSkills: readonly AgentGUIProviderSkillOption[];
+  editorRef: { current: Editor | null };
+  mentionSuggestionSuppression: MentionSuggestionSuppression;
+  resolvePastedPath?:
+    | ((text: string) => Promise<WorkspaceFileReference | null>)
+    | null;
+  text: string;
+}): boolean {
+  const pathCandidate = input.text.trim();
+  const resolvePastedPath = input.resolvePastedPath;
+  if (
+    !resolvePastedPath ||
+    !isAgentRichTextAbsolutePathPasteCandidate(pathCandidate)
+  ) {
+    return false;
+  }
+
+  const insertPlainPasteText = (): void => {
+    const currentEditor = input.editorRef.current;
+    if (!currentEditor || currentEditor.isDestroyed) {
+      return;
+    }
+    if (!currentEditor.isFocused) {
+      currentEditor.commands.setTextSelection(
+        currentEditor.state.doc.content.size
+      );
+    }
+    input.mentionSuggestionSuppression.suppressTextInsertion(input.text);
+    currentEditor.commands.insertContent(
+      plainTextToAgentRichTextInlineContent(input.text, {
+        capabilities: input.availableCapabilities,
+        skills: input.availableSkills
+      })
+    );
+  };
+
+  void resolvePastedPath(pathCandidate)
+    .then((reference) => {
+      const currentEditor = input.editorRef.current;
+      if (!currentEditor || currentEditor.isDestroyed) {
+        return;
+      }
+      if (!reference) {
+        insertPlainPasteText();
+        return;
+      }
+      if (!currentEditor.isFocused) {
+        currentEditor.commands.setTextSelection(
+          currentEditor.state.doc.content.size
+        );
+      }
+      input.mentionSuggestionSuppression.suppressTextInsertion(pathCandidate);
+      currentEditor.commands.insertContent(
+        createAgentFileMentionContent([reference], {
+          prefixCaretAnchor: isPromptVisualLineStart(
+            currentEditor,
+            currentEditor.state.selection.from
+          )
+        })
+      );
+    })
+    .catch(() => {
+      insertPlainPasteText();
+    });
+  return true;
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/routeAgentRichTextTextPaste.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/routeAgentRichTextTextPaste.ts
@@ -1,0 +1,79 @@
+import type { Editor } from "@tiptap/core";
+import type { WorkspaceFileReference } from "@tutti-os/workspace-file-reference/contracts";
+import type { AgentGUIProviderSkillOption } from "../model/agentGuiNodeTypes";
+import type { AgentCapabilityTokenOption } from "./agentCapabilityTokenExtension";
+import { plainTextToAgentRichTextInlineContent } from "./agentRichTextDocument";
+import {
+  classifyAgentRichTextTextPaste,
+  insertAgentRichTextClipboardHtml
+} from "./agentRichTextEditorSupport";
+import { handleAgentRichTextAbsolutePathPaste } from "./handleAgentRichTextAbsolutePathPaste";
+
+type MentionSuggestionSuppression = {
+  suppressTextInsertion: (text: string) => void;
+};
+
+export function routeAgentRichTextTextPaste(input: {
+  availableCapabilities: readonly AgentCapabilityTokenOption[];
+  availableSkills: readonly AgentGUIProviderSkillOption[];
+  editorRef: { current: Editor | null };
+  html: string;
+  mentionSuggestionSuppression: MentionSuggestionSuppression;
+  onPasteLargeText?: ((text: string) => void) | null;
+  resolvePastedPath?:
+    | ((text: string) => Promise<WorkspaceFileReference | null>)
+    | null;
+  text: string;
+}): boolean {
+  const textPasteKind = classifyAgentRichTextTextPaste(
+    input.text,
+    input.html,
+    Boolean(input.onPasteLargeText)
+  );
+  if (textPasteKind === "empty") {
+    return false;
+  }
+  if (textPasteKind === "large-text") {
+    input.onPasteLargeText?.(input.text);
+    return true;
+  }
+  if (textPasteKind === "structured-mention") {
+    const currentEditor = input.editorRef.current;
+    if (!currentEditor) {
+      return true;
+    }
+    if (insertAgentRichTextClipboardHtml(currentEditor, input.html)) {
+      input.mentionSuggestionSuppression.suppressTextInsertion(input.text);
+    }
+    return true;
+  }
+  if (
+    handleAgentRichTextAbsolutePathPaste({
+      availableCapabilities: input.availableCapabilities,
+      availableSkills: input.availableSkills,
+      editorRef: input.editorRef,
+      mentionSuggestionSuppression: input.mentionSuggestionSuppression,
+      resolvePastedPath: input.resolvePastedPath,
+      text: input.text
+    })
+  ) {
+    return true;
+  }
+  const currentEditor = input.editorRef.current;
+  if (!currentEditor) {
+    return true;
+  }
+  if (!currentEditor.isFocused) {
+    currentEditor.commands.setTextSelection(
+      currentEditor.state.doc.content.size
+    );
+  }
+  input.mentionSuggestionSuppression.suppressTextInsertion(input.text);
+  currentEditor.commands.insertContent(
+    plainTextToAgentRichTextInlineContent(input.text, {
+      capabilities: input.availableCapabilities,
+      skills: input.availableSkills
+    })
+  );
+  return true;
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
@@ -10,6 +10,7 @@ import type { AgentPromptContentBlock } from "../../../shared/contracts/dto/agen
 import type { WorkspaceUserProjectI18nRuntime } from "@tutti-os/workspace-user-project/i18n";
 import type { WorkspaceLinkAction } from "../../../actions/workspaceLinkActions";
 import type { AgentContextMentionItem } from "../agentRichText/agentFileMentionExtension";
+import type { AgentRichTextEditorProps } from "../agentRichText/AgentRichTextEditor.types";
 import type { AgentExternalPromptEntryResolver } from "../model/agentExternalPromptEntries";
 import type { AgentExternalPromptFilePreparer } from "../model/agentExternalPromptFiles";
 import type { AgentProjectPathChangeMetadata } from "../AgentComposerSettingsMenus";
@@ -434,6 +435,7 @@ export interface AgentComposerProps {
     | null;
   resolveExternalPromptEntries?: AgentExternalPromptEntryResolver | null;
   prepareExternalPromptFiles?: AgentExternalPromptFilePreparer | null;
+  resolvePastedPath?: AgentRichTextEditorProps["onResolvePastedPath"] | null;
   promptAssetLimit?: number | null;
   selectProjectDirectory?: () => Promise<{ path: string } | null>;
   onRequestGitBranches?: AgentComposerGitBranchLoader | null;

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerView.tsx
@@ -445,6 +445,9 @@ export function AgentComposerView(input: Props): React.JSX.Element {
                         ? input.addExternalPromptEntries
                         : undefined
                     }
+                    onResolvePastedPath={
+                      input.props.resolvePastedPath ?? undefined
+                    }
                   />
                   {!isHeroLayout ? composerActionButton : null}
                 </div>

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
@@ -71,6 +71,7 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
   onRequestWorkspaceReferences,
   resolveExternalPromptEntries = null,
   prepareExternalPromptFiles = null,
+  resolvePastedPath = null,
   promptAssetLimit = null,
   selectProjectDirectory,
   onRequestGitBranches,
@@ -489,6 +490,7 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       onRequestWorkspaceReferences: stableRequestWorkspaceReferences,
       resolveExternalPromptEntries,
       prepareExternalPromptFiles,
+      resolvePastedPath,
       promptAssetLimit,
       selectProjectDirectory: stableSelectProjectDirectory,
       onRequestGitBranches: stableRequestGitBranches
@@ -529,6 +531,7 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       removeQueuedPrompt,
       resolveExternalPromptEntries,
       prepareExternalPromptFiles,
+      resolvePastedPath,
       promptAssetLimit,
       sendQueuedPromptNext,
       showPromptImagesUnsupported,

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
@@ -712,6 +712,7 @@ export interface AgentGUINodeViewProps {
   ) => void | Promise<void>;
   resolveExternalPromptEntries?: AgentComposerProps["resolveExternalPromptEntries"];
   prepareExternalPromptFiles?: AgentComposerProps["prepareExternalPromptFiles"];
+  resolvePastedPath?: AgentComposerProps["resolvePastedPath"];
   promptAssetLimit?: number | null;
   onConversationRailWidthChanged: (widthPx: number) => void;
   onConversationRailLayoutChange?: (
@@ -779,6 +780,7 @@ export interface AgentGUIDetailPaneProps {
     | null;
   resolveExternalPromptEntries?: AgentComposerProps["resolveExternalPromptEntries"];
   prepareExternalPromptFiles?: AgentComposerProps["prepareExternalPromptFiles"];
+  resolvePastedPath?: AgentComposerProps["resolvePastedPath"];
   promptAssetLimit?: number | null;
   selectProjectDirectory?: () => Promise<{ path: string } | null>;
   onRequestGitBranches?: AgentComposerGitBranchLoader | null;

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
@@ -558,7 +558,14 @@ export type AgentGUIConversationRailLabels = Pick<
   | "viewActivity"
   | "viewActivityNeedsAttention"
 >;
-export interface AgentGUINodeViewProps {
+type AgentGUIComposerExternalPromptProps = Pick<
+  AgentComposerProps,
+  | "resolveExternalPromptEntries"
+  | "prepareExternalPromptFiles"
+  | "resolvePastedPath"
+  | "promptAssetLimit"
+>;
+export interface AgentGUINodeViewProps extends AgentGUIComposerExternalPromptProps {
   viewModel: AgentGUINodeViewModel;
   referenceProvenanceFilters?: AgentComposerReferenceProvenanceFilters | null;
   sessionInputHistoryEnabled?: boolean;
@@ -710,10 +717,6 @@ export interface AgentGUINodeViewProps {
   onWorkspaceFileReferencesAdded?: (
     references: readonly WorkspaceFileReference[]
   ) => void | Promise<void>;
-  resolveExternalPromptEntries?: AgentComposerProps["resolveExternalPromptEntries"];
-  prepareExternalPromptFiles?: AgentComposerProps["prepareExternalPromptFiles"];
-  resolvePastedPath?: AgentComposerProps["resolvePastedPath"];
-  promptAssetLimit?: number | null;
   onConversationRailWidthChanged: (widthPx: number) => void;
   onConversationRailLayoutChange?: (
     layout: AgentGUIConversationRailLayout
@@ -738,7 +741,7 @@ export interface AgentGUINodeViewProps {
   workspaceAppIcons?: readonly AgentMessageMarkdownWorkspaceAppIcon[];
   renderComposerFooterAccessory?: AgentGUIComposerFooterAccessoryRenderer;
 }
-export interface AgentGUIDetailPaneProps {
+export interface AgentGUIDetailPaneProps extends AgentGUIComposerExternalPromptProps {
   shell: AgentGUINodeViewModel["shell"];
   rail: AgentGUINodeViewModel["rail"];
   detail: AgentGUINodeViewModel["detail"];
@@ -778,10 +781,6 @@ export interface AgentGUIDetailPaneProps {
         entity?: AgentContextMentionItem | null
       ) => Promise<WorkspaceReferencePickResult>)
     | null;
-  resolveExternalPromptEntries?: AgentComposerProps["resolveExternalPromptEntries"];
-  prepareExternalPromptFiles?: AgentComposerProps["prepareExternalPromptFiles"];
-  resolvePastedPath?: AgentComposerProps["resolvePastedPath"];
-  promptAssetLimit?: number | null;
   selectProjectDirectory?: () => Promise<{ path: string } | null>;
   onRequestGitBranches?: AgentComposerGitBranchLoader | null;
   onRequestComposerFocus: () => void;
@@ -797,6 +796,5 @@ export interface AgentGUISidebarFooterContext {
 export type AgentGUISidebarFooterRenderer = (
   ctx: AgentGUISidebarFooterContext
 ) => ReactNode;
-
 /** Renders the host-owned empty state for an exact provider rail. */
 export type AgentGUIAgentsEmptyRenderer = () => ReactNode;


### PR DESCRIPTION
## Summary
- Add optional `workspace.resolvePastedPath` so hosts can turn a single absolute path paste into a file/directory mention.
- AgentGUI only applies a strict sync candidate gate; existence checks, host-namespace projection, and Shared-Agent policy stay host-owned.
- Fall back to plain text when resolution returns `null` or rejects; omit the callback to keep previous paste behavior.
- Document the contract in `docs/architecture/agent-gui-node.md`.

## Impact
- Additive optional API only. Hosts that do not wire `resolvePastedPath` keep plain-text paste.
- Touches composer rich-text paste path and prop plumbing through AgentGUI → DetailPane → Composer → Editor.
- No lifecycle, runtime, or Engine ownership changes.
- Text/path paste routing extracted so AgentGUI stays under the 800-line degradation budget.

## Review lanes
| Lane | Trigger | Result | Evidence | Affected consumers |
| --- | --- | --- | --- | --- |
| Architecture | Composer paste / workspace public contract | pass | Optional host boundary documented next to external paste prep in `agent-gui-node.md`; mention insertion reuses `createAgentFileMentionContent` | AgentGUI hosts that opt in |
| Performance | Rich-text paste path | pass | Sync gate only; host resolve is async and host-owned; no engine subscription or list fanout | Composer editor |
| Consumers | New optional workspace prop | pass | Default `null`; non-wired hosts unchanged; TSH will consume after Tutti release | TSH Desktop (planned), other AgentGUI hosts |

## Test plan
- [x] `pnpm exec vitest run agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx`
- [ ] Paste an existing absolute path with a host resolver → file/directory chip
- [ ] Paste a missing / quoted / spaced / multi-path string → plain text
- [ ] Host resolver reject → plain text, no silent paste loss
- [ ] Host without `resolvePastedPath` → unchanged plain-text paste


Made with [Cursor](https://cursor.com)