### PR TITLE
fix(browser): close workbench on final tab

### DIFF
--- a/docs/architecture/browser-node-package.md
+++ b/docs/architecture/browser-node-package.md
@@ -78,6 +78,14 @@ one surface must use the package-owned surface-event predicate so both the
 parent ID and its `:tab:*` child IDs are accepted without admitting events from
 other Browser surfaces.
 
+The final tab is a surface-close action, not a child-guest close. Standalone
+hosts may handle it through the ordinary Browser `onCloseRequest`; the shared
+Workbench adapter binds its dedicated final-tab request to
+`windowActions.close()`. It must not send the parent surface ID to
+`BrowserNodeHostApi.close()`, because that API closes registered child guests
+and does not remove a Workbench node. Once the Workbench node unmounts, the
+tab-surface leases close every remaining child guest.
+
 Ordinary guest `target="_blank"` links and `window.open` calls emit an
 `open-url` event with the exact source child ID. The full workspace Browser host
 uses that identity to create and select a new tab in the same Browser surface.

--- a/docs/conventions/troubleshooting/workbench-renderer.md
+++ b/docs/conventions/troubleshooting/workbench-renderer.md
@@ -59,6 +59,38 @@
   [standaloneAgentToolWorkbench.ts](../../../apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentToolWorkbench.ts)
   [browser-node-package.md](../../architecture/browser-node-package.md)
 
+### Final Browser tab close leaves the Workbench window open
+
+- Symptom:
+  A Browser Workbench node has one tab. Its tab close control is visible, but
+  clicking it leaves the Browser window open. The native Workbench close
+  control may still work.
+- Quick checks:
+  Inspect the callbacks passed to `BrowserNodeWorkbenchHeader`. Confirm that
+  the final-tab callback reaches `windowActions.close()` and is not implemented
+  as `BrowserNodeHostApi.close({ nodeId: surfaceNodeId })`. The Workbench node ID
+  is a parent surface ID; registered Browser guests use `:tab:*` child IDs.
+- Root cause:
+  Browser guest cleanup and Workbench surface closure are different lifecycle
+  boundaries. Closing a parent ID through the Browser host API emits a guest
+  close event but cannot remove the Workbench node. The native window control
+  can mask this mismatch because its own click handler separately closes the
+  Workbench window, while the final-tab control has no such fallback.
+- Fix:
+  Keep the native action and final-tab request separate. Bind the dedicated
+  final-tab request to `windowActions.close()` and let Browser tab-surface lease
+  release close the remaining child guests after unmount. Do not add a second
+  Workbench close call to the native control's capture path.
+- Validation:
+  Exercise the Browser Workbench close-request adapter and assert that its
+  final-tab request runs the Workbench close action exactly once. Keep the
+  package tab intent tests to prove that the dedicated Workbench request wins
+  while the ordinary standalone-host callback remains a supported fallback.
+- References:
+  [BrowserNodeChrome.tsx](../../../packages/browser/workbench-node/src/react/BrowserNodeChrome.tsx)
+  [Browser Workbench adapter](../../../packages/browser/workbench-node/src/workbench/index.ts)
+  [Browser Workbench adapter test](../../../packages/browser/workbench-node/src/workbench/browserNodeCloseRequests.test.ts)
+
 ### Inline custom-header menu is clipped to the Workbench title bar
 
 - Symptom:

--- a/packages/browser/workbench-node/src/react/BrowserNodeChrome.tsx
+++ b/packages/browser/workbench-node/src/react/BrowserNodeChrome.tsx
@@ -34,7 +34,10 @@ import {
   openBrowserNodeExternal,
   resolveBrowserNodeOpenExternalUrl
 } from "./browserNodeOperations.ts";
