### PR TITLE
fix(agent-gui): clear setup auth pending when projection is ready

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentTargetSetupGate.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentTargetSetupGate.spec.tsx
@@ -107,6 +107,51 @@ describe("AgentTargetSetupGate", () => {
     expect(authenticate.mock.calls[0]?.[0]).toMatchObject({ methodId: "iOA" });
   });
 
+  it("stops showing Opening sign in once setup becomes ready while authenticate is still in flight", async () => {
+    let resolveAuthenticate: (() => void) | undefined;
+    const authenticate = vi.fn<AgentHostAgentTargetSetupWatch["authenticate"]>(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveAuthenticate = resolve;
+        })
+    );
+    const setup = createWatch(authRequired("extension:gemini"), {
+      authenticate
+    });
+    installHost(new Map([["extension:gemini", setup.watch]]));
+    render(<Harness openDialog target={geminiTarget} />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Continue to sign in" })
+    );
+    await waitFor(() => expect(authenticate).toHaveBeenCalledTimes(1));
+    expect(
+      screen.getByRole("button", { name: "Opening sign in…" })
+    ).toBeTruthy();
+
+    act(() =>
+      setup.publish({
+        ...ready("extension:gemini"),
+        authMethods: authRequired("extension:gemini").snapshot!.authMethods,
+        account: {
+          id: "user-1",
+          displayName: "sunhello135@gmail.com",
+          authMethodId: "oauth-personal",
+          organization: null
+        }
+      })
+    );
+
+    expect(await screen.findByText("Signed-in account")).toBeTruthy();
+    expect(screen.getByText("sunhello135@gmail.com")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Sign in again" })).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "Opening sign in…" })
+    ).toBeNull();
+
+    resolveAuthenticate?.();
+  });
+
   it("installs from the shared dialog and can reopen after dismissal", async () => {
     const install = vi.fn<AgentHostAgentTargetSetupWatch["install"]>();
     const setup = createWatch(notInstalled("extension:codebuddy"), { install });

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentTargetSetupGate.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentTargetSetupGate.tsx
@@ -156,6 +156,10 @@ export function AgentTargetSetupGate({
     account !== null ||
     snapshot?.status === "auth_required" ||
     snapshot?.status === "authenticating";
+  // Prefer setup projection over the local authenticate promise. OAuth can mark
+  // the account ready before the host login call settles.
+  const loginActionPending =
+    authenticatePending && snapshot?.status !== "ready";
 
   return (
     <>
@@ -295,10 +299,10 @@ export function AgentTargetSetupGate({
                       <Button
                         type="button"
                         size="sm"
-                        disabled={!effectiveAuthMethodId || authenticatePending}
+                        disabled={!effectiveAuthMethodId || loginActionPending}
                         onClick={() => void handleAuthenticate()}
                       >
-                        {authenticatePending
+                        {loginActionPending
                           ? t("agentHost.agentGui.targetSetupAuthStarting")
                           : snapshot?.status === "ready"
                             ? t("agentHost.agentGui.targetSetupReauthenticate")

--- a/packages/agent/gui/shared/agentEnv/agentTargetSetupController.tsx
+++ b/packages/agent/gui/shared/agentEnv/agentTargetSetupController.tsx
@@ -351,17 +351,23 @@ function createAgentTargetSetupController(input: {
         unsubscribe = input.watch.subscribe((setup) => {
           const notification = notifications.observe(setup);
           if (notification) input.onNotification(notification);
-          if (
-            state.terminalLoginPhase === "waiting" &&
-            setup.snapshot?.status === "ready"
-          ) {
+          const ready = setup.snapshot?.status === "ready";
+          // Setup projection is the source of truth for signed-in. Clear local
+          // in-flight flags as soon as ready arrives so CTAs cannot keep saying
+          // "opening login" after the checklist already shows a signed-in account.
+          if (ready && state.terminalLoginPhase === "waiting") {
             terminalLoginGeneration += 1;
             closeTerminalLoginHandle();
             update({
               setup,
+              authenticatePending: false,
               terminalLoginError: null,
               terminalLoginPhase: "idle"
             });
+            return;
+          }
+          if (ready && state.authenticatePending) {
+            update({ setup, authenticatePending: false });
             return;
           }
           update({ setup });


### PR DESCRIPTION
## Summary
- Clear local `authenticatePending` as soon as Agent Target setup projection reports `ready`, matching the existing terminal-login ready path.
- Prefer setup projection over the in-flight authenticate promise in `AgentTargetSetupGate`, so the CTA cannot keep saying “Opening sign in…” after a signed-in account is already shown.
- Add a regression test for OAuth completing (ready + account) while the host authenticate promise is still open.

## Tests
- `pnpm --dir packages/agent/gui exec vitest run agent-gui/agentGuiNode/view/AgentTargetSetupGate.spec.tsx`
- `pnpm check:changed -- --push-ready`

## Notes
- TSH still needs a Tutti cohort upgrade after this lands and publishes; no TSH-side override.
- `pnpm push:checked` / `check:full` currently fails on an unrelated agent-session-replay tool test (`next checkpoint fast-forwards…`); this change was validated with the changed-aware push-ready gate instead.

Made with [Cursor](https://cursor.com)