### PR TITLE
feat(agent-gui): add performance telemetry monitor

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2268,6 +2268,26 @@ the removed lifecycle callbacks as no-op or forwarding adapters. Metadata
 actions that AgentGUI still reads directly remain on this surface until their
 Engine migration preserves all host observability and product integration.
 
+AgentGUI performance correlation is package-owned through
+`createAgentGUIPerformanceMonitor`. A host supplies the workspace Engine, the
+existing Session-event subscription, a clock, and a product-neutral event
+sink. The monitor joins AgentGUI's preserved `submittedAtUnixMs` and queue
+diagnostics to exact Session and Turn identities, then emits activation
+settlement, Prompt admission, first-token receipt, and Turn settlement facts.
+Hosts map those facts to their own analytics catalogs; they must not copy the
+Turn-binding, early-event buffering, duration-bucket, or token-classification
+logic.
+
+First-token time ends when the renderer receives the first non-empty Agent
+content `message_delta`; its bounded kind is text, reasoning, plan, or other.
+It deliberately does not use the producer timestamp, infer a latest Turn,
+count tool output, or inspect Prompt or response content. Early deltas are
+retained only until the Engine supplies the exact Turn binding, duplicate
+deltas emit once, and bounded caches prevent an abandoned Prompt from growing
+runtime memory without limit. Exact `durationMs` accompanies the stable
+buckets `lt_1s`, `1s_to_3s`, `3s_to_10s`, `10s_to_30s`, `30s_to_60s`, and
+`gte_60s`.
+
 `AgentHostApi` supplies host capabilities only: files, clipboard, project/account lookup, Agent Target setup/probes, diagnostics, and OS/Workbench helpers. It must not become a Session, Turn, timeline, or write source again.
 
 Terminal authentication is one such Host capability. AgentGUI receives an
@@ -2808,6 +2828,7 @@ unable to resurrect a deleted Session.
 | `services/tuttid/api/openapi/tuttid.v1.yaml`              | daemon HTTP contract                                |
 | `packages/agent/activity-core/src/engine/**`              | frontend workspace engine                           |
 | `packages/agent/gui/agentActivityRuntime.tsx`             | AgentGUI runtime interface                          |
+| `packages/agent/gui/agentGUIPerformanceMonitor.ts`        | product-neutral AgentGUI latency correlation        |
 | `packages/agent/gui/agent-gui/agentGuiNode/controller/**` | focused controller modules                          |
 | `packages/agent/gui/agent-gui/agentGuiNode/model/**`      | pure node projection/policy                         |
 | `packages/agent/gui/shared/agentConversation/**`          | reusable transcript projections/components          |

--- a/packages/agent/activity-core/src/engine/pendingIntents.selectors.test.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.selectors.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createInitialAgentSessionEngineState } from "./rootReducer.ts";
+import {
+  selectPendingActivations,
+  selectPendingSubmits
+} from "./pendingIntents.selectors.ts";
+
+test("pending-intent collection selectors reuse results for unchanged record maps", () => {
+  const initial = createInitialAgentSessionEngineState();
+
+  assert.strictEqual(
+    selectPendingActivations(initial),
+    selectPendingActivations(initial)
+  );
+  assert.strictEqual(
+    selectPendingSubmits(initial),
+    selectPendingSubmits(initial)
+  );
+
+  const copied = {
+    ...initial,
+    pendingIntents: {
+      ...initial.pendingIntents,
+      activationsByRequestId: {
+        ...initial.pendingIntents.activationsByRequestId
+      },
+      submitsByClientSubmitId: {
+        ...initial.pendingIntents.submitsByClientSubmitId
+      }
+    }
+  };
+  assert.notStrictEqual(
+    selectPendingActivations(initial),
+    selectPendingActivations(copied)
+  );
+  assert.notStrictEqual(
+    selectPendingSubmits(initial),
+    selectPendingSubmits(copied)
+  );
+});

