### PR TITLE
fix(agent): settle providerless Claude failures

### DIFF
--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -41,9 +41,10 @@ Use the focused runtime index or open one area directly:
   legacy startup wakes, provider-completed submissions reported as delivery
   unknown after canonical message provenance conflicts, completed Claude Code
   Turns that lack a Fork entry because provider identity was not observed from
-  the durable transcript, and Claude Fork operations that fail because an empty
-  query never creates a durable provider child. It also covers a Claude Query
-  that keeps returning connection errors after the machine network recovers.
+  the durable transcript, Claude failures before provider Turn identity that
+  leave AgentGUI thinking, and Claude Fork operations that fail because an
+  empty query never creates a durable provider child. It also covers a Claude
+  Query that keeps returning connection errors after the machine network recovers.
   Also covers inactive Claude Resume timing out the queue send and leaving later
   prompts stuck as 排队中 behind `uncertainDelivery`.
 - [Agent Approvals And Child Sessions](./agent-approvals-subagents.md): Approval gates, plan exits, root/parent/child event attribution, child sessions, and Message Center.

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -689,6 +689,47 @@ be resent`). The app never opens.
   [report_coalescer.go](../../../packages/agent/daemon/runtime/report_coalescer.go),
   [controller_report_queue_test.go](../../../packages/agent/daemon/runtime/controller_report_queue_test.go)
 
+### Claude fails before provider Turn identity but AgentGUI keeps thinking
+
+- **Symptom:** Claude returns no assistant result and the provider invocation
+  has already failed, but AgentGUI keeps showing the Turn as processing. Later
+  sends may be rejected because the runtime still reports an active Turn.
+- **Quick checks:** Correlate the canonical Turn ID across the submit report,
+  Claude sidecar event, and runtime controller. The characteristic sequence has
+  a durable submitted Turn, `turn_failed` without `providerTurnId`, dispatch
+  disposition `applied_without_provider_turn`, and a canonical failed report,
+  while `HasActiveTurn` remains true. Do not interpret
+  `applied_without_provider_turn` itself as a failure; cancel-before-acceptance
+  legitimately uses the same admission result.
+- **Root cause:** Provider acceptance and canonical completion are independent
+  contracts. The acceptance wrapper treated an exact providerless
+  `turn.failed` as premature provider output, while the blocking controller
+  released its active-Turn fence only for failures carrying explicit rejection
+  metadata. A non-rejection failure could therefore be durable but never close
+  the runtime fence.
+- **Fix:** Hold an exact canonical terminal behind the acceptance barrier and
+  return it to the controller without inventing provider identity. Classify
+  completion from the typed terminal event for the exact Turn, never from the
+  dispatch disposition or error text. Partition every pre-acceptance batch so
+  an exact terminal cannot carry provider-dependent assistant/tool output
+  through the barrier. Release the active-Turn fence only after the terminal
+  crosses the synchronous durable-report barrier. If that commit fails or its
+  acknowledgement is lost, retain the terminal and retry it idempotently until
+  the commit succeeds or daemon reconciliation proves the Turn already settled.
+  Provider-root completion with an identity continues through canonical
+  aggregation.
+- **Validation:** Cover Claude translation of a providerless `turn_failed`,
+  mixed terminal/provider-output batches, controller settlement after a
+  successful terminal report, transient report failure, commit-success/ACK-loss,
+  explicit rejection, cancel-before-acceptance, and outcome-unknown. Run the
+  Host conformance scenario for initial and ordinary idempotent submissions.
+  Retain a root-provider lifecycle test proving provider-root completion does
+  not clear the canonical Turn before daemon reconciliation.
+- **References:**
+  [claude_sdk_execution.go](../../../packages/agent/daemon/runtime/claude_sdk_execution.go),
+  [controller_turn_completion.go](../../../packages/agent/daemon/runtime/controller_turn_completion.go),
+  [controller_turn_exec.go](../../../packages/agent/daemon/runtime/controller_turn_exec.go)
+
 ### Tutti mode is active in the composer but disappears after the first submit
 
 - **Symptom:** The home composer shows Tutti enabled and the submit trace records

--- a/packages/agent/daemon/runtime/claude_sdk_acceptance_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_acceptance_test.go
@@ -131,7 +131,10 @@ func TestClaudeSDKEventMayPrecedeProviderAcceptanceAllowsCompactNotice(t *testin
 	if !claudeSDKEventMayPrecedeProviderAcceptance(compact) {
 		t.Fatalf("compact notice must be holdable before provider acceptance: %#v", compact)
 	}
-	if !claudeSDKEventsMayPrecedeProviderAcceptance([]activityshared.Event{compact}) {
+	if !partitionClaudeSDKPreAcceptanceEvents(
+		"turn-compact",
+		[]activityshared.Event{compact},
+	).safe() {
 		t.Fatal("compact-only batch must precede provider acceptance")
 	}
 	if !isClaudeSDKCompactPrompt(
@@ -139,6 +142,55 @@ func TestClaudeSDKEventMayPrecedeProviderAcceptanceAllowsCompactNotice(t *testin
 		"/compact",
 	) {
 		t.Fatal("expected /compact prompt detection")
+	}
+}
+
+func TestPartitionClaudeSDKPreAcceptanceEventsDoesNotLetTerminalMaskProviderOutput(t *testing.T) {
+	t.Parallel()
+
+	session := standardTestSession(ProviderClaudeCode)
+	turnID := "canonical-turn"
+	local := newTurnActivityEvent(
+		session,
+		EventTurnStarted,
+		turnID,
+		SessionStatusWorking,
+		"",
+		"",
+		nil,
+	)
+	terminal := newTurnActivityEvent(
+		session,
+		EventTurnFailed,
+		turnID,
+		SessionStatusFailed,
+		"",
+		"",
+		map[string]any{"error": "provider failed"},
+	)
+	providerOutput := activityshared.Event{
+		Type: activityshared.EventMessageAppended,
+		Payload: activityshared.EventPayload{
+			TurnID: turnID,
+			Role:   activityshared.MessageRole("assistant"),
+		},
+	}
+
+	partition := partitionClaudeSDKPreAcceptanceEvents(
+		turnID,
+		[]activityshared.Event{local, terminal, providerOutput},
+	)
+	if partition.safe() {
+		t.Fatal("mixed terminal/provider-output batch must not cross acceptance")
+	}
+	if !partition.hasDirectCanonicalTerminal {
+		t.Fatal("exact canonical terminal was not classified as authoritative")
+	}
+	if len(partition.allowed) != 2 || len(partition.providerDependent) != 1 {
+		t.Fatalf("partition = %#v, want 2 allowed and 1 provider-dependent", partition)
+	}
+	if partition.providerDependent[0].Type != activityshared.EventMessageAppended {
+		t.Fatalf("provider-dependent events = %#v", partition.providerDependent)
 	}
 }
 
@@ -326,6 +378,107 @@ func TestClaudeSDKProviderAcceptanceReportsExplicitAuthenticationRejection(t *te
 	select {
 	case event := <-emitted:
 		t.Fatalf("event %q escaped before rejected provider acceptance", event.Type)
+	default:
+	}
+}
+
+func TestClaudeSDKProviderlessFailureReturnsCanonicalTerminal(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	conn := newBlockingClaudeSDKConnection()
+	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, conn)
+	adapterSession.providerSessionID = session.ProviderSessionID
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	dispatch := make(chan ProviderDispatchResult, 1)
+	emitted := make(chan activityshared.Event, 4)
+	barrierEntered := make(chan struct{}, 1)
+	type execOutcome struct {
+		events []activityshared.Event
+		err    error
+	}
+	execDone := make(chan execOutcome, 1)
+	go func() {
+		events, err := adapter.ExecWithProviderAcceptance(
+			ctx,
+			session,
+			[]PromptContentBlock{{Type: "text", Text: "hello"}},
+			"hello",
+			"canonical-turn-providerless-failure",
+			func(events []activityshared.Event) {
+				for _, event := range events {
+					emitted <- event
+				}
+			},
+			nil,
+			func(result ProviderDispatchResult) {
+				dispatch <- result
+			},
+			func(ProviderAcceptanceReceipt) error {
+				barrierEntered <- struct{}{}
+				return nil
+			},
+		)
+		execDone <- execOutcome{events: events, err: err}
+	}()
+
+	waitForClaudeSDKSentRequest(t, conn, "exec")
+	conn.pushEvent(claudeSDKSidecarEvent{
+		Type: "turn_failed",
+		Payload: map[string]any{
+			"turnId": "canonical-turn-providerless-failure",
+			"code":   "execution_failed",
+			"error":  "Claude execution failed before identity resolution",
+		},
+	})
+
+	select {
+	case outcome := <-execDone:
+		if outcome.err == nil {
+			t.Fatal("ExecWithProviderAcceptance error=nil, want providerless failure")
+		}
+		var terminal *activityshared.Event
+		for index := range outcome.events {
+			if outcome.events[index].Type == activityshared.EventTurnFailed &&
+				outcome.events[index].Payload.TurnID == "canonical-turn-providerless-failure" {
+				terminal = &outcome.events[index]
+				break
+			}
+		}
+		if terminal == nil {
+			t.Fatalf("events = %#v, want exact canonical turn.failed", outcome.events)
+		}
+		partition := partitionClaudeSDKPreAcceptanceEvents(
+			"canonical-turn-providerless-failure",
+			outcome.events,
+		)
+		if !partition.safe() {
+			t.Fatalf(
+				"provider-dependent events escaped before acceptance: %#v",
+				partition.providerDependent,
+			)
+		}
+		if got := payloadString(terminal.Payload.Metadata, "dispatchDisposition"); got != "" {
+			t.Fatalf("dispatchDisposition = %q, want provider-neutral terminal", got)
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for providerless terminal")
+	}
+	select {
+	case result := <-dispatch:
+		t.Fatalf("provider dispatch = %#v, want no provider identity disposition", result)
+	default:
+	}
+	select {
+	case <-barrierEntered:
+		t.Fatal("provider acceptance barrier ran without a provider Turn identity")
+	default:
+	}
+	select {
+	case event := <-emitted:
+		t.Fatalf("event %q escaped before providerless terminal return", event.Type)
 	default:
 	}
 }

--- a/packages/agent/daemon/runtime/claude_sdk_execution.go
+++ b/packages/agent/daemon/runtime/claude_sdk_execution.go
@@ -186,22 +186,15 @@ func (a *ClaudeCodeSDKAdapter) ExecWithProviderAcceptance(
 	var acceptanceErr error
 	accepted := false
 	acceptedProviderTurnID := ""
+	preAcceptanceOutputViolation := false
 	pendingEvents := make([]activityshared.Event, 0, 2)
 	wrappedEmit := func(events []activityshared.Event) {
 		if acceptanceErr != nil {
 			return
 		}
 		observedAcceptance := false
-		explicitRejection := false
 		providerTurnID := ""
 		for _, event := range events {
-			if event.Type == activityshared.EventTurnFailed &&
-				strings.EqualFold(
-					strings.TrimSpace(payloadString(event.Payload.Metadata, "dispatchDisposition")),
-					string(DispatchDispositionRejected),
-				) {
-				explicitRejection = true
-			}
 			if event.Type != activityshared.EventRootProviderTurnStarted ||
 				strings.TrimSpace(event.Payload.TurnID) != strings.TrimSpace(turnID) {
 				continue
@@ -249,12 +242,13 @@ func (a *ClaudeCodeSDKAdapter) ExecWithProviderAcceptance(
 				return
 			}
 		}
-		if !accepted && !observedAcceptance &&
-			(explicitRejection || claudeSDKEventsMayPrecedeProviderAcceptance(events)) {
-			pendingEvents = append(pendingEvents, events...)
-			return
-		}
 		if !accepted && !observedAcceptance {
+			partition := partitionClaudeSDKPreAcceptanceEvents(turnID, events)
+			if partition.safe() {
+				pendingEvents = append(pendingEvents, events...)
+				return
+			}
+			preAcceptanceOutputViolation = true
 			acceptanceErr = errors.New(
 				"claude SDK published provider output before durable acceptance",
 			)
@@ -298,6 +292,28 @@ func (a *ClaudeCodeSDKAdapter) ExecWithProviderAcceptance(
 		emitCommands,
 		reportDispatch,
 	)
+	if !accepted {
+		partition := partitionClaudeSDKPreAcceptanceEvents(turnID, events)
+		if preAcceptanceOutputViolation || !partition.safe() {
+			if !preAcceptanceOutputViolation && reportDispatch != nil {
+				reportDispatch(ProviderDispatchResult{
+					Disposition: DispatchDispositionOutcomeUnknown,
+				})
+			}
+			if acceptanceErr == nil {
+				acceptanceErr = errors.New(
+					"claude SDK returned provider output before durable acceptance",
+				)
+			}
+			// The exact canonical terminal and caller-owned pre-acceptance facts
+			// remain authoritative. Provider-dependent output in the same batch
+			// does not cross the acceptance barrier.
+			if partition.hasDirectCanonicalTerminal {
+				return partition.allowed, acceptanceErr
+			}
+			return nil, acceptanceErr
+		}
+	}
 	if isClaudeSDKProviderRejectedError(err) {
 		if !claudeSDKEventsContainTurnFailed(events) {
 			metadata := map[string]any{
@@ -357,18 +373,45 @@ func stripClaudeSDKHeldEventProviderInputUnits(
 	return stripped
 }
 
-func claudeSDKEventsMayPrecedeProviderAcceptance(
+type claudeSDKPreAcceptanceEventPartition struct {
+	allowed                    []activityshared.Event
+	providerDependent          []activityshared.Event
+	hasDirectCanonicalTerminal bool
+}
+
+func (partition claudeSDKPreAcceptanceEventPartition) safe() bool {
+	return len(partition.providerDependent) == 0
+}
+
+// partitionClaudeSDKPreAcceptanceEvents is the single acceptance-boundary
+// classifier for Claude event batches. Only caller-owned local facts and an
+// exact terminal for the canonical Turn may survive without provider identity;
+// every other event remains provider-dependent even when it shares a batch
+// with that terminal.
+func partitionClaudeSDKPreAcceptanceEvents(
+	turnID string,
 	events []activityshared.Event,
-) bool {
-	if len(events) == 0 {
-		return true
+) claudeSDKPreAcceptanceEventPartition {
+	partition := claudeSDKPreAcceptanceEventPartition{
+		allowed:           make([]activityshared.Event, 0, len(events)),
+		providerDependent: make([]activityshared.Event, 0, len(events)),
 	}
 	for _, event := range events {
-		if !claudeSDKEventMayPrecedeProviderAcceptance(event) {
-			return false
+		if claudeSDKEventMayPrecedeProviderAcceptance(event) {
+			partition.allowed = append(partition.allowed, event)
+			continue
 		}
+		if classifyRootTurnCompletion(
+			turnID,
+			[]activityshared.Event{event},
+		) == rootTurnCompletionDirectCanonical {
+			partition.allowed = append(partition.allowed, event)
+			partition.hasDirectCanonicalTerminal = true
+			continue
+		}
+		partition.providerDependent = append(partition.providerDependent, event)
 	}
-	return true
+	return partition
 }
 
 func claudeSDKEventMayPrecedeProviderAcceptance(event activityshared.Event) bool {

--- a/packages/agent/daemon/runtime/controller_provisional_acceptance_test.go
+++ b/packages/agent/daemon/runtime/controller_provisional_acceptance_test.go
@@ -3,14 +3,110 @@ package agentruntime
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 type rejectingProviderAcceptanceAdapter struct {
 	recordingStartAdapter
 	failure error
+}
+
+// providerlessTerminalAcceptanceAdapter models a provider invocation that
+// reaches an authoritative canonical terminal before a provider Turn identity
+// can be bound. The dispatch result remains providerless; the exact terminal
+// event is the lifecycle authority.
+type providerlessTerminalAcceptanceAdapter struct {
+	recordingStartAdapter
+	failure error
+}
+
+func (*providerlessTerminalAcceptanceAdapter) ForkCapabilities(
+	context.Context,
+	Session,
+) (SessionForkCapabilities, error) {
+	return SessionForkCapabilities{ThroughTurn: true}, nil
+}
+
+func (*providerlessTerminalAcceptanceAdapter) Fork(
+	context.Context,
+	SessionForkInput,
+) (SessionForkResult, error) {
+	return SessionForkResult{}, nil
+}
+
+func (a *providerlessTerminalAcceptanceAdapter) ExecWithProviderAcceptance(
+	_ context.Context,
+	session Session,
+	_ []PromptContentBlock,
+	_ string,
+	turnID string,
+	_ EventSink,
+	_ CommandSnapshotSink,
+	_ ProviderDispatchSink,
+	_ ProviderAcceptanceBarrier,
+) ([]activityshared.Event, error) {
+	return []activityshared.Event{newTurnActivityEvent(
+		session,
+		EventTurnFailed,
+		turnID,
+		SessionStatusFailed,
+		"",
+		"",
+		map[string]any{
+			"error":      a.failure.Error(),
+			"stopReason": "failed_before_provider_acceptance",
+		},
+	)}, a.failure
+}
+
+func (*providerlessTerminalAcceptanceAdapter) UsesRootProviderTurnLifecycle() bool {
+	return true
+}
+
+type retryingTerminalReporter struct {
+	recordingReporter
+	attemptMu                sync.Mutex
+	terminalAttempts         int
+	commitBeforeFirstFailure bool
+}
+
+func (r *retryingTerminalReporter) Report(
+	ctx context.Context,
+	report agentsessionstore.ReportActivityInput,
+) error {
+	terminal := false
+	for _, patch := range report.StatePatches {
+		if patch.Turn != nil && patch.Turn.Phase == "settled" {
+			terminal = true
+			break
+		}
+	}
+	if !terminal {
+		return r.recordingReporter.Report(ctx, report)
+	}
+
+	r.attemptMu.Lock()
+	r.terminalAttempts++
+	attempt := r.terminalAttempts
+	commitBeforeFailure := attempt == 1 && r.commitBeforeFirstFailure
+	r.attemptMu.Unlock()
+	if commitBeforeFailure {
+		_ = r.recordingReporter.Report(ctx, report)
+	}
+	if attempt == 1 {
+		return errors.New("terminal report unavailable")
+	}
+	return r.recordingReporter.Report(ctx, report)
+}
+
+func (r *retryingTerminalReporter) attempts() int {
+	r.attemptMu.Lock()
+	defer r.attemptMu.Unlock()
+	return r.terminalAttempts
 }
 
 func (*rejectingProviderAcceptanceAdapter) ForkCapabilities(
@@ -111,6 +207,146 @@ func TestControllerProvisionalSessionPublishesPromptAndSettlesRejectedFirstTurn(
 	}
 	if !foundSubmitted || !foundFailed {
 		t.Fatalf("reports = %#v, want visible submitted and failed Turn reports", reports)
+	}
+}
+
+func TestControllerProviderlessCanonicalTerminalSettlesRootTurn(t *testing.T) {
+	t.Parallel()
+
+	providerFailure := errors.New("provider failed before durable acceptance")
+	adapter := &providerlessTerminalAcceptanceAdapter{
+		recordingStartAdapter: recordingStartAdapter{provider: ProviderClaudeCode},
+		failure:               providerFailure,
+	}
+	reporter := &recordingReporter{}
+	controller := NewController([]Adapter{adapter}, reporter)
+	if _, err := controller.Start(t.Context(), StartInput{
+		RoomID: "room-1", AgentSessionID: "session-providerless-terminal",
+		Provider: ProviderClaudeCode, CWD: "/workspace", Provisional: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := controller.Exec(t.Context(), ExecInput{
+		RoomID: "room-1", AgentSessionID: "session-providerless-terminal",
+		TurnID: "turn-providerless-terminal", Content: textPrompt("hello"),
+		RequireProviderAcceptance: true,
+	})
+	if err != nil {
+		t.Fatalf("Exec() error = %v, want canonical submit retained", err)
+	}
+	if result.ProviderDispatch == nil ||
+		result.ProviderDispatch.Disposition != DispatchDispositionAppliedWithoutProviderTurn ||
+		result.ProviderDispatch.Acceptance != nil {
+		t.Fatalf(
+			"provider dispatch = %#v, want applied_without_provider_turn",
+			result.ProviderDispatch,
+		)
+	}
+	waitForCondition(t, func() bool {
+		return !controller.HasActiveTurn("room-1", "session-providerless-terminal")
+	})
+	sessions := controller.Sessions("room-1")
+	if len(sessions) != 1 || sessions[0].AgentSessionID != "session-providerless-terminal" {
+		t.Fatalf("visible sessions = %#v, want providerless-terminal session retained", sessions)
+	}
+	if sessions[0].Status != SessionStatusFailed {
+		t.Fatalf("providerless-terminal session status = %q, want failed", sessions[0].Status)
+	}
+
+	reports := reporter.waitForCalls(t, 2)
+	var foundSubmitted, foundFailed bool
+	for _, report := range reports {
+		for _, patch := range report.report.StatePatches {
+			if patch.Turn == nil || patch.Turn.TurnID != "turn-providerless-terminal" {
+				continue
+			}
+			if patch.Turn.Phase == "submitted" && patch.RuntimeContext["visible"] == true {
+				foundSubmitted = true
+			}
+			if patch.Turn.Phase == "settled" && patch.Turn.Outcome == "failed" {
+				foundFailed = true
+			}
+		}
+	}
+	if !foundSubmitted || !foundFailed {
+		t.Fatalf("reports = %#v, want visible submitted and failed Turn reports", reports)
+	}
+}
+
+func TestControllerProviderlessCanonicalTerminalCommitRetryConverges(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name                     string
+		commitBeforeFirstFailure bool
+	}{
+		{name: "write failure"},
+		{name: "commit success acknowledgment lost", commitBeforeFirstFailure: true},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			adapter := &providerlessTerminalAcceptanceAdapter{
+				recordingStartAdapter: recordingStartAdapter{provider: ProviderClaudeCode},
+				failure: errors.New(
+					"provider failed before durable acceptance",
+				),
+			}
+			reporter := &retryingTerminalReporter{
+				commitBeforeFirstFailure: test.commitBeforeFirstFailure,
+			}
+			controller := NewController([]Adapter{adapter}, reporter)
+			sessionID := "session-providerless-terminal-commit-retry"
+			turnID := "turn-providerless-terminal-commit-retry"
+			if _, err := controller.Start(t.Context(), StartInput{
+				RoomID: "room-1", AgentSessionID: sessionID,
+				Provider: ProviderClaudeCode, CWD: "/workspace", Provisional: true,
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			result, err := controller.Exec(t.Context(), ExecInput{
+				RoomID: "room-1", AgentSessionID: sessionID,
+				TurnID: turnID, Content: textPrompt("hello"),
+				RequireProviderAcceptance: true,
+			})
+			if err != nil {
+				t.Fatalf("Exec() error = %v, want canonical submit retained", err)
+			}
+			if result.ProviderDispatch == nil ||
+				result.ProviderDispatch.Disposition != DispatchDispositionAppliedWithoutProviderTurn {
+				t.Fatalf(
+					"provider dispatch = %#v, want applied_without_provider_turn",
+					result.ProviderDispatch,
+				)
+			}
+			waitForCondition(t, func() bool {
+				return reporter.attempts() >= 1
+			})
+			if !controller.HasActiveTurn("room-1", sessionID) {
+				t.Fatal("active-turn fence released before terminal retry committed")
+			}
+			waitForCondition(t, func() bool {
+				return reporter.attempts() >= 2 &&
+					!controller.HasActiveTurn("room-1", sessionID)
+			})
+
+			reports := reporter.snapshot()
+			foundFailed := false
+			for _, call := range reports {
+				for _, patch := range call.report.StatePatches {
+					if patch.Turn != nil && patch.Turn.TurnID == turnID &&
+						patch.Turn.Phase == "settled" && patch.Turn.Outcome == "failed" {
+						foundFailed = true
+					}
+				}
+			}
+			if !foundFailed {
+				t.Fatalf("reports = %#v, want durable failed Turn", reports)
+			}
+		})
 	}
 }
 
@@ -229,6 +465,13 @@ func TestControllerCancelBeforeProviderAcceptanceDoesNotLeaveDeliveryUnknown(t *
 	if outcome.result.TurnID != "turn-cancel-before-accept" {
 		t.Fatalf("turn id = %q, want turn-cancel-before-accept", outcome.result.TurnID)
 	}
+	assertRootTurnFenceAwaitsCanonicalSettlement(
+		t,
+		controller,
+		"session-cancel-before-accept",
+		"turn-cancel-before-accept",
+		"canceled",
+	)
 }
 
 // preAcceptanceOutcomeUnknownAdapter reports outcome_unknown then returns
@@ -313,6 +556,13 @@ func TestControllerPreAcceptanceOutcomeUnknownDoesNotLeaveDeliveryUnknown(t *tes
 			result.ProviderDispatch,
 		)
 	}
+	assertRootTurnFenceAwaitsCanonicalSettlement(
+		t,
+		controller,
+		"session-outcome-unknown",
+		"turn-outcome-unknown",
+		"failed",
+	)
 }
 
 func TestControllerCallerCancelDuringAcceptanceDoesNotLeaveDeliveryUnknown(t *testing.T) {
@@ -373,4 +623,37 @@ func TestControllerCallerCancelDuringAcceptanceDoesNotLeaveDeliveryUnknown(t *te
 			outcome.result.ProviderDispatch,
 		)
 	}
+	if !controller.HasActiveTurn("room-1", "session-caller-cancel") {
+		t.Fatal("caller cancellation released root Turn before canonical settlement")
+	}
+	controller.cancelActiveTurn("room-1", "session-caller-cancel")
+	assertRootTurnFenceAwaitsCanonicalSettlement(
+		t,
+		controller,
+		"session-caller-cancel",
+		"turn-caller-cancel",
+		"canceled",
+	)
+}
+
+func assertRootTurnFenceAwaitsCanonicalSettlement(
+	t *testing.T,
+	controller *Controller,
+	sessionID string,
+	turnID string,
+	outcome string,
+) {
+	t.Helper()
+	if !controller.HasActiveTurn("room-1", sessionID) {
+		t.Fatalf("root Turn %q released before canonical settlement", turnID)
+	}
+	controller.ReconcileRootTurnSettlement(RootTurnSettlement{
+		RoomID:         "room-1",
+		AgentSessionID: sessionID,
+		TurnID:         turnID,
+		Outcome:        outcome,
+	})
+	waitForCondition(t, func() bool {
+		return !controller.HasActiveTurn("room-1", sessionID)
+	})
 }

--- a/packages/agent/daemon/runtime/controller_turn_completion.go
+++ b/packages/agent/daemon/runtime/controller_turn_completion.go
@@ -1,0 +1,147 @@
+package agentruntime
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+)
+
+const (
+	canonicalTerminalCommitRetryInitialBackoff = 100 * time.Millisecond
+	canonicalTerminalCommitRetryMaxBackoff     = 5 * time.Second
+)
+
+type rootTurnCompletionAuthority uint8
+
+const (
+	rootTurnCompletionAwaitProviderAggregation rootTurnCompletionAuthority = iota
+	rootTurnCompletionDirectCanonical
+)
+
+// classifyRootTurnCompletion distinguishes a terminal fact for the exact
+// canonical Turn from provider-root lifecycle facts. Dispatch disposition is
+// deliberately absent: admission and completion are independent contracts.
+func classifyRootTurnCompletion(
+	turnID string,
+	events []activityshared.Event,
+) rootTurnCompletionAuthority {
+	if turnHasTerminalEvent(events, turnID) {
+		return rootTurnCompletionDirectCanonical
+	}
+	return rootTurnCompletionAwaitProviderAggregation
+}
+
+// pendingCanonicalTerminalCommit retains a terminal fact that the Controller
+// accepted in memory but could not yet confirm through the durable reporter.
+// The owning blocking-exec goroutine keeps the exact active-turn fence until
+// this record commits or daemon reconciliation proves the Turn already settled.
+type pendingCanonicalTerminalCommit struct {
+	session Session
+	events  []activityshared.Event
+}
+
+func (pending *pendingCanonicalTerminalCommit) merge(
+	session Session,
+	events []activityshared.Event,
+) {
+	if pending == nil || len(events) == 0 {
+		return
+	}
+	pending.session = session
+	pending.events = append(
+		pending.events,
+		unemittedActivityEvents(events, pending.events)...,
+	)
+}
+
+func (pending *pendingCanonicalTerminalCommit) directCanonical(turnID string) bool {
+	return pending != nil && classifyRootTurnCompletion(
+		turnID,
+		pending.events,
+	) == rootTurnCompletionDirectCanonical
+}
+
+// convergeCanonicalTerminalCommit retries the same idempotent terminal facts
+// after the bounded synchronous barrier fails. It intentionally outlives the
+// submit caller's context: the submitted Turn is already durable, so only a
+// successful terminal commit or an exact daemon reconciliation may release the
+// active-turn fence.
+func (c *Controller) convergeCanonicalTerminalCommit(
+	ctx context.Context,
+	turnID string,
+	pending *pendingCanonicalTerminalCommit,
+) bool {
+	if c == nil || pending == nil || len(pending.events) == 0 {
+		return false
+	}
+	retryCtx := context.WithoutCancel(ctx)
+	backoff := canonicalTerminalCommitRetryInitialBackoff
+	attempt := 1
+	for {
+		timer := time.NewTimer(backoff)
+		<-timer.C
+
+		active, ok := c.activeTurn(
+			pending.session.RoomID,
+			pending.session.AgentSessionID,
+		)
+		if !ok || strings.TrimSpace(active.turnID) != strings.TrimSpace(turnID) {
+			// ReconcileRootTurnSettlement may win this race after proving the
+			// canonical Store is already settled. Never republish after that.
+			return false
+		}
+
+		session := c.preserveCurrentSessionSettings(pending.session)
+		accepted, ok := c.storeTurnSession(session, turnID)
+		if !ok {
+			return false
+		}
+		pending.session = accepted
+		err := c.reportSessionBeforePublish(retryCtx, accepted, pending.events)
+		if err == nil {
+			if !c.isProvisionalSession(accepted) {
+				c.publish(accepted, pending.events)
+			}
+			return pending.directCanonical(turnID)
+		}
+		slog.Warn(
+			"agent session terminal activity report remains pending",
+			"event", "agent_session.activity_report.terminal_commit_retry",
+			"room_id", accepted.RoomID,
+			"agent_session_id", accepted.AgentSessionID,
+			"turn_id", strings.TrimSpace(turnID),
+			"attempt", attempt,
+			"retry_backoff", backoff,
+			"error", err,
+		)
+
+		if backoff < canonicalTerminalCommitRetryMaxBackoff {
+			backoff *= 2
+			if backoff > canonicalTerminalCommitRetryMaxBackoff {
+				backoff = canonicalTerminalCommitRetryMaxBackoff
+			}
+		}
+		attempt++
+	}
+}
+
+// finalizeBlockingExecTurn owns the active-turn fence transition after a
+// blocking adapter invocation exits. Root-provider adapters normally wait for
+// canonical provider aggregation. The only providerless exception is an exact
+// canonical terminal that already crossed the synchronous durable-report
+// barrier; it needs no provider identity to become authoritative.
+func (c *Controller) finalizeBlockingExecTurn(
+	session Session,
+	turnID string,
+	rootProviderLifecycle bool,
+	directCanonicalTerminalCommitted bool,
+) {
+	if !rootProviderLifecycle || directCanonicalTerminalCommitted {
+		_, _ = c.finishTurn(session, turnID)
+		return
+	}
+	_, _ = c.storeTurnSession(session, turnID)
+}

--- a/packages/agent/daemon/runtime/controller_turn_exec.go
+++ b/packages/agent/daemon/runtime/controller_turn_exec.go
@@ -123,7 +123,7 @@ func (c *Controller) runProviderAcceptanceTurn(
 			acceptProviderTurn,
 		)
 		if reportedDispatch.Disposition == DispatchDispositionRejected &&
-			!eventsContainRejectedProviderTurn(events) {
+			!eventsContainExplicitDispatchRejection(events) {
 			metadata := map[string]any{
 				"dispatchDisposition": string(DispatchDispositionRejected),
 			}
@@ -154,7 +154,7 @@ func (c *Controller) runProviderAcceptanceTurn(
 	})
 }
 
-func eventsContainRejectedProviderTurn(events []activityshared.Event) bool {
+func eventsContainExplicitDispatchRejection(events []activityshared.Event) bool {
 	for _, event := range events {
 		if event.Type != activityshared.EventTurnFailed {
 			continue
@@ -206,6 +206,8 @@ func (c *Controller) runBlockingExecTurn(
 ) {
 	var emitted []activityshared.Event
 	var emittedSummary agentSubmitRuntimeEventSummary
+	directCanonicalTerminalCommitted := false
+	var pendingTerminalCommit *pendingCanonicalTerminalCommit
 	metadata := execMetadataFromContext(ctx)
 	logAgentSubmitTrace("runtime.turn_goroutine_started", session, turnID, metadata, nil)
 	emit := func(events []activityshared.Event) {
@@ -228,7 +230,16 @@ func (c *Controller) runBlockingExecTurn(
 		session = accepted
 		emitted = append(emitted, events...)
 		if eventsRequireDurablePublish(events) {
-			if err := c.reportSessionBeforePublish(ctx, session, events); err != nil {
+			durableEvents := events
+			if pendingTerminalCommit != nil {
+				pendingTerminalCommit.merge(session, events)
+				durableEvents = pendingTerminalCommit.events
+			}
+			if err := c.reportSessionBeforePublish(ctx, session, durableEvents); err != nil {
+				if pendingTerminalCommit == nil {
+					pendingTerminalCommit = &pendingCanonicalTerminalCommit{}
+					pendingTerminalCommit.merge(session, events)
+				}
 				slog.Error(
 					"agent session terminal activity report failed before publish",
 					"event", "agent_session.activity_report.terminal_barrier_failed",
@@ -239,10 +250,14 @@ func (c *Controller) runBlockingExecTurn(
 				)
 				return
 			}
-			if !c.isProvisionalSession(session) {
-				c.publish(session, events)
+			pendingTerminalCommit = nil
+			if classifyRootTurnCompletion(turnID, durableEvents) == rootTurnCompletionDirectCanonical {
+				directCanonicalTerminalCommitted = true
 			}
-			emittedSummary.observe(events, session)
+			if !c.isProvisionalSession(session) {
+				c.publish(session, durableEvents)
+			}
+			emittedSummary.observe(durableEvents, session)
 			return
 		}
 		if !c.isProvisionalSession(session) {
@@ -279,11 +294,11 @@ func (c *Controller) runBlockingExecTurn(
 		}
 		shouldEmitTerminalEvents = true
 	}
-	if err == nil {
+	if err == nil || shouldEmitTerminalEvents || len(emitted) == 0 {
+		// Adapters may both invoke emit and return the same terminal batch.
+		// Re-entering the durable barrier for already-observed events can make
+		// one failed attempt look like an immediate retry and publish twice.
 		emit(unemittedActivityEvents(events, emitted))
-	}
-	if shouldEmitTerminalEvents || len(emitted) == 0 {
-		emit(events)
 	}
 	statusEvents := events
 	if len(statusEvents) == 0 {
@@ -299,23 +314,20 @@ func (c *Controller) runBlockingExecTurn(
 	if shouldAdvanceSessionUpdatedAtFromEvents(statusEvents) {
 		session.UpdatedAtUnixMS = unixMS(now())
 	}
-	emittedSummary.log("runtime.events_emitted.summary", session, turnID, metadata)
-	if rootProviderLifecycle {
-		if eventsContainRejectedProviderTurn(statusEvents) {
-			// A provider rejection before identity resolution has no root-provider
-			// Turn for the durable aggregation path to settle. The direct Turn
-			// failure is authoritative, so release the in-memory active-turn fence
-			// immediately after its event has been reported.
-			_, _ = c.finishTurn(session, turnID)
-			return
-		}
-		// Exec returning closes only the provider invocation. The controller's
-		// active root turn remains addressable for guidance/cancel until the
-		// daemon commits and reconciles canonical root settlement.
-		_, _ = c.storeTurnSession(session, turnID)
-		return
+	if pendingTerminalCommit != nil {
+		directCanonicalTerminalCommitted = c.convergeCanonicalTerminalCommit(
+			ctx,
+			turnID,
+			pendingTerminalCommit,
+		) || directCanonicalTerminalCommitted
 	}
-	_, _ = c.finishTurn(session, turnID)
+	emittedSummary.log("runtime.events_emitted.summary", session, turnID, metadata)
+	c.finalizeBlockingExecTurn(
+		session,
+		turnID,
+		rootProviderLifecycle,
+		directCanonicalTerminalCommitted,
+	)
 }
 
 func (c *Controller) isProvisionalSession(session Session) bool {

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -82,8 +82,16 @@ output or interaction until the exact provider identity has been resolved. The
 adapter then blocks its provider event path while the Host atomically persists
 `canonicalTurnId + providerSessionId + providerTurnId`; only that commit moves
 the Turn to `durably_accepted`. Streaming, waiting for approval/input, running
-tools, checkpoints, and terminal events all follow the barrier and retain the
-same authoritative provider Turn ID. Correlation IDs are never provider IDs.
+tools, checkpoints, and provider-root terminal events all follow the barrier
+and retain the same authoritative provider Turn ID. Correlation IDs are never
+provider IDs. A provider may instead fail before any provider Turn identity
+exists. In that case the adapter returns an exact canonical `turn.failed`
+terminal without inventing a provider ID. Runtime dispatch remains an
+independent admission fact, and the runtime releases its local active-Turn
+fence only after that canonical terminal crosses the synchronous durable-report
+barrier. A failed or acknowledgement-lost terminal commit remains pending and
+is retried idempotently; exact daemon settlement reconciliation is the only
+other path allowed to release that fence.
 
 Canonical external identity inheritance is separate from provider acceptance
 and Turn lifecycle. A Turn may carry one immutable `IdentityAnchorTurnID`

--- a/packages/agent/host/conformance/conformance.go
+++ b/packages/agent/host/conformance/conformance.go
@@ -204,6 +204,16 @@ type Driver interface {
 	Metrics() Metrics
 }
 
+// ProviderlessTerminalDriver is the narrow fault-injection capability for a
+// Runtime that durably fails the exact canonical Turn before it acquires a
+// provider identity. It stays separate from Fixture so downstream conformance
+// drivers can adopt this lifecycle scenario before upgrading their pinned
+// Tutti dependency; an extra test-driver method is source-compatible with the
+// previous conformance contract.
+type ProviderlessTerminalDriver interface {
+	ResetProviderlessTerminalExec(context.Context, *SessionSeed) error
+}
+
 type Scenario struct {
 	Name string
 	run  func(context.Context, Driver) error

--- a/packages/agent/host/conformance/conformance_test.go
+++ b/packages/agent/host/conformance/conformance_test.go
@@ -12,8 +12,8 @@ func TestPublishedScenarioCatalogsHaveUniqueNames(t *testing.T) {
 		scenarios []Scenario
 		wantCount int
 	}{
-		{name: "adapter lifecycle", scenarios: Scenarios(), wantCount: 32},
-		{name: "application core", scenarios: ApplicationCoreScenarios(), wantCount: 27},
+		{name: "adapter lifecycle", scenarios: Scenarios(), wantCount: 33},
+		{name: "application core", scenarios: ApplicationCoreScenarios(), wantCount: 28},
 		{name: "guidance", scenarios: GuidanceScenarios(), wantCount: 3},
 		{name: "resume policy", scenarios: ResumePolicyScenarios(), wantCount: 5},
 		{name: "submission fence", scenarios: SubmissionFenceScenarios(), wantCount: 1},
@@ -95,6 +95,7 @@ func TestScenarioOwnershipIsExplicit(t *testing.T) {
 		"guidance forwards exact target",
 		"guidance target mismatch does not dispatch provider and cleans claim",
 		"new turns require durable provider acceptance",
+		"providerless canonical terminal settles and replays submission",
 		"rejected initial submit discards runtime without completing canonical session",
 		"duplicate client submit id",
 		"exact turn cancel",
@@ -129,6 +130,7 @@ func TestScenarioOwnershipIsExplicit(t *testing.T) {
 		"guidance forwards exact target",
 		"guidance target mismatch does not dispatch provider and cleans claim",
 		"new turns require durable provider acceptance",
+		"providerless canonical terminal settles and replays submission",
 		"rejected initial submit discards runtime without completing canonical session",
 		"duplicate client submit id",
 		"initial title cas",

--- a/packages/agent/host/conformance/scenarios.go
+++ b/packages/agent/host/conformance/scenarios.go
@@ -21,6 +21,10 @@ var (
 		Name: "new turns require durable provider acceptance",
 		run:  runNewTurnsRequireDurableProviderAcceptance,
 	}
+	providerlessCanonicalTerminalScenario = Scenario{
+		Name: "providerless canonical terminal settles and replays submission",
+		run:  runProviderlessCanonicalTerminalSettlesAndReplaysSubmission,
+	}
 	rejectedInitialSubmitScenario = Scenario{
 		Name: "rejected initial submit discards runtime without completing canonical session",
 		run:  runRejectedInitialSubmitDiscardsRuntime,
@@ -76,6 +80,7 @@ func Scenarios() []Scenario {
 		guidanceExactTargetScenario,
 		guidanceTargetMismatchScenario,
 		providerAcceptanceScenario,
+		providerlessCanonicalTerminalScenario,
 		rejectedInitialSubmitScenario,
 		duplicateClientSubmitIDScenario,
 		exactTurnCancelScenario,
@@ -227,6 +232,7 @@ func ApplicationCoreScenarios() []Scenario {
 		guidanceExactTargetScenario,
 		guidanceTargetMismatchScenario,
 		providerAcceptanceScenario,
+		providerlessCanonicalTerminalScenario,
 		rejectedInitialSubmitScenario,
 		duplicateClientSubmitIDScenario,
 		initialTitleCASScenario,

--- a/packages/agent/host/conformance/session_lifecycle_scenarios.go
+++ b/packages/agent/host/conformance/session_lifecycle_scenarios.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
@@ -573,6 +574,131 @@ func runNewTurnsRequireDurableProviderAcceptance(
 		return errors.New("sent Turn did not require durable provider acceptance")
 	}
 	return nil
+}
+
+func runProviderlessCanonicalTerminalSettlesAndReplaysSubmission(
+	ctx context.Context,
+	driver Driver,
+) error {
+	providerlessDriver, ok := driver.(ProviderlessTerminalDriver)
+	if !ok {
+		return errors.New("conformance driver does not support providerless terminal execution")
+	}
+	if err := providerlessDriver.ResetProviderlessTerminalExec(ctx, nil); err != nil {
+		return err
+	}
+	createInput := agenthost.CreateSessionInput{
+		AgentSessionID: "session-providerless-terminal-create",
+		AgentTargetID:  "target-1",
+		Provider:       "codex",
+		InitialContent: []agenthost.PromptContentBlock{{
+			Type: "text", Text: "fail before provider identity",
+		}},
+		ClientSubmitID: "providerless-terminal-create-1",
+	}
+	_, firstCreateTurnID, err := driver.Create(ctx, "workspace-1", createInput)
+	if err != nil {
+		return fmt.Errorf("create with providerless canonical terminal: %w", err)
+	}
+	if err := requireCanonicalFailedTurn(
+		ctx,
+		driver,
+		agenthost.SessionRef{
+			WorkspaceID: "workspace-1", AgentSessionID: createInput.AgentSessionID,
+		},
+		firstCreateTurnID,
+	); err != nil {
+		return fmt.Errorf("initial providerless terminal: %w", err)
+	}
+	_, replayedCreateTurnID, err := driver.Create(ctx, "workspace-1", createInput)
+	if err != nil {
+		return fmt.Errorf("replay providerless initial submit: %w", err)
+	}
+	if firstCreateTurnID == "" || replayedCreateTurnID != firstCreateTurnID {
+		return fmt.Errorf(
+			"providerless initial replay turns first=%q replay=%q",
+			firstCreateTurnID,
+			replayedCreateTurnID,
+		)
+	}
+	if metrics := driver.Metrics(); metrics.StartCalls != 1 || metrics.ExecCalls != 1 {
+		return fmt.Errorf(
+			"providerless initial replay calls start=%d exec=%d",
+			metrics.StartCalls,
+			metrics.ExecCalls,
+		)
+	}
+
+	sendFixture := liveSessionFixture("session-providerless-terminal-send", "")
+	if err := providerlessDriver.ResetProviderlessTerminalExec(
+		ctx,
+		sendFixture.Session,
+	); err != nil {
+		return err
+	}
+	ref := agenthost.SessionRef{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-providerless-terminal-send",
+	}
+	sendInput := agenthost.SendInput{
+		Content: []agenthost.PromptContentBlock{{
+			Type: "text", Text: "fail before provider identity",
+		}},
+		ClientSubmitID: "providerless-terminal-send-1",
+	}
+	firstSend, err := driver.SendInput(ctx, ref, sendInput)
+	if err != nil {
+		return fmt.Errorf("send with providerless canonical terminal: %w", err)
+	}
+	if err := requireCanonicalFailedTurn(ctx, driver, ref, firstSend.TurnID); err != nil {
+		return fmt.Errorf("ordinary providerless terminal: %w", err)
+	}
+	replayedSend, err := driver.SendInput(ctx, ref, sendInput)
+	if err != nil {
+		return fmt.Errorf("replay providerless ordinary submit: %w", err)
+	}
+	if firstSend.TurnID == "" || replayedSend.TurnID != firstSend.TurnID {
+		return fmt.Errorf(
+			"providerless send replay turns first=%q replay=%q",
+			firstSend.TurnID,
+			replayedSend.TurnID,
+		)
+	}
+	if metrics := driver.Metrics(); metrics.ExecCalls != 1 {
+		return fmt.Errorf("providerless send replay exec calls=%d", metrics.ExecCalls)
+	}
+	return nil
+}
+
+func requireCanonicalFailedTurn(
+	ctx context.Context,
+	driver Driver,
+	ref agenthost.SessionRef,
+	turnID string,
+) error {
+	turnID = strings.TrimSpace(turnID)
+	if turnID == "" {
+		return errors.New("canonical Turn id is empty")
+	}
+	page, err := driver.ListSessionTurns(ctx, ref, agenthost.SessionTurnQuery{Limit: 20})
+	if err != nil {
+		return err
+	}
+	for _, turn := range page.Turns {
+		if strings.TrimSpace(turn.TurnID) != turnID {
+			continue
+		}
+		if strings.TrimSpace(turn.Phase) != "settled" ||
+			strings.TrimSpace(turn.Outcome) != "failed" {
+			return fmt.Errorf(
+				"canonical Turn %q phase=%q outcome=%q, want settled/failed",
+				turnID,
+				turn.Phase,
+				turn.Outcome,
+			)
+		}
+		return nil
+	}
+	return fmt.Errorf("canonical Turn %q not found", turnID)
 }
 
 func runRejectedInitialSubmitDiscardsRuntime(

--- a/services/tuttid/service/agent/host_conformance_test.go
+++ b/services/tuttid/service/agent/host_conformance_test.go
@@ -669,6 +669,40 @@ func (d *legacyHostConformanceDriver) Reset(_ context.Context, fixture hostconfo
 	return nil
 }
 
+func (d *legacyHostConformanceDriver) ResetProviderlessTerminalExec(
+	ctx context.Context,
+	session *hostconformance.SessionSeed,
+) error {
+	fixture := hostconformance.Fixture{}
+	if session != nil {
+		seed := *session
+		fixture.Session = &seed
+	}
+	if err := d.Reset(ctx, fixture); err != nil {
+		return err
+	}
+	d.runtime.execHook = func(input RuntimeExecInput) (RuntimeExecResult, error) {
+		d.recordSubmittedTurn(input.WorkspaceID, input.AgentSessionID, input.TurnID)
+		d.recordProviderlessFailedTurn(
+			input.WorkspaceID,
+			input.AgentSessionID,
+			input.TurnID,
+		)
+		return RuntimeExecResult{
+			AgentSessionID: input.AgentSessionID,
+			Status:         "started",
+			Accepted:       true,
+			SessionStatus:  "working",
+			TurnID:         input.TurnID,
+			TurnLifecycle:  TurnLifecycle{Phase: "submitted"},
+			ProviderDispatch: agenthost.RuntimeProviderDispatchResult{
+				Disposition: agenthost.RuntimeDispatchDispositionAppliedWithoutProviderTurn,
+			},
+		}, nil
+	}
+	return nil
+}
+
 func (d *legacyHostConformanceDriver) DisconnectRuntimeSession(ctx context.Context, ref agenthost.SessionRef) error {
 	return d.runtime.Close(ctx, RuntimeCloseInput{
 		WorkspaceID: ref.WorkspaceID, AgentSessionID: ref.AgentSessionID,
@@ -1482,11 +1516,39 @@ func (d *legacyHostConformanceDriver) recordSubmittedTurn(workspaceID, sessionID
 	if turnID == "" {
 		return
 	}
+	key := sessionID + ":" + turnID
+	if existing, ok := d.turns.turns[key]; ok &&
+		existing.Phase == agentactivitybiz.TurnPhaseSettled {
+		// Submit provenance and Host's post-Exec submission record are
+		// idempotent facts. They must never downgrade a terminal event that the
+		// Runtime committed before Exec returned.
+		return
+	}
 	startedAtUnixMS := int64(len(d.turns.turns) + 1)
-	d.turns.turns[sessionID+":"+turnID] = agentactivitybiz.Turn{
+	d.turns.turns[key] = agentactivitybiz.Turn{
 		WorkspaceID: workspaceID, AgentSessionID: sessionID, TurnID: turnID,
 		Phase: agentactivitybiz.TurnPhaseSubmitted, StartedAtUnixMS: startedAtUnixMS,
 	}
+	d.service.TurnStore = d.turns
+}
+
+func (d *legacyHostConformanceDriver) recordProviderlessFailedTurn(
+	workspaceID string,
+	sessionID string,
+	turnID string,
+) {
+	key := sessionID + ":" + turnID
+	turn := d.turns.turns[key]
+	turn.WorkspaceID = workspaceID
+	turn.AgentSessionID = sessionID
+	turn.TurnID = turnID
+	turn.Phase = agentactivitybiz.TurnPhaseSettled
+	turn.Outcome = "failed"
+	if turn.StartedAtUnixMS == 0 {
+		turn.StartedAtUnixMS = int64(len(d.turns.turns) + 1)
+	}
+	turn.SettledAtUnixMS = turn.StartedAtUnixMS + 1
+	d.turns.turns[key] = turn
 	d.service.TurnStore = d.turns
 }
 


### PR DESCRIPTION
## 背景

Claude 可能在拿到 provider Turn identity 之前直接返回 canonical `turn.failed`。此前 acceptance wrapper 会把该 terminal 当作未接受的 provider 输出，而 blocking controller 又只针对显式 rejection 释放 active-turn fence，导致失败已经发生但 AgentGUI 长时间保持思考中。

## 改动

- 将 Claude pre-acceptance 事件批次结构化分区，只允许调用方本地事实和 exact canonical terminal 穿过边界；assistant、tool 等 provider-dependent 输出即使与 terminal 同批也会 fail closed
- 用 exact canonical terminal 作为 providerless completion authority，并在 durable terminal report 成功后释放对应 active-turn fence
- terminal report 最终失败或 ACK 丢失时保留 pending terminal，幂等重试直到提交成功，或由 exact daemon settlement reconciliation 证明已收敛
- 补充 Host conformance，覆盖首次 Session、普通 Send、`ClientSubmitID` 重放以及 `applied_without_provider_turn + durable failed Turn`
- 加强 explicit rejection、cancel-before-acceptance、outcome-unknown、caller cancellation 和 provider-root aggregation 的边界测试
- 更新 Host contract 与 Agent Session troubleshooting 文档

## 风险与边界

- 影响 Claude SDK acceptance path、blocking Controller terminal commit 与 Host conformance catalog
- 带 provider identity 的 root completion 仍由 daemon canonical aggregation 收敛，不会被本地提前释放
- mixed batch 仅保留可证明安全的 canonical/local 事实，不会发布未接受的 provider 输出
- TSH conformance driver 已通过本地 Tutti `go.work` 组合验证；正式 driver 变更应在本 PR 发布后随 Tutti dependency cohort upgrade 提交，避免 TSH 临时替换或兼容分支

## 验证

- `pnpm check:changed -- --push-ready`：13/13 lanes passed
- `go test -race ./packages/agent/daemon/runtime -run "Test(PartitionClaudeSDKPreAcceptanceEvents|ClaudeSDKProviderlessFailure|ControllerProviderlessCanonicalTerminal|ControllerCancelBeforeProviderAcceptance|ControllerPreAcceptanceOutcomeUnknown|ControllerCallerCancelDuringAcceptance)" -count=5`
- tutt id service adapter 与 direct Host 的 providerless terminal conformance 场景通过
- TSH 本地 Tutti 组合下完整 Host conformance 通过
- TSH shared Owner provider failure/reconciliation 定向测试通过
- TSH 当前固定 Tutti `v0.0.329` 时 driver 仍可编译运行
