### PR TITLE
fix(agent-gui): separate mention identity from action catalogs

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1611,12 +1611,15 @@ presentation context. The standalone flow also owns its visibility-aware
 conversation clock, so a hidden host does not keep elapsed-time presentation
 timers active.
 
-The full AgentGUI catalog is the union of provider-rail targets and handoff
-targets, including handoff-only shared Agents. Interactive composer mentions,
-readonly rich text, and Markdown links must resolve presentation through the
-shared target-presentation resolver. They must not infer icons from target-id
-formats such as `local:*`; serialized mention presentation is only the fallback
-when the current catalog no longer contains a historical target.
+Hosts whose action directories omit valid identities supply the complete
+presentation-only catalog through `mentionAgentDirectory`. It retains exact
+target IDs and unavailable Agents without making them launchable. Hosts that
+omit this capability keep the existing union of provider-rail and handoff
+targets. Interactive composer mentions, readonly rich text, and Markdown links
+must resolve presentation through the shared target-presentation resolver.
+They must not infer icons from target-id formats such as `local:*`; serialized
+mention presentation is only the fallback when the current catalog no longer
+contains a historical target.
 
 ## 5. Agent identity and provider architecture
 
@@ -1738,6 +1741,13 @@ Desktop Workspace Agent projections first inherit the resolved icon of their
 Harness target by exact target ID, then use the provider/icon catalog fallback.
 Host projections preserve these roles independently and do not create
 provider-specific renderer catalogs.
+
+AgentGUI accepts separate directory projections for separate responsibilities:
+`agentDirectory` owns the current runtime rail, `handoffAgentDirectory` owns
+launch choices, and optional `mentionAgentDirectory` owns exact rendered
+identity. The mention directory may include offline or otherwise unavailable
+Agents and must not participate in selection, admission, setup, or handoff.
+This keeps availability as action state instead of deleting identity metadata.
 
 Agent presentation images decoded for a canvas-backed texture must use
 anonymous CORS loading before assigning `src`. Any host-owned custom protocol

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1611,6 +1611,13 @@ presentation context. The standalone flow also owns its visibility-aware
 conversation clock, so a hidden host does not keep elapsed-time presentation
 timers active.
 
+The full AgentGUI catalog is the union of provider-rail targets and handoff
+targets, including handoff-only shared Agents. Interactive composer mentions,
+readonly rich text, and Markdown links must resolve presentation through the
+shared target-presentation resolver. They must not infer icons from target-id
+formats such as `local:*`; serialized mention presentation is only the fallback
+when the current catalog no longer contains a historical target.
+
 ## 5. Agent identity and provider architecture
 
 ### 5.1 `agentTargetId` is UI identity

--- a/packages/agent/gui/AgentGUI.spec.tsx
+++ b/packages/agent/gui/AgentGUI.spec.tsx
@@ -20,6 +20,11 @@ interface AgentGUINodeProbeProps {
       availability: unknown;
       ref: unknown;
     }[];
+    mentionAgentTargets?: readonly {
+      agentTargetId?: string;
+      disabled?: boolean;
+      iconUrl?: string;
+    }[];
     showHandoffTargetOwnershipLabels?: boolean;
   };
 }
@@ -85,6 +90,9 @@ vi.mock("./agent-gui/agentGuiNode/AgentGUINode", async () => {
                 (target) => target.agentTargetId
               ) ?? []
             )}
+          </div>
+          <div data-testid="agent-gui-mention-targets-probe">
+            {JSON.stringify(props.hostCapabilities.mentionAgentTargets ?? [])}
           </div>
           <Tooltip>
             <TooltipTrigger asChild>
