### PR TITLE
feat(agent-gui): project standalone agent target presentations

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1601,6 +1601,16 @@ reply content.
 This presentation input is view data only and must not enter canonical Session,
 Turn, Message, activity-runtime, or workspace-engine state.
 
+Standalone hosts rendering `AgentConversationFlow` may also pass the current
+Agent target presentation catalog through the `agent-conversation` entrypoint.
+The flow scopes that catalog to all historical rich-text rows, so `agent-target`
+and `agent-session` mentions use the same provider icon and identity
+presentation as the full AgentGUI node without copying the catalog into
+canonical activity data. Omitting the catalog preserves an inherited AgentGUI
+presentation context. The standalone flow also owns its visibility-aware
+conversation clock, so a hidden host does not keep elapsed-time presentation
+timers active.
+
 ## 5. Agent identity and provider architecture
 
 ### 5.1 `agentTargetId` is UI identity

--- a/packages/agent/gui/agent-conversation/index.ts
+++ b/packages/agent/gui/agent-conversation/index.ts
@@ -32,6 +32,7 @@ export type {
 } from "../shared/workspaceAgentSessionDetailViewModel";
 
 export type { AgentConversationVM } from "../shared/agentConversation/contracts/agentConversationVM";
+export type { AgentMessageMarkdownAgentTarget as AgentConversationAgentTargetPresentation } from "../shared/AgentTargetPresentationContext";
 export type {
   AgentConversationParticipantIdentity,
   AgentConversationParticipantPresentation

--- a/packages/agent/gui/shared/WorkspaceAgentSessionDetail.tsx
+++ b/packages/agent/gui/shared/WorkspaceAgentSessionDetail.tsx
@@ -1,6 +1,7 @@
 import { useMemo, type JSX } from "react";
 import type { WorkspaceLinkAction } from "../contexts/workspace/presentation/renderer/actions/workspaceLinkActions";
 import { translate } from "../i18n/index";
+import type { AgentMessageMarkdownAgentTarget } from "./AgentTargetPresentationContext";
 import { AgentConversationFlow } from "./agentConversation/components/AgentConversationFlow";
 import type { AgentConversationParticipantPresentation } from "./agentConversation/contracts/agentConversationParticipantPresentation";
 import { useProjectedAgentConversation } from "./agentConversation/projection/useProjectedAgentConversation";
@@ -11,6 +12,7 @@ export interface WorkspaceAgentSessionDetailProps {
   avoidGroupingEdits?: boolean;
   isLoading: boolean;
   timelineItemCount: number;
+  agentTargets?: readonly AgentMessageMarkdownAgentTarget[];
   onLinkAction?: (action: WorkspaceLinkAction) => void;
   toolCallsLabel: (count: number) => string;
   thinkingLabel?: string;
@@ -25,6 +27,7 @@ export function WorkspaceAgentSessionDetail({
   avoidGroupingEdits = false,
   isLoading,
   timelineItemCount,
+  agentTargets,
   onLinkAction,
   toolCallsLabel,
   thinkingLabel = translate("agentHost.workspaceAgentSessionDetailThinking"),
@@ -70,6 +73,7 @@ export function WorkspaceAgentSessionDetail({
     <div className="workspace-agents-status-panel__detail">
       <AgentConversationFlow
         conversation={detail.turns.length > 0 ? conversation : null}
+        agentTargets={agentTargets}
         isLoading={showLoadingSkeleton}
         loadingLabel={loadingLabel}
         empty={emptyState}

--- a/packages/agent/gui/shared/agentConversation/components/AgentConversationFlow.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentConversationFlow.tsx
@@ -1,6 +1,10 @@
 import { memo, type ReactNode, type JSX, type Ref } from "react";
 import type { WorkspaceLinkAction } from "../../../contexts/workspace/presentation/renderer/actions/workspaceLinkActions";
 import type { AgentMessageMarkdownWorkspaceAppIcon } from "../../AgentMessageMarkdown";
+import {
+  AgentTargetPresentationProvider,
+  type AgentMessageMarkdownAgentTarget
+} from "../../AgentTargetPresentationContext";
 import type { AgentConversationVM } from "../contracts/agentConversationVM";
 import type { AgentConversationParticipantPresentation } from "../contracts/agentConversationParticipantPresentation";
 import type { AgentConversationFollowEndMode } from "../agentConversationFollowEndController";
@@ -12,6 +16,7 @@ import {
   type AgentTranscriptVirtualScrollController
 } from "./AgentTranscriptView";
 import type { AgentTranscriptEditRetryControl } from "./useAgentTranscriptEditRetryProjection";
+import { AgentConversationClockProvider } from "./AgentConversationClock";
 import { AgentTurnDisclosureProvider } from "./AgentTurnDisclosureContext";
 import type { AgentGUIProviderSkillOption } from "../../../agent-gui/agentGuiNode/model/agentGuiNodeTypes";
 
@@ -33,6 +38,7 @@ export interface AgentConversationFlowProps {
   onAuthLogin?: (provider?: string | null) => void;
   onForkThroughTurn?: (turnId: string) => void;
   availableSkills?: readonly AgentGUIProviderSkillOption[];
+  agentTargets?: readonly AgentMessageMarkdownAgentTarget[];
   workspaceAppIcons?: readonly AgentMessageMarkdownWorkspaceAppIcon[];
   showRawTimelineJson?: boolean;
   participantPresentation?: AgentConversationParticipantPresentation;
@@ -65,6 +71,7 @@ export const AgentConversationFlow = memo(function AgentConversationFlow({
   onAuthLogin,
   onForkThroughTurn,
   availableSkills,
+  agentTargets,
   workspaceAppIcons,
   showRawTimelineJson = false,
   participantPresentation,
@@ -111,5 +118,20 @@ export const AgentConversationFlow = memo(function AgentConversationFlow({
     );
   }
 
-  return <AgentTurnDisclosureProvider>{content}</AgentTurnDisclosureProvider>;
+  const disclosedContent = (
+    <AgentTurnDisclosureProvider>{content}</AgentTurnDisclosureProvider>
+  );
+  const presentedContent =
+    agentTargets === undefined ? (
+      disclosedContent
+    ) : (
+      <AgentTargetPresentationProvider agentTargets={agentTargets}>
+        {disclosedContent}
+      </AgentTargetPresentationProvider>
+    );
+  return (
+    <AgentConversationClockProvider isVisible={isVisible}>
+      {presentedContent}
+    </AgentConversationClockProvider>
+  );
 });

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
@@ -13,6 +13,7 @@ import {
   AgentTranscriptView,
   areAgentTranscriptViewPropsEqual
 } from "./AgentTranscriptView";
+import { AgentConversationFlow } from "./AgentConversationFlow";
 import { AgentObservationGapSourceProvider } from "../AgentObservationGapContext";
 import { AgentTurnDisclosureProvider } from "./AgentTurnDisclosureContext";
 import { projectAgentConversationVM } from "../projection/agentConversationProjection";
@@ -30,6 +31,53 @@ vi.mock("../../../i18n/index", async (importOriginal) => {
 });
 
 describe("AgentTranscriptView", () => {
+  it("uses standalone Agent target presentations for session mention icons", () => {
+    const mention =
+      "[@Jun Sun's Tutti Agent](mention://agent-session/session-source?agentTargetId=shared-agent%3Ajun-tutti&workspaceId=workspace-1) what is this";
+    const base = detailViewModel();
+    const conversation = projectAgentConversationVM(
+      detailViewModel({
+        turns: [
+          {
+            ...base.turns[0]!,
+            userMessage: { id: "user-1", body: mention },
+            userMessages: [{ id: "user-1", body: mention }]
+          }
+        ]
+      })
+    );
+
+    const { container } = render(
+      <AgentConversationFlow
+        agentTargets={[
+          {
+            agentTargetId: "shared-agent:jun-tutti",
+            iconUrl: "https://example.test/tutti-agent.png",
+            name: "Jun Sun's Tutti Agent",
+            provider: "tutti-agent",
+            workspaceId: "workspace-1"
+          }
+        ]}
+        conversation={conversation}
+        empty={null}
+        isLoading={false}
+        loadingLabel="Loading"
+        labels={{
+          thinkingLabel: "Thought process",
+          toolCallsLabel: (count) => `Tool calls (${count})`,
+          processing: "Planning next moves",
+          turnSummary: "Changed files"
+        }}
+      />
+    );
+
+    expect(
+      container
+        .querySelector('[data-agent-mention-kind="session"]')
+        ?.querySelector("img")
+    ).toHaveAttribute("src", "https://example.test/tutti-agent.png");
+  });
+
   it("shows through-turn fork for a supported provider-bound Turn and passes its exact id", () => {
     const onForkThroughTurn = vi.fn();
     const settledTurn = canonicalTurn({


### PR DESCRIPTION
## 概要

- 为独立 `AgentConversationFlow` 增加可选的 Agent Target presentation 目录输入。
- 将目录限定在 conversation flow 内，让历史 `agent-session` / `agent-target` mention 使用宿主提供的名称和图标。
- `WorkspaceAgentSessionDetail` 可继续转发该目录，Activity Center 等独立宿主无需复制 presentation 到 canonical activity 数据。
- 独立 flow 同时挂载 visibility-aware conversation clock，隐藏时不继续运行展示计时器。
- 增加独立 conversation flow 的 session mention 图标回归测试。

## 原因

完整 AgentGUI 已有 Agent Target presentation context，但独立渲染的 conversation flow 没有公开注入入口，导致 Activity Center 等宿主无法给历史 mention 提供一致的 Agent 展示信息。

## 风险与范围

- 只增加可选的视图层输入。
- 未修改 Session、Turn、Message、activity runtime 或 workspace engine 的 canonical state。
- 未提供目录时继续继承外层 AgentGUI context。

## 验证

- AgentGUI 聚焦测试通过。
- PR 合并前 GitHub checks 13/13 通过。