### PR TITLE
fix(analytics): populate DataFinder preset metadata

### DIFF
--- a/docs/architecture/analytics-tracking.md
+++ b/docs/architecture/analytics-tracking.md
@@ -60,12 +60,23 @@ Common params are split by ownership. tuttid injects its params on every event
 before forwarding to Tea. The renderer supplies only the params it uniquely
 knows.
 
+Runtime and application metadata that DataFinder defines as preset properties
+is sent in the SDK header as well as retained in the legacy custom common
+params where one already exists. This keeps existing dashboards compatible
+while allowing DataFinder's built-in dimensions to receive `os_name`,
+`os_version`, `app_version`, and `cpu_abi`. Event UUIDs follow the same
+transition: `event_id` remains in event params and is also assigned to the SDK
+event's preset ID field.
+
 | Param               | Owner    | Notes                                               |
 | ------------------- | -------- | --------------------------------------------------- |
 | `device_id`         | tuttid   | Persisted UUID in state dir; stable across restarts |
 | `session_id`        | tuttid   | UUID generated once at daemon startup               |
 | `app_version`       | tuttid   | Resolved from generated defaults or env override    |
 | `os`                | tuttid   | Resolved at startup                                 |
+| `os_name`           | tuttid   | Preset SDK header; currently the Go runtime OS key  |
+| `os_version`        | tuttid   | Preset SDK header; best-effort product OS version   |
+| `cpu_abi`           | tuttid   | Preset SDK header; Go runtime architecture key      |
 | `event_id`          | tuttid   | Generated UUID when the event does not supply one   |
 | `authority`         | tuttid   | `"client"` for Tutti Desktop events                 |
 | `business_app_id`   | tuttid   | Tutti account/commerce application ID               |

--- a/packages/analytics/reporter-go/debug_reporter.go
+++ b/packages/analytics/reporter-go/debug_reporter.go
@@ -25,7 +25,8 @@ func (r *DebugReporter) Track(ctx context.Context, events ...Event) {
 	}
 
 	common, _ := r.common.snapshot()
-	normalized := normalizeEvents(events, common)
+	header := r.common.teaHeader()
+	normalized := normalizeEvents(events, common, header)
 	if len(normalized) == 0 {
 		return
 	}
