### PR TITLE
fix(agent-gui): preserve queued optimistic prompt ordering

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -763,6 +763,11 @@ A durable message has two independent ordering values:
 - `version`: per-session mutable change cursor used for incremental updates and gap detection
 
 Lifecycle timestamps describe occurrence time; they do not replace durable sequence. A live message with unknown Turn ownership must be completed or rejected at the boundary, never assigned an owner in GUI.
+Optimistic prompt and Goal-control echoes occupy a separate overlay ordering
+domain. They remain after all currently durable messages until canonical
+confirmation replaces them; their earlier submission timestamps must not move
+them back through durable transcript history during message projection or
+timeline merging.
 
 Neither value is a history-coverage signal. A newest-to-oldest message read
 projects an explicit Session message window into the frontend engine:

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIActiveMessages.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIActiveMessages.spec.tsx
@@ -1,6 +1,8 @@
 import { renderHook } from "@testing-library/react";
 import type {
   AgentActivityMessage,
+  EngineQueuedPrompt,
+  PendingSubmitIntentRecord,
   PendingActivationIntentRecord
 } from "@tutti-os/agent-activity-core";
 import { describe, expect, it } from "vitest";
@@ -50,6 +52,89 @@ describe("useAgentGUIActiveMessages", () => {
       clientSubmitId: "initial-submit"
     });
   });