--- a/packages/agent/activity-core/src/engine/pendingIntents.selectors.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.selectors.ts
@@ -25,6 +25,16 @@ export function selectPendingActivationByRequestId(
 
 const EMPTY_PENDING_SUBMITS: readonly PendingSubmitIntentRecord[] = [];
 
+export function selectPendingSubmits(
+  state: AgentSessionEngineStateBase
+): readonly PendingSubmitIntentRecord[] {
+  return Object.values(state.pendingIntents.submitsByClientSubmitId).sort(
+    (left, right) =>
+      left.requestedAtUnixMs - right.requestedAtUnixMs ||
+      left.clientSubmitId.localeCompare(right.clientSubmitId)
+  );
+}
+
 export interface SessionActivationPresentation {
   errorCode: string | null;
   errorMessage: string | null;

--- a/packages/agent/activity-core/src/engine/pendingIntents.selectors.ts
+++ b/packages/agent/activity-core/src/engine/pendingIntents.selectors.ts
@@ -5,14 +5,28 @@ import type {
 } from "./pendingIntents.types.ts";
 import { canonicalTurnKey } from "./sessionEntityKeys.ts";
 
+const pendingActivationsCache = new WeakMap<
+  Readonly<Record<string, PendingActivationIntentRecord>>,
+  readonly PendingActivationIntentRecord[]
+>();
+const pendingSubmitsCache = new WeakMap<
+  Readonly<Record<string, PendingSubmitIntentRecord>>,
+  readonly PendingSubmitIntentRecord[]
+>();
+
 export function selectPendingActivations(
   state: AgentSessionEngineStateBase
 ): readonly PendingActivationIntentRecord[] {
-  return Object.values(state.pendingIntents.activationsByRequestId).sort(
+  const records = state.pendingIntents.activationsByRequestId;
+  const cached = pendingActivationsCache.get(records);
+  if (cached) return cached;
+  const selected = Object.values(records).sort(
     (left, right) =>
       left.requestedAtUnixMs - right.requestedAtUnixMs ||
       left.requestId.localeCompare(right.requestId)
   );
+  pendingActivationsCache.set(records, selected);
+  return selected;
 }
 
 export function selectPendingActivationByRequestId(
@@ -28,11 +42,16 @@ const EMPTY_PENDING_SUBMITS: readonly PendingSubmitIntentRecord[] = [];
 export function selectPendingSubmits(
   state: AgentSessionEngineStateBase
 ): readonly PendingSubmitIntentRecord[] {
-  return Object.values(state.pendingIntents.submitsByClientSubmitId).sort(
+  const records = state.pendingIntents.submitsByClientSubmitId;
+  const cached = pendingSubmitsCache.get(records);
+  if (cached) return cached;
+  const selected = Object.values(records).sort(
     (left, right) =>
       left.requestedAtUnixMs - right.requestedAtUnixMs ||
       left.clientSubmitId.localeCompare(right.clientSubmitId)
   );
+  pendingSubmitsCache.set(records, selected);
+  return selected;
 }
 
 export interface SessionActivationPresentation {

--- a/packages/agent/activity-core/src/index.ts
+++ b/packages/agent/activity-core/src/index.ts
@@ -343,6 +343,7 @@ export {
   sessionActivationPresentationMapsEqual,
   selectLatestActivationForSession,
   selectLatestPendingSubmitForSession,
+  selectPendingSubmits,
   selectPendingSubmitsForSession,
   selectSessionActivationPresentations,
   selectSessionHasUnconfirmedSubmit,

--- a/packages/agent/gui/agentGUIPerformanceMonitor.spec.ts
+++ b/packages/agent/gui/agentGUIPerformanceMonitor.spec.ts
@@ -1,0 +1,318 @@
+import {
+  canonicalTurnKey,
+  type AgentSessionEngine,
+  type AgentSessionEngineState
+} from "@tutti-os/agent-activity-core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  agentGUIPerformanceDuration,
+  createAgentGUIPerformanceMonitor
+} from "./agentGUIPerformanceMonitor";
+
+describe("createAgentGUIPerformanceMonitor", () => {
+  it.each([
+    [0, "lt_1s"],
+    [999, "lt_1s"],
+    [1_000, "1s_to_3s"],
+    [3_000, "3s_to_10s"],
+    [10_000, "10s_to_30s"],
+    [30_000, "30s_to_60s"],
+    [60_000, "gte_60s"]
+  ] as const)("buckets %d ms as %s", (durationMs, durationBucket) => {
+    expect(agentGUIPerformanceDuration(durationMs)).toEqual({
+      durationBucket,
+      durationMs
+    });
+  });
+
+  it("reports an exact early queued first-token duration after exact Turn binding", () => {
+    let nowUnixMs = 1_000;
+    const harness = createEngineHarness(
+      engineState({
+        submits: {
+          "submit-1": pendingSubmit({ status: "requested", turnId: null })
+        }
+      })
+    );
+    const onEvent = vi.fn();
+    const monitor = createAgentGUIPerformanceMonitor({
+      engine: harness.engine,
+      nowUnixMs: () => nowUnixMs,
+      onEvent,
+      subscribeSessionEvents: harness.subscribeSessionEvents
+    });
+
+    nowUnixMs = 2_000;
+    harness.emitSessionEvent(messageDelta({ turnId: "stale-turn" }));
+    nowUnixMs = 61_500;
+    const firstToken = messageDelta({ kind: "reasoning", turnId: "turn-1" });
+    harness.emitSessionEvent(firstToken);
+    expect(onEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "prompt_first_token_received" })
+    );
+
+    harness.setState(
+      engineState({
+        submits: {
+          "submit-1": pendingSubmit({ status: "accepted", turnId: "turn-1" })
+        }
+      })
+    );
+    harness.emitSessionEvent(firstToken);
+
+    expect(onEvent).toHaveBeenCalledWith({
+      agentSessionId: "session-1",
+      durationBucket: "gte_60s",
+      durationMs: 60_500,
+      firstTokenKind: "reasoning",
+      observedAtUnixMs: 61_500,
+      operationId: "submit-1",
+      provider: "codex",
+      queued: true,
+      source: "submit",
+      startedAtUnixMs: 1_000,
+      turnId: "turn-1",
+      type: "prompt_first_token_received",
+      workspaceId: "workspace-1"
+    });
+    expect(
+      onEvent.mock.calls.filter(
+        ([event]) => event.type === "prompt_first_token_received"
+      )
+    ).toHaveLength(1);
+    expect(onEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ turnId: "stale-turn" })
+    );
+
+    monitor.dispose();
+  });
+
+  it("reports activation, initial-prompt admission, first token, and settled Turn", () => {
+    let nowUnixMs = 10_000;
+    const activation = pendingActivation({ status: "requested" });
+    const harness = createEngineHarness(
+      engineState({ activations: { "activation-1": activation } })
+    );
+    const onEvent = vi.fn();
+    const monitor = createAgentGUIPerformanceMonitor({
+      engine: harness.engine,
+      nowUnixMs: () => nowUnixMs,
+      onEvent,
+      subscribeSessionEvents: harness.subscribeSessionEvents
+    });
+
+    nowUnixMs = 11_200;
+    harness.setState(
+      engineState({
+        activations: {
+          "activation-1": pendingActivation({ status: "confirmed" })
+        }
+      })
+    );
+
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        durationBucket: "1s_to_3s",
+        durationMs: 1_200,
+        mode: "new",
+        outcome: "confirmed",
+        type: "session_activation_settled"
+      })
+    );
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        durationMs: 1_200,
+        operationId: "submit-new",
+        outcome: "accepted",
+        source: "activation",
+        type: "prompt_admission_settled"
+      })
+    );
+
+    nowUnixMs = 12_000;
+    harness.emitSessionEvent(
+      messageDelta({
+        content: { operation: "set", value: [{ text: "private token" }] },
+        kind: "plan",
+        turnId: "turn-new"
+      })
+    );
+    harness.emitSessionEvent(
+      messageDelta({ role: "user", turnId: "turn-new" })
+    );
+    harness.emitSessionEvent(messageDelta({ text: "  ", turnId: "turn-new" }));
+
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        durationMs: 2_000,
+        firstTokenKind: "plan",
+        operationId: "submit-new",
+        source: "activation",
+        turnId: "turn-new",
+        type: "prompt_first_token_received"
+      })
+    );
+    expect(JSON.stringify(onEvent.mock.calls)).not.toContain("private token");
+
+    harness.setState(
+      engineState({
+        activations: {
+          "activation-1": pendingActivation({ status: "confirmed" })
+        },
+        turns: {
+          [canonicalTurnKey("session-1", "turn-new")]: {
+            agentSessionId: "session-1",
+            origin: "user_prompt",
+            outcome: "completed",
+            phase: "settled",
+            settledAtUnixMs: 13_000,
+            startedAtUnixMs: 10_500,
+            turnId: "turn-new",
+            updatedAtUnixMs: 13_000
+          }
+        }
+      })
+    );
+
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        durationBucket: "1s_to_3s",
+        durationMs: 2_500,
+        outcome: "completed",
+        turnId: "turn-new",
+        type: "turn_settled"
+      })
+    );
+
+    monitor.dispose();
+  });
+});
+
+function createEngineHarness(initialState: AgentSessionEngineState) {
+  let state = initialState;
+  const engineListeners = new Set<() => void>();
+  const sessionListeners = new Set<(event: unknown) => void>();
+  const engine = {
+    getSnapshot: () => state,
+    identity: { origin: "local", workspaceId: "workspace-1" },
+    subscribe: (listener: () => void) => {
+      engineListeners.add(listener);
+      return () => engineListeners.delete(listener);
+    }
+  } as unknown as AgentSessionEngine;
+  return {
+    emitSessionEvent(event: unknown) {
+      for (const listener of sessionListeners) listener(event);
+    },
+    engine,
+    setState(nextState: AgentSessionEngineState) {
+      state = nextState;
+      for (const listener of engineListeners) listener();
+    },
+    subscribeSessionEvents(listener: (event: unknown) => void) {
+      sessionListeners.add(listener);
+      return () => sessionListeners.delete(listener);
+    }
+  };
+}
+
+function engineState(input: {
+  activations?: Record<string, ReturnType<typeof pendingActivation>>;
+  submits?: Record<string, ReturnType<typeof pendingSubmit>>;
+  turns?: Record<string, Record<string, unknown>>;
+}): AgentSessionEngineState {
+  return {
+    pendingIntents: {
+      activationsByRequestId: input.activations ?? {},
+      inactiveSessionIds: {},
+      submitsByClientSubmitId: input.submits ?? {}
+    },
+    sessionLifecycle: {
+      sessionsById: {
+        "session-1": {
+          agentSessionId: "session-1",
+          provider: "codex"
+        }
+      },
+      turnsById: input.turns ?? {}
+    }
+  } as unknown as AgentSessionEngineState;
+}
+
+function pendingSubmit(input: {
+  status: "accepted" | "requested";
+  turnId: string | null;
+}) {
+  return {
+    acceptedSessionVersion: null,
+    agentSessionId: "session-1",
+    clientSubmitId: "submit-1",
+    content: [{ text: "prompt", type: "text" as const }],
+    errorCode: null,
+    errorMessage: null,
+    expiresAtUnixMs: 121_000,
+    requestedAtUnixMs: 1_000,
+    status: input.status,
+    submitDiagnostics: {
+      queued: true,
+      source: "agent-gui",
+      submittedAtUnixMs: 1_000
+    },
+    turnId: input.turnId,
+    workspaceId: "workspace-1"
+  };
+}
+
+function pendingActivation(input: { status: "confirmed" | "requested" }) {
+  return {
+    agentSessionId: "session-1",
+    agentTargetId: "codex",
+    clientSubmitId: "submit-new",
+    content: [{ text: "prompt", type: "text" as const }],
+    cwd: "/workspace",
+    errorCode: null,
+    errorMessage: null,
+    expiresAtUnixMs: 130_000,
+    initialPromptRetracted: false,
+    initialTurnExpected: true,
+    mode: "new" as const,
+    requestId: "activation-1",
+    requestedAtUnixMs: 10_000,
+    status: input.status,
+    submitDiagnostics: {
+      queued: false,
+      source: "agent-gui",
+      submittedAtUnixMs: 10_000
+    },
+    title: null,
+    workspaceId: "workspace-1"
+  };
+}
+
+function messageDelta(input: {
+  content?: Record<string, unknown>;
+  kind?: string;
+  role?: string;
+  text?: string;
+  turnId: string;
+}) {
+  return {
+    agentSessionId: "session-1",
+    data: {
+      agentSessionId: "session-1",
+      content: input.content ?? {
+        operation: "append_text",
+        text: input.text ?? "token"
+      },
+      eventType: "message_delta",
+      kind: input.kind ?? "text",
+      messageId: `message-${input.turnId}`,
+      occurredAtUnixMs: 1,
+      role: input.role ?? "assistant",
+      turnId: input.turnId,
+      workspaceId: "workspace-1"
+    },
+    eventType: "message_delta",
+    workspaceId: "workspace-1"
+  };
+}

