### PR TITLE
fix(desktop): keep unsigned macOS uv archives out of notarized app

### DIFF
--- a/docs/architecture/windows-platform-support.md
+++ b/docs/architecture/windows-platform-support.md
@@ -169,6 +169,13 @@ dynamic official-download fallback. Node, Python, Kimi, Hermes, and other agent
 payloads remain dynamically installed, so this adds roughly one compressed uv
 archive per architecture rather than a complete cross-language toolchain.
 
+The signed macOS release is the one packaging exception. The upstream macOS
+archives contain nested `uv` and `uvx` executables without Tutti's Developer ID
+signature, so Apple notarization rejects the archive when it is embedded in the
+app. macOS therefore uses the same pinned, checksum-verified dynamic download
+fallback at first use; Windows and Linux continue to ship their bundled uv
+archive.
+
 For generic ACP providers such as OpenCode, provider resolution rewrites the
 adapter command once and every status, login, model-catalog, and session path
 uses that resolved executable. On Windows a complete isolated npm package is

--- a/tools/scripts/build-desktop-package.sh
+++ b/tools/scripts/build-desktop-package.sh
@@ -229,11 +229,15 @@ prepare_managed_uv() {
       platforms=(linux-amd64)
       ;;
     mac|mac-unsigned|mac-signed)
-      case "${MAC_ARCH}" in
-        x64) platforms=(darwin-amd64) ;;
-        arm64) platforms=(darwin-arm64) ;;
-        all|universal) platforms=(darwin-amd64 darwin-arm64) ;;
-      esac
+      # The upstream macOS uv archives contain the uv and uvx executables.
+      # They are intentionally left out of the signed app: Apple notarization
+      # recursively validates executable members in nested tar.gz files and
+      # rejects these upstream binaries because they are not signed with the
+      # app's Developer ID identity. macOS keeps the daemon's verified dynamic
+      # download fallback; Windows and Linux still receive the bundled archive.
+      rm -rf "${APP_DIR}/build/managed-uv"
+      mkdir -p "${APP_DIR}/build/managed-uv"
+      return
       ;;
     unpack)
       platforms=("$(node -e 'const os = process.platform === "win32" ? "windows" : process.platform === "darwin" ? "darwin" : "linux"; const arch = process.arch === "arm64" ? "arm64" : "amd64"; process.stdout.write(`${os}-${arch}`)')")

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -1217,7 +1217,12 @@ test("desktop packages and daemon agree on the bundled uv archive root", async (
   });
   assert.match(buildScript, /vendor-managed-uv\.mjs/);
   assert.match(buildScript, /windows-amd64/);
-  assert.match(buildScript, /darwin-amd64 darwin-arm64/);
+  assert.match(
+    buildScript,
+    /upstream macOS uv archives contain the uv and uvx executables/
+  );
+  assert.match(buildScript, /rm -rf "\$\{APP_DIR\}\/build\/managed-uv"/);
+  assert.match(buildScript, /mkdir -p "\$\{APP_DIR\}\/build\/managed-uv"/);
   assert.match(tuttidManager, /TUTTI_BUNDLED_UV_ROOT/);
   assert.equal(defaults.agentRuntimeTools.uv.version, "0.11.31");
   assert.ok(defaults.agentRuntimeTools.uv.artifacts.length >= 5);


### PR DESCRIPTION
## Root cause\nApple notarization rejects the upstream macOS uv tar.gz archives because nested uv and uvx executables are not signed with Tutti's Developer ID identity, do not carry a secure timestamp, and do not enable hardened runtime.\n\n## Fix\n- do not stage macOS uv archives into the signed app\n- preserve the pinned checksum-verified dynamic download fallback on macOS\n- keep bundled uv archives for Windows and Linux\n- document the packaging boundary and cover the release config with a regression assertion\n\n## Verification\n- node --test tools/scripts/desktop-release-config.test.mjs (48 passed)\n- git diff --check