### PR TITLE
Backport Windows agent runtime reliability to release/0807

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ apps/desktop/build/browser-mcp/
 apps/desktop/build/claude-sdk-sidecar/
 apps/desktop/build/workspace-app-shell/
 apps/desktop/build/managed-posix-shell/
+apps/desktop/build/managed-uv/
 apps/cli/build/
 services/tuttid/builtin-apps/tutti-onboarding/build/
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -42,6 +42,13 @@
         "filter": [
           "**/*"
         ]
+      },
+      {
+        "from": "build/managed-uv",
+        "to": "bin/managed-uv",
+        "filter": [
+          "**/*"
+        ]
       }
     ],
     "publish": [

--- a/apps/desktop/scripts/vendor-managed-uv.mjs
+++ b/apps/desktop/scripts/vendor-managed-uv.mjs
@@ -1,0 +1,114 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, "../../..");
+const defaults = JSON.parse(
+  await readFile(join(repoRoot, "config/tutti.defaults.json"), "utf8")
+);
+const uv = defaults.agentRuntimeTools?.uv;
+if (!uv?.version || !Array.isArray(uv.artifacts)) {
+  throw new Error("config/tutti.defaults.json has no managed uv artifact catalog");
+}
+
+const platforms = parsePlatformArguments(process.argv.slice(2));
+const outputRoot = resolve(
+  process.env.TUTTI_UV_STAGING_DIR?.trim() ||
+    join(repoRoot, "apps/desktop/build/managed-uv")
+);
+await rm(outputRoot, { recursive: true, force: true });
+
+for (const platform of platforms) {
+  const artifact = uv.artifacts.find((entry) => entry.platform === platform);
+  if (!artifact) throw new Error(`managed uv catalog does not contain ${platform}`);
+  const targetDir = join(outputRoot, platform, uv.version);
+  const target = join(targetDir, basename(artifact.url));
+  const source = await resolveArchive(artifact);
+  await mkdir(targetDir, { recursive: true });
+  await copyVerifiedArchive(source, target, artifact);
+}
+
+await writeFile(
+  join(outputRoot, "THIRD_PARTY_NOTICES.md"),
+  `# uv third-party notice
+
+Tutti packages unmodified uv ${uv.version} release archives for offline Agent
+Target setup. Each archive is selected from config/tutti.defaults.json and is
+verified by its pinned byte size and SHA-256 before packaging and again before
+extraction by tuttid.
+
+- Project: https://github.com/astral-sh/uv
+- Release: https://github.com/astral-sh/uv/releases/tag/${uv.version}
+- Licenses: https://github.com/astral-sh/uv/tree/${uv.version}#license
+`,
+  "utf8"
+);
+
+function parsePlatformArguments(args) {
+  const values = args
+    .filter((argument) => argument.startsWith("--platform="))
+    .flatMap((argument) => argument.slice("--platform=".length).split(","))
+    .map((value) => value.trim())
+    .filter(Boolean);
+  if (values.length === 0 || values.length !== args.length) {
+    throw new Error("provide one or more --platform=<runtime-platform> arguments");
+  }
+  return [...new Set(values)];
+}
+
+async function resolveArchive(artifact) {
+  const envKey = `TUTTI_UV_ARCHIVE_${artifact.platform.toUpperCase().replaceAll("-", "_")}`;
+  const override = process.env[envKey]?.trim();
+  if (override) {
+    const path = resolve(override);
+    await verifyArchive(path, artifact);
+    return path;
+  }
+  const cacheRoot = join(tmpdir(), "tutti-build-cache", "uv", uv.version);
+  const path = join(cacheRoot, basename(artifact.url));
+  await mkdir(cacheRoot, { recursive: true });
+  try {
+    await verifyArchive(path, artifact);
+    return path;
+  } catch {
+    await rm(path, { force: true });
+  }
+  const response = await fetch(artifact.url, { redirect: "follow" });
+  if (!response.ok) throw new Error(`download ${artifact.url}: HTTP ${response.status}`);
+  const bytes = Buffer.from(await response.arrayBuffer());
+  const temporary = `${path}.${randomUUID()}.tmp`;
+  await writeFile(temporary, bytes, { flag: "wx" });
+  try {
+    await verifyArchive(temporary, artifact);
+    await rename(temporary, path);
+  } finally {
+    await rm(temporary, { force: true });
+  }
+  return path;
+}
+
+async function copyVerifiedArchive(source, target, artifact) {
+  const bytes = await readFile(source);
+  const temporary = `${target}.${randomUUID()}.tmp`;
+  await writeFile(temporary, bytes, { flag: "wx" });
+  try {
+    await verifyArchive(temporary, artifact);
+    await rename(temporary, target);
+  } finally {
+    await rm(temporary, { force: true });
+  }
+}
+
+async function verifyArchive(path, artifact) {
+  const info = await stat(path);
+  if (!info.isFile() || info.size !== artifact.sizeBytes) {
+    throw new Error(`uv archive size mismatch for ${path}: got ${info.size}, want ${artifact.sizeBytes}`);
+  }
+  const actual = createHash("sha256").update(await readFile(path)).digest("hex");
+  if (actual !== artifact.sha256) {
+    throw new Error(`uv archive checksum mismatch for ${path}: got ${actual}, want ${artifact.sha256}`);
+  }
+}

--- a/apps/desktop/src/main/daemon/tuttidManager.test.ts
+++ b/apps/desktop/src/main/daemon/tuttidManager.test.ts
@@ -26,8 +26,55 @@ import {
   resolveLaunchSpec,
   resolveManagedDaemonProcessEnv,
   resolveManagedPosixShellDaemonEnv,
+  resolveManagedUVDaemonEnv,
   resolveMutagenDaemonEnv
 } from "./tuttidManager.ts";
