### PR TITLE
fix(connector): count only connector skills

### DIFF
--- a/packages/connector/runtime/artifact/skills.go
+++ b/packages/connector/runtime/artifact/skills.go
@@ -14,7 +14,7 @@ import (
 const (
 	connectorSkillEntryName    = "SKILL.md"
 	connectorSkillMaxDepth     = 8
-	connectorSkillMaxEntries   = 128
+	connectorSkillMaxCount     = 128
 	connectorSkillMaxEntrySize = 512 * 1024
 )
 
@@ -55,17 +55,13 @@ func InspectSkills(installedRoot string) (SkillProjection, error) {
 
 	skills := make([]SkillSummary, 0)
 	seen := make(map[string]struct{})
-	entryCount := 0
+	skillCount := 0
 	err = filepath.WalkDir(skillRoot, func(path string, entry os.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
 		if path == skillRoot {
 			return nil
-		}
-		entryCount++
-		if entryCount > connectorSkillMaxEntries {
-			return fmt.Errorf("connector Skill tree entry count exceeds %d", connectorSkillMaxEntries)
 		}
 		relative, err := filepath.Rel(skillRoot, path)
 		if err != nil {
@@ -80,6 +76,10 @@ func InspectSkills(installedRoot string) (SkillProjection, error) {
 		}
 		if entry.IsDir() || entry.Name() != connectorSkillEntryName {
 			return nil
+		}
+		skillCount++
+		if skillCount > connectorSkillMaxCount {
+			return fmt.Errorf("connector Skill count exceeds %d", connectorSkillMaxCount)
 		}
 		entryInfo, err := entry.Info()
 		if err != nil {

--- a/packages/connector/runtime/artifact/skills_test.go
+++ b/packages/connector/runtime/artifact/skills_test.go
@@ -54,14 +54,31 @@ func TestInspectSkillsRejectsSymlink(t *testing.T) {
 	}
 }
 
-func TestInspectSkillsBoundsTheCompleteTree(t *testing.T) {
+func TestInspectSkillsDoesNotCountSupportingTreeEntriesAsSkills(t *testing.T) {
 	root := t.TempDir()
-	for index := 0; index <= connectorSkillMaxEntries; index++ {
-		if err := os.MkdirAll(filepath.Join(root, "skills", "empty-"+fmt.Sprint(index)), 0o700); err != nil {
+	writeSkillTestFile(t, filepath.Join(root, "skills", "calendar", "SKILL.md"), "calendar", "Calendar")
+	for index := 0; index <= connectorSkillMaxCount; index++ {
+		path := filepath.Join(root, "skills", "calendar", "references", fmt.Sprintf("reference-%d.md", index))
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("supporting reference"), 0o600); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if _, err := InspectSkills(root); err == nil || !strings.Contains(err.Error(), "tree entry count exceeds") {
+	projection, err := InspectSkills(root)
+	if err != nil || len(projection.Skills) != 1 || projection.Skills[0].Name != "calendar" {
+		t.Fatalf("projection = %#v, error = %v", projection, err)
+	}
+}
+
+func TestInspectSkillsBoundsSkillCount(t *testing.T) {
+	root := t.TempDir()
+	for index := 0; index <= connectorSkillMaxCount; index++ {
+		name := fmt.Sprintf("skill-%d", index)
+		writeSkillTestFile(t, filepath.Join(root, "skills", name, "SKILL.md"), name, name)
+	}
+	if _, err := InspectSkills(root); err == nil || !strings.Contains(err.Error(), "Skill count exceeds") {
 		t.Fatalf("error = %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- count only `SKILL.md` entries toward the connector Skill limit
- exclude supporting directories and files such as `references`, `assets`, and `scripts`
- retain depth, symlink, regular-file, and per-Skill size validation
- cover both supporting-tree and actual Skill-count boundaries

## Verification

- `go test ./packages/connector/runtime/artifact ./packages/connector/runtime/implementationhost -count=1`
- `pnpm check:changed -- --failed-only`
- push hook: `pnpm check:changed -- --push-ready`
- `git diff --check`

## Checklist

- [x] I kept the change focused on one concern.
- [x] Documentation changes are not required for this internal validation correction.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commit is signed off with DCO.