### PR TITLE
backport: detect OpenCode API credentials from config to release/0807

### DIFF
--- a/services/tuttid/service/agentstatus/provider_custom_config.go
+++ b/services/tuttid/service/agentstatus/provider_custom_config.go
@@ -2,6 +2,7 @@ package agentstatus
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -30,7 +31,7 @@ import (
 //
 // The config-file parsing mirrors the runtime's endpoint adaptation in
 // packages/agent/daemon/runtime/provider_endpoint.go (Codex config.toml,
-// Claude settings.json); kept in sync by intent.
+// Claude settings.json, OpenCode provider config); kept in sync by intent.
 
 // providerUsesCustomConfig reports whether the user configured their own API
 // key or a custom API endpoint for the provider — via environment variables OR
@@ -49,6 +50,8 @@ func (s Service) providerUsesCustomConfig(provider string) bool {
 			return s.codexConfigDeclares("base_url", "chatgpt_base_url", "api_key") || s.codexAuthJSONHasAPIKey()
 		case providerregistry.StatusKindClaudeCLI:
 			return s.claudeSettingsDeclares(claudeCustomConfigKeys, true)
+		case providerregistry.StatusKindOpenCodeCLI:
+			return s.openCodeConfigSignals().custom
 		}
 	}
 	return false
@@ -72,9 +75,297 @@ func (s Service) providerHasAPICredential(provider string) bool {
 			return s.codexConfigHasAPICredential() || s.codexAuthJSONHasAPIKey()
 		case providerregistry.StatusKindClaudeCLI:
 			return s.claudeSettingsHasAPICredential()
+		case providerregistry.StatusKindOpenCodeCLI:
+			return s.openCodeConfigSignals().credential
 		}
 	}
 	return false
