### PR TITLE
fix(agent-activity): absorb host-fenced turn settlements

### DIFF
--- a/.changeset/agent-activity-host-fenced-settlement.md
+++ b/.changeset/agent-activity-host-fenced-settlement.md
@@ -1,0 +1,7 @@
+---
+"@tutti-os/agent-activity-core": patch
+---
+
+Allow hosts that already fence transport identity and ordering to mark a
+same-Turn settlement as authoritative across source clock skew, while keeping
+the canonical timestamp guard for ordinary realtime and generic projections.

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -1480,6 +1480,11 @@ the normalized event is applied:
   projection that updates the Turn and the cached Session's `activeTurnId`
   together; a settled Turn may clear only its own active reference, so delayed
   events cannot clear a newer Turn
+- after the host has fenced transport identity and ordering, it may explicitly
+  mark settlement of that same immutable Turn as absorbing when the cached
+  nonterminal projection belongs to another source version domain; unmarked
+  realtime projections and generic Turn and Session upserts retain their
+  canonical version guards
 - use canonical Turn versions as the Engine-local fence against stale Session
   snapshots; event-envelope `occurredAtUnixMs` is transport metadata and must
   not advance canonical Session timestamps or participate in entity ordering

--- a/packages/agent/activity-core/src/engine/sessionEntities.reducer.ts
+++ b/packages/agent/activity-core/src/engine/sessionEntities.reducer.ts
@@ -277,6 +277,15 @@ export function upsertCanonicalTurn(
   const key = canonicalTurnKey(turn.agentSessionId, turn.turnId);
   const current = state.turnsById[key];
   if (current && !shouldUseIncomingTurn(current, turn)) return state;
+  return writeCanonicalTurn(state, turn, current);
+}
+
+function writeCanonicalTurn(
+  state: SessionLifecycleState,
+  turn: AgentActivityTurn,
+  current: AgentActivityTurn | undefined
+): SessionLifecycleState {
+  const key = canonicalTurnKey(turn.agentSessionId, turn.turnId);
   const nextTurn = current ? preserveTurnProvenance(current, turn) : turn;
   if (current && areJsonLikeValuesEqual(current, nextTurn)) return state;
   return {
@@ -300,11 +309,18 @@ export function upsertCanonicalTurnProjection(
 
   const key = canonicalTurnKey(agentSessionId, turnId);
   const currentTurn = state.turnsById[key];
-  if (currentTurn && !shouldUseIncomingTurn(currentTurn, input.turn)) {
+  if (
+    currentTurn &&
+    !shouldUseIncomingTurnProjection(
+      currentTurn,
+      input.turn,
+      input.hostFencedSameTurnSettlement === true
+    )
+  ) {
     return state;
   }
 
-  const withTurn = upsertCanonicalTurn(state, input.turn);
+  const withTurn = writeCanonicalTurn(state, input.turn, currentTurn);
   const session = withTurn.sessionsById[agentSessionId];
   if (!session) return withTurn;
 
@@ -420,8 +436,25 @@ function shouldUseIncomingTurn(
   return true;
 }
 
+function shouldUseIncomingTurnProjection(
+  current: AgentActivityTurn,
+  incoming: AgentActivityTurn,
+  hostFencedSameTurnSettlement: boolean
+): boolean {
+  if (
+    hostFencedSameTurnSettlement &&
+    current.phase !== "settled" &&
+    incoming.phase === "settled" &&
+    allowedTurnTransition(current.phase, incoming.phase)
+  ) {
+    return true;
+  }
+  return shouldUseIncomingTurn(current, incoming);
+}
+
 interface CanonicalTurnProjection {
   activeTurnId: string | null;
+  hostFencedSameTurnSettlement?: true;
   turn: AgentActivityTurn;
 }
 

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.reducer.test.ts
@@ -23,6 +23,7 @@ import {
   validateCancelResult,
   validateSendInputResult
 } from "./commandResult.validation.ts";
+import { deriveCanonicalSubmitAvailability } from "./sessionLifecycle.availability.ts";
 
 test("snapshot decomposes protocol v2 session and turn entities", () => {
   const result = reduce(createInitialSessionLifecycleState(), {
@@ -1873,6 +1874,135 @@ test("realtime Turn projection atomically clears its owned Session reference", (
   }).state;
   assert.equal(state.sessionsById["session-1"]?.title, "Reconciled");
   assert.equal(state.sessionsById["session-1"]?.updatedAtUnixMs, 3);
+});
+
+test("host-fenced same-Turn settlement survives cross-device clock skew", () => {
+  const running = activeTurn(200);
+  let state = reduce(createInitialSessionLifecycleState(), {
+    sessions: [session(running, 300)],
+    type: "session/snapshotReceived"
+  }).state;
+
+  state = reduce(state, {
+    activeTurnId: null,
+    hostFencedSameTurnSettlement: true,
+    turn: {
+      ...running,
+      outcome: "completed",
+      phase: "settled",
+      settledAtUnixMs: 190,
+      updatedAtUnixMs: 190
+    },
+    type: "turn/projectionReceived",
+    workspaceId: "workspace-1"
+  }).state;
+
+  assert.equal(state.sessionsById["session-1"]?.activeTurnId, null);
+  assert.equal(state.sessionsById["session-1"]?.updatedAtUnixMs, 300);
+  assert.deepEqual(state.turnsById[canonicalTurnKey("session-1", "turn-1")], {
+    ...running,
+    outcome: "completed",
+    phase: "settled",
+    settledAtUnixMs: 190,
+    updatedAtUnixMs: 190
+  });
+
+  state = reduce(state, {
+    session: session(running, 300),
+    type: "session/upserted"
+  }).state;
+  assert.equal(state.sessionsById["session-1"]?.activeTurnId, null);
+});
+
+test("host-fenced settlement cannot clear a different active Turn", () => {
+  const turnA = { ...activeTurn(200), turnId: "turn-a" };
+  const turnB = { ...activeTurn(300), turnId: "turn-b" };
+  let state = reduce(createInitialSessionLifecycleState(), {
+    sessions: [session(turnB, 300)],
+    type: "session/snapshotReceived"
+  }).state;
+  state = reduce(state, {
+    live: true,
+    turn: turnA,
+    type: "turn/upserted"
+  }).state;
+
+  state = reduce(state, {
+    activeTurnId: null,
+    hostFencedSameTurnSettlement: true,
+    turn: {
+      ...turnA,
+      outcome: "completed",
+      phase: "settled",
+      settledAtUnixMs: 190,
+      updatedAtUnixMs: 190
+    },
+    type: "turn/projectionReceived",
+    workspaceId: "workspace-1"
+  }).state;
+
+  assert.equal(
+    state.turnsById[canonicalTurnKey("session-1", "turn-a")]?.phase,
+    "settled"
+  );
+  assert.equal(state.sessionsById["session-1"]?.activeTurnId, "turn-b");
+  assert.deepEqual(deriveCanonicalSubmitAvailability(state, "session-1"), {
+    state: "blocked",
+    reason: "active_turn"
+  });
+});
+
+test("unmarked Turn projection still rejects an older settlement", () => {
+  const running = activeTurn(200);
+  let state = reduce(createInitialSessionLifecycleState(), {
+    sessions: [session(running, 300)],
+    type: "session/snapshotReceived"
+  }).state;
+
+  state = reduce(state, {
+    activeTurnId: null,
+    turn: {
+      ...running,
+      outcome: "completed",
+      phase: "settled",
+      settledAtUnixMs: 190,
+      updatedAtUnixMs: 190
+    },
+    type: "turn/projectionReceived",
+    workspaceId: "workspace-1"
+  }).state;
+
+  assert.equal(state.sessionsById["session-1"]?.activeTurnId, "turn-1");
+  assert.equal(
+    state.turnsById[canonicalTurnKey("session-1", "turn-1")]?.phase,
+    "running"
+  );
+});
+
+test("generic Turn upsert still rejects an older settlement", () => {
+  const running = activeTurn(200);
+  let state = reduce(createInitialSessionLifecycleState(), {
+    sessions: [session(running, 300)],
+    type: "session/snapshotReceived"
+  }).state;
+
+  state = reduce(state, {
+    live: true,
+    turn: {
+      ...running,
+      outcome: "completed",
+      phase: "settled",
+      settledAtUnixMs: 190,
+      updatedAtUnixMs: 190
+    },
+    type: "turn/upserted"
+  }).state;
+
+  assert.equal(state.sessionsById["session-1"]?.activeTurnId, "turn-1");
+  assert.equal(
+    state.turnsById[canonicalTurnKey("session-1", "turn-1")]?.phase,
+    "running"
+  );
 });
 
 test("cached Turn projection fences a stale Session loaded afterward", () => {

--- a/packages/agent/activity-core/src/engine/sessionLifecycle.types.ts
+++ b/packages/agent/activity-core/src/engine/sessionLifecycle.types.ts
@@ -168,6 +168,12 @@ export interface TurnUpsertedIntent {
 export interface TurnProjectionReceivedIntent {
   type: "turn/projectionReceived";
   activeTurnId: string | null;
+  /**
+   * The host has already fenced transport identity and ordering, so settlement
+   * of this immutable Turn may absorb a temporary projection from another
+   * version domain even when its wall-clock timestamp is lower.
+   */
+  hostFencedSameTurnSettlement?: true;
   turn: AgentActivityTurn;
   workspaceId: string;
 }

--- a/packages/agent/activity-core/src/index.ts
+++ b/packages/agent/activity-core/src/index.ts
@@ -51,6 +51,7 @@ export {
 } from "./usage.ts";
 export {
   createAgentActivityWorkspaceEventCoordinator,
+  type AgentActivityWorkspaceEventIngestOptions,
   type AgentActivityWorkspaceEventInput
 } from "./workspaceEventCoordinator.ts";
 export {

--- a/packages/agent/activity-core/src/workspaceEventCoordinator.test.ts
+++ b/packages/agent/activity-core/src/workspaceEventCoordinator.test.ts
@@ -466,6 +466,35 @@ test("rejects a late Turn fact without leaking completion into attention", () =>
   harness.engine.dispose();
 });
 
+test("accepts host-fenced settlement across source version domains", () => {
+  const harness = createHarness();
+  const runningTurn = turn("running", 4);
+  harness.engine.dispatch({
+    session: session(runningTurn, 4),
+    type: "session/upserted"
+  });
+
+  const result = harness.coordinator.ingestEvent(
+    turnUpdateEvent("settled", 2, "turn-1", 100),
+    { hostFencedSameTurnSettlement: true }
+  );
+  const snapshot = harness.engine.getSnapshot();
+
+  assert.equal(result.accepted, true);
+  assert.equal(
+    snapshot.sessionLifecycle.turnsById[canonicalTurnKey("session-1", "turn-1")]
+      ?.phase,
+    "settled"
+  );
+  assert.equal(
+    snapshot.sessionLifecycle.sessionsById["session-1"]?.activeTurnId,
+    null
+  );
+
+  harness.coordinator.dispose();
+  harness.engine.dispose();
+});
+
 test("replays an accepted completion after live reconcile supplies identity", () => {
   const harness = createHarness();
   const settledTurn = turn("settled", 2);

--- a/packages/agent/activity-core/src/workspaceEventCoordinator.ts
+++ b/packages/agent/activity-core/src/workspaceEventCoordinator.ts
@@ -59,7 +59,8 @@ export interface AgentActivityWorkspaceEventCoordinator {
   }): void;
   dispose(): void;
   ingestEvent(
-    event: AgentActivityWorkspaceEventInput
+    event: AgentActivityWorkspaceEventInput,
+    options?: AgentActivityWorkspaceEventIngestOptions
   ): AgentActivityWorkspaceEventResult;
   isSessionDeleted(agentSessionId: string): boolean;
   project(canonical: AgentActivitySnapshot): AgentActivitySnapshot;
@@ -78,6 +79,15 @@ export interface AgentActivityWorkspaceEventCoordinator {
   ): void;
   removeSession(agentSessionId: string): boolean;
   subscribe(listener: () => void): () => void;
+}
+
+export interface AgentActivityWorkspaceEventIngestOptions {
+  /**
+   * Use only after the host has fenced transport identity and ordering. It
+   * makes settlement absorbing for the same immutable Turn across otherwise
+   * incomparable source version domains.
+   */
+  hostFencedSameTurnSettlement?: true;
 }
 
 export interface CreateAgentActivityWorkspaceEventCoordinatorInput {
@@ -257,7 +267,7 @@ export function createAgentActivityWorkspaceEventCoordinator({
       listeners.clear();
       snapshotCache = null;
     },
-    ingestEvent(event) {
+    ingestEvent(event, options) {
       const agentSessionId = event.agentSessionId.trim();
       const eventType = event.eventType;
       if (
@@ -390,6 +400,9 @@ export function createAgentActivityWorkspaceEventCoordinator({
         }
         engine.dispatch({
           ...projection,
+          ...(options?.hostFencedSameTurnSettlement
+            ? { hostFencedSameTurnSettlement: true as const }
+            : {}),
           type: "turn/projectionReceived",
           workspaceId: normalizedWorkspaceId
         });


### PR DESCRIPTION
## Summary

- 为 workspace event coordinator 增加显式的 `hostFencedSameTurnSettlement` ingest 语义；仅当 Host 已完成 transport identity/order fence 时，同一不可变 Turn 的 settled 投影可以跨源时钟偏差吸收临时非终态投影
- 保留未标记实时事件、generic Turn/Session upsert 的 canonical timestamp guard，避免普通晚到终态制造 completion 或错误解锁
- 继续要求 settled Turn 只能清除自身的 `activeTurnId`；Turn A 的终态不会清掉正在运行的 Turn B
- 更新 Agent activity 架构文档，并为 `@tutti-os/agent-activity-core` 增加 patch changeset

## Why

Shared Agent Caller 可能先从 coordination projection 得到 `running updatedAt=200`，随后从 Owner 收到已由 desktopd epoch/seq/generation fence 的 canonical `settled updatedAt=190`。这两个时间戳来自不同设备，不能作为 merge order；旧逻辑会丢弃 Owner 终态，使 composer 继续被 `active_turn` 阻塞。

本 PR 不改变 Turn 何时成为 terminal：该 canonical lifecycle 仍由 Agent Host/Owner 定义。这里修复的是 AgentGUI 对一个已经 canonical、且已由产品 Host 完成 transport fence 的终态事实如何原子合并。TSH 需要消费此投影 API，但不新增或复制 Host lifecycle 规则。

## Risks and boundaries

- 该能力为显式 opt-in；误用可能让旧终态跨过 timestamp guard，因此 API 文档要求调用方先完成 identity/order fence
- 普通 late Turn 测试保持原预期；未标记的旧终态仍被拒绝
- 新增边界测试确保 fenced Turn A settlement 只记录 A，不能清除活跃 Turn B 或解除其 submit blocker
- 非终态 `waiting`/`settling` 的跨设备时钟排序不在本次修复范围内
- 后续：此 patch 发布后，TSH 再升级统一 Tutti dependency cohort，并提交 shared-agent adapter PR

## Verification

- `corepack pnpm@10.11.0 --filter @tutti-os/agent-activity-core test` — 458 tests passed
- `corepack pnpm@10.11.0 check:changed` — 11 lanes passed
- pre-push `corepack pnpm@10.11.0 check:changed -- --push-ready` — 13 lanes passed
- 使用本地 package link 在 TSH 验证相关两个 spec 文件 — 71 tests passed
- TSH `pnpm check` passed

## Checklist

- [x] Canonical Agent lifecycle 未改变；这是 Host-fenced AgentGUI projection reconciliation，不需要新增 Host lifecycle scenario
- [x] 改动聚焦于同一 Turn 的权威终态投影
- [x] 已更新架构文档
- [x] 未修改 README/CONTRIBUTING，无多语言同步需求
- [x] 已运行变更面所需的最小检查和 push-ready 检查
- [x] commit 已包含 DCO sign-off
