### PR TITLE
fix(agent-runtime): harden Claude cancellation fencing

### DIFF
--- a/apps/desktop/scripts/smoke-claude-sdk-sidecar.mjs
+++ b/apps/desktop/scripts/smoke-claude-sdk-sidecar.mjs
@@ -36,7 +36,7 @@ export async function smokeClaudeSDKSidecar({
   });
 
   const send = (request) => {
-    child.stdin.write(`${JSON.stringify({ version: 8, ...request })}\n`);
+    child.stdin.write(`${JSON.stringify({ version: 9, ...request })}\n`);
   };
   const waitForEvent = async (predicate, label) => {
     while (true) {

--- a/docs/architecture/claude-code-sdk-runtime.md
+++ b/docs/architecture/claude-code-sdk-runtime.md
@@ -182,18 +182,41 @@ The Go transport retains only a bounded failure classification; explicitly
 prefixed auth diagnostics are separately sanitized before structured logging.
 
 SDK Query lifetime is narrower than durable provider-session lifetime. A user
-cancel first revokes the current Query generation, awaits the SDK interrupt
-acknowledgment, then closes that Query in cleanup. Closing before the interrupt
-response turns a successful provider stop into a transport failure. Revocation
-fences message routing, hooks, and `canUseTool` before permission-mode handling,
-including `bypassPermissions`; background-task notifications from the canceled
-generation therefore cannot start a synthetic continuation or execute another
-tool. The next real user prompt creates a fresh Query with
+cancel carries the exact canonical Turn and returns one structured disposition:
+`pre_accept`, `provider_active`, `absent`, or `mismatch`. An undispatched queue
+entry can be removed locally. Once the prompt has been dispatched, cancel first
+revokes the current Query generation, awaits the SDK interrupt acknowledgment,
+then closes that Query in cleanup; the sidecar publishes `turn_canceled` only
+after that acknowledgment. Closing before the interrupt response turns a
+successful provider stop into a transport failure. Revocation fences message
+routing, hooks, and `canUseTool` before permission-mode handling, including
+`bypassPermissions`; background-task notifications from the canceled generation
+therefore cannot start a synthetic continuation or execute another tool. Every
+Turn already handed to the retired Query's prompt queue settles after that same
+acknowledgment, including a drained Goal command that can no longer execute; a
+Goal command still in the sidecar's deferred queue is independent and remains
+eligible for exact local removal. For a
+`provider_active` response, the Go adapter also waits for the exact Turn's
+durable provider-acceptance outcome before confirming cancellation. `absent`
+is the only authoritative not-found result; mismatches, unknown dispositions,
+interrupt failures, and acceptance failures remain fail-closed. The next real
+user prompt creates a fresh Query with
 `resume: providerSessionId` and generation-local prompt/abort resources. If the
 SDK replays the canceled generation's terminal task notification and paired
 result during resume, the new generation consumes that tail without attaching
 it to the new canonical Turn. Session close remains permanent and closes the
 current generation without creating a resumable successor.
+
+The Go adapter also tracks each accepted-but-not-started typed Goal command by
+its operation, revision, repair epoch, action, and previous optimistic Goal
+mirror. A Goal-generation fence targets both those pending commands and Turns
+that already have provider bindings. When the sidecar confirms an exact pending
+Goal cancellation, the adapter removes its bookkeeping and restores the
+previous mirror only while that same identity is still current, so a stale
+cancellation cannot overwrite a newer Goal. `goal_command_started` records
+provider progress but does not commit the optimistic mirror; an authoritative
+Goal observation or successful command terminal commits it, while cancellation,
+failure, or supersession closes the exact pending transaction.
 
 Background-task lifecycle uses the SDK's `background_tasks_changed` system
 message as a level signal. Its `tasks` array fully replaces the previous live
@@ -251,7 +274,8 @@ The daemon and sidecar exchange newline-delimited JSON over standard input and
 output. Every request and event carries the current protocol version. Missing
 or unsupported versions fail explicitly. Change both
 `claude_sdk_protocol.go` and `src/protocol.ts` together and cover the change on
-both sides.
+both sides. Version 9 makes the cancel disposition, exact canonical Turn ID,
+provider Turn ID, and dispatch phase correctness-required response fields.
 
 Capability and composer contracts are intentionally stable across this runtime
 split. Imported historical metadata may still be read for display compatibility

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -2923,13 +2923,20 @@ inline data URL instead`. Claude or standard ACP may instead receive no
   settings flag application with turn dispatch and retire the idle generation
   before a live settings mutation. The workspace Engine and composer gate both
   block send while the settings operation is unsettled. For cancel, carry the
-  exact Turn ID to the sidecar and wait for durable provider acceptance before
-  publishing cancel settlement; a pre-acceptance cancellation reports applied
-  without a provider Turn rather than poisoning the delivery claim as unknown.
+  exact Turn ID to the sidecar and dispatch the native cancel before consulting
+  acceptance state. The sidecar returns `pre_accept`, `provider_active`,
+  `absent`, or `mismatch`: locally remove only an undispatched queue item; after
+  dispatch, publish the canceled terminal only after SDK interrupt/shutdown
+  acknowledges. Wait for the exact Turn's durable provider-acceptance outcome
+  only for `provider_active`. Treat only `absent` as authoritative not-found;
+  mismatch, unknown disposition, interrupt failure, and acceptance failure stay
+  fail-closed.
 - Validation:
   Cover follow-up resume, settings timeout/retry gating, exact targeted cancel,
-  cancel before acceptance, and cancel followed by a new send. Native guidance
-  must interrupt active tool work before enqueueing the steering prompt.
+  same-tick Goal cancellation, cancel before dispatch, interrupt acknowledgment
+  and failure, durable acceptance success and failure, mismatched/absent targets,
+  and cancel followed by a new send. Native guidance must interrupt active tool
+  work before enqueueing the steering prompt.
 - References:
   [sessionRuntime.ts](../../../packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts)
   [claude_sdk_execution.go](../../../packages/agent/daemon/runtime/claude_sdk_execution.go)

--- a/packages/agent/claude-sdk-sidecar/README.md
+++ b/packages/agent/claude-sdk-sidecar/README.md
@@ -87,6 +87,14 @@ after that durable barrier succeeds does it publish canonical
 proceed. Checkpoint and terminal events use the same bound provider Turn ID and
 never fall back to the outbound correlation UUID.
 
+Exact cancellation returns a structured `pre_accept`, `provider_active`,
+`absent`, or `mismatch` disposition. An undispatched Turn or deferred Goal
+command can be removed locally. A dispatched Turn is fenced immediately, but
+its terminal event is emitted only after the SDK interrupt and Query shutdown
+acknowledge. `provider_active` includes the resolved provider Turn ID so the
+daemon can wait for that exact Turn's durable acceptance result before it
+confirms cancellation; failures and unknown dispositions remain fail-closed.
+
 Interactive responses use `(turnId, requestId)` identity. The sidecar keeps a
 bounded terminal disposition registry so `submit_interactive` is idempotent:
 an identical replay reports `answered` without resolving the SDK permission

--- a/packages/agent/claude-sdk-sidecar/src/goalExecQueue.ts
+++ b/packages/agent/claude-sdk-sidecar/src/goalExecQueue.ts
@@ -58,6 +58,21 @@ export class GoalExecQueue {
     setTimeout(() => this.drain(), 0);
   }
 
+  cancelExact(turnId: string): GoalExecInput | undefined {
+    const expected = turnId.trim();
+    if (!expected) {
+      return undefined;
+    }
+    const index = this.pending.findIndex(
+      (input) => input.turnId.trim() === expected
+    );
+    if (index < 0) {
+      return undefined;
+    }
+    const [canceled] = this.pending.splice(index, 1);
+    return canceled;
+  }
+
   private drain(): void {
     this.dispatchScheduled = false;
     const pending = this.pending;

--- a/packages/agent/claude-sdk-sidecar/src/main.ts
+++ b/packages/agent/claude-sdk-sidecar/src/main.ts
@@ -125,8 +125,8 @@ export async function handleRequest(
       case "cancel": {
         const payload = request.payload ?? {};
         const session = requireSession(stringValue(payload.agentSessionId));
-        const canceled = await session.cancel(stringValue(payload.turnId));
-        emit({ id, type: "ok", payload: { canceled } });
+        const result = await session.cancel(stringValue(payload.turnId));
+        emit({ id, type: "ok", payload: result });
         return;
       }
       case "stop_task": {

--- a/packages/agent/claude-sdk-sidecar/src/protocol.ts
+++ b/packages/agent/claude-sdk-sidecar/src/protocol.ts
@@ -1,4 +1,4 @@
-export const CLAUDE_SDK_SIDECAR_PROTOCOL_VERSION = 8 as const;
+export const CLAUDE_SDK_SIDECAR_PROTOCOL_VERSION = 9 as const;
 
 export type ClaudeSDKSidecarRequestType =
   | "start"

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.cancel.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.cancel.test.ts
@@ -15,6 +15,385 @@ import {
 } from "./sessionRuntimeTestCommon.ts";
 import { waitForEvent } from "./sessionRuntimeTestQueries.nested.ts";
 
+function cancelTestSession(
+  queryFactory: NonNullable<ConstructorParameters<typeof SessionRuntime>[8]>
+): SessionRuntime {
+  return new SessionRuntime(
+    "provider-session-cancel-test",
+    "/repo",
+    {},
+    false,
+    false,
+    {
+      model: "",
+      permissionModeId: "default",
+      planMode: false,
+      effort: "",
+      speed: ""
+    },
+    sidecarClaudeOptionsFromPayload({}),
+    undefined,
+    queryFactory
+  );
+}
+
+test("exact cancel removes an undispatched turn without retiring the query", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  const shutdownOrder: string[] = [];
+  try {
+    const session = new SessionRuntime(
+      "provider-session-pre-accept",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) => ({
+        async *[Symbol.asyncIterator]() {
+          const next = await prompt[Symbol.asyncIterator]().next();
+          if (!next.done) {
+            yield next.value;
+          }
+        },
+        async interrupt() {
+          shutdownOrder.push("interrupt");
+        },
+        close() {
+          shutdownOrder.push("close");
+        }
+      })
+    );
+
+    await session.start();
+    session.exec("turn-pre-accept", "hello");
+    const result = await session.cancel("turn-pre-accept");
+
+    assert.deepEqual(result, {
+      canceled: true,
+      disposition: "pre_accept",
+      turnId: "turn-pre-accept",
+      providerTurnId: "",
+      dispatchPhase: "queued"
+    });
+    assert.deepEqual(shutdownOrder, []);
+    const canceledEvent = events.find(
+      (event) => event.type === "turn_canceled"
+    );
+    assert.equal(canceledEvent?.payload?.turnId, "turn-pre-accept");
+    assert.equal(
+      events.some((event) => event.type === "provider_turn_identity_resolved"),
+      false
+    );
+  } finally {
+    restoreSink();
+  }
+});
+
+test("dispatched pre-accept cancel publishes terminal only after interrupt ack", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  let markPromptObserved: () => void = () => {};
+  let releaseInterrupt: () => void = () => {};
+  const promptObserved = new Promise<void>((resolve) => {
+    markPromptObserved = resolve;
+  });
+  const interruptAck = new Promise<void>((resolve) => {
+    releaseInterrupt = resolve;
+  });
+  try {
+    const session = cancelTestSession(({ prompt }) => ({
+      async *[Symbol.asyncIterator]() {
+        const next = await prompt[Symbol.asyncIterator]().next();
+        markPromptObserved();
+        await new Promise(() => {});
+        if (!next.done) {
+          yield next.value;
+        }
+      },
+      async interrupt() {
+        await interruptAck;
+      },
+      close() {}
+    }));
+
+    await session.start();
+    session.exec("turn-dispatched", "hello");
+    await promptObserved;
+    const canceling = session.cancel("turn-dispatched");
+    await Promise.resolve();
+
+    assert.equal(
+      events.some((event) => event.type === "turn_canceled"),
+      false
+    );
+    releaseInterrupt();
+    const result = await canceling;
+    assert.equal(result.disposition, "pre_accept");
+    assert.equal(
+      events.some((event) => event.type === "turn_canceled"),
+      true
+    );
+  } finally {
+    restoreSink();
+  }
+});
+
+test("cancel aborting identity resolution cannot publish terminal before interrupt ack", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  let markResolutionStarted: () => void = () => {};
+  let releaseInterrupt: () => void = () => {};
+  const resolutionStarted = new Promise<void>((resolve) => {
+    markResolutionStarted = resolve;
+  });
+  const interruptAck = new Promise<void>((resolve) => {
+    releaseInterrupt = resolve;
+  });
+  try {
+    const session = new SessionRuntime(
+      "provider-session-resolving-cancel",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) => ({
+        async *[Symbol.asyncIterator]() {
+          await prompt[Symbol.asyncIterator]().next();
+          yield {
+            type: "assistant",
+            uuid: "assistant-before-identity",
+            parent_tool_use_id: null,
+            session_id: "provider-session-resolving-cancel",
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "pending" }]
+            }
+          } as never;
+        },
+        async interrupt() {
+          await interruptAck;
+        },
+        close() {}
+      }),
+      30_000,
+      async () => {
+        markResolutionStarted();
+        return await new Promise<never>(() => {});
+      }
+    );
+
+    await session.start();
+    session.exec("turn-resolving", "hello");
+    await resolutionStarted;
+    const canceling = session.cancel("turn-resolving");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assert.equal(
+      events.some((event) =>
+        ["turn_canceled", "turn_failed", "turn_completed"].includes(event.type)
+      ),
+      false
+    );
+    releaseInterrupt();
+    const result = await canceling;
+    assert.equal(result.disposition, "pre_accept");
+    assert.equal(
+      events.filter((event) => event.type === "turn_canceled").length,
+      1
+    );
+  } finally {
+    restoreSink();
+  }
+});
+
+test("cancel settles every dispatched prompt retired with the Query generation", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  let markPromptsObserved: () => void = () => {};
+  const promptsObserved = new Promise<void>((resolve) => {
+    markPromptsObserved = resolve;
+  });
+  try {
+    const session = cancelTestSession(({ prompt }) => ({
+      async *[Symbol.asyncIterator]() {
+        const iterator = prompt[Symbol.asyncIterator]();
+        for (let index = 0; index < 2; index += 1) {
+          const next = await iterator.next();
+          if (next.done) {
+            return;
+          }
+        }
+        markPromptsObserved();
+        await new Promise(() => {});
+        yield {} as SDKMessage;
+      },
+      async interrupt() {},
+      close() {}
+    }));
+
+    await session.start();
+    session.exec("turn-root", "hello");
+    session.exec("turn-goal", "/goal ship it", undefined, "goal_arm", {
+      operationId: "goal-operation",
+      revision: 1,
+      repairEpoch: 0,
+      action: "set"
+    });
+    await promptsObserved;
+
+    const result = await session.cancel("turn-root");
+
+    assert.equal(result.disposition, "pre_accept");
+    assert.deepEqual(
+      events
+        .filter((event) => event.type === "turn_canceled")
+        .map((event) => event.payload?.turnId),
+      ["turn-root"]
+    );
+    assert.deepEqual(
+      events.find((event) => event.type === "goal_command_canceled")?.payload,
+      {
+        turnId: "turn-goal",
+        operationId: "goal-operation",
+        revision: 1,
+        repairEpoch: 0,
+        action: "set",
+        reason: "cancel_requested"
+      }
+    );
+    assert.equal(
+      events.some((event) => event.type === "goal_command_started"),
+      false
+    );
+  } finally {
+    restoreSink();
+  }
+});
+
+test("interrupt failure leaves exact cancellation unresolved without terminal", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  let markPromptObserved: () => void = () => {};
+  const promptObserved = new Promise<void>((resolve) => {
+    markPromptObserved = resolve;
+  });
+  try {
+    const session = cancelTestSession(({ prompt }) => ({
+      async *[Symbol.asyncIterator]() {
+        const next = await prompt[Symbol.asyncIterator]().next();
+        markPromptObserved();
+        await new Promise(() => {});
+        if (!next.done) {
+          yield next.value;
+        }
+      },
+      async interrupt() {
+        throw new Error("interrupt failed");
+      },
+      close() {}
+    }));
+
+    await session.start();
+    session.exec("turn-interrupt-failed", "hello");
+    await promptObserved;
+
+    await assert.rejects(
+      session.cancel("turn-interrupt-failed"),
+      /interrupt failed/
+    );
+    assert.equal(
+      events.some((event) => event.type === "turn_canceled"),
+      false
+    );
+    await assert.rejects(
+      session.cancel("turn-interrupt-failed"),
+      /remains unresolved/
+    );
+  } finally {
+    restoreSink();
+  }
+});
+
+test("same-tick exact cancel removes a deferred Goal command", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  let promptCount = 0;
+  try {
+    const session = cancelTestSession(({ prompt }) => ({
+      async *[Symbol.asyncIterator]() {
+        const next = await prompt[Symbol.asyncIterator]().next();
+        if (!next.done) {
+          promptCount += 1;
+          yield next.value;
+        }
+      },
+      close() {}
+    }));
+
+    await session.start();
+    session.exec("goal-turn", "/goal ship it", undefined, "goal_arm", {
+      operationId: "goal-op",
+      revision: 1,
+      repairEpoch: 2,
+      action: "set"
+    });
+    const result = await session.cancel("goal-turn");
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.equal(result.disposition, "pre_accept");
+    assert.equal(result.dispatchPhase, "pending_goal");
+    assert.equal(promptCount, 0);
+    assert.equal(
+      events.some((event) => event.type === "goal_command_started"),
+      false
+    );
+    assert.deepEqual(
+      events.find((event) => event.type === "goal_command_canceled")?.payload,
+      {
+        turnId: "goal-turn",
+        operationId: "goal-op",
+        revision: 1,
+        repairEpoch: 2,
+        action: "set",
+        reason: "cancel_requested"
+      }
+    );
+  } finally {
+    restoreSink();
+  }
+});
+
 for (const permissionModeId of ["default", "bypassPermissions"] as const) {
   test(`cancel retires ${permissionModeId} query before background completion can run another tool`, async () => {
     const events: Array<{ type: string; payload?: Record<string, unknown> }> =
@@ -92,9 +471,11 @@ for (const permissionModeId of ["default", "bypassPermissions"] as const) {
       await session.start();
       session.exec("turn-1", "create a site in the background");
       await firstPromptObserved;
-      await session.cancel();
+      const cancelResult = await session.cancel();
       await waitForEvent(events, "turn_canceled");
 
+      assert.equal(cancelResult.disposition, "provider_active");
+      assert.equal(cancelResult.providerTurnId.length > 0, true);
       assert.equal(closeCount, 1);
       assert.deepEqual(shutdownOrder, [
         "interrupt",

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts
@@ -27,7 +27,11 @@ import {
   type ToolPermissionOptions
 } from "./interactive.ts";
 import { resolveInteractiveTurnId } from "./interactiveTurnResolver.ts";
-import { GoalExecQueue, type GoalCommandDispatch } from "./goalExecQueue.ts";
+import {
+  GoalExecQueue,
+  type GoalCommandDispatch,
+  type GoalExecInput
+} from "./goalExecQueue.ts";
 import { TurnLifecycle, type RuntimeTurn } from "./turnLifecycle.ts";
 import { normalizeTitle, stringValue } from "./runtimeValues.ts";
 import {
@@ -66,6 +70,36 @@ type ClaudeQueryFactory = (input: {
   prompt: AsyncIterable<SDKUserMessage>;
   options: ClaudeQueryOptions;
 }) => ClaudeQueryRuntime;
+
+export type SessionCancelDisposition =
+  | "pre_accept"
+  | "provider_active"
+  | "absent"
+  | "mismatch";
+
+export type SessionCancelResult = {
+  canceled: boolean;
+  disposition: SessionCancelDisposition;
+  turnId: string;
+  providerTurnId: string;
+  dispatchPhase: ProviderTurnPhase | "pending_goal" | "unknown";
+};
+
+function cancelResult(
+  canceled: boolean,
+  disposition: SessionCancelDisposition,
+  turnId: string,
+  providerTurnId = "",
+  dispatchPhase: SessionCancelResult["dispatchPhase"] = "unknown"
+): SessionCancelResult {
+  return {
+    canceled,
+    disposition,
+    turnId: turnId.trim(),
+    providerTurnId: providerTurnId.trim(),
+    dispatchPhase
+  };
+}
 
 export class SessionRuntime {
   providerSessionId: string;
@@ -443,6 +477,7 @@ export class SessionRuntime {
           !generation ||
           !this.isQueryGenerationActive(generation) ||
           executionEpoch !== this.executionEpoch ||
+          turn.canceling ||
           turn.settled
         ) {
           return;
@@ -583,40 +618,103 @@ export class SessionRuntime {
       });
   }
 
-  async cancel(expectedTurnId = ""): Promise<boolean> {
+  async cancel(expectedTurnId = ""): Promise<SessionCancelResult> {
+    expectedTurnId =
+      expectedTurnId.trim() || this.turns.activeTurn?.turnId.trim() || "";
     if (this.sessionClosed) {
-      return false;
+      return cancelResult(false, "absent", expectedTurnId);
     }
-    let hasActiveTurn: boolean;
-    if (expectedTurnId) {
-      hasActiveTurn = this.turns.cancelActiveExact(expectedTurnId);
-      if (!hasActiveTurn) {
-        return false;
-      }
-    } else if (!this.turns.activeTurn || this.turns.activeTurn.settled) {
-      // No live provider turn yet. Do not settle queued turns or tear down the
-      // query — that leaves HasSettledTurn without root_provider_turn_id and
-      // blocks cancel→resend with provider_session_not_established.
-      return false;
-    } else {
-      hasActiveTurn = this.turns.cancelQueued();
+    if (!expectedTurnId) {
+      return cancelResult(false, "absent", "");
     }
-    this.activities.cancel();
-    this.executionEpoch += 1;
-    this.providerTurnAcceptance.cancel(expectedTurnId);
-    this.canceledQueryTailPending = true;
-    this.interactions.rejectAll(new Error("Tool use aborted"));
-    const generation = this.queryGeneration;
-    this.queryGeneration = undefined;
-    try {
-      await generation?.shutdown(true);
-    } finally {
-      if (hasActiveTurn) {
-        this.turns.settleActive("turn_canceled");
+
+    const pendingGoal = this.goalExecQueue.cancelExact(expectedTurnId);
+    if (pendingGoal) {
+      this.emitPendingGoalCanceled(pendingGoal);
+      return cancelResult(
+        true,
+        "pre_accept",
+        expectedTurnId,
+        "",
+        "pending_goal"
+      );
+    }
+
+    const preparation = this.turns.prepareExactCancellation(expectedTurnId);
+    if (preparation.disposition === "absent") {
+      return cancelResult(false, "absent", expectedTurnId);
+    }
+    if (preparation.disposition === "mismatch") {
+      return cancelResult(false, "mismatch", expectedTurnId);
+    }
+    if (preparation.disposition === "unresolved") {
+      throw new Error(
+        `Claude SDK exact cancellation remains unresolved for turn ${expectedTurnId}`
+      );
+    }
+
+    const phase =
+      this.providerTurnAcceptance.phase(expectedTurnId) ?? "unknown";
+    if (preparation.differentActiveTurn && phase !== "queued") {
+      this.turns.releaseExactCancellation(expectedTurnId);
+      return cancelResult(false, "mismatch", expectedTurnId, "", phase);
+    }
+    if (preparation.disposition === "queued" && phase === "queued") {
+      if (!this.turns.commitExactCancellation(expectedTurnId)) {
+        throw new Error(
+          `Claude SDK lost exact cancellation target ${expectedTurnId}`
+        );
       }
       this.turns.clearCancelled();
+      return cancelResult(true, "pre_accept", expectedTurnId, "", phase);
     }
-    return hasActiveTurn;
+
+    const generation = this.queryGeneration;
+    if (!generation) {
+      this.turns.discardExactAbsent(expectedTurnId);
+      this.turns.clearCancelled();
+      return cancelResult(false, "absent", expectedTurnId, "", phase);
+    }
+
+    // One SDK Query owns every Turn already handed to its prompt queue. Native
+    // interrupt retires that entire generation, so fence and settle every such
+    // Turn after the same shutdown ACK instead of stranding collateral Goal
+    // commands whose prompts can no longer run.
+    const generationTurnIds = this.turns.prepareGenerationCancellation();
+    this.activities.cancel();
+    this.executionEpoch += 1;
+    this.providerTurnAcceptance.cancel();
+    this.canceledQueryTailPending = true;
+    this.interactions.rejectAll(new Error("Tool use aborted"));
+    this.queryGeneration = undefined;
+    await generation.shutdown(true);
+    for (const turnId of generationTurnIds) {
+      if (!this.turns.commitExactCancellation(turnId)) {
+        throw new Error(`Claude SDK lost canceled Query turn ${turnId}`);
+      }
+    }
+    this.turns.clearCancelled();
+    return cancelResult(
+      true,
+      preparation.providerTurnId ? "provider_active" : "pre_accept",
+      expectedTurnId,
+      preparation.providerTurnId,
+      phase
+    );
+  }
+
+  private emitPendingGoalCanceled(input: GoalExecInput): void {
+    emit({
+      type: "goal_command_canceled",
+      payload: {
+        turnId: input.turnId,
+        operationId: input.goal.operationId,
+        revision: input.goal.revision,
+        repairEpoch: input.goal.repairEpoch ?? 0,
+        action: input.goal.action,
+        reason: "cancel_requested"
+      }
+    });
   }
 
   async stopTask(taskId: string, parentToolUseId = ""): Promise<boolean> {
@@ -749,6 +847,9 @@ export class SessionRuntime {
           await this.router.handle(message);
         }
       } catch (error) {
+        if (isAbortError(error) && !this.isQueryGenerationActive(generation)) {
+          return;
+        }
         this.logAuthRefresh("query_consume.failed", {
           activeTurnId: this.turns.activeId,
           queuedTurnIds: this.turns.queue

--- a/packages/agent/claude-sdk-sidecar/src/turnLifecycle.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/turnLifecycle.test.ts
@@ -206,17 +206,62 @@ test("cancelQueued cancels queued turns and consumes their orphan results", () =
   assert.equal(events.at(-1)?.payload?.turnId, "turn-2");
 });
 
-test("cancelActiveExact rejects unknown or queued-only turns", () => {
-  const { lifecycle } = createLifecycle();
+test("exact cancellation prepares before committing a queued terminal", () => {
+  const { lifecycle, events } = createLifecycle();
   lifecycle.enqueue({
     turnId: "turn-queued",
     promptUuid: "prompt-queued",
     settled: false
   });
-  assert.equal(lifecycle.cancelActiveExact("turn-queued"), false);
-  lifecycle.activateForUserMessage("prompt-queued");
-  assert.equal(lifecycle.cancelActiveExact("turn-other"), false);
-  assert.equal(lifecycle.cancelActiveExact("turn-queued"), true);
+
+  assert.equal(
+    lifecycle.prepareExactCancellation("turn-queued").disposition,
+    "queued"
+  );
+  assert.equal(events.length, 0);
+  assert.equal(lifecycle.commitExactCancellation("turn-queued"), true);
+  assert.deepEqual(events.at(-1), {
+    type: "turn_canceled",
+    payload: { turnId: "turn-queued" }
+  });
+  assert.equal(lifecycle.queue.length, 0);
+});
+
+test("exact cancellation exposes a queued turn behind a different active turn", () => {
+  const { lifecycle } = createLifecycle();
+  lifecycle.enqueue({
+    turnId: "turn-active",
+    promptUuid: "prompt-active",
+    settled: false
+  });
+  lifecycle.enqueue({
+    turnId: "turn-queued",
+    promptUuid: "prompt-queued",
+    settled: false
+  });
+  lifecycle.activateForUserMessage("prompt-active");
+
+  const queued = lifecycle.prepareExactCancellation("turn-queued");
+  assert.equal(queued.disposition, "queued");
+  assert.equal(queued.differentActiveTurn, true);
+  lifecycle.releaseExactCancellation("turn-queued");
+  assert.equal(
+    lifecycle.prepareExactCancellation("turn-other").disposition,
+    "mismatch"
+  );
+  assert.equal(
+    lifecycle.prepareExactCancellation("turn-active").disposition,
+    "active"
+  );
+});
+
+test("exact cancellation rejects an unknown turn", () => {
+  const { lifecycle } = createLifecycle();
+
+  assert.equal(
+    lifecycle.prepareExactCancellation("turn-unknown").disposition,
+    "absent"
+  );
 });
 
 test("notification-reserved synthetic turn times out and rejects late continuation", async () => {

--- a/packages/agent/claude-sdk-sidecar/src/turnLifecycle.ts
+++ b/packages/agent/claude-sdk-sidecar/src/turnLifecycle.ts
@@ -19,10 +19,17 @@ export type RuntimeTurn = {
   readonly goalRevision?: number;
   readonly goalRepairEpoch?: number;
   readonly goalAction?: "set" | "clear";
+  canceling?: boolean;
   settled: boolean;
 };
 
 type TerminalEvent = "turn_completed" | "turn_canceled" | "turn_failed";
+
+export type ExactTurnCancellationPreparation = {
+  disposition: "active" | "queued" | "absent" | "mismatch" | "unresolved";
+  providerTurnId: string;
+  differentActiveTurn?: boolean;
+};
 
 function turnProvenancePayload(
   turn: RuntimeTurn
@@ -130,7 +137,10 @@ export class TurnLifecycle {
 
   expectProviderTurnIdentity(turnId: string): void {
     const turn = this.turns.find(
-      (candidate) => !candidate.settled && candidate.turnId === turnId.trim()
+      (candidate) =>
+        !candidate.settled &&
+        !candidate.canceling &&
+        candidate.turnId === turnId.trim()
     );
     if (turn && !turn.synthetic && !turn.providerTurnId?.trim()) {
       turn.awaitingProviderTurnIdentity = true;
@@ -143,6 +153,7 @@ export class TurnLifecycle {
     if (
       !turn ||
       turn.settled ||
+      turn.canceling ||
       turn.synthetic ||
       turn.providerTurnStarted ||
       !normalizedProviderTurnId
@@ -159,13 +170,17 @@ export class TurnLifecycle {
       return;
     }
     const matched = this.turns.find(
-      (turn) => !turn.settled && turn.promptUuid === normalizedPromptUuid
+      (turn) =>
+        !turn.settled &&
+        !turn.canceling &&
+        turn.promptUuid === normalizedPromptUuid
     );
     const candidate =
       matched ??
       this.turns.find(
         (turn) =>
           !turn.settled &&
+          !turn.canceling &&
           !turn.synthetic &&
           turn.awaitingProviderTurnIdentity === true
       );
@@ -186,7 +201,10 @@ export class TurnLifecycle {
   ): ProviderTurnIdentityBindingDisposition {
     const normalizedTurnId = turnId.trim();
     const turn = this.turns.find(
-      (candidate) => !candidate.settled && candidate.turnId === normalizedTurnId
+      (candidate) =>
+        !candidate.settled &&
+        !candidate.canceling &&
+        candidate.turnId === normalizedTurnId
     );
     if (!turn) {
       return "missing";
@@ -204,7 +222,7 @@ export class TurnLifecycle {
   }
 
   ensureActive(messageType: string): RuntimeTurn | undefined {
-    if (this.active && !this.active.settled) {
+    if (this.active && !this.active.settled && !this.active.canceling) {
       if (messageType === "assistant" || messageType === "stream_event") {
         this.confirmContinuationStarted();
       }
@@ -216,7 +234,12 @@ export class TurnLifecycle {
     if (messageType !== "user" && this.pendingOrphanCount > 0) {
       return undefined;
     }
-    const turn = this.turns.find((candidate) => !candidate.settled);
+    if (this.active?.canceling) {
+      return undefined;
+    }
+    const turn = this.turns.find(
+      (candidate) => !candidate.settled && !candidate.canceling
+    );
     if (!turn) {
       return messageType === "assistant" ? this.activateSynthetic() : undefined;
     }
@@ -356,12 +379,142 @@ export class TurnLifecycle {
     return Boolean(this.active);
   }
 
-  cancelActiveExact(turnId: string): boolean {
+  prepareExactCancellation(turnId: string): ExactTurnCancellationPreparation {
     const expected = turnId.trim();
-    if (!expected || this.active?.turnId !== expected || this.active.settled) {
+    if (!expected) {
+      return { disposition: "absent", providerTurnId: "" };
+    }
+    if (this.active && !this.active.settled) {
+      if (this.active.turnId !== expected) {
+        const queued = this.turns.find(
+          (turn) =>
+            turn !== this.active && !turn.settled && turn.turnId === expected
+        );
+        if (!queued) {
+          return { disposition: "mismatch", providerTurnId: "" };
+        }
+        if (queued.canceling) {
+          return {
+            disposition: "unresolved",
+            providerTurnId: this.providerTurnId(queued),
+            differentActiveTurn: true
+          };
+        }
+        queued.canceling = true;
+        return {
+          disposition: "queued",
+          providerTurnId: this.providerTurnId(queued),
+          differentActiveTurn: true
+        };
+      }
+      if (this.active.canceling) {
+        return {
+          disposition: "unresolved",
+          providerTurnId: this.providerTurnId(this.active)
+        };
+      }
+      this.cancelledValue = true;
+      this.active.canceling = true;
+      return {
+        disposition: "active",
+        providerTurnId: this.providerTurnId(this.active)
+      };
+    }
+
+    const queued = this.turns.find(
+      (turn) => !turn.settled && turn.turnId === expected
+    );
+    if (!queued) {
+      return {
+        disposition: this.turns.some((turn) => !turn.settled)
+          ? "mismatch"
+          : "absent",
+        providerTurnId: ""
+      };
+    }
+    if (queued.canceling) {
+      return {
+        disposition: "unresolved",
+        providerTurnId: this.providerTurnId(queued)
+      };
+    }
+
+    queued.canceling = true;
+    return {
+      disposition: "queued",
+      providerTurnId: this.providerTurnId(queued)
+    };
+  }
+
+  commitExactCancellation(turnId: string): boolean {
+    const expected = turnId.trim();
+    if (!expected) {
       return false;
     }
-    this.cancelledValue = true;
+    if (
+      this.active?.turnId === expected &&
+      !this.active.settled &&
+      this.active.canceling
+    ) {
+      this.settleActive("turn_canceled");
+      return true;
+    }
+    const queued = this.turns.find(
+      (turn) => !turn.settled && turn.canceling && turn.turnId === expected
+    );
+    if (!queued) {
+      return false;
+    }
+    if (!this.isUnstartedGoalCommand(queued)) {
+      this.completedTurnCount += 1;
+    }
+    this.settleQueuedTurn(queued, "turn_canceled");
+    this.compactQueue();
+    this.onSettled(queued.turnId);
+    return true;
+  }
+
+  prepareGenerationCancellation(): string[] {
+    const turnIds: string[] = [];
+    for (const turn of this.turns) {
+      if (turn.settled) {
+        continue;
+      }
+      turn.canceling = true;
+      turnIds.push(turn.turnId);
+    }
+    return turnIds;
+  }
+
+  releaseExactCancellation(turnId: string): void {
+    const expected = turnId.trim();
+    const turn = this.turns.find(
+      (candidate) =>
+        !candidate.settled &&
+        candidate.canceling &&
+        candidate.turnId === expected
+    );
+    if (turn) {
+      turn.canceling = false;
+    }
+  }
+
+  discardExactAbsent(turnId: string): boolean {
+    const expected = turnId.trim();
+    const turn = this.turns.find(
+      (candidate) => !candidate.settled && candidate.turnId === expected
+    );
+    if (!turn) {
+      return false;
+    }
+    turn.settled = true;
+    if (this.active === turn) {
+      this.clearContinuationStartTimer();
+      this.active = undefined;
+      this.activeIdValue = "";
+    }
+    this.compactQueue();
+    this.onSettled(turn.turnId);
     return true;
   }
   clearCancelled(): void {
@@ -447,6 +600,20 @@ export class TurnLifecycle {
       return;
     }
     turn.settled = true;
+    if (type === "turn_canceled" && this.isUnstartedGoalCommand(turn)) {
+      this.emit({
+        type: "goal_command_canceled",
+        payload: {
+          turnId: turn.turnId,
+          operationId: turn.goalOperationId,
+          revision: turn.goalRevision,
+          repairEpoch: turn.goalRepairEpoch ?? 0,
+          action: turn.goalAction,
+          reason: "cancel_requested"
+        }
+      });
+      return;
+    }
     this.emit({
       type,
       payload: {
@@ -457,6 +624,15 @@ export class TurnLifecycle {
           : {})
       }
     });
+  }
+
+  private isUnstartedGoalCommand(turn: RuntimeTurn): boolean {
+    return Boolean(
+      turn.goalOperationId &&
+      turn.goalRevision &&
+      turn.goalAction &&
+      !turn.providerTurnStarted
+    );
   }
 
   private bindProviderTurnId(

--- a/packages/agent/daemon/runtime/claude_sdk_adapter.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter.go
@@ -78,11 +78,11 @@ type claudeSDKAdapterSession struct {
 	// WorkspaceAgentTurn ids.
 	rootTurnID        string
 	rootProviderTurns map[string]struct{}
-	// providerTurnAccepted closes after the current root turn's provider
-	// identity has crossed the durable acceptance barrier. Cancel waits on it
-	// so CompleteCancel cannot settle HasSettledTurn before Established.
-	// Guarded by the adapter mutex; recreate on each new root turn.
-	providerTurnAccepted chan struct{}
+	// providerAcceptanceOutcomes retains the durable Host acceptance result by
+	// exact canonical Turn. Cancel dispatches to the provider first and consults
+	// this latch only when the sidecar confirms a provider-active cancellation.
+	// Guarded by the adapter mutex.
+	providerAcceptanceOutcomes map[string]*claudeSDKProviderAcceptanceOutcome
 	// goalArmTurnID is the sidecar turn carrying a queued /goal set command
 	// that has not settled yet; until it does, other turns settling must not
 	// be read as goal completion. Guarded by the adapter mutex.
@@ -101,6 +101,13 @@ type claudeSDKAdapterSession struct {
 	fencedGoalIdentities map[goalOperationIdentity]struct{}
 	fencedGoalTurns      map[string]claudeSDKGoalTurnFenceState
 	goalTurnBindings     map[string]claudeSDKGoalTurnBinding
+	pendingGoalCommands  map[string]claudeSDKPendingGoalCommand
+}
+
+type claudeSDKProviderAcceptanceOutcome struct {
+	done chan struct{}
+	once sync.Once
+	err  error
 }
 
 type claudeSDKGoalTurnFenceState uint8
@@ -117,6 +124,13 @@ type claudeSDKGoalTurnBinding struct {
 	identity        goalOperationIdentity
 	published       bool
 	publicationDone chan struct{}
+}
+
+type claudeSDKPendingGoalCommand struct {
+	identity     goalOperationIdentity
+	action       string
+	previousGoal map[string]any
+	started      bool
 }
 
 type claudeSDKCompactMessage struct {

--- a/packages/agent/daemon/runtime/claude_sdk_event_dispatch.go
+++ b/packages/agent/daemon/runtime/claude_sdk_event_dispatch.go
@@ -1,0 +1,81 @@
+package agentruntime
+
+import (
+	"context"
+	"strings"
+)
+
+func (a *ClaudeCodeSDKAdapter) dispatchClaudeSDKEvent(
+	agentSessionID string,
+	adapterSession *claudeSDKAdapterSession,
+	event claudeSDKSidecarEvent,
+) error {
+	if a == nil || adapterSession == nil {
+		return nil
+	}
+	eventCtx := context.Background()
+	if event.inputUnit != nil {
+		eventCtx = contextWithProviderInputUnit(eventCtx, *event.inputUnit)
+	}
+	endInputUnit := a.inputUnits.begin(eventCtx, agentSessionID)
+	defer endInputUnit()
+	a.logClaudeSDKLifecycleEvent(agentSessionID, adapterSession, event)
+	if response := a.takeClaudeSDKResponseWaiter(adapterSession, event); response != nil {
+		response <- event
+		return completeClaudeSDKProviderInputUnit(
+			context.Background(),
+			adapterSession.conn,
+			event,
+		)
+	}
+	turnID := payloadString(event.Payload, "turnId")
+	if turnID == "" {
+		turnID = payloadString(event.Payload, "turnID")
+	}
+	waiter := a.claudeSDKTurnWaiter(adapterSession, turnID)
+	if claudeSDKSidecarTurnTerminal(event.Type) {
+		providerTurnID := firstNonEmptyString(
+			payloadString(event.Payload, "providerTurnId"),
+			turnID,
+		)
+		known := a.consumeClaudeSDKRootProviderTurn(adapterSession, providerTurnID)
+		goalClearControlTurn := a.isGoalClearControlTurn(adapterSession, turnID)
+		if waiter == nil && !known && !goalClearControlTurn {
+			return completeClaudeSDKProviderInputUnit(
+				context.Background(),
+				adapterSession.conn,
+				event,
+			)
+		}
+	}
+	session := a.claudeSDKSessionSnapshot(adapterSession)
+	if strings.TrimSpace(session.AgentSessionID) == "" {
+		session.AgentSessionID = agentSessionID
+	}
+	next, terminal, err := a.sidecarTurnEvents(adapterSession, session, turnID, event)
+	next = a.stampTurnLifecycleSnapshots(adapterSession, next)
+	next = a.inputUnits.stamp(agentSessionID, next)
+	if len(next) > 0 {
+		a.updateClaudeSDKSessionSnapshot(adapterSession, next)
+	}
+	if waiter != nil {
+		a.completeClaudeSDKWaiterEvent(adapterSession, waiter, turnID, next, terminal, err)
+		return completeClaudeSDKProviderInputUnit(
+			context.Background(),
+			adapterSession.conn,
+			event,
+		)
+	}
+	if err != nil {
+		next = append(next, newSessionActivityEvent(session, EventSessionFailed, SessionStatusFailed, map[string]any{
+			"error": err.Error(),
+		}))
+	}
+	a.emitClaudeSDKSessionEvents(agentSessionID, next)
+	a.finishClaudeSDKGoalTurnPublication(adapterSession, next)
+	return completeClaudeSDKProviderInputUnit(
+		context.Background(),
+		adapterSession.conn,
+		event,
+	)
+}

--- a/packages/agent/daemon/runtime/claude_sdk_event_projection_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_event_projection_test.go
@@ -1553,13 +1553,8 @@ func TestClaudeCodeSDKAdapterMapsExitPlanModeInteractive(t *testing.T) {
 
 func TestClaudeCodeSDKAdapterCancelClearsPendingInteractive(t *testing.T) {
 	adapter := NewClaudeCodeSDKAdapter(nil)
-	session := standardTestSession(ProviderClaudeCode)
-	adapterSession := &claudeSDKAdapterSession{
-		conn:            &recordingClaudeSDKConnection{},
-		pendingRequests: make(map[string]*pendingInteractiveRequest),
-		liveState:       newClaudeSDKLiveState(),
-	}
-	adapter.storeSession(session.AgentSessionID, adapterSession)
+	conn := &ackClaudeSDKConnection{}
+	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, conn)
 	adapter.beginClaudeSDKRootTurn(
 		adapterSession,
 		"turn-cancel",
@@ -1600,12 +1595,8 @@ func TestClaudeCodeSDKAdapterCancelClearsPendingInteractive(t *testing.T) {
 
 func TestClaudeCodeSDKAdapterCancelFailsOpenToolCalls(t *testing.T) {
 	adapter := NewClaudeCodeSDKAdapter(nil)
-	session := standardTestSession(ProviderClaudeCode)
-	adapterSession := &claudeSDKAdapterSession{
-		conn:      &recordingClaudeSDKConnection{},
-		liveState: newClaudeSDKLiveState(),
-	}
-	adapter.storeSession(session.AgentSessionID, adapterSession)
+	conn := &ackClaudeSDKConnection{}
+	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, conn)
 	adapter.registerClaudeSDKTurn(adapterSession, "turn-write", nil)
 
 	started, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-write", claudeSDKSidecarEvent{
@@ -1660,12 +1651,8 @@ func TestClaudeCodeSDKAdapterCancelFailsOpenThinking(t *testing.T) {
 	// Mirrors the open-Write cancel path: thinking must leave the shared turn
 	// normalizer so Stop does not leave a forever-"thinking" disclosure.
 	adapter := NewClaudeCodeSDKAdapter(nil)
-	session := standardTestSession(ProviderClaudeCode)
-	adapterSession := &claudeSDKAdapterSession{
-		conn:      &recordingClaudeSDKConnection{},
-		liveState: newClaudeSDKLiveState(),
-	}
-	adapter.storeSession(session.AgentSessionID, adapterSession)
+	conn := &ackClaudeSDKConnection{}
+	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, conn)
 	adapter.registerClaudeSDKTurn(adapterSession, "turn-think", nil)
 
 	streaming, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-think", claudeSDKSidecarEvent{
@@ -1705,12 +1692,8 @@ func TestClaudeCodeSDKAdapterCancelFailsOpenToolsAfterWaiterUnregistered(t *test
 	// Mirrors controller Cancel ordering: active.cancel() makes Exec unregister
 	// its waiter before adapter.Cancel runs. Open tools must still close.
 	adapter := NewClaudeCodeSDKAdapter(nil)
-	session := standardTestSession(ProviderClaudeCode)
-	adapterSession := &claudeSDKAdapterSession{
-		conn:      &recordingClaudeSDKConnection{},
-		liveState: newClaudeSDKLiveState(),
-	}
-	adapter.storeSession(session.AgentSessionID, adapterSession)
+	conn := &ackClaudeSDKConnection{}
+	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, conn)
 	waiter := adapter.registerClaudeSDKTurn(adapterSession, "turn-write", nil)
 
 	if _, _, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-write", claudeSDKSidecarEvent{

--- a/packages/agent/daemon/runtime/claude_sdk_event_types.go
+++ b/packages/agent/daemon/runtime/claude_sdk_event_types.go
@@ -1,0 +1,49 @@
+package agentruntime
+
+import "encoding/json"
+
+func payloadInt64(payload map[string]any, key string) int64 {
+	switch value := payload[key].(type) {
+	case int64:
+		return value
+	case int:
+		return int64(value)
+	case float64:
+		return int64(value)
+	case json.Number:
+		result, _ := value.Int64()
+		return result
+	default:
+		return 0
+	}
+}
+
+func isClaudeSDKTerminalEvent(eventType string) bool {
+	switch eventType {
+	case "turn_completed", "turn_canceled", "turn_failed",
+		"goal_command_canceled", "goal_command_superseded":
+		return true
+	default:
+		return false
+	}
+}
+
+func claudeSDKSidecarTurnTerminal(eventType string) bool {
+	switch eventType {
+	case "turn_completed", "turn_canceled", "turn_failed":
+		return true
+	default:
+		return false
+	}
+}
+
+func validClaudeSDKCancelDispatchPhase(phase string) bool {
+	switch phase {
+	case "queued", "dispatched", "provider_observed", "resolving_identity",
+		"identity_resolved", "streaming", "waiting_approval", "waiting_input",
+		"running_tool", "terminal", "pending_goal", "unknown":
+		return true
+	default:
+		return false
+	}
+}

--- a/packages/agent/daemon/runtime/claude_sdk_events.go
+++ b/packages/agent/daemon/runtime/claude_sdk_events.go
@@ -2,7 +2,6 @@ package agentruntime
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"log/slog"
 	"sort"
@@ -10,22 +9,6 @@ import (
 
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
-
-func payloadInt64(payload map[string]any, key string) int64 {
-	switch value := payload[key].(type) {
-	case int64:
-		return value
-	case int:
-		return int64(value)
-	case float64:
-		return int64(value)
-	case json.Number:
-		result, _ := value.Int64()
-		return result
-	default:
-		return 0
-	}
-}
 
 func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapterSession, session Session, turnID string, event claudeSDKSidecarEvent) ([]activityshared.Event, bool, error) {
 	adapterSession.applySessionPayload(&session, event.Payload)
@@ -70,7 +53,15 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 		}
 	}
 	terminalEvent := isClaudeSDKTerminalEvent(event.Type)
+	fencedPendingGoalUpdateType := ""
 	if fenceState != 0 && terminalEvent {
+		fencedPendingGoalUpdateType = finishClaudeSDKPendingGoalCommandLocked(
+			adapterSession,
+			firstNonEmptyString(eventTurnID, strings.TrimSpace(turnID)),
+			nil,
+			event.Type != "turn_completed",
+			true,
+		)
 		delete(adapterSession.fencedGoalTurns, providerTurnID)
 		delete(adapterSession.fencedGoalTurns, eventTurnID)
 		delete(adapterSession.goalTurnBindings, eventTurnID)
@@ -79,7 +70,10 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 	}
 	a.mu.Unlock()
 	if fenceState != 0 && (!terminalEvent || fenceState == claudeSDKGoalTurnFenceSuppress) {
-		return nil, terminalEvent, nil
+		if fencedPendingGoalUpdateType == "" {
+			return nil, terminalEvent, nil
+		}
+		return a.goalMirrorEvents(session, fencedPendingGoalUpdateType), terminalEvent, nil
 	}
 	if explicitProviderTurnID != "" &&
 		activeProviderTurnID != "" &&
@@ -92,13 +86,24 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 	if goalClearControlTurn && isClaudeSDKGoalClearHiddenEvent(event.Type) {
 		return nil, false, nil
 	}
-	if goalClearControlTurn && isClaudeSDKTerminalEvent(event.Type) {
+	if goalClearControlTurn &&
+		isClaudeSDKTerminalEvent(event.Type) &&
+		event.Type != "goal_command_canceled" {
+		events := a.finishClaudeSDKPendingGoalTurn(
+			adapterSession,
+			session,
+			eventTurnID,
+			event.Type != "turn_completed",
+			true,
+		)
 		a.forgetGoalClearControlTurn(adapterSession, providerTurnID)
 		a.forgetGoalClearControlTurn(adapterSession, eventTurnID)
-		return nil, true, nil
+		return events, true, nil
 	}
 	rootTurnID := ""
-	if event.Type != "provider_turn_identity_resolved" && event.Type != "turn_started" {
+	if event.Type != "provider_turn_identity_resolved" &&
+		event.Type != "turn_started" &&
+		event.Type != "goal_command_canceled" {
 		rootTurnID = a.claudeSDKRootTurnID(adapterSession, providerTurnID)
 	}
 	if events, handled := claudeSDKSidecarBackgroundTaskEvents(adapterSession, session, event); handled {
@@ -208,6 +213,7 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 			metadata,
 		)}, false, nil
 	case "goal_command_started":
+		a.markClaudeSDKPendingGoalCommandStarted(adapterSession, event)
 		metadata := map[string]any{
 			"operationId":    payloadString(event.Payload, "operationId"),
 			"revision":       payloadInt64(event.Payload, "revision"),
@@ -223,7 +229,18 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 		events = append(events, newSessionActivityEvent(session, EventSessionUpdated, firstNonEmpty(session.Status, SessionStatusReady), claudeSDKRuntimeContext(session, adapterSession)))
 		return events, false, nil
 	case "goal_command_superseded":
-		return nil, false, nil
+		return a.finishClaudeSDKPendingGoalTurn(
+			adapterSession,
+			session,
+			eventTurnID,
+			true,
+			true,
+		), true, nil
+	case "goal_command_canceled":
+		events := a.finishClaudeSDKPendingGoalCommand(adapterSession, session, event)
+		a.forgetGoalClearControlTurn(adapterSession, eventTurnID)
+		a.forgetClaudeSDKGoalTurnBinding(adapterSession, eventTurnID)
+		return events, true, nil
 	case "commands_updated":
 		if adapterSession.applyCommandsUpdated(session.AgentSessionID, event.Payload) {
 			a.emitCommandSnapshot(claudeSDKCommandSnapshot(session.AgentSessionID, adapterSession.liveState))
@@ -374,6 +391,13 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 		if updateType == "" {
 			return nil, false, nil
 		}
+		a.finishClaudeSDKPendingGoalTurn(
+			adapterSession,
+			session,
+			eventTurnID,
+			false,
+			false,
+		)
 		events := make([]activityshared.Event, 0, 2)
 		if goalEvent, ok := normalizedGoalUpdatedEvent(session, updateType); ok {
 			events = append(events, goalEvent)
@@ -384,6 +408,7 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 		if boundProviderTurnID == "" {
 			return nil, false, errors.New("claude SDK provider turn completion omitted identity")
 		}
+		a.finishClaudeSDKPendingGoalTurn(adapterSession, session, eventTurnID, false, true)
 		events := a.finishClaudeSDKTurnLifecycle(adapterSession, session, rootTurnID, claudeSDKTurnFinishCompleted, "")
 		events = append(events, claudeSDKRootProviderTurnCompletedEvent(session, rootTurnID, boundProviderTurnID, activityshared.TurnOutcomeCompleted, map[string]any{
 			"adapter":    claudeSDKSidecarAdapterName,
@@ -392,23 +417,30 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 		a.forgetClaudeSDKGoalTurnBinding(adapterSession, eventTurnID)
 		return events, true, nil
 	case "turn_canceled":
+		goalEvents := a.finishClaudeSDKPendingGoalTurn(adapterSession, session, eventTurnID, true, true)
 		if boundProviderTurnID == "" {
-			return a.finishClaudeSDKTurnLifecycle(
+			events := a.finishClaudeSDKTurnLifecycle(
 				adapterSession,
 				session,
 				rootTurnID,
 				claudeSDKTurnFinishInterrupted,
 				"interrupted_before_provider_acceptance",
-			), true, nil
+			)
+			return append(events, goalEvents...), true, nil
 		}
 		events := a.finishClaudeSDKTurnLifecycle(adapterSession, session, rootTurnID, claudeSDKTurnFinishInterrupted, "interrupted")
 		events = append(events, claudeSDKRootProviderTurnCompletedEvent(session, rootTurnID, boundProviderTurnID, activityshared.TurnOutcomeCanceled, map[string]any{
 			"adapter": claudeSDKSidecarAdapterName,
 		}))
-		events = append(events, a.goalEventsOnArmTurnFailed(adapterSession, session, firstNonEmptyString(eventTurnID, strings.TrimSpace(turnID), providerTurnID))...)
+		if len(goalEvents) > 0 {
+			events = append(events, goalEvents...)
+		} else {
+			events = append(events, a.goalEventsOnArmTurnFailed(adapterSession, session, firstNonEmptyString(eventTurnID, strings.TrimSpace(turnID), providerTurnID))...)
+		}
 		a.forgetClaudeSDKGoalTurnBinding(adapterSession, eventTurnID)
 		return events, true, nil
 	case "turn_failed":
+		goalEvents := a.finishClaudeSDKPendingGoalTurn(adapterSession, session, eventTurnID, true, true)
 		if boundProviderTurnID == "" {
 			events := a.finishClaudeSDKTurnLifecycle(
 				adapterSession,
@@ -424,6 +456,7 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 			events = ensureClaudeSDKPreAcceptanceFailureEvent(
 				events, session, rootTurnID, event.Payload, rejected,
 			)
+			events = append(events, goalEvents...)
 			if rejected {
 				return events, true, newClaudeSDKProviderRejectedError(session, event.Payload)
 			}
@@ -434,20 +467,15 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 			"adapter": claudeSDKSidecarAdapterName,
 			"error":   payloadString(event.Payload, "error"),
 		}))
-		events = append(events, a.goalEventsOnArmTurnFailed(adapterSession, session, firstNonEmptyString(eventTurnID, strings.TrimSpace(turnID), providerTurnID))...)
+		if len(goalEvents) > 0 {
+			events = append(events, goalEvents...)
+		} else {
+			events = append(events, a.goalEventsOnArmTurnFailed(adapterSession, session, firstNonEmptyString(eventTurnID, strings.TrimSpace(turnID), providerTurnID))...)
+		}
 		a.forgetClaudeSDKGoalTurnBinding(adapterSession, eventTurnID)
 		return events, true, nil
 	default:
 		return nil, false, nil
-	}
-}
-
-func isClaudeSDKTerminalEvent(eventType string) bool {
-	switch eventType {
-	case "turn_completed", "turn_canceled", "turn_failed":
-		return true
-	default:
-		return false
 	}
 }
 
@@ -537,81 +565,6 @@ func (a *ClaudeCodeSDKAdapter) stampTurnLifecycleSnapshots(adapterSession *claud
 	return events
 }
 
-func (a *ClaudeCodeSDKAdapter) dispatchClaudeSDKEvent(
-	agentSessionID string,
-	adapterSession *claudeSDKAdapterSession,
-	event claudeSDKSidecarEvent,
-) error {
-	if a == nil || adapterSession == nil {
-		return nil
-	}
-	eventCtx := context.Background()
-	if event.inputUnit != nil {
-		eventCtx = contextWithProviderInputUnit(eventCtx, *event.inputUnit)
-	}
-	endInputUnit := a.inputUnits.begin(eventCtx, agentSessionID)
-	defer endInputUnit()
-	a.logClaudeSDKLifecycleEvent(agentSessionID, adapterSession, event)
-	if response := a.takeClaudeSDKResponseWaiter(adapterSession, event); response != nil {
-		response <- event
-		return completeClaudeSDKProviderInputUnit(
-			context.Background(),
-			adapterSession.conn,
-			event,
-		)
-	}
-	turnID := payloadString(event.Payload, "turnId")
-	if turnID == "" {
-		turnID = payloadString(event.Payload, "turnID")
-	}
-	waiter := a.claudeSDKTurnWaiter(adapterSession, turnID)
-	if claudeSDKSidecarTurnTerminal(event.Type) {
-		providerTurnID := firstNonEmptyString(
-			payloadString(event.Payload, "providerTurnId"),
-			turnID,
-		)
-		known := a.consumeClaudeSDKRootProviderTurn(adapterSession, providerTurnID)
-		goalClearControlTurn := a.isGoalClearControlTurn(adapterSession, turnID)
-		if waiter == nil && !known && !goalClearControlTurn {
-			return completeClaudeSDKProviderInputUnit(
-				context.Background(),
-				adapterSession.conn,
-				event,
-			)
-		}
-	}
-	session := a.claudeSDKSessionSnapshot(adapterSession)
-	if strings.TrimSpace(session.AgentSessionID) == "" {
-		session.AgentSessionID = agentSessionID
-	}
-	next, terminal, err := a.sidecarTurnEvents(adapterSession, session, turnID, event)
-	next = a.stampTurnLifecycleSnapshots(adapterSession, next)
-	next = a.inputUnits.stamp(agentSessionID, next)
-	if len(next) > 0 {
-		a.updateClaudeSDKSessionSnapshot(adapterSession, next)
-	}
-	if waiter != nil {
-		a.completeClaudeSDKWaiterEvent(adapterSession, waiter, turnID, next, terminal, err)
-		return completeClaudeSDKProviderInputUnit(
-			context.Background(),
-			adapterSession.conn,
-			event,
-		)
-	}
-	if err != nil {
-		next = append(next, newSessionActivityEvent(session, EventSessionFailed, SessionStatusFailed, map[string]any{
-			"error": err.Error(),
-		}))
-	}
-	a.emitClaudeSDKSessionEvents(agentSessionID, next)
-	a.finishClaudeSDKGoalTurnPublication(adapterSession, next)
-	return completeClaudeSDKProviderInputUnit(
-		context.Background(),
-		adapterSession.conn,
-		event,
-	)
-}
-
 func (a *ClaudeCodeSDKAdapter) logClaudeSDKLifecycleEvent(agentSessionID string, adapterSession *claudeSDKAdapterSession, event claudeSDKSidecarEvent) {
 	if !claudeSDKLifecycleEventDiagnostic(event) {
 		return
@@ -645,7 +598,7 @@ func claudeSDKLifecycleEventDiagnostic(event claudeSDKSidecarEvent) bool {
 	switch strings.TrimSpace(event.Type) {
 	case "sdk_lifecycle_observed",
 		"provider_turn_identity_resolved", "provider_turn_checkpoint",
-		"goal_observed",
+		"goal_observed", "goal_command_canceled",
 		"approval_requested", "user_input_requested",
 		"turn_started", "turn_completed", "turn_canceled", "turn_failed",
 		"continuation_delayed",
@@ -655,15 +608,6 @@ func claudeSDKLifecycleEventDiagnostic(event claudeSDKSidecarEvent) bool {
 	case "tool_started", "tool_completed", "tool_failed":
 		return strings.EqualFold(strings.TrimSpace(payloadString(event.Payload, "toolName")), "Agent") ||
 			strings.EqualFold(strings.TrimSpace(payloadString(event.Payload, "toolName")), "Task")
-	default:
-		return false
-	}
-}
-
-func claudeSDKSidecarTurnTerminal(eventType string) bool {
-	switch eventType {
-	case "turn_completed", "turn_canceled", "turn_failed":
-		return true
 	default:
 		return false
 	}

--- a/packages/agent/daemon/runtime/claude_sdk_execution.go
+++ b/packages/agent/daemon/runtime/claude_sdk_execution.go
@@ -3,6 +3,7 @@ package agentruntime
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 
@@ -223,13 +224,17 @@ func (a *ClaudeCodeSDKAdapter) ExecWithProviderAcceptance(
 					acceptanceErr = errors.New(
 						"provider acceptance barrier is unavailable",
 					)
-					return
+				} else {
+					acceptanceErr = acceptProviderTurn(receipt)
 				}
-				acceptanceErr = acceptProviderTurn(receipt)
+				a.completeClaudeSDKProviderAcceptance(
+					adapterSession,
+					turnID,
+					acceptanceErr,
+				)
 				accepted = acceptanceErr == nil
 				if accepted {
 					acceptedProviderTurnID = providerTurnID
-					a.signalClaudeSDKProviderTurnAccepted(adapterSession)
 				}
 			})
 			if acceptanceErr != nil {
@@ -515,24 +520,65 @@ func (a *ClaudeCodeSDKAdapter) cancelClaudeSDKTurn(
 	}
 	cancelCtx, cancel := context.WithTimeout(ctx, claudeSDKGoalCommandTimeout)
 	defer cancel()
-	// Durable cancel settlement marks HasSettledTurn. Waiting here ensures
-	// root_provider_turn_id is already committed (Established) before that
-	// settlement, so a cancel→resend cannot hit provider_session_not_established.
-	if err := a.waitClaudeSDKProviderTurnAccepted(cancelCtx, adapterSession); err != nil {
-		return nil, err
-	}
 	payload := map[string]any{
 		"agentSessionId": session.AgentSessionID,
 	}
 	if turnID != "" {
 		payload["turnId"] = turnID
 	}
-	if err := a.roundTripClaudeSDK(cancelCtx, session.AgentSessionID, adapterSession, claudeSDKSidecarRequest{
+	response, err := a.roundTripClaudeSDKResponse(cancelCtx, session.AgentSessionID, adapterSession, claudeSDKSidecarRequest{
 		ID:      newID(),
 		Type:    "cancel",
 		Payload: payload,
-	}); err != nil {
+	})
+	if err != nil {
 		return nil, err
+	}
+	disposition := strings.TrimSpace(payloadString(response.Payload, "disposition"))
+	responseTurnID := strings.TrimSpace(payloadString(response.Payload, "turnId"))
+	providerTurnID := strings.TrimSpace(payloadString(response.Payload, "providerTurnId"))
+	dispatchPhase := strings.TrimSpace(payloadString(response.Payload, "dispatchPhase"))
+	canceled := payloadBoolValue(response.Payload, "canceled")
+	if responseTurnID != turnID {
+		return nil, fmt.Errorf(
+			"claude SDK cancel response turn mismatch: requested %q, received %q",
+			turnID,
+			responseTurnID,
+		)
+	}
+	if !validClaudeSDKCancelDispatchPhase(dispatchPhase) {
+		return nil, fmt.Errorf(
+			"claude SDK returned unknown cancel dispatch phase %q",
+			dispatchPhase,
+		)
+	}
+	switch disposition {
+	case "pre_accept":
+		if !canceled || providerTurnID != "" {
+			return nil, errors.New("claude SDK returned inconsistent pre-accept cancellation")
+		}
+	case "provider_active":
+		if !canceled || providerTurnID == "" {
+			return nil, errors.New("claude SDK returned inconsistent provider-active cancellation")
+		}
+		if dispatchPhase == "queued" || dispatchPhase == "pending_goal" || dispatchPhase == "unknown" {
+			return nil, errors.New("claude SDK returned provider-active cancellation before dispatch")
+		}
+		if err := a.waitClaudeSDKProviderAcceptanceOutcome(cancelCtx, adapterSession, turnID); err != nil {
+			return nil, fmt.Errorf("claude SDK durable provider acceptance: %w", err)
+		}
+	case "absent":
+		if canceled || providerTurnID != "" {
+			return nil, errors.New("claude SDK returned inconsistent absent cancellation")
+		}
+		return nil, ErrSessionNoActiveTurn
+	case "mismatch":
+		if canceled || providerTurnID != "" {
+			return nil, errors.New("claude SDK returned inconsistent mismatched cancellation")
+		}
+		return nil, fmt.Errorf("%w: turn %q", ErrCancelTargetMismatch, turnID)
+	default:
+		return nil, fmt.Errorf("claude SDK returned unknown cancel disposition %q", disposition)
 	}
 	events := a.claudeSDKPendingRequestFailureEvents(adapterSession, session, "", errPermissionRequestCanceled)
 	// Finish open turn lifecycles by normalizer ownership, not by the live
@@ -558,19 +604,18 @@ func (a *ClaudeCodeSDKAdapter) CancelTargets(ctx context.Context, rootSession Se
 				return TargetedCancelResult{}, ErrSessionDisconnected
 			}
 			rootTurnID := strings.TrimSpace(target.TurnID)
-			// services/tuttid owns the exact durable cancellation target set.
-			// Close those projection boundaries before asking the SDK to stop so
-			// cancellation-caused task/tool terminal events cannot race the
-			// durable canceled state and reinterpret a child as failed.
-			for _, cancelTarget := range targets {
-				a.markClaudeSDKTurnClosed(adapterSession, cancelTarget.TurnID, "cancel_requested")
-			}
 			// Claude SDK exposes cancellation for the root query. That provider
 			// operation stops its nested Task executions as part of the same
 			// query; services/tuttid supplied the exact durable target set.
 			events, err := a.cancelClaudeSDKTurn(ctx, rootSession, rootTurnID, reason)
 			if err != nil {
 				return TargetedCancelResult{}, err
+			}
+			// Commit projection fences only after the sidecar has confirmed its
+			// exact disposition. Absent, mismatch, timeout, or protocol failure
+			// must leave later provider evidence observable for reconciliation.
+			for _, cancelTarget := range targets {
+				a.markClaudeSDKTurnClosed(adapterSession, cancelTarget.TurnID, "cancel_requested")
 			}
 			return TargetedCancelResult{
 				Events:           events,

--- a/packages/agent/daemon/runtime/claude_sdk_goal.go
+++ b/packages/agent/daemon/runtime/claude_sdk_goal.go
@@ -84,6 +84,8 @@ func (a *ClaudeCodeSDKAdapter) FenceGoalGeneration(
 	}
 	adapterSession.fencedGoalIdentities[identity] = struct{}{}
 	bindings := make([]claudeSDKGoalTurnBinding, 0, 1)
+	pendingTurnIDs := make([]string, 0, 1)
+	boundTurnIDs := make(map[string]struct{})
 	publicationDone := make([]<-chan struct{}, 0, 1)
 	for _, binding := range adapterSession.goalTurnBindings {
 		if binding.identity != identity {
@@ -91,15 +93,46 @@ func (a *ClaudeCodeSDKAdapter) FenceGoalGeneration(
 		}
 		markClaudeSDKGoalTurnFencedLocked(adapterSession, binding.published, binding.turnID, binding.providerTurnID)
 		bindings = append(bindings, binding)
+		boundTurnIDs[binding.turnID] = struct{}{}
 		if binding.published && binding.publicationDone != nil {
 			publicationDone = append(publicationDone, binding.publicationDone)
 		}
+	}
+	for turnID, pending := range adapterSession.pendingGoalCommands {
+		if pending.identity != identity {
+			continue
+		}
+		if _, alreadyBound := boundTurnIDs[turnID]; alreadyBound {
+			continue
+		}
+		// The provider identity/start events may already be queued in the
+		// transport while the accepted Goal command is still pending here. Own
+		// the exact Turn fence before releasing the lock so those late events
+		// cannot publish a canonical start, and retain both aliases until their
+		// terminal cleanup arrives.
+		markClaudeSDKGoalTurnFencedLocked(adapterSession, false, turnID)
+		if adapterSession.goalTurnBindings == nil {
+			adapterSession.goalTurnBindings = make(map[string]claudeSDKGoalTurnBinding)
+		}
+		if _, bound := adapterSession.goalTurnBindings[turnID]; !bound {
+			adapterSession.goalTurnBindings[turnID] = claudeSDKGoalTurnBinding{
+				turnID: turnID, identity: pending.identity,
+			}
+		}
+		if adapterSession.rootProviderTurns == nil {
+			adapterSession.rootProviderTurns = make(map[string]struct{})
+		}
+		adapterSession.rootProviderTurns[turnID] = struct{}{}
+		pendingTurnIDs = append(pendingTurnIDs, turnID)
 	}
 	a.mu.Unlock()
 	for _, binding := range bindings {
 		a.rememberClaudeSDKRootProviderTurn(adapterSession, binding.turnID)
 		a.rememberClaudeSDKRootProviderTurn(adapterSession, binding.providerTurnID)
 		a.cancelClaudeSDKGoalTurn(adapterSession, session, binding.turnID, identity.revision, identity.repairEpoch)
+	}
+	for _, turnID := range pendingTurnIDs {
+		a.cancelClaudeSDKGoalTurn(adapterSession, session, turnID, identity.revision, identity.repairEpoch)
 	}
 	for _, done := range publicationDone {
 		select {
@@ -434,7 +467,7 @@ func (a *ClaudeCodeSDKAdapter) applyGoalMirrorAndSend(
 ) error {
 	previous := a.localGoal(adapterSession)
 	a.applyLocalGoal(adapterSession, goal)
-	if err := a.sendGoalCommandExec(ctx, session, adapterSession, command, operationID, revision, repairEpoch); err != nil {
+	if err := a.sendGoalCommandExec(ctx, session, adapterSession, command, operationID, revision, repairEpoch, previous); err != nil {
 		a.restoreClaudeGoalMirrorIfCurrent(adapterSession, operationID, revision, repairEpoch, previous)
 		return err
 	}
@@ -519,7 +552,7 @@ func (a *ClaudeCodeSDKAdapter) ExecGoalControl(
 	if event, ok := adapterSession.mirrorGoalSlashPrompt(session, visibleText); ok {
 		events = append(events, event)
 	}
-	if err := a.sendGoalCommandExec(ctx, session, adapterSession, visibleText, "", 0, 0); err != nil {
+	if err := a.sendGoalCommandExec(ctx, session, adapterSession, visibleText, "", 0, 0, nil); err != nil {
 		return events, true, err
 	}
 	return events, true, nil
@@ -567,6 +600,7 @@ func (a *ClaudeCodeSDKAdapter) sendGoalCommandExec(
 	operationID string,
 	revision int64,
 	repairEpoch int64,
+	previousGoal map[string]any,
 ) error {
 	if err := a.startClaudeSDKReader(session.AgentSessionID, adapterSession); err != nil {
 		return err
@@ -586,6 +620,25 @@ func (a *ClaudeCodeSDKAdapter) sendGoalCommandExec(
 		adapterSession.goalClearControlTurns[turnID] = struct{}{}
 	} else {
 		adapterSession.goalArmTurnID = assignedArm
+	}
+	identity := goalOperationIdentity{
+		operationID: strings.TrimSpace(operationID),
+		revision:    revision,
+		repairEpoch: repairEpoch,
+	}
+	if identity.valid() {
+		if adapterSession.pendingGoalCommands == nil {
+			adapterSession.pendingGoalCommands = make(map[string]claudeSDKPendingGoalCommand)
+		}
+		action := "set"
+		if isClear {
+			action = "clear"
+		}
+		adapterSession.pendingGoalCommands[turnID] = claudeSDKPendingGoalCommand{
+			identity:     identity,
+			action:       action,
+			previousGoal: clonePayload(previousGoal),
+		}
 	}
 	a.mu.Unlock()
 	// The API context may carry no deadline; a missing sidecar ack must not
@@ -625,84 +678,9 @@ func (a *ClaudeCodeSDKAdapter) sendGoalCommandExec(
 			delete(adapterSession.goalClearControlTurns, turnID)
 			a.mu.Unlock()
 		}
+		a.forgetClaudeSDKPendingGoalCommand(adapterSession, turnID)
 	}
 	return err
-}
-
-func (a *ClaudeCodeSDKAdapter) isGoalClearControlTurn(
-	adapterSession *claudeSDKAdapterSession,
-	turnID string,
-) bool {
-	if a == nil || adapterSession == nil {
-		return false
-	}
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	_, ok := adapterSession.goalClearControlTurns[strings.TrimSpace(turnID)]
-	return ok
-}
-
-func (a *ClaudeCodeSDKAdapter) forgetGoalClearControlTurn(
-	adapterSession *claudeSDKAdapterSession,
-	turnID string,
-) {
-	if a == nil || adapterSession == nil {
-		return
-	}
-	a.mu.Lock()
-	delete(adapterSession.goalClearControlTurns, strings.TrimSpace(turnID))
-	a.mu.Unlock()
-}
-
-func (a *ClaudeCodeSDKAdapter) restoreClaudeGoalArmIfCurrent(
-	adapterSession *claudeSDKAdapterSession,
-	operationID string,
-	revision int64,
-	repairEpoch int64,
-	assignedArm string,
-	previousArm string,
-) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	currentOperationID := strings.TrimSpace(adapterSession.goalOperationID)
-	operationID = strings.TrimSpace(operationID)
-	identityMatches := operationID == "" && revision == 0 ||
-		currentOperationID == operationID && adapterSession.goalRevision == revision && adapterSession.goalRepairEpoch == repairEpoch
-	if identityMatches && adapterSession.goalArmTurnID == assignedArm {
-		adapterSession.goalArmTurnID = previousArm
-	}
-}
-
-// goalEventsOnArmTurnFailed rolls back the optimistic mirror only when the
-// /goal arm command itself never completes. Ordinary terminal Turn events are
-// not Goal evidence; only normalized provider Goal observations are.
-func (a *ClaudeCodeSDKAdapter) goalEventsOnArmTurnFailed(
-	adapterSession *claudeSDKAdapterSession,
-	session Session,
-	turnID string,
-) []activityshared.Event {
-	trimmed := strings.TrimSpace(turnID)
-	a.mu.Lock()
-	goal := adapterSession.liveState.goal
-	armTurnID := adapterSession.goalArmTurnID
-	if len(goal) == 0 || asString(goal["status"]) != "active" {
-		a.mu.Unlock()
-		return nil
-	}
-	if armTurnID != "" && trimmed != armTurnID {
-		// The queued /goal set has not run yet; this settle belongs to an
-		// earlier turn and says nothing about the goal.
-		a.mu.Unlock()
-		return nil
-	}
-	if armTurnID != "" && trimmed == armTurnID {
-		adapterSession.goalArmTurnID = ""
-		adapterSession.liveState.goal = nil
-		a.mu.Unlock()
-		return a.goalMirrorEvents(session, "thread_goal_cleared")
-	}
-	a.mu.Unlock()
-	return nil
 }
 
 // applyClaudeSDKGoalObservation consumes the sidecar's normalized projection

--- a/packages/agent/daemon/runtime/claude_sdk_goal_lifecycle_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_goal_lifecycle_test.go
@@ -168,7 +168,6 @@ func TestClaudeSDKCancelLiveTurnWaitsForProviderTerminal(t *testing.T) {
 	// Cancel argument (which is the cancel reason). Register a live turn and pass
 	// an unrelated reason to prove the terminal is stamped for the real turnID.
 	adapter.beginClaudeSDKRootTurn(adapterSession, "turn-live", "")
-	adapter.signalClaudeSDKProviderTurnAccepted(adapterSession)
 	adapter.registerClaudeSDKTurn(adapterSession, "turn-live", nil)
 
 	events, err := adapter.Cancel(context.Background(), session, "user")
@@ -199,7 +198,6 @@ func TestClaudeSDKCancelUsesRegistryTurnNotReasonArg(t *testing.T) {
 	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, conn)
 
 	adapter.beginClaudeSDKRootTurn(adapterSession, "turn-live", "")
-	adapter.signalClaudeSDKProviderTurnAccepted(adapterSession)
 	adapter.registerClaudeSDKTurn(adapterSession, "turn-live", nil)
 
 	// Reason is the free-form stop reason the controller passes, not a turnID.
@@ -226,7 +224,7 @@ func TestClaudeSDKCancelUsesRegistryTurnNotReasonArg(t *testing.T) {
 	}
 }
 
-func TestClaudeSDKCancelWaitsForDurableProviderAcceptance(t *testing.T) {
+func TestClaudeSDKCancelBeforeProviderAcceptanceIsForwarded(t *testing.T) {
 	t.Parallel()
 
 	adapter := NewClaudeCodeSDKAdapter(nil)
@@ -235,32 +233,140 @@ func TestClaudeSDKCancelWaitsForDurableProviderAcceptance(t *testing.T) {
 	adapter.beginClaudeSDKRootTurn(adapterSession, "turn-accept", "")
 	adapter.registerClaudeSDKTurn(adapterSession, "turn-accept", nil)
 
-	started := make(chan struct{})
-	done := make(chan error, 1)
-	go func() {
-		close(started)
-		_, err := adapter.Cancel(context.Background(), session, "user")
-		done <- err
-	}()
-	<-started
-	select {
-	case err := <-done:
-		t.Fatalf("Cancel returned before durable acceptance: %v", err)
-	case <-time.After(50 * time.Millisecond):
-	}
-	adapter.signalClaudeSDKProviderTurnAccepted(adapterSession)
-	select {
-	case err := <-done:
-		if err != nil {
-			t.Fatalf("Cancel after acceptance: %v", err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("Cancel did not resume after durable acceptance")
+	if _, err := adapter.Cancel(context.Background(), session, "user"); err != nil {
+		t.Fatalf("Cancel before provider acceptance: %v", err)
 	}
 	sent := conn.sentRequests()
 	if len(sent) != 1 || sent[0].Type != "cancel" ||
 		payloadString(sent[0].Payload, "turnId") != "turn-accept" {
-		t.Fatalf("cancel after acceptance = %#v", sent)
+		t.Fatalf("cancel before acceptance = %#v", sent)
+	}
+}
+
+func TestClaudeSDKCancelProviderActiveWaitsOnlyAfterSendingCancel(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	conn := newBlockingClaudeSDKConnection()
+	defer func() { _ = conn.Close() }()
+	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, conn)
+	adapter.beginClaudeSDKRootTurn(adapterSession, "turn-provider-active", "")
+	adapter.registerClaudeSDKTurn(adapterSession, "turn-provider-active", nil)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := adapter.Cancel(context.Background(), session, "user")
+		done <- err
+	}()
+	request := waitForClaudeSDKSentRequest(t, conn, "cancel")
+	conn.pushEvent(claudeSDKSidecarEvent{
+		ID: request.ID, Type: "ok",
+		Payload: map[string]any{
+			"canceled": true, "disposition": "provider_active",
+			"turnId": "turn-provider-active", "providerTurnId": "provider-turn-active",
+			"dispatchPhase": "identity_resolved",
+		},
+	})
+	select {
+	case err := <-done:
+		t.Fatalf("Cancel returned before durable acceptance completed: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	adapter.completeClaudeSDKProviderAcceptance(adapterSession, "turn-provider-active", nil)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Cancel after durable acceptance: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Cancel did not resume after durable acceptance")
+	}
+}
+
+func TestClaudeSDKCancelProviderActiveReturnsDurableAcceptanceFailure(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	conn := &ackClaudeSDKConnection{
+		cancelDisposition:    "provider_active",
+		cancelProviderTurnID: "provider-turn-failed",
+	}
+	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, conn)
+	adapter.beginClaudeSDKRootTurn(adapterSession, "turn-acceptance-failed", "")
+	adapter.registerClaudeSDKTurn(adapterSession, "turn-acceptance-failed", nil)
+	acceptanceErr := errors.New("durable acceptance failed")
+	adapter.completeClaudeSDKProviderAcceptance(adapterSession, "turn-acceptance-failed", acceptanceErr)
+
+	_, err := adapter.Cancel(context.Background(), session, "user")
+	if !errors.Is(err, acceptanceErr) {
+		t.Fatalf("Cancel error = %v, want durable acceptance failure", err)
+	}
+}
+
+func TestClaudeSDKCancelUnknownDispositionFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	conn := &ackClaudeSDKConnection{cancelDisposition: "future_state"}
+	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, conn)
+	adapter.beginClaudeSDKRootTurn(adapterSession, "turn-unknown-disposition", "")
+	adapter.registerClaudeSDKTurn(adapterSession, "turn-unknown-disposition", nil)
+
+	_, err := adapter.Cancel(context.Background(), session, "user")
+	if err == nil || !strings.Contains(err.Error(), "unknown cancel disposition") {
+		t.Fatalf("Cancel error = %v, want unknown disposition failure", err)
+	}
+}
+
+func TestClaudeSDKCancelUnknownDispatchPhaseFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	conn := &ackClaudeSDKConnection{cancelDispatchPhase: "future_phase"}
+	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, conn)
+	adapter.beginClaudeSDKRootTurn(adapterSession, "turn-unknown-phase", "")
+	adapter.registerClaudeSDKTurn(adapterSession, "turn-unknown-phase", nil)
+
+	_, err := adapter.Cancel(context.Background(), session, "user")
+	if err == nil || !strings.Contains(err.Error(), "unknown cancel dispatch phase") {
+		t.Fatalf("Cancel error = %v, want unknown dispatch phase failure", err)
+	}
+}
+
+func TestClaudeSDKCancelMismatchIsNotTargetAbsent(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	canceled := false
+	conn := &ackClaudeSDKConnection{
+		cancelResult:      &canceled,
+		cancelDisposition: "mismatch",
+	}
+	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, conn)
+	adapter.beginClaudeSDKRootTurn(adapterSession, "turn-mismatch", "")
+	adapter.registerClaudeSDKTurn(adapterSession, "turn-mismatch", nil)
+
+	_, err := adapter.CancelTargets(context.Background(), session, []CancelTarget{{
+		AgentSessionID: session.AgentSessionID,
+		TurnID:         "turn-mismatch",
+	}}, "user")
+	if !errors.Is(err, ErrCancelTargetMismatch) || errors.Is(err, ErrSessionNoActiveTurn) {
+		t.Fatalf("CancelTargets error = %v, want target mismatch", err)
+	}
+	if adapter.turnAlreadySettled(adapterSession, "turn-mismatch") {
+		t.Fatal("mismatched cancel permanently fenced the still-live Turn")
+	}
+	projected, terminal, projectionErr := adapter.sidecarTurnEvents(adapterSession, session, "turn-mismatch", claudeSDKSidecarEvent{
+		Type: "tool_started",
+		Payload: map[string]any{
+			"turnId":     "turn-mismatch",
+			"toolCallId": "tool-after-mismatch",
+			"toolName":   "Bash",
+			"input":      map[string]any{"command": "pwd"},
+		},
+	})
+	if projectionErr != nil || terminal || len(projected) == 0 {
+		t.Fatalf("post-mismatch projection events=%#v terminal=%v err=%v", projected, terminal, projectionErr)
 	}
 }
 
@@ -271,7 +377,6 @@ func TestClaudeSDKCancelTargetsPassesExactTurnID(t *testing.T) {
 	conn := &ackClaudeSDKConnection{}
 	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, conn)
 	adapter.beginClaudeSDKRootTurn(adapterSession, "turn-exact", "")
-	adapter.signalClaudeSDKProviderTurnAccepted(adapterSession)
 	adapter.registerClaudeSDKTurn(adapterSession, "turn-exact", nil)
 
 	result, err := adapter.CancelTargets(context.Background(), session, []CancelTarget{{
@@ -291,6 +396,31 @@ func TestClaudeSDKCancelTargetsPassesExactTurnID(t *testing.T) {
 	}
 }
 
+func TestClaudeSDKCancelTargetsReportsExactTurnAbsent(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	canceled := false
+	conn := &ackClaudeSDKConnection{cancelResult: &canceled}
+	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, conn)
+	adapter.beginClaudeSDKRootTurn(adapterSession, "turn-absent", "")
+	adapter.registerClaudeSDKTurn(adapterSession, "turn-absent", nil)
+
+	result, err := adapter.CancelTargets(context.Background(), session, []CancelTarget{{
+		AgentSessionID: session.AgentSessionID,
+		TurnID:         "turn-absent",
+	}}, "user")
+	if !errors.Is(err, ErrSessionNoActiveTurn) {
+		t.Fatalf("CancelTargets error = %v, want %v", err, ErrSessionNoActiveTurn)
+	}
+	if len(result.ConfirmedTargets) != 0 {
+		t.Fatalf("confirmed = %#v, want none", result.ConfirmedTargets)
+	}
+	if adapter.turnAlreadySettled(adapterSession, "turn-absent") {
+		t.Fatal("absent cancel permanently fenced the unconfirmed Turn")
+	}
+}
+
 // A cancel racing the turn's own settle must not fabricate a second,
 // contradicting terminal event (the stuck-view class ADR 0008 removes).
 func TestClaudeSDKCancelAfterSettleIsIdempotent(t *testing.T) {
@@ -301,7 +431,6 @@ func TestClaudeSDKCancelAfterSettleIsIdempotent(t *testing.T) {
 	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, conn)
 
 	adapter.beginClaudeSDKRootTurn(adapterSession, "turn-1", "provider-turn-1")
-	adapter.signalClaudeSDKProviderTurnAccepted(adapterSession)
 	adapter.registerClaudeSDKTurn(adapterSession, "turn-1", nil)
 	_ = adapter.dispatchClaudeSDKEvent(session.AgentSessionID, adapterSession, claudeSDKSidecarEvent{
 		Type:    "turn_completed",
@@ -874,6 +1003,477 @@ func TestClaudeSDKGoalArmTurnGatesCompletion(t *testing.T) {
 	}
 	if goal := adapter.localGoal(adapterSession); goal["status"] != "active" {
 		t.Fatalf("goal after arm turn completed = %#v", goal)
+	}
+}
+
+func TestClaudeSDKPendingGoalCancelRollsBackExactArmWithoutTurnTerminal(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, &recordingClaudeSDKConnection{})
+	var events []activityshared.Event
+	adapter.SetSessionEventSink(func(_ string, next []activityshared.Event) {
+		events = append(events, next...)
+	})
+	adapter.applyLocalGoal(adapterSession, map[string]any{
+		"objective": "ship it",
+		"status":    "active",
+	})
+	adapterSession.goalOperationID = "goal-operation-1"
+	adapterSession.goalRevision = 1
+	adapterSession.goalArmTurnID = "goal-turn-pending"
+	adapterSession.pendingGoalCommands = map[string]claudeSDKPendingGoalCommand{
+		"goal-turn-pending": {
+			identity: goalOperationIdentity{
+				operationID: "goal-operation-1",
+				revision:    1,
+			},
+			action: "set",
+		},
+	}
+	adapterSession.goalTurnBindings = map[string]claudeSDKGoalTurnBinding{
+		"goal-turn-pending": {turnID: "goal-turn-pending"},
+	}
+
+	err := adapter.dispatchClaudeSDKEvent(
+		session.AgentSessionID,
+		adapterSession,
+		claudeSDKSidecarEvent{
+			Type: "goal_command_canceled",
+			Payload: map[string]any{
+				"turnId":      "goal-turn-pending",
+				"operationId": "goal-operation-1",
+				"revision":    1,
+				"repairEpoch": 0,
+				"action":      "set",
+				"reason":      "cancel_requested",
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("goal_command_canceled: %v", err)
+	}
+	if goal := adapter.localGoal(adapterSession); len(goal) != 0 {
+		t.Fatalf("goal mirror after pending cancel = %#v, want empty", goal)
+	}
+	if adapterSession.goalArmTurnID != "" {
+		t.Fatalf("goal arm after pending cancel = %q, want empty", adapterSession.goalArmTurnID)
+	}
+	if _, ok := adapterSession.goalTurnBindings["goal-turn-pending"]; ok {
+		t.Fatal("pending Goal binding survived exact cancellation")
+	}
+	assertClaudeSDKGoalUpdateEvent(t, events, "thread_goal_cleared")
+	if terminals := activityEventsWithType(events, activityshared.EventTurnCompleted); len(terminals) != 0 {
+		t.Fatalf("pending Goal cancel fabricated a Turn terminal: %#v", terminals)
+	}
+}
+
+func TestClaudeSDKPendingGoalClearCancelRestoresPreviousMirror(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, &recordingClaudeSDKConnection{})
+	var events []activityshared.Event
+	adapter.SetSessionEventSink(func(_ string, next []activityshared.Event) {
+		events = append(events, next...)
+	})
+	previous := map[string]any{"objective": "keep shipping", "status": "active"}
+	adapterSession.goalOperationID = "goal-clear-operation"
+	adapterSession.goalRevision = 3
+	adapterSession.goalRepairEpoch = 1
+	adapterSession.goalClearControlTurns = map[string]struct{}{"goal-clear-pending": {}}
+	adapterSession.pendingGoalCommands = map[string]claudeSDKPendingGoalCommand{
+		"goal-clear-pending": {
+			identity: goalOperationIdentity{
+				operationID: "goal-clear-operation",
+				revision:    3,
+				repairEpoch: 1,
+			},
+			action:       "clear",
+			previousGoal: previous,
+		},
+	}
+
+	err := adapter.dispatchClaudeSDKEvent(
+		session.AgentSessionID,
+		adapterSession,
+		claudeSDKSidecarEvent{
+			Type: "goal_command_canceled",
+			Payload: map[string]any{
+				"turnId":      "goal-clear-pending",
+				"operationId": "goal-clear-operation",
+				"revision":    3,
+				"repairEpoch": 1,
+				"action":      "clear",
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("goal clear cancel: %v", err)
+	}
+	if goal := adapter.localGoal(adapterSession); asString(goal["objective"]) != "keep shipping" {
+		t.Fatalf("goal mirror after clear cancel = %#v, want previous", goal)
+	}
+	if _, ok := adapterSession.goalClearControlTurns["goal-clear-pending"]; ok {
+		t.Fatal("clear-control bookkeeping survived exact cancellation")
+	}
+	assertClaudeSDKGoalUpdateEvent(t, events, "thread_goal_update")
+}
+
+func TestClaudeSDKStalePendingGoalCancelDoesNotRollbackNewerIdentity(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, &recordingClaudeSDKConnection{})
+	var events []activityshared.Event
+	adapter.SetSessionEventSink(func(_ string, next []activityshared.Event) {
+		events = append(events, next...)
+	})
+	adapterSession.goalOperationID = "goal-operation-new"
+	adapterSession.goalRevision = 2
+	adapterSession.goalArmTurnID = "goal-turn-new"
+	adapterSession.pendingGoalCommands = map[string]claudeSDKPendingGoalCommand{
+		"goal-turn-old": {
+			identity: goalOperationIdentity{
+				operationID: "goal-operation-old",
+				revision:    1,
+			},
+			action: "set",
+		},
+	}
+	adapter.applyLocalGoal(adapterSession, map[string]any{
+		"objective": "new goal",
+		"status":    "active",
+	})
+
+	err := adapter.dispatchClaudeSDKEvent(
+		session.AgentSessionID,
+		adapterSession,
+		claudeSDKSidecarEvent{
+			Type: "goal_command_canceled",
+			Payload: map[string]any{
+				"turnId":      "goal-turn-old",
+				"operationId": "goal-operation-old",
+				"revision":    1,
+				"repairEpoch": 0,
+				"action":      "set",
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("stale goal cancel: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("stale goal cancel emitted updates: %#v", events)
+	}
+	if goal := adapter.localGoal(adapterSession); asString(goal["objective"]) != "new goal" {
+		t.Fatalf("stale cancel rolled back newer goal: %#v", goal)
+	}
+	if adapterSession.goalArmTurnID != "goal-turn-new" {
+		t.Fatalf("stale cancel cleared newer arm: %q", adapterSession.goalArmTurnID)
+	}
+}
+
+func TestClaudeSDKFenceCancelsPendingGoalBeforeProviderStart(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	conn := newBlockingClaudeSDKConnection()
+	defer func() { _ = conn.Close() }()
+	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, conn)
+	adapter.applyLocalGoal(adapterSession, map[string]any{
+		"objective": "previous goal",
+		"status":    "active",
+	})
+
+	applyDone := make(chan error, 1)
+	go func() {
+		_, err := adapter.ApplyGoal(context.Background(), session, GoalApplyInput{
+			Action: GoalControlSet, Objective: "new goal",
+			OperationID: "goal-operation-pending", Revision: 4, RepairEpoch: 2,
+		})
+		applyDone <- err
+	}()
+	execRequest := waitForClaudeSDKSentRequestMatching(t, conn, "exec", "/goal new goal")
+	conn.pushEvent(claudeSDKSidecarEvent{ID: execRequest.ID, Type: "ok"})
+	if err := <-applyDone; err != nil {
+		t.Fatalf("ApplyGoal: %v", err)
+	}
+	turnID := payloadString(execRequest.Payload, "turnId")
+
+	if err := adapter.FenceGoalGeneration(context.Background(), session, GoalGenerationFenceInput{
+		OperationID: "goal-operation-pending", Revision: 4, RepairEpoch: 2,
+		Reason: "superseded",
+	}); err != nil {
+		t.Fatalf("FenceGoalGeneration: %v", err)
+	}
+	cancelRequest := waitForClaudeSDKSentRequest(t, conn, "cancel")
+	if payloadString(cancelRequest.Payload, "turnId") != turnID {
+		t.Fatalf("pending Goal cancel payload = %#v, want turn %q", cancelRequest.Payload, turnID)
+	}
+	conn.pushEvent(claudeSDKSidecarEvent{
+		Type: "goal_command_canceled",
+		Payload: map[string]any{
+			"turnId":      turnID,
+			"operationId": "goal-operation-pending",
+			"revision":    4,
+			"repairEpoch": 2,
+			"action":      "set",
+			"reason":      "cancel_requested",
+		},
+	})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		goal := adapter.localGoal(adapterSession)
+		adapter.mu.Lock()
+		_, pending := adapterSession.pendingGoalCommands[turnID]
+		adapter.mu.Unlock()
+		if asString(goal["objective"]) == "previous goal" && !pending {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("pending Goal did not converge after fence: goal=%#v pending=%v", goal, pending)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	for _, request := range conn.sentRequests() {
+		if request.Type == "exec" && request.ID != execRequest.ID {
+			t.Fatalf("fenced pending Goal was dispatched again: %#v", conn.sentRequests())
+		}
+	}
+}
+
+func TestClaudeSDKTypedGoalCancellationConvergesAcrossStartBacklog(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		action           GoalControlAction
+		objective        string
+		fenceBeforeStart bool
+		observeBeforeEnd bool
+	}{
+		{name: "fenced set", action: GoalControlSet, objective: "new goal", fenceBeforeStart: true},
+		{name: "fenced clear", action: GoalControlClear, fenceBeforeStart: true},
+		{name: "started set", action: GoalControlSet, objective: "new goal"},
+		{name: "started clear", action: GoalControlClear},
+		{name: "observed set commits", action: GoalControlSet, objective: "new goal", observeBeforeEnd: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			adapter := NewClaudeCodeSDKAdapter(nil)
+			conn := newBlockingClaudeSDKConnection()
+			defer func() { _ = conn.Close() }()
+			session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, conn)
+			adapter.applyLocalGoal(adapterSession, map[string]any{
+				"objective": "previous goal",
+				"status":    "active",
+			})
+			var emitted []activityshared.Event
+			adapter.SetSessionEventSink(func(_ string, next []activityshared.Event) {
+				emitted = append(emitted, next...)
+			})
+
+			applyDone := make(chan error, 1)
+			go func() {
+				_, err := adapter.ApplyGoal(context.Background(), session, GoalApplyInput{
+					Action: test.action, Objective: test.objective,
+					OperationID: "goal-operation-backlog", Revision: 9, RepairEpoch: 2,
+				})
+				applyDone <- err
+			}()
+			command := "/goal clear"
+			if test.action == GoalControlSet {
+				command = "/goal new goal"
+			}
+			execRequest := waitForClaudeSDKSentRequestMatching(t, conn, "exec", command)
+			conn.pushEvent(claudeSDKSidecarEvent{ID: execRequest.ID, Type: "ok"})
+			if err := <-applyDone; err != nil {
+				t.Fatalf("ApplyGoal: %v", err)
+			}
+			turnID := payloadString(execRequest.Payload, "turnId")
+			providerTurnID := "provider-" + turnID
+
+			if test.fenceBeforeStart {
+				if err := adapter.FenceGoalGeneration(context.Background(), session, GoalGenerationFenceInput{
+					OperationID: "goal-operation-backlog", Revision: 9, RepairEpoch: 2,
+					Reason: "superseded",
+				}); err != nil {
+					t.Fatalf("FenceGoalGeneration: %v", err)
+				}
+				cancelRequest := waitForClaudeSDKSentRequest(t, conn, "cancel")
+				if payloadString(cancelRequest.Payload, "turnId") != turnID {
+					t.Fatalf("cancel payload = %#v, want turn %q", cancelRequest.Payload, turnID)
+				}
+			}
+
+			provenance := map[string]any{
+				"turnId": turnID, "providerTurnId": providerTurnID,
+				"sourceGoalOperationId": "goal-operation-backlog",
+				"sourceGoalRevision":    float64(9),
+				"sourceGoalRepairEpoch": float64(2),
+			}
+			if test.action == GoalControlSet {
+				provenance["turnOrigin"] = "goal_arm"
+			}
+			for _, sidecarEvent := range []claudeSDKSidecarEvent{
+				{Type: "provider_turn_identity_resolved", Payload: clonePayload(provenance)},
+				{Type: "goal_command_started", Payload: map[string]any{
+					"turnId": turnID, "providerTurnId": providerTurnID,
+					"operationId": "goal-operation-backlog", "revision": float64(9),
+					"repairEpoch": float64(2), "action": string(test.action),
+				}},
+			} {
+				if err := adapter.dispatchClaudeSDKEvent(session.AgentSessionID, adapterSession, sidecarEvent); err != nil {
+					t.Fatalf("dispatch %s: %v", sidecarEvent.Type, err)
+				}
+			}
+			if test.action == GoalControlSet {
+				turnStarted := clonePayload(provenance)
+				delete(turnStarted, "providerTurnId")
+				if err := adapter.dispatchClaudeSDKEvent(session.AgentSessionID, adapterSession, claudeSDKSidecarEvent{
+					Type: "turn_started", Payload: turnStarted,
+				}); err != nil {
+					t.Fatalf("dispatch turn_started: %v", err)
+				}
+			}
+
+			if test.observeBeforeEnd {
+				if err := adapter.dispatchClaudeSDKEvent(session.AgentSessionID, adapterSession, claudeSDKSidecarEvent{
+					Type: "goal_observed",
+					Payload: map[string]any{
+						"turnId": turnID, "providerTurnId": providerTurnID,
+						"action": "set", "source": "active_goal",
+						"updateType": "thread_goal_update",
+						"goal":       map[string]any{"objective": "new goal", "status": "active"},
+					},
+				}); err != nil {
+					t.Fatalf("dispatch goal_observed: %v", err)
+				}
+			}
+			if err := adapter.dispatchClaudeSDKEvent(session.AgentSessionID, adapterSession, claudeSDKSidecarEvent{
+				Type: "turn_canceled",
+				Payload: map[string]any{
+					"turnId": turnID, "providerTurnId": providerTurnID,
+				},
+			}); err != nil {
+				t.Fatalf("dispatch turn_canceled: %v", err)
+			}
+
+			wantObjective := "previous goal"
+			if test.observeBeforeEnd {
+				wantObjective = "new goal"
+			}
+			if goal := adapter.localGoal(adapterSession); asString(goal["objective"]) != wantObjective {
+				t.Fatalf("goal after cancellation = %#v, want objective %q", goal, wantObjective)
+			}
+			adapter.mu.Lock()
+			_, pending := adapterSession.pendingGoalCommands[turnID]
+			_, clearControl := adapterSession.goalClearControlTurns[turnID]
+			armTurnID := adapterSession.goalArmTurnID
+			fencedTurns := len(adapterSession.fencedGoalTurns)
+			bindings := len(adapterSession.goalTurnBindings)
+			adapter.mu.Unlock()
+			if pending || clearControl || armTurnID == turnID || fencedTurns != 0 || bindings != 0 {
+				t.Fatalf("Goal bookkeeping survived terminal: pending=%v clear=%v arm=%q fences=%d bindings=%d",
+					pending, clearControl, armTurnID, fencedTurns, bindings)
+			}
+			started := activityEventsWithType(emitted, activityshared.EventRootProviderTurnStarted)
+			wantStarts := 0
+			if !test.fenceBeforeStart && test.action == GoalControlSet {
+				wantStarts = 1
+			}
+			if len(started) != wantStarts {
+				t.Fatalf("canonical starts = %#v, want %d", started, wantStarts)
+			}
+		})
+	}
+}
+
+func TestClaudeSDKFencedPendingGoalConsumesLateSuperseded(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	conn := newBlockingClaudeSDKConnection()
+	defer func() { _ = conn.Close() }()
+	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, conn)
+	adapter.applyLocalGoal(adapterSession, map[string]any{
+		"objective": "previous goal",
+		"status":    "active",
+	})
+
+	applyGoal := func(input GoalApplyInput, command string) string {
+		t.Helper()
+		done := make(chan error, 1)
+		go func() {
+			_, err := adapter.ApplyGoal(context.Background(), session, input)
+			done <- err
+		}()
+		request := waitForClaudeSDKSentRequestMatching(t, conn, "exec", command)
+		conn.pushEvent(claudeSDKSidecarEvent{ID: request.ID, Type: "ok"})
+		if err := <-done; err != nil {
+			t.Fatalf("ApplyGoal %s: %v", input.Action, err)
+		}
+		return payloadString(request.Payload, "turnId")
+	}
+	oldTurnID := applyGoal(GoalApplyInput{
+		Action: GoalControlSet, Objective: "superseded goal",
+		OperationID: "goal-operation-old", Revision: 1,
+	}, "/goal superseded goal")
+	newTurnID := applyGoal(GoalApplyInput{
+		Action:      GoalControlClear,
+		OperationID: "goal-operation-new", Revision: 2,
+	}, "/goal clear")
+
+	if err := adapter.FenceGoalGeneration(context.Background(), session, GoalGenerationFenceInput{
+		OperationID: "goal-operation-old", Revision: 1, Reason: "superseded",
+	}); err != nil {
+		t.Fatalf("FenceGoalGeneration: %v", err)
+	}
+	waitForClaudeSDKSentRequest(t, conn, "cancel")
+	if err := adapter.dispatchClaudeSDKEvent(session.AgentSessionID, adapterSession, claudeSDKSidecarEvent{
+		Type: "goal_command_superseded",
+		Payload: map[string]any{
+			"turnId": oldTurnID, "operationId": "goal-operation-old",
+			"revision": float64(1), "action": "set", "supersededByRevision": float64(2),
+		},
+	}); err != nil {
+		t.Fatalf("dispatch late goal_command_superseded: %v", err)
+	}
+
+	adapter.mu.Lock()
+	_, oldPending := adapterSession.pendingGoalCommands[oldTurnID]
+	_, newPending := adapterSession.pendingGoalCommands[newTurnID]
+	fencedTurns := len(adapterSession.fencedGoalTurns)
+	bindings := len(adapterSession.goalTurnBindings)
+	aliases := len(adapterSession.rootProviderTurns)
+	adapter.mu.Unlock()
+	if oldPending || !newPending || fencedTurns != 0 || bindings != 0 || aliases != 0 {
+		t.Fatalf("late superseded cleanup: oldPending=%v newPending=%v fences=%d bindings=%d aliases=%d",
+			oldPending, newPending, fencedTurns, bindings, aliases)
+	}
+	if goal := adapter.localGoal(adapterSession); len(goal) != 0 {
+		t.Fatalf("stale superseded event rolled back newer clear mirror: %#v", goal)
+	}
+
+	countCancels := func() int {
+		count := 0
+		for _, request := range conn.sentRequests() {
+			if request.Type == "cancel" {
+				count++
+			}
+		}
+		return count
+	}
+	cancelCount := countCancels()
+	if err := adapter.FenceGoalGeneration(context.Background(), session, GoalGenerationFenceInput{
+		OperationID: "goal-operation-old", Revision: 1, Reason: "retry",
+	}); err != nil {
+		t.Fatalf("repeat FenceGoalGeneration: %v", err)
+	}
+	if nextCancelCount := countCancels(); nextCancelCount != cancelCount {
+		t.Fatalf("repeat fence sent another cancel: before=%d after=%d", cancelCount, nextCancelCount)
 	}
 }
 

--- a/packages/agent/daemon/runtime/claude_sdk_pending_goal.go
+++ b/packages/agent/daemon/runtime/claude_sdk_pending_goal.go
@@ -1,0 +1,219 @@
+package agentruntime
+
+import (
+	"strings"
+
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+)
+
+func (a *ClaudeCodeSDKAdapter) isGoalClearControlTurn(
+	adapterSession *claudeSDKAdapterSession,
+	turnID string,
+) bool {
+	if a == nil || adapterSession == nil {
+		return false
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	_, ok := adapterSession.goalClearControlTurns[strings.TrimSpace(turnID)]
+	return ok
+}
+
+func (a *ClaudeCodeSDKAdapter) forgetGoalClearControlTurn(
+	adapterSession *claudeSDKAdapterSession,
+	turnID string,
+) {
+	if a == nil || adapterSession == nil {
+		return
+	}
+	a.mu.Lock()
+	delete(adapterSession.goalClearControlTurns, strings.TrimSpace(turnID))
+	a.mu.Unlock()
+}
+
+func (a *ClaudeCodeSDKAdapter) restoreClaudeGoalArmIfCurrent(
+	adapterSession *claudeSDKAdapterSession,
+	operationID string,
+	revision int64,
+	repairEpoch int64,
+	assignedArm string,
+	previousArm string,
+) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	currentOperationID := strings.TrimSpace(adapterSession.goalOperationID)
+	operationID = strings.TrimSpace(operationID)
+	identityMatches := operationID == "" && revision == 0 ||
+		currentOperationID == operationID && adapterSession.goalRevision == revision && adapterSession.goalRepairEpoch == repairEpoch
+	if identityMatches && adapterSession.goalArmTurnID == assignedArm {
+		adapterSession.goalArmTurnID = previousArm
+	}
+}
+
+// goalEventsOnArmTurnFailed rolls back the optimistic mirror only when the
+// /goal arm command itself never completes. Ordinary terminal Turn events are
+// not Goal evidence; only normalized provider Goal observations are.
+func (a *ClaudeCodeSDKAdapter) goalEventsOnArmTurnFailed(
+	adapterSession *claudeSDKAdapterSession,
+	session Session,
+	turnID string,
+) []activityshared.Event {
+	trimmed := strings.TrimSpace(turnID)
+	a.mu.Lock()
+	goal := adapterSession.liveState.goal
+	armTurnID := adapterSession.goalArmTurnID
+	if len(goal) == 0 || asString(goal["status"]) != "active" {
+		a.mu.Unlock()
+		return nil
+	}
+	if armTurnID != "" && trimmed != armTurnID {
+		// The queued /goal set has not run yet; this settle belongs to an
+		// earlier turn and says nothing about the goal.
+		a.mu.Unlock()
+		return nil
+	}
+	if armTurnID != "" && trimmed == armTurnID {
+		adapterSession.goalArmTurnID = ""
+		adapterSession.liveState.goal = nil
+		a.mu.Unlock()
+		return a.goalMirrorEvents(session, "thread_goal_cleared")
+	}
+	a.mu.Unlock()
+	return nil
+}
+
+func (a *ClaudeCodeSDKAdapter) forgetClaudeSDKPendingGoalCommand(
+	adapterSession *claudeSDKAdapterSession,
+	turnID string,
+) {
+	if a == nil || adapterSession == nil {
+		return
+	}
+	a.mu.Lock()
+	delete(adapterSession.pendingGoalCommands, strings.TrimSpace(turnID))
+	a.mu.Unlock()
+}
+
+func (a *ClaudeCodeSDKAdapter) markClaudeSDKPendingGoalCommandStarted(
+	adapterSession *claudeSDKAdapterSession,
+	event claudeSDKSidecarEvent,
+) {
+	if a == nil || adapterSession == nil {
+		return
+	}
+	turnID := strings.TrimSpace(payloadString(event.Payload, "turnId"))
+	identity := goalOperationIdentity{
+		operationID: strings.TrimSpace(payloadString(event.Payload, "operationId")),
+		revision:    payloadInt64(event.Payload, "revision"),
+		repairEpoch: payloadInt64(event.Payload, "repairEpoch"),
+	}
+	action := strings.TrimSpace(payloadString(event.Payload, "action"))
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	pending, ok := adapterSession.pendingGoalCommands[turnID]
+	if !ok || pending.identity != identity || pending.action != action {
+		return
+	}
+	pending.started = true
+	adapterSession.pendingGoalCommands[turnID] = pending
+}
+
+// finishClaudeSDKPendingGoalCommandLocked closes the optimistic command
+// transaction for one exact sidecar Turn. A successful provider observation or
+// completion commits the mirror; cancellation/failure restores the previous
+// mirror only while this command's immutable Goal identity remains current.
+// The caller holds a.mu.
+func finishClaudeSDKPendingGoalCommandLocked(
+	adapterSession *claudeSDKAdapterSession,
+	turnID string,
+	expected *claudeSDKPendingGoalCommand,
+	rollback bool,
+	forgetClearControl bool,
+) string {
+	if adapterSession == nil {
+		return ""
+	}
+	turnID = strings.TrimSpace(turnID)
+	pending, ok := adapterSession.pendingGoalCommands[turnID]
+	if !ok || expected != nil && (pending.identity != expected.identity || pending.action != expected.action) {
+		return ""
+	}
+	delete(adapterSession.pendingGoalCommands, turnID)
+	if adapterSession.goalArmTurnID == turnID {
+		adapterSession.goalArmTurnID = ""
+	}
+	if forgetClearControl {
+		delete(adapterSession.goalClearControlTurns, turnID)
+	}
+	if !rollback {
+		return ""
+	}
+	currentIdentity := goalOperationIdentity{
+		operationID: strings.TrimSpace(adapterSession.goalOperationID),
+		revision:    adapterSession.goalRevision,
+		repairEpoch: adapterSession.goalRepairEpoch,
+	}
+	if currentIdentity != pending.identity {
+		return ""
+	}
+	adapterSession.liveState.goal = clonePayload(pending.previousGoal)
+	if len(pending.previousGoal) == 0 {
+		return "thread_goal_cleared"
+	}
+	return "thread_goal_update"
+}
+
+func (a *ClaudeCodeSDKAdapter) finishClaudeSDKPendingGoalTurn(
+	adapterSession *claudeSDKAdapterSession,
+	session Session,
+	turnID string,
+	rollback bool,
+	forgetClearControl bool,
+) []activityshared.Event {
+	if a == nil || adapterSession == nil {
+		return nil
+	}
+	a.mu.Lock()
+	updateType := finishClaudeSDKPendingGoalCommandLocked(
+		adapterSession,
+		turnID,
+		nil,
+		rollback,
+		forgetClearControl,
+	)
+	a.mu.Unlock()
+	if updateType == "" {
+		return nil
+	}
+	return a.goalMirrorEvents(session, updateType)
+}
+
+func (a *ClaudeCodeSDKAdapter) finishClaudeSDKPendingGoalCommand(
+	adapterSession *claudeSDKAdapterSession,
+	session Session,
+	event claudeSDKSidecarEvent,
+) []activityshared.Event {
+	if a == nil || adapterSession == nil {
+		return nil
+	}
+	turnID := strings.TrimSpace(payloadString(event.Payload, "turnId"))
+	identity := goalOperationIdentity{
+		operationID: strings.TrimSpace(payloadString(event.Payload, "operationId")),
+		revision:    payloadInt64(event.Payload, "revision"),
+		repairEpoch: payloadInt64(event.Payload, "repairEpoch"),
+	}
+	action := strings.TrimSpace(payloadString(event.Payload, "action"))
+	a.mu.Lock()
+	updateType := finishClaudeSDKPendingGoalCommandLocked(
+		adapterSession,
+		turnID,
+		&claudeSDKPendingGoalCommand{identity: identity, action: action},
+		true,
+		true,
+	)
+	a.mu.Unlock()
+	if updateType == "" {
+		return nil
+	}
+	return a.goalMirrorEvents(session, updateType)
+}

--- a/packages/agent/daemon/runtime/claude_sdk_protocol.go
+++ b/packages/agent/daemon/runtime/claude_sdk_protocol.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-const claudeSDKSidecarProtocolVersion = 8
+const claudeSDKSidecarProtocolVersion = 9
 
 type claudeSDKSidecarRequest struct {
 	Version int            `json:"version"`

--- a/packages/agent/daemon/runtime/claude_sdk_test_support_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_test_support_test.go
@@ -147,9 +147,14 @@ func (c *recordingClaudeSDKConnection) sentRequests() []claudeSDKSidecarRequest 
 }
 
 type ackClaudeSDKConnection struct {
-	mu     sync.Mutex
-	sent   []claudeSDKSidecarRequest
-	frames []ProcessFrame
+	mu                   sync.Mutex
+	sent                 []claudeSDKSidecarRequest
+	frames               []ProcessFrame
+	cancelResult         *bool
+	cancelDisposition    string
+	cancelProviderTurnID string
+	cancelTurnID         string
+	cancelDispatchPhase  string
 }
 
 func (c *ackClaudeSDKConnection) Send(data []byte) error {
@@ -157,7 +162,34 @@ func (c *ackClaudeSDKConnection) Send(data []byte) error {
 	if err := json.Unmarshal(data, &request); err != nil {
 		return err
 	}
-	response, err := json.Marshal(claudeSDKSidecarEvent{Version: claudeSDKSidecarProtocolVersion, ID: request.ID, Type: "ok"})
+	payload := map[string]any(nil)
+	if request.Type == "cancel" {
+		canceled := true
+		if c.cancelResult != nil {
+			canceled = *c.cancelResult
+		}
+		disposition := strings.TrimSpace(c.cancelDisposition)
+		if disposition == "" {
+			if canceled {
+				disposition = "pre_accept"
+			} else {
+				disposition = "absent"
+			}
+		}
+		turnID := firstNonEmptyString(c.cancelTurnID, payloadString(request.Payload, "turnId"))
+		dispatchPhase := strings.TrimSpace(c.cancelDispatchPhase)
+		if dispatchPhase == "" {
+			dispatchPhase = "dispatched"
+		}
+		payload = map[string]any{
+			"canceled":       canceled,
+			"disposition":    disposition,
+			"turnId":         turnID,
+			"providerTurnId": strings.TrimSpace(c.cancelProviderTurnID),
+			"dispatchPhase":  dispatchPhase,
+		}
+	}
+	response, err := json.Marshal(claudeSDKSidecarEvent{Version: claudeSDKSidecarProtocolVersion, ID: request.ID, Type: "ok", Payload: payload})
 	if err != nil {
 		return err
 	}

--- a/packages/agent/daemon/runtime/claude_sdk_transport_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_transport_test.go
@@ -578,7 +578,7 @@ func TestClaudeSDKLineReaderTracksNDJSONInputUnitsAtCompletionChunk(t *testing.T
 			RecordingID:  "recording-1",
 			ConnectionID: "connection-1",
 			ChunkSeq:     4,
-			Stdout:       []byte(`{"version":8,"type":"assistant_delta","payload":{"text":"hel`),
+			Stdout:       []byte(`{"version":9,"type":"assistant_delta","payload":{"text":"hel`),
 		},
 		{
 			RecordingID:  "recording-1",
@@ -586,7 +586,7 @@ func TestClaudeSDKLineReaderTracksNDJSONInputUnitsAtCompletionChunk(t *testing.T
 			ChunkSeq:     5,
 			Stdout: []byte(
 				`lo"}}` + "\n" +
-					`{"version":8,"type":"turn_completed","payload":{"turnId":"turn-1"}}` + "\n",
+					`{"version":9,"type":"turn_completed","payload":{"turnId":"turn-1"}}` + "\n",
 			),
 		},
 	}}

--- a/packages/agent/daemon/runtime/claude_sdk_turn_binding.go
+++ b/packages/agent/daemon/runtime/claude_sdk_turn_binding.go
@@ -3,6 +3,7 @@ package agentruntime
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
@@ -119,62 +120,96 @@ func (a *ClaudeCodeSDKAdapter) beginClaudeSDKRootTurn(
 	adapterSession.rootProviderTurns = make(map[string]struct{})
 	if providerTurnID != "" {
 		adapterSession.rootProviderTurns[providerTurnID] = struct{}{}
-	} else {
-		// A new root turn must re-arm the acceptance gate Cancel waits on.
-		adapterSession.providerTurnAccepted = make(chan struct{})
+	} else if rootTurnID != "" {
+		if adapterSession.providerAcceptanceOutcomes == nil {
+			adapterSession.providerAcceptanceOutcomes = make(map[string]*claudeSDKProviderAcceptanceOutcome)
+		}
+		adapterSession.providerAcceptanceOutcomes[rootTurnID] = &claudeSDKProviderAcceptanceOutcome{
+			done: make(chan struct{}),
+		}
+		pruneClaudeSDKProviderAcceptanceOutcomesLocked(adapterSession, rootTurnID)
 	}
 	a.mu.Unlock()
 }
 
-func (a *ClaudeCodeSDKAdapter) signalClaudeSDKProviderTurnAccepted(
+func (a *ClaudeCodeSDKAdapter) completeClaudeSDKProviderAcceptance(
 	adapterSession *claudeSDKAdapterSession,
+	turnID string,
+	acceptanceErr error,
 ) {
 	if a == nil || adapterSession == nil {
 		return
 	}
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	ch := adapterSession.providerTurnAccepted
-	if ch == nil {
+	turnID = strings.TrimSpace(turnID)
+	if turnID == "" {
 		return
 	}
+	a.mu.Lock()
+	outcome := adapterSession.providerAcceptanceOutcomes[turnID]
+	if outcome != nil {
+		outcome.once.Do(func() {
+			outcome.err = acceptanceErr
+			close(outcome.done)
+		})
+	}
+	a.mu.Unlock()
+}
+
+func (a *ClaudeCodeSDKAdapter) waitClaudeSDKProviderAcceptanceOutcome(
+	ctx context.Context,
+	adapterSession *claudeSDKAdapterSession,
+	turnID string,
+) error {
+	if a == nil || adapterSession == nil {
+		return errors.New("claude SDK provider acceptance outcome is unavailable")
+	}
+	turnID = strings.TrimSpace(turnID)
+	a.mu.Lock()
+	outcome := adapterSession.providerAcceptanceOutcomes[turnID]
+	a.mu.Unlock()
+	if outcome == nil {
+		return errors.New("claude SDK provider acceptance outcome is unavailable")
+	}
 	select {
-	case <-ch:
-	default:
-		close(ch)
+	case <-outcome.done:
+		return outcome.err
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 
-func (a *ClaudeCodeSDKAdapter) waitClaudeSDKProviderTurnAccepted(
-	ctx context.Context,
+func pruneClaudeSDKProviderAcceptanceOutcomesLocked(
 	adapterSession *claudeSDKAdapterSession,
-) error {
-	if a == nil || adapterSession == nil {
-		return nil
+	keepTurnID string,
+) {
+	if adapterSession == nil || len(adapterSession.providerAcceptanceOutcomes) <= 64 {
+		return
 	}
-	a.mu.Lock()
-	ch := adapterSession.providerTurnAccepted
-	if ch != nil {
+	for turnID, outcome := range adapterSession.providerAcceptanceOutcomes {
+		if turnID == keepTurnID || outcome == nil {
+			continue
+		}
 		select {
-		case <-ch:
-			a.mu.Unlock()
-			return nil
+		case <-outcome.done:
+			delete(adapterSession.providerAcceptanceOutcomes, turnID)
 		default:
 		}
-	} else if len(adapterSession.rootProviderTurns) > 0 {
-		// No gate armed (tests / already-bound identity): nothing to wait for.
-		a.mu.Unlock()
-		return nil
-	} else {
-		a.mu.Unlock()
-		return nil
+		if len(adapterSession.providerAcceptanceOutcomes) <= 64 {
+			return
+		}
 	}
-	a.mu.Unlock()
-	select {
-	case <-ch:
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
+	// A Session admits only one live root Turn. Any older incomplete outcome can
+	// no longer become a provider-active cancellation target once a newer root
+	// Turn begins, so keep the diagnostic cache bounded without touching the
+	// current Turn's latch.
+	for turnID := range adapterSession.providerAcceptanceOutcomes {
+		if turnID == keepTurnID {
+			continue
+		}
+		delete(adapterSession.providerAcceptanceOutcomes, turnID)
+		if len(adapterSession.providerAcceptanceOutcomes) <= 64 {
+			return
+		}
 	}
 }
 

--- a/packages/agent/daemon/runtime/errors.go
+++ b/packages/agent/daemon/runtime/errors.go
@@ -12,6 +12,7 @@ var (
 	ErrInteractiveRequestNotLive     = errors.New("interactive request is no longer live")
 	ErrInteractiveAlreadyAnswered    = errors.New("interactive request has already been answered")
 	ErrSessionNoActiveTurn           = errors.New("agent session has no active turn")
+	ErrCancelTargetMismatch          = errors.New("agent cancellation target is no longer active")
 	ErrActiveTurnTargetRequired      = errors.New("active-turn guidance requires an exact target turn")
 	ErrActiveTurnTargetMismatch      = errors.New("active-turn guidance target is no longer active")
 	ErrActiveTurnGuidanceUnsupported = errors.New("agent provider does not support active-turn guidance")

--- a/packages/agent/daemon/runtime/process_transport_cassette_test.go
+++ b/packages/agent/daemon/runtime/process_transport_cassette_test.go
@@ -728,8 +728,8 @@ func TestReplayProcessTransportIgnoresVolatileInitializeClientInfo(t *testing.T)
 func TestClaudeSidecarRecordingAndReplayProjectsEnvironmentAndGeneratedIdentities(t *testing.T) {
 	directory := t.TempDir()
 	base := &cassetteTestConnection{received: []ProcessFrame{
-		{Stdout: []byte(`{"version":8,"id":"request-recorded","type":"ok","payload":{"providerSessionId":"provider-recorded"}}` + "\n")},
-		{Stdout: []byte(`{"version":8,"id":"exec-recorded","type":"ok"}` + "\n")},
+		{Stdout: []byte(`{"version":9,"id":"request-recorded","type":"ok","payload":{"providerSessionId":"provider-recorded"}}` + "\n")},
+		{Stdout: []byte(`{"version":9,"id":"exec-recorded","type":"ok"}` + "\n")},
 	}}
 	recording, err := NewRecordingProcessTransport(
 		cassetteTestTransport{connection: base},
@@ -752,14 +752,14 @@ func TestClaudeSidecarRecordingAndReplayProjectsEnvironmentAndGeneratedIdentitie
 	if err != nil {
 		t.Fatal(err)
 	}
-	recordedStart := []byte(`{"version":8,"id":"request-recorded","type":"start","payload":{"agentSessionId":"session-recorded","providerSessionId":"provider-recorded","cwd":"/Users/recorded/project","env":{"ANTHROPIC_API_KEY":"secret-recorded","CLAUDE_CONFIG_DIR":"/Users/recorded/.claude","IS_SANDBOX":"1"}}}` + "\n")
+	recordedStart := []byte(`{"version":9,"id":"request-recorded","type":"start","payload":{"agentSessionId":"session-recorded","providerSessionId":"provider-recorded","cwd":"/Users/recorded/project","env":{"ANTHROPIC_API_KEY":"secret-recorded","CLAUDE_CONFIG_DIR":"/Users/recorded/.claude","IS_SANDBOX":"1"}}}` + "\n")
 	if err := connection.Send(recordedStart); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := connection.Recv(); err != nil {
 		t.Fatal(err)
 	}
-	recordedExec := []byte(`{"version":8,"id":"exec-recorded","type":"exec","payload":{"agentSessionId":"session-recorded","turnId":"turn-recorded","promptCorrelationId":"submit-recorded","prompt":"REPLAY_EXACT"}}` + "\n")
+	recordedExec := []byte(`{"version":9,"id":"exec-recorded","type":"exec","payload":{"agentSessionId":"session-recorded","turnId":"turn-recorded","promptCorrelationId":"submit-recorded","prompt":"REPLAY_EXACT"}}` + "\n")
 	if err := connection.Send(recordedExec); err != nil {
 		t.Fatal(err)
 	}
@@ -816,7 +816,7 @@ func TestClaudeSidecarRecordingAndReplayProjectsEnvironmentAndGeneratedIdentitie
 	if err != nil {
 		t.Fatal(err)
 	}
-	replayStart := []byte(`{"payload":{"env":{"ANTHROPIC_API_KEY":"different-secret","CLAUDE_CONFIG_DIR":"/isolated/.claude","IS_SANDBOX":"1"},"cwd":"/isolated/project","providerSessionId":"provider-replayed","agentSessionId":"session-replayed"},"type":"start","id":"request-replayed","version":8}` + "\n")
+	replayStart := []byte(`{"payload":{"env":{"ANTHROPIC_API_KEY":"different-secret","CLAUDE_CONFIG_DIR":"/isolated/.claude","IS_SANDBOX":"1"},"cwd":"/isolated/project","providerSessionId":"provider-replayed","agentSessionId":"session-replayed"},"type":"start","id":"request-replayed","version":9}` + "\n")
 	if err := replayed.Send(replayStart); err != nil {
 		t.Fatal(err)
 	}
@@ -828,7 +828,7 @@ func TestClaudeSidecarRecordingAndReplayProjectsEnvironmentAndGeneratedIdentitie
 		!bytes.Contains(frame.Stdout, []byte(`"providerSessionId":"provider-recorded"`)) {
 		t.Fatalf("mapped Claude start response = %s", frame.Stdout)
 	}
-	replayExec := []byte(`{"version":8,"id":"exec-replayed","type":"exec","payload":{"agentSessionId":"session-replayed","turnId":"turn-replayed","promptCorrelationId":"submit-replayed","prompt":"REPLAY_EXACT"}}` + "\n")
+	replayExec := []byte(`{"version":9,"id":"exec-replayed","type":"exec","payload":{"agentSessionId":"session-replayed","turnId":"turn-replayed","promptCorrelationId":"submit-replayed","prompt":"REPLAY_EXACT"}}` + "\n")
 	if err := replayed.Send(replayExec); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## 变更内容

- 将 Claude SDK sidecar 协议升级到 v9，为精确取消返回 `pre_accept`、`provider_active`、`absent` 或 `mismatch` 结构化结果，并携带规范 Turn、provider Turn 与 dispatch phase
- 对已 dispatch 的 generation 先撤销并等待 SDK interrupt/Query shutdown ACK，再发布取消 terminal；仅在 `provider_active` 时等待该 Turn 的 durable provider acceptance，其他未知或不匹配结果保持 fail-closed
- 补齐 typed Goal 在 deferred、drained、provider-started、fenced 与 superseded 交错下的 pending bookkeeping、精确清理和 optimistic mirror 回滚
- 将 fenced terminal、Goal pending transaction 和 event dispatch 拆分为独立模块，并更新架构、sidecar README 与故障排查文档

## 修复原因

房间退出或 Goal generation fence 触发取消时，旧实现可能在 provider ACK 之前发布 terminal，或在 sidecar/Go 事件投影交错下遗漏 pending Goal 清理。这会导致取消等待约 30 秒、HTTP 503、stale Goal mirror，或后续 provider 事件被错误抑制。

## 风险与影响面

- Claude Code SDK sidecar 与 Go daemon runtime 的协议同步升级；旧协议会显式拒绝，不做静默兼容
- 影响 Claude Turn cancel、房间退出、provider acceptance barrier、typed Goal set/clear/fence/supersede 路径
- 不改变其他 provider、Agent Host 公共 API 或桌面 UI

## 验证

- `pnpm check:changed`：16 lanes passed，128.9s
- pre-push `pnpm check:changed -- --push-ready`：19 lanes passed，136.1s
- `go test -race ./packages/agent/daemon/runtime -run TestClaudeSDK -count=1`
- `make dev-gui` + Computer Use 实机回归：`/goal clear` 响应 175ms；活动 Goal 下退出房间约 6.5s 完成，日志为 `room_entry.leave.succeeded`，未出现 30 秒等待、HTTP 503、`adapter_failed` 或 `room leave failed`

## 文档影响

已更新 Claude SDK runtime 架构、sidecar README 和 Agent Session 生命周期排障说明，记录协议 v9、ACK 顺序、fail-closed 规则及 pending Goal 清理语义。