### PR TITLE
feat(agent-host): expose session rail recovery proof

### DIFF
--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -237,7 +237,10 @@ an idempotent clear once to resolve a crash window, while unsafe set replay
 remains rejected.
 
 `GetSession` reads canonical session truth plus an optional live runtime
-observation without starting a provider. `GetTurn`, `GetInteraction`,
+observation without starting a provider. `GetSessionWithRailPlacement` adds
+the Host-owned immutable rail proof for idempotent recovery; application
+adapters must not reproduce rail normalization from canonical fields.
+`GetTurn`, `GetInteraction`,
 `ListSessionTurns`, `ListSessionMessages`, `FindTurnByClientSubmitID`, and
 `GetSessionInteractionSnapshot` expose canonical queries without leaking an
 adapter's concrete store. `GetSessionInteractionTreeSnapshot` is the

--- a/packages/agent/host/conformance/conformance.go
+++ b/packages/agent/host/conformance/conformance.go
@@ -208,6 +208,20 @@ type Scenario struct {
 	run  func(context.Context, Driver) error
 }
 
+// RailPlacementRecoveryDriver is separate from Driver so Host consumers adopt
+// the immutable rail recovery proof explicitly instead of reimplementing rail
+// normalization in an application adapter.
+type RailPlacementRecoveryDriver interface {
+	Reset(context.Context, Fixture) error
+	Create(context.Context, string, agenthost.CreateSessionInput) (SessionObservation, string, error)
+	GetSessionWithRailPlacement(context.Context, agenthost.SessionRef, *agenthost.RailPlacement) (SessionObservation, error)
+}
+
+type RailPlacementRecoveryScenario struct {
+	Name string
+	run  func(context.Context, RailPlacementRecoveryDriver) error
+}
+
 // DeletedSessionLifecycleDriver is separate from Driver so adapters adopt the
 // lossless tombstone contract explicitly while rolling out its new canonical
 // storage capability.
@@ -272,6 +286,20 @@ func Run(ctx context.Context, driver Driver, scenario Scenario) error {
 	}
 	if scenario.run == nil {
 		return fmt.Errorf("agent host conformance scenario %q has no runner", scenario.Name)
+	}
+	return scenario.run(ctx, driver)
+}
+
+func RunRailPlacementRecovery(
+	ctx context.Context,
+	driver RailPlacementRecoveryDriver,
+	scenario RailPlacementRecoveryScenario,
+) error {
+	if driver == nil {
+		return fmt.Errorf("agent host rail placement recovery conformance driver is required")
+	}
+	if scenario.run == nil {
+		return fmt.Errorf("agent host rail placement recovery conformance scenario %q has no runner", scenario.Name)
 	}
 	return scenario.run(ctx, driver)
 }

--- a/packages/agent/host/conformance/conformance_test.go
+++ b/packages/agent/host/conformance/conformance_test.go
@@ -52,6 +52,14 @@ func TestPublishedInteractionTreeScenarioCatalogHasUniqueNames(t *testing.T) {
 	}
 }
 
