### PR TITLE
feat(workspace-apps): validate canonical reference paths

### DIFF
--- a/services/tuttid/service/workspace/app_factory_reference/SKILL.md
+++ b/services/tuttid/service/workspace/app_factory_reference/SKILL.md
@@ -131,7 +131,7 @@ The runtime must:
 - Read the current UI locale from the optional host-injected app context when localized in-app copy is needed. Do not pass locale in the launch URL query.
 - Keep localized in-app copy behind stable keys and use the harness pattern in `references/i18n-harness.md` so future edits can check locale parity.
 - Use CSS `prefers-color-scheme` / `matchMedia("(prefers-color-scheme: dark)")` for dark/light rendering. Do not pass theme in the launch URL query.
-- When exposing app-owned files through references or generated content, return reference-list `location` objects scoped to `app-data-relative` or `app-package-relative`. Do not emit, persist, or instruct clients to open direct `.tutti` / `.tutti-dev` app state paths such as `$TUTTI_STATE_DIR/apps/...`; the daemon resolves valid locations before desktop clients open files.
+- When exposing files through references or generated content, return a reference-list `location` object. Use `app-data-relative` or `app-package-relative` for files owned by the app package; use `workspace-path` with the actual absolute path for a file the app owns in the current workspace. Do not emit, persist, or instruct clients to open direct `.tutti` / `.tutti-dev` app state paths such as `$TUTTI_STATE_DIR/apps/...`; the daemon validates workspace paths against the current workspace root and resolves valid locations before desktop clients open files.
 
 ## Agent Runtime Integration
 

--- a/services/tuttid/service/workspace/app_factory_reference/references/manifest-contract.md
+++ b/services/tuttid/service/workspace/app_factory_reference/references/manifest-contract.md
@@ -60,9 +60,10 @@ Rules:
 - `references.listEndpoint` must be a relative URL path that starts with `/` and has no scheme, host, query, hash, or percent-encoded characters.
 - `references.searchEndpoint` is optional and declares that the app provides recursive search over its references. Include it when references should be searchable; omit it when the app can only list and per-level filter them.
 - When `references.searchEndpoint` is present, Tutti marks the app as searchable and shows the picker search box for it. The endpoint must satisfy the same URL constraints as `listEndpoint`. Without it, the picker offers only the per-level `filterText` filtering of `listEndpoint`, never a global search.
-- v1 references may only return groups and file references. File references must use `kind: "file"` and a `location` object. Tutti resolves the location to a filesystem path; apps must not emit host absolute paths.
-- `location.type` must be `app-data-relative` for files under the app data directory or `app-package-relative` for files under the immutable app package directory.
-- `location.path` must be a non-empty relative path using `/` separators. It must not contain a scheme, drive prefix, leading slash, NUL, or any `..` segment.
+- v1 references may only return groups and file references. File references must use `kind: "file"` and a `location` object.
+- `location.type` must be `app-data-relative` for files under the app data directory, `app-package-relative` for files under the immutable app package directory, or `workspace-path` for an existing file the app actually reads or writes in the current workspace.
+- For `app-data-relative` and `app-package-relative`, `location.path` must be a non-empty relative path using `/` separators. It must not contain a scheme, drive prefix, leading slash, NUL, or any `..` segment.
+- For `workspace-path`, `location.path` must be the app's actual absolute filesystem path. Do not convert it to a logical path or rebuild it from an app id; Tutti validates that it is contained by the current workspace root before exposing the reference.
 - `window` is optional. Omit it unless the app explicitly needs non-default window behavior or minimum dimensions.
 - `window.minimizeBehavior` may be `keep-mounted` or `hibernate`; omitted defaults to `keep-mounted`.
 - `window.minWidth` and `window.minHeight` are optional integer minimum dimensions for the app webview window.
@@ -165,7 +166,7 @@ Response:
 - Reference items are insertable artifacts and must include a valid file reference in `reference`.
 - `nextCursor` is optional; omit it or return `null` when there is no next page.
 - File `displayName`, `description`, `sizeBytes`, `mtimeMs`, `mimeType`, and `score` are optional. `score` must be between `0` and `1` when present.
-- Apps must return `location`, not an absolute `path`. Tutti resolves valid locations to absolute paths before exposing results to desktop clients.
+- Apps must return `location`, not a separate `path` field. Tutti resolves `app-data-relative` and `app-package-relative` locations, and validates `workspace-path` locations, before exposing absolute paths to desktop clients.
 
 ## Reference Search Runtime Protocol
 
