### PR TITLE
chore(agent): add Claude turn identity diagnostics

### DIFF
--- a/packages/agent/claude-sdk-sidecar/README.md
+++ b/packages/agent/claude-sdk-sidecar/README.md
@@ -90,6 +90,10 @@ approval, user-input, and result projection. It uses the official
 by the opaque correlation UUID, with a bounded cancellable retry window for
 transcript persistence lag.
 
+Fallback and pre-identity Query terminals emit sanitized stderr records with
+the `CLAUDE_CODE_PROVIDER_TURN_DIAGNOSTIC` prefix. The daemon forwards them as
+`agent_session.claude_sdk.provider_turn_diagnostic` structured logs.
+
 The daemon synchronously persists the canonical Turn, provider Session, and
 provider Turn binding when it receives `provider_turn_identity_resolved`. Only
 after that durable barrier succeeds does it publish canonical

--- a/packages/agent/claude-sdk-sidecar/README.md
+++ b/packages/agent/claude-sdk-sidecar/README.md
@@ -93,6 +93,9 @@ transcript persistence lag.
 Fallback and pre-identity Query terminals emit sanitized stderr records with
 the `CLAUDE_CODE_PROVIDER_TURN_DIAGNOSTIC` prefix. The daemon forwards them as
 `agent_session.claude_sdk.provider_turn_diagnostic` structured logs.
+A dispatched Turn that still has no provider Turn identity after two minutes
+emits one structured warning with the same event name. This diagnostic timer
+does not cancel, fail, or otherwise change the Turn.
 
 The daemon synchronously persists the canonical Turn, provider Session, and
 provider Turn binding when it receives `provider_turn_identity_resolved`. Only

--- a/packages/agent/claude-sdk-sidecar/package.json
+++ b/packages/agent/claude-sdk-sidecar/package.json
@@ -23,6 +23,7 @@
     "src/normalizer.ts",
     "src/options.ts",
     "src/providerTurnAcceptance.ts",
+    "src/providerTurnDiagnostics.ts",
     "src/promptQueue.ts",
     "src/protocol.ts",
     "src/queryGeneration.ts",

--- a/packages/agent/claude-sdk-sidecar/package.json
+++ b/packages/agent/claude-sdk-sidecar/package.json
@@ -33,6 +33,7 @@
     "src/sessionSettings.ts",
     "src/sessionRuntime.ts",
     "src/sessionConfiguration.ts",
+    "src/sessionDiagnostics.ts",
     "src/sessionFork.ts",
     "src/settingsEnv.ts",
     "src/taskNotification.ts",

--- a/packages/agent/claude-sdk-sidecar/src/providerTurnAcceptance.ts
+++ b/packages/agent/claude-sdk-sidecar/src/providerTurnAcceptance.ts
@@ -3,6 +3,10 @@ import {
   type ClaudeTurnBinding,
   type ClaudeTurnBindingResolver
 } from "./sessionFork.ts";
+import {
+  logClaudeProviderTurnDiagnostic,
+  providerTurnDiagnosticError
+} from "./providerTurnDiagnostics.ts";
 
 export type ProviderTurnPhase =
   | "queued"
@@ -21,6 +25,11 @@ export type ProviderTurnIdentityBindingDisposition =
   | "already_bound"
   | "conflict"
   | "missing";
