### PR TITLE
fix(agent-host): serialize canonical session initialization

### DIFF
--- a/packages/agent/daemon/hostadapter/runtime.go
+++ b/packages/agent/daemon/hostadapter/runtime.go
@@ -19,6 +19,7 @@ import (
 // *runtime.Controller implements this interface.
 type RuntimeBackend interface {
 	Start(context.Context, agentruntime.StartInput) (agentruntime.StartResult, error)
+	PublishSessionInitialization(context.Context, string, string) (agentruntime.Session, error)
 	Resume(context.Context, agentruntime.ResumeInput) (agentruntime.Session, error)
 	Session(string, string) (agentruntime.Session, bool)
 	State(string, string) (agentruntime.SessionStateSnapshot, error)
@@ -52,6 +53,7 @@ type RuntimeController struct {
 
 var (
 	_ host.RuntimeController                       = (*RuntimeController)(nil)
+	_ host.RuntimeSessionInitializationPublisher   = (*RuntimeController)(nil)
 	_ host.RuntimeHistoryController                = (*RuntimeController)(nil)
 	_ host.RuntimeProviderTurnAcceptanceReconciler = (*RuntimeController)(nil)
 	_ host.RuntimeSessionLiveness                  = (*RuntimeController)(nil)
@@ -133,9 +135,9 @@ func (a *RuntimeController) RollbackLatestTurn(
 	return projected, mapRuntimeError(err)
 }
 
-func (a *RuntimeController) Start(ctx context.Context, input host.RuntimeStartInput) (host.ProviderRuntimeSession, error) {
+func (a *RuntimeController) Start(ctx context.Context, input host.RuntimeStartInput) (host.RuntimeStartResult, error) {
 	if err := a.requireBackend(); err != nil {
-		return host.ProviderRuntimeSession{}, err
+		return host.RuntimeStartResult{}, err
 	}
 	result, err := a.Backend.Start(ctx, agentruntime.StartInput{
 		RoomID:                  input.WorkspaceID,
@@ -161,14 +163,33 @@ func (a *RuntimeController) Start(ctx context.Context, input host.RuntimeStartIn
 			Speed:                  input.Speed,
 			ConversationDetailMode: input.ConversationDetailMode,
 		}),
-		Provisional: input.Provisional,
+		Provisional:          input.Provisional,
+		CanonicalInitPending: input.CanonicalInitPending,
 	})
 	if err != nil {
-		return host.ProviderRuntimeSession{}, mapRuntimeError(err)
+		return host.RuntimeStartResult{}, mapRuntimeError(err)
 	}
 	session := a.sessionWithState(result.Session)
 	session.Provisional = input.Provisional
-	return session, nil
+	return host.RuntimeStartResult{Session: session, Created: result.Created}, nil
+}
+
+func (a *RuntimeController) PublishSessionInitialization(
+	ctx context.Context,
+	input host.RuntimeSessionInitializationPublishInput,
+) (host.ProviderRuntimeSession, error) {
+	if err := a.requireBackend(); err != nil {
+		return host.ProviderRuntimeSession{}, err
+	}
+	session, err := a.Backend.PublishSessionInitialization(
+		ctx,
+		input.WorkspaceID,
+		input.AgentSessionID,
+	)
+	if err != nil {
+		return host.ProviderRuntimeSession{}, mapRuntimeError(err)
+	}
+	return a.sessionWithState(session), nil
 }
 
 func (a *RuntimeController) Resume(ctx context.Context, input host.RuntimeResumeInput) (host.ProviderRuntimeSession, error) {
@@ -769,97 +790,4 @@ func runtimeCapabilityReferences(input []host.CapabilityReference) []agentruntim
 		})
 	}
 	return references
-}
-
-func runtimeTuttiModeSnapshot(input *host.TuttiModeTurnSnapshot) *agentruntime.TuttiModeTurnSnapshot {
-	if input == nil {
-		return nil
-	}
-	legacyOrchestrationIntensity := input.OrchestrationIntensity //nolint:staticcheck // Compatibility bridge preserves version-zero snapshots.
-	return &agentruntime.TuttiModeTurnSnapshot{
-		ActivationID: input.ActivationID, RevisionID: input.RevisionID, Revision: input.Revision,
-		State: input.State, Source: input.Source,
-		PreferenceVersion:      input.PreferenceVersion,
-		Effect:                 input.Effect,
-		Speed:                  input.Speed,
-		OrchestrationIntensity: legacyOrchestrationIntensity,
-	}
-}
-
-func runtimeSettings(settings host.ComposerSettings) *agentruntime.SessionSettings {
-	return &agentruntime.SessionSettings{
-		CodexSaverMode: settings.CodexSaverMode,
-		Model:          settings.Model, ReasoningEffort: settings.ReasoningEffort, Speed: settings.Speed,
-		PlanMode: settings.PlanMode, BrowserUse: settings.BrowserUse, ComputerUse: settings.ComputerUse,
-		PermissionModeID: settings.PermissionModeID, ConversationDetailMode: settings.ConversationDetailMode,
-	}
-}
-
-func hostSettings(settings agentruntime.SessionSettings) host.ComposerSettings {
-	return host.ComposerSettings{
-		CodexSaverMode: settings.CodexSaverMode,
-		Model:          settings.Model, ReasoningEffort: settings.ReasoningEffort, Speed: settings.Speed,
-		PlanMode: settings.PlanMode, BrowserUse: settings.BrowserUse, ComputerUse: settings.ComputerUse,
-		PermissionModeID: settings.PermissionModeID, ConversationDetailMode: settings.ConversationDetailMode,
-	}
-}
-
-func hostTurnLifecyclePointer(input *agentruntime.TurnLifecycle) *host.TurnLifecycle {
-	if input == nil {
-		return nil
-	}
-	value := hostTurnLifecycle(*input)
-	return &value
-}
-
-func hostTurnLifecycle(input agentruntime.TurnLifecycle) host.TurnLifecycle {
-	var completed *host.CompletedCommand
-	if input.CompletedCommand != nil {
-		completed = &host.CompletedCommand{Kind: input.CompletedCommand.Kind, Status: input.CompletedCommand.Status}
-	}
-	return host.TurnLifecycle{
-		ActiveTurnID: input.ActiveTurnID, Phase: input.Phase, Settling: input.Settling,
-		Outcome: input.Outcome, CompletedCommand: completed,
-	}
-}
-
-func runtimeTurnLifecyclePointer(input *host.TurnLifecycle) *agentruntime.TurnLifecycle {
-	if input == nil {
-		return nil
-	}
-	var completed *agentruntime.CompletedCommand
-	if input.CompletedCommand != nil {
-		completed = &agentruntime.CompletedCommand{
-			Kind: input.CompletedCommand.Kind, Status: input.CompletedCommand.Status,
-		}
-	}
-	return &agentruntime.TurnLifecycle{
-		ActiveTurnID: input.ActiveTurnID, Phase: input.Phase, Settling: input.Settling,
-		Outcome: input.Outcome, CompletedCommand: completed,
-	}
-}
-
-func hostSubmitAvailability(input *agentruntime.SubmitAvailability) *host.SubmitAvailability {
-	if input == nil {
-		return nil
-	}
-	return &host.SubmitAvailability{State: input.State, Reason: input.Reason}
-}
-
-func runtimeSubmitAvailability(input *host.SubmitAvailability) *agentruntime.SubmitAvailability {
-	if input == nil {
-		return nil
-	}
-	return &agentruntime.SubmitAvailability{State: input.State, Reason: input.Reason}
-}
-
-func cloneMap(input map[string]any) map[string]any {
-	if input == nil {
-		return nil
-	}
-	out := make(map[string]any, len(input))
-	for key, value := range input {
-		out[key] = value
-	}
-	return out
 }

--- a/packages/agent/daemon/hostadapter/runtime_projection.go
+++ b/packages/agent/daemon/hostadapter/runtime_projection.go
@@ -1,0 +1,99 @@
+package hostadapter
+
+import (
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
+	host "github.com/tutti-os/tutti/packages/agent/host"
+)
+
+func runtimeTuttiModeSnapshot(input *host.TuttiModeTurnSnapshot) *agentruntime.TuttiModeTurnSnapshot {
+	if input == nil {
+		return nil
+	}
+	legacyOrchestrationIntensity := input.OrchestrationIntensity //nolint:staticcheck // Compatibility bridge preserves version-zero snapshots.
+	return &agentruntime.TuttiModeTurnSnapshot{
+		ActivationID: input.ActivationID, RevisionID: input.RevisionID, Revision: input.Revision,
+		State: input.State, Source: input.Source,
+		PreferenceVersion:      input.PreferenceVersion,
+		Effect:                 input.Effect,
+		Speed:                  input.Speed,
+		OrchestrationIntensity: legacyOrchestrationIntensity,
+	}
+}
+
+func runtimeSettings(settings host.ComposerSettings) *agentruntime.SessionSettings {
+	return &agentruntime.SessionSettings{
+		CodexSaverMode: settings.CodexSaverMode,
+		Model:          settings.Model, ReasoningEffort: settings.ReasoningEffort, Speed: settings.Speed,
+		PlanMode: settings.PlanMode, BrowserUse: settings.BrowserUse, ComputerUse: settings.ComputerUse,
+		PermissionModeID: settings.PermissionModeID, ConversationDetailMode: settings.ConversationDetailMode,
+	}
+}
+
+func hostSettings(settings agentruntime.SessionSettings) host.ComposerSettings {
+	return host.ComposerSettings{
+		CodexSaverMode: settings.CodexSaverMode,
+		Model:          settings.Model, ReasoningEffort: settings.ReasoningEffort, Speed: settings.Speed,
+		PlanMode: settings.PlanMode, BrowserUse: settings.BrowserUse, ComputerUse: settings.ComputerUse,
+		PermissionModeID: settings.PermissionModeID, ConversationDetailMode: settings.ConversationDetailMode,
+	}
+}
+
+func hostTurnLifecyclePointer(input *agentruntime.TurnLifecycle) *host.TurnLifecycle {
+	if input == nil {
+		return nil
+	}
+	value := hostTurnLifecycle(*input)
+	return &value
+}
+
+func hostTurnLifecycle(input agentruntime.TurnLifecycle) host.TurnLifecycle {
+	var completed *host.CompletedCommand
+	if input.CompletedCommand != nil {
+		completed = &host.CompletedCommand{Kind: input.CompletedCommand.Kind, Status: input.CompletedCommand.Status}
+	}
+	return host.TurnLifecycle{
+		ActiveTurnID: input.ActiveTurnID, Phase: input.Phase, Settling: input.Settling,
+		Outcome: input.Outcome, CompletedCommand: completed,
+	}
+}
+
+func runtimeTurnLifecyclePointer(input *host.TurnLifecycle) *agentruntime.TurnLifecycle {
+	if input == nil {
+		return nil
+	}
+	var completed *agentruntime.CompletedCommand
+	if input.CompletedCommand != nil {
+		completed = &agentruntime.CompletedCommand{
+			Kind: input.CompletedCommand.Kind, Status: input.CompletedCommand.Status,
+		}
+	}
+	return &agentruntime.TurnLifecycle{
+		ActiveTurnID: input.ActiveTurnID, Phase: input.Phase, Settling: input.Settling,
+		Outcome: input.Outcome, CompletedCommand: completed,
+	}
+}
+
+func hostSubmitAvailability(input *agentruntime.SubmitAvailability) *host.SubmitAvailability {
+	if input == nil {
+		return nil
+	}
+	return &host.SubmitAvailability{State: input.State, Reason: input.Reason}
+}
+
+func runtimeSubmitAvailability(input *host.SubmitAvailability) *agentruntime.SubmitAvailability {
+	if input == nil {
+		return nil
+	}
+	return &agentruntime.SubmitAvailability{State: input.State, Reason: input.Reason}
+}
+
+func cloneMap(input map[string]any) map[string]any {
+	if input == nil {
+		return nil
+	}
+	out := make(map[string]any, len(input))
+	for key, value := range input {
+		out[key] = value
+	}
+	return out
+}

--- a/packages/agent/daemon/runtime/claude_sdk_close_context_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_close_context_test.go
@@ -1,0 +1,37 @@
+package agentruntime
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestClaudeCodeSDKAdapterCloseHonorsContextWhileSendGateIsHeld(t *testing.T) {
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	connection := &recordingClaudeSDKConnection{}
+	session := standardTestSession(ProviderClaudeCode)
+	adapterSession := &claudeSDKAdapterSession{
+		conn:             connection,
+		readerStarted:    true,
+		pendingResponses: make(map[string]chan claudeSDKSidecarEvent),
+	}
+	adapter.storeSession(session.AgentSessionID, adapterSession)
+
+	adapterSession.sendMu.Lock()
+	defer adapterSession.sendMu.Unlock()
+	ctx, cancel := context.WithTimeout(t.Context(), 25*time.Millisecond)
+	defer cancel()
+
+	startedAt := time.Now()
+	err := adapter.Close(ctx, session)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Close() error = %v, want context deadline exceeded", err)
+	}
+	if elapsed := time.Since(startedAt); elapsed > time.Second {
+		t.Fatalf("Close() elapsed = %v, want bounded by context", elapsed)
+	}
+	if sent := connection.sentRequests(); len(sent) != 0 {
+		t.Fatalf("Close() sent requests after deadline: %#v", sent)
+	}
+}

--- a/packages/agent/daemon/runtime/claude_sdk_transport.go
+++ b/packages/agent/daemon/runtime/claude_sdk_transport.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"strings"
+	"time"
 
 	sessionreplay "github.com/tutti-os/tutti/packages/agent/session-replay"
 )
