### PR TITLE
Fix stuck loading state in Agent Activity View

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1322,11 +1322,14 @@ boundary for the Conversation Rail Activity View. Desktop opts in explicitly;
 external hosts that omit or disable it retain the ordinary Rail unchanged.
 
 The view is a presentation-only activation over the current workspace Engine:
-it reads visible root Session summaries, each root Session's own
-working/waiting state, attention/read state, and already-cached Session
-messages. Descendant activity remains available in the conversation detail
-and interaction surfaces, but it does not change the root row's Rail status.
-Opening Activity View must not call list pagination or transcript hydration.
+it reads visible root Session summaries, each root Session's own lifecycle
+status, root-conversation attention/read state, and already-cached Session
+messages. Descendant lifecycle activity remains available in the conversation
+detail and interaction surfaces, but it does not change the root row's Rail
+status. A pending descendant Interaction still contributes canonical
+root-conversation attention so an approval or question cannot disappear with
+the filtered child row; submission retains the exact child identity. Opening
+Activity View must not call list pagination or transcript hydration.
 Its membership input is the canonical mounted Engine summary collection, never
 the ordinary Rail's transient `runtimeRailConversations` overlay; stale page
 projections therefore cannot leak into Activity View.

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1308,9 +1308,11 @@ boundary for the Conversation Rail Activity View. Desktop opts in explicitly;
 external hosts that omit or disable it retain the ordinary Rail unchanged.
 
 The view is a presentation-only activation over the current workspace Engine:
-it reads visible root Session summaries, root-aggregated descendant
+it reads visible root Session summaries, each root Session's own
 working/waiting state, attention/read state, and already-cached Session
-messages. Opening it must not call list pagination or transcript hydration.
+messages. Descendant activity remains available in the conversation detail
+and interaction surfaces, but it does not change the root row's Rail status.
+Opening Activity View must not call list pagination or transcript hydration.
 Its membership input is the canonical mounted Engine summary collection, never
 the ordinary Rail's transient `runtimeRailConversations` overlay; stale page
 projections therefore cannot leak into Activity View.

--- a/docs/conventions/troubleshooting/agent-approvals-subagents.md
+++ b/docs/conventions/troubleshooting/agent-approvals-subagents.md
@@ -382,18 +382,30 @@ session-level child summaries.
 
 - Cause: a child terminal did not trigger root-gate evaluation, or a later
   provider continuation opened without publishing its root-provider lifecycle.
+  In the Codex adapter, a child can outlive the root Turn. If its terminal
+  notification arrives after the root active-Turn emitter is detached, the
+  session-level handler must not discard the reduced child event. A newly
+  started client must also refresh the live root provider-thread identity
+  before routing that notification; the startup Session snapshot predates
+  `thread/start` and may not contain it.
   If provider logs contain `turn/completed` and the controller emits an event,
   but the root turn's persisted root-provider columns are empty, check that the
   runtime reportable-event filter includes both root-provider lifecycle event
   types; stream publication alone does not update durable state.
 - Fix: child terminal, exact child-cancel completion, and root-provider terminal
-  transitions all run the same durable root settlement check. The final
+  transitions all run the same durable root settlement check. The Codex
+  session-level handler refreshes the live root provider-thread identity and,
+  when no root active-Turn emitter exists, sends reduced child-owned events
+  through the root runtime's Session event sink with an adapter lifecycle
+  snapshot. It does not replay unrelated unowned root events. The final
   transition atomically clears the root active-turn pointer, emits the root turn
   update, and reconciles the controller's root runtime view. Root-provider
   lifecycle events must reach `services/tuttid` through the state-report path.
 - Validate: cover concurrent and nested children, failed children, and a later
-  root continuation. Child failure may remain visible without forcing root
-  failure.
+  root continuation. Also complete the root first, deliver a child terminal
+  through the actual session-level transport handler with no active root Turn,
+  and assert that the child terminal reaches the durable Session event sink.
+  Child failure may remain visible without forcing root failure.
 
 ### Provider terminal report replays a settled root as running
 

--- a/docs/conventions/troubleshooting/agent-approvals-subagents.md
+++ b/docs/conventions/troubleshooting/agent-approvals-subagents.md
@@ -383,29 +383,34 @@ session-level child summaries.
 - Cause: a child terminal did not trigger root-gate evaluation, or a later
   provider continuation opened without publishing its root-provider lifecycle.
   In the Codex adapter, a child can outlive the root Turn. If its terminal
-  notification arrives after the root active-Turn emitter is detached, the
-  session-level handler must not discard the reduced child event. A newly
-  started client must also refresh the live root provider-thread identity
-  before routing that notification; the startup Session snapshot predates
-  `thread/start` and may not contain it.
+  notification arrives after that root active-Turn emitter is detached, the
+  session-level handler must not discard the reduced child event or attach it
+  to a newer root Turn's emitter. A newly started client must also refresh the
+  live root provider-thread identity before routing that notification; the
+  startup Session snapshot predates `thread/start` and may not contain it.
   If provider logs contain `turn/completed` and the controller emits an event,
   but the root turn's persisted root-provider columns are empty, check that the
   runtime reportable-event filter includes both root-provider lifecycle event
   types; stream publication alone does not update durable state.
 - Fix: child terminal, exact child-cancel completion, and root-provider terminal
   transitions all run the same durable root settlement check. The Codex
-  session-level handler refreshes the live root provider-thread identity and,
-  when no root active-Turn emitter exists, sends reduced child-owned events
-  through the root runtime's Session event sink with an adapter lifecycle
-  snapshot. It does not replay unrelated unowned root events. The final
+  session-level handler refreshes the live root provider-thread identity and
+  compares each child event's canonical `rootTurnId` with the active root
+  Turn. Matching events stay on that Turn's emitter; detached events go through
+  the root runtime's Session event sink with an adapter lifecycle snapshot. The
+  Controller applies the same commit-before-publish barrier to terminal events
+  from that sink, so a child terminal is durable before consumers observe it.
+  It does not replay unrelated unowned root events. The final
   transition atomically clears the root active-turn pointer, emits the root turn
   update, and reconciles the controller's root runtime view. Root-provider
   lifecycle events must reach `services/tuttid` through the state-report path.
 - Validate: cover concurrent and nested children, failed children, and a later
-  root continuation. Also complete the root first, deliver a child terminal
-  through the actual session-level transport handler with no active root Turn,
-  and assert that the child terminal reaches the durable Session event sink.
-  Child failure may remain visible without forcing root failure.
+  root continuation. Complete the root first and deliver a child terminal
+  through the actual session-level transport handler both with no active root
+  Turn and while a newer root Turn is active. Assert that the child terminal
+  bypasses the newer emitter, reaches the Session event sink, waits for the
+  durable report before stream publication, and remains unpublished when that
+  report fails. Child failure may remain visible without forcing root failure.
 
 ### Provider terminal report replays a settled root as running
 

--- a/docs/specs/2026-08-05-agent-conversation-activity-view-prd.md
+++ b/docs/specs/2026-08-05-agent-conversation-activity-view-prd.md
@@ -108,8 +108,8 @@ Activity View 的核心价值是把 Conversation Rail 从“目录”临时切�
 | D2   | Desktop 默认关闭，由用户显式开启；Mobile 会话首页固定开启        | Desktop 保留既有项目目录心智；Mobile 直接采用已批准的新首页承载   |
 | D3   | 最近范围固定为最近 7 个自然日                                    | 覆盖一周工作上下文，避免无边界加载历史                            |
 | D4   | Priority 顺序复刻 Codex：`waiting`、`unread`、`active`           | 不按失败/成功再创造一套 Tutti 排序标准                            |
-| D5   | `waiting` 由 Tutti canonical `needsUserAction` 映射              | UI 语义跟随 Codex，事实来源仍由 Tutti lifecycle 保证              |
-| D6   | 子 Session 不作为左栏独立行                                      | Codex 将子线程作为独立实体管理，但左栏由根线程代表                |
+| D5   | `waiting` 由根 Session 自身的 canonical `needsUserAction` 映射   | 左栏状态与普通 Rail 统一，事实来源仍由 Tutti lifecycle 保证       |
+| D6   | 子 Session 不作为左栏独立行，也不改变根行状态                    | 子 Agent 状态留在会话详情中，左栏只表达主会话自身状态             |
 | D7   | Priority 与近期日期段之间去重                                    | 一个 Session 只在最靠前的可见位置出现一次                         |
 | D8   | 搜索临时接管内容区，清空搜索后恢复 Activity View                 | 搜索是明确查找意图，避免搜索结果与工作队列结构混杂                |
 | D9   | Activity View 不新增或改造通用筛选器                             | 当前 Engine 是完整输入边界，不增加 host context 契约              |
