### PR TITLE
fix(agent): compact duplicate terminal command output

### DIFF
--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -1280,18 +1280,31 @@ metadata, image base64, and unknown provider-only result keys are not retained.
 Provider adapters may continue accepting those wire shapes, but shared
 business code consumes only the explicit canonical fields. Each canonical
 `output` or `error` `text`, `stdout`, and `stderr` field, including nested tool
-steps, is bounded to 1 MiB total by retaining a valid UTF-8 prefix and the fixed
-`[Output truncated]` marker. A terminal command snapshot omits `text` only when
-it is exactly reconstructible as `strings.TrimSpace(stdout)` or
-`strings.TrimSpace(stderr)`; the raw stream remains canonical. Running command
-output retains `text` for ordered live deltas, and non-command tools retain it
-as their provider-neutral display contract. Agent reference/session output uses
-the same canonical projection rather than depending on a retained raw tool
-result. Canonical compaction is normally a forward-write rule. One bounded
-migration also repairs active terminal command rows whose payload already
-exceeds 1 MiB by removing only that reconstructible alias, without changing
-message versions or timestamps; smaller and non-command historical rows are not
-rewritten.
+steps, first receives a 1 MiB per-field bound by retaining a valid UTF-8 prefix
+and the fixed `[Output truncated]` marker. Durable tool-call payloads then fit
+those formal output streams into a 768 KiB aggregate JSON budget, leaving
+deterministic headroom below the 1 MiB replication request limit for mutation
+identity, scope, and batch framing. Inputs and structured results are never
+discarded merely to satisfy that output budget.
+
+A terminal command snapshot omits `text` only when it is exactly
+reconstructible as `strings.TrimSpace(stdout)` or
+`strings.TrimSpace(stderr)`; the raw stream remains canonical. The Reporter
+recognizes that alias before per-field truncation and emits a tombstone so a
+terminal snapshot also clears any `text` retained from its running snapshot.
+Nested steps use their own lifecycle status, even beneath a running parent.
+Explicit non-command tool identity wins over command-shaped input, so MCP and
+other non-command tools retain `text` as their provider-neutral display
+contract. Running command output retains `text` for ordered live deltas. Agent
+reference/session output uses the same canonical projection rather than
+depending on a retained raw tool result.
+
+Canonical compaction is normally a forward-write rule. One bounded migration
+also repairs retained terminal command rows, including deleted/tombstoned rows
+that remain replication inputs, whose payload reaches the 768 KiB safe budget.
+It removes only reconstructible aliases and refits formal output streams without
+changing message versions or timestamps. Rows whose structured data cannot fit
+without semantic loss remain unchanged for explicit handling.
 
 The Go live-protocol adapter owns the complete fast-lane envelope on both sides
 of a device link: schema validation, recipient identity projection,

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -1281,11 +1281,17 @@ Provider adapters may continue accepting those wire shapes, but shared
 business code consumes only the explicit canonical fields. Each canonical
 `output` or `error` `text`, `stdout`, and `stderr` field, including nested tool
 steps, is bounded to 1 MiB total by retaining a valid UTF-8 prefix and the fixed
-`[Output truncated]` marker. Agent
-reference/session output uses the same canonical projection rather than
-depending on a retained raw tool result. This is a forward-write rule: existing
-rows are not rewritten, their removed fields are ignored, and normal retention
-eventually ages them out.
+`[Output truncated]` marker. A terminal command snapshot omits `text` only when
+it is exactly reconstructible as `strings.TrimSpace(stdout)` or
+`strings.TrimSpace(stderr)`; the raw stream remains canonical. Running command
+output retains `text` for ordered live deltas, and non-command tools retain it
+as their provider-neutral display contract. Agent reference/session output uses
+the same canonical projection rather than depending on a retained raw tool
+result. Canonical compaction is normally a forward-write rule. One bounded
+migration also repairs active terminal command rows whose payload already
+exceeds 1 MiB by removing only that reconstructible alias, without changing
+message versions or timestamps; smaller and non-command historical rows are not
+rewritten.
 
 The Go live-protocol adapter owns the complete fast-lane envelope on both sides
 of a device link: schema validation, recipient identity projection,

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -100,6 +100,9 @@ Realtime events reduce latency but are not automatically complete truth:
 - canonical tool `output`/`error` bodies bound each `text`, `stdout`, and
   `stderr` field to 1 MiB total, including nested tool steps, by retaining a
   valid UTF-8 prefix and the fixed `[Output truncated]` marker
+- terminal command snapshots may omit `text` only when it exactly equals the
+  trimmed `stdout` or `stderr`; the raw stream remains canonical, while running
+  commands and non-command tools retain provider-neutral `text`
 - continuous, version-complete `message_update` events may merge inline
 - terminal `message_update` is the durable confirmation; message version gaps,
   invalid/unanchored deltas, nonterminal deltas after known terminal message

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -98,11 +98,14 @@ Realtime events reduce latency but are not automatically complete truth:
   tool output arrive as optimistic `message_delta` payloads on the
   `/v1/events/ws` business-event WebSocket
 - canonical tool `output`/`error` bodies bound each `text`, `stdout`, and
-  `stderr` field to 1 MiB total, including nested tool steps, by retaining a
-  valid UTF-8 prefix and the fixed `[Output truncated]` marker
+  `stderr` field to 1 MiB, then fit formal output streams into a 768 KiB
+  aggregate durable payload budget, including nested tool steps, by retaining
+  a valid UTF-8 prefix and the fixed `[Output truncated]` marker
 - terminal command snapshots may omit `text` only when it exactly equals the
-  trimmed `stdout` or `stderr`; the raw stream remains canonical, while running
-  commands and non-command tools retain provider-neutral `text`
+  trimmed `stdout` or `stderr`; Reporter resolves the alias before independent
+  field truncation and clears an earlier running `text`, while the raw stream
+  remains canonical and explicit non-command tools retain provider-neutral
+  `text`
 - continuous, version-complete `message_update` events may merge inline
 - terminal `message_update` is the durable confirmation; message version gaps,
   invalid/unanchored deltas, nonterminal deltas after known terminal message

--- a/packages/agent/daemon/runtime/reporter_message.go
+++ b/packages/agent/daemon/runtime/reporter_message.go
@@ -219,6 +219,12 @@ func callMessageUpdateFromSessionEvent(
 			payload["error"] = canonicalToolBodyPayload(event.Payload.Error)
 		}
 	}
+	// Preserve an explicit nil until the canonical deep merge so a terminal
+	// snapshot can clear reconstructible text left by an earlier running
+	// update. Detect the alias while the raw stream still has its full prefix;
+	// independent per-field truncation can otherwise make equal values diverge.
+	canonical.TombstoneTerminalCommandOutputAliases(status, payload)
+	truncateCanonicalToolMessagePayload(payload)
 	update := agentsessionstore.WorkspaceAgentMessageUpdate{
 		AgentSessionID:   strings.TrimSpace(sessionID),
 		MessageID:        messageID,
@@ -255,17 +261,34 @@ func canonicalToolBodyPayload(value any) any {
 			body["text"] = text
 		}
 	}
