### PR TITLE
fix(mobile): surface Agent live protocol incompatibility

### DIFF
--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -11,10 +11,11 @@ import { type NativeTheme, useNativeTheme } from "@tutti-os/ui-system/native";
 import { useServiceSnapshot } from "./bindings/useServiceSnapshot";
 import { MobileConnectionRecoveryOverlay } from "./components/MobileConnectionRecoveryOverlay";
 import { MobileUIProviders } from "./components/MobileUIProviders";
+import { presentMobileSoftwareUpdate } from "./components/presentMobileSoftwareUpdate";
 import { NativeComponentGallery } from "./dev/NativeComponentGallery";
 import { t } from "./i18n";
 import "@tutti-os/ui-system/native.css";
-import { mobileApplicationService } from "./mobileRuntime";
+import { mobileApplicationService, mobileUpdateService } from "./mobileRuntime";
 import { MobileNavigator } from "./navigation/MobileNavigator";
 
 export default function App() {
@@ -64,6 +65,9 @@ function AppContent() {
               connection={snapshot.connection}
               onBackToDevices={() =>
                 void mobileApplicationService.disconnectDevice()
+              }
+              onCheckForUpdates={() =>
+                presentMobileSoftwareUpdate(mobileUpdateService)
               }
               onRetry={() =>
                 void mobileApplicationService.retryDeviceConnection()

--- a/apps/mobile/src/components/MobileConnectionRecoveryOverlay.test.tsx
+++ b/apps/mobile/src/components/MobileConnectionRecoveryOverlay.test.tsx
@@ -1,0 +1,48 @@
+import { NativeButton } from "@tutti-os/ui-system/native";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { Text } from "react-native";
+import { MobileConnectionRecoveryOverlay } from "./MobileConnectionRecoveryOverlay";
+
+test("offers a software update instead of retrying incompatible revisions", () => {
+  const checkForUpdates = jest.fn();
+  const retry = jest.fn();
+  let renderer: ReactTestRenderer;
+  act(() => {
+    renderer = create(
+      <MobileConnectionRecoveryOverlay
+        connection={{
+          expectedRevision: "sha256:new",
+          phase: "failed",
+          reasonCode: "protocol_revision_mismatch",
+          receivedRevision: "sha256:old",
+          trigger: "initial_connect"
+        }}
+        onBackToDevices={() => undefined}
+        onCheckForUpdates={checkForUpdates}
+        onRetry={retry}
+      />
+    );
+  });
+
+  expect(
+    renderer!.root.findAllByType(Text).map((node) => node.props.children)
+  ).toEqual(
+    expect.arrayContaining([
+      "Computer and phone versions are incompatible",
+      "Update Tutti on your phone or computer, then connect again."
+    ])
+  );
+  const primary = renderer!.root.find(
+    (node) => node.type === NativeButton && node.props.variant !== "secondary"
+  );
+  expect(primary.props.label).toBe("Check for updates");
+  expect(
+    renderer!.root.findAll(
+      (node) => node.type === NativeButton && node.props.label === "Reconnect"
+    )
+  ).toHaveLength(0);
+
+  act(() => primary.props.onPress());
+  expect(checkForUpdates).toHaveBeenCalledTimes(1);
+  expect(retry).not.toHaveBeenCalled();
+});

--- a/apps/mobile/src/components/MobileConnectionRecoveryOverlay.tsx
+++ b/apps/mobile/src/components/MobileConnectionRecoveryOverlay.tsx
@@ -10,12 +10,14 @@ import type { MobileConnectionSnapshot } from "../services/mobileApplicationServ
 interface MobileConnectionRecoveryOverlayProps {
   connection: MobileConnectionSnapshot;
   onBackToDevices(): void;
+  onCheckForUpdates(): void;
   onRetry(): void;
 }
 
 export function MobileConnectionRecoveryOverlay({
   connection,
   onBackToDevices,
+  onCheckForUpdates,
   onRetry
 }: MobileConnectionRecoveryOverlayProps) {
   const theme = useNativeTheme();
@@ -24,6 +26,8 @@ export function MobileConnectionRecoveryOverlay({
     return null;
   }
   const failed = connection.phase === "failed";
+  const protocolIncompatible =
+    failed && connection.reasonCode === "protocol_revision_mismatch";
 
   return (
     <Modal
@@ -40,21 +44,29 @@ export function MobileConnectionRecoveryOverlay({
           )}
           <Text accessibilityRole="header" style={styles.title}>
             {failed
-              ? t("connectionRecoveryFailedTitle")
+              ? protocolIncompatible
+                ? t("connectionVersionIncompatibleTitle")
+                : t("connectionRecoveryFailedTitle")
               : connection.phase === "synchronizing"
                 ? t("connectionSynchronizingTitle")
                 : t("connectionReconnectingTitle")}
           </Text>
           <Text style={styles.description}>
             {failed
-              ? t("connectionRecoveryFailedDescription")
+              ? protocolIncompatible
+                ? t("connectionVersionIncompatibleDescription")
+                : t("connectionRecoveryFailedDescription")
               : t("connectionRecoveryDescription")}
           </Text>
           <View style={styles.actions}>
             {failed ? (
               <NativeButton
-                label={t("retryConnection")}
-                onPress={onRetry}
+                label={
+                  protocolIncompatible
+                    ? t("checkForUpdates")
+                    : t("retryConnection")
+                }
+                onPress={protocolIncompatible ? onCheckForUpdates : onRetry}
                 size="large"
               />
             ) : null}

--- a/apps/mobile/src/components/presentMobileSoftwareUpdate.ts
+++ b/apps/mobile/src/components/presentMobileSoftwareUpdate.ts
@@ -1,0 +1,49 @@
+import { Alert } from "react-native";
+import { t } from "../i18n";
+import {
+  isMobileUpdateInstallPermissionRequired,
+  type MobileUpdateService
+} from "../services/mobileUpdateService";
+
+export function presentMobileSoftwareUpdate(
+  mobileUpdateService: MobileUpdateService
+): void {
+  void mobileUpdateService
+    .checkForUpdates()
+    .then((nextSnapshot) => {
+      if (nextSnapshot.status === "unsupported") {
+        Alert.alert(t("softwareUpdate"), t("updatesUnavailable"));
+        return;
+      }
+      if (nextSnapshot.status === "upToDate") {
+        Alert.alert(t("softwareUpdate"), t("upToDate"));
+        return;
+      }
+      if (nextSnapshot.status !== "available" || !nextSnapshot.release) {
+        return;
+      }
+
+      Alert.alert(
+        t("updateAvailable"),
+        t("updateAvailableDescription", {
+          version: nextSnapshot.release.versionName
+        }),
+        [
+          { style: "cancel", text: t("cancel") },
+          {
+            onPress: () => {
+              void mobileUpdateService.installUpdate().catch((error) => {
+                if (!isMobileUpdateInstallPermissionRequired(error)) {
+                  Alert.alert(t("updateInstallFailed"));
+                }
+              });
+            },
+            text: t("downloadAndInstall")
+          }
+        ]
+      );
+    })
+    .catch(() => {
+      Alert.alert(t("updateCheckFailed"));
+    });
+}

--- a/apps/mobile/src/i18n.ts
+++ b/apps/mobile/src/i18n.ts
@@ -30,6 +30,7 @@ const messages = {
     copyAsMarkdown: "Copy as Markdown",
     copyImageUrl: "Copy image URL",
     changedFiles: "{count} changed files",
+    checkForUpdates: "Check for updates",
     closeSheet: "Close sheet",
     collapseSection: "Collapse section",
     connecting: "Connecting securely…",
@@ -52,6 +53,10 @@ const messages = {
       "Make sure Tutti is running on your computer, then try again or return to your computers.",
     connectionRecoveryFailedTitle: "Could not reconnect",
     connectionSynchronizingTitle: "Syncing the latest data",
+    connectionVersionIncompatibleDescription:
+      "Update Tutti on your phone or computer, then connect again.",
+    connectionVersionIncompatibleTitle:
+      "Computer and phone versions are incompatible",
     connectionStatus: "Status",
     connectionTransport: "Channel",
     connectionTransportP2p: "End-to-end encrypted P2P",
@@ -230,6 +235,7 @@ const messages = {
     copyAsMarkdown: "复制为 Markdown",
     copyImageUrl: "复制图片链接",
     changedFiles: "已变更 {count} 个文件",
+    checkForUpdates: "检查手机更新",
     closeSheet: "关闭面板",
     collapseSection: "收起分组",
     connecting: "正在建立安全连接…",
@@ -251,6 +257,9 @@ const messages = {
       "请确认电脑端 Tutti 正在运行，然后重试或返回电脑列表",
     connectionRecoveryFailedTitle: "无法重新连接",
     connectionSynchronizingTitle: "正在同步最新数据",
+    connectionVersionIncompatibleDescription:
+      "请更新手机或电脑上的 Tutti，然后重新连接",
+    connectionVersionIncompatibleTitle: "电脑版本与手机不兼容",
     connectionStatus: "状态",
     connectionTransport: "传输通道",
     connectionTransportP2p: "端到端加密 P2P",

--- a/apps/mobile/src/native/agentLiveNativeBridge.test.ts
+++ b/apps/mobile/src/native/agentLiveNativeBridge.test.ts
@@ -82,6 +82,7 @@ describe("parseAgentLiveDeliveries", () => {
       {
         kind: "connection",
         reason: "stream_closed",
+        retryable: true,
         status: "disconnected"
       }
     ]);
@@ -96,6 +97,40 @@ describe("parseAgentLiveDeliveries", () => {
         })
       )
     ).toEqual([]);
+  });
+
+  test("preserves a protocol rejection as a terminal connection failure", () => {
+    expect(
+      parseAgentLiveDeliveries(
+        "workspace-1",
+        7,
+        JSON.stringify({
+          result: {
+            accepted: [
+              {
+                kind: "rejected",
+                rejected: {
+                  expectedRevision: "sha256:new",
+                  reason: "protocol_revision_mismatch",
+                  receivedRevision: "sha256:old"
+                }
+              }
+            ]
+          },
+          subscriptionGeneration: 7,
+          workspaceId: "workspace-1"
+        })
+      )
+    ).toEqual([
+      {
+        expectedRevision: "sha256:new",
+        kind: "connection",
+        reason: "protocol_revision_mismatch",
+        receivedRevision: "sha256:old",
+        retryable: false,
+        status: "disconnected"
+      }
+    ]);
   });
 
   test("rejects queued deliveries from an obsolete native subscription", () => {

--- a/apps/mobile/src/native/agentLiveNativeBridge.ts
+++ b/apps/mobile/src/native/agentLiveNativeBridge.ts
@@ -35,6 +35,7 @@ export function parseAgentLiveDeliveries(
             typeof envelope.reason === "string"
               ? envelope.reason
               : "stream_closed",
+          retryable: true,
           status: "disconnected"
         }
       ];
@@ -91,9 +92,20 @@ export function parseAgentLiveDeliveries(
         continue;
       }
       if (accepted.kind === "rejected") {
+        const rejected = isRecord(accepted.rejected) ? accepted.rejected : {};
         deliveries.push({
+          ...(typeof rejected.expectedRevision === "string"
+            ? { expectedRevision: rejected.expectedRevision }
+            : {}),
           kind: "connection",
-          reason: "protocol_rejected",
+          reason:
+            typeof rejected.reason === "string"
+              ? rejected.reason
+              : "stream_rejected",
+          ...(typeof rejected.receivedRevision === "string"
+            ? { receivedRevision: rejected.receivedRevision }
+            : {}),
+          retryable: false,
           status: "disconnected"
         });
         continue;

--- a/apps/mobile/src/native/createMobileServicePorts.ts
+++ b/apps/mobile/src/native/createMobileServicePorts.ts
@@ -66,6 +66,7 @@ export function createMobileServicePorts(): MobileServicePorts {
               listener({
                 kind: "connection",
                 reason: "subscribe_failed",
+                retryable: true,
                 status: "disconnected"
               });
             }

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -1,6 +1,7 @@
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { Alert } from "react-native";
 import { useServiceSnapshot } from "../bindings/useServiceSnapshot";
+import { presentMobileSoftwareUpdate } from "../components/presentMobileSoftwareUpdate";
 import { t } from "../i18n";
 import {
   mobileThemePreferenceService,
@@ -9,7 +10,6 @@ import {
 import { mobileSecurity } from "../native/mobileNative";
 import type { MobileRootStackParamList } from "../navigation/mobileNavigation";
 import type { MobileApplicationService } from "../services/mobileApplicationService";
-import { isMobileUpdateInstallPermissionRequired } from "../services/mobileUpdateService";
 import { SettingsScreenView } from "./SettingsScreenView";
 
 type Props = NativeStackScreenProps<MobileRootStackParamList, "Settings"> & {
@@ -41,51 +41,12 @@ export function SettingsScreen({ application, navigation }: Props) {
     });
   };
 
-  const checkForSoftwareUpdate = (): void => {
-    void mobileUpdateService
-      .checkForUpdates()
-      .then((nextSnapshot) => {
-        if (nextSnapshot.status === "unsupported") {
-          Alert.alert(t("softwareUpdate"), t("updatesUnavailable"));
-          return;
-        }
-        if (nextSnapshot.status === "upToDate") {
-          Alert.alert(t("softwareUpdate"), t("upToDate"));
-          return;
-        }
-        if (nextSnapshot.status !== "available" || !nextSnapshot.release) {
-          return;
-        }
-
-        Alert.alert(
-          t("updateAvailable"),
-          t("updateAvailableDescription", {
-            version: nextSnapshot.release.versionName
-          }),
-          [
-            { style: "cancel", text: t("cancel") },
-            {
-              onPress: () => {
-                void mobileUpdateService.installUpdate().catch((error) => {
-                  if (!isMobileUpdateInstallPermissionRequired(error)) {
-                    Alert.alert(t("updateInstallFailed"));
-                  }
-                });
-              },
-              text: t("downloadAndInstall")
-            }
-          ]
-        );
-      })
-      .catch(() => {
-        Alert.alert(t("updateCheckFailed"));
-      });
-  };
-
   return (
     <SettingsScreenView
       onBack={() => navigation.goBack()}
-      onSoftwareUpdatePress={checkForSoftwareUpdate}
+      onSoftwareUpdatePress={() =>
+        presentMobileSoftwareUpdate(mobileUpdateService)
+      }
       onSignOut={confirmSignOut}
       onThemePreferenceChange={changeThemePreference}
       session={snapshot.session}

--- a/apps/mobile/src/services/mobileApplicationService.test.ts
+++ b/apps/mobile/src/services/mobileApplicationService.test.ts
@@ -6,8 +6,10 @@ import { InstantiationService } from "@tutti-os/infra/di";
 import type { AccountSession } from "./mobileDomain";
 import { MobileApplicationService } from "./mobileApplicationService";
 import type {
+  AgentLiveDelivery,
   AppLifecycleState,
   ClockPort,
+  MobileDiagnosticEvent,
   MobileServicePorts
 } from "./servicePorts";
 
@@ -128,10 +130,140 @@ describe("MobileApplicationService scopes", () => {
     expect(harness.closeCalls).toBe(0);
     expect(harness.connectCalls).toBe(1);
 
+    harness.emitAgentLiveConnection("disconnected");
+
     harness.clock.advanceBy(1);
     await flushPromises();
     expect(harness.closeCalls).toBe(1);
     expect(harness.connectCalls).toBe(2);
+  });
+
+  test("stops retrying and reports incompatible Agent live revisions", async () => {
+    const harness = createHarness(session, [workspace]);
+    const service = new MobileApplicationService(
+      new InstantiationService(),
+      harness.ports
+    );
+    await service.start();
+    await service.deviceService!.connect(pairing);
+
+    harness.emitAgentLiveConnection("disconnected", {
+      expectedRevision: "sha256:new",
+      reason: "protocol_revision_mismatch",
+      receivedRevision: "sha256:old",
+      retryable: false
+    });
+
+    expect(service.getSnapshot()).toMatchObject({
+      connection: {
+        expectedRevision: "sha256:new",
+        phase: "failed",
+        reasonCode: "protocol_revision_mismatch",
+        receivedRevision: "sha256:old",
+        trigger: "initial_connect"
+      },
+      workspace: { id: workspace.id }
+    });
+    expect(harness.subscribeCalls).toBe(1);
+    expect(harness.diagnosticEvents).toContainEqual({
+      expectedRevision: "sha256:new",
+      name: "device_connection.phase_changed",
+      phase: "failed",
+      reasonCode: "protocol_revision_mismatch",
+      receivedRevision: "sha256:old",
+      trigger: "initial_connect"
+    });
+
+    harness.clock.advanceBy(30_000);
+    await flushPromises();
+    expect(harness.subscribeCalls).toBe(1);
+    expect(harness.closeCalls).toBe(0);
+    expect(harness.connectCalls).toBe(1);
+
+    harness.emitLifecycle("background");
+    harness.clock.advanceBy(15_000);
+    harness.emitLifecycle("foreground");
+    await flushPromises();
+    expect(service.getSnapshot()).toMatchObject({
+      connection: {
+        phase: "failed",
+        reasonCode: "protocol_revision_mismatch"
+      }
+    });
+    expect(harness.closeCalls).toBe(0);
+    expect(harness.connectCalls).toBe(1);
+  });
+
+  test("preserves a synchronous protocol rejection during workspace startup", async () => {
+    const harness = createHarness(session, [workspace], {
+      agentLiveDeliveriesOnSubscribe: [
+        {
+          expectedRevision: "sha256:new",
+          kind: "connection",
+          reason: "protocol_revision_mismatch",
+          receivedRevision: "sha256:old",
+          retryable: false,
+          status: "disconnected"
+        }
+      ]
+    });
+    const service = new MobileApplicationService(
+      new InstantiationService(),
+      harness.ports
+    );
+    await service.start();
+    await service.deviceService!.connect(pairing);
+
+    expect(service.getSnapshot()).toMatchObject({
+      connection: {
+        expectedRevision: "sha256:new",
+        phase: "failed",
+        reasonCode: "protocol_revision_mismatch",
+        receivedRevision: "sha256:old",
+        trigger: "initial_connect"
+      },
+      workspace: { id: workspace.id }
+    });
+    expect(harness.subscribeCalls).toBe(1);
+    expect(harness.subscriptionCloseCalls).toBe(1);
+
+    harness.clock.advanceBy(30_000);
+    expect(harness.subscribeCalls).toBe(1);
+  });
+
+  test("retries after a synchronous retryable stream close", async () => {
+    const harness = createHarness(session, [workspace], {
+      agentLiveDeliveriesOnSubscribe: [
+        {
+          kind: "connection",
+          reason: "stream_closed",
+          retryable: true,
+          status: "disconnected"
+        },
+        { kind: "connection", status: "connected" }
+      ]
+    });
+    const service = new MobileApplicationService(
+      new InstantiationService(),
+      harness.ports
+    );
+    await service.start();
+    await service.deviceService!.connect(pairing);
+
+    expect(service.getSnapshot()).toMatchObject({
+      connection: { phase: "synchronizing", trigger: "initial_connect" }
+    });
+    expect(harness.subscribeCalls).toBe(1);
+    expect(harness.subscriptionCloseCalls).toBe(1);
+
+    harness.clock.advanceBy(999);
+    expect(harness.subscribeCalls).toBe(1);
+    harness.clock.advanceBy(1);
+
+    expect(harness.subscribeCalls).toBe(2);
+    expect(service.getSnapshot()).toMatchObject({
+      connection: { phase: "connected" }
+    });
   });
 
   test("keeps the workspace available after recovery fails and retries explicitly", async () => {
@@ -296,13 +428,24 @@ function createHarness(
   storedSession: AccountSession | null | Promise<AccountSession | null>,
   workspaces: readonly WorkspaceSummary[] = [],
   overrides: {
+    agentLiveDeliveriesOnSubscribe?: readonly AgentLiveDelivery[];
     closeLink?(): Promise<void>;
   } = {}
 ): {
   clock: ManualClock;
   closeCalls: number;
   connectCalls: number;
-  emitAgentLiveConnection(status: "connected" | "disconnected"): void;
+  diagnosticEvents: MobileDiagnosticEvent[];
+  emitAgentLiveConnection(
+    status: "connected" | "disconnected",
+    failure?: Pick<
+      Extract<
+        AgentLiveDelivery,
+        { kind: "connection"; status: "disconnected" }
+      >,
+      "expectedRevision" | "reason" | "receivedRevision" | "retryable"
+    >
+  ): void;
   emitLifecycle(state: AppLifecycleState): void;
   failNextConnection(): void;
   failNextLatencyProbe(): void;
@@ -310,6 +453,8 @@ function createHarness(
   ports: MobileServicePorts;
   registerCalls: number;
   requestCalls: number;
+  subscribeCalls: number;
+  subscriptionCloseCalls: number;
 } {
   const clock = new ManualClock();
   let lifecycleListener: ((state: AppLifecycleState) => void) | null = null;
@@ -318,12 +463,40 @@ function createHarness(
     | null = null;
   let failNextConnection = false;
   let failNextLatencyProbe = false;
+  const agentLiveDeliveriesOnSubscribe = [
+    ...(overrides.agentLiveDeliveriesOnSubscribe ?? [])
+  ];
   const harness = {
     clock,
     closeCalls: 0,
     connectCalls: 0,
-    emitAgentLiveConnection(status: "connected" | "disconnected") {
-      liveListener?.({ kind: "connection", status });
+    diagnosticEvents: [] as MobileDiagnosticEvent[],
+    emitAgentLiveConnection(
+      status: "connected" | "disconnected",
+      failure?: Pick<
+        Extract<
+          AgentLiveDelivery,
+          { kind: "connection"; status: "disconnected" }
+        >,
+        "expectedRevision" | "reason" | "receivedRevision" | "retryable"
+      >
+    ) {
+      if (status === "connected") {
+        liveListener?.({ kind: "connection", status });
+        return;
+      }
+      liveListener?.({
+        kind: "connection",
+        reason: failure?.reason ?? "stream_closed",
+        retryable: failure?.retryable ?? true,
+        status,
+        ...(failure?.expectedRevision
+          ? { expectedRevision: failure.expectedRevision }
+          : {}),
+        ...(failure?.receivedRevision
+          ? { receivedRevision: failure.receivedRevision }
+          : {})
+      });
     },
     legacyCookieClearCalls: 0,
     registerCalls: 0,
@@ -337,7 +510,9 @@ function createHarness(
       failNextLatencyProbe = true;
     },
     ports: null as unknown as MobileServicePorts,
-    requestCalls: 0
+    requestCalls: 0,
+    subscribeCalls: 0,
+    subscriptionCloseCalls: 0
   };
   harness.ports = {
     account: {
@@ -386,16 +561,20 @@ function createHarness(
         };
       },
       subscribeAgentLive: (_workspaceId, listener) => {
+        harness.subscribeCalls += 1;
         liveListener = listener;
+        const delivery = agentLiveDeliveriesOnSubscribe.shift();
+        if (delivery) listener(delivery);
         return {
           close() {
+            harness.subscriptionCloseCalls += 1;
             if (liveListener === listener) liveListener = null;
           }
         };
       }
     },
     diagnostics: {
-      record: () => undefined
+      record: (event) => harness.diagnosticEvents.push(event)
     },
     legacySessionCookie: {
       clear: async () => {

--- a/apps/mobile/src/services/mobileApplicationService.ts
+++ b/apps/mobile/src/services/mobileApplicationService.ts
@@ -30,7 +30,11 @@ import {
 import { ObservableService } from "./observableService";
 import { MobileQuickPromptLibraryService } from "./mobileQuickPromptLibraryService";
 import { MobileUserProjectDirectoryService } from "./mobileUserProjectDirectoryService";
-import type { AppLifecycleState, MobileServicePorts } from "./servicePorts";
+import type {
+  AgentLiveDelivery,
+  AppLifecycleState,
+  MobileServicePorts
+} from "./servicePorts";
 import { WorkspaceActivityService } from "./workspaceActivityService";
 import { WorkspaceCatalogService } from "./workspaceCatalogService";
 import type { WorkspaceConversationRailService } from "./workspaceConversationRailService";
@@ -51,9 +55,25 @@ export type MobileConnectionSnapshot =
   | { phase: "idle" }
   | { phase: "connected" }
   | {
-      phase: "failed" | "reconnecting" | "synchronizing";
+      phase: "reconnecting" | "synchronizing";
+      trigger: MobileConnectionRecoveryTrigger;
+    }
+  | {
+      expectedRevision?: string;
+      phase: "failed";
+      reasonCode: MobileConnectionFailureReason;
+      receivedRevision?: string;
       trigger: MobileConnectionRecoveryTrigger;
     };
+
+export type MobileConnectionFailureReason =
+  | "connection_unavailable"
+  | "protocol_revision_mismatch";
+
+type AgentLiveConnectionFailure = Extract<
+  AgentLiveDelivery,
+  { kind: "connection"; status: "disconnected" }
+>;
 
 export type MobileApplicationSnapshot =
   | { status: "bootstrapping" }
@@ -85,6 +105,7 @@ interface WorkspaceScope {
   generation: number;
   navigation: WorkspaceNavigationService;
   rail: WorkspaceConversationRailService;
+  terminalConnectionFailure: AgentLiveConnectionFailure | null;
   workspace: WorkspaceSummary;
 }
 
@@ -252,8 +273,12 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
       this.ports.clock,
       authenticated.session.userId,
       this.ports.deviceLink,
-      (connected) =>
-        this.handleWorkspaceTransportConnectionChanged(generation, connected)
+      (connected, failure) =>
+        this.handleWorkspaceTransportConnectionChanged(
+          generation,
+          connected,
+          failure
+        )
     );
     const rail = activity.rail;
     const services = new ServiceCollection();
@@ -270,6 +295,7 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
       generation,
       navigation,
       rail,
+      terminalConnectionFailure: null,
       workspace
     };
     this.workspaceCandidate = candidate;
@@ -291,10 +317,19 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
       const previousScope = this.workspaceScope;
       this.workspaceScope = candidate;
       previousScope?.container.dispose();
-      const connection: MobileConnectionSnapshot =
-        candidate.activity.isTransportConnected()
+      const terminalFailure = candidate.terminalConnectionFailure;
+      const connection: MobileConnectionSnapshot = terminalFailure
+        ? this.createConnectionFailureSnapshot(
+            trigger,
+            connectionFailureReason(terminalFailure),
+            terminalFailure
+          )
+        : candidate.activity.isTransportConnected()
           ? { phase: "connected" }
           : { phase: "synchronizing", trigger };
+      if (terminalFailure) {
+        candidate.activity.pause();
+      }
       this.publishAuthenticated(authenticated, connection, workspace);
       if (connection.phase === "synchronizing") {
         this.scheduleConnectionReadyDeadline(candidate, trigger);
@@ -456,6 +491,12 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
         this.snapshot.workspace
       ) {
         if (
+          this.snapshot.connection.phase === "failed" &&
+          this.snapshot.connection.reasonCode === "protocol_revision_mismatch"
+        ) {
+          return;
+        }
+        if (
           backgroundElapsedMs >= BACKGROUND_GRACE_MS ||
           this.snapshot.connection.phase === "reconnecting" ||
           this.snapshot.connection.phase === "failed"
@@ -539,7 +580,8 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
 
   private handleWorkspaceTransportConnectionChanged(
     generation: number,
-    connected: boolean
+    connected: boolean,
+    failure?: AgentLiveConnectionFailure
   ): void {
     if (
       this.disposed ||
@@ -549,7 +591,17 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
       return;
     }
     const workspace = this.workspaceScope;
-    if (!workspace || workspace.generation !== generation) return;
+    if (!workspace || workspace.generation !== generation) {
+      const candidate = this.workspaceCandidate;
+      if (
+        failure &&
+        !failure.retryable &&
+        candidate?.generation === generation
+      ) {
+        candidate.terminalConnectionFailure = failure;
+      }
+      return;
+    }
     const authenticated = this.authenticatedScope;
     if (!authenticated?.device) return;
     if (connected) {
@@ -561,9 +613,20 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
       this.snapshot.status === "authenticated"
         ? this.snapshot.connection
         : null;
+    if (failure && !failure.retryable) {
+      const trigger =
+        current && "trigger" in current ? current.trigger : "transport_lost";
+      this.markConnectionFailed(
+        trigger,
+        connectionFailureReason(failure),
+        failure
+      );
+      return;
+    }
     if (current?.phase === "reconnecting" || current?.phase === "failed") {
       return;
     }
+    if (current?.phase === "synchronizing") return;
     this.cancelConnectionTimers();
     this.publishAuthenticated(authenticated, {
       phase: "synchronizing",
@@ -605,12 +668,43 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
     );
   }
 
-  private markConnectionFailed(trigger: MobileConnectionRecoveryTrigger): void {
+  private markConnectionFailed(
+    trigger: MobileConnectionRecoveryTrigger,
+    reasonCode: MobileConnectionFailureReason = "connection_unavailable",
+    protocol?: Pick<
+      AgentLiveConnectionFailure,
+      "expectedRevision" | "receivedRevision"
+    >
+  ): void {
     const authenticated = this.authenticatedScope;
     if (!authenticated?.device || !this.appForeground) return;
     this.cancelConnectionTimers();
     this.workspaceScope?.activity.pause();
-    this.publishAuthenticated(authenticated, { phase: "failed", trigger });
+    this.publishAuthenticated(
+      authenticated,
+      this.createConnectionFailureSnapshot(trigger, reasonCode, protocol)
+    );
+  }
+
+  private createConnectionFailureSnapshot(
+    trigger: MobileConnectionRecoveryTrigger,
+    reasonCode: MobileConnectionFailureReason,
+    protocol?: Pick<
+      AgentLiveConnectionFailure,
+      "expectedRevision" | "receivedRevision"
+    >
+  ): Extract<MobileConnectionSnapshot, { phase: "failed" }> {
+    return {
+      ...(protocol?.expectedRevision
+        ? { expectedRevision: protocol.expectedRevision }
+        : {}),
+      phase: "failed",
+      reasonCode,
+      ...(protocol?.receivedRevision
+        ? { receivedRevision: protocol.receivedRevision }
+        : {}),
+      trigger
+    };
   }
 
   private isConnectionRecoveryCurrent(
@@ -692,8 +786,17 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
       previousTrigger !== nextTrigger
     ) {
       this.ports.diagnostics.record({
+        ...(connection.phase === "failed" && connection.expectedRevision
+          ? { expectedRevision: connection.expectedRevision }
+          : {}),
         name: "device_connection.phase_changed",
         phase: connection.phase,
+        ...(connection.phase === "failed"
+          ? { reasonCode: connection.reasonCode }
+          : {}),
+        ...(connection.phase === "failed" && connection.receivedRevision
+          ? { receivedRevision: connection.receivedRevision }
+          : {}),
         ...(nextTrigger ? { trigger: nextTrigger } : {})
       });
     }
@@ -729,4 +832,12 @@ export class MobileApplicationService extends ObservableService<MobileApplicatio
     this.deviceLinkCloseTask = task;
     return task;
   }
+}
+
+function connectionFailureReason(
+  failure: AgentLiveConnectionFailure
+): MobileConnectionFailureReason {
+  return failure.reason === "protocol_revision_mismatch"
+    ? "protocol_revision_mismatch"
+    : "connection_unavailable";
 }

--- a/apps/mobile/src/services/servicePorts.ts
+++ b/apps/mobile/src/services/servicePorts.ts
@@ -68,8 +68,15 @@ export interface DeviceLinkPort {
 export type AgentLiveDelivery =
   | {
       kind: "connection";
-      reason?: string;
-      status: "connected" | "disconnected";
+      status: "connected";
+    }
+  | {
+      expectedRevision?: string;
+      kind: "connection";
+      reason: string;
+      receivedRevision?: string;
+      retryable: boolean;
+      status: "disconnected";
     }
   | {
       event: AgentActivityLiveEvent;
@@ -149,6 +156,9 @@ export type MobileDiagnosticEvent =
   | {
       name: "device_connection.phase_changed";
       phase: "connected" | "failed" | "idle" | "reconnecting" | "synchronizing";
+      expectedRevision?: string;
+      reasonCode?: "connection_unavailable" | "protocol_revision_mismatch";
+      receivedRevision?: string;
       trigger?:
         | "background_expired"
         | "foreground_resume"

--- a/apps/mobile/src/services/workspaceActivityService.ts
+++ b/apps/mobile/src/services/workspaceActivityService.ts
@@ -31,7 +31,11 @@ import {
   resolvePendingSubmission,
   type PendingSubmission
 } from "./pendingSubmission";
-import type { ClockPort, DeviceLinkPort } from "./servicePorts";
+import type {
+  AgentLiveDelivery,
+  ClockPort,
+  DeviceLinkPort
+} from "./servicePorts";
 import {
   createWorkspaceActivityEffectPort,
   executeWorkspaceActivityExtensionCommand
@@ -92,7 +96,13 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
     private readonly clock: ClockPort,
     private readonly currentUserId: string,
     deviceLink?: DeviceLinkPort,
-    private readonly onTransportConnectionChanged?: (connected: boolean) => void
+    private readonly onTransportConnectionChanged?: (
+      connected: boolean,
+      failure?: Extract<
+        AgentLiveDelivery,
+        { kind: "connection"; status: "disconnected" }
+      >
+    ) => void
   ) {
     super();
     this.requiresLiveTransport = deviceLink !== undefined;
@@ -148,7 +158,7 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
       isAvailable: () => !this.disposed && !this.paused,
       navigation: this.navigation,
       onActivityChanged: () => this.onDependencyChanged(),
-      onConnectionChanged: (connected) => {
+      onConnectionChanged: (connected, failure) => {
         this.setTransportConnected(connected);
         if (connected) {
           this.messagePollTask?.cancel();
@@ -156,7 +166,7 @@ export class WorkspaceActivityService extends ObservableService<WorkspaceActivit
         } else {
           this.scheduleMessagesPoll();
         }
-        this.onTransportConnectionChanged?.(connected);
+        this.onTransportConnectionChanged?.(connected, failure);
       },
       rail: this.rail,
       readCanonicalActivity: () =>

--- a/apps/mobile/src/services/workspaceAgentLiveLane.ts
+++ b/apps/mobile/src/services/workspaceAgentLiveLane.ts
@@ -25,7 +25,13 @@ interface WorkspaceAgentLiveLaneOptions {
   isAvailable(): boolean;
   navigation: WorkspaceNavigationService;
   onActivityChanged(): void;
-  onConnectionChanged(connected: boolean): void;
+  onConnectionChanged(
+    connected: boolean,
+    failure?: Extract<
+      AgentLiveDelivery,
+      { kind: "connection"; status: "disconnected" }
+    >
+  ): void;
   rail: WorkspaceConversationRailService;
   readCanonicalActivity(): AgentActivitySnapshot;
   workspaceId: string;
@@ -62,13 +68,22 @@ export class WorkspaceAgentLiveLane {
     this.retryTask = null;
     this.attachmentFence = null;
     const subscriptionGeneration = ++this.subscriptionGeneration;
-    this.subscription = this.options.deviceLink.subscribeAgentLive(
+    const subscription = this.options.deviceLink.subscribeAgentLive(
       this.options.workspaceId,
       (delivery) => {
         if (subscriptionGeneration !== this.subscriptionGeneration) return;
         this.handleDelivery(delivery);
       }
     );
+    if (
+      subscriptionGeneration !== this.subscriptionGeneration ||
+      !this.active ||
+      !this.options.isAvailable()
+    ) {
+      subscription.close();
+      return;
+    }
+    this.subscription = subscription;
   }
 
   stop(): void {
@@ -145,8 +160,10 @@ export class WorkspaceAgentLiveLane {
       this.coordinator.eventStreamConnectionChanged({
         status: "disconnected"
       });
-      this.setConnected(false, true);
-      this.scheduleRetry();
+      this.setConnected(false, true, delivery);
+      if (delivery.retryable) {
+        this.scheduleRetry();
+      }
       return;
     }
     if (delivery.kind === "session_deleted") {
@@ -286,15 +303,22 @@ export class WorkspaceAgentLiveLane {
     );
   }
 
-  private setConnected(connected: boolean, observedFailure = false): void {
+  private setConnected(
+    connected: boolean,
+    observedFailure = false,
+    failure?: Extract<
+      AgentLiveDelivery,
+      { kind: "connection"; status: "disconnected" }
+    >
+  ): void {
     if (this.connected !== connected) {
       this.connected = connected;
       this.options.rail.setLiveConnected(connected);
-      this.options.onConnectionChanged(connected);
+      this.options.onConnectionChanged(connected, failure);
       return;
     }
     if (observedFailure) {
-      this.options.onConnectionChanged(false);
+      this.options.onConnectionChanged(false, failure);
     }
   }
 }

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -162,6 +162,7 @@ CLI behavior, CI, package assets, skills, Browser Node, and terminal input.
 Android app login, native bridge, secure identity, and mobile transport diagnostics.
 
 - [Android QR scan closes without advancing pairing](./mobile.md#android-qr-scan-closes-without-advancing-pairing)
+- [Android stays on “Syncing the latest data” after pairing](./mobile.md#android-stays-on-syncing-the-latest-data-after-pairing)
 - [Android release bundling cannot resolve the JSX transform](./mobile.md#android-release-bundling-cannot-resolve-the-jsx-transform)
 - [Android update stays on MainActivity without opening the installer](./mobile.md#android-update-stays-on-mainactivity-without-opening-the-installer)
 - [Mobile quick prompts are missing from the plus menu](./mobile.md#mobile-quick-prompts-are-missing-from-the-plus-menu)

--- a/docs/conventions/troubleshooting/mobile.md
+++ b/docs/conventions/troubleshooting/mobile.md
@@ -1,5 +1,41 @@
 # Mobile Troubleshooting
 
+## Android stays on “Syncing the latest data” after pairing
+
+- **Symptom:** Device pairing and the direct DeviceLink handshake succeed, but
+  the mobile App remains on **Syncing the latest data**. The native log repeats
+  `Agent live stream rejected`, often once per retry interval.
+- **Quick checks:** Correlate the pairing ID and workspace across the phone and
+  computer logs. If DeviceLink reaches its connected stage and the Agent live
+  rejection reports `protocol_revision_mismatch`, compare the safe
+  `expectedRevision` and `receivedRevision` hashes. This is a protocol
+  compatibility failure, not a local-network or pairing failure.
+- **Root cause:** The computer rejects an Agent live subscription whose protocol
+  revision does not match its own. If the native rejection is collapsed into a
+  generic disconnect, the live lane treats a deterministic incompatibility as
+  transient and retries forever. Repeated disconnect callbacks can also keep
+  replacing the connection-ready deadline, so the App never reaches a visible
+  failed state.
+- **Fix:** Preserve the typed rejection reason and revision hashes through the
+  native bridge. Classify `protocol_revision_mismatch` as terminal for the
+  current connection attempt, close the rejected subscription without
+  scheduling another live retry, and keep the original synchronization
+  deadline for retryable transport failures. Present an explicit incompatible
+  version message with a mobile update action; do not automatically restart a
+  terminal attempt after foreground resume.
+- **Validation:** Verify an ordinary stream close still retries and rebuilds
+  DeviceLink after the recovery grace period. Inject a protocol-revision
+  rejection and assert that the connection enters the failed state once, emits
+  a `device_connection.phase_changed` diagnostic with stable
+  `protocol_revision_mismatch`, preserves both revision hashes, schedules no
+  additional subscription, and stays terminal across background and foreground
+  transitions. Confirm the failure UI offers **Check for updates** instead of
+  **Reconnect**.
+- **References:** `apps/mobile/src/native/agentLiveNativeBridge.ts`,
+  `apps/mobile/src/services/workspaceAgentLiveLane.ts`,
+  `apps/mobile/src/services/mobileApplicationService.ts`,
+  `apps/mobile/src/components/MobileConnectionRecoveryOverlay.tsx`
+
 ## Android QR scan closes without advancing pairing
 
 - **Symptom:** The pairing scanner opens, reads a valid Desktop QR code, and


### PR DESCRIPTION
## 背景

手机与电脑的 Agent live 协议版本不匹配时，电脑会拒绝订阅。移动端此前把确定性的协议拒绝折叠为普通断线并持续重试，导致界面长期停留在“正在同步最新数据”。

## 改动

- 保留 native rejection 的稳定原因以及 expected/received revision 摘要
- 将协议不兼容判定为当前连接尝试的终态，停止订阅重试、超时重置和前后台自动恢复
- 保留普通网络断开的短暂重试与 DeviceLink 恢复行为
- 在移动端展示明确的版本不兼容提示，并复用现有软件更新流程提供“检查手机更新”入口
- 防护 subscribeAgentLive 同步回调，避免过期订阅句柄阻塞重试
- 保留 workspace candidate 初始化阶段收到的终态拒绝
- 增加结构化诊断字段、异步/同步回调回归测试和移动端排障文档

## 验证

- `pnpm check:changed`
- `pnpm check:changed -- --push-ready`
- `pnpm check:i18n`
- 移动端聚焦测试：24/24 通过