@@ -224,7 +225,7 @@ Response:
 
 - `items` is required and must contain only reference items. Do not return `group` items from search; results are a flat ranked list of insertable file references.
 - Return results ordered by descending relevance and set `score` (`0..1`) so Tutti can preserve your ranking. When `score` is omitted Tutti keeps the returned order.
-- Each reference item must include a valid file reference with a `location`; the same `location` rules and host-path prohibition as the list protocol apply.
+- Each reference item must include a valid file reference with a `location`; the same `location` rules and workspace-root validation as the list protocol apply.
 - `nextCursor` is optional; omit it or return `null` when there is no next page.
 - Return an empty `items` array (not an error) when nothing matches.
 - `parentGroupLabel` is optional (string, max 160 chars). Because search is flattened across the whole app, set it to the name of the group/project the file lives in (e.g. the project a design belongs to) so users can tell results apart. Tutti shows each item's `displayName` as the title and `parentGroupLabel` as the context subtitle. When you omit it, Tutti falls back to your app's manifest display name as the subtitle, so still keep the manifest display name and each `displayName` meaningful.

--- a/services/tuttid/service/workspace/app_references.go
+++ b/services/tuttid/service/workspace/app_references.go
@@ -9,12 +9,14 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"os"
 	pathpkg "path"
 	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/tutti-os/tutti/packages/agent/daemon/httpx"
+	workspacefiles "github.com/tutti-os/tutti/packages/workspace/files"
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 )
 
@@ -191,8 +193,16 @@ func (s *AppCenterService) requestAppRuntimeReferencePage(ctx context.Context, e
 		dataRoot:    filepath.Join(s.workspaceAppStateRoot(workspaceID, appPackage.AppID), "data"),
 		packageRoot: appPackage.PackageDir,
 	}
