### PR TITLE
fix(connector): finalize credential broker v1

### DIFF
--- a/packages/connector/host/account_runtime_binding_test.go
+++ b/packages/connector/host/account_runtime_binding_test.go
@@ -79,7 +79,7 @@ func TestAccountRuntimeBindingResolverUsesConnectorOwnedCredentialBrokerWithoutS
 	release := testReleaseWithImplementation("lark-cli", "1.0.0", ImplementationKindManagedStdio)
 	release.Manifest.AuthorizationKind = "oauth2"
 	release.Manifest.Implementation.ManagedStdio.CredentialBroker = &ManagedCredentialBroker{
-		Protocol: CredentialBrokerProtocolV2, Entrypoint: "credential-broker.mjs", TimeoutMS: 30_000,
+		Protocol: CredentialBrokerProtocolV1, Entrypoint: "credential-broker.mjs", TimeoutMS: 30_000,
 	}
 	projections := &authorizationProjectionStoreStub{projection: AuthorizationProjection{
 		AccountID: "account-1", ConnectorKey: "lark-cli", State: AuthorizationStateConnected,

--- a/packages/connector/host/application_test.go
+++ b/packages/connector/host/application_test.go
@@ -1214,7 +1214,7 @@ func testManagedAuthorizedConnector(key string) Connector {
 	connector.Release.Manifest.Implementation.ManagedStdio.Runtime.VersionRange = ">=20.0.0 <21.0.0"
 	connector.Release.Manifest.Implementation.ManagedStdio.CLI = &ManagedCLIInterface{Entrypoint: "bin/lark-cli", TimeoutMS: 120_000}
 	connector.Release.Manifest.Implementation.ManagedStdio.CredentialBroker = &ManagedCredentialBroker{
-		Protocol: CredentialBrokerProtocolV2, Entrypoint: "authorization/broker.mjs", TimeoutMS: 30_000,
+		Protocol: CredentialBrokerProtocolV1, Entrypoint: "authorization/broker.mjs", TimeoutMS: 30_000,
 		AllowedHosts: []string{"open.larksuite.com"},
 	}
 	connector.Installation = Installation{State: InstallationStateInstalled, InstalledVersion: connector.Release.Version,

--- a/packages/connector/host/manifest.go
+++ b/packages/connector/host/manifest.go
@@ -16,7 +16,7 @@ const (
 	ImplementationKindBuiltin              = "builtin"
 	ImplementationKindManagedStdio         = "managed_stdio"
 	ImplementationKindRemoteStreamableHTTP = "remote_streamable_http"
-	CredentialBrokerProtocolV2             = "tutti.connector.credentials.v2"
+	CredentialBrokerProtocolV1             = "tutti.connector.credentials.v1"
 	maxAgentRoutingAliases                 = 12
 	maxAgentRoutingAliasRunes              = 48
 )
@@ -332,8 +332,8 @@ func validateManagedCredentialBroker(broker *ManagedCredentialBroker, hasCLI boo
 	if broker == nil || !hasCLI {
 		return invalidManifest("authorized managed_stdio connectors require a CLI credential broker", nil)
 	}
-	if broker.Protocol != CredentialBrokerProtocolV2 || !safeRelativeEntrypoint(broker.Entrypoint) {
-		return invalidManifest("credential broker requires the v2 protocol and a safe connector-relative entrypoint", nil)
+	if broker.Protocol != CredentialBrokerProtocolV1 || !safeRelativeEntrypoint(broker.Entrypoint) {
+		return invalidManifest("credential broker requires the v1 protocol and a safe connector-relative entrypoint", nil)
 	}
 	if broker.TimeoutMS < 1_000 || broker.TimeoutMS > 10*60*1_000 {
 		return invalidManifest("credential broker timeoutMs must be between 1000 and 600000", nil)

--- a/packages/connector/host/manifest_test.go
+++ b/packages/connector/host/manifest_test.go
@@ -30,7 +30,7 @@ func TestImplementationRegistryValidatesSupportedManifest(t *testing.T) {
 					VersionRange: ">=20.0.0 <21.0.0"},
 				CLI: &ManagedCLIInterface{Entrypoint: "github-cli", TimeoutMS: 120_000,
 					Commands: []CLICommand{{Name: "run", InputSchema: map[string]any{"type": "object"}, TimeoutMS: 30_000}}},
-				CredentialBroker: &ManagedCredentialBroker{Protocol: CredentialBrokerProtocolV2,
+				CredentialBroker: &ManagedCredentialBroker{Protocol: CredentialBrokerProtocolV1,
 					Entrypoint: "authorization/broker.mjs", TimeoutMS: 300_000, AllowedHosts: []string{"github.com"}},
 			},
 		},
@@ -95,7 +95,7 @@ func TestManagedCredentialBrokerRequiresConnectorOwnedEntrypointAndAllowedHosts(
 				VersionRange: ">=22.0.0 <23.0.0"},
 			CLI: &ManagedCLIInterface{Entrypoint: "example", TimeoutMS: 120_000,
 				Commands: []CLICommand{{Name: "run", InputSchema: map[string]any{"type": "object"}, TimeoutMS: 30_000}}},
-			CredentialBroker: &ManagedCredentialBroker{Protocol: CredentialBrokerProtocolV2,
+			CredentialBroker: &ManagedCredentialBroker{Protocol: CredentialBrokerProtocolV1,
 				Entrypoint: "authorization/broker.mjs", TimeoutMS: 300_000, AllowedHosts: []string{"accounts.example.com"}},
 		}}}
 	if err := ValidateManifestShape(manifest); err != nil {

--- a/packages/connector/market/src/contracts/domain.ts
+++ b/packages/connector/market/src/contracts/domain.ts
@@ -80,7 +80,7 @@ export interface ConnectorManagedCliInterface {
 }
 
 export interface ConnectorManagedCredentialBroker {
-  protocol: "tutti.connector.credentials.v2";
+  protocol: "tutti.connector.credentials.v1";
   entrypoint: string;
   timeoutMs: number;
   allowedHosts: string[];

--- a/packages/connector/runtime/README.md
+++ b/packages/connector/runtime/README.md
@@ -47,8 +47,8 @@ and affects runtime interface readiness, not installation truth.
 
 Authorized `managed_stdio` Connectors declare a connector-owned
 credential broker entrypoint. The broker translates its provider-specific
-flow into the `tutti.connector.credentials.v2` event protocol. Version 2 adds
-typed `inspect` alongside `begin` and `disconnect`, so a runtime owner can
+flow into the `tutti.connector.credentials.v1` event protocol. The final v1
+contract includes typed `inspect` alongside `begin` and `disconnect`, so a runtime owner can
 calibrate connected, disconnected, expired, and failed state after restart.
 Tutti validates
 every authorization URL against the manifest's exact HTTPS host allowlist and

--- a/packages/connector/runtime/implementationhost/credential_authorization.go
+++ b/packages/connector/runtime/implementationhost/credential_authorization.go
@@ -162,7 +162,7 @@ func (provider *managedCredentialAuthorizationProvider) Disconnect(
 	operationContext, cancel := context.WithTimeout(ctx, route.credentialBrokerLaunch.timeout)
 	defer cancel()
 	connection, processID, err := provider.host.startCredentialBroker(operationContext, route, credentialBrokerRequest{
-		Protocol: market.CredentialBrokerProtocolV2, Operation: "disconnect",
+		Protocol: market.CredentialBrokerProtocolV1, Operation: "disconnect",
 	})
 	if err != nil {
 		return fmt.Errorf("start connector credential broker disconnect: %w", err)
@@ -191,7 +191,7 @@ func (provider *managedCredentialAuthorizationProvider) Inspect(
 	operationContext, cancel := context.WithTimeout(ctx, route.credentialBrokerLaunch.timeout)
 	defer cancel()
 	connection, processID, err := provider.host.startCredentialBroker(operationContext, route, credentialBrokerRequest{
-		Protocol: market.CredentialBrokerProtocolV2, Operation: "inspect",
+		Protocol: market.CredentialBrokerProtocolV1, Operation: "inspect",
 	})
 	if err != nil {
 		return market.AuthorizationObservation{}, fmt.Errorf("start connector credential broker inspect: %w", err)
@@ -240,7 +240,7 @@ func (provider *managedCredentialAuthorizationProvider) authorizationSessionOrSt
 	}
 	processContext, cancel := context.WithTimeout(context.Background(), route.credentialBrokerLaunch.timeout)
 	connection, processID, err := provider.host.startCredentialBroker(processContext, route, credentialBrokerRequest{
-		Protocol: market.CredentialBrokerProtocolV2, Operation: "begin",
+		Protocol: market.CredentialBrokerProtocolV1, Operation: "begin",
 	})
 	if err != nil {
 		cancel()
@@ -481,7 +481,7 @@ func (host *Host) startCredentialBroker(
 	request credentialBrokerRequest,
 ) (agentruntime.ProcessConnection, uint64, error) {
 	launch := route.credentialBrokerLaunch
-	if launch == nil || request.Protocol != market.CredentialBrokerProtocolV2 ||
+	if launch == nil || request.Protocol != market.CredentialBrokerProtocolV1 ||
 		(request.Operation != "begin" && request.Operation != "inspect" && request.Operation != "disconnect") {
 		return nil, 0, errors.New("connector credential broker request is invalid")
 	}
@@ -492,7 +492,7 @@ func (host *Host) startCredentialBroker(
 		return nil, 0, err
 	}
 	spec.Env = append(spec.Env,
-		"TUTTI_CONNECTOR_CREDENTIAL_BROKER_PROTOCOL="+market.CredentialBrokerProtocolV2,
+		"TUTTI_CONNECTOR_CREDENTIAL_BROKER_PROTOCOL="+market.CredentialBrokerProtocolV1,
 		"TUTTI_CONNECTOR_CLI_LAUNCH_JSON="+string(cliLaunch),
 	)
 	connection, processID, err := host.startProcess(ctx, route, spec, false)

--- a/packages/connector/runtime/implementationhost/credential_authorization_test.go
+++ b/packages/connector/runtime/implementationhost/credential_authorization_test.go
@@ -150,7 +150,7 @@ func TestManagedCredentialAuthorizationContinuesConnectorOwnedBroker(t *testing.
 	if connected.State != market.AuthorizationStateConnected {
 		t.Fatalf("connected session = %#v", connected)
 	}
-	if !reflect.DeepEqual(host.requests, []credentialBrokerRequest{{Protocol: market.CredentialBrokerProtocolV2, Operation: "begin"}}) {
+	if !reflect.DeepEqual(host.requests, []credentialBrokerRequest{{Protocol: market.CredentialBrokerProtocolV1, Operation: "begin"}}) {
 		t.Fatalf("broker requests = %#v", host.requests)
 	}
 	observed := awaitAuthorizationObservations(t, host, 3)
@@ -172,7 +172,7 @@ func TestManagedCredentialAuthorizationDisconnectUsesBrokerProtocol(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(host.requests, []credentialBrokerRequest{{Protocol: market.CredentialBrokerProtocolV2, Operation: "disconnect"}}) {
+	if !reflect.DeepEqual(host.requests, []credentialBrokerRequest{{Protocol: market.CredentialBrokerProtocolV1, Operation: "disconnect"}}) {
 		t.Fatalf("broker requests = %#v", host.requests)
 	}
 	observed := awaitAuthorizationObservations(t, host, 1)
@@ -207,7 +207,7 @@ func TestManagedCredentialAuthorizationInspectReturnsFencedObservation(t *testin
 		observation.ReleaseDigest != strings.Repeat("a", 64) || observation.StateRevision != 9 || observation.ObservedAt.IsZero() {
 		t.Fatalf("observation = %#v", observation)
 	}
-	if !reflect.DeepEqual(host.requests, []credentialBrokerRequest{{Protocol: market.CredentialBrokerProtocolV2, Operation: "inspect"}}) {
+	if !reflect.DeepEqual(host.requests, []credentialBrokerRequest{{Protocol: market.CredentialBrokerProtocolV1, Operation: "inspect"}}) {
 		t.Fatalf("broker requests = %#v", host.requests)
 	}
 }

--- a/services/tuttid/api/daemon_connector_market_test.go
+++ b/services/tuttid/api/daemon_connector_market_test.go
@@ -237,7 +237,7 @@ func connectorMarketTestConnector() market.Connector {
 						Runtime: market.RuntimeRequirement{Language: "node", Profile: "connector-node-static", ABI: "node20-darwin-arm64", VersionRange: ">=20.0.0 <21.0.0"},
 						CLI: &market.ManagedCLIInterface{Entrypoint: "notion", TimeoutMS: 120_000,
 							Commands: []market.CLICommand{{Name: "run", InputSchema: map[string]any{"type": "object"}, TimeoutMS: 30_000}}},
-						CredentialBroker: &market.ManagedCredentialBroker{Protocol: market.CredentialBrokerProtocolV2,
+						CredentialBroker: &market.ManagedCredentialBroker{Protocol: market.CredentialBrokerProtocolV1,
 							Entrypoint: "authorization/broker.mjs", TimeoutMS: 300_000, AllowedHosts: []string{"notion.so"}},
 					},
 				},


### PR DESCRIPTION
## Summary

Finalize the Connector credential-broker contract under the pre-launch `tutti.connector.credentials.v1` identifier while retaining the observable authorization semantics introduced by the previous draft: `inspect`, `begin`, and `disconnect`.

This removes the unnecessary v2 protocol boundary before launch and keeps the Host, runtime implementation, Market TypeScript contract, and tuttild API fixtures on one exact identifier. The runtime still calibrates `connected`, `disconnected`, `expired`, and failed authorization state through the connector-owned broker.

## Verification

- `go test ./packages/connector/host ./packages/connector/runtime/implementationhost ./services/tuttid/api`
- `pnpm --filter @tutti-os/connector-market typecheck`
- `pnpm --filter @tutti-os/connector-market test` (38 tests passed)

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter. (Not applicable: Connector authorization protocol only.)
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. (No localized variant exists for the changed runtime README.)
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
