### PR TITLE
feat(desktop): add update check to Windows help menu

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceChromeActions.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceChromeActions.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const directory = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(
+  resolve(directory, "WorkspaceChromeActions.tsx"),
+  "utf8"
+);
+
+test("Windows help menu exposes the shared desktop update check", () => {
+  assert.match(source, /useAppUpdateService\(\)/);
+  assert.match(source, /void appUpdateService\.checkForUpdates\(\)/);
+  assert.match(source, /t\("desktop\.menu\.checkForUpdates"\)/);
+  assert.match(
+    source,
+    /disabled=\{appUpdateState\.isActing\}[\s\S]{0,220}updates\.checkingTitle/
+  );
+});

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceChromeActions.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceChromeActions.tsx
@@ -24,6 +24,7 @@ import {
 import { useWorkspaceSettingsPanelRequest } from "@tutti-os/agent-gui/workspace-settings-panel";
 import { useTranslation } from "@renderer/i18n";
 import { cn } from "@renderer/lib/format";
+import { useAppUpdateService } from "@renderer/features/app-update";
 import { WorkspaceSettingsPanel } from "./WorkspaceSettingsPanel";
 import { WorkspaceConnectorMarketDialogHost } from "./WorkspaceConnectorMarketDialogHost";
 import { useWorkspaceSettingsService } from "./useWorkspaceSettingsService";
@@ -110,6 +111,8 @@ export function WorkspaceHelpMenu({
   workspace: WorkspaceSummary;
 }) {
   const { t } = useTranslation();
+  const { service: appUpdateService, state: appUpdateState } =
+    useAppUpdateService();
   const { service: settingsService, state: settingsState } =
     useWorkspaceSettingsService();
 
@@ -153,6 +156,16 @@ export function WorkspaceHelpMenu({
           }
         >
           {t("workspace.settings.nav.about")}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          disabled={appUpdateState.isActing}
+          onSelect={() => {
+            void appUpdateService.checkForUpdates();
+          }}
+        >
+          {appUpdateState.isActing
+            ? t("updates.checkingTitle")
+            : t("desktop.menu.checkForUpdates")}
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuSub>


### PR DESCRIPTION
## 变更内容

- 在 Windows 工作区顶部的“帮助”下拉菜单中增加“检查更新”入口
- 入口位于“关于”下方、日志导出操作上方
- 复用现有桌面更新服务，不新增 IPC 或 Windows 专属更新逻辑
- 检查进行中禁用重复点击，并显示“正在检查更新”
- 增加回归测试，约束该入口继续使用共享更新服务和既有国际化文案

## 用户影响

Windows 用户无需通过按 Alt 打开原生应用菜单，即可直接从顶部问号菜单手动检查 Tutti 更新。

## 验证

- `node --import ./apps/desktop/test/register-asset-stub.mjs --test --experimental-strip-types ./apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceChromeActions.test.ts`：通过
- `git diff --check`：通过
- Desktop typecheck：本机执行超过 2 分钟无输出后超时，交由 CI 完成

## 文档影响

本次仅增加已有能力的 Windows UI 入口，不改变更新架构、公共 API、配置或轮询策略，无需更新持久文档。