### PR TITLE
perf(agent-import): project history ranges in memory

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/ExternalAgentSessionImportWizard.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/ExternalAgentSessionImportWizard.tsx
@@ -33,10 +33,11 @@ import {
   externalImportScanSource,
   externalImportScanStateReducer,
   externalImportSelectionProjects,
-  externalImportUsableScan,
+  externalImportUsableScanCatalog,
   filterExternalImportGroups,
   isExternalImportArchiveMode,
   isExternalImportWizardBusy,
+  projectExternalImportScan,
   shouldAllowExternalImportDialogOpenChange,
   type ExternalImportProjectGroup
 } from "./externalAgentSessionImportWizardModel";
@@ -153,10 +154,23 @@ export function ExternalAgentSessionImportWizard({
   const currentScanSource = externalImportScanSource({
     archiveKind,
     archivePath,
-    days,
     providers: selectedProviderList
   });
-  const scan = externalImportUsableScan(scanState, currentScanSource);
+  const scanCatalog = externalImportUsableScanCatalog(
+    scanState,
+    currentScanSource
+  );
+  const scan = useMemo(
+    () =>
+      scanCatalog
+        ? projectExternalImportScan(
+            scanCatalog.response,
+            days,
+            scanCatalog.anchorUnixMs
+          )
+        : null,
+    [days, scanCatalog]
+  );
   const archiveMode = isExternalImportArchiveMode(archivePath);
   const groups = useMemo(
     () =>
@@ -218,7 +232,6 @@ export function ExternalAgentSessionImportWizard({
   };
 
   const runScan = async (
-    nextDays: number,
     nextArchivePath: string | null,
     nextArchiveKind: ExternalAgentImportArchiveKind = archiveKind
   ) => {
@@ -226,13 +239,13 @@ export function ExternalAgentSessionImportWizard({
     const source = externalImportScanSource({
       archiveKind: nextArchiveKind,
       archivePath: nextArchivePath,
-      days: nextDays,
       providers: selectedProviderList
     });
     dispatchScanState({ type: "scan-started" });
     setLoading(true);
     setError(null);
     try {
+      const anchorUnixMs = Date.now();
       const nextScan =
         await workspaceAgentActivityService.scanExternalSessionImports(
           workspace.id,
@@ -243,6 +256,7 @@ export function ExternalAgentSessionImportWizard({
       }
       dispatchScanState({
         type: "scan-succeeded",
+        anchorUnixMs,
         response: nextScan,
         source
       });
@@ -287,7 +301,7 @@ export function ExternalAgentSessionImportWizard({
       return;
     }
     setArchivePath(null);
-    await runScan(days, null);
+    await runScan(null);
   };
 
   const handleSelectArchive = async (
@@ -310,7 +324,7 @@ export function ExternalAgentSessionImportWizard({
       setArchivePath(nextArchivePath);
       setArchiveKind(nextArchiveKind);
       setDays(-1);
-      await runScan(-1, nextArchivePath, nextArchiveKind);
+      await runScan(nextArchivePath, nextArchiveKind);
     } catch {
       if (generation !== scanGeneration.current) {
         return;
@@ -330,16 +344,15 @@ export function ExternalAgentSessionImportWizard({
     }
   };
 
-  const handleSelectRange = async (nextDays: number) => {
+  const handleSelectRange = (nextDays: number) => {
     if (nextDays === days || loading || importing) {
       return;
     }
     setDays(nextDays);
-    await runScan(nextDays, archivePath);
   };
 
   const handleImport = async () => {
-    if (!canImport || !scan || !scanState) {
+    if (!canImport || !scan || !scanCatalog) {
       return;
     }
     setImporting(true);
@@ -354,11 +367,11 @@ export function ExternalAgentSessionImportWizard({
           workspace.id,
           {
             ...externalImportRequestSource(
-              scanState.source.kind === "archive"
-                ? scanState.source.archivePath
+              scanCatalog.source.kind === "archive"
+                ? scanCatalog.source.archivePath
                 : null,
-              scanState.source.kind === "archive"
-                ? scanState.source.archiveKind
+              scanCatalog.source.kind === "archive"
+                ? scanCatalog.source.archiveKind
                 : null,
               registerProjects
             ),

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/externalAgentSessionImportWizardModel.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/externalAgentSessionImportWizardModel.test.ts
@@ -7,10 +7,11 @@ import {
   externalImportScanSource,
   externalImportScanStateReducer,
   externalImportSelectionProjects,
-  externalImportUsableScan,
+  externalImportUsableScanCatalog,
   filterExternalImportGroups,
   isExternalImportArchiveMode,
   isExternalImportWizardBusy,
+  projectExternalImportScan,
   shouldAllowExternalImportDialogOpenChange
 } from "./externalAgentSessionImportWizardModel.ts";
 
@@ -19,7 +20,6 @@ test("archive source keeps the same path and kind for scan and disables project 
   const source = externalImportScanSource({
     archiveKind: "claude",
     archivePath: " /tmp/claude-export.zip ",
-    days: -1,
     providers: ["codex", "claude-code"]
   });
   assert.deepEqual(externalImportScanRequest(source), {
@@ -41,7 +41,6 @@ test("chatgpt archive source threads its kind through scan and import requests",
   const source = externalImportScanSource({
     archiveKind: "chatgpt",
     archivePath: "/tmp/chatgpt-export.zip",
-    days: -1,
     providers: []
   });
   assert.deepEqual(externalImportScanRequest(source), {
@@ -59,25 +58,24 @@ test("chatgpt archive source threads its kind through scan and import requests",
   );
 });
 
-test("local source keeps providers and the project registration preference", () => {
+test("local source requests all history and keeps the project registration preference", () => {
   assert.equal(isExternalImportArchiveMode(null), false);
   assert.deepEqual(
     externalImportScanRequest(
       externalImportScanSource({
         archiveKind: "claude",
         archivePath: null,
-        days: 30,
         providers: ["codex"]
       })
     ),
-    { days: 30, providers: ["codex"] }
+    { days: -1, providers: ["codex"] }
   );
   assert.deepEqual(externalImportRequestSource(null, null, false), {
     registerUserProjects: false
   });
 });
 
-test("completed scan is usable only for its exact source identity", () => {
+test("completed scan is reusable for the same provider catalog identity", () => {
   const response = {
     errors: [],
     projects: [],
@@ -90,35 +88,36 @@ test("completed scan is usable only for its exact source identity", () => {
   const source = externalImportScanSource({
     archiveKind: "claude",
     archivePath: "/tmp/claude-export-a.zip",
-    days: -1,
     providers: ["codex", "claude-code"]
   });
   const state = externalImportScanStateReducer(null, {
     type: "scan-succeeded",
+    anchorUnixMs: 123,
     response,
     source
   });
 
-  assert.equal(externalImportUsableScan(state, source), response);
   assert.equal(
-    externalImportUsableScan(
+    externalImportUsableScanCatalog(state, source)?.response,
+    response
+  );
+  assert.equal(
+    externalImportUsableScanCatalog(
       state,
       externalImportScanSource({
         archiveKind: "claude",
         archivePath: "/tmp/claude-export-b.zip",
-        days: -1,
         providers: ["codex", "claude-code"]
       })
     ),
     null
   );
   assert.equal(
-    externalImportUsableScan(
+    externalImportUsableScanCatalog(
       state,
       externalImportScanSource({
         archiveKind: "chatgpt",
         archivePath: "/tmp/claude-export-a.zip",
-        days: -1,
         providers: ["codex", "claude-code"]
       })
     ),
@@ -126,16 +125,50 @@ test("completed scan is usable only for its exact source identity", () => {
     "same path but a different archive kind must not reuse the scan"
   );
   assert.equal(
-    externalImportUsableScan(
+    externalImportUsableScanCatalog(
       state,
       externalImportScanSource({
         archiveKind: "claude",
         archivePath: null,
-        days: -1,
         providers: ["codex", "claude-code"]
       })
     ),
     null
+  );
+});
+
+test("local catalog identity ignores provider order and active range", () => {
+  const response = {
+    errors: [],
+    projects: [],
+    providers: [],
+    scannedMessages: 0,
+    scannedSessions: 0,
+    sessions: [],
+    skippedSessions: 0
+  };
+  const source = externalImportScanSource({
+    archiveKind: "claude",
+    archivePath: null,
+    providers: ["codex", "claude-code"]
+  });
+  const state = externalImportScanStateReducer(null, {
+    type: "scan-succeeded",
+    anchorUnixMs: 123,
+    response,
+    source
+  });
+
+  assert.equal(
+    externalImportUsableScanCatalog(
+      state,
+      externalImportScanSource({
+        archiveKind: "claude",
+        archivePath: null,
+        providers: ["claude-code", "codex"]
+      })
+    )?.response,
+    response
   );
 });
 
@@ -152,11 +185,11 @@ test("starting, failing, or changing source clears the completed scan", () => {
   const source = externalImportScanSource({
     archiveKind: "claude",
     archivePath: "/tmp/claude-export.zip",
-    days: -1,
     providers: []
   });
   const completed = externalImportScanStateReducer(null, {
     type: "scan-succeeded",
+    anchorUnixMs: 123,
     response,
     source
   });
@@ -172,6 +205,250 @@ test("starting, failing, or changing source clears the completed scan", () => {
   assert.equal(
     externalImportScanStateReducer(completed, { type: "source-changed" }),
     null
+  );
+});
+
+test("projects all supported ranges from one catalog with daemon cutoff semantics", () => {
+  const dayMs = 24 * 60 * 60 * 1000;
+  const anchorUnixMs = 100 * dayMs;
+  const catalog: Parameters<typeof projectExternalImportScan>[0] = {
+    errors: [{ provider: "codex", message: "one catalog diagnostic" }],
+    projects: [
+      {
+        path: "/b",
+        label: "Beta",
+        providers: ["codex"],
+        sessionCount: 1,
+        messageCount: 5,
+        lastUpdatedAtUnixMs: anchorUnixMs - dayMs
+      },
+      {
+        path: "/a",
+        label: "Alpha",
+        providers: ["claude-code", "codex"],
+        sessionCount: 3,
+        messageCount: 11,
+        lastUpdatedAtUnixMs: anchorUnixMs - 7 * dayMs
+      },
+      {
+        path: "/c",
+        label: "Gamma",
+        providers: ["codex"],
+        sessionCount: 1,
+        messageCount: 4,
+        lastUpdatedAtUnixMs: anchorUnixMs - 30 * dayMs
+      },
+      {
+        path: "/d",
+        label: "Delta",
+        providers: ["codex"],
+        sessionCount: 1,
+        messageCount: 1,
+        lastUpdatedAtUnixMs: anchorUnixMs - 90 * dayMs
+      }
+    ],
+    providers: [
+      {
+        provider: "codex",
+        root: "/codex",
+        available: true,
+        sessionCount: 4,
+        messageCount: 12
+      },
+      {
+        provider: "claude-code",
+        root: "/claude",
+        available: true,
+        sessionCount: 2,
+        messageCount: 9
+      }
+    ],
+    scannedMessages: 21,
+    scannedSessions: 6,
+    sessions: [
+      {
+        id: "recent",
+        projectPath: "/b",
+        provider: "codex",
+        title: "Recent",
+        messageCount: 5,
+        lastUpdatedAtUnixMs: anchorUnixMs - dayMs
+      },
+      {
+        id: "boundary-7",
+        projectPath: "/a",
+        provider: "claude-code",
+        title: "Seven day boundary",
+        messageCount: 3,
+        lastUpdatedAtUnixMs: anchorUnixMs - 7 * dayMs
+      },
+      {
+        id: "day-8",
+        projectPath: "/a",
+        provider: "codex",
+        title: "Eight days",
+        messageCount: 2,
+        lastUpdatedAtUnixMs: anchorUnixMs - 8 * dayMs
+      },
+      {
+        id: "boundary-30",
+        projectPath: "/c",
+        provider: "codex",
+        title: "Thirty day boundary",
+        messageCount: 4,
+        lastUpdatedAtUnixMs: anchorUnixMs - 30 * dayMs
+      },
+      {
+        id: "boundary-90",
+        projectPath: "/d",
+        provider: "codex",
+        title: "Ninety day boundary",
+        messageCount: 1,
+        lastUpdatedAtUnixMs: anchorUnixMs - 90 * dayMs
+      },
+      {
+        id: "day-91",
+        projectPath: "/a",
+        provider: "claude-code",
+        title: "Older",
+        messageCount: 6,
+        lastUpdatedAtUnixMs: anchorUnixMs - 91 * dayMs
+      }
+    ],
+    skippedSessions: 2
+  };
+
+  const sevenDays = projectExternalImportScan(catalog, 7, anchorUnixMs);
+  assert.deepEqual(
+    sevenDays.sessions.map((session) => session.id),
+    ["recent", "boundary-7"],
+    "the exact cutoff boundary remains included"
+  );
+  assert.equal(sevenDays.scannedSessions, 2);
+  assert.equal(sevenDays.scannedMessages, 8);
+  assert.deepEqual(
+    sevenDays.projects.map((project) => ({
+      path: project.path,
+      providers: project.providers,
+      sessions: project.sessionCount,
+      messages: project.messageCount
+    })),
+    [
+      { path: "/b", providers: ["codex"], sessions: 1, messages: 5 },
+      {
+        path: "/a",
+        providers: ["claude-code"],
+        sessions: 1,
+        messages: 3
+      }
+    ]
+  );
+  assert.deepEqual(
+    sevenDays.providers.map((provider) => [
+      provider.provider,
+      provider.sessionCount,
+      provider.messageCount
+    ]),
+    [
+      ["codex", 1, 5],
+      ["claude-code", 1, 3]
+    ]
+  );
+
+  assert.deepEqual(
+    projectExternalImportScan(catalog, 30, anchorUnixMs).sessions.map(
+      (session) => session.id
+    ),
+    ["recent", "boundary-7", "day-8", "boundary-30"]
+  );
+  assert.deepEqual(
+    projectExternalImportScan(catalog, 90, anchorUnixMs).sessions.map(
+      (session) => session.id
+    ),
+    ["recent", "boundary-7", "day-8", "boundary-30", "boundary-90"]
+  );
+  const allHistory = projectExternalImportScan(catalog, -1, anchorUnixMs);
+  assert.deepEqual(
+    allHistory.sessions.map((session) => session.id),
+    catalog.sessions.map((session) => session.id)
+  );
+  assert.equal(allHistory.scannedSessions, 6);
+  assert.equal(allHistory.scannedMessages, 21);
+  assert.equal(allHistory.skippedSessions, 2);
+  assert.equal(allHistory.errors, catalog.errors);
+});
+
+test("range projections preserve deselections when sessions leave and re-enter", () => {
+  const anchorUnixMs = 100 * 24 * 60 * 60 * 1000;
+  const catalog: Parameters<typeof projectExternalImportScan>[0] = {
+    errors: [],
+    projects: [
+      {
+        path: "/project",
+        label: "Project",
+        providers: ["codex"],
+        sessionCount: 2,
+        messageCount: 2
+      }
+    ],
+    providers: [
+      {
+        provider: "codex",
+        root: "/codex",
+        available: true,
+        sessionCount: 2,
+        messageCount: 2
+      }
+    ],
+    scannedMessages: 2,
+    scannedSessions: 2,
+    sessions: [
+      {
+        id: "recent",
+        projectPath: "/project",
+        provider: "codex",
+        title: "Recent",
+        messageCount: 1,
+        lastUpdatedAtUnixMs: anchorUnixMs
+      },
+      {
+        id: "older-deselected",
+        projectPath: "/project",
+        provider: "codex",
+        title: "Older",
+        messageCount: 1,
+        lastUpdatedAtUnixMs: 1
+      }
+    ],
+    skippedSessions: 0
+  };
+  const deselected = new Set(["older-deselected"]);
+
+  assert.deepEqual(
+    externalImportSelectionProjects(
+      projectExternalImportScan(catalog, 7, anchorUnixMs).sessions,
+      deselected
+    ),
+    [
+      {
+        path: "/project",
+        providers: ["codex"],
+        sessionIds: ["recent"]
+      }
+    ]
+  );
+  assert.deepEqual(
+    externalImportSelectionProjects(
+      projectExternalImportScan(catalog, -1, anchorUnixMs).sessions,
+      deselected
+    ),
+    [
+      {
+        path: "/project",
+        providers: ["codex"],
+        sessionIds: ["recent"]
+      }
+    ]
   );
 });
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/externalAgentSessionImportWizardModel.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/externalAgentSessionImportWizardModel.test.ts
@@ -378,6 +378,126 @@ test("projects all supported ranges from one catalog with daemon cutoff semantic
   assert.equal(allHistory.errors, catalog.errors);
 });
 
+test("every range preset is served by one scan of the same catalog", () => {
+  // Issue #2060 acceptance criteria 1 and 2: after the initial local-history
+  // scan, switching among 7/30/90/All must not issue another scan request.
+  // There is no React rendering harness here (see the module header), so drive
+  // the same reducer -> usable-catalog -> projection pipeline the wizard runs
+  // on each render and count how often a scan would actually be needed: the
+  // wizard calls the scan endpoint exactly when no usable catalog is available
+  // for the current source.
+  const dayMs = 24 * 60 * 60 * 1000;
+  // Anchor well past the oldest fixture stamp so "all history" stays a
+  // positive Unix time; the all-history cutoff is 0, so a negative stamp
+  // would be filtered out and no real session ever has one.
+  const anchorUnixMs = 400 * dayMs;
+  const source = externalImportScanSource({
+    archiveKind: "claude",
+    archivePath: null,
+    providers: ["codex", "claude-code"]
+  });
+  const catalog: Parameters<typeof projectExternalImportScan>[0] = {
+    errors: [],
+    projects: [],
+    providers: [],
+    scannedMessages: 3,
+    scannedSessions: 3,
+    sessions: [
+      {
+        id: "in-7",
+        projectPath: "/p",
+        provider: "codex",
+        title: "Recent",
+        messageCount: 1,
+        lastUpdatedAtUnixMs: anchorUnixMs - dayMs
+      },
+      {
+        id: "in-30",
+        projectPath: "/p",
+        provider: "codex",
+        title: "Mid",
+        messageCount: 1,
+        lastUpdatedAtUnixMs: anchorUnixMs - 20 * dayMs
+      },
+      {
+        id: "in-all",
+        projectPath: "/p",
+        provider: "codex",
+        title: "Old",
+        messageCount: 1,
+        lastUpdatedAtUnixMs: anchorUnixMs - 200 * dayMs
+      }
+    ],
+    skippedSessions: 0
+  };
+
+  let scanCalls = 0;
+  let state = externalImportScanStateReducer(null, { type: "source-changed" });
+  const renderRange = (days: number) => {
+    let usable = externalImportUsableScanCatalog(state, source);
+    if (!usable) {
+      // This is the only branch that hits the network in the wizard.
+      scanCalls += 1;
+      state = externalImportScanStateReducer(state, {
+        type: "scan-succeeded",
+        anchorUnixMs,
+        response: catalog,
+        source
+      });
+      usable = externalImportUsableScanCatalog(state, source);
+    }
+    return projectExternalImportScan(
+      usable!.response,
+      days,
+      usable!.anchorUnixMs
+    );
+  };
+
+  // Initial scan, then every preset, including revisiting an earlier one.
+  assert.deepEqual(
+    renderRange(30).sessions.map((session) => session.id),
+    ["in-7", "in-30"]
+  );
+  assert.equal(scanCalls, 1, "the initial scan is the only scan request");
+
+  assert.deepEqual(
+    renderRange(7).sessions.map((session) => session.id),
+    ["in-7"]
+  );
+  assert.deepEqual(
+    renderRange(90).sessions.map((session) => session.id),
+    ["in-7", "in-30"]
+  );
+  assert.deepEqual(
+    renderRange(-1).sessions.map((session) => session.id),
+    ["in-7", "in-30", "in-all"]
+  );
+  // Returning to an already-viewed preset must also stay in memory.
+  assert.deepEqual(
+    renderRange(30).sessions.map((session) => session.id),
+    ["in-7", "in-30"]
+  );
+  assert.equal(
+    scanCalls,
+    1,
+    "switching among 7/30/90/All issues no additional scan request"
+  );
+
+  // Changing the provider selection still invalidates the reusable catalog.
+  assert.equal(
+    externalImportUsableScanCatalog(
+      state,
+      externalImportScanSource({
+        archiveKind: "claude",
+        archivePath: null,
+        providers: ["codex"]
+      })
+    ),
+    null,
+    "a narrower provider selection must not reuse the previous catalog"
+  );
+});
+
 test("range projections preserve deselections when sessions leave and re-enter", () => {
   const anchorUnixMs = 100 * 24 * 60 * 60 * 1000;
   const catalog: Parameters<typeof projectExternalImportScan>[0] = {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/externalAgentSessionImportWizardModel.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/externalAgentSessionImportWizardModel.ts
@@ -22,18 +22,19 @@ export type ExternalImportScanSource =
       kind: "archive";
       archivePath: string;
       archiveKind: ExternalAgentImportArchiveKind;
-      days: number;
     }
   | {
       kind: "local";
-      days: number;
       providers: WorkspaceAgentProvider[];
     };
 
-export type ExternalImportScanState = {
+export type ExternalImportScanCatalog = {
+  anchorUnixMs: number;
   response: ExternalAgentImportScanResponse;
   source: ExternalImportScanSource;
-} | null;
+};
+
+export type ExternalImportScanState = ExternalImportScanCatalog | null;
 
 export type ExternalImportScanStateAction =
   | { type: "scan-started" }
@@ -41,6 +42,7 @@ export type ExternalImportScanStateAction =
   | { type: "source-changed" }
   | {
       type: "scan-succeeded";
+      anchorUnixMs: number;
       response: ExternalAgentImportScanResponse;
       source: ExternalImportScanSource;
     };
@@ -54,12 +56,10 @@ export function isExternalImportArchiveMode(
 export function externalImportScanSource({
   archiveKind,
   archivePath,
-  days,
   providers
 }: {
   archiveKind: ExternalAgentImportArchiveKind;
   archivePath: string | null;
-  days: number;
   providers: WorkspaceAgentProvider[];
 }): ExternalImportScanSource {
   const normalizedArchivePath = archivePath?.trim();
@@ -67,14 +67,12 @@ export function externalImportScanSource({
     return {
       kind: "archive",
       archivePath: normalizedArchivePath,
-      archiveKind,
-      days
+      archiveKind
     };
   }
   return {
     kind: "local",
-    days,
-    providers: [...new Set(providers)]
+    providers: [...new Set(providers)].sort(compareExternalImportStrings)
   };
 }
 
@@ -85,9 +83,9 @@ export function externalImportScanRequest(
     ? {
         archivePath: source.archivePath,
         archiveKind: source.archiveKind,
-        days: source.days
+        days: -1
       }
-    : { days: source.days, providers: source.providers };
+    : { days: -1, providers: source.providers };
 }
 
 export function externalImportScanStateReducer(
@@ -95,17 +93,21 @@ export function externalImportScanStateReducer(
   action: ExternalImportScanStateAction
 ): ExternalImportScanState {
   if (action.type === "scan-succeeded") {
-    return { response: action.response, source: action.source };
+    return {
+      anchorUnixMs: action.anchorUnixMs,
+      response: action.response,
+      source: action.source
+    };
   }
   return null;
 }
 
-export function externalImportUsableScan(
+export function externalImportUsableScanCatalog(
   state: ExternalImportScanState,
   source: ExternalImportScanSource
-): ExternalAgentImportScanResponse | null {
+): ExternalImportScanCatalog | null {
   return state && externalImportScanSourcesEqual(state.source, source)
-    ? state.response
+    ? state
     : null;
 }
 
@@ -113,7 +115,7 @@ function externalImportScanSourcesEqual(
   left: ExternalImportScanSource,
   right: ExternalImportScanSource
 ): boolean {
-  if (left.kind !== right.kind || left.days !== right.days) {
+  if (left.kind !== right.kind) {
     return false;
   }
   if (left.kind === "archive" && right.kind === "archive") {
@@ -125,10 +127,114 @@ function externalImportScanSourcesEqual(
   if (left.kind === "local" && right.kind === "local") {
     return (
       left.providers.length === right.providers.length &&
-      left.providers.every((provider) => right.providers.includes(provider))
+      left.providers.every(
+        (provider, index) => provider === right.providers[index]
+      )
     );
   }
   return false;
+}
+
+const externalImportDayMs = 24 * 60 * 60 * 1000;
+
+export function projectExternalImportScan(
+  catalog: ExternalAgentImportScanResponse,
+  days: number,
+  anchorUnixMs: number
+): ExternalAgentImportScanResponse {
+  const effectiveDays = days === 0 ? 30 : days;
+  const cutoffUnixMs =
+    effectiveDays < 0 ? 0 : anchorUnixMs - effectiveDays * externalImportDayMs;
+  const sessions = catalog.sessions.filter(
+    (session) => (session.lastUpdatedAtUnixMs ?? 0) >= cutoffUnixMs
+  );
+  const catalogProjects = new Map(
+    catalog.projects.map((project) => [project.path, project])
+  );
+  const projectCounts = new Map<
+    string,
+    {
+      label: string;
+      lastUpdatedAtUnixMs: number;
+      messageCount: number;
+      providers: Set<WorkspaceAgentProvider>;
+      sessionCount: number;
+    }
+  >();
+  const providerCounts = new Map<
+    WorkspaceAgentProvider,
+    { messageCount: number; sessionCount: number }
+  >();
+  let scannedMessages = 0;
+
+  for (const session of sessions) {
+    const updatedAtUnixMs = session.lastUpdatedAtUnixMs ?? 0;
+    scannedMessages += session.messageCount;
+
+    const provider = providerCounts.get(session.provider) ?? {
+      messageCount: 0,
+      sessionCount: 0
+    };
+    provider.messageCount += session.messageCount;
+    provider.sessionCount += 1;
+    providerCounts.set(session.provider, provider);
+
+    const project = projectCounts.get(session.projectPath) ?? {
+      label:
+        catalogProjects.get(session.projectPath)?.label ?? session.projectPath,
+      lastUpdatedAtUnixMs: 0,
+      messageCount: 0,
+      providers: new Set<WorkspaceAgentProvider>(),
+      sessionCount: 0
+    };
+    project.lastUpdatedAtUnixMs = Math.max(
+      project.lastUpdatedAtUnixMs,
+      updatedAtUnixMs
+    );
+    project.messageCount += session.messageCount;
+    project.providers.add(session.provider);
+    project.sessionCount += 1;
+    projectCounts.set(session.projectPath, project);
+  }
+
+  const projects = [...projectCounts.entries()]
+    .map(([path, project]) => ({
+      path,
+      label: project.label,
+      providers: [...project.providers].sort(compareExternalImportStrings),
+      sessionCount: project.sessionCount,
+      messageCount: project.messageCount,
+      lastUpdatedAtUnixMs: project.lastUpdatedAtUnixMs
+    }))
+    .sort((left, right) => {
+      if (left.lastUpdatedAtUnixMs === right.lastUpdatedAtUnixMs) {
+        return compareExternalImportStrings(left.path, right.path);
+      }
+      return right.lastUpdatedAtUnixMs - left.lastUpdatedAtUnixMs;
+    });
+
+  return {
+    ...catalog,
+    providers: catalog.providers.map((provider) => {
+      const counts = providerCounts.get(provider.provider);
+      return {
+        ...provider,
+        sessionCount: counts?.sessionCount ?? 0,
+        messageCount: counts?.messageCount ?? 0
+      };
+    }),
+    projects,
+    sessions,
+    scannedSessions: sessions.length,
+    scannedMessages
+  };
+}
+
+function compareExternalImportStrings(left: string, right: string): number {
+  if (left === right) {
+    return 0;
+  }
+  return left < right ? -1 : 1;
 }
 
 export function externalImportRequestSource(

--- a/services/tuttid/service/agent/external_import.go
+++ b/services/tuttid/service/agent/external_import.go
@@ -19,7 +19,14 @@ import (
 )
 
 func (*Service) ScanExternalImports(ctx context.Context, input ExternalImportScanInput) (ExternalImportScanResult, error) {
-	data, err := scanExternalAgentSessions(ctx, normalizeExternalImportProviders(input.Providers), input.Days, input.ArchivePath, input.ArchiveKind)
+	data, err := scanExternalAgentSessionsWithRetention(
+		ctx,
+		normalizeExternalImportProviders(input.Providers),
+		input.Days,
+		input.ArchivePath,
+		input.ArchiveKind,
+		externalScanSummaryOnly,
+	)
 	if err != nil {
 		return ExternalImportScanResult{}, err
 	}
@@ -227,6 +234,24 @@ func externalImportAgentTargetID(provider string) string {
 }
 
 func scanExternalAgentSessions(ctx context.Context, providers []string, days int, archivePath string, archiveKind string) (externalScanData, error) {
+	return scanExternalAgentSessionsWithRetention(
+		ctx,
+		providers,
+		days,
+		archivePath,
+		archiveKind,
+		externalScanRetainTranscripts,
+	)
+}
+
+func scanExternalAgentSessionsWithRetention(
+	ctx context.Context,
+	providers []string,
+	days int,
+	archivePath string,
+	archiveKind string,
+	retention externalScanRetention,
+) (externalScanData, error) {
 	if strings.TrimSpace(archivePath) != "" {
 		archiveKind = normalizeExternalImportArchiveKind(archiveKind)
 		// The Claude archive scan still requires the claude-code provider to be
@@ -247,55 +272,28 @@ func scanExternalAgentSessions(ctx context.Context, providers []string, days int
 		}
 		switch archiveKind {
 		case ExternalImportArchiveKindChatGPT:
-			return scanChatGPTExportArchive(ctx, archivePath, cutoffUnixMS)
+			return scanChatGPTExportArchiveWithRetention(ctx, archivePath, cutoffUnixMS, retention)
 		default:
-			return scanClaudeExportArchive(ctx, archivePath, cutoffUnixMS)
+			return scanClaudeExportArchiveWithRetention(ctx, archivePath, cutoffUnixMS, retention)
 		}
 	}
 	data := externalScanData{}
-	projects := map[string]*ExternalImportProject{}
+	collector := newExternalScanCollector(&data, retention)
 	cutoffUnixMS := externalScanCutoffUnixMS(days)
 	for _, provider := range normalizeExternalImportProviders(providers) {
 		if ctx.Err() != nil {
 			break
 		}
-		sessions, summary, errors := scanExternalProviderSessions(provider, cutoffUnixMS)
+		summary, errors := scanExternalProviderSessions(provider, cutoffUnixMS, collector.add)
 		data.result.Providers = append(data.result.Providers, summary)
 		data.result.Errors = append(data.result.Errors, errors...)
-		for _, session := range sessions {
-			project, ok := projectFromExternalSession(session)
-			if !ok {
-				data.result.SkippedSessions++
-				continue
-			}
-			data.sessions = append(data.sessions, session)
-			data.result.ScannedSessions++
-			data.result.ScannedMessages += len(session.Messages)
-			data.result.Sessions = append(data.result.Sessions, externalImportSessionSummary(session, project.Path))
-			upsertExternalImportProject(projects, project, session.Provider)
-		}
 	}
-	for _, project := range projects {
-		sort.Strings(project.Providers)
-		data.result.Projects = append(data.result.Projects, *project)
-	}
-	sort.SliceStable(data.result.Projects, func(left, right int) bool {
-		if data.result.Projects[left].LastUpdatedAtUnixMS == data.result.Projects[right].LastUpdatedAtUnixMS {
-			return data.result.Projects[left].Path < data.result.Projects[right].Path
-		}
-		return data.result.Projects[left].LastUpdatedAtUnixMS > data.result.Projects[right].LastUpdatedAtUnixMS
-	})
-	sort.SliceStable(data.result.Sessions, func(left, right int) bool {
-		if data.result.Sessions[left].LastUpdatedAtUnixMS == data.result.Sessions[right].LastUpdatedAtUnixMS {
-			return data.result.Sessions[left].ID < data.result.Sessions[right].ID
-		}
-		return data.result.Sessions[left].LastUpdatedAtUnixMS > data.result.Sessions[right].LastUpdatedAtUnixMS
-	})
 	// The provider loop breaks on cancellation, so surface it instead of
 	// letting a partial scan pass as a complete result.
 	if err := ctx.Err(); err != nil {
 		return externalScanData{}, err
 	}
+	collector.finish()
 	return data, nil
 }
 
@@ -339,24 +337,28 @@ func externalScanCutoffUnixMS(days int) int64 {
 	return time.Now().Add(-time.Duration(days) * 24 * time.Hour).UnixMilli()
 }
 
-func scanExternalProviderSessions(provider string, cutoffUnixMS int64) ([]externalImportedSession, ExternalImportProvider, []ExternalImportError) {
+func scanExternalProviderSessions(
+	provider string,
+	cutoffUnixMS int64,
+	visit func(externalImportedSession),
+) (ExternalImportProvider, []ExternalImportError) {
 	descriptor, ok := providerregistry.Find(provider)
 	if !ok || !descriptor.ExternalImport.Enabled {
-		return nil, ExternalImportProvider{Provider: provider}, nil
+		return ExternalImportProvider{Provider: provider}, nil
 	}
 	root := externalProviderRoot(descriptor.ExternalImport)
 	summary := ExternalImportProvider{Provider: provider, Root: root}
 	if root == "" {
-		return nil, summary, nil
+		return summary, nil
 	}
 	if info, err := os.Stat(root); err != nil || !info.IsDir() {
-		return nil, summary, nil
+		return summary, nil
 	}
 	summary.Available = true
 	files, err := externalProviderJSONLFiles(descriptor.ExternalImport, root)
 	if err != nil {
 		summary.Error = err.Error()
-		return nil, summary, []ExternalImportError{{Provider: provider, Message: err.Error()}}
+		return summary, []ExternalImportError{{Provider: provider, Message: err.Error()}}
 	}
 	// Codex stores the generated conversation title in its app-server SQLite
 	// state DB rather than in the rollout transcript, so resolve it up front and
@@ -365,7 +367,6 @@ func scanExternalProviderSessions(provider string, cutoffUnixMS int64) ([]extern
 	if descriptor.ExternalImport.TitleCatalogKind == providerregistry.ExternalImportTitleCatalogKindCodexSQLite {
 		importedTitles = codexThreadTitles(root)
 	}
-	sessions := make([]externalImportedSession, 0, len(files))
 	errors := make([]ExternalImportError, 0)
 	for _, file := range files {
 		session, ok, err := parseExternalProviderJSONL(descriptor, file)
@@ -382,11 +383,11 @@ func scanExternalProviderSessions(provider string, cutoffUnixMS int64) ([]extern
 		if title := strings.TrimSpace(importedTitles[session.ProviderSessionID]); title != "" {
 			session.Title = truncateExternalTitle(title)
 		}
-		sessions = append(sessions, session)
 		summary.SessionCount++
 		summary.MessageCount += len(session.Messages)
+		visit(session)
 	}
-	return sessions, summary, errors
+	return summary, errors
 }
 
 func externalProviderRoot(descriptor providerregistry.ExternalImportDescriptor) string {

--- a/services/tuttid/service/agent/external_import_chatgpt_export.go
+++ b/services/tuttid/service/agent/external_import_chatgpt_export.go
@@ -95,6 +95,20 @@ type chatgptExportArchiveHandle struct {
 }
 
 func scanChatGPTExportArchive(ctx context.Context, archivePath string, cutoffUnixMS int64) (externalScanData, error) {
+	return scanChatGPTExportArchiveWithRetention(
+		ctx,
+		archivePath,
+		cutoffUnixMS,
+		externalScanRetainTranscripts,
+	)
+}
+
+func scanChatGPTExportArchiveWithRetention(
+	ctx context.Context,
+	archivePath string,
+	cutoffUnixMS int64,
+	retention externalScanRetention,
+) (externalScanData, error) {
 	handle, err := openChatGPTExportConversationEntries(archivePath)
 	if err != nil {
 		return externalScanData{}, err
@@ -114,7 +128,7 @@ func scanChatGPTExportArchive(ctx context.Context, archivePath string, cutoffUni
 		Provider:  chatgptExportProvider,
 		Available: true,
 	}}
-	projects := map[string]*ExternalImportProject{}
+	collector := newExternalScanCollector(&data, retention)
 	conversationIDs := map[string]struct{}{}
 	totalMessages := 0
 	conversationIndex := 0
@@ -182,17 +196,7 @@ func scanChatGPTExportArchive(ctx context.Context, archivePath string, cutoffUni
 				conversationIndex++
 				continue
 			}
-			project, ok := projectFromExternalSession(session)
-			if !ok {
-				data.result.SkippedSessions++
-				conversationIndex++
-				continue
-			}
-			data.sessions = append(data.sessions, session)
-			data.result.ScannedSessions++
-			data.result.ScannedMessages += len(session.Messages)
-			data.result.Sessions = append(data.result.Sessions, externalImportSessionSummary(session, project.Path))
-			upsertExternalImportProject(projects, project, session.Provider)
+			collector.add(session)
 			conversationIndex++
 		}
 		if err := entryReader.Close(); err != nil {
@@ -200,16 +204,7 @@ func scanChatGPTExportArchive(ctx context.Context, archivePath string, cutoffUni
 		}
 	}
 
-	for _, project := range projects {
-		sort.Strings(project.Providers)
-		data.result.Projects = append(data.result.Projects, *project)
-	}
-	sort.SliceStable(data.result.Sessions, func(left, right int) bool {
-		if data.result.Sessions[left].LastUpdatedAtUnixMS == data.result.Sessions[right].LastUpdatedAtUnixMS {
-			return data.result.Sessions[left].ID < data.result.Sessions[right].ID
-		}
-		return data.result.Sessions[left].LastUpdatedAtUnixMS > data.result.Sessions[right].LastUpdatedAtUnixMS
-	})
+	collector.finish()
 	data.result.Providers[0].SessionCount = data.result.ScannedSessions
 	data.result.Providers[0].MessageCount = data.result.ScannedMessages
 	return data, nil

--- a/services/tuttid/service/agent/external_import_chatgpt_export_test.go
+++ b/services/tuttid/service/agent/external_import_chatgpt_export_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"sort"
 	"strings"
@@ -14,6 +15,38 @@ import (
 
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 )
+
+func TestScanChatGPTExportArchiveSummaryOnlyMatchesRetainedResult(t *testing.T) {
+	archivePath := writeChatGPTExportArchive(t, []map[string]any{
+		chatgptExportConversationFixture("summary-only", "Summary only", "n-user", map[string]any{
+			"root":   chatgptExportNodeFixture("root", "", []string{"n-user"}, nil),
+			"n-user": chatgptExportNodeFixture("n-user", "root", []string{}, chatgptExportTextMessageFixture("m-user", "user", 1785542401, "Hello")),
+		}),
+	})
+
+	summaryOnly, err := scanChatGPTExportArchiveWithRetention(
+		context.Background(),
+		archivePath,
+		0,
+		externalScanSummaryOnly,
+	)
+	if err != nil {
+		t.Fatalf("summary-only scan error = %v", err)
+	}
+	retained, err := scanChatGPTExportArchive(context.Background(), archivePath, 0)
+	if err != nil {
+		t.Fatalf("retained scan error = %v", err)
+	}
+	if !reflect.DeepEqual(summaryOnly.result, retained.result) {
+		t.Fatalf("summary-only result = %#v, want retained result %#v", summaryOnly.result, retained.result)
+	}
+	if len(summaryOnly.sessions) != 0 {
+		t.Fatalf("summary-only sessions = %#v, want no retained transcripts", summaryOnly.sessions)
+	}
+	if len(retained.sessions) != 1 {
+		t.Fatalf("retained sessions = %#v, want one full transcript", retained.sessions)
+	}
+}
 
 func TestScanChatGPTExportArchiveNormalizesRolesTextAndAssetPlaceholders(t *testing.T) {
 	archivePath := writeChatGPTExportArchive(t, []map[string]any{

--- a/services/tuttid/service/agent/external_import_claude_export.go
+++ b/services/tuttid/service/agent/external_import_claude_export.go
@@ -72,6 +72,20 @@ type parsedClaudeExportMessage struct {
 }
 
 func scanClaudeExportArchive(ctx context.Context, archivePath string, cutoffUnixMS int64) (externalScanData, error) {
+	return scanClaudeExportArchiveWithRetention(
+		ctx,
+		archivePath,
+		cutoffUnixMS,
+		externalScanRetainTranscripts,
+	)
+}
+
+func scanClaudeExportArchiveWithRetention(
+	ctx context.Context,
+	archivePath string,
+	cutoffUnixMS int64,
+	retention externalScanRetention,
+) (externalScanData, error) {
 	archivePath, entry, closeArchive, err := openClaudeExportConversations(archivePath)
 	if err != nil {
 		return externalScanData{}, err
@@ -94,7 +108,7 @@ func scanClaudeExportArchive(ctx context.Context, archivePath string, cutoffUnix
 		Root:      archivePath,
 		Available: true,
 	}}
-	projects := map[string]*ExternalImportProject{}
+	collector := newExternalScanCollector(&data, retention)
 	conversationIDs := map[string]struct{}{}
 	messageIDs := map[string]struct{}{}
 	conversationStream, err := newClaudeExportConversationStream(ctx, entryReader)
@@ -153,28 +167,10 @@ func scanClaudeExportArchive(ctx context.Context, archivePath string, cutoffUnix
 		if session.UpdatedAtUnixMS < cutoffUnixMS {
 			continue
 		}
-		project, ok := projectFromExternalSession(session)
-		if !ok {
-			data.result.SkippedSessions++
-			continue
-		}
-		data.sessions = append(data.sessions, session)
-		data.result.ScannedSessions++
-		data.result.ScannedMessages += len(session.Messages)
-		data.result.Sessions = append(data.result.Sessions, externalImportSessionSummary(session, project.Path))
-		upsertExternalImportProject(projects, project, session.Provider)
+		collector.add(session)
 	}
 
-	for _, project := range projects {
-		sort.Strings(project.Providers)
-		data.result.Projects = append(data.result.Projects, *project)
-	}
-	sort.SliceStable(data.result.Sessions, func(left, right int) bool {
-		if data.result.Sessions[left].LastUpdatedAtUnixMS == data.result.Sessions[right].LastUpdatedAtUnixMS {
-			return data.result.Sessions[left].ID < data.result.Sessions[right].ID
-		}
-		return data.result.Sessions[left].LastUpdatedAtUnixMS > data.result.Sessions[right].LastUpdatedAtUnixMS
-	})
+	collector.finish()
 	data.result.Providers[0].SessionCount = data.result.ScannedSessions
 	data.result.Providers[0].MessageCount = data.result.ScannedMessages
 	return data, nil

--- a/services/tuttid/service/agent/external_import_claude_export_test.go
+++ b/services/tuttid/service/agent/external_import_claude_export_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strings"
 	"testing"
@@ -15,6 +16,46 @@ import (
 	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 )
+
+func TestScanClaudeExportArchiveSummaryOnlyMatchesRetainedResult(t *testing.T) {
+	archivePath := writeClaudeExportArchive(t, []map[string]any{
+		claudeExportConversationFixture(
+			"summary-only",
+			"Summary only",
+			[]map[string]any{
+				claudeExportMessageFixture(
+					"message-user",
+					"human",
+					"2026-08-01T00:00:01Z",
+					[]map[string]any{{"type": "text", "text": "Hello"}},
+				),
+			},
+		),
+	})
+
+	summaryOnly, err := scanClaudeExportArchiveWithRetention(
+		context.Background(),
+		archivePath,
+		0,
+		externalScanSummaryOnly,
+	)
+	if err != nil {
+		t.Fatalf("summary-only scan error = %v", err)
+	}
+	retained, err := scanClaudeExportArchive(context.Background(), archivePath, 0)
+	if err != nil {
+		t.Fatalf("retained scan error = %v", err)
+	}
+	if !reflect.DeepEqual(summaryOnly.result, retained.result) {
+		t.Fatalf("summary-only result = %#v, want retained result %#v", summaryOnly.result, retained.result)
+	}
+	if len(summaryOnly.sessions) != 0 {
+		t.Fatalf("summary-only sessions = %#v, want no retained transcripts", summaryOnly.sessions)
+	}
+	if len(retained.sessions) != 1 {
+		t.Fatalf("retained sessions = %#v, want one full transcript", retained.sessions)
+	}
+}
 
 func TestScanClaudeExportArchiveUsesVisibleTextBlocksAndPreservesFileReferences(t *testing.T) {
 	archivePath := writeClaudeExportArchive(t, []map[string]any{

--- a/services/tuttid/service/agent/external_import_codex_titles.go
+++ b/services/tuttid/service/agent/external_import_codex_titles.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -33,11 +34,8 @@ func codexThreadTitles(codexHome string) map[string]string {
 	}
 
 	// Open read-only with a short busy timeout so a live Codex process holding
-	// the write lock never blocks the import scan. Build the file: URI via
-	// url.URL so paths containing spaces or other reserved characters are
-	// percent-encoded rather than corrupting the DSN.
-	dsn := (&url.URL{Scheme: "file", Path: dbPath, RawQuery: "mode=ro&_pragma=busy_timeout(2000)"}).String()
-	db, err := sql.Open("sqlite", dsn)
+	// the write lock never blocks the import scan.
+	db, err := sql.Open("sqlite", codexStateDBDSN(dbPath, runtime.GOOS))
 	if err != nil {
 		return titles
 	}
@@ -64,6 +62,42 @@ func codexThreadTitles(codexHome string) map[string]string {
 		}
 	}
 	return titles
+}
+
+// codexStateDBDSN builds the read-only `file:` DSN for the Codex state
+// database. Building the URI via url.URL percent-encodes paths containing
+// spaces or other reserved characters rather than corrupting the DSN.
+//
+// Windows paths need normalizing first. A native path such as
+// `C:\Users\me\.codex\state_5.sqlite` has no leading slash, so url.URL treats
+// `C:` as the authority and percent-encodes every `\` as `%5C`, producing
+// `file://C:%5CUsers%5C...`. SQLite then resolves that to a bogus location and
+// fails to open the database, silently degrading every imported Codex
+// conversation to its message-derived title instead of the generated one. Match
+// the repository's other SQLite DSN builders and convert to forward slashes
+// with a leading slash before a drive letter (see
+// `services/tuttid/data/workspace/sqlite_store.go` and
+// `packages/connector/store-sqlite/store.go`).
+func codexStateDBDSN(dbPath string, goos string) string {
+	databaseURL := &url.URL{
+		Scheme:   "file",
+		Path:     dbPath,
+		RawQuery: "mode=ro&_pragma=busy_timeout(2000)",
+	}
+	if goos == "windows" && filepath.IsAbs(dbPath) {
+		slashPath := filepath.ToSlash(dbPath)
+		if uncPath := strings.TrimPrefix(slashPath, "//"); uncPath != slashPath {
+			// UNC path: `\\host\share\...` -> host becomes the URI authority.
+			host, path, found := strings.Cut(uncPath, "/")
+			if found {
+				databaseURL.Host = host
+				databaseURL.Path = "/" + path
+			}
+		} else {
+			databaseURL.Path = "/" + slashPath
+		}
+	}
+	return databaseURL.String()
 }
 
 // codexStateDBPath returns the highest-versioned state_<n>.sqlite under codexHome.

--- a/services/tuttid/service/agent/external_import_codex_titles_test.go
+++ b/services/tuttid/service/agent/external_import_codex_titles_test.go
@@ -53,6 +53,51 @@ func TestScanExternalImportsAppliesCodexSQLiteTitle(t *testing.T) {
 	}
 }
 
+func TestCodexStateDBDSNNormalizesWindowsPaths(t *testing.T) {
+	// A native Windows path has no leading slash, so an unnormalized url.URL
+	// treats the drive letter as the authority and percent-encodes every
+	// separator, yielding file://C:%5CUsers%5C... which SQLite cannot open.
+	// Assert on the built DSN directly so the regression is caught on every
+	// platform, not only when the suite runs on Windows.
+	for _, testCase := range []struct {
+		name string
+		goos string
+		path string
+		want string
+	}{
+		{
+			name: "windows drive letter",
+			goos: "windows",
+			path: `C:\Users\me\.codex\state_5.sqlite`,
+			want: "file:///C:/Users/me/.codex/state_5.sqlite?mode=ro&_pragma=busy_timeout(2000)",
+		},
+		{
+			name: "windows path with spaces stays percent-encoded",
+			goos: "windows",
+			path: `C:\code x home\state_5.sqlite`,
+			want: "file:///C:/code%20x%20home/state_5.sqlite?mode=ro&_pragma=busy_timeout(2000)",
+		},
+		{
+			name: "windows unc path uses the host as authority",
+			goos: "windows",
+			path: `\\server\share\.codex\state_5.sqlite`,
+			want: "file://server/share/.codex/state_5.sqlite?mode=ro&_pragma=busy_timeout(2000)",
+		},
+		{
+			name: "posix path is unchanged",
+			goos: "darwin",
+			path: "/Users/me/.codex/state_5.sqlite",
+			want: "file:///Users/me/.codex/state_5.sqlite?mode=ro&_pragma=busy_timeout(2000)",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := codexStateDBDSN(testCase.path, testCase.goos); got != testCase.want {
+				t.Fatalf("codexStateDBDSN(%q, %q) = %q, want %q", testCase.path, testCase.goos, got, testCase.want)
+			}
+		})
+	}
+}
+
 func TestCodexThreadTitlesReadsStateDB(t *testing.T) {
 	codexHome := t.TempDir()
 	writeCodexThreadsDB(t, filepath.Join(codexHome, "state_5.sqlite"), map[string]string{

--- a/services/tuttid/service/agent/external_import_scan_collector.go
+++ b/services/tuttid/service/agent/external_import_scan_collector.go
@@ -1,0 +1,58 @@
+package agent
+
+import "sort"
+
+type externalScanRetention uint8
+
+const (
+	externalScanSummaryOnly externalScanRetention = iota
+	externalScanRetainTranscripts
+)
+
+type externalScanCollector struct {
+	data      *externalScanData
+	projects  map[string]*ExternalImportProject
+	retention externalScanRetention
+}
+
+func newExternalScanCollector(data *externalScanData, retention externalScanRetention) *externalScanCollector {
+	return &externalScanCollector{
+		data:      data,
+		projects:  map[string]*ExternalImportProject{},
+		retention: retention,
+	}
+}
+
+func (c *externalScanCollector) add(session externalImportedSession) {
+	project, ok := projectFromExternalSession(session)
+	if !ok {
+		c.data.result.SkippedSessions++
+		return
+	}
+	if c.retention == externalScanRetainTranscripts {
+		c.data.sessions = append(c.data.sessions, session)
+	}
+	c.data.result.ScannedSessions++
+	c.data.result.ScannedMessages += len(session.Messages)
+	c.data.result.Sessions = append(c.data.result.Sessions, externalImportSessionSummary(session, project.Path))
+	upsertExternalImportProject(c.projects, project, session.Provider)
+}
+
+func (c *externalScanCollector) finish() {
+	for _, project := range c.projects {
+		sort.Strings(project.Providers)
+		c.data.result.Projects = append(c.data.result.Projects, *project)
+	}
+	sort.SliceStable(c.data.result.Projects, func(left, right int) bool {
+		if c.data.result.Projects[left].LastUpdatedAtUnixMS == c.data.result.Projects[right].LastUpdatedAtUnixMS {
+			return c.data.result.Projects[left].Path < c.data.result.Projects[right].Path
+		}
+		return c.data.result.Projects[left].LastUpdatedAtUnixMS > c.data.result.Projects[right].LastUpdatedAtUnixMS
+	})
+	sort.SliceStable(c.data.result.Sessions, func(left, right int) bool {
+		if c.data.result.Sessions[left].LastUpdatedAtUnixMS == c.data.result.Sessions[right].LastUpdatedAtUnixMS {
+			return c.data.result.Sessions[left].ID < c.data.result.Sessions[right].ID
+		}
+		return c.data.result.Sessions[left].LastUpdatedAtUnixMS > c.data.result.Sessions[right].LastUpdatedAtUnixMS
+	})
+}

--- a/services/tuttid/service/agent/external_import_test.go
+++ b/services/tuttid/service/agent/external_import_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 
@@ -12,6 +13,60 @@ import (
 	userprojectbiz "github.com/tutti-os/tutti/services/tuttid/biz/userproject"
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 )
+
+func TestScanExternalAgentSessionsSummaryOnlyMatchesRetainedResult(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatalf("create project error = %v", err)
+	}
+	codexHome := filepath.Join(root, "codex-home")
+	t.Setenv("CODEX_HOME", codexHome)
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(root, "claude-home"))
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	writeAgentServiceJSONL(t, filepath.Join(codexHome, "sessions", "summary-only.jsonl"),
+		map[string]any{
+			"timestamp": now,
+			"type":      "session_meta",
+			"payload":   map[string]any{"id": "summary-only", "cwd": project},
+		},
+		map[string]any{"timestamp": now, "type": "response_item", "payload": map[string]any{
+			"type": "message", "id": "summary-only-1", "role": "user",
+			"content": []any{map[string]any{"type": "input_text", "text": "Retain only the summary"}},
+		}},
+	)
+
+	summaryOnly, err := scanExternalAgentSessionsWithRetention(
+		context.Background(),
+		[]string{"codex"},
+		-1,
+		"",
+		"",
+		externalScanSummaryOnly,
+	)
+	if err != nil {
+		t.Fatalf("summary-only scan error = %v", err)
+	}
+	retained, err := scanExternalAgentSessions(
+		context.Background(),
+		[]string{"codex"},
+		-1,
+		"",
+		"",
+	)
+	if err != nil {
+		t.Fatalf("retained scan error = %v", err)
+	}
+	if !reflect.DeepEqual(summaryOnly.result, retained.result) {
+		t.Fatalf("summary-only result = %#v, want retained result %#v", summaryOnly.result, retained.result)
+	}
+	if len(summaryOnly.sessions) != 0 {
+		t.Fatalf("summary-only sessions = %#v, want no retained transcripts", summaryOnly.sessions)
+	}
+	if len(retained.sessions) != 1 || len(retained.sessions[0].Messages) != 1 {
+		t.Fatalf("retained sessions = %#v, want one full transcript", retained.sessions)
+	}
+}
 
 func TestServiceImportExternalSessionsOmitsProjectsWithoutValidSessions(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Fixes #2060

本 PR 将本地 Codex / Claude Code 历史导入的时间范围切换改为基于首次扫描结果的内存投影。首次 local-history scan 后，7 天、30 天、90 天和 All 之间切换不再重新请求 daemon，也不会清空当前列表或显示全屏 loading

同时修复一个在本次真实 Windows 验证中暴露的既有问题：Codex state DB 的 Windows SQLite file URI 构造错误会让生成标题查询静默失败。现在会按仓库既有规则规范化 Windows 驱动器路径、UNC 路径和 POSIX 路径，并加入回归测试

## Verification

真实本机数据包含 988 个 transcript，Codex 477 个、Claude 511 个；以 daemon 各区间输出作为 ground truth，对比前端投影结果如下

| Range | Result | Project groups |
| --- | --- | ---: |
| 7 days | MATCH, missing=0, extra=0 | 6/6 |
| 30 days | MATCH, missing=0, extra=0 | 18/18 |
| 90 days | MATCH, missing=0, extra=0 | 26/26 |
| All | MATCH, missing=0, extra=0 | 26/26 |

性能验证控制了文件系统缓存影响；warm 三轮中全量扫描和 30 天扫描均约 6.9 秒，未观察到初次加载明显变差。最初的冷缓存比较被文件系统缓存状态误导，已重新测量并以受控结果为准

补充验证包括：

- range-switching 变异测试：将 externalImportUsableScanCatalog 改为恒返回 null 后，3 个测试失败，证明 scan-call-count 断言能够捕获回归
- Windows Codex SQLite DSN 回归：原实现实测 SQL logic error: out of memory (1)，规范化后成功读取标题且无错误
- git diff --check db752980f..HEAD 通过
- 已完成等价的 Oxfmt、Oxlint、相关 TypeScript 测试、TypeScript typecheck 和 Go 相关测试验证

本机 Windows 上 pnpm test:ts 会因 Node 对 .cmd 的 spawn 加固返回 spawn EINVAL，已使用仓库测试文件直接运行方式绕过。Go 测试中仍有 22 个与本变更无关的既有失败，涉及 symlink 权限、写死的路径分隔符和本机缺少 Codex 可执行文件；相关差集验证未发现本 PR 回归

## Fallback Three Questions

- Source: 范围切换事件会触发当前导入目录的重新扫描
- Why can it not be fixed at that source: daemon 扫描不拥有 renderer 的范围选择状态，且重复扫描会重复遍历和解析本地 transcript
- Removal condition: 只有当 daemon 提供等价的范围索引并且 renderer 不再需要复用全量扫描目录时，才可移除当前可复用扫描目录

## Checklist

- [x] 本 PR 不改变 agent session/turn/goal/runtime-operation 生命周期语义，因此无需迁移到 packages/agent/host 或新增 conformance 场景
- [x] 变更聚焦于一个 concern：本地历史导入的范围投影和相关 Windows 标题读取回归
- [x] 已完成文档影响检查；未发现需要更新的 durable documentation
- [x] 未修改 README 或 CONTRIBUTING 源文件
- [x] 已运行 changed surface 的最低有意义验证，并在上文记录 Windows 环境限制
- [x] 三个提交均包含 DCO sign-off