### PR TITLE
fix(agent-runtime): bound Claude cancellation shutdown

### DIFF
--- a/apps/desktop/scripts/smoke-claude-sdk-sidecar.mjs
+++ b/apps/desktop/scripts/smoke-claude-sdk-sidecar.mjs
@@ -36,7 +36,7 @@ export async function smokeClaudeSDKSidecar({
   });
 
   const send = (request) => {
-    child.stdin.write(`${JSON.stringify({ version: 9, ...request })}\n`);
+    child.stdin.write(`${JSON.stringify({ version: 10, ...request })}\n`);
   };
   const waitForEvent = async (predicate, label) => {
     while (true) {

--- a/docs/architecture/claude-code-sdk-runtime.md
+++ b/docs/architecture/claude-code-sdk-runtime.md
@@ -181,25 +181,31 @@ Raw sidecar stderr is never copied into activity, logs, or user-visible errors.
 The Go transport retains only a bounded failure classification; explicitly
 prefixed auth diagnostics are separately sanitized before structured logging.
 
-SDK Query lifetime is narrower than durable provider-session lifetime. A user
-cancel carries the exact canonical Turn and returns one structured disposition:
+SDK Query lifetime is narrower than durable provider-session lifetime. The
+sidecar owns Query termination; an RPC caller deadline alone is never treated
+as cancellation because it cannot stop an already-dispatched SDK control
+request. A user cancel carries the exact canonical Turn, a cooperative
+interrupt budget, and a consumer-drain budget, and returns one structured disposition:
 `pre_accept`, `provider_active`, `absent`, or `mismatch`. An undispatched queue
 entry can be removed locally. Once the prompt has been dispatched, cancel first
-revokes the current Query generation, awaits the SDK interrupt acknowledgment,
-then closes that Query in cleanup; the sidecar publishes `turn_canceled` only
-after that acknowledgment. Closing before the interrupt response turns a
-successful provider stop into a transport failure. Revocation fences message
-routing, hooks, and `canUseTool` before permission-mode handling, including
-`bypassPermissions`; background-task notifications from the canceled generation
-therefore cannot start a synthetic continuation or execute another tool. Every
-Turn already handed to the retired Query's prompt queue settles after that same
-acknowledgment, including a drained Goal command that can no longer execute; a
-Goal command still in the sidecar's deferred queue is independent and remains
+revokes the current Query generation and requests the SDK interrupt. If Claude
+Code acknowledges within the cooperative budget, shutdown remains graceful. If
+the acknowledgment is missing or fails, the sidecar closes the owned SDK Query
+transport; the pinned SDK then ends stdin and escalates its Claude Code child
+from `SIGTERM` to `SIGKILL`. The sidecar waits only for the separate drain budget
+for its consumer to settle. A drain timeout is an explicit bounded failure and
+never leaves the request pending. Revocation fences message routing, hooks, and
+`canUseTool` before permission-mode handling, including `bypassPermissions`;
+background-task notifications from the canceled generation therefore cannot
+start a synthetic continuation or execute another tool. Every Turn already
+handed to the retired Query's prompt queue settles after that same authoritative
+shutdown boundary, including a drained Goal command that can no longer execute;
+a Goal command still in the sidecar's deferred queue is independent and remains
 eligible for exact local removal. For a
 `provider_active` response, the Go adapter also waits for the exact Turn's
 durable provider-acceptance outcome before confirming cancellation. `absent`
 is the only authoritative not-found result; mismatches, unknown dispositions,
-interrupt failures, and acceptance failures remain fail-closed. The next real
+drain failures, and acceptance failures remain fail-closed. The next real
 user prompt creates a fresh Query with
 `resume: providerSessionId` and generation-local prompt/abort resources. If the
 SDK replays the canceled generation's terminal task notification and paired
@@ -274,7 +280,8 @@ The daemon and sidecar exchange newline-delimited JSON over standard input and
 output. Every request and event carries the current protocol version. Missing
 or unsupported versions fail explicitly. Change both
 `claude_sdk_protocol.go` and `src/protocol.ts` together and cover the change on
-both sides. Version 9 makes the cancel disposition, exact canonical Turn ID,
+both sides. Version 10 makes the cooperative-interrupt and consumer-drain
+budgets required cancel-request fields. Version 9 makes the cancel disposition, exact canonical Turn ID,
 provider Turn ID, and dispatch phase correctness-required response fields.
 
 Capability and composer contracts are intentionally stable across this runtime

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -2,6 +2,34 @@
 
 [Agent runtime index](./agent-runtime.md) · [All troubleshooting](./README.md)
 
+### Claude cancellation reaches `context deadline exceeded`
+
+- **Symptom:** Canceling a Claude Code Turn, closing its Session, or leaving a
+  room waits until the caller deadline and reports `context deadline exceeded`.
+  Repeating the action leaves the same Turn active.
+- **Quick checks:** Filter daemon logs by `CLAUDE_CODE_CANCEL_DIAGNOSTIC`, then
+  group by `requestId`, `agentSessionId`, `turnId`, and `generationId`. Compare
+  `interrupt_started` with `interrupt_succeeded`, `interrupt_timed_out`, or
+  `interrupt_failed`; then require `query_close_succeeded` and either
+  `consumption_settled` or `consumption_timed_out`. The payload deliberately
+  excludes prompts, tool inputs, credentials, and provider output.
+- **Root cause:** The SDK interrupt is a control request whose Promise has no
+  native timeout. A wedged Claude Code process may never return its control
+  response. A caller-side Go deadline only stops the RPC waiter and cannot
+  terminate that Promise or the provider process.
+- **Fix:** Treat cancellation as a Query-lifecycle protocol. Revoke the exact
+  generation, bound cooperative interrupt, close the owned SDK transport when
+  ACK is missing or fails, and separately bound consumer drain before settling
+  canonical Turns. Do not increase only the outer RPC timeout.
+- **Validation:** Cover an interrupt Promise that never settles, immediate
+  interrupt rejection, and a consumer Promise that never drains. The first two
+  must close transport and cancel the Turn; the last must return an explicit
+  bounded failure.
+- **References:**
+  [queryGeneration.ts](../../../packages/agent/claude-sdk-sidecar/src/queryGeneration.ts),
+  [sessionRuntime.ts](../../../packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts),
+  [claude_sdk_execution.go](../../../packages/agent/daemon/runtime/claude_sdk_execution.go)
+
 ### Claude Goal stays active after the model becomes idle
 
 - **Symptom:** Claude has stopped producing output and the Session becomes
@@ -2926,17 +2954,19 @@ inline data URL instead`. Claude or standard ACP may instead receive no
   exact Turn ID to the sidecar and dispatch the native cancel before consulting
   acceptance state. The sidecar returns `pre_accept`, `provider_active`,
   `absent`, or `mismatch`: locally remove only an undispatched queue item; after
-  dispatch, publish the canceled terminal only after SDK interrupt/shutdown
-  acknowledges. Wait for the exact Turn's durable provider-acceptance outcome
-  only for `provider_active`. Treat only `absent` as authoritative not-found;
-  mismatch, unknown disposition, interrupt failure, and acceptance failure stay
-  fail-closed.
+  dispatch, publish the canceled terminal only after the bounded Query shutdown
+  protocol either receives the SDK interrupt acknowledgment or closes the owned
+  transport and drains its consumer. Wait for the exact Turn's durable
+  provider-acceptance outcome only for `provider_active`. Treat only `absent` as
+  authoritative not-found; mismatch, unknown disposition, drain failure, and
+  acceptance failure stay fail-closed.
 - Validation:
   Cover follow-up resume, settings timeout/retry gating, exact targeted cancel,
-  same-tick Goal cancellation, cancel before dispatch, interrupt acknowledgment
-  and failure, durable acceptance success and failure, mismatched/absent targets,
-  and cancel followed by a new send. Native guidance must interrupt active tool
-  work before enqueueing the steering prompt.
+  same-tick Goal cancellation, cancel before dispatch, interrupt acknowledgment,
+  missing acknowledgment, interrupt failure, consumer-drain timeout, durable
+  acceptance success and failure, mismatched/absent targets, and cancel followed
+  by a new send. Native guidance must interrupt active tool work before enqueueing
+  the steering prompt.
 - References:
   [sessionRuntime.ts](../../../packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts)
   [claude_sdk_execution.go](../../../packages/agent/daemon/runtime/claude_sdk_execution.go)

--- a/packages/agent/claude-sdk-sidecar/README.md
+++ b/packages/agent/claude-sdk-sidecar/README.md
@@ -19,9 +19,19 @@ build step and no bundled entry point beyond the source files.
 ## Sidecar protocol
 
 The daemon and sidecar exchange newline-delimited JSON envelopes over standard
-input and output. Every request and event carries `"version": 7`; either side
+input and output. Every request and event carries `"version": 10`; either side
 rejects unsupported or missing versions instead of guessing compatibility.
 Protocol types and validation live in `src/protocol.ts`.
+
+Protocol version 10 makes cancellation deadlines part of the request contract.
+The daemon supplies separate cooperative-interrupt and consumer-drain budgets.
+If Claude Code does not acknowledge the SDK interrupt within its budget, the
+sidecar closes the owned Query transport, which terminates the Query's Claude
+Code process, then waits only for the bounded drain budget before responding.
+Every cancellation phase is emitted to stderr with the
+`CLAUDE_CODE_CANCEL_DIAGNOSTIC` prefix and one JSON payload containing request,
+Session, Turn, Query-generation, duration, and outcome fields; prompts, tool
+inputs, credentials, and raw provider output are never included.
 
 Protocol version 7 adds the stateless `recover_turn_binding` read. It resolves
 exactly one root user-message UUID from an opaque recovery token, or performs a
@@ -90,8 +100,10 @@ never fall back to the outbound correlation UUID.
 Exact cancellation returns a structured `pre_accept`, `provider_active`,
 `absent`, or `mismatch` disposition. An undispatched Turn or deferred Goal
 command can be removed locally. A dispatched Turn is fenced immediately, but
-its terminal event is emitted only after the SDK interrupt and Query shutdown
-acknowledge. `provider_active` includes the resolved provider Turn ID so the
+its terminal event is emitted only after the Query reaches an authoritative
+shutdown boundary: either the SDK acknowledges the interrupt or the sidecar
+closes the owned Query transport and its consumer drains. `provider_active`
+includes the resolved provider Turn ID so the
 daemon can wait for that exact Turn's durable acceptance result before it
 confirms cancellation; failures and unknown dispositions remain fail-closed.
 

--- a/packages/agent/claude-sdk-sidecar/package.json
+++ b/packages/agent/claude-sdk-sidecar/package.json
@@ -7,6 +7,7 @@
     "src/assistantStream.ts",
     "src/authDiagnostics.ts",
     "src/backgroundTaskLifecycle.ts",
+    "src/cancelDiagnostics.ts",
     "src/compaction.ts",
     "src/errors.ts",
     "src/eventSink.ts",

--- a/packages/agent/claude-sdk-sidecar/src/cancelDiagnostics.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/cancelDiagnostics.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { pid } from "node:process";
+import test from "node:test";
+import {
+  CLAUDE_CODE_CANCEL_DIAGNOSTIC_PREFIX,
+  logClaudeCodeCancellation,
+  withCancellationDiagnosticSinkForTest
+} from "./cancelDiagnostics.ts";
+
+test("cancellation diagnostics use one prefix and JSON payload", () => {
+  const lines: string[] = [];
+  const restore = withCancellationDiagnosticSinkForTest((line) =>
+    lines.push(line)
+  );
+  try {
+    logClaudeCodeCancellation("interrupt_started", {
+      agentSessionId: "agent-session",
+      turnId: "turn-1",
+      generationId: 3
+    });
+  } finally {
+    restore();
+  }
+
+  assert.equal(lines.length, 1);
+  assert.equal(
+    lines[0]?.startsWith(`${CLAUDE_CODE_CANCEL_DIAGNOSTIC_PREFIX} `),
+    true
+  );
+  assert.deepEqual(
+    JSON.parse(
+      lines[0]?.slice(CLAUDE_CODE_CANCEL_DIAGNOSTIC_PREFIX.length + 1) ?? ""
+    ),
+    {
+      stage: "interrupt_started",
+      sidecarPid: pid,
+      agentSessionId: "agent-session",
+      turnId: "turn-1",
+      generationId: 3
+    }
+  );
+});

--- a/packages/agent/claude-sdk-sidecar/src/cancelDiagnostics.ts
+++ b/packages/agent/claude-sdk-sidecar/src/cancelDiagnostics.ts
@@ -1,0 +1,45 @@
+import { pid, stderr } from "node:process";
+import { errorMessage } from "./errors.ts";
+
+export const CLAUDE_CODE_CANCEL_DIAGNOSTIC_PREFIX =
+  "CLAUDE_CODE_CANCEL_DIAGNOSTIC";
+
+type CancellationDiagnosticSink = (line: string) => void;
+
+let cancellationDiagnosticSink: CancellationDiagnosticSink = (line) => {
+  stderr.write(`${line}\n`);
+};
+
+export function logClaudeCodeCancellation(
+  stage: string,
+  payload: Record<string, unknown>
+): void {
+  cancellationDiagnosticSink(
+    `${CLAUDE_CODE_CANCEL_DIAGNOSTIC_PREFIX} ${JSON.stringify({
+      stage,
+      sidecarPid: pid,
+      ...payload
+    })}`
+  );
+}
+
+export function cancellationErrorPayload(error: unknown): {
+  name: string;
+  message: string;
+} {
+  return {
+    name: error instanceof Error ? error.name : typeof error,
+    message: errorMessage(error)
+  };
+}
+
+export function withCancellationDiagnosticSinkForTest(
+  sink: CancellationDiagnosticSink
+): () => void {
+  cancellationDiagnosticSink = sink;
+  return () => {
+    cancellationDiagnosticSink = (line) => {
+      stderr.write(`${line}\n`);
+    };
+  };
+}

--- a/packages/agent/claude-sdk-sidecar/src/main.ts
+++ b/packages/agent/claude-sdk-sidecar/src/main.ts
@@ -2,6 +2,10 @@ import * as readline from "node:readline/promises";
 import { stdin } from "node:process";
 import { pathToFileURL } from "node:url";
 import { errorMessage } from "./errors.ts";
+import {
+  cancellationErrorPayload,
+  logClaudeCodeCancellation
+} from "./cancelDiagnostics.ts";
 import { emit } from "./eventSink.ts";
 import { numberValue, recordValue } from "./normalizer.ts";
 import { sidecarClaudeOptionsFromPayload } from "./options.ts";
@@ -124,9 +128,56 @@ export async function handleRequest(
       }
       case "cancel": {
         const payload = request.payload ?? {};
-        const session = requireSession(stringValue(payload.agentSessionId));
-        const result = await session.cancel(stringValue(payload.turnId));
-        emit({ id, type: "ok", payload: result });
+        const agentSessionId = stringValue(payload.agentSessionId);
+        const turnId = stringValue(payload.turnId);
+        const interruptTimeoutMs = requiredPositiveInteger(
+          payload.interruptTimeoutMs,
+          "cancel interruptTimeoutMs"
+        );
+        const drainTimeoutMs = requiredPositiveInteger(
+          payload.drainTimeoutMs,
+          "cancel drainTimeoutMs"
+        );
+        const session = requireSession(agentSessionId);
+        const diagnosticContext = {
+          requestId: id ?? "",
+          agentSessionId,
+          providerSessionId: session.providerSessionId,
+          turnId
+        };
+        const startedAt = Date.now();
+        logClaudeCodeCancellation("cancel_received", {
+          ...diagnosticContext,
+          interruptTimeoutMs,
+          drainTimeoutMs
+        });
+        try {
+          const result = await session.cancel(turnId, {
+            interruptTimeoutMs,
+            drainTimeoutMs,
+            observe: (stage, stagePayload) =>
+              logClaudeCodeCancellation(stage, {
+                ...diagnosticContext,
+                ...stagePayload
+              })
+          });
+          logClaudeCodeCancellation("cancel_succeeded", {
+            ...diagnosticContext,
+            durationMs: Date.now() - startedAt,
+            canceled: result.canceled,
+            disposition: result.disposition,
+            dispatchPhase: result.dispatchPhase,
+            providerTurnId: result.providerTurnId
+          });
+          emit({ id, type: "ok", payload: result });
+        } catch (error) {
+          logClaudeCodeCancellation("cancel_failed", {
+            ...diagnosticContext,
+            durationMs: Date.now() - startedAt,
+            error: cancellationErrorPayload(error)
+          });
+          throw error;
+        }
         return;
       }
       case "stop_task": {
@@ -229,6 +280,13 @@ function requireSession(agentSessionId: string): SessionRuntime {
     throw new Error(`session ${agentSessionId} is not started`);
   }
   return session;
+}
+
+function requiredPositiveInteger(value: unknown, label: string): number {
+  if (!Number.isSafeInteger(value) || Number(value) <= 0) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  return Number(value);
 }
 
 async function runMain(): Promise<void> {

--- a/packages/agent/claude-sdk-sidecar/src/protocol.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/protocol.test.ts
@@ -34,6 +34,30 @@ test("sidecar protocol accepts stop_task requests", () => {
   );
 });
 
+test("sidecar protocol requires bounded cancellation phases", () => {
+  const request = parseClaudeSDKSidecarRequest({
+    version: CLAUDE_SDK_SIDECAR_PROTOCOL_VERSION,
+    type: "cancel",
+    payload: {
+      agentSessionId: "session-1",
+      turnId: "turn-1",
+      interruptTimeoutMs: 10_000,
+      drainTimeoutMs: 8_000
+    }
+  });
+  assert.equal(request.type, "cancel");
+
+  assert.throws(
+    () =>
+      parseClaudeSDKSidecarRequest({
+        version: CLAUDE_SDK_SIDECAR_PROTOCOL_VERSION,
+        type: "cancel",
+        payload: { interruptTimeoutMs: 10_000 }
+      }),
+    /cancel drainTimeoutMs must be a positive integer/
+  );
+});
+
 test("sidecar protocol accepts stateless session fork requests", () => {
   for (const type of [
     "inspect_fork_checkpoints",

--- a/packages/agent/claude-sdk-sidecar/src/protocol.ts
+++ b/packages/agent/claude-sdk-sidecar/src/protocol.ts
@@ -1,4 +1,4 @@
-export const CLAUDE_SDK_SIDECAR_PROTOCOL_VERSION = 9 as const;
+export const CLAUDE_SDK_SIDECAR_PROTOCOL_VERSION = 10 as const;
 
 export type ClaudeSDKSidecarRequestType =
   | "start"
@@ -61,6 +61,11 @@ export function parseClaudeSDKSidecarRequest(
   ) {
     throw new Error("sidecar request payload must be an object");
   }
+  if (request.type === "cancel") {
+    const payload = request.payload as Record<string, unknown> | undefined;
+    requirePositiveInteger(payload?.interruptTimeoutMs, "interruptTimeoutMs");
+    requirePositiveInteger(payload?.drainTimeoutMs, "drainTimeoutMs");
+  }
   return request as ClaudeSDKSidecarRequest;
 }
 
@@ -90,4 +95,10 @@ function isRequestType(value: unknown): value is ClaudeSDKSidecarRequestType {
     typeof value === "string" &&
     REQUEST_TYPES.has(value as ClaudeSDKSidecarRequestType)
   );
+}
+
+function requirePositiveInteger(value: unknown, field: string): void {
+  if (!Number.isSafeInteger(value) || Number(value) <= 0) {
+    throw new Error(`cancel ${field} must be a positive integer`);
+  }
 }

--- a/packages/agent/claude-sdk-sidecar/src/queryGeneration.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/queryGeneration.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  QueryGeneration,
+  QueryShutdownTimeoutError,
+  type QueryShutdownStage
+} from "./queryGeneration.ts";
+
+test("query shutdown closes transport when interrupt acknowledgement times out", async () => {
+  const generation = new QueryGeneration(41);
+  const stages: QueryShutdownStage[] = [];
+  let closed = false;
+  generation.query = {
+    async *[Symbol.asyncIterator]() {},
+    async interrupt() {
+      await new Promise(() => {});
+    },
+    close() {
+      closed = true;
+    }
+  };
+  generation.consumption = Promise.resolve();
+
+  const result = await generation.shutdown(true, {
+    interruptTimeoutMs: 10,
+    drainTimeoutMs: 10,
+    observe: (stage) => stages.push(stage)
+  });
+
+  assert.equal(closed, true);
+  assert.deepEqual(result, { terminationMode: "transport_closed" });
+  assert.deepEqual(stages, [
+    "shutdown_started",
+    "interrupt_started",
+    "interrupt_timed_out",
+    "query_close_started",
+    "query_close_succeeded",
+    "consumption_wait_started",
+    "consumption_settled",
+    "shutdown_succeeded"
+  ]);
+});
+
+test("query shutdown reports a bounded failure when consumption cannot drain", async () => {
+  const generation = new QueryGeneration(42);
+  const stages: QueryShutdownStage[] = [];
+  generation.query = {
+    async *[Symbol.asyncIterator]() {},
+    async interrupt() {},
+    close() {}
+  };
+  generation.consumption = new Promise(() => {});
+
+  await assert.rejects(
+    generation.shutdown(true, {
+      interruptTimeoutMs: 10,
+      drainTimeoutMs: 10,
+      observe: (stage) => stages.push(stage)
+    }),
+    (error: unknown) =>
+      error instanceof QueryShutdownTimeoutError &&
+      error.stage === "consumption"
+  );
+  assert.deepEqual(stages, [
+    "shutdown_started",
+    "interrupt_started",
+    "interrupt_succeeded",
+    "query_close_started",
+    "query_close_succeeded",
+    "consumption_wait_started",
+    "consumption_timed_out"
+  ]);
+});

--- a/packages/agent/claude-sdk-sidecar/src/queryGeneration.ts
+++ b/packages/agent/claude-sdk-sidecar/src/queryGeneration.ts
@@ -22,6 +22,45 @@ export type ClaudeQueryRuntime = AsyncIterable<SDKMessage> & {
   close?: () => void;
 };
 
+export const DEFAULT_QUERY_INTERRUPT_TIMEOUT_MS = 10_000;
+export const DEFAULT_QUERY_DRAIN_TIMEOUT_MS = 8_000;
+
+export type QueryShutdownStage =
+  | "shutdown_started"
+  | "interrupt_started"
+  | "interrupt_succeeded"
+  | "interrupt_failed"
+  | "interrupt_timed_out"
+  | "query_close_started"
+  | "query_close_succeeded"
+  | "query_close_failed"
+  | "consumption_wait_started"
+  | "consumption_settled"
+  | "consumption_timed_out"
+  | "shutdown_succeeded";
+
+export type QueryShutdownOptions = {
+  interruptTimeoutMs?: number;
+  drainTimeoutMs?: number;
+  observe?: (
+    stage: QueryShutdownStage,
+    payload: Record<string, unknown>
+  ) => void;
+};
+
+export type QueryShutdownResult = {
+  terminationMode: "interrupt_acknowledged" | "transport_closed";
+};
+
+export class QueryShutdownTimeoutError extends Error {
+  readonly stage = "consumption" as const;
+
+  constructor(timeoutMs: number) {
+    super(`Claude SDK Query consumption timed out after ${timeoutMs}ms`);
+    this.name = "QueryShutdownTimeoutError";
+  }
+}
+
 export class QueryGeneration {
   readonly promptQueue = new AsyncPromptQueue();
   readonly cancelController = new AbortController();
@@ -98,28 +137,111 @@ export class QueryGeneration {
     this.query?.close?.();
   }
 
-  async shutdown(interrupt: boolean): Promise<void> {
-    this.revoke();
-    let failure: unknown;
-    try {
-      if (interrupt) {
-        await this.query?.interrupt?.();
-      }
-    } catch (error) {
-      failure = error;
-    } finally {
-      // Revocation fences callbacks while interrupt waits for its SDK ACK.
-      // Closing earlier rejects that pending ACK as a transport failure.
+  async shutdown(
+    interrupt: boolean,
+    options: QueryShutdownOptions = {}
+  ): Promise<QueryShutdownResult> {
+    const interruptTimeoutMs = positiveTimeout(
+      options.interruptTimeoutMs,
+      DEFAULT_QUERY_INTERRUPT_TIMEOUT_MS
+    );
+    const drainTimeoutMs = positiveTimeout(
+      options.drainTimeoutMs,
+      DEFAULT_QUERY_DRAIN_TIMEOUT_MS
+    );
+    const report = (
+      stage: QueryShutdownStage,
+      payload: Record<string, unknown>
+    ): void => {
       try {
-        this.closeQuery();
-      } catch (error) {
-        failure ??= error;
+        options.observe?.(stage, payload);
+      } catch {
+        // Diagnostics must not change cancellation semantics.
+      }
+    };
+    const shutdownStartedAt = Date.now();
+    let terminationMode: QueryShutdownResult["terminationMode"] =
+      interrupt && this.query?.interrupt
+        ? "interrupt_acknowledged"
+        : "transport_closed";
+    this.revoke();
+    report("shutdown_started", {
+      generationId: this.id,
+      interrupt,
+      interruptTimeoutMs,
+      drainTimeoutMs,
+      hasQuery: Boolean(this.query),
+      hasConsumption: Boolean(this.consumption)
+    });
+
+    if (interrupt && this.query?.interrupt) {
+      const interruptStartedAt = Date.now();
+      report("interrupt_started", { generationId: this.id });
+      const interruptResult = await settleWithin(
+        Promise.resolve().then(() => this.query?.interrupt?.()),
+        interruptTimeoutMs
+      );
+      if (interruptResult.kind === "resolved") {
+        report("interrupt_succeeded", {
+          generationId: this.id,
+          durationMs: Date.now() - interruptStartedAt
+        });
+      } else {
+        terminationMode = "transport_closed";
+        report(
+          interruptResult.kind === "timeout"
+            ? "interrupt_timed_out"
+            : "interrupt_failed",
+          {
+            generationId: this.id,
+            durationMs: Date.now() - interruptStartedAt,
+            ...(interruptResult.kind === "rejected"
+              ? { error: diagnosticError(interruptResult.error) }
+              : { timeoutMs: interruptTimeoutMs })
+          }
+        );
       }
     }
-    await this.consumption;
-    if (failure !== undefined) {
-      throw failure;
+
+    report("query_close_started", { generationId: this.id });
+    try {
+      this.closeQuery();
+      report("query_close_succeeded", { generationId: this.id });
+    } catch (error) {
+      report("query_close_failed", {
+        generationId: this.id,
+        error: diagnosticError(error)
+      });
+      throw error;
     }
+
+    const consumptionStartedAt = Date.now();
+    report("consumption_wait_started", { generationId: this.id });
+    const consumptionResult = await settleWithin(
+      this.consumption ?? Promise.resolve(),
+      drainTimeoutMs
+    );
+    if (consumptionResult.kind === "timeout") {
+      report("consumption_timed_out", {
+        generationId: this.id,
+        durationMs: Date.now() - consumptionStartedAt,
+        timeoutMs: drainTimeoutMs
+      });
+      throw new QueryShutdownTimeoutError(drainTimeoutMs);
+    }
+    if (consumptionResult.kind === "rejected") {
+      throw consumptionResult.error;
+    }
+    report("consumption_settled", {
+      generationId: this.id,
+      durationMs: Date.now() - consumptionStartedAt
+    });
+    report("shutdown_succeeded", {
+      generationId: this.id,
+      durationMs: Date.now() - shutdownStartedAt,
+      terminationMode
+    });
+    return { terminationMode };
   }
 
   private isCurrentPromptEcho(
@@ -148,6 +270,46 @@ export class QueryGeneration {
     this.currentPromptObserved = false;
     this.canceledTaskTailObserved = false;
   }
+}
+
+function positiveTimeout(value: number | undefined, fallback: number): number {
+  return Number.isSafeInteger(value) && Number(value) > 0
+    ? Number(value)
+    : fallback;
+}
+
+type TimedSettlement<T> =
+  | { kind: "resolved"; value: T }
+  | { kind: "rejected"; error: unknown }
+  | { kind: "timeout" };
+
+async function settleWithin<T>(
+  promise: Promise<T>,
+  timeoutMs: number
+): Promise<TimedSettlement<T>> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise.then(
+        (value): TimedSettlement<T> => ({ kind: "resolved", value }),
+        (error: unknown): TimedSettlement<T> => ({ kind: "rejected", error })
+      ),
+      new Promise<TimedSettlement<T>>((resolve) => {
+        timer = setTimeout(() => resolve({ kind: "timeout" }), timeoutMs);
+      })
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+function diagnosticError(error: unknown): { name: string; message: string } {
+  return {
+    name: error instanceof Error ? error.name : typeof error,
+    message: error instanceof Error ? error.message : String(error)
+  };
 }
 
 function isTaskLifecycleTail(

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.cancel.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.cancel.test.ts
@@ -151,6 +151,55 @@ test("dispatched pre-accept cancel publishes terminal only after interrupt ack",
   }
 });
 
+test("dispatched cancel terminates the Query when interrupt ack never arrives", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  let markPromptObserved: () => void = () => {};
+  const promptObserved = new Promise<void>((resolve) => {
+    markPromptObserved = resolve;
+  });
+  let closed = false;
+  try {
+    const session = cancelTestSession(({ prompt }) => ({
+      async *[Symbol.asyncIterator]() {
+        await prompt[Symbol.asyncIterator]().next();
+        markPromptObserved();
+        await new Promise(() => {});
+        yield {} as SDKMessage;
+      },
+      async interrupt() {
+        await new Promise(() => {});
+      },
+      close() {
+        closed = true;
+      }
+    }));
+
+    await session.start();
+    session.exec("turn-interrupt-timeout", "hello");
+    await promptObserved;
+    const result = await session.cancel("turn-interrupt-timeout", {
+      interruptTimeoutMs: 10,
+      drainTimeoutMs: 10
+    });
+
+    assert.equal(result.canceled, true);
+    assert.equal(closed, true);
+    assert.equal(
+      events.some(
+        (event) =>
+          event.type === "turn_canceled" &&
+          event.payload?.turnId === "turn-interrupt-timeout"
+      ),
+      true
+    );
+  } finally {
+    restoreSink();
+  }
+});
+
 test("cancel aborting identity resolution cannot publish terminal before interrupt ack", async () => {
   const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
   const restoreSink = withSidecarEventSinkForTest((event) =>
@@ -297,7 +346,7 @@ test("cancel settles every dispatched prompt retired with the Query generation",
   }
 });
 
-test("interrupt failure leaves exact cancellation unresolved without terminal", async () => {
+test("interrupt failure closes the owned Query and settles cancellation", async () => {
   const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
   const restoreSink = withSidecarEventSinkForTest((event) =>
     events.push(event)
@@ -306,6 +355,7 @@ test("interrupt failure leaves exact cancellation unresolved without terminal", 
   const promptObserved = new Promise<void>((resolve) => {
     markPromptObserved = resolve;
   });
+  let closed = false;
   try {
     const session = cancelTestSession(({ prompt }) => ({
       async *[Symbol.asyncIterator]() {
@@ -319,24 +369,22 @@ test("interrupt failure leaves exact cancellation unresolved without terminal", 
       async interrupt() {
         throw new Error("interrupt failed");
       },
-      close() {}
+      close() {
+        closed = true;
+      }
     }));
 
     await session.start();
     session.exec("turn-interrupt-failed", "hello");
     await promptObserved;
 
-    await assert.rejects(
-      session.cancel("turn-interrupt-failed"),
-      /interrupt failed/
-    );
+    const result = await session.cancel("turn-interrupt-failed");
+
+    assert.equal(result.canceled, true);
+    assert.equal(closed, true);
     assert.equal(
       events.some((event) => event.type === "turn_canceled"),
-      false
-    );
-    await assert.rejects(
-      session.cancel("turn-interrupt-failed"),
-      /remains unresolved/
+      true
     );
   } finally {
     restoreSink();

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts
@@ -13,7 +13,11 @@ import {
   claudeQueryOptionOverrides,
   type SidecarClaudeOptions
 } from "./options.ts";
-import { QueryGeneration, type ClaudeQueryRuntime } from "./queryGeneration.ts";
+import {
+  QueryGeneration,
+  type ClaudeQueryRuntime,
+  type QueryShutdownOptions
+} from "./queryGeneration.ts";
 import { queryGenerationHooks } from "./queryHooks.ts";
 import {
   claudeAuthRefreshDiagnosticsEnabled,
@@ -618,7 +622,10 @@ export class SessionRuntime {
       });
   }
 
-  async cancel(expectedTurnId = ""): Promise<SessionCancelResult> {
+  async cancel(
+    expectedTurnId = "",
+    shutdownOptions: QueryShutdownOptions = {}
+  ): Promise<SessionCancelResult> {
     expectedTurnId =
       expectedTurnId.trim() || this.turns.activeTurn?.turnId.trim() || "";
     if (this.sessionClosed) {
@@ -687,7 +694,7 @@ export class SessionRuntime {
     this.canceledQueryTailPending = true;
     this.interactions.rejectAll(new Error("Tool use aborted"));
     this.queryGeneration = undefined;
-    await generation.shutdown(true);
+    await generation.shutdown(true, shutdownOptions);
     for (const turnId of generationTurnIds) {
       if (!this.turns.commitExactCancellation(turnId)) {
         throw new Error(`Claude SDK lost canceled Query turn ${turnId}`);

--- a/packages/agent/daemon/runtime/acp_turn_normalizer_test.go
+++ b/packages/agent/daemon/runtime/acp_turn_normalizer_test.go
@@ -255,6 +255,7 @@ func TestFinishCompletedFailsDanglingToolCall(t *testing.T) {
 	}
 	if callEvent == nil {
 		t.Fatalf("FinishCompleted did not emit any event for the dangling call %q: %+v", startedEvent.EventID, completed)
+		return
 	}
 	if callEvent.Type != EventCallFailed {
 		t.Fatalf("dangling call event type = %q, want %q (a call with no item/completed must never be reported as a successful completion)", callEvent.Type, EventCallFailed)

--- a/packages/agent/daemon/runtime/activity_projection_test.go
+++ b/packages/agent/daemon/runtime/activity_projection_test.go
@@ -709,6 +709,7 @@ func TestRootProviderTurnFailurePersistsVisibleErrorCode(t *testing.T) {
 	completed := report.StatePatches[0].RootProviderTurn
 	if completed == nil {
 		t.Fatal("root provider turn transition is nil")
+		return
 	}
 	if completed.ErrorMessage != errorMessage {
 		t.Fatalf("root provider turn error message = %q, want %q", completed.ErrorMessage, errorMessage)

--- a/packages/agent/daemon/runtime/claude_sdk_adapter.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter.go
@@ -18,6 +18,7 @@ const (
 	claudeSDKSidecarAdapterName    = "claude-agent-sdk"
 	claudeSDKSidecarDefaultNodeArg = "--experimental-strip-types"
 	claudeSDKAuthRefreshLogPrefix  = "CLAUDE_CODE_AUTH_REFRESH_DEBUG"
+	claudeSDKCancelLogPrefix       = "CLAUDE_CODE_CANCEL_DIAGNOSTIC"
 )
 
 type ClaudeCodeSDKAdapter struct {

--- a/packages/agent/daemon/runtime/claude_sdk_execution.go
+++ b/packages/agent/daemon/runtime/claude_sdk_execution.go
@@ -6,8 +6,15 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+)
+
+const (
+	claudeSDKCancelInterruptTimeout = 10 * time.Second
+	claudeSDKCancelDrainTimeout     = 8 * time.Second
+	claudeSDKCancelCompletionGrace  = 7 * time.Second
 )
 
 func (*ClaudeCodeSDKAdapter) ValidatePromptContent(_ Session, content []PromptContentBlock) error {
@@ -518,10 +525,15 @@ func (a *ClaudeCodeSDKAdapter) cancelClaudeSDKTurn(
 	} else {
 		_ = a.claudeSDKRootTurnID(adapterSession, turnID)
 	}
-	cancelCtx, cancel := context.WithTimeout(ctx, claudeSDKGoalCommandTimeout)
+	cancelCtx, cancel := context.WithTimeout(
+		ctx,
+		claudeSDKCancelInterruptTimeout+claudeSDKCancelDrainTimeout+claudeSDKCancelCompletionGrace,
+	)
 	defer cancel()
 	payload := map[string]any{
-		"agentSessionId": session.AgentSessionID,
+		"agentSessionId":     session.AgentSessionID,
+		"interruptTimeoutMs": claudeSDKCancelInterruptTimeout.Milliseconds(),
+		"drainTimeoutMs":     claudeSDKCancelDrainTimeout.Milliseconds(),
 	}
 	if turnID != "" {
 		payload["turnId"] = turnID

--- a/packages/agent/daemon/runtime/claude_sdk_goal_lifecycle_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_goal_lifecycle_test.go
@@ -184,6 +184,12 @@ func TestClaudeSDKCancelLiveTurnWaitsForProviderTerminal(t *testing.T) {
 	if payloadString(sent[0].Payload, "turnId") != "turn-live" {
 		t.Fatalf("cancel payload = %#v, want turnId=turn-live", sent[0].Payload)
 	}
+	if payloadInt64(sent[0].Payload, "interruptTimeoutMs") != claudeSDKCancelInterruptTimeout.Milliseconds() {
+		t.Fatalf("cancel payload = %#v, want interrupt timeout", sent[0].Payload)
+	}
+	if payloadInt64(sent[0].Payload, "drainTimeoutMs") != claudeSDKCancelDrainTimeout.Milliseconds() {
+		t.Fatalf("cancel payload = %#v, want drain timeout", sent[0].Payload)
+	}
 }
 
 // The controller calls adapter.Cancel(ctx, session, reason) — the third argument

--- a/packages/agent/daemon/runtime/claude_sdk_protocol.go
+++ b/packages/agent/daemon/runtime/claude_sdk_protocol.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-const claudeSDKSidecarProtocolVersion = 9
+const claudeSDKSidecarProtocolVersion = 10
 
 type claudeSDKSidecarRequest struct {
 	Version int            `json:"version"`

--- a/packages/agent/daemon/runtime/claude_sdk_transport.go
+++ b/packages/agent/daemon/runtime/claude_sdk_transport.go
@@ -268,16 +268,30 @@ func claudeSDKSidecarExitError(exitCode int, stderrTail []byte) error {
 func logClaudeSDKSidecarDebugStderr(content []byte) {
 	for _, line := range strings.Split(string(content), "\n") {
 		line = strings.TrimSpace(line)
-		if !strings.HasPrefix(line, claudeSDKAuthRefreshLogPrefix) {
-			continue
+		switch {
+		case strings.HasPrefix(line, claudeSDKAuthRefreshLogPrefix):
+			logClaudeSDKStructuredDiagnostic(
+				line,
+				claudeSDKAuthRefreshLogPrefix,
+				"agent_session.claude_sdk.auth_refresh_debug",
+			)
+		case strings.HasPrefix(line, claudeSDKCancelLogPrefix):
+			logClaudeSDKStructuredDiagnostic(
+				line,
+				claudeSDKCancelLogPrefix,
+				"agent_session.claude_sdk.cancel_diagnostic",
+			)
 		}
-		payloadJSON := strings.TrimSpace(strings.TrimPrefix(line, claudeSDKAuthRefreshLogPrefix))
-		if payloadJSON == "" {
-			payloadJSON = "{}"
-		}
-		slog.Info(claudeSDKAuthRefreshLogPrefix,
-			"event", "agent_session.claude_sdk.auth_refresh_debug",
-			"payload_json", payloadJSON,
-		)
 	}
+}
+
+func logClaudeSDKStructuredDiagnostic(line string, prefix string, event string) {
+	payloadJSON := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+	if !json.Valid([]byte(payloadJSON)) {
+		payloadJSON = `{"stage":"invalid_diagnostic_payload"}`
+	}
+	slog.Info(prefix,
+		"event", event,
+		"payload_json", payloadJSON,
+	)
 }

--- a/packages/agent/daemon/runtime/claude_sdk_transport_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_transport_test.go
@@ -1,8 +1,10 @@
 package agentruntime
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"strings"
 	"testing"
 	"time"
@@ -12,6 +14,30 @@ import (
 	"github.com/tutti-os/tutti/packages/agent/daemon/liveprotocol"
 	sessionreplay "github.com/tutti-os/tutti/packages/agent/session-replay"
 )
+
+func TestClaudeSDKCancellationDiagnosticsAreForwardedAsStructuredLogs(t *testing.T) {
+	var output bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&output, nil)))
+	t.Cleanup(func() {
+		slog.SetDefault(previousLogger)
+	})
+
+	logClaudeSDKSidecarDebugStderr([]byte(
+		"ignored stderr\n" + claudeSDKCancelLogPrefix + ` {"stage":"interrupt_timed_out","turnId":"turn-1"}` + "\n",
+	))
+
+	logged := output.String()
+	if !strings.Contains(logged, `msg=CLAUDE_CODE_CANCEL_DIAGNOSTIC`) {
+		t.Fatalf("log = %q, want cancellation prefix", logged)
+	}
+	if !strings.Contains(logged, `event=agent_session.claude_sdk.cancel_diagnostic`) {
+		t.Fatalf("log = %q, want cancellation diagnostic event", logged)
+	}
+	if !strings.Contains(logged, `interrupt_timed_out`) || !strings.Contains(logged, `turn-1`) {
+		t.Fatalf("log = %q, want structured payload", logged)
+	}
+}
 
 func TestClaudeCodeSDKAdapterExecWithSidecarTestDriver(t *testing.T) {
 	t.Setenv(claudeSDKSidecarTestDriverEnv, "1")
@@ -578,7 +604,7 @@ func TestClaudeSDKLineReaderTracksNDJSONInputUnitsAtCompletionChunk(t *testing.T
 			RecordingID:  "recording-1",
 			ConnectionID: "connection-1",
 			ChunkSeq:     4,
-			Stdout:       []byte(`{"version":9,"type":"assistant_delta","payload":{"text":"hel`),
+			Stdout:       []byte(`{"version":10,"type":"assistant_delta","payload":{"text":"hel`),
 		},
 		{
 			RecordingID:  "recording-1",
@@ -586,7 +612,7 @@ func TestClaudeSDKLineReaderTracksNDJSONInputUnitsAtCompletionChunk(t *testing.T
 			ChunkSeq:     5,
 			Stdout: []byte(
 				`lo"}}` + "\n" +
-					`{"version":9,"type":"turn_completed","payload":{"turnId":"turn-1"}}` + "\n",
+					`{"version":10,"type":"turn_completed","payload":{"turnId":"turn-1"}}` + "\n",
 			),
 		},
 	}}

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_execution_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_execution_test.go
@@ -64,6 +64,7 @@ func TestCodexAppServerAdapterExecStreamsTurn(t *testing.T) {
 	}
 	if bashCall == nil {
 		t.Fatalf("missing completed Bash tool call: %#v", callsCompleted)
+		return
 	}
 	output := payloadMap(bashCall.Payload.Metadata, "output")
 	if stdout, _ := output["stdout"].(string); stdout != "README.md\n" {

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_review_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_review_test.go
@@ -529,6 +529,7 @@ func TestCodexAppServerAdapterCompactionBannerSettlesOnInterrupt(t *testing.T) {
 	}
 	if settled == nil {
 		t.Fatalf("expected interrupted compaction banner in terminal events; got %#v", terminal)
+		return
 	}
 	if got, want := asString(settled.Payload.Metadata["messageId"]), asString(started[0].Payload.Metadata["messageId"]); got != want || got == "" {
 		t.Fatalf("interrupted banner messageId = %q, want %q", got, want)
@@ -574,6 +575,7 @@ func TestCodexAppServerAdapterCompactionBannerSettlesOnFailure(t *testing.T) {
 	}
 	if settled == nil {
 		t.Fatalf("expected failed compaction banner in terminal events; got %#v", terminal)
+		return
 	}
 	if got := asString(settled.Payload.Metadata["noticeCommandStatus"]); got != "failed" {
 		t.Fatalf("failed banner status = %q, want failed", got)

--- a/packages/agent/daemon/runtime/codex_appserver_events_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_events_test.go
@@ -680,6 +680,7 @@ func TestCodexAppServerAdapterRoutesChildFileChangeApprovalWithChildInput(t *tes
 	pending := adapter.getPendingRequest(child.agentSessionID, child.turnID, "child-approval-1")
 	if pending == nil {
 		t.Fatal("approval was not registered on canonical child")
+		return
 	}
 	changes, ok := pending.input["changes"].([]any)
 	if !ok || len(changes) != 1 || asString(payloadObject(changes[0])["path"]) != "/workspace/permission-probe.txt" {

--- a/packages/agent/daemon/runtime/codex_appserver_filechange_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_filechange_test.go
@@ -113,6 +113,7 @@ func TestAppServerFileChangeApprovalUsesStartedItemChanges(t *testing.T) {
 	}
 	if pending == nil {
 		t.Fatal("pending approval is nil")
+		return
 	}
 	if pending.approvalPurpose != approvalPurposeEditFiles {
 		t.Fatalf("pending approval purpose = %q, want %q", pending.approvalPurpose, approvalPurposeEditFiles)

--- a/packages/agent/daemon/runtime/controller_exec_async_test.go
+++ b/packages/agent/daemon/runtime/controller_exec_async_test.go
@@ -370,6 +370,7 @@ func TestControllerExecReportsTerminalTurnAsSettledAndAvailable(t *testing.T) {
 	}
 	if terminalPatch == nil {
 		t.Fatalf("reports = %#v, missing terminal turn patch", reports)
+		return
 	}
 	if terminalPatch.CurrentPhase != string(activityshared.TurnPhaseIdle) {
 		t.Fatalf("terminal patch current phase = %q, want idle", terminalPatch.CurrentPhase)

--- a/packages/agent/daemon/runtime/liveprotocol_verify_test.go
+++ b/packages/agent/daemon/runtime/liveprotocol_verify_test.go
@@ -53,6 +53,7 @@ func TestLiveProtocolResumeServerRequestReissue(t *testing.T) {
 	if pending == nil {
 		t.Logf("notifications so far:\n%s", proc1.notificationDigest())
 		t.Fatalf("no approval server-request arrived; cannot verify re-issue behavior")
+		return
 	}
 	t.Logf("pending approval request: id=%v method=%s params=%s",
 		pending.ID, pending.Method, compactJSON(pending.Params))

--- a/packages/agent/daemon/runtime/process_transport_cassette_test.go
+++ b/packages/agent/daemon/runtime/process_transport_cassette_test.go
@@ -728,8 +728,8 @@ func TestReplayProcessTransportIgnoresVolatileInitializeClientInfo(t *testing.T)
 func TestClaudeSidecarRecordingAndReplayProjectsEnvironmentAndGeneratedIdentities(t *testing.T) {
 	directory := t.TempDir()
 	base := &cassetteTestConnection{received: []ProcessFrame{
-		{Stdout: []byte(`{"version":9,"id":"request-recorded","type":"ok","payload":{"providerSessionId":"provider-recorded"}}` + "\n")},
-		{Stdout: []byte(`{"version":9,"id":"exec-recorded","type":"ok"}` + "\n")},
+		{Stdout: []byte(`{"version":10,"id":"request-recorded","type":"ok","payload":{"providerSessionId":"provider-recorded"}}` + "\n")},
+		{Stdout: []byte(`{"version":10,"id":"exec-recorded","type":"ok"}` + "\n")},
 	}}
 	recording, err := NewRecordingProcessTransport(
 		cassetteTestTransport{connection: base},
@@ -752,14 +752,14 @@ func TestClaudeSidecarRecordingAndReplayProjectsEnvironmentAndGeneratedIdentitie
 	if err != nil {
 		t.Fatal(err)
 	}
-	recordedStart := []byte(`{"version":9,"id":"request-recorded","type":"start","payload":{"agentSessionId":"session-recorded","providerSessionId":"provider-recorded","cwd":"/Users/recorded/project","env":{"ANTHROPIC_API_KEY":"secret-recorded","CLAUDE_CONFIG_DIR":"/Users/recorded/.claude","IS_SANDBOX":"1"}}}` + "\n")
+	recordedStart := []byte(`{"version":10,"id":"request-recorded","type":"start","payload":{"agentSessionId":"session-recorded","providerSessionId":"provider-recorded","cwd":"/Users/recorded/project","env":{"ANTHROPIC_API_KEY":"secret-recorded","CLAUDE_CONFIG_DIR":"/Users/recorded/.claude","IS_SANDBOX":"1"}}}` + "\n")
 	if err := connection.Send(recordedStart); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := connection.Recv(); err != nil {
 		t.Fatal(err)
 	}
-	recordedExec := []byte(`{"version":9,"id":"exec-recorded","type":"exec","payload":{"agentSessionId":"session-recorded","turnId":"turn-recorded","promptCorrelationId":"submit-recorded","prompt":"REPLAY_EXACT"}}` + "\n")
+	recordedExec := []byte(`{"version":10,"id":"exec-recorded","type":"exec","payload":{"agentSessionId":"session-recorded","turnId":"turn-recorded","promptCorrelationId":"submit-recorded","prompt":"REPLAY_EXACT"}}` + "\n")
 	if err := connection.Send(recordedExec); err != nil {
 		t.Fatal(err)
 	}
@@ -816,7 +816,7 @@ func TestClaudeSidecarRecordingAndReplayProjectsEnvironmentAndGeneratedIdentitie
 	if err != nil {
 		t.Fatal(err)
 	}
-	replayStart := []byte(`{"payload":{"env":{"ANTHROPIC_API_KEY":"different-secret","CLAUDE_CONFIG_DIR":"/isolated/.claude","IS_SANDBOX":"1"},"cwd":"/isolated/project","providerSessionId":"provider-replayed","agentSessionId":"session-replayed"},"type":"start","id":"request-replayed","version":9}` + "\n")
+	replayStart := []byte(`{"payload":{"env":{"ANTHROPIC_API_KEY":"different-secret","CLAUDE_CONFIG_DIR":"/isolated/.claude","IS_SANDBOX":"1"},"cwd":"/isolated/project","providerSessionId":"provider-replayed","agentSessionId":"session-replayed"},"type":"start","id":"request-replayed","version":10}` + "\n")
 	if err := replayed.Send(replayStart); err != nil {
 		t.Fatal(err)
 	}
@@ -828,7 +828,7 @@ func TestClaudeSidecarRecordingAndReplayProjectsEnvironmentAndGeneratedIdentitie
 		!bytes.Contains(frame.Stdout, []byte(`"providerSessionId":"provider-recorded"`)) {
 		t.Fatalf("mapped Claude start response = %s", frame.Stdout)
 	}
-	replayExec := []byte(`{"version":9,"id":"exec-replayed","type":"exec","payload":{"agentSessionId":"session-replayed","turnId":"turn-replayed","promptCorrelationId":"submit-replayed","prompt":"REPLAY_EXACT"}}` + "\n")
+	replayExec := []byte(`{"version":10,"id":"exec-replayed","type":"exec","payload":{"agentSessionId":"session-replayed","turnId":"turn-replayed","promptCorrelationId":"submit-replayed","prompt":"REPLAY_EXACT"}}` + "\n")
 	if err := replayed.Send(replayExec); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## 变更

- 为 Claude SDK cancel 路径增加统一前缀、JSON 序列化的阶段诊断日志
- 将 interrupt 请求与事件流 drain 纳入显式超时边界，取消时不再无界等待
- 在 drain 超时后关闭 SDK query iterator，并保持 Go daemon 与 TypeScript sidecar 协议同步升级
- 补充取消、协议校验、超时及 transport 测试，并更新架构与排障文档
- 修复 agent daemon 既有测试中的 nil guard，使 Go staticcheck 流水线通过

## 原因

Claude SDK 的取消流程此前会等待 interrupt 和异步事件流自然结束；当 SDK 未完成其中任一步骤时，provider shutdown 会无限阻塞，最终导致上层无法退出房间。本次将 shutdown 期限作为协议的一部分由 daemon 显式传入 sidecar，并在唯一的 query 生命周期所有者中完成超时终止。

## 风险与影响面

- Claude Code SDK sidecar 协议由 9 升级为 10，daemon 与 sidecar 必须作为同一版本 cohort 发布和消费
- 超时后会主动结束 query iterator；相关阶段、耗时和结果均通过诊断日志可观测
- 不改变其他 provider 的取消语义

## 验证

- pnpm check:changed -- --failed-only：16/16 lanes passed
- pre-push pnpm check:changed -- --push-ready：19/19 lanes passed
- git diff --check：passed

## 文档影响

已更新 Claude Code SDK runtime 架构文档、sidecar README 和 Agent Session 生命周期排障文档。