### PR TITLE
fix(browser-node): propagate workspace into session preparation

### DIFF
--- a/packages/browser/workbench-node/src/core/types.ts
+++ b/packages/browser/workbench-node/src/core/types.ts
@@ -130,6 +130,7 @@ export interface BrowserNodeActivationInput {
 }
 
 export interface BrowserNodePrepareSessionInput {
+  automationTarget?: BrowserNodeAutomationTargetMetadata | null;
   navigationPolicy?: BrowserNodeNavigationPolicy | null;
   nodeId: string;
   profileId: string | null;

--- a/packages/browser/workbench-node/src/core/webviewController.test.ts
+++ b/packages/browser/workbench-node/src/core/webviewController.test.ts
@@ -7,13 +7,18 @@ import type { BrowserNodeHostApi } from "./types.ts";
 import type { BrowserNodeWebviewTag } from "../react/webviewTag.ts";
 
 test("Browser Node webview controller prepares sessions when active", async () => {
-  const prepareCalls: Array<{ nodeId: string; profileId: string | null }> = [];
+  const prepareCalls: Array<{
+    nodeId: string;
+    profileId: string | null;
+    workspaceId: string | null;
+  }> = [];
   const feature = createBrowserNodeFeature({
     hostApi: createBrowserNodeHostApi({
       prepareSession(payload) {
         prepareCalls.push({
           nodeId: payload.nodeId,
-          profileId: payload.profileId
+          profileId: payload.profileId,
+          workspaceId: payload.automationTarget?.workspaceId ?? null
         });
         return Promise.resolve();
       }
@@ -21,6 +26,14 @@ test("Browser Node webview controller prepares sessions when active", async () =
   });
 
   const controller = acquireBrowserNodeWebviewController({
+    automationTarget: {
+      focused: false,
+      selected: true,
+      surfaceId: "surface-1",
+      surfaceRole: "user",
+      tabId: "tab-1",
+      workspaceId: "workspace-1"
+    },
     feature,
     initialUrl: "https://example.com/",
     lifecycle: "active",
@@ -31,7 +44,13 @@ test("Browser Node webview controller prepares sessions when active", async () =
 
   controller.retain();
   await Promise.resolve();
-  assert.deepEqual(prepareCalls, [{ nodeId: "browser-1", profileId: null }]);
+  assert.deepEqual(prepareCalls, [
+    {
+      nodeId: "browser-1",
+      profileId: null,
+      workspaceId: "workspace-1"
+    }
+  ]);
   controller.release();
 });
 

--- a/packages/browser/workbench-node/src/core/webviewController.ts
+++ b/packages/browser/workbench-node/src/core/webviewController.ts
@@ -275,6 +275,7 @@ function reconcileBrowserNodeWebviewControllerState(
       }
       void entry.context.feature.hostApi
         .prepareSession({
+          automationTarget: entry.context.automationTarget,
           navigationPolicy: entry.context.navigationPolicy,
           nodeId: entry.context.nodeId,
           profileId: entry.context.profileId,

--- a/packages/browser/workbench-node/src/electron-main/electronMain.test.ts
+++ b/packages/browser/workbench-node/src/electron-main/electronMain.test.ts
@@ -1477,9 +1477,14 @@ test("keeps Browser Node navigation failures as the final emitted event", async 
 
 test("uses registerGuest URL before loading a newly attached guest", async () => {
   const contents = new MockBrowserGuestWebContents(21);
+  const preparedWorkspaceIds: Array<string | null> = [];
   const manager = createBrowserGuestManager({
     emit: () => undefined,
     openExternal: () => undefined,
+    prepareSession: (input) => {
+      preparedWorkspaceIds.push(input.automationTarget?.workspaceId ?? null);
+      return Promise.resolve();
+    },
     resolveWebContents: (id) => (id === contents.id ? contents : null)
   });
 
@@ -1491,6 +1496,14 @@ test("uses registerGuest URL before loading a newly attached guest", async () =>
   });
 
   await manager.registerGuest({
+    automationTarget: {
+      focused: false,
+      selected: true,
+      surfaceId: "surface-1",
+      surfaceRole: "user",
+      tabId: "tab-1",
+      workspaceId: "workspace-1"
+    },
     nodeId: "browser-stale-desired",
     profileId: null,
     sessionMode: "shared",
@@ -1499,6 +1512,7 @@ test("uses registerGuest URL before loading a newly attached guest", async () =>
   });
 
   assert.deepEqual(contents.loadedUrls, ["http://127.0.0.1:51103/"]);
+  assert.deepEqual(preparedWorkspaceIds, [null, "workspace-1"]);
   assert.equal(
     manager.debugDump({ nodeId: "browser-stale-desired" })?.desiredUrl,
     "http://127.0.0.1:51103/"

--- a/packages/browser/workbench-node/src/electron-main/guestManager.ts
+++ b/packages/browser/workbench-node/src/electron-main/guestManager.ts
@@ -765,6 +765,7 @@ export function createBrowserGuestManager({
     },
     async registerGuest(input) {
       await prepareSession?.({
+        automationTarget: input.automationTarget,
         nodeId: input.nodeId,
         profileId: input.profileId,
         sessionMode: input.sessionMode,


### PR DESCRIPTION
## Summary

- propagate `automationTarget` through BrowserNode session preparation
- preserve workspace identity when `registerGuest` prepares the owning Electron session
- cover renderer and Electron-main propagation before guest navigation

This lets BrowserNode hosts prepare workspace-scoped routing before a newly attached guest begins loading its localhost URL.

## Verification

- `node --test --experimental-strip-types ./src/core/webviewController.test.ts ./src/electron-main/electronMain.test.ts` (43 passed)
- `pnpm typecheck` in `packages/browser/workbench-node`
- `pnpm build` for `@tutti-os/browser-node` through TSH's local Tutti linker
- `pnpm check:changed` selected nine lanes; six passed. The Windows baseline remained red because WSL had no `git`, generated UI token outputs were already stale outside this diff, symlink tests require Windows symlink privilege, one SQLite cleanup hit `EBUSY`, and the POSIX file-mode assertion observed Windows mode `0666` instead of `0600`.

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): not applicable; this changes BrowserNode session metadata propagation.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed. Not applicable; public setup is unchanged.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. Not applicable.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.