### PR TITLE
perf(release): publish npm packages concurrently

### DIFF
--- a/.github/workflows/npm-package-release.yml
+++ b/.github/workflows/npm-package-release.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Publish packages
         env:
           TUTTI_PACKAGE_RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          TUTTI_NPM_PUBLISH_CONCURRENCY: "4"
           TUTTI_NPM_PROVENANCE: ${{ github.event.repository.private != true }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/docs/conventions/npm-package-release.md
+++ b/docs/conventions/npm-package-release.md
@@ -29,6 +29,7 @@ The current fixed release group is:
 @tutti-os/workspace-terminal
 @tutti-os/agent-activity-core
 @tutti-os/agent-gui
+@tutti-os/agent-session-replay
 @tutti-os/commerce
 @tutti-os/claude-sdk-sidecar
 @tutti-os/browser-node
@@ -87,6 +88,15 @@ packages with the `latest` dist-tag, then points the matching npm release tag
 and every `packages/**/go.mod` module tag at that release commit. The commit is
 reachable through those tags only and is not pushed to `main`. Stable releases
 do not open version PRs and do not require Changeset files.
+
+Package publication uses bounded concurrency so registry and provenance
+round-trips do not serialize the full fixed release group. The workflow pins
+`TUTTI_NPM_PUBLISH_CONCURRENCY=4`; release tooling accepts an integer from `1`
+through `8` for controlled CI tuning and rejects unbounded or invalid values.
+Each worker checks only the exact immutable package version before publishing,
+preserves the bounded provenance retry, and stops admitting new packages after
+the first terminal failure. Release and Go module tags are created and pushed
+only after every package publish has completed successfully.
 
 Because the stable release version is applied only in CI, repository manifests
 on `main` may lag behind the latest published `0.0.x` version. The durable

--- a/tools/scripts/publish-packages.mjs
+++ b/tools/scripts/publish-packages.mjs
@@ -1,7 +1,8 @@
-import { execFileSync } from "node:child_process";
+import { execFile, execFileSync, spawn } from "node:child_process";
 import { readFile, readdir } from "node:fs/promises";
 import { join, relative, sep } from "node:path";
 import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
 
 import {
   getNpmReleasePackages,
@@ -12,6 +13,10 @@ import {
   parseStablePackageReleaseVersion
 } from "./package-release-version.mjs";
 import { preparePackageGoModuleReleaseTree } from "./go-module-release.mjs";
+
+const execFileAsync = promisify(execFile);
+const defaultPackagePublishConcurrency = 4;
+const maximumPackagePublishConcurrency = 8;
 
 if (isExecutedAsEntryPoint()) {
   await main();
@@ -27,6 +32,9 @@ async function main() {
       process.env.TUTTI_NPM_PROVENANCE
     )
   });
+  const publishConcurrency = resolvePackagePublishConcurrency(
+    process.env.TUTTI_NPM_PUBLISH_CONCURRENCY
+  );
 
   if (expectedVersion && releaseVersion !== expectedVersion) {
     throw new Error(
@@ -52,30 +60,19 @@ async function main() {
     ...rewrittenGoModules
   ]);
 
-  for (const packageConfig of packages) {
-    if (isPackageVersionPublished(packageConfig.name, releaseVersion)) {
-      console.log(
-        `Skipping ${packageConfig.name}@${releaseVersion}; version is already published`
-      );
-      continue;
-    }
-
-    await publishPackageWithRetry({
-      packageName: packageConfig.name,
-      version: releaseVersion,
-      publish: () => {
-        console.log(
-          `Publishing ${packageConfig.name}@${releaseVersion} with latest tag`
-        );
-        execFileSync("pnpm", publishArguments, {
-          cwd: join(workspaceRoot, packageConfig.directory),
-          stdio: "inherit"
-        });
-      },
-      isPublished: () =>
-        isPackageVersionPublished(packageConfig.name, releaseVersion)
-    });
-  }
+  console.log(
+    `Publishing ${packages.length} packages with concurrency ${publishConcurrency}`
+  );
+  await publishPackageGroup({
+    concurrency: publishConcurrency,
+    isPublished: isPackageVersionPublished,
+    packages,
+    publish: (packageConfig) =>
+      runCommand("pnpm", publishArguments, {
+        cwd: join(workspaceRoot, packageConfig.directory)
+      }),
+    releaseVersion
+  });
 
   for (const tagName of releaseTagNames) {
     execFileSync("git", ["tag", tagName], {
@@ -105,11 +102,11 @@ export async function publishPackageWithRetry({
   let lastError;
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     try {
-      publish();
+      await publish();
       return;
     } catch (error) {
       lastError = error;
-      if (isPublished()) {
+      if (await isPublished()) {
         console.log(
           `${packageName}@${version} became visible after publish returned an error; continuing`
         );
@@ -124,6 +121,92 @@ export async function publishPackageWithRetry({
     }
   }
   throw lastError;
+}
+
+export async function publishPackageGroup({
+  concurrency,
+  isPublished,
+  packages,
+  publish,
+  releaseVersion
+}) {
+  await runWithConcurrency(packages, concurrency, async (packageConfig) => {
+    if (await isPublished(packageConfig.name, releaseVersion)) {
+      console.log(
+        `Skipping ${packageConfig.name}@${releaseVersion}; version is already published`
+      );
+      return;
+    }
+
+    await publishPackageWithRetry({
+      packageName: packageConfig.name,
+      version: releaseVersion,
+      publish: async () => {
+        console.log(
+          `Publishing ${packageConfig.name}@${releaseVersion} with latest tag`
+        );
+        await publish(packageConfig);
+      },
+      isPublished: () => isPublished(packageConfig.name, releaseVersion)
+    });
+  });
+}
+
+export async function runWithConcurrency(items, concurrency, task) {
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw new Error("Concurrency must be a positive integer");
+  }
+
+  let nextIndex = 0;
+  let failed = false;
+  let firstError;
+  const workerCount = Math.min(concurrency, items.length);
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (!failed) {
+      const index = nextIndex;
+      nextIndex += 1;
+
+      if (index >= items.length) {
+        return;
+      }
+
+      try {
+        await task(items[index], index);
+      } catch (error) {
+        if (!failed) {
+          failed = true;
+          firstError = error;
+        }
+      }
+    }
+  });
+
+  await Promise.all(workers);
+
+  if (failed) {
+    throw firstError;
+  }
+}
+
+export function resolvePackagePublishConcurrency(value) {
+  if (value === undefined) {
+    return defaultPackagePublishConcurrency;
+  }
+
+  if (!/^\d+$/u.test(value)) {
+    throw new Error(
+      `TUTTI_NPM_PUBLISH_CONCURRENCY must be an integer from 1 to ${maximumPackagePublishConcurrency}`
+    );
+  }
+
+  const concurrency = Number(value);
+  if (concurrency < 1 || concurrency > maximumPackagePublishConcurrency) {
+    throw new Error(
+      `TUTTI_NPM_PUBLISH_CONCURRENCY must be an integer from 1 to ${maximumPackagePublishConcurrency}`
+    );
+  }
+
+  return concurrency;
 }
 
 function defaultPublishRetryWait(attempt) {
@@ -236,6 +319,10 @@ export function createPublishArguments({ withProvenance }) {
   return arguments_;
 }
 
+export function createPublishedVersionViewArguments(packageName, version) {
+  return ["view", `${packageName}@${version}`, "version", "--json"];
+}
+
 export function createReleaseGitEnvironment() {
   return {
     ...process.env,
@@ -338,19 +425,18 @@ function toPosixPath(path) {
   return path.split(sep).join("/");
 }
 
-function isPackageVersionPublished(packageName, version) {
+async function isPackageVersionPublished(packageName, version) {
   try {
-    const output = execFileSync(
+    const { stdout } = await execFileAsync(
       "npm",
-      ["view", packageName, "versions", "--json"],
+      createPublishedVersionViewArguments(packageName, version),
       {
         cwd: workspaceRoot,
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "pipe"]
+        encoding: "utf8"
       }
     );
 
-    return isPublishedVersionListed(JSON.parse(output), version);
+    return isPublishedVersionListed(JSON.parse(stdout), version);
   } catch (error) {
     const stderr =
       error instanceof Error &&
@@ -369,4 +455,49 @@ function isPackageVersionPublished(packageName, version) {
 
     throw error;
   }
+}
+
+function runCommand(command, args, { cwd }) {
+  return new Promise((resolve, reject) => {
+    const outputChunks = [];
+    let outputFlushed = false;
+    const child = spawn(command, args, {
+      cwd,
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+
+    child.stdout.on("data", (chunk) => {
+      outputChunks.push([process.stdout, chunk]);
+    });
+    child.stderr.on("data", (chunk) => {
+      outputChunks.push([process.stderr, chunk]);
+    });
+
+    const flushOutput = () => {
+      if (outputFlushed) {
+        return;
+      }
+      outputFlushed = true;
+      for (const [stream, chunk] of outputChunks) {
+        stream.write(chunk);
+      }
+    };
+
+    child.once("error", (error) => {
+      flushOutput();
+      reject(error);
+    });
+    child.once("close", (code, signal) => {
+      flushOutput();
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      const termination = signal ? `signal ${signal}` : `exit code ${code}`;
+      reject(
+        new Error(`${command} ${args.join(" ")} failed with ${termination}`)
+      );
+    });
+  });
 }

--- a/tools/scripts/publish-packages.test.mjs
+++ b/tools/scripts/publish-packages.test.mjs
@@ -2,13 +2,17 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  createPublishedVersionViewArguments,
   createPublishArguments,
   createReleaseGitEnvironment,
   formatPackageGoModuleReleaseTag,
   isPublishedVersionListed,
   normalizePublishedPackageVersions,
+  publishPackageGroup,
   publishPackageWithRetry,
-  resolveReleaseTagNames
+  resolvePackagePublishConcurrency,
+  resolveReleaseTagNames,
+  runWithConcurrency
 } from "./publish-packages.mjs";
 
 test("createPublishArguments omits provenance by default", () => {
@@ -32,6 +36,13 @@ test("createPublishArguments enables provenance when requested", () => {
     "--no-git-checks",
     "--provenance"
   ]);
+});
+
+test("createPublishedVersionViewArguments queries only the exact immutable version", () => {
+  assert.deepEqual(
+    createPublishedVersionViewArguments("@tutti-os/example", "0.0.25"),
+    ["view", "@tutti-os/example@0.0.25", "version", "--json"]
+  );
 });
 
 test("createReleaseGitEnvironment disables husky hooks for CI release pushes", () => {
@@ -83,19 +94,112 @@ test("isPublishedVersionListed detects already published versions", () => {
   assert.equal(isPublishedVersionListed(["0.0.1", "0.0.2"], "0.0.3"), false);
 });
 
+test("resolvePackagePublishConcurrency defaults to four bounded workers", () => {
+  assert.equal(resolvePackagePublishConcurrency(undefined), 4);
+  assert.equal(resolvePackagePublishConcurrency("1"), 1);
+  assert.equal(resolvePackagePublishConcurrency("8"), 8);
+  assert.throws(
+    () => resolvePackagePublishConcurrency("0"),
+    /integer from 1 to 8/
+  );
+  assert.throws(
+    () => resolvePackagePublishConcurrency("9"),
+    /integer from 1 to 8/
+  );
+  assert.throws(
+    () => resolvePackagePublishConcurrency("4.5"),
+    /integer from 1 to 8/
+  );
+});
+
+test("publishPackageGroup bounds concurrent publishes and skips existing versions", async () => {
+  const packages = ["a", "b", "c", "existing"].map((name) => ({
+    name: `@tutti-os/${name}`
+  }));
+  const published = [];
+  let activePublishes = 0;
+  let maximumActivePublishes = 0;
+  let releaseFirstWave;
+  const firstWave = new Promise((resolve) => {
+    releaseFirstWave = resolve;
+  });
+
+  await publishPackageGroup({
+    concurrency: 2,
+    isPublished: async (name) => name === "@tutti-os/existing",
+    packages,
+    publish: async (packageConfig) => {
+      activePublishes += 1;
+      maximumActivePublishes = Math.max(
+        maximumActivePublishes,
+        activePublishes
+      );
+      if (maximumActivePublishes === 2) {
+        releaseFirstWave();
+      }
+      await firstWave;
+      published.push(packageConfig.name);
+      activePublishes -= 1;
+    },
+    releaseVersion: "0.0.1"
+  });
+
+  assert.equal(maximumActivePublishes, 2);
+  assert.deepEqual(published.sort(), [
+    "@tutti-os/a",
+    "@tutti-os/b",
+    "@tutti-os/c"
+  ]);
+});
+
+test("runWithConcurrency stops admitting work after failure and drains in-flight tasks", async () => {
+  const expected = new Error("publish failed");
+  const started = [];
+  let inFlightFinished = false;
+  let markSecondStarted;
+  let markFailureTriggered;
+  const secondStarted = new Promise((resolve) => {
+    markSecondStarted = resolve;
+  });
+  const failureTriggered = new Promise((resolve) => {
+    markFailureTriggered = resolve;
+  });
+
+  await assert.rejects(
+    runWithConcurrency([0, 1, 2, 3], 2, async (item) => {
+      started.push(item);
+      if (item === 0) {
+        await secondStarted;
+        markFailureTriggered();
+        throw expected;
+      }
+      if (item === 1) {
+        markSecondStarted();
+        await failureTriggered;
+        await new Promise((resolve) => setImmediate(resolve));
+        inFlightFinished = true;
+      }
+    }),
+    expected
+  );
+
+  assert.deepEqual(started, [0, 1]);
+  assert.equal(inFlightFinished, true);
+});
+
 test("publishPackageWithRetry retries a failed unpublished version", async () => {
   let attempts = 0;
   const waits = [];
   await publishPackageWithRetry({
     packageName: "@tutti-os/example",
     version: "0.0.1",
-    publish() {
+    async publish() {
       attempts += 1;
       if (attempts === 1) {
         throw new Error("transparency log conflict");
       }
     },
-    isPublished: () => false,
+    isPublished: async () => false,
     wait: async (attempt) => waits.push(attempt)
   });
   assert.equal(attempts, 2);


### PR DESCRIPTION
## 背景

npm 固定发布组目前包含 31 个包。最近发布的 Publish packages 阶段约耗时 2 分 31 秒，主要原因是逐包串行执行版本探测和 pnpm publish。

## 改动

- 将固定发布组改为默认 4 路有界并发发布，并允许通过 TUTTI_NPM_PUBLISH_CONCURRENCY 在 1～8 之间调整
- 将完整 versions 历史查询改为精确 package@version 探测
- 保留 provenance 重试、重复运行幂等性，以及全部成功后才推送 npm/Go 发布 tags 的约束
- 首个终态失败后停止接纳新包，并等待在途发布收尾
- 按包缓冲并输出并发 publish 日志，避免日志交叉
- 补充并发上限、跳过已发布版本、失败收敛及异步重试测试
- 更新 npm 发布约定并补齐 agent-session-replay 固定组记录

## 验证

- pnpm check:changed
- pre-commit hooks
- pre-push pnpm check:changed -- --push-ready

## 预期效果

按最近一次正式发布数据，Publish packages 阶段预计从约 2 分 31 秒下降到 40～70 秒。合并后将触发一次正式 npm Package Release 验证实际耗时和 provenance 稳定性。