### PR TITLE
fix(agent-gui): keep plan waiting and processing visible

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIViewAssembly.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIViewAssembly.ts
@@ -186,6 +186,38 @@ export function useAgentGUIViewAssembly(input: UseAgentGUIViewAssemblyInput) {
     pendingApproval: detail.pendingApproval,
     serverInteractivePrompt: detail.serverInteractivePrompt
   });
+  const railConversations = useMemo(() => {
+    const prompt = session.pendingInteractivePrompt;
+    if (prompt?.kind !== "plan-implementation" || !input.activeConversationId) {
+      return visibleConversations;
+    }
+    let changed = false;
+    const next = visibleConversations.map((conversation) => {
+      if (
+        conversation.id !== input.activeConversationId ||
+        conversation.needsUserAction
+      ) {
+        return conversation;
+      }
+      changed = true;
+      return { ...conversation, needsUserAction: true };
+    });
+    return changed ? next : visibleConversations;
+  }, [
+    input.activeConversationId,
+    session.pendingInteractivePrompt,
+    visibleConversations
+  ]);
+  const railActiveConversation = useMemo(() => {
+    if (
+      !activeConversation ||
+      session.pendingInteractivePrompt?.kind !== "plan-implementation" ||
+      activeConversation.needsUserAction
+    ) {
+      return activeConversation;
+    }
+    return { ...activeConversation, needsUserAction: true };
+  }, [activeConversation, session.pendingInteractivePrompt]);
   const providerHome = useAgentGUIProviderHome(input);
   const controllerActions = useAgentGUIControllerActions({
     ...input.operationActions,
@@ -217,9 +249,9 @@ export function useAgentGUIViewAssembly(input: UseAgentGUIViewAssemblyInput) {
       providerRailMode: input.providerRailMode ?? "catalog",
       comingSoonProviders: input.normalizedComingSoonProviders,
       conversationFilter: input.conversationFilter,
-      conversations: visibleConversations,
+      conversations: railConversations,
       userProjects: input.userProjects,
-      activeConversation,
+      activeConversation: railActiveConversation,
       activeConversationId: input.activeConversationId,
       revealRequest: input.railRevealRequest,
       isLoadingConversations: input.isLoadingConversations,

--- a/packages/agent/gui/shared/agentConversation/projection/workspaceAgentTimelineProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/workspaceAgentTimelineProjection.spec.ts
@@ -510,6 +510,37 @@ describe("projectWorkspaceAgentTimelineToConversationVM", () => {
 
     expect(detail.showProcessingIndicator).toBe(false);
   });
+
+  it("keeps processing after settle until authoritative terminal transcript content arrives", () => {
+    const userOnlyTimelineItems: WorkspaceAgentActivityTimelineItem[] = [
+      timelineItems()[0]!
+    ];
+    const settledWithoutFinal = {
+      ...session({
+        effectiveStatus: "working",
+        turnPhase: "working"
+      }),
+      activeTurn: activeTurn("settled")
+    };
+
+    const detail = buildCanonicalWorkspaceAgentDetailView({
+      activity: activity(),
+      session: settledWithoutFinal,
+      workspaceRoot: "/workspace/demo",
+      timelineItems: userOnlyTimelineItems
+    });
+    const conversation = projectWorkspaceAgentTimelineToConversationVM({
+      activity: activity(),
+      session: settledWithoutFinal,
+      workspaceRoot: "/workspace/demo",
+      timelineItems: userOnlyTimelineItems
+    });
+
+    expect(detail.showProcessingIndicator).toBe(true);
+    expect(conversation.rows.some((row) => row.kind === "processing")).toBe(
+      true
+    );
+  });
 });
 
 function activity(

--- a/packages/agent/gui/shared/workspaceAgentTimelineProjectionHelpers.ts
+++ b/packages/agent/gui/shared/workspaceAgentTimelineProjectionHelpers.ts
@@ -234,19 +234,59 @@ export function shouldShowProcessingIndicator(
   session: BuildWorkspaceAgentSessionDetailInput["session"],
   turns: readonly WorkspaceAgentSessionDetailTurn[]
 ): boolean {
-  if (!sessionHasRunnableIndicatorState(session)) return false;
-  const lastTurn = turns.at(-1);
-  if (!lastTurn) return true;
-  const lastAgentItem = lastTurn.agentItems.at(-1);
+  const activeTurn = session.activeTurn;
+  const settledTurn =
+    activeTurn == null
+      ? null
+      : (turns.find((turn) => turn.id === activeTurn.turnId) ??
+        turns.at(-1) ??
+        null);
+
+  if (sessionHasRunnableIndicatorState(session)) {
+    if (!settledTurn) return true;
+    const lastAgentItem = settledTurn.agentItems.at(-1);
+    if (
+      lastAgentItem?.kind === "message" &&
+      isTerminalAgentMessageStatus(lastAgentItem.message.statusKind) &&
+      !hasActiveRunningTurn(session)
+    ) {
+      return false;
+    }
+    return !settledTurn.toolCalls.some(
+      (call) => call.statusKind === "working" || call.statusKind === "waiting"
+    );
+  }
+
+  // Settle-to-final observation gap: the engine can mark the active turn
+  // settled before authoritative terminal transcript rows are observable.
+  // Keep the processing placeholder until that turn has terminal content.
+  if (!activeTurn || activeTurn.phase !== "settled") {
+    return false;
+  }
+  if (!settledTurn) {
+    return true;
+  }
+  if (settledTurn.agentItems.length === 0) {
+    return true;
+  }
+  const lastAgentItem = settledTurn.agentItems.at(-1);
   if (
     lastAgentItem?.kind === "message" &&
-    isTerminalAgentMessageStatus(lastAgentItem.message.statusKind) &&
-    !hasActiveRunningTurn(session)
+    isTerminalAgentMessageStatus(lastAgentItem.message.statusKind)
   ) {
     return false;
   }
-  return !lastTurn.toolCalls.some(
-    (call) => call.statusKind === "working" || call.statusKind === "waiting"
+  if (
+    settledTurn.toolCalls.some(
+      (call) => call.statusKind === "working" || call.statusKind === "waiting"
+    )
+  ) {
+    return false;
+  }
+  return !settledTurn.agentItems.some(
+    (item) =>
+      item.kind === "message" &&
+      isTerminalAgentMessageStatus(item.message.statusKind)
   );
 }
 


### PR DESCRIPTION
## Summary
- Project `needsUserAction` on the conversation rail when an unresolved synthetic plan-implementation prompt is active, so the waiting glyph matches the body card.
- Keep the canonical processing row across settle-to-final observation until authoritative terminal transcript content arrives, instead of dropping it as soon as the engine active turn settles.

## Tests
- `pnpm exec vitest run shared/agentConversation/projection/workspaceAgentTimelineProjection.spec.ts` in `packages/agent/gui`

## Notes
- TSH-owned AGUI defects are in a separate TSH PR; this release must land before any coordinated Tutti cohort upgrade there.
- Composer clear-after-historical-submit (6A) and missing generated-file card (10B) remain out of scope.


Made with [Cursor](https://cursor.com)