### PR TITLE
feat(agent-gui): track composer options load performance

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2273,7 +2273,15 @@ AgentGUI performance correlation is package-owned through
 existing Session-event subscription, a clock, and a product-neutral event
 sink. The monitor joins AgentGUI's preserved `submittedAtUnixMs` and queue
 diagnostics to exact Session and Turn identities, then emits activation
-settlement, Prompt admission, first-token receipt, and Turn settlement facts.
+settlement, Prompt admission, first-token receipt, Turn settlement, and
+Composer-options load facts. `trackComposerOptionsLoad` emits a start fact
+before calling either the runtime `getComposerOptions` or exposed Engine
+`loadComposerOptions` path, then emits a correlated completed or failed fact
+with exact duration. An unmatched start therefore remains observable when a
+Provider options request never settles. The facts distinguish runtime from
+session-Engine entry, force refresh, directory presence, bounded error
+category, and model count without carrying paths, settings, model names, or
+error messages.
 Hosts map those facts to their own analytics catalogs; they must not copy the
 Turn-binding, early-event buffering, duration-bucket, or token-classification
 logic.

--- a/packages/agent/gui/agentGUIPerformanceMonitor.spec.ts
+++ b/packages/agent/gui/agentGUIPerformanceMonitor.spec.ts
@@ -1,12 +1,14 @@
 import {
   canonicalTurnKey,
+  type AgentActivityComposerOptions,
   type AgentSessionEngine,
   type AgentSessionEngineState
 } from "@tutti-os/agent-activity-core";
 import { describe, expect, it, vi } from "vitest";
 import {
   agentGUIPerformanceDuration,
-  createAgentGUIPerformanceMonitor
+  createAgentGUIPerformanceMonitor,
+  trackAgentGUIComposerOptionsLoad
 } from "./agentGUIPerformanceMonitor";
 
 describe("createAgentGUIPerformanceMonitor", () => {
@@ -23,6 +25,135 @@ describe("createAgentGUIPerformanceMonitor", () => {
       durationBucket,
       durationMs
     });
+  });
+
+  it("reports a Composer options load start before a slow request settles", async () => {
+    let nowUnixMs = 1_000;
+    const harness = createEngineHarness(engineState({}));
+    const onEvent = vi.fn();
+    const monitor = createAgentGUIPerformanceMonitor({
+      engine: harness.engine,
+      nowUnixMs: () => nowUnixMs,
+      onEvent,
+      subscribeSessionEvents: harness.subscribeSessionEvents
+    });
+    let resolveOptions!: (value: AgentActivityComposerOptions) => void;
+    const optionsPromise = new Promise<AgentActivityComposerOptions>(
+      (resolve) => {
+        resolveOptions = resolve;
+      }
+    );
+
+    const pending = monitor.trackComposerOptionsLoad({
+      agentTargetId: "codex-target",
+      cwd: "/workspace/project",
+      force: true,
+      load: () => optionsPromise,
+      provider: "codex",
+      source: "runtime"
+    });
+
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentTargetId: "codex-target",
+        force: true,
+        hasDirectory: true,
+        provider: "codex",
+        source: "runtime",
+        startedAtUnixMs: 1_000,
+        type: "composer_options_load_started",
+        workspaceId: "workspace-1"
+      })
+    );
+    const operationId = onEvent.mock.calls[0]?.[0]?.operationId;
+    const options = {
+      models: [{ label: "GPT-5", value: "gpt-5" }],
+      provider: "codex"
+    } as AgentActivityComposerOptions;
+    nowUnixMs = 61_000;
+    resolveOptions(options);
+
+    await expect(pending).resolves.toBe(options);
+    expect(onEvent).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        durationBucket: "gte_60s",
+        durationMs: 60_000,
+        modelCount: 1,
+        operationId,
+        outcome: "completed",
+        source: "runtime",
+        type: "composer_options_load_settled"
+      })
+    );
+    monitor.dispose();
+  });
+
+  it("reports an engine Composer options failure without exposing its message", async () => {
+    let nowUnixMs = 2_000;
+    const harness = createEngineHarness(engineState({}));
+    const onEvent = vi.fn();
+    const monitor = createAgentGUIPerformanceMonitor({
+      engine: harness.engine,
+      nowUnixMs: () => nowUnixMs,
+      onEvent,
+      subscribeSessionEvents: harness.subscribeSessionEvents
+    });
+    const failure = new Error("private provider response");
+    Object.assign(failure, { code: "composer_options_timeout" });
+
+    const pending = monitor.trackComposerOptionsLoad({
+      agentTargetId: "codex-target",
+      load: () => Promise.reject(failure),
+      provider: "codex",
+      source: "session-engine"
+    });
+    nowUnixMs = 6_000;
+
+    await expect(pending).rejects.toBe(failure);
+    expect(onEvent).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        durationBucket: "3s_to_10s",
+        durationMs: 4_000,
+        errorCategory: "composer_options_timeout",
+        outcome: "failed",
+        source: "session-engine",
+        type: "composer_options_load_settled"
+      })
+    );
+    expect(JSON.stringify(onEvent.mock.calls)).not.toContain(
+      "private provider response"
+    );
+    monitor.dispose();
+  });
+
+  it("does not let a Composer options event sink change the load result", async () => {
+    const eventSinkFailure = new Error("event sink failed");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const options = {
+      models: [],
+      provider: "codex"
+    } as unknown as AgentActivityComposerOptions;
+
+    try {
+      await expect(
+        trackAgentGUIComposerOptionsLoad({
+          agentTargetId: "codex-target",
+          load: () => Promise.resolve(options),
+          onEvent: () => {
+            throw eventSinkFailure;
+          },
+          provider: "codex",
+          source: "runtime",
+          workspaceId: "workspace-1"
+        })
+      ).resolves.toBe(options);
+      expect(consoleError).toHaveBeenCalledTimes(2);
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   it("reports an exact early queued first-token duration after exact Turn binding", () => {

--- a/packages/agent/gui/agentGUIPerformanceMonitor.ts
+++ b/packages/agent/gui/agentGUIPerformanceMonitor.ts
@@ -3,6 +3,7 @@ import {
   selectEngineTurn,
   selectPendingActivations,
   selectPendingSubmits,
+  type AgentActivityComposerOptions,
   type AgentSessionEngine,
   type AgentSessionEngineState
 } from "@tutti-os/agent-activity-core";
@@ -18,6 +19,8 @@ export type AgentGUIPerformanceDurationBucket =
   | "gte_60s";
 
 export type AgentGUIFirstTokenKind = "other" | "plan" | "reasoning" | "text";
+
+export type AgentGUIComposerOptionsLoadSource = "runtime" | "session-engine";
 
 interface AgentGUIPerformanceEventBase {
   agentSessionId: string;
@@ -59,10 +62,63 @@ export type AgentGUIPerformanceEvent =
       source: "activation" | "submit";
       turnId: string;
       type: "turn_settled";
-    });
+    })
+  | {
+      agentTargetId: string;
+      force: boolean;
+      hasDirectory: boolean;
+      observedAtUnixMs: number;
+      operationId: string;
+      provider: string;
+      source: AgentGUIComposerOptionsLoadSource;
+      startedAtUnixMs: number;
+      type: "composer_options_load_started";
+      workspaceId: string;
+    }
+  | {
+      agentTargetId: string;
+      durationBucket: AgentGUIPerformanceDurationBucket;
+      durationMs: number;
+      errorCategory?: string;
+      force: boolean;
+      hasDirectory: boolean;
+      modelCount?: number;
+      observedAtUnixMs: number;
+      operationId: string;
+      outcome: "completed" | "failed";
+      provider: string;
+      source: AgentGUIComposerOptionsLoadSource;
+      startedAtUnixMs: number;
+      type: "composer_options_load_settled";
+      workspaceId: string;
+    };
+
+export type AgentGUIComposerOptionsPerformanceEvent = Extract<
+  AgentGUIPerformanceEvent,
+  { type: "composer_options_load_settled" | "composer_options_load_started" }
+>;
+
+export interface AgentGUIComposerOptionsLoadInput {
+  agentTargetId: string;
+  cwd?: string | null;
+  force?: boolean;
+  load: () => Promise<AgentActivityComposerOptions>;
+  provider?: string | null;
+  source: AgentGUIComposerOptionsLoadSource;
+}
+
+export interface AgentGUIComposerOptionsPerformanceTrackerInput extends AgentGUIComposerOptionsLoadInput {
+  createOperationId?: () => string;
+  nowUnixMs?: () => number;
+  onEvent: (event: AgentGUIComposerOptionsPerformanceEvent) => void;
+  workspaceId: string;
+}
 
 export interface AgentGUIPerformanceMonitor {
   dispose(): void;
+  trackComposerOptionsLoad(
+    input: AgentGUIComposerOptionsLoadInput
+  ): Promise<AgentActivityComposerOptions>;
 }
 
 interface PromptAttempt {
@@ -90,6 +146,7 @@ interface TurnContext extends Omit<
 }
 
 export function createAgentGUIPerformanceMonitor(input: {
+  createOperationId?: () => string;
   engine: AgentSessionEngine;
   nowUnixMs?: () => number;
   onEvent: (event: AgentGUIPerformanceEvent) => void;
@@ -114,12 +171,7 @@ export function createAgentGUIPerformanceMonitor(input: {
   let disposed = false;
 
   const emit = (event: AgentGUIPerformanceEvent): void => {
-    try {
-      input.onEvent(event);
-    } catch (error) {
-      // Performance reporting must never affect the Agent runtime.
-      console.error("[agent-gui] performance event sink failed", error);
-    }
+    emitPerformanceEvent(input.onEvent, event);
   };
 
   const providerFor = (
@@ -464,8 +516,83 @@ export function createAgentGUIPerformanceMonitor(input: {
       reportedActivationSettlements.clear();
       reportedPromptSettlements.clear();
       reportedTurnSettlements.clear();
+    },
+    trackComposerOptionsLoad(loadInput) {
+      if (disposed) return loadInput.load();
+      return trackAgentGUIComposerOptionsLoad({
+        ...loadInput,
+        createOperationId: input.createOperationId,
+        nowUnixMs,
+        onEvent: emit,
+        workspaceId
+      });
     }
   };
+}
+
+export async function trackAgentGUIComposerOptionsLoad(
+  input: AgentGUIComposerOptionsPerformanceTrackerInput
+): Promise<AgentActivityComposerOptions> {
+  const nowUnixMs = input.nowUnixMs ?? Date.now;
+  const startedAtUnixMs = safeNowUnixMs(nowUnixMs);
+  const operationId = composerOptionsOperationId(input, startedAtUnixMs);
+  const agentTargetId = input.agentTargetId.trim();
+  const force = input.force === true;
+  const hasDirectory = Boolean(input.cwd?.trim());
+  const provider = input.provider?.trim() || "unknown";
+  emitPerformanceEvent(input.onEvent, {
+    agentTargetId,
+    force,
+    hasDirectory,
+    observedAtUnixMs: startedAtUnixMs,
+    operationId,
+    provider,
+    source: input.source,
+    startedAtUnixMs,
+    type: "composer_options_load_started",
+    workspaceId: input.workspaceId
+  });
+
+  let options: AgentActivityComposerOptions;
+  try {
+    options = await input.load();
+  } catch (error) {
+    const observedAtUnixMs = safeNowUnixMs(nowUnixMs);
+    emitPerformanceEvent(input.onEvent, {
+      agentTargetId,
+      ...agentGUIPerformanceDuration(observedAtUnixMs - startedAtUnixMs),
+      errorCategory: performanceErrorCategory(error),
+      force,
+      hasDirectory,
+      observedAtUnixMs,
+      operationId,
+      outcome: "failed",
+      provider,
+      source: input.source,
+      startedAtUnixMs,
+      type: "composer_options_load_settled",
+      workspaceId: input.workspaceId
+    });
+    throw error;
+  }
+
+  const observedAtUnixMs = safeNowUnixMs(nowUnixMs);
+  emitPerformanceEvent(input.onEvent, {
+    agentTargetId,
+    ...agentGUIPerformanceDuration(observedAtUnixMs - startedAtUnixMs),
+    force,
+    hasDirectory,
+    modelCount: Array.isArray(options.models) ? options.models.length : 0,
+    observedAtUnixMs,
+    operationId,
+    outcome: "completed",
+    provider: options.provider?.trim() || provider,
+    source: input.source,
+    startedAtUnixMs,
+    type: "composer_options_load_settled",
+    workspaceId: input.workspaceId
+  });
+  return options;
 }
 
 export function agentGUIPerformanceDuration(durationMs: number): {
@@ -579,6 +706,59 @@ function turnContext(attempt: PromptAttempt, turnId: string): TurnContext {
 
 function performanceTurnKey(agentSessionId: string, turnId: string): string {
   return `${agentSessionId}\u0000${turnId}`;
+}
+
+function performanceErrorCategory(error: unknown): string {
+  const record = asRecord(error);
+  const candidate =
+    stringField(record, "code") ??
+    (error instanceof Error ? error.name : undefined) ??
+    "unknown";
+  const normalized = candidate
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 120);
+  return normalized || "unknown";
+}
+
+function composerOptionsOperationId(
+  input: Pick<
+    AgentGUIComposerOptionsPerformanceTrackerInput,
+    "createOperationId"
+  >,
+  startedAtUnixMs: number
+): string {
+  const fallback = `composer-options:${startedAtUnixMs}:${Math.random()
+    .toString(36)
+    .slice(2)}`;
+  try {
+    return input.createOperationId?.().trim() || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function safeNowUnixMs(nowUnixMs: () => number): number {
+  try {
+    const value = nowUnixMs();
+    return Number.isFinite(value) ? value : Date.now();
+  } catch {
+    return Date.now();
+  }
+}
+
+function emitPerformanceEvent<TEvent extends AgentGUIPerformanceEvent>(
+  onEvent: (event: TEvent) => void,
+  event: TEvent
+): void {
+  try {
+    onEvent(event);
+  } catch (error) {
+    // Performance reporting must never affect the Agent runtime.
+    console.error("[agent-gui] performance event sink failed", error);
+  }
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {

--- a/packages/agent/gui/index.ts
+++ b/packages/agent/gui/index.ts
@@ -207,9 +207,14 @@ export type {
 } from "./agentActivityRuntime";
 export {
   agentGUIPerformanceDuration,
-  createAgentGUIPerformanceMonitor
+  createAgentGUIPerformanceMonitor,
+  trackAgentGUIComposerOptionsLoad
 } from "./agentGUIPerformanceMonitor";
 export type {
+  AgentGUIComposerOptionsLoadInput,
+  AgentGUIComposerOptionsLoadSource,
+  AgentGUIComposerOptionsPerformanceEvent,
+  AgentGUIComposerOptionsPerformanceTrackerInput,
   AgentGUIFirstTokenKind,
   AgentGUIPerformanceDurationBucket,
   AgentGUIPerformanceEvent,


### PR DESCRIPTION
## Summary

- 在 `@tutti-os/agent-gui` 增加 Composer Options 加载性能跟踪，覆盖 runtime `getComposerOptions` 与公开 Engine `loadComposerOptions` 两个入口。
- 在调用 Provider 前发出 start fact；完成或失败时用同一 `operationId` 发出 terminal fact，包含精确耗时和稳定区间。
- 仅输出 target/provider、入口、是否强刷、是否有目录、模型数量和结构化错误分类；不输出路径、设置、模型名或错误消息。
- 保持 package-neutral：宿主负责映射自己的分析事件名。TSH 已通过本地打包链接验证。

## Tests

- `pnpm --dir packages/agent/gui exec vitest run agentGUIPerformanceMonitor.spec.ts --project node`（14 tests）
- `pnpm --dir packages/agent/gui typecheck`
- `pnpm check:changed -- --failed-only`（13 lanes）
- Push hook: `pnpm check:changed -- --push-ready`（12 lanes）
- TSH linked consumer: `pnpm --dir apps/tsh-desktop check`
- TSH linked consumer: 相关测试 33 tests；push gate 37 tests

## Review

| Lane | Trigger | Result | Evidence | Affected consumers |
| --- | --- | --- | --- | --- |
| Architecture | AgentGUI public export 与 Engine 性能入口 | pass | 中性计时留在 AgentGUI package；宿主只接收 fact；`docs/architecture/agent-gui-node.md` 已更新 | Desktop AgentGUI、TSH AgentGUI hosts |
| Performance | 性能 monitor 与加载入口 | pass | 每次加载仅生成一个 ID、两次时钟读取、start/terminal 两个回调；不新增 token/Engine 订阅；degradation gate 通过 | Composer Options 加载路径 |
| Consumers | 新 public symbol 与 monitor method | pass | API 为 additive；本地 packed/linked TSH Web typecheck 与相关测试通过 | TSH 与其他外部 AgentGUI hosts |

## Notes

- 这是观测能力，不增加加载 timeout，也不改变 Composer Options 缓存、合流、重试或失败语义。
- 永不 settle 的请求会保留一个无 terminal fact 的 start fact，用于识别模型列表长期加载。
- TSH consumer PR 在 Tutti 发布并升级依赖 cohort 前保持 Draft。