@@ -121,6 +121,7 @@ Activity View 的核心价值是把 Conversation Rail 从“目录”临时切�
 | Codex 行为/概念                   | Tutti 特有事实                                     | 处理方式                                               | 是否改变体验                 |
 | --------------------------------- | -------------------------------------------------- | ------------------------------------------------------ | ---------------------------- |
 | 本地 task attention `waiting`     | Tutti 用 pending Interaction / `needsUserAction`   | adapter 映射为 waiting                                 | 否                           |
+| 子 Agent 仍在工作或等待           | 子 Session 有独立 canonical lifecycle              | 详情继续展示；Activity Rail 根行只读取根 Session 状态  | 是；与普通 Rail 状态口径统一 |
 | `threadId` / `parentThreadId`     | Tutti 用 `agentSessionId` / `parentAgentSessionId` | identity adapter，保留根行/子行关系                    | 否                           |
 | ChatGPT 模式可筛 Work / Chat      | Tutti Agent GUI 只有 Agent Session                 | 不显示无意义的 Work/Chat 选项                          | 是；最小差异，数据类型不存在 |
 | Scheduled 选项                    | Tutti 没有 canonical scheduled Session 类型        | 不显示 Scheduled 选项                                  | 是；数据类型不存在           |
@@ -230,11 +231,11 @@ Priority 内部不再增加多层可折叠标题，避免窄 Rail 产生过多 c
 
 每个根 Session 先映射为 Codex 同构的 attention state，再计算纯 presentation rank：
 
-| rank | Codex 同构状态 | Tutti canonical 映射                                       | 行内原因                         |
-| ---- | -------------- | ---------------------------------------------------------- | -------------------------------- |
-| 0    | `waiting`      | `needsUserAction=true`，通常来自 pending Interaction       | 需要处理                         |
-| 1    | `unread`       | 现有 attention/read state 表示存在未读结果                 | 未读；不再细分失败或成功的优先级 |
-| 2    | `active`       | 根 Session 或其子 Session 仍有 active lifecycle projection | 进行中                           |
+| rank | Codex 同构状态 | Tutti canonical 映射                                                 | 行内原因                         |
+| ---- | -------------- | -------------------------------------------------------------------- | -------------------------------- |
+| 0    | `waiting`      | 根 Session 自身 `needsUserAction=true`，通常来自 pending Interaction | 需要处理                         |
+| 1    | `unread`       | 现有 attention/read state 表示存在未读结果                           | 未读；不再细分失败或成功的优先级 |
+| 2    | `active`       | 根 Session 自身仍有 active lifecycle projection                      | 进行中                           |
 
 普通 idle 不进入 Priority，由近期日期范围决定是否出现在某个日期段。Activity View 运行期间晚到的 canonical idle summary 也不会被视为 activity，不会改变 Priority；它只可在下一次 toggle 的初始快照中按近期日期进入日期段。仅因用户选择历史会话而临时注入的 idle summary 同样不属于 Activity candidate。已经进入当前 Priority snapshot 的会话即使随后标记已读或变为 idle，也保留原成员和相对顺序，直到下一次 toggle；删除 tombstone 是唯一的即时移除例外。
 
