### PR TITLE
fix(cli): send schema-declared scalar types to the daemon

### DIFF
--- a/apps/cli/internal/app/command_input.go
+++ b/apps/cli/internal/app/command_input.go
@@ -3,17 +3,91 @@ package app
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/tutti-os/tutti/apps/cli/internal/daemon"
 )
 
 func parseCommandInput(command daemon.Capability, args []string) (map[string]any, error) {
+	input, err := parseCommandArguments(command, args)
+	if err != nil {
+		return nil, err
+	}
+	return typedCommandInput(command.InputSchema, input), nil
+}
+
+func parseCommandArguments(command daemon.Capability, args []string) (map[string]any, error) {
 	if input, ok, err := parsePositionalCommandInput(command, args); ok || err != nil {
 		return input, err
 	}
 	return parseFlagCommandInput(command, args)
+}
+
+// typedCommandInput restores the JSON types the advertised input schema
+// declares. Terminal arguments always arrive as text, and the daemon validates
+// invocation input against that schema before a command binds it, so a numeric
+// or boolean flag has to leave the CLI as a JSON number or boolean rather than
+// a quoted string.
+//
+// Values that do not parse are forwarded untouched: rejecting them here would
+// duplicate daemon-owned validation, and the daemon already reports the
+// authoritative error for the declared type.
+func typedCommandInput(schema map[string]any, input map[string]any) map[string]any {
+	if len(input) == 0 {
+		return input
+	}
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		return input
+	}
+	for name, value := range input {
+		text, isText := value.(string)
+		if !isText {
+			continue
+		}
+		property, declared := properties[name]
+		if !declared {
+			continue
+		}
+		if typed, ok := schemaTypedValue(schemaPropertyType(property), text); ok {
+			input[name] = typed
+		}
+	}
+	return input
+}
+
+func schemaTypedValue(propertyType string, value string) (any, bool) {
+	value = strings.TrimSpace(value)
+	switch propertyType {
+	case "integer":
+		parsed, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return nil, false
+		}
+		return parsed, true
+	case "number":
+		parsed, err := strconv.ParseFloat(value, 64)
+		if err != nil || math.IsNaN(parsed) || math.IsInf(parsed, 0) {
+			return nil, false
+		}
+		return parsed, true
+	case "boolean":
+		// Mirrors the daemon input binder, which has always accepted these
+		// spellings for boolean flags.
+		switch strings.ToLower(value) {
+		case "1", "true", "yes", "on":
+			return true, true
+		case "0", "false", "no", "off":
+			return false, true
+		default:
+			return nil, false
+		}
+	default:
+		return nil, false
+	}
 }
 
 func parseFlagCommandInput(command daemon.Capability, args []string) (map[string]any, error) {

--- a/apps/cli/internal/app/run_test.go
+++ b/apps/cli/internal/app/run_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -691,6 +692,69 @@ func TestRunDynamicCommandAggregatesRepeatedFlags(t *testing.T) {
 	params, ok := input["param"].([]any)
 	if !ok || len(params) != 2 || params[0] != "path=/tmp/a" || params[1] != "mode=preview" {
 		t.Fatalf("param input = %#v", input["param"])
+	}
+}
+
+func TestRunDynamicCommandSendsSchemaDeclaredScalarTypes(t *testing.T) {
+	const capabilities = `{"commands":[{"id":"agent-context.agent.messages","path":["agent","messages"],"summary":"Read messages","inputSchema":{"type":"object","required":["session-id"],"properties":{"session-id":{"type":"string"},"limit":{"type":"integer"},"waterline-percent":{"type":"number"},"follow":{"type":"boolean"}}},"output":{"defaultMode":"json","json":true}}]}`
+	tests := []struct {
+		name      string
+		args      []string
+		wantInput map[string]any
+	}{
+		{
+			name:      "scalar flags reach the daemon as declared JSON types",
+			args:      []string{"agent", "messages", "--session-id", "S-1", "--limit", "25", "--waterline-percent", "12.5", "--follow", "yes"},
+			wantInput: map[string]any{"session-id": "S-1", "limit": float64(25), "waterline-percent": 12.5, "follow": true},
+		},
+		{
+			name:      "a bare boolean flag stays boolean",
+			args:      []string{"agent", "messages", "--session-id", "S-1", "--follow"},
+			wantInput: map[string]any{"session-id": "S-1", "follow": true},
+		},
+		{
+			// Terminal text the declared type cannot hold is forwarded as-is:
+			// the daemon owns input rejection wording, not the CLI.
+			name:      "unparseable values are forwarded unchanged",
+			args:      []string{"agent", "messages", "--session-id", "S-1", "--limit", "many"},
+			wantInput: map[string]any{"session-id": "S-1", "limit": "many"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var invokedBody map[string]any
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/v1/cli/capabilities":
+					_, _ = w.Write([]byte(capabilities))
+				case "/v1/cli/commands/agent-context.agent.messages/invoke":
+					if err := json.NewDecoder(r.Body).Decode(&invokedBody); err != nil {
+						t.Fatalf("decode body: %v", err)
+					}
+					_, _ = w.Write([]byte(`{"ok":true,"output":{"kind":"json","value":{"ok":true}}}`))
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+
+			writeEndpoint(t, server.URL, "token-1")
+
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			if code := runDefaultProgram(t, tt.args, &stdout, &stderr); code != 0 {
+				t.Fatalf("code = %d, stderr = %s", code, stderr.String())
+			}
+			input, ok := invokedBody["input"].(map[string]any)
+			if !ok {
+				t.Fatalf("input = %#v", invokedBody["input"])
+			}
+			if !reflect.DeepEqual(input, tt.wantInput) {
+				t.Fatalf("input = %#v, want %#v", input, tt.wantInput)
+			}
+		})
 	}
 }
 

--- a/apps/cli/internal/app/tutti_mode_plan_contract_test.go
+++ b/apps/cli/internal/app/tutti_mode_plan_contract_test.go
@@ -12,7 +12,8 @@ import (
 const tuttiModePlanCapabilitiesFixture = `{"commands":[
   {"id":"tutti-mode-plan.plan.propose","path":["plan","propose"],"summary":"Propose a Tutti Mode plan","inputSchema":{"type":"object","required":["file","request-id"],"properties":{"file":{"type":"string","description":"Markdown proposal file."},"request-id":{"type":"string"}}},"output":{"defaultMode":"json","json":true},"source":{"kind":"builtin"}},
   {"id":"tutti-mode-plan.plan.revise","path":["plan","revise"],"summary":"Revise a Tutti Mode plan","inputSchema":{"type":"object","required":["workflow-id","file","request-id"],"properties":{"workflow-id":{"type":"string"},"file":{"type":"string"},"request-id":{"type":"string"}}},"output":{"defaultMode":"json","json":true},"source":{"kind":"builtin"}},
-  {"id":"tutti-mode-plan.plan.get","path":["plan","get"],"summary":"Get a Tutti Mode plan","inputSchema":{"type":"object","required":["workflow-id"],"properties":{"workflow-id":{"type":"string"}}},"output":{"defaultMode":"json","json":true},"source":{"kind":"builtin"}}
+  {"id":"tutti-mode-plan.plan.get","path":["plan","get"],"summary":"Get a Tutti Mode plan","inputSchema":{"type":"object","required":["workflow-id"],"properties":{"workflow-id":{"type":"string"}}},"output":{"defaultMode":"json","json":true},"source":{"kind":"builtin"}},
+  {"id":"tutti-mode-plan.plan.issue.schedule","path":["plan","issue","schedule"],"summary":"Schedule exact Tutti Mode Issue tasks","inputSchema":{"type":"object","required":["issue-id","checkpoint-id","expected-graph-revision","task-ids-json","request-id"],"properties":{"issue-id":{"type":"string"},"checkpoint-id":{"type":"string"},"expected-graph-revision":{"type":"integer"},"task-ids-json":{"type":"string"},"request-id":{"type":"string"}}},"output":{"defaultMode":"json","json":true},"source":{"kind":"builtin"}}
 ]}`
 
 func TestRunTuttiModePlanCommandsUseDynamicDaemonCapabilityProtocol(t *testing.T) {
@@ -39,6 +40,69 @@ func TestRunTuttiModePlanCommandsUseDynamicDaemonCapabilityProtocol(t *testing.T
 			commandID: "tutti-mode-plan.plan.get",
 			args:      []string{"plan", "get", "--workflow-id", "WF-1"},
 			wantInput: map[string]any{"workflow-id": "WF-1"},
+		},
+		{
+			// The checkpoint-fenced commands carry an integer revision fence.
+			// The daemon validates invocation input against the advertised
+			// schema before binding it, so the fence has to reach the wire as
+			// a JSON number instead of a quoted terminal argument.
+			name:      "issue schedule",
+			commandID: "tutti-mode-plan.plan.issue.schedule",
+			args: []string{
+				"plan", "issue", "schedule",
+				"--issue-id", "ISSUE-1",
+				"--checkpoint-id", "CP-1",
+				"--expected-graph-revision", "1",
+				"--task-ids-json", `["task-1"]`,
+				"--request-id", "schedule-request-1",
+			},
+			wantInput: map[string]any{
+				"issue-id":                "ISSUE-1",
+				"checkpoint-id":           "CP-1",
+				"expected-graph-revision": 1,
+				"task-ids-json":           `["task-1"]`,
+				"request-id":              "schedule-request-1",
+			},
+		},
+		{
+			name:      "issue schedule with inline flag values",
+			commandID: "tutti-mode-plan.plan.issue.schedule",
+			args: []string{
+				"plan", "issue", "schedule",
+				"--issue-id=ISSUE-1",
+				"--checkpoint-id=CP-1",
+				"--expected-graph-revision=12",
+				`--task-ids-json=["task-1"]`,
+				"--request-id=schedule-request-2",
+			},
+			wantInput: map[string]any{
+				"issue-id":                "ISSUE-1",
+				"checkpoint-id":           "CP-1",
+				"expected-graph-revision": 12,
+				"task-ids-json":           `["task-1"]`,
+				"request-id":              "schedule-request-2",
+			},
+		},
+		{
+			// A value the declared type cannot hold stays untouched so the
+			// daemon owns the rejection wording instead of the CLI.
+			name:      "issue schedule with non-integer revision",
+			commandID: "tutti-mode-plan.plan.issue.schedule",
+			args: []string{
+				"plan", "issue", "schedule",
+				"--issue-id", "ISSUE-1",
+				"--checkpoint-id", "CP-1",
+				"--expected-graph-revision", "1.5",
+				"--task-ids-json", `["task-1"]`,
+				"--request-id", "schedule-request-3",
+			},
+			wantInput: map[string]any{
+				"issue-id":                "ISSUE-1",
+				"checkpoint-id":           "CP-1",
+				"expected-graph-revision": "1.5",
+				"task-ids-json":           `["task-1"]`,
+				"request-id":              "schedule-request-3",
+			},
 		},
 	}
 


### PR DESCRIPTION
## Problem

Every checkpoint-fenced Tutti Mode command is unreachable from a terminal:

```
$ tutti plan issue schedule --json --issue-id X --checkpoint-id Y \
    --expected-graph-revision 7 --task-ids-json '["a"]' --request-id r1
{
  "error": {
    "reasonCode": "input_schema_mismatch",
    "message": "input.expected-graph-revision must be an integer"
  }
}
```

Reported from a real 0.2.20 session: an Agent finished planning, the Issue
materialized, `task-1` was ready — and the Agent could not dispatch it. It
retried `--flag 1`, `--flag=1`, `--json` first, a non-login shell, `1.0`, and
dummy ids; all five checkpoint commands (`schedule` / `mutate` / `acknowledge`
/ `complete` / `stop`) share the fence flag, so the session dead-ended and
asked the user to file a bug.

## Root cause

The CLI stores every flag value as a string (`command_input.go`
`parseFlagCommandInput`) and lets the daemon's input binder coerce it —
`framework.BindInput` has always accepted `"1"` for an `int64` field.

#2004 (`cf33c5f48`) added `validateCapabilityInput` to `Registry.Invoke`, which
now type-checks invocation input against the advertised schema **before** the
command binds it. `schemaNumber` has no `case string`, so the string never
reaches the coercion that used to accept it.

Scope of the break: it is the CLI's stringly-typed transport that is affected —
GUI/HTTP callers send real JSON numbers and pass. Within the CLI it is every
`integer` / `number` flag on builtin and app commands (`computer click --x/--y`,
`agent messages --limit`, `issue list --page-size`, `--token-budget`,
`--quota-waterline-percent`, …) plus `--flag=true` spellings of boolean flags
(bare `--flag` already sent a real boolean and kept working).

## Fix

Restore the declared JSON types in the CLI — the component that loses the type
information, and one that already reads the advertised schema to shape boolean
and array flags. Values the declared type cannot hold are forwarded untouched,
so the CLI adds no validation of its own and the daemon keeps owning the
rejection wording (`apps/cli/AGENTS.md`: *do not duplicate domain validation in
the CLI*).

Fixing the daemon instead was the alternative. It was rejected: that validator
is the trust boundary for connector-supplied schemas, and teaching it to accept
strings would loosen it for untrusted callers to compensate for a first-party
transport detail.

## Testing

- `go test ./...` in `apps/cli` (green; both new tests fail on `main` without
  the source change — verified by stashing it).
- `apps/cli/internal/app/tutti_mode_plan_contract_test.go` now drives the real
  `plan issue schedule` argv through the CLI and asserts the wire payload
  carries `"expected-graph-revision": 1` as a JSON number, in both `--flag v`
  and `--flag=v` spellings, and that a non-integer stays a string.
- `apps/cli/internal/app/run_test.go` locks the generic contract for
  `integer` / `number` / `boolean` flags, bare boolean flags, and pass-through.
- Confirmed against the daemon validator directly (throwaway test, not
  committed): `int64(1)` passes `validateCapabilityInput`, `"1"` fails with the
  exact reported message.

## Not in this PR

The same pre-binding validation also enforces `advertise-required` flags that
the binder still treats as optional, which hard-breaks the legacy
`--provider` path on `agent start`, the skill bundle, and composer options, and
replaces the binder's `hint`-enriched "required input is missing" wording with a
bare `input.<name> is required`. Filed as #2193 and left out of this hotfix so
it stays confined to the paths that were actually failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