+
+  it("keeps a dequeued optimistic image prompt after the durable assistant response", () => {
+    const durableUserMessage = message("user-a", "submit-a", {
+      occurredAtUnixMs: 100,
+      sequence: 1,
+      turnId: "turn-a"
+    });
+    const durableAssistantMessage = message("assistant-a", "", {
+      occurredAtUnixMs: 300,
+      payload: { text: "Assistant A" },
+      role: "assistant",
+      sequence: 2,
+      turnId: "turn-a",
+      version: 2
+    });
+    const pendingImageSubmit = pendingSubmit();
+    const queuedImageSubmit = queuedPrompt();
+    const { result, rerender } = renderHook(
+      ({
+        activeQueuedPrompts,
+        storedMessages
+      }: {
+        activeQueuedPrompts: readonly EngineQueuedPrompt[];
+        storedMessages: readonly AgentActivityMessage[];
+      }) =>
+        useAgentGUIActiveMessages({
+          activeConversationId: "session-1",
+          activePendingActivation: null,
+          activePendingSubmits: [pendingImageSubmit],
+          activeQueuedPrompts,
+          currentUserId: "user-1",
+          storedMessages,
+          workspaceId: "workspace-1"
+        }),
+      {
+        initialProps: {
+          activeQueuedPrompts: [queuedImageSubmit],
+          storedMessages: [durableUserMessage, durableAssistantMessage]
+        }
+      }
+    );
+
+    expect(timelineEventIds(result.current.activeTimelineItems)).toEqual([
+      "user-a",
+      "assistant-a"
+    ]);
+
+    rerender({
+      activeQueuedPrompts: [],
+      storedMessages: [durableUserMessage, durableAssistantMessage]
+    });
+
+    expect(timelineEventIds(result.current.activeTimelineItems)).toEqual([
+      "user-a",
+      "assistant-a",
+      "client-submit:user:submit-b"
+    ]);
+
+    rerender({
+      activeQueuedPrompts: [],
+      storedMessages: [
+        durableUserMessage,
+        durableAssistantMessage,
+        message("client-submit:user:submit-b", "submit-b", {
+          occurredAtUnixMs: 400,
+          payload: {
+            clientSubmitId: "submit-b",
+            content: pendingImageSubmit.content,
+            text: "[Image]"
+          },
+          sequence: 3,
+          turnId: "turn-b",
+          version: 3
+        })
+      ]
+    });
+
+    expect(timelineEventIds(result.current.activeTimelineItems)).toEqual([
+      "user-a",
+      "assistant-a",
+      "client-submit:user:submit-b"
+    ]);
+  });
 });
 
 function activation(
@@ -78,7 +163,8 @@ function activation(
 
 function message(
   messageId: string,
-  clientSubmitId: string
+  clientSubmitId: string,
+  patch: Partial<AgentActivityMessage> = {}
 ): AgentActivityMessage {
   return {
     agentSessionId: "session-1",
@@ -89,6 +175,46 @@ function message(
     role: "user",
     turnId: "replacement-turn",
     version: 1,
+    workspaceId: "workspace-1",
+    ...patch
+  };
+}
+
+function pendingSubmit(): PendingSubmitIntentRecord {
+  return {
+    acceptedSessionVersion: null,
+    agentSessionId: "session-1",
+    clientSubmitId: "submit-b",
+    content: [
+      {
+        type: "image",
+        data: "aW1hZ2UtYQ==",
+        mimeType: "image/png",
+        name: "image-a.png"
+      }
+    ],
+    errorCode: null,
+    errorMessage: null,
+    expiresAtUnixMs: 120_000,
+    requestedAtUnixMs: 200,
+    status: "requested",
+    turnId: null,
     workspaceId: "workspace-1"
   };
+}
+
+function queuedPrompt(): EngineQueuedPrompt {
+  const pending = pendingSubmit();
+  return {
+    clientSubmitId: pending.clientSubmitId,
+    content: pending.content,
+    createdAtUnixMs: pending.requestedAtUnixMs,
+    id: "queued-b"
+  };
+}
+
+function timelineEventIds(
+  items: ReturnType<typeof useAgentGUIActiveMessages>["activeTimelineItems"]
+): string[] {
+  return items.map((item) => item.eventId);
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiTimelineMerge.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiTimelineMerge.ts
@@ -207,6 +207,11 @@ export function compareTimelineItemsForMerge(
   left: WorkspaceAgentActivityTimelineItem,
   right: WorkspaceAgentActivityTimelineItem
 ): number {
+  const leftOptimistic = isOptimisticUserPromptItem(left);
+  const rightOptimistic = isOptimisticUserPromptItem(right);
+  if (leftOptimistic !== rightOptimistic) {
+    return leftOptimistic ? 1 : -1;
+  }
   const leftSeq = left.seq ?? 0;
   const rightSeq = right.seq ?? 0;
   return (

--- a/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.spec.ts
@@ -412,6 +412,55 @@ describe("projectWorkspaceAgentMessagesToConversationVM", () => {
     ).toEqual(["assistant:I will start the agents.", "tool:Agent"]);
   });
 
+  it("keeps an optimistic prompt after durable messages with later timestamps", () => {
+    const durableAssistant = message({
+      messageId: "assistant-a",
+      occurredAtUnixMs: 300,
+      payload: { text: "Assistant A" },
+      role: "assistant",
+      sequence: 2,
+      turnId: "turn-a",
+      version: 2
+    });
+    const optimisticImagePrompt = message({
+      messageId: "client-submit:user:submit-b",
+      occurredAtUnixMs: 200,
+      payload: {
+        __agentGuiOptimisticPrompt: true,
+        clientSubmitId: "submit-b",
+        content: [
+          {
+            type: "image",
+            data: "aW1hZ2UtYQ==",
+            mimeType: "image/png",
+            name: "image-a.png"
+          }
+        ],
+        text: "[Image]"
+      },
+      role: "user",
+      startedAtUnixMs: 200,
+      turnId: "pending:submit-b",
+      version: 0
+    });
+    const mergedMessages = mergeWorkspaceAgentActivityDurableAndOverlayMessages(
+      {
+        durableMessages: [durableAssistant],
+        localMessages: [optimisticImagePrompt]
+      }
+    );
+
+    expect(mergedMessages.map((item) => item.messageId)).toEqual([
+      "assistant-a",
+      "client-submit:user:submit-b"
+    ]);
+    expect(
+      projectWorkspaceAgentMessagesToTimelineItems(mergedMessages).map(
+        (item) => item.eventId
+      )
+    ).toEqual(["assistant-a", "client-submit:user:submit-b"]);
+  });
+
   it("projects text, reasoning, errors, and unknown kinds conservatively", () => {
     const conversation = projectWorkspaceAgentMessagesToConversationVM({
       activity: activity(),

--- a/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.ts
@@ -3,6 +3,7 @@ import type {
   AgentActivitySnapshot,
   AgentActivityTurn
 } from "@tutti-os/agent-activity-core";
+import { isWorkspaceAgentActivityOptimisticMessage } from "../../workspaceAgentMessageOverlay";
 import { buildWorkspaceAgentActivityListViewModel } from "../../workspaceAgentActivityListViewModel";
 import type { BuildWorkspaceAgentSessionDetailInput } from "../../workspaceAgentSessionDetailViewModel";
 import { buildCanonicalWorkspaceAgentDetailView } from "../../workspaceAgentTimelineCanonical";
@@ -480,6 +481,11 @@ function compareMessagesByDisplayOrder(
   left: AgentActivityMessage,
   right: AgentActivityMessage
 ): number {
+  const leftOptimistic = isWorkspaceAgentActivityOptimisticMessage(left);
+  const rightOptimistic = isWorkspaceAgentActivityOptimisticMessage(right);
+  if (leftOptimistic !== rightOptimistic) {
+    return leftOptimistic ? 1 : -1;
+  }
   // Durable sequence is assigned once when the message is first stored and is
   // not changed by later streaming snapshots. Timestamps are compatibility
   // fallbacks for messages produced by older runtimes.


### PR DESCRIPTION
## Summary

- 保证当前持久化消息始终排在尚未确认的乐观 Prompt 和 Goal Control 消息之前
- 在消息投影与 Timeline 二次合并两个排序边界统一该规则
- 覆盖图片 Prompt 从排队、出队乐观显示到持久化确认的完整状态转换
- 更新 AgentGUI 消息排序架构说明

## Tests

- `pnpm check:changed -- --push-ready`
- `pnpm --filter @tutti-os/agent-gui exec vitest run agent-gui/agentGuiNode/controller/useAgentGUIActiveMessages.spec.tsx shared/agentConversation/projection/workspaceAgentMessageProjection.spec.ts`
- `pnpm --filter @tutti-os/agent-gui test -- useAgentGUIActiveMessages.spec.tsx`

## Notes

- 不改变持久化消息内部的 sequence 顺序，也不改变普通 streaming 消息的时间排序
- 未运行 GUI E2E；本次变更由纯投影和状态转换测试覆盖