+func TestPublishedRailPlacementRecoveryScenarioCatalogHasUniqueNames(t *testing.T) {
+	t.Parallel()
+	scenarios := RailPlacementRecoveryScenarios()
+	if len(scenarios) != 1 || scenarios[0].Name == "" {
+		t.Fatalf("rail placement recovery scenarios=%#v", scenarios)
+	}
+}
+
 func TestPublishedEditRetryScenarioCatalogHasUniqueNames(t *testing.T) {
 	t.Parallel()
 	scenarios := EditRetryScenarios()

--- a/packages/agent/host/conformance/scenarios.go
+++ b/packages/agent/host/conformance/scenarios.go
@@ -113,6 +113,15 @@ func TitlePolicyScenarios() []Scenario {
 	return []Scenario{{Name: "clear canonical title", run: runClearCanonicalTitle}}
 }
 
+// RailPlacementRecoveryScenarios verifies the Host-owned immutable rail proof
+// used by application adapters during idempotent recovery.
+func RailPlacementRecoveryScenarios() []RailPlacementRecoveryScenario {
+	return []RailPlacementRecoveryScenario{{
+		Name: "recover canonical session only on matching rail",
+		run:  runRecoverCanonicalSessionOnlyOnMatchingRail,
+	}}
+}
+
 // DeletionAdmissionScenarios verifies the provider-neutral guard around the
 // exact canonical closure owned and replanned by Host.
 func DeletionAdmissionScenarios() []Scenario {

--- a/packages/agent/host/conformance/session_lifecycle_scenarios.go
+++ b/packages/agent/host/conformance/session_lifecycle_scenarios.go
@@ -302,6 +302,46 @@ func runCreateWithRailPlacement(ctx context.Context, driver Driver) error {
 	return nil
 }
 
+func runRecoverCanonicalSessionOnlyOnMatchingRail(
+	ctx context.Context,
+	driver RailPlacementRecoveryDriver,
+) error {
+	if err := driver.Reset(ctx, Fixture{}); err != nil {
+		return err
+	}
+	ref := agenthost.SessionRef{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-rail-recovery",
+	}
+	placement := &agenthost.RailPlacement{
+		Version: 1, Kind: agenthost.RailPlacementKindProject,
+		ProjectPath: "/workspace/project", SectionKey: "project:/workspace/project",
+	}
+	created, _, err := driver.Create(ctx, ref.WorkspaceID, agenthost.CreateSessionInput{
+		AgentSessionID: ref.AgentSessionID, AgentTargetID: "target-1", Provider: "codex",
+		RailPlacement: placement,
+	})
+	if err != nil {
+		return fmt.Errorf("create session for rail recovery: %w", err)
+	}
+	recovered, err := driver.GetSessionWithRailPlacement(ctx, ref, &agenthost.RailPlacement{
+		Version: 1, Kind: agenthost.RailPlacementKindProject,
+		ProjectPath: "/workspace/project", SectionKey: "project:/ignored-by-normalization",
+	})
+	if err != nil {
+		return fmt.Errorf("recover session on matching rail: %w", err)
+	}
+	if recovered.SessionID != created.SessionID || recovered.RailSectionKey != created.RailSectionKey {
+		return fmt.Errorf("recovered session=%#v, want %#v", recovered, created)
+	}
+	if _, err := driver.GetSessionWithRailPlacement(ctx, ref, &agenthost.RailPlacement{
+		Version: 1, Kind: agenthost.RailPlacementKindProject,
+		ProjectPath: "/workspace/other-project",
+	}); !errors.Is(err, agenthost.ErrRailPlacementConflict) {
+		return fmt.Errorf("recover session on mismatched rail error=%v", err)
+	}
+	return nil
+}
+
 func runResumePersistedSession(ctx context.Context, driver Driver) error {
 	fixture := Fixture{Session: &SessionSeed{
 		WorkspaceID: "workspace-1", AgentSessionID: "session-resume", Provider: "codex",

--- a/packages/agent/host/rail_placement.go
+++ b/packages/agent/host/rail_placement.go
@@ -1,6 +1,7 @@
 package agenthost
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -55,4 +56,30 @@ func railPlacementMatchesSession(placement *RailPlacement, session storesqlite.S
 			storesqlite.NormalizeProjectPath(placement.ProjectPath) &&
 		storesqlite.NormalizeRailSectionKey(session.RailSectionKey) ==
 			storesqlite.NormalizeRailSectionKey(placement.SectionKey)
+}
+
+// GetSessionWithRailPlacement reads one canonical Session only when its
+// immutable rail identity matches the caller's Host-normalized placement.
+// Recovery consumers use this boundary instead of reproducing rail
+// normalization or comparing canonical storage fields outside Agent Host.
+func (h *Host) GetSessionWithRailPlacement(
+	ctx context.Context,
+	ref SessionRef,
+	placement *RailPlacement,
+) (GetSessionResult, error) {
+	normalized, err := normalizeRailPlacement(placement)
+	if err != nil {
+		return GetSessionResult{}, err
+	}
+	if normalized == nil {
+		return GetSessionResult{}, ErrInvalidArgument
+	}
+	result, err := h.GetSession(ctx, ref)
+	if err != nil {
+		return GetSessionResult{}, err
+	}
+	if !railPlacementMatchesSession(normalized, result.Canonical) {
+		return GetSessionResult{}, ErrRailPlacementConflict
+	}
+	return result, nil
 }

--- a/packages/agent/host/rail_placement_test.go
+++ b/packages/agent/host/rail_placement_test.go
@@ -1,11 +1,36 @@
 package agenthost
 
 import (
+	"context"
+	"errors"
 	"runtime"
 	"testing"
 
 	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 )
+
+type railPlacementCanonicalStore struct {
+	CanonicalStore
+	session storesqlite.Session
+}
+
+func (railPlacementCanonicalStore) SessionDeleted(context.Context, string, string) (bool, error) {
+	return false, nil
+}
+
+func (s railPlacementCanonicalStore) GetSession(
+	context.Context,
+	string,
+	string,
+) (storesqlite.Session, bool, error) {
+	return s.session, true, nil
+}
+
+type railPlacementRuntime struct{ RuntimeController }
+
+func (railPlacementRuntime) Session(string, string) (ProviderRuntimeSession, bool) {
+	return ProviderRuntimeSession{}, false
+}
 
 func TestNormalizeRailPlacementDerivesCanonicalSectionKey(t *testing.T) {
 	t.Parallel()
@@ -57,5 +82,35 @@ func TestRailPlacementMatchesSessionAcrossSymlinkForms(t *testing.T) {
 	}
 	if !railPlacementMatchesSession(placement, session) {
 		t.Fatalf("expected alias forms to match: placement=%#v session=%#v", placement, session)
+	}
+}
+
+func TestGetSessionWithRailPlacementOwnsCanonicalRecoveryPolicy(t *testing.T) {
+	t.Parallel()
+	ref := SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-1"}
+	host := New(Config{
+		CanonicalStore: railPlacementCanonicalStore{session: storesqlite.Session{
+			WorkspaceID: ref.WorkspaceID, ID: ref.AgentSessionID,
+			RailSectionKind: storesqlite.RailSectionKindProject,
+			RailProjectPath: "/workspace/project",
+			RailSectionKey:  storesqlite.RailSectionKeyForProject("/workspace/project"),
+		}},
+		Runtime: railPlacementRuntime{},
+	})
+
+	result, err := host.GetSessionWithRailPlacement(t.Context(), ref, &RailPlacement{
+		Version: 1, Kind: RailPlacementKindProject,
+		ProjectPath: "/workspace/project", SectionKey: "project:/ignored-by-normalization",
+	})
+	if err != nil || result.Canonical.ID != ref.AgentSessionID {
+		t.Fatalf("GetSessionWithRailPlacement() = (%#v, %v), want canonical Session", result, err)
+	}
+	if _, err := host.GetSessionWithRailPlacement(t.Context(), ref, &RailPlacement{
+		Version: 1, Kind: RailPlacementKindProject, ProjectPath: "/workspace/other-project",
+	}); !errors.Is(err, ErrRailPlacementConflict) {
+		t.Fatalf("mismatched project rail error = %v, want %v", err, ErrRailPlacementConflict)
+	}
+	if _, err := host.GetSessionWithRailPlacement(t.Context(), ref, nil); !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("missing recovery rail error = %v, want %v", err, ErrInvalidArgument)
 	}
 }


### PR DESCRIPTION
## What changed

- add GetSessionWithRailPlacement as the Host-owned idempotent recovery boundary
- normalize the requested rail in Host and fail with ErrRailPlacementConflict on mismatch
- add a reusable downstream conformance scenario for matching and mismatched recovery
- document that application adapters must not reproduce canonical rail normalization

## Why

Shared-agent Goal and invocation recovery need to decide whether an already durable Session belongs to the binding rail. That policy was being duplicated in TSH desktopd, which could diverge from Host normalization.

## Risk

The API is read-only and requires an explicit versioned placement. Missing or invalid placement fails closed; mismatch errors do not include raw project paths or section keys.

## Verification

- go test ./packages/agent/host ./packages/agent/host/conformance
- pnpm check:changed
- pre-push: pnpm check:changed -- --push-ready

E2E tests were not run.