### PR TITLE
fix(agent): classify sessions by rail section key

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/adapters/desktopWorkspaceSettingsClient.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/adapters/desktopWorkspaceSettingsClient.ts
@@ -52,8 +52,7 @@ interface ClearWorkspaceAgentSessionsResponse {
 export interface ListWorkspaceDeletedAgentSessionsInput {
   cursor: string | null;
   limit: number;
-  projectPath: string | null;
-  projectScope: "all" | "project" | "unscoped";
+  railSectionKey: string | null;
   search: string | null;
 }
 
@@ -396,24 +395,17 @@ export function createDesktopWorkspaceSettingsClient(input: {
         {
           cursor: query.cursor ?? undefined,
           limit: query.limit,
-          projectPath:
-            query.projectScope === "project"
-              ? (query.projectPath ?? undefined)
-              : undefined,
-          projectScope:
-            query.projectScope === "unscoped" ? "unscoped" : undefined,
+          railSectionKey: query.railSectionKey ?? undefined,
           searchQuery: query.search ?? undefined
         }
       );
-      const projectsByPath = new Map(
-        page.projectOptions.map((project) => [project.projectPath, project])
+      const projectsBySectionKey = new Map(
+        page.projectOptions.map((project) => [project.railSectionKey, project])
       );
       return {
         ...page,
         sessions: page.sessions.map((session) => {
-          const project = session.projectPath
-            ? projectsByPath.get(session.projectPath)
-            : undefined;
+          const project = projectsBySectionKey.get(session.railSectionKey);
           return {
             ...session,
             projectAvailable: project?.projectAvailable ?? false,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceDeletedConversationsController.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceDeletedConversationsController.test.ts
@@ -21,7 +21,8 @@ test("deleted conversations load in update-time order and continue from the curs
               {
                 projectAvailable: false,
                 projectLabel: "Removed project",
-                projectPath: "/projects/removed"
+                projectPath: "/projects/removed",
+                railSectionKey: "project:/projects/removed"
               }
             ],
             sessions: [
@@ -175,7 +176,7 @@ test("restore reloads a project filter started while the operation is pending", 
   >((resolve) => {
     resolveStaleFilterPage = resolve;
   });
-  const listProjectPaths: Array<string | null> = [];
+  const listRailSectionKeys: Array<string | null> = [];
   const store = createWorkspaceSettingsStore();
   store.workspaceID = "workspace-1";
   store.deletedConversations.sessions = [createConversation("session-1", 200)];
@@ -184,8 +185,8 @@ test("restore reloads a project filter started while the operation is pending", 
   const controller = new WorkspaceDeletedConversationsController({
     client: createClient({
       async listWorkspaceDeletedAgentSessions(_workspaceID, input) {
-        listProjectPaths.push(input.projectPath);
-        if (listProjectPaths.length === 1) {
+        listRailSectionKeys.push(input.railSectionKey);
+        if (listRailSectionKeys.length === 1) {
           return await staleFilterPage;
         }
         return deletedConversationPage([createConversation("session-2", 100)]);
@@ -199,7 +200,7 @@ test("restore reloads a project filter started while the operation is pending", 
   const restore = controller.restore("session-1");
   controller.selectProject({
     kind: "project",
-    projectPath: "/projects/filtered"
+    railSectionKey: "project:/projects/filtered"
   });
   finishRestore?.();
   assert.equal(await restore, true);
@@ -209,9 +210,9 @@ test("restore reloads a project filter started while the operation is pending", 
   );
   await new Promise<void>((resolve) => setImmediate(resolve));
 
-  assert.deepEqual(listProjectPaths, [
-    "/projects/filtered",
-    "/projects/filtered"
+  assert.deepEqual(listRailSectionKeys, [
+    "project:/projects/filtered",
+    "project:/projects/filtered"
   ]);
   assert.deepEqual(
     store.deletedConversations.sessions.map(
@@ -221,7 +222,7 @@ test("restore reloads a project filter started while the operation is pending", 
   );
   assert.deepEqual(store.deletedConversations.projectFilter, {
     kind: "project",
-    projectPath: "/projects/filtered"
+    railSectionKey: "project:/projects/filtered"
   });
 });
 
@@ -262,7 +263,7 @@ test("permanent delete reloads a project filter started while the operation is p
   const purge = controller.purgeOne("session-1");
   controller.selectProject({
     kind: "project",
-    projectPath: "/projects/filtered"
+    railSectionKey: "project:/projects/filtered"
   });
   finishPurge?.();
   assert.equal(await purge, true);
@@ -331,7 +332,7 @@ test("delete all ignores filters and resets the empty surface", async () => {
   store.deletedConversations.search = "matching title";
   store.deletedConversations.projectFilter = {
     kind: "project",
-    projectPath: "/projects/one"
+    railSectionKey: "project:/projects/one"
   };
   store.deletedConversations.sessions = [createConversation("session-1", 100)];
   store.deletedConversations.totalCount = 1;
@@ -370,7 +371,7 @@ test("a failed delete all reloads the current filter after fencing an in-flight 
     rejectPurge = reject;
   });
   const listInputs: Array<{
-    projectPath: string | null;
+    railSectionKey: string | null;
     search: string | null;
   }> = [];
   const messages: string[] = [];
@@ -379,7 +380,7 @@ test("a failed delete all reloads the current filter after fencing an in-flight 
   store.deletedConversations.search = "current title";
   store.deletedConversations.projectFilter = {
     kind: "project",
-    projectPath: "/projects/current"
+    railSectionKey: "project:/projects/current"
   };
   store.deletedConversations.sessions = [createConversation("session-1", 100)];
   store.deletedConversations.totalCount = 1;
@@ -388,7 +389,7 @@ test("a failed delete all reloads the current filter after fencing an in-flight 
     client: createClient({
       async listWorkspaceDeletedAgentSessions(_workspaceID, input) {
         listInputs.push({
-          projectPath: input.projectPath,
+          railSectionKey: input.railSectionKey,
           search: input.search
         });
         if (listInputs.length === 1) {
@@ -415,8 +416,14 @@ test("a failed delete all reloads the current filter after fencing an in-flight 
   await staleRefresh;
 
   assert.deepEqual(listInputs, [
-    { projectPath: "/projects/current", search: "current title" },
-    { projectPath: "/projects/current", search: "current title" }
+    {
+      railSectionKey: "project:/projects/current",
+      search: "current title"
+    },
+    {
+      railSectionKey: "project:/projects/current",
+      search: "current title"
+    }
   ]);
   assert.deepEqual(
     store.deletedConversations.sessions.map(
@@ -506,6 +513,7 @@ function createConversation(
     projectAvailable: true,
     projectLabel: "Project",
     projectPath: "/projects/project",
+    railSectionKey: "project:/projects/project",
     restorable: true,
     title: agentSessionId,
     unavailableReason: null,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceDeletedConversationsController.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceDeletedConversationsController.ts
@@ -242,8 +242,12 @@ export class WorkspaceDeletedConversationsController implements IWorkspaceDelete
           {
             cursor: append ? state.nextCursor : null,
             limit: deletedConversationPageSize,
-            projectPath: filter.kind === "project" ? filter.projectPath : null,
-            projectScope: filter.kind,
+            railSectionKey:
+              filter.kind === "project"
+                ? filter.railSectionKey
+                : filter.kind === "unscoped"
+                  ? "conversations"
+                  : null,
             search: search || null
           }
         );
@@ -415,24 +419,27 @@ function mergeProjectOptions(
     | readonly WorkspaceDeletedConversationProjectOption[]
     | readonly WorkspaceDeletedConversation[]
 ): WorkspaceDeletedConversationProjectOption[] {
-  const byPath = new Map(
-    existing.map((option) => [option.projectPath, option])
+  const bySectionKey = new Map(
+    existing.map((option) => [option.railSectionKey, option])
   );
   for (const item of incoming) {
-    if (!item.projectPath) {
+    if (!item.railSectionKey || item.railSectionKey === "conversations") {
       continue;
     }
-    byPath.set(item.projectPath, {
+    bySectionKey.set(item.railSectionKey, {
       projectAvailable: item.projectAvailable,
       projectLabel:
-        item.projectLabel?.trim() || projectBasename(item.projectPath),
-      projectPath: item.projectPath
+        item.projectLabel?.trim() ||
+        (item.projectPath ? projectBasename(item.projectPath) : null) ||
+        item.railSectionKey,
+      projectPath: item.projectPath,
+      railSectionKey: item.railSectionKey
     });
   }
-  return [...byPath.values()].sort(
+  return [...bySectionKey.values()].sort(
     (left, right) =>
       left.projectLabel.localeCompare(right.projectLabel) ||
-      left.projectPath.localeCompare(right.projectPath)
+      left.railSectionKey.localeCompare(right.railSectionKey)
   );
 }
 
@@ -452,7 +459,8 @@ function projectFiltersEqual(
   return (
     left.kind === right.kind &&
     (left.kind !== "project" ||
-      (right.kind === "project" && left.projectPath === right.projectPath))
+      (right.kind === "project" &&
+        left.railSectionKey === right.railSectionKey))
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceSettingsTypes.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceSettingsTypes.ts
@@ -32,6 +32,7 @@ export interface WorkspaceDeletedConversation {
   readonly projectAvailable: boolean;
   readonly projectLabel: string | null;
   readonly projectPath: string | null;
+  readonly railSectionKey: string;
   readonly restorable: boolean;
   readonly title: string;
   readonly unavailableReason:
@@ -44,13 +45,14 @@ export interface WorkspaceDeletedConversation {
 export interface WorkspaceDeletedConversationProjectOption {
   readonly projectAvailable: boolean;
   readonly projectLabel: string;
-  readonly projectPath: string;
+  readonly projectPath: string | null;
+  readonly railSectionKey: string;
 }
 
 export type WorkspaceDeletedConversationProjectFilter =
   | { readonly kind: "all" }
   | { readonly kind: "unscoped" }
-  | { readonly kind: "project"; readonly projectPath: string };
+  | { readonly kind: "project"; readonly railSectionKey: string };
 
 export type WorkspaceDeletedConversationOperation = "deleting" | "restoring";
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceDeletedConversationsSection.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceDeletedConversationsSection.tsx
@@ -197,8 +197,8 @@ export function WorkspaceDeletedConversationsSection({
               </SelectItem>
               {state.projectOptions.map((project) => (
                 <SelectItem
-                  key={project.projectPath}
-                  value={`project:${project.projectPath}`}
+                  key={project.railSectionKey}
+                  value={`project:${project.railSectionKey}`}
                 >
                   {project.projectAvailable
                     ? project.projectLabel
@@ -475,15 +475,19 @@ function DeletedConversationRow({
 }) {
   const { t } = useTranslation();
   const pending = operation !== undefined;
-  const projectLabel = conversation.projectPath
-    ? conversation.projectAvailable
-      ? conversation.projectLabel || projectBasename(conversation.projectPath)
-      : t("workspace.settings.deletedConversations.removedProject", {
-          project:
-            conversation.projectLabel ||
-            projectBasename(conversation.projectPath)
-        })
-    : t("workspace.settings.deletedConversations.unscoped");
+  const projectDisplayLabel =
+    conversation.projectLabel ||
+    (conversation.projectPath
+      ? projectBasename(conversation.projectPath)
+      : conversation.railSectionKey);
+  const projectLabel =
+    conversation.railSectionKey !== "conversations"
+      ? conversation.projectAvailable
+        ? projectDisplayLabel
+        : t("workspace.settings.deletedConversations.removedProject", {
+            project: projectDisplayLabel
+          })
+      : t("workspace.settings.deletedConversations.unscoped");
   const shortTime = formatConversationTime(
     conversation.updatedAtUnixMs,
     locale,
@@ -666,7 +670,7 @@ function serializeProjectFilter(
   filter: WorkspaceDeletedConversationProjectFilter
 ): string {
   return filter.kind === "project"
-    ? `project:${filter.projectPath}`
+    ? `project:${filter.railSectionKey}`
     : filter.kind;
 }
 
@@ -676,7 +680,7 @@ function deserializeProjectFilter(
   if (value === "all" || value === "unscoped") {
     return { kind: value };
   }
-  return { kind: "project", projectPath: value.slice("project:".length) };
+  return { kind: "project", railSectionKey: value.slice("project:".length) };
 }
 
 function formatConversationTime(

--- a/apps/mobile/src/services/workspaceActivityProjection.ts
+++ b/apps/mobile/src/services/workspaceActivityProjection.ts
@@ -234,16 +234,12 @@ export function projectWorkspaceActivitySnapshot({
       workspaceId
     }
   );
-  const projectBySessionId = new Map<string, UserProject>();
   const projectBySectionKey = new Map<string, UserProject>();
   for (const section of rail.sections) {
     if (section.kind !== "project" || !section.project) continue;
     const project = section.project;
-    const sectionKey = project.sectionKey?.trim() ?? section.id;
+    const sectionKey = project.sectionKey?.trim();
     if (sectionKey) projectBySectionKey.set(sectionKey, project);
-    for (const sessionId of section.sessionIds) {
-      projectBySessionId.set(sessionId, project);
-    }
   }
   for (const project of userProjects.projects) {
     const sectionKey = project.sectionKey?.trim();
@@ -257,9 +253,7 @@ export function projectWorkspaceActivitySnapshot({
     hasUnreadCompletion:
       attentionReadState.recordsBySessionId[conversation.id]?.isUnread ?? false,
     project:
-      projectBySessionId.get(conversation.id) ??
-      projectBySectionKey.get(conversation.railSectionKey?.trim() ?? "") ??
-      null
+      projectBySectionKey.get(conversation.railSectionKey?.trim() ?? "") ?? null
   }));
   const selectedRuntimeAvailability = selectEngineSessionRuntimeAvailability(
     state,

--- a/apps/mobile/src/services/workspaceActivityService.test.ts
+++ b/apps/mobile/src/services/workspaceActivityService.test.ts
@@ -116,6 +116,66 @@ describe("WorkspaceActivityService", () => {
     service.dispose();
   });
 
+  test("projects a conversation project from its rail key instead of cwd or Rail membership", async () => {
+    const expectedProject = createUserProject();
+    const wrongProject = createUserProject({
+      id: "project-2",
+      label: "wrong",
+      path: "/workspace/wrong",
+      sectionKey: "project:wrong"
+    });
+    const session = {
+      ...createSession(),
+      cwd: "/workspace/wrong/.tutti/agent/worktrees/session-1",
+      railSectionKey: expectedProject.sectionKey
+    };
+    const service = createService(
+      createClient({
+        listMessages: emptyMessagePage,
+        listSections: async () => ({
+          pinned: { hasMore: false, sessions: [], totalCount: 0 },
+          sections: [
+            {
+              hasMore: false,
+              kind: "project",
+              sectionKey: wrongProject.sectionKey,
+              sessions: [session],
+              totalCount: 1,
+              userProject: wrongProject
+            },
+            {
+              hasMore: false,
+              kind: "project",
+              sectionKey: expectedProject.sectionKey,
+              sessions: [],
+              totalCount: 0,
+              userProject: expectedProject
+            }
+          ],
+          workspaceId: workspace.id
+        }),
+        projects: [expectedProject, wrongProject],
+        session: () => session
+      })
+    );
+
+    await service.start();
+    await flushAsyncWork();
+
+    expect(
+      service
+        .getSnapshot()
+        .activityConversations.find(
+          (conversation) => conversation.id === session.id
+        )?.project
+    ).toMatchObject({
+      id: expectedProject.id,
+      sectionKey: expectedProject.sectionKey
+    });
+
+    service.dispose();
+  });
+
   test("projects processing before the active Turn receives its first message", async () => {
     const activeSession = createSession();
     activeSession.activeTurnId = "turn-1";
@@ -1895,6 +1955,7 @@ function createClient(options: {
     latestVersion: number;
     messages: WorkspaceAgentSessionMessage[];
   }>;
+  listSections?: NonNullable<TuttidClient["listWorkspaceAgentSessionSections"]>;
   projects?: Awaited<ReturnType<TuttidClient["listUserProjects"]>>["projects"];
   send?(
     workspaceId: string,
@@ -2001,42 +2062,44 @@ function createClient(options: {
         workspaceId: workspace.id
       };
     },
-    listWorkspaceAgentSessionSections: async () => {
-      const sessions = railSessions();
-      if (sessions.length === 0) {
+    listWorkspaceAgentSessionSections:
+      options.listSections ??
+      (async () => {
+        const sessions = railSessions();
+        if (sessions.length === 0) {
+          return {
+            pinned: { hasMore: false, sessions: [], totalCount: 0 },
+            sections: [],
+            workspaceId: workspace.id
+          };
+        }
+        const pinnedSessions = sessions.filter(
+          (session) => session.pinnedAtUnixMs != null
+        );
+        const conversationSessions = sessions.filter(
+          (session) => session.pinnedAtUnixMs == null
+        );
         return {
-          pinned: { hasMore: false, sessions: [], totalCount: 0 },
-          sections: [],
+          pinned: {
+            hasMore: false,
+            sessions: pinnedSessions,
+            totalCount: pinnedSessions.length
+          },
+          sections:
+            conversationSessions.length === 0
+              ? []
+              : [
+                  {
+                    hasMore: false,
+                    kind: "conversations" as const,
+                    sectionKey: "conversations",
+                    sessions: conversationSessions,
+                    totalCount: conversationSessions.length
+                  }
+                ],
           workspaceId: workspace.id
         };
-      }
-      const pinnedSessions = sessions.filter(
-        (session) => session.pinnedAtUnixMs != null
-      );
-      const conversationSessions = sessions.filter(
-        (session) => session.pinnedAtUnixMs == null
-      );
-      return {
-        pinned: {
-          hasMore: false,
-          sessions: pinnedSessions,
-          totalCount: pinnedSessions.length
-        },
-        sections:
-          conversationSessions.length === 0
-            ? []
-            : [
-                {
-                  hasMore: false,
-                  kind: "conversations" as const,
-                  sectionKey: "conversations",
-                  sessions: conversationSessions,
-                  totalCount: conversationSessions.length
-                }
-              ],
-        workspaceId: workspace.id
-      };
-    },
+      }),
     sendWorkspaceAgentSessionInput: options.send,
     submitWorkspaceAgentInteractive: options.interactive,
     updateWorkspaceAgentSessionPin: options.pin,

--- a/apps/mobile/src/services/workspaceConversationRailProjection.test.ts
+++ b/apps/mobile/src/services/workspaceConversationRailProjection.test.ts
@@ -70,6 +70,50 @@ describe("projectWorkspaceConversationRail", () => {
     expect(sections[0]?.items.map((item) => item.id)).toEqual(["new", "known"]);
   });
 
+  test("rehomes a conversation when server membership disagrees with its rail key", () => {
+    const sections = projectWorkspaceConversationRail({
+      conversations: [conversation("session-1", "project:/right", 20)],
+      loadingMoreSectionId: null,
+      memberships: [
+        membership(
+          "section:project:/wrong",
+          "project",
+          "project:/wrong",
+          ["session-1"],
+          "Wrong"
+        ),
+        membership(
+          "section:project:/right",
+          "project",
+          "project:/right",
+          [],
+          "Right"
+        )
+      ]
+    });
+
+    expect(
+      sections.map((section) => ({
+        id: section.id,
+        ids: section.items.map((item) => item.id)
+      }))
+    ).toEqual([{ id: "section:project:/right", ids: ["session-1"] }]);
+  });
+
+  test("does not classify a missing rail key as conversations", () => {
+    const sections = projectWorkspaceConversationRail({
+      conversations: [conversation("session-1", "", 20)],
+      loadingMoreSectionId: null,
+      memberships: [
+        membership("section:conversations", "conversations", "conversations", [
+          "session-1"
+        ])
+      ]
+    });
+
+    expect(sections).toEqual([]);
+  });
+
   test("deduplicates canonical navigation ids across Rail memberships", () => {
     expect(
       selectWorkspaceConversationRailSessionIds([

--- a/apps/mobile/src/services/workspaceConversationRailProjection.ts
+++ b/apps/mobile/src/services/workspaceConversationRailProjection.ts
@@ -36,7 +36,12 @@ export function projectWorkspaceConversationRail(input: {
     (membership): WorkspaceConversationRailSection => {
       const items = membership.sessionIds.flatMap((id) => {
         const conversation = conversationsById.get(id);
-        if (!conversation) return [];
+        if (
+          !conversation ||
+          !conversationMatchesRailMembership(conversation, membership)
+        ) {
+          return [];
+        }
         placedIds.add(id);
         return [conversation];
       });
@@ -64,8 +69,14 @@ export function projectWorkspaceConversationRail(input: {
       target.totalCount = Math.max(target.totalCount, target.items.length);
       continue;
     }
-    const kind = conversation.pinnedAtUnixMs ? "pinned" : "conversations";
-    const sectionKey = conversation.railSectionKey?.trim() ?? "conversations";
+    const pinned = (conversation.pinnedAtUnixMs ?? 0) > 0;
+    const sectionKey = conversation.railSectionKey?.trim() ?? "";
+    if (!pinned && !sectionKey) continue;
+    const kind = pinned
+      ? "pinned"
+      : sectionKey === "conversations"
+        ? "conversations"
+        : "project";
     sections.push({
       hasMore: false,
       id: kind === "pinned" ? "pinned" : `section:${sectionKey}`,
@@ -98,6 +109,20 @@ function findExactSection(
   if (!sectionKey) return null;
   return (
     sections.find((section) => section.id === `section:${sectionKey}`) ?? null
+  );
+}
+
+function conversationMatchesRailMembership(
+  conversation: AgentConversationRailSummary,
+  membership: WorkspaceConversationRailMembership
+): boolean {
+  const pinned = (conversation.pinnedAtUnixMs ?? 0) > 0;
+  if (membership.kind === "pinned") return pinned;
+  if (pinned) return false;
+  const railSectionKey = conversation.railSectionKey?.trim() ?? "";
+  return (
+    railSectionKey !== "" &&
+    railSectionKey === (membership.sectionKey?.trim() ?? "")
   );
 }
 

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -119,6 +119,13 @@ deletion.
 `Host.ListDeletedSessions` exposes topmost deleted Sessions in one Workspace—a
 root or child tombstone whose parent is not tombstoned—with title/project
 filtering and stable `updated_at DESC, session id ASC` cursor paging.
+Deleted-session classification and filtering use the immutable persisted
+`railSectionKey` exclusively. The read contract carries that key on every
+Session and project option; `rail_project_path` remains optional presentation
+metadata for labels and restore context and must not become a join or filter
+identity. Transport adapters may resolve an explicit legacy project-path
+filter to its canonical section key before calling Host, but must never infer a
+deleted Session's section from that path or from `cwd`.
 `Host.RestoreDeletedSession` clears the tombstone for the exact complete
 component in one transaction and deliberately does not start or resume a
 provider runtime. Tombstones created by the older lossy implementation remain

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1220,6 +1220,20 @@ their renderer and interaction layout; they must not import Desktop or Web
 components, infer project membership from `cwd`, or create a second Session
 lifecycle store.
 
+AgentGUI's existing-Session project projection uses the immutable
+`railSectionKey` as its only join key: it matches that value exactly against a
+registered user project's `sectionKey`. The `conversations` key, a missing key,
+or an unknown key fails closed to no project label even when the Session `cwd`
+equals or sits below a registered project path. Conversely, a recognized
+project key keeps its project identity when the runtime `cwd` is an isolated
+worktree or another detached execution directory. Path matching is reserved
+for resolving the user's explicit project selection before a new activation;
+it is not an existing-Session compatibility fallback.
+Native Mobile applies the same rule to Activity labels and Rail placement.
+Section `sessionIds` remain query ordering and hydration data; if their section
+disagrees with a Session's canonical `railSectionKey`, Mobile rehomes the row by
+the Session key instead of accepting the stale membership.
+
 Cross-platform hosts may also reuse the DOM-free canonical transcript
 projection from `@tutti-os/agent-gui/conversation-projection`. It accepts the
 canonical activity snapshot, selected Session id, and known Turns. The

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIControllerRefs.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIControllerRefs.ts
@@ -24,7 +24,6 @@ interface UseAgentGUIControllerRefsInput {
   homeComposerTargetOverride: AgentGUIAgentTarget | null;
   isComposerHome: boolean;
   isCreatingConversation: boolean;
-  isNoProjectPath: ((input: { path: string }) => boolean) | undefined;
   onDataChange: (
     updater: (current: AgentGUINodeData) => AgentGUINodeData
   ) => void;
@@ -49,7 +48,6 @@ export function useAgentGUIControllerRefs(
   const activeConversationIdRef = useRef(input.activeConversationId);
   const selectedProjectPathRef = useRef(input.selectedProjectPath);
   const userProjectsRef = useRef(input.userProjects);
-  const isNoProjectPathRef = useRef(input.isNoProjectPath);
   const userProjectsLoadSeqRef = useRef(0);
   const conversationsRef = useRef(input.conversations);
   const isMountedRef = useRef(true);
@@ -118,7 +116,6 @@ export function useAgentGUIControllerRefs(
   activeConversationIdRef.current = input.activeConversationId;
   selectedProjectPathRef.current = input.selectedProjectPath;
   userProjectsRef.current = input.userProjects;
-  isNoProjectPathRef.current = input.isNoProjectPath;
   conversationsRef.current = input.conversations;
   dataRef.current = input.data;
   selectedAgentTargetRef.current = input.effectiveSelectedProviderTarget;
@@ -152,7 +149,6 @@ export function useAgentGUIControllerRefs(
     isComposerHomeRef,
     isCreatingConversationRef,
     isMountedRef,
-    isNoProjectPathRef,
     lastRenderStateDiagnosticKeyRef,
     loadDraftComposerOptionsRef,
     onDataChangeRef,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationPresentation.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationPresentation.spec.tsx
@@ -28,6 +28,28 @@ describe("useAgentGUIConversationPresentation", () => {
     );
   });
 
+  it("does not infer fallback conversation project identity from workspacePath", () => {
+    const conversation = createConversation();
+    const input = createInput(conversation);
+    const rendered = renderHook(() =>
+      useAgentGUIConversationPresentation({
+        ...input,
+        conversations: [],
+        userProjects: [
+          {
+            id: "workspace-project",
+            label: "Workspace",
+            path: "/workspace",
+            pinnedAtUnixMs: 0,
+            sectionKey: "project:/workspace"
+          }
+        ]
+      })
+    );
+
+    expect(rendered.result.current.activeConversation?.project).toBeNull();
+  });
+
   it("reuses visible and active conversation references for render-equal input", () => {
     const conversation = createConversation();
     const input = createInput(conversation);

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationPresentation.ts
@@ -10,7 +10,6 @@ import type { AgentComposerDraft } from "../model/agentGuiNodeTypes";
 import { resolveAgentComposerDraftScopeKey } from "../model/agentComposerDraftScope";
 import {
   applyAgentGUIConversationProjects,
-  resolveAgentGUIConversationProject,
   type AgentGUIConversationSummary
 } from "../model/agentGuiConversationModel";
 import { isAgentGUIProviderUnresolved } from "../../../shared/agentConversationTitleProjection.ts";
@@ -41,7 +40,6 @@ interface UseAgentGUIConversationPresentationInput {
   draftByScopeKey: Record<string, AgentComposerDraft>;
   hasUnconfirmedSubmit: boolean;
   isCreatingConversation: boolean;
-  isNoProjectPath?: (input: { path: string }) => boolean;
   isSubmitting: boolean;
   normalizedExplicitProviderTargets: readonly AgentGUIAgentTarget[];
   normalizedProviderTargets: readonly AgentGUIAgentTarget[];
@@ -75,9 +73,7 @@ export function useAgentGUIConversationPresentation(
         ? { ...conversation, status: activityBusyStatus }
         : conversation;
     });
-    const next = applyAgentGUIConversationProjects(mapped, input.userProjects, {
-      isNoProjectPath: input.isNoProjectPath
-    });
+    const next = applyAgentGUIConversationProjects(mapped, input.userProjects);
     // Semantic conversations keep hidden entries so an explicitly opened
     // invisible session resolves its real identity; the rail list never
     // renders them.
@@ -90,7 +86,6 @@ export function useAgentGUIConversationPresentation(
   }, [
     input.activityDisplayStatuses,
     input.conversations,
-    input.isNoProjectPath,
     input.transientConversation,
     input.userProjects
   ]);
@@ -183,11 +178,7 @@ export function useAgentGUIConversationPresentation(
       titleFallback: "untitled-conversation",
       status: activityBusyStatus ?? fallbackStatus,
       cwd: input.workspacePath,
-      project: resolveAgentGUIConversationProject(
-        input.workspacePath,
-        input.userProjects,
-        { isNoProjectPath: input.isNoProjectPath }
-      ),
+      project: null,
       sortTimeUnixMs: fallbackUpdatedAtUnixMs,
       updatedAtUnixMs: fallbackUpdatedAtUnixMs
     });
@@ -202,11 +193,9 @@ export function useAgentGUIConversationPresentation(
     input.draftByScopeKey,
     input.hasUnconfirmedSubmit,
     input.isCreatingConversation,
-    input.isNoProjectPath,
     input.isSubmitting,
     input.normalizedProviderTargets,
     input.shouldUseStaticProviderTargets,
-    input.userProjects,
     conversationProjection.semanticConversations,
     input.workspacePath
   ]);

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.activity.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.activity.spec.tsx
@@ -111,6 +111,93 @@ describe("useAgentGUIConversationRailQuery Activity facts", () => {
     engine.dispose();
   });
 
+  it("projects Activity project identity from railSectionKey instead of cwd", async () => {
+    const engine = createTestAgentSessionEngine("workspace-1");
+    const runtime = {
+      conversationActivityViewEnabled: true,
+      getSessionEngine: () => engine
+    } as unknown as AgentGUIRuntime;
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AgentGUIRuntimeProvider runtime={runtime}>
+        {children}
+      </AgentGUIRuntimeProvider>
+    );
+    const rendered = renderHook(
+      () =>
+        useAgentGUIConversationRailQuery({
+          activeConversationId: null,
+          conversationFilter: { kind: "all" },
+          conversationQuery: "",
+          userProjects: [
+            {
+              id: "project-1",
+              label: "Workspace",
+              path: "/workspace",
+              pinnedAtUnixMs: 0,
+              sectionKey: "project:/workspace"
+            }
+          ],
+          workspaceId: "workspace-1"
+        }),
+      { wrapper }
+    );
+
+    act(() => {
+      engine.dispatch({
+        type: "session/upserted",
+        session: normalizeAgentActivitySession({
+          activeTurnId: null,
+          agentSessionId: "worktree-session",
+          cwd: "/Users/local/.tutti/agent/worktrees/worktree-session",
+          latestTurnInteractions: [],
+          pendingInteractions: [],
+          provider: "codex",
+          railSectionKey: "project:/workspace",
+          title: "Worktree session",
+          workspaceId: "workspace-1"
+        })
+      });
+    });
+
+    await waitFor(() =>
+      expect(rendered.result.current.activityConversations[0]).toEqual(
+        expect.objectContaining({
+          id: "worktree-session",
+          project: expect.objectContaining({
+            id: "project-1",
+            sectionKey: "project:/workspace"
+          })
+        })
+      )
+    );
+
+    act(() => {
+      engine.dispatch({
+        type: "session/upserted",
+        session: normalizeAgentActivitySession({
+          activeTurnId: null,
+          agentSessionId: "worktree-session",
+          cwd: "/workspace",
+          latestTurnInteractions: [],
+          pendingInteractions: [],
+          provider: "codex",
+          railSectionKey: "conversations",
+          title: "Worktree session",
+          workspaceId: "workspace-1"
+        })
+      });
+    });
+
+    await waitFor(() =>
+      expect(
+        rendered.result.current.activityConversations[0]?.project
+      ).toBeNull()
+    );
+
+    rendered.unmount();
+    engine.dispose();
+  });
+
   it("returns the shared empty Activity facts when the host capability is disabled", () => {
     const engine = createTestAgentSessionEngine("workspace-1");
     engine.dispatch({

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.ts
@@ -36,7 +36,7 @@ import {
 import { resolveAgentComposerDraftScopeKey } from "../model/agentComposerDraftScope";
 import {
   type AgentGUIConversationUserProject,
-  resolveAgentGUIConversationProject
+  resolveAgentGUISelectedUserProject
 } from "../model/agentGuiConversationProjectResolver";
 import type { AgentComposerSubmitOptions } from "../composer/AgentComposer.types";
 
@@ -91,7 +91,7 @@ export function resolveInitialRailPlacement(input: {
       sectionKey: "conversations"
     };
   }
-  const selectedProject = resolveAgentGUIConversationProject(
+  const selectedProject = resolveAgentGUISelectedUserProject(
     selectedProjectPath,
     input.userProjects
   );

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -232,7 +232,6 @@ export function useAgentGUINodeController({
     conversationListState,
     conversations
   } = conversationList;
-  const isNoProjectPath = agentHostApi.userProjects?.isNoProjectPath;
   const hasLoadedConversations = conversationListState?.initialized ?? false;
   const isLoadingConversations = conversationListState?.isLoading ?? false;
   const sessionEngineState = useAgentGUISessionEngineState({
@@ -309,7 +308,6 @@ export function useAgentGUINodeController({
     homeComposerTargetOverride,
     isComposerHome,
     isCreatingConversation,
-    isNoProjectPath,
     onDataChange,
     onRememberComposerDefaults,
     onShowMessage,
@@ -380,7 +378,6 @@ export function useAgentGUINodeController({
       }
       return {
         ...conversationSummaryFromAgentSession(session, {
-          isNoProjectPath,
           needsUserAction: activeRelatedPendingInteractions.length > 0,
           userProjects
         }),
@@ -391,7 +388,6 @@ export function useAgentGUINodeController({
       activeRelatedPendingInteractions.length,
       agentActivityDisplayStatuses,
       conversations,
-      isNoProjectPath,
       userProjects
     ]);
   // Stashes the error message from a failed first-message create so the
@@ -460,9 +456,10 @@ export function useAgentGUINodeController({
   ]);
 
   // NOTE: project metadata is intentionally NOT written back into the shared
-  // conversation store. `conversation.project` is a per-window JOIN of cwd ×
-  // userProjects; deriving it here and persisting it caused cross-window update
-  // storms. Rail membership now comes from the backend railSectionKey contract.
+  // conversation store. `conversation.project` is a per-window exact JOIN of
+  // railSectionKey × userProjects.sectionKey; deriving it here and persisting it
+  // caused cross-window update storms. Rail membership comes from the same
+  // backend railSectionKey contract.
 
   useEffect(() => {
     if (activeConversationId === null && isComposerHome) {

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.spec.ts
@@ -19,141 +19,56 @@ import {
   buildAgentGUITimelineRows,
   mergeAgentGUITimelineRows,
   selectAgentGUIConversationId,
-  resolveAgentGUIConversationProject,
+  resolveAgentGUIConversationProjectBySectionKey,
   type AgentGUIConversationUserProject
 } from "./agentGuiConversationModel";
 
 describe("agentGuiConversationModel", () => {
-  it("resolves a project for an exact cwd match", () => {
+  it("resolves a project only from an exact rail section key", () => {
     expect(
-      resolveAgentGUIConversationProject("/workspace/app", [
+      resolveAgentGUIConversationProjectBySectionKey("project:/workspace/app", [
         userProject("app", "/workspace/app", "App")
       ])
     ).toEqual({
       id: "app",
       path: "/workspace/app",
       label: "App",
+      sectionKey: "project:/workspace/app",
       pinnedAtUnixMs: 0
     });
   });
 
-  it("resolves a project when cwd is inside a project directory", () => {
-    expect(
-      resolveAgentGUIConversationProject("/workspace/app/packages/web", [
-        userProject("app", "/workspace/app", "App")
-      ])
-    ).toEqual({
-      id: "app",
-      path: "/workspace/app",
-      label: "App",
-      pinnedAtUnixMs: 0
-    });
-  });
+  it("fails closed for conversations, missing, and unknown section keys", () => {
+    const projects = [userProject("app", "/workspace/app", "App")];
 
-  it("chooses the longest project path when multiple projects match cwd", () => {
     expect(
-      resolveAgentGUIConversationProject("/workspace/app/packages/web", [
-        userProject("workspace", "/workspace", "Workspace"),
-        userProject("app", "/workspace/app", "App"),
-        userProject("web", "/workspace/app/packages/web", "Web")
-      ])
-    ).toEqual({
-      id: "web",
-      path: "/workspace/app/packages/web",
-      label: "Web",
-      pinnedAtUnixMs: 0
-    });
-  });
-
-  it("returns null when cwd does not match any project path", () => {
-    expect(
-      resolveAgentGUIConversationProject("/workspace/app-archive", [
-        userProject("app", "/workspace/app", "App")
-      ])
-    ).toBeNull();
-  });
-
-  it("does not treat a root project path as a parent project", () => {
-    expect(
-      resolveAgentGUIConversationProject("/workspace/app", [
-        userProject("root", "/", "Root")
-      ])
+      resolveAgentGUIConversationProjectBySectionKey("conversations", projects)
     ).toBeNull();
     expect(
-      resolveAgentGUIConversationProject("/", [
-        userProject("root", "/", "Root")
-      ])
-    ).toEqual({
-      id: "root",
-      path: "/",
-      label: "Root",
-      pinnedAtUnixMs: 0
-    });
-  });
-
-  it("returns null for a no-project cwd before matching parent projects", () => {
-    const noProjectPath =
-      "/Users/local/Documents/tutti/session-44444444-4444-4444-8444-444444444444";
-
+      resolveAgentGUIConversationProjectBySectionKey(undefined, projects)
+    ).toBeNull();
     expect(
-      resolveAgentGUIConversationProject(
-        noProjectPath,
-        [userProject("home", "/Users/local", "Home")],
-        {
-          isNoProjectPath: ({ path }) => path === noProjectPath
-        }
+      resolveAgentGUIConversationProjectBySectionKey(
+        "project:/workspace/missing",
+        projects
       )
     ).toBeNull();
   });
 
-  it("keeps generated-looking cwd values grouped under real parent projects without host no-project context", () => {
-    expect(
-      resolveAgentGUIConversationProject(
-        "/repo/Documents/tutti/session-44444444-4444-4444-8444-444444444444",
-        [userProject("repo", "/repo", "Repo")]
-      )
-    ).toEqual({
-      id: "repo",
-      path: "/repo",
-      label: "Repo",
-      pinnedAtUnixMs: 0
-    });
-  });
-
-  it("keeps an explicit project whose path looks like a generated no-project cwd", () => {
-    expect(
-      resolveAgentGUIConversationProject(
-        "/Users/local/Documents/tutti/session-44444444-4444-4444-8444-444444444444",
-        [
-          userProject("home", "/Users/local", "Home"),
-          userProject(
-            "odd",
-            "/Users/local/Documents/tutti/session-44444444-4444-4444-8444-444444444444",
-            "Odd project"
-          )
-        ]
-      )
-    ).toEqual({
-      id: "odd",
-      path: "/Users/local/Documents/tutti/session-44444444-4444-4444-8444-444444444444",
-      label: "Odd project",
-      pinnedAtUnixMs: 0
-    });
-  });
-
-  it("builds no-project runtime sessions without parent project assignment", () => {
-    const noProjectPath =
-      "/Users/local/Documents/tutti/session-44444444-4444-4444-8444-444444444444";
+  it("uses railSectionKey even when cwd points at a detached worktree", () => {
+    const worktreePath =
+      "/Users/local/.tutti/agent/worktrees/session-44444444-4444-4444-8444-444444444444";
     const snapshot: AgentActivitySnapshot = {
       workspaceId: "workspace-1",
       sessionMessagesById: {},
       presences: [],
       sessions: [
         workspaceAgentSession({
-          agentSessionId: "no-project-session",
-          cwd: noProjectPath,
+          agentSessionId: "worktree-session",
+          cwd: worktreePath,
           provider: "codex",
-          title: "No project",
+          railSectionKey: "project:/workspace/app",
+          title: "Project worktree",
           updatedAtUnixMs: 10
         })
       ]
@@ -161,21 +76,20 @@ describe("agentGuiConversationModel", () => {
 
     expect(
       buildAgentGUIConversationSummaries({
-        isNoProjectPath: ({ path }) => path === noProjectPath,
         snapshot,
         provider: "codex",
-        userProjects: [userProject("home", "/Users/local", "Home")]
+        userProjects: [userProject("app", "/workspace/app", "App")]
       })
     ).toEqual([
       expect.objectContaining({
-        id: "no-project-session",
-        cwd: noProjectPath,
-        project: null
+        id: "worktree-session",
+        cwd: worktreePath,
+        project: expect.objectContaining({ id: "app" })
       })
     ]);
   });
 
-  it("keeps imported home-cwd sessions unassigned when external import marks no project", () => {
+  it("does not infer a project from cwd when the rail key says conversations", () => {
     const snapshot: AgentActivitySnapshot = {
       workspaceId: "workspace-1",
       sessionMessagesById: {},
@@ -188,12 +102,12 @@ describe("agentGuiConversationModel", () => {
             pendingInteractions: []
           },
           workspaceId: "workspace-1",
-          agentSessionId: "imported-home-session",
+          agentSessionId: "conversation-session",
           provider: "codex",
-          providerSessionId: "imported-home-session",
-          cwd: "/Users/local",
-          title: "Imported scratch",
-          imported: true,
+          providerSessionId: "conversation-session",
+          cwd: "/workspace/app",
+          railSectionKey: "conversations",
+          title: "Scratch conversation",
           createdAtUnixMs: 1,
           updatedAtUnixMs: 30
         })
@@ -203,26 +117,50 @@ describe("agentGuiConversationModel", () => {
     const summaries = buildAgentGUIConversationSummaries({
       snapshot,
       provider: "codex",
-      userProjects: [userProject("home", "/Users/local", "Home")]
+      userProjects: [userProject("app", "/workspace/app", "App")]
     });
 
     expect(summaries).toEqual([
       expect.objectContaining({
-        id: "imported-home-session",
-        isImported: true,
-        project: null,
-        projectMode: "none"
+        id: "conversation-session",
+        project: null
       })
     ]);
+  });
+
+  it("trusts a project rail key for imported sessions too", () => {
+    const snapshot: AgentActivitySnapshot = {
+      workspaceId: "workspace-1",
+      sessionMessagesById: {},
+      presences: [],
+      sessions: [
+        normalizeAgentActivitySession({
+          activeTurnId: null,
+          agentSessionId: "imported-project-session",
+          cwd: "/tmp/imported-session",
+          imported: true,
+          latestTurnInteractions: [],
+          pendingInteractions: [],
+          provider: "codex",
+          providerSessionId: "imported-project-session",
+          railSectionKey: "project:/workspace/app",
+          title: "Imported project session",
+          workspaceId: "workspace-1"
+        })
+      ]
+    };
+
     expect(
-      applyAgentGUIConversationProjects(summaries, [
-        userProject("home", "/Users/local", "Home")
-      ])
+      buildAgentGUIConversationSummaries({
+        snapshot,
+        provider: "codex",
+        userProjects: [userProject("app", "/workspace/app", "App")]
+      })
     ).toEqual([
       expect.objectContaining({
-        id: "imported-home-session",
-        project: null,
-        projectMode: "none"
+        id: "imported-project-session",
+        isImported: true,
+        project: expect.objectContaining({ id: "app" })
       })
     ]);
   });
@@ -362,7 +300,7 @@ describe("agentGuiConversationModel", () => {
     });
   });
 
-  it("indexes user project paths once when building conversation batches", () => {
+  it("indexes user project section keys once when building conversation batches", () => {
     const snapshot: AgentActivitySnapshot = {
       workspaceId: "workspace-1",
       sessionMessagesById: {},
@@ -372,6 +310,7 @@ describe("agentGuiConversationModel", () => {
           agentSessionId: "one",
           cwd: "/workspace/app/packages/one",
           provider: "codex",
+          railSectionKey: "project:/workspace/app",
           title: "One",
           updatedAtUnixMs: 10
         }),
@@ -379,17 +318,19 @@ describe("agentGuiConversationModel", () => {
           agentSessionId: "two",
           cwd: "/workspace/app/packages/two",
           provider: "codex",
+          railSectionKey: "project:/workspace/app",
           title: "Two",
           updatedAtUnixMs: 20
         })
       ]
     };
-    let archivePathReads = 0;
+    let archiveSectionKeyReads = 0;
     const archiveProject: AgentGUIConversationUserProject = {
       id: "archive",
-      get path() {
-        archivePathReads += 1;
-        return "/workspace/archive";
+      path: "/workspace/archive",
+      get sectionKey() {
+        archiveSectionKeyReads += 1;
+        return "project:/workspace/archive";
       },
       label: "Archive",
       pinnedAtUnixMs: 0
@@ -408,7 +349,7 @@ describe("agentGuiConversationModel", () => {
       expect.objectContaining({ id: "app" }),
       expect.objectContaining({ id: "app" })
     ]);
-    expect(archivePathReads).toBe(1);
+    expect(archiveSectionKeyReads).toBe(1);
   });
 
   it("applies conversation projects without mutating existing conversations", () => {
@@ -418,6 +359,7 @@ describe("agentGuiConversationModel", () => {
       title: "Session",
       status: "ready" as const,
       cwd: "/workspace/app",
+      railSectionKey: "project:/workspace/app",
       project: null,
       updatedAtUnixMs: 1
     };
@@ -434,6 +376,7 @@ describe("agentGuiConversationModel", () => {
           id: "app",
           path: "/workspace/app",
           label: "App",
+          sectionKey: "project:/workspace/app",
           pinnedAtUnixMs: 0
         }
       })
@@ -1710,6 +1653,7 @@ function userProject(id: string, path: string, label: string) {
     id,
     path,
     label,
+    sectionKey: `project:${path}`,
     pinnedAtUnixMs: 0
   };
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.ts
@@ -37,8 +37,6 @@ import type { WorkspaceAgentActivityTimelineItem } from "../../../shared/workspa
 import { resolveWorkspaceAgentSessionSortTimeUnixMs } from "../../../shared/workspaceAgentSessionSortTime";
 import {
   createAgentGUIConversationProjectResolver,
-  type AgentGUIConversationNoProjectPathResolver,
-  type AgentGUIConversationProjectResolutionOptions,
   type AgentGUIConversationProjectResolver,
   type AgentGUIConversationProjectSummary,
   type AgentGUIConversationUserProject
@@ -64,10 +62,11 @@ export {
   AGENT_GUI_RUNTIME_SESSION_ORIGIN,
   resolveAgentGUIConversationSortTimeUnixMs
 } from "./agentGuiConversationTypes";
-export { resolveAgentGUIConversationProject } from "./agentGuiConversationProjectResolver";
+export {
+  resolveAgentGUIConversationProjectBySectionKey,
+  resolveAgentGUISelectedUserProject
+} from "./agentGuiConversationProjectResolver";
 export type {
-  AgentGUIConversationNoProjectPathResolver,
-  AgentGUIConversationProjectResolutionOptions,
   AgentGUIConversationProjectSummary,
   AgentGUIConversationUserProject
 } from "./agentGuiConversationProjectResolver";
@@ -85,7 +84,6 @@ export type {
 } from "./agentGuiConversationTypes";
 export function buildAgentGUIConversationSummaries({
   conversationFilter,
-  isNoProjectPath,
   snapshot,
   provider,
   sessionMessagesById,
@@ -108,10 +106,8 @@ export function buildAgentGUIConversationSummaries({
       session
     ])
   );
-  const projectResolver = createAgentGUIConversationProjectResolver(
-    userProjects,
-    { isNoProjectPath }
-  );
+  const projectResolver =
+    createAgentGUIConversationProjectResolver(userProjects);
   const conversations = buildWorkspaceAgentActivityListViewModel(
     runtimeSnapshot,
     {
@@ -319,14 +315,12 @@ export function mergeTimelineItemsByEventID(
 export function conversationSummaryFromAgentSession(
   session: CanonicalAgentSession,
   options: {
-    isNoProjectPath?: AgentGUIConversationNoProjectPathResolver;
     needsUserAction?: boolean;
     userProjects?: readonly AgentGUIConversationUserProject[];
   } = {}
 ): AgentGUIConversationSummary {
   const projectResolver = createAgentGUIConversationProjectResolver(
-    options.userProjects ?? [],
-    { isNoProjectPath: options.isNoProjectPath }
+    options.userProjects ?? []
   );
   const provider = resolveAgentGUIProviderIdentity({
     sessionProvider: session.provider
@@ -349,9 +343,6 @@ export function conversationSummaryFromAgentSession(
     isolation: session.isolation,
     railSectionKey: session.railSectionKey,
     project: resolveConversationProject(session, projectResolver),
-    ...(isExternalImportNoProjectSession(session)
-      ? { projectMode: "none" }
-      : {}),
     pinnedAtUnixMs: session.pinnedAtUnixMs ?? null,
     needsUserAction: options.needsUserAction ?? false,
     ...(session.visible === false ? { hiddenFromRail: true } : {}),
@@ -363,19 +354,15 @@ export function conversationSummaryFromAgentSession(
 
 export function applyAgentGUIConversationProjects(
   conversations: readonly AgentGUIConversationSummary[],
-  userProjects: readonly AgentGUIConversationUserProject[] = [],
-  options: AgentGUIConversationProjectResolutionOptions = {}
+  userProjects: readonly AgentGUIConversationUserProject[] = []
 ): AgentGUIConversationSummary[] {
   let changed = false;
-  const projectResolver = createAgentGUIConversationProjectResolver(
-    userProjects,
-    options
-  );
+  const projectResolver =
+    createAgentGUIConversationProjectResolver(userProjects);
   const next = conversations.map((conversation) => {
-    const project =
-      conversation.projectMode === "none"
-        ? null
-        : projectResolver.resolve(conversation.cwd);
+    const project = projectResolver.resolveSectionKey(
+      conversation.railSectionKey
+    );
     if (isSameAgentGUIConversationProject(conversation.project, project)) {
       return conversation;
     }
@@ -482,9 +469,6 @@ function conversationSummaryFromActivity(
     isolation: session?.isolation ?? null,
     ...(session ? { railSectionKey: session.railSectionKey } : {}),
     project: resolveConversationProject(session, options.projectResolver),
-    ...(isExternalImportNoProjectSession(session)
-      ? { projectMode: "none" }
-      : {}),
     pinnedAtUnixMs: session?.pinnedAtUnixMs ?? null,
     needsUserAction: rootSessionIdsAwaitingUserAction.has(activity.sessionId),
     sortTimeUnixMs: activity.sortTimeUnixMs,
@@ -498,20 +482,7 @@ function resolveConversationProject(
   session: AgentActivitySession | CanonicalAgentSession | undefined,
   projectResolver: AgentGUIConversationProjectResolver
 ): AgentGUIConversationProjectSummary | null {
-  if (isExternalImportNoProjectSession(session)) {
-    return null;
-  }
-  return projectResolver.resolve(session?.cwd);
-}
-
-function isExternalImportNoProjectSession(
-  session: AgentActivitySession | CanonicalAgentSession | undefined
-): boolean {
-  return Boolean(
-    session &&
-    "imported" in session &&
-    (session.noProject === true || session.imported === true)
-  );
+  return projectResolver.resolveSectionKey(session?.railSectionKey);
 }
 
 function isImportedWorkspaceAgentSession(

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationProjectResolver.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationProjectResolver.ts
@@ -30,63 +30,114 @@ export type AgentGUIConversationUserProject = Pick<
   | "pinnedAtUnixMs"
 >;
 
-export type AgentGUIConversationNoProjectPathResolver = (input: {
-  path: string;
-}) => boolean;
-
-export interface AgentGUIConversationProjectResolutionOptions {
-  isNoProjectPath?: AgentGUIConversationNoProjectPathResolver;
-}
-
 export interface AgentGUIConversationProjectResolver {
-  resolve: (
-    cwd: string | null | undefined
+  resolveSectionKey: (
+    railSectionKey: string | null | undefined
   ) => AgentGUIConversationProjectSummary | null;
 }
 
 export function createAgentGUIConversationProjectResolver(
-  userProjects: readonly AgentGUIConversationUserProject[] = [],
-  options: AgentGUIConversationProjectResolutionOptions = {}
+  userProjects: readonly AgentGUIConversationUserProject[] = []
 ): AgentGUIConversationProjectResolver {
-  const projectByNormalizedPath =
+  const projectBySectionKey =
     buildAgentGUIConversationProjectIndex(userProjects);
-  const resolvedByNormalizedCwd = new Map<
-    string,
-    AgentGUIConversationProjectSummary | null
-  >();
   return {
-    resolve: (cwd) => {
-      const normalizedCwd = normalizeAgentGUIProjectPath(cwd);
-      if (!normalizedCwd) {
+    resolveSectionKey: (railSectionKey) => {
+      const sectionKey = normalizeAgentGUIProjectSectionKey(railSectionKey);
+      if (!sectionKey || sectionKey === "conversations") {
         return null;
       }
-      const cached = resolvedByNormalizedCwd.get(normalizedCwd);
-      if (cached !== undefined) {
-        return cached;
-      }
-      const resolved = resolveAgentGUIConversationProjectFromIndex(
-        normalizedCwd,
-        projectByNormalizedPath,
-        options
-      );
-      resolvedByNormalizedCwd.set(normalizedCwd, resolved);
-      return resolved;
+      const project = projectBySectionKey.get(sectionKey);
+      return project
+        ? agentGUIConversationProjectSummaryFromProject(project)
+        : null;
     }
   };
 }
 
-export function resolveAgentGUIConversationProject(
-  cwd: string | null | undefined,
-  userProjects: readonly AgentGUIConversationUserProject[] = [],
-  options: AgentGUIConversationProjectResolutionOptions = {}
+export function resolveAgentGUIConversationProjectBySectionKey(
+  railSectionKey: string | null | undefined,
+  userProjects: readonly AgentGUIConversationUserProject[] = []
 ): AgentGUIConversationProjectSummary | null {
   return createAgentGUIConversationProjectResolver(
-    userProjects,
-    options
-  ).resolve(cwd);
+    userProjects
+  ).resolveSectionKey(railSectionKey);
+}
+
+export function resolveAgentGUISelectedUserProject(
+  selectedPath: string | null | undefined,
+  userProjects: readonly AgentGUIConversationUserProject[] = []
+): AgentGUIConversationProjectSummary | null {
+  const normalizedSelectedPath = normalizeAgentGUIProjectPath(selectedPath);
+  if (!normalizedSelectedPath) {
+    return null;
+  }
+  const projectByNormalizedPath =
+    buildAgentGUISelectedProjectPathIndex(userProjects);
+  const project = lookupAgentGUISelectedProject(
+    normalizedSelectedPath,
+    projectByNormalizedPath
+  );
+  return project
+    ? agentGUIConversationProjectSummaryFromProject(project)
+    : null;
 }
 
 function buildAgentGUIConversationProjectIndex(
+  userProjects: readonly AgentGUIConversationUserProject[]
+): ReadonlyMap<string, AgentGUIConversationUserProject> {
+  const projectBySectionKey = new Map<
+    string,
+    AgentGUIConversationUserProject
+  >();
+  for (const project of userProjects) {
+    const sectionKey = normalizeAgentGUIProjectSectionKey(project.sectionKey);
+    if (
+      !sectionKey ||
+      sectionKey === "conversations" ||
+      projectBySectionKey.has(sectionKey)
+    ) {
+      continue;
+    }
+    projectBySectionKey.set(sectionKey, project);
+  }
+  return projectBySectionKey;
+}
+
+function normalizeAgentGUIProjectSectionKey(
+  sectionKey: string | null | undefined
+): string {
+  return sectionKey?.trim() ?? "";
+}
+
+function agentGUIConversationProjectSummaryFromProject(
+  matchedProject: AgentGUIConversationUserProject
+): AgentGUIConversationProjectSummary {
+  const sectionKey = normalizeAgentGUIProjectSectionKey(
+    matchedProject.sectionKey
+  );
+  const summary: AgentGUIConversationProjectSummary = {
+    id: matchedProject.id,
+    path: matchedProject.path,
+    label: resolveWorkspaceUserProjectDisplayLabel(matchedProject),
+    pinnedAtUnixMs: matchedProject.pinnedAtUnixMs
+  };
+  if (sectionKey) {
+    summary.sectionKey = sectionKey;
+  }
+  if (matchedProject.createdAtUnixMs !== undefined) {
+    summary.createdAtUnixMs = matchedProject.createdAtUnixMs;
+  }
+  if (matchedProject.updatedAtUnixMs !== undefined) {
+    summary.updatedAtUnixMs = matchedProject.updatedAtUnixMs;
+  }
+  if (matchedProject.lastUsedAtUnixMs !== undefined) {
+    summary.lastUsedAtUnixMs = matchedProject.lastUsedAtUnixMs;
+  }
+  return cachedAgentGUIConversationProjectSummary(summary);
+}
+
+function buildAgentGUISelectedProjectPathIndex(
   userProjects: readonly AgentGUIConversationUserProject[]
 ): ReadonlyMap<string, AgentGUIConversationUserProject> {
   const projectByNormalizedPath = new Map<
@@ -103,57 +154,11 @@ function buildAgentGUIConversationProjectIndex(
   return projectByNormalizedPath;
 }
 
-function resolveAgentGUIConversationProjectFromIndex(
-  normalizedCwd: string,
-  projectByNormalizedPath: ReadonlyMap<string, AgentGUIConversationUserProject>,
-  options: AgentGUIConversationProjectResolutionOptions
-): AgentGUIConversationProjectSummary | null {
-  const exactProject = projectByNormalizedPath.get(normalizedCwd);
-  if (exactProject) {
-    return agentGUIConversationProjectSummaryFromProject(exactProject);
-  }
-  if (options.isNoProjectPath?.({ path: normalizedCwd })) {
-    return null;
-  }
-  const matchedProject = lookupAgentGUIConversationProject(
-    normalizedCwd,
-    projectByNormalizedPath
-  );
-  if (!matchedProject) {
-    return null;
-  }
-  return agentGUIConversationProjectSummaryFromProject(matchedProject);
-}
-
-function agentGUIConversationProjectSummaryFromProject(
-  matchedProject: AgentGUIConversationUserProject
-): AgentGUIConversationProjectSummary {
-  const summary: AgentGUIConversationProjectSummary = {
-    id: matchedProject.id,
-    path: matchedProject.path,
-    label: resolveWorkspaceUserProjectDisplayLabel(matchedProject),
-    pinnedAtUnixMs: matchedProject.pinnedAtUnixMs
-  };
-  if (matchedProject.sectionKey !== undefined) {
-    summary.sectionKey = matchedProject.sectionKey;
-  }
-  if (matchedProject.createdAtUnixMs !== undefined) {
-    summary.createdAtUnixMs = matchedProject.createdAtUnixMs;
-  }
-  if (matchedProject.updatedAtUnixMs !== undefined) {
-    summary.updatedAtUnixMs = matchedProject.updatedAtUnixMs;
-  }
-  if (matchedProject.lastUsedAtUnixMs !== undefined) {
-    summary.lastUsedAtUnixMs = matchedProject.lastUsedAtUnixMs;
-  }
-  return cachedAgentGUIConversationProjectSummary(summary);
-}
-
-function lookupAgentGUIConversationProject(
-  normalizedCwd: string,
+function lookupAgentGUISelectedProject(
+  normalizedSelectedPath: string,
   projectByNormalizedPath: ReadonlyMap<string, AgentGUIConversationUserProject>
 ): AgentGUIConversationUserProject | null {
-  let currentPath = normalizedCwd;
+  let currentPath = normalizedSelectedPath;
   while (currentPath) {
     const project = projectByNormalizedPath.get(currentPath);
     if (project) {
@@ -165,7 +170,7 @@ function lookupAgentGUIConversationProject(
     }
     currentPath = currentPath.slice(0, slashIndex);
   }
-  if (normalizedCwd === "/") {
+  if (normalizedSelectedPath === "/") {
     return projectByNormalizedPath.get("/") ?? null;
   }
   return null;

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationTypes.ts
@@ -16,7 +16,6 @@ import type {
 import { WORKSPACE_AGENT_ACTIVITY_RUNTIME_SESSION_ORIGIN } from "../../../shared/workspaceAgentSessionOrigin";
 import type { AgentGUIConversationFilter } from "./agentGuiConversationFilter";
 import type {
-  AgentGUIConversationNoProjectPathResolver,
   AgentGUIConversationProjectResolver,
   AgentGUIConversationProjectSummary,
   AgentGUIConversationUserProject
@@ -25,9 +24,8 @@ import type {
 export const AGENT_GUI_RUNTIME_SESSION_ORIGIN =
   WORKSPACE_AGENT_ACTIVITY_RUNTIME_SESSION_ORIGIN;
 export {
-  resolveAgentGUIConversationProject,
-  type AgentGUIConversationNoProjectPathResolver,
-  type AgentGUIConversationProjectResolutionOptions,
+  resolveAgentGUIConversationProjectBySectionKey,
+  resolveAgentGUISelectedUserProject,
   type AgentGUIConversationProjectSummary,
   type AgentGUIConversationUserProject
 } from "./agentGuiConversationProjectResolver";
@@ -46,7 +44,6 @@ export interface AgentGUIConversationSummary {
   isolation?: AgentActivitySession["isolation"];
   railSectionKey?: string;
   project?: AgentGUIConversationProjectSummary | null;
-  projectMode?: "none";
   pinnedAtUnixMs?: number | null;
   sortTimeUnixMs?: number;
   updatedAtUnixMs: number;
@@ -81,7 +78,6 @@ export type AgentGUIConversationProjectionSource = Pick<
   | "isolation"
   | "railSectionKey"
   | "project"
-  | "projectMode"
   | "pinnedAtUnixMs"
   | "sortTimeUnixMs"
   | "updatedAtUnixMs"
@@ -155,7 +151,6 @@ export type AgentGUIInteractivePrompt =
 
 export interface BuildAgentGUIConversationsInput {
   conversationFilter?: AgentGUIConversationFilter;
-  isNoProjectPath?: AgentGUIConversationNoProjectPathResolver;
   snapshot: AgentActivitySnapshot;
   provider: AgentGUIProvider;
   sessionMessagesById?: Record<string, AgentActivityMessage[]>;

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -390,7 +390,10 @@ Goal, observed Goal, revision, and tombstone semantics remain available after
 restore.
 `ListDeletedSessions` exposes workspace-scoped topmost tombstones—those with no
 tombstoned parent—with stable `updatedAt + sessionId` paging and explicitly
-marks legacy lossy tombstones unavailable. `RestoreDeletedSession` restores the
+marks legacy lossy tombstones unavailable. Its summaries, project-option
+catalog, and optional filter use the exact persisted `railSectionKey` as their
+identity; the retained project path is presentation metadata only.
+`RestoreDeletedSession` restores the
 exact component atomically without starting or resuming a provider.
 `PurgeDeletedSessionTrees` permanently removes selected topmost components, or
 all such components in one Workspace. The optional

--- a/packages/agent/host/deleted_sessions.go
+++ b/packages/agent/host/deleted_sessions.go
@@ -23,7 +23,7 @@ type PurgeDeletedSessionsResult struct {
 type ListDeletedSessionsInput struct {
 	WorkspaceID           string
 	SearchQuery           string
-	ProjectPath           *string
+	RailSectionKey        *string
 	CursorUpdatedAtUnixMS int64
 	CursorAgentSessionID  string
 	Limit                 int
@@ -39,7 +39,7 @@ const (
 type DeletedSessionPage struct {
 	WorkspaceID         string
 	Sessions            []DeletedSessionSummary
-	ProjectPaths        []string
+	RailSections        []storesqlite.DeletedSessionRailSection
 	TotalCount          int
 	WorkspaceTotalCount int
 	HasMore             bool
@@ -76,8 +76,16 @@ func (h *Host) ListDeletedSessions(ctx context.Context, input ListDeletedSession
 	if h == nil || h.deletedSessions == nil || workspaceID == "" {
 		return DeletedSessionPage{}, ErrInvalidArgument
 	}
+	var railSectionKey *string
+	if input.RailSectionKey != nil {
+		value := strings.TrimSpace(*input.RailSectionKey)
+		if value == "" {
+			return DeletedSessionPage{}, ErrInvalidArgument
+		}
+		railSectionKey = &value
+	}
 	page, err := h.deletedSessions.ListDeletedSessions(ctx, storesqlite.ListDeletedSessionsInput{
-		WorkspaceID: workspaceID, SearchQuery: input.SearchQuery, ProjectPath: input.ProjectPath,
+		WorkspaceID: workspaceID, SearchQuery: input.SearchQuery, RailSectionKey: railSectionKey,
 		CursorUpdatedAtUnixMS: input.CursorUpdatedAtUnixMS,
 		CursorAgentSessionID:  input.CursorAgentSessionID, Limit: input.Limit,
 	})
@@ -86,7 +94,7 @@ func (h *Host) ListDeletedSessions(ctx context.Context, input ListDeletedSession
 	}
 	return DeletedSessionPage{
 		WorkspaceID: page.WorkspaceID, Sessions: page.Sessions,
-		ProjectPaths: page.ProjectPaths, TotalCount: page.TotalCount,
+		RailSections: page.RailSections, TotalCount: page.TotalCount,
 		WorkspaceTotalCount: page.WorkspaceTotalCount,
 		HasMore:             page.HasMore, NextCursor: page.NextCursor,
 	}, nil

--- a/packages/agent/host/deleted_sessions_test.go
+++ b/packages/agent/host/deleted_sessions_test.go
@@ -33,14 +33,16 @@ func (s *deletedSessionStoreStub) PurgeDeletedSessionTrees(_ context.Context, in
 }
 
 func TestDeletedSessionHostSurfaceDelegatesWithoutStartingRuntime(t *testing.T) {
-	projectPath := ""
+	railSectionKey := storesqlite.RailSectionKeyConversations
 	store := &deletedSessionStoreStub{
 		page: storesqlite.DeletedSessionPage{
 			WorkspaceID: "workspace-1",
 			Sessions: []storesqlite.DeletedSessionSummary{{
-				AgentSessionID: "root", Restorable: true, UpdatedAtUnixMS: 30,
+				AgentSessionID: "root", RailSectionKey: railSectionKey, Restorable: true, UpdatedAtUnixMS: 30,
 			}},
-			ProjectPaths: []string{"/project"}, TotalCount: 1, WorkspaceTotalCount: 2,
+			RailSections: []storesqlite.DeletedSessionRailSection{{
+				RailSectionKey: "project:/project", ProjectPath: "/project",
+			}}, TotalCount: 1, WorkspaceTotalCount: 2,
 		},
 		restore: storesqlite.RestoreDeletedSessionResult{Restored: true, RestoredSessionIDs: []string{"root", "child"}},
 		purge: storesqlite.PurgeDeletedSessionTreesResult{
@@ -50,13 +52,13 @@ func TestDeletedSessionHostSurfaceDelegatesWithoutStartingRuntime(t *testing.T) 
 	}
 	host := New(Config{DeletedSessions: store})
 	page, err := host.ListDeletedSessions(t.Context(), ListDeletedSessionsInput{
-		WorkspaceID: " workspace-1 ", SearchQuery: "root", ProjectPath: &projectPath,
+		WorkspaceID: " workspace-1 ", SearchQuery: "root", RailSectionKey: &railSectionKey,
 		CursorUpdatedAtUnixMS: 40, CursorAgentSessionID: "cursor", Limit: 10,
 	})
 	if err != nil || len(page.Sessions) != 1 || page.TotalCount != 1 || page.WorkspaceTotalCount != 2 {
 		t.Fatalf("ListDeletedSessions()=%#v err=%v", page, err)
 	}
-	if store.listInput.WorkspaceID != "workspace-1" || store.listInput.ProjectPath == nil || *store.listInput.ProjectPath != "" {
+	if store.listInput.WorkspaceID != "workspace-1" || store.listInput.RailSectionKey == nil || *store.listInput.RailSectionKey != storesqlite.RailSectionKeyConversations {
 		t.Fatalf("list input=%#v", store.listInput)
 	}
 	restored, err := host.RestoreDeletedSession(t.Context(), RestoreDeletedSessionInput{WorkspaceID: "workspace-1", AgentSessionID: "root"})

--- a/packages/agent/store-sqlite/activity_deleted_sessions.go
+++ b/packages/agent/store-sqlite/activity_deleted_sessions.go
@@ -53,9 +53,13 @@ func (s *Store) ListDeletedSessions(ctx context.Context, input ListDeletedSessio
 )`,
 	}
 	args := []any{workspaceID}
-	if input.ProjectPath != nil {
-		predicates = append(predicates, "s.rail_project_path = ?")
-		args = append(args, strings.TrimSpace(*input.ProjectPath))
+	if input.RailSectionKey != nil {
+		railSectionKey := strings.TrimSpace(*input.RailSectionKey)
+		if railSectionKey == "" {
+			return DeletedSessionPage{}, errors.New("rail section key is required")
+		}
+		predicates = append(predicates, "s.rail_section_key = ?")
+		args = append(args, railSectionKey)
 	}
 	for _, token := range strings.Fields(strings.ToLower(input.SearchQuery)) {
 		predicates = append(predicates, "LOWER(s.title) LIKE ? ESCAPE '\\'")
@@ -80,7 +84,7 @@ WHERE s.workspace_id = ? AND s.deleted_at_unix_ms > 0
 `, workspaceID).Scan(&workspaceTotalCount); err != nil {
 		return DeletedSessionPage{}, fmt.Errorf("count all deleted workspace agent sessions: %w", err)
 	}
-	projectPaths, err := listDeletedSessionProjectPathsTx(ctx, tx, workspaceID)
+	railSections, err := listDeletedSessionRailSectionsTx(ctx, tx, workspaceID)
 	if err != nil {
 		return DeletedSessionPage{}, err
 	}
@@ -94,7 +98,7 @@ WHERE s.workspace_id = ? AND s.deleted_at_unix_ms > 0
 	}
 	pageArgs = append(pageArgs, limit+1)
 	rows, err := tx.QueryContext(ctx, `
-SELECT s.agent_session_id, s.title, s.rail_project_path,
+SELECT s.agent_session_id, s.title, s.rail_section_key, s.rail_project_path,
 	   s.updated_at_unix_ms, s.deleted_at_unix_ms, s.recoverable_delete_version,
 	   s.recoverable_delete_tree_size
 FROM workspace_agent_sessions s
@@ -118,6 +122,7 @@ LIMIT ?
 		if err := rows.Scan(
 			&row.summary.AgentSessionID,
 			&row.summary.Title,
+			&row.summary.RailSectionKey,
 			&row.summary.ProjectPath,
 			&row.summary.UpdatedAtUnixMS,
 			&row.summary.DeletedAtUnixMS,
@@ -125,6 +130,10 @@ LIMIT ?
 			&row.treeSize,
 		); err != nil {
 			return DeletedSessionPage{}, fmt.Errorf("scan deleted workspace agent session: %w", err)
+		}
+		row.summary.RailSectionKey = strings.TrimSpace(row.summary.RailSectionKey)
+		if row.summary.RailSectionKey == "" {
+			return DeletedSessionPage{}, fmt.Errorf("deleted workspace agent session %q has no rail section key", row.summary.AgentSessionID)
 		}
 		pageRows = append(pageRows, row)
 	}
@@ -154,42 +163,47 @@ LIMIT ?
 		nextCursor = strconv.FormatInt(last.UpdatedAtUnixMS, 10) + "|" + strings.TrimSpace(last.AgentSessionID)
 	}
 	return DeletedSessionPage{
-		WorkspaceID: workspaceID, Sessions: summaries, ProjectPaths: projectPaths,
+		WorkspaceID: workspaceID, Sessions: summaries, RailSections: railSections,
 		TotalCount: totalCount, WorkspaceTotalCount: workspaceTotalCount,
 		HasMore: hasMore, NextCursor: nextCursor,
 	}, nil
 }
 
-func listDeletedSessionProjectPathsTx(ctx context.Context, tx *sql.Tx, workspaceID string) ([]string, error) {
+func listDeletedSessionRailSectionsTx(ctx context.Context, tx *sql.Tx, workspaceID string) ([]DeletedSessionRailSection, error) {
 	rows, err := tx.QueryContext(ctx, `
-SELECT DISTINCT s.rail_project_path
+SELECT s.rail_section_key, MIN(NULLIF(s.rail_project_path, ''))
 FROM workspace_agent_sessions s
 WHERE s.workspace_id = ? AND s.deleted_at_unix_ms > 0
-  AND s.rail_project_path <> ''
+  AND TRIM(s.rail_section_key) <> ''
+  AND s.rail_section_key <> ?
   AND NOT EXISTS (
     SELECT 1 FROM workspace_agent_sessions parent
     WHERE parent.workspace_id = s.workspace_id
       AND parent.agent_session_id = s.parent_agent_session_id
       AND parent.deleted_at_unix_ms > 0
   )
-ORDER BY s.rail_project_path ASC
-`, workspaceID)
+GROUP BY s.rail_section_key
+ORDER BY s.rail_section_key ASC
+`, workspaceID, RailSectionKeyConversations)
 	if err != nil {
-		return nil, fmt.Errorf("list deleted workspace agent session project paths: %w", err)
+		return nil, fmt.Errorf("list deleted workspace agent session rail sections: %w", err)
 	}
 	defer rows.Close()
-	paths := make([]string, 0)
+	sections := make([]DeletedSessionRailSection, 0)
 	for rows.Next() {
-		var path string
-		if err := rows.Scan(&path); err != nil {
-			return nil, fmt.Errorf("scan deleted workspace agent session project path: %w", err)
+		var section DeletedSessionRailSection
+		var projectPath sql.NullString
+		if err := rows.Scan(&section.RailSectionKey, &projectPath); err != nil {
+			return nil, fmt.Errorf("scan deleted workspace agent session rail section: %w", err)
 		}
-		paths = append(paths, path)
+		section.RailSectionKey = strings.TrimSpace(section.RailSectionKey)
+		section.ProjectPath = strings.TrimSpace(projectPath.String)
+		sections = append(sections, section)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate deleted workspace agent session project paths: %w", err)
+		return nil, fmt.Errorf("iterate deleted workspace agent session rail sections: %w", err)
 	}
-	return paths, nil
+	return sections, nil
 }
 
 // deletedSessionRestorabilityTx returns the presentation reason and the full

--- a/packages/agent/store-sqlite/activity_deleted_sessions_test.go
+++ b/packages/agent/store-sqlite/activity_deleted_sessions_test.go
@@ -16,7 +16,7 @@ func TestRecoverableDeletePreservesGraphAndRestoresWholeTree(t *testing.T) {
 	seedChildSessionTree(t, store)
 	if _, err := store.db.ExecContext(ctx, `
 UPDATE workspace_agent_sessions
-SET title='Recover me', rail_project_path='/projects/removed', cwd='/managed/root', updated_at_unix_ms=3000
+SET title='Recover me', rail_section_key='project:/projects/removed', rail_project_path='/projects/removed', cwd='/managed/root', updated_at_unix_ms=3000
 WHERE workspace_id='ws-1' AND agent_session_id='root';
 UPDATE workspace_agent_sessions SET cwd='/managed/child-1' WHERE workspace_id='ws-1' AND agent_session_id='child-1';
 UPDATE workspace_agent_sessions SET cwd='/managed/child-2' WHERE workspace_id='ws-1' AND agent_session_id='child-2';
@@ -75,8 +75,11 @@ FROM workspace_agent_sessions WHERE workspace_id='ws-1' AND agent_session_id='ro
 	page, err := store.ListDeletedSessions(ctx, ListDeletedSessionsInput{WorkspaceID: "ws-1"})
 	if err != nil || len(page.Sessions) != 1 || !page.Sessions[0].Restorable ||
 		page.Sessions[0].Title != "Recover me" || page.Sessions[0].ProjectPath != "/projects/removed" ||
+		page.Sessions[0].RailSectionKey != "project:/projects/removed" ||
 		page.Sessions[0].UpdatedAtUnixMS != 3000 || page.TotalCount != 1 || page.WorkspaceTotalCount != 1 ||
-		!reflect.DeepEqual(page.ProjectPaths, []string{"/projects/removed"}) {
+		!reflect.DeepEqual(page.RailSections, []DeletedSessionRailSection{{
+			RailSectionKey: "project:/projects/removed", ProjectPath: "/projects/removed",
+		}}) {
 		t.Fatalf("ListDeletedSessions()=%#v err=%v", page, err)
 	}
 	resources, err := store.ListRecoverableDeletedSessionResources(ctx)
@@ -124,7 +127,7 @@ func TestRecoverableChildSubtreeIsListedAndRestoredAsTopmostDeletedComponent(t *
 	seedChildSessionTree(t, store)
 	if _, err := store.db.ExecContext(ctx, `
 UPDATE workspace_agent_sessions
-SET title='Recover child subtree', rail_project_path='/project/child'
+SET title='Recover child subtree', rail_section_key='project:/project/child', rail_project_path='/project/child'
 WHERE workspace_id='ws-1' AND agent_session_id='child-1'
 `); err != nil {
 		t.Fatal(err)
@@ -170,13 +173,13 @@ func TestDeletingLiveAncestorAbsorbsCompleteRecoverableChildComponent(t *testing
 	seedChildSessionTree(t, store)
 	if _, err := store.db.ExecContext(ctx, `
 UPDATE workspace_agent_sessions
-SET title='Root metadata', rail_project_path='/project/root', cwd='/cwd/root', updated_at_unix_ms=101
+SET title='Root metadata', rail_section_key='project:/project/root', rail_project_path='/project/root', cwd='/cwd/root', updated_at_unix_ms=101
 WHERE workspace_id='ws-1' AND agent_session_id='root';
 UPDATE workspace_agent_sessions
-SET title='Child metadata', rail_project_path='/project/child', cwd='/cwd/child', updated_at_unix_ms=202
+SET title='Child metadata', rail_section_key='project:/project/child', rail_project_path='/project/child', cwd='/cwd/child', updated_at_unix_ms=202
 WHERE workspace_id='ws-1' AND agent_session_id='child-1';
 UPDATE workspace_agent_sessions
-SET title='Leaf metadata', rail_project_path='/project/leaf', cwd='/cwd/leaf', updated_at_unix_ms=303
+SET title='Leaf metadata', rail_section_key='project:/project/leaf', rail_project_path='/project/leaf', cwd='/cwd/leaf', updated_at_unix_ms=303
 WHERE workspace_id='ws-1' AND agent_session_id='child-2';
 INSERT INTO workspace_agent_messages (
  workspace_id,agent_session_id,message_id,version,turn_id,role,kind,status,
@@ -589,7 +592,7 @@ func TestDeletedSessionListFiltersAndUsesStableUpdatedCursor(t *testing.T) {
 		if _, err := store.ReportSessionState(ctx, SessionStateReport{WorkspaceID: "ws-list", AgentSessionID: row.id, Provider: "codex", Title: row.title, OccurredAtUnixMS: row.updated}); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := store.db.ExecContext(ctx, `UPDATE workspace_agent_sessions SET rail_project_path=?,updated_at_unix_ms=? WHERE workspace_id='ws-list' AND agent_session_id=?`, row.project, row.updated, row.id); err != nil {
+		if _, err := store.db.ExecContext(ctx, `UPDATE workspace_agent_sessions SET rail_section_key=?,rail_project_path=?,updated_at_unix_ms=? WHERE workspace_id='ws-list' AND agent_session_id=?`, RailSectionKeyForProject(row.project), row.project, row.updated, row.id); err != nil {
 			t.Fatal(err)
 		}
 		if _, err := store.DeleteSession(ctx, "ws-list", row.id); err != nil {
@@ -607,10 +610,68 @@ func TestDeletedSessionListFiltersAndUsesStableUpdatedCursor(t *testing.T) {
 	if err != nil || len(second.Sessions) != 1 || second.Sessions[0].AgentSessionID != "beta" || second.HasMore {
 		t.Fatalf("second page=%#v err=%v", second, err)
 	}
-	unscoped := ""
-	filtered, err := store.ListDeletedSessions(ctx, ListDeletedSessionsInput{WorkspaceID: "ws-list", ProjectPath: &unscoped})
+	unscoped := RailSectionKeyConversations
+	filtered, err := store.ListDeletedSessions(ctx, ListDeletedSessionsInput{WorkspaceID: "ws-list", RailSectionKey: &unscoped})
 	if err != nil || len(filtered.Sessions) != 1 || filtered.Sessions[0].AgentSessionID != "beta" || filtered.TotalCount != 1 {
 		t.Fatalf("unscoped page=%#v err=%v", filtered, err)
+	}
+}
+
+func TestDeletedSessionListUsesRailSectionKeyWhenPersistedPathsDisagree(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	ctx := context.Background()
+	projectSectionKey := RailSectionKeyForProject("/project/right")
+	for _, sessionID := range []string{"project-session", "conversation-session"} {
+		if _, err := store.ReportSessionState(ctx, SessionStateReport{
+			WorkspaceID: "ws-key-authority", AgentSessionID: sessionID,
+			Provider: "codex", Title: sessionID, OccurredAtUnixMS: 100,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := store.db.ExecContext(ctx, `
+UPDATE workspace_agent_sessions
+SET rail_section_key=?, rail_project_path='/project/wrong', cwd='/project/wrong/.tutti/agent/worktrees/project-session'
+WHERE workspace_id='ws-key-authority' AND agent_session_id='project-session';
+UPDATE workspace_agent_sessions
+SET rail_section_key='conversations', rail_project_path='/project/wrong', cwd='/project/right'
+WHERE workspace_id='ws-key-authority' AND agent_session_id='conversation-session';
+`, projectSectionKey); err != nil {
+		t.Fatal(err)
+	}
+	for _, sessionID := range []string{"project-session", "conversation-session"} {
+		if _, err := store.DeleteSession(ctx, "ws-key-authority", sessionID); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	projectPage, err := store.ListDeletedSessions(ctx, ListDeletedSessionsInput{
+		WorkspaceID: "ws-key-authority", RailSectionKey: &projectSectionKey,
+	})
+	if err != nil || len(projectPage.Sessions) != 1 ||
+		projectPage.Sessions[0].AgentSessionID != "project-session" ||
+		projectPage.Sessions[0].RailSectionKey != projectSectionKey ||
+		projectPage.Sessions[0].ProjectPath != "/project/wrong" ||
+		!reflect.DeepEqual(projectPage.RailSections, []DeletedSessionRailSection{{
+			RailSectionKey: projectSectionKey, ProjectPath: "/project/wrong",
+		}}) {
+		t.Fatalf("project page=%#v error=%v", projectPage, err)
+	}
+	wrongPathKey := RailSectionKeyForProject("/project/wrong")
+	wrongPathPage, err := store.ListDeletedSessions(ctx, ListDeletedSessionsInput{
+		WorkspaceID: "ws-key-authority", RailSectionKey: &wrongPathKey,
+	})
+	if err != nil || len(wrongPathPage.Sessions) != 0 {
+		t.Fatalf("wrong-path page=%#v error=%v", wrongPathPage, err)
+	}
+	conversations := RailSectionKeyConversations
+	conversationPage, err := store.ListDeletedSessions(ctx, ListDeletedSessionsInput{
+		WorkspaceID: "ws-key-authority", RailSectionKey: &conversations,
+	})
+	if err != nil || len(conversationPage.Sessions) != 1 ||
+		conversationPage.Sessions[0].AgentSessionID != "conversation-session" {
+		t.Fatalf("conversation page=%#v error=%v", conversationPage, err)
 	}
 }
 

--- a/packages/agent/store-sqlite/repository.go
+++ b/packages/agent/store-sqlite/repository.go
@@ -128,13 +128,13 @@ const (
 
 // ListDeletedSessionsInput selects topmost tombstones in one workspace. A
 // topmost tombstone has no tombstoned parent, so it may anchor either a root
-// tree or a deleted child subtree. A nil ProjectPath means all project scopes,
-// a pointer to an empty string selects unscoped conversations, and a non-empty
-// value selects that exact original project path.
+// tree or a deleted child subtree. A nil RailSectionKey means every section;
+// a non-nil value selects that exact persisted rail section key, including the
+// fixed conversations key.
 type ListDeletedSessionsInput struct {
 	WorkspaceID           string
 	SearchQuery           string
-	ProjectPath           *string
+	RailSectionKey        *string
 	CursorUpdatedAtUnixMS int64
 	CursorAgentSessionID  string
 	Limit                 int
@@ -143,6 +143,7 @@ type ListDeletedSessionsInput struct {
 type DeletedSessionSummary struct {
 	AgentSessionID    string
 	Title             string
+	RailSectionKey    string
 	ProjectPath       string
 	UpdatedAtUnixMS   int64
 	DeletedAtUnixMS   int64
@@ -150,10 +151,15 @@ type DeletedSessionSummary struct {
 	UnavailableReason string
 }
 
+type DeletedSessionRailSection struct {
+	RailSectionKey string
+	ProjectPath    string
+}
+
 type DeletedSessionPage struct {
 	WorkspaceID         string
 	Sessions            []DeletedSessionSummary
-	ProjectPaths        []string
+	RailSections        []DeletedSessionRailSection
 	TotalCount          int
 	WorkspaceTotalCount int
 	HasMore             bool

--- a/packages/clients/tuttid-ts/src/generated/sdk.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/sdk.gen.ts
@@ -5506,7 +5506,9 @@ export const installConnectorMarketConnector = <
   });
 
 /**
- * Uninstall one connector
+ * Uninstall one connector from this device
+ *
+ * Deactivates local runtime routes and removes the installed release and optional CLI. Account authorization is not disconnected and can be reused after reinstalling or from another device.
  */
 export const uninstallConnectorMarketConnector = <
   ThrowOnError extends boolean = false

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -413,7 +413,11 @@ export type WorkspaceDeletedAgentSession = {
    */
   title: string;
   /**
-   * Persisted original project path; null means the conversations section.
+   * Immutable persisted rail section identity used for classification.
+   */
+  railSectionKey: string;
+  /**
+   * Persisted project path retained as presentation metadata. Classification is determined only by railSectionKey.
    */
   projectPath: string | null;
   /**
@@ -432,7 +436,14 @@ export type WorkspaceDeletedAgentSession = {
 };
 
 export type WorkspaceDeletedAgentSessionProjectOption = {
-  projectPath: string;
+  /**
+   * Exact persisted rail section identity represented by this option.
+   */
+  railSectionKey: string;
+  /**
+   * Persisted project path retained as presentation metadata; it is not the option identity.
+   */
+  projectPath: string | null;
   projectLabel: string;
   /**
    * Whether the original project is still registered in the current project catalog.
@@ -10737,11 +10748,19 @@ export type ListWorkspaceDeletedAgentSessionsData = {
      */
     searchQuery?: string;
     /**
-     * Select sessions without an original project. Mutually exclusive with projectPath; omit both project filters to list every location.
+     * Select sessions by their exact persisted rail section key. Mutually exclusive with the deprecated project filters; omit every section filter to list all locations.
+     */
+    railSectionKey?: string;
+    /**
+     * Deprecated explicit conversations-section selector. It is resolved to the fixed conversations rail section key and is mutually exclusive with railSectionKey and projectPath.
+     *
+     * @deprecated
      */
     projectScope?: "unscoped";
     /**
-     * Select sessions by their persisted original project path. Mutually exclusive with projectScope.
+     * Deprecated explicit project selector. The path is resolved to its canonical rail section key before querying and is mutually exclusive with railSectionKey and projectScope.
+     *
+     * @deprecated
      */
     projectPath?: string;
     /**

--- a/packages/clients/tuttid-ts/src/index.test.ts
+++ b/packages/clients/tuttid-ts/src/index.test.ts
@@ -108,6 +108,7 @@ test("shared tuttid client manages workspace deleted Agent sessions", async () =
       {
         agentSessionId: "session-1",
         title: "Deleted session",
+        railSectionKey: "project:/projects/tutti",
         projectPath: "/projects/tutti",
         updatedAtUnixMs: 20,
         deletedAtUnixMs: 30,
@@ -117,6 +118,7 @@ test("shared tuttid client manages workspace deleted Agent sessions", async () =
     ],
     projectOptions: [
       {
+        railSectionKey: "project:/projects/tutti",
         projectPath: "/projects/tutti",
         projectLabel: "tutti",
         projectAvailable: true
@@ -146,7 +148,7 @@ test("shared tuttid client manages workspace deleted Agent sessions", async () =
       {
         cursor: "opaque-cursor",
         limit: 25,
-        projectPath: "/projects/tutti",
+        railSectionKey: "project:/projects/tutti",
         searchQuery: "deleted"
       },
       { signal: controller.signal }
@@ -177,7 +179,7 @@ test("shared tuttid client manages workspace deleted Agent sessions", async () =
     query: {
       cursor: "opaque-cursor",
       limit: "25",
-      projectPath: "/projects/tutti",
+      railSectionKey: "project:/projects/tutti",
       searchQuery: "deleted"
     }
   });

--- a/packages/clients/tuttid-ts/src/tuttidClientTypes.ts
+++ b/packages/clients/tuttid-ts/src/tuttidClientTypes.ts
@@ -462,6 +462,7 @@ export interface TuttidClient
       limit?: number;
       projectPath?: string;
       projectScope?: "unscoped";
+      railSectionKey?: string;
       searchQuery?: string;
     },
     requestOptions?: TuttidRequestOptions

--- a/services/tuttid/api/daemon_agent_deleted_sessions.go
+++ b/services/tuttid/api/daemon_agent_deleted_sessions.go
@@ -8,6 +8,7 @@ import (
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	tuttigenerated "github.com/tutti-os/tutti/services/tuttid/api/generated"
 	"github.com/tutti-os/tutti/services/tuttid/apierrors"
+	userprojectbiz "github.com/tutti-os/tutti/services/tuttid/biz/userproject"
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
 	agentmaintenance "github.com/tutti-os/tutti/services/tuttid/service/agentmaintenance"
 )
@@ -28,19 +29,34 @@ func (api DaemonAPI) ListWorkspaceDeletedAgentSessions(
 		}, nil
 	}
 	input := agentservice.ListDeletedSessionsInput{}
-	if request.Params.ProjectScope != nil {
-		if !request.Params.ProjectScope.Valid() || request.Params.ProjectPath != nil {
+	sectionFilterCount := 0
+	if request.Params.RailSectionKey != nil {
+		sectionFilterCount++
+		railSectionKey := strings.TrimSpace(*request.Params.RailSectionKey)
+		if railSectionKey == "" {
 			return writeListWorkspaceDeletedAgentSessionsError(agentservice.ErrInvalidArgument), nil
 		}
-		unscoped := ""
-		input.ProjectPath = &unscoped
+		input.RailSectionKey = &railSectionKey
+	}
+	if request.Params.ProjectScope != nil {
+		sectionFilterCount++
+		if !request.Params.ProjectScope.Valid() {
+			return writeListWorkspaceDeletedAgentSessionsError(agentservice.ErrInvalidArgument), nil
+		}
+		conversations := "conversations"
+		input.RailSectionKey = &conversations
 	}
 	if request.Params.ProjectPath != nil {
+		sectionFilterCount++
 		projectPath := strings.TrimSpace(*request.Params.ProjectPath)
 		if projectPath == "" {
 			return writeListWorkspaceDeletedAgentSessionsError(agentservice.ErrInvalidArgument), nil
 		}
-		input.ProjectPath = &projectPath
+		railSectionKey := userprojectbiz.SectionKeyFromPath(projectPath)
+		input.RailSectionKey = &railSectionKey
+	}
+	if sectionFilterCount > 1 {
+		return writeListWorkspaceDeletedAgentSessionsError(agentservice.ErrInvalidArgument), nil
 	}
 	if request.Params.SearchQuery != nil {
 		input.SearchQuery = strings.TrimSpace(*request.Params.SearchQuery)
@@ -76,6 +92,7 @@ func (api DaemonAPI) ListWorkspaceDeletedAgentSessions(
 		sessions = append(sessions, tuttigenerated.WorkspaceDeletedAgentSession{
 			AgentSessionId:    strings.TrimSpace(session.AgentSessionID),
 			Title:             session.Title,
+			RailSectionKey:    strings.TrimSpace(session.RailSectionKey),
 			ProjectPath:       projectPath,
 			UpdatedAtUnixMs:   session.UpdatedAtUnixMS,
 			DeletedAtUnixMs:   session.DeletedAtUnixMS,
@@ -85,8 +102,13 @@ func (api DaemonAPI) ListWorkspaceDeletedAgentSessions(
 	}
 	projectOptions := make([]tuttigenerated.WorkspaceDeletedAgentSessionProjectOption, 0, len(page.ProjectOptions))
 	for _, option := range page.ProjectOptions {
+		var projectPath *string
+		if value := strings.TrimSpace(option.ProjectPath); value != "" {
+			projectPath = &value
+		}
 		projectOptions = append(projectOptions, tuttigenerated.WorkspaceDeletedAgentSessionProjectOption{
-			ProjectPath:      option.ProjectPath,
+			RailSectionKey:   strings.TrimSpace(option.RailSectionKey),
+			ProjectPath:      projectPath,
 			ProjectLabel:     option.ProjectLabel,
 			ProjectAvailable: option.ProjectAvailable,
 		})

--- a/services/tuttid/api/daemon_agent_deleted_sessions_test.go
+++ b/services/tuttid/api/daemon_agent_deleted_sessions_test.go
@@ -47,16 +47,18 @@ func TestDaemonAPIListsWorkspaceDeletedAgentSessions(t *testing.T) {
 				if workspaceID != "ws-1" || input.SearchQuery != "hello" || input.Cursor != "20|session-0" || input.Limit != 25 {
 					t.Fatalf("workspace/input = %q/%#v", workspaceID, input)
 				}
-				if input.ProjectPath == nil || *input.ProjectPath != "" {
-					t.Fatalf("project path = %#v, want explicit unscoped", input.ProjectPath)
+				if input.RailSectionKey == nil || *input.RailSectionKey != "conversations" {
+					t.Fatalf("rail section key = %#v, want conversations", input.RailSectionKey)
 				}
 				return agentservice.DeletedSessionPage{
 					Sessions: []agentservice.DeletedSessionSummary{{
 						AgentSessionID: "session-1", Title: "Hello", UpdatedAtUnixMS: 20,
+						RailSectionKey:  "conversations",
 						DeletedAtUnixMS: 30, Restorable: false, UnavailableReason: "legacyDataUnavailable",
 					}},
 					ProjectOptions: []agentservice.DeletedSessionProjectOption{{
-						ProjectPath: "/projects/tutti", ProjectLabel: "tutti", ProjectAvailable: false,
+						RailSectionKey: "project:/projects/tutti", ProjectPath: "/projects/tutti",
+						ProjectLabel: "tutti", ProjectAvailable: false,
 					}},
 					TotalCount: 1, WorkspaceTotalCount: 3, HasMore: true, NextCursor: "10|session-2",
 				}, nil
@@ -68,7 +70,7 @@ func TestDaemonAPIListsWorkspaceDeletedAgentSessions(t *testing.T) {
 		t,
 		mux,
 		http.MethodGet,
-		"/v1/workspaces/ws-1/deleted-agent-sessions?searchQuery=hello&projectScope=unscoped&cursor=20%7Csession-0&limit=25",
+		"/v1/workspaces/ws-1/deleted-agent-sessions?searchQuery=hello&railSectionKey=conversations&cursor=20%7Csession-0&limit=25",
 		nil,
 	)
 	if recorder.Code != http.StatusOK {
@@ -76,13 +78,13 @@ func TestDaemonAPIListsWorkspaceDeletedAgentSessions(t *testing.T) {
 	}
 	var response tuttigenerated.WorkspaceDeletedAgentSessionListResponse
 	decodeGeneratedRouteResponse(t, recorder, &response)
-	if len(response.Sessions) != 1 || response.Sessions[0].ProjectPath != nil || response.Sessions[0].UnavailableReason == nil {
+	if len(response.Sessions) != 1 || response.Sessions[0].RailSectionKey != "conversations" || response.Sessions[0].ProjectPath != nil || response.Sessions[0].UnavailableReason == nil {
 		t.Fatalf("sessions = %#v", response.Sessions)
 	}
 	if response.TotalCount != 1 || response.WorkspaceTotalCount != 3 || !response.HasMore || response.NextCursor == nil {
 		t.Fatalf("page = %#v", response)
 	}
-	if len(response.ProjectOptions) != 1 || response.ProjectOptions[0].ProjectAvailable {
+	if len(response.ProjectOptions) != 1 || response.ProjectOptions[0].RailSectionKey != "project:/projects/tutti" || response.ProjectOptions[0].ProjectAvailable {
 		t.Fatalf("project options = %#v", response.ProjectOptions)
 	}
 }
@@ -96,7 +98,7 @@ func TestDaemonAPIRejectsAmbiguousDeletedSessionProjectFilter(t *testing.T) {
 		t,
 		mux,
 		http.MethodGet,
-		"/v1/workspaces/ws-1/deleted-agent-sessions?projectScope=unscoped&projectPath=%2Fprojects%2Ftutti",
+		"/v1/workspaces/ws-1/deleted-agent-sessions?railSectionKey=conversations&projectPath=%2Fprojects%2Ftutti",
 		nil,
 	)
 	if recorder.Code != http.StatusBadRequest {

--- a/services/tuttid/api/generated/server.gen.go
+++ b/services/tuttid/api/generated/server.gen.go
@@ -119,7 +119,7 @@ type ServerInterface interface {
 	// Install or update one connector
 	// (POST /v1/connector-market/connectors/{connectorKey}:install)
 	InstallConnectorMarketConnector(w http.ResponseWriter, r *http.Request, connectorKey ConnectorMarketConnectorKey)
-	// Uninstall one connector
+	// Uninstall one connector from this device
 	// (POST /v1/connector-market/connectors/{connectorKey}:uninstall)
 	UninstallConnectorMarketConnector(w http.ResponseWriter, r *http.Request, connectorKey ConnectorMarketConnectorKey)
 	// Get one durable connector-market operation
@@ -7364,6 +7364,19 @@ func (siw *ServerInterfaceWrapper) ListWorkspaceDeletedAgentSessions(w http.Resp
 			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "searchQuery"})
 		} else {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "searchQuery", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "railSectionKey" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "railSectionKey", r.URL.Query(), &params.RailSectionKey, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "railSectionKey"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "railSectionKey", Err: err})
 		}
 		return
 	}
@@ -39165,7 +39178,7 @@ type StrictServerInterface interface {
 	// Install or update one connector
 	// (POST /v1/connector-market/connectors/{connectorKey}:install)
 	InstallConnectorMarketConnector(ctx context.Context, request InstallConnectorMarketConnectorRequestObject) (InstallConnectorMarketConnectorResponseObject, error)
-	// Uninstall one connector
+	// Uninstall one connector from this device
 	// (POST /v1/connector-market/connectors/{connectorKey}:uninstall)
 	UninstallConnectorMarketConnector(ctx context.Context, request UninstallConnectorMarketConnectorRequestObject) (UninstallConnectorMarketConnectorResponseObject, error)
 	// Get one durable connector-market operation

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -9427,9 +9427,12 @@ type WorkspaceDeletedAgentSession struct {
 	// DeletedAtUnixMs Tombstone time used by the retention policy.
 	DeletedAtUnixMs int64 `json:"deletedAtUnixMs"`
 
-	// ProjectPath Persisted original project path; null means the conversations section.
+	// ProjectPath Persisted project path retained as presentation metadata. Classification is determined only by railSectionKey.
 	ProjectPath *string `json:"projectPath"`
-	Restorable  bool    `json:"restorable"`
+
+	// RailSectionKey Immutable persisted rail section identity used for classification.
+	RailSectionKey string `json:"railSectionKey"`
+	Restorable     bool   `json:"restorable"`
 
 	// Title Original canonical title. Empty titles remain empty.
 	Title string `json:"title"`
@@ -9465,7 +9468,12 @@ type WorkspaceDeletedAgentSessionProjectOption struct {
 	// ProjectAvailable Whether the original project is still registered in the current project catalog.
 	ProjectAvailable bool   `json:"projectAvailable"`
 	ProjectLabel     string `json:"projectLabel"`
-	ProjectPath      string `json:"projectPath"`
+
+	// ProjectPath Persisted project path retained as presentation metadata; it is not the option identity.
+	ProjectPath *string `json:"projectPath"`
+
+	// RailSectionKey Exact persisted rail section identity represented by this option.
+	RailSectionKey string `json:"railSectionKey"`
 }
 
 // WorkspaceDeletedAgentSessionUnavailableReason defines model for WorkspaceDeletedAgentSessionUnavailableReason.
@@ -10296,10 +10304,13 @@ type ListWorkspaceDeletedAgentSessionsParams struct {
 	// SearchQuery Case-insensitive search over the original session title only.
 	SearchQuery *string `form:"searchQuery,omitempty" json:"searchQuery,omitempty"`
 
-	// ProjectScope Select sessions without an original project. Mutually exclusive with projectPath; omit both project filters to list every location.
+	// RailSectionKey Select sessions by their exact persisted rail section key. Mutually exclusive with the deprecated project filters; omit every section filter to list all locations.
+	RailSectionKey *string `form:"railSectionKey,omitempty" json:"railSectionKey,omitempty"`
+
+	// ProjectScope Deprecated explicit conversations-section selector. It is resolved to the fixed conversations rail section key and is mutually exclusive with railSectionKey and projectPath.
 	ProjectScope *ListWorkspaceDeletedAgentSessionsParamsProjectScope `form:"projectScope,omitempty" json:"projectScope,omitempty"`
 
-	// ProjectPath Select sessions by their persisted original project path. Mutually exclusive with projectScope.
+	// ProjectPath Deprecated explicit project selector. The path is resolved to its canonical rail section key before querying and is mutually exclusive with railSectionKey and projectScope.
 	ProjectPath *string `form:"projectPath,omitempty" json:"projectPath,omitempty"`
 
 	// Cursor Opaque cursor returned by the previous page.

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -3724,10 +3724,18 @@ paths:
           description: Case-insensitive search over the original session title only.
           schema:
             type: string
+        - name: railSectionKey
+          in: query
+          required: false
+          description: Select sessions by their exact persisted rail section key. Mutually exclusive with the deprecated project filters; omit every section filter to list all locations.
+          schema:
+            type: string
+            minLength: 1
         - name: projectScope
           in: query
           required: false
-          description: Select sessions without an original project. Mutually exclusive with projectPath; omit both project filters to list every location.
+          deprecated: true
+          description: Deprecated explicit conversations-section selector. It is resolved to the fixed conversations rail section key and is mutually exclusive with railSectionKey and projectPath.
           schema:
             type: string
             enum:
@@ -3735,7 +3743,8 @@ paths:
         - name: projectPath
           in: query
           required: false
-          description: Select sessions by their persisted original project path. Mutually exclusive with projectScope.
+          deprecated: true
+          description: Deprecated explicit project selector. The path is resolved to its canonical rail section key before querying and is mutually exclusive with railSectionKey and projectScope.
           schema:
             type: string
             minLength: 1
@@ -7932,6 +7941,7 @@ components:
       required:
         - agentSessionId
         - title
+        - railSectionKey
         - projectPath
         - updatedAtUnixMs
         - deletedAtUnixMs
@@ -7945,10 +7955,14 @@ components:
         title:
           type: string
           description: Original canonical title. Empty titles remain empty.
+        railSectionKey:
+          type: string
+          minLength: 1
+          description: Immutable persisted rail section identity used for classification.
         projectPath:
           type: string
           nullable: true
-          description: Persisted original project path; null means the conversations section.
+          description: Persisted project path retained as presentation metadata. Classification is determined only by railSectionKey.
         updatedAtUnixMs:
           type: integer
           format: int64
@@ -7970,13 +7984,19 @@ components:
       type: object
       additionalProperties: false
       required:
+        - railSectionKey
         - projectPath
         - projectLabel
         - projectAvailable
       properties:
-        projectPath:
+        railSectionKey:
           type: string
           minLength: 1
+          description: Exact persisted rail section identity represented by this option.
+        projectPath:
+          type: string
+          nullable: true
+          description: Persisted project path retained as presentation metadata; it is not the option identity.
         projectLabel:
           type: string
           minLength: 1

--- a/services/tuttid/service/agent/host_deleted_session_lifecycle_conformance_test.go
+++ b/services/tuttid/service/agent/host_deleted_session_lifecycle_conformance_test.go
@@ -114,10 +114,10 @@ func (d *serviceAdapterDeletedSessionLifecycleConformanceDriver) ListDeletedSess
 		cursor = strconv.FormatInt(input.CursorUpdatedAtUnixMS, 10) + "|" + input.CursorAgentSessionID
 	}
 	page, err := d.service.ListDeletedSessions(ctx, input.WorkspaceID, ListDeletedSessionsInput{
-		SearchQuery: input.SearchQuery,
-		ProjectPath: input.ProjectPath,
-		Cursor:      cursor,
-		Limit:       input.Limit,
+		SearchQuery:    input.SearchQuery,
+		RailSectionKey: input.RailSectionKey,
+		Cursor:         cursor,
+		Limit:          input.Limit,
 	})
 	if err != nil {
 		return agenthost.DeletedSessionPage{}, err
@@ -127,6 +127,7 @@ func (d *serviceAdapterDeletedSessionLifecycleConformanceDriver) ListDeletedSess
 		sessions = append(sessions, agenthost.DeletedSessionSummary{
 			AgentSessionID:    session.AgentSessionID,
 			Title:             session.Title,
+			RailSectionKey:    session.RailSectionKey,
 			ProjectPath:       session.ProjectPath,
 			UpdatedAtUnixMS:   session.UpdatedAtUnixMS,
 			DeletedAtUnixMS:   session.DeletedAtUnixMS,

--- a/services/tuttid/service/agent/service_deleted_sessions.go
+++ b/services/tuttid/service/agent/service_deleted_sessions.go
@@ -11,15 +11,16 @@ import (
 const maximumDeletedSessionPageLimit = 100
 
 type ListDeletedSessionsInput struct {
-	SearchQuery string
-	ProjectPath *string
-	Cursor      string
-	Limit       int
+	SearchQuery    string
+	RailSectionKey *string
+	Cursor         string
+	Limit          int
 }
 
 type DeletedSessionSummary struct {
 	AgentSessionID    string
 	Title             string
+	RailSectionKey    string
 	ProjectPath       string
 	UpdatedAtUnixMS   int64
 	DeletedAtUnixMS   int64
@@ -28,6 +29,7 @@ type DeletedSessionSummary struct {
 }
 
 type DeletedSessionProjectOption struct {
+	RailSectionKey   string
 	ProjectPath      string
 	ProjectLabel     string
 	ProjectAvailable bool
@@ -65,15 +67,18 @@ func (s *Service) ListDeletedSessions(
 		cursor = parsed
 	}
 
-	var projectPath *string
-	if input.ProjectPath != nil {
-		value := strings.TrimSpace(*input.ProjectPath)
-		projectPath = &value
+	var railSectionKey *string
+	if input.RailSectionKey != nil {
+		value := strings.TrimSpace(*input.RailSectionKey)
+		if value == "" {
+			return DeletedSessionPage{}, ErrInvalidArgument
+		}
+		railSectionKey = &value
 	}
 	page, err := s.ApplicationHost().ListDeletedSessions(ctx, agenthost.ListDeletedSessionsInput{
 		WorkspaceID:           workspaceID,
 		SearchQuery:           strings.TrimSpace(input.SearchQuery),
-		ProjectPath:           projectPath,
+		RailSectionKey:        railSectionKey,
 		CursorUpdatedAtUnixMS: cursor.SortTimeUnixMS,
 		CursorAgentSessionID:  cursor.ID,
 		Limit:                 input.Limit,
@@ -89,31 +94,33 @@ func (s *Service) ListDeletedSessions(
 			return DeletedSessionPage{}, err
 		}
 		for _, project := range projects {
-			sectionKey := userprojectbiz.SectionKeyFromPath(project.Path)
+			sectionKey := strings.TrimSpace(project.SectionKey)
 			if sectionKey != "" {
 				projectsBySectionKey[sectionKey] = project
 			}
 		}
 	}
 
-	projectOptions := make([]DeletedSessionProjectOption, 0, len(page.ProjectPaths))
-	for _, originalPath := range page.ProjectPaths {
-		originalPath = strings.TrimSpace(originalPath)
-		if originalPath == "" {
+	projectOptions := make([]DeletedSessionProjectOption, 0, len(page.RailSections))
+	for _, originalSection := range page.RailSections {
+		sectionKey := strings.TrimSpace(originalSection.RailSectionKey)
+		if sectionKey == "" || sectionKey == "conversations" {
 			continue
 		}
+		originalPath := strings.TrimSpace(originalSection.ProjectPath)
 		label := userprojectbiz.LabelFromPath(originalPath)
 		available := false
-		if project, found := projectsBySectionKey[userprojectbiz.SectionKeyFromPath(originalPath)]; found {
+		if project, found := projectsBySectionKey[sectionKey]; found {
 			available = true
 			if currentLabel := strings.TrimSpace(project.Label); currentLabel != "" {
 				label = currentLabel
 			}
 		}
 		if label == "" {
-			label = originalPath
+			label = sectionKey
 		}
 		projectOptions = append(projectOptions, DeletedSessionProjectOption{
+			RailSectionKey:   sectionKey,
 			ProjectPath:      originalPath,
 			ProjectLabel:     label,
 			ProjectAvailable: available,
@@ -125,6 +132,7 @@ func (s *Service) ListDeletedSessions(
 		sessions = append(sessions, DeletedSessionSummary{
 			AgentSessionID:    session.AgentSessionID,
 			Title:             session.Title,
+			RailSectionKey:    session.RailSectionKey,
 			ProjectPath:       session.ProjectPath,
 			UpdatedAtUnixMS:   session.UpdatedAtUnixMS,
 			DeletedAtUnixMS:   session.DeletedAtUnixMS,

--- a/services/tuttid/service/agent/service_deleted_sessions_test.go
+++ b/services/tuttid/service/agent/service_deleted_sessions_test.go
@@ -41,12 +41,18 @@ func (s *deletedSessionAdapterStoreStub) PurgeDeletedSessionTrees(
 }
 
 func TestListDeletedSessionsMapsOpaqueCursorAndProjectOptions(t *testing.T) {
+	currentSectionKey := agentactivitybiz.RailSectionKeyForProject("/current/project")
+	removedSectionKey := agentactivitybiz.RailSectionKeyForProject("/removed/repo")
 	store := &deletedSessionAdapterStoreStub{page: agentactivitybiz.DeletedSessionPage{
 		Sessions: []agentactivitybiz.DeletedSessionSummary{{
-			AgentSessionID: "root-1", Title: "Deleted", ProjectPath: "/current/project",
+			AgentSessionID: "root-1", Title: "Deleted", RailSectionKey: currentSectionKey,
+			ProjectPath:     "/stale/original",
 			UpdatedAtUnixMS: 200, DeletedAtUnixMS: 300, Restorable: true,
 		}},
-		ProjectPaths:        []string{"/current/project", "/removed/repo"},
+		RailSections: []agentactivitybiz.DeletedSessionRailSection{
+			{RailSectionKey: currentSectionKey, ProjectPath: "/stale/original"},
+			{RailSectionKey: removedSectionKey, ProjectPath: "/removed/repo"},
+		},
 		TotalCount:          1,
 		WorkspaceTotalCount: 2,
 		HasMore:             true,
@@ -55,26 +61,28 @@ func TestListDeletedSessionsMapsOpaqueCursorAndProjectOptions(t *testing.T) {
 	service := NewService(newFakeRuntime())
 	service.SetApplicationHost(agenthost.New(agenthost.Config{DeletedSessions: store}))
 	service.UserProjectReader = fakeUserProjectReader{projects: []userprojectbiz.Project{{
-		Path: "/current/project", Label: "Current project",
+		Path: "/current/project", Label: "Current project", SectionKey: currentSectionKey,
 	}}}
-	unscoped := ""
+	unscoped := agentactivitybiz.RailSectionKeyConversations
 
 	page, err := service.ListDeletedSessions(context.Background(), " workspace-1 ", ListDeletedSessionsInput{
-		SearchQuery: " deleted ", ProjectPath: &unscoped, Cursor: "200|root-z", Limit: 25,
+		SearchQuery: " deleted ", RailSectionKey: &unscoped, Cursor: "200|root-z", Limit: 25,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if store.listInput.WorkspaceID != "workspace-1" || store.listInput.SearchQuery != "deleted" ||
 		store.listInput.CursorUpdatedAtUnixMS != 200 || store.listInput.CursorAgentSessionID != "root-z" ||
-		store.listInput.ProjectPath == nil || *store.listInput.ProjectPath != "" || store.listInput.Limit != 25 {
+		store.listInput.RailSectionKey == nil || *store.listInput.RailSectionKey != agentactivitybiz.RailSectionKeyConversations || store.listInput.Limit != 25 {
 		t.Fatalf("host input = %#v", store.listInput)
 	}
 	if len(page.Sessions) != 1 || page.TotalCount != 1 || page.WorkspaceTotalCount != 2 ||
-		!page.HasMore || page.NextCursor != "100|root-2" {
+		!page.HasMore || page.NextCursor != "100|root-2" ||
+		page.Sessions[0].RailSectionKey != currentSectionKey {
 		t.Fatalf("page = %#v", page)
 	}
 	if len(page.ProjectOptions) != 2 || !page.ProjectOptions[0].ProjectAvailable ||
+		page.ProjectOptions[0].RailSectionKey != currentSectionKey ||
 		page.ProjectOptions[0].ProjectLabel != "Current project" ||
 		page.ProjectOptions[1].ProjectAvailable || page.ProjectOptions[1].ProjectLabel != "repo" {
 		t.Fatalf("project options = %#v", page.ProjectOptions)


### PR DESCRIPTION
## 背景

项目内会话可能运行在 worktree 或其他派生 `cwd` 下。现有展示层仍有按路径和 section membership 反推项目的逻辑，导致已经固化了项目归属的会话被显示为“对话”。

## 改动

- AgentGUI 对既有会话只使用持久化的 `railSectionKey` 与用户项目 `sectionKey` 做精确关联；缺失、未知或 `conversations` key 均不再从 `cwd` 回退推断
- 新会话仍可根据用户显式选择的项目路径生成初始 rail placement，但这条路径不参与既有会话归类
- 移动端 Activity 与 Rail 投影采用相同规则；过期的 section `sessionIds` 会按会话自身 key 重新归位，缺 key 时 fail closed
- 回收站的列表过滤、项目选项、行展示和恢复前查询均以 `railSectionKey` 为身份；`projectPath` 仅保留为展示元数据
- OpenAPI 新增 `railSectionKey` 过滤与响应字段；旧的显式路径过滤标记为 deprecated，并在 API 边界转换成 key 后再查询
- 更新 AgentGUI、Activity 与 Agent Host 的持久化归类契约文档

## 验证

- `pnpm check:changed`：28 个通道通过
- pre-push `pnpm check:changed -- --push-ready`：31 个通道通过
- `pnpm --filter @tutti-os/desktop build`：通过
- 聚焦覆盖桌面、移动端、TypeScript client、AgentGUI、Agent Host、SQLite store、tuttid service/API 的测试与类型检查均通过

## AgentGUI review

| Lane | 结果 | 证据 |
| --- | --- | --- |
| Architecture | pass | 归类身份统一收敛到持久化 `railSectionKey`，未新增生命周期语义，架构文档已更新 |
| Performance | pass | 热路径只增加 key 的 Map 查找和相等比较，无新增订阅、快照或协调循环；degradation checks 通过 |
| Consumers | pass（仓内） | Desktop、Mobile、生成 client、tuttid API/service/store 与 Host 测试通过；仓外 Host 消费者需同步从 deleted-session `ProjectPath` 字段迁移到 `RailSectionKey` |