### PR TITLE
feat(agent-gui): support disabled Message Center prompts

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -258,6 +258,16 @@ and early write admission for the pending card. An observation gap may still
 govern the active Turn before or after that Interaction, but it cannot override
 the exact ready or blocked readiness result while the card is presented.
 
+Message Center and attention-card consumers preserve this separation in their
+presentation contract: `isSubmitting` describes an in-flight response, while
+an independently supplied interaction-disabled state blocks the nested prompt
+controls without hiding the pending card or its conversation navigation. A
+host-provided blocked reason is exposed through a focusable, hoverable
+description so a blocked card remains understandable without making Tooltip
+the command authority. If the Host omits the reason, the disabled wrapper stays
+out of the tab order and does not create an empty Tooltip. The final semantic
+command admission check remains in the consumer/controller path.
+
 ### 2.6 On-demand status
 
 AgentGUI owns one provider-neutral `AgentStatusController` for `/status`, Agent

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.spec.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.spec.tsx
@@ -192,6 +192,90 @@ describe("WorkspaceAgentMessageCenterCard prompt presentation", () => {
     expect(container.textContent).not.toContain("Allow the complete command?");
   });
 
+  it("disables prompt controls separately from submitting and exposes the reason", () => {
+    const pendingItem = item({ summary: "Allow the complete command?" });
+    pendingItem.status = "waiting";
+    pendingItem.pendingInteractionTarget = {
+      agentSessionId: "codex-1",
+      turnId: "turn-1",
+      requestId: "request-1"
+    };
+    pendingItem.pendingPrompt = {
+      kind: "approval",
+      id: "approval:request-1",
+      turnId: "turn-1",
+      requestId: "request-1",
+      callId: "call-1",
+      title: "Run command",
+      toolName: "Bash",
+      status: "pending",
+      input: { command: "printf a" },
+      options: [{ id: "allow", label: "Allow", kind: "allow" }],
+      output: null,
+      occurredAtUnixMs: 1
+    };
+
+    render(
+      <WorkspaceAgentMessageCenterCard
+        item={pendingItem}
+        isSubmitting={false}
+        isInteractionDisabled
+        interactionDisabledReason="The shared Agent owner is offline"
+        onOpenChat={() => undefined}
+        onSubmitPrompt={() => undefined}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Allow" })).toBeDisabled();
+    expect(
+      screen.getByRole("group", {
+        name: "The shared Agent owner is offline"
+      })
+    ).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("does not focus or render an empty description when the disabled reason is absent", () => {
+    const pendingItem = item({ summary: "Allow the complete command?" });
+    pendingItem.status = "waiting";
+    pendingItem.pendingInteractionTarget = {
+      agentSessionId: "codex-1",
+      turnId: "turn-1",
+      requestId: "request-1"
+    };
+    pendingItem.pendingPrompt = {
+      kind: "approval",
+      id: "approval:request-1",
+      turnId: "turn-1",
+      requestId: "request-1",
+      callId: "call-1",
+      title: "Run command",
+      toolName: "Bash",
+      status: "pending",
+      input: { command: "printf a" },
+      options: [{ id: "allow", label: "Allow", kind: "allow" }],
+      output: null,
+      occurredAtUnixMs: 1
+    };
+
+    const { container } = render(
+      <WorkspaceAgentMessageCenterCard
+        item={pendingItem}
+        isSubmitting={false}
+        isInteractionDisabled
+        onOpenChat={() => undefined}
+        onSubmitPrompt={() => undefined}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Allow" })).toBeDisabled();
+    const disabledGroup = container.querySelector<HTMLElement>(
+      '[data-agent-interaction-disabled="true"]'
+    );
+    expect(disabledGroup).not.toBeNull();
+    expect(disabledGroup).not.toHaveAttribute("aria-label");
+    expect(disabledGroup).not.toHaveAttribute("tabindex");
+  });
+
   it("keeps the summary when a leaving or read-only card cannot render its prompt", () => {
     const pendingItem = item({ summary: "Allow the complete command?" });
     pendingItem.status = "waiting";

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
@@ -49,6 +49,8 @@ export interface WorkspaceAgentMessageCenterCardProps {
   highlighted?: boolean;
   interactive?: boolean;
   isSubmitting: boolean;
+  isInteractionDisabled?: boolean;
+  interactionDisabledReason?: string | null;
   lazySummary?: boolean;
   promptVariant?: "compact" | "full";
   showSummaryWithPrompt?: boolean;
@@ -93,6 +95,8 @@ export const WorkspaceAgentMessageCenterCard = memo(
     interactive = true,
     item,
     isSubmitting,
+    isInteractionDisabled = false,
+    interactionDisabledReason = null,
     lazySummary = false,
     promptVariant = "compact",
     showSummaryWithPrompt = true,
@@ -109,6 +113,34 @@ export const WorkspaceAgentMessageCenterCard = memo(
     const displayStatus = statusClass(item);
     const statusTone = messageCenterStatusTone(item);
     const statusLabel = workspaceAgentActivityStatusLabel(displayStatus, t);
+    const promptInteractionDisabled =
+      interactive && prompt !== null && isInteractionDisabled;
+    const promptDisabledReason = interactionDisabledReason?.trim() ?? "";
+
+    const promptSurface = prompt ? (
+      <AgentInteractivePromptSurface
+        embedded
+        variant={promptVariant}
+        keyboardShortcuts={false}
+        prompt={prompt}
+        isSubmitting={isSubmitting}
+        isInteractionDisabled={promptInteractionDisabled}
+        onSubmit={onSubmitPrompt}
+        labels={buildWorkspaceAgentInteractivePromptLabels(t, item.provider)}
+      />
+    ) : null;
+    const disabledPromptSurface = (
+      <div
+        aria-disabled="true"
+        aria-label={promptDisabledReason || undefined}
+        className="cursor-not-allowed rounded-md opacity-70 outline-none focus-visible:ring-2 focus-visible:ring-[var(--border-focus)]"
+        data-agent-interaction-disabled="true"
+        role="group"
+        tabIndex={promptDisabledReason ? 0 : undefined}
+      >
+        {promptSurface}
+      </div>
+    );
 
     return (
       <article
@@ -180,18 +212,20 @@ export const WorkspaceAgentMessageCenterCard = memo(
 
         {prompt && interactive ? (
           <div className="min-w-0">
-            <AgentInteractivePromptSurface
-              embedded
-              variant={promptVariant}
-              keyboardShortcuts={false}
-              prompt={prompt}
-              isSubmitting={isSubmitting}
-              onSubmit={onSubmitPrompt}
-              labels={buildWorkspaceAgentInteractivePromptLabels(
-                t,
-                item.provider
-              )}
-            />
+            {promptInteractionDisabled && promptDisabledReason ? (
+              <LazyMessageCenterTooltip
+                content={promptDisabledReason}
+                side="top"
+                align="start"
+                className="max-w-[min(360px,calc(100vw-32px))] whitespace-normal text-left [overflow-wrap:anywhere]"
+              >
+                {disabledPromptSurface}
+              </LazyMessageCenterTooltip>
+            ) : promptInteractionDisabled ? (
+              disabledPromptSurface
+            ) : (
+              promptSurface
+            )}
           </div>
         ) : null}
 

--- a/packages/agent/gui/shared/agentConversation/components/AgentAskUserPromptSurface.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentAskUserPromptSurface.tsx
@@ -20,7 +20,7 @@ type AskUserPrompt = Extract<AgentConversationPromptVM, { kind: "ask-user" }>;
 
 type SharedAskUserSurfaceProps = Pick<
   AgentInteractivePromptSurfaceProps,
-  "edgeGlow" | "isSubmitting" | "labels" | "onSubmit"
+  "edgeGlow" | "isInteractionDisabled" | "isSubmitting" | "labels" | "onSubmit"
 > & {
   embedded?: boolean;
   prompt: AskUserPrompt;
@@ -67,6 +67,7 @@ function CompactQuickAnswerSurface({
   embedded = false,
   edgeGlow = false,
   isSubmitting,
+  isInteractionDisabled = false,
   onSubmit
 }: Omit<SharedAskUserSurfaceProps, "labels"> & {
   question: AskUserPrompt["questions"][number];
@@ -104,7 +105,7 @@ function CompactQuickAnswerSurface({
                   ? `agent-question-${prompt.requestId}-${question.id}-option-${option.id}`
                   : undefined
               }
-              disabled={isSubmitting}
+              disabled={isSubmitting || isInteractionDisabled}
               onClick={() =>
                 onSubmit({
                   requestId: prompt.requestId,
@@ -140,12 +141,13 @@ function AskUserAnswerFlowSurface({
   embedded = false,
   edgeGlow = false,
   isSubmitting,
+  isInteractionDisabled = false,
   onSubmit,
   labels
 }: SharedAskUserSurfaceProps): JSX.Element {
   "use memo";
   const flow = useAskUserAnswerFlow({
-    isSubmitting,
+    isSubmitting: isSubmitting || isInteractionDisabled,
     questions: prompt.questions
   });
   const question = flow.currentQuestion;
@@ -211,7 +213,7 @@ function AskUserAnswerFlowSurface({
                       ? `agent-question-${prompt.requestId}-${question.id}-option-${option.id}`
                       : undefined
                   }
-                  disabled={isSubmitting}
+                  disabled={isSubmitting || isInteractionDisabled}
                   onClick={() => flow.toggleOption(option.label)}
                 >
                   <span className={styles.interactiveOptionContent}>
@@ -233,7 +235,7 @@ function AskUserAnswerFlowSurface({
           <textarea
             value={flow.freeText}
             placeholder={labels.answerPlaceholder}
-            disabled={isSubmitting}
+            disabled={isSubmitting || isInteractionDisabled}
             className={styles.interactivePromptTextarea}
             data-testid={`agent-question-${prompt.requestId}-${question.id}-custom-answer`}
             onChange={(event) => flow.setFreeText(event.currentTarget.value)}
@@ -245,7 +247,9 @@ function AskUserAnswerFlowSurface({
               type="button"
               variant="secondary"
               size="sm"
-              disabled={isSubmitting || flow.currentIndex === 0}
+              disabled={
+                isSubmitting || isInteractionDisabled || flow.currentIndex === 0
+              }
               onClick={flow.goToPreviousQuestion}
             >
               {labels.previousQuestion}
@@ -256,7 +260,11 @@ function AskUserAnswerFlowSurface({
               type="button"
               variant="default"
               size="sm"
-              disabled={isSubmitting || !flow.allQuestionsAnswered}
+              disabled={
+                isSubmitting ||
+                isInteractionDisabled ||
+                !flow.allQuestionsAnswered
+              }
               data-testid={`agent-question-${prompt.requestId}-${question.id}-submit`}
               onClick={() =>
                 onSubmit({
@@ -273,7 +281,11 @@ function AskUserAnswerFlowSurface({
               type="button"
               variant="default"
               size="sm"
-              disabled={isSubmitting || !flow.currentQuestionAnswered}
+              disabled={
+                isSubmitting ||
+                isInteractionDisabled ||
+                !flow.currentQuestionAnswered
+              }
               onClick={flow.goToNextQuestion}
             >
               {labels.nextQuestion}

--- a/packages/agent/gui/shared/agentConversation/components/AgentInteractiveDecisionPromptSurfaces.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentInteractiveDecisionPromptSurfaces.tsx
@@ -40,6 +40,7 @@ export function ApprovalPromptSurface({
   edgeGlow = false,
   keyboardShortcuts = true,
   isSubmitting,
+  isInteractionDisabled = false,
   onSubmit,
   labels
 }: AgentInteractivePromptSurfaceProps & {
@@ -61,6 +62,7 @@ export function ApprovalPromptSurface({
   const feedbackTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const agentHostApi = useOptionalAgentHostApi() ?? getOptionalAgentHostApi();
   const isDarwin = isDarwinPlatform(agentHostApi?.meta?.platform);
+  const controlsDisabled = isSubmitting || isInteractionDisabled;
   const feedbackOptionId = useMemo(
     () => approvalFeedbackOptionId(prompt.options),
     [prompt.options]
@@ -107,6 +109,9 @@ export function ApprovalPromptSurface({
 
   const submitOption = useCallback(
     (optionId: string) => {
+      if (controlsDisabled) {
+        return;
+      }
       const feedbackOption = feedbackOptionId === optionId;
       if (feedbackOption && pendingFeedbackOptionId !== optionId) {
         setFeedback("");
@@ -126,6 +131,7 @@ export function ApprovalPromptSurface({
     [
       feedbackOptionId,
       feedbackValue,
+      controlsDisabled,
       onSubmit,
       pendingFeedbackOptionId,
       prompt.requestId
@@ -135,7 +141,7 @@ export function ApprovalPromptSurface({
   useEffect(() => {
     if (
       !keyboardShortcuts ||
-      isSubmitting ||
+      controlsDisabled ||
       submittingOptionId !== null ||
       prompt.options.length === 0
     ) {
@@ -165,7 +171,7 @@ export function ApprovalPromptSurface({
     window.addEventListener("keydown", handleKeyDown, true);
     return () => window.removeEventListener("keydown", handleKeyDown, true);
   }, [
-    isSubmitting,
+    controlsDisabled,
     keyboardShortcuts,
     prompt.options,
     submitOption,
@@ -246,7 +252,7 @@ export function ApprovalPromptSurface({
                     ref={feedbackTextareaRef}
                     value={feedback}
                     placeholder={labels.feedbackPlaceholder}
-                    disabled={isSubmitting || submittingOptionId !== null}
+                    disabled={controlsDisabled || submittingOptionId !== null}
                     className={styles.interactivePromptTextarea}
                     aria-label={interactiveOptionLabel(
                       optionLabel,
@@ -274,7 +280,7 @@ export function ApprovalPromptSurface({
                     type="button"
                     className={styles.interactiveFeedbackSendButton}
                     disabled={
-                      isSubmitting ||
+                      controlsDisabled ||
                       submittingOptionId !== null ||
                       !feedbackValue
                     }
@@ -311,7 +317,7 @@ export function ApprovalPromptSurface({
                 data-agent-approval-action={action}
                 data-agent-approval-option-id={option.id}
                 data-testid={`agent-approval-${prompt.requestId}-${action}`}
-                disabled={isSubmitting || submittingOptionId !== null}
+                disabled={controlsDisabled || submittingOptionId !== null}
                 onClick={() => submitOption(option.id)}
               >
                 <span className={styles.interactiveOptionContent}>
@@ -367,6 +373,7 @@ export function ExitPlanPromptSurface({
   embedded = false,
   edgeGlow = false,
   isSubmitting,
+  isInteractionDisabled = false,
   onSubmit,
   labels
 }: AgentInteractivePromptSurfaceProps & {
@@ -384,6 +391,7 @@ export function ExitPlanPromptSurface({
   const trimmed = feedback.trim();
   const continueLabel =
     trimmed === "" ? labels.stayInPlan : labels.sendFeedback;
+  const controlsDisabled = isSubmitting || isInteractionDisabled;
   // Render the permission modes the runtime actually offered ("Yes, and ...")
   // so newly added modes (e.g. "auto") appear automatically. Localized
   // label/description are looked up by option id, falling back to the runtime's
@@ -435,7 +443,7 @@ export function ExitPlanPromptSurface({
                   mode.description
                 )}
                 data-testid={`agent-exit-plan-confirm-${mode.id}`}
-                disabled={isSubmitting || submittingOptionId !== null}
+                disabled={controlsDisabled || submittingOptionId !== null}
                 onClick={() => {
                   setSubmittingOptionId(mode.id);
                   onSubmit({
@@ -463,7 +471,7 @@ export function ExitPlanPromptSurface({
             <textarea
               value={feedback}
               placeholder={labels.feedbackPlaceholder}
-              disabled={isSubmitting}
+              disabled={controlsDisabled}
               className={styles.interactivePromptTextarea}
               data-testid="agent-exit-plan-feedback"
               onChange={(event) => setFeedback(event.currentTarget.value)}
@@ -473,7 +481,7 @@ export function ExitPlanPromptSurface({
                 type="button"
                 variant="secondary"
                 size="sm"
-                disabled={isSubmitting}
+                disabled={controlsDisabled}
                 data-testid="agent-exit-plan-keep-planning"
                 onClick={() =>
                   onSubmit({
@@ -503,7 +511,7 @@ export function ExitPlanPromptSurface({
               type="button"
               variant="secondary"
               size="sm"
-              disabled={isSubmitting}
+              disabled={controlsDisabled}
               data-testid="agent-exit-plan-keep-planning"
               onClick={() =>
                 onSubmit({
@@ -533,6 +541,7 @@ export function PlanImplementationSurface({
   embedded = false,
   edgeGlow = false,
   isSubmitting,
+  isInteractionDisabled = false,
   onSubmit,
   labels
 }: AgentInteractivePromptSurfaceProps & {
@@ -550,6 +559,7 @@ export function PlanImplementationSurface({
   // Refining or staying in plan mode is deferred to the conversation, reachable
   // via the card's "open conversation" jump.
   const showFeedbackFooter = variant !== "compact";
+  const controlsDisabled = isSubmitting || isInteractionDisabled;
 
   return (
     <section className={interactivePromptClassName(embedded)}>
@@ -562,7 +572,7 @@ export function PlanImplementationSurface({
             type="button"
             className={styles.interactiveOptionButton}
             data-testid="agent-plan-implementation-implement"
-            disabled={isSubmitting}
+            disabled={controlsDisabled}
             onClick={() =>
               onSubmit({
                 requestId: prompt.requestId,
@@ -582,7 +592,7 @@ export function PlanImplementationSurface({
             <textarea
               value={feedback}
               placeholder={labels.planImplementationFeedbackPlaceholder}
-              disabled={isSubmitting}
+              disabled={controlsDisabled}
               className={styles.interactivePromptTextarea}
               data-testid="agent-plan-implementation-feedback"
               onChange={(event) => setFeedback(event.currentTarget.value)}
@@ -593,7 +603,7 @@ export function PlanImplementationSurface({
                 variant="secondary"
                 size="sm"
                 data-testid="agent-plan-implementation-continue"
-                disabled={isSubmitting}
+                disabled={controlsDisabled}
                 onClick={() =>
                   onSubmit({
                     requestId: prompt.requestId,

--- a/packages/agent/gui/shared/agentConversation/components/AgentInteractivePromptSurface.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentInteractivePromptSurface.tsx
@@ -27,6 +27,7 @@ export interface AgentInteractivePromptSurfaceProps {
   edgeGlow?: boolean;
   keyboardShortcuts?: boolean;
   isSubmitting: boolean;
+  isInteractionDisabled?: boolean;
   onSubmit: (input: AgentInteractionResponseInput) => boolean | void;
   labels: {
     approvalLead: string;
@@ -56,6 +57,7 @@ export function AgentInteractivePromptSurface({
   embedded = false,
   keyboardShortcuts = true,
   isSubmitting,
+  isInteractionDisabled = false,
   onSubmit,
   labels
 }: AgentInteractivePromptSurfaceProps & {
@@ -84,6 +86,7 @@ export function AgentInteractivePromptSurface({
         edgeGlow={edgeGlow}
         keyboardShortcuts={keyboardShortcuts}
         isSubmitting={isSubmitting}
+        isInteractionDisabled={isInteractionDisabled}
         onSubmit={submitPrompt}
         labels={labels}
       />
@@ -97,6 +100,7 @@ export function AgentInteractivePromptSurface({
         embedded={embedded}
         edgeGlow={edgeGlow}
         isSubmitting={isSubmitting}
+        isInteractionDisabled={isInteractionDisabled}
         onSubmit={submitPrompt}
         labels={labels}
       />
@@ -110,6 +114,7 @@ export function AgentInteractivePromptSurface({
         embedded={embedded}
         edgeGlow={edgeGlow}
         isSubmitting={isSubmitting}
+        isInteractionDisabled={isInteractionDisabled}
         onSubmit={submitPrompt}
         labels={labels}
       />
@@ -123,6 +128,7 @@ export function AgentInteractivePromptSurface({
       embedded={embedded}
       edgeGlow={edgeGlow}
       isSubmitting={isSubmitting}
+      isInteractionDisabled={isInteractionDisabled}
       onSubmit={submitPrompt}
       labels={labels}
     />


### PR DESCRIPTION
## 背景

Message Center 目前只用 `isSubmitting` 表示响应提交中，无法独立表达某个待处理 Interaction 因宿主状态暂时不可操作。共享或远端宿主需要在保留卡片和会话入口的同时禁用嵌套交互，并向用户说明原因。

本 PR 在 AgentGUI 中增加通用、可选的禁用呈现契约。宿主仍然拥有 Interaction readiness 和最终命令准入权，AgentGUI 不推断网络、Owner 或绑定状态。

## 变更

- 为 Message Center 卡片和交互 Prompt 增加独立的 `isInteractionDisabled`
- 覆盖 approval、ask-user、exit-plan、plan-implementation 的按钮、文本输入、键盘快捷键和防御性提交
- 可选禁用原因支持 Hover 与键盘 Focus 提示；空原因不生成空 Tooltip、额外 Tab 停靠点或无意义 aria-label
- 保持卡片和打开会话入口可用，并保持 `isSubmitting` 只表示提交中的状态
- 增加 reason 存在/缺失两类组件测试，并更新 AgentGUI 架构说明

## 验证

- `pnpm check:changed`：11 个 lane 通过
- pre-push `pnpm check:changed -- --push-ready`：12 个 lane 通过
- AgentGUI 完整包测试：312 个文件、2709 个测试通过
- 下游桌面宿主通过本地包链接完成类型检查、focused tests 和桌面检查

## AgentGUI Review Contract

| Lane | Trigger | Result | Evidence | Affected consumers |
| --- | --- | --- | --- | --- |
| Architecture | Message Center、Interactive Prompt 与公开 Props 发生变化 | pass | 架构文档 §2.5 明确 `isSubmitting` 与独立禁用状态的边界；最终命令准入仍由宿主 consumer/controller 负责 | Message Center、attention card、仓库外 AgentGUI 宿主 |
| Performance | Message Center 渲染路径发生变化 | pass | 仅新增可选标量 Props 和局部包装层；未新增 Engine 订阅、Workspace snapshot、流式解析或布局测量；degradation gate 通过 | Message Center |
| Consumers | 公开组件输入契约扩展 | pass | 新 Props 均为可选且默认保持原行为；组件测试覆盖有原因和无原因；下游桌面宿主已完成本地链接验证 | Desktop Message Center、仓库外桌面宿主 |

## 未解决风险

真实阻塞原因及最终提交拦截依赖宿主提供准确的 Interaction readiness。本 PR 只提供通用展示与早期控件禁用能力，不复制宿主状态机。