### PR TITLE
test(agent-gui): remove deprecated dock identity test

### DIFF
--- a/packages/agent/gui/workbench/launch.test.ts
+++ b/packages/agent/gui/workbench/launch.test.ts
@@ -1,15 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
-  agentGuiWorkbenchDockEntryId,
   agentGuiWorkbenchPrefillPromptActivationType,
-  agentGuiWorkbenchDockIdentityFromIdentifier,
   agentGuiWorkbenchProviderFromLaunchRequest,
   agentGuiWorkbenchUnifiedDockEntryId,
   createAgentGuiWorkbenchDraftLaunchRequest,
   createAgentGuiWorkbenchInstanceId,
   createAgentGuiWorkbenchLaunchDescriptor,
   createAgentGuiWorkbenchSessionLaunchRequest,
-  resolveAgentGuiWorkbenchLaunchDockEntryId
 } from "./launch.ts";
 
 describe("agent gui workbench launch contract", () => {
@@ -20,25 +17,6 @@ describe("agent gui workbench launch contract", () => {
     expect(first).toMatch(/^agent-gui:instance:/);
     expect(second).toMatch(/^agent-gui:instance:/);
     expect(first).not.toBe(second);
-  });
-
-  it("keeps deprecated dock identity helpers canonical", () => {
-    expect(agentGuiWorkbenchDockEntryId("codex")).toBe("agent-gui:unified");
-    expect(agentGuiWorkbenchDockEntryId("acp:gemini")).toBe(
-      "agent-gui:unified"
-    );
-    expect(
-      resolveAgentGuiWorkbenchLaunchDockEntryId({
-        provider: "acp:gemini",
-        requestedDockEntryId: "agent-gui:acp:gemini"
-      })
-    ).toBe("agent-gui:unified");
-    expect(
-      resolveAgentGuiWorkbenchLaunchDockEntryId({
-        provider: "codex",
-        requestedDockEntryId: null
-      })
-    ).toBe("agent-gui:unified");
   });
 
   it("requires launch providers in payloads", () => {
@@ -74,17 +52,6 @@ describe("agent gui workbench launch contract", () => {
     expect(descriptor.dockEntryId).toBe("agent-gui:unified");
     expect(descriptor.instanceId).toMatch(/^agent-gui:instance:/);
     expect(descriptor.provider).toBe("codex");
-  });
-
-  it("parses only the canonical aggregate dock identity", () => {
-    expect(agentGuiWorkbenchUnifiedDockEntryId()).toBe("agent-gui:unified");
-    expect(
-      agentGuiWorkbenchDockIdentityFromIdentifier("agent-gui:unified")
-    ).toEqual({ kind: "unifiedAggregate" });
-    expect(agentGuiWorkbenchDockIdentityFromIdentifier("agent-gui")).toBeNull();
-    expect(
-      agentGuiWorkbenchDockIdentityFromIdentifier("agent-gui:claude-code")
-    ).toBeNull();
   });
 
   it("launches sessions into provider panels until current session state can reuse a node", () => {


### PR DESCRIPTION
## 变更说明

删除 AgentGUI workbench launch contract 中专门验证已 deprecated dock identity helpers 的测试。

旧 dock identity 已统一收敛到 `agent-gui:unified`，当前文件其余测试继续覆盖统一 dock、provider、session 和 prompt launch contract；删除该兼容实现细节测试不会减少核心行为覆盖。

## 验证

- `git diff --check` 通过
- 基于 PR #2157 合入后的最新 `main`

无文档影响。