### PR TITLE
fix(agent-gui): compose browser window actions in tab header

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2151,6 +2151,13 @@ otherwise recover interactively.
 | `hostActions`      | host mutations, Workbench/window actions  |
 | `renderSlots`      | narrow product-neutral presentation slots |
 
+`AgentToolBrowserPanel` owns its BrowserNode feature, surface identity, and
+tab state. It also owns the single browser chrome instance for that surface.
+Hosts compose window controls into the tab strip through `defaultActions`,
+pass draggable-header semantics through `dragHandleProps`, and use
+`navigationActions` for address-row actions. A host must not wrap the panel in
+a second visible title bar or recreate the browser header outside the panel.
+
 Host-issued `runtimeRequests.composerAppend` values are one-shot requests.
 AgentGUI waits until the exact requested Session is the active conversation,
 applies the append once, and then calls

--- a/packages/agent/gui/workbench/tool-sidebar/AgentToolBrowserPanel.render.test.tsx
+++ b/packages/agent/gui/workbench/tool-sidebar/AgentToolBrowserPanel.render.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { BrowserNodeHostApi } from "@tutti-os/browser-node";
+import type { BrowserNodeWorkbenchHeaderProps } from "@tutti-os/browser-node/react";
+import type { I18nRuntime } from "@tutti-os/ui-i18n-runtime";
+import { AgentToolBrowserPanel } from "./AgentToolBrowserPanel.tsx";
+
+const browserNodeMocks = vi.hoisted(() => ({
+  headerProps: null as BrowserNodeWorkbenchHeaderProps | null
+}));
+
+vi.mock("@tutti-os/browser-node/react", () => ({
+  BrowserNodeWorkbenchHeader: (props: BrowserNodeWorkbenchHeaderProps) => {
+    browserNodeMocks.headerProps = props;
+    return (
+      <div data-browser-node-header="true" {...props.dragHandleProps}>
+        <div data-testid="browser-default-actions">{props.defaultActions}</div>
+        <div data-testid="browser-navigation-actions">
+          {props.navigationActions}
+        </div>
+      </div>
+    );
+  }
+}));
+
+describe("AgentToolBrowserPanel header composition", () => {
+  afterEach(() => {
+    browserNodeMocks.headerProps = null;
+  });
+
+  it("composes host window actions into the browser tab header", async () => {
+    render(
+      <AgentToolBrowserPanel
+        browserApi={createBrowserApi()}
+        defaultActions={<button type="button">Window actions</button>}
+        dragHandleProps={{ "aria-label": "Browser drag handle" }}
+        hidden={false}
+        i18n={{ t: (key) => key } as I18nRuntime<string>}
+        navigationActions={<button type="button">Navigation action</button>}
+      />
+    );
+
+    expect(
+      await screen.findByLabelText("Browser drag handle")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Window actions")).toBeInTheDocument();
+    expect(screen.getByText("Navigation action")).toBeInTheDocument();
+    expect(browserNodeMocks.headerProps?.defaultActions).not.toBeNull();
+    expect(
+      document.querySelectorAll('[data-browser-node-header="true"]')
+    ).toHaveLength(1);
+  });
+});
+
+function createBrowserApi(): BrowserNodeHostApi {
+  return {
+    activate: async () => undefined,
+    close: async () => undefined,
+    goBack: async () => undefined,
+    goForward: async () => undefined,
+    navigate: async () => undefined,
+    onEvent: () => () => undefined,
+    prepareSession: async () => undefined,
+    registerGuest: async () => undefined,
+    reload: async () => undefined,
+    unregisterGuest: async () => undefined
+  };
+}

--- a/packages/agent/gui/workbench/tool-sidebar/AgentToolBrowserPanel.tsx
+++ b/packages/agent/gui/workbench/tool-sidebar/AgentToolBrowserPanel.tsx
@@ -4,6 +4,7 @@ import {
   useCallback,
   useMemo,
   useState,
+  type HTMLAttributes,
   type ReactNode
 } from "react";
 import {
@@ -24,6 +25,13 @@ const LazyBrowserNode = lazy(() =>
     default: BrowserNode
   }))
 );
+const LazyBrowserNodeWorkbenchHeader = lazy(() =>
+  import("@tutti-os/browser-node/react").then(
+    ({ BrowserNodeWorkbenchHeader }) => ({
+      default: BrowserNodeWorkbenchHeader
+    })
+  )
+);
 
 export const agentToolBrowserDefaultUrl = "https://www.google.com/";
 
