### PR TITLE
fix(agent-gui): place worktree icon before status indicator

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/agentGuiNodeViewConversation.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentGuiNodeViewConversation.spec.ts
@@ -77,6 +77,38 @@ describe("ConversationMeta", () => {
     expect(screen.getByTestId("agent-gui-conversation-spinner")).toBeVisible();
   });
 
+  it("keeps the worktree mark to the left of the loading indicator", () => {
+    const nowMs = new Date("2026-06-05T12:00:00Z").getTime();
+    const item = conversation("working-worktree", nowMs, {
+      status: "working",
+      isolation: {
+        mode: "worktree",
+        worktreePath: "/state/worktrees/session",
+        branch: "tutti/session",
+        baseCommit: "abc123"
+      }
+    });
+
+    const { container } = render(
+      createElement(ConversationMeta, {
+        item,
+        nowMs,
+        labels: relativeLabels
+      })
+    );
+
+    const meta = container.querySelector(
+      ".agent-gui-node__conversation-meta"
+    );
+    expect(meta?.firstElementChild).toHaveClass(
+      "agent-gui-node__conversation-worktree-glyph"
+    );
+    expect(meta?.lastElementChild).toHaveAttribute(
+      "data-testid",
+      "agent-gui-conversation-spinner"
+    );
+  });
+
   it("shows the ask indicator whenever a conversation needs user action", () => {
     const nowMs = new Date("2026-06-05T12:00:00Z").getTime();
     const item = conversation("user-action-waiting", nowMs, {

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentGuiNodeViewConversation.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentGuiNodeViewConversation.tsx
@@ -46,8 +46,8 @@ export function ConversationMeta({
         data-worktree={worktreeData}
         data-testid={`agent-gui-conversation-meta-${item.id}`}
       >
-        <LoadingGlyph />
         {worktreeGlyph}
+        <LoadingGlyph />
       </span>
     );
   }
@@ -60,11 +60,11 @@ export function ConversationMeta({
         data-worktree={worktreeData}
         data-testid={`agent-gui-conversation-meta-${item.id}`}
       >
+        {worktreeGlyph}
         <AskLinedIcon
           aria-hidden="true"
           className={styles.conversationStatusGlyph}
         />
-        {worktreeGlyph}
       </span>
     );
   }
@@ -77,8 +77,8 @@ export function ConversationMeta({
         data-worktree={worktreeData}
         data-testid={`agent-gui-conversation-meta-${item.id}`}
       >
-        <AttentionGlyph />
         {worktreeGlyph}
+        <AttentionGlyph />
       </span>
     );
   }
@@ -91,8 +91,8 @@ export function ConversationMeta({
         data-worktree={worktreeData}
         data-testid={`agent-gui-conversation-meta-${item.id}`}
       >
-        <span className={styles.conversationUnreadLamp} aria-hidden="true" />
         {worktreeGlyph}
+        <span className={styles.conversationUnreadLamp} aria-hidden="true" />
       </span>
     );
   }


### PR DESCRIPTION
## 摘要

- 将会话列表中的 worktree 图标固定在右侧元信息组的最左侧
- 将 loading、等待、失败和未读状态图标排在 worktree 图标之后
- 增加回归测试，确保 working worktree 会话的图标顺序稳定

## 验证

- 未运行检查：本次仅调整 UI 展示，遵循仓库对纯 UI 展示改动的检查例外

## 文档影响

- 无文档影响