+
+type ProviderTurnAcceptanceTriggerPhase = Extract<
+  ProviderTurnPhase,
+  "streaming" | "waiting_approval" | "waiting_input" | "running_tool"
+>;
 
 export type ProviderTurnAcceptanceTarget = {
   turnId: string;
@@ -104,10 +113,7 @@ export class ProviderTurnAcceptanceCoordinator {
   }
 
   async ensure(
-    nextPhase: Extract<
-      ProviderTurnPhase,
-      "streaming" | "waiting_approval" | "waiting_input" | "running_tool"
-    >,
+    nextPhase: ProviderTurnAcceptanceTriggerPhase,
     signal?: AbortSignal
   ): Promise<void> {
     const target = this.resolveTarget();
@@ -129,13 +135,15 @@ export class ProviderTurnAcceptanceCoordinator {
       active.controller.abort();
     }
     const controller = new AbortController();
-    const promise = this.resolveAndBind(target, controller.signal).finally(
-      () => {
-        if (this.active?.promise === promise) {
-          this.active = undefined;
-        }
+    const promise = this.resolveAndBind(
+      target,
+      nextPhase,
+      controller.signal
+    ).finally(() => {
+      if (this.active?.promise === promise) {
+        this.active = undefined;
       }
-    );
+    });
     this.active = { turnId: target.turnId, controller, promise };
     await raceWithAbort(promise, signal);
     this.setPhase(target.turnId, nextPhase);
@@ -166,21 +174,42 @@ export class ProviderTurnAcceptanceCoordinator {
 
   private async resolveAndBind(
     target: ProviderTurnAcceptanceTarget,
+    triggerPhase: ProviderTurnAcceptanceTriggerPhase,
     signal: AbortSignal
   ): Promise<void> {
+    const startedAtMs = this.now();
     const providerSessionId = this.getProviderSessionId().trim();
     const recoveryToken = target.promptCorrelationId.trim();
+    const basePayload = {
+      turnId: target.turnId,
+      providerSessionId,
+      promptCorrelationId: recoveryToken,
+      triggerPhase,
+      timeoutMs: this.resolutionTimeoutMs
+    };
     if (!providerSessionId || !recoveryToken) {
+      logClaudeProviderTurnDiagnostic("identity_recovery_failed", {
+        ...basePayload,
+        attempts: 0,
+        elapsedMs: 0,
+        reason: "missing_required_identity",
+        hasProviderSessionId: Boolean(providerSessionId),
+        hasPromptCorrelationId: Boolean(recoveryToken)
+      });
       throw new Error(
         "Claude provider turn identity resolution requires session and correlation identities"
       );
     }
     const deadline = this.now() + Math.max(0, this.resolutionTimeoutMs);
     let retryDelayMs = Math.max(1, this.retryDelayMs);
+    let attempts = 0;
+    let lastAbsent: ClaudeTurnBindingResolutionError | undefined;
     this.setPhase(target.turnId, "resolving_identity");
+    logClaudeProviderTurnDiagnostic("identity_recovery_started", basePayload);
     for (;;) {
-      throwIfAborted(signal);
       try {
+        throwIfAborted(signal);
+        attempts += 1;
         const binding = await raceWithAbort(
           this.resolveBinding({
             sessionId: providerSessionId,
@@ -191,25 +220,74 @@ export class ProviderTurnAcceptanceCoordinator {
         );
         this.acceptBinding(target.turnId, providerSessionId, binding);
         this.setPhase(target.turnId, "identity_resolved");
+        logClaudeProviderTurnDiagnostic("identity_recovery_resolved", {
+          ...basePayload,
+          attempts,
+          elapsedMs: Math.max(0, this.now() - startedAtMs),
+          providerTurnId: binding.providerTurnId.trim(),
+          providerCheckpointMessageId:
+            binding.providerCheckpointMessageId.trim(),
+          correlationIdRewritten:
+            binding.providerTurnId.trim() !== recoveryToken
+        });
         return;
       } catch (error) {
         if (signal.aborted) {
+          logClaudeProviderTurnDiagnostic("identity_recovery_failed", {
+            ...basePayload,
+            attempts,
+            elapsedMs: Math.max(0, this.now() - startedAtMs),
+            reason: "canceled",
+            ...resolutionDetails(lastAbsent),
+            error: providerTurnDiagnosticError(error)
+          });
           throw abortError();
         }
         if (
           !(error instanceof ClaudeTurnBindingResolutionError) ||
           error.reason !== "absent"
         ) {
+          logClaudeProviderTurnDiagnostic("identity_recovery_failed", {
+            ...basePayload,
+            attempts,
+            elapsedMs: Math.max(0, this.now() - startedAtMs),
+            reason: identityRecoveryFailureReason(error),
+            ...resolutionDetails(error),
+            error: providerTurnDiagnosticError(error)
+          });
           throw error;
         }
+        lastAbsent = error;
         const remainingMs = deadline - this.now();
         if (remainingMs <= 0) {
+          logClaudeProviderTurnDiagnostic("identity_recovery_failed", {
+            ...basePayload,
+            attempts,
+            elapsedMs: Math.max(0, this.now() - startedAtMs),
+            reason: "transcript_absent_at_deadline",
+            ...resolutionDetails(error),
+            error: providerTurnDiagnosticError(error)
+          });
           throw new Error(
             "Claude provider turn identity was not persisted before the acceptance deadline",
             { cause: error }
           );
         }
-        await this.wait(Math.min(retryDelayMs, remainingMs), signal);
+        try {
+          await this.wait(Math.min(retryDelayMs, remainingMs), signal);
+        } catch (waitError) {
+          if (signal.aborted) {
+            logClaudeProviderTurnDiagnostic("identity_recovery_failed", {
+              ...basePayload,
+              attempts,
+              elapsedMs: Math.max(0, this.now() - startedAtMs),
+              reason: "canceled",
+              ...resolutionDetails(lastAbsent),
+              error: providerTurnDiagnosticError(waitError)
+            });
+          }
+          throw waitError;
+        }
         retryDelayMs = Math.min(retryDelayMs * 2, MAX_RETRY_DELAY_MS);
       }
     }
@@ -245,6 +323,20 @@ export class ProviderTurnAcceptanceCoordinator {
     }
     this.phases.set(normalizedTurnId, phase);
   }
+}
+
+function identityRecoveryFailureReason(error: unknown): string {
+  if (error instanceof ClaudeTurnBindingResolutionError) {
+    return `transcript_${error.reason}`;
+  }
+  return "transcript_read_or_binding_failed";
+}
+
+function resolutionDetails(error: unknown): Record<string, unknown> {
+  if (!(error instanceof ClaudeTurnBindingResolutionError) || !error.details) {
+    return {};
+  }
+  return { ...error.details };
 }
 
 function abortableDelay(delayMs: number, signal: AbortSignal): Promise<void> {

--- a/packages/agent/claude-sdk-sidecar/src/providerTurnDiagnostics.ts
+++ b/packages/agent/claude-sdk-sidecar/src/providerTurnDiagnostics.ts
@@ -13,14 +13,20 @@ type ProviderTurnDiagnosticCandidate = {
   awaitingProviderTurnIdentity?: boolean;
 };
 
+type ProviderTurnDiagnosticSeverity = "warning";
+
+const PROVIDER_TURN_IDENTITY_WARNING_AFTER_MS = 2 * 60 * 1_000;
+
 export function logClaudeProviderTurnDiagnostic(
   stage: string,
-  payload: Record<string, unknown>
+  payload: Record<string, unknown>,
+  severity?: ProviderTurnDiagnosticSeverity
 ): void {
   try {
     stderr.write(
       `${CLAUDE_CODE_PROVIDER_TURN_DIAGNOSTIC_PREFIX} ${JSON.stringify({
         stage,
+        ...(severity ? { severity } : {}),
         sidecarPid: pid,
         ...payload
       })}\n`
@@ -69,6 +75,9 @@ export function logClaudeUnresolvedProviderTurns(
     turns: readonly ProviderTurnDiagnosticCandidate[];
     phaseForTurn: (turnId: string) => string | undefined;
     error?: unknown;
+    severity?: ProviderTurnDiagnosticSeverity;
+    warningAfterMs?: number;
+    elapsedMs?: number;
   }
 ): void {
   for (const turn of input.turns) {
@@ -81,21 +90,67 @@ export function logClaudeUnresolvedProviderTurns(
       continue;
     }
     try {
-      logClaudeProviderTurnDiagnostic(stage, {
-        turnId: turn.turnId.trim(),
-        providerSessionId: input.providerSessionId.trim(),
-        promptCorrelationId: turn.promptUuid.trim(),
-        generationId: input.generationId,
-        providerTurnPhase: input.phaseForTurn(turn.turnId) ?? "unknown",
-        awaitingProviderTurnIdentity:
-          turn.awaitingProviderTurnIdentity === true,
-        ...(input.error
-          ? { error: providerTurnDiagnosticError(input.error) }
-          : {})
-      });
+      logClaudeProviderTurnDiagnostic(
+        stage,
+        {
+          turnId: turn.turnId.trim(),
+          providerSessionId: input.providerSessionId.trim(),
+          promptCorrelationId: turn.promptUuid.trim(),
+          generationId: input.generationId,
+          providerTurnPhase: input.phaseForTurn(turn.turnId) ?? "unknown",
+          awaitingProviderTurnIdentity:
+            turn.awaitingProviderTurnIdentity === true,
+          ...(input.warningAfterMs !== undefined
+            ? { warningAfterMs: input.warningAfterMs }
+            : {}),
+          ...(input.elapsedMs !== undefined
+            ? { elapsedMs: input.elapsedMs }
+            : {}),
+          ...(input.error
+            ? { error: providerTurnDiagnosticError(input.error) }
+            : {})
+        },
+        input.severity
+      );
     } catch {
       // Diagnostics must never change query settlement semantics.
     }
+  }
+}
+
+export function scheduleClaudeProviderTurnIdentityWarning(input: {
+  providerSessionId: () => string;
+  generationId: number;
+  turn: ProviderTurnDiagnosticCandidate;
+  phaseForTurn: (turnId: string) => string | undefined;
+}): void {
+  const startedAtMs = Date.now();
+  try {
+    const timer = setTimeout(() => {
+      try {
+        logClaudeUnresolvedProviderTurns(
+          "provider_turn_identity_pending_after_timeout",
+          {
+            providerSessionId: input.providerSessionId(),
+            generationId: input.generationId,
+            turns: [input.turn],
+            phaseForTurn: input.phaseForTurn,
+            severity: "warning",
+            warningAfterMs: PROVIDER_TURN_IDENTITY_WARNING_AFTER_MS,
+            elapsedMs: Math.max(0, Date.now() - startedAtMs)
+          }
+        );
+      } catch {
+        // Diagnostics must never change provider execution semantics.
+      }
+    }, PROVIDER_TURN_IDENTITY_WARNING_AFTER_MS);
+    (
+      timer as ReturnType<typeof setTimeout> & {
+        unref?: () => void;
+      }
+    ).unref?.();
+  } catch {
+    // Diagnostics must never change provider execution semantics.
   }
 }
 

--- a/packages/agent/claude-sdk-sidecar/src/providerTurnDiagnostics.ts
+++ b/packages/agent/claude-sdk-sidecar/src/providerTurnDiagnostics.ts
@@ -1,0 +1,111 @@
+import { createHash } from "node:crypto";
+import { pid, stderr } from "node:process";
+
+export const CLAUDE_CODE_PROVIDER_TURN_DIAGNOSTIC_PREFIX =
+  "CLAUDE_CODE_PROVIDER_TURN_DIAGNOSTIC";
+
+type ProviderTurnDiagnosticCandidate = {
+  turnId: string;
+  promptUuid: string;
+  providerTurnId?: string;
+  settled: boolean;
+  synthetic?: boolean;
+  awaitingProviderTurnIdentity?: boolean;
+};
+
+export function logClaudeProviderTurnDiagnostic(
+  stage: string,
+  payload: Record<string, unknown>
+): void {
+  try {
+    stderr.write(
+      `${CLAUDE_CODE_PROVIDER_TURN_DIAGNOSTIC_PREFIX} ${JSON.stringify({
+        stage,
+        sidecarPid: pid,
+        ...payload
+      })}\n`
+    );
+  } catch {
+    // Diagnostics must never change provider execution semantics.
+  }
+}
+
+export function providerTurnDiagnosticError(
+  error: unknown
+): Record<string, unknown> {
+  try {
+    const name = error instanceof Error ? error.name : typeof error;
+    const message = error instanceof Error ? error.message : String(error);
+    const withMetadata =
+      error && typeof error === "object"
+        ? (error as { code?: unknown; status?: unknown })
+        : undefined;
+    const code = diagnosticScalar(withMetadata?.code);
+    const status = diagnosticScalar(withMetadata?.status);
+    return {
+      name,
+      ...(code !== undefined ? { code } : {}),
+      ...(status !== undefined ? { status } : {}),
+      ...(message
+        ? {
+            messageLength: message.length,
+            messageFingerprint: createHash("sha256")
+              .update(message)
+              .digest("hex")
+              .slice(0, 12)
+          }
+        : {})
+    };
+  } catch {
+    return { name: "UninspectableError" };
+  }
+}
+
+export function logClaudeUnresolvedProviderTurns(
+  stage: string,
+  input: {
+    providerSessionId: string;
+    generationId: number;
+    turns: readonly ProviderTurnDiagnosticCandidate[];
+    phaseForTurn: (turnId: string) => string | undefined;
+    error?: unknown;
+  }
+): void {
+  for (const turn of input.turns) {
+    if (
+      turn.settled ||
+      turn.synthetic ||
+      turn.providerTurnId?.trim() ||
+      !turn.turnId.trim()
+    ) {
+      continue;
+    }
+    try {
+      logClaudeProviderTurnDiagnostic(stage, {
+        turnId: turn.turnId.trim(),
+        providerSessionId: input.providerSessionId.trim(),
+        promptCorrelationId: turn.promptUuid.trim(),
+        generationId: input.generationId,
+        providerTurnPhase: input.phaseForTurn(turn.turnId) ?? "unknown",
+        awaitingProviderTurnIdentity:
+          turn.awaitingProviderTurnIdentity === true,
+        ...(input.error
+          ? { error: providerTurnDiagnosticError(input.error) }
+          : {})
+      });
+    } catch {
+      // Diagnostics must never change query settlement semantics.
+    }
+  }
+}
+
+function diagnosticScalar(value: unknown): string | number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim()) {
+    const normalized = value.trim();
+    return /^[a-z0-9_.:-]{1,64}$/iu.test(normalized) ? normalized : undefined;
+  }
+  return undefined;
+}

--- a/packages/agent/claude-sdk-sidecar/src/sessionDiagnostics.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionDiagnostics.ts
@@ -1,0 +1,85 @@
+import {
+  claudeAuthRefreshDiagnosticsEnabled,
+  claudeCredentialSnapshot,
+  debugClaudeAuthRefreshLog
+} from "./authDiagnostics.ts";
+import {
+  logClaudeUnresolvedProviderTurns,
+  scheduleClaudeProviderTurnIdentityWarning
+} from "./providerTurnDiagnostics.ts";
+import type { ProviderTurnPhase } from "./providerTurnAcceptance.ts";
+import type { RuntimeTurn } from "./turnLifecycle.ts";
+
+export class ClaudeSessionDiagnostics {
+  private readonly cwd: string;
+  private readonly providerSessionId: () => string;
+  private readonly turns: () => readonly RuntimeTurn[];
+  private readonly phaseForTurn: (
+    turnId: string
+  ) => ProviderTurnPhase | undefined;
+
+  constructor(options: {
+    cwd: string;
+    providerSessionId: () => string;
+    turns: () => readonly RuntimeTurn[];
+    phaseForTurn: (turnId: string) => ProviderTurnPhase | undefined;
+  }) {
+    this.cwd = options.cwd;
+    this.providerSessionId = options.providerSessionId;
+    this.turns = options.turns;
+    this.phaseForTurn = options.phaseForTurn;
+  }
+
+  logAuthRefresh(stage: string, payload: Record<string, unknown>): void {
+    if (!claudeAuthRefreshDiagnosticsEnabled()) {
+      return;
+    }
+    debugClaudeAuthRefreshLog(stage, {
+      providerSessionId: this.providerSessionId(),
+      cwd: this.cwd,
+      credentials: claudeCredentialSnapshot(),
+      ...payload
+    });
+  }
+
+  scheduleProviderTurnIdentityWarning(
+    turn: RuntimeTurn,
+    generationId: number
+  ): void {
+    scheduleClaudeProviderTurnIdentityWarning({
+      providerSessionId: this.providerSessionId,
+      generationId,
+      turn,
+      phaseForTurn: this.phaseForTurn
+    });
+  }
+
+  logQueryFailure(generationId: number, error: unknown): void {
+    this.logUnresolvedProviderTurns(
+      "query_consumption_failed_before_identity",
+      generationId,
+      error
+    );
+  }
+
+  logQueryEnd(generationId: number): void {
+    this.logUnresolvedProviderTurns(
+      "query_ended_before_identity",
+      generationId
+    );
+  }
+
+  private logUnresolvedProviderTurns(
+    stage: string,
+    generationId: number,
+    error?: unknown
+  ): void {
+    logClaudeUnresolvedProviderTurns(stage, {
+      providerSessionId: this.providerSessionId(),
+      generationId,
+      turns: this.turns(),
+      phaseForTurn: this.phaseForTurn,
+      ...(error !== undefined ? { error } : {})
+    });
+  }
+}

--- a/packages/agent/claude-sdk-sidecar/src/sessionFork.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionFork.ts
@@ -45,13 +45,25 @@ export type ClaudeTurnBindingResolver = (input: {
   recoveryToken: string;
 }) => Promise<ClaudeTurnBinding>;
 
+export type ClaudeTurnBindingResolutionDetails = {
+  transcriptMessageCount: number;
+  rootUserMessageCount: number;
+  matchingRootUserMessageCount: number;
+  latestRootUserMessageId: string;
+};
+
 export class ClaudeTurnBindingResolutionError extends Error {
   readonly reason: "absent" | "ambiguous";
+  readonly details: ClaudeTurnBindingResolutionDetails | undefined;
 
-  constructor(reason: "absent" | "ambiguous") {
+  constructor(
+    reason: "absent" | "ambiguous",
+    details?: ClaudeTurnBindingResolutionDetails
+  ) {
     super(`Claude provider turn recovery proof is ${reason}`);
     this.name = "ClaudeTurnBindingResolutionError";
     this.reason = reason;
+    this.details = details;
   }
 }
 
@@ -115,11 +127,20 @@ async function resolveClaudeTurnBinding(
     transcriptOptions(input.cwd)
   )) as SDKMessage[];
   const matches = rootTurnBindingMatches(messages, input);
+  const rootMessages = messages.filter(isRootUserMessage);
+  const details: ClaudeTurnBindingResolutionDetails = {
+    transcriptMessageCount: messages.length,
+    rootUserMessageCount: rootMessages.length,
+    matchingRootUserMessageCount: matches.length,
+    latestRootUserMessageId: messageIdentity(
+      rootMessages[rootMessages.length - 1]
+    )
+  };
   if (matches.length === 0) {
-    throw new ClaudeTurnBindingResolutionError("absent");
+    throw new ClaudeTurnBindingResolutionError("absent", details);
   }
   if (matches.length > 1) {
-    throw new ClaudeTurnBindingResolutionError("ambiguous");
+    throw new ClaudeTurnBindingResolutionError("ambiguous", details);
   }
   return {
     providerSessionId: input.sessionId,

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts
@@ -62,7 +62,10 @@ import {
   ProviderTurnAcceptanceCoordinator,
   type ProviderTurnPhase
 } from "./providerTurnAcceptance.ts";
-import { logClaudeUnresolvedProviderTurns } from "./providerTurnDiagnostics.ts";
+import {
+  logClaudeUnresolvedProviderTurns,
+  scheduleClaudeProviderTurnIdentityWarning
+} from "./providerTurnDiagnostics.ts";
 import {
   canBypassPermissions,
   effectivePermissionMode,
@@ -522,6 +525,13 @@ export class SessionRuntime {
             content: outboundContent
           }
         } as SDKUserMessage);
+        scheduleClaudeProviderTurnIdentityWarning({
+          providerSessionId: () => this.providerSessionId,
+          generationId: generation.id,
+          turn,
+          phaseForTurn: (candidateTurnId) =>
+            this.providerTurnAcceptance.phase(candidateTurnId)
+        });
         this.consume(generation);
       })
       .catch((error) => {

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts
@@ -19,11 +19,6 @@ import {
   type QueryShutdownOptions
 } from "./queryGeneration.ts";
 import { queryGenerationHooks } from "./queryHooks.ts";
-import {
-  claudeAuthRefreshDiagnosticsEnabled,
-  claudeCredentialSnapshot,
-  debugClaudeAuthRefreshLog
-} from "./authDiagnostics.ts";
 import { errorMessage, errorPayload } from "./errors.ts";
 import { AssistantStreamProjector } from "./assistantStream.ts";
 import {
@@ -62,10 +57,7 @@ import {
   ProviderTurnAcceptanceCoordinator,
   type ProviderTurnPhase
 } from "./providerTurnAcceptance.ts";
-import {
-  logClaudeUnresolvedProviderTurns,
-  scheduleClaudeProviderTurnIdentityWarning
-} from "./providerTurnDiagnostics.ts";
+import { ClaudeSessionDiagnostics } from "./sessionDiagnostics.ts";
 import {
   canBypassPermissions,
   effectivePermissionMode,
@@ -149,6 +141,7 @@ export class SessionRuntime {
   private readonly driver?: SidecarTestDriver;
   private readonly goalExecQueue: GoalExecQueue;
   private readonly providerTurnAcceptance: ProviderTurnAcceptanceCoordinator;
+  private readonly diagnostics: ClaudeSessionDiagnostics;
   private readonly emittedProviderCheckpoints = new Set<string>();
 
   get query(): ClaudeQueryRuntime | undefined {
@@ -226,6 +219,12 @@ export class SessionRuntime {
           binding.providerCheckpointMessageId
         ),
       resolutionTimeoutMs: providerTurnIdentityResolutionTimeoutMs
+    });
+    this.diagnostics = new ClaudeSessionDiagnostics({
+      cwd: this.cwd,
+      providerSessionId: () => this.providerSessionId,
+      turns: () => this.turns.queue,
+      phaseForTurn: (turnId) => this.providerTurnAcceptance.phase(turnId)
     });
     this.assistantStream = new AssistantStreamProjector(
       () => this.turns.activeId,
@@ -354,7 +353,7 @@ export class SessionRuntime {
   }
 
   async start(): Promise<void> {
-    this.logAuthRefresh("session_start.begin", {
+    this.diagnostics.logAuthRefresh("session_start.begin", {
       restore: this.restore,
       initialized: this.initialized,
       queryClosed: this.sessionClosed
@@ -388,7 +387,7 @@ export class SessionRuntime {
       // Default never has to be inferred from the advertised catalog label.
       this.consume(generation);
     }
-    this.logAuthRefresh("session_start.succeeded", {
+    this.diagnostics.logAuthRefresh("session_start.succeeded", {
       restore: this.restore,
       initialized: this.initialized,
       queryClosed: this.sessionClosed
@@ -525,20 +524,17 @@ export class SessionRuntime {
             content: outboundContent
           }
         } as SDKUserMessage);
-        scheduleClaudeProviderTurnIdentityWarning({
-          providerSessionId: () => this.providerSessionId,
-          generationId: generation.id,
+        this.diagnostics.scheduleProviderTurnIdentityWarning(
           turn,
-          phaseForTurn: (candidateTurnId) =>
-            this.providerTurnAcceptance.phase(candidateTurnId)
-        });
+          generation.id
+        );
         this.consume(generation);
       })
       .catch((error) => {
         if (executionEpoch !== this.executionEpoch || turn.settled) {
           return;
         }
-        this.logAuthRefresh("exec.ensure_query_failed", {
+        this.diagnostics.logAuthRefresh("exec.ensure_query_failed", {
           turnId,
           error: errorPayload(error)
         });
@@ -593,7 +589,7 @@ export class SessionRuntime {
         await interrupt.call(generation.query);
       } catch (error) {
         this.pendingGuidanceInterrupt = false;
-        this.logAuthRefresh("guide.interrupt_failed", {
+        this.diagnostics.logAuthRefresh("guide.interrupt_failed", {
           error: errorPayload(error)
         });
         throw new Error(
@@ -636,7 +632,7 @@ export class SessionRuntime {
         throw error;
       }
     } catch (error) {
-      this.logAuthRefresh("guide.failed", {
+      this.diagnostics.logAuthRefresh("guide.failed", {
         error: errorPayload(error)
       });
       throw error;
@@ -878,17 +874,8 @@ export class SessionRuntime {
         if (isAbortError(error) && !this.isQueryGenerationActive(generation)) {
           return;
         }
-        logClaudeUnresolvedProviderTurns(
-          "query_consumption_failed_before_identity",
-          {
-            providerSessionId: this.providerSessionId,
-            generationId: generation.id,
-            turns: this.turns.queue,
-            phaseForTurn: (turnId) => this.providerTurnAcceptance.phase(turnId),
-            error
-          }
-        );
-        this.logAuthRefresh("query_consume.failed", {
+        this.diagnostics.logQueryFailure(generation.id, error);
+        this.diagnostics.logAuthRefresh("query_consume.failed", {
           activeTurnId: this.turns.activeId,
           queuedTurnIds: this.turns.queue
             .filter((turn) => !turn.settled)
@@ -898,12 +885,7 @@ export class SessionRuntime {
         this.turns.failLiveTurns(errorMessage(error));
       } finally {
         if (this.queryGeneration === generation) {
-          logClaudeUnresolvedProviderTurns("query_ended_before_identity", {
-            providerSessionId: this.providerSessionId,
-            generationId: generation.id,
-            turns: this.turns.queue,
-            phaseForTurn: (turnId) => this.providerTurnAcceptance.phase(turnId)
-          });
+          this.diagnostics.logQueryEnd(generation.id);
           this.queryGeneration = undefined;
           generation.revoke();
           generation.closeQuery();
@@ -1030,7 +1012,7 @@ export class SessionRuntime {
           this.activities.handleTaskLifecycleHook(input)
       })
     } as ClaudeQueryOptions;
-    this.logAuthRefresh("query_create.begin", {
+    this.diagnostics.logAuthRefresh("query_create.begin", {
       initialize: startOptions.initialize === true,
       restore: this.resumeQueries,
       permissionMode,
@@ -1047,7 +1029,7 @@ export class SessionRuntime {
         prompt: generation.promptQueue.iterate(),
         options: queryOptions
       }) as ClaudeQueryRuntime;
-      this.logAuthRefresh("query_create.succeeded", {
+      this.diagnostics.logAuthRefresh("query_create.succeeded", {
         initialize: startOptions.initialize === true,
         restore: this.resumeQueries,
         hasInitializationResult:
@@ -1055,7 +1037,7 @@ export class SessionRuntime {
       });
       if (startOptions.initialize || this.resumeQueries) {
         try {
-          this.logAuthRefresh("query_initialization.begin", {
+          this.diagnostics.logAuthRefresh("query_initialization.begin", {
             restore: this.resumeQueries
           });
           const initializationResult =
@@ -1069,12 +1051,12 @@ export class SessionRuntime {
           this.configuration.applyInitializationResult(initializationResult);
           this.initialized = true;
           this.resumeQueries = true;
-          this.logAuthRefresh("query_initialization.succeeded", {
+          this.diagnostics.logAuthRefresh("query_initialization.succeeded", {
             restore: this.resumeQueries,
             resultKeys: Object.keys(recordValue(initializationResult) ?? {})
           });
         } catch (error) {
-          this.logAuthRefresh("query_initialization.failed", {
+          this.diagnostics.logAuthRefresh("query_initialization.failed", {
             restore: this.resumeQueries,
             error: errorPayload(error)
           });
@@ -1183,21 +1165,6 @@ export class SessionRuntime {
     this.resumeQueries = true;
     QueryGeneration.retire(this.queryGeneration, () => {
       this.queryGeneration = undefined;
-    });
-  }
-
-  private logAuthRefresh(
-    stage: string,
-    payload: Record<string, unknown>
-  ): void {
-    if (!claudeAuthRefreshDiagnosticsEnabled()) {
-      return;
-    }
-    debugClaudeAuthRefreshLog(stage, {
-      providerSessionId: this.providerSessionId,
-      cwd: this.cwd,
-      credentials: claudeCredentialSnapshot(),
-      ...payload
     });
   }
 

--- a/packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts
+++ b/packages/agent/claude-sdk-sidecar/src/sessionRuntime.ts
@@ -62,6 +62,7 @@ import {
   ProviderTurnAcceptanceCoordinator,
   type ProviderTurnPhase
 } from "./providerTurnAcceptance.ts";
+import { logClaudeUnresolvedProviderTurns } from "./providerTurnDiagnostics.ts";
 import {
   canBypassPermissions,
   effectivePermissionMode,
@@ -867,6 +868,16 @@ export class SessionRuntime {
         if (isAbortError(error) && !this.isQueryGenerationActive(generation)) {
           return;
         }
+        logClaudeUnresolvedProviderTurns(
+          "query_consumption_failed_before_identity",
+          {
+            providerSessionId: this.providerSessionId,
+            generationId: generation.id,
+            turns: this.turns.queue,
+            phaseForTurn: (turnId) => this.providerTurnAcceptance.phase(turnId),
+            error
+          }
+        );
         this.logAuthRefresh("query_consume.failed", {
           activeTurnId: this.turns.activeId,
           queuedTurnIds: this.turns.queue
@@ -877,6 +888,12 @@ export class SessionRuntime {
         this.turns.failLiveTurns(errorMessage(error));
       } finally {
         if (this.queryGeneration === generation) {
+          logClaudeUnresolvedProviderTurns("query_ended_before_identity", {
+            providerSessionId: this.providerSessionId,
+            generationId: generation.id,
+            turns: this.turns.queue,
+            phaseForTurn: (turnId) => this.providerTurnAcceptance.phase(turnId)
+          });
           this.queryGeneration = undefined;
           generation.revoke();
           generation.closeQuery();

--- a/packages/agent/daemon/runtime/claude_sdk_adapter.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter.go
@@ -180,10 +180,11 @@ type claudeSDKTurnResult struct {
 }
 
 type claudeSDKLineReader struct {
-	conn            ProcessConnection
-	buffer          string
-	trackInputUnits bool
-	lines           []claudeSDKBufferedLine
+	conn                   ProcessConnection
+	buffer                 string
+	stderrDiagnosticBuffer string
+	trackInputUnits        bool
+	lines                  []claudeSDKBufferedLine
 	// stderrTail keeps only a bounded, sanitized classification of sidecar
 	// diagnostics. Raw stderr may contain prompts, paths, credentials, or stack
 	// traces and must never enter durable activity or user-visible errors.

--- a/packages/agent/daemon/runtime/claude_sdk_adapter.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter.go
@@ -19,6 +19,7 @@ const (
 	claudeSDKSidecarDefaultNodeArg = "--experimental-strip-types"
 	claudeSDKAuthRefreshLogPrefix  = "CLAUDE_CODE_AUTH_REFRESH_DEBUG"
 	claudeSDKCancelLogPrefix       = "CLAUDE_CODE_CANCEL_DIAGNOSTIC"
+	claudeSDKProviderTurnLogPrefix = "CLAUDE_CODE_PROVIDER_TURN_DIAGNOSTIC"
 )
 
 type ClaudeCodeSDKAdapter struct {

--- a/packages/agent/daemon/runtime/claude_sdk_transport.go
+++ b/packages/agent/daemon/runtime/claude_sdk_transport.go
@@ -162,16 +162,18 @@ func (r *claudeSDKLineReader) next(ctx context.Context) (claudeSDKSidecarEvent, 
 		}
 		if err != nil {
 			if errors.Is(err, io.EOF) {
+				r.flushStderrDiagnostics()
 				return claudeSDKSidecarEvent{}, ErrSessionDisconnected
 			}
 			return claudeSDKSidecarEvent{}, err
 		}
 		if len(frame.Stderr) > 0 {
-			logClaudeSDKSidecarDebugStderr(frame.Stderr)
+			r.appendStderrDiagnostics(frame.Stderr)
 			r.appendStderrTail(frame.Stderr)
 			continue
 		}
 		if frame.ExitCode != nil {
+			r.flushStderrDiagnostics()
 			return claudeSDKSidecarEvent{}, claudeSDKSidecarExitError(*frame.ExitCode, r.stderrTail)
 		}
 		if len(frame.Stdout) > 0 {
@@ -230,6 +232,28 @@ func nextBufferedLine(buffer *string) (string, bool) {
 	line := strings.TrimSpace((*buffer)[:index])
 	*buffer = (*buffer)[index+1:]
 	return line, line != ""
+}
+
+func (r *claudeSDKLineReader) appendStderrDiagnostics(content []byte) {
+	if len(content) == 0 {
+		return
+	}
+	r.stderrDiagnosticBuffer += string(content)
+	for {
+		line, ok := nextBufferedLine(&r.stderrDiagnosticBuffer)
+		if !ok {
+			return
+		}
+		logClaudeSDKSidecarDebugStderr([]byte(line))
+	}
+}
+
+func (r *claudeSDKLineReader) flushStderrDiagnostics() {
+	line := strings.TrimSpace(r.stderrDiagnosticBuffer)
+	r.stderrDiagnosticBuffer = ""
+	if line != "" {
+		logClaudeSDKSidecarDebugStderr([]byte(line))
+	}
 }
 
 func (r *claudeSDKLineReader) appendStderrTail(content []byte) {

--- a/packages/agent/daemon/runtime/claude_sdk_transport.go
+++ b/packages/agent/daemon/runtime/claude_sdk_transport.go
@@ -296,6 +296,16 @@ func logClaudeSDKStructuredDiagnostic(line string, prefix string, event string) 
 	if !json.Valid([]byte(payloadJSON)) {
 		payloadJSON = `{"stage":"invalid_diagnostic_payload"}`
 	}
+	var envelope struct {
+		Severity string `json:"severity"`
+	}
+	if json.Unmarshal([]byte(payloadJSON), &envelope) == nil && envelope.Severity == "warning" {
+		slog.Warn(prefix,
+			"event", event,
+			"payload_json", payloadJSON,
+		)
+		return
+	}
 	slog.Info(prefix,
 		"event", event,
 		"payload_json", payloadJSON,

--- a/packages/agent/daemon/runtime/claude_sdk_transport.go
+++ b/packages/agent/daemon/runtime/claude_sdk_transport.go
@@ -281,6 +281,12 @@ func logClaudeSDKSidecarDebugStderr(content []byte) {
 				claudeSDKCancelLogPrefix,
 				"agent_session.claude_sdk.cancel_diagnostic",
 			)
+		case strings.HasPrefix(line, claudeSDKProviderTurnLogPrefix):
+			logClaudeSDKStructuredDiagnostic(
+				line,
+				claudeSDKProviderTurnLogPrefix,
+				"agent_session.claude_sdk.provider_turn_diagnostic",
+			)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

为 Claude Provider Turn 身份无法建立的场景补充结构化诊断日志。

- 记录 transcript 身份回查的开始、成功、超时、歧义、取消及读取/绑定失败
- 记录 Query 在 Provider Turn 身份建立前失败或结束的边界
- Prompt 成功排入 Claude Query 后，若两分钟仍未建立 Provider Turn 身份，仅输出一次 WARN；该计时器不取消、不失败也不改变 Turn
- 仅保留 Turn/Session 标识、阶段、次数、耗时、transcript 计数和错误指纹，不记录 prompt、路径、凭据、原始错误文本或 provider 输出
- 跨 ProcessFrame 缓冲 stderr，拿到完整换行记录后才解析结构化载荷
- 将会话诊断编排提取到 sessionDiagnostics.ts，使 sessionRuntime.ts 相对主线净减少 6 行
- 将 sidecar 前缀日志转发为 agent_session.claude_sdk.provider_turn_diagnostic

## Verification

- pre-push: pnpm check:changed -- --push-ready（15 lanes passed）

## Checklist

- [x] This change does not change agent lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior changed.
- [x] README translation updates are not applicable because the changed README is package-local and has no language variants.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO.