### PR TITLE
fix(agent): preserve initial Goal loading until execution starts

### DIFF
--- a/apps/desktop/src/main/agentPowerSaveBlocker.test.ts
+++ b/apps/desktop/src/main/agentPowerSaveBlocker.test.ts
@@ -216,6 +216,7 @@ function createSession(id: string, status: string): WorkspaceAgentSession {
     cwd: "/tmp/ws-1",
     endedAtUnixMs: null,
     goal: null,
+    goalSyncState: null,
     tuttiModeActivation: null,
     id,
     imported: false,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -2538,6 +2538,7 @@ function createSession(
     ...canonicalOverrides,
     messageVersion: canonicalOverrides.messageVersion ?? 0,
     forkedFrom: canonicalOverrides.forkedFrom ?? null,
+    goalSyncState: canonicalOverrides.goalSyncState ?? null,
     tuttiModeActivation: canonicalOverrides.tuttiModeActivation ?? null,
     kind: canonicalOverrides.kind ?? "root",
     rootAgentSessionId: canonicalOverrides.rootAgentSessionId ?? null,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -202,7 +202,7 @@ test("WorkspaceAgentActivityService.sendInput preserves the authoritative ready 
   assert.equal(snapshotSession?.activeTurn, null);
 });
 
-test("Desktop Engine applies send results without a host-side Session dispatch", async () => {
+test("Desktop Engine applies send results without a host-side Session dispatch", async (t) => {
   const readySession = workspaceAgentSession({ status: "ready" });
   const observedIntentTypes: string[] = [];
   const service = new WorkspaceAgentActivityService({
@@ -222,6 +222,7 @@ test("Desktop Engine applies send results without a host-side Session dispatch",
     runtimeApi: { logTerminalDiagnostic: async () => {} },
     sessionReplayEnabled: true
   });
+  t.after(() => service.dispose());
   await service.load("ws-1");
   service.addSessionEngineActivityObserver("ws-1", {
     observeCommand() {},
@@ -352,7 +353,7 @@ test("WorkspaceAgentActivityService.activateSession creates target-backed sessio
   });
 });
 
-test("Desktop Engine applies activation results through its authoritative projection", async () => {
+test("Desktop Engine applies activation results through its authoritative projection", async (t) => {
   const observedIntentTypes: string[] = [];
   const service = new WorkspaceAgentActivityService({
     tuttidClient: {
@@ -362,6 +363,7 @@ test("Desktop Engine applies activation results through its authoritative projec
     runtimeApi: { logTerminalDiagnostic: async () => {} },
     sessionReplayEnabled: true
   });
+  t.after(() => service.dispose());
   service.addSessionEngineActivityObserver("ws-1", {
     observeCommand() {},
     observeIntent(intent) {
@@ -521,7 +523,7 @@ test("WorkspaceAgentActivityService does not report a cached availability snapsh
   );
 });
 
-test("WorkspaceAgentActivityService confirms engine activation from the realtime session upsert", async () => {
+test("WorkspaceAgentActivityService confirms engine activation from the realtime session upsert", async (t) => {
   const createRequests: unknown[] = [];
   const service = new WorkspaceAgentActivityService({
     tuttidClient: {
@@ -543,6 +545,7 @@ test("WorkspaceAgentActivityService confirms engine activation from the realtime
     } as unknown as TuttidClient,
     runtimeApi: { logTerminalDiagnostic: async () => {} }
   });
+  t.after(() => service.dispose());
   const engine = service.getSessionEngine("ws-1");
   const requestedAtUnixMs = Date.now();
   engine.dispatch({
@@ -3933,6 +3936,7 @@ function workspaceAgentSession(overrides: {
     endedAtUnixMs: null,
     forkedFrom: null,
     goal: null,
+    goalSyncState: null,
     id: "session-1",
     imported: false,
     kind: "root",

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentSessionEngineHost.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentSessionEngineHost.test.ts
@@ -352,6 +352,7 @@ function tuttidSession(
     endedAtUnixMs: null,
     forkedFrom: null,
     goal,
+    goalSyncState: null,
     id: "session-1",
     imported: false,
     kind: "root",

--- a/apps/mobile/src/services/workspaceActivityService.test.ts
+++ b/apps/mobile/src/services/workspaceActivityService.test.ts
@@ -2176,6 +2176,7 @@ function createSession(): WorkspaceAgentSession {
     endedAtUnixMs: null,
     forkedFrom: null,
     goal: null,
+    goalSyncState: null,
     id: "session-1",
     imported: false,
     kind: "root",

--- a/apps/mobile/src/services/workspaceConversationRailService.test.ts
+++ b/apps/mobile/src/services/workspaceConversationRailService.test.ts
@@ -457,6 +457,7 @@ function createSession(
     endedAtUnixMs: null,
     forkedFrom: null,
     goal: null,
+    goalSyncState: null,
     id,
     imported: false,
     kind: "root",

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -360,6 +360,15 @@ title from the display prompt, or from a synthesized `/goal` command when the
 display prompt is absent. Non-empty initial content and typed initial Goal are
 mutually exclusive, and product adapters must not reconstruct the command from
 display text.
+The public Session contract optionally carries `goalSyncState` as a narrow
+Host-owned observation: revision, sync status, and pending operation identity.
+It does not move Goal saga ownership into Activity Core. Missing state means the
+host cannot prove progress; explicit `null` clears prior evidence, and Session
+merge preserves prior evidence when a compatible partial projection merely
+omits the field. AgentGUI may use an identified pending/applying/unknown
+operation for initial-Goal loading continuity without inventing a Turn or a UI
+timeout. A synced operation is terminal mutation evidence, not proof that a
+future Turn will exist.
 Desktop AgentGUI and Mobile call `stopSession` instead of constructing
 `session/stopRequested` protocol fields. The same method stops an active Turn
 or records a bounded request that cancels the first Turn produced by an

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -361,14 +361,16 @@ display prompt is absent. Non-empty initial content and typed initial Goal are
 mutually exclusive, and product adapters must not reconstruct the command from
 display text.
 The public Session contract optionally carries `goalSyncState` as a narrow
-Host-owned observation: revision, sync status, and pending operation identity.
-It does not move Goal saga ownership into Activity Core. Missing state means the
-host cannot prove progress; explicit `null` clears prior evidence, and Session
-merge preserves prior evidence when a compatible partial projection merely
-omits the field. AgentGUI may use an identified pending/applying/unknown
-operation for initial-Goal loading continuity without inventing a Turn or a UI
-timeout. A synced operation is terminal mutation evidence, not proof that a
-future Turn will exist.
+Host-owned observation: revision, sync status, pending operation identity, and
+optional `executionPending` proof. It does not move Goal saga ownership into
+Activity Core. Missing state means the host cannot prove progress; explicit
+`null` clears prior evidence, and Session merge preserves prior evidence when a
+compatible partial projection merely omits the field. AgentGUI may use an
+identified pending/applying/unknown operation for initial-Goal loading
+continuity without inventing a Turn or a UI timeout. `synced` alone is terminal
+mutation evidence, not proof that a future Turn will exist; only explicit
+Host-owned `executionPending=true` bridges convergence to the first exact Goal
+Turn. Terminal/non-active Goal evidence and that Turn clear the proof.
 Desktop AgentGUI and Mobile call `stopSession` instead of constructing
 `session/stopRequested` protocol fields. The same method stops an active Turn
 or records a bounded request that cancels the first Turn produced by an

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2474,11 +2474,15 @@ canonical replacement does not remove and recreate the visible `goal-control`
 row.
 Hosts that can observe the durable Goal saga may additionally project the
 optional Session `goalSyncState` (`revision`, `syncStatus`, and
-`pendingOperationId`). It is read evidence owned by the Host, not Session-owned
-Goal lifecycle state. AgentGUI uses it only while the exact initial Goal
-operation remains pending. Omission means unknown capability; `synced`,
-`failed`, and `diverged` all release that operation bridge. Canonical Turn or
-runtime activity independently owns any later execution presentation.
+`pendingOperationId`, plus optional `executionPending`). It is read evidence
+owned by the Host, not Session-owned Goal lifecycle state. AgentGUI uses an
+identified `pending`, `applying`, or `unknown` operation while the exact initial
+Goal mutation remains pending. After mutation convergence, `synced` retains the
+bridge only when the Host explicitly reports `executionPending=true`. The Host
+clears that proof on the first canonical Turn with exact Goal provenance or on
+terminal, diverged, failed, or non-active Goal evidence. Omission fails closed,
+including across mixed-version hosts; AgentGUI never infers future execution
+from `synced` alone or uses a UI timeout.
 The pending activation carries the same resolved project section key as the
 create command. Exact rail projection therefore shows the conversation as soon
 as the intent is accepted; it does not wait for provider startup or invent a

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -877,8 +877,20 @@ canonical Session first appears. Session existence or an `available` runtime
 must not create an idle frame before the exact Turn claims the submission. A
 viable new-Session activation with `initialTurnExpected` remains the same busy
 bridge while no canonical latest Turn exists. Goal-only activation deliberately
-does not expect a Turn. When a provider exposes an exact session-level
-`running`/`idle` observation before Turn identity, the daemon projects that
+does not set `initialTurnExpected`, because Goal Control does not synchronously
+create a Turn. A viable initial Goal `set` whose projected Goal is still active
+remains a busy bridge only while the Goal is optimistic or the host supplies an
+exact pending/applying/unknown `goalSyncState` with a pending operation
+identity. A synced Goal proves only that the Goal mutation converged; it does
+not prove that a future Turn will exist. The first canonical Turn, a synced or
+non-active Goal,
+`failed`/`diverged` synchronization, `pending`/`applying`/`unknown` without an operation identity,
+or a canceled/failed activation releases the bridge; initial Goal `clear` never
+creates it. A host that omits `goalSyncState` cannot prove post-create execution
+and therefore fails closed to the canonical availability projection instead of
+keeping the composer busy indefinitely. When a provider exposes an exact
+session-level `running`/`idle` observation before Turn identity, the daemon
+projects that
 typed, non-persistent runtime activity through `agent.activity.updated` after
 the associated state report wins canonical ordering. Desktop and Mobile Live
 consume the same event variant. The workspace Engine uses its occurrence time
@@ -2460,6 +2472,13 @@ callers that omit the structured field. AgentGUI represents the pending control
 and its durable audit with the same client-submit presentation identity, so
 canonical replacement does not remove and recreate the visible `goal-control`
 row.
+Hosts that can observe the durable Goal saga may additionally project the
+optional Session `goalSyncState` (`revision`, `syncStatus`, and
+`pendingOperationId`). It is read evidence owned by the Host, not Session-owned
+Goal lifecycle state. AgentGUI uses it only while the exact initial Goal
+operation remains pending. Omission means unknown capability; `synced`,
+`failed`, and `diverged` all release that operation bridge. Canonical Turn or
+runtime activity independently owns any later execution presentation.
 The pending activation carries the same resolved project section key as the
 create command. Exact rail projection therefore shows the conversation as soon
 as the intent is accepted; it does not wait for provider startup or invent a

--- a/packages/agent/activity-core/README.md
+++ b/packages/agent/activity-core/README.md
@@ -343,12 +343,15 @@ empty initial content to their Create transport, and Agent Host creates the
 Session plus durable Goal operation without creating a Turn.
 Hosts that already observe that durable operation may attach the optional,
 read-only `goalSyncState` projection to the Session. The field carries only the
-revision, sync status, and pending operation identity. Omission means the host
-cannot prove progress; consumers must not reinterpret it as idle or successful.
+revision, sync status, pending operation identity, and optional Host-owned
+`executionPending` proof. Omission means the host cannot prove progress;
+consumers must not reinterpret it as idle or successful.
 For loading continuity, `pending`, `applying`, and `unknown` require a non-empty
-pending operation identity. `synced` proves the Goal mutation converged and
-releases this bridge; canonical Turn or runtime activity must independently
-prove later execution.
+pending operation identity. A `synced` mutation keeps the initial-Goal bridge
+only when `executionPending` is explicitly true. The Host clears that proof on
+the first canonical Turn with exact Goal provenance or when the Goal becomes
+terminal, diverged, failed, or otherwise non-executing. Missing proof fails
+closed, including for mixed-version hosts.
 Engine Session merging preserves known state across compatible projections that
 omit the optional field, while an explicit `null` clears it.
 Existing-Session Goal Control is a separate Engine operation. The caller

--- a/packages/agent/activity-core/README.md
+++ b/packages/agent/activity-core/README.md
@@ -341,6 +341,16 @@ for external hosts that use them for goal setup or idempotency. A typed
 new-Session Goal is part of activation: hosts forward `initialGoalControl` and
 empty initial content to their Create transport, and Agent Host creates the
 Session plus durable Goal operation without creating a Turn.
+Hosts that already observe that durable operation may attach the optional,
+read-only `goalSyncState` projection to the Session. The field carries only the
+revision, sync status, and pending operation identity. Omission means the host
+cannot prove progress; consumers must not reinterpret it as idle or successful.
+For loading continuity, `pending`, `applying`, and `unknown` require a non-empty
+pending operation identity. `synced` proves the Goal mutation converged and
+releases this bridge; canonical Turn or runtime activity must independently
+prove later execution.
+Engine Session merging preserves known state across compatible projections that
+omit the optional field, while an explicit `null` clears it.
 Existing-Session Goal Control is a separate Engine operation. The caller
 proposes a stable client-submit identity; admission returns the effective
 identity actually used by the Engine. The Engine owns command identity,

--- a/packages/agent/activity-core/src/engine/pendingIntents.reducer.test.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.reducer.test.ts
@@ -676,6 +676,45 @@ test("typed activation rejects malformed nested Session entities", () => {
   assert.deepEqual(result.followUpIntents, undefined);
 });
 
+test("typed activation rejects malformed Goal synchronization evidence", () => {
+  for (const goalSyncState of [
+    { pendingOperationId: 42, revision: 1, syncStatus: "applying" },
+    { pendingOperationId: null, revision: -1, syncStatus: "applying" },
+    { pendingOperationId: null, revision: 1, syncStatus: "future" },
+    { revision: 1, syncStatus: "applying" }
+  ]) {
+    const state = reduce(
+      createInitialPendingIntentsState(),
+      activation()
+    ).state;
+    const result = reduce(state, {
+      commandId: "activate:activation-1",
+      commandType: "session/activate",
+      correlationId: "activation-1",
+      outcome: "succeeded",
+      resultContract: "activation-v1",
+      type: "engine/commandResult",
+      value: {
+        activation: { mode: "new", status: "attached" },
+        session: {
+          ...session("session-new"),
+          goalSyncState
+        }
+      }
+    });
+
+    assert.equal(
+      result.state.activationsByRequestId["activation-1"]?.errorCode,
+      "invalid_command_result"
+    );
+    assert.equal(
+      result.state.activationsByRequestId["activation-1"]?.status,
+      "uncertain"
+    );
+    assert.deepEqual(result.followUpIntents, undefined);
+  }
+});
+
 test("confirmed activation may hydrate detail but cannot be failed by a late result", () => {
   let state = reduce(
     createInitialPendingIntentsState(),

--- a/packages/agent/activity-core/src/engine/sessionEntities.reducer.ts
+++ b/packages/agent/activity-core/src/engine/sessionEntities.reducer.ts
@@ -699,17 +699,25 @@ function preserveProjectedSessionState(
   current: CanonicalAgentSession | undefined,
   incoming: CanonicalAgentSession
 ): CanonicalAgentSession {
+  const goalSyncState =
+    current?.goalSyncState !== undefined &&
+    !Object.prototype.hasOwnProperty.call(incoming, "goalSyncState")
+      ? current.goalSyncState
+      : undefined;
   if (
     current?.lifecycleCapabilitiesProjected === true &&
     incoming.lifecycleCapabilitiesProjected !== true
   ) {
     return {
       ...incoming,
+      ...(goalSyncState === undefined ? {} : { goalSyncState }),
       lifecycleCapabilities: current.lifecycleCapabilities,
       lifecycleCapabilitiesProjected: true
     };
   }
-  return incoming;
+  return goalSyncState === undefined
+    ? incoming
+    : { ...incoming, goalSyncState };
 }
 
 function sessionVersion(session: CanonicalAgentSession): number {

--- a/packages/agent/activity-core/src/engine/sessionGoalControl.semantic.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionGoalControl.semantic.test.ts
@@ -4,6 +4,7 @@ import { normalizeAgentActivitySession } from "../sessionNormalization.ts";
 import type { AgentActivityGoalControlResult } from "../types.ts";
 import { createAgentSessionEngine } from "./createAgentSessionEngine.ts";
 import { createTestEngineCommandPort } from "./testEngineCommandPort.ts";
+import { selectEngineSession } from "./sessionLifecycle.selectors.ts";
 import {
   selectSessionGoalControlPresentation,
   selectSessionGoalControlSettlement
@@ -547,7 +548,12 @@ test("new-session Goal projection stops being optimistic after canonical hydrati
   engine.dispatch({
     session: {
       ...session(goal("ship it", "active"), 2),
-      agentSessionId: "session-new"
+      agentSessionId: "session-new",
+      goalSyncState: {
+        pendingOperationId: "goal-operation-1",
+        revision: 1,
+        syncStatus: "applying"
+      }
     },
     type: "session/upserted"
   });
@@ -560,6 +566,43 @@ test("new-session Goal projection stops being optimistic after canonical hydrati
       optimistic: false,
       status: "idle"
     }
+  );
+  assert.deepEqual(
+    selectEngineSession(engine.getSnapshot(), "session-new")?.goalSyncState,
+    {
+      pendingOperationId: "goal-operation-1",
+      revision: 1,
+      syncStatus: "applying"
+    }
+  );
+
+  engine.dispatch({
+    session: {
+      ...session(goal("ship it", "active"), 2),
+      agentSessionId: "session-new"
+    },
+    type: "session/upserted"
+  });
+  assert.deepEqual(
+    selectEngineSession(engine.getSnapshot(), "session-new")?.goalSyncState,
+    {
+      pendingOperationId: "goal-operation-1",
+      revision: 1,
+      syncStatus: "applying"
+    }
+  );
+
+  engine.dispatch({
+    session: {
+      ...session(goal("ship it", "active"), 2),
+      agentSessionId: "session-new",
+      goalSyncState: null
+    },
+    type: "session/upserted"
+  });
+  assert.equal(
+    selectEngineSession(engine.getSnapshot(), "session-new")?.goalSyncState,
+    null
   );
 });
 

--- a/packages/agent/activity-core/src/engine/sessionGoalControl.semantic.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionGoalControl.semantic.test.ts
@@ -570,6 +570,7 @@ test("new-session Goal projection stops being optimistic after canonical hydrati
   assert.deepEqual(
     selectEngineSession(engine.getSnapshot(), "session-new")?.goalSyncState,
     {
+      executionPending: false,
       pendingOperationId: "goal-operation-1",
       revision: 1,
       syncStatus: "applying"
@@ -586,6 +587,7 @@ test("new-session Goal projection stops being optimistic after canonical hydrati
   assert.deepEqual(
     selectEngineSession(engine.getSnapshot(), "session-new")?.goalSyncState,
     {
+      executionPending: false,
       pendingOperationId: "goal-operation-1",
       revision: 1,
       syncStatus: "applying"

--- a/packages/agent/activity-core/src/engine/sessionProjection.validation.ts
+++ b/packages/agent/activity-core/src/engine/sessionProjection.validation.ts
@@ -113,6 +113,7 @@ function optionalSessionFieldsMatch(
     optionalForkLineage(value.forkedFrom) &&
     optionalUsage(value.usage) &&
     optionalGoal(value.goal) &&
+    optionalGoalSyncState(value.goalSyncState) &&
     optionalTuttiModeActivation(
       value.tuttiModeActivation,
       agentSessionId,
@@ -128,6 +129,18 @@ function optionalSessionFieldsMatch(
     optionalNullableNumber(value.pinnedAtUnixMs) &&
     optionalFiniteNumber(value.createdAtUnixMs) &&
     optionalFiniteNumber(value.updatedAtUnixMs)
+  );
+}
+
+function optionalGoalSyncState(value: unknown): boolean {
+  return Boolean(
+    value === undefined ||
+    value === null ||
+    (isRecord(value) &&
+      Number.isSafeInteger(value.revision) &&
+      (value.revision as number) >= 0 &&
+      isOneOf(value.syncStatus, GOAL_SYNC_STATUSES) &&
+      isNullableString(value.pendingOperationId))
   );
 }
 
@@ -459,6 +472,14 @@ const GOAL_STATUSES = [
   "usageLimited",
   "budgetLimited",
   "complete"
+] as const;
+const GOAL_SYNC_STATUSES = [
+  "pending",
+  "applying",
+  "synced",
+  "diverged",
+  "unknown",
+  "failed"
 ] as const;
 const TUTTI_MODE_STATUSES = ["active", "inactive"] as const;
 const TUTTI_MODE_SOURCES = ["slash_command", "badge_remove"] as const;

--- a/packages/agent/activity-core/src/engine/sessionProjection.validation.ts
+++ b/packages/agent/activity-core/src/engine/sessionProjection.validation.ts
@@ -140,7 +140,9 @@ function optionalGoalSyncState(value: unknown): boolean {
       Number.isSafeInteger(value.revision) &&
       (value.revision as number) >= 0 &&
       isOneOf(value.syncStatus, GOAL_SYNC_STATUSES) &&
-      isNullableString(value.pendingOperationId))
+      isNullableString(value.pendingOperationId) &&
+      (value.executionPending === undefined ||
+        typeof value.executionPending === "boolean"))
   );
 }
 

--- a/packages/agent/activity-core/src/index.ts
+++ b/packages/agent/activity-core/src/index.ts
@@ -417,6 +417,7 @@ export type {
   AgentActivitySessionCapabilities,
   AgentActivitySessionGoal,
   AgentActivitySessionGoalState,
+  AgentActivitySessionGoalSyncState,
   AgentActivitySessionGoalSyncStatus,
   AgentActivitySessionPermissionConfig,
   AgentActivitySessionUsage,

--- a/packages/agent/activity-core/src/sessionNormalization.test.ts
+++ b/packages/agent/activity-core/src/sessionNormalization.test.ts
@@ -68,6 +68,7 @@ test("clones an explicitly projected Goal synchronization state", () => {
     agentSessionId: "session-goal-sync",
     cwd: "/workspace",
     goalSyncState: {
+      executionPending: true,
       pendingOperationId: " goal-operation-1 ",
       revision: 3,
       syncStatus: "applying"
@@ -80,6 +81,7 @@ test("clones an explicitly projected Goal synchronization state", () => {
   });
 
   assert.deepEqual(session.goalSyncState, {
+    executionPending: true,
     pendingOperationId: "goal-operation-1",
     revision: 3,
     syncStatus: "applying"

--- a/packages/agent/activity-core/src/sessionNormalization.test.ts
+++ b/packages/agent/activity-core/src/sessionNormalization.test.ts
@@ -61,3 +61,27 @@ test("normalizes a transport session into the complete canonical contract", () =
     workspaceId: "workspace-1"
   });
 });
+
+test("clones an explicitly projected Goal synchronization state", () => {
+  const session = normalizeAgentActivitySession({
+    activeTurnId: null,
+    agentSessionId: "session-goal-sync",
+    cwd: "/workspace",
+    goalSyncState: {
+      pendingOperationId: " goal-operation-1 ",
+      revision: 3,
+      syncStatus: "applying"
+    },
+    latestTurnInteractions: [],
+    pendingInteractions: [],
+    provider: "codex",
+    title: "Goal session",
+    workspaceId: "workspace-1"
+  });
+
+  assert.deepEqual(session.goalSyncState, {
+    pendingOperationId: "goal-operation-1",
+    revision: 3,
+    syncStatus: "applying"
+  });
+});

--- a/packages/agent/activity-core/src/sessionNormalization.ts
+++ b/packages/agent/activity-core/src/sessionNormalization.ts
@@ -86,6 +86,18 @@ export function normalizeAgentActivitySession(
       : null,
     usage: source.usage ?? null,
     goal: source.goal ?? null,
+    ...(Object.prototype.hasOwnProperty.call(source, "goalSyncState")
+      ? {
+          goalSyncState: source.goalSyncState
+            ? {
+                revision: source.goalSyncState.revision,
+                syncStatus: source.goalSyncState.syncStatus,
+                pendingOperationId:
+                  source.goalSyncState.pendingOperationId?.trim() || null
+              }
+            : null
+        }
+      : {}),
     tuttiModeActivation: source.tuttiModeActivation ?? null,
     imported: source.imported ?? false,
     visible: source.visible ?? true,

--- a/packages/agent/activity-core/src/sessionNormalization.ts
+++ b/packages/agent/activity-core/src/sessionNormalization.ts
@@ -93,7 +93,8 @@ export function normalizeAgentActivitySession(
                 revision: source.goalSyncState.revision,
                 syncStatus: source.goalSyncState.syncStatus,
                 pendingOperationId:
-                  source.goalSyncState.pendingOperationId?.trim() || null
+                  source.goalSyncState.pendingOperationId?.trim() || null,
+                executionPending: source.goalSyncState.executionPending === true
               }
             : null
         }

--- a/packages/agent/activity-core/src/types.ts
+++ b/packages/agent/activity-core/src/types.ts
@@ -683,6 +683,8 @@ export interface AgentActivitySessionGoalSyncState {
   revision: number;
   syncStatus: AgentActivitySessionGoalSyncStatus;
   pendingOperationId: string | null;
+  /** Optional for mixed-version hosts; true is authoritative Host evidence. */
+  executionPending?: boolean;
 }
 
 export interface AgentActivitySessionGoalState {

--- a/packages/agent/activity-core/src/types.ts
+++ b/packages/agent/activity-core/src/types.ts
@@ -115,6 +115,12 @@ export interface AgentActivitySession {
   usage: AgentActivitySessionUsage | null;
   goal: AgentActivitySessionGoal | null;
   /**
+   * Optional host-owned projection of the durable Goal synchronization state.
+   * Absence means the host cannot prove operation progress; it is not an idle,
+   * failed, or synced assertion.
+   */
+  goalSyncState?: AgentActivitySessionGoalSyncState | null;
+  /**
    * Read projection of the independent daemon-owned TuttiModeActivation.
    * The session does not own this lifecycle; activity-core normalizes it into
    * its dedicated activation slice.
@@ -672,6 +678,12 @@ export type AgentActivitySessionGoalSyncStatus =
   | "diverged"
   | "unknown"
   | "failed";
+
+export interface AgentActivitySessionGoalSyncState {
+  revision: number;
+  syncStatus: AgentActivitySessionGoalSyncStatus;
+  pendingOperationId: string | null;
+}
 
 export interface AgentActivitySessionGoalState {
   desired?: AgentActivitySessionGoal | null;

--- a/packages/agent/activity-tuttid-adapter/src/mappers.test.ts
+++ b/packages/agent/activity-tuttid-adapter/src/mappers.test.ts
@@ -72,6 +72,7 @@ test("session mapping preserves durable Goal synchronization evidence", () => {
     {
       ...createSession(),
       goalSyncState: {
+        executionPending: true,
         pendingOperationId: " goal-operation-1 ",
         revision: 4,
         syncStatus: "applying"
@@ -81,6 +82,7 @@ test("session mapping preserves durable Goal synchronization evidence", () => {
   );
 
   assert.deepEqual(session.goalSyncState, {
+    executionPending: true,
     pendingOperationId: "goal-operation-1",
     revision: 4,
     syncStatus: "applying"
@@ -89,9 +91,25 @@ test("session mapping preserves durable Goal synchronization evidence", () => {
 
 test("session mapping rejects malformed Goal synchronization evidence", () => {
   for (const goalSyncState of [
-    { pendingOperationId: 42, revision: 1, syncStatus: "applying" },
-    { pendingOperationId: null, revision: -1, syncStatus: "applying" },
-    { pendingOperationId: null, revision: 1, syncStatus: "future" }
+    {
+      executionPending: false,
+      pendingOperationId: 42,
+      revision: 1,
+      syncStatus: "applying"
+    },
+    {
+      executionPending: false,
+      pendingOperationId: null,
+      revision: -1,
+      syncStatus: "applying"
+    },
+    {
+      executionPending: false,
+      pendingOperationId: null,
+      revision: 1,
+      syncStatus: "future"
+    },
+    { pendingOperationId: null, revision: 1, syncStatus: "synced" }
   ]) {
     assert.throws(
       () =>

--- a/packages/agent/activity-tuttid-adapter/src/mappers.test.ts
+++ b/packages/agent/activity-tuttid-adapter/src/mappers.test.ts
@@ -56,6 +56,7 @@ test("session mapping requires and preserves the host-owned user identity", () =
   );
   assert.equal(session.userId, "account-user-1");
   assert.equal(session.messageVersion, 7);
+  assert.equal(session.goalSyncState, null);
   assert.deepEqual(session.forkedFrom, {
     forkedAtUnixMs: 9,
     operationId: "operation-1",
@@ -63,6 +64,48 @@ test("session mapping requires and preserves the host-owned user identity", () =
     sourceTurnId: "turn-1",
     targetTurnId: "target-turn-1"
   });
+});
+
+test("session mapping preserves durable Goal synchronization evidence", () => {
+  const session = agentActivitySessionFromTuttidSession(
+    "workspace-1",
+    {
+      ...createSession(),
+      goalSyncState: {
+        pendingOperationId: " goal-operation-1 ",
+        revision: 4,
+        syncStatus: "applying"
+      }
+    },
+    { currentUserId: "account-user-1" }
+  );
+
+  assert.deepEqual(session.goalSyncState, {
+    pendingOperationId: "goal-operation-1",
+    revision: 4,
+    syncStatus: "applying"
+  });
+});
+
+test("session mapping rejects malformed Goal synchronization evidence", () => {
+  for (const goalSyncState of [
+    { pendingOperationId: 42, revision: 1, syncStatus: "applying" },
+    { pendingOperationId: null, revision: -1, syncStatus: "applying" },
+    { pendingOperationId: null, revision: 1, syncStatus: "future" }
+  ]) {
+    assert.throws(
+      () =>
+        agentActivitySessionFromTuttidSession(
+          "workspace-1",
+          {
+            ...createSession(),
+            goalSyncState
+          } as unknown as WorkspaceAgentSession,
+          { currentUserId: "account-user-1" }
+        ),
+      /goalSyncState is invalid/
+    );
+  }
 });
 
 test("session mapping rejects an invalid message cursor", () => {
@@ -179,6 +222,7 @@ function createSession(): WorkspaceAgentSession {
     cwd: "/",
     endedAtUnixMs: null,
     goal: null,
+    goalSyncState: null,
     id: "session-1",
     imported: false,
     kind: "root",

--- a/packages/agent/activity-tuttid-adapter/src/mappers.ts
+++ b/packages/agent/activity-tuttid-adapter/src/mappers.ts
@@ -78,7 +78,8 @@ export function agentActivitySessionFromTuttidSession(
           revision: session.goalSyncState.revision,
           syncStatus: session.goalSyncState.syncStatus,
           pendingOperationId:
-            session.goalSyncState.pendingOperationId?.trim() || null
+            session.goalSyncState.pendingOperationId?.trim() || null,
+          executionPending: session.goalSyncState.executionPending === true
         }
       : null,
     tuttiModeActivation: session.tuttiModeActivation
@@ -208,7 +209,8 @@ function isTuttidGoalSyncState(value: unknown): boolean {
     typeof state.syncStatus === "string" &&
     TUTTID_GOAL_SYNC_STATUSES.has(state.syncStatus) &&
     (state.pendingOperationId === null ||
-      typeof state.pendingOperationId === "string")
+      typeof state.pendingOperationId === "string") &&
+    typeof state.executionPending === "boolean"
   );
 }
 

--- a/packages/agent/activity-tuttid-adapter/src/mappers.ts
+++ b/packages/agent/activity-tuttid-adapter/src/mappers.ts
@@ -73,6 +73,14 @@ export function agentActivitySessionFromTuttidSession(
       : null,
     usage: session.usage ? cloneSerializable(session.usage) : null,
     goal: session.goal ? cloneSerializable(session.goal) : null,
+    goalSyncState: session.goalSyncState
+      ? {
+          revision: session.goalSyncState.revision,
+          syncStatus: session.goalSyncState.syncStatus,
+          pendingOperationId:
+            session.goalSyncState.pendingOperationId?.trim() || null
+        }
+      : null,
     tuttiModeActivation: session.tuttiModeActivation
       ? agentActivityTuttiModeActivationFromTuttid(session.tuttiModeActivation)
       : null,
@@ -148,6 +156,7 @@ export function assertTuttidProtocolV2SessionContract(
     "latestTurnInteractions",
     "lifecycleCapabilities",
     "forkedFrom",
+    "goalSyncState",
     "pendingInteractions",
     "railSectionKey",
     "tuttiModeActivation"
@@ -163,6 +172,11 @@ export function assertTuttidProtocolV2SessionContract(
   ) {
     throw new Error(
       "Protocol v2 contract error: workspace agent interaction collections must be arrays"
+    );
+  }
+  if (!isTuttidGoalSyncState(value.goalSyncState)) {
+    throw new Error(
+      "Protocol v2 contract error: workspace agent goalSyncState is invalid"
     );
   }
   if (
@@ -183,6 +197,29 @@ export function assertTuttidProtocolV2SessionContract(
     );
   }
 }
+
+function isTuttidGoalSyncState(value: unknown): boolean {
+  if (value === null) return true;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const state = value as Record<string, unknown>;
+  return (
+    Number.isSafeInteger(state.revision) &&
+    (state.revision as number) >= 0 &&
+    typeof state.syncStatus === "string" &&
+    TUTTID_GOAL_SYNC_STATUSES.has(state.syncStatus) &&
+    (state.pendingOperationId === null ||
+      typeof state.pendingOperationId === "string")
+  );
+}
+
+const TUTTID_GOAL_SYNC_STATUSES = new Set([
+  "pending",
+  "applying",
+  "synced",
+  "diverged",
+  "unknown",
+  "failed"
+]);
 
 export function agentActivityTuttiModeActivationFromTuttid(
   activation: TuttiModeActivation

--- a/packages/agent/activity-tuttid-adapter/src/sessionDetail.test.ts
+++ b/packages/agent/activity-tuttid-adapter/src/sessionDetail.test.ts
@@ -297,6 +297,7 @@ function createSession(
     endedAtUnixMs: null,
     forkedFrom: null,
     goal: null,
+    goalSyncState: null,
     id: "session-1",
     imported: false,
     kind: "root",

--- a/packages/agent/daemon/hostadapter/goal_lifecycle.go
+++ b/packages/agent/daemon/hostadapter/goal_lifecycle.go
@@ -28,6 +28,7 @@ func (o goalControlLifecycleObserver) ObserveGoalControlApplied(
 		RepairEpoch: observation.RepairEpoch, Action: observation.Action,
 		ProviderTurnID: observation.ProviderTurnID, Observed: observation.Observed,
 		OccurredAtUnixMS: observation.OccurredAtUnixMS,
+		ExecutionPending: observation.ExecutionPending,
 	})
 }
 

--- a/packages/agent/daemon/hostadapter/runtime.go
+++ b/packages/agent/daemon/hostadapter/runtime.go
@@ -554,7 +554,7 @@ func (a *RuntimeController) GoalControl(ctx context.Context, input host.RuntimeG
 	})
 	return host.RuntimeGoalControlResult{
 		AgentSessionID: result.AgentSessionID, Goal: cloneMap(result.Goal), Evidence: cloneMap(result.Evidence),
-		ProviderPhase: result.ProviderPhase,
+		ProviderPhase: result.ProviderPhase, ExecutionPending: result.ExecutionPending,
 	}, mapRuntimeError(err)
 }
 

--- a/packages/agent/daemon/runtime/adapter.go
+++ b/packages/agent/daemon/runtime/adapter.go
@@ -460,6 +460,9 @@ type GoalAdapterResult struct {
 	// ProviderPhase separates transport acceptance from evidence that the
 	// provider actually consumed/applied the command.
 	ProviderPhase string
+	// ExecutionPending is set only when the provider accepted a command that
+	// is expected to start autonomous Goal execution.
+	ExecutionPending bool
 }
 
 // GoalApplyInput carries the durable control identity allocated above the

--- a/packages/agent/daemon/runtime/claude_sdk_events.go
+++ b/packages/agent/daemon/runtime/claude_sdk_events.go
@@ -215,12 +215,13 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 	case "goal_command_started":
 		a.markClaudeSDKPendingGoalCommandStarted(adapterSession, event)
 		metadata := map[string]any{
-			"operationId":    payloadString(event.Payload, "operationId"),
-			"revision":       payloadInt64(event.Payload, "revision"),
-			"repairEpoch":    payloadInt64(event.Payload, "repairEpoch"),
-			"action":         payloadString(event.Payload, "action"),
-			"providerTurnId": firstNonEmptyString(payloadString(event.Payload, "providerTurnId"), turnID),
-			"goal":           a.localGoal(adapterSession),
+			"operationId":      payloadString(event.Payload, "operationId"),
+			"revision":         payloadInt64(event.Payload, "revision"),
+			"repairEpoch":      payloadInt64(event.Payload, "repairEpoch"),
+			"action":           payloadString(event.Payload, "action"),
+			"providerTurnId":   firstNonEmptyString(payloadString(event.Payload, "providerTurnId"), turnID),
+			"goal":             a.localGoal(adapterSession),
+			"executionPending": payloadString(event.Payload, "action") == string(GoalControlSet),
 		}
 		events := make([]activityshared.Event, 0, 2)
 		if ctx, ok := activityEventContext(session, newID(), ""); ok {

--- a/packages/agent/daemon/runtime/claude_sdk_goal.go
+++ b/packages/agent/daemon/runtime/claude_sdk_goal.go
@@ -196,8 +196,9 @@ func (a *ClaudeCodeSDKAdapter) ApplyGoal(
 	}
 	return GoalAdapterResult{
 		Events: events, Observation: a.localGoal(adapterSession),
-		Evidence:      map[string]any{"source": "claude_command_ack", "confidence": "accepted_only", "phase": "accepted", "repairEpoch": input.RepairEpoch},
-		ProviderPhase: "accepted",
+		Evidence:         map[string]any{"source": "claude_command_ack", "confidence": "accepted_only", "phase": "accepted", "repairEpoch": input.RepairEpoch},
+		ProviderPhase:    "accepted",
+		ExecutionPending: action == GoalControlSet,
 	}, nil
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_goal.go
+++ b/packages/agent/daemon/runtime/codex_appserver_goal.go
@@ -166,8 +166,9 @@ func (a *CodexAppServerAdapter) ApplyGoal(
 	observation := a.sessionGoal(session.AgentSessionID)
 	return GoalAdapterResult{
 		Events: events, Observation: observation,
-		Evidence:      map[string]any{"source": "codex_goal_rpc", "confidence": "authoritative", "repairEpoch": input.RepairEpoch},
-		ProviderPhase: "applied",
+		Evidence:         map[string]any{"source": "codex_goal_rpc", "confidence": "authoritative", "repairEpoch": input.RepairEpoch},
+		ProviderPhase:    "applied",
+		ExecutionPending: action == GoalControlSet,
 	}, nil
 }
 

--- a/packages/agent/daemon/runtime/controller.go
+++ b/packages/agent/daemon/runtime/controller.go
@@ -91,6 +91,7 @@ type GoalControlAppliedObservation struct {
 	ProviderTurnID   string
 	Observed         map[string]any
 	OccurredAtUnixMS int64
+	ExecutionPending bool
 }
 
 type GoalControlLifecycleObserver interface {

--- a/packages/agent/daemon/runtime/controller_exec.go
+++ b/packages/agent/daemon/runtime/controller_exec.go
@@ -434,9 +434,10 @@ type GoalControlInput struct {
 type GoalControlResult struct {
 	AgentSessionID string
 	// Goal is the fresh goal snapshot after the action (nil after clear).
-	Goal          map[string]any
-	Evidence      map[string]any
-	ProviderPhase string
+	Goal             map[string]any
+	Evidence         map[string]any
+	ProviderPhase    string
+	ExecutionPending bool
 }
 
 // GoalControl performs a direct goal action (banner buttons) as a
@@ -488,9 +489,10 @@ func (c *Controller) GoalControl(ctx context.Context, input GoalControlInput) (G
 		"action", string(input.Action),
 	)
 	return GoalControlResult{
-		AgentSessionID: session.AgentSessionID,
-		Goal:           goalAdapter.NormalizeGoalObservation(adapterResult.Observation),
-		Evidence:       clonePayload(adapterResult.Evidence),
-		ProviderPhase:  adapterResult.ProviderPhase,
+		AgentSessionID:   session.AgentSessionID,
+		Goal:             goalAdapter.NormalizeGoalObservation(adapterResult.Observation),
+		Evidence:         clonePayload(adapterResult.Evidence),
+		ProviderPhase:    adapterResult.ProviderPhase,
+		ExecutionPending: adapterResult.ExecutionPending,
 	}, nil
 }

--- a/packages/agent/daemon/runtime/controller_report_worker.go
+++ b/packages/agent/daemon/runtime/controller_report_worker.go
@@ -166,6 +166,7 @@ func (c *Controller) observeGoalControlLifecycle(
 			ProviderTurnID:   stringFromPayload(metadata, "providerTurnId"),
 			Observed:         payloadObject(metadata["goal"]),
 			OccurredAtUnixMS: event.OccurredAtUnixMS,
+			ExecutionPending: payloadBoolValue(metadata, "executionPending"),
 		}
 		if err := observer.ObserveGoalControlApplied(ctx, observation); err != nil {
 			slog.Warn(

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.spec.tsx
@@ -286,6 +286,18 @@ describe("useAgentGUISessionPresentation", () => {
     input.activeEngineSession = {
       ...input.activeEngineSession!,
       goalSyncState: {
+        executionPending: true,
+        pendingOperationId: null,
+        revision: 1,
+        syncStatus: "synced"
+      }
+    };
+    rendered.rerender();
+    expect(rendered.result.current.activeConversationBusy).toBe(true);
+
+    input.activeEngineSession = {
+      ...input.activeEngineSession!,
+      goalSyncState: {
         pendingOperationId: "goal-operation-1",
         revision: 1,
         syncStatus: "synced"
@@ -297,6 +309,7 @@ describe("useAgentGUISessionPresentation", () => {
     input.activeEngineSession = {
       ...input.activeEngineSession!,
       goalSyncState: {
+        executionPending: true,
         pendingOperationId: null,
         revision: 1,
         syncStatus: "diverged"
@@ -328,6 +341,16 @@ describe("useAgentGUISessionPresentation", () => {
       rendered.rerender();
       expect(rendered.result.current.activeConversationBusy).toBe(true);
     }
+
+    input.activeEngineSession = {
+      ...input.activeEngineSession!,
+      goalSyncState: {
+        executionPending: true,
+        pendingOperationId: null,
+        revision: 1,
+        syncStatus: "synced"
+      }
+    };
 
     input.activeEngineLatestTurn = {
       agentSessionId: "session-1",

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.spec.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook } from "@testing-library/react";
 import {
   createAgentSessionEngine,
+  type AgentActivitySessionGoalSyncState,
   type AgentActivityTurn,
   type PendingActivationIntentRecord
 } from "@tutti-os/agent-activity-core";
@@ -91,7 +92,7 @@ describe("useAgentGUISessionPresentation", () => {
     });
   });
 
-  it("keeps a confirmed Session busy until its expected Turn exists", () => {
+  it("keeps confirmed initial work busy until canonical state takes over", () => {
     const sessionEngine = createAgentSessionEngine({
       clock: { nowUnixMs: () => 1 },
       commandPort: createTestEngineCommandPort({
@@ -112,6 +113,7 @@ describe("useAgentGUISessionPresentation", () => {
       activeEngineSession: {
         agentSessionId: "session-1",
         goal: null,
+        goalSyncState: null as AgentActivitySessionGoalSyncState | null,
         resumable: true
       },
       activeEngineSettingsUpdate: null,
@@ -186,7 +188,7 @@ describe("useAgentGUISessionPresentation", () => {
       mode: "new",
       requestedAtUnixMs: 1,
       requestId: "request-1",
-      status: "confirmed",
+      status: "requested",
       title: null,
       workspaceId: "workspace-1"
     };
@@ -214,6 +216,200 @@ describe("useAgentGUISessionPresentation", () => {
     expect(rendered.result.current.activeConversationBusy).toBe(true);
 
     input.activeEngineRuntimeActivity = "idle";
+    rendered.rerender();
+    expect(rendered.result.current.activeConversationBusy).toBe(false);
+
+    input.activePendingActivation = {
+      agentSessionId: "session-1",
+      agentTargetId: "local:claude-code",
+      clientSubmitId: "goal-submit-1",
+      content: [{ type: "text", text: "/goal ship it" }],
+      cwd: "/workspace",
+      errorCode: null,
+      errorMessage: null,
+      expiresAtUnixMs: Number.MAX_SAFE_INTEGER,
+      initialGoalControl: { action: "set", objective: "ship it" },
+      initialPromptRetracted: false,
+      initialTurnExpected: false,
+      mode: "new",
+      requestedAtUnixMs: 4,
+      requestId: "goal-request-1",
+      status: "confirmed",
+      title: null,
+      workspaceId: "workspace-1"
+    };
+    input.activeGoalControlPresentation = {
+      agentSessionId: "session-1",
+      goal: { objective: "ship it", status: "active" },
+      optimistic: true,
+      status: "pending_create"
+    };
+    rendered.rerender();
+    expect(rendered.result.current.activeConversationBusy).toBe(true);
+
+    input.activePendingActivation = {
+      ...input.activePendingActivation,
+      status: "confirmed"
+    };
+    input.activeGoalControlPresentation = {
+      ...input.activeGoalControlPresentation,
+      optimistic: false,
+      status: "idle"
+    };
+    rendered.rerender();
+    expect(rendered.result.current.activeConversationBusy).toBe(false);
+
+    for (const syncStatus of ["pending", "applying", "unknown"] as const) {
+      input.activeEngineSession = {
+        ...input.activeEngineSession!,
+        goalSyncState: {
+          pendingOperationId: null,
+          revision: 1,
+          syncStatus
+        }
+      };
+      rendered.rerender();
+      expect(rendered.result.current.activeConversationBusy).toBe(false);
+    }
+
+    input.activeEngineSession = {
+      ...input.activeEngineSession!,
+      goalSyncState: {
+        pendingOperationId: null,
+        revision: 1,
+        syncStatus: "synced"
+      }
+    };
+    rendered.rerender();
+    expect(rendered.result.current.activeConversationBusy).toBe(false);
+
+    input.activeEngineSession = {
+      ...input.activeEngineSession!,
+      goalSyncState: {
+        pendingOperationId: "goal-operation-1",
+        revision: 1,
+        syncStatus: "synced"
+      }
+    };
+    rendered.rerender();
+    expect(rendered.result.current.activeConversationBusy).toBe(false);
+
+    input.activeEngineSession = {
+      ...input.activeEngineSession!,
+      goalSyncState: {
+        pendingOperationId: null,
+        revision: 1,
+        syncStatus: "diverged"
+      }
+    };
+    rendered.rerender();
+    expect(rendered.result.current.activeConversationBusy).toBe(false);
+
+    input.activeEngineSession = {
+      ...input.activeEngineSession!,
+      goalSyncState: {
+        pendingOperationId: "goal-operation-1",
+        revision: 1,
+        syncStatus: "applying"
+      }
+    };
+    rendered.rerender();
+    expect(rendered.result.current.activeConversationBusy).toBe(true);
+
+    for (const syncStatus of ["pending", "unknown"] as const) {
+      input.activeEngineSession = {
+        ...input.activeEngineSession!,
+        goalSyncState: {
+          pendingOperationId: "goal-operation-1",
+          revision: 1,
+          syncStatus
+        }
+      };
+      rendered.rerender();
+      expect(rendered.result.current.activeConversationBusy).toBe(true);
+    }
+
+    input.activeEngineLatestTurn = {
+      agentSessionId: "session-1",
+      origin: "goal_arm",
+      phase: "running",
+      startedAtUnixMs: 5,
+      turnId: "goal-turn-1",
+      updatedAtUnixMs: 5
+    };
+    input.activeEngineRuntimeActivity = "running";
+    rendered.rerender();
+    expect(rendered.result.current.activeConversationBusy).toBe(true);
+
+    input.activeEngineLatestTurn = {
+      ...input.activeEngineLatestTurn,
+      outcome: "completed",
+      phase: "settled",
+      settledAtUnixMs: 6,
+      updatedAtUnixMs: 6
+    };
+    input.activeEngineRuntimeActivity = "idle";
+    rendered.rerender();
+    expect(rendered.result.current.activeConversationBusy).toBe(false);
+
+    input.activeEngineLatestTurn = null;
+    input.activeEngineSession = {
+      ...input.activeEngineSession!,
+      goalSyncState: {
+        pendingOperationId: null,
+        revision: 1,
+        syncStatus: "failed"
+      }
+    };
+    rendered.rerender();
+    expect(rendered.result.current.activeConversationBusy).toBe(false);
+
+    input.activeEngineSession = {
+      ...input.activeEngineSession!,
+      goalSyncState: {
+        pendingOperationId: "goal-operation-1",
+        revision: 1,
+        syncStatus: "applying"
+      }
+    };
+    for (const status of ["canceled", "failed"] as const) {
+      input.activePendingActivation = {
+        ...input.activePendingActivation,
+        status
+      };
+      rendered.rerender();
+      expect(rendered.result.current.activeConversationBusy).toBe(false);
+    }
+
+    input.activePendingActivation = {
+      ...input.activePendingActivation,
+      status: "confirmed"
+    };
+    for (const status of [
+      "paused",
+      "blocked",
+      "usageLimited",
+      "budgetLimited",
+      "complete"
+    ] as const) {
+      input.activeGoalControlPresentation = {
+        ...input.activeGoalControlPresentation,
+        goal: { objective: "ship it", status }
+      };
+      rendered.rerender();
+      expect(rendered.result.current.activeConversationBusy).toBe(false);
+    }
+
+    input.activeGoalControlPresentation = {
+      agentSessionId: "session-1",
+      goal: null,
+      optimistic: false,
+      status: "idle"
+    };
+    input.activePendingActivation = {
+      ...input.activePendingActivation,
+      initialGoalControl: { action: "clear" }
+    };
     rendered.rerender();
     expect(rendered.result.current.activeConversationBusy).toBe(false);
   });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.ts
@@ -731,6 +731,8 @@ function initialGoalHasPendingOperationEvidence(input: {
     case "applying":
     case "unknown":
       return Boolean(input.syncState.pendingOperationId?.trim());
+    case "synced":
+      return input.syncState.executionPending === true;
     default:
       return false;
   }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISessionPresentation.ts
@@ -4,6 +4,7 @@ import {
   selectPlanTurnDismissed,
   type AgentActivityDisplayStatus,
   type AgentActivityMessage,
+  type AgentActivitySessionGoalSyncState,
   type AgentActivityTurn,
   type CanonicalAgentSession,
   type PendingActivationIntentRecord,
@@ -275,9 +276,24 @@ export function useAgentGUISessionPresentation(
     isPendingActivationViable(input.activePendingActivation) &&
     !input.activeEngineLatestTurn
   );
+  const activeInitialGoalSetHasPendingOperation = Boolean(
+    input.activeConversationId &&
+    input.activePendingActivation?.mode === "new" &&
+    input.activePendingActivation.agentSessionId ===
+      input.activeConversationId &&
+    input.activePendingActivation.initialGoalControl?.action === "set" &&
+    isPendingActivationViable(input.activePendingActivation) &&
+    input.activeGoalControlPresentation.goal?.status === "active" &&
+    initialGoalHasPendingOperationEvidence({
+      goalIsOptimistic: input.activeGoalControlPresentation.optimistic,
+      syncState: input.activeEngineSession?.goalSyncState ?? null
+    }) &&
+    !input.activeEngineLatestTurn
+  );
   const activeHasPendingSubmittedTurn = Boolean(
     input.activeConversationId &&
     (activeActivationAwaitsInitialTurn ||
+      activeInitialGoalSetHasPendingOperation ||
       input.hasUnconfirmedSubmit ||
       input.isSubmitting ||
       (!input.activeEngineSession && input.activeLatestPendingSubmitTurnId))
@@ -703,6 +719,21 @@ export function useAgentGUISessionPresentation(
     pendingInteractivePrompt,
     sessionChrome
   };
+}
+
+function initialGoalHasPendingOperationEvidence(input: {
+  goalIsOptimistic: boolean;
+  syncState: AgentActivitySessionGoalSyncState | null;
+}): boolean {
+  if (input.goalIsOptimistic) return true;
+  switch (input.syncState?.syncStatus) {
+    case "pending":
+    case "applying":
+    case "unknown":
+      return Boolean(input.syncState.pendingOperationId?.trim());
+    default:
+      return false;
+  }
 }
 
 function interactionReadinessReasonMessage(

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -40,6 +40,12 @@ its submit claim before provider delivery and rolls back the provisional
 canonical shell when delivery fails. Typed initial Goal is mutually exclusive
 with non-empty initial content; it creates a non-provisional Session and enters
 the same durable Goal saga under `ClientSubmitID` without opening a Turn.
+When the provider confirms that the accepted `set` command will begin
+autonomous execution, Host persists `execution_pending` on that Goal
+generation. Only a canonical `goal_arm` or `goal_continuation` Turn carrying the
+exact operation, revision, and repair epoch clears it; terminal/non-active Goal
+observation, divergence, failure, replacement, and clear also release it. This
+fact bridges loading presentation without making Goal convergence imply a Turn.
 Before runtime preparation or provider startup, a retry with that identity
 checks the canonical Goal operation. A completed retry returns the existing
 Session and operation; an in-progress or failed operation returns its existing

--- a/packages/agent/host/conformance/conformance.go
+++ b/packages/agent/host/conformance/conformance.go
@@ -113,6 +113,7 @@ type GoalObservation struct {
 	Revision           int64
 	PendingOperationID string
 	SyncStatus         string
+	ExecutionPending   bool
 }
 
 type CancelObservation struct {

--- a/packages/agent/host/conformance/conformance_test.go
+++ b/packages/agent/host/conformance/conformance_test.go
@@ -12,8 +12,8 @@ func TestPublishedScenarioCatalogsHaveUniqueNames(t *testing.T) {
 		scenarios []Scenario
 		wantCount int
 	}{
-		{name: "adapter lifecycle", scenarios: Scenarios(), wantCount: 31},
-		{name: "application core", scenarios: ApplicationCoreScenarios(), wantCount: 26},
+		{name: "adapter lifecycle", scenarios: Scenarios(), wantCount: 32},
+		{name: "application core", scenarios: ApplicationCoreScenarios(), wantCount: 27},
 		{name: "guidance", scenarios: GuidanceScenarios(), wantCount: 3},
 		{name: "resume policy", scenarios: ResumePolicyScenarios(), wantCount: 5},
 		{name: "submission fence", scenarios: SubmissionFenceScenarios(), wantCount: 1},
@@ -84,6 +84,7 @@ func TestScenarioOwnershipIsExplicit(t *testing.T) {
 		"create empty session",
 		"create with initial content",
 		"create with typed initial goal",
+		"initial Goal exposes execution pending",
 		"typed initial goal waits for canonical rail initialization",
 		"failed canonical initialization aborts unpublished runtime",
 		"create with explicit rail placement",
@@ -117,6 +118,7 @@ func TestScenarioOwnershipIsExplicit(t *testing.T) {
 		"create empty session",
 		"create with initial content",
 		"create with typed initial goal",
+		"initial Goal exposes execution pending",
 		"typed initial goal waits for canonical rail initialization",
 		"failed canonical initialization aborts unpublished runtime",
 		"create with explicit rail placement",

--- a/packages/agent/host/conformance/scenarios.go
+++ b/packages/agent/host/conformance/scenarios.go
@@ -4,6 +4,7 @@ var (
 	createEmptySessionScenario          = Scenario{Name: "create empty session", run: runCreateEmptySession}
 	createWithInitialContentScenario    = Scenario{Name: "create with initial content", run: runCreateWithInitialContent}
 	createWithInitialGoalScenario       = Scenario{Name: "create with typed initial goal", run: runCreateWithInitialGoal}
+	initialGoalExecutionPendingScenario = Scenario{Name: "initial Goal exposes execution pending", run: runInitialGoalExecutionPending}
 	typedInitialGoalRailBarrierScenario = Scenario{
 		Name: "typed initial goal waits for canonical rail initialization",
 		run:  runTypedInitialGoalWaitsForCanonicalRailInitialization,
@@ -64,6 +65,7 @@ func Scenarios() []Scenario {
 		createEmptySessionScenario,
 		createWithInitialContentScenario,
 		createWithInitialGoalScenario,
+		initialGoalExecutionPendingScenario,
 		typedInitialGoalRailBarrierScenario,
 		failedCanonicalInitializationScenario,
 		createWithRailPlacementScenario,
@@ -214,6 +216,7 @@ func ApplicationCoreScenarios() []Scenario {
 		createEmptySessionScenario,
 		createWithInitialContentScenario,
 		createWithInitialGoalScenario,
+		initialGoalExecutionPendingScenario,
 		typedInitialGoalRailBarrierScenario,
 		failedCanonicalInitializationScenario,
 		createWithRailPlacementScenario,

--- a/packages/agent/host/conformance/session_lifecycle_scenarios.go
+++ b/packages/agent/host/conformance/session_lifecycle_scenarios.go
@@ -117,6 +117,9 @@ func runCreateWithInitialGoal(ctx context.Context, driver Driver) error {
 	if goal.Goal["objective"] != "ship the feature" {
 		return fmt.Errorf("typed initial goal = %#v", goal.Goal)
 	}
+	if goal.ExecutionPending {
+		return fmt.Errorf("completed initial Goal retained execution pending: %#v", goal)
+	}
 	replayed, replayedTurnID, err := driver.Create(ctx, "workspace-1", input)
 	if err != nil {
 		return fmt.Errorf("retry create with typed initial goal: %w", err)
@@ -137,6 +140,34 @@ func runCreateWithInitialGoal(ctx context.Context, driver Driver) error {
 			metrics.ExecCalls,
 			metrics.GoalControlCalls,
 		)
+	}
+	return nil
+}
+
+func runInitialGoalExecutionPending(ctx context.Context, driver Driver) error {
+	if err := driver.Reset(ctx, Fixture{}); err != nil {
+		return err
+	}
+	ref := agenthost.SessionRef{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-initial-goal-execution-pending",
+	}
+	if _, turnID, err := driver.Create(ctx, ref.WorkspaceID, agenthost.CreateSessionInput{
+		AgentSessionID: ref.AgentSessionID, AgentTargetID: "target-1", Provider: "codex",
+		ClientSubmitID: "create-goal-execution-pending-1",
+		InitialGoalControl: &agenthost.TypedGoalControl{
+			Action: "set", Objective: "start autonomous execution",
+		},
+	}); err != nil {
+		return fmt.Errorf("create initial Goal execution: %w", err)
+	} else if turnID != "" {
+		return fmt.Errorf("initial Goal manufactured turn %q", turnID)
+	}
+	goal, err := driver.GetGoalState(ctx, ref)
+	if err != nil {
+		return fmt.Errorf("read initial Goal execution state: %w", err)
+	}
+	if goal.SyncStatus != storesqlite.GoalSyncStatusSynced || !goal.ExecutionPending {
+		return fmt.Errorf("initial Goal execution state=%#v", goal)
 	}
 	return nil
 }

--- a/packages/agent/host/goal_control.go
+++ b/packages/agent/host/goal_control.go
@@ -449,6 +449,7 @@ func (h *Host) goalControlSerialized(
 				_, state, _, err := h.goals.AcknowledgeGoalControlOperation(actorCtx, storesqlite.GoalControlOperationAcknowledge{
 					WorkspaceID: workspaceID, OperationID: operationID,
 					Evidence: clonePayload(controlResult.Evidence), OccurredAtUnixMS: h.goalOperationNow().UnixMilli(),
+					ExecutionPending: controlResult.ExecutionPending,
 				})
 				persistedState = &state
 				return err
@@ -457,6 +458,7 @@ func (h *Host) goalControlSerialized(
 				WorkspaceID: workspaceID, OperationID: operationID, Succeeded: true,
 				Observed: clonePayload(controlResult.Goal), Evidence: clonePayload(controlResult.Evidence),
 				OccurredAtUnixMS: h.goalOperationNow().UnixMilli(),
+				ExecutionPending: controlResult.ExecutionPending,
 			})
 			persistedState = &state
 			return err

--- a/packages/agent/host/goal_operation_worker.go
+++ b/packages/agent/host/goal_operation_worker.go
@@ -210,7 +210,8 @@ func (h *Host) recoverGoalOperation(ctx context.Context, operation storesqlite.G
 		_, _, _, err = h.goals.AcknowledgeGoalControlOperation(ctx, storesqlite.GoalControlOperationAcknowledge{
 			WorkspaceID: leased.WorkspaceID, OperationID: leased.OperationID,
 			Evidence: clonePayload(result.Evidence), OccurredAtUnixMS: h.goalOperationNow().UnixMilli(),
-			RepairEpoch: leased.RepairEpoch,
+			RepairEpoch:      leased.RepairEpoch,
+			ExecutionPending: result.ExecutionPending,
 		})
 		return err
 	}
@@ -219,6 +220,7 @@ func (h *Host) recoverGoalOperation(ctx context.Context, operation storesqlite.G
 		Observed: clonePayload(result.Goal), Evidence: clonePayload(result.Evidence),
 		OccurredAtUnixMS: h.goalOperationNow().UnixMilli(),
 		RepairEpoch:      leased.RepairEpoch,
+		ExecutionPending: result.ExecutionPending,
 	})
 	return err
 }

--- a/packages/agent/host/goal_reconcile.go
+++ b/packages/agent/host/goal_reconcile.go
@@ -96,6 +96,7 @@ func (h *Host) ObserveRuntimeGoalControlApplied(ctx context.Context, input Runti
 			},
 			OccurredAtUnixMS: occurredAt,
 			RepairEpoch:      input.RepairEpoch,
+			ExecutionPending: state.ExecutionPending || input.ExecutionPending,
 		})
 		return err
 	})

--- a/packages/agent/host/types.go
+++ b/packages/agent/host/types.go
@@ -905,6 +905,10 @@ type RuntimeGoalControlResult struct {
 	Goal           map[string]any
 	Evidence       map[string]any
 	ProviderPhase  string
+	// ExecutionPending is explicit provider evidence that this Goal mutation
+	// will begin autonomous execution. Host persists it until the first exact
+	// Goal Turn is canonical or the Goal reaches a terminal state.
+	ExecutionPending bool
 }
 
 // RuntimeGoalControlAppliedInput is an internal runtime-to-Host lifecycle
@@ -920,6 +924,7 @@ type RuntimeGoalControlAppliedInput struct {
 	ProviderTurnID   string
 	Observed         map[string]any
 	OccurredAtUnixMS int64
+	ExecutionPending bool
 }
 
 type RuntimeGoalReconcileResult struct {

--- a/packages/agent/store-sqlite/activity_turns.go
+++ b/packages/agent/store-sqlite/activity_turns.go
@@ -202,6 +202,22 @@ WHERE workspace_id = ? AND agent_session_id = ? AND deleted_at_unix_ms = 0
 			return Turn{}, false, fmt.Errorf("set workspace agent session active turn: %w", err)
 		}
 	}
+	if acceptedGoalExecutionTurn(merged) {
+		if _, err := tx.ExecContext(ctx, `
+UPDATE workspace_agent_session_goals
+SET execution_pending = 0, updated_at_unix_ms = MAX(updated_at_unix_ms, ?)
+WHERE workspace_id = ? AND agent_session_id = ? AND revision = ? AND execution_pending = 1
+  AND EXISTS (
+    SELECT 1 FROM workspace_agent_goal_control_operations operation
+    WHERE operation.workspace_id = workspace_agent_session_goals.workspace_id
+      AND operation.agent_session_id = workspace_agent_session_goals.agent_session_id
+      AND operation.operation_id = ? AND operation.goal_revision = ? AND operation.repair_epoch = ?
+  )
+`, occurred, workspaceID, agentSessionID, merged.SourceGoalRevision,
+			merged.SourceGoalOperationID, merged.SourceGoalRevision, merged.SourceGoalRepairEpoch); err != nil {
+			return Turn{}, false, fmt.Errorf("clear Goal execution-pending state: %w", err)
+		}
+	}
 
 	stored, ok, err := getAgentTurnTx(ctx, tx, workspaceID, agentSessionID, turnID)
 	if err != nil {
@@ -211,6 +227,14 @@ WHERE workspace_id = ? AND agent_session_id = ? AND deleted_at_unix_ms = 0
 		return Turn{}, false, fmt.Errorf("read recorded workspace agent turn: %w", sql.ErrNoRows)
 	}
 	return stored, true, nil
+}
+
+func acceptedGoalExecutionTurn(turn Turn) bool {
+	if turn.Origin != TurnOriginGoalArm && turn.Origin != TurnOriginGoalContinuation {
+		return false
+	}
+	return strings.TrimSpace(turn.SourceGoalOperationID) != "" &&
+		turn.SourceGoalRevision > 0 && turn.SourceGoalRepairEpoch >= 0
 }
 
 // validateLiveTurnSlotTx enforces the session-to-live-turn cardinality at the

--- a/packages/agent/store-sqlite/goal_operation_outbox.go
+++ b/packages/agent/store-sqlite/goal_operation_outbox.go
@@ -114,7 +114,7 @@ WHERE workspace_id = ? AND operation_id = ? AND lease_owner = ? AND repair_epoch
 	}
 	if input.Fail && changed {
 		_, err = tx.ExecContext(ctx, `UPDATE workspace_agent_session_goals
-SET sync_status = ?, pending_operation_id = NULL, last_error = ?, updated_at_unix_ms = ?
+SET sync_status = ?, pending_operation_id = NULL, execution_pending = 0, last_error = ?, updated_at_unix_ms = ?
 WHERE workspace_id = ? AND pending_operation_id = ?`, GoalSyncStatusFailed, strings.TrimSpace(input.LastError),
 			input.NowUnixMS, strings.TrimSpace(input.WorkspaceID), strings.TrimSpace(input.OperationID))
 		if err != nil {

--- a/packages/agent/store-sqlite/goal_provider_adoption.go
+++ b/packages/agent/store-sqlite/goal_provider_adoption.go
@@ -115,6 +115,7 @@ ON CONFLICT(workspace_id, agent_session_id) DO UPDATE SET
   tombstoned = 0,
   sync_status = excluded.sync_status,
   pending_operation_id = NULL,
+  execution_pending = 0,
   last_evidence_json = excluded.last_evidence_json,
   last_error = '',
   observed_at_unix_ms = excluded.observed_at_unix_ms,

--- a/packages/agent/store-sqlite/goal_state.go
+++ b/packages/agent/store-sqlite/goal_state.go
@@ -14,7 +14,7 @@ import (
 const sessionGoalStateSelectSQL = `
 SELECT workspace_id, agent_session_id, desired_json, observed_json, revision,
        tombstoned, sync_status, COALESCE(pending_operation_id, ''),
-       last_evidence_json, last_error, COALESCE(observed_at_unix_ms, 0),
+       execution_pending, last_evidence_json, last_error, COALESCE(observed_at_unix_ms, 0),
        created_at_unix_ms, updated_at_unix_ms
 FROM workspace_agent_session_goals`
 
@@ -140,15 +140,16 @@ WHERE workspace_id = ? AND operation_id = ? AND status IN (?, ?)
 	if _, err := tx.ExecContext(ctx, `
 INSERT INTO workspace_agent_session_goals (
   workspace_id, agent_session_id, desired_json, observed_json, revision,
-  tombstoned, sync_status, pending_operation_id, last_evidence_json,
+  tombstoned, sync_status, pending_operation_id, execution_pending, last_evidence_json,
   last_error, observed_at_unix_ms, created_at_unix_ms, updated_at_unix_ms
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, '', ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, '', ?, ?, ?)
 ON CONFLICT(workspace_id, agent_session_id) DO UPDATE SET
   desired_json = excluded.desired_json,
   revision = excluded.revision,
   tombstoned = excluded.tombstoned,
   sync_status = excluded.sync_status,
   pending_operation_id = excluded.pending_operation_id,
+  execution_pending = 0,
   last_error = '',
   updated_at_unix_ms = excluded.updated_at_unix_ms
 `, input.WorkspaceID, input.AgentSessionID, desiredJSON, nullableJSONMap(state.Observed), revision,
@@ -332,9 +333,10 @@ WHERE workspace_id = ? AND operation_id = ? AND status = ?
 	}
 	if _, err := tx.ExecContext(ctx, `
 UPDATE workspace_agent_session_goals
-SET sync_status = ?, last_evidence_json = ?, updated_at_unix_ms = ?
+SET sync_status = ?, execution_pending = ?, last_evidence_json = ?, updated_at_unix_ms = ?
 WHERE workspace_id = ? AND agent_session_id = ? AND pending_operation_id = ?
-`, GoalSyncStatusApplying, evidenceJSON, input.OccurredAtUnixMS, input.WorkspaceID, op.AgentSessionID, input.OperationID); err != nil {
+`, GoalSyncStatusApplying, boolInt(input.ExecutionPending), evidenceJSON, input.OccurredAtUnixMS,
+		input.WorkspaceID, op.AgentSessionID, input.OperationID); err != nil {
 		return GoalControlOperation{}, SessionGoalState{}, false, err
 	}
 	op, _, err = getGoalControlOperationTx(ctx, tx, input.WorkspaceID, input.OperationID)
@@ -577,10 +579,11 @@ func (s *Store) ReconcileSessionGoalObservation(ctx context.Context, input GoalO
 		result, err := tx.ExecContext(ctx, `
 UPDATE workspace_agent_session_goals
 SET observed_json = ?, sync_status = ?, pending_operation_id = ?, last_evidence_json = ?,
-    last_error = ?, observed_at_unix_ms = ?, updated_at_unix_ms = ?
+    execution_pending = ?, last_error = ?, observed_at_unix_ms = ?, updated_at_unix_ms = ?
 WHERE workspace_id = ? AND agent_session_id = ? AND revision = ?
   AND COALESCE(pending_operation_id, '') = ? AND COALESCE(observed_at_unix_ms, 0) = ?
-`, nullableJSONMap(input.Observed), syncStatus, pendingValue, marshalJSONMapOrEmpty(input.Evidence), lastError,
+`, nullableJSONMap(input.Observed), syncStatus, pendingValue, marshalJSONMapOrEmpty(input.Evidence),
+			boolInt(goalExecutionPendingAfterObservation(state.ExecutionPending, input.Observed, syncStatus)), lastError,
 			input.OccurredAtUnixMS, input.OccurredAtUnixMS, input.WorkspaceID, input.AgentSessionID,
 			state.Revision, expectedPending, state.ObservedAtUnixMS)
 		if err != nil {
@@ -733,12 +736,13 @@ INSERT INTO workspace_agent_session_goals (
 	_, err = tx.ExecContext(ctx, `
 UPDATE workspace_agent_session_goals
 SET observed_json = ?, sync_status = ?, last_evidence_json = ?, last_error = ?,
-    observed_at_unix_ms = ?, updated_at_unix_ms = ?
+    execution_pending = ?, observed_at_unix_ms = ?, updated_at_unix_ms = ?
 WHERE workspace_id = ? AND agent_session_id = ? AND revision = ?
   AND COALESCE(pending_operation_id, '') = ? AND COALESCE(observed_at_unix_ms, 0) = ?
 `, nullableJSONMap(observed), syncStatus,
 		`{"source":"runtime_session_report","confidence":"provider_observed"}`,
-		lastError, occurredAt, occurredAt, workspaceID, agentSessionID, state.Revision,
+		lastError, boolInt(goalExecutionPendingAfterObservation(state.ExecutionPending, observed, syncStatus)),
+		occurredAt, occurredAt, workspaceID, agentSessionID, state.Revision,
 		state.PendingOperationID, state.ObservedAtUnixMS)
 	return err
 }
@@ -771,10 +775,10 @@ func scanSessionGoalState(row *sql.Row) (SessionGoalState, bool, error) {
 	var state SessionGoalState
 	var desiredJSON, observedJSON sql.NullString
 	var evidenceJSON string
-	var tombstoned int
+	var tombstoned, executionPending int
 	if err := row.Scan(&state.WorkspaceID, &state.AgentSessionID, &desiredJSON, &observedJSON,
 		&state.Revision, &tombstoned, &state.SyncStatus, &state.PendingOperationID,
-		&evidenceJSON, &state.LastError, &state.ObservedAtUnixMS,
+		&executionPending, &evidenceJSON, &state.LastError, &state.ObservedAtUnixMS,
 		&state.CreatedAtUnixMS, &state.UpdatedAtUnixMS); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return SessionGoalState{}, false, nil
@@ -782,6 +786,7 @@ func scanSessionGoalState(row *sql.Row) (SessionGoalState, bool, error) {
 		return SessionGoalState{}, false, err
 	}
 	state.Tombstoned = tombstoned != 0
+	state.ExecutionPending = executionPending != 0
 	state.Desired = unmarshalNullableJSONMap(desiredJSON)
 	state.Observed = unmarshalNullableJSONMap(observedJSON)
 	state.LastEvidence, _ = unmarshalJSONMap(evidenceJSON)

--- a/packages/agent/store-sqlite/goal_state_completion.go
+++ b/packages/agent/store-sqlite/goal_state_completion.go
@@ -23,18 +23,20 @@ func updateGoalStateForOperationCompletionTx(
 	query := `
 UPDATE workspace_agent_session_goals
 SET observed_json = ?, sync_status = ?, pending_operation_id = NULL,
-    last_evidence_json = ?, last_error = ?, observed_at_unix_ms = ?, updated_at_unix_ms = ?
+    execution_pending = ?, last_evidence_json = ?, last_error = ?, observed_at_unix_ms = ?, updated_at_unix_ms = ?
 WHERE workspace_id = ? AND agent_session_id = ? AND pending_operation_id = ?
 	`
 	args := []any{
-		nullableJSONMap(input.Observed), syncStatus, evidenceJSON, stateLastError,
+		nullableJSONMap(input.Observed), syncStatus,
+		boolInt(input.ExecutionPending && goalExecutionPendingAfterObservation(true, input.Observed, syncStatus)),
+		evidenceJSON, stateLastError,
 		observedAtUnixMS, input.OccurredAtUnixMS, input.WorkspaceID, op.AgentSessionID, input.OperationID,
 	}
 	if localStop {
 		query = `
 UPDATE workspace_agent_session_goals
 SET observed_json = ?, sync_status = ?, pending_operation_id = NULL,
-    last_evidence_json = ?, last_error = ?, observed_at_unix_ms = ?, updated_at_unix_ms = ?
+    execution_pending = 0, last_evidence_json = ?, last_error = ?, observed_at_unix_ms = ?, updated_at_unix_ms = ?
 WHERE workspace_id = ? AND agent_session_id = ? AND revision = ?
   AND (pending_operation_id = ? OR pending_operation_id IS NULL)
 		`

--- a/packages/agent/store-sqlite/goal_state_helpers.go
+++ b/packages/agent/store-sqlite/goal_state_helpers.go
@@ -41,6 +41,13 @@ func goalStateConverged(desired, observed map[string]any, tombstoned bool) bool 
 	return false
 }
 
+func goalExecutionPendingAfterObservation(current bool, observed map[string]any, syncStatus string) bool {
+	if !current || (syncStatus != GoalSyncStatusApplying && syncStatus != GoalSyncStatusSynced) {
+		return false
+	}
+	return strings.TrimSpace(asJSONMapString(observed, "status")) == "active"
+}
+
 // normalizeObservedGoalTiming keeps one durable clock for each Goal
 // generation. Provider observations often omit timing, so preserve the
 // canonical desired/observed start for the same objective and stamp only a

--- a/packages/agent/store-sqlite/goal_state_reads.go
+++ b/packages/agent/store-sqlite/goal_state_reads.go
@@ -1,0 +1,83 @@
+package storesqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ListSessionGoalStates returns the durable Goal state for the requested
+// Sessions in one bounded read. Missing rows are omitted from the result.
+func (s *Store) ListSessionGoalStates(ctx context.Context, workspaceID string, agentSessionIDs []string) (map[string]SessionGoalState, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("workspace database is not initialized")
+	}
+	workspaceID = strings.TrimSpace(workspaceID)
+	ids := make([]string, 0, len(agentSessionIDs))
+	seen := make(map[string]struct{}, len(agentSessionIDs))
+	for _, rawID := range agentSessionIDs {
+		id := strings.TrimSpace(rawID)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	if workspaceID == "" || len(ids) == 0 {
+		return map[string]SessionGoalState{}, nil
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",")
+	args := make([]any, 0, len(ids)+1)
+	args = append(args, workspaceID)
+	for _, id := range ids {
+		args = append(args, id)
+	}
+	rows, err := s.db.QueryContext(ctx, sessionGoalStateSelectSQL+`
+WHERE workspace_id = ? AND agent_session_id IN (`+placeholders+`)
+ORDER BY agent_session_id ASC
+`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list workspace agent session Goal states: %w", err)
+	}
+	defer rows.Close()
+	result := make(map[string]SessionGoalState, len(ids))
+	for rows.Next() {
+		state, found, err := scanSessionGoalStateRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		if found {
+			result[state.AgentSessionID] = state
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate workspace agent session Goal states: %w", err)
+	}
+	return result, nil
+}
+
+func scanSessionGoalStateRows(row rowScanner) (SessionGoalState, bool, error) {
+	var state SessionGoalState
+	var desiredJSON, observedJSON sql.NullString
+	var evidenceJSON string
+	var tombstoned int
+	if err := row.Scan(&state.WorkspaceID, &state.AgentSessionID, &desiredJSON, &observedJSON,
+		&state.Revision, &tombstoned, &state.SyncStatus, &state.PendingOperationID,
+		&evidenceJSON, &state.LastError, &state.ObservedAtUnixMS,
+		&state.CreatedAtUnixMS, &state.UpdatedAtUnixMS); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return SessionGoalState{}, false, nil
+		}
+		return SessionGoalState{}, false, err
+	}
+	state.Tombstoned = tombstoned != 0
+	state.Desired = unmarshalNullableJSONMap(desiredJSON)
+	state.Observed = unmarshalNullableJSONMap(observedJSON)
+	state.LastEvidence, _ = unmarshalJSONMap(evidenceJSON)
+	return state, true, nil
+}

--- a/packages/agent/store-sqlite/goal_state_reads.go
+++ b/packages/agent/store-sqlite/goal_state_reads.go
@@ -65,10 +65,10 @@ func scanSessionGoalStateRows(row rowScanner) (SessionGoalState, bool, error) {
 	var state SessionGoalState
 	var desiredJSON, observedJSON sql.NullString
 	var evidenceJSON string
-	var tombstoned int
+	var tombstoned, executionPending int
 	if err := row.Scan(&state.WorkspaceID, &state.AgentSessionID, &desiredJSON, &observedJSON,
 		&state.Revision, &tombstoned, &state.SyncStatus, &state.PendingOperationID,
-		&evidenceJSON, &state.LastError, &state.ObservedAtUnixMS,
+		&executionPending, &evidenceJSON, &state.LastError, &state.ObservedAtUnixMS,
 		&state.CreatedAtUnixMS, &state.UpdatedAtUnixMS); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return SessionGoalState{}, false, nil
@@ -76,6 +76,7 @@ func scanSessionGoalStateRows(row rowScanner) (SessionGoalState, bool, error) {
 		return SessionGoalState{}, false, err
 	}
 	state.Tombstoned = tombstoned != 0
+	state.ExecutionPending = executionPending != 0
 	state.Desired = unmarshalNullableJSONMap(desiredJSON)
 	state.Observed = unmarshalNullableJSONMap(observedJSON)
 	state.LastEvidence, _ = unmarshalJSONMap(evidenceJSON)

--- a/packages/agent/store-sqlite/goal_state_test.go
+++ b/packages/agent/store-sqlite/goal_state_test.go
@@ -306,13 +306,38 @@ func TestGoalControlOperationPersistsWithoutTurn(t *testing.T) {
 		WorkspaceID: "ws-1", OperationID: "goal-op-1", Succeeded: true,
 		Observed:         map[string]any{"objective": "ship it", "status": "active"},
 		Evidence:         map[string]any{"source": "provider_ack", "confidence": "authoritative"},
+		ExecutionPending: true,
 		OccurredAtUnixMS: 30,
 	})
-	if err != nil || !changed || op.Status != GoalOperationStatusCompleted || state.SyncStatus != GoalSyncStatusSynced || state.PendingOperationID != "" {
+	if err != nil || !changed || op.Status != GoalOperationStatusCompleted || state.SyncStatus != GoalSyncStatusSynced || state.PendingOperationID != "" || !state.ExecutionPending {
 		t.Fatalf("complete op=%#v state=%#v changed=%v error=%v", op, state, changed, err)
 	}
 	if jsonMapInt64(state.Observed, "startedAtUnixMs") != 20 {
 		t.Fatalf("completed Goal lost canonical start: %#v", state.Observed)
+	}
+	if _, accepted, err := store.RecordTurnTransition(ctx, TurnTransition{
+		WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "invocation-turn-1",
+		Phase: TurnPhaseSettled, Outcome: TurnOutcomeCompleted, Origin: TurnOriginUserPrompt,
+		SourceGoalOperationID: "goal-op-1", SourceGoalRevision: 1,
+		SourceGoalRepairEpoch: 0, OccurredAtUnixMS: 34,
+	}); err != nil || !accepted {
+		t.Fatalf("record non-Goal Turn accepted=%v error=%v", accepted, err)
+	}
+	state, found, err = store.GetSessionGoalState(ctx, "ws-1", "session-1")
+	if err != nil || !found || !state.ExecutionPending {
+		t.Fatalf("non-Goal Turn cleared execution pending: %#v found=%v error=%v", state, found, err)
+	}
+	if _, accepted, err := store.RecordTurnTransition(ctx, TurnTransition{
+		WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "goal-turn-1",
+		Phase: TurnPhaseRunning, Origin: TurnOriginGoalArm,
+		SourceGoalOperationID: "goal-op-1", SourceGoalRevision: 1,
+		SourceGoalRepairEpoch: 0, OccurredAtUnixMS: 35,
+	}); err != nil || !accepted {
+		t.Fatalf("record exact Goal Turn accepted=%v error=%v", accepted, err)
+	}
+	state, found, err = store.GetSessionGoalState(ctx, "ws-1", "session-1")
+	if err != nil || !found || state.ExecutionPending {
+		t.Fatalf("Goal Turn did not clear execution pending: %#v found=%v error=%v", state, found, err)
 	}
 
 	_, cleared, created, err := store.PrepareGoalControlOperation(ctx, GoalControlOperationPrepare{
@@ -328,6 +353,32 @@ func TestGoalControlOperationPersistsWithoutTurn(t *testing.T) {
 	})
 	if err != nil || !changed || cleared.SyncStatus != GoalSyncStatusSynced || len(cleared.Observed) != 0 {
 		t.Fatalf("clear completion state=%#v changed=%v error=%v", cleared, changed, err)
+	}
+}
+
+func TestGoalExecutionPendingAfterObservationRequiresExecutingState(t *testing.T) {
+	t.Parallel()
+	active := map[string]any{"status": "active"}
+	for _, tc := range []struct {
+		name       string
+		current    bool
+		observed   map[string]any
+		syncStatus string
+		want       bool
+	}{
+		{name: "applying active", current: true, observed: active, syncStatus: GoalSyncStatusApplying, want: true},
+		{name: "synced active", current: true, observed: active, syncStatus: GoalSyncStatusSynced, want: true},
+		{name: "unknown active", current: true, observed: active, syncStatus: GoalSyncStatusUnknown},
+		{name: "failed active", current: true, observed: active, syncStatus: GoalSyncStatusFailed},
+		{name: "diverged active", current: true, observed: active, syncStatus: GoalSyncStatusDiverged},
+		{name: "synced complete", current: true, observed: map[string]any{"status": "complete"}, syncStatus: GoalSyncStatusSynced},
+		{name: "not previously pending", observed: active, syncStatus: GoalSyncStatusSynced},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := goalExecutionPendingAfterObservation(tc.current, tc.observed, tc.syncStatus); got != tc.want {
+				t.Fatalf("goalExecutionPendingAfterObservation() = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 
@@ -476,8 +527,9 @@ func TestGoalAcceptedIgnoresSessionMetadataUntilHostCompletesOperation(t *testin
 	_, state, changed, err := store.AcknowledgeGoalControlOperation(ctx, GoalControlOperationAcknowledge{
 		WorkspaceID: "ws-accepted", OperationID: "goal-op-accepted",
 		Evidence: map[string]any{"phase": "accepted"}, OccurredAtUnixMS: 22,
+		ExecutionPending: true,
 	})
-	if err != nil || !changed || state.SyncStatus != GoalSyncStatusApplying || state.PendingOperationID != "goal-op-accepted" {
+	if err != nil || !changed || state.SyncStatus != GoalSyncStatusApplying || state.PendingOperationID != "goal-op-accepted" || !state.ExecutionPending {
 		t.Fatalf("ack state=%#v changed=%v error=%v", state, changed, err)
 	}
 	appliedReport, err := store.ReportSessionState(ctx, SessionStateReport{
@@ -492,7 +544,7 @@ func TestGoalAcceptedIgnoresSessionMetadataUntilHostCompletesOperation(t *testin
 	assertParticipantMutationKinds(t, appliedReport.CommitDelta,
 		MutationEntitySession, MutationEntityGoalState)
 	state, found, err := store.GetSessionGoalState(ctx, "ws-accepted", "session-accepted")
-	if err != nil || !found || state.SyncStatus != GoalSyncStatusApplying || state.PendingOperationID != "goal-op-accepted" {
+	if err != nil || !found || state.SyncStatus != GoalSyncStatusApplying || state.PendingOperationID != "goal-op-accepted" || !state.ExecutionPending {
 		t.Fatalf("reported state=%#v found=%v error=%v", state, found, err)
 	}
 	if jsonMapInt64(state.Observed, "startedAtUnixMs") != 20 {
@@ -506,7 +558,8 @@ func TestGoalAcceptedIgnoresSessionMetadataUntilHostCompletesOperation(t *testin
 		WorkspaceID: "ws-accepted", OperationID: "goal-op-accepted", Succeeded: true,
 		Observed: map[string]any{"objective": "ship it", "status": "active"},
 		Evidence: map[string]any{"source": "runtime_goal_control_lifecycle"}, OccurredAtUnixMS: 31,
-	}); err != nil || !changed || state.SyncStatus != GoalSyncStatusSynced || state.PendingOperationID != "" {
+		ExecutionPending: state.ExecutionPending,
+	}); err != nil || !changed || state.SyncStatus != GoalSyncStatusSynced || state.PendingOperationID != "" || !state.ExecutionPending {
 		t.Fatalf("completed state=%#v changed=%v error=%v", state, changed, err)
 	}
 	repair, _, created, err := store.EnsureOrWakeGoalRepairOperation(ctx, EnsureGoalRepairOperationInput{WorkspaceID: "ws-accepted", AgentSessionID: "session-accepted", SourceOperationID: "stale-provider-op", SourceRevision: 0, CurrentRevision: 1, OccurredAtUnixMS: 40})

--- a/packages/agent/store-sqlite/goal_state_test.go
+++ b/packages/agent/store-sqlite/goal_state_test.go
@@ -7,6 +7,44 @@ import (
 	"testing"
 )
 
+func TestListSessionGoalStatesReturnsRequestedRowsInOneRead(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	ctx := context.Background()
+	for index, sessionID := range []string{"session-1", "session-2"} {
+		if _, err := store.ReportSessionState(ctx, SessionStateReport{
+			AgentSessionID:   sessionID,
+			OccurredAtUnixMS: int64(index + 1),
+			Provider:         "codex",
+			WorkspaceID:      "workspace-goal-list",
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, _, err := store.PrepareGoalControlOperation(ctx, GoalControlOperationPrepare{
+			Action:           "set",
+			AgentSessionID:   sessionID,
+			Objective:        "ship " + sessionID,
+			OccurredAtUnixMS: int64(index + 10),
+			OperationID:      "goal-" + sessionID,
+			WorkspaceID:      "workspace-goal-list",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	states, err := store.ListSessionGoalStates(ctx, " workspace-goal-list ", []string{
+		" session-2 ", "session-missing", "session-1", "session-2", "",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(states) != 2 ||
+		states["session-1"].PendingOperationID != "goal-session-1" ||
+		states["session-2"].PendingOperationID != "goal-session-2" {
+		t.Fatalf("states = %#v", states)
+	}
+}
+
 func TestProviderGoalAdoptionCompletesWithoutProviderRedispatch(t *testing.T) {
 	t.Parallel()
 	store := openTestStore(t, testOptions(&staticProjectPaths{}))

--- a/packages/agent/store-sqlite/goal_state_types.go
+++ b/packages/agent/store-sqlite/goal_state_types.go
@@ -52,11 +52,15 @@ type SessionGoalState struct {
 	Tombstoned          bool
 	SyncStatus          string
 	PendingOperationID  string
-	LastEvidence        map[string]any
-	LastError           string
-	ObservedAtUnixMS    int64
-	CreatedAtUnixMS     int64
-	UpdatedAtUnixMS     int64
+	// ExecutionPending is Host-owned proof that the accepted Goal command is
+	// expected to begin autonomous execution but no exact Goal Turn has been
+	// persisted yet. It is cleared by the first provenance-matched Turn.
+	ExecutionPending bool
+	LastEvidence     map[string]any
+	LastError        string
+	ObservedAtUnixMS int64
+	CreatedAtUnixMS  int64
+	UpdatedAtUnixMS  int64
 }
 
 type GoalControlOperation struct {
@@ -126,6 +130,7 @@ type GoalControlOperationComplete struct {
 	Evidence         map[string]any
 	LastError        string
 	Succeeded        bool
+	ExecutionPending bool
 	OccurredAtUnixMS int64
 	RepairEpoch      int64
 }
@@ -136,6 +141,7 @@ type GoalControlOperationAcknowledge struct {
 	Evidence         map[string]any
 	OccurredAtUnixMS int64
 	RepairEpoch      int64
+	ExecutionPending bool
 }
 
 type GoalObservationReconcile struct {

--- a/packages/agent/store-sqlite/goal_terminal_fence.go
+++ b/packages/agent/store-sqlite/goal_terminal_fence.go
@@ -42,7 +42,7 @@ last_source_id=excluded.last_source_id,updated_at_unix_ms=excluded.updated_at_un
 		return err
 	}
 	_, err := tx.ExecContext(ctx, `UPDATE workspace_agent_session_goals
-SET sync_status=?,last_error=?,pending_operation_id=NULL,updated_at_unix_ms=?
+SET sync_status=?,last_error=?,pending_operation_id=NULL,execution_pending=0,updated_at_unix_ms=?
 WHERE workspace_id=? AND agent_session_id=? AND revision=?`, GoalSyncStatusUnknown, lastError, occurredAt,
 		state.WorkspaceID, state.AgentSessionID, state.Revision)
 	return err

--- a/packages/agent/store-sqlite/migrations.go
+++ b/packages/agent/store-sqlite/migrations.go
@@ -66,6 +66,7 @@ const schemaMigrationWorkspaceAgentGoalStateV4 = "workspace_agent_goal_state_v4"
 const schemaMigrationWorkspaceAgentGoalStateV5 = "workspace_agent_goal_state_v5"
 const schemaMigrationWorkspaceAgentGoalStateV6 = "workspace_agent_goal_state_v6"
 const schemaMigrationWorkspaceAgentGoalStateV7 = "workspace_agent_goal_state_v7"
+const schemaMigrationWorkspaceAgentGoalStateV8 = "workspace_agent_goal_state_v8"
 const schemaMigrationWorkspaceAgentGoalProvenanceLedgerV1 = "workspace_agent_goal_provenance_ledger_v1"
 const schemaMigrationWorkspaceAgentGoalGenerationFencesV1 = "workspace_agent_goal_generation_fences_v1"
 const schemaMigrationWorkspaceAgentMessageSemanticsV1 = "workspace_agent_message_semantics_v1"
@@ -257,6 +258,9 @@ CREATE TABLE IF NOT EXISTS `+schemaMigrationsTable+` (
 		return err
 	}
 	if err := s.applyWorkspaceAgentGoalStateV7(ctx); err != nil {
+		return err
+	}
+	if err := s.applyWorkspaceAgentGoalStateV8(ctx); err != nil {
 		return err
 	}
 	if err := s.applyWorkspaceAgentGoalProvenanceLedgerV1(ctx); err != nil {

--- a/packages/agent/store-sqlite/migrations_goal_state.go
+++ b/packages/agent/store-sqlite/migrations_goal_state.go
@@ -30,6 +30,7 @@ CREATE TABLE workspace_agent_session_goals (
   tombstoned INTEGER NOT NULL DEFAULT 0 CHECK (tombstoned IN (0,1)),
   sync_status TEXT NOT NULL CHECK (sync_status IN ('pending','applying','synced','diverged','unknown','failed')),
   pending_operation_id TEXT,
+  execution_pending INTEGER NOT NULL DEFAULT 0 CHECK (execution_pending IN (0,1)),
   last_evidence_json TEXT NOT NULL DEFAULT '{}' CHECK (json_valid(last_evidence_json)),
   last_error TEXT NOT NULL DEFAULT '',
   observed_at_unix_ms INTEGER,

--- a/packages/agent/store-sqlite/migrations_goal_state_v8.go
+++ b/packages/agent/store-sqlite/migrations_goal_state_v8.go
@@ -1,0 +1,31 @@
+package storesqlite
+
+import (
+	"context"
+	"fmt"
+)
+
+func (s *Store) applyWorkspaceAgentGoalStateV8(ctx context.Context) error {
+	applied, err := s.hasMigration(ctx, schemaMigrationWorkspaceAgentGoalStateV8)
+	if err != nil || applied {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	exists, err := hasColumnTx(ctx, tx, "workspace_agent_session_goals", "execution_pending")
+	if err != nil {
+		return err
+	}
+	if !exists {
+		if _, err = tx.ExecContext(ctx, `ALTER TABLE workspace_agent_session_goals ADD COLUMN execution_pending INTEGER NOT NULL DEFAULT 0 CHECK (execution_pending IN (0,1))`); err != nil {
+			return fmt.Errorf("add Goal execution-pending state: %w", err)
+		}
+	}
+	if err = recordMigrationTx(ctx, tx, schemaMigrationWorkspaceAgentGoalStateV8); err != nil {
+		return err
+	}
+	return tx.Commit()
+}

--- a/packages/clients/tuttid-ts/src/generated/index.ts
+++ b/packages/clients/tuttid-ts/src/generated/index.ts
@@ -2031,6 +2031,7 @@ export type {
   WorkspaceAgentSessionGoalControlResponse,
   WorkspaceAgentSessionGoalState,
   WorkspaceAgentSessionGoalStateResponse,
+  WorkspaceAgentSessionGoalSyncState,
   WorkspaceAgentSessionIsolation,
   WorkspaceAgentSessionIsolationMode,
   WorkspaceAgentSessionKind,

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -3187,6 +3187,10 @@ export type WorkspaceAgentSessionGoalSyncState = {
     | "unknown"
     | "failed";
   pendingOperationId: string | null;
+  /**
+   * Host-owned proof that an accepted initial Goal is expected to begin autonomous execution and has not produced its first exact Goal Turn yet.
+   */
+  executionPending: boolean;
 };
 
 export type WorkspaceAgentSessionGoalState = {

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -2567,6 +2567,10 @@ export type WorkspaceAgentSession = {
    */
   goal: WorkspaceAgentSessionGoal | null;
   /**
+   * Narrow Host-owned evidence for the durable Goal operation. Null means no Goal state exists for this Session; clients must not infer pending execution from the visible Goal alone.
+   */
+  goalSyncState: WorkspaceAgentSessionGoalSyncState | null;
+  /**
    * Independent, session-scoped Tutti mode activation projection. Null until the first activation revision exists; capability references are audit records and never determine this state.
    */
   tuttiModeActivation: TuttiModeActivation | null;
@@ -3171,6 +3175,18 @@ export type WorkspaceAgentSessionGoalControlResponse = {
    */
   operationId?: string | null;
   state?: WorkspaceAgentSessionGoalState | null;
+};
+
+export type WorkspaceAgentSessionGoalSyncState = {
+  revision: number;
+  syncStatus:
+    | "pending"
+    | "applying"
+    | "synced"
+    | "diverged"
+    | "unknown"
+    | "failed";
+  pendingOperationId: string | null;
 };
 
 export type WorkspaceAgentSessionGoalState = {

--- a/services/tuttid/api/daemon_agent_prompt_content.go
+++ b/services/tuttid/api/daemon_agent_prompt_content.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	tuttigenerated "github.com/tutti-os/tutti/services/tuttid/api/generated"
+	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
+)
+
+func agentPromptContentFromGenerated(content []tuttigenerated.AgentPromptContentBlock) []agentservice.PromptContentBlock {
+	result := make([]agentservice.PromptContentBlock, 0, len(content))
+	for _, block := range content {
+		item := agentservice.PromptContentBlock{
+			Type: string(block.Type),
+		}
+		if block.Text != nil {
+			item.Text = *block.Text
+		}
+		if block.MimeType != nil {
+			item.MimeType = string(*block.MimeType)
+		}
+		if block.Data != nil {
+			item.Data = *block.Data
+		}
+		if block.Url != nil {
+			item.URL = *block.Url
+		}
+		if block.AttachmentId != nil {
+			item.AttachmentID = *block.AttachmentId
+		}
+		if block.Name != nil {
+			item.Name = *block.Name
+		}
+		if block.Path != nil {
+			item.Path = *block.Path
+		}
+		if block.ConnectorKey != nil {
+			item.ConnectorKey = *block.ConnectorKey
+		}
+		result = append(result, item)
+	}
+	return result
+}

--- a/services/tuttid/api/daemon_agent_session_goal_sync.go
+++ b/services/tuttid/api/daemon_agent_session_goal_sync.go
@@ -21,5 +21,6 @@ func generatedAgentSessionGoalSyncState(
 		PendingOperationId: optionalStringPointer(strings.TrimSpace(state.PendingOperationID)),
 		Revision:           state.Revision,
 		SyncStatus:         syncStatus,
+		ExecutionPending:   state.ExecutionPending,
 	}
 }

--- a/services/tuttid/api/daemon_agent_session_goal_sync.go
+++ b/services/tuttid/api/daemon_agent_session_goal_sync.go
@@ -1,0 +1,25 @@
+package api
+
+import (
+	"strings"
+
+	tuttigenerated "github.com/tutti-os/tutti/services/tuttid/api/generated"
+	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
+)
+
+func generatedAgentSessionGoalSyncState(
+	state *agentservice.SessionGoalSyncState,
+) *tuttigenerated.WorkspaceAgentSessionGoalSyncState {
+	if state == nil {
+		return nil
+	}
+	syncStatus := tuttigenerated.WorkspaceAgentSessionGoalSyncStateSyncStatus(state.SyncStatus)
+	if !syncStatus.Valid() {
+		syncStatus = tuttigenerated.WorkspaceAgentSessionGoalSyncStateSyncStatusUnknown
+	}
+	return &tuttigenerated.WorkspaceAgentSessionGoalSyncState{
+		PendingOperationId: optionalStringPointer(strings.TrimSpace(state.PendingOperationID)),
+		Revision:           state.Revision,
+		SyncStatus:         syncStatus,
+	}
+}

--- a/services/tuttid/api/daemon_agent_session_helpers.go
+++ b/services/tuttid/api/daemon_agent_session_helpers.go
@@ -1,0 +1,8 @@
+package api
+
+func stringPtrValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}

--- a/services/tuttid/api/daemon_agent_sessions.go
+++ b/services/tuttid/api/daemon_agent_sessions.go
@@ -686,48 +686,6 @@ func generatedAgentGeneratedFiles(files []agentservice.GeneratedFile) []tuttigen
 	return result
 }
 
-func stringPtrValue(value *string) string {
-	if value == nil {
-		return ""
-	}
-	return *value
-}
-
-func agentPromptContentFromGenerated(content []tuttigenerated.AgentPromptContentBlock) []agentservice.PromptContentBlock {
-	result := make([]agentservice.PromptContentBlock, 0, len(content))
-	for _, block := range content {
-		item := agentservice.PromptContentBlock{
-			Type: string(block.Type),
-		}
-		if block.Text != nil {
-			item.Text = *block.Text
-		}
-		if block.MimeType != nil {
-			item.MimeType = string(*block.MimeType)
-		}
-		if block.Data != nil {
-			item.Data = *block.Data
-		}
-		if block.Url != nil {
-			item.URL = *block.Url
-		}
-		if block.AttachmentId != nil {
-			item.AttachmentID = *block.AttachmentId
-		}
-		if block.Name != nil {
-			item.Name = *block.Name
-		}
-		if block.Path != nil {
-			item.Path = *block.Path
-		}
-		if block.ConnectorKey != nil {
-			item.ConnectorKey = *block.ConnectorKey
-		}
-		result = append(result, item)
-	}
-	return result
-}
-
 func generatedAgentSession(session agentservice.Session) (tuttigenerated.WorkspaceAgentSession, error) {
 	var settings *tuttigenerated.AgentSessionComposerSettings
 	if session.Settings != nil {
@@ -785,6 +743,7 @@ func generatedAgentSession(session agentservice.Session) (tuttigenerated.Workspa
 			TargetTurnId:         strings.TrimSpace(session.ForkedFrom.TargetTurnID),
 		}
 	}
+	goalSyncState := generatedAgentSessionGoalSyncState(session.GoalSyncState)
 	return tuttigenerated.WorkspaceAgentSession{
 		ActiveTurn:             activeTurn,
 		ActiveTurnId:           optionalStringPointer(strings.TrimSpace(session.ActiveTurnID)),
@@ -795,6 +754,7 @@ func generatedAgentSession(session agentservice.Session) (tuttigenerated.Workspa
 		EndedAtUnixMs:          endedAtUnixMS,
 		ForkedFrom:             forkedFrom,
 		Goal:                   generatedAgentSessionGoal(session.Metadata.Goal),
+		GoalSyncState:          goalSyncState,
 		Id:                     session.ID,
 		Imported:               session.Metadata.Imported,
 		Isolation:              generatedAgentSessionIsolation(session.Isolation),

--- a/services/tuttid/api/daemon_agent_sessions_latest_turn_test.go
+++ b/services/tuttid/api/daemon_agent_sessions_latest_turn_test.go
@@ -45,6 +45,7 @@ func TestGeneratedAgentSessionIncludesIndependentLatestTurnProjection(t *testing
 			PendingOperationID: "goal-operation-1",
 			Revision:           3,
 			SyncStatus:         agentactivitybiz.GoalSyncStatusApplying,
+			ExecutionPending:   true,
 		},
 		Capabilities: canonical.NewCapabilitySnapshot([]string{"planMode", "planImplementation"}),
 		Metadata: agentactivitybiz.SessionMetadata{
@@ -85,7 +86,8 @@ func TestGeneratedAgentSessionIncludesIndependentLatestTurnProjection(t *testing
 		generated.GoalSyncState.Revision != 3 ||
 		generated.GoalSyncState.SyncStatus != "applying" ||
 		generated.GoalSyncState.PendingOperationId == nil ||
-		*generated.GoalSyncState.PendingOperationId != "goal-operation-1" {
+		*generated.GoalSyncState.PendingOperationId != "goal-operation-1" ||
+		!generated.GoalSyncState.ExecutionPending {
 		t.Fatalf("goal sync state = %#v", generated.GoalSyncState)
 	}
 	encoded, err := json.Marshal(generated)

--- a/services/tuttid/api/daemon_agent_sessions_latest_turn_test.go
+++ b/services/tuttid/api/daemon_agent_sessions_latest_turn_test.go
@@ -41,7 +41,12 @@ func TestGeneratedAgentSessionIncludesIndependentLatestTurnProjection(t *testing
 		MessageVersion:         11,
 		LatestTurn:             &latest,
 		LatestTurnInteractions: latestInteractions,
-		Capabilities:           canonical.NewCapabilitySnapshot([]string{"planMode", "planImplementation"}),
+		GoalSyncState: &agentservice.SessionGoalSyncState{
+			PendingOperationID: "goal-operation-1",
+			Revision:           3,
+			SyncStatus:         agentactivitybiz.GoalSyncStatusApplying,
+		},
+		Capabilities: canonical.NewCapabilitySnapshot([]string{"planMode", "planImplementation"}),
 		Metadata: agentactivitybiz.SessionMetadata{
 			Usage: &agentactivitybiz.SessionUsage{
 				ContextWindow: &agentactivitybiz.SessionUsageContextWindow{UsedTokens: 7_460, TotalTokens: 200_000},
@@ -75,6 +80,13 @@ func TestGeneratedAgentSessionIncludesIndependentLatestTurnProjection(t *testing
 	}
 	if generated.RailSectionKey != "project:repo-1" {
 		t.Fatalf("rail section key = %q, want project:repo-1", generated.RailSectionKey)
+	}
+	if generated.GoalSyncState == nil ||
+		generated.GoalSyncState.Revision != 3 ||
+		generated.GoalSyncState.SyncStatus != "applying" ||
+		generated.GoalSyncState.PendingOperationId == nil ||
+		*generated.GoalSyncState.PendingOperationId != "goal-operation-1" {
+		t.Fatalf("goal sync state = %#v", generated.GoalSyncState)
 	}
 	encoded, err := json.Marshal(generated)
 	if err != nil {

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -9002,6 +9002,8 @@ type WorkspaceAgentSessionGoalStateResponse struct {
 
 // WorkspaceAgentSessionGoalSyncState defines model for WorkspaceAgentSessionGoalSyncState.
 type WorkspaceAgentSessionGoalSyncState struct {
+	// ExecutionPending Host-owned proof that an accepted initial Goal is expected to begin autonomous execution and has not produced its first exact Goal Turn yet.
+	ExecutionPending   bool                                         `json:"executionPending"`
 	PendingOperationId *string                                      `json:"pendingOperationId"`
 	Revision           int64                                        `json:"revision"`
 	SyncStatus         WorkspaceAgentSessionGoalSyncStateSyncStatus `json:"syncStatus"`

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -3640,6 +3640,36 @@ func (e WorkspaceAgentSessionGoalStateSyncStatus) Valid() bool {
 	}
 }
 
+// Defines values for WorkspaceAgentSessionGoalSyncStateSyncStatus.
+const (
+	WorkspaceAgentSessionGoalSyncStateSyncStatusApplying WorkspaceAgentSessionGoalSyncStateSyncStatus = "applying"
+	WorkspaceAgentSessionGoalSyncStateSyncStatusDiverged WorkspaceAgentSessionGoalSyncStateSyncStatus = "diverged"
+	WorkspaceAgentSessionGoalSyncStateSyncStatusFailed   WorkspaceAgentSessionGoalSyncStateSyncStatus = "failed"
+	WorkspaceAgentSessionGoalSyncStateSyncStatusPending  WorkspaceAgentSessionGoalSyncStateSyncStatus = "pending"
+	WorkspaceAgentSessionGoalSyncStateSyncStatusSynced   WorkspaceAgentSessionGoalSyncStateSyncStatus = "synced"
+	WorkspaceAgentSessionGoalSyncStateSyncStatusUnknown  WorkspaceAgentSessionGoalSyncStateSyncStatus = "unknown"
+)
+
+// Valid indicates whether the value is a known member of the WorkspaceAgentSessionGoalSyncStateSyncStatus enum.
+func (e WorkspaceAgentSessionGoalSyncStateSyncStatus) Valid() bool {
+	switch e {
+	case WorkspaceAgentSessionGoalSyncStateSyncStatusApplying:
+		return true
+	case WorkspaceAgentSessionGoalSyncStateSyncStatusDiverged:
+		return true
+	case WorkspaceAgentSessionGoalSyncStateSyncStatusFailed:
+		return true
+	case WorkspaceAgentSessionGoalSyncStateSyncStatusPending:
+		return true
+	case WorkspaceAgentSessionGoalSyncStateSyncStatusSynced:
+		return true
+	case WorkspaceAgentSessionGoalSyncStateSyncStatusUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for WorkspaceAgentSessionIsolationMode.
 const (
 	WorkspaceAgentSessionIsolationModeWorktree WorkspaceAgentSessionIsolationMode = "worktree"
@@ -4500,25 +4530,25 @@ func (e WorkspaceWorkflowOperationKind) Valid() bool {
 
 // Defines values for WorkspaceWorkflowOperationStatus.
 const (
-	Canceled  WorkspaceWorkflowOperationStatus = "canceled"
-	Failed    WorkspaceWorkflowOperationStatus = "failed"
-	Pending   WorkspaceWorkflowOperationStatus = "pending"
-	Running   WorkspaceWorkflowOperationStatus = "running"
-	Succeeded WorkspaceWorkflowOperationStatus = "succeeded"
+	WorkspaceWorkflowOperationStatusCanceled  WorkspaceWorkflowOperationStatus = "canceled"
+	WorkspaceWorkflowOperationStatusFailed    WorkspaceWorkflowOperationStatus = "failed"
+	WorkspaceWorkflowOperationStatusPending   WorkspaceWorkflowOperationStatus = "pending"
+	WorkspaceWorkflowOperationStatusRunning   WorkspaceWorkflowOperationStatus = "running"
+	WorkspaceWorkflowOperationStatusSucceeded WorkspaceWorkflowOperationStatus = "succeeded"
 )
 
 // Valid indicates whether the value is a known member of the WorkspaceWorkflowOperationStatus enum.
 func (e WorkspaceWorkflowOperationStatus) Valid() bool {
 	switch e {
-	case Canceled:
+	case WorkspaceWorkflowOperationStatusCanceled:
 		return true
-	case Failed:
+	case WorkspaceWorkflowOperationStatusFailed:
 		return true
-	case Pending:
+	case WorkspaceWorkflowOperationStatusPending:
 		return true
-	case Running:
+	case WorkspaceWorkflowOperationStatusRunning:
 		return true
-	case Succeeded:
+	case WorkspaceWorkflowOperationStatusSucceeded:
 		return true
 	default:
 		return false
@@ -8739,7 +8769,10 @@ type WorkspaceAgentSession struct {
 
 	// Goal Protocol v2. Explicit field extracted from runtimeContext.
 	Goal *WorkspaceAgentSessionGoal `json:"goal"`
-	Id   string                     `json:"id"`
+
+	// GoalSyncState Narrow Host-owned evidence for the durable Goal operation. Null means no Goal state exists for this Session; clients must not infer pending execution from the visible Goal alone.
+	GoalSyncState *WorkspaceAgentSessionGoalSyncState `json:"goalSyncState"`
+	Id            string                              `json:"id"`
 
 	// Imported Protocol v2. True when the session was imported from external provider history. Explicit field extracted from runtimeContext.
 	Imported bool `json:"imported"`
@@ -8966,6 +8999,16 @@ type WorkspaceAgentSessionGoalStateResponse struct {
 	Session WorkspaceAgentSession          `json:"session"`
 	State   WorkspaceAgentSessionGoalState `json:"state"`
 }
+
+// WorkspaceAgentSessionGoalSyncState defines model for WorkspaceAgentSessionGoalSyncState.
+type WorkspaceAgentSessionGoalSyncState struct {
+	PendingOperationId *string                                      `json:"pendingOperationId"`
+	Revision           int64                                        `json:"revision"`
+	SyncStatus         WorkspaceAgentSessionGoalSyncStateSyncStatus `json:"syncStatus"`
+}
+
+// WorkspaceAgentSessionGoalSyncStateSyncStatus defines model for WorkspaceAgentSessionGoalSyncState.SyncStatus.
+type WorkspaceAgentSessionGoalSyncStateSyncStatus string
 
 // WorkspaceAgentSessionIsolation defines model for WorkspaceAgentSessionIsolation.
 type WorkspaceAgentSessionIsolation struct {

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -14306,6 +14306,7 @@ components:
         - revision
         - syncStatus
         - pendingOperationId
+        - executionPending
       properties:
         revision:
           type: integer
@@ -14323,6 +14324,12 @@ components:
         pendingOperationId:
           type: string
           nullable: true
+        executionPending:
+          type: boolean
+          description: >-
+            Host-owned proof that an accepted initial Goal is expected to
+            begin autonomous execution and has not produced its first exact
+            Goal Turn yet.
     WorkspaceAgentSessionGoalState:
       type: object
       additionalProperties: false

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -12685,6 +12685,7 @@ components:
         - forkedFrom
         - usage
         - goal
+        - goalSyncState
         - tuttiModeActivation
         - imported
       properties:
@@ -12833,6 +12834,14 @@ components:
             - $ref: "#/components/schemas/WorkspaceAgentSessionGoal"
           nullable: true
           description: Protocol v2. Explicit field extracted from runtimeContext.
+        goalSyncState:
+          allOf:
+            - $ref: "#/components/schemas/WorkspaceAgentSessionGoalSyncState"
+          nullable: true
+          description: >-
+            Narrow Host-owned evidence for the durable Goal operation. Null
+            means no Goal state exists for this Session; clients must not infer
+            pending execution from the visible Goal alone.
         tuttiModeActivation:
           allOf:
             - $ref: "#/components/schemas/TuttiModeActivation"
@@ -14289,6 +14298,30 @@ components:
         state:
           allOf:
             - $ref: "#/components/schemas/WorkspaceAgentSessionGoalState"
+          nullable: true
+    WorkspaceAgentSessionGoalSyncState:
+      type: object
+      additionalProperties: false
+      required:
+        - revision
+        - syncStatus
+        - pendingOperationId
+      properties:
+        revision:
+          type: integer
+          format: int64
+          minimum: 0
+        syncStatus:
+          type: string
+          enum:
+            - pending
+            - applying
+            - synced
+            - diverged
+            - unknown
+            - failed
+        pendingOperationId:
+          type: string
           nullable: true
     WorkspaceAgentSessionGoalState:
       type: object

--- a/services/tuttid/data/workspace/agent_store.go
+++ b/services/tuttid/data/workspace/agent_store.go
@@ -444,6 +444,10 @@ func (s *SQLiteStore) GetSessionGoalState(ctx context.Context, workspaceID, agen
 	return s.agentReadStore().GetSessionGoalState(ctx, workspaceID, agentSessionID)
 }
 
+func (s *SQLiteStore) ListSessionGoalStates(ctx context.Context, workspaceID string, agentSessionIDs []string) (map[string]agentactivitybiz.SessionGoalState, error) {
+	return s.agentReadStore().ListSessionGoalStates(ctx, workspaceID, agentSessionIDs)
+}
+
 func (s *SQLiteStore) ReconcileSessionGoalObservation(ctx context.Context, input agentactivitybiz.GoalObservationReconcile) (agentactivitybiz.SessionGoalState, error) {
 	return s.agentStore().ReconcileSessionGoalObservation(ctx, input)
 }

--- a/services/tuttid/service/agent/host_conformance_test.go
+++ b/services/tuttid/service/agent/host_conformance_test.go
@@ -463,6 +463,7 @@ func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconfo
 		return RuntimeGoalControlResult{
 			AgentSessionID: input.AgentSessionID, Goal: clonePayload(resultGoal),
 			Evidence: evidence, ProviderPhase: providerPhase,
+			ExecutionPending: input.Action == "set" && resultGoal["status"] == "active",
 		}, nil
 	}
 	if fixture.AcceptGoalControlsOnly {
@@ -1182,6 +1183,7 @@ func (d *legacyHostConformanceDriver) GoalControl(ctx context.Context, input age
 		observation.Revision = result.GoalState.Revision
 		observation.PendingOperationID = result.GoalState.PendingOperationID
 		observation.SyncStatus = result.GoalState.SyncStatus
+		observation.ExecutionPending = result.GoalState.ExecutionPending
 	}
 	return observation, err
 }
@@ -1208,7 +1210,8 @@ func (d *legacyHostConformanceDriver) AdoptProviderGoal(ctx context.Context, inp
 	return hostconformance.GoalObservation{
 		Goal: clonePayload(result.Goal), OperationID: result.OperationID,
 		Revision: state.State.Revision, PendingOperationID: state.State.PendingOperationID,
-		SyncStatus: state.State.SyncStatus,
+		SyncStatus:       state.State.SyncStatus,
+		ExecutionPending: state.State.ExecutionPending,
 	}, nil
 }
 
@@ -1254,6 +1257,7 @@ func hostGoalControlObservation(result agenthost.GoalControlResult) hostconforma
 		observation.Revision = result.GoalState.Revision
 		observation.PendingOperationID = result.GoalState.PendingOperationID
 		observation.SyncStatus = result.GoalState.SyncStatus
+		observation.ExecutionPending = result.GoalState.ExecutionPending
 	}
 	return observation
 }
@@ -1262,6 +1266,7 @@ func hostGoalStateObservation(result agenthost.GoalStateResult) hostconformance.
 	return hostconformance.GoalObservation{
 		Goal: clonePayload(result.State.Desired), Revision: result.State.Revision,
 		PendingOperationID: result.State.PendingOperationID, SyncStatus: result.State.SyncStatus,
+		ExecutionPending: result.State.ExecutionPending,
 	}
 }
 

--- a/services/tuttid/service/agent/service_turns.go
+++ b/services/tuttid/service/agent/service_turns.go
@@ -477,6 +477,7 @@ func projectedSessionGoalSyncState(state agentactivitybiz.SessionGoalState) *Ses
 		Revision:           state.Revision,
 		SyncStatus:         strings.TrimSpace(state.SyncStatus),
 		PendingOperationID: strings.TrimSpace(state.PendingOperationID),
+		ExecutionPending:   state.ExecutionPending,
 	}
 }
 

--- a/services/tuttid/service/agent/service_turns.go
+++ b/services/tuttid/service/agent/service_turns.go
@@ -24,6 +24,10 @@ type TurnStore interface {
 	ListPendingInteractionsBySession(context.Context, string, []string) (map[string][]agentactivitybiz.Interaction, error)
 }
 
+type sessionGoalStateBatchReader interface {
+	ListSessionGoalStates(context.Context, string, []string) (map[string]agentactivitybiz.SessionGoalState, error)
+}
+
 // TurnCancelObserver is notified after CancelTurn actually canceled a live
 // turn. The Issue manager uses it to cascade a user's stop on a planning
 // conversation to every running task run that conversation orchestrates.
@@ -203,10 +207,10 @@ func (s *Service) persistedActiveTurnID(ctx context.Context, workspaceID string,
 }
 
 // projectSessionForResponse is the canonical boundary for every public service
-// response that contains one Session. Keep the persisted Turn projection and
-// the Tutti-owned, session-associated activation read projection here so
-// mutations cannot accidentally return a partial Session that clears newer
-// client state.
+// response that contains one Session. Keep the persisted Turn projection, the
+// Host-owned Goal synchronization evidence, and the Tutti-owned,
+// session-associated activation read projection here so mutations cannot
+// accidentally return a partial Session that clears newer client state.
 func (s *Service) projectSessionForResponse(ctx context.Context, workspaceID string, session Session) (Session, error) {
 	return s.withProtocolV2TurnState(ctx, strings.TrimSpace(workspaceID), session)
 }
@@ -222,7 +226,8 @@ func (s *Service) projectSessionsForResponse(ctx context.Context, workspaceID st
 // persisted v2 turn state: activeTurnId pointer, embedded active/latest turns,
 // and pending interactions. latestTurn remains an independent turn entity
 // projection; it is never persisted on the session row. The Tutti-owned,
-// session-associated TuttiModeActivation read projection is attached last.
+// session-associated TuttiModeActivation and Host-owned Goal synchronization
+// read projections are attached last.
 func (s *Service) withProtocolV2TurnState(ctx context.Context, workspaceID string, session Session) (Session, error) {
 	return s.withProtocolV2TurnStateProjectionOptions(
 		ctx,
@@ -247,7 +252,11 @@ func (s *Service) withProtocolV2TurnStateProjectionOptions(
 		if err != nil {
 			return Session{}, err
 		}
-		return s.withTuttiModeActivation(ctx, workspaceID, session)
+		session, err = s.withTuttiModeActivation(ctx, workspaceID, session)
+		if err != nil {
+			return Session{}, err
+		}
+		return s.withSessionGoalSyncState(ctx, workspaceID, session)
 	}
 	latestTurn, ok, err := s.TurnStore.GetLatestTurn(ctx, workspaceID, session.ID)
 	if err != nil {
@@ -284,7 +293,11 @@ func (s *Service) withProtocolV2TurnStateProjectionOptions(
 	if err != nil {
 		return Session{}, err
 	}
-	return s.withTuttiModeActivation(ctx, workspaceID, session)
+	session, err = s.withTuttiModeActivation(ctx, workspaceID, session)
+	if err != nil {
+		return Session{}, err
+	}
+	return s.withSessionGoalSyncState(ctx, workspaceID, session)
 }
 
 func (s *Service) withProtocolV2TurnStateProjection(ctx context.Context, workspaceID string, session Session, latestTurn *agentactivitybiz.Turn, latestTurnInteractions []agentactivitybiz.Interaction) (Session, error) {
@@ -324,7 +337,11 @@ func (s *Service) withProtocolV2TurnStates(ctx context.Context, workspaceID stri
 		return sessions, nil
 	}
 	if s == nil || s.TurnStore == nil {
-		return s.withTuttiModeActivations(ctx, workspaceID, sessions)
+		result, err := s.withTuttiModeActivations(ctx, workspaceID, sessions)
+		if err != nil {
+			return nil, err
+		}
+		return s.withSessionGoalSyncStates(ctx, workspaceID, result)
 	}
 	ids := make([]string, 0, len(sessions))
 	activeTurnIDBySessionID := make(map[string]string)
@@ -370,7 +387,97 @@ func (s *Service) withProtocolV2TurnStates(ctx context.Context, workspaceID stri
 		}
 		result[i] = session
 	}
-	return s.withTuttiModeActivations(ctx, workspaceID, result)
+	result, err = s.withTuttiModeActivations(ctx, workspaceID, result)
+	if err != nil {
+		return nil, err
+	}
+	return s.withSessionGoalSyncStates(ctx, workspaceID, result)
+}
+
+func (s *Service) withSessionGoalSyncState(
+	ctx context.Context,
+	workspaceID string,
+	session Session,
+) (Session, error) {
+	session.GoalSyncState = nil
+	if s == nil || s.GoalStateStore == nil {
+		return session, nil
+	}
+	state, found, err := s.GoalStateStore.GetSessionGoalState(
+		ctx,
+		strings.TrimSpace(workspaceID),
+		strings.TrimSpace(session.ID),
+	)
+	if err != nil {
+		return Session{}, err
+	}
+	if found {
+		session.GoalSyncState = projectedSessionGoalSyncState(state)
+	}
+	return session, nil
+}
+
+func (s *Service) withSessionGoalSyncStates(
+	ctx context.Context,
+	workspaceID string,
+	sessions []Session,
+) ([]Session, error) {
+	if len(sessions) == 0 {
+		return sessions, nil
+	}
+	result := make([]Session, len(sessions))
+	for i, session := range sessions {
+		session.GoalSyncState = nil
+		result[i] = session
+	}
+	if s == nil || s.GoalStateStore == nil {
+		return result, nil
+	}
+	ids := make([]string, 0, len(sessions))
+	for _, session := range result {
+		ids = append(ids, strings.TrimSpace(session.ID))
+	}
+	states := make(map[string]agentactivitybiz.SessionGoalState)
+	if reader, ok := s.GoalStateStore.(sessionGoalStateBatchReader); ok {
+		var err error
+		states, err = reader.ListSessionGoalStates(
+			ctx,
+			strings.TrimSpace(workspaceID),
+			ids,
+		)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		for _, id := range ids {
+			state, found, err := s.GoalStateStore.GetSessionGoalState(
+				ctx,
+				strings.TrimSpace(workspaceID),
+				id,
+			)
+			if err != nil {
+				return nil, err
+			}
+			if found {
+				states[id] = state
+			}
+		}
+	}
+	for i, session := range result {
+		if state, ok := states[strings.TrimSpace(session.ID)]; ok {
+			session.GoalSyncState = projectedSessionGoalSyncState(state)
+		}
+		result[i] = session
+	}
+	return result, nil
+}
+
+func projectedSessionGoalSyncState(state agentactivitybiz.SessionGoalState) *SessionGoalSyncState {
+	return &SessionGoalSyncState{
+		Revision:           state.Revision,
+		SyncStatus:         strings.TrimSpace(state.SyncStatus),
+		PendingOperationID: strings.TrimSpace(state.PendingOperationID),
+	}
 }
 
 func (s *Service) withSessionForkLineage(

--- a/services/tuttid/service/agent/service_turns_error_test.go
+++ b/services/tuttid/service/agent/service_turns_error_test.go
@@ -253,6 +253,7 @@ func TestProtocolV2ProjectionIncludesDurableGoalSyncState(t *testing.T) {
 			PendingOperationID: " goal-operation-1 ",
 			Revision:           4,
 			SyncStatus:         agentactivitybiz.GoalSyncStatusApplying,
+			ExecutionPending:   true,
 			WorkspaceID:        "workspace-1",
 		},
 	}}
@@ -269,7 +270,8 @@ func TestProtocolV2ProjectionIncludesDurableGoalSyncState(t *testing.T) {
 	if projected.GoalSyncState == nil ||
 		projected.GoalSyncState.Revision != 4 ||
 		projected.GoalSyncState.SyncStatus != agentactivitybiz.GoalSyncStatusApplying ||
-		projected.GoalSyncState.PendingOperationID != "goal-operation-1" {
+		projected.GoalSyncState.PendingOperationID != "goal-operation-1" ||
+		!projected.GoalSyncState.ExecutionPending {
 		t.Fatalf("GoalSyncState = %#v", projected.GoalSyncState)
 	}
 }

--- a/services/tuttid/service/agent/service_turns_error_test.go
+++ b/services/tuttid/service/agent/service_turns_error_test.go
@@ -245,6 +245,107 @@ func TestProtocolV2BatchProjectionUsesFourBulkReadsWithoutPerSessionQueries(t *t
 	}
 }
 
+func TestProtocolV2ProjectionIncludesDurableGoalSyncState(t *testing.T) {
+	t.Parallel()
+	store := &goalStateProjectionStore{states: map[string]agentactivitybiz.SessionGoalState{
+		"session-1": {
+			AgentSessionID:     "session-1",
+			PendingOperationID: " goal-operation-1 ",
+			Revision:           4,
+			SyncStatus:         agentactivitybiz.GoalSyncStatusApplying,
+			WorkspaceID:        "workspace-1",
+		},
+	}}
+	service := &Service{GoalStateStore: store}
+
+	projected, err := service.withProtocolV2TurnState(
+		context.Background(),
+		"workspace-1",
+		Session{ID: "session-1"},
+	)
+	if err != nil {
+		t.Fatalf("withProtocolV2TurnState() error = %v", err)
+	}
+	if projected.GoalSyncState == nil ||
+		projected.GoalSyncState.Revision != 4 ||
+		projected.GoalSyncState.SyncStatus != agentactivitybiz.GoalSyncStatusApplying ||
+		projected.GoalSyncState.PendingOperationID != "goal-operation-1" {
+		t.Fatalf("GoalSyncState = %#v", projected.GoalSyncState)
+	}
+}
+
+func TestProtocolV2BatchProjectionReadsGoalSyncStatesOnce(t *testing.T) {
+	t.Parallel()
+	listCalls, getCalls := 0, 0
+	store := &goalStateProjectionStore{
+		getCalls:  &getCalls,
+		listCalls: &listCalls,
+		states: map[string]agentactivitybiz.SessionGoalState{
+			"session-1": {
+				AgentSessionID:     "session-1",
+				PendingOperationID: "goal-operation-1",
+				Revision:           2,
+				SyncStatus:         agentactivitybiz.GoalSyncStatusPending,
+				WorkspaceID:        "workspace-1",
+			},
+		},
+	}
+	service := &Service{GoalStateStore: store}
+
+	projected, err := service.withProtocolV2TurnStates(
+		context.Background(),
+		"workspace-1",
+		[]Session{{ID: "session-1"}, {ID: "session-2"}},
+	)
+	if err != nil {
+		t.Fatalf("withProtocolV2TurnStates() error = %v", err)
+	}
+	if listCalls != 1 || getCalls != 0 {
+		t.Fatalf("Goal state reads list=%d get=%d, want 1/0", listCalls, getCalls)
+	}
+	if projected[0].GoalSyncState == nil || projected[0].GoalSyncState.Revision != 2 {
+		t.Fatalf("first GoalSyncState = %#v", projected[0].GoalSyncState)
+	}
+	if projected[1].GoalSyncState != nil {
+		t.Fatalf("second GoalSyncState = %#v, want nil", projected[1].GoalSyncState)
+	}
+}
+
+type goalStateProjectionStore struct {
+	GoalStateStore
+	getCalls  *int
+	listCalls *int
+	states    map[string]agentactivitybiz.SessionGoalState
+}
+
+func (s *goalStateProjectionStore) GetSessionGoalState(
+	_ context.Context,
+	_, agentSessionID string,
+) (agentactivitybiz.SessionGoalState, bool, error) {
+	if s.getCalls != nil {
+		*s.getCalls = *s.getCalls + 1
+	}
+	state, ok := s.states[agentSessionID]
+	return state, ok, nil
+}
+
+func (s *goalStateProjectionStore) ListSessionGoalStates(
+	_ context.Context,
+	_ string,
+	agentSessionIDs []string,
+) (map[string]agentactivitybiz.SessionGoalState, error) {
+	if s.listCalls != nil {
+		*s.listCalls = *s.listCalls + 1
+	}
+	result := make(map[string]agentactivitybiz.SessionGoalState)
+	for _, id := range agentSessionIDs {
+		if state, ok := s.states[id]; ok {
+			result[id] = state
+		}
+	}
+	return result, nil
+}
+
 type failingTurnStore struct {
 	getTurnErr                 error
 	latestTurnErr              error

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -306,6 +306,7 @@ type SessionGoalSyncState struct {
 	Revision           int64
 	SyncStatus         string
 	PendingOperationID string
+	ExecutionPending   bool
 }
 
 // SessionForkLineage is the durable provenance of a user-initiated root

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -294,9 +294,18 @@ type Session struct {
 	LatestTurn             *agentactivitybiz.Turn
 	LatestTurnInteractions []agentactivitybiz.Interaction
 	PendingInteractions    []agentactivitybiz.Interaction
+	GoalSyncState          *SessionGoalSyncState
 	TuttiModeActivation    *tuttimodeactivationbiz.Activation
 	LifecycleCapabilities  SessionLifecycleCapabilities
 	ForkedFrom             *SessionForkLineage
+}
+
+// SessionGoalSyncState is the narrow durable Goal-operation evidence exposed
+// with a Session read. Goal lifecycle and recovery remain Host-owned.
+type SessionGoalSyncState struct {
+	Revision           int64
+	SyncStatus         string
+	PendingOperationID string
 }
 
 // SessionForkLineage is the durable provenance of a user-initiated root


### PR DESCRIPTION
## 摘要

- 在 Host/SQLite 中持久化 `executionPending`：只在 initial Goal 已被 provider 接受、预期开始自主执行且首个精确 Goal Turn 尚未落库时为 true
- 首个带相同 operation/revision/repair epoch 的 Goal Turn 原子清除该证据；普通 prompt Turn、旧 operation、终态/失败/分歧 Goal 均不会误清或误保留
- 通过 tuttid OpenAPI、生成 DTO、activity adapter 和 AgentGUI Session 投影下发该只读事实
- AgentGUI 在 pending/applying/unknown 阶段仍要求 operation identity；synced 阶段仅凭 `executionPending=true` 维持 initial Goal busy，不再从 synced 推断未来一定有 Turn
- TSH 等外部 Host 可通过可选字段渐进接入；字段缺失或未知时 fail closed，避免混合版本永久 loading

## 背景

typed initial Goal 会先创建 Session 和 durable Goal operation，但不会同步创建 Turn。原 bridge 在 Goal mutation 收敛后缺少一个权威事实来表达“provider 已接受自主执行、首个 Turn 尚未出现”：直接把 synced 当作依据会在合法零 Turn或异步失败场景永久 busy，直接释放又会在首个 Turn 前出现 idle 空窗。

本次把该事实放回 Agent Host/Store，由 provider acceptance 置位、精确 Goal provenance 的首个 canonical Turn 或终态观察清除；AgentGUI 只消费投影，不制造 Turn、不使用 UI timeout。

## 风险与兼容性

- SQLite 增加前向迁移 V8，默认 false；旧数据不会被解释为执行中
- `WorkspaceAgentSessionGoalSyncState.executionPending` 对公共 Activity Core 保持 optional，tuttid 同 cohort 返回 required boolean
- 混合版本 Host 缺字段时安全释放 loading；完整行为需要 Owner 与 Caller 都升级到包含该字段的版本
- 不改变 `initialTurnExpected`，不改变 processing/“思考中”投影，也不制造虚假 Turn
- 生命周期语义位于 `packages/agent/host` 和 canonical Store；tuttid、TSH 仅做 adapter/transport 投影

## 验证

- Activity Core、activity-tuttid-adapter、AgentGUI package tests 通过；AgentGUI focused 6 tests
- Host conformance、store-sqlite、daemon runtime/hostadapter、service/agent、API Go tests 通过
- `pnpm check:agent-gui-degradation`、TypeScript typecheck、Agent Host boundary、generated API checks、`git diff --check` 通过
- TSH 本地 link 集成：2 files / 104 tests、Desktop `pnpm check`、desktopd 与 connector Go tests 通过
- `make dev-gui` + Computer Use：新 `/goal` 提交后、首个 Turn 前按钮保持「停止回复」，首个 Turn 出现后继续 busy，结束后释放
- 混合版本实测：旧 Owner 缺字段时 fail closed，仅在 Goal RPC 与首 Turn 同一批投影间出现瞬时释放；这是预期兼容行为，Owner/Caller 同版后由 `executionPending` 消除
- commit hooks 与 `git diff --check` 通过

备注：本地 `check:changed --push-ready` 两次都卡在与本改动无关的 Desktop Node test 退出句柄（进程 CPU 为 0、无失败断言）；已中止悬挂 runner，相关变更由上述 focused/package/Go 检查覆盖，远端 CI 会重新执行完整选择。
