### PR TITLE
fix(agent-gui): show placeholders while images load

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1584,6 +1584,15 @@ text, but they are not an additional transcript text block when the canonical
 structured content already renders the same image. Explicit display prompts
 remain transcript content and continue to replace expanded rich prompt text.
 
+Structured user-prompt transcript images keep resource acquisition and browser
+image decoding as separate presentation states. A URL or hydrated data source
+is not proof that pixels are ready: AgentGUI reserves the final thumbnail
+geometry and shows its loading treatment until the exact image element reports
+`load`. `error` replaces that slot with the retryable failure treatment. A retry
+of the same URL or a replacement effective source starts a new decode attempt
+instead of reusing stale loaded or failed state. These loading and retry states
+are UI-local and never enter canonical Message or workspace-engine state.
+
 Standalone hosts may opt a transcript into participant avatars through the
 `agent-conversation` entrypoint's explicit presentation contract. Omitted or
 disabled presentation preserves the existing transcript DOM. Enabled

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -4217,12 +4217,37 @@ aside.workspace-agents-status-panel
 }
 
 .agent-gui-conversation__user-image-thumbnail {
+  position: relative;
   box-sizing: border-box;
+  height: 80px;
   max-height: 80px;
   min-width: 0;
   overflow: hidden;
   border: 1px solid var(--line-2);
   border-radius: 8px;
+}
+
+.agent-gui-conversation__user-image-thumbnail > .tsh-zoomable-image {
+  width: 100%;
+  height: 100%;
+}
+
+.agent-gui-conversation__user-image-thumbnail > .tsh-zoomable-image > img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.agent-gui-conversation__user-image-thumbnail[data-image-state="loading"]
+  > .tsh-zoomable-image {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.agent-gui-conversation__user-image-thumbnail[data-image-state="loading"]
+  > .tsh-zoomable-image
+  > .tsh-zoomable-image__trigger {
+  visibility: hidden;
 }
 
 .agent-gui-conversation__assistant-message-flow {

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageImages.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageImages.tsx
@@ -19,6 +19,19 @@ import type {
 } from "../contracts/agentMessageRowVM";
 
 type ImageFailureKind = "load" | "read" | "unavailable";
+type ImageFailureSource =
+  | {
+      kind: "resolved";
+      src: string;
+    }
+  | {
+      agentSessionId: string;
+      attachmentId: string;
+      kind: "locator";
+      path: string;
+      readerAvailable: boolean;
+      workspaceId: string;
+    };
 type ImageFailureReporter = (
   image: AgentMessageImageVM,
   kind: ImageFailureKind,
@@ -39,7 +52,7 @@ export function AgentUserImageGrid({
     },
     [runtime]
   );
-  const { failedIds, loadingIds, retryCounts, sources, markFailed, retry } =
+  const { failedSources, loadingIds, retryCounts, sources, markFailed, retry } =
     useAgentMessageImageSources(images, reportFailure);
   const { t } = useTranslation();
   const columnCount = Math.min(Math.max(images.length, 1), 4);
@@ -53,53 +66,102 @@ export function AgentUserImageGrid({
     >
       {images.map((image) => {
         const src = sources.get(image.id) ?? imageSourceUrl(image);
-        const failed = failedIds.has(image.id);
-        const loading = !src && loadingIds.has(image.id);
+        const failureSource = imageFailureSource(image, src, runtime);
+        const failed = isMatchingImageFailure(
+          failedSources.get(image.id),
+          failureSource
+        );
         const attempt = retryCounts.get(image.id) ?? 0;
         return (
-          <div key={image.id} className={styles.userImageThumbnail}>
-            {failed ? (
-              <ImageLoadFailurePlaceholder
-                label={t("agentHost.agentGui.imageLoadFailed")}
-                retryLabel={t("agentHost.agentGui.retryImage")}
-                icon={AlertCircle}
-                onRetry={() => retry(image.id)}
-              />
-            ) : src ? (
-              <ZoomableImage
-                key={`${image.id}:${attempt}:${src}`}
-                src={src}
-                alt={image.name?.trim() || "image"}
-                className="block max-h-20 w-full rounded-[7px] object-contain"
-                draggable={false}
-                downloadName={image.name?.trim() || "image.png"}
-                onError={() => {
-                  markFailed(image.id);
-                  reportFailure(image, "load", attempt);
-                }}
-              />
-            ) : loading ? (
-              <div
-                className="flex h-20 w-full items-center justify-center bg-[color-mix(in_srgb,var(--text-primary)_6%,transparent)]"
-                data-testid="agent-gui-message-image-loading"
-              >
-                <LoaderCircle
-                  aria-hidden="true"
-                  className="size-5 animate-spin text-[color-mix(in_srgb,var(--text-primary)_45%,transparent)]"
-                  strokeWidth={2}
-                />
-              </div>
-            ) : (
-              <ImageLoadFailurePlaceholder
-                label={t("agentHost.agentGui.imageLoadFailed")}
-                retryLabel={t("agentHost.agentGui.retryImage")}
-                icon={AlertCircle}
-                onRetry={() => retry(image.id)}
-              />
-            )}
-          </div>
+          <AgentUserImageTile
+            key={image.id}
+            image={image}
+            src={src}
+            failed={failed}
+            sourceLoading={!src && loadingIds.has(image.id)}
+            attempt={attempt}
+            failureLabel={t("agentHost.agentGui.imageLoadFailed")}
+            retryLabel={t("agentHost.agentGui.retryImage")}
+            onFailed={() => {
+              markFailed(image.id, failureSource);
+              reportFailure(image, "load", attempt);
+            }}
+            onRetry={() => retry(image.id)}
+          />
         );
       })}
+    </div>
+  );
+}
+
+function AgentUserImageTile({
+  attempt,
+  failed,
+  failureLabel,
+  image,
+  onFailed,
+  onRetry,
+  retryLabel,
+  sourceLoading,
+  src
+}: {
+  attempt: number;
+  failed: boolean;
+  failureLabel: string;
+  image: AgentMessageImageVM;
+  onFailed: () => void;
+  onRetry: () => void;
+  retryLabel: string;
+  sourceLoading: boolean;
+  src: string | null;
+}): JSX.Element {
+  const [loadedImage, setLoadedImage] = useState<{
+    attempt: number;
+    src: string;
+  } | null>(null);
+  const browserLoaded = Boolean(
+    src && loadedImage?.attempt === attempt && loadedImage.src === src
+  );
+  const showingFailure = failed || (!src && !sourceLoading);
+  const loading = !failed && (src ? !browserLoaded : sourceLoading);
+  const state = showingFailure ? "failed" : loading ? "loading" : "loaded";
+
+  return (
+    <div
+      aria-busy={loading || undefined}
+      className={styles.userImageThumbnail}
+      data-image-state={state}
+    >
+      {showingFailure ? (
+        <ImageLoadFailurePlaceholder
+          label={failureLabel}
+          retryLabel={retryLabel}
+          icon={AlertCircle}
+          onRetry={onRetry}
+        />
+      ) : src ? (
+        <>
+          <ZoomableImage
+            key={`${image.id}:${attempt}:${src}`}
+            src={src}
+            alt={image.name?.trim() || "image"}
+            className="block h-full w-full rounded-[7px] object-contain"
+            draggable={false}
+            downloadName={image.name?.trim() || "image.png"}
+            onLoad={() => {
+              setLoadedImage((current) =>
+                current?.attempt === attempt && current.src === src
+                  ? current
+                  : { attempt, src }
+              );
+            }}
+            onError={onFailed}
+          />
+          {loading ? <ImageLoadingPlaceholder /> : null}
+        </>
+      ) : (
+        <ImageLoadingPlaceholder />
+      )}
     </div>
   );
 }
@@ -108,38 +170,45 @@ function useAgentMessageImageSources(
   images: readonly AgentMessageImageVM[],
   reportFailure: ImageFailureReporter
 ): {
-  failedIds: ReadonlySet<string>;
+  failedSources: ReadonlyMap<string, ImageFailureSource>;
   loadingIds: ReadonlySet<string>;
   retryCounts: ReadonlyMap<string, number>;
   sources: ReadonlyMap<string, string>;
-  markFailed: (imageId: string) => void;
+  markFailed: (imageId: string, source: ImageFailureSource) => void;
   retry: (imageId: string) => void;
 } {
   const runtime = useOptionalAgentGUIRuntime();
-  const [failedIds, setFailedIds] = useState<Set<string>>(() => new Set());
+  const [failedSources, setFailedSources] = useState<
+    Map<string, ImageFailureSource>
+  >(() => new Map());
   const [sources, setSources] = useState<Map<string, string>>(() => new Map());
   const [loadingIds, setLoadingIds] = useState<Set<string>>(() => new Set());
   const [retryCounts, setRetryCounts] = useState<Map<string, number>>(
     () => new Map()
   );
-  const markFailed = useCallback((imageId: string): void => {
-    setFailedIds((current) => {
-      if (current.has(imageId)) return current;
-      const next = new Set(current);
-      next.add(imageId);
-      return next;
-    });
-    setLoadingIds((current) => {
-      if (!current.has(imageId)) return current;
-      const next = new Set(current);
-      next.delete(imageId);
-      return next;
-    });
-  }, []);
+  const markFailed = useCallback(
+    (imageId: string, source: ImageFailureSource): void => {
+      setFailedSources((current) => {
+        if (isMatchingImageFailure(current.get(imageId), source)) {
+          return current;
+        }
+        const next = new Map(current);
+        next.set(imageId, source);
+        return next;
+      });
+      setLoadingIds((current) => {
+        if (!current.has(imageId)) return current;
+        const next = new Set(current);
+        next.delete(imageId);
+        return next;
+      });
+    },
+    []
+  );
   const retry = useCallback((imageId: string): void => {
-    setFailedIds((current) => {
+    setFailedSources((current) => {
       if (!current.has(imageId)) return current;
-      const next = new Set(current);
+      const next = new Map(current);
       next.delete(imageId);
       return next;
     });
@@ -155,7 +224,10 @@ function useAgentMessageImageSources(
         (image) =>
           !imageSourceUrl(image) &&
           !sources.has(image.id) &&
-          !failedIds.has(image.id) &&
+          !isMatchingImageFailure(
+            failedSources.get(image.id),
+            imageFailureSource(image, null, runtime)
+          ) &&
           image.workspaceId &&
           image.agentSessionId &&
           (image.attachmentId
@@ -163,7 +235,7 @@ function useAgentMessageImageSources(
             : runtime?.readPromptAsset) &&
           (image.attachmentId || image.path)
       ),
-    [failedIds, images, runtime, sources]
+    [failedSources, images, runtime, sources]
   );
   const unavailableImages = useMemo(
     () =>
@@ -171,7 +243,10 @@ function useAgentMessageImageSources(
         (image) =>
           !imageSourceUrl(image) &&
           !sources.has(image.id) &&
-          !failedIds.has(image.id) &&
+          !isMatchingImageFailure(
+            failedSources.get(image.id),
+            imageFailureSource(image, null, runtime)
+          ) &&
           (!image.workspaceId ||
             !image.agentSessionId ||
             !(image.attachmentId || image.path) ||
@@ -179,8 +254,10 @@ function useAgentMessageImageSources(
               ? !runtime?.readSessionAttachment
               : !runtime?.readPromptAsset))
       ),
-    [failedIds, images, runtime, sources]
+    [failedSources, images, runtime, sources]
   );
+  const visibleLoadingIds = new Set(loadingIds);
+  for (const image of missingImages) visibleLoadingIds.add(image.id);
 
   useEffect(() => {
     let canceled = false;
@@ -220,7 +297,7 @@ function useAgentMessageImageSources(
           })
           .catch(() => {
             if (canceled) return;
-            markFailed(image.id);
+            markFailed(image.id, imageFailureSource(image, null, runtime));
             reportFailure(image, "read", attempt);
           })
           .finally(() => {
@@ -235,7 +312,7 @@ function useAgentMessageImageSources(
     }
     for (const image of unavailableImages) {
       const attempt = retryCounts.get(image.id) ?? 0;
-      markFailed(image.id);
+      markFailed(image.id, imageFailureSource(image, null, runtime));
       reportFailure(image, "unavailable", attempt);
     }
     return () => {
@@ -251,13 +328,28 @@ function useAgentMessageImageSources(
   ]);
 
   return {
-    failedIds,
-    loadingIds,
+    failedSources,
+    loadingIds: visibleLoadingIds,
     retryCounts,
     sources,
     markFailed,
     retry
   };
+}
+
+function ImageLoadingPlaceholder(): JSX.Element {
+  return (
+    <div
+      className="absolute inset-0 flex items-center justify-center bg-[color-mix(in_srgb,var(--text-primary)_6%,transparent)]"
+      data-testid="agent-gui-message-image-loading"
+    >
+      <LoaderCircle
+        aria-hidden="true"
+        className="size-5 animate-spin text-[color-mix(in_srgb,var(--text-primary)_45%,transparent)]"
+        strokeWidth={2}
+      />
+    </div>
+  );
 }
 
 function ImageLoadFailurePlaceholder({
@@ -273,7 +365,7 @@ function ImageLoadFailurePlaceholder({
 }): JSX.Element {
   return (
     <div
-      className="flex h-20 w-full flex-col items-center justify-center gap-1 bg-[var(--transparency-block)] px-1 text-[var(--text-secondary)]"
+      className="flex h-full w-full flex-col items-center justify-center gap-1 bg-[var(--transparency-block)] px-1 text-[var(--text-secondary)]"
       data-testid="agent-gui-message-image-failed"
       role="status"
       aria-label={label}
@@ -352,4 +444,43 @@ function imageDataUrl(image: AgentMessageImageVM): string | null {
 function imageSourceUrl(image: AgentMessageImageVM): string | null {
   const url = image.url?.trim() ?? "";
   return url || imageDataUrl(image);
+}
+
+function imageFailureSource(
+  image: AgentMessageImageVM,
+  src: string | null,
+  runtime: AgentGUIRuntime | null
+): ImageFailureSource {
+  if (src) {
+    return { kind: "resolved", src };
+  }
+  const attachmentId = image.attachmentId?.trim() ?? "";
+  return {
+    kind: "locator",
+    workspaceId: image.workspaceId?.trim() ?? "",
+    agentSessionId: image.agentSessionId.trim(),
+    attachmentId,
+    path: image.path?.trim() ?? "",
+    readerAvailable: Boolean(
+      attachmentId ? runtime?.readSessionAttachment : runtime?.readPromptAsset
+    )
+  };
+}
+
+function isMatchingImageFailure(
+  failed: ImageFailureSource | undefined,
+  current: ImageFailureSource
+): boolean {
+  if (!failed || failed.kind !== current.kind) return false;
+  if (failed.kind === "resolved" && current.kind === "resolved") {
+    return failed.src === current.src;
+  }
+  if (failed.kind !== "locator" || current.kind !== "locator") return false;
+  return (
+    failed.workspaceId === current.workspaceId &&
+    failed.agentSessionId === current.agentSessionId &&
+    failed.attachmentId === current.attachmentId &&
+    failed.path === current.path &&
+    failed.readerAvailable === current.readerAvailable
+  );
 }

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import {
   act,
   fireEvent,
@@ -5,7 +7,7 @@ import {
   screen,
   waitFor
 } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   resetAgentHostApiForTests,
   setAgentHostApiForTests
@@ -25,6 +27,16 @@ const mockState = vi.hoisted(() => ({
   markdownStreamingFlags: [] as Array<boolean | undefined>,
   toolGroupOnLinkClicks: [] as Array<((href: string) => void) | undefined>
 }));
+const agentActivityStyles = readFileSync(
+  resolve(process.cwd(), "app/renderer/agentactivity.css"),
+  "utf8"
+);
+const agentActivityStyleElement = document.createElement("style");
+agentActivityStyleElement.textContent = agentActivityStyles;
+
+afterEach(() => {
+  agentActivityStyleElement.remove();
+});
 
 vi.mock("../../../i18n/index", () => ({
   getActiveUiLanguage: () => "en",
@@ -630,9 +642,10 @@ describe("AgentTranscriptItemView render stability", () => {
         attachmentId: "attachment-1"
       });
     });
+    const image = await screen.findByRole("img", { name: "screen.png" });
+    expect(image).toHaveAttribute("src", "data:image/png;base64,aW1hZ2U=");
+    fireEvent.load(image);
     await waitFor(() => {
-      const image = screen.getByRole("img", { name: "screen.png" });
-      expect(image).toHaveAttribute("src", "data:image/png;base64,aW1hZ2U=");
       expect(
         screen.getByRole("button", { name: "common.expandImage" })
       ).toBeTruthy();
@@ -712,6 +725,12 @@ describe("AgentTranscriptItemView render stability", () => {
       "src",
       "data:image/png;base64,b3B0aW1pc3RpYw=="
     );
+    fireEvent.load(optimisticImage);
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("agent-gui-message-image-loading")
+      ).toBeNull();
+    });
 
     rerender(
       <AgentMessageBlock
@@ -732,7 +751,8 @@ describe("AgentTranscriptItemView render stability", () => {
     delete (window as { agentGUIRuntime?: unknown }).agentGUIRuntime;
   });
 
-  it("renders a user prompt image directly from its remote HTTPS URL", () => {
+  it("reserves a loading slot until a remote HTTPS image loads", async () => {
+    document.head.append(agentActivityStyleElement);
     const readPromptAsset = vi.fn();
     Object.defineProperty(window, "agentGUIRuntime", {
       configurable: true,
@@ -767,10 +787,34 @@ describe("AgentTranscriptItemView render stability", () => {
       />
     );
 
-    expect(screen.getByRole("img", { name: "screen.png" })).toHaveAttribute(
+    const image = screen.getByRole("img", { name: "screen.png" });
+    expect(image).toHaveAttribute(
       "src",
       "https://objects.example.test/signed/screen.png"
     );
+    expect(
+      screen.getByTestId("agent-gui-message-image-loading")
+    ).toBeInTheDocument();
+    expect(image.closest("[data-image-state]")).toHaveAttribute(
+      "data-image-state",
+      "loading"
+    );
+    const imageSlot = image.closest("[data-image-state]");
+    expect(imageSlot).not.toBeNull();
+    expect(window.getComputedStyle(imageSlot as Element).height).toBe("80px");
+
+    fireEvent.load(image);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("agent-gui-message-image-loading")
+      ).toBeNull();
+      expect(image.closest("[data-image-state]")).toHaveAttribute(
+        "data-image-state",
+        "loaded"
+      );
+      expect(window.getComputedStyle(imageSlot as Element).height).toBe("80px");
+    });
     expect(readPromptAsset).not.toHaveBeenCalled();
 
     delete (window as { agentGUIRuntime?: unknown }).agentGUIRuntime;
@@ -806,6 +850,9 @@ describe("AgentTranscriptItemView render stability", () => {
     );
 
     const image = screen.getByRole("img", { name: "screen.png" });
+    expect(
+      screen.getByTestId("agent-gui-message-image-loading")
+    ).toBeInTheDocument();
     fireEvent.error(image);
 
     expect(
@@ -823,9 +870,66 @@ describe("AgentTranscriptItemView render stability", () => {
     });
     expect(retriedImage).not.toBe(image);
     expect(retriedImage).toHaveAttribute("src", signedUrl);
+    expect(
+      screen.getByTestId("agent-gui-message-image-loading")
+    ).toBeInTheDocument();
     fireEvent.load(retriedImage);
 
     expect(screen.queryByTestId("agent-gui-message-image-failed")).toBeNull();
+    expect(screen.queryByTestId("agent-gui-message-image-loading")).toBeNull();
+  });
+
+  it("starts a fresh load when a failed remote image URL changes", async () => {
+    const firstUrl = "https://objects.example.test/signed/screen-v1.png";
+    const secondUrl = "https://objects.example.test/signed/screen-v2.png";
+    const renderMessage = (url: string) => (
+      <AgentMessageBlock
+        workspaceRoot="/workspace/demo"
+        basePath="/workspace/demo"
+        row={userMessageRow({
+          kind: "message-content",
+          id: "user-images-url-refreshed",
+          turnId: "turn-1",
+          body: "",
+          contentKind: "image-grid",
+          images: [
+            {
+              id: "remote-image-refreshed",
+              workspaceId: "room-1",
+              agentSessionId: "session-1",
+              mimeType: "image/png",
+              name: "screen.png",
+              url
+            }
+          ],
+          occurredAtUnixMs: 1
+        })}
+        thinkingLabel="Thought process"
+      />
+    );
+    const { rerender } = render(renderMessage(firstUrl));
+
+    const firstImage = screen.getByRole("img", { name: "screen.png" });
+    fireEvent.error(firstImage);
+    expect(
+      await screen.findByTestId("agent-gui-message-image-failed")
+    ).toBeInTheDocument();
+
+    rerender(renderMessage(secondUrl));
+
+    const refreshedImage = await screen.findByRole("img", {
+      name: "screen.png"
+    });
+    expect(refreshedImage).not.toBe(firstImage);
+    expect(refreshedImage).toHaveAttribute("src", secondUrl);
+    expect(screen.queryByTestId("agent-gui-message-image-failed")).toBeNull();
+    expect(
+      screen.getByTestId("agent-gui-message-image-loading")
+    ).toBeInTheDocument();
+
+    fireEvent.load(refreshedImage);
+
+    expect(screen.queryByTestId("agent-gui-message-image-loading")).toBeNull();
   });
 
   it("shows a loading spinner while a user prompt image is being read", async () => {
@@ -897,14 +1001,18 @@ describe("AgentTranscriptItemView render stability", () => {
       name: "screen.png"
     });
 
+    const image = await screen.findByRole("img", { name: "screen.png" });
+    expect(image).toHaveAttribute("src", "data:image/png;base64,aW1hZ2U=");
+    expect(
+      screen.getByTestId("agent-gui-message-image-loading")
+    ).toBeInTheDocument();
+
+    fireEvent.load(image);
+
     await waitFor(() => {
       expect(
         screen.queryByTestId("agent-gui-message-image-loading")
       ).toBeNull();
-      expect(screen.getByRole("img", { name: "screen.png" })).toHaveAttribute(
-        "src",
-        "data:image/png;base64,aW1hZ2U="
-      );
     });
 
     delete (window as { agentGUIRuntime?: unknown }).agentGUIRuntime;


### PR DESCRIPTION
## 背景

AgentGUI 展示 HTTPS 用户提示图片时，浏览器完成加载和解码前没有稳定占位，导致消息区域暂时空白，并在图片出现后发生布局变化。

## 改动

- 将图片资源读取状态与浏览器 load/error 状态分开处理
- 首帧保留固定 80px 缩略图槽位并显示 loading，真实 load 后再展示图片
- 加载期间禁用不可见的图片放大入口，失败后保留可重试占位
- 将失败状态绑定到当前 URL 或 attachment/path locator，签名 URL 或 durable source 更新后自动重新加载
- 补充真实 stylesheet 几何、HTTPS 加载、失败重试和 source replacement 回归测试
- 更新 AgentGUI transcript 图片加载架构说明

## 验证

- pnpm check:changed
- AgentTranscriptItemView.spec.tsx：30 个测试通过