### PR TITLE
fix(desktop): capture composer follow-ups + configurable capture shortcut

### DIFF
--- a/apps/desktop/src/main/capture/captureShortcut.test.ts
+++ b/apps/desktop/src/main/capture/captureShortcut.test.ts
@@ -2,10 +2,32 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   desktopCaptureAccelerator,
-  desktopCaptureShortcutKeys
+  desktopCaptureShortcutKeys,
+  resolveCaptureAccelerator
 } from "./captureShortcut.ts";
 
 test("desktop capture uses a discoverable shortcut with at most three keys", () => {
   assert.equal(desktopCaptureAccelerator, "CommandOrControl+Shift+S");
   assert.ok(desktopCaptureShortcutKeys.length <= 3);
+});
+
+test("capture accelerator follows a valid persisted binding", () => {
+  assert.equal(resolveCaptureAccelerator("Meta+Shift+P"), "Meta+Shift+P");
+  assert.equal(resolveCaptureAccelerator("Ctrl+Alt+F5"), "Ctrl+Alt+F5");
+  assert.equal(resolveCaptureAccelerator("Alt+Space"), "Alt+Space");
+  assert.equal(resolveCaptureAccelerator("Meta+ArrowUp"), "Meta+Up");
+});
+
+test("capture accelerator falls back to the default for unusable bindings", () => {
+  assert.equal(resolveCaptureAccelerator(null), desktopCaptureAccelerator);
+  assert.equal(resolveCaptureAccelerator(""), desktopCaptureAccelerator);
+  assert.equal(resolveCaptureAccelerator("  "), desktopCaptureAccelerator);
+  assert.equal(resolveCaptureAccelerator("S"), desktopCaptureAccelerator);
+  // Shift-only bindings would shadow plain typing system-wide.
+  assert.equal(resolveCaptureAccelerator("Shift+S"), desktopCaptureAccelerator);
+  assert.equal(
+    resolveCaptureAccelerator("Meta+Shift"),
+    desktopCaptureAccelerator
+  );
+  assert.equal(resolveCaptureAccelerator("Bogus+S"), desktopCaptureAccelerator);
 });

--- a/apps/desktop/src/main/capture/captureShortcut.ts
+++ b/apps/desktop/src/main/capture/captureShortcut.ts
@@ -5,3 +5,41 @@ export const desktopCaptureShortcutKeys = [
 ] as const;
 
 export const desktopCaptureAccelerator = desktopCaptureShortcutKeys.join("+");
+
+const bindingModifiers = new Set(["Meta", "Ctrl", "Alt", "Shift"]);
+
+const acceleratorKeyByBindingKey: Record<string, string> = {
+  ArrowDown: "Down",
+  ArrowLeft: "Left",
+  ArrowRight: "Right",
+  ArrowUp: "Up"
+};
+
+/**
+ * Maps a persisted capture shortcut binding (e.g. "Meta+Shift+S") onto an
+ * Electron accelerator. Malformed bindings and bindings without a
+ * Meta/Ctrl/Alt modifier resolve to the built-in default, so a bad
+ * preference can never disable capture or shadow plain typing system-wide.
+ */
+export function resolveCaptureAccelerator(
+  binding: string | null | undefined
+): string {
+  const normalized = binding?.trim() ?? "";
+  if (!normalized) {
+    return desktopCaptureAccelerator;
+  }
+  const parts = normalized.split("+").filter(Boolean);
+  if (parts.length < 2) {
+    return desktopCaptureAccelerator;
+  }
+  const key = parts[parts.length - 1] as string;
+  const modifiers = parts.slice(0, -1);
+  if (
+    bindingModifiers.has(key) ||
+    !modifiers.every((modifier) => bindingModifiers.has(modifier)) ||
+    !modifiers.some((modifier) => modifier !== "Shift")
+  ) {
+    return desktopCaptureAccelerator;
+  }
+  return [...modifiers, acceleratorKeyByBindingKey[key] ?? key].join("+");
+}

--- a/apps/desktop/src/main/capture/desktopCaptureService.ts
+++ b/apps/desktop/src/main/capture/desktopCaptureService.ts
@@ -76,7 +76,10 @@ import {
   enterCaptureSelectionFullscreen,
   resolveCaptureSelectionFullscreenOptions
 } from "./captureSelectionFullscreen.ts";
-import { desktopCaptureAccelerator } from "./captureShortcut.ts";
+import {
+  desktopCaptureAccelerator,
+  resolveCaptureAccelerator
+} from "./captureShortcut.ts";
 import type { DesktopFileDialogAccess } from "../host/desktopFileDialogAccess.ts";
 
 const captureComposerWidth = 760;