@@ -194,6 +202,53 @@ describe("AgentGUI i18n", () => {
     expect(
       screen.getByTestId("agent-gui-handoff-targets-probe")
     ).toHaveTextContent('["local-codex","shared-agent:claude"]');
+  });
+
+  it("keeps unavailable mention identities outside action directories", () => {
+    render(
+      <AgentGUI
+        {...createAgentGUIProps("en")}
+        agentDirectory={{
+          agents: [agent("local-codex", "codex")],
+          capturedAtUnixMs: null,
+          error: null,
+          status: "ready"
+        }}
+        handoffAgentDirectory={{
+          agents: [agent("local-codex", "codex")],
+          capturedAtUnixMs: null,
+          error: null,
+          status: "ready"
+        }}
+        mentionAgentDirectory={{
+          agents: [
+            {
+              ...agent("shared-agent:offline-codex", "codex"),
+              availability: { status: "unavailable", reason: "owner_offline" }
+            }
+          ],
+          capturedAtUnixMs: null,
+          error: null,
+          status: "ready"
+        }}
+      />
+    );
+
+    expect(
+      screen.getByTestId("agent-gui-directory-targets-probe")
+    ).toHaveTextContent('["local-codex"]');
+    expect(
+      screen.getByTestId("agent-gui-handoff-targets-probe")
+    ).toHaveTextContent('["local-codex"]');
+    expect(
+      screen.getByTestId("agent-gui-mention-targets-probe")
+    ).toHaveTextContent('"agentTargetId":"shared-agent:offline-codex"');
+    expect(
+      screen.getByTestId("agent-gui-mention-targets-probe")
+    ).toHaveTextContent('"disabled":true');
+    expect(
+      screen.getByTestId("agent-gui-mention-targets-probe")
+    ).toHaveTextContent('"iconUrl":"/shared-agent:offline-codex.png"');
   });
 
   it("forwards the host-owned handoff ownership presentation", () => {

--- a/packages/agent/gui/AgentGUI.tsx
+++ b/packages/agent/gui/AgentGUI.tsx
@@ -32,6 +32,7 @@ type AgentGUIPublicHostCapabilities = Omit<
   AgentGUINodeProps["hostCapabilities"],
   | "agentTargets"
   | "agentTargetsLoading"
+  | "mentionAgentTargets"
   | "handoffAgentTargets"
   | "handoffAgentTargetsLoading"
   | "providerRailAllPresentation"
@@ -49,6 +50,12 @@ export interface AgentGUIProps extends Omit<
   "hostCapabilities" | "renderSlots"
 > {
   agentDirectory: AgentGUIAgentDirectorySnapshot;
+  /**
+   * Complete host-owned identity catalog for rendered Agent mentions. Unlike
+   * handoff, this directory may include unavailable targets because it does
+   * not grant launch capability.
+   */
+  mentionAgentDirectory?: AgentGUIAgentDirectorySnapshot;
   /**
    * Host-owned launch catalog for conversation handoff. When omitted, handoff
    * uses `agentDirectory`, preserving the single-runtime host contract.
@@ -72,6 +79,7 @@ export const AgentGUI = memo(function AgentGUI({
   agentHostApi,
   tuttiModePlanReviewRuntime,
   agentDirectory,
+  mentionAgentDirectory,
   handoffAgentDirectory,
   allAgentsPresentation = null,
   renderAgentsEmpty,
@@ -118,6 +126,11 @@ export const AgentGUI = memo(function AgentGUI({
         agentDirectory.agents.length === 0 &&
         (agentDirectory.status === "idle" ||
           agentDirectory.status === "loading"),
+      mentionAgentTargets: mentionAgentDirectory
+        ? projectAgentGUIAgentsToTargets(
+            normalizeAgentGUIAgents(mentionAgentDirectory.agents)
+          )
+        : undefined,
       handoffAgentTargets,
       handoffAgentTargetsLoading:
         effectiveHandoffAgentDirectory.agents.length === 0 &&
@@ -136,7 +149,8 @@ export const AgentGUI = memo(function AgentGUI({
       effectiveHandoffAgentDirectory.agents.length,
       effectiveHandoffAgentDirectory.status,
       handoffAgentTargets,
-      hostCapabilities
+      hostCapabilities,
+      mentionAgentDirectory?.agents
     ]
   );
   const nodeRenderSlots = useMemo<AgentGUINodeProps["renderSlots"]>(

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -101,6 +101,7 @@ export const AgentGUINode = memo(function AgentGUINode({
     capabilityControlsReadOnly = false,
     agentTargets,
     agentTargetsLoading = false,
+    mentionAgentTargets,
     handoffAgentTargets,
     handoffAgentTargetsLoading = false,
     showHandoffTargetOwnershipLabels = false,
@@ -476,6 +477,7 @@ export const AgentGUINode = memo(function AgentGUINode({
           return (
             <AgentGUINodeView
               viewModel={viewModel}
+              mentionAgentTargets={mentionAgentTargets}
               renderAgentTargetInfo={renderAgentTargetInfo}
               renderSidebarFooter={renderSidebarFooter}
               renderProviderRailEmpty={renderProviderRailEmpty}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.types.ts
@@ -150,6 +150,8 @@ export interface AgentGUINodeHostCapabilities {
   visibleErrorPresentationOverrides?: AgentVisibleErrorOverrides | null;
   agentTargets?: readonly AgentGUIAgentTarget[];
   agentTargetsLoading?: boolean;
+  /** Complete presentation-only catalog for resolving Agent mention identity. */
+  mentionAgentTargets?: readonly AgentGUIAgentTarget[];
   /** Launch-only targets for active-conversation handoff. */
   handoffAgentTargets?: readonly AgentGUIAgentTarget[];
   handoffAgentTargetsLoading?: boolean;

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -76,6 +76,7 @@ export {
 import { useAgentGUIExternalRequests } from "./view/useAgentGUIExternalRequests";
 export function AgentGUINodeView({
   viewModel,
+  mentionAgentTargets,
   referenceProvenanceFilters = null,
   sessionInputHistoryEnabled = false,
   sessionForkEnabled = false,
@@ -406,7 +407,6 @@ export function AgentGUINodeView({
     selectedAgentTarget: viewModel.rail.selectedAgentTarget
   });
   const openAgentSettings = useCallback(() => {
-    // Provider-scoped config menu -> Agents tab, focusing this provider's row.
     openWorkspaceSettingsPanel({
       section: "agent",
       pane: "agents",
@@ -512,7 +512,8 @@ export function AgentGUINodeView({
   );
   const targetPresentationKey = mentionAgentTargetPresentationKey(
     viewModel.rail.agentTargets,
-    viewModel.composer.handoffAgentTargets
+    viewModel.composer.handoffAgentTargets,
+    mentionAgentTargets
   );
   const agentTargetPresentations = useMemo<
     readonly AgentMessageMarkdownAgentTarget[]
@@ -520,6 +521,7 @@ export function AgentGUINodeView({
     () =>
       projectMentionAgentTargetPresentations({
         handoffTargets: viewModel.composer.handoffAgentTargets,
+        mentionTargets: mentionAgentTargets,
         ownerSeparator: labels.sharedAgentOwnerSeparator,
         railTargets: viewModel.rail.agentTargets,
         workspaceId: viewModel.shell.workspaceId
@@ -634,8 +636,7 @@ export function AgentGUINodeView({
             inert={conversationRailCollapsed ? true : undefined}
           >
             <AgentConversationClockProvider isVisible={isVisible}>
-              {/* Activity is an all-provider rail snapshot. Selecting a row
-                  changes the active provider/target, but must not rebuild it. */}
+              {/* Selecting an Activity row must not rebuild its all-provider snapshot. */}
               <AgentGUIConversationRailController
                 {...conversationRailStoreState}
                 activityContextKey={[

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchModel.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchModel.ts
@@ -735,8 +735,7 @@ export function providerItemToAgentMentionItem(input: {
           presentation.agentIconUrl?.trim() ||
           presentation.iconUrl?.trim() ||
           undefined,
-        agentProviderId: presentation.agentProviderId,
-        agentTargetId: scope.agentTargetId
+        agentProviderId: presentation.agentProviderId
       }),
       ...(scope.agentTargetId ? { agentTargetId: scope.agentTargetId } : {}),
       status: presentation.status?.trim() || undefined,

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
@@ -18,10 +18,14 @@ import {
   resolveAgentMentionFileThumbnailUrl,
   resolveAgentMentionFileVisualKind
 } from "../../shared/mentionFilePresentation";
-import { managedAgentRoundedIconUrl } from "../../../shared/managedAgentIcons";
 import { getAgentCustomMentionKind } from "../../../shared/agentCustomMentionKinds";
+import { managedAgentRoundedIconUrl } from "../../../shared/managedAgentIcons";
+import { useAgentTargetPresentations } from "../../../shared/AgentTargetPresentationContext";
+import {
+  resolveAgentMentionTargetPresentation,
+  type AgentMessageMarkdownAgentTarget
+} from "../../../shared/agentTargetPresentation";
 import { AGENT_RICH_TEXT_CARET_ANCHOR } from "./agentRichTextCaretAnchor";
-import { resolveAgentSessionMentionIconUrl } from "./agentMentionPresentation";
 import { agentExternalPromptFileErrorI18nKey } from "../model/agentExternalPromptFiles";
 
 type AgentMentionNodeViewKind =
@@ -127,7 +131,8 @@ function dirnameFromPath(path: string): string {
 
 function mentionViewModel(
   attrs: Record<string, unknown>,
-  t: (key: string) => string
+  t: (key: string) => string,
+  agentTargets: readonly AgentMessageMarkdownAgentTarget[]
 ): AgentMentionNodeViewModel {
   const kind = normalizeKind(attrString(attrs, "kind"));
   const name = attrString(attrs, "name");
@@ -136,17 +141,19 @@ function mentionViewModel(
   if (kind === "session") {
     const label = attrString(attrs, "title").trim() || name.trim();
     const agentTargetId = attrString(attrs, "agentTargetId").trim();
+    const presentation = resolveAgentMentionTargetPresentation({
+      agentTargetId,
+      agentTargets,
+      fallbackIconUrl: attrString(attrs, "iconUrl"),
+      workspaceId: attrString(attrs, "workspaceId")
+    });
     return {
       ariaLabel:
         `${t("agentHost.agentGui.mentionKindSession")} ${label}`.trim(),
       directoryPath: "",
       entryKind: "",
       href,
-      iconUrl: resolveAgentSessionMentionIconUrl({
-        agentIconUrl: attrString(attrs, "iconUrl"),
-        agentTargetId,
-        href
-      }),
+      iconUrl: presentation.iconUrl,
       kind,
       label
     };
@@ -202,16 +209,25 @@ function mentionViewModel(
 
   if (kind === "agent-target") {
     const agentProviderId = attrString(attrs, "agentProviderId").trim();
+    const presentation = resolveAgentMentionTargetPresentation({
+      agentTargetId: attrString(attrs, "targetId"),
+      agentTargets,
+      fallbackIconUrl:
+        attrString(attrs, "iconUrl").trim() ||
+        managedAgentRoundedIconUrl(agentProviderId || undefined),
+      fallbackName: name,
+      fallbackProvider: agentProviderId,
+      workspaceId: attrString(attrs, "workspaceId")
+    });
     return {
-      ariaLabel: `${t("agentHost.agentGui.mentionKindAgent")} ${name}`.trim(),
+      ariaLabel:
+        `${t("agentHost.agentGui.mentionKindAgent")} ${presentation.name ?? name}`.trim(),
       directoryPath: "",
       entryKind: "",
       href,
-      iconUrl:
-        attrString(attrs, "iconUrl").trim() ||
-        managedAgentRoundedIconUrl(agentProviderId),
+      iconUrl: presentation.iconUrl,
       kind,
-      label: name
+      label: presentation.name ?? name
     };
   }
 
@@ -416,6 +432,7 @@ function AgentMentionLegacyFileView({
 }
 
 function AgentMentionView({
+  agentTargets,
   attrs,
   isEditable,
   onRemove,
@@ -423,6 +440,7 @@ function AgentMentionView({
   selected,
   Wrapper
 }: {
+  agentTargets?: readonly AgentMessageMarkdownAgentTarget[];
   attrs: Record<string, unknown>;
   isEditable: boolean;
   onRemove?: MouseEventHandler<HTMLButtonElement>;
@@ -432,7 +450,12 @@ function AgentMentionView({
 }): JSX.Element {
   const { t } = useTranslation();
   const withTooltipProvider = useContext(AgentMentionTooltipProviderContext);
-  const mention = mentionViewModel(attrs, t);
+  const contextAgentTargets = useAgentTargetPresentations();
+  const mention = mentionViewModel(
+    attrs,
+    t,
+    agentTargets ?? contextAgentTargets
+  );
 
   if (mention.kind === "file") {
     return (
@@ -600,12 +623,15 @@ function AgentMentionView({
 }
 
 export function AgentMentionReadonlyView({
+  agentTargets,
   attrs
 }: {
+  agentTargets?: readonly AgentMessageMarkdownAgentTarget[];
   attrs: Record<string, unknown>;
 }): JSX.Element {
   return (
     <AgentMentionView
+      agentTargets={agentTargets}
       attrs={attrs}
       isEditable={false}
       selected={false}

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
@@ -5,6 +5,7 @@ import {
   registerAgentCustomMentionKind,
   resetAgentCustomMentionKindsForTests
 } from "../../../shared/agentCustomMentionKinds";
+import { AgentTargetPresentationProvider } from "../../../shared/AgentTargetPresentationContext";
 import { AgentRichTextEditor } from "./AgentRichTextEditor";
 import type { AgentRichTextEditorHandle } from "./AgentRichTextEditor.types";
 import { isAgentRichTextAbsolutePathPasteCandidate } from "./agentRichTextEditorSupport";
@@ -288,6 +289,41 @@ describe("AgentRichTextEditor file paste", () => {
 
     fireEvent.mouseDown(rendered.getByLabelText("Remove file"));
     await waitFor(() => expect(onChange).toHaveBeenLastCalledWith(""));
+  });
+});
+
+describe("AgentRichTextEditor Agent mention presentation", () => {
+  it("uses the target directory icon for a restored session mention", async () => {
+    const iconUrl = "data:image/png;base64,gemini";
+    const href =
+      "mention://agent-session/session-1?agentTargetId=extension%3Agemini&workspaceId=workspace-1";
+    const { container } = render(
+      <AgentTargetPresentationProvider
+        agentTargets={[
+          {
+            agentTargetId: "extension:gemini",
+            iconUrl,
+            name: "Gemini CLI",
+            provider: "acp:gemini",
+            workspaceId: "workspace-1"
+          }
+        ]}
+      >
+        <AgentRichTextEditor
+          value={`Review [@Gemini session](${href})`}
+          disabled={false}
+          placeholder="Prompt"
+          onChange={vi.fn()}
+          onSubmit={vi.fn()}
+        />
+      </AgentTargetPresentationProvider>
+    );
+
+    await waitFor(() =>
+      expect(
+        container.querySelector('[data-agent-mention-kind="session"] img')
+      ).toHaveAttribute("src", iconUrl)
+    );
   });
 });
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.spec.ts
@@ -18,7 +18,6 @@ import {
   resetAgentCustomMentionKindsForTests
 } from "../../../shared/agentCustomMentionKinds";
 import { createRichTextMentionHref } from "@tutti-os/ui-rich-text/core";
-import { managedAgentRoundedIconUrl } from "../../../shared/managedAgentIcons";
 import {
   agentComposerFileMentionReferences,
   createAgentComposerFileMentionMarkdown,
@@ -202,19 +201,15 @@ describe("parseAgentMentionMarkdown", () => {
         name: "Session"
       }
     });
-    expect(mentionItemToAttrs(parsed!.item).iconUrl).toBe(
-      managedAgentRoundedIconUrl("claude-code")
-    );
+    expect(mentionItemToAttrs(parsed!.item).iconUrl).toBeUndefined();
   });
 
-  it("derives the Cursor icon for a pasted local session mention", () => {
+  it("does not invent presentation metadata for a pasted session mention", () => {
     const parsed = parseAgentMentionMarkdown(
       "[@Cursor session](mention://agent-session/session-1?agentTargetId=local%3Acursor&workspaceId=workspace-1)"
     );
 
-    expect(mentionItemToAttrs(parsed!.item).iconUrl).toBe(
-      managedAgentRoundedIconUrl("cursor")
-    );
+    expect(mentionItemToAttrs(parsed!.item).iconUrl).toBeUndefined();
   });
 
   it("parses registered custom mention kinds into custom items", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentMentionAttrs.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentMentionAttrs.ts
@@ -37,9 +37,7 @@ export function mentionItemToAttrs(
   }
   if (item.kind === "session") {
     const iconUrl = resolveAgentSessionMentionIconUrl({
-      agentIconUrl: item.agentIconUrl,
-      agentTargetId: item.agentTargetId,
-      href: item.href
+      agentIconUrl: item.agentIconUrl
     });
     return {
       name: item.name,

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentMentionPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentMentionPresentation.ts
@@ -1,12 +1,9 @@
 import type { AgentContextMentionItem } from "./agentFileMentionContracts";
 import { managedAgentRoundedIconUrl } from "../../../shared/managedAgentIcons";
-import { agentSessionTargetIdFromHref } from "./agentMentionMarkdown";
 
 export function resolveAgentSessionMentionIconUrl(input: {
   agentIconUrl?: string | null;
   agentProviderId?: string | null;
-  agentTargetId?: string | null;
-  href?: string | null;
 }): string | undefined {
   const explicitIconUrl = input.agentIconUrl?.trim() ?? "";
   if (explicitIconUrl) {
@@ -16,15 +13,7 @@ export function resolveAgentSessionMentionIconUrl(input: {
   if (agentProviderId) {
     return managedAgentRoundedIconUrl(agentProviderId);
   }
-  const agentTargetId =
-    input.agentTargetId?.trim() ||
-    agentSessionTargetIdFromHref(input.href?.trim() ?? "") ||
-    "";
-  if (!agentTargetId.startsWith("local:")) {
-    return undefined;
-  }
-  const provider = agentTargetId.slice("local:".length).trim();
-  return provider ? managedAgentRoundedIconUrl(provider) : undefined;
+  return undefined;
 }
 
 export function mentionVisual(item: AgentContextMentionItem): {

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiTargetPresentation.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiTargetPresentation.spec.ts
@@ -3,7 +3,9 @@ import type { AgentGUIAgentTarget } from "../../../types";
 import {
   agentTargetPresentationKey,
   mergeAgentTargetsForMentionPresentations,
-  projectAgentTargetPresentations
+  projectAgentTargetPresentations,
+  projectMentionAgentTargetPresentations,
+  resolveMentionAgentTargetsForPresentations
 } from "./agentGuiTargetPresentation";
 
 const TARGET: AgentGUIAgentTarget = {
@@ -116,6 +118,53 @@ describe("Agent GUI target presentation projection", () => {
         agentTargetId: "shared-agent:jun-codex",
         iconUrl: "data:image/png;base64,shared-codex",
         name: "Jun Sun 的 Codex"
+      }
+    ]);
+  });
+
+  it("uses a complete identity catalog instead of action projections", () => {
+    const local: AgentGUIAgentTarget = {
+      ...TARGET,
+      agentTargetId: "local:codex",
+      label: "Codex",
+      provider: "codex",
+      targetId: "local:codex"
+    };
+    const offlineShared: AgentGUIAgentTarget = {
+      ...TARGET,
+      agentTargetId: "shared-agent:rv4no-codex",
+      disabled: true,
+      iconUrl: "data:image/png;base64,shared-codex",
+      label: "Codex",
+      ownerLabel: "rv4no",
+      ownership: "shared",
+      provider: "codex",
+      targetId: "shared-agent:rv4no-codex"
+    };
+
+    expect(
+      resolveMentionAgentTargetsForPresentations({
+        handoffTargets: [local],
+        mentionTargets: [offlineShared],
+        railTargets: [local]
+      })
+    ).toEqual([offlineShared]);
+    expect(
+      projectMentionAgentTargetPresentations({
+        handoffTargets: [local],
+        mentionTargets: [offlineShared],
+        ownerSeparator: "'s ",
+        railTargets: [local],
+        workspaceId: "workspace-1"
+      })
+    ).toEqual([
+      {
+        agentTargetId: "shared-agent:rv4no-codex",
+        iconUrl: "data:image/png;base64,shared-codex",
+        maskIconUrl: TARGET.maskIconUrl,
+        name: "rv4no's Codex",
+        provider: "codex",
+        workspaceId: "workspace-1"
       }
     ]);
   });

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiTargetPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiTargetPresentation.ts
@@ -19,10 +19,8 @@ export function agentTargetPresentationKey(
 }
 
 /**
- * Transcript mentions are markdown links that only carry target id + workspace.
- * Icon lookup therefore needs every Agent the host can already hand off to, not
- * only the current directory rail. Local conversations that @ a shared Agent
- * otherwise miss the target and fall back to the colorful "all agents" glyph.
+ * Legacy hosts only expose action catalogs. Keep their transcript identity
+ * lookup broad enough to cover both rail and handoff targets.
  */
 export function mergeAgentTargetsForMentionPresentations(
   railTargets: readonly AgentGUIAgentTarget[],
@@ -48,26 +46,43 @@ export function mergeAgentTargetsForMentionPresentations(
   return byId.size === railTargets.length ? railTargets : [...byId.values()];
 }
 
+export function resolveMentionAgentTargetsForPresentations(input: {
+  handoffTargets?: readonly AgentGUIAgentTarget[];
+  mentionTargets?: readonly AgentGUIAgentTarget[];
+  railTargets: readonly AgentGUIAgentTarget[];
+}): readonly AgentGUIAgentTarget[] {
+  return (
+    input.mentionTargets ??
+    mergeAgentTargetsForMentionPresentations(
+      input.railTargets,
+      input.handoffTargets
+    )
+  );
+}
+
 export function mentionAgentTargetPresentationKey(
   railTargets: readonly AgentGUIAgentTarget[],
-  handoffTargets: readonly AgentGUIAgentTarget[] = []
+  handoffTargets: readonly AgentGUIAgentTarget[] = [],
+  mentionTargets?: readonly AgentGUIAgentTarget[]
 ): string {
   return agentTargetPresentationKey(
-    mergeAgentTargetsForMentionPresentations(railTargets, handoffTargets)
+    resolveMentionAgentTargetsForPresentations({
+      handoffTargets,
+      mentionTargets,
+      railTargets
+    })
   );
 }
 
 export function projectMentionAgentTargetPresentations(input: {
   handoffTargets?: readonly AgentGUIAgentTarget[];
+  mentionTargets?: readonly AgentGUIAgentTarget[];
   ownerSeparator: string;
   railTargets: readonly AgentGUIAgentTarget[];
   workspaceId: string;
 }): readonly AgentMessageMarkdownAgentTarget[] {
   return projectAgentTargetPresentations({
-    agentTargets: mergeAgentTargetsForMentionPresentations(
-      input.railTargets,
-      input.handoffTargets
-    ),
+    agentTargets: resolveMentionAgentTargetsForPresentations(input),
     ownerSeparator: input.ownerSeparator,
     workspaceId: input.workspaceId
   });

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
@@ -17,6 +17,7 @@ import type { WorkspaceLinkAction } from "../../../actions/workspaceLinkActions"
 import type {
   AgentGUIProvider,
   AgentGUIProviderRailAllPresentation,
+  AgentGUIAgentTarget,
   AgentGUIAgentTargetInfoRenderer
 } from "../../../types";
 import type { AgentMessageMarkdownWorkspaceAppIcon } from "../../../shared/AgentMessageMarkdown";
@@ -567,6 +568,8 @@ type AgentGUIComposerExternalPromptProps = Pick<
 >;
 export interface AgentGUINodeViewProps extends AgentGUIComposerExternalPromptProps {
   viewModel: AgentGUINodeViewModel;
+  /** Complete presentation-only catalog for exact Agent mention identity. */
+  mentionAgentTargets?: readonly AgentGUIAgentTarget[];
   referenceProvenanceFilters?: AgentComposerReferenceProvenanceFilters | null;
   sessionInputHistoryEnabled?: boolean;
   sessionForkEnabled?: boolean;

--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -7,6 +7,11 @@ import {
   waitFor
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { RichTextMentionServiceProvider } from "@tutti-os/ui-rich-text/editor";
+import type {
+  RichTextMentionService,
+  RichTextMentionSnapshot
+} from "@tutti-os/ui-rich-text/service";
 import {
   AgentMessageMarkdown,
   resetCachedMarkdownImagesForTests,
@@ -1630,6 +1635,71 @@ describe("AgentMessageMarkdown", () => {
     expect(mention).toHaveAttribute("data-agent-mention-kind", "agent-target");
     expect(mention).toHaveAttribute("data-agent-mention-icon-url", iconUrl);
     expect(mention?.querySelector("img")).toHaveAttribute("src", iconUrl);
+  });
+
+  it("keeps exact target-directory icons over stale mention-service presentations", () => {
+    const currentIconUrl = "data:image/png;base64,current-codex";
+    const staleUnifiedIconUrl = "data:image/png;base64,stale-unified";
+    const snapshot: RichTextMentionSnapshot = {
+      state: "ready",
+      resolved: {
+        label: "Stale Unified Agent",
+        presentation: { iconUrl: staleUnifiedIconUrl }
+      }
+    };
+    const mentionService: RichTextMentionService = {
+      dispose: vi.fn(),
+      getProvider: () => undefined,
+      getSnapshot: () => snapshot,
+      invalidate: vi.fn(),
+      listProviders: () => [],
+      listTriggerConfigs: () => [],
+      query: async () => [],
+      resolve: async () => snapshot,
+      subscribe: () => () => {}
+    };
+    const { container } = render(
+      <RichTextMentionServiceProvider service={mentionService}>
+        <AgentMessageMarkdown
+          agentTargets={[
+            {
+              agentTargetId: "shared-agent:rv4no-codex",
+              iconUrl: currentIconUrl,
+              name: "rv4no's Codex",
+              provider: "codex",
+              workspaceId: "room-1"
+            }
+          ]}
+          content={
+            "[@rv4no's Codex](mention://agent-target/shared-agent:rv4no-codex?workspaceId=room-1) [@Build session](mention://agent-session/session-1?agentTargetId=shared-agent%3Arv4no-codex&workspaceId=room-1) [@Missing target](mention://agent-target/shared-agent:missing?workspaceId=room-1)"
+          }
+        />
+      </RichTextMentionServiceProvider>
+    );
+
+    const targetMention = container.querySelector(
+      '[data-agent-mention-kind="agent-target"]'
+    );
+    const sessionMention = container.querySelector(
+      '[data-agent-mention-kind="session"]'
+    );
+    const missingTargetMention = container.querySelector(
+      '[data-agent-mention-href*="shared-agent:missing"]'
+    );
+    expect(targetMention).toHaveTextContent("rv4no's Codex");
+    expect(targetMention?.querySelector("img")).toHaveAttribute(
+      "src",
+      currentIconUrl
+    );
+    expect(sessionMention?.querySelector("img")).toHaveAttribute(
+      "src",
+      currentIconUrl
+    );
+    expect(missingTargetMention).toHaveTextContent("Stale Unified Agent");
+    expect(missingTargetMention?.querySelector("img")).toHaveAttribute(
+      "src",
+      staleUnifiedIconUrl
+    );
   });
 
   it("falls back to a scoped provider icon when the presentation catalog misses", () => {

--- a/packages/agent/gui/shared/AgentMessageMarkdown.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.tsx
@@ -32,6 +32,7 @@ import {
   useAgentTargetPresentations,
   type AgentMessageMarkdownAgentTarget
 } from "./AgentTargetPresentationContext";
+import { resolveAgentMentionTargetPresentation } from "./agentTargetPresentation";
 import {
   activateMarkdownLink,
   activateMarkdownLinkFromKey,
@@ -461,6 +462,7 @@ function MarkdownLink({
     return (
       <MentionLink
         {...props}
+        agentTargets={agentTargets ?? EMPTY_AGENT_TARGETS}
         href={targetHref}
         mention={mention}
         onLinkClick={onLinkClick}
@@ -653,12 +655,14 @@ function WorkspaceFileMentionLink({
 }
 
 function MentionLink({
+  agentTargets,
   onClick: _onClick,
   onLinkClick,
   href,
   mention,
   ...props
 }: AnchorHTMLAttributes<HTMLAnchorElement> & {
+  agentTargets: readonly AgentMessageMarkdownAgentTarget[];
   href: string;
   mention: ParsedMentionLink;
   onLinkClick?: (href: string) => void;
@@ -671,13 +675,33 @@ function MentionLink({
     scope: mention.scope
   });
   const resolved = snapshot.state === "ready" ? snapshot.resolved : undefined;
-  const label = resolved?.label?.trim() || mention.label;
   const presentation = resolved?.presentation;
-  const iconUrl =
+  const fallbackIconUrl =
     presentation?.iconUrl?.trim() ||
     presentation?.thumbnailUrl?.trim() ||
     presentation?.agentIconUrl?.trim() ||
     mention.iconUrl;
+  const fallbackLabel = resolved?.label?.trim() || mention.label;
+  const agentTargetPresentation =
+    mention.kind === "agent-target" || mention.kind === "session"
+      ? resolveAgentMentionTargetPresentation({
+          agentTargetId:
+            mention.kind === "agent-target"
+              ? mention.entityId
+              : mention.scope?.agentTargetId,
+          agentTargets,
+          fallbackIconUrl,
+          fallbackName: fallbackLabel,
+          fallbackProvider:
+            presentation?.agentProviderId?.trim() || mention.agentProviderId,
+          workspaceId: mention.scope?.workspaceId
+        })
+      : null;
+  const label =
+    mention.kind === "agent-target"
+      ? (agentTargetPresentation?.name ?? fallbackLabel)
+      : fallbackLabel;
+  const iconUrl = agentTargetPresentation?.iconUrl ?? fallbackIconUrl;
   const pillKind =
     mention.kind === "workspace-issue" || mention.referenceSource === "task"
       ? "issue"

--- a/packages/agent/gui/shared/AgentRichTextReadonly.tsx
+++ b/packages/agent/gui/shared/AgentRichTextReadonly.tsx
@@ -9,7 +9,6 @@ import { AgentMentionReadonlyView } from "../agent-gui/agentGuiNode/agentRichTex
 import type { AgentMessageMarkdownWorkspaceAppIcon } from "./AgentMessageMarkdown";
 import type { AgentGUIProviderSkillOption } from "../agent-gui/agentGuiNode/model/agentGuiNodeTypes";
 import {
-  resolveAgentTargetPresentation,
   useAgentTargetPresentations,
   type AgentMessageMarkdownAgentTarget
 } from "./AgentTargetPresentationContext";
@@ -60,12 +59,10 @@ export function AgentRichTextReadonly({
   );
   const contentDoc = useMemo(
     () =>
-      hydrateAgentRichTextMentionPresentations(
-        parsedDoc,
-        workspaceAppIcons,
-        effectiveAgentTargets
-      ),
-    [effectiveAgentTargets, parsedDoc, workspaceAppIcons]
+      workspaceAppIcons.length > 0
+        ? hydrateWorkspaceAppMentionIcons(parsedDoc, workspaceAppIcons)
+        : parsedDoc,
+    [parsedDoc, workspaceAppIcons]
   );
   const isMentionOnly = isMentionOnlyRichTextDoc(contentDoc);
   const extensions = useMemo(
@@ -83,12 +80,15 @@ export function AgentRichTextReadonly({
         options: {
           nodeMapping: {
             agentFileMention: ({ node }) => (
-              <AgentMentionReadonlyView attrs={node.attrs ?? {}} />
+              <AgentMentionReadonlyView
+                agentTargets={effectiveAgentTargets}
+                attrs={node.attrs ?? {}}
+              />
             )
           }
         }
       }),
-    [contentDoc, extensions]
+    [contentDoc, effectiveAgentTargets, extensions]
   );
 
   const handleClick = (event: MouseEvent<HTMLDivElement>) => {
@@ -150,21 +150,6 @@ function isMentionOnlyRichTextDoc(doc: JSONContent): boolean {
   return (
     inlineContent.length === 1 && inlineContent[0]?.type === "agentFileMention"
   );
-}
-
-function hydrateAgentRichTextMentionPresentations(
-  parsedDoc: JSONContent,
-  workspaceAppIcons: readonly AgentMessageMarkdownWorkspaceAppIcon[],
-  agentTargets: readonly AgentMessageMarkdownAgentTarget[]
-): JSONContent {
-  let doc = parsedDoc;
-  if (workspaceAppIcons.length > 0) {
-    doc = hydrateWorkspaceAppMentionIcons(doc, workspaceAppIcons);
-  }
-  if (agentTargets.length > 0) {
-    doc = hydrateAgentMentionPresentations(doc, agentTargets);
-  }
-  return doc;
 }
 
 function hydrateWorkspaceAppMentionIcons(
@@ -231,51 +216,4 @@ function resolveWorkspaceAppIconUrl(input: {
   return (
     exactMatch?.iconUrl?.trim() || fallbackMatch?.iconUrl?.trim() || undefined
   );
-}
-
-function hydrateAgentMentionPresentations(
-  node: JSONContent,
-  agentTargets: readonly AgentMessageMarkdownAgentTarget[]
-): JSONContent {
-  const nextContent = node.content?.map((child) =>
-    hydrateAgentMentionPresentations(child, agentTargets)
-  );
-  if (node.type !== "agentFileMention") {
-    return nextContent ? { ...node, content: nextContent } : node;
-  }
-  const attrs = node.attrs ?? {};
-  const kind = typeof attrs.kind === "string" ? attrs.kind : "";
-  if (kind !== "agent-target" && kind !== "session") {
-    return nextContent ? { ...node, content: nextContent } : node;
-  }
-  const agentTargetId =
-    kind === "session"
-      ? typeof attrs.agentTargetId === "string"
-        ? attrs.agentTargetId.trim()
-        : ""
-      : typeof attrs.targetId === "string"
-        ? attrs.targetId.trim()
-        : "";
-  const workspaceId =
-    typeof attrs.workspaceId === "string" ? attrs.workspaceId.trim() : "";
-  const target = resolveAgentTargetPresentation({
-    agentTargetId,
-    agentTargets,
-    workspaceId
-  });
-  if (!target) {
-    return nextContent ? { ...node, content: nextContent } : node;
-  }
-  return {
-    ...node,
-    attrs: {
-      ...node.attrs,
-      agentProviderId: target.provider?.trim() ?? "",
-      iconUrl: target.iconUrl?.trim() ?? "",
-      ...(kind === "agent-target"
-        ? { name: target.name?.trim() || attrs.name }
-        : {})
-    },
-    ...(nextContent ? { content: nextContent } : {})
-  };
 }

--- a/packages/agent/gui/shared/AgentTargetPresentationContext.tsx
+++ b/packages/agent/gui/shared/AgentTargetPresentationContext.tsx
@@ -1,13 +1,10 @@
 import { createContext, useContext, type JSX, type ReactNode } from "react";
+import type { AgentMessageMarkdownAgentTarget } from "./agentTargetPresentation";
 
-export interface AgentMessageMarkdownAgentTarget {
-  agentTargetId: string;
-  iconUrl?: string | null;
-  maskIconUrl?: string | null;
-  name?: string | null;
-  provider?: string | null;
-  workspaceId?: string | null;
-}
+export {
+  resolveAgentTargetPresentation,
+  type AgentMessageMarkdownAgentTarget
+} from "./agentTargetPresentation";
 
 const EMPTY_AGENT_TARGETS: readonly AgentMessageMarkdownAgentTarget[] =
   Object.freeze([]);
@@ -33,27 +30,4 @@ export function AgentTargetPresentationProvider({
 
 export function useAgentTargetPresentations(): readonly AgentMessageMarkdownAgentTarget[] {
   return useContext(AgentTargetPresentationContext);
-}
-
-export function resolveAgentTargetPresentation(input: {
-  agentTargetId: string;
-  agentTargets: readonly AgentMessageMarkdownAgentTarget[];
-  workspaceId?: string | null;
-}): AgentMessageMarkdownAgentTarget | null {
-  const agentTargetId = input.agentTargetId.trim();
-  if (!agentTargetId) {
-    return null;
-  }
-  const workspaceId = input.workspaceId?.trim() ?? "";
-  return (
-    input.agentTargets.find(
-      (target) =>
-        target.agentTargetId.trim() === agentTargetId &&
-        (target.workspaceId?.trim() ?? "") === workspaceId
-    ) ??
-    input.agentTargets.find(
-      (target) => target.agentTargetId.trim() === agentTargetId
-    ) ??
-    null
-  );
 }

--- a/packages/agent/gui/shared/agentMessageMarkdownLinks.ts
+++ b/packages/agent/gui/shared/agentMessageMarkdownLinks.ts
@@ -10,9 +10,9 @@ import {
 import { managedAgentRoundedIconUrl } from "./managedAgentIcons";
 import { isDirectAgentGeneratedMediaPath } from "../actions/workspaceFilePathCandidate";
 import {
-  resolveAgentTargetPresentation,
+  resolveAgentMentionTargetPresentation,
   type AgentMessageMarkdownAgentTarget
-} from "./AgentTargetPresentationContext";
+} from "./agentTargetPresentation";
 import type { AgentMessageMarkdownWorkspaceAppIcon } from "./AgentMessageMarkdown";
 
 const PLAIN_SESSION_MENTION_AGENT_LABELS = [
@@ -550,42 +550,36 @@ export function parseMentionLink(
   }
   if (kind === "agent-target") {
     const workspaceId = mention.scope?.workspaceId?.trim() || "";
-    const target = resolveAgentTargetPresentation({
+    const scopedProvider = mention.scope?.agentProviderId?.trim() || "";
+    const presentation = resolveAgentMentionTargetPresentation({
       agentTargetId: entityId,
       agentTargets,
+      fallbackIconUrl: managedAgentRoundedIconUrl(scopedProvider || undefined),
+      fallbackName: label,
+      fallbackProvider: scopedProvider,
       workspaceId
     });
-    const scopedProvider = mention.scope?.agentProviderId?.trim() || "";
-    const agentProviderId =
-      target?.provider?.trim() || scopedProvider || undefined;
-    const targetLabel = target?.name?.trim() || label;
     return {
       ...identity,
-      agentProviderId,
+      agentProviderId: presentation.provider,
       kind,
-      label: targetLabel,
-      iconUrl:
-        target?.iconUrl?.trim() || managedAgentRoundedIconUrl(agentProviderId)
+      label: presentation.name ?? label,
+      iconUrl: presentation.iconUrl
     };
   }
   if (kind === "session") {
     const workspaceId = mention.scope?.workspaceId?.trim() || "";
     const agentTargetId = mention.scope?.agentTargetId?.trim() || "";
-    const target = resolveAgentTargetPresentation({
+    const presentation = resolveAgentMentionTargetPresentation({
       agentTargetId,
       agentTargets,
       workspaceId
     });
-    const localProvider = agentTargetId.startsWith("local:")
-      ? agentTargetId.slice("local:".length).trim()
-      : "";
     return {
       ...identity,
       kind,
       label,
-      iconUrl:
-        target?.iconUrl?.trim() ||
-        (localProvider ? managedAgentRoundedIconUrl(localProvider) : undefined)
+      iconUrl: presentation.iconUrl
     };
   }
   if (kind === "workspace-reference") {

--- a/packages/agent/gui/shared/agentTargetPresentation.spec.ts
+++ b/packages/agent/gui/shared/agentTargetPresentation.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { resolveAgentMentionTargetPresentation } from "./agentTargetPresentation";
+
+describe("resolveAgentMentionTargetPresentation", () => {
+  it("prefers the exact workspace target over stale serialized metadata", () => {
+    expect(
+      resolveAgentMentionTargetPresentation({
+        agentTargetId: "extension:gemini",
+        agentTargets: [
+          {
+            agentTargetId: "extension:gemini",
+            iconUrl: "current-icon",
+            name: "Gemini CLI",
+            provider: "acp:gemini",
+            workspaceId: "workspace-1"
+          }
+        ],
+        fallbackIconUrl: "stale-icon",
+        fallbackName: "Old Gemini",
+        fallbackProvider: "all-agents",
+        workspaceId: "workspace-1"
+      })
+    ).toMatchObject({
+      iconUrl: "current-icon",
+      name: "Gemini CLI",
+      provider: "acp:gemini"
+    });
+  });
+
+  it("keeps the supplied provider fallback when the directory has no match", () => {
+    const presentation = resolveAgentMentionTargetPresentation({
+      agentTargetId: "local:codex",
+      agentTargets: [],
+      fallbackProvider: "codex"
+    });
+
+    expect(presentation.provider).toBe("codex");
+    expect(presentation.iconUrl).toContain("codex");
+    expect(presentation.target).toBeNull();
+  });
+});

--- a/packages/agent/gui/shared/agentTargetPresentation.ts
+++ b/packages/agent/gui/shared/agentTargetPresentation.ts
@@ -1,0 +1,72 @@
+import { managedAgentRoundedIconUrl } from "./managedAgentIcons";
+
+export interface AgentMessageMarkdownAgentTarget {
+  agentTargetId: string;
+  iconUrl?: string | null;
+  maskIconUrl?: string | null;
+  name?: string | null;
+  provider?: string | null;
+  workspaceId?: string | null;
+}
+
+export interface ResolvedAgentMentionTargetPresentation {
+  iconUrl: string | undefined;
+  name: string | undefined;
+  provider: string | undefined;
+  target: AgentMessageMarkdownAgentTarget | null;
+}
+
+export function resolveAgentTargetPresentation(input: {
+  agentTargetId: string;
+  agentTargets: readonly AgentMessageMarkdownAgentTarget[];
+  workspaceId?: string | null;
+}): AgentMessageMarkdownAgentTarget | null {
+  const agentTargetId = input.agentTargetId.trim();
+  if (!agentTargetId) {
+    return null;
+  }
+  const workspaceId = input.workspaceId?.trim() ?? "";
+  return (
+    input.agentTargets.find(
+      (target) =>
+        target.agentTargetId.trim() === agentTargetId &&
+        (target.workspaceId?.trim() ?? "") === workspaceId
+    ) ??
+    input.agentTargets.find(
+      (target) => target.agentTargetId.trim() === agentTargetId
+    ) ??
+    null
+  );
+}
+
+/**
+ * Resolves every Agent mention surface from the same target directory.
+ * Serialized mention metadata is only a fallback because it can outlive the
+ * Agent directory entry that owns the current name, provider, and icon.
+ */
+export function resolveAgentMentionTargetPresentation(input: {
+  agentTargetId?: string | null;
+  agentTargets: readonly AgentMessageMarkdownAgentTarget[];
+  fallbackIconUrl?: string | null;
+  fallbackName?: string | null;
+  fallbackProvider?: string | null;
+  workspaceId?: string | null;
+}): ResolvedAgentMentionTargetPresentation {
+  const agentTargetId = input.agentTargetId?.trim() ?? "";
+  const target = resolveAgentTargetPresentation({
+    agentTargetId,
+    agentTargets: input.agentTargets,
+    workspaceId: input.workspaceId
+  });
+  const provider =
+    target?.provider?.trim() || input.fallbackProvider?.trim() || undefined;
+  return {
+    iconUrl:
+      target?.iconUrl?.trim() ||
+      input.fallbackIconUrl?.trim() ||
+      (provider ? managedAgentRoundedIconUrl(provider) : undefined),
+    name: target?.name?.trim() || input.fallbackName?.trim() || undefined,
+    provider,
+    target
+  };
+}


### PR DESCRIPTION
## Summary
- centralize Agent target and Session mention presentation across composer, readonly rich text, and Markdown
- add a complete presentation-only mention directory that preserves exact offline and shared Agent identities without granting launch capability
- prefer the current target directory over stale mention-service presentation snapshots

## Tests
- `pnpm --filter @tutti-os/agent-gui test -- AgentGUI.spec.tsx agentGuiTargetPresentation.spec.ts AgentMessageMarkdown.spec.tsx` (315 files, 2783 tests)
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm check:changed -- --push-ready` (12 lanes)

## Notes
- Hosts that omit `mentionAgentDirectory` retain the existing rail + handoff presentation catalog.
- The presentation directory does not affect selection, setup, admission, or handoff.