-	return canonical.TruncateToolOutputBody(body)
+	return body
 }
 
 func canonicalToolMetadataPayload(metadata map[string]any) map[string]any {
-	result := clonePayload(metadata)
-	if result == nil || result["steps"] == nil {
-		return result
+	return clonePayload(metadata)
+}
+
+func truncateCanonicalToolMessagePayload(payload map[string]any) {
+	for _, key := range []string{"output", "error"} {
+		body, _ := payload[key].(map[string]any)
+		if body != nil {
+			payload[key] = canonical.TruncateToolOutputBody(body)
+		}
 	}
-	truncated := canonical.TruncateToolOutputBody(map[string]any{"steps": result["steps"]})
-	result["steps"] = truncated["steps"]
-	return result
+	if steps := payload["steps"]; steps != nil {
+		truncated := canonical.TruncateToolOutputBody(map[string]any{
+			"steps": steps,
+		})
+		payload["steps"] = truncated["steps"]
+	}
+	metadata, _ := payload["metadata"].(map[string]any)
+	if metadata == nil || metadata["steps"] == nil {
+		return
+	}
+	truncated := canonical.TruncateToolOutputBody(map[string]any{
+		"steps": metadata["steps"],
+	})
+	metadata["steps"] = truncated["steps"]
 }
 
 func canonicalToolBodyText(body map[string]any) string {

--- a/packages/agent/daemon/runtime/reporter_test.go
+++ b/packages/agent/daemon/runtime/reporter_test.go
@@ -3,6 +3,7 @@ package agentruntime
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"reflect"
@@ -906,14 +907,14 @@ func TestReporterProjectsCanonicalFieldsFromStartedAndCompletedCallsToMessageUpd
 	if got := updates[1].Payload["output"].(map[string]any)["stdout"]; got != "README.md\n" {
 		t.Fatalf("payload = %#v, want completed output preserved", updates[1].Payload)
 	}
-	if got := updates[1].Payload["output"].(map[string]any)["text"]; got != "README.md" {
-		t.Fatalf("payload = %#v, want canonical output text", updates[1].Payload)
+	if got := updates[1].Payload["output"].(map[string]any)["text"]; got != nil {
+		t.Fatalf("payload = %#v, want terminal output text tombstone", updates[1].Payload)
 	}
 	if got := updates[1].Payload["error"].(map[string]any)["stderr"]; got != "warning: truncated\n" {
 		t.Fatalf("payload = %#v, want completed error preserved", updates[1].Payload)
 	}
-	if got := updates[1].Payload["error"].(map[string]any)["text"]; got != "warning: truncated" {
-		t.Fatalf("payload = %#v, want canonical error text", updates[1].Payload)
+	if got := updates[1].Payload["error"].(map[string]any)["text"]; got != nil {
+		t.Fatalf("payload = %#v, want terminal error text tombstone", updates[1].Payload)
 	}
 	if got := updates[1].Status; got != "completed" {
 		t.Fatalf("completed update = %#v, want completed status preserved", updates[1])
@@ -956,8 +957,129 @@ func TestReporterProjectsStandardACPToolLifecycleToStableMessageUpdates(t *testi
 	if got := updates[1].Payload["output"].(map[string]any)["stdout"]; got != "/workspace/app\n" {
 		t.Fatalf("payload = %#v, want preserved output", updates[1].Payload)
 	}
-	if got := updates[1].Payload["output"].(map[string]any)["text"]; got != "/workspace/app" {
-		t.Fatalf("payload = %#v, want canonical output text", updates[1].Payload)
+	if got := updates[1].Payload["output"].(map[string]any)["text"]; got != nil {
+		t.Fatalf("payload = %#v, want terminal output text tombstone", updates[1].Payload)
+	}
+}
+
+func TestReporterCompactsTerminalCommandAliasBeforeTruncationAndMerge(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		stdout string
+	}{
+		{
+			name: "leading whitespace shifts independent truncation windows",
+			stdout: " " + strings.Repeat(
+				"x",
+				canonical.ToolOutputTextMaxBytes+64,
+			) + "\n",
+		},
+		{
+			name: "trailing whitespace pushes raw stream over field limit",
+			stdout: strings.Repeat(
+				"y",
+				canonical.ToolOutputTextMaxBytes,
+			) + strings.Repeat("\n", 64),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			session := reportTestSession()
+			report := reportActivityInput(session, []activityshared.Event{
+				newTurnActivityEventWithID(
+					session,
+					"terminal-alias",
+					EventCallCompleted,
+					"turn-terminal-alias",
+					messageStreamStateCompleted,
+					"",
+					"Run command",
+					map[string]any{
+						"callId":   "call-terminal-alias",
+						"name":     "Run command",
+						"toolName": "Bash",
+						"input": map[string]any{
+							"command": "print output",
+						},
+						"output": map[string]any{
+							"stdout": test.stdout,
+						},
+					},
+				),
+			})
+			if len(report.MessageUpdates) != 1 {
+				t.Fatalf("message updates = %#v, want one", report.MessageUpdates)
+			}
+			update := report.MessageUpdates[0]
+			output := update.Payload["output"].(map[string]any)
+			if output["text"] != nil {
+				t.Fatalf("reporter output retained alias: %#v", output)
+			}
+			stdout := output["stdout"].(string)
+			if len(stdout) > canonical.ToolOutputTextMaxBytes ||
+				!strings.HasSuffix(stdout, canonical.ToolOutputTruncationMarker) {
+				t.Fatalf("reporter stdout was not bounded: %d bytes", len(stdout))
+			}
+
+			existing := canonical.MessageSnapshot{
+				AgentSessionID: "session-1",
+				MessageID:      update.MessageID,
+				Version:        1,
+				TurnID:         update.TurnID,
+				Role:           update.Role,
+				Kind:           update.Kind,
+				Status:         "running",
+				Payload: map[string]any{
+					"toolName": "Bash",
+					"input":    map[string]any{"command": "print output"},
+					"output": map[string]any{
+						"text": canonical.TruncateToolOutputText(
+							strings.TrimSpace(test.stdout),
+						),
+					},
+				},
+				OccurredAtUnixMS: 10,
+				StartedAtUnixMS:  10,
+				CreatedAtUnixMS:  10,
+				UpdatedAtUnixMS:  10,
+			}
+			projected, ok := canonical.ProjectMessageUpdate(
+				existing,
+				true,
+				canonical.MessageUpdate{
+					MessageID:         update.MessageID,
+					TurnID:            update.TurnID,
+					Role:              update.Role,
+					Kind:              update.Kind,
+					Status:            update.Status,
+					Payload:           update.Payload,
+					OccurredAtUnixMS:  update.OccurredAtUnixMS,
+					StartedAtUnixMS:   update.StartedAtUnixMS,
+					CompletedAtUnixMS: update.CompletedAtUnixMS,
+				},
+				2,
+				20,
+			)
+			if !ok {
+				t.Fatal("ProjectMessageUpdate() rejected terminal report")
+			}
+			projectedOutput := projected.Payload["output"].(map[string]any)
+			if _, exists := projectedOutput["text"]; exists {
+				t.Fatalf("durable output retained running text alias: %#v", projectedOutput)
+			}
+			encoded, err := json.Marshal(projected.Payload)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(encoded) > canonical.ToolCallPayloadMaxBytes {
+				t.Fatalf("durable payload has %d bytes", len(encoded))
+			}
+		})
 	}
 }
 

--- a/packages/agent/session-replay/replay_state_compare.go
+++ b/packages/agent/session-replay/replay_state_compare.go
@@ -19,6 +19,7 @@ func normalizeReplayStateForComparison(state TuttiReplayState) TuttiReplayState 
 	var value map[string]any
 	_ = json.Unmarshal(raw, &value)
 
+	canonicalizeTerminalCommandOutputAliases(value)
 	canonicalizeGoalControlAuditIdentities(value)
 	replacements := map[string]string{}
 	registerReplayIDs(replacements, value)
@@ -30,6 +31,27 @@ func normalizeReplayStateForComparison(state TuttiReplayState) TuttiReplayState 
 	var result TuttiReplayState
 	_ = json.Unmarshal(normalized, &result)
 	return result
+}
+
+// canonicalizeTerminalCommandOutputAliases keeps pre-compaction cassettes
+// comparable with current durable state. It changes comparison data only;
+// historical restore still receives the cassette's original payload.
+func canonicalizeTerminalCommandOutputAliases(value map[string]any) {
+	agent, _ := value["agent"].(map[string]any)
+	sessions, _ := agent["sessions"].([]any)
+	for _, sessionItem := range sessions {
+		session, _ := sessionItem.(map[string]any)
+		messages, _ := session["messages"].([]any)
+		for _, messageItem := range messages {
+			message, _ := messageItem.(map[string]any)
+			if message == nil || message["kind"] != "tool_call" {
+				continue
+			}
+			status, _ := message["status"].(string)
+			payload, _ := message["payload"].(map[string]any)
+			canonical.CompactTerminalCommandOutputAliases(status, payload)
+		}
+	}
 }
 
 // canonicalizeGoalControlAuditIdentities keeps the identity graph of goal

--- a/packages/agent/session-replay/replay_state_compare.go
+++ b/packages/agent/session-replay/replay_state_compare.go
@@ -34,8 +34,9 @@ func normalizeReplayStateForComparison(state TuttiReplayState) TuttiReplayState 
 }
 
 // canonicalizeTerminalCommandOutputAliases keeps pre-compaction cassettes
-// comparable with current durable state. It changes comparison data only;
-// historical restore still receives the cassette's original payload.
+// comparable with the current alias and aggregate output storage shape. It
+// changes comparison data only; historical restore still receives the
+// cassette's original payload.
 func canonicalizeTerminalCommandOutputAliases(value map[string]any) {
 	agent, _ := value["agent"].(map[string]any)
 	sessions, _ := agent["sessions"].([]any)
@@ -50,6 +51,10 @@ func canonicalizeTerminalCommandOutputAliases(value map[string]any) {
 			status, _ := message["status"].(string)
 			payload, _ := message["payload"].(map[string]any)
 			canonical.CompactTerminalCommandOutputAliases(status, payload)
+			canonical.FitToolCallPayloadOutputBudget(
+				payload,
+				canonical.ToolCallPayloadMaxBytes,
+			)
 		}
 	}
 }

--- a/packages/agent/session-replay/replay_state_domain_test.go
+++ b/packages/agent/session-replay/replay_state_domain_test.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
+	"github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
 )
 
 func TestProjectAndResolvePortableAgentSessionBinding(t *testing.T) {
@@ -1291,6 +1293,94 @@ func TestCompareTuttiReplayStateCanonicalizesTerminalCommandOutputAliases(
 		buildState(nil),
 	); !errors.Is(err, ErrTuttiReplayStateConflict) {
 		t.Fatalf("distinct command text must remain semantic, got %v", err)
+	}
+}
+
+func TestCompareTuttiReplayStateCanonicalizesNestedAndBudgetedCommandOutput(
+	t *testing.T,
+) {
+	buildState := func(status string, payload map[string]any) TuttiReplayState {
+		return TuttiReplayState{
+			SchemaVersion: SchemaVersion,
+			Agent: TuttiReplayAgent{
+				RootSessionID: "session-1",
+				Sessions: []agenthost.HistoricalSession{{
+					ID:                "session-1",
+					Kind:              "root",
+					AgentTargetID:     "local:codex",
+					Provider:          "codex",
+					ProviderSessionID: "provider-session-1",
+					Messages: []agenthost.HistoricalMessage{{
+						ID:      "toolcall:call-1",
+						Role:    "assistant",
+						Kind:    "tool_call",
+						Status:  status,
+						Payload: payload,
+					}},
+				}},
+			},
+			TuttiMode: TuttiReplayTuttiMode{
+				Activations:   []TuttiReplayActivation{},
+				TurnSnapshots: []TuttiReplayTurnSnapshot{},
+			},
+			Workflows: []TuttiReplayWorkflow{},
+			Issues:    []TuttiReplayIssue{},
+		}
+	}
+
+	nestedPayload := func(includeAlias bool) map[string]any {
+		body := map[string]any{"stdout": "nested output\n"}
+		if includeAlias {
+			body["text"] = "nested output"
+		}
+		return map[string]any{
+			"toolName": "Task",
+			"steps": []any{map[string]any{
+				"status":   "running",
+				"toolName": "Task",
+				"toolResult": map[string]any{"steps": []any{
+					map[string]any{
+						"status":     "completed",
+						"toolName":   "Bash",
+						"toolInput":  map[string]any{"command": "printf nested"},
+						"toolResult": body,
+					},
+				}},
+			}},
+		}
+	}
+	if err := CompareTuttiReplayState(
+		buildState("running", nestedPayload(true)),
+		buildState("running", nestedPayload(false)),
+	); err != nil {
+		t.Fatalf("nested terminal command alias must compare equal: %v", err)
+	}
+
+	stream := strings.Repeat("x", canonical.ToolCallPayloadMaxBytes) + "\n"
+	rawPayload := map[string]any{
+		"toolName": "Bash",
+		"input":    map[string]any{"command": "generate output"},
+		"output": map[string]any{
+			"text":   strings.TrimSpace(stream),
+			"stdout": stream,
+		},
+	}
+	budgetedPayload := map[string]any{
+		"toolName": "Bash",
+		"input":    map[string]any{"command": "generate output"},
+		"output":   map[string]any{"stdout": stream},
+	}
+	if _, fits := canonical.FitToolCallPayloadOutputBudget(
+		budgetedPayload,
+		canonical.ToolCallPayloadMaxBytes,
+	); !fits {
+		t.Fatal("expected comparison fixture to fit aggregate payload budget")
+	}
+	if err := CompareTuttiReplayState(
+		buildState("completed", rawPayload),
+		buildState("completed", budgetedPayload),
+	); err != nil {
+		t.Fatalf("pre-budget cassette output must compare equal: %v", err)
 	}
 }
 

