### PR TITLE
fix(agent-gui): surface conversation rail load failures

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1353,6 +1353,14 @@ update only an already-resolved matching scope. A subordinate result must not
 cancel the full query, publish partial membership for an unresolved scope, or
 unlock Rail interactions.
 
+When Activity View has a non-null in-memory projection, that projection remains
+visible while the unrelated initial Rail membership query is pending; Rail
+loading, empty, or failure placeholders must not replace it. A refresh or page
+failure after Rail rows already exist preserves those rows and reports a
+non-blocking error through the host toast capability, falling back to the UI
+System toast when that optional capability is absent. An unresolved empty Rail
+scope retains the centered error state and its retry action.
+
 Presentation-invisible Sessions remain canonical engine entities and stay
 available through exact Session selectors for trusted open, reconcile, and
 command flows. Plural consumer selectors exclude them before Rail and Message

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.styles.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.styles.ts
@@ -159,6 +159,9 @@ const styles = {
     "agent-gui-node__empty-provider-gate-description",
   emptyProviderGateStatus: "agent-gui-node__empty-provider-gate-status",
   emptyState: "agent-gui-node__empty-state",
+  conversationRailLoadError: "agent-gui-node__conversation-rail-load-error",
+  conversationRailLoadErrorIcon:
+    "agent-gui-node__conversation-rail-load-error-icon",
   unavailableChatEmpty: "agent-gui-node__unavailable-chat-empty",
   unavailableChatEmptyIcon: "agent-gui-node__unavailable-chat-empty-icon",
   unavailableChatEmptyText: "agent-gui-node__unavailable-chat-empty-text",

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
@@ -956,6 +956,93 @@ describe("AgentGUIConversationRailQueryController", () => {
     engine.dispose();
   });
 
+  it("retries a failed section page load when More is requested again", async () => {
+    const engine = createTestAgentSessionEngine();
+    const firstSession = createTestSession("session-1", "conversations");
+    const secondSession = createTestSession("session-2", "conversations");
+    let pageRequestCount = 0;
+    const listSessionSectionPage = vi.fn<
+      NonNullable<ConversationRailQueryRuntime["listSessionSectionPage"]>
+    >(async (input) => {
+      pageRequestCount += 1;
+      if (pageRequestCount === 1) throw new Error("transient page failure");
+      return {
+        hasMore: false,
+        kind: "conversations",
+        sectionKey: input.sectionKey,
+        sessions: [secondSession],
+        totalCount: 2
+      };
+    });
+    const controller = new AgentGUIConversationRailQueryController({
+      engine,
+      getActiveConversationId: () => null,
+      runtime: {
+        listSessionSectionPage,
+        listSessionSections: async (input) => ({
+          sections: [
+            {
+              hasMore: true,
+              kind: "conversations",
+              nextCursor: "cursor-2",
+              sectionKey: "conversations",
+              sessions: [firstSession],
+              totalCount: 2
+            }
+          ],
+          workspaceId: input.workspaceId
+        })
+      },
+      workspaceId: "test-workspace"
+    });
+    controller.configure({
+      conversationFilter: { kind: "all" },
+      userProjects: []
+    });
+    const detach = controller.attach();
+    await vi.waitFor(() =>
+      expect(controller.getSnapshot().runtimeRailSectionsPending).toBe(false)
+    );
+
+    controller.loadMoreSectionConversations({ id: "conversations" });
+    await vi.waitFor(() =>
+      expect(listSessionSectionPage).toHaveBeenCalledTimes(1)
+    );
+    await vi.waitFor(() =>
+      expect(controller.getSnapshot().runtimeRailFailed).toBe(true)
+    );
+    expect(
+      controller.getSnapshot().sectionPageStates.get("conversations")
+    ).toEqual({
+      hasMore: true,
+      isLoading: false,
+      nextCursor: "cursor-2",
+      totalCount: 2
+    });
+
+    controller.loadMoreSectionConversations({ id: "conversations" });
+    await vi.waitFor(() =>
+      expect(listSessionSectionPage).toHaveBeenCalledTimes(2)
+    );
+    await vi.waitFor(() =>
+      expect(controller.getSnapshot().runtimeRailFailed).toBe(false)
+    );
+    expect(
+      controller.getSnapshot().sectionPageStates.get("conversations")
+    ).toEqual({
+      hasMore: false,
+      isLoading: false,
+      nextCursor: null,
+      totalCount: 2
+    });
+    expect(
+      selectEngineSession(engine.getSnapshot(), secondSession.agentSessionId)
+    ).not.toBeNull();
+
+    detach();
+    engine.dispose();
+  });
+
   it("isolates subscriber failures from successful rail queries", async () => {
     const engine = createTestAgentSessionEngine();
     const controller = new AgentGUIConversationRailQueryController({

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import {
   selectAttentionReadState,
   selectWorkspaceAgentConsumerSessions,
@@ -223,6 +223,10 @@ export function useAgentGUIConversationRailQuery({
       }).scopeKey,
     [conversationFilter, userProjects, workspaceId]
   );
+  const retryRuntimeRail = useCallback(
+    () => controller.refresh(),
+    [controller]
+  );
   return useMemo(
     () => ({
       ...querySnapshot,
@@ -241,7 +245,8 @@ export function useAgentGUIConversationRailQuery({
       runtimeRailScopeResolved:
         !querySnapshot.runtimeSectionsEnabled ||
         querySnapshot.runtimeRailResolvedScopeKey === requestedRailScopeKey,
-      runtimeRailConversations
+      runtimeRailConversations,
+      retryRuntimeRail
     }),
     [
       batchDeletionCapability.available,
@@ -251,7 +256,8 @@ export function useAgentGUIConversationRailQuery({
       deletedSessionIds,
       querySnapshot,
       requestedRailScopeKey,
-      runtimeRailConversations
+      runtimeRailConversations,
+      retryRuntimeRail
     ]
   );
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailContentState.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailContentState.tsx
@@ -9,7 +9,7 @@ export function AgentGUIConversationRailContentState({
   children,
   conversationQuery,
   conversations,
-  hasConversations,
+  hasRailContent,
   isLoading,
   labels,
   onRetry,
@@ -21,7 +21,7 @@ export function AgentGUIConversationRailContentState({
   children: React.ReactNode;
   conversationQuery: string;
   conversations: AgentGUINodeViewModel["rail"]["conversations"];
-  hasConversations: boolean;
+  hasRailContent: boolean;
   isLoading: boolean;
   labels: AgentGUIConversationRailLabels;
   onRetry: () => void;
@@ -60,14 +60,14 @@ export function AgentGUIConversationRailContentState({
 
   return (
     <>
-      {railError && !hasConversations ? (
+      {railError && !hasRailContent ? (
         <AgentGUIConversationRailLoadError
           errorLabel={labels.conversationsLoadFailed}
           onRetry={onRetry}
           retryLabel={labels.retryConversations}
         />
       ) : null}
-      {railError && !hasConversations ? null : content}
+      {railError && !hasRailContent ? null : content}
     </>
   );
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailContentState.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailContentState.tsx
@@ -1,0 +1,73 @@
+import { Button as SystemButton } from "@tutti-os/ui-system";
+import { AgentConversationListSkeleton } from "../AgentConversationListSkeleton";
+import type { AgentGUINodeViewModel } from "../model/agentGuiNodeTypes";
+import { AgentGUIConversationRailLoadError } from "./AgentGUIConversationRailLoadError";
+import type { AgentGUIConversationRailLabels } from "./agentGUIConversationRailLabels";
+import styles from "../AgentGUINode.styles";
+
+export function AgentGUIConversationRailContentState({
+  children,
+  conversationQuery,
+  conversations,
+  hasConversations,
+  isLoading,
+  labels,
+  onRetry,
+  onRetrySearch,
+  railError,
+  searchError,
+  showEmptyState
+}: {
+  children: React.ReactNode;
+  conversationQuery: string;
+  conversations: AgentGUINodeViewModel["rail"]["conversations"];
+  hasConversations: boolean;
+  isLoading: boolean;
+  labels: AgentGUIConversationRailLabels;
+  onRetry: () => void;
+  onRetrySearch: () => void;
+  railError: boolean;
+  searchError: boolean;
+  showEmptyState: boolean;
+}): React.JSX.Element {
+  const content = isLoading ? (
+    <AgentConversationListSkeleton label={labels.loadingConversations} />
+  ) : searchError ? (
+    <div className={styles.emptyState}>
+      <span>{labels.searchFailed}</span>
+      <SystemButton
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={onRetrySearch}
+      >
+        {labels.retrySearch}
+      </SystemButton>
+    </div>
+  ) : showEmptyState ? (
+    <div className={styles.emptyState}>
+      <span>
+        {conversationQuery.trim()
+          ? labels.searchNoConversations
+          : conversations.length === 0
+            ? labels.noConversations
+            : labels.conversationUnavailable}
+      </span>
+    </div>
+  ) : (
+    <>{children}</>
+  );
+
+  return (
+    <>
+      {railError && !hasConversations ? (
+        <AgentGUIConversationRailLoadError
+          errorLabel={labels.conversationsLoadFailed}
+          onRetry={onRetry}
+          retryLabel={labels.retryConversations}
+        />
+      ) : null}
+      {railError && !hasConversations ? null : content}
+    </>
+  );
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailLoadError.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailLoadError.tsx
@@ -1,0 +1,31 @@
+import { AlertCircle } from "lucide-react";
+import { Button as SystemButton } from "@tutti-os/ui-system";
+import styles from "../AgentGUINode.styles";
+
+export function AgentGUIConversationRailLoadError({
+  errorLabel,
+  onRetry,
+  retryLabel
+}: {
+  errorLabel: string;
+  onRetry: () => void;
+  retryLabel: string;
+}): React.JSX.Element {
+  return (
+    <div
+      aria-live="polite"
+      className={styles.conversationRailLoadError}
+      data-testid="agent-gui-conversation-rail-load-error"
+      role="status"
+    >
+      <AlertCircle
+        aria-hidden="true"
+        className={styles.conversationRailLoadErrorIcon}
+      />
+      <span>{errorLabel}</span>
+      <SystemButton type="button" variant="outline" size="sm" onClick={onRetry}>
+        {retryLabel}
+      </SystemButton>
+    </div>
+  );
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.activity.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.activity.spec.tsx
@@ -1,6 +1,6 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { useState } from "react";
-import { TooltipProvider } from "@tutti-os/ui-system";
+import { toast, TooltipProvider } from "@tutti-os/ui-system";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentActivitySnapshot } from "@tutti-os/agent-activity-core";
 import { setAgentHostApiForTests } from "../../../agentActivityHost";
@@ -73,6 +73,56 @@ describe("AgentGUIConversationRailPane Activity capability", () => {
     expect(toastError).toHaveBeenCalledTimes(1);
     expect(toastError).toHaveBeenCalledWith("Could not load sessions");
     expect(screen.getByText("Session 1")).toBeTruthy();
+  });
+
+  it("falls back to the UI toast when the host does not provide one", () => {
+    const fallbackToastError = vi.spyOn(toast, "error");
+    setAgentHostApiForTests({
+      clipboard: {},
+      filesystem: {},
+      workspace: {}
+    } as never);
+    renderPane({
+      capability: false,
+      conversations: [
+        { ...conversationFixture(), railSectionKey: "conversations" }
+      ],
+      retryRuntimeRail: vi.fn(() => Promise.resolve()),
+      runtimeRailFailed: true,
+      runtimeRailMemberships: [
+        {
+          id: "conversations",
+          kind: "conversations",
+          project: null,
+          sessionIds: ["session-1"]
+        }
+      ],
+      runtimeSectionsEnabled: true
+    });
+
+    expect(fallbackToastError).toHaveBeenCalledWith("Could not load sessions");
+    fallbackToastError.mockRestore();
+  });
+
+  it("keeps Activity View visible while the rail list is loading", async () => {
+    vi.useFakeTimers();
+    try {
+      renderPane({
+        capability: true,
+        runtimeRailSectionsPending: true,
+        runtimeSectionsEnabled: true
+      });
+      fireEvent.click(screen.getByTestId("agent-gui-activity-view-toggle"));
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      expect(screen.getByRole("heading", { name: "Priority" })).toBeTruthy();
+      expect(screen.queryByText("Loading sessions")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("toggles an in-memory Activity View without requesting another page", () => {
@@ -178,6 +228,7 @@ function renderPane({
   runtimeRailConversations = [],
   runtimeRailFailed = false,
   runtimeRailMemberships = null,
+  runtimeRailSectionsPending = false,
   runtimeSectionsEnabled = false,
   retryRuntimeRail = vi.fn(() => Promise.resolve()),
   activityConversations: requestedActivityConversations,
@@ -191,6 +242,7 @@ function renderPane({
   runtimeRailMemberships?: ReturnType<
     typeof useAgentGUIConversationRailQuery
   >["runtimeRailMemberships"];
+  runtimeRailSectionsPending?: boolean;
   runtimeSectionsEnabled?: boolean;
   retryRuntimeRail?: () => Promise<void>;
   activityConversations?: AgentGUIConversationSummary[];
@@ -242,6 +294,7 @@ function renderPane({
           runtimeRailConversations,
           runtimeRailFailed,
           runtimeRailMemberships,
+          runtimeRailSectionsPending,
           runtimeSectionsEnabled,
           retryRuntimeRail
         }}

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.activity.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.activity.spec.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { TooltipProvider } from "@tutti-os/ui-system";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentActivitySnapshot } from "@tutti-os/agent-activity-core";
+import { setAgentHostApiForTests } from "../../../agentActivityHost";
 import {
   AgentGUIRuntimeProvider,
   type AgentGUIRuntime
@@ -18,6 +19,60 @@ describe("AgentGUIConversationRailPane Activity capability", () => {
     renderPane({ capability: false });
 
     expect(screen.queryByTestId("agent-gui-activity-view-toggle")).toBeNull();
+  });
+
+  it("surfaces a rail load failure with a retry action", () => {
+    const retryRuntimeRail = vi.fn(() => Promise.resolve());
+    renderPane({
+      activityConversations: [],
+      capability: false,
+      conversations: [],
+      retryRuntimeRail,
+      runtimeRailFailed: true,
+      runtimeSectionsEnabled: true
+    });
+
+    expect(
+      screen.getByTestId("agent-gui-conversation-rail-load-error")
+    ).toHaveTextContent("Could not load sessions");
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(retryRuntimeRail).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains existing sessions while reporting a rail refresh failure through a toast", () => {
+    const toastError = vi.fn();
+    setAgentHostApiForTests({
+      clipboard: {},
+      filesystem: {},
+      toast: { error: toastError },
+      workspace: {}
+    } as never);
+    renderPane({
+      capability: false,
+      conversations: [
+        { ...conversationFixture(), railSectionKey: "conversations" }
+      ],
+      retryRuntimeRail: vi.fn(() => Promise.resolve()),
+      runtimeRailFailed: true,
+      runtimeRailMemberships: [
+        {
+          id: "conversations",
+          kind: "conversations",
+          project: null,
+          sessionIds: ["session-1"]
+        }
+      ],
+      runtimeSectionsEnabled: true
+    });
+
+    expect(
+      screen.queryByTestId("agent-gui-conversation-rail-load-error")
+    ).toBeNull();
+    expect(toastError).toHaveBeenCalledTimes(1);
+    expect(toastError).toHaveBeenCalledWith("Could not load sessions");
+    expect(screen.getByText("Session 1")).toBeTruthy();
   });
 
   it("toggles an in-memory Activity View without requesting another page", () => {
@@ -121,6 +176,10 @@ function renderPane({
   hasUnreadCompletion = false,
   listPage = vi.fn(),
   runtimeRailConversations = [],
+  runtimeRailFailed = false,
+  runtimeRailMemberships = null,
+  runtimeSectionsEnabled = false,
+  retryRuntimeRail = vi.fn(() => Promise.resolve()),
   activityConversations: requestedActivityConversations,
   conversations: requestedConversations
 }: {
@@ -128,6 +187,12 @@ function renderPane({
   hasUnreadCompletion?: boolean;
   listPage?: ReturnType<typeof vi.fn>;
   runtimeRailConversations?: AgentGUIConversationSummary[];
+  runtimeRailFailed?: boolean;
+  runtimeRailMemberships?: ReturnType<
+    typeof useAgentGUIConversationRailQuery
+  >["runtimeRailMemberships"];
+  runtimeSectionsEnabled?: boolean;
+  retryRuntimeRail?: () => Promise<void>;
   activityConversations?: AgentGUIConversationSummary[];
   conversations?: AgentGUIConversationSummary[];
 }) {
@@ -174,7 +239,11 @@ function renderPane({
           ...RAIL_QUERY,
           activityController,
           activityConversations,
-          runtimeRailConversations
+          runtimeRailConversations,
+          runtimeRailFailed,
+          runtimeRailMemberships,
+          runtimeSectionsEnabled,
+          retryRuntimeRail
         }}
         revealRequest={null}
         uiLanguage="en"
@@ -241,10 +310,12 @@ const RAIL_QUERY = {
     sessionIds: []
   },
   runtimeRailConversations: [],
+  runtimeRailFailed: false,
   runtimeRailMemberships: null,
   runtimeRailReconcilingSessionIds: new Set<string>(),
   runtimeRailScopeResolved: true,
   runtimeRailSectionsPending: false,
+  retryRuntimeRail: () => Promise.resolve(),
   runtimeSectionsEnabled: false,
   sectionPageStates: new Map()
 } as unknown as ReturnType<typeof useAgentGUIConversationRailQuery>;
@@ -266,11 +337,13 @@ const LABELS = {
   activityToday: "Today",
   activityYesterday: "Yesterday",
   conversationUnavailable: "Session unavailable",
+  conversationsLoadFailed: "Could not load sessions",
   loadingConversations: "Loading sessions",
   newConversation: "New session",
   noConversations: "No sessions",
   projectRailCreateProject: "New project",
   projectRailLinkExistingProject: "Link project",
+  retryConversations: "Retry",
   retrySearch: "Retry",
   searchFailed: "Search failed",
   searchNoConversations: "No results",

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.tsx
@@ -1,10 +1,9 @@
 import { Fragment, memo, useEffect, useMemo, useRef, useState } from "react";
-import { Button as SystemButton } from "@tutti-os/ui-system";
 import { ScrollArea } from "@tutti-os/ui-system/components";
 import type { UiLanguage } from "../../../contexts/settings/domain/agentSettings";
 import type { WorkspaceLinkAction } from "../../../actions/workspaceLinkActions";
 import type { WorkspaceUserProjectI18nRuntime } from "@tutti-os/workspace-user-project/i18n";
-import { AgentConversationListSkeleton } from "../AgentConversationListSkeleton";
+import { useOptionalAgentHostApi } from "../../../agentActivityHost";
 import type { AgentGUINodeViewModel } from "../model/agentGuiNodeTypes";
 import { matchesAgentGUIConversationSummaryFilter } from "../model/agentGuiConversationFilter";
 import type { ConversationSection } from "../agentGuiNodeViewConversation";
@@ -29,14 +28,14 @@ import { useAgentGUIProjectDrag } from "../controller/useAgentGUIProjectDrag";
 import { AgentGUIConversationRailSection } from "./AgentGUIConversationRailSection";
 import { AgentGUIConversationActivityView } from "./AgentGUIConversationActivityView";
 import { AgentGUIConversationRailToolbar } from "./AgentGUIConversationRailToolbar";
+import { AgentGUIConversationRailContentState } from "./AgentGUIConversationRailContentState";
 import { AgentGUIConversationRailSectionPresentationProvider } from "./agentGUIConversationRailSectionPresentationContext";
 import { AgentGUIProjectActionConfirmationDialog } from "./AgentGUIProjectActionConfirmationDialog";
 import { AgentGUIProjectRailHeader } from "./AgentGUIConversationRailItem";
 import {
   agentGuiPerfNowMs,
   conversationPlainTitle,
-  roundAgentGuiPerfMs,
-  useStableEventCallback
+  roundAgentGuiPerfMs
 } from "./agentGUIViewUtils";
 import type { AgentGUIConversationRailLabels } from "./agentGUIConversationRailLabels";
 import styles from "../AgentGUINode.styles";
@@ -44,7 +43,12 @@ import { useAgentGUIConversationRailViewState } from "./useAgentGUIConversationR
 import { useAgentGUIProjectMenuState } from "./useAgentGUIProjectMenuState";
 import { useAgentGUIConversationActivityView } from "../controller/useAgentGUIConversationActivityView";
 import { useDelayedBoolean } from "../controller/useDelayedBoolean";
-import type { AgentGUIConversationFilterTargetSelection } from "./agentGUIConversationRailTypes";
+import type {
+  AgentGUIConversationFilterTargetSelection,
+  AgentGUIProjectActionDialog
+} from "./agentGUIConversationRailTypes";
+import { useAgentGUIConversationRailBatchDeletion } from "./useAgentGUIConversationRailBatchDeletion";
+export type { AgentGUIProjectActionDialog } from "./agentGUIConversationRailTypes";
 export interface AgentGUIConversationRailControllerProps {
   activityContextKey?: string;
   conversations: AgentGUINodeViewModel["rail"]["conversations"];
@@ -114,25 +118,6 @@ export type AgentGUIConversationRailPaneProps =
     railQuery: ReturnType<typeof useAgentGUIConversationRailQuery>;
   };
 
-export type AgentGUIProjectActionDialog =
-  | {
-      kind: "batch-delete";
-      conversationCount: number;
-      label: string;
-      sessionIds: string[];
-    }
-  | {
-      kind: "batch-delete-conversations";
-      conversationCount: number;
-      label: string;
-      sessionIds: string[];
-    }
-  | {
-      kind: "remove";
-      label: string;
-      path: string;
-    };
-
 type AgentGUIConversationRailDataProps = Pick<
   AgentGUIConversationRailControllerProps,
   "conversations" | "userProjects" | "workspaceId"
@@ -184,12 +169,14 @@ export const AgentGUIConversationRailPane = memo(
     onConversationQueryChange
   }: AgentGUIConversationRailPaneProps): React.JSX.Element {
     "use memo";
+    const agentHostApi = useOptionalAgentHostApi();
     const [pendingProjectAction, setPendingProjectAction] =
       useState<AgentGUIProjectActionDialog | null>(null);
     const [isRequestingBatchDeletion, setIsRequestingBatchDeletion] =
       useState(false);
     const { railSearch } = railQuery;
     const railElementRef = useRef<HTMLElement | null>(null);
+    const railFailureToastShownRef = useRef(false);
     const railActiveConversationRef = useRef<
       AgentGUINodeViewModel["rail"]["conversations"]
     >([]);
@@ -405,6 +392,9 @@ export const AgentGUIConversationRailPane = memo(
       userProjects
     ]);
     const groupedConversations = groupedConversationResult.groups;
+    const hasConversations = groupedConversations.some(
+      (section) => section.items.length > 0
+    );
     const appendProjectRailHeader =
       groupedConversations.length > 0 &&
       !groupedConversations.some(
@@ -429,38 +419,17 @@ export const AgentGUIConversationRailPane = memo(
       conversationFilter.kind === "agentTarget"
         ? conversationFilter.agentTargetId.trim()
         : "";
-    const requestSectionBatchDeletion = useStableEventCallback(
-      (section: ConversationSection) => {
-        if (
-          !batchDeletionAvailable ||
-          isInteractionLocked() ||
-          isDeletingProjectConversations ||
-          isRequestingBatchDeletion
-        ) {
-          return;
-        }
-        setIsRequestingBatchDeletion(true);
-        void onConfirmDeleteProjectConversations(
-          section.id,
-          sectionAgentTargetId || undefined
-        )
-          .then((sessionIds) => {
-            if (isInteractionLocked() || sessionIds.length === 0) {
-              return;
-            }
-            setPendingProjectAction({
-              kind:
-                section.kind === "project"
-                  ? "batch-delete"
-                  : "batch-delete-conversations",
-              conversationCount: sessionIds.length,
-              label: section.label,
-              sessionIds: [...sessionIds]
-            });
-          })
-          .finally(() => setIsRequestingBatchDeletion(false));
-      }
-    );
+    const requestSectionBatchDeletion =
+      useAgentGUIConversationRailBatchDeletion({
+        batchDeletionAvailable,
+        isDeletingProjectConversations,
+        isInteractionLocked,
+        isRequestingBatchDeletion,
+        onConfirmDeleteProjectConversations,
+        sectionAgentTargetId,
+        setIsRequestingBatchDeletion,
+        setPendingProjectAction
+      });
     const isRuntimeRailLoading = isConversationRailInitialLoadPending({
       pending: runtimeRailSectionsPending,
       runtimeSectionsEnabled,
@@ -480,6 +449,13 @@ export const AgentGUIConversationRailPane = memo(
       backendSearchActive &&
       railSearch.failed &&
       railSearch.sessionIds.length === 0;
+    const conversationRailError =
+      runtimeSectionsEnabled &&
+      railQuery.runtimeRailFailed &&
+      runtimeRailScopeResolved &&
+      !backendSearchActive &&
+      !activityView.presentationActive;
+    const hostToast = agentHostApi?.toast;
     const railViewState = useAgentGUIConversationRailViewState({
       activeConversationId,
       contentReady:
@@ -509,8 +485,20 @@ export const AgentGUIConversationRailPane = memo(
     });
     const projectDragLocked = projectDragBaseLocked || isProjectMovePending;
     useEffect(() => {
+      if (!conversationRailError || !hasConversations) {
+        railFailureToastShownRef.current = false;
+      } else if (!railFailureToastShownRef.current && hostToast) {
+        railFailureToastShownRef.current = true;
+        hostToast.error(labels.conversationsLoadFailed);
+      }
       return installProjectDragGlobalListeners();
-    }, [installProjectDragGlobalListeners]);
+    }, [
+      conversationRailError,
+      hasConversations,
+      hostToast,
+      installProjectDragGlobalListeners,
+      labels.conversationsLoadFailed
+    ]);
 
     return (
       <aside
@@ -531,255 +519,256 @@ export const AgentGUIConversationRailPane = memo(
           className="min-h-0 flex-1 [&_[data-orientation=vertical][data-slot=scroll-area-scrollbar]]:opacity-100"
           viewportRef={railViewState.conversationListRef}
           viewportClassName={styles.conversationList}
+          viewportContentStyle={{
+            display: "flex",
+            flexDirection: "column",
+            minHeight: "100%"
+          }}
           viewportProps={{
             onDragOver: keepValidProjectDropTarget,
             onDrop: dropProject
           }}
         >
-          {activityView.presentationActive && activityView.projection ? (
-            <AgentGUIConversationActivityView
-              activeConversationId={activeConversationId}
-              conversationsById={activityView.conversationsById}
-              isDeletingConversation={isDeletingConversation}
-              isRailInteractionLocked={isInteractionLocked}
-              labels={labels}
-              pendingDeleteConversationId={pendingDeleteConversationId}
-              projection={activityView.projection}
-              registerItemElement={
-                railViewState.registerConversationItemElement
-              }
-              uiLanguage={uiLanguage}
-              workspaceId={workspaceId}
-              onCancelDeleteConversation={onCancelDeleteConversation}
-              onConfirmDeleteConversation={onConfirmDeleteConversation}
-              onMarkConversationUnread={onMarkConversationUnread}
-              onOpenConversationWindow={onOpenConversationWindow}
-              onRequestDeleteConversation={onRequestDeleteConversation}
-              onRequestRenameConversation={onRequestRenameConversation}
-              onSelectConversation={onSelectConversation}
-              onToggleConversationPinned={onToggleConversationPinned}
-            />
-          ) : shouldShowConversationSkeleton ? (
-            <AgentConversationListSkeleton
-              label={labels.loadingConversations}
-            />
-          ) : shouldShowConversationSearchError ? (
-            <div className={styles.emptyState}>
-              <span>{labels.searchFailed}</span>
-              <SystemButton
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={railSearch.retry}
-              >
-                {labels.retrySearch}
-              </SystemButton>
-            </div>
-          ) : shouldShowConversationEmptyState ? (
-            <div className={styles.emptyState}>
-              <span>
-                {conversationQuery.trim()
-                  ? labels.searchNoConversations
-                  : conversations.length === 0
-                    ? labels.noConversations
-                    : labels.conversationUnavailable}
-              </span>
-            </div>
-          ) : (
-            <fieldset className="contents" disabled={railInteractionsLocked}>
-              {groupedConversations.map((section, sectionIndex) => {
-                const projectPath =
-                  section.kind === "project"
-                    ? (section.project?.path ?? "")
-                    : "";
-                const projectLabel =
-                  section.kind === "project" ? section.label : "";
-                const isProjectSection = section.kind === "project";
-                const {
-                  showPinnedHeader: showPinnedProjectHeader,
-                  showProjectsHeader: showProjectRailHeader
-                } = conversationRailSectionHeaderVisibility(
-                  groupedConversations,
-                  sectionIndex
-                );
-                const isSectionCollapsed =
-                  isProjectSection &&
-                  railViewState.collapsedSectionIds.has(section.id);
-                const sectionPageState = sectionPageStates.get(section.id);
-                const searchSectionHasMore =
-                  backendSearchActive &&
-                  sectionIndex === groupedConversations.length - 1 &&
-                  railSearch.hasMore;
-                const activeOverlayConversation =
-                  !backendSearchActive &&
-                  railActiveOverlay?.sectionId === section.id &&
-                  (!conversationQuery.trim() ||
-                    filteredConversations.some(
-                      (conversation) =>
-                        conversation.id === railActiveOverlay.conversation.id
-                    ))
-                    ? railActiveOverlay.conversation
-                    : null;
-                const activeOverlayIsCanonical = Boolean(
-                  activeOverlayConversation &&
-                  section.items.some(
-                    (item) =>
-                      item.projectionSource !== "pending_activation" &&
-                      item.id === activeOverlayConversation.id
-                  )
-                );
-                const activeOverlayCountsTowardTotal = Boolean(
-                  activeOverlayConversation &&
-                  activeOverlayConversation.projectionSource !==
-                    "pending_activation" &&
-                  matchesAgentGUIConversationSummaryFilter(
-                    activeOverlayConversation,
-                    conversationFilter
-                  )
-                );
-                const sectionTotalCount = backendSearchActive
-                  ? section.items.length + (searchSectionHasMore ? 1 : 0)
-                  : (sectionPageState?.totalCount ??
-                    section.items.filter(
-                      (item) => item.projectionSource !== "pending_activation"
-                    ).length +
-                      (activeOverlayCountsTowardTotal &&
-                      !activeOverlayIsCanonical
-                        ? 1
-                        : 0));
-                const sectionHasMore =
-                  searchSectionHasMore ||
-                  (!conversationQuery.trim() &&
-                    sectionPageState?.hasMore === true);
-                const batchDeletionDisabled =
-                  !batchDeletionAvailable ||
-                  hasConversationQuery ||
-                  (section.items.length === 0 && !sectionHasMore) ||
-                  isDeletingProjectConversations ||
-                  isRequestingBatchDeletion;
-                return (
-                  <Fragment key={section.id}>
-                    {showPinnedProjectHeader ? (
-                      <div className={styles.pinnedProjectRailHeader}>
-                        {labels.sectionPinned}
-                      </div>
-                    ) : null}
-                    {showProjectRailHeader ? (
-                      <AgentGUIProjectRailHeader
-                        disabled={
-                          railInteractionsLocked || isUserProjectMutationPending
-                        }
-                        labels={labels}
-                        selectProjectDirectory={selectProjectDirectory}
-                        workspaceUserProjectI18n={workspaceUserProjectI18n}
-                      />
-                    ) : null}
-                    <AgentGUIConversationRailSectionPresentationProvider
-                      batchDeletionDisabled={batchDeletionDisabled}
-                      projectActionLocked={projectActionLocked}
-                      projectDragDisabled={projectDragLocked}
-                    >
-                      <AgentGUIConversationRailSection
-                        activeConversation={activeOverlayConversation}
-                        activeConversationCountsTowardTotal={
-                          activeOverlayCountsTowardTotal
-                        }
-                        activeConversationId={conversationRailSectionActiveConversationId(
-                          {
-                            activeConversation: activeOverlayConversation,
-                            activeConversationId,
-                            section
+          <AgentGUIConversationRailContentState
+            conversationQuery={conversationQuery}
+            conversations={conversations}
+            hasConversations={hasConversations}
+            isLoading={shouldShowConversationSkeleton}
+            labels={labels}
+            onRetry={() => {
+              void railQuery.retryRuntimeRail();
+            }}
+            onRetrySearch={railSearch.retry}
+            railError={conversationRailError}
+            searchError={shouldShowConversationSearchError}
+            showEmptyState={shouldShowConversationEmptyState}
+          >
+            {activityView.presentationActive && activityView.projection ? (
+              <AgentGUIConversationActivityView
+                activeConversationId={activeConversationId}
+                conversationsById={activityView.conversationsById}
+                isDeletingConversation={isDeletingConversation}
+                isRailInteractionLocked={isInteractionLocked}
+                labels={labels}
+                pendingDeleteConversationId={pendingDeleteConversationId}
+                projection={activityView.projection}
+                registerItemElement={
+                  railViewState.registerConversationItemElement
+                }
+                uiLanguage={uiLanguage}
+                workspaceId={workspaceId}
+                onCancelDeleteConversation={onCancelDeleteConversation}
+                onConfirmDeleteConversation={onConfirmDeleteConversation}
+                onMarkConversationUnread={onMarkConversationUnread}
+                onOpenConversationWindow={onOpenConversationWindow}
+                onRequestDeleteConversation={onRequestDeleteConversation}
+                onRequestRenameConversation={onRequestRenameConversation}
+                onSelectConversation={onSelectConversation}
+                onToggleConversationPinned={onToggleConversationPinned}
+              />
+            ) : (
+              <fieldset className="contents" disabled={railInteractionsLocked}>
+                {groupedConversations.map((section, sectionIndex) => {
+                  const projectPath =
+                    section.kind === "project"
+                      ? (section.project?.path ?? "")
+                      : "";
+                  const projectLabel =
+                    section.kind === "project" ? section.label : "";
+                  const isProjectSection = section.kind === "project";
+                  const {
+                    showPinnedHeader: showPinnedProjectHeader,
+                    showProjectsHeader: showProjectRailHeader
+                  } = conversationRailSectionHeaderVisibility(
+                    groupedConversations,
+                    sectionIndex
+                  );
+                  const isSectionCollapsed =
+                    isProjectSection &&
+                    railViewState.collapsedSectionIds.has(section.id);
+                  const sectionPageState = sectionPageStates.get(section.id);
+                  const searchSectionHasMore =
+                    backendSearchActive &&
+                    sectionIndex === groupedConversations.length - 1 &&
+                    railSearch.hasMore;
+                  const activeOverlayConversation =
+                    !backendSearchActive &&
+                    railActiveOverlay?.sectionId === section.id &&
+                    (!conversationQuery.trim() ||
+                      filteredConversations.some(
+                        (conversation) =>
+                          conversation.id === railActiveOverlay.conversation.id
+                      ))
+                      ? railActiveOverlay.conversation
+                      : null;
+                  const activeOverlayIsCanonical = Boolean(
+                    activeOverlayConversation &&
+                    section.items.some(
+                      (item) =>
+                        item.projectionSource !== "pending_activation" &&
+                        item.id === activeOverlayConversation.id
+                    )
+                  );
+                  const activeOverlayCountsTowardTotal = Boolean(
+                    activeOverlayConversation &&
+                    activeOverlayConversation.projectionSource !==
+                      "pending_activation" &&
+                    matchesAgentGUIConversationSummaryFilter(
+                      activeOverlayConversation,
+                      conversationFilter
+                    )
+                  );
+                  const sectionTotalCount = backendSearchActive
+                    ? section.items.length + (searchSectionHasMore ? 1 : 0)
+                    : (sectionPageState?.totalCount ??
+                      section.items.filter(
+                        (item) => item.projectionSource !== "pending_activation"
+                      ).length +
+                        (activeOverlayCountsTowardTotal &&
+                        !activeOverlayIsCanonical
+                          ? 1
+                          : 0));
+                  const sectionHasMore =
+                    searchSectionHasMore ||
+                    (!conversationQuery.trim() &&
+                      sectionPageState?.hasMore === true);
+                  const batchDeletionDisabled =
+                    !batchDeletionAvailable ||
+                    hasConversationQuery ||
+                    (section.items.length === 0 && !sectionHasMore) ||
+                    isDeletingProjectConversations ||
+                    isRequestingBatchDeletion;
+                  return (
+                    <Fragment key={section.id}>
+                      {showPinnedProjectHeader ? (
+                        <div className={styles.pinnedProjectRailHeader}>
+                          {labels.sectionPinned}
+                        </div>
+                      ) : null}
+                      {showProjectRailHeader ? (
+                        <AgentGUIProjectRailHeader
+                          disabled={
+                            railInteractionsLocked ||
+                            isUserProjectMutationPending
                           }
-                        )}
-                        createConversationDisabled={createConversationDisabled}
-                        isDeletingConversation={isDeletingConversation}
-                        isLoadingMoreConversations={
-                          backendSearchActive
-                            ? railSearch.loadingMore
-                            : (sectionPageState?.isLoading ?? false)
-                        }
-                        isRailInteractionLocked={isInteractionLocked}
-                        isProjectActionLocked={isProjectActionLocked}
-                        projectDragging={
-                          projectDragState !== null &&
-                          projectDragState.projectId === section.project?.id
-                        }
-                        projectDropIndicator={
-                          projectDragState?.indicatorSectionId === section.id
-                            ? projectDragState.indicator
-                            : null
-                        }
-                        isSectionCollapsed={isSectionCollapsed}
-                        labels={labels}
-                        pendingDeleteConversationId={
-                          pendingDeleteConversationId
-                        }
-                        projectLabel={projectLabel}
-                        projectPath={projectPath}
-                        registerItemElement={
-                          railViewState.registerConversationItemElement
-                        }
-                        section={section}
-                        sectionHasMore={sectionHasMore}
-                        sectionTotalCount={sectionTotalCount}
-                        visibleItemLimit={railViewState.visibleItemLimitForSection(
-                          section.id
-                        )}
-                        uiLanguage={uiLanguage}
-                        workspaceId={workspaceId}
-                        onCancelDeleteConversation={onCancelDeleteConversation}
-                        onConfirmDeleteConversation={
-                          onConfirmDeleteConversation
-                        }
-                        onCreateConversation={onCreateConversation}
-                        onLoadMoreConversations={
-                          backendSearchActive
-                            ? railSearch.loadMore
-                            : loadMoreSectionConversations
-                        }
-                        onRequestDeleteConversation={
-                          onRequestDeleteConversation
-                        }
-                        onRequestRenameConversation={
-                          onRequestRenameConversation
-                        }
-                        onSelectConversation={onSelectConversation}
-                        onRequestSectionBatchDeletion={
-                          requestSectionBatchDeletion
-                        }
-                        setPendingProjectAction={setPendingProjectAction}
-                        onToggleConversationPinned={onToggleConversationPinned}
-                        onToggleProjectPinned={onToggleProjectPinned}
-                        onMarkConversationUnread={onMarkConversationUnread}
-                        onOpenProjectFiles={onOpenProjectFiles}
-                        onOpenConversationWindow={onOpenConversationWindow}
-                        onToggleProjectSectionCollapsed={
-                          railViewState.toggleProjectSectionCollapsed
-                        }
-                        onVisibleItemLimitChange={
-                          railViewState.setSectionVisibleItemLimit
-                        }
-                        onProjectDragStart={startProjectDrag}
-                        onProjectDragEnd={clearProjectDrag}
-                        onProjectDragOver={updateProjectDropTarget}
-                        onProjectMenuOpenChange={onProjectMenuOpenChange}
-                      />
-                    </AgentGUIConversationRailSectionPresentationProvider>
-                  </Fragment>
-                );
-              })}
-              {appendProjectRailHeader ? (
-                <AgentGUIProjectRailHeader
-                  disabled={
-                    railInteractionsLocked || isUserProjectMutationPending
-                  }
-                  labels={labels}
-                  selectProjectDirectory={selectProjectDirectory}
-                  workspaceUserProjectI18n={workspaceUserProjectI18n}
-                />
-              ) : null}
-            </fieldset>
-          )}
+                          labels={labels}
+                          selectProjectDirectory={selectProjectDirectory}
+                          workspaceUserProjectI18n={workspaceUserProjectI18n}
+                        />
+                      ) : null}
+                      <AgentGUIConversationRailSectionPresentationProvider
+                        batchDeletionDisabled={batchDeletionDisabled}
+                        projectActionLocked={projectActionLocked}
+                        projectDragDisabled={projectDragLocked}
+                      >
+                        <AgentGUIConversationRailSection
+                          activeConversation={activeOverlayConversation}
+                          activeConversationCountsTowardTotal={
+                            activeOverlayCountsTowardTotal
+                          }
+                          activeConversationId={conversationRailSectionActiveConversationId(
+                            {
+                              activeConversation: activeOverlayConversation,
+                              activeConversationId,
+                              section
+                            }
+                          )}
+                          createConversationDisabled={
+                            createConversationDisabled
+                          }
+                          isDeletingConversation={isDeletingConversation}
+                          isLoadingMoreConversations={
+                            backendSearchActive
+                              ? railSearch.loadingMore
+                              : (sectionPageState?.isLoading ?? false)
+                          }
+                          isRailInteractionLocked={isInteractionLocked}
+                          isProjectActionLocked={isProjectActionLocked}
+                          projectDragging={
+                            projectDragState !== null &&
+                            projectDragState.projectId === section.project?.id
+                          }
+                          projectDropIndicator={
+                            projectDragState?.indicatorSectionId === section.id
+                              ? projectDragState.indicator
+                              : null
+                          }
+                          isSectionCollapsed={isSectionCollapsed}
+                          labels={labels}
+                          pendingDeleteConversationId={
+                            pendingDeleteConversationId
+                          }
+                          projectLabel={projectLabel}
+                          projectPath={projectPath}
+                          registerItemElement={
+                            railViewState.registerConversationItemElement
+                          }
+                          section={section}
+                          sectionHasMore={sectionHasMore}
+                          sectionTotalCount={sectionTotalCount}
+                          visibleItemLimit={railViewState.visibleItemLimitForSection(
+                            section.id
+                          )}
+                          uiLanguage={uiLanguage}
+                          workspaceId={workspaceId}
+                          onCancelDeleteConversation={
+                            onCancelDeleteConversation
+                          }
+                          onConfirmDeleteConversation={
+                            onConfirmDeleteConversation
+                          }
+                          onCreateConversation={onCreateConversation}
+                          onLoadMoreConversations={
+                            backendSearchActive
+                              ? railSearch.loadMore
+                              : loadMoreSectionConversations
+                          }
+                          onRequestDeleteConversation={
+                            onRequestDeleteConversation
+                          }
+                          onRequestRenameConversation={
+                            onRequestRenameConversation
+                          }
+                          onSelectConversation={onSelectConversation}
+                          onRequestSectionBatchDeletion={
+                            requestSectionBatchDeletion
+                          }
+                          setPendingProjectAction={setPendingProjectAction}
+                          onToggleConversationPinned={
+                            onToggleConversationPinned
+                          }
+                          onToggleProjectPinned={onToggleProjectPinned}
+                          onMarkConversationUnread={onMarkConversationUnread}
+                          onOpenProjectFiles={onOpenProjectFiles}
+                          onOpenConversationWindow={onOpenConversationWindow}
+                          onToggleProjectSectionCollapsed={
+                            railViewState.toggleProjectSectionCollapsed
+                          }
+                          onVisibleItemLimitChange={
+                            railViewState.setSectionVisibleItemLimit
+                          }
+                          onProjectDragStart={startProjectDrag}
+                          onProjectDragEnd={clearProjectDrag}
+                          onProjectDragOver={updateProjectDropTarget}
+                          onProjectMenuOpenChange={onProjectMenuOpenChange}
+                        />
+                      </AgentGUIConversationRailSectionPresentationProvider>
+                    </Fragment>
+                  );
+                })}
+                {appendProjectRailHeader ? (
+                  <AgentGUIProjectRailHeader
+                    disabled={
+                      railInteractionsLocked || isUserProjectMutationPending
+                    }
+                    labels={labels}
+                    selectProjectDirectory={selectProjectDirectory}
+                    workspaceUserProjectI18n={workspaceUserProjectI18n}
+                  />
+                ) : null}
+              </fieldset>
+            )}
+          </AgentGUIConversationRailContentState>
         </ScrollArea>
         {footer ? <div className="shrink-0 pb-2">{footer}</div> : null}
         <AgentGUIProjectActionConfirmationDialog

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.tsx
@@ -393,8 +393,10 @@ export const AgentGUIConversationRailPane = memo(
       userProjects
     ]);
     const groupedConversations = groupedConversationResult.groups;
-    const hasConversations = groupedConversations.some(
-      (section) => section.items.length > 0
+    const hasRailContent = groupedConversations.some(
+      (section) =>
+        section.items.length > 0 ||
+        (section.kind === "project" && section.project !== null)
     );
     const appendProjectRailHeader =
       groupedConversations.length > 0 &&
@@ -490,7 +492,7 @@ export const AgentGUIConversationRailPane = memo(
     });
     const projectDragLocked = projectDragBaseLocked || isProjectMovePending;
     useEffect(() => {
-      if (!conversationRailError || !hasConversations) {
+      if (!conversationRailError || !hasRailContent) {
         railFailureToastShownRef.current = false;
       } else if (!railFailureToastShownRef.current) {
         railFailureToastShownRef.current = true;
@@ -502,7 +504,7 @@ export const AgentGUIConversationRailPane = memo(
       return installProjectDragGlobalListeners();
     }, [
       conversationRailError,
-      hasConversations,
+      hasRailContent,
       hostToast,
       installProjectDragGlobalListeners,
       labels.conversationsLoadFailed
@@ -540,7 +542,7 @@ export const AgentGUIConversationRailPane = memo(
           <AgentGUIConversationRailContentState
             conversationQuery={conversationQuery}
             conversations={conversations}
-            hasConversations={hasConversations}
+            hasRailContent={hasRailContent}
             isLoading={shouldShowConversationSkeleton && !activityViewVisible}
             labels={labels}
             onRetry={() => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.tsx
@@ -7,6 +7,7 @@ import { useOptionalAgentHostApi } from "../../../agentActivityHost";
 import type { AgentGUINodeViewModel } from "../model/agentGuiNodeTypes";
 import { matchesAgentGUIConversationSummaryFilter } from "../model/agentGuiConversationFilter";
 import type { ConversationSection } from "../agentGuiNodeViewConversation";
+import { showAgentGUIControllerErrorToast } from "../controller/agentGuiController.reporting";
 import {
   isConversationRailInitialLoadPending,
   projectConversationRailMemberships,
@@ -449,12 +450,16 @@ export const AgentGUIConversationRailPane = memo(
       backendSearchActive &&
       railSearch.failed &&
       railSearch.sessionIds.length === 0;
+    const activityProjection = activityView.presentationActive
+      ? activityView.projection
+      : null;
+    const activityViewVisible = activityProjection !== null;
     const conversationRailError =
       runtimeSectionsEnabled &&
       railQuery.runtimeRailFailed &&
       runtimeRailScopeResolved &&
       !backendSearchActive &&
-      !activityView.presentationActive;
+      !activityViewVisible;
     const hostToast = agentHostApi?.toast;
     const railViewState = useAgentGUIConversationRailViewState({
       activeConversationId,
@@ -487,9 +492,12 @@ export const AgentGUIConversationRailPane = memo(
     useEffect(() => {
       if (!conversationRailError || !hasConversations) {
         railFailureToastShownRef.current = false;
-      } else if (!railFailureToastShownRef.current && hostToast) {
+      } else if (!railFailureToastShownRef.current) {
         railFailureToastShownRef.current = true;
-        hostToast.error(labels.conversationsLoadFailed);
+        showAgentGUIControllerErrorToast(
+          hostToast,
+          labels.conversationsLoadFailed
+        );
       }
       return installProjectDragGlobalListeners();
     }, [
@@ -533,7 +541,7 @@ export const AgentGUIConversationRailPane = memo(
             conversationQuery={conversationQuery}
             conversations={conversations}
             hasConversations={hasConversations}
-            isLoading={shouldShowConversationSkeleton}
+            isLoading={shouldShowConversationSkeleton && !activityViewVisible}
             labels={labels}
             onRetry={() => {
               void railQuery.retryRuntimeRail();
@@ -543,7 +551,7 @@ export const AgentGUIConversationRailPane = memo(
             searchError={shouldShowConversationSearchError}
             showEmptyState={shouldShowConversationEmptyState}
           >
-            {activityView.presentationActive && activityView.projection ? (
+            {activityProjection ? (
               <AgentGUIConversationActivityView
                 activeConversationId={activeConversationId}
                 conversationsById={activityView.conversationsById}
@@ -551,7 +559,7 @@ export const AgentGUIConversationRailPane = memo(
                 isRailInteractionLocked={isInteractionLocked}
                 labels={labels}
                 pendingDeleteConversationId={pendingDeleteConversationId}
-                projection={activityView.projection}
+                projection={activityProjection}
                 registerItemElement={
                   railViewState.registerConversationItemElement
                 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailSection.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailSection.tsx
@@ -3,7 +3,7 @@ import type { UiLanguage } from "../../../contexts/settings/domain/agentSettings
 import type { WorkspaceLinkAction } from "../../../actions/workspaceLinkActions";
 import type { ConversationSection } from "../agentGuiNodeViewConversation";
 import type { AgentGUIConversationRailLabels } from "./agentGUIConversationRailLabels";
-import type { AgentGUIProjectActionDialog } from "./AgentGUIConversationRailPane";
+import type { AgentGUIProjectActionDialog } from "./agentGUIConversationRailTypes";
 import { AgentGUIConversationRailItem } from "./AgentGUIConversationRailItem";
 import { AgentGUIConversationRailSectionHeader } from "./AgentGUIConversationRailSectionHeader";
 import { insertConversationRailSectionOverlay } from "../model/agentGuiConversationRail";

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
@@ -59,18 +59,15 @@ export interface AgentWorkspaceReferenceInitialTargetInput {
   composerSelectedProjectPath: string | null;
   userProjects: AgentGUINodeViewModel["rail"]["userProjects"];
 }
-
 export type AgentWorkspaceReferenceInitialTargetResolver = (
   input: AgentWorkspaceReferenceInitialTargetInput
 ) => ReferenceLocateTarget | null;
-
 export interface AgentGUIConversationRailLayout {
   providerRailWidthPx: number;
   conversationRailWidthPx: number;
   leftPanelWidthPx: number;
   resizing: boolean;
 }
-
 // Provider-gate labels live on AgentGUIProviderReadinessLabels; extend it
 // rather than restating every key here.
 export interface AgentGUIViewLabels extends AgentGUIProviderReadinessLabels {
@@ -214,11 +211,13 @@ export interface AgentGUIViewLabels extends AgentGUIProviderReadinessLabels {
   startConversation: string;
   selectConversation: string;
   loadingConversations: string;
+  conversationsLoadFailed: string;
   loadingConversation: string;
   continuedFromTask: string;
   scrollToBottom: string;
   searchNoConversations: string;
   searchFailed: string;
+  retryConversations: string;
   retrySearch: string;
   activityPriority: string;
   activityNothingNeedsAttention: string;
@@ -461,7 +460,6 @@ export type ChromeLabels = {
   retryActivation: string;
   continueInNewConversation: string;
 };
-
 export type InteractivePromptLabels = {
   approvalLead: string;
   fileChangeApprovalLead: string;
@@ -515,6 +513,7 @@ export type AgentGUIConversationRailLabels = Pick<
   | "conversationCopyPreviousMessages"
   | "copiedToClipboard"
   | "copyFailed"
+  | "conversationsLoadFailed"
   | "moreSessionActions"
   | "deleteSession"
   | "deleteSessionConfirm"
@@ -542,6 +541,7 @@ export type AgentGUIConversationRailLabels = Pick<
   | "removeProjectConfirmDescription"
   | "removeProjectConfirmTitle"
   | "renameSession"
+  | "retryConversations"
   | "retrySearch"
   | "searchFailed"
   | "searchNoConversations"

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIProjectActionConfirmationDialog.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIProjectActionConfirmationDialog.tsx
@@ -1,6 +1,6 @@
 import { ConfirmationDialog } from "@tutti-os/ui-system";
 import type { AgentGUIConversationRailLabels } from "./agentGUIConversationRailLabels";
-import type { AgentGUIProjectActionDialog } from "./AgentGUIConversationRailPane";
+import type { AgentGUIProjectActionDialog } from "./agentGUIConversationRailTypes";
 
 const DIALOG_CLASS_NAME =
   "nodrag tsh-desktop-no-drag [-webkit-app-region:no-drag]";

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIConversationRailLabels.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIConversationRailLabels.ts
@@ -115,7 +115,9 @@ export function agentGUIConversationRailLabels(
       "agentHost.agentGui.removeProjectConfirmTitle"
     ),
     renameSession: t("agentHost.agentGui.renameSession"),
+    retryConversations: t("agentHost.agentGui.retryConversations"),
     retrySearch: t("agentHost.agentGui.retrySearch"),
+    conversationsLoadFailed: t("agentHost.agentGui.conversationsLoadFailed"),
     searchFailed: t("agentHost.agentGui.searchFailed"),
     searchNoConversations: t("agentHost.agentGui.searchNoConversations"),
     searchPlaceholder: t("agentHost.agentGui.searchPlaceholder"),

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIConversationRailTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIConversationRailTypes.ts
@@ -8,3 +8,22 @@ export interface AgentGUIConversationFilterTargetInput {
 export type AgentGUIConversationFilterTargetSelection = (
   input: AgentGUIConversationFilterTargetInput
 ) => void;
+
+export type AgentGUIProjectActionDialog =
+  | {
+      kind: "batch-delete";
+      conversationCount: number;
+      label: string;
+      sessionIds: string[];
+    }
+  | {
+      kind: "batch-delete-conversations";
+      conversationCount: number;
+      label: string;
+      sessionIds: string[];
+    }
+  | {
+      kind: "remove";
+      label: string;
+      path: string;
+    };

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIConversationRailBatchDeletion.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIConversationRailBatchDeletion.ts
@@ -1,0 +1,58 @@
+import type { Dispatch, SetStateAction } from "react";
+import type { ConversationSection } from "../agentGuiNodeViewConversation";
+import type { AgentGUIProjectActionDialog } from "./agentGUIConversationRailTypes";
+import { useStableEventCallback } from "./agentGUIViewUtils";
+
+export function useAgentGUIConversationRailBatchDeletion({
+  batchDeletionAvailable,
+  isDeletingProjectConversations,
+  isInteractionLocked,
+  isRequestingBatchDeletion,
+  onConfirmDeleteProjectConversations,
+  sectionAgentTargetId,
+  setIsRequestingBatchDeletion,
+  setPendingProjectAction
+}: {
+  batchDeletionAvailable: boolean;
+  isDeletingProjectConversations: boolean;
+  isInteractionLocked: () => boolean;
+  isRequestingBatchDeletion: boolean;
+  onConfirmDeleteProjectConversations: (
+    sectionKey?: string,
+    agentTargetId?: string | null
+  ) => Promise<string[]>;
+  sectionAgentTargetId: string;
+  setIsRequestingBatchDeletion: Dispatch<SetStateAction<boolean>>;
+  setPendingProjectAction: Dispatch<
+    SetStateAction<AgentGUIProjectActionDialog | null>
+  >;
+}): (section: ConversationSection) => void {
+  return useStableEventCallback((section: ConversationSection) => {
+    if (
+      !batchDeletionAvailable ||
+      isInteractionLocked() ||
+      isDeletingProjectConversations ||
+      isRequestingBatchDeletion
+    ) {
+      return;
+    }
+    setIsRequestingBatchDeletion(true);
+    void onConfirmDeleteProjectConversations(
+      section.id,
+      sectionAgentTargetId || undefined
+    )
+      .then((sessionIds) => {
+        if (isInteractionLocked() || sessionIds.length === 0) return;
+        setPendingProjectAction({
+          kind:
+            section.kind === "project"
+              ? "batch-delete"
+              : "batch-delete-conversations",
+          conversationCount: sessionIds.length,
+          label: section.label,
+          sessionIds: [...sessionIds]
+        });
+      })
+      .finally(() => setIsRequestingBatchDeletion(false));
+  });
+}

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -7953,6 +7953,28 @@ button.agent-gui-node__conversation-section-toggle:hover
   text-align: center;
 }
 
+.agent-gui-node__conversation-rail-load-error {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 16px 14px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 20px;
+  text-align: center;
+}
+
+.agent-gui-node__conversation-rail-load-error-icon {
+  width: 20px;
+  height: 20px;
+  color: var(--text-secondary);
+}
+
 .agent-gui-node__unavailable-chat-empty {
   display: flex;
   flex-direction: column;

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
@@ -439,6 +439,7 @@ export const enAgentGui = {
   startConversation: "Start session",
   selectConversation: "Select a session",
   loadingConversations: "Loading sessions...",
+  conversationsLoadFailed: "Could not load sessions",
   loadingConversation: "Loading session...",
   scrollToBottom: "Scroll to bottom",
   searchNoConversations: "No related sessions",

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGuiSessionActions.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGuiSessionActions.ts
@@ -5,6 +5,7 @@ export const enAgentGuiSessionActions = {
   copyAsMarkdown: "Copy as Markdown",
   copyAsReference: "Copy as reference",
   markSessionUnread: "Mark as unread",
+  retryConversations: "Retry",
   conversationCopyImage: "Image",
   conversationCopyMentionPrefix: "@",
   conversationCopyFile: "File",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
@@ -9,7 +9,6 @@ import { zhCNAgentGuiSessionActions } from "./zh-CN.agentGuiSessionActions.ts";
 import { zhCNAgentGuiCollaboration } from "./zh-CN.agentGuiCollaboration.ts";
 import { zhCNTuttiModePlan } from "./zh-CN.tuttiModePlan.ts";
 import { zhCNAgentGuiComposer } from "./zh-CN.agentGuiComposer.ts";
-
 export const zhCNAgentGui = {
   imageDownloaded: "图片已下载",
   imageLoadFailed: "图片加载失败",
@@ -469,6 +468,7 @@ export const zhCNAgentGui = {
   startConversation: "开始会话",
   selectConversation: "选择一个会话",
   loadingConversations: "正在加载会话...",
+  conversationsLoadFailed: "无法加载会话",
   loadingConversation: "正在加载会话...",
   scrollToBottom: "滚动至底部",
   searchNoConversations: "暂无相关会话",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGuiSessionActions.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGuiSessionActions.ts
@@ -5,6 +5,7 @@ export const zhCNAgentGuiSessionActions = {
   copyAsMarkdown: "复制为 Markdown",
   copyAsReference: "复制为引用",
   markSessionUnread: "标记为未读",
+  retryConversations: "重试",
   conversationCopyImage: "图片",
   conversationCopyMentionPrefix: "@",
   conversationCopyFile: "文件",


### PR DESCRIPTION
## 背景

AgentGUI 左侧会话列表请求失败后没有页面反馈，也没有明确的恢复路径。

## 改动

- 空列表加载失败时展示垂直居中的错误态，并提供“重试”入口。
- 已有列表刷新或分页失败时保留现有列表，仅通过 Toast 告知失败，不再显示固定错误卡。
- 分页失败后保留 cursor/hasMore，重新滚动触发或再次点击“更多”会幂等重试同一分页请求。
- Activity View 在 Rail 初始列表加载期间优先保留内存投影，不被无关的加载骨架屏遮挡。
- 宿主未提供可选 Toast 能力时，已有列表失败降级到 UI System Toast。
- 增加失败恢复、Toast 去重、分页重试和 Activity View 加载期间可见性测试。
- 已移除本地验证使用的临时 mock 代码。

## 验证

- `pnpm check:changed -- --push-ready`
- AgentGUI focused tests：28/28
- typecheck、格式检查、AgentGUI degradation boundary 通过
- 本地 `make dev-gui` 启动并进入测试房间验证

## Review notes

- Architecture：改动限于 AgentGUI Rail 查询失败投影、恢复反馈与 Activity View 加载优先级，不改变 Session/Turn 生命周期所有权。
- Performance：未增加 effect 数量，Pane 文件保持在 800 行以内，degradation 检查通过。
- Consumer compatibility：保留现有类型导出，TSH 使用本地链接包验证通过。
- Durable documentation：已在 `docs/architecture/agent-gui-node.md` 记录 Activity View 与 Rail failure fallback 规则。