### PR TITLE
fix(agent): harden Windows agent compatibility

### DIFF
--- a/docs/architecture/agent-runtime-preparation.md
+++ b/docs/architecture/agent-runtime-preparation.md
@@ -118,13 +118,14 @@ skill roots, and merge those session roots into a supported YAML string-list key
 such as `skills.external_dirs`.
 
 Source-home resolution is also descriptor-driven. A declared source environment
-variable has highest priority. Otherwise, `sourceDefaultRel` first resolves
-literally under the user's home so existing Unix-style locations keep working.
-On Windows, when that literal directory does not exist and its top-level name
-starts with a dot, runtimeprep also resolves the portable name under the native
-user cache root, removing the leading dot (for example `.vendor` becomes
-`%LOCALAPPDATA%\vendor`). The shared resolver remains provider-neutral and only
-copies files explicitly declared by the signed profile.
+variable has highest priority. On Windows, a `sourceDefaultRel` whose top-level
+name starts with a dot first resolves under the native user cache root with the
+leading dot removed (for example `.vendor` becomes `%LOCALAPPDATA%\vendor`). If
+that native directory does not exist, runtimeprep falls back to the literal
+user-home-relative directory so migrated Unix-style locations keep working.
+Other platforms keep the literal user-home-relative default. The shared resolver
+remains provider-neutral and only copies files explicitly declared by the signed
+profile.
 
 For Hermes, the extension profile declares the `HERMES_HOME` overlay instead of
 Tutti core knowing `acp:hermes`. The resulting session keeps per-session state,

--- a/docs/architecture/agent-runtime-preparation.md
+++ b/docs/architecture/agent-runtime-preparation.md
@@ -117,6 +117,15 @@ skills into session-scoped roots derived from the extension's declared workspace
 skill roots, and merge those session roots into a supported YAML string-list key
 such as `skills.external_dirs`.
 
+Source-home resolution is also descriptor-driven. A declared source environment
+variable has highest priority. Otherwise, `sourceDefaultRel` first resolves
+literally under the user's home so existing Unix-style locations keep working.
+On Windows, when that literal directory does not exist and its top-level name
+starts with a dot, runtimeprep also resolves the portable name under the native
+user cache root, removing the leading dot (for example `.vendor` becomes
+`%LOCALAPPDATA%\vendor`). The shared resolver remains provider-neutral and only
+copies files explicitly declared by the signed profile.
+
 For Hermes, the extension profile declares the `HERMES_HOME` overlay instead of
 Tutti core knowing `acp:hermes`. The resulting session keeps per-session state,
 copies only the declared auth/env/config files needed for provider login, and

--- a/docs/architecture/windows-platform-support.md
+++ b/docs/architecture/windows-platform-support.md
@@ -211,11 +211,11 @@ Registry changes affect new processes only, so an already-open terminal must be
 restarted before it can resolve a newly published command.
 
 Extension session-home preparation keeps its source declaration portable. An
-explicit source environment variable wins; otherwise the shared resolver
-preserves an existing user-home-relative directory and lets the Windows adapter
-map a leading-dot top-level directory to the native user cache root
-(`%LOCALAPPDATA%`). Provider IDs and Windows path literals must not leak into
-extension or Agent lifecycle policy.
+explicit source environment variable wins; otherwise the Windows adapter maps a
+leading-dot top-level directory to the native user cache root
+(`%LOCALAPPDATA%`) before the shared resolver considers a migrated literal
+user-home-relative directory. Provider IDs and Windows path literals must not
+leak into extension or Agent lifecycle policy.
 
 System proxy resolution follows the same shared precedence on macOS and
 Windows: session/process environment, then the operating-system static proxy,

--- a/docs/architecture/windows-platform-support.md
+++ b/docs/architecture/windows-platform-support.md
@@ -210,6 +210,13 @@ write failures, while status-time adoption repairs PATH on a best-effort basis.
 Registry changes affect new processes only, so an already-open terminal must be
 restarted before it can resolve a newly published command.
 
+Extension session-home preparation keeps its source declaration portable. An
+explicit source environment variable wins; otherwise the shared resolver
+preserves an existing user-home-relative directory and lets the Windows adapter
+map a leading-dot top-level directory to the native user cache root
+(`%LOCALAPPDATA%`). Provider IDs and Windows path literals must not leak into
+extension or Agent lifecycle policy.
+
 System proxy resolution follows the same shared precedence on macOS and
 Windows: session/process environment, then the operating-system static proxy,
 then direct connection. The common resolver owns merging, `NO_PROXY`, caching,

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -23,15 +23,17 @@ Provider discovery, installation, authentication, models, configuration, and run
 - Fix:
   Keep an explicit `HERMES_HOME` as the highest-priority source. Otherwise,
   preserve an existing `%USERPROFILE%\.hermes`; when it is absent, resolve the
-  portable leading-dot directory through the Windows user cache root and copy
-  only the files declared by the signed runtime-preparation profile. Keep this
-  behavior in the platform adapter rather than branching on `acp:hermes`.
+  resolve the portable leading-dot directory through the Windows user cache
+  root first, then fall back to a migrated `%USERPROFILE%\.hermes` only when the
+  native directory is absent. Copy only the files declared by the signed
+  runtime-preparation profile. Keep this behavior in the platform adapter rather
+  than branching on `acp:hermes`.
 - Validation:
   With no user-level `HERMES_HOME`, place credentials in
   `%LOCALAPPDATA%\hermes`, create a new session, and verify the model picker is
   populated and the first message starts successfully. Confirm an explicit
