### PR TITLE
fix(desktop): reuse existing Browser window for Agent GUI links

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.test.ts
@@ -170,7 +170,6 @@ test("desktop agent gui link actions open urls through the workspace browser", a
   assert.equal(handled, true);
   assert.deepEqual(openedUrls, [
     {
-      reuseIfOpen: false,
       source: "agent_command",
       url: "https://example.com",
       workspaceId: "workspace-1"

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.ts
@@ -99,7 +99,6 @@ export async function runDesktopAgentGUILinkAction(
         return true;
       }
       return dependencies.openBrowserUrl({
-        reuseIfOpen: false,
         source: "agent_command",
         url: action.url,
         workspaceId: dependencies.workspaceId


### PR DESCRIPTION
## Summary
- Agent GUI 打开 URL 时不再强制 `reuseIfOpen: false`
- 已有 workspace Browser 窗口时，优先复用该窗口，而不是每次新开一个

## Test plan
- [ ] 打开一个 Browser 窗口并停留在任意页面
- [ ] 在 Agent 消息中点击普通链接（非外部账户类链接）
- [ ] 确认复用已有 Browser 窗口，而不是再开一个新窗口
- [ ] `node --import ./test/register-asset-stub.mjs --test --experimental-strip-types src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.test.ts`


Made with [Cursor](https://cursor.com)