### PR TITLE
fix(agent): align CodeBuddy full access permissions

### DIFF
--- a/docs/architecture/agent-extensions.md
+++ b/docs/architecture/agent-extensions.md
@@ -128,6 +128,18 @@ scope. When no project is selected, it uses the daemon-owned discovery directory
 under `<state>/agent/discovery/<provider>`, because standard ACP session creation
 requires a concrete working directory.
 
+A signed Composer permission mode may declare `automaticDecision: "approved"`
+only with the `full-access` semantic, or `automaticDecision: "denied"` with a
+`read-only` or `locked-down` semantic. The Standard ACP adapter applies that
+decision to execution-authorization callbacks using the session's exact live
+runtime mode. It does not apply automatic permission decisions to
+`AskUserQuestion`, `ExitPlanMode`, or other canonical interactive prompts:
+full access removes repeated execution approval, but it does not answer a
+question or make a workflow decision for the user. Multiple runtime IDs may
+share one semantic, so an extension that intends to approve only one of them
+must declare the decision on that exact runtime ID and preserve the other IDs
+unchanged.
+
 ### Spawn Settings And ACP Workflow Modes
 
 Composer profile v1 has an optional, closed `launchSettings.permission`

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -1282,6 +1282,45 @@ file or directory`. A failed `codex app-server` probe is diagnostic evidence,
   proving bypass mode allows an ordinary Bash request without
   `approval_requested`, while `AskUserQuestion` still surfaces user input.
 
+### CodeBuddy fullAccess still requests execution approval
+
+- Symptom:
+  A CodeBuddy extension session reports `permissionModeId=fullAccess`, and
+  `session/set_mode` succeeds, but ordinary file or command operations still
+  create a Tutti waiting-approval interaction.
+- Quick checks:
+  Inspect the session-pinned extension installation and its
+  `profiles/composer.json`. Confirm that `fullAccess` is preserved as the exact
+  runtime ID, rather than collapsed into `bypassPermissions`, and check whether
+  that mode declares `automaticDecision: "approved"`. In ACP logs, distinguish
+  a residual `session/request_permission` authorization callback from an
+  `AskUserQuestion` or `ExitPlanMode` interaction.
+- Root cause:
+  `session/set_mode` configures CodeBuddy's permission tier, but an ACP runtime
+  may still emit a permission callback. Tutti resolves such a callback
+  automatically only when the signed Composer profile declares the live
+  runtime mode's automatic decision. Without that declaration, the generic ACP
+  adapter correctly falls back to a manual approval. Treating every callback
+  as approval is also unsafe because ACP carries user questions and workflow
+  transitions through the same request method.
+- Fix:
+  Publish a new signed CodeBuddy extension release whose exact `fullAccess`
+  mode declares `automaticDecision: "approved"`; leave
+  `bypassPermissions` and all other runtime IDs unchanged. The Standard ACP
+  adapter must apply the decision only to execution authorization and preserve
+  canonical interactive prompts. Do not patch an installed signed package or
+  add a CodeBuddy provider branch to the daemon. Sessions remain pinned to
+  their installation, so recreate sessions that still reference the previous
+  extension version.
+- Validation:
+  In a new session pinned to the updated extension, confirm the runtime receives
+  `session/set_mode` with `modeId=fullAccess`. Trigger an ordinary write and a
+  dangerous command and verify both complete without `waiting_approval`.
+  Trigger `AskUserQuestion` and verify it still publishes exactly one canonical
+  question interaction and waits for the user's answer. Confirm
+  `bypassPermissions` has no automatic decision and that other permission
+  modes behave unchanged.
+
 ### Extension session create rejects a semantic permission id
 
 - Symptom:

--- a/packages/agent/daemon/runtime/acp_pending.go
+++ b/packages/agent/daemon/runtime/acp_pending.go
@@ -29,6 +29,19 @@ func acpPermissionRequestDecisionOptionID(
 	return resolveACPPermissionDecisionOptionID(params.Options, decision)
 }
 
+// acpPermissionRequestIsInteractive distinguishes workflow/user-input prompts
+// from execution authorization. Automatic permission tiers may resolve the
+// latter, but must never choose an answer or workflow transition for the user.
+func acpPermissionRequestIsInteractive(raw json.RawMessage) bool {
+	var params struct {
+		ToolCall map[string]any `json:"toolCall"`
+	}
+	if err := json.Unmarshal(raw, &params); err != nil {
+		return false
+	}
+	return normalizedInteractiveToolName(params.ToolCall) != ""
+}
+
 func resolveACPPermissionDecisionOptionID(options []map[string]any, decision string) (string, bool) {
 	aliases := permissionOptionDecisionAliases(decision)
 	if len(aliases) == 0 {

--- a/packages/agent/daemon/runtime/standard_acp_interactive_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_interactive_test.go
@@ -2,6 +2,7 @@ package agentruntime
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"sync"
@@ -10,6 +11,83 @@ import (
 
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
+
+func TestACPPermissionRequestInteractiveClassification(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{name: "ask user", raw: `{"toolCall":{"title":"AskUserQuestion"}}`, want: true},
+		{name: "exit plan", raw: `{"toolCall":{"name":"exit_plan_mode"}}`, want: true},
+		{name: "ordinary authorization", raw: `{"toolCall":{"title":"Allow Bash"}}`, want: false},
+		{name: "invalid request", raw: `{`, want: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := acpPermissionRequestIsInteractive(json.RawMessage(test.raw)); got != test.want {
+				t.Fatalf("acpPermissionRequestIsInteractive() = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
+func TestStandardACPAdapterAutomaticPermissionTierPreservesAskUserPrompt(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Hermes Agent", "hermes-session-auto-ask-user")
+	transport.conn.promptKind = "ask-user-after-permission"
+	adapter := newHermesExtensionTestAdapter(transport)
+	session := standardTestSession(hermesExtensionTestProvider)
+	session.PermissionModeID = "yolo"
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	session.ProviderSessionID = "hermes-session-auto-ask-user"
+
+	execDone := make(chan error, 1)
+	go func() {
+		_, err := adapter.Exec(context.Background(), session, textPrompt("ask how I feel"), "", "turn-auto-ask-user", func([]activityshared.Event) {}, nil)
+		execDone <- err
+	}()
+
+	waitForCondition(t, func() bool {
+		snapshot := adapter.SessionState(session)
+		return snapshot.PendingInteractive != nil &&
+			snapshot.PendingInteractive.Kind == "ask-user" &&
+			snapshot.PendingInteractive.RequestID == "permission-1"
+	})
+	if got := transport.conn.permissionOptionID(); got != "" {
+		t.Fatalf("permission option id before user input = %q, want empty", got)
+	}
+
+	if _, err := adapter.SubmitInteractive(context.Background(), session, SubmitInteractiveInput{
+		RoomID:         session.RoomID,
+		AgentSessionID: session.AgentSessionID,
+		TurnID:         "turn-auto-ask-user",
+		RequestID:      "permission-1",
+		Action:         "submit",
+		Payload: map[string]any{
+			"answers":             []any{"很好"},
+			"answersByQuestionId": map[string]any{"question-1": "很好"},
+		},
+	}); err != nil {
+		t.Fatalf("SubmitInteractive: %v", err)
+	}
+	select {
+	case err := <-execDone:
+		if err != nil {
+			t.Fatalf("Exec after interactive submission: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Exec did not finish after interactive submission")
+	}
+	if got := transport.conn.permissionOptionID(); got != "q0_opt_0" {
+		t.Fatalf("permission option id after user input = %q, want q0_opt_0", got)
+	}
+}
 
 func TestStandardACPAdapterSessionStateExposesPendingAskUserPrompt(t *testing.T) {
 	t.Parallel()

--- a/packages/agent/daemon/runtime/standard_acp_stream.go
+++ b/packages/agent/daemon/runtime/standard_acp_stream.go
@@ -106,10 +106,12 @@ func (a *standardACPAdapter) handleACPMessage(
 			_ = client.Respond(ctx, message.ID, nil, &acpError{Code: -32000, Message: err.Error()})
 			return nil, err
 		}
-		// Automatic tiers resolve the request from the live permission tier
-		// without prompting; the tool call still streams its own activity via
-		// session/update.
-		if decision := a.automaticPermissionDecision(session.AgentSessionID); decision != "" {
+		// Automatic tiers resolve execution authorization from the live
+		// permission tier without prompting; the tool call still streams its own
+		// activity via session/update. Interactive requests such as
+		// AskUserQuestion and ExitPlanMode remain user-owned decisions.
+		if decision := a.automaticPermissionDecision(session.AgentSessionID); decision != "" &&
+			!acpPermissionRequestIsInteractive(message.Params) {
 			if optionID, ok := acpPermissionRequestDecisionOptionID(
 				message.Params,
 				decision,

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
@@ -11,6 +11,7 @@ import { enAgentGuiCollaboration } from "./en.agentGuiCollaboration.ts";
 import { enAgentGuiUsageStatus } from "./en.agentGuiUsageStatus.ts";
 import { enAgentGuiComposer } from "./en.agentGuiComposer.ts";
 import { enAgentGuiProjectLaunch } from "./en.agentGuiProjectLaunch.ts";
+import { enAgentGuiProviderPermissionModes } from "./en.agentGuiProviderPermissionModes.ts";
 
 export const enAgentGui = {
   imageDownloaded: "Image downloaded",
@@ -229,21 +230,7 @@ export const enAgentGui = {
           "Automatically allows gated actions without changing OpenCode's separate Plan mode restrictions."
       }
     },
-    nexight: {
-      "read-only": {
-        label: "Ask for approval",
-        description: "Always ask to edit external files and use the internet"
-      },
-      auto: {
-        label: "Approve for me",
-        description: "Only ask for actions detected as potentially unsafe"
-      },
-      "full-access": {
-        label: "Full access",
-        description:
-          "Unrestricted access to the internet and any file on your computer"
-      }
-    },
+    ...enAgentGuiProviderPermissionModes,
     "claude-code": {
       default: {
         label: "Default",

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGuiProviderPermissionModes.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGuiProviderPermissionModes.ts
@@ -1,0 +1,38 @@
+export const enAgentGuiProviderPermissionModes = {
+  nexight: {
+    "read-only": {
+      label: "Ask for approval",
+      description: "Always ask to edit external files and use the internet"
+    },
+    auto: {
+      label: "Approve for me",
+      description: "Only ask for actions detected as potentially unsafe"
+    },
+    "full-access": {
+      label: "Full access",
+      description:
+        "Unrestricted access to the internet and any file on your computer"
+    }
+  },
+  "acp:codebuddy": {
+    dontAsk: {
+      label: "Don't ask",
+      description:
+        "Won't prompt for approval. Actions not already allowed are rejected."
+    },
+    bypassPermissions: {
+      label: "Skip permission prompts",
+      description: "Skips permission prompts while keeping safety checks."
+    },
+    fullAccess: {
+      label: "Full access",
+      description:
+        "Skips all permission checks, including dangerous commands, for every agent."
+    },
+    plan: {
+      label: "Plan mode",
+      description:
+        "Analyzes and plans without modifying files or running commands."
+    }
+  }
+};

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
@@ -10,6 +10,7 @@ import { zhCNAgentGuiCollaboration } from "./zh-CN.agentGuiCollaboration.ts";
 import { zhCNTuttiModePlan } from "./zh-CN.tuttiModePlan.ts";
 import { zhCNAgentGuiComposer } from "./zh-CN.agentGuiComposer.ts";
 import { zhCNAgentGuiProjectLaunch } from "./zh-CN.agentGuiProjectLaunch.ts";
+import { zhCNAgentGuiProviderPermissionModes } from "./zh-CN.agentGuiProviderPermissionModes.ts";
 export const zhCNAgentGui = {
   imageDownloaded: "图片已下载",
   imageLoadFailed: "图片加载失败",
@@ -214,20 +215,7 @@ export const zhCNAgentGui = {
           "自动允许需授权操作，但不会改变 OpenCode 独立的 Plan 模式限制"
       }
     },
-    nexight: {
-      "read-only": {
-        label: "请求批准",
-        description: "编辑外部文件或使用互联网前始终询问你"
-      },
-      auto: {
-        label: "替我审批",
-        description: "仅在检测到可能不安全的操作时询问你"
-      },
-      "full-access": {
-        label: "完全访问",
-        description: "可不受限制地访问互联网和你电脑上的任何文件"
-      }
-    },
+    ...zhCNAgentGuiProviderPermissionModes,
     "claude-code": {
       default: {
         label: "默认权限",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGuiProviderPermissionModes.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGuiProviderPermissionModes.ts
@@ -1,0 +1,34 @@
+export const zhCNAgentGuiProviderPermissionModes = {
+  nexight: {
+    "read-only": {
+      label: "请求批准",
+      description: "编辑外部文件或使用互联网前始终询问你"
+    },
+    auto: {
+      label: "替我审批",
+      description: "仅在检测到可能不安全的操作时询问你"
+    },
+    "full-access": {
+      label: "完全访问",
+      description: "可不受限制地访问互联网和你电脑上的任何文件"
+    }
+  },
+  "acp:codebuddy": {
+    dontAsk: {
+      label: "不再询问",
+      description: "不会弹出确认；未预先允许的操作会被直接拒绝"
+    },
+    bypassPermissions: {
+      label: "跳过权限提示",
+      description: "跳过权限提示，但仍保留安全检查"
+    },
+    fullAccess: {
+      label: "完全访问权限",
+      description: "跳过所有权限检查，包括所有 Agent 的危险命令"
+    },
+    plan: {
+      label: "计划模式",
+      description: "只分析和规划，不修改文件或执行命令"
+    }
+  }
+};

--- a/services/tuttid/service/agentextension/manager_test.go
+++ b/services/tuttid/service/agentextension/manager_test.go
@@ -999,6 +999,29 @@ func TestComposerAutomaticPermissionDecisionsAreRestrictedBySemantic(t *testing.
 	}
 }
 
+func TestComposerAutomaticPermissionDecisionsPreserveExactRuntimeIDScope(t *testing.T) {
+	var profile ComposerProfile
+	if err := json.Unmarshal([]byte(`{
+		"schemaVersion":"tutti.agent.composer.v1",
+		"permissionModes":[
+			{"runtimeId":"bypassPermissions","semantic":"full-access"},
+			{"runtimeId":"fullAccess","semantic":"full-access","automaticDecision":"approved"}
+		]
+	}`), &profile); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateComposerProfile(profile); err != nil {
+		t.Fatalf("validateComposerProfile() error = %v", err)
+	}
+	decisions := profile.AutomaticPermissionDecisions()
+	if decisions["fullaccess"] != "approved" {
+		t.Fatalf("fullAccess decision = %q, want approved", decisions["fullaccess"])
+	}
+	if decision, exists := decisions["bypasspermissions"]; exists {
+		t.Fatalf("bypassPermissions decision = %q, want no automatic decision", decision)
+	}
+}
+
 func TestComposerProfileACPConfigOptionIDs(t *testing.T) {
 	t.Run("canonical", func(t *testing.T) {
 		profile := ComposerProfile{SchemaVersion: "tutti.agent.composer.v1"}


### PR DESCRIPTION
## 背景

CodeBuddy 通过标准 ACP 成功切换到 fullAccess 后，仍可能发出残留的 session/request_permission。Tutti 在没有精确自动决策时会将其投影为人工授权，导致完全访问任务被重复弹窗打断。同时，CodeBuddy 的多个运行时权限模式共享通用语义标签，界面中会出现重复且边界不清晰的“完全访问权限”。

## 改动

- 让 Standard ACP 自动权限层只处理普通执行授权
- 识别并保留 AskUserQuestion、ExitPlanMode 等用户交互，不替用户自动选择
- 增加精确 runtime ID 范围测试，确保 fullAccess 的自动决策不会扩散到 bypassPermissions
- 为 CodeBuddy 提供 provider 专属权限模式文案，区分“不再询问”“跳过权限提示”“完全访问权限”和“计划模式”
- 补充扩展契约与排障文档

## 行为边界

- 本 PR 不增加 CodeBuddy provider 特判，继续使用标准 ACP 和签名扩展契约
- 只有扩展精确声明 automaticDecision 的运行时模式才会自动决策
- 用户提问和工作流决策始终保留人工交互
- bypassPermissions 及其他权限模式保持原有 provider 行为
- 完整上线仍需配套发布 agent-extension-codebuddy 2.0.4，在精确的 fullAccess 模式声明 automaticDecision: approved

## 验证

- pnpm check:changed -- --base upstream/main --push-ready
- 19 条门禁全部通过，包括 Go lint/test/build、AgentGUI typecheck/test、i18n、边界检查和 npm pack
- pre-commit 格式化及 staged 边界检查通过

## 文档影响

已更新 Agent Extensions 架构说明和 Agent Provider Setup 排障指南，记录自动权限决策的安全边界及 CodeBuddy fullAccess 排查方法。