### PR TITLE
fix(app-catalog): support controlled app withdrawal

### DIFF
--- a/.github/workflows/publish-tutti-app-catalog.yml
+++ b/.github/workflows/publish-tutti-app-catalog.yml
@@ -15,6 +15,10 @@ on:
         description: Optional comma or newline separated remote app ids. In merge mode, leave empty to refresh the existing catalog.
         required: false
         type: string
+      withdraw_app_versions:
+        description: Optional comma or newline separated appId@version entries to withdraw before publishing. Requires merge mode; immutable release files are retained.
+        required: false
+        type: string
       aws_region:
         description: AWS region. Defaults to vars.TUTTI_APP_RELEASES_AWS_REGION.
         required: false
@@ -49,6 +53,7 @@ jobs:
     env:
       CATALOG_MODE: ${{ inputs.catalog_mode }}
       APP_IDS_INPUT: ${{ inputs.app_ids }}
+      WITHDRAW_APP_VERSIONS_INPUT: ${{ inputs.withdraw_app_versions }}
       AWS_REGION_VALUE: ${{ inputs.aws_region || vars.TUTTI_APP_RELEASES_AWS_REGION }}
       AWS_ROLE_ARN_VALUE: ${{ inputs.aws_role_arn || vars.TUTTI_APP_RELEASES_AWS_ROLE_ARN }}
       S3_BUCKET_VALUE: ${{ inputs.s3_bucket || vars.TUTTI_APP_RELEASES_S3_BUCKET }}
@@ -86,6 +91,95 @@ jobs:
         with:
           aws-region: ${{ env.AWS_REGION_VALUE }}
           role-to-assume: ${{ env.AWS_ROLE_ARN_VALUE }}
+
+      - name: Withdraw app versions
+        if: env.WITHDRAW_APP_VERSIONS_INPUT != ''
+        shell: bash
+        run: |
+          if [ "${CATALOG_MODE}" != "merge" ]; then
+            echo "withdraw_app_versions requires catalog_mode=merge" >&2
+            exit 1
+          fi
+
+          mkdir -p tutti-app-releases/withdrawals
+          prefix="${S3_PREFIX_VALUE%/}"
+          : > tutti-app-releases/withdrawn-app-ids.txt
+          : > tutti-app-releases/withdrawn-versions.txt
+
+          while IFS= read -r raw_entry; do
+            entry="$(echo "${raw_entry}" | xargs)"
+            if [ -z "${entry}" ]; then
+              continue
+            fi
+            if [[ "${entry}" != *@* ]]; then
+              echo "Withdrawal entry must be appId@version: ${entry}" >&2
+              exit 1
+            fi
+
+            app_id="${entry%@*}"
+            version="${entry##*@}"
+            if [[ ! "${app_id}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+              echo "Invalid app id in withdrawal entry: ${entry}" >&2
+              exit 1
+            fi
+            if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]; then
+              echo "Invalid semver in withdrawal entry: ${entry}" >&2
+              exit 1
+            fi
+
+            marker="${app_id}@${version}"
+            if grep -Fqx "${marker}" tutti-app-releases/withdrawn-versions.txt; then
+              echo "Duplicate withdrawal entry: ${marker}" >&2
+              exit 1
+            fi
+
+            versions_key="apps/${app_id}/versions.json"
+            versions_path="tutti-app-releases/withdrawals/${app_id}.json"
+            updated_path="tutti-app-releases/withdrawals/${app_id}.updated.json"
+            if [ -n "${prefix}" ]; then
+              versions_key="${prefix}/${versions_key}"
+            fi
+
+            if ! aws s3api head-object \
+              --bucket "${S3_BUCKET_VALUE}" \
+              --key "${versions_key}" \
+              >/dev/null; then
+              echo "Missing versions index for ${app_id}" >&2
+              exit 1
+            fi
+            etag="$(aws s3api head-object \
+              --bucket "${S3_BUCKET_VALUE}" \
+              --key "${versions_key}" \
+              --query ETag \
+              --output text)"
+            aws s3api get-object \
+              --bucket "${S3_BUCKET_VALUE}" \
+              --key "${versions_key}" \
+              "${versions_path}" \
+              >/dev/null
+
+            pnpm --package @tutti-os/app-release-tools@latest dlx build-tutti-app-versions \
+              --existing-versions "${versions_path}" \
+              --set-status-version "${version}" \
+              --status withdrawn \
+              --output "${updated_path}"
+            aws s3api put-object \
+              --bucket "${S3_BUCKET_VALUE}" \
+              --key "${versions_key}" \
+              --body "${updated_path}" \
+              --content-type application/json \
+              --cache-control "public, max-age=60" \
+              --if-match "${etag}" \
+              >/dev/null
+
+            printf '%s\n' "${app_id}" >> tutti-app-releases/withdrawn-app-ids.txt
+            printf '%s\n' "${marker}" >> tutti-app-releases/withdrawn-versions.txt
+          done < <(printf '%s\n' "${WITHDRAW_APP_VERSIONS_INPUT}" | tr ',' '\n')
+
+          sort -u -o tutti-app-releases/withdrawn-app-ids.txt \
+            tutti-app-releases/withdrawn-app-ids.txt
+          echo "Withdrawn versions:"
+          cat tutti-app-releases/withdrawn-versions.txt
 
       - name: Resolve catalog app ids
         shell: bash
@@ -137,6 +231,10 @@ jobs:
               }
             ' tutti-app-releases/existing-catalog.json)"
             app_ids_value="${existing_app_ids}"
+          fi
+
+          if [ -s tutti-app-releases/withdrawn-app-ids.txt ]; then
+            app_ids_value="${app_ids_value},$(paste -sd, tutti-app-releases/withdrawn-app-ids.txt)"
           fi
 
           : > tutti-app-releases/app-ids.txt

--- a/docs/conventions/workspace-app-catalog.md
+++ b/docs/conventions/workspace-app-catalog.md
@@ -254,6 +254,14 @@ existing catalog apps and updates only selected app ids. Replace mode publishes
 only the selected app ids and should be used only for deliberate full catalog
 replacement.
 
+For a controlled withdrawal, dispatch the production workflow in `merge` mode
+with `withdraw_app_versions` set to comma- or newline-separated
+`appId@version` entries. The workflow marks those records `withdrawn` in their
+mutable `versions.json` indexes and then rebuilds the catalog. It never deletes
+the immutable release directory or `latest.json`, so restoring a withdrawn
+release remains a metadata-only operation. Withdrawal is intentionally rejected
+in `replace` mode to prevent an accidental partial catalog publication.
+
 There are three normal publishing modes:
 
 1. Release only: `publish_catalog: false` and `catalog_only: false`. This


### PR DESCRIPTION
## Summary
- add a guarded production catalog workflow input for withdrawing selected `appId@version` records
- mark only the mutable versions index record as `withdrawn`, then merge-refresh the catalog
- keep immutable release artifacts and `latest.json` for rollback

## Validation
- `git diff --check`
- Prettier check passed for the workflow and catalog convention doc

This enables the previously published competitive-product-analysis, design-review, and draw-topic-app entries to be withdrawn without a replace-mode catalog rewrite.