@@ -15,8 +16,15 @@ import (
 const claudeSDKStderrTailLimit = 8192
 
 func (s *claudeSDKAdapterSession) send(request claudeSDKSidecarRequest) error {
+	return s.sendContext(context.Background(), request)
+}
+
+func (s *claudeSDKAdapterSession) sendContext(ctx context.Context, request claudeSDKSidecarRequest) error {
 	if s == nil || s.conn == nil {
 		return ErrSessionDisconnected
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 	if err := request.normalize(); err != nil {
 		return err
@@ -26,8 +34,21 @@ func (s *claudeSDKAdapterSession) send(request claudeSDKSidecarRequest) error {
 		return err
 	}
 	data = append(data, '\n')
-	s.sendMu.Lock()
+	if !s.sendMu.TryLock() {
+		ticker := time.NewTicker(time.Millisecond)
+		defer ticker.Stop()
+		for !s.sendMu.TryLock() {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-ticker.C:
+			}
+		}
+	}
 	defer s.sendMu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	return s.conn.Send(data)
 }
 
@@ -47,13 +68,13 @@ func (a *ClaudeCodeSDKAdapter) roundTripClaudeSDKResponse(ctx context.Context, a
 	readerStarted := adapterSession.readerStarted
 	a.mu.Unlock()
 	if !readerStarted {
-		if err := adapterSession.send(request); err != nil {
+		if err := adapterSession.sendContext(ctx, request); err != nil {
 			return claudeSDKSidecarEvent{}, err
 		}
 		return adapterSession.roundTripDirectResponse(ctx, request)
 	}
 	response := a.registerClaudeSDKResponse(adapterSession, request.ID)
-	if err := adapterSession.send(request); err != nil {
+	if err := adapterSession.sendContext(ctx, request); err != nil {
 		a.unregisterClaudeSDKResponse(adapterSession, request.ID, response)
 		return claudeSDKSidecarEvent{}, err
 	}

--- a/packages/agent/daemon/runtime/controller.go
+++ b/packages/agent/daemon/runtime/controller.go
@@ -40,6 +40,7 @@ type Controller struct {
 	configOptionsUpdates        map[string]AgentSessionConfigOptionsUpdate
 	pendingConfigOptionsUpdates map[string][]AgentSessionConfigOptionsUpdate
 	provisionalSessions         map[string]bool
+	sessionInitializations      map[string]*controllerSessionInitialization
 	goalGenerationFences        map[string]*controllerGoalGenerationFenceRegistry
 	startupLocks                map[startupLockKey]*controllerLifecycleLock
 	lifecycleLocks              map[string]*controllerLifecycleLock
@@ -99,6 +100,17 @@ type GoalControlLifecycleObserver interface {
 type controllerLifecycleLock struct {
 	gate chan struct{}
 	refs int
+}
+
+// controllerSessionInitialization retains every provider observation emitted
+// between Runtime start and Host's canonical initialization commit. The map
+// entry itself is the publication barrier; it remains present while Publish
+// drains events and side-channel snapshots so later observations cannot
+// overtake the initial Session report.
+type controllerSessionInitialization struct {
+	events                  []activityshared.Event
+	initialEventsPublished  bool
+	commandSnapshotResolved bool
 }
 
 // startupLockKey uses agentSessionID for normal Host calls. Provider is set
@@ -186,6 +198,7 @@ func NewControllerWithAdapterResolver(adapters []Adapter, reporter DurableActivi
 		configOptionsUpdates:        make(map[string]AgentSessionConfigOptionsUpdate),
 		pendingConfigOptionsUpdates: make(map[string][]AgentSessionConfigOptionsUpdate),
 		provisionalSessions:         make(map[string]bool),
+		sessionInitializations:      make(map[string]*controllerSessionInitialization),
 		goalGenerationFences:        make(map[string]*controllerGoalGenerationFenceRegistry),
 		startupLocks:                make(map[startupLockKey]*controllerLifecycleLock),
 		lifecycleLocks:              make(map[string]*controllerLifecycleLock),
@@ -202,6 +215,17 @@ func NewControllerWithAdapterResolver(adapters []Adapter, reporter DurableActivi
 		controller.configureAdapter(adapter)
 	}
 	return controller
+}
+
+func (c *Controller) sessionPublicationPendingLocked(key string) bool {
+	if c == nil {
+		return false
+	}
+	if c.provisionalSessions[key] {
+		return true
+	}
+	_, pending := c.sessionInitializations[key]
+	return pending
 }
 
 func (c *Controller) configureAdapter(adapter Adapter) {

--- a/packages/agent/daemon/runtime/controller_report_worker.go
+++ b/packages/agent/daemon/runtime/controller_report_worker.go
@@ -14,8 +14,26 @@ import (
 )
 
 func (c *Controller) enqueueSessionReport(ctx context.Context, session Session, events []activityshared.Event) {
+	c.enqueueSessionReportWithInitializationState(ctx, session, events, false)
+}
+
+// enqueueInitializedSessionReport publishes the release batch after Host has
+// already committed the canonical Session. The Controller intentionally keeps
+// its in-memory publication marker until all queued runtime callbacks are
+// drained, so this path must not mistake that ordering marker for an
+// uninitialized canonical Session and hide the report again.
+func (c *Controller) enqueueInitializedSessionReport(ctx context.Context, session Session, events []activityshared.Event) {
+	c.enqueueSessionReportWithInitializationState(ctx, session, events, true)
+}
+
+func (c *Controller) enqueueSessionReportWithInitializationState(
+	ctx context.Context,
+	session Session,
+	events []activityshared.Event,
+	canonicalInitialized bool,
+) {
 	c.observeGoalControlLifecycle(ctx, session, events)
-	report := c.prepareSessionReport(session, events)
+	report := c.prepareSessionReportWithInitializationState(session, events, canonicalInitialized)
 	c.observeProviderObservations(ctx, session, report.ProviderObservations)
 	if len(report.GoalReconcileRequests) > 0 {
 		control := report
@@ -33,10 +51,18 @@ func (c *Controller) prepareSessionReport(
 	session Session,
 	events []activityshared.Event,
 ) agentsessionstore.ReportActivityInput {
+	return c.prepareSessionReportWithInitializationState(session, events, false)
+}
+
+func (c *Controller) prepareSessionReportWithInitializationState(
+	session Session,
+	events []activityshared.Event,
+	canonicalInitialized bool,
+) agentsessionstore.ReportActivityInput {
 	c.mu.Lock()
-	provisional := c.provisionalSessions[sessionKey(session.RoomID, session.AgentSessionID)]
+	publicationPending := !canonicalInitialized && c.sessionPublicationPendingLocked(sessionKey(session.RoomID, session.AgentSessionID))
 	c.mu.Unlock()
-	if provisional {
+	if publicationPending {
 		// A still-provisional runtime has not crossed the durable submitted-intent
 		// barrier. Keep incidental provider events hidden until that barrier
 		// publishes the canonical prompt. The normal initial-content path removes
@@ -46,7 +72,7 @@ func (c *Controller) prepareSessionReport(
 	}
 	report := reportActivityInput(session, events)
 	c.enrichReportStatePatchesWithSessionMetadata(session, &report)
-	if provisional {
+	if publicationPending {
 		hideProvisionalSessionReport(&report)
 		report.MessageUpdates = nil
 		report.SessionAudits = nil

--- a/packages/agent/daemon/runtime/controller_session_lifecycle.go
+++ b/packages/agent/daemon/runtime/controller_session_lifecycle.go
@@ -44,12 +44,12 @@ func (c *Controller) Start(ctx context.Context, input StartInput) (StartResult, 
 	permissionModeID := settings.PermissionModeID
 	if agentSessionID == "" {
 		if existing, ok := c.findStartSession(roomID, strings.TrimSpace(input.AgentTargetID), provider, input.CWD, title, settings, input.ProviderTargetRef); ok {
-			return StartResult{Session: existing}, nil
+			return StartResult{Session: existing, Created: false}, nil
 		}
 		agentSessionID = newID()
 	}
 	if existing, ok := c.get(roomID, agentSessionID); ok {
-		return StartResult{Session: existing}, nil
+		return StartResult{Session: existing, Created: false}, nil
 	}
 	c.deleteRetainedGoalGenerationFences(roomID, agentSessionID)
 	session := Session{
@@ -102,9 +102,15 @@ func (c *Controller) Start(ctx context.Context, input StartInput) (StartResult, 
 	if input.Provisional {
 		c.provisionalSessions[key] = true
 	}
+	if input.CanonicalInitPending {
+		c.sessionInitializations[key] = &controllerSessionInitialization{
+			events: append([]activityshared.Event(nil), events...),
+		}
+	}
+	publicationPending := c.sessionPublicationPendingLocked(key)
 	c.mu.Unlock()
-	if input.Provisional {
-		return StartResult{Session: session}, nil
+	if publicationPending {
+		return StartResult{Session: session, Created: true}, nil
 	}
 	c.publish(session, events)
 	c.publishPendingConfigOptionsUpdates(session)
@@ -112,7 +118,111 @@ func (c *Controller) Start(ctx context.Context, input StartInput) (StartResult, 
 		c.publishAdapterCommandSnapshot(session, adapter)
 	}
 	c.enqueueSessionReport(ctx, session, events)
-	return StartResult{Session: session}, nil
+	return StartResult{Session: session, Created: true}, nil
+}
+
+// PublishSessionInitialization releases the Runtime's report/event barrier
+// after Host has durably initialized the canonical Session. The transition is
+// idempotent. Prompt-provisional Sessions remain hidden until their submitted
+// intent crosses its separate durable barrier in Exec.
+func (c *Controller) PublishSessionInitialization(
+	ctx context.Context,
+	roomID string,
+	agentSessionID string,
+) (Session, error) {
+	roomID = strings.TrimSpace(roomID)
+	agentSessionID = strings.TrimSpace(agentSessionID)
+	if roomID == "" || agentSessionID == "" {
+		return Session{}, fmt.Errorf("room id and agent session id are required")
+	}
+	releaseLifecycleLock, err := c.acquireLifecycleLockContext(ctx, roomID, agentSessionID)
+	if err != nil {
+		return Session{}, err
+	}
+	defer releaseLifecycleLock()
+
+	key := sessionKey(roomID, agentSessionID)
+	c.mu.Lock()
+	session, found := c.sessions[key]
+	initialization, pending := c.sessionInitializations[key]
+	provisional := c.provisionalSessions[key]
+	if pending && provisional {
+		// Canonical rail initialization is complete, but the initial-content
+		// submit barrier still owns visibility. Preserve the historical
+		// provisional behavior: provider callbacks stay hidden until Exec
+		// durably publishes the submitted Turn.
+		delete(c.sessionInitializations, key)
+	}
+	c.mu.Unlock()
+	if !found {
+		return Session{}, ErrSessionNotFound
+	}
+	if !pending || provisional {
+		return session, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return Session{}, err
+	}
+
+	for {
+		c.mu.Lock()
+		current, stillPending := c.sessionInitializations[key]
+		session, found = c.sessions[key]
+		if !found {
+			c.mu.Unlock()
+			return Session{}, ErrSessionNotFound
+		}
+		if !stillPending || current != initialization {
+			c.mu.Unlock()
+			return session, nil
+		}
+
+		events := append([]activityshared.Event(nil), initialization.events...)
+		initialization.events = nil
+		configUpdates := append([]AgentSessionConfigOptionsUpdate(nil), c.pendingConfigOptionsUpdates[key]...)
+		delete(c.pendingConfigOptionsUpdates, key)
+		commandSnapshot, hasCommandSnapshot := c.pendingCommandSnapshots[agentSessionID]
+		if hasCommandSnapshot {
+			delete(c.pendingCommandSnapshots, agentSessionID)
+			initialization.commandSnapshotResolved = true
+		}
+		resolveAdapterCommandSnapshot := !initialization.commandSnapshotResolved
+		if resolveAdapterCommandSnapshot {
+			initialization.commandSnapshotResolved = true
+		}
+		if !initialization.initialEventsPublished {
+			if len(events) == 0 {
+				events = []activityshared.Event{
+					newSessionActivityEvent(session, EventSessionStarted, session.Status, nil),
+				}
+			}
+			initialization.initialEventsPublished = true
+		}
+		if len(events) == 0 && len(configUpdates) == 0 && !hasCommandSnapshot && !resolveAdapterCommandSnapshot {
+			// This lock transition is the ordering fence: callbacks that acquire
+			// c.mu before deletion are drained above; callbacks that acquire it
+			// afterwards observe a published Session and may fan out directly.
+			delete(c.sessionInitializations, key)
+			c.mu.Unlock()
+			return session, nil
+		}
+		c.mu.Unlock()
+
+		if len(events) > 0 {
+			c.publish(session, events)
+			c.enqueueInitializedSessionReport(ctx, session, events)
+		}
+		if len(configUpdates) > 0 {
+			c.publishConfigOptionsUpdates(session, configUpdates)
+		}
+		if hasCommandSnapshot {
+			c.applyCommandSnapshot(session, commandSnapshot)
+		} else if resolveAdapterCommandSnapshot {
+			if adapter := c.adapter(session.Provider); adapter != nil {
+				c.publishAdapterCommandSnapshot(session, adapter)
+			}
+		}
+	}
 }
 
 func (c *Controller) Resume(ctx context.Context, input ResumeInput) (Session, error) {
@@ -234,7 +344,10 @@ func (c *Controller) Resume(ctx context.Context, input ResumeInput) (Session, er
 }
 
 func (c *Controller) Close(ctx context.Context, input CloseInput) (CloseResult, error) {
-	releaseLifecycleLock := c.acquireLifecycleLock(input.RoomID, input.AgentSessionID)
+	releaseLifecycleLock, err := c.acquireLifecycleLockContext(ctx, input.RoomID, input.AgentSessionID)
+	if err != nil {
+		return CloseResult{}, err
+	}
 	defer releaseLifecycleLock()
 
 	session, adapter, err := c.sessionAndAdapter(input.RoomID, input.AgentSessionID)
@@ -248,9 +361,10 @@ func (c *Controller) Close(ctx context.Context, input CloseInput) (CloseResult, 
 		return CloseResult{}, closeErr
 	}
 	c.mu.Lock()
-	provisional := c.provisionalSessions[key]
-	if provisional || input.PreserveCanonicalState {
+	publicationPending := c.sessionPublicationPendingLocked(key)
+	if publicationPending || input.PreserveCanonicalState {
 		delete(c.provisionalSessions, key)
+		delete(c.sessionInitializations, key)
 		delete(c.sessions, key)
 		delete(c.turns, key)
 		delete(c.commands, key)
@@ -262,7 +376,7 @@ func (c *Controller) Close(ctx context.Context, input CloseInput) (CloseResult, 
 	if closeErr != nil {
 		return CloseResult{AgentSessionID: session.AgentSessionID, Disconnected: true}, closeErr
 	}
-	if provisional || input.PreserveCanonicalState {
+	if publicationPending || input.PreserveCanonicalState {
 		return CloseResult{AgentSessionID: session.AgentSessionID, Disconnected: true}, nil
 	}
 	session.Status = SessionStatusCompleted
@@ -280,6 +394,7 @@ func (c *Controller) Close(ctx context.Context, input CloseInput) (CloseResult, 
 	delete(c.pendingCommandSnapshots, session.AgentSessionID)
 	delete(c.pendingConfigOptionsUpdates, key)
 	delete(c.provisionalSessions, key)
+	delete(c.sessionInitializations, key)
 	delete(c.goalGenerationFences, key)
 	c.mu.Unlock()
 	return CloseResult{AgentSessionID: session.AgentSessionID, Disconnected: true}, nil

--- a/packages/agent/daemon/runtime/controller_session_lifecycle_test.go
+++ b/packages/agent/daemon/runtime/controller_session_lifecycle_test.go
@@ -1,10 +1,157 @@
 package agentruntime
 
 import (
+	"context"
+	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
+
+type blockingInitializationStreamObserver struct {
+	mu           sync.Mutex
+	calls        [][]StreamEvent
+	firstEntered chan struct{}
+	releaseFirst chan struct{}
+	once         sync.Once
+}
+
+func (o *blockingInitializationStreamObserver) ObserveRuntimeStreamEvents(
+	_ context.Context,
+	_, _ string,
+	events []StreamEvent,
+) error {
+	o.mu.Lock()
+	o.calls = append(o.calls, append([]StreamEvent(nil), events...))
+	call := len(o.calls)
+	o.mu.Unlock()
+	if call == 1 {
+		o.once.Do(func() { close(o.firstEntered) })
+		<-o.releaseFirst
+	}
+	return nil
+}
+
+func (o *blockingInitializationStreamObserver) callCount() int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return len(o.calls)
+}
+
+func TestPublishSessionInitializationDrainsEventsArrivingDuringRelease(t *testing.T) {
+	adapter := &recordingStartAdapter{provider: ProviderCodex}
+	controller := NewController([]Adapter{adapter}, nil)
+	observer := &blockingInitializationStreamObserver{
+		firstEntered: make(chan struct{}),
+		releaseFirst: make(chan struct{}),
+	}
+	controller.SetStreamEventObserver(observer)
+
+	started, err := controller.Start(t.Context(), StartInput{
+		RoomID: "room-1", AgentSessionID: "session-1", Provider: ProviderCodex,
+		CanonicalInitPending: true,
+	})
+	if err != nil || !started.Created {
+		t.Fatalf("Start() = %#v, %v", started, err)
+	}
+	beforeRelease := newSessionActivityEvent(started.Session, EventSessionUpdated, SessionStatusReady, map[string]any{"title": "before release"})
+	controller.applySessionEventsByAgentSessionID("session-1", []activityshared.Event{beforeRelease})
+	if observer.callCount() != 0 {
+		t.Fatal("event escaped before canonical initialization release")
+	}
+
+	publishCtx, cancelPublish := context.WithCancel(t.Context())
+	publishDone := make(chan error, 1)
+	go func() {
+		_, publishErr := controller.PublishSessionInitialization(publishCtx, "room-1", "session-1")
+		publishDone <- publishErr
+	}()
+	select {
+	case <-observer.firstEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("initial publication did not reach stream observer")
+	}
+
+	duringRelease := newSessionActivityEvent(started.Session, EventSessionUpdated, SessionStatusReady, map[string]any{"title": "during release"})
+	controller.applySessionEventsByAgentSessionID("session-1", []activityshared.Event{duringRelease})
+	controller.mu.Lock()
+	pending := controller.sessionInitializations[sessionKey("room-1", "session-1")]
+	pendingEvents := 0
+	if pending != nil {
+		pendingEvents = len(pending.events)
+	}
+	controller.mu.Unlock()
+	if pendingEvents != 1 {
+		t.Fatalf("events queued during release = %d, want 1", pendingEvents)
+	}
+	// Once the first batch is externally visible, cancellation must not leave a
+	// half-released marker that Host would treat as a failed canonical publish.
+	// Finish draining with detached report contexts and return success.
+	cancelPublish()
+	close(observer.releaseFirst)
+	select {
+	case err := <-publishDone:
+		if err != nil {
+			t.Fatalf("PublishSessionInitialization() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("publication did not finish")
+	}
+	if observer.callCount() != 2 {
+		t.Fatalf("publication observer calls = %d, want initial and drained batches", observer.callCount())
+	}
+	controller.mu.Lock()
+	_, stillPending := controller.sessionInitializations[sessionKey("room-1", "session-1")]
+	controller.mu.Unlock()
+	if stillPending {
+		t.Fatal("initialization marker remained after queue drained")
+	}
+
+	afterRelease := newSessionActivityEvent(started.Session, EventSessionUpdated, SessionStatusReady, map[string]any{"title": "after release"})
+	controller.applySessionEventsByAgentSessionID("session-1", []activityshared.Event{afterRelease})
+	if observer.callCount() != 3 {
+		t.Fatalf("post-release event was not published directly: calls=%d", observer.callCount())
+	}
+}
+
+func TestCloseStopsAtCanceledLifecycleLockWithoutCallingProvider(t *testing.T) {
+	adapter := &recordingStartAdapter{provider: ProviderCodex}
+	controller := NewController([]Adapter{adapter}, nil)
+	if _, err := controller.Start(t.Context(), StartInput{
+		RoomID: "room-1", AgentSessionID: "session-1", Provider: ProviderCodex,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	release := controller.acquireLifecycleLock("room-1", "session-1")
+	defer release()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		_, closeErr := controller.Close(ctx, CloseInput{RoomID: "room-1", AgentSessionID: "session-1"})
+		done <- closeErr
+	}()
+	waitForCondition(t, func() bool {
+		controller.mu.Lock()
+		defer controller.mu.Unlock()
+		lock := controller.lifecycleLocks[sessionKey("room-1", "session-1")]
+		return lock != nil && lock.refs == 2
+	})
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Close() error = %v, want canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close() ignored canceled lifecycle-lock wait")
+	}
+	if adapter.closeCalls != 0 {
+		t.Fatalf("provider close calls = %d, want zero", adapter.closeCalls)
+	}
+}
 
 func TestApplySessionEventsTracksLastError(t *testing.T) {
 	t.Parallel()

--- a/packages/agent/daemon/runtime/controller_session_registry.go
+++ b/packages/agent/daemon/runtime/controller_session_registry.go
@@ -130,7 +130,7 @@ func (c *Controller) Sessions(roomID string) []Session {
 		if strings.TrimSpace(session.RoomID) != roomID {
 			continue
 		}
-		if c.provisionalSessions[key] {
+		if c.sessionPublicationPendingLocked(key) {
 			continue
 		}
 		session = c.reconcileSessionStatusLocked(key, session)
@@ -414,7 +414,11 @@ func (c *Controller) publishPendingConfigOptionsUpdates(session Session) {
 		delete(c.pendingConfigOptionsUpdates, key)
 	}
 	c.mu.Unlock()
-	if len(pending) == 0 {
+	c.publishConfigOptionsUpdates(session, pending)
+}
+
+func (c *Controller) publishConfigOptionsUpdates(session Session, pending []AgentSessionConfigOptionsUpdate) {
+	if c == nil || len(pending) == 0 {
 		return
 	}
 	events := make([]StreamEvent, 0, len(pending))
@@ -423,7 +427,7 @@ func (c *Controller) publishPendingConfigOptionsUpdates(session Session) {
 		c.recordConfigOptionsUpdate(session, update)
 		events = append(events, configOptionsUpdateStreamEvent(update))
 	}
-	c.publishStreamEvents(roomID, agentSessionID, events)
+	c.publishStreamEvents(session.RoomID, session.AgentSessionID, events)
 	c.enqueueSessionSnapshotReport(context.Background(), session)
 }
 
@@ -552,16 +556,16 @@ func (c *Controller) applyCommandSnapshotByAgentSessionID(snapshot AgentSessionC
 	c.mu.Lock()
 	var session Session
 	found := false
-	provisional := false
+	publicationPending := false
 	for key, candidate := range c.sessions {
 		if strings.TrimSpace(candidate.AgentSessionID) == agentSessionID {
 			session = candidate
 			found = true
-			provisional = c.provisionalSessions[key]
+			publicationPending = c.sessionPublicationPendingLocked(key)
 			break
 		}
 	}
-	if !found || provisional {
+	if !found || publicationPending {
 		snapshot.AgentSessionID = agentSessionID
 		snapshot.Commands = cloneAgentSessionCommands(snapshot.Commands)
 		c.pendingCommandSnapshots[agentSessionID] = snapshot
@@ -641,9 +645,12 @@ func (c *Controller) applySessionEventsByAgentSessionID(agentSessionID string, e
 		session.UpdatedAtUnixMS = unixMS(now())
 	}
 	c.sessions[foundKey] = session
-	provisional := c.provisionalSessions[foundKey]
+	if initialization := c.sessionInitializations[foundKey]; initialization != nil {
+		initialization.events = append(initialization.events, events...)
+	}
+	publicationPending := c.sessionPublicationPendingLocked(foundKey)
 	c.mu.Unlock()
-	if provisional {
+	if publicationPending {
 		return
 	}
 	c.publish(session, events)
@@ -669,25 +676,25 @@ func (c *Controller) applyConfigOptionsUpdateByAgentSessionID(update AgentSessio
 	c.mu.Lock()
 	var session Session
 	found := false
-	provisional := false
+	publicationPending := false
 	if roomID != "" {
 		key := sessionKey(roomID, agentSessionID)
 		if candidate, ok := c.sessions[key]; ok {
 			session = candidate
 			found = true
-			provisional = c.provisionalSessions[key]
+			publicationPending = c.sessionPublicationPendingLocked(key)
 		}
 	} else {
 		for key, candidate := range c.sessions {
 			if strings.TrimSpace(candidate.AgentSessionID) == agentSessionID {
 				session = candidate
 				found = true
-				provisional = c.provisionalSessions[key]
+				publicationPending = c.sessionPublicationPendingLocked(key)
 				break
 			}
 		}
 	}
-	if !found || provisional {
+	if !found || publicationPending {
 		pendingRoomID := firstNonEmpty(roomID, session.RoomID)
 		if pendingRoomID != "" {
 			key := sessionKey(pendingRoomID, agentSessionID)

--- a/packages/agent/daemon/runtime/controller_start_test.go
+++ b/packages/agent/daemon/runtime/controller_start_test.go
@@ -329,6 +329,12 @@ func TestControllerAnonymousStartsRemainProviderScopedAndIdempotent(t *testing.T
 	if replayed.Session.AgentSessionID != first.Session.AgentSessionID {
 		t.Fatalf("replayed session = %q, want %q", replayed.Session.AgentSessionID, first.Session.AgentSessionID)
 	}
+	if !first.Created {
+		t.Fatal("first anonymous start Created = false, want true")
+	}
+	if replayed.Created {
+		t.Fatal("replayed anonymous start Created = true, want false")
+	}
 	if calls := adapter.startCalls.Load(); calls != 1 {
 		t.Fatalf("adapter start calls = %d, want 1", calls)
 	}
@@ -645,6 +651,12 @@ func TestControllerStartReusesTargetSessionWithSameProviderTargetRef(t *testing.
 
 	if second.Session.AgentSessionID != first.Session.AgentSessionID {
 		t.Fatalf("second start session = %q, want reused %q", second.Session.AgentSessionID, first.Session.AgentSessionID)
+	}
+	if !first.Created {
+		t.Fatal("first start Created = false, want true")
+	}
+	if second.Created {
+		t.Fatal("reused start Created = true, want false")
 	}
 }
 

--- a/packages/agent/daemon/runtime/controller_submit_provenance.go
+++ b/packages/agent/daemon/runtime/controller_submit_provenance.go
@@ -39,9 +39,9 @@ func (c *Controller) DurablyReportSubmitProvenance(ctx context.Context, input Su
 	}
 	key := sessionKey(input.RoomID, input.AgentSessionID)
 	c.mu.Lock()
-	provisional := c.provisionalSessions[key]
+	publicationPending := c.sessionPublicationPendingLocked(key)
 	c.mu.Unlock()
-	if provisional {
+	if publicationPending {
 		// A nonstandard caller may still be inside the provisional window when
 		// this late provenance arrives. Keep it hidden until the submitted-intent
 		// barrier publishes the canonical prompt; normal initial-content creates
@@ -71,7 +71,7 @@ func (c *Controller) DurablyReportSubmitProvenance(ctx context.Context, input Su
 	// without regressing a fast provider that already moved it onward.
 	report := reportActivityInput(session, []activityshared.Event{message})
 	c.enrichReportWithSessionSnapshot(session, &report)
-	if provisional {
+	if publicationPending {
 		hideProvisionalSessionReport(&report)
 	}
 	if len(report.StatePatches) != 1 || len(report.MessageUpdates) != 1 {

--- a/packages/agent/daemon/runtime/types.go
+++ b/packages/agent/daemon/runtime/types.go
@@ -77,6 +77,7 @@ type StartInput struct {
 	PermissionModeID        string
 	Settings                *SessionSettings
 	Provisional             bool
+	CanonicalInitPending    bool
 }
 
 type ResumeInput struct {
@@ -485,6 +486,7 @@ type StreamEvent struct {
 
 type StartResult struct {
 	Session Session `json:"session"`
+	Created bool    `json:"created"`
 }
 
 type CloseResult struct {

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -47,6 +47,28 @@ state instead of starting another provider Session. This preflight is durable
 across Host process restarts and does not depend on the runtime's in-memory
 Session registry.
 
+Session creation also has a Host-owned canonical initialization barrier. Every
+Runtime used by `CreateSession` must implement
+`RuntimeSessionInitializationPublisher`. Host calls
+`Start(CanonicalInitPending=true)`, durably initializes the exact canonical
+Session (including immutable rail placement), and only then calls
+`PublishSessionInitialization`. While that barrier is pending, the Runtime may
+start its provider connection but must buffer activity reports, stream events,
+configuration updates, and command snapshots so none of them can create or
+expose canonical state before Host commits it. Publication is idempotent and
+releases the buffered observations in order. An initial-content Session keeps
+its separate provisional submit barrier after canonical initialization and
+does not become visible until its submitted intent is durable.
+
+`RuntimeStartResult.Created` records ownership of the live Runtime for the
+exact `Start` call. Failed-create compensation may close only a Runtime with
+`Created=true` and may roll back only a canonical Session created by that
+attempt. A retry that reuses an existing Runtime or canonical Session must not
+close or delete the earlier owner's resources; it must validate the existing
+immutable rail and fail closed on a mismatch. Host consumers must preserve the
+`Start -> canonical initialize -> publish` sequence instead of publishing a
+runtime-start report directly from `Start`.
+
 Provider Turn acceptance is a cross-process barrier, not a generic lifecycle
 notification. The runtime may move through `queued`, `dispatched`,
 `provider_observed`, and `resolving_identity`, but it must not expose provider

--- a/packages/agent/host/conformance/conformance.go
+++ b/packages/agent/host/conformance/conformance.go
@@ -63,6 +63,14 @@ type Fixture struct {
 	AcceptGoalControlsOnly bool
 	CompleteGoalOnSet      bool
 	EmptyPauseResumeGoal   bool
+	// RaceRuntimeStartReport makes the test Runtime attempt its ordinary
+	// session-start activity report before CreateSession initializes canonical
+	// state. A conforming Host must keep that report behind the canonical
+	// initialization barrier.
+	RaceRuntimeStartReport bool
+	// FailSessionInitialization fails the canonical initialize half after the
+	// Runtime has started, before its report/event barrier may be released.
+	FailSessionInitialization bool
 	// DisconnectGoalFenceDelivery drops the live Runtime Session during the
 	// first fence delivery, modeling a Host restart with accepted durable intent
 	// but no in-memory provider Session.
@@ -141,6 +149,8 @@ type Metrics struct {
 	CloseCalls                         int
 	GoalControlCalls                   int
 	GoalReconcileCalls                 int
+	RuntimeSessionPublishCalls         int
+	RuntimeStartReportWrites           int
 	RuntimeOperationCommits            int
 	GoalOperationCommits               int
 	RootTurnSettlements                int

--- a/packages/agent/host/conformance/conformance_test.go
+++ b/packages/agent/host/conformance/conformance_test.go
@@ -12,8 +12,8 @@ func TestPublishedScenarioCatalogsHaveUniqueNames(t *testing.T) {
 		scenarios []Scenario
 		wantCount int
 	}{
-		{name: "adapter lifecycle", scenarios: Scenarios(), wantCount: 29},
-		{name: "application core", scenarios: ApplicationCoreScenarios(), wantCount: 24},
+		{name: "adapter lifecycle", scenarios: Scenarios(), wantCount: 31},
+		{name: "application core", scenarios: ApplicationCoreScenarios(), wantCount: 26},
 		{name: "guidance", scenarios: GuidanceScenarios(), wantCount: 3},
 		{name: "resume policy", scenarios: ResumePolicyScenarios(), wantCount: 5},
 		{name: "submission fence", scenarios: SubmissionFenceScenarios(), wantCount: 1},
@@ -76,6 +76,8 @@ func TestScenarioOwnershipIsExplicit(t *testing.T) {
 		"create empty session",
 		"create with initial content",
 		"create with typed initial goal",
+		"typed initial goal waits for canonical rail initialization",
+		"failed canonical initialization aborts unpublished runtime",
 		"create with explicit rail placement",
 		"resume persisted session",
 		"send input",
@@ -107,6 +109,8 @@ func TestScenarioOwnershipIsExplicit(t *testing.T) {
 		"create empty session",
 		"create with initial content",
 		"create with typed initial goal",
+		"typed initial goal waits for canonical rail initialization",
+		"failed canonical initialization aborts unpublished runtime",
 		"create with explicit rail placement",
 		"resume persisted session",
 		"send input",

--- a/packages/agent/host/conformance/scenarios.go
+++ b/packages/agent/host/conformance/scenarios.go
@@ -1,14 +1,22 @@
 package conformance
 
 var (
-	createEmptySessionScenario       = Scenario{Name: "create empty session", run: runCreateEmptySession}
-	createWithInitialContentScenario = Scenario{Name: "create with initial content", run: runCreateWithInitialContent}
-	createWithInitialGoalScenario    = Scenario{Name: "create with typed initial goal", run: runCreateWithInitialGoal}
-	createWithRailPlacementScenario  = Scenario{Name: "create with explicit rail placement", run: runCreateWithRailPlacement}
-	resumePersistedSessionScenario   = Scenario{Name: "resume persisted session", run: runResumePersistedSession}
-	sendInputScenario                = Scenario{Name: "send input", run: runSendInput}
-	sendConnectorOnlyInputScenario   = Scenario{Name: "send connector-only input", run: runSendConnectorOnlyInput}
-	providerAcceptanceScenario       = Scenario{
+	createEmptySessionScenario          = Scenario{Name: "create empty session", run: runCreateEmptySession}
+	createWithInitialContentScenario    = Scenario{Name: "create with initial content", run: runCreateWithInitialContent}
+	createWithInitialGoalScenario       = Scenario{Name: "create with typed initial goal", run: runCreateWithInitialGoal}
+	typedInitialGoalRailBarrierScenario = Scenario{
+		Name: "typed initial goal waits for canonical rail initialization",
+		run:  runTypedInitialGoalWaitsForCanonicalRailInitialization,
+	}
+	failedCanonicalInitializationScenario = Scenario{
+		Name: "failed canonical initialization aborts unpublished runtime",
+		run:  runFailedCanonicalInitializationAbortsUnpublishedRuntime,
+	}
+	createWithRailPlacementScenario = Scenario{Name: "create with explicit rail placement", run: runCreateWithRailPlacement}
+	resumePersistedSessionScenario  = Scenario{Name: "resume persisted session", run: runResumePersistedSession}
+	sendInputScenario               = Scenario{Name: "send input", run: runSendInput}
+	sendConnectorOnlyInputScenario  = Scenario{Name: "send connector-only input", run: runSendConnectorOnlyInput}
+	providerAcceptanceScenario      = Scenario{
 		Name: "new turns require durable provider acceptance",
 		run:  runNewTurnsRequireDurableProviderAcceptance,
 	}
@@ -56,6 +64,8 @@ func Scenarios() []Scenario {
 		createEmptySessionScenario,
 		createWithInitialContentScenario,
 		createWithInitialGoalScenario,
+		typedInitialGoalRailBarrierScenario,
+		failedCanonicalInitializationScenario,
 		createWithRailPlacementScenario,
 		resumePersistedSessionScenario,
 		sendInputScenario,
@@ -195,6 +205,8 @@ func ApplicationCoreScenarios() []Scenario {
 		createEmptySessionScenario,
 		createWithInitialContentScenario,
 		createWithInitialGoalScenario,
+		typedInitialGoalRailBarrierScenario,
+		failedCanonicalInitializationScenario,
 		createWithRailPlacementScenario,
 		resumePersistedSessionScenario,
 		sendInputScenario,

--- a/packages/agent/host/conformance/session_lifecycle_scenarios.go
+++ b/packages/agent/host/conformance/session_lifecycle_scenarios.go
@@ -141,6 +141,119 @@ func runCreateWithInitialGoal(ctx context.Context, driver Driver) error {
 	return nil
 }
 
+func runTypedInitialGoalWaitsForCanonicalRailInitialization(ctx context.Context, driver Driver) error {
+	if err := driver.Reset(ctx, Fixture{
+		CompleteGoalOnSet:      true,
+		RaceRuntimeStartReport: true,
+	}); err != nil {
+		return err
+	}
+	input := agenthost.CreateSessionInput{
+		AgentSessionID:       "session-initial-goal-rail-race",
+		AgentTargetID:        "target-1",
+		Provider:             "codex",
+		ClientSubmitID:       "create-goal-rail-race-1",
+		InitialDisplayPrompt: "/goal ship from the selected project",
+		InitialGoalControl: &agenthost.TypedGoalControl{
+			Action:    "set",
+			Objective: "ship from the selected project",
+		},
+		RailPlacement: &agenthost.RailPlacement{
+			Version:     1,
+			Kind:        agenthost.RailPlacementKindProject,
+			ProjectPath: "/workspace/selected-project",
+		},
+	}
+	created, turnID, err := driver.Create(ctx, "workspace-1", input)
+	if err != nil {
+		return fmt.Errorf("create typed initial goal during runtime start report: %w", err)
+	}
+	if turnID != "" {
+		return fmt.Errorf("typed initial goal race created turn %q", turnID)
+	}
+	wantRail := storesqlite.RailSectionKeyForProject("/workspace/selected-project")
+	if created.RailSectionKey != wantRail {
+		return fmt.Errorf(
+			"typed initial goal race rail=%q, want %q",
+			created.RailSectionKey,
+			wantRail,
+		)
+	}
+
+	replayed, replayedTurnID, err := driver.Create(ctx, "workspace-1", input)
+	if err != nil {
+		return fmt.Errorf("retry typed initial goal after runtime start report: %w", err)
+	}
+	if replayed.SessionID != created.SessionID || replayedTurnID != "" {
+		return fmt.Errorf(
+			"retried typed initial goal race=%#v turn=%q, want session %q without turn",
+			replayed,
+			replayedTurnID,
+			created.SessionID,
+		)
+	}
+	metrics := driver.Metrics()
+	if metrics.StartCalls != 1 || metrics.RuntimeSessionPublishCalls != 1 ||
+		metrics.GoalControlCalls != 1 || metrics.RuntimeStartReportWrites != 1 {
+		return fmt.Errorf(
+			"typed initial goal race calls start=%d publish=%d goal=%d runtimeReports=%d, want 1/1/1/1",
+			metrics.StartCalls,
+			metrics.RuntimeSessionPublishCalls,
+			metrics.GoalControlCalls,
+			metrics.RuntimeStartReportWrites,
+		)
+	}
+	return nil
+}
+
+func runFailedCanonicalInitializationAbortsUnpublishedRuntime(ctx context.Context, driver Driver) error {
+	if err := driver.Reset(ctx, Fixture{
+		RaceRuntimeStartReport:    true,
+		FailSessionInitialization: true,
+	}); err != nil {
+		return err
+	}
+	ref := agenthost.SessionRef{
+		WorkspaceID:    "workspace-1",
+		AgentSessionID: "session-initialization-failure",
+	}
+	_, _, err := driver.Create(ctx, ref.WorkspaceID, agenthost.CreateSessionInput{
+		AgentSessionID: ref.AgentSessionID,
+		AgentTargetID:  "target-1",
+		Provider:       "codex",
+		ClientSubmitID: "create-initialization-failure-1",
+		InitialGoalControl: &agenthost.TypedGoalControl{
+			Action:    "set",
+			Objective: "must not execute",
+		},
+		RailPlacement: &agenthost.RailPlacement{
+			Version:     1,
+			Kind:        agenthost.RailPlacementKindProject,
+			ProjectPath: "/workspace/selected-project",
+		},
+	})
+	if err == nil {
+		return errors.New("failed canonical initialization returned nil error")
+	}
+	if _, readErr := driver.GetCanonicalSession(ctx, ref); !errors.Is(readErr, agenthost.ErrSessionNotFound) {
+		return fmt.Errorf("canonical session after initialization failure error=%v", readErr)
+	}
+	metrics := driver.Metrics()
+	if metrics.StartCalls != 1 || metrics.RuntimeSessionPublishCalls != 0 ||
+		metrics.CloseCalls != 1 || metrics.GoalControlCalls != 0 ||
+		metrics.RuntimeStartReportWrites != 0 {
+		return fmt.Errorf(
+			"failed canonical initialization calls start=%d publish=%d close=%d goal=%d runtimeReports=%d, want 1/0/1/0/0",
+			metrics.StartCalls,
+			metrics.RuntimeSessionPublishCalls,
+			metrics.CloseCalls,
+			metrics.GoalControlCalls,
+			metrics.RuntimeStartReportWrites,
+		)
+	}
+	return nil
+}
+
 func runCreateWithRailPlacement(ctx context.Context, driver Driver) error {
 	if err := driver.Reset(ctx, Fixture{}); err != nil {
 		return err

--- a/packages/agent/host/create_session_initialization.go
+++ b/packages/agent/host/create_session_initialization.go
@@ -1,0 +1,92 @@
+package agenthost
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+const (
+	runtimeSessionPublishTimeout    = 5 * time.Second
+	failedCreateLockTimeout         = 2 * time.Second
+	failedCreateRuntimeCloseTimeout = 5 * time.Second
+	failedCreateRollbackTimeout     = 3 * time.Second
+	failedCreatePreparationTimeout  = 2 * time.Second
+)
+
+type failedCreateCleanupState struct {
+	RuntimeStarted   bool
+	CanonicalCreated bool
+	SessionLockHeld  bool
+}
+
+func publishRuntimeSessionInitialization(
+	ctx context.Context,
+	publisher RuntimeSessionInitializationPublisher,
+	input RuntimeSessionInitializationPublishInput,
+) (ProviderRuntimeSession, error) {
+	publishCtx, cancel := detachedPhaseContext(ctx, runtimeSessionPublishTimeout)
+	defer cancel()
+	return publisher.PublishSessionInitialization(publishCtx, input)
+}
+
+func (h *Host) cleanupFailedCreate(
+	ctx context.Context,
+	ref SessionRef,
+	provider string,
+	cause error,
+	state failedCreateCleanupState,
+) error {
+	errs := []error{cause}
+	closeRuntime := state.RuntimeStarted
+	if closeRuntime && !state.SessionLockHeld {
+		startedAt := h.now()
+		lockCtx, cancel := detachedPhaseContext(ctx, failedCreateLockTimeout)
+		release, err := h.acquireSession(lockCtx, ref)
+		h.observeStep(lockCtx, "session_create_cleanup", "lifecycle_lock_acquired", ref.AgentSessionID, provider, startedAt, err)
+		cancel()
+		if err != nil {
+			errs = append(errs, err)
+			closeRuntime = false
+		} else {
+			defer release()
+		}
+	}
+	if closeRuntime {
+		startedAt := h.now()
+		closeCtx, cancel := detachedPhaseContext(ctx, failedCreateRuntimeCloseTimeout)
+		err := h.runtime.Close(closeCtx, RuntimeCloseInput{
+			WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
+		})
+		h.observeStep(closeCtx, "session_create_cleanup", "runtime_closed", ref.AgentSessionID, provider, startedAt, err)
+		cancel()
+		errs = append(errs, err)
+	}
+	if state.CanonicalCreated {
+		startedAt := h.now()
+		rollbackCtx, cancel := detachedPhaseContext(ctx, failedCreateRollbackTimeout)
+		_, err := h.store.RollbackRuntimeSessionInitialization(
+			rollbackCtx,
+			ref.WorkspaceID,
+			ref.AgentSessionID,
+		)
+		h.observeStep(rollbackCtx, "session_create_cleanup", "canonical_rolled_back", ref.AgentSessionID, provider, startedAt, err)
+		cancel()
+		errs = append(errs, err)
+	}
+	if h.preparation != nil {
+		startedAt := h.now()
+		cleanupCtx, cancel := detachedPhaseContext(ctx, failedCreatePreparationTimeout)
+		err := h.preparation.Cleanup(cleanupCtx, RuntimeCleanupInput{
+			WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID, Provider: provider,
+		})
+		h.observeStep(cleanupCtx, "session_create_cleanup", "preparation_cleaned", ref.AgentSessionID, provider, startedAt, err)
+		cancel()
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}
+
+func detachedPhaseContext(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(parent), timeout)
+}

--- a/packages/agent/host/create_session_initialization_test.go
+++ b/packages/agent/host/create_session_initialization_test.go
@@ -1,0 +1,314 @@
+package agenthost
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+type initializationBarrierTestStore struct {
+	CanonicalStore
+	cancelParent context.CancelFunc
+	existing     storesqlite.Session
+	exists       bool
+	rollback     bool
+	rollbackCtx  contextObservation
+}
+
+func (s *initializationBarrierTestStore) GetSession(
+	_ context.Context,
+	_, _ string,
+) (storesqlite.Session, bool, error) {
+	return s.existing, s.exists, nil
+}
+
+func (s *initializationBarrierTestStore) InitializeRuntimeSession(
+	_ context.Context,
+	input RuntimeSessionInitialization,
+) (storesqlite.Session, error) {
+	if s.cancelParent != nil {
+		s.cancelParent()
+	}
+	railKind := storesqlite.RailSectionKindConversations
+	railKey := storesqlite.RailSectionKeyConversations
+	railProjectPath := ""
+	if input.RailPlacement != nil {
+		railKind = string(input.RailPlacement.Kind)
+		railKey = input.RailPlacement.SectionKey
+		railProjectPath = input.RailPlacement.ProjectPath
+	}
+	return storesqlite.Session{
+		ID: input.Session.ID, WorkspaceID: input.Session.WorkspaceID,
+		Provider: input.Session.Provider, ProviderSessionID: input.Session.ProviderSessionID,
+		RailSectionKind: railKind, RailProjectPath: railProjectPath, RailSectionKey: railKey,
+		Metadata: storesqlite.SessionMetadata{Visible: true},
+	}, nil
+}
+
+func (s *initializationBarrierTestStore) RollbackRuntimeSessionInitialization(
+	ctx context.Context,
+	_, _ string,
+) (bool, error) {
+	s.rollbackCtx = observeContext(ctx)
+	s.rollback = true
+	return true, nil
+}
+
+type initializationBarrierTestRuntime struct {
+	RuntimeController
+	locker        *initializationBarrierTestLocker
+	session       ProviderRuntimeSession
+	reuseExisting bool
+	publishErr    error
+	publishCtx    contextObservation
+	closeCtx      contextObservation
+	closeCalls    int
+	startCalls    int
+	publishCalls  int
+}
+
+func (r *initializationBarrierTestRuntime) Start(
+	_ context.Context,
+	input RuntimeStartInput,
+) (RuntimeStartResult, error) {
+	r.startCalls++
+	r.session = ProviderRuntimeSession{
+		ID: input.AgentSessionID, WorkspaceID: input.WorkspaceID,
+		AgentTargetID: input.AgentTargetID, Provider: input.Provider,
+		ProviderSessionID: "provider-" + input.AgentSessionID,
+		Cwd:               input.Cwd, Status: "ready", Visible: true,
+		CreatedAtUnixMS: 1, UpdatedAtUnixMS: 1,
+	}
+	return RuntimeStartResult{Session: r.session, Created: !r.reuseExisting}, nil
+}
+
+func (r *initializationBarrierTestRuntime) PublishSessionInitialization(
+	ctx context.Context,
+	_ RuntimeSessionInitializationPublishInput,
+) (ProviderRuntimeSession, error) {
+	r.publishCalls++
+	r.publishCtx = observeContext(ctx)
+	if r.publishErr != nil {
+		return ProviderRuntimeSession{}, r.publishErr
+	}
+	return r.session, nil
+}
+
+func (r *initializationBarrierTestRuntime) Close(
+	ctx context.Context,
+	_ RuntimeCloseInput,
+) error {
+	r.closeCalls++
+	r.closeCtx = observeContext(ctx)
+	if r.locker != nil && !r.locker.isHeld() {
+		return errors.New("runtime close ran without the session lifecycle lock")
+	}
+	return context.DeadlineExceeded
+}
+
+type initializationBarrierTestPreparation struct {
+	cleanupCalls int
+	cleanupCtx   contextObservation
+}
+
+func (*initializationBarrierTestPreparation) Prepare(
+	_ context.Context,
+	input RuntimePreparationInput,
+) (PreparedRuntime, error) {
+	return PreparedRuntime{Cwd: input.Cwd}, nil
+}
+
+func (p *initializationBarrierTestPreparation) Cleanup(
+	ctx context.Context,
+	_ RuntimeCleanupInput,
+) error {
+	p.cleanupCalls++
+	p.cleanupCtx = observeContext(ctx)
+	return nil
+}
+
+type initializationBarrierTestLocker struct {
+	mu       sync.Mutex
+	held     bool
+	acquires int
+	releases int
+}
+
+func (l *initializationBarrierTestLocker) Acquire(ctx context.Context, _ SessionRef) (func(), error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.held {
+		return nil, errors.New("session lifecycle lock acquired twice")
+	}
+	l.held = true
+	l.acquires++
+	return func() {
+		l.mu.Lock()
+		l.held = false
+		l.releases++
+		l.mu.Unlock()
+	}, nil
+}
+
+func (l *initializationBarrierTestLocker) isHeld() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.held
+}
+
+type initializationBarrierGoalRuntime struct {
+	calls int
+}
+
+func (r *initializationBarrierGoalRuntime) GoalControl(
+	context.Context,
+	RuntimeGoalControlInput,
+) (RuntimeGoalControlResult, error) {
+	r.calls++
+	return RuntimeGoalControlResult{}, nil
+}
+
+type contextObservation struct {
+	err         error
+	hasDeadline bool
+	remaining   time.Duration
+}
+
+func observeContext(ctx context.Context) contextObservation {
+	deadline, hasDeadline := ctx.Deadline()
+	remaining := time.Duration(0)
+	if hasDeadline {
+		remaining = time.Until(deadline)
+	}
+	return contextObservation{
+		err: ctx.Err(), hasDeadline: hasDeadline, remaining: remaining,
+	}
+}
+
+func TestCreateSessionPublishFailureCleansWithIndependentDeadlinesUnderLifecycleLock(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	store := &initializationBarrierTestStore{cancelParent: cancel}
+	locker := &initializationBarrierTestLocker{}
+	publishErr := errors.New("publish initialization")
+	runtime := &initializationBarrierTestRuntime{locker: locker, publishErr: publishErr}
+	preparation := &initializationBarrierTestPreparation{}
+	goalRuntime := &initializationBarrierGoalRuntime{}
+	host := New(Config{
+		CanonicalStore: store, Runtime: runtime, RuntimePreparation: preparation,
+		SessionLocker: locker, GoalRuntime: goalRuntime,
+	})
+
+	result, err := host.CreateSession(ctx, "workspace-1", CreateSessionInput{
+		AgentSessionID: "session-1", AgentTargetID: "target-1", Provider: "codex",
+		InitialGoalControl: &TypedGoalControl{Action: "set", Objective: "must not execute"},
+		RailPlacement: &RailPlacement{
+			Version: 1, Kind: RailPlacementKindProject, ProjectPath: "/workspace/project",
+		},
+	})
+	if !errors.Is(err, publishErr) || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("CreateSession() result=%#v error=%v, want publish and close errors", result, err)
+	}
+	if result.SessionStatus != CreateSessionStatusNotCreated {
+		t.Fatalf("CreateSession() status=%q, want %q", result.SessionStatus, CreateSessionStatusNotCreated)
+	}
+	if runtime.publishCalls != 1 || runtime.closeCalls != 1 || !store.rollback ||
+		preparation.cleanupCalls != 1 || goalRuntime.calls != 0 {
+		t.Fatalf(
+			"cleanup calls publish=%d close=%d rollback=%v preparation=%d goal=%d",
+			runtime.publishCalls,
+			runtime.closeCalls,
+			store.rollback,
+			preparation.cleanupCalls,
+			goalRuntime.calls,
+		)
+	}
+	if locker.isHeld() || locker.acquires != 1 || locker.releases != 1 {
+		t.Fatalf("lifecycle lock held=%v acquires=%d releases=%d", locker.isHeld(), locker.acquires, locker.releases)
+	}
+	assertDetachedDeadline(t, "publish", runtime.publishCtx, runtimeSessionPublishTimeout)
+	assertDetachedDeadline(t, "runtime close", runtime.closeCtx, failedCreateRuntimeCloseTimeout)
+	assertDetachedDeadline(t, "canonical rollback", store.rollbackCtx, failedCreateRollbackTimeout)
+	assertDetachedDeadline(t, "preparation cleanup", preparation.cleanupCtx, failedCreatePreparationTimeout)
+}
+
+func TestCreateSessionConflictDoesNotStartOrCloseExistingRuntime(t *testing.T) {
+	store := &initializationBarrierTestStore{
+		exists: true,
+		existing: storesqlite.Session{
+			ID: "session-1", WorkspaceID: "workspace-1", Provider: "codex",
+			RailSectionKind: storesqlite.RailSectionKindConversations,
+			RailSectionKey:  storesqlite.RailSectionKeyConversations,
+		},
+	}
+	runtime := &initializationBarrierTestRuntime{reuseExisting: true}
+	host := New(Config{CanonicalStore: store, Runtime: runtime})
+
+	_, err := host.CreateSession(t.Context(), "workspace-1", CreateSessionInput{
+		AgentSessionID: "session-1", AgentTargetID: "target-1", Provider: "codex",
+		RailPlacement: &RailPlacement{
+			Version: 1, Kind: RailPlacementKindProject,
+			ProjectPath: "/workspace/project", SectionKey: "project:/workspace/project",
+		},
+	})
+	if !errors.Is(err, ErrRailPlacementConflict) {
+		t.Fatalf("CreateSession() error = %v, want rail conflict", err)
+	}
+	if runtime.startCalls != 0 || runtime.closeCalls != 0 || store.rollback {
+		t.Fatalf("conflicting retry mutated existing state: start=%d close=%d rollback=%v", runtime.startCalls, runtime.closeCalls, store.rollback)
+	}
+}
+
+func TestCreateSessionPublishFailurePreservesReusedRuntimeAndCanonicalSession(t *testing.T) {
+	canonical := storesqlite.Session{
+		ID: "session-1", WorkspaceID: "workspace-1", Provider: "codex",
+		RailSectionKind: storesqlite.RailSectionKindProject,
+		RailProjectPath: "/workspace/project",
+		RailSectionKey:  "project:/workspace/project",
+	}
+	store := &initializationBarrierTestStore{exists: true, existing: canonical}
+	runtime := &initializationBarrierTestRuntime{
+		reuseExisting: true,
+		publishErr:    errors.New("publish initialization"),
+	}
+	host := New(Config{CanonicalStore: store, Runtime: runtime})
+
+	_, err := host.CreateSession(t.Context(), "workspace-1", CreateSessionInput{
+		AgentSessionID: "session-1", AgentTargetID: "target-1", Provider: "codex",
+		RailPlacement: &RailPlacement{
+			Version: 1, Kind: RailPlacementKindProject,
+			ProjectPath: "/workspace/project", SectionKey: "project:/workspace/project",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "publish initialization") {
+		t.Fatalf("CreateSession() error = %v, want publish failure", err)
+	}
+	if runtime.startCalls != 1 || runtime.closeCalls != 0 || store.rollback {
+		t.Fatalf("failed retry compensated existing state: start=%d close=%d rollback=%v", runtime.startCalls, runtime.closeCalls, store.rollback)
+	}
+}
+
+func assertDetachedDeadline(
+	t *testing.T,
+	name string,
+	observation contextObservation,
+	wantMaximum time.Duration,
+) {
+	t.Helper()
+	if observation.err != nil || !observation.hasDeadline || observation.remaining <= 0 ||
+		observation.remaining > wantMaximum {
+		t.Fatalf(
+			"%s context=%#v, want active detached deadline within %s",
+			name,
+			observation,
+			wantMaximum,
+		)
+	}
+}

--- a/packages/agent/host/deleted_session_lifecycle_conformance_test.go
+++ b/packages/agent/host/deleted_session_lifecycle_conformance_test.go
@@ -153,9 +153,9 @@ type deletedSessionLifecycleRuntime struct {
 func (r *deletedSessionLifecycleRuntime) Start(
 	context.Context,
 	agenthost.RuntimeStartInput,
-) (agenthost.ProviderRuntimeSession, error) {
+) (agenthost.RuntimeStartResult, error) {
 	r.startCalls++
-	return agenthost.ProviderRuntimeSession{}, nil
+	return agenthost.RuntimeStartResult{}, nil
 }
 
 func (r *deletedSessionLifecycleRuntime) Resume(

--- a/packages/agent/host/edit_retry_saga_test.go
+++ b/packages/agent/host/edit_retry_saga_test.go
@@ -436,8 +436,8 @@ type hostEditRetryRuntime struct {
 	content                     []agenthost.PromptContentBlock
 }
 
-func (*hostEditRetryRuntime) Start(context.Context, agenthost.RuntimeStartInput) (agenthost.ProviderRuntimeSession, error) {
-	return agenthost.ProviderRuntimeSession{}, nil
+func (*hostEditRetryRuntime) Start(context.Context, agenthost.RuntimeStartInput) (agenthost.RuntimeStartResult, error) {
+	return agenthost.RuntimeStartResult{}, nil
 }
 func (r *hostEditRetryRuntime) Resume(context.Context, agenthost.RuntimeResumeInput) (agenthost.ProviderRuntimeSession, error) {
 	return r.session(), nil

--- a/packages/agent/host/errors.go
+++ b/packages/agent/host/errors.go
@@ -18,6 +18,7 @@ var (
 	ErrActiveTurnTargetMismatch          = errors.New("active-turn guidance target is no longer active")
 	ErrSessionTitleTooLong               = errors.New("agent session title is too long")
 	ErrRuntimeSessionDisconnected        = errors.New("agent runtime session is disconnected")
+	ErrRuntimeSessionPublishUnavailable  = errors.New("agent runtime session initialization publication is unavailable")
 	ErrInteractionNotFound               = errors.New("agent interaction was not found")
 	ErrRuntimeOperationInProgress        = errors.New("agent runtime operation is already in progress")
 	ErrRuntimeOperationFailed            = errors.New("agent runtime operation failed")

--- a/packages/agent/host/goal_control_restart_test.go
+++ b/packages/agent/host/goal_control_restart_test.go
@@ -43,7 +43,7 @@ type createGoalRestartRuntime struct {
 func (r *createGoalRestartRuntime) Start(
 	_ context.Context,
 	input agenthost.RuntimeStartInput,
-) (agenthost.ProviderRuntimeSession, error) {
+) (agenthost.RuntimeStartResult, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.starts++
@@ -54,7 +54,7 @@ func (r *createGoalRestartRuntime) Start(
 		Cwd:               input.Cwd, Status: "ready", Visible: true,
 		CreatedAtUnixMS: 1, UpdatedAtUnixMS: 1,
 	}
-	return r.session, nil
+	return agenthost.RuntimeStartResult{Session: r.session, Created: true}, nil
 }
 
 func (r *createGoalRestartRuntime) Session(
@@ -65,6 +65,18 @@ func (r *createGoalRestartRuntime) Session(
 	defer r.mu.Unlock()
 	found := workspaceID == r.session.WorkspaceID && agentSessionID == r.session.ID
 	return r.session, found
+}
+
+func (r *createGoalRestartRuntime) PublishSessionInitialization(
+	_ context.Context,
+	input agenthost.RuntimeSessionInitializationPublishInput,
+) (agenthost.ProviderRuntimeSession, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if input.WorkspaceID != r.session.WorkspaceID || input.AgentSessionID != r.session.ID {
+		return agenthost.ProviderRuntimeSession{}, agenthost.ErrSessionNotFound
+	}
+	return r.session, nil
 }
 
 func (r *createGoalRestartRuntime) startCount() int {

--- a/packages/agent/host/lifecycle.go
+++ b/packages/agent/host/lifecycle.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 	"unicode/utf8"
 
 	"github.com/google/uuid"
@@ -86,6 +85,10 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 			h.abandonSubmitClaim(ref, claim.ClientSubmitID)
 		}
 	}()
+	runtimePublisher, ok := h.runtime.(RuntimeSessionInitializationPublisher)
+	if !ok {
+		return createSessionFailureResult(input, ErrRuntimeSessionPublishUnavailable)
+	}
 
 	prepared := PreparedRuntime{Cwd: strings.TrimSpace(value(input.Cwd))}
 	if h.preparation != nil {
@@ -94,24 +97,28 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 			return createSessionFailureResult(input, err)
 		}
 	}
+	sessionLockHeld := false
 	cleanup := func(cause error, started bool, canonicalCreated bool) error {
-		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
-		defer cancel()
-		var cleanupErrs []error
-		cleanupErrs = append(cleanupErrs, cause)
-		if started {
-			cleanupErrs = append(cleanupErrs, h.runtime.Close(cleanupCtx, RuntimeCloseInput{WorkspaceID: workspaceID, AgentSessionID: input.AgentSessionID}))
+		return h.cleanupFailedCreate(ctx, ref, input.Provider, cause, failedCreateCleanupState{
+			RuntimeStarted: started, CanonicalCreated: canonicalCreated, SessionLockHeld: sessionLockHeld,
+		})
+	}
+	releaseSession, err := h.acquireSession(ctx, ref)
+	if err != nil {
+		return createSessionFailureResult(input, cleanup(err, false, false))
+	}
+	sessionLockHeld = true
+	defer func() {
+		if sessionLockHeld {
+			releaseSession()
 		}
-		if canonicalCreated {
-			_, deleteErr := h.store.RollbackRuntimeSessionInitialization(cleanupCtx, workspaceID, input.AgentSessionID)
-			cleanupErrs = append(cleanupErrs, deleteErr)
-		}
-		if h.preparation != nil {
-			cleanupErrs = append(cleanupErrs, h.preparation.Cleanup(cleanupCtx, RuntimeCleanupInput{
-				WorkspaceID: workspaceID, AgentSessionID: input.AgentSessionID, Provider: input.Provider,
-			}))
-		}
-		return errors.Join(cleanupErrs...)
+	}()
+	canonicalBeforeStart, canonicalExisted, err := h.store.GetSession(ctx, workspaceID, input.AgentSessionID)
+	if err != nil {
+		return createSessionFailureResult(input, cleanup(err, false, false))
+	}
+	if canonicalExisted && !railPlacementMatchesSession(input.RailPlacement, canonicalBeforeStart) {
+		return createSessionFailureResult(input, cleanup(ErrRailPlacementConflict, false, false))
 	}
 	startedAt := h.now()
 	release, err := h.acquireStartup(ctx, input.Provider)
@@ -119,7 +126,7 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 		h.observeStep(ctx, "session_create", "runtime_started", input.AgentSessionID, input.Provider, startedAt, err)
 		return createSessionFailureResult(input, cleanup(err, false, false))
 	}
-	session, err := func() (ProviderRuntimeSession, error) {
+	startResult, err := func() (RuntimeStartResult, error) {
 		defer release()
 		runtimeTitle, initialTitleEstablished := initialGoalRuntimeTitle(value(input.Title), input.InitialDisplayPrompt, typedGoal, isTypedGoal)
 		return h.runtime.Start(ctx, RuntimeStartInput{
@@ -132,12 +139,15 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 			RuntimeContext:    cloneMap(input.RuntimeContext), ReasoningEffort: value(input.ReasoningEffort),
 			Speed: value(input.Speed), ConversationDetailMode: strings.TrimSpace(input.ConversationDetailMode),
 			Visible: input.Visible, Provisional: len(normalized) > 0,
+			CanonicalInitPending: true,
 		})
 	}()
 	if err != nil {
 		h.observeStep(ctx, "session_create", "runtime_started", input.AgentSessionID, input.Provider, startedAt, err)
 		return createSessionFailureResult(input, cleanup(err, false, false))
 	}
+	session := startResult.Session
+	runtimeCreated := startResult.Created
 	h.observeStep(ctx, "session_create", "runtime_started", session.ID, session.Provider, startedAt, nil)
 	startedAt = h.now()
 	canonicalSession, err := h.store.InitializeRuntimeSession(ctx, RuntimeSessionInitialization{
@@ -146,23 +156,46 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 	})
 	if err != nil {
 		h.observeStep(ctx, "session_create", "session_persisted", session.ID, session.Provider, startedAt, err)
-		return createSessionFailureResult(input, cleanup(err, true, false))
+		return createSessionFailureResult(input, cleanup(err, runtimeCreated, false))
 	}
+	canonicalCreated := !canonicalExisted
 	if strings.TrimSpace(canonicalSession.ID) != strings.TrimSpace(session.ID) || strings.TrimSpace(canonicalSession.WorkspaceID) != workspaceID || strings.TrimSpace(canonicalSession.RailSectionKey) == "" {
 		identityErr := fmt.Errorf("initialize workspace agent session: persisted session identity mismatch")
 		h.observeStep(ctx, "session_create", "session_persisted", session.ID, session.Provider, startedAt, identityErr)
-		return createSessionFailureResult(input, cleanup(identityErr, true, true))
+		return createSessionFailureResult(input, cleanup(identityErr, runtimeCreated, canonicalCreated))
 	}
 	if !railPlacementMatchesSession(input.RailPlacement, canonicalSession) {
 		placementErr := ErrRailPlacementConflict
 		h.observeStep(ctx, "session_create", "session_persisted", session.ID, session.Provider, startedAt, placementErr)
-		return createSessionFailureResult(input, cleanup(placementErr, true, true))
+		return createSessionFailureResult(input, cleanup(placementErr, runtimeCreated, canonicalCreated))
 	}
 	h.observeStep(ctx, "session_create", "session_persisted", session.ID, session.Provider, startedAt, nil)
+	startedAt = h.now()
+	published, err := publishRuntimeSessionInitialization(
+		ctx,
+		runtimePublisher,
+		RuntimeSessionInitializationPublishInput{
+			WorkspaceID: workspaceID, AgentSessionID: session.ID,
+		},
+	)
+	if err != nil {
+		h.observeStep(ctx, "session_create", "session_published", session.ID, session.Provider, startedAt, err)
+		return createSessionFailureResult(input, cleanup(err, runtimeCreated, canonicalCreated))
+	}
+	if strings.TrimSpace(published.ID) != strings.TrimSpace(session.ID) ||
+		strings.TrimSpace(published.WorkspaceID) != workspaceID {
+		publishErr := errors.New("publish workspace agent session: runtime session identity mismatch")
+		h.observeStep(ctx, "session_create", "session_published", session.ID, session.Provider, startedAt, publishErr)
+		return createSessionFailureResult(input, cleanup(publishErr, runtimeCreated, canonicalCreated))
+	}
+	session = published
+	h.observeStep(ctx, "session_create", "session_published", session.ID, session.Provider, startedAt, nil)
 	if len(normalized) == 0 && !isTypedGoal {
 		return CreateSessionResult{Session: session, Canonical: canonicalSession, SessionStatus: CreateSessionStatusCreated, InitialGoalStatus: CreateSessionInitialGoalStatusNotRequested}, nil
 	}
 	if isTypedGoal {
+		releaseSession()
+		sessionLockHeld = false
 		goalInput.AgentSessionID = session.ID
 		goalResult, goalErr := h.goalControl(ctx, goalInput)
 		if goalErr != nil {
@@ -179,7 +212,7 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 			// session. Preserve that canonical session on command failure just as
 			// the legacy Service did; rolling it back would leave subscribers with
 			// an unpaired session-created event.
-			return CreateSessionResult{Session: session, Canonical: canonicalSession, Kind: "goalControl", SessionStatus: CreateSessionStatusCreated, InitialGoalStatus: CreateSessionInitialGoalStatusFailed}, cleanup(goalErr, true, false)
+			return CreateSessionResult{Session: session, Canonical: canonicalSession, Kind: "goalControl", SessionStatus: CreateSessionStatusCreated, InitialGoalStatus: CreateSessionInitialGoalStatusFailed}, cleanup(goalErr, runtimeCreated, false)
 		}
 		if refreshed, ok := h.runtime.Session(workspaceID, session.ID); ok {
 			session = refreshed
@@ -189,14 +222,14 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 	startedAt = h.now()
 	if err := h.runtime.ValidatePromptContent(ctx, RuntimeExecInput{WorkspaceID: workspaceID, AgentSessionID: session.ID, Content: normalized}); err != nil {
 		h.observeStep(ctx, "session_create", "prompt_validated", session.ID, session.Provider, startedAt, err)
-		return createSessionFailureResult(input, cleanup(err, true, true))
+		return createSessionFailureResult(input, cleanup(err, runtimeCreated, canonicalCreated))
 	}
 	h.observeStep(ctx, "session_create", "prompt_validated", session.ID, session.Provider, startedAt, nil)
 	startedAt = h.now()
 	preparedContent, err := h.prepareContent(workspaceID, session.ID, normalized)
 	if err != nil {
 		h.observeStep(ctx, "session_create", "prompt_prepared", session.ID, session.Provider, startedAt, err)
-		return createSessionFailureResult(input, cleanup(err, true, true))
+		return createSessionFailureResult(input, cleanup(err, runtimeCreated, canonicalCreated))
 	}
 	h.observeStep(ctx, "session_create", "prompt_prepared", session.ID, session.Provider, startedAt, nil)
 	displayPrompt := strings.TrimSpace(input.InitialDisplayPrompt)
@@ -249,12 +282,12 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 			claimPending = false
 			return createSessionCreatedErrorResult(input, session, canonicalSession, errors.Join(ErrSubmitDeliveryUnknown, err))
 		}
-		return createSessionFailureResult(input, cleanup(err, true, true))
+		return createSessionFailureResult(input, cleanup(err, runtimeCreated, canonicalCreated))
 	}
 	turnID = strings.TrimSpace(execResult.TurnID)
 	if turnID == "" {
 		h.observeStep(ctx, "session_create", "runtime_exec", session.ID, session.Provider, startedAt, ErrSubmitDeliveryUnknown)
-		return createSessionFailureResult(input, cleanup(ErrSubmitDeliveryUnknown, true, true))
+		return createSessionFailureResult(input, cleanup(ErrSubmitDeliveryUnknown, runtimeCreated, canonicalCreated))
 	}
 	if expectedTurnID := strings.TrimSpace(input.TurnID); expectedTurnID != "" && turnID != expectedTurnID {
 		claimPending = false
@@ -747,106 +780,4 @@ func (h *Host) acquireStartup(ctx context.Context, provider string) (func(), err
 		return func() {}, nil
 	}
 	return h.startupGate.Acquire(ctx, provider)
-}
-
-func normalizeOptionalPromptContent(content []PromptContentBlock) ([]PromptContentBlock, string, error) {
-	if len(content) == 0 {
-		return nil, "", nil
-	}
-	return normalizePromptContent(content)
-}
-
-func createPreparationInput(workspaceID string, input CreateSessionInput) RuntimePreparationInput {
-	return RuntimePreparationInput{
-		WorkspaceID: workspaceID, AgentSessionID: input.AgentSessionID, AgentTargetID: input.AgentTargetID,
-		Provider: input.Provider, Cwd: value(input.Cwd), Title: value(input.Title), PermissionModeID: value(input.PermissionModeID),
-		PlanMode: valueBool(input.PlanMode), BrowserUse: valueBoolDefault(input.BrowserUse, true), ComputerUse: valueBoolDefault(input.ComputerUse, true), CodexSaverMode: valueBool(input.CodexSaverMode),
-		ProviderTargetRef: cloneMap(input.ProviderTargetRef), Model: value(input.Model), ReasoningEffort: value(input.ReasoningEffort),
-		ConversationDetailMode: input.ConversationDetailMode, Metadata: cloneMap(input.Metadata), RuntimeContext: cloneMap(input.RuntimeContext),
-	}
-}
-
-func resumePreparationInput(session storesqlite.Session, settings ComposerSettings) RuntimePreparationInput {
-	return RuntimePreparationInput{
-		WorkspaceID: session.WorkspaceID, AgentSessionID: session.ID, AgentTargetID: session.AgentTargetID,
-		Provider: session.Provider, Cwd: session.Cwd, Title: session.Title, PermissionModeID: settings.PermissionModeID,
-		PlanMode: settings.PlanMode, BrowserUse: valueBoolDefault(settings.BrowserUse, true), ComputerUse: valueBoolDefault(settings.ComputerUse, true), CodexSaverMode: settings.CodexSaverMode,
-		Model: settings.Model, ReasoningEffort: settings.ReasoningEffort, ConversationDetailMode: settings.ConversationDetailMode,
-		RuntimeContext: cloneMap(session.InternalRuntimeContext), SessionOrigin: session.Origin,
-		ProviderSessionID: session.ProviderSessionID, CreatedAtUnixMS: session.CreatedAtUnixMS,
-		UpdatedAtUnixMS: session.UpdatedAtUnixMS, Visible: session.Metadata.Visible, Settings: settings,
-		SessionMetadata: session.Metadata,
-	}
-}
-
-func composerSettingsFromMap(values map[string]any) ComposerSettings {
-	result := ComposerSettings{}
-	result.CodexSaverMode, _ = values["codexSaverMode"].(bool)
-	result.Model, _ = values["model"].(string)
-	result.PermissionModeID, _ = values["permissionModeId"].(string)
-	result.PlanMode, _ = values["planMode"].(bool)
-	if value, ok := values["browserUse"].(bool); ok {
-		result.BrowserUse = &value
-	}
-	if value, ok := values["computerUse"].(bool); ok {
-		result.ComputerUse = &value
-	}
-	result.ReasoningEffort, _ = values["reasoningEffort"].(string)
-	result.Speed, _ = values["speed"].(string)
-	result.ConversationDetailMode, _ = values["conversationDetailMode"].(string)
-	return result
-}
-
-func lifecycleFromTurn(turn storesqlite.Turn) TurnLifecycle {
-	result := TurnLifecycle{Phase: turn.Phase}
-	if turnID := strings.TrimSpace(turn.TurnID); turnID != "" && turn.Phase != "settled" {
-		result.ActiveTurnID = &turnID
-	}
-	if turn.Outcome != "" {
-		outcome := turn.Outcome
-		result.Outcome = &outcome
-	}
-	if turn.CompletedCommandKind != "" || turn.CompletedCommandStatus != "" {
-		result.CompletedCommand = &CompletedCommand{Kind: turn.CompletedCommandKind, Status: turn.CompletedCommandStatus}
-	}
-	return result
-}
-
-func imageOnlyDisplayText(content []PromptContentBlock) string {
-	count := 0
-	for _, block := range content {
-		if block.Type == "image" {
-			count++
-		}
-	}
-	if count == 1 {
-		return "[Image]"
-	}
-	if count > 1 {
-		return "[Images]"
-	}
-	return ""
-}
-
-func value(input *string) string {
-	if input == nil {
-		return ""
-	}
-	return strings.TrimSpace(*input)
-}
-func valueBool(input *bool) bool { return input != nil && *input }
-func valueBoolDefault(input *bool, fallback bool) bool {
-	if input == nil {
-		return fallback
-	}
-	return *input
-}
-func boolPointer(value bool) *bool { return &value }
-func firstMap(values ...map[string]any) map[string]any {
-	for _, value := range values {
-		if len(value) > 0 {
-			return value
-		}
-	}
-	return nil
 }

--- a/packages/agent/host/lifecycle_values.go
+++ b/packages/agent/host/lifecycle_values.go
@@ -1,0 +1,113 @@
+package agenthost
+
+import (
+	"strings"
+
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+func normalizeOptionalPromptContent(content []PromptContentBlock) ([]PromptContentBlock, string, error) {
+	if len(content) == 0 {
+		return nil, "", nil
+	}
+	return normalizePromptContent(content)
+}
+
+func createPreparationInput(workspaceID string, input CreateSessionInput) RuntimePreparationInput {
+	return RuntimePreparationInput{
+		WorkspaceID: workspaceID, AgentSessionID: input.AgentSessionID, AgentTargetID: input.AgentTargetID,
+		Provider: input.Provider, Cwd: value(input.Cwd), Title: value(input.Title), PermissionModeID: value(input.PermissionModeID),
+		PlanMode: valueBool(input.PlanMode), BrowserUse: valueBoolDefault(input.BrowserUse, true), ComputerUse: valueBoolDefault(input.ComputerUse, true), CodexSaverMode: valueBool(input.CodexSaverMode),
+		ProviderTargetRef: cloneMap(input.ProviderTargetRef), Model: value(input.Model), ReasoningEffort: value(input.ReasoningEffort),
+		ConversationDetailMode: input.ConversationDetailMode, Metadata: cloneMap(input.Metadata), RuntimeContext: cloneMap(input.RuntimeContext),
+	}
+}
+
+func resumePreparationInput(session storesqlite.Session, settings ComposerSettings) RuntimePreparationInput {
+	return RuntimePreparationInput{
+		WorkspaceID: session.WorkspaceID, AgentSessionID: session.ID, AgentTargetID: session.AgentTargetID,
+		Provider: session.Provider, Cwd: session.Cwd, Title: session.Title, PermissionModeID: settings.PermissionModeID,
+		PlanMode: settings.PlanMode, BrowserUse: valueBoolDefault(settings.BrowserUse, true), ComputerUse: valueBoolDefault(settings.ComputerUse, true), CodexSaverMode: settings.CodexSaverMode,
+		Model: settings.Model, ReasoningEffort: settings.ReasoningEffort, ConversationDetailMode: settings.ConversationDetailMode,
+		RuntimeContext: cloneMap(session.InternalRuntimeContext), SessionOrigin: session.Origin,
+		ProviderSessionID: session.ProviderSessionID, CreatedAtUnixMS: session.CreatedAtUnixMS,
+		UpdatedAtUnixMS: session.UpdatedAtUnixMS, Visible: session.Metadata.Visible, Settings: settings,
+		SessionMetadata: session.Metadata,
+	}
+}
+
+func composerSettingsFromMap(values map[string]any) ComposerSettings {
+	result := ComposerSettings{}
+	result.CodexSaverMode, _ = values["codexSaverMode"].(bool)
+	result.Model, _ = values["model"].(string)
+	result.PermissionModeID, _ = values["permissionModeId"].(string)
+	result.PlanMode, _ = values["planMode"].(bool)
+	if value, ok := values["browserUse"].(bool); ok {
+		result.BrowserUse = &value
+	}
+	if value, ok := values["computerUse"].(bool); ok {
+		result.ComputerUse = &value
+	}
+	result.ReasoningEffort, _ = values["reasoningEffort"].(string)
+	result.Speed, _ = values["speed"].(string)
+	result.ConversationDetailMode, _ = values["conversationDetailMode"].(string)
+	return result
+}
+
+func lifecycleFromTurn(turn storesqlite.Turn) TurnLifecycle {
+	result := TurnLifecycle{Phase: turn.Phase}
+	if turnID := strings.TrimSpace(turn.TurnID); turnID != "" && turn.Phase != "settled" {
+		result.ActiveTurnID = &turnID
+	}
+	if turn.Outcome != "" {
+		outcome := turn.Outcome
+		result.Outcome = &outcome
+	}
+	if turn.CompletedCommandKind != "" || turn.CompletedCommandStatus != "" {
+		result.CompletedCommand = &CompletedCommand{Kind: turn.CompletedCommandKind, Status: turn.CompletedCommandStatus}
+	}
+	return result
+}
+
+func imageOnlyDisplayText(content []PromptContentBlock) string {
+	count := 0
+	for _, block := range content {
+		if block.Type == "image" {
+			count++
+		}
+	}
+	if count == 1 {
+		return "[Image]"
+	}
+	if count > 1 {
+		return "[Images]"
+	}
+	return ""
+}
+
+func value(input *string) string {
+	if input == nil {
+		return ""
+	}
+	return strings.TrimSpace(*input)
+}
+
+func valueBool(input *bool) bool { return input != nil && *input }
+
+func valueBoolDefault(input *bool, fallback bool) bool {
+	if input == nil {
+		return fallback
+	}
+	return *input
+}
+
+func boolPointer(value bool) *bool { return &value }
+
+func firstMap(values ...map[string]any) map[string]any {
+	for _, value := range values {
+		if len(value) > 0 {
+			return value
+		}
+	}
+	return nil
+}

--- a/packages/agent/host/ports.go
+++ b/packages/agent/host/ports.go
@@ -250,7 +250,7 @@ type HistoricalSessionStateStore interface {
 // create, resume, send, exact cancel, interactive, plan, title, and visibility
 // workflows. Process transport and provider implementations stay behind it.
 type RuntimeController interface {
-	Start(context.Context, RuntimeStartInput) (ProviderRuntimeSession, error)
+	Start(context.Context, RuntimeStartInput) (RuntimeStartResult, error)
 	Resume(context.Context, RuntimeResumeInput) (ProviderRuntimeSession, error)
 	Session(workspaceID string, agentSessionID string) (ProviderRuntimeSession, bool)
 	CanResume(RuntimeResumeInput) bool
@@ -263,6 +263,14 @@ type RuntimeController interface {
 	SetTitle(context.Context, RuntimeSetTitleInput) (ProviderRuntimeSession, error)
 	SetVisible(context.Context, RuntimeSetVisibleInput) (ProviderRuntimeSession, error)
 	Close(context.Context, RuntimeCloseInput) error
+}
+
+// RuntimeSessionInitializationPublisher is the explicit release half of a
+// create-time canonical initialization barrier. CreateSession requires this
+// capability before starting a provider Runtime; other Host workflows can use
+// a narrower RuntimeController without pretending to support creation.
+type RuntimeSessionInitializationPublisher interface {
+	PublishSessionInitialization(context.Context, RuntimeSessionInitializationPublishInput) (ProviderRuntimeSession, error)
 }
 
 // RuntimeSessionLiveness distinguishes a registered runtime Session from a

--- a/packages/agent/host/types.go
+++ b/packages/agent/host/types.go
@@ -287,6 +287,28 @@ type RuntimeStartInput struct {
 	ConversationDetailMode  string
 	Visible                 *bool
 	Provisional             bool
+	// CanonicalInitPending starts the provider runtime while keeping
+	// its activity reports and stream events behind the Host-owned canonical
+	// initialization barrier. Host releases that barrier only after the exact
+	// canonical Session (including immutable rail placement) is durable.
+	CanonicalInitPending bool
+}
+
+// RuntimeSessionInitializationPublishInput identifies the started Runtime
+// Session whose canonical initialization barrier may be released. Publication
+// is idempotent; it never creates or changes canonical rail placement itself.
+type RuntimeSessionInitializationPublishInput struct {
+	WorkspaceID    string
+	AgentSessionID string
+}
+
+// RuntimeStartResult distinguishes a provider Runtime created by this exact
+// call from an idempotently reused Runtime. CreateSession may compensate only
+// resources it owns; a conflicting retry must never close an earlier live
+// Session.
+type RuntimeStartResult struct {
+	Session ProviderRuntimeSession
+	Created bool
 }
 
 type RuntimeResumeInput struct {

--- a/services/tuttid/agent_runtime_adapter.go
+++ b/services/tuttid/agent_runtime_adapter.go
@@ -449,7 +449,7 @@ func (a agentRuntimeAdapter) Sessions(workspaceID string) []agentservice.Provide
 	return result
 }
 
-func (a agentRuntimeAdapter) Start(ctx context.Context, input agentservice.RuntimeStartInput) (agentservice.ProviderRuntimeSession, error) {
+func (a agentRuntimeAdapter) Start(ctx context.Context, input agentservice.RuntimeStartInput) (agentservice.RuntimeStartResult, error) {
 	result, err := a.controller.Start(ctx, agentruntime.StartInput{
 		RoomID:                  input.WorkspaceID,
 		AgentSessionID:          input.AgentSessionID,
@@ -471,15 +471,31 @@ func (a agentRuntimeAdapter) Start(ctx context.Context, input agentservice.Runti
 			PermissionModeID:       input.PermissionModeID,
 			ConversationDetailMode: input.ConversationDetailMode,
 		},
-		Visible:     input.Visible,
-		Provisional: input.Provisional,
+		Visible:              input.Visible,
+		Provisional:          input.Provisional,
+		CanonicalInitPending: input.CanonicalInitPending,
 	})
 	if err != nil {
-		return agentservice.ProviderRuntimeSession{}, mapAgentRuntimeError(err)
+		return agentservice.RuntimeStartResult{}, mapAgentRuntimeError(err)
 	}
 	session := a.runtimeSessionWithState(result.Session)
 	session.Provisional = input.Provisional
-	return session, nil
+	return agentservice.RuntimeStartResult{Session: session, Created: result.Created}, nil
+}
+
+func (a agentRuntimeAdapter) PublishSessionInitialization(
+	ctx context.Context,
+	input agentservice.RuntimeSessionInitializationPublishInput,
+) (agentservice.ProviderRuntimeSession, error) {
+	session, err := a.controller.PublishSessionInitialization(
+		ctx,
+		input.WorkspaceID,
+		input.AgentSessionID,
+	)
+	if err != nil {
+		return agentservice.ProviderRuntimeSession{}, mapAgentRuntimeError(err)
+	}
+	return a.runtimeSessionWithState(session), nil
 }
 
 func (a agentRuntimeAdapter) Subscribe(workspaceID string, agentSessionID string) (<-chan agentservice.RuntimeStreamEvent, func(), bool) {

--- a/services/tuttid/agent_runtime_adapter_test.go
+++ b/services/tuttid/agent_runtime_adapter_test.go
@@ -288,13 +288,14 @@ func TestAgentRuntimeAdapterPreservesProviderAcceptanceRequirement(t *testing.T)
 		reporter,
 	)
 	adapter := newAgentRuntimeAdapter(controller)
-	session, err := adapter.Start(t.Context(), agentservice.RuntimeStartInput{
+	startResult, err := adapter.Start(t.Context(), agentservice.RuntimeStartInput{
 		WorkspaceID: "workspace-1", AgentSessionID: "session-1",
 		Provider: provider.Provider(),
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
+	session := startResult.Session
 	result, err := adapter.Exec(t.Context(), agentservice.RuntimeExecInput{
 		WorkspaceID: "workspace-1", AgentSessionID: "session-1",
 		TurnID: "canonical-turn-1", ClientSubmitID: "opaque-submit-1",
@@ -399,7 +400,7 @@ func TestAgentRuntimeAdapterReturnsClaudeSDKModelConfigOptions(t *testing.T) {
 		nil,
 	)
 	adapter := newAgentRuntimeAdapter(controller)
-	session, err := adapter.Start(ctx, agentservice.RuntimeStartInput{
+	startResult, err := adapter.Start(ctx, agentservice.RuntimeStartInput{
 		WorkspaceID:    "workspace-1",
 		AgentSessionID: "agent-session-1",
 		Provider:       agentruntime.ProviderClaudeCode,
@@ -410,6 +411,7 @@ func TestAgentRuntimeAdapterReturnsClaudeSDKModelConfigOptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Start() error = %v", err)
 	}
+	session := startResult.Session
 	defer func() {
 		_ = adapter.Close(context.Background(), agentservice.RuntimeCloseInput{
 			WorkspaceID:    session.WorkspaceID,

--- a/services/tuttid/service/agent/canonical_session_initialization_integration_test.go
+++ b/services/tuttid/service/agent/canonical_session_initialization_integration_test.go
@@ -1,0 +1,366 @@
+package agent
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+	hostadapter "github.com/tutti-os/tutti/packages/agent/daemon/hostadapter"
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+	_ "modernc.org/sqlite"
+)
+
+type canonicalInitializationIntegrationStore struct {
+	*agenthost.SQLiteWorkspaceStore
+	initializeEntered chan struct{}
+	releaseInitialize chan struct{}
+	enterOnce         sync.Once
+}
+
+func (s *canonicalInitializationIntegrationStore) InitializeRuntimeSession(
+	ctx context.Context,
+	input agenthost.RuntimeSessionInitialization,
+) (storesqlite.Session, error) {
+	s.enterOnce.Do(func() { close(s.initializeEntered) })
+	select {
+	case <-s.releaseInitialize:
+	case <-ctx.Done():
+		return storesqlite.Session{}, ctx.Err()
+	}
+	return s.SQLiteWorkspaceStore.InitializeRuntimeSession(ctx, input)
+}
+
+type canonicalInitializationIntegrationReporter struct {
+	projection *ActivityProjection
+	reports    atomic.Int32
+	mu         sync.Mutex
+	lastReport agentsessionstore.ReportActivityInput
+}
+
+func (*canonicalInitializationIntegrationReporter) AsyncActivityReporter() {}
+
+func (r *canonicalInitializationIntegrationReporter) Report(
+	ctx context.Context,
+	input agentsessionstore.ReportActivityInput,
+) error {
+	r.reports.Add(1)
+	r.mu.Lock()
+	r.lastReport = input
+	r.mu.Unlock()
+	return r.projection.Report(ctx, input)
+}
+
+func (r *canonicalInitializationIntegrationReporter) ReportSubmitProvenance(
+	ctx context.Context,
+	input agentsessionstore.ReportActivityInput,
+) error {
+	return r.projection.ReportSubmitProvenance(ctx, input)
+}
+
+func (r *canonicalInitializationIntegrationReporter) snapshot() agentsessionstore.ReportActivityInput {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.lastReport
+}
+
+type canonicalInitializationIntegrationObserver struct {
+	calls atomic.Int32
+}
+
+func (o *canonicalInitializationIntegrationObserver) ObserveRuntimeStreamEvents(
+	context.Context,
+	string,
+	string,
+	[]agentruntime.StreamEvent,
+) error {
+	o.calls.Add(1)
+	return nil
+}
+
+type canonicalInitializationIntegrationAdapter struct {
+	sinkMu     sync.Mutex
+	sink       agentruntime.SessionEventSink
+	startCalls atomic.Int32
+	goalCalls  atomic.Int32
+}
+
+func (*canonicalInitializationIntegrationAdapter) Provider() string {
+	return agentruntime.ProviderCodex
+}
+
+func (a *canonicalInitializationIntegrationAdapter) Start(
+	_ context.Context,
+	session agentruntime.Session,
+) ([]activityshared.Event, error) {
+	a.startCalls.Add(1)
+	return []activityshared.Event{activityshared.NewSessionStarted(activityshared.EventContext{
+		EventID:           "canonical-init-session-started",
+		Provider:          activityshared.Provider(session.Provider),
+		ProviderSessionID: "provider-session-1",
+		AgentSessionID:    session.AgentSessionID,
+		CWD:               session.CWD,
+		Title:             session.Title,
+	})}, nil
+}
+
+func (*canonicalInitializationIntegrationAdapter) Resume(context.Context, agentruntime.Session) error {
+	return nil
+}
+
+func (*canonicalInitializationIntegrationAdapter) Close(context.Context, agentruntime.Session) error {
+	return nil
+}
+
+func (*canonicalInitializationIntegrationAdapter) Exec(
+	context.Context,
+	agentruntime.Session,
+	[]agentruntime.PromptContentBlock,
+	string,
+	string,
+	agentruntime.EventSink,
+	agentruntime.CommandSnapshotSink,
+) ([]activityshared.Event, error) {
+	return nil, nil
+}
+
+func (*canonicalInitializationIntegrationAdapter) Cancel(
+	context.Context,
+	agentruntime.Session,
+	string,
+) ([]activityshared.Event, error) {
+	return nil, nil
+}
+
+func (a *canonicalInitializationIntegrationAdapter) SetSessionEventSink(
+	sink agentruntime.SessionEventSink,
+) {
+	a.sinkMu.Lock()
+	a.sink = sink
+	a.sinkMu.Unlock()
+}
+
+func (a *canonicalInitializationIntegrationAdapter) emitTitleUpdate(agentSessionID, title string) {
+	a.sinkMu.Lock()
+	sink := a.sink
+	a.sinkMu.Unlock()
+	if sink == nil {
+		return
+	}
+	sink(agentSessionID, []activityshared.Event{
+		activityshared.NewSessionTitleUpdated(activityshared.EventContext{
+			EventID:           "canonical-init-title-updated",
+			Provider:          activityshared.Provider(agentruntime.ProviderCodex),
+			ProviderSessionID: "provider-session-1",
+			AgentSessionID:    agentSessionID,
+			Title:             title,
+		}),
+	})
+}
+
+func (*canonicalInitializationIntegrationAdapter) GoalCapabilities() agentruntime.GoalAdapterCapabilities {
+	return agentruntime.GoalAdapterCapabilities{}
+}
+
+func (a *canonicalInitializationIntegrationAdapter) ApplyGoal(
+	_ context.Context,
+	_ agentruntime.Session,
+	input agentruntime.GoalApplyInput,
+) (agentruntime.GoalAdapterResult, error) {
+	a.goalCalls.Add(1)
+	return agentruntime.GoalAdapterResult{
+		Observation: map[string]any{
+			"objective": input.Objective,
+			"status":    "active",
+		},
+		Evidence: map[string]any{"phase": "applied"},
+	}, nil
+}
+
+func (*canonicalInitializationIntegrationAdapter) ReconcileGoal(
+	context.Context,
+	agentruntime.Session,
+) (agentruntime.GoalAdapterResult, error) {
+	return agentruntime.GoalAdapterResult{}, nil
+}
+
+func (*canonicalInitializationIntegrationAdapter) NormalizeGoalObservation(raw map[string]any) map[string]any {
+	return raw
+}
+
+func (*canonicalInitializationIntegrationAdapter) ExecGoalControl(
+	context.Context,
+	agentruntime.Session,
+	[]agentruntime.PromptContentBlock,
+	string,
+) ([]activityshared.Event, bool, error) {
+	return nil, false, nil
+}
+
+func TestCreateSessionCanonicalInitializationBarrierWithRealControllerAndSQLite(t *testing.T) {
+	ctx := t.Context()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "canonical-initialization.db"))
+	if err != nil {
+		t.Fatalf("open SQLite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+	canonical := storesqlite.New(db, storesqlite.Options{})
+	if err := canonical.Migrate(ctx); err != nil {
+		t.Fatalf("migrate SQLite: %v", err)
+	}
+
+	workspaceID := "workspace-canonical-initialization"
+	agentSessionID := "session-canonical-initialization"
+	baseStore := &agenthost.SQLiteWorkspaceStore{
+		StoreForWorkspace: func(candidate string) *storesqlite.Store {
+			if candidate == workspaceID {
+				return canonical
+			}
+			return nil
+		},
+		CurrentUserID: func() string { return "user-1" },
+	}
+	store := &canonicalInitializationIntegrationStore{
+		SQLiteWorkspaceStore: baseStore,
+		initializeEntered:    make(chan struct{}),
+		releaseInitialize:    make(chan struct{}),
+	}
+	projection := NewActivityProjection(canonical)
+	reporter := &canonicalInitializationIntegrationReporter{projection: projection}
+	adapter := &canonicalInitializationIntegrationAdapter{}
+	controller := agentruntime.NewController([]agentruntime.Adapter{adapter}, reporter)
+	observer := &canonicalInitializationIntegrationObserver{}
+	controller.SetStreamEventObserver(observer)
+	bridge := &hostadapter.RuntimeController{Backend: controller}
+	applicationHost := agenthost.New(agenthost.Config{
+		CanonicalStore: store,
+		Runtime:        bridge,
+		GoalStore:      canonical,
+		GoalRuntime:    bridge,
+	})
+
+	cwd := "/workspace/selected-project"
+	input := agenthost.CreateSessionInput{
+		AgentSessionID:       agentSessionID,
+		AgentTargetID:        "local:codex",
+		Provider:             agentruntime.ProviderCodex,
+		Cwd:                  &cwd,
+		ClientSubmitID:       "canonical-initialization-goal-1",
+		InitialDisplayPrompt: "/goal ship from the selected project",
+		InitialGoalControl: &agenthost.TypedGoalControl{
+			Action:    "set",
+			Objective: "ship from the selected project",
+		},
+		RailPlacement: &agenthost.RailPlacement{
+			Version:     1,
+			Kind:        agenthost.RailPlacementKindProject,
+			ProjectPath: cwd,
+		},
+	}
+	type createResult struct {
+		result agenthost.CreateSessionResult
+		err    error
+	}
+	created := make(chan createResult, 1)
+	go func() {
+		result, createErr := applicationHost.CreateSession(ctx, workspaceID, input)
+		created <- createResult{result: result, err: createErr}
+	}()
+
+	select {
+	case <-store.initializeEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Host did not reach canonical initialization")
+	}
+	adapter.emitTitleUpdate(agentSessionID, "provider title during initialization")
+	if got := reporter.reports.Load(); got != 0 {
+		t.Fatalf("runtime reports before canonical initialization = %d, want 0", got)
+	}
+	if got := observer.calls.Load(); got != 0 {
+		t.Fatalf("stream publications before canonical initialization = %d, want 0", got)
+	}
+	if sessions := controller.Sessions(workspaceID); len(sessions) != 0 {
+		t.Fatalf("visible runtime sessions before canonical initialization = %#v", sessions)
+	}
+	if _, found, readErr := canonical.GetSession(ctx, workspaceID, agentSessionID); readErr != nil || found {
+		t.Fatalf("canonical session before initialization found=%v error=%v", found, readErr)
+	}
+
+	close(store.releaseInitialize)
+	var create createResult
+	select {
+	case create = <-created:
+	case <-time.After(2 * time.Second):
+		t.Fatal("CreateSession did not finish after canonical initialization release")
+	}
+	if create.err != nil {
+		t.Fatalf("CreateSession error = %v", create.err)
+	}
+	if create.result.SessionStatus != agenthost.CreateSessionStatusCreated ||
+		create.result.InitialGoalStatus != agenthost.CreateSessionInitialGoalStatusSucceeded ||
+		create.result.TurnID != "" {
+		t.Fatalf("CreateSession result = %#v", create.result)
+	}
+	persisted, found, err := canonical.GetSession(ctx, workspaceID, agentSessionID)
+	if err != nil || !found {
+		t.Fatalf("canonical session after create found=%v error=%v", found, err)
+	}
+	wantRailKey := storesqlite.RailSectionKeyForProject(cwd)
+	if persisted.RailSectionKind != string(agenthost.RailPlacementKindProject) ||
+		persisted.RailProjectPath != cwd || persisted.RailSectionKey != wantRailKey {
+		t.Fatalf(
+			"canonical rail = %q/%q/%q, want project/%q/%q",
+			persisted.RailSectionKind,
+			persisted.RailProjectPath,
+			persisted.RailSectionKey,
+			cwd,
+			wantRailKey,
+		)
+	}
+	report := reporter.snapshot()
+	bufferedTitleFound := false
+	for _, patch := range report.StatePatches {
+		if patch.Title == "provider title during initialization" {
+			bufferedTitleFound = true
+			break
+		}
+	}
+	if !bufferedTitleFound {
+		t.Fatalf("released runtime report lost buffered title update: %#v", report.StatePatches)
+	}
+	if reporter.reports.Load() != 1 || observer.calls.Load() != 1 ||
+		adapter.startCalls.Load() != 1 || adapter.goalCalls.Load() != 1 {
+		t.Fatalf(
+			"calls reports=%d streams=%d starts=%d goals=%d, want 1/1/1/1",
+			reporter.reports.Load(),
+			observer.calls.Load(),
+			adapter.startCalls.Load(),
+			adapter.goalCalls.Load(),
+		)
+	}
+
+	replayed, err := applicationHost.CreateSession(ctx, workspaceID, input)
+	if err != nil {
+		t.Fatalf("replayed CreateSession error = %v", err)
+	}
+	if replayed.Session.ID != agentSessionID || replayed.TurnID != "" ||
+		replayed.InitialGoalStatus != agenthost.CreateSessionInitialGoalStatusSucceeded {
+		t.Fatalf("replayed CreateSession result = %#v", replayed)
+	}
+	if reporter.reports.Load() != 1 || adapter.startCalls.Load() != 1 || adapter.goalCalls.Load() != 1 {
+		t.Fatalf(
+			"replay calls reports=%d starts=%d goals=%d, want 1/1/1",
+			reporter.reports.Load(),
+			adapter.startCalls.Load(),
+			adapter.goalCalls.Load(),
+		)
+	}
+}

--- a/services/tuttid/service/agent/composer_live_model_discovery.go
+++ b/services/tuttid/service/agent/composer_live_model_discovery.go
@@ -277,7 +277,7 @@ func (s *Service) discoverLiveComposerModelsUncachedForScope(
 		if prepareErr != nil {
 			return ProviderRuntimeSession{}, prepareErr
 		}
-		runtimeSession, startErr := s.controller().Start(ctx, RuntimeStartInput{
+		startResult, startErr := s.controller().Start(ctx, RuntimeStartInput{
 			WorkspaceID:       scope.workspaceID,
 			AgentSessionID:    startInput.AgentSessionID,
 			AgentTargetID:     scope.agentTargetID,
@@ -301,7 +301,7 @@ func (s *Service) discoverLiveComposerModelsUncachedForScope(
 		if startErr != nil {
 			return ProviderRuntimeSession{}, normalizeRuntimeError(startErr)
 		}
-		return runtimeSession, nil
+		return startResult.Session, nil
 	}()
 	if err != nil {
 		s.invalidateProviderAvailability(scope.provider)

--- a/services/tuttid/service/agent/host_conformance_test.go
+++ b/services/tuttid/service/agent/host_conformance_test.go
@@ -249,26 +249,27 @@ func TestHostFindTurnByClientSubmitIDUsesPublicCanonicalPort(t *testing.T) {
 }
 
 type legacyHostConformanceDriver struct {
-	t               *testing.T
-	service         *Service
-	runtime         *fakeRuntime
-	sessions        *fakeSessionReader
-	turns           *legacyHostConformanceTurnStore
-	operations      *runtimeOperationMemoryStore
-	operationPort   *conformanceRuntimeOperationStore
-	goalStore       *conformanceGoalStateStore
-	goalInbox       *conformanceGoalInboxStore
-	commitObserver  *conformanceCommitObserver
-	recoverySteps   *[]string
-	createdTurns    map[string]string
-	directHost      bool
-	goalNowUnixMS   int64
-	deletionHost    *agenthost.Host
-	deletionAdapter *Service
-	deletionStore   *conformanceDeletionStore
-	deletionGuard   *conformanceDeletionGuard
-	deletionEvents  *[]string
-	historicalState *conformanceHistoricalStateStore
+	t                        *testing.T
+	service                  *Service
+	runtime                  *fakeRuntime
+	sessions                 *fakeSessionReader
+	turns                    *legacyHostConformanceTurnStore
+	operations               *runtimeOperationMemoryStore
+	operationPort            *conformanceRuntimeOperationStore
+	goalStore                *conformanceGoalStateStore
+	goalInbox                *conformanceGoalInboxStore
+	commitObserver           *conformanceCommitObserver
+	recoverySteps            *[]string
+	createdTurns             map[string]string
+	directHost               bool
+	goalNowUnixMS            int64
+	deletionHost             *agenthost.Host
+	deletionAdapter          *Service
+	deletionStore            *conformanceDeletionStore
+	deletionGuard            *conformanceDeletionGuard
+	deletionEvents           *[]string
+	historicalState          *conformanceHistoricalStateStore
+	runtimeStartReportWrites int
 }
 
 func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconformance.Fixture) error {
@@ -277,6 +278,43 @@ func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconfo
 	d.sessions = &fakeSessionReader{
 		sessions: map[string]PersistedSession{}, tombstoned: map[string]bool{}, deletedAt: map[string]int64{},
 		parentByKey: map[string]string{},
+	}
+	d.runtimeStartReportWrites = 0
+	if fixture.RaceRuntimeStartReport {
+		reportRuntimeStart := func(session ProviderRuntimeSession) error {
+			persisted, err := (fakeSessionInitializer{}).InitializeRuntimeSession(
+				context.Background(),
+				session,
+				nil,
+			)
+			if err != nil {
+				return err
+			}
+			key := persisted.WorkspaceID + ":" + persisted.ID
+			if existing, found := d.sessions.sessions[key]; found {
+				persisted.RailSectionKind = existing.RailSectionKind
+				persisted.RailProjectPath = existing.RailProjectPath
+				persisted.RailSectionKey = existing.RailSectionKey
+			}
+			d.sessions.sessions[key] = persisted
+			d.runtimeStartReportWrites++
+			return nil
+		}
+		d.runtime.startHook = func(input RuntimeStartInput, session ProviderRuntimeSession) ProviderRuntimeSession {
+			if input.CanonicalInitPending {
+				return session
+			}
+			if err := reportRuntimeStart(session); err != nil {
+				d.t.Fatalf("prepare raced runtime start report: %v", err)
+			}
+			return session
+		}
+		d.runtime.publishInitHook = func(
+			_ RuntimeSessionInitializationPublishInput,
+			session ProviderRuntimeSession,
+		) error {
+			return reportRuntimeStart(session)
+		}
 	}
 	d.turns = &legacyHostConformanceTurnStore{
 		sessions:     map[string]agentactivitybiz.Session{},
@@ -323,6 +361,7 @@ func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconfo
 	d.service.SessionInitializer = legacyHostConformanceSessionInitializer{
 		canonicalStore: canonicalStore,
 		sessions:       d.sessions,
+		fail:           fixture.FailSessionInitialization,
 	}
 	d.service.TurnSummaryReader = d.turns
 	d.service.SubmitClaimStore = canonicalStore
@@ -1194,7 +1233,9 @@ func (d *legacyHostConformanceDriver) Metrics() hostconformance.Metrics {
 		InteractiveCalls:      len(d.runtime.submitInteractiveCalls), UpdateSettingsCalls: len(d.runtime.updateSettingsCalls),
 		CloseCalls:       len(d.runtime.closeCalls),
 		GoalControlCalls: len(d.runtime.goalControlCalls), GoalReconcileCalls: len(d.runtime.goalReconcileCalls),
-		RecoverySteps: append([]string(nil), (*d.recoverySteps)...),
+		RuntimeSessionPublishCalls: len(d.runtime.publishInitCalls),
+		RuntimeStartReportWrites:   d.runtimeStartReportWrites,
+		RecoverySteps:              append([]string(nil), (*d.recoverySteps)...),
 	}
 	if closeCallCount := len(d.runtime.closeCalls); closeCallCount > 0 {
 		metrics.LastClosePreservedCanonicalState = d.runtime.closeCalls[closeCallCount-1].PreserveCanonicalState
@@ -1406,6 +1447,7 @@ func (d *legacyHostConformanceDriver) recordSubmittedTurn(workspaceID, sessionID
 type legacyHostConformanceSessionInitializer struct {
 	canonicalStore *workspacedata.SQLiteStore
 	sessions       *fakeSessionReader
+	fail           bool
 }
 
 func (i legacyHostConformanceSessionInitializer) InitializeRuntimeSession(
@@ -1413,6 +1455,17 @@ func (i legacyHostConformanceSessionInitializer) InitializeRuntimeSession(
 	session ProviderRuntimeSession,
 	railPlacement *agenthost.RailPlacement,
 ) (PersistedSession, error) {
+	if i.fail {
+		return PersistedSession{}, errors.New("injected canonical session initialization failure")
+	}
+	if railPlacement != nil {
+		if existing, found := i.sessions.sessions[session.WorkspaceID+":"+session.ID]; found &&
+			(strings.TrimSpace(existing.RailSectionKind) != strings.TrimSpace(string(railPlacement.Kind)) ||
+				strings.TrimSpace(existing.RailProjectPath) != strings.TrimSpace(railPlacement.ProjectPath) ||
+				strings.TrimSpace(existing.RailSectionKey) != strings.TrimSpace(railPlacement.SectionKey)) {
+			return PersistedSession{}, agenthost.ErrRailPlacementConflict
+		}
+	}
 	persisted, err := (fakeSessionInitializer{}).InitializeRuntimeSession(ctx, session, railPlacement)
 	if err != nil {
 		return PersistedSession{}, err

--- a/services/tuttid/service/agent/host_test_adapters_test.go
+++ b/services/tuttid/service/agent/host_test_adapters_test.go
@@ -274,12 +274,19 @@ func (a serviceHostRuntime) RuntimeSessionLive(workspaceID, agentSessionID strin
 	return found
 }
 
-func (a serviceHostRuntime) Start(ctx context.Context, input RuntimeStartInput) (ProviderRuntimeSession, error) {
-	session, err := a.service.controller().Start(ctx, input)
-	session.Provisional = input.Provisional
+func (a serviceHostRuntime) Start(ctx context.Context, input RuntimeStartInput) (RuntimeStartResult, error) {
+	result, err := a.service.controller().Start(ctx, input)
+	result.Session.Provisional = input.Provisional
 	if err != nil {
 		a.service.invalidateProviderAvailability(input.Provider)
 	}
+	return result, normalizeRuntimeError(err)
+}
+func (a serviceHostRuntime) PublishSessionInitialization(
+	ctx context.Context,
+	input RuntimeSessionInitializationPublishInput,
+) (ProviderRuntimeSession, error) {
+	session, err := a.service.controller().PublishSessionInitialization(ctx, input)
 	return session, normalizeRuntimeError(err)
 }
 func (a serviceHostRuntime) Resume(ctx context.Context, input RuntimeResumeInput) (ProviderRuntimeSession, error) {

--- a/services/tuttid/service/agent/service_create_test.go
+++ b/services/tuttid/service/agent/service_create_test.go
@@ -684,6 +684,7 @@ func TestServiceCreateReportsNodeResults(t *testing.T) {
 		"runtime_prepared",
 		"runtime_started",
 		"session_persisted",
+		"session_published",
 		"prompt_validated",
 		"prompt_prepared",
 		"runtime_exec",

--- a/services/tuttid/service/agent/service_host_create_rollback_test.go
+++ b/services/tuttid/service/agent/service_host_create_rollback_test.go
@@ -284,7 +284,11 @@ func TestHostCreateWithSuccessfulTypedGoalPreservesSessionWhenResponseReadFails(
 	projection := NewActivityProjection(store)
 	goalStore := &recordingGoalStateStore{}
 	service := newTestService(runtime)
-	service.SessionReader = &failAfterSessionReads{delegate: projection, allowedReads: 2}
+	// Canonical initialization now performs one durable preflight read while
+	// holding the Host session lock. Allow that additional internal read so this
+	// test still fails at the response projection boundary after GoalControl has
+	// durably succeeded.
+	service.SessionReader = &failAfterSessionReads{delegate: projection, allowedReads: 3}
 	service.SessionInitializer = projection
 	service.GoalStateStore = goalStore
 

--- a/services/tuttid/service/agent/service_test_runtime_test.go
+++ b/services/tuttid/service/agent/service_test_runtime_test.go
@@ -57,6 +57,9 @@ type fakeRuntime struct {
 	startErr                error
 	startCalls              []RuntimeStartInput
 	startHook               func(RuntimeStartInput, ProviderRuntimeSession) ProviderRuntimeSession
+	publishInitCalls        []RuntimeSessionInitializationPublishInput
+	publishInitHook         func(RuntimeSessionInitializationPublishInput, ProviderRuntimeSession) error
+	pendingInits            map[string]bool
 	updateSettingsCalls     []RuntimeUpdateSettingsInput
 	closeHook               func(RuntimeCloseInput)
 	validateErr             error
@@ -460,7 +463,8 @@ func (f fakeMessageReader) ListSessionMessages(
 
 func newFakeRuntime() *fakeRuntime {
 	return &fakeRuntime{
-		sessions: make(map[string]ProviderRuntimeSession),
+		sessions:     make(map[string]ProviderRuntimeSession),
+		pendingInits: make(map[string]bool),
 	}
 }
 
@@ -538,7 +542,9 @@ func (f *fakeRuntime) Close(_ context.Context, input RuntimeCloseInput) error {
 	f.closeCalls = append(f.closeCalls, input)
 	err := f.closeErr
 	if err == nil {
-		delete(f.sessions, input.WorkspaceID+":"+input.AgentSessionID)
+		key := input.WorkspaceID + ":" + input.AgentSessionID
+		delete(f.sessions, key)
+		delete(f.pendingInits, key)
 	}
 	// Hooks observe completion, so publish them only after the fake's state is
 	// fully updated. Tests use this callback as the synchronization boundary.
@@ -1109,10 +1115,10 @@ func (f fakeSessionReader) PurgeDeletedSessions(_ context.Context, input agentac
 	return result, nil
 }
 
-func (f *fakeRuntime) Start(_ context.Context, input RuntimeStartInput) (ProviderRuntimeSession, error) {
+func (f *fakeRuntime) Start(_ context.Context, input RuntimeStartInput) (RuntimeStartResult, error) {
 	f.startCalls = append(f.startCalls, input)
 	if f.startErr != nil {
-		return ProviderRuntimeSession{}, f.startErr
+		return RuntimeStartResult{}, f.startErr
 	}
 	f.nextID++
 	now := time.Now().UnixMilli()
@@ -1121,7 +1127,7 @@ func (f *fakeRuntime) Start(_ context.Context, input RuntimeStartInput) (Provide
 		id = "session-" + string(rune('0'+f.nextID))
 	}
 	if existing, ok := f.sessions[input.WorkspaceID+":"+id]; ok {
-		return existing, nil
+		return RuntimeStartResult{Session: existing, Created: false}, nil
 	}
 	session := ProviderRuntimeSession{
 		ID:            id,
@@ -1149,6 +1155,31 @@ func (f *fakeRuntime) Start(_ context.Context, input RuntimeStartInput) (Provide
 		session = f.startHook(input, session)
 	}
 	f.sessions[input.WorkspaceID+":"+session.ID] = session
+	if input.CanonicalInitPending {
+		if f.pendingInits == nil {
+			f.pendingInits = make(map[string]bool)
+		}
+		f.pendingInits[input.WorkspaceID+":"+session.ID] = true
+	}
+	return RuntimeStartResult{Session: session, Created: true}, nil
+}
+
+func (f *fakeRuntime) PublishSessionInitialization(
+	_ context.Context,
+	input RuntimeSessionInitializationPublishInput,
+) (ProviderRuntimeSession, error) {
+	f.publishInitCalls = append(f.publishInitCalls, input)
+	key := input.WorkspaceID + ":" + input.AgentSessionID
+	session, found := f.sessions[key]
+	if !found {
+		return ProviderRuntimeSession{}, ErrSessionNotFound
+	}
+	if f.publishInitHook != nil {
+		if err := f.publishInitHook(input, session); err != nil {
+			return ProviderRuntimeSession{}, err
+		}
+	}
+	delete(f.pendingInits, key)
 	return session, nil
 }
 

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -157,12 +157,13 @@ type RuntimeController interface {
 	// cannot make that guarantee, so the service treats guidance errors as
 	// delivery-unknown. Accepted=true is not a durable provenance receipt.
 	Exec(context.Context, RuntimeExecInput) (RuntimeExecResult, error)
+	PublishSessionInitialization(context.Context, RuntimeSessionInitializationPublishInput) (ProviderRuntimeSession, error)
 	Resume(context.Context, RuntimeResumeInput) (ProviderRuntimeSession, error)
 	Session(workspaceID string, agentSessionID string) (ProviderRuntimeSession, bool)
 	SetTitle(context.Context, RuntimeSetTitleInput) (ProviderRuntimeSession, error)
 	SetVisible(context.Context, RuntimeSetVisibleInput) (ProviderRuntimeSession, error)
 	Sessions(workspaceID string) []ProviderRuntimeSession
-	Start(context.Context, RuntimeStartInput) (ProviderRuntimeSession, error)
+	Start(context.Context, RuntimeStartInput) (RuntimeStartResult, error)
 	SubmitInteractive(context.Context, RuntimeSubmitInteractiveInput) (RuntimeSubmitInteractiveResult, error)
 	InteractiveDisposition(workspaceID string, rootAgentSessionID string, agentSessionID string, turnID string, requestID string) RuntimeInteractiveDisposition
 	Subscribe(workspaceID string, agentSessionID string) (<-chan RuntimeStreamEvent, func(), bool)
@@ -562,6 +563,8 @@ type SessionTitleUpdater interface {
 // Interaction entities.
 type ProviderRuntimeSession = agenthost.ProviderRuntimeSession
 type RuntimeStartInput = agenthost.RuntimeStartInput
+type RuntimeStartResult = agenthost.RuntimeStartResult
+type RuntimeSessionInitializationPublishInput = agenthost.RuntimeSessionInitializationPublishInput
 type RuntimeResumeInput = agenthost.RuntimeResumeInput
 type RuntimeExecInput = agenthost.RuntimeExecInput
 type RuntimeExecResult = agenthost.RuntimeExecResult


### PR DESCRIPTION
## Summary

- add a Host-owned publication barrier so runtime activity cannot create the canonical session before immutable rail placement is durable
- drain runtime events, config updates, and command snapshots in order before releasing the session, including callbacks arriving during release
- track runtime creation ownership so failed or conflicting retries never close an existing live runtime
- make lifecycle-lock cleanup and the Claude SDK send gate honor context deadlines
- add Host/runtime/conformance coverage for the first-writer race, failed initialization, reused runtimes, event draining, and bounded close

This fixes the `rail_placement_conflict` race where a runtime activity report could become the first canonical-session writer ahead of `CreateSession` with an explicit project rail.

## Verification

- `pnpm check:changed` — passed 13 lanes
- `cd packages/agent/daemon && go test ./hostadapter/... ./runtime/...`
- `golangci-lint` for `packages/agent/daemon/{hostadapter,runtime}` — 0 issues
- targeted Host initialization, ownership, cancellation, and service response-projection tests
- `git diff --check`

## Fallback Three Questions

- Source: provider callbacks can arrive while canonical initialization is in flight, and cleanup can encounter a busy provider lifecycle/send gate.
- Why can it not be fixed at that source? The canonical first-writer race is fixed at Host/runtime ownership; bounded cleanup still needs a deadline because external provider processes cannot provide transactional cancellation guarantees.
- Removal condition: the cleanup bounds can be removed once every runtime and process connection guarantees context-bounded close without an external guard.

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
