### PR TITLE
feat(agent-host): aggregated terminal failure observer

### DIFF
--- a/docs/architecture/analytics-tracking.md
+++ b/docs/architecture/analytics-tracking.md
@@ -461,12 +461,24 @@ Agent Host may emit aggregated terminal failures through
 `TerminalFailureObserver`. Sources:
 
 - failed `session_create` / `message_send` lifecycle commands
+- guidance target binding failures (`flow=guidance`,
+  `failure_stage=guidance_target`) before claim creation or when the runtime
+  rejects an exact turn target before provider admission
 - goal-control prepare / refresh command failures, and durable
   `GoalOperationFailed` / terminal incidents
 - durable runtime-operation failures for `interactive_response`,
-  `plan_decision`, and `turn_cancel`
-- settled failed / interrupted root turns
+  `plan_decision`, `turn_cancel`, and `edit_retry`
+- settled failed / interrupted root turns (including child/subagent sessions
+  via `IsChildSession`)
 - failed / errored `tool_call` messages in session-message commits
+
+Out of scope for dedicated Host terminal-failure flows:
+
+- queue as a separate event family (queued submits still fail as
+  `message_send` / turn settlements; `isQueued` remains a diagnostic trait)
+- session fork (TSH does not expose fork)
+- file-change card open failures (desktop UI / TSH Analytics only)
+- shared-agent product events (owned by the shared-agent analytics track)
 
 Adapters should map those observations into product analytics events. Call
 `ObserveTerminalFailuresFromDelta` alongside `NotifyCommitted` when activity

--- a/docs/architecture/analytics-tracking.md
+++ b/docs/architecture/analytics-tracking.md
@@ -458,7 +458,19 @@ The method calls the generated OpenAPI SDK and reuses generated request types.
 ## Agent Host terminal failure telemetry
 
 Agent Host may emit aggregated terminal failures through
-`TerminalFailureObserver`. Adapters should map those observations into product
-analytics events. Do not promote every `LifecycleStep` into an analytics event;
-lifecycle steps remain diagnostic. Terminal failures carry the original error
-message and failure stage for investigation without user-supplied logs.
+`TerminalFailureObserver`. Sources:
+
+- failed `session_create` / `message_send` lifecycle commands
+- goal-control prepare / refresh command failures, and durable
+  `GoalOperationFailed` / terminal incidents
+- durable runtime-operation failures for `interactive_response`,
+  `plan_decision`, and `turn_cancel`
+- settled failed / interrupted root turns
+- failed / errored `tool_call` messages in session-message commits
+
+Adapters should map those observations into product analytics events. Call
+`ObserveTerminalFailuresFromDelta` alongside `NotifyCommitted` when activity
+projection commits are not routed through `Host.notifyCommitted`. Do not
+promote every `LifecycleStep` into a product analytics event; lifecycle steps
+remain diagnostic. Terminal failures carry the original error message and
+failure stage for investigation without user-supplied logs.

--- a/docs/architecture/analytics-tracking.md
+++ b/docs/architecture/analytics-tracking.md
@@ -454,3 +454,11 @@ The method calls the generated OpenAPI SDK and reuses generated request types.
 - Do not read Tea credentials from anywhere other than `ResolveAnalyticsConfig()`
 - After modifying `config/tutti.defaults.json`, always re-run
   `generate-defaults.mjs` and commit the generated files together
+
+## Agent Host terminal failure telemetry
+
+Agent Host may emit aggregated terminal failures through
+`TerminalFailureObserver`. Adapters should map those observations into product
+analytics events. Do not promote every `LifecycleStep` into an analytics event;
+lifecycle steps remain diagnostic. Terminal failures carry the original error
+message and failure stage for investigation without user-supplied logs.

--- a/packages/agent/host/committed_delta.go
+++ b/packages/agent/host/committed_delta.go
@@ -266,6 +266,7 @@ func NotifyCommitted(ctx context.Context, observer CommitObserver, delta Committ
 
 func (h *Host) notifyCommitted(ctx context.Context, delta CommittedDelta) {
 	if h != nil {
+		ObserveTerminalFailuresFromDelta(ctx, h.terminalFailure, delta)
 		NotifyCommitted(ctx, h.commitObserver, delta)
 	}
 }

--- a/packages/agent/host/committed_delta.go
+++ b/packages/agent/host/committed_delta.go
@@ -25,6 +25,7 @@ type RootTurnSettled struct {
 	WorkspaceID    string
 	AgentSessionID string
 	Turn           storesqlite.Turn
+	IsChildSession bool
 }
 
 type RuntimeOperationCommitStage string
@@ -102,6 +103,7 @@ func ActivityStateDelta(input canonical.ReportSessionStateInput, reply canonical
 	if result.RootTurnAccepted && result.RootTurn.Phase == storesqlite.TurnPhaseSettled {
 		delta.RootTurnsSettled = append(delta.RootTurnsSettled, RootTurnSettled{
 			WorkspaceID: result.RootTurn.WorkspaceID, AgentSessionID: result.RootTurn.AgentSessionID, Turn: result.RootTurn,
+			IsChildSession: sessionStateIsChild(input.State),
 		})
 	}
 	if goalOp := goalOperationFromActivityState(input, result); goalOp != nil {
@@ -112,6 +114,14 @@ func ActivityStateDelta(input canonical.ReportSessionStateInput, reply canonical
 		delta.addView(input.WorkspaceID, result.RootTurn.AgentSessionID)
 	}
 	return delta
+}
+
+func sessionStateIsChild(state canonical.WorkspaceAgentSessionStateUpdate) bool {
+	kind := strings.TrimSpace(state.Kind)
+	if strings.EqualFold(kind, storesqlite.SessionKindChild) {
+		return true
+	}
+	return strings.TrimSpace(state.ParentToolCallID) != ""
 }
 
 // goalOperationFromActivityState promotes bottom-up Goal observed updates

--- a/packages/agent/host/create_session_initialization.go
+++ b/packages/agent/host/create_session_initialization.go
@@ -43,7 +43,7 @@ func (h *Host) cleanupFailedCreate(
 		startedAt := h.now()
 		lockCtx, cancel := detachedPhaseContext(ctx, failedCreateLockTimeout)
 		release, err := h.acquireSession(lockCtx, ref)
-		h.observeStep(lockCtx, "session_create_cleanup", "lifecycle_lock_acquired", ref.AgentSessionID, provider, startedAt, err)
+		h.observeStep(lockCtx, "session_create_cleanup", "lifecycle_lock_acquired", ref.WorkspaceID, ref.AgentSessionID, provider, startedAt, err)
 		cancel()
 		if err != nil {
 			errs = append(errs, err)
@@ -58,7 +58,7 @@ func (h *Host) cleanupFailedCreate(
 		err := h.runtime.Close(closeCtx, RuntimeCloseInput{
 			WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
 		})
-		h.observeStep(closeCtx, "session_create_cleanup", "runtime_closed", ref.AgentSessionID, provider, startedAt, err)
+		h.observeStep(closeCtx, "session_create_cleanup", "runtime_closed", ref.WorkspaceID, ref.AgentSessionID, provider, startedAt, err)
 		cancel()
 		errs = append(errs, err)
 	}
@@ -70,7 +70,7 @@ func (h *Host) cleanupFailedCreate(
 			ref.WorkspaceID,
 			ref.AgentSessionID,
 		)
-		h.observeStep(rollbackCtx, "session_create_cleanup", "canonical_rolled_back", ref.AgentSessionID, provider, startedAt, err)
+		h.observeStep(rollbackCtx, "session_create_cleanup", "canonical_rolled_back", ref.WorkspaceID, ref.AgentSessionID, provider, startedAt, err)
 		cancel()
 		errs = append(errs, err)
 	}
@@ -80,7 +80,7 @@ func (h *Host) cleanupFailedCreate(
 		err := h.preparation.Cleanup(cleanupCtx, RuntimeCleanupInput{
 			WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID, Provider: provider,
 		})
-		h.observeStep(cleanupCtx, "session_create_cleanup", "preparation_cleaned", ref.AgentSessionID, provider, startedAt, err)
+		h.observeStep(cleanupCtx, "session_create_cleanup", "preparation_cleaned", ref.WorkspaceID, ref.AgentSessionID, provider, startedAt, err)
 		cancel()
 		errs = append(errs, err)
 	}

--- a/packages/agent/host/errors.go
+++ b/packages/agent/host/errors.go
@@ -3,6 +3,7 @@ package agenthost
 import (
 	"context"
 	"errors"
+	"strings"
 
 	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 )
@@ -94,4 +95,12 @@ func (e *ProviderError) Unwrap() error {
 		return nil
 	}
 	return e.Cause
+}
+
+func terminalFailureCode(err error) string {
+	var providerErr *ProviderError
+	if errors.As(err, &providerErr) && providerErr != nil {
+		return strings.TrimSpace(providerErr.Code)
+	}
+	return ""
 }

--- a/packages/agent/host/errors.go
+++ b/packages/agent/host/errors.go
@@ -104,3 +104,16 @@ func terminalFailureCode(err error) string {
 	}
 	return ""
 }
+
+func guidanceTargetFailureCode(err error) string {
+	switch {
+	case errors.Is(err, ErrActiveTurnTargetRequired):
+		return "active_turn_target_required"
+	case errors.Is(err, ErrActiveTurnTargetMismatch):
+		return "active_turn_target_mismatch"
+	}
+	if code := terminalFailureCode(err); code != "" {
+		return code
+	}
+	return "guidance_target"
+}

--- a/packages/agent/host/goal_control.go
+++ b/packages/agent/host/goal_control.go
@@ -330,6 +330,17 @@ func (h *Host) goalControlSerialized(
 			"agentSessionId", agentSessionID,
 			"error", err.Error(),
 		)
+		h.observeTerminalFailure(ctx, TerminalFailure{
+			Flow:           "goal_control",
+			FailureStage:   "prepare",
+			WorkspaceID:    workspaceID,
+			AgentSessionID: agentSessionID,
+			OperationID:    operationID,
+			ClientSubmitID: clientSubmitID,
+			ErrorCode:      terminalFailureCode(err),
+			ErrorMessage:   err.Error(),
+			Retryable:      isRetryableRuntimeOperationError(err),
+		})
 		return acceptedGoalControlResult(operationID, persistedState), err
 	}
 	if h.goals != nil {
@@ -408,6 +419,17 @@ func (h *Host) goalControlSerialized(
 			"action", action,
 			"error", normalizedErr.Error(),
 		)
+		h.observeTerminalFailure(ctx, TerminalFailure{
+			Flow:           "goal_control",
+			FailureStage:   "runtime_exec",
+			WorkspaceID:    workspaceID,
+			AgentSessionID: agentSessionID,
+			OperationID:    operationID,
+			ClientSubmitID: clientSubmitID,
+			ErrorCode:      terminalFailureCode(normalizedErr),
+			ErrorMessage:   normalizedErr.Error(),
+			Retryable:      isRetryableRuntimeOperationError(normalizedErr),
+		})
 		return acceptedGoalControlResult(operationID, persistedState), normalizedErr
 	}
 	responseGoal := clonePayload(controlResult.Goal)