@@ -35,6 +43,8 @@ export interface AgentToolBrowserPanelProps {
   browserApi: BrowserNodeHostApi;
   chromeCookieImportPrompt?: BrowserNodeChromeImportPromptAdapter;
   defaultUrl?: string;
+  defaultActions?: ReactNode;
+  dragHandleProps?: HTMLAttributes<HTMLElement>;
   hidden: boolean;
   i18n: I18nRuntime<string>;
   loadingFallback?: ReactNode;
@@ -60,6 +70,8 @@ export function AgentToolBrowserPanel({
   browserApi,
   chromeCookieImportPrompt,
   defaultUrl = agentToolBrowserDefaultUrl,
+  defaultActions,
+  dragHandleProps,
   hidden,
   i18n,
   loadingFallback = null,
@@ -120,28 +132,41 @@ export function AgentToolBrowserPanel({
 
   return (
     <div
-      className="relative h-full min-h-0 overflow-hidden"
+      className="relative flex h-full min-h-0 flex-col overflow-hidden"
       data-agent-tool-browser-surface="true"
       data-agent-tool-browser-surface-id={nodeId}
       ref={bindController}
     >
       <Suspense fallback={loadingFallback}>
-        <LazyBrowserNode
-          automationTarget={
-            automationTarget ? { ...automationTarget, focused: !hidden } : null
-          }
+        <LazyBrowserNodeWorkbenchHeader
           defaultUrl={defaultUrl}
           feature={feature}
-          hidden={hidden}
+          defaultActions={defaultActions}
+          dragHandleProps={dragHandleProps}
           navigationActions={navigationActions}
           nodeId={nodeId}
           onCloseRequest={onCloseRequest}
-          profileId={profileId}
-          sessionMode={sessionMode}
-          sessionPartition={sessionPartition}
-          syncDefaultUrl
-          tabs
         />
+        <div className="min-h-0 flex-1">
+          <LazyBrowserNode
+            automationTarget={
+              automationTarget
+                ? { ...automationTarget, focused: !hidden }
+                : null
+            }
+            defaultUrl={defaultUrl}
+            feature={feature}
+            hidden={hidden}
+            nodeId={nodeId}
+            onCloseRequest={onCloseRequest}
+            profileId={profileId}
+            sessionMode={sessionMode}
+            sessionPartition={sessionPartition}
+            showHeader={false}
+            syncDefaultUrl
+            tabs
+          />
+        </div>
       </Suspense>
     </div>
   );


### PR DESCRIPTION
## 变更说明

- 让 `AgentToolBrowserPanel` 统一拥有 BrowserNode header 与 tab 状态
- 新增 `defaultActions` 和 `dragHandleProps` 组合入口，供宿主把窗口控制按钮放入 tab 行
- 保留 `navigationActions` 作为地址栏右侧操作入口
- 增加 DOM 测试，确保只渲染一套 browser header
- 更新 AgentGUI 架构文档，明确 browser chrome 所有权

## 原因

TSH 的 Agent Browser 之前由 Workbench 外层标题栏和 BrowserNode 内部 tab header 分别渲染，形成两层 header。窗口控制必须由拥有 tab 状态的 `AgentToolBrowserPanel` 组合，宿主不应在外部复制 browser header。

## 风险与影响面

- `AgentToolBrowserPanel` 的公开可选 props 扩展，现有调用方无需迁移
- 默认调用路径仍渲染相同 BrowserNode header
- 不改变 Session、Turn、browser runtime 或 tab 生命周期

## AgentGUI Review

| Lane | Trigger | Result | Evidence | Affected consumers |
| --- | --- | --- | --- | --- |
| Architecture | Workbench integration 与公开组合契约 | pass | panel 继续拥有 feature、surface identity、tab state；架构文档已更新 | Desktop、TSH Agent Browser |
| Performance | browser header 渲染边界 | pass | 未增加订阅、observer 或高频状态；沿用 BrowserNode tabs store | Desktop、TSH Agent Browser |
| Consumers | tool-sidebar 子路径公开 props | pass | 新 props 均为可选；DOM 测试与 package typecheck 通过 | Desktop、TSH、外部 AgentGUI hosts |

未发现遗留风险。

## 验证

- `pnpm --filter @tutti-os/agent-gui exec vitest run workbench/tool-sidebar/AgentToolBrowserPanel.render.test.tsx workbench/tool-sidebar/AgentToolBrowserPanel.test.ts --reporter=verbose`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- pre-commit hooks
- `pnpm check:changed -- --push-ready`
