### PR TITLE
fix(session-replay): ignore reminted shared prompt image locators

### DIFF
--- a/packages/agent/session-replay/replay_state.go
+++ b/packages/agent/session-replay/replay_state.go
@@ -287,10 +287,15 @@ func projectPortableMaterializedContent(payload map[string]any) {
 		projectedBlock := cloneReplayMap(block)
 		blockType, _ := projectedBlock["type"].(string)
 		if blockType == "text" || blockType == "image" {
-			// The provider materializes this path while building the message. The
-			// attachmentId/text is the portable semantic contract; the path is
-			// workspace-local and must not enter replay-state validation.
+			// Workspace-local / transport locators are not part of the portable
+			// semantic contract. Final compare also strips attachmentId (see
+			// stripVolatilePromptImageLocators) because shared object-upload
+			// replay may omit it while recorded local cassettes still carry it.
 			delete(projectedBlock, "path")
+			delete(projectedBlock, "url")
+			delete(projectedBlock, "uri")
+			delete(projectedBlock, "assetId")
+			delete(projectedBlock, "uploadStatus")
 		}
 		projectedContent[index] = projectedBlock
 	}

--- a/packages/agent/session-replay/replay_state_compare.go
+++ b/packages/agent/session-replay/replay_state_compare.go
@@ -21,6 +21,12 @@ func normalizeReplayStateForComparison(state TuttiReplayState) TuttiReplayState 
 
 	canonicalizeTerminalCommandOutputAliases(value)
 	canonicalizeGoalControlAuditIdentities(value)
+	// Prompt image locators remint across local record → shared (self-shared)
+	// object-upload replay: attachmentId may be absent on the URL path while
+	// recorded expected-state still carries the Host attachment identity.
+	// Compare mimeType/name/type only; strip transport locators before alpha
+	// registration so a present-vs-missing attachmentId cannot conflict.
+	stripVolatilePromptImageLocators(value)
 	replacements := map[string]string{}
 	registerReplayIDs(replacements, value)
 	replaceReplayIDs(value, replacements)
@@ -152,6 +158,47 @@ func setGoalControlIdentity(payload map[string]any, key, value string) {
 	current, ok := payload[key].(string)
 	if ok && strings.TrimSpace(current) != "" {
 		payload[key] = value
+	}
+}
+
+// stripVolatilePromptImageLocators drops transport / Host-local image identity
+// from message content before final compare. Local record stores attachmentId;
+// shared object-upload replay often keeps only url/assetId (and may omit
+// attachmentId entirely). mimeType + name remain the comparable contract.
+func stripVolatilePromptImageLocators(value map[string]any) {
+	agent, _ := value["agent"].(map[string]any)
+	sessions, _ := agent["sessions"].([]any)
+	for _, item := range sessions {
+		session, _ := item.(map[string]any)
+		messages, _ := session["messages"].([]any)
+		for _, messageItem := range messages {
+			message, _ := messageItem.(map[string]any)
+			payload, _ := message["payload"].(map[string]any)
+			if payload == nil {
+				continue
+			}
+			content, ok := payload["content"].([]any)
+			if !ok {
+				continue
+			}
+			for _, contentItem := range content {
+				block, _ := contentItem.(map[string]any)
+				if block == nil {
+					continue
+				}
+				blockType, _ := block["type"].(string)
+				if blockType != "image" && blockType != "file" {
+					continue
+				}
+				delete(block, "attachmentId")
+				delete(block, "path")
+				delete(block, "url")
+				delete(block, "uri")
+				delete(block, "assetId")
+				delete(block, "uploadStatus")
+				delete(block, "data")
+			}
+		}
 	}
 }
 

--- a/packages/agent/session-replay/replay_state_domain_test.go
+++ b/packages/agent/session-replay/replay_state_domain_test.go
@@ -910,6 +910,8 @@ func TestCompareTuttiReplayStateTreatsAttachmentIDsAsAlphaEquivalent(
 						Payload: map[string]any{
 							"content": []any{map[string]any{
 								"type":         "image",
+								"mimeType":     "image/png",
+								"name":         "shot.png",
 								"attachmentId": attachmentID,
 							}},
 						},
@@ -931,6 +933,60 @@ func TestCompareTuttiReplayStateTreatsAttachmentIDsAsAlphaEquivalent(
 	); err != nil {
 		t.Fatalf(
 			"attachment identities must be alpha-equivalent, got %v",
+			err,
+		)
+	}
+}
+
+func TestCompareTuttiReplayStateIgnoresSharedObjectUploadImageLocators(
+	t *testing.T,
+) {
+	buildState := func(content map[string]any) TuttiReplayState {
+		return TuttiReplayState{
+			SchemaVersion: SchemaVersion,
+			Agent: TuttiReplayAgent{
+				RootSessionID: "session-1",
+				Sessions: []agenthost.HistoricalSession{{
+					ID:                "session-1",
+					Kind:              "root",
+					AgentTargetID:     "codex",
+					Provider:          "codex",
+					ProviderSessionID: "provider-session-1",
+					Messages: []agenthost.HistoricalMessage{{
+						ID:   "message-1",
+						Kind: "text",
+						Payload: map[string]any{
+							"content": []any{content},
+						},
+					}},
+				}},
+			},
+			TuttiMode: TuttiReplayTuttiMode{
+				Activations:   []TuttiReplayActivation{},
+				TurnSnapshots: []TuttiReplayTurnSnapshot{},
+			},
+			Workflows: []TuttiReplayWorkflow{},
+			Issues:    []TuttiReplayIssue{},
+		}
+	}
+
+	recorded := buildState(map[string]any{
+		"type":         "image",
+		"mimeType":     "image/png",
+		"name":         "r05-image-only.png",
+		"attachmentId": "0075df1d-7a65-401f-bba1-8524f5de040b",
+	})
+	sharedReplay := buildState(map[string]any{
+		"type":     "image",
+		"mimeType": "image/png",
+		"name":     "r05-image-only.png",
+		"assetId":  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"url":      "https://example.com/object-uploads/image.png",
+		"uri":      "asset://shared/image.png",
+	})
+	if err := CompareTuttiReplayState(recorded, sharedReplay); err != nil {
+		t.Fatalf(
+			"shared object-upload image locators must not conflict with recorded attachmentId, got %v",
 			err,
 		)
 	}


### PR DESCRIPTION
## Summary
- Strip ephemeral prompt image locators (`attachmentId` / `url` / `uri` / `assetId`) during final Tutti Replay State compare.
- Keeps local-recorded cassettes and self-shared object-upload replay alpha-equivalent for image turns.

## Tests
- `go test ./packages/agent/session-replay -run 'CompareTuttiReplayStateTreatsAttachment|CompareTuttiReplayStateIgnoresShared|ProjectPortableAgentStateProjectsMaterialized|ProjectPortableAgentStateProjectsImage'`
- pre-push `pnpm check:changed -- --push-ready`

## Notes
- Companion fixes live in TSH (object-upload prepare) and tsh-server (upload object-key race). With `go.work`, desktopd picks this up on next compile; package bump needed for published consumers.


Made with [Cursor](https://cursor.com)