### PR TITLE
fix(agent): recover stale mutagen auth markers

### DIFF
--- a/packages/agent/runtimeprep/mutagen_auth.go
+++ b/packages/agent/runtimeprep/mutagen_auth.go
@@ -111,10 +111,16 @@ func (p MutagenAuthFileProjector) Project(ctx context.Context, input AuthFilePro
 			return nil, errors.New("invalid persisted Mutagen auth session marker")
 		}
 		executable, err := p.resolveExecutable(ctx)
-		if err != nil {
-			return nil, err
+		if err == nil {
+			return p.cleanupCallback(executable, sessionName, markerPath), nil
 		}
-		return p.cleanupCallback(executable, sessionName, markerPath), nil
+		// The marker can outlive the bundled or cached Mutagen executable after
+		// an upgrade or an interrupted shutdown. Drop only the marker and keep
+		// the runtime auth file; the normal guarded-copy path below refreshes it
+		// from the stable source before the provider starts.
+		if err := os.Remove(markerPath); err != nil && !os.IsNotExist(err) {
+			return nil, fmt.Errorf("remove unavailable Mutagen session marker: %w", err)
+		}
 	} else if !os.IsNotExist(err) {
 		return nil, fmt.Errorf("read Mutagen auth session marker: %w", err)
 	}

--- a/packages/agent/runtimeprep/mutagen_auth_test.go
+++ b/packages/agent/runtimeprep/mutagen_auth_test.go
@@ -175,6 +175,46 @@ func TestMutagenAuthProjectorCopyFallbackRejectsInvalidRuntimeJSON(t *testing.T)
 	}
 }
 
+func TestMutagenAuthProjectorFallsBackFromPersistedMarkerWhenMutagenIsUnavailable(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "stable", "auth.json")
+	target := filepath.Join(root, "run", "auth.json")
+	if err := os.MkdirAll(filepath.Dir(source), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(source, []byte(`{"token":"stable"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte(`{"token":"stale-run"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(filepath.Dir(target), mutagenSessionMarker)
+	if err := os.WriteFile(marker, []byte("stale-session\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	projector := MutagenAuthFileProjector{
+		StateDir:          root,
+		Symlink:           func(string, string) error { return os.ErrPermission },
+		ResolveExecutable: func(context.Context) (string, error) { return "", errors.New("missing") },
+	}
+	cleanup, err := projector.Project(context.Background(), AuthFileProjection{SourcePath: source, TargetPath: target})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cleanup == nil {
+		t.Fatal("cleanup = nil, want copy fallback cleanup")
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("marker still exists: %v", err)
+	}
+	if content, err := os.ReadFile(target); err != nil || string(content) != `{"token":"stable"}` {
+		t.Fatalf("refreshed runtime auth = %q, %v", content, err)
+	}
+}
+
 func TestMutagenAuthProjectorPreservesSessionOnConflict(t *testing.T) {
 	root := t.TempDir()
 	source := filepath.Join(root, "stable", "auth.json")


### PR DESCRIPTION
## 问题

正式版无 Mutagen E2E 发现：旧会话留下的 .tutti-mutagen-session 会在受保护复制 fallback 之前直接返回 Mutagen is unavailable，导致复用 Codex 会话发送失败。

## 修复

- Mutagen 可用时继续恢复并清理原同步会话
- Mutagen 不可用时只移除过期 marker，保留 runtime auth，然后继续进入受保护复制路径
- 新增旧 marker + 无 Mutagen 的回归测试

## 验证

- PASS: go test -run 'TestMutagenAuthProjector' -count=1 -v`n- 7 项通过，真实 Mutagen E2E 因未设置显式测试二进制按预期跳过