### PR TITLE
fix(agent-gui): reopen Cursor slash palette after editing

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2012,11 +2012,19 @@ animation frame; ResizeObserver and MutationObserver keep layout roots current.
 Composer text transactions may publish the current draft, but the draft value
 must not drive synchronous pre-paint geometry reads or an urgent AgentGUI tree
 render. The rich-text editor DOM owns the urgent input transaction. The latest
-prompt ref updates synchronously for submit and attachment reconciliation,
-while palette and controlled-draft projections publish in a React transition.
-The editor recognizes stale controlled echoes from that transition so an older
+prompt ref and command-palette trigger revision update synchronously for submit,
+attachment reconciliation, and Slash/Skill palette visibility, while the
+controlled editor value and full draft publication remain in a React
+transition. Command-palette dismissal applies only to the current trigger
+revision: a later user edit, including deleting and retyping `/`, creates a new
+revision and may reopen the palette, while a programmatic command replacement
+dismisses the replacement revision. File-mention palette openness is a separate
+local channel and cannot dismiss or reopen the Slash/Skill palette. The editor
+projects trigger queries from text before the current caret, so invisible text
+remaining after the caret cannot suppress a newly typed Slash/Skill trigger.
+The editor recognizes stale controlled echoes from the transition so an older
 projection cannot overwrite newer local input; a value not emitted locally
-remains an authoritative external replacement.
+remains an authoritative external replacement and resets the palette revision.
 
 An existing-Session composer derives input history from that Session's
 canonical user-message projection and its turnless Goal-control audit entries;

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import type {
   AgentComposerDraft,
   AgentComposerDraftFile,
@@ -53,6 +53,11 @@ import {
   resolveAgentExternalPromptEntries
 } from "./model/agentExternalPromptEntries";
 import { useComposerInputHistory } from "./composer/useComposerInputHistory";
+import {
+  createComposerCommandPaletteState,
+  isComposerCommandPaletteDismissed,
+  reduceComposerCommandPaletteState
+} from "./composer/composerCommandPaletteState";
 
 export { formatSlashStatusTokenCount };
 
@@ -197,7 +202,17 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
       hadPrefill: agentComposerDraftHasContent(draftContent)
     });
   };
-  const [isPaletteOpen, setIsPaletteOpen] = useState(true);
+  const initialEditorDraftPrompt = goalDraftObjective ?? draftPrompt;
+  const [editorDraftPrompt, setEditorDraftPrompt] = useState(
+    initialEditorDraftPrompt
+  );
+  const [commandPaletteState, dispatchCommandPalette] = useReducer(
+    reduceComposerCommandPaletteState,
+    initialEditorDraftPrompt,
+    createComposerCommandPaletteState
+  );
+  const [isFileMentionPaletteOpen, setIsFileMentionPaletteOpen] =
+    useState(true);
   const [isReviewPickerOpen, setIsReviewPickerOpen] = useState(false);
   const submitGuidanceWithComposerModifiers: NonNullable<
     AgentComposerProps["onSubmitGuidance"]
@@ -222,9 +237,6 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     shouldResetMentionHighlightToFilter,
     setShouldResetMentionHighlightToFilter
   ] = useState(false);
-  const [paletteDraftPrompt, setPaletteDraftPrompt] = useState(
-    goalDraftObjective ?? draftPrompt
-  );
   const [fileMentionSuggestion, setFileMentionSuggestion] =
     useState<AgentFileMentionSuggestionState | null>(null);
   const selectedProjectPath =
@@ -272,6 +284,7 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
   const previousSlashStatusAgentSessionIdRef = useRef<string | null>(
     slashStatusAgentSessionId
   );
+  const previousDraftScopeKeyRef = useRef(draftScopeKey);
   const previousSelectedProjectPathRef = useRef(selectedProjectPath);
   const composerRef = useRef<HTMLFormElement | null>(null);
   const inputShellRef = useRef<HTMLDivElement | null>(null);
@@ -318,7 +331,7 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     provider,
     isGoalModeActive,
     goalSupported: canGoalControl,
-    paletteDraftPrompt,
+    paletteDraftPrompt: commandPaletteState.prompt,
     availableCommands,
     availableSkills,
     hasCompactableContext,
@@ -340,11 +353,11 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     promptBeforeSelection
   } = paletteCatalog;
   const showFileMentionPalette =
-    !disabled && isPaletteOpen && fileMentionSuggestion !== null;
+    !disabled && isFileMentionPaletteOpen && fileMentionSuggestion !== null;
   const showSlashPalette =
     !showFileMentionPalette &&
     !disabled &&
