### PR TITLE
fix(agent-gui): hide failed write diffs and surface error text

### DIFF
--- a/packages/agent/gui/shared/agentConversation/components/AgentToolCallCard.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentToolCallCard.spec.tsx
@@ -565,6 +565,35 @@ describe("Agent specialized tool cards", () => {
     expect(screen.getByText("+2")).toBeTruthy();
   });
 
+  it("hides diff stats for failed writes that still carry proposed content", async () => {
+    setAgentGuiI18nTestLocale("en");
+
+    render(
+      <AgentToolCallCard
+        call={projectAgentToolCall(
+          toolCall({
+            toolName: "Write",
+            status: "Failed",
+            statusKind: "failed",
+            payload: {
+              input: {
+                file_path: "/workspace/123.txt",
+                content: "{}"
+              },
+              error: {
+                message:
+                  "<tool_use_error>File has not been read yet. Read it first before writing to it.</tool_use_error>"
+              }
+            }
+          })
+        )}
+      />
+    );
+
+    expect(screen.queryByText("+1")).toBeNull();
+    expect(screen.getByText("failed")).toBeTruthy();
+  });
+
   it("keeps edit cards collapsed by default and expands detail on demand", async () => {
     setAgentGuiI18nTestLocale("en");
 

--- a/packages/agent/gui/shared/agentConversation/components/AgentToolCallHeader.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentToolCallHeader.tsx
@@ -8,7 +8,10 @@ import { WriteLinedIcon } from "../../../app/renderer/components/icons/WriteLine
 import { ToolNameIcon } from "../../toolActivityKindIcons";
 import { isImageGenerationToolCall } from "../../imageGenerationTool";
 import type { AgentToolCallVM } from "../contracts/agentToolCallVM";
-import { getFileChangeRenderData } from "./tool-renderers/render-data/agentToolRenderData";
+import {
+  getFileChangeRenderData,
+  isFailedToolCall
+} from "./tool-renderers/render-data/agentToolRenderData";
 
 const TOOL_ROW_ICON_SIZE = 16;
 
@@ -27,7 +30,7 @@ export function AgentToolCallHeader({
   const diffStats = diffStatsForCall(call);
   const isActive =
     call.statusKind === "working" || call.statusKind === "waiting";
-  const isFailed = call.statusKind === "failed" || isFailedStatus(call.status);
+  const isFailed = isFailedToolCall(call);
 
   return (
     <div
@@ -187,11 +190,6 @@ function formatInlineStatusLabel(label: string): string {
   return /^[A-Z][a-z]+$/.test(label) ? label.toLowerCase() : label;
 }
 
-function isFailedStatus(value: string | null | undefined): boolean {
-  const normalized = (value ?? "").trim().toLowerCase();
-  return normalized === "failed" || normalized === "error";
-}
-
 function formatInlineTitleLabel(label: string): string {
   const trimmed = label.trim();
   if (!/[a-z]/.test(trimmed) || !/[A-Z]/.test(trimmed.slice(1))) {
@@ -226,7 +224,7 @@ function LoadingEllipsis(): JSX.Element {
 function diffStatsForCall(
   call: AgentToolCallVM
 ): { added: number; removed: number } | null {
-  if (call.rendererKind === "approval") {
+  if (call.rendererKind === "approval" || isFailedToolCall(call)) {
     return null;
   }
   const files = getFileChangeRenderData(call);

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentEditContent.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentEditContent.tsx
@@ -1,13 +1,18 @@
 import type { JSX } from "react";
+import { translate } from "../../../../i18n/index";
 import { AgentCodeBlock } from "./code/AgentCodeBlock";
 import { AgentMonacoDiffViewer } from "./file-diff/AgentMonacoDiffViewer";
 import { AgentUnifiedPatchViewer } from "./file-diff/AgentUnifiedPatchViewer";
 import {
   stringValue,
   ToolMarkdownBlock,
+  ToolSection,
   type AgentToolRendererProps
 } from "./agentToolContentShared";
-import { getFileChangeRenderData } from "./render-data/agentToolRenderData";
+import {
+  getFileChangeRenderData,
+  getToolCallFailureText
+} from "./render-data/agentToolRenderData";
 
 export function AgentEditContent({
   call,
@@ -37,7 +42,9 @@ export function AgentEditContent({
       !(candidate.oldString !== null && candidate.newString !== null) &&
       candidate.content !== null
   );
+  const failureText = getToolCallFailureText(call);
   const hasRenderableContent =
+    Boolean(failureText) ||
     Boolean(path && files.length === 0) ||
     patchFiles.length > 0 ||
     diffFiles.length > 0 ||
@@ -49,6 +56,15 @@ export function AgentEditContent({
 
   return (
     <div className="workspace-agents-status-panel__detail-tool-body workspace-agents-status-panel__detail-tool-body--flat">
+      {failureText ? (
+        <ToolSection title={translate("agentHost.agentTool.details.error")}>
+          <ToolMarkdownBlock
+            content={failureText}
+            onLinkClick={onLinkClick}
+            collapsible
+          />
+        </ToolSection>
+      ) : null}
       {path && files.length === 0 ? (
         <ToolMarkdownBlock content={path} onLinkClick={onLinkClick} />
       ) : null}

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentExpandedToolContent.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentExpandedToolContent.spec.tsx
@@ -464,6 +464,41 @@ describe("AgentExpandedToolContent", () => {
     expect(screen.getByText("export const routes = []")).toBeTruthy();
   });
 
+  it("shows unwrapped failure text above proposed write content", async () => {
+    setAgentGuiI18nTestLocale("en");
+
+    render(
+      <AgentExpandedToolContent
+        call={projectAgentToolCall(
+          toolCall({
+            toolName: "Write",
+            status: "Failed",
+            statusKind: "failed",
+            payload: {
+              input: {
+                file_path: "/workspace/123.txt",
+                content: "{}"
+              },
+              error: {
+                message:
+                  "<tool_use_error>File has not been read yet. Read it first before writing to it.</tool_use_error>"
+              }
+            }
+          })
+        )}
+      />
+    );
+
+    expect(screen.getByText("Error")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "File has not been read yet. Read it first before writing to it."
+      )
+    ).toBeTruthy();
+    expect(screen.queryByText(/tool_use_error/i)).toBeNull();
+    expect(screen.getByText("{}")).toBeTruthy();
+  });
+
   it("renders an (empty) placeholder when write content is empty", async () => {
     setAgentGuiI18nTestLocale("en");
 

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentWriteContent.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentWriteContent.tsx
@@ -1,12 +1,17 @@
 import type { JSX } from "react";
+import { translate } from "../../../../i18n/index";
 import { AgentCodeBlock } from "./code/AgentCodeBlock";
 import { AgentUnifiedPatchViewer } from "./file-diff/AgentUnifiedPatchViewer";
 import {
   stringValue,
   ToolMarkdownBlock,
+  ToolSection,
   type AgentToolRendererProps
 } from "./agentToolContentShared";
-import { getFileChangeRenderData } from "./render-data/agentToolRenderData";
+import {
+  getFileChangeRenderData,
+  getToolCallFailureText
+} from "./render-data/agentToolRenderData";
 
 export function AgentWriteContent({
   call,
@@ -29,8 +34,10 @@ export function AgentWriteContent({
   );
   const fallbackContent =
     files.length === 0 ? call.summary.trim() || null : null;
+  const failureText = getToolCallFailureText(call);
   const showFileHeaders = files.length > 1;
   const hasRenderableContent =
+    Boolean(failureText) ||
     Boolean(path && files.length === 0) ||
     patchFiles.length > 0 ||
     contentFiles.length > 0 ||
@@ -42,6 +49,15 @@ export function AgentWriteContent({
 
   return (
     <div className="workspace-agents-status-panel__detail-tool-body workspace-agents-status-panel__detail-tool-body--flat">
+      {failureText ? (
+        <ToolSection title={translate("agentHost.agentTool.details.error")}>
+          <ToolMarkdownBlock
+            content={failureText}
+            onLinkClick={onLinkClick}
+            collapsible
+          />
+        </ToolSection>
+      ) : null}
       {path && files.length === 0 ? (
         <ToolMarkdownBlock content={path} onLinkClick={onLinkClick} />
       ) : null}

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/agentToolContentShared.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/agentToolContentShared.tsx
@@ -8,6 +8,7 @@ import {
   getCommandRenderData,
   getFileChangeRenderData,
   getImageGenerationRenderData,
+  getToolCallFailureText,
   getToolFallbackText,
   getWebFetchRenderData,
   getWebSearchRenderData
@@ -262,6 +263,7 @@ function hasReadContent(call: AgentToolCallVM): boolean {
 function hasWriteContent(call: AgentToolCallVM): boolean {
   const files = getFileChangeRenderData(call);
   return Boolean(
+    getToolCallFailureText(call) ||
     files.some((file) => file.content !== null || file.unifiedDiff !== null) ||
     (files.length === 0 &&
       (call.summary.trim() ||
@@ -274,6 +276,7 @@ function hasWriteContent(call: AgentToolCallVM): boolean {
 function hasEditContent(call: AgentToolCallVM): boolean {
   const files = getFileChangeRenderData(call);
   return Boolean(
+    getToolCallFailureText(call) ||
     files.some(
       (file) =>
         file.unifiedDiff !== null ||

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/render-data/agentToolRenderData.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/render-data/agentToolRenderData.spec.ts
@@ -7,6 +7,7 @@ import {
   getSearchRenderData,
   getSkillRenderData,
   getTaskRenderData,
+  getToolCallFailureText,
   getToolFallbackText,
   getWebSearchRenderData,
   getWebFetchRenderData
@@ -240,6 +241,39 @@ describe("agentToolRenderData", () => {
     );
 
     expect(text.error).toBe("permission denied");
+  });
+
+  it("unwraps tool_use_error tags from failed write payloads", () => {
+    const failure = getToolCallFailureText(
+      makeCall({
+        toolName: "Write",
+        status: "Failed",
+        statusKind: "failed",
+        error: {
+          message:
+            "<tool_use_error>File has not been read yet. Read it first before writing to it.</tool_use_error>"
+        }
+      })
+    );
+
+    expect(failure).toBe(
+      "File has not been read yet. Read it first before writing to it."
+    );
+  });
+
+  it("falls back to failed output text when error payload is missing", () => {
+    const failure = getToolCallFailureText(
+      makeCall({
+        toolName: "Write",
+        status: "Failed",
+        statusKind: "failed",
+        output: {
+          text: "<tool_use_error>Write blocked</tool_use_error>"
+        }
+      })
+    );
+
+    expect(failure).toBe("Write blocked");
   });
 
   it("extracts file changes from direct file content input", () => {

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/render-data/agentToolRenderData.ts
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/render-data/agentToolRenderData.ts
@@ -354,6 +354,38 @@ export function getToolFallbackText(
   };
 }
 
+export function isFailedToolCall(call: AgentToolCallVM): boolean {
+  if (call.statusKind === "failed") {
+    return true;
+  }
+  const normalized = (call.status ?? "").trim().toLowerCase();
+  return normalized === "failed" || normalized === "error";
+}
+
+/** Human-readable failure detail for collapsed/expanded tool rows. */
+export function getToolCallFailureText(call: AgentToolCallVM): string | null {
+  const fallback = getToolFallbackText(call);
+  const raw = firstString(
+    fallback.error,
+    isFailedToolCall(call) ? fallback.output : null
+  );
+  return unwrapToolUseErrorText(raw);
+}
+
+function unwrapToolUseErrorText(value: string | null): string | null {
+  if (!value) {
+    return null;
+  }
+  const match = value.match(
+    /<tool_use_error>\s*([\s\S]*?)\s*<\/tool_use_error>/i
+  );
+  const unwrapped = match?.[1]?.trim();
+  if (unwrapped) {
+    return unwrapped;
+  }
+  return value.trim() || null;
+}
+
 function normalizeTaskStepsFromCall(call: AgentToolCallVM): AgentTaskStepVM[] {
   const steps =
     arrayValue(call.metadata?.steps) ??


### PR DESCRIPTION
## Summary
- Failed Write/Edit tool rows no longer show misleading `+/-` stats from proposed (unapplied) content.
- Expanded Write/Edit detail now surfaces unwrapped failure text (for example Claude `tool_use_error` / “Read it first before writing”) above the proposed content.
- Adds unit coverage for the failed Write case that previously showed `+1` and only `{}`.

## Test plan
- [x] `pnpm check:changed` on this branch
- [ ] Repro in Desktop/AgentGUI: Write a new file without Read first → tool row shows failed with **no** `+N`; expand shows the failure reason and optional proposed content
- [ ] Successful Write still shows `+/-` and content as before


Made with [Cursor](https://cursor.com)