@@ -36,6 +37,9 @@ func (r *DebugReporter) Track(ctx context.Context, events ...Event) {
 			params = map[string]any{}
 		}
 		for key, value := range common {
+			params[key] = value
+		}
+		for key, value := range header.presetParams() {
 			params[key] = value
 		}
 		debugEvents = append(debugEvents, DebugEvent{

--- a/packages/analytics/reporter-go/go.mod
+++ b/packages/analytics/reporter-go/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/gofrs/flock v0.13.0
 	github.com/google/uuid v1.6.0
 	github.com/volcengine/datarangers-sdk-go v1.1.8
+	golang.org/x/sys v0.41.0
 )
 
 require (
@@ -34,7 +35,6 @@ require (
 	go.uber.org/zap v1.16.0 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/net v0.50.0 // indirect
-	golang.org/x/sys v0.41.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/packages/analytics/reporter-go/go.sum
+++ b/packages/analytics/reporter-go/go.sum
@@ -388,6 +388,7 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
+golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/packages/analytics/reporter-go/os_release.go
+++ b/packages/analytics/reporter-go/os_release.go
@@ -1,0 +1,23 @@
+package reporter
+
+import (
+	"strconv"
+	"strings"
+)
+
+func osReleaseVersion(content string) string {
+	for line := range strings.SplitSeq(content, "\n") {
+		key, value, found := strings.Cut(line, "=")
+		if !found || strings.TrimSpace(key) != "VERSION_ID" {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		if len(value) >= 2 && value[0] == '\'' && value[len(value)-1] == '\'' {
+			value = value[1 : len(value)-1]
+		} else if unquoted, err := strconv.Unquote(value); err == nil {
+			value = unquoted
+		}
+		return strings.TrimSpace(value)
+	}
+	return ""
+}

--- a/packages/analytics/reporter-go/os_version_darwin.go
+++ b/packages/analytics/reporter-go/os_version_darwin.go
@@ -1,0 +1,17 @@
+//go:build darwin
+
+package reporter
+
+import (
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+func currentOSVersion() string {
+	version, err := unix.Sysctl("kern.osproductversion")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(version)
+}

--- a/packages/analytics/reporter-go/os_version_linux.go
+++ b/packages/analytics/reporter-go/os_version_linux.go
@@ -1,0 +1,18 @@
+//go:build linux
+
+package reporter
+
+import "os"
+
+func currentOSVersion() string {
+	for _, path := range []string{"/etc/os-release", "/usr/lib/os-release"} {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		if version := osReleaseVersion(string(content)); version != "" {
+			return version
+		}
+	}
+	return ""
+}

--- a/packages/analytics/reporter-go/os_version_linux_test.go
+++ b/packages/analytics/reporter-go/os_version_linux_test.go
@@ -1,0 +1,15 @@
+package reporter
+
+import "testing"
+
+func TestOSReleaseVersion(t *testing.T) {
+	for _, content := range []string{
+		"NAME=Ubuntu\nVERSION_ID=\"24.04\"\n",
+		"NAME=Ubuntu\nVERSION_ID='24.04'\n",
+		"NAME=Ubuntu\nVERSION_ID=24.04\n",
+	} {
+		if got := osReleaseVersion(content); got != "24.04" {
+			t.Fatalf("osReleaseVersion(%q) = %q, want 24.04", content, got)
+		}
+	}
+}

--- a/packages/analytics/reporter-go/os_version_other.go
+++ b/packages/analytics/reporter-go/os_version_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin && !linux && !windows
+
+package reporter
+
+func currentOSVersion() string {
+	return ""
+}

--- a/packages/analytics/reporter-go/os_version_windows.go
+++ b/packages/analytics/reporter-go/os_version_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package reporter
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/windows"
+)
+
+func currentOSVersion() string {
+	version := windows.RtlGetVersion()
+	if version == nil {
+		return ""
+	}
+	return fmt.Sprintf("%d.%d.%d", version.MajorVersion, version.MinorVersion, version.BuildNumber)
+}

--- a/packages/analytics/reporter-go/reporter.go
+++ b/packages/analytics/reporter-go/reporter.go
@@ -184,11 +184,23 @@ type reporterCommon struct {
 	sessionID              string
 	appVersion             string
 	osName                 string
+	osVersion              string
+	cpuABI                 string
 	additional             map[string]any
 	dynamicContextProvider func() DynamicContext
 }
 
+type runtimeInfo struct {
+	osName    string
+	osVersion string
+	cpuABI    string
+}
+
 func newReporterCommon(config Config) (reporterCommon, error) {
+	return newReporterCommonWithRuntimeInfo(config, currentRuntimeInfo())
+}
+
+func newReporterCommonWithRuntimeInfo(config Config, runtimeInfo runtimeInfo) (reporterCommon, error) {
 	deviceID, err := resolveDeviceID(config)
 	if err != nil {
 		return reporterCommon{}, err
@@ -197,10 +209,29 @@ func newReporterCommon(config Config) (reporterCommon, error) {
 		deviceID:               deviceID,
 		sessionID:              uuid.NewString(),
 		appVersion:             config.Analytics.AppVersion,
-		osName:                 runtime.GOOS,
+		osName:                 runtimeInfo.osName,
+		osVersion:              runtimeInfo.osVersion,
+		cpuABI:                 runtimeInfo.cpuABI,
 		additional:             copyParams(config.CommonParams),
 		dynamicContextProvider: config.DynamicContextProvider,
 	}, nil
+}
+
+func currentRuntimeInfo() runtimeInfo {
+	return runtimeInfo{
+		osName:    runtime.GOOS,
+		osVersion: currentOSVersion(),
+		cpuABI:    runtime.GOARCH,
+	}
+}
+
+func (c reporterCommon) teaHeader() teaSDKHeader {
+	return teaSDKHeader{
+		AppVersion: c.appVersion,
+		OSName:     c.osName,
+		OSVersion:  c.osVersion,
+		CPUABI:     c.cpuABI,
+	}
 }
 
 func (c reporterCommon) snapshot() (map[string]any, string) {
@@ -237,7 +268,7 @@ func (c reporterCommon) dynamicContext() (dynamic DynamicContext) {
 	return dynamic
 }
 
-func normalizeEvents(events []Event, common map[string]any) []teaSDKEvent {
+func normalizeEvents(events []Event, common map[string]any, header teaSDKHeader) []teaSDKEvent {
 	normalized := make([]teaSDKEvent, 0, len(events))
 	for _, event := range events {
 		if event.Name == "" {
@@ -254,12 +285,19 @@ func normalizeEvents(events []Event, common map[string]any) []teaSDKEvent {
 		for key := range common {
 			delete(params, key)
 		}
-		if _, exists := params["event_id"]; !exists {
-			params["event_id"] = uuid.NewString()
+		for _, key := range []string{"app_version", "os_name", "os_version", "cpu_abi"} {
+			delete(params, key)
 		}
+		eventID, _ := params["event_id"].(string)
+		eventID = strings.TrimSpace(eventID)
+		if eventID == "" {
+			eventID = uuid.NewString()
+		}
+		params["event_id"] = eventID
 		normalized = append(normalized, teaSDKEvent{
 			Name:     event.Name,
 			ClientTS: clientTS,
+			EventID:  eventID,
 			Params:   params,
 		})
 	}

--- a/packages/analytics/reporter-go/reporter_test.go
+++ b/packages/analytics/reporter-go/reporter_test.go
@@ -29,6 +29,7 @@ type fakeTeaSend struct {
 	uuid   string
 	events []teaSDKEvent
 	common map[string]any
+	header teaSDKHeader
 }
 
 func (f *fakeTeaSDK) Init(config teaSDKConfig) error {
@@ -36,12 +37,19 @@ func (f *fakeTeaSDK) Init(config teaSDKConfig) error {
 	return nil
 }
 
-func (f *fakeTeaSDK) Send(appID int64, uuid string, events []teaSDKEvent, common map[string]any) error {
+func (f *fakeTeaSDK) Send(
+	appID int64,
+	uuid string,
+	events []teaSDKEvent,
+	common map[string]any,
+	header teaSDKHeader,
+) error {
 	f.sends = append(f.sends, fakeTeaSend{
 		appID:  appID,
 		uuid:   uuid,
 		events: events,
 		common: common,
+		header: header,
 	})
 	return nil
 }
@@ -168,6 +176,12 @@ func TestTeaReporterPersistsIdentityAndSendsSanitizedEvents(t *testing.T) {
 	if send.events[0].ClientTS < before || send.events[0].ClientTS > after {
 		t.Fatalf("client timestamp = %d, want between %d and %d", send.events[0].ClientTS, before, after)
 	}
+	if send.events[0].EventID == "" || send.events[0].EventID != send.events[0].Params["event_id"] {
+		t.Fatalf("event ID preset=%q params=%v, want matching compatibility values", send.events[0].EventID, send.events[0].Params["event_id"])
+	}
+	if send.header.AppVersion != "0.0.0" || send.header.OSName == "" || send.header.CPUABI == "" {
+		t.Fatalf("preset header = %#v, want app and runtime metadata", send.header)
+	}
 	for _, key := range []string{"device_id", "session_id", "app_version", "os", "product_variant"} {
 		if _, exists := send.events[0].Params[key]; exists {
 			t.Fatalf("event params contains common key %q", key)
@@ -200,6 +214,112 @@ func TestTeaReporterPersistsIdentityAndSendsSanitizedEvents(t *testing.T) {
 	}
 	if !sdk.closed {
 		t.Fatal("Close did not delegate to SDK")
+	}
+}
+
+func TestReporterCommonBuildsPresetHeaderFromRuntimeInfo(t *testing.T) {
+	common, err := newReporterCommonWithRuntimeInfo(Config{
+		Analytics: AnalyticsConfig{AppVersion: "1.2.3"},
+		DeviceID:  "host-device",
+	}, runtimeInfo{
+		osName:    "darwin",
+		osVersion: "15.6",
+		cpuABI:    "arm64",
+	})
+	if err != nil {
+		t.Fatalf("newReporterCommonWithRuntimeInfo() error = %v", err)
+	}
+
+	got := common.teaHeader()
+	want := (teaSDKHeader{
+		AppVersion: "1.2.3",
+		OSName:     "darwin",
+		OSVersion:  "15.6",
+		CPUABI:     "arm64",
+	})
+	if got != want {
+		t.Fatalf("preset header = %#v, want %#v", got, want)
+	}
+}
+
+func TestDebugReporterPublishesPresetHeaderFields(t *testing.T) {
+	publisher := &fakeDebugPublisher{}
+	common, err := newReporterCommonWithRuntimeInfo(Config{
+		Analytics: AnalyticsConfig{AppVersion: "1.2.3"},
+		DeviceID:  "host-device",
+	}, runtimeInfo{
+		osName:    "darwin",
+		osVersion: "15.6",
+		cpuABI:    "arm64",
+	})
+	if err != nil {
+		t.Fatalf("newReporterCommonWithRuntimeInfo() error = %v", err)
+	}
+	reporter := &DebugReporter{common: common, debug: publisher}
+
+	reporter.Track(context.Background(), Event{
+		Name: "workspace.opened",
+		Params: map[string]any{
+			"os_name":    "spoofed",
+			"os_version": "spoofed",
+			"cpu_abi":    "spoofed",
+		},
+	})
+
+	if len(publisher.events) != 1 {
+		t.Fatalf("debug events = %d, want 1", len(publisher.events))
+	}
+	for key, want := range map[string]string{
+		"app_version": "1.2.3",
+		"os_name":     "darwin",
+		"os_version":  "15.6",
+		"cpu_abi":     "arm64",
+	} {
+		if got := publisher.events[0].Params[key]; got != want {
+			t.Fatalf("debug params[%q] = %v, want %q", key, got, want)
+		}
+	}
+}
+
+func TestNormalizeEventsRepairsInvalidEventIDs(t *testing.T) {
+	for _, input := range []any{" ", 42, nil} {
+		events := normalizeEvents([]Event{{
+			Name:   "workspace.opened",
+			Params: map[string]any{"event_id": input},
+		}}, nil, teaSDKHeader{})
+		if len(events) != 1 {
+			t.Fatalf("normalizeEvents(event_id=%v) returned %d events, want 1", input, len(events))
+		}
+		if events[0].EventID == "" || events[0].Params["event_id"] != events[0].EventID {
+			t.Fatalf("normalized event_id=%v preset=%q, want matching generated IDs", events[0].Params["event_id"], events[0].EventID)
+		}
+	}
+}
+
+func TestNormalizeEventsAlwaysProtectsPresetHeaderFields(t *testing.T) {
+	events := normalizeEvents([]Event{{
+		Name: "workspace.opened",
+		Params: map[string]any{
+			"app_version": "spoofed",
+			"os_name":     "spoofed",
+			"os_version":  "spoofed",
+			"cpu_abi":     "spoofed",
+		},
+	}}, nil, teaSDKHeader{})
+	if len(events) != 1 {
+		t.Fatalf("normalizeEvents() returned %d events, want 1", len(events))
+	}
+	for _, key := range []string{"app_version", "os_name", "os_version", "cpu_abi"} {
+		if _, exists := events[0].Params[key]; exists {
+			t.Fatalf("normalized event contains protected preset key %q", key)
+		}
+	}
+}
+
+func TestCurrentRuntimeInfoIncludesStablePlatformKeys(t *testing.T) {
+	got := currentRuntimeInfo()
+	if got.osName == "" || got.cpuABI == "" {
+		t.Fatalf("runtime info = %#v, want OS and CPU architecture", got)
 	}
 }
 

--- a/packages/analytics/reporter-go/tea_reporter.go
+++ b/packages/analytics/reporter-go/tea_reporter.go
@@ -54,20 +54,26 @@ func (r *TeaReporter) Track(ctx context.Context, events ...Event) {
 	}
 
 	common, userUniqueID := r.common.snapshot()
-	sendEvents := normalizeEvents(events, common)
+	header := r.common.teaHeader()
+	sendEvents := normalizeEvents(events, common, header)
 	if len(sendEvents) == 0 {
 		return
 	}
 
-	r.publishDebugEvents(ctx, sendEvents, common)
-	_ = r.sdk.Send(r.appID, userUniqueID, sendEvents, common)
+	r.publishDebugEvents(ctx, sendEvents, common, header)
+	_ = r.sdk.Send(r.appID, userUniqueID, sendEvents, common, header)
 }
 
 func (r *TeaReporter) Close() error {
 	return r.sdk.Close()
 }
 
-func (r *TeaReporter) publishDebugEvents(ctx context.Context, events []teaSDKEvent, common map[string]any) {
+func (r *TeaReporter) publishDebugEvents(
+	ctx context.Context,
+	events []teaSDKEvent,
+	common map[string]any,
+	header teaSDKHeader,
+) {
 	if r.debug == nil || len(events) == 0 {
 		return
 	}
@@ -78,6 +84,9 @@ func (r *TeaReporter) publishDebugEvents(ctx context.Context, events []teaSDKEve
 			params = map[string]any{}
 		}
 		for key, value := range common {
+			params[key] = value
+		}
+		for key, value := range header.presetParams() {
 			params[key] = value
 		}
 		debugEvents = append(debugEvents, DebugEvent{

--- a/packages/analytics/reporter-go/tea_sdk_adapter.go
+++ b/packages/analytics/reporter-go/tea_sdk_adapter.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	sdk "github.com/volcengine/datarangers-sdk-go"
@@ -11,7 +12,7 @@ import (
 
 type teaSDK interface {
 	Init(teaSDKConfig) error
-	Send(appID int64, uuid string, events []teaSDKEvent, common map[string]any) error
+	Send(appID int64, uuid string, events []teaSDKEvent, common map[string]any, header teaSDKHeader) error
 	Close() error
 }
 
@@ -25,10 +26,35 @@ type teaSDKConfig struct {
 type teaSDKEvent struct {
 	Name     string
 	ClientTS int64
+	EventID  string
 	Params   map[string]any
 }
 
-type defaultTeaSDK struct{}
+type teaSDKHeader struct {
+	AppVersion string
+	OSName     string
+	OSVersion  string
+	CPUABI     string
+}
+
+func (h teaSDKHeader) presetParams() map[string]any {
+	params := map[string]any{}
+	for key, value := range map[string]string{
+		"app_version": h.AppVersion,
+		"os_name":     h.OSName,
+		"os_version":  h.OSVersion,
+		"cpu_abi":     h.CPUABI,
+	} {
+		if value = strings.TrimSpace(value); value != "" {
+			params[key] = value
+		}
+	}
+	return params
+}
+
+type defaultTeaSDK struct {
+	sendEventsWithHeader func(sdk.AppType, int64, *sdk.Header, []*sdk.EventV3) error
+}
 
 func (defaultTeaSDK) Init(config teaSDKConfig) error {
 	logDir, err := ensureTeaSDKLogDir(config.LogDir)
@@ -110,17 +136,48 @@ func newTeaSDKSysConf(config teaSDKConfig, logDir string) *sdk.SysConf {
 	}
 }
 
-func (defaultTeaSDK) Send(appID int64, uuid string, events []teaSDKEvent, common map[string]any) error {
+func (d defaultTeaSDK) Send(
+	appID int64,
+	uuid string,
+	events []teaSDKEvent,
+	common map[string]any,
+	header teaSDKHeader,
+) error {
 	sdkEvents := make([]*sdk.EventV3, 0, len(events))
 	for _, event := range events {
 		clientTS := event.ClientTS
-		sdkEvents = append(sdkEvents, &sdk.EventV3{
+		sdkEvent := &sdk.EventV3{
 			Event:       event.Name,
 			LocalTimeMs: &clientTS,
 			Params:      event.Params,
-		})
+		}
+		if event.EventID != "" {
+			sdkEvent.EventId = sdk.PtrString(event.EventID)
+		}
+		sdkEvents = append(sdkEvents, sdkEvent)
 	}
-	return sdk.SendEventInfos(sdk.APP, appID, uuid, sdkEvents, common)
+	sdkHeader := &sdk.Header{
+		Aid:          &appID,
+		Custom:       common,
+		UserUniqueId: &uuid,
+		AppVersion:   optionalTeaString(header.AppVersion),
+		OsName:       optionalTeaString(header.OSName),
+		OsVersion:    optionalTeaString(header.OSVersion),
+		CpuAbi:       optionalTeaString(header.CPUABI),
+	}
+	sendEventsWithHeader := d.sendEventsWithHeader
+	if sendEventsWithHeader == nil {
+		sendEventsWithHeader = sdk.SendEventsWithHeader
+	}
+	return sendEventsWithHeader(sdk.APP, appID, sdkHeader, sdkEvents)
+}
+
+func optionalTeaString(value string) *string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	return &value
 }
 
 func (defaultTeaSDK) Close() error {

--- a/packages/analytics/reporter-go/tea_sdk_adapter_test.go
+++ b/packages/analytics/reporter-go/tea_sdk_adapter_test.go
@@ -1,6 +1,7 @@
 package reporter
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -8,6 +9,61 @@ import (
 
 	sdk "github.com/volcengine/datarangers-sdk-go"
 )
+
+func TestTeaSDKPayloadUsesPresetHeaderAndEventID(t *testing.T) {
+	var payload []byte
+	adapter := defaultTeaSDK{
+		sendEventsWithHeader: func(_ sdk.AppType, appID int64, header *sdk.Header, events []*sdk.EventV3) error {
+			var err error
+			payload, err = json.Marshal(&sdk.ServerSdkEventMessage{
+				AppId:   &appID,
+				Header:  header,
+				EventV3: events,
+			})
+			return err
+		},
+	}
+	eventID := "event-1"
+	err := adapter.Send(
+		20004092,
+		"user-1",
+		[]teaSDKEvent{{
+			Name:     "workspace.opened",
+			ClientTS: 1749124800000,
+			EventID:  eventID,
+			Params:   map[string]any{"event_id": eventID},
+		}},
+		map[string]any{"os": "darwin", "app_version": "1.2.3"},
+		teaSDKHeader{
+			AppVersion: "1.2.3",
+			OSName:     "darwin",
+			OSVersion:  "15.6",
+			CPUABI:     "arm64",
+		},
+	)
+	if err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	decodedHeader := decoded["header"].(map[string]any)
+	for key, want := range map[string]string{
+		"app_version": "1.2.3",
+		"os_name":     "darwin",
+		"os_version":  "15.6",
+		"cpu_abi":     "arm64",
+	} {
+		if got := decodedHeader[key]; got != want {
+			t.Fatalf("header[%q] = %v, want %q; payload=%s", key, got, want, payload)
+		}
+	}
+	decodedEvent := decoded["event_v3"].([]any)[0].(map[string]any)
+	if got := decodedEvent["event_id"]; got != eventID {
+		t.Fatalf("event_id = %v, want %q; payload=%s", got, eventID, payload)
+	}
+}
 
 func TestEnsureTeaSDKLogDirSecuresExistingDirectory(t *testing.T) {
 	logDir := filepath.Join(t.TempDir(), "sdk-logs")


### PR DESCRIPTION
## 背景

Go 服务端 SDK 此前只通过 Custom 参数上报运行环境，导致 DataFinder 预置字段 os_name、os_version、app_version、cpu_abi 以及 EventId 缺失。

## 改动

- 使用完整 Header 上报预置平台和应用字段，并保留旧自定义字段以兼容现有看板
- 跨平台采集产品系统版本，采集失败时安全省略
- 同步 EventId，并修复空白或非法 event_id
- 在 analytics debug 中投影最终预置字段，并阻止事件参数伪造
- 更新 analytics 架构文档

## 验证

- pnpm check:changed
- packages/analytics/reporter-go: go test -race ./...、go vet ./...
- services/tuttid: go build ./...
- Windows amd64、Linux amd64、Darwin arm64 交叉编译
- adapter payload 序列化测试验证 Header 和 EventId
- 独立 subagent review：APPROVE，无剩余 P1/P2