### PR TITLE
fix(workspace): keep controller snapshots cloneable

### DIFF
--- a/docs/architecture/agent-reference-sources.md
+++ b/docs/architecture/agent-reference-sources.md
@@ -350,6 +350,8 @@ cache expires; they do not claim exhaustive history.
   filter.
 - Capture the provenance constraint with speculative preload and provider-query
   inputs; do not read mutable controller state after an async boundary.
+- Keep picker snapshots and source-service inputs as plain structured-cloneable
+  data; never pass state-library proxies across host boundaries.
 - Append cursor pages without reordering already loaded entries.
 - Hide unavailable sources before rendering their tabs or sidebar groups.
 - Expose only running workspace apps in the app-artifact sidebar; installed or

--- a/packages/workspace/file-reference/src/react/internal/reference/WorkspaceFileReferencePickerController.test.ts
+++ b/packages/workspace/file-reference/src/react/internal/reference/WorkspaceFileReferencePickerController.test.ts
@@ -37,6 +37,45 @@ test("workspace file reference picker controller searches a query only once when
   );
 });
 
+test("workspace file reference picker keeps snapshot and preview inputs cloneable", async () => {
+  let previewReference: WorkspaceFileReference | null = null;
+  const adapter: WorkspaceFileReferenceAdapter = {
+    async readReferencePreview({ reference }) {
+      previewReference = reference;
+      return null;
+    },
+    async searchReferences() {
+      return [
+        {
+          displayName: "photo.png",
+          kind: "file",
+          path: "/workspace/photo.png"
+        }
+      ];
+    }
+  };
+  const controller = createWorkspaceFileReferencePickerController({
+    fileAdapter: adapter,
+    searchDebounceMs: 0,
+    workspaceId: "workspace-cloneable"
+  });
+
+  controller.open();
+  controller.setSearchQuery("photo");
+  await settlePromises();
+
+  const reference = controller.getSnapshot().searchEntries[0];
+  assert.ok(reference);
+  assert.doesNotThrow(() => structuredClone(controller.getSnapshot()));
+  assert.doesNotThrow(() => structuredClone(reference));
+
+  controller.setPreviewReference(reference);
+  await settlePromises();
+
+  assert.ok(previewReference);
+  assert.doesNotThrow(() => structuredClone(previewReference));
+});
+
 test("workspace file reference picker controller cancels stale searches", async () => {
   const calls: Array<{
     query: string;

--- a/packages/workspace/file-reference/src/react/internal/reference/WorkspaceFileReferencePickerController.ts
+++ b/packages/workspace/file-reference/src/react/internal/reference/WorkspaceFileReferencePickerController.ts
@@ -1,4 +1,4 @@
-import { proxy } from "valtio/vanilla";
+import { proxy, snapshot as readProxySnapshot } from "valtio/vanilla";
 import {
   createWorkspaceFilePreviewController,
   type WorkspaceFilePreviewControllerState,
@@ -130,6 +130,11 @@ export function createWorkspaceFileReferencePickerController(
     searchQuery: ""
   };
   const store = proxy(snapshot);
+  const readSnapshot = () =>
+    readProxySnapshot(
+      store
+    ) as unknown as WorkspaceFileReferencePickerControllerSnapshot;
+  snapshot = readSnapshot();
 
   const setSnapshot = (
     update:
@@ -145,8 +150,8 @@ export function createWorkspaceFileReferencePickerController(
     if (next === snapshot) {
       return;
     }
-    snapshot = next;
     Object.assign(store, next);
+    snapshot = readSnapshot();
   };
 
   const previewController = createWorkspaceFilePreviewController({

--- a/packages/workspace/file-reference/src/react/internal/reference/referenceSourcePickerController.test.ts
+++ b/packages/workspace/file-reference/src/react/internal/reference/referenceSourcePickerController.test.ts
@@ -778,6 +778,66 @@ test("sources can route file-type-only filters through scoped search", async () 
   assert.equal(searchInputs[0]?.withinNodeId, "host-path-downloads");
 });
 
+test("controller-owned state stays cloneable across source service calls", async () => {
+  const searchInputs: SearchInput[] = [];
+  let preparedNode: ReferenceNode | null = null;
+  const aggregator = fakeAggregator({
+    tabs: [
+      {
+        sourceId: "host-local-file",
+        label: "Local files",
+        capabilities: {
+          filterable: true,
+          filtersUseSearch: true,
+          paginated: false,
+          previewable: true,
+          searchable: true
+        }
+      }
+    ],
+    children: {},
+    searchImpl: async (input) => {
+      searchInputs.push(input);
+      return {
+        entries: Array.from({ length: input.limit ?? 0 }, (_, index) =>
+          file("host-local-file", `/photo-${index}.png`)
+        ),
+        nextCursor: null
+      };
+    }
+  });
+  aggregator.prepareSelection = async (_scope, node) => {
+    preparedNode = node;
+    return { kind: node.kind, path: node.ref.nodeId };
+  };
+  const controller = createReferenceSourcePickerController({
+    aggregator,
+    scope,
+    searchDebounceMs: 0,
+    searchResultKind: "file"
+  });
+  controller.open();
+  await flush();
+
+  controller.setSearchFilters(["image"], "host-path-downloads");
+  await flush();
+  controller.loadMoreSearch();
+  await flush();
+
+  assert.equal(searchInputs.length, 2);
+  assert.doesNotThrow(() => structuredClone(searchInputs[1]?.filters));
+  assert.doesNotThrow(() => structuredClone(controller.getSnapshot()));
+
+  const selected =
+    controller.getSnapshot().bySource["host-local-file"]?.searchEntries[0];
+  assert.ok(selected);
+  controller.toggleSelection(selected);
+  await controller.confirm();
+
+  assert.ok(preparedNode);
+  assert.doesNotThrow(() => structuredClone(preparedNode));
+});
+
 test("semantically equal provenance filters do not repeat the active search", async () => {
   const searchInputs: SearchInput[] = [];
   const controller = createReferenceSourcePickerController({

--- a/packages/workspace/file-reference/src/react/internal/reference/referenceSourcePickerController.ts
+++ b/packages/workspace/file-reference/src/react/internal/reference/referenceSourcePickerController.ts
@@ -1,4 +1,4 @@
-import { proxy } from "valtio/vanilla";
+import { proxy, snapshot as readProxySnapshot } from "valtio/vanilla";
 import type {
   NodeRef,
   ReferenceHandle,
@@ -263,6 +263,9 @@ export function createReferenceSourcePickerController(
     selection: []
   };
   const store = proxy(snapshot);
+  const readSnapshot = () =>
+    readProxySnapshot(store) as unknown as ReferenceSourcePickerSnapshot;
+  snapshot = readSnapshot();
 
   const setSnapshot = (
     update:
@@ -278,8 +281,8 @@ export function createReferenceSourcePickerController(
     if (next === snapshot) {
       return;
     }
-    snapshot = next;
     Object.assign(store, next);
+    snapshot = readSnapshot();
   };
 
   /** 不可变地更新某 tab 的状态。 */

--- a/packages/workspace/issue-manager/src/services/internal/controllerRuntime.test.ts
+++ b/packages/workspace/issue-manager/src/services/internal/controllerRuntime.test.ts
@@ -73,6 +73,30 @@ test("controllerRuntime loads issue detail without defaulting to a task selectio
   runtime.release();
 });
 
+test("controllerRuntime exposes cloneable controller state", async () => {
+  const runtime = createIssueManagerControllerRuntime({
+    feature: createFeature({
+      async listIssues() {
+        return {
+          issues: [
+            createIssueSummary({
+              issueId: "issue-cloneable",
+              title: "Clone controller state"
+            })
+          ]
+        };
+      }
+    }),
+    workspaceId: "workspace-cloneable"
+  });
+
+  runtime.retain();
+  await flushAsyncWork();
+
+  assert.doesNotThrow(() => structuredClone(runtime.getSnapshot()));
+  runtime.release();
+});
+
 test("controllerRuntime reports issue-manager opened once per session", async () => {
   const analyticsEvents: IssueManagerAnalyticsEvent[] = [];
   const runtime = createIssueManagerControllerRuntime({

--- a/packages/workspace/issue-manager/src/services/internal/controllerRuntime.ts
+++ b/packages/workspace/issue-manager/src/services/internal/controllerRuntime.ts
@@ -1,5 +1,5 @@
 import type { SetStateAction } from "react";
-import { proxy } from "valtio/vanilla";
+import { proxy, snapshot as readProxySnapshot } from "valtio/vanilla";
 import type {
   IssueManagerIssueDetail,
   IssueManagerIssueSummary,
@@ -147,6 +147,9 @@ export function createIssueManagerControllerRuntime(
     })
   };
   const store = proxy(snapshot);
+  const readSnapshot = () =>
+    readProxySnapshot(store) as unknown as IssueManagerControllerSnapshot;
+  snapshot = readSnapshot();
 
   const notify = () => {
     for (const listener of listeners) {
@@ -171,8 +174,8 @@ export function createIssueManagerControllerRuntime(
     if (next === snapshot) {
       return;
     }
-    snapshot = next;
     Object.assign(store, next);
+    snapshot = readSnapshot();
     notify();
   };
 


### PR DESCRIPTION
## Summary
- keep manually exposed Valtio controller snapshots as plain structured-cloneable data
- cover the shared reference picker, legacy file picker, and Issue Manager runtime
- remove the bounded single-page workaround and document the host-boundary invariant

## Tests
- `pnpm --filter @tutti-os/workspace-file-reference test`
- `pnpm --filter @tutti-os/workspace-issue-manager test`
- `pnpm check:changed`
- `pnpm check:changed -- --push-ready`
- `pnpm --dir apps/tsh-desktop check`
- local TSH package-link reproduction: first search 30, load more 60, second filters and snapshot structured-clone successfully

## Notes
- no TSH production-code change; temporary diagnostics and the pagination workaround were removed
- no E2E tests were run