### PR TITLE
fix(desktop): shorten deleted conversations settings tab

### DIFF
--- a/apps/desktop/src/shared/i18n/locales/en.ts
+++ b/apps/desktop/src/shared/i18n/locales/en.ts
@@ -971,7 +971,7 @@ export const en = {
         appearance: "Appearance",
         agent: "Agent",
         connection: "Connection",
-        deletedConversations: "Deleted conversations",
+        deletedConversations: "Trash",
         developer: "Developer",
         general: "General",
         lab: "Lab",

--- a/apps/desktop/src/shared/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/shared/i18n/locales/zh-CN.ts
@@ -911,7 +911,7 @@ export const zhCN = {
         appearance: "外观",
         agent: "Agent",
         connection: "连接",
-        deletedConversations: "已删除会话",
+        deletedConversations: "回收站",
         developer: "开发者",
         general: "通用",
         lab: "实验室",


### PR DESCRIPTION
## 摘要

- 将设置面板左侧导航文案由“已删除会话”缩短为“回收站”
- 英文导航同步为 “Trash”
- 页面标题、搜索、清理和恢复相关文案保持不变，避免语义丢失

## 验证

- 提交钩子中的 Electron/UI/renderer 边界检查通过
- `pnpm check:changed -- --push-ready`（37 个 lane，通过）

## 清单

- [x] 变更聚焦于设置面板导航文案
- [x] 中英文 i18n 文案已同步
- [x] 已运行改动范围内的本地校验
- [x] 提交已使用 DCO 签名（`git commit -s`）