+
+test("resolveManagedUVDaemonEnv points the daemon at packaged archives", async () => {
+  const previousEnv = { ...process.env };
+  const resourcesPath = await mkdtemp(join(tmpdir(), "tutti-managed-uv-"));
+  try {
+    delete process.env.TUTTI_BUNDLED_UV_ROOT;
+    const runtimeRoot = join(resourcesPath, "bin", "managed-uv");
+    await mkdir(runtimeRoot, { recursive: true });
+    assert.deepEqual(
+      resolveManagedUVDaemonEnv({ isPackaged: true, resourcesPath }),
+      { TUTTI_BUNDLED_UV_ROOT: runtimeRoot }
+    );
+  } finally {
+    restoreEnv(previousEnv);
+    await rm(resourcesPath, { recursive: true, force: true });
+  }
+});
+
+test("resolveManagedUVDaemonEnv preserves an explicit override", () => {
+  const previousEnv = { ...process.env };
+  try {
+    process.env.TUTTI_BUNDLED_UV_ROOT = "C:\\custom\\uv";
+    assert.deepEqual(
+      resolveManagedUVDaemonEnv({ isPackaged: true, resourcesPath: "C:\\resources" }),
+      {}
+    );
+  } finally {
+    restoreEnv(previousEnv);
+  }
+});
+
+test("resolveManagedUVDaemonEnv preserves a shell environment override", () => {
+  const previousEnv = { ...process.env };
+  try {
+    delete process.env.TUTTI_BUNDLED_UV_ROOT;
+    assert.deepEqual(
+      resolveManagedUVDaemonEnv(
+        { isPackaged: true, resourcesPath: "C:\\resources" },
+        { inheritedEnv: { TUTTI_BUNDLED_UV_ROOT: "C:\\shell-uv" } }
+      ),
+      {}
+    );
+  } finally {
+    restoreEnv(previousEnv);
+  }
+});
 
 const repoRoot = resolve(
   fileURLToPath(new URL("../../../../..", import.meta.url))

--- a/apps/desktop/src/main/daemon/tuttidManager.ts
+++ b/apps/desktop/src/main/daemon/tuttidManager.ts
@@ -343,6 +343,7 @@ const vendoredClaudeSDKSidecarRelPath = join(
 );
 const vendoredManagedPosixShellRootRelPath = join("bin", "managed-posix-shell");
 const vendoredMutagenRootRelPath = join("bin", "mutagen");
+const vendoredManagedUVRootRelPath = join("bin", "managed-uv");
 
 // resolveBrowserMcpDaemonEnv points the daemon at a vendored chrome-devtools-mcp
 // in packaged builds so browser use never has to fetch it over the network at
@@ -545,6 +546,30 @@ export function resolveMutagenDaemonEnv(
   return { TUTTI_MUTAGEN_BIN: entry };
 }
 
+export function resolveManagedUVDaemonEnv(
+  runtime?: DesktopElectronAppRuntime,
+  options: ResolveLaunchSpecOptions & {
+    inheritedEnv?: Record<string, string>;
+  } = {}
+): Record<string, string> {
+  if (
+    process.env.TUTTI_BUNDLED_UV_ROOT?.trim() ||
+    options.inheritedEnv?.TUTTI_BUNDLED_UV_ROOT?.trim()
+  ) {
+    return {};
+  }
+  let appRuntime: DesktopElectronAppRuntime;
+  try {
+    appRuntime = runtime ?? resolveElectronAppRuntime();
+  } catch {
+    return {};
+  }
+  const runtimeRoot = appRuntime.isPackaged
+    ? resolve(appRuntime.resourcesPath, vendoredManagedUVRootRelPath)
+    : resolve(options.repoRoot ?? resolveRepoRoot(), "apps/desktop/build/managed-uv");
+  return existsSync(runtimeRoot) ? { TUTTI_BUNDLED_UV_ROOT: runtimeRoot } : {};
+}
+
 function resolveManagedRuntimeDaemonEnv(
   userShellEnv?: Record<string, string>
 ): Record<string, string> {
@@ -579,6 +604,7 @@ export function resolveManagedDaemonProcessEnv(
     ...resolveClaudeSDKSidecarDaemonEnv(),
     ...resolveManagedPosixShellDaemonEnv(),
     ...resolveMutagenDaemonEnv(undefined, { inheritedEnv: input.userShellEnv }),
+    ...resolveManagedUVDaemonEnv(undefined, { inheritedEnv: input.userShellEnv }),
     TUTTI_APP_VERSION: process.env.TUTTI_APP_VERSION?.trim() ?? "",
     TUTTI_DESKTOP_UPDATE_ADMISSION_ARCHITECTURE:
       desktopUpdateAdmission?.architecture ?? "",

--- a/docs/architecture/windows-platform-support.md
+++ b/docs/architecture/windows-platform-support.md
@@ -146,6 +146,35 @@ command resolution, executable verification, npm launcher layout, and process
 creation stay in the runtime command/process boundary. Do not make provider
 installers assemble shell command strings to handle Windows.
 
+System proxy resolution follows the same shared precedence on macOS and
+Windows: session/process environment, then the operating-system static proxy,
+then direct connection. The common resolver owns merging, `NO_PROXY`, caching,
+diagnostics, and the `TUTTI_DISABLE_PROXY_AUTODETECT` escape hatch. Build-tagged
+adapters only read native state: Darwin uses `scutil --proxy`; Windows reads the
+current-user WinINet `Internet Settings` values. Windows protocol maps and
+bypass entries are normalized to `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`.
+PAC execution and SOCKS conversion remain out of scope because the daemon does
+not embed a PAC/SOCKS engine. WinINet bypass entries that cannot be represented
+faithfully by standard `NO_PROXY` syntax (for example `10.*` and `<local>`) are
+not projected; loopback, `.local`, exact hosts, and `*.domain` suffixes remain
+covered.
+
+Agent Target setup uses one Desktop-owned, version-pinned `uv` resource rather
+than downloading `uv` separately for each Python agent. Release staging copies
+the official compressed archive for each packaged architecture under
+`bin/managed-uv/<platform>/<version>/`; both staging and tuttid verify the
+pinned size and SHA-256. Electron injects only the resource root through
+`TUTTI_BUNDLED_UV_ROOT`. The daemon keeps extraction, cache markers, and the
+dynamic official-download fallback. Node, Python, Kimi, Hermes, and other agent
+payloads remain dynamically installed, so this adds roughly one compressed uv
+archive per architecture rather than a complete cross-language toolchain.
+
+For generic ACP providers such as OpenCode, provider resolution rewrites the
+adapter command once and every status, login, model-catalog, and session path
+uses that resolved executable. On Windows a complete isolated npm package is
+preferred over an earlier stale PATH shim; package metadata and containment are
+validated before its declared binary is accepted.
+
 The Windows Desktop package also vendors the pinned Mutagen executable used
 when file-symlink creation is unavailable. Electron resolves the packaged
 resource and injects `TUTTI_MUTAGEN_BIN` into `tuttid`; Workspace Apps inherit

--- a/docs/specs/2026-08-08-windows-agent-runtime-setup-reliability.md
+++ b/docs/specs/2026-08-08-windows-agent-runtime-setup-reliability.md
@@ -1,0 +1,122 @@
+# Windows Agent Runtime Setup Reliability
+
+## Background and goal
+
+Windows Agent installation currently depends on three independent conditions:
+the daemon must inherit the same outbound proxy behavior as Desktop, the `uv`
+bootstrap download must reach GitHub, and every consumer must select the same
+installed agent executable. The goal is to remove the avoidable `uv` network
+dependency, make static system-proxy handling symmetric with macOS, and prevent
+stale Windows shims from splitting status/login/model/session behavior.
+
+## Current architecture and chain
+
+```text
+Desktop -> tuttid -> Target installer -> download uv -> uv installs Python agent
+                  -> provider resolver -> PATH/npm shim -> status/login/session
+```
+
+- macOS system proxy is converted to process proxy environment; Windows only
+  receives explicit environment variables.
+- `uv` is pinned and verified, but downloaded dynamically on first use.
+- OpenCode installation may produce a complete managed npm package while an
+  older PATH shim remains visible to some consumers.
+- Kimi versions before `0.34.0` can initialize ACP yet reject API-key
+  `session/new` as unauthenticated.
+
+## Target architecture and chain
+
+```text
+Desktop package
+  -> inject packaged uv archive root
+  -> tuttid verifies cache or packaged archive; download only when absent
+  -> uv installs the pinned Python agent dynamically
+
+OS proxy adapter -> shared merge/cache -> daemon HTTP + every child process
+
+provider resolver -> one absolute executable
+                  -> status + login + model catalog + ACP session
+```
+
+## Repository and module changes
+
+| Repository/module | Change |
+| --- | --- |
+| `tutti` Desktop packaging | Stage one official compressed `uv` archive per packaged architecture; inject `TUTTI_BUNDLED_UV_ROOT`. |
+| `tutti` agent extension service | Verify size/SHA, safely extract packaged `uv`, keep verified cache and network fallback. |
+| `tutti` runtime command | Split native proxy reads into Darwin/Windows/other build-tagged files; keep merge policy shared. |
+| `tutti` agent status | Resolve a complete managed npm binary once and reuse it across OpenCode consumers. |
+| Kimi extension | Pin install to `0.34.0`, require local `>=0.34.0 <1.0.0`, and verify API-key `session/new`. |
+| Hermes extension | Document that the host owns `uv`; keep Hermes/Python installation dynamic and the package declarative. |
+
+No public HTTP API or persisted-data schema is added. The only new interface is
+the internal Desktop-to-daemon environment variable `TUTTI_BUNDLED_UV_ROOT`.
+
+## Reuse and adapter boundary
+
+Proxy precedence, bypass normalization, caching, child-process injection, and
+HTTP transport behavior remain shared. Native adapters only read OS settings.
+The existing UV artifact catalog, checksum, safe archive extraction, and
+verified cache are reused; Desktop owns resource layout, while tuttid never
+depends on Electron paths directly.
+
+## Explicitly out of scope
+
+- Bundling Node, Python, Kimi, Hermes, OpenCode, or their dependency graphs.
+- Executing Windows PAC scripts or translating SOCKS proxies.
+- Changing user credentials or publishing managed agent commands globally.
+- Adding a new public service/API or migrating persisted records.
+
+## Migration and compatibility
+
+There is no data migration. Existing verified UV caches continue to win. A
+package without the new resource uses the existing signed dynamic download.
+Explicit proxy environment variables and `TUTTI_DISABLE_PROXY_AUTODETECT`
+retain precedence. Kimi installations below `0.34.0` are not reused; the Target
+installer creates/updates its isolated pinned runtime without overwriting the
+user's global Kimi installation.
+
+## Risk and rollback
+
+- Package size grows by about 22–26 MiB compressed per shipped architecture.
+  Production architecture-specific builds stage one archive; the local
+  `MAC_ARCH=all` convenience build stages both Darwin archives into every
+  artifact produced by that combined invocation.
+- Native proxy state can be stale for at most the existing 60-second cache TTL.
+- A corrupt packaged UV archive is never executed; tuttid falls back to the
+  same checksum-verified official download and reports both causes if that
+  download also fails.
+
+Rollback is a normal code/package rollback: remove the Desktop resource and
+environment injection to restore dynamic UV download; revert the Windows
+adapter to restore explicit-env-only proxy behavior; revert the Kimi pin if the
+upstream runtime regresses. No database rollback is required.
+
+## Tests and acceptance
+
+- Parser/precedence tests cover macOS and Windows proxy forms, bypasses, SOCKS
+  rejection, and explicit-env priority; Windows and Darwin files compile.
+- UV tests prove a verified bundle performs zero network requests and corrupt
+  bundles are rejected; release staging verifies the real official archive.
+- OpenCode tests plant a stale shim plus complete managed package and require
+  the managed absolute command.
+- Kimi tests require pinned version, API-key ACP `session/new`, commands, and
+  Skill discovery.
+- Packaged Windows acceptance blocks GitHub UV downloads, installs Hermes, and
+  completes ACP initialize/session creation through the configured package
+  index.
+
+## Phased order
+
+1. Land host proxy, bundled UV, and OpenCode resolution with compatibility
+   fallback.
+2. Land Kimi minimum-version/package pin and its ACP regression test.
+3. Land Hermes host-contract documentation and run packaged Windows acceptance.
+4. Monitor integrity/proxy diagnostics; promote Windows packaging only through
+   its existing release gates.
+
+## Pending confirmation
+
+- Whether PAC support is required for managed enterprise Windows deployments.
+- Final installer-size budget and whether universal macOS packages may include
+  both architecture archives.

--- a/packages/agent/daemon/runtimecmd/proxy.go
+++ b/packages/agent/daemon/runtimecmd/proxy.go
@@ -1,13 +1,10 @@
 package runtimecmd
 
 import (
-	"context"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -18,28 +15,27 @@ import (
 // System proxy injection.
 //
 // Some standalone agent processes only honor the
-// HTTP(S)_PROXY environment variables — they do NOT read the macOS system proxy.
+// HTTP(S)_PROXY environment variables — they do NOT read the OS system proxy.
 // Desktop runtimes commonly work around this by resolving the OS proxy via
 // Electron's session.resolveProxy() (Chromium/SystemConfiguration) and injecting
 // HTTPS_PROXY/HTTP_PROXY into the spawned process. Without it, a child agent
 // connects directly and, from a restricted region, gets `403 Request not
 // allowed` from the upstream API while the app keeps working.
 //
-// We mirror that behavior here by reading the same SystemConfiguration data via
-// `scutil --proxy` and injecting equivalent env vars. To stay faithful to the
+// We mirror that behavior here through a narrow platform adapter and inject
+// equivalent env vars. To stay faithful to the
 // app we: skip SOCKS entries (downstream HTTP agents don't speak SOCKS), use the
 // same default NO_PROXY, and never override a proxy the user/session already set.
 //
 // Effective precedence, everywhere (spawned agents and in-process clients):
 //
 //	session-explicit env > process env (incl. the user's shell env, when the
-//	desktop forwards it) > macOS system proxy > direct
+//	desktop forwards it) > OS system proxy > direct
 //
 // Out of scope, deliberately: SOCKS proxies and PAC resolution (scutil only
-// exposes the PAC URL; the desktop's Chromium stack handles PAC natively for
-// its own requests), and Windows/Linux system-proxy detection (those platforms
-// conventionally drive proxies via env vars, which the precedence above already
-// honors). Setting TUTTI_DISABLE_PROXY_AUTODETECT=1 disables the system-proxy
+// exposes only a PAC URL; the desktop's Chromium stack handles PAC natively for
+// its own requests). Windows support intentionally covers the static per-user
+// proxy only. Setting TUTTI_DISABLE_PROXY_AUTODETECT=1 disables system-proxy
 // detection and injection entirely; explicit env proxies keep working.
 
 // noProxyDefault matches the value the Claude desktop app injects.
@@ -55,7 +51,7 @@ func proxyAutodetectDisabled() bool {
 }
 
 // injectSystemProxyEnv appends HTTPS_PROXY/HTTP_PROXY/NO_PROXY derived from the
-// macOS system proxy, but only for keys not already present (case-insensitive)
+// OS system proxy, but only for keys not already present (case-insensitive)
 // in env, so explicit user/session settings always win.
 func (r Resolver) injectSystemProxyEnv(env []string) []string {
 	if proxyAutodetectDisabled() {
@@ -78,12 +74,12 @@ func (r Resolver) injectSystemProxyEnv(env []string) []string {
 	return env
 }
 
-// InjectSystemProxyEnv appends the macOS system proxy variables
+// InjectSystemProxyEnv appends the OS system proxy variables
 // (HTTPS_PROXY/HTTP_PROXY/NO_PROXY) to env for any key not already present,
-// reading the same SystemConfiguration source as Resolver.Env(). It exists so
+// reading the same platform system-proxy source as Resolver.Env(). It exists so
 // the spawn paths that build their own environment instead of going through
 // Resolver.Env() — managed-runtime installs, agent logins, workspace terminals —
-// get identical proxy treatment. No-op on non-macOS or when no system proxy is
+// get identical proxy treatment. No-op on unsupported platforms or when no system proxy is
 // configured; never overrides a user/session-set value.
 func InjectSystemProxyEnv(env []string) []string {
 	return Resolver{}.injectSystemProxyEnv(env)
@@ -91,7 +87,7 @@ func InjectSystemProxyEnv(env []string) []string {
 
 // DynamicProxyFunc returns an http.Transport.Proxy function that resolves the
 // proxy per request: explicit proxies from the process environment win, the
-// macOS system proxy fills in the blanks, and NO_PROXY (from env, the system
+// OS system proxy fills in the blanks, and NO_PROXY (from env, the system
 // exceptions, or noProxyDefault) plus loopback targets always bypass. It is the
 // in-process counterpart of InjectSystemProxyEnv, so daemon HTTP clients and
 // spawned agents make the same routing decision. The system proxy is re-read
@@ -108,7 +104,7 @@ func DynamicProxyFunc() func(*http.Request) (*url.URL, error) {
 }
 
 // EffectiveProxySummary reports which source currently supplies the outbound
-// proxy — "env" (explicit environment variables), "system" (macOS system
+// proxy — "env" (explicit environment variables), "system" (OS system
 // proxy), or "none" — plus the proxy address as host:port with any credentials
 // stripped. Startup/diagnostic logging only; it answers "did requests on this
 // machine go through a proxy" without another capture round-trip.
@@ -151,7 +147,7 @@ func proxyHostForLog(raw string) string {
 	return parsed.Host
 }
 
-// SystemProxyEnv exposes the (cached) macOS system proxy as env-style keys
+// SystemProxyEnv exposes the cached OS system proxy as env-style keys
 // (HTTPS_PROXY/HTTP_PROXY/NO_PROXY) for observability call sites that want to
 // log the effective proxy source. Returns nil when autodetect is disabled or no
 // system proxy is configured.
@@ -182,9 +178,9 @@ func mergeSystemProxy(cfg *httpproxy.Config, systemEnv map[string]string) {
 	}
 }
 
-// systemProxyCache memoizes the parsed `scutil --proxy` output so hot paths
-// (per-spawn env injection, per-request proxy resolution) don't fork a scutil
-// process each time, while still noticing proxy-panel toggles within the TTL.
+// systemProxyCache memoizes platform proxy reads so hot paths (per-spawn env
+// injection, per-request proxy resolution) avoid native I/O each time, while
+// still noticing proxy-panel toggles within the TTL.
 var systemProxyCache = struct {
 	sync.Mutex
 	env       map[string]string
@@ -207,28 +203,10 @@ func (r Resolver) systemProxyEnv() map[string]string {
 	if time.Now().Before(systemProxyCache.expiresAt) {
 		return systemProxyCache.env
 	}
-	var env map[string]string
-	if output, ok := runScutilProxy(); ok {
-		env = parseScutilProxy(output)
-	}
+	env := readSystemProxyEnv()
 	systemProxyCache.env = env
 	systemProxyCache.expiresAt = time.Now().Add(systemProxyCacheTTL)
 	return env
-}
-
-// runScutilProxy reads the macOS system proxy configuration. It is a no-op on
-// non-macOS platforms, where proxies are conventionally driven by env vars.
-func runScutilProxy() (string, bool) {
-	if runtime.GOOS != "darwin" {
-		return "", false
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	out, err := exec.CommandContext(ctx, "scutil", "--proxy").Output()
-	if err != nil {
-		return "", false
-	}
-	return string(out), true
 }
 
 // parseScutilProxy turns `scutil --proxy` output into proxy env vars.
@@ -283,4 +261,87 @@ func parseScutilProxy(output string) map[string]string {
 		"HTTP_PROXY":  url,
 		"NO_PROXY":    noProxyDefault,
 	}
+}
+
+// parseWindowsProxyServer converts the WinINet ProxyServer registry value into
+// env-style HTTP proxy settings. Windows accepts either one proxy for all
+// protocols ("host:port") or a protocol map ("http=...;https=...;socks=...").
+// SOCKS entries are deliberately ignored because downstream HTTP agents do not
+// consistently support SOCKS proxy URLs.
+func parseWindowsProxyServer(proxyServer, proxyOverride string) map[string]string {
+	proxyServer = strings.TrimSpace(proxyServer)
+	if proxyServer == "" {
+		return nil
+	}
+	values := map[string]string{}
+	if strings.Contains(proxyServer, "=") {
+		for _, part := range strings.Split(proxyServer, ";") {
+			key, value, ok := strings.Cut(part, "=")
+			if !ok {
+				continue
+			}
+			key = strings.ToLower(strings.TrimSpace(key))
+			value = normalizeHTTPProxyURL(value)
+			if value != "" && (key == "http" || key == "https") {
+				values[key] = value
+			}
+		}
+	} else if value := normalizeHTTPProxyURL(proxyServer); value != "" {
+		values["http"] = value
+		values["https"] = value
+	}
+	if len(values) == 0 {
+		return nil
+	}
+	if values["https"] == "" {
+		values["https"] = values["http"]
+	}
+	if values["http"] == "" {
+		values["http"] = values["https"]
+	}
+	result := map[string]string{
+		"HTTPS_PROXY": values["https"],
+		"HTTP_PROXY":  values["http"],
+		"NO_PROXY":    windowsNoProxy(proxyOverride),
+	}
+	return result
+}
+
+func normalizeHTTPProxyURL(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if !strings.Contains(value, "://") {
+		value = "http://" + value
+	}
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return ""
+	}
+	return parsed.String()
+}
+
+func windowsNoProxy(proxyOverride string) string {
+	items := strings.Split(noProxyDefault, ",")
+	seen := map[string]struct{}{}
+	for _, value := range items {
+		seen[strings.ToLower(value)] = struct{}{}
+	}
+	for _, raw := range strings.Split(proxyOverride, ";") {
+		value := strings.TrimSpace(raw)
+		if value == "" || strings.EqualFold(value, "<local>") {
+			continue
+		}
+		if strings.HasPrefix(value, "*.") {
+			value = value[1:]
+		}
+		key := strings.ToLower(value)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		items = append(items, value)
+	}
+	return strings.Join(items, ",")
 }

--- a/packages/agent/daemon/runtimecmd/proxy_system_darwin.go
+++ b/packages/agent/daemon/runtimecmd/proxy_system_darwin.go
@@ -1,0 +1,19 @@
+//go:build darwin
+
+package runtimecmd
+
+import (
+	"context"
+	"os/exec"
+	"time"
+)
+
+func readSystemProxyEnv() map[string]string {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "scutil", "--proxy").Output()
+	if err != nil {
+		return nil
+	}
+	return parseScutilProxy(string(out))
+}

--- a/packages/agent/daemon/runtimecmd/proxy_system_other.go
+++ b/packages/agent/daemon/runtimecmd/proxy_system_other.go
@@ -1,0 +1,5 @@
+//go:build !darwin && !windows
+
+package runtimecmd
+
+func readSystemProxyEnv() map[string]string { return nil }

--- a/packages/agent/daemon/runtimecmd/proxy_system_windows.go
+++ b/packages/agent/daemon/runtimecmd/proxy_system_windows.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+package runtimecmd
+
+import "golang.org/x/sys/windows/registry"
+
+const windowsInternetSettingsKey = `Software\Microsoft\Windows\CurrentVersion\Internet Settings`
+
+func readSystemProxyEnv() map[string]string {
+	key, err := registry.OpenKey(registry.CURRENT_USER, windowsInternetSettingsKey, registry.QUERY_VALUE)
+	if err != nil {
+		return nil
+	}
+	defer key.Close()
+	enabled, _, err := key.GetIntegerValue("ProxyEnable")
+	if err != nil || enabled == 0 {
+		return nil
+	}
+	server, _, err := key.GetStringValue("ProxyServer")
+	if err != nil {
+		return nil
+	}
+	override, _, _ := key.GetStringValue("ProxyOverride")
+	return parseWindowsProxyServer(server, override)
+}

--- a/packages/agent/daemon/runtimecmd/proxy_test.go
+++ b/packages/agent/daemon/runtimecmd/proxy_test.go
@@ -89,6 +89,29 @@ func TestParseScutilProxySOCKSOnlyIgnored(t *testing.T) {
 	}
 }
 
+func TestParseWindowsProxyServerSingleProxy(t *testing.T) {
+	got := parseWindowsProxyServer("127.0.0.1:7890", "<local>;*.corp.example;localhost")
+	if got["HTTPS_PROXY"] != "http://127.0.0.1:7890" || got["HTTP_PROXY"] != "http://127.0.0.1:7890" {
+		t.Fatalf("parseWindowsProxyServer() proxy = %v", got)
+	}
+	if got["NO_PROXY"] != "localhost,127.0.0.1,::1,.local,.corp.example" {
+		t.Fatalf("parseWindowsProxyServer() NO_PROXY = %q", got["NO_PROXY"])
+	}
+}
+
+func TestParseWindowsProxyServerProtocolMap(t *testing.T) {
+	got := parseWindowsProxyServer("http=proxy.internal:8080;https=secure.internal:8443;socks=127.0.0.1:1080", "")
+	if got["HTTP_PROXY"] != "http://proxy.internal:8080" || got["HTTPS_PROXY"] != "http://secure.internal:8443" {
+		t.Fatalf("parseWindowsProxyServer() = %v", got)
+	}
+}
+
+func TestParseWindowsProxyServerIgnoresSocksOnly(t *testing.T) {
+	if got := parseWindowsProxyServer("socks=127.0.0.1:1080", ""); got != nil {
+		t.Fatalf("parseWindowsProxyServer() = %v, want nil", got)
+	}
+}
+
 func TestEnvInjectsSystemProxy(t *testing.T) {
 	resolver := Resolver{
 		Environ:     func() []string { return []string{"PATH=/usr/bin:/bin"} },

--- a/packages/agent/daemon/runtimecmd/resolver.go
+++ b/packages/agent/daemon/runtimecmd/resolver.go
@@ -16,8 +16,8 @@ type Resolver struct {
 	IsExecutableFile func(string) bool
 	LookPath         func(string) (string, error)
 	// ScutilProxy returns the raw output of `scutil --proxy` (and whether it is
-	// available). It is injectable for tests; the default reads the macOS system
-	// proxy and is a no-op on other platforms. See proxy.go.
+	// available). It is injectable for legacy macOS parser tests; production
+	// reads the platform system proxy through the build-tagged adapter.
 	ScutilProxy func() (string, bool)
 }
 

--- a/services/tuttid/service/agentextension/uv_toolchain.go
+++ b/services/tuttid/service/agentextension/uv_toolchain.go
@@ -5,6 +5,8 @@ import (
 	"archive/zip"
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -29,6 +31,7 @@ const (
 	uvToolchainKindName     = "uv"
 	uvToolchainCacheName    = "cache"
 	uvToolchainVerifiedName = ".verified"
+	bundledUVRootEnvKey     = "TUTTI_BUNDLED_UV_ROOT"
 )
 
 // uvToolchainProvenanceURL documents where the managed uv archives come from;
@@ -79,7 +82,7 @@ func ensureManagedUVToolchain(ctx context.Context, client *http.Client, runtimeI
 	if err := os.MkdirAll(toolDir, 0o700); err != nil {
 		return "", err
 	}
-	archivePath, err := downloadUVToolchainArchive(ctx, client, artifact, toolDir)
+	archivePath, err := stageUVToolchainArchive(ctx, client, artifact, toolDir)
 	if err != nil {
 		return "", err
 	}
@@ -95,6 +98,81 @@ func ensureManagedUVToolchain(ctx context.Context, client *http.Client, runtimeI
 		return "", err
 	}
 	return toolDir, nil
+}
+
+func stageUVToolchainArchive(ctx context.Context, client *http.Client, artifact tuttitypes.UVToolArtifact, toolDir string) (string, error) {
+	var bundledErr error
+	if root := strings.TrimSpace(os.Getenv(bundledUVRootEnvKey)); root != "" {
+		archivePath, err := copyBundledUVToolchainArchive(root, artifact, toolDir)
+		if err == nil {
+			return archivePath, nil
+		}
+		bundledErr = fmt.Errorf("use bundled managed uv toolchain: %w", err)
+	}
+	archivePath, err := downloadUVToolchainArchive(ctx, client, artifact, toolDir)
+	if err != nil && bundledErr != nil {
+		return "", errors.Join(bundledErr, err)
+	}
+	return archivePath, err
+}
+
+func copyBundledUVToolchainArchive(root string, artifact tuttitypes.UVToolArtifact, toolDir string) (string, error) {
+	if !filepath.IsAbs(root) {
+		return "", errors.New("bundled uv root is not absolute")
+	}
+	if err := rejectManagedRuntimeSymlinkAncestors(root); err != nil {
+		return "", fmt.Errorf("bundled uv root is unsafe: %w", err)
+	}
+	archiveName := filepath.Base(artifact.URL)
+	if archiveName == "." || archiveName == string(filepath.Separator) || archiveName == "" {
+		return "", errors.New("bundled uv archive name is invalid")
+	}
+	sourcePath := filepath.Join(root, artifact.Platform, artifact.Version, archiveName)
+	info, err := os.Lstat(sourcePath)
+	if err != nil {
+		return "", err
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return "", errors.New("bundled uv archive is not a regular file")
+	}
+	if info.Size() != artifact.SizeBytes {
+		return "", fmt.Errorf("bundled uv archive size is %d, want %d", info.Size(), artifact.SizeBytes)
+	}
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		return "", err
+	}
+	defer source.Close()
+	destination, err := os.CreateTemp(toolDir, ".uv-bundled-*")
+	if err != nil {
+		return "", err
+	}
+	keep := false
+	defer func() {
+		_ = destination.Close()
+		if !keep {
+			_ = os.Remove(destination.Name())
+		}
+	}()
+	hash := sha256.New()
+	written, err := io.Copy(io.MultiWriter(destination, hash), io.LimitReader(source, artifact.SizeBytes+1))
+	if err != nil {
+		return "", err
+	}
+	if written != artifact.SizeBytes {
+		return "", fmt.Errorf("bundled uv archive copied %d bytes, want %d", written, artifact.SizeBytes)
+	}
+	if actual := hex.EncodeToString(hash.Sum(nil)); !strings.EqualFold(actual, artifact.SHA256) {
+		return "", fmt.Errorf("bundled uv archive sha256 is %s, want %s", actual, artifact.SHA256)
+	}
+	if err := destination.Sync(); err != nil {
+		return "", err
+	}
+	if err := destination.Close(); err != nil {
+		return "", err
+	}
+	keep = true
+	return destination.Name(), nil
 }
 
 // verifiedManagedUV reports whether a previously extracted uv executable is

--- a/services/tuttid/service/agentextension/uv_toolchain_test.go
+++ b/services/tuttid/service/agentextension/uv_toolchain_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestResolveManagedUVToolchainDownloadsVerifiesAndCaches(t *testing.T) {
+	t.Setenv(bundledUVRootEnvKey, "")
 	uvBytes := []byte("#!/bin/sh\necho fake-uv\n")
 	archive := buildUVToolchainTarGz(t, "uv-bundle/uv", uvBytes)
 	var hits atomic.Int32
@@ -62,6 +63,71 @@ func TestResolveManagedUVToolchainDownloadsVerifiesAndCaches(t *testing.T) {
 	}
 	if got := hits.Load(); got != 1 {
 		t.Fatalf("server hits = %d, want 1 (cache hit on second resolve)", got)
+	}
+}
+
+func TestResolveManagedUVToolchainUsesVerifiedBundledArchiveWithoutNetwork(t *testing.T) {
+	uvBytes := []byte("#!/bin/sh\necho bundled-uv\n")
+	archive := buildUVToolchainTarGz(t, "uv-bundle/uv", uvBytes)
+	var hits atomic.Int32
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		http.Error(w, "network must not be used", http.StatusBadGateway)
+	}))
+	defer server.Close()
+	artifact := testUVToolArtifact(server.URL+"/uv.tar.gz", archive, "tar.gz", "uv-bundle/uv")
+	bundleRoot := testResolvedTempDir(t)
+	bundleDir := filepath.Join(bundleRoot, artifact.Platform, artifact.Version)
+	if err := os.MkdirAll(bundleDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bundleDir, "uv.tar.gz"), archive, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(bundledUVRootEnvKey, bundleRoot)
+
+	toolDir, err := ensureManagedUVToolchain(context.Background(), server.Client(), testResolvedTempDir(t), artifact)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contents, err := os.ReadFile(filepath.Join(toolDir, uvExecutableName()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(contents, uvBytes) {
+		t.Fatalf("uv bytes = %q, want %q", contents, uvBytes)
+	}
+	if got := hits.Load(); got != 0 {
+		t.Fatalf("server hits = %d, want 0", got)
+	}
+}
+
+func TestResolveManagedUVToolchainFallsBackWhenBundledArchiveIsCorrupt(t *testing.T) {
+	archive := buildUVToolchainTarGz(t, "uv-bundle/uv", []byte("valid"))
+	var hits atomic.Int32
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write(archive)
+	}))
+	defer server.Close()
+	artifact := testUVToolArtifact(server.URL+"/uv.tar.gz", archive, "tar.gz", "uv-bundle/uv")
+	bundleRoot := testResolvedTempDir(t)
+	bundleDir := filepath.Join(bundleRoot, artifact.Platform, artifact.Version)
+	if err := os.MkdirAll(bundleDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	corrupt := append([]byte(nil), archive...)
+	corrupt[len(corrupt)-1] ^= 0xff
+	if err := os.WriteFile(filepath.Join(bundleDir, "uv.tar.gz"), corrupt, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(bundledUVRootEnvKey, bundleRoot)
+
+	if _, err := ensureManagedUVToolchain(context.Background(), server.Client(), testResolvedTempDir(t), artifact); err != nil {
+		t.Fatal(err)
+	}
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("server hits = %d, want 1 fallback download", got)
 	}
 }
 

--- a/services/tuttid/service/agentstatus/installer_runtime.go
+++ b/services/tuttid/service/agentstatus/installer_runtime.go
@@ -58,6 +58,10 @@ func (s Service) resolveProviderRuntime(ctx context.Context, spec ProviderSpec) 
 		cliPath = s.managedClaudeCodeExecutable()
 	}
 	adapterPath := resolveBinaryWithResolver(resolver, adapterBinaryNames(spec), spec.AdapterEnv)
+	if isStandardACPStatusSpec(spec) && len(spec.AdapterCommand) > 0 && s.executableFile(spec.AdapterCommand[0]) {
+		cliPath = spec.AdapterCommand[0]
+		adapterPath = spec.AdapterCommand[0]
+	}
 	if isCodexStatusSpec(spec) && len(spec.AdapterCommand) > 0 && s.executableFile(spec.AdapterCommand[0]) {
 		if cliPath == "" {
 			cliPath = spec.AdapterCommand[0]

--- a/services/tuttid/service/agentstatus/provider_descriptor_test.go
+++ b/services/tuttid/service/agentstatus/provider_descriptor_test.go
@@ -1,7 +1,12 @@
 package agentstatus
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"reflect"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -9,6 +14,89 @@ import (
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerstatus"
 	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 )
+
+func TestResolveProviderCommandPrefersCompleteManagedNPMPackageOverStaleShim(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("managed npm fallback is Windows-only")
+	}
+	home := t.TempDir()
+	legacyShim := filepath.Join(home, ".local", "bin", "opencode.cmd")
+	if err := os.MkdirAll(filepath.Dir(legacyShim), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyShim, []byte("@echo off\r\nmissing.exe %*\r\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	prefix := filepath.Join(home, ".local")
+	packageDir, ok := managedNPMGlobalPackageDir(prefix, "opencode-ai")
+	if !ok {
+		t.Fatal("managed npm package path rejected")
+	}
+	managedBinary := filepath.Join(packageDir, "bin", "opencode.exe")
+	if err := os.MkdirAll(filepath.Dir(managedBinary), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(packageDir, "package.json"), []byte(`{"name":"opencode-ai","bin":{"opencode":"./bin/opencode.exe"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(managedBinary, []byte("test binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	service := Service{
+		HomeDir:  func() (string, error) { return home, nil },
+		Environ:  func() []string { return []string{"PATH=" + filepath.Dir(legacyShim)} },
+		LookPath: func(string) (string, error) { return legacyShim, nil },
+		IsExecutableFile: func(path string) bool {
+			info, err := os.Stat(path)
+			return err == nil && !info.IsDir()
+		},
+	}
+	resolved, err := service.ResolveProviderCommand(context.Background(), agentprovider.OpenCode)
+	if err != nil {
+		t.Fatalf("ResolveProviderCommand() error = %v", err)
+	}
+	if !reflect.DeepEqual(resolved.Command, []string{managedBinary, "acp"}) {
+		t.Fatalf("Command = %#v, want managed package binary", resolved.Command)
+	}
+}
+
+func TestResolveStaticGenericProviderDoesNotRewriteClaudeSDKSidecar(t *testing.T) {
+	specs, err := DefaultRegistry().Select([]string{agentprovider.ClaudeCode})
+	if err != nil || len(specs) != 1 {
+		t.Fatalf("Select(claude-code) = %#v, %v", specs, err)
+	}
+	spec := specs[0]
+	spec.AdapterCommand = []string{"node", "--experimental-strip-types", "sidecar.ts"}
+	service := Service{
+		LookPath:         func(string) (string, error) { return "/usr/local/bin/claude", nil },
+		IsExecutableFile: func(string) bool { return true },
+	}
+	resolved := service.resolveStaticProviderSpec(context.Background(), spec, false)
+	if !reflect.DeepEqual(resolved.AdapterCommand, spec.AdapterCommand) {
+		t.Fatalf("AdapterCommand = %#v, want sidecar command %#v", resolved.AdapterCommand, spec.AdapterCommand)
+	}
+}
+
+func TestResolveStaticGenericProviderUsesSeparateAdapterBinary(t *testing.T) {
+	specs, err := DefaultRegistry().Select([]string{providerregistry.NexightProviderID})
+	if err != nil || len(specs) != 1 {
+		t.Fatalf("Select(nexight) = %#v, %v", specs, err)
+	}
+	spec := specs[0]
+	service := Service{
+		LookPath: func(name string) (string, error) {
+			return filepath.Join(t.TempDir(), name), nil
+		},
+		IsExecutableFile: func(string) bool { return true },
+	}
+	resolved := service.resolveStaticProviderSpec(context.Background(), spec, false)
+	got := filepath.Base(resolved.AdapterCommand[0])
+	got = strings.TrimSuffix(got, filepath.Ext(got))
+	if !strings.EqualFold(got, spec.AdapterBinaryNames[0]) {
+		t.Fatalf("AdapterCommand[0] = %q, want resolved %q adapter", resolved.AdapterCommand[0], spec.AdapterBinaryNames[0])
+	}
+}
 
 func TestCodexStatusSpecComesFromProviderDescriptor(t *testing.T) {
 	specs, err := DefaultRegistry().Select([]string{agentprovider.Codex})

--- a/services/tuttid/service/agentstatus/provider_resolution.go
+++ b/services/tuttid/service/agentstatus/provider_resolution.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
+	"github.com/tutti-os/tutti/packages/agent/daemon/runtimecmd"
 	externalagentregistry "github.com/tutti-os/tutti/services/tuttid/service/externalagentregistry"
 	managedruntime "github.com/tutti-os/tutti/services/tuttid/service/managedruntime"
 )
@@ -189,6 +190,9 @@ func (s Service) resolveStaticProviderSpec(ctx context.Context, spec ProviderSpe
 	case providerregistry.StaticSpecResolverKindCursor:
 		return s.resolveCursorProviderSpec(spec)
 	case providerregistry.StaticSpecResolverKindGeneric:
+		if isStandardACPStatusSpec(spec) {
+			return s.resolveGenericProviderSpec(spec)
+		}
 		return spec
 	case providerregistry.StaticSpecResolverKindManagedNode:
 	default:
@@ -206,6 +210,116 @@ func (s Service) resolveStaticProviderSpec(ctx context.Context, spec ProviderSpe
 	}
 	spec.AdapterEnv = append(s.managedRuntimeAdapterEnv(appRuntime), spec.AdapterEnv...)
 	return s.resolveCodexProviderSpec(ctx, spec)
+}
+
+// resolveGenericProviderSpec makes sessions, status, login and model catalog
+// calls consume one resolved executable. On Windows the isolated managed npm
+// package is authoritative when present; this avoids selecting a stale .cmd
+// shim that happens to appear earlier on PATH.
+func (s Service) resolveGenericProviderSpec(spec ProviderSpec) ProviderSpec {
+	if len(spec.AdapterCommand) == 0 {
+		return spec
+	}
+	adapterBinaryNames := cloneStrings(spec.AdapterBinaryNames)
+	if len(adapterBinaryNames) == 0 {
+		adapterBinaryNames = []string{spec.AdapterCommand[0]}
+	}
+	path := ""
+	if runtime.GOOS == "windows" && managedNPMProvidesAdapter(spec, adapterBinaryNames) {
+		path = s.resolveManagedNPMPackageBinary(spec)
+	}
+	if path == "" {
+		path = s.commandResolver().ResolveBinary(adapterBinaryNames, spec.AdapterEnv)
+	}
+	if strings.TrimSpace(path) == "" {
+		return spec
+	}
+	command := cloneStrings(spec.AdapterCommand)
+	command[0] = path
+	spec.AdapterCommand = command
+	return spec
+}
+
+func managedNPMProvidesAdapter(spec ProviderSpec, adapterBinaryNames []string) bool {
+	if spec.Install.ManagedNPM == nil {
+		return false
+	}
+	managedBinaryName := strings.TrimSpace(spec.Install.ManagedNPM.BinaryName)
+	for _, name := range adapterBinaryNames {
+		if strings.EqualFold(strings.TrimSpace(name), managedBinaryName) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s Service) resolveManagedNPMPackageBinary(spec ProviderSpec) string {
+	managed := spec.Install.ManagedNPM
+	if managed == nil || strings.TrimSpace(managed.PackageName) == "" || strings.TrimSpace(managed.BinaryName) == "" {
+		return ""
+	}
+	installBinDir := strings.TrimSpace(managed.InstallDir)
+	if installBinDir == "" {
+		home, err := s.homeDir()
+		if err != nil || strings.TrimSpace(home) == "" {
+			return ""
+		}
+		installBinDir = filepath.Join(home, ".local", "bin")
+	}
+	prefix := runtimecmd.ResolveNPMGlobalLayout(installBinDir).PrefixDir
+	packageDir, ok := managedNPMGlobalPackageDir(prefix, managed.PackageName)
+	if !ok {
+		return ""
+	}
+	path := installedNPMPackageBinaryPath(packageDir, managed.PackageName, managed.BinaryName)
+	if path == "" || !s.executableFile(path) {
+		return ""
+	}
+	return path
+}
+
+func installedNPMPackageBinaryPath(packageDir, packageName, binaryName string) string {
+	manifestPath := filepath.Join(packageDir, "package.json")
+	if !regularNonSymlinkFile(manifestPath) {
+		return ""
+	}
+	content, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return ""
+	}
+	var manifest struct {
+		Name string          `json:"name"`
+		Bin  json.RawMessage `json:"bin"`
+	}
+	if json.Unmarshal(content, &manifest) != nil || strings.TrimSpace(manifest.Name) != strings.TrimSpace(packageName) {
+		return ""
+	}
+	var relative string
+	if json.Unmarshal(manifest.Bin, &relative) != nil {
+		var bins map[string]string
+		if json.Unmarshal(manifest.Bin, &bins) != nil {
+			return ""
+		}
+		relative = bins[strings.TrimSpace(binaryName)]
+	}
+	relative = strings.TrimSpace(relative)
+	if relative == "" || filepath.IsAbs(relative) {
+		return ""
+	}
+	path := filepath.Clean(filepath.Join(packageDir, filepath.FromSlash(relative)))
+	within, err := filepath.Rel(packageDir, path)
+	if err != nil || within == ".." || strings.HasPrefix(within, ".."+string(os.PathSeparator)) {
+		return ""
+	}
+	if !regularNonSymlinkFile(path) {
+		return ""
+	}
+	return path
+}
+
+func regularNonSymlinkFile(path string) bool {
+	info, err := os.Lstat(path)
+	return err == nil && info.Mode().IsRegular() && info.Mode()&os.ModeSymlink == 0
 }
 
 func (s Service) userNodeRuntimeAvailable(overrides []string) bool {

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -1496,7 +1496,7 @@ func TestServiceRunActionInstallsThenProbesProvider(t *testing.T) {
 	if err := os.MkdirAll(binDir, 0o755); err != nil {
 		t.Fatalf("mkdir bin dir: %v", err)
 	}
-	adapterArchive, adapterSHA256 := releaseBinaryArchive(t, "codex-acp", "#!/bin/sh\nsleep 5\n")
+	adapterArchive, adapterSHA256 := releaseBinaryArchive(t, "codex-acp", "#!/bin/sh\nread -r line\nid=$(printf '%s' \"$line\" | sed -n 's/.*\"id\":\\([0-9]*\\).*/\\1/p')\nprintf '{\"jsonrpc\":\"2.0\",\"id\":%s,\"result\":{}}\\n' \"$id\"\n")
 	installerServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		switch request.URL.Path {
 		case "/install.sh":

--- a/tools/scripts/build-desktop-package.sh
+++ b/tools/scripts/build-desktop-package.sh
@@ -219,6 +219,34 @@ prepare_mutagen() {
   node "${ROOT_DIR}/apps/desktop/scripts/vendor-mutagen.mjs" --platform=windows-amd64
 }
 
+prepare_managed_uv() {
+  local platforms=()
+  case "${VARIANT}" in
+    win|win-store)
+      platforms=(windows-amd64)
+      ;;
+    linux)
+      platforms=(linux-amd64)
+      ;;
+    mac|mac-unsigned|mac-signed)
+      case "${MAC_ARCH}" in
+        x64) platforms=(darwin-amd64) ;;
+        arm64) platforms=(darwin-arm64) ;;
+        all|universal) platforms=(darwin-amd64 darwin-arm64) ;;
+      esac
+      ;;
+    unpack)
+      platforms=("$(node -e 'const os = process.platform === "win32" ? "windows" : process.platform === "darwin" ? "darwin" : "linux"; const arch = process.arch === "arm64" ? "arm64" : "amd64"; process.stdout.write(`${os}-${arch}`)')")
+      ;;
+  esac
+  local args=()
+  local platform
+  for platform in "${platforms[@]}"; do
+    args+=("--platform=${platform}")
+  done
+  node "${ROOT_DIR}/apps/desktop/scripts/vendor-managed-uv.mjs" "${args[@]}"
+}
+
 run_pnpm_build() {
   pnpm build
 }
@@ -347,6 +375,7 @@ case "${VARIANT}" in
     run_timed_phase "prepare_claude_sdk_sidecar" prepare_claude_sdk_sidecar
     run_timed_phase "prepare_managed_posix_shell" prepare_managed_posix_shell
     run_timed_phase "prepare_mutagen" prepare_mutagen
+    run_timed_phase "prepare_managed_uv" prepare_managed_uv
     (
       cd "${APP_DIR}"
       run_timed_phase "resolve_desktop_build_version" resolve_desktop_build_version

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -43,6 +43,10 @@ const mutagenLockPath = new URL(
   "../../config/tutti.mutagen.lock.json",
   import.meta.url
 );
+const managedUVVendorScriptPath = new URL(
+  "../../apps/desktop/scripts/vendor-managed-uv.mjs",
+  import.meta.url
+);
 const tuttidManagerPath = new URL(
   "../../apps/desktop/src/main/daemon/tuttidManager.ts",
   import.meta.url
@@ -1195,4 +1199,26 @@ test("desktop Windows package and daemon agree on the bundled Mutagen resource",
   assert.match(tuttidManager, /tutti\.mutagen\.v1/);
   assert.equal(lock.schemaVersion, "tutti.mutagen-lock.v1");
   assert.equal(lock.platforms["windows-amd64"].executable, "mutagen.exe");
+});
+
+test("desktop packages and daemon agree on the bundled uv archive root", async () => {
+  const packageJson = JSON.parse(await readFile(desktopPackagePath, "utf8"));
+  const defaults = JSON.parse(
+    await readFile(new URL("../../config/tutti.defaults.json", import.meta.url), "utf8")
+  );
+  const buildScript = await readFile(buildScriptPath, "utf8");
+  const tuttidManager = await readFile(tuttidManagerPath, "utf8");
+
+  await access(managedUVVendorScriptPath);
+  assert.deepEqual(packageJson.build.extraResources.at(-1), {
+    from: "build/managed-uv",
+    to: "bin/managed-uv",
+    filter: ["**/*"]
+  });
+  assert.match(buildScript, /vendor-managed-uv\.mjs/);
+  assert.match(buildScript, /windows-amd64/);
+  assert.match(buildScript, /darwin-amd64 darwin-arm64/);
+  assert.match(tuttidManager, /TUTTI_BUNDLED_UV_ROOT/);
+  assert.equal(defaults.agentRuntimeTools.uv.version, "0.11.31");
+  assert.ok(defaults.agentRuntimeTools.uv.artifacts.length >= 5);
 });


### PR DESCRIPTION
## Summary
- cherry-pick #2189 onto release/0807
- add Windows WinINet system proxy resolution
- package checksum-pinned managed uv with Desktop and preserve verified download fallback
- keep OpenCode CLI/ACP binary resolution consistent without rewriting separate ACP adapters

## Verification
- targeted Windows proxy tests pass
- managed uv toolchain tests pass
- OpenCode/standard ACP provider resolution tests pass
- source cherry-pick applied without conflicts