@@ -502,7 +503,7 @@ interface AgentConversationActivityViewModel {
 1. 开启 Activity View 只投影 Engine 当前内存态；不调用 Session list/page、SQLite 或 transcript 接口。
 2. Engine 已知、距离现在超过 7 天但为 waiting 的根 Session 仍出现在 Priority。
 3. Engine 已知、距离现在超过 7 天但为 unread 的根 Session 仍出现在 Priority。
-4. Tutti 的 `needsUserAction=true` 映射为 waiting；普通运行映射为 active。
+4. 根 Session 自身的 `needsUserAction=true` 映射为 waiting；根 Session 自身运行映射为 active；子 Session 的 working/waiting 不改变根行状态。
 5. waiting 排在 unread 前，unread 排在 active 前；unread 不按结果成功/失败二次排序。
 6. 同 rank 两条会话按 recency 倒序；时间相同保留输入顺序。
 7. 同时满足 Priority 与近期日期范围的 Session 只出现在 Priority。
@@ -533,7 +534,7 @@ interface AgentConversationActivityViewModel {
 
 ### 15.3 实时与异常
 
-1. 新 pending Interaction 到达时会话进入 Priority，且不需要手动刷新。
+1. 根 Session 的新 pending Interaction 到达时会话进入 Priority，且不需要手动刷新；子 Session 的 pending Interaction 不改变根行状态。
 2. Interaction 处理完后行状态立即更新，但本次 snapshot 中的既有成员与顺序保持；重新开启后按剩余 facts 重建。
 3. Turn 完成或失败生成新 unread completion 时，新候选增量进入 Priority；既有成员不因该事件全量重排。
 4. Desktop daemon 推送的新建/更新根 Session 先进入 Engine；符合规则时无需刷新即可增量入队，重复事件不产生重复行。
@@ -556,9 +557,9 @@ interface AgentConversationActivityViewModel {
 ### 16.1 单元测试
 
 - rank 判定矩阵；
-- Tutti `needsUserAction` 到 waiting、普通运行到 active 的映射；
+- 根 Session 自身的 `needsUserAction` 到 waiting、普通运行到 active 的映射；
 - waiting/unread/active 的排序，以及已读后既有 Priority 成员的 snapshot retention；
-- child Session 过滤与 child activity 到 root 的投影；
+- child Session 过滤，以及 child working/waiting 不改变 root Rail 状态；
 - Priority 与日期段去重；
 - 7 日 cutoff 和本地午夜边界；
 - imported、hidden、deleted、unknown enum；

--- a/docs/specs/2026-08-05-agent-conversation-activity-view-prd.md
+++ b/docs/specs/2026-08-05-agent-conversation-activity-view-prd.md
@@ -102,34 +102,34 @@ Activity View 的核心价值是把 Conversation Rail 从“目录”临时切�
 
 ## 4. 关键产品决策
 
-| 编号 | 决策                                                             | 理由                                                              |
-| ---- | ---------------------------------------------------------------- | ----------------------------------------------------------------- |
-| D1   | 功能名称为 Activity View；Priority 是视图顶部的固定标题区段      | 不再把整个能力称为 Priority View                                  |
-| D2   | Desktop 默认关闭，由用户显式开启；Mobile 会话首页固定开启        | Desktop 保留既有项目目录心智；Mobile 直接采用已批准的新首页承载   |
-| D3   | 最近范围固定为最近 7 个自然日                                    | 覆盖一周工作上下文，避免无边界加载历史                            |
-| D4   | Priority 顺序复刻 Codex：`waiting`、`unread`、`active`           | 不按失败/成功再创造一套 Tutti 排序标准                            |
-| D5   | `waiting` 由根 Session 自身的 canonical `needsUserAction` 映射   | 左栏状态与普通 Rail 统一，事实来源仍由 Tutti lifecycle 保证       |
-| D6   | 子 Session 不作为左栏独立行，也不改变根行状态                    | 子 Agent 状态留在会话详情中，左栏只表达主会话自身状态             |
-| D7   | Priority 与近期日期段之间去重                                    | 一个 Session 只在最靠前的可见位置出现一次                         |
-| D8   | 搜索临时接管内容区，清空搜索后恢复 Activity View                 | 搜索是明确查找意图，避免搜索结果与工作队列结构混杂                |
-| D9   | Activity View 不新增或改造通用筛选器                             | 当前 Engine 是完整输入边界，不增加 host context 契约              |
-| D10  | Activity View 开启本身仅投影当前 Engine 内存态，不因开启视图补页 | Desktop Activity View 聚焦当前工作；Mobile 的显式搜索另走分页查询 |
-| D11  | Activity View 不提供批量归档或批量删除入口                       | Archive chats 映射为 Tutti 删除，但首期不纳入标题菜单             |
+| 编号 | 决策                                                                | 理由                                                              |
+| ---- | ------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| D1   | 功能名称为 Activity View；Priority 是视图顶部的固定标题区段         | 不再把整个能力称为 Priority View                                  |
+| D2   | Desktop 默认关闭，由用户显式开启；Mobile 会话首页固定开启           | Desktop 保留既有项目目录心智；Mobile 直接采用已批准的新首页承载   |
+| D3   | 最近范围固定为最近 7 个自然日                                       | 覆盖一周工作上下文，避免无边界加载历史                            |
+| D4   | Priority 顺序复刻 Codex：`waiting`、`unread`、`active`              | 不按失败/成功再创造一套 Tutti 排序标准                            |
+| D5   | `waiting` 由根会话 canonical `needsUserAction` 映射                 | 与普通 Rail 一致，包含后代 pending Interaction，但保留精确子身份  |
+| D6   | 子 Session 不作为左栏独立行，其 lifecycle 不改变根行 lifecycle 状态 | 子 Agent 运行状态留在详情中；待处理提醒仍汇总到根会话             |
+| D7   | Priority 与近期日期段之间去重                                       | 一个 Session 只在最靠前的可见位置出现一次                         |
+| D8   | 搜索临时接管内容区，清空搜索后恢复 Activity View                    | 搜索是明确查找意图，避免搜索结果与工作队列结构混杂                |
+| D9   | Activity View 不新增或改造通用筛选器                                | 当前 Engine 是完整输入边界，不增加 host context 契约              |
+| D10  | Activity View 开启本身仅投影当前 Engine 内存态，不因开启视图补页    | Desktop Activity View 聚焦当前工作；Mobile 的显式搜索另走分页查询 |
+| D11  | Activity View 不提供批量归档或批量删除入口                          | Archive chats 映射为 Tutti 删除，但首期不纳入标题菜单             |
 
 ### 4.1 已识别的体验差异与数据映射
 
-| Codex 行为/概念                   | Tutti 特有事实                                     | 处理方式                                               | 是否改变体验                 |
-| --------------------------------- | -------------------------------------------------- | ------------------------------------------------------ | ---------------------------- |
-| 本地 task attention `waiting`     | Tutti 用 pending Interaction / `needsUserAction`   | adapter 映射为 waiting                                 | 否                           |
-| 子 Agent 仍在工作或等待           | 子 Session 有独立 canonical lifecycle              | 详情继续展示；Activity Rail 根行只读取根 Session 状态  | 是；与普通 Rail 状态口径统一 |
-| `threadId` / `parentThreadId`     | Tutti 用 `agentSessionId` / `parentAgentSessionId` | identity adapter，保留根行/子行关系                    | 否                           |
-| ChatGPT 模式可筛 Work / Chat      | Tutti Agent GUI 只有 Agent Session                 | 不显示无意义的 Work/Chat 选项                          | 是；最小差异，数据类型不存在 |
-| Scheduled 选项                    | Tutti 没有 canonical scheduled Session 类型        | 不显示 Scheduled 选项                                  | 是；数据类型不存在           |
-| Activity View options             | 首期明确不纳入范围                                 | 不显示标题菜单；不实现 Pinned、Mark all as read 等操作 | 是；已批准的首期范围裁剪     |
-| 首次使用 coachmark                | 首期明确不纳入范围                                 | 不展示引导，也不保存“已看过引导” preference            | 是；已批准的首期范围裁剪     |
-| 前 9 个 Priority 快捷导航         | Tutti 没有 Rail 级会话快捷导航基础设施             | 首期不实现，也不新增全局快捷键                         | 是；已批准的首期范围裁剪     |
-| Codex `Archive chats`             | Tutti 对应现有 delete 会话语义                     | 复用现有单条删除；首期 Activity View 不新增批量入口    | 是；首期裁剪批量操作         |
-| Codex 本地 catalog 已提供全局摘要 | Tutti 只保证 Engine 当前内存态                     | 不补历史；对内存态会话投影并接收 daemon 实时增量       | 是；覆盖范围较窄             |
+| Codex 行为/概念                   | Tutti 特有事实                                     | 处理方式                                                       | 是否改变体验                 |
+| --------------------------------- | -------------------------------------------------- | -------------------------------------------------------------- | ---------------------------- |
+| 本地 task attention `waiting`     | Tutti 用 pending Interaction / `needsUserAction`   | adapter 映射为 waiting                                         | 否                           |
+| 子 Agent 仍在工作或等待           | 子 Session 有独立 lifecycle 和 pending Interaction | lifecycle 留在详情；pending Interaction 汇总为根会话 attention | 是；状态与提醒分别投影       |
+| `threadId` / `parentThreadId`     | Tutti 用 `agentSessionId` / `parentAgentSessionId` | identity adapter，保留根行/子行关系                            | 否                           |
+| ChatGPT 模式可筛 Work / Chat      | Tutti Agent GUI 只有 Agent Session                 | 不显示无意义的 Work/Chat 选项                                  | 是；最小差异，数据类型不存在 |
+| Scheduled 选项                    | Tutti 没有 canonical scheduled Session 类型        | 不显示 Scheduled 选项                                          | 是；数据类型不存在           |
+| Activity View options             | 首期明确不纳入范围                                 | 不显示标题菜单；不实现 Pinned、Mark all as read 等操作         | 是；已批准的首期范围裁剪     |
+| 首次使用 coachmark                | 首期明确不纳入范围                                 | 不展示引导，也不保存“已看过引导” preference                    | 是；已批准的首期范围裁剪     |
+| 前 9 个 Priority 快捷导航         | Tutti 没有 Rail 级会话快捷导航基础设施             | 首期不实现，也不新增全局快捷键                                 | 是；已批准的首期范围裁剪     |
+| Codex `Archive chats`             | Tutti 对应现有 delete 会话语义                     | 复用现有单条删除；首期 Activity View 不新增批量入口            | 是；首期裁剪批量操作         |
+| Codex 本地 catalog 已提供全局摘要 | Tutti 只保证 Engine 当前内存态                     | 不补历史；对内存态会话投影并接收 daemon 实时增量               | 是；覆盖范围较窄             |
 
 除本表外当前没有批准的体验差异。新增差异必须更新本表、验收标准和 parity 测试后才能实现。
 
@@ -170,7 +170,7 @@ flowchart TD
 - **activation instance**：每次开启 Activity View 创建的 surface-local 快照实例；关闭时丢弃，重新开启时重建。
 - **轻量会话数据**：Session、latest Turn、pending Interactions、attention/read marker、项目归属和标题等列表投影，不含完整消息历史。
 - **根 Session**：`kind = root` 的顶层会话，是 Conversation Rail 的展示单位。
-- **子 Session**：由另一个 Session 派生、`kind = child` 且带 `parentAgentSessionId` 的协作/子 Agent 会话；可独立读取和导航，但不在 Rail 中单列。
+- **子 Session**：由另一个 Session 派生、`kind = child` 且带 `parentAgentSessionId` 的协作/子 Agent 会话；可独立读取，但不在 Rail 中单列，当前通过父会话中的活动卡片展开查看。
 
 ### 6.2 事实来源
 
@@ -231,11 +231,11 @@ Priority 内部不再增加多层可折叠标题，避免窄 Rail 产生过多 c
 
 每个根 Session 先映射为 Codex 同构的 attention state，再计算纯 presentation rank：
 
-| rank | Codex 同构状态 | Tutti canonical 映射                                                 | 行内原因                         |
-| ---- | -------------- | -------------------------------------------------------------------- | -------------------------------- |
-| 0    | `waiting`      | 根 Session 自身 `needsUserAction=true`，通常来自 pending Interaction | 需要处理                         |
-| 1    | `unread`       | 现有 attention/read state 表示存在未读结果                           | 未读；不再细分失败或成功的优先级 |
-| 2    | `active`       | 根 Session 自身仍有 active lifecycle projection                      | 进行中                           |
+| rank | Codex 同构状态 | Tutti canonical 映射                                        | 行内原因                         |
+| ---- | -------------- | ----------------------------------------------------------- | -------------------------------- |
+| 0    | `waiting`      | 根会话 `needsUserAction=true`，包含后代 pending Interaction | 需要处理                         |
+| 1    | `unread`       | 现有 attention/read state 表示存在未读结果                  | 未读；不再细分失败或成功的优先级 |
+| 2    | `active`       | 根 Session 自身仍有 active lifecycle projection             | 进行中                           |
 
 普通 idle 不进入 Priority，由近期日期范围决定是否出现在某个日期段。Activity View 运行期间晚到的 canonical idle summary 也不会被视为 activity，不会改变 Priority；它只可在下一次 toggle 的初始快照中按近期日期进入日期段。仅因用户选择历史会话而临时注入的 idle summary 同样不属于 Activity candidate。已经进入当前 Priority snapshot 的会话即使随后标记已读或变为 idle，也保留原成员和相对顺序，直到下一次 toggle；删除 tombstone 是唯一的即时移除例外。
 
@@ -260,10 +260,11 @@ Priority 内部不再增加多层可折叠标题，避免窄 Rail 产生过多 c
 
 Codex.app 同时采用了“实体独立、导航聚合”的设计，Tutti 首期照此实现：
 
-- 子 Session 有自己的 `agentSessionId`、`parentAgentSessionId`、状态和 transcript，可通过父会话中的子 Agent 活动入口直接打开；
+- 子 Session 有自己的 `agentSessionId`、`parentAgentSessionId`、状态和 transcript；当前可在父会话的子 Agent 活动卡片中展开查看；
 - 普通 Rail 和 Activity View 都过滤 `kind = child` 的条目，不把子 Session 当成与根 Session 并列的会话行；
-- 子 Session 的运行变化应触发根 Session 的 aggregate activity projection，使根行可表现为 active/有子 Agent 活动；
-- 根行的标题、未读和“需要处理”不通过拼接子 Session 文案推测，仍取 canonical aggregate selector；
+- 子 Session 的 working/waiting lifecycle 不覆盖根 Session 的 lifecycle 状态，根行仅在根 Session 自身运行时表现为 active；
+- 子 Session 的 pending Interaction 通过 canonical root-attention selector 让根行表现为“需要处理”，但提交仍使用精确子 Session/Turn/Interaction 身份；
+- 根行的标题和未读不通过拼接子 Session 文案推测，继续读取各自 canonical selector；
 - 父会话协作详情沿用现有子 Session 加载机制；该机制不属于本 PRD，也不得把加载到的子 Session 自动插入普通 Rail 或 Activity View。
 
 ### 7.7 项目上下文
@@ -417,7 +418,7 @@ interface AgentConversationActivityViewModel {
 - 去重使用 exact `agentSessionId`；
 - 未知 enum 或缺失 identity 必须 fail closed；
 - rank 是 presentation policy，不写回 Session；
-- 子 Session 在 projection 入口被过滤；其 activity 只通过根 Session 的 canonical aggregate 进入排序；
+- 子 Session 在 projection 入口被过滤；其 lifecycle 不进入根行状态，只有 pending Interaction 通过 canonical root-attention selector 进入 waiting 排序；
 - projection 仅服务本 PRD 的 Desktop Rail；不在此处承诺其他终端复用。
 
 ## 11. 组件和架构落点
@@ -436,28 +437,28 @@ interface AgentConversationActivityViewModel {
 
 ## 12. 功能需求清单
 
-| ID    | 需求                                                                  | 优先级 |
-| ----- | --------------------------------------------------------------------- | ------ |
-| FR-01 | Rail 提供可发现、可访问的 Activity View 切换入口                      | P0     |
-| FR-02 | 首帧基于 Engine 已知会话立即投影                                      | P0     |
-| FR-03 | 只展示根 Session；子 Session activity 投影到根行                      | P0     |
-| FR-04 | waiting/unread/active 事实可投影                                      | P0     |
-| FR-05 | 近期日期段只使用当前 Engine 内存态，不触发补页                        | P0     |
-| FR-06 | Priority 按 waiting/unread/active 和 recency 排序                     | P0     |
-| FR-07 | Priority 与近期日期段全局去重                                         | P0     |
-| FR-08 | 不新增筛选入口、筛选条件、组合状态或通用 filter API                   | P0     |
-| FR-09 | 搜索接管与恢复行为逐项沿用 Codex                                      | P0     |
-| FR-10 | daemon 推送先写入 Engine，再按 snapshot 规则增量入队/移除             | P0     |
-| FR-11 | 开启 Activity View 不触发 Session 查询、补页或 transcript hydration   | P0     |
-| FR-12 | 普通视图状态、scroll 和分页不受破坏                                   | P0     |
-| FR-13 | 复用现有 Rail scroll；不设独立 visible limit                          | P0     |
-| FR-14 | 不提供 Activity view options 标题菜单                                 | P0     |
-| FR-15 | 不提供批量已读、批量归档或批量删除                                    | P0     |
-| FR-16 | 现有 pin/unpin、单条标记已读和单条删除能力保持原样                    | P0     |
-| FR-17 | 首期不展示 coachmark，也不保存引导 preference                         | P0     |
-| FR-18 | 首期不提供前 9 个 Priority 会话快捷导航                               | P0     |
-| FR-19 | 会话行按 Codex 两层布局展示标题、项目上下文、状态及 secondary content | P0     |
-| FR-20 | 外部 host 可通过默认关闭的 runtime capability 禁用全部能力            | P0     |
+| ID    | 需求                                                                                 | 优先级 |
+| ----- | ------------------------------------------------------------------------------------ | ------ |
+| FR-01 | Rail 提供可发现、可访问的 Activity View 切换入口                                     | P0     |
+| FR-02 | 首帧基于 Engine 已知会话立即投影                                                     | P0     |
+| FR-03 | 只展示根 Session；子 lifecycle 留在详情，子 pending Interaction 投影为根行 attention | P0     |
+| FR-04 | waiting/unread/active 事实可投影                                                     | P0     |
+| FR-05 | 近期日期段只使用当前 Engine 内存态，不触发补页                                       | P0     |
+| FR-06 | Priority 按 waiting/unread/active 和 recency 排序                                    | P0     |
+| FR-07 | Priority 与近期日期段全局去重                                                        | P0     |
+| FR-08 | 不新增筛选入口、筛选条件、组合状态或通用 filter API                                  | P0     |
+| FR-09 | 搜索接管与恢复行为逐项沿用 Codex                                                     | P0     |
+| FR-10 | daemon 推送先写入 Engine，再按 snapshot 规则增量入队/移除                            | P0     |
+| FR-11 | 开启 Activity View 不触发 Session 查询、补页或 transcript hydration                  | P0     |
+| FR-12 | 普通视图状态、scroll 和分页不受破坏                                                  | P0     |
+| FR-13 | 复用现有 Rail scroll；不设独立 visible limit                                         | P0     |
+| FR-14 | 不提供 Activity view options 标题菜单                                                | P0     |
+| FR-15 | 不提供批量已读、批量归档或批量删除                                                   | P0     |
+| FR-16 | 现有 pin/unpin、单条标记已读和单条删除能力保持原样                                   | P0     |
+| FR-17 | 首期不展示 coachmark，也不保存引导 preference                                        | P0     |
+| FR-18 | 首期不提供前 9 个 Priority 会话快捷导航                                              | P0     |
+| FR-19 | 会话行按 Codex 两层布局展示标题、项目上下文、状态及 secondary content                | P0     |
+| FR-20 | 外部 host 可通过默认关闭的 runtime capability 禁用全部能力                           | P0     |
 
 ## 13. 非功能需求
 
@@ -503,7 +504,7 @@ interface AgentConversationActivityViewModel {
 1. 开启 Activity View 只投影 Engine 当前内存态；不调用 Session list/page、SQLite 或 transcript 接口。
 2. Engine 已知、距离现在超过 7 天但为 waiting 的根 Session 仍出现在 Priority。
 3. Engine 已知、距离现在超过 7 天但为 unread 的根 Session 仍出现在 Priority。
-4. 根 Session 自身的 `needsUserAction=true` 映射为 waiting；根 Session 自身运行映射为 active；子 Session 的 working/waiting 不改变根行状态。
+4. 根会话 canonical `needsUserAction=true` 映射为 waiting，包含后代 pending Interaction；根 Session 自身运行映射为 active；子 Session 的 lifecycle working/waiting 不改变根行 lifecycle 状态。
 5. waiting 排在 unread 前，unread 排在 active 前；unread 不按结果成功/失败二次排序。
 6. 同 rank 两条会话按 recency 倒序；时间相同保留输入顺序。
 7. 同时满足 Priority 与近期日期范围的 Session 只出现在 Priority。
@@ -534,7 +535,7 @@ interface AgentConversationActivityViewModel {
 
 ### 15.3 实时与异常
 
-1. 根 Session 的新 pending Interaction 到达时会话进入 Priority，且不需要手动刷新；子 Session 的 pending Interaction 不改变根行状态。
+1. 根或子 Session 的新 pending Interaction 到达时，根会话以 waiting 进入 Priority 且不需要手动刷新；子 Session 的 lifecycle 状态仍不覆盖根行状态。
 2. Interaction 处理完后行状态立即更新，但本次 snapshot 中的既有成员与顺序保持；重新开启后按剩余 facts 重建。
 3. Turn 完成或失败生成新 unread completion 时，新候选增量进入 Priority；既有成员不因该事件全量重排。
 4. Desktop daemon 推送的新建/更新根 Session 先进入 Engine；符合规则时无需刷新即可增量入队，重复事件不产生重复行。
@@ -557,9 +558,9 @@ interface AgentConversationActivityViewModel {
 ### 16.1 单元测试
 
 - rank 判定矩阵；
-- 根 Session 自身的 `needsUserAction` 到 waiting、普通运行到 active 的映射；
+- 根会话 canonical `needsUserAction` 到 waiting、根 Session 普通运行到 active 的映射；
 - waiting/unread/active 的排序，以及已读后既有 Priority 成员的 snapshot retention；
-- child Session 过滤，以及 child working/waiting 不改变 root Rail 状态；
+- child Session 过滤、child lifecycle 不改变 root Rail status，以及 child pending Interaction 保留 root attention；
 - Priority 与日期段去重；
 - 7 日 cutoff 和本地午夜边界；
 - imported、hidden、deleted、unknown enum；
@@ -578,7 +579,7 @@ interface AgentConversationActivityViewModel {
 ### 16.3 Engine 与 adapter 测试
 
 - Desktop daemon DTO mapper 不丢 latest Turn、pending Interaction、parent/root 或 rail identity；
-- daemon 推送的 child Session 只更新根行 aggregate，不形成独立 Rail 行；
+- daemon 推送的 child Session 不形成独立 Rail 行；child lifecycle 不覆盖根 status，pending Interaction 只更新根 attention；
 - 删除 tombstone 从 Engine 和 Priority 投影移除 exact Session；
 - 不新增 OpenAPI、SQLite query 或 generated client 变更。
 
@@ -638,16 +639,16 @@ interface AgentConversationActivityViewModel {
 
 ## 18. 风险与缓解
 
-| 风险                         | 后果                          | 缓解                                                             |
-| ---------------------------- | ----------------------------- | ---------------------------------------------------------------- |
-| 只读取当前 DOM 行            | 漏掉已在 Engine、但未挂载的行 | projection 输入取 Engine 内存态，不读取 DOM                      |
-| 用户误以为覆盖全部历史       | 未加载旧会话不会出现          | 产品定位为当前工作队列；不开启历史查询，不展示 coverage 承诺     |
-| daemon 推送重复或乱序        | 重复行或状态回退              | Engine canonical reconciliation、exact ID 去重、activation fence |
-| 子 Session 与根 Session 并列 | 左栏重复、状态难理解          | Rail 过滤 child；根行接收 aggregate activity projection          |
-| 实时更新造成列表移动         | 用户需重新定位                | 复刻 Codex activation snapshot；既有成员不全量重排               |
-| 批量执行 Tutti 删除          | 产生不可恢复的高风险批量操作  | Archive chats 虽映射为删除，首期仍不提供 archive/delete 批量入口 |
-| 多 surface 状态互相影响      | 一个窗口切换另一个窗口        | activation 保持 surface-local                                    |
-| 共享包升级影响外部 host      | 意外出现入口或触发查询        | optional capability 默认关闭；disabled-path consumer tests       |
+| 风险                         | 后果                          | 缓解                                                                               |
+| ---------------------------- | ----------------------------- | ---------------------------------------------------------------------------------- |
+| 只读取当前 DOM 行            | 漏掉已在 Engine、但未挂载的行 | projection 输入取 Engine 内存态，不读取 DOM                                        |
+| 用户误以为覆盖全部历史       | 未加载旧会话不会出现          | 产品定位为当前工作队列；不开启历史查询，不展示 coverage 承诺                       |
+| daemon 推送重复或乱序        | 重复行或状态回退              | Engine canonical reconciliation、exact ID 去重、activation fence                   |
+| 子 Session 与根 Session 并列 | 左栏重复、状态难理解          | Rail 过滤 child；根 status 只读根 lifecycle，根 attention 汇总 pending Interaction |
+| 实时更新造成列表移动         | 用户需重新定位                | 复刻 Codex activation snapshot；既有成员不全量重排                                 |
+| 批量执行 Tutti 删除          | 产生不可恢复的高风险批量操作  | Archive chats 虽映射为删除，首期仍不提供 archive/delete 批量入口                   |
+| 多 surface 状态互相影响      | 一个窗口切换另一个窗口        | activation 保持 surface-local                                                      |
+| 共享包升级影响外部 host      | 意外出现入口或触发查询        | optional capability 默认关闭；disabled-path consumer tests                         |
 
 ## 19. 已确认的范围边界
 
@@ -688,4 +689,4 @@ interface AgentConversationActivityViewModel {
 - Message Center 已存在 priority/status/agent/time 分组，可复用其产品语义，但不能成为 Rail 的第二数据源；
 - attention/read state 已在 Engine 中按用户与 workspace 分区，并由 Desktop local storage 持久化 completion keys。
 
-这些基础能力使首期重点集中在“内存态 Codex 同构 Activity View presentation + daemon 实时入队 + 子 Session 根行聚合”，无需新增 Activity View API、数据库查询或 Session lifecycle。
+这些基础能力使首期重点集中在“内存态 Codex 同构 Activity View presentation + daemon 实时入队 + 根 lifecycle/会话树 attention 分离投影”，无需新增 Activity View API、数据库查询或 Session lifecycle。

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_cancel_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_cancel_test.go
@@ -2,9 +2,10 @@ package agentruntime
 
 import (
 	"context"
-	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 	"testing"
 	"time"
+
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 func TestCodexAppServerAdapterCancelInterruptsActiveTurn(t *testing.T) {
@@ -224,6 +225,63 @@ func TestCodexAppServerAdapterCancelAfterTurnCompletedStillMarksChildrenCanceled
 		t.Fatalf("confirmed targets = %#v, want child", cancelResult.ConfirmedTargets)
 	}
 	_ = transport
+}
+
+func TestCodexAppServerAdapterEmitsLateChildCompletionAfterRootTurnCompleted(t *testing.T) {
+	adapter, transport, session := startedAppServerAdapter(t)
+	_, _ = adapter.rememberAppServerChildThreads(session, "codex-thread-1", session.AgentSessionID, "turn-local-1", session.AgentSessionID, "turn-local-1", map[string]any{
+		"type":              "collabAgentToolCall",
+		"id":                "spawn-child-1",
+		"receiverThreadIds": []any{"child-thread-1"},
+	})
+	child, ok := adapter.appServerChildThread(session.AgentSessionID, "child-thread-1")
+	if !ok {
+		t.Fatal("child thread was not registered")
+	}
+
+	// The parent finishes first, leaving the provider child alive without an
+	// active root-turn emitter attached to the session-level message handler.
+	if _, err := adapter.Exec(context.Background(), session, []PromptContentBlock{{
+		Type: "text", Text: "parent task",
+	}}, "", "turn-local-1", nil, nil); err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if activeTurn := adapter.sessionActiveTurn(session.AgentSessionID); activeTurn != nil {
+		t.Fatal("root turn remained active after completion")
+	}
+
+	type emittedBatch struct {
+		agentSessionID string
+		events         []activityshared.Event
+	}
+	emitted := make(chan emittedBatch, 1)
+	adapter.SetSessionEventSink(func(agentSessionID string, events []activityshared.Event) {
+		emitted <- emittedBatch{
+			agentSessionID: agentSessionID,
+			events:         append([]activityshared.Event(nil), events...),
+		}
+	})
+	transport.conn.notify(appServerNotifyTurnCompleted, map[string]any{
+		"threadId": "child-thread-1",
+		"turn":     map[string]any{"id": "child-provider-turn-1", "status": "completed"},
+	})
+
+	select {
+	case batch := <-emitted:
+		if batch.agentSessionID != session.AgentSessionID {
+			t.Fatalf("sink session = %q, want root %q", batch.agentSessionID, session.AgentSessionID)
+		}
+		completed := eventsOfType(batch.events, activityshared.EventTurnCompleted)
+		if len(completed) != 1 || completed[0].AgentSessionID != child.agentSessionID || completed[0].Payload.TurnID != child.turnID {
+			t.Fatalf("late child completion events = %#v", batch.events)
+		}
+		lifecycle, stamped := activityshared.TurnLifecycleSnapshotFromEvent(completed[0])
+		if !stamped || lifecycle.Phase != string(activityshared.TurnPhaseSettled) {
+			t.Fatalf("late child lifecycle = %#v, stamped=%v", lifecycle, stamped)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("late child completion did not reach the session event sink")
+	}
 }
 
 func TestCodexAppServerAdapterCancelInterruptsLateUnownedRootTurn(t *testing.T) {

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_cancel_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_cancel_test.go
@@ -284,6 +284,85 @@ func TestCodexAppServerAdapterEmitsLateChildCompletionAfterRootTurnCompleted(t *
 	}
 }
 
+func TestCodexAppServerAdapterKeepsLateChildCompletionOutOfNewRootTurnEmitter(t *testing.T) {
+	adapter, transport, session := startedAppServerAdapter(t)
+	_, _ = adapter.rememberAppServerChildThreads(session, "codex-thread-1", session.AgentSessionID, "turn-local-1", session.AgentSessionID, "turn-local-1", map[string]any{
+		"type":              "collabAgentToolCall",
+		"id":                "spawn-child-1",
+		"receiverThreadIds": []any{"child-thread-1"},
+	})
+	child, ok := adapter.appServerChildThread(session.AgentSessionID, "child-thread-1")
+	if !ok {
+		t.Fatal("child thread was not registered")
+	}
+
+	if _, err := adapter.Exec(context.Background(), session, []PromptContentBlock{{
+		Type: "text", Text: "parent task A",
+	}}, "", "turn-local-1", nil, nil); err != nil {
+		t.Fatalf("Exec turn A: %v", err)
+	}
+	if activeTurn := adapter.sessionActiveTurn(session.AgentSessionID); activeTurn != nil {
+		t.Fatal("root turn A remained active after completion")
+	}
+
+	type emittedBatch struct {
+		agentSessionID string
+		events         []activityshared.Event
+	}
+	emitted := make(chan emittedBatch, 1)
+	adapter.SetSessionEventSink(func(agentSessionID string, events []activityshared.Event) {
+		emitted <- emittedBatch{
+			agentSessionID: agentSessionID,
+			events:         append([]activityshared.Event(nil), events...),
+		}
+	})
+
+	transport.server.holdTurn = true
+	execDone := make(chan []activityshared.Event, 1)
+	go func() {
+		events, _ := adapter.Exec(context.Background(), session, []PromptContentBlock{{
+			Type: "text", Text: "parent task B",
+		}}, "", "turn-local-2", nil, nil)
+		execDone <- events
+	}()
+	waitForCondition(t, func() bool {
+		activeTurn := adapter.sessionActiveTurn(session.AgentSessionID)
+		return activeTurn != nil && activeTurn.turnID == "turn-local-2"
+	})
+
+	transport.conn.notify(appServerNotifyTurnCompleted, map[string]any{
+		"threadId": "child-thread-1",
+		"turn":     map[string]any{"id": "child-provider-turn-1", "status": "completed"},
+	})
+
+	select {
+	case batch := <-emitted:
+		if batch.agentSessionID != session.AgentSessionID {
+			t.Fatalf("sink session = %q, want root %q", batch.agentSessionID, session.AgentSessionID)
+		}
+		completed := eventsOfType(batch.events, activityshared.EventTurnCompleted)
+		if len(completed) != 1 ||
+			completed[0].AgentSessionID != child.agentSessionID ||
+			completed[0].RootTurnID != "turn-local-1" {
+			t.Fatalf("detached child completion events = %#v", batch.events)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("late child completion was coupled to root turn B")
+	}
+
+	transport.server.completePendingTurn()
+	select {
+	case events := <-execDone:
+		for _, event := range events {
+			if event.AgentSessionID == child.agentSessionID {
+				t.Fatalf("root turn B captured detached child event: %#v", event)
+			}
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("root turn B did not finish")
+	}
+}
+
 func TestCodexAppServerAdapterCancelInterruptsLateUnownedRootTurn(t *testing.T) {
 	adapter, transport, session := startedAppServerAdapter(t)
 	transport.server.holdTurn = true

--- a/packages/agent/daemon/runtime/codex_appserver_session.go
+++ b/packages/agent/daemon/runtime/codex_appserver_session.go
@@ -544,12 +544,21 @@ func (a *CodexAppServerAdapter) startClientPrepared(
 		// different emission path. The tracker is idempotent, so the emitter
 		// can retain its existing boundary without duplicating indexes.
 		events = a.inputUnits.stamp(session.AgentSessionID, events)
+		// A child may outlive its root Turn. Only child events owned by the
+		// currently active canonical root Turn may enter that Turn's emitter;
+		// otherwise a newer Turn's acceptance buffer or close fence can drop them.
+		turnEvents, detachedChildEvents := appServerEventsForActiveRootTurn(
+			session.AgentSessionID,
+			turnID,
+			events,
+		)
 		if turnEmit != nil {
-			turnEmit(events)
-		} else if childEvents := appServerChildSessionEvents(session.AgentSessionID, events); len(childEvents) > 0 {
+			turnEmit(turnEvents)
+		}
+		if len(detachedChildEvents) > 0 {
 			a.emitSessionEvents(
 				session.AgentSessionID,
-				a.stampTurnLifecycleSnapshots(session.AgentSessionID, childEvents),
+				a.stampTurnLifecycleSnapshots(session.AgentSessionID, detachedChildEvents),
 			)
 		}
 		return err
@@ -608,17 +617,26 @@ func (a *CodexAppServerAdapter) startClientPrepared(
 	return client, initializeResult, false, nil
 }
 
-func appServerChildSessionEvents(
+func appServerEventsForActiveRootTurn(
 	rootAgentSessionID string,
+	activeRootTurnID string,
 	events []activityshared.Event,
-) []activityshared.Event {
+) ([]activityshared.Event, []activityshared.Event) {
 	rootAgentSessionID = strings.TrimSpace(rootAgentSessionID)
-	childEvents := make([]activityshared.Event, 0, len(events))
+	activeRootTurnID = strings.TrimSpace(activeRootTurnID)
+	turnEvents := make([]activityshared.Event, 0, len(events))
+	detachedChildEvents := make([]activityshared.Event, 0, len(events))
 	for _, event := range events {
 		eventAgentSessionID := strings.TrimSpace(event.AgentSessionID)
 		if eventAgentSessionID != "" && eventAgentSessionID != rootAgentSessionID {
-			childEvents = append(childEvents, event)
+			if activeRootTurnID == "" || strings.TrimSpace(event.RootTurnID) != activeRootTurnID {
+				detachedChildEvents = append(detachedChildEvents, event)
+				continue
+			}
+		}
+		if activeRootTurnID != "" {
+			turnEvents = append(turnEvents, event)
 		}
 	}
-	return childEvents
+	return turnEvents, detachedChildEvents
 }

--- a/packages/agent/daemon/runtime/codex_appserver_session.go
+++ b/packages/agent/daemon/runtime/codex_appserver_session.go
@@ -517,11 +517,15 @@ func (a *CodexAppServerAdapter) startClientPrepared(
 	// an in-flight RPC. Because turn/start responds immediately while the
 	// turn keeps streaming, this is the main delivery path for turn output:
 	// resolve the active turn context so notifications keep producing
-	// activity events after the RPC has returned.
+	// activity events after the RPC has returned. Child sessions may outlive
+	// that root turn, so their events retain a session-level fallback below.
 	client.SetMessageHandler(func(ctx context.Context, message acpMessage) error {
 		endInputUnit := a.inputUnits.begin(ctx, session.AgentSessionID)
 		defer endInputUnit()
 		turnSession := session
+		if appSession := a.getSession(session.AgentSessionID); appSession != nil {
+			turnSession.ProviderSessionID = firstNonEmpty(appSession.threadID, turnSession.ProviderSessionID)
+		}
 		turnID := ""
 		var normalizer *acpTurnNormalizer
 		var turnEmit func([]activityshared.Event)
@@ -542,6 +546,11 @@ func (a *CodexAppServerAdapter) startClientPrepared(
 		events = a.inputUnits.stamp(session.AgentSessionID, events)
 		if turnEmit != nil {
 			turnEmit(events)
+		} else if childEvents := appServerChildSessionEvents(session.AgentSessionID, events); len(childEvents) > 0 {
+			a.emitSessionEvents(
+				session.AgentSessionID,
+				a.stampTurnLifecycleSnapshots(session.AgentSessionID, childEvents),
+			)
 		}
 		return err
 	})
@@ -597,4 +606,19 @@ func (a *CodexAppServerAdapter) startClientPrepared(
 	})
 	started = true
 	return client, initializeResult, false, nil
+}
+
+func appServerChildSessionEvents(
+	rootAgentSessionID string,
+	events []activityshared.Event,
+) []activityshared.Event {
+	rootAgentSessionID = strings.TrimSpace(rootAgentSessionID)
+	childEvents := make([]activityshared.Event, 0, len(events))
+	for _, event := range events {
+		eventAgentSessionID := strings.TrimSpace(event.AgentSessionID)
+		if eventAgentSessionID != "" && eventAgentSessionID != rootAgentSessionID {
+			childEvents = append(childEvents, event)
+		}
+	}
+	return childEvents
 }

--- a/packages/agent/daemon/runtime/controller_session_registry.go
+++ b/packages/agent/daemon/runtime/controller_session_registry.go
@@ -654,6 +654,23 @@ func (c *Controller) applySessionEventsByAgentSessionID(agentSessionID string, e
 	if publicationPending {
 		return
 	}
+	// Session-scoped adapter callbacks can carry child terminals after the
+	// owning root Turn emitter has detached. They still cross the same durable
+	// commit-before-publish barrier as terminals emitted by an active Turn.
+	if eventsRequireDurablePublish(events) {
+		if err := c.reportSessionBeforePublish(context.Background(), session, events); err != nil {
+			slog.Error(
+				"agent session sink terminal activity report failed before publish",
+				"event", "agent_session.activity_report.session_sink_terminal_barrier_failed",
+				"room_id", session.RoomID,
+				"agent_session_id", session.AgentSessionID,
+				"error", err,
+			)
+			return
+		}
+		c.publish(session, events)
+		return
+	}
 	c.publish(session, events)
 	c.enqueueSessionReport(context.Background(), session, events)
 }

--- a/packages/agent/daemon/runtime/controller_turn_lifecycle_test.go
+++ b/packages/agent/daemon/runtime/controller_turn_lifecycle_test.go
@@ -2,9 +2,11 @@ package agentruntime
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
@@ -97,6 +99,155 @@ func TestControllerSessionEventSinkTracksSyntheticTurnLifecycle(t *testing.T) {
 		*patches[0].TurnLifecycle.ActiveTurnID != "synthetic-turn-1" {
 		t.Fatalf("reported state patches = %#v, want synthetic turn lifecycle", patches)
 	}
+}
+
+func TestControllerSessionEventSinkCommitsChildTerminalBeforePublish(t *testing.T) {
+	reporter := newSessionEventTerminalBarrierReporter()
+	controller := NewController(nil, reporter)
+	session := Session{
+		RoomID:         "room-1",
+		AgentSessionID: "root-session-1",
+		Provider:       ProviderCodex,
+		Status:         SessionStatusReady,
+	}
+	controller.store(session)
+	stream, unsubscribe, ok := controller.Subscribe(session.RoomID, session.AgentSessionID)
+	if !ok {
+		t.Fatal("Subscribe returned ok=false")
+	}
+	defer unsubscribe()
+	select {
+	case <-stream:
+	case <-time.After(2 * time.Second):
+		t.Fatal("initial session snapshot was not published")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		controller.applySessionEventsByAgentSessionID(
+			session.AgentSessionID,
+			[]activityshared.Event{lateChildCompletionEvent(session)},
+		)
+		close(done)
+	}()
+
+	var report agentsessionstore.ReportActivityInput
+	select {
+	case report = <-reporter.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("terminal report did not reach the durable barrier")
+	}
+	if !reportContainsAgentSessionStatePatch(report, "child-session-1") {
+		t.Fatalf("terminal report = %#v, want child state patch", report)
+	}
+	expectNoStreamEventType(t, stream, StreamEventStatePatch)
+
+	reporter.release <- nil
+	waitForPublishedSessionEvent(t, stream, EventTurnCompleted, "", "")
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("session event sink did not return after durable commit")
+	}
+}
+
+func TestControllerSessionEventSinkWithholdsChildTerminalWhenCommitFails(t *testing.T) {
+	reporter := newSessionEventTerminalBarrierReporter()
+	controller := NewController(nil, reporter)
+	session := Session{
+		RoomID:         "room-1",
+		AgentSessionID: "root-session-1",
+		Provider:       ProviderCodex,
+		Status:         SessionStatusReady,
+	}
+	controller.store(session)
+	stream, unsubscribe, ok := controller.Subscribe(session.RoomID, session.AgentSessionID)
+	if !ok {
+		t.Fatal("Subscribe returned ok=false")
+	}
+	defer unsubscribe()
+	select {
+	case <-stream:
+	case <-time.After(2 * time.Second):
+		t.Fatal("initial session snapshot was not published")
+	}
+
+	reporter.release <- errors.New("durable report failed")
+	controller.applySessionEventsByAgentSessionID(
+		session.AgentSessionID,
+		[]activityshared.Event{lateChildCompletionEvent(session)},
+	)
+	select {
+	case <-reporter.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("terminal report did not reach the durable barrier")
+	}
+	expectNoStreamEventType(t, stream, StreamEventStatePatch)
+}
+
+type sessionEventTerminalBarrierReporter struct {
+	started chan agentsessionstore.ReportActivityInput
+	release chan error
+}
+
+func newSessionEventTerminalBarrierReporter() *sessionEventTerminalBarrierReporter {
+	return &sessionEventTerminalBarrierReporter{
+		started: make(chan agentsessionstore.ReportActivityInput, 1),
+		release: make(chan error, 1),
+	}
+}
+
+func (r *sessionEventTerminalBarrierReporter) Report(
+	ctx context.Context,
+	report agentsessionstore.ReportActivityInput,
+) error {
+	select {
+	case r.started <- report:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	select {
+	case err := <-r.release:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (r *sessionEventTerminalBarrierReporter) ReportSubmitProvenance(
+	ctx context.Context,
+	report agentsessionstore.ReportActivityInput,
+) error {
+	return r.Report(ctx, report)
+}
+
+func lateChildCompletionEvent(root Session) activityshared.Event {
+	event := newTurnActivityEvent(
+		root,
+		EventTurnCompleted,
+		"child-turn-1",
+		SessionStatusReady,
+		"",
+		"",
+		nil,
+	)
+	event.AgentSessionID = "child-session-1"
+	event.SessionKind = "child"
+	event.RootAgentSessionID = root.AgentSessionID
+	event.RootTurnID = "root-turn-1"
+	return event
+}
+
+func reportContainsAgentSessionStatePatch(
+	report agentsessionstore.ReportActivityInput,
+	agentSessionID string,
+) bool {
+	for _, patch := range report.StatePatches {
+		if patch.AgentSessionID == agentSessionID {
+			return true
+		}
+	}
+	return false
 }
 
 func TestControllerFinishParentTurnDoesNotOverwriteSyntheticLifecycle(t *testing.T) {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.activity.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.activity.spec.tsx
@@ -12,7 +12,7 @@ import { createTestAgentSessionEngine } from "../../../shared/testing/createTest
 import { useAgentGUIConversationRailQuery } from "./useAgentGUIConversationRailQuery";
 
 describe("useAgentGUIConversationRailQuery Activity facts", () => {
-  it("keeps child sessions hidden and aggregates their activity onto the root", async () => {
+  it("keeps child sessions hidden without aggregating their activity onto the root", async () => {
     const engine = createTestAgentSessionEngine("workspace-1");
     engine.dispatch({
       type: "session/upserted",
@@ -75,7 +75,7 @@ describe("useAgentGUIConversationRailQuery Activity facts", () => {
     await waitFor(() =>
       expect(rendered.result.current.activityRootFacts.get("root")).toEqual({
         needsUserAction: false,
-        status: "working"
+        status: "ready"
       })
     );
     expect(rendered.result.current.activityRootFacts.has("child")).toBe(false);
@@ -84,6 +84,11 @@ describe("useAgentGUIConversationRailQuery Activity facts", () => {
         (conversation) => conversation.id
       )
     ).toEqual(["root"]);
+    expect(rendered.result.current.activityConversations[0]).toMatchObject({
+      id: "root",
+      needsUserAction: false,
+      status: "ready"
+    });
 
     act(() => {
       engine.dispatch({
@@ -102,10 +107,15 @@ describe("useAgentGUIConversationRailQuery Activity facts", () => {
     });
     await waitFor(() =>
       expect(rendered.result.current.activityRootFacts.get("root")).toEqual({
-        needsUserAction: true,
-        status: "waiting"
+        needsUserAction: false,
+        status: "ready"
       })
     );
+    expect(rendered.result.current.activityConversations[0]).toMatchObject({
+      id: "root",
+      needsUserAction: false,
+      status: "ready"
+    });
 
     rendered.unmount();
     engine.dispose();

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.activity.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.activity.spec.tsx
@@ -12,18 +12,20 @@ import { createTestAgentSessionEngine } from "../../../shared/testing/createTest
 import { useAgentGUIConversationRailQuery } from "./useAgentGUIConversationRailQuery";
 
 describe("useAgentGUIConversationRailQuery Activity facts", () => {
-  it("keeps child sessions hidden without aggregating their activity onto the root", async () => {
+  it("keeps child lifecycle out of root status while preserving descendant attention", async () => {
     const engine = createTestAgentSessionEngine("workspace-1");
     engine.dispatch({
       type: "session/upserted",
       session: normalizeAgentActivitySession({
         activeTurnId: null,
         agentSessionId: "root",
+        createdAtUnixMs: 1,
         cwd: "/workspace",
         latestTurnInteractions: [],
         pendingInteractions: [],
         provider: "codex",
         title: "Root",
+        updatedAtUnixMs: 1,
         workspaceId: "workspace-1"
       })
     });
@@ -89,6 +91,36 @@ describe("useAgentGUIConversationRailQuery Activity facts", () => {
       needsUserAction: false,
       status: "ready"
     });
+    await waitFor(() =>
+      expect(
+        rendered.result.current.activityController.getSnapshot().available
+      ).toBe(true)
+    );
+    act(() => {
+      rendered.result.current.activityController.toggle();
+    });
+    expect(
+      rendered.result.current.activityController.getSnapshot().activation
+        ?.priority
+    ).toEqual([]);
+
+    const rootFactsBeforeChildLifecycleUpdate =
+      rendered.result.current.activityRootFacts;
+    const conversationsBeforeChildLifecycleUpdate =
+      rendered.result.current.activityConversations;
+    act(() => {
+      engine.dispatch({
+        live: true,
+        type: "turn/upserted",
+        turn: runningChildTurn(3)
+      });
+    });
+    expect(rendered.result.current.activityRootFacts).toBe(
+      rootFactsBeforeChildLifecycleUpdate
+    );
+    expect(rendered.result.current.activityConversations).toBe(
+      conversationsBeforeChildLifecycleUpdate
+    );
 
     act(() => {
       engine.dispatch({
@@ -107,15 +139,62 @@ describe("useAgentGUIConversationRailQuery Activity facts", () => {
     });
     await waitFor(() =>
       expect(rendered.result.current.activityRootFacts.get("root")).toEqual({
-        needsUserAction: false,
+        needsUserAction: true,
         status: "ready"
       })
     );
     expect(rendered.result.current.activityConversations[0]).toMatchObject({
       id: "root",
-      needsUserAction: false,
+      needsUserAction: true,
       status: "ready"
     });
+    await waitFor(() =>
+      expect(
+        rendered.result.current.activityController.getSnapshot().activation
+          ?.priority
+      ).toMatchObject([
+        {
+          id: "root",
+          priorityReason: "waiting"
+        }
+      ])
+    );
+
+    act(() => {
+      engine.dispatch({
+        type: "session/upserted",
+        session: normalizeAgentActivitySession({
+          activeTurnId: "root-turn",
+          agentSessionId: "root",
+          createdAtUnixMs: 1,
+          cwd: "/workspace",
+          latestTurnInteractions: [],
+          pendingInteractions: [],
+          provider: "codex",
+          title: "Root",
+          updatedAtUnixMs: 4,
+          workspaceId: "workspace-1"
+        })
+      });
+      engine.dispatch({
+        live: true,
+        type: "turn/upserted",
+        turn: {
+          agentSessionId: "root",
+          origin: "user_prompt",
+          phase: "running",
+          startedAtUnixMs: 4,
+          turnId: "root-turn",
+          updatedAtUnixMs: 4
+        }
+      });
+    });
+    await waitFor(() =>
+      expect(rendered.result.current.activityRootFacts.get("root")).toEqual({
+        needsUserAction: true,
+        status: "working"
+      })
+    );
 
     rendered.unmount();
     engine.dispose();
@@ -251,13 +330,13 @@ describe("useAgentGUIConversationRailQuery Activity facts", () => {
   });
 });
 
-function runningChildTurn(): AgentActivityTurn {
+function runningChildTurn(updatedAtUnixMs = 2): AgentActivityTurn {
   return {
     agentSessionId: "child",
     origin: "provider_initiated",
     phase: "running",
     startedAtUnixMs: 2,
     turnId: "child-turn",
-    updatedAtUnixMs: 2
+    updatedAtUnixMs
   };
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import {
   selectAttentionReadState,
+  selectRootAgentSessionIdsWithPendingInteractions,
   selectWorkspaceAgentConsumerSessions
 } from "@tutti-os/agent-activity-core";
 import {
@@ -271,13 +272,18 @@ function selectEmptyAgentGUIConversationActivityRootFacts(): ReadonlyMap<
 function selectAgentGUIConversationActivityRootFacts(
   state: Parameters<typeof selectWorkspaceAgentConsumerSessions>[0]
 ): ReadonlyMap<string, AgentGUIConversationActivityRootFact> {
+  const rootSessionIdsAwaitingUserAction = new Set(
+    selectRootAgentSessionIdsWithPendingInteractions(state)
+  );
   return new Map(
     selectWorkspaceAgentConsumerSessions(state)
       .filter((item) => item.session.visible !== false)
       .map((item) => [
         item.session.agentSessionId,
         {
-          needsUserAction: item.pendingInteractions.length > 0,
+          needsUserAction: rootSessionIdsAwaitingUserAction.has(
+            item.session.agentSessionId
+          ),
           status: item.displayStatus === "idle" ? "ready" : item.displayStatus
         }
       ])

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts
@@ -1,8 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import {
   selectAttentionReadState,
-  selectWorkspaceAgentConsumerSessions,
-  selectWorkspaceAgentRootConversationSessions
+  selectWorkspaceAgentConsumerSessions
 } from "@tutti-os/agent-activity-core";
 import {
   useAgentGUIRuntime,
@@ -270,10 +269,10 @@ function selectEmptyAgentGUIConversationActivityRootFacts(): ReadonlyMap<
 }
 
 function selectAgentGUIConversationActivityRootFacts(
-  state: Parameters<typeof selectWorkspaceAgentRootConversationSessions>[0]
+  state: Parameters<typeof selectWorkspaceAgentConsumerSessions>[0]
 ): ReadonlyMap<string, AgentGUIConversationActivityRootFact> {
   return new Map(
-    selectWorkspaceAgentRootConversationSessions(state)
+    selectWorkspaceAgentConsumerSessions(state)
       .filter((item) => item.session.visible !== false)
       .map((item) => [
         item.session.agentSessionId,


### PR DESCRIPTION
## 背景

Agent Activity View 的左侧列表曾聚合子 Agent 的 working/waiting lifecycle。当子 Agent 的完成通知晚于主会话结束到达且未被持久化时，主会话行会长期显示 loading；普通 Rail 与 Activity View 的状态口径也因此不一致。

## 变更

- Activity View 根行的 lifecycle 状态只读取主 Session；子 Agent lifecycle 继续保留在会话详情
- 子 Session 的 pending Interaction 仍通过 canonical root-attention selector 提醒根会话，避免隐藏审批或问题，并保留精确子 Session/Turn/Interaction 身份
- Codex app-server 刷新 live provider thread identity，并在主 Turn 已结束后继续投递晚到的子 Agent 事件
- 按 canonical `rootTurnId` 分流子事件：当前 Turn 所有的事件走其 emitter，旧 Turn 的晚到子事件绕开新 Turn emitter，避免被新 Turn acceptance/close fence 丢弃
- Controller 对 Session event sink 收到的终态事件复用 commit-before-publish durable barrier；持久化失败时不向消费者广播未提交终态
- 同步更新 Activity View 架构、PRD 和子 Agent 排障文档

## 验证

- `pnpm check:changed`
- `pnpm check:changed -- --push-ready`（16 lanes）
- AgentGUI：311 个测试文件、2737 个测试通过
- `go test ./packages/agent/daemon/runtime -count=1`
- 新增并发回归重复 20 次通过：旧子 Turn 在新主 Turn 活跃时仍独立投递
- 新增 durable barrier 回归：提交完成前不发布，提交失败时不发布