@@ -470,6 +492,17 @@ func (h *Host) goalControlSerialized(
 			"agentSessionId", agentSessionID,
 			"error", err.Error(),
 		)
+		h.observeTerminalFailure(ctx, TerminalFailure{
+			Flow:           "goal_control",
+			FailureStage:   "refresh",
+			WorkspaceID:    workspaceID,
+			AgentSessionID: agentSessionID,
+			OperationID:    operationID,
+			ClientSubmitID: clientSubmitID,
+			ErrorCode:      terminalFailureCode(err),
+			ErrorMessage:   err.Error(),
+			Retryable:      isRetryableRuntimeOperationError(err),
+		})
 		return acceptedGoalControlResult(operationID, persistedState), err
 	}
 	if !found {

--- a/packages/agent/host/goal_control.go
+++ b/packages/agent/host/goal_control.go
@@ -419,17 +419,6 @@ func (h *Host) goalControlSerialized(
 			"action", action,
 			"error", normalizedErr.Error(),
 		)
-		h.observeTerminalFailure(ctx, TerminalFailure{
-			Flow:           "goal_control",
-			FailureStage:   "runtime_exec",
-			WorkspaceID:    workspaceID,
-			AgentSessionID: agentSessionID,
-			OperationID:    operationID,
-			ClientSubmitID: clientSubmitID,
-			ErrorCode:      terminalFailureCode(normalizedErr),
-			ErrorMessage:   normalizedErr.Error(),
-			Retryable:      isRetryableRuntimeOperationError(normalizedErr),
-		})
 		return acceptedGoalControlResult(operationID, persistedState), normalizedErr
 	}
 	responseGoal := clonePayload(controlResult.Goal)