-import { resolveBrowserNodeTabCloseIntent } from "./browserNodeTabClose.ts";
+import {
+  resolveBrowserNodeFinalTabCloseRequest,
+  resolveBrowserNodeTabCloseIntent
+} from "./browserNodeTabClose.ts";
 import { useBrowserNodeController } from "./useBrowserNodeController.ts";
 
 export interface BrowserNodeChromeProps {
@@ -47,6 +50,7 @@ export interface BrowserNodeChromeProps {
   feature: BrowserNodeFeature;
   navigationActions?: ReactNode;
   onCloseRequest?: () => void;
+  onFinalTabCloseRequest?: () => void;
   onFocusRequest?: () => void;
   surfaceNodeId: string;
   withBorder?: boolean;
@@ -62,6 +66,7 @@ export interface BrowserNodeWorkbenchHeaderProps {
   navigationActions?: ReactNode;
   nodeId: string;
   onCloseRequest?: () => void;
+  onFinalTabCloseRequest?: () => void;
   onFocusRequest?: () => void;
 }
 
@@ -75,6 +80,7 @@ export function BrowserNodeWorkbenchHeader({
   navigationActions,
   nodeId,
   onCloseRequest,
+  onFinalTabCloseRequest,
   onFocusRequest
 }: BrowserNodeWorkbenchHeaderProps): JSX.Element {
   return (
@@ -87,6 +93,7 @@ export function BrowserNodeWorkbenchHeader({
       feature={feature}
       navigationActions={navigationActions}
       onCloseRequest={onCloseRequest}
+      onFinalTabCloseRequest={onFinalTabCloseRequest}
       onFocusRequest={onFocusRequest}
       surfaceNodeId={nodeId}
       withBorder={false}
@@ -104,6 +111,7 @@ export function BrowserNodeChrome({
   feature,
   navigationActions,
   onCloseRequest,
+  onFinalTabCloseRequest,
   onFocusRequest,
   surfaceNodeId,
   withBorder = true
@@ -112,6 +120,10 @@ export function BrowserNodeChrome({
   const activeTab =
     tabsState.tabs.find((tab) => tab.id === tabsState.activeTabId) ??
     tabsState.tabs[0];
+  const finalTabCloseRequest = resolveBrowserNodeFinalTabCloseRequest({
+    onCloseRequest,
+    onFinalTabCloseRequest
+  });
 
   if (!activeTab) {
     throw new Error(`Browser tab surface has no tabs: ${surfaceNodeId}`);
@@ -187,7 +199,7 @@ export function BrowserNodeChrome({
         >
           {tabsState.tabs.map((tab) => {
             const closeIntent = resolveBrowserNodeTabCloseIntent({
-              hasSurfaceCloseRequest: Boolean(onCloseRequest),
+              hasSurfaceCloseRequest: Boolean(finalTabCloseRequest),
               tabCount: tabsState.tabs.length
             });
             return (
@@ -199,7 +211,7 @@ export function BrowserNodeChrome({
                 tab={tab}
                 onClose={() => {
                   if (closeIntent === "surface") {
-                    onCloseRequest?.();
+                    finalTabCloseRequest?.();
                     return;
                   }
                   closeBrowserNodeTab(feature, surfaceNodeId, tab.id);

--- a/packages/browser/workbench-node/src/react/browserNodeTabClose.test.ts
+++ b/packages/browser/workbench-node/src/react/browserNodeTabClose.test.ts
@@ -1,6 +1,32 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { resolveBrowserNodeTabCloseIntent } from "./browserNodeTabClose.ts";
+import {
+  resolveBrowserNodeFinalTabCloseRequest,
+  resolveBrowserNodeTabCloseIntent
+} from "./browserNodeTabClose.ts";
+
+test("Browser Node prefers a dedicated final-tab surface close request", () => {
+  const requests: string[] = [];
+  const request = resolveBrowserNodeFinalTabCloseRequest({
+    onCloseRequest: () => requests.push("default"),
+    onFinalTabCloseRequest: () => requests.push("final-tab")
+  });
+
+  request?.();
+
+  assert.deepEqual(requests, ["final-tab"]);
+});
+
+test("Browser Node keeps the existing surface close request as a fallback", () => {
+  const requests: string[] = [];
+  const request = resolveBrowserNodeFinalTabCloseRequest({
+    onCloseRequest: () => requests.push("default")
+  });
+
+  request?.();
+
+  assert.deepEqual(requests, ["default"]);
+});
 
 test("Browser Node closes one of multiple tabs", () => {
   assert.equal(

--- a/packages/browser/workbench-node/src/react/browserNodeTabClose.ts
+++ b/packages/browser/workbench-node/src/react/browserNodeTabClose.ts
@@ -1,5 +1,12 @@
 export type BrowserNodeTabCloseIntent = "surface" | "tab";
 
+export function resolveBrowserNodeFinalTabCloseRequest(input: {
+  onCloseRequest?: () => void;
+  onFinalTabCloseRequest?: () => void;
+}): (() => void) | undefined {
+  return input.onFinalTabCloseRequest ?? input.onCloseRequest;
+}
+
 export function resolveBrowserNodeTabCloseIntent(input: {
   hasSurfaceCloseRequest: boolean;
   tabCount: number;

--- a/packages/browser/workbench-node/src/workbench/browserNodeCloseRequests.test.ts
+++ b/packages/browser/workbench-node/src/workbench/browserNodeCloseRequests.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createBrowserNodeWorkbenchCloseRequests } from "./browserNodeCloseRequests.ts";
+
+test("final Browser tab closes the owning Workbench window once", () => {
+  let workbenchCloseCount = 0;
+  const requests = createBrowserNodeWorkbenchCloseRequests({
+    close: () => {
+      workbenchCloseCount += 1;
+    }
+  });
+
+  requests.onFinalTabCloseRequest();
+
+  assert.equal(workbenchCloseCount, 1);
+  assert.deepEqual(Object.keys(requests), ["onFinalTabCloseRequest"]);
+});

--- a/packages/browser/workbench-node/src/workbench/browserNodeCloseRequests.ts
+++ b/packages/browser/workbench-node/src/workbench/browserNodeCloseRequests.ts
@@ -1,0 +1,9 @@
+import type { WorkbenchHostNodeHeaderWindowActions } from "@tutti-os/workbench-surface";
+
+export function createBrowserNodeWorkbenchCloseRequests(
+  windowActions: Pick<WorkbenchHostNodeHeaderWindowActions, "close">
+): { onFinalTabCloseRequest: () => void } {
+  return {
+    onFinalTabCloseRequest: () => windowActions.close()
+  };
+}

--- a/packages/browser/workbench-node/src/workbench/index.ts
+++ b/packages/browser/workbench-node/src/workbench/index.ts
@@ -18,6 +18,7 @@ import {
   resolveBrowserNodeInitialUrl,
   type BrowserNodeExternalState
 } from "./browserNodeInitialUrl.ts";
+import { createBrowserNodeWorkbenchCloseRequests } from "./browserNodeCloseRequests.ts";
 
 export type {
   BrowserNodeExternalState,
@@ -137,11 +138,7 @@ export function createBrowserNodeDefinition({
         dragHandleProps: headerContext.dragHandleProps,
         feature,
         nodeId: headerContext.node.id,
-        onCloseRequest: () => {
-          void feature.hostApi
-            .close({ nodeId: headerContext.node.id })
-            .catch(() => undefined);
-        },
+        ...createBrowserNodeWorkbenchCloseRequests(headerContext.windowActions),
         onFocusRequest: headerContext.isFocused
           ? undefined
           : () => headerContext.windowActions.focus()


### PR DESCRIPTION
## 背景

Browser Workbench 节点只剩一个标签页时，点击标签关闭按钮不会移除窗口。此前的接线把 Workbench 父节点 ID 传给了 Browser guest 的关闭 API；该 API 只管理 `:tab:*` 子 guest，无法关闭 Workbench surface。

## 修改

- 为最后一个标签页增加独立的 surface close 回调，同时保留 standalone host 的原有回调作为兼容兜底
- Workbench adapter 将最后标签关闭请求接到 `windowActions.close()`
- 避免与窗口原生关闭按钮的捕获处理重复触发
- 增加回调优先级和 Workbench 接线测试
- 补充 Browser Node 架构说明与 Workbench 排障文档

## 验证

- Browser package tests：160/160 通过
- package typecheck 通过
- `pnpm check:changed` 通过
- pre-push `pnpm check:changed -- --push-ready`：10 个 lane 通过
- `make dev-gui` 真实 UI 验证：Browser 节点降到只剩一个标签页后，点击最后一个关闭按钮，页面注册立即清空，关闭动画结束后 Browser 窗口与标签组均消失