### PR TITLE
feat(mobile): refine conversation detail experience

### DIFF
--- a/apps/mobile/src/components/MobileComposerDock.test.tsx
+++ b/apps/mobile/src/components/MobileComposerDock.test.tsx
@@ -136,6 +136,49 @@ test("selects the new-session Agent and working directory above the composer", (
   expect(selectedProjects).toEqual(["/workspace/tutti"]);
 });
 
+test("shows platform-neutral overflow hints for the horizontal settings rail", () => {
+  let renderer: ReactTestRenderer;
+  act(() => {
+    renderer = create(composerDock(createModel()));
+  });
+  const rail = renderer!.root.find(
+    (node) => node.props.testID === "mobile-composer-settings-rail"
+  );
+
+  act(() => {
+    rail.props.onLayout({ nativeEvent: { layout: { width: 180 } } });
+    rail.props.onContentSizeChange(400, 40);
+  });
+  expect(
+    renderer!.root.findAll(
+      (node) => node.props.testID === "mobile-composer-settings-trailing-hint"
+    ).length
+  ).toBeGreaterThan(0);
+
+  act(() => {
+    rail.props.onScroll({ nativeEvent: { contentOffset: { x: 100 } } });
+  });
+  expect(
+    renderer!.root.findAll(
+      (node) => node.props.testID === "mobile-composer-settings-leading-hint"
+    ).length
+  ).toBeGreaterThan(0);
+  expect(
+    renderer!.root.findAll(
+      (node) => node.props.testID === "mobile-composer-settings-trailing-hint"
+    ).length
+  ).toBeGreaterThan(0);
+
+  act(() => {
+    rail.props.onScroll({ nativeEvent: { contentOffset: { x: 220 } } });
+  });
+  expect(
+    renderer!.root.findAll(
+      (node) => node.props.testID === "mobile-composer-settings-trailing-hint"
+    )
+  ).toHaveLength(0);
+});
+
 function press(renderer: ReactTestRenderer, testID: string): void {
   const target = renderer.root.find(
     (node) =>

--- a/apps/mobile/src/components/MobileComposerDock.tsx
+++ b/apps/mobile/src/components/MobileComposerDock.tsx
@@ -26,6 +26,13 @@ import {
   type ComposerSettingMenu
 } from "./MobileComposerSettingsSheet";
 import {
+  MobileAddGlyph,
+  MobileBackGlyph,
+  MobileChevronGlyph,
+  MobileSendGlyph,
+  MobileStopGlyph
+} from "./MobileControlGlyphs";
+import {
   MobileKeyboardAvoidingView,
   mobileKeyboardDismissMode
 } from "./MobileKeyboardAvoidingView";
@@ -193,25 +200,8 @@ export function MobileComposerDock({
           onSelectTarget={onSelectTarget}
         />
       ) : null}
-      <MobileComposerSettingsSheet
-        activationId={settingsActivationId}
-        disabled={!model.commandsAvailable}
-        menu={settingsMenu}
-        model={model}
-        onMenuChange={setSettingsMenu}
-        onUpdate={onUpdate}
-      />
-      <View style={styles.inputRow}>
-        <NativeIconButton
-          accessibilityLabel={t("moreActions")}
-          disabled={!model.commandsAvailable}
-          icon={<Text style={styles.plus}>＋</Text>}
-          onPress={openToolsMenu}
-          style={styles.addButton}
-          testID="mobile-composer-tools"
-          variant="secondary"
-        />
-        <View style={styles.inputPill}>
+      <View style={styles.composerShell}>
+        <View style={styles.inputRow}>
           <TextInput
             ref={inputRef}
             editable={!model.sending && model.commandsAvailable}
@@ -227,11 +217,36 @@ export function MobileComposerDock({
             style={styles.input}
             value={model.draft}
           />
+        </View>
+        <View style={styles.actionRow}>
+          <NativeIconButton
+            accessibilityLabel={t("moreActions")}
+            disabled={!model.commandsAvailable}
+            icon={
+              <MobileAddGlyph color={theme.color.textSecondary} size={20} />
+            }
+            onPress={openToolsMenu}
+            style={styles.addButton}
+            testID="mobile-composer-tools"
+            variant="ghost"
+          />
+          <View style={styles.settingsRail}>
+            <MobileComposerSettingsSheet
+              activationId={settingsActivationId}
+              disabled={!model.commandsAvailable}
+              menu={settingsMenu}
+              model={model}
+              onMenuChange={setSettingsMenu}
+              onUpdate={onUpdate}
+            />
+          </View>
           {hasActiveTurn ? (
             <NativeIconButton
               accessibilityLabel={t("stop")}
               disabled={!model.commandsAvailable}
-              icon={<Text style={styles.actionIcon}>■</Text>}
+              icon={
+                <MobileStopGlyph color={theme.color.background} size={20} />
+              }
               onPress={onStop}
               style={styles.actionButton}
             />
@@ -240,13 +255,19 @@ export function MobileComposerDock({
               accessibilityLabel={
                 model.ambiguousSubmission ? t("retry") : t("send")
               }
-              icon={<Text style={styles.sendIcon}>↑</Text>}
+              icon={
+                <MobileSendGlyph color={theme.color.background} size={20} />
+              }
               onPress={onSend}
               style={styles.actionButton}
             />
           ) : model.sending ? (
-            <ActivityIndicator color={theme.color.text} size="small" />
-          ) : null}
+            <View style={styles.actionSlot}>
+              <ActivityIndicator color={theme.color.text} size="small" />
+            </View>
+          ) : (
+            <View style={styles.actionSlot} />
+          )}
         </View>
       </View>
 
@@ -275,7 +296,13 @@ export function MobileComposerDock({
                       description={selectedModelLabel}
                       onPress={() => setToolsMenu("model")}
                       title={t("model")}
-                      trailing={<Text style={styles.chevron}>›</Text>}
+                      trailing={
+                        <MobileChevronGlyph
+                          color={theme.color.muted}
+                          direction="right"
+                          size={16}
+                        />
+                      }
                     />
                   ) : null}
                   {model.composerSettingsSupport.permission &&
@@ -284,7 +311,13 @@ export function MobileComposerDock({
                       description={selectedPermissionLabel}
                       onPress={() => setToolsMenu("permission")}
                       title={t("permissions")}
-                      trailing={<Text style={styles.chevron}>›</Text>}
+                      trailing={
+                        <MobileChevronGlyph
+                          color={theme.color.muted}
+                          direction="right"
+                          size={16}
+                        />
+                      }
                     />
                   ) : null}
                   {model.composerSettingsSupport.plan ? (
@@ -315,7 +348,13 @@ export function MobileComposerDock({
                       }
                       onPress={() => setToolsMenu("quickPrompts")}
                       title={t("quickPrompts")}
-                      trailing={<Text style={styles.chevron}>›</Text>}
+                      trailing={
+                        <MobileChevronGlyph
+                          color={theme.color.muted}
+                          direction="right"
+                          size={16}
+                        />
+                      }
                     />
                   ) : null}
                   {model.composerOptionsLoadStatus === "loading" ? (
@@ -345,7 +384,9 @@ export function MobileComposerDock({
                   <View style={styles.menuHeader}>
                     <NativeIconButton
                       accessibilityLabel={t("cancel")}
-                      icon={<Text style={styles.menuBackIcon}>←</Text>}
+                      icon={
+                        <MobileBackGlyph color={theme.color.text} size={20} />
+                      }
                       onPress={() => setToolsMenu("tools")}
                       style={styles.menuBackButton}
                     />
@@ -479,40 +520,53 @@ function createStyles(theme: NativeTheme) {
     actionButton: {
       alignItems: "center",
       backgroundColor: theme.color.text,
-      borderRadius: 18,
-      height: 36,
+      borderRadius: theme.control.regular / 2,
+      height: theme.control.regular,
       justifyContent: "center",
-      width: 36
+      width: theme.control.regular
     },
-    actionIcon: {
-      color: theme.color.background,
-      fontSize: 11
+    actionRow: {
+      alignItems: "center",
+      borderTopColor: theme.color.border,
+      borderTopWidth: StyleSheet.hairlineWidth,
+      flexDirection: "row",
+      minHeight: theme.control.regular,
+      paddingHorizontal: 4
+    },
+    actionSlot: {
+      alignItems: "center",
+      height: theme.control.regular,
+      justifyContent: "center",
+      width: theme.control.regular
     },
     backdrop: {
       flex: 1,
       justifyContent: "flex-end",
-      paddingBottom: 96
-    },
-    chevron: {
-      color: theme.color.muted,
-      fontSize: 20,
-      lineHeight: 22
+      paddingBottom: theme.control.regular * 2 + theme.space.medium
     },
     addButton: {
       alignItems: "center",
+      borderRadius: theme.control.regular / 2,
+      height: theme.control.regular,
+      justifyContent: "center",
+      width: theme.control.regular
+    },
+    composerShell: {
       backgroundColor: theme.color.panelRaised,
       borderColor: theme.color.border,
-      borderRadius: 20,
+      borderRadius: theme.radius.large,
       borderWidth: StyleSheet.hairlineWidth,
-      height: 40,
-      justifyContent: "center",
-      width: 40
+      overflow: "hidden",
+      width: "100%"
     },
     dock: {
+      alignSelf: "center",
       gap: theme.space.small,
+      maxWidth: 760 + theme.space.medium * 2,
       paddingBottom: theme.space.small,
       paddingHorizontal: theme.space.medium,
-      paddingTop: theme.space.small
+      paddingTop: theme.space.small,
+      width: "100%"
     },
     emptyMenu: {
       color: theme.color.muted,
@@ -532,40 +586,16 @@ function createStyles(theme: NativeTheme) {
       fontSize: 16,
       lineHeight: 22,
       maxHeight: 120,
-      minHeight: 40,
-      paddingLeft: 14,
-      paddingVertical: 9
-    },
-    inputPill: {
-      alignItems: "center",
-      backgroundColor: theme.color.panelRaised,
-      borderColor: theme.color.border,
-      borderRadius: 22,
-      borderWidth: StyleSheet.hairlineWidth,
-      flex: 1,
-      flexDirection: "row",
-      gap: theme.space.small,
-      minHeight: 44,
-      paddingRight: 4
+      minHeight: theme.control.regular,
+      paddingHorizontal: theme.space.medium,
+      paddingVertical: 12,
+      textAlignVertical: "top"
     },
     inputRow: {
-      alignItems: "flex-end",
-      flexDirection: "row",
-      gap: theme.space.small
+      alignItems: "stretch",
+      minHeight: theme.control.regular
     },
     loading: { marginVertical: theme.space.medium },
-    plus: {
-      color: theme.color.text,
-      fontSize: 24,
-      fontWeight: "300",
-      lineHeight: 26
-    },
-    sendIcon: {
-      color: theme.color.background,
-      fontSize: 18,
-      fontWeight: "700",
-      lineHeight: 20
-    },
     menu: {
       backgroundColor: theme.color.panelRaised,
       borderColor: theme.color.border,
@@ -582,18 +612,14 @@ function createStyles(theme: NativeTheme) {
     },
     modalRoot: { flex: 1 },
     menuBackButton: {
-      height: 40,
-      width: 40
-    },
-    menuBackIcon: {
-      color: theme.color.text,
-      fontSize: 20
+      height: theme.control.regular,
+      width: theme.control.regular
     },
     menuHeader: {
       alignItems: "center",
       flexDirection: "row",
       gap: theme.space.small,
-      minHeight: 50
+      minHeight: theme.control.regular
     },
     menuOptions: { flexShrink: 1 },
     menuTitle: {
@@ -613,8 +639,9 @@ function createStyles(theme: NativeTheme) {
       color: theme.color.text,
       fontSize: 16,
       marginBottom: theme.space.small,
-      minHeight: 44,
+      minHeight: theme.control.regular,
       paddingHorizontal: theme.space.medium
-    }
+    },
+    settingsRail: { flex: 1, minWidth: 0 }
   });
 }

--- a/apps/mobile/src/components/MobileComposerSettingsSheet.tsx
+++ b/apps/mobile/src/components/MobileComposerSettingsSheet.tsx
@@ -6,10 +6,11 @@ import {
   type NativeTheme,
   useNativeTheme
 } from "@tutti-os/ui-system/native";
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { ScrollView, StyleSheet, Text, View } from "react-native";
 import { t } from "../i18n";
 import type { WorkspaceActivitySnapshot } from "../services/workspaceActivityService";
+import { MobileChevronGlyph } from "./MobileControlGlyphs";
 
 export type ComposerSettingMenu =
   | "model"
@@ -36,6 +37,15 @@ export function MobileComposerSettingsSheet({
   const styles = createStyles(theme);
   const activeActivationIdRef = useRef(activationId);
   const disabledRef = useRef(disabled);
+  const chipRailMetricsRef = useRef({
+    contentWidth: 0,
+    offset: 0,
+    viewportWidth: 0
+  });
+  const [chipRailHints, setChipRailHints] = useState({
+    leading: false,
+    trailing: false
+  });
   activeActivationIdRef.current = activationId;
   disabledRef.current = disabled;
   const options = model.composerOptions;
@@ -48,6 +58,21 @@ export function MobileComposerSettingsSheet({
   const showsModelChip = Boolean(
     model.composerSettingsSupport.model && options?.models.length
   );
+  const updateChipRailMetrics = (
+    metrics: Partial<(typeof chipRailMetricsRef)["current"]>
+  ): void => {
+    Object.assign(chipRailMetricsRef.current, metrics);
+    const { contentWidth, offset, viewportWidth } = chipRailMetricsRef.current;
+    const maxOffset = Math.max(0, contentWidth - viewportWidth);
+    const visibleOffset = Math.min(maxOffset, Math.max(0, offset));
+    const leading = visibleOffset > 4;
+    const trailing = maxOffset - visibleOffset > 4;
+    setChipRailHints((current) =>
+      current.leading === leading && current.trailing === trailing
+        ? current
+        : { leading, trailing }
+    );
+  };
 
   const closeWith = (settings: AgentActivitySessionSettings): void => {
     if (
@@ -63,67 +88,112 @@ export function MobileComposerSettingsSheet({
 
   return (
     <>
-      <View style={styles.chips}>
-        {showsModelChip ? (
-          <ComposerChip
-            disabled={disabled}
-            label={[
-              selectedOptionLabel(options?.models ?? [], selectedModel) ??
-                t("model"),
-              model.composerSettingsSupport.reasoning
-                ? selectedOptionLabel(
-                    reasoningOptions,
-                    model.composerSettings.reasoningEffort ?? null
-                  )
-                : null
-            ]
-              .filter(Boolean)
-              .join(" ")}
-            onPress={() => onMenuChange("model")}
-            testID="mobile-composer-model-settings"
-          />
+      <View style={styles.chipRail}>
+        <ScrollView
+          contentContainerStyle={styles.chips}
+          fadingEdgeLength={theme.space.large}
+          horizontal
+          keyboardShouldPersistTaps="handled"
+          onContentSizeChange={(width) =>
+            updateChipRailMetrics({ contentWidth: width })
+          }
+          onLayout={({ nativeEvent }) =>
+            updateChipRailMetrics({ viewportWidth: nativeEvent.layout.width })
+          }
+          onScroll={({ nativeEvent }) =>
+            updateChipRailMetrics({ offset: nativeEvent.contentOffset.x })
+          }
+          scrollEventThrottle={16}
+          showsHorizontalScrollIndicator={false}
+          testID="mobile-composer-settings-rail"
+        >
+          {showsModelChip ? (
+            <ComposerChip
+              disabled={disabled}
+              label={[
+                selectedOptionLabel(options?.models ?? [], selectedModel) ??
+                  t("model"),
+                model.composerSettingsSupport.reasoning
+                  ? selectedOptionLabel(
+                      reasoningOptions,
+                      model.composerSettings.reasoningEffort ?? null
+                    )
+                  : null
+              ]
+                .filter(Boolean)
+                .join(" ")}
+              onPress={() => onMenuChange("model")}
+              testID="mobile-composer-model-settings"
+            />
+          ) : null}
+          {!showsModelChip &&
+          model.composerSettingsSupport.reasoning &&
+          reasoningOptions.length ? (
+            <ComposerChip
+              disabled={disabled}
+              label={
+                selectedOptionLabel(
+                  reasoningOptions,
+                  model.composerSettings.reasoningEffort ?? null
+                ) ?? t("reasoning")
+              }
+              onPress={() => onMenuChange("reasoning")}
+              testID="mobile-composer-reasoning-settings"
+            />
+          ) : null}
+          {model.composerSettingsSupport.speed && options?.speeds.length ? (
+            <ComposerChip
+              disabled={disabled}
+              label={
+                selectedOptionLabel(
+                  options?.speeds ?? [],
+                  model.composerSettings.speed ?? null
+                ) ?? t("speed")
+              }
+              onPress={() => onMenuChange("speed")}
+              testID="mobile-composer-speed-settings"
+            />
+          ) : null}
+          {model.composerSettingsSupport.permission &&
+          options?.permissionConfig?.modes.length ? (
+            <ComposerChip
+              disabled={disabled}
+              label={
+                selectedOptionLabel(
+                  options?.permissionConfig?.modes ?? [],
+                  model.composerSettings.permissionModeId ?? null
+                ) ?? t("defaultPermissions")
+              }
+              onPress={() => onMenuChange("permission")}
+              testID="mobile-composer-permission-settings"
+            />
+          ) : null}
+        </ScrollView>
+        {chipRailHints.leading ? (
+          <View
+            pointerEvents="none"
+            style={[styles.chipRailHint, styles.chipRailHintLeading]}
+            testID="mobile-composer-settings-leading-hint"
+          >
+            <MobileChevronGlyph
+              color={theme.color.textSecondary}
+              direction="left"
+              size={14}
+            />
+          </View>
         ) : null}
-        {!showsModelChip &&
-        model.composerSettingsSupport.reasoning &&
-        reasoningOptions.length ? (
-          <ComposerChip
-            disabled={disabled}
-            label={
-              selectedOptionLabel(
-                reasoningOptions,
-                model.composerSettings.reasoningEffort ?? null
-              ) ?? t("reasoning")
-            }
-            onPress={() => onMenuChange("reasoning")}
-            testID="mobile-composer-reasoning-settings"
-          />
-        ) : null}
-        {model.composerSettingsSupport.speed && options?.speeds.length ? (
-          <ComposerChip
-            disabled={disabled}
-            label={
-              selectedOptionLabel(
-                options?.speeds ?? [],
-                model.composerSettings.speed ?? null
-              ) ?? t("speed")
-            }
-            onPress={() => onMenuChange("speed")}
-            testID="mobile-composer-speed-settings"
-          />
-        ) : null}
-        {model.composerSettingsSupport.permission &&
-        options?.permissionConfig?.modes.length ? (
-          <ComposerChip
-            disabled={disabled}
-            label={
-              selectedOptionLabel(
-                options?.permissionConfig?.modes ?? [],
-                model.composerSettings.permissionModeId ?? null
-              ) ?? t("defaultPermissions")
-            }
-            onPress={() => onMenuChange("permission")}
-            testID="mobile-composer-permission-settings"
-          />
+        {chipRailHints.trailing ? (
+          <View
+            pointerEvents="none"
+            style={[styles.chipRailHint, styles.chipRailHintTrailing]}
+            testID="mobile-composer-settings-trailing-hint"
+          >
+            <MobileChevronGlyph
+              color={theme.color.textSecondary}
+              direction="right"
+              size={14}
+            />
+          </View>
         ) : null}
       </View>
 
@@ -236,7 +306,7 @@ function ComposerChip({
       disabled={disabled}
       label={label}
       onPress={onPress}
-      size="compact"
+      size="regular"
       style={styles.chip}
       testID={testID}
       variant="secondary"
@@ -274,12 +344,33 @@ function createStyles(theme: NativeTheme) {
   return StyleSheet.create({
     chip: {
       backgroundColor: theme.color.panel,
-      borderColor: theme.color.panel,
-      borderRadius: 20,
-      minHeight: theme.control.compact,
-      paddingHorizontal: theme.space.medium
+      borderColor: theme.color.border,
+      borderRadius: theme.control.regular / 2,
+      minHeight: theme.control.regular,
+      paddingHorizontal: theme.space.small
     },
-    chips: { flexDirection: "row", flexWrap: "wrap", gap: theme.space.small },
+    chipRail: { flex: 1, minWidth: 0, position: "relative" },
+    chipRailHint: {
+      alignItems: "center",
+      backgroundColor: theme.color.panelRaised,
+      borderColor: theme.color.border,
+      borderRadius: theme.control.regular / 2,
+      borderWidth: StyleSheet.hairlineWidth,
+      height: theme.control.regular,
+      justifyContent: "center",
+      opacity: 0.96,
+      position: "absolute",
+      top: 0,
+      width: 24
+    },
+    chipRailHintLeading: { left: 0 },
+    chipRailHintTrailing: { right: 0 },
+    chips: {
+      alignItems: "center",
+      flexDirection: "row",
+      gap: 6,
+      paddingRight: theme.space.small
+    },
     loading: { color: theme.color.muted, padding: theme.space.medium },
     options: { padding: theme.space.small },
     sectionTitle: {

--- a/apps/mobile/src/components/MobileControlGlyphs.tsx
+++ b/apps/mobile/src/components/MobileControlGlyphs.tsx
@@ -1,0 +1,222 @@
+import type { ReactNode } from "react";
+import { View } from "react-native";
+
+interface MobileControlGlyphProps {
+  color: string;
+  size?: number;
+}
+
+export function MobileAddGlyph({ color, size = 20 }: MobileControlGlyphProps) {
+  const stroke = Math.max(2, size * 0.1);
+  return (
+    <GlyphFrame size={size}>
+      <View
+        style={{
+          backgroundColor: color,
+          borderRadius: stroke / 2,
+          height: stroke,
+          left: size * 0.2,
+          position: "absolute",
+          top: (size - stroke) / 2,
+          width: size * 0.6
+        }}
+      />
+      <View
+        style={{
+          backgroundColor: color,
+          borderRadius: stroke / 2,
+          height: size * 0.6,
+          left: (size - stroke) / 2,
+          position: "absolute",
+          top: size * 0.2,
+          width: stroke
+        }}
+      />
+    </GlyphFrame>
+  );
+}
+
+export function MobileBackGlyph({ color, size = 20 }: MobileControlGlyphProps) {
+  const stroke = Math.max(2, size * 0.1);
+  const wing = size * 0.38;
+  return (
+    <GlyphFrame size={size}>
+      <View
+        style={{
+          backgroundColor: color,
+          borderRadius: stroke / 2,
+          height: stroke,
+          left: size * 0.16,
+          position: "absolute",
+          top: (size - stroke) / 2,
+          width: size * 0.68
+        }}
+      />
+      <View
+        style={{
+          backgroundColor: color,
+          borderRadius: stroke / 2,
+          height: stroke,
+          left: size * 0.14,
+          position: "absolute",
+          top: size * 0.34,
+          transform: [{ rotate: "-45deg" }],
+          width: wing
+        }}
+      />
+      <View
+        style={{
+          backgroundColor: color,
+          borderRadius: stroke / 2,
+          height: stroke,
+          left: size * 0.14,
+          position: "absolute",
+          top: size * 0.61,
+          transform: [{ rotate: "45deg" }],
+          width: wing
+        }}
+      />
+    </GlyphFrame>
+  );
+}
+
+export function MobileChevronGlyph({
+  color,
+  direction,
+  size = 18
+}: MobileControlGlyphProps & {
+  direction: "down" | "left" | "right" | "up";
+}) {
+  const stroke = Math.max(2, size * 0.11);
+  const bar = size * 0.48;
+  const transforms =
+    direction === "down"
+      ? (["45deg", "-45deg"] as const)
+      : direction === "up"
+        ? (["-45deg", "45deg"] as const)
+        : direction === "right"
+          ? (["45deg", "-45deg"] as const)
+          : (["-45deg", "45deg"] as const);
+  const vertical = direction === "left" || direction === "right";
+
+  return (
+    <GlyphFrame size={size}>
+      <View
+        style={{
+          backgroundColor: color,
+          borderRadius: stroke / 2,
+          height: stroke,
+          left: vertical ? size * 0.28 : size * 0.18,
+          position: "absolute",
+          top: vertical ? size * 0.34 : size * 0.42,
+          transform: [{ rotate: transforms[0] }],
+          width: bar
+        }}
+      />
+      <View
+        style={{
+          backgroundColor: color,
+          borderRadius: stroke / 2,
+          height: stroke,
+          left: vertical ? size * 0.28 : size * 0.48,
+          position: "absolute",
+          top: vertical ? size * 0.6 : size * 0.42,
+          transform: [{ rotate: transforms[1] }],
+          width: bar
+        }}
+      />
+    </GlyphFrame>
+  );
+}
+
+export function MobileSendGlyph({ color, size = 20 }: MobileControlGlyphProps) {
+  const stroke = Math.max(2, size * 0.1);
+  return (
+    <GlyphFrame size={size}>
+      <View
+        style={{
+          backgroundColor: color,
+          borderRadius: stroke / 2,
+          height: size * 0.68,
+          left: (size - stroke) / 2,
+          position: "absolute",
+          top: size * 0.2,
+          width: stroke
+        }}
+      />
+      <View
+        style={{
+          backgroundColor: color,
+          borderRadius: stroke / 2,
+          height: stroke,
+          left: size * 0.28,
+          position: "absolute",
+          top: size * 0.26,
+          transform: [{ rotate: "-45deg" }],
+          width: size * 0.38
+        }}
+      />
+      <View
+        style={{
+          backgroundColor: color,
+          borderRadius: stroke / 2,
+          height: stroke,
+          left: size * 0.46,
+          position: "absolute",
+          top: size * 0.26,
+          transform: [{ rotate: "45deg" }],
+          width: size * 0.38
+        }}
+      />
+    </GlyphFrame>
+  );
+}
+
+export function MobileStopGlyph({ color, size = 20 }: MobileControlGlyphProps) {
+  const square = size * 0.48;
+  return (
+    <GlyphFrame size={size}>
+      <View
+        style={{
+          backgroundColor: color,
+          borderRadius: Math.max(2, size * 0.08),
+          height: square,
+          left: (size - square) / 2,
+          position: "absolute",
+          top: (size - square) / 2,
+          width: square
+        }}
+      />
+    </GlyphFrame>
+  );
+}
+
+export function MobileStatusDotGlyph({
+  color,
+  size = 8
+}: MobileControlGlyphProps) {
+  return (
+    <View
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+      style={{
+        backgroundColor: color,
+        borderRadius: size / 2,
+        height: size,
+        width: size
+      }}
+    />
+  );
+}
+
+function GlyphFrame({ children, size }: { children: ReactNode; size: number }) {
+  return (
+    <View
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+      style={{ height: size, width: size }}
+    >
+      {children}
+    </View>
+  );
+}

--- a/apps/mobile/src/components/MobileConversationInteractionDock.test.tsx
+++ b/apps/mobile/src/components/MobileConversationInteractionDock.test.tsx
@@ -1,0 +1,84 @@
+import {
+  canonicalInteractionKey,
+  type AgentActivityInteraction
+} from "@tutti-os/agent-activity-core";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { MobileConversationInteractionDock } from "./MobileConversationInteractionDock";
+import { MobileInteractionCard } from "./MobileConversationRows";
+
+test("renders every pending Interaction with its exact projected state", () => {
+  const first = approvalInteraction("first");
+  const second = approvalInteraction("second");
+  const secondKey = canonicalInteractionKey(
+    second.agentSessionId,
+    second.turnId,
+    second.requestId
+  );
+  const responses: Array<{
+    interaction: AgentActivityInteraction;
+    input: Readonly<Record<string, unknown>>;
+  }> = [];
+  let renderer: ReactTestRenderer;
+
+  act(() => {
+    renderer = create(
+      <MobileConversationInteractionDock
+        interactionStates={{
+          [secondKey]: {
+            failed: true,
+            runtimeAvailable: true,
+            submitting: false
+          }
+        }}
+        interactions={[first, second]}
+        onRespond={(interaction, input) =>
+          responses.push({ interaction, input })
+        }
+      />
+    );
+  });
+
+  const cards = renderer!.root.findAllByType(MobileInteractionCard);
+  expect(cards).toHaveLength(2);
+  expect(cards[0]?.props.runtimeAvailable).toBe(false);
+  expect(cards[1]?.props.failed).toBe(true);
+  expect(cards[1]?.props.runtimeAvailable).toBe(true);
+
+  act(() => cards[1]?.props.onSubmit({ optionId: "allow-once" }));
+  expect(responses).toEqual([
+    { interaction: second, input: { optionId: "allow-once" } }
+  ]);
+});
+
+test("does not reserve dock space when there are no pending Interactions", () => {
+  let renderer: ReactTestRenderer;
+  act(() => {
+    renderer = create(
+      <MobileConversationInteractionDock
+        interactionStates={{}}
+        interactions={[]}
+        onRespond={() => undefined}
+      />
+    );
+  });
+  expect(renderer!.toJSON()).toBeNull();
+});
+
+function approvalInteraction(suffix: string): AgentActivityInteraction {
+  return {
+    agentSessionId: "session-1",
+    createdAtUnixMs: 1,
+    input: {
+      callId: `call-${suffix}`,
+      options: [{ label: "Allow", optionId: "allow-once" }]
+    },
+    kind: "approval",
+    metadata: {},
+    output: null,
+    requestId: `request-${suffix}`,
+    status: "pending",
+    toolName: "Approval",
+    turnId: `turn-${suffix}`,
+    updatedAtUnixMs: 1
+  };
+}

--- a/apps/mobile/src/components/MobileConversationInteractionDock.tsx
+++ b/apps/mobile/src/components/MobileConversationInteractionDock.tsx
@@ -1,0 +1,89 @@
+import {
+  canonicalInteractionKey,
+  type AgentActivityInteraction
+} from "@tutti-os/agent-activity-core";
+import { type NativeTheme, useNativeTheme } from "@tutti-os/ui-system/native";
+import { ScrollView, StyleSheet, View } from "react-native";
+import type { WorkspaceActivitySnapshot } from "../services/workspaceActivityService";
+import { mobileKeyboardDismissMode } from "./MobileKeyboardAvoidingView";
+import { MobileInteractionCard } from "./MobileConversationRows";
+
+export function MobileConversationInteractionDock({
+  interactionStates,
+  interactions,
+  onRespond
+}: {
+  interactionStates: WorkspaceActivitySnapshot["interactionStates"];
+  interactions: readonly AgentActivityInteraction[];
+  onRespond(
+    interaction: AgentActivityInteraction,
+    input: {
+      action?: string;
+      optionId?: string;
+      payload?: Readonly<Record<string, unknown>>;
+    }
+  ): void;
+}) {
+  const theme = useNativeTheme();
+  const styles = createStyles(theme);
+  if (interactions.length === 0) return null;
+
+  return (
+    <View style={styles.dock} testID="mobile-conversation-interaction-dock">
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        keyboardDismissMode={mobileKeyboardDismissMode}
+        keyboardShouldPersistTaps="handled"
+        nestedScrollEnabled
+        showsVerticalScrollIndicator
+      >
+        <View style={styles.content}>
+          {interactions.map((interaction) => {
+            const interactionKey = canonicalInteractionKey(
+              interaction.agentSessionId,
+              interaction.turnId,
+              interaction.requestId
+            );
+            const state = interactionStates[interactionKey] ?? {
+              failed: false,
+              runtimeAvailable: false,
+              submitting: false
+            };
+            return (
+              <MobileInteractionCard
+                failed={state.failed}
+                interaction={interaction}
+                key={interactionKey}
+                onSubmit={(input) => onRespond(interaction, input)}
+                runtimeAvailable={state.runtimeAvailable}
+                submitting={state.submitting}
+              />
+            );
+          })}
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+function createStyles(theme: NativeTheme) {
+  return StyleSheet.create({
+    content: {
+      alignSelf: "center",
+      gap: theme.space.small,
+      maxWidth: 760,
+      width: "100%"
+    },
+    dock: {
+      backgroundColor: theme.color.background,
+      borderTopColor: theme.color.border,
+      borderTopWidth: StyleSheet.hairlineWidth,
+      maxHeight: "40%"
+    },
+    scrollContent: {
+      paddingBottom: theme.space.small,
+      paddingHorizontal: theme.space.medium,
+      paddingTop: theme.space.small
+    }
+  });
+}

--- a/apps/mobile/src/components/MobileConversationRows.test.tsx
+++ b/apps/mobile/src/components/MobileConversationRows.test.tsx
@@ -24,6 +24,7 @@ test("keeps the explicit Interaction choices available after a failed response",
   const option = renderer!.root.findByType(PrimaryButton);
   expect(option.props.disabled).toBe(false);
   expect(option.props.label).toBe("Allow");
+  expect(option.props.accessibilityLabel).toBe("Allow. Run this command once");
   act(() => option.props.onPress());
   expect(submissions).toEqual([{ optionId: "allow-once" }]);
   expect(
@@ -65,7 +66,13 @@ function approvalInteraction(): AgentActivityInteraction {
     createdAtUnixMs: 1,
     input: {
       callId: "call-1",
-      options: [{ label: "Allow", optionId: "allow-once" }]
+      options: [
+        {
+          description: "Run this command once",
+          label: "Allow",
+          optionId: "allow-once"
+        }
+      ]
     },
     kind: "approval",
     metadata: {},

--- a/apps/mobile/src/components/MobileConversationRows.tsx
+++ b/apps/mobile/src/components/MobileConversationRows.tsx
@@ -103,9 +103,10 @@ export function MobileInteractionCard({
                               return updated;
                             });
                           }}
-                          style={[
+                          style={({ pressed }) => [
                             styles.option,
-                            active && styles.optionSelected
+                            active && styles.optionSelected,
+                            pressed && styles.pressed
                           ]}
                         >
                           <Text style={styles.optionText}>{option.label}</Text>
@@ -175,13 +176,22 @@ export function MobileInteractionCard({
       ) : prompt?.kind === "approval" ? (
         <View style={styles.actionList}>
           {options.map((option) => (
-            <PrimaryButton
-              disabled={submitting || !runtimeAvailable}
-              key={option.id}
-              label={option.label}
-              onPress={() => submit({ optionId: option.id })}
-              secondary
-            />
+            <View key={option.id} style={styles.approvalOption}>
+              <PrimaryButton
+                accessibilityLabel={[option.label, option.description]
+                  .filter(Boolean)
+                  .join(". ")}
+                disabled={submitting || !runtimeAvailable}
+                label={option.label}
+                onPress={() => submit({ optionId: option.id })}
+                secondary
+              />
+              {option.description ? (
+                <Text style={styles.optionDescription}>
+                  {option.description}
+                </Text>
+              ) : null}
+            </View>
           ))}
         </View>
       ) : prompt?.kind === "exit-plan" && prompt.options.length > 0 ? (
@@ -234,7 +244,7 @@ function MobileExitPlanActions({
           disabled={submitting || !runtimeAvailable}
           key={mode.id}
           onPress={() => onSubmit({ action: "allow", optionId: mode.id })}
-          style={styles.option}
+          style={({ pressed }) => [styles.option, pressed && styles.pressed]}
         >
           <Text style={styles.optionText}>{mode.label}</Text>
           {mode.description ? (
@@ -290,23 +300,31 @@ function interactionSummary(interaction: AgentActivityInteraction): string {
 
 function createStyles(theme: NativeTheme) {
   return StyleSheet.create({
-    actionList: { gap: theme.space.small, marginTop: theme.space.medium },
+    actionList: { gap: theme.space.small, marginTop: theme.space.small },
     answerInput: {
+      backgroundColor: theme.color.panel,
       borderColor: theme.color.border,
       borderRadius: theme.radius.medium,
       borderWidth: StyleSheet.hairlineWidth,
       color: theme.color.text,
-      minHeight: 72,
-      padding: theme.space.small
+      fontSize: 15,
+      lineHeight: 21,
+      minHeight: 84,
+      padding: theme.space.medium,
+      textAlignVertical: "top"
     },
+    approvalOption: { gap: 3 },
     error: { color: theme.color.danger, fontSize: 12 },
     interactionCard: {
       backgroundColor: theme.color.panelRaised,
-      borderColor: theme.color.accent,
-      borderRadius: theme.radius.medium,
+      borderColor: theme.color.border,
+      borderLeftColor: theme.color.accent,
+      borderLeftWidth: 3,
+      borderRadius: theme.radius.large,
       borderWidth: StyleSheet.hairlineWidth,
       gap: theme.space.small,
-      padding: theme.space.medium
+      paddingHorizontal: theme.space.medium,
+      paddingVertical: theme.space.medium
     },
     interactionKind: {
       color: theme.color.accent,
@@ -316,22 +334,44 @@ function createStyles(theme: NativeTheme) {
     },
     interactionTitle: {
       color: theme.color.text,
-      fontSize: 15,
+      fontSize: 16,
       fontWeight: "700",
-      lineHeight: 21
+      lineHeight: 22
     },
     option: {
+      backgroundColor: theme.color.panel,
       borderColor: theme.color.border,
       borderRadius: theme.radius.medium,
       borderWidth: StyleSheet.hairlineWidth,
-      padding: theme.space.small
+      justifyContent: "center",
+      minHeight: theme.control.regular,
+      paddingHorizontal: theme.space.medium,
+      paddingVertical: theme.space.small
     },
-    optionDescription: { color: theme.color.muted, fontSize: 12, marginTop: 3 },
-    optionList: { gap: 6 },
-    optionSelected: { borderColor: theme.color.accent },
-    optionText: { color: theme.color.text, fontSize: 14 },
+    optionDescription: {
+      color: theme.color.muted,
+      fontSize: 12,
+      lineHeight: 17,
+      marginTop: 3
+    },
+    optionList: { gap: theme.space.small },
+    optionSelected: {
+      backgroundColor: theme.color.panelRaised,
+      borderColor: theme.color.accent
+    },
+    optionText: {
+      color: theme.color.text,
+      fontSize: 14,
+      fontWeight: "600",
+      lineHeight: 20
+    },
+    pressed: { opacity: 0.72 },
     question: { gap: theme.space.small },
-    questionText: { color: theme.color.textSecondary, fontSize: 14 },
+    questionText: {
+      color: theme.color.textSecondary,
+      fontSize: 14,
+      lineHeight: 20
+    },
     unsupportedInteraction: {
       color: theme.color.textSecondary,
       fontSize: 13,

--- a/apps/mobile/src/components/MobileConversationTimeline.tsx
+++ b/apps/mobile/src/components/MobileConversationTimeline.tsx
@@ -8,10 +8,15 @@ import {
   MobileConversationImages,
   MobileGeneratedImage
 } from "./MobileConversationImages";
+import {
+  MobileChevronGlyph,
+  MobileStatusDotGlyph
+} from "./MobileControlGlyphs";
 import { MobileMarkdownText } from "./MobileMarkdownText";
 
 type TranscriptRow = AgentConversationVM["rows"][number];
 type MessageRow = Extract<TranscriptRow, { kind: "message" }>;
+type ThinkingContent = MessageRow["thinking"][number];
 type ToolGroupRow = Extract<TranscriptRow, { kind: "tool-group" }>;
 type ToolCall = ToolGroupRow["calls"][number];
 
@@ -31,15 +36,18 @@ export function MobileConversationTimeline({
   media: WorkspaceMediaSnapshot;
   onLinkPress(href: string): boolean;
 }) {
+  const theme = useNativeTheme();
+  const styles = createStyles(theme);
   return (
     <>
       {conversation.rows.map((row) => (
-        <MobileTranscriptRow
-          key={row.id}
-          media={media}
-          onLinkPress={onLinkPress}
-          row={row}
-        />
+        <View key={row.id} style={styles.rowFrame}>
+          <MobileTranscriptRow
+            media={media}
+            onLinkPress={onLinkPress}
+            row={row}
+          />
+        </View>
       ))}
     </>
   );
@@ -106,17 +114,11 @@ function MobileMessageRow({
         style={styles.speakerAccessibilityLabel}
       />
       {row.thinking.map((thinking) => (
-        <View key={thinking.id} style={styles.thinkingBlock}>
-          <Text style={styles.thinkingLabel}>{t("reasoning")}</Text>
-          {thinking.body.trim() ? (
-            <MobileMarkdownText
-              content={thinking.body}
-              onLinkPress={onLinkPress}
-              streaming={thinking.statusKind === "working"}
-              textColor={theme.color.textSecondary}
-            />
-          ) : null}
-        </View>
+        <MobileThinkingBlock
+          key={thinking.id}
+          onLinkPress={onLinkPress}
+          thinking={thinking}
+        />
       ))}
       {messageBodies.map((message) => (
         <View key={message.id} style={styles.messageContent}>
@@ -156,6 +158,77 @@ function MobileMessageRow({
   );
 }
 
+function MobileThinkingBlock({
+  onLinkPress,
+  thinking
+}: {
+  onLinkPress(href: string): boolean;
+  thinking: ThinkingContent;
+}) {
+  const theme = useNativeTheme();
+  const styles = createStyles(theme);
+  const hasBody = thinking.body.trim().length > 0;
+  const statusKind = thinking.statusKind ?? null;
+  const statusLabel = toolStatusLabel(statusKind, null);
+  const [expanded, setExpanded] = useState(
+    hasBody &&
+      (statusKind === "working" ||
+        statusKind === "failed" ||
+        statusKind === "waiting")
+  );
+  const accessibilityLabel = [
+    t("reasoning"),
+    statusLabel,
+    hasBody ? (expanded ? t("hideDetails") : t("showDetails")) : null
+  ]
+    .filter(Boolean)
+    .join(". ");
+
+  return (
+    <View style={styles.thinkingBlock}>
+      <Pressable
+        accessibilityLabel={accessibilityLabel}
+        accessibilityRole="button"
+        accessibilityState={{ disabled: !hasBody, expanded }}
+        disabled={!hasBody}
+        onPress={() => setExpanded((value) => !value)}
+        style={({ pressed }) => [
+          styles.thinkingHeader,
+          pressed && styles.pressed
+        ]}
+      >
+        <View style={styles.disclosureHeaderLine}>
+          <MobileStatusDotGlyph
+            color={toolStatusColor(theme, statusKind)}
+            size={8}
+          />
+          <Text style={styles.thinkingLabel}>{t("reasoning")}</Text>
+          {statusLabel ? (
+            <Text style={styles.thinkingStatus}>{statusLabel}</Text>
+          ) : null}
+          {hasBody ? (
+            <MobileChevronGlyph
+              color={theme.color.muted}
+              direction={expanded ? "up" : "down"}
+              size={16}
+            />
+          ) : null}
+        </View>
+      </Pressable>
+      {expanded && hasBody ? (
+        <View style={styles.thinkingBody}>
+          <MobileMarkdownText
+            content={thinking.body}
+            onLinkPress={onLinkPress}
+            streaming={statusKind === "working"}
+            textColor={theme.color.textSecondary}
+          />
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
 function MobileRawErrorDisclosure({ detail }: { detail: string }) {
   const theme = useNativeTheme();
   const styles = createStyles(theme);
@@ -173,7 +246,11 @@ function MobileRawErrorDisclosure({ detail }: { detail: string }) {
         ]}
       >
         <Text style={styles.errorDisclosureLabel}>{t("rawError")}</Text>
-        <Text style={styles.disclosure}>{expanded ? "−" : "+"}</Text>
+        <MobileChevronGlyph
+          color={theme.color.danger}
+          direction={expanded ? "up" : "down"}
+          size={16}
+        />
       </Pressable>
       {expanded ? <Text style={styles.errorText}>{detail}</Text> : null}
     </View>
@@ -189,54 +266,78 @@ function MobileToolGroupRow({
 }) {
   const theme = useNativeTheme();
   const styles = createStyles(theme);
-  const [expanded, setExpanded] = useState(false);
   const label =
     row.summary?.trim() || t("toolCalls", { count: row.calls.length });
   const singleCall = row.calls[0];
-  if (!row.grouped && singleCall) {
-    return <MobileToolCallRow call={singleCall} />;
-  }
   const hasDetails = row.entries.length > 0;
+  const statusKind = toolGroupStatusKind(row.calls);
+  const statusLabel = toolStatusLabel(statusKind, null);
+  const countLabel =
+    row.calls.length === 1
+      ? t("tool")
+      : t("toolCalls", { count: row.calls.length });
+  const [expanded, setExpanded] = useState(
+    hasDetails &&
+      (statusKind === "working" ||
+        statusKind === "failed" ||
+        statusKind === "waiting")
+  );
+  if (!row.grouped && singleCall) {
+    return (
+      <View style={styles.toolGroup}>
+        <MobileToolCallRow call={singleCall} />
+      </View>
+    );
+  }
+  const accessibilityLabel = [
+    label,
+    statusLabel,
+    hasDetails ? (expanded ? t("hideDetails") : t("showDetails")) : null
+  ]
+    .filter(Boolean)
+    .join(". ");
 
   return (
     <View style={styles.toolGroup}>
       <Pressable
-        accessibilityLabel={expanded ? t("hideDetails") : t("showDetails")}
+        accessibilityLabel={accessibilityLabel}
         accessibilityRole="button"
         accessibilityState={{ disabled: !hasDetails, expanded }}
         disabled={!hasDetails}
         onPress={() => setExpanded((value) => !value)}
         style={({ pressed }) => [styles.toolHeader, pressed && styles.pressed]}
       >
-        <View style={styles.toolHeaderText}>
-          <Text numberOfLines={1} style={styles.toolTitle}>
-            {label}
-          </Text>
-          <Text style={styles.toolMeta}>
-            {row.calls.length === 1
-              ? t("tool")
-              : t("toolCalls", { count: row.calls.length })}
-          </Text>
+        <View style={styles.disclosureHeaderLine}>
+          <MobileStatusDotGlyph
+            color={toolStatusColor(theme, statusKind)}
+            size={8}
+          />
+          <View style={styles.toolHeaderText}>
+            <Text numberOfLines={1} style={styles.toolTitle}>
+              {label}
+            </Text>
+            <Text style={styles.toolMeta}>
+              {[countLabel, statusLabel].filter(Boolean).join(" · ")}
+            </Text>
+          </View>
+          {hasDetails ? (
+            <MobileChevronGlyph
+              color={theme.color.muted}
+              direction={expanded ? "up" : "down"}
+              size={16}
+            />
+          ) : null}
         </View>
-        {hasDetails ? (
-          <Text style={styles.disclosure}>{expanded ? "−" : "+"}</Text>
-        ) : null}
       </Pressable>
       {expanded && hasDetails ? (
         <View style={styles.toolList}>
           {row.entries.map((entry) =>
             entry.kind === "thinking" ? (
-              <View key={entry.thinking.id} style={styles.toolThinking}>
-                <Text style={styles.thinkingLabel}>{t("reasoning")}</Text>
-                {entry.thinking.body.trim() ? (
-                  <MobileMarkdownText
-                    content={entry.thinking.body}
-                    onLinkPress={onLinkPress}
-                    streaming={entry.thinking.statusKind === "working"}
-                    textColor={theme.color.textSecondary}
-                  />
-                ) : null}
-              </View>
+              <MobileThinkingBlock
+                key={entry.thinking.id}
+                onLinkPress={onLinkPress}
+                thinking={entry.thinking}
+              />
             ) : (
               <MobileToolCallRow call={entry.call} key={entry.call.id} />
             )
@@ -254,26 +355,69 @@ function MobileToolCallRow({ call }: { call: ToolCall }) {
   const status = toolStatusLabel(call.statusKind, call.status);
   return (
     <View style={styles.toolCall}>
-      <View style={styles.toolCallHeader}>
-        <Text style={styles.toolCallName}>{call.name}</Text>
-        {status ? (
-          <Text
-            style={[
-              styles.toolCallStatus,
-              call.statusKind === "failed" && styles.toolCallStatusFailed
-            ]}
-          >
-            {status}
+      <View style={styles.toolCallStatusDot}>
+        <MobileStatusDotGlyph
+          color={toolStatusColor(theme, call.statusKind)}
+          size={8}
+        />
+      </View>
+      <View style={styles.toolCallContent}>
+        <View style={styles.toolCallHeader}>
+          <Text numberOfLines={1} style={styles.toolCallName}>
+            {call.name}
+          </Text>
+          {status ? (
+            <Text
+              style={[
+                styles.toolCallStatus,
+                call.statusKind === "failed" && styles.toolCallStatusFailed
+              ]}
+            >
+              {status}
+            </Text>
+          ) : null}
+        </View>
+        {summary ? (
+          <Text numberOfLines={2} style={styles.toolCallSummary}>
+            {summary}
           </Text>
         ) : null}
       </View>
-      {summary ? (
-        <Text numberOfLines={3} style={styles.toolCallSummary}>
-          {summary}
-        </Text>
-      ) : null}
     </View>
   );
+}
+
+function toolGroupStatusKind(
+  calls: readonly ToolCall[]
+): ToolCall["statusKind"] {
+  for (const statusKind of [
+    "failed",
+    "working",
+    "waiting",
+    "canceled",
+    "completed"
+  ] as const) {
+    if (calls.some((call) => call.statusKind === statusKind)) return statusKind;
+  }
+  return null;
+}
+
+function toolStatusColor(
+  theme: NativeTheme,
+  statusKind: ToolCall["statusKind"]
+): string {
+  switch (statusKind) {
+    case "working":
+      return theme.color.accent;
+    case "completed":
+      return theme.color.success;
+    case "failed":
+      return theme.color.danger;
+    case "canceled":
+    case "waiting":
+    default:
+      return theme.color.muted;
+  }
 }
 
 function toolStatusLabel(
@@ -301,7 +445,7 @@ function MobileProcessingRow({ label }: { label: string | null | undefined }) {
   const styles = createStyles(theme);
   return (
     <View accessibilityLiveRegion="polite" style={styles.processing}>
-      <View style={styles.processingDot} />
+      <MobileStatusDotGlyph color={theme.color.accent} size={8} />
       <Text style={styles.processingText}>
         {label?.trim() || t("processing")}
       </Text>
@@ -327,19 +471,24 @@ function MobileTurnSummaryRow({
         onPress={() => setExpanded((value) => !value)}
         style={({ pressed }) => [styles.toolHeader, pressed && styles.pressed]}
       >
-        <Text style={styles.summaryTitle}>{label}</Text>
-        <Text style={styles.disclosure}>{expanded ? "−" : "+"}</Text>
+        <View style={styles.disclosureHeaderLine}>
+          <Text style={styles.summaryTitle}>{label}</Text>
+          <MobileChevronGlyph
+            color={theme.color.muted}
+            direction={expanded ? "up" : "down"}
+            size={16}
+          />
+        </View>
       </Pressable>
       {expanded ? (
         <View style={styles.fileList}>
           {row.files.map((file) => (
-            <Text
-              key={file.messageId}
-              numberOfLines={1}
-              style={styles.fileName}
-            >
-              {file.label}
-            </Text>
+            <View key={file.messageId} style={styles.fileRow}>
+              <MobileStatusDotGlyph color={theme.color.muted} size={6} />
+              <Text numberOfLines={1} style={styles.fileName}>
+                {file.label}
+              </Text>
+            </View>
           ))}
         </View>
       ) : null}
@@ -359,17 +508,41 @@ function MobileGoalControlRow({ body }: { body: string }) {
 
 function createStyles(theme: NativeTheme) {
   return StyleSheet.create({
-    disclosure: { color: theme.color.muted, fontSize: 18, lineHeight: 18 },
     errorDisclosure: {
       alignItems: "center",
       flexDirection: "row",
-      gap: theme.space.small
+      gap: theme.space.small,
+      justifyContent: "space-between",
+      minHeight: theme.control.regular
     },
     errorDisclosureContainer: { marginTop: theme.space.small },
     errorDisclosureLabel: { color: theme.color.danger, fontSize: 13 },
     errorText: { color: theme.color.danger, fontSize: 14, lineHeight: 21 },
-    fileList: { gap: theme.space.small, paddingTop: theme.space.small },
-    fileName: { color: theme.color.textSecondary, fontSize: 13 },
+    disclosureHeaderLine: {
+      alignItems: "center",
+      alignSelf: "stretch",
+      flexDirection: "row",
+      gap: theme.space.small,
+      paddingHorizontal: theme.space.medium
+    },
+    fileList: {
+      borderTopColor: theme.color.border,
+      borderTopWidth: StyleSheet.hairlineWidth,
+      gap: theme.space.small,
+      paddingHorizontal: theme.space.medium,
+      paddingVertical: theme.space.small
+    },
+    fileName: {
+      color: theme.color.textSecondary,
+      flex: 1,
+      fontSize: 13
+    },
+    fileRow: {
+      alignItems: "center",
+      flexDirection: "row",
+      gap: theme.space.small,
+      minHeight: theme.control.compact
+    },
     goalControl: {
       borderLeftColor: theme.color.accent,
       borderLeftWidth: 2,
@@ -385,11 +558,13 @@ function createStyles(theme: NativeTheme) {
       alignSelf: "flex-start",
       borderRadius: theme.radius.large,
       gap: theme.space.small,
-      maxWidth: "88%"
+      maxWidth: "86%"
     },
     assistantMessage: {
       alignSelf: "stretch",
-      maxWidth: "100%"
+      marginBottom: theme.space.small,
+      maxWidth: "100%",
+      paddingVertical: theme.space.small
     },
     messageContent: { gap: theme.space.small },
     noticeDetail: {
@@ -403,16 +578,15 @@ function createStyles(theme: NativeTheme) {
       alignItems: "center",
       flexDirection: "row",
       gap: theme.space.small,
-      paddingHorizontal: theme.space.small,
-      paddingVertical: theme.space.small
-    },
-    processingDot: {
-      backgroundColor: theme.color.accent,
-      borderRadius: 4,
-      height: 8,
-      width: 8
+      minHeight: theme.control.compact,
+      paddingHorizontal: theme.space.medium
     },
     processingText: { color: theme.color.muted, fontSize: 13 },
+    rowFrame: {
+      alignSelf: "center",
+      maxWidth: 760,
+      width: "100%"
+    },
     speakerAccessibilityLabel: {
       height: 1,
       position: "absolute",
@@ -425,29 +599,46 @@ function createStyles(theme: NativeTheme) {
       fontWeight: "700"
     },
     thinkingBlock: {
-      backgroundColor: theme.color.background,
-      borderRadius: theme.radius.medium,
-      gap: 4,
-      padding: theme.space.small
+      borderLeftColor: theme.color.border,
+      borderLeftWidth: 2,
+      marginVertical: 2
+    },
+    thinkingBody: {
+      paddingBottom: theme.space.small,
+      paddingHorizontal: theme.space.medium
+    },
+    thinkingHeader: {
+      justifyContent: "center",
+      minHeight: theme.control.regular
     },
     thinkingLabel: {
       color: theme.color.muted,
-      fontSize: 11,
+      flex: 1,
+      fontSize: 13,
       fontWeight: "700"
     },
+    thinkingStatus: { color: theme.color.muted, fontSize: 11 },
     toolCall: {
-      borderTopColor: theme.color.border,
-      borderTopWidth: StyleSheet.hairlineWidth,
-      gap: 3,
-      paddingTop: theme.space.small
+      alignItems: "flex-start",
+      flexDirection: "row",
+      gap: theme.space.small,
+      minHeight: theme.control.regular,
+      paddingHorizontal: theme.space.medium,
+      paddingVertical: theme.space.small
     },
+    toolCallContent: { flex: 1, gap: 3, minWidth: 0 },
     toolCallHeader: {
       alignItems: "center",
       flexDirection: "row",
       gap: theme.space.small,
       justifyContent: "space-between"
     },
-    toolCallName: { color: theme.color.text, fontSize: 13, fontWeight: "700" },
+    toolCallName: {
+      color: theme.color.text,
+      flex: 1,
+      fontSize: 13,
+      fontWeight: "700"
+    },
     toolCallStatus: { color: theme.color.muted, fontSize: 11 },
     toolCallStatusFailed: { color: theme.color.danger },
     toolCallSummary: {
@@ -455,38 +646,41 @@ function createStyles(theme: NativeTheme) {
       fontSize: 13,
       lineHeight: 18
     },
+    toolCallStatusDot: { paddingTop: 5 },
     toolGroup: {
-      backgroundColor: theme.color.panelRaised,
+      backgroundColor: theme.color.panel,
       borderColor: theme.color.border,
-      borderRadius: theme.radius.medium,
+      borderRadius: theme.radius.large,
       borderWidth: StyleSheet.hairlineWidth,
-      padding: theme.space.medium
+      overflow: "hidden"
     },
     toolHeader: {
-      alignItems: "center",
-      flexDirection: "row",
-      gap: theme.space.small
+      justifyContent: "center",
+      minHeight: theme.control.regular,
+      paddingVertical: theme.space.small
     },
-    toolHeaderText: { flex: 1, gap: 2 },
-    toolList: { gap: theme.space.small, paddingTop: theme.space.small },
-    toolMeta: { color: theme.color.muted, fontSize: 12 },
-    toolThinking: {
+    toolHeaderText: { flex: 1, gap: 2, minWidth: 0 },
+    toolList: {
       borderTopColor: theme.color.border,
-      borderTopWidth: StyleSheet.hairlineWidth,
-      gap: 4,
-      paddingTop: theme.space.small
+      borderTopWidth: StyleSheet.hairlineWidth
     },
+    toolMeta: { color: theme.color.muted, fontSize: 12 },
     toolTitle: { color: theme.color.text, fontSize: 14, fontWeight: "700" },
     turnSummary: {
+      backgroundColor: theme.color.panel,
       borderColor: theme.color.border,
-      borderRadius: theme.radius.medium,
+      borderRadius: theme.radius.large,
       borderWidth: StyleSheet.hairlineWidth,
-      padding: theme.space.medium
+      overflow: "hidden"
     },
     userMessage: {
       alignSelf: "flex-end",
-      backgroundColor: theme.color.panel,
-      padding: theme.space.medium
+      backgroundColor: theme.color.panelRaised,
+      borderColor: theme.color.border,
+      borderWidth: StyleSheet.hairlineWidth,
+      marginTop: theme.space.medium,
+      paddingHorizontal: theme.space.medium,
+      paddingVertical: theme.space.small
     }
   });
 }

--- a/apps/mobile/src/components/PrimaryButton.tsx
+++ b/apps/mobile/src/components/PrimaryButton.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import type { StyleProp, ViewStyle } from "react-native";
 
 interface PrimaryButtonProps {
+  accessibilityLabel?: string;
   disabled?: boolean;
   leading?: ReactNode;
   label: string;
@@ -14,6 +15,7 @@ interface PrimaryButtonProps {
 }
 
 export function PrimaryButton({
+  accessibilityLabel,
   disabled = false,
   leading,
   label,
@@ -25,6 +27,7 @@ export function PrimaryButton({
 }: PrimaryButtonProps) {
   return (
     <NativeButton
+      accessibilityLabel={accessibilityLabel}
       disabled={disabled}
       leading={leading}
       label={label}

--- a/apps/mobile/src/screens/ConversationScreenView.tsx
+++ b/apps/mobile/src/screens/ConversationScreenView.tsx
@@ -1,5 +1,4 @@
 import {
-  canonicalInteractionKey,
   type AgentActivityInteraction,
   type AgentActivitySessionSettings
 } from "@tutti-os/agent-activity-core";
@@ -11,10 +10,11 @@ import {
   type NativeTheme,
   useNativeTheme
 } from "@tutti-os/ui-system/native";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Linking, ScrollView, StyleSheet, Text, View } from "react-native";
-import { MobileInteractionCard } from "../components/MobileConversationRows";
 import { MobileComposerDock } from "../components/MobileComposerDock";
+import { MobileBackGlyph } from "../components/MobileControlGlyphs";
+import { MobileConversationInteractionDock } from "../components/MobileConversationInteractionDock";
 import { MobileConversationTimeline } from "../components/MobileConversationTimeline";
 import {
   MobileKeyboardAvoidingView,
@@ -28,6 +28,7 @@ import { t } from "../i18n";
 import type { WorkspaceActivitySnapshot } from "../services/workspaceActivityService";
 import type { WorkspaceMediaSnapshot } from "../services/workspaceMediaService";
 import type { MobileQuickPromptLibrarySnapshot } from "../services/mobileQuickPromptLibraryService";
+import { createConversationScrollScheduler } from "./conversationScrollScheduler";
 
 export function ConversationScreenView({
   deviceName,
@@ -82,24 +83,46 @@ export function ConversationScreenView({
   );
   const followEndController = followEndControllerRef.current;
   const lastScrollOffsetY = useRef(0);
+  const contentHeight = useRef(0);
+  const viewportHeight = useRef(0);
+  const scrollScheduler = useRef<
+    ReturnType<typeof createConversationScrollScheduler> | undefined
+  >(undefined);
+  if (!scrollScheduler.current) {
+    scrollScheduler.current = createConversationScrollScheduler({
+      getFollowState: () => followEndControllerRef.current.getSnapshot(),
+      onScrollToEnd: (animated) => scroll.current?.scrollToEnd({ animated })
+    });
+  }
   const window = model.selectedAgentSessionId
     ? model.activity.sessionMessageWindowsById?.[model.selectedAgentSessionId]
     : null;
 
+  const scheduleScrollToBottom = useCallback(
+    (animated: boolean, intent: "auto-follow" | "requested") => {
+      scrollScheduler.current?.schedule(animated, intent);
+    },
+    []
+  );
+
   useEffect(() => {
     followEndController.dispatch("conversation-changed");
     lastScrollOffsetY.current = 0;
+    contentHeight.current = 0;
+    viewportHeight.current = 0;
     setShowScrollToBottom(false);
-    const frame = requestAnimationFrame(() => {
-      scroll.current?.scrollToEnd({ animated: false });
-    });
-    return () => cancelAnimationFrame(frame);
-  }, [followEndController, model.selectedAgentSessionId]);
+    scheduleScrollToBottom(false, "auto-follow");
+    return () => scrollScheduler.current?.cancel();
+  }, [
+    followEndController,
+    model.selectedAgentSessionId,
+    scheduleScrollToBottom
+  ]);
 
   const scrollToBottom = (animated: boolean) => {
     followEndController.dispatch("scroll-to-end-requested");
     setShowScrollToBottom(false);
-    scroll.current?.scrollToEnd({ animated });
+    scheduleScrollToBottom(animated, "requested");
   };
   const openConversationLink = (href: string): boolean => {
     if (!model.conversation) return false;
@@ -125,40 +148,42 @@ export function ConversationScreenView({
   return (
     <MobileKeyboardAvoidingView style={styles.root}>
       <View style={styles.conversationHeader}>
-        <View style={styles.headerButtonSlot}>
+        <View style={styles.headerContent}>
           <NativeIconButton
             accessibilityLabel={t("sessions")}
             onPress={onBack}
-            icon={<Text style={styles.backIcon}>←</Text>}
+            icon={<MobileBackGlyph color={theme.color.text} size={20} />}
             style={styles.headerCircleButton}
-            variant="secondary"
+            variant="ghost"
           />
-        </View>
-        <View style={styles.conversationTitle}>
-          <Text numberOfLines={1} style={styles.sessionTitle}>
-            {model.creating
-              ? t("newSession")
-              : model.selectedSession?.title || workspaceName}
-          </Text>
-          <View style={styles.locationRow}>
-            <View style={styles.locationItem}>
-              <MobileFolderGlyph color={theme.color.textSecondary} size={14} />
-              <Text numberOfLines={1} style={styles.locationLabel}>
-                {workspaceName}
-              </Text>
-            </View>
-            <View style={styles.locationItem}>
-              <MobileComputerGlyph
-                color={theme.color.textSecondary}
-                size={14}
-              />
-              <Text numberOfLines={1} style={styles.locationLabel}>
-                {deviceName || t("desktopFallback")}
-              </Text>
+          <View style={styles.conversationTitle}>
+            <Text numberOfLines={1} style={styles.sessionTitle}>
+              {model.creating
+                ? t("newSession")
+                : model.selectedSession?.title || workspaceName}
+            </Text>
+            <View style={styles.locationRow}>
+              <View style={styles.locationItem}>
+                <MobileFolderGlyph
+                  color={theme.color.textSecondary}
+                  size={14}
+                />
+                <Text numberOfLines={1} style={styles.locationLabel}>
+                  {workspaceName}
+                </Text>
+              </View>
+              <View style={styles.locationItem}>
+                <MobileComputerGlyph
+                  color={theme.color.textSecondary}
+                  size={14}
+                />
+                <Text numberOfLines={1} style={styles.locationLabel}>
+                  {deviceName || t("desktopFallback")}
+                </Text>
+              </View>
             </View>
           </View>
         </View>
-        <View style={styles.headerButtonSlot} />
       </View>
 
       {model.loading ? (
@@ -167,8 +192,10 @@ export function ConversationScreenView({
           accessibilityLiveRegion="polite"
           style={styles.loadingSkeleton}
         >
-          <View style={[styles.skeletonBlock, styles.skeletonShort]} />
-          <View style={[styles.skeletonBlock, styles.skeletonLong]} />
+          <View style={styles.loadingColumn}>
+            <View style={[styles.skeletonBlock, styles.skeletonShort]} />
+            <View style={[styles.skeletonBlock, styles.skeletonLong]} />
+          </View>
         </View>
       ) : model.selectedSession && !model.creating ? (
         <View style={styles.conversationBody}>
@@ -177,17 +204,20 @@ export function ConversationScreenView({
             keyboardDismissMode={mobileKeyboardDismissMode}
             keyboardShouldPersistTaps="handled"
             maintainVisibleContentPosition={{ minIndexForVisible: 0 }}
-            onContentSizeChange={() => {
+            onContentSizeChange={(_width, height) => {
+              contentHeight.current = height;
               if (followEndController.getSnapshot() === "following") {
-                scrollToBottom(false);
+                scheduleScrollToBottom(false, "auto-follow");
               }
             }}
-            onLayout={() => {
+            onLayout={({ nativeEvent }) => {
+              viewportHeight.current = nativeEvent.layout.height;
               if (followEndController.getSnapshot() === "following") {
-                scrollToBottom(false);
+                scheduleScrollToBottom(false, "auto-follow");
               }
             }}
             onScrollBeginDrag={() => {
+              scrollScheduler.current?.cancel();
               followEndController.dispatch("user-scrolled-away");
               setShowScrollToBottom(true);
             }}
@@ -216,6 +246,17 @@ export function ConversationScreenView({
                 followEndController.getSnapshot() === "detached"
               );
             }}
+            onTouchStart={() => {
+              const distanceFromBottom =
+                contentHeight.current -
+                viewportHeight.current -
+                lastScrollOffsetY.current;
+              if (distanceFromBottom > 48) {
+                scrollScheduler.current?.cancel();
+                followEndController.dispatch("user-scrolled-away");
+                setShowScrollToBottom(true);
+              }
+            }}
             ref={scroll}
             scrollEventThrottle={16}
             style={styles.messageScroller}
@@ -224,7 +265,9 @@ export function ConversationScreenView({
               <Text style={styles.loadOlder}>{t("loading")}</Text>
             ) : null}
             {!model.conversation || model.conversation.rows.length === 0 ? (
-              <Text style={styles.emptyText}>{t("emptyConversation")}</Text>
+              <Text style={[styles.emptyText, styles.transcriptFrame]}>
+                {t("emptyConversation")}
+              </Text>
             ) : (
               <MobileConversationTimeline
                 conversation={model.conversation}
@@ -232,34 +275,12 @@ export function ConversationScreenView({
                 onLinkPress={openConversationLink}
               />
             )}
-            {model.pendingInteractions.map((interaction) => {
-              const interactionKey = canonicalInteractionKey(
-                interaction.agentSessionId,
-                interaction.turnId,
-                interaction.requestId
-              );
-              const state = model.interactionStates[interactionKey] ?? {
-                failed: false,
-                runtimeAvailable: false,
-                submitting: false
-              };
-              return (
-                <MobileInteractionCard
-                  failed={state.failed}
-                  interaction={interaction}
-                  key={interactionKey}
-                  onSubmit={(input) => onRespond(interaction, input)}
-                  runtimeAvailable={state.runtimeAvailable}
-                  submitting={state.submitting}
-                />
-              );
-            })}
           </ScrollView>
           {showScrollToBottom ? (
             <NativeButton
               label={t("scrollToBottom")}
               onPress={() => scrollToBottom(true)}
-              size="compact"
+              size="regular"
               style={styles.scrollToBottom}
               variant="secondary"
             />
@@ -278,6 +299,11 @@ export function ConversationScreenView({
       {model.errorCode ? (
         <Text style={styles.inlineError}>{t("genericError")}</Text>
       ) : null}
+      <MobileConversationInteractionDock
+        interactionStates={model.interactionStates}
+        interactions={model.pendingInteractions}
+        onRespond={onRespond}
+      />
       {model.selectedSession || model.creating ? (
         <MobileComposerDock
           model={model}
@@ -306,17 +332,27 @@ function createStyles(theme: NativeTheme) {
     },
     conversationHeader: {
       alignItems: "center",
+      backgroundColor: theme.color.background,
+      borderBottomColor: theme.color.border,
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      paddingHorizontal: theme.space.small,
+      paddingVertical: theme.space.small / 2
+    },
+    headerContent: {
+      alignItems: "center",
+      alignSelf: "center",
       flexDirection: "row",
       gap: theme.space.small,
-      paddingHorizontal: theme.space.medium,
-      paddingVertical: theme.space.small
+      maxWidth: 760,
+      width: "100%"
     },
     conversationBody: { flex: 1, minHeight: 0, position: "relative" },
     conversationTitle: {
-      alignItems: "center",
+      alignItems: "flex-start",
       flex: 1,
       justifyContent: "center",
-      minWidth: 0
+      minWidth: 0,
+      paddingRight: theme.space.small
     },
     emptyText: {
       color: theme.color.textSecondary,
@@ -324,27 +360,13 @@ function createStyles(theme: NativeTheme) {
       lineHeight: 22,
       textAlign: "center"
     },
-    backIcon: {
-      color: theme.color.text,
-      fontSize: 22,
-      fontWeight: "400",
-      lineHeight: 26
-    },
     headerCircleButton: {
       alignItems: "center",
-      backgroundColor: theme.color.panelRaised,
-      borderColor: theme.color.border,
-      borderRadius: 20,
-      borderWidth: StyleSheet.hairlineWidth,
+      borderRadius: theme.control.regular / 2,
       flexShrink: 0,
-      height: 40,
+      height: theme.control.regular,
       justifyContent: "center",
-      width: 40
-    },
-    headerButtonSlot: {
-      flexShrink: 0,
-      height: 40,
-      width: 40
+      width: theme.control.regular
     },
     inlineError: {
       backgroundColor: theme.color.panel,
@@ -353,17 +375,31 @@ function createStyles(theme: NativeTheme) {
       padding: theme.space.small,
       textAlign: "center"
     },
-    loadOlder: { color: theme.color.muted, fontSize: 12, textAlign: "center" },
+    loadOlder: {
+      alignSelf: "center",
+      color: theme.color.muted,
+      fontSize: 12,
+      maxWidth: 760,
+      paddingVertical: theme.space.small,
+      textAlign: "center",
+      width: "100%"
+    },
+    loadingColumn: {
+      alignSelf: "center",
+      gap: theme.space.medium,
+      maxWidth: 760,
+      width: "100%"
+    },
     loadingSkeleton: {
       flex: 1,
-      gap: theme.space.medium,
-      paddingHorizontal: theme.space.large,
+      paddingHorizontal: theme.space.medium,
       paddingTop: theme.space.xlarge
     },
     locationLabel: {
       color: theme.color.textSecondary,
       flexShrink: 1,
-      fontSize: 12
+      fontSize: 12,
+      lineHeight: 16
     },
     locationItem: {
       alignItems: "center",
@@ -375,21 +411,20 @@ function createStyles(theme: NativeTheme) {
     locationRow: {
       flexDirection: "row",
       gap: theme.space.small,
-      justifyContent: "center",
-      marginTop: 3,
+      marginTop: 2,
       overflow: "hidden"
     },
     messageList: {
-      gap: theme.space.medium,
+      gap: theme.space.small,
       paddingBottom: theme.space.xlarge,
       paddingHorizontal: theme.space.medium,
       paddingTop: theme.space.medium
     },
     messageScroller: { flex: 1 },
-    pressed: { opacity: 0.7 },
     root: { backgroundColor: theme.color.background, flex: 1 },
     scrollToBottom: {
       bottom: theme.space.medium,
+      borderRadius: theme.control.regular / 2,
       position: "absolute",
       right: theme.space.medium
     },
@@ -405,9 +440,15 @@ function createStyles(theme: NativeTheme) {
     },
     sessionTitle: {
       color: theme.color.text,
-      fontSize: 16,
+      fontSize: 17,
       fontWeight: "700",
-      textAlign: "center"
+      lineHeight: 22,
+      textAlign: "left"
+    },
+    transcriptFrame: {
+      alignSelf: "center",
+      maxWidth: 760,
+      width: "100%"
     }
   });
 }

--- a/apps/mobile/src/screens/conversationScrollScheduler.test.ts
+++ b/apps/mobile/src/screens/conversationScrollScheduler.test.ts
@@ -1,0 +1,63 @@
+import { createConversationScrollScheduler } from "./conversationScrollScheduler";
+
+test("drops queued auto-follow scrolling after the user detaches", () => {
+  let followState: "detached" | "following" = "following";
+  let nextFrame = 1;
+  const frames = new Map<number, () => void>();
+  const scrolls: boolean[] = [];
+  const scheduler = createConversationScrollScheduler({
+    cancelFrame: (frame) => frames.delete(frame),
+    getFollowState: () => followState,
+    onScrollToEnd: (animated) => scrolls.push(animated),
+    requestFrame: (callback) => {
+      const frame = nextFrame++;
+      frames.set(frame, callback);
+      return frame;
+    }
+  });
+
+  scheduler.schedule(false, "auto-follow");
+  followState = "detached";
+  frames.get(1)?.();
+
+  expect(scrolls).toEqual([]);
+});
+
+test("keeps explicit scroll-to-bottom requests while detached", () => {
+  const frames = new Map<number, () => void>();
+  const scrolls: boolean[] = [];
+  const scheduler = createConversationScrollScheduler({
+    cancelFrame: (frame) => frames.delete(frame),
+    getFollowState: () => "detached",
+    onScrollToEnd: (animated) => scrolls.push(animated),
+    requestFrame: (callback) => {
+      frames.set(1, callback);
+      return 1;
+    }
+  });
+
+  scheduler.schedule(true, "requested");
+  frames.get(1)?.();
+
+  expect(scrolls).toEqual([true]);
+});
+
+test("cancels queued scrolling when a touch takes ownership", () => {
+  const frames = new Map<number, () => void>();
+  const scrolls: boolean[] = [];
+  const scheduler = createConversationScrollScheduler({
+    cancelFrame: (frame) => frames.delete(frame),
+    getFollowState: () => "following",
+    onScrollToEnd: (animated) => scrolls.push(animated),
+    requestFrame: (callback) => {
+      frames.set(1, callback);
+      return 1;
+    }
+  });
+
+  scheduler.schedule(false, "auto-follow");
+  scheduler.cancel();
+  frames.get(1)?.();
+
+  expect(scrolls).toEqual([]);
+});

--- a/apps/mobile/src/screens/conversationScrollScheduler.ts
+++ b/apps/mobile/src/screens/conversationScrollScheduler.ts
@@ -1,0 +1,37 @@
+export type ConversationScrollIntent = "auto-follow" | "requested";
+
+export function createConversationScrollScheduler({
+  cancelFrame = (frame: number) => cancelAnimationFrame(frame),
+  getFollowState,
+  onScrollToEnd,
+  requestFrame = (callback: () => void) => requestAnimationFrame(callback)
+}: {
+  cancelFrame?(frame: number): void;
+  getFollowState(): "detached" | "following";
+  onScrollToEnd(animated: boolean): void;
+  requestFrame?(callback: () => void): number;
+}) {
+  let pendingFrame: number | null = null;
+
+  const cancel = (): void => {
+    if (pendingFrame === null) return;
+    cancelFrame(pendingFrame);
+    pendingFrame = null;
+  };
+
+  const schedule = (
+    animated: boolean,
+    intent: ConversationScrollIntent
+  ): void => {
+    cancel();
+    pendingFrame = requestFrame(() => {
+      pendingFrame = null;
+      if (intent === "auto-follow" && getFollowState() !== "following") {
+        return;
+      }
+      onScrollToEnd(animated);
+    });
+  };
+
+  return { cancel, schedule };
+}

--- a/docs/specs/2026-07-23-mobile-agentgui-device-link-design.md
+++ b/docs/specs/2026-07-23-mobile-agentgui-device-link-design.md
@@ -426,6 +426,26 @@ MVP 优先共享 conversation projection、稳定 row identity、相邻消息合
 
 所有移动端文案仍进入 i18n。不得在 Native 组件中硬编码用户可见文案。
 
+### 11.4 会话详情展示节奏
+
+Native Mobile 会话详情保持正常时间顺序，不在展示层重组 Turn 或推断新的
+Interaction 状态。页面 Header 使用两层信息展示会话标题与现有 workspace/device
+上下文；Transcript 在宽屏上限制阅读宽度，用户消息使用紧凑气泡，Assistant 正文保持
+平面排版，Reasoning、Tool、Processing 和文件摘要使用低权重的渐进披露样式。
+会话首次进入时在最终布局帧跟随最新消息；用户已离开底部并触摸历史内容时，应先退出
+follow-end，再处理 Reasoning、Tool 或文件摘要的展开，避免内容高度变化把阅读位置强制跳回
+末尾。离开底部后保留明确的“回到底部”动作。
+
+Pending Interaction 是 Composer 前的 normal-flow sibling，并且仍是当前 exact
+Interaction 的唯一 actionable 挂载点。多个 pending 项在有限高度的独立滚动区中保持
+canonical 顺序和 exact identity；页面不把它复制为第二张 transcript 操作卡，也不使用
+absolute overlay，也不参与 Transcript 的滚动锚点或 follow-end 几何计算。Composer 使用单一 token-backed surface
+组织草稿、现有设置入口和 Send/Stop action，继续服从原有 Engine projection、草稿、
+readiness 和 overlay activation fence，不在 Native presentation 中重解释业务状态。
+窄屏上的 Composer 设置入口允许水平滚动，并使用跨平台边缘方向提示表达仍有更多设置
+（Android 同时保留原生渐隐）；键盘弹起时
+Composer 整体上移，Transcript 继续保留可阅读区域。
+
 ## 12. Composer
 
 MVP 支持：


### PR DESCRIPTION
## 背景

Mobile 会话详情已有完整功能，但信息层级、内容密度、渐进披露、Composer 和滚动交互仍偏桌面化。本次在不改变业务语义的前提下，集中优化会话详情的移动端体验。

## 变更

- 收紧会话 Header，突出标题并弱化 workspace/device 辅助信息
- 调整消息视觉层级：用户消息使用紧凑气泡，Assistant 正文保持平面排版
- 统一 Reasoning、Tool、Processing 和文件摘要的渐进披露样式与状态表达
- 将 Pending Interaction 移到 Composer 上方的 normal-flow dock，保持 canonical identity 和既有响应语义
- 重构 Composer 视觉层级，增加跨平台横向设置溢出提示与更清晰的操作图标
- 修复首次进入定位最新消息、展开历史内容跳到底部等 follow-end 竞态
- 增加滚动调度与设置栏溢出状态测试
- 补充 Mobile 会话详情展示与交互规范

## 边界

- 仅修改 Mobile 会话详情，没有修改会话列表
- 没有修改 service、engine、Host、DTO、权限或 Interaction 生命周期语义
- 用户可见文案继续通过 i18n，样式使用 UI System 语义 token

## 验证

- `pnpm --filter @tutti-os/mobile typecheck`
- `pnpm --filter @tutti-os/mobile test`：34 suites / 191 tests passed
- `git diff --check`
- pre-commit formatting、UI boundary 和 AgentGUI degradation checks
- `pnpm check:changed -- --push-ready`：7 lanes passed
- Android 16 真机验证：进入会话定位、历史内容展开、回到底部、键盘输入、设置横向滚动和权限 Sheet 均正常，未发现崩溃或 React Native fatal error

## 文档

更新 Mobile AgentGUI 设计文档，记录会话详情布局、Pending Interaction、Composer 和 follow-end 的持久约束。