--- a/packages/agent/gui/agentGUIPerformanceMonitor.spec.ts
+++ b/packages/agent/gui/agentGUIPerformanceMonitor.spec.ts
@@ -87,6 +87,60 @@ describe("createAgentGUIPerformanceMonitor", () => {
     monitor.dispose();
   });
 
+  it("stops inspecting stream deltas after reporting the first token", () => {
+    const nowUnixMs = vi.fn(() => 2_000);
+    const harness = createEngineHarness(
+      engineState({
+        submits: {
+          "submit-1": pendingSubmit({ status: "accepted", turnId: "turn-1" })
+        }
+      })
+    );
+    const onEvent = vi.fn();
+    const monitor = createAgentGUIPerformanceMonitor({
+      engine: harness.engine,
+      nowUnixMs,
+      onEvent,
+      subscribeSessionEvents: harness.subscribeSessionEvents
+    });
+    const firstToken = messageDelta({ turnId: "turn-1" });
+
+    harness.emitSessionEvent(firstToken);
+    const callsAfterFirstToken = nowUnixMs.mock.calls.length;
+    for (let index = 0; index < 100; index += 1) {
+      harness.emitSessionEvent(firstToken);
+    }
+
+    expect(nowUnixMs).toHaveBeenCalledTimes(callsAfterFirstToken);
+    expect(
+      onEvent.mock.calls.filter(
+        ([event]) => event.type === "prompt_first_token_received"
+      )
+    ).toHaveLength(1);
+
+    monitor.dispose();
+  });
+
+  it("skips unchanged pending intents on unrelated engine notifications", () => {
+    const nowUnixMs = vi.fn(() => 1_000);
+    const harness = createEngineHarness(engineState({}));
+    const monitor = createAgentGUIPerformanceMonitor({
+      engine: harness.engine,
+      nowUnixMs,
+      onEvent: vi.fn(),
+      subscribeSessionEvents: harness.subscribeSessionEvents
+    });
+    const callsAfterInitialState = nowUnixMs.mock.calls.length;
+
+    for (let index = 0; index < 100; index += 1) {
+      harness.notifyEngine();
+    }
+
+    expect(nowUnixMs).toHaveBeenCalledTimes(callsAfterInitialState);
+
+    monitor.dispose();
+  });
+
   it("reports activation, initial-prompt admission, first token, and settled Turn", () => {
     let nowUnixMs = 10_000;
     const activation = pendingActivation({ status: "requested" });
@@ -205,6 +259,9 @@ function createEngineHarness(initialState: AgentSessionEngineState) {
       for (const listener of sessionListeners) listener(event);
     },
     engine,
+    notifyEngine() {
+      for (const listener of engineListeners) listener();
+    },
     setState(nextState: AgentSessionEngineState) {
       state = nextState;
       for (const listener of engineListeners) listener();

--- a/packages/agent/gui/agentGUIPerformanceMonitor.ts
+++ b/packages/agent/gui/agentGUIPerformanceMonitor.ts
@@ -107,6 +107,10 @@ export function createAgentGUIPerformanceMonitor(input: {
   const reportedActivationSettlements = new Set<string>();
   const reportedPromptSettlements = new Set<string>();
   const reportedTurnSettlements = new Set<string>();
+  let lastPendingActivations:
+    | ReturnType<typeof selectPendingActivations>
+    | undefined;
+  let lastPendingSubmits: ReturnType<typeof selectPendingSubmits> | undefined;
   let disposed = false;
 
   const emit = (event: AgentGUIPerformanceEvent): void => {
@@ -213,9 +217,27 @@ export function createAgentGUIPerformanceMonitor(input: {
   const reportState = (): void => {
     if (disposed) return;
     const state = input.engine.getSnapshot();
+    const selectedActivations = selectPendingActivations(state);
+    const selectedSubmits = selectPendingSubmits(state);
+    const activationsChanged = selectedActivations !== lastPendingActivations;
+    const submitsChanged = selectedSubmits !== lastPendingSubmits;
+    lastPendingActivations = selectedActivations;
+    lastPendingSubmits = selectedSubmits;
+    if (!activationsChanged && !submitsChanged && turnContexts.size === 0) {
+      return;
+    }
+    const pendingActivations = activationsChanged ? selectedActivations : [];
+    const pendingSubmits = submitsChanged ? selectedSubmits : [];
+    if (
+      pendingActivations.length === 0 &&
+      pendingSubmits.length === 0 &&
+      turnContexts.size === 0
+    ) {
+      return;
+    }
     const observedAtUnixMs = nowUnixMs();
 
-    for (const activation of selectPendingActivations(state)) {
+    for (const activation of pendingActivations) {
       if (observedActivationRecords.has(activation)) continue;
       observedActivationRecords.add(activation);
       const startedAtUnixMs = performanceStartedAt(
@@ -288,7 +310,7 @@ export function createAgentGUIPerformanceMonitor(input: {
       }
     }
 
-    for (const submit of selectPendingSubmits(state)) {
+    for (const submit of pendingSubmits) {
       if (observedSubmitRecords.has(submit)) continue;
       observedSubmitRecords.add(submit);
       const startedAtUnixMs = performanceStartedAt(
@@ -386,7 +408,7 @@ export function createAgentGUIPerformanceMonitor(input: {
   };
 
   const observeSessionEvent = (event: unknown): void => {
-    if (disposed) return;
+    if (disposed || attemptsByOperationId.size === 0) return;
     const observation = firstTokenObservation(event, workspaceId, nowUnixMs());
     if (!observation) return;
     const key = performanceTurnKey(

--- a/packages/agent/gui/agentGUIPerformanceMonitor.ts
+++ b/packages/agent/gui/agentGUIPerformanceMonitor.ts
@@ -1,0 +1,591 @@
+import {
+  selectEngineSession,
+  selectEngineTurn,
+  selectPendingActivations,
+  selectPendingSubmits,
+  type AgentSessionEngine,
+  type AgentSessionEngineState
+} from "@tutti-os/agent-activity-core";
+
+const MAX_RETAINED_PERFORMANCE_RECORDS = 512;
+
+export type AgentGUIPerformanceDurationBucket =
+  | "lt_1s"
+  | "1s_to_3s"
+  | "3s_to_10s"
+  | "10s_to_30s"
+  | "30s_to_60s"
+  | "gte_60s";
+
+export type AgentGUIFirstTokenKind = "other" | "plan" | "reasoning" | "text";
+
+interface AgentGUIPerformanceEventBase {
+  agentSessionId: string;
+  durationBucket: AgentGUIPerformanceDurationBucket;
+  durationMs: number;
+  observedAtUnixMs: number;
+  operationId: string;
+  provider: string;
+  startedAtUnixMs: number;
+  workspaceId: string;
+}
+
+export type AgentGUIPerformanceEvent =
+  | (AgentGUIPerformanceEventBase & {
+      errorCategory?: string;
+      hasInitialPrompt: boolean;
+      mode: "existing" | "new";
+      outcome: "confirmed" | "failed";
+      type: "session_activation_settled";
+    })
+  | (AgentGUIPerformanceEventBase & {
+      errorCategory?: string;
+      outcome: "accepted" | "failed";
+      queued: boolean;
+      source: "activation" | "submit";
+      turnId: string | null;
+      type: "prompt_admission_settled";
+    })
+  | (AgentGUIPerformanceEventBase & {
+      firstTokenKind: AgentGUIFirstTokenKind;
+      queued: boolean;
+      source: "activation" | "submit";
+      turnId: string;
+      type: "prompt_first_token_received";
+    })
+  | (AgentGUIPerformanceEventBase & {
+      errorCategory?: string;
+      outcome: "canceled" | "completed" | "failed" | "interrupted";
+      source: "activation" | "submit";
+      turnId: string;
+      type: "turn_settled";
+    });
+
+export interface AgentGUIPerformanceMonitor {
+  dispose(): void;
+}
+
+interface PromptAttempt {
+  agentSessionId: string;
+  allowUnboundTurnMatch: boolean;
+  operationId: string;
+  queued: boolean;
+  source: "activation" | "submit";
+  startedAtUnixMs: number;
+  turnId: string | null;
+}
+
+interface FirstTokenObservation {
+  agentSessionId: string;
+  firstTokenKind: AgentGUIFirstTokenKind;
+  observedAtUnixMs: number;
+  turnId: string;
+}
+
+interface TurnContext extends Omit<
+  PromptAttempt,
+  "allowUnboundTurnMatch" | "turnId"
+> {
+  turnId: string;
+}
+
+export function createAgentGUIPerformanceMonitor(input: {
+  engine: AgentSessionEngine;
+  nowUnixMs?: () => number;
+  onEvent: (event: AgentGUIPerformanceEvent) => void;
+  subscribeSessionEvents: (listener: (event: unknown) => void) => () => void;
+}): AgentGUIPerformanceMonitor {
+  const workspaceId = input.engine.identity.workspaceId.trim();
+  const nowUnixMs = input.nowUnixMs ?? Date.now;
+  const attemptsByOperationId = new Map<string, PromptAttempt>();
+  const attemptsByTurnKey = new Map<string, PromptAttempt>();
+  const observationsByTurnKey = new Map<string, FirstTokenObservation>();
+  const turnContexts = new Map<string, TurnContext>();
+  const observedActivationRecords = new WeakSet<object>();
+  const observedSubmitRecords = new WeakSet<object>();
+  const seenPromptAttempts = new Set<string>();
+  const reportedActivationSettlements = new Set<string>();
+  const reportedPromptSettlements = new Set<string>();
+  const reportedTurnSettlements = new Set<string>();
+  let disposed = false;
+
+  const emit = (event: AgentGUIPerformanceEvent): void => {
+    try {
+      input.onEvent(event);
+    } catch (error) {
+      // Performance reporting must never affect the Agent runtime.
+      console.error("[agent-gui] performance event sink failed", error);
+    }
+  };
+
+  const providerFor = (
+    state: AgentSessionEngineState,
+    agentSessionId: string
+  ): string =>
+    selectEngineSession(state, agentSessionId)?.provider?.trim() || "unknown";
+
+  const clearOrphanedObservations = (agentSessionId: string): void => {
+    const hasUnboundAttempt = [...attemptsByOperationId.values()].some(
+      (attempt) =>
+        attempt.agentSessionId === agentSessionId && attempt.turnId === null
+    );
+    if (hasUnboundAttempt) return;
+    for (const [key, observation] of observationsByTurnKey) {
+      if (observation.agentSessionId === agentSessionId) {
+        observationsByTurnKey.delete(key);
+      }
+    }
+  };
+
+  const removeAttempt = (attempt: PromptAttempt): void => {
+    attemptsByOperationId.delete(attempt.operationId);
+    if (attempt.turnId) {
+      attemptsByTurnKey.delete(
+        performanceTurnKey(attempt.agentSessionId, attempt.turnId)
+      );
+    }
+    clearOrphanedObservations(attempt.agentSessionId);
+  };
+
+  const reportFirstToken = (
+    attempt: PromptAttempt,
+    observation: FirstTokenObservation,
+    state: AgentSessionEngineState
+  ): void => {
+    const key = performanceTurnKey(
+      observation.agentSessionId,
+      observation.turnId
+    );
+    turnContexts.set(key, turnContext(attempt, observation.turnId));
+    trimMap(turnContexts);
+    removeAttempt(attempt);
+    observationsByTurnKey.delete(key);
+    const duration = agentGUIPerformanceDuration(
+      observation.observedAtUnixMs - attempt.startedAtUnixMs
+    );
+    emit({
+      agentSessionId: attempt.agentSessionId,
+      ...duration,
+      firstTokenKind: observation.firstTokenKind,
+      observedAtUnixMs: observation.observedAtUnixMs,
+      operationId: attempt.operationId,
+      provider: providerFor(state, attempt.agentSessionId),
+      queued: attempt.queued,
+      source: attempt.source,
+      startedAtUnixMs: attempt.startedAtUnixMs,
+      turnId: observation.turnId,
+      type: "prompt_first_token_received",
+      workspaceId
+    });
+  };
+
+  const bindTurn = (
+    attempt: PromptAttempt,
+    turnId: string,
+    state: AgentSessionEngineState
+  ): void => {
+    const normalizedTurnId = turnId.trim();
+    if (!normalizedTurnId) return;
+    attempt.turnId = normalizedTurnId;
+    const key = performanceTurnKey(attempt.agentSessionId, normalizedTurnId);
+    attemptsByTurnKey.set(key, attempt);
+    turnContexts.set(key, turnContext(attempt, normalizedTurnId));
+    trimMap(attemptsByTurnKey);
+    trimMap(turnContexts);
+    const observation = observationsByTurnKey.get(key);
+    if (observation) {
+      reportFirstToken(attempt, observation, state);
+    } else {
+      clearOrphanedObservations(attempt.agentSessionId);
+    }
+  };
+
+  const trackPromptAttempt = (attempt: PromptAttempt): PromptAttempt | null => {
+    if (seenPromptAttempts.has(attempt.operationId)) {
+      return attemptsByOperationId.get(attempt.operationId) ?? null;
+    }
+    remember(seenPromptAttempts, attempt.operationId);
+    attemptsByOperationId.set(attempt.operationId, attempt);
+    trimMap(attemptsByOperationId);
+    return attempt;
+  };
+
+  const reportState = (): void => {
+    if (disposed) return;
+    const state = input.engine.getSnapshot();
+    const observedAtUnixMs = nowUnixMs();
+
+    for (const activation of selectPendingActivations(state)) {
+      if (observedActivationRecords.has(activation)) continue;
+      observedActivationRecords.add(activation);
+      const startedAtUnixMs = performanceStartedAt(
+        activation.submitDiagnostics?.submittedAtUnixMs,
+        activation.requestedAtUnixMs
+      );
+      const hasInitialPrompt = (activation.content?.length ?? 0) > 0;
+      const operationId =
+        activation.mode === "new" && activation.clientSubmitId
+          ? activation.clientSubmitId
+          : activation.requestId;
+      const attempt = hasInitialPrompt
+        ? trackPromptAttempt({
+            agentSessionId: activation.agentSessionId,
+            allowUnboundTurnMatch: activation.mode === "new",
+            operationId,
+            queued: activation.submitDiagnostics?.queued === true,
+            source: "activation",
+            startedAtUnixMs,
+            turnId: null
+          })
+        : null;
+      if (activation.status !== "confirmed" && activation.status !== "failed") {
+        continue;
+      }
+      const duration = agentGUIPerformanceDuration(
+        observedAtUnixMs - startedAtUnixMs
+      );
+      if (!reportedActivationSettlements.has(activation.requestId)) {
+        remember(reportedActivationSettlements, activation.requestId);
+        emit({
+          agentSessionId: activation.agentSessionId,
+          ...duration,
+          ...(activation.status === "failed"
+            ? { errorCategory: activation.errorCode ?? "runtime" }
+            : {}),
+          hasInitialPrompt,
+          mode: activation.mode,
+          observedAtUnixMs,
+          operationId: activation.requestId,
+          outcome: activation.status,
+          provider: providerFor(state, activation.agentSessionId),
+          startedAtUnixMs,
+          type: "session_activation_settled",
+          workspaceId
+        });
+      }
+      if (hasInitialPrompt && !reportedPromptSettlements.has(operationId)) {
+        remember(reportedPromptSettlements, operationId);
+        emit({
+          agentSessionId: activation.agentSessionId,
+          ...duration,
+          ...(activation.status === "failed"
+            ? { errorCategory: activation.errorCode ?? "runtime" }
+            : {}),
+          observedAtUnixMs,
+          operationId,
+          outcome: activation.status === "confirmed" ? "accepted" : "failed",
+          provider: providerFor(state, activation.agentSessionId),
+          queued: activation.submitDiagnostics?.queued === true,
+          source: "activation",
+          startedAtUnixMs,
+          turnId: null,
+          type: "prompt_admission_settled",
+          workspaceId
+        });
+      }
+      if (activation.status === "failed" && attempt) {
+        removeAttempt(attempt);
+      }
+    }
+
+    for (const submit of selectPendingSubmits(state)) {
+      if (observedSubmitRecords.has(submit)) continue;
+      observedSubmitRecords.add(submit);
+      const startedAtUnixMs = performanceStartedAt(
+        submit.submitDiagnostics?.submittedAtUnixMs,
+        submit.requestedAtUnixMs
+      );
+      const attempt = trackPromptAttempt({
+        agentSessionId: submit.agentSessionId,
+        allowUnboundTurnMatch: false,
+        operationId: submit.clientSubmitId,
+        queued: submit.submitDiagnostics?.queued === true,
+        source: "submit",
+        startedAtUnixMs,
+        turnId: null
+      });
+      if (attempt && submit.turnId && attempt.turnId !== submit.turnId) {
+        bindTurn(attempt, submit.turnId, state);
+      }
+      if (
+        submit.status !== "accepted" &&
+        submit.status !== "confirmed" &&
+        submit.status !== "failed"
+      ) {
+        continue;
+      }
+      if (!reportedPromptSettlements.has(submit.clientSubmitId)) {
+        remember(reportedPromptSettlements, submit.clientSubmitId);
+        const duration = agentGUIPerformanceDuration(
+          observedAtUnixMs - startedAtUnixMs
+        );
+        emit({
+          agentSessionId: submit.agentSessionId,
+          ...duration,
+          ...(submit.status === "failed"
+            ? { errorCategory: submit.errorCode ?? "runtime" }
+            : {}),
+          observedAtUnixMs,
+          operationId: submit.clientSubmitId,
+          outcome: submit.status === "failed" ? "failed" : "accepted",
+          provider: providerFor(state, submit.agentSessionId),
+          queued: submit.submitDiagnostics?.queued === true,
+          source: "submit",
+          startedAtUnixMs,
+          turnId: submit.turnId,
+          type: "prompt_admission_settled",
+          workspaceId
+        });
+      }
+      if (submit.status === "failed" && attempt) {
+        removeAttempt(attempt);
+      }
+    }
+
+    for (const context of turnContexts.values()) {
+      const turn = selectEngineTurn(
+        state,
+        context.agentSessionId,
+        context.turnId
+      );
+      if (!turn) continue;
+      const key = performanceTurnKey(turn.agentSessionId, turn.turnId);
+      if (
+        turn.phase !== "settled" ||
+        !turn.outcome ||
+        reportedTurnSettlements.has(key)
+      ) {
+        continue;
+      }
+      remember(reportedTurnSettlements, key);
+      const settledAtUnixMs = turn.settledAtUnixMs ?? turn.updatedAtUnixMs;
+      const duration = agentGUIPerformanceDuration(
+        settledAtUnixMs - turn.startedAtUnixMs
+      );
+      emit({
+        agentSessionId: turn.agentSessionId,
+        ...duration,
+        ...(turn.outcome === "failed"
+          ? { errorCategory: turn.error?.code ?? "runtime" }
+          : {}),
+        observedAtUnixMs,
+        operationId: context.operationId,
+        outcome: turn.outcome,
+        provider: providerFor(state, turn.agentSessionId),
+        source: context.source,
+        startedAtUnixMs: turn.startedAtUnixMs,
+        turnId: turn.turnId,
+        type: "turn_settled",
+        workspaceId
+      });
+      const attempt = attemptsByTurnKey.get(key);
+      if (attempt) removeAttempt(attempt);
+      observationsByTurnKey.delete(key);
+      turnContexts.delete(key);
+    }
+  };
+
+  const observeSessionEvent = (event: unknown): void => {
+    if (disposed) return;
+    const observation = firstTokenObservation(event, workspaceId, nowUnixMs());
+    if (!observation) return;
+    const key = performanceTurnKey(
+      observation.agentSessionId,
+      observation.turnId
+    );
+    const state = input.engine.getSnapshot();
+    const exactAttempt = attemptsByTurnKey.get(key);
+    if (exactAttempt) {
+      reportFirstToken(exactAttempt, observation, state);
+      return;
+    }
+    const unboundActivationAttempts = [
+      ...attemptsByOperationId.values()
+    ].filter(
+      (attempt) =>
+        attempt.allowUnboundTurnMatch &&
+        attempt.agentSessionId === observation.agentSessionId &&
+        attempt.turnId === null
+    );
+    if (unboundActivationAttempts.length === 1) {
+      reportFirstToken(unboundActivationAttempts[0]!, observation, state);
+      return;
+    }
+    const hasUnboundSubmit = [...attemptsByOperationId.values()].some(
+      (attempt) =>
+        !attempt.allowUnboundTurnMatch &&
+        attempt.agentSessionId === observation.agentSessionId &&
+        attempt.turnId === null
+    );
+    if (hasUnboundSubmit && !observationsByTurnKey.has(key)) {
+      observationsByTurnKey.set(key, observation);
+      trimMap(observationsByTurnKey);
+    }
+  };
+
+  reportState();
+  const releaseEngine = input.engine.subscribe(reportState);
+  const releaseSessionEvents =
+    input.subscribeSessionEvents(observeSessionEvent);
+
+  return {
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      releaseEngine();
+      releaseSessionEvents();
+      attemptsByOperationId.clear();
+      attemptsByTurnKey.clear();
+      observationsByTurnKey.clear();
+      turnContexts.clear();
+      seenPromptAttempts.clear();
+      reportedActivationSettlements.clear();
+      reportedPromptSettlements.clear();
+      reportedTurnSettlements.clear();
+    }
+  };
+}
+
+export function agentGUIPerformanceDuration(durationMs: number): {
+  durationBucket: AgentGUIPerformanceDurationBucket;
+  durationMs: number;
+} {
+  const normalizedDurationMs = Number.isFinite(durationMs)
+    ? Math.max(0, durationMs)
+    : 0;
+  const durationBucket =
+    normalizedDurationMs < 1_000
+      ? "lt_1s"
+      : normalizedDurationMs < 3_000
+        ? "1s_to_3s"
+        : normalizedDurationMs < 10_000
+          ? "3s_to_10s"
+          : normalizedDurationMs < 30_000
+            ? "10s_to_30s"
+            : normalizedDurationMs < 60_000
+              ? "30s_to_60s"
+              : "gte_60s";
+  return { durationBucket, durationMs: normalizedDurationMs };
+}
+
+function firstTokenObservation(
+  event: unknown,
+  workspaceId: string,
+  observedAtUnixMs: number
+): FirstTokenObservation | null {
+  const record = asRecord(event);
+  if (stringField(record, "eventType") !== "message_delta") return null;
+  const data = asRecord(record?.data);
+  const eventWorkspaceId =
+    stringField(record, "workspaceId") ?? stringField(data, "workspaceId");
+  if (eventWorkspaceId !== workspaceId) return null;
+  const role = stringField(data, "role")?.toLowerCase();
+  if (role !== "assistant" && role !== "agent") return null;
+  const content = asRecord(data?.content);
+  if (!content || !deltaContentHasText(content)) return null;
+  const agentSessionId =
+    stringField(record, "agentSessionId") ??
+    stringField(data, "agentSessionId");
+  const turnId = stringField(data, "turnId") ?? stringField(record, "turnId");
+  if (!agentSessionId || !turnId) return null;
+  return {
+    agentSessionId,
+    firstTokenKind: normalizeFirstTokenKind(stringField(data, "kind")),
+    observedAtUnixMs,
+    turnId
+  };
+}
+
+function deltaContentHasText(content: Record<string, unknown>): boolean {
+  if (content.operation === "append_text") {
+    return typeof content.text === "string" && content.text.trim().length > 0;
+  }
+  if (content.operation !== "set") return false;
+  const pending: unknown[] = [content.value];
+  let inspected = 0;
+  while (pending.length > 0 && inspected < 100) {
+    const value = pending.pop();
+    inspected += 1;
+    if (typeof value === "string" && value.trim()) return true;
+    if (Array.isArray(value)) {
+      pending.push(...value);
+      continue;
+    }
+    const record = asRecord(value);
+    if (!record) continue;
+    for (const key of ["text", "content", "value", "parts", "blocks"]) {
+      if (Object.hasOwn(record, key)) pending.push(record[key]);
+    }
+  }
+  return false;
+}
+
+function normalizeFirstTokenKind(
+  kind: string | undefined
+): AgentGUIFirstTokenKind {
+  const normalized = kind?.trim().toLowerCase().replaceAll("-", "_");
+  if (
+    normalized === "text" ||
+    normalized === "reasoning" ||
+    normalized === "plan"
+  ) {
+    return normalized;
+  }
+  return "other";
+}
+
+function performanceStartedAt(
+  submittedAtUnixMs: number | undefined,
+  requestedAtUnixMs: number
+): number {
+  return typeof submittedAtUnixMs === "number" &&
+    Number.isFinite(submittedAtUnixMs)
+    ? submittedAtUnixMs
+    : requestedAtUnixMs;
+}
+
+function turnContext(attempt: PromptAttempt, turnId: string): TurnContext {
+  return {
+    agentSessionId: attempt.agentSessionId,
+    operationId: attempt.operationId,
+    queued: attempt.queued,
+    source: attempt.source,
+    startedAtUnixMs: attempt.startedAtUnixMs,
+    turnId
+  };
+}
+
+function performanceTurnKey(agentSessionId: string, turnId: string): string {
+  return `${agentSessionId}\u0000${turnId}`;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function stringField(
+  value: Record<string, unknown> | null,
+  key: string
+): string | undefined {
+  const field = value?.[key];
+  return typeof field === "string" && field.trim() ? field.trim() : undefined;
+}
+
+function remember(set: Set<string>, key: string): void {
+  set.add(key);
+  while (set.size > MAX_RETAINED_PERFORMANCE_RECORDS) {
+    const oldest = set.values().next().value;
+    if (typeof oldest !== "string") break;
+    set.delete(oldest);
+  }
+}
+
+function trimMap<TKey, TValue>(map: Map<TKey, TValue>): void {
+  while (map.size > MAX_RETAINED_PERFORMANCE_RECORDS) {
+    const oldest = map.keys().next().value;
+    if (oldest === undefined) break;
+    map.delete(oldest);
+  }
+}

--- a/packages/agent/gui/index.ts
+++ b/packages/agent/gui/index.ts
@@ -205,6 +205,16 @@ export type {
   AgentActivityRuntimeUpdateSessionSettingsInput,
   AgentActivityRuntimeUpdateSessionSettingsResult
 } from "./agentActivityRuntime";
+export {
+  agentGUIPerformanceDuration,
+  createAgentGUIPerformanceMonitor
+} from "./agentGUIPerformanceMonitor";
+export type {
+  AgentGUIFirstTokenKind,
+  AgentGUIPerformanceDurationBucket,
+  AgentGUIPerformanceEvent,
+  AgentGUIPerformanceMonitor
+} from "./agentGUIPerformanceMonitor";
 export type {
   AgentHostApi,
   AgentHostAgentTargetAuthenticatedAccount,


### PR DESCRIPTION
## Summary

- Add a package-owned AgentGUI performance monitor that correlates activation, prompt admission, first-token, and turn settlement timing.
- Emit neutral, content-free performance events with exact duration and bounded duration buckets for host products to map into their own analytics catalogs.
- Expose the pending-submit selector required for exact prompt correlation, with bounded caches and stale-event suppression.
- Memoize pending-intent collection selectors on immutable record maps, skip unchanged Engine polling, and stop inspecting stream deltas after first-token correlation completes.

## Tests

- `corepack pnpm check:changed`
- `corepack pnpm check:changed -- --push-ready` (14 lanes)
- Red/green coverage verifies that 100 repeated post-first-token deltas and 100 unchanged Engine notifications do not re-enter the timing hot path.
- Packed and linked the changed AgentGUI/activity-core packages into TSH Desktop through the repository-owned local package workflow.

## Notes

- No prompt, response, or tool content is reported.
- Host products remain responsible for product-specific event names and dimensions.
- The TSH consumer PR will remain draft until this change is released and its exact Tutti dependency cohort is upgraded.