### PR TITLE
fix(connector): commit installation before projection

### DIFF
--- a/packages/connector/host/application_execution.go
+++ b/packages/connector/host/application_execution.go
@@ -133,6 +133,17 @@ func (application *Application) executeInstall(ctx context.Context, operation Op
 	if err != nil {
 		return err
 	}
+	// The physical owner must publish the verified installation before the
+	// repository projects installed. If desktopd crashes after this commit but
+	// before the transaction below, bootstrap calibration sees an extra physical
+	// installation and the user can safely retry. The inverse ordering can leave
+	// durable installed truth pointing at an uncommitted VM candidate.
+	if err := application.config.ReleaseInstallations.CommitReleaseInstallation(ctx, CommitReleaseInstallationRequest{
+		OperationID: operation.OperationID, Scope: operation.Scope, Generation: operation.HostGeneration,
+		Release: release, Receipt: installed,
+	}); err != nil {
+		return NewDomainError(ErrorCodeInstallFailed, "connector release installation commit failed", true, err)
+	}
 	if err := application.completeConnectorOperation(ctx, operation.OperationID, func(connector Connector) Connector {
 		connector.Installation = Installation{
 			State:                  InstallationStateInstalled,
@@ -143,12 +154,6 @@ func (application *Application) executeInstall(ctx context.Context, operation Op
 		return connector
 	}); err != nil {
 		return err
-	}
-	if err := application.config.ReleaseInstallations.CommitReleaseInstallation(ctx, CommitReleaseInstallationRequest{
-		OperationID: operation.OperationID, Scope: operation.Scope, Generation: operation.HostGeneration,
-		Release: release, Receipt: installed,
-	}); err != nil {
-		return NewDomainError(ErrorCodeInstallFailed, "connector release cache commit failed", true, err)
 	}
 	// Runtime publication is a distinct durable operation. Failure to enqueue it
 	// cannot roll back installed truth; bootstrap and authorization observation

--- a/packages/connector/host/application_test.go
+++ b/packages/connector/host/application_test.go
@@ -115,6 +115,30 @@ func TestApplicationExecutesAcceptedInstall(t *testing.T) {
 	}
 }
 
+func TestApplicationDoesNotProjectInstalledBeforePhysicalCommit(t *testing.T) {
+	repository := newMemoryRepository(testConnector("github"))
+	scheduler := &memoryScheduler{}
+	physicalCommitErr := errors.New("physical commit unavailable")
+	installationHost := &memoryInstallRuntime{installationCommitErr: physicalCommitErr}
+	application := newTestApplication(t, repository, scheduler, installationHost, CatalogSnapshot{})
+	accepted, err := application.Install(context.Background(), ConnectorMutation{
+		Mutation: Mutation{ClientRequestID: "request-physical-commit", ExpectedRevision: 0}, ConnectorKey: "github",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := application.ExecuteOperation(context.Background(), accepted.Operation.OperationID); err == nil {
+		t.Fatal("physical commit failure was accepted")
+	}
+	connector, err := repository.Connector(context.Background(), "github")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if connector.Installation.State == InstallationStateInstalled {
+		t.Fatalf("installation projected before physical commit: %#v", connector.Installation)
+	}
+}
+
 func TestApplicationExecutesTypedCLIInstallationBeforeCompletion(t *testing.T) {
 	connector := testConnector("lark")
 	connector.Release.Manifest.SchemaVersion = "1"
@@ -1303,6 +1327,7 @@ type memoryInstallRuntime struct {
 	installationInspections int
 	installationResult      ReleaseInstallationObservation
 	installationInspectErr  error
+	installationCommitErr   error
 }
 
 func (host *memoryInstallRuntime) Reconcile(_ context.Context, request RuntimeReconcileRequest) (RuntimeReceipt, error) {
@@ -1396,8 +1421,8 @@ func (host *memoryInstallRuntime) UninstallRelease(ctx context.Context, request 
 		ReleaseDigest: request.Release.ReleaseDigest})
 }
 
-func (*memoryInstallRuntime) CommitReleaseInstallation(context.Context, CommitReleaseInstallationRequest) error {
-	return nil
+func (host *memoryInstallRuntime) CommitReleaseInstallation(context.Context, CommitReleaseInstallationRequest) error {
+	return host.installationCommitErr
 }
 
 type runtimeBindingResolverStub struct {


### PR DESCRIPTION
## Summary
- commit the verified physical Connector installation before projecting installed state
- keep the installation operation non-installed when physical commit fails
- add a regression test for the crash-consistency ordering

## Validation
- go test ./packages/connector/host