### PR TITLE
fix(agent-replay): accept short tool detail evidence

### DIFF
--- a/tools/scripts/run-agent-session-replay.mjs
+++ b/tools/scripts/run-agent-session-replay.mjs
@@ -2912,10 +2912,10 @@ export async function captureScreenshot(client, outputPath, options = {}) {
               return (element.textContent ?? '').trim().length > 0;
             });
             const commandVisible = Boolean(visibleCommand);
-            const toolDetailTextVisible = openRowReveals.some((reveal) => {
-              const text = (reveal.textContent ?? '').trim();
-              return text.length > 12;
-            });
+            const hasOpenToolDetailText = ${hasOpenToolDetailText.toString()};
+            const toolDetailTextVisible = hasOpenToolDetailText(
+              openRowReveals.map((reveal) => reveal.textContent ?? '')
+            );
             return {
               ready: commandVisible || toolDetailTextVisible,
               reason:
@@ -3390,10 +3390,10 @@ export async function prepareToolEvidenceForScreenshot(
           if (!painted) return false;
           return (element.textContent ?? '').trim().length > 0;
         });
-        const toolDetailTextVisible = openRowReveals.some((reveal) => {
-          const text = (reveal.textContent ?? '').trim();
-          return text.length > 12;
-        });
+        const hasOpenToolDetailText = ${hasOpenToolDetailText.toString()};
+        const toolDetailTextVisible = hasOpenToolDetailText(
+          openRowReveals.map((reveal) => reveal.textContent ?? '')
+        );
         return {
           ready: commandVisible || toolDetailTextVisible,
           openToolRevealCount: openRowReveals.length,
@@ -3415,6 +3415,12 @@ export async function prepareToolEvidenceForScreenshot(
     );
   }
   return null;
+}
+
+export function hasOpenToolDetailText(texts) {
+  return texts.some(
+    (text) => typeof text === "string" && text.trim().length > 0
+  );
 }
 
 function setMode(options, mode, directory) {

--- a/tools/scripts/run-agent-session-replay.test.mjs
+++ b/tools/scripts/run-agent-session-replay.test.mjs
@@ -47,6 +47,7 @@ import {
   checkpointNeedsScreenshotSettle,
   captureCheckpointScreenshot,
   captureScreenshot,
+  hasOpenToolDetailText,
   normalizeScreenshotClip,
   parseArgs,
   resolveDesktopHeadless,
@@ -77,6 +78,15 @@ import {
 const replayCassetteAID = "277377ed-af34-454f-a8b9-1047b4064e74";
 const replayCassetteBID = "628c61c4-cbcb-4445-83f7-718bbbd414bd";
 const workspaceRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+test("open tool detail accepts short rendered fileChange content", () => {
+  assert.equal(hasOpenToolDetailText(["R15_TEST"]), true);
+});
+
+test("open tool detail rejects missing or empty content", () => {
+  assert.equal(hasOpenToolDetailText([]), false);
+  assert.equal(hasOpenToolDetailText([null, undefined, " \n\t "]), false);
+});
 
 function respondToCheckpointVerification(request, response) {
   const match = request.url?.match(


### PR DESCRIPTION
## Summary
- 将 Replay 截图就绪判定从“工具详情文本长度大于 12”改为“存在任意非空文本”
- 同时修正截图捕获与 checkpoint 预处理中的两处相同判断
- 增加短 fileChange 内容和空内容的回归测试，覆盖 `R15_TEST` 场景

## Tests
- `node --test tools/scripts/run-agent-session-replay.test.mjs`：86/86 通过
- `pnpm check:changed`：6/6 lanes 通过
- pre-push `pnpm check:changed -- --push-ready`：5/5 lanes 通过
- pre-commit lint-staged、Oxlint 与 staged boundary checks 通过

## Notes
- 本 PR 仅包含 `tools/scripts/run-agent-session-replay.mjs` 及其测试文件
- 原工作区已有的 3 个 Windows 相关修改未包含
- 文档影响检查：不改变公共 API、CLI、配置或目录职责，无需更新持久文档