+	workspaceRootResolved := false
 	items := make([]workspacebiz.AppReferenceListItem, 0, len(raw.Items))
 	for index, rawItem := range raw.Items {
+		if !workspaceRootResolved && appRuntimeReferenceListItemUsesWorkspacePath(rawItem) {
+			validator.workspaceRoot, err = s.workspaceReferenceRoot(ctx, workspaceID)
+			if err != nil {
+				return workspacebiz.AppReferenceListResult{}, err
+			}
+			workspaceRootResolved = true
+		}
 		item, ok := decodeAppRuntimeReferenceListItem(rawItem, validator)
 		if !ok {
 			slog.Warn("workspace app reference item dropped", "workspaceId", workspaceID, "appId", appPackage.AppID, "index", index)
@@ -211,6 +221,19 @@ func (s *AppCenterService) requestAppRuntimeReferencePage(ctx context.Context, e
 		Items:      items,
 		NextCursor: normalizeOptionalCursor(raw.NextCursor),
 	}, nil
+}
+
+func appRuntimeReferenceListItemUsesWorkspacePath(raw json.RawMessage) bool {
+	var item struct {
+		Type      string `json:"type"`
+		Reference struct {
+			Location *appRuntimeReferenceLocation `json:"location"`
+		} `json:"reference"`
+	}
+	if json.Unmarshal(raw, &item) != nil || strings.TrimSpace(item.Type) != "reference" || item.Reference.Location == nil {
+		return false
+	}
+	return strings.TrimSpace(item.Reference.Location.Type) == "workspace-path"
 }
 
 type appRuntimeReferenceListRequest struct {
@@ -281,8 +304,9 @@ type appRuntimeReferenceLocation struct {
 }
 
 type appReferenceLocationValidator struct {
-	dataRoot    string
-	packageRoot string
+	dataRoot      string
+	packageRoot   string
+	workspaceRoot string
 }
 
 func decodeAppRuntimeReferenceListItem(raw json.RawMessage, validator appReferenceLocationValidator) (workspacebiz.AppReferenceListItem, bool) {
@@ -416,20 +440,21 @@ func normalizeAppRuntimeFileReferencePath(reference appRuntimeFileReference, val
 }
 
 func resolveAppRuntimeFileReferenceLocation(location appRuntimeReferenceLocation, validator appReferenceLocationValidator) (string, bool) {
-	relativePath, ok := normalizeAppReferenceRelativePath(location.Path)
-	if !ok {
-		return "", false
-	}
-	var root string
 	switch strings.TrimSpace(location.Type) {
 	case "app-data-relative":
-		root = validator.dataRoot
+		return resolveAppRuntimeRelativeReferencePath(location.Path, validator.dataRoot)
 	case "app-package-relative":
-		root = validator.packageRoot
+		return resolveAppRuntimeRelativeReferencePath(location.Path, validator.packageRoot)
+	case "workspace-path":
+		return resolveAppRuntimeWorkspaceReferencePath(location.Path, validator.workspaceRoot)
 	default:
 		return "", false
 	}
-	if strings.TrimSpace(root) == "" {
+}
+
+func resolveAppRuntimeRelativeReferencePath(value string, root string) (string, bool) {
+	relativePath, ok := normalizeAppReferenceRelativePath(value)
+	if !ok || strings.TrimSpace(root) == "" {
 		return "", false
 	}
 	absoluteRoot, err := filepath.Abs(root)
@@ -444,6 +469,63 @@ func resolveAppRuntimeFileReferenceLocation(location appRuntimeReferenceLocation
 		return "", false
 	}
 	return absolutePath, true
+}
+
+func resolveAppRuntimeWorkspaceReferencePath(value string, root string) (string, bool) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" || strings.Contains(trimmed, "\x00") || !filepath.IsAbs(trimmed) {
+		return "", false
+	}
+	if strings.TrimSpace(root) == "" {
+		return "", false
+	}
+	absoluteRoot, err := filepath.Abs(root)
+	if err != nil {
+		return "", false
+	}
+	absolutePath, err := filepath.Abs(trimmed)
+	if err != nil || !workspacefiles.IsPhysicalPathWithinRoot(absoluteRoot, absolutePath) {
+		return "", false
+	}
+
+	// Resolve symlinks for the existing portion of the path. This preserves
+	// support for a reference whose file is being created while rejecting a
+	// path that escapes through an existing symlink inside the workspace root.
+	resolvedRoot, err := filepath.EvalSymlinks(absoluteRoot)
+	if err != nil {
+		return "", false
+	}
+	for candidate := absolutePath; ; candidate = filepath.Dir(candidate) {
+		resolvedCandidate, resolveErr := filepath.EvalSymlinks(candidate)
+		if resolveErr == nil {
+			if !workspacefiles.IsPhysicalPathWithinRoot(resolvedRoot, resolvedCandidate) {
+				return "", false
+			}
+			break
+		}
+		if !os.IsNotExist(resolveErr) {
+			return "", false
+		}
+		parent := filepath.Dir(candidate)
+		if parent == candidate {
+			return "", false
+		}
+	}
+	return absolutePath, true
+}
+
+func (s *AppCenterService) workspaceReferenceRoot(ctx context.Context, workspaceID string) (string, error) {
+	if s.WorkspaceRootResolver == nil {
+		return "", nil
+	}
+	root, err := s.WorkspaceRootResolver.ResolveWorkspaceRoot(ctx, workspaceID)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(root.PhysicalRoot) == "" {
+		return "", nil
+	}
+	return filepath.Abs(root.PhysicalRoot)
 }
 
 func normalizeAppReferenceRelativePath(value string) (string, bool) {

--- a/services/tuttid/service/workspace/app_references_test.go
+++ b/services/tuttid/service/workspace/app_references_test.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	workspacefiles "github.com/tutti-os/tutti/packages/workspace/files"
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 )
 
@@ -140,6 +142,83 @@ func TestDecodeAppRuntimeReferenceAcceptsFileLocationTypes(t *testing.T) {
 	}
 }
 
+func TestDecodeAppRuntimeReferenceAcceptsWorkspacePathWithinCurrentWorkspaceRoot(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	referencePath := filepath.Join(workspaceRoot, "projects", "report.md")
+	if err := os.MkdirAll(filepath.Dir(referencePath), 0o755); err != nil {
+		t.Fatalf("mkdir reference parent: %v", err)
+	}
+	if err := os.WriteFile(referencePath, []byte("report"), 0o644); err != nil {
+		t.Fatalf("write reference: %v", err)
+	}
+	raw, err := json.Marshal(map[string]any{
+		"kind": "file",
+		"location": map[string]any{
+			"type": "workspace-path",
+			"path": referencePath,
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal reference: %v", err)
+	}
+	reference, ok := decodeAppRuntimeReference(raw, appReferenceLocationValidator{workspaceRoot: workspaceRoot})
+	if !ok {
+		t.Fatal("decodeAppRuntimeReference() ok = false, want true")
+	}
+	fileReference, ok := reference.(workspacebiz.AppFileReference)
+	if !ok {
+		t.Fatalf("decodeAppRuntimeReference() = %T, want AppFileReference", reference)
+	}
+	if fileReference.Path != referencePath {
+		t.Fatalf("Path = %q, want %q", fileReference.Path, referencePath)
+	}
+}
+
+func TestDecodeAppRuntimeReferenceRejectsWorkspacePathOutsideCurrentWorkspaceRoot(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	outsideRoot := t.TempDir()
+	outsidePath := filepath.Join(outsideRoot, "secret.md")
+	if err := os.WriteFile(outsidePath, []byte("secret"), 0o644); err != nil {
+		t.Fatalf("write outside reference: %v", err)
+	}
+	raw := json.RawMessage(`{"kind":"file","location":{"type":"workspace-path","path":"` + outsidePath + `"}}`)
+	if _, ok := decodeAppRuntimeReference(raw, appReferenceLocationValidator{workspaceRoot: workspaceRoot}); ok {
+		t.Fatal("decodeAppRuntimeReference() ok = true, want false")
+	}
+}
+
+func TestDecodeAppRuntimeReferenceRejectsWorkspacePathSymlinkEscape(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	outsideRoot := t.TempDir()
+	outsidePath := filepath.Join(outsideRoot, "secret.md")
+	if err := os.WriteFile(outsidePath, []byte("secret"), 0o644); err != nil {
+		t.Fatalf("write outside reference: %v", err)
+	}
+	linkPath := filepath.Join(workspaceRoot, "linked")
+	if err := os.Symlink(outsideRoot, linkPath); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	raw, err := json.Marshal(map[string]any{
+		"kind": "file",
+		"location": map[string]any{
+			"type": "workspace-path",
+			"path": filepath.Join(linkPath, "secret.md"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal reference: %v", err)
+	}
+	if _, ok := decodeAppRuntimeReference(raw, appReferenceLocationValidator{workspaceRoot: workspaceRoot}); ok {
+		t.Fatal("decodeAppRuntimeReference() ok = true, want false")
+	}
+}
+
 func TestDecodeAppRuntimeReferenceDropsInvalidLocation(t *testing.T) {
 	t.Parallel()
 
@@ -151,6 +230,7 @@ func TestDecodeAppRuntimeReferenceDropsInvalidLocation(t *testing.T) {
 		"{\"kind\":\"file\",\"path\":\"/tmp/bad\\u0000name.txt\"}",
 		`{"kind":"file","type":"app-data-relative","path":"a.txt"}`,
 		`{"kind":"file","location":{"type":"workspace-relative","path":"a.txt"}}`,
+		`{"kind":"file","location":{"type":"workspace-path","path":"relative.txt"}}`,
 		`{"kind":"file","location":{"type":"app-data-relative","path":""}}`,
 		`{"kind":"file","location":{"type":"app-data-relative","path":"/a.txt"}}`,
 		`{"kind":"file","location":{"type":"app-data-relative","path":"../secret.txt"}}`,
@@ -194,6 +274,14 @@ func TestListReferencesQueriesRunningEnabledAppAndDropsInvalidItems(t *testing.T
 
 	packageDir := t.TempDir()
 	guidePath := filepath.Join(packageDir, "docs", "guide.md")
+	workspaceRoot := t.TempDir()
+	workspacePath := filepath.Join(workspaceRoot, "slide-1", "deck.pdf")
+	if err := os.MkdirAll(filepath.Dir(workspacePath), 0o755); err != nil {
+		t.Fatalf("mkdir workspace reference parent: %v", err)
+	}
+	if err := os.WriteFile(workspacePath, []byte("deck"), 0o644); err != nil {
+		t.Fatalf("write workspace reference: %v", err)
+	}
 	requests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		requests++
@@ -224,6 +312,10 @@ func TestListReferencesQueriesRunningEnabledAppAndDropsInvalidItems(t *testing.T
 					"type": "app-package-relative",
 					"path": "docs/guide.md",
 				}}},
+				{"type": "reference", "reference": map[string]any{"kind": "file", "displayName": "Deck", "location": map[string]any{
+					"type": "workspace-path",
+					"path": workspacePath,
+				}}},
 			},
 			"nextCursor": "next-page",
 		}); err != nil {
@@ -242,6 +334,7 @@ func TestListReferencesQueriesRunningEnabledAppAndDropsInvalidItems(t *testing.T
 		runtimeHTTPClient:   server.Client(),
 		runtimeResolverStub: &appRuntimeResolverStub{called: make(chan struct{})},
 		packageDir:          packageDir,
+		workspaceRoot:       workspaceRoot,
 	})
 
 	result, err := service.ListReferences(context.Background(), "ws-1", "docs", workspacebiz.AppReferenceListInput{
@@ -258,8 +351,8 @@ func TestListReferencesQueriesRunningEnabledAppAndDropsInvalidItems(t *testing.T
 	if requests != 1 {
 		t.Fatalf("runtime requests = %d, want 1", requests)
 	}
-	if len(result.Items) != 2 {
-		t.Fatalf("items = %#v, want two valid items", result.Items)
+	if len(result.Items) != 3 {
+		t.Fatalf("items = %#v, want three valid items", result.Items)
 	}
 	group, ok := result.Items[0].(workspacebiz.AppReferenceGroup)
 	if !ok {
@@ -278,6 +371,14 @@ func TestListReferencesQueriesRunningEnabledAppAndDropsInvalidItems(t *testing.T
 	}
 	if fileReference.Path != guidePath {
 		t.Fatalf("reference path = %q, want %q", fileReference.Path, guidePath)
+	}
+	workspaceReferenceItem, ok := result.Items[2].(workspacebiz.AppReferenceListReferenceItem)
+	if !ok {
+		t.Fatalf("third item type = %T, want AppReferenceListReferenceItem", result.Items[2])
+	}
+	workspaceReference, ok := workspaceReferenceItem.Reference.(workspacebiz.AppFileReference)
+	if !ok || workspaceReference.Path != workspacePath {
+		t.Fatalf("workspace reference = %#v, want path %q", workspaceReferenceItem.Reference, workspacePath)
 	}
 	if result.NextCursor == nil || *result.NextCursor != "next-page" {
 		t.Fatalf("nextCursor = %#v, want next-page", result.NextCursor)
@@ -428,6 +529,7 @@ type appReferenceListServiceTestInput struct {
 	runtimeHTTPClient   *http.Client
 	runtimeResolverStub *appRuntimeResolverStub
 	packageDir          string
+	workspaceRoot       string
 }
 
 func newAppReferenceListServiceForTest(t *testing.T, input appReferenceListServiceTestInput) *AppCenterService {
@@ -480,12 +582,19 @@ func newAppReferenceListServiceForTest(t *testing.T, input appReferenceListServi
 		state.LaunchURL = &input.runtimeLaunchURL
 	}
 	runner.setState(appRuntimeKey("ws-1", "docs"), state)
-	return &AppCenterService{
+	service := &AppCenterService{
 		Store:          store,
 		WorkspaceStore: &catalogStoreStub{getWorkspace: workspacebiz.Summary{ID: "ws-1", Name: "Workspace"}},
 		Runner:         runner,
 		StateDir:       t.TempDir(),
 	}
+	if input.workspaceRoot != "" {
+		service.WorkspaceRootResolver = workspaceRootResolverStub{root: workspacefiles.WorkspaceRoot{
+			LogicalRoot:  "/workspace",
+			PhysicalRoot: input.workspaceRoot,
+		}}
+	}
+	return service
 }
 
 func assertRuntimeResolverNotCalled(t *testing.T, resolver *appRuntimeResolverStub) {

--- a/services/tuttid/service/workspace/apps.go
+++ b/services/tuttid/service/workspace/apps.go
@@ -23,6 +23,7 @@ type AppCenterService struct {
 	Store                  workspacedata.AppStore
 	AppFactoryStore        workspacedata.AppFactoryStore
 	WorkspaceStore         workspacedata.CatalogStore
+	WorkspaceRootResolver  WorkspaceRootResolver
 	PreferencesStore       workspacedata.PreferencesStore
 	Runner                 *AppRunner
 	ShellAdapter           AppShellAdapter

--- a/services/tuttid/wiring_daemon_api.go
+++ b/services/tuttid/wiring_daemon_api.go
@@ -645,6 +645,7 @@ func buildDaemonAPI(
 		Store:                 appStore,
 		AppFactoryStore:       appFactoryStore,
 		WorkspaceStore:        store,
+		WorkspaceRootResolver: workspaceservice.FileService{Adapter: fileAdapter},
 		PreferencesStore:      preferencesStore,
 		Runner:                &workspaceservice.AppRunner{RuntimeResolver: managedRuntimeResolver, ShellAdapter: appShellAdapter},
 		ShellAdapter:          appShellAdapter,


### PR DESCRIPTION
## Summary\n- accept workspace-path from running workspace apps\n- resolve against the current workspace physical root\n- reject relative, outside-root, and symlink-escape locations before producing file references\n\n## Validation\n- focused workspace service Go tests\n- Desktop typecheck\n- push-ready changed-lane checks