--- a/packages/agent/host/guidance_target_test.go
+++ b/packages/agent/host/guidance_target_test.go
@@ -18,8 +18,8 @@ func (o *recordingGuidanceTerminalFailureObserver) ObserveTerminalFailure(_ cont
 
 func TestHostGuidanceRequiresExactTargetBeforeCreatingClaim(t *testing.T) {
 	observer := &recordingGuidanceTerminalFailureObserver{}
-	host, store, runtime := newHostEditRetryFixture(t)
-	host = agenthost.New(agenthost.Config{
+	_, store, runtime := newHostEditRetryFixture(t)
+	host := agenthost.New(agenthost.Config{
 		CanonicalStore:          sqliteCanonicalStore{Store: store},
 		TurnSubmissions:         store,
 		EffectiveHistory:        store,
@@ -56,8 +56,8 @@ func TestHostGuidanceRequiresExactTargetBeforeCreatingClaim(t *testing.T) {
 
 func TestHostGuidanceTargetMismatchCleansPreparedClaim(t *testing.T) {
 	observer := &recordingGuidanceTerminalFailureObserver{}
-	host, store, runtime := newHostEditRetryFixture(t)
-	host = agenthost.New(agenthost.Config{
+	_, store, runtime := newHostEditRetryFixture(t)
+	host := agenthost.New(agenthost.Config{
 		CanonicalStore:          sqliteCanonicalStore{Store: store},
 		TurnSubmissions:         store,
 		EffectiveHistory:        store,

--- a/packages/agent/host/guidance_target_test.go
+++ b/packages/agent/host/guidance_target_test.go
@@ -1,14 +1,35 @@
 package agenthost_test
 
 import (
+	"context"
 	"testing"
 
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 )
 
+type recordingGuidanceTerminalFailureObserver struct {
+	failures []agenthost.TerminalFailure
+}
+
+func (o *recordingGuidanceTerminalFailureObserver) ObserveTerminalFailure(_ context.Context, failure agenthost.TerminalFailure) {
+	o.failures = append(o.failures, failure)
+}
+
 func TestHostGuidanceRequiresExactTargetBeforeCreatingClaim(t *testing.T) {
+	observer := &recordingGuidanceTerminalFailureObserver{}
 	host, store, runtime := newHostEditRetryFixture(t)
+	host = agenthost.New(agenthost.Config{
+		CanonicalStore:          sqliteCanonicalStore{Store: store},
+		TurnSubmissions:         store,
+		EffectiveHistory:        store,
+		RuntimeOperations:       store,
+		Runtime:                 runtime,
+		HistoryRuntime:          runtime,
+		GoalRuntime:             runtime,
+		OperationOwner:          "worker-1",
+		TerminalFailureObserver: observer,
+	})
 	_, err := host.SendInput(t.Context(), agenthost.SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-1"}, agenthost.SendInput{
 		Content: []agenthost.PromptContentBlock{{Type: "text", Text: "missing target"}}, Guidance: true,
 		ClientSubmitID: "guidance-required",
@@ -24,10 +45,29 @@ func TestHostGuidanceRequiresExactTargetBeforeCreatingClaim(t *testing.T) {
 	if runtime.execCalls != 0 {
 		t.Fatalf("runtime exec calls = %d, want 0", runtime.execCalls)
 	}
+	if len(observer.failures) != 1 {
+		t.Fatalf("terminal failures = %#v, want 1", observer.failures)
+	}
+	got := observer.failures[0]
+	if got.Flow != "guidance" || got.FailureStage != "guidance_target" || got.ErrorCode != "active_turn_target_required" {
+		t.Fatalf("guidance terminal failure = %#v", got)
+	}
 }
 
 func TestHostGuidanceTargetMismatchCleansPreparedClaim(t *testing.T) {
+	observer := &recordingGuidanceTerminalFailureObserver{}
 	host, store, runtime := newHostEditRetryFixture(t)
+	host = agenthost.New(agenthost.Config{
+		CanonicalStore:          sqliteCanonicalStore{Store: store},
+		TurnSubmissions:         store,
+		EffectiveHistory:        store,
+		RuntimeOperations:       store,
+		Runtime:                 runtime,
+		HistoryRuntime:          runtime,
+		GoalRuntime:             runtime,
+		OperationOwner:          "worker-1",
+		TerminalFailureObserver: observer,
+	})
 	runtime.mu.Lock()
 	runtime.guidanceMismatch = true
 	runtime.mu.Unlock()
@@ -52,5 +92,12 @@ func TestHostGuidanceTargetMismatchCleansPreparedClaim(t *testing.T) {
 	defer runtime.mu.Unlock()
 	if runtime.execCalls != 1 {
 		t.Fatalf("runtime exec calls = %d, want 1", runtime.execCalls)
+	}
+	if len(observer.failures) != 1 {
+		t.Fatalf("terminal failures = %#v, want 1", observer.failures)
+	}
+	got := observer.failures[0]
+	if got.Flow != "guidance" || got.FailureStage != "guidance_target" || got.TurnID != "turn-original" {
+		t.Fatalf("guidance terminal failure = %#v", got)
 	}
 }

--- a/packages/agent/host/host.go
+++ b/packages/agent/host/host.go
@@ -174,7 +174,7 @@ func New(config Config) *Host {
 	return host
 }
 
-func (h *Host) observeStep(ctx context.Context, flow, name, sessionID, provider string, startedAt time.Time, err error) {
+func (h *Host) observeStep(ctx context.Context, flow, name, workspaceID, sessionID, provider string, startedAt time.Time, err error) {
 	if h != nil && h.observer != nil {
 		h.observer.ObserveLifecycleStep(ctx, LifecycleStep{
 			Flow: flow, Name: name, AgentSessionID: sessionID, Provider: provider, StartedAt: startedAt, Err: err,
@@ -184,6 +184,7 @@ func (h *Host) observeStep(ctx context.Context, flow, name, sessionID, provider 
 		h.observeTerminalFailure(ctx, TerminalFailure{
 			Flow:           flow,
 			FailureStage:   name,
+			WorkspaceID:    workspaceID,
 			AgentSessionID: sessionID,
 			Provider:       provider,
 			ErrorCode:      terminalFailureCode(err),

--- a/packages/agent/host/host.go
+++ b/packages/agent/host/host.go
@@ -7,50 +7,51 @@ import (
 )
 
 type Config struct {
-	CanonicalStore         CanonicalStore
-	InteractionTrees       CanonicalInteractionTreeStore
-	TurnSubmissions        TurnSubmissionStore
-	EffectiveHistory       EffectiveHistoryStore
-	SessionManagement      SessionManagementStore
-	SessionBatchManagement SessionBatchManagementStore
-	SessionDeletionGuard   SessionDeletionGuard
-	SessionPurge           SessionPurgeStore
-	DeletedSessions        DeletedSessionStore
-	HistoricalState        HistoricalSessionStateStore
-	SessionForks           SessionForkStore
-	SessionForkRecovery    SessionForkRecoveryStore
-	SessionForkRuntime     SessionForkRuntime
-	SessionForkContext     SessionForkContextPolicy
-	SessionForkState       SessionForkProviderStateBinder
-	SessionForkAttachments SessionForkAttachmentStager
-	Runtime                RuntimeController
-	HistoryRuntime         RuntimeHistoryController
-	RuntimePreparation     RuntimePreparationPort
-	SettingsPolicy         SettingsPolicy
-	Attachments            AttachmentMaterializer
-	Clock                  Clock
-	SessionLocker          SessionLocker
-	RuntimeStartGate       RuntimeStartGate
-	LifecycleObserver      LifecycleObserver
-	CommitObserver         CommitObserver
-	RuntimeOperations      RuntimeOperationStore
-	OperationEvents        RuntimeOperationEventPublisher
-	OperationOwner         string
-	Scheduler              Scheduler
-	StaleTurnSettler       StaleTurnSettler
-	WorktreeGC             WorktreeGarbageCollector
-	GoalStore              GoalStateStore
-	GoalFences             GoalGenerationFenceStore
-	GoalRuntime            GoalRuntimeController
-	GoalInbox              GoalReconcileInboxStore
-	GoalOwner              string
-	GoalClock              Clock
-	GoalAttemptTimeout     time.Duration
-	GoalRecoveryBudget     time.Duration
-	GoalMaxAttempts        int
-	GoalDispatchDeadline   time.Duration
-	GoalActor              *SessionActor
-	SessionMutationActor   *SessionActor
+	CanonicalStore          CanonicalStore
+	InteractionTrees        CanonicalInteractionTreeStore
+	TurnSubmissions         TurnSubmissionStore
+	EffectiveHistory        EffectiveHistoryStore
+	SessionManagement       SessionManagementStore
+	SessionBatchManagement  SessionBatchManagementStore
+	SessionDeletionGuard    SessionDeletionGuard
+	SessionPurge            SessionPurgeStore
+	DeletedSessions         DeletedSessionStore
+	HistoricalState         HistoricalSessionStateStore
+	SessionForks            SessionForkStore
+	SessionForkRecovery     SessionForkRecoveryStore
+	SessionForkRuntime      SessionForkRuntime
+	SessionForkContext      SessionForkContextPolicy
+	SessionForkState        SessionForkProviderStateBinder
+	SessionForkAttachments  SessionForkAttachmentStager
+	Runtime                 RuntimeController
+	HistoryRuntime          RuntimeHistoryController
+	RuntimePreparation      RuntimePreparationPort
+	SettingsPolicy          SettingsPolicy
+	Attachments             AttachmentMaterializer
+	Clock                   Clock
+	SessionLocker           SessionLocker
+	RuntimeStartGate        RuntimeStartGate
+	LifecycleObserver       LifecycleObserver
+	TerminalFailureObserver TerminalFailureObserver
+	CommitObserver          CommitObserver
+	RuntimeOperations       RuntimeOperationStore
+	OperationEvents         RuntimeOperationEventPublisher
+	OperationOwner          string
+	Scheduler               Scheduler
+	StaleTurnSettler        StaleTurnSettler
+	WorktreeGC              WorktreeGarbageCollector
+	GoalStore               GoalStateStore
+	GoalFences              GoalGenerationFenceStore
+	GoalRuntime             GoalRuntimeController
+	GoalInbox               GoalReconcileInboxStore
+	GoalOwner               string
+	GoalClock               Clock
+	GoalAttemptTimeout      time.Duration
+	GoalRecoveryBudget      time.Duration
+	GoalMaxAttempts         int
+	GoalDispatchDeadline    time.Duration
+	GoalActor               *SessionActor
+	SessionMutationActor    *SessionActor
 
 	// EditRetryDisabled neutralizes the durable edit-and-retry feature (PR
 	// #1681). When set, new edit-retry operations are refused and any operation
@@ -87,6 +88,7 @@ type Host struct {
 	locker                 SessionLocker
 	startupGate            RuntimeStartGate
 	observer               LifecycleObserver
+	terminalFailure        TerminalFailureObserver
 	commitObserver         CommitObserver
 	operations             RuntimeOperationStore
 	events                 RuntimeOperationEventPublisher
@@ -133,8 +135,9 @@ func New(config Config) *Host {
 		sessionForkRecovery:    config.SessionForkRecovery,
 		preparation:            config.RuntimePreparation, settingsPolicy: config.SettingsPolicy, attachments: config.Attachments,
 		clock: config.Clock, locker: config.SessionLocker, startupGate: config.RuntimeStartGate,
-		observer: config.LifecycleObserver, commitObserver: config.CommitObserver,
-		operations: config.RuntimeOperations, events: config.OperationEvents,
+		observer: config.LifecycleObserver, terminalFailure: config.TerminalFailureObserver,
+		commitObserver: config.CommitObserver,
+		operations:     config.RuntimeOperations, events: config.OperationEvents,
 		owner: config.OperationOwner, scheduler: config.Scheduler, staleTurns: config.StaleTurnSettler,
 		worktreeGC: config.WorktreeGC,
 		goals:      config.GoalStore, goalFences: config.GoalFences, goalRuntime: config.GoalRuntime, goalInbox: config.GoalInbox,
@@ -177,6 +180,27 @@ func (h *Host) observeStep(ctx context.Context, flow, name, sessionID, provider 
 			Flow: flow, Name: name, AgentSessionID: sessionID, Provider: provider, StartedAt: startedAt, Err: err,
 		})
 	}
+	if err != nil {
+		h.observeTerminalFailure(ctx, TerminalFailure{
+			Flow:           flow,
+			FailureStage:   name,
+			AgentSessionID: sessionID,
+			Provider:       provider,
+			ErrorCode:      terminalFailureCode(err),
+			ErrorMessage:   err.Error(),
+			Retryable:      isRetryableRuntimeOperationError(err),
+		})
+	}
+}
+
+func (h *Host) observeTerminalFailure(ctx context.Context, failure TerminalFailure) {
+	if h == nil || h.terminalFailure == nil {
+		return
+	}
+	if failure.ErrorMessage == "" && failure.ErrorCode == "" {
+		return
+	}
+	h.terminalFailure.ObserveTerminalFailure(ctx, failure)
 }
 
 type systemClock struct{}

--- a/packages/agent/host/host.go
+++ b/packages/agent/host/host.go
@@ -2,6 +2,7 @@ package agenthost
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"time"
 )
@@ -192,6 +193,36 @@ func (h *Host) observeStep(ctx context.Context, flow, name, workspaceID, session
 			Retryable:      isRetryableRuntimeOperationError(err),
 		})
 	}
+}
+
+func (h *Host) observeGuidanceTargetFailure(
+	ctx context.Context,
+	ref SessionRef,
+	provider, turnID, clientSubmitID string,
+	startedAt time.Time,
+	err error,
+) {
+	if err == nil {
+		return
+	}
+	if h != nil && h.observer != nil {
+		h.observer.ObserveLifecycleStep(ctx, LifecycleStep{
+			Flow: "guidance", Name: "guidance_target", AgentSessionID: ref.AgentSessionID,
+			Provider: provider, StartedAt: startedAt, Err: err,
+		})
+	}
+	h.observeTerminalFailure(ctx, TerminalFailure{
+		Flow:           "guidance",
+		FailureStage:   "guidance_target",
+		WorkspaceID:    ref.WorkspaceID,
+		AgentSessionID: ref.AgentSessionID,
+		TurnID:         strings.TrimSpace(turnID),
+		ClientSubmitID: strings.TrimSpace(clientSubmitID),
+		Provider:       provider,
+		ErrorCode:      guidanceTargetFailureCode(err),
+		ErrorMessage:   err.Error(),
+		Retryable:      false,
+	})
 }
 
 func (h *Host) observeTerminalFailure(ctx context.Context, failure TerminalFailure) {

--- a/packages/agent/host/lifecycle.go
+++ b/packages/agent/host/lifecycle.go
@@ -454,7 +454,18 @@ func (h *Host) SendInput(ctx context.Context, ref SessionRef, input SendInput) (
 	// interaction boundary; allowing the runtime to infer "current" would make
 	// an A->B transition during transport silently steer B.
 	if input.Guidance && strings.TrimSpace(input.TurnID) == "" {
-		return SendInputResult{}, ErrActiveTurnTargetRequired
+		err := ErrActiveTurnTargetRequired
+		h.observeTerminalFailure(ctx, TerminalFailure{
+			Flow:           "guidance",
+			FailureStage:   "guidance_target",
+			WorkspaceID:    ref.WorkspaceID,
+			AgentSessionID: ref.AgentSessionID,
+			ClientSubmitID: strings.TrimSpace(input.ClientSubmitID),
+			ErrorCode:      guidanceTargetFailureCode(err),
+			ErrorMessage:   err.Error(),
+			Retryable:      false,
+		})
+		return SendInputResult{}, err
 	}
 	normalized, promptText, err := normalizePromptContent(input.Content)
 	if err != nil {
@@ -571,7 +582,13 @@ func (h *Host) sendInputSerialized(
 		})
 	}()
 	if err != nil {
-		h.observeStep(ctx, "message_send", "runtime_exec", ref.WorkspaceID, ref.AgentSessionID, session.Provider, startedAt, err)
+		if input.Guidance &&
+			(errors.Is(err, ErrActiveTurnTargetMismatch) ||
+				execResult.ProviderDispatch.Disposition == RuntimeDispatchDispositionNotDispatched) {
+			h.observeGuidanceTargetFailure(ctx, ref, session.Provider, input.TurnID, claim.ClientSubmitID, startedAt, err)
+		} else {
+			h.observeStep(ctx, "message_send", "runtime_exec", ref.WorkspaceID, ref.AgentSessionID, session.Provider, startedAt, err)
+		}
 		if !input.Guidance && strings.TrimSpace(execResult.TurnID) != "" {
 			if persistErr := h.persistRuntimeSubmitOutcome(
 				ctx, ref, execResult,

--- a/packages/agent/host/lifecycle.go
+++ b/packages/agent/host/lifecycle.go
@@ -123,7 +123,7 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 	startedAt := h.now()
 	release, err := h.acquireStartup(ctx, input.Provider)
 	if err != nil {
-		h.observeStep(ctx, "session_create", "runtime_started", input.AgentSessionID, input.Provider, startedAt, err)
+		h.observeStep(ctx, "session_create", "runtime_started", workspaceID, input.AgentSessionID, input.Provider, startedAt, err)
 		return createSessionFailureResult(input, cleanup(err, false, false))
 	}
 	startResult, err := func() (RuntimeStartResult, error) {
@@ -143,33 +143,33 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 		})
 	}()
 	if err != nil {
-		h.observeStep(ctx, "session_create", "runtime_started", input.AgentSessionID, input.Provider, startedAt, err)
+		h.observeStep(ctx, "session_create", "runtime_started", workspaceID, input.AgentSessionID, input.Provider, startedAt, err)
 		return createSessionFailureResult(input, cleanup(err, false, false))
 	}
 	session := startResult.Session
 	runtimeCreated := startResult.Created
-	h.observeStep(ctx, "session_create", "runtime_started", session.ID, session.Provider, startedAt, nil)
+	h.observeStep(ctx, "session_create", "runtime_started", workspaceID, session.ID, session.Provider, startedAt, nil)
 	startedAt = h.now()
 	canonicalSession, err := h.store.InitializeRuntimeSession(ctx, RuntimeSessionInitialization{
 		Session:       session,
 		RailPlacement: input.RailPlacement,
 	})
 	if err != nil {
-		h.observeStep(ctx, "session_create", "session_persisted", session.ID, session.Provider, startedAt, err)
+		h.observeStep(ctx, "session_create", "session_persisted", workspaceID, session.ID, session.Provider, startedAt, err)
 		return createSessionFailureResult(input, cleanup(err, runtimeCreated, false))
 	}
 	canonicalCreated := !canonicalExisted
 	if strings.TrimSpace(canonicalSession.ID) != strings.TrimSpace(session.ID) || strings.TrimSpace(canonicalSession.WorkspaceID) != workspaceID || strings.TrimSpace(canonicalSession.RailSectionKey) == "" {
 		identityErr := fmt.Errorf("initialize workspace agent session: persisted session identity mismatch")
-		h.observeStep(ctx, "session_create", "session_persisted", session.ID, session.Provider, startedAt, identityErr)
+		h.observeStep(ctx, "session_create", "session_persisted", workspaceID, session.ID, session.Provider, startedAt, identityErr)
 		return createSessionFailureResult(input, cleanup(identityErr, runtimeCreated, canonicalCreated))
 	}
 	if !railPlacementMatchesSession(input.RailPlacement, canonicalSession) {
 		placementErr := ErrRailPlacementConflict
-		h.observeStep(ctx, "session_create", "session_persisted", session.ID, session.Provider, startedAt, placementErr)
+		h.observeStep(ctx, "session_create", "session_persisted", workspaceID, session.ID, session.Provider, startedAt, placementErr)
 		return createSessionFailureResult(input, cleanup(placementErr, runtimeCreated, canonicalCreated))
 	}
-	h.observeStep(ctx, "session_create", "session_persisted", session.ID, session.Provider, startedAt, nil)
+	h.observeStep(ctx, "session_create", "session_persisted", workspaceID, session.ID, session.Provider, startedAt, nil)
 	startedAt = h.now()
 	published, err := publishRuntimeSessionInitialization(
 		ctx,
@@ -179,17 +179,17 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 		},
 	)
 	if err != nil {
-		h.observeStep(ctx, "session_create", "session_published", session.ID, session.Provider, startedAt, err)
+		h.observeStep(ctx, "session_create", "session_published", workspaceID, session.ID, session.Provider, startedAt, err)
 		return createSessionFailureResult(input, cleanup(err, runtimeCreated, canonicalCreated))
 	}
 	if strings.TrimSpace(published.ID) != strings.TrimSpace(session.ID) ||
 		strings.TrimSpace(published.WorkspaceID) != workspaceID {
 		publishErr := errors.New("publish workspace agent session: runtime session identity mismatch")
-		h.observeStep(ctx, "session_create", "session_published", session.ID, session.Provider, startedAt, publishErr)
+		h.observeStep(ctx, "session_create", "session_published", workspaceID, session.ID, session.Provider, startedAt, publishErr)
 		return createSessionFailureResult(input, cleanup(publishErr, runtimeCreated, canonicalCreated))
 	}
 	session = published
-	h.observeStep(ctx, "session_create", "session_published", session.ID, session.Provider, startedAt, nil)
+	h.observeStep(ctx, "session_create", "session_published", workspaceID, session.ID, session.Provider, startedAt, nil)
 	if len(normalized) == 0 && !isTypedGoal {
 		return CreateSessionResult{Session: session, Canonical: canonicalSession, SessionStatus: CreateSessionStatusCreated, InitialGoalStatus: CreateSessionInitialGoalStatusNotRequested}, nil
 	}
@@ -221,17 +221,17 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 	}
 	startedAt = h.now()
 	if err := h.runtime.ValidatePromptContent(ctx, RuntimeExecInput{WorkspaceID: workspaceID, AgentSessionID: session.ID, Content: normalized}); err != nil {
-		h.observeStep(ctx, "session_create", "prompt_validated", session.ID, session.Provider, startedAt, err)
+		h.observeStep(ctx, "session_create", "prompt_validated", workspaceID, session.ID, session.Provider, startedAt, err)
 		return createSessionFailureResult(input, cleanup(err, runtimeCreated, canonicalCreated))
 	}
-	h.observeStep(ctx, "session_create", "prompt_validated", session.ID, session.Provider, startedAt, nil)
+	h.observeStep(ctx, "session_create", "prompt_validated", workspaceID, session.ID, session.Provider, startedAt, nil)
 	startedAt = h.now()
 	preparedContent, err := h.prepareContent(workspaceID, session.ID, normalized)
 	if err != nil {
-		h.observeStep(ctx, "session_create", "prompt_prepared", session.ID, session.Provider, startedAt, err)
+		h.observeStep(ctx, "session_create", "prompt_prepared", workspaceID, session.ID, session.Provider, startedAt, err)
 		return createSessionFailureResult(input, cleanup(err, runtimeCreated, canonicalCreated))
 	}
-	h.observeStep(ctx, "session_create", "prompt_prepared", session.ID, session.Provider, startedAt, nil)
+	h.observeStep(ctx, "session_create", "prompt_prepared", workspaceID, session.ID, session.Provider, startedAt, nil)
 	displayPrompt := strings.TrimSpace(input.InitialDisplayPrompt)
 	initialTitle := ""
 	if !session.InitialTitleEstablished {
@@ -251,7 +251,7 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 		RequireProviderAcceptance: true,
 	})
 	if err != nil {
-		h.observeStep(ctx, "session_create", "runtime_exec", session.ID, session.Provider, startedAt, err)
+		h.observeStep(ctx, "session_create", "runtime_exec", workspaceID, session.ID, session.Provider, startedAt, err)
 		disposition := execResult.ProviderDispatch.Disposition
 		if disposition == RuntimeDispatchDispositionRejected ||
 			disposition == RuntimeDispatchDispositionApplied ||
@@ -286,7 +286,7 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 	}
 	turnID = strings.TrimSpace(execResult.TurnID)
 	if turnID == "" {
-		h.observeStep(ctx, "session_create", "runtime_exec", session.ID, session.Provider, startedAt, ErrSubmitDeliveryUnknown)
+		h.observeStep(ctx, "session_create", "runtime_exec", workspaceID, session.ID, session.Provider, startedAt, ErrSubmitDeliveryUnknown)
 		return createSessionFailureResult(input, cleanup(ErrSubmitDeliveryUnknown, runtimeCreated, canonicalCreated))
 	}
 	if expectedTurnID := strings.TrimSpace(input.TurnID); expectedTurnID != "" && turnID != expectedTurnID {
@@ -324,7 +324,7 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 	if refreshed, ok, readErr := h.store.GetSession(ctx, workspaceID, session.ID); readErr == nil && ok {
 		canonicalSession = refreshed
 	}
-	h.observeStep(ctx, "session_create", "runtime_exec", session.ID, session.Provider, startedAt, nil)
+	h.observeStep(ctx, "session_create", "runtime_exec", workspaceID, session.ID, session.Provider, startedAt, nil)
 	return CreateSessionResult{Session: session, Canonical: canonicalSession, TurnID: turnID, SessionStatus: CreateSessionStatusCreated, InitialGoalStatus: CreateSessionInitialGoalStatusNotRequested}, nil
 }
 
@@ -527,23 +527,23 @@ func (h *Host) sendInputSerialized(
 	startedAt := h.now()
 	session, err := h.ensureRuntimeSessionLocked(ctx, ref)
 	if err != nil {
-		h.observeStep(ctx, "message_send", "runtime_session_ready", ref.AgentSessionID, "", startedAt, err)
+		h.observeStep(ctx, "message_send", "runtime_session_ready", ref.WorkspaceID, ref.AgentSessionID, "", startedAt, err)
 		return SendInputResult{}, err
 	}
-	h.observeStep(ctx, "message_send", "runtime_session_ready", ref.AgentSessionID, session.Provider, startedAt, nil)
+	h.observeStep(ctx, "message_send", "runtime_session_ready", ref.WorkspaceID, ref.AgentSessionID, session.Provider, startedAt, nil)
 	startedAt = h.now()
 	if err := h.runtime.ValidatePromptContent(ctx, RuntimeExecInput{WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID, Content: normalized}); err != nil {
-		h.observeStep(ctx, "message_send", "prompt_validated", ref.AgentSessionID, session.Provider, startedAt, err)
+		h.observeStep(ctx, "message_send", "prompt_validated", ref.WorkspaceID, ref.AgentSessionID, session.Provider, startedAt, err)
 		return SendInputResult{}, err
 	}
-	h.observeStep(ctx, "message_send", "prompt_validated", ref.AgentSessionID, session.Provider, startedAt, nil)
+	h.observeStep(ctx, "message_send", "prompt_validated", ref.WorkspaceID, ref.AgentSessionID, session.Provider, startedAt, nil)
 	startedAt = h.now()
 	preparedContent, err := h.prepareContent(ref.WorkspaceID, ref.AgentSessionID, normalized)
 	if err != nil {
-		h.observeStep(ctx, "message_send", "prompt_prepared", ref.AgentSessionID, session.Provider, startedAt, err)
+		h.observeStep(ctx, "message_send", "prompt_prepared", ref.WorkspaceID, ref.AgentSessionID, session.Provider, startedAt, err)
 		return SendInputResult{}, err
 	}
-	h.observeStep(ctx, "message_send", "prompt_prepared", ref.AgentSessionID, session.Provider, startedAt, nil)
+	h.observeStep(ctx, "message_send", "prompt_prepared", ref.WorkspaceID, ref.AgentSessionID, session.Provider, startedAt, nil)
 	displayPrompt, initialTitle := strings.TrimSpace(input.DisplayPrompt), ""
 	if !input.Guidance && !session.InitialTitleEstablished {
 		initialTitle = DeriveInitialTitle(session.Title, firstNonEmpty(displayPrompt, promptText, preparedContent.DisplayText))
@@ -551,7 +551,7 @@ func (h *Host) sendInputSerialized(
 	startedAt = h.now()
 	releaseStartup, err := h.acquireStartup(ctx, session.Provider)
 	if err != nil {
-		h.observeStep(ctx, "message_send", "runtime_exec", ref.AgentSessionID, session.Provider, startedAt, err)
+		h.observeStep(ctx, "message_send", "runtime_exec", ref.WorkspaceID, ref.AgentSessionID, session.Provider, startedAt, err)
 		return SendInputResult{}, err
 	}
 	execResult, err := func() (RuntimeExecResult, error) {
@@ -571,7 +571,7 @@ func (h *Host) sendInputSerialized(
 		})
 	}()
 	if err != nil {
-		h.observeStep(ctx, "message_send", "runtime_exec", ref.AgentSessionID, session.Provider, startedAt, err)
+		h.observeStep(ctx, "message_send", "runtime_exec", ref.WorkspaceID, ref.AgentSessionID, session.Provider, startedAt, err)
 		if !input.Guidance && strings.TrimSpace(execResult.TurnID) != "" {
 			if persistErr := h.persistRuntimeSubmitOutcome(
 				ctx, ref, execResult,
@@ -614,7 +614,7 @@ func (h *Host) sendInputSerialized(
 	}
 	turnID := strings.TrimSpace(execResult.TurnID)
 	if turnID == "" {
-		h.observeStep(ctx, "message_send", "runtime_exec", ref.AgentSessionID, session.Provider, startedAt, ErrSubmitDeliveryUnknown)
+		h.observeStep(ctx, "message_send", "runtime_exec", ref.WorkspaceID, ref.AgentSessionID, session.Provider, startedAt, ErrSubmitDeliveryUnknown)
 		return SendInputResult{}, ErrSubmitDeliveryUnknown
 	}
 	if expectedTurnID := strings.TrimSpace(input.TurnID); !input.Guidance && expectedTurnID != "" && turnID != expectedTurnID {
@@ -646,7 +646,7 @@ func (h *Host) sendInputSerialized(
 			return SendInputResult{}, errors.Join(ErrSubmitDeliveryUnknown, err)
 		}
 	}
-	h.observeStep(ctx, "message_send", "runtime_exec", ref.AgentSessionID, session.Provider, startedAt, nil)
+	h.observeStep(ctx, "message_send", "runtime_exec", ref.WorkspaceID, ref.AgentSessionID, session.Provider, startedAt, nil)
 	canonicalSession, ok, err := h.store.GetSession(ctx, ref.WorkspaceID, ref.AgentSessionID)
 	if err != nil {
 		return SendInputResult{}, err

--- a/packages/agent/host/ports.go
+++ b/packages/agent/host/ports.go
@@ -525,7 +525,11 @@ type TerminalFailure struct {
 	ErrorMessage    string
 	ToolNameFamily  string
 	InteractionKind string
-	Retryable       bool
+	// IsChildSession marks provider-native subagent sessions (parent tool call).
+	// Adapters may use it to distinguish child-session turn/tool failures from
+	// root-session ones without a separate event family.
+	IsChildSession bool
+	Retryable      bool
 }
 
 // TerminalFailureObserver receives aggregated terminal failures. It must not

--- a/packages/agent/host/ports.go
+++ b/packages/agent/host/ports.go
@@ -500,8 +500,38 @@ type LifecycleStep struct {
 
 // LifecycleObserver receives diagnostic step outcomes. It must not influence
 // command correctness; durable state remains in CanonicalStore.
+//
+// Adapters must not turn every LifecycleStep into a product analytics event.
+// Prefer TerminalFailureObserver for aggregated failure telemetry.
 type LifecycleObserver interface {
 	ObserveLifecycleStep(context.Context, LifecycleStep)
+}
+
+// TerminalFailure is one aggregated failure fact for product telemetry.
+// Host emits at most one observation per failed command or durable terminal
+// settlement. It carries the failure stage and original error text so adapters
+// can report without depending on user-supplied logs.
+type TerminalFailure struct {
+	Flow            string
+	FailureStage    string
+	WorkspaceID     string
+	AgentSessionID  string
+	TurnID          string
+	OperationID     string
+	ClientSubmitID  string
+	RequestID       string
+	Provider        string
+	ErrorCode       string
+	ErrorMessage    string
+	ToolNameFamily  string
+	InteractionKind string
+	Retryable       bool
+}
+
+// TerminalFailureObserver receives aggregated terminal failures. It must not
+// influence command correctness; durable state remains in CanonicalStore.
+type TerminalFailureObserver interface {
+	ObserveTerminalFailure(context.Context, TerminalFailure)
 }
 
 // CommitObserver is the single post-commit wake surface. Implementations must

--- a/packages/agent/host/terminal_failure.go
+++ b/packages/agent/host/terminal_failure.go
@@ -1,0 +1,241 @@
+package agenthost
+
+import (
+	"context"
+	"strings"
+
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+// ObserveTerminalFailuresFromDelta extracts aggregated terminal failures from an
+// already-committed delta. Adapters that call NotifyCommitted for activity
+// projection should also call this with their TerminalFailureObserver so tool
+// and turn settlements reach product telemetry.
+func ObserveTerminalFailuresFromDelta(ctx context.Context, observer TerminalFailureObserver, delta CommittedDelta) {
+	if observer == nil {
+		return
+	}
+	for _, failure := range terminalFailuresFromDelta(delta) {
+		if failure.ErrorMessage == "" && failure.ErrorCode == "" {
+			continue
+		}
+		observer.ObserveTerminalFailure(ctx, failure)
+	}
+}
+
+func terminalFailuresFromDelta(delta CommittedDelta) []TerminalFailure {
+	failures := make([]TerminalFailure, 0, 4)
+	if delta.RuntimeOperation != nil && delta.RuntimeOperation.Stage == RuntimeOperationFailed {
+		if failure, ok := terminalFailureFromRuntimeOperation(*delta.RuntimeOperation); ok {
+			failures = append(failures, failure)
+		}
+	}
+	if delta.GoalOperation != nil &&
+		(delta.GoalOperation.Stage == GoalOperationFailed || delta.GoalOperation.Stage == GoalOperationTerminal) {
+		if failure, ok := terminalFailureFromGoalOperation(*delta.GoalOperation); ok {
+			failures = append(failures, failure)
+		}
+	}
+	for _, settled := range delta.RootTurnsSettled {
+		if failure, ok := terminalFailureFromRootTurn(settled); ok {
+			failures = append(failures, failure)
+		}
+	}
+	if delta.SessionMessages != nil {
+		failures = append(failures, terminalFailuresFromSessionMessages(*delta.SessionMessages)...)
+	}
+	return failures
+}
+
+func terminalFailureFromRuntimeOperation(committed RuntimeOperationCommitted) (TerminalFailure, bool) {
+	op := committed.Operation
+	flow := runtimeOperationFailureFlow(op.Kind)
+	if flow == "" {
+		return TerminalFailure{}, false
+	}
+	message := strings.TrimSpace(op.LastError)
+	if message == "" {
+		message = strings.TrimSpace(op.Result)
+	}
+	if message == "" {
+		message = "runtime operation failed"
+	}
+	return TerminalFailure{
+		Flow:            flow,
+		FailureStage:    "runtime_exec",
+		WorkspaceID:     strings.TrimSpace(op.WorkspaceID),
+		AgentSessionID:  strings.TrimSpace(op.AgentSessionID),
+		TurnID:          strings.TrimSpace(op.TurnID),
+		OperationID:     strings.TrimSpace(op.OperationID),
+		ClientSubmitID:  runtimeOperationPayloadText(op.Payload, "clientSubmitId"),
+		RequestID:       strings.TrimSpace(op.RequestID),
+		ErrorCode:       strings.TrimSpace(op.Result),
+		ErrorMessage:    message,
+		InteractionKind: runtimeOperationInteractionKind(op),
+		Retryable:       false,
+	}, true
+}
+
+func runtimeOperationFailureFlow(kind string) string {
+	switch strings.TrimSpace(kind) {
+	case storesqlite.RuntimeOperationKindInteractiveResponse:
+		return "interactive_response"
+	case storesqlite.RuntimeOperationKindPlanDecision:
+		return "plan_decision"
+	case storesqlite.RuntimeOperationKindCancelTurn:
+		return "turn_cancel"
+	default:
+		return ""
+	}
+}
+
+func runtimeOperationInteractionKind(op storesqlite.RuntimeOperation) string {
+	if value := runtimeOperationPayloadText(op.Payload, "interactionKind"); value != "" {
+		return value
+	}
+	if op.Kind == storesqlite.RuntimeOperationKindPlanDecision {
+		return storesqlite.InteractionKindPlan
+	}
+	return ""
+}
+
+func terminalFailureFromGoalOperation(committed GoalOperationCommitted) (TerminalFailure, bool) {
+	op := committed.Operation
+	message := strings.TrimSpace(op.LastError)
+	if message == "" {
+		message = strings.TrimSpace(committed.State.LastError)
+	}
+	if message == "" && committed.Stage == GoalOperationTerminal {
+		message = "goal control terminal incident"
+	}
+	if message == "" {
+		return TerminalFailure{}, false
+	}
+	workspaceID := strings.TrimSpace(op.WorkspaceID)
+	sessionID := strings.TrimSpace(op.AgentSessionID)
+	if workspaceID == "" {
+		workspaceID = strings.TrimSpace(committed.State.WorkspaceID)
+	}
+	if sessionID == "" {
+		sessionID = strings.TrimSpace(committed.State.AgentSessionID)
+	}
+	return TerminalFailure{
+		Flow:           "goal_control",
+		FailureStage:   string(committed.Stage),
+		WorkspaceID:    workspaceID,
+		AgentSessionID: sessionID,
+		OperationID:    strings.TrimSpace(op.OperationID),
+		ClientSubmitID: strings.TrimSpace(op.ClientSubmitID),
+		ErrorMessage:   message,
+		Retryable:      false,
+	}, true
+}
+
+func terminalFailureFromRootTurn(settled RootTurnSettled) (TerminalFailure, bool) {
+	outcome := strings.TrimSpace(settled.Turn.Outcome)
+	switch outcome {
+	case storesqlite.TurnOutcomeFailed, storesqlite.TurnOutcomeInterrupted:
+	default:
+		return TerminalFailure{}, false
+	}
+	message := strings.TrimSpace(settled.Turn.ErrorMessage)
+	if message == "" {
+		message = "turn " + outcome
+	}
+	return TerminalFailure{
+		Flow:           "turn",
+		FailureStage:   "settled",
+		WorkspaceID:    strings.TrimSpace(settled.WorkspaceID),
+		AgentSessionID: strings.TrimSpace(settled.AgentSessionID),
+		TurnID:         strings.TrimSpace(settled.Turn.TurnID),
+		ErrorCode:      strings.TrimSpace(settled.Turn.ErrorCode),
+		ErrorMessage:   message,
+		Retryable:      false,
+	}, true
+}
+
+func terminalFailuresFromSessionMessages(committed SessionMessagesCommitted) []TerminalFailure {
+	workspaceID := strings.TrimSpace(committed.Input.WorkspaceID)
+	failures := make([]TerminalFailure, 0)
+	for _, message := range committed.Result.Messages {
+		if !isFailedToolCallMessage(message) {
+			continue
+		}
+		messageText := toolCallFailureMessage(message)
+		failures = append(failures, TerminalFailure{
+			Flow:           "tool_call",
+			FailureStage:   "settled",
+			WorkspaceID:    workspaceID,
+			AgentSessionID: firstNonEmptyTrimmed(message.AgentSessionID, committed.Input.AgentSessionID),
+			TurnID:         strings.TrimSpace(message.TurnID),
+			RequestID:      strings.TrimSpace(message.MessageID),
+			ErrorCode:      strings.TrimSpace(message.Status),
+			ErrorMessage:   messageText,
+			ToolNameFamily: toolNameFamily(message.Payload),
+			Retryable:      false,
+		})
+	}
+	return failures
+}
+
+func isFailedToolCallMessage(message storesqlite.Message) bool {
+	if strings.TrimSpace(message.Kind) != "tool_call" {
+		return false
+	}
+	switch strings.TrimSpace(message.Status) {
+	case "failed", "errored":
+		return true
+	default:
+		return false
+	}
+}
+
+func toolCallFailureMessage(message storesqlite.Message) string {
+	for _, key := range []string{"errorMessage", "error", "message"} {
+		if value := runtimeOperationPayloadText(message.Payload, key); value != "" {
+			return value
+		}
+	}
+	status := strings.TrimSpace(message.Status)
+	if status == "" {
+		return "tool call failed"
+	}
+	return "tool call " + status
+}
+
+func toolNameFamily(payload map[string]any) string {
+	raw := firstNonEmptyTrimmed(
+		runtimeOperationPayloadText(payload, "toolName"),
+		runtimeOperationPayloadText(payload, "name"),
+		runtimeOperationPayloadText(payload, "tool_name"),
+	)
+	if raw == "" {
+		return "unknown"
+	}
+	normalized := strings.ToLower(strings.TrimSpace(raw))
+	normalized = strings.ReplaceAll(normalized, " ", "_")
+	switch {
+	case strings.Contains(normalized, "bash"), strings.Contains(normalized, "shell"), strings.Contains(normalized, "terminal"):
+		return "bash"
+	case strings.Contains(normalized, "edit"), strings.Contains(normalized, "write"), strings.Contains(normalized, "apply_patch"):
+		return "edit"
+	case strings.Contains(normalized, "read"), strings.Contains(normalized, "grep"), strings.Contains(normalized, "glob"), strings.Contains(normalized, "search"):
+		return "read"
+	case strings.Contains(normalized, "browser"), strings.Contains(normalized, "web"):
+		return "browser"
+	default:
+		if len(normalized) > 48 {
+			return normalized[:48]
+		}
+		return normalized
+	}
+}
+
+func firstNonEmptyTrimmed(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/packages/agent/host/terminal_failure.go
+++ b/packages/agent/host/terminal_failure.go
@@ -25,6 +25,16 @@ func ObserveTerminalFailuresFromDelta(ctx context.Context, observer TerminalFail
 
 func terminalFailuresFromDelta(delta CommittedDelta) []TerminalFailure {
 	failures := make([]TerminalFailure, 0, 4)
+	childBySession := map[string]bool{}
+	if delta.ActivityState != nil {
+		sessionID := firstNonEmptyTrimmed(
+			delta.ActivityState.Input.AgentSessionID,
+			delta.ActivityState.Result.RootTurn.AgentSessionID,
+		)
+		if sessionID != "" {
+			childBySession[sessionID] = sessionStateIsChild(delta.ActivityState.Input.State)
+		}
+	}
 	if delta.RuntimeOperation != nil && delta.RuntimeOperation.Stage == RuntimeOperationFailed {
 		if failure, ok := terminalFailureFromRuntimeOperation(*delta.RuntimeOperation); ok {
 			failures = append(failures, failure)
@@ -42,7 +52,7 @@ func terminalFailuresFromDelta(delta CommittedDelta) []TerminalFailure {
 		}
 	}
 	if delta.SessionMessages != nil {
-		failures = append(failures, terminalFailuresFromSessionMessages(*delta.SessionMessages)...)
+		failures = append(failures, terminalFailuresFromSessionMessages(*delta.SessionMessages, childBySession)...)
 	}
 	return failures
 }
@@ -84,6 +94,8 @@ func runtimeOperationFailureFlow(kind string) string {
 		return "plan_decision"
 	case storesqlite.RuntimeOperationKindCancelTurn:
 		return "turn_cancel"
+	case storesqlite.RuntimeOperationKindEditRetry:
+		return "edit_retry"
 	default:
 		return ""
 	}
@@ -150,11 +162,12 @@ func terminalFailureFromRootTurn(settled RootTurnSettled) (TerminalFailure, bool
 		TurnID:         strings.TrimSpace(settled.Turn.TurnID),
 		ErrorCode:      strings.TrimSpace(settled.Turn.ErrorCode),
 		ErrorMessage:   message,
+		IsChildSession: settled.IsChildSession,
 		Retryable:      false,
 	}, true
 }
 
-func terminalFailuresFromSessionMessages(committed SessionMessagesCommitted) []TerminalFailure {
+func terminalFailuresFromSessionMessages(committed SessionMessagesCommitted, childBySession map[string]bool) []TerminalFailure {
 	workspaceID := strings.TrimSpace(committed.Input.WorkspaceID)
 	failures := make([]TerminalFailure, 0)
 	for _, message := range committed.Result.Messages {
@@ -162,16 +175,18 @@ func terminalFailuresFromSessionMessages(committed SessionMessagesCommitted) []T
 			continue
 		}
 		messageText := toolCallFailureMessage(message)
+		sessionID := firstNonEmptyTrimmed(message.AgentSessionID, committed.Input.AgentSessionID)
 		failures = append(failures, TerminalFailure{
 			Flow:           "tool_call",
 			FailureStage:   "settled",
 			WorkspaceID:    workspaceID,
-			AgentSessionID: firstNonEmptyTrimmed(message.AgentSessionID, committed.Input.AgentSessionID),
+			AgentSessionID: sessionID,
 			TurnID:         strings.TrimSpace(message.TurnID),
 			RequestID:      strings.TrimSpace(message.MessageID),
 			ErrorCode:      strings.TrimSpace(message.Status),
 			ErrorMessage:   messageText,
 			ToolNameFamily: toolNameFamily(message.Payload),
+			IsChildSession: childBySession[sessionID],
 			Retryable:      false,
 		})
 	}

--- a/packages/agent/host/terminal_failure_test.go
+++ b/packages/agent/host/terminal_failure_test.go
@@ -120,3 +120,79 @@ func TestTerminalFailuresFromDeltaEmitsPlanDecisionFailures(t *testing.T) {
 		t.Fatalf("failures = %#v", observer.failures)
 	}
 }
+
+func TestTerminalFailuresFromDeltaEmitsEditRetryFailures(t *testing.T) {
+	observer := &recordingTerminalFailureObserver{}
+	ObserveTerminalFailuresFromDelta(context.Background(), observer, CommittedDelta{
+		RuntimeOperation: &RuntimeOperationCommitted{
+			Stage: RuntimeOperationFailed,
+			Operation: storesqlite.RuntimeOperation{
+				WorkspaceID: "ws-1", AgentSessionID: "session-1", OperationID: "op-edit-retry",
+				Kind: storesqlite.RuntimeOperationKindEditRetry, TurnID: "turn-edit",
+				LastError: "edit retry disabled",
+			},
+		},
+	})
+	if len(observer.failures) != 1 || observer.failures[0].Flow != "edit_retry" {
+		t.Fatalf("failures = %#v", observer.failures)
+	}
+}
+
+func TestTerminalFailuresFromDeltaMarksChildSessionTurnAndTool(t *testing.T) {
+	observer := &recordingTerminalFailureObserver{}
+	ObserveTerminalFailuresFromDelta(context.Background(), observer, CommittedDelta{
+		ActivityState: &ActivityStateCommitted{
+			Input: canonical.ReportSessionStateInput{
+				WorkspaceID: "ws-1", AgentSessionID: "child-1",
+				State: canonical.WorkspaceAgentSessionStateUpdate{
+					Kind: storesqlite.SessionKindChild, ParentToolCallID: "call-1",
+				},
+			},
+		},
+		RootTurnsSettled: []RootTurnSettled{{
+			WorkspaceID: "ws-1", AgentSessionID: "child-1", IsChildSession: true,
+			Turn: storesqlite.Turn{
+				TurnID: "turn-child", Outcome: storesqlite.TurnOutcomeFailed,
+				ErrorMessage: "child turn failed",
+			},
+		}},
+		SessionMessages: &SessionMessagesCommitted{
+			Input: canonical.ReportSessionMessagesInput{WorkspaceID: "ws-1", AgentSessionID: "child-1"},
+			Result: storesqlite.MessageReportResult{
+				Messages: []storesqlite.Message{{
+					MessageID: "toolcall:child", AgentSessionID: "child-1", TurnID: "turn-child",
+					Kind: "tool_call", Status: "failed",
+					Payload: map[string]any{"toolName": "Bash", "errorMessage": "child tool failed"},
+				}},
+			},
+		},
+	})
+	if len(observer.failures) != 2 {
+		t.Fatalf("failures = %#v, want 2", observer.failures)
+	}
+	for _, failure := range observer.failures {
+		if !failure.IsChildSession {
+			t.Fatalf("expected child session marker on %#v", failure)
+		}
+	}
+}
+
+func TestObserveGuidanceTargetFailureEmitsAggregatedTerminalFailure(t *testing.T) {
+	observer := &recordingTerminalFailureObserver{}
+	host := New(Config{TerminalFailureObserver: observer})
+	host.observeGuidanceTargetFailure(
+		context.Background(),
+		SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-1"},
+		"codex", "turn-1", "guidance-1", host.now(), ErrActiveTurnTargetMismatch,
+	)
+	if len(observer.failures) != 1 {
+		t.Fatalf("terminal failures = %#v, want 1", observer.failures)
+	}
+	got := observer.failures[0]
+	if got.Flow != "guidance" || got.FailureStage != "guidance_target" || got.TurnID != "turn-1" {
+		t.Fatalf("failure identity = %#v", got)
+	}
+	if got.ErrorCode != "active_turn_target_mismatch" || got.ClientSubmitID != "guidance-1" {
+		t.Fatalf("failure payload = %#v", got)
+	}
+}

--- a/packages/agent/host/terminal_failure_test.go
+++ b/packages/agent/host/terminal_failure_test.go
@@ -1,0 +1,43 @@
+package agenthost
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type recordingTerminalFailureObserver struct {
+	failures []TerminalFailure
+}
+
+func (o *recordingTerminalFailureObserver) ObserveTerminalFailure(_ context.Context, failure TerminalFailure) {
+	o.failures = append(o.failures, failure)
+}
+
+func TestObserveStepEmitsAggregatedTerminalFailure(t *testing.T) {
+	observer := &recordingTerminalFailureObserver{}
+	host := New(Config{TerminalFailureObserver: observer})
+	cause := NewProviderError("provider_timeout", "provider timed out after 30s", "debug", errors.New("deadline"))
+
+	host.observeStep(context.Background(), "message_send", "runtime_exec", "session-1", "claude", host.now(), cause)
+
+	if len(observer.failures) != 1 {
+		t.Fatalf("terminal failures = %d, want 1", len(observer.failures))
+	}
+	got := observer.failures[0]
+	if got.Flow != "message_send" || got.FailureStage != "runtime_exec" || got.AgentSessionID != "session-1" {
+		t.Fatalf("failure identity = %#v", got)
+	}
+	if got.ErrorCode != "provider_timeout" || got.ErrorMessage != "provider timed out after 30s" {
+		t.Fatalf("failure payload = %#v", got)
+	}
+}
+
+func TestObserveStepSkipsTerminalFailureOnSuccess(t *testing.T) {
+	observer := &recordingTerminalFailureObserver{}
+	host := New(Config{TerminalFailureObserver: observer})
+	host.observeStep(context.Background(), "message_send", "runtime_exec", "session-1", "claude", host.now(), nil)
+	if len(observer.failures) != 0 {
+		t.Fatalf("terminal failures = %#v, want none", observer.failures)
+	}
+}

--- a/packages/agent/host/terminal_failure_test.go
+++ b/packages/agent/host/terminal_failure_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+	"github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
 )
 
 type recordingTerminalFailureObserver struct {
@@ -19,13 +22,13 @@ func TestObserveStepEmitsAggregatedTerminalFailure(t *testing.T) {
 	host := New(Config{TerminalFailureObserver: observer})
 	cause := NewProviderError("provider_timeout", "provider timed out after 30s", "debug", errors.New("deadline"))
 
-	host.observeStep(context.Background(), "message_send", "runtime_exec", "session-1", "claude", host.now(), cause)
+	host.observeStep(context.Background(), "message_send", "runtime_exec", "workspace-1", "session-1", "claude", host.now(), cause)
 
 	if len(observer.failures) != 1 {
 		t.Fatalf("terminal failures = %d, want 1", len(observer.failures))
 	}
 	got := observer.failures[0]
-	if got.Flow != "message_send" || got.FailureStage != "runtime_exec" || got.AgentSessionID != "session-1" {
+	if got.Flow != "message_send" || got.FailureStage != "runtime_exec" || got.WorkspaceID != "workspace-1" || got.AgentSessionID != "session-1" {
 		t.Fatalf("failure identity = %#v", got)
 	}
 	if got.ErrorCode != "provider_timeout" || got.ErrorMessage != "provider timed out after 30s" {
@@ -36,8 +39,84 @@ func TestObserveStepEmitsAggregatedTerminalFailure(t *testing.T) {
 func TestObserveStepSkipsTerminalFailureOnSuccess(t *testing.T) {
 	observer := &recordingTerminalFailureObserver{}
 	host := New(Config{TerminalFailureObserver: observer})
-	host.observeStep(context.Background(), "message_send", "runtime_exec", "session-1", "claude", host.now(), nil)
+	host.observeStep(context.Background(), "message_send", "runtime_exec", "workspace-1", "session-1", "claude", host.now(), nil)
 	if len(observer.failures) != 0 {
 		t.Fatalf("terminal failures = %#v, want none", observer.failures)
+	}
+}
+
+func TestTerminalFailuresFromDeltaCoversInteractivePlanToolAndTurn(t *testing.T) {
+	observer := &recordingTerminalFailureObserver{}
+	delta := CommittedDelta{
+		RuntimeOperation: &RuntimeOperationCommitted{
+			Stage: RuntimeOperationFailed,
+			Operation: storesqlite.RuntimeOperation{
+				WorkspaceID: "ws-1", AgentSessionID: "session-1", OperationID: "op-interactive",
+				Kind: storesqlite.RuntimeOperationKindInteractiveResponse, RequestID: "request-1", TurnID: "turn-1",
+				LastError: "interactive submit rejected", Payload: map[string]any{"interactionKind": "plan"},
+			},
+		},
+		GoalOperation: &GoalOperationCommitted{
+			Stage: GoalOperationFailed,
+			Operation: storesqlite.GoalControlOperation{
+				WorkspaceID: "ws-1", AgentSessionID: "session-1", OperationID: "op-goal",
+				ClientSubmitID: "goal-1", LastError: "goal runtime unavailable",
+			},
+		},
+		RootTurnsSettled: []RootTurnSettled{{
+			WorkspaceID: "ws-1", AgentSessionID: "session-1",
+			Turn: storesqlite.Turn{
+				TurnID: "turn-2", Outcome: storesqlite.TurnOutcomeFailed,
+				ErrorCode: "provider_timeout", ErrorMessage: "turn timed out",
+			},
+		}},
+		SessionMessages: &SessionMessagesCommitted{
+			Input: canonical.ReportSessionMessagesInput{WorkspaceID: "ws-1", AgentSessionID: "session-1"},
+			Result: storesqlite.MessageReportResult{
+				Messages: []storesqlite.Message{{
+					MessageID: "toolcall:1", AgentSessionID: "session-1", TurnID: "turn-2",
+					Kind: "tool_call", Status: "failed",
+					Payload: map[string]any{"toolName": "Bash", "errorMessage": "command exited 1"},
+				}},
+			},
+		},
+	}
+
+	ObserveTerminalFailuresFromDelta(context.Background(), observer, delta)
+	if len(observer.failures) != 4 {
+		t.Fatalf("failures = %#v, want 4", observer.failures)
+	}
+	byFlow := map[string]TerminalFailure{}
+	for _, failure := range observer.failures {
+		byFlow[failure.Flow] = failure
+	}
+	if byFlow["interactive_response"].InteractionKind != "plan" || byFlow["interactive_response"].ErrorMessage != "interactive submit rejected" {
+		t.Fatalf("interactive failure = %#v", byFlow["interactive_response"])
+	}
+	if byFlow["goal_control"].ClientSubmitID != "goal-1" || byFlow["goal_control"].ErrorMessage != "goal runtime unavailable" {
+		t.Fatalf("goal failure = %#v", byFlow["goal_control"])
+	}
+	if byFlow["turn"].TurnID != "turn-2" || byFlow["turn"].ErrorCode != "provider_timeout" {
+		t.Fatalf("turn failure = %#v", byFlow["turn"])
+	}
+	if byFlow["tool_call"].ToolNameFamily != "bash" || byFlow["tool_call"].ErrorMessage != "command exited 1" {
+		t.Fatalf("tool failure = %#v", byFlow["tool_call"])
+	}
+}
+
+func TestTerminalFailuresFromDeltaEmitsPlanDecisionFailures(t *testing.T) {
+	observer := &recordingTerminalFailureObserver{}
+	ObserveTerminalFailuresFromDelta(context.Background(), observer, CommittedDelta{
+		RuntimeOperation: &RuntimeOperationCommitted{
+			Stage: RuntimeOperationFailed,
+			Operation: storesqlite.RuntimeOperation{
+				WorkspaceID: "ws-1", AgentSessionID: "session-1", OperationID: "op-plan",
+				Kind: storesqlite.RuntimeOperationKindPlanDecision, TurnID: "turn-plan",
+				LastError: "plan decision send failed",
+			},
+		},
+	})
+	if len(observer.failures) != 1 || observer.failures[0].Flow != "plan_decision" {
+		t.Fatalf("failures = %#v", observer.failures)
 	}
 }

--- a/services/tuttid/service/agent/activity_projection.go
+++ b/services/tuttid/service/agent/activity_projection.go
@@ -31,6 +31,7 @@ type ActivityProjection struct {
 	rootTurnObserver             RootTurnObserver
 	turnForkabilityResolver      TurnForkabilityResolver
 	replayCommitObserver         ReplayCommitObserver
+	terminalFailureObserver      agenthost.TerminalFailureObserver
 	// rootTurnSettleStateObserver is the dedicated, opt-in consumer list for
 	// synthesized canonical root-turn settlement states. It is deliberately
 	// separate from sessionStateObserver: the general observers historically

--- a/services/tuttid/service/agent/activity_projection_commits.go
+++ b/services/tuttid/service/agent/activity_projection_commits.go
@@ -20,6 +20,7 @@ func (p *ActivityProjection) ObserveCommitted(ctx context.Context, delta agentho
 	if p == nil {
 		return nil
 	}
+	agenthost.ObserveTerminalFailuresFromDelta(ctx, p.terminalFailureObserver, delta)
 	if committed := delta.ActivityState; committed != nil {
 		provisional := activityStateIsProvisional(committed.Input)
 		if !provisional {

--- a/services/tuttid/service/agent/activity_projection_replay_commits.go
+++ b/services/tuttid/service/agent/activity_projection_replay_commits.go
@@ -25,6 +25,14 @@ func (p *ActivityProjection) SetReplayCommitObserver(
 	}
 }
 
+func (p *ActivityProjection) SetTerminalFailureObserver(
+	observer agenthost.TerminalFailureObserver,
+) {
+	if p != nil {
+		p.terminalFailureObserver = observer
+	}
+}
+
 func (p *ActivityProjection) notifyReplayCommitted(
 	ctx context.Context,
 	delta agenthost.CommittedDelta,


### PR DESCRIPTION
## Summary
- Add `TerminalFailure` / `TerminalFailureObserver` for one aggregated failure fact per failed command or durable settlement (stage + original error message).
- Emit from failed `session_create` / `message_send` lifecycle commands (with workspace id).
- Emit from goal-control prepare / refresh, plus durable `GoalOperationFailed` / terminal incidents.
- Emit guidance/steer target binding failures (`flow=guidance`, `failure_stage=guidance_target`) when TurnID is missing or the runtime rejects the exact target before provider admission.
- Extract interactive / plan / turn-cancel / `edit_retry` runtime-operation failures, failed root turns, and failed `tool_call` messages from committed deltas via `ObserveTerminalFailuresFromDelta`.
- Mark child/subagent turn and tool failures with `IsChildSession` (no separate subagent event family).
- Wire `ActivityProjection.ObserveCommitted` to forward delta terminal failures when an observer is configured.
- Document adapter mapping guidance and explicit out-of-scope items (queue event family, session fork, file-change card opens, shared-agent product events, parent/child settlement desync).

## Test plan
- [x] `go test ./packages/agent/host -count=1`
- [ ] TSH wires `TerminalFailureObserver` into desktopd Analytics after Tutti release upgrade
- [ ] TSH `CommitObserver` / activity path also calls `ObserveTerminalFailuresFromDelta` if commits bypass Host