-  source environment variable and an existing `%USERPROFILE%\.hermes` still
-  take precedence.
+  source environment variable still takes precedence, and that a migrated
+  `%USERPROFILE%\.hermes` is used only when the native directory is absent.
 - References:
   [agent-runtime-preparation.md](../../architecture/agent-runtime-preparation.md)
   [windows-platform-support.md](../../architecture/windows-platform-support.md)

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -4,6 +4,39 @@
 
 Provider discovery, installation, authentication, models, configuration, and runtime reachability.
 
+### Hermes is ready but a new Windows session reports Agent failed to start
+
+- Symptom:
+  Hermes passes setup detection, but the new-conversation model picker is empty
+  and sending the first message reports `Agent failed to start`.
+- Quick checks:
+  In the daemon log, compare setup-probe configuration with the session-scoped
+  `HERMES_HOME`. The failing session typically reports no `.env` in its
+  `.tutti*/agent/runs/<session>/hermes` directory, followed by ACP `session/new`
+  returning `No LLM provider configured`. Check whether the working user config
+  is under `%LOCALAPPDATA%\hermes` while `%USERPROFILE%\.hermes` is absent.
+- Root cause:
+  The signed extension profile uses the portable default `.hermes`, but the
+  shared runtime preparer previously resolved it only relative to the Windows
+  user profile. Hermes itself uses the native Windows user cache location, so
+  discovery could see credentials while the isolated session home copied none.
+- Fix:
+  Keep an explicit `HERMES_HOME` as the highest-priority source. Otherwise,
+  preserve an existing `%USERPROFILE%\.hermes`; when it is absent, resolve the
+  portable leading-dot directory through the Windows user cache root and copy
+  only the files declared by the signed runtime-preparation profile. Keep this
+  behavior in the platform adapter rather than branching on `acp:hermes`.
+- Validation:
+  With no user-level `HERMES_HOME`, place credentials in
+  `%LOCALAPPDATA%\hermes`, create a new session, and verify the model picker is
+  populated and the first message starts successfully. Confirm an explicit
+  source environment variable and an existing `%USERPROFILE%\.hermes` still
+  take precedence.
+- References:
+  [agent-runtime-preparation.md](../../architecture/agent-runtime-preparation.md)
+  [windows-platform-support.md](../../architecture/windows-platform-support.md)
+  [extension_runtime.go](../../../packages/agent/runtimeprep/extension_runtime.go)
+
 ### Focusing a workspace repeatedly starts provider CLIs and raises CPU usage
 
 - Symptom:

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -8,6 +8,7 @@ Open only the area that matches the symptom:
 
 Provider discovery, installation, authentication, models, configuration, and runtime reachability.
 