+}
+
+type openCodeConfigDocument struct {
+	content []byte
+	baseDir string
+}
+
+type openCodeConfigValue struct {
+	value   any
+	baseDir string
+}
+
+type openCodeConfigObject map[string]openCodeConfigValue
+
+type openCodeConfigSignals struct {
+	custom     bool
+	credential bool
+}
+
+// openCodeConfigSignals reads the global OpenCode config sources that can be
+// selected by CCSwitch or the OpenCode CLI. Status detection is intentionally
+// provider-agnostic: the status endpoint has no selected model/provider ID, so
+// any API key in the final merged provider config is treated as an agent-level
+// API credential.
+func (s Service) openCodeConfigSignals() openCodeConfigSignals {
+	result := openCodeConfigSignals{}
+	merged := openCodeConfigObject{}
+	for _, document := range s.openCodeConfigDocuments() {
+		parsed, err := parseOpenCodeConfig(document.content, document.baseDir)
+		if err != nil {
+			// Ignore malformed documents and let the native auth marker/CLI
+			// probe remain authoritative.
+			continue
+		}
+		mergeOpenCodeConfigObject(merged, parsed)
+	}
+
+	providerValue, ok := merged["provider"]
+	if !ok {
+		return result
+	}
+	providers, ok := providerValue.value.(openCodeConfigObject)
+	if !ok {
+		return result
+	}
+	for _, providerValue := range providers {
+		provider, ok := providerValue.value.(openCodeConfigObject)
+		if !ok {
+			continue
+		}
+		optionsValue, ok := provider["options"]
+		if !ok {
+			continue
+		}
+		options, ok := optionsValue.value.(openCodeConfigObject)
+		if !ok {
+			continue
+		}
+		if apiKey, ok := options["apiKey"]; ok && s.openCodeCredentialValueConfigured(apiKey.value, apiKey.baseDir) {
+			result.custom = true
+			result.credential = true
+		}
+		for _, key := range []string{"baseURL", "baseUrl"} {
+			if raw, ok := options[key]; ok && openCodeConfigStringConfigured(raw.value) {
+				result.custom = true
+			}
+		}
+	}
+	return result
+}
+
+// openCodeConfigDocuments resolves the same global locations used by the
+// OpenCode/CCSwitch integration. OPENCODE_CONFIG_DIR selects the global root
+// (otherwise XDG_CONFIG_HOME or the user's default root is used); the
+// OPENCODE_CONFIG file and OPENCODE_CONFIG_CONTENT are layered afterward.
+func (s Service) openCodeConfigDocuments() []openCodeConfigDocument {
+	documents := make([]openCodeConfigDocument, 0, 6)
+	seen := make(map[string]struct{})
+	appendFile := func(path string) {
+		path = filepath.Clean(strings.TrimSpace(path))
+		if path == "." || path == "" {
+			return
+		}
+		if _, ok := seen[path]; ok {
+			return
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return
+		}
+		seen[path] = struct{}{}
+		documents = append(documents, openCodeConfigDocument{content: content, baseDir: filepath.Dir(path)})
+	}
+
+	home, _ := s.homeDir()
+	expand := func(path string) string {
+		return expandHomePath(path, home)
+	}
+
+	configDir := strings.TrimSpace(s.lookupEnv("OPENCODE_CONFIG_DIR"))
+	if configDir != "" {
+		configDir = expand(configDir)
+	} else if xdgConfigHome := strings.TrimSpace(s.lookupEnv("XDG_CONFIG_HOME")); xdgConfigHome != "" {
+		configDir = filepath.Join(expand(xdgConfigHome), "opencode")
+	} else if strings.TrimSpace(home) != "" {
+		configDir = filepath.Join(home, ".config", "opencode")
+	}
+	for _, name := range []string{"config.json", "opencode.json", "opencode.jsonc"} {
+		if configDir != "" {
+			appendFile(filepath.Join(configDir, name))
+		}
+	}
+	if path := strings.TrimSpace(s.lookupEnv("OPENCODE_CONFIG")); path != "" {
+		appendFile(expand(path))
+	}
+	if content := strings.TrimSpace(s.lookupEnv("OPENCODE_CONFIG_CONTENT")); content != "" {
+		documents = append(documents, openCodeConfigDocument{content: []byte(content)})
+	}
+	return documents
+}
+
+func parseOpenCodeConfig(content []byte, baseDir string) (openCodeConfigObject, error) {
+	cleaned, err := stripOpenCodeJSONC(content)
+	if err != nil {
+		return nil, err
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(cleaned, &parsed); err != nil {
+		return nil, err
+	}
+	return openCodeConfigObjectFromMap(parsed, baseDir), nil
+}
+
+func openCodeConfigObjectFromMap(input map[string]any, baseDir string) openCodeConfigObject {
+	result := make(openCodeConfigObject, len(input))
+	for key, value := range input {
+		if child, ok := value.(map[string]any); ok {
+			value = openCodeConfigObjectFromMap(child, baseDir)
+		}
+		result[key] = openCodeConfigValue{value: value, baseDir: baseDir}
+	}
+	return result
+}
+
+func mergeOpenCodeConfigObject(dst, src openCodeConfigObject) {
+	for key, next := range src {
+		current, ok := dst[key]
+		if ok {
+			currentObject, currentOK := current.value.(openCodeConfigObject)
+			nextObject, nextOK := next.value.(openCodeConfigObject)
+			if currentOK && nextOK {
+				mergeOpenCodeConfigObject(currentObject, nextObject)
+				current.value = currentObject
+				dst[key] = current
+				continue
+			}
+		}
+		dst[key] = next
+	}
+}
+
+func (s Service) openCodeCredentialValueConfigured(raw any, baseDir string) bool {
+	value, ok := raw.(string)
+	if !ok {
+		return false
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return false
+	}
+	if strings.HasPrefix(value, "{env:") && strings.HasSuffix(value, "}") {
+		name := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(value, "{env:"), "}"))
+		return name != "" && strings.TrimSpace(s.lookupEnv(name)) != ""
+	}
+	if strings.HasPrefix(value, "{file:") && strings.HasSuffix(value, "}") {
+		path := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(value, "{file:"), "}"))
+		if path == "" {
+			return false
+		}
+		home, _ := s.homeDir()
+		path = expandHomePath(path, home)
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(baseDir, path)
+		}
+		content, err := os.ReadFile(filepath.Clean(path))
+		return err == nil && strings.TrimSpace(string(content)) != ""
+	}
+	return true
+}
+
+func openCodeConfigStringConfigured(raw any) bool {
+	value, ok := raw.(string)
+	return ok && strings.TrimSpace(value) != ""
+}
+
+func stripOpenCodeJSONC(input []byte) ([]byte, error) {
+	output := make([]byte, 0, len(input))
+	inString, escaped, lineComment, blockComment := false, false, false, false
+	for i := 0; i < len(input); i++ {
+		current := input[i]
+		if lineComment {
+			if current == '\n' {
+				lineComment = false
+				output = append(output, current)
+			}
+			continue
+		}
+		if blockComment {
+			if current == '*' && i+1 < len(input) && input[i+1] == '/' {
+				blockComment = false
+				i++
+				continue
+			}
+			if current == '\n' || current == '\r' {
+				output = append(output, current)
+			}
+			continue
+		}
+		if inString {
+			output = append(output, current)
+			if escaped {
+				escaped = false
+			} else if current == '\\' {
+				escaped = true
+			} else if current == '"' {
+				inString = false
+			}
+			continue
+		}
+		switch current {
+		case '"':
+			inString = true
+			output = append(output, current)
+		case '/':
+			if i+1 < len(input) && input[i+1] == '/' {
+				lineComment = true
+				i++
+			} else if i+1 < len(input) && input[i+1] == '*' {
+				blockComment = true
+				i++
+			} else {
+				output = append(output, current)
+			}
+		default:
+			output = append(output, current)
+		}
+	}
+	if blockComment {
+		return nil, fmt.Errorf("unterminated block comment")
+	}
+	return removeOpenCodeTrailingCommas(output), nil
+}
+
+func removeOpenCodeTrailingCommas(input []byte) []byte {
+	output := make([]byte, 0, len(input))
+	inString, escaped := false, false
+	for i := 0; i < len(input); i++ {
+		current := input[i]
+		if inString {
+			output = append(output, current)
+			if escaped {
+				escaped = false
+			} else if current == '\\' {
+				escaped = true
+			} else if current == '"' {
+				inString = false
+			}
+			continue
+		}
+		if current == '"' {
+			inString = true
+			output = append(output, current)
+			continue
+		}
+		if current == ',' {
+			next := i + 1
+			for next < len(input) && (input[next] == ' ' || input[next] == '\t' || input[next] == '\r' || input[next] == '\n') {
+				next++
+			}
+			if next < len(input) && (input[next] == '}' || input[next] == ']') {
+				continue
+			}
+		}
+		output = append(output, current)
+	}
+	return output
 }
 
 func (s Service) codexConfigHasAPICredential() bool {

--- a/services/tuttid/service/agentstatus/provider_custom_config_test.go
+++ b/services/tuttid/service/agentstatus/provider_custom_config_test.go
@@ -107,6 +107,145 @@ func TestProviderUsesCustomConfigClaudeApiKeyHelper(t *testing.T) {
 	}
 }
 
