### PR TITLE
fix(connector): scope managed authorization by account

### DIFF
--- a/packages/connector/host/application.go
+++ b/packages/connector/host/application.go
@@ -315,11 +315,12 @@ func (application *Application) BeginAuthorization(
 		return AuthorizationResult{}, err
 	}
 	remote := current.Release.Manifest.Implementation.RemoteStreamableHTTP != nil
-	if remote {
-		accountID := strings.TrimSpace(mutation.AccountID)
-		if accountID == "" {
-			return AuthorizationResult{}, invalidRequest("accountId is required for remote connector authorization")
-		}
+	accountID := strings.TrimSpace(mutation.AccountID)
+	accountScoped := accountID != ""
+	if remote && !accountScoped {
+		return AuthorizationResult{}, invalidRequest("accountId is required for remote connector authorization")
+	}
+	if accountScoped {
 		projection, projectionErr := application.GetAuthorizationProjection(ctx, accountID, mutation.ConnectorKey)
 		if projectionErr != nil && !errors.Is(projectionErr, ErrNotFound) {
 			return AuthorizationResult{}, projectionErr
@@ -337,6 +338,12 @@ func (application *Application) BeginAuthorization(
 		OperationKindStartAuthorization,
 		func(connector Connector) (Connector, error) {
 			if remote {
+				return connector, nil
+			}
+			// Account-scoped authorization may reuse an already connected local
+			// credential broker. Keep device truth intact while the provider binds
+			// that credential to the current account projection.
+			if accountScoped && connector.Authorization.State == AuthorizationStateConnected {
 				return connector, nil
 			}
 			if !CanTransitionAuthorization(connector.Authorization.State, AuthorizationStatePending) {
@@ -377,8 +384,8 @@ func (application *Application) BeginAuthorization(
 	if err != nil {
 		return AuthorizationResult{}, err
 	}
-	if remote {
-		projection, projectionErr := application.GetAuthorizationProjection(ctx, mutation.AccountID, mutation.ConnectorKey)
+	if accountScoped {
+		projection, projectionErr := application.GetAuthorizationProjection(ctx, accountID, mutation.ConnectorKey)
 		if errors.Is(projectionErr, ErrNotFound) {
 			connector.Authorization = Authorization{State: AuthorizationStateDisconnected}
 		} else if projectionErr != nil {

--- a/packages/connector/host/application_execution.go
+++ b/packages/connector/host/application_execution.go
@@ -309,16 +309,18 @@ func (application *Application) beginAuthorizationSession(
 		return AuthorizationSession{}, invalidOperationReceipt("authorization provider returned an invalid session")
 	}
 	remote := release.Manifest.Implementation.RemoteStreamableHTTP != nil
+	accountScoped := strings.TrimSpace(operation.Scope.AccountID) != ""
 	if session.State == AuthorizationStateConnected && !remote {
 		session.Resolution = AuthorizationSessionResolutionProviderConnected
 	} else {
 		session.Resolution = AuthorizationSessionResolutionUnresolved
 	}
-	if err := application.completeAuthorizationStart(ctx, operation.OperationID, session, !remote); err != nil {
+	projectDeviceState := !remote && (!accountScoped || connector.Authorization.State != AuthorizationStateConnected)
+	if err := application.completeAuthorizationStart(ctx, operation.OperationID, session, projectDeviceState); err != nil {
 		return AuthorizationSession{}, err
 	}
-	if session.State == AuthorizationStateConnected {
-		if err := application.projectAuthorizationAndScheduleRuntime(ctx, operation.Scope, operation.ConnectorKey, session.ConnectionID, AuthorizationStateConnected, ""); err != nil {
+	if session.State == AuthorizationStateConnected || (!remote && accountScoped) {
+		if err := application.projectAuthorizationAndScheduleRuntime(ctx, operation.Scope, operation.ConnectorKey, session.ConnectionID, session.State, ""); err != nil {
 			return AuthorizationSession{}, err
 		}
 	}

--- a/packages/connector/host/application_test.go
+++ b/packages/connector/host/application_test.go
@@ -556,6 +556,57 @@ func TestApplicationRemoteAuthorizationStartUsesAccountProjectionInsteadOfDevice
 	}
 }
 
+func TestApplicationManagedAuthorizationStartRepairsMissingAccountProjection(t *testing.T) {
+	connector := testManagedAuthorizedConnector("lark-cli")
+	// This device state predates account-scoped authorization projections.
+	connector.Authorization = Authorization{State: AuthorizationStateConnected}
+	repository := newMemoryRepository(connector)
+	projections := &recordingAuthorizationProjectionStore{}
+	application := newTestApplication(t, repository, &memoryScheduler{}, &memoryInstallRuntime{}, CatalogSnapshot{})
+	application.config.Authorization = connectedAuthorizationProviderStub{}
+	application.config.AuthorizationProjections = projections
+
+	result, err := application.BeginAuthorization(context.Background(), ConnectorMutation{
+		Mutation:     Mutation{ClientRequestID: "authorization-bind-existing-login"},
+		ConnectorKey: connector.Key, AccountID: "account-1",
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Connector.Authorization.State != AuthorizationStateConnected ||
+		projections.projection.State != AuthorizationStateConnected ||
+		projections.projection.AccountID != "account-1" {
+		t.Fatalf("result=%#v projection=%#v", result, projections.projection)
+	}
+	if repository.connectors[connector.Key].Authorization.State != AuthorizationStateConnected {
+		t.Fatalf("device authorization = %#v", repository.connectors[connector.Key].Authorization)
+	}
+}
+
+func TestApplicationManagedAuthorizationStartCanChallengeAnotherAccount(t *testing.T) {
+	connector := testManagedAuthorizedConnector("lark-cli")
+	connector.Authorization = Authorization{State: AuthorizationStateConnected}
+	repository := newMemoryRepository(connector)
+	projections := &recordingAuthorizationProjectionStore{}
+	application := newTestApplication(t, repository, &memoryScheduler{}, &memoryInstallRuntime{}, CatalogSnapshot{})
+	application.config.AuthorizationProjections = projections
+
+	result, err := application.BeginAuthorization(context.Background(), ConnectorMutation{
+		Mutation:     Mutation{ClientRequestID: "authorization-select-account"},
+		ConnectorKey: connector.Key, AccountID: "account-2",
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.AuthorizationURL == "" || result.Connector.Authorization.State != AuthorizationStatePending ||
+		projections.projection.State != AuthorizationStatePending {
+		t.Fatalf("result=%#v projection=%#v", result, projections.projection)
+	}
+	if repository.connectors[connector.Key].Authorization.State != AuthorizationStateConnected {
+		t.Fatalf("device authorization = %#v", repository.connectors[connector.Key].Authorization)
+	}
+}
+
 func TestApplicationConnectedProjectionConvergesReceiptWithoutProviderPolling(t *testing.T) {
 	connector := testConnector("tencent-docs")
 	connector.Release.Manifest.AuthorizationKind = "oauth2"
@@ -1136,6 +1187,21 @@ func testConnector(key string) Connector {
 	}
 }
 
+func testManagedAuthorizedConnector(key string) Connector {
+	connector := testConnector(key)
+	connector.Release.Manifest.AuthorizationKind = "oauth2"
+	connector.Release.Manifest.RequiredCapabilities = []string{"tools"}
+	connector.Release.Manifest.Implementation.ManagedStdio.Runtime.VersionRange = ">=20.0.0 <21.0.0"
+	connector.Release.Manifest.Implementation.ManagedStdio.CLI = &ManagedCLIInterface{Entrypoint: "bin/lark-cli", TimeoutMS: 120_000}
+	connector.Release.Manifest.Implementation.ManagedStdio.CredentialBroker = &ManagedCredentialBroker{
+		Protocol: CredentialBrokerProtocolV1, Entrypoint: "authorization/broker.mjs", TimeoutMS: 30_000,
+		AllowedHosts: []string{"open.larksuite.com"},
+	}
+	connector.Installation = Installation{State: InstallationStateInstalled, InstalledVersion: connector.Release.Version,
+		InstalledReleaseID: connector.Release.ReleaseID, InstalledReleaseDigest: connector.Release.ReleaseDigest}
+	return connector
+}
+
 func testReleaseWithImplementation(key, version, implementationKind string) Release {
 	implementation := Implementation{Kind: implementationKind, Builtin: &BuiltinImplementation{ProviderID: key, MCP: true}}
 	if implementationKind == "mcp_stdio" || implementationKind == ImplementationKindManagedStdio {
@@ -1447,6 +1513,20 @@ func (authorizationProviderStub) Begin(_ context.Context, request AuthorizationS
 
 func (authorizationProviderStub) Disconnect(context.Context, AuthorizationDisconnectRequest) error {
 	return nil
+}
+
+type connectedAuthorizationProviderStub struct {
+	authorizationProviderStub
+}
+
+func (connectedAuthorizationProviderStub) Begin(_ context.Context, request AuthorizationStartRequest) (AuthorizationSession, error) {
+	return AuthorizationSession{
+		OperationID:  request.OperationID,
+		ConnectorKey: request.Connector.Key,
+		SessionID:    "session-connected",
+		ConnectionID: "existing-cli-login",
+		State:        AuthorizationStateConnected,
+	}, nil
 }
 
 type countingAuthorizationProvider struct {

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -49,7 +49,7 @@ import (
 )
 
 const connectorMarketDefaultBaseURL = "https://api.tutti.sh/api/desktop"
-const connectorMCPDefaultBaseURL = "https://api.tutti.sh/api/desktop"
+const connectorMCPDefaultBaseURL = "https://tutti.sh/api/desktop"
 const connectorArtifactBaseURL = "https://d27a59zdy4534h.cloudfront.net/tutti/connector-market/"
 
 type tuttiWiring struct {

--- a/services/tuttid/wiring_connector_market_test.go
+++ b/services/tuttid/wiring_connector_market_test.go
@@ -12,7 +12,7 @@ func TestConnectorMarketDefaultUsesDesktopGateway(t *testing.T) {
 }
 
 func TestConnectorMCPDefaultUsesDesktopGateway(t *testing.T) {
-	const expected = "https://api.tutti.sh/api/desktop"
+	const expected = "https://tutti.sh/api/desktop"
 	if connectorMCPDefaultBaseURL != expected {
 		t.Fatalf("connector MCP base URL = %q, want %q", connectorMCPDefaultBaseURL, expected)
 	}


### PR DESCRIPTION
## Summary
- gate managed connector authorization starts with the current account projection instead of stale device state
- preserve an already connected local credential broker while binding or challenging another account
- persist managed pending/connected authorization results into the account projection used by the UI and runtime
- route remote Connector MCP traffic through the canonical https://tutti.sh/api/desktop gateway while leaving the connector market gateway unchanged

## Root cause
The connector list overlays account-scoped authorization projections, but managed authorization start still validated the device-scoped connector state. Existing users could therefore see disconnected when their account projection was missing while the operation rejected connected to pending with HTTP 409.

The desktop MCP client also defaulted to https://api.tutti.sh/api/desktop, while the canonical product gateway is https://tutti.sh/api/desktop. The client appends /mcp/connectors/{connectorKey} to this base URL.

## Verification
- go test ./packages/connector/host ./packages/connector/runtime/implementationhost ./services/tuttid/api -count=1
- go test ./services/tuttid -run TestConnectorMarketDefaultUsesDesktopGateway\|TestConnectorMCPDefaultUsesDesktopGateway -count=1
- go test ./services/tuttid/service/connectormarket -count=1
- pnpm check:changed
- pnpm check:changed -- --push-ready