### PR TITLE
refactor(connectors): inject remote MCP client factory

### DIFF
--- a/docs/architecture/connector-remote-mcp.md
+++ b/docs/architecture/connector-remote-mcp.md
@@ -5,9 +5,12 @@
 ## 当前落地范围
 
 Tutti 侧已经采用独立的 MCP `2026-07-28` 无状态 HTTP Client，不复用旧 Stdio / Legacy
-Streamable HTTP Client。Gateway Base URL 默认是 `https://api.tutti.sh/api/desktop`，可通过
-`TUTTI_CONNECTOR_MCP_BASE_URL` 按环境覆盖；实际地址固定派生为
-`POST {baseUrl}/mcp/connectors/{connectorId}`，Connector 无法覆盖该地址。
+Streamable HTTP Client。公共 `ImplementationHost` 通过
+`RemoteMCPClientFactory` 请求一个产品实现的远端 Client，不再持有 Gateway Base URL、
+HTTP Client 或账号授权回调。Tuttid 的 Direct Factory 使用默认
+`https://api.tutti.sh/api/desktop`（可通过 `TUTTI_CONNECTOR_MCP_BASE_URL` 覆盖），并把
+实际地址固定派生为 `POST {baseUrl}/mcp/connectors/{connectorId}`；Connector 无法覆盖
+该地址。VM-backed 产品可以提供指向 typed desktop relay 的 Factory。
 
 Remote Connector 在建立 Route 时仍会解析本地安装发布物，并把其中合法的 `skills/`
 目录投影为 Agent Skill Root；它只是不创建本地执行快照、不启动 Connector 进程。Agent
@@ -135,6 +138,25 @@ Cookie: <Tutti account session>
 `MCP-Protocol-Version`、`Mcp-Method`、`Mcp-Name` 和 Connector Version 必须与 Body 中对应字段一致。当 `Mcp-Name` 或 `Mcp-Param-*` 不是安全的纯 ASCII Header 值时，必须使用 MCP Base64 Sentinel 编码。HTTP Client 从 `tools/list` 校验 `x-mcp-header` 声明，排除不合法的 Tool，并在 `tools/call` 时将合法的基本类型参数映射到 `Mcp-Param-*` Header。
 
 ## 客户端架构
+
+公共 Host 与产品连接策略通过以下 Port 隔离：
+
+```text
+ImplementationHost
+  -> RemoteMCPClientFactory
+       -> Tuttid Direct Factory -> Tutti Gateway
+       -> VM Product Factory    -> typed desktop relay -> Tutti Gateway
+```
+
+Factory request 只携带 operation、connection、Connector、account、release、generation
+和 signed binding contract 等非凭证身份。公共 Host 继续负责 `server/discover`、
+`tools/list`、Tool Schema 注册、Route publication、generation fence 和 Close；Factory
+只负责创建实现这些协议方法的 Client。产品不得通过通用 `RoundTripper` 静默改变业务
+目标，也不得把账号 Cookie、Provider Credential 或任意上游 URL 放入 Factory request。
+
+Tuttid Direct Factory 在每次请求时通过 daemon-owned authorizer 注入当前账号 Cookie。
+VM-backed Factory 使用其产品本地 capability 到达 desktop relay，由 desktop host 校验
+生命周期身份并注入账号 Cookie；Relay 失败时不得回退为 VM 持有账号 Session 直连。
 
 远程 HTTP MCP 和本地托管 MCP 使用两个独立的协议 Client：
 

--- a/packages/connector/runtime/README.md
+++ b/packages/connector/runtime/README.md
@@ -10,9 +10,13 @@ Connector discovery, stable CLI shims, verified Connector Skill discovery, and
 the session-bound loopback MCP server used by native Agent MCP clients.
 
 Hosts supply the managed runtime resolver, implementation host, process
-transport, HTTP client/proxy policy, state roots, and product-facing command
+transport, `RemoteMCPClientFactory`, state roots, and product-facing command
 transport. Runtime code must not import `services/tuttid` or expose host
