### PR TITLE
Support bounded cross-version Agent live protocol compatibility

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -28,8 +28,8 @@ permissions:
   id-token: write
 
 concurrency:
-  group: ${{ inputs.publish_android && 'mobile-android-release-publish' || format('mobile-internal-build-{0}-{1}', inputs.platform, github.ref) }}
-  cancel-in-progress: ${{ !inputs.publish_android }}
+  group: ${{ (inputs.publish_android || inputs.platform == 'ios' || inputs.platform == 'all') && 'agent-live-release-publish' || format('mobile-internal-build-{0}-{1}', inputs.platform, github.ref) }}
+  cancel-in-progress: ${{ !inputs.publish_android && inputs.platform == 'android' }}
 
 jobs:
   android:
@@ -163,12 +163,14 @@ jobs:
         env:
           AWS_REGION: ${{ vars.AWS_REGION }}
           TUTTI_ARTIFACTS_AWS_ROLE_ARN: ${{ vars.TUTTI_ARTIFACTS_AWS_ROLE_ARN }}
+          TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET: ${{ vars.TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET }}
+          TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX: ${{ vars.TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX }}
           TUTTI_MOBILE_RELEASE_ASSETS_BASE_URL: ${{ vars.TUTTI_MOBILE_RELEASE_ASSETS_BASE_URL }}
           TUTTI_MOBILE_RELEASE_ASSETS_S3_BUCKET: ${{ vars.TUTTI_MOBILE_RELEASE_ASSETS_S3_BUCKET }}
           TUTTI_MOBILE_RELEASE_ASSETS_S3_PREFIX: ${{ vars.TUTTI_MOBILE_RELEASE_ASSETS_S3_PREFIX }}
           TUTTI_ANDROID_VERSION_NAME: ${{ inputs.android_version_name }}
         run: |
-          for name in AWS_REGION TUTTI_ARTIFACTS_AWS_ROLE_ARN TUTTI_MOBILE_RELEASE_ASSETS_BASE_URL TUTTI_MOBILE_RELEASE_ASSETS_S3_BUCKET TUTTI_MOBILE_RELEASE_ASSETS_S3_PREFIX; do
+          for name in AWS_REGION TUTTI_ARTIFACTS_AWS_ROLE_ARN TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX TUTTI_MOBILE_RELEASE_ASSETS_BASE_URL TUTTI_MOBILE_RELEASE_ASSETS_S3_BUCKET TUTTI_MOBILE_RELEASE_ASSETS_S3_PREFIX; do
             if [[ -z "${!name:-}" ]]; then
               echo "Missing required Android release publishing variable: ${name}" >&2
               exit 1
@@ -200,6 +202,20 @@ jobs:
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: ${{ vars.TUTTI_ARTIFACTS_AWS_ROLE_ARN }}
+
+      - name: Verify Desktop RC compatibility for Android release
+        if: inputs.publish_android && (inputs.platform == 'android' || inputs.platform == 'all')
+        env:
+          TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET: ${{ vars.TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET }}
+          TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX: ${{ vars.TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX }}
+        run: |
+          desktop_prefix="${TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX%/}"
+          aws s3 cp \
+            "s3://${TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET}/${desktop_prefix}/channels/rc/latest.json" \
+            current-desktop-rc-release-pointer.json
+          node tools/scripts/agent-live-release-compatibility.mjs \
+            --desktop current-desktop-rc-release-pointer.json \
+            --mobile mobile-release-latest.json
 
       - name: Prevent Android release rollback
         if: inputs.publish_android && (inputs.platform == 'android' || inputs.platform == 'all')
@@ -330,7 +346,8 @@ jobs:
 
   ios:
     name: Build and upload iOS TestFlight
-    if: inputs.platform == 'ios' || inputs.platform == 'all'
+    needs: android
+    if: ${{ always() && (inputs.platform == 'ios' || inputs.platform == 'all') && (inputs.platform != 'all' || needs.android.result == 'success') }}
     runs-on: macos-26
     timeout-minutes: 60
 
@@ -390,8 +407,50 @@ jobs:
           echo "APPLE_API_KEY_PATH=${private_key_path}" >> "${GITHUB_ENV}"
           echo "IOS_DEVELOPMENT_TEAM=${IOS_DEVELOPMENT_TEAM}" >> "${GITHUB_ENV}"
 
+      - name: Validate iOS release compatibility configuration
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          TUTTI_ARTIFACTS_AWS_ROLE_ARN: ${{ vars.TUTTI_ARTIFACTS_AWS_ROLE_ARN }}
+          TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET: ${{ vars.TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET }}
+          TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX: ${{ vars.TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX }}
+          TUTTI_MOBILE_RELEASE_ASSETS_S3_BUCKET: ${{ vars.TUTTI_MOBILE_RELEASE_ASSETS_S3_BUCKET }}
+          TUTTI_MOBILE_RELEASE_ASSETS_S3_PREFIX: ${{ vars.TUTTI_MOBILE_RELEASE_ASSETS_S3_PREFIX }}
+        run: |
+          for name in AWS_REGION TUTTI_ARTIFACTS_AWS_ROLE_ARN TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX TUTTI_MOBILE_RELEASE_ASSETS_S3_BUCKET TUTTI_MOBILE_RELEASE_ASSETS_S3_PREFIX; do
+            if [[ -z "${!name:-}" ]]; then
+              echo "Missing required iOS release compatibility variable: ${name}" >&2
+              exit 1
+            fi
+          done
+
+      - name: Configure AWS credentials for iOS release
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: ${{ vars.TUTTI_ARTIFACTS_AWS_ROLE_ARN }}
+
       - name: Build iOS framework and install pods
         run: pnpm --filter @tutti-os/mobile ios:pods
+
+      - name: Verify Desktop RC compatibility for iOS release
+        env:
+          TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET: ${{ vars.TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET }}
+          TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX: ${{ vars.TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX }}
+          TUTTI_MOBILE_RELEASE_ASSETS_S3_BUCKET: ${{ vars.TUTTI_MOBILE_RELEASE_ASSETS_S3_BUCKET }}
+          TUTTI_MOBILE_RELEASE_ASSETS_S3_PREFIX: ${{ vars.TUTTI_MOBILE_RELEASE_ASSETS_S3_PREFIX }}
+        run: |
+          desktop_prefix="${TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX%/}"
+          mobile_prefix="${TUTTI_MOBILE_RELEASE_ASSETS_S3_PREFIX%/}"
+          aws s3 cp \
+            "s3://${TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET}/${desktop_prefix}/channels/rc/latest.json" \
+            current-desktop-rc-release-pointer.json
+          aws s3 cp \
+            "s3://${TUTTI_MOBILE_RELEASE_ASSETS_S3_BUCKET}/${mobile_prefix}/latest.json" \
+            current-mobile-release-pointer.json
+          node tools/scripts/agent-live-release-compatibility.mjs \
+            --desktop current-desktop-rc-release-pointer.json \
+            --mobile-generated \
+            --released-mobile current-mobile-release-pointer.json
 
       - name: Archive iOS app
         shell: bash

--- a/.github/workflows/desktop-release-promote.yml
+++ b/.github/workflows/desktop-release-promote.yml
@@ -51,7 +51,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: desktop-release-promotion
+  group: ${{ (inputs.expected_channel == 'rc' || contains(inputs.release_tag, '-rc.')) && 'agent-live-release-publish' || 'desktop-release-promotion' }}
   cancel-in-progress: false
 
 env:
@@ -189,6 +189,8 @@ jobs:
       TUTTI_DESKTOP_RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
       TUTTI_DESKTOP_RELEASE_TARGET: ${{ needs.resolve.outputs.release_target }}
       TUTTI_DESKTOP_RELEASE_VERSION: ${{ needs.resolve.outputs.release_version }}
+      TUTTI_MOBILE_RELEASE_ASSETS_S3_BUCKET: ${{ vars.TUTTI_MOBILE_RELEASE_ASSETS_S3_BUCKET }}
+      TUTTI_MOBILE_RELEASE_ASSETS_S3_PREFIX: ${{ vars.TUTTI_MOBILE_RELEASE_ASSETS_S3_PREFIX }}
 
     steps:
       - name: Checkout release target
@@ -276,6 +278,13 @@ jobs:
               missing+=("$name")
             fi
           done
