### PR TITLE
fix(workbench): contain overflowing custom headers

### DIFF
--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -107,6 +107,7 @@ React rendering, Workbench state, external stores, input composition, and UI per
 - [Renderer component repeatedly re-renders without visible changes](./workbench-renderer.md#renderer-component-repeatedly-re-renders-without-visible-changes)
 - [Renderer services initialize twice and consume one event twice](./workbench-renderer.md#renderer-services-initialize-twice-and-consume-one-event-twice)
 - [Inline custom-header menu is clipped to the Workbench title bar](./workbench-renderer.md#inline-custom-header-menu-is-clipped-to-the-workbench-title-bar)
+- [Overflowing custom header widens the Workbench body](./workbench-renderer.md#overflowing-custom-header-widens-the-workbench-body)
 - [Dialog action reacts to Enter but ignores pointer clicks](./workbench-renderer.md#dialog-action-reacts-to-enter-but-ignores-pointer-clicks)
 - [Daemon validation error appears as untranslated developer text](./workbench-renderer.md#daemon-validation-error-appears-as-untranslated-developer-text)
 - [Mask-backed icon renders as a solid color block](./workbench-renderer.md#mask-backed-icon-renders-as-a-solid-color-block)

--- a/docs/conventions/troubleshooting/workbench-renderer.md
+++ b/docs/conventions/troubleshooting/workbench-renderer.md
@@ -93,6 +93,40 @@
   [workbench.css](../../../packages/workbench/surface/src/styles/workbench.css)
   [browser-node-package.md](../../architecture/browser-node-package.md)
 
+### Overflowing custom header widens the Workbench body
+
+- Symptom:
+  A resizable Workbench node remains visually inside its frame, but after a
+  custom header gains enough non-wrapping content, its body and embedded
+  webview retain a much wider layout viewport. Narrowing the node clips the
+  page instead of triggering its responsive layout.
+- Quick checks:
+  Compare the bounding widths of `.workbench-window`,
+  `.workbench-window__header--custom`, and `.workbench-window__body`, then
+  inspect the computed Grid columns. If the outer window keeps its saved width
+  while the implicit column, header, and body all resolve wider, trace the
+  header's min-content contribution rather than changing the webview width.
+- Root cause:
+  A Grid that defines only rows leaves its single implicit column sized as
+  `auto`. A custom header with `overflow: visible` retains a content-based
+  automatic minimum, so non-wrapping tabs or controls can enlarge that column.
+  The body shares the enlarged track, and a `width: 100%` webview then receives
+  the wrong layout viewport even though the outer window clips the result.
+- Fix:
+  Define the Workbench window's single column as `minmax(0, 1fr)`. Keep the
+  header's intentional visible overflow for inline overlays; the explicit
+  zero-minimum track prevents horizontal min-content from resizing the shared
+  body column. Adding `min-width: 0` only inside the custom header does not
+  change the Grid item's automatic minimum contribution.
+- Validation:
+  Open enough fixed-minimum-width tabs to overflow a Browser node, then resize
+  the node narrower and wider. Confirm the tab list scrolls, the header and
+  body widths remain equal to the Workbench frame, and the guest page responds
+  to each available width instead of being clipped at its previous viewport.
+- References:
+  [workbench.css](../../../packages/workbench/surface/src/styles/workbench.css)
+  [BrowserNodeChrome.tsx](../../../packages/browser/workbench-node/src/react/BrowserNodeChrome.tsx)
+
 ### Standalone Agent dev window stays black during cold startup
 
 - Symptom:

--- a/packages/workbench/surface/src/styles/workbench.css
+++ b/packages/workbench/surface/src/styles/workbench.css
@@ -184,6 +184,7 @@
   display: grid;
   width: 100%;
   height: 100%;
+  grid-template-columns: minmax(0, 1fr);
   grid-template-rows: var(--workbench-header-height) minmax(0, 1fr);
   overflow: hidden;
   border: 1px solid var(--workbench-window-border);


### PR DESCRIPTION
## 变更概述

- 为 Workbench 窗口显式声明零最小宽度的单列 Grid，避免自定义头部标签的 min-content 宽度撑大内容区和内嵌 WebView
- 保留自定义头部现有的可见溢出能力，同时让 Browser 节点在标签溢出后仍能随节点宽度正常响应
- 补充对应的 Workbench Renderer 排障条目和索引

## 验证

- `pnpm check:changed`：6 个检查通道通过
- pre-commit：格式化、CSS 性能策略、Electron/Renderer/UI 边界等检查通过
- pre-push `pnpm check:changed -- --push-ready`：7 个检查通道通过
- `make dev-gui`：在真实 Electron 环境创建 10 个 Browser 标签并反复缩放节点；WebView 宽度从 1082 缩小到 702 后恢复到 1083，`innerWidth`、`clientWidth` 与 `bodyWidth` 始终一致，标签横向滚动和页面响应式布局正常

## 检查清单

- [x] 本变更不涉及 Agent 生命周期语义
- [x] 变更聚焦于单一问题
- [x] 已同步更新行为相关文档
- [x] 未修改 README/CONTRIBUTING 英文源文件，无需同步多语言版本
- [x] 已运行该变更范围内最低且有意义的本地检查
- [x] 提交已包含 DCO sign-off