### PR TITLE
fix(agent-gui): recover shared composer options loading

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -896,6 +896,14 @@ while canonical Turn state remains authoritative once it exists.
   Mobile retain transport execution in their `EngineExtensionCommand`
   adapters and delegate pure generated-DTO projection to
   `@tutti-os/agent-activity-tuttid-adapter`
+- A composer-option failure with no signature-matching cached value remains an
+  explicit Engine `error` state. AgentGUI renders a compact failure and retry
+  action in the existing options slot instead of presenting an empty list or a
+  stale/default selection; a last valid cached value remains renderable while
+  its load status is reconciled. The retry is the same semantic
+  `engine.loadComposerOptions` operation with `force` left false, so request
+  identity, cache reuse, and identical in-flight joining remain Engine-owned;
+  a view must not call the transport adapter directly.
 - an acknowledged home Composer default remains an optimistic draft until a
   later authoritative Composer-options response reports the same effective
   field value. A successful read alone must not retire the draft because a

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerModelReasoningDropdown.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerModelReasoningDropdown.tsx
@@ -21,6 +21,7 @@ import {
   RoomsHintIcon,
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
   cn
 } from "@tutti-os/ui-system";
@@ -83,6 +84,7 @@ export function AgentModelReasoningDropdown({
   disabled = false,
   labels,
   modelHistoryTargetId = null,
+  onRetryComposerOptions,
   onSettingsChange
 }: {
   composerSettings: AgentGUIComposerSettingsVM;
@@ -93,6 +95,7 @@ export function AgentModelReasoningDropdown({
    * state; omit to fall back to one shared "default" bucket.
    */
   modelHistoryTargetId?: string | null;
+  onRetryComposerOptions?: () => void;
   onSettingsChange: (patch: {
     model?: string;
     reasoningEffort?: string;
@@ -153,6 +156,13 @@ export function AgentModelReasoningDropdown({
   const isModelLoading =
     composerSettings.isModelOptionsLoading ||
     composerSettings.isSettingsLoading;
+  const composerOptionsError = composerSettings.composerOptionsError === true;
+  const retryLabel = labels.retry ?? labels.loadingOptions;
+  const retryDisabled =
+    disabled ||
+    composerSettings.composerOptionsLoadStatus === "loading" ||
+    !onRetryComposerOptions;
+  const triggerDisabled = composerOptionsError ? retryDisabled : menuDisabled;
   const applySettingsChange = (patch: {
     model?: string;
     reasoningEffort?: string;
@@ -195,17 +205,33 @@ export function AgentModelReasoningDropdown({
       className={cn(
         "w-auto",
         styles.composerMenuTrigger,
-        menuDisabled &&
+        triggerDisabled &&
           "cursor-not-allowed text-[var(--agent-gui-text-tertiary)] opacity-60 hover:text-[var(--agent-gui-text-tertiary)]",
-        (composerSettings.isSettingsLoading ||
-          composerSettings.isModelOptionsLoading) &&
+        !composerOptionsError &&
+          (composerSettings.isSettingsLoading ||
+            composerSettings.isModelOptionsLoading) &&
           "animate-pulse"
       )}
-      aria-label={`${labels.modelLabel} / ${labels.reasoningLabel}`}
+      aria-label={
+        composerOptionsError
+          ? retryLabel
+          : `${labels.modelLabel} / ${labels.reasoningLabel}`
+      }
+      disabled={triggerDisabled}
+      onClick={
+        composerOptionsError && !retryDisabled
+          ? onRetryComposerOptions
+          : undefined
+      }
       data-agent-model-reasoning-trigger="true"
+      data-agent-composer-options-state={
+        composerOptionsError ? "error" : undefined
+      }
     >
       <span className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
-        {menu.speed.show && menu.trigger.isFast ? (
+        {composerOptionsError ? (
+          <span className="min-w-0 truncate">{retryLabel}</span>
+        ) : menu.speed.show && menu.trigger.isFast ? (
           <ZapIcon
             aria-hidden
             className="size-3.5 shrink-0"
@@ -222,9 +248,29 @@ export function AgentModelReasoningDropdown({
           </>
         )}
       </span>
-      <ChevronDown aria-hidden="true" className="shrink-0" size={16} />
+      {!composerOptionsError ? (
+        <ChevronDown aria-hidden="true" className="shrink-0" size={16} />
+      ) : null}
     </button>
   );
+
+  if (composerOptionsError) {
+    return (
+      <TooltipProvider delayDuration={120}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span
+              className="inline-flex"
+              tabIndex={retryDisabled ? 0 : undefined}
+            >
+              {trigger}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="top">{retryLabel}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
 
   return (
     <DropdownMenu open={menuOpen} onOpenChange={handleMenuOpenChange}>

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerModelReasoningDropdown.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerModelReasoningDropdown.tsx
@@ -18,6 +18,7 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
+  RefreshIcon,
   RoomsHintIcon,
   Tooltip,
   TooltipContent,
@@ -158,6 +159,8 @@ export function AgentModelReasoningDropdown({
     composerSettings.isSettingsLoading;
   const composerOptionsError = composerSettings.composerOptionsError === true;
   const retryLabel = labels.retry ?? labels.loadingOptions;
+  const optionsLoadFailed = labels.optionsLoadFailed ?? retryLabel;
+  const retryTooltip = labels.retryTooltip ?? retryLabel;
   const retryDisabled =
     disabled ||
     composerSettings.composerOptionsLoadStatus === "loading" ||
@@ -207,6 +210,9 @@ export function AgentModelReasoningDropdown({
         styles.composerMenuTrigger,
         triggerDisabled &&
           "cursor-not-allowed text-[var(--agent-gui-text-tertiary)] opacity-60 hover:text-[var(--agent-gui-text-tertiary)]",
+        composerOptionsError &&
+          !retryDisabled &&
+          "!text-[var(--state-warning)] hover:!text-[var(--state-warning)]",
         !composerOptionsError &&
           (composerSettings.isSettingsLoading ||
             composerSettings.isModelOptionsLoading) &&
@@ -228,23 +234,50 @@ export function AgentModelReasoningDropdown({
         composerOptionsError ? "error" : undefined
       }
     >
-      <span className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
+      <span
+        className={cn(
+          "flex min-w-0 items-center gap-2 overflow-hidden",
+          composerOptionsError ? "flex-none" : "flex-1"
+        )}
+      >
         {composerOptionsError ? (
-          <span className="min-w-0 truncate">{retryLabel}</span>
-        ) : menu.speed.show && menu.trigger.isFast ? (
-          <ZapIcon
-            aria-hidden
-            className="size-3.5 shrink-0"
-            data-agent-speed-indicator="fast"
-            strokeWidth={2.5}
-          />
-        ) : null}
-        {menu.trigger.showCombined ? (
-          <span className="min-w-0 truncate">{menu.trigger.combinedLabel}</span>
+          <>
+            <RefreshIcon
+              aria-hidden
+              className={cn(
+                "size-3.5 shrink-0",
+                retryDisabled
+                  ? "text-[var(--agent-gui-text-tertiary)]"
+                  : "text-[var(--state-warning)]"
+              )}
+              data-agent-composer-options-retry-icon="true"
+            />
+            <span className="shrink-0 whitespace-nowrap">
+              {optionsLoadFailed}
+            </span>
+          </>
         ) : (
           <>
-            <span className="min-w-0 truncate">{menu.trigger.modelLabel}</span>
-            <span className="shrink-0">{menu.trigger.reasoningLabel}</span>
+            {menu.speed.show && menu.trigger.isFast ? (
+              <ZapIcon
+                aria-hidden
+                className="size-3.5 shrink-0"
+                data-agent-speed-indicator="fast"
+                strokeWidth={2.5}
+              />
+            ) : null}
+            {menu.trigger.showCombined ? (
+              <span className="min-w-0 truncate">
+                {menu.trigger.combinedLabel}
+              </span>
+            ) : (
+              <>
+                <span className="min-w-0 truncate">
+                  {menu.trigger.modelLabel}
+                </span>
+                <span className="shrink-0">{menu.trigger.reasoningLabel}</span>
+              </>
+            )}
           </>
         )}
       </span>
@@ -266,7 +299,7 @@ export function AgentModelReasoningDropdown({
               {trigger}
             </span>
           </TooltipTrigger>
-          <TooltipContent side="top">{retryLabel}</TooltipContent>
+          <TooltipContent side="top">{retryTooltip}</TooltipContent>
         </Tooltip>
       </TooltipProvider>
     );

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
@@ -100,6 +100,53 @@ describe("AgentModelReasoningDropdown", () => {
     ).toBe('["gpt-5.4"]');
     expect(screen.getByText("Model selection")).toBeInTheDocument();
   });
+
+  it("retries composer options from the compact error state", () => {
+    const onRetryComposerOptions = vi.fn();
+    render(
+      <AgentModelReasoningDropdown
+        composerSettings={{
+          ...composerSettings(),
+          composerOptionsError: true
+        }}
+        labels={{ ...modelSettingsLabels, retry: "Try again" }}
+        onRetryComposerOptions={onRetryComposerOptions}
+        onSettingsChange={vi.fn()}
+      />
+    );
+
+    const retryButton = screen.getByRole("button", { name: "Try again" });
+    expect(retryButton).toHaveAttribute(
+      "data-agent-composer-options-state",
+      "error"
+    );
+    fireEvent.click(retryButton);
+
+    expect(onRetryComposerOptions).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText("Model selection")).not.toBeInTheDocument();
+  });
+
+  it("disables the compact retry while composer options are loading", () => {
+    const onRetryComposerOptions = vi.fn();
+    render(
+      <AgentModelReasoningDropdown
+        composerSettings={{
+          ...composerSettings(),
+          composerOptionsError: true,
+          composerOptionsLoadStatus: "loading"
+        }}
+        labels={{ ...modelSettingsLabels, retry: "Try again" }}
+        onRetryComposerOptions={onRetryComposerOptions}
+        onSettingsChange={vi.fn()}
+      />
+    );
+
+    const retryButton = screen.getByRole("button", { name: "Try again" });
+    expect(retryButton).toBeDisabled();
+    fireEvent.click(retryButton);
+
+    expect(onRetryComposerOptions).not.toHaveBeenCalled();
+  });
 });
 
 describe("AgentPermissionModeDropdown", () => {
@@ -373,6 +420,7 @@ const modelSettingsLabels: AgentComposerSettingsMenuLabels = {
   modelTooltipVersionLabel: "Version",
   defaultModel: "Default model",
   loadingOptions: "Loading…",
+  retry: "Try again",
   inheritedUnavailable: "Unavailable",
   reasoningLabel: "Reasoning",
   reasoningDegreeLabel: "Reasoning degree",

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
@@ -101,7 +101,7 @@ describe("AgentModelReasoningDropdown", () => {
     expect(screen.getByText("Model selection")).toBeInTheDocument();
   });
 
-  it("retries composer options from the compact error state", () => {
+  it("retries composer options from the compact error state", async () => {
     const onRetryComposerOptions = vi.fn();
     render(
       <AgentModelReasoningDropdown
@@ -119,6 +119,19 @@ describe("AgentModelReasoningDropdown", () => {
     expect(retryButton).toHaveAttribute(
       "data-agent-composer-options-state",
       "error"
+    );
+    expect(
+      retryButton.querySelector(
+        '[data-agent-composer-options-retry-icon="true"]'
+      )
+    ).not.toBeNull();
+    expect(
+      screen.getByText("Configuration failed to load")
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Default model")).not.toBeInTheDocument();
+    fireEvent.focus(retryButton);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Shared Agent information failed to load. Click to retry"
     );
     fireEvent.click(retryButton);
 
@@ -420,7 +433,9 @@ const modelSettingsLabels: AgentComposerSettingsMenuLabels = {
   modelTooltipVersionLabel: "Version",
   defaultModel: "Default model",
   loadingOptions: "Loading…",
+  optionsLoadFailed: "Configuration failed to load",
   retry: "Try again",
+  retryTooltip: "Shared Agent information failed to load. Click to retry",
   inheritedUnavailable: "Unavailable",
   reasoningLabel: "Reasoning",
   reasoningDegreeLabel: "Reasoning degree",

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.labels.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.labels.ts
@@ -217,6 +217,7 @@ export function useAgentGUIViewLabels(input: {
       ),
       defaultModel: t("agentHost.agentGui.defaultModel"),
       loadingOptions: t("agentHost.agentGui.loadingOptions"),
+      composerOptionsRetry: t("agentHost.agentGui.composerOptionsRetry"),
       inheritedUnavailable: t("agentHost.agentGui.inheritedUnavailable"),
       reasoningLabel: t("agentHost.agentGui.reasoningLabel"),
       reasoningDegreeLabel: t("agentHost.agentGui.reasoningDegreeLabel"),

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.labels.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.labels.ts
@@ -217,7 +217,13 @@ export function useAgentGUIViewLabels(input: {
       ),
       defaultModel: t("agentHost.agentGui.defaultModel"),
       loadingOptions: t("agentHost.agentGui.loadingOptions"),
+      composerOptionsLoadFailed: t(
+        "agentHost.agentGui.composerOptionsLoadFailed"
+      ),
       composerOptionsRetry: t("agentHost.agentGui.composerOptionsRetry"),
+      composerOptionsRetryTooltip: t(
+        "agentHost.agentGui.composerOptionsRetryTooltip"
+      ),
       inheritedUnavailable: t("agentHost.agentGui.inheritedUnavailable"),
       reasoningLabel: t("agentHost.agentGui.reasoningLabel"),
       reasoningDegreeLabel: t("agentHost.agentGui.reasoningDegreeLabel"),
@@ -779,7 +785,6 @@ export function useAgentGUIViewLabels(input: {
     ]
   );
 }
-
 export function useAgentGUIWorkspaceFileReferenceCopy(
   t: TranslateFn
 ): WorkspaceFileReferenceCopy {

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
@@ -180,6 +180,7 @@ export interface AgentComposerProps {
     modelTooltipVersionLabel: string;
     defaultModel: string;
     loadingOptions: string;
+    retry?: string;
     inheritedUnavailable: string;
     loadingConversation: string;
     reasoningLabel: string;
@@ -404,6 +405,8 @@ export interface AgentComposerProps {
     computerUse?: boolean;
     permissionModeId?: string | null;
   }) => void;
+  /** Retries the target-scoped composer options request after a terminal failure. */
+  onRetryComposerOptions?: () => void;
   onTuttiModeChange?: (active: boolean) => void;
   onTuttiModeEffectChange?: (value: number) => void;
   onTuttiModeSpeedChange?: (value: number) => void;

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposer.types.ts
@@ -180,7 +180,9 @@ export interface AgentComposerProps {
     modelTooltipVersionLabel: string;
     defaultModel: string;
     loadingOptions: string;
+    composerOptionsLoadFailed?: string;
     retry?: string;
+    composerOptionsRetryTooltip?: string;
     inheritedUnavailable: string;
     loadingConversation: string;
     reasoningLabel: string;

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerView.tsx
@@ -720,6 +720,7 @@ export function AgentComposerView(input: Props): React.JSX.Element {
             onWorkspaceReferencePicker={handleWorkspaceReferencePicker}
             onMentionPaletteButton={handleMentionPaletteButton}
             onSettingsChange={onSettingsChange}
+            onRetryComposerOptions={input.props.onRetryComposerOptions}
             onSubmit={onSubmit}
             onClearGoalMode={clearGoalModeBadge}
             draftPrompt={draftPrompt}

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerFooter.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerFooter.tsx
@@ -82,6 +82,7 @@ interface Props {
   onWorkspaceReferencePicker: () => void;
   onMentionPaletteButton: () => void;
   onSettingsChange: AgentComposerProps["onSettingsChange"];
+  onRetryComposerOptions: AgentComposerProps["onRetryComposerOptions"];
   onSubmit: AgentComposerProps["onSubmit"];
   onClearGoalMode: () => void;
   draftPrompt: string;
@@ -136,6 +137,7 @@ export function ComposerFooter({
   onWorkspaceReferencePicker: handleWorkspaceReferencePicker,
   onMentionPaletteButton: handleMentionPaletteButton,
   onSettingsChange,
+  onRetryComposerOptions,
   onSubmit,
   onClearGoalMode: clearGoalModeBadge,
   draftPrompt: _draftPrompt,
@@ -437,8 +439,9 @@ export function ComposerFooter({
               }}
             />
           ) : null}
-          {showSettingsLoadingPlaceholders ||
-          composerSettings.supportsPermissionMode ? (
+          {!composerSettings.composerOptionsError &&
+          (showSettingsLoadingPlaceholders ||
+            composerSettings.supportsPermissionMode) ? (
             <AgentPermissionModeDropdown
               composerSettings={composerSettings}
               disabled={permissionModeControlsDisabled}
@@ -458,10 +461,12 @@ export function ComposerFooter({
           ) : null}
           {showSettingsLoadingPlaceholders ||
           composerSettings.supportsModel ||
-          composerSettings.supportsReasoningEffort ? (
+          composerSettings.supportsReasoningEffort ||
+          composerSettings.composerOptionsError ? (
             <AgentModelReasoningDropdown
               composerSettings={composerSettings}
               disabled={settingsControlsDisabled}
+              onRetryComposerOptions={onRetryComposerOptions}
               labels={{
                 modelLabel: labels.modelLabel,
                 modelSelectionLabel: labels.modelSelectionLabel,
@@ -489,6 +494,7 @@ export function ComposerFooter({
                 modelDescriptions: labels.modelDescriptions,
                 defaultModel: labels.defaultModel,
                 loadingOptions: labels.loadingOptions,
+                retry: labels.retry,
                 inheritedUnavailable: labels.inheritedUnavailable
               }}
               onSettingsChange={onSettingsChange}

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerFooter.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerFooter.tsx
@@ -494,7 +494,9 @@ export function ComposerFooter({
                 modelDescriptions: labels.modelDescriptions,
                 defaultModel: labels.defaultModel,
                 loadingOptions: labels.loadingOptions,
+                optionsLoadFailed: labels.composerOptionsLoadFailed,
                 retry: labels.retry,
+                retryTooltip: labels.composerOptionsRetryTooltip,
                 inheritedUnavailable: labels.inheritedUnavailable
               }}
               onSettingsChange={onSettingsChange}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.stableHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.stableHelpers.ts
@@ -466,6 +466,10 @@ export function areComposerSettingsVMsEqual(
       (right.permissionModeChangeDuringTurn ?? false) &&
     sameSlashPolicy(left.slashCommandPolicy, right.slashCommandPolicy) &&
     left.isSettingsLoading === right.isSettingsLoading &&
+    Boolean(left.composerOptionsError) ===
+      Boolean(right.composerOptionsError) &&
+    (left.composerOptionsLoadStatus ?? null) ===
+      (right.composerOptionsLoadStatus ?? null) &&
     !!left.isCapabilityOptionsLoading === !!right.isCapabilityOptionsLoading &&
     !!left.isModelOptionsLoading === !!right.isModelOptionsLoading &&
     left.modelUnavailable === right.modelUnavailable &&

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerCapabilities.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerCapabilities.ts
@@ -146,6 +146,7 @@ export function useAgentGUIComposerCapabilities(
         sessionCapabilities
       }),
     composerSupport,
+    composerOptionsLoadStatus,
     composerOptionsLoading,
     composerTargetData,
     defaultReasoningEffort,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerPresentation.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerPresentation.spec.tsx
@@ -9,6 +9,50 @@ import type { AgentGUIComposerTargetData } from "./agentGuiController.composerPr
 import { useAgentGUIComposerPresentation } from "./useAgentGUIComposerPresentation";
 
 describe("useAgentGUIComposerPresentation", () => {
+  it("exposes a terminal options error without leaving the composer in loading state", () => {
+    const data: AgentGUINodeData = {
+      provider: "opencode",
+      agentTargetId: "local:opencode",
+      lastActiveAgentSessionId: null
+    };
+    const target: AgentGUIComposerTargetData = {
+      agentTargetId: "local:opencode",
+      data,
+      provider: "opencode",
+      targetId: "local:opencode"
+    };
+
+    const { result } = renderHook(() =>
+      useAgentGUIComposerPresentation({
+        activeConversation: null,
+        activeConversationId: null,
+        activeEngineSession: null,
+        activeSessionState: null,
+        agentActivityRuntime: {
+          projectPathIsRemote: false
+        } as AgentGUIRuntime,
+        composerOptionsLoadStatus: "error",
+        composerOptionsLoading: false,
+        composerSupport: composerSettingsSupportFromOptions(null, null),
+        composerTargetProvider: "opencode",
+        data,
+        defaultReasoningEffort: null,
+        draftSettingsBySessionId: {},
+        providerComposerOptions: null,
+        selectedComposerTargetData: target,
+        selectedProjectPath: null,
+        shouldApplyPreparedProjectSelection: false,
+        userProjects: []
+      })
+    );
+
+    expect(result.current.stableComposerSettings).toMatchObject({
+      composerOptionsError: true,
+      composerOptionsLoadStatus: "error",
+      isSettingsLoading: false
+    });
+  });
+
   it("keeps all explicit home defaults above stale options, then yields to authority after retirement", () => {
     const data: AgentGUINodeData = {
       provider: "opencode",

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerPresentation.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentActivityComposerOptionsLoadStatus,
   AgentActivityComposerOptions,
   AgentActivitySession
 } from "@tutti-os/agent-activity-core";
@@ -47,6 +48,7 @@ interface UseAgentGUIComposerPresentationInput {
   activeSessionState: AgentSessionState | null;
   agentActivityRuntime: AgentGUIRuntime;
   composerSupport: ReturnType<typeof composerSettingsSupportFromOptions>;
+  composerOptionsLoadStatus?: AgentActivityComposerOptionsLoadStatus;
   composerOptionsLoading: boolean;
   composerTargetProvider: AgentGUIProvider;
   codexSaverModeEntryEnabled?: boolean;
@@ -181,6 +183,8 @@ export function useAgentGUIComposerPresentation(
       (!input.composerSupport.model || activeSessionModelSelection !== null) &&
       (!input.composerSupport.reasoning ||
         activeSessionReasoningSelection !== null);
+    const composerOptionsError =
+      input.composerOptionsLoadStatus === "error" && !hasOptionsSource;
     const selectedPermissionModeValue =
       normalizePermissionModeId(draftSettings.permissionModeId) ??
       normalizePermissionModeId(permissionConfig?.defaultValue);
@@ -243,7 +247,9 @@ export function useAgentGUIComposerPresentation(
       planExclusiveWithPermissionMode:
         input.providerComposerOptions?.behavior
           ?.planModeExclusiveWithPermissionMode === true,
-      isSettingsLoading: !hasACPSettings,
+      composerOptionsError,
+      composerOptionsLoadStatus: input.composerOptionsLoadStatus,
+      isSettingsLoading: !hasACPSettings && !composerOptionsError,
       isCapabilityOptionsLoading: input.composerOptionsLoading,
       isModelOptionsLoading: isForegroundModelOptionsLoading({
         modelOptionsLoading: input.providerComposerOptions?.modelOptionsLoading,
@@ -335,6 +341,7 @@ export function useAgentGUIComposerPresentation(
     input.activeConversationId,
     input.agentActivityRuntime.projectPathIsRemote,
     input.composerSupport,
+    input.composerOptionsLoadStatus,
     input.composerOptionsLoading,
     input.composerTargetProvider,
     input.providerComposerOptions,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerSettingsActions.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerSettingsActions.spec.tsx
@@ -810,6 +810,63 @@ describe("useAgentGUIComposerSettingsActions", () => {
       settings: {}
     });
   });
+
+  it("retries composer options without forcing a superseding request", () => {
+    const sessionEngine = createAgentSessionEngine({
+      clock: { nowUnixMs: () => 1 },
+      commandPort: createTestEngineCommandPort({ execute: vi.fn() }),
+      identity: { origin: "test", workspaceId: "workspace-1" },
+      scheduler: { schedule: () => ({ cancel() {} }) }
+    });
+    const data: AgentGUINodeData = {
+      agentTargetId: "local:codex",
+      lastActiveAgentSessionId: null,
+      provider: "codex"
+    };
+    const target = {
+      agentTargetId: "local:codex",
+      data,
+      provider: "codex" as const,
+      targetId: "local:codex"
+    };
+    const loadDraftComposerOptions = vi.fn();
+    const rendered = renderHook(() =>
+      useAgentGUIComposerSettingsActions({
+        activation: {
+          stateFor: vi.fn(() => "inactive" as const)
+        } as unknown as ReturnType<typeof useAgentGUIActivation>,
+        activeCanonicalComposerSettings: {},
+        activeConversationIdRef: { current: null },
+        activeEngineActiveTurn: null,
+        agentActivityRuntime: {
+          getSnapshot: () => ({})
+        } as unknown as AgentGUIRuntime,
+        composerSupportPermissionModeChangeDeferred: false,
+        dataRef: { current: data },
+        defaultReasoningEffort: null,
+        draftSettingsBySessionIdRef: { current: {} },
+        isMountedRef: { current: true },
+        loadDraftComposerOptions,
+        onComposerDefaultsAuthorityReloadedRef:
+          createComposerDefaultsAuthorityReconcilerRef(),
+        onDataChangeRef: { current: vi.fn() },
+        onRememberComposerDefaultsRef: { current: undefined },
+        onShowMessageRef: { current: vi.fn() },
+        reloadComposerOptionsForTarget: vi.fn(async () => {}),
+        selectedComposerTargetDataRef: { current: target },
+        sessionEngine,
+        setDraftSettingsBySessionId: vi.fn(),
+        updateComposerSettingsRef: { current: vi.fn() },
+        workspaceId: "workspace-1"
+      })
+    );
+
+    act(() => {
+      rendered.result.current.retryComposerOptions();
+    });
+
+    expect(loadDraftComposerOptions).toHaveBeenCalledWith();
+  });
 });
 
 function createComposerDefaultsAuthorityReconcilerRef(): {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerSettingsActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerSettingsActions.ts
@@ -504,11 +504,11 @@ export function useAgentGUIComposerSettingsActions(
     }
   );
 
-  // Recovery entry for the composer-options terminal error state: re-issues
-  // the draft options load (the engine grants a fresh retry budget per
-  // user-driven request).
+  // Recovery entry for the composer-options terminal error state. Leave the
+  // request non-forced so Activity Core joins an already-running load when a
+  // user double-clicks the retry control instead of superseding it.
   const retryComposerOptions = useStableControllerEventCallback(() => {
-    loadDraftComposerOptions({ force: true });
+    loadDraftComposerOptions();
   });
 
   return {

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
@@ -1,5 +1,6 @@
 import type {
   AgentActivityUsage,
+  AgentActivityComposerOptionsLoadStatus,
   CanonicalAgentSession,
   SessionRuntimeAvailability
 } from "@tutti-os/agent-activity-core";
@@ -310,6 +311,10 @@ export interface AgentGUIComposerSettingsVM {
   permissionModeChangeDuringTurn?: boolean;
   slashCommandPolicy?: AgentSlashCommandPolicy | null;
   isSettingsLoading: boolean;
+  /** Terminal composer-options failure with no cached catalog to render. */
+  composerOptionsError?: boolean;
+  /** Activity-core request lifecycle for the target-scoped options catalog. */
+  composerOptionsLoadStatus?: AgentActivityComposerOptionsLoadStatus;
   /** Initial slash command and capability catalog request is in flight. */
   isCapabilityOptionsLoading?: boolean;
   isModelOptionsLoading?: boolean;

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/composerSettingsMenuModel.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/composerSettingsMenuModel.ts
@@ -15,6 +15,7 @@ export type AgentComposerSettingsMenuLabels = {
   modelTooltipVersionLabel: string;
   defaultModel: string;
   loadingOptions: string;
+  retry?: string;
   inheritedUnavailable: string;
   reasoningLabel: string;
   reasoningDegreeLabel: string;

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/composerSettingsMenuModel.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/composerSettingsMenuModel.ts
@@ -15,7 +15,9 @@ export type AgentComposerSettingsMenuLabels = {
   modelTooltipVersionLabel: string;
   defaultModel: string;
   loadingOptions: string;
+  optionsLoadFailed?: string;
   retry?: string;
+  retryTooltip?: string;
   inheritedUnavailable: string;
   reasoningLabel: string;
   reasoningDegreeLabel: string;

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
@@ -71,9 +71,8 @@ export interface AgentGUIConversationRailLayout {
   resizing: boolean;
 }
 
-// The provider-gate content labels (checking / install / login / coming-soon /
-// unavailable / runtime-selection) live on AgentGUIProviderReadinessLabels;
-// extend it rather than restating every key here.
+// Provider-gate labels live on AgentGUIProviderReadinessLabels; extend it
+// rather than restating every key here.
 export interface AgentGUIViewLabels extends AgentGUIProviderReadinessLabels {
   initialPlaceholder: string;
   followupPlaceholder: string;
@@ -90,7 +89,9 @@ export interface AgentGUIViewLabels extends AgentGUIProviderReadinessLabels {
   modelTooltipVersionLabel: string;
   defaultModel: string;
   loadingOptions: string;
+  composerOptionsLoadFailed?: string;
   composerOptionsRetry?: string;
+  composerOptionsRetryTooltip?: string;
   inheritedUnavailable: string;
   reasoningLabel: string;
   reasoningDegreeLabel: string;
@@ -792,7 +793,6 @@ export interface AgentGUISidebarFooterContext {
   currentUserId?: string | null;
   activeConversation: AgentGUINodeViewModel["rail"]["activeConversation"];
 }
-
 export type AgentGUISidebarFooterRenderer = (
   ctx: AgentGUISidebarFooterContext
 ) => ReactNode;

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
@@ -50,7 +50,6 @@ import type {
 } from "../../../workspaceWorkflow";
 import type { TuttiWorkflowDockLabels } from "../TuttiWorkflowDock";
 import type { AgentGUIComposerFooterAccessoryRenderer } from "./AgentGUIComposerFooterAccessory.types";
-
 export type AgentMentionReferenceTargetResolver = (
   item: AgentContextMentionItem
 ) => ReferenceLocateTarget | null;
@@ -91,6 +90,7 @@ export interface AgentGUIViewLabels extends AgentGUIProviderReadinessLabels {
   modelTooltipVersionLabel: string;
   defaultModel: string;
   loadingOptions: string;
+  composerOptionsRetry?: string;
   inheritedUnavailable: string;
   reasoningLabel: string;
   reasoningDegreeLabel: string;

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailModel.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailModel.tsx
@@ -385,7 +385,12 @@ export function useAgentGUIDetailModel(input: Input) {
       modelTooltipVersionLabel: labels.modelTooltipVersionLabel,
       defaultModel: labels.defaultModel,
       loadingOptions: labels.loadingOptions,
+      composerOptionsLoadFailed: labels.composerOptionsLoadFailed,
       retry: labels.composerOptionsRetry ?? labels.retryActivation,
+      retryTooltip:
+        labels.composerOptionsRetryTooltip ??
+        labels.composerOptionsRetry ??
+        labels.retryActivation,
       inheritedUnavailable: labels.inheritedUnavailable,
       loadingConversation: labels.loadingConversation,
       reasoningLabel: labels.reasoningLabel,
@@ -567,7 +572,9 @@ export function useAgentGUIDetailModel(input: Input) {
     }),
     [
       interactivePromptLabels,
+      labels.composerOptionsLoadFailed,
       labels.composerOptionsRetry,
+      labels.composerOptionsRetryTooltip,
       labels.defaultModel,
       labels.tuttiModePlanSendAccept,
       labels.tuttiModePlanSendRequestChanges,

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailModel.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailModel.tsx
@@ -385,6 +385,7 @@ export function useAgentGUIDetailModel(input: Input) {
       modelTooltipVersionLabel: labels.modelTooltipVersionLabel,
       defaultModel: labels.defaultModel,
       loadingOptions: labels.loadingOptions,
+      retry: labels.composerOptionsRetry ?? labels.retryActivation,
       inheritedUnavailable: labels.inheritedUnavailable,
       loadingConversation: labels.loadingConversation,
       reasoningLabel: labels.reasoningLabel,
@@ -566,6 +567,7 @@ export function useAgentGUIDetailModel(input: Input) {
     }),
     [
       interactivePromptLabels,
+      labels.composerOptionsRetry,
       labels.defaultModel,
       labels.tuttiModePlanSendAccept,
       labels.tuttiModePlanSendRequestChanges,

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
@@ -9,6 +9,7 @@ import { enAgentGuiSlashPalette } from "./en.agentGuiSlashPalette.ts";
 import { enAgentGuiSessionActions } from "./en.agentGuiSessionActions.ts";
 import { enAgentGuiCollaboration } from "./en.agentGuiCollaboration.ts";
 import { enAgentGuiUsageStatus } from "./en.agentGuiUsageStatus.ts";
+import { enAgentGuiComposer } from "./en.agentGuiComposer.ts";
 
 export const enAgentGui = {
   imageDownloaded: "Image downloaded",
@@ -102,8 +103,7 @@ export const enAgentGui = {
   modelLabel: "Model",
   modelSelectionLabel: "Model selection",
   defaultModel: "Default model",
-  loadingOptions: "Loading…",
-  inheritedUnavailable: "Inherited / unavailable",
+  ...enAgentGuiComposer,
   reasoningLabel: "Reasoning",
   reasoningDegreeLabel: "Reasoning level",
   reasoningOptionDefault: "Default",

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGuiComposer.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGuiComposer.ts
@@ -1,5 +1,8 @@
 export const enAgentGuiComposer = {
   loadingOptions: "Loading…",
+  composerOptionsLoadFailed: "Configuration failed to load",
   composerOptionsRetry: "Retry",
+  composerOptionsRetryTooltip:
+    "Unable to load shared Agent information. Click to retry",
   inheritedUnavailable: "Inherited / unavailable"
 };

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGuiComposer.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGuiComposer.ts
@@ -1,0 +1,5 @@
+export const enAgentGuiComposer = {
+  loadingOptions: "Loading…",
+  composerOptionsRetry: "Retry",
+  inheritedUnavailable: "Inherited / unavailable"
+};

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
@@ -8,6 +8,7 @@ import { zhCNAgentGuiSlashPalette } from "./zh-CN.agentGuiSlashPalette.ts";
 import { zhCNAgentGuiSessionActions } from "./zh-CN.agentGuiSessionActions.ts";
 import { zhCNAgentGuiCollaboration } from "./zh-CN.agentGuiCollaboration.ts";
 import { zhCNTuttiModePlan } from "./zh-CN.tuttiModePlan.ts";
+import { zhCNAgentGuiComposer } from "./zh-CN.agentGuiComposer.ts";
 
 export const zhCNAgentGui = {
   imageDownloaded: "图片已下载",
@@ -98,8 +99,7 @@ export const zhCNAgentGui = {
   modelLabel: "模型",
   modelSelectionLabel: "模型选择",
   defaultModel: "默认模型",
-  loadingOptions: "正在加载",
-  inheritedUnavailable: "继承 / 不可用",
+  ...zhCNAgentGuiComposer,
   reasoningLabel: "推理强度",
   reasoningDegreeLabel: "推理程度",
   reasoningOptionDefault: "默认",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGuiComposer.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGuiComposer.ts
@@ -1,0 +1,5 @@
+export const zhCNAgentGuiComposer = {
+  loadingOptions: "正在加载",
+  composerOptionsRetry: "重试",
+  inheritedUnavailable: "继承 / 不可用"
+};

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGuiComposer.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGuiComposer.ts
@@ -1,5 +1,7 @@
 export const zhCNAgentGuiComposer = {
   loadingOptions: "正在加载",
+  composerOptionsLoadFailed: "配置加载失败",
   composerOptionsRetry: "重试",
+  composerOptionsRetryTooltip: "共享 Agent 信息加载失败，点击重试",
   inheritedUnavailable: "继承 / 不可用"
 };


### PR DESCRIPTION
## Summary

- 在 AgentGUI 现有模型/推理选项控件槽位展示共享 Agent 信息加载失败态和轻量重试按钮，不新增 inline 行；已有缓存仍可继续使用。
- owner 查询失败，或 owner connection 未就绪且没有缓存时，透传真实错误，避免用空 options 伪装成功。
- 重试复用相同请求签名的进行中请求，loading 期间禁用重试 CTA，并补充中英文专用文案。

## Verification

- `pnpm --dir packages/agent/gui test` — 309 个测试文件、2703 个测试通过
- `pnpm --dir packages/agent/gui typecheck`
- `pnpm check:agent-gui-degradation`
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm check:agent-provider-strategy-boundaries`

## Fallback 三问

- **来源是什么？** owner 设备连接仍处于 connecting/unavailable，或 transport response 失败，同时本地可能没有可用缓存。
- **为什么不从来源解决？** 连接/传输失败受跨设备网络和 owner 生命周期影响，可能是瞬时状态；核心层负责保留查询状态和生命周期语义，GUI 需要提供一个有界的用户恢复入口。
- **什么时候移除？** 只有在共享 Agent query 能在每次 composer load 前保证 owner connection ready，并且持续观测和测试都不再出现 terminal load failure 时，才重新评估移除该 recovery path；在此之前保留它。

## Scope

- 不改变共享 Agent 的生命周期、权限或查询协议语义；新增字段保持可选。
- TSH 的消费侧修复会在该 Tutti 变更发布后单独升级，不包含在本 PR 中。

## Checklist

- [x] 已补充失败态、loading 防重复点击和重试行为测试
- [x] 已补充中英文文案
- [x] 已通过 AgentGUI degradation 和 runtime boundary checks
- [x] 已确认没有引入新的 UI 行或额外布局占用