+          if [[ "${TUTTI_DESKTOP_RELEASE_CHANNEL}" == "rc" ]]; then
+            for name in TUTTI_MOBILE_RELEASE_ASSETS_S3_BUCKET TUTTI_MOBILE_RELEASE_ASSETS_S3_PREFIX; do
+              if [[ -z "${!name:-}" ]]; then
+                missing+=("$name")
+              fi
+            done
+          fi
           if (( ${#missing[@]} > 0 )); then
             echo "Missing required AWS S3 release asset configuration: ${missing[*]}" >&2
             exit 1
@@ -401,6 +410,17 @@ jobs:
         run: |
           export RELEASE_ASSET_BASE_URL="${TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL}"
           node apps/desktop/scripts/build-release-latest.mjs release-assets release-latest.json
+
+      - name: Verify Mobile compatibility for Desktop RC
+        if: ${{ needs.resolve.outputs.release_channel == 'rc' }}
+        run: |
+          mobile_prefix="${TUTTI_MOBILE_RELEASE_ASSETS_S3_PREFIX%/}"
+          aws s3 cp \
+            "s3://${TUTTI_MOBILE_RELEASE_ASSETS_S3_BUCKET}/${mobile_prefix}/latest.json" \
+            current-mobile-release-pointer.json
+          node tools/scripts/agent-live-release-compatibility.mjs \
+            --desktop release-latest.json \
+            --mobile current-mobile-release-pointer.json
 
       - name: Update stable changelog metadata
         if: ${{ needs.resolve.outputs.release_channel == 'stable' }}

--- a/apps/desktop/scripts/build-release-latest.mjs
+++ b/apps/desktop/scripts/build-release-latest.mjs
@@ -3,6 +3,7 @@
 import { readdir, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { loadGeneratedAgentLiveProtocol } from "../../../tools/scripts/agent-live-release-compatibility.mjs";
 
 const schemaVersion = "tutti.desktop.release.latest.v1";
 
@@ -172,6 +173,8 @@ async function buildDesktopReleaseLatest(options) {
     options.releasedAt instanceof Date
       ? options.releasedAt.toISOString()
       : String(options.releasedAt ?? new Date().toISOString()).trim();
+  const agentLiveProtocol =
+    channel === "rc" ? await loadGeneratedAgentLiveProtocol() : null;
 
   const entries = await readdir(assetDirPath, { withFileTypes: true });
   const assetNames = entries
@@ -195,6 +198,7 @@ async function buildDesktopReleaseLatest(options) {
   const windowsX64Exe = assets.find(isWindowsX64Exe)?.url ?? null;
 
   return {
+    ...(agentLiveProtocol ? { agentLiveProtocol } : {}),
     schemaVersion,
     tag: releaseTag,
     version: releaseVersion,

--- a/apps/mobile/android/Makefile
+++ b/apps/mobile/android/Makefile
@@ -15,7 +15,8 @@ android-bindings-check:
 	trap 'rm -rf "$$bind_tmp"' EXIT; \
 	cd "$(DEVICE_LINK_DIR)" && $(GOMOBILE_GO) tool gobind -lang=java -javapkg=$(JAVA_PACKAGE) -outdir="$$bind_tmp" ./mobile ../agent/daemon/liveprotocol/mobile; \
 	test -f "$$bind_tmp/java/sh/tutti/mobile/bindings/mobile/Mobile.java"; \
-	test -f "$$bind_tmp/java/sh/tutti/mobile/bindings/liveprotocolmobile/Liveprotocolmobile.java"
+	test -f "$$bind_tmp/java/sh/tutti/mobile/bindings/liveprotocolmobile/Liveprotocolmobile.java"; \
+	grep -Fq 'newSubscriberForRevision' "$$bind_tmp/java/sh/tutti/mobile/bindings/liveprotocolmobile/Liveprotocolmobile.java"
 
 android-aar:
 	@test -n "$(ANDROID_HOME)" || (echo "ANDROID_HOME is required" >&2; exit 1)

--- a/apps/mobile/android/app/src/main/java/sh/tutti/mobile/DeviceLinkModule.kt
+++ b/apps/mobile/android/app/src/main/java/sh/tutti/mobile/DeviceLinkModule.kt
@@ -279,6 +279,7 @@ class DeviceLinkModule(
     fun startAgentLive(
         workspaceId: String,
         subscriptionGeneration: Double,
+        protocolRevision: String,
         promise: Promise,
     ) {
         val normalizedWorkspaceId = workspaceId.trim()
@@ -297,6 +298,14 @@ class DeviceLinkModule(
             promise.reject(
                 "AGENT_LIVE_SUBSCRIBE_FAILED",
                 "Agent live subscription generation must be a positive integer",
+            )
+            return
+        }
+        val normalizedProtocolRevision = protocolRevision.trim()
+        if (normalizedProtocolRevision.isEmpty()) {
+            promise.reject(
+                "AGENT_LIVE_SUBSCRIBE_FAILED",
+                "Agent live protocol revision is required",
             )
             return
         }
@@ -323,13 +332,18 @@ class DeviceLinkModule(
                     check(promoteAgentLiveStream(stream, generation)) {
                         "Agent live subscription was cancelled"
                     }
-                    val subscriber = Liveprotocolmobile.newSubscriber(0, 0)
+                    val subscriber =
+                        Liveprotocolmobile.newSubscriberForRevision(
+                            normalizedProtocolRevision,
+                            0,
+                            0,
+                        )
                     val requestID = UUID.randomUUID().toString()
                     val subscription =
                         JSONObject()
                             .put(
                                 "protocolRevision",
-                                Liveprotocolmobile.protocolRevision(),
+                                normalizedProtocolRevision,
                             ).put("workspaceId", normalizedWorkspaceId)
                             .toString()
                             .toByteArray(StandardCharsets.UTF_8)

--- a/apps/mobile/ios/Makefile
+++ b/apps/mobile/ios/Makefile
@@ -15,7 +15,8 @@ ios-bindings-check:
 	test -f "$$bind_tmp/src/gobind/$(OBJC_PREFIX)Mobile.objc.h"; \
 	test -f "$$bind_tmp/src/gobind/$(OBJC_PREFIX)Liveprotocolmobile.objc.h"; \
 	grep -Fq 'TUTMobileNewLink' "$$bind_tmp/src/gobind/$(OBJC_PREFIX)Mobile.objc.h"; \
-	grep -Fq 'TUTLiveprotocolmobileNewSubscriber' "$$bind_tmp/src/gobind/$(OBJC_PREFIX)Liveprotocolmobile.objc.h"
+	grep -Fq 'TUTLiveprotocolmobileNewSubscriber' "$$bind_tmp/src/gobind/$(OBJC_PREFIX)Liveprotocolmobile.objc.h"; \
+	grep -Fq 'TUTLiveprotocolmobileNewSubscriberForRevision' "$$bind_tmp/src/gobind/$(OBJC_PREFIX)Liveprotocolmobile.objc.h"
 
 ios-framework:
 	@xcode_path=$$(xcode-select -p 2>/dev/null); \

--- a/apps/mobile/ios/TuttiMobile/DeviceLinkModule.mm
+++ b/apps/mobile/ios/TuttiMobile/DeviceLinkModule.mm
@@ -316,6 +316,7 @@ RCT_REMAP_METHOD(requestAgentHTTP,
 RCT_REMAP_METHOD(startAgentLive,
                  startAgentLive:(NSString *)workspaceID
                  subscriptionGeneration:(nonnull NSNumber *)subscriptionGeneration
+                 protocolRevision:(NSString *)protocolRevision
                  resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
   NSString *normalized =
@@ -332,6 +333,14 @@ RCT_REMAP_METHOD(startAgentLive,
     reject(@"AGENT_LIVE_SUBSCRIBE_FAILED",
            @"Agent live subscription generation must be a positive integer",
            nil);
+    return;
+  }
+  NSString *normalizedProtocolRevision =
+      [protocolRevision stringByTrimmingCharactersInSet:
+                            [NSCharacterSet whitespaceAndNewlineCharacterSet]];
+  if (normalizedProtocolRevision.length == 0) {
+    reject(@"AGENT_LIVE_SUBSCRIBE_FAILED",
+           @"Agent live protocol revision is required", nil);
     return;
   }
   TUTMobileLink *selected = [self linkSnapshot];
@@ -360,7 +369,8 @@ RCT_REMAP_METHOD(startAgentLive,
     }
 
     TUTLiveprotocolmobileSubscriber *subscriber =
-        TUTLiveprotocolmobileNewSubscriber(0, 0, &error);
+        TUTLiveprotocolmobileNewSubscriberForRevision(
+            normalizedProtocolRevision, 0, 0, &error);
     if (subscriber == nil || error != nil) {
       [self clearAgentLiveStream:stream generation:generation];
       [self closeDetachedStream:stream];
@@ -369,7 +379,7 @@ RCT_REMAP_METHOD(startAgentLive,
       return;
     }
     NSDictionary *subscription = @{
-      @"protocolRevision" : TUTLiveprotocolmobileProtocolRevision(),
+      @"protocolRevision" : normalizedProtocolRevision,
       @"workspaceId" : normalized,
     };
     NSData *subscriptionData = TUTJSONData(subscription, &error);

--- a/apps/mobile/src/native/createMobileServicePorts.ts
+++ b/apps/mobile/src/native/createMobileServicePorts.ts
@@ -1,4 +1,5 @@
 import { DeviceEventEmitter, NativeEventEmitter } from "react-native";
+import { AGENT_ACTIVITY_LIVE_PROTOCOL_REVISION } from "@tutti-os/agent-activity-core";
 import { createAppLifecyclePort } from "./appLifecyclePort";
 import { appLifecycle, deviceLink, mobileSecurity } from "./mobileNative";
 import { signInWithBrowser } from "../services/accountClient";
@@ -43,7 +44,7 @@ export function createMobileServicePorts(): MobileServicePorts {
       closeLink: () => deviceLink.closeLink(),
       requestAgentHTTP: (method, path, body, timeoutMillis) =>
         deviceLink.requestAgentHTTP(method, path, body, timeoutMillis),
-      subscribeAgentLive(workspaceId, listener) {
+      subscribeAgentLive(workspaceId, listener, protocolRevision) {
         let active = true;
         const subscriptionGeneration = ++nextAgentLiveSubscriptionGeneration;
         const subscription = DeviceEventEmitter.addListener(
@@ -60,7 +61,11 @@ export function createMobileServicePorts(): MobileServicePorts {
           }
         );
         void deviceLink
-          .startAgentLive(workspaceId, subscriptionGeneration)
+          .startAgentLive(
+            workspaceId,
+            subscriptionGeneration,
+            protocolRevision ?? AGENT_ACTIVITY_LIVE_PROTOCOL_REVISION
+          )
           .catch(() => {
             if (active) {
               listener({

--- a/apps/mobile/src/native/mobileNative.ts
+++ b/apps/mobile/src/native/mobileNative.ts
@@ -90,7 +90,8 @@ interface DeviceLinkNative {
   runLoopbackProbe(timeoutMillis: number): Promise<string>;
   startAgentLive(
     workspaceId: string,
-    subscriptionGeneration: number
+    subscriptionGeneration: number,
+    protocolRevision: string
   ): Promise<void>;
   stopAgentLive(): Promise<void>;
 }

--- a/apps/mobile/src/services/mobileApplicationService.test.ts
+++ b/apps/mobile/src/services/mobileApplicationService.test.ts
@@ -3,6 +3,7 @@ import type {
   WorkspaceSummary
 } from "@tutti-os/client-tuttid-ts";
 import { InstantiationService } from "@tutti-os/infra/di";
+import { AGENT_ACTIVITY_LIVE_PROTOCOL_REVISION } from "@tutti-os/agent-activity-core";
 import type { AccountSession } from "./mobileDomain";
 import { MobileApplicationService } from "./mobileApplicationService";
 import type {
@@ -192,6 +193,81 @@ describe("MobileApplicationService scopes", () => {
     });
     expect(harness.closeCalls).toBe(0);
     expect(harness.connectCalls).toBe(1);
+  });
+
+  test("falls back once to an accepted Desktop Agent live revision", async () => {
+    const harness = createHarness(session, [workspace], {
+      agentLiveDeliveriesOnSubscribe: [
+        {
+          expectedRevision: "sha256:7101e69f2559036c",
+          kind: "connection",
+          reason: "protocol_revision_mismatch",
+          receivedRevision: AGENT_ACTIVITY_LIVE_PROTOCOL_REVISION,
+          retryable: false,
+          status: "disconnected"
+        }
+      ]
+    });
+    const service = new MobileApplicationService(
+      new InstantiationService(),
+      harness.ports
+    );
+    await service.start();
+    await service.deviceService!.connect(pairing);
+
+    expect(harness.subscribedProtocolRevisions).toEqual([
+      AGENT_ACTIVITY_LIVE_PROTOCOL_REVISION,
+      "sha256:7101e69f2559036c"
+    ]);
+    expect(service.getSnapshot()).toMatchObject({
+      connection: { phase: "synchronizing" }
+    });
+
+    harness.emitAgentLiveConnection("connected");
+    expect(service.getSnapshot()).toMatchObject({
+      connection: { phase: "connected" }
+    });
+
+    harness.emitLifecycle("background");
+    harness.clock.advanceBy(1_000);
+    harness.emitLifecycle("foreground");
+    await flushPromises();
+    expect(harness.subscribedProtocolRevisions).toEqual([
+      AGENT_ACTIVITY_LIVE_PROTOCOL_REVISION,
+      "sha256:7101e69f2559036c",
+      "sha256:7101e69f2559036c"
+    ]);
+  });
+
+  test("does not loop when the fallback Agent live revision is rejected", async () => {
+    const rejection: AgentLiveDelivery = {
+      expectedRevision: "sha256:7101e69f2559036c",
+      kind: "connection",
+      reason: "protocol_revision_mismatch",
+      receivedRevision: AGENT_ACTIVITY_LIVE_PROTOCOL_REVISION,
+      retryable: false,
+      status: "disconnected"
+    };
+    const harness = createHarness(session, [workspace], {
+      agentLiveDeliveriesOnSubscribe: [rejection, rejection]
+    });
+    const service = new MobileApplicationService(
+      new InstantiationService(),
+      harness.ports
+    );
+    await service.start();
+    await service.deviceService!.connect(pairing);
+
+    expect(harness.subscribeCalls).toBe(2);
+    expect(service.getSnapshot()).toMatchObject({
+      connection: {
+        expectedRevision: "sha256:7101e69f2559036c",
+        phase: "failed",
+        reasonCode: "protocol_revision_mismatch"
+      }
+    });
+    harness.clock.advanceBy(30_000);
+    expect(harness.subscribeCalls).toBe(2);
   });
 
   test("preserves a synchronous protocol rejection during workspace startup", async () => {
@@ -454,6 +530,7 @@ function createHarness(
   registerCalls: number;
   requestCalls: number;
   subscribeCalls: number;
+  subscribedProtocolRevisions: Array<string | undefined>;
   subscriptionCloseCalls: number;
 } {
   const clock = new ManualClock();
@@ -512,6 +589,7 @@ function createHarness(
     ports: null as unknown as MobileServicePorts,
     requestCalls: 0,
     subscribeCalls: 0,
+    subscribedProtocolRevisions: [] as Array<string | undefined>,
     subscriptionCloseCalls: 0
   };
   harness.ports = {
@@ -560,8 +638,9 @@ function createHarness(
           status: 204
         };
       },
-      subscribeAgentLive: (_workspaceId, listener) => {
+      subscribeAgentLive: (_workspaceId, listener, protocolRevision) => {
         harness.subscribeCalls += 1;
+        harness.subscribedProtocolRevisions.push(protocolRevision);
         liveListener = listener;
         const delivery = agentLiveDeliveriesOnSubscribe.shift();
         if (delivery) listener(delivery);

--- a/apps/mobile/src/services/servicePorts.ts
+++ b/apps/mobile/src/services/servicePorts.ts
@@ -61,7 +61,8 @@ export interface DeviceLinkPort {
   }>;
   subscribeAgentLive(
     workspaceId: string,
-    listener: (delivery: AgentLiveDelivery) => void
+    listener: (delivery: AgentLiveDelivery) => void,
+    protocolRevision?: string
   ): { close(): void };
 }
 

--- a/apps/mobile/src/services/workspaceAgentLiveLane.ts
+++ b/apps/mobile/src/services/workspaceAgentLiveLane.ts
@@ -1,4 +1,6 @@
 import {
+  AGENT_ACTIVITY_LIVE_ACCEPTED_PROTOCOL_REVISIONS,
+  AGENT_ACTIVITY_LIVE_PROTOCOL_REVISION,
   createAgentActivityWorkspaceEventCoordinator,
   type AgentActivityDurableMessage,
   type AgentActivityLiveEvent,
@@ -45,6 +47,9 @@ export class WorkspaceAgentLiveLane {
   private railReconcileTask: { cancel(): void } | null = null;
   private subscription: { close(): void } | null = null;
   private subscriptionGeneration = 0;
+  private requestedProtocolRevision: string =
+    AGENT_ACTIVITY_LIVE_PROTOCOL_REVISION;
+  private revisionFallbackAttempted = false;
   // Mobile currently opens every native stream from epoch/sequence zero, so
   // this projection has the same lifetime as the subscription. A future
   // persisted resume cursor must persist this fence with it.
@@ -73,7 +78,8 @@ export class WorkspaceAgentLiveLane {
       (delivery) => {
         if (subscriptionGeneration !== this.subscriptionGeneration) return;
         this.handleDelivery(delivery);
-      }
+      },
+      this.requestedProtocolRevision
     );
     if (
       subscriptionGeneration !== this.subscriptionGeneration ||
@@ -153,10 +159,17 @@ export class WorkspaceAgentLiveLane {
         this.setConnected(true);
         return;
       }
+      const fallbackRevision = this.resolveFallbackRevision(delivery);
       this.subscriptionGeneration += 1;
       this.subscription?.close();
       this.subscription = null;
       this.attachmentFence = null;
+      if (fallbackRevision) {
+        this.requestedProtocolRevision = fallbackRevision;
+        this.revisionFallbackAttempted = true;
+        this.start();
+        return;
+      }
       this.coordinator.eventStreamConnectionChanged({
         status: "disconnected"
       });
@@ -206,6 +219,26 @@ export class WorkspaceAgentLiveLane {
       return;
     }
     this.applyEvent(delivery.event);
+  }
+
+  private resolveFallbackRevision(
+    delivery: Extract<
+      AgentLiveDelivery,
+      { kind: "connection"; status: "disconnected" }
+    >
+  ): string | null {
+    if (
+      this.revisionFallbackAttempted ||
+      delivery.reason !== "protocol_revision_mismatch" ||
+      !delivery.expectedRevision ||
+      delivery.expectedRevision === this.requestedProtocolRevision ||
+      !AGENT_ACTIVITY_LIVE_ACCEPTED_PROTOCOL_REVISIONS.some(
+        (revision) => revision === delivery.expectedRevision
+      )
+    ) {
+      return null;
+    }
+    return delivery.expectedRevision;
   }
 
   private handleAttachmentChanged(

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -1278,8 +1278,32 @@ Session, and Turn identity fields. Opaque business values remain
 `json.RawMessage`, including file paths and large JSON integers, so transport
 does not sanitize or reinterpret renderer data. The exact protocol revision
 covers the event schema, protobuf field numbers, delivery-kind values, and JSON
-control shapes. A revision mismatch is an explicit rejection followed by
-canonical reconciliation; it is not a compatibility conversion path.
+control shapes. The generated compatibility contract distinguishes the current
+revision from an explicit, bounded set of historical dialects. A Publisher and
+Subscriber remain strict about the exact revision selected for one stream;
+supporting a historical revision never means relabeling a current frame.
+Instead, each historical revision has a named projection profile and historical
+wire fixtures captured from the published implementation. Codec validation
+also enforces the selected profile, so a caller cannot bypass Publisher
+projection by attaching a historical revision to a current-only semantic.
+Revisions or profiles without an implemented handler remain explicit typed
+rejections.
+
+The paired-device handshake deliberately remains scalar. Mobile requests its
+current revision first. If an older Desktop rejects it with the existing typed
+`expectedRevision`, Mobile may reopen the stream exactly once when that exact
+historical dialect is locally accepted. A newer Desktop directly accepts an
+older Mobile's requested dialect. This provides rolling compatibility without
+min/max ordering or a capability matrix. Compatibility preserves connection,
+continuity, and every semantic already defined by the selected historical
+dialect; it does not promise that a newer product feature exists on an older
+client. The `sha256:7101e69f2559036c` profile therefore projects
+`session_restored` as an ordinary canonical-update reconcile hint. That old
+Mobile cannot clear an existing deletion tombstone until it upgrades and
+receives the explicit newer restore semantic.
+Mobile retains a successfully selected historical revision across ordinary
+pause/resume and stream reconnects; constructing a new Workspace lane starts a
+new negotiation from current.
 
 `StreamReady` is transport-only and must not be interpreted as canonical
 catch-up. `AttachmentChanged` starts a baseline for one positive attachment
@@ -1338,8 +1362,9 @@ message/reconcile variants into scoped discontinuities, and preserves an
 explicit `session_deleted` or `session_restored` reason plus Session reconcile
 key for the Mobile adapter to normalize into the shared coordinator's lifecycle
 path. Those semantic reasons participate in
-`AGENT_ACTIVITY_LIVE_PROTOCOL_REVISION`; mismatched builds are rejected instead
-of silently degrading deletion or restore into an ordinary reconcile. The
+`AGENT_ACTIVITY_LIVE_PROTOCOL_REVISION`; an accepted historical profile must
+explicitly define any lossy projection instead of silently inheriting current
+semantics. The
 adapter establishes the workspace subscription before publishing
 `stream_ready`, so events produced during ready-frame delivery are already
 buffered instead of falling through a subscribe gap. The Android

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -316,6 +316,18 @@ https://<asset-base-url>/channels/beta/latest.json
 
 `preview` is the user-facing name for the RC channel. RC releases write both `channels/preview/latest.json` and `channels/rc/latest.json`. Beta releases write only `channels/beta/latest.json`.
 
+The RC pointer includes the generated Agent live `currentRevision` and exact
+`acceptedRevisions`. Before an RC pointer is replaced, promotion downloads the
+Mobile `latest.json` directly from its authoritative S3 location and requires
+that the two scalar-handshake paths are
+reachable: the Desktop candidate accepts Mobile current directly, or Mobile
+accepts Desktop current for its one typed-rejection fallback. This gate is RC
+specific; stable and beta pointers do not receive Agent live metadata. Desktop
+RC, published Android, and TestFlight workflows share one repository release
+lock so neither side can validate a stale pair while the other mutates it. The
+pre-metadata `v0.2.21-rc.0` and Mobile `0.1.8` pointers are recognized only by
+their exact one-time bootstrap entries.
+
 The packaged desktop updater consumes the stable and RC pointer contracts. Before
 each update check it reads `latest.json` for the stable channel or
 `channels/rc/latest.json` for the RC channel, validates the schema, expected

--- a/docs/conventions/static-analysis.md
+++ b/docs/conventions/static-analysis.md
@@ -542,13 +542,33 @@ binding surface as an XCFramework, archives the React Native app, and uses the
 repository App Store Connect API key plus the `IOS_DEVELOPMENT_TEAM` repository
 variable for Xcode-managed cloud signing. It loads the Mobile Podfile's pnpm
 path compatibility shim before generating the Pods project, combines the GitHub
-Actions run number and attempt as the unique iOS build number, exports an App
-Store Connect IPA, verifies that the signed app contains its release
+Actions run number and attempt as the unique iOS build number, and verifies the
+generated Mobile Agent live protocol against the current Desktop RC pointer
+before archiving. The generated iOS protocol must also exactly match the
+published Android pointer, which remains the single Mobile protocol state used
+by later Desktop RC gates. It then exports an App Store Connect IPA, verifies
+that the signed app contains its release
 `main.jsbundle`, and uploads the archive to TestFlight without registering test
 device UDIDs. The exported IPA and checksum remain available as a 14-day private
 validation artifact rather than creating a GitHub Release. Both jobs remain
 manual so pull request code does not receive mobile signing credentials
 automatically.
+
+Published Android and Desktop RC pointers carry the generated Agent live
+`currentRevision` and exact `acceptedRevisions`. Before replacing either mutable
+pointer, the release workflow reads the other product's authoritative S3
+pointer and
+checks the scalar-handshake reachability rule: Desktop must accept Mobile's
+current revision, or Mobile must accept Desktop's current revision. An
+arbitrary third historical revision in both lists is insufficient because the
+typed fallback advertises only the server's current revision. The exact
+pre-metadata Mobile `0.1.8` and Desktop `0.2.21-rc.0` pointers have bounded
+bootstrap entries; every later pointer must publish protocol metadata and fails
+closed when it is absent. The bootstrap file itself selects both tool-contract
+tests and the generated Agent live check, and its loader rejects any additional
+release kind or tag. Desktop RC, Android publication, and TestFlight share one
+release concurrency group. Stable and beta Desktop pointers do not carry this
+RC-specific metadata.
 
 Local runs resolve `golangci-lint` from `$(go env GOPATH)/bin` first and fall
 back to `PATH`. This matches the repository install command without requiring a

--- a/docs/conventions/troubleshooting/mobile.md
+++ b/docs/conventions/troubleshooting/mobile.md
@@ -1,6 +1,6 @@
 # Mobile Troubleshooting
 
-## Android stays on “Syncing the latest data” after pairing
+## Mobile stays on “Syncing the latest data” after pairing
 
 - **Symptom:** Device pairing and the direct DeviceLink handshake succeed, but
   the mobile App remains on **Syncing the latest data**. The native log repeats
@@ -10,28 +10,35 @@
   rejection reports `protocol_revision_mismatch`, compare the safe
   `expectedRevision` and `receivedRevision` hashes. This is a protocol
   compatibility failure, not a local-network or pairing failure.
-- **Root cause:** The computer rejects an Agent live subscription whose protocol
-  revision does not match its own. If the native rejection is collapsed into a
-  generic disconnect, the live lane treats a deterministic incompatibility as
-  transient and retries forever. Repeated disconnect callbacks can also keep
-  replacing the connection-ready deadline, so the App never reaches a visible
-  failed state.
+- **Root cause:** The computer rejects an Agent live subscription whose exact
+  revision is neither current nor one of its explicit historical dialects. If
+  the native rejection is collapsed into a generic disconnect, the live lane
+  treats a deterministic incompatibility as transient and retries forever.
+  Repeated disconnect callbacks can also keep replacing the connection-ready
+  deadline, so the App never reaches a visible failed state.
 - **Fix:** Preserve the typed rejection reason and revision hashes through the
-  native bridge. Classify `protocol_revision_mismatch` as terminal for the
-  current connection attempt, close the rejected subscription without
-  scheduling another live retry, and keep the original synchronization
-  deadline for retryable transport failures. Present an explicit incompatible
-  version message with a mobile update action; do not automatically restart a
-  terminal attempt after foreground resume.
+  native bridge. When `expectedRevision` names an accepted historical dialect,
+  close the rejected stream and reopen it exactly once with that revision.
+  Cache the selected revision for ordinary reconnects and foreground resumes;
+  create a new negotiation only with a new Workspace lane. An unknown revision or
+  a rejection after fallback is terminal: schedule no further live retry and
+  present the incompatible-version recovery surface. Historical dialects
+  preserve old semantics only; for example, the `7101` dialect cannot deliver
+  the newer explicit Session-restore semantic.
 - **Validation:** Verify an ordinary stream close still retries and rebuilds
   DeviceLink after the recovery grace period. Inject a protocol-revision
-  rejection and assert that the connection enters the failed state once, emits
-  a `device_connection.phase_changed` diagnostic with stable
-  `protocol_revision_mismatch`, preserves both revision hashes, schedules no
-  additional subscription, and stays terminal across background and foreground
-  transitions. Confirm the failure UI offers **Check for updates** instead of
-  **Reconnect**.
+  rejection for `7101` and assert that Mobile performs one successful fallback
+  without publishing a terminal connection failure. Reject that fallback a
+  second time and assert that the connection enters the failed state once,
+  preserves both revision hashes, schedules no additional subscription, and
+  stays terminal across background and foreground transitions. An unsupported
+  revision must fail immediately. After a successful fallback, background and
+  foreground the App and assert that the next subscription requests `7101`
+  directly. Confirm the failure UI offers **Check for
+  updates** instead of **Reconnect**.
 - **References:** `apps/mobile/src/native/agentLiveNativeBridge.ts`,
+  `apps/mobile/android/app/src/main/java/sh/tutti/mobile/DeviceLinkModule.kt`,
+  `apps/mobile/ios/TuttiMobile/DeviceLinkModule.mm`,
   `apps/mobile/src/services/workspaceAgentLiveLane.ts`,
   `apps/mobile/src/services/mobileApplicationService.ts`,
   `apps/mobile/src/components/MobileConnectionRecoveryOverlay.tsx`

--- a/packages/agent/activity-core/src/index.ts
+++ b/packages/agent/activity-core/src/index.ts
@@ -1,5 +1,8 @@
 export type { AgentActivityAdapter } from "./adapter.ts";
-export { AGENT_ACTIVITY_LIVE_PROTOCOL_REVISION } from "./liveProtocolRevision.gen.ts";
+export {
+  AGENT_ACTIVITY_LIVE_ACCEPTED_PROTOCOL_REVISIONS,
+  AGENT_ACTIVITY_LIVE_PROTOCOL_REVISION
+} from "./liveProtocolRevision.gen.ts";
 export { parseAgentActivityGoalControlText } from "./goalControl.ts";
 export type { AgentActivityLiveEvent } from "./liveEvent.types.ts";
 export type { AgentActivityComposerModelConfiguration } from "./composerModelConfiguration.types.ts";

--- a/packages/agent/activity-core/src/liveProtocolRevision.gen.ts
+++ b/packages/agent/activity-core/src/liveProtocolRevision.gen.ts
@@ -2,3 +2,8 @@
 
 export const AGENT_ACTIVITY_LIVE_PROTOCOL_REVISION =
   "sha256:b29022aba44d33cb" as const;
+
+export const AGENT_ACTIVITY_LIVE_ACCEPTED_PROTOCOL_REVISIONS = [
+  "sha256:b29022aba44d33cb",
+  "sha256:7101e69f2559036c"
+] as const;

--- a/packages/agent/daemon/liveprotocol/codec.go
+++ b/packages/agent/daemon/liveprotocol/codec.go
@@ -281,9 +281,12 @@ func validateFrame(frame Frame) error {
 			return ErrSequenceGap
 		}
 		previous = delivery.Seq
+		if delivery.StreamReady != nil && delivery.StreamReady.ProtocolRevision != frame.ProtocolRevision {
+			return ErrInvalidFrame
+		}
 	}
-	if frame.ProtocolRevision != ProtocolRevision && !isTypedRejectionFrame(frame) {
-		return fmt.Errorf("%w: got %q want %q", ErrProtocolMismatch, frame.ProtocolRevision, ProtocolRevision)
+	if err := validateFrameForProtocolDialect(frame); err != nil {
+		return fmt.Errorf("%w: frame violates %q dialect", err, frame.ProtocolRevision)
 	}
 	return nil
 }
@@ -347,7 +350,7 @@ func validateDelivery(delivery Delivery) error {
 	case DeliveryKindStreamReady:
 		count = boolCount(delivery.StreamReady != nil)
 		if delivery.StreamReady != nil &&
-			(delivery.StreamReady.ProtocolRevision != ProtocolRevision ||
+			(strings.TrimSpace(delivery.StreamReady.ProtocolRevision) == "" ||
 				strings.TrimSpace(delivery.StreamReady.StreamID) == "" ||
 				strings.TrimSpace(delivery.StreamReady.BindingID) == "") {
 			return ErrInvalidFrame

--- a/packages/agent/daemon/liveprotocol/dialect.go
+++ b/packages/agent/daemon/liveprotocol/dialect.go
@@ -1,0 +1,92 @@
+package liveprotocol
+
+import "strings"
+
+type protocolDialectDescriptor struct {
+	Revision string
+	Profile  string
+}
+
+// AcceptedProtocolRevisions returns exact dialect revisions that this build
+// can safely speak. Historical revisions preserve their existing semantics;
+// newer-only semantics may be downgraded by the matching profile.
+func AcceptedProtocolRevisions() []string {
+	revisions := make([]string, 0, len(generatedProtocolDialects))
+	for _, dialect := range generatedProtocolDialects {
+		revisions = append(revisions, dialect.Revision)
+	}
+	return revisions
+}
+
+func SupportsProtocolRevision(revision string) bool {
+	dialect, ok := protocolDialectForRevision(revision)
+	return ok && supportsProtocolDialectProfile(dialect.Profile)
+}
+
+func protocolDialectForRevision(revision string) (protocolDialectDescriptor, bool) {
+	normalized := strings.TrimSpace(revision)
+	if normalized != revision {
+		return protocolDialectDescriptor{}, false
+	}
+	for _, dialect := range generatedProtocolDialects {
+		if dialect.Revision == normalized {
+			return dialect, true
+		}
+	}
+	return protocolDialectDescriptor{}, false
+}
+
+func projectPublishInputForRevision(revision string, input PublishInput) (PublishInput, error) {
+	dialect, ok := protocolDialectForRevision(revision)
+	if !ok {
+		return PublishInput{}, ErrProtocolMismatch
+	}
+	switch dialect.Profile {
+	case protocolDialectProfileCurrent:
+		return input, nil
+	case protocolDialectProfilePreSessionRestored:
+		if input.Discontinuity == nil ||
+			strings.TrimSpace(input.Discontinuity.Reason) != "session_restored" {
+			return input, nil
+		}
+		discontinuity := *input.Discontinuity
+		discontinuity.Reason = "canonical_update"
+		input.Discontinuity = &discontinuity
+		return input, nil
+	default:
+		return PublishInput{}, ErrProtocolMismatch
+	}
+}
+
+func validateFrameForProtocolDialect(frame Frame) error {
+	if isTypedRejectionFrame(frame) {
+		return nil
+	}
+	dialect, ok := protocolDialectForRevision(frame.ProtocolRevision)
+	if !ok {
+		return ErrProtocolMismatch
+	}
+	switch dialect.Profile {
+	case protocolDialectProfileCurrent:
+		return nil
+	case protocolDialectProfilePreSessionRestored:
+		for _, delivery := range frame.Deliveries {
+			if delivery.Discontinuity != nil &&
+				strings.TrimSpace(delivery.Discontinuity.Reason) == "session_restored" {
+				return ErrProtocolMismatch
+			}
+		}
+		return nil
+	default:
+		return ErrProtocolMismatch
+	}
+}
+
+func supportsProtocolDialectProfile(profile string) bool {
+	switch profile {
+	case protocolDialectProfileCurrent, protocolDialectProfilePreSessionRestored:
+		return true
+	default:
+		return false
+	}
+}

--- a/packages/agent/daemon/liveprotocol/dialect_test.go
+++ b/packages/agent/daemon/liveprotocol/dialect_test.go
@@ -1,0 +1,259 @@
+package liveprotocol
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"slices"
+	"testing"
+)
+
+const legacyProtocolRevision7101 = "sha256:7101e69f2559036c"
+
+const (
+	historical7101EventFrame              = "0a177368613235363a37313031653639663235353930333663120d6c65676163792d73747265616d1a0962696e64696e672d3120072af701080110011af0017b22776f726b73706163654964223a22776f726b73706163652d31222c226167656e7453657373696f6e4964223a2273657373696f6e2d31222c226576656e7454797065223a2272756e74696d655f61637469766974795f757064617465222c2264617461223a7b22776f726b73706163654964223a22776f726b73706163652d31222c226167656e7453657373696f6e4964223a2273657373696f6e2d31222c226576656e7454797065223a2272756e74696d655f61637469766974795f757064617465222c227374617465223a2272756e6e696e67222c226f636375727265644174556e69784d73223a34327d7d"
+	historical7101DiscontinuityFrame      = "0a177368613235363a37313031653639663235353930333663120d6c65676163792d73747265616d1a0962696e64696e672d3120072a810108011002227b7b22726561736f6e223a2263616e6f6e6963616c5f757064617465222c227265636f6e63696c654b657973223a5b7b226b696e64223a2273657373696f6e222c22776f726b73706163654964223a22776f726b73706163652d31222c226167656e7453657373696f6e4964223a2273657373696f6e2d31227d5d7d"
+	historical7101UnprojectedRestoreFrame = "0a177368613235363a37313031653639663235353930333663120d6c65676163792d73747265616d1a0962696e64696e672d3120072a810108011002227b7b22726561736f6e223a2273657373696f6e5f726573746f726564222c227265636f6e63696c654b657973223a5b7b226b696e64223a2273657373696f6e222c22776f726b73706163654964223a22776f726b73706163652d31222c226167656e7453657373696f6e4964223a2273657373696f6e2d31227d5d7d"
+)
+
+func TestAcceptedProtocolRevisionsAreExplicit(t *testing.T) {
+	t.Parallel()
+	want := []string{ProtocolRevision, legacyProtocolRevision7101}
+	if got := AcceptedProtocolRevisions(); !slices.Equal(got, want) {
+		t.Fatalf("accepted revisions = %v, want %v", got, want)
+	}
+	if !SupportsProtocolRevision(legacyProtocolRevision7101) {
+		t.Fatal("legacy revision must be accepted")
+	}
+	if SupportsProtocolRevision("sha256:0000000000000000") {
+		t.Fatal("unknown revision must not be accepted")
+	}
+}
+
+func TestLegacyDialectDowngradesSessionRestore(t *testing.T) {
+	t.Parallel()
+	publisher, err := NewPublisher(PublisherConfig{
+		ProtocolRevision: legacyProtocolRevision7101,
+		StreamID:         "stream-1",
+		BindingID:        "binding-1",
+		Epoch:            1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	frames, err := publisher.Publish(PublishInput{
+		Discontinuity: &Discontinuity{
+			Reason: "session_restored",
+			ReconcileKeys: []ReconcileKey{{
+				Kind:           "session",
+				WorkspaceID:    "workspace-1",
+				AgentSessionID: "session-1",
+			}},
+		},
+		Immediate: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(frames) != 1 || frames[0].ProtocolRevision != legacyProtocolRevision7101 ||
+		len(frames[0].Deliveries) != 1 ||
+		frames[0].Deliveries[0].Discontinuity == nil ||
+		frames[0].Deliveries[0].Discontinuity.Reason != "canonical_update" {
+		t.Fatalf("legacy restore projection = %#v", frames)
+	}
+	encoded, err := EncodeFrame(frames[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	subscriber, err := NewSubscriber(SubscriberConfig{ProtocolRevision: legacyProtocolRevision7101})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := DecodeAndApply(subscriber, encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.ReconcileRequired || result.Reason != "canonical_update" {
+		t.Fatalf("legacy apply result = %#v", result)
+	}
+}
+
+func TestLegacyDialectRejectsUnprojectedSessionRestoreFrame(t *testing.T) {
+	t.Parallel()
+	frame := Frame{
+		ProtocolRevision: legacyProtocolRevision7101,
+		StreamID:         "legacy-stream",
+		BindingID:        "binding-1",
+		Epoch:            7,
+		Deliveries: []Delivery{{
+			Seq:  1,
+			Kind: DeliveryKindDiscontinuity,
+			Discontinuity: &Discontinuity{
+				Reason: "session_restored",
+				ReconcileKeys: []ReconcileKey{{
+					Kind:           "session",
+					WorkspaceID:    "workspace-1",
+					AgentSessionID: "session-1",
+				}},
+			},
+		}},
+	}
+	if _, err := EncodeFrame(frame); !errors.Is(err, ErrProtocolMismatch) {
+		t.Fatalf("encode error = %v, want %v", err, ErrProtocolMismatch)
+	}
+	raw, err := hex.DecodeString(historical7101UnprojectedRestoreFrame)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := DecodeFrame(raw); !errors.Is(err, ErrProtocolMismatch) {
+		t.Fatalf("decode error = %v, want %v", err, ErrProtocolMismatch)
+	}
+}
+
+func TestHistorical7101PublishedFixturesRemainStable(t *testing.T) {
+	t.Parallel()
+	event := Event{
+		WorkspaceID:    "workspace-1",
+		AgentSessionID: "session-1",
+		EventType:      EventTypeRuntimeActivityUpdate,
+		Data:           json.RawMessage(`{"workspaceId":"workspace-1","agentSessionId":"session-1","eventType":"runtime_activity_update","state":"running","occurredAtUnixMs":42}`),
+	}
+	tests := []struct {
+		name    string
+		input   PublishInput
+		fixture string
+		kind    DeliveryKind
+	}{
+		{
+			name:    "event",
+			input:   PublishInput{Event: &event, Immediate: true},
+			fixture: historical7101EventFrame,
+			kind:    DeliveryKindEvent,
+		},
+		{
+			name: "discontinuity",
+			input: PublishInput{
+				Discontinuity: &Discontinuity{
+					Reason: "canonical_update",
+					ReconcileKeys: []ReconcileKey{{
+						Kind:           "session",
+						WorkspaceID:    "workspace-1",
+						AgentSessionID: "session-1",
+					}},
+				},
+				Immediate: true,
+			},
+			fixture: historical7101DiscontinuityFrame,
+			kind:    DeliveryKindDiscontinuity,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := hex.DecodeString(tt.fixture)
+			if err != nil {
+				t.Fatal(err)
+			}
+			decoded, err := DecodeFrame(raw)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if decoded.ProtocolRevision != legacyProtocolRevision7101 ||
+				len(decoded.Deliveries) != 1 || decoded.Deliveries[0].Kind != tt.kind {
+				t.Fatalf("decoded historical frame = %#v", decoded)
+			}
+			publisher, err := NewPublisher(PublisherConfig{
+				ProtocolRevision: legacyProtocolRevision7101,
+				StreamID:         "legacy-stream",
+				BindingID:        "binding-1",
+				Epoch:            7,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			frames, err := publisher.Publish(tt.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			encoded, err := EncodeFrame(frames[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := hex.EncodeToString(encoded); got != tt.fixture {
+				t.Fatalf("historical output = %s, want %s", got, tt.fixture)
+			}
+		})
+	}
+}
+
+func TestUnknownDialectProfileFailsClosed(t *testing.T) {
+	t.Parallel()
+	for _, dialect := range generatedProtocolDialects {
+		if !supportsProtocolDialectProfile(dialect.Profile) {
+			t.Fatalf("generated dialect has no implementation: %#v", dialect)
+		}
+	}
+	if supportsProtocolDialectProfile("future-unimplemented") {
+		t.Fatal("unknown profile must not be supported")
+	}
+}
+
+func TestPublisherRejectsUnknownDialect(t *testing.T) {
+	t.Parallel()
+	_, err := NewPublisher(PublisherConfig{
+		ProtocolRevision: "sha256:0000000000000000",
+		StreamID:         "stream-1",
+		BindingID:        "binding-1",
+		Epoch:            1,
+	})
+	if !errors.Is(err, ErrProtocolMismatch) {
+		t.Fatalf("publisher error = %v, want %v", err, ErrProtocolMismatch)
+	}
+}
+
+func TestStreamReadyRevisionMustMatchOuterFrame(t *testing.T) {
+	t.Parallel()
+	_, err := EncodeFrame(Frame{
+		ProtocolRevision: legacyProtocolRevision7101,
+		StreamID:         "stream-1",
+		BindingID:        "binding-1",
+		Epoch:            1,
+		Deliveries: []Delivery{{
+			Seq:  1,
+			Kind: DeliveryKindStreamReady,
+			StreamReady: &StreamReady{
+				ProtocolRevision: ProtocolRevision,
+				StreamID:         "stream-1",
+				BindingID:        "binding-1",
+			},
+		}},
+	})
+	if !errors.Is(err, ErrInvalidFrame) {
+		t.Fatalf("encode error = %v, want %v", err, ErrInvalidFrame)
+	}
+}
+
+func TestHistorical7101StreamReadyGoldenFrame(t *testing.T) {
+	t.Parallel()
+	encoded, err := EncodeFrame(Frame{
+		ProtocolRevision: legacyProtocolRevision7101,
+		StreamID:         "legacy-stream",
+		BindingID:        "binding-1",
+		Epoch:            1,
+		Deliveries: []Delivery{{
+			Seq:  1,
+			Kind: DeliveryKindStreamReady,
+			StreamReady: &StreamReady{
+				ProtocolRevision: legacyProtocolRevision7101,
+				StreamID:         "legacy-stream",
+				BindingID:        "binding-1",
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const golden = "0a177368613235363a37313031653639663235353930333663120d6c65676163792d73747265616d1a0962696e64696e672d3120012a67080110053a617b2270726f746f636f6c5265766973696f6e223a227368613235363a37313031653639663235353930333663222c2273747265616d4964223a226c65676163792d73747265616d222c2262696e64696e674964223a2262696e64696e672d31227d"
+	if got := hex.EncodeToString(encoded); got != golden {
+		t.Fatalf("historical 7101 frame = %s", got)
+	}
+}

--- a/packages/agent/daemon/liveprotocol/mobile/subscriber.go
+++ b/packages/agent/daemon/liveprotocol/mobile/subscriber.go
@@ -39,12 +39,17 @@ func ProtocolRevision() string {
 }
 
 func NewSubscriber(epoch int64, afterSeq int64) (*Subscriber, error) {
+	return NewSubscriberForRevision(liveprotocol.ProtocolRevision, epoch, afterSeq)
+}
+
+func NewSubscriberForRevision(revision string, epoch int64, afterSeq int64) (*Subscriber, error) {
 	if epoch < 0 || afterSeq < 0 {
 		return nil, fmt.Errorf("agent live resume cursor must not be negative")
 	}
 	subscriber, err := liveprotocol.NewSubscriber(liveprotocol.SubscriberConfig{
-		Epoch:    uint64(epoch),
-		AfterSeq: uint64(afterSeq),
+		ProtocolRevision: revision,
+		Epoch:            uint64(epoch),
+		AfterSeq:         uint64(afterSeq),
 	})
 	if err != nil {
 		return nil, err

--- a/packages/agent/daemon/liveprotocol/mobile/subscriber_test.go
+++ b/packages/agent/daemon/liveprotocol/mobile/subscriber_test.go
@@ -1,6 +1,7 @@
 package liveprotocolmobile
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"testing"
 
@@ -162,5 +163,31 @@ func TestSubscriberReportsSequenceGap(t *testing.T) {
 	if !decoded.ReconcileRequired || decoded.Reason != "sequence_gap" ||
 		decoded.AfterSeq != 0 || len(decoded.Accepted) != 0 {
 		t.Fatalf("unexpected gap result: %+v", decoded)
+	}
+}
+
+func TestSubscriberSupportsExplicitHistoricalRevision(t *testing.T) {
+	t.Parallel()
+	const revision = "sha256:7101e69f2559036c"
+	const published7101EventFrame = "0a177368613235363a37313031653639663235353930333663120d6c65676163792d73747265616d1a0962696e64696e672d3120072af701080110011af0017b22776f726b73706163654964223a22776f726b73706163652d31222c226167656e7453657373696f6e4964223a2273657373696f6e2d31222c226576656e7454797065223a2272756e74696d655f61637469766974795f757064617465222c2264617461223a7b22776f726b73706163654964223a22776f726b73706163652d31222c226167656e7453657373696f6e4964223a2273657373696f6e2d31222c226576656e7454797065223a2272756e74696d655f61637469766974795f757064617465222c227374617465223a2272756e6e696e67222c226f636375727265644174556e69784d73223a34327d7d"
+	subscriber, err := NewSubscriberForRevision(revision, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := hex.DecodeString(published7101EventFrame)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := subscriber.Apply(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded applyEnvelope
+	if err := json.Unmarshal([]byte(result), &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded.Accepted) != 1 || decoded.Accepted[0].Kind != "event" ||
+		len(decoded.Accepted[0].Event) == 0 {
+		t.Fatalf("historical delivery = %+v", decoded)
 	}
 }

--- a/packages/agent/daemon/liveprotocol/protocol_compatibility.gen.json
+++ b/packages/agent/daemon/liveprotocol/protocol_compatibility.gen.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": "tutti.agent-live.compatibility.v1",
+  "currentRevision": "sha256:b29022aba44d33cb",
+  "acceptedRevisions": ["sha256:b29022aba44d33cb", "sha256:7101e69f2559036c"],
+  "dialects": [
+    {
+      "revision": "sha256:b29022aba44d33cb",
+      "profile": "current"
+    },
+    {
+      "revision": "sha256:7101e69f2559036c",
+      "profile": "pre-session-restored"
+    }
+  ]
+}

--- a/packages/agent/daemon/liveprotocol/protocol_revision.gen.go
+++ b/packages/agent/daemon/liveprotocol/protocol_revision.gen.go
@@ -4,6 +4,16 @@ package liveprotocol
 
 const ProtocolRevision = "sha256:b29022aba44d33cb"
 
+const (
+	protocolDialectProfileCurrent            = "current"
+	protocolDialectProfilePreSessionRestored = "pre-session-restored"
+)
+
+var generatedProtocolDialects = [...]protocolDialectDescriptor{
+	{Revision: "sha256:b29022aba44d33cb", Profile: "current"},
+	{Revision: "sha256:7101e69f2559036c", Profile: "pre-session-restored"},
+}
+
 // Protobuf-wire field numbers and delivery kinds are generated from
 // schema/agent-activity-live-wire-contract.json. They participate in
 // ProtocolRevision and must not be edited independently.

--- a/packages/agent/daemon/liveprotocol/publisher.go
+++ b/packages/agent/daemon/liveprotocol/publisher.go
@@ -34,6 +34,9 @@ type Publisher struct {
 
 func NewPublisher(config PublisherConfig) (*Publisher, error) {
 	applyPublisherDefaults(&config)
+	if !SupportsProtocolRevision(config.ProtocolRevision) {
+		return nil, ErrProtocolMismatch
+	}
 	if strings.TrimSpace(config.StreamID) == "" || strings.TrimSpace(config.BindingID) == "" || config.Epoch == 0 {
 		return nil, fmt.Errorf("%w: publisher identity", ErrInvalidFrame)
 	}
@@ -47,6 +50,10 @@ func (p *Publisher) Publish(input PublishInput) ([]Frame, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
+	input, err := projectPublishInputForRevision(p.config.ProtocolRevision, input)
+	if err != nil {
+		return nil, err
+	}
 	delivery, size, err := deliveryFromInput(input)
 	if err != nil {
 		return nil, err
@@ -231,7 +238,7 @@ func (p *Publisher) replayFramesLocked(entries []replayEntry) ([]Frame, error) {
 		limit = DefaultFrameMaxBytes
 	}
 	base := Frame{
-		ProtocolRevision: ProtocolRevision,
+		ProtocolRevision: p.config.ProtocolRevision,
 		StreamID:         p.config.StreamID,
 		BindingID:        p.config.BindingID,
 		Epoch:            p.config.Epoch,
@@ -316,7 +323,7 @@ func (p *Publisher) flushLocked() ([]Frame, error) {
 		return nil, nil
 	}
 	frame := Frame{
-		ProtocolRevision: ProtocolRevision,
+		ProtocolRevision: p.config.ProtocolRevision,
 		StreamID:         p.config.StreamID,
 		BindingID:        p.config.BindingID,
 		Epoch:            p.config.Epoch,
@@ -510,6 +517,10 @@ func reconcileKeysForEvent(event *Event) []ReconcileKey {
 }
 
 func applyPublisherDefaults(config *PublisherConfig) {
+	config.ProtocolRevision = strings.TrimSpace(config.ProtocolRevision)
+	if config.ProtocolRevision == "" {
+		config.ProtocolRevision = ProtocolRevision
+	}
 	if config.BatchDelay <= 0 {
 		config.BatchDelay = DefaultBatchDelay
 	}

--- a/packages/agent/daemon/liveprotocol/schema/agent-activity-live-compatibility.json
+++ b/packages/agent/daemon/liveprotocol/schema/agent-activity-live-compatibility.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": "tutti.agent-live.compatibility.v1",
+  "historicalDialects": [
+    {
+      "revision": "sha256:7101e69f2559036c",
+      "profile": "pre-session-restored"
+    }
+  ],
+  "rejectedRevisions": []
+}

--- a/packages/agent/daemon/liveprotocol/subscriber.go
+++ b/packages/agent/daemon/liveprotocol/subscriber.go
@@ -18,7 +18,7 @@ func NewSubscriber(config SubscriberConfig) (*Subscriber, error) {
 	if revision == "" {
 		revision = ProtocolRevision
 	}
-	if revision != ProtocolRevision {
+	if !SupportsProtocolRevision(revision) {
 		return nil, ErrProtocolMismatch
 	}
 	return &Subscriber{

--- a/packages/agent/daemon/liveprotocol/types.go
+++ b/packages/agent/daemon/liveprotocol/types.go
@@ -280,6 +280,7 @@ type PublishInput struct {
 }
 
 type PublisherConfig struct {
+	ProtocolRevision string
 	StreamID         string
 	BindingID        string
 	Epoch            uint64

--- a/services/tuttid/service/mobileremote/remote_protocol.go
+++ b/services/tuttid/service/mobileremote/remote_protocol.go
@@ -93,15 +93,20 @@ func serveAgentLiveStream(
 		return err
 	}
 	streamID := "device-link:" + strings.TrimSpace(request.RequestID)
+	selectedRevision := liveprotocol.ProtocolRevision
+	if liveprotocol.SupportsProtocolRevision(subscription.ProtocolRevision) {
+		selectedRevision = subscription.ProtocolRevision
+	}
 	publisher, err := liveprotocol.NewPublisher(liveprotocol.PublisherConfig{
-		StreamID:  streamID,
-		BindingID: strings.TrimSpace(bindingID),
-		Epoch:     1,
+		ProtocolRevision: selectedRevision,
+		StreamID:         streamID,
+		BindingID:        strings.TrimSpace(bindingID),
+		Epoch:            1,
 	})
 	if err != nil {
 		return err
 	}
-	if subscription.ProtocolRevision != liveprotocol.ProtocolRevision {
+	if !liveprotocol.SupportsProtocolRevision(subscription.ProtocolRevision) {
 		return publishAgentLiveInput(stream, publisher, liveprotocol.PublishInput{
 			Rejected: &liveprotocol.Rejected{
 				Reason:           liveprotocol.RejectionProtocolRevisionMismatch,
@@ -124,7 +129,7 @@ func serveAgentLiveStream(
 		func() error {
 			if err := publishAgentLiveInput(stream, publisher, liveprotocol.PublishInput{
 				StreamReady: &liveprotocol.StreamReady{
-					ProtocolRevision: liveprotocol.ProtocolRevision,
+					ProtocolRevision: selectedRevision,
 					StreamID:         streamID,
 					BindingID:        strings.TrimSpace(bindingID),
 				},

--- a/services/tuttid/service/mobileremote/remote_protocol_test.go
+++ b/services/tuttid/service/mobileremote/remote_protocol_test.go
@@ -250,6 +250,8 @@ type stubAgentLiveEventSource struct {
 	payloads [][]byte
 }
 
+const historicalAgentLiveRevision = "sha256:7101e69f2559036c"
+
 func (s stubAgentLiveEventSource) StreamAgentActivity(
 	ctx context.Context,
 	_ string,
@@ -331,6 +333,95 @@ func TestRemoteProtocolStreamsValidatedAgentLiveFrames(t *testing.T) {
 		event.WorkspaceID != "workspace-1" ||
 		event.AgentSessionID != "session-1" {
 		t.Fatalf("unexpected live event: %+v", event)
+	}
+	_ = client.Close()
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRemoteProtocolAcceptsHistoricalAgentLiveRevision(t *testing.T) {
+	t.Parallel()
+	server, client := net.Pipe()
+	done := make(chan error, 1)
+	go func() {
+		done <- serveRemoteStreamWithAgentLive(
+			context.Background(),
+			server,
+			http.NotFoundHandler(),
+			"pairing-1",
+			stubAgentLiveEventSource{},
+		)
+	}()
+	body, err := json.Marshal(agentLiveSubscribeRequest{
+		ProtocolRevision: historicalAgentLiveRevision,
+		WorkspaceID:      "workspace-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeRemoteFrame(client, RemoteRequest{
+		ProtocolEpoch: ApplicationProtocolEpoch,
+		Service:       AgentLiveService,
+		RequestID:     "request-live-legacy",
+		Method:        AgentLiveSubscribeMethod,
+		Path:          "/v1/workspaces/workspace-1/agent-live",
+		Body:          body,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	ready := readAgentLiveTestFrame(t, client)
+	if ready.ProtocolRevision != historicalAgentLiveRevision ||
+		len(ready.Deliveries) != 1 ||
+		ready.Deliveries[0].StreamReady == nil ||
+		ready.Deliveries[0].StreamReady.ProtocolRevision != historicalAgentLiveRevision {
+		t.Fatalf("historical ready frame = %+v", ready)
+	}
+	_ = client.Close()
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRemoteProtocolRejectsUnknownAgentLiveRevisionWithCurrentExpected(t *testing.T) {
+	t.Parallel()
+	server, client := net.Pipe()
+	done := make(chan error, 1)
+	go func() {
+		done <- serveRemoteStreamWithAgentLive(
+			context.Background(),
+			server,
+			http.NotFoundHandler(),
+			"pairing-1",
+			stubAgentLiveEventSource{},
+		)
+	}()
+	const unknownRevision = "sha256:0000000000000000"
+	body, err := json.Marshal(agentLiveSubscribeRequest{
+		ProtocolRevision: unknownRevision,
+		WorkspaceID:      "workspace-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeRemoteFrame(client, RemoteRequest{
+		ProtocolEpoch: ApplicationProtocolEpoch,
+		Service:       AgentLiveService,
+		RequestID:     "request-live-unknown",
+		Method:        AgentLiveSubscribeMethod,
+		Path:          "/v1/workspaces/workspace-1/agent-live",
+		Body:          body,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	rejected := readAgentLiveTestFrame(t, client)
+	if rejected.ProtocolRevision != liveprotocol.ProtocolRevision ||
+		len(rejected.Deliveries) != 1 ||
+		rejected.Deliveries[0].Rejected == nil ||
+		rejected.Deliveries[0].Rejected.Reason != liveprotocol.RejectionProtocolRevisionMismatch ||
+		rejected.Deliveries[0].Rejected.ExpectedRevision != liveprotocol.ProtocolRevision ||
+		rejected.Deliveries[0].Rejected.ReceivedRevision != unknownRevision {
+		t.Fatalf("unknown revision rejection = %+v", rejected)
 	}
 	_ = client.Close()
 	if err := <-done; err != nil {
@@ -497,6 +588,50 @@ func TestRemoteProtocolPreservesCanonicalSessionRestore(t *testing.T) {
 		len(frame.Deliveries[0].Discontinuity.ReconcileKeys) != 1 ||
 		frame.Deliveries[0].Discontinuity.ReconcileKeys[0].AgentSessionID != "session-1" {
 		t.Fatalf("unexpected session restore frame: %+v", frame)
+	}
+	_ = client.Close()
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRemoteProtocolDowngradesSessionRestoreForHistoricalRevision(t *testing.T) {
+	t.Parallel()
+	publisher, err := liveprotocol.NewPublisher(liveprotocol.PublisherConfig{
+		ProtocolRevision: historicalAgentLiveRevision,
+		StreamID:         "stream-1",
+		BindingID:        "binding-1",
+		Epoch:            1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	server, client := net.Pipe()
+	done := make(chan error, 1)
+	go func() {
+		done <- publishAgentActivityEnvelope(
+			server,
+			publisher,
+			"workspace-1",
+			[]byte(`{
+				"workspaceId":"workspace-1",
+				"agentSessionId":"session-1",
+				"eventType":"session_restored",
+				"data":{
+					"workspaceId":"workspace-1",
+					"agentSessionId":"session-1",
+					"eventType":"session_restored",
+					"restoredAtUnixMs":10
+				}
+			}`),
+		)
+	}()
+	frame := readAgentLiveTestFrame(t, client)
+	if frame.ProtocolRevision != historicalAgentLiveRevision ||
+		len(frame.Deliveries) != 1 ||
+		frame.Deliveries[0].Discontinuity == nil ||
+		frame.Deliveries[0].Discontinuity.Reason != "canonical_update" {
+		t.Fatalf("historical restore frame = %+v", frame)
 	}
 	_ = client.Close()
 	if err := <-done; err != nil {

--- a/tools/release/agent-live-protocol-bootstrap.json
+++ b/tools/release/agent-live-protocol-bootstrap.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "tutti.agent-live.release-bootstrap.v1",
+  "releases": {
+    "desktopRc": {
+      "v0.2.21-rc.0": {
+        "currentRevision": "sha256:7101e69f2559036c",
+        "acceptedRevisions": ["sha256:7101e69f2559036c"]
+      }
+    },
+    "mobile": {
+      "tutti-mobile-v0.1.8": {
+        "currentRevision": "sha256:b29022aba44d33cb",
+        "acceptedRevisions": ["sha256:b29022aba44d33cb"]
+      }
+    }
+  }
+}

--- a/tools/scripts/agent-live-release-compatibility.mjs
+++ b/tools/scripts/agent-live-release-compatibility.mjs
@@ -1,0 +1,310 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const generatedProtocolURL = new URL(
+  "../../packages/agent/daemon/liveprotocol/protocol_compatibility.gen.json",
+  import.meta.url
+);
+const releaseBootstrapURL = new URL(
+  "../release/agent-live-protocol-bootstrap.json",
+  import.meta.url
+);
+const releaseBootstrapTags = {
+  desktopRc: ["v0.2.21-rc.0"],
+  mobile: ["tutti-mobile-v0.1.8"]
+};
+
+export async function loadGeneratedAgentLiveProtocol() {
+  return validateAgentLiveProtocol(
+    JSON.parse(await readFile(generatedProtocolURL, "utf8")),
+    "generated Agent live protocol"
+  );
+}
+
+export function validateAgentLiveProtocol(value, label) {
+  if (!isRecord(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  const currentRevision = requireRevision(
+    value.currentRevision,
+    `${label}.currentRevision`
+  );
+  if (!Array.isArray(value.acceptedRevisions)) {
+    throw new Error(`${label}.acceptedRevisions must be an array`);
+  }
+  const acceptedRevisions = value.acceptedRevisions.map((revision, index) =>
+    requireRevision(revision, `${label}.acceptedRevisions[${index}]`)
+  );
+  if (new Set(acceptedRevisions).size !== acceptedRevisions.length) {
+    throw new Error(`${label}.acceptedRevisions must be unique`);
+  }
+  if (!acceptedRevisions.includes(currentRevision)) {
+    throw new Error(`${label}.acceptedRevisions must include currentRevision`);
+  }
+  return { currentRevision, acceptedRevisions };
+}
+
+export function releaseAgentLiveProtocol(document, label) {
+  if (!isRecord(document)) {
+    throw new Error(`${label} release pointer must be an object`);
+  }
+  return validateAgentLiveProtocol(
+    document.agentLiveProtocol,
+    `${label} release pointer agentLiveProtocol`
+  );
+}
+
+export async function releaseAgentLiveProtocolWithBootstrap(
+  document,
+  label,
+  releaseKind
+) {
+  validateReleasePointerIdentity(document, label, releaseKind);
+  if (isRecord(document?.agentLiveProtocol)) {
+    return releaseAgentLiveProtocol(document, label);
+  }
+  const bootstrap = validateReleaseBootstrap(
+    JSON.parse(await readFile(releaseBootstrapURL, "utf8"))
+  );
+  const tag = String(document?.tag ?? "").trim();
+  const protocol = bootstrap.releases[releaseKind][tag];
+  if (!protocol) {
+    throw new Error(
+      `${label} release pointer ${tag || "<missing tag>"} has no agentLiveProtocol metadata or exact bootstrap entry`
+    );
+  }
+  return validateAgentLiveProtocol(
+    protocol,
+    `${label} release pointer bootstrap ${tag}`
+  );
+}
+
+export function validateReleasePointerIdentity(document, label, releaseKind) {
+  if (!isRecord(document)) {
+    throw new Error(`${label} release pointer must be an object`);
+  }
+  switch (releaseKind) {
+    case "desktopRc": {
+      if (document.schemaVersion !== "tutti.desktop.release.latest.v1") {
+        throw new Error(`${label} release pointer schemaVersion is invalid`);
+      }
+      const version = requireExactString(
+        document.version,
+        `${label} release pointer version`
+      );
+      if (!/^\d+\.\d+\.\d+-rc\.\d+$/.test(version)) {
+        throw new Error(
+          `${label} release pointer version must be an RC semver`
+        );
+      }
+      if (
+        document.tag !== `v${version}` ||
+        document.channel !== "rc" ||
+        document.prerelease !== true
+      ) {
+        throw new Error(`${label} release pointer must identify Desktop RC`);
+      }
+      return;
+    }
+    case "mobile": {
+      if (document.schemaVersion !== "tutti.android.mobile.latest.v1") {
+        throw new Error(`${label} release pointer schemaVersion is invalid`);
+      }
+      const versionName = requireExactString(
+        document.versionName,
+        `${label} release pointer versionName`
+      );
+      if (!/^\d+\.\d+\.\d+$/.test(versionName)) {
+        throw new Error(
+          `${label} release pointer versionName must be a stable semver`
+        );
+      }
+      if (
+        document.tag !== `tutti-mobile-v${versionName}` ||
+        document.packageName !== "sh.tutti.mobile" ||
+        !Number.isSafeInteger(document.versionCode) ||
+        document.versionCode <= 0
+      ) {
+        throw new Error(`${label} release pointer must identify Mobile`);
+      }
+      return;
+    }
+    default:
+      throw new Error(`Unknown Agent live release kind: ${releaseKind}`);
+  }
+}
+
+export function validateReleaseBootstrap(bootstrap) {
+  if (
+    bootstrap?.schemaVersion !== "tutti.agent-live.release-bootstrap.v1" ||
+    !isRecord(bootstrap.releases) ||
+    !sameStringArray(
+      Object.keys(bootstrap.releases).sort(),
+      Object.keys(releaseBootstrapTags).sort()
+    )
+  ) {
+    throw new Error("Agent live release bootstrap contract is invalid");
+  }
+  for (const [releaseKind, expectedTags] of Object.entries(
+    releaseBootstrapTags
+  )) {
+    const releases = bootstrap.releases[releaseKind];
+    if (
+      !isRecord(releases) ||
+      !sameStringArray(Object.keys(releases).sort(), [...expectedTags].sort())
+    ) {
+      throw new Error(
+        `Agent live release bootstrap ${releaseKind} entries are invalid`
+      );
+    }
+    for (const tag of expectedTags) {
+      validateAgentLiveProtocol(
+        releases[tag],
+        `Agent live release bootstrap ${releaseKind}.${tag}`
+      );
+    }
+  }
+  return bootstrap;
+}
+
+export function assertAgentLiveProtocolExactMatch({ actual, expected }) {
+  if (
+    actual.currentRevision === expected.currentRevision &&
+    sameStringArray(actual.acceptedRevisions, expected.acceptedRevisions)
+  ) {
+    return;
+  }
+  throw new Error(
+    "Generated Mobile Agent live protocol does not exactly match the published Android pointer: " +
+      `generated current=${actual.currentRevision} accepted=${actual.acceptedRevisions.join(",")}; ` +
+      `published current=${expected.currentRevision} accepted=${expected.acceptedRevisions.join(",")}`
+  );
+}
+
+export function canReachAgentLiveProtocol({ desktop, mobile }) {
+  return (
+    desktop.acceptedRevisions.includes(mobile.currentRevision) ||
+    mobile.acceptedRevisions.includes(desktop.currentRevision)
+  );
+}
+
+export function assertAgentLiveReleaseCompatibility({ desktop, mobile }) {
+  if (canReachAgentLiveProtocol({ desktop, mobile })) return;
+  throw new Error(
+    "Mobile and Desktop RC Agent live protocols are unreachable: " +
+      `mobile current=${mobile.currentRevision} accepted=${mobile.acceptedRevisions.join(",")}; ` +
+      `desktop current=${desktop.currentRevision} accepted=${desktop.acceptedRevisions.join(",")}`
+  );
+}
+
+function requireRevision(value, label) {
+  const revision = String(value ?? "").trim();
+  if (!/^sha256:[0-9a-f]{16}$/.test(revision)) {
+    throw new Error(`${label} must be a truncated SHA-256 protocol revision`);
+  }
+  return revision;
+}
+
+function requireExactString(value, label) {
+  if (typeof value !== "string" || !value || value.trim() !== value) {
+    throw new Error(`${label} must be a non-empty exact string`);
+  }
+  return value;
+}
+
+function sameStringArray(left, right) {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
+  );
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function parseCompatibilityArguments(argv) {
+  const result = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--mobile-generated") {
+      result.mobileGenerated = true;
+      continue;
+    }
+    if (
+      argument !== "--desktop" &&
+      argument !== "--mobile" &&
+      argument !== "--released-mobile"
+    ) {
+      throw new Error(`Unexpected argument: ${argument}`);
+    }
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`Missing value for ${argument}`);
+    }
+    result[
+      argument === "--released-mobile" ? "releasedMobile" : argument.slice(2)
+    ] = value;
+    index += 1;
+  }
+  if (result.mobile && result.mobileGenerated) {
+    throw new Error("--mobile and --mobile-generated are mutually exclusive");
+  }
+  if (result.releasedMobile && !result.mobileGenerated) {
+    throw new Error("--released-mobile requires --mobile-generated");
+  }
+  return result;
+}
+
+async function main() {
+  const args = parseCompatibilityArguments(process.argv.slice(2));
+  if (!args.desktop) {
+    throw new Error("--desktop is required");
+  }
+  if (!args.mobile && !args.mobileGenerated) {
+    throw new Error("--mobile or --mobile-generated is required");
+  }
+  const desktopDocument = JSON.parse(
+    await readFile(path.resolve(args.desktop), "utf8")
+  );
+  const desktop = await releaseAgentLiveProtocolWithBootstrap(
+    desktopDocument,
+    "Desktop RC",
+    "desktopRc"
+  );
+  const mobile = args.mobileGenerated
+    ? await loadGeneratedAgentLiveProtocol()
+    : await releaseAgentLiveProtocolWithBootstrap(
+        JSON.parse(await readFile(path.resolve(args.mobile), "utf8")),
+        "Mobile",
+        "mobile"
+      );
+  if (args.releasedMobile) {
+    const releasedMobile = await releaseAgentLiveProtocolWithBootstrap(
+      JSON.parse(await readFile(path.resolve(args.releasedMobile), "utf8")),
+      "Published Android",
+      "mobile"
+    );
+    assertAgentLiveProtocolExactMatch({
+      actual: mobile,
+      expected: releasedMobile
+    });
+  }
+  assertAgentLiveReleaseCompatibility({ desktop, mobile });
+  console.log(
+    `Agent live release pair is reachable: mobile=${mobile.currentRevision} desktop=${desktop.currentRevision}`
+  );
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  void main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/tools/scripts/agent-live-release-compatibility.test.mjs
+++ b/tools/scripts/agent-live-release-compatibility.test.mjs
@@ -1,0 +1,271 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  assertAgentLiveProtocolExactMatch,
+  assertAgentLiveReleaseCompatibility,
+  canReachAgentLiveProtocol,
+  loadGeneratedAgentLiveProtocol,
+  parseCompatibilityArguments,
+  releaseAgentLiveProtocol,
+  releaseAgentLiveProtocolWithBootstrap,
+  validateReleaseBootstrap,
+  validateReleasePointerIdentity
+} from "./agent-live-release-compatibility.mjs";
+
+const current = "sha256:1111111111111111";
+const previous = "sha256:2222222222222222";
+const sharedThird = "sha256:3333333333333333";
+
+function desktopRcPointer({ agentLiveProtocol, tag = "v1.2.3-rc.4" } = {}) {
+  const version = tag.slice(1);
+  return {
+    ...(agentLiveProtocol ? { agentLiveProtocol } : {}),
+    channel: "rc",
+    prerelease: true,
+    schemaVersion: "tutti.desktop.release.latest.v1",
+    tag,
+    version
+  };
+}
+
+function mobilePointer({
+  agentLiveProtocol,
+  tag = "tutti-mobile-v1.2.3",
+  versionCode = 42
+} = {}) {
+  const versionName = tag.replace("tutti-mobile-v", "");
+  return {
+    ...(agentLiveProtocol ? { agentLiveProtocol } : {}),
+    packageName: "sh.tutti.mobile",
+    schemaVersion: "tutti.android.mobile.latest.v1",
+    tag,
+    versionCode,
+    versionName
+  };
+}
+
+test("loads the generated Agent live release protocol", async () => {
+  const protocol = await loadGeneratedAgentLiveProtocol();
+  assert.equal(protocol.currentRevision, "sha256:b29022aba44d33cb");
+  assert.deepEqual(protocol.acceptedRevisions, [
+    "sha256:b29022aba44d33cb",
+    "sha256:7101e69f2559036c"
+  ]);
+});
+
+test("selects the generated Mobile protocol for an iOS release gate", () => {
+  assert.deepEqual(
+    parseCompatibilityArguments([
+      "--desktop",
+      "desktop.json",
+      "--mobile-generated",
+      "--released-mobile",
+      "mobile.json"
+    ]),
+    {
+      desktop: "desktop.json",
+      mobileGenerated: true,
+      releasedMobile: "mobile.json"
+    }
+  );
+  assert.throws(
+    () =>
+      parseCompatibilityArguments([
+        "--desktop",
+        "desktop.json",
+        "--mobile",
+        "mobile.json",
+        "--mobile-generated"
+      ]),
+    /mutually exclusive/
+  );
+  assert.throws(
+    () =>
+      parseCompatibilityArguments([
+        "--desktop",
+        "desktop.json",
+        "--mobile",
+        "mobile.json",
+        "--released-mobile",
+        "published.json"
+      ]),
+    /requires --mobile-generated/
+  );
+});
+
+test("accepts both reachable handshake directions", () => {
+  assert.equal(
+    canReachAgentLiveProtocol({
+      desktop: { currentRevision: previous, acceptedRevisions: [previous] },
+      mobile: {
+        currentRevision: current,
+        acceptedRevisions: [current, previous]
+      }
+    }),
+    true
+  );
+  assert.equal(
+    canReachAgentLiveProtocol({
+      desktop: {
+        currentRevision: current,
+        acceptedRevisions: [current, previous]
+      },
+      mobile: { currentRevision: previous, acceptedRevisions: [previous] }
+    }),
+    true
+  );
+});
+
+test("rejects a third shared revision that the handshake cannot select", () => {
+  const desktop = {
+    currentRevision: current,
+    acceptedRevisions: [current, sharedThird]
+  };
+  const mobile = {
+    currentRevision: previous,
+    acceptedRevisions: [previous, sharedThird]
+  };
+  assert.equal(canReachAgentLiveProtocol({ desktop, mobile }), false);
+  assert.throws(
+    () => assertAgentLiveReleaseCompatibility({ desktop, mobile }),
+    /protocols are unreachable/
+  );
+});
+
+test("requires release metadata to include its current revision", () => {
+  assert.throws(
+    () =>
+      releaseAgentLiveProtocol(
+        {
+          agentLiveProtocol: {
+            acceptedRevisions: [previous],
+            currentRevision: current
+          }
+        },
+        "Mobile"
+      ),
+    /must include currentRevision/
+  );
+});
+
+test("release pointer identity rejects non-RC Desktop and malformed Mobile documents", () => {
+  assert.doesNotThrow(() =>
+    validateReleasePointerIdentity(
+      desktopRcPointer(),
+      "Desktop RC",
+      "desktopRc"
+    )
+  );
+  assert.throws(
+    () =>
+      validateReleasePointerIdentity(
+        {
+          ...desktopRcPointer(),
+          channel: "stable",
+          prerelease: false,
+          tag: "v1.2.3",
+          version: "1.2.3"
+        },
+        "Desktop RC",
+        "desktopRc"
+      ),
+    /must be an RC semver|must identify Desktop RC/
+  );
+  assert.throws(
+    () =>
+      validateReleasePointerIdentity(
+        { ...mobilePointer(), packageName: "wrong.package" },
+        "Mobile",
+        "mobile"
+      ),
+    /must identify Mobile/
+  );
+});
+
+test("requires the generated iOS protocol to exactly match the Android pointer", () => {
+  const generated = {
+    acceptedRevisions: [current, previous],
+    currentRevision: current
+  };
+  assert.doesNotThrow(() =>
+    assertAgentLiveProtocolExactMatch({
+      actual: generated,
+      expected: generated
+    })
+  );
+  assert.throws(
+    () =>
+      assertAgentLiveProtocolExactMatch({
+        actual: generated,
+        expected: {
+          acceptedRevisions: [previous],
+          currentRevision: previous
+        }
+      }),
+    /does not exactly match/
+  );
+});
+
+test("release bootstrap allowlist is exact and bounded", () => {
+  const protocol = {
+    acceptedRevisions: [current],
+    currentRevision: current
+  };
+  const valid = {
+    releases: {
+      desktopRc: { "v0.2.21-rc.0": protocol },
+      mobile: { "tutti-mobile-v0.1.8": protocol }
+    },
+    schemaVersion: "tutti.agent-live.release-bootstrap.v1"
+  };
+  assert.equal(validateReleaseBootstrap(valid), valid);
+  assert.throws(
+    () =>
+      validateReleaseBootstrap({
+        ...valid,
+        releases: {
+          ...valid.releases,
+          mobile: {
+            ...valid.releases.mobile,
+            "tutti-mobile-v0.1.9": protocol
+          }
+        }
+      }),
+    /entries are invalid/
+  );
+});
+
+test("bootstraps only the exact existing Mobile and Desktop RC pointers", async () => {
+  assert.deepEqual(
+    await releaseAgentLiveProtocolWithBootstrap(
+      mobilePointer({ tag: "tutti-mobile-v0.1.8", versionCode: 8 }),
+      "Mobile",
+      "mobile"
+    ),
+    {
+      acceptedRevisions: ["sha256:b29022aba44d33cb"],
+      currentRevision: "sha256:b29022aba44d33cb"
+    }
+  );
+  assert.deepEqual(
+    await releaseAgentLiveProtocolWithBootstrap(
+      desktopRcPointer({ tag: "v0.2.21-rc.0" }),
+      "Desktop RC",
+      "desktopRc"
+    ),
+    {
+      acceptedRevisions: ["sha256:7101e69f2559036c"],
+      currentRevision: "sha256:7101e69f2559036c"
+    }
+  );
+  await assert.rejects(
+    () =>
+      releaseAgentLiveProtocolWithBootstrap(
+        mobilePointer({ tag: "tutti-mobile-v0.1.9", versionCode: 9 }),
+        "Mobile",
+        "mobile"
+      ),
+    /no agentLiveProtocol metadata or exact bootstrap entry/
+  );
+});

--- a/tools/scripts/build-mobile-release-latest.mjs
+++ b/tools/scripts/build-mobile-release-latest.mjs
@@ -4,6 +4,7 @@ import { createHash } from "node:crypto";
 import { readFile, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { loadGeneratedAgentLiveProtocol } from "./agent-live-release-compatibility.mjs";
 
 export const mobileReleaseLatestSchemaVersion =
   "tutti.android.mobile.latest.v1";
@@ -31,8 +32,10 @@ export async function buildMobileReleaseLatest(options) {
     .update(await readFile(apkPath))
     .digest("hex");
   const apkName = path.basename(apkPath);
+  const agentLiveProtocol = await loadGeneratedAgentLiveProtocol();
 
   return {
+    agentLiveProtocol,
     apkUrl:
       `${baseUrl}/${encodeURLPathSegment(tag)}/${sha256}/` +
       encodeURLPathSegment(apkName),

--- a/tools/scripts/build-mobile-release-latest.test.mjs
+++ b/tools/scripts/build-mobile-release-latest.test.mjs
@@ -26,6 +26,10 @@ test("builds an Android latest pointer with immutable APK metadata", async () =>
   });
 
   assert.deepEqual(latest, {
+    agentLiveProtocol: {
+      acceptedRevisions: ["sha256:b29022aba44d33cb", "sha256:7101e69f2559036c"],
+      currentRevision: "sha256:b29022aba44d33cb"
+    },
     apkUrl:
       "https://downloads.example.test/tutti-mobile-releases/tutti-mobile-v0.1.1/1e10ba560383b17472b4cf72fef8f9e76c66815a3e6ae8c5a9b0c5e696b0bdf8/app-release.apk",
     baseUrl: "https://downloads.example.test/tutti-mobile-releases",
@@ -119,13 +123,20 @@ test("serializes pointer publication and protects immutable assets", async () =>
   );
   const workflow = await readFile(workflowPath, "utf8");
 
-  assert.match(workflow, /mobile-android-release-publish/);
-  assert.match(
-    workflow,
-    /cancel-in-progress: \$\{\{ !inputs\.publish_android \}\}/
-  );
+  assert.match(workflow, /agent-live-release-publish/);
+  assert.match(workflow, /inputs\.platform == 'ios'/);
+  assert.match(workflow, /needs: android/);
   assert.match(workflow, /preflight_immutable\(\)/);
   assert.match(workflow, /upload_immutable\(\)/);
+  assert.match(
+    workflow,
+    /TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET.+channels\/rc\/latest\.json/s
+  );
+  assert.match(workflow, /agent-live-release-compatibility\.mjs/);
+  assert.match(
+    workflow,
+    /--released-mobile current-mobile-release-pointer\.json/
+  );
   assert.match(
     workflow,
     /Refusing to overwrite immutable Android release asset/

--- a/tools/scripts/change-classification.test.mjs
+++ b/tools/scripts/change-classification.test.mjs
@@ -485,6 +485,16 @@ test("repository check registry selects only relevant generated checks", () => {
   );
 });
 
+test("Agent live release bootstrap selects tool and generated contracts", () => {
+  const checks = selectRepositoryChecks([
+    "tools/release/agent-live-protocol-bootstrap.json"
+  ]);
+  const keys = checks.map((check) => check.key);
+
+  assert.ok(keys.includes("contracts:tool-tests"));
+  assert.ok(keys.includes("generated:agent-live-protocol"));
+});
+
 test("provider source changes select catalog and strategy checks", () => {
   const checks = selectRepositoryChecks([
     "packages/agent/daemon/providerregistry/providers.go"

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -714,7 +714,10 @@ test("desktop promotion validates draft identity, checksums, and channel orderin
 
   assert.match(promoteWorkflow, /workflow_call:/);
   assert.match(promoteWorkflow, /workflow_dispatch:/);
-  assert.match(promoteWorkflow, /group:\s+desktop-release-promotion/);
+  assert.match(
+    promoteWorkflow,
+    /group:\s+\$\{\{[\s\S]*contains\(inputs\.release_tag, '-rc\.'\)[\s\S]*'agent-live-release-publish'[\s\S]*'desktop-release-promotion'[\s\S]*\}\}/
+  );
   assert.match(
     promoteWorkflow,
     /gh release view "\$\{release_tag\}"[\s\S]*assets,isDraft,isPrerelease,tagName,targetCommitish,url/
@@ -1204,7 +1207,10 @@ test("desktop Windows package and daemon agree on the bundled Mutagen resource",
 test("desktop packages and daemon agree on the bundled uv archive root", async () => {
   const packageJson = JSON.parse(await readFile(desktopPackagePath, "utf8"));
   const defaults = JSON.parse(
-    await readFile(new URL("../../config/tutti.defaults.json", import.meta.url), "utf8")
+    await readFile(
+      new URL("../../config/tutti.defaults.json", import.meta.url),
+      "utf8"
+    )
   );
   const buildScript = await readFile(buildScriptPath, "utf8");
   const tuttidManager = await readFile(tuttidManagerPath, "utf8");

--- a/tools/scripts/desktop-release-latest.test.mjs
+++ b/tools/scripts/desktop-release-latest.test.mjs
@@ -6,6 +6,25 @@ import path from "node:path";
 
 import { buildDesktopReleaseLatest } from "../../apps/desktop/scripts/build-release-latest.mjs";
 
+test("desktop RC promotion gates against the Mobile latest protocol", async () => {
+  const workflow = await import("node:fs/promises").then(({ readFile }) =>
+    readFile(
+      new URL(
+        "../../.github/workflows/desktop-release-promote.yml",
+        import.meta.url
+      ),
+      "utf8"
+    )
+  );
+  assert.match(workflow, /needs\.resolve\.outputs\.release_channel == 'rc'/);
+  assert.match(workflow, /agent-live-release-publish/);
+  assert.match(
+    workflow,
+    /TUTTI_MOBILE_RELEASE_ASSETS_S3_BUCKET.+latest\.json/s
+  );
+  assert.match(workflow, /agent-live-release-compatibility\.mjs/);
+});
+
 test("desktop release latest metadata exposes CloudFront URLs for every asset", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "desktop-release-latest-"));
   try {
@@ -33,6 +52,7 @@ test("desktop release latest metadata exposes CloudFront URLs for every asset", 
     assert.equal(latest.releasedAt, "2026-07-04T12:00:00.000Z");
     assert.equal(latest.gitSha, "537327a1");
     assert.equal(latest.sourceRef, "main");
+    assert.equal(latest.agentLiveProtocol, undefined);
     assert.equal(
       latest.baseUrl,
       "https://d111111abcdef8.cloudfront.net/desktop-release-assets"
@@ -124,6 +144,10 @@ test("desktop release latest metadata supports rc channel tags", async () => {
     assert.equal(latest.channel, "rc");
     assert.equal(latest.prerelease, true);
     assert.equal(latest.version, "1.2.3-rc.1");
+    assert.deepEqual(latest.agentLiveProtocol, {
+      acceptedRevisions: ["sha256:b29022aba44d33cb", "sha256:7101e69f2559036c"],
+      currentRevision: "sha256:b29022aba44d33cb"
+    });
     assert.equal(
       latest.preferredDownloads.macosUniversalDmg?.includes("v1.2.3-rc.1"),
       true
@@ -181,6 +205,7 @@ test("desktop release latest metadata supports beta channel tags", async () => {
     assert.equal(latest.channel, "beta");
     assert.equal(latest.prerelease, true);
     assert.equal(latest.version, "1.2.3-beta.1");
+    assert.equal(latest.agentLiveProtocol, undefined);
     assert.equal(
       latest.preferredDownloads.macosUniversalDmg?.includes("v1.2.3-beta.1"),
       true

--- a/tools/scripts/generate-agent-live-protocol.mjs
+++ b/tools/scripts/generate-agent-live-protocol.mjs
@@ -13,6 +13,10 @@ const wireContractPath = resolve(
   repoRoot,
   "packages/agent/daemon/liveprotocol/schema/agent-activity-live-wire-contract.json"
 );
+const compatibilityPath = resolve(
+  repoRoot,
+  "packages/agent/daemon/liveprotocol/schema/agent-activity-live-compatibility.json"
+);
 const canonicalPath = resolve(
   repoRoot,
   "packages/events/protocol/definitions/agent/activity.updated.event.json"
@@ -25,10 +29,28 @@ const tsOutputPath = resolve(
   repoRoot,
   "packages/agent/activity-core/src/liveProtocolRevision.gen.ts"
 );
+const compatibilityOutputPath = resolve(
+  repoRoot,
+  "packages/agent/daemon/liveprotocol/protocol_compatibility.gen.json"
+);
 const checkOnly = process.argv.includes("--check");
+const dialectProfileDefinitions = [
+  {
+    goConstant: "protocolDialectProfileCurrent",
+    profile: "current"
+  },
+  {
+    goConstant: "protocolDialectProfilePreSessionRestored",
+    profile: "pre-session-restored"
+  }
+];
 
 const liveSchema = JSON.parse(readFileSync(schemaPath, "utf8"));
 const wireContract = JSON.parse(readFileSync(wireContractPath, "utf8"));
+const compatibility = JSON.parse(readFileSync(compatibilityPath, "utf8"));
+const previousGeneratedCompatibility = readOptionalJSON(
+  compatibilityOutputPath
+);
 const canonicalDefinition = JSON.parse(readFileSync(canonicalPath, "utf8"));
 const canonicalVariants = [
   "session_audit",
@@ -44,11 +66,41 @@ const canonicalVariants = [
   return variant;
 });
 validateWireContract(wireContract);
+validateCompatibility(compatibility);
 const digest = createHash("sha256")
   .update(JSON.stringify({ liveSchema, wireContract, canonicalVariants }))
   .digest("hex")
   .slice(0, 16);
 const revision = `sha256:${digest}`;
+requirePreviousRevisionDecision({
+  compatibility,
+  previousGeneratedCompatibility,
+  revision
+});
+const dialects = [
+  { revision, profile: "current" },
+  ...compatibility.historicalDialects
+];
+if (
+  new Set(dialects.map((dialect) => dialect.revision)).size !== dialects.length
+) {
+  throw new Error("Agent live compatibility revisions must be unique");
+}
+const goDialectDeclarations = dialects
+  .map(
+    (dialect) =>
+      `\t{Revision: ${JSON.stringify(dialect.revision)}, Profile: ${JSON.stringify(dialect.profile)}},`
+  )
+  .join("\n");
+const goDialectProfileConstantWidth = Math.max(
+  ...dialectProfileDefinitions.map((profile) => profile.goConstant.length)
+);
+const goDialectProfileDeclarations = dialectProfileDefinitions
+  .map(
+    (profile) =>
+      `\t${profile.goConstant.padEnd(goDialectProfileConstantWidth)} = ${JSON.stringify(profile.profile)}`
+  )
+  .join("\n");
 const goWireFieldConstants = [
   ...wireContract.frameFields,
   ...wireContract.deliveryFields
@@ -81,6 +133,14 @@ package liveprotocol
 
 const ProtocolRevision = ${JSON.stringify(revision)}
 
+const (
+${goDialectProfileDeclarations}
+)
+
+var generatedProtocolDialects = [...]protocolDialectDescriptor{
+${goDialectDeclarations}
+}
+
 // Protobuf-wire field numbers and delivery kinds are generated from
 // schema/agent-activity-live-wire-contract.json. They participate in
 // ProtocolRevision and must not be edited independently.
@@ -99,7 +159,22 @@ ${goDeliveryKindConstants}
 
 export const AGENT_ACTIVITY_LIVE_PROTOCOL_REVISION =
   ${JSON.stringify(revision)} as const;
+
+export const AGENT_ACTIVITY_LIVE_ACCEPTED_PROTOCOL_REVISIONS = ${JSON.stringify(
+      dialects.map((dialect) => dialect.revision),
+      null,
+      2
+    )} as const;
 `
+  ],
+  [
+    compatibilityOutputPath,
+    `{
+  "schemaVersion": ${JSON.stringify(compatibility.schemaVersion)},
+  "currentRevision": ${JSON.stringify(revision)},
+  "acceptedRevisions": [${dialects.map((dialect) => JSON.stringify(dialect.revision)).join(", ")}],
+  "dialects": ${JSON.stringify(dialects, null, 2).replaceAll("\n", "\n  ")}
+}\n`
   ]
 ]);
 
@@ -153,6 +228,81 @@ function validateWireContract(contract) {
     if (!(requiredControl in contract.controls)) {
       throw new Error(`wire contract is missing ${requiredControl} control`);
     }
+  }
+}
+
+function validateCompatibility(contract) {
+  if (
+    contract?.schemaVersion !== "tutti.agent-live.compatibility.v1" ||
+    !Array.isArray(contract.historicalDialects) ||
+    !Array.isArray(contract.rejectedRevisions)
+  ) {
+    throw new Error(
+      "Agent live compatibility contract has an invalid root shape"
+    );
+  }
+  if (contract.historicalDialects.length > 2) {
+    throw new Error(
+      "Agent live compatibility supports at most two historical dialects"
+    );
+  }
+  const supportedProfiles = new Set(
+    dialectProfileDefinitions
+      .map((profile) => profile.profile)
+      .filter((profile) => profile !== "current")
+  );
+  for (const dialect of contract.historicalDialects) {
+    if (
+      typeof dialect?.revision !== "string" ||
+      !/^sha256:[0-9a-f]{16}$/.test(dialect.revision) ||
+      typeof dialect?.profile !== "string" ||
+      !supportedProfiles.has(dialect.profile)
+    ) {
+      throw new Error(
+        "Agent live compatibility contract has an invalid dialect"
+      );
+    }
+  }
+  for (const rejected of contract.rejectedRevisions) {
+    if (
+      typeof rejected?.revision !== "string" ||
+      !/^sha256:[0-9a-f]{16}$/.test(rejected.revision) ||
+      typeof rejected?.reason !== "string" ||
+      rejected.reason.trim().length === 0
+    ) {
+      throw new Error(
+        "Agent live compatibility contract has an invalid rejected revision"
+      );
+    }
+  }
+}
+
+function readOptionalJSON(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    if (error?.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function requirePreviousRevisionDecision({
+  compatibility,
+  previousGeneratedCompatibility,
+  revision
+}) {
+  const previous = previousGeneratedCompatibility?.currentRevision;
+  if (typeof previous !== "string" || previous === revision) return;
+  const accepted = compatibility.historicalDialects.some(
+    (dialect) => dialect.revision === previous
+  );
+  const rejected = compatibility.rejectedRevisions.some(
+    (candidate) => candidate.revision === previous
+  );
+  if (!accepted && !rejected) {
+    throw new Error(
+      `Agent live protocol changed from ${previous} to ${revision}; add the previous revision to historicalDialects with a profile or rejectedRevisions with a reason`
+    );
   }
 }
 

--- a/tools/scripts/repository-checks.mjs
+++ b/tools/scripts/repository-checks.mjs
@@ -187,6 +187,7 @@ export function isToolContractRelevant(file) {
   const normalized = normalize(file);
   return (
     normalized.startsWith("tools/scripts/") ||
+    normalized.startsWith("tools/release/") ||
     normalized.startsWith("packages/workspace/app-release-tools/") ||
     normalized.startsWith("apps/desktop/scripts/") ||
     normalized.startsWith(".github/workflows/") ||
@@ -287,10 +288,15 @@ function isAgentLiveProtocolContractRelevant(file) {
       "packages/agent/daemon/liveprotocol/schema/agent-activity-live-event.schema.json" ||
     file ===
       "packages/agent/daemon/liveprotocol/schema/agent-activity-live-wire-contract.json" ||
+    file ===
+      "packages/agent/daemon/liveprotocol/schema/agent-activity-live-compatibility.json" ||
     file === "packages/agent/daemon/liveprotocol/protocol_revision.gen.go" ||
+    file ===
+      "packages/agent/daemon/liveprotocol/protocol_compatibility.gen.json" ||
     file === "packages/agent/activity-core/src/liveProtocolRevision.gen.ts" ||
     file ===
       "packages/events/protocol/definitions/agent/activity.updated.event.json" ||
+    file === "tools/release/agent-live-protocol-bootstrap.json" ||
     file === "tools/scripts/generate-agent-live-protocol.mjs"
   );
 }


### PR DESCRIPTION
## 背景

Mobile 与 Desktop 之前按协议 revision 做精确相等判断。协议新增语义后，即使手机已经是最新公开版本，也可能因为 Desktop RC 使用了更新 revision 而被判定为不兼容，缺少一个受控的跨版本升级窗口。

## 改动

- 将 Agent live 协议设计为显式的 `current + previous` 兼容集合，Mobile 优先使用 current，收到结构化协议拒绝后最多回退一次
- 为每个历史 revision 绑定明确方言；新语义发布给旧 revision 时进行投影，并在原始编码与解码入口拒绝错误标注的新语义
- 使用已发布 `v0.2.21-rc.0` 实现生成的固定 wire fixtures 验证旧协议，而不是由当前实现自生成测试数据
- Mobile 在后台恢复和断线重连时保留已经协商成功的 revision；Android 与 iOS 原生桥同步传递选择结果
- Desktop 只在 RC 发布指针写入协议元数据，stable 与 beta 不参与该协议发布流程
- Desktop RC、Android 和 iOS TestFlight 使用共享发布锁与 S3 权威指针，校验发布身份、兼容集合及 bootstrap 白名单；iOS 协议集合必须与已发布 Android 完全一致
- 补齐变更选择器、发布契约、架构约定与排障文档

## 验证

- `pnpm check:changed`：33 条门禁通过
- `pnpm check:changed -- --push-ready`：36 条门禁通过
- Agent live 与 tuttId Mobile remote Go 测试通过
- 发布与仓库工具契约测试通过
- Mobile 生命周期测试 15/15 通过
- Android debug APK、AAR、iOS XCFramework 及两端绑定检查通过

本 PR 不触发 Desktop RC、Android 或 TestFlight 发布。