### PR TITLE
fix(agent-gui): keep plan-implementation waiting across conversations

### DIFF
--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -914,6 +914,10 @@ confirmed turn and notice update. These payloads contain semantic IDs only;
 user-visible copy belongs to consumer i18n. Provider-originated exit-plan
 prompts remain ordinary durable interaction responses and use the existing
 `interactive_response` operation rather than this synthetic-plan endpoint.
+Until the user confirms or dismisses the plan, AgentGUI projects that wait
+through one shared awaiting predicate into conversation-rail
+`needsUserAction`, conversation-list awaiting sets, and Message Center
+attention; it must not invent an active-session-only overlay for the same fact.
 
 Provider interaction lifecycle is an explicit entity stream, independent of
 transcript projection and runtime session snapshots:

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.activity.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.activity.spec.tsx
@@ -287,6 +287,127 @@ describe("useAgentGUIConversationRailQuery Activity facts", () => {
     engine.dispose();
   });
 
+  it("keeps plan-implementation waiting on non-active conversations", async () => {
+    const engine = createTestAgentSessionEngine("workspace-1");
+    engine.dispatch({
+      type: "session/snapshotReceived",
+      sessions: [
+        normalizeAgentActivitySession({
+          agentSessionId: "plan-session",
+          capabilities: {
+            imageInput: false,
+            modelImageInputRequired: false,
+            modelPlanBinding: false,
+            modelSwitch: false,
+            skills: false,
+            compact: false,
+            tokenUsage: false,
+            rateLimits: false,
+            planMode: true,
+            interrupt: false,
+            activeTurnGuidance: false,
+            browserUse: false,
+            computerUse: false,
+            goalPause: false,
+            planImplementation: true,
+            permissionModeChangeDuringTurn: false,
+            permissionModeChangeDeferred: false,
+            review: false,
+            resumeRunningTurn: false
+          },
+          cwd: "/workspace",
+          latestTurn: {
+            turnId: "turn-plan",
+            agentSessionId: "plan-session",
+            origin: "user_prompt",
+            phase: "settled",
+            outcome: "completed",
+            startedAtUnixMs: 10,
+            settledAtUnixMs: 20,
+            updatedAtUnixMs: 20
+          },
+          latestTurnInteractions: [],
+          pendingInteractions: [],
+          provider: "codex",
+          title: "Plan session",
+          workspaceId: "workspace-1"
+        }),
+        normalizeAgentActivitySession({
+          agentSessionId: "other-session",
+          cwd: "/workspace",
+          latestTurnInteractions: [],
+          pendingInteractions: [],
+          provider: "codex",
+          title: "Other session",
+          workspaceId: "workspace-1"
+        })
+      ]
+    });
+    engine.dispatch({
+      type: "message/snapshotReceived",
+      messages: [
+        {
+          agentSessionId: "plan-session",
+          kind: "message",
+          messageId: "plan-message",
+          occurredAtUnixMs: 20,
+          payload: { messageKind: "plan" },
+          role: "agent",
+          turnId: "turn-plan",
+          version: 1,
+          workspaceId: "workspace-1"
+        }
+      ]
+    });
+    const runtime = {
+      conversationActivityViewEnabled: true,
+      getSessionEngine: () => engine
+    } as unknown as AgentGUIRuntime;
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AgentGUIRuntimeProvider runtime={runtime}>
+        {children}
+      </AgentGUIRuntimeProvider>
+    );
+    const rendered = renderHook(
+      () =>
+        useAgentGUIConversationRailQuery({
+          activeConversationId: "other-session",
+          conversationFilter: { kind: "all" },
+          conversationQuery: "",
+          userProjects: [],
+          workspaceId: "workspace-1"
+        }),
+      { wrapper }
+    );
+
+    await waitFor(() =>
+      expect(
+        rendered.result.current.activityRootFacts.get("plan-session")
+      ).toEqual({
+        needsUserAction: true,
+        status: "completed"
+      })
+    );
+    expect(
+      rendered.result.current.activityConversations.find(
+        (conversation) => conversation.id === "plan-session"
+      )
+    ).toMatchObject({
+      id: "plan-session",
+      needsUserAction: true,
+      status: "completed"
+    });
+    expect(
+      rendered.result.current.activityRootFacts.get("other-session")
+    ).toEqual({
+      needsUserAction: false,
+      status: "ready"
+    });
+
+    rendered.unmount();
+    engine.dispose();
+  });
+
   it("returns the shared empty Activity facts when the host capability is disabled", () => {
     const engine = createTestAgentSessionEngine("workspace-1");
     engine.dispatch({

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.activity.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.activity.spec.tsx
@@ -293,6 +293,7 @@ describe("useAgentGUIConversationRailQuery Activity facts", () => {
       type: "session/snapshotReceived",
       sessions: [
         normalizeAgentActivitySession({
+          activeTurnId: null,
           agentSessionId: "plan-session",
           capabilities: {
             imageInput: false,
@@ -333,6 +334,7 @@ describe("useAgentGUIConversationRailQuery Activity facts", () => {
           workspaceId: "workspace-1"
         }),
         normalizeAgentActivitySession({
+          activeTurnId: null,
           agentSessionId: "other-session",
           cwd: "/workspace",
           latestTurnInteractions: [],

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts
@@ -27,6 +27,7 @@ import {
 } from "../model/agentGuiConversationFilter";
 import { createAgentGUIConversationRailTitlePromptSelector } from "../../../shared/agentConversationRailTitlePromptSelector";
 import { projectCanonicalAgentGUIConversationSummaries } from "../../../shared/agentGUIConversationSummaryProjection";
+import { selectRootAgentSessionIdsAwaitingPlanImplementation } from "../../../shared/agentConversation/planImplementationAwaiting";
 import { conversationSummariesRenderEqual } from "./agentGuiController.stableHelpers";
 import { createConversationRailConversationsSelector } from "./agentGuiConversationRailQuerySnapshot";
 import { resolveConversationRailQueryScope } from "./agentGuiConversationRailQueryTypes";
@@ -272,9 +273,10 @@ function selectEmptyAgentGUIConversationActivityRootFacts(): ReadonlyMap<
 function selectAgentGUIConversationActivityRootFacts(
   state: Parameters<typeof selectWorkspaceAgentConsumerSessions>[0]
 ): ReadonlyMap<string, AgentGUIConversationActivityRootFact> {
-  const rootSessionIdsAwaitingUserAction = new Set(
-    selectRootAgentSessionIdsWithPendingInteractions(state)
-  );
+  const rootSessionIdsAwaitingUserAction = new Set([
+    ...selectRootAgentSessionIdsWithPendingInteractions(state),
+    ...selectRootAgentSessionIdsAwaitingPlanImplementation(state)
+  ]);
   return new Map(
     selectWorkspaceAgentConsumerSessions(state)
       .filter((item) => item.session.visible !== false)

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIViewAssembly.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIViewAssembly.ts
@@ -186,38 +186,8 @@ export function useAgentGUIViewAssembly(input: UseAgentGUIViewAssemblyInput) {
     pendingApproval: detail.pendingApproval,
     serverInteractivePrompt: detail.serverInteractivePrompt
   });
-  const railConversations = useMemo(() => {
-    const prompt = session.pendingInteractivePrompt;
-    if (prompt?.kind !== "plan-implementation" || !input.activeConversationId) {
-      return visibleConversations;
-    }
-    let changed = false;
-    const next = visibleConversations.map((conversation) => {
-      if (
-        conversation.id !== input.activeConversationId ||
-        conversation.needsUserAction
-      ) {
-        return conversation;
-      }
-      changed = true;
-      return { ...conversation, needsUserAction: true };
-    });
-    return changed ? next : visibleConversations;
-  }, [
-    input.activeConversationId,
-    session.pendingInteractivePrompt,
-    visibleConversations
-  ]);
-  const railActiveConversation = useMemo(() => {
-    if (
-      !activeConversation ||
-      session.pendingInteractivePrompt?.kind !== "plan-implementation" ||
-      activeConversation.needsUserAction
-    ) {
-      return activeConversation;
-    }
-    return { ...activeConversation, needsUserAction: true };
-  }, [activeConversation, session.pendingInteractivePrompt]);
+  const railConversations = visibleConversations;
+  const railActiveConversation = activeConversation;
   const providerHome = useAgentGUIProviderHome(input);
   const controllerActions = useAgentGUIControllerActions({
     ...input.operationActions,

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterEngineModel.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterEngineModel.ts
@@ -21,10 +21,8 @@ import {
   extractExitPlanModeOptions,
   isExitPlanSwitchModeInput
 } from "../shared/agentConversation/exitPlanOptions";
-import {
-  latestPlanTurnId,
-  planImplementationPromptFromPlanTurn
-} from "../shared/agentConversation/planImplementationPresentation";
+import { consumerAwaitingPlanImplementation } from "../shared/agentConversation/planImplementationAwaiting";
+import { planImplementationPromptFromPlanTurn } from "../shared/agentConversation/planImplementationPresentation";
 import {
   buildWorkspaceAgentMessageCenterItem,
   buildWorkspaceAgentMessageCenterModelFromItems,
@@ -257,12 +255,19 @@ export function selectWorkspaceAgentAttentionItems(
     }
 
     const latestTurn = consumer.latestTurn;
+    const statusKey = promptStatusKey(
+      consumer.session.agentSessionId,
+      latestTurn?.turnId ?? "",
+      latestTurn?.turnId ?? ""
+    );
     if (
-      latestTurn?.phase !== "settled" ||
-      latestTurn.outcome !== "completed" ||
-      consumer.session.capabilities?.planImplementation !== true ||
-      consumer.session.capabilities.planMode !== true ||
-      latestPlanTurnId(messages) !== latestTurn.turnId
+      !consumerAwaitingPlanImplementation({
+        capabilities: consumer.session.capabilities,
+        dismissed: presentation.dismissedPlanTurnKeys[statusKey] === true,
+        latestTurn,
+        messages
+      }) ||
+      !latestTurn
     ) {
       continue;
     }
@@ -273,12 +278,6 @@ export function selectWorkspaceAgentAttentionItems(
       turnId: latestTurn.turnId,
       requestId: latestTurn.turnId
     };
-    const statusKey = promptStatusKey(
-      target.agentSessionId,
-      target.turnId,
-      target.requestId
-    );
-    if (presentation.dismissedPlanTurnKeys[statusKey]) continue;
     const prompt = planImplementationPromptFromPlanTurn(
       latestTurn.turnId,
       consumer.session.title

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/useAgentGuiConversationList.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/useAgentGuiConversationList.ts
@@ -27,6 +27,7 @@ import {
 } from "../../../../../shared/agentConversationTitleProjection.ts";
 import { createAgentGUIConversationRailTitlePromptSelector } from "../../../../../shared/agentConversationRailTitlePromptSelector.ts";
 import { projectCanonicalAgentGUIConversationSummaries } from "../../../../../shared/agentGUIConversationSummaryProjection.ts";
+import { selectRootAgentSessionIdsAwaitingPlanImplementation } from "../../../../../shared/agentConversation/planImplementationAwaiting";
 
 export interface AgentGUIConversationListQuery {
   conversationFilter?: AgentGUIConversationFilter | null;
@@ -57,6 +58,11 @@ export function useAgentGuiConversationList(
     selectRootAgentSessionIdsWithPendingInteractions,
     stringArraysEqual
   );
+  const rootAgentSessionIdsAwaitingPlanImplementation = useEngineSelector(
+    engine,
+    selectRootAgentSessionIdsAwaitingPlanImplementation,
+    stringArraysEqual
+  );
   const pendingActivations = useEngineSelector(
     engine,
     selectPendingActivations,
@@ -73,9 +79,10 @@ export function useAgentGuiConversationList(
   );
   return useMemo(() => {
     if (!query) return null;
-    const rootSessionIdsAwaitingUserAction = new Set(
-      rootAgentSessionIdsWithPendingInteractions
-    );
+    const rootSessionIdsAwaitingUserAction = new Set([
+      ...rootAgentSessionIdsWithPendingInteractions,
+      ...rootAgentSessionIdsAwaitingPlanImplementation
+    ]);
     const canonicalIds = new Set(
       sessions.map((item) => item.session.agentSessionId)
     );
@@ -233,6 +240,7 @@ export function useAgentGuiConversationList(
     firstUserDisplayPromptsBySessionId,
     pendingActivations,
     query,
+    rootAgentSessionIdsAwaitingPlanImplementation,
     rootAgentSessionIdsWithPendingInteractions,
     sessions,
     workspaceReconcile

--- a/packages/agent/gui/shared/agentConversation/planImplementationAwaiting.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/planImplementationAwaiting.spec.ts
@@ -1,0 +1,163 @@
+import {
+  normalizeAgentActivitySession,
+  type AgentActivitySessionCapabilities,
+  type AgentActivityTurn
+} from "@tutti-os/agent-activity-core";
+import { describe, expect, it } from "vitest";
+import { createTestAgentSessionEngine } from "../testing/createTestAgentSessionEngine";
+import {
+  consumerAwaitingPlanImplementation,
+  selectRootAgentSessionIdsAwaitingPlanImplementation
+} from "./planImplementationAwaiting";
+
+describe("planImplementationAwaiting", () => {
+  it("matches a settled plan turn that still needs implementation confirmation", () => {
+    expect(
+      consumerAwaitingPlanImplementation({
+        capabilities: planCapabilities(),
+        dismissed: false,
+        latestTurn: settledPlanTurn("turn-plan"),
+        messages: [
+          {
+            turnId: "turn-plan",
+            occurredAtUnixMs: 20,
+            payload: { messageKind: "plan" }
+          }
+        ]
+      })
+    ).toBe(true);
+  });
+
+  it("fails closed for dismissals, missing plan messages, or missing capabilities", () => {
+    const messages = [
+      {
+        turnId: "turn-plan",
+        occurredAtUnixMs: 20,
+        payload: { messageKind: "plan" }
+      }
+    ];
+    expect(
+      consumerAwaitingPlanImplementation({
+        capabilities: planCapabilities(),
+        dismissed: true,
+        latestTurn: settledPlanTurn("turn-plan"),
+        messages
+      })
+    ).toBe(false);
+    expect(
+      consumerAwaitingPlanImplementation({
+        capabilities: planCapabilities({ planImplementation: false }),
+        dismissed: false,
+        latestTurn: settledPlanTurn("turn-plan"),
+        messages
+      })
+    ).toBe(false);
+    expect(
+      consumerAwaitingPlanImplementation({
+        capabilities: planCapabilities(),
+        dismissed: false,
+        latestTurn: settledPlanTurn("turn-plan"),
+        messages: [
+          {
+            turnId: "turn-plan",
+            occurredAtUnixMs: 20,
+            payload: { messageKind: "text" }
+          }
+        ]
+      })
+    ).toBe(false);
+  });
+
+  it("selects every root session awaiting plan implementation from engine state", () => {
+    const engine = createTestAgentSessionEngine("workspace-1");
+    engine.dispatch({
+      type: "session/snapshotReceived",
+      sessions: [
+        normalizeAgentActivitySession({
+          agentSessionId: "plan-session",
+          capabilities: planCapabilities(),
+          cwd: "/workspace",
+          latestTurn: settledPlanTurn("turn-plan", "plan-session"),
+          latestTurnInteractions: [],
+          pendingInteractions: [],
+          provider: "codex",
+          title: "Plan session",
+          workspaceId: "workspace-1"
+        }),
+        normalizeAgentActivitySession({
+          agentSessionId: "idle-session",
+          capabilities: planCapabilities(),
+          cwd: "/workspace",
+          latestTurnInteractions: [],
+          pendingInteractions: [],
+          provider: "codex",
+          title: "Idle session",
+          workspaceId: "workspace-1"
+        })
+      ]
+    });
+    engine.dispatch({
+      type: "message/snapshotReceived",
+      messages: [
+        {
+          agentSessionId: "plan-session",
+          kind: "message",
+          messageId: "plan-message",
+          occurredAtUnixMs: 20,
+          payload: { messageKind: "plan" },
+          role: "agent",
+          turnId: "turn-plan",
+          version: 1,
+          workspaceId: "workspace-1"
+        }
+      ]
+    });
+
+    expect(
+      selectRootAgentSessionIdsAwaitingPlanImplementation(engine.getSnapshot())
+    ).toEqual(["plan-session"]);
+  });
+});
+
+function settledPlanTurn(
+  turnId: string,
+  agentSessionId = "session-1"
+): AgentActivityTurn {
+  return {
+    turnId,
+    agentSessionId,
+    origin: "user_prompt",
+    phase: "settled",
+    outcome: "completed",
+    startedAtUnixMs: 10,
+    settledAtUnixMs: 20,
+    updatedAtUnixMs: 20
+  };
+}
+
+function planCapabilities(
+  overrides: Partial<AgentActivitySessionCapabilities> = {}
+): AgentActivitySessionCapabilities {
+  return {
+    imageInput: false,
+    modelImageInputRequired: false,
+    modelPlanBinding: false,
+    modelSwitch: false,
+    skills: false,
+    compact: false,
+    tokenUsage: false,
+    rateLimits: false,
+    planMode: true,
+    interrupt: false,
+    activeTurnGuidance: false,
+    browserUse: false,
+    computerUse: false,
+    goalPause: false,
+    planImplementation: true,
+    permissionModeChangeDuringTurn: false,
+    permissionModeChangeDeferred: false,
+    review: false,
+    resumeRunningTurn: false,
+    ...overrides
+  };
+}

--- a/packages/agent/gui/shared/agentConversation/planImplementationAwaiting.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/planImplementationAwaiting.spec.ts
@@ -74,6 +74,7 @@ describe("planImplementationAwaiting", () => {
       type: "session/snapshotReceived",
       sessions: [
         normalizeAgentActivitySession({
+          activeTurnId: null,
           agentSessionId: "plan-session",
           capabilities: planCapabilities(),
           cwd: "/workspace",
@@ -85,6 +86,7 @@ describe("planImplementationAwaiting", () => {
           workspaceId: "workspace-1"
         }),
         normalizeAgentActivitySession({
+          activeTurnId: null,
           agentSessionId: "idle-session",
           capabilities: planCapabilities(),
           cwd: "/workspace",

--- a/packages/agent/gui/shared/agentConversation/planImplementationAwaiting.ts
+++ b/packages/agent/gui/shared/agentConversation/planImplementationAwaiting.ts
@@ -1,0 +1,79 @@
+import {
+  selectPlanTurnDismissed,
+  selectSessionMessages,
+  selectWorkspaceAgentConsumerSessions,
+  type AgentActivitySession,
+  type AgentActivityTurn,
+  type AgentSessionEngineStateBase
+} from "@tutti-os/agent-activity-core";
+import { latestPlanTurnId } from "./planImplementationPresentation";
+
+/**
+ * Shared predicate for the synthesized plan-implementation wait. Durable
+ * approval / question / exit-plan waits already ride pendingInteractions;
+ * this predicate is the matching cross-surface fact for plan confirmation so
+ * rail, conversation list, and attention do not each invent a private rule.
+ */
+export function consumerAwaitingPlanImplementation(input: {
+  capabilities: AgentActivitySession["capabilities"] | null | undefined;
+  dismissed: boolean;
+  latestTurn: AgentActivityTurn | null | undefined;
+  messages: readonly {
+    turnId?: string | null;
+    occurredAtUnixMs?: number | null;
+    createdAtUnixMs?: number | null;
+    seq?: number | null;
+    payload?: Record<string, unknown> | null;
+  }[];
+}): boolean {
+  const latestTurn = input.latestTurn;
+  if (
+    !latestTurn ||
+    latestTurn.phase !== "settled" ||
+    latestTurn.outcome !== "completed" ||
+    input.capabilities?.planImplementation !== true ||
+    input.capabilities?.planMode !== true ||
+    input.dismissed
+  ) {
+    return false;
+  }
+  return latestPlanTurnId(input.messages) === latestTurn.turnId;
+}
+
+export function selectRootAgentSessionIdsAwaitingPlanImplementation(
+  state: AgentSessionEngineStateBase
+): readonly string[] {
+  const sessionIds: string[] = [];
+  for (const consumer of selectWorkspaceAgentConsumerSessions(state)) {
+    const sessionId = consumer.session.agentSessionId;
+    if (
+      !consumerAwaitingPlanImplementation({
+        capabilities: consumer.session.capabilities,
+        dismissed: selectPlanTurnDismissed(
+          state,
+          sessionId,
+          consumer.latestTurn?.turnId
+        ),
+        latestTurn: consumer.latestTurn,
+        messages: sessionMessagesForPlanDetection(state, consumer.session)
+      })
+    ) {
+      continue;
+    }
+    sessionIds.push(sessionId);
+  }
+  return sessionIds;
+}
+
+function sessionMessagesForPlanDetection(
+  state: AgentSessionEngineStateBase,
+  session: Pick<AgentActivitySession, "agentSessionId" | "providerSessionId">
+) {
+  for (const id of [session.agentSessionId, session.providerSessionId]) {
+    const messages = selectSessionMessages(state, id);
+    if (messages.length > 0) {
+      return messages;
+    }
+  }
+  return [];
+}

--- a/packages/agent/gui/shared/agentConversation/planImplementationAwaiting.ts
+++ b/packages/agent/gui/shared/agentConversation/planImplementationAwaiting.ts
@@ -4,7 +4,7 @@ import {
   selectWorkspaceAgentConsumerSessions,
   type AgentActivitySession,
   type AgentActivityTurn,
-  type AgentSessionEngineStateBase
+  type AgentSessionEngineState
 } from "@tutti-os/agent-activity-core";
 import { latestPlanTurnId } from "./planImplementationPresentation";
 
@@ -41,7 +41,7 @@ export function consumerAwaitingPlanImplementation(input: {
 }
 
 export function selectRootAgentSessionIdsAwaitingPlanImplementation(
-  state: AgentSessionEngineStateBase
+  state: AgentSessionEngineState
 ): readonly string[] {
   const sessionIds: string[] = [];
   for (const consumer of selectWorkspaceAgentConsumerSessions(state)) {
@@ -66,7 +66,7 @@ export function selectRootAgentSessionIdsAwaitingPlanImplementation(
 }
 
 function sessionMessagesForPlanDetection(
-  state: AgentSessionEngineStateBase,
+  state: AgentSessionEngineState,
   session: Pick<AgentActivitySession, "agentSessionId" | "providerSessionId">
 ) {
   for (const id of [session.agentSessionId, session.providerSessionId]) {

--- a/packages/agent/gui/shared/agentConversation/planImplementationAwaiting.ts
+++ b/packages/agent/gui/shared/agentConversation/planImplementationAwaiting.ts
@@ -3,10 +3,13 @@ import {
   selectSessionMessages,
   selectWorkspaceAgentConsumerSessions,
   type AgentActivitySession,
-  type AgentActivityTurn,
-  type AgentSessionEngineState
+  type AgentActivityTurn
 } from "@tutti-os/agent-activity-core";
 import { latestPlanTurnId } from "./planImplementationPresentation";
+
+type AgentSessionEngineSnapshot = Parameters<
+  typeof selectWorkspaceAgentConsumerSessions
+>[0];
 
 /**
  * Shared predicate for the synthesized plan-implementation wait. Durable
@@ -41,7 +44,7 @@ export function consumerAwaitingPlanImplementation(input: {
 }
 
 export function selectRootAgentSessionIdsAwaitingPlanImplementation(
-  state: AgentSessionEngineState
+  state: AgentSessionEngineSnapshot
 ): readonly string[] {
   const sessionIds: string[] = [];
   for (const consumer of selectWorkspaceAgentConsumerSessions(state)) {
@@ -66,7 +69,7 @@ export function selectRootAgentSessionIdsAwaitingPlanImplementation(
 }
 
 function sessionMessagesForPlanDetection(
-  state: AgentSessionEngineState,
+  state: AgentSessionEngineSnapshot,
   session: Pick<AgentActivitySession, "agentSessionId" | "providerSessionId">
 ) {
   for (const id of [session.agentSessionId, session.providerSessionId]) {


### PR DESCRIPTION
## Summary
- Project synthesized plan-implementation waits through the shared awaiting-user-action selector used by conversation rail, conversation list, and Message Center attention
- Remove the active-session-only `needsUserAction` overlay that hid the waiting icon after switching away from the plan session
- Document the cross-surface awaiting rule next to the existing plan-decision contract

## Test plan
- [x] `planImplementationAwaiting` unit coverage for match / fail-closed / engine selection
- [x] Conversation rail activity facts keep `needsUserAction` for a non-active plan session
- [x] Pre-push `pnpm check:changed -- --push-ready` for the branch
- [ ] Manual: Codex plan mode waits for implementation, switch to another session, confirm the yellow waiting icon remains on the plan session while Attention still works


Made with [Cursor](https://cursor.com)