### PR TITLE
fix(agent-host): harden terminal failure observer from review

### DIFF
--- a/docs/architecture/analytics-tracking.md
+++ b/docs/architecture/analytics-tracking.md
@@ -480,9 +480,30 @@ Out of scope for dedicated Host terminal-failure flows:
 - file-change card open failures (desktop UI / TSH Analytics only)
 - shared-agent product events (owned by the shared-agent analytics track)
 
-Adapters should map those observations into product analytics events. Call
-`ObserveTerminalFailuresFromDelta` alongside `NotifyCommitted` when activity
-projection commits are not routed through `Host.notifyCommitted`. Do not
+Adapters should map those observations into product analytics events. Do not
 promote every `LifecycleStep` into a product analytics event; lifecycle steps
 remain diagnostic. Terminal failures carry the original error message and
 failure stage for investigation without user-supplied logs.
+
+### Who extracts failures from a committed delta
+
+`Host.notifyCommitted` owns delta terminal failures. It calls
+`ObserveTerminalFailuresFromDelta` before `NotifyCommitted`, so every commit
+Host publishes is already accounted for by the time observers run. A
+`CommitObserver` — `ActivityProjection.ObserveCommitted` included — must never
+re-observe the delta it receives; doing so double-counts every durable runtime,
+goal, turn, and tool-call failure whenever the same observer is wired to both.
+
+A report path that commits and fans out without going through Host calls
+`ObserveTerminalFailuresFromDelta` exactly once next to its own
+`NotifyCommitted`. In tuttid that path is
+`ActivityProjection.observeCommittedOutsideHost`, the single entrypoint for the
+direct activity-state, session-message, and stale-turn reports;
+`ActivityProjection.SetTerminalFailureObserver` exists to feed it. Canonical
+bookkeeping commits (`CanonicalDelta`) carry no failure-bearing sections, so
+they need no extraction.
+
+Because the observed `RuntimeOperations`, `EffectiveHistory`, and `GoalStore`
+wrappers are the only source of durable runtime and goal commit deltas, `New`
+installs them when either `CommitObserver` or `TerminalFailureObserver` is
+configured. An adapter that wants failure analytics alone still gets them.

--- a/packages/agent/daemon/hostadapter/runtime.go
+++ b/packages/agent/daemon/hostadapter/runtime.go
@@ -614,6 +614,12 @@ func mapRuntimeError(err error) error {
 	if errors.Is(err, agentruntime.ErrSessionNotFound) {
 		return errors.Join(host.ErrSessionNotFound, err)
 	}
+	if errors.Is(err, agentruntime.ErrActiveTurnTargetRequired) {
+		return errors.Join(host.ErrActiveTurnTargetRequired, err)
+	}
+	if errors.Is(err, agentruntime.ErrActiveTurnTargetMismatch) {
+		return errors.Join(host.ErrActiveTurnTargetMismatch, err)
+	}
 	if errors.Is(err, agentruntime.ErrEffectiveHistoryUnsupported) {
 		return host.ErrRuntimeHistoryUnsupported
 	}

--- a/packages/agent/daemon/hostadapter/runtime_test.go
+++ b/packages/agent/daemon/hostadapter/runtime_test.go
@@ -183,6 +183,26 @@ func TestMapRuntimeErrorMapsMissingSessionAcrossHostBoundary(t *testing.T) {
 	}
 }
 