@@ -115,7 +118,7 @@ export function createDesktopCaptureService(input: {
   logger: DesktopLogger;
   preferences: Pick<
     DesktopHostPreferencesState,
-    "getLocale" | "getThemeSource"
+    "getLocale" | "getThemeSource" | "getWorkbenchShortcuts" | "subscribe"
   >;
   preloadPath: string;
   rendererFilePath: string;
@@ -442,29 +445,68 @@ export function createDesktopCaptureService(input: {
     }
   };
 
-  const registered = globalShortcut.register(desktopCaptureAccelerator, () => {
+  const captureShortcutCallback = () => {
     const returnFocusToExternalApplication =
       BrowserWindow.getFocusedWindow() === null;
     input.logger.info("screenshot shortcut activated", {
-      accelerator: desktopCaptureAccelerator
+      accelerator: registeredAccelerator
     });
     void openCapture(returnFocusToExternalApplication);
-  });
-  if (!registered || !globalShortcut.isRegistered(desktopCaptureAccelerator)) {
+  };
+  let registeredAccelerator: string | null = null;
+  const tryRegisterCaptureShortcut = (accelerator: string): boolean => {
+    try {
+      return (
+        globalShortcut.register(accelerator, captureShortcutCallback) &&
+        globalShortcut.isRegistered(accelerator)
+      );
+    } catch {
+      return false;
+    }
+  };
+  const applyCaptureShortcut = () => {
+    const accelerator = resolveCaptureAccelerator(
+      input.preferences.getWorkbenchShortcuts().captureScreenshot
+    );
+    if (accelerator === registeredAccelerator) {
+      return;
+    }
+    const previousAccelerator = registeredAccelerator;
+    if (previousAccelerator) {
+      globalShortcut.unregister(previousAccelerator);
+      registeredAccelerator = null;
+    }
+    if (tryRegisterCaptureShortcut(accelerator)) {
+      registeredAccelerator = accelerator;
+      input.logger.info("screenshot shortcut registered", { accelerator });
+      return;
+    }
     input.logger.warn("screenshot shortcut registration failed", {
-      accelerator: desktopCaptureAccelerator
+      accelerator
     });
-  } else {
-    input.logger.info("screenshot shortcut registered", {
-      accelerator: desktopCaptureAccelerator
-    });
-  }
+    // Keep capture reachable: restore the last working accelerator, or the
+    // built-in default when this was the initial registration.
+    const fallback = previousAccelerator ?? desktopCaptureAccelerator;
+    if (fallback !== accelerator && tryRegisterCaptureShortcut(fallback)) {
+      registeredAccelerator = fallback;
+      input.logger.info("screenshot shortcut registered", {
+        accelerator: fallback
+      });
+    }
+  };
+  applyCaptureShortcut();
+  const unsubscribePreferences =
+    input.preferences.subscribe(applyCaptureShortcut);
 
   return {
     dispose() {
       persistComposerPosition();
       app.removeListener("browser-window-focus", onBrowserWindowFocus);
-      globalShortcut.unregister(desktopCaptureAccelerator);
+      unsubscribePreferences();
+      if (registeredAccelerator) {
+        globalShortcut.unregister(registeredAccelerator);
+        registeredAccelerator = null;
+      }
       workspaceRendererReadiness.dispose();
       for (const channel of Object.values(desktopIpcChannels.capture)) {
         ipcMain.removeHandler(channel);

--- a/apps/desktop/src/main/capture/desktopCaptureService.ts
+++ b/apps/desktop/src/main/capture/desktopCaptureService.ts
@@ -369,9 +369,7 @@ export function createDesktopCaptureService(input: {
       try {
         const result = await capture.submission;
         const workspaceId = capture.state.workspaceId;
-        if (!capture.window.isDestroyed()) {
-          capture.window.close();
-        }
+        closeSubmittedCapture(capture);
         focusWorkspace(workspaceId);
         return result;
       } finally {
@@ -645,6 +643,16 @@ function cancelCapture(capture: ActiveCapture): void {
   capture.window.destroy();
 }
 
+function closeSubmittedCapture(capture: ActiveCapture): void {
+  if (capture.closing || capture.window.isDestroyed()) {
+    return;
+  }
+  capture.closing = true;
+  // Same rationale as cancelCapture: `close()` can be held open by renderer
+  // lifecycle handlers, leaving a submitted capture stranded on screen.
+  capture.window.destroy();
+}
+
 function cropSelection(
   capture: ActiveCapture,
   raw: DesktopCaptureSelectionInput
@@ -869,6 +877,7 @@ async function submitCapture(
         ...(cwd ? { cwd } : {}),
         initialContent: content,
         ...(displayPrompt ? { initialDisplayPrompt: displayPrompt } : {}),
+        reveal: true,
         ...(input.settings ? { settings: input.settings } : {}),
         title: resolveCaptureTitle(displayPrompt, attachment.displayName),
         visible: true

--- a/apps/desktop/src/main/desktopHostPreferences.ts
+++ b/apps/desktop/src/main/desktopHostPreferences.ts
@@ -52,6 +52,7 @@ import {
   type DesktopUpdateChannel,
   type DesktopUpdatePolicy,
   type DesktopWorkbenchShortcuts,
+  type DesktopWorkbenchShortcutsInput,
   type DesktopWorkbenchWindowSnapping
 } from "../shared/preferences/index.ts";
 import {
@@ -106,7 +107,7 @@ export interface DesktopHostPreferencesState {
     themeSource?: DesktopThemeSource;
     updateChannel?: DesktopUpdateChannel;
     updatePolicy?: DesktopUpdatePolicy;
-    workbenchShortcuts?: DesktopWorkbenchShortcuts;
+    workbenchShortcuts?: DesktopWorkbenchShortcutsInput;
     workbenchWindowSnapping?: DesktopWorkbenchWindowSnapping;
   }): void;
 }

--- a/apps/desktop/src/main/desktopHostPreferencesEventStream.test.ts
+++ b/apps/desktop/src/main/desktopHostPreferencesEventStream.test.ts
@@ -4,7 +4,11 @@ import type {
   DesktopPreferencesStateResponse,
   TuttidEventStreamClient
 } from "@tutti-os/client-tuttid-ts";
-import { defaultDesktopWorkbenchShortcuts } from "../shared/preferences/index.ts";
+import {
+  defaultDesktopWorkbenchShortcuts,
+  normalizeDesktopWorkbenchShortcuts,
+  type DesktopWorkbenchShortcuts
+} from "../shared/preferences/index.ts";
 import type { DesktopThemeSource } from "../shared/theme";
 import type { DesktopHostPreferencesState } from "./desktopHostPreferences";
 import type { DesktopLogger } from "./logging";
@@ -213,9 +217,8 @@ function createHostPreferencesState(): DesktopHostPreferencesState {
     "stable";
   let updatePolicy: DesktopPreferencesStateResponse["preferences"]["updatePolicy"] =
     "prompt";
-  let workbenchShortcuts: NonNullable<
-    DesktopPreferencesStateResponse["preferences"]["workbenchShortcuts"]
-  > = defaultDesktopWorkbenchShortcuts;
+  let workbenchShortcuts: DesktopWorkbenchShortcuts =
+    defaultDesktopWorkbenchShortcuts;
   let workbenchWindowSnapping: NonNullable<
     DesktopPreferencesStateResponse["preferences"]["workbenchWindowSnapping"]
   > = {
@@ -332,7 +335,9 @@ function createHostPreferencesState(): DesktopHostPreferencesState {
         updatePolicy = input.updatePolicy;
       }
       if (input.workbenchShortcuts) {
-        workbenchShortcuts = input.workbenchShortcuts;
+        workbenchShortcuts = normalizeDesktopWorkbenchShortcuts(
+          input.workbenchShortcuts
+        );
       }
       if (input.workbenchWindowSnapping) {
         workbenchWindowSnapping = input.workbenchWindowSnapping;

--- a/apps/desktop/src/renderer/src/features/desktop-preferences/services/internal/desktopPreferencesService.ts
+++ b/apps/desktop/src/renderer/src/features/desktop-preferences/services/internal/desktopPreferencesService.ts
@@ -57,6 +57,7 @@ import {
   type DesktopUpdateChannel,
   type DesktopUpdatePolicy,
   type DesktopWorkbenchShortcuts,
+  type DesktopWorkbenchShortcutsInput,
   type DesktopWorkbenchWindowSnapping
 } from "../../../../../../shared/preferences/index.ts";
 
@@ -816,7 +817,7 @@ export class DesktopPreferencesService implements IDesktopPreferencesService {
     themeSource: DesktopThemeSource;
     updateChannel: DesktopUpdateChannel;
     updatePolicy: DesktopUpdatePolicy;
-    workbenchShortcuts?: DesktopWorkbenchShortcuts;
+    workbenchShortcuts?: DesktopWorkbenchShortcutsInput;
     workbenchWindowSnapping?: DesktopWorkbenchWindowSnapping;
   }): void {
     this.store.agentCliUpdateCheckEnabled =

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceSettingsService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceSettingsService.test.ts
@@ -1242,7 +1242,8 @@ function createPreferencesState(
     updatePolicy: "prompt",
     workbenchShortcuts: {
       newAgentConversation: null,
-      newSameTypeWindow: null
+      newSameTypeWindow: null,
+      captureScreenshot: null
     },
     workbenchWindowSnapping: {
       enabled: false,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchShortcutService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchShortcutService.test.ts
@@ -18,7 +18,11 @@ function keyEvent(
 }
 
 test("matches configured binding", () => {
-  const shortcuts = { newAgentConversation: "Meta+K", newSameTypeWindow: null };
+  const shortcuts = {
+    newAgentConversation: "Meta+K",
+    newSameTypeWindow: null,
+    captureScreenshot: null
+  };
   assert.equal(
     resolveWorkbenchShortcutAction(
       keyEvent({ key: "k", metaKey: true }),
@@ -32,7 +36,8 @@ test("returns null when binding unset", () => {
   assert.equal(
     resolveWorkbenchShortcutAction(keyEvent({ key: "k", metaKey: true }), {
       newAgentConversation: null,
-      newSameTypeWindow: null
+      newSameTypeWindow: null,
+      captureScreenshot: null
     }),
     null
   );

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAppExternalBridge.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAppExternalBridge.tsx
@@ -36,6 +36,7 @@ import { IAgentsService } from "@renderer/features/workspace-agent/services/agen
 import type { AgentHostAgentSessionComposerSettings } from "@shared/contracts/dto";
 import { useService } from "@tutti-os/infra/di";
 import { requestGroupChatLaunch } from "../services/groupChatLaunchCoordinator.ts";
+import { normalizeDesktopAgentGUIProvider } from "@renderer/features/workspace-agent/desktopAgentGUINodeState.ts";
 import { requestWorkspaceAgentGuiLaunch } from "@renderer/features/workspace-agent/services/workspaceAgentGuiLaunchCoordinator.ts";
 import { useWorkspaceAppCenterService } from "@renderer/features/workspace-app-center";
 import { useTranslation } from "@renderer/i18n";
@@ -354,26 +355,45 @@ export function WorkspaceAppExternalBridge({
             settings: toAgentHostComposerSettings(request.input.settings),
             workspaceId
           })) as TuttiExternalAgentActivityComposerOptions;
-        case "agentActivity.activateSession":
-          return workspaceAgentActivityService.activateSession({
-            agentSessionId: request.input.agentSessionId,
-            agentTargetId: request.input.agentTargetId,
-            clientSubmitId: request.input.clientSubmitId,
-            ...(request.input.cwd ? { cwd: request.input.cwd } : {}),
-            initialContent: request.input.initialContent,
-            ...(request.input.initialDisplayPrompt !== undefined
-              ? { initialDisplayPrompt: request.input.initialDisplayPrompt }
-              : {}),
-            mode: "new",
-            ...(request.input.settings
-              ? { settings: request.input.settings }
-              : {}),
-            ...(request.input.title ? { title: request.input.title } : {}),
-            ...(request.input.visible !== undefined
-              ? { visible: request.input.visible }
-              : {}),
-            workspaceId
-          });
+        case "agentActivity.activateSession": {
+          const activation =
+            await workspaceAgentActivityService.activateSession({
+              agentSessionId: request.input.agentSessionId,
+              agentTargetId: request.input.agentTargetId,
+              clientSubmitId: request.input.clientSubmitId,
+              ...(request.input.cwd ? { cwd: request.input.cwd } : {}),
+              initialContent: request.input.initialContent,
+              ...(request.input.initialDisplayPrompt !== undefined
+                ? { initialDisplayPrompt: request.input.initialDisplayPrompt }
+                : {}),
+              mode: "new",
+              ...(request.input.settings
+                ? { settings: request.input.settings }
+                : {}),
+              ...(request.input.title ? { title: request.input.title } : {}),
+              ...(request.input.visible !== undefined
+                ? { visible: request.input.visible }
+                : {}),
+              workspaceId
+            });
+          if (request.input.reveal === true) {
+            // Navigation is best-effort: the session already exists, so a
+            // failed launch must not fail the activation result.
+            try {
+              await requestWorkspaceAgentGuiLaunch({
+                agentSessionId: activation.session.agentSessionId,
+                agentTargetId: request.input.agentTargetId,
+                provider: normalizeDesktopAgentGUIProvider(
+                  activation.session.provider
+                ),
+                workspaceId
+              });
+            } catch {
+              // Ignore navigation failures; the caller still gets the session.
+            }
+          }
+          return activation;
+        }
         case "agentActivity.sendInput":
           return workspaceAgentActivityService.sendInput({
             agentSessionId: request.input.agentSessionId,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
@@ -419,12 +419,16 @@ export function WorkspaceSettingsPanel({
                 purgingDeletedConversations={
                   settingsState.purgingDeletedConversations
                 }
+                onWorkbenchShortcutsChange={(shortcuts) => {
+                  void settingsService.changeWorkbenchShortcuts(shortcuts);
+                }}
                 onWorkspaceUiModeChange={(mode) => {
                   void settingsService.changeWorkspaceUiMode(mode);
                 }}
                 sleepPreventionMode={
                   desktopPreferencesState.sleepPreventionMode
                 }
+                workbenchShortcuts={desktopPreferencesState.workbenchShortcuts}
               />
             ) : settingsState.activeSection === "agent" ? (
               <div className="flex min-h-0 flex-col gap-5 pt-5">
@@ -761,24 +765,46 @@ function WorkspaceLabSettingsSection({
 }
 
 function WorkspaceLabShortcutRow({
+  className,
+  description,
   disabled,
   label,
+  placeholder,
+  requireNonShiftModifier = false,
   value,
   onChange
 }: {
+  className?: string;
+  description?: string;
   disabled: boolean;
   label: string;
+  placeholder?: string;
+  /**
+   * Reject bindings without Meta/Ctrl/Alt. Global accelerators must not
+   * shadow plain or shift-only typing in other applications.
+   */
+  requireNonShiftModifier?: boolean;
   value: string | null;
   onChange: (binding: string | null) => void;
 }) {
   const { t } = useTranslation();
   const clearLabel = t("workspace.settings.lab.clearShortcutLabel", { label });
   return (
-    <div className="flex w-full items-center justify-between gap-4 max-[560px]:flex-col max-[560px]:items-stretch">
+    <div
+      className={cn(
+        "flex w-full items-center justify-between gap-4 max-[560px]:flex-col max-[560px]:items-stretch",
+        className
+      )}
+    >
       <div className="flex min-w-0 flex-1 flex-col gap-1 max-[560px]:w-full">
         <strong className="text-[13px] font-semibold text-[var(--text-primary)]">
           {label}
         </strong>
+        {description ? (
+          <p className="m-0 text-[13px] leading-[1.3] text-[var(--text-secondary)]">
+            {description}
+          </p>
+        ) : null}
       </div>
       <div className="flex w-[220px] min-w-[220px] items-center gap-2 max-[560px]:w-full max-[560px]:min-w-0">
         <Input
@@ -789,7 +815,9 @@ function WorkspaceLabShortcutRow({
             disabled && "opacity-70"
           )}
           disabled={disabled}
-          placeholder={t("workspace.settings.lab.shortcutUnbound")}
+          placeholder={
+            placeholder ?? t("workspace.settings.lab.shortcutUnbound")
+          }
           readOnly
           value={value ?? ""}
           onKeyDown={(event) => {
@@ -804,6 +832,14 @@ function WorkspaceLabShortcutRow({
               event.key === "Escape"
             ) {
               onChange(null);
+              return;
+            }
+            if (
+              requireNonShiftModifier &&
+              !event.metaKey &&
+              !event.ctrlKey &&
+              !event.altKey
+            ) {
               return;
             }
             const binding = formatDesktopShortcutBinding({
@@ -2484,9 +2520,11 @@ function WorkspaceGeneralSettingsSection({
   onLocaleChange,
   onPurgeDeletedConversations,
   onSleepPreventionModeChange,
+  onWorkbenchShortcutsChange,
   onWorkspaceUiModeChange,
   purgingDeletedConversations,
-  sleepPreventionMode
+  sleepPreventionMode,
+  workbenchShortcuts
 }: {
   changingDeletedAgentConversationRetentionDays: DeletedAgentConversationRetentionDays | null;
   changingFeatureFlags: DesktopFeatureFlags | null;
@@ -2501,9 +2539,11 @@ function WorkspaceGeneralSettingsSection({
   onLocaleChange: (locale: DesktopLocale) => void;
   onPurgeDeletedConversations: () => Promise<void>;
   onSleepPreventionModeChange: (mode: DesktopSleepPreventionMode) => void;
+  onWorkbenchShortcutsChange: (shortcuts: DesktopWorkbenchShortcuts) => void;
   onWorkspaceUiModeChange: (mode: DesktopWorkspaceUiMode) => void;
   purgingDeletedConversations: boolean;
   sleepPreventionMode: DesktopSleepPreventionMode;
+  workbenchShortcuts: DesktopWorkbenchShortcuts;
 }) {
   const { t } = useTranslation();
   const agentDiagnosticsReporting = useAgentDiagnosticsConsent();
@@ -2777,6 +2817,24 @@ function WorkspaceGeneralSettingsSection({
           </Tooltip>
         </div>
       </div>
+
+      <WorkspaceLabShortcutRow
+        className="order-6"
+        description={t("workspace.settings.general.captureShortcutDescription")}
+        disabled={false}
+        label={t("workspace.settings.general.captureShortcutLabel")}
+        placeholder={t(
+          "workspace.settings.general.captureShortcutDefaultPlaceholder"
+        )}
+        requireNonShiftModifier
+        value={workbenchShortcuts.captureScreenshot}
+        onChange={(binding) => {
+          onWorkbenchShortcutsChange({
+            ...workbenchShortcuts,
+            captureScreenshot: binding
+          });
+        }}
+      />
 
       <Dialog open={purgeDialogOpen} onOpenChange={setPurgeDialogOpen}>
         <DialogContent>

--- a/apps/desktop/src/shared/i18n/locales/en.ts
+++ b/apps/desktop/src/shared/i18n/locales/en.ts
@@ -897,6 +897,10 @@ export const en = {
           zhCN: "Simplified Chinese"
         },
         localeSaveFailed: "We couldn't switch the app language right now.",
+        captureShortcutDefaultPlaceholder: "Default: Cmd/Ctrl+Shift+S",
+        captureShortcutDescription:
+          "Global shortcut that starts a screen capture. Include Cmd, Ctrl, or Alt; clear to restore the default.",
+        captureShortcutLabel: "Screenshot shortcut",
         preventSleepDescription: "Controls whether the system can enter sleep",
         preventSleepLabel: "Sleep prevention",
         preventSleepOptions: {

--- a/apps/desktop/src/shared/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/shared/i18n/locales/zh-CN.ts
@@ -845,6 +845,10 @@ export const zhCN = {
           zhCN: "简体中文"
         },
         localeSaveFailed: "暂时无法切换应用语言",
+        captureShortcutDefaultPlaceholder: "默认：Cmd/Ctrl+Shift+S",
+        captureShortcutDescription:
+          "全局截图快捷键，需包含 Cmd、Ctrl 或 Alt 修饰键；清除后恢复默认",
+        captureShortcutLabel: "截图快捷键",
         preventSleepDescription: "可控制系统是否进入休眠",
         preventSleepLabel: "防止休眠",
         preventSleepOptions: {

--- a/apps/desktop/src/shared/preferences/core.test.ts
+++ b/apps/desktop/src/shared/preferences/core.test.ts
@@ -81,7 +81,11 @@ test("normalizeDesktopWorkbenchShortcuts clamps + nulls empty", () => {
       newAgentConversation: "  Meta+K ",
       newSameTypeWindow: ""
     }),
-    { newAgentConversation: "Meta+K", newSameTypeWindow: null }
+    {
+      newAgentConversation: "Meta+K",
+      newSameTypeWindow: null,
+      captureScreenshot: null
+    }
   );
 });
 

--- a/apps/desktop/src/shared/preferences/core.ts
+++ b/apps/desktop/src/shared/preferences/core.ts
@@ -81,11 +81,25 @@ export const defaultDesktopWorkspaceUiMode: DesktopWorkspaceUiMode = "os";
 export interface DesktopWorkbenchShortcuts {
   newAgentConversation: string | null;
   newSameTypeWindow: string | null;
+  /**
+   * Global screenshot capture binding. Unlike the other bindings, null means
+   * the built-in default accelerator applies, not "unbound".
+   */
+  captureScreenshot: string | null;
 }
+
+/**
+ * Wire-compatible shortcuts shape: generated client payloads may omit newer
+ * bindings, so boundaries that normalize accept this partial form.
+ */
+export type DesktopWorkbenchShortcutsInput = {
+  [Key in keyof DesktopWorkbenchShortcuts]?: string | null;
+};
 
 export const defaultDesktopWorkbenchShortcuts: DesktopWorkbenchShortcuts = {
   newAgentConversation: null,
-  newSameTypeWindow: null
+  newSameTypeWindow: null,
+  captureScreenshot: null
 };
 
 export const desktopAgentConversationDetailModes = [
@@ -448,20 +462,22 @@ export function normalizeDesktopWorkbenchShortcuts(
     newAgentConversation: normalizeDesktopShortcutBinding(
       value.newAgentConversation
     ),
-    newSameTypeWindow: normalizeDesktopShortcutBinding(value.newSameTypeWindow)
+    newSameTypeWindow: normalizeDesktopShortcutBinding(value.newSameTypeWindow),
+    captureScreenshot: normalizeDesktopShortcutBinding(value.captureScreenshot)
   };
 }
 
 export function desktopWorkbenchShortcutsEqual(
-  left: DesktopWorkbenchShortcuts | null | undefined,
-  right: DesktopWorkbenchShortcuts | null | undefined
+  left: DesktopWorkbenchShortcutsInput | null | undefined,
+  right: DesktopWorkbenchShortcutsInput | null | undefined
 ): boolean {
   const normalizedLeft = normalizeDesktopWorkbenchShortcuts(left);
   const normalizedRight = normalizeDesktopWorkbenchShortcuts(right);
   return (
     normalizedLeft.newAgentConversation ===
       normalizedRight.newAgentConversation &&
-    normalizedLeft.newSameTypeWindow === normalizedRight.newSameTypeWindow
+    normalizedLeft.newSameTypeWindow === normalizedRight.newSameTypeWindow &&
+    normalizedLeft.captureScreenshot === normalizedRight.captureScreenshot
   );
 }
 

--- a/apps/desktop/src/shared/preferences/index.ts
+++ b/apps/desktop/src/shared/preferences/index.ts
@@ -94,6 +94,7 @@ export {
   type DesktopUpdateChannel,
   type DesktopUpdatePolicy,
   type DesktopWorkbenchShortcuts,
+  type DesktopWorkbenchShortcutsInput,
   type DesktopWorkbenchWindowSnapping,
   type DesktopWorkbenchWindowSnappingShortcutPreset
 } from "./core.ts";

--- a/docs/architecture/desktop-screenshot-to-qute.md
+++ b/docs/architecture/desktop-screenshot-to-qute.md
@@ -84,7 +84,9 @@ screen. Main-process requests wait for an explicit renderer-ready signal emitted
 only after the React workspace-external request handler is installed;
 `did-finish-load` alone is not a sufficient application-readiness boundary.
 Successful submission may then reveal that Agent window; cancellation leaves it
-hidden.
+hidden. Submission activates with the external contract's `reveal` request, so
+the workspace owner opens its Agent GUI on the created session before the
+window is focused; a failed navigation never fails the activation result.
 
 ## Floating Composer
 
@@ -131,7 +133,9 @@ create an Issue directly.
 
 The bottom toolbar keeps `+`, `@`, the exact Agent Target selector, the project
 selector, the **Create Task and track** switch, and the primary send action on
-one alignment baseline. The project selector reuses AgentGUI's canonical
+one alignment baseline. The Quick Composer hides the connector capability
+control: quick-composer hosts expose no capability-settings channel, so it
+could only render as a dead trigger and pushed the toolbar onto a second line. The project selector reuses AgentGUI's canonical
 no-project/existing-project control. The capture preload proxies the workspace
 owner's real `WorkspaceUserProjectApi` for catalog reads, selection preparation,
 and project registration; only the directory dialog itself remains native to
@@ -175,7 +179,9 @@ closing, destroyed, or unexpectedly hidden capture is replaced rather than
 focused. A shortcut invoked from a focused Tutti window keeps Tutti active. At
 least one ready Agent is required. The capture window closes only after the
 workspace Engine confirms activation, then focus returns to the workspace
-window.
+window. Like cancellation, the submitted window is destroyed rather than
+closed, so a renderer close handler cannot strand a submitted capture on
+screen.
 
 ## Attachment Contract And Storage
 

--- a/docs/architecture/desktop-screenshot-to-qute.md
+++ b/docs/architecture/desktop-screenshot-to-qute.md
@@ -4,7 +4,13 @@ The desktop can send an arbitrary rectangular screen region directly to an
 Agent as a multimodal prompt. The Agent can optionally be instructed to create
 and manage a Qute Task while it works. The default global shortcut is
 `CommandOrControl+Shift+S`, and it works while another application has focus as
-long as Tutti is running and can resolve a current or startup workspace.
+long as Tutti is running and can resolve a current or startup workspace. The
+binding is adjustable in Settings → General: it persists as the
+`captureScreenshot` workbench-shortcut preference, where null keeps the
+built-in default rather than meaning unbound. The recorder and the
+main-process accelerator resolver both require a Meta/Ctrl/Alt modifier, and
+an unregisterable binding falls back to the last working accelerator so a bad
+preference can never disable capture.
 
 ## Ownership And Flow
 
@@ -303,7 +309,8 @@ composer reuse Tutti's UI System.
   source. Wayland global shortcuts additionally depend on the environment's
   shortcut portal support.
 - Global shortcut registration can fail when another application owns the same
-  accelerator. The desktop logs that failure; making the accelerator a durable
-  user preference is a separate settings slice.
+  accelerator. The desktop logs that failure and re-registers the previous
+  working accelerator (or the built-in default) so capture stays reachable.
+  The accelerator is a durable user preference under Settings → General.
 - Region selection currently stays within the display nearest the pointer when
   the shortcut is pressed; it does not span display boundaries.

--- a/packages/agent/gui/AgentGUIQuickComposer.spec.tsx
+++ b/packages/agent/gui/AgentGUIQuickComposer.spec.tsx
@@ -549,6 +549,27 @@ describe("AgentGUIQuickComposer", () => {
     expect(accessory?.parentElement).toBe(send?.parentElement);
   });
 
+  it("hides the connector capability control quick-composer hosts cannot service", () => {
+    const { container } = render(
+      <AgentGUIQuickComposer
+        agentTargets={agentTargets}
+        capabilitiesByAgentTargetId={capabilitiesByAgentTargetId}
+        content={[{ text: "Inspect this", type: "text" }]}
+        selectedAgentTargetId="agent:codex"
+        workspaceId="workspace:test"
+        onAgentTargetChange={vi.fn()}
+        onContentChange={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    );
+
+    expect(
+      container.querySelector(
+        '[data-testid="agent-gui-composer-connectors-trigger"]'
+      )
+    ).toBeNull();
+  });
+
   it("installs the mention service supplied by the embedding host", () => {
     const query = vi.fn().mockResolvedValue([]);
     const provider: RichTextTriggerProvider<{ id: string; label: string }> = {

--- a/packages/agent/gui/AgentGUIQuickComposer.tsx
+++ b/packages/agent/gui/AgentGUIQuickComposer.tsx
@@ -237,6 +237,10 @@ function AgentGUIQuickComposerInner({
         activePrompt={null}
         agentTargets={composerAgentTargets}
         availableCommands={[]}
+        // Quick Composer hosts expose no capability-settings channel, so the
+        // connector control could only render as a dead trigger. Hiding it
+        // also keeps the footer controls on one alignment baseline.
+        capabilityMenuState={{ connectors: { enabled: false } }}
         canGoalControl={false}
         canUploadAttachment={Boolean(
           selectedTargetCapabilities?.imageInput ||

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -441,6 +441,10 @@ export type DesktopWorkbenchShortcuts = {
    * Keyboard shortcut binding for opening a new window of the active workbench node type, or null when unbound.
    */
   newSameTypeWindow: string | null;
+  /**
+   * Keyboard shortcut binding for the global screenshot capture, or null/absent when the built-in CommandOrControl+Shift+S default applies. Unlike the other bindings, null does not mean unbound.
+   */
+  captureScreenshot?: string | null;
 };
 
 export type DesktopWorkbenchWindowSnapping = {

--- a/packages/events/protocol/schemas/topics/preferences/desktop-preferences.schema.json
+++ b/packages/events/protocol/schemas/topics/preferences/desktop-preferences.schema.json
@@ -117,6 +117,10 @@
         "newSameTypeWindow": {
           "type": ["string", "null"],
           "maxLength": 80
+        },
+        "captureScreenshot": {
+          "type": ["string", "null"],
+          "maxLength": 80
         }
       }
     },

--- a/packages/events/protocol/src/generated/contracts.ts
+++ b/packages/events/protocol/src/generated/contracts.ts
@@ -135,6 +135,7 @@ export interface PreferencesDesktopPreferencesV1 {
   workbenchShortcuts: {
     newAgentConversation: string | null;
     newSameTypeWindow: string | null;
+    captureScreenshot?: string | null;
   };
   locale: "en" | "zh-CN";
   minimizeAnimation: "scale" | "genie" | "off";

--- a/packages/events/protocol/src/generated/registry.ts
+++ b/packages/events/protocol/src/generated/registry.ts
@@ -55,7 +55,7 @@ export interface BusinessEventDefinition {
   scope: BusinessEventScopeName;
 }
 
-export const businessEventCatalogRevision = "sha256:0634d21b53d490cf" as const;
+export const businessEventCatalogRevision = "sha256:e22b1c247f39c553" as const;
 
 export const businessEventDefinitions = [
   {

--- a/packages/events/protocol/src/generated/schemas.ts
+++ b/packages/events/protocol/src/generated/schemas.ts
@@ -271,6 +271,10 @@ export const preferencesDesktopPreferencesSchema = {
         newSameTypeWindow: {
           type: ["string", "null"],
           maxLength: 80
+        },
+        captureScreenshot: {
+          type: ["string", "null"],
+          maxLength: 80
         }
       }
     },
@@ -2115,6 +2119,10 @@ export const preferencesDesktopUpdateRequestedPayloadSchema = {
             newSameTypeWindow: {
               type: ["string", "null"],
               maxLength: 80
+            },
+            captureScreenshot: {
+              type: ["string", "null"],
+              maxLength: 80
             }
           }
         },
@@ -2461,6 +2469,10 @@ export const preferencesDesktopUpdatedPayloadSchema = {
               maxLength: 80
             },
             newSameTypeWindow: {
+              type: ["string", "null"],
+              maxLength: 80
+            },
+            captureScreenshot: {
               type: ["string", "null"],
               maxLength: 80
             }

--- a/packages/workspace/external-core/src/contracts/index.ts
+++ b/packages/workspace/external-core/src/contracts/index.ts
@@ -304,6 +304,12 @@ export interface TuttiExternalAgentActivityActivateSessionInput {
   cwd?: string | null;
   initialContent: AgentPromptContentBlock[];
   initialDisplayPrompt?: string | null;
+  /**
+   * Host-owned navigation request. When true, the workspace owner opens its
+   * Agent GUI on the activated session after activation succeeds. Missing
+   * preserves the existing activate-without-navigation behavior.
+   */
+  reveal?: boolean;
   settings?: AgentActivitySessionSettings;
   title?: string;
   visible?: boolean;

--- a/packages/workspace/external-core/src/core/index.test.ts
+++ b/packages/workspace/external-core/src/core/index.test.ts
@@ -153,6 +153,7 @@ test("normalizes agent activity session inputs without dropping prompt assets", 
         }
       ],
       initialDisplayPrompt: " provider smoke test ",
+      reveal: true,
       settings: {
         browserUse: false,
         model: " test-model ",
@@ -176,6 +177,7 @@ test("normalizes agent activity session inputs without dropping prompt assets", 
         }
       ],
       initialDisplayPrompt: "provider smoke test",
+      reveal: true,
       settings: {
         browserUse: false,
         model: "test-model",
@@ -184,6 +186,16 @@ test("normalizes agent activity session inputs without dropping prompt assets", 
       title: "Provider Core Lab",
       visible: true
     }
+  );
+  assert.equal(
+    "reveal" in
+      normalizeTuttiExternalAgentActivityActivateSessionInput({
+        agentSessionId: "session-1",
+        agentTargetId: "codex",
+        clientSubmitId: "batch-1",
+        initialContent: [{ type: "text", text: "test" }]
+      }),
+    false
   );
   assert.deepEqual(
     normalizeTuttiExternalAgentActivitySendInput({
@@ -257,6 +269,17 @@ test("rejects malformed agent activity inputs", () => {
         visible: "yes"
       }),
     /visible must be a boolean/
+  );
+  assert.throws(
+    () =>
+      normalizeTuttiExternalAgentActivityActivateSessionInput({
+        agentSessionId: "session-1",
+        agentTargetId: "codex",
+        clientSubmitId: "batch-1",
+        initialContent: [{ type: "text", text: "test" }],
+        reveal: "yes"
+      }),
+    /reveal must be a boolean/
   );
 });
 

--- a/packages/workspace/external-core/src/core/index.ts
+++ b/packages/workspace/external-core/src/core/index.ts
@@ -209,6 +209,7 @@ export function normalizeTuttiExternalAgentActivityActivateSessionInput(
       "initialDisplayPrompt",
       true
     ),
+    ...normalizeAgentActivityReveal(input.reveal),
     ...(input.settings === undefined || input.settings === null
       ? {}
       : { settings: normalizeAgentActivitySettings(input.settings) }),
@@ -909,6 +910,18 @@ function normalizeAgentActivityVisible(
     throw new Error("agentActivity visible must be a boolean.");
   }
   return { visible: value };
+}
+
+function normalizeAgentActivityReveal(
+  value: unknown
+): Partial<Pick<TuttiExternalAgentActivityActivateSessionInput, "reveal">> {
+  if (value === undefined) {
+    return {};
+  }
+  if (typeof value !== "boolean") {
+    throw new Error("agentActivity reveal must be a boolean.");
+  }
+  return { reveal: value };
 }
 
 function normalizeAgentActivityContent(

--- a/services/tuttid/api/daemon_preferences.go
+++ b/services/tuttid/api/daemon_preferences.go
@@ -433,6 +433,7 @@ func (api DaemonAPI) PutDesktopPreferences(ctx context.Context, request tuttigen
 		WorkbenchShortcuts: preferencesbiz.DesktopWorkbenchShortcuts{
 			NewAgentConversation: optionalStringValue(request.Body.Preferences.WorkbenchShortcuts.NewAgentConversation),
 			NewSameTypeWindow:    optionalStringValue(request.Body.Preferences.WorkbenchShortcuts.NewSameTypeWindow),
+			CaptureScreenshot:    optionalStringValue(request.Body.Preferences.WorkbenchShortcuts.CaptureScreenshot),
 		},
 		Locale:                  locale,
 		MinimizeAnimation:       minimizeAnimation,

--- a/services/tuttid/api/events/generated/protocol.gen.go
+++ b/services/tuttid/api/events/generated/protocol.gen.go
@@ -6,7 +6,7 @@ import "encoding/json"
 
 const (
 	BusinessEventProtocolVersion = 1
-	BusinessEventCatalogRevision = "sha256:0634d21b53d490cf"
+	BusinessEventCatalogRevision = "sha256:e22b1c247f39c553"
 )
 
 type Topic string
@@ -143,6 +143,7 @@ type PreferencesDesktopPreferences struct {
 	WorkbenchShortcuts                    struct {
 		NewAgentConversation *string `json:"newAgentConversation"`
 		NewSameTypeWindow    *string `json:"newSameTypeWindow"`
+		CaptureScreenshot    *string `json:"captureScreenshot,omitempty"`
 	} `json:"workbenchShortcuts"`
 	Locale                  string `json:"locale"`
 	MinimizeAnimation       string `json:"minimizeAnimation"`

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -6757,6 +6757,9 @@ type DesktopUpdatePolicy string
 
 // DesktopWorkbenchShortcuts defines model for DesktopWorkbenchShortcuts.
 type DesktopWorkbenchShortcuts struct {
+	// CaptureScreenshot Keyboard shortcut binding for the global screenshot capture, or null/absent when the built-in CommandOrControl+Shift+S default applies. Unlike the other bindings, null does not mean unbound.
+	CaptureScreenshot *string `json:"captureScreenshot,omitempty"`
+
 	// NewAgentConversation Keyboard shortcut binding for opening an AgentGUI new conversation, or null when unbound.
 	NewAgentConversation *string `json:"newAgentConversation"`
 

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -7826,6 +7826,11 @@ components:
           nullable: true
           maxLength: 80
           description: Keyboard shortcut binding for opening a new window of the active workbench node type, or null when unbound.
+        captureScreenshot:
+          type: string
+          nullable: true
+          maxLength: 80
+          description: Keyboard shortcut binding for the global screenshot capture, or null/absent when the built-in CommandOrControl+Shift+S default applies. Unlike the other bindings, null does not mean unbound.
     DesktopWorkbenchWindowSnapping:
       type: object
       additionalProperties: false

--- a/services/tuttid/api/preferences/types.go
+++ b/services/tuttid/api/preferences/types.go
@@ -13,6 +13,7 @@ func GeneratedDesktopPreferencesFromBiz(value preferencesbiz.DesktopPreferences)
 	workbenchShortcuts := tuttigenerated.DesktopWorkbenchShortcuts{
 		NewAgentConversation: optionalStringPointer(value.WorkbenchShortcuts.NewAgentConversation),
 		NewSameTypeWindow:    optionalStringPointer(value.WorkbenchShortcuts.NewSameTypeWindow),
+		CaptureScreenshot:    optionalStringPointer(value.WorkbenchShortcuts.CaptureScreenshot),
 	}
 	return tuttigenerated.DesktopPreferences{
 		AgentCliUpdateCheckEnabled:                  value.AgentCLIUpdateCheckEnabled,

--- a/services/tuttid/biz/preferences/model.go
+++ b/services/tuttid/biz/preferences/model.go
@@ -117,6 +117,9 @@ func LocalAgentTargetIDForProvider(provider string) string {
 type DesktopWorkbenchShortcuts struct {
 	NewAgentConversation string
 	NewSameTypeWindow    string
+	// CaptureScreenshot empty means the built-in default accelerator applies,
+	// not "unbound" like the other bindings.
+	CaptureScreenshot string
 }
 
 func DefaultDesktopPreferences() DesktopPreferences {
@@ -354,5 +357,6 @@ func NormalizeDesktopWorkbenchShortcuts(value DesktopWorkbenchShortcuts) Desktop
 	return DesktopWorkbenchShortcuts{
 		NewAgentConversation: NormalizeDesktopShortcutBinding(value.NewAgentConversation),
 		NewSameTypeWindow:    NormalizeDesktopShortcutBinding(value.NewSameTypeWindow),
+		CaptureScreenshot:    NormalizeDesktopShortcutBinding(value.CaptureScreenshot),
 	}
 }

--- a/services/tuttid/data/workspace/sqlite_preferences.go
+++ b/services/tuttid/data/workspace/sqlite_preferences.go
@@ -415,6 +415,7 @@ func decodeWorkbenchShortcuts(raw string) preferencesbiz.DesktopWorkbenchShortcu
 	var decoded struct {
 		NewAgentConversation *string `json:"newAgentConversation"`
 		NewSameTypeWindow    *string `json:"newSameTypeWindow"`
+		CaptureScreenshot    *string `json:"captureScreenshot"`
 	}
 	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
 		return preferencesbiz.DesktopWorkbenchShortcuts{}
@@ -428,6 +429,7 @@ func decodeWorkbenchShortcuts(raw string) preferencesbiz.DesktopWorkbenchShortcu
 	return preferencesbiz.NormalizeDesktopWorkbenchShortcuts(preferencesbiz.DesktopWorkbenchShortcuts{
 		NewAgentConversation: deref(decoded.NewAgentConversation),
 		NewSameTypeWindow:    deref(decoded.NewSameTypeWindow),
+		CaptureScreenshot:    deref(decoded.CaptureScreenshot),
 	})
 }
 
@@ -442,7 +444,8 @@ func encodeWorkbenchShortcuts(value preferencesbiz.DesktopWorkbenchShortcuts) (s
 	data, err := json.Marshal(struct {
 		NewAgentConversation *string `json:"newAgentConversation"`
 		NewSameTypeWindow    *string `json:"newSameTypeWindow"`
-	}{ptr(n.NewAgentConversation), ptr(n.NewSameTypeWindow)})
+		CaptureScreenshot    *string `json:"captureScreenshot,omitempty"`
+	}{ptr(n.NewAgentConversation), ptr(n.NewSameTypeWindow), ptr(n.CaptureScreenshot)})
 	if err != nil {
 		return "", err
 	}

--- a/services/tuttid/data/workspace/sqlite_preferences_test.go
+++ b/services/tuttid/data/workspace/sqlite_preferences_test.go
@@ -505,7 +505,10 @@ func TestDesktopPreferencesFeatureFlagsRoundtrip(t *testing.T) {
 	ctx := context.Background()
 	in := preferencesbiz.DefaultDesktopPreferences()
 	in.FeatureFlags = map[string]bool{"lab.enabled": true, "lab.workbenchShortcuts": true}
-	in.WorkbenchShortcuts = preferencesbiz.DesktopWorkbenchShortcuts{NewAgentConversation: "Meta+K"}
+	in.WorkbenchShortcuts = preferencesbiz.DesktopWorkbenchShortcuts{
+		NewAgentConversation: "Meta+K",
+		CaptureScreenshot:    "Meta+Shift+P",
+	}
 	if _, err := store.PutDesktopPreferences(ctx, in); err != nil {
 		t.Fatal(err)
 	}
@@ -516,7 +519,9 @@ func TestDesktopPreferencesFeatureFlagsRoundtrip(t *testing.T) {
 	if !got.FeatureFlags["lab.enabled"] || !got.FeatureFlags["lab.workbenchShortcuts"] {
 		t.Fatalf("flags not persisted: %v", got.FeatureFlags)
 	}
-	if got.WorkbenchShortcuts.NewAgentConversation != "Meta+K" || got.WorkbenchShortcuts.NewSameTypeWindow != "" {
+	if got.WorkbenchShortcuts.NewAgentConversation != "Meta+K" ||
+		got.WorkbenchShortcuts.NewSameTypeWindow != "" ||
+		got.WorkbenchShortcuts.CaptureScreenshot != "Meta+Shift+P" {
 		t.Fatalf("shortcuts wrong: %+v", got.WorkbenchShortcuts)
 	}
 }

--- a/services/tuttid/service/eventstream/preferences.go
+++ b/services/tuttid/service/eventstream/preferences.go
@@ -99,6 +99,7 @@ func (p DesktopPreferencesPublisher) PublishDesktopPreferencesUpdated(ctx contex
 			WorkbenchShortcuts: desktopWorkbenchShortcutsPayload{
 				NewAgentConversation: shortcutPointerFromBiz(preferences.WorkbenchShortcuts.NewAgentConversation),
 				NewSameTypeWindow:    shortcutPointerFromBiz(preferences.WorkbenchShortcuts.NewSameTypeWindow),
+				CaptureScreenshot:    shortcutPointerFromBiz(preferences.WorkbenchShortcuts.CaptureScreenshot),
 			},
 			Locale:                  preferences.Locale,
 			MinimizeAnimation:       preferences.MinimizeAnimation,
@@ -265,6 +266,7 @@ func decodeDesktopPreferencesMutationPayload(payload []byte) (decodedDesktopPref
 		WorkbenchShortcuts: preferencesbiz.DesktopWorkbenchShortcuts{
 			NewAgentConversation: shortcutStringFromPayload(decoded.Preferences.WorkbenchShortcuts.NewAgentConversation),
 			NewSameTypeWindow:    shortcutStringFromPayload(decoded.Preferences.WorkbenchShortcuts.NewSameTypeWindow),
+			CaptureScreenshot:    shortcutStringFromPayload(decoded.Preferences.WorkbenchShortcuts.CaptureScreenshot),
 		},
 		Locale:                  decoded.Preferences.Locale,
 		MinimizeAnimation:       decoded.Preferences.MinimizeAnimation,

--- a/services/tuttid/service/eventstream/preferences_payloads.go
+++ b/services/tuttid/service/eventstream/preferences_payloads.go
@@ -67,6 +67,7 @@ type desktopWorkbenchWindowSnappingPayload struct {
 type desktopWorkbenchShortcutsPayload struct {
 	NewAgentConversation *string `json:"newAgentConversation"`
 	NewSameTypeWindow    *string `json:"newSameTypeWindow"`
+	CaptureScreenshot    *string `json:"captureScreenshot,omitempty"`
 }
 
 type desktopAgentComposerDefaultsByProviderPayload map[string]desktopAgentComposerDefaultsPayload


### PR DESCRIPTION
## Summary

Follow-ups to the screenshot capture composer (#2109): three user-reported fixes plus a configurable capture shortcut.

- destroy the capture window after a confirmed submission so it can no longer stay on screen after send
- open the workspace Agent GUI on the newly created session when the workspace window is revealed after submission
- keep the capture footer controls on the documented single alignment baseline by hiding the connector control Quick Composer hosts cannot service
- make the global capture shortcut a durable preference, adjustable under Settings → General

## Fixes

### Submitted capture window could stay on screen

The submit handler tore the window down with `close()`, which a renderer
lifecycle handler can hold open — the exact stranding that already moved
cancellation to `destroy()` inside this feature. The submit success path now
mirrors `cancelCapture`: mark `closing`, then `destroy()`. Failed activation
still keeps the composer open with its draft intact, and the `closed`-event
placement persistence keeps firing.

### Revealed window did not navigate to the created session

Submission only focused the workspace window; nothing told the Agent GUI which
session to open, so the revealed window stayed on whatever it showed last. The
external `agentActivity.activateSession` contract gains an optional `reveal`
flag (normalizer-validated, absent means the existing activate-without-
navigation behavior). Capture submission requests it, and the workspace
external bridge then routes `requestWorkspaceAgentGuiLaunch` to the activated
session with the provider taken from the activation result — covering both the
workbench window and the standalone Agent window handlers. Navigation is
best-effort: a failed launch never fails the activation result, so the capture
window cannot be stranded open for a session that was actually created.

### Footer controls wrapped onto a second line

The connector capability control rendered inside the capture composer as a
dead trigger: Quick Composer hosts expose no capability-settings channel, so
it could never be serviced, and its width pushed the right-hand controls onto
a second row below the documented one-baseline toolbar. Quick Composer now
pins `connectors: { enabled: false }`; the primary-capability slot falls back
to the Tutti Mode chip, which renders nothing without a host activation
handler.

## Feature: configurable capture shortcut

Settings → General gains a shortcut recorder row for the screenshot capture
binding.

- The binding persists as a new `captureScreenshot` field on the
  workbench-shortcuts preference. It is optional on the wire (older clients
  stay valid) and required in the desktop shared type so every construction
  site is compiler-enforced. Unlike the other two bindings, **null means the
  built-in `CommandOrControl+Shift+S` default applies, not "unbound"** —
  clearing the row restores the default; capture can never be disabled by
  preference.
- The field flows through the daemon: OpenAPI schema + regenerated Go/TS
  clients, the biz model and normalizer, SQLite persistence, and the
  `preferences.desktop.updated` event payload including its strict topic
  schema (`desktop-preferences.schema.json`), which would otherwise drop the
  whole publish once the field appears.
- The capture service resolves its accelerator from the preference, subscribes
  to host preference changes, and re-registers idempotently. The recorder and
  the main-process resolver both require a Meta/Ctrl/Alt modifier so a global
  accelerator can never shadow plain or shift-only typing, and a binding
  Electron rejects (malformed or OS-conflicted) falls back to the last working
  accelerator with a logged warning.

`docs/architecture/desktop-screenshot-to-qute.md` is updated in place for all
of the above.

## Testing

- `packages/workspace/external-core`: `node --test` — 33 pass (adds `reveal`
  round-trip, omission, and rejection cases)
- `packages/agent/gui`: `vitest run AgentGUIQuickComposer.spec.tsx` — 17 pass
  (adds connectors-trigger-absent assertion)
- `apps/desktop`: capture + preferences/settings node tests — 69 pass,
  including new `resolveCaptureAccelerator` cases (valid bindings, arrow-key
  mapping, shift-only/malformed fallbacks)
- Go: `services/tuttid` biz/preferences, data/workspace (SQLite round-trip now
  covers `captureScreenshot`), service/eventstream — pass
- `generate:api --check` and `generate:event-protocol --check` clean; `tsgo`
  typecheck clean on all touched packages

Manual verification checklist (capture needs the global shortcut plus macOS
screen-recording consent, so this stays manual):

1. `Cmd+Shift+S` → select region → send → the floating composer disappears
   immediately
2. the workspace/Agent window that comes forward is showing the newly created
   session
3. the footer renders `+ @ agent target / project selector … permission,
   model, Create-Task switch, send` on a single row with no connector button
4. set a custom shortcut in Settings → General → the old combo stops working,
   the new one captures; restart the app → the custom shortcut still works
   (exercises PUT → SQLite → reload end to end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