-    isPaletteOpen &&
+    !isComposerCommandPaletteDismissed(commandPaletteState) &&
     ((slashQuery !== null &&
       (slashPaletteEntries.length > 0 ||
         composerSettings.isCapabilityOptionsLoading === true)) ||
@@ -415,8 +428,17 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     draftFilesRef.current = agentComposerDraftFiles(draftContent);
     draftLargeTextsRef.current = agentComposerDraftLargeTexts(draftContent);
     const isExternalDraftReplacement = draftPromptRef.current !== draftPrompt;
+    const didDraftScopeChange =
+      previousDraftScopeKeyRef.current !== draftScopeKey;
+    previousDraftScopeKeyRef.current = draftScopeKey;
     draftPromptRef.current = draftPrompt;
-    setPaletteDraftPrompt(goalDraftObjective ?? draftPrompt);
+    setEditorDraftPrompt(goalDraftObjective ?? draftPrompt);
+    if (isExternalDraftReplacement || didDraftScopeChange) {
+      dispatchCommandPalette({
+        type: "reset",
+        prompt: goalDraftObjective ?? draftPrompt
+      });
+    }
     settlePendingInputHistory();
     if (isExternalDraftReplacement && draftPrompt) {
       window.requestAnimationFrame(() => {
@@ -430,6 +452,7 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
   }, [
     draftContent,
     draftPrompt,
+    draftScopeKey,
     goalDraftObjective,
     settlePendingInputHistory
   ]);
@@ -490,8 +513,8 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     draftImagesRef,
     draftFilesRef,
     draftLargeTextsRef,
-    setPaletteDraftPrompt,
-    setIsPaletteOpen,
+    setEditorDraftPrompt,
+    dispatchCommandPalette,
     setIsReviewPickerOpen,
     setIsSlashStatusPanelOpen,
     setHighlightedIndex
@@ -512,8 +535,9 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     mentionControllerRef,
     editorHandleRef,
     draftPromptRef,
-    setPaletteDraftPrompt,
-    setIsPaletteOpen,
+    setEditorDraftPrompt,
+    dispatchCommandPalette,
+    setIsFileMentionPaletteOpen,
     onDraftContentChange,
     showFileMentionPalette,
     mentionHighlightedKey,
@@ -554,8 +578,8 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     draftImagesRef,
     draftFilesRef,
     draftLargeTextsRef,
-    setPaletteDraftPrompt,
-    setIsPaletteOpen,
+    setEditorDraftPrompt,
+    dispatchCommandPalette,
     clearActiveFileMentionTrigger,
     onDraftContentChange,
     onPromptImagesUnsupported,
@@ -719,7 +743,7 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
       externalPromptEntriesSupported={externalPromptEntriesSupported}
       addExternalPromptEntries={addExternalPromptEntries}
       onDismissProjectMenuAutoFocus={restoreComposerCaretAfterProjectMenu}
-      paletteDraftPrompt={paletteDraftPrompt}
+      editorDraftPrompt={editorDraftPrompt}
       showFileMentionPalette={showFileMentionPalette}
       showSlashPalette={showSlashPalette}
       activeHighlight={activeHighlight}
@@ -731,7 +755,7 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
       isReviewPickerOpen={isReviewPickerOpen}
       isSelectedProjectMissing={isSelectedProjectMissing}
       setIsSelectedProjectMissing={setIsSelectedProjectMissing}
-      setIsPaletteOpen={setIsPaletteOpen}
+      setIsFileMentionPaletteOpen={setIsFileMentionPaletteOpen}
       setHighlightedIndex={setHighlightedIndex}
       isGoalModeActive={isGoalModeActive}
       isPlanModeActive={composerSettings.draftSettings.planMode}

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerView.tsx
@@ -87,7 +87,7 @@ interface Props {
   externalPromptEntriesSupported: boolean;
   addExternalPromptEntries: (files: readonly File[]) => void;
   onDismissProjectMenuAutoFocus?: (event: Event) => void;
-  paletteDraftPrompt: string;
+  editorDraftPrompt: string;
   showFileMentionPalette: boolean;
   showSlashPalette: boolean;
   activeHighlight: number;
@@ -99,7 +99,7 @@ interface Props {
   isReviewPickerOpen: boolean;
   isSelectedProjectMissing: boolean;
   setIsSelectedProjectMissing: (value: boolean) => void;
-  setIsPaletteOpen: Dispatch<SetStateAction<boolean>>;
+  setIsFileMentionPaletteOpen: Dispatch<SetStateAction<boolean>>;
   setHighlightedIndex: Dispatch<SetStateAction<number>>;
   isGoalModeActive: boolean;
   isPlanModeActive: boolean;
@@ -419,7 +419,7 @@ export function AgentComposerView(input: Props): React.JSX.Element {
         >
           <Popover
             open={input.showFileMentionPalette}
-            onOpenChange={input.setIsPaletteOpen}
+            onOpenChange={input.setIsFileMentionPaletteOpen}
             modal={false}
           >
             <PopoverAnchor asChild>
@@ -453,7 +453,7 @@ export function AgentComposerView(input: Props): React.JSX.Element {
                 >
                   <AgentRichTextEditor
                     ref={input.editorHandleRef}
-                    value={input.paletteDraftPrompt}
+                    value={input.editorDraftPrompt}
                     contentScopeKey={input.props.draftScopeKey}
                     placeholder={effectivePlaceholder}
                     disabled={inputDisabled}

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/composerCommandPaletteState.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/composerCommandPaletteState.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  createComposerCommandPaletteState,
+  isComposerCommandPaletteDismissed,
+  reduceComposerCommandPaletteState
+} from "./composerCommandPaletteState";
+
+describe("composerCommandPaletteState", () => {
+  it("reopens the command palette after slash is deleted and typed again", () => {
+    let state = createComposerCommandPaletteState("");
+
+    state = reduceComposerCommandPaletteState(state, {
+      type: "draftChanged",
+      prompt: "/"
+    });
+    expect(isComposerCommandPaletteDismissed(state)).toBe(false);
+
+    state = reduceComposerCommandPaletteState(state, {
+      type: "dismissCurrent"
+    });
+    expect(isComposerCommandPaletteDismissed(state)).toBe(true);
+
+    state = reduceComposerCommandPaletteState(state, {
+      type: "draftChanged",
+      prompt: ""
+    });
+    state = reduceComposerCommandPaletteState(state, {
+      type: "draftChanged",
+      prompt: "/"
+    });
+
+    expect(state.prompt).toBe("/");
+    expect(isComposerCommandPaletteDismissed(state)).toBe(false);
+  });
+
+  it("keeps a programmatic command replacement dismissed", () => {
+    const state = reduceComposerCommandPaletteState(
+      createComposerCommandPaletteState("/browser"),
+      {
+        type: "replaceAndDismiss",
+        prompt: ""
+      }
+    );
+
+    expect(state.prompt).toBe("");
+    expect(isComposerCommandPaletteDismissed(state)).toBe(true);
+  });
+
+  it("does not carry a dismissal into an externally restored draft", () => {
+    const dismissed = reduceComposerCommandPaletteState(
+      createComposerCommandPaletteState("/"),
+      { type: "dismissCurrent" }
+    );
+    const restored = reduceComposerCommandPaletteState(dismissed, {
+      type: "reset",
+      prompt: "/"
+    });
+
+    expect(restored.prompt).toBe("/");
+    expect(isComposerCommandPaletteDismissed(restored)).toBe(false);
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/composerCommandPaletteState.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/composerCommandPaletteState.ts
@@ -1,0 +1,53 @@
+export interface ComposerCommandPaletteState {
+  dismissedRevision: number | null;
+  prompt: string;
+  revision: number;
+}
+
+export type ComposerCommandPaletteAction =
+  | { type: "dismissCurrent" }
+  | { type: "draftChanged"; prompt: string }
+  | { type: "replaceAndDismiss"; prompt: string }
+  | { type: "reset"; prompt: string };
+
+export function createComposerCommandPaletteState(
+  prompt: string
+): ComposerCommandPaletteState {
+  return {
+    dismissedRevision: null,
+    prompt,
+    revision: 0
+  };
+}
+
+export function reduceComposerCommandPaletteState(
+  state: ComposerCommandPaletteState,
+  action: ComposerCommandPaletteAction
+): ComposerCommandPaletteState {
+  if (action.type === "dismissCurrent") {
+    if (state.dismissedRevision === state.revision) {
+      return state;
+    }
+    return { ...state, dismissedRevision: state.revision };
+  }
+
+  const revision = state.revision + 1;
+  if (action.type === "replaceAndDismiss") {
+    return {
+      dismissedRevision: revision,
+      prompt: action.prompt,
+      revision
+    };
+  }
+  return {
+    dismissedRevision: null,
+    prompt: action.prompt,
+    revision
+  };
+}
+
+export function isComposerCommandPaletteDismissed(
+  state: ComposerCommandPaletteState
+): boolean {
+  return state.dismissedRevision === state.revision;
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerDraftAttachments.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerDraftAttachments.spec.tsx
@@ -310,6 +310,26 @@ describe("useComposerDraftAttachments", () => {
     ]);
   });
 
+  it("publishes every editor revision to the command palette lifecycle", () => {
+    const onCommandPaletteDraftChange = vi.fn();
+    const input = createInput({
+      draft: buildAgentComposerDraft({ prompt: "" }),
+      onCommandPaletteDraftChange,
+      prepareExternalPromptFiles: vi.fn()
+    });
+    const rendered = renderHook(() => useComposerDraftAttachments(input));
+
+    act(() => rendered.result.current.handleDraftChange("/"));
+    act(() => rendered.result.current.handleDraftChange(""));
+    act(() => rendered.result.current.handleDraftChange("/"));
+
+    expect(onCommandPaletteDraftChange.mock.calls).toEqual([
+      ["/"],
+      [""],
+      ["/"]
+    ]);
+  });
+
   it("keeps picker files as workspace references", async () => {
     const reference = {
       kind: "file",
@@ -347,6 +367,7 @@ function createInput(input: {
     files: readonly WorkspaceFileReference[];
     mentionItems: [];
   }>;
+  onCommandPaletteDraftChange?: (prompt: string) => void;
   prepareExternalPromptFiles: AgentExternalPromptFilePreparer;
 }) {
   const draftByScopeKeyRef = { current: { home: input.draft } };
@@ -379,8 +400,12 @@ function createInput(input: {
     draftImagesRef: { current: [] },
     draftFilesRef: { current: [] },
     draftLargeTextsRef: { current: [] },
-    setPaletteDraftPrompt: vi.fn(),
-    setIsPaletteOpen: vi.fn(),
+    setEditorDraftPrompt: vi.fn(),
+    dispatchCommandPalette: vi.fn((action) => {
+      if (action.type === "draftChanged") {
+        input.onCommandPaletteDraftChange?.(action.prompt);
+      }
+    }),
     clearActiveFileMentionTrigger: vi.fn(),
     onDraftContentChange: input.onDraftContentChange ?? vi.fn(),
     onRequestWorkspaceReferences: input.onRequestWorkspaceReferences,

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerDraftAttachments.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerDraftAttachments.ts
@@ -56,6 +56,7 @@ import {
 } from "./composerDraftUtils";
 import { reportAgentComposerDiagnostic } from "./agentComposerDiagnostics";
 import type { AgentGUIComposerContentType } from "../engagement/agentGUIEngagement.types";
+import type { ComposerCommandPaletteAction } from "./composerCommandPaletteState";
 
 export interface WorkspaceReferencePickResult {
   files: readonly WorkspaceFileReference[];
@@ -86,8 +87,8 @@ interface UseComposerDraftAttachmentsInput {
   draftImagesRef: RefObject<AgentComposerDraftImage[]>;
   draftFilesRef: RefObject<AgentComposerDraftFile[]>;
   draftLargeTextsRef: RefObject<AgentComposerDraftLargeText[]>;
-  setPaletteDraftPrompt: Dispatch<SetStateAction<string>>;
-  setIsPaletteOpen: Dispatch<SetStateAction<boolean>>;
+  setEditorDraftPrompt: Dispatch<SetStateAction<string>>;
+  dispatchCommandPalette: Dispatch<ComposerCommandPaletteAction>;
   clearActiveFileMentionTrigger: () => void;
   onDraftContentChange: (
     draft: AgentComposerDraft,
@@ -120,8 +121,8 @@ export function useComposerDraftAttachments({
   draftImagesRef,
   draftFilesRef,
   draftLargeTextsRef,
-  setPaletteDraftPrompt,
-  setIsPaletteOpen,
+  setEditorDraftPrompt,
+  dispatchCommandPalette,
   clearActiveFileMentionTrigger,
   onDraftContentChange,
   onPromptImagesUnsupported,
@@ -176,9 +177,9 @@ export function useComposerDraftAttachments({
       if (isGoalModeActive) {
         const nextGoalPrompt = buildGoalModePrompt(nextDraft);
         draftPromptRef.current = nextGoalPrompt;
+        dispatchCommandPalette({ type: "draftChanged", prompt: nextDraft });
         startTransition(() => {
-          setPaletteDraftPrompt(nextDraft);
-          setIsPaletteOpen(true);
+          setEditorDraftPrompt(nextDraft);
           updateScopedDraft(draftScopeKey, (currentDraft) =>
             updateDraftPromptAndReconcileFiles(currentDraft, nextGoalPrompt)
           );
@@ -189,9 +190,12 @@ export function useComposerDraftAttachments({
       if (nextGoalObjective !== null) {
         const nextGoalPrompt = buildGoalModePrompt(nextGoalObjective);
         draftPromptRef.current = nextGoalPrompt;
+        dispatchCommandPalette({
+          type: "draftChanged",
+          prompt: nextGoalObjective
+        });
         startTransition(() => {
-          setPaletteDraftPrompt(nextGoalObjective);
-          setIsPaletteOpen(true);
+          setEditorDraftPrompt(nextGoalObjective);
           updateScopedDraft(draftScopeKey, (currentDraft) =>
             updateDraftPromptAndReconcileFiles(currentDraft, nextGoalPrompt)
           );
@@ -199,9 +203,9 @@ export function useComposerDraftAttachments({
         return;
       }
       draftPromptRef.current = nextDraft;
+      dispatchCommandPalette({ type: "draftChanged", prompt: nextDraft });
       startTransition(() => {
-        setPaletteDraftPrompt(nextDraft);
-        setIsPaletteOpen(true);
+        setEditorDraftPrompt(nextDraft);
         updateScopedDraft(draftScopeKey, (currentDraft) =>
           updateDraftPromptAndReconcileFiles(currentDraft, nextDraft)
         );
@@ -215,7 +219,8 @@ export function useComposerDraftAttachments({
     }
     const nextPrompt = goalDraftObjective ?? "";
     draftPromptRef.current = nextPrompt;
-    setPaletteDraftPrompt(nextPrompt);
+    dispatchCommandPalette({ type: "draftChanged", prompt: nextPrompt });
+    setEditorDraftPrompt(nextPrompt);
     updateScopedDraft(draftScopeKey, (currentDraft) =>
       updateDraftPromptAndReconcileFiles(currentDraft, nextPrompt)
     );
@@ -599,7 +604,8 @@ export function useComposerDraftAttachments({
       );
       draftPromptRef.current = nextPrompt;
       draftLargeTextsRef.current = nextDraftLargeTexts;
-      setPaletteDraftPrompt(nextPrompt);
+      dispatchCommandPalette({ type: "draftChanged", prompt: nextPrompt });
+      setEditorDraftPrompt(nextPrompt);
       publishScopedDraft(
         draftScopeKey,
         buildAgentComposerDraft({

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerMentionActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerMentionActions.ts
@@ -34,6 +34,7 @@ import {
   type AgentMentionSearchState,
   AgentMentionSearchController
 } from "../AgentMentionSearchController";
+import type { ComposerCommandPaletteAction } from "./composerCommandPaletteState";
 
 interface Input {
   workspaceId: string;
@@ -48,8 +49,9 @@ interface Input {
   mentionControllerRef: RefObject<AgentMentionSearchController | null>;
   editorHandleRef: RefObject<AgentRichTextEditorHandle | null>;
   draftPromptRef: RefObject<string>;
-  setPaletteDraftPrompt: Dispatch<SetStateAction<string>>;
-  setIsPaletteOpen: Dispatch<SetStateAction<boolean>>;
+  setEditorDraftPrompt: Dispatch<SetStateAction<string>>;
+  dispatchCommandPalette: Dispatch<ComposerCommandPaletteAction>;
+  setIsFileMentionPaletteOpen: Dispatch<SetStateAction<boolean>>;
   onDraftContentChange: (draft: AgentComposerDraft) => void;
   showFileMentionPalette: boolean;
   mentionHighlightedKey: string | null;
@@ -92,8 +94,9 @@ export function useComposerMentionActions(input: Input) {
     mentionControllerRef,
     editorHandleRef,
     draftPromptRef,
-    setPaletteDraftPrompt,
-    setIsPaletteOpen,
+    setEditorDraftPrompt,
+    dispatchCommandPalette,
+    setIsFileMentionPaletteOpen,
     onDraftContentChange,
     showFileMentionPalette,
     mentionHighlightedKey,
@@ -127,7 +130,7 @@ export function useComposerMentionActions(input: Input) {
       }
       mentionControllerRef.current?.close();
       setFileMentionSuggestion(null);
-      setIsPaletteOpen(false);
+      setIsFileMentionPaletteOpen(false);
     },
     [fileMentionSuggestion]
   );
@@ -138,7 +141,7 @@ export function useComposerMentionActions(input: Input) {
     }
     mentionControllerRef.current?.close();
     setFileMentionSuggestion(null);
-    setIsPaletteOpen(false);
+    setIsFileMentionPaletteOpen(false);
   }, [fileMentionSuggestion]);
 
   const clearActiveFileMentionTrigger = useCallback((): void => {
@@ -157,7 +160,8 @@ export function useComposerMentionActions(input: Input) {
       return;
     }
     draftPromptRef.current = nextDraft;
-    setPaletteDraftPrompt(nextDraft);
+    dispatchCommandPalette({ type: "draftChanged", prompt: nextDraft });
+    setEditorDraftPrompt(nextDraft);
     onDraftContentChange(
       updateAgentComposerDraft(draftContent, { prompt: nextDraft })
     );
@@ -167,8 +171,8 @@ export function useComposerMentionActions(input: Input) {
       closeFileMentionPalette();
       return;
     }
-    setIsPaletteOpen(false);
-  }, [closeFileMentionPalette, showFileMentionPalette]);
+    dispatchCommandPalette({ type: "dismissCurrent" });
+  }, [closeFileMentionPalette, dispatchCommandPalette, showFileMentionPalette]);
 
   const createFileMentionPaletteAdapter = useCallback(
     (highlightedKey: string | null = mentionHighlightedKey) =>
@@ -371,9 +375,10 @@ export function useComposerMentionActions(input: Input) {
       setFileMentionSuggestion(state);
       if (!state) {
         mentionControllerRef.current?.close();
+        setIsFileMentionPaletteOpen(false);
         return;
       }
-      setIsPaletteOpen(true);
+      setIsFileMentionPaletteOpen(true);
       mentionControllerRef.current?.updateQuery({
         workspaceId,
         currentUserId,

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerPaletteCatalog.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerPaletteCatalog.spec.tsx
@@ -1,10 +1,56 @@
 import { renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import type { AgentGUIComposerSettingsVM } from "../model/agentGuiNodeTypes";
+import type { AgentRichTextEditorHandle } from "../agentRichText/AgentRichTextEditor";
 import type { AgentComposerProps } from "./AgentComposer.types";
 import { useComposerPaletteCatalog } from "./useComposerPaletteCatalog";
 
 describe("useComposerPaletteCatalog", () => {
+  it("opens the slash palette from text before the caret when trailing text remains", () => {
+    const { result } = renderHook(() =>
+      useComposerPaletteCatalog({
+        provider: "cursor",
+        isGoalModeActive: false,
+        goalSupported: false,
+        paletteDraftPrompt: "/ ",
+        availableCommands: [],
+        availableSkills: [
+          {
+            name: "review",
+            trigger: "/review",
+            sourceKind: "project",
+            kind: "skill"
+          }
+        ],
+        hasCompactableContext: false,
+        compactSupported: false,
+        composerSettings: {
+          supportsPlanMode: false,
+          supportsBrowser: false,
+          supportsComputerUse: false,
+          slashCommandPolicy: {
+            fallbackCommands: [],
+            commandEffects: [],
+            commandCatalogAuthoritative: true
+          }
+        } as unknown as AgentGUIComposerSettingsVM,
+        capabilityControlsReadOnly: false,
+        labels: {} as AgentComposerProps["labels"],
+        uiLanguage: "en",
+        editorHandleRef: {
+          current: {
+            getPromptTextBeforeSelection: () => "/"
+          } as AgentRichTextEditorHandle
+        }
+      })
+    );
+
+    expect(result.current.slashQuery).toBe("");
+    expect(result.current.slashPaletteEntries).toEqual([
+      expect.objectContaining({ label: "review", type: "skill" })
+    ]);
+  });
+
   it("places connector entries before ordinary skills", () => {
     const { result } = renderHook(() =>
       useComposerPaletteCatalog({

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerPaletteCatalog.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerPaletteCatalog.ts
@@ -75,14 +75,14 @@ export function useComposerPaletteCatalog({
   uiLanguage,
   editorHandleRef
 }: UseComposerPaletteCatalogInput) {
-  const slashQuery = isGoalModeActive
-    ? null
-    : getPromptStartSlashCommandQuery(paletteDraftPrompt);
-  const slashCommandPolicy = composerSettings.slashCommandPolicy;
   const promptBeforeSelection =
     editorHandleRef.current?.getPromptTextBeforeSelection() ?? "";
-  const skillQueryDraft = promptBeforeSelection || paletteDraftPrompt;
-  const skillQueryMatch = getAgentComposerTriggerQueryMatch(skillQueryDraft);
+  const triggerQueryDraft = promptBeforeSelection || paletteDraftPrompt;
+  const slashQuery = isGoalModeActive
+    ? null
+    : getPromptStartSlashCommandQuery(triggerQueryDraft);
+  const slashCommandPolicy = composerSettings.slashCommandPolicy;
+  const skillQueryMatch = getAgentComposerTriggerQueryMatch(triggerQueryDraft);
   const presentationSkills = useMemo(
     () =>
       capabilityMenuState?.connectors?.enabled === false

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerSlashActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerSlashActions.ts
@@ -46,6 +46,7 @@ import { resolvePermissionModeControlsDisabled } from "../model/composerModeSele
 import { GOAL_MODE_SLASH_COMMAND } from "./AgentComposerChrome";
 import type { AgentComposerProps } from "./AgentComposer.types";
 import { reportAgentComposerDiagnostic } from "./agentComposerDiagnostics";
+import type { ComposerCommandPaletteAction } from "./composerCommandPaletteState";
 
 type TriggerMatch = ReturnType<typeof getAgentComposerTriggerQueryMatch>;
 
@@ -97,8 +98,8 @@ interface UseComposerSlashActionsInput extends Props {
   draftImagesRef: RefObject<AgentComposerDraftImage[]>;
   draftFilesRef: RefObject<AgentComposerDraftFile[]>;
   draftLargeTextsRef: RefObject<AgentComposerDraftLargeText[]>;
-  setPaletteDraftPrompt: Dispatch<SetStateAction<string>>;
-  setIsPaletteOpen: Dispatch<SetStateAction<boolean>>;
+  setEditorDraftPrompt: Dispatch<SetStateAction<string>>;
+  dispatchCommandPalette: Dispatch<ComposerCommandPaletteAction>;
   setIsReviewPickerOpen: Dispatch<SetStateAction<boolean>>;
   setIsSlashStatusPanelOpen: Dispatch<SetStateAction<boolean>>;
   setHighlightedIndex: Dispatch<SetStateAction<number>>;
@@ -157,16 +158,16 @@ export function useComposerSlashActions(input: UseComposerSlashActionsInput) {
     draftImagesRef,
     draftFilesRef,
     draftLargeTextsRef,
-    setPaletteDraftPrompt,
-    setIsPaletteOpen,
+    setEditorDraftPrompt,
+    dispatchCommandPalette,
     setIsReviewPickerOpen,
     setIsSlashStatusPanelOpen,
     setHighlightedIndex
   } = input;
   const clearSlashCommandDraft = useCallback((): void => {
     draftPromptRef.current = "";
-    setPaletteDraftPrompt("");
-    setIsPaletteOpen(false);
+    setEditorDraftPrompt("");
+    dispatchCommandPalette({ type: "replaceAndDismiss", prompt: "" });
     onDraftContentChange(emptyAgentComposerDraft());
   }, [onDraftContentChange]);
 
@@ -197,11 +198,11 @@ export function useComposerSlashActions(input: UseComposerSlashActionsInput) {
     }
     setIsSlashStatusPanelOpen(false);
     setIsReviewPickerOpen(false);
-    setIsPaletteOpen(false);
+    dispatchCommandPalette({ type: "dismissCurrent" });
   }, [
+    dispatchCommandPalette,
     isSlashStatusPanelOpen,
     onSlashStatusClose,
-    setIsPaletteOpen,
     setIsReviewPickerOpen,
     setIsSlashStatusPanelOpen
   ]);
@@ -278,10 +279,10 @@ export function useComposerSlashActions(input: UseComposerSlashActionsInput) {
           onSlashStatusClose?.();
         }
         draftPromptRef.current = GOAL_MODE_SLASH_COMMAND;
-        setPaletteDraftPrompt("");
+        setEditorDraftPrompt("");
+        dispatchCommandPalette({ type: "replaceAndDismiss", prompt: "" });
         setIsSlashStatusPanelOpen(false);
         setIsReviewPickerOpen(false);
-        setIsPaletteOpen(false);
         onDraftContentChange(
           updateAgentComposerDraft(draftContent, {
             prompt: GOAL_MODE_SLASH_COMMAND
@@ -304,11 +305,14 @@ export function useComposerSlashActions(input: UseComposerSlashActionsInput) {
       if (effect.kind === "enableBrowserUse") {
         const nextDraft = effect.draft;
         draftPromptRef.current = nextDraft;
-        setPaletteDraftPrompt(nextDraft);
+        setEditorDraftPrompt(nextDraft);
+        dispatchCommandPalette({
+          type: "replaceAndDismiss",
+          prompt: nextDraft
+        });
         onDraftContentChange(
           updateAgentComposerDraft(draftContent, { prompt: nextDraft })
         );
-        setIsPaletteOpen(false);
         if (!settingsControlsDisabled) {
           onSettingsChange({ browserUse: true });
         }
@@ -317,11 +321,14 @@ export function useComposerSlashActions(input: UseComposerSlashActionsInput) {
       if (effect.kind === "enableComputerUse") {
         const nextDraft = effect.draft;
         draftPromptRef.current = nextDraft;
-        setPaletteDraftPrompt(nextDraft);
+        setEditorDraftPrompt(nextDraft);
+        dispatchCommandPalette({
+          type: "replaceAndDismiss",
+          prompt: nextDraft
+        });
         onDraftContentChange(
           updateAgentComposerDraft(draftContent, { prompt: nextDraft })
         );
-        setIsPaletteOpen(false);
         if (!settingsControlsDisabled) {
           onSettingsChange({ computerUse: true });
         }
@@ -342,11 +349,11 @@ export function useComposerSlashActions(input: UseComposerSlashActionsInput) {
       }
       const nextDraft = effect.draft;
       draftPromptRef.current = nextDraft;
-      setPaletteDraftPrompt(nextDraft);
+      setEditorDraftPrompt(nextDraft);
+      dispatchCommandPalette({ type: "replaceAndDismiss", prompt: nextDraft });
       onDraftContentChange(
         updateAgentComposerDraft(draftContent, { prompt: nextDraft })
       );
-      setIsPaletteOpen(false);
     },
     [
       clearSlashCommandDraft,
@@ -412,9 +419,13 @@ export function useComposerSlashActions(input: UseComposerSlashActionsInput) {
       if (capability.capability !== "tutti") {
         onCapabilitySettingsRequest?.(capability.capability);
       }
-      setIsPaletteOpen(false);
+      dispatchCommandPalette({ type: "dismissCurrent" });
     },
-    [capabilityControlsReadOnly, onCapabilitySettingsRequest]
+    [
+      capabilityControlsReadOnly,
+      dispatchCommandPalette,
+      onCapabilitySettingsRequest
+    ]
   );
 
   const selectSkill = useCallback(
@@ -428,7 +439,7 @@ export function useComposerSlashActions(input: UseComposerSlashActionsInput) {
             connectorKey: skill.connectorKey
           });
         }
-        setIsPaletteOpen(false);
+        dispatchCommandPalette({ type: "dismissCurrent" });
         return;
       }
       const trigger = skillTriggerForPrefix(skill, skillQueryMatch?.prefix);
@@ -447,11 +458,11 @@ export function useComposerSlashActions(input: UseComposerSlashActionsInput) {
           match: skillQueryMatch
         });
       draftPromptRef.current = nextDraft;
-      setPaletteDraftPrompt(nextDraft);
+      setEditorDraftPrompt(nextDraft);
+      dispatchCommandPalette({ type: "replaceAndDismiss", prompt: nextDraft });
       onDraftContentChange(
         updateAgentComposerDraft(draftContent, { prompt: nextDraft })
       );
-      setIsPaletteOpen(false);
     },
     [
       draftContent,
@@ -543,7 +554,7 @@ export function useComposerSlashActions(input: UseComposerSlashActionsInput) {
           return;
         }
       }
-      setIsPaletteOpen(false);
+      dispatchCommandPalette({ type: "dismissCurrent" });
       // workspace-reference 保持为单条 mention，由 skill+CLI 按需解析。
       const submission = projectAgentComposerDraftSubmission({
         draft: nextDraftContent,
@@ -627,7 +638,7 @@ export function useComposerSlashActions(input: UseComposerSlashActionsInput) {
       }
       if (event.key === "Escape") {
         event.preventDefault();
-        setIsPaletteOpen(false);
+        dispatchCommandPalette({ type: "dismissCurrent" });
         return true;
       }
       if (event.key === "Tab" || event.key === "Enter") {


### PR DESCRIPTION
## Summary

- 修复 Cursor Composer 首次输入 `/` 能显示指令面板、删除后再次输入 `/` 却不再显示的问题
- 用输入 revision 管理 Slash/Skill 面板的关闭状态，使关闭只影响当前输入版本；文件引用面板保持独立状态
- 改为根据光标前文本解析 Slash/Skill 触发，避免光标后的残留空格或文本错误抑制面板
- 补充删除后重输、程序化命令替换、外部 Draft 恢复及光标后残留文本的回归测试
- 更新 AgentGUI 架构说明，记录面板状态与光标投影约束

## Verification

- `pnpm check:changed -- --base upstream/main`
- `pnpm check:changed -- --base upstream/main --push-ready`
- 在 Tutti Dev 中手动验证：输入 `/` 显示面板，删除后再次输入 `/` 仍会重新显示；光标后残留空格时也能正确显示

## Checklist

- [x] 本 PR 不改变 session、turn、goal 或 runtime-operation 的 Agent Host 生命周期语义
- [x] 修改仅聚焦 Cursor `/` 指令面板交互
- [x] 已更新相关 AgentGUI 架构说明
- [x] 不涉及 README 或 CONTRIBUTING 多语言同步
- [x] 已运行变更范围内最低且充分的本地检查
- [x] 提交已包含 DCO sign-off