+func TestMapRuntimeErrorMapsGuidanceTargetVerdictsAcrossHostBoundary(t *testing.T) {
+	for _, testCase := range []struct {
+		runtimeErr error
+		hostErr    error
+	}{
+		{agentruntime.ErrActiveTurnTargetRequired, host.ErrActiveTurnTargetRequired},
+		{agentruntime.ErrActiveTurnTargetMismatch, host.ErrActiveTurnTargetMismatch},
+	} {
+		t.Run(testCase.runtimeErr.Error(), func(t *testing.T) {
+			mapped := mapRuntimeError(fmt.Errorf("guidance dispatch: %w", testCase.runtimeErr))
+			if !errors.Is(mapped, testCase.hostErr) {
+				t.Fatalf("mapped error = %v, want Host sentinel %v", mapped, testCase.hostErr)
+			}
+			if !errors.Is(mapped, testCase.runtimeErr) {
+				t.Fatalf("mapped error = %v, want source runtime sentinel preserved", mapped)
+			}
+		})
+	}
+}
+
 func TestRuntimeControllerProjectsSessionWithoutAliasingMutableInputs(t *testing.T) {
 	runtimeContext := map[string]any{"mode": "plan"}
 	providerTargetRef := map[string]any{"agent": "codex"}

--- a/packages/agent/host/command_failure.go
+++ b/packages/agent/host/command_failure.go
@@ -1,0 +1,114 @@
+package agenthost
+
+import (
+	"context"
+	"strings"
+	"sync"
+)
+
+// commandPreconditionStage names the boundary emission for a command that
+// failed before it reached any observable lifecycle step: argument validation,
+// submit-claim preparation, send fences, and lock acquisition.
+const commandPreconditionStage = "precondition"
+
+// commandTerminalFailure aggregates one Host command into at most one
+// TerminalFailure. LifecycleStep stays diagnostic; it only records the first
+// failing stage so the command boundary can name where the command broke.
+// A more specific emission inside the command (guidance target, goal control,
+// durable delta) marks the aggregation as already reported.
+type commandTerminalFailure struct {
+	flow string
+
+	mu             sync.Mutex
+	workspaceID    string
+	agentSessionID string
+	provider       string
+	stage          string
+	emitted        bool
+}
+
+type commandTerminalFailureKey struct{}
+
+// beginCommand scopes a terminal-failure aggregation to one Host command. A
+// nested command scopes its own aggregation for its callees only.
+func (h *Host) beginCommand(
+	ctx context.Context,
+	flow, workspaceID, agentSessionID string,
+) (context.Context, *commandTerminalFailure) {
+	command := &commandTerminalFailure{
+		flow:           flow,
+		workspaceID:    strings.TrimSpace(workspaceID),
+		agentSessionID: strings.TrimSpace(agentSessionID),
+	}
+	if h == nil || h.terminalFailure == nil {
+		return ctx, command
+	}
+	return context.WithValue(ctx, commandTerminalFailureKey{}, command), command
+}
+
+func commandTerminalFailureFrom(ctx context.Context) *commandTerminalFailure {
+	command, _ := ctx.Value(commandTerminalFailureKey{}).(*commandTerminalFailure)
+	return command
+}
+
+// recordCommandFailureStage keeps the first failing stage of the running
+// command. Steps from a different flow (notably session_create_cleanup, which
+// runs only after a primary failure) never claim the stage.
+func recordCommandFailureStage(ctx context.Context, flow, workspaceID, agentSessionID, provider, stage string, err error) {
+	command := commandTerminalFailureFrom(ctx)
+	if command == nil || err == nil || command.flow != flow {
+		return
+	}
+	command.mu.Lock()
+	defer command.mu.Unlock()
+	if command.stage != "" {
+		return
+	}
+	command.stage = stage
+	if value := strings.TrimSpace(workspaceID); value != "" {
+		command.workspaceID = value
+	}
+	if value := strings.TrimSpace(agentSessionID); value != "" {
+		command.agentSessionID = value
+	}
+	if value := strings.TrimSpace(provider); value != "" {
+		command.provider = value
+	}
+}
+
+func markCommandTerminalFailureEmitted(ctx context.Context) {
+	command := commandTerminalFailureFrom(ctx)
+	if command == nil {
+		return
+	}
+	command.mu.Lock()
+	command.emitted = true
+	command.mu.Unlock()
+}
+
+// finish emits the single aggregated failure for a command that returned err.
+func (c *commandTerminalFailure) finish(ctx context.Context, h *Host, err error) {
+	if c == nil || err == nil {
+		return
+	}
+	c.mu.Lock()
+	emitted, stage := c.emitted, c.stage
+	failure := TerminalFailure{
+		Flow:           c.flow,
+		WorkspaceID:    c.workspaceID,
+		AgentSessionID: c.agentSessionID,
+		Provider:       c.provider,
+	}
+	c.mu.Unlock()
+	if emitted {
+		return
+	}
+	if stage == "" {
+		stage = commandPreconditionStage
+	}
+	failure.FailureStage = stage
+	failure.ErrorCode = terminalFailureCode(err)
+	failure.ErrorMessage = err.Error()
+	failure.Retryable = isRetryableRuntimeOperationError(err)
+	h.observeTerminalFailure(ctx, failure)
+}

--- a/packages/agent/host/committed_delta.go
+++ b/packages/agent/host/committed_delta.go
@@ -19,6 +19,10 @@ type SessionMessagesCommitted struct {
 	Input  canonical.ReportSessionMessagesInput
 	Reply  canonical.ReportSessionMessagesReply
 	Result storesqlite.MessageReportResult
+	// IsChildSession marks a provider-native subagent session. Message reports
+	// carry no session state, so the reporting adapter resolves it from the
+	// canonical session before publishing the delta.
+	IsChildSession bool
 }
 
 type RootTurnSettled struct {
@@ -26,6 +30,11 @@ type RootTurnSettled struct {
 	AgentSessionID string
 	Turn           storesqlite.Turn
 	IsChildSession bool
+	// StartupReconciled marks a turn force-settled by daemon-start
+	// reconciliation rather than by a live provider settlement. Failure
+	// analytics still count it; runtime fan-out that reacts to a real
+	// completion must skip it.
+	StartupReconciled bool
 }
 
 type RuntimeOperationCommitStage string
@@ -182,6 +191,9 @@ func SessionMessagesDelta(input canonical.ReportSessionMessagesInput, reply cano
 	return delta
 }
 
+// StaleTurnSettlementDelta projects daemon-start reconciliation. Every listed
+// turn was force-settled as interrupted, so it enters RootTurnsSettled with
+// that outcome and the StartupReconciled marker.
 func StaleTurnSettlementDelta(settlements []storesqlite.StaleTurnSettlement) CommittedDelta {
 	delta := CommittedDelta{}
 	if len(settlements) > 0 {
@@ -189,6 +201,25 @@ func StaleTurnSettlementDelta(settlements []storesqlite.StaleTurnSettlement) Com
 	}
 	for _, settlement := range settlements {
 		delta.addView(settlement.WorkspaceID, settlement.AgentSessionID)
+		turnID := strings.TrimSpace(settlement.TurnID)
+		if turnID == "" {
+			continue
+		}
+		workspaceID := strings.TrimSpace(settlement.WorkspaceID)
+		agentSessionID := strings.TrimSpace(settlement.AgentSessionID)
+		delta.RootTurnsSettled = append(delta.RootTurnsSettled, RootTurnSettled{
+			WorkspaceID:    workspaceID,
+			AgentSessionID: agentSessionID,
+			Turn: storesqlite.Turn{
+				WorkspaceID:    workspaceID,
+				AgentSessionID: agentSessionID,
+				TurnID:         turnID,
+				Phase:          storesqlite.TurnPhaseSettled,
+				Outcome:        storesqlite.TurnOutcomeInterrupted,
+				ErrorMessage:   "stale turn settled on daemon startup",
+			},
+			StartupReconciled: true,
+		})
 	}
 	return delta
 }

--- a/packages/agent/host/edit_retry_saga_test.go
+++ b/packages/agent/host/edit_retry_saga_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -430,6 +431,7 @@ type hostEditRetryRuntime struct {
 	execOutcomeUnknownAccepted  bool
 	execNotDispatchedBeforeTurn bool
 	guidanceMismatch            bool
+	guidanceTransportFailure    bool
 	reconcileAcceptanceCalls    int
 	reconcileAcceptanceInput    agenthost.RuntimeProviderTurnAcceptanceInput
 	goalControlCalls            int
@@ -461,6 +463,7 @@ func (r *hostEditRetryRuntime) Exec(ctx context.Context, input agenthost.Runtime
 	outcomeUnknownAccepted := r.execOutcomeUnknownAccepted
 	notDispatchedBeforeTurn := r.execNotDispatchedBeforeTurn
 	guidanceMismatch := r.guidanceMismatch
+	guidanceTransportFailure := r.guidanceTransportFailure
 	r.execOutcomeUnknown = false
 	r.execOutcomeUnknownAccepted = false
 	r.execNotDispatchedBeforeTurn = false
@@ -473,12 +476,22 @@ func (r *hostEditRetryRuntime) Exec(ctx context.Context, input agenthost.Runtime
 	}
 	r.mu.Unlock()
 	if input.Guidance && guidanceMismatch {
+		// The runtime adapter maps its own target verdict onto the Host
+		// sentinel, so the fixture reports the same shape production sees.
 		return agenthost.RuntimeExecResult{
 			TurnID: input.TurnID,
 			ProviderDispatch: agenthost.RuntimeProviderDispatchResult{
 				Disposition: agenthost.RuntimeDispatchDispositionNotDispatched,
 			},
-		}, errors.New("guidance target changed before provider admission")
+		}, fmt.Errorf("%w: guidance target changed before provider admission", agenthost.ErrActiveTurnTargetMismatch)
+	}
+	if input.Guidance && guidanceTransportFailure {
+		return agenthost.RuntimeExecResult{
+			TurnID: input.TurnID,
+			ProviderDispatch: agenthost.RuntimeProviderDispatchResult{
+				Disposition: agenthost.RuntimeDispatchDispositionNotDispatched,
+			},
+		}, errors.New("guidance transport failed before provider admission")
 	}
 	if notDispatchedBeforeTurn {
 		return agenthost.RuntimeExecResult{

--- a/packages/agent/host/guidance_target_test.go
+++ b/packages/agent/host/guidance_target_test.go
@@ -101,3 +101,36 @@ func TestHostGuidanceTargetMismatchCleansPreparedClaim(t *testing.T) {
 		t.Fatalf("guidance terminal failure = %#v", got)
 	}
 }
+
+func TestHostGuidanceTransportFailureReportsMessageSendFailure(t *testing.T) {
+	observer := &recordingGuidanceTerminalFailureObserver{}
+	_, store, runtime := newHostEditRetryFixture(t)
+	host := agenthost.New(agenthost.Config{
+		CanonicalStore:          sqliteCanonicalStore{Store: store},
+		TurnSubmissions:         store,
+		EffectiveHistory:        store,
+		RuntimeOperations:       store,
+		Runtime:                 runtime,
+		HistoryRuntime:          runtime,
+		GoalRuntime:             runtime,
+		OperationOwner:          "worker-1",
+		TerminalFailureObserver: observer,
+	})
+	runtime.mu.Lock()
+	runtime.guidanceTransportFailure = true
+	runtime.mu.Unlock()
+	_, err := host.SendInput(t.Context(), agenthost.SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-1"}, agenthost.SendInput{
+		Content: []agenthost.PromptContentBlock{{Type: "text", Text: "guidance"}}, Guidance: true,
+		TurnID: "turn-original", ClientSubmitID: "guidance-transport",
+	})
+	if err == nil {
+		t.Fatal("SendInput() error = nil, want transport failure")
+	}
+	if len(observer.failures) != 1 {
+		t.Fatalf("terminal failures = %#v, want 1", observer.failures)
+	}
+	got := observer.failures[0]
+	if got.Flow != "message_send" || got.FailureStage != "runtime_exec" {
+		t.Fatalf("guidance transport failure = %#v, want message_send/runtime_exec", got)
+	}
+}

--- a/packages/agent/host/host.go
+++ b/packages/agent/host/host.go
@@ -157,16 +157,20 @@ func New(config Config) *Host {
 	if host.sessionForkRecovery == nil {
 		host.sessionForkRecovery, _ = host.sessionForks.(SessionForkRecoveryStore)
 	}
-	if host.operations != nil && host.commitObserver != nil {
+	// Durable runtime and goal failures reach TerminalFailureObserver through
+	// the same wrappers, so an adapter that wires only failure analytics still
+	// observes them.
+	observesCommits := host.commitObserver != nil || host.terminalFailure != nil
+	if host.operations != nil && observesCommits {
 		host.operations = &observedRuntimeOperationStore{RuntimeOperationStore: host.operations, host: host}
 	}
-	if host.effectiveHistory != nil && host.commitObserver != nil {
+	if host.effectiveHistory != nil && observesCommits {
 		host.effectiveHistory = &observedEffectiveHistoryStore{
 			EffectiveHistoryStore: host.effectiveHistory,
 			host:                  host,
 		}
 	}
-	if host.goals != nil && host.commitObserver != nil {
+	if host.goals != nil && observesCommits {
 		host.goals = &observedGoalStateStore{GoalStateStore: host.goals, host: host}
 	}
 	if registrar, ok := config.GoalRuntime.(GoalRuntimeControlLifecycleRegistrar); ok {
@@ -175,24 +179,16 @@ func New(config Config) *Host {
 	return host
 }
 
+// observeStep reports a diagnostic lifecycle step. A failed step never emits a
+// TerminalFailure on its own; it only names the stage that the enclosing
+// command reports once at its boundary.
 func (h *Host) observeStep(ctx context.Context, flow, name, workspaceID, sessionID, provider string, startedAt time.Time, err error) {
 	if h != nil && h.observer != nil {
 		h.observer.ObserveLifecycleStep(ctx, LifecycleStep{
 			Flow: flow, Name: name, AgentSessionID: sessionID, Provider: provider, StartedAt: startedAt, Err: err,
 		})
 	}
-	if err != nil {
-		h.observeTerminalFailure(ctx, TerminalFailure{
-			Flow:           flow,
-			FailureStage:   name,
-			WorkspaceID:    workspaceID,
-			AgentSessionID: sessionID,
-			Provider:       provider,
-			ErrorCode:      terminalFailureCode(err),
-			ErrorMessage:   err.Error(),
-			Retryable:      isRetryableRuntimeOperationError(err),
-		})
-	}
+	recordCommandFailureStage(ctx, flow, workspaceID, sessionID, provider, name, err)
 }
 
 func (h *Host) observeGuidanceTargetFailure(
@@ -232,6 +228,9 @@ func (h *Host) observeTerminalFailure(ctx context.Context, failure TerminalFailu
 	if failure.ErrorMessage == "" && failure.ErrorCode == "" {
 		return
 	}
+	// A specific emission owns the incident; the enclosing command boundary
+	// must not report the same failure a second time.
+	markCommandTerminalFailureEmitted(ctx)
 	h.terminalFailure.ObserveTerminalFailure(ctx, failure)
 }
 

--- a/packages/agent/host/lifecycle.go
+++ b/packages/agent/host/lifecycle.go
@@ -103,8 +103,11 @@ func (h *Host) createSession(ctx context.Context, workspaceID string, input Crea
 	if h.preparation != nil {
 		preparedAt := h.now()
 		prepared, err = h.preparation.Prepare(ctx, createPreparationInput(workspaceID, input))
-		h.observeStep(ctx, "session_create", "runtime_prepared", workspaceID, input.AgentSessionID, input.Provider, preparedAt, err)
+		// Only observe failures here. Service adapters already emit the success
+		// node_result for runtime_prepared before Host CreateSession; a success
+		// LifecycleStep would duplicate that analytics event.
 		if err != nil {
+			h.observeStep(ctx, "session_create", "runtime_prepared", workspaceID, input.AgentSessionID, input.Provider, preparedAt, err)
 			return createSessionFailureResult(input, err)
 		}
 	}

--- a/packages/agent/host/lifecycle.go
+++ b/packages/agent/host/lifecycle.go
@@ -12,7 +12,16 @@ import (
 	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 )
 
+// CreateSession reports at most one aggregated TerminalFailure for a failed
+// command. Cleanup after a primary failure stays diagnostic.
 func (h *Host) CreateSession(ctx context.Context, workspaceID string, input CreateSessionInput) (CreateSessionResult, error) {
+	ctx, command := h.beginCommand(ctx, "session_create", workspaceID, input.AgentSessionID)
+	result, err := h.createSession(ctx, workspaceID, input)
+	command.finish(ctx, h, err)
+	return result, err
+}
+
+func (h *Host) createSession(ctx context.Context, workspaceID string, input CreateSessionInput) (CreateSessionResult, error) {
 	workspaceID, input.AgentSessionID = strings.TrimSpace(workspaceID), strings.TrimSpace(input.AgentSessionID)
 	input.Provider, input.AgentTargetID = strings.TrimSpace(input.Provider), strings.TrimSpace(input.AgentTargetID)
 	if h == nil || h.runtime == nil || h.store == nil || workspaceID == "" || input.AgentSessionID == "" || input.Provider == "" {
@@ -92,7 +101,9 @@ func (h *Host) CreateSession(ctx context.Context, workspaceID string, input Crea
 
 	prepared := PreparedRuntime{Cwd: strings.TrimSpace(value(input.Cwd))}
 	if h.preparation != nil {
+		preparedAt := h.now()
 		prepared, err = h.preparation.Prepare(ctx, createPreparationInput(workspaceID, input))
+		h.observeStep(ctx, "session_create", "runtime_prepared", workspaceID, input.AgentSessionID, input.Provider, preparedAt, err)
 		if err != nil {
 			return createSessionFailureResult(input, err)
 		}
@@ -444,7 +455,16 @@ func (h *Host) ensureRuntimeSessionLocked(ctx context.Context, ref SessionRef) (
 	return result, nil
 }
 
+// SendInput reports at most one aggregated TerminalFailure for a failed
+// command. Guidance target binding and goal control own their own emissions.
 func (h *Host) SendInput(ctx context.Context, ref SessionRef, input SendInput) (SendInputResult, error) {
+	ctx, command := h.beginCommand(ctx, "message_send", ref.WorkspaceID, ref.AgentSessionID)
+	result, err := h.sendInput(ctx, ref, input)
+	command.finish(ctx, h, err)
+	return result, err
+}
+
+func (h *Host) sendInput(ctx context.Context, ref SessionRef, input SendInput) (SendInputResult, error) {
 	ref.WorkspaceID, ref.AgentSessionID = strings.TrimSpace(ref.WorkspaceID), strings.TrimSpace(ref.AgentSessionID)
 	if h == nil || h.runtime == nil || h.store == nil || ref.WorkspaceID == "" || ref.AgentSessionID == "" {
 		return SendInputResult{}, ErrInvalidArgument
@@ -582,9 +602,11 @@ func (h *Host) sendInputSerialized(
 		})
 	}()
 	if err != nil {
+		// Only an explicit target verdict is a guidance-target failure. Any
+		// other undispatched guidance is an ordinary runtime_exec failure that
+		// the command boundary aggregates.
 		if input.Guidance &&
-			(errors.Is(err, ErrActiveTurnTargetMismatch) ||
-				execResult.ProviderDispatch.Disposition == RuntimeDispatchDispositionNotDispatched) {
+			(errors.Is(err, ErrActiveTurnTargetMismatch) || errors.Is(err, ErrActiveTurnTargetRequired)) {
 			h.observeGuidanceTargetFailure(ctx, ref, session.Provider, input.TurnID, claim.ClientSubmitID, startedAt, err)
 		} else {
 			h.observeStep(ctx, "message_send", "runtime_exec", ref.WorkspaceID, ref.AgentSessionID, session.Provider, startedAt, err)

--- a/packages/agent/host/stale_turn_settlement_test.go
+++ b/packages/agent/host/stale_turn_settlement_test.go
@@ -1,0 +1,65 @@
+package agenthost
+
+import (
+	"context"
+	"testing"
+
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+type recordingStaleTurnFailureObserver struct {
+	failures []TerminalFailure
+}
+
+func (o *recordingStaleTurnFailureObserver) ObserveTerminalFailure(_ context.Context, failure TerminalFailure) {
+	o.failures = append(o.failures, failure)
+}
+
+func TestObserveTerminalFailuresFromStaleTurnSettlementDelta(t *testing.T) {
+	delta := StaleTurnSettlementDelta([]storesqlite.StaleTurnSettlement{
+		{WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-stale"},
+		{WorkspaceID: "ws-1", AgentSessionID: "session-2", TurnID: ""},
+	})
+	if len(delta.RootTurnsSettled) != 1 {
+		t.Fatalf("root turns settled = %#v, want only the settlement carrying a turn", delta.RootTurnsSettled)
+	}
+	settled := delta.RootTurnsSettled[0]
+	if settled.Turn.Phase != storesqlite.TurnPhaseSettled || settled.Turn.Outcome != storesqlite.TurnOutcomeInterrupted {
+		t.Fatalf("settled turn = %#v, want settled phase with interrupted outcome", settled.Turn)
+	}
+	if !settled.StartupReconciled {
+		t.Fatalf("settled turn = %#v, want the startup reconciliation marker", settled)
+	}
+
+	observer := &recordingStaleTurnFailureObserver{}
+	ObserveTerminalFailuresFromDelta(context.Background(), observer, delta)
+	if len(observer.failures) != 1 {
+		t.Fatalf("terminal failures = %#v, want 1", observer.failures)
+	}
+	got := observer.failures[0]
+	if got.Flow != "turn" || got.FailureStage != "settled" {
+		t.Fatalf("failure identity = %#v", got)
+	}
+	if got.WorkspaceID != "ws-1" || got.AgentSessionID != "session-1" || got.TurnID != "turn-stale" {
+		t.Fatalf("failure session identity = %#v", got)
+	}
+	if got.ErrorMessage != "stale turn settled on daemon startup" {
+		t.Fatalf("failure message = %q", got.ErrorMessage)
+	}
+}
+
+func TestStaleTurnSettlementDeltaKeepsChildSessionIdentityFromCallSite(t *testing.T) {
+	delta := StaleTurnSettlementDelta([]storesqlite.StaleTurnSettlement{
+		{WorkspaceID: "ws-1", AgentSessionID: "child-1", TurnID: "turn-stale"},
+	})
+	if len(delta.RootTurnsSettled) != 1 || delta.RootTurnsSettled[0].IsChildSession {
+		t.Fatalf("root turns settled = %#v, want child identity left to the call site", delta.RootTurnsSettled)
+	}
+	delta.RootTurnsSettled[0].IsChildSession = true
+
+	observer := &recordingStaleTurnFailureObserver{}
+	ObserveTerminalFailuresFromDelta(context.Background(), observer, delta)
+	if len(observer.failures) != 1 || !observer.failures[0].IsChildSession {
+		t.Fatalf("terminal failures = %#v, want one child-session turn failure", observer.failures)
+	}
+}

--- a/packages/agent/host/terminal_failure.go
+++ b/packages/agent/host/terminal_failure.go
@@ -7,10 +7,14 @@ import (
 	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 )
 
-// ObserveTerminalFailuresFromDelta extracts aggregated terminal failures from an
-// already-committed delta. Adapters that call NotifyCommitted for activity
-// projection should also call this with their TerminalFailureObserver so tool
-// and turn settlements reach product telemetry.
+// ObserveTerminalFailuresFromDelta extracts aggregated terminal failures from
+// an already-committed delta.
+//
+// Host.notifyCommitted owns this for every delta it publishes, so a
+// CommitObserver must never call it again for the deltas it receives. Only a
+// report path that commits and calls NotifyCommitted without going through
+// Host — the daemon's direct activity-state, session-message, and stale-turn
+// reports — calls it, exactly once, next to its own NotifyCommitted.
 func ObserveTerminalFailuresFromDelta(ctx context.Context, observer TerminalFailureObserver, delta CommittedDelta) {
 	if observer == nil {
 		return
@@ -169,9 +173,19 @@ func terminalFailureFromRootTurn(settled RootTurnSettled) (TerminalFailure, bool
 
 func terminalFailuresFromSessionMessages(committed SessionMessagesCommitted, childBySession map[string]bool) []TerminalFailure {
 	workspaceID := strings.TrimSpace(committed.Input.WorkspaceID)
+	// Result.Messages also carries messages the report replayed without
+	// changing anything. Only a real transition into the failed status is a
+	// new incident.
+	transitioned := make(map[string]struct{}, len(committed.Result.StatusTransitionedMessageIDs))
+	for _, messageID := range committed.Result.StatusTransitionedMessageIDs {
+		transitioned[strings.TrimSpace(messageID)] = struct{}{}
+	}
 	failures := make([]TerminalFailure, 0)
 	for _, message := range committed.Result.Messages {
 		if !isFailedToolCallMessage(message) {
+			continue
+		}
+		if _, ok := transitioned[strings.TrimSpace(message.MessageID)]; !ok {
 			continue
 		}
 		messageText := toolCallFailureMessage(message)
@@ -186,7 +200,7 @@ func terminalFailuresFromSessionMessages(committed SessionMessagesCommitted, chi
 			ErrorCode:      strings.TrimSpace(message.Status),
 			ErrorMessage:   messageText,
 			ToolNameFamily: toolNameFamily(message.Payload),
-			IsChildSession: childBySession[sessionID],
+			IsChildSession: committed.IsChildSession || childBySession[sessionID],
 			Retryable:      false,
 		})
 	}
@@ -206,8 +220,8 @@ func isFailedToolCallMessage(message storesqlite.Message) bool {
 }
 
 func toolCallFailureMessage(message storesqlite.Message) string {
-	for _, key := range []string{"errorMessage", "error", "message"} {
-		if value := runtimeOperationPayloadText(message.Payload, key); value != "" {
+	for _, key := range []string{"error", "errorMessage", "message"} {
+		if value := toolCallPayloadFailureText(message.Payload, key); value != "" {
 			return value
 		}
 	}
@@ -216,6 +230,27 @@ func toolCallFailureMessage(message storesqlite.Message) string {
 		return "tool call failed"
 	}
 	return "tool call " + status
+}
+
+// toolCallPayloadFailureText prefers the provider's own text. Normalized ACP
+// tool failures carry it in a nested body under payload.error, while imported
+// and legacy shapes keep a plain string on the same key.
+func toolCallPayloadFailureText(payload map[string]any, key string) string {
+	if value := runtimeOperationPayloadText(payload, key); value != "" {
+		return value
+	}
+	nested, ok := payload[key].(map[string]any)
+	if !ok {
+		return ""
+	}
+	return firstNonEmptyTrimmed(
+		runtimeOperationPayloadText(nested, "text"),
+		runtimeOperationPayloadText(nested, "message"),
+		runtimeOperationPayloadText(nested, "errorMessage"),
+		runtimeOperationPayloadText(nested, "stderr"),
+		runtimeOperationPayloadText(nested, "stdout"),
+		runtimeOperationPayloadText(nested, "output"),
+	)
 }
 
 func toolNameFamily(payload map[string]any) string {

--- a/packages/agent/host/terminal_failure_test.go
+++ b/packages/agent/host/terminal_failure_test.go
@@ -133,6 +133,7 @@ func TestTerminalFailuresFromDeltaCoversInteractivePlanToolAndTurn(t *testing.T)
 					Kind: "tool_call", Status: "failed",
 					Payload: map[string]any{"toolName": "Bash", "errorMessage": "command exited 1"},
 				}},
+				StatusTransitionedMessageIDs: []string{"toolcall:1"},
 			},
 		},
 	}
@@ -219,6 +220,7 @@ func TestTerminalFailuresFromDeltaMarksChildSessionTurnAndTool(t *testing.T) {
 					Kind: "tool_call", Status: "failed",
 					Payload: map[string]any{"toolName": "Bash", "errorMessage": "child tool failed"},
 				}},
+				StatusTransitionedMessageIDs: []string{"toolcall:child"},
 			},
 		},
 	})
@@ -229,6 +231,119 @@ func TestTerminalFailuresFromDeltaMarksChildSessionTurnAndTool(t *testing.T) {
 		if !failure.IsChildSession {
 			t.Fatalf("expected child session marker on %#v", failure)
 		}
+	}
+}
+
+func TestTerminalFailuresFromDeltaSkipsAlreadyAppliedToolCalls(t *testing.T) {
+	observer := &recordingTerminalFailureObserver{}
+	ObserveTerminalFailuresFromDelta(context.Background(), observer, CommittedDelta{
+		SessionMessages: &SessionMessagesCommitted{
+			Input: canonical.ReportSessionMessagesInput{WorkspaceID: "ws-1", AgentSessionID: "session-1"},
+			Result: storesqlite.MessageReportResult{
+				Messages: []storesqlite.Message{
+					{
+						MessageID: "toolcall:replayed", AgentSessionID: "session-1", TurnID: "turn-1",
+						Kind: "tool_call", Status: "failed",
+						Payload: map[string]any{"toolName": "Bash", "errorMessage": "command exited 1"},
+					},
+					{
+						MessageID: "toolcall:new", AgentSessionID: "session-1", TurnID: "turn-1",
+						Kind: "tool_call", Status: "failed",
+						Payload: map[string]any{"toolName": "Bash", "errorMessage": "command exited 2"},
+					},
+				},
+				StatusTransitionedMessageIDs: []string{"toolcall:new"},
+			},
+		},
+	})
+	if len(observer.failures) != 1 || observer.failures[0].RequestID != "toolcall:new" {
+		t.Fatalf("failures = %#v, want only the newly failed tool call", observer.failures)
+	}
+}
+
+func TestTerminalFailuresFromDeltaMarksChildSessionFromCommittedMessages(t *testing.T) {
+	observer := &recordingTerminalFailureObserver{}
+	ObserveTerminalFailuresFromDelta(context.Background(), observer, CommittedDelta{
+		SessionMessages: &SessionMessagesCommitted{
+			Input:          canonical.ReportSessionMessagesInput{WorkspaceID: "ws-1", AgentSessionID: "child-1"},
+			IsChildSession: true,
+			Result: storesqlite.MessageReportResult{
+				Messages: []storesqlite.Message{{
+					MessageID: "toolcall:child", AgentSessionID: "child-1", TurnID: "turn-child",
+					Kind: "tool_call", Status: "failed",
+					Payload: map[string]any{"toolName": "Bash", "errorMessage": "child tool failed"},
+				}},
+				StatusTransitionedMessageIDs: []string{"toolcall:child"},
+			},
+		},
+	})
+	if len(observer.failures) != 1 || !observer.failures[0].IsChildSession {
+		t.Fatalf("failures = %#v, want one child-session tool failure", observer.failures)
+	}
+}
+
+func TestTerminalFailuresFromDeltaReadsNestedToolErrorText(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload map[string]any
+		want    string
+	}{
+		{
+			name:    "top level string",
+			payload: map[string]any{"toolName": "Bash", "error": "command exited 1"},
+			want:    "command exited 1",
+		},
+		{
+			name:    "nested text",
+			payload: map[string]any{"toolName": "Bash", "error": map[string]any{"text": "Exit code 137", "status": "failed"}},
+			want:    "Exit code 137",
+		},
+		{
+			name:    "nested message",
+			payload: map[string]any{"toolName": "Bash", "error": map[string]any{"message": "permission denied"}},
+			want:    "permission denied",
+		},
+		{
+			name:    "nested error message",
+			payload: map[string]any{"toolName": "Bash", "error": map[string]any{"errorMessage": "tool crashed"}},
+			want:    "tool crashed",
+		},
+		{
+			name:    "nested stderr",
+			payload: map[string]any{"toolName": "Bash", "error": map[string]any{"stderr": "no such file"}},
+			want:    "no such file",
+		},
+		{
+			// acpNormalizeToolOutput keys a scalar provider output as "output".
+			name:    "nested scalar output",
+			payload: map[string]any{"toolName": "Bash", "error": map[string]any{"output": "connection reset"}},
+			want:    "connection reset",
+		},
+		{
+			name:    "no readable text falls back to the status",
+			payload: map[string]any{"toolName": "Bash", "error": map[string]any{"exitCode": 137}},
+			want:    "tool call failed",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			observer := &recordingTerminalFailureObserver{}
+			ObserveTerminalFailuresFromDelta(context.Background(), observer, CommittedDelta{
+				SessionMessages: &SessionMessagesCommitted{
+					Input: canonical.ReportSessionMessagesInput{WorkspaceID: "ws-1", AgentSessionID: "session-1"},
+					Result: storesqlite.MessageReportResult{
+						Messages: []storesqlite.Message{{
+							MessageID: "toolcall:nested", AgentSessionID: "session-1", TurnID: "turn-1",
+							Kind: "tool_call", Status: "failed", Payload: tt.payload,
+						}},
+						StatusTransitionedMessageIDs: []string{"toolcall:nested"},
+					},
+				},
+			})
+			if len(observer.failures) != 1 || observer.failures[0].ErrorMessage != tt.want {
+				t.Fatalf("failures = %#v, want error message %q", observer.failures, tt.want)
+			}
+		})
 	}
 }
 

--- a/packages/agent/host/terminal_failure_test.go
+++ b/packages/agent/host/terminal_failure_test.go
@@ -17,18 +17,22 @@ func (o *recordingTerminalFailureObserver) ObserveTerminalFailure(_ context.Cont
 	o.failures = append(o.failures, failure)
 }
 
-func TestObserveStepEmitsAggregatedTerminalFailure(t *testing.T) {
+func TestCommandBoundaryEmitsOneFailureForTheFirstFailedStep(t *testing.T) {
 	observer := &recordingTerminalFailureObserver{}
 	host := New(Config{TerminalFailureObserver: observer})
 	cause := NewProviderError("provider_timeout", "provider timed out after 30s", "debug", errors.New("deadline"))
 
-	host.observeStep(context.Background(), "message_send", "runtime_exec", "workspace-1", "session-1", "claude", host.now(), cause)
+	ctx, command := host.beginCommand(context.Background(), "message_send", "workspace-1", "session-1")
+	host.observeStep(ctx, "message_send", "runtime_session_ready", "workspace-1", "session-1", "claude", host.now(), cause)
+	host.observeStep(ctx, "message_send", "runtime_exec", "workspace-1", "session-1", "claude", host.now(), errors.New("later stage"))
+	command.finish(ctx, host, cause)
 
 	if len(observer.failures) != 1 {
-		t.Fatalf("terminal failures = %d, want 1", len(observer.failures))
+		t.Fatalf("terminal failures = %#v, want 1", observer.failures)
 	}
 	got := observer.failures[0]
-	if got.Flow != "message_send" || got.FailureStage != "runtime_exec" || got.WorkspaceID != "workspace-1" || got.AgentSessionID != "session-1" {
+	if got.Flow != "message_send" || got.FailureStage != "runtime_session_ready" ||
+		got.WorkspaceID != "workspace-1" || got.AgentSessionID != "session-1" || got.Provider != "claude" {
 		t.Fatalf("failure identity = %#v", got)
 	}
 	if got.ErrorCode != "provider_timeout" || got.ErrorMessage != "provider timed out after 30s" {
@@ -36,12 +40,63 @@ func TestObserveStepEmitsAggregatedTerminalFailure(t *testing.T) {
 	}
 }
 
-func TestObserveStepSkipsTerminalFailureOnSuccess(t *testing.T) {
+func TestObserveStepDoesNotEmitTerminalFailure(t *testing.T) {
 	observer := &recordingTerminalFailureObserver{}
 	host := New(Config{TerminalFailureObserver: observer})
-	host.observeStep(context.Background(), "message_send", "runtime_exec", "workspace-1", "session-1", "claude", host.now(), nil)
+	ctx, _ := host.beginCommand(context.Background(), "message_send", "workspace-1", "session-1")
+	host.observeStep(ctx, "message_send", "runtime_exec", "workspace-1", "session-1", "claude", host.now(), errors.New("boom"))
+	if len(observer.failures) != 0 {
+		t.Fatalf("terminal failures = %#v, want none until the command boundary", observer.failures)
+	}
+}
+
+func TestCommandBoundarySkipsTerminalFailureOnSuccess(t *testing.T) {
+	observer := &recordingTerminalFailureObserver{}
+	host := New(Config{TerminalFailureObserver: observer})
+	ctx, command := host.beginCommand(context.Background(), "message_send", "workspace-1", "session-1")
+	host.observeStep(ctx, "message_send", "runtime_exec", "workspace-1", "session-1", "claude", host.now(), nil)
+	command.finish(ctx, host, nil)
 	if len(observer.failures) != 0 {
 		t.Fatalf("terminal failures = %#v, want none", observer.failures)
+	}
+}
+
+func TestCommandBoundaryIgnoresCleanupStepsAfterPrimaryFailure(t *testing.T) {
+	observer := &recordingTerminalFailureObserver{}
+	host := New(Config{TerminalFailureObserver: observer})
+	primary := errors.New("runtime start failed")
+
+	ctx, command := host.beginCommand(context.Background(), "session_create", "workspace-1", "session-1")
+	host.observeStep(ctx, "session_create", "runtime_started", "workspace-1", "session-1", "codex", host.now(), primary)
+	host.observeStep(ctx, "session_create_cleanup", "runtime_closed", "workspace-1", "session-1", "codex", host.now(), errors.New("cleanup failed"))
+	command.finish(ctx, host, primary)
+
+	if len(observer.failures) != 1 || observer.failures[0].FailureStage != "runtime_started" {
+		t.Fatalf("terminal failures = %#v, want one runtime_started failure", observer.failures)
+	}
+}
+
+func TestCommandBoundaryUsesPreconditionStageWithoutAFailedStep(t *testing.T) {
+	observer := &recordingTerminalFailureObserver{}
+	host := New(Config{TerminalFailureObserver: observer})
+	ctx, command := host.beginCommand(context.Background(), "session_create", "workspace-1", "session-1")
+	command.finish(ctx, host, ErrInvalidArgument)
+	if len(observer.failures) != 1 || observer.failures[0].FailureStage != commandPreconditionStage {
+		t.Fatalf("terminal failures = %#v, want one precondition failure", observer.failures)
+	}
+}
+
+func TestCommandBoundaryDefersToASpecificEmission(t *testing.T) {
+	observer := &recordingTerminalFailureObserver{}
+	host := New(Config{TerminalFailureObserver: observer})
+	ctx, command := host.beginCommand(context.Background(), "message_send", "workspace-1", "session-1")
+	host.observeGuidanceTargetFailure(
+		ctx, SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-1"},
+		"codex", "turn-1", "guidance-1", host.now(), ErrActiveTurnTargetMismatch,
+	)
+	command.finish(ctx, host, ErrActiveTurnTargetMismatch)
+	if len(observer.failures) != 1 || observer.failures[0].Flow != "guidance" {
+		t.Fatalf("terminal failures = %#v, want only the guidance emission", observer.failures)
 	}
 }
 

--- a/packages/agent/host/terminal_failure_wiring_test.go
+++ b/packages/agent/host/terminal_failure_wiring_test.go
@@ -1,0 +1,83 @@
+package agenthost
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+)
+
+type failingRuntimeOperationStore struct {
+	RuntimeOperationStore
+	operation storesqlite.RuntimeOperation
+}
+
+func (s failingRuntimeOperationStore) ReleaseOrFailRuntimeOperation(
+	context.Context,
+	storesqlite.ReleaseOrFailRuntimeOperationInput,
+) (storesqlite.RuntimeOperation, bool, error) {
+	return s.operation, true, nil
+}
+
+type failingEditRetryHistoryStore struct {
+	EffectiveHistoryStore
+	operation storesqlite.RuntimeOperation
+}
+
+func (s failingEditRetryHistoryStore) FailEditRetryRecovery(
+	context.Context,
+	storesqlite.FailEditRetryRecoveryInput,
+) (storesqlite.RuntimeOperation, bool, error) {
+	return s.operation, true, nil
+}
+
+// An adapter that wires failure analytics without a CommitObserver still needs
+// the durable runtime, edit-retry, and goal failures that only reach an
+// observer through the observed store wrappers.
+func TestTerminalFailureObserverOnlyHostObservesDurableCommitFailures(t *testing.T) {
+	observer := &recordingTerminalFailureObserver{}
+	host := New(Config{
+		TerminalFailureObserver: observer,
+		RuntimeOperations: failingRuntimeOperationStore{operation: storesqlite.RuntimeOperation{
+			WorkspaceID: "ws-1", AgentSessionID: "session-1", OperationID: "op-interactive",
+			Kind: storesqlite.RuntimeOperationKindInteractiveResponse, TurnID: "turn-1",
+			LastError: "interactive submit rejected",
+		}},
+		EffectiveHistory: failingEditRetryHistoryStore{operation: storesqlite.RuntimeOperation{
+			WorkspaceID: "ws-1", AgentSessionID: "session-1", OperationID: "op-edit-retry",
+			Kind: storesqlite.RuntimeOperationKindEditRetry, TurnID: "turn-1",
+			LastError: "edit retry recovery failed",
+		}},
+		GoalStore: goalCommitStageStore{releaseOperation: storesqlite.GoalControlOperation{
+			WorkspaceID: "ws-1", AgentSessionID: "session-1", OperationID: "op-goal",
+			LastError: "goal runtime unavailable",
+		}},
+	})
+
+	ctx := context.Background()
+	if _, _, err := host.operations.ReleaseOrFailRuntimeOperation(
+		ctx, storesqlite.ReleaseOrFailRuntimeOperationInput{Fail: true},
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := host.effectiveHistory.FailEditRetryRecovery(
+		ctx, storesqlite.FailEditRetryRecoveryInput{},
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := host.goals.ReleaseGoalControlOperation(
+		ctx, storesqlite.ReleaseGoalControlOperationInput{Fail: true},
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	flows := make([]string, 0, len(observer.failures))
+	for _, failure := range observer.failures {
+		flows = append(flows, failure.Flow)
+	}
+	want := []string{"interactive_response", "edit_retry", "goal_control"}
+	if !slices.Equal(flows, want) {
+		t.Fatalf("failure flows = %#v, want %#v", flows, want)
+	}
+}

--- a/packages/agent/store-sqlite/activity.go
+++ b/packages/agent/store-sqlite/activity.go
@@ -157,7 +157,7 @@ func (s *Store) ReportActivityState(
 					index,
 				)
 			}
-			acceptedMessage, messageAccepted, messageErr := s.upsertAgentMessageTx(
+			acceptedMessage, messageAccepted, _, messageErr := s.upsertAgentMessageTx(
 				ctx, tx, workspaceID, agentSessionID, message, now, false, true,
 			)
 			if messageErr != nil {
@@ -354,7 +354,7 @@ func (s *Store) ReportSessionMessages(
 		if message.MessageID == "" {
 			continue
 		}
-		acceptedMessage, accepted, err := s.upsertAgentMessageTx(ctx, tx, workspaceID, agentSessionID, message, now, allowLegacyTurnless, false)
+		acceptedMessage, accepted, statusTransitioned, err := s.upsertAgentMessageTx(ctx, tx, workspaceID, agentSessionID, message, now, allowLegacyTurnless, false)
 		if err != nil {
 			return MessageReportResult{}, err
 		}
@@ -370,6 +370,9 @@ func (s *Store) ReportSessionMessages(
 		result.AcceptedCount++
 		result.LatestVersion = acceptedMessage.Version
 		result.Messages = append(result.Messages, acceptedMessage)
+		if statusTransitioned {
+			result.StatusTransitionedMessageIDs = append(result.StatusTransitionedMessageIDs, acceptedMessage.MessageID)
+		}
 	}
 
 	historicalTurns := []Turn(nil)

--- a/packages/agent/store-sqlite/activity_message_status_transition_test.go
+++ b/packages/agent/store-sqlite/activity_message_status_transition_test.go
@@ -1,0 +1,72 @@
+package storesqlite
+
+import (
+	"context"
+	"testing"
+)
+
+func TestReportSessionMessagesReportsStatusTransitionOnlyOnce(t *testing.T) {
+	t.Parallel()
+
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	ctx := context.Background()
+	if _, err := store.ReportSessionState(ctx, SessionStateReport{
+		WorkspaceID: "ws-tool", AgentSessionID: "session-tool", Origin: "runtime",
+		Provider: "codex", ProviderSessionID: "provider-tool", Status: "running", OccurredAtUnixMS: 100,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, accepted, err := store.RecordTurnTransition(ctx, TurnTransition{
+		WorkspaceID: "ws-tool", AgentSessionID: "session-tool", TurnID: "turn-1",
+		Phase: TurnPhaseRunning, OccurredAtUnixMS: 101,
+	}); err != nil || !accepted {
+		t.Fatalf("RecordTurnTransition() accepted=%v error=%v", accepted, err)
+	}
+
+	report := func(status string, payload map[string]any, occurredAt int64) MessageReportResult {
+		t.Helper()
+		result, err := store.ReportSessionMessages(ctx, SessionMessageReport{
+			WorkspaceID: "ws-tool", AgentSessionID: "session-tool", Origin: "runtime", Provider: "codex",
+			Messages: []MessageUpdate{{
+				MessageID: "toolcall:1", TurnID: "turn-1", Role: "assistant", Kind: "tool_call",
+				Status: status, Payload: payload, OccurredAtUnixMS: occurredAt,
+			}},
+		})
+		if err != nil {
+			t.Fatalf("ReportSessionMessages(%s) error = %v", status, err)
+		}
+		return result
+	}
+
+	running := report("running", map[string]any{"toolName": "Bash"}, 110)
+	if len(running.StatusTransitionedMessageIDs) != 1 || running.StatusTransitionedMessageIDs[0] != "toolcall:1" {
+		t.Fatalf("first report transitions = %#v, want the created message", running.StatusTransitionedMessageIDs)
+	}
+
+	failed := report("failed", map[string]any{
+		"toolName": "Bash", "error": map[string]any{"text": "Exit code 137"},
+	}, 120)
+	if len(failed.StatusTransitionedMessageIDs) != 1 || failed.StatusTransitionedMessageIDs[0] != "toolcall:1" {
+		t.Fatalf("failed report transitions = %#v, want the first move into failed", failed.StatusTransitionedMessageIDs)
+	}
+
+	replayed := report("failed", map[string]any{
+		"toolName": "Bash", "error": map[string]any{"text": "Exit code 137"},
+	}, 130)
+	if replayed.AcceptedCount != 1 {
+		t.Fatalf("replayed report = %#v, want the already-applied snapshot accepted", replayed)
+	}
+	if len(replayed.StatusTransitionedMessageIDs) != 0 {
+		t.Fatalf("replayed report transitions = %#v, want none", replayed.StatusTransitionedMessageIDs)
+	}
+
+	enriched := report("failed", map[string]any{
+		"toolName": "Bash", "error": map[string]any{"text": "Exit code 137", "stderr": "no such file"},
+	}, 140)
+	if enriched.AcceptedCount != 1 {
+		t.Fatalf("enriched report = %#v, want the payload update accepted", enriched)
+	}
+	if len(enriched.StatusTransitionedMessageIDs) != 0 {
+		t.Fatalf("enriched report transitions = %#v, want none for a payload-only update", enriched.StatusTransitionedMessageIDs)
+	}
+}

--- a/packages/agent/store-sqlite/activity_messages.go
+++ b/packages/agent/store-sqlite/activity_messages.go
@@ -34,6 +34,10 @@ WHERE workspace_id = ? AND agent_session_id = ? AND deleted_at_unix_ms = 0
 	return version, nil
 }
 
+// upsertAgentMessageTx returns whether the update was accepted and, separately,
+// whether it moved the message to a new status. An accepted replay of an
+// already-stored snapshot reports no status transition, so observers that treat
+// a terminal status as an incident do not report it again.
 func (*Store) upsertAgentMessageTx(
 	ctx context.Context,
 	tx *sql.Tx,
@@ -43,17 +47,17 @@ func (*Store) upsertAgentMessageTx(
 	now int64,
 	allowLegacyTurnless bool,
 	protectExisting bool,
-) (Message, bool, error) {
+) (Message, bool, bool, error) {
 	if err := requireSessionForkSourceWritableTx(ctx, tx, workspaceID, agentSessionID); err != nil {
-		return Message{}, false, err
+		return Message{}, false, false, err
 	}
 	existing, ok, err := getAgentMessageForUpdate(ctx, tx, workspaceID, agentSessionID, input.MessageID)
 	if err != nil {
-		return Message{}, false, err
+		return Message{}, false, false, err
 	}
 	normalizedPayload, err := normalizeJSONMap(input.Payload)
 	if err != nil {
-		return Message{}, false, fmt.Errorf("normalize workspace agent message payload: %w", err)
+		return Message{}, false, false, fmt.Errorf("normalize workspace agent message payload: %w", err)
 	}
 	message, accepted := agentactivityprojection.ProjectMessageUpdate(
 		messageProjectionSnapshot(existing),
@@ -74,16 +78,17 @@ func (*Store) upsertAgentMessageTx(
 		now,
 	)
 	if !accepted {
-		return Message{}, false, nil
+		return Message{}, false, false, nil
 	}
 	if ok && agentMessageProjectionAlreadyApplied(existing, message) {
-		return existing, true, nil
+		return existing, true, false, nil
 	}
+	statusTransitioned := !ok || strings.TrimSpace(existing.Status) != strings.TrimSpace(message.Status)
 	if ok && protectExisting {
 		if agentMessageSubmitProvenanceReplay(existing, message, input.Semantics) {
-			return existing, true, nil
+			return existing, true, false, nil
 		}
-		return Message{}, false, fmt.Errorf(
+		return Message{}, false, false, fmt.Errorf(
 			"workspace agent activity message %q conflicts with durable submit provenance",
 			input.MessageID,
 		)
@@ -93,33 +98,33 @@ func (*Store) upsertAgentMessageTx(
 	kind := strings.TrimSpace(message.Kind)
 	if kind == "session_audit" {
 		if turnID != "" {
-			return Message{}, false, fmt.Errorf("workspace agent session audit must not reference turn %q", turnID)
+			return Message{}, false, false, fmt.Errorf("workspace agent session audit must not reference turn %q", turnID)
 		}
 	} else if kind == "collaboration" {
 		if turnID != "" {
-			return Message{}, false, fmt.Errorf("workspace agent collaboration message must not reference turn %q", turnID)
+			return Message{}, false, false, fmt.Errorf("workspace agent collaboration message must not reference turn %q", turnID)
 		}
 	} else if turnID == "" && !allowLegacyTurnless {
-		return Message{}, false, fmt.Errorf("workspace agent message %q kind %q is missing turn", message.MessageID, kind)
+		return Message{}, false, false, fmt.Errorf("workspace agent message %q kind %q is missing turn", message.MessageID, kind)
 	} else if turnID != "" {
 		if _, exists, err := getAgentTurnTx(ctx, tx, workspaceID, agentSessionID, turnID); err != nil {
-			return Message{}, false, err
+			return Message{}, false, false, err
 		} else if !exists {
-			return Message{}, false, fmt.Errorf("workspace agent message references unknown turn %q", turnID)
+			return Message{}, false, false, fmt.Errorf("workspace agent message references unknown turn %q", turnID)
 		}
 	}
 	version, err := incrementAgentSessionMessageVersion(ctx, tx, workspaceID, agentSessionID)
 	if err != nil {
-		return Message{}, false, err
+		return Message{}, false, false, err
 	}
 	message.Version = version
 	payloadJSON, err := json.Marshal(message.Payload)
 	if err != nil {
-		return Message{}, false, fmt.Errorf("encode workspace agent message payload: %w", err)
+		return Message{}, false, false, fmt.Errorf("encode workspace agent message payload: %w", err)
 	}
 	semanticsJSON, err := json.Marshal(messageSemantics)
 	if err != nil {
-		return Message{}, false, fmt.Errorf("encode workspace agent message semantics: %w", err)
+		return Message{}, false, false, fmt.Errorf("encode workspace agent message semantics: %w", err)
 	}
 	_, err = tx.ExecContext(ctx, `
 INSERT INTO workspace_agent_messages (
@@ -145,16 +150,16 @@ ON CONFLICT(workspace_id, agent_session_id, message_id) DO UPDATE SET
 		message.OccurredAtUnixMS, message.StartedAtUnixMS, message.CompletedAtUnixMS,
 		message.CreatedAtUnixMS, message.UpdatedAtUnixMS)
 	if err != nil {
-		return Message{}, false, fmt.Errorf("upsert workspace agent message: %w", err)
+		return Message{}, false, false, fmt.Errorf("upsert workspace agent message: %w", err)
 	}
 	acceptedMessage, ok, err := getAgentMessageForUpdate(ctx, tx, workspaceID, agentSessionID, input.MessageID)
 	if err != nil {
-		return Message{}, false, err
+		return Message{}, false, false, err
 	}
 	if !ok {
-		return Message{}, false, fmt.Errorf("read accepted workspace agent message: %w", sql.ErrNoRows)
+		return Message{}, false, false, fmt.Errorf("read accepted workspace agent message: %w", sql.ErrNoRows)
 	}
-	return acceptedMessage, true, nil
+	return acceptedMessage, true, statusTransitioned, nil
 }
 
 func agentMessageProjectionAlreadyApplied(

--- a/packages/agent/store-sqlite/goal_state.go
+++ b/packages/agent/store-sqlite/goal_state.go
@@ -167,7 +167,7 @@ INSERT INTO workspace_agent_goal_control_operations (
 		input.OccurredAtUnixMS, input.OccurredAtUnixMS, input.ClientSubmitID); err != nil {
 		return GoalControlOperation{}, SessionGoalState{}, false, fmt.Errorf("insert goal control operation: %w", err)
 	}
-	auditMessage, accepted, err := s.upsertAgentMessageTx(
+	auditMessage, accepted, _, err := s.upsertAgentMessageTx(
 		ctx,
 		tx,
 		input.WorkspaceID,

--- a/packages/agent/store-sqlite/repository.go
+++ b/packages/agent/store-sqlite/repository.go
@@ -754,12 +754,17 @@ type MessageUpdate struct {
 }
 
 type MessageReportResult struct {
-	TransactionID    string           `json:"-"`
-	CommitDelta      TransactionDelta `json:"-"`
-	AcceptedCount    int
-	LatestVersion    uint64
-	Messages         []Message
-	RequestBodyBytes int
+	TransactionID string           `json:"-"`
+	CommitDelta   TransactionDelta `json:"-"`
+	AcceptedCount int
+	LatestVersion uint64
+	Messages      []Message
+	// StatusTransitionedMessageIDs lists the accepted messages that actually
+	// moved to a new status in this report. Messages replays a stored snapshot
+	// unchanged as well, so observers that treat a terminal status as an
+	// incident must key on this list instead.
+	StatusTransitionedMessageIDs []string
+	RequestBodyBytes             int
 }
 
 type Message struct {

--- a/services/tuttid/service/agent/activity_projection.go
+++ b/services/tuttid/service/agent/activity_projection.go
@@ -13,9 +13,7 @@ import (
 	replay "github.com/tutti-os/tutti/packages/agent/session-replay"
 	agentactivitybiz "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 	"github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
-	"github.com/tutti-os/tutti/services/tuttid/biz/agentanalytics"
 	reporterservice "github.com/tutti-os/tutti/services/tuttid/service/reporter"
-	agentnoderesult "github.com/tutti-os/tutti/services/tuttid/service/reporter/events/agent/node_result"
 )
 
 type ActivityProjection struct {
@@ -353,113 +351,6 @@ func (p *ActivityProjection) reportSessionState(
 	return reply, nil
 }
 
-func canonicalRailSection(placement *canonical.RailPlacement) *agentactivitybiz.RailSection {
-	if placement == nil {
-		return nil
-	}
-	return &agentactivitybiz.RailSection{
-		Kind:        strings.TrimSpace(placement.Kind),
-		ProjectPath: strings.TrimSpace(placement.ProjectPath),
-		Key:         strings.TrimSpace(placement.SectionKey),
-	}
-}
-
-func (p *ActivityProjection) reportFailedRuntimeNodeResult(ctx context.Context, input canonical.ReportSessionStateInput) {
-	if p == nil || p.analyticsReporter == nil {
-		return
-	}
-	if !isFailedAgentLifecycleStatus(input.State.LifecycleStatus) {
-		return
-	}
-	errorMessage := strings.TrimSpace(input.State.LastError)
-	if errorMessage == "" {
-		errorMessage = "Agent runtime session failed."
-	}
-	agentnoderesult.Track(ctx, p.analyticsReporter, agentnoderesult.BuildParams(agentnoderesult.NodeResultInput{
-		AgentSessionID: input.AgentSessionID,
-		ErrorCode:      classifyRuntimeNodeErrorCode(errorMessage),
-		ErrorMessage:   errorMessage,
-		Flow:           "runtime_activity",
-		Node:           "runtime_exec",
-		Provider:       firstNonEmptyString(input.State.Provider, input.Source.Provider),
-		Status:         "failure",
-	}))
-}
-
-func sessionStateTitle(state canonical.WorkspaceAgentSessionStateUpdate) string {
-	return firstNonEmptyString(
-		state.Title,
-		payloadString(state.RuntimeContext, "title"),
-	)
-}
-
-func activitySessionUpdateEventPayload(workspaceID string, agentSessionID string, lastEventUnixMS int64, agentTargetID ...string) map[string]any {
-	if lastEventUnixMS <= 0 {
-		lastEventUnixMS = time.Now().UnixMilli()
-	}
-	payload := map[string]any{
-		"agentSessionId":  strings.TrimSpace(agentSessionID),
-		"eventType":       "session_reconcile_required",
-		"lastEventUnixMs": lastEventUnixMS,
-		"workspaceId":     strings.TrimSpace(workspaceID),
-	}
-	if len(agentTargetID) > 0 {
-		if value := strings.TrimSpace(agentTargetID[0]); value != "" {
-			payload["agentTargetId"] = value
-		}
-	}
-	return payload
-}
-
-func activitySessionDeletedEventPayload(workspaceID string, agentSessionID string) map[string]any {
-	return map[string]any{
-		"agentSessionId":  strings.TrimSpace(agentSessionID),
-		"deletedAtUnixMs": time.Now().UnixMilli(),
-		"eventType":       "session_deleted",
-		"workspaceId":     strings.TrimSpace(workspaceID),
-	}
-}
-
-func activitySessionRestoredEventPayload(workspaceID string, agentSessionID string) map[string]any {
-	return map[string]any{
-		"agentSessionId":   strings.TrimSpace(agentSessionID),
-		"eventType":        "session_restored",
-		"restoredAtUnixMs": time.Now().UnixMilli(),
-		"workspaceId":      strings.TrimSpace(workspaceID),
-	}
-}
-
-func (p *ActivityProjection) PublishSessionDeleted(ctx context.Context, workspaceID string, agentSessionID string) {
-	p.publishActivityUpdated(ctx, workspaceID, agentSessionID,
-		"session_deleted", activitySessionDeletedEventPayload(workspaceID, agentSessionID))
-}
-
-func isFailedAgentLifecycleStatus(status string) bool {
-	switch strings.ToLower(strings.TrimSpace(status)) {
-	case "failed", "failure", "error", "errored":
-		return true
-	default:
-		return false
-	}
-}
-
-func classifyRuntimeNodeErrorCode(message string) string {
-	normalized := strings.ToLower(strings.TrimSpace(message))
-	if strings.Contains(normalized, "network") ||
-		strings.Contains(normalized, "connection") ||
-		strings.Contains(normalized, "disconnected") ||
-		strings.Contains(normalized, "econnreset") ||
-		strings.Contains(normalized, "socket") {
-		return agentanalytics.ErrorCodeRuntimeNetworkDisconnected
-	}
-	if strings.Contains(normalized, "process") ||
-		strings.Contains(normalized, "exit") ||
-		strings.Contains(normalized, "exited") {
-		return agentanalytics.ErrorCodeRuntimeProcessExited
-	}
-	return agentanalytics.ErrorCodeRuntimeExecFailed
-}
-
 func (p *ActivityProjection) ReportSessionMessages(
 	ctx context.Context,
 	input canonical.ReportSessionMessagesInput,
@@ -520,21 +411,6 @@ func (p *ActivityProjection) reportSessionMessages(
 	p.observeCommittedOutsideHost(ctx, delta)
 	p.notifyReplayCommitted(ctx, delta, replayContext)
 	return reply, nil
-}
-
-// sessionIsChild reports whether a canonical session is a provider-native
-// subagent session.
-func (p *ActivityProjection) sessionIsChild(ctx context.Context, workspaceID, agentSessionID string) bool {
-	workspaceID, agentSessionID = strings.TrimSpace(workspaceID), strings.TrimSpace(agentSessionID)
-	if p == nil || p.repo == nil || workspaceID == "" || agentSessionID == "" {
-		return false
-	}
-	session, found, err := p.repo.GetSession(ctx, workspaceID, agentSessionID)
-	if err != nil || !found {
-		return false
-	}
-	return strings.EqualFold(strings.TrimSpace(session.Kind), agentactivitybiz.SessionKindChild) ||
-		strings.TrimSpace(session.ParentToolCallID) != ""
 }
 
 func (p *ActivityProjection) ReportGoalReconcileRequired(ctx context.Context, input agentsessionstore.ReportGoalReconcileRequiredInput) (agentsessionstore.ReportGoalReconcileRequiredReply, error) {

--- a/services/tuttid/service/agent/activity_projection.go
+++ b/services/tuttid/service/agent/activity_projection.go
@@ -347,7 +347,7 @@ func (p *ActivityProjection) reportSessionState(
 	}
 	if notify {
 		delta := agenthost.ActivityStateDelta(input, reply, activityResult)
-		agenthost.NotifyCommitted(ctx, p, delta)
+		p.observeCommittedOutsideHost(ctx, delta)
 		p.notifyReplayCommitted(ctx, delta, replayContext)
 	}
 	return reply, nil
@@ -510,9 +510,31 @@ func (p *ActivityProjection) reportSessionMessages(
 		RequestBodyBytes: result.RequestBodyBytes,
 	}
 	delta := agenthost.SessionMessagesDelta(input, reply, result)
-	agenthost.NotifyCommitted(ctx, p, delta)
+	if delta.SessionMessages != nil {
+		// A message report carries no session state, so child identity for
+		// failed tool calls has to come from the canonical session.
+		delta.SessionMessages.IsChildSession = p.sessionIsChild(
+			ctx, input.WorkspaceID, canonicalMessageUpdateSessionID(input.AgentSessionID, result.Messages),
+		)
+	}
+	p.observeCommittedOutsideHost(ctx, delta)
 	p.notifyReplayCommitted(ctx, delta, replayContext)
 	return reply, nil
+}
+
+// sessionIsChild reports whether a canonical session is a provider-native
+// subagent session.
+func (p *ActivityProjection) sessionIsChild(ctx context.Context, workspaceID, agentSessionID string) bool {
+	workspaceID, agentSessionID = strings.TrimSpace(workspaceID), strings.TrimSpace(agentSessionID)
+	if p == nil || p.repo == nil || workspaceID == "" || agentSessionID == "" {
+		return false
+	}
+	session, found, err := p.repo.GetSession(ctx, workspaceID, agentSessionID)
+	if err != nil || !found {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(session.Kind), agentactivitybiz.SessionKindChild) ||
+		strings.TrimSpace(session.ParentToolCallID) != ""
 }
 
 func (p *ActivityProjection) ReportGoalReconcileRequired(ctx context.Context, input agentsessionstore.ReportGoalReconcileRequiredInput) (agentsessionstore.ReportGoalReconcileRequiredReply, error) {

--- a/services/tuttid/service/agent/activity_projection_commits.go
+++ b/services/tuttid/service/agent/activity_projection_commits.go
@@ -16,11 +16,15 @@ var _ agenthost.CommitObserver = (*ActivityProjection)(nil)
 // ObserveCommitted is the one post-commit fanout for daemon-local views,
 // analytics, provider ownership cleanup, and event-stream wakeups. Durable
 // delivery never depends on this callback succeeding.
+//
+// It must not extract terminal failures: Host.notifyCommitted already observes
+// the deltas it relays here, and observeCommittedOutsideHost observes the ones
+// that never reach Host. Doing it here too would double-count every durable
+// runtime and goal failure.
 func (p *ActivityProjection) ObserveCommitted(ctx context.Context, delta agenthost.CommittedDelta) error {
 	if p == nil {
 		return nil
 	}
-	agenthost.ObserveTerminalFailuresFromDelta(ctx, p.terminalFailureObserver, delta)
 	if committed := delta.ActivityState; committed != nil {
 		provisional := activityStateIsProvisional(committed.Input)
 		if !provisional {
@@ -46,6 +50,12 @@ func (p *ActivityProjection) ObserveCommitted(ctx context.Context, delta agentho
 		p.observeSessionMessages(ctx, committed.Input, committed.Reply)
 	}
 	for _, settled := range delta.RootTurnsSettled {
+		if settled.StartupReconciled {
+			// Startup reconciliation force-settles every turn left on disk.
+			// Waking the Tutti-mode and automation observers for those would
+			// resume chains the daemon restart already interrupted.
+			continue
+		}
 		p.observeRootTurnSettled(ctx, settled.WorkspaceID, settled.AgentSessionID, settled.Turn)
 	}
 	if committed := delta.GoalOperation; committed != nil && committed.Stage == agenthost.GoalOperationPrepared && committed.Audit != nil {

--- a/services/tuttid/service/agent/activity_projection_reconcile.go
+++ b/services/tuttid/service/agent/activity_projection_reconcile.go
@@ -34,6 +34,10 @@ func (p *ActivityProjection) SettleStaleTurnsOnStartup(ctx context.Context) erro
 		"event", "workspace.agent_turn.stale_settled",
 		"count", len(settlements),
 	)
-	agenthost.NotifyCommitted(ctx, p, agenthost.StaleTurnSettlementDelta(settlements))
+	delta := agenthost.StaleTurnSettlementDelta(settlements)
+	for index, settled := range delta.RootTurnsSettled {
+		delta.RootTurnsSettled[index].IsChildSession = p.sessionIsChild(ctx, settled.WorkspaceID, settled.AgentSessionID)
+	}
+	p.observeCommittedOutsideHost(ctx, delta)
 	return nil
 }

--- a/services/tuttid/service/agent/activity_projection_reconcile.go
+++ b/services/tuttid/service/agent/activity_projection_reconcile.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"strings"
 
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
+	agentactivitybiz "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 )
 
 // SettleStaleTurnsOnStartup is the daemon-start reconciliation of protocol v2
@@ -40,4 +42,19 @@ func (p *ActivityProjection) SettleStaleTurnsOnStartup(ctx context.Context) erro
 	}
 	p.observeCommittedOutsideHost(ctx, delta)
 	return nil
+}
+
+// sessionIsChild reports whether a canonical session is a provider-native
+// subagent session.
+func (p *ActivityProjection) sessionIsChild(ctx context.Context, workspaceID, agentSessionID string) bool {
+	workspaceID, agentSessionID = strings.TrimSpace(workspaceID), strings.TrimSpace(agentSessionID)
+	if p == nil || p.repo == nil || workspaceID == "" || agentSessionID == "" {
+		return false
+	}
+	session, found, err := p.repo.GetSession(ctx, workspaceID, agentSessionID)
+	if err != nil || !found {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(session.Kind), agentactivitybiz.SessionKindChild) ||
+		strings.TrimSpace(session.ParentToolCallID) != ""
 }

--- a/services/tuttid/service/agent/activity_projection_replay_commits.go
+++ b/services/tuttid/service/agent/activity_projection_replay_commits.go
@@ -33,6 +33,21 @@ func (p *ActivityProjection) SetTerminalFailureObserver(
 	}
 }
 
+// observeCommittedOutsideHost publishes a commit that the daemon made without
+// going through Host: direct activity-state, session-message, and stale-turn
+// reports. Host owns terminal-failure extraction for everything it commits, so
+// this is the only place that extracts it for the bypass paths.
+func (p *ActivityProjection) observeCommittedOutsideHost(
+	ctx context.Context,
+	delta agenthost.CommittedDelta,
+) {
+	if p == nil {
+		return
+	}
+	agenthost.ObserveTerminalFailuresFromDelta(ctx, p.terminalFailureObserver, delta)
+	agenthost.NotifyCommitted(ctx, p, delta)
+}
+
 func (p *ActivityProjection) notifyReplayCommitted(
 	ctx context.Context,
 	delta agenthost.CommittedDelta,

--- a/services/tuttid/service/agent/activity_projection_runtime_node.go
+++ b/services/tuttid/service/agent/activity_projection_runtime_node.go
@@ -117,4 +117,3 @@ func classifyRuntimeNodeErrorCode(message string) string {
 	}
 	return agentanalytics.ErrorCodeRuntimeExecFailed
 }
-

--- a/services/tuttid/service/agent/activity_projection_runtime_node.go
+++ b/services/tuttid/service/agent/activity_projection_runtime_node.go
@@ -1,0 +1,120 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	agentactivitybiz "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+	"github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
+	"github.com/tutti-os/tutti/services/tuttid/biz/agentanalytics"
+	agentnoderesult "github.com/tutti-os/tutti/services/tuttid/service/reporter/events/agent/node_result"
+)
+
+func canonicalRailSection(placement *canonical.RailPlacement) *agentactivitybiz.RailSection {
+	if placement == nil {
+		return nil
+	}
+	return &agentactivitybiz.RailSection{
+		Kind:        strings.TrimSpace(placement.Kind),
+		ProjectPath: strings.TrimSpace(placement.ProjectPath),
+		Key:         strings.TrimSpace(placement.SectionKey),
+	}
+}
+
+func (p *ActivityProjection) reportFailedRuntimeNodeResult(ctx context.Context, input canonical.ReportSessionStateInput) {
+	if p == nil || p.analyticsReporter == nil {
+		return
+	}
+	if !isFailedAgentLifecycleStatus(input.State.LifecycleStatus) {
+		return
+	}
+	errorMessage := strings.TrimSpace(input.State.LastError)
+	if errorMessage == "" {
+		errorMessage = "Agent runtime session failed."
+	}
+	agentnoderesult.Track(ctx, p.analyticsReporter, agentnoderesult.BuildParams(agentnoderesult.NodeResultInput{
+		AgentSessionID: input.AgentSessionID,
+		ErrorCode:      classifyRuntimeNodeErrorCode(errorMessage),
+		ErrorMessage:   errorMessage,
+		Flow:           "runtime_activity",
+		Node:           "runtime_exec",
+		Provider:       firstNonEmptyString(input.State.Provider, input.Source.Provider),
+		Status:         "failure",
+	}))
+}
+
+func sessionStateTitle(state canonical.WorkspaceAgentSessionStateUpdate) string {
+	return firstNonEmptyString(
+		state.Title,
+		payloadString(state.RuntimeContext, "title"),
+	)
+}
+
+func activitySessionUpdateEventPayload(workspaceID string, agentSessionID string, lastEventUnixMS int64, agentTargetID ...string) map[string]any {
+	if lastEventUnixMS <= 0 {
+		lastEventUnixMS = time.Now().UnixMilli()
+	}
+	payload := map[string]any{
+		"agentSessionId":  strings.TrimSpace(agentSessionID),
+		"eventType":       "session_reconcile_required",
+		"lastEventUnixMs": lastEventUnixMS,
+		"workspaceId":     strings.TrimSpace(workspaceID),
+	}
+	if len(agentTargetID) > 0 {
+		if value := strings.TrimSpace(agentTargetID[0]); value != "" {
+			payload["agentTargetId"] = value
+		}
+	}
+	return payload
+}
+
+func activitySessionDeletedEventPayload(workspaceID string, agentSessionID string) map[string]any {
+	return map[string]any{
+		"agentSessionId":  strings.TrimSpace(agentSessionID),
+		"deletedAtUnixMs": time.Now().UnixMilli(),
+		"eventType":       "session_deleted",
+		"workspaceId":     strings.TrimSpace(workspaceID),
+	}
+}
+
+func activitySessionRestoredEventPayload(workspaceID string, agentSessionID string) map[string]any {
+	return map[string]any{
+		"agentSessionId":   strings.TrimSpace(agentSessionID),
+		"eventType":        "session_restored",
+		"restoredAtUnixMs": time.Now().UnixMilli(),
+		"workspaceId":      strings.TrimSpace(workspaceID),
+	}
+}
+
+func (p *ActivityProjection) PublishSessionDeleted(ctx context.Context, workspaceID string, agentSessionID string) {
+	p.publishActivityUpdated(ctx, workspaceID, agentSessionID,
+		"session_deleted", activitySessionDeletedEventPayload(workspaceID, agentSessionID))
+}
+
+func isFailedAgentLifecycleStatus(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "failed", "failure", "error", "errored":
+		return true
+	default:
+		return false
+	}
+}
+
+func classifyRuntimeNodeErrorCode(message string) string {
+	normalized := strings.ToLower(strings.TrimSpace(message))
+	if strings.Contains(normalized, "network") ||
+		strings.Contains(normalized, "connection") ||
+		strings.Contains(normalized, "disconnected") ||
+		strings.Contains(normalized, "econnreset") ||
+		strings.Contains(normalized, "socket") {
+		return agentanalytics.ErrorCodeRuntimeNetworkDisconnected
+	}
+	if strings.Contains(normalized, "process") ||
+		strings.Contains(normalized, "exit") ||
+		strings.Contains(normalized, "exited") {
+		return agentanalytics.ErrorCodeRuntimeProcessExited
+	}
+	return agentanalytics.ErrorCodeRuntimeExecFailed
+}
+

--- a/services/tuttid/service/agent/activity_projection_terminal_failure_test.go
+++ b/services/tuttid/service/agent/activity_projection_terminal_failure_test.go
@@ -1,0 +1,145 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+	agenthost "github.com/tutti-os/tutti/packages/agent/host"
+	agentactivitybiz "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+	"github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
+)
+
+type recordingAgentTerminalFailureObserver struct {
+	failures []agenthost.TerminalFailure
+}
+
+func (o *recordingAgentTerminalFailureObserver) ObserveTerminalFailure(
+	_ context.Context,
+	failure agenthost.TerminalFailure,
+) {
+	o.failures = append(o.failures, failure)
+}
+
+type sessionKindRepoStub struct {
+	*activityProjectionRepoStub
+	session agentactivitybiz.Session
+}
+
+func (r *sessionKindRepoStub) GetSession(
+	_ context.Context,
+	_ string,
+	_ string,
+) (agentactivitybiz.Session, bool, error) {
+	return r.session, true, nil
+}
+
+// A live provider reports a failed tool call through ReportSessionMessages
+// alone: there is no session state on that path, so child identity has to come
+// from the canonical session.
+func TestReportSessionMessagesMarksChildSessionToolFailures(t *testing.T) {
+	tests := []struct {
+		name    string
+		session agentactivitybiz.Session
+		want    bool
+	}{
+		{
+			name:    "child session by kind",
+			session: agentactivitybiz.Session{ID: "session-1", Kind: agentactivitybiz.SessionKindChild},
+			want:    true,
+		},
+		{
+			name:    "child session by parent tool call",
+			session: agentactivitybiz.Session{ID: "session-1", ParentToolCallID: "call-1"},
+			want:    true,
+		},
+		{
+			name:    "root session",
+			session: agentactivitybiz.Session{ID: "session-1", Kind: agentactivitybiz.SessionKindRoot},
+			want:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &sessionKindRepoStub{
+				activityProjectionRepoStub: &activityProjectionRepoStub{
+					messageResult: agentactivitybiz.MessageReportResult{
+						AcceptedCount: 1,
+						LatestVersion: 1,
+						Messages: []agentactivitybiz.Message{{
+							AgentSessionID: "session-1", MessageID: "toolcall:1", Version: 1, TurnID: "turn-1",
+							Role: "assistant", Kind: "tool_call", Status: "failed",
+							Payload: map[string]any{
+								"toolName": "Bash",
+								"error":    map[string]any{"text": "Exit code 137"},
+							},
+						}},
+						StatusTransitionedMessageIDs: []string{"toolcall:1"},
+					},
+				},
+				session: tt.session,
+			}
+			observer := &recordingAgentTerminalFailureObserver{}
+			projection := NewActivityProjection(repo)
+			projection.SetTerminalFailureObserver(observer)
+
+			if _, err := projection.ReportSessionMessages(context.Background(), canonical.ReportSessionMessagesInput{
+				WorkspaceID:    "ws-1",
+				AgentSessionID: "session-1",
+				SessionOrigin:  agentsessionstore.WorkspaceAgentSessionOriginRuntime,
+				Source:         canonical.EventSource{Provider: "codex"},
+				Updates: []canonical.WorkspaceAgentSessionMessageUpdate{{
+					MessageID: "toolcall:1", TurnID: "turn-1", Role: "assistant", Kind: "tool_call", Status: "failed",
+				}},
+			}); err != nil {
+				t.Fatalf("ReportSessionMessages() error = %v", err)
+			}
+
+			if len(observer.failures) != 1 {
+				t.Fatalf("terminal failures = %#v, want 1", observer.failures)
+			}
+			got := observer.failures[0]
+			if got.Flow != "tool_call" || got.ErrorMessage != "Exit code 137" || got.ToolNameFamily != "bash" {
+				t.Fatalf("tool failure = %#v", got)
+			}
+			if got.IsChildSession != tt.want {
+				t.Fatalf("IsChildSession = %v, want %v", got.IsChildSession, tt.want)
+			}
+		})
+	}
+}
+
+func TestReportSessionMessagesSkipsReplayedToolFailures(t *testing.T) {
+	repo := &sessionKindRepoStub{
+		activityProjectionRepoStub: &activityProjectionRepoStub{
+			messageResult: agentactivitybiz.MessageReportResult{
+				AcceptedCount: 1,
+				LatestVersion: 1,
+				Messages: []agentactivitybiz.Message{{
+					AgentSessionID: "session-1", MessageID: "toolcall:1", Version: 1, TurnID: "turn-1",
+					Role: "assistant", Kind: "tool_call", Status: "failed",
+					Payload: map[string]any{"toolName": "Bash", "error": map[string]any{"text": "Exit code 137"}},
+				}},
+			},
+		},
+		session: agentactivitybiz.Session{ID: "session-1", Kind: agentactivitybiz.SessionKindRoot},
+	}
+	observer := &recordingAgentTerminalFailureObserver{}
+	projection := NewActivityProjection(repo)
+	projection.SetTerminalFailureObserver(observer)
+
+	if _, err := projection.ReportSessionMessages(context.Background(), canonical.ReportSessionMessagesInput{
+		WorkspaceID:    "ws-1",
+		AgentSessionID: "session-1",
+		SessionOrigin:  agentsessionstore.WorkspaceAgentSessionOriginRuntime,
+		Source:         canonical.EventSource{Provider: "codex"},
+		Updates: []canonical.WorkspaceAgentSessionMessageUpdate{{
+			MessageID: "toolcall:1", TurnID: "turn-1", Role: "assistant", Kind: "tool_call", Status: "failed",
+		}},
+	}); err != nil {
+		t.Fatalf("ReportSessionMessages() error = %v", err)
+	}
+	if len(observer.failures) != 0 {
+		t.Fatalf("terminal failures = %#v, want none for a replayed failed tool call", observer.failures)
+	}
+}


### PR DESCRIPTION
## Summary
- Aggregate at most one `TerminalFailure` per failed `CreateSession` / `SendInput` command; lifecycle steps stay diagnostic.
- Stop double-observing committed deltas from `ActivityProjection` when Host already owns extraction; wrap observed stores when only `TerminalFailureObserver` is configured.
- Key tool-call failures on the real session-message path (child-session identity, first status transition, nested `error.text`).
- Cover startup stale interrupted turns and map production guidance target verdicts through hostadapter.
- Avoid duplicate `runtime_prepared` success node_results when Service already reported the prepare step.

## Test plan
- [x] `go test ./packages/agent/host ./packages/agent/daemon/hostadapter ./services/tuttid/service/agent -count=1`
- [x] `TestServiceCreateReportsNodeResults` no longer double-emits `runtime_prepared`


Made with [Cursor](https://cursor.com)