+func TestProviderUsesCustomConfigOpenCodeProviderEndpoint(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".config", "opencode", "opencode.json"), `{
+		"provider": {
+			"newapi": {"options": {"baseURL": "https://gateway.example/v1"}}
+		}
+	}`)
+	svc := customConfigService(home)
+	if !svc.providerUsesCustomConfig(agentprovider.OpenCode) {
+		t.Fatal("expected OpenCode provider baseURL to count as custom config")
+	}
+}
+
+func TestProviderHasAPICredentialOpenCodeProviderAPIKey(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".config", "opencode", "opencode.json"), `{
+		"provider": {
+			"newapi": {"options": {"apiKey": "sk-test"}}
+		}
+	}`)
+	svc := customConfigService(home)
+	if !svc.providerHasAPICredential(agentprovider.OpenCode) {
+		t.Fatal("expected OpenCode provider apiKey to count as an API credential")
+	}
+}
+
+func TestProviderHasAPICredentialOpenCodeConfigDir(t *testing.T) {
+	home := t.TempDir()
+	configDir := filepath.Join(home, "custom-opencode")
+	writeFile(t, filepath.Join(configDir, "opencode.json"), `{
+		"provider": {
+			"newapi": {"options": {"apiKey": "sk-override"}}
+		}
+	}`)
+	svc := customConfigService(home)
+	svc.Environ = func() []string { return []string{"OPENCODE_CONFIG_DIR=" + configDir} }
+	if !svc.providerHasAPICredential(agentprovider.OpenCode) {
+		t.Fatal("expected OPENCODE_CONFIG_DIR provider apiKey to be detected")
+	}
+}
+
+func TestProviderHasAPICredentialOpenCodeConfigContentEnvReference(t *testing.T) {
+	svc := customConfigService(t.TempDir())
+	svc.Environ = func() []string {
+		return []string{
+			"OPENCODE_CONFIG_CONTENT={\"provider\":{\"newapi\":{\"options\":{\"apiKey\":\"{env:NEWAPI_KEY}\"}}}}",
+			"NEWAPI_KEY=sk-env",
+		}
+	}
+	if !svc.providerHasAPICredential(agentprovider.OpenCode) {
+		t.Fatal("expected OpenCode config content env reference to be detected")
+	}
+}
+
+func TestProviderHasAPICredentialOpenCodeEndpointOnlyIsNotCredential(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".config", "opencode", "opencode.json"), `{
+		"provider": {
+			"newapi": {"options": {"baseURL": "https://gateway.example/v1"}}
+		}
+	}`)
+	svc := customConfigService(home)
+	if svc.providerHasAPICredential(agentprovider.OpenCode) {
+		t.Fatal("an OpenCode endpoint without apiKey must not count as an API credential")
+	}
+	if !svc.providerUsesCustomConfig(agentprovider.OpenCode) {
+		t.Fatal("an OpenCode endpoint should still count as custom config")
+	}
+}
+
+func TestProviderHasAPICredentialOpenCodeJSONC(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".config", "opencode", "opencode.jsonc"), `{
+		// CCSwitch/OpenCode also accept JSONC config files.
+		"provider": {
+			"newapi": {
+				"options": {
+					"apiKey": "sk-jsonc",
+				},
+			},
+		},
+	}`)
+	if !customConfigService(home).providerHasAPICredential(agentprovider.OpenCode) {
+		t.Fatal("expected OpenCode JSONC apiKey to be detected")
+	}
+}
+
+func TestProviderHasAPICredentialOpenCodeConfigPrecedence(t *testing.T) {
+	home := t.TempDir()
+	configDir := filepath.Join(home, ".config", "opencode")
+	writeFile(t, filepath.Join(configDir, "config.json"), `{
+		"provider": {"newapi": {"options": {"apiKey": "sk-global"}}}
+	}`)
+	writeFile(t, filepath.Join(configDir, "opencode.jsonc"), `{
+		"provider": {"newapi": {"options": {"apiKey": null}}}
+	}`)
+	if customConfigService(home).providerHasAPICredential(agentprovider.OpenCode) {
+		t.Fatal("a later JSONC null must override an earlier provider apiKey")
+	}
+
+	overrideHome := t.TempDir()
+	overrideConfigDir := filepath.Join(overrideHome, ".config", "opencode")
+	writeFile(t, filepath.Join(overrideConfigDir, "opencode.json"), `{
+		"provider": {"newapi": {"options": {"apiKey": "sk-global"}}}
+	}`)
+	override := filepath.Join(overrideHome, "override.json")
+	writeFile(t, override, `{
+		"provider": {"newapi": {"options": {"apiKey": null}}}
+	}`)
+	svc := customConfigService(overrideHome)
+	svc.Environ = func() []string { return []string{"OPENCODE_CONFIG=" + override} }
+	if svc.providerHasAPICredential(agentprovider.OpenCode) {
+		t.Fatal("OPENCODE_CONFIG must override an earlier global provider apiKey")
+	}
+}
+
+func TestProviderHasAPICredentialOpenCodeFileReference(t *testing.T) {
+	home := t.TempDir()
+	configDir := filepath.Join(home, ".config", "opencode")
+	writeFile(t, filepath.Join(configDir, "secrets", "api-key"), "sk-file\n")
+	writeFile(t, filepath.Join(configDir, "opencode.json"), `{
+		"provider": {"newapi": {"options": {"apiKey": "{file:secrets/api-key}"}}}
+	}`)
+	if !customConfigService(home).providerHasAPICredential(agentprovider.OpenCode) {
+		t.Fatal("expected OpenCode {file:...} apiKey to be detected")
+	}
+}
+
+func TestProviderHasAPICredentialOpenCodeWindowsHomeFileReference(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, "api-key"), "sk-home-file\n")
+	writeFile(t, filepath.Join(home, ".config", "opencode", "opencode.json"), `{
+		"provider": {"newapi": {"options": {"apiKey": "{file:~\\api-key}"}}}
+	}`)
+	if !customConfigService(home).providerHasAPICredential(agentprovider.OpenCode) {
+		t.Fatal("expected OpenCode Windows-style home file reference to be detected")
+	}
+}
+
 func TestProviderUsesCustomConfigCleanCodexLoginIsNotCustom(t *testing.T) {
 	home := t.TempDir()
 	// A normal ChatGPT-login config.toml with only a model pin — no custom key

--- a/services/tuttid/service/agentstatus/registry.go
+++ b/services/tuttid/service/agentstatus/registry.go
@@ -197,6 +197,16 @@ func isClaudeStatusSpec(spec ProviderSpec) bool {
 	return kind == providerregistry.StatusKindClaudeCLI
 }
 
+func isOpenCodeStatusSpec(spec ProviderSpec) bool {
+	kind := spec.Kind
+	if kind == "" {
+		if status, ok := migratedProviderStatus(spec.Provider); ok {
+			kind = status.Kind
+		}
+	}
+	return kind == providerregistry.StatusKindOpenCodeCLI
+}
+
 // isStandardACPStatusSpec reports whether spec's runtime is a "standard ACP"
 // provider (e.g. cursor-agent, opencode): the CLI binary itself, invoked with
 // an `acp` subcommand, IS the ACP adapter. This is the same architecture

--- a/services/tuttid/service/agentstatus/service_helpers.go
+++ b/services/tuttid/service/agentstatus/service_helpers.go
@@ -635,8 +635,8 @@ func expandHomePath(path string, home string) string {
 	if path == "~" {
 		return home
 	}
-	if strings.HasPrefix(path, "~/") {
-		return filepath.Join(home, strings.TrimPrefix(path, "~/"))
+	if strings.HasPrefix(path, "~/") || strings.HasPrefix(path, `~\`) {
+		return filepath.Join(home, path[2:])
 	}
 	return path
 }

--- a/services/tuttid/service/agentstatus/service_status.go
+++ b/services/tuttid/service/agentstatus/service_status.go
@@ -209,11 +209,11 @@ func (s Service) statusForSpec(
 			actions = append(actions, terminalAction(ActionLogin, loginCommandForRuntime(spec, runtimeResolution)))
 		}
 
-		// Codex and Claude Code can run in API Usage Billing mode. Their auth
+		// Codex, Claude Code, and OpenCode can run in API Usage Billing mode. Their auth
 		// status commands report stored login sessions and may not reflect an API
-		// key, auth token, or apiKeyHelper, so explicit API billing credentials
+		// key, auth token, apiKeyHelper, or OpenCode provider apiKey, so explicit API billing credentials
 		// override the command result. A bare custom endpoint is not a credential.
-		if (isCodexStatusSpec(spec) || isClaudeStatusSpec(spec)) &&
+		if (isCodexStatusSpec(spec) || isClaudeStatusSpec(spec) || isOpenCodeStatusSpec(spec)) &&
 			s.providerHasAPICredential(spec.Provider) {
 			auth.Status = AuthAuthenticated
 			auth.AccountLabel = "API Usage Billing"

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerstatus"
 	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
+	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 	externalagentregistry "github.com/tutti-os/tutti/services/tuttid/service/externalagentregistry"
 	managedruntime "github.com/tutti-os/tutti/services/tuttid/service/managedruntime"
 )
@@ -496,6 +497,40 @@ func TestServiceListReportsCodexAPIKeyAsAuthenticatedWithoutLogin(t *testing.T) 
 		t.Fatalf("List() error = %v", err)
 	}
 	status := onlyStatus(t, snapshot)
+	if status.Availability.Status != AvailabilityReady {
+		t.Fatalf("availability = %q, want %q", status.Availability.Status, AvailabilityReady)
+	}
+	if status.Auth.Status != AuthAuthenticated ||
+		status.Auth.AuthMethod != "apiKey" ||
+		status.Auth.AccountLabel != "API Usage Billing" {
+		t.Fatalf("auth = %#v, want API billing authentication", status.Auth)
+	}
+}
+
+func TestServiceStatusReportsOpenCodeConfigAPIKeyAsAuthenticatedWithoutLogin(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".config", "opencode", "opencode.json"), `{
+		"provider": {
+			"newapi": {"options": {"apiKey": "sk-test"}}
+		}
+	}`)
+
+	service := customConfigService(home)
+	service.LookPath = func(string) (string, error) {
+		return filepath.Join(home, "opencode"), nil
+	}
+	service.IsExecutableFile = func(string) bool { return true }
+	service.RunOutcomes = NewRunOutcomeStore()
+	specs, err := DefaultRegistry().Select([]string{agentprovider.OpenCode})
+	if err != nil {
+		t.Fatalf("Select(opencode) error = %v", err)
+	}
+	status := service.statusForSpec(
+		context.Background(),
+		specs[0],
+		time.Now(),
+		statusDetectionOptions{skipAdapterProbe: true},
+	)
 	if status.Availability.Status != AvailabilityReady {
 		t.Fatalf("availability = %q, want %q", status.Availability.Status, AvailabilityReady)
 	}


### PR DESCRIPTION
## Backport

Cherry-pick the reviewed OpenCode API credential detection fix from merged PR #2188 onto `release/0807`.

Source:
- PR: https://github.com/tutti-os/tutti/pull/2188
- Source commit: cf68e37ad5dbd7ee4e69834fd96ee6a88cd63cdc
- Backport commit: 5303a40cf

## Validation

- Independent CR: PASS, no blocking findings.
- Main PR required checks: Go tests/lint, Windows daemon adapters, TypeScript tests, tooling consistency and external review gate passed.
- Backport patch is limited to the same six `services/tuttid/service/agentstatus` files; `git diff --check` passed.
- Focused release-branch Go test was attempted but exceeded the local timeout during the first full Go build; the identical focused test passed on the merged main worktree.