### PR TITLE
fix(agent): persist canonical Turn identity anchors

### DIFF
--- a/packages/agent/activity-replication/README.md
+++ b/packages/agent/activity-replication/README.md
@@ -32,6 +32,16 @@ WebSocket behavior, or GUI-derived state. `runtimeOperation`,
 `runtimeOperationEvent`, and `submitClaim` are retained only as entity names
 for decoding tombstone deletes; new upserts are invalid.
 
+`Turn.identityAnchorTurnId` is an optional, provider-neutral identity relation.
+When present, the Turn inherits the ultimate external identity of another Turn
+in the same canonical Session; absence means the Turn owns its identity. The
+anchor is immutable, non-self-referential, and flattened to one hop by the
+canonical store. It does not change lifecycle, cancellation, interaction,
+provider-Turn binding, or message ownership. Cloud sinks must treat an omitted
+field as “not asserted” and must not clear an anchor already stored by a newer
+owner. This keeps old owners readable while limiting the new behavior to owners
+that actually emit the relation.
+
 The production module depends only on the nested, dependency-free
 `store-sqlite/canonical` module. The SQLite conformance adapter lives in the
 store module's tests, so importing this contract does not add the SQLite driver

--- a/packages/agent/activity-replication/types.go
+++ b/packages/agent/activity-replication/types.go
@@ -104,6 +104,7 @@ type Turn struct {
 	WorkspaceID                      string          `json:"workspaceId"`
 	AgentSessionID                   string          `json:"agentSessionId"`
 	TurnID                           string          `json:"turnId"`
+	IdentityAnchorTurnID             *string         `json:"identityAnchorTurnId,omitempty"`
 	Phase                            string          `json:"phase"`
 	Outcome                          *string         `json:"outcome"`
 	Error                            json.RawMessage `json:"error"`

--- a/packages/agent/activity-replication/validation.go
+++ b/packages/agent/activity-replication/validation.go
@@ -224,6 +224,12 @@ func validTurnMutation(mutation Mutation) bool {
 	if turn.Outcome != nil && !canonical.IsKnownTurnOutcome(*turn.Outcome) {
 		return false
 	}
+	if turn.IdentityAnchorTurnID != nil {
+		anchorTurnID := strings.TrimSpace(*turn.IdentityAnchorTurnID)
+		if anchorTurnID == "" || anchorTurnID == strings.TrimSpace(turn.TurnID) {
+			return false
+		}
+	}
 	if turn.Phase == canonical.TurnPhaseSettled {
 		if turn.Outcome == nil || turn.SettledAtUnixMS == nil {
 			return false

--- a/packages/agent/activity-replication/validation_test.go
+++ b/packages/agent/activity-replication/validation_test.go
@@ -23,6 +23,7 @@ func TestValidateMutationAcceptsEveryProjectionSnapshot(t *testing.T) {
 		}
 	}
 	turnID := "turn-1"
+	identityAnchorTurnID := "plan-turn-1"
 	tests := []struct {
 		name     string
 		mutation activityreplication.Mutation
@@ -56,7 +57,8 @@ func TestValidateMutationAcceptsEveryProjectionSnapshot(t *testing.T) {
 				mutation := base(activityreplication.EntityTurn, activityreplication.EntityKey{AgentSessionID: "session-1", TurnID: turnID})
 				mutation.Turn = &activityreplication.Turn{
 					WorkspaceID: "workspace-1", AgentSessionID: "session-1", TurnID: turnID,
-					Phase: canonical.TurnPhaseRunning, Origin: canonical.TurnOriginUserPrompt,
+					IdentityAnchorTurnID: &identityAnchorTurnID,
+					Phase:                canonical.TurnPhaseRunning, Origin: canonical.TurnOriginUserPrompt,
 					ProviderTurnBindingJSON: json.RawMessage(`{}`),
 				}
 				mutation.SessionScope = sessionScope
@@ -100,6 +102,33 @@ func TestValidateMutationAcceptsEveryProjectionSnapshot(t *testing.T) {
 			t.Parallel()
 			if err := activityreplication.ValidateMutation(test.mutation); err != nil {
 				t.Fatalf("ValidateMutation() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateMutationRejectsInvalidTurnIdentityAnchor(t *testing.T) {
+	t.Parallel()
+	for _, anchor := range []string{" ", "turn-1"} {
+		anchor := anchor
+		t.Run(anchor, func(t *testing.T) {
+			t.Parallel()
+			mutation := activityreplication.Mutation{
+				SchemaVersion: activityreplication.SchemaVersion, MutationID: "mutation-1", TransactionID: "transaction-1",
+				SourceDeviceID: "device-1", WorkspaceID: "workspace-1", EntityType: activityreplication.EntityTurn,
+				Operation: activityreplication.OperationUpsert,
+				Key:       activityreplication.EntityKey{AgentSessionID: "session-1", TurnID: "turn-1"},
+				Turn: &activityreplication.Turn{
+					WorkspaceID: "workspace-1", AgentSessionID: "session-1", TurnID: "turn-1",
+					IdentityAnchorTurnID: &anchor, Phase: canonical.TurnPhaseRunning,
+					Origin: canonical.TurnOriginUserPrompt, ProviderTurnBindingJSON: json.RawMessage(`{}`),
+				},
+				SessionScope: &activityreplication.SessionScope{
+					ExecutorOwnerUserID: "owner-1", SourceDeviceID: "device-1", Visibility: activityreplication.VisibilityMembers,
+				},
+			}
+			if err := activityreplication.ValidateMutation(mutation); err == nil {
+				t.Fatal("ValidateMutation() error = nil")
 			}
 		})
 	}

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -57,6 +57,14 @@ the Turn to `durably_accepted`. Streaming, waiting for approval/input, running
 tools, checkpoints, and terminal events all follow the barrier and retain the
 same authoritative provider Turn ID. Correlation IDs are never provider IDs.
 
+Canonical external identity inheritance is separate from provider acceptance
+and Turn lifecycle. A Turn may carry one immutable `IdentityAnchorTurnID`
+pointing to an ultimate Turn in the same Session. Plan-decision completion uses
+that generic relation when it confirms the implementation Turn, and commits the
+anchor before the completed notice in the same canonical transaction. Host and
+downstream projections consume only the relation; they never recover it from
+plan text, status notices, submit IDs, or transcript page history.
+
 The acceptance barrier does not decide whether the user's prompt is durable.
 After `Exec` returns an explicit rejection or an outcome-unknown timeout, Host
 records the submit provenance and lossless replay envelope on a

--- a/packages/agent/host/canonical_queries.go
+++ b/packages/agent/host/canonical_queries.go
@@ -108,8 +108,11 @@ func (h *Host) GetPlanDecisionContinuation(
 		operation.TurnID != parentTurnID {
 		return PlanDecisionContinuation{}, false, ErrRuntimeOperationIdentityMismatch
 	}
-	if operation.Status == storesqlite.RuntimeOperationStatusFailed {
+	if operation.Status != storesqlite.RuntimeOperationStatusCompleted {
 		return PlanDecisionContinuation{}, false, nil
+	}
+	if operation.Result != storesqlite.RuntimeOperationResultApplied {
+		return PlanDecisionContinuation{}, false, ErrRuntimeOperationIdentityMismatch
 	}
 	if runtimeOperationPayloadText(operation.Payload, "step") != "send_confirmed" {
 		return PlanDecisionContinuation{}, false, nil
@@ -142,6 +145,13 @@ func (h *Host) GetPlanDecisionContinuation(
 		turn.AgentSessionID != ref.AgentSessionID {
 		return PlanDecisionContinuation{}, false, ErrTurnNotFound
 	}
+	parentIdentityTurnID, err := h.resolveUltimateTurnIdentity(ctx, ref, parentTurnID)
+	if err != nil {
+		return PlanDecisionContinuation{}, false, err
+	}
+	if strings.TrimSpace(turn.IdentityAnchorTurnID) != parentIdentityTurnID {
+		return PlanDecisionContinuation{}, false, ErrRuntimeOperationIdentityMismatch
+	}
 	latest, err := h.store.ListSessionTurnSummaries(ctx, storesqlite.ListSessionTurnSummariesInput{
 		WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID, Limit: 1,
 	})
@@ -158,6 +168,41 @@ func (h *Host) GetPlanDecisionContinuation(
 		Session: session,
 		Turn:    turn,
 	}, true, nil
+}
+
+// resolveUltimateTurnIdentity returns the one-hop canonical Turn whose
+// external identity the requested Turn represents. Canonical persistence
+// flattens inherited identities, so a nested or dangling anchor is corruption
+// rather than another relation for callers to traverse.
+func (h *Host) resolveUltimateTurnIdentity(
+	ctx context.Context,
+	ref SessionRef,
+	turnID string,
+) (string, error) {
+	turn, found, err := h.store.GetTurn(ctx, ref.WorkspaceID, ref.AgentSessionID, turnID)
+	if err != nil {
+		return "", err
+	}
+	if !found || turn.TurnID != turnID || turn.AgentSessionID != ref.AgentSessionID {
+		return "", ErrTurnNotFound
+	}
+	anchorTurnID := strings.TrimSpace(turn.IdentityAnchorTurnID)
+	if anchorTurnID == "" {
+		return turnID, nil
+	}
+	if anchorTurnID == turnID {
+		return "", ErrRuntimeOperationIdentityMismatch
+	}
+	anchor, found, err := h.store.GetTurn(ctx, ref.WorkspaceID, ref.AgentSessionID, anchorTurnID)
+	if err != nil {
+		return "", err
+	}
+	if !found || anchor.TurnID != anchorTurnID ||
+		anchor.AgentSessionID != ref.AgentSessionID ||
+		strings.TrimSpace(anchor.IdentityAnchorTurnID) != "" {
+		return "", ErrRuntimeOperationIdentityMismatch
+	}
+	return anchorTurnID, nil
 }
 
 // FindTurnByClientSubmitID exposes the canonical idempotency lookup without

--- a/packages/agent/host/canonical_queries_test.go
+++ b/packages/agent/host/canonical_queries_test.go
@@ -31,11 +31,12 @@ type canonicalQueryStore struct {
 
 type planContinuationCanonicalStore struct {
 	CanonicalStore
-	session      storesqlite.Session
-	turn         storesqlite.Turn
-	submitTurnID string
-	submitFound  bool
-	turnPage     storesqlite.SessionTurnSummaryPage
+	session       storesqlite.Session
+	turn          storesqlite.Turn
+	identityTurns map[string]storesqlite.Turn
+	submitTurnID  string
+	submitFound   bool
+	turnPage      storesqlite.SessionTurnSummaryPage
 }
 
 func (s planContinuationCanonicalStore) GetSessionAndTurn(
@@ -46,6 +47,17 @@ func (s planContinuationCanonicalStore) GetSessionAndTurn(
 		return storesqlite.Session{}, storesqlite.Turn{}, false, errors.New("unexpected continuation identity")
 	}
 	return s.session, s.turn, true, nil
+}
+
+func (s planContinuationCanonicalStore) GetTurn(
+	_ context.Context,
+	workspaceID, sessionID, turnID string,
+) (storesqlite.Turn, bool, error) {
+	if workspaceID != s.session.WorkspaceID || sessionID != s.session.ID {
+		return storesqlite.Turn{}, false, errors.New("unexpected identity turn scope")
+	}
+	turn, found := s.identityTurns[turnID]
+	return turn, found, nil
 }
 
 func (s planContinuationCanonicalStore) FindTurnByClientSubmitID(
@@ -186,7 +198,8 @@ func TestGetPlanDecisionContinuationOwnsDurableParentChildProof(t *testing.T) {
 	operation := storesqlite.RuntimeOperation{
 		OperationID: operationID, WorkspaceID: ref.WorkspaceID,
 		AgentSessionID: ref.AgentSessionID, Kind: storesqlite.RuntimeOperationKindPlanDecision,
-		Status: storesqlite.RuntimeOperationStatusCompleted, TurnID: parentTurnID,
+		Status: storesqlite.RuntimeOperationStatusCompleted, Result: storesqlite.RuntimeOperationResultApplied,
+		TurnID: parentTurnID,
 		Payload: map[string]any{
 			"promptKind": "plan-implementation", "action": "implement",
 			"step": "send_confirmed", "confirmedTurnId": childTurnID,
@@ -195,7 +208,8 @@ func TestGetPlanDecisionContinuationOwnsDurableParentChildProof(t *testing.T) {
 	}
 	child := storesqlite.Turn{
 		WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
-		TurnID: childTurnID, Phase: storesqlite.TurnPhaseRunning,
+		TurnID: childTurnID, IdentityAnchorTurnID: parentTurnID,
+		Phase: storesqlite.TurnPhaseRunning,
 	}
 	host := New(Config{
 		CanonicalStore: planContinuationCanonicalStore{
@@ -203,7 +217,14 @@ func TestGetPlanDecisionContinuationOwnsDurableParentChildProof(t *testing.T) {
 				WorkspaceID: ref.WorkspaceID, ID: ref.AgentSessionID,
 				ActiveTurnID: childTurnID,
 			},
-			turn: child, submitTurnID: childTurnID, submitFound: true,
+			turn: child,
+			identityTurns: map[string]storesqlite.Turn{
+				parentTurnID: {
+					WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
+					TurnID: parentTurnID,
+				},
+			},
+			submitTurnID: childTurnID, submitFound: true,
 			turnPage: storesqlite.SessionTurnSummaryPage{Turns: []storesqlite.SessionTurnSummary{{TurnID: childTurnID}}},
 		},
 		RuntimeOperations: planContinuationOperationStore{operation: operation, found: true},
@@ -212,6 +233,60 @@ func TestGetPlanDecisionContinuationOwnsDurableParentChildProof(t *testing.T) {
 	got, found, err := host.GetPlanDecisionContinuation(t.Context(), ref, parentTurnID)
 	if err != nil || !found || !reflect.DeepEqual(got.Turn, child) || got.Session.ActiveTurnID != childTurnID {
 		t.Fatalf("GetPlanDecisionContinuation() = (%#v, %v, %v), want authorized child", got, found, err)
+	}
+}
+
+func TestGetPlanDecisionContinuationUsesParentsUltimateIdentity(t *testing.T) {
+	ref := SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-1"}
+	rootTurnID := "root-turn"
+	parentTurnID := "parent-turn"
+	childTurnID := "child-turn"
+	operationID := runtimeOperationID(
+		ref.WorkspaceID, ref.AgentSessionID,
+		storesqlite.RuntimeOperationKindPlanDecision, parentTurnID,
+	)
+	operation := storesqlite.RuntimeOperation{
+		OperationID: operationID, WorkspaceID: ref.WorkspaceID,
+		AgentSessionID: ref.AgentSessionID, Kind: storesqlite.RuntimeOperationKindPlanDecision,
+		Status: storesqlite.RuntimeOperationStatusCompleted, Result: storesqlite.RuntimeOperationResultApplied,
+		TurnID: parentTurnID,
+		Payload: map[string]any{
+			"promptKind": "plan-implementation", "action": "implement",
+			"step": "send_confirmed", "confirmedTurnId": childTurnID,
+			"clientSubmitId": "plan-decision:" + operationID,
+		},
+	}
+	child := storesqlite.Turn{
+		WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
+		TurnID: childTurnID, IdentityAnchorTurnID: rootTurnID,
+		Phase: storesqlite.TurnPhaseRunning,
+	}
+	host := New(Config{
+		CanonicalStore: planContinuationCanonicalStore{
+			session: storesqlite.Session{
+				WorkspaceID: ref.WorkspaceID, ID: ref.AgentSessionID,
+				ActiveTurnID: childTurnID,
+			},
+			turn: child,
+			identityTurns: map[string]storesqlite.Turn{
+				parentTurnID: {
+					WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
+					TurnID: parentTurnID, IdentityAnchorTurnID: rootTurnID,
+				},
+				rootTurnID: {
+					WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
+					TurnID: rootTurnID,
+				},
+			},
+			submitTurnID: childTurnID, submitFound: true,
+			turnPage: storesqlite.SessionTurnSummaryPage{Turns: []storesqlite.SessionTurnSummary{{TurnID: childTurnID}}},
+		},
+		RuntimeOperations: planContinuationOperationStore{operation: operation, found: true},
+	})
+
+	got, found, err := host.GetPlanDecisionContinuation(t.Context(), ref, parentTurnID)
+	if err != nil || !found || !reflect.DeepEqual(got.Turn, child) {
+		t.Fatalf("GetPlanDecisionContinuation() = (%#v, %v, %v), want flattened child identity", got, found, err)
 	}
 }
 
@@ -226,7 +301,8 @@ func TestGetPlanDecisionContinuationRejectsStaleChildBehindNewerTurn(t *testing.
 	operation := storesqlite.RuntimeOperation{
 		OperationID: operationID, WorkspaceID: ref.WorkspaceID,
 		AgentSessionID: ref.AgentSessionID, Kind: storesqlite.RuntimeOperationKindPlanDecision,
-		Status: storesqlite.RuntimeOperationStatusCompleted, TurnID: parentTurnID,
+		Status: storesqlite.RuntimeOperationStatusCompleted, Result: storesqlite.RuntimeOperationResultApplied,
+		TurnID: parentTurnID,
 		Payload: map[string]any{
 			"promptKind": "plan-implementation", "action": "implement",
 			"step": "send_confirmed", "confirmedTurnId": childTurnID,
@@ -234,8 +310,17 @@ func TestGetPlanDecisionContinuationRejectsStaleChildBehindNewerTurn(t *testing.
 		},
 	}
 	store := planContinuationCanonicalStore{
-		session:      storesqlite.Session{WorkspaceID: ref.WorkspaceID, ID: ref.AgentSessionID, ActiveTurnID: "newer-turn"},
-		turn:         storesqlite.Turn{WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID, TurnID: childTurnID},
+		session: storesqlite.Session{WorkspaceID: ref.WorkspaceID, ID: ref.AgentSessionID, ActiveTurnID: "newer-turn"},
+		turn: storesqlite.Turn{
+			WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
+			TurnID: childTurnID, IdentityAnchorTurnID: parentTurnID,
+		},
+		identityTurns: map[string]storesqlite.Turn{
+			parentTurnID: {
+				WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
+				TurnID: parentTurnID,
+			},
+		},
 		submitTurnID: childTurnID, submitFound: true,
 		turnPage: storesqlite.SessionTurnSummaryPage{Turns: []storesqlite.SessionTurnSummary{{TurnID: "newer-turn"}}},
 	}
@@ -271,6 +356,34 @@ func TestGetPlanDecisionContinuationDoesNotAuthorizeBeforeSubmitConfirmation(t *
 	_, found, err := host.GetPlanDecisionContinuation(t.Context(), ref, parentTurnID)
 	if err != nil || found {
 		t.Fatalf("GetPlanDecisionContinuation() = (found=%v, err=%v), want not-ready operation", found, err)
+	}
+}
+
+func TestGetPlanDecisionContinuationDoesNotExposeConfirmedSubmitBeforeCompletion(t *testing.T) {
+	ref := SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-1"}
+	parentTurnID := "parent-turn"
+	childTurnID := "child-turn"
+	operationID := runtimeOperationID(
+		ref.WorkspaceID, ref.AgentSessionID,
+		storesqlite.RuntimeOperationKindPlanDecision, parentTurnID,
+	)
+	operation := storesqlite.RuntimeOperation{
+		OperationID: operationID, WorkspaceID: ref.WorkspaceID,
+		AgentSessionID: ref.AgentSessionID, Kind: storesqlite.RuntimeOperationKindPlanDecision,
+		Status: storesqlite.RuntimeOperationStatusLeased, TurnID: parentTurnID,
+		Payload: map[string]any{
+			"promptKind": "plan-implementation", "action": "implement",
+			"step": "send_confirmed", "confirmedTurnId": childTurnID,
+			"clientSubmitId": "plan-decision:" + operationID,
+		},
+	}
+	host := New(Config{
+		CanonicalStore:    planContinuationCanonicalStore{},
+		RuntimeOperations: planContinuationOperationStore{operation: operation, found: true},
+	})
+	_, found, err := host.GetPlanDecisionContinuation(t.Context(), ref, parentTurnID)
+	if err != nil || found {
+		t.Fatalf("GetPlanDecisionContinuation() = (found=%v, err=%v), want completion barrier", found, err)
 	}
 }
 

--- a/packages/agent/host/conformance/conformance.go
+++ b/packages/agent/host/conformance/conformance.go
@@ -115,9 +115,11 @@ type CancelObservation struct {
 }
 
 type OperationObservation struct {
-	OperationID string
-	Status      string
-	Result      string
+	OperationID          string
+	Status               string
+	Result               string
+	ConfirmedTurnID      string
+	IdentityAnchorTurnID string
 }
 
 type InteractiveObservation struct {

--- a/packages/agent/host/conformance/coordinator_scenarios.go
+++ b/packages/agent/host/conformance/coordinator_scenarios.go
@@ -48,7 +48,8 @@ func runPlanDecision(ctx context.Context, driver Driver) error {
 		return fmt.Errorf("submit plan decision: %w", err)
 	}
 	metrics := driver.Metrics()
-	if operation.OperationID == "" || metrics.UpdateSettingsCalls != 1 || metrics.ExecCalls != 1 {
+	if operation.OperationID == "" || operation.ConfirmedTurnID == "" || operation.IdentityAnchorTurnID != "plan-turn" ||
+		metrics.UpdateSettingsCalls != 1 || metrics.ExecCalls != 1 {
 		return fmt.Errorf("plan operation=%#v metrics=%#v", operation, metrics)
 	}
 	return nil

--- a/packages/agent/host/historical_state.go
+++ b/packages/agent/host/historical_state.go
@@ -95,6 +95,7 @@ func ValidateHistoricalSessionGraph(graph HistoricalSessionGraph) error {
 			return fmt.Errorf("%w: duplicate Session %q", ErrHistoricalStateConflict, sessionID)
 		}
 		turns := make(map[string]struct{}, len(session.Turns))
+		turnAnchors := make(map[string]string, len(session.Turns))
 		for _, turn := range session.Turns {
 			turnID := strings.TrimSpace(turn.ID)
 			if turnID == "" {
@@ -104,6 +105,32 @@ func ValidateHistoricalSessionGraph(graph HistoricalSessionGraph) error {
 				return fmt.Errorf("%w: duplicate Turn %q", ErrHistoricalStateConflict, turnID)
 			}
 			turns[turnID] = struct{}{}
+			turnAnchors[turnID] = strings.TrimSpace(turn.IdentityAnchorTurnID)
+		}
+		for _, turn := range session.Turns {
+			anchorTurnID := strings.TrimSpace(turn.IdentityAnchorTurnID)
+			if anchorTurnID == "" {
+				continue
+			}
+			if anchorTurnID == strings.TrimSpace(turn.ID) {
+				return fmt.Errorf("%w: Turn %q anchors itself", ErrHistoricalStateConflict, turn.ID)
+			}
+			if _, exists := turns[anchorTurnID]; !exists {
+				return fmt.Errorf(
+					"%w: Turn %q references missing identity anchor %q",
+					ErrHistoricalStateConflict,
+					turn.ID,
+					anchorTurnID,
+				)
+			}
+			if turnAnchors[anchorTurnID] != "" {
+				return fmt.Errorf(
+					"%w: Turn %q identity anchor %q is not ultimate",
+					ErrHistoricalStateConflict,
+					turn.ID,
+					anchorTurnID,
+				)
+			}
 		}
 		for _, message := range session.Messages {
 			if strings.TrimSpace(message.ID) == "" {

--- a/packages/agent/host/historical_state_test.go
+++ b/packages/agent/host/historical_state_test.go
@@ -1,0 +1,67 @@
+package agenthost
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestValidateHistoricalSessionGraphAcceptsUltimateTurnIdentityAnchor(t *testing.T) {
+	graph := historicalIdentityAnchorGraph()
+	if err := ValidateHistoricalSessionGraph(graph); err != nil {
+		t.Fatalf("ValidateHistoricalSessionGraph() error = %v", err)
+	}
+}
+
+func TestValidateHistoricalSessionGraphRejectsInvalidTurnIdentityAnchors(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*HistoricalSessionGraph)
+	}{
+		{
+			name: "self",
+			mutate: func(graph *HistoricalSessionGraph) {
+				graph.Sessions[0].Turns[1].IdentityAnchorTurnID = "implementation-turn"
+			},
+		},
+		{
+			name: "missing",
+			mutate: func(graph *HistoricalSessionGraph) {
+				graph.Sessions[0].Turns[1].IdentityAnchorTurnID = "missing-turn"
+			},
+		},
+		{
+			name: "nested",
+			mutate: func(graph *HistoricalSessionGraph) {
+				graph.Sessions[0].Turns = append(graph.Sessions[0].Turns, HistoricalTurn{
+					ID: "nested-turn", IdentityAnchorTurnID: "implementation-turn",
+					Phase: "settled", Origin: "user_prompt",
+				})
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			graph := historicalIdentityAnchorGraph()
+			test.mutate(&graph)
+			if err := ValidateHistoricalSessionGraph(graph); !errors.Is(err, ErrHistoricalStateConflict) {
+				t.Fatalf("ValidateHistoricalSessionGraph() error = %v, want conflict", err)
+			}
+		})
+	}
+}
+
+func historicalIdentityAnchorGraph() HistoricalSessionGraph {
+	return HistoricalSessionGraph{
+		RootSessionID: "session-root",
+		Sessions: []HistoricalSession{{
+			ID: "session-root", Kind: "root", AgentTargetID: "local:codex",
+			Provider: "codex", ProviderSessionID: "provider-session-root",
+			Turns: []HistoricalTurn{
+				{ID: "plan-turn", Phase: "settled", Origin: "user_prompt"},
+				{
+					ID: "implementation-turn", IdentityAnchorTurnID: "plan-turn",
+					Phase: "settled", Origin: "user_prompt",
+				},
+			},
+		}},
+	}
+}

--- a/packages/agent/store-sqlite/activity_replication_conformance_test.go
+++ b/packages/agent/store-sqlite/activity_replication_conformance_test.go
@@ -372,7 +372,8 @@ func (b *sqliteProjectionBuilder) buildMutation(ctx context.Context, descriptor 
 func turnSnapshot(stored storesqlite.Turn) *activityreplication.Turn {
 	return &activityreplication.Turn{
 		WorkspaceID: stored.WorkspaceID, AgentSessionID: stored.AgentSessionID, TurnID: stored.TurnID,
-		Phase: stored.Phase, Outcome: nullable(stored.Outcome), Error: structuredResult(stored.ErrorMessage, stored.ErrorCode),
+		IdentityAnchorTurnID: nullable(stored.IdentityAnchorTurnID),
+		Phase:                stored.Phase, Outcome: nullable(stored.Outcome), Error: structuredResult(stored.ErrorMessage, stored.ErrorCode),
 		FileChanges: rawObject(stored.FileChanges), CompletedCommand: structuredResult(stored.CompletedCommandKind, stored.CompletedCommandStatus),
 		Backfilled: stored.Backfilled, Origin: stored.Origin, SourceGoalOperationID: nullable(stored.SourceGoalOperationID),
 		SourceGoalRevision:    nullableInt64(stored.SourceGoalOperationID, stored.SourceGoalRevision),

--- a/packages/agent/store-sqlite/activity_turn_scan.go
+++ b/packages/agent/store-sqlite/activity_turn_scan.go
@@ -8,7 +8,7 @@ import (
 )
 
 const agentTurnSelectSQL = `
-SELECT workspace_id, agent_session_id, turn_id, phase, outcome, error_json,
+SELECT workspace_id, agent_session_id, turn_id, COALESCE(identity_anchor_turn_id, ''), phase, outcome, error_json,
 	       file_changes_json, completed_command_json, backfilled,
 	       started_at_unix_ms, settled_at_unix_ms, created_at_unix_ms, updated_at_unix_ms,
 	       turn_origin, COALESCE(source_goal_operation_id, ''), COALESCE(source_goal_revision, 0),
@@ -35,6 +35,7 @@ func scanAgentTurn(scanner rowScanner) (Turn, error) {
 		&turn.WorkspaceID,
 		&turn.AgentSessionID,
 		&turn.TurnID,
+		&turn.IdentityAnchorTurnID,
 		&turn.Phase,
 		&outcome,
 		&errorJSON,

--- a/packages/agent/store-sqlite/historical_state.go
+++ b/packages/agent/store-sqlite/historical_state.go
@@ -51,6 +51,7 @@ type HistoricalSession struct {
 
 type HistoricalTurn struct {
 	ID                    string                `json:"id"`
+	IdentityAnchorTurnID  string                `json:"identityAnchorTurnId,omitempty"`
 	CapabilityRefs        []CapabilityReference `json:"capabilityRefs"`
 	Phase                 string                `json:"phase"`
 	Outcome               string                `json:"outcome,omitempty"`

--- a/packages/agent/store-sqlite/historical_state_capture.go
+++ b/packages/agent/store-sqlite/historical_state_capture.go
@@ -137,7 +137,7 @@ func (s *Store) captureHistoricalTurns(
 	session *HistoricalSession,
 ) error {
 	rows, err := s.db.QueryContext(ctx, `
-SELECT turn_id, phase, COALESCE(outcome, ''), COALESCE(error_json, '{}'),
+SELECT turn_id, COALESCE(identity_anchor_turn_id, ''), phase, COALESCE(outcome, ''), COALESCE(error_json, '{}'),
        COALESCE(file_changes_json, '{}'), COALESCE(completed_command_json, '{}'),
        turn_origin, COALESCE(source_goal_operation_id, ''),
        COALESCE(source_goal_revision, 0), COALESCE(source_goal_repair_epoch, 0),
@@ -160,7 +160,7 @@ ORDER BY COALESCE((
 		var turn HistoricalTurn
 		var errorJSON, filesJSON, commandJSON, capabilitiesJSON string
 		if err := rows.Scan(
-			&turn.ID, &turn.Phase, &turn.Outcome, &errorJSON, &filesJSON,
+			&turn.ID, &turn.IdentityAnchorTurnID, &turn.Phase, &turn.Outcome, &errorJSON, &filesJSON,
 			&commandJSON, &turn.Origin, &turn.SourceGoalOperationID,
 			&turn.SourceGoalRevision, &turn.SourceGoalRepairEpoch,
 			&turn.RootProviderTurnID, &capabilitiesJSON,

--- a/packages/agent/store-sqlite/historical_state_restore.go
+++ b/packages/agent/store-sqlite/historical_state_restore.go
@@ -320,16 +320,16 @@ func restoreHistoricalTurns(
 		}
 		_, err = tx.ExecContext(ctx, `
 INSERT INTO workspace_agent_turns (
-  workspace_id, agent_session_id, turn_id, phase, outcome, error_json,
+  workspace_id, agent_session_id, turn_id, identity_anchor_turn_id, phase, outcome, error_json,
   file_changes_json, completed_command_json, backfilled, turn_origin,
   source_goal_operation_id, source_goal_revision, source_goal_repair_epoch,
   started_at_unix_ms, settled_at_unix_ms, created_at_unix_ms,
   updated_at_unix_ms, root_provider_turn_id, root_provider_turn_phase,
   root_provider_turn_outcome, root_provider_turn_updated_at_unix_ms,
   capability_refs_json
-) VALUES (?, ?, ?, ?, NULLIF(?, ''), ?, ?, ?, 0, ?, NULLIF(?, ''),
+) VALUES (?, ?, ?, NULLIF(?, ''), ?, NULLIF(?, ''), ?, ?, ?, 0, ?, NULLIF(?, ''),
           NULLIF(?, 0), NULLIF(?, 0), ?, ?, ?, ?, NULLIF(?, ''), ?, ?, ?, ?)
-`, workspaceID, session.ID, turn.ID, turn.Phase, turn.Outcome,
+`, workspaceID, session.ID, turn.ID, turn.IdentityAnchorTurnID, turn.Phase, turn.Outcome,
 			string(errorJSON), string(filesJSON), string(commandJSON), turn.Origin,
 			turn.SourceGoalOperationID, turn.SourceGoalRevision,
 			turn.SourceGoalRepairEpoch, now, settledAt, now, now,

--- a/packages/agent/store-sqlite/historical_state_restore_test.go
+++ b/packages/agent/store-sqlite/historical_state_restore_test.go
@@ -61,3 +61,53 @@ func TestRestoreHistoricalSessionGraphBindsRuntimeUserOutsidePortableGraph(t *te
 		t.Fatalf("different runtime user restore error = %v", err)
 	}
 }
+
+func TestHistoricalSessionGraphRoundTripPreservesTurnIdentityAnchor(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	ctx := context.Background()
+	graph := HistoricalSessionGraph{
+		RootSessionID: "session-root",
+		Sessions: []HistoricalSession{{
+			ID: "session-root", Kind: SessionKindRoot,
+			AgentTargetID: "local:codex", Provider: "codex",
+			ProviderSessionID: "provider-session-root",
+			Settings:          map[string]any{},
+			RailSectionKind:   RailSectionKindConversations,
+			RailSectionKey:    RailSectionKeyConversations,
+			Turns: []HistoricalTurn{
+				{
+					ID: "plan-turn", CapabilityRefs: []CapabilityReference{},
+					Phase: TurnPhaseSettled, Outcome: TurnOutcomeCompleted,
+					Origin: TurnOriginUserPrompt,
+				},
+				{
+					ID: "implementation-turn", IdentityAnchorTurnID: "plan-turn",
+					CapabilityRefs: []CapabilityReference{}, Phase: TurnPhaseSettled,
+					Outcome: TurnOutcomeCompleted, Origin: TurnOriginUserPrompt,
+				},
+			},
+			Messages:     []HistoricalMessage{},
+			Interactions: []HistoricalInteraction{},
+		}},
+	}
+	if err := store.RestoreHistoricalSessionGraph(ctx, HistoricalSessionGraphRestoreInput{
+		WorkspaceID: "workspace-replay",
+		UserID:      "user-current",
+		Graph:       graph,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	turn, found, err := store.GetTurn(ctx, "workspace-replay", "session-root", "implementation-turn")
+	if err != nil || !found || turn.IdentityAnchorTurnID != "plan-turn" {
+		t.Fatalf("restored implementation Turn=%#v found=%v error=%v", turn, found, err)
+	}
+	captured, err := store.CaptureHistoricalSessionGraph(ctx, "workspace-replay", "session-root")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(captured.Sessions) != 1 || len(captured.Sessions[0].Turns) != 2 ||
+		captured.Sessions[0].Turns[1].IdentityAnchorTurnID != "plan-turn" {
+		t.Fatalf("captured historical identity anchor=%#v", captured)
+	}
+}

--- a/packages/agent/store-sqlite/migrations.go
+++ b/packages/agent/store-sqlite/migrations.go
@@ -84,6 +84,7 @@ const schemaMigrationWorkspaceAgentSessionForkV7 = "workspace_agent_session_fork
 const schemaMigrationWorkspaceAgentProviderCheckpointV1 = "workspace_agent_provider_checkpoint_v1"
 const schemaMigrationWorkspaceAgentProviderTurnBindingJSONV1 = "workspace_agent_provider_turn_binding_json_v1"
 const schemaMigrationWorkspaceAgentRecoverableDeletionV1 = "workspace_agent_recoverable_deletion_v1"
+const schemaMigrationWorkspaceAgentTurnIdentityAnchorV1 = "workspace_agent_turn_identity_anchor_v1"
 
 // claimableMigrationIDs are the migration IDs that may already be recorded
 // in the legacy tuttid ledger; the claim copies exactly these.
@@ -308,7 +309,10 @@ CREATE TABLE IF NOT EXISTS `+schemaMigrationsTable+` (
 	if err := s.applyWorkspaceAgentProviderTurnBindingJSONV1(ctx); err != nil {
 		return err
 	}
-	return s.applyWorkspaceAgentRecoverableDeletionV1(ctx)
+	if err := s.applyWorkspaceAgentRecoverableDeletionV1(ctx); err != nil {
+		return err
+	}
+	return s.applyWorkspaceAgentTurnIdentityAnchorV1(ctx)
 }
 
 // claimLegacyMigrations copies agent-store migration records that were

--- a/packages/agent/store-sqlite/migrations_turn_identity_anchor.go
+++ b/packages/agent/store-sqlite/migrations_turn_identity_anchor.go
@@ -1,0 +1,111 @@
+package storesqlite
+
+import (
+	"context"
+	"fmt"
+)
+
+type historicalTurnIdentityAnchor struct {
+	workspaceID    string
+	agentSessionID string
+	turnID         string
+	anchorTurnID   string
+}
+
+// applyWorkspaceAgentTurnIdentityAnchorV1 adds the provider-neutral identity
+// inheritance relation and repairs only historical plan continuations that
+// still have complete canonical operation and submit-message proof. Rows with
+// incomplete legacy evidence remain unclassified rather than being guessed.
+func (s *Store) applyWorkspaceAgentTurnIdentityAnchorV1(ctx context.Context) error {
+	applied, err := s.hasMigration(ctx, schemaMigrationWorkspaceAgentTurnIdentityAnchorV1)
+	if err != nil || applied {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin workspace agent turn identity anchor v1: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	hasColumn, err := hasColumnTx(ctx, tx, "workspace_agent_turns", "identity_anchor_turn_id")
+	if err != nil {
+		return err
+	}
+	if !hasColumn {
+		if _, err := tx.ExecContext(ctx, `
+ALTER TABLE workspace_agent_turns
+ADD COLUMN identity_anchor_turn_id TEXT
+  CHECK (identity_anchor_turn_id IS NULL OR
+    (length(trim(identity_anchor_turn_id)) > 0 AND identity_anchor_turn_id != turn_id))`); err != nil {
+			return fmt.Errorf("add workspace agent turn identity anchor: %w", err)
+		}
+	}
+
+	rows, err := tx.QueryContext(ctx, `
+SELECT operation.workspace_id,
+       operation.agent_session_id,
+       json_extract(operation.payload_json, '$.confirmedTurnId'),
+       operation.turn_id
+FROM workspace_agent_runtime_operations AS operation
+JOIN workspace_agent_turns AS parent_turn
+  ON parent_turn.workspace_id = operation.workspace_id
+ AND parent_turn.agent_session_id = operation.agent_session_id
+ AND parent_turn.turn_id = operation.turn_id
+JOIN workspace_agent_turns AS child_turn
+  ON child_turn.workspace_id = operation.workspace_id
+ AND child_turn.agent_session_id = operation.agent_session_id
+ AND child_turn.turn_id = json_extract(operation.payload_json, '$.confirmedTurnId')
+JOIN workspace_agent_messages AS submit_message
+  ON submit_message.workspace_id = operation.workspace_id
+ AND submit_message.agent_session_id = operation.agent_session_id
+ AND submit_message.turn_id = child_turn.turn_id
+ AND submit_message.deleted_at_unix_ms = 0
+ AND json_extract(submit_message.payload_json, '$.clientSubmitId') =
+     json_extract(operation.payload_json, '$.clientSubmitId')
+WHERE operation.kind = 'plan_decision'
+  AND operation.status = 'completed'
+  AND operation.result = 'applied'
+  AND json_extract(operation.payload_json, '$.promptKind') = 'plan-implementation'
+  AND json_extract(operation.payload_json, '$.action') = 'implement'
+  AND json_extract(operation.payload_json, '$.step') = 'send_confirmed'
+  AND length(json_extract(operation.payload_json, '$.confirmedTurnId')) > 0
+  AND json_extract(operation.payload_json, '$.confirmedTurnId') != operation.turn_id
+  AND json_extract(operation.payload_json, '$.clientSubmitId') = 'plan-decision:' || operation.operation_id
+  AND child_turn.identity_anchor_turn_id IS NULL
+ORDER BY operation.completed_at_unix_ms, operation.operation_id`)
+	if err != nil {
+		return fmt.Errorf("list historical workspace agent turn identity anchors: %w", err)
+	}
+	repairs := make([]historicalTurnIdentityAnchor, 0)
+	for rows.Next() {
+		var repair historicalTurnIdentityAnchor
+		if err := rows.Scan(&repair.workspaceID, &repair.agentSessionID, &repair.turnID, &repair.anchorTurnID); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan historical workspace agent turn identity anchor: %w", err)
+		}
+		repairs = append(repairs, repair)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("iterate historical workspace agent turn identity anchors: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close historical workspace agent turn identity anchors: %w", err)
+	}
+	for _, repair := range repairs {
+		if _, _, err := bindTurnIdentityAnchorTx(
+			ctx, tx, repair.workspaceID, repair.agentSessionID,
+			repair.turnID, repair.anchorTurnID, 0,
+		); err != nil {
+			return fmt.Errorf("repair historical workspace agent turn identity anchor: %w", err)
+		}
+	}
+
+	if err := recordMigrationTx(ctx, tx, schemaMigrationWorkspaceAgentTurnIdentityAnchorV1); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit workspace agent turn identity anchor v1: %w", err)
+	}
+	return nil
+}

--- a/packages/agent/store-sqlite/migrations_turn_identity_anchor.go
+++ b/packages/agent/store-sqlite/migrations_turn_identity_anchor.go
@@ -12,6 +12,70 @@ type historicalTurnIdentityAnchor struct {
 	anchorTurnID   string
 }
 
+type historicalTurnIdentityKey struct {
+	workspaceID    string
+	agentSessionID string
+	turnID         string
+}
+
+func (anchor historicalTurnIdentityAnchor) turnKey() historicalTurnIdentityKey {
+	return historicalTurnIdentityKey{
+		workspaceID:    anchor.workspaceID,
+		agentSessionID: anchor.agentSessionID,
+		turnID:         anchor.turnID,
+	}
+}
+
+func (anchor historicalTurnIdentityAnchor) anchorKey() historicalTurnIdentityKey {
+	return historicalTurnIdentityKey{
+		workspaceID:    anchor.workspaceID,
+		agentSessionID: anchor.agentSessionID,
+		turnID:         anchor.anchorTurnID,
+	}
+}
+
+// orderHistoricalTurnIdentityAnchorRepairs puts every repair after any repair
+// that establishes its requested anchor. This lets the binder flatten a
+// continuation chain to its ultimate identity even when operation timestamps
+// tie and their stable query order is not causal.
+func orderHistoricalTurnIdentityAnchorRepairs(
+	repairs []historicalTurnIdentityAnchor,
+) ([]historicalTurnIdentityAnchor, error) {
+	pendingByTurn := make(map[historicalTurnIdentityKey]int, len(repairs))
+	for _, repair := range repairs {
+		pendingByTurn[repair.turnKey()]++
+	}
+
+	waitingForTurn := make(map[historicalTurnIdentityKey][]int, len(repairs))
+	ready := make([]int, 0, len(repairs))
+	for index, repair := range repairs {
+		anchorKey := repair.anchorKey()
+		if pendingByTurn[anchorKey] == 0 {
+			ready = append(ready, index)
+			continue
+		}
+		waitingForTurn[anchorKey] = append(waitingForTurn[anchorKey], index)
+	}
+
+	ordered := make([]historicalTurnIdentityAnchor, 0, len(repairs))
+	for len(ready) > 0 {
+		index := ready[0]
+		ready = ready[1:]
+		repair := repairs[index]
+		ordered = append(ordered, repair)
+
+		turnKey := repair.turnKey()
+		pendingByTurn[turnKey]--
+		if pendingByTurn[turnKey] == 0 {
+			ready = append(ready, waitingForTurn[turnKey]...)
+		}
+	}
+	if len(ordered) != len(repairs) {
+		return nil, fmt.Errorf("%w: historical repair dependencies contain a cycle", ErrTurnIdentityAnchorConflict)
+	}
+	return ordered, nil
+}
+
 // applyWorkspaceAgentTurnIdentityAnchorV1 adds the provider-neutral identity
 // inheritance relation and repairs only historical plan continuations that
 // still have complete canonical operation and submit-message proof. Rows with
@@ -91,6 +155,10 @@ ORDER BY operation.completed_at_unix_ms, operation.operation_id`)
 	}
 	if err := rows.Close(); err != nil {
 		return fmt.Errorf("close historical workspace agent turn identity anchors: %w", err)
+	}
+	repairs, err = orderHistoricalTurnIdentityAnchorRepairs(repairs)
+	if err != nil {
+		return fmt.Errorf("order historical workspace agent turn identity anchors: %w", err)
 	}
 	for _, repair := range repairs {
 		if _, _, err := bindTurnIdentityAnchorTx(

--- a/packages/agent/store-sqlite/migrations_turns.go
+++ b/packages/agent/store-sqlite/migrations_turns.go
@@ -43,6 +43,9 @@ CREATE TABLE IF NOT EXISTS workspace_agent_turns (
   workspace_id TEXT NOT NULL,
   agent_session_id TEXT NOT NULL,
   turn_id TEXT NOT NULL CHECK (length(turn_id) > 0),
+  identity_anchor_turn_id TEXT
+    CHECK (identity_anchor_turn_id IS NULL OR
+      (length(trim(identity_anchor_turn_id)) > 0 AND identity_anchor_turn_id != turn_id)),
   phase TEXT NOT NULL CHECK (phase IN ('submitted','running','waiting','settling','settled')),
   outcome TEXT CHECK (outcome IS NULL OR outcome IN ('completed','failed','canceled','interrupted')),
   error_json TEXT,

--- a/packages/agent/store-sqlite/repository.go
+++ b/packages/agent/store-sqlite/repository.go
@@ -466,9 +466,14 @@ const (
 // provider-initiated interaction and carries both Goal provenance and the
 // root-provider completion projection.
 type Turn struct {
-	WorkspaceID                            string
-	AgentSessionID                         string
-	TurnID                                 string
+	WorkspaceID    string
+	AgentSessionID string
+	TurnID         string
+	// IdentityAnchorTurnID is the canonical Turn whose externally projected
+	// identity this Turn inherits. Empty means the Turn anchors itself. The
+	// field never replaces TurnID for lifecycle, provider, or interaction
+	// operations.
+	IdentityAnchorTurnID                   string
 	CapabilityRefs                         []CapabilityReference
 	Phase                                  string
 	Outcome                                string

--- a/packages/agent/store-sqlite/runtime_operation_completion.go
+++ b/packages/agent/store-sqlite/runtime_operation_completion.go
@@ -237,6 +237,12 @@ SELECT EXISTS(
 				if confirmed != 1 {
 					return "", "", nil, ErrRuntimeOperationSubjectState
 				}
+				if _, _, err := bindTurnIdentityAnchorTx(
+					ctx, tx, op.WorkspaceID, op.AgentSessionID,
+					confirmedTurnID, op.TurnID, input.NowUnixMS,
+				); err != nil {
+					return "", "", nil, fmt.Errorf("bind plan implementation turn identity: %w", err)
+				}
 				if err := completePlanDecisionNoticeTx(ctx, tx, op, confirmedTurnID, input.NowUnixMS); err != nil {
 					return "", "", nil, err
 				}
@@ -403,6 +409,18 @@ func runtimeOperationCompletionMutations(ctx context.Context, tx *sql.Tx, op Run
 			)
 		}
 	case RuntimeOperationEventPlanDecisionCompleted:
+		confirmedTurnID := payloadString(event.Payload, "confirmedTurnId")
+		turn, found, err := getAgentTurnTx(ctx, tx, op.WorkspaceID, op.AgentSessionID, confirmedTurnID)
+		if err != nil {
+			return nil, err
+		}
+		if !found {
+			return nil, ErrTurnIdentityAnchorConflict
+		}
+		mutations = append(mutations, transactionMutation(
+			op.WorkspaceID, op.AgentSessionID, MutationEntityTurn,
+			confirmedTurnID, "identity_anchor", turn.UpdatedAtUnixMS,
+		))
 		messageID := planDecisionNoticeMessageID(op.OperationID)
 		message, found, err := getAgentMessageForUpdate(ctx, tx, op.WorkspaceID, op.AgentSessionID, messageID)
 		if err != nil {

--- a/packages/agent/store-sqlite/runtime_operation_plan_decision_test.go
+++ b/packages/agent/store-sqlite/runtime_operation_plan_decision_test.go
@@ -115,6 +115,23 @@ WHERE workspace_id = 'ws-1' AND agent_session_id = 'session-1' AND message_id = 
 	if err != nil || !changed || completion.Operation.Result != RuntimeOperationResultApplied || completion.Event.Kind != RuntimeOperationEventPlanDecisionCompleted {
 		t.Fatalf("completion=%#v changed=%v err=%v", completion, changed, err)
 	}
+	var identityAnchorTurnID string
+	if err := store.db.QueryRow(`
+SELECT COALESCE(identity_anchor_turn_id, '')
+FROM workspace_agent_turns
+WHERE workspace_id = 'ws-1' AND agent_session_id = 'session-1' AND turn_id = 'implementation-turn'
+`).Scan(&identityAnchorTurnID); err != nil || identityAnchorTurnID != "turn-1" {
+		t.Fatalf("implementation identity anchor=%q err=%v", identityAnchorTurnID, err)
+	}
+	var sawIdentityMutation bool
+	for _, mutation := range completion.CommitDelta.Mutations {
+		if mutation.EntityKind == MutationEntityTurn && mutation.EntityID == "implementation-turn" && mutation.Operation == "identity_anchor" {
+			sawIdentityMutation = true
+		}
+	}
+	if !sawIdentityMutation {
+		t.Fatalf("completion mutations=%#v, want implementation Turn identity mutation", completion.CommitDelta.Mutations)
+	}
 	if err := store.db.QueryRow(`
 SELECT status, payload_json, COALESCE(turn_id, '') FROM workspace_agent_messages
 WHERE workspace_id = 'ws-1' AND agent_session_id = 'session-1' AND message_id = ?

--- a/packages/agent/store-sqlite/session_fork_identity.go
+++ b/packages/agent/store-sqlite/session_fork_identity.go
@@ -203,6 +203,16 @@ func remapSessionForkTurn(
 	}
 	turn.AgentSessionID = identityMap.TargetSessionID
 	turn.TurnID = targetTurnID
+	if sourceAnchorTurnID := strings.TrimSpace(turn.IdentityAnchorTurnID); sourceAnchorTurnID != "" {
+		targetAnchorTurnID, exists := identityMap.TurnIDs[sourceAnchorTurnID]
+		if !exists {
+			return Turn{}, fmt.Errorf(
+				"session fork turn identity anchor %q has no canonical mapping",
+				sourceAnchorTurnID,
+			)
+		}
+		turn.IdentityAnchorTurnID = targetAnchorTurnID
+	}
 	if sourceMessageID := strings.TrimSpace(turn.FinalAssistantMessageID); sourceMessageID != "" {
 		targetMessageID, exists := identityMap.MessageIDs[sourceMessageID]
 		if !exists {

--- a/packages/agent/store-sqlite/session_fork_snapshot.go
+++ b/packages/agent/store-sqlite/session_fork_snapshot.go
@@ -392,7 +392,7 @@ func insertForkedTurnTx(ctx context.Context, tx *sql.Tx, workspaceID, sessionID 
 	}
 	_, err = tx.ExecContext(ctx, `
 INSERT INTO workspace_agent_turns (
-  workspace_id, agent_session_id, turn_id, capability_refs_json, phase, outcome,
+  workspace_id, agent_session_id, turn_id, identity_anchor_turn_id, capability_refs_json, phase, outcome,
   error_json, file_changes_json, completed_command_json, backfilled,
   started_at_unix_ms, settled_at_unix_ms, created_at_unix_ms, updated_at_unix_ms,
   turn_origin, source_goal_operation_id, source_goal_revision, source_goal_repair_epoch,
@@ -400,8 +400,8 @@ INSERT INTO workspace_agent_turns (
   root_provider_turn_phase, root_provider_turn_outcome,
   root_provider_turn_error_json, root_provider_turn_completed_command_json,
   root_provider_turn_updated_at_unix_ms
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, ?, ?, ?, ?, ?, ?, ?)
-`, workspaceID, sessionID, turn.TurnID, string(capabilityRefsJSON), turn.Phase,
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, ?, ?, ?, ?, ?, ?, ?)
+`, workspaceID, sessionID, turn.TurnID, nullString(turn.IdentityAnchorTurnID), string(capabilityRefsJSON), turn.Phase,
 		nullString(turn.Outcome), encodeTurnErrorJSON(turn.ErrorMessage, turn.ErrorCode),
 		fileChangesJSON,
 		encodeCompletedCommandJSON(turn.CompletedCommandKind, turn.CompletedCommandStatus, finalAssistantWatermark{

--- a/packages/agent/store-sqlite/session_fork_test.go
+++ b/packages/agent/store-sqlite/session_fork_test.go
@@ -261,6 +261,31 @@ WHERE workspace_id = 'ws-1' AND agent_session_id = 'target'
 	}
 }
 
+func TestSessionForkRemapsTurnIdentityAnchorWithinFork(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	ctx := context.Background()
+	seedForkSession(t, store)
+	if _, err := store.db.ExecContext(ctx, `UPDATE workspace_agent_turns
+		SET identity_anchor_turn_id='turn-1'
+		WHERE workspace_id='ws-1' AND agent_session_id='source' AND turn_id='turn-2'`); err != nil {
+		t.Fatal(err)
+	}
+	result := commitFork(t, store, SessionForkPrepare{
+		OperationID: "fork-identity-anchor", WorkspaceID: "ws-1",
+		RequestID: "request-identity-anchor", RequestHash: "hash-identity-anchor",
+		SourceAgentSessionID: "source", TargetAgentSessionID: "target-identity-anchor",
+		SourceTurnID: "turn-2", DriverKind: "codex", DriverVersion: "1",
+		OccurredAtUnixMS: 100,
+	})
+	wantTurnID := deterministicSessionForkCanonicalID(result.Operation, "turn", "turn-2")
+	wantAnchorTurnID := deterministicSessionForkCanonicalID(result.Operation, "turn", "turn-1")
+	turn, found, err := store.GetTurn(ctx, "ws-1", "target-identity-anchor", wantTurnID)
+	if err != nil || !found || turn.IdentityAnchorTurnID != wantAnchorTurnID {
+		t.Fatalf("forked identity Turn=%#v found=%v error=%v wantAnchor=%q", turn, found, err, wantAnchorTurnID)
+	}
+}
+
 func TestHardPurgeForkSourceRemovesSnapshotAndKeepsTargetRestorable(t *testing.T) {
 	t.Parallel()
 	store := openTestStore(t, testOptions(&staticProjectPaths{}))

--- a/packages/agent/store-sqlite/turn_identity.go
+++ b/packages/agent/store-sqlite/turn_identity.go
@@ -1,0 +1,102 @@
+package storesqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var ErrTurnIdentityAnchorConflict = errors.New("workspace agent turn identity anchor conflicts with canonical state")
+
+// bindTurnIdentityAnchorTx gives one canonical Turn the already-established
+// external identity of another Turn in the same Session. The stored value is
+// always flattened to an ultimate anchor so consumers need only one lookup.
+// updatedAtUnixMS may be zero for migration repair that must preserve the
+// historical lifecycle timestamp.
+func bindTurnIdentityAnchorTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	workspaceID, agentSessionID, turnID, requestedAnchorTurnID string,
+	updatedAtUnixMS int64,
+) (Turn, bool, error) {
+	workspaceID = strings.TrimSpace(workspaceID)
+	agentSessionID = strings.TrimSpace(agentSessionID)
+	turnID = strings.TrimSpace(turnID)
+	requestedAnchorTurnID = strings.TrimSpace(requestedAnchorTurnID)
+	if tx == nil || workspaceID == "" || agentSessionID == "" || turnID == "" || requestedAnchorTurnID == "" || turnID == requestedAnchorTurnID {
+		return Turn{}, false, ErrTurnIdentityAnchorConflict
+	}
+
+	turn, found, err := getAgentTurnTx(ctx, tx, workspaceID, agentSessionID, turnID)
+	if err != nil {
+		return Turn{}, false, err
+	}
+	if !found {
+		return Turn{}, false, ErrTurnIdentityAnchorConflict
+	}
+	requestedAnchor, found, err := getAgentTurnTx(ctx, tx, workspaceID, agentSessionID, requestedAnchorTurnID)
+	if err != nil {
+		return Turn{}, false, err
+	}
+	if !found {
+		return Turn{}, false, ErrTurnIdentityAnchorConflict
+	}
+
+	anchorTurnID := requestedAnchor.TurnID
+	if inherited := strings.TrimSpace(requestedAnchor.IdentityAnchorTurnID); inherited != "" {
+		anchorTurnID = inherited
+		ultimate, ultimateFound, ultimateErr := getAgentTurnTx(ctx, tx, workspaceID, agentSessionID, anchorTurnID)
+		if ultimateErr != nil {
+			return Turn{}, false, ultimateErr
+		}
+		if !ultimateFound || strings.TrimSpace(ultimate.IdentityAnchorTurnID) != "" {
+			return Turn{}, false, ErrTurnIdentityAnchorConflict
+		}
+	}
+	if anchorTurnID == turnID {
+		return Turn{}, false, ErrTurnIdentityAnchorConflict
+	}
+
+	if current := strings.TrimSpace(turn.IdentityAnchorTurnID); current != "" {
+		if current != anchorTurnID {
+			return Turn{}, false, ErrTurnIdentityAnchorConflict
+		}
+		return turn, false, nil
+	}
+
+	query := `
+UPDATE workspace_agent_turns
+SET identity_anchor_turn_id = ?
+WHERE workspace_id = ? AND agent_session_id = ? AND turn_id = ?
+  AND identity_anchor_turn_id IS NULL`
+	args := []any{anchorTurnID, workspaceID, agentSessionID, turnID}
+	if updatedAtUnixMS > 0 {
+		query = `
+UPDATE workspace_agent_turns
+SET identity_anchor_turn_id = ?, updated_at_unix_ms = MAX(updated_at_unix_ms, ?)
+WHERE workspace_id = ? AND agent_session_id = ? AND turn_id = ?
+  AND identity_anchor_turn_id IS NULL`
+		args = []any{anchorTurnID, updatedAtUnixMS, workspaceID, agentSessionID, turnID}
+	}
+	result, err := tx.ExecContext(ctx, query, args...)
+	if err != nil {
+		return Turn{}, false, fmt.Errorf("bind workspace agent turn identity anchor: %w", err)
+	}
+	changed, err := rowsWereAffected(result, "bind workspace agent turn identity anchor")
+	if err != nil {
+		return Turn{}, false, err
+	}
+	if !changed {
+		return Turn{}, false, ErrTurnIdentityAnchorConflict
+	}
+	stored, found, err := getAgentTurnTx(ctx, tx, workspaceID, agentSessionID, turnID)
+	if err != nil {
+		return Turn{}, false, err
+	}
+	if !found {
+		return Turn{}, false, ErrTurnIdentityAnchorConflict
+	}
+	return stored, true, nil
+}

--- a/packages/agent/store-sqlite/turn_identity_test.go
+++ b/packages/agent/store-sqlite/turn_identity_test.go
@@ -110,3 +110,80 @@ WHERE workspace_id='ws-1' AND agent_session_id='session-1' AND turn_id='unproven
 		t.Fatalf("migration anchors: implementation=%q unproven=%q", implementationAnchor, unprovenAnchor)
 	}
 }
+
+func TestTurnIdentityAnchorMigrationTopologicallyFlattensContinuationChain(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	seedTurnTestSession(t, store, "ws-1", "session-1")
+	if _, err := store.db.Exec(`
+INSERT INTO workspace_agent_turns (
+  workspace_id, agent_session_id, turn_id, phase,
+  started_at_unix_ms, created_at_unix_ms, updated_at_unix_ms
+) VALUES
+  ('ws-1', 'session-1', 'turn-a', 'submitted', 1, 1, 1),
+  ('ws-1', 'session-1', 'turn-b', 'submitted', 2, 2, 2),
+  ('ws-1', 'session-1', 'turn-c', 'submitted', 3, 3, 3);
+
+INSERT INTO workspace_agent_messages (
+  workspace_id, agent_session_id, message_id, version, turn_id, role, kind,
+  status, payload_json, occurred_at_unix_ms, created_at_unix_ms, updated_at_unix_ms
+) VALUES
+  ('ws-1', 'session-1', 'submit-b', 1, 'turn-b', 'user', 'text', 'completed',
+   '{"clientSubmitId":"plan-decision:operation-z-parent"}', 4, 4, 4),
+  ('ws-1', 'session-1', 'submit-c', 2, 'turn-c', 'user', 'text', 'completed',
+   '{"clientSubmitId":"plan-decision:operation-a-descendant"}', 5, 5, 5);
+
+INSERT INTO workspace_agent_runtime_operations (
+  operation_id, workspace_id, agent_session_id, kind, status, result,
+  turn_id, request_id, payload_json, attempt, version, last_error,
+  created_at_unix_ms, updated_at_unix_ms, completed_at_unix_ms
+) VALUES
+  ('operation-z-parent', 'ws-1', 'session-1', 'plan_decision', 'completed', 'applied',
+   'turn-a', 'turn-a',
+   '{"promptKind":"plan-implementation","action":"implement","idempotencyKey":"decision-parent","step":"send_confirmed","clientSubmitId":"plan-decision:operation-z-parent","confirmedTurnId":"turn-b"}',
+   1, 1, '', 6, 7, 10),
+  ('operation-a-descendant', 'ws-1', 'session-1', 'plan_decision', 'completed', 'applied',
+   'turn-b', 'turn-b',
+   '{"promptKind":"plan-implementation","action":"implement","idempotencyKey":"decision-descendant","step":"send_confirmed","clientSubmitId":"plan-decision:operation-a-descendant","confirmedTurnId":"turn-c"}',
+   1, 1, '', 8, 9, 10);
+
+DELETE FROM agent_store_schema_migrations
+WHERE id = 'workspace_agent_turn_identity_anchor_v1';
+`); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.applyWorkspaceAgentTurnIdentityAnchorV1(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, expectation := range []struct {
+		turnID     string
+		wantAnchor string
+	}{
+		{turnID: "turn-b", wantAnchor: "turn-a"},
+		{turnID: "turn-c", wantAnchor: "turn-a"},
+	} {
+		var anchor string
+		if err := store.db.QueryRow(`
+SELECT COALESCE(identity_anchor_turn_id, '')
+FROM workspace_agent_turns
+WHERE workspace_id='ws-1' AND agent_session_id='session-1' AND turn_id=?
+`, expectation.turnID).Scan(&anchor); err != nil {
+			t.Fatal(err)
+		}
+		if anchor != expectation.wantAnchor {
+			t.Fatalf("turn %s identity anchor = %q, want %q", expectation.turnID, anchor, expectation.wantAnchor)
+		}
+	}
+}
+
+func TestOrderHistoricalTurnIdentityAnchorRepairsRejectsCycle(t *testing.T) {
+	t.Parallel()
+	_, err := orderHistoricalTurnIdentityAnchorRepairs([]historicalTurnIdentityAnchor{
+		{workspaceID: "ws-1", agentSessionID: "session-1", turnID: "turn-a", anchorTurnID: "turn-b"},
+		{workspaceID: "ws-1", agentSessionID: "session-1", turnID: "turn-b", anchorTurnID: "turn-a"},
+	})
+	if !errors.Is(err, ErrTurnIdentityAnchorConflict) {
+		t.Fatalf("cycle error = %v, want %v", err, ErrTurnIdentityAnchorConflict)
+	}
+}

--- a/packages/agent/store-sqlite/turn_identity_test.go
+++ b/packages/agent/store-sqlite/turn_identity_test.go
@@ -1,0 +1,112 @@
+package storesqlite
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestBindTurnIdentityAnchorFlattensAndPreservesIdentity(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	seedTurnTestSession(t, store, "ws-1", "session-1")
+	if _, err := store.db.Exec(`
+INSERT INTO workspace_agent_turns (
+  workspace_id, agent_session_id, turn_id, identity_anchor_turn_id, phase,
+  started_at_unix_ms, created_at_unix_ms, updated_at_unix_ms
+) VALUES
+  ('ws-1', 'session-1', 'root-turn', NULL, 'submitted', 1, 1, 1),
+  ('ws-1', 'session-1', 'intermediate-turn', 'root-turn', 'submitted', 2, 2, 2),
+  ('ws-1', 'session-1', 'child-turn', NULL, 'submitted', 3, 3, 3),
+  ('ws-1', 'session-1', 'other-turn', NULL, 'submitted', 4, 4, 4)
+`); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := store.db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	turn, changed, err := bindTurnIdentityAnchorTx(
+		context.Background(), tx, "ws-1", "session-1", "child-turn", "intermediate-turn", 10,
+	)
+	if err != nil || !changed || turn.IdentityAnchorTurnID != "root-turn" {
+		_ = tx.Rollback()
+		t.Fatalf("bind flattened identity anchor: turn=%#v changed=%v error=%v", turn, changed, err)
+	}
+	turn, changed, err = bindTurnIdentityAnchorTx(
+		context.Background(), tx, "ws-1", "session-1", "child-turn", "root-turn", 11,
+	)
+	if err != nil || changed || turn.IdentityAnchorTurnID != "root-turn" {
+		_ = tx.Rollback()
+		t.Fatalf("repeat identity anchor: turn=%#v changed=%v error=%v", turn, changed, err)
+	}
+	if _, _, err := bindTurnIdentityAnchorTx(
+		context.Background(), tx, "ws-1", "session-1", "child-turn", "other-turn", 12,
+	); !errors.Is(err, ErrTurnIdentityAnchorConflict) {
+		_ = tx.Rollback()
+		t.Fatalf("identity anchor rewrite error = %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTurnIdentityAnchorMigrationBackfillsOnlyProvenContinuation(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	seedTurnTestSession(t, store, "ws-1", "session-1")
+	if _, err := store.db.Exec(`
+INSERT INTO workspace_agent_turns (
+  workspace_id, agent_session_id, turn_id, phase,
+  started_at_unix_ms, created_at_unix_ms, updated_at_unix_ms
+) VALUES
+  ('ws-1', 'session-1', 'plan-turn', 'submitted', 1, 1, 1),
+  ('ws-1', 'session-1', 'implementation-turn', 'submitted', 2, 2, 2),
+  ('ws-1', 'session-1', 'unproven-turn', 'submitted', 3, 3, 3);
+
+INSERT INTO workspace_agent_messages (
+  workspace_id, agent_session_id, message_id, version, turn_id, role, kind,
+  status, payload_json, occurred_at_unix_ms, created_at_unix_ms, updated_at_unix_ms
+) VALUES (
+  'ws-1', 'session-1', 'implementation-submit', 1, 'implementation-turn',
+  'user', 'text', 'completed', '{"clientSubmitId":"plan-decision:operation-1"}', 4, 4, 4
+);
+
+INSERT INTO workspace_agent_runtime_operations (
+  operation_id, workspace_id, agent_session_id, kind, status, result,
+  turn_id, request_id, payload_json, attempt, version, last_error,
+  created_at_unix_ms, updated_at_unix_ms, completed_at_unix_ms
+) VALUES (
+  'operation-1', 'ws-1', 'session-1', 'plan_decision', 'completed', 'applied',
+  'plan-turn', 'plan-turn',
+  '{"promptKind":"plan-implementation","action":"implement","idempotencyKey":"decision-1","step":"send_confirmed","clientSubmitId":"plan-decision:operation-1","confirmedTurnId":"implementation-turn"}',
+  1, 1, '', 5, 6, 6
+);
+
+DELETE FROM agent_store_schema_migrations
+WHERE id = 'workspace_agent_turn_identity_anchor_v1';
+`); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.applyWorkspaceAgentTurnIdentityAnchorV1(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	var implementationAnchor, unprovenAnchor string
+	if err := store.db.QueryRow(`
+SELECT COALESCE(identity_anchor_turn_id, '')
+FROM workspace_agent_turns
+WHERE workspace_id='ws-1' AND agent_session_id='session-1' AND turn_id='implementation-turn'
+`).Scan(&implementationAnchor); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRow(`
+SELECT COALESCE(identity_anchor_turn_id, '')
+FROM workspace_agent_turns
+WHERE workspace_id='ws-1' AND agent_session_id='session-1' AND turn_id='unproven-turn'
+`).Scan(&unprovenAnchor); err != nil {
+		t.Fatal(err)
+	}
+	if implementationAnchor != "plan-turn" || unprovenAnchor != "" {
+		t.Fatalf("migration anchors: implementation=%q unproven=%q", implementationAnchor, unprovenAnchor)
+	}
+}

--- a/services/tuttid/service/agent/host_conformance_test.go
+++ b/services/tuttid/service/agent/host_conformance_test.go
@@ -283,7 +283,10 @@ func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconfo
 		turns:        map[string]agentactivitybiz.Turn{},
 		interactions: map[string][]agentactivitybiz.Interaction{},
 	}
-	d.operations = &runtimeOperationMemoryStore{interactionStore: d.turns}
+	d.operations = &runtimeOperationMemoryStore{
+		interactionStore:  d.turns,
+		turnIdentityStore: d.turns,
+	}
 	d.createdTurns = make(map[string]string)
 	steps := make([]string, 0)
 	d.recoverySteps = &steps
@@ -302,6 +305,7 @@ func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconfo
 	}}
 	d.runtime.provenanceHook = func(input RuntimeSubmitProvenanceInput) error {
 		d.recordSubmittedTurn(input.WorkspaceID, input.AgentSessionID, input.TurnID)
+		d.operations.recordConfirmedTurn(input.ClientSubmitID, input.TurnID)
 		return nil
 	}
 	if fixture.RejectInitialExec {
@@ -869,7 +873,8 @@ func (s *conformanceHistoricalStateStore) RestoreHistoricalSessionGraph(
 				WorkspaceID: workspaceID, AgentSessionID: historical.ID,
 				TurnID: turn.ID, Phase: turn.Phase, Outcome: turn.Outcome,
 				Origin: turn.Origin, RootProviderTurnID: turn.RootProviderTurnID,
-				StartedAtUnixMS: 1, SettledAtUnixMS: 1,
+				IdentityAnchorTurnID: turn.IdentityAnchorTurnID,
+				StartedAtUnixMS:      1, SettledAtUnixMS: 1,
 			}
 		}
 	}
@@ -960,9 +965,44 @@ func (d *legacyHostConformanceDriver) SubmitPlanDecision(
 	} else {
 		operation, err = d.service.SubmitPlanDecision(ctx, ref.WorkspaceID, ref.AgentSessionID, turnID, requestID, input)
 	}
-	return hostconformance.OperationObservation{
+	observation := hostconformance.OperationObservation{
 		OperationID: operation.OperationID, Status: operation.Status, Result: operation.Result,
-	}, err
+	}
+	if err != nil {
+		return observation, err
+	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		continuation, found, continuationErr := d.service.ApplicationHost().GetPlanDecisionContinuation(ctx, ref, turnID)
+		if continuationErr != nil {
+			return observation, continuationErr
+		}
+		if found {
+			observation.ConfirmedTurnID = continuation.Turn.TurnID
+			observation.IdentityAnchorTurnID = continuation.Turn.IdentityAnchorTurnID
+			return observation, nil
+		}
+		if time.Now().After(deadline) {
+			persisted, persistedFound, persistedErr := d.service.ApplicationHost().GetRuntimeOperation(
+				ctx,
+				ref.WorkspaceID,
+				operation.OperationID,
+			)
+			d.t.Logf(
+				"plan continuation timeout: operation=%#v found=%v err=%v turns=%#v",
+				persisted,
+				persistedFound,
+				persistedErr,
+				d.turns.turns,
+			)
+			return observation, nil
+		}
+		select {
+		case <-ctx.Done():
+			return observation, ctx.Err()
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
 }
 
 func (d *legacyHostConformanceDriver) UpdateTitle(ctx context.Context, input agenthost.UpdateTitleInput) (hostconformance.SessionObservation, error) {
@@ -1396,9 +1436,10 @@ func (d *legacyHostConformanceDriver) recordSubmittedTurn(workspaceID, sessionID
 	if turnID == "" {
 		return
 	}
+	startedAtUnixMS := int64(len(d.turns.turns) + 1)
 	d.turns.turns[sessionID+":"+turnID] = agentactivitybiz.Turn{
 		WorkspaceID: workspaceID, AgentSessionID: sessionID, TurnID: turnID,
-		Phase: agentactivitybiz.TurnPhaseSubmitted,
+		Phase: agentactivitybiz.TurnPhaseSubmitted, StartedAtUnixMS: startedAtUnixMS,
 	}
 	d.service.TurnStore = d.turns
 }

--- a/services/tuttid/service/agent/host_conformance_turn_store_test.go
+++ b/services/tuttid/service/agent/host_conformance_turn_store_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"sort"
 
 	agentactivitybiz "github.com/tutti-os/tutti/packages/agent/store-sqlite"
@@ -11,6 +12,29 @@ type legacyHostConformanceTurnStore struct {
 	sessions     map[string]agentactivitybiz.Session
 	turns        map[string]agentactivitybiz.Turn
 	interactions map[string][]agentactivitybiz.Interaction
+}
+
+func (s *legacyHostConformanceTurnStore) bindTurnIdentityAnchor(
+	workspaceID string,
+	sessionID string,
+	turnID string,
+	anchorTurnID string,
+) error {
+	turnKey := sessionID + ":" + turnID
+	turn, turnFound := s.turns[turnKey]
+	anchor, anchorFound := s.turns[sessionID+":"+anchorTurnID]
+	if !turnFound || !anchorFound ||
+		turn.WorkspaceID != workspaceID || anchor.WorkspaceID != workspaceID ||
+		turn.AgentSessionID != sessionID || anchor.AgentSessionID != sessionID {
+		return fmt.Errorf("bind turn identity anchor: turn or anchor not found")
+	}
+	if anchor.IdentityAnchorTurnID != "" ||
+		(turn.IdentityAnchorTurnID != "" && turn.IdentityAnchorTurnID != anchorTurnID) {
+		return agentactivitybiz.ErrTurnIdentityAnchorConflict
+	}
+	turn.IdentityAnchorTurnID = anchorTurnID
+	s.turns[turnKey] = turn
+	return nil
 }
 
 func (s *legacyHostConformanceTurnStore) GetLatestTurn(_ context.Context, _ string, sessionID string) (agentactivitybiz.Turn, bool, error) {

--- a/services/tuttid/service/agent/service_post_runtime_persistence_failure_test.go
+++ b/services/tuttid/service/agent/service_post_runtime_persistence_failure_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -454,9 +455,11 @@ type runtimeOperationMemoryStore struct {
 	operation         agentactivitybiz.RuntimeOperation
 	operations        map[string]agentactivitybiz.RuntimeOperation
 	interactionStore  runtimeOperationInteractionStore
+	turnIdentityStore runtimeOperationTurnIdentityStore
 	completeErr       error
 	events            []agentactivitybiz.RuntimeOperationEvent
 	confirmedTurnID   string
+	confirmedTurnIDs  map[string]string
 	checkpointSteps   []string
 	checkpointErr     error
 	cancelCompletions []agentactivitybiz.CompleteCancelRuntimeOperationInput
@@ -465,6 +468,10 @@ type runtimeOperationMemoryStore struct {
 type runtimeOperationInteractionStore interface {
 	interaction(sessionID, turnID, requestID string) (agentactivitybiz.Interaction, bool)
 	storeInteraction(agentactivitybiz.Interaction)
+}
+
+type runtimeOperationTurnIdentityStore interface {
+	bindTurnIdentityAnchor(workspaceID, sessionID, turnID, anchorTurnID string) error
 }
 
 func (s *runtimeOperationMemoryStore) operationsLocked() map[string]agentactivitybiz.RuntimeOperation {
@@ -526,8 +533,27 @@ func (s *runtimeOperationMemoryStore) CheckpointRuntimeOperation(_ context.Conte
 	return operation, true, nil
 }
 
-func (s *runtimeOperationMemoryStore) FindTurnByClientSubmitID(_ context.Context, _, _, _ string) (string, bool, error) {
+func (s *runtimeOperationMemoryStore) FindTurnByClientSubmitID(_ context.Context, _, _, clientSubmitID string) (string, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if turnID := s.confirmedTurnIDs[strings.TrimSpace(clientSubmitID)]; turnID != "" {
+		return turnID, true, nil
+	}
 	return s.confirmedTurnID, s.confirmedTurnID != "", nil
+}
+
+func (s *runtimeOperationMemoryStore) recordConfirmedTurn(clientSubmitID, turnID string) {
+	clientSubmitID = strings.TrimSpace(clientSubmitID)
+	turnID = strings.TrimSpace(turnID)
+	if clientSubmitID == "" || turnID == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.confirmedTurnIDs == nil {
+		s.confirmedTurnIDs = make(map[string]string)
+	}
+	s.confirmedTurnIDs[clientSubmitID] = turnID
 }
 
 type runtimeOperationFailingPublisher struct{ err error }
@@ -716,6 +742,17 @@ func (s *runtimeOperationMemoryStore) CompletePlanDecisionRuntimeOperation(_ con
 	operation, found := s.operationLocked(input.OperationID)
 	if !found {
 		return agentactivitybiz.RuntimeOperationCompletion{}, false, nil
+	}
+	confirmedTurnID := payloadText(operation.Payload, "confirmedTurnId")
+	if s.turnIdentityStore != nil && confirmedTurnID != "" {
+		if err := s.turnIdentityStore.bindTurnIdentityAnchor(
+			operation.WorkspaceID,
+			operation.AgentSessionID,
+			confirmedTurnID,
+			operation.TurnID,
+		); err != nil {
+			return agentactivitybiz.RuntimeOperationCompletion{}, false, err
+		}
 	}
 	operation.Status, operation.Result = agentactivitybiz.RuntimeOperationStatusCompleted, agentactivitybiz.RuntimeOperationResultApplied
 	operation.LeaseOwner, operation.LeaseExpiresAtMS = "", 0


### PR DESCRIPTION
## Summary

- 为通用 canonical Turn 增加可选的 `identityAnchorTurnId`，持久化“当前 Turn 继承哪个 ultimate Turn 的外部身份”
- 在 Plan implementation operation 完成事务中原子绑定 child Turn，并以 operation `completed` 作为 continuation 可见性的 durable barrier
- Host 查询校验 operation、submit evidence、ultimate identity 和最新 Turn，不再依赖消息标记或页面历史推断关系
- 让该关系完整经过 activity replication、历史 capture/restore、Session fork 与 conformance adapter
- 保持锚点不可变、同 Session、非 self、单跳展平；老调用方省略字段时视为“不声明”，不会清空已有关系

## Why

Shared-Agent transcript 使用版本游标分页时，当前页可能只包含 continuation message。若关系只存在于更早的 Plan submit/status message 中，投影会永久等待历史证据。这个改动把关系放回 canonical Turn 权威状态，供 tsh-server 等消费者按页稳定投影，同时不让消费者感知 Plan 协议。

独立 review 还覆盖并修正了两个边界：`send_confirmed` 到 operation completion 之间的并发窗口，以及已 anchored parent 继续产生 continuation 时必须比较 ultimate identity 的链式语义。

## Risk / rollout

- 这是 additive optional contract；老 Owner 可以继续写入，但升级前不会获得该特定投影修复
- 新消费者必须等待本 PR 合入并发布 Tutti 版本后再升级完整依赖 cohort；不使用 `replace` 或复制实现
- 历史 SQLite 只回填“completed operation + matching durable submit”能够严格证明的 continuation，证据不完整时保持未分类

## Verification

- `go test ./packages/agent/store-sqlite ./packages/agent/activity-replication ./packages/agent/host/conformance ./packages/agent/host ./packages/agent/session-replay ./packages/agent/daemon ./services/tuttid/service/agent -count=1`
- `pnpm check:changed -- --push-ready`（pre-push，23 lanes）
- `git diff --check`

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
