### PR TITLE
fix(agent-gui): show disabled reason for approval prompts

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -258,6 +258,12 @@ and early write admission for the pending card. An observation gap may still
 govern the active Turn before or after that Interaction, but it cannot override
 the exact ready or blocked readiness result while the card is presented.
 
+When an exact Interaction is blocked, AgentGUI keeps the pending action visible
+but disables its controls. The disabled action group remains focusable and
+hoverable so the same readiness reason is discoverable in the conversation
+chrome and Message Center; this is presentation only and does not change the
+Host-owned admission decision.
+
 Message Center and attention-card consumers preserve this separation in their
 presentation contract: `isSubmitting` describes an in-flight response, while
 an independently supplied interaction-disabled state blocks the nested prompt

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentInteractivePromptSurface.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentInteractivePromptSurface.spec.tsx
@@ -120,6 +120,47 @@ describe("AgentInteractivePromptSurface", () => {
     });
   });
 
+  it("shows the disabled reason when an approval control is hovered", async () => {
+    const reason = "The shared Agent owner is offline";
+    render(
+      <AgentInteractivePromptSurface
+        prompt={{
+          kind: "approval",
+          id: "approval:request-disabled",
+          turnId: "turn-1",
+          requestId: "request-disabled",
+          callId: "request-disabled",
+          title: "Run command",
+          status: "waiting_approval",
+          toolName: "Bash",
+          input: { command: "printf offline" },
+          options: [
+            {
+              id: "allow_once",
+              label: "Allow once",
+              kind: "allow_once"
+            }
+          ],
+          output: null,
+          occurredAtUnixMs: 1
+        }}
+        isSubmitting={false}
+        isInteractionDisabled
+        interactionDisabledReason={reason}
+        onSubmit={vi.fn()}
+        labels={labels}
+      />
+    );
+
+    const disabledGroup = screen.getByRole("group", { name: reason });
+    expect(screen.getByRole("button", { name: "Yes, proceed" })).toBeDisabled();
+    expect(disabledGroup.firstElementChild).toHaveClass("pointer-events-none");
+
+    fireEvent.pointerMove(disabledGroup);
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(reason);
+  });
+
   it("shows approval reasons and file-change paths below the title", () => {
     render(
       <AgentInteractivePromptSurface

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentSessionChrome.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentSessionChrome.spec.tsx
@@ -88,6 +88,34 @@ describe("AgentSessionChrome", () => {
     expect(onAuthLogin).toHaveBeenCalledTimes(1);
   });
 
+  it("explains why approval actions are disabled on hover", async () => {
+    const reason = "The shared Agent owner is offline";
+    render(
+      <AgentSessionChrome
+        approvalDisabledReason={reason}
+        chrome={chromeState()}
+        isRespondingApproval
+        onSubmitApprovalOption={vi.fn()}
+        onRetryActivation={vi.fn()}
+        onContinueInNewConversation={vi.fn()}
+        labels={{
+          approvalRequired: "Approval required",
+          authRequired: "Authentication required",
+          activatingSession: "Connecting session...",
+          retryActivation: "Retry",
+          continueInNewConversation: "Continue in new session"
+        }}
+      />
+    );
+
+    const disabledGroup = screen.getByRole("group", { name: reason });
+    expect(screen.getByRole("button", { name: "Yes, proceed" })).toBeDisabled();
+
+    fireEvent.pointerMove(disabledGroup);
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(reason);
+  });
+
   it("offers login without manual retry for authentication failures", () => {
     const onAuthLogin = vi.fn();
     const onRetryActivation = vi.fn();

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentSessionChrome.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentSessionChrome.tsx
@@ -1,5 +1,11 @@
 import { type JSX, type ReactNode } from "react";
-import { Button } from "@tutti-os/ui-system";
+import {
+  Button,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger
+} from "@tutti-os/ui-system";
 import { CastIcon } from "../../app/renderer/components/icons/CastIcon";
 import { cn } from "../../app/renderer/lib/utils";
 import { approvalOptionDisplayLabel } from "../../shared/agentConversation/approvalOptionPresentation";
@@ -18,6 +24,7 @@ interface AgentChromeNoticeProps {
 
 interface AgentSessionChromeProps {
   chrome: AgentGUISessionChrome;
+  approvalDisabledReason?: string | null;
   isRespondingApproval: boolean;
   onSubmitApprovalOption: (input: AgentInteractionResponseInput) => boolean;
   onAuthLogin?: () => void;
@@ -105,6 +112,7 @@ export function AgentChromeNotice({
 
 export function AgentSessionChrome({
   chrome,
+  approvalDisabledReason = null,
   isRespondingApproval,
   onSubmitApprovalOption,
   onAuthLogin,
@@ -172,29 +180,36 @@ export function AgentSessionChrome({
         <section className={cn(styles.chromeCard, styles.chromeCardAction)}>
           <div className={styles.chromeTitle}>{labels.approvalRequired}</div>
           <p className={styles.chromeMessage}>{chrome.approval.title}</p>
-          <div className={styles.chromeActions}>
-            {chrome.approval.options.map((option) => (
-              <button
-                key={option.id}
-                type="button"
-                disabled={isRespondingApproval}
-                onClick={() =>
-                  onSubmitApprovalOption({
-                    ...(chrome.approval?.agentSessionId
-                      ? { agentSessionId: chrome.approval.agentSessionId }
-                      : {}),
-                    optionId: option.id,
-                    requestId: chrome.approval?.requestId ?? "",
-                    ...(chrome.approval?.turnId
-                      ? { turnId: chrome.approval.turnId }
-                      : {})
-                  })
-                }
-              >
-                {approvalOptionDisplayLabel(option)}
-              </button>
-            ))}
-          </div>
+          <DisabledApprovalActions reason={approvalDisabledReason}>
+            <div className={styles.chromeActions}>
+              {chrome.approval.options.map((option) => (
+                <button
+                  key={option.id}
+                  type="button"
+                  className={
+                    approvalDisabledReason?.trim()
+                      ? "pointer-events-none"
+                      : undefined
+                  }
+                  disabled={isRespondingApproval}
+                  onClick={() =>
+                    onSubmitApprovalOption({
+                      ...(chrome.approval?.agentSessionId
+                        ? { agentSessionId: chrome.approval.agentSessionId }
+                        : {}),
+                      optionId: option.id,
+                      requestId: chrome.approval?.requestId ?? "",
+                      ...(chrome.approval?.turnId
+                        ? { turnId: chrome.approval.turnId }
+                        : {})
+                    })
+                  }
+                >
+                  {approvalOptionDisplayLabel(option)}
+                </button>
+              ))}
+            </div>
+          </DisabledApprovalActions>
         </section>
       ) : null}
 
@@ -304,5 +319,48 @@ export function AgentSessionChrome({
         </section>
       ) : null}
     </div>
+  );
+}
+
+function DisabledApprovalActions({
+  children,
+  reason
+}: {
+  children: ReactNode;
+  reason?: string | null;
+}): JSX.Element {
+  const normalizedReason = reason?.trim() ?? "";
+  const actions = (
+    <div
+      aria-disabled={normalizedReason ? "true" : undefined}
+      aria-label={normalizedReason || undefined}
+      className={cn(
+        normalizedReason && "cursor-not-allowed rounded-md outline-none"
+      )}
+      data-agent-interaction-disabled={normalizedReason ? "true" : undefined}
+      role={normalizedReason ? "group" : undefined}
+      tabIndex={normalizedReason ? 0 : undefined}
+    >
+      {children}
+    </div>
+  );
+
+  if (!normalizedReason) {
+    return actions;
+  }
+
+  return (
+    <TooltipProvider delayDuration={120} skipDelayDuration={0}>
+      <Tooltip>
+        <TooltipTrigger asChild>{actions}</TooltipTrigger>
+        <TooltipContent
+          side="top"
+          align="start"
+          className="max-w-[min(360px,calc(100vw-32px))] whitespace-normal text-left [overflow-wrap:anywhere]"
+        >
+          {normalizedReason}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
@@ -138,6 +138,8 @@ export interface AgentComposerProps {
   draftOverridesStopButton?: boolean;
   stopDisabled: boolean;
   activePrompt: AgentConversationPromptVM | null;
+  /** Host readiness reason for the active prompt's disabled controls. */
+  activePromptDisabledReason?: string | null;
   activePromptKeyboardShortcutsEnabled?: boolean;
   promptTips?: readonly AgentComposerPromptTip[];
   isInterrupting: boolean;

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerView.tsx
@@ -127,6 +127,7 @@ export function AgentComposerView(input: Props): React.JSX.Element {
     queuedPrompts,
     drainingQueuedPromptId,
     workspaceAppIcons = EMPTY_WORKSPACE_APP_ICONS,
+    activePromptDisabledReason = null,
     activePromptKeyboardShortcutsEnabled = true,
     promptImagesSupported = true,
     layoutMode = "dock",
@@ -292,6 +293,8 @@ export function AgentComposerView(input: Props): React.JSX.Element {
             edgeGlow={true}
             keyboardShortcuts={activePromptKeyboardShortcutsEnabled}
             isSubmitting={isSubmittingPrompt}
+            isInteractionDisabled={Boolean(activePromptDisabledReason)}
+            interactionDisabledReason={activePromptDisabledReason}
             onSubmit={submitInteractivePromptAndDismiss}
             labels={{
               approvalLead: labels.approvalLead,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.ts
@@ -24,6 +24,7 @@ import type { AgentSessionState } from "../../../shared/agentSessionTypes";
 import type { AppErrorCode } from "../../../shared/contracts/dto";
 import type {
   AgentGUIObservationGapSource,
+  AgentGUIInteractionReadinessReason,
   AgentGUIInteractionReadinessSource,
   AgentGUITargetConnectionSource
 } from "../../../types";
@@ -687,13 +688,33 @@ export function useAgentGUISessionPresentation(
     pendingInteractivePrompt
   ]);
   return {
+    approvalDisabledReason: approvalReadiness.block
+      ? interactionReadinessReasonMessage(approvalReadiness.block.reason)
+      : null,
     activeConversationBusy,
     composerGate,
     hasSentUserMessage,
+    interactivePromptDisabledReason: interactiveReadiness.block
+      ? interactionReadinessReasonMessage(interactiveReadiness.block.reason)
+      : null,
     isRespondingApproval,
     isRespondingInteractivePrompt,
     pendingApproval,
     pendingInteractivePrompt,
     sessionChrome
   };
+}
+
+function interactionReadinessReasonMessage(
+  reason: AgentGUIInteractionReadinessReason
+): string {
+  switch (reason) {
+    case "owner_offline":
+      return translate("agentHost.agentGui.interactionOwnerOffline");
+    case "binding_revoked":
+      return translate("agentHost.agentGui.interactionBindingRevoked");
+    case "synchronizing":
+    default:
+      return translate("agentHost.agentGui.interactionSynchronizing");
+  }
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIViewAssembly.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIViewAssembly.ts
@@ -264,6 +264,8 @@ export function useAgentGUIViewAssembly(input: UseAgentGUIViewAssemblyInput) {
       drainingQueuedPromptId: detail.drainingQueuedPromptId
     },
     interaction: {
+      approvalDisabledReason: session.approvalDisabledReason,
+      interactivePromptDisabledReason: session.interactivePromptDisabledReason,
       isRespondingApproval: session.isRespondingApproval,
       isRespondingInteractivePrompt: session.isRespondingInteractivePrompt,
       pendingApproval: session.pendingApproval,

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/AgentGUINodeViewModel.fixture.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/AgentGUINodeViewModel.fixture.ts
@@ -81,6 +81,9 @@ export function groupAgentGUINodeViewModelFixture(
       drainingQueuedPromptId: flat.drainingQueuedPromptId
     },
     interaction: {
+      approvalDisabledReason: flat.approvalDisabledReason ?? null,
+      interactivePromptDisabledReason:
+        flat.interactivePromptDisabledReason ?? null,
       isRespondingApproval: flat.isRespondingApproval,
       isRespondingInteractivePrompt:
         flat.isRespondingInteractivePrompt ?? flat.isRespondingApproval,

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
@@ -509,6 +509,8 @@ export interface AgentGUIComposerViewModel {
 }
 
 export interface AgentGUIInteractionViewModel {
+  approvalDisabledReason: string | null;
+  interactivePromptDisabledReason: string | null;
   isRespondingApproval: boolean;
   isRespondingInteractivePrompt: boolean;
   pendingApproval: AgentGUIApprovalRequest | null;

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/useAgentGUIViewModel.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/useAgentGUIViewModel.ts
@@ -77,6 +77,8 @@ export function useAgentGUIViewModel(
     () => candidate.interaction,
     [
       candidate.interaction.inlineNotice,
+      candidate.interaction.approvalDisabledReason,
+      candidate.interaction.interactivePromptDisabledReason,
       candidate.interaction.isRespondingApproval,
       candidate.interaction.isRespondingInteractivePrompt,
       candidate.interaction.pendingApproval,

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIBottomDockPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIBottomDockPane.tsx
@@ -102,6 +102,15 @@ export const AgentGUIBottomDockPane = memo(function AgentGUIBottomDockPane({
 }: AgentGUIBottomDockPaneProps): React.JSX.Element {
   "use memo";
 
+  const liftedPromptDisabledReason =
+    bottomDockLiftedPrompt?.kind === "approval"
+      ? approvalDisabledReason
+      : interactivePromptDisabledReason;
+  const replacementPromptDisabledReason =
+    bottomDockReplacementPrompt?.kind === "approval"
+      ? approvalDisabledReason
+      : interactivePromptDisabledReason;
+
   // Active thread goal rides the same runtimeContext channel as account /
   // rateLimits, so we read it straight off the session chrome's raw state.
   const goal = objectRecord(sessionChrome.rawState?.goal);
@@ -152,8 +161,8 @@ export const AgentGUIBottomDockPane = memo(function AgentGUIBottomDockPane({
               edgeGlow={true}
               keyboardShortcuts={keyboardShortcutsEnabled}
               isSubmitting={isRespondingApproval}
-              isInteractionDisabled={Boolean(interactivePromptDisabledReason)}
-              interactionDisabledReason={interactivePromptDisabledReason}
+              isInteractionDisabled={Boolean(liftedPromptDisabledReason)}
+              interactionDisabledReason={liftedPromptDisabledReason}
               onSubmit={onSubmitBottomDockInteractivePrompt}
               labels={promptLabels}
             />
@@ -263,8 +272,8 @@ export const AgentGUIBottomDockPane = memo(function AgentGUIBottomDockPane({
               edgeGlow={true}
               keyboardShortcuts={keyboardShortcutsEnabled}
               isSubmitting={isRespondingApproval}
-              isInteractionDisabled={Boolean(interactivePromptDisabledReason)}
-              interactionDisabledReason={interactivePromptDisabledReason}
+              isInteractionDisabled={Boolean(replacementPromptDisabledReason)}
+              interactionDisabledReason={replacementPromptDisabledReason}
               onSubmit={onSubmitBottomDockInteractivePrompt}
               labels={promptLabels}
             />

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIBottomDockPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIBottomDockPane.tsx
@@ -47,6 +47,8 @@ interface AgentGUIBottomDockPaneProps {
     | AgentGUINodeViewModel["interaction"]["pendingApproval"]
     | AgentGUINodeViewModel["interaction"]["pendingInteractivePrompt"];
   composerProps: AgentComposerProps;
+  approvalDisabledReason: string | null;
+  interactivePromptDisabledReason: string | null;
   inlineNoticeChrome: AgentGUISessionChrome | null;
   isRespondingApproval: boolean;
   sessionChrome: AgentGUISessionChrome;
@@ -76,6 +78,8 @@ export const AgentGUIBottomDockPane = memo(function AgentGUIBottomDockPane({
   bottomDockLiftedPrompt,
   bottomDockReplacementPrompt,
   composerProps,
+  approvalDisabledReason,
+  interactivePromptDisabledReason,
   inlineNoticeChrome,
   isRespondingApproval,
   sessionChrome,
@@ -148,6 +152,8 @@ export const AgentGUIBottomDockPane = memo(function AgentGUIBottomDockPane({
               edgeGlow={true}
               keyboardShortcuts={keyboardShortcutsEnabled}
               isSubmitting={isRespondingApproval}
+              isInteractionDisabled={Boolean(interactivePromptDisabledReason)}
+              interactionDisabledReason={interactivePromptDisabledReason}
               onSubmit={onSubmitBottomDockInteractivePrompt}
               labels={promptLabels}
             />
@@ -159,6 +165,7 @@ export const AgentGUIBottomDockPane = memo(function AgentGUIBottomDockPane({
           {inlineNoticeChrome ? (
             <AgentSessionChrome
               chrome={inlineNoticeChrome}
+              approvalDisabledReason={approvalDisabledReason}
               isRespondingApproval={isRespondingApproval}
               onSubmitApprovalOption={onSubmitApprovalOption}
               onAuthLogin={onAuthLogin}
@@ -169,6 +176,7 @@ export const AgentGUIBottomDockPane = memo(function AgentGUIBottomDockPane({
           ) : null}
           <AgentSessionChrome
             chrome={sessionChrome}
+            approvalDisabledReason={approvalDisabledReason}
             isRespondingApproval={isRespondingApproval}
             onSubmitApprovalOption={onSubmitApprovalOption}
             onAuthLogin={onAuthLogin}
@@ -255,6 +263,8 @@ export const AgentGUIBottomDockPane = memo(function AgentGUIBottomDockPane({
               edgeGlow={true}
               keyboardShortcuts={keyboardShortcutsEnabled}
               isSubmitting={isRespondingApproval}
+              isInteractionDisabled={Boolean(interactivePromptDisabledReason)}
+              interactionDisabledReason={interactivePromptDisabledReason}
               onSubmit={onSubmitBottomDockInteractivePrompt}
               labels={promptLabels}
             />

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIBottomDockPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIBottomDockPane.tsx
@@ -15,6 +15,7 @@ import {
   TuttiWorkflowDock,
   type TuttiWorkflowDockLabels
 } from "../TuttiWorkflowDock";
+import { resolveAgentGUIInteractionDisabledReason } from "./agentGUIDetailModelHelpers";
 import type {
   TuttiModePlanPanelLabels,
   TuttiPlanIssuePanelLabels
@@ -102,14 +103,17 @@ export const AgentGUIBottomDockPane = memo(function AgentGUIBottomDockPane({
 }: AgentGUIBottomDockPaneProps): React.JSX.Element {
   "use memo";
 
-  const liftedPromptDisabledReason =
-    bottomDockLiftedPrompt?.kind === "approval"
-      ? approvalDisabledReason
-      : interactivePromptDisabledReason;
+  const liftedPromptDisabledReason = resolveAgentGUIInteractionDisabledReason({
+    promptKind: bottomDockLiftedPrompt?.kind,
+    approvalReason: approvalDisabledReason,
+    interactivePromptReason: interactivePromptDisabledReason
+  });
   const replacementPromptDisabledReason =
-    bottomDockReplacementPrompt?.kind === "approval"
-      ? approvalDisabledReason
-      : interactivePromptDisabledReason;
+    resolveAgentGUIInteractionDisabledReason({
+      promptKind: bottomDockReplacementPrompt?.kind,
+      approvalReason: approvalDisabledReason,
+      interactivePromptReason: interactivePromptDisabledReason
+    });
 
   // Active thread goal rides the same runtimeContext channel as account /
   // rateLimits, so we read it straight off the session chrome's raw state.

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
@@ -9,6 +9,7 @@ import { resolveAgentComposerDraftScopeKey } from "../model/agentComposerDraftSc
 import {
   buildAgentConversationHandoffPrompt,
   handoffProjectPathForConversation,
+  resolveAgentGUIInteractionDisabledReason,
   resolveAgentGUITuttiStopTargets
 } from "./agentGUIDetailModelHelpers";
 import { AgentGUIBottomDockPane } from "./AgentGUIBottomDockPane";
@@ -310,6 +311,13 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
     [submitInteractivePrompt]
   );
   const isInteractionPending = activePromptResponsePending;
+  const composerActivePromptDisabledReason =
+    resolveAgentGUIInteractionDisabledReason({
+      promptKind: composerActivePrompt?.kind,
+      approvalReason: viewModel.interaction.approvalDisabledReason,
+      interactivePromptReason:
+        viewModel.interaction.interactivePromptDisabledReason
+    });
   const homeComposerProviderTargets = homeTargetProjection.agentTargets;
   const selectedHomeComposerTarget = homeTargetProjection.selectedAgentTarget;
   const composerProviderTargets =
@@ -425,6 +433,7 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       workspaceReferencePickerOpen,
       referenceProvenanceFilters,
       activePrompt: composerActivePrompt,
+      activePromptDisabledReason: composerActivePromptDisabledReason,
       activePromptKeyboardShortcutsEnabled: isActive,
       promptTips: labels.promptTips,
       composerFocusRequestSequence,
@@ -526,6 +535,7 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       onSlashStatusRefresh,
       workspaceReferencePickerOpen,
       composerActivePrompt,
+      composerActivePromptDisabledReason,
       editQueuedPrompt,
       onCapabilitySettingsRequest,
       removeQueuedPrompt,

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
@@ -736,6 +736,10 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
           bottomDockLiftedPrompt={bottomDockLiftedPrompt}
           bottomDockReplacementPrompt={bottomDockReplacementPrompt}
           composerProps={bottomDockComposerProps}
+          approvalDisabledReason={viewModel.interaction.approvalDisabledReason}
+          interactivePromptDisabledReason={
+            viewModel.interaction.interactivePromptDisabledReason
+          }
           inlineNoticeChrome={inlineNoticeChrome}
           isRespondingApproval={isInteractionPending}
           sessionChrome={sessionChrome}

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.spec.ts
@@ -4,6 +4,7 @@ import {
   handoffProjectPathForConversation,
   isAgentGUIHomeStatusNoticeVisible,
   resolveAgentGUITuttiStopTargets,
+  resolveAgentGUIInteractionDisabledReason,
   resolveAgentGUIHomeNoticeChrome,
   resolveAgentGUIStopControl,
   shouldShowAgentGUIStopButton
@@ -82,6 +83,38 @@ describe("shouldShowAgentGUIStopButton", () => {
         isCreatingConversation: true
       })
     ).toBe(false);
+  });
+});
+
+describe("resolveAgentGUIInteractionDisabledReason", () => {
+  it("uses the approval reason for approval prompts", () => {
+    expect(
+      resolveAgentGUIInteractionDisabledReason({
+        promptKind: "approval",
+        approvalReason: "The shared Agent owner is offline",
+        interactivePromptReason: "The shared Agent caller is offline"
+      })
+    ).toBe("The shared Agent owner is offline");
+  });
+
+  it("uses the interactive prompt reason for non-approval prompts", () => {
+    expect(
+      resolveAgentGUIInteractionDisabledReason({
+        promptKind: "ask-user",
+        approvalReason: "The shared Agent owner is offline",
+        interactivePromptReason: "The shared Agent caller is offline"
+      })
+    ).toBe("The shared Agent caller is offline");
+  });
+
+  it("does not expose a reason when there is no active prompt", () => {
+    expect(
+      resolveAgentGUIInteractionDisabledReason({
+        promptKind: null,
+        approvalReason: "The shared Agent owner is offline",
+        interactivePromptReason: "The shared Agent caller is offline"
+      })
+    ).toBeNull();
   });
 });
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.ts
@@ -2,7 +2,10 @@ import { useRef } from "react";
 import { normalizeOptionalWorkspaceAgentStatus } from "../../../shared/workspaceAgentStatusNormalizer";
 import type { UiLanguage } from "../../../contexts/settings/domain/agentSettings";
 import type { AgentMessageMarkdownWorkspaceAppIcon } from "../../../shared/AgentMessageMarkdown";
-import type { AgentConversationVM } from "../../../shared/agentConversation/contracts/agentConversationVM";
+import type {
+  AgentConversationPromptVM,
+  AgentConversationVM
+} from "../../../shared/agentConversation/contracts/agentConversationVM";
 import { createAgentSessionHandoffPrompt } from "../agentRichText/agentFileMentionExtension";
 import type {
   AgentComposerSlashStatus,
@@ -255,6 +258,19 @@ export function isAgentGUIHomeStatusNoticeVisible(
     recovery?.kind === "transport-connecting" ||
     recovery?.kind === "transport-unavailable"
   );
+}
+
+export function resolveAgentGUIInteractionDisabledReason(input: {
+  promptKind: AgentConversationPromptVM["kind"] | null | undefined;
+  approvalReason: string | null;
+  interactivePromptReason: string | null;
+}): string | null {
+  if (input.promptKind === null || input.promptKind === undefined) {
+    return null;
+  }
+  return input.promptKind === "approval"
+    ? input.approvalReason
+    : input.interactivePromptReason;
 }
 
 export function resolveAgentGUIHomeNoticeChrome(input: {

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGuiRuntimeNotices.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGuiRuntimeNotices.ts
@@ -56,5 +56,9 @@ export const enAgentGuiRuntimeNotices = {
     "Connection to {{device}} was lost. The system will retry automatically.",
   runtimeUnavailableActive:
     "Connection to {{device}} was lost. Sending and stopping are temporarily unavailable; the task may still be running on the device.",
-  runtimeSynchronizingProgress: "Synchronizing the latest task progress…"
+  runtimeSynchronizingProgress: "Synchronizing the latest task progress…",
+  interactionSynchronizing:
+    "The shared Agent state is synchronizing. Try again in a moment.",
+  interactionOwnerOffline: "The shared Agent owner is offline",
+  interactionBindingRevoked: "The shared Agent is no longer available"
 } as const;

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGuiRuntimeNotices.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGuiRuntimeNotices.ts
@@ -48,5 +48,8 @@ export const zhCNAgentGuiRuntimeNotices = {
   runtimeUnavailable: "与 {{device}} 的连接已断开，系统将自动重试",
   runtimeUnavailableActive:
     "与 {{device}} 的连接已断开，暂时无法发送或停止；任务可能仍在设备上运行",
-  runtimeSynchronizingProgress: "正在同步最新任务进度…"
+  runtimeSynchronizingProgress: "正在同步最新任务进度…",
+  interactionSynchronizing: "正在同步共享 Agent 状态，请稍后重试",
+  interactionOwnerOffline: "共享 Agent 的 Owner 当前离线",
+  interactionBindingRevoked: "共享 Agent 已失效，暂不可操作"
 } as const;

--- a/packages/agent/gui/shared/agentConversation/components/AgentInteractivePromptSurface.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentInteractivePromptSurface.tsx
@@ -159,7 +159,10 @@ export function AgentInteractivePromptSurface({
             role="group"
             tabIndex={0}
           >
-            {promptSurface}
+            {/* Disabled form controls do not reliably dispatch pointer events.
+                Keep the actual prompt out of hit testing so the wrapper can
+                receive hover/focus events and expose the disabled reason. */}
+            <div className="pointer-events-none">{promptSurface}</div>
           </div>
         </TooltipTrigger>
         <TooltipContent

--- a/packages/agent/gui/shared/agentConversation/components/AgentInteractivePromptSurface.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentInteractivePromptSurface.tsx
@@ -1,4 +1,10 @@
 import type { JSX } from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger
+} from "@tutti-os/ui-system";
 import type {
   AgentConversationPromptVM,
   AgentInteractionResponseInput
@@ -28,6 +34,7 @@ export interface AgentInteractivePromptSurfaceProps {
   keyboardShortcuts?: boolean;
   isSubmitting: boolean;
   isInteractionDisabled?: boolean;
+  interactionDisabledReason?: string | null;
   onSubmit: (input: AgentInteractionResponseInput) => boolean | void;
   labels: {
     approvalLead: string;
@@ -58,6 +65,7 @@ export function AgentInteractivePromptSurface({
   keyboardShortcuts = true,
   isSubmitting,
   isInteractionDisabled = false,
+  interactionDisabledReason = null,
   onSubmit,
   labels
 }: AgentInteractivePromptSurfaceProps & {
@@ -78,8 +86,9 @@ export function AgentInteractivePromptSurface({
     });
   };
 
+  let promptSurface: JSX.Element;
   if (prompt.kind === "approval") {
-    return (
+    promptSurface = (
       <ApprovalPromptSurface
         prompt={prompt}
         embedded={embedded}
@@ -91,9 +100,8 @@ export function AgentInteractivePromptSurface({
         labels={labels}
       />
     );
-  }
-  if (prompt.kind === "exit-plan") {
-    return (
+  } else if (prompt.kind === "exit-plan") {
+    promptSurface = (
       <ExitPlanPromptSurface
         prompt={prompt}
         variant={variant}
@@ -105,9 +113,8 @@ export function AgentInteractivePromptSurface({
         labels={labels}
       />
     );
-  }
-  if (prompt.kind === "plan-implementation") {
-    return (
+  } else if (prompt.kind === "plan-implementation") {
+    promptSurface = (
       <PlanImplementationSurface
         prompt={prompt}
         variant={variant}
@@ -119,18 +126,50 @@ export function AgentInteractivePromptSurface({
         labels={labels}
       />
     );
+  } else {
+    promptSurface = (
+      <AgentAskUserPromptSurface
+        key={prompt.requestId}
+        prompt={prompt}
+        variant={variant}
+        embedded={embedded}
+        edgeGlow={edgeGlow}
+        isSubmitting={isSubmitting}
+        isInteractionDisabled={isInteractionDisabled}
+        onSubmit={submitPrompt}
+        labels={labels}
+      />
+    );
   }
+
+  const normalizedReason = interactionDisabledReason?.trim() ?? "";
+  if (!isInteractionDisabled || !normalizedReason) {
+    return promptSurface;
+  }
+
   return (
-    <AgentAskUserPromptSurface
-      key={prompt.requestId}
-      prompt={prompt}
-      variant={variant}
-      embedded={embedded}
-      edgeGlow={edgeGlow}
-      isSubmitting={isSubmitting}
-      isInteractionDisabled={isInteractionDisabled}
-      onSubmit={submitPrompt}
-      labels={labels}
-    />
+    <TooltipProvider delayDuration={120} skipDelayDuration={0}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            aria-disabled="true"
+            aria-label={normalizedReason}
+            className="cursor-not-allowed rounded-md outline-none"
+            data-agent-interaction-disabled="true"
+            role="group"
+            tabIndex={0}
+          >
+            {promptSurface}
+          </div>
+        </TooltipTrigger>
+        <TooltipContent
+          side="top"
+          align="start"
+          className="max-w-[min(360px,calc(100vw-32px))] whitespace-normal text-left [overflow-wrap:anywhere]"
+        >
+          {normalizedReason}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }


### PR DESCRIPTION
## 变更

- 为 Composer 内嵌的审批和交互 prompt 传递对应的禁用原因
- 抽取统一的 prompt 类型到禁用原因映射逻辑，供 Bottom Dock 和 Composer 共用
- 保留禁用 prompt 的 hover/focus 提示能力
- 增加映射逻辑和禁用审批 Tooltip 的回归测试

## 验证

- AgentGUI 全量测试：312 个测试文件、2714 个用例通过
- AgentGUI typecheck 通过
- 提交钩子和 push 检查通过

## 范围

- 不修改独立的断连恢复稳定性问题
- 当前 PR 保持 Draft，等待 review 和 CI