### PR TITLE
fix(agent-gui): resolve shared agent mention icons via handoff targets

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -18,9 +18,8 @@ import { AgentTargetInfoRendererProvider } from "../../shared/AgentTargetInfoRen
 import { AgentConversationClockProvider } from "../../shared/agentConversation/components/AgentConversationClock";
 import type { AgentGUINodeViewModel } from "./model/agentGuiNodeTypes";
 import {
-  agentTargetPresentationKey,
-  mergeAgentTargetsForMentionPresentations,
-  projectAgentTargetPresentations
+  mentionAgentTargetPresentationKey,
+  projectMentionAgentTargetPresentations
 } from "./model/agentGuiTargetPresentation";
 import styles from "./AgentGUINode.styles";
 import {
@@ -511,20 +510,18 @@ export function AgentGUINodeView({
       workspaceUserProjectI18n
     ]
   );
-  const mentionPresentationTargets = mergeAgentTargetsForMentionPresentations(
+  const targetPresentationKey = mentionAgentTargetPresentationKey(
     viewModel.rail.agentTargets,
     viewModel.composer.handoffAgentTargets
-  );
-  const targetPresentationKey = agentTargetPresentationKey(
-    mentionPresentationTargets
   );
   const agentTargetPresentations = useMemo<
     readonly AgentMessageMarkdownAgentTarget[]
   >(
     () =>
-      projectAgentTargetPresentations({
-        agentTargets: mentionPresentationTargets,
+      projectMentionAgentTargetPresentations({
+        handoffTargets: viewModel.composer.handoffAgentTargets,
         ownerSeparator: labels.sharedAgentOwnerSeparator,
+        railTargets: viewModel.rail.agentTargets,
         workspaceId: viewModel.shell.workspaceId
       }),
     [

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -511,29 +511,25 @@ export function AgentGUINodeView({
       workspaceUserProjectI18n
     ]
   );
+  const mentionPresentationTargets = mergeAgentTargetsForMentionPresentations(
+    viewModel.rail.agentTargets,
+    viewModel.composer.handoffAgentTargets
+  );
   const targetPresentationKey = agentTargetPresentationKey(
-    mergeAgentTargetsForMentionPresentations(
-      viewModel.rail.agentTargets,
-      viewModel.composer.handoffAgentTargets
-    )
+    mentionPresentationTargets
   );
   const agentTargetPresentations = useMemo<
     readonly AgentMessageMarkdownAgentTarget[]
   >(
     () =>
       projectAgentTargetPresentations({
-        agentTargets: mergeAgentTargetsForMentionPresentations(
-          viewModel.rail.agentTargets,
-          viewModel.composer.handoffAgentTargets
-        ),
+        agentTargets: mentionPresentationTargets,
         ownerSeparator: labels.sharedAgentOwnerSeparator,
         workspaceId: viewModel.shell.workspaceId
       }),
     [
       labels.sharedAgentOwnerSeparator,
       targetPresentationKey,
-      viewModel.composer.handoffAgentTargets,
-      viewModel.rail.agentTargets,
       viewModel.shell.workspaceId
     ]
   );

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -19,6 +19,7 @@ import { AgentConversationClockProvider } from "../../shared/agentConversation/c
 import type { AgentGUINodeViewModel } from "./model/agentGuiNodeTypes";
 import {
   agentTargetPresentationKey,
+  mergeAgentTargetsForMentionPresentations,
   projectAgentTargetPresentations
 } from "./model/agentGuiTargetPresentation";
 import styles from "./AgentGUINode.styles";
@@ -511,20 +512,28 @@ export function AgentGUINodeView({
     ]
   );
   const targetPresentationKey = agentTargetPresentationKey(
-    viewModel.rail.agentTargets
+    mergeAgentTargetsForMentionPresentations(
+      viewModel.rail.agentTargets,
+      viewModel.composer.handoffAgentTargets
+    )
   );
   const agentTargetPresentations = useMemo<
     readonly AgentMessageMarkdownAgentTarget[]
   >(
     () =>
       projectAgentTargetPresentations({
-        agentTargets: viewModel.rail.agentTargets,
+        agentTargets: mergeAgentTargetsForMentionPresentations(
+          viewModel.rail.agentTargets,
+          viewModel.composer.handoffAgentTargets
+        ),
         ownerSeparator: labels.sharedAgentOwnerSeparator,
         workspaceId: viewModel.shell.workspaceId
       }),
     [
       labels.sharedAgentOwnerSeparator,
       targetPresentationKey,
+      viewModel.composer.handoffAgentTargets,
+      viewModel.rail.agentTargets,
       viewModel.shell.workspaceId
     ]
   );

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiTargetPresentation.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiTargetPresentation.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { AgentGUIAgentTarget } from "../../../types";
 import {
   agentTargetPresentationKey,
+  mergeAgentTargetsForMentionPresentations,
   projectAgentTargetPresentations
 } from "./agentGuiTargetPresentation";
 
@@ -76,5 +77,46 @@ describe("Agent GUI target presentation projection", () => {
         }
       ])
     );
+  });
+
+  it("merges handoff-only shared targets into mention presentation lookup", () => {
+    const local: AgentGUIAgentTarget = {
+      ...TARGET,
+      agentTargetId: "local:codex",
+      label: "Codex",
+      provider: "codex",
+      targetId: "local:codex"
+    };
+    const shared: AgentGUIAgentTarget = {
+      ...TARGET,
+      agentTargetId: "shared-agent:jun-codex",
+      iconUrl: "data:image/png;base64,shared-codex",
+      label: "Codex",
+      ownerLabel: "Jun Sun",
+      ownership: "shared",
+      provider: "codex",
+      targetId: "shared-agent:jun-codex"
+    };
+
+    expect(
+      mergeAgentTargetsForMentionPresentations([local], [local, shared])
+    ).toEqual([local, shared]);
+    expect(
+      projectAgentTargetPresentations({
+        agentTargets: mergeAgentTargetsForMentionPresentations(
+          [local],
+          [shared]
+        ),
+        ownerSeparator: " 的 ",
+        workspaceId: "workspace-1"
+      })
+    ).toMatchObject([
+      { agentTargetId: "local:codex", iconUrl: local.iconUrl },
+      {
+        agentTargetId: "shared-agent:jun-codex",
+        iconUrl: "data:image/png;base64,shared-codex",
+        name: "Jun Sun 的 Codex"
+      }
+    ]);
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiTargetPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiTargetPresentation.ts
@@ -18,6 +18,36 @@ export function agentTargetPresentationKey(
   );
 }
 
+/**
+ * Transcript mentions are markdown links that only carry target id + workspace.
+ * Icon lookup therefore needs every Agent the host can already hand off to, not
+ * only the current directory rail. Local conversations that @ a shared Agent
+ * otherwise miss the target and fall back to the colorful "all agents" glyph.
+ */
+export function mergeAgentTargetsForMentionPresentations(
+  railTargets: readonly AgentGUIAgentTarget[],
+  handoffTargets: readonly AgentGUIAgentTarget[] = []
+): readonly AgentGUIAgentTarget[] {
+  if (handoffTargets.length === 0) {
+    return railTargets;
+  }
+  const byId = new Map<string, AgentGUIAgentTarget>();
+  for (const target of railTargets) {
+    const agentTargetId = target.agentTargetId?.trim();
+    if (agentTargetId) {
+      byId.set(agentTargetId, target);
+    }
+  }
+  for (const target of handoffTargets) {
+    const agentTargetId = target.agentTargetId?.trim();
+    if (!agentTargetId || byId.has(agentTargetId)) {
+      continue;
+    }
+    byId.set(agentTargetId, target);
+  }
+  return byId.size === railTargets.length ? railTargets : [...byId.values()];
+}
+
 export function projectAgentTargetPresentations(input: {
   agentTargets: readonly AgentGUIAgentTarget[];
   ownerSeparator: string;

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiTargetPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiTargetPresentation.ts
@@ -48,6 +48,31 @@ export function mergeAgentTargetsForMentionPresentations(
   return byId.size === railTargets.length ? railTargets : [...byId.values()];
 }
 
+export function mentionAgentTargetPresentationKey(
+  railTargets: readonly AgentGUIAgentTarget[],
+  handoffTargets: readonly AgentGUIAgentTarget[] = []
+): string {
+  return agentTargetPresentationKey(
+    mergeAgentTargetsForMentionPresentations(railTargets, handoffTargets)
+  );
+}
+
+export function projectMentionAgentTargetPresentations(input: {
+  handoffTargets?: readonly AgentGUIAgentTarget[];
+  ownerSeparator: string;
+  railTargets: readonly AgentGUIAgentTarget[];
+  workspaceId: string;
+}): readonly AgentMessageMarkdownAgentTarget[] {
+  return projectAgentTargetPresentations({
+    agentTargets: mergeAgentTargetsForMentionPresentations(
+      input.railTargets,
+      input.handoffTargets
+    ),
+    ownerSeparator: input.ownerSeparator,
+    workspaceId: input.workspaceId
+  });
+}
+
 export function projectAgentTargetPresentations(input: {
   agentTargets: readonly AgentGUIAgentTarget[];
   ownerSeparator: string;

--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -1552,6 +1552,41 @@ describe("AgentMessageMarkdown", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("hydrates shared agent-target mention icons from the presentation catalog", () => {
+    const iconUrl = "data:image/png;base64,shared-codex";
+    const { container } = render(
+      <AgentMessageMarkdown
+        agentTargets={[
+          {
+            agentTargetId: "shared-agent:jun-codex",
+            iconUrl,
+            name: "Jun Sun 的 Codex",
+            provider: "codex",
+            workspaceId: "room-1"
+          }
+        ]}
+        content="[@Jun Sun 的 Codex](mention://agent-target/shared-agent:jun-codex?workspaceId=room-1) what is this"
+      />
+    );
+
+    const mention = container.querySelector('[data-agent-file-mention="true"]');
+    expect(mention).toHaveAttribute("data-agent-mention-kind", "agent-target");
+    expect(mention).toHaveAttribute("data-agent-mention-icon-url", iconUrl);
+    expect(mention?.querySelector("img")).toHaveAttribute("src", iconUrl);
+  });
+
+  it("falls back to a scoped provider icon when the presentation catalog misses", () => {
+    const { container } = render(
+      <AgentMessageMarkdown content="[@Jun Sun 的 Codex](mention://agent-target/shared-agent:jun-codex?workspaceId=room-1&agentProviderId=codex) what is this" />
+    );
+
+    const mention = container.querySelector('[data-agent-file-mention="true"]');
+    expect(mention).toHaveAttribute(
+      "data-agent-mention-icon-url",
+      managedAgentRoundedIconUrl("codex")
+    );
+  });
+
   it("renders workspace app factory mentions as object tokens", () => {
     const { container, queryByText } = render(
       <AgentMessageMarkdown content="[@Create App](mention://workspace-app-factory/create)" />

--- a/packages/agent/gui/shared/agentMessageMarkdownLinks.ts
+++ b/packages/agent/gui/shared/agentMessageMarkdownLinks.ts
@@ -507,7 +507,9 @@ export function parseMentionLink(
       agentTargets,
       workspaceId
     });
-    const agentProviderId = target?.provider?.trim() || undefined;
+    const scopedProvider = mention.scope?.agentProviderId?.trim() || "";
+    const agentProviderId =
+      target?.provider?.trim() || scopedProvider || undefined;
     const targetLabel = target?.name?.trim() || label;
     return {
       ...identity,


### PR DESCRIPTION
## Summary
- Transcript `@agent-target` mentions are markdown links without icons; icon lookup previously used only the current directory rail, so local conversations that @ a shared Agent missed the target and fell back to the colorful “all agents” glyph.
- Merge rail ∪ `handoffAgentTargets` for mention presentation lookup, and accept `scope.agentProviderId` when the catalog miss still leaves provider unknown.
- Keep `AgentGUINodeView` under the degradation line budget by extracting mention presentation helpers.

## Test plan
- [x] `pnpm --filter @tutti-os/agent-gui exec vitest run agent-gui/agentGuiNode/model/agentGuiTargetPresentation.spec.ts shared/AgentMessageMarkdown.spec.tsx`
- [ ] In TSH with this package (or after cohort upgrade): open a local Agent conversation, `@` another member’s Codex/Claude/Tutti Agent, confirm the pill uses provider artwork (including already-sent transcript bubbles after hydrate).


Made with [Cursor](https://cursor.com)