### PR TITLE
Fix Windows project identity and imported session rail

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.ts
@@ -16,6 +16,7 @@ import type {
   DesktopRuntimeApi
 } from "@preload/types";
 import type { WorkspaceFileEntry } from "@tutti-os/workspace-file-manager/services";
+import { areWorkspaceUserProjectPathsEqual } from "@tutti-os/workspace-user-project/core";
 import type { IDesktopRichTextAtService } from "@renderer/features/rich-text-at";
 import type { IReporterService } from "@renderer/features/analytics";
 import type { IWorkspaceFileManagerService } from "@renderer/features/workspace-file-manager";
@@ -210,8 +211,11 @@ export function createDesktopAgentGUIWorkbenchHostInput({
           const sectionKey =
             workspaceUserProjectService
               ?.getSnapshot()
-              .projects.find(
-                (project) => project.path === searchInput.withinNodeId
+              .projects.find((project) =>
+                areWorkspaceUserProjectPathsEqual(
+                  project.path,
+                  searchInput.withinNodeId
+                )
               )
               ?.sectionKey?.trim() ?? "";
           const items = await agentGeneratedFileMentionProvider.query({

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityImportOperations.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityImportOperations.ts
@@ -43,10 +43,11 @@ export class WorkspaceAgentActivityImportOperations {
         normalizedWorkspaceId,
         request
       );
-    await Promise.all([
-      this.dependencies.refreshActivity(normalizedWorkspaceId),
-      this.dependencies.refreshUserProjects()
-    ]);
+    // Project registration repairs imported rail membership in the daemon.
+    // Refresh it before querying activity so the first rail read uses the
+    // newly registered project section instead of the conversations section.
+    await this.dependencies.refreshUserProjects();
+    await this.dependencies.refreshActivity(normalizedWorkspaceId);
     return result;
   }
 

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityOperations.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityOperations.test.ts
@@ -96,7 +96,7 @@ test("activity import operations refresh activity and projects after daemon impo
   assert.equal(result.importedSessions, 1);
   assert.deepEqual(events, [
     "import:workspace-1",
-    "activity:workspace-1",
-    "projects"
+    "projects",
+    "activity:workspace-1"
   ]);
 });

--- a/apps/desktop/src/renderer/src/features/workspace-user-project/services/internal/desktopWorkspaceUserProjectService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-user-project/services/internal/desktopWorkspaceUserProjectService.test.ts
@@ -42,6 +42,39 @@ test("workspace user project service loads projects into Valtio state once", asy
   assert.equal(service.getRevision() > 0, true);
 });
 
+test("workspace user project service matches Windows project paths by identity", async () => {
+  const service = createService({
+    platformApi: createPlatformApi({
+      homeDirectory: "C:/Users/Demo",
+      os: "win32"
+    }),
+    tuttidClient: createTuttidClient({
+      async listUserProjects() {
+        return {
+          projects: [
+            createProject({
+              id: "project-windows",
+              path: "C:\\Users\\Demo\\Repo"
+            })
+          ]
+        };
+      }
+    })
+  });
+
+  await service.ensureLoaded();
+  assert.equal(service.isNoProjectPath("c:/users/demo/repo/"), false);
+  assert.deepEqual(
+    (
+      await service.prepareSelection({
+        projectLocked: false,
+        selectedPath: "c:/users/demo/repo/"
+      })
+    ).selection,
+    { kind: "none" }
+  );
+});
+
 test("workspace user project service refresh updates projects and preserves them on API failure", async () => {
   const service = createService({
     tuttidClient: createTuttidClient({

--- a/apps/desktop/src/renderer/src/features/workspace-user-project/services/internal/desktopWorkspaceUserProjectService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-user-project/services/internal/desktopWorkspaceUserProjectService.ts
@@ -14,8 +14,11 @@ import type {
   WorkspaceUserProjectValtioStore
 } from "@tutti-os/workspace-user-project/contracts";
 import {
+  areWorkspaceUserProjectPathsEqual,
   pinWorkspaceUserProjectOptimistically,
-  upsertWorkspaceUserProject
+  normalizeWorkspaceUserProjectPath,
+  upsertWorkspaceUserProject,
+  workspaceUserProjectPathIdentityKey
 } from "@tutti-os/workspace-user-project/core";
 import { createWorkspaceUserProjectI18nRuntime } from "@tutti-os/workspace-user-project/i18n";
 import type { DesktopHostFilesApi, DesktopPlatformApi } from "@preload/types";
@@ -136,16 +139,17 @@ export class DesktopWorkspaceUserProjectService implements IWorkspaceUserProject
   }
 
   isNoProjectPath(path: string): boolean {
-    const normalizedPath = path.trim();
+    const normalizedPath = normalizeWorkspaceUserProjectPath(path);
+    const pathKey = projectPathKey(normalizedPath);
     if (
       !normalizedPath ||
       hasProjectPath(this.store.projects, normalizedPath) ||
-      this.workspaceState.explicitProjectPaths.has(normalizedPath)
+      this.workspaceState.explicitProjectPaths.has(pathKey)
     ) {
       return false;
     }
     return (
-      this.workspaceState.noProjectPaths.has(normalizedPath) ||
+      this.workspaceState.noProjectPaths.has(pathKey) ||
       isGeneratedNoProjectCwd({
         homeDirectory: this.dependencies.platformApi.homeDirectory,
         path: normalizedPath,
@@ -155,7 +159,7 @@ export class DesktopWorkspaceUserProjectService implements IWorkspaceUserProject
   }
 
   rememberNoProjectPath(path: string | null | undefined): void {
-    const normalizedPath = path?.trim() ?? "";
+    const normalizedPath = projectPathKey(path);
     if (normalizedPath) {
       this.workspaceState.noProjectPaths.add(normalizedPath);
     }
@@ -311,9 +315,10 @@ export class DesktopWorkspaceUserProjectService implements IWorkspaceUserProject
       path
     });
     this.supersedeLoad();
-    this.workspaceState.explicitProjectPaths.add(project.path);
-    this.workspaceState.noProjectPaths.delete(project.path);
-    this.workspaceState.removedProjectPaths.delete(project.path);
+    const projectKey = projectPathKey(project.path);
+    this.workspaceState.explicitProjectPaths.add(projectKey);
+    this.workspaceState.noProjectPaths.delete(projectKey);
+    this.workspaceState.removedProjectPaths.delete(projectKey);
     this.store.projects = upsertWorkspaceUserProject(
       this.store.projects,
       project
@@ -327,7 +332,8 @@ export class DesktopWorkspaceUserProjectService implements IWorkspaceUserProject
   }
 
   async removeProjectPath(path: string): Promise<void> {
-    const normalizedPath = path.trim();
+    const normalizedPath = normalizeWorkspaceUserProjectPath(path);
+    const pathKey = projectPathKey(normalizedPath);
     if (!normalizedPath) {
       return;
     }
@@ -337,12 +343,18 @@ export class DesktopWorkspaceUserProjectService implements IWorkspaceUserProject
         path: normalizedPath
       });
       const previousProjectCount = this.store.projects.length;
-      this.workspaceState.explicitProjectPaths.delete(normalizedPath);
-      this.workspaceState.removedProjectPaths.add(normalizedPath);
+      this.workspaceState.explicitProjectPaths.delete(pathKey);
+      this.workspaceState.removedProjectPaths.add(pathKey);
       this.store.projects = this.store.projects.filter(
-        (project) => project.path !== normalizedPath
+        (project) =>
+          !areWorkspaceUserProjectPathsEqual(project.path, normalizedPath)
       );
-      if (this.workspaceState.defaultSelection?.path === normalizedPath) {
+      if (
+        areWorkspaceUserProjectPathsEqual(
+          this.workspaceState.defaultSelection?.path,
+          normalizedPath
+        )
+      ) {
         this.workspaceState.defaultSelection = { path: null };
       }
       this.store.error = null;
@@ -388,7 +400,10 @@ export class DesktopWorkspaceUserProjectService implements IWorkspaceUserProject
         return;
       }
       this.store.projects = response.projects.filter(
-        (project) => !this.workspaceState.removedProjectPaths.has(project.path)
+        (project) =>
+          !this.workspaceState.removedProjectPaths.has(
+            projectPathKey(project.path)
+          )
       );
       this.store.initialized = true;
       this.store.error = null;
@@ -441,7 +456,9 @@ export class DesktopWorkspaceUserProjectService implements IWorkspaceUserProject
     projects: readonly WorkspaceUserProject[]
   ): void {
     for (const project of projects) {
-      this.workspaceState.removedProjectPaths.delete(project.path);
+      this.workspaceState.removedProjectPaths.delete(
+        projectPathKey(project.path)
+      );
     }
     this.supersedeLoad();
     this.store.projects = projects.map((project) => ({ ...project }));
@@ -563,7 +580,7 @@ function areProjectSnapshotsEqual(
       return (
         candidate !== undefined &&
         project.id === candidate.id &&
-        project.path === candidate.path &&
+        areWorkspaceUserProjectPathsEqual(project.path, candidate.path) &&
         project.label === candidate.label &&
         project.pinnedAtUnixMs === candidate.pinnedAtUnixMs &&
         project.sectionKey === candidate.sectionKey &&
@@ -579,7 +596,13 @@ function hasProjectPath(
   projects: readonly WorkspaceUserProject[],
   path: string
 ): boolean {
-  return projects.some((project) => project.path === path);
+  return projects.some((project) =>
+    areWorkspaceUserProjectPathsEqual(project.path, path)
+  );
+}
+
+function projectPathKey(path: string | null | undefined): string {
+  return workspaceUserProjectPathIdentityKey(path);
 }
 
 function workspaceUserProjectState(

--- a/docs/architecture/windows-platform-support.md
+++ b/docs/architecture/windows-platform-support.md
@@ -73,6 +73,26 @@ system:
 This is dependency inversion at the native boundary, not a requirement to
 create parallel copies of each service.
 
+### Workspace project identity and imported rail placement
+
+Project paths have one display form and one comparison form; callers must not
+compare raw strings when the path crosses a desktop/daemon boundary. The shared
+user-project core normalizes slash direction and trailing separators, then
+folds case only for Windows-shaped drive or UNC paths. POSIX paths remain
+case-sensitive. The Go rail store keeps the existing canonical filesystem path
+for display and derives a Windows-stable section key for persistence. Project
+registration and deletion resolve an incoming path variant to the existing
+stored row before applying the table's ordinary unique-path write guard, so no
+second identity column is needed.
+
+External session import can persist a session before its selected project is
+registered. The import path therefore registers projects and repairs only
+sessions carrying the durable `imported` marker in the same workspace SQLite
+transaction. Startup migration `workspace_agent_activity_rail_v2` replays the
+same repair for historical rows; ordinary conversations are not moved. This
+uses existing APIs and tables—no new wire fields or database columns are
+required.
+
 ## Workspace App Data Flow
 
 Workspace Apps keep one manifest and one POSIX `bootstrap.sh` across platforms:

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.interactiveHelpers.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.interactiveHelpers.spec.ts
@@ -174,6 +174,29 @@ describe("AgentGUI user-project snapshot projection", () => {
     ).toBe(false);
   });
 
+  it("treats Windows slash and case differences as the same project", () => {
+    expect(
+      areAgentGUIUserProjectsEqual(
+        [
+          {
+            id: "project",
+            label: "Project",
+            path: "C:\\Users\\Demo\\Repo",
+            pinnedAtUnixMs: 0
+          }
+        ],
+        [
+          {
+            id: "project",
+            label: "Project",
+            path: "c:/users/demo/repo/",
+            pinnedAtUnixMs: 0
+          }
+        ]
+      )
+    ).toBe(true);
+  });
+
   it("treats a pin-state-only change as a new AgentGUI snapshot", () => {
     expect(
       areAgentGUIUserProjectsEqual(

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.interactiveHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.interactiveHelpers.ts
@@ -2,6 +2,7 @@ import type {
   AgentHostUserProject,
   AgentHostUserProjectsApi
 } from "../../../host/agentHostApi";
+import { areWorkspaceUserProjectPathsEqual } from "@tutti-os/workspace-user-project/core";
 export {
   projectAgentApprovalPromptFromInteraction as interactiveApprovalFromInteraction,
   projectAgentInteractivePromptFromInteraction as interactivePromptFromInteraction
@@ -42,7 +43,7 @@ export function areAgentGUIUserProjectsEqual(
       return (
         candidate !== undefined &&
         project.id === candidate.id &&
-        project.path === candidate.path &&
+        areWorkspaceUserProjectPathsEqual(project.path, candidate.path) &&
         project.label === candidate.label &&
         project.sectionKey === candidate.sectionKey &&
         project.pinnedAtUnixMs === candidate.pinnedAtUnixMs &&
@@ -89,7 +90,7 @@ export function upsertAgentGUIUserProject(
   const index = projects.findIndex(
     (candidate) =>
       candidate.id === normalizedProject.id ||
-      candidate.path === normalizedProject.path
+      areWorkspaceUserProjectPathsEqual(candidate.path, normalizedProject.path)
   );
   if (index === -1) {
     return [...projects, normalizedProject];

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerPresentation.ts
@@ -4,6 +4,7 @@ import type {
   AgentActivitySession
 } from "@tutti-os/agent-activity-core";
 import { useMemo } from "react";
+import { areWorkspaceUserProjectPathsEqual } from "@tutti-os/workspace-user-project/core";
 import type { AgentGUIRuntime } from "../../../agentActivityRuntime";
 import type {
   AgentSessionComposerSettings,
@@ -374,7 +375,9 @@ function resolveSelectedProjectSectionKey(
   }
   return (
     userProjects
-      .find((project) => project.path.trim() === projectPath)
+      .find((project) =>
+        areWorkspaceUserProjectPathsEqual(project.path, projectPath)
+      )
       ?.sectionKey?.trim() || null
   );
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationMetadataActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationMetadataActions.ts
@@ -8,6 +8,7 @@ import {
   dispatchSessionForkThroughTurn,
   type AgentSessionEngine
 } from "@tutti-os/agent-activity-core";
+import { areWorkspaceUserProjectPathsEqual } from "@tutti-os/workspace-user-project/core";
 import type { AgentGUIRuntime } from "../../../agentActivityRuntime";
 import type { useAgentHostApi } from "../../../agentActivityHost";
 import type { AgentHostUserProject } from "../../../host/agentHostApi";
@@ -81,7 +82,11 @@ export function useAgentGUIConversationMetadataActions(
           .then(() => {
             setUserProjectsSnapshot(
               userProjectsRef.current.filter(
-                (project) => project.path !== normalizedPath
+                (project) =>
+                  !areWorkspaceUserProjectPathsEqual(
+                    project.path,
+                    normalizedPath
+                  )
               )
             );
           })

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -16,7 +16,10 @@ import {
   conversationSummaryFromAgentSession,
   type AgentGUIConversationSummary
 } from "../model/agentGuiConversationModel";
-import { normalizeAgentComposerDraftProjectPath } from "../model/agentComposerDraftScope";
+import {
+  areAgentComposerProjectPathsEqual,
+  normalizeAgentComposerDraftProjectPath
+} from "../model/agentComposerDraftScope";
 import { mergeVisibleConversations } from "./agentGuiController.conversationHelpers";
 import { reuseAgentActivityDisplayStatusesIfUnchanged } from "./agentGuiController.draftMessageHelpers";
 import {
@@ -528,7 +531,11 @@ export function useAgentGUINodeController({
     ) => {
       const normalizedPath = normalizeAgentComposerDraftProjectPath(path);
       const project = metadata?.project;
-      if (project && normalizedPath && project.path === normalizedPath) {
+      if (
+        project &&
+        normalizedPath &&
+        areAgentComposerProjectPathsEqual(project.path, normalizedPath)
+      ) {
         const nextProjects = upsertAgentGUIUserProject(
           userProjectsRef.current,
           project

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraftScope.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraftScope.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   AGENT_COMPOSER_HOME_DRAFT_SCOPE,
+  areAgentComposerProjectPathsEqual,
   normalizeAgentComposerDraftProjectPath,
   resolveAgentComposerDraftScopeKey
 } from "./agentComposerDraftScope";
@@ -35,6 +36,15 @@ describe("agentComposerDraftScope", () => {
     expect(normalizeAgentComposerDraftProjectPath("///")).toBe("/");
     expect(normalizeAgentComposerDraftProjectPath("C:\\")).toBe("C:/");
     expect(normalizeAgentComposerDraftProjectPath("C:\\\\\\")).toBe("C:/");
+  });
+
+  it("matches Windows project metadata despite slash style and casing", () => {
+    expect(
+      areAgentComposerProjectPathsEqual(
+        "C:\\Users\\Demo\\Repo",
+        "c:/users/demo/repo/"
+      )
+    ).toBe(true);
   });
 
   it("gives an existing session precedence over the shared home draft", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraftScope.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraftScope.ts
@@ -1,16 +1,22 @@
+import {
+  areWorkspaceUserProjectPathsEqual,
+  normalizeWorkspaceUserProjectPath
+} from "@tutti-os/workspace-user-project/core";
+
 /** Shared home-composer draft scope. Project selection does not partition this. */
 export const AGENT_COMPOSER_HOME_DRAFT_SCOPE = "home";
 
 export function normalizeAgentComposerDraftProjectPath(
   value: string | null | undefined
 ): string | null {
-  const slashed = value?.trim().replaceAll("\\", "/") ?? "";
-  const normalized = /^\/+$/u.test(slashed)
-    ? "/"
-    : /^[A-Za-z]:\/+$/u.test(slashed)
-      ? `${slashed.slice(0, 2)}/`
-      : slashed.replace(/\/+$/, "");
-  return normalized ? normalized : null;
+  return normalizeWorkspaceUserProjectPath(value) || null;
+}
+
+export function areAgentComposerProjectPathsEqual(
+  left: string | null | undefined,
+  right: string | null | undefined
+): boolean {
+  return areWorkspaceUserProjectPathsEqual(left, right);
 }
 
 export function resolveAgentComposerDraftScopeKey(input: {

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationProjectResolver.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationProjectResolver.ts
@@ -1,4 +1,8 @@
-import { resolveWorkspaceUserProjectDisplayLabel } from "@tutti-os/workspace-user-project/core";
+import {
+  normalizeWorkspaceUserProjectPath,
+  resolveWorkspaceUserProjectDisplayLabel,
+  workspaceUserProjectPathIdentityKey
+} from "@tutti-os/workspace-user-project/core";
 import type { AgentHostUserProject } from "../../../host/agentHostApi";
 
 const AGENT_GUI_CONVERSATION_PROJECT_SUMMARY_CACHE_LIMIT = 512;
@@ -68,7 +72,8 @@ export function resolveAgentGUISelectedUserProject(
   selectedPath: string | null | undefined,
   userProjects: readonly AgentGUIConversationUserProject[] = []
 ): AgentGUIConversationProjectSummary | null {
-  const normalizedSelectedPath = normalizeAgentGUIProjectPath(selectedPath);
+  const normalizedSelectedPath =
+    workspaceUserProjectPathIdentityKey(selectedPath);
   if (!normalizedSelectedPath) {
     return null;
   }
@@ -145,7 +150,7 @@ function buildAgentGUISelectedProjectPathIndex(
     AgentGUIConversationUserProject
   >();
   for (const project of userProjects) {
-    const projectPath = normalizeAgentGUIProjectPath(project.path);
+    const projectPath = workspaceUserProjectPathIdentityKey(project.path);
     if (!projectPath || projectByNormalizedPath.has(projectPath)) {
       continue;
     }
@@ -179,11 +184,7 @@ function lookupAgentGUISelectedProject(
 export function normalizeAgentGUIProjectPath(
   path: string | null | undefined
 ): string {
-  const normalized = path?.trim().replaceAll("\\", "/") ?? "";
-  if (!normalized) {
-    return "";
-  }
-  return normalized.replace(/\/+$/, "") || "/";
+  return normalizeWorkspaceUserProjectPath(path);
 }
 
 function cachedAgentGUIConversationProjectSummary(

--- a/packages/agent/store-sqlite/migrations.go
+++ b/packages/agent/store-sqlite/migrations.go
@@ -31,6 +31,7 @@ const schemaMigrationWorkspaceAgentActivityV8 = "workspace_agent_activity_v8"
 const schemaMigrationWorkspaceAgentActivityV9 = "workspace_agent_activity_v9"
 const schemaMigrationWorkspaceAgentActivityV10 = "workspace_agent_activity_v10"
 const schemaMigrationWorkspaceAgentActivityRailV1 = "workspace_agent_activity_rail_v1"
+const schemaMigrationWorkspaceAgentActivityRailV2 = "workspace_agent_activity_rail_v2"
 const schemaMigrationWorkspaceAgentActivityTurnsV1 = "workspace_agent_activity_turns_v1"
 const schemaMigrationWorkspaceAgentActivityInteractionsV2 = "workspace_agent_activity_interactions_v2"
 const schemaMigrationWorkspaceAgentActivityMessagesV2 = "workspace_agent_activity_messages_v2"
@@ -320,7 +321,10 @@ CREATE TABLE IF NOT EXISTS `+schemaMigrationsTable+` (
 	if err := s.applyWorkspaceAgentTurnIdentityAnchorV1(ctx); err != nil {
 		return err
 	}
-	return s.applyWorkspaceAgentCommandOutputAliasesV1(ctx)
+	if err := s.applyWorkspaceAgentCommandOutputAliasesV1(ctx); err != nil {
+		return err
+	}
+	return s.applyWorkspaceAgentActivityRailV2(ctx)
 }
 
 // claimLegacyMigrations copies agent-store migration records that were

--- a/packages/agent/store-sqlite/migrations_rail_v2.go
+++ b/packages/agent/store-sqlite/migrations_rail_v2.go
@@ -1,0 +1,41 @@
+package storesqlite
+
+import (
+	"context"
+	"fmt"
+)
+
+// Rail V2 repairs imported sessions that were written while the project list
+// was still empty. V1 can only backfill ordinary conversation rows during
+// startup; this version uses the durable imported marker so it does not move
+// unrelated conversations and remains safe to replay once.
+func (s *Store) applyWorkspaceAgentActivityRailV2(ctx context.Context) error {
+	applied, err := s.hasMigration(ctx, schemaMigrationWorkspaceAgentActivityRailV2)
+	if err != nil {
+		return err
+	}
+	if applied {
+		return nil
+	}
+	projects, err := s.listRailProjectPaths(ctx, s.db)
+	if err != nil {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin workspace agent activity rail v2: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	for _, projectPath := range projects {
+		if _, err := s.RepairImportedProjectRailSectionsTx(ctx, tx, projectPath); err != nil {
+			return err
+		}
+	}
+	if err := recordMigrationTx(ctx, tx, schemaMigrationWorkspaceAgentActivityRailV2); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit workspace agent activity rail v2: %w", err)
+	}
+	return nil
+}

--- a/packages/agent/store-sqlite/rail.go
+++ b/packages/agent/store-sqlite/rail.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 )
@@ -201,7 +202,7 @@ func ClassifyRailSection(
 	projects := normalizeRailProjectPaths(projectPaths)
 	normalizedCWD := NormalizeProjectPath(cwd)
 	for _, project := range projects {
-		if project == normalizedCWD {
+		if sameRailPath(project, normalizedCWD) {
 			return RailSection{
 				Kind:        RailSectionKindProject,
 				ProjectPath: project,
@@ -274,10 +275,10 @@ func agentSessionRailPathContains(parent string, child string) bool {
 	if parent == "" || child == "" {
 		return false
 	}
-	if parent == child {
+	if sameRailPath(parent, child) {
 		return true
 	}
-	rel, err := filepath.Rel(parent, child)
+	rel, err := filepath.Rel(railPathForComparison(parent), railPathForComparison(child))
 	if err != nil {
 		return false
 	}
@@ -354,7 +355,7 @@ func conversationsAgentSessionRailSection() RailSection {
 // the given project are stored under, matching the SectionKey accepted by
 // ListSessionSection.
 func RailSectionKeyForProject(projectPath string) string {
-	projectPath = NormalizeProjectPath(projectPath)
+	projectPath = railIdentityPath(projectPath)
 	if projectPath == "" {
 		return RailSectionKeyConversations
 	}
@@ -374,6 +375,38 @@ func NormalizeRailSectionKey(sectionKey string) string {
 		return RailSectionKeyForProject(strings.TrimPrefix(sectionKey, prefix))
 	}
 	return sectionKey
+}
+
+func railIdentityPath(path string) string {
+	path = NormalizeProjectPath(path)
+	if runtime.GOOS == "windows" {
+		return strings.ToLower(path)
+	}
+	return path
+}
+
+func railPathForComparison(path string) string {
+	if runtime.GOOS == "windows" {
+		return strings.ToLower(path)
+	}
+	return path
+}
+
+func sameRailPath(left string, right string) bool {
+	return railPathForComparison(left) == railPathForComparison(right)
+}
+
+// AreProjectPathsEqual compares project paths using the filesystem identity
+// rules of the current platform. Windows drive and UNC paths are
+// case-insensitive and accept either slash direction; POSIX paths remain
+// case-sensitive.
+func AreProjectPathsEqual(left string, right string) bool {
+	left = NormalizeProjectPath(left)
+	right = NormalizeProjectPath(right)
+	if left == "" || right == "" {
+		return left == right
+	}
+	return sameRailPath(left, right)
 }
 
 func normalizeAgentSessionRailSection(section RailSection) RailSection {

--- a/packages/agent/store-sqlite/rail.go
+++ b/packages/agent/store-sqlite/rail.go
@@ -270,6 +270,12 @@ func NormalizeProjectPath(path string) string {
 }
 
 func agentSessionRailPathContains(parent string, child string) bool {
+	return IsProjectPathWithin(parent, child)
+}
+
+// IsProjectPathWithin reports whether child is the same as, or nested below,
+// parent using the current platform's filesystem identity rules.
+func IsProjectPathWithin(parent string, child string) bool {
 	parent = NormalizeProjectPath(parent)
 	child = NormalizeProjectPath(child)
 	if parent == "" || child == "" {

--- a/packages/agent/store-sqlite/rail_normalize_test.go
+++ b/packages/agent/store-sqlite/rail_normalize_test.go
@@ -96,3 +96,16 @@ func TestClassifyRailSectionUsesCanonicalProjectKey(t *testing.T) {
 		t.Fatalf("ClassifyRailSection key = %q, want %q", section.Key, want)
 	}
 }
+
+func TestRailSectionKeyForProjectUsesWindowsCaseInsensitiveIdentity(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows filesystem identity is platform-specific")
+	}
+	left := `C:\Users\Demo\Repo`
+	right := `c:\users\demo\repo`
+	if RailSectionKeyForProject(left) != RailSectionKeyForProject(right) {
+		t.Fatalf("Windows project keys differ: %q vs %q", RailSectionKeyForProject(left), RailSectionKeyForProject(right))
+	}
+}

--- a/packages/agent/store-sqlite/rail_normalize_test.go
+++ b/packages/agent/store-sqlite/rail_normalize_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -107,5 +108,21 @@ func TestRailSectionKeyForProjectUsesWindowsCaseInsensitiveIdentity(t *testing.T
 	right := `c:\users\demo\repo`
 	if RailSectionKeyForProject(left) != RailSectionKeyForProject(right) {
 		t.Fatalf("Windows project keys differ: %q vs %q", RailSectionKeyForProject(left), RailSectionKeyForProject(right))
+	}
+}
+
+func TestIsProjectPathWithinUsesWindowsCaseInsensitiveIdentity(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows filesystem identity is platform-specific")
+	}
+	root := filepath.Join(t.TempDir(), "Project")
+	child := filepath.Join(root, "Packages", "App")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if !IsProjectPathWithin(strings.ToUpper(root), strings.ToLower(child)) {
+		t.Fatalf("Windows path identity should recognize %q as within %q", child, root)
 	}
 }

--- a/packages/agent/store-sqlite/rail_repair.go
+++ b/packages/agent/store-sqlite/rail_repair.go
@@ -1,0 +1,199 @@
+package storesqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// RepairImportedProjectRailSections repairs project identity after a project
+// is registered. It canonicalizes already-project rows (path/key only) and
+// moves imported rows that were persisted in conversations before registration.
+// Ordinary conversations stay immutable; the imported marker and explicit
+// project path are the reclassification boundary.
+func (s *Store) RepairImportedProjectRailSections(
+	ctx context.Context,
+	projectPath string,
+) (int, error) {
+	if s == nil || s.db == nil {
+		return 0, errors.New("workspace database is not initialized")
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("begin imported project rail repair: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	repaired, err := s.RepairImportedProjectRailSectionsTx(ctx, tx, projectPath)
+	if err != nil {
+		return 0, err
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("commit imported project rail repair: %w", err)
+	}
+	return repaired, nil
+}
+
+// RepairImportedProjectRailSectionsTx is the transaction participant used by
+// workspace user-project registration and rail migrations. The caller owns
+// the transaction and commits it together with the project row.
+func (s *Store) RepairImportedProjectRailSectionsTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	projectPath string,
+) (int, error) {
+	if s == nil || tx == nil {
+		return 0, errors.New("workspace database transaction is not initialized")
+	}
+	projectPath = NormalizeProjectPath(projectPath)
+	if projectPath == "" {
+		return 0, nil
+	}
+	repaired, err := normalizePersistedProjectRailSectionsTx(ctx, tx)
+	if err != nil {
+		return 0, err
+	}
+	projectPaths, err := s.listRailProjectPaths(ctx, tx)
+	if err != nil {
+		return 0, fmt.Errorf("list registered projects for imported project rail repair: %w", err)
+	}
+	projectPaths = append(projectPaths, projectPath)
+	projectPaths = normalizeRailProjectPaths(projectPaths)
+	rows, err := tx.QueryContext(ctx, `
+SELECT workspace_id, agent_session_id, cwd, session_metadata_json, internal_runtime_context_json
+FROM workspace_agent_sessions
+WHERE rail_section_key = ?
+  AND rail_section_kind = ?
+  AND (
+    json_extract(session_metadata_json, '$.imported') = 1
+    OR lower(CAST(json_extract(session_metadata_json, '$.imported') AS TEXT)) = 'true'
+  )
+`, RailSectionKeyConversations, RailSectionKindConversations)
+	if err != nil {
+		return 0, fmt.Errorf("list imported sessions for project rail repair: %w", err)
+	}
+	defer rows.Close()
+
+	type candidate struct {
+		workspaceID    string
+		agentSessionID string
+		section        RailSection
+	}
+	candidates := make([]candidate, 0)
+	for rows.Next() {
+		var workspaceID string
+		var agentSessionID string
+		var cwd string
+		var metadataJSON string
+		var internalRuntimeContextJSON string
+		if err := rows.Scan(&workspaceID, &agentSessionID, &cwd, &metadataJSON, &internalRuntimeContextJSON); err != nil {
+			return 0, fmt.Errorf("scan imported session for project rail repair: %w", err)
+		}
+		runtimeContext, err := unmarshalJSONMap(metadataJSON)
+		if err != nil {
+			return 0, fmt.Errorf("decode imported session for project rail repair: %w", err)
+		}
+		internalRuntimeContext, err := unmarshalJSONMap(internalRuntimeContextJSON)
+		if err != nil {
+			return 0, fmt.Errorf("decode imported session internal context for project rail repair: %w", err)
+		}
+		for key, value := range internalRuntimeContext {
+			runtimeContext[key] = value
+		}
+		if isAgentSessionNoProjectRuntimeContext(runtimeContext) {
+			continue
+		}
+		section := ClassifyRailSection(cwd, runtimeContext, projectPaths)
+		if section.Kind != RailSectionKindProject {
+			continue
+		}
+		candidates = append(candidates, candidate{
+			workspaceID:    workspaceID,
+			agentSessionID: agentSessionID,
+			section:        section,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("iterate imported sessions for project rail repair: %w", err)
+	}
+
+	for _, item := range candidates {
+		result, err := tx.ExecContext(ctx, `
+UPDATE workspace_agent_sessions
+SET rail_section_kind = ?,
+    rail_project_path = ?,
+    rail_section_key = ?
+WHERE workspace_id = ?
+  AND agent_session_id = ?
+  AND rail_section_key = ?
+  AND rail_section_kind = ?
+`, item.section.Kind, item.section.ProjectPath, item.section.Key,
+			item.workspaceID, item.agentSessionID,
+			RailSectionKeyConversations, RailSectionKindConversations)
+		if err != nil {
+			return 0, fmt.Errorf("repair imported session rail %s/%s: %w", item.workspaceID, item.agentSessionID, err)
+		}
+		changed, err := result.RowsAffected()
+		if err != nil {
+			return 0, fmt.Errorf("count imported session rail repair %s/%s: %w", item.workspaceID, item.agentSessionID, err)
+		}
+		repaired += int(changed)
+	}
+	return repaired, nil
+}
+
+func normalizePersistedProjectRailSectionsTx(ctx context.Context, tx *sql.Tx) (int, error) {
+	rows, err := tx.QueryContext(ctx, `
+SELECT workspace_id, agent_session_id, rail_project_path, rail_section_key
+FROM workspace_agent_sessions
+WHERE rail_section_kind = ?
+`, RailSectionKindProject)
+	if err != nil {
+		return 0, fmt.Errorf("list project sessions for rail identity repair: %w", err)
+	}
+	defer rows.Close()
+	type candidate struct {
+		workspaceID    string
+		agentSessionID string
+		projectPath    string
+		sectionKey     string
+	}
+	candidates := make([]candidate, 0)
+	for rows.Next() {
+		var item candidate
+		if err := rows.Scan(&item.workspaceID, &item.agentSessionID, &item.projectPath, &item.sectionKey); err != nil {
+			return 0, fmt.Errorf("scan project session for rail identity repair: %w", err)
+		}
+		projectPath := NormalizeProjectPath(item.projectPath)
+		if projectPath == "" {
+			continue
+		}
+		key := RailSectionKeyForProject(projectPath)
+		if item.projectPath == projectPath && item.sectionKey == key {
+			continue
+		}
+		item.projectPath = projectPath
+		item.sectionKey = key
+		candidates = append(candidates, item)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("iterate project sessions for rail identity repair: %w", err)
+	}
+	repaired := 0
+	for _, item := range candidates {
+		result, err := tx.ExecContext(ctx, `
+UPDATE workspace_agent_sessions
+SET rail_project_path = ?, rail_section_key = ?
+WHERE workspace_id = ? AND agent_session_id = ? AND rail_section_kind = ?
+`, item.projectPath, item.sectionKey, item.workspaceID, item.agentSessionID, RailSectionKindProject)
+		if err != nil {
+			return 0, fmt.Errorf("repair project session rail %s/%s: %w", item.workspaceID, item.agentSessionID, err)
+		}
+		changed, err := result.RowsAffected()
+		if err != nil {
+			return 0, fmt.Errorf("count project session rail repair %s/%s: %w", item.workspaceID, item.agentSessionID, err)
+		}
+		repaired += int(changed)
+	}
+	return repaired, nil
+}

--- a/packages/agent/store-sqlite/rail_repair_test.go
+++ b/packages/agent/store-sqlite/rail_repair_test.go
@@ -1,0 +1,164 @@
+package storesqlite
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRepairImportedProjectRailSectionsRepairsRowsCreatedBeforeProjectRegistration(t *testing.T) {
+	t.Parallel()
+
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	ctx := context.Background()
+	projectPath := filepath.Join(t.TempDir(), "project")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	cwd := filepath.Join(projectPath, "src")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatalf("create project cwd: %v", err)
+	}
+	if _, err := store.ReportSessionState(ctx, SessionStateReport{
+		WorkspaceID:    "ws-imported-rail-repair",
+		AgentSessionID: "imported-before-project",
+		Origin:         "runtime",
+		Provider:       "codex",
+		Cwd:            cwd,
+		RuntimeContext: map[string]any{"imported": true},
+	}); err != nil {
+		t.Fatalf("ReportSessionState() error = %v", err)
+	}
+	initial, found, err := store.getAgentSessionRailSection(ctx, "ws-imported-rail-repair", "imported-before-project")
+	if err != nil || !found || initial.Key != RailSectionKeyConversations {
+		t.Fatalf("initial rail = %#v found=%v err=%v, want conversations", initial, found, err)
+	}
+	if _, err := store.ReportSessionState(ctx, SessionStateReport{
+		WorkspaceID:    "ws-imported-rail-repair",
+		AgentSessionID: "ordinary-before-project",
+		Origin:         "runtime",
+		Provider:       "codex",
+		Cwd:            cwd,
+	}); err != nil {
+		t.Fatalf("ReportSessionState(ordinary) error = %v", err)
+	}
+	if _, err := store.ReportSessionState(ctx, SessionStateReport{
+		WorkspaceID:    "ws-imported-rail-repair",
+		AgentSessionID: "no-project-before-project",
+		Origin:         "runtime",
+		Provider:       "codex",
+		Cwd:            cwd,
+		RuntimeContext: map[string]any{"imported": true, "externalImportNoProject": true},
+	}); err != nil {
+		t.Fatalf("ReportSessionState(no-project) error = %v", err)
+	}
+
+	repaired, err := store.RepairImportedProjectRailSections(ctx, projectPath)
+	if err != nil {
+		t.Fatalf("RepairImportedProjectRailSections() error = %v", err)
+	}
+	if repaired != 1 {
+		t.Fatalf("repaired = %d, want 1", repaired)
+	}
+	final, found, err := store.getAgentSessionRailSection(ctx, "ws-imported-rail-repair", "imported-before-project")
+	if err != nil || !found {
+		t.Fatalf("repaired rail = %#v found=%v err=%v", final, found, err)
+	}
+	wantPath := NormalizeProjectPath(projectPath)
+	if final.Kind != RailSectionKindProject || final.ProjectPath != wantPath || final.Key != RailSectionKeyForProject(wantPath) {
+		t.Fatalf("repaired rail = %#v, want project %q", final, wantPath)
+	}
+	ordinary, found, err := store.getAgentSessionRailSection(ctx, "ws-imported-rail-repair", "ordinary-before-project")
+	if err != nil || !found {
+		t.Fatalf("ordinary rail = %#v found=%v err=%v", ordinary, found, err)
+	}
+	if ordinary.Kind != RailSectionKindConversations || ordinary.Key != RailSectionKeyConversations {
+		t.Fatalf("ordinary rail = %#v, want conversations", ordinary)
+	}
+	noProject, found, err := store.getAgentSessionRailSection(ctx, "ws-imported-rail-repair", "no-project-before-project")
+	if err != nil || !found {
+		t.Fatalf("no-project rail = %#v found=%v err=%v", noProject, found, err)
+	}
+	if noProject.Kind != RailSectionKindConversations || noProject.Key != RailSectionKeyConversations {
+		t.Fatalf("no-project rail = %#v, want conversations", noProject)
+	}
+}
+
+func TestRepairImportedProjectRailSectionsUsesRegisteredProjectsLongestFirst(t *testing.T) {
+	t.Parallel()
+
+	projects := &staticProjectPaths{}
+	store := openTestStore(t, testOptions(projects))
+	ctx := context.Background()
+	parentPath := filepath.Join(t.TempDir(), "project")
+	childPath := filepath.Join(parentPath, "nested")
+	cwd := filepath.Join(childPath, "src")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatalf("create nested project cwd: %v", err)
+	}
+	if _, err := store.ReportSessionState(ctx, SessionStateReport{
+		WorkspaceID:    "ws-nested-imported-rail-repair",
+		AgentSessionID: "nested-imported-before-project",
+		Origin:         "runtime",
+		Provider:       "codex",
+		Cwd:            cwd,
+		RuntimeContext: map[string]any{"imported": true},
+	}); err != nil {
+		t.Fatalf("ReportSessionState() error = %v", err)
+	}
+
+	projects.paths = []string{parentPath, childPath}
+	repaired, err := store.RepairImportedProjectRailSections(ctx, parentPath)
+	if err != nil {
+		t.Fatalf("RepairImportedProjectRailSections() error = %v", err)
+	}
+	if repaired != 1 {
+		t.Fatalf("repaired = %d, want 1", repaired)
+	}
+	final, found, err := store.getAgentSessionRailSection(ctx, "ws-nested-imported-rail-repair", "nested-imported-before-project")
+	if err != nil || !found {
+		t.Fatalf("repaired nested rail = %#v found=%v err=%v", final, found, err)
+	}
+	wantPath := NormalizeProjectPath(childPath)
+	if final.Kind != RailSectionKindProject || final.ProjectPath != wantPath || final.Key != RailSectionKeyForProject(wantPath) {
+		t.Fatalf("repaired nested rail = %#v, want project %q", final, wantPath)
+	}
+}
+
+func TestWorkspaceAgentActivityRailV2RepairsHistoricalImportedRows(t *testing.T) {
+	t.Parallel()
+
+	projects := &staticProjectPaths{}
+	store := openTestStore(t, testOptions(projects))
+	ctx := context.Background()
+	projectPath := filepath.Join(t.TempDir(), "historical-project")
+	if err := os.MkdirAll(filepath.Join(projectPath, "src"), 0o755); err != nil {
+		t.Fatalf("create historical project: %v", err)
+	}
+	if _, err := store.ReportSessionState(ctx, SessionStateReport{
+		WorkspaceID:    "ws-historical-rail-repair",
+		AgentSessionID: "historical-import",
+		Origin:         "runtime",
+		Provider:       "codex",
+		Cwd:            filepath.Join(projectPath, "src"),
+		RuntimeContext: map[string]any{"imported": true},
+	}); err != nil {
+		t.Fatalf("ReportSessionState() error = %v", err)
+	}
+	projects.paths = []string{projectPath}
+	if _, err := store.db.ExecContext(ctx, `DELETE FROM agent_store_schema_migrations WHERE id = ?`, schemaMigrationWorkspaceAgentActivityRailV2); err != nil {
+		t.Fatalf("remove rail v2 marker: %v", err)
+	}
+	if err := store.applyWorkspaceAgentActivityRailV2(ctx); err != nil {
+		t.Fatalf("applyWorkspaceAgentActivityRailV2() error = %v", err)
+	}
+	section, found, err := store.getAgentSessionRailSection(ctx, "ws-historical-rail-repair", "historical-import")
+	if err != nil || !found {
+		t.Fatalf("historical rail = %#v found=%v err=%v", section, found, err)
+	}
+	wantPath := NormalizeProjectPath(projectPath)
+	if section.Kind != RailSectionKindProject || section.ProjectPath != wantPath || section.Key != RailSectionKeyForProject(wantPath) {
+		t.Fatalf("historical rail = %#v, want project %q", section, wantPath)
+	}
+}

--- a/packages/workspace/user-project/src/core/index.test.ts
+++ b/packages/workspace/user-project/src/core/index.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  areWorkspaceUserProjectPathsEqual,
   basenameWorkspaceUserProjectPath,
   getWorkspaceUserProjectErrorCode,
   pinWorkspaceUserProjectOptimistically,
@@ -9,6 +10,20 @@ import {
   stripAbsolutePathFromWorkspaceUserProjectLabel,
   upsertWorkspaceUserProject
 } from "./index.ts";
+
+test("workspace user project path identity handles Windows separators and case", () => {
+  assert.equal(
+    areWorkspaceUserProjectPathsEqual(
+      "C:\\Users\\Demo\\Repo\\",
+      "c:/users/demo/repo"
+    ),
+    true
+  );
+  assert.equal(
+    areWorkspaceUserProjectPathsEqual("/Users/Demo/Repo", "/users/demo/repo"),
+    false
+  );
+});
 
 test("workspace user project labels hide absolute paths", () => {
   assert.equal(
@@ -90,6 +105,26 @@ test("workspace user project upsert replaces by id or path", () => {
       {
         ...first,
         label: "Tutti"
+      }
+    ]
+  );
+  const windowsProject = {
+    id: "windows-project",
+    label: "Windows",
+    path: "C:\\Users\\Demo\\Repo",
+    pinnedAtUnixMs: 0
+  };
+  assert.deepEqual(
+    upsertWorkspaceUserProject([windowsProject], {
+      ...windowsProject,
+      id: "windows-project-reported",
+      path: "c:/users/demo/repo/"
+    }),
+    [
+      {
+        ...windowsProject,
+        id: "windows-project-reported",
+        path: "c:/users/demo/repo/"
       }
     ]
   );
@@ -322,6 +357,48 @@ test("prepareWorkspaceUserProjectSelection resolves fallback decisions", async (
       isSelectedPathMissing: true,
       projects,
       selection: { kind: "none" }
+    }
+  );
+});
+
+test("prepareWorkspaceUserProjectSelection matches Windows path identity", async () => {
+  const projects = [
+    {
+      id: "windows-project",
+      label: "Windows",
+      path: "C:\\Users\\Demo\\Repo",
+      pinnedAtUnixMs: 0
+    }
+  ];
+  const api = {
+    async getDefaultSelection() {
+      return { path: "c:/users/demo/repo/" };
+    },
+    async list() {
+      return { projects };
+    }
+  };
+
+  assert.deepEqual(
+    await prepareWorkspaceUserProjectSelection(api, {
+      projectLocked: false,
+      selectedPath: "c:/users/demo/repo/"
+    }),
+    {
+      isSelectedPathMissing: false,
+      projects,
+      selection: { kind: "none" }
+    }
+  );
+  assert.deepEqual(
+    await prepareWorkspaceUserProjectSelection(api, {
+      projectLocked: false,
+      selectedPath: null
+    }),
+    {
+      isSelectedPathMissing: false,
+      projects,
+      selection: { kind: "select", path: "c:/users/demo/repo/" }
     }
   );
 });

--- a/packages/workspace/user-project/src/core/index.ts
+++ b/packages/workspace/user-project/src/core/index.ts
@@ -11,7 +11,9 @@ export function upsertWorkspaceUserProject(
   project: WorkspaceUserProject
 ): WorkspaceUserProject[] {
   const existingIndex = projects.findIndex(
-    (item) => item.id === project.id || item.path === project.path
+    (item) =>
+      item.id === project.id ||
+      areWorkspaceUserProjectPathsEqual(item.path, project.path)
   );
   if (existingIndex < 0) {
     const insertionIndex =
@@ -100,6 +102,48 @@ export function basenameWorkspaceUserProjectPath(path: string): string {
   return segments[segments.length - 1] ?? "";
 }
 
+/**
+ * Normalizes a project path for identity comparisons at the UI boundary.
+ * Windows paths can arrive from different hosts with either slash style and
+ * different casing even though they refer to the same directory. POSIX paths
+ * remain case-sensitive, so case folding is limited to Windows-shaped paths.
+ */
+export function normalizeWorkspaceUserProjectPath(
+  path: string | null | undefined
+): string {
+  const slashed = path?.trim().replaceAll("\\", "/") ?? "";
+  if (!slashed) {
+    return "";
+  }
+  if (/^\/+$/u.test(slashed)) {
+    return "/";
+  }
+  if (/^[A-Za-z]:\/+$/u.test(slashed)) {
+    return `${slashed.slice(0, 2)}/`;
+  }
+  return slashed.replace(/\/+$/u, "");
+}
+
+export function areWorkspaceUserProjectPathsEqual(
+  left: string | null | undefined,
+  right: string | null | undefined
+): boolean {
+  return (
+    workspaceUserProjectPathIdentityKey(left) ===
+    workspaceUserProjectPathIdentityKey(right)
+  );
+}
+
+export function workspaceUserProjectPathIdentityKey(
+  path: string | null | undefined
+): string {
+  const normalized = normalizeWorkspaceUserProjectPath(path);
+  if (/^[A-Za-z]:\//u.test(normalized) || normalized.startsWith("//")) {
+    return normalized.toLowerCase();
+  }
+  return normalized;
+}
+
 export function getWorkspaceUserProjectErrorCode(
   error: unknown
 ): WorkspaceUserProjectCreationErrorCode | null {
@@ -136,7 +180,9 @@ export async function prepareWorkspaceUserProjectSelection(
     !input.projectLocked &&
     selectedPath &&
     !isSelectedPathNoProject &&
-    !projects.some((project) => project.path === selectedPath)
+    !projects.some((project) =>
+      areWorkspaceUserProjectPathsEqual(project.path, selectedPath)
+    )
   ) {
     await api.rememberDefaultSelection?.({ path: null });
     return {
@@ -159,7 +205,12 @@ export async function prepareWorkspaceUserProjectSelection(
 
   const defaultSelection = await api.getDefaultSelection?.();
   const defaultPath = defaultSelection?.path?.trim() ?? "";
-  if (defaultPath && projects.some((project) => project.path === defaultPath)) {
+  if (
+    defaultPath &&
+    projects.some((project) =>
+      areWorkspaceUserProjectPathsEqual(project.path, defaultPath)
+    )
+  ) {
     return {
       isSelectedPathMissing,
       projects,

--- a/packages/workspace/user-project/src/ui/internal/project/WorkspaceUserProjectSelect.tsx
+++ b/packages/workspace/user-project/src/ui/internal/project/WorkspaceUserProjectSelect.tsx
@@ -40,6 +40,7 @@ import type {
   WorkspaceUserProjectService
 } from "../../../contracts/index.ts";
 import {
+  areWorkspaceUserProjectPathsEqual,
   basenameWorkspaceUserProjectPath,
   getWorkspaceUserProjectErrorCode,
   prepareWorkspaceUserProjectSelection,
@@ -258,7 +259,8 @@ export function WorkspaceUserProjectSelect({
   const [isSelectedPathMissing, setIsSelectedPathMissing] = useState(false);
   const rawSelectedPath = selectedProjectPath?.trim() ?? "";
   const selectedPath =
-    rawSelectedPath && rawSelectedPath === suppressedSelectedPath
+    rawSelectedPath &&
+    areWorkspaceUserProjectPathsEqual(rawSelectedPath, suppressedSelectedPath)
       ? ""
       : rawSelectedPath;
   const projects = service ? [...serviceSnapshot.projects] : apiProjects;
@@ -272,7 +274,9 @@ export function WorkspaceUserProjectSelect({
   const selectedPathLabel =
     basenameWorkspaceUserProjectPath(selectedPath) || selectedPath;
   const selectedProject = showKnownProjectOptions
-    ? (projects.find((project) => project.path === selectedPath) ?? null)
+    ? (projects.find((project) =>
+        areWorkspaceUserProjectPathsEqual(project.path, selectedPath)
+      ) ?? null)
     : null;
   const selectedProjectLabel = selectedProject
     ? resolveWorkspaceUserProjectDisplayLabel(selectedProject)
@@ -337,7 +341,11 @@ export function WorkspaceUserProjectSelect({
     }
     if (
       suppressedSelectedPath &&
-      (!rawSelectedPath || rawSelectedPath !== suppressedSelectedPath)
+      (!rawSelectedPath ||
+        !areWorkspaceUserProjectPathsEqual(
+          rawSelectedPath,
+          suppressedSelectedPath
+        ))
     ) {
       setSuppressedSelectedPath(null);
     }
@@ -520,7 +528,9 @@ export function WorkspaceUserProjectSelect({
         .catch(() => {});
       return;
     }
-    const knownProject = projects.find((project) => project.path === nextValue);
+    const knownProject = projects.find((project) =>
+      areWorkspaceUserProjectPathsEqual(project.path, nextValue)
+    );
     if (knownProject) {
       void effectiveApi.rememberDefaultSelection?.({ path: knownProject.path });
       setHasPinnedNoProjectSelection(false);

--- a/services/tuttid/biz/userproject/model.go
+++ b/services/tuttid/biz/userproject/model.go
@@ -31,11 +31,11 @@ func SectionKeyFromPath(path string) string {
 }
 
 func LabelFromPath(path string) string {
-	path = strings.TrimRight(strings.TrimSpace(path), "/")
+	path = strings.TrimRight(strings.TrimSpace(path), "/\\")
 	if path == "" {
 		return ""
 	}
-	index := strings.LastIndex(path, "/")
+	index := strings.LastIndexAny(path, "/\\")
 	if index < 0 {
 		return path
 	}

--- a/services/tuttid/biz/userproject/model_test.go
+++ b/services/tuttid/biz/userproject/model_test.go
@@ -37,3 +37,16 @@ func TestSectionKeyFromPathEmpty(t *testing.T) {
 		t.Fatalf("empty path section key = %q, want empty", got)
 	}
 }
+
+func TestLabelFromPathSupportsWindowsAndPOSIXSeparators(t *testing.T) {
+	tests := map[string]string{
+		"/workspace/tutti/":              "tutti",
+		`C:\Users\demo\Documents\tutti`:  "tutti",
+		`C:\Users\demo\Documents\tutti\`: "tutti",
+	}
+	for path, want := range tests {
+		if got := LabelFromPath(path); got != want {
+			t.Errorf("LabelFromPath(%q) = %q, want %q", path, got, want)
+		}
+	}
+}

--- a/services/tuttid/data/workspace/sqlite_user_projects.go
+++ b/services/tuttid/data/workspace/sqlite_user_projects.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	agentactivitybiz "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 	userprojectbiz "github.com/tutti-os/tutti/services/tuttid/biz/userproject"
 )
 
@@ -76,12 +77,10 @@ WHERE id = ?
 	return nil
 }
 
-// DeleteUserProjectByPath removes a user project by its unique path rather
-// than by a recomputed id. The `path` column carries the table's UNIQUE
-// constraint (see applyUserProjectsV1), so it is the durable lookup key for a
-// caller-supplied path; deleting by an id that gets recomputed from the path
-// on every call can silently miss the row if that derivation ever drifts from
-// what was actually stored, leaving the "removed" project in place.
+// DeleteUserProjectByPath removes a user project by its stored path rather
+// than by a recomputed id. The path column remains the durable lookup key, with
+// a platform-aware identity fallback so Windows slash/case variants resolve
+// to the same stored row.
 func (s *SQLiteStore) DeleteUserProjectByPath(ctx context.Context, path string) error {
 	if s == nil || s.writeDB == nil {
 		return errors.New("workspace database is not initialized")
@@ -91,10 +90,23 @@ func (s *SQLiteStore) DeleteUserProjectByPath(ctx context.Context, path string) 
 		return fmt.Errorf("begin delete user project by path: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
+	storedPath, found, err := findUserProjectPathTx(ctx, tx, path)
+	if err != nil {
+		return fmt.Errorf("find user project by path before delete: %w", err)
+	}
+	if !found {
+		if err := compactUserProjectOrder(ctx, tx); err != nil {
+			return err
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit delete user project by path: %w", err)
+		}
+		return nil
+	}
 	_, err = tx.ExecContext(ctx, `
 DELETE FROM user_projects
 WHERE path = ?
-`, path)
+`, storedPath)
 	if err != nil {
 		return fmt.Errorf("delete user project by path: %w", err)
 	}
@@ -125,12 +137,17 @@ func (s *SQLiteStore) PutUserProject(ctx context.Context, project userprojectbiz
 		return userprojectbiz.Project{}, fmt.Errorf("begin put user project: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
-	var existingID string
-	err = tx.QueryRowContext(ctx, `SELECT id FROM user_projects WHERE path = ?`, project.Path).Scan(&existingID)
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+	existingPath, found, err := findUserProjectPathTx(ctx, tx, project.Path)
+	if err != nil {
 		return userprojectbiz.Project{}, fmt.Errorf("find user project before put: %w", err)
 	}
-	if errors.Is(err, sql.ErrNoRows) {
+	if found {
+		// Preserve the first stored spelling while treating Windows path
+		// variants as one project identity. The UNIQUE(path) constraint then
+		// remains the final write guard without a schema change.
+		project.Path = existingPath
+	}
+	if !found {
 		var firstUnpinnedOrder int
 		if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM user_projects WHERE pinned_at_unix_ms > 0`).Scan(&firstUnpinnedOrder); err != nil {
 			return userprojectbiz.Project{}, fmt.Errorf("find first unpinned user project order: %w", err)
@@ -174,10 +191,46 @@ WHERE path = ?
 		return userprojectbiz.Project{}, fmt.Errorf("get user project after put: %w", err)
 	}
 	stored.SectionKey = userprojectbiz.SectionKeyFromPath(stored.Path)
+	if _, err := s.agentStore().RepairImportedProjectRailSectionsTx(ctx, tx, stored.Path); err != nil {
+		return userprojectbiz.Project{}, fmt.Errorf("repair imported project rail after put: %w", err)
+	}
 	if err := tx.Commit(); err != nil {
 		return userprojectbiz.Project{}, fmt.Errorf("commit put user project: %w", err)
 	}
 	return stored, nil
+}
+
+// findUserProjectPathTx first uses the UNIQUE column directly, then applies
+// the platform path identity rules for a Windows slash/case variant. The
+// fallback scan is intentionally limited to project registration/deletion,
+// which are low-frequency mutations; rail reads keep their indexed section
+// key queries.
+func findUserProjectPathTx(ctx context.Context, tx *sql.Tx, path string) (string, bool, error) {
+	row := tx.QueryRowContext(ctx, `SELECT path FROM user_projects WHERE path = ?`, path)
+	var storedPath string
+	if err := row.Scan(&storedPath); err == nil {
+		return storedPath, true, nil
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return "", false, fmt.Errorf("find exact user project path: %w", err)
+	}
+
+	rows, err := tx.QueryContext(ctx, `SELECT path FROM user_projects`)
+	if err != nil {
+		return "", false, fmt.Errorf("list user project paths for identity match: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		if err := rows.Scan(&storedPath); err != nil {
+			return "", false, fmt.Errorf("scan user project path for identity match: %w", err)
+		}
+		if agentactivitybiz.AreProjectPathsEqual(path, storedPath) {
+			return storedPath, true, nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return "", false, fmt.Errorf("iterate user project paths for identity match: %w", err)
+	}
+	return "", false, nil
 }
 
 func (s *SQLiteStore) TouchUserProject(ctx context.Context, id string, atUnixMS int64) error {

--- a/services/tuttid/data/workspace/sqlite_user_projects_test.go
+++ b/services/tuttid/data/workspace/sqlite_user_projects_test.go
@@ -3,12 +3,104 @@ package workspace
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
+	agentactivitybiz "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 	userprojectbiz "github.com/tutti-os/tutti/services/tuttid/biz/userproject"
+	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 )
+
+func TestSQLiteStorePutUserProjectRepairsImportedSessionRail(t *testing.T) {
+	ctx := context.Background()
+	store := openTestSQLiteStore(t)
+	if err := store.Create(ctx, workspacebiz.Summary{ID: "ws-project-rail", Name: "Project rail"}); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	projectPath := filepath.Join(t.TempDir(), "project")
+	cwd := filepath.Join(projectPath, "src")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if _, err := store.ReportSessionState(ctx, agentactivitybiz.SessionStateReport{
+		WorkspaceID:    "ws-project-rail",
+		AgentSessionID: "imported-before-registration",
+		Origin:         "runtime",
+		Provider:       "codex",
+		Cwd:            cwd,
+		RuntimeContext: map[string]any{"imported": true},
+	}); err != nil {
+		t.Fatalf("ReportSessionState() error = %v", err)
+	}
+	initial := getTestAgentSessionRailSection(t, store, "ws-project-rail", "imported-before-registration")
+	if initial.Key != agentactivitybiz.RailSectionKeyConversations {
+		t.Fatalf("initial rail = %#v, want conversations", initial)
+	}
+
+	if _, err := store.PutUserProject(ctx, userprojectbiz.Project{
+		ID:    "project-rail",
+		Path:  projectPath,
+		Label: "project",
+	}); err != nil {
+		t.Fatalf("PutUserProject() error = %v", err)
+	}
+	final := getTestAgentSessionRailSection(t, store, "ws-project-rail", "imported-before-registration")
+	wantPath := agentactivitybiz.NormalizeProjectPath(projectPath)
+	if final.Kind != agentactivitybiz.RailSectionKindProject || final.ProjectPath != wantPath || final.Key != agentactivitybiz.RailSectionKeyForProject(wantPath) {
+		t.Fatalf("final rail = %#v, want project path=%q", final, wantPath)
+	}
+}
+
+func TestSQLiteStoreUserProjectPathIdentityTreatsWindowsVariantsAsOneProject(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows filesystem identity is platform-specific")
+	}
+
+	ctx := context.Background()
+	store := openTestSQLiteStore(t)
+	projectPath := agentactivitybiz.NormalizeProjectPath(t.TempDir())
+	variantPath := strings.ToLower(filepath.ToSlash(projectPath))
+	first, err := store.PutUserProject(ctx, userprojectbiz.Project{
+		ID:    "windows-project",
+		Path:  projectPath,
+		Label: "Windows project",
+	})
+	if err != nil {
+		t.Fatalf("PutUserProject(first) error = %v", err)
+	}
+	second, err := store.PutUserProject(ctx, userprojectbiz.Project{
+		ID:    "windows-project-variant",
+		Path:  variantPath,
+		Label: "Windows project variant",
+	})
+	if err != nil {
+		t.Fatalf("PutUserProject(variant) error = %v", err)
+	}
+	if second.ID != first.ID || second.Path != first.Path {
+		t.Fatalf("variant project = %#v, want existing project %#v", second, first)
+	}
+	projects, err := store.ListUserProjects(ctx)
+	if err != nil {
+		t.Fatalf("ListUserProjects() error = %v", err)
+	}
+	if len(projects) != 1 {
+		t.Fatalf("ListUserProjects() len = %d, want 1", len(projects))
+	}
+	if err := store.DeleteUserProjectByPath(ctx, variantPath); err != nil {
+		t.Fatalf("DeleteUserProjectByPath(variant) error = %v", err)
+	}
+	projects, err = store.ListUserProjects(ctx)
+	if err != nil {
+		t.Fatalf("ListUserProjects() after delete error = %v", err)
+	}
+	if len(projects) != 0 {
+		t.Fatalf("ListUserProjects() after delete len = %d, want 0", len(projects))
+	}
+}
 
 func TestSQLiteStorePutUserProjectKeepsDurableOrderWhenReused(t *testing.T) {
 	ctx := context.Background()

--- a/services/tuttid/service/agent/external_import_parse.go
+++ b/services/tuttid/service/agent/external_import_parse.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
+	agentactivitybiz "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 	agentproviderbiz "github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 )
 
@@ -394,7 +395,7 @@ func isExternalImportNoProjectCwd(provider string, cwd string) bool {
 	}
 	cwd = filepath.Clean(cwd)
 	home = filepath.Clean(home)
-	if cwd == home {
+	if agentactivitybiz.AreProjectPathsEqual(cwd, home) {
 		return true
 	}
 	descriptor, ok := providerregistry.Find(provider)
@@ -416,13 +417,13 @@ func isExternalImportNoProjectCwd(provider string, cwd string) bool {
 // only checks that the path is nested under Documents/Codex rather than
 // pattern-matching a specific segment shape, to stay robust across formats.
 func isExternalImportScratchCwd(home string, cwd string, relativeRoot string) bool {
-	rel, err := filepath.Rel(home, cwd)
-	if err != nil || rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+	root := strings.Trim(strings.TrimSpace(filepath.ToSlash(relativeRoot)), "/")
+	if root == "" {
 		return false
 	}
-	rel = filepath.ToSlash(rel)
-	root := strings.Trim(strings.TrimSpace(filepath.ToSlash(relativeRoot)), "/")
-	return root != "" && strings.HasPrefix(rel, root+"/") && strings.TrimPrefix(rel, root+"/") != ""
+	scratchRoot := filepath.Join(home, filepath.FromSlash(root))
+	return agentactivitybiz.IsProjectPathWithin(scratchRoot, cwd) &&
+		!agentactivitybiz.AreProjectPathsEqual(scratchRoot, cwd)
 }
 
 func externalImportedMessageHasContent(message externalImportedMessage) bool {

--- a/services/tuttid/service/agent/external_import_projects.go
+++ b/services/tuttid/service/agent/external_import_projects.go
@@ -237,9 +237,10 @@ func externalImportSessionSummary(session externalImportedSession, projectPath s
 }
 
 func upsertExternalImportProject(projects map[string]*ExternalImportProject, next ExternalImportProject, provider string) {
-	project, ok := projects[next.Path]
+	identityKey := agentactivitybiz.RailSectionKeyForProject(next.Path)
+	project, ok := projects[identityKey]
 	if !ok {
-		projects[next.Path] = &next
+		projects[identityKey] = &next
 		return
 	}
 	project.SessionCount += next.SessionCount

--- a/services/tuttid/service/agent/external_import_projects.go
+++ b/services/tuttid/service/agent/external_import_projects.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	agentactivitybiz "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 	agentproviderbiz "github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 )
 
@@ -264,11 +265,11 @@ func matchingExternalImportProject(session externalImportedSession, selections [
 			continue
 		}
 		if externalProjectPathContains(selection.Path, session.Cwd) {
-			selectionPath := filepath.Clean(selection.Path)
-			if selectionPath == filepath.Clean(session.Cwd) {
+			selectionPath := agentactivitybiz.NormalizeProjectPath(selection.Path)
+			if agentactivitybiz.AreProjectPathsEqual(selectionPath, session.Cwd) {
 				return selection.Path, true
 			}
-			if bestPath == "" || len(selectionPath) > len(filepath.Clean(bestPath)) {
+			if bestPath == "" || len(selectionPath) > len(agentactivitybiz.NormalizeProjectPath(bestPath)) {
 				bestPath = selection.Path
 			}
 		}
@@ -303,16 +304,7 @@ func externalProviderSelected(provider string, providers []string) bool {
 }
 
 func externalProjectPathContains(parent string, child string) bool {
-	parent = filepath.Clean(parent)
-	child = filepath.Clean(child)
-	if parent == child {
-		return true
-	}
-	rel, err := filepath.Rel(parent, child)
-	if err != nil {
-		return false
-	}
-	return rel != "." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && rel != ".."
+	return agentactivitybiz.IsProjectPathWithin(parent, child)
 }
 
 func canonicalExistingDir(path string) (string, bool) {

--- a/services/tuttid/service/agent/external_import_test.go
+++ b/services/tuttid/service/agent/external_import_test.go
@@ -353,6 +353,32 @@ func TestMatchingExternalImportProjectPrefersExactSelection(t *testing.T) {
 	}
 }
 
+func TestUpsertExternalImportProjectUsesWindowsPathIdentity(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows filesystem identity is platform-specific")
+	}
+	projectPath := t.TempDir()
+	projects := map[string]*ExternalImportProject{}
+	upsertExternalImportProject(projects, ExternalImportProject{
+		Path:         strings.ToUpper(projectPath),
+		SessionCount: 1,
+	}, "codex")
+	upsertExternalImportProject(projects, ExternalImportProject{
+		Path:         strings.ToLower(projectPath),
+		SessionCount: 1,
+	}, "claude-code")
+	if len(projects) != 1 {
+		t.Fatalf("project identity map has %d entries, want one: %#v", len(projects), projects)
+	}
+	for _, project := range projects {
+		if project.SessionCount != 2 {
+			t.Fatalf("merged project session count = %d, want 2", project.SessionCount)
+		}
+	}
+}
+
 func TestExternalSessionProjectPathUsesGitRoot(t *testing.T) {
 	root := t.TempDir()
 	project := filepath.Join(root, "repo")

--- a/services/tuttid/service/agent/external_import_test.go
+++ b/services/tuttid/service/agent/external_import_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -333,6 +335,21 @@ func TestMatchingExternalImportProjectPrefersExactSelection(t *testing.T) {
 	)
 	if !ok || got != child {
 		t.Fatalf("matchingExternalImportProject() = %q, %v; want exact child path %q", got, ok, child)
+	}
+	if runtime.GOOS == "windows" {
+		got, ok = matchingExternalImportProject(
+			externalImportedSession{
+				Provider: "codex",
+				Cwd:      strings.ToLower(child),
+			},
+			[]ExternalImportProjectSelection{
+				{Path: strings.ToUpper(parent), Providers: []string{"codex"}},
+				{Path: strings.ToUpper(child), Providers: []string{"codex"}},
+			},
+		)
+		if !ok || !agentactivitybiz.AreProjectPathsEqual(got, child) {
+			t.Fatalf("Windows identity matching = %q, %v; want child path equivalent to %q", got, ok, child)
+		}
 	}
 }
 

--- a/services/tuttid/service/agent/external_import_test.go
+++ b/services/tuttid/service/agent/external_import_test.go
@@ -108,7 +108,7 @@ func TestServiceImportExternalSessionsRepairsSelectedNestedProjectRailMembership
 	if err != nil {
 		t.Fatalf("ReportSessionState(legacy parent membership) error = %v", err)
 	}
-	if legacy.Session.RailSectionKey != "project:"+parentProject {
+	if legacy.Session.RailSectionKey != agentactivitybiz.RailSectionKeyForProject(parentProject) {
 		t.Fatalf("legacy railSectionKey = %q, want parent before reimport", legacy.Session.RailSectionKey)
 	}
 
@@ -131,7 +131,7 @@ func TestServiceImportExternalSessionsRepairsSelectedNestedProjectRailMembership
 	if err != nil || !ok {
 		t.Fatalf("GetSession() ok=%v error=%v", ok, err)
 	}
-	wantSectionKey := "project:" + nestedProject
+	wantSectionKey := agentactivitybiz.RailSectionKeyForProject(nestedProject)
 	if persisted.RailSectionKey != wantSectionKey {
 		t.Fatalf("railSectionKey = %q, want selected nested project %q", persisted.RailSectionKey, wantSectionKey)
 	}


### PR DESCRIPTION
## 背景

修复 Windows 下的三个关联问题：项目标签显示为完整路径、外部导入会话没有进入项目 rail、从子目录创建新会话时项目未被选中。根因是路径分隔符/大小写没有使用统一 identity，且导入时会话写入早于项目注册，历史 rail 没有补偿修复。

## 改动

- 共享 user-project path identity：统一 slash、根路径和 Windows drive/UNC 大小写比较；GUI/桌面项目查找、选择、upsert、删除和新会话上下文全部复用。
- Go rail：Windows section key 使用平台 identity，项目路径比较使用 Windows 大小写不敏感规则；项目注册事务中修复先导入后注册的历史 imported rows，最长项目优先，保留 no-project 和普通 conversations。
- 数据兼容：增加幂等 `workspace_agent_activity_rail_v2` migration；不增加 API 字段或 SQLite 列，已有普通会话不迁移。
- 导入顺序：桌面端先刷新项目注册状态，再刷新 activity rail，避免读取到旧 rail 快照。
- Windows 项目 label：同时识别 `/` 和 `\\` 作为分隔符。
- 增加 Go/TypeScript/桌面服务回归测试与 Windows 平台架构说明。

## 验证

- Go rail repair、workspace user-project、external import service、import API 定向测试通过。
- workspace-user-project 13 项、desktop activity/project service 24 项测试通过。
- workspace-user-project、agent-gui、desktop typecheck 通过。
- agent host boundary、agent-gui degradation、oxfmt、Prettier、`git diff --check` 通过。

## 风险与回滚

- repair 仅处理带 imported 标记且仍位于 conversations 的会话；普通 conversations 和显式 no-project 会话不移动。
- migration 使用 marker 且 repair 幂等；如需回滚可回滚本 PR。已完成的历史 rail 归类不会被旧代码自动反向恢复，回滚前应确认是否需要保留已修复数据。
- 变更集中在路径 identity、rail 分类/修复和 UI 刷新顺序，不改变对外 API/数据字段。

## 已知验证限制

仓库完整 `check:changed` 在 Windows 环境仍受既有 `bash ENOENT`、POSIX 路径假设、生成 renderer token 和 Node heap 限制影响；本 PR 相关的定向测试、类型检查和边界检查均已单独通过。