-filesystem paths as a cross-machine protocol.
+filesystem paths as a cross-machine protocol. `ImplementationHost` owns remote
+MCP bootstrap and route lifecycle, while the product factory owns the physical
+connection path and request authorization. A desktop host may connect directly
+to its Gateway; a VM-backed host may return a client for a typed desktop relay
+without hiding target rewrites inside a generic HTTP transport.
 
 `mcpserver.Start` projects one `implementationhost.MCPRegistry` through the
 stateless Connector Streamable HTTP protocol on an ephemeral loopback port.

--- a/packages/connector/runtime/implementationhost/host.go
+++ b/packages/connector/runtime/implementationhost/host.go
@@ -5,9 +5,9 @@ package implementationhost
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -32,45 +32,70 @@ type ReconcileRequest struct {
 	Runtime market.RuntimeReconcileRequest
 }
 
+// RemoteMCPClient is the protocol client required by one remote Connector
+// route. Products decide whether the client connects directly to their MCP
+// Gateway or through a product-owned relay.
+type RemoteMCPClient interface {
+	Call(context.Context, string, any) (json.RawMessage, error)
+	RegisterTool(string, map[string]any) error
+	ReplaceTools(map[string]map[string]any) error
+	Close(context.Context) error
+}
+
+// RemoteMCPClientRequest carries the complete non-credential identity of one
+// remote Connector route. A product adapter may use it to bind a relay request
+// to the lifecycle operation without exposing account credentials to the
+// runtime machine.
+type RemoteMCPClientRequest struct {
+	OperationID    string
+	ConnectionID   string
+	ConnectorKey   string
+	AccountID      string
+	ReleaseDigest  string
+	Version        string
+	Generation     market.HostGeneration
+	Implementation market.RemoteStreamableHTTPImplementation
+}
+
+// RemoteMCPClientFactory is the product port for remote Connector MCP
+// connectivity. ImplementationHost owns protocol bootstrap and route
+// lifecycle; the factory owns the physical connection path and request
+// authorization.
+type RemoteMCPClientFactory interface {
+	NewRemoteMCPClient(context.Context, RemoteMCPClientRequest) (RemoteMCPClient, error)
+}
+
 type Config struct {
-	Artifacts                     PreparedArtifactResolver
-	CLIInstallations              market.CLIInstallationManager
-	Runtimes                      connectorruntime.ConnectorRuntimeResolver
-	Processes                     agentruntime.ProcessTransport
-	Routes                        RouteObserver
-	Authorization                 AuthorizationObserver
-	Registry                      *RouteRegistry
-	MCP                           *MCPRegistry
-	StateRoot                     string
-	BinDir                        string
-	UserHome                      string
-	MCPStartupTimeout             time.Duration
-	RemoteHTTPClient              *http.Client
-	RemoteMCPBaseURL              string
-	RemoteMCPTimeout              time.Duration
-	RemoteMCPMaxResponse          int
-	AuthorizeRemoteAccountRequest func(*http.Request, string) error
+	Artifacts              PreparedArtifactResolver
+	CLIInstallations       market.CLIInstallationManager
+	Runtimes               connectorruntime.ConnectorRuntimeResolver
+	Processes              agentruntime.ProcessTransport
+	Routes                 RouteObserver
+	Authorization          AuthorizationObserver
+	Registry               *RouteRegistry
+	MCP                    *MCPRegistry
+	StateRoot              string
+	BinDir                 string
+	UserHome               string
+	MCPStartupTimeout      time.Duration
+	RemoteMCPClientFactory RemoteMCPClientFactory
 }
 
 type Host struct {
-	artifacts                     PreparedArtifactResolver
-	planner                       *connectorruntime.ManagedRoutePlanner
-	processes                     agentruntime.ProcessTransport
-	routeObserver                 RouteObserver
-	authorizationObserver         AuthorizationObserver
-	mcpStartupTimeout             time.Duration
-	routes                        *connectorruntime.RouteTable
-	snapshots                     *connectorruntime.ExecutionSnapshotter
-	authorizationProvider         *managedCredentialAuthorizationProvider
-	authorizationMu               sync.Mutex
-	authorizationRoutes           map[string]*connectorRoute
-	remoteHTTPClient              *http.Client
-	remoteMCPBaseURL              string
-	remoteMCPTimeout              time.Duration
-	remoteMCPMaxResponse          int
-	authorizeRemoteAccountRequest func(*http.Request, string) error
-	mcpRegistry                   *MCPRegistry
-	binDir                        string
+	artifacts              PreparedArtifactResolver
+	planner                *connectorruntime.ManagedRoutePlanner
+	processes              agentruntime.ProcessTransport
+	routeObserver          RouteObserver
+	authorizationObserver  AuthorizationObserver
+	mcpStartupTimeout      time.Duration
+	routes                 *connectorruntime.RouteTable
+	snapshots              *connectorruntime.ExecutionSnapshotter
+	authorizationProvider  *managedCredentialAuthorizationProvider
+	authorizationMu        sync.Mutex
+	authorizationRoutes    map[string]*connectorRoute
+	remoteMCPClientFactory RemoteMCPClientFactory
+	mcpRegistry            *MCPRegistry
+	binDir                 string
 }
 
 type connectorRoute struct {
@@ -82,7 +107,7 @@ type connectorRoute struct {
 	mcpTools               map[string]registeredMCPTool
 	closeMu                sync.Mutex
 	mcpClient              *mcp.StdioClient
-	remoteMCP              *mcp.ModernStreamableHTTPClient
+	remoteMCP              RemoteMCPClient
 	executionRoot          string
 	installedRoot          string
 	displayName            string
@@ -117,12 +142,6 @@ func New(config Config) (*Host, error) {
 	if config.MCPStartupTimeout <= 0 {
 		config.MCPStartupTimeout = 15 * time.Second
 	}
-	if config.RemoteMCPTimeout <= 0 {
-		config.RemoteMCPTimeout = 30 * time.Second
-	}
-	if config.RemoteMCPMaxResponse <= 0 {
-		config.RemoteMCPMaxResponse = 4 * 1024 * 1024
-	}
 	snapshots, err := connectorruntime.NewExecutionSnapshotter(config.StateRoot)
 	if err != nil {
 		return nil, err
@@ -137,22 +156,18 @@ func New(config Config) (*Host, error) {
 	config.Registry.attach(routes)
 	config.MCP.attach(routes)
 	host := &Host{
-		artifacts:                     config.Artifacts,
-		planner:                       planner,
-		processes:                     config.Processes,
-		routeObserver:                 config.Routes,
-		authorizationObserver:         config.Authorization,
-		mcpStartupTimeout:             config.MCPStartupTimeout,
-		routes:                        routes,
-		snapshots:                     snapshots,
-		authorizationRoutes:           make(map[string]*connectorRoute),
-		remoteHTTPClient:              config.RemoteHTTPClient,
-		remoteMCPBaseURL:              strings.TrimRight(strings.TrimSpace(config.RemoteMCPBaseURL), "/"),
-		remoteMCPTimeout:              config.RemoteMCPTimeout,
-		remoteMCPMaxResponse:          config.RemoteMCPMaxResponse,
-		authorizeRemoteAccountRequest: config.AuthorizeRemoteAccountRequest,
-		mcpRegistry:                   config.MCP,
-		binDir:                        config.BinDir,
+		artifacts:              config.Artifacts,
+		planner:                planner,
+		processes:              config.Processes,
+		routeObserver:          config.Routes,
+		authorizationObserver:  config.Authorization,
+		mcpStartupTimeout:      config.MCPStartupTimeout,
+		routes:                 routes,
+		snapshots:              snapshots,
+		authorizationRoutes:    make(map[string]*connectorRoute),
+		remoteMCPClientFactory: config.RemoteMCPClientFactory,
+		mcpRegistry:            config.MCP,
+		binDir:                 config.BinDir,
 	}
 	host.authorizationProvider = newManagedCredentialAuthorizationProvider(host)
 	return host, nil

--- a/packages/connector/runtime/implementationhost/mcp_routes.go
+++ b/packages/connector/runtime/implementationhost/mcp_routes.go
@@ -5,12 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
-	"net/url"
 	"strings"
 
 	market "github.com/tutti-os/tutti/packages/connector/host"
-	"github.com/tutti-os/tutti/packages/connector/runtime/mcp"
 )
 
 func (host *Host) buildRemoteRoute(ctx context.Context, request market.RuntimeReconcileRequest) (*connectorRoute, error) {
@@ -19,27 +16,19 @@ func (host *Host) buildRemoteRoute(ctx context.Context, request market.RuntimeRe
 		return nil, errors.New("remote_streamable_http connector config is unavailable")
 	}
 	accountID := strings.TrimSpace(request.Scope.AccountID)
-	if accountID == "" || host.authorizeRemoteAccountRequest == nil {
-		return nil, errors.New("remote MCP host-session authentication is unavailable")
+	if accountID == "" || host.remoteMCPClientFactory == nil {
+		return nil, errors.New("remote MCP product client factory is unavailable")
 	}
-	base, err := url.Parse(host.remoteMCPBaseURL)
-	if err != nil || base.Scheme == "" || base.Host == "" {
-		return nil, errors.New("remote MCP Gateway base URL is unavailable")
-	}
-	endpoint, err := url.JoinPath(base.String(), "mcp", "connectors", request.Connector.Key)
-	if err != nil {
-		return nil, errors.New("build remote MCP Gateway endpoint")
-	}
-	connectorVersion := strings.TrimSpace(request.Connector.Release.Version)
-	client, err := mcp.NewModernStreamableHTTPClient(mcp.ModernStreamableHTTPClientConfig{
-		Endpoint: endpoint, AllowedHosts: []string{base.Hostname()}, ConnectorVersion: connectorVersion,
-		HTTPClient: host.remoteHTTPClient, AuthorizeRequest: func(httpRequest *http.Request) error {
-			return host.authorizeRemoteAccountRequest(httpRequest, accountID)
-		},
-		Timeout: host.remoteMCPTimeout, MaxResponseBytes: host.remoteMCPMaxResponse,
+	client, err := host.remoteMCPClientFactory.NewRemoteMCPClient(ctx, RemoteMCPClientRequest{
+		OperationID: request.OperationID, ConnectionID: request.ConnectionID,
+		ConnectorKey: request.Connector.Key, AccountID: accountID,
+		ReleaseDigest:  request.Connector.Release.ReleaseDigest,
+		Version:        request.Connector.Release.Version,
+		Generation:     request.Generation,
+		Implementation: *remote,
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("create remote connector MCP client: %w", err)
 	}
 	closeClient := func() { _ = client.Close(context.Background()) }
 	if _, err := client.Call(ctx, "server/discover", map[string]any{}); err != nil {

--- a/packages/connector/runtime/implementationhost/remote_mcp_client_factory_test.go
+++ b/packages/connector/runtime/implementationhost/remote_mcp_client_factory_test.go
@@ -1,0 +1,83 @@
+package implementationhost
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	market "github.com/tutti-os/tutti/packages/connector/host"
+	"github.com/tutti-os/tutti/packages/connector/runtime/mcp"
+)
+
+type remoteMCPFactoryRecorder struct {
+	request RemoteMCPClientRequest
+	client  RemoteMCPClient
+}
+
+func (factory *remoteMCPFactoryRecorder) NewRemoteMCPClient(_ context.Context, request RemoteMCPClientRequest) (RemoteMCPClient, error) {
+	factory.request = request
+	return factory.client, nil
+}
+
+type remoteMCPClientStub struct {
+	calls      []string
+	registered []string
+	closed     bool
+}
+
+func (client *remoteMCPClientStub) Call(_ context.Context, method string, _ any) (json.RawMessage, error) {
+	client.calls = append(client.calls, method)
+	if method == "tools/list" {
+		return json.RawMessage(`{"resultType":"complete","tools":[{"name":"search","description":"Search","inputSchema":{"type":"object"}}]}`), nil
+	}
+	return json.RawMessage(`{"resultType":"complete"}`), nil
+}
+
+func (client *remoteMCPClientStub) RegisterTool(name string, _ map[string]any) error {
+	client.registered = append(client.registered, name)
+	return nil
+}
+
+func (*remoteMCPClientStub) ReplaceTools(map[string]map[string]any) error { return nil }
+
+func (client *remoteMCPClientStub) Close(context.Context) error {
+	client.closed = true
+	return nil
+}
+
+func TestBuildRemoteRouteUsesProductClientFactoryWithLifecycleIdentity(t *testing.T) {
+	client := &remoteMCPClientStub{}
+	factory := &remoteMCPFactoryRecorder{client: client}
+	host := &Host{remoteMCPClientFactory: factory}
+	implementation := market.RemoteStreamableHTTPImplementation{
+		ProtocolVersion: mcp.ModernProtocolVersion, BindingRef: "documents.primary", ContractVersion: 1,
+		BindingContractHash: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+	}
+	generation := market.HostGeneration{BootEpoch: "boot-1", Generation: 7}
+	request := market.RuntimeReconcileRequest{
+		OperationID: "operation-1", ConnectionID: "connection-1", Scope: market.OperationScope{AccountID: "account-1"},
+		Connector: market.Connector{Key: "documents", Release: market.Release{
+			Version: "1.2.3", ReleaseDigest: "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+			Manifest: market.Manifest{Implementation: market.Implementation{
+				Kind: market.ImplementationKindRemoteStreamableHTTP, RemoteStreamableHTTP: &implementation,
+			}},
+		}},
+		Generation: generation,
+	}
+	route, err := host.buildRemoteRoute(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := RemoteMCPClientRequest{
+		OperationID: "operation-1", ConnectionID: "connection-1", ConnectorKey: "documents", AccountID: "account-1",
+		ReleaseDigest: request.Connector.Release.ReleaseDigest, Version: "1.2.3", Generation: generation, Implementation: implementation,
+	}
+	if !reflect.DeepEqual(factory.request, want) {
+		t.Fatalf("factory request = %#v, want %#v", factory.request, want)
+	}
+	if route.remoteMCP != client || !reflect.DeepEqual(client.calls, []string{"server/discover", "tools/list"}) ||
+		!reflect.DeepEqual(client.registered, []string{"search"}) {
+		t.Fatalf("remote client bootstrap = route:%v calls:%#v registered:%#v", route.remoteMCP == client, client.calls, client.registered)
+	}
+}

--- a/services/tuttid/service/connectormarket/implementation_host.go
+++ b/services/tuttid/service/connectormarket/implementation_host.go
@@ -3,7 +3,6 @@ package connectormarket
 import (
 	"context"
 	"errors"
-	"net/http"
 	"os"
 	"runtime"
 	"time"
@@ -23,20 +22,16 @@ type ConnectorRuntimeRegistry struct {
 }
 
 type ImplementationHostConfig struct {
-	Artifacts                     PreparedArtifactResolver
-	CLIInstallations              market.CLIInstallationManager
-	Runtimes                      ConnectorRuntimeResolver
-	Processes                     agentruntime.ProcessTransport
-	Registry                      *ConnectorRuntimeRegistry
-	StateRoot                     string
-	BinDir                        string
-	UserHome                      string
-	MCPStartupTimeout             time.Duration
-	RemoteHTTPClient              *http.Client
-	RemoteMCPBaseURL              string
-	RemoteMCPTimeout              time.Duration
-	RemoteMCPMaxResponse          int
-	AuthorizeRemoteAccountRequest func(*http.Request, string) error
+	Artifacts              PreparedArtifactResolver
+	CLIInstallations       market.CLIInstallationManager
+	Runtimes               ConnectorRuntimeResolver
+	Processes              agentruntime.ProcessTransport
+	Registry               *ConnectorRuntimeRegistry
+	StateRoot              string
+	BinDir                 string
+	UserHome               string
+	MCPStartupTimeout      time.Duration
+	RemoteMCPClientFactory implementationhost.RemoteMCPClientFactory
 }
 
 // ImplementationHost adapts the host-neutral Connector runtime to tuttId.
@@ -71,9 +66,7 @@ func NewImplementationHost(config ImplementationHostConfig) (*ImplementationHost
 		Artifacts: config.Artifacts, CLIInstallations: config.CLIInstallations, Runtimes: config.Runtimes,
 		Processes: config.Processes, Registry: config.Registry.runtime, MCP: config.Registry.mcp, StateRoot: config.StateRoot, BinDir: config.BinDir,
 		UserHome: config.UserHome, MCPStartupTimeout: config.MCPStartupTimeout,
-		RemoteHTTPClient: config.RemoteHTTPClient, RemoteMCPBaseURL: config.RemoteMCPBaseURL,
-		RemoteMCPTimeout: config.RemoteMCPTimeout, RemoteMCPMaxResponse: config.RemoteMCPMaxResponse,
-		AuthorizeRemoteAccountRequest: config.AuthorizeRemoteAccountRequest,
+		RemoteMCPClientFactory: config.RemoteMCPClientFactory,
 	})
 	if err != nil {
 		return nil, err

--- a/services/tuttid/service/connectormarket/implementation_host_test.go
+++ b/services/tuttid/service/connectormarket/implementation_host_test.go
@@ -380,18 +380,24 @@ func TestImplementationHostDiscoversAndInvokesRemoteStreamableHTTPMCP(t *testing
 		return (&net.Dialer{}).DialContext(ctx, network, server.Listener.Addr().String())
 	}
 	endpoint := strings.Replace(server.URL, "127.0.0.1", "example.com", 1)
-	host, err := NewImplementationHost(ImplementationHostConfig{
-		Artifacts: preparedResolverStub{receipt: market.PreparedArtifactReceipt{PreparedPath: root}}, Runtimes: connectorRuntimeStub{executable: connectorruntime.ConnectorExecutable{
-			Path: runtimePath, SHA256: strings.Repeat("a", 64), SizeBytes: 7,
-		}}, Processes: &connectorProcessStub{}, Registry: commands, StateRoot: t.TempDir(),
-		RemoteHTTPClient: &http.Client{Transport: transport}, RemoteMCPBaseURL: endpoint,
-		AuthorizeRemoteAccountRequest: func(request *http.Request, accountID string) error {
+	remoteMCPClientFactory, err := NewDirectRemoteMCPClientFactory(DirectRemoteMCPClientFactoryConfig{
+		BaseURL: endpoint, HTTPClient: &http.Client{Transport: transport},
+		AuthorizeAccountRequest: func(request *http.Request, accountID string) error {
 			if accountID != "account-1" {
 				t.Fatalf("accountID = %q", accountID)
 			}
 			request.Header.Set("Cookie", "session_id=user-session")
 			return nil
 		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, err := NewImplementationHost(ImplementationHostConfig{
+		Artifacts: preparedResolverStub{receipt: market.PreparedArtifactReceipt{PreparedPath: root}}, Runtimes: connectorRuntimeStub{executable: connectorruntime.ConnectorExecutable{
+			Path: runtimePath, SHA256: strings.Repeat("a", 64), SizeBytes: 7,
+		}}, Processes: &connectorProcessStub{}, Registry: commands, StateRoot: t.TempDir(),
+		RemoteMCPClientFactory: remoteMCPClientFactory,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/services/tuttid/service/connectormarket/remote_mcp_client_factory.go
+++ b/services/tuttid/service/connectormarket/remote_mcp_client_factory.go
@@ -1,0 +1,78 @@
+package connectormarket
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	implementationhost "github.com/tutti-os/tutti/packages/connector/runtime/implementationhost"
+	"github.com/tutti-os/tutti/packages/connector/runtime/mcp"
+)
+
+type DirectRemoteMCPClientFactoryConfig struct {
+	BaseURL                 string
+	HTTPClient              *http.Client
+	Timeout                 time.Duration
+	MaxResponseBytes        int
+	AuthorizeAccountRequest func(*http.Request, string) error
+}
+
+// DirectRemoteMCPClientFactory is the Tuttid product adapter for remote MCP.
+// It connects directly to the configured Tutti Gateway and reads account
+// authorization through the daemon-owned authorizer on every request.
+type DirectRemoteMCPClientFactory struct {
+	base                    *url.URL
+	httpClient              *http.Client
+	timeout                 time.Duration
+	maxResponseBytes        int
+	authorizeAccountRequest func(*http.Request, string) error
+}
+
+func NewDirectRemoteMCPClientFactory(config DirectRemoteMCPClientFactoryConfig) (*DirectRemoteMCPClientFactory, error) {
+	base, err := url.Parse(strings.TrimSpace(config.BaseURL))
+	if err != nil || base.Scheme == "" || base.Host == "" || base.User != nil || base.RawQuery != "" || base.Fragment != "" {
+		return nil, errors.New("remote MCP Gateway base URL is unavailable")
+	}
+	if config.AuthorizeAccountRequest == nil {
+		return nil, errors.New("remote MCP account authorizer is unavailable")
+	}
+	if config.Timeout <= 0 {
+		config.Timeout = 30 * time.Second
+	}
+	if config.MaxResponseBytes <= 0 {
+		config.MaxResponseBytes = 4 * 1024 * 1024
+	}
+	return &DirectRemoteMCPClientFactory{
+		base: base, httpClient: config.HTTPClient, timeout: config.Timeout,
+		maxResponseBytes: config.MaxResponseBytes, authorizeAccountRequest: config.AuthorizeAccountRequest,
+	}, nil
+}
+
+func (factory *DirectRemoteMCPClientFactory) NewRemoteMCPClient(
+	_ context.Context,
+	request implementationhost.RemoteMCPClientRequest,
+) (implementationhost.RemoteMCPClient, error) {
+	if factory == nil || factory.base == nil || factory.authorizeAccountRequest == nil {
+		return nil, errors.New("remote MCP client factory is unavailable")
+	}
+	connectorKey := strings.TrimSpace(request.ConnectorKey)
+	accountID := strings.TrimSpace(request.AccountID)
+	if connectorKey == "" || accountID == "" {
+		return nil, errors.New("remote MCP route identity is invalid")
+	}
+	endpoint, err := url.JoinPath(factory.base.String(), "mcp", "connectors", connectorKey)
+	if err != nil {
+		return nil, errors.New("build remote MCP Gateway endpoint")
+	}
+	return mcp.NewModernStreamableHTTPClient(mcp.ModernStreamableHTTPClientConfig{
+		Endpoint: endpoint, AllowedHosts: []string{factory.base.Hostname()},
+		ConnectorVersion: strings.TrimSpace(request.Version), HTTPClient: factory.httpClient,
+		AuthorizeRequest: func(httpRequest *http.Request) error {
+			return factory.authorizeAccountRequest(httpRequest, accountID)
+		},
+		Timeout: factory.timeout, MaxResponseBytes: factory.maxResponseBytes,
+	})
+}

--- a/services/tuttid/service/connectormarket/remote_mcp_client_factory_test.go
+++ b/services/tuttid/service/connectormarket/remote_mcp_client_factory_test.go
@@ -1,0 +1,59 @@
+package connectormarket
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	market "github.com/tutti-os/tutti/packages/connector/host"
+	implementationhost "github.com/tutti-os/tutti/packages/connector/runtime/implementationhost"
+	"github.com/tutti-os/tutti/packages/connector/runtime/mcp"
+)
+
+func TestDirectRemoteMCPClientFactoryBuildsFixedGatewayRouteAndAuthorizesAccount(t *testing.T) {
+	var gotAccountID string
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/api/desktop/mcp/connectors/documents" || request.Header.Get("Cookie") != "session_id=session-1" {
+			t.Errorf("request path/cookie = %q / %q", request.URL.Path, request.Header.Get("Cookie"))
+		}
+		var message struct {
+			ID json.RawMessage `json:"id"`
+		}
+		if err := json.NewDecoder(request.Body).Decode(&message); err != nil {
+			t.Error(err)
+			return
+		}
+		response.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(response).Encode(map[string]any{
+			"jsonrpc": "2.0", "id": message.ID, "result": map[string]any{"resultType": "complete"},
+		})
+	}))
+	defer server.Close()
+
+	factory, err := NewDirectRemoteMCPClientFactory(DirectRemoteMCPClientFactoryConfig{
+		BaseURL: server.URL + "/api/desktop", HTTPClient: server.Client(),
+		AuthorizeAccountRequest: func(request *http.Request, accountID string) error {
+			gotAccountID = accountID
+			request.Header.Set("Cookie", "session_id=session-1")
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := factory.NewRemoteMCPClient(context.Background(), implementationhost.RemoteMCPClientRequest{
+		ConnectorKey: "documents", AccountID: "account-1", Version: "1.2.3",
+		Implementation: market.RemoteStreamableHTTPImplementation{ProtocolVersion: mcp.ModernProtocolVersion},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Call(context.Background(), "server/discover", map[string]any{}); err != nil {
+		t.Fatal(err)
+	}
+	if gotAccountID != "account-1" {
+		t.Fatalf("authorized account = %q", gotAccountID)
+	}
+}

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -313,16 +313,21 @@ func (w *tuttiWiring) buildWorkspaceModule(ctx context.Context) error {
 	if connectorMCPBaseURL == "" {
 		connectorMCPBaseURL = connectorMCPDefaultBaseURL
 	}
+	remoteMCPClientFactory, err := connectormarketservice.NewDirectRemoteMCPClientFactory(connectormarketservice.DirectRemoteMCPClientFactoryConfig{
+		BaseURL: connectorMCPBaseURL, HTTPClient: agenthttpx.NewClient(2 * time.Minute),
+		Timeout: 30 * time.Second, MaxResponseBytes: 4 * 1024 * 1024,
+		AuthorizeAccountRequest: marketAuthorizer.AuthorizeForAccount,
+	})
+	if err != nil {
+		return fmt.Errorf("configure remote connector MCP client factory: %w", err)
+	}
 	implementationHost, err := connectormarketservice.NewImplementationHost(connectormarketservice.ImplementationHostConfig{
 		Artifacts: artifactPreparer, CLIInstallations: nodePackageInstaller,
 		Runtimes: runtimeResolver, Processes: processTransport, Registry: connectorRegistry,
-		RemoteHTTPClient: agenthttpx.NewClient(2 * time.Minute),
-		RemoteMCPBaseURL: connectorMCPBaseURL,
-		RemoteMCPTimeout: 30 * time.Second, RemoteMCPMaxResponse: 4 * 1024 * 1024,
-		AuthorizeRemoteAccountRequest: marketAuthorizer.AuthorizeForAccount,
-		StateRoot:                     filepath.Join(connectorStateRoot, "user-state"),
-		BinDir:                        filepath.Join(tuttitypes.DefaultStateDir(), "bin"),
-		UserHome:                      userHome,
+		RemoteMCPClientFactory: remoteMCPClientFactory,
+		StateRoot:              filepath.Join(connectorStateRoot, "user-state"),
+		BinDir:                 filepath.Join(tuttitypes.DefaultStateDir(), "bin"),
+		UserHome:               userHome,
 	})
 	if err != nil {
 		return fmt.Errorf("configure connector implementation host: %w", err)


### PR DESCRIPTION
## Summary

- extract a host-neutral RemoteMCPClientFactory port from Connector ImplementationHost
- keep protocol bootstrap and route lifecycle in the shared host while moving physical connectivity and authorization into product adapters
- add the Tuttid direct Gateway adapter and document the VM typed-relay composition path

## Verification

- `cd packages/connector/runtime && go test ./implementationhost ./mcp`
- `cd services/tuttid && go test ./service/connectormarket`
- `pnpm check:changed`
- `pnpm release:pack:check`

## Docs impact

Updated the Connector runtime README and remote MCP architecture document.