+- [Hermes is ready but a new Windows session reports Agent failed to start](./agent-provider-setup.md#hermes-is-ready-but-a-new-windows-session-reports-agent-failed-to-start)
 - [An extension Agent is installed in the terminal but Tutti cannot detect it](./agent-provider-setup.md#an-extension-agent-is-installed-in-the-terminal-but-tutti-cannot-detect-it)
 - [Codex `/status` shows a 5h limit for a weekly-only account window](./agent-provider-setup.md#codex-status-shows-a-5h-limit-for-a-weekly-only-account-window)
 - [Bun-installed Codex works in a terminal but Tutti cannot use it](./agent-provider-setup.md#bun-installed-codex-works-in-a-terminal-but-tutti-cannot-use-it)

--- a/packages/agent/daemon/runtime/standard_acp_launch_settings_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_launch_settings_test.go
@@ -476,24 +476,43 @@ func TestStandardACPSessionNewAndLoadPassStandardClientMCPConfig(t *testing.T) {
 	}
 }
 
-func TestStandardACPSessionRejectsHTTPMCPWhenAgentDoesNotAdvertiseCapability(t *testing.T) {
+func TestStandardACPSessionOmitsHTTPMCPWhenAgentDoesNotAdvertiseCapability(t *testing.T) {
 	t.Parallel()
 
-	transport := newStandardACPTransport("MCP Unsupported ACP", "mcp-unsupported-session")
-	transport.conn.supportsHTTPMCP = false
-	adapter, err := NewStandardACPAdapter(StandardACPAdapterConfig{
+	newTransport := newStandardACPTransport("MCP Unsupported ACP", "mcp-unsupported-session")
+	newTransport.conn.supportsHTTPMCP = false
+	newAdapter, err := NewStandardACPAdapter(StandardACPAdapterConfig{
 		Provider: "acp:mcp-unsupported", Name: "mcp-unsupported-acp", DisplayName: "MCP Unsupported ACP", Command: []string{"mcp-acp", "stdio"},
-	}, transport, LegacyHostMetadata())
+	}, newTransport, LegacyHostMetadata())
 	if err != nil {
 		t.Fatalf("NewStandardACPAdapter: %v", err)
 	}
 	session := standardTestSession("acp:mcp-unsupported")
 	session.MCPServers = []MCPServerBinding{{Name: "connector", Type: "http", URL: "http://127.0.0.1:1234/mcp/connector"}}
-	if _, err := adapter.Start(context.Background(), session); !errors.Is(err, ErrMCPHTTPUnsupported) {
-		t.Fatalf("Start error = %v, want ErrMCPHTTPUnsupported", err)
+	if _, err := newAdapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
 	}
-	if transport.conn.lastNewSessionParams != nil {
-		t.Fatalf("session/new was sent despite unsupported HTTP MCP: %#v", transport.conn.lastNewSessionParams)
+	if servers, ok := newTransport.conn.lastNewSessionParams["mcpServers"].([]any); !ok || len(servers) != 0 {
+		t.Fatalf("session/new mcpServers = %#v, want empty fallback", newTransport.conn.lastNewSessionParams["mcpServers"])
+	}
+
+	loadTransport := newStandardACPTransport("MCP Unsupported ACP", "mcp-unsupported-load-session")
+	loadTransport.conn.supportsHTTPMCP = false
+	loadTransport.conn.supportsLoadSession = true
+	loadAdapter, err := NewStandardACPAdapter(StandardACPAdapterConfig{
+		Provider: "acp:mcp-unsupported", Name: "mcp-unsupported-acp", DisplayName: "MCP Unsupported ACP", Command: []string{"mcp-acp", "stdio"},
+	}, loadTransport, LegacyHostMetadata())
+	if err != nil {
+		t.Fatalf("NewStandardACPAdapter load: %v", err)
+	}
+	loadSession := standardTestSession("acp:mcp-unsupported")
+	loadSession.ProviderSessionID = "mcp-unsupported-load-session"
+	loadSession.MCPServers = cloneMCPServerBindings(session.MCPServers)
+	if err := loadAdapter.Resume(context.Background(), loadSession); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if servers, ok := loadTransport.conn.lastLoadSessionParams["mcpServers"].([]any); !ok || len(servers) != 0 {
+		t.Fatalf("session/load mcpServers = %#v, want empty fallback", loadTransport.conn.lastLoadSessionParams["mcpServers"])
 	}
 }
 

--- a/packages/agent/daemon/runtime/standard_acp_launch_settings_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_launch_settings_test.go
@@ -476,7 +476,7 @@ func TestStandardACPSessionNewAndLoadPassStandardClientMCPConfig(t *testing.T) {
 	}
 }
 
-func TestStandardACPSessionOmitsHTTPMCPWhenAgentDoesNotAdvertiseCapability(t *testing.T) {
+func TestStandardACPSessionRejectsHTTPMCPWhenAgentDoesNotAdvertiseCapability(t *testing.T) {
 	t.Parallel()
 
 	newTransport := newStandardACPTransport("MCP Unsupported ACP", "mcp-unsupported-session")
@@ -489,11 +489,11 @@ func TestStandardACPSessionOmitsHTTPMCPWhenAgentDoesNotAdvertiseCapability(t *te
 	}
 	session := standardTestSession("acp:mcp-unsupported")
 	session.MCPServers = []MCPServerBinding{{Name: "connector", Type: "http", URL: "http://127.0.0.1:1234/mcp/connector"}}
-	if _, err := newAdapter.Start(context.Background(), session); err != nil {
-		t.Fatalf("Start: %v", err)
+	if _, err := newAdapter.Start(context.Background(), session); !errors.Is(err, ErrMCPHTTPUnsupported) {
+		t.Fatalf("Start error = %v, want ErrMCPHTTPUnsupported", err)
 	}
-	if servers, ok := newTransport.conn.lastNewSessionParams["mcpServers"].([]any); !ok || len(servers) != 0 {
-		t.Fatalf("session/new mcpServers = %#v, want empty fallback", newTransport.conn.lastNewSessionParams["mcpServers"])
+	if newTransport.conn.lastNewSessionParams != nil {
+		t.Fatalf("session/new params = %#v, want no session creation", newTransport.conn.lastNewSessionParams)
 	}
 
 	loadTransport := newStandardACPTransport("MCP Unsupported ACP", "mcp-unsupported-load-session")
@@ -508,11 +508,11 @@ func TestStandardACPSessionOmitsHTTPMCPWhenAgentDoesNotAdvertiseCapability(t *te
 	loadSession := standardTestSession("acp:mcp-unsupported")
 	loadSession.ProviderSessionID = "mcp-unsupported-load-session"
 	loadSession.MCPServers = cloneMCPServerBindings(session.MCPServers)
-	if err := loadAdapter.Resume(context.Background(), loadSession); err != nil {
-		t.Fatalf("Resume: %v", err)
+	if err := loadAdapter.Resume(context.Background(), loadSession); !errors.Is(err, ErrMCPHTTPUnsupported) {
+		t.Fatalf("Resume error = %v, want ErrMCPHTTPUnsupported", err)
 	}
-	if servers, ok := loadTransport.conn.lastLoadSessionParams["mcpServers"].([]any); !ok || len(servers) != 0 {
-		t.Fatalf("session/load mcpServers = %#v, want empty fallback", loadTransport.conn.lastLoadSessionParams["mcpServers"])
+	if loadTransport.conn.lastLoadSessionParams != nil {
+		t.Fatalf("session/load params = %#v, want no session resume", loadTransport.conn.lastLoadSessionParams)
 	}
 }
 

--- a/packages/agent/daemon/runtime/standard_acp_session.go
+++ b/packages/agent/daemon/runtime/standard_acp_session.go
@@ -39,9 +39,14 @@ func (a *standardACPAdapter) Start(ctx context.Context, session Session) ([]acti
 		})
 		return nil, err
 	}
-	if len(acpMCPServers(session.MCPServers)) > 0 && !standardACPHTTPMCPSupported(initializeResult) {
-		_ = client.Close()
-		return nil, ErrMCPHTTPUnsupported
+	mcpServers := acpMCPServers(session.MCPServers)
+	if len(mcpServers) > 0 && !standardACPHTTPMCPSupported(initializeResult) {
+		a.logStandardACPStartupDiagnostics("mcp_http.unsupported", map[string]any{
+			"room_id":          session.RoomID,
+			"agent_session_id": session.AgentSessionID,
+			"binding_count":    len(mcpServers),
+		})
+		mcpServers = []any{}
 	}
 	started := false
 	keepSession := false
@@ -77,7 +82,7 @@ func (a *standardACPAdapter) Start(ctx context.Context, session Session) ([]acti
 
 	newSessionParams := map[string]any{
 		"cwd":        firstNonEmpty(session.CWD, "/"),
-		"mcpServers": acpMCPServers(session.MCPServers),
+		"mcpServers": mcpServers,
 	}
 	if err := a.applyProviderSessionMeta(newSessionParams, session); err != nil {
 		return nil, err
@@ -185,9 +190,14 @@ func (a *standardACPAdapter) Resume(ctx context.Context, session Session) error 
 	if err != nil {
 		return err
 	}
-	if !attachedCheckpoint && len(acpMCPServers(session.MCPServers)) > 0 && !standardACPHTTPMCPSupported(initializeResult) {
-		_ = client.Close()
-		return ErrMCPHTTPUnsupported
+	mcpServers := acpMCPServers(session.MCPServers)
+	if !attachedCheckpoint && len(mcpServers) > 0 && !standardACPHTTPMCPSupported(initializeResult) {
+		a.logStandardACPStartupDiagnostics("mcp_http.unsupported", map[string]any{
+			"room_id":          session.RoomID,
+			"agent_session_id": session.AgentSessionID,
+			"binding_count":    len(mcpServers),
+		})
+		mcpServers = []any{}
 	}
 	started := false
 	keepSession := false
@@ -256,7 +266,7 @@ func (a *standardACPAdapter) Resume(ctx context.Context, session Session) error 
 	resumeParams := map[string]any{
 		"sessionId":  session.ProviderSessionID,
 		"cwd":        firstNonEmpty(session.CWD, "/"),
-		"mcpServers": acpMCPServers(session.MCPServers),
+		"mcpServers": mcpServers,
 	}
 	if err := a.applyProviderSessionMeta(resumeParams, session); err != nil {
 		return err

--- a/packages/agent/daemon/runtime/standard_acp_session.go
+++ b/packages/agent/daemon/runtime/standard_acp_session.go
@@ -46,7 +46,8 @@ func (a *standardACPAdapter) Start(ctx context.Context, session Session) ([]acti
 			"agent_session_id": session.AgentSessionID,
 			"binding_count":    len(mcpServers),
 		})
-		mcpServers = []any{}
+		_ = client.Close()
+		return nil, ErrMCPHTTPUnsupported
 	}
 	started := false
 	keepSession := false
@@ -197,7 +198,8 @@ func (a *standardACPAdapter) Resume(ctx context.Context, session Session) error 
 			"agent_session_id": session.AgentSessionID,
 			"binding_count":    len(mcpServers),
 		})
-		mcpServers = []any{}
+		_ = client.Close()
+		return ErrMCPHTTPUnsupported
 	}
 	started := false
 	keepSession := false

--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -636,12 +636,12 @@ describe("AgentMessageMarkdown", () => {
 
     render(
       <AgentMessageMarkdown
-        content={"![generated image](<C:/Users/local user/project/image.png>)"}
+        content={String.raw`![generated image](X:\screenshots\browser.png)`}
       />
     );
 
     expect(readFile).toHaveBeenCalledWith({
-      path: "C:/Users/local user/project/image.png"
+      path: "X:/screenshots/browser.png"
     });
     expect(
       await screen.findByRole("img", {

--- a/packages/agent/gui/shared/agentMessageMarkdownLinks.ts
+++ b/packages/agent/gui/shared/agentMessageMarkdownLinks.ts
@@ -73,15 +73,15 @@ export function resolveMarkdownWorkspaceMediaPath(src: string): string | null {
   const candidate = src.trim();
   const fileUrlPath = resolveMarkdownFileUrlPath(candidate);
   const pathCandidate = fileUrlPath ?? candidate;
-  if (
-    !isLocalAbsolutePath(pathCandidate) &&
-    !isWindowsAbsolutePath(pathCandidate)
-  ) {
-    return null;
-  }
-
   try {
     const decodedPath = fileUrlPath ?? decodeURIComponent(pathCandidate);
+    if (
+      !isLocalAbsolutePath(pathCandidate) &&
+      !isWindowsAbsolutePath(pathCandidate) &&
+      !isWindowsAbsolutePath(decodedPath)
+    ) {
+      return null;
+    }
     const isPosixAbsolutePath =
       decodedPath.length > 1 &&
       decodedPath.startsWith("/") &&

--- a/packages/agent/runtimeprep/extension_runtime.go
+++ b/packages/agent/runtimeprep/extension_runtime.go
@@ -106,11 +106,11 @@ func resolveExtensionRuntimeSourceHome(home ExtensionRuntimeHome) string {
 	}
 
 	candidates := []string{}
-	if userHome, err := os.UserHomeDir(); err == nil && userHome != "" {
-		candidates = appendUniquePath(candidates, filepath.Join(userHome, filepath.FromSlash(rel)))
-	}
 	if platformHome := extensionRuntimePlatformSourceHome(rel); platformHome != "" {
 		candidates = appendUniquePath(candidates, platformHome)
+	}
+	if userHome, err := os.UserHomeDir(); err == nil && userHome != "" {
+		candidates = appendUniquePath(candidates, filepath.Join(userHome, filepath.FromSlash(rel)))
 	}
 	for _, candidate := range candidates {
 		info, err := os.Stat(candidate)

--- a/packages/agent/runtimeprep/extension_runtime.go
+++ b/packages/agent/runtimeprep/extension_runtime.go
@@ -100,10 +100,30 @@ func resolveExtensionRuntimeSourceHome(home ExtensionRuntimeHome) string {
 			return v
 		}
 	}
-	if rel := strings.TrimSpace(home.SourceDefaultRel); rel != "" {
-		if userHome, err := os.UserHomeDir(); err == nil && userHome != "" {
-			return filepath.Join(userHome, filepath.FromSlash(rel))
+	rel := strings.TrimSpace(home.SourceDefaultRel)
+	if rel == "" {
+		return ""
+	}
+
+	candidates := []string{}
+	if userHome, err := os.UserHomeDir(); err == nil && userHome != "" {
+		candidates = appendUniquePath(candidates, filepath.Join(userHome, filepath.FromSlash(rel)))
+	}
+	if platformHome := extensionRuntimePlatformSourceHome(rel); platformHome != "" {
+		candidates = appendUniquePath(candidates, platformHome)
+	}
+	for _, candidate := range candidates {
+		info, err := os.Stat(candidate)
+		if err == nil && info.IsDir() {
+			return candidate
 		}
+		if err != nil && !os.IsNotExist(err) {
+			return candidate
+		}
+	}
+	if len(candidates) > 0 {
+		// Preserve the original default even when it has not been created yet.
+		return candidates[0]
 	}
 	return ""
 }

--- a/packages/agent/runtimeprep/extension_runtime_source_other.go
+++ b/packages/agent/runtimeprep/extension_runtime_source_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package runtimeprep
+
+func extensionRuntimePlatformSourceHome(string) string {
+	return ""
+}

--- a/packages/agent/runtimeprep/extension_runtime_source_windows.go
+++ b/packages/agent/runtimeprep/extension_runtime_source_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package runtimeprep
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func extensionRuntimePlatformSourceHome(rel string) string {
+	clean := filepath.Clean(filepath.FromSlash(strings.TrimSpace(rel)))
+	parts := strings.Split(clean, string(filepath.Separator))
+	if len(parts) == 0 || len(parts[0]) < 2 || !strings.HasPrefix(parts[0], ".") || strings.HasPrefix(parts[0], "..") {
+		return ""
+	}
+	parts[0] = strings.TrimPrefix(parts[0], ".")
+	cacheHome, err := os.UserCacheDir()
+	if err != nil || strings.TrimSpace(cacheHome) == "" {
+		return ""
+	}
+	return filepath.Join(append([]string{cacheHome}, parts...)...)
+}

--- a/packages/agent/runtimeprep/extension_runtime_source_windows_test.go
+++ b/packages/agent/runtimeprep/extension_runtime_source_windows_test.go
@@ -1,0 +1,59 @@
+package runtimeprep
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveExtensionRuntimeSourceHomeUsesWindowsUserCacheFallback(t *testing.T) {
+	userHome := t.TempDir()
+	localAppData := t.TempDir()
+	t.Setenv("USERPROFILE", userHome)
+	t.Setenv("LOCALAPPDATA", localAppData)
+	t.Setenv("HERMES_HOME", "")
+
+	windowsHome := filepath.Join(localAppData, "hermes")
+	if err := os.MkdirAll(windowsHome, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(windowsHome, ".env"), []byte("OPENAI_API_KEY=test\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := resolveExtensionRuntimeSourceHome(*hermesRuntimePrep().Home)
+	if got != windowsHome {
+		t.Fatalf("resolve source home = %q, want %q", got, windowsHome)
+	}
+}
+
+func TestResolveExtensionRuntimeSourceHomePrefersLiteralUserHomeDefault(t *testing.T) {
+	userHome := t.TempDir()
+	localAppData := t.TempDir()
+	t.Setenv("USERPROFILE", userHome)
+	t.Setenv("LOCALAPPDATA", localAppData)
+	t.Setenv("HERMES_HOME", "")
+
+	literalHome := filepath.Join(userHome, ".hermes")
+	windowsHome := filepath.Join(localAppData, "hermes")
+	for _, dir := range []string{literalHome, windowsHome} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got := resolveExtensionRuntimeSourceHome(*hermesRuntimePrep().Home)
+	if got != literalHome {
+		t.Fatalf("resolve source home = %q, want %q", got, literalHome)
+	}
+}
+
+func TestResolveExtensionRuntimeSourceHomePrefersExplicitEnvironment(t *testing.T) {
+	explicitHome := t.TempDir()
+	t.Setenv("HERMES_HOME", explicitHome)
+
+	got := resolveExtensionRuntimeSourceHome(*hermesRuntimePrep().Home)
+	if got != explicitHome {
+		t.Fatalf("resolve source home = %q, want %q", got, explicitHome)
+	}
+}

--- a/packages/agent/runtimeprep/extension_runtime_source_windows_test.go
+++ b/packages/agent/runtimeprep/extension_runtime_source_windows_test.go
@@ -27,7 +27,7 @@ func TestResolveExtensionRuntimeSourceHomeUsesWindowsUserCacheFallback(t *testin
 	}
 }
 
-func TestResolveExtensionRuntimeSourceHomePrefersLiteralUserHomeDefault(t *testing.T) {
+func TestResolveExtensionRuntimeSourceHomePrefersWindowsUserCacheDefault(t *testing.T) {
 	userHome := t.TempDir()
 	localAppData := t.TempDir()
 	t.Setenv("USERPROFILE", userHome)
@@ -40,6 +40,24 @@ func TestResolveExtensionRuntimeSourceHomePrefersLiteralUserHomeDefault(t *testi
 		if err := os.MkdirAll(dir, 0o700); err != nil {
 			t.Fatal(err)
 		}
+	}
+
+	got := resolveExtensionRuntimeSourceHome(*hermesRuntimePrep().Home)
+	if got != windowsHome {
+		t.Fatalf("resolve source home = %q, want %q", got, windowsHome)
+	}
+}
+
+func TestResolveExtensionRuntimeSourceHomeFallsBackToLiteralUserHomeDefault(t *testing.T) {
+	userHome := t.TempDir()
+	localAppData := t.TempDir()
+	t.Setenv("USERPROFILE", userHome)
+	t.Setenv("LOCALAPPDATA", localAppData)
+	t.Setenv("HERMES_HOME", "")
+
+	literalHome := filepath.Join(userHome, ".hermes")
+	if err := os.MkdirAll(literalHome, 0o700); err != nil {
+		t.Fatal(err)
 	}
 
 	got := resolveExtensionRuntimeSourceHome(*hermesRuntimePrep().Home)

--- a/packages/agent/runtimeprep/hermes_test.go
+++ b/packages/agent/runtimeprep/hermes_test.go
@@ -313,6 +313,7 @@ func TestExtensionRuntimePreparerSkipsGlobalCopiesWhenHomeUnavailable(t *testing
 	t.Setenv("HERMES_HOME", "")
 	t.Setenv("HOME", "")
 	t.Setenv("USERPROFILE", "")
+	t.Setenv("LOCALAPPDATA", "")
 	stateDir := t.TempDir()
 	cwd := t.TempDir()
 	for _, name := range []string{"config.yaml", "auth.json", ".env"} {

--- a/services/tuttid/biz/agenttarget/model.go
+++ b/services/tuttid/biz/agenttarget/model.go
@@ -65,6 +65,7 @@ type Target struct {
 	UpdatedAtUnixMS    int64
 	AvailabilityStatus string
 	AvailabilityReason string
+	ExecutablePath     string
 }
 
 type LaunchRef struct {
@@ -203,6 +204,7 @@ func NormalizeTarget(value Target) (Target, error) {
 	value.Source = normalizeSource(value.Source)
 	value.AvailabilityStatus = strings.TrimSpace(value.AvailabilityStatus)
 	value.AvailabilityReason = strings.TrimSpace(value.AvailabilityReason)
+	value.ExecutablePath = strings.TrimSpace(value.ExecutablePath)
 	if !agentTargetIDPattern.MatchString(value.ID) {
 		return Target{}, fmt.Errorf("%w: id must match %s", ErrInvalidTarget, agentTargetIDPattern.String())
 	}

--- a/services/tuttid/service/agent/composer_extension_scope_test.go
+++ b/services/tuttid/service/agent/composer_extension_scope_test.go
@@ -512,12 +512,18 @@ func TestExtensionHiddenComposerDiscoveryCleansPreparedRuntimeAfterStartFailure(
 	}
 }
 
-func TestExtensionHiddenComposerDiscoveryCallerCancellationClosesSession(t *testing.T) {
+func TestExtensionHiddenComposerDiscoveryCallerCancellationLeavesSharedDiscoveryRunning(t *testing.T) {
 	runtime := newFakeRuntime()
 	started := make(chan struct{})
+	release := make(chan struct{})
 	closed := make(chan struct{})
 	runtime.startHook = func(_ RuntimeStartInput, session ProviderRuntimeSession) ProviderRuntimeSession {
 		close(started)
+		<-release
+		session.RuntimeContext["configOptions"] = []any{map[string]any{
+			"id": "model", "currentValue": "example-pro",
+			"options": []any{map[string]any{"value": "example-pro", "name": "Example Pro"}},
+		}}
 		return session
 	}
 	runtime.closeHook = func(RuntimeCloseInput) { close(closed) }
@@ -535,13 +541,21 @@ func TestExtensionHiddenComposerDiscoveryCallerCancellationClosesSession(t *test
 	if err := <-result; !errors.Is(err, context.Canceled) {
 		t.Fatalf("discovery error = %v, want caller cancellation", err)
 	}
+	close(release)
 	select {
 	case <-closed:
 	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for caller-canceled discovery cleanup")
+		t.Fatal("timed out waiting for shared discovery cleanup")
 	}
 	if len(runtime.closeCalls) != 1 || len(runtime.sessions) != 0 {
-		t.Fatalf("close=%d sessions=%d, want caller-canceled discovery closed", len(runtime.closeCalls), len(runtime.sessions))
+		t.Fatalf("close=%d sessions=%d, want completed shared discovery closed", len(runtime.closeCalls), len(runtime.sessions))
+	}
+	models, err := service.discoverLiveComposerModels(context.Background(), input, ComposerSettings{})
+	if err != nil || len(models) != 1 || models[0].Value != "example-pro" {
+		t.Fatalf("cached discovery result = %#v, error = %v", models, err)
+	}
+	if len(runtime.startCalls) != 1 {
+		t.Fatalf("start calls = %d, want cached result without another runtime", len(runtime.startCalls))
 	}
 }
 

--- a/services/tuttid/service/agent/composer_live_model_coordinator.go
+++ b/services/tuttid/service/agent/composer_live_model_coordinator.go
@@ -28,7 +28,7 @@ func (s *Service) discoverLiveComposerModels(
 	}
 	cacheKey := scope.key()
 	resultCh := s.liveModelDiscoveryGroup.DoChan(cacheKey, func() (any, error) {
-		lifecycleCtx, cancelLifecycle := context.WithTimeout(ctx, liveModelDiscoveryLifecycleTimeout)
+		lifecycleCtx, cancelLifecycle := context.WithTimeout(context.WithoutCancel(ctx), liveModelDiscoveryLifecycleTimeout)
 		defer cancelLifecycle()
 		if newComposerLiveModelScopeForInput(input, settings).key() != cacheKey {
 			return nil, errLiveModelDiscoverySuperseded

--- a/services/tuttid/service/agent/provider_descriptor_test.go
+++ b/services/tuttid/service/agent/provider_descriptor_test.go
@@ -41,10 +41,11 @@ func TestTuttiAgentComposerProfileUsesSkillsOnlyAppServerCatalog(t *testing.T) {
 	if profile.CapabilityCatalogKind != providerregistry.CapabilityCatalogKindAppServerSkills {
 		t.Fatalf("capability catalog profile = %#v", profile)
 	}
-	if !reflect.DeepEqual(profile.SlashCommandPolicy.FallbackCommands, []string{"plan", "goal", "review"}) {
+	if !reflect.DeepEqual(profile.SlashCommandPolicy.FallbackCommands, []string{"compact", "plan", "goal", "review"}) {
 		t.Fatalf("fallbackCommands = %#v", profile.SlashCommandPolicy.FallbackCommands)
 	}
 	wantEffects := []providerregistry.SlashCommandEffectDescriptor{
+		{Command: "compact", Effect: providerregistry.SlashCommandEffectSubmitImmediate},
 		{Command: "plan", Effect: providerregistry.SlashCommandEffectTogglePlanMode},
 		{Command: "goal", Effect: providerregistry.SlashCommandEffectActivateGoalMode},
 		{Command: "review", Effect: providerregistry.SlashCommandEffectShowReviewPicker},

--- a/services/tuttid/service/agentextension/manager.go
+++ b/services/tuttid/service/agentextension/manager.go
@@ -374,16 +374,20 @@ func (m *Manager) runtimeBinding(installation Installation, command []string, ve
 	}, nil
 }
 
-func (m *Manager) ResolveAgentTargetAvailability(ctx context.Context, target agenttargetbiz.Target) (string, string) {
+func (m *Manager) ResolveAgentTargetAvailability(ctx context.Context, target agenttargetbiz.Target) (string, string, string) {
 	launchRef, err := agenttargetbiz.RuntimeProviderTargetRef(target)
 	if err != nil || launchRef["kind"] != agenttargetbiz.LaunchRefTypeAgentExtension {
-		return "unknown", "invalid_extension_launch_ref"
+		return "unknown", "invalid_extension_launch_ref", ""
 	}
 	installationID, _ := launchRef["extensionInstallationId"].(string)
-	if _, err := m.ResolveRuntime(ctx, installationID); err != nil {
-		return "not_installed", "compatible_runtime_not_installed"
+	binding, err := m.ResolveRuntime(ctx, installationID)
+	if err != nil {
+		return "not_installed", "compatible_runtime_not_installed", ""
 	}
-	return "ready", ""
+	if len(binding.Command) == 0 {
+		return "not_installed", "compatible_runtime_not_installed", ""
+	}
+	return "ready", "", strings.TrimSpace(binding.Command[0])
 }
 
 func (m *Manager) reconcileSource(ctx context.Context, source tuttitypes.AgentExtensionSource) (Installation, error) {

--- a/services/tuttid/service/agenttarget/service.go
+++ b/services/tuttid/service/agenttarget/service.go
@@ -21,7 +21,7 @@ type Service struct {
 }
 
 type AvailabilityResolver interface {
-	ResolveAgentTargetAvailability(context.Context, agenttargetbiz.Target) (status string, reason string)
+	ResolveAgentTargetAvailability(context.Context, agenttargetbiz.Target) (status string, reason string, executablePath string)
 }
 
 type PutInput struct {
@@ -48,7 +48,7 @@ func (s Service) List(ctx context.Context) ([]agenttargetbiz.Target, error) {
 	for index := range targets {
 		launchRef, launchRefErr := agenttargetbiz.RuntimeProviderTargetRef(targets[index])
 		if launchRefErr == nil && launchRef["kind"] == agenttargetbiz.LaunchRefTypeAgentExtension {
-			targets[index].AvailabilityStatus, targets[index].AvailabilityReason = s.AvailabilityResolver.ResolveAgentTargetAvailability(ctx, targets[index])
+			targets[index].AvailabilityStatus, targets[index].AvailabilityReason, targets[index].ExecutablePath = s.AvailabilityResolver.ResolveAgentTargetAvailability(ctx, targets[index])
 		}
 	}
 	return targets, nil

--- a/services/tuttid/service/agenttarget/service_test.go
+++ b/services/tuttid/service/agenttarget/service_test.go
@@ -18,9 +18,9 @@ type availabilityResolverStub struct {
 	resolved []string
 }
 
-func (s *availabilityResolverStub) ResolveAgentTargetAvailability(_ context.Context, target agenttargetbiz.Target) (string, string) {
+func (s *availabilityResolverStub) ResolveAgentTargetAvailability(_ context.Context, target agenttargetbiz.Target) (string, string, string) {
 	s.resolved = append(s.resolved, target.ID)
-	return "not_installed", "compatible_runtime_not_installed"
+	return "not_installed", "compatible_runtime_not_installed", "/resolved/bin/extension"
 }
 
 func TestServiceListResolvesOnlyExtensionTargetAvailability(t *testing.T) {
@@ -43,7 +43,7 @@ func TestServiceListResolvesOnlyExtensionTargetAvailability(t *testing.T) {
 		t.Fatalf("resolved targets = %#v", resolver.resolved)
 	}
 	for _, target := range targets {
-		if target.ID == "extension" && (target.AvailabilityStatus != "not_installed" || target.AvailabilityReason != "compatible_runtime_not_installed") {
+		if target.ID == "extension" && (target.AvailabilityStatus != "not_installed" || target.AvailabilityReason != "compatible_runtime_not_installed" || target.ExecutablePath != "/resolved/bin/extension") {
 			t.Fatalf("extension availability = %#v", target)
 		}
 	}

--- a/services/tuttid/service/cli/providers/agentcontext/legacy_compat_test.go
+++ b/services/tuttid/service/cli/providers/agentcontext/legacy_compat_test.go
@@ -79,6 +79,7 @@ func TestAgentListUsesExtensionSetupAuthenticationStateForBroadAndExactCatalogs(
 		return agenttargetbiz.Target{
 			ID: id, Provider: provider, LaunchRefJSON: launchRef, Name: name, Enabled: true,
 			Source: agenttargetbiz.SourceSystem, AvailabilityStatus: "ready",
+			ExecutablePath: "/resolved/bin/" + strings.TrimPrefix(id, "extension:"),
 		}
 	}
 	hermes := newExtension("extension:hermes", "acp:hermes", "Hermes Agent")
@@ -120,6 +121,9 @@ func TestAgentListUsesExtensionSetupAuthenticationStateForBroadAndExactCatalogs(
 			t.Fatalf("Handler(%s): %v", target.ID, err)
 		}
 		agent := output.Value["agents"].([]any)[0].(map[string]any)
+		if agent["executablePath"] != target.ExecutablePath {
+			t.Fatalf("executablePath(%s) = %#v, want %q", target.ID, agent["executablePath"], target.ExecutablePath)
+		}
 		byID[agent["id"].(string)] = agent["availability"].(map[string]any)
 	}
 	if len(sessions.availabilityIn) != 0 {

--- a/services/tuttid/service/cli/providers/agentcontext/providers.go
+++ b/services/tuttid/service/cli/providers/agentcontext/providers.go
@@ -162,14 +162,17 @@ func (p Provider) applyExtensionSetupAvailability(
 		go func(index int) {
 			defer probes.Done()
 			target := items[index].Target
+			executablePath := items[index].Availability.ExecutablePath
 			snapshot, setupErr := p.extensionAvailabilityCache.load(ctx, agentextensionservice.InstallPlanInput{
 				WorkspaceID: workspaceID, AgentTargetID: target.ID,
 			}, refresh)
 			if setupErr != nil {
 				items[index].Availability = unknownExtensionSetupAvailability(target.Provider, setupErr)
+				items[index].Availability.ExecutablePath = executablePath
 				return
 			}
 			items[index].Availability = extensionSetupAvailability(target.Provider, snapshot)
+			items[index].Availability.ExecutablePath = executablePath
 		}(index)
 	}
 	probes.Wait()
@@ -323,7 +326,11 @@ func extensionTargetAvailability(target agenttargetbiz.Target) agentservice.Prov
 	case "not_installed", "auth_required", "unsupported":
 		status = agentservice.ProviderAvailabilityUnavailable
 	}
-	result := agentservice.ProviderAvailability{Provider: target.Provider, Status: status}
+	result := agentservice.ProviderAvailability{
+		Provider:       target.Provider,
+		Status:         status,
+		ExecutablePath: strings.TrimSpace(target.ExecutablePath),
+	}
 	if reason := strings.TrimSpace(target.AvailabilityReason); reason != "" {
 		result.LastError = &agentservice.ProviderAvailabilityError{Code: reason, Message: reason}
 	}


### PR DESCRIPTION
## Summary

- 修复 Windows 下 Hermes 扩展运行目录解析错误，确保读取正确的用户配置与环境
- 保留扩展安装后解析出的实际可执行路径，避免回退到错误命令
- 让实时模型发现超出前台等待预算后继续在后台完成并写入缓存，避免 Hermes 只显示一个静态模型
- 当 Agent 未声明可选 HTTP MCP 能力时跳过该绑定继续启动，避免直接报 Agent failed to start
- 修复 Windows 盘符路径经 Markdown 编码后无法识别的问题，使 Agent 返回的本地截图能够正常显示
- 补充 Windows、扩展目标、模型发现、ACP 启动与消息媒体相关测试

## Verification

- go test ./packages/agent/daemon/runtime -run 'TestStandardACPSession(NewAndLoadPassStandardClientMCPConfig|OmitsHTTPMCPWhenAgentDoesNotAdvertiseCapability)$' -count=1
- pnpm --filter @tutti-os/agent-gui exec vitest run shared/AgentMessageMarkdown.spec.tsx --pool=forks（99 tests passed）
- pnpm --filter @tutti-os/agent-gui typecheck
- 本地 Tutti Dev 实测 Hermes 可启动、可发送消息、可发现完整模型
- 本地 Tutti Dev 实测 OpenCode 返回的 Windows 本地截图可正常显示
- git diff --check origin/main...HEAD

## Fallback Three Questions

- Source: 扩展 Agent 的能力声明、Windows 路径来源和冷启动耗时与内置 Agent 不完全一致
- Why can it not be fixed at that source?: Tutti 需要兼容已发布扩展和 ACP Agent 的现有能力声明，并负责安全解析 Agent 消息中的跨平台本地媒体路径
- Removal condition: 当扩展安装契约、ACP MCP 能力协商、模型发现和本地媒体引用均提供强制一致的端到端协议后，可移除兼容分支

## Checklist

- [x] 本 PR 不改变 session/turn/goal/runtime-operation 的生命周期语义
- [x] 改动聚焦于 Windows Agent 的启动、发现与消息媒体兼容性
- [x] 已更新相关架构与排障文档
- [x] 不涉及 README 多语言源变更
- [x] 已运行改动表面的最低有效检查
- [x] 所有提交均包含 DCO sign-off