### PR TITLE
fix(app-catalog): bootstrap legacy withdrawal indexes

### DIFF
--- a/.github/workflows/publish-tutti-app-catalog.yml
+++ b/.github/workflows/publish-tutti-app-catalog.yml
@@ -106,6 +106,22 @@ jobs:
           : > tutti-app-releases/withdrawn-app-ids.txt
           : > tutti-app-releases/withdrawn-versions.txt
 
+          catalog_key="catalog.json"
+          if [ -n "${prefix}" ]; then
+            catalog_key="${prefix}/${catalog_key}"
+          fi
+          if ! aws s3api get-object \
+            --bucket "${S3_BUCKET_VALUE}" \
+            --key "${catalog_key}" \
+            tutti-app-releases/withdrawal-baseline-catalog.json \
+            >/dev/null 2>tutti-app-releases/withdrawal-catalog-error.txt; then
+            if ! grep -Eq "(404|Not Found|NoSuchKey)" \
+              tutti-app-releases/withdrawal-catalog-error.txt; then
+              cat tutti-app-releases/withdrawal-catalog-error.txt >&2
+              exit 1
+            fi
+          fi
+
           while IFS= read -r raw_entry; do
             entry="$(echo "${raw_entry}" | xargs)"
             if [ -z "${entry}" ]; then
@@ -140,36 +156,79 @@ jobs:
               versions_key="${prefix}/${versions_key}"
             fi
 
-            if ! aws s3api head-object \
-              --bucket "${S3_BUCKET_VALUE}" \
-              --key "${versions_key}" \
-              >/dev/null; then
-              echo "Missing versions index for ${app_id}" >&2
-              exit 1
-            fi
-            etag="$(aws s3api head-object \
+            if etag="$(aws s3api head-object \
               --bucket "${S3_BUCKET_VALUE}" \
               --key "${versions_key}" \
               --query ETag \
-              --output text)"
-            aws s3api get-object \
-              --bucket "${S3_BUCKET_VALUE}" \
-              --key "${versions_key}" \
-              "${versions_path}" \
-              >/dev/null
-
-            pnpm --package @tutti-os/app-release-tools@latest dlx build-tutti-app-versions \
-              --existing-versions "${versions_path}" \
-              --set-status-version "${version}" \
-              --status withdrawn \
-              --output "${updated_path}"
+              --output text 2>tutti-app-releases/withdrawal-head-error.txt)"; then
+              aws s3api get-object \
+                --bucket "${S3_BUCKET_VALUE}" \
+                --key "${versions_key}" \
+                "${versions_path}" \
+                >/dev/null
+              pnpm --package @tutti-os/app-release-tools@latest dlx build-tutti-app-versions \
+                --existing-versions "${versions_path}" \
+                --set-status-version "${version}" \
+                --status withdrawn \
+                --output "${updated_path}"
+              put_condition=(--if-match "${etag}")
+            elif grep -Eq "(404|Not Found|NoSuchKey)" \
+              tutti-app-releases/withdrawal-head-error.txt; then
+              if [ ! -f tutti-app-releases/withdrawal-baseline-catalog.json ]; then
+                echo "Cannot bootstrap missing versions index for ${app_id}: catalog baseline is unavailable" >&2
+                exit 1
+              fi
+              min_tutti_version="$(node -e '
+                const fs = require("fs");
+                const catalog = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+                const appId = process.argv[2];
+                const version = process.argv[3];
+                const compatibility = catalog.compatibility?.apps?.[appId] ?? [];
+                const compatible = compatibility.find(
+                  (entry) => entry?.app?.manifest?.version === version
+                );
+                if (compatible?.minTuttiVersion) {
+                  console.log(compatible.minTuttiVersion);
+                  process.exit(0);
+                }
+                const legacy = (catalog.apps ?? []).find(
+                  (app) =>
+                    app?.manifest?.appId === appId &&
+                    app?.manifest?.version === version
+                );
+                if (legacy) console.log("0.0.0");
+              ' tutti-app-releases/withdrawal-baseline-catalog.json "${app_id}" "${version}")"
+              if [ -z "${min_tutti_version}" ]; then
+                echo "Cannot infer compatibility baseline for ${app_id}@${version}" >&2
+                exit 1
+              fi
+              release_key="apps/${app_id}/${version}/release.json"
+              release_path="tutti-app-releases/withdrawals/${app_id}.${version}.release.json"
+              if [ -n "${prefix}" ]; then
+                release_key="${prefix}/${release_key}"
+              fi
+              aws s3api get-object \
+                --bucket "${S3_BUCKET_VALUE}" \
+                --key "${release_key}" \
+                "${release_path}" \
+                >/dev/null
+              pnpm --package @tutti-os/app-release-tools@latest dlx build-tutti-app-versions \
+                --release-file "${release_path}" \
+                --min-tutti-version "${min_tutti_version}" \
+                --status withdrawn \
+                --output "${updated_path}"
+              put_condition=(--if-none-match '*')
+            else
+              cat tutti-app-releases/withdrawal-head-error.txt >&2
+              exit 1
+            fi
             aws s3api put-object \
               --bucket "${S3_BUCKET_VALUE}" \
               --key "${versions_key}" \
               --body "${updated_path}" \
               --content-type application/json \
               --cache-control "public, max-age=60" \
-              --if-match "${etag}" \
+              "${put_condition[@]}" \
               >/dev/null
 
             printf '%s\n' "${app_id}" >> tutti-app-releases/withdrawn-app-ids.txt


### PR DESCRIPTION
## Summary
- allow controlled withdrawals to bootstrap a missing versions index from the catalog legacy entry and immutable release metadata
- fail closed for missing or ambiguous compatibility baselines
- preserve conditional writes and immutable artifacts

## Validation
- `git diff --check`
- Prettier check passed for the workflow

This is needed for older published apps that predate `versions.json`.