### PR TITLE
test(file-manager): remove obsolete arrange mode test

### DIFF
--- a/packages/workspace/file-manager/src/ui/workspaceFileManagerArrangeMode.test.ts
+++ b/packages/workspace/file-manager/src/ui/workspaceFileManagerArrangeMode.test.ts
@@ -2,9 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { WorkspaceFileEntry } from "../services/workspaceFileManagerTypes.ts";
 import {
-  readWorkspaceFileManagerArrangeMode,
-  sortWorkspaceFileEntriesForArrangeMode,
-  workspaceFileManagerArrangeModeStorageKey
+  sortWorkspaceFileEntriesForArrangeMode
 } from "./workspaceFileManagerArrangeMode.ts";
 
 function createEntry(
@@ -22,30 +20,6 @@ function createEntry(
     ...overrides
   };
 }
-
-test("workspace file manager arrange mode ignores removed tags mode", () => {
-  const originalWindow = globalThis.window;
-
-  Object.defineProperty(globalThis, "window", {
-    configurable: true,
-    value: {
-      localStorage: {
-        getItem: (key: string) =>
-          key === workspaceFileManagerArrangeModeStorageKey ? "tags" : null,
-        setItem: () => undefined
-      }
-    }
-  });
-
-  try {
-    assert.equal(readWorkspaceFileManagerArrangeMode(), "none");
-  } finally {
-    Object.defineProperty(globalThis, "window", {
-      configurable: true,
-      value: originalWindow
-    });
-  }
-});
 
 test("workspace file manager arrange mode sorts by name with directories first", () => {
   const entries = [


### PR DESCRIPTION
## 变更说明

删除文件管理器中专门验证已移除 `tags` 排序模式的单测。

该测试只覆盖历史 localStorage 值的兜底行为，属于已移除功能的实现细节；同文件的名称、大小、修改时间、创建时间和最近打开时间排序测试继续保留。

## 验证

- `git diff --check` 通过
- 文件管理器测试因当前 worktree 缺少 workspace 依赖未能完整运行；已加载的测试中 16 项通过，13 项因缺少 `@tutti-os/workspace-file-preview`、`@tutti-os/ui-i18n-runtime`、`valtio` 等依赖失败

无文档影响。