--- a/packages/agent/session-replay/replay_state_domain_test.go
+++ b/packages/agent/session-replay/replay_state_domain_test.go
@@ -1236,6 +1236,64 @@ func TestCompareTuttiReplayStateTreatsToolCallIDsAsAlphaEquivalent(
 	}
 }
 
+func TestCompareTuttiReplayStateCanonicalizesTerminalCommandOutputAliases(
+	t *testing.T,
+) {
+	buildState := func(text *string) TuttiReplayState {
+		output := map[string]any{"stdout": "command output\n"}
+		if text != nil {
+			output["text"] = *text
+		}
+		return TuttiReplayState{
+			SchemaVersion: SchemaVersion,
+			Agent: TuttiReplayAgent{
+				RootSessionID: "session-1",
+				Sessions: []agenthost.HistoricalSession{{
+					ID:                "session-1",
+					Kind:              "root",
+					AgentTargetID:     "local:codex",
+					Provider:          "codex",
+					ProviderSessionID: "provider-session-1",
+					Messages: []agenthost.HistoricalMessage{{
+						ID:     "toolcall:call-1",
+						Role:   "assistant",
+						Kind:   "tool_call",
+						Status: "completed",
+						Payload: map[string]any{
+							"callId":   "call-1",
+							"toolName": "exec_command",
+							"input":    map[string]any{"command": "printf output"},
+							"output":   output,
+						},
+					}},
+				}},
+			},
+			TuttiMode: TuttiReplayTuttiMode{
+				Activations:   []TuttiReplayActivation{},
+				TurnSnapshots: []TuttiReplayTurnSnapshot{},
+			},
+			Workflows: []TuttiReplayWorkflow{},
+			Issues:    []TuttiReplayIssue{},
+		}
+	}
+
+	reconstructible := "command output"
+	if err := CompareTuttiReplayState(
+		buildState(&reconstructible),
+		buildState(nil),
+	); err != nil {
+		t.Fatalf("reconstructible command text alias must compare equal: %v", err)
+	}
+
+	distinct := "formatted command output"
+	if err := CompareTuttiReplayState(
+		buildState(&distinct),
+		buildState(nil),
+	); !errors.Is(err, ErrTuttiReplayStateConflict) {
+		t.Fatalf("distinct command text must remain semantic, got %v", err)
+	}
+}
+
 func TestCompareTuttiReplayStateTreatsInteractionToolCallIDsAsAlphaEquivalent(
 	t *testing.T,
 ) {

--- a/packages/agent/store-sqlite/canonical/tool_output_alias.go
+++ b/packages/agent/store-sqlite/canonical/tool_output_alias.go
@@ -2,6 +2,14 @@ package canonical
 
 import "strings"
 
+type terminalCommandAliasMode uint8
+
+const (
+	terminalCommandAliasInspect terminalCommandAliasMode = iota
+	terminalCommandAliasDelete
+	terminalCommandAliasTombstone
+)
+
 var terminalCommandTokenReplacer = strings.NewReplacer(
 	"_", "",
 	"-", "",
@@ -11,69 +19,234 @@ var terminalCommandTokenReplacer = strings.NewReplacer(
 
 // CompactTerminalCommandOutputAliases removes only display text that is
 // exactly reconstructible from a terminal command's canonical stdout or
-// stderr. Running commands retain text because live tool-output deltas use it;
-// non-command tools retain text as their provider-neutral display contract.
-// The payload is mutated in place and the return value reports whether it
-// changed.
+// stderr. Running command bodies retain text because live tool-output deltas
+// use it; terminal nested steps are evaluated by their own status. Non-command
+// tools retain text as their provider-neutral display contract. The payload is
+// mutated in place and the return value reports whether it changed.
 func CompactTerminalCommandOutputAliases(
 	status string,
 	payload map[string]any,
 ) bool {
-	if !isTerminalToolStatus(status) || len(payload) == 0 {
-		return false
+	_, changed := transformTerminalCommandOutputAliases(
+		status,
+		payload,
+		terminalCommandAliasDelete,
+	)
+	return changed
+}
+
+// TombstoneTerminalCommandOutputAliases replaces reconstructible display text
+// with nil before a reporter truncates or merges the payload. The explicit nil
+// clears an earlier running output.text during the canonical deep merge; normal
+// compaction then removes the tombstone before persistence.
+func TombstoneTerminalCommandOutputAliases(
+	status string,
+	payload map[string]any,
+) bool {
+	_, changed := transformTerminalCommandOutputAliases(
+		status,
+		payload,
+		terminalCommandAliasTombstone,
+	)
+	return changed
+}
+
+// HasTerminalCommandOutput reports whether the payload contains a root or
+// nested command whose own effective status is terminal. It does not mutate
+// the payload.
+func HasTerminalCommandOutput(status string, payload map[string]any) bool {
+	found, _ := transformTerminalCommandOutputAliases(
+		status,
+		payload,
+		terminalCommandAliasInspect,
+	)
+	return found
+}
+
+func transformTerminalCommandOutputAliases(
+	status string,
+	payload map[string]any,
+	mode terminalCommandAliasMode,
+) (bool, bool) {
+	if len(payload) == 0 {
+		return false, false
 	}
 
+	found := false
 	changed := false
-	input, _ := payload["input"].(map[string]any)
-	if isTerminalCommandPayload(payload, input) {
-		changed = compactTerminalCommandBodyAlias(payload["output"]) || changed
-		changed = compactTerminalCommandBodyAlias(payload["error"]) || changed
+	input := firstToolMapReference(payload["input"])
+	if isTerminalToolStatus(status) && isTerminalCommandPayload(payload, input) {
+		found = true
+		changed = transformTerminalCommandBodyAlias(payload["output"], mode) || changed
+		changed = transformTerminalCommandBodyAlias(payload["error"], mode) || changed
 	}
 
-	steps, _ := payload["steps"].([]any)
+	for _, value := range []any{
+		payload["steps"],
+		toolMapValue(payload["output"], "steps"),
+		toolMapValue(payload["error"], "steps"),
+		toolMapValue(payload["metadata"], "steps"),
+	} {
+		stepFound, stepChanged := transformTerminalCommandSteps(status, value, mode)
+		found = stepFound || found
+		changed = stepChanged || changed
+	}
+	return found, changed
+}
+
+func transformTerminalCommandSteps(
+	parentStatus string,
+	value any,
+	mode terminalCommandAliasMode,
+) (bool, bool) {
+	steps, _ := value.([]any)
+	found := false
+	changed := false
 	for _, item := range steps {
 		step, _ := item.(map[string]any)
 		if len(step) == 0 {
 			continue
 		}
-		stepStatus := firstToolString(step["status"], status)
-		if !isTerminalToolStatus(stepStatus) {
-			continue
+		stepPayload := firstToolMapReference(step["payload"])
+		stepStatus := firstToolString(
+			step["status"],
+			toolMapValue(step["toolResult"], "status"),
+			toolMapValue(step["tool_result"], "status"),
+			toolMapValue(step["toolError"], "status"),
+			toolMapValue(step["tool_error"], "status"),
+			stepPayload["status"],
+			parentStatus,
+		)
+		stepInput := firstToolMapReference(
+			step["toolInput"],
+			step["tool_input"],
+			step["input"],
+			stepPayload["input"],
+		)
+		if isTerminalToolStatus(stepStatus) &&
+			isTerminalCommandPayloadPair(step, stepPayload, stepInput) {
+			found = true
+			for _, body := range []any{
+				step["toolResult"],
+				step["tool_result"],
+				step["toolError"],
+				step["tool_error"],
+				step["output"],
+				step["error"],
+				stepPayload["output"],
+				stepPayload["error"],
+			} {
+				changed = transformTerminalCommandBodyAlias(body, mode) || changed
+			}
 		}
-		stepInput, _ := step["toolInput"].(map[string]any)
-		if !isTerminalCommandPayload(step, stepInput) {
-			continue
+
+		for _, nested := range []any{
+			step["steps"],
+			toolMapValue(step["metadata"], "steps"),
+			toolMapValue(step["toolResult"], "steps"),
+			toolMapValue(step["tool_result"], "steps"),
+			toolMapValue(step["toolError"], "steps"),
+			toolMapValue(step["tool_error"], "steps"),
+			stepPayload["steps"],
+			toolMapValue(stepPayload["metadata"], "steps"),
+			toolMapValue(stepPayload["output"], "steps"),
+			toolMapValue(stepPayload["error"], "steps"),
+		} {
+			nestedFound, nestedChanged := transformTerminalCommandSteps(
+				stepStatus,
+				nested,
+				mode,
+			)
+			found = nestedFound || found
+			changed = nestedChanged || changed
 		}
-		changed = compactTerminalCommandBodyAlias(step["toolResult"]) || changed
-		changed = compactTerminalCommandBodyAlias(step["toolError"]) || changed
 	}
-	return changed
+	return found, changed
 }
 
 func isTerminalCommandPayload(payload, input map[string]any) bool {
-	metadata, _ := payload["metadata"].(map[string]any)
-	for _, value := range []any{
-		payload["toolName"],
-		payload["name"],
-		payload["activityKind"],
-		metadata["toolName"],
-		metadata["tool"],
-		metadata["kind"],
-	} {
-		token := strings.ToLower(toolString(value))
-		token = terminalCommandTokenReplacer.Replace(token)
-		switch token {
-		case "bash", "exec", "execcommand", "runcommand", "runshellcommand", "shell", "shellcommand", "terminal", "commandexecution", "executecommand":
-			return true
-		}
-	}
-	if input != nil && firstToolString(input["command"], input["cmd"]) != "" {
-		return true
-	}
-	return firstToolString(payload["command"]) != ""
+	return isTerminalCommandPayloadPair(payload, nil, input)
 }
 
-func compactTerminalCommandBodyAlias(value any) bool {
+func isTerminalCommandPayloadPair(
+	primary, fallback, input map[string]any,
+) bool {
+	for _, payload := range []map[string]any{primary, fallback} {
+		if command, present := explicitTerminalCommandIdentity(payload); present {
+			return command
+		}
+	}
+	for _, payload := range []map[string]any{primary, fallback} {
+		if hasExplicitNonCommandTransport(payload) {
+			return false
+		}
+	}
+	for _, payload := range []map[string]any{primary, fallback} {
+		metadata := firstToolMapReference(payload["metadata"])
+		for _, value := range []any{
+			payload["name"],
+			payload["activityKind"],
+			metadata["kind"],
+		} {
+			if isTerminalCommandToken(value) {
+				return true
+			}
+		}
+	}
+	if len(input) > 0 && firstToolString(input["command"], input["cmd"]) != "" {
+		return true
+	}
+	return firstToolString(primary["command"], fallback["command"]) != ""
+}
+
+func explicitTerminalCommandIdentity(payload map[string]any) (bool, bool) {
+	if len(payload) == 0 {
+		return false, false
+	}
+	metadata := firstToolMapReference(payload["metadata"])
+	for _, value := range []any{
+		payload["toolName"],
+		metadata["toolName"],
+		metadata["tool"],
+	} {
+		if firstToolString(value) == "" {
+			continue
+		}
+		return isTerminalCommandToken(value), true
+	}
+	return false, false
+}
+
+func hasExplicitNonCommandTransport(payload map[string]any) bool {
+	if len(payload) == 0 {
+		return false
+	}
+	if strings.EqualFold(firstToolString(payload["callType"]), "mcp") {
+		return true
+	}
+	metadata := firstToolMapReference(payload["metadata"])
+	return firstToolString(
+		metadata["server"],
+		metadata["serverName"],
+		metadata["mcpServer"],
+	) != ""
+}
+
+func isTerminalCommandToken(value any) bool {
+	token := strings.ToLower(toolString(value))
+	token = terminalCommandTokenReplacer.Replace(token)
+	switch token {
+	case "bash", "exec", "execcommand", "runcommand", "runshellcommand", "shell", "shellcommand", "terminal", "commandexecution", "executecommand":
+		return true
+	default:
+		return false
+	}
+}
+
+func transformTerminalCommandBodyAlias(
+	value any,
+	mode terminalCommandAliasMode,
+) bool {
 	body, _ := value.(map[string]any)
 	if body == nil {
 		return false
@@ -84,12 +257,42 @@ func compactTerminalCommandBodyAlias(value any) bool {
 	}
 	for _, key := range []string{"stdout", "stderr"} {
 		stream, ok := body[key].(string)
-		if ok && text == strings.TrimSpace(stream) {
-			delete(body, "text")
-			return true
+		if !ok || text != strings.TrimSpace(stream) {
+			continue
 		}
+		switch mode {
+		case terminalCommandAliasDelete:
+			delete(body, "text")
+		case terminalCommandAliasTombstone:
+			body["text"] = nil
+		}
+		return mode != terminalCommandAliasInspect
 	}
 	return false
+}
+
+func compactTerminalCommandBodyAlias(value any) bool {
+	return transformTerminalCommandBodyAlias(
+		value,
+		terminalCommandAliasDelete,
+	)
+}
+
+func firstToolMapReference(values ...any) map[string]any {
+	for _, value := range values {
+		if typed, ok := value.(map[string]any); ok && len(typed) > 0 {
+			return typed
+		}
+	}
+	return nil
+}
+
+func toolMapValue(value any, key string) any {
+	valueMap, _ := value.(map[string]any)
+	if valueMap == nil {
+		return nil
+	}
+	return valueMap[key]
 }
 
 func isTerminalToolStatus(status string) bool {

--- a/packages/agent/store-sqlite/canonical/tool_output_alias.go
+++ b/packages/agent/store-sqlite/canonical/tool_output_alias.go
@@ -1,0 +1,97 @@
+package canonical
+
+import "strings"
+
+var terminalCommandTokenReplacer = strings.NewReplacer(
+	"_", "",
+	"-", "",
+	" ", "",
+	".", "",
+)
+
+// CompactTerminalCommandOutputAliases removes only display text that is
+// exactly reconstructible from a terminal command's canonical stdout or
+// stderr. Running commands retain text because live tool-output deltas use it;
+// non-command tools retain text as their provider-neutral display contract.
+// The payload is mutated in place and the return value reports whether it
+// changed.
+func CompactTerminalCommandOutputAliases(
+	status string,
+	payload map[string]any,
+) bool {
+	if !isTerminalToolStatus(status) || len(payload) == 0 {
+		return false
+	}
+
+	changed := false
+	input, _ := payload["input"].(map[string]any)
+	if isTerminalCommandPayload(payload, input) {
+		changed = compactTerminalCommandBodyAlias(payload["output"]) || changed
+		changed = compactTerminalCommandBodyAlias(payload["error"]) || changed
+	}
+
+	steps, _ := payload["steps"].([]any)
+	for _, item := range steps {
+		step, _ := item.(map[string]any)
+		if len(step) == 0 {
+			continue
+		}
+		stepStatus := firstToolString(step["status"], status)
+		if !isTerminalToolStatus(stepStatus) {
+			continue
+		}
+		stepInput, _ := step["toolInput"].(map[string]any)
+		if !isTerminalCommandPayload(step, stepInput) {
+			continue
+		}
+		changed = compactTerminalCommandBodyAlias(step["toolResult"]) || changed
+		changed = compactTerminalCommandBodyAlias(step["toolError"]) || changed
+	}
+	return changed
+}
+
+func isTerminalCommandPayload(payload, input map[string]any) bool {
+	metadata, _ := payload["metadata"].(map[string]any)
+	for _, value := range []any{
+		payload["toolName"],
+		payload["name"],
+		payload["activityKind"],
+		metadata["toolName"],
+		metadata["tool"],
+		metadata["kind"],
+	} {
+		token := strings.ToLower(toolString(value))
+		token = terminalCommandTokenReplacer.Replace(token)
+		switch token {
+		case "bash", "exec", "execcommand", "runcommand", "runshellcommand", "shell", "shellcommand", "terminal", "commandexecution", "executecommand":
+			return true
+		}
+	}
+	if input != nil && firstToolString(input["command"], input["cmd"]) != "" {
+		return true
+	}
+	return firstToolString(payload["command"]) != ""
+}
+
+func compactTerminalCommandBodyAlias(value any) bool {
+	body, _ := value.(map[string]any)
+	if body == nil {
+		return false
+	}
+	text, ok := body["text"].(string)
+	if !ok {
+		return false
+	}
+	for _, key := range []string{"stdout", "stderr"} {
+		stream, ok := body[key].(string)
+		if ok && text == strings.TrimSpace(stream) {
+			delete(body, "text")
+			return true
+		}
+	}
+	return false
+}
+
+func isTerminalToolStatus(status string) bool {
+	return isCompletedToolStatus(status) || isFailedToolStatus(status)
+}

--- a/packages/agent/store-sqlite/canonical/tool_output_truncation.go
+++ b/packages/agent/store-sqlite/canonical/tool_output_truncation.go
@@ -1,6 +1,7 @@
 package canonical
 
 import (
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 )
@@ -8,6 +9,9 @@ import (
 const (
 	// ToolOutputTextMaxBytes is the per-field persisted and live projection bound.
 	ToolOutputTextMaxBytes = 1 << 20
+	// ToolCallPayloadMaxBytes leaves deterministic headroom below the 1 MiB
+	// replication request limit for mutation identity, scope, and batch framing.
+	ToolCallPayloadMaxBytes = 768 << 10
 	// ToolOutputTruncationMarker identifies a tool output prefix with omitted bytes.
 	ToolOutputTruncationMarker    = "[Output truncated]"
 	toolOutputTruncationSeparator = "\n"
@@ -18,16 +22,31 @@ var truncatedToolOutputTextKeys = [...]string{"text", "stdout", "stderr"}
 // TruncateToolOutputText bounds one canonical tool output field while
 // preserving a valid UTF-8 prefix and an explicit truncation marker.
 func TruncateToolOutputText(value string) string {
-	if len(value) <= ToolOutputTextMaxBytes {
+	return truncateToolOutputTextToBytes(value, ToolOutputTextMaxBytes)
+}
+
+func truncateToolOutputTextToBytes(value string, maxBytes int) string {
+	if maxBytes <= 0 {
+		return ""
+	}
+	if len(value) <= maxBytes {
 		return value
 	}
 
 	value = strings.ToValidUTF8(value, string(utf8.RuneError))
-	if len(value) <= ToolOutputTextMaxBytes {
+	if len(value) <= maxBytes {
 		return value
 	}
 
-	prefixLimit := ToolOutputTextMaxBytes -
+	if maxBytes <= len(ToolOutputTruncationMarker) {
+		marker := ToolOutputTruncationMarker
+		for len(marker) > maxBytes || !utf8.ValidString(marker) {
+			marker = marker[:len(marker)-1]
+		}
+		return marker
+	}
+
+	prefixLimit := maxBytes -
 		len(toolOutputTruncationSeparator) -
 		len(ToolOutputTruncationMarker)
 	for prefixLimit > 0 && !utf8.RuneStart(value[prefixLimit]) {
@@ -39,6 +58,151 @@ func TruncateToolOutputText(value string) string {
 		separator = ""
 	}
 	return prefix + separator + ToolOutputTruncationMarker
+}
+
+type toolOutputTextField struct {
+	body     map[string]any
+	key      string
+	original string
+}
+
+// FitToolCallPayloadOutputBudget bounds the encoded canonical tool payload by
+// fairly reducing only formal output/error text streams. It preserves inputs
+// and structured fields, emits the standard truncation marker, and reports
+// both whether a field changed and whether the final encoded payload fits.
+// A false fits result means non-textual payload data alone exceeds the budget.
+func FitToolCallPayloadOutputBudget(
+	payload map[string]any,
+	maxBytes int,
+) (bool, bool) {
+	if len(payload) == 0 || maxBytes <= 0 {
+		return false, len(payload) == 0
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return false, false
+	}
+	fields := collectToolOutputTextFields(payload)
+	if len(fields) == 0 {
+		return false, len(encoded) <= maxBytes
+	}
+
+	applyCap := func(capBytes int) {
+		for _, field := range fields {
+			field.body[field.key] = truncateToolOutputTextToBytes(
+				field.original,
+				capBytes,
+			)
+		}
+	}
+	encodedSize := func() (int, bool) {
+		value, marshalErr := json.Marshal(payload)
+		return len(value), marshalErr == nil
+	}
+	changed := func() bool {
+		for _, field := range fields {
+			if field.body[field.key] != field.original {
+				return true
+			}
+		}
+		return false
+	}
+
+	applyCap(ToolOutputTextMaxBytes)
+	if size, ok := encodedSize(); ok && size <= maxBytes {
+		return changed(), true
+	}
+
+	minimumCap := len(ToolOutputTruncationMarker)
+	applyCap(minimumCap)
+	if size, ok := encodedSize(); !ok || size > maxBytes {
+		for _, field := range fields {
+			field.body[field.key] = truncateToolOutputTextToBytes(
+				field.original,
+				ToolOutputTextMaxBytes,
+			)
+		}
+		return changed(), false
+	}
+
+	best := minimumCap
+	low, high := minimumCap+1, ToolOutputTextMaxBytes
+	for low <= high {
+		middle := low + (high-low)/2
+		applyCap(middle)
+		size, ok := encodedSize()
+		if ok && size <= maxBytes {
+			best = middle
+			low = middle + 1
+			continue
+		}
+		high = middle - 1
+	}
+	applyCap(best)
+	return changed(), true
+}
+
+func collectToolOutputTextFields(payload map[string]any) []toolOutputTextField {
+	fields := make([]toolOutputTextField, 0, 4)
+	var collectBody func(any)
+	var collectSteps func(any)
+
+	collectBody = func(value any) {
+		body, _ := value.(map[string]any)
+		if len(body) == 0 {
+			return
+		}
+		for _, key := range truncatedToolOutputTextKeys {
+			if text, ok := body[key].(string); ok {
+				fields = append(fields, toolOutputTextField{
+					body: body, key: key, original: text,
+				})
+			}
+		}
+		collectSteps(body["steps"])
+		if metadata, _ := body["metadata"].(map[string]any); metadata != nil {
+			collectSteps(metadata["steps"])
+		}
+	}
+	collectSteps = func(value any) {
+		steps, _ := value.([]any)
+		for _, item := range steps {
+			step, _ := item.(map[string]any)
+			if len(step) == 0 {
+				continue
+			}
+			for _, key := range []string{
+				"toolResult",
+				"tool_result",
+				"toolError",
+				"tool_error",
+				"output",
+				"error",
+			} {
+				collectBody(step[key])
+			}
+			collectSteps(step["steps"])
+			if metadata, _ := step["metadata"].(map[string]any); metadata != nil {
+				collectSteps(metadata["steps"])
+			}
+			if nested, _ := step["payload"].(map[string]any); nested != nil {
+				collectBody(nested["output"])
+				collectBody(nested["error"])
+				collectSteps(nested["steps"])
+				if metadata, _ := nested["metadata"].(map[string]any); metadata != nil {
+					collectSteps(metadata["steps"])
+				}
+			}
+		}
+	}
+
+	collectBody(payload["output"])
+	collectBody(payload["error"])
+	collectSteps(payload["steps"])
+	if metadata, _ := payload["metadata"].(map[string]any); metadata != nil {
+		collectSteps(metadata["steps"])
+	}
+	return fields
 }
 
 // TruncateToolOutputBody clones one canonical output/error body and applies

--- a/packages/agent/store-sqlite/canonical/tool_payload.go
+++ b/packages/agent/store-sqlite/canonical/tool_payload.go
@@ -192,6 +192,12 @@ func CompactToolCallPayload(status string, payload map[string]any) map[string]an
 		delete(result, "fileChanges")
 	}
 
+	// Compare aliases before per-field truncation can make equal source
+	// strings diverge at the byte boundary.
+	if isTerminalToolStatus(status) && isTerminalCommandPayload(result, input) {
+		compactTerminalCommandBodyAlias(output)
+		compactTerminalCommandBodyAlias(toolError)
+	}
 	if output != nil {
 		delete(output, "content")
 		output = TruncateToolOutputBody(selectToolKeys(output, canonicalToolBodyKeys))
@@ -223,9 +229,10 @@ func CompactToolCallPayload(status string, payload map[string]any) map[string]an
 		result["steps"] = steps
 	}
 
-	return selectToolKeys(result, canonicalToolPayloadKeys)
+	result = selectToolKeys(result, canonicalToolPayloadKeys)
+	CompactTerminalCommandOutputAliases(status, result)
+	return result
 }
-
 func compactToolSteps(value any) []any {
 	rawSteps, ok := value.([]any)
 	if !ok {
@@ -289,14 +296,20 @@ func compactToolSteps(value any) []any {
 		if len(input) > 0 {
 			step["toolInput"] = input
 		}
+		if len(metadata) > 0 {
+			step["metadata"] = metadata
+		}
+		if isTerminalToolStatus(status) && isTerminalCommandPayload(step, input) {
+			compactTerminalCommandBodyAlias(output)
+			compactTerminalCommandBodyAlias(toolError)
+		}
+		output = TruncateToolOutputBody(output)
+		toolError = TruncateToolOutputBody(toolError)
 		if len(output) > 0 {
 			step["toolResult"] = output
 		}
 		if len(toolError) > 0 && !isCompletedToolStatus(status) {
 			step["toolError"] = toolError
-		}
-		if len(metadata) > 0 {
-			step["metadata"] = metadata
 		}
 		if fileChanges := normalizeToolFileChanges(firstToolValue(rawStep["fileChanges"], payload["fileChanges"])); fileChanges != nil {
 			step["fileChanges"] = fileChanges
@@ -396,7 +409,7 @@ func compactToolBody(value any) map[string]any {
 	delete(body, "content")
 	delete(body, "metadata")
 	delete(body, "toolResponse")
-	return TruncateToolOutputBody(selectToolKeys(body, canonicalToolBodyKeys))
+	return selectToolKeys(body, canonicalToolBodyKeys)
 }
 
 func compactToolMetadata(value any) map[string]any {

--- a/packages/agent/store-sqlite/canonical/tool_payload.go
+++ b/packages/agent/store-sqlite/canonical/tool_payload.go
@@ -231,8 +231,10 @@ func CompactToolCallPayload(status string, payload map[string]any) map[string]an
 
 	result = selectToolKeys(result, canonicalToolPayloadKeys)
 	CompactTerminalCommandOutputAliases(status, result)
+	FitToolCallPayloadOutputBudget(result, ToolCallPayloadMaxBytes)
 	return result
 }
+
 func compactToolSteps(value any) []any {
 	rawSteps, ok := value.([]any)
 	if !ok {

--- a/packages/agent/store-sqlite/canonical/tool_payload_test.go
+++ b/packages/agent/store-sqlite/canonical/tool_payload_test.go
@@ -1,6 +1,7 @@
 package canonical
 
 import (
+	"encoding/json"
 	"reflect"
 	"strings"
 	"testing"
@@ -437,7 +438,8 @@ func TestCompactToolCallPayloadRetainsTextOutsideTerminalCommandAlias(t *testing
 			name:   "non-command tool",
 			status: "completed",
 			payload: map[string]any{
-				"toolName": "AskUserQuestion",
+				"toolName": "Edit",
+				"input":    map[string]any{"command": "domain command"},
 				"output":   map[string]any{"text": "same output", "stdout": "same output\n"},
 			},
 		},
@@ -460,6 +462,98 @@ func TestCompactToolCallPayloadRetainsTextOutsideTerminalCommandAlias(t *testing
 				t.Fatalf("output.text removed: %#v", output)
 			}
 		})
+	}
+}
+
+func TestCompactTerminalCommandOutputAliasesUsesNestedStepStatusRecursively(
+	t *testing.T,
+) {
+	payload := map[string]any{
+		"toolName": "Task",
+		"output": map[string]any{
+			"text":   "running task output",
+			"stdout": "running task output\n",
+		},
+		"steps": []any{
+			map[string]any{
+				"toolName": "Bash",
+				"status":   "completed",
+				"toolInput": map[string]any{
+					"command": "printf direct",
+				},
+				"toolResult": map[string]any{
+					"text":   "direct output",
+					"stdout": "direct output\n",
+				},
+			},
+			map[string]any{
+				"toolName": "Task",
+				"status":   "running",
+				"toolResult": map[string]any{
+					"steps": []any{map[string]any{
+						"toolName": "Bash",
+						"status":   "failed",
+						"toolInput": map[string]any{
+							"command": "printf nested",
+						},
+						"toolError": map[string]any{
+							"text":   "nested failure",
+							"stderr": "nested failure\n",
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	if !CompactTerminalCommandOutputAliases("running", payload) {
+		t.Fatal("completed nested command aliases were not compacted")
+	}
+	rootOutput := payload["output"].(map[string]any)
+	if rootOutput["text"] == nil {
+		t.Fatalf("running root text was removed: %#v", rootOutput)
+	}
+	steps := payload["steps"].([]any)
+	direct := steps[0].(map[string]any)["toolResult"].(map[string]any)
+	if _, exists := direct["text"]; exists {
+		t.Fatalf("direct completed step retained text alias: %#v", direct)
+	}
+	nested := steps[1].(map[string]any)["toolResult"].(map[string]any)["steps"].([]any)[0].(map[string]any)["toolError"].(map[string]any)
+	if _, exists := nested["text"]; exists {
+		t.Fatalf("recursive failed step retained text alias: %#v", nested)
+	}
+}
+
+func TestCompactToolCallPayloadFitsAggregateOutputBudget(t *testing.T) {
+	largeText := strings.Repeat("t", ToolCallPayloadMaxBytes)
+	largeStream := strings.Repeat("s", ToolCallPayloadMaxBytes) + "\n"
+	input := strings.Repeat("i", 1024)
+	got := CompactToolCallPayload("completed", map[string]any{
+		"toolName": "McpResult",
+		"callType": "mcp",
+		"input":    map[string]any{"query": input},
+		"output": map[string]any{
+			"text":   largeText,
+			"stdout": largeStream,
+		},
+	})
+
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(encoded) > ToolCallPayloadMaxBytes {
+		t.Fatalf("encoded payload has %d bytes, limit is %d", len(encoded), ToolCallPayloadMaxBytes)
+	}
+	if got["input"].(map[string]any)["query"] != input {
+		t.Fatal("aggregate output budget changed tool input")
+	}
+	output := got["output"].(map[string]any)
+	for _, key := range []string{"text", "stdout"} {
+		value := output[key].(string)
+		if !strings.HasSuffix(value, ToolOutputTruncationMarker) {
+			t.Fatalf("output.%s does not carry truncation marker", key)
+		}
 	}
 }
 

--- a/packages/agent/store-sqlite/canonical/tool_payload_test.go
+++ b/packages/agent/store-sqlite/canonical/tool_payload_test.go
@@ -2,6 +2,7 @@ package canonical
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -353,6 +354,138 @@ func TestCompactToolCallPayloadRetainsFormalTextAndStreamFields(t *testing.T) {
 		if output[key] != "same output" {
 			t.Fatalf("output.%s = %#v, want formal field retained", key, output[key])
 		}
+	}
+}
+
+func TestCompactToolCallPayloadOmitsReconstructibleTerminalCommandText(t *testing.T) {
+	got := CompactToolCallPayload("completed", map[string]any{
+		"callId":   "call-1",
+		"toolName": "Bash",
+		"input": map[string]any{
+			"command": "printf output",
+		},
+		"output": map[string]any{
+			"text":   "same output",
+			"stdout": "same output\n",
+			"stderr": "warning\n",
+		},
+	})
+
+	output := got["output"].(map[string]any)
+	if _, exists := output["text"]; exists {
+		t.Fatalf("output.text retained reconstructible command alias: %#v", output)
+	}
+	if output["stdout"] != "same output\n" || output["stderr"] != "warning\n" {
+		t.Fatalf("output = %#v, want raw streams retained", output)
+	}
+}
+
+func TestCompactToolCallPayloadOmitsReconstructibleTerminalCommandErrorText(t *testing.T) {
+	got := CompactToolCallPayload("failed", map[string]any{
+		"toolName": "shell_command",
+		"input":    map[string]any{"command": "exit 1"},
+		"error": map[string]any{
+			"text":   "command failed",
+			"stderr": "command failed\n",
+		},
+	})
+
+	errorBody := got["error"].(map[string]any)
+	if _, exists := errorBody["text"]; exists {
+		t.Fatalf("error.text retained reconstructible command alias: %#v", errorBody)
+	}
+	if errorBody["stderr"] != "command failed\n" {
+		t.Fatalf("error = %#v, want raw stderr retained", errorBody)
+	}
+}
+
+func TestCompactToolCallPayloadCompactsTerminalAliasBeforeStreamTruncation(t *testing.T) {
+	text := strings.Repeat("x", ToolOutputTextMaxBytes)
+	got := CompactToolCallPayload("completed", map[string]any{
+		"toolName": "Bash",
+		"input":    map[string]any{"command": "print output"},
+		"output":   map[string]any{"text": text, "stdout": text + "\n"},
+	})
+
+	output := got["output"].(map[string]any)
+	if _, exists := output["text"]; exists {
+		t.Fatalf("output.text retained alias across truncation boundary")
+	}
+	stdout := output["stdout"].(string)
+	marked := strings.HasSuffix(stdout, ToolOutputTruncationMarker)
+	if len(stdout) > ToolOutputTextMaxBytes || !marked {
+		t.Fatalf("stdout has %d bytes and truncation marker %t, want bounded marked stream", len(stdout), marked)
+	}
+}
+
+func TestCompactToolCallPayloadRetainsTextOutsideTerminalCommandAlias(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  string
+		payload map[string]any
+	}{
+		{
+			name:   "running command",
+			status: "running",
+			payload: map[string]any{
+				"toolName": "Bash",
+				"input":    map[string]any{"command": "printf output"},
+				"output":   map[string]any{"text": "same output", "stdout": "same output\n"},
+			},
+		},
+		{
+			name:   "non-command tool",
+			status: "completed",
+			payload: map[string]any{
+				"toolName": "AskUserQuestion",
+				"output":   map[string]any{"text": "same output", "stdout": "same output\n"},
+			},
+		},
+		{
+			name:   "distinct command display text",
+			status: "completed",
+			payload: map[string]any{
+				"toolName": "exec_command",
+				"input":    map[string]any{"cmd": "printf raw"},
+				"output":   map[string]any{"text": "formatted output", "stdout": "raw output\n"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := CompactToolCallPayload(test.status, test.payload)
+			output := got["output"].(map[string]any)
+			if output["text"] == nil {
+				t.Fatalf("output.text removed: %#v", output)
+			}
+		})
+	}
+}
+
+func TestCompactToolCallPayloadOmitsNestedTerminalCommandTextAlias(t *testing.T) {
+	got := CompactToolCallPayload("completed", map[string]any{
+		"toolName": "Task",
+		"steps": []any{map[string]any{
+			"toolName": "Bash",
+			"status":   "completed",
+			"toolInput": map[string]any{
+				"command": "printf nested",
+			},
+			"toolResult": map[string]any{
+				"text":   "nested output",
+				"stdout": "nested output\n",
+			},
+		}},
+	})
+
+	step := got["steps"].([]any)[0].(map[string]any)
+	output := step["toolResult"].(map[string]any)
+	if _, exists := output["text"]; exists {
+		t.Fatalf("nested output.text retained reconstructible alias: %#v", output)
+	}
+	if output["stdout"] != "nested output\n" {
+		t.Fatalf("nested output = %#v, want raw stdout retained", output)
 	}
 }
 

--- a/packages/agent/store-sqlite/migrations.go
+++ b/packages/agent/store-sqlite/migrations.go
@@ -85,6 +85,7 @@ const schemaMigrationWorkspaceAgentProviderCheckpointV1 = "workspace_agent_provi
 const schemaMigrationWorkspaceAgentProviderTurnBindingJSONV1 = "workspace_agent_provider_turn_binding_json_v1"
 const schemaMigrationWorkspaceAgentRecoverableDeletionV1 = "workspace_agent_recoverable_deletion_v1"
 const schemaMigrationWorkspaceAgentTurnIdentityAnchorV1 = "workspace_agent_turn_identity_anchor_v1"
+const schemaMigrationWorkspaceAgentCommandOutputAliasesV1 = "workspace_agent_command_output_aliases_v1"
 
 // claimableMigrationIDs are the migration IDs that may already be recorded
 // in the legacy tuttid ledger; the claim copies exactly these.
@@ -312,7 +313,10 @@ CREATE TABLE IF NOT EXISTS `+schemaMigrationsTable+` (
 	if err := s.applyWorkspaceAgentRecoverableDeletionV1(ctx); err != nil {
 		return err
 	}
-	return s.applyWorkspaceAgentTurnIdentityAnchorV1(ctx)
+	if err := s.applyWorkspaceAgentTurnIdentityAnchorV1(ctx); err != nil {
+		return err
+	}
+	return s.applyWorkspaceAgentCommandOutputAliasesV1(ctx)
 }
 
 // claimLegacyMigrations copies agent-store migration records that were

--- a/packages/agent/store-sqlite/migrations_command_output_aliases.go
+++ b/packages/agent/store-sqlite/migrations_command_output_aliases.go
@@ -1,0 +1,157 @@
+package storesqlite
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
+)
+
+type historicalCommandOutputAlias struct {
+	id          int64
+	status      string
+	payloadJSON string
+}
+
+const workspaceAgentCommandOutputAliasPayloadThresholdBytes = 1 << 20
+
+// applyWorkspaceAgentCommandOutputAliasesV1 heals only oversized active
+// terminal command messages whose display text is exactly reconstructible
+// from stdout or stderr. Versions and timestamps stay unchanged so this is a
+// physical representation repair, not a new logical activity event.
+func (s *Store) applyWorkspaceAgentCommandOutputAliasesV1(
+	ctx context.Context,
+) error {
+	const migrationID = schemaMigrationWorkspaceAgentCommandOutputAliasesV1
+	applied, err := s.hasMigration(ctx, migrationID)
+	if err != nil || applied {
+		return err
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin workspace agent command output alias migration: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	const candidatePageSize = 8
+	lastID := int64(0)
+	for {
+		rows, err := tx.QueryContext(ctx, `
+SELECT message.id, message.status, message.payload_json
+FROM workspace_agent_messages AS message
+JOIN workspace_agent_sessions AS session
+  ON session.workspace_id = message.workspace_id
+ AND session.agent_session_id = message.agent_session_id
+WHERE message.id > ?
+  AND message.deleted_at_unix_ms = 0
+  AND session.deleted_at_unix_ms = 0
+  AND message.kind = 'tool_call'
+  AND message.status IN ('completed', 'failed', 'errored', 'canceled')
+  AND length(CAST(message.payload_json AS BLOB)) > ?
+  AND (
+    (json_type(message.payload_json, '$.output.text') = 'text' AND
+      (json_type(message.payload_json, '$.output.stdout') = 'text' OR
+       json_type(message.payload_json, '$.output.stderr') = 'text'))
+    OR
+    (json_type(message.payload_json, '$.error.text') = 'text' AND
+      (json_type(message.payload_json, '$.error.stdout') = 'text' OR
+       json_type(message.payload_json, '$.error.stderr') = 'text'))
+    OR json_type(message.payload_json, '$.steps') = 'array'
+  )
+ORDER BY message.id
+LIMIT ?
+`, lastID, workspaceAgentCommandOutputAliasPayloadThresholdBytes, candidatePageSize)
+		if err != nil {
+			return fmt.Errorf("select oversized workspace agent command output aliases: %w", err)
+		}
+		candidates := make([]historicalCommandOutputAlias, 0, candidatePageSize)
+		for rows.Next() {
+			var candidate historicalCommandOutputAlias
+			if err := rows.Scan(
+				&candidate.id,
+				&candidate.status,
+				&candidate.payloadJSON,
+			); err != nil {
+				_ = rows.Close()
+				return fmt.Errorf("scan workspace agent command output alias: %w", err)
+			}
+			candidates = append(candidates, candidate)
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("iterate workspace agent command output aliases: %w", err)
+		}
+		if err := rows.Close(); err != nil {
+			return fmt.Errorf("close workspace agent command output aliases: %w", err)
+		}
+		if len(candidates) == 0 {
+			break
+		}
+		lastID = candidates[len(candidates)-1].id
+
+		for _, candidate := range candidates {
+			var payload map[string]any
+			decoder := json.NewDecoder(strings.NewReader(candidate.payloadJSON))
+			decoder.UseNumber()
+			if err := decoder.Decode(&payload); err != nil {
+				return fmt.Errorf(
+					"decode workspace agent command output alias row %d: %w",
+					candidate.id,
+					err,
+				)
+			}
+			if !canonical.CompactTerminalCommandOutputAliases(
+				candidate.status,
+				payload,
+			) {
+				continue
+			}
+			compactedJSON, err := json.Marshal(payload)
+			if err != nil {
+				return fmt.Errorf(
+					"encode workspace agent command output alias row %d: %w",
+					candidate.id,
+					err,
+				)
+			}
+			result, err := tx.ExecContext(ctx, `
+UPDATE workspace_agent_messages
+SET payload_json = ?
+WHERE id = ? AND payload_json = ?
+`, string(compactedJSON), candidate.id, candidate.payloadJSON)
+			if err != nil {
+				return fmt.Errorf(
+					"compact workspace agent command output alias row %d: %w",
+					candidate.id,
+					err,
+				)
+			}
+			updated, err := result.RowsAffected()
+			if err != nil {
+				return fmt.Errorf(
+					"read workspace agent command output alias update %d: %w",
+					candidate.id,
+					err,
+				)
+			}
+			if updated != 1 {
+				return fmt.Errorf(
+					"compact workspace agent command output alias row %d: updated %d rows",
+					candidate.id,
+					updated,
+				)
+			}
+		}
+	}
+
+	if err := recordMigrationTx(ctx, tx, migrationID); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit workspace agent command output alias migration: %w", err)
+	}
+	return nil
+}

--- a/packages/agent/store-sqlite/migrations_command_output_aliases.go
+++ b/packages/agent/store-sqlite/migrations_command_output_aliases.go
@@ -15,11 +15,12 @@ type historicalCommandOutputAlias struct {
 	payloadJSON string
 }
 
-const workspaceAgentCommandOutputAliasPayloadThresholdBytes = 1 << 20
+const workspaceAgentCommandOutputAliasPayloadThresholdBytes = canonical.ToolCallPayloadMaxBytes
 
-// applyWorkspaceAgentCommandOutputAliasesV1 heals only oversized active
-// terminal command messages whose display text is exactly reconstructible
-// from stdout or stderr. Versions and timestamps stay unchanged so this is a
+// applyWorkspaceAgentCommandOutputAliasesV1 heals retained command messages
+// whose payload exceeds the canonical replication-safe budget. Exact display
+// aliases are removed; independently truncated legacy streams receive the same
+// aggregate output budget. Versions and timestamps stay unchanged so this is a
 // physical representation repair, not a new logical activity event.
 func (s *Store) applyWorkspaceAgentCommandOutputAliasesV1(
 	ctx context.Context,
@@ -42,24 +43,20 @@ func (s *Store) applyWorkspaceAgentCommandOutputAliasesV1(
 		rows, err := tx.QueryContext(ctx, `
 SELECT message.id, message.status, message.payload_json
 FROM workspace_agent_messages AS message
-JOIN workspace_agent_sessions AS session
-  ON session.workspace_id = message.workspace_id
- AND session.agent_session_id = message.agent_session_id
 WHERE message.id > ?
-  AND message.deleted_at_unix_ms = 0
-  AND session.deleted_at_unix_ms = 0
   AND message.kind = 'tool_call'
-  AND message.status IN ('completed', 'failed', 'errored', 'canceled')
   AND length(CAST(message.payload_json AS BLOB)) > ?
   AND (
-    (json_type(message.payload_json, '$.output.text') = 'text' AND
-      (json_type(message.payload_json, '$.output.stdout') = 'text' OR
-       json_type(message.payload_json, '$.output.stderr') = 'text'))
-    OR
-    (json_type(message.payload_json, '$.error.text') = 'text' AND
-      (json_type(message.payload_json, '$.error.stdout') = 'text' OR
-       json_type(message.payload_json, '$.error.stderr') = 'text'))
+    json_type(message.payload_json, '$.output.text') = 'text'
+    OR json_type(message.payload_json, '$.output.stdout') = 'text'
+    OR json_type(message.payload_json, '$.output.stderr') = 'text'
+    OR json_type(message.payload_json, '$.error.text') = 'text'
+    OR json_type(message.payload_json, '$.error.stdout') = 'text'
+    OR json_type(message.payload_json, '$.error.stderr') = 'text'
     OR json_type(message.payload_json, '$.steps') = 'array'
+    OR json_type(message.payload_json, '$.output.steps') = 'array'
+    OR json_type(message.payload_json, '$.error.steps') = 'array'
+    OR json_type(message.payload_json, '$.metadata.steps') = 'array'
   )
 ORDER BY message.id
 LIMIT ?
@@ -103,10 +100,21 @@ LIMIT ?
 					err,
 				)
 			}
-			if !canonical.CompactTerminalCommandOutputAliases(
+			if !canonical.HasTerminalCommandOutput(
 				candidate.status,
 				payload,
 			) {
+				continue
+			}
+			aliasChanged := canonical.CompactTerminalCommandOutputAliases(
+				candidate.status,
+				payload,
+			)
+			budgetChanged, fits := canonical.FitToolCallPayloadOutputBudget(
+				payload,
+				canonical.ToolCallPayloadMaxBytes,
+			)
+			if !fits || (!aliasChanged && !budgetChanged) {
 				continue
 			}
 			compactedJSON, err := json.Marshal(payload)

--- a/packages/agent/store-sqlite/migrations_command_output_aliases_test.go
+++ b/packages/agent/store-sqlite/migrations_command_output_aliases_test.go
@@ -26,11 +26,25 @@ func TestCommandOutputAliasMigrationCompactsOnlyOversizedTerminalCommands(
 	}
 
 	large := strings.Repeat("x", canonical.ToolOutputTextMaxBytes/2+256)
+	nearWireLimit := strings.Repeat(
+		"n",
+		canonical.ToolCallPayloadMaxBytes/2+2048,
+	)
+	legacyRaw := "  " + strings.Repeat(
+		"p",
+		canonical.ToolOutputTextMaxBytes+64,
+	) + "\n"
+	legacyText := canonical.TruncateToolOutputText(strings.TrimSpace(legacyRaw))
+	legacyStdout := canonical.TruncateToolOutputText(legacyRaw)
+	if legacyText == strings.TrimSpace(legacyStdout) {
+		t.Fatal("legacy independently truncated fixture still compares as alias")
+	}
 	tests := []struct {
-		messageID string
-		status    string
-		payload   map[string]any
-		wantText  bool
+		messageID    string
+		status       string
+		payload      map[string]any
+		wantText     bool
+		wantBudgeted bool
 	}{
 		{
 			messageID: "oversized-terminal-alias",
@@ -41,7 +55,36 @@ func TestCommandOutputAliasMigrationCompactsOnlyOversizedTerminalCommands(
 				"output":   map[string]any{"text": large, "stdout": large + "\n"},
 				"seq":      json.Number("9007199254740993"),
 			},
-			wantText: false,
+			wantText:     false,
+			wantBudgeted: true,
+		},
+		{
+			messageID: "below-wire-limit-terminal-alias",
+			status:    "completed",
+			payload: map[string]any{
+				"toolName": "Bash",
+				"input":    map[string]any{"command": "print output"},
+				"output": map[string]any{
+					"text":   nearWireLimit,
+					"stdout": nearWireLimit + "\n",
+				},
+			},
+			wantText:     false,
+			wantBudgeted: true,
+		},
+		{
+			messageID: "independently-truncated-terminal-output",
+			status:    "completed",
+			payload: map[string]any{
+				"toolName": "Bash",
+				"input":    map[string]any{"command": "print output"},
+				"output": map[string]any{
+					"text":   legacyText,
+					"stdout": legacyStdout,
+				},
+			},
+			wantText:     true,
+			wantBudgeted: true,
 		},
 		{
 			messageID: "small-terminal-alias",
@@ -57,7 +100,8 @@ func TestCommandOutputAliasMigrationCompactsOnlyOversizedTerminalCommands(
 			messageID: "oversized-non-command",
 			status:    "completed",
 			payload: map[string]any{
-				"toolName": "AskUserQuestion",
+				"toolName": "Edit",
+				"input":    map[string]any{"command": "domain command"},
 				"output":   map[string]any{"text": large, "stdout": large + "\n"},
 			},
 			wantText: true,
@@ -83,7 +127,35 @@ func TestCommandOutputAliasMigrationCompactsOnlyOversizedTerminalCommands(
 					"stdout": large + "\n",
 				},
 			},
-			wantText: true,
+			wantText:     true,
+			wantBudgeted: true,
+		},
+		{
+			messageID: "running-task-recursive-terminal-step",
+			status:    "running",
+			payload: map[string]any{
+				"toolName": "Task",
+				"output":   map[string]any{"text": "task running"},
+				"steps": []any{map[string]any{
+					"toolName": "Task",
+					"status":   "running",
+					"toolResult": map[string]any{
+						"steps": []any{map[string]any{
+							"toolName": "Bash",
+							"status":   "completed",
+							"toolInput": map[string]any{
+								"command": "print nested output",
+							},
+							"toolResult": map[string]any{
+								"text":   large,
+								"stdout": large + "\n",
+							},
+						}},
+					},
+				}},
+			},
+			wantText:     true,
+			wantBudgeted: true,
 		},
 	}
 
@@ -102,6 +174,20 @@ INSERT INTO workspace_agent_messages (
 			test.status, string(payloadJSON)); err != nil {
 			t.Fatalf("insert %s: %v", test.messageID, err)
 		}
+	}
+	if _, err := store.db.ExecContext(ctx, `
+UPDATE workspace_agent_sessions
+SET deleted_at_unix_ms = 99
+WHERE workspace_id = ? AND agent_session_id = ?
+`, "ws-command-alias", "session-command-alias"); err != nil {
+		t.Fatalf("mark fixture session deleted: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `
+UPDATE workspace_agent_messages
+SET deleted_at_unix_ms = 99
+WHERE workspace_id = ? AND agent_session_id = ? AND message_id = ?
+`, "ws-command-alias", "session-command-alias", "oversized-terminal-alias"); err != nil {
+		t.Fatalf("mark fixture message deleted: %v", err)
 	}
 
 	if _, err := store.db.ExecContext(ctx, `
@@ -145,12 +231,35 @@ WHERE workspace_id = ? AND agent_session_id = ? AND message_id = ?
 		if hasText != test.wantText {
 			t.Fatalf("%s output = %#v, want text present %t", test.messageID, output, test.wantText)
 		}
+		if test.wantBudgeted && len(payloadJSON) > canonical.ToolCallPayloadMaxBytes {
+			t.Fatalf(
+				"%s payload has %d bytes, safe budget is %d",
+				test.messageID,
+				len(payloadJSON),
+				canonical.ToolCallPayloadMaxBytes,
+			)
+		}
 		if test.messageID == "oversized-terminal-alias" &&
 			!strings.Contains(payloadJSON, `"seq":9007199254740993`) {
 			t.Fatalf("%s lost exact JSON integer: %s", test.messageID, payloadJSON[:128])
 		}
 		if test.messageID == "oversized-terminal-alias" && output["stdout"] != large+"\n" {
 			t.Fatal("oversized terminal alias migration changed raw stdout")
+		}
+		if test.messageID == "independently-truncated-terminal-output" {
+			for _, key := range []string{"text", "stdout"} {
+				value := output[key].(string)
+				if !strings.HasSuffix(value, canonical.ToolOutputTruncationMarker) {
+					t.Fatalf("legacy output.%s lost truncation marker", key)
+				}
+			}
+		}
+		if test.messageID == "running-task-recursive-terminal-step" {
+			steps := payload["steps"].([]any)
+			nested := steps[0].(map[string]any)["toolResult"].(map[string]any)["steps"].([]any)[0].(map[string]any)["toolResult"].(map[string]any)
+			if _, exists := nested["text"]; exists {
+				t.Fatalf("recursive completed step retained text alias: %#v", nested)
+			}
 		}
 		if version != index+1 || occurredAt != 101 || startedAt != 102 ||
 			completedAt != 103 || createdAt != 104 || updatedAt != 105 {
@@ -173,8 +282,8 @@ SELECT payload_json FROM workspace_agent_messages WHERE message_id = ?
 `, "oversized-terminal-alias").Scan(&compactedJSON); err != nil {
 		t.Fatalf("read compacted payload: %v", err)
 	}
-	if len(compactedJSON) >= canonical.ToolOutputTextMaxBytes {
-		t.Fatalf("compacted payload has %d bytes, want below %d", len(compactedJSON), canonical.ToolOutputTextMaxBytes)
+	if len(compactedJSON) > canonical.ToolCallPayloadMaxBytes {
+		t.Fatalf("compacted payload has %d bytes, want at most %d", len(compactedJSON), canonical.ToolCallPayloadMaxBytes)
 	}
 	if err := store.Migrate(ctx); err != nil {
 		t.Fatalf("repeat command output alias migration: %v", err)

--- a/packages/agent/store-sqlite/migrations_command_output_aliases_test.go
+++ b/packages/agent/store-sqlite/migrations_command_output_aliases_test.go
@@ -1,0 +1,191 @@
+package storesqlite
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
+)
+
+func TestCommandOutputAliasMigrationCompactsOnlyOversizedTerminalCommands(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	ctx := context.Background()
+	if _, err := store.ReportSessionState(ctx, SessionStateReport{
+		WorkspaceID:      "ws-command-alias",
+		AgentSessionID:   "session-command-alias",
+		Provider:         "codex",
+		OccurredAtUnixMS: 10,
+	}); err != nil {
+		t.Fatalf("ReportSessionState() error = %v", err)
+	}
+
+	large := strings.Repeat("x", canonical.ToolOutputTextMaxBytes/2+256)
+	tests := []struct {
+		messageID string
+		status    string
+		payload   map[string]any
+		wantText  bool
+	}{
+		{
+			messageID: "oversized-terminal-alias",
+			status:    "completed",
+			payload: map[string]any{
+				"toolName": "Bash",
+				"input":    map[string]any{"command": "print output"},
+				"output":   map[string]any{"text": large, "stdout": large + "\n"},
+				"seq":      json.Number("9007199254740993"),
+			},
+			wantText: false,
+		},
+		{
+			messageID: "small-terminal-alias",
+			status:    "completed",
+			payload: map[string]any{
+				"toolName": "Bash",
+				"input":    map[string]any{"command": "print output"},
+				"output":   map[string]any{"text": "small", "stdout": "small\n"},
+			},
+			wantText: true,
+		},
+		{
+			messageID: "oversized-non-command",
+			status:    "completed",
+			payload: map[string]any{
+				"toolName": "AskUserQuestion",
+				"output":   map[string]any{"text": large, "stdout": large + "\n"},
+			},
+			wantText: true,
+		},
+		{
+			messageID: "oversized-running-command",
+			status:    "running",
+			payload: map[string]any{
+				"toolName": "exec_command",
+				"input":    map[string]any{"cmd": "print output"},
+				"output":   map[string]any{"text": large, "stdout": large + "\n"},
+			},
+			wantText: true,
+		},
+		{
+			messageID: "oversized-distinct-command-text",
+			status:    "completed",
+			payload: map[string]any{
+				"toolName": "Bash",
+				"input":    map[string]any{"command": "print output"},
+				"output": map[string]any{
+					"text":   strings.Repeat("y", len(large)),
+					"stdout": large + "\n",
+				},
+			},
+			wantText: true,
+		},
+	}
+
+	for index, test := range tests {
+		payloadJSON, err := json.Marshal(test.payload)
+		if err != nil {
+			t.Fatalf("marshal %s payload: %v", test.messageID, err)
+		}
+		if _, err := store.db.ExecContext(ctx, `
+INSERT INTO workspace_agent_messages (
+  workspace_id, agent_session_id, message_id, version, role, kind, status,
+  payload_json, occurred_at_unix_ms, started_at_unix_ms, completed_at_unix_ms,
+  created_at_unix_ms, updated_at_unix_ms
+) VALUES (?, ?, ?, ?, 'assistant', 'tool_call', ?, ?, 101, 102, 103, 104, 105)
+`, "ws-command-alias", "session-command-alias", test.messageID, index+1,
+			test.status, string(payloadJSON)); err != nil {
+			t.Fatalf("insert %s: %v", test.messageID, err)
+		}
+	}
+
+	if _, err := store.db.ExecContext(ctx, `
+DELETE FROM agent_store_schema_migrations WHERE id = ?
+`, schemaMigrationWorkspaceAgentCommandOutputAliasesV1); err != nil {
+		t.Fatalf("reset command output alias migration marker: %v", err)
+	}
+	if err := store.Migrate(ctx); err != nil {
+		t.Fatalf("rerun command output alias migration: %v", err)
+	}
+
+	for index, test := range tests {
+		var (
+			payloadJSON                        string
+			version                            int
+			occurredAt, startedAt, completedAt int64
+			createdAt, updatedAt               int64
+		)
+		if err := store.db.QueryRowContext(ctx, `
+SELECT payload_json, version, occurred_at_unix_ms, started_at_unix_ms,
+       completed_at_unix_ms, created_at_unix_ms, updated_at_unix_ms
+FROM workspace_agent_messages
+WHERE workspace_id = ? AND agent_session_id = ? AND message_id = ?
+`, "ws-command-alias", "session-command-alias", test.messageID).Scan(
+			&payloadJSON,
+			&version,
+			&occurredAt,
+			&startedAt,
+			&completedAt,
+			&createdAt,
+			&updatedAt,
+		); err != nil {
+			t.Fatalf("read %s: %v", test.messageID, err)
+		}
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
+			t.Fatalf("decode %s: %v", test.messageID, err)
+		}
+		output := payload["output"].(map[string]any)
+		_, hasText := output["text"]
+		if hasText != test.wantText {
+			t.Fatalf("%s output = %#v, want text present %t", test.messageID, output, test.wantText)
+		}
+		if test.messageID == "oversized-terminal-alias" &&
+			!strings.Contains(payloadJSON, `"seq":9007199254740993`) {
+			t.Fatalf("%s lost exact JSON integer: %s", test.messageID, payloadJSON[:128])
+		}
+		if test.messageID == "oversized-terminal-alias" && output["stdout"] != large+"\n" {
+			t.Fatal("oversized terminal alias migration changed raw stdout")
+		}
+		if version != index+1 || occurredAt != 101 || startedAt != 102 ||
+			completedAt != 103 || createdAt != 104 || updatedAt != 105 {
+			t.Fatalf(
+				"%s metadata changed: version=%d times=%d/%d/%d/%d/%d",
+				test.messageID,
+				version,
+				occurredAt,
+				startedAt,
+				completedAt,
+				createdAt,
+				updatedAt,
+			)
+		}
+	}
+
+	var compactedJSON string
+	if err := store.db.QueryRowContext(ctx, `
+SELECT payload_json FROM workspace_agent_messages WHERE message_id = ?
+`, "oversized-terminal-alias").Scan(&compactedJSON); err != nil {
+		t.Fatalf("read compacted payload: %v", err)
+	}
+	if len(compactedJSON) >= canonical.ToolOutputTextMaxBytes {
+		t.Fatalf("compacted payload has %d bytes, want below %d", len(compactedJSON), canonical.ToolOutputTextMaxBytes)
+	}
+	if err := store.Migrate(ctx); err != nil {
+		t.Fatalf("repeat command output alias migration: %v", err)
+	}
+	var repeatedJSON string
+	if err := store.db.QueryRowContext(ctx, `
+SELECT payload_json FROM workspace_agent_messages WHERE message_id = ?
+`, "oversized-terminal-alias").Scan(&repeatedJSON); err != nil {
+		t.Fatalf("read repeated payload: %v", err)
+	}
+	if repeatedJSON != compactedJSON {
+		t.Fatal("repeated migration changed the compacted payload")
+	}
+}


### PR DESCRIPTION
## Summary

终端命令在 canonical payload 中可能同时保存 provider-neutral `text` 与原始 `stdout`/`stderr`。两个字段内容可重建时，这份重复数据会把单条 Agent Activity mutation 推到服务端 1 MiB 限制以上，并让历史 mutation 持续进入 oversized/sideline 路径。

- 对已结束的 Bash/exec 命令，在 Reporter 独立截断字段之前识别 `text == strings.TrimSpace(stdout|stderr)`，用 tombstone 清除 running 阶段已经合入的 `text`，原始 stream 仍保留
- 嵌套 step 按自身 status 递归判断；显式非命令 `toolName`、MCP transport 和内容不同的 `text` 不会被误删
- 保留每个 live/formal output 字段的 1 MiB 上限，并将 durable tool-call payload 的正式输出流收敛到 768 KiB aggregate JSON 预算，为 mutation identity、scope 和 batch framing 留出确定余量；input 和结构化结果不会为了预算被丢弃
- 一次性迁移修复所有仍参与复制的历史终端命令行，包括 deleted/tombstoned 行、running Task 下已经结束的 Bash step，以及旧 Reporter 已分别截断、无法再证明等价的双字段记录；不修改 message version、业务时间戳或大整数精度
- payload 变化会自然产生新的 fingerprint，使旧 oversized/sidelined mutation 重新进入投影；无法在不损失结构化语义的前提下满足预算的行保持不变
- Session Replay 比较对旧 alias、深层嵌套 step 和旧 aggregate output shape 做同口径归一化
- 更新 Agent Activity 与 Agent GUI 的持久化契约文档

## Verification

- `pnpm check:changed`
- `pnpm check:changed -- --push-ready`：13/13 lanes 通过
- `go test ./packages/agent/store-sqlite/canonical ./packages/agent/store-sqlite ./packages/agent/session-replay ./packages/agent/daemon/runtime`
- commit hooks：gofmt、Prettier、staged repository boundary checks

## Checklist

- [x] 此 PR 不改变 session/turn/goal/runtime-operation 生命周期语义
- [x] 改动聚焦于 canonical tool output 的可重建 alias 与 replication-safe 预算
- [x] 已覆盖 Reporter、SQLite migration、canonical projection 和 Session Replay
- [x] 已更新相关架构文档
- [x] 未修改 README/CONTRIBUTING，无多语言同步需求
- [x] 提交已包含 DCO sign-off
