### PR TITLE
fix(agent): preserve create settings and sandbox temp writes

### DIFF
--- a/packages/agent/daemon/runtime/codex_appserver_adapter_execution_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_execution_test.go
@@ -291,6 +291,10 @@ func TestCodexAppServerAdapterExecAutoPermissionUsesAutoReviewer(t *testing.T) {
 	if asString(sandboxPolicy["type"]) != "workspaceWrite" {
 		t.Fatalf("turn/start sandboxPolicy = %#v", turnStart["sandboxPolicy"])
 	}
+	writableRoots, ok := sandboxPolicy["writableRoots"].([]any)
+	if !ok || len(writableRoots) != 1 || asString(writableRoots[0]) != "/sandbox-tmp" {
+		t.Fatalf("turn/start sandboxPolicy writableRoots = %#v, want [/sandbox-tmp]", sandboxPolicy["writableRoots"])
+	}
 	if asString(turnStart["approvalsReviewer"]) != "auto_review" {
 		t.Fatalf("turn/start approvalsReviewer = %q, want auto_review", turnStart["approvalsReviewer"])
 	}

--- a/packages/agent/daemon/runtime/codex_appserver_event_params.go
+++ b/packages/agent/daemon/runtime/codex_appserver_event_params.go
@@ -349,7 +349,10 @@ func codexAppServerSandboxPolicy(modeID string, commandNetworkAccess bool) map[s
 	case "read-only":
 		policy = map[string]any{"type": "readOnly"}
 	case "auto":
-		policy = map[string]any{"type": "workspaceWrite"}
+		policy = map[string]any{
+			"type":          "workspaceWrite",
+			"writableRoots": []string{"/sandbox-tmp"},
+		}
 	case "full-access":
 		return map[string]any{"type": "dangerFullAccess"}
 	default:

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.spec.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   resolveInitialRailPlacement,
-  resolveInitialTuttiModeActivation
+  resolveInitialTuttiModeActivation,
+  resolveSparseNewConversationActivationSettings
 } from "./useAgentGUINewConversationActivation";
 
 describe("resolveInitialRailPlacement", () => {
@@ -121,5 +122,70 @@ describe("resolveInitialTuttiModeActivation", () => {
       },
       source: "engine_draft"
     });
+  });
+});
+
+describe("resolveSparseNewConversationActivationSettings", () => {
+  it("keeps presented full-access after the optimistic draft was retired", () => {
+    expect(
+      resolveSparseNewConversationActivationSettings({
+        draftSettings: { model: "gpt-5.4" },
+        composerOptions: {
+          effectiveSettings: {
+            model: "gpt-5.4",
+            permissionModeId: "full-access"
+          },
+          permissionConfig: {
+            configurable: true,
+            defaultValue: "full-access",
+            modes: [
+              { id: "auto", label: "Approve for me", semantic: "auto" },
+              {
+                id: "full-access",
+                label: "Full access",
+                semantic: "full-access"
+              }
+            ]
+          },
+          models: [],
+          reasoningEfforts: [],
+          speeds: [],
+          capabilities: {},
+          behavior: {},
+          skills: [],
+          loadedAtUnixMs: 1
+        } as never
+      }).permissionModeId
+    ).toBe("full-access");
+  });
+
+  it("prefers an explicit draft permission over remembered presentation", () => {
+    expect(
+      resolveSparseNewConversationActivationSettings({
+        draftSettings: { permissionModeId: "auto" },
+        composerOptions: {
+          effectiveSettings: { permissionModeId: "full-access" },
+          permissionConfig: {
+            configurable: true,
+            defaultValue: "full-access",
+            modes: [
+              { id: "auto", label: "Approve for me", semantic: "auto" },
+              {
+                id: "full-access",
+                label: "Full access",
+                semantic: "full-access"
+              }
+            ]
+          },
+          models: [],
+          reasoningEfforts: [],
+          speeds: [],
+          capabilities: {},
+          behavior: {},
+          skills: [],
+          loadedAtUnixMs: 1
+        } as never
+      }).permissionModeId
+    ).toBe("auto");
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.ts
@@ -1,4 +1,5 @@
 import {
+  type AgentActivityComposerOptions,
   type AgentActivityInitialGoalControl,
   type AgentActivityRailPlacement,
   isPendingActivationViable,
@@ -9,6 +10,7 @@ import {
 import { useCallback } from "react";
 import { translate } from "../../../i18n/index";
 import type { AgentPromptContentBlock } from "../../../shared/contracts/dto";
+import type { AgentSessionComposerSettings } from "../../../shared/agentSessionTypes";
 import { deriveAgentGUIOptimisticConversationTitle } from "../../../shared/agentConversationTitleProjection";
 import {
   agentPromptContentDisplayText,
@@ -17,11 +19,23 @@ import {
   snapshotAgentComposerDraft,
   textPromptContent
 } from "../model/agentComposerDraft";
-import { readNodeDefaultDraftSettings } from "./agentGuiController.composerHelpers";
+import type { AgentComposerSubmitOptions } from "../composer/AgentComposer.types";
+import { resolveAgentComposerDraftScopeKey } from "../model/agentComposerDraftScope";
+import {
+  type AgentGUIConversationUserProject,
+  resolveAgentGUISelectedUserProject
+} from "../model/agentGuiConversationProjectResolver";
+import {
+  normalizePermissionModeId,
+  permissionConfigFromComposerOptions,
+  readNodeDefaultDraftSettings
+} from "./agentGuiController.composerHelpers";
+import { effectiveComposerSettingsFromOptions } from "./agentGuiController.composerPresentation";
 import { toRuntimeSendContent } from "./agentGuiController.draftMessageHelpers";
 import {
   createAgentGUIConversationId,
-  normalizeOptionalPrompt
+  normalizeOptionalPrompt,
+  normalizeOptionalText
 } from "./agentGuiController.promptHelpers";
 import {
   agentSubmitTraceDiagnostics,
@@ -33,12 +47,6 @@ import {
   type AgentGUINewConversationActivationResult,
   type UseAgentGUINewConversationActivationInput
 } from "./agentGuiNewConversationActivation.types";
-import { resolveAgentComposerDraftScopeKey } from "../model/agentComposerDraftScope";
-import {
-  type AgentGUIConversationUserProject,
-  resolveAgentGUISelectedUserProject
-} from "../model/agentGuiConversationProjectResolver";
-import type { AgentComposerSubmitOptions } from "../composer/AgentComposer.types";
 
 interface ResolvedInitialTuttiModeActivation {
   activation: {
@@ -77,6 +85,80 @@ export function resolveInitialTuttiModeActivation(input: {
 function normalizePreference(value: number | null | undefined) {
   if (typeof value !== "number" || !Number.isFinite(value)) return null;
   return Math.min(100, Math.max(0, Math.round(value)));
+}
+
+function firstResolvedComposerText(
+  ...values: Array<string | null | undefined>
+): string | null {
+  for (const value of values) {
+    const normalized = normalizeOptionalText(value);
+    if (normalized) {
+      return normalized;
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve the sparse Create payload to match the home composer presentation.
+ *
+ * Remembered defaults can retire out of the optimistic draft after authority
+ * confirmation while the UI still shows them via effectiveSettings /
+ * permissionConfig.defaultValue. Create must send those presented values so
+ * the first turn does not fall back to the provider default (for Codex: auto /
+ * "Approve for me").
+ */
+export function resolveSparseNewConversationActivationSettings(input: {
+  draftSettings: AgentSessionComposerSettings;
+  composerOptions: AgentActivityComposerOptions | null;
+  requiredSettingsPatch?: Partial<AgentSessionComposerSettings> | null;
+  codexSaverModeEntryEnabled?: boolean;
+}): AgentSessionComposerSettings {
+  const draft = input.draftSettings ?? {};
+  const patch = input.requiredSettingsPatch ?? {};
+  const effective = effectiveComposerSettingsFromOptions(input.composerOptions);
+  const permissionConfig = permissionConfigFromComposerOptions(
+    input.composerOptions
+  );
+  const model = firstResolvedComposerText(
+    typeof patch.model === "string" ? patch.model : null,
+    draft.model,
+    effective?.model
+  );
+  const reasoningEffort = firstResolvedComposerText(
+    typeof patch.reasoningEffort === "string" ? patch.reasoningEffort : null,
+    draft.reasoningEffort,
+    effective?.reasoningEffort
+  );
+  const speed = firstResolvedComposerText(
+    typeof patch.speed === "string" ? patch.speed : null,
+    draft.speed,
+    effective?.speed
+  );
+  const permissionModeId = firstResolvedComposerText(
+    typeof patch.permissionModeId === "string" ? patch.permissionModeId : null,
+    draft.permissionModeId,
+    effective?.permissionModeId,
+    permissionConfig?.defaultValue
+  );
+  return {
+    ...draft,
+    ...patch,
+    ...(model ? { model } : {}),
+    ...(reasoningEffort ? { reasoningEffort } : {}),
+    ...(speed ? { speed } : {}),
+    ...(permissionModeId
+      ? { permissionModeId: normalizePermissionModeId(permissionModeId) }
+      : {}),
+    // Fail closed at the activation boundary. Presentation gating alone is
+    // insufficient because a remembered draft can outlive the lab flag.
+    codexSaverMode:
+      input.codexSaverModeEntryEnabled === true &&
+      input.composerOptions?.codexSaverModeSupported === true &&
+      (patch.codexSaverMode ??
+        draft.codexSaverMode ??
+        input.composerOptions.effectiveSettings?.codexSaverMode) === true
+  };
 }
 
 export function resolveInitialRailPlacement(input: {
@@ -209,19 +291,16 @@ export function useAgentGUINewConversationActivation(
         drafts: draftSettingsBySessionIdRef.current
       });
       const snapshotComposerOptions = getCachedComposerOptions();
-      // Only sparse, explicit home intent crosses Create. Target defaults and
-      // final provider validation are resolved from the latest daemon state.
-      const settings = {
-        ...initialNodeSettings,
-        ...submitOptions?.requiredSettingsPatch,
-        // Fail closed at the activation boundary. Presentation gating alone is
-        // insufficient because a remembered draft can outlive the lab flag.
-        codexSaverMode:
-          codexSaverModeEntryEnabled === true &&
-          snapshotComposerOptions?.codexSaverModeSupported === true &&
-          (initialNodeSettings.codexSaverMode ??
-            snapshotComposerOptions.effectiveSettings?.codexSaverMode) === true
-      };
+      // Sparse Create settings must match the home presentation. Draft fields
+      // retired after remembered-default acknowledgement still appear in
+      // effectiveSettings / permissionConfig.defaultValue; resolve them here
+      // so the first turn does not fall back to the provider default.
+      const settings = resolveSparseNewConversationActivationSettings({
+        draftSettings: initialNodeSettings,
+        composerOptions: snapshotComposerOptions,
+        requiredSettingsPatch: submitOptions?.requiredSettingsPatch,
+        codexSaverModeEntryEnabled
+      });
       const prewarmedSessionId =
         normalizedInitialContent.length > 0 &&
         snapshotComposerOptions?.behavior?.prewarmDraftSession === true
@@ -328,6 +407,7 @@ export function useAgentGUINewConversationActivation(
       currentUserId,
       data,
       defaultReasoningEffort,
+      getCachedComposerOptions,
       requestRailReveal,
       activation,
       conversationListQuery,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIOperationActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIOperationActions.ts
@@ -1,5 +1,5 @@
 import { selectEngineSession } from "@tutti-os/agent-activity-core";
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import { translate } from "../../../i18n/index";
 import { textPromptContent } from "../model/agentComposerDraft";
 import {
@@ -52,9 +52,19 @@ type UseAgentGUIOperationActionsInput = Omit<
 export function useAgentGUIOperationActions(
   input: UseAgentGUIOperationActionsInput
 ) {
+  // startConversation is memoized without providerComposerOptions in its
+  // dependency list. Read through a ref so Create densification sees the same
+  // live options the home composer is presenting (e.g. auto after the user
+  // switches away from a remembered full-access default).
+  const providerComposerOptionsRef = useRef(input.providerComposerOptions);
+  providerComposerOptionsRef.current = input.providerComposerOptions;
+  const getCachedComposerOptions = useCallback(
+    () => providerComposerOptionsRef.current,
+    []
+  );
   const startConversation = useAgentGUINewConversationActivation({
     ...input,
-    getCachedComposerOptions: () => input.providerComposerOptions
+    getCachedComposerOptions
   });
 
   const { createConversation: enterConversationHome } =


### PR DESCRIPTION
## Summary

- preserve the home composer effective settings when creating a sparse new conversation, including the presented permission mode
- read live provider composer options without destabilizing the conversation-start callback
- grant /sandbox-tmp to Codex workspace-write turns so projected logical /tmp paths remain writable

## Testing

- go test ./runtime -run ^TestCodexAppServerAdapterExecAutoPermissionUsesAutoReviewer$ -count=1
- pnpm exec vitest run agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.spec.ts
- pnpm check:changed
- pre-push check:changed --push-ready (16 lanes)