### PR TITLE
fix(runtime): publish Windows Python baseline

### DIFF
--- a/config/tutti.app-runtime.lock.json
+++ b/config/tutti.app-runtime.lock.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "tutti.app.runtime-lock.v1",
-  "runtimeVersion": "2026.07.0",
+  "runtimeVersion": "2026.07.1",
   "uv": {
     "version": "0.11.19"
   },
@@ -10,7 +10,7 @@
     "sourceSha256": "0816c4761c97ecdb3f50a3924de0a93fd78cb63ee8e6c04201ddfaedca500b0b",
     "windows": {
       "archiveUrl": "https://github.com/astral-sh/python-build-standalone/releases/download/20260728/cpython-3.12.13%2B20260728-x86_64-pc-windows-msvc-install_only.tar.gz",
-      "archiveSha256": "86617be5b7f23e36263e1a6b3f27d8a0cd6e0eb2293f06b690de531720d9f59b",
+      "archiveSha256": "8a0e1ded37e11f4c72b9671bf134bb478b1b2d55efe53a3d6e589b166f1bf2e1",
       "archiveRoot": "python"
     }
   },


### PR DESCRIPTION
## 变更内容

- 将 Workspace App runtime 版本从 `2026.07.0` 提升到 `2026.07.1`
- 将 Windows Python 3.12.13 relocatable archive 的 SHA-256 更新为 GitHub immutable release API 公布的摘要

## 根因

生产 runtime catalog 的 `windows-amd64` 仍是 Node-only baseline，导致 Automation 启动时 `TUTTI_APP_PYTHON` 为空并以状态 1 退出。Windows Python 打包逻辑已经存在，但旧 runtime 版本尚未重新发布；同时锁文件中的 Windows Python archive SHA-256 与上游 immutable release 资产不一致，会使发布 workflow 在校验阶段失败。

## 用户影响

合入并运行 `Publish Tutti App Runtime` 后，生产 catalog 会为 `windows-amd64` 发布 Python + Node baseline，现有 Python Workspace Apps 可在 Windows 上获得 `TUTTI_APP_PYTHON` 并正常启动。新 patch 版本避免覆盖旧的不可变 artifact URL。

## 验证

- `node --test ./tools/scripts/build-tutti-app-runtime-catalog.test.mjs`（3/3 通过）
- `pnpm check:changed -- --failed-only`（2/2 lanes 通过）
- 下载目标 archive 并核对本地 SHA-256、文件大小与 GitHub release API digest 一致
- 使用该 Python runtime 隔离启动 Automation，`/healthz` 返回 HTTP 200 / `ok`

## 文档影响

现有 `docs/conventions/workspace-app-runtime.md` 已描述 Windows Python + Node baseline、版本递增和独立发布流程，无需新增文档。
