### PR TITLE
fix(mobile): address conversation detail review feedback

### DIFF
--- a/apps/mobile/src/components/MobileComposerDock.tsx
+++ b/apps/mobile/src/components/MobileComposerDock.tsx
@@ -1,5 +1,6 @@
 import type { AgentActivitySessionSettings } from "@tutti-os/agent-activity-core";
 import {
+  NativeControlGlyph,
   NativeIconButton,
   NativeListRow,
   type NativeTheme,
@@ -25,13 +26,6 @@ import {
   MobileComposerSettingsSheet,
   type ComposerSettingMenu
 } from "./MobileComposerSettingsSheet";
-import {
-  MobileAddGlyph,
-  MobileBackGlyph,
-  MobileChevronGlyph,
-  MobileSendGlyph,
-  MobileStopGlyph
-} from "./MobileControlGlyphs";
 import {
   MobileKeyboardAvoidingView,
   mobileKeyboardDismissMode
@@ -223,7 +217,11 @@ export function MobileComposerDock({
             accessibilityLabel={t("moreActions")}
             disabled={!model.commandsAvailable}
             icon={
-              <MobileAddGlyph color={theme.color.textSecondary} size={20} />
+              <NativeControlGlyph
+                color={theme.color.textSecondary}
+                size={20}
+                variant="add"
+              />
             }
             onPress={openToolsMenu}
             style={styles.addButton}
@@ -245,7 +243,11 @@ export function MobileComposerDock({
               accessibilityLabel={t("stop")}
               disabled={!model.commandsAvailable}
               icon={
-                <MobileStopGlyph color={theme.color.background} size={20} />
+                <NativeControlGlyph
+                  color={theme.color.background}
+                  size={20}
+                  variant="stop"
+                />
               }
               onPress={onStop}
               style={styles.actionButton}
@@ -256,7 +258,11 @@ export function MobileComposerDock({
                 model.ambiguousSubmission ? t("retry") : t("send")
               }
               icon={
-                <MobileSendGlyph color={theme.color.background} size={20} />
+                <NativeControlGlyph
+                  color={theme.color.background}
+                  size={20}
+                  variant="send"
+                />
               }
               onPress={onSend}
               style={styles.actionButton}
@@ -297,10 +303,11 @@ export function MobileComposerDock({
                       onPress={() => setToolsMenu("model")}
                       title={t("model")}
                       trailing={
-                        <MobileChevronGlyph
+                        <NativeControlGlyph
                           color={theme.color.muted}
                           direction="right"
                           size={16}
+                          variant="chevron"
                         />
                       }
                     />
@@ -312,10 +319,11 @@ export function MobileComposerDock({
                       onPress={() => setToolsMenu("permission")}
                       title={t("permissions")}
                       trailing={
-                        <MobileChevronGlyph
+                        <NativeControlGlyph
                           color={theme.color.muted}
                           direction="right"
                           size={16}
+                          variant="chevron"
                         />
                       }
                     />
@@ -349,10 +357,11 @@ export function MobileComposerDock({
                       onPress={() => setToolsMenu("quickPrompts")}
                       title={t("quickPrompts")}
                       trailing={
-                        <MobileChevronGlyph
+                        <NativeControlGlyph
                           color={theme.color.muted}
                           direction="right"
                           size={16}
+                          variant="chevron"
                         />
                       }
                     />
@@ -385,7 +394,11 @@ export function MobileComposerDock({
                     <NativeIconButton
                       accessibilityLabel={t("cancel")}
                       icon={
-                        <MobileBackGlyph color={theme.color.text} size={20} />
+                        <NativeControlGlyph
+                          color={theme.color.text}
+                          size={20}
+                          variant="back"
+                        />
                       }
                       onPress={() => setToolsMenu("tools")}
                       style={styles.menuBackButton}

--- a/apps/mobile/src/components/MobileComposerSettingsSheet.tsx
+++ b/apps/mobile/src/components/MobileComposerSettingsSheet.tsx
@@ -1,6 +1,7 @@
 import type { AgentActivitySessionSettings } from "@tutti-os/agent-activity-core";
 import {
   NativeButton,
+  NativeControlGlyph,
   NativeListRow,
   NativeSheet,
   type NativeTheme,
@@ -10,7 +11,6 @@ import { useRef, useState } from "react";
 import { ScrollView, StyleSheet, Text, View } from "react-native";
 import { t } from "../i18n";
 import type { WorkspaceActivitySnapshot } from "../services/workspaceActivityService";
-import { MobileChevronGlyph } from "./MobileControlGlyphs";
 
 export type ComposerSettingMenu =
   | "model"
@@ -175,10 +175,11 @@ export function MobileComposerSettingsSheet({
             style={[styles.chipRailHint, styles.chipRailHintLeading]}
             testID="mobile-composer-settings-leading-hint"
           >
-            <MobileChevronGlyph
+            <NativeControlGlyph
               color={theme.color.textSecondary}
               direction="left"
               size={14}
+              variant="chevron"
             />
           </View>
         ) : null}
@@ -188,10 +189,11 @@ export function MobileComposerSettingsSheet({
             style={[styles.chipRailHint, styles.chipRailHintTrailing]}
             testID="mobile-composer-settings-trailing-hint"
           >
-            <MobileChevronGlyph
+            <NativeControlGlyph
               color={theme.color.textSecondary}
               direction="right"
               size={14}
+              variant="chevron"
             />
           </View>
         ) : null}

--- a/apps/mobile/src/components/MobileConversationTimeline.tsx
+++ b/apps/mobile/src/components/MobileConversationTimeline.tsx
@@ -1,5 +1,9 @@
 import type { AgentConversationVM } from "@tutti-os/agent-gui/conversation-projection";
-import { type NativeTheme, useNativeTheme } from "@tutti-os/ui-system/native";
+import {
+  NativeControlGlyph,
+  type NativeTheme,
+  useNativeTheme
+} from "@tutti-os/ui-system/native";
 import { useState } from "react";
 import { Pressable, StyleSheet, Text, View } from "react-native";
 import { t } from "../i18n";
@@ -8,10 +12,6 @@ import {
   MobileConversationImages,
   MobileGeneratedImage
 } from "./MobileConversationImages";
-import {
-  MobileChevronGlyph,
-  MobileStatusDotGlyph
-} from "./MobileControlGlyphs";
 import { MobileMarkdownText } from "./MobileMarkdownText";
 
 type TranscriptRow = AgentConversationVM["rows"][number];
@@ -198,19 +198,21 @@ function MobileThinkingBlock({
         ]}
       >
         <View style={styles.disclosureHeaderLine}>
-          <MobileStatusDotGlyph
+          <NativeControlGlyph
             color={toolStatusColor(theme, statusKind)}
             size={8}
+            variant="status"
           />
           <Text style={styles.thinkingLabel}>{t("reasoning")}</Text>
           {statusLabel ? (
             <Text style={styles.thinkingStatus}>{statusLabel}</Text>
           ) : null}
           {hasBody ? (
-            <MobileChevronGlyph
+            <NativeControlGlyph
               color={theme.color.muted}
               direction={expanded ? "up" : "down"}
               size={16}
+              variant="chevron"
             />
           ) : null}
         </View>
@@ -246,10 +248,11 @@ function MobileRawErrorDisclosure({ detail }: { detail: string }) {
         ]}
       >
         <Text style={styles.errorDisclosureLabel}>{t("rawError")}</Text>
-        <MobileChevronGlyph
+        <NativeControlGlyph
           color={theme.color.danger}
           direction={expanded ? "up" : "down"}
           size={16}
+          variant="chevron"
         />
       </Pressable>
       {expanded ? <Text style={styles.errorText}>{detail}</Text> : null}
@@ -308,9 +311,10 @@ function MobileToolGroupRow({
         style={({ pressed }) => [styles.toolHeader, pressed && styles.pressed]}
       >
         <View style={styles.disclosureHeaderLine}>
-          <MobileStatusDotGlyph
+          <NativeControlGlyph
             color={toolStatusColor(theme, statusKind)}
             size={8}
+            variant="status"
           />
           <View style={styles.toolHeaderText}>
             <Text numberOfLines={1} style={styles.toolTitle}>
@@ -321,10 +325,11 @@ function MobileToolGroupRow({
             </Text>
           </View>
           {hasDetails ? (
-            <MobileChevronGlyph
+            <NativeControlGlyph
               color={theme.color.muted}
               direction={expanded ? "up" : "down"}
               size={16}
+              variant="chevron"
             />
           ) : null}
         </View>
@@ -356,9 +361,10 @@ function MobileToolCallRow({ call }: { call: ToolCall }) {
   return (
     <View style={styles.toolCall}>
       <View style={styles.toolCallStatusDot}>
-        <MobileStatusDotGlyph
+        <NativeControlGlyph
           color={toolStatusColor(theme, call.statusKind)}
           size={8}
+          variant="status"
         />
       </View>
       <View style={styles.toolCallContent}>
@@ -445,7 +451,11 @@ function MobileProcessingRow({ label }: { label: string | null | undefined }) {
   const styles = createStyles(theme);
   return (
     <View accessibilityLiveRegion="polite" style={styles.processing}>
-      <MobileStatusDotGlyph color={theme.color.accent} size={8} />
+      <NativeControlGlyph
+        color={theme.color.accent}
+        size={8}
+        variant="status"
+      />
       <Text style={styles.processingText}>
         {label?.trim() || t("processing")}
       </Text>
@@ -473,10 +483,11 @@ function MobileTurnSummaryRow({
       >
         <View style={styles.disclosureHeaderLine}>
           <Text style={styles.summaryTitle}>{label}</Text>
-          <MobileChevronGlyph
+          <NativeControlGlyph
             color={theme.color.muted}
             direction={expanded ? "up" : "down"}
             size={16}
+            variant="chevron"
           />
         </View>
       </Pressable>
@@ -484,7 +495,11 @@ function MobileTurnSummaryRow({
         <View style={styles.fileList}>
           {row.files.map((file) => (
             <View key={file.messageId} style={styles.fileRow}>
-              <MobileStatusDotGlyph color={theme.color.muted} size={6} />
+              <NativeControlGlyph
+                color={theme.color.muted}
+                size={6}
+                variant="status"
+              />
               <Text numberOfLines={1} style={styles.fileName}>
                 {file.label}
               </Text>

--- a/apps/mobile/src/dev/NativeComponentGallery.tsx
+++ b/apps/mobile/src/dev/NativeComponentGallery.tsx
@@ -1,6 +1,7 @@
 import {
   NativeAvatar,
   NativeButton,
+  NativeControlGlyph,
   NativeIconButton,
   NativeListRow,
   NativeProgressBar,
@@ -114,6 +115,32 @@ export function NativeComponentGallery({ onClose }: { onClose(): void }) {
               icon={<Text style={styles.moreIcon}>⋯</Text>}
               onPress={() => undefined}
             />
+          </View>
+        </GallerySection>
+
+        <GallerySection title="native-control-glyph">
+          <View style={styles.glyphGrid}>
+            {(["add", "back", "send", "status", "stop"] as const).map(
+              (variant) => (
+                <View key={variant} style={styles.glyphPreview}>
+                  <NativeControlGlyph
+                    color={theme.color.text}
+                    variant={variant}
+                  />
+                  <Text style={styles.galleryStateLabel}>{variant}</Text>
+                </View>
+              )
+            )}
+            {(["down", "left", "right", "up"] as const).map((direction) => (
+              <View key={direction} style={styles.glyphPreview}>
+                <NativeControlGlyph
+                  color={theme.color.text}
+                  direction={direction}
+                  variant="chevron"
+                />
+                <Text style={styles.galleryStateLabel}>{direction}</Text>
+              </View>
+            ))}
           </View>
         </GallerySection>
 
@@ -236,6 +263,16 @@ function createStyles(theme: NativeTheme) {
     galleryStateLabel: {
       color: theme.color.muted,
       fontSize: theme.space.small
+    },
+    glyphGrid: {
+      flexDirection: "row",
+      flexWrap: "wrap",
+      gap: theme.space.medium
+    },
+    glyphPreview: {
+      alignItems: "center",
+      gap: theme.space.small / 2,
+      minWidth: theme.control.regular
     },
     inline: { flexDirection: "row", gap: theme.space.small },
     moreIcon: {

--- a/apps/mobile/src/screens/ConversationScreenView.tsx
+++ b/apps/mobile/src/screens/ConversationScreenView.tsx
@@ -6,6 +6,7 @@ import { resolveAgentConversationNavigationAction } from "@tutti-os/agent-gui/co
 import { createAgentConversationFollowEndController } from "@tutti-os/agent-gui/agent-conversation/follow-end";
 import {
   NativeButton,
+  NativeControlGlyph,
   NativeIconButton,
   type NativeTheme,
   useNativeTheme
@@ -13,7 +14,6 @@ import {
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Linking, ScrollView, StyleSheet, Text, View } from "react-native";
 import { MobileComposerDock } from "../components/MobileComposerDock";
-import { MobileBackGlyph } from "../components/MobileControlGlyphs";
 import { MobileConversationInteractionDock } from "../components/MobileConversationInteractionDock";
 import { MobileConversationTimeline } from "../components/MobileConversationTimeline";
 import {
@@ -28,6 +28,11 @@ import { t } from "../i18n";
 import type { WorkspaceActivitySnapshot } from "../services/workspaceActivityService";
 import type { WorkspaceMediaSnapshot } from "../services/workspaceMediaService";
 import type { MobileQuickPromptLibrarySnapshot } from "../services/mobileQuickPromptLibraryService";
+import {
+  conversationDistanceFromBottom,
+  initialConversationScrollGeometry,
+  updateConversationScrollGeometry
+} from "./conversationScrollGeometry";
 import { createConversationScrollScheduler } from "./conversationScrollScheduler";
 
 export function ConversationScreenView({
@@ -82,9 +87,7 @@ export function ConversationScreenView({
     createAgentConversationFollowEndController()
   );
   const followEndController = followEndControllerRef.current;
-  const lastScrollOffsetY = useRef(0);
-  const contentHeight = useRef(0);
-  const viewportHeight = useRef(0);
+  const scrollGeometry = useRef(initialConversationScrollGeometry);
   const scrollScheduler = useRef<
     ReturnType<typeof createConversationScrollScheduler> | undefined
   >(undefined);
@@ -107,9 +110,10 @@ export function ConversationScreenView({
 
   useEffect(() => {
     followEndController.dispatch("conversation-changed");
-    lastScrollOffsetY.current = 0;
-    contentHeight.current = 0;
-    viewportHeight.current = 0;
+    scrollGeometry.current = updateConversationScrollGeometry(
+      scrollGeometry.current,
+      { type: "conversation-changed" }
+    );
     setShowScrollToBottom(false);
     scheduleScrollToBottom(false, "auto-follow");
     return () => scrollScheduler.current?.cancel();
@@ -152,7 +156,13 @@ export function ConversationScreenView({
           <NativeIconButton
             accessibilityLabel={t("sessions")}
             onPress={onBack}
-            icon={<MobileBackGlyph color={theme.color.text} size={20} />}
+            icon={
+              <NativeControlGlyph
+                color={theme.color.text}
+                size={20}
+                variant="back"
+              />
+            }
             style={styles.headerCircleButton}
             variant="ghost"
           />
@@ -205,13 +215,22 @@ export function ConversationScreenView({
             keyboardShouldPersistTaps="handled"
             maintainVisibleContentPosition={{ minIndexForVisible: 0 }}
             onContentSizeChange={(_width, height) => {
-              contentHeight.current = height;
+              scrollGeometry.current = updateConversationScrollGeometry(
+                scrollGeometry.current,
+                { height, type: "content-size-changed" }
+              );
               if (followEndController.getSnapshot() === "following") {
                 scheduleScrollToBottom(false, "auto-follow");
               }
             }}
             onLayout={({ nativeEvent }) => {
-              viewportHeight.current = nativeEvent.layout.height;
+              scrollGeometry.current = updateConversationScrollGeometry(
+                scrollGeometry.current,
+                {
+                  height: nativeEvent.layout.height,
+                  type: "layout-changed"
+                }
+              );
               if (followEndController.getSnapshot() === "following") {
                 scheduleScrollToBottom(false, "auto-follow");
               }
@@ -233,8 +252,16 @@ export function ConversationScreenView({
                 nativeEvent.layoutMeasurement.height -
                 nativeEvent.contentOffset.y;
               const scrollingTowardEnd =
-                nativeEvent.contentOffset.y > lastScrollOffsetY.current;
-              lastScrollOffsetY.current = nativeEvent.contentOffset.y;
+                nativeEvent.contentOffset.y > scrollGeometry.current.offsetY;
+              scrollGeometry.current = updateConversationScrollGeometry(
+                scrollGeometry.current,
+                {
+                  contentHeight: nativeEvent.contentSize.height,
+                  offsetY: nativeEvent.contentOffset.y,
+                  type: "scrolled",
+                  viewportHeight: nativeEvent.layoutMeasurement.height
+                }
+              );
               if (
                 followEndController.getSnapshot() === "detached" &&
                 scrollingTowardEnd &&
@@ -247,10 +274,9 @@ export function ConversationScreenView({
               );
             }}
             onTouchStart={() => {
-              const distanceFromBottom =
-                contentHeight.current -
-                viewportHeight.current -
-                lastScrollOffsetY.current;
+              const distanceFromBottom = conversationDistanceFromBottom(
+                scrollGeometry.current
+              );
               if (distanceFromBottom > 48) {
                 scrollScheduler.current?.cancel();
                 followEndController.dispatch("user-scrolled-away");

--- a/apps/mobile/src/screens/conversationScrollGeometry.test.ts
+++ b/apps/mobile/src/screens/conversationScrollGeometry.test.ts
@@ -1,0 +1,48 @@
+import {
+  conversationDistanceFromBottom,
+  initialConversationScrollGeometry,
+  updateConversationScrollGeometry
+} from "./conversationScrollGeometry";
+
+test("preserves measured native geometry across conversation changes", () => {
+  const measured = [
+    { height: 1_800, type: "content-size-changed" as const },
+    { height: 600, type: "layout-changed" as const },
+    {
+      contentHeight: 1_800,
+      offsetY: 1_200,
+      type: "scrolled" as const,
+      viewportHeight: 600
+    }
+  ].reduce(updateConversationScrollGeometry, initialConversationScrollGeometry);
+
+  const switched = updateConversationScrollGeometry(measured, {
+    type: "conversation-changed"
+  });
+
+  expect(switched).toBe(measured);
+  expect(conversationDistanceFromBottom(switched)).toBe(0);
+});
+
+test("uses replacement native measurements after a conversation changes", () => {
+  const measured = {
+    contentHeight: 1_800,
+    offsetY: 1_200,
+    viewportHeight: 600
+  };
+  const switched = updateConversationScrollGeometry(measured, {
+    type: "conversation-changed"
+  });
+  const resized = updateConversationScrollGeometry(switched, {
+    height: 2_400,
+    type: "content-size-changed"
+  });
+  const scrolled = updateConversationScrollGeometry(resized, {
+    contentHeight: 2_400,
+    offsetY: 1_800,
+    type: "scrolled",
+    viewportHeight: 600
+  });
+
+  expect(conversationDistanceFromBottom(scrolled)).toBe(0);
+});

--- a/apps/mobile/src/screens/conversationScrollGeometry.ts
+++ b/apps/mobile/src/screens/conversationScrollGeometry.ts
@@ -1,0 +1,51 @@
+export interface ConversationScrollGeometry {
+  contentHeight: number;
+  offsetY: number;
+  viewportHeight: number;
+}
+
+export type ConversationScrollGeometryEvent =
+  | { type: "content-size-changed"; height: number }
+  | { type: "conversation-changed" }
+  | { type: "layout-changed"; height: number }
+  | {
+      type: "scrolled";
+      contentHeight: number;
+      offsetY: number;
+      viewportHeight: number;
+    };
+
+export const initialConversationScrollGeometry: ConversationScrollGeometry = {
+  contentHeight: 0,
+  offsetY: 0,
+  viewportHeight: 0
+};
+
+export function updateConversationScrollGeometry(
+  geometry: ConversationScrollGeometry,
+  event: ConversationScrollGeometryEvent
+): ConversationScrollGeometry {
+  switch (event.type) {
+    case "content-size-changed":
+      return { ...geometry, contentHeight: event.height };
+    case "conversation-changed":
+      // The same native ScrollView remains mounted and may not emit onLayout
+      // again. Preserve its last measured viewport and current geometry until
+      // native content-size and scroll events replace the values.
+      return geometry;
+    case "layout-changed":
+      return { ...geometry, viewportHeight: event.height };
+    case "scrolled":
+      return {
+        contentHeight: event.contentHeight,
+        offsetY: event.offsetY,
+        viewportHeight: event.viewportHeight
+      };
+  }
+}
+
+export function conversationDistanceFromBottom(
+  geometry: ConversationScrollGeometry
+): number {
+  return geometry.contentHeight - geometry.viewportHeight - geometry.offsetY;
+}

--- a/packages/ui/system/src/metadata/components.json
+++ b/packages/ui/system/src/metadata/components.json
@@ -3534,6 +3534,27 @@
       "nativePreview": true
     },
     {
+      "id": "native-control-glyph",
+      "layer": "base",
+      "name": "NativeControlGlyph",
+      "export": "NativeControlGlyph",
+      "from": "@tutti-os/ui-system/native",
+      "category": "icon",
+      "status": "experimental",
+      "source": "src/native/control-glyph.tsx",
+      "propsType": "NativeControlGlyphProps",
+      "description": "Decorative add, back, chevron, send, status, and stop glyph variants for React Native controls.",
+      "useCases": [
+        "Native icon buttons",
+        "Disclosure affordances",
+        "Compact status indicators"
+      ],
+      "migrationHints": [
+        "Keep the glyph decorative and provide the localized accessible name on its owning control."
+      ],
+      "nativePreview": true
+    },
+    {
       "id": "native-progress-bar",
       "layer": "base",
       "name": "NativeProgressBar",

--- a/packages/ui/system/src/native/control-glyph.tsx
+++ b/packages/ui/system/src/native/control-glyph.tsx
@@ -1,12 +1,60 @@
 import type { ReactNode } from "react";
 import { View } from "react-native";
 
-interface MobileControlGlyphProps {
+export type NativeControlGlyphVariant =
+  | "add"
+  | "back"
+  | "chevron"
+  | "send"
+  | "status"
+  | "stop";
+
+interface NativeControlGlyphBaseProps {
   color: string;
   size?: number;
 }
 
-export function MobileAddGlyph({ color, size = 20 }: MobileControlGlyphProps) {
+interface NativeGlyphRenderProps {
+  color: string;
+  size: number;
+}
+
+export type NativeControlGlyphProps = NativeControlGlyphBaseProps &
+  (
+    | {
+        direction: "down" | "left" | "right" | "up";
+        variant: "chevron";
+      }
+    | {
+        direction?: never;
+        variant: Exclude<NativeControlGlyphVariant, "chevron">;
+      }
+  );
+
+export function NativeControlGlyph(props: NativeControlGlyphProps) {
+  switch (props.variant) {
+    case "add":
+      return <AddGlyph color={props.color} size={props.size ?? 20} />;
+    case "back":
+      return <BackGlyph color={props.color} size={props.size ?? 20} />;
+    case "chevron":
+      return (
+        <ChevronGlyph
+          color={props.color}
+          direction={props.direction}
+          size={props.size ?? 18}
+        />
+      );
+    case "send":
+      return <SendGlyph color={props.color} size={props.size ?? 20} />;
+    case "status":
+      return <StatusGlyph color={props.color} size={props.size ?? 8} />;
+    case "stop":
+      return <StopGlyph color={props.color} size={props.size ?? 20} />;
+  }
+}
+
+function AddGlyph({ color, size }: NativeGlyphRenderProps) {
   const stroke = Math.max(2, size * 0.1);
   return (
     <GlyphFrame size={size}>
@@ -36,7 +84,7 @@ export function MobileAddGlyph({ color, size = 20 }: MobileControlGlyphProps) {
   );
 }
 
-export function MobileBackGlyph({ color, size = 20 }: MobileControlGlyphProps) {
+function BackGlyph({ color, size }: NativeGlyphRenderProps) {
   const stroke = Math.max(2, size * 0.1);
   const wing = size * 0.38;
   return (
@@ -80,11 +128,11 @@ export function MobileBackGlyph({ color, size = 20 }: MobileControlGlyphProps) {
   );
 }
 
-export function MobileChevronGlyph({
+function ChevronGlyph({
   color,
   direction,
-  size = 18
-}: MobileControlGlyphProps & {
+  size
+}: NativeGlyphRenderProps & {
   direction: "down" | "left" | "right" | "up";
 }) {
   const stroke = Math.max(2, size * 0.11);
@@ -129,7 +177,7 @@ export function MobileChevronGlyph({
   );
 }
 
-export function MobileSendGlyph({ color, size = 20 }: MobileControlGlyphProps) {
+function SendGlyph({ color, size }: NativeGlyphRenderProps) {
   const stroke = Math.max(2, size * 0.1);
   return (
     <GlyphFrame size={size}>
@@ -172,7 +220,22 @@ export function MobileSendGlyph({ color, size = 20 }: MobileControlGlyphProps) {
   );
 }
 
-export function MobileStopGlyph({ color, size = 20 }: MobileControlGlyphProps) {
+function StatusGlyph({ color, size }: NativeGlyphRenderProps) {
+  return (
+    <View
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+      style={{
+        backgroundColor: color,
+        borderRadius: size / 2,
+        height: size,
+        width: size
+      }}
+    />
+  );
+}
+
+function StopGlyph({ color, size }: NativeGlyphRenderProps) {
   const square = size * 0.48;
   return (
     <GlyphFrame size={size}>
@@ -188,24 +251,6 @@ export function MobileStopGlyph({ color, size = 20 }: MobileControlGlyphProps) {
         }}
       />
     </GlyphFrame>
-  );
-}
-
-export function MobileStatusDotGlyph({
-  color,
-  size = 8
-}: MobileControlGlyphProps) {
-  return (
-    <View
-      accessibilityElementsHidden
-      importantForAccessibility="no-hide-descendants"
-      style={{
-        backgroundColor: color,
-        borderRadius: size / 2,
-        height: size,
-        width: size
-      }}
-    />
   );
 }
 

--- a/packages/ui/system/src/native/index.ts
+++ b/packages/ui/system/src/native/index.ts
@@ -9,6 +9,11 @@ export {
   type ButtonSize,
   type ButtonVariant
 } from "./button";
+export {
+  NativeControlGlyph,
+  type NativeControlGlyphProps,
+  type NativeControlGlyphVariant
+} from "./control-glyph";
 export { NativeIconButton, type NativeIconButtonProps } from "./icon-button";
 export { NativeListRow, type NativeListRowProps } from "./list-row";
 export { NativeProgressBar, type NativeProgressBarProps } from "./progress-bar";

--- a/packages/ui/system/ui-system.md
+++ b/packages/ui/system/ui-system.md
@@ -79,6 +79,12 @@ determinate values to the inclusive zero-to-one range, exposes progressbar
 accessibility semantics, and accepts `null` for an indeterminate task. Product
 phase labels, byte counts, cancellation, and workflow state stay caller-owned.
 
+`NativeControlGlyph` is the decorative React Native control-glyph primitive.
+Its finite variants cover add, back, chevron, send, status, and stop shapes;
+callers supply the semantic token color and keep the localized accessible name
+on the owning control. Chevron direction is explicit, and glyph content remains
+hidden from the accessibility tree.
+
 ## Current Package Role
 
 `@tutti-os/ui-system` is the single source of truth for:


### PR DESCRIPTION
## 背景

PR #2200 合入后，review 留下两个 follow-up：通用 Native 控制 Glyph 应归属 UI System；会话切换时不应清空仍由同一 ScrollView 持有的测量 geometry。

## 变更

- 将 add/back/chevron/send/status/stop 收敛为 `@tutti-os/ui-system/native` 的 `NativeControlGlyph` base primitive
- 使用有限 variant 和 chevron direction 判别联合，保留原像素公式与无障碍隐藏语义
- 补 stable export、UI System metadata、Native development gallery 和 durable docs
- 迁移 Mobile 会话 Header、Timeline、Composer、设置 Sheet，并删除 app-local glyph module
- 将会话滚动 geometry 收敛为显式状态更新；`conversation-changed` 保留测量值
- `onScroll` 同步 authoritative content height、viewport height、offset
- 补会话切换 geometry 回归测试

## 边界

- 不修改会话列表
- 不修改 service、engine、Host、DTO、权限或 Interaction lifecycle
- 不改变会话详情视觉与业务路径；Glyph promotion 保持像素等价

## 验证

- `pnpm --filter @tutti-os/ui-system typecheck`
- `pnpm --filter @tutti-os/ui-system test`：6 files / 33 tests
- `pnpm --filter @tutti-os/mobile typecheck`
- `pnpm --filter @tutti-os/mobile test`：35 suites / 193 tests
- `node tools/scripts/check-ui-metadata.mjs`
- `pnpm check:ui-boundaries`
- `pnpm --filter @tutti-os/ui-storyboard typecheck`
- `pnpm check:changed`：11 lanes
- pre-push `pnpm check:changed -- --push-ready`：12 lanes
- independent UI System promotion gate：PASS，无 blocker / major / minor

## Review 对应

- Follow-up to #2200
- [通用 Mobile glyph 应归属 UI System](https://github.com/tutti-os/tutti/pull/2200#discussion_r3742175071)
- [会话切换应保留 ScrollView 测量 geometry](https://github.com/tutti-os/tutti/pull/2200#discussion_r3742175072)
