### PR TITLE
refactor(workbench): decompose host dock orchestration

### DIFF
--- a/packages/workbench/surface/package.json
+++ b/packages/workbench/surface/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "build": "tsup --config tsup.config.ts && node ../../../tools/scripts/copy-package-assets.mjs src/styles dist/styles",
-    "test": "node --test --experimental-strip-types ./src/**/*.test.ts && vitest run ./src/host/WorkbenchHostDock.render.test.tsx ./src/host/WorkbenchHostDockMinimizedPreview.test.tsx ./src/host/WorkbenchHost.render.test.tsx ./src/host/useWorkbenchMinimizedDockPreview.test.tsx ./src/preview/createWorkbenchNodePreviewCaptureAdapter.test.tsx ./src/react/genieTextureCapture.test.tsx --environment jsdom",
+    "test": "node --test --experimental-strip-types ./src/**/*.test.ts && vitest run ./src/host/WorkbenchHostDock.render.test.tsx ./src/host/WorkbenchHostDock.interactions.render.test.tsx ./src/host/WorkbenchHostDockMinimizedPreview.test.tsx ./src/host/WorkbenchHost.render.test.tsx ./src/host/useWorkbenchMinimizedDockPreview.test.tsx ./src/preview/createWorkbenchNodePreviewCaptureAdapter.test.tsx ./src/react/genieTextureCapture.test.tsx --environment jsdom",
     "typecheck": "node ../../../tools/scripts/run-tsgo-typecheck.mjs"
   },
   "devDependencies": {

--- a/packages/workbench/surface/src/host/WorkbenchHostDock.interactions.render.test.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDock.interactions.render.test.tsx
@@ -1,0 +1,540 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { describe, expect, it, vi } from "vitest";
+import type { WorkbenchNode, WorkbenchState } from "../core/types.ts";
+import type { WorkbenchDockContext } from "../react/types.ts";
+import type { WorkbenchController } from "../store/types.ts";
+import { WorkbenchHostDock } from "./WorkbenchHostDock.tsx";
+import type {
+  WorkbenchHostDockEntry,
+  WorkbenchHostHandle,
+  WorkbenchHostNodeData,
+  WorkbenchHostNodeDefinition
+} from "./types.ts";
+import { createWorkbenchHostI18nRuntime } from "./workbenchHostI18n.ts";
+
+describe("WorkbenchHostDock interactions", () => {
+  it("preserves blocked, action, focus, popup, and launch click effects", async () => {
+    const focusNode = createNode("focus-node", "focus-entry");
+    const popupNode = createNode("popup-node", "popup-entry");
+    const fixture = createDockFixture([focusNode, popupNode]);
+    const events: string[] = [];
+    fixture.host.focusNode = vi.fn((nodeId) => {
+      events.push(`focus:${nodeId}`);
+    });
+    fixture.host.launchNode = vi.fn(async (input) => {
+      events.push(`launch:${input.dockEntryId}`);
+      return null;
+    });
+    const onDockEntryAction = vi.fn(({ actionId }) => {
+      events.push(`action:${actionId}`);
+    });
+    const onDockEntryClick = vi.fn(({ nodeId }) => {
+      events.push(`click:${nodeId}`);
+    });
+    const entries: WorkbenchHostDockEntry[] = [
+      entry("blocked-entry", {
+        state: { kind: "disabled", reason: "Unavailable" }
+      }),
+      entry("action-entry", { clickActionId: "retry" }),
+      entry("focus-entry"),
+      entry("popup-entry", { instanceMode: "multi" }),
+      entry("launch-entry")
+    ];
+    const mounted = await mountDock(
+      <WorkbenchHostDock
+        {...fixture.props}
+        dockEntries={entries}
+        onDockEntryAction={onDockEntryAction}
+        onDockEntryClick={onDockEntryClick}
+      />
+    );
+
+    try {
+      await clickDockEntry(mounted.container, "blocked-entry");
+      expect(onDockEntryAction).not.toHaveBeenCalled();
+      expect(onDockEntryClick).not.toHaveBeenCalled();
+      expect(fixture.host.launchNode).not.toHaveBeenCalled();
+
+      await clickDockEntry(mounted.container, "action-entry");
+      await vi.waitFor(() => {
+        expect(onDockEntryAction).toHaveBeenCalledWith({
+          actionId: "retry",
+          entryId: "action-entry",
+          host: fixture.host
+        });
+      });
+
+      await clickDockEntry(mounted.container, "focus-entry");
+      expect(events.slice(-2)).toEqual([
+        "click:focus-node",
+        "focus:focus-node"
+      ]);
+      expect(fixture.launchNodeFromAnchor).toHaveBeenCalledWith(
+        "focus-entry",
+        "focus-node",
+        expect.any(Function)
+      );
+
+      await clickDockEntry(mounted.container, "popup-entry");
+      expect(
+        dockEntryButton(mounted.container, "popup-entry").getAttribute(
+          "aria-expanded"
+        )
+      ).toBe("true");
+      expect(document.body.querySelector('[role="dialog"]')).not.toBeNull();
+
+      await clickDockEntry(mounted.container, "launch-entry");
+      await vi.waitFor(() => {
+        expect(fixture.host.launchNode).toHaveBeenCalledWith({
+          dockEntryId: "launch-entry",
+          payload: undefined,
+          reason: "dock",
+          typeId: "launch-entry"
+        });
+      });
+    } finally {
+      await mounted.unmount();
+    }
+  });
+
+  it("keeps context-menu launch metadata and fallback payload semantics", async () => {
+    const fixture = createDockFixture();
+    const launchNode = vi.fn(async () => null);
+    fixture.host.launchNode = launchNode;
+    const mounted = await mountDock(
+      <WorkbenchHostDock
+        {...fixture.props}
+        dockEntries={[
+          entry("context-entry", {
+            launchPayload: { source: "primary" },
+            newWindowLaunchPayload: { source: "new-window" }
+          })
+        ]}
+      />
+    );
+
+    try {
+      const button = dockEntryButton(mounted.container, "context-entry");
+      await act(async () => {
+        button.dispatchEvent(
+          new MouseEvent("contextmenu", { bubbles: true, cancelable: true })
+        );
+      });
+      const menu = document.body.querySelector<HTMLElement>(
+        '[data-desktop-dock-context-menu="true"]'
+      );
+      expect(menu).not.toBeNull();
+      const command =
+        menu?.querySelector<HTMLButtonElement>('[role="menuitem"]');
+      expect(command?.disabled).toBe(false);
+
+      await act(async () => {
+        command?.click();
+      });
+      await vi.waitFor(() => {
+        expect(launchNode).toHaveBeenCalledWith({
+          dockEntryId: "context-entry",
+          launchSource: "dock-popup-new-window",
+          payload: { source: "new-window" },
+          reason: "dock",
+          typeId: "context-entry"
+        });
+      });
+    } finally {
+      await mounted.unmount();
+    }
+  });
+
+  it("runs hover pointer actions once and preserves keyboard activation", async () => {
+    const fixture = createDockFixture();
+    const pending = deferred();
+    const onDockEntryAction = vi.fn(({ actionId }) =>
+      actionId === "pointer" ? pending.promise : undefined
+    );
+    const mounted = await mountDock(
+      <WorkbenchHostDock
+        {...fixture.props}
+        dockEntries={[
+          entry("hover-entry", {
+            hoverActions: [
+              {
+                id: "pointer",
+                label: "Retry",
+                pendingLabel: "Retrying"
+              },
+              { id: "keyboard", label: "Open settings" }
+            ],
+            state: { kind: "unavailable", reason: "Connection failed。" }
+          })
+        ]}
+        onDockEntryAction={onDockEntryAction}
+      />
+    );
+
+    try {
+      await act(async () => {
+        dockEntryButton(mounted.container, "hover-entry").focus();
+      });
+      const panel = mounted.container.querySelector<HTMLElement>(
+        ".desktop-dock__hover-panel"
+      );
+      expect(panel?.textContent).toContain("Connection failed");
+      expect(panel?.textContent).not.toContain("Connection failed。");
+      const [pointerAction, keyboardAction] = Array.from(
+        panel?.querySelectorAll<HTMLButtonElement>("button") ?? []
+      );
+
+      await act(async () => {
+        pointerAction?.dispatchEvent(
+          new MouseEvent("pointerdown", { bubbles: true, button: 0 })
+        );
+        pointerAction?.click();
+      });
+      expect(onDockEntryAction).toHaveBeenCalledTimes(1);
+      expect(onDockEntryAction).toHaveBeenLastCalledWith({
+        actionId: "pointer",
+        entryId: "hover-entry",
+        host: fixture.host
+      });
+      expect(pointerAction?.getAttribute("aria-busy")).toBe("true");
+      expect(pointerAction?.textContent).toBe("Retrying");
+
+      await act(async () => {
+        keyboardAction?.click();
+      });
+      expect(onDockEntryAction).toHaveBeenCalledTimes(2);
+      expect(onDockEntryAction).toHaveBeenLastCalledWith({
+        actionId: "keyboard",
+        entryId: "hover-entry",
+        host: fixture.host
+      });
+
+      await act(async () => {
+        pending.resolve();
+        await pending.promise;
+      });
+      await vi.waitFor(() => {
+        expect(pointerAction?.textContent).toBe("Retry");
+      });
+    } finally {
+      pending.resolve();
+      await mounted.unmount();
+    }
+  });
+
+  it("opens and closes label tooltips through keyboard focus", async () => {
+    const fixture = createDockFixture();
+    const mounted = await mountDock(
+      <WorkbenchHostDock
+        {...fixture.props}
+        dockEntries={[entry("tooltip-entry", { label: "Tooltip label" })]}
+      />
+    );
+
+    try {
+      const button = dockEntryButton(mounted.container, "tooltip-entry");
+      await act(async () => {
+        button.focus();
+      });
+      expect(
+        mounted.container.querySelector('[role="tooltip"]')?.textContent
+      ).toBe("Tooltip label");
+
+      await act(async () => {
+        button.blur();
+      });
+      expect(mounted.container.querySelector('[role="tooltip"]')).toBeNull();
+    } finally {
+      await mounted.unmount();
+    }
+  });
+
+  it("restores an independent minimized slot through its Genie anchor", async () => {
+    const minimizedNode = createMinimizedNode("minimized-one", 10);
+    const fixture = createDockFixture([], [minimizedNode]);
+    const mounted = await mountDock(
+      <WorkbenchHostDock
+        {...fixture.props}
+        dockEntries={[]}
+        nodeDefinitions={minimizedNodeDefinitions()}
+      />
+    );
+
+    try {
+      const restoreButton = mounted.container.querySelector<HTMLElement>(
+        '[data-desktop-dock-anchor-key="minimized:minimized-one"] [role="button"]'
+      );
+      expect(restoreButton).not.toBeNull();
+      await act(async () => {
+        restoreButton?.click();
+      });
+
+      expect(fixture.launchNodeFromAnchor).toHaveBeenCalledWith(
+        "minimized:minimized-one",
+        "minimized-one",
+        expect.any(Function)
+      );
+      expect(fixture.host.focusNode).toHaveBeenCalledWith("minimized-one");
+    } finally {
+      await mounted.unmount();
+    }
+  });
+
+  it("restores a minimized stack card without replacing the stack anchor", async () => {
+    const minimizedNodes = Array.from({ length: 6 }, (_, index) =>
+      createMinimizedNode(`minimized-${index + 1}`, index + 1)
+    );
+    const fixture = createDockFixture([], minimizedNodes);
+    const mounted = await mountDock(
+      <WorkbenchHostDock
+        {...fixture.props}
+        dockEntries={[]}
+        nodeDefinitions={minimizedNodeDefinitions()}
+      />
+    );
+
+    try {
+      const stackButton = mounted.container.querySelector<HTMLElement>(
+        '[data-desktop-dock-anchor-key="minimized-stack"] [role="button"]'
+      );
+      expect(stackButton).not.toBeNull();
+      await act(async () => {
+        stackButton?.click();
+      });
+      const firstCard = document.body.querySelector<HTMLElement>(
+        '[data-popup-variant="minimized-stack"] [data-desktop-dock-popup-card="true"] [role="button"]'
+      );
+      expect(firstCard).not.toBeNull();
+      const selectedTitle = firstCard?.getAttribute("aria-label");
+      await act(async () => {
+        firstCard?.click();
+      });
+
+      await vi.waitFor(() => {
+        expect(fixture.launchNodeFromAnchor).toHaveBeenCalledWith(
+          "minimized-stack",
+          selectedTitle,
+          expect.any(Function)
+        );
+      });
+      expect(fixture.host.focusNode).toHaveBeenCalledWith(selectedTitle);
+    } finally {
+      await mounted.unmount();
+    }
+  });
+});
+
+function entry(
+  id: string,
+  overrides: Partial<WorkbenchHostDockEntry> = {}
+): WorkbenchHostDockEntry {
+  return {
+    icon: null,
+    id,
+    label: id,
+    typeId: id,
+    visibility: "always",
+    ...overrides
+  };
+}
+
+function createNode(
+  id: string,
+  dockEntryId: string
+): WorkbenchNode<WorkbenchHostNodeData> {
+  return {
+    data: {
+      dockEntryId,
+      instanceId: id,
+      instanceKey: null,
+      typeId: dockEntryId
+    },
+    displayMode: "floating",
+    frame: { height: 560, width: 1040, x: 20, y: 20 },
+    id,
+    isMinimized: false,
+    kind: dockEntryId,
+    restoreFrame: null,
+    title: id
+  };
+}
+
+function createMinimizedNode(
+  id: string,
+  minimizedAtUnixMs: number
+): WorkbenchNode<WorkbenchHostNodeData> {
+  return {
+    ...createNode(id, "agent"),
+    isMinimized: true,
+    minimizedAtUnixMs,
+    title: id
+  };
+}
+
+function minimizedNodeDefinitions(): Map<string, WorkbenchHostNodeDefinition> {
+  return new Map([
+    [
+      "agent",
+      {
+        frame: { height: 560, width: 1040, x: 20, y: 20 },
+        renderBody: () => null,
+        title: "Agent",
+        typeId: "agent",
+        window: {
+          minimizedDock: {
+            kind: "component",
+            providePreview: () => ({ element: null, kind: "component" })
+          }
+        }
+      } as WorkbenchHostNodeDefinition
+    ]
+  ]);
+}
+
+function createDockFixture(
+  nodes: readonly WorkbenchNode<WorkbenchHostNodeData>[] = [],
+  minimizedNodes: readonly WorkbenchNode<WorkbenchHostNodeData>[] = []
+) {
+  const allNodes = [...nodes, ...minimizedNodes];
+  const state: WorkbenchState<WorkbenchHostNodeData> = {
+    activeDragNodeId: null,
+    activeResizeNodeId: null,
+    activeSnapTarget: null,
+    layoutConstraints: {
+      minHeight: 160,
+      minWidth: 280,
+      safeArea: { bottom: 0, left: 0, right: 0, top: 0 },
+      surfacePadding: 0
+    },
+    lockedLayout: null,
+    nodes: allNodes,
+    nodeStack: allNodes.map((node) => node.id),
+    surfaceSize: { height: 800, width: 1200 }
+  };
+  const controller: WorkbenchController<WorkbenchHostNodeData> = {
+    commands: {
+      enterFullscreen: vi.fn(),
+      restoreNode: vi.fn()
+    } as unknown as WorkbenchController<WorkbenchHostNodeData>["commands"],
+    dispatch() {},
+    getSnapshot: () => state,
+    subscribe: () => () => {}
+  };
+  const launchNodeFromAnchor = vi.fn(
+    (_anchorKey: string, _nodeId: string, launch: () => unknown) => {
+      void launch();
+    }
+  );
+  const context: WorkbenchDockContext<WorkbenchHostNodeData> = {
+    controller,
+    focusedNodeId: null,
+    genie: {
+      isPendingMinimizedDockNode: () => false,
+      launchNodeFromAnchor,
+      registerDockAnchor() {},
+      shouldAnimateMinimizedDockEnter: () => false
+    },
+    minimizedNodes: [...minimizedNodes],
+    nodes: allNodes
+  };
+  const host: WorkbenchHostHandle = {
+    activateNode() {},
+    closeNode() {},
+    collectWindowCloseEffects: async () => [],
+    dispose() {},
+    exitFullscreenNode() {},
+    focusNode: vi.fn(),
+    getSnapshot: () => state,
+    launchNode: vi.fn(async () => null),
+    load: async () => {},
+    minimizeNode: vi.fn(),
+    reconcileProjectedNodes() {},
+    requestNodeClose: vi.fn(),
+    setNodeRuntimeState() {},
+    setNodeSizeConstraints() {},
+    setNodeTitle() {},
+    setSnapshotNodeState() {}
+  };
+
+  return {
+    host,
+    launchNodeFromAnchor,
+    props: {
+      context,
+      host,
+      i18n: createWorkbenchHostI18nRuntime(undefined),
+      nodeDefinitions: new Map(),
+      workspaceId: "workspace-interactions"
+    }
+  };
+}
+
+async function mountDock(element: React.ReactNode): Promise<{
+  container: HTMLDivElement;
+  unmount(): Promise<void>;
+}> {
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      disconnect() {}
+      observe() {}
+      unobserve() {}
+    }
+  );
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root: Root = createRoot(container);
+  const previousActEnvironment = (
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT;
+  (
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  await act(async () => {
+    root.render(element);
+  });
+  return {
+    container,
+    async unmount() {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      (
+        globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+      ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+      vi.unstubAllGlobals();
+    }
+  };
+}
+
+async function clickDockEntry(container: HTMLElement, entryId: string) {
+  await act(async () => {
+    dockEntryButton(container, entryId).click();
+  });
+}
+
+function dockEntryButton(
+  container: HTMLElement,
+  entryId: string
+): HTMLButtonElement {
+  const button = container.querySelector<HTMLButtonElement>(
+    `[data-desktop-dock-anchor-key="${entryId}"] > button`
+  );
+  if (!button) {
+    throw new Error(`Expected dock entry button for ${entryId}`);
+  }
+  return button;
+}
+
+function deferred(): {
+  promise: Promise<void>;
+  resolve(): void;
+} {
+  let resolvePromise = (): void => undefined;
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return { promise, resolve: resolvePromise };
+}

--- a/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
@@ -1,80 +1,54 @@
 import {
   useCallback,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
-  type CSSProperties,
-  type Dispatch,
-  type FocusEvent as ReactFocusEvent,
-  type KeyboardEvent as ReactKeyboardEvent,
-  type PointerEvent as ReactPointerEvent,
-  type RefObject,
-  type SetStateAction
+  type CSSProperties
 } from "react";
 import {
   ArrowLeftIcon,
   ArrowRightIcon,
-  Button,
   ChevronDownIcon,
   ChevronUpIcon
 } from "@tutti-os/ui-system";
 import type { WorkbenchDockContext } from "../react/types.ts";
-import {
-  readWorkbenchMinimizedDockPreviewImage,
-  resolveWorkbenchMinimizedDockPreviewImage,
-  resolveWorkbenchMinimizedDockPreviewRevision
-} from "./useWorkbenchMinimizedDockPreview.ts";
-import {
-  minimizedDockPreviewFreezeKey,
-  WorkbenchHostDockMinimizedNodePreview
-} from "./WorkbenchHostDockMinimizedPreview.tsx";
 export { renderMinimizedDockPreviewContent } from "./WorkbenchHostDockMinimizedPreview.tsx";
-import {
-  canCreateNewWindow,
-  canCreateNewWindowInDockPopup,
-  resolveWorkbenchDockEntries,
-  resolveWorkbenchDockEntryClick,
-  type ResolvedWorkbenchHostDockEntry
-} from "./dockEntries.ts";
-import {
-  DOCK_ICON_PEAK_SIZE,
-  useDockMagnification
-} from "./dockMagnification.ts";
-import { resolveDockLabelTooltipAnchorRect } from "./dockLabelTooltipAnchor.ts";
-import {
-  getDockWallpaperImageSample,
-  sampleDockWallpaperLuminanceAtElement
-} from "./dockWallpaperSampling.ts";
-import {
-  resolveWorkbenchHostDockScrollState,
-  type WorkbenchHostDockScrollState
-} from "./dockScrollState.ts";
-import {
-  createWorkbenchHostExternalStateLookupInput,
-  readWorkbenchHostExternalState
-} from "./externalState.ts";
+import { resolveWorkbenchDockEntries } from "./dockEntries.ts";
+import { readWorkbenchHostExternalState } from "./externalState.ts";
 import {
   resolveWorkbenchMinimizedDockSlots,
-  type WorkbenchMinimizedDockNode,
-  type WorkbenchMinimizedDockSlot
+  type WorkbenchMinimizedDockNode
 } from "./minimizedDockSlots.ts";
 import { useMinimizedDockStackPromotion } from "./minimizedDockStackPromotion.ts";
+import { resolveWorkbenchMinimizedDockRestoreIntent } from "./minimizedDockRestoreIntent.ts";
 import {
-  resolveWorkbenchMinimizedDockRestoreIntent,
-  type WorkbenchMinimizedDockRestoreIntent
-} from "./minimizedDockRestoreIntent.ts";
+  createWorkbenchHostDockItems as createDockItems,
+  resolveWorkbenchHostDockItemsWidth as getDockItemsWidth
+} from "./dockItems.ts";
+import { useWorkbenchHostDockPresence as useDockPresence } from "./useWorkbenchHostDockPresence.ts";
+import { useWorkbenchHostDockInteractions } from "./useWorkbenchHostDockInteractions.ts";
 import {
-  WorkbenchHostDockPopup,
-  workbenchHostDockPopupPreviewViewport,
+  isDockVisualMutationActive,
+  useWorkbenchHostDockViewport,
+  type WorkbenchHostDockScrollDirection
+} from "./useWorkbenchHostDockViewport.ts";
+import { useWorkbenchHostDockOverlays } from "./useWorkbenchHostDockOverlays.ts";
+import {
+  WorkbenchHostDockHoverPanel as DockHoverPanel,
+  WorkbenchHostDockLabelTooltip as DockLabelTooltip
+} from "./WorkbenchHostDockOverlayPresentation.tsx";
+import { dockActionKey as createDockActionKey } from "./dockActions.ts";
+import { WorkbenchHostDockEntrySlot } from "./WorkbenchHostDockEntrySlot.tsx";
+import { WorkbenchHostDockMinimizedSlot } from "./WorkbenchHostDockMinimizedSlot.tsx";
+import { WorkbenchHostDockPopups } from "./WorkbenchHostDockPopups.tsx";
+import { useWorkbenchHostDockEntryActivation } from "./useWorkbenchHostDockEntryActivation.ts";
+import { useWorkbenchHostDockActivity } from "./useWorkbenchHostDockActivity.ts";
+import {
   type WorkbenchHostDockPopupAnchorRect,
   type WorkbenchHostDockPopupState
 } from "./WorkbenchHostDockPopup.tsx";
-import type {
-  WorkbenchDockPreviewCache,
-  WorkbenchDockPreviewCacheKey
-} from "../react/dockPreviewCache.ts";
+import type { WorkbenchDockPreviewCache } from "../react/dockPreviewCache.ts";
 import type {
   WorkbenchDockPreviewContent,
   WorkbenchHostDockEntry,
@@ -83,62 +57,14 @@ import type {
   WorkbenchHostHandle,
   WorkbenchHostNodeDefinition,
   WorkbenchHostNodeData,
-  WorkbenchHostNodeInstanceStrategy,
   WorkbenchHostProps
 } from "./types.ts";
 import type { createWorkbenchHostI18nRuntime } from "./workbenchHostI18n.ts";
-
-type WorkbenchMinimizedDockNodeSlotRestoreIntent = Extract<
-  WorkbenchMinimizedDockRestoreIntent,
-  { kind: "node-slot" }
->;
-
-type WorkbenchMinimizedDockStackPopupCardRestoreIntent = Extract<
-  WorkbenchMinimizedDockRestoreIntent,
-  { kind: "stack-popup-card" }
->;
-
-type WorkbenchDockWallpaperTone = "dark" | "light";
 
 const minimizedDockPreviewViewport = {
   height: 34.2,
   width: 46.8
 };
-const dockPopupNewWindowLaunchSource = "dock-popup-new-window";
-
-function stripDockDescriptionTerminalPunctuation(value: string): string {
-  const trimmed = value.trim();
-  if (!trimmed || trimmed.endsWith("...") || trimmed.endsWith("…")) {
-    return trimmed;
-  }
-  return trimmed.replace(/[。．.]+$/u, "");
-}
-
-function activateDockButtonFromKeyboard(
-  event: ReactKeyboardEvent<HTMLElement>,
-  disabled = false
-) {
-  if (disabled || (event.key !== "Enter" && event.key !== " ")) {
-    return;
-  }
-
-  event.preventDefault();
-  event.currentTarget.click();
-}
-
-function isDockVisualMutationActive(element: HTMLElement | null): boolean {
-  if (!element) {
-    return false;
-  }
-
-  return (
-    element.hasAttribute("data-dock-pointer-active") ||
-    element.hasAttribute("data-dock-hover-panel-open") ||
-    element.querySelector(
-      '[data-collapsing="true"], [data-presence="entering"], [data-presence="exiting"], [data-stack-dispatching="true"], [data-promoted-from-stack="true"]'
-    ) !== null
-  );
-}
 
 export function WorkbenchHostDock({
   captureNodePreviewImage,
@@ -185,203 +111,15 @@ export function WorkbenchHostDock({
     () => new Set(context.minimizedNodes.map((node) => node.id)),
     [context.minimizedNodes]
   );
-  const dockPlateRef = useRef<HTMLDivElement | null>(null);
-  const dockMeasureRef = useRef<HTMLDivElement | null>(null);
-  const dockItemsRef = useRef<HTMLDivElement | null>(null);
-  const hoverPanelRef = useRef<HTMLDivElement | null>(null);
-  const hoverPanelCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null
-  );
-  const hoverPanelOpenTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null
-  );
-  const labelTooltipOpenTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null
-  );
-  const hoverPanelScheduledPointRef = useRef<{
-    clientX: number;
-    clientY: number;
-  } | null>(null);
-  const labelTooltipScheduledPointRef = useRef<{
-    clientX: number;
-    clientY: number;
-  } | null>(null);
-  const hoverPanelRestTargetRef = useRef<{
-    anchorKey: string;
-    entryId: string;
-  } | null>(null);
-  const activeHoverPanelRef = useRef<WorkbenchHostDockHoverPanelState | null>(
-    null
-  );
-  const activeLabelTooltipRef =
-    useRef<WorkbenchHostDockLabelTooltipState | null>(null);
   const pendingDockStateRefreshRef = useRef(false);
-  const slotRefs = useRef(new Map<string, HTMLElement>());
-  const wallpaperToneElementRefs = useRef(new Map<string, HTMLElement>());
-  const dockSlotRefCallbacksRef = useRef(
-    new Map<string, (element: HTMLElement | null) => void>()
-  );
-  const previousAttentionTokenByEntryId = useRef(new Map<string, unknown>());
-  const dockEntryClickThrottleUntilRef = useRef(new Map<string, number>());
-  const attentionTimeouts = useRef(
-    new Map<string, ReturnType<typeof setTimeout>>()
-  );
-  const [activeAttentionEntryIds, setActiveAttentionEntryIds] = useState<
-    Set<string>
-  >(new Set());
   const [activePopup, setActivePopup] =
     useState<WorkbenchHostDockPopupState | null>(null);
-  const [activeHoverPanel, setActiveHoverPanel] =
-    useState<WorkbenchHostDockHoverPanelState | null>(null);
-  const [activeLabelTooltip, setActiveLabelTooltip] =
-    useState<WorkbenchHostDockLabelTooltipState | null>(null);
   const [activeMinimizedStackPopup, setActiveMinimizedStackPopup] =
     useState<WorkbenchHostDockPopupAnchorRect | null>(null);
   const [pendingActionKeys, setPendingActionKeys] = useState<Set<string>>(
     () => new Set()
   );
-  const [dockFrameSize, setDockFrameSize] = useState<number | null>(null);
-  const { triggerDockBounce } = useDockBounce(slotRefs);
-  const [dockScrollState, setDockScrollState] =
-    useState<WorkbenchHostDockScrollState>(() => ({
-      canScrollBackward: false,
-      canScrollForward: false,
-      hasOverflow: false
-    }));
   const [dockStateRevision, setDockStateRevision] = useState(0);
-  const [externalStateRevision, setExternalStateRevision] = useState(0);
-  const [
-    collapsingMinimizedLaunchAnchorKeys,
-    setCollapsingMinimizedLaunchAnchorKeys
-  ] = useState<Set<string>>(() => new Set());
-  const collapsingMinimizedLaunchTimerRef = useRef(
-    new Map<string, ReturnType<typeof setTimeout>>()
-  );
-
-  const clearHoverPanelCloseTimer = useCallback(() => {
-    if (hoverPanelCloseTimerRef.current === null) {
-      return;
-    }
-    clearTimeout(hoverPanelCloseTimerRef.current);
-    hoverPanelCloseTimerRef.current = null;
-  }, []);
-
-  const clearHoverPanelOpenTimer = useCallback(() => {
-    if (hoverPanelOpenTimerRef.current === null) {
-      return;
-    }
-    clearTimeout(hoverPanelOpenTimerRef.current);
-    hoverPanelOpenTimerRef.current = null;
-    hoverPanelScheduledPointRef.current = null;
-  }, []);
-
-  const clearLabelTooltipOpenTimer = useCallback(() => {
-    if (labelTooltipOpenTimerRef.current === null) {
-      return;
-    }
-    clearTimeout(labelTooltipOpenTimerRef.current);
-    labelTooltipOpenTimerRef.current = null;
-    labelTooltipScheduledPointRef.current = null;
-  }, []);
-
-  useEffect(
-    () => () => {
-      clearHoverPanelCloseTimer();
-      clearHoverPanelOpenTimer();
-      clearLabelTooltipOpenTimer();
-      for (const timer of collapsingMinimizedLaunchTimerRef.current.values()) {
-        clearTimeout(timer);
-      }
-      collapsingMinimizedLaunchTimerRef.current.clear();
-    },
-    [
-      clearHoverPanelCloseTimer,
-      clearHoverPanelOpenTimer,
-      clearLabelTooltipOpenTimer
-    ]
-  );
-
-  const clearCollapsingMinimizedLaunch = useCallback((anchorKey: string) => {
-    const timer = collapsingMinimizedLaunchTimerRef.current.get(anchorKey);
-    if (timer) {
-      clearTimeout(timer);
-      collapsingMinimizedLaunchTimerRef.current.delete(anchorKey);
-    }
-    const slotElement = slotRefs.current.get(anchorKey);
-    slotElement?.removeAttribute("data-collapsing");
-    slotElement?.style.removeProperty("--desktop-dock-collapse-inline-size");
-    slotElement?.style.removeProperty("--desktop-dock-collapse-block-size");
-    setCollapsingMinimizedLaunchAnchorKeys((current) => {
-      if (!current.has(anchorKey)) {
-        return current;
-      }
-      const next = new Set(current);
-      next.delete(anchorKey);
-      return next;
-    });
-  }, []);
-
-  const scheduleCollapsingMinimizedLaunchClear = useCallback(
-    (anchorKey: string) => {
-      const existing = collapsingMinimizedLaunchTimerRef.current.get(anchorKey);
-      if (existing) {
-        clearTimeout(existing);
-      }
-      collapsingMinimizedLaunchTimerRef.current.set(
-        anchorKey,
-        setTimeout(() => {
-          clearCollapsingMinimizedLaunch(anchorKey);
-        }, minimizedDockSlotLayoutAnimationMs)
-      );
-    },
-    [clearCollapsingMinimizedLaunch]
-  );
-
-  useLayoutEffect(() => {
-    const element = dockMeasureRef.current;
-    if (!element || typeof window === "undefined") {
-      return undefined;
-    }
-
-    let frameId: number | null = null;
-    const updateDockFrameSize = () => {
-      frameId = null;
-      if (isDockVisualMutationActive(dockMeasureRef.current)) {
-        return;
-      }
-      const rect = element.getBoundingClientRect();
-      const nextSize = Math.ceil(
-        (dockPlacement === "left" ? rect.height : rect.width) +
-          desktopDockPlateChromeWidth
-      );
-      setDockFrameSize((current) =>
-        current === nextSize ? current : nextSize
-      );
-    };
-    const scheduleUpdate = () => {
-      if (frameId !== null) {
-        return;
-      }
-      frameId = window.requestAnimationFrame(updateDockFrameSize);
-    };
-
-    updateDockFrameSize();
-
-    const resizeObserver =
-      typeof ResizeObserver === "undefined"
-        ? null
-        : new ResizeObserver(scheduleUpdate);
-    resizeObserver?.observe(element);
-    window.addEventListener("resize", scheduleUpdate);
-
-    return () => {
-      if (frameId !== null) {
-        window.cancelAnimationFrame(frameId);
-      }
-      resizeObserver?.disconnect();
-      window.removeEventListener("resize", scheduleUpdate);
-    };
-  }, [dockPlacement]);
 
   const flushPendingDockStateRefresh = useCallback(() => {
     if (!pendingDockStateRefreshRef.current) {
@@ -433,763 +171,107 @@ export function WorkbenchHostDock({
     useMinimizedDockStackPromotion(minimizedDockSlots);
   const dockItems = useMemo(
     () =>
-      createWorkbenchHostDockItems({
+      createDockItems({
         minimizedDockSlots,
         resolvedEntries
       }),
     [minimizedDockSlots, resolvedEntries]
   );
-  const presentDockItems = useDockPresenceItems(dockItems, (nodeId) =>
+  const presentDockItems = useDockPresence(dockItems, (nodeId) =>
     context.genie.shouldAnimateMinimizedDockEnter(nodeId)
   );
   const presentDockItemKeys = useMemo(
     () => presentDockItems.map((item) => item.key).join("\n"),
     [presentDockItems]
   );
-  const wallpaperTones = useDockWallpaperTones({
-    dockItemsRef,
-    elementRefs: wallpaperToneElementRefs,
-    itemKeys: presentDockItemKeys
-  });
-  const dockWidth = useMemo(
-    () => resolveWorkbenchHostDockItemsWidth(dockItems),
-    [dockItems]
-  );
+  const dockWidth = useMemo(() => getDockItemsWidth(dockItems), [dockItems]);
   const {
     clearSlotMagnification,
+    dockFrameSize,
+    dockItemsRef,
+    dockMeasureRef,
+    dockPlateRef,
+    dockScrollState,
     handlePointerLeave: handleDockPointerLeave,
     handlePointerMove: handleDockPointerMove,
     pauseMagnification: pauseDockMagnification,
-    resetMagnification: resetDockMagnification
-  } = useDockMagnification({
-    dockPlateRef,
+    registerDockSlot,
+    registerWallpaperToneElement,
+    resetMagnification: resetDockMagnification,
+    scrollDockItems: scrollDockViewport,
+    slotRefs,
+    triggerDockBounce,
+    wallpaperTones
+  } = useWorkbenchHostDockViewport({
+    dockItemsCount: presentDockItems.length,
+    dockItemsKey: presentDockItemKeys,
     dockPlacement,
-    dockRootRef: dockMeasureRef,
-    dockViewportRef: dockItemsRef,
-    slotRefs
-  });
-  const clearSlotMagnificationRef = useRef<(anchorKey: string) => void>(() => {
-    return;
-  });
-  const registerDockAnchorRef = useRef(
-    (anchorKey: string, element: HTMLElement | null) => {
+    dockWidth,
+    registerDockAnchor: (anchorKey, element) => {
       context.genie.registerDockAnchor(anchorKey, element);
     }
-  );
-  clearSlotMagnificationRef.current = (anchorKey) => {
-    clearSlotMagnification(anchorKey);
-  };
-  registerDockAnchorRef.current = (anchorKey, element) => {
-    context.genie.registerDockAnchor(anchorKey, element);
-  };
-  const registerWallpaperToneElement = useCallback(
-    (key: string) => (element: HTMLElement | null) => {
-      if (element) {
-        wallpaperToneElementRefs.current.set(key, element);
-        return;
-      }
-      wallpaperToneElementRefs.current.delete(key);
-    },
-    []
-  );
+  });
 
-  const setDockHoverPanelOpen = useCallback((open: boolean) => {
-    if (open) {
-      dockMeasureRef.current?.setAttribute(
-        "data-dock-hover-panel-open",
-        "true"
-      );
-      return;
-    }
-    dockMeasureRef.current?.removeAttribute("data-dock-hover-panel-open");
-  }, []);
+  const {
+    activeHoverPanel,
+    activeLabelTooltip,
+    beginDockIconInteraction,
+    clearHoverPanelCloseTimer,
+    clearHoverPanelOpenTimer,
+    clearHoverPanelRestTarget,
+    clearHoverPanelRestTargetForAnchor,
+    clearLabelTooltipOpenTimer,
+    closeHoverPanelImmediate,
+    closeLabelTooltipImmediate,
+    dismissHoverPanelForPopup,
+    handleDockPointerTravel,
+    handleDockRootPointerLeave,
+    hoverPanelRef,
+    scheduleHoverPanelAfterRest,
+    scheduleHoverPanelAtPointAfterRest,
+    scheduleHoverPanelClose,
+    scheduleLabelTooltipAfterRest,
+    scheduleLabelTooltipAtPointAfterRest,
+    showHoverPanel,
+    showLabelTooltip
+  } = useWorkbenchHostDockOverlays({
+    dockMeasureRef,
+    flushPendingDockStateRefresh,
+    handleDockPointerLeave,
+    handleDockPointerMove,
+    pauseDockMagnification,
+    slotRefs,
+    triggerDockBounce
+  });
+  const {
+    beginDockMinimizedInteraction,
+    claimDockEntryClick,
+    clearCollapsingMinimizedLaunch,
+    collapsingMinimizedLaunchAnchorKeys,
+    isDockEntryClickThrottled,
+    runDockMinimizedLaunchAfterCollapse,
+    runDockMinimizedStackLaunch
+  } = useWorkbenchHostDockInteractions({
+    clearHoverPanelOpenTimer,
+    clearHoverPanelRestTarget,
+    clearLabelTooltipOpenTimer,
+    clearSlotMagnification,
+    closeHoverPanelImmediate,
+    closeLabelTooltipImmediate,
+    pauseDockMagnification,
+    slotRefs
+  });
 
-  useEffect(() => {
-    activeHoverPanelRef.current = activeHoverPanel;
-  }, [activeHoverPanel]);
-
-  useEffect(() => {
-    activeLabelTooltipRef.current = activeLabelTooltip;
-  }, [activeLabelTooltip]);
-
-  const closeLabelTooltipImmediate = useCallback(
-    (targetKey?: string) => {
-      clearLabelTooltipOpenTimer();
-      if (
-        targetKey !== undefined &&
-        activeLabelTooltipRef.current?.key !== targetKey
-      ) {
-        return;
-      }
-      if (activeLabelTooltipRef.current === null) {
-        return;
-      }
-      activeLabelTooltipRef.current = null;
-      setActiveLabelTooltip(null);
-    },
-    [clearLabelTooltipOpenTimer]
-  );
-
-  const closeHoverPanelImmediate = useCallback(
-    (entryId?: string) => {
-      clearHoverPanelOpenTimer();
-      clearHoverPanelCloseTimer();
-      if (
-        entryId !== undefined &&
-        activeHoverPanelRef.current?.entryId !== entryId
-      ) {
-        return;
-      }
-      if (activeHoverPanelRef.current === null) {
-        return;
-      }
-      hoverPanelRestTargetRef.current = null;
-      setDockHoverPanelOpen(false);
-      activeHoverPanelRef.current = null;
-      setActiveHoverPanel(null);
-      flushPendingDockStateRefresh();
-    },
-    [
-      clearHoverPanelCloseTimer,
-      clearHoverPanelOpenTimer,
-      flushPendingDockStateRefresh,
-      setDockHoverPanelOpen
-    ]
-  );
-
-  const scheduleHoverPanelClose = useCallback(
-    (entryId?: string) => {
-      clearHoverPanelOpenTimer();
-      clearHoverPanelCloseTimer();
-      hoverPanelCloseTimerRef.current = setTimeout(() => {
-        hoverPanelCloseTimerRef.current = null;
-        closeHoverPanelImmediate(entryId);
-        handleDockPointerLeave();
-      }, dockHoverPanelCloseDelayMs);
-    },
-    [
-      clearHoverPanelCloseTimer,
-      clearHoverPanelOpenTimer,
-      closeHoverPanelImmediate,
-      handleDockPointerLeave
-    ]
-  );
-
-  const showHoverPanel = useCallback(
-    (entryId: string, anchorKey: string, anchorElement: HTMLElement): void => {
-      const dockElement = dockMeasureRef.current;
-      if (!dockElement) {
-        return;
-      }
-
-      pauseDockMagnification();
-      const dockRect = dockElement.getBoundingClientRect();
-      const anchorRect = anchorElement.getBoundingClientRect();
-      clearHoverPanelCloseTimer();
-      const nextHoverPanel = {
-        anchorKey,
-        anchorRect: {
-          height: anchorRect.height,
-          left: anchorRect.left - dockRect.left,
-          top: anchorRect.top - dockRect.top,
-          width: anchorRect.width
-        },
-        entryId
-      };
-      setDockHoverPanelOpen(true);
-      activeHoverPanelRef.current = nextHoverPanel;
-      setActiveHoverPanel(nextHoverPanel);
-    },
-    [clearHoverPanelCloseTimer, pauseDockMagnification, setDockHoverPanelOpen]
-  );
-
-  const scheduleHoverPanelAfterRest = useCallback(
-    (entryId: string, anchorKey: string) => {
-      hoverPanelRestTargetRef.current = { anchorKey, entryId };
-      clearHoverPanelOpenTimer();
-      hoverPanelScheduledPointRef.current = null;
-      hoverPanelOpenTimerRef.current = setTimeout(() => {
-        hoverPanelOpenTimerRef.current = null;
-        hoverPanelScheduledPointRef.current = null;
-        const pending = hoverPanelRestTargetRef.current;
-        if (!pending || pending.entryId !== entryId) {
-          return;
-        }
-        const slotElement = slotRefs.current.get(anchorKey);
-        if (!slotElement) {
-          return;
-        }
-        showHoverPanel(entryId, anchorKey, slotElement);
-      }, dockHoverPanelOpenDelayMs);
-    },
-    [clearHoverPanelOpenTimer, showHoverPanel]
-  );
-
-  const showLabelTooltip = useCallback(
-    (
-      target: WorkbenchHostDockLabelTooltipTarget,
-      anchorKey: string,
-      anchorElement: HTMLElement
-    ): void => {
-      const dockElement = dockMeasureRef.current;
-      if (!dockElement) {
-        return;
-      }
-
-      const dockRect = dockElement.getBoundingClientRect();
-      const anchorRect = resolveDockLabelTooltipAnchorRect(anchorElement);
-      clearLabelTooltipOpenTimer();
-      const nextTooltip = {
-        anchorKey,
-        anchorRect: {
-          height: anchorRect.height,
-          left: anchorRect.left - dockRect.left,
-          top: anchorRect.top - dockRect.top,
-          width: anchorRect.width
-        },
-        key: target.key,
-        label: target.label
-      };
-      activeLabelTooltipRef.current = nextTooltip;
-      setActiveLabelTooltip(nextTooltip);
-    },
-    [clearLabelTooltipOpenTimer]
-  );
-
-  const scheduleLabelTooltipAfterRest = useCallback(
-    (target: WorkbenchHostDockLabelTooltipTarget, anchorKey: string) => {
-      clearLabelTooltipOpenTimer();
-      labelTooltipScheduledPointRef.current = null;
-      labelTooltipOpenTimerRef.current = setTimeout(() => {
-        labelTooltipOpenTimerRef.current = null;
-        labelTooltipScheduledPointRef.current = null;
-        const slotElement = slotRefs.current.get(anchorKey);
-        if (!slotElement) {
-          return;
-        }
-        showLabelTooltip(target, anchorKey, slotElement);
-      }, dockHoverPanelOpenDelayMs);
-    },
-    [clearLabelTooltipOpenTimer, showLabelTooltip]
-  );
-
-  const resolveHoverPanelTargetAtPoint = useCallback(
-    (
-      clientX: number,
-      clientY: number
-    ): {
-      anchorKey: string;
-      entryId: string;
-      slotElement: HTMLElement;
-    } | null => {
-      for (const [anchorKey, slotElement] of slotRefs.current) {
-        const entryId = slotElement.dataset.dockHoverPanelEntryId;
-        if (!entryId) {
-          continue;
-        }
-
-        const rect = slotElement.getBoundingClientRect();
-        if (
-          clientX >= rect.left - dockHoverPanelHitSlopPx &&
-          clientX <= rect.right + dockHoverPanelHitSlopPx &&
-          clientY >= rect.top - dockHoverPanelHitSlopPx &&
-          clientY <= rect.bottom + dockHoverPanelHitSlopPx
-        ) {
-          return { anchorKey, entryId, slotElement };
-        }
-      }
-      return null;
-    },
-    []
-  );
-
-  const resolveLabelTooltipTargetAtPoint = useCallback(
-    (
-      clientX: number,
-      clientY: number
-    ): {
-      anchorKey: string;
-      slotElement: HTMLElement;
-      target: WorkbenchHostDockLabelTooltipTarget;
-    } | null => {
-      for (const [anchorKey, slotElement] of slotRefs.current) {
-        if (slotElement.dataset.dockHoverPanelEntryId) {
-          continue;
-        }
-        const key = slotElement.dataset.dockLabelTooltipKey;
-        const label = slotElement.dataset.dockLabelTooltipLabel?.trim() ?? "";
-        if (!key || !label) {
-          continue;
-        }
-
-        const rect = slotElement.getBoundingClientRect();
-        if (
-          clientX >= rect.left - dockHoverPanelHitSlopPx &&
-          clientX <= rect.right + dockHoverPanelHitSlopPx &&
-          clientY >= rect.top - dockHoverPanelHitSlopPx &&
-          clientY <= rect.bottom + dockHoverPanelHitSlopPx
-        ) {
-          return {
-            anchorKey,
-            slotElement,
-            target: {
-              key,
-              label
-            }
-          };
-        }
-      }
-      return null;
-    },
-    []
-  );
-
-  const isPointerInsideActiveHoverPanelRegion = useCallback(
-    (clientX: number, clientY: number): boolean => {
-      const activeHoverPanel = activeHoverPanelRef.current;
-      if (!activeHoverPanel) {
-        return false;
-      }
-
-      const anchorSlot = slotRefs.current.get(activeHoverPanel.anchorKey);
-      const panel = hoverPanelRef.current;
-      if (
-        !anchorSlot ||
-        !panel ||
-        !anchorSlot.isConnected ||
-        !panel.isConnected
-      ) {
-        return false;
-      }
-
-      const anchorRect = anchorSlot.getBoundingClientRect();
-      const panelRect = panel.getBoundingClientRect();
-      return (
-        rectContainsPoint(
-          anchorRect,
-          clientX,
-          clientY,
-          dockHoverPanelHitSlopPx
-        ) ||
-        rectContainsPoint(
-          panelRect,
-          clientX,
-          clientY,
-          dockHoverPanelHitSlopPx
-        ) ||
-        rectContainsPoint(
-          createHoverPanelBridgeRect(anchorRect, panelRect),
-          clientX,
-          clientY,
-          dockHoverPanelBridgeSlopPx
-        )
-      );
-    },
-    []
-  );
-
-  const scheduleHoverPanelAtPointAfterRest = useCallback(
-    (clientX: number, clientY: number) => {
-      const scheduledPoint = hoverPanelScheduledPointRef.current;
-      if (
-        hoverPanelOpenTimerRef.current !== null &&
-        scheduledPoint &&
-        Math.abs(clientX - scheduledPoint.clientX) <=
-          dockHoverPanelPointerRestTolerancePx &&
-        Math.abs(clientY - scheduledPoint.clientY) <=
-          dockHoverPanelPointerRestTolerancePx
-      ) {
-        return;
-      }
-
-      clearHoverPanelOpenTimer();
-      hoverPanelScheduledPointRef.current = { clientX, clientY };
-      hoverPanelOpenTimerRef.current = setTimeout(() => {
-        hoverPanelOpenTimerRef.current = null;
-        hoverPanelScheduledPointRef.current = null;
-        if (activeHoverPanelRef.current !== null) {
-          return;
-        }
-        const target = resolveHoverPanelTargetAtPoint(clientX, clientY);
-        if (!target) {
-          hoverPanelRestTargetRef.current = null;
-          return;
-        }
-        hoverPanelRestTargetRef.current = {
-          anchorKey: target.anchorKey,
-          entryId: target.entryId
-        };
-        showHoverPanel(target.entryId, target.anchorKey, target.slotElement);
-      }, dockHoverPanelOpenDelayMs);
-    },
-    [clearHoverPanelOpenTimer, resolveHoverPanelTargetAtPoint, showHoverPanel]
-  );
-
-  const scheduleLabelTooltipAtPointAfterRest = useCallback(
-    (clientX: number, clientY: number) => {
-      if (activeLabelTooltipRef.current !== null) {
-        return;
-      }
-
-      const scheduledPoint = labelTooltipScheduledPointRef.current;
-      if (
-        labelTooltipOpenTimerRef.current !== null &&
-        scheduledPoint &&
-        Math.abs(clientX - scheduledPoint.clientX) <=
-          dockHoverPanelPointerRestTolerancePx &&
-        Math.abs(clientY - scheduledPoint.clientY) <=
-          dockHoverPanelPointerRestTolerancePx
-      ) {
-        return;
-      }
-
-      clearLabelTooltipOpenTimer();
-      labelTooltipScheduledPointRef.current = { clientX, clientY };
-      labelTooltipOpenTimerRef.current = setTimeout(() => {
-        labelTooltipOpenTimerRef.current = null;
-        labelTooltipScheduledPointRef.current = null;
-        if (activeHoverPanelRef.current !== null) {
-          return;
-        }
-        const target = resolveLabelTooltipTargetAtPoint(clientX, clientY);
-        if (!target) {
-          return;
-        }
-        showLabelTooltip(target.target, target.anchorKey, target.slotElement);
-      }, dockHoverPanelOpenDelayMs);
-    },
-    [
-      clearLabelTooltipOpenTimer,
-      resolveLabelTooltipTargetAtPoint,
-      showLabelTooltip
-    ]
-  );
-
-  const beginDockIconInteraction = useCallback(
-    (anchorKey: string) => {
-      hoverPanelRestTargetRef.current = null;
-      clearHoverPanelOpenTimer();
-      closeLabelTooltipImmediate();
-      closeHoverPanelImmediate();
-      triggerDockBounce(anchorKey);
-    },
-    [
-      clearHoverPanelOpenTimer,
-      closeHoverPanelImmediate,
-      closeLabelTooltipImmediate,
-      triggerDockBounce
-    ]
-  );
-
-  const isDockEntryClickThrottled = useCallback(
-    (anchorKey: string): boolean => {
-      const throttledUntil =
-        dockEntryClickThrottleUntilRef.current.get(anchorKey);
-      return throttledUntil !== undefined && Date.now() < throttledUntil;
-    },
-    []
-  );
-
-  const claimDockEntryClick = useCallback((anchorKey: string): void => {
-    dockEntryClickThrottleUntilRef.current.set(
-      anchorKey,
-      Date.now() + DOCK_ENTRY_CLICK_THROTTLE_MS
-    );
-  }, []);
-
-  const beginDockMinimizedInteraction = useCallback(
-    (anchorKey?: string): boolean => {
-      hoverPanelRestTargetRef.current = null;
-      clearHoverPanelOpenTimer();
-      clearLabelTooltipOpenTimer();
-      closeLabelTooltipImmediate();
-      closeHoverPanelImmediate();
-      pauseDockMagnification();
-
-      if (!anchorKey) {
-        return false;
-      }
-      const slotElement = slotRefs.current.get(anchorKey);
-      if (!slotElement) {
-        return false;
-      }
-      clearSlotMagnification(anchorKey);
-      if (slotElement.dataset.collapsing === "true") {
-        return true;
-      }
-      const rect = slotElement.getBoundingClientRect();
-      slotElement.style.setProperty(
-        "--desktop-dock-collapse-inline-size",
-        `${rect.width}px`
-      );
-      slotElement.style.setProperty(
-        "--desktop-dock-collapse-block-size",
-        `${rect.height}px`
-      );
-      slotElement.dataset.collapsing = "true";
-      return true;
-    },
-    [
-      clearHoverPanelOpenTimer,
-      clearLabelTooltipOpenTimer,
-      clearSlotMagnification,
-      closeHoverPanelImmediate,
-      closeLabelTooltipImmediate,
-      pauseDockMagnification
-    ]
-  );
-
-  const runDockMinimizedLaunchAfterCollapse = useCallback(
-    (
-      intent: WorkbenchMinimizedDockNodeSlotRestoreIntent,
-      launch: (intent: WorkbenchMinimizedDockNodeSlotRestoreIntent) => void
-    ) => {
-      const { anchorKey } = intent;
-      beginDockMinimizedInteraction(anchorKey);
-      setCollapsingMinimizedLaunchAnchorKeys((current) => {
-        const next = new Set(current);
-        next.add(anchorKey);
-        return next;
-      });
-      scheduleCollapsingMinimizedLaunchClear(anchorKey);
-      launch(intent);
-    },
-    [beginDockMinimizedInteraction, scheduleCollapsingMinimizedLaunchClear]
-  );
-
-  const runDockMinimizedStackLaunch = useCallback(
-    (
-      intent: WorkbenchMinimizedDockStackPopupCardRestoreIntent,
-      launch: (
-        intent: WorkbenchMinimizedDockStackPopupCardRestoreIntent
-      ) => void
-    ) => {
-      beginDockMinimizedInteraction();
-      launch(intent);
-    },
-    [beginDockMinimizedInteraction]
-  );
-
-  const handleDockPointerTravel = useCallback(
-    (clientX: number, clientY: number) => {
-      if (activeHoverPanelRef.current !== null) {
-        closeLabelTooltipImmediate();
-        if (isPointerInsideActiveHoverPanelRegion(clientX, clientY)) {
-          clearHoverPanelCloseTimer();
-          return;
-        }
-        scheduleHoverPanelClose(activeHoverPanelRef.current.entryId);
-        handleDockPointerLeave();
-        return;
-      }
-
-      const activeLabelTooltip = activeLabelTooltipRef.current;
-      if (activeLabelTooltip) {
-        const target = resolveLabelTooltipTargetAtPoint(clientX, clientY);
-        if (target?.target.key !== activeLabelTooltip.key) {
-          closeLabelTooltipImmediate(activeLabelTooltip.key);
-        }
-      }
-
-      handleDockPointerMove(clientX, clientY);
-      scheduleHoverPanelAtPointAfterRest(clientX, clientY);
-      scheduleLabelTooltipAtPointAfterRest(clientX, clientY);
-    },
-    [
-      clearHoverPanelCloseTimer,
-      closeLabelTooltipImmediate,
-      handleDockPointerMove,
-      handleDockPointerLeave,
-      isPointerInsideActiveHoverPanelRegion,
-      resolveLabelTooltipTargetAtPoint,
-      scheduleHoverPanelClose,
-      scheduleHoverPanelAtPointAfterRest,
-      scheduleLabelTooltipAtPointAfterRest
-    ]
-  );
-
-  const updateDockScrollState = useCallback(() => {
-    const scrollElement = dockItemsRef.current;
-    const viewportElement = dockMeasureRef.current;
-    if (!scrollElement || !viewportElement) {
-      setDockScrollState((current) =>
-        current.hasOverflow ||
-        current.canScrollBackward ||
-        current.canScrollForward
-          ? {
-              canScrollBackward: false,
-              canScrollForward: false,
-              hasOverflow: false
-            }
-          : current
-      );
-      return;
-    }
-
-    const isVertical = dockPlacement === "left";
-    const viewportSize = isVertical
-      ? viewportElement.clientHeight
-      : viewportElement.clientWidth;
-    const scrollSize = isVertical
-      ? scrollElement.scrollHeight
-      : scrollElement.scrollWidth;
-    const scrollOffset = isVertical
-      ? scrollElement.scrollTop
-      : scrollElement.scrollLeft;
-    const nextState = resolveWorkbenchHostDockScrollState({
-      contentSize: dockWidth,
-      scrollOffset,
-      scrollSize,
-      viewportSize
+  const { activeAttentionEntryIds, externalStateRevision } =
+    useWorkbenchHostDockActivity({
+      activePopup: activePopup !== null,
+      context,
+      externalStateSource,
+      minimizedDockSlots,
+      nodeDefinitions,
+      renderedDockEntries,
+      workspaceId
     });
-
-    setDockScrollState((current) =>
-      current.canScrollBackward === nextState.canScrollBackward &&
-      current.canScrollForward === nextState.canScrollForward &&
-      current.hasOverflow === nextState.hasOverflow
-        ? current
-        : nextState
-    );
-  }, [dockPlacement, dockWidth]);
-
-  useLayoutEffect(() => {
-    const element = dockItemsRef.current;
-    if (!element || typeof window === "undefined") {
-      return undefined;
-    }
-
-    let frameId: number | null = null;
-    const scheduleUpdate = () => {
-      if (isDockVisualMutationActive(dockMeasureRef.current)) {
-        return;
-      }
-      if (frameId !== null) {
-        return;
-      }
-      frameId = window.requestAnimationFrame(() => {
-        frameId = null;
-        updateDockScrollState();
-      });
-    };
-
-    updateDockScrollState();
-
-    const resizeObserver =
-      typeof ResizeObserver === "undefined"
-        ? null
-        : new ResizeObserver(scheduleUpdate);
-    resizeObserver?.observe(element);
-    window.addEventListener("resize", scheduleUpdate);
-    element.addEventListener("scroll", scheduleUpdate, { passive: true });
-
-    return () => {
-      if (frameId !== null) {
-        window.cancelAnimationFrame(frameId);
-      }
-      resizeObserver?.disconnect();
-      window.removeEventListener("resize", scheduleUpdate);
-      element.removeEventListener("scroll", scheduleUpdate);
-    };
-  }, [dockPlacement, presentDockItems.length, updateDockScrollState]);
-
-  const hasMinimizedPreviewCapture = minimizedDockSlots.some((slot) =>
-    minimizedDockSlotNodes(slot).some((node) =>
-      (() => {
-        if (context.genie.isPendingMinimizedDockNode(node.id)) {
-          return false;
-        }
-        const minimizedDock = nodeDefinitions.get(node.data.typeId)?.window
-          ?.minimizedDock;
-        return (
-          minimizedDock?.kind === "snapshot" &&
-          Boolean(minimizedDock.capturePreview)
-        );
-      })()
-    )
-  );
-
-  useEffect(() => {
-    const shouldSubscribe = activePopup !== null || hasMinimizedPreviewCapture;
-    if (!shouldSubscribe || !externalStateSource?.subscribeNodeState) {
-      return undefined;
-    }
-    const nodes = activePopup ? context.nodes : context.minimizedNodes;
-    const disposers = nodes.map((node) =>
-      externalStateSource.subscribeNodeState?.(
-        createWorkbenchHostExternalStateLookupInput({ node, workspaceId }),
-        () => setExternalStateRevision((revision) => revision + 1)
-      )
-    );
-    return () => {
-      for (const dispose of disposers) {
-        dispose?.();
-      }
-    };
-  }, [
-    activePopup,
-    context.minimizedNodes,
-    context.nodes,
-    externalStateSource,
-    hasMinimizedPreviewCapture,
-    workspaceId
-  ]);
-
-  useEffect(() => {
-    const nextAttentionIds = new Set<string>();
-
-    for (const entry of renderedDockEntries) {
-      const nextToken = entry.attentionToken ?? null;
-      const previousToken =
-        previousAttentionTokenByEntryId.current.get(entry.id) ?? null;
-      if (nextToken !== null && nextToken !== previousToken) {
-        nextAttentionIds.add(entry.id);
-      }
-      previousAttentionTokenByEntryId.current.set(entry.id, nextToken);
-    }
-
-    if (nextAttentionIds.size === 0) {
-      return;
-    }
-
-    setActiveAttentionEntryIds((current) => {
-      const next = new Set(current);
-      for (const entryId of nextAttentionIds) {
-        next.add(entryId);
-      }
-      return next;
-    });
-
-    for (const entryId of nextAttentionIds) {
-      const existingTimeout = attentionTimeouts.current.get(entryId);
-      if (existingTimeout) {
-        globalThis.clearTimeout(existingTimeout);
-      }
-      attentionTimeouts.current.set(
-        entryId,
-        globalThis.setTimeout(() => {
-          attentionTimeouts.current.delete(entryId);
-          setActiveAttentionEntryIds((current) => {
-            if (!current.has(entryId)) {
-              return current;
-            }
-            const next = new Set(current);
-            next.delete(entryId);
-            return next;
-          });
-        }, 900)
-      );
-    }
-  }, [renderedDockEntries]);
-
-  useEffect(
-    () => () => {
-      for (const timeout of attentionTimeouts.current.values()) {
-        globalThis.clearTimeout(timeout);
-      }
-      attentionTimeouts.current.clear();
-    },
-    []
-  );
 
   const captureMinimizedNodePreview = useCallback(
     async (node: WorkbenchMinimizedDockNode) => {
@@ -1277,66 +359,35 @@ export function WorkbenchHostDock({
     clearHoverPanelCloseTimer();
     clearHoverPanelOpenTimer();
     clearLabelTooltipOpenTimer();
-    hoverPanelRestTargetRef.current = null;
-    setDockHoverPanelOpen(false);
+    clearHoverPanelRestTarget();
+    dismissHoverPanelForPopup();
     setActivePopup(null);
-    setActiveHoverPanel(null);
     closeLabelTooltipImmediate();
     setActiveMinimizedStackPopup(null);
   };
+  const { activateDockEntry, openDockEntryContextMenu } =
+    useWorkbenchHostDockEntryActivation({
+      closePopup,
+      context,
+      debugDiagnostics,
+      host,
+      onDockEntryAction,
+      onDockEntryClick,
+      setActivePopup,
+      workspaceId
+    });
 
   const scrollDockItems = (direction: WorkbenchHostDockScrollDirection) => {
-    const element = dockItemsRef.current;
-    if (!element) {
-      return;
-    }
-
     resetDockMagnification();
     closeHoverPanelImmediate();
     closeLabelTooltipImmediate();
-    hoverPanelRestTargetRef.current = null;
-
-    const isVertical = dockPlacement === "left";
-    const viewportSize = isVertical
-      ? element.clientHeight
-      : element.clientWidth;
-    const delta =
-      Math.max(DOCK_ICON_PEAK_SIZE * 2, viewportSize * 0.72) *
-      (direction === "forward" ? 1 : -1);
-
-    element.scrollBy({
-      behavior: "smooth",
-      left: isVertical ? 0 : delta,
-      top: isVertical ? delta : 0
-    });
+    clearHoverPanelRestTarget();
+    scrollDockViewport(direction);
   };
-
-  const registerDockSlot = useCallback((anchorKey: string) => {
-    const existing = dockSlotRefCallbacksRef.current.get(anchorKey);
-    if (existing) {
-      return existing;
-    }
-
-    const callback = (element: HTMLElement | null) => {
-      if (element) {
-        slotRefs.current.set(anchorKey, element);
-        wallpaperToneElementRefs.current.set(anchorKey, element);
-      } else {
-        slotRefs.current.delete(anchorKey);
-        wallpaperToneElementRefs.current.delete(anchorKey);
-        if (!dockMeasureRef.current?.hasAttribute("data-dock-pointer-active")) {
-          clearSlotMagnificationRef.current(anchorKey);
-        }
-      }
-      registerDockAnchorRef.current(anchorKey, element);
-    };
-    dockSlotRefCallbacksRef.current.set(anchorKey, callback);
-    return callback;
-  }, []);
 
   const runDockEntryAction = useCallback(
     (entryId: string, actionId: string) => {
-      const actionKey = dockActionKey(entryId, actionId);
+      const actionKey = createDockActionKey(entryId, actionId);
       if (pendingActionKeys.has(actionKey)) {
         return;
       }
@@ -1369,52 +420,54 @@ export function WorkbenchHostDock({
     [host, onDockEntryAction, pendingActionKeys]
   );
 
+  const handleMinimizedNodePointerDown = (
+    nodeId: string,
+    anchorKey: string
+  ) => {
+    const restoreIntent = resolveWorkbenchMinimizedDockRestoreIntent({
+      nodeId,
+      slots: minimizedDockSlots,
+      source: { anchorKey, kind: "node-slot" }
+    });
+    if (restoreIntent?.kind !== "node-slot") {
+      clearCollapsingMinimizedLaunch(anchorKey);
+      return;
+    }
+    beginDockMinimizedInteraction();
+  };
+
+  const handleMinimizedNodeActivate = (nodeId: string, anchorKey: string) => {
+    const restoreIntent = resolveWorkbenchMinimizedDockRestoreIntent({
+      nodeId,
+      slots: minimizedDockSlots,
+      source: { anchorKey, kind: "node-slot" }
+    });
+    if (restoreIntent?.kind !== "node-slot") {
+      clearCollapsingMinimizedLaunch(anchorKey);
+      return;
+    }
+    closePopup();
+    runDockMinimizedLaunchAfterCollapse(restoreIntent, (intent) => {
+      context.genie.launchNodeFromAnchor(
+        intent.anchorKey,
+        intent.nodeId,
+        () => {
+          host.focusNode(intent.nodeId);
+        }
+      );
+    });
+  };
+
+  const toggleMinimizedStackPopup = (
+    anchorRect: WorkbenchHostDockPopupAnchorRect
+  ) => {
+    setActivePopup(null);
+    setActiveMinimizedStackPopup((current) => (current ? null : anchorRect));
+  };
+
   if (dockItems.length === 0 && presentDockItems.length === 0) {
     return null;
   }
-
-  const popupEntry =
-    activePopup === null
-      ? null
-      : (resolvedEntries.find(
-          (entry) => entry.entry.id === activePopup.entryId
-        ) ?? null);
-  const activeMinimizedStackSlot =
-    activeMinimizedStackPopup === null
-      ? null
-      : (minimizedDockSlots.find(
-          (
-            slot
-          ): slot is Extract<WorkbenchMinimizedDockSlot, { kind: "stack" }> =>
-            slot.kind === "stack"
-        ) ?? null);
-  const openDockContextMenuNodeIds =
-    popupEntry?.matchedNodes.map((node) => node.id) ?? [];
-  const dockContextMenuInstanceMode =
-    popupEntry === null
-      ? undefined
-      : resolveDockEntryInstanceMode(popupEntry.entry, nodeDefinitions);
-  const canShowAllWindowsFromDockContextMenu =
-    onMissionControlRequestOpen !== undefined &&
-    dockContextMenuInstanceMode === "multi" &&
-    openDockContextMenuNodeIds.length > 1;
-  const fullscreenNodeFromDockContextMenu =
-    popupEntry === null
-      ? null
-      : resolveDockContextMenuFullscreenNode({
-          focusedNodeId: context.focusedNodeId,
-          minimizedNodeIDs,
-          nodeDefinitions,
-          nodes: popupEntry.matchedNodes
-        });
-  const canOpenFromDockContextMenu =
-    popupEntry !== null &&
-    popupEntry.matchedNodes.length === 0 &&
-    resolveWorkbenchDockEntryClick({
-      entry: popupEntry.entry,
-      instanceMode: dockContextMenuInstanceMode,
-      matchedNodes: popupEntry.matchedNodes
-    }).kind === "launch";
 
   return (
     <div
@@ -1448,15 +501,7 @@ export function WorkbenchHostDock({
           data-scroll-forward={
             dockScrollState.canScrollForward ? "true" : undefined
           }
-          onPointerLeave={() => {
-            hoverPanelRestTargetRef.current = null;
-            clearHoverPanelOpenTimer();
-            clearLabelTooltipOpenTimer();
-            closeLabelTooltipImmediate();
-            closeHoverPanelImmediate();
-            handleDockPointerLeave();
-            flushPendingDockStateRefresh();
-          }}
+          onPointerLeave={handleDockRootPointerLeave}
           onPointerMoveCapture={(event) => {
             handleDockPointerTravel(event.clientX, event.clientY);
           }}
@@ -1505,636 +550,86 @@ export function WorkbenchHostDock({
 
               if (dockItem.item.kind === "entry") {
                 const resolvedEntry = dockItem.item.resolvedEntry;
-                const { anchorKey, entry } = resolvedEntry;
                 const currentPopup =
-                  activePopup?.entryId === entry.id ? activePopup : null;
-                const instanceMode = resolveDockEntryInstanceMode(
-                  entry,
-                  nodeDefinitions
-                );
-                const clickResolution = resolveWorkbenchDockEntryClick({
-                  entry,
-                  instanceMode,
-                  matchedNodes: resolvedEntry.matchedNodes
-                });
-                const hasHoverPanel = dockEntryHasHoverPanel(entry);
-                const labelTooltipTarget = hasHoverPanel
-                  ? null
-                  : dockLabelTooltipTarget(`entry:${entry.id}`, entry.label);
-                const dockButton = (
-                  <button
-                    aria-expanded={currentPopup ? true : undefined}
-                    aria-haspopup={
-                      clickResolution.kind === "open-popup"
-                        ? "dialog"
-                        : undefined
-                    }
-                    aria-label={i18n.t("launch", { title: entry.label })}
-                    aria-disabled={
-                      clickResolution.kind === "blocked" ? true : undefined
-                    }
-                    className="desktop-dock__btn"
-                    data-interactive={
-                      clickResolution.kind === "blocked" ? "false" : "true"
-                    }
-                    data-dock-hover-panel-trigger={
-                      hasHoverPanel ? "true" : undefined
-                    }
-                    type="button"
-                    onPointerDown={(event) => {
-                      if (event.button !== 0) {
-                        return;
-                      }
-                      if (clickResolution.kind === "blocked") {
-                        return;
-                      }
-                      if (isDockEntryClickThrottled(anchorKey)) {
-                        return;
-                      }
-                      beginDockIconInteraction(anchorKey);
-                    }}
-                    onClick={(event) => {
-                      if (clickResolution.kind === "blocked") {
-                        return;
-                      }
-                      if (isDockEntryClickThrottled(anchorKey)) {
-                        return;
-                      }
-                      claimDockEntryClick(anchorKey);
-                      logWorkbenchDockDebug("dock.click", debugDiagnostics, {
-                        anchorKey,
-                        clickResolution,
-                        dockDiagnostics: entry.diagnostics ?? null,
-                        dockNodeState: resolvedEntry.dockNodeState,
-                        entryId: entry.id,
-                        entryLaunchBehavior: entry.launchBehavior ?? "enabled",
-                        entryOrder: entry.order ?? null,
-                        entryState: entry.state ?? { kind: "enabled" },
-                        entryVisibility: entry.visibility ?? "always",
-                        hoverActions:
-                          entry.hoverActions?.map((action) => ({
-                            disabled: action.disabled === true,
-                            id: action.id,
-                            pending: Boolean(action.pendingLabel)
-                          })) ?? [],
-                        instanceMode: instanceMode ?? null,
-                        matchedNodeCount: resolvedEntry.matchedNodes.length,
-                        matchedNodeIds: resolvedEntry.matchedNodes.map(
-                          (node) => node.id
-                        ),
-                        typeId: entry.typeId,
-                        workspaceId
-                      });
-                      switch (clickResolution.kind) {
-                        case "focus-node":
-                          closePopup();
-                          void (async () => {
-                            try {
-                              await onDockEntryClick?.({
-                                entryId: entry.id,
-                                host,
-                                nodeId: clickResolution.nodeId
-                              });
-                            } catch {
-                              // Keep dock click failures contained.
-                            }
-                          })();
-                          context.genie.launchNodeFromAnchor(
-                            anchorKey,
-                            clickResolution.nodeId,
-                            () => {
-                              host.focusNode(clickResolution.nodeId);
-                            }
-                          );
-                          return;
-                        case "open-popup": {
-                          const rect =
-                            event.currentTarget.getBoundingClientRect();
-                          logWorkbenchDockDebug(
-                            "dock.popup.toggle",
-                            debugDiagnostics,
-                            {
-                              anchorKey,
-                              entryId: entry.id,
-                              matchedNodeCount:
-                                resolvedEntry.matchedNodes.length,
-                              nextOpen: currentPopup === null,
-                              typeId: entry.typeId,
-                              workspaceId
-                            }
-                          );
-                          setActivePopup((current) =>
-                            current?.entryId === entry.id
-                              ? null
-                              : {
-                                  anchorRect: {
-                                    height: rect.height,
-                                    left: rect.left,
-                                    top: rect.top,
-                                    width: rect.width
-                                  },
-                                  kind: "preview",
-                                  entryId: entry.id
-                                }
-                          );
-                          return;
-                        }
-                        case "action":
-                          closePopup();
-                          void (async () => {
-                            try {
-                              await onDockEntryAction?.({
-                                actionId: clickResolution.actionId,
-                                entryId: entry.id,
-                                host
-                              });
-                            } catch {
-                              // Keep dock action failures contained.
-                            }
-                          })();
-                          return;
-                        case "launch":
-                          closePopup();
-                          context.genie.launchNodeFromAnchor(
-                            anchorKey,
-                            entry.id,
-                            () =>
-                              host.launchNode({
-                                dockEntryId: entry.id,
-                                payload: entry.launchPayload,
-                                reason: "dock",
-                                typeId: entry.typeId
-                              })
-                          );
-                          return;
-                      }
-                    }}
-                    onContextMenu={(event) => {
-                      if (
-                        clickResolution.kind === "blocked" ||
-                        !dockEntryHasContextMenu(entry, resolvedEntry)
-                      ) {
-                        return;
-                      }
-                      event.preventDefault();
-                      const rect = event.currentTarget.getBoundingClientRect();
-                      logWorkbenchDockDebug(
-                        "dock.popup.context_menu",
-                        debugDiagnostics,
-                        {
-                          anchorKey,
-                          entryId: entry.id,
-                          matchedNodeCount: resolvedEntry.matchedNodes.length,
-                          typeId: entry.typeId,
-                          workspaceId
-                        }
-                      );
-                      setActivePopup({
-                        anchorRect: {
-                          height: rect.height,
-                          left: rect.left,
-                          top: rect.top,
-                          width: rect.width
-                        },
-                        kind: "context-menu",
-                        entryId: entry.id
-                      });
-                    }}
-                  >
-                    <span
-                      className="desktop-dock__icon-shell"
-                      data-desktop-dock-icon-shell="true"
-                      data-entry-state={entry.state?.kind ?? "enabled"}
-                      aria-hidden
-                    >
-                      <span className="desktop-dock__icon-content">
-                        {entry.icon}
-                      </span>
-                      {renderDockBadge(
-                        entry,
-                        resolvedEntry.matchedNodes.length
-                      )}
-                    </span>
-                  </button>
-                );
-
+                  activePopup?.entryId === resolvedEntry.entry.id
+                    ? activePopup
+                    : null;
                 return (
-                  <span
+                  <WorkbenchHostDockEntrySlot
                     key={dockItem.key}
-                    ref={registerDockSlot(anchorKey)}
-                    className="desktop-dock__slot"
-                    data-attention-active={
-                      activeAttentionEntryIds.has(entry.id) ? "true" : undefined
-                    }
-                    data-desktop-dock-anchor-key={anchorKey}
-                    data-desktop-dock-slot="true"
-                    data-entry-state={entry.state?.kind ?? "enabled"}
-                    data-dock-hover-panel-entry-id={
-                      hasHoverPanel ? entry.id : undefined
-                    }
-                    data-dock-label-tooltip-key={labelTooltipTarget?.key}
-                    data-dock-label-tooltip-label={labelTooltipTarget?.label}
-                    data-icon-size={entry.iconSize ?? "default"}
-                    data-node-state={resolvedEntry.dockNodeState}
-                    data-popup-active={currentPopup ? "true" : undefined}
-                    data-presence={dockItem.presence}
-                    data-section-id={entry.sectionId}
-                    data-wallpaper-tone={wallpaperTones.get(anchorKey)}
-                    onBlur={(event) => {
-                      if (
-                        hasHoverPanel &&
-                        !event.currentTarget.contains(event.relatedTarget)
-                      ) {
-                        closeHoverPanelImmediate(entry.id);
-                      }
-                      if (
-                        labelTooltipTarget &&
-                        !event.currentTarget.contains(event.relatedTarget)
-                      ) {
-                        closeLabelTooltipImmediate(labelTooltipTarget.key);
-                      }
+                    activeAttention={activeAttentionEntryIds.has(
+                      resolvedEntry.entry.id
+                    )}
+                    beginDockIconInteraction={beginDockIconInteraction}
+                    claimDockEntryClick={claimDockEntryClick}
+                    currentPopup={currentPopup}
+                    isDockEntryClickThrottled={isDockEntryClickThrottled}
+                    launchLabel={i18n.t("launch", {
+                      title: resolvedEntry.entry.label
+                    })}
+                    nodeDefinitions={nodeDefinitions}
+                    onActivate={activateDockEntry}
+                    onOpenContextMenu={openDockEntryContextMenu}
+                    overlay={{
+                      clearHoverPanelOpenTimer,
+                      clearHoverPanelRestTargetForAnchor,
+                      clearLabelTooltipOpenTimer,
+                      closeHoverPanelImmediate,
+                      closeLabelTooltipImmediate,
+                      dockMeasureRef,
+                      handleDockPointerLeave,
+                      hoverPanelRef,
+                      scheduleHoverPanelAfterRest,
+                      scheduleHoverPanelAtPointAfterRest,
+                      scheduleLabelTooltipAfterRest,
+                      scheduleLabelTooltipAtPointAfterRest,
+                      showHoverPanel,
+                      showLabelTooltip
                     }}
-                    onFocus={(event) => {
-                      if (hasHoverPanel) {
-                        showHoverPanel(
-                          entry.id,
-                          anchorKey,
-                          event.currentTarget
-                        );
-                        return;
-                      }
-                      if (labelTooltipTarget) {
-                        showLabelTooltip(
-                          labelTooltipTarget,
-                          anchorKey,
-                          event.currentTarget
-                        );
-                      }
-                    }}
-                    onPointerEnter={() => {
-                      if (hasHoverPanel) {
-                        scheduleHoverPanelAfterRest(entry.id, anchorKey);
-                        return;
-                      }
-                      if (labelTooltipTarget) {
-                        scheduleLabelTooltipAfterRest(
-                          labelTooltipTarget,
-                          anchorKey
-                        );
-                      }
-                    }}
-                    onPointerLeave={(event) => {
-                      if (!hasHoverPanel) {
-                        if (labelTooltipTarget) {
-                          clearLabelTooltipOpenTimer();
-                          closeLabelTooltipImmediate(labelTooltipTarget.key);
-                          const relatedTarget = event.relatedTarget;
-                          if (
-                            relatedTarget instanceof Node &&
-                            dockMeasureRef.current?.contains(relatedTarget)
-                          ) {
-                            scheduleLabelTooltipAtPointAfterRest(
-                              event.clientX,
-                              event.clientY
-                            );
-                          }
-                        }
-                        return;
-                      }
-                      const relatedTarget = event.relatedTarget;
-                      if (
-                        relatedTarget instanceof Node &&
-                        hoverPanelRef.current?.contains(relatedTarget)
-                      ) {
-                        return;
-                      }
-                      if (
-                        relatedTarget instanceof Node &&
-                        dockMeasureRef.current?.contains(relatedTarget)
-                      ) {
-                        scheduleHoverPanelAtPointAfterRest(
-                          event.clientX,
-                          event.clientY
-                        );
-                        return;
-                      }
-                      if (
-                        hoverPanelRestTargetRef.current?.anchorKey === anchorKey
-                      ) {
-                        hoverPanelRestTargetRef.current = null;
-                      }
-                      clearHoverPanelOpenTimer();
-                      closeHoverPanelImmediate(entry.id);
-                      handleDockPointerLeave();
-                    }}
-                  >
-                    {dockButton}
-                  </span>
+                    presence={dockItem.presence}
+                    registerDockSlot={registerDockSlot}
+                    resolvedEntry={resolvedEntry}
+                    wallpaperTone={wallpaperTones.get(resolvedEntry.anchorKey)}
+                  />
                 );
               }
 
               const slot = dockItem.item.slot;
-              if (slot.kind === "stack") {
-                const stackPopupActive =
-                  activeMinimizedStackPopup !== null ? true : undefined;
-                const stackLabel = i18n.t("minimizedWindows");
-                const labelTooltipTarget = dockLabelTooltipTarget(
-                  `minimized-stack:${slot.anchorKey}`,
-                  stackLabel
-                );
-                const stackButton = (
-                  <span
-                    aria-expanded={stackPopupActive}
-                    aria-haspopup="dialog"
-                    aria-label={stackLabel}
-                    className="desktop-dock__btn desktop-dock__minimized-btn"
-                    data-interactive="true"
-                    role="button"
-                    tabIndex={0}
-                    onKeyDown={activateDockButtonFromKeyboard}
-                    onPointerDown={(event) => {
-                      if (event.button !== 0) {
-                        return;
-                      }
-                      beginDockMinimizedInteraction();
-                    }}
-                    onClick={(event) => {
-                      setActivePopup(null);
-                      const rect = event.currentTarget.getBoundingClientRect();
-                      const dockRect =
-                        dockMeasureRef.current?.getBoundingClientRect();
-                      setActiveMinimizedStackPopup((current) =>
-                        current
-                          ? null
-                          : {
-                              dockRight: Math.max(
-                                rect.right,
-                                dockRect?.right ?? rect.right
-                              ),
-                              height: rect.height,
-                              left: rect.left,
-                              top: rect.top,
-                              width: rect.width
-                            }
-                      );
-                    }}
-                  >
-                    <span
-                      className="desktop-dock__minimized-stack-icon"
-                      data-desktop-dock-icon-shell="true"
-                      data-stack-folded={
-                        slot.nodes.length > 1 ? "true" : undefined
-                      }
-                      aria-hidden
-                    >
-                      {Array.from(
-                        {
-                          length:
-                            slot.nodes.length > 1
-                              ? 3
-                              : Math.min(slot.nodes.length, 1)
-                        },
-                        (_, index) => {
-                          const node = slot.nodes[index];
-                          if (index === 0 && node) {
-                            return (
-                              <WorkbenchHostDockMinimizedNodePreview
-                                key={minimizedDockPreviewFreezeKey(node)}
-                                capturePreview={captureMinimizedNodePreview}
-                                className={`desktop-dock__minimized-stack-layer desktop-dock__minimized-stack-layer--${index}`}
-                                dockPreviewCache={dockPreviewCache}
-                                node={node}
-                                providePreview={provideMinimizedNodePreviewForNode(
-                                  node
-                                )}
-                                workspaceId={workspaceId}
-                              />
-                            );
-                          }
-                          return (
-                            <span
-                              key={`${slot.anchorKey}-stack-back-${index}`}
-                              aria-hidden="true"
-                              className={`desktop-dock__minimized-preview desktop-dock__minimized-stack-layer desktop-dock__minimized-stack-layer--${index} desktop-dock__minimized-stack-layer-back`}
-                            />
-                          );
-                        }
-                      )}
-                      <span className="desktop-dock__count-badge">
-                        {slot.nodes.length}
-                      </span>
-                    </span>
-                  </span>
-                );
-
-                return (
-                  <span
-                    key={dockItem.key}
-                    ref={registerDockSlot(slot.anchorKey)}
-                    className="desktop-dock__slot desktop-dock__slot--minimized"
-                    data-desktop-dock-anchor-key={slot.anchorKey}
-                    data-desktop-dock-slot="true"
-                    data-dock-label-tooltip-key={labelTooltipTarget.key}
-                    data-dock-label-tooltip-label={labelTooltipTarget.label}
-                    data-node-state="minimized"
-                    data-popup-active={stackPopupActive}
-                    data-presence={dockItem.presence}
-                    data-section-id="minimized"
-                    data-stack-dispatching={
-                      stackDispatching ? "true" : undefined
-                    }
-                    data-wallpaper-tone={wallpaperTones.get(slot.anchorKey)}
-                    onBlur={(event) => {
-                      if (!event.currentTarget.contains(event.relatedTarget)) {
-                        closeLabelTooltipImmediate(labelTooltipTarget.key);
-                      }
-                    }}
-                    onFocus={(event) => {
-                      showLabelTooltip(
-                        labelTooltipTarget,
-                        slot.anchorKey,
-                        event.currentTarget
-                      );
-                    }}
-                    onPointerEnter={() => {
-                      scheduleLabelTooltipAfterRest(
-                        labelTooltipTarget,
-                        slot.anchorKey
-                      );
-                    }}
-                    onPointerLeave={(event) => {
-                      clearLabelTooltipOpenTimer();
-                      closeLabelTooltipImmediate(labelTooltipTarget.key);
-                      const relatedTarget = event.relatedTarget;
-                      if (
-                        relatedTarget instanceof Node &&
-                        dockMeasureRef.current?.contains(relatedTarget)
-                      ) {
-                        scheduleLabelTooltipAtPointAfterRest(
-                          event.clientX,
-                          event.clientY
-                        );
-                      }
-                    }}
-                  >
-                    {stackButton}
-                  </span>
-                );
-              }
-
-              const node = slot.node;
-              const isPendingMinimizedNode =
-                context.genie.isPendingMinimizedDockNode(node.id);
-              const labelTooltipTarget = dockLabelTooltipTarget(
-                `minimized-node:${node.id}`,
-                node.title
-              );
-              const dockButton = (
-                <span
-                  aria-label={i18n.t("launch", { title: node.title })}
-                  aria-disabled={isPendingMinimizedNode ? true : undefined}
-                  className="desktop-dock__btn desktop-dock__minimized-btn"
-                  data-interactive={isPendingMinimizedNode ? "false" : "true"}
-                  role="button"
-                  tabIndex={isPendingMinimizedNode ? -1 : 0}
-                  onKeyDown={(event) =>
-                    activateDockButtonFromKeyboard(
-                      event,
-                      isPendingMinimizedNode
-                    )
-                  }
-                  onPointerDown={(event) => {
-                    if (event.button !== 0 || isPendingMinimizedNode) {
-                      return;
-                    }
-                    const restoreIntent =
-                      resolveWorkbenchMinimizedDockRestoreIntent({
-                        nodeId: node.id,
-                        slots: minimizedDockSlots,
-                        source: {
-                          anchorKey: slot.anchorKey,
-                          kind: "node-slot"
-                        }
-                      });
-                    if (restoreIntent?.kind !== "node-slot") {
-                      clearCollapsingMinimizedLaunch(slot.anchorKey);
-                      return;
-                    }
-                    beginDockMinimizedInteraction();
-                  }}
-                  onClick={() => {
-                    if (isPendingMinimizedNode) {
-                      return;
-                    }
-                    const restoreIntent =
-                      resolveWorkbenchMinimizedDockRestoreIntent({
-                        nodeId: node.id,
-                        slots: minimizedDockSlots,
-                        source: {
-                          anchorKey: slot.anchorKey,
-                          kind: "node-slot"
-                        }
-                      });
-                    if (restoreIntent?.kind !== "node-slot") {
-                      clearCollapsingMinimizedLaunch(slot.anchorKey);
-                      return;
-                    }
-                    closePopup();
-                    runDockMinimizedLaunchAfterCollapse(
-                      restoreIntent,
-                      (intent) => {
-                        context.genie.launchNodeFromAnchor(
-                          intent.anchorKey,
-                          intent.nodeId,
-                          () => {
-                            host.focusNode(intent.nodeId);
-                          }
-                        );
-                      }
-                    );
-                  }}
-                >
-                  <WorkbenchHostDockMinimizedNodePreview
-                    key={minimizedDockPreviewFreezeKey(node)}
-                    capturePreview={
-                      isPendingMinimizedNode
-                        ? undefined
-                        : captureMinimizedNodePreview
-                    }
-                    deferPreview={isPendingMinimizedNode}
-                    dockPreviewCache={
-                      isPendingMinimizedNode ? undefined : dockPreviewCache
-                    }
-                    node={node}
-                    providePreview={
-                      isPendingMinimizedNode
-                        ? undefined
-                        : provideMinimizedNodePreviewForNode(node)
-                    }
-                    workspaceId={workspaceId}
-                  />
-                </span>
-              );
-
               return (
-                <span
+                <WorkbenchHostDockMinimizedSlot
                   key={dockItem.key}
-                  ref={registerDockSlot(slot.anchorKey)}
-                  className="desktop-dock__slot desktop-dock__slot--minimized"
-                  data-collapsing={
-                    collapsingMinimizedLaunchAnchorKeys.has(slot.anchorKey)
-                      ? "true"
-                      : undefined
+                  activeStackPopup={activeMinimizedStackPopup !== null}
+                  capturePreview={captureMinimizedNodePreview}
+                  collapsing={collapsingMinimizedLaunchAnchorKeys.has(
+                    slot.anchorKey
+                  )}
+                  dockPreviewCache={dockPreviewCache}
+                  isPendingNode={context.genie.isPendingMinimizedDockNode}
+                  minimizedWindowsLabel={i18n.t("minimizedWindows")}
+                  nodeLaunchLabel={(title) => i18n.t("launch", { title })}
+                  onBeginStackInteraction={() =>
+                    beginDockMinimizedInteraction()
                   }
-                  data-desktop-dock-anchor-key={slot.anchorKey}
-                  data-desktop-dock-slot="true"
-                  data-dock-label-tooltip-key={labelTooltipTarget.key}
-                  data-dock-label-tooltip-label={labelTooltipTarget.label}
-                  data-node-state="minimized"
-                  data-pending-minimize={
-                    isPendingMinimizedNode ? "true" : undefined
-                  }
-                  data-presence={dockItem.presence}
-                  data-promoted-from-stack={
-                    promotedNodeId === node.id ? "true" : undefined
-                  }
-                  data-section-id="minimized"
-                  data-wallpaper-tone={wallpaperTones.get(slot.anchorKey)}
-                  onBlur={(event) => {
-                    if (!event.currentTarget.contains(event.relatedTarget)) {
-                      closeLabelTooltipImmediate(labelTooltipTarget.key);
-                    }
+                  onNodeActivate={handleMinimizedNodeActivate}
+                  onNodePointerDown={handleMinimizedNodePointerDown}
+                  onToggleStackPopup={toggleMinimizedStackPopup}
+                  overlay={{
+                    clearLabelTooltipOpenTimer,
+                    closeLabelTooltipImmediate,
+                    dockMeasureRef,
+                    scheduleLabelTooltipAfterRest,
+                    scheduleLabelTooltipAtPointAfterRest,
+                    showLabelTooltip
                   }}
-                  onFocus={(event) => {
-                    showLabelTooltip(
-                      labelTooltipTarget,
-                      slot.anchorKey,
-                      event.currentTarget
-                    );
-                  }}
-                  onPointerEnter={() => {
-                    scheduleLabelTooltipAfterRest(
-                      labelTooltipTarget,
-                      slot.anchorKey
-                    );
-                  }}
-                  onPointerLeave={(event) => {
-                    clearLabelTooltipOpenTimer();
-                    closeLabelTooltipImmediate(labelTooltipTarget.key);
-                    const relatedTarget = event.relatedTarget;
-                    if (
-                      relatedTarget instanceof Node &&
-                      dockMeasureRef.current?.contains(relatedTarget)
-                    ) {
-                      scheduleLabelTooltipAtPointAfterRest(
-                        event.clientX,
-                        event.clientY
-                      );
-                    }
-                  }}
-                >
-                  {dockButton}
-                </span>
+                  presence={dockItem.presence}
+                  promotedNodeId={promotedNodeId}
+                  providePreviewForNode={provideMinimizedNodePreviewForNode}
+                  registerDockSlot={registerDockSlot}
+                  slot={slot}
+                  stackDispatching={stackDispatching}
+                  wallpaperTone={wallpaperTones.get(slot.anchorKey)}
+                  workspaceId={workspaceId}
+                />
               );
             })}
           </div>
@@ -2155,7 +650,7 @@ export function WorkbenchHostDock({
             )}
           </button>
           {activeHoverPanel ? (
-            <WorkbenchHostDockHoverPanel
+            <DockHoverPanel
               entry={
                 resolvedEntries.find(
                   (entry) => entry.entry.id === activeHoverPanel.entryId
@@ -2192,1372 +687,42 @@ export function WorkbenchHostDock({
             />
           ) : null}
           {activeLabelTooltip ? (
-            <WorkbenchHostDockLabelTooltip
+            <DockLabelTooltip
               placement={dockPlacement}
               state={activeLabelTooltip}
             />
           ) : null}
         </div>
       </div>
-      {popupEntry && activePopup ? (
-        <WorkbenchHostDockPopup
-          anchorRect={activePopup.anchorRect}
-          placement={dockPlacement}
-          canEnterFullscreen={fullscreenNodeFromDockContextMenu !== null}
-          canShowAllWindows={canShowAllWindowsFromDockContextMenu}
-          debugDiagnostics={debugDiagnostics}
-          dockRetention={
-            popupEntry.entry.dockRetention
-              ? {
-                  checked: popupEntry.entry.dockRetention.retained,
-                  disabled:
-                    popupEntry.entry.dockRetention.disabled === true ||
-                    pendingActionKeys.has(
-                      dockActionKey(
-                        popupEntry.entry.id,
-                        popupEntry.entry.dockRetention.actionId
-                      )
-                    ),
-                  label: i18n.t(
-                    popupEntry.entry.dockRetention.retained
-                      ? "dockContextMenu.removeFromDock"
-                      : "dockContextMenu.keepInDock"
-                  ),
-                  pendingLabel: pendingActionKeys.has(
-                    dockActionKey(
-                      popupEntry.entry.id,
-                      popupEntry.entry.dockRetention.actionId
-                    )
-                  )
-                    ? popupEntry.entry.dockRetention.pendingLabel
-                    : undefined
-                }
-              : null
-          }
-          capturePreview={
-            popupEntry.entry.capturePopupItemPreview || captureNodePreviewImage
-              ? async (item) => {
-                  const previewImageUrl = await Promise.resolve(
-                    popupEntry.entry.capturePopupItemPreview
-                      ? popupEntry.entry.capturePopupItemPreview(item)
-                      : (captureNodePreviewImage?.(item.node) ?? null)
-                  ).catch(() => null);
-                  return previewImageUrl
-                    ? {
-                        kind: "image",
-                        revision: item.previewRevision ?? undefined,
-                        src: previewImageUrl
-                      }
-                    : null;
-                }
-              : undefined
-          }
-          dockPreviewCache={dockPreviewCache}
-          items={popupEntry.matchedNodes
-            .map((node) => {
-              const externalState = readWorkbenchHostExternalState({
-                externalStateSource,
-                node,
-                workspaceId
-              });
-              const item = {
-                externalNodeState: externalState.externalNodeState,
-                externalWorkspaceState: externalState.externalWorkspaceState,
-                host,
-                isFocused: context.focusedNodeId === node.id,
-                isMinimized: minimizedNodeIDs.has(node.id),
-                node,
-                previewViewport: workbenchHostDockPopupPreviewViewport
-              };
-              const descriptor =
-                popupEntry.entry.resolvePopupItem?.(item) ?? {};
-              const descriptorPreview =
-                descriptor.preview ??
-                popupEntry.entry.providePopupItemPreview?.(item) ??
-                null;
-              return {
-                ...item,
-                preview: descriptorPreview,
-                previewRevision:
-                  previewRevision(descriptorPreview) ??
-                  descriptor.revision ??
-                  null,
-                subtitle:
-                  descriptor.subtitle === undefined
-                    ? (node.data.instanceKey ?? node.data.instanceId)
-                    : descriptor.subtitle,
-                title:
-                  descriptor.title === undefined
-                    ? node.title
-                    : descriptor.title?.trim() || null
-              };
-            })
-            .sort((left, right) => {
-              if (left.isFocused !== right.isFocused) {
-                return left.isFocused ? -1 : 1;
-              }
-              return left.node.id.localeCompare(right.node.id);
-            })}
-          label={popupEntry.entry.label}
-          labelMode={popupEntry.entry.popupCardLabelMode}
-          newWindowLabel={i18n.t("newWindow")}
-          closeWindowLabel={(title) => i18n.t("closeWindow", { title })}
-          fullscreenLabel={i18n.t("dockContextMenu.fullscreen")}
-          hideLabel={i18n.t("dockContextMenu.hide")}
-          onClose={() => {
-            logWorkbenchDockDebug(
-              "dock.popup.close_requested",
-              debugDiagnostics,
-              {
-                entryId: popupEntry.entry.id,
-                itemCount: popupEntry.matchedNodes.length,
-                workspaceId
-              }
-            );
-            closePopup();
-          }}
-          onCloseNode={(nodeId) => {
-            host.requestNodeClose(nodeId);
-            const hasRemainingItems = popupEntry.matchedNodes.some(
-              (node) => node.id !== nodeId
-            );
-            if (!hasRemainingItems) {
-              closePopup();
-            }
-          }}
-          onCreateNew={() => {
-            closePopup();
-            context.genie.launchNodeFromAnchor(
-              anchorKeyFromPopupEntry(popupEntry),
-              popupEntry.entry.id,
-              () =>
-                host.launchNode({
-                  dockEntryId: popupEntry.entry.id,
-                  launchSource: dockPopupNewWindowLaunchSource,
-                  payload:
-                    popupEntry.entry.newWindowLaunchPayload ??
-                    popupEntry.entry.launchPayload,
-                  reason: "dock",
-                  typeId: popupEntry.entry.typeId
-                })
-            );
-          }}
-          onEnterFullscreen={() => {
-            if (!fullscreenNodeFromDockContextMenu) {
-              return;
-            }
-            context.controller.commands.enterFullscreen(
-              fullscreenNodeFromDockContextMenu.id
-            );
-            closePopup();
-          }}
-          onHide={() => {
-            for (const node of popupEntry.matchedNodes) {
-              if (!minimizedNodeIDs.has(node.id)) {
-                host.minimizeNode(node.id);
-              }
-            }
-            closePopup();
-          }}
-          onRunDockRetentionAction={
-            popupEntry.entry.dockRetention
-              ? () => {
-                  const dockRetention = popupEntry.entry.dockRetention;
-                  if (!dockRetention || dockRetention.disabled === true) {
-                    return;
-                  }
-                  runDockEntryAction(
-                    popupEntry.entry.id,
-                    dockRetention.actionId
-                  );
-                  closePopup();
-                }
-              : undefined
-          }
-          onSelectNode={(nodeId) => {
-            closePopup();
-            void (async () => {
-              try {
-                await onDockEntryClick?.({
-                  entryId: popupEntry.entry.id,
-                  host,
-                  nodeId
-                });
-              } catch {
-                // Keep dock click failures contained.
-              }
-            })();
-            context.genie.launchNodeFromAnchor(
-              anchorKeyFromPopupEntry(popupEntry),
-              nodeId,
-              () => {
-                host.focusNode(nodeId);
-              }
-            );
-          }}
-          onShowAllWindows={() => {
-            closePopup();
-            for (const node of popupEntry.matchedNodes) {
-              if (minimizedNodeIDs.has(node.id)) {
-                context.controller.commands.restoreNode(node.id);
-              }
-            }
-            window.requestAnimationFrame(() => {
-              onMissionControlRequestOpen?.({
-                nodeIds: openDockContextMenuNodeIds,
-                trigger: "dock-context-menu"
-              });
-            });
-          }}
-          onQuit={() => {
-            for (const node of popupEntry.matchedNodes) {
-              host.requestNodeClose(node.id);
-            }
-            closePopup();
-          }}
-          quitLabel={i18n.t("dockContextMenu.quit")}
-          showCreateNew={canCreateNewWindowInDockPopup(
-            popupEntry.entry,
-            dockContextMenuInstanceMode
-          )}
-          showCreateNewInContextMenu={canCreateNewWindow(
-            popupEntry.entry,
-            dockContextMenuInstanceMode
-          )}
-          showOpen={canOpenFromDockContextMenu}
-          showAllWindowsLabel={i18n.t("dockContextMenu.showAllWindows")}
-          resolveDockPreviewCacheKey={(node) =>
-            resolveDockPreviewCacheKey(workspaceId, node)
-          }
-          variant={
-            activePopup.kind === "context-menu" ? "context-menu" : "default"
-          }
-        />
-      ) : null}
-      {activeMinimizedStackSlot && activeMinimizedStackPopup ? (
-        <WorkbenchHostDockPopup
-          anchorRect={activeMinimizedStackPopup}
-          placement={dockPlacement}
-          debugDiagnostics={debugDiagnostics}
-          capturePreview={async (item) => {
-            const src = await resolveWorkbenchMinimizedDockPreviewImage({
-              capturePreview: () => captureMinimizedNodePreview(item.node),
-              dockPreviewCache,
-              node: item.node,
-              workspaceId
-            });
-            return src ? { kind: "image", src } : null;
-          }}
-          dockPreviewCache={dockPreviewCache}
-          items={activeMinimizedStackSlot.nodes.map((node) => {
-            const externalState = readWorkbenchHostExternalState({
-              externalStateSource,
-              node,
-              workspaceId
-            });
-            const minimizedDock = nodeDefinitions.get(node.data.typeId)?.window
-              ?.minimizedDock;
-            return {
-              externalNodeState: externalState.externalNodeState,
-              externalWorkspaceState: externalState.externalWorkspaceState,
-              host,
-              isFocused: context.focusedNodeId === node.id,
-              isMinimized: true,
-              node,
-              preview:
-                minimizedDock?.kind === "component"
-                  ? (provideMinimizedNodePreview(node) ?? null)
-                  : minimizedDock?.kind === "snapshot" &&
-                      minimizedDock.capturePreview
-                    ? null
-                    : (() => {
-                        const previewImageUrl =
-                          readWorkbenchMinimizedDockPreviewImage(node.id);
-                        return previewImageUrl
-                          ? ({ kind: "image", src: previewImageUrl } as const)
-                          : null;
-                      })(),
-              previewRevision:
-                resolveWorkbenchMinimizedDockPreviewRevision(node),
-              subtitle: node.data.instanceKey ?? node.data.instanceId,
-              title: node.title
-            };
-          })}
-          label={i18n.t("minimizedWindows")}
-          newWindowLabel={i18n.t("newWindow")}
-          closeWindowLabel={(title) => i18n.t("closeWindow", { title })}
-          onClose={() => {
-            logWorkbenchDockDebug(
-              "dock.popup.close_requested",
-              debugDiagnostics,
-              {
-                entryId: "minimized-stack",
-                itemCount: activeMinimizedStackSlot.nodes.length,
-                workspaceId
-              }
-            );
-            closePopup();
-          }}
-          onCloseNode={(nodeId) => {
-            host.requestNodeClose(nodeId);
-            const hasRemainingItems = activeMinimizedStackSlot.nodes.some(
-              (node) => node.id !== nodeId
-            );
-            if (!hasRemainingItems) {
-              closePopup();
-            }
-          }}
-          onCreateNew={() => undefined}
-          onSelectNode={(nodeId) => {
-            const restoreIntent = resolveWorkbenchMinimizedDockRestoreIntent({
-              nodeId,
-              slots: minimizedDockSlots,
-              source: {
-                kind: "stack-popup-card",
-                stackAnchorKey: activeMinimizedStackSlot.anchorKey
-              }
-            });
-            if (restoreIntent?.kind !== "stack-popup-card") {
-              return;
-            }
-            closePopup();
-            runDockMinimizedStackLaunch(restoreIntent, (intent) => {
-              context.genie.launchNodeFromAnchor(
-                intent.anchorKey,
-                intent.nodeId,
-                () => {
-                  host.focusNode(intent.nodeId);
-                }
-              );
-            });
-          }}
-          showCreateNew={false}
-          resolveDockPreviewCacheKey={(node) =>
-            resolveDockPreviewCacheKey(workspaceId, node)
-          }
-          variant="minimized-stack"
-        />
-      ) : null}
+      <WorkbenchHostDockPopups
+        activeMinimizedStackPopup={activeMinimizedStackPopup}
+        activePopup={activePopup}
+        captureMinimizedNodePreview={captureMinimizedNodePreview}
+        captureNodePreviewImage={captureNodePreviewImage}
+        closePopup={closePopup}
+        context={context}
+        debugDiagnostics={debugDiagnostics}
+        dockPlacement={dockPlacement}
+        dockPreviewCache={dockPreviewCache}
+        externalStateSource={externalStateSource}
+        host={host}
+        i18n={i18n}
+        minimizedDockSlots={minimizedDockSlots}
+        minimizedNodeIDs={minimizedNodeIDs}
+        nodeDefinitions={nodeDefinitions}
+        onDockEntryClick={onDockEntryClick}
+        onMissionControlRequestOpen={onMissionControlRequestOpen}
+        pendingActionKeys={pendingActionKeys}
+        provideMinimizedNodePreview={provideMinimizedNodePreview}
+        resolvedEntries={resolvedEntries}
+        runDockEntryAction={runDockEntryAction}
+        runDockMinimizedStackLaunch={runDockMinimizedStackLaunch}
+        workspaceId={workspaceId}
+      />
     </div>
   );
 }
-
-function dockEntryHasHoverPanel(entry: WorkbenchHostDockEntry): boolean {
-  return (
-    Boolean(entry.state?.reason?.trim()) ||
-    (entry.hoverActions?.length ?? 0) > 0
-  );
-}
-
-function dockEntryHasContextMenu(
-  entry: WorkbenchHostDockEntry,
-  resolvedEntry: ResolvedWorkbenchHostDockEntry
-): boolean {
-  if (resolvedEntry.matchedNodes.length > 0 || entry.dockRetention) {
-    return true;
-  }
-  return entry.clickActionId === undefined;
-}
-
-function resolveDockContextMenuFullscreenNode({
-  focusedNodeId,
-  minimizedNodeIDs,
-  nodeDefinitions,
-  nodes
-}: {
-  focusedNodeId: string | null;
-  minimizedNodeIDs: ReadonlySet<string>;
-  nodeDefinitions: ReadonlyMap<string, WorkbenchHostNodeDefinition>;
-  nodes: readonly WorkbenchMinimizedDockNode[];
-}) {
-  const candidates = nodes.filter((node) => {
-    if (node.displayMode === "fullscreen" || minimizedNodeIDs.has(node.id)) {
-      return false;
-    }
-    return (
-      nodeDefinitions.get(node.data.typeId)?.window?.fullscreenable !== false
-    );
-  });
-  return (
-    candidates.find((node) => node.id === focusedNodeId) ??
-    candidates[0] ??
-    null
-  );
-}
-
-function dockLabelTooltipTarget(
-  key: string,
-  label: string
-): WorkbenchHostDockLabelTooltipTarget {
-  return { key, label: label.trim() };
-}
-
-function renderDockBadge(
-  entry: WorkbenchHostDockEntry,
-  matchedNodeCount: number
-) {
-  const badge =
-    entry.badge ??
-    (matchedNodeCount > 1
-      ? ({
-          kind: "count",
-          value: matchedNodeCount
-        } as const)
-      : null);
-  if (!badge) {
-    return null;
-  }
-  if (badge.kind === "count") {
-    return <span className="desktop-dock__count-badge">{badge.value}</span>;
-  }
-  if (badge.kind === "custom") {
-    return <span className="desktop-dock__custom-badge">{badge.content}</span>;
-  }
-  return (
-    <span className="desktop-dock__status-badge" data-status={badge.status} />
-  );
-}
-
-function WorkbenchHostDockLabelTooltip({
-  placement,
-  state
-}: {
-  placement: WorkbenchHostProps["dockPlacement"];
-  state: WorkbenchHostDockLabelTooltipState;
-}) {
-  return (
-    <div
-      className="desktop-dock__label-tooltip"
-      data-dock-placement={placement}
-      role="tooltip"
-      style={
-        {
-          "--desktop-dock-label-tooltip-anchor-height": `${state.anchorRect.height}px`,
-          "--desktop-dock-label-tooltip-anchor-left": `${state.anchorRect.left}px`,
-          "--desktop-dock-label-tooltip-anchor-top": `${state.anchorRect.top}px`,
-          "--desktop-dock-label-tooltip-anchor-width": `${state.anchorRect.width}px`
-        } as WorkbenchHostDockLabelTooltipStyle
-      }
-    >
-      {state.label}
-    </div>
-  );
-}
-
-function WorkbenchHostDockHoverPanel({
-  entry,
-  host,
-  hoverPanelRef,
-  onBlur,
-  onDockEntryAction,
-  onFocus,
-  onPointerEnter,
-  onPointerLeave,
-  pendingActionKeys,
-  placement,
-  setPendingActionKeys,
-  state
-}: {
-  entry: WorkbenchHostDockEntry | null;
-  host: WorkbenchHostHandle;
-  hoverPanelRef: RefObject<HTMLDivElement | null>;
-  onDockEntryAction?: (input: {
-    actionId: string;
-    entryId: string;
-    host: WorkbenchHostHandle;
-  }) => Promise<void> | void;
-  onBlur?: (event: ReactFocusEvent<HTMLDivElement>) => void;
-  onFocus?: () => void;
-  onPointerEnter?: () => void;
-  onPointerLeave?: (event: ReactPointerEvent<HTMLDivElement>) => void;
-  pendingActionKeys: Set<string>;
-  placement: WorkbenchHostProps["dockPlacement"];
-  setPendingActionKeys: Dispatch<SetStateAction<Set<string>>>;
-  state: WorkbenchHostDockHoverPanelState;
-}) {
-  const lastPointerActionAtRef = useRef<Map<string, number>>(new Map());
-  if (!entry) {
-    return null;
-  }
-  const hoverPanelEntry = entry;
-
-  const runHoverAction = (
-    actionKey: string,
-    actionId: string,
-    disabled: boolean
-  ): void => {
-    if (disabled || pendingActionKeys.has(actionKey)) {
-      return;
-    }
-    setPendingActionKeys((current) => {
-      const next = new Set(current);
-      next.add(actionKey);
-      return next;
-    });
-    void (async () => {
-      try {
-        await onDockEntryAction?.({
-          actionId,
-          entryId: hoverPanelEntry.id,
-          host
-        });
-      } catch {
-        // Keep dock action failures contained.
-      } finally {
-        setPendingActionKeys((current) => {
-          if (!current.has(actionKey)) {
-            return current;
-          }
-          const next = new Set(current);
-          next.delete(actionKey);
-          return next;
-        });
-      }
-    })();
-  };
-
-  return (
-    <div
-      ref={hoverPanelRef}
-      className="desktop-dock__hover-panel"
-      data-dock-placement={placement}
-      role="group"
-      aria-label={entry.label}
-      onBlur={onBlur}
-      onFocus={onFocus}
-      onPointerEnter={onPointerEnter}
-      onPointerLeave={onPointerLeave}
-      style={
-        {
-          "--desktop-dock-hover-panel-anchor-height": `${state.anchorRect.height}px`,
-          "--desktop-dock-hover-panel-anchor-left": `${state.anchorRect.left}px`,
-          "--desktop-dock-hover-panel-anchor-top": `${state.anchorRect.top}px`,
-          "--desktop-dock-hover-panel-anchor-width": `${state.anchorRect.width}px`
-        } as WorkbenchHostDockHoverPanelStyle
-      }
-    >
-      <div className="desktop-dock__hover-panel-title">{entry.label}</div>
-      {entry.state?.reason ? (
-        <div className="desktop-dock__hover-panel-description">
-          {stripDockDescriptionTerminalPunctuation(entry.state.reason)}
-        </div>
-      ) : null}
-      {entry.hoverActions?.length ? (
-        <div className="desktop-dock__hover-actions">
-          {entry.hoverActions.map((action) => {
-            const actionKey = dockActionKey(entry.id, action.id);
-            const isLocallyPending = pendingActionKeys.has(actionKey);
-            const isPending =
-              isLocallyPending ||
-              (action.disabled === true && action.pendingLabel !== undefined);
-            return (
-              <Button
-                key={action.id}
-                aria-busy={isPending ? true : undefined}
-                className="desktop-dock__hover-action"
-                disabled={action.disabled || isLocallyPending}
-                type="button"
-                onPointerDown={(event) => {
-                  // The dock hover panel can be torn down between pointerdown
-                  // and the synthetic click — a re-render race, or the
-                  // overlapping workspace-app webview swallowing the pointerup —
-                  // which silently drops the click and makes the button look
-                  // dead. Act on pointerdown (primary button), the event proven
-                  // to reliably reach this button; keyboard activation still
-                  // flows through onClick below.
-                  if (event.button !== 0) {
-                    return;
-                  }
-                  event.preventDefault();
-                  event.stopPropagation();
-                  lastPointerActionAtRef.current.set(
-                    actionKey,
-                    performance.now()
-                  );
-                  runHoverAction(
-                    actionKey,
-                    action.id,
-                    action.disabled === true
-                  );
-                }}
-                onClick={(event) => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                  // A mouse activation already ran on pointerdown; skip its
-                  // trailing click. Only the keyboard path (Enter/Space, with no
-                  // preceding pointerdown) should trigger the action here.
-                  const lastPointerAt =
-                    lastPointerActionAtRef.current.get(actionKey);
-                  if (
-                    lastPointerAt !== undefined &&
-                    performance.now() - lastPointerAt < 700
-                  ) {
-                    return;
-                  }
-                  runHoverAction(
-                    actionKey,
-                    action.id,
-                    action.disabled === true
-                  );
-                }}
-              >
-                {isPending
-                  ? (action.pendingLabel ?? action.label)
-                  : action.label}
-              </Button>
-            );
-          })}
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-function resolveDockEntryInstanceMode(
-  entry: WorkbenchHostDockEntry,
-  nodeDefinitions: ReadonlyMap<string, WorkbenchHostNodeDefinition>
-): WorkbenchHostNodeInstanceStrategy["mode"] | undefined {
-  return (
-    entry.instanceMode ?? nodeDefinitions.get(entry.typeId)?.instance?.mode
-  );
-}
-
-function anchorKeyFromPopupEntry(
-  entry: ResolvedWorkbenchHostDockEntry
-): string {
-  return entry.anchorKey;
-}
-
-function previewRevision(
-  preview: WorkbenchDockPreviewContent | null | undefined
-): string | null {
-  return preview?.revision ?? null;
-}
-
-function logWorkbenchDockDebug(
-  event: string,
-  debugDiagnostics: WorkbenchHostProps["debugDiagnostics"],
-  details: Record<string, unknown>
-): void {
-  if (!debugDiagnostics?.log) {
-    return;
-  }
-  void Promise.resolve(
-    debugDiagnostics.log({
-      details,
-      event,
-      level: "info",
-      source: "workbench-dock",
-      workspaceId:
-        typeof details.workspaceId === "string" ? details.workspaceId : null
-    })
-  ).catch(() => undefined);
-}
-
-function minimizedDockSlotNodes(
-  slot: WorkbenchMinimizedDockSlot
-): readonly WorkbenchMinimizedDockNode[] {
-  return slot.kind === "stack" ? slot.nodes : [slot.node];
-}
-
-function resolveDockPreviewCacheKey(
-  workspaceId: string,
-  node: WorkbenchMinimizedDockNode
-): WorkbenchDockPreviewCacheKey {
-  return {
-    instanceId: node.data.instanceId,
-    instanceKey: node.data.instanceKey ?? null,
-    nodeId: node.id,
-    typeId: node.data.typeId,
-    workspaceId
-  };
-}
-
-function dockActionKey(entryId: string, actionId: string): string {
-  return `${entryId}:${actionId}`;
-}
-
-function createWorkbenchHostDockItems({
-  minimizedDockSlots,
-  resolvedEntries
-}: {
-  minimizedDockSlots: readonly WorkbenchMinimizedDockSlot[];
-  resolvedEntries: readonly ResolvedWorkbenchHostDockEntry[];
-}): WorkbenchHostDockItem[] {
-  const items: WorkbenchHostDockItem[] = [];
-
-  for (const resolvedEntry of resolvedEntries) {
-    if (resolvedEntry.sectionBreakBefore) {
-      items.push({
-        key: `separator:before:${resolvedEntry.entry.id}`,
-        kind: "separator"
-      });
-    }
-    items.push({
-      key: `entry:${resolvedEntry.entry.id}`,
-      kind: "entry",
-      resolvedEntry
-    });
-    if (resolvedEntry.entry.separatorAfter) {
-      items.push({
-        key: `separator:after:${resolvedEntry.entry.id}`,
-        kind: "separator"
-      });
-    }
-  }
-
-  if (minimizedDockSlots.length > 0 && resolvedEntries.length > 0) {
-    items.push({
-      key: "separator:minimized",
-      kind: "separator"
-    });
-  }
-
-  for (const slot of minimizedDockSlots) {
-    items.push({
-      key: `minimized:${slot.anchorKey}`,
-      kind: "minimized",
-      slot
-    });
-  }
-
-  return items;
-}
-
-function resolveMinimizedDockItemNodeId(
-  item: WorkbenchHostDockItem
-): string | null {
-  if (item.kind !== "minimized" || item.slot.kind !== "node") {
-    return null;
-  }
-  return item.slot.node.id;
-}
-
-function resolveNextDockItemPresence(
-  item: WorkbenchHostDockItem,
-  initialized: boolean,
-  previousPresence: WorkbenchHostDockPresence | undefined,
-  shouldAnimateMinimizedDockEnter: (nodeId: string) => boolean
-): WorkbenchHostDockPresence {
-  if (!initialized) {
-    return "present";
-  }
-
-  if (item.key === "separator:minimized") {
-    return "present";
-  }
-
-  if (item.kind === "minimized") {
-    const nodeId = resolveMinimizedDockItemNodeId(item);
-    if (nodeId && shouldAnimateMinimizedDockEnter(nodeId)) {
-      if (previousPresence === "exiting") {
-        return "entering";
-      }
-      return previousPresence ?? "entering";
-    }
-    return "present";
-  }
-
-  if (previousPresence === "exiting") {
-    return "entering";
-  }
-
-  return previousPresence ?? "entering";
-}
-
-function resolveDockPresenceItems(input: {
-  current: readonly WorkbenchHostPresentDockItem[];
-  initialized: boolean;
-  nextSourceItems: readonly WorkbenchHostDockItem[];
-  shouldAnimateMinimizedDockEnter: (nodeId: string) => boolean;
-}): WorkbenchHostPresentDockItem[] {
-  const currentByKey = new Map(input.current.map((item) => [item.key, item]));
-  const currentIndexByKey = new Map(
-    input.current.map((item, index) => [item.key, index])
-  );
-  const nextByKey = new Map(
-    input.nextSourceItems.map((item) => [item.key, item])
-  );
-  const nextKeys = new Set(input.nextSourceItems.map((item) => item.key));
-  const currentVisibleItemCount = input.current.filter(
-    (item) => item.presence !== "exiting"
-  ).length;
-  const shouldRetainExitingItems =
-    input.nextSourceItems.length < currentVisibleItemCount;
-  const emittedKeys = new Set<string>();
-  const nextItems: WorkbenchHostPresentDockItem[] = [];
-  let currentIndex = 0;
-
-  const emitExitingUntil = (nextCurrentIndex: number) => {
-    while (currentIndex < nextCurrentIndex) {
-      const currentItem = input.current[currentIndex];
-      currentIndex += 1;
-      if (
-        shouldRetainExitingItems &&
-        currentItem &&
-        !nextKeys.has(currentItem.key) &&
-        !emittedKeys.has(currentItem.key)
-      ) {
-        emittedKeys.add(currentItem.key);
-        nextItems.push({
-          ...currentItem,
-          presence: "exiting"
-        });
-      }
-    }
-  };
-
-  for (const item of input.nextSourceItems) {
-    const previousIndex = currentIndexByKey.get(item.key);
-    if (previousIndex !== undefined) {
-      emitExitingUntil(previousIndex);
-      currentIndex = Math.max(currentIndex, previousIndex + 1);
-    }
-    emittedKeys.add(item.key);
-    nextItems.push({
-      item,
-      key: item.key,
-      presence: resolveNextDockItemPresence(
-        item,
-        input.initialized,
-        currentByKey.get(item.key)?.presence,
-        input.shouldAnimateMinimizedDockEnter
-      )
-    });
-  }
-
-  for (const currentItem of input.current) {
-    if (shouldRetainExitingItems && !nextKeys.has(currentItem.key)) {
-      if (emittedKeys.has(currentItem.key)) {
-        continue;
-      }
-      emittedKeys.add(currentItem.key);
-      nextItems.push({
-        ...currentItem,
-        presence: "exiting"
-      });
-    }
-  }
-
-  return nextItems.filter(
-    (item) => nextByKey.has(item.key) || item.presence === "exiting"
-  );
-}
-
-function resolveDockPresenceSettleMs(
-  items: readonly WorkbenchHostPresentDockItem[]
-): number {
-  if (
-    items.some(
-      (item) =>
-        item.item.kind === "minimized" &&
-        (item.presence === "entering" || item.presence === "exiting")
-    )
-  ) {
-    return minimizedDockSlotLayoutAnimationMs;
-  }
-  return dockPresenceAnimationMs;
-}
-
-function useDockPresenceItems(
-  items: readonly WorkbenchHostDockItem[],
-  shouldAnimateMinimizedDockEnter: (nodeId: string) => boolean
-): WorkbenchHostPresentDockItem[] {
-  const latestItemsByKey = useRef(new Map<string, WorkbenchHostDockItem>());
-  const shouldAnimateMinimizedDockEnterRef = useRef(
-    shouldAnimateMinimizedDockEnter
-  );
-  latestItemsByKey.current = new Map(items.map((item) => [item.key, item]));
-  shouldAnimateMinimizedDockEnterRef.current = shouldAnimateMinimizedDockEnter;
-  const itemKeys = items.map((item) => item.key).join("\u0000");
-  const [presentItems, setPresentItems] = useState<
-    WorkbenchHostPresentDockItem[]
-  >(() =>
-    items.map((item) => ({
-      item,
-      key: item.key,
-      presence: "present" as const
-    }))
-  );
-  const initialized = useRef(false);
-
-  useEffect(() => {
-    let nextSettleMs = dockPresenceAnimationMs;
-
-    setPresentItems((current) => {
-      const filteredItems = resolveDockPresenceItems({
-        current,
-        initialized: initialized.current,
-        nextSourceItems: [...latestItemsByKey.current.values()],
-        shouldAnimateMinimizedDockEnter:
-          shouldAnimateMinimizedDockEnterRef.current
-      });
-      nextSettleMs = resolveDockPresenceSettleMs(filteredItems);
-      return filteredItems;
-    });
-    initialized.current = true;
-
-    const timeout = globalThis.setTimeout(() => {
-      setPresentItems((current) =>
-        current
-          .filter((item) => item.presence !== "exiting")
-          .map((item) =>
-            item.presence === "entering"
-              ? { ...item, presence: "present" as const }
-              : item
-          )
-      );
-    }, nextSettleMs);
-
-    return () => globalThis.clearTimeout(timeout);
-  }, [itemKeys]);
-
-  const renderedPresentItems = resolveDockPresenceItems({
-    current: presentItems,
-    initialized: initialized.current,
-    nextSourceItems: [...latestItemsByKey.current.values()],
-    shouldAnimateMinimizedDockEnter
-  });
-
-  return renderedPresentItems.map((presentItem) => {
-    const latestItem = latestItemsByKey.current.get(presentItem.key);
-    return latestItem ? { ...presentItem, item: latestItem } : presentItem;
-  });
-}
-
-function useDockWallpaperTones({
-  dockItemsRef,
-  elementRefs,
-  itemKeys
-}: {
-  dockItemsRef: RefObject<HTMLElement | null>;
-  elementRefs: RefObject<Map<string, HTMLElement>>;
-  itemKeys: string;
-}): ReadonlyMap<string, WorkbenchDockWallpaperTone> {
-  const [tones, setTones] = useState<Map<string, WorkbenchDockWallpaperTone>>(
-    () => new Map()
-  );
-
-  useLayoutEffect(() => {
-    if (typeof window === "undefined") {
-      return undefined;
-    }
-
-    let canceled = false;
-    let frameId: number | null = null;
-
-    const updateTones = () => {
-      frameId = null;
-      void resolveDockWallpaperTones({
-        dockItemsElement: dockItemsRef.current,
-        elements: elementRefs.current
-      }).then((nextTones) => {
-        if (canceled) {
-          return;
-        }
-        setTones((current) =>
-          dockWallpaperToneMapsEqual(current, nextTones) ? current : nextTones
-        );
-      });
-    };
-
-    const scheduleUpdate = () => {
-      if (frameId !== null) {
-        return;
-      }
-      frameId = window.requestAnimationFrame(updateTones);
-    };
-
-    scheduleUpdate();
-    window.addEventListener("resize", scheduleUpdate);
-
-    const resizeObserver =
-      typeof ResizeObserver === "undefined"
-        ? null
-        : new ResizeObserver(scheduleUpdate);
-    if (dockItemsRef.current) {
-      resizeObserver?.observe(dockItemsRef.current);
-    }
-    const wallpaperElement = dockItemsRef.current
-      ?.closest(".workbench-surface")
-      ?.querySelector(".workbench-surface__wallpaper");
-    if (wallpaperElement instanceof HTMLElement) {
-      resizeObserver?.observe(wallpaperElement);
-    }
-
-    return () => {
-      canceled = true;
-      if (frameId !== null) {
-        window.cancelAnimationFrame(frameId);
-      }
-      resizeObserver?.disconnect();
-      window.removeEventListener("resize", scheduleUpdate);
-    };
-  }, [dockItemsRef, elementRefs, itemKeys]);
-
-  return tones;
-}
-
-async function resolveDockWallpaperTones({
-  dockItemsElement,
-  elements
-}: {
-  dockItemsElement: HTMLElement | null;
-  elements: ReadonlyMap<string, HTMLElement>;
-}): Promise<Map<string, WorkbenchDockWallpaperTone>> {
-  const wallpaperElement = dockItemsElement
-    ?.closest(".workbench-surface")
-    ?.querySelector(".workbench-surface__wallpaper");
-  if (!(wallpaperElement instanceof HTMLElement)) {
-    return new Map();
-  }
-
-  const wallpaperStyle = window.getComputedStyle(wallpaperElement);
-  const wallpaperUrl = parseDockWallpaperCssUrl(wallpaperStyle.backgroundImage);
-  if (!wallpaperUrl) {
-    return new Map();
-  }
-
-  const wallpaperImage = await loadDockWallpaperImage(wallpaperUrl);
-  if (!wallpaperImage) {
-    return new Map();
-  }
-
-  const wallpaperSample = getDockWallpaperImageSample(wallpaperImage);
-  if (!wallpaperSample) {
-    return new Map();
-  }
-
-  const wallpaperRect = wallpaperElement.getBoundingClientRect();
-  const renderedImageRect = resolveDockWallpaperRenderedImageRect({
-    containerHeight: wallpaperRect.height,
-    containerWidth: wallpaperRect.width,
-    imageHeight: wallpaperImage.naturalHeight,
-    imageWidth: wallpaperImage.naturalWidth,
-    positionX: wallpaperStyle.backgroundPositionX,
-    positionY: wallpaperStyle.backgroundPositionY,
-    size: wallpaperStyle.backgroundSize
-  });
-  const nextTones = new Map<string, WorkbenchDockWallpaperTone>();
-
-  for (const [key, element] of elements) {
-    const luminance = sampleDockWallpaperLuminanceAtElement({
-      elementRect: element.getBoundingClientRect(),
-      renderedImageRect,
-      sample: wallpaperSample,
-      wallpaperRect
-    });
-    if (luminance === null) {
-      continue;
-    }
-    nextTones.set(
-      key,
-      luminance < dockWallpaperDarkLuminanceThreshold ? "dark" : "light"
-    );
-  }
-
-  return nextTones;
-}
-
-function parseDockWallpaperCssUrl(backgroundImage: string): string | null {
-  const match = /^url\((['"]?)(.*)\1\)$/u.exec(backgroundImage.trim());
-  return match?.[2] ? match[2] : null;
-}
-
-const dockWallpaperImageCache = new Map<
-  string,
-  Promise<HTMLImageElement | null>
->();
-
-function loadDockWallpaperImage(url: string): Promise<HTMLImageElement | null> {
-  const cached = dockWallpaperImageCache.get(url);
-  if (cached) {
-    return cached;
-  }
-  const promise = new Promise<HTMLImageElement | null>((resolve) => {
-    const image = new Image();
-    image.decoding = "async";
-    image.onload = () => resolve(image);
-    image.onerror = () => resolve(null);
-    image.src = url;
-  });
-  dockWallpaperImageCache.set(url, promise);
-  return promise;
-}
-
-function resolveDockWallpaperRenderedImageRect({
-  containerHeight,
-  containerWidth,
-  imageHeight,
-  imageWidth,
-  positionX,
-  positionY,
-  size
-}: {
-  containerHeight: number;
-  containerWidth: number;
-  imageHeight: number;
-  imageWidth: number;
-  positionX: string;
-  positionY: string;
-  size: string;
-}): { height: number; left: number; top: number; width: number } {
-  const imageAspect = imageWidth / imageHeight;
-  const containerAspect = containerWidth / containerHeight;
-  let width = containerWidth;
-  let height = containerHeight;
-
-  if (size === "cover") {
-    if (containerAspect > imageAspect) {
-      height = containerWidth / imageAspect;
-    } else {
-      width = containerHeight * imageAspect;
-    }
-  } else if (size === "contain") {
-    if (containerAspect > imageAspect) {
-      width = containerHeight * imageAspect;
-    } else {
-      height = containerWidth / imageAspect;
-    }
-  } else if (size !== "100% 100%") {
-    width = imageWidth;
-    height = imageHeight;
-  }
-
-  return {
-    height,
-    left: resolveDockWallpaperPositionOffset(positionX, containerWidth - width),
-    top: resolveDockWallpaperPositionOffset(
-      positionY,
-      containerHeight - height
-    ),
-    width
-  };
-}
-
-function resolveDockWallpaperPositionOffset(
-  value: string,
-  availableSpace: number
-): number {
-  const trimmed = value.trim();
-  if (trimmed.endsWith("%")) {
-    const percentage = Number.parseFloat(trimmed);
-    return Number.isFinite(percentage)
-      ? (availableSpace * percentage) / 100
-      : availableSpace / 2;
-  }
-  if (trimmed.endsWith("px")) {
-    const px = Number.parseFloat(trimmed);
-    return Number.isFinite(px) ? px : availableSpace / 2;
-  }
-  if (trimmed === "left" || trimmed === "top") {
-    return 0;
-  }
-  if (trimmed === "right" || trimmed === "bottom") {
-    return availableSpace;
-  }
-  return availableSpace / 2;
-}
-
-function dockWallpaperToneMapsEqual(
-  left: ReadonlyMap<string, WorkbenchDockWallpaperTone>,
-  right: ReadonlyMap<string, WorkbenchDockWallpaperTone>
-): boolean {
-  if (left.size !== right.size) {
-    return false;
-  }
-  for (const [key, value] of left) {
-    if (right.get(key) !== value) {
-      return false;
-    }
-  }
-  return true;
-}
-
-const DOCK_BOUNCE_MS = 600;
-const DOCK_ENTRY_CLICK_THROTTLE_MS = DOCK_BOUNCE_MS;
-
-function useDockBounce(slotRefs: RefObject<Map<string, HTMLElement>>) {
-  const timeoutsRef = useRef(new Map<string, ReturnType<typeof setTimeout>>());
-
-  const clearDockBounce = useCallback(
-    (anchorKey: string): boolean => {
-      const timeout = timeoutsRef.current.get(anchorKey);
-      const slotElement = slotRefs.current.get(anchorKey);
-      const wasBouncing = slotElement?.hasAttribute("data-bouncing") === true;
-      if (timeout) {
-        clearTimeout(timeout);
-        timeoutsRef.current.delete(anchorKey);
-      }
-      slotElement?.removeAttribute("data-bouncing");
-      return wasBouncing;
-    },
-    [slotRefs]
-  );
-
-  useEffect(
-    () => () => {
-      for (const anchorKey of timeoutsRef.current.keys()) {
-        clearDockBounce(anchorKey);
-      }
-      timeoutsRef.current.clear();
-    },
-    [clearDockBounce]
-  );
-
-  const triggerDockBounce = useCallback(
-    (anchorKey: string) => {
-      const shouldRestartAnimation = clearDockBounce(anchorKey);
-
-      const slotElement = slotRefs.current.get(anchorKey);
-      if (!slotElement) {
-        return;
-      }
-
-      if (shouldRestartAnimation) {
-        // Restart the CSS keyframes without scheduling a React render.
-        void slotElement.offsetWidth;
-      }
-      slotElement.setAttribute("data-bouncing", "true");
-      timeoutsRef.current.set(
-        anchorKey,
-        setTimeout(() => {
-          clearDockBounce(anchorKey);
-        }, DOCK_BOUNCE_MS)
-      );
-    },
-    [clearDockBounce, slotRefs]
-  );
-
-  return { triggerDockBounce };
-}
-
-function resolveWorkbenchHostDockItemsWidth(
-  items: readonly WorkbenchHostDockItem[]
-): number {
-  if (items.length === 0) {
-    return dockItemsHorizontalPaddingPx;
-  }
-
-  const itemWidth = items.reduce(
-    (sum, item) =>
-      sum +
-      (item.kind === "separator" ? dockSeparatorOuterWidthPx : dockSlotWidthPx),
-    0
-  );
-  const gapWidth = Math.max(0, items.length - 1) * dockItemsGapPx;
-  return itemWidth + gapWidth + dockItemsHorizontalPaddingPx;
-}
-
-const dockHoverPanelOpenDelayMs = 120;
-const dockHoverPanelCloseDelayMs = 160;
-const dockHoverPanelHitSlopPx = 12;
-const dockHoverPanelBridgeSlopPx = 6;
-const dockHoverPanelPointerRestTolerancePx = 4;
-const dockWallpaperDarkLuminanceThreshold = 132;
-
-function rectContainsPoint(
-  rect: DOMRect,
-  clientX: number,
-  clientY: number,
-  slopPx = 0
-): boolean {
-  return (
-    clientX >= rect.left - slopPx &&
-    clientX <= rect.right + slopPx &&
-    clientY >= rect.top - slopPx &&
-    clientY <= rect.bottom + slopPx
-  );
-}
-
-function createHoverPanelBridgeRect(anchor: DOMRect, panel: DOMRect): DOMRect {
-  if (anchor.right <= panel.left || panel.right <= anchor.left) {
-    const left = Math.min(anchor.right, panel.right);
-    const right = Math.max(anchor.left, panel.left);
-    const top = Math.max(anchor.top, panel.top);
-    const bottom = Math.min(anchor.bottom, panel.bottom);
-    return new DOMRect(left, top, right - left, Math.max(0, bottom - top));
-  }
-
-  const left = Math.max(anchor.left, panel.left);
-  const right = Math.min(anchor.right, panel.right);
-  const top = Math.min(anchor.bottom, panel.bottom);
-  const bottom = Math.max(anchor.top, panel.top);
-  return new DOMRect(left, top, Math.max(0, right - left), bottom - top);
-}
-const dockPresenceAnimationMs = 300;
-const minimizedDockSlotLayoutAnimationMs = 720;
-const dockItemsGapPx = 10.8;
-const dockItemsHorizontalPaddingPx = 12.6;
-const dockSeparatorOuterWidthPx = 8.1;
-const dockSlotWidthPx = 43.2;
-const desktopDockPlateChromeWidth = 15.3;
 
 interface WorkbenchHostDockPlateStyle extends CSSProperties {
   "--desktop-dock-frame-size"?: string;
-}
-
-interface WorkbenchHostDockHoverPanelStyle extends CSSProperties {
-  "--desktop-dock-hover-panel-anchor-height"?: string;
-  "--desktop-dock-hover-panel-anchor-left"?: string;
-  "--desktop-dock-hover-panel-anchor-top"?: string;
-  "--desktop-dock-hover-panel-anchor-width"?: string;
-}
-
-interface WorkbenchHostDockLabelTooltipStyle extends CSSProperties {
-  "--desktop-dock-label-tooltip-anchor-height"?: string;
-  "--desktop-dock-label-tooltip-anchor-left"?: string;
-  "--desktop-dock-label-tooltip-anchor-top"?: string;
-  "--desktop-dock-label-tooltip-anchor-width"?: string;
-}
-
-type WorkbenchHostDockPresence = "entering" | "exiting" | "present";
-type WorkbenchHostDockScrollDirection = "backward" | "forward";
-
-interface WorkbenchHostDockLabelTooltipTarget {
-  key: string;
-  label: string;
-}
-
-interface WorkbenchHostDockLabelTooltipState extends WorkbenchHostDockLabelTooltipTarget {
-  anchorKey: string;
-  anchorRect: {
-    height: number;
-    left: number;
-    top: number;
-    width: number;
-  };
-}
-
-interface WorkbenchHostDockHoverPanelState {
-  anchorKey: string;
-  anchorRect: {
-    height: number;
-    left: number;
-    top: number;
-    width: number;
-  };
-  entryId: string;
-}
-
-type WorkbenchHostDockItem =
-  | {
-      key: string;
-      kind: "entry";
-      resolvedEntry: ResolvedWorkbenchHostDockEntry;
-    }
-  | {
-      key: string;
-      kind: "minimized";
-      slot: WorkbenchMinimizedDockSlot;
-    }
-  | {
-      key: string;
-      kind: "separator";
-    };
-
-interface WorkbenchHostPresentDockItem {
-  item: WorkbenchHostDockItem;
-  key: string;
-  presence: WorkbenchHostDockPresence;
 }

--- a/packages/workbench/surface/src/host/WorkbenchHostDockEntrySlot.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDockEntrySlot.tsx
@@ -1,0 +1,324 @@
+import type {
+  FocusEvent as ReactFocusEvent,
+  PointerEvent as ReactPointerEvent,
+  RefObject
+} from "react";
+import {
+  resolveWorkbenchDockEntryClick,
+  type ResolvedWorkbenchHostDockEntry
+} from "./dockEntries.ts";
+import { resolveDockEntryInstanceMode } from "./dockItems.ts";
+import type { WorkbenchHostDockPresence } from "./dockPresence.ts";
+import { dockLabelTooltipTarget } from "./useWorkbenchHostDockOverlays.ts";
+import type {
+  WorkbenchHostDockEntryActivationInput,
+  WorkbenchHostDockEntryContextMenuInput
+} from "./useWorkbenchHostDockEntryActivation.ts";
+import type { WorkbenchHostDockPopupState } from "./WorkbenchHostDockPopup.tsx";
+import type {
+  WorkbenchHostDockEntry,
+  WorkbenchHostNodeDefinition
+} from "./types.ts";
+import type { WorkbenchDockWallpaperTone } from "./useWorkbenchHostDockWallpaperTones.ts";
+
+interface WorkbenchHostDockEntryOverlayController {
+  clearHoverPanelOpenTimer: () => void;
+  clearHoverPanelRestTargetForAnchor: (anchorKey: string) => void;
+  clearLabelTooltipOpenTimer: () => void;
+  closeHoverPanelImmediate: (entryId?: string) => void;
+  closeLabelTooltipImmediate: (targetKey?: string) => void;
+  dockMeasureRef: RefObject<HTMLDivElement | null>;
+  handleDockPointerLeave: () => void;
+  hoverPanelRef: RefObject<HTMLDivElement | null>;
+  scheduleHoverPanelAfterRest: (entryId: string, anchorKey: string) => void;
+  scheduleHoverPanelAtPointAfterRest: (
+    clientX: number,
+    clientY: number
+  ) => void;
+  scheduleLabelTooltipAfterRest: (
+    target: { key: string; label: string },
+    anchorKey: string
+  ) => void;
+  scheduleLabelTooltipAtPointAfterRest: (
+    clientX: number,
+    clientY: number
+  ) => void;
+  showHoverPanel: (
+    entryId: string,
+    anchorKey: string,
+    anchorElement: HTMLElement
+  ) => void;
+  showLabelTooltip: (
+    target: { key: string; label: string },
+    anchorKey: string,
+    anchorElement: HTMLElement
+  ) => void;
+}
+
+export function WorkbenchHostDockEntrySlot({
+  activeAttention,
+  beginDockIconInteraction,
+  claimDockEntryClick,
+  currentPopup,
+  isDockEntryClickThrottled,
+  launchLabel,
+  nodeDefinitions,
+  onActivate,
+  onOpenContextMenu,
+  overlay,
+  presence,
+  registerDockSlot,
+  resolvedEntry,
+  wallpaperTone
+}: {
+  activeAttention: boolean;
+  beginDockIconInteraction: (anchorKey: string) => void;
+  claimDockEntryClick: (anchorKey: string) => void;
+  currentPopup: WorkbenchHostDockPopupState | null;
+  isDockEntryClickThrottled: (anchorKey: string) => boolean;
+  launchLabel: string;
+  nodeDefinitions: ReadonlyMap<string, WorkbenchHostNodeDefinition>;
+  onActivate: (input: WorkbenchHostDockEntryActivationInput) => void;
+  onOpenContextMenu: (input: WorkbenchHostDockEntryContextMenuInput) => void;
+  overlay: WorkbenchHostDockEntryOverlayController;
+  presence: WorkbenchHostDockPresence;
+  registerDockSlot: (
+    anchorKey: string
+  ) => (element: HTMLElement | null) => void;
+  resolvedEntry: ResolvedWorkbenchHostDockEntry;
+  wallpaperTone?: WorkbenchDockWallpaperTone;
+}) {
+  const { anchorKey, entry } = resolvedEntry;
+  const instanceMode = resolveDockEntryInstanceMode(entry, nodeDefinitions);
+  const clickResolution = resolveWorkbenchDockEntryClick({
+    entry,
+    instanceMode,
+    matchedNodes: resolvedEntry.matchedNodes
+  });
+  const hasHoverPanel = dockEntryHasHoverPanel(entry);
+  const labelTooltip = hasHoverPanel
+    ? null
+    : dockLabelTooltipTarget(`entry:${entry.id}`, entry.label);
+
+  return (
+    <span
+      ref={registerDockSlot(anchorKey)}
+      className="desktop-dock__slot"
+      data-attention-active={activeAttention ? "true" : undefined}
+      data-desktop-dock-anchor-key={anchorKey}
+      data-desktop-dock-slot="true"
+      data-entry-state={entry.state?.kind ?? "enabled"}
+      data-dock-hover-panel-entry-id={hasHoverPanel ? entry.id : undefined}
+      data-dock-label-tooltip-key={labelTooltip?.key}
+      data-dock-label-tooltip-label={labelTooltip?.label}
+      data-icon-size={entry.iconSize ?? "default"}
+      data-node-state={resolvedEntry.dockNodeState}
+      data-popup-active={currentPopup ? "true" : undefined}
+      data-presence={presence}
+      data-section-id={entry.sectionId}
+      data-wallpaper-tone={wallpaperTone}
+      onBlur={(event) =>
+        handleEntryBlur(event, entry.id, hasHoverPanel, labelTooltip, overlay)
+      }
+      onFocus={(event) => {
+        if (hasHoverPanel) {
+          overlay.showHoverPanel(entry.id, anchorKey, event.currentTarget);
+          return;
+        }
+        if (labelTooltip) {
+          overlay.showLabelTooltip(
+            labelTooltip,
+            anchorKey,
+            event.currentTarget
+          );
+        }
+      }}
+      onPointerEnter={() => {
+        if (hasHoverPanel) {
+          overlay.scheduleHoverPanelAfterRest(entry.id, anchorKey);
+          return;
+        }
+        if (labelTooltip) {
+          overlay.scheduleLabelTooltipAfterRest(labelTooltip, anchorKey);
+        }
+      }}
+      onPointerLeave={(event) =>
+        handleEntryPointerLeave(
+          event,
+          anchorKey,
+          entry.id,
+          hasHoverPanel,
+          labelTooltip,
+          overlay
+        )
+      }
+    >
+      <button
+        aria-expanded={currentPopup ? true : undefined}
+        aria-haspopup={
+          clickResolution.kind === "open-popup" ? "dialog" : undefined
+        }
+        aria-label={launchLabel}
+        aria-disabled={clickResolution.kind === "blocked" ? true : undefined}
+        className="desktop-dock__btn"
+        data-interactive={clickResolution.kind === "blocked" ? "false" : "true"}
+        data-dock-hover-panel-trigger={hasHoverPanel ? "true" : undefined}
+        type="button"
+        onPointerDown={(event) => {
+          if (
+            event.button !== 0 ||
+            clickResolution.kind === "blocked" ||
+            isDockEntryClickThrottled(anchorKey)
+          ) {
+            return;
+          }
+          beginDockIconInteraction(anchorKey);
+        }}
+        onClick={(event) => {
+          if (
+            clickResolution.kind === "blocked" ||
+            isDockEntryClickThrottled(anchorKey)
+          ) {
+            return;
+          }
+          claimDockEntryClick(anchorKey);
+          onActivate({
+            anchorKey,
+            clickResolution,
+            currentPopup,
+            instanceMode,
+            resolvedEntry,
+            triggerRect:
+              clickResolution.kind === "open-popup"
+                ? event.currentTarget.getBoundingClientRect()
+                : null
+          });
+        }}
+        onContextMenu={(event) => {
+          if (
+            clickResolution.kind === "blocked" ||
+            !dockEntryHasContextMenu(entry, resolvedEntry)
+          ) {
+            return;
+          }
+          event.preventDefault();
+          onOpenContextMenu({
+            anchorKey,
+            resolvedEntry,
+            triggerRect: event.currentTarget.getBoundingClientRect()
+          });
+        }}
+      >
+        <span
+          className="desktop-dock__icon-shell"
+          data-desktop-dock-icon-shell="true"
+          data-entry-state={entry.state?.kind ?? "enabled"}
+          aria-hidden
+        >
+          <span className="desktop-dock__icon-content">{entry.icon}</span>
+          {renderDockBadge(entry, resolvedEntry.matchedNodes.length)}
+        </span>
+      </button>
+    </span>
+  );
+}
+
+export function dockEntryHasHoverPanel(entry: WorkbenchHostDockEntry): boolean {
+  return (
+    Boolean(entry.state?.reason?.trim()) ||
+    (entry.hoverActions?.length ?? 0) > 0
+  );
+}
+
+function dockEntryHasContextMenu(
+  entry: WorkbenchHostDockEntry,
+  resolvedEntry: ResolvedWorkbenchHostDockEntry
+): boolean {
+  if (resolvedEntry.matchedNodes.length > 0 || entry.dockRetention) {
+    return true;
+  }
+  return entry.clickActionId === undefined;
+}
+
+function renderDockBadge(
+  entry: WorkbenchHostDockEntry,
+  matchedNodeCount: number
+) {
+  const badge =
+    entry.badge ??
+    (matchedNodeCount > 1
+      ? ({ kind: "count", value: matchedNodeCount } as const)
+      : null);
+  if (!badge) {
+    return null;
+  }
+  if (badge.kind === "count") {
+    return <span className="desktop-dock__count-badge">{badge.value}</span>;
+  }
+  if (badge.kind === "custom") {
+    return <span className="desktop-dock__custom-badge">{badge.content}</span>;
+  }
+  return (
+    <span className="desktop-dock__status-badge" data-status={badge.status} />
+  );
+}
+
+function handleEntryBlur(
+  event: ReactFocusEvent<HTMLSpanElement>,
+  entryId: string,
+  hasHoverPanel: boolean,
+  labelTooltip: { key: string; label: string } | null,
+  overlay: WorkbenchHostDockEntryOverlayController
+) {
+  if (hasHoverPanel && !event.currentTarget.contains(event.relatedTarget)) {
+    overlay.closeHoverPanelImmediate(entryId);
+  }
+  if (labelTooltip && !event.currentTarget.contains(event.relatedTarget)) {
+    overlay.closeLabelTooltipImmediate(labelTooltip.key);
+  }
+}
+
+function handleEntryPointerLeave(
+  event: ReactPointerEvent<HTMLSpanElement>,
+  anchorKey: string,
+  entryId: string,
+  hasHoverPanel: boolean,
+  labelTooltip: { key: string; label: string } | null,
+  overlay: WorkbenchHostDockEntryOverlayController
+) {
+  if (!hasHoverPanel) {
+    if (labelTooltip) {
+      overlay.clearLabelTooltipOpenTimer();
+      overlay.closeLabelTooltipImmediate(labelTooltip.key);
+      const relatedTarget = event.relatedTarget;
+      if (
+        relatedTarget instanceof Node &&
+        overlay.dockMeasureRef.current?.contains(relatedTarget)
+      ) {
+        overlay.scheduleLabelTooltipAtPointAfterRest(
+          event.clientX,
+          event.clientY
+        );
+      }
+    }
+    return;
+  }
+  const relatedTarget = event.relatedTarget;
+  if (
+    relatedTarget instanceof Node &&
+    overlay.hoverPanelRef.current?.contains(relatedTarget)
+  ) {
+    return;
+  }
+  if (
+    relatedTarget instanceof Node &&
+    overlay.dockMeasureRef.current?.contains(relatedTarget)
+  ) {
+    overlay.scheduleHoverPanelAtPointAfterRest(event.clientX, event.clientY);
+    return;
+  }
+  overlay.clearHoverPanelRestTargetForAnchor(anchorKey);
+  overlay.clearHoverPanelOpenTimer();
+  overlay.closeHoverPanelImmediate(entryId);
+  overlay.handleDockPointerLeave();
+}

--- a/packages/workbench/surface/src/host/WorkbenchHostDockMinimizedSlot.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDockMinimizedSlot.tsx
@@ -1,0 +1,283 @@
+import type { KeyboardEvent as ReactKeyboardEvent, RefObject } from "react";
+import type { WorkbenchDockPreviewCache } from "../react/dockPreviewCache.ts";
+import {
+  minimizedDockPreviewFreezeKey,
+  WorkbenchHostDockMinimizedNodePreview
+} from "./WorkbenchHostDockMinimizedPreview.tsx";
+import type { WorkbenchHostDockPresence } from "./dockPresence.ts";
+import type {
+  WorkbenchMinimizedDockNode,
+  WorkbenchMinimizedDockSlot
+} from "./minimizedDockSlots.ts";
+import { dockLabelTooltipTarget } from "./useWorkbenchHostDockOverlays.ts";
+import type { WorkbenchDockWallpaperTone } from "./useWorkbenchHostDockWallpaperTones.ts";
+import type { WorkbenchDockPreviewContent } from "./types.ts";
+
+interface WorkbenchHostDockMinimizedOverlayController {
+  clearLabelTooltipOpenTimer: () => void;
+  closeLabelTooltipImmediate: (targetKey?: string) => void;
+  dockMeasureRef: RefObject<HTMLDivElement | null>;
+  scheduleLabelTooltipAfterRest: (
+    target: { key: string; label: string },
+    anchorKey: string
+  ) => void;
+  scheduleLabelTooltipAtPointAfterRest: (
+    clientX: number,
+    clientY: number
+  ) => void;
+  showLabelTooltip: (
+    target: { key: string; label: string },
+    anchorKey: string,
+    anchorElement: HTMLElement
+  ) => void;
+}
+
+export function WorkbenchHostDockMinimizedSlot({
+  activeStackPopup,
+  capturePreview,
+  collapsing,
+  dockPreviewCache,
+  isPendingNode,
+  minimizedWindowsLabel,
+  nodeLaunchLabel,
+  onBeginStackInteraction,
+  onNodeActivate,
+  onNodePointerDown,
+  onToggleStackPopup,
+  overlay,
+  presence,
+  promotedNodeId,
+  providePreviewForNode,
+  registerDockSlot,
+  slot,
+  stackDispatching,
+  wallpaperTone,
+  workspaceId
+}: {
+  activeStackPopup: boolean;
+  capturePreview: (
+    node: WorkbenchMinimizedDockNode
+  ) => Promise<string | null> | string | null;
+  collapsing: boolean;
+  dockPreviewCache?: WorkbenchDockPreviewCache;
+  isPendingNode: (nodeId: string) => boolean;
+  minimizedWindowsLabel: string;
+  nodeLaunchLabel: (title: string) => string;
+  onBeginStackInteraction: () => void;
+  onNodeActivate: (nodeId: string, anchorKey: string) => void;
+  onNodePointerDown: (nodeId: string, anchorKey: string) => void;
+  onToggleStackPopup: (anchorRect: {
+    dockRight: number;
+    height: number;
+    left: number;
+    top: number;
+    width: number;
+  }) => void;
+  overlay: WorkbenchHostDockMinimizedOverlayController;
+  presence: WorkbenchHostDockPresence;
+  promotedNodeId: string | null;
+  providePreviewForNode: (
+    node: WorkbenchMinimizedDockNode
+  ) =>
+    | ((node: WorkbenchMinimizedDockNode) => WorkbenchDockPreviewContent | null)
+    | undefined;
+  registerDockSlot: (
+    anchorKey: string
+  ) => (element: HTMLElement | null) => void;
+  slot: WorkbenchMinimizedDockSlot;
+  stackDispatching: boolean;
+  wallpaperTone?: WorkbenchDockWallpaperTone;
+  workspaceId: string;
+}) {
+  if (slot.kind === "stack") {
+    const labelTooltip = dockLabelTooltipTarget(
+      `minimized-stack:${slot.anchorKey}`,
+      minimizedWindowsLabel
+    );
+    return (
+      <span
+        ref={registerDockSlot(slot.anchorKey)}
+        className="desktop-dock__slot desktop-dock__slot--minimized"
+        data-desktop-dock-anchor-key={slot.anchorKey}
+        data-desktop-dock-slot="true"
+        data-dock-label-tooltip-key={labelTooltip.key}
+        data-dock-label-tooltip-label={labelTooltip.label}
+        data-node-state="minimized"
+        data-popup-active={activeStackPopup ? true : undefined}
+        data-presence={presence}
+        data-section-id="minimized"
+        data-stack-dispatching={stackDispatching ? "true" : undefined}
+        data-wallpaper-tone={wallpaperTone}
+        {...minimizedTooltipHandlers(labelTooltip, slot.anchorKey, overlay)}
+      >
+        <span
+          aria-expanded={activeStackPopup ? true : undefined}
+          aria-haspopup="dialog"
+          aria-label={minimizedWindowsLabel}
+          className="desktop-dock__btn desktop-dock__minimized-btn"
+          data-interactive="true"
+          role="button"
+          tabIndex={0}
+          onKeyDown={activateDockButtonFromKeyboard}
+          onPointerDown={(event) => {
+            if (event.button === 0) {
+              onBeginStackInteraction();
+            }
+          }}
+          onClick={(event) => {
+            const rect = event.currentTarget.getBoundingClientRect();
+            const dockRect =
+              overlay.dockMeasureRef.current?.getBoundingClientRect();
+            onToggleStackPopup({
+              dockRight: Math.max(rect.right, dockRect?.right ?? rect.right),
+              height: rect.height,
+              left: rect.left,
+              top: rect.top,
+              width: rect.width
+            });
+          }}
+        >
+          <span
+            className="desktop-dock__minimized-stack-icon"
+            data-desktop-dock-icon-shell="true"
+            data-stack-folded={slot.nodes.length > 1 ? "true" : undefined}
+            aria-hidden
+          >
+            {Array.from(
+              {
+                length:
+                  slot.nodes.length > 1 ? 3 : Math.min(slot.nodes.length, 1)
+              },
+              (_, index) => {
+                const node = slot.nodes[index];
+                if (index === 0 && node) {
+                  return (
+                    <WorkbenchHostDockMinimizedNodePreview
+                      key={minimizedDockPreviewFreezeKey(node)}
+                      capturePreview={capturePreview}
+                      className={`desktop-dock__minimized-stack-layer desktop-dock__minimized-stack-layer--${index}`}
+                      dockPreviewCache={dockPreviewCache}
+                      node={node}
+                      providePreview={providePreviewForNode(node)}
+                      workspaceId={workspaceId}
+                    />
+                  );
+                }
+                return (
+                  <span
+                    key={`${slot.anchorKey}-stack-back-${index}`}
+                    aria-hidden="true"
+                    className={`desktop-dock__minimized-preview desktop-dock__minimized-stack-layer desktop-dock__minimized-stack-layer--${index} desktop-dock__minimized-stack-layer-back`}
+                  />
+                );
+              }
+            )}
+            <span className="desktop-dock__count-badge">
+              {slot.nodes.length}
+            </span>
+          </span>
+        </span>
+      </span>
+    );
+  }
+
+  const { node } = slot;
+  const pending = isPendingNode(node.id);
+  const labelTooltip = dockLabelTooltipTarget(
+    `minimized-node:${node.id}`,
+    node.title
+  );
+  return (
+    <span
+      ref={registerDockSlot(slot.anchorKey)}
+      className="desktop-dock__slot desktop-dock__slot--minimized"
+      data-collapsing={collapsing ? "true" : undefined}
+      data-desktop-dock-anchor-key={slot.anchorKey}
+      data-desktop-dock-slot="true"
+      data-dock-label-tooltip-key={labelTooltip.key}
+      data-dock-label-tooltip-label={labelTooltip.label}
+      data-node-state="minimized"
+      data-pending-minimize={pending ? "true" : undefined}
+      data-presence={presence}
+      data-promoted-from-stack={promotedNodeId === node.id ? "true" : undefined}
+      data-section-id="minimized"
+      data-wallpaper-tone={wallpaperTone}
+      {...minimizedTooltipHandlers(labelTooltip, slot.anchorKey, overlay)}
+    >
+      <span
+        aria-label={nodeLaunchLabel(node.title)}
+        aria-disabled={pending ? true : undefined}
+        className="desktop-dock__btn desktop-dock__minimized-btn"
+        data-interactive={pending ? "false" : "true"}
+        role="button"
+        tabIndex={pending ? -1 : 0}
+        onKeyDown={(event) => activateDockButtonFromKeyboard(event, pending)}
+        onPointerDown={(event) => {
+          if (event.button === 0 && !pending) {
+            onNodePointerDown(node.id, slot.anchorKey);
+          }
+        }}
+        onClick={() => {
+          if (!pending) {
+            onNodeActivate(node.id, slot.anchorKey);
+          }
+        }}
+      >
+        <WorkbenchHostDockMinimizedNodePreview
+          key={minimizedDockPreviewFreezeKey(node)}
+          capturePreview={pending ? undefined : capturePreview}
+          deferPreview={pending}
+          dockPreviewCache={pending ? undefined : dockPreviewCache}
+          node={node}
+          providePreview={pending ? undefined : providePreviewForNode(node)}
+          workspaceId={workspaceId}
+        />
+      </span>
+    </span>
+  );
+}
+
+function activateDockButtonFromKeyboard(
+  event: ReactKeyboardEvent<HTMLElement>,
+  disabled = false
+) {
+  if (disabled || (event.key !== "Enter" && event.key !== " ")) {
+    return;
+  }
+  event.preventDefault();
+  event.currentTarget.click();
+}
+
+function minimizedTooltipHandlers(
+  target: { key: string; label: string },
+  anchorKey: string,
+  overlay: WorkbenchHostDockMinimizedOverlayController
+) {
+  return {
+    onBlur: (event: React.FocusEvent<HTMLSpanElement>) => {
+      if (!event.currentTarget.contains(event.relatedTarget)) {
+        overlay.closeLabelTooltipImmediate(target.key);
+      }
+    },
+    onFocus: (event: React.FocusEvent<HTMLSpanElement>) => {
+      overlay.showLabelTooltip(target, anchorKey, event.currentTarget);
+    },
+    onPointerEnter: () => {
+      overlay.scheduleLabelTooltipAfterRest(target, anchorKey);
+    },
+    onPointerLeave: (event: React.PointerEvent<HTMLSpanElement>) => {
+      overlay.clearLabelTooltipOpenTimer();
+      overlay.closeLabelTooltipImmediate(target.key);
+      const relatedTarget = event.relatedTarget;
+      if (
+        relatedTarget instanceof Node &&
+        overlay.dockMeasureRef.current?.contains(relatedTarget)
+      ) {
+        overlay.scheduleLabelTooltipAtPointAfterRest(
+          event.clientX,
+          event.clientY
+        );
+      }
+    }
+  };
+}

--- a/packages/workbench/surface/src/host/WorkbenchHostDockOverlayPresentation.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDockOverlayPresentation.tsx
@@ -1,0 +1,229 @@
+import {
+  useRef,
+  type CSSProperties,
+  type Dispatch,
+  type FocusEvent as ReactFocusEvent,
+  type PointerEvent as ReactPointerEvent,
+  type RefObject,
+  type SetStateAction
+} from "react";
+import { Button } from "@tutti-os/ui-system";
+import { dockActionKey } from "./dockActions.ts";
+import type {
+  WorkbenchHostDockHoverPanelState,
+  WorkbenchHostDockLabelTooltipState
+} from "./useWorkbenchHostDockOverlays.ts";
+import type {
+  WorkbenchHostDockEntry,
+  WorkbenchHostHandle,
+  WorkbenchHostProps
+} from "./types.ts";
+
+export function WorkbenchHostDockLabelTooltip({
+  placement,
+  state
+}: {
+  placement: WorkbenchHostProps["dockPlacement"];
+  state: WorkbenchHostDockLabelTooltipState;
+}) {
+  return (
+    <div
+      className="desktop-dock__label-tooltip"
+      data-dock-placement={placement}
+      role="tooltip"
+      style={
+        {
+          "--desktop-dock-label-tooltip-anchor-height": `${state.anchorRect.height}px`,
+          "--desktop-dock-label-tooltip-anchor-left": `${state.anchorRect.left}px`,
+          "--desktop-dock-label-tooltip-anchor-top": `${state.anchorRect.top}px`,
+          "--desktop-dock-label-tooltip-anchor-width": `${state.anchorRect.width}px`
+        } as WorkbenchHostDockLabelTooltipStyle
+      }
+    >
+      {state.label}
+    </div>
+  );
+}
+
+export function WorkbenchHostDockHoverPanel({
+  entry,
+  host,
+  hoverPanelRef,
+  onBlur,
+  onDockEntryAction,
+  onFocus,
+  onPointerEnter,
+  onPointerLeave,
+  pendingActionKeys,
+  placement,
+  setPendingActionKeys,
+  state
+}: {
+  entry: WorkbenchHostDockEntry | null;
+  host: WorkbenchHostHandle;
+  hoverPanelRef: RefObject<HTMLDivElement | null>;
+  onDockEntryAction?: (input: {
+    actionId: string;
+    entryId: string;
+    host: WorkbenchHostHandle;
+  }) => Promise<void> | void;
+  onBlur?: (event: ReactFocusEvent<HTMLDivElement>) => void;
+  onFocus?: () => void;
+  onPointerEnter?: () => void;
+  onPointerLeave?: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  pendingActionKeys: Set<string>;
+  placement: WorkbenchHostProps["dockPlacement"];
+  setPendingActionKeys: Dispatch<SetStateAction<Set<string>>>;
+  state: WorkbenchHostDockHoverPanelState;
+}) {
+  const lastPointerActionAtRef = useRef<Map<string, number>>(new Map());
+  if (!entry) {
+    return null;
+  }
+  const hoverPanelEntry = entry;
+
+  const runHoverAction = (
+    actionKey: string,
+    actionId: string,
+    disabled: boolean
+  ): void => {
+    if (disabled || pendingActionKeys.has(actionKey)) {
+      return;
+    }
+    setPendingActionKeys((current) => {
+      const next = new Set(current);
+      next.add(actionKey);
+      return next;
+    });
+    void (async () => {
+      try {
+        await onDockEntryAction?.({
+          actionId,
+          entryId: hoverPanelEntry.id,
+          host
+        });
+      } catch {
+        // Keep dock action failures contained.
+      } finally {
+        setPendingActionKeys((current) => {
+          if (!current.has(actionKey)) {
+            return current;
+          }
+          const next = new Set(current);
+          next.delete(actionKey);
+          return next;
+        });
+      }
+    })();
+  };
+
+  return (
+    <div
+      ref={hoverPanelRef}
+      className="desktop-dock__hover-panel"
+      data-dock-placement={placement}
+      role="group"
+      aria-label={entry.label}
+      onBlur={onBlur}
+      onFocus={onFocus}
+      onPointerEnter={onPointerEnter}
+      onPointerLeave={onPointerLeave}
+      style={
+        {
+          "--desktop-dock-hover-panel-anchor-height": `${state.anchorRect.height}px`,
+          "--desktop-dock-hover-panel-anchor-left": `${state.anchorRect.left}px`,
+          "--desktop-dock-hover-panel-anchor-top": `${state.anchorRect.top}px`,
+          "--desktop-dock-hover-panel-anchor-width": `${state.anchorRect.width}px`
+        } as WorkbenchHostDockHoverPanelStyle
+      }
+    >
+      <div className="desktop-dock__hover-panel-title">{entry.label}</div>
+      {entry.state?.reason ? (
+        <div className="desktop-dock__hover-panel-description">
+          {stripDockDescriptionTerminalPunctuation(entry.state.reason)}
+        </div>
+      ) : null}
+      {entry.hoverActions?.length ? (
+        <div className="desktop-dock__hover-actions">
+          {entry.hoverActions.map((action) => {
+            const actionKey = dockActionKey(entry.id, action.id);
+            const isLocallyPending = pendingActionKeys.has(actionKey);
+            const isPending =
+              isLocallyPending ||
+              (action.disabled === true && action.pendingLabel !== undefined);
+            return (
+              <Button
+                key={action.id}
+                aria-busy={isPending ? true : undefined}
+                className="desktop-dock__hover-action"
+                disabled={action.disabled || isLocallyPending}
+                type="button"
+                onPointerDown={(event) => {
+                  // Pointer activation runs before a re-render can tear down the
+                  // hover panel. The trailing synthetic click is deduplicated.
+                  if (event.button !== 0) {
+                    return;
+                  }
+                  event.preventDefault();
+                  event.stopPropagation();
+                  lastPointerActionAtRef.current.set(
+                    actionKey,
+                    performance.now()
+                  );
+                  runHoverAction(
+                    actionKey,
+                    action.id,
+                    action.disabled === true
+                  );
+                }}
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  const lastPointerAt =
+                    lastPointerActionAtRef.current.get(actionKey);
+                  if (
+                    lastPointerAt !== undefined &&
+                    performance.now() - lastPointerAt < 700
+                  ) {
+                    return;
+                  }
+                  runHoverAction(
+                    actionKey,
+                    action.id,
+                    action.disabled === true
+                  );
+                }}
+              >
+                {isPending
+                  ? (action.pendingLabel ?? action.label)
+                  : action.label}
+              </Button>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function stripDockDescriptionTerminalPunctuation(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.endsWith("...") || trimmed.endsWith("…")) {
+    return trimmed;
+  }
+  return trimmed.replace(/[。．.]+$/u, "");
+}
+
+interface WorkbenchHostDockHoverPanelStyle extends CSSProperties {
+  "--desktop-dock-hover-panel-anchor-height"?: string;
+  "--desktop-dock-hover-panel-anchor-left"?: string;
+  "--desktop-dock-hover-panel-anchor-top"?: string;
+  "--desktop-dock-hover-panel-anchor-width"?: string;
+}
+
+interface WorkbenchHostDockLabelTooltipStyle extends CSSProperties {
+  "--desktop-dock-label-tooltip-anchor-height"?: string;
+  "--desktop-dock-label-tooltip-anchor-left"?: string;
+  "--desktop-dock-label-tooltip-anchor-top"?: string;
+  "--desktop-dock-label-tooltip-anchor-width"?: string;
+}

--- a/packages/workbench/surface/src/host/WorkbenchHostDockPopups.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDockPopups.tsx
@@ -1,0 +1,543 @@
+import type { WorkbenchDockContext } from "../react/types.ts";
+import type {
+  WorkbenchDockPreviewCache,
+  WorkbenchDockPreviewCacheKey
+} from "../react/dockPreviewCache.ts";
+import {
+  canCreateNewWindow,
+  canCreateNewWindowInDockPopup,
+  resolveWorkbenchDockEntryClick,
+  type ResolvedWorkbenchHostDockEntry
+} from "./dockEntries.ts";
+import { dockActionKey } from "./dockActions.ts";
+import { logWorkbenchDockDebug } from "./dockDiagnostics.ts";
+import { resolveDockEntryInstanceMode } from "./dockItems.ts";
+import { readWorkbenchHostExternalState } from "./externalState.ts";
+import {
+  resolveWorkbenchMinimizedDockRestoreIntent,
+  type WorkbenchMinimizedDockRestoreIntent
+} from "./minimizedDockRestoreIntent.ts";
+import type {
+  WorkbenchMinimizedDockNode,
+  WorkbenchMinimizedDockSlot
+} from "./minimizedDockSlots.ts";
+import {
+  readWorkbenchMinimizedDockPreviewImage,
+  resolveWorkbenchMinimizedDockPreviewImage,
+  resolveWorkbenchMinimizedDockPreviewRevision
+} from "./useWorkbenchMinimizedDockPreview.ts";
+import {
+  WorkbenchHostDockPopup,
+  workbenchHostDockPopupPreviewViewport,
+  type WorkbenchHostDockPopupAnchorRect,
+  type WorkbenchHostDockPopupState
+} from "./WorkbenchHostDockPopup.tsx";
+import type {
+  WorkbenchDockPreviewContent,
+  WorkbenchHostExternalStateSource,
+  WorkbenchHostHandle,
+  WorkbenchHostNodeData,
+  WorkbenchHostNodeDefinition,
+  WorkbenchHostProps
+} from "./types.ts";
+import type { createWorkbenchHostI18nRuntime } from "./workbenchHostI18n.ts";
+
+type WorkbenchMinimizedDockStackPopupCardRestoreIntent = Extract<
+  WorkbenchMinimizedDockRestoreIntent,
+  { kind: "stack-popup-card" }
+>;
+
+const dockPopupNewWindowLaunchSource = "dock-popup-new-window";
+
+export function WorkbenchHostDockPopups({
+  activeMinimizedStackPopup,
+  activePopup,
+  captureMinimizedNodePreview,
+  captureNodePreviewImage,
+  closePopup,
+  context,
+  debugDiagnostics,
+  dockPlacement,
+  dockPreviewCache,
+  externalStateSource,
+  host,
+  i18n,
+  minimizedDockSlots,
+  minimizedNodeIDs,
+  nodeDefinitions,
+  onDockEntryClick,
+  onMissionControlRequestOpen,
+  pendingActionKeys,
+  provideMinimizedNodePreview,
+  resolvedEntries,
+  runDockEntryAction,
+  runDockMinimizedStackLaunch,
+  workspaceId
+}: {
+  activeMinimizedStackPopup: WorkbenchHostDockPopupAnchorRect | null;
+  activePopup: WorkbenchHostDockPopupState | null;
+  captureMinimizedNodePreview: (
+    node: WorkbenchMinimizedDockNode
+  ) => Promise<string | null> | string | null;
+  captureNodePreviewImage?: WorkbenchHostProps["captureNodePreviewImage"];
+  closePopup: () => void;
+  context: WorkbenchDockContext<WorkbenchHostNodeData>;
+  debugDiagnostics?: WorkbenchHostProps["debugDiagnostics"];
+  dockPlacement: NonNullable<WorkbenchHostProps["dockPlacement"]>;
+  dockPreviewCache?: WorkbenchDockPreviewCache;
+  externalStateSource?: WorkbenchHostExternalStateSource;
+  host: WorkbenchHostHandle;
+  i18n: ReturnType<typeof createWorkbenchHostI18nRuntime>;
+  minimizedDockSlots: readonly WorkbenchMinimizedDockSlot[];
+  minimizedNodeIDs: ReadonlySet<string>;
+  nodeDefinitions: ReadonlyMap<string, WorkbenchHostNodeDefinition>;
+  onDockEntryClick?: (input: {
+    entryId: string;
+    host: WorkbenchHostHandle;
+    nodeId?: string;
+  }) => Promise<void> | void;
+  onMissionControlRequestOpen?: WorkbenchHostProps["onMissionControlRequestOpen"];
+  pendingActionKeys: ReadonlySet<string>;
+  provideMinimizedNodePreview: (
+    node: WorkbenchMinimizedDockNode
+  ) => WorkbenchDockPreviewContent | null;
+  resolvedEntries: readonly ResolvedWorkbenchHostDockEntry[];
+  runDockEntryAction: (entryId: string, actionId: string) => void;
+  runDockMinimizedStackLaunch: (
+    intent: WorkbenchMinimizedDockStackPopupCardRestoreIntent,
+    launch: (intent: WorkbenchMinimizedDockStackPopupCardRestoreIntent) => void
+  ) => void;
+  workspaceId: string;
+}) {
+  const popupEntry =
+    activePopup === null
+      ? null
+      : (resolvedEntries.find(
+          (entry) => entry.entry.id === activePopup.entryId
+        ) ?? null);
+  const activeMinimizedStackSlot =
+    activeMinimizedStackPopup === null
+      ? null
+      : (minimizedDockSlots.find(
+          (
+            slot
+          ): slot is Extract<WorkbenchMinimizedDockSlot, { kind: "stack" }> =>
+            slot.kind === "stack"
+        ) ?? null);
+  const openDockContextMenuNodeIds =
+    popupEntry?.matchedNodes.map((node) => node.id) ?? [];
+  const dockContextMenuInstanceMode =
+    popupEntry === null
+      ? undefined
+      : resolveDockEntryInstanceMode(popupEntry.entry, nodeDefinitions);
+  const canShowAllWindowsFromDockContextMenu =
+    onMissionControlRequestOpen !== undefined &&
+    dockContextMenuInstanceMode === "multi" &&
+    openDockContextMenuNodeIds.length > 1;
+  const fullscreenNodeFromDockContextMenu =
+    popupEntry === null
+      ? null
+      : resolveDockContextMenuFullscreenNode({
+          focusedNodeId: context.focusedNodeId,
+          minimizedNodeIDs,
+          nodeDefinitions,
+          nodes: popupEntry.matchedNodes
+        });
+  const canOpenFromDockContextMenu =
+    popupEntry !== null &&
+    popupEntry.matchedNodes.length === 0 &&
+    resolveWorkbenchDockEntryClick({
+      entry: popupEntry.entry,
+      instanceMode: dockContextMenuInstanceMode,
+      matchedNodes: popupEntry.matchedNodes
+    }).kind === "launch";
+
+  return (
+    <>
+      {popupEntry && activePopup ? (
+        <WorkbenchHostDockPopup
+          anchorRect={activePopup.anchorRect}
+          placement={dockPlacement}
+          canEnterFullscreen={fullscreenNodeFromDockContextMenu !== null}
+          canShowAllWindows={canShowAllWindowsFromDockContextMenu}
+          debugDiagnostics={debugDiagnostics}
+          dockRetention={
+            popupEntry.entry.dockRetention
+              ? {
+                  checked: popupEntry.entry.dockRetention.retained,
+                  disabled:
+                    popupEntry.entry.dockRetention.disabled === true ||
+                    pendingActionKeys.has(
+                      dockActionKey(
+                        popupEntry.entry.id,
+                        popupEntry.entry.dockRetention.actionId
+                      )
+                    ),
+                  label: i18n.t(
+                    popupEntry.entry.dockRetention.retained
+                      ? "dockContextMenu.removeFromDock"
+                      : "dockContextMenu.keepInDock"
+                  ),
+                  pendingLabel: pendingActionKeys.has(
+                    dockActionKey(
+                      popupEntry.entry.id,
+                      popupEntry.entry.dockRetention.actionId
+                    )
+                  )
+                    ? popupEntry.entry.dockRetention.pendingLabel
+                    : undefined
+                }
+              : null
+          }
+          capturePreview={
+            popupEntry.entry.capturePopupItemPreview || captureNodePreviewImage
+              ? async (item) => {
+                  const previewImageUrl = await Promise.resolve(
+                    popupEntry.entry.capturePopupItemPreview
+                      ? popupEntry.entry.capturePopupItemPreview(item)
+                      : (captureNodePreviewImage?.(item.node) ?? null)
+                  ).catch(() => null);
+                  return previewImageUrl
+                    ? {
+                        kind: "image",
+                        revision: item.previewRevision ?? undefined,
+                        src: previewImageUrl
+                      }
+                    : null;
+                }
+              : undefined
+          }
+          dockPreviewCache={dockPreviewCache}
+          items={popupEntry.matchedNodes
+            .map((node) => {
+              const externalState = readWorkbenchHostExternalState({
+                externalStateSource,
+                node,
+                workspaceId
+              });
+              const item = {
+                externalNodeState: externalState.externalNodeState,
+                externalWorkspaceState: externalState.externalWorkspaceState,
+                host,
+                isFocused: context.focusedNodeId === node.id,
+                isMinimized: minimizedNodeIDs.has(node.id),
+                node,
+                previewViewport: workbenchHostDockPopupPreviewViewport
+              };
+              const descriptor =
+                popupEntry.entry.resolvePopupItem?.(item) ?? {};
+              const descriptorPreview =
+                descriptor.preview ??
+                popupEntry.entry.providePopupItemPreview?.(item) ??
+                null;
+              return {
+                ...item,
+                preview: descriptorPreview,
+                previewRevision:
+                  previewRevision(descriptorPreview) ??
+                  descriptor.revision ??
+                  null,
+                subtitle:
+                  descriptor.subtitle === undefined
+                    ? (node.data.instanceKey ?? node.data.instanceId)
+                    : descriptor.subtitle,
+                title:
+                  descriptor.title === undefined
+                    ? node.title
+                    : descriptor.title?.trim() || null
+              };
+            })
+            .sort((left, right) => {
+              if (left.isFocused !== right.isFocused) {
+                return left.isFocused ? -1 : 1;
+              }
+              return left.node.id.localeCompare(right.node.id);
+            })}
+          label={popupEntry.entry.label}
+          labelMode={popupEntry.entry.popupCardLabelMode}
+          newWindowLabel={i18n.t("newWindow")}
+          closeWindowLabel={(title) => i18n.t("closeWindow", { title })}
+          fullscreenLabel={i18n.t("dockContextMenu.fullscreen")}
+          hideLabel={i18n.t("dockContextMenu.hide")}
+          onClose={() => {
+            logWorkbenchDockDebug(
+              "dock.popup.close_requested",
+              debugDiagnostics,
+              {
+                entryId: popupEntry.entry.id,
+                itemCount: popupEntry.matchedNodes.length,
+                workspaceId
+              }
+            );
+            closePopup();
+          }}
+          onCloseNode={(nodeId) => {
+            host.requestNodeClose(nodeId);
+            const hasRemainingItems = popupEntry.matchedNodes.some(
+              (node) => node.id !== nodeId
+            );
+            if (!hasRemainingItems) {
+              closePopup();
+            }
+          }}
+          onCreateNew={() => {
+            closePopup();
+            context.genie.launchNodeFromAnchor(
+              popupEntry.anchorKey,
+              popupEntry.entry.id,
+              () =>
+                host.launchNode({
+                  dockEntryId: popupEntry.entry.id,
+                  launchSource: dockPopupNewWindowLaunchSource,
+                  payload:
+                    popupEntry.entry.newWindowLaunchPayload ??
+                    popupEntry.entry.launchPayload,
+                  reason: "dock",
+                  typeId: popupEntry.entry.typeId
+                })
+            );
+          }}
+          onEnterFullscreen={() => {
+            if (!fullscreenNodeFromDockContextMenu) {
+              return;
+            }
+            context.controller.commands.enterFullscreen(
+              fullscreenNodeFromDockContextMenu.id
+            );
+            closePopup();
+          }}
+          onHide={() => {
+            for (const node of popupEntry.matchedNodes) {
+              if (!minimizedNodeIDs.has(node.id)) {
+                host.minimizeNode(node.id);
+              }
+            }
+            closePopup();
+          }}
+          onRunDockRetentionAction={
+            popupEntry.entry.dockRetention
+              ? () => {
+                  const dockRetention = popupEntry.entry.dockRetention;
+                  if (!dockRetention || dockRetention.disabled === true) {
+                    return;
+                  }
+                  runDockEntryAction(
+                    popupEntry.entry.id,
+                    dockRetention.actionId
+                  );
+                  closePopup();
+                }
+              : undefined
+          }
+          onSelectNode={(nodeId) => {
+            closePopup();
+            void (async () => {
+              try {
+                await onDockEntryClick?.({
+                  entryId: popupEntry.entry.id,
+                  host,
+                  nodeId
+                });
+              } catch {
+                // Keep dock click failures contained.
+              }
+            })();
+            context.genie.launchNodeFromAnchor(
+              popupEntry.anchorKey,
+              nodeId,
+              () => {
+                host.focusNode(nodeId);
+              }
+            );
+          }}
+          onShowAllWindows={() => {
+            closePopup();
+            for (const node of popupEntry.matchedNodes) {
+              if (minimizedNodeIDs.has(node.id)) {
+                context.controller.commands.restoreNode(node.id);
+              }
+            }
+            window.requestAnimationFrame(() => {
+              onMissionControlRequestOpen?.({
+                nodeIds: openDockContextMenuNodeIds,
+                trigger: "dock-context-menu"
+              });
+            });
+          }}
+          onQuit={() => {
+            for (const node of popupEntry.matchedNodes) {
+              host.requestNodeClose(node.id);
+            }
+            closePopup();
+          }}
+          quitLabel={i18n.t("dockContextMenu.quit")}
+          showCreateNew={canCreateNewWindowInDockPopup(
+            popupEntry.entry,
+            dockContextMenuInstanceMode
+          )}
+          showCreateNewInContextMenu={canCreateNewWindow(
+            popupEntry.entry,
+            dockContextMenuInstanceMode
+          )}
+          showOpen={canOpenFromDockContextMenu}
+          showAllWindowsLabel={i18n.t("dockContextMenu.showAllWindows")}
+          resolveDockPreviewCacheKey={(node) =>
+            resolveDockPreviewCacheKey(workspaceId, node)
+          }
+          variant={
+            activePopup.kind === "context-menu" ? "context-menu" : "default"
+          }
+        />
+      ) : null}
+      {activeMinimizedStackSlot && activeMinimizedStackPopup ? (
+        <WorkbenchHostDockPopup
+          anchorRect={activeMinimizedStackPopup}
+          placement={dockPlacement}
+          debugDiagnostics={debugDiagnostics}
+          capturePreview={async (item) => {
+            const src = await resolveWorkbenchMinimizedDockPreviewImage({
+              capturePreview: () => captureMinimizedNodePreview(item.node),
+              dockPreviewCache,
+              node: item.node,
+              workspaceId
+            });
+            return src ? { kind: "image", src } : null;
+          }}
+          dockPreviewCache={dockPreviewCache}
+          items={activeMinimizedStackSlot.nodes.map((node) => {
+            const externalState = readWorkbenchHostExternalState({
+              externalStateSource,
+              node,
+              workspaceId
+            });
+            const minimizedDock = nodeDefinitions.get(node.data.typeId)?.window
+              ?.minimizedDock;
+            return {
+              externalNodeState: externalState.externalNodeState,
+              externalWorkspaceState: externalState.externalWorkspaceState,
+              host,
+              isFocused: context.focusedNodeId === node.id,
+              isMinimized: true,
+              node,
+              preview:
+                minimizedDock?.kind === "component"
+                  ? (provideMinimizedNodePreview(node) ?? null)
+                  : minimizedDock?.kind === "snapshot" &&
+                      minimizedDock.capturePreview
+                    ? null
+                    : (() => {
+                        const previewImageUrl =
+                          readWorkbenchMinimizedDockPreviewImage(node.id);
+                        return previewImageUrl
+                          ? ({ kind: "image", src: previewImageUrl } as const)
+                          : null;
+                      })(),
+              previewRevision:
+                resolveWorkbenchMinimizedDockPreviewRevision(node),
+              subtitle: node.data.instanceKey ?? node.data.instanceId,
+              title: node.title
+            };
+          })}
+          label={i18n.t("minimizedWindows")}
+          newWindowLabel={i18n.t("newWindow")}
+          closeWindowLabel={(title) => i18n.t("closeWindow", { title })}
+          onClose={() => {
+            logWorkbenchDockDebug(
+              "dock.popup.close_requested",
+              debugDiagnostics,
+              {
+                entryId: "minimized-stack",
+                itemCount: activeMinimizedStackSlot.nodes.length,
+                workspaceId
+              }
+            );
+            closePopup();
+          }}
+          onCloseNode={(nodeId) => {
+            host.requestNodeClose(nodeId);
+            const hasRemainingItems = activeMinimizedStackSlot.nodes.some(
+              (node) => node.id !== nodeId
+            );
+            if (!hasRemainingItems) {
+              closePopup();
+            }
+          }}
+          onCreateNew={() => undefined}
+          onSelectNode={(nodeId) => {
+            const restoreIntent = resolveWorkbenchMinimizedDockRestoreIntent({
+              nodeId,
+              slots: minimizedDockSlots,
+              source: {
+                kind: "stack-popup-card",
+                stackAnchorKey: activeMinimizedStackSlot.anchorKey
+              }
+            });
+            if (restoreIntent?.kind !== "stack-popup-card") {
+              return;
+            }
+            closePopup();
+            runDockMinimizedStackLaunch(restoreIntent, (intent) => {
+              context.genie.launchNodeFromAnchor(
+                intent.anchorKey,
+                intent.nodeId,
+                () => {
+                  host.focusNode(intent.nodeId);
+                }
+              );
+            });
+          }}
+          showCreateNew={false}
+          resolveDockPreviewCacheKey={(node) =>
+            resolveDockPreviewCacheKey(workspaceId, node)
+          }
+          variant="minimized-stack"
+        />
+      ) : null}
+    </>
+  );
+}
+
+function resolveDockContextMenuFullscreenNode({
+  focusedNodeId,
+  minimizedNodeIDs,
+  nodeDefinitions,
+  nodes
+}: {
+  focusedNodeId: string | null;
+  minimizedNodeIDs: ReadonlySet<string>;
+  nodeDefinitions: ReadonlyMap<string, WorkbenchHostNodeDefinition>;
+  nodes: readonly WorkbenchMinimizedDockNode[];
+}) {
+  const candidates = nodes.filter((node) => {
+    if (node.displayMode === "fullscreen" || minimizedNodeIDs.has(node.id)) {
+      return false;
+    }
+    return (
+      nodeDefinitions.get(node.data.typeId)?.window?.fullscreenable !== false
+    );
+  });
+  return (
+    candidates.find((node) => node.id === focusedNodeId) ??
+    candidates[0] ??
+    null
+  );
+}
+
+function previewRevision(
+  preview: WorkbenchDockPreviewContent | null | undefined
+): string | null {
+  return preview?.revision ?? null;
+}
+
+function resolveDockPreviewCacheKey(
+  workspaceId: string,
+  node: WorkbenchMinimizedDockNode
+): WorkbenchDockPreviewCacheKey {
+  return {
+    instanceId: node.data.instanceId,
+    instanceKey: node.data.instanceKey ?? null,
+    nodeId: node.id,
+    typeId: node.data.typeId,
+    workspaceId
+  };
+}

--- a/packages/workbench/surface/src/host/dockActions.ts
+++ b/packages/workbench/surface/src/host/dockActions.ts
@@ -1,0 +1,3 @@
+export function dockActionKey(entryId: string, actionId: string): string {
+  return `${entryId}:${actionId}`;
+}

--- a/packages/workbench/surface/src/host/dockDiagnostics.ts
+++ b/packages/workbench/surface/src/host/dockDiagnostics.ts
@@ -1,0 +1,21 @@
+import type { WorkbenchHostProps } from "./types.ts";
+
+export function logWorkbenchDockDebug(
+  event: string,
+  debugDiagnostics: WorkbenchHostProps["debugDiagnostics"],
+  details: Record<string, unknown>
+): void {
+  if (!debugDiagnostics?.log) {
+    return;
+  }
+  void Promise.resolve(
+    debugDiagnostics.log({
+      details,
+      event,
+      level: "info",
+      source: "workbench-dock",
+      workspaceId:
+        typeof details.workspaceId === "string" ? details.workspaceId : null
+    })
+  ).catch(() => undefined);
+}

--- a/packages/workbench/surface/src/host/dockItems.test.ts
+++ b/packages/workbench/surface/src/host/dockItems.test.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ResolvedWorkbenchHostDockEntry } from "./dockEntries.ts";
+import {
+  createWorkbenchHostDockItems,
+  minimizedDockSlotNodes,
+  resolveDockEntryInstanceMode,
+  resolveWorkbenchHostDockItemsWidth
+} from "./dockItems.ts";
+import type {
+  WorkbenchMinimizedDockNode,
+  WorkbenchMinimizedDockSlot
+} from "./minimizedDockSlots.ts";
+import type {
+  WorkbenchHostDockEntry,
+  WorkbenchHostNodeDefinition
+} from "./types.ts";
+
+test("builds entry separators and minimized slots in source order", () => {
+  const first = resolvedEntry("first", { separatorAfter: true });
+  const second = resolvedEntry("second", {}, true);
+  const node = minimizedNode("node-1");
+  const minimizedSlot: WorkbenchMinimizedDockSlot = {
+    anchorKey: "minimized:node-1",
+    kind: "node",
+    node
+  };
+
+  const items = createWorkbenchHostDockItems({
+    minimizedDockSlots: [minimizedSlot],
+    resolvedEntries: [first, second]
+  });
+
+  assert.deepEqual(
+    items.map((item) => [item.kind, item.key]),
+    [
+      ["entry", "entry:first"],
+      ["separator", "separator:after:first"],
+      ["separator", "separator:before:second"],
+      ["entry", "entry:second"],
+      ["separator", "separator:minimized"],
+      ["minimized", "minimized:minimized:node-1"]
+    ]
+  );
+  assert.deepEqual(minimizedDockSlotNodes(minimizedSlot), [node]);
+});
+
+test("does not add the minimized separator without entry items", () => {
+  const nodes = [minimizedNode("node-1"), minimizedNode("node-2")];
+  const stack: WorkbenchMinimizedDockSlot = {
+    anchorKey: "minimized-stack",
+    kind: "stack",
+    nodes
+  };
+
+  const items = createWorkbenchHostDockItems({
+    minimizedDockSlots: [stack],
+    resolvedEntries: []
+  });
+
+  assert.deepEqual(
+    items.map((item) => item.key),
+    ["minimized:minimized-stack"]
+  );
+  assert.deepEqual(minimizedDockSlotNodes(stack), nodes);
+});
+
+test("calculates the dock axis size from slots, separators, gaps, and padding", () => {
+  const items = createWorkbenchHostDockItems({
+    minimizedDockSlots: [],
+    resolvedEntries: [
+      resolvedEntry("first", { separatorAfter: true }),
+      resolvedEntry("second")
+    ]
+  });
+
+  assert.equal(resolveWorkbenchHostDockItemsWidth([]), 12.6);
+  assert.equal(resolveWorkbenchHostDockItemsWidth(items), 128.7);
+});
+
+test("prefers an entry instance mode over its node definition", () => {
+  const definitions = new Map<string, WorkbenchHostNodeDefinition>([
+    [
+      "agent",
+      {
+        instance: { mode: "single" },
+        typeId: "agent"
+      } as WorkbenchHostNodeDefinition
+    ]
+  ]);
+
+  assert.equal(
+    resolveDockEntryInstanceMode(
+      {
+        icon: null,
+        id: "agent",
+        instanceMode: "multi",
+        label: "Agent",
+        typeId: "agent"
+      },
+      definitions
+    ),
+    "multi"
+  );
+  assert.equal(
+    resolveDockEntryInstanceMode(
+      { icon: null, id: "agent", label: "Agent", typeId: "agent" },
+      definitions
+    ),
+    "single"
+  );
+});
+
+function resolvedEntry(
+  id: string,
+  overrides: Partial<WorkbenchHostDockEntry> = {},
+  sectionBreakBefore = false
+): ResolvedWorkbenchHostDockEntry {
+  return {
+    anchorKey: id,
+    dockNodeState: "closed",
+    entry: {
+      icon: null,
+      id,
+      label: id,
+      typeId: id,
+      ...overrides
+    },
+    hasMatchingNodes: false,
+    matchedNodes: [],
+    sectionBreakBefore
+  };
+}
+
+function minimizedNode(id: string): WorkbenchMinimizedDockNode {
+  return {
+    data: {
+      instanceId: id,
+      typeId: "agent"
+    },
+    displayMode: "floating",
+    frame: { height: 100, width: 100, x: 0, y: 0 },
+    id,
+    isMinimized: true,
+    kind: "agent",
+    restoreFrame: null,
+    title: id
+  };
+}

--- a/packages/workbench/surface/src/host/dockItems.ts
+++ b/packages/workbench/surface/src/host/dockItems.ts
@@ -1,0 +1,112 @@
+import type { ResolvedWorkbenchHostDockEntry } from "./dockEntries.ts";
+import type {
+  WorkbenchMinimizedDockNode,
+  WorkbenchMinimizedDockSlot
+} from "./minimizedDockSlots.ts";
+import type {
+  WorkbenchHostDockEntry,
+  WorkbenchHostNodeDefinition,
+  WorkbenchHostNodeInstanceStrategy
+} from "./types.ts";
+
+export const minimizedDockSlotLayoutAnimationMs = 720;
+
+const dockItemsGapPx = 10.8;
+const dockItemsHorizontalPaddingPx = 12.6;
+const dockSeparatorOuterWidthPx = 8.1;
+const dockSlotWidthPx = 43.2;
+
+export type WorkbenchHostDockItem =
+  | {
+      key: string;
+      kind: "entry";
+      resolvedEntry: ResolvedWorkbenchHostDockEntry;
+    }
+  | {
+      key: string;
+      kind: "minimized";
+      slot: WorkbenchMinimizedDockSlot;
+    }
+  | {
+      key: string;
+      kind: "separator";
+    };
+
+export function createWorkbenchHostDockItems({
+  minimizedDockSlots,
+  resolvedEntries
+}: {
+  minimizedDockSlots: readonly WorkbenchMinimizedDockSlot[];
+  resolvedEntries: readonly ResolvedWorkbenchHostDockEntry[];
+}): WorkbenchHostDockItem[] {
+  const items: WorkbenchHostDockItem[] = [];
+
+  for (const resolvedEntry of resolvedEntries) {
+    if (resolvedEntry.sectionBreakBefore) {
+      items.push({
+        key: `separator:before:${resolvedEntry.entry.id}`,
+        kind: "separator"
+      });
+    }
+    items.push({
+      key: `entry:${resolvedEntry.entry.id}`,
+      kind: "entry",
+      resolvedEntry
+    });
+    if (resolvedEntry.entry.separatorAfter) {
+      items.push({
+        key: `separator:after:${resolvedEntry.entry.id}`,
+        kind: "separator"
+      });
+    }
+  }
+
+  if (minimizedDockSlots.length > 0 && resolvedEntries.length > 0) {
+    items.push({
+      key: "separator:minimized",
+      kind: "separator"
+    });
+  }
+
+  for (const slot of minimizedDockSlots) {
+    items.push({
+      key: `minimized:${slot.anchorKey}`,
+      kind: "minimized",
+      slot
+    });
+  }
+
+  return items;
+}
+
+export function minimizedDockSlotNodes(
+  slot: WorkbenchMinimizedDockSlot
+): readonly WorkbenchMinimizedDockNode[] {
+  return slot.kind === "stack" ? slot.nodes : [slot.node];
+}
+
+export function resolveDockEntryInstanceMode(
+  entry: WorkbenchHostDockEntry,
+  nodeDefinitions: ReadonlyMap<string, WorkbenchHostNodeDefinition>
+): WorkbenchHostNodeInstanceStrategy["mode"] | undefined {
+  return (
+    entry.instanceMode ?? nodeDefinitions.get(entry.typeId)?.instance?.mode
+  );
+}
+
+export function resolveWorkbenchHostDockItemsWidth(
+  items: readonly WorkbenchHostDockItem[]
+): number {
+  if (items.length === 0) {
+    return dockItemsHorizontalPaddingPx;
+  }
+
+  const itemWidth = items.reduce(
+    (sum, item) =>
+      sum +
+      (item.kind === "separator" ? dockSeparatorOuterWidthPx : dockSlotWidthPx),
+    0
+  );
+  const gapWidth = Math.max(0, items.length - 1) * dockItemsGapPx;
+  return itemWidth + gapWidth + dockItemsHorizontalPaddingPx;
+}

--- a/packages/workbench/surface/src/host/dockPresence.test.ts
+++ b/packages/workbench/surface/src/host/dockPresence.test.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { WorkbenchHostDockItem } from "./dockItems.ts";
+import {
+  resolveDockPresenceItems,
+  resolveDockPresenceSettleMs,
+  resolveNextDockItemPresence,
+  type WorkbenchHostPresentDockItem
+} from "./dockPresence.ts";
+import type { WorkbenchMinimizedDockNode } from "./minimizedDockSlots.ts";
+
+test("marks initial items present without an entrance transition", () => {
+  const item = separator("separator:first");
+
+  assert.equal(
+    resolveNextDockItemPresence(item, false, undefined, no),
+    "present"
+  );
+});
+
+test("retains removed items in place while they exit", () => {
+  const first = separator("first");
+  const removed = separator("removed");
+  const last = separator("last");
+  const current = [first, removed, last].map(present);
+
+  const next = resolveDockPresenceItems({
+    current,
+    initialized: true,
+    nextSourceItems: [first, last],
+    shouldAnimateMinimizedDockEnter: no
+  });
+
+  assert.deepEqual(
+    next.map((item) => [item.key, item.presence]),
+    [
+      ["first", "present"],
+      ["removed", "exiting"],
+      ["last", "present"]
+    ]
+  );
+});
+
+test("turns a re-entering item back into an entrance transition", () => {
+  const item = separator("entry:agent");
+
+  assert.equal(
+    resolveNextDockItemPresence(item, true, "exiting", no),
+    "entering"
+  );
+});
+
+test("only animates eligible minimized node slots", () => {
+  const nodeItem = minimized("node-1");
+  const stackItem: WorkbenchHostDockItem = {
+    key: "minimized:minimized-stack",
+    kind: "minimized",
+    slot: {
+      anchorKey: "minimized-stack",
+      kind: "stack",
+      nodes: [minimizedNode("node-1")]
+    }
+  };
+
+  assert.equal(
+    resolveNextDockItemPresence(
+      nodeItem,
+      true,
+      undefined,
+      (id) => id === "node-1"
+    ),
+    "entering"
+  );
+  assert.equal(
+    resolveNextDockItemPresence(nodeItem, true, undefined, no),
+    "present"
+  );
+  assert.equal(
+    resolveNextDockItemPresence(stackItem, true, undefined, () => true),
+    "present"
+  );
+});
+
+test("uses the longer settle window whenever a minimized slot is moving", () => {
+  const minimizedItem = minimized("node-1");
+  const moving: WorkbenchHostPresentDockItem = {
+    item: minimizedItem,
+    key: minimizedItem.key,
+    presence: "entering"
+  };
+
+  assert.equal(resolveDockPresenceSettleMs([moving]), 720);
+  assert.equal(
+    resolveDockPresenceSettleMs([
+      {
+        item: separator("entry:agent"),
+        key: "entry:agent",
+        presence: "entering"
+      }
+    ]),
+    300
+  );
+});
+
+function no(): boolean {
+  return false;
+}
+
+function present(item: WorkbenchHostDockItem): WorkbenchHostPresentDockItem {
+  return { item, key: item.key, presence: "present" };
+}
+
+function separator(key: string): WorkbenchHostDockItem {
+  return { key, kind: "separator" };
+}
+
+function minimized(id: string): WorkbenchHostDockItem {
+  return {
+    key: `minimized:${id}`,
+    kind: "minimized",
+    slot: {
+      anchorKey: `minimized:${id}`,
+      kind: "node",
+      node: minimizedNode(id)
+    }
+  };
+}
+
+function minimizedNode(id: string): WorkbenchMinimizedDockNode {
+  return {
+    data: { instanceId: id, typeId: "agent" },
+    displayMode: "floating",
+    frame: { height: 100, width: 100, x: 0, y: 0 },
+    id,
+    isMinimized: true,
+    kind: "agent",
+    restoreFrame: null,
+    title: id
+  };
+}

--- a/packages/workbench/surface/src/host/dockPresence.ts
+++ b/packages/workbench/surface/src/host/dockPresence.ts
@@ -1,0 +1,149 @@
+import {
+  minimizedDockSlotLayoutAnimationMs,
+  type WorkbenchHostDockItem
+} from "./dockItems.ts";
+
+export type WorkbenchHostDockPresence = "entering" | "exiting" | "present";
+
+export interface WorkbenchHostPresentDockItem {
+  item: WorkbenchHostDockItem;
+  key: string;
+  presence: WorkbenchHostDockPresence;
+}
+
+const dockPresenceAnimationMs = 300;
+
+export function resolveMinimizedDockItemNodeId(
+  item: WorkbenchHostDockItem
+): string | null {
+  if (item.kind !== "minimized" || item.slot.kind !== "node") {
+    return null;
+  }
+  return item.slot.node.id;
+}
+
+export function resolveNextDockItemPresence(
+  item: WorkbenchHostDockItem,
+  initialized: boolean,
+  previousPresence: WorkbenchHostDockPresence | undefined,
+  shouldAnimateMinimizedDockEnter: (nodeId: string) => boolean
+): WorkbenchHostDockPresence {
+  if (!initialized) {
+    return "present";
+  }
+
+  if (item.key === "separator:minimized") {
+    return "present";
+  }
+
+  if (item.kind === "minimized") {
+    const nodeId = resolveMinimizedDockItemNodeId(item);
+    if (nodeId && shouldAnimateMinimizedDockEnter(nodeId)) {
+      if (previousPresence === "exiting") {
+        return "entering";
+      }
+      return previousPresence ?? "entering";
+    }
+    return "present";
+  }
+
+  if (previousPresence === "exiting") {
+    return "entering";
+  }
+
+  return previousPresence ?? "entering";
+}
+
+export function resolveDockPresenceItems(input: {
+  current: readonly WorkbenchHostPresentDockItem[];
+  initialized: boolean;
+  nextSourceItems: readonly WorkbenchHostDockItem[];
+  shouldAnimateMinimizedDockEnter: (nodeId: string) => boolean;
+}): WorkbenchHostPresentDockItem[] {
+  const currentByKey = new Map(input.current.map((item) => [item.key, item]));
+  const currentIndexByKey = new Map(
+    input.current.map((item, index) => [item.key, index])
+  );
+  const nextByKey = new Map(
+    input.nextSourceItems.map((item) => [item.key, item])
+  );
+  const nextKeys = new Set(input.nextSourceItems.map((item) => item.key));
+  const currentVisibleItemCount = input.current.filter(
+    (item) => item.presence !== "exiting"
+  ).length;
+  const shouldRetainExitingItems =
+    input.nextSourceItems.length < currentVisibleItemCount;
+  const emittedKeys = new Set<string>();
+  const nextItems: WorkbenchHostPresentDockItem[] = [];
+  let currentIndex = 0;
+
+  const emitExitingUntil = (nextCurrentIndex: number) => {
+    while (currentIndex < nextCurrentIndex) {
+      const currentItem = input.current[currentIndex];
+      currentIndex += 1;
+      if (
+        shouldRetainExitingItems &&
+        currentItem &&
+        !nextKeys.has(currentItem.key) &&
+        !emittedKeys.has(currentItem.key)
+      ) {
+        emittedKeys.add(currentItem.key);
+        nextItems.push({
+          ...currentItem,
+          presence: "exiting"
+        });
+      }
+    }
+  };
+
+  for (const item of input.nextSourceItems) {
+    const previousIndex = currentIndexByKey.get(item.key);
+    if (previousIndex !== undefined) {
+      emitExitingUntil(previousIndex);
+      currentIndex = Math.max(currentIndex, previousIndex + 1);
+    }
+    emittedKeys.add(item.key);
+    nextItems.push({
+      item,
+      key: item.key,
+      presence: resolveNextDockItemPresence(
+        item,
+        input.initialized,
+        currentByKey.get(item.key)?.presence,
+        input.shouldAnimateMinimizedDockEnter
+      )
+    });
+  }
+
+  for (const currentItem of input.current) {
+    if (shouldRetainExitingItems && !nextKeys.has(currentItem.key)) {
+      if (emittedKeys.has(currentItem.key)) {
+        continue;
+      }
+      emittedKeys.add(currentItem.key);
+      nextItems.push({
+        ...currentItem,
+        presence: "exiting"
+      });
+    }
+  }
+
+  return nextItems.filter(
+    (item) => nextByKey.has(item.key) || item.presence === "exiting"
+  );
+}
+
+export function resolveDockPresenceSettleMs(
+  items: readonly WorkbenchHostPresentDockItem[]
+): number {
+  if (
+    items.some(
+      (item) =>
+        item.item.kind === "minimized" &&
+        (item.presence === "entering" || item.presence === "exiting")
+    )
+  ) {
+    return minimizedDockSlotLayoutAnimationMs;
+  }
+  return dockPresenceAnimationMs;
+}

--- a/packages/workbench/surface/src/host/dockWallpaperSampling.test.ts
+++ b/packages/workbench/surface/src/host/dockWallpaperSampling.test.ts
@@ -2,6 +2,9 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   getDockWallpaperImageSample,
+  parseDockWallpaperCssUrl,
+  resolveDockWallpaperPositionOffset,
+  resolveDockWallpaperRenderedImageRect,
   sampleDockWallpaperLuminanceAtElement
 } from "./dockWallpaperSampling.ts";
 
@@ -70,6 +73,72 @@ test("samples cached RGBA bytes without additional canvas readbacks", () => {
 
   assert.ok(luminance !== null);
   assert.ok(luminance > 100 && luminance < 155);
+});
+
+test("parses quoted and unquoted wallpaper URLs", () => {
+  assert.equal(
+    parseDockWallpaperCssUrl('url("wallpaper.png")'),
+    "wallpaper.png"
+  );
+  assert.equal(parseDockWallpaperCssUrl("url(wallpaper.png)"), "wallpaper.png");
+  assert.equal(parseDockWallpaperCssUrl("none"), null);
+  assert.equal(parseDockWallpaperCssUrl("url()"), null);
+});
+
+test("maps cover and contain images into the wallpaper container", () => {
+  assert.deepEqual(
+    resolveDockWallpaperRenderedImageRect({
+      containerHeight: 100,
+      containerWidth: 200,
+      imageHeight: 100,
+      imageWidth: 100,
+      positionX: "50%",
+      positionY: "50%",
+      size: "cover"
+    }),
+    { height: 200, left: 0, top: -50, width: 200 }
+  );
+  assert.deepEqual(
+    resolveDockWallpaperRenderedImageRect({
+      containerHeight: 100,
+      containerWidth: 200,
+      imageHeight: 100,
+      imageWidth: 100,
+      positionX: "right",
+      positionY: "bottom",
+      size: "contain"
+    }),
+    { height: 100, left: 100, top: 0, width: 100 }
+  );
+});
+
+test("supports stretched, native, percentage, and pixel wallpaper geometry", () => {
+  assert.deepEqual(
+    resolveDockWallpaperRenderedImageRect({
+      containerHeight: 100,
+      containerWidth: 200,
+      imageHeight: 40,
+      imageWidth: 80,
+      positionX: "25%",
+      positionY: "12px",
+      size: "100% 100%"
+    }),
+    { height: 100, left: 0, top: 12, width: 200 }
+  );
+  assert.deepEqual(
+    resolveDockWallpaperRenderedImageRect({
+      containerHeight: 100,
+      containerWidth: 200,
+      imageHeight: 40,
+      imageWidth: 80,
+      positionX: "25%",
+      positionY: "12px",
+      size: "auto"
+    }),
+    { height: 40, left: 30, top: 12, width: 80 }
+  );
+  assert.equal(resolveDockWallpaperPositionOffset("invalid", 80), 40);
+  assert.equal(resolveDockWallpaperPositionOffset("not-a-number%", 80), 40);
 });
 
 function rect({

--- a/packages/workbench/surface/src/host/dockWallpaperSampling.ts
+++ b/packages/workbench/surface/src/host/dockWallpaperSampling.ts
@@ -7,7 +7,7 @@ export interface DockWallpaperImageSample {
   width: number;
 }
 
-interface DockWallpaperRenderedImageRect {
+export interface DockWallpaperRenderedImageRect {
   height: number;
   left: number;
   top: number;
@@ -108,4 +108,85 @@ export function sampleDockWallpaperLuminanceAtElement({
   }
 
   return samples > 0 ? luminanceSum / samples : null;
+}
+
+export function parseDockWallpaperCssUrl(
+  backgroundImage: string
+): string | null {
+  const match = /^url\((['"]?)(.*)\1\)$/u.exec(backgroundImage.trim());
+  return match?.[2] ? match[2] : null;
+}
+
+export function resolveDockWallpaperRenderedImageRect({
+  containerHeight,
+  containerWidth,
+  imageHeight,
+  imageWidth,
+  positionX,
+  positionY,
+  size
+}: {
+  containerHeight: number;
+  containerWidth: number;
+  imageHeight: number;
+  imageWidth: number;
+  positionX: string;
+  positionY: string;
+  size: string;
+}): DockWallpaperRenderedImageRect {
+  const imageAspect = imageWidth / imageHeight;
+  const containerAspect = containerWidth / containerHeight;
+  let width = containerWidth;
+  let height = containerHeight;
+
+  if (size === "cover") {
+    if (containerAspect > imageAspect) {
+      height = containerWidth / imageAspect;
+    } else {
+      width = containerHeight * imageAspect;
+    }
+  } else if (size === "contain") {
+    if (containerAspect > imageAspect) {
+      width = containerHeight * imageAspect;
+    } else {
+      height = containerWidth / imageAspect;
+    }
+  } else if (size !== "100% 100%") {
+    width = imageWidth;
+    height = imageHeight;
+  }
+
+  return {
+    height,
+    left: resolveDockWallpaperPositionOffset(positionX, containerWidth - width),
+    top: resolveDockWallpaperPositionOffset(
+      positionY,
+      containerHeight - height
+    ),
+    width
+  };
+}
+
+export function resolveDockWallpaperPositionOffset(
+  value: string,
+  availableSpace: number
+): number {
+  const trimmed = value.trim();
+  if (trimmed.endsWith("%")) {
+    const percentage = Number.parseFloat(trimmed);
+    return Number.isFinite(percentage)
+      ? (availableSpace * percentage) / 100
+      : availableSpace / 2;
+  }
+  if (trimmed.endsWith("px")) {
+    const px = Number.parseFloat(trimmed);
+    return Number.isFinite(px) ? px : availableSpace / 2;
+  }
+  if (trimmed === "left" || trimmed === "top") {
+    return 0;
+  }
+  if (trimmed === "right" || trimmed === "bottom") {
+    return availableSpace;
+  }
+  return availableSpace / 2;
 }

--- a/packages/workbench/surface/src/host/useWorkbenchHostDockActivity.ts
+++ b/packages/workbench/surface/src/host/useWorkbenchHostDockActivity.ts
@@ -1,0 +1,136 @@
+import { useEffect, useRef, useState } from "react";
+import type { WorkbenchDockContext } from "../react/types.ts";
+import type { ResolvedWorkbenchHostDockEntry } from "./dockEntries.ts";
+import { minimizedDockSlotNodes } from "./dockItems.ts";
+import { createWorkbenchHostExternalStateLookupInput } from "./externalState.ts";
+import type { WorkbenchMinimizedDockSlot } from "./minimizedDockSlots.ts";
+import type {
+  WorkbenchHostExternalStateSource,
+  WorkbenchHostNodeData,
+  WorkbenchHostNodeDefinition
+} from "./types.ts";
+
+export function useWorkbenchHostDockActivity({
+  activePopup,
+  context,
+  externalStateSource,
+  minimizedDockSlots,
+  nodeDefinitions,
+  renderedDockEntries,
+  workspaceId
+}: {
+  activePopup: boolean;
+  context: WorkbenchDockContext<WorkbenchHostNodeData>;
+  externalStateSource?: WorkbenchHostExternalStateSource;
+  minimizedDockSlots: readonly WorkbenchMinimizedDockSlot[];
+  nodeDefinitions: ReadonlyMap<string, WorkbenchHostNodeDefinition>;
+  renderedDockEntries: readonly ResolvedWorkbenchHostDockEntry["entry"][];
+  workspaceId: string;
+}) {
+  const previousAttentionTokenByEntryId = useRef(new Map<string, unknown>());
+  const attentionTimeouts = useRef(
+    new Map<string, ReturnType<typeof setTimeout>>()
+  );
+  const [activeAttentionEntryIds, setActiveAttentionEntryIds] = useState<
+    Set<string>
+  >(new Set());
+  const [externalStateRevision, setExternalStateRevision] = useState(0);
+  const hasMinimizedPreviewCapture = minimizedDockSlots.some((slot) =>
+    minimizedDockSlotNodes(slot).some((node) => {
+      if (context.genie.isPendingMinimizedDockNode(node.id)) {
+        return false;
+      }
+      const minimizedDock = nodeDefinitions.get(node.data.typeId)?.window
+        ?.minimizedDock;
+      return (
+        minimizedDock?.kind === "snapshot" &&
+        Boolean(minimizedDock.capturePreview)
+      );
+    })
+  );
+
+  useEffect(() => {
+    const shouldSubscribe = activePopup || hasMinimizedPreviewCapture;
+    if (!shouldSubscribe || !externalStateSource?.subscribeNodeState) {
+      return undefined;
+    }
+    const nodes = activePopup ? context.nodes : context.minimizedNodes;
+    const disposers = nodes.map((node) =>
+      externalStateSource.subscribeNodeState?.(
+        createWorkbenchHostExternalStateLookupInput({ node, workspaceId }),
+        () => setExternalStateRevision((revision) => revision + 1)
+      )
+    );
+    return () => {
+      for (const dispose of disposers) {
+        dispose?.();
+      }
+    };
+  }, [
+    activePopup,
+    context.minimizedNodes,
+    context.nodes,
+    externalStateSource,
+    hasMinimizedPreviewCapture,
+    workspaceId
+  ]);
+
+  useEffect(() => {
+    const nextAttentionIds = new Set<string>();
+
+    for (const entry of renderedDockEntries) {
+      const nextToken = entry.attentionToken ?? null;
+      const previousToken =
+        previousAttentionTokenByEntryId.current.get(entry.id) ?? null;
+      if (nextToken !== null && nextToken !== previousToken) {
+        nextAttentionIds.add(entry.id);
+      }
+      previousAttentionTokenByEntryId.current.set(entry.id, nextToken);
+    }
+
+    if (nextAttentionIds.size === 0) {
+      return;
+    }
+
+    setActiveAttentionEntryIds((current) => {
+      const next = new Set(current);
+      for (const entryId of nextAttentionIds) {
+        next.add(entryId);
+      }
+      return next;
+    });
+
+    for (const entryId of nextAttentionIds) {
+      const existingTimeout = attentionTimeouts.current.get(entryId);
+      if (existingTimeout) {
+        globalThis.clearTimeout(existingTimeout);
+      }
+      attentionTimeouts.current.set(
+        entryId,
+        globalThis.setTimeout(() => {
+          attentionTimeouts.current.delete(entryId);
+          setActiveAttentionEntryIds((current) => {
+            if (!current.has(entryId)) {
+              return current;
+            }
+            const next = new Set(current);
+            next.delete(entryId);
+            return next;
+          });
+        }, 900)
+      );
+    }
+  }, [renderedDockEntries]);
+
+  useEffect(
+    () => () => {
+      for (const timeout of attentionTimeouts.current.values()) {
+        globalThis.clearTimeout(timeout);
+      }
+      attentionTimeouts.current.clear();
+    },
+    []
+  );
+
+  return { activeAttentionEntryIds, externalStateRevision };
+}

--- a/packages/workbench/surface/src/host/useWorkbenchHostDockBounce.ts
+++ b/packages/workbench/surface/src/host/useWorkbenchHostDockBounce.ts
@@ -1,0 +1,62 @@
+import { useCallback, useEffect, useRef, type RefObject } from "react";
+
+const dockBounceMs = 600;
+
+export const dockEntryClickThrottleMs = dockBounceMs;
+
+export function useWorkbenchHostDockBounce(
+  slotRefs: RefObject<Map<string, HTMLElement>>
+) {
+  const timeoutsRef = useRef(new Map<string, ReturnType<typeof setTimeout>>());
+
+  const clearDockBounce = useCallback(
+    (anchorKey: string): boolean => {
+      const timeout = timeoutsRef.current.get(anchorKey);
+      const slotElement = slotRefs.current.get(anchorKey);
+      const wasBouncing = slotElement?.hasAttribute("data-bouncing") === true;
+      if (timeout) {
+        clearTimeout(timeout);
+        timeoutsRef.current.delete(anchorKey);
+      }
+      slotElement?.removeAttribute("data-bouncing");
+      return wasBouncing;
+    },
+    [slotRefs]
+  );
+
+  useEffect(
+    () => () => {
+      for (const anchorKey of timeoutsRef.current.keys()) {
+        clearDockBounce(anchorKey);
+      }
+      timeoutsRef.current.clear();
+    },
+    [clearDockBounce]
+  );
+
+  const triggerDockBounce = useCallback(
+    (anchorKey: string) => {
+      const shouldRestartAnimation = clearDockBounce(anchorKey);
+
+      const slotElement = slotRefs.current.get(anchorKey);
+      if (!slotElement) {
+        return;
+      }
+
+      if (shouldRestartAnimation) {
+        // Restart the CSS keyframes without scheduling a React render.
+        void slotElement.offsetWidth;
+      }
+      slotElement.setAttribute("data-bouncing", "true");
+      timeoutsRef.current.set(
+        anchorKey,
+        setTimeout(() => {
+          clearDockBounce(anchorKey);
+        }, dockBounceMs)
+      );
+    },
+    [clearDockBounce, slotRefs]
+  );
+
+  return { triggerDockBounce };
+}

--- a/packages/workbench/surface/src/host/useWorkbenchHostDockEntryActivation.ts
+++ b/packages/workbench/surface/src/host/useWorkbenchHostDockEntryActivation.ts
@@ -1,0 +1,209 @@
+import { useCallback, type Dispatch, type SetStateAction } from "react";
+import type { WorkbenchDockContext } from "../react/types.ts";
+import type {
+  ResolvedWorkbenchHostDockEntry,
+  WorkbenchHostDockClickResolution
+} from "./dockEntries.ts";
+import { logWorkbenchDockDebug } from "./dockDiagnostics.ts";
+import type { WorkbenchHostDockPopupState } from "./WorkbenchHostDockPopup.tsx";
+import type {
+  WorkbenchHostHandle,
+  WorkbenchHostNodeData,
+  WorkbenchHostNodeInstanceStrategy,
+  WorkbenchHostProps
+} from "./types.ts";
+
+export interface WorkbenchHostDockEntryActivationInput {
+  anchorKey: string;
+  clickResolution: WorkbenchHostDockClickResolution;
+  currentPopup: WorkbenchHostDockPopupState | null;
+  instanceMode?: WorkbenchHostNodeInstanceStrategy["mode"];
+  resolvedEntry: ResolvedWorkbenchHostDockEntry;
+  triggerRect: DOMRect | null;
+}
+
+export interface WorkbenchHostDockEntryContextMenuInput {
+  anchorKey: string;
+  resolvedEntry: ResolvedWorkbenchHostDockEntry;
+  triggerRect: DOMRect;
+}
+
+export function useWorkbenchHostDockEntryActivation({
+  closePopup,
+  context,
+  debugDiagnostics,
+  host,
+  onDockEntryAction,
+  onDockEntryClick,
+  setActivePopup,
+  workspaceId
+}: {
+  closePopup: () => void;
+  context: WorkbenchDockContext<WorkbenchHostNodeData>;
+  debugDiagnostics?: WorkbenchHostProps["debugDiagnostics"];
+  host: WorkbenchHostHandle;
+  onDockEntryAction?: (input: {
+    actionId: string;
+    entryId: string;
+    host: WorkbenchHostHandle;
+  }) => Promise<void> | void;
+  onDockEntryClick?: (input: {
+    entryId: string;
+    host: WorkbenchHostHandle;
+    nodeId?: string;
+  }) => Promise<void> | void;
+  setActivePopup: Dispatch<SetStateAction<WorkbenchHostDockPopupState | null>>;
+  workspaceId: string;
+}) {
+  const activateDockEntry = useCallback(
+    ({
+      anchorKey,
+      clickResolution,
+      currentPopup,
+      instanceMode,
+      resolvedEntry,
+      triggerRect
+    }: WorkbenchHostDockEntryActivationInput) => {
+      const { entry } = resolvedEntry;
+      logWorkbenchDockDebug("dock.click", debugDiagnostics, {
+        anchorKey,
+        clickResolution,
+        dockDiagnostics: entry.diagnostics ?? null,
+        dockNodeState: resolvedEntry.dockNodeState,
+        entryId: entry.id,
+        entryLaunchBehavior: entry.launchBehavior ?? "enabled",
+        entryOrder: entry.order ?? null,
+        entryState: entry.state ?? { kind: "enabled" },
+        entryVisibility: entry.visibility ?? "always",
+        hoverActions:
+          entry.hoverActions?.map((action) => ({
+            disabled: action.disabled === true,
+            id: action.id,
+            pending: Boolean(action.pendingLabel)
+          })) ?? [],
+        instanceMode: instanceMode ?? null,
+        matchedNodeCount: resolvedEntry.matchedNodes.length,
+        matchedNodeIds: resolvedEntry.matchedNodes.map((node) => node.id),
+        typeId: entry.typeId,
+        workspaceId
+      });
+
+      switch (clickResolution.kind) {
+        case "blocked":
+          return;
+        case "focus-node":
+          closePopup();
+          void (async () => {
+            try {
+              await onDockEntryClick?.({
+                entryId: entry.id,
+                host,
+                nodeId: clickResolution.nodeId
+              });
+            } catch {
+              // Keep dock click failures contained.
+            }
+          })();
+          context.genie.launchNodeFromAnchor(
+            anchorKey,
+            clickResolution.nodeId,
+            () => {
+              host.focusNode(clickResolution.nodeId);
+            }
+          );
+          return;
+        case "open-popup":
+          if (!triggerRect) {
+            return;
+          }
+          logWorkbenchDockDebug("dock.popup.toggle", debugDiagnostics, {
+            anchorKey,
+            entryId: entry.id,
+            matchedNodeCount: resolvedEntry.matchedNodes.length,
+            nextOpen: currentPopup === null,
+            typeId: entry.typeId,
+            workspaceId
+          });
+          setActivePopup((current) =>
+            current?.entryId === entry.id
+              ? null
+              : {
+                  anchorRect: {
+                    height: triggerRect.height,
+                    left: triggerRect.left,
+                    top: triggerRect.top,
+                    width: triggerRect.width
+                  },
+                  kind: "preview",
+                  entryId: entry.id
+                }
+          );
+          return;
+        case "action":
+          closePopup();
+          void (async () => {
+            try {
+              await onDockEntryAction?.({
+                actionId: clickResolution.actionId,
+                entryId: entry.id,
+                host
+              });
+            } catch {
+              // Keep dock action failures contained.
+            }
+          })();
+          return;
+        case "launch":
+          closePopup();
+          context.genie.launchNodeFromAnchor(anchorKey, entry.id, () =>
+            host.launchNode({
+              dockEntryId: entry.id,
+              payload: entry.launchPayload,
+              reason: "dock",
+              typeId: entry.typeId
+            })
+          );
+      }
+    },
+    [
+      closePopup,
+      context.genie,
+      debugDiagnostics,
+      host,
+      onDockEntryAction,
+      onDockEntryClick,
+      setActivePopup,
+      workspaceId
+    ]
+  );
+
+  const openDockEntryContextMenu = useCallback(
+    ({
+      anchorKey,
+      resolvedEntry,
+      triggerRect
+    }: WorkbenchHostDockEntryContextMenuInput) => {
+      const { entry } = resolvedEntry;
+      logWorkbenchDockDebug("dock.popup.context_menu", debugDiagnostics, {
+        anchorKey,
+        entryId: entry.id,
+        matchedNodeCount: resolvedEntry.matchedNodes.length,
+        typeId: entry.typeId,
+        workspaceId
+      });
+      setActivePopup({
+        anchorRect: {
+          height: triggerRect.height,
+          left: triggerRect.left,
+          top: triggerRect.top,
+          width: triggerRect.width
+        },
+        kind: "context-menu",
+        entryId: entry.id
+      });
+    },
+    [debugDiagnostics, setActivePopup, workspaceId]
+  );
+
+  return { activateDockEntry, openDockEntryContextMenu };
+}

--- a/packages/workbench/surface/src/host/useWorkbenchHostDockInteractions.ts
+++ b/packages/workbench/surface/src/host/useWorkbenchHostDockInteractions.ts
@@ -1,0 +1,199 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type RefObject
+} from "react";
+import { minimizedDockSlotLayoutAnimationMs } from "./dockItems.ts";
+import type { WorkbenchMinimizedDockRestoreIntent } from "./minimizedDockRestoreIntent.ts";
+import { dockEntryClickThrottleMs } from "./useWorkbenchHostDockBounce.ts";
+
+type WorkbenchMinimizedDockNodeSlotRestoreIntent = Extract<
+  WorkbenchMinimizedDockRestoreIntent,
+  { kind: "node-slot" }
+>;
+
+type WorkbenchMinimizedDockStackPopupCardRestoreIntent = Extract<
+  WorkbenchMinimizedDockRestoreIntent,
+  { kind: "stack-popup-card" }
+>;
+
+export function useWorkbenchHostDockInteractions({
+  clearHoverPanelOpenTimer,
+  clearHoverPanelRestTarget,
+  clearLabelTooltipOpenTimer,
+  clearSlotMagnification,
+  closeHoverPanelImmediate,
+  closeLabelTooltipImmediate,
+  pauseDockMagnification,
+  slotRefs
+}: {
+  clearHoverPanelOpenTimer: () => void;
+  clearHoverPanelRestTarget: () => void;
+  clearLabelTooltipOpenTimer: () => void;
+  clearSlotMagnification: (anchorKey: string) => void;
+  closeHoverPanelImmediate: (entryId?: string) => void;
+  closeLabelTooltipImmediate: (targetKey?: string) => void;
+  pauseDockMagnification: () => void;
+  slotRefs: RefObject<Map<string, HTMLElement>>;
+}) {
+  const dockEntryClickThrottleUntilRef = useRef(new Map<string, number>());
+  const [
+    collapsingMinimizedLaunchAnchorKeys,
+    setCollapsingMinimizedLaunchAnchorKeys
+  ] = useState<Set<string>>(() => new Set());
+  const collapsingMinimizedLaunchTimerRef = useRef(
+    new Map<string, ReturnType<typeof setTimeout>>()
+  );
+
+  useEffect(
+    () => () => {
+      for (const timer of collapsingMinimizedLaunchTimerRef.current.values()) {
+        clearTimeout(timer);
+      }
+      collapsingMinimizedLaunchTimerRef.current.clear();
+    },
+    []
+  );
+
+  const clearCollapsingMinimizedLaunch = useCallback(
+    (anchorKey: string) => {
+      const timer = collapsingMinimizedLaunchTimerRef.current.get(anchorKey);
+      if (timer) {
+        clearTimeout(timer);
+        collapsingMinimizedLaunchTimerRef.current.delete(anchorKey);
+      }
+      const slotElement = slotRefs.current.get(anchorKey);
+      slotElement?.removeAttribute("data-collapsing");
+      slotElement?.style.removeProperty("--desktop-dock-collapse-inline-size");
+      slotElement?.style.removeProperty("--desktop-dock-collapse-block-size");
+      setCollapsingMinimizedLaunchAnchorKeys((current) => {
+        if (!current.has(anchorKey)) {
+          return current;
+        }
+        const next = new Set(current);
+        next.delete(anchorKey);
+        return next;
+      });
+    },
+    [slotRefs]
+  );
+
+  const scheduleCollapsingMinimizedLaunchClear = useCallback(
+    (anchorKey: string) => {
+      const existing = collapsingMinimizedLaunchTimerRef.current.get(anchorKey);
+      if (existing) {
+        clearTimeout(existing);
+      }
+      collapsingMinimizedLaunchTimerRef.current.set(
+        anchorKey,
+        setTimeout(() => {
+          clearCollapsingMinimizedLaunch(anchorKey);
+        }, minimizedDockSlotLayoutAnimationMs)
+      );
+    },
+    [clearCollapsingMinimizedLaunch]
+  );
+
+  const isDockEntryClickThrottled = useCallback(
+    (anchorKey: string): boolean => {
+      const throttledUntil =
+        dockEntryClickThrottleUntilRef.current.get(anchorKey);
+      return throttledUntil !== undefined && Date.now() < throttledUntil;
+    },
+    []
+  );
+
+  const claimDockEntryClick = useCallback((anchorKey: string): void => {
+    dockEntryClickThrottleUntilRef.current.set(
+      anchorKey,
+      Date.now() + dockEntryClickThrottleMs
+    );
+  }, []);
+
+  const beginDockMinimizedInteraction = useCallback(
+    (anchorKey?: string): boolean => {
+      clearHoverPanelRestTarget();
+      clearHoverPanelOpenTimer();
+      clearLabelTooltipOpenTimer();
+      closeLabelTooltipImmediate();
+      closeHoverPanelImmediate();
+      pauseDockMagnification();
+
+      if (!anchorKey) {
+        return false;
+      }
+      const slotElement = slotRefs.current.get(anchorKey);
+      if (!slotElement) {
+        return false;
+      }
+      clearSlotMagnification(anchorKey);
+      if (slotElement.dataset.collapsing === "true") {
+        return true;
+      }
+      const rect = slotElement.getBoundingClientRect();
+      slotElement.style.setProperty(
+        "--desktop-dock-collapse-inline-size",
+        `${rect.width}px`
+      );
+      slotElement.style.setProperty(
+        "--desktop-dock-collapse-block-size",
+        `${rect.height}px`
+      );
+      slotElement.dataset.collapsing = "true";
+      return true;
+    },
+    [
+      clearHoverPanelOpenTimer,
+      clearHoverPanelRestTarget,
+      clearLabelTooltipOpenTimer,
+      clearSlotMagnification,
+      closeHoverPanelImmediate,
+      closeLabelTooltipImmediate,
+      pauseDockMagnification,
+      slotRefs
+    ]
+  );
+
+  const runDockMinimizedLaunchAfterCollapse = useCallback(
+    (
+      intent: WorkbenchMinimizedDockNodeSlotRestoreIntent,
+      launch: (intent: WorkbenchMinimizedDockNodeSlotRestoreIntent) => void
+    ) => {
+      const { anchorKey } = intent;
+      beginDockMinimizedInteraction(anchorKey);
+      setCollapsingMinimizedLaunchAnchorKeys((current) => {
+        const next = new Set(current);
+        next.add(anchorKey);
+        return next;
+      });
+      scheduleCollapsingMinimizedLaunchClear(anchorKey);
+      launch(intent);
+    },
+    [beginDockMinimizedInteraction, scheduleCollapsingMinimizedLaunchClear]
+  );
+
+  const runDockMinimizedStackLaunch = useCallback(
+    (
+      intent: WorkbenchMinimizedDockStackPopupCardRestoreIntent,
+      launch: (
+        intent: WorkbenchMinimizedDockStackPopupCardRestoreIntent
+      ) => void
+    ) => {
+      beginDockMinimizedInteraction();
+      launch(intent);
+    },
+    [beginDockMinimizedInteraction]
+  );
+
+  return {
+    beginDockMinimizedInteraction,
+    claimDockEntryClick,
+    clearCollapsingMinimizedLaunch,
+    collapsingMinimizedLaunchAnchorKeys,
+    isDockEntryClickThrottled,
+    runDockMinimizedLaunchAfterCollapse,
+    runDockMinimizedStackLaunch
+  };
+}

--- a/packages/workbench/surface/src/host/useWorkbenchHostDockOverlays.ts
+++ b/packages/workbench/surface/src/host/useWorkbenchHostDockOverlays.ts
@@ -1,0 +1,656 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type RefObject
+} from "react";
+import { resolveDockLabelTooltipAnchorRect } from "./dockLabelTooltipAnchor.ts";
+
+export interface WorkbenchHostDockLabelTooltipTarget {
+  key: string;
+  label: string;
+}
+
+export interface WorkbenchHostDockLabelTooltipState extends WorkbenchHostDockLabelTooltipTarget {
+  anchorKey: string;
+  anchorRect: {
+    height: number;
+    left: number;
+    top: number;
+    width: number;
+  };
+}
+
+export interface WorkbenchHostDockHoverPanelState {
+  anchorKey: string;
+  anchorRect: {
+    height: number;
+    left: number;
+    top: number;
+    width: number;
+  };
+  entryId: string;
+}
+
+const dockHoverPanelOpenDelayMs = 120;
+const dockHoverPanelCloseDelayMs = 160;
+const dockHoverPanelHitSlopPx = 12;
+const dockHoverPanelBridgeSlopPx = 6;
+const dockHoverPanelPointerRestTolerancePx = 4;
+
+export function dockLabelTooltipTarget(
+  key: string,
+  label: string
+): WorkbenchHostDockLabelTooltipTarget {
+  return { key, label: label.trim() };
+}
+
+export function useWorkbenchHostDockOverlays({
+  dockMeasureRef,
+  flushPendingDockStateRefresh,
+  handleDockPointerLeave,
+  handleDockPointerMove,
+  pauseDockMagnification,
+  slotRefs,
+  triggerDockBounce
+}: {
+  dockMeasureRef: RefObject<HTMLDivElement | null>;
+  flushPendingDockStateRefresh: () => void;
+  handleDockPointerLeave: () => void;
+  handleDockPointerMove: (clientX: number, clientY: number) => void;
+  pauseDockMagnification: () => void;
+  slotRefs: RefObject<Map<string, HTMLElement>>;
+  triggerDockBounce: (anchorKey: string) => void;
+}) {
+  const hoverPanelRef = useRef<HTMLDivElement | null>(null);
+  const hoverPanelCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
+  const hoverPanelOpenTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
+  const labelTooltipOpenTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
+  const hoverPanelScheduledPointRef = useRef<{
+    clientX: number;
+    clientY: number;
+  } | null>(null);
+  const labelTooltipScheduledPointRef = useRef<{
+    clientX: number;
+    clientY: number;
+  } | null>(null);
+  const hoverPanelRestTargetRef = useRef<{
+    anchorKey: string;
+    entryId: string;
+  } | null>(null);
+  const activeHoverPanelRef = useRef<WorkbenchHostDockHoverPanelState | null>(
+    null
+  );
+  const activeLabelTooltipRef =
+    useRef<WorkbenchHostDockLabelTooltipState | null>(null);
+  const [activeHoverPanel, setActiveHoverPanel] =
+    useState<WorkbenchHostDockHoverPanelState | null>(null);
+  const [activeLabelTooltip, setActiveLabelTooltip] =
+    useState<WorkbenchHostDockLabelTooltipState | null>(null);
+
+  const clearHoverPanelCloseTimer = useCallback(() => {
+    if (hoverPanelCloseTimerRef.current === null) {
+      return;
+    }
+    clearTimeout(hoverPanelCloseTimerRef.current);
+    hoverPanelCloseTimerRef.current = null;
+  }, []);
+
+  const clearHoverPanelOpenTimer = useCallback(() => {
+    if (hoverPanelOpenTimerRef.current === null) {
+      return;
+    }
+    clearTimeout(hoverPanelOpenTimerRef.current);
+    hoverPanelOpenTimerRef.current = null;
+    hoverPanelScheduledPointRef.current = null;
+  }, []);
+
+  const clearLabelTooltipOpenTimer = useCallback(() => {
+    if (labelTooltipOpenTimerRef.current === null) {
+      return;
+    }
+    clearTimeout(labelTooltipOpenTimerRef.current);
+    labelTooltipOpenTimerRef.current = null;
+    labelTooltipScheduledPointRef.current = null;
+  }, []);
+
+  useEffect(
+    () => () => {
+      clearHoverPanelCloseTimer();
+      clearHoverPanelOpenTimer();
+      clearLabelTooltipOpenTimer();
+    },
+    [
+      clearHoverPanelCloseTimer,
+      clearHoverPanelOpenTimer,
+      clearLabelTooltipOpenTimer
+    ]
+  );
+
+  const setDockHoverPanelOpen = useCallback(
+    (open: boolean) => {
+      if (open) {
+        dockMeasureRef.current?.setAttribute(
+          "data-dock-hover-panel-open",
+          "true"
+        );
+        return;
+      }
+      dockMeasureRef.current?.removeAttribute("data-dock-hover-panel-open");
+    },
+    [dockMeasureRef]
+  );
+
+  useEffect(() => {
+    activeHoverPanelRef.current = activeHoverPanel;
+  }, [activeHoverPanel]);
+
+  useEffect(() => {
+    activeLabelTooltipRef.current = activeLabelTooltip;
+  }, [activeLabelTooltip]);
+
+  const closeLabelTooltipImmediate = useCallback(
+    (targetKey?: string) => {
+      clearLabelTooltipOpenTimer();
+      if (
+        targetKey !== undefined &&
+        activeLabelTooltipRef.current?.key !== targetKey
+      ) {
+        return;
+      }
+      if (activeLabelTooltipRef.current === null) {
+        return;
+      }
+      activeLabelTooltipRef.current = null;
+      setActiveLabelTooltip(null);
+    },
+    [clearLabelTooltipOpenTimer]
+  );
+
+  const closeHoverPanelImmediate = useCallback(
+    (entryId?: string) => {
+      clearHoverPanelOpenTimer();
+      clearHoverPanelCloseTimer();
+      if (
+        entryId !== undefined &&
+        activeHoverPanelRef.current?.entryId !== entryId
+      ) {
+        return;
+      }
+      if (activeHoverPanelRef.current === null) {
+        return;
+      }
+      hoverPanelRestTargetRef.current = null;
+      setDockHoverPanelOpen(false);
+      activeHoverPanelRef.current = null;
+      setActiveHoverPanel(null);
+      flushPendingDockStateRefresh();
+    },
+    [
+      clearHoverPanelCloseTimer,
+      clearHoverPanelOpenTimer,
+      flushPendingDockStateRefresh,
+      setDockHoverPanelOpen
+    ]
+  );
+
+  const dismissHoverPanelForPopup = useCallback(() => {
+    setDockHoverPanelOpen(false);
+    setActiveHoverPanel(null);
+  }, [setDockHoverPanelOpen]);
+
+  const scheduleHoverPanelClose = useCallback(
+    (entryId?: string) => {
+      clearHoverPanelOpenTimer();
+      clearHoverPanelCloseTimer();
+      hoverPanelCloseTimerRef.current = setTimeout(() => {
+        hoverPanelCloseTimerRef.current = null;
+        closeHoverPanelImmediate(entryId);
+        handleDockPointerLeave();
+      }, dockHoverPanelCloseDelayMs);
+    },
+    [
+      clearHoverPanelCloseTimer,
+      clearHoverPanelOpenTimer,
+      closeHoverPanelImmediate,
+      handleDockPointerLeave
+    ]
+  );
+
+  const showHoverPanel = useCallback(
+    (entryId: string, anchorKey: string, anchorElement: HTMLElement): void => {
+      const dockElement = dockMeasureRef.current;
+      if (!dockElement) {
+        return;
+      }
+
+      pauseDockMagnification();
+      const dockRect = dockElement.getBoundingClientRect();
+      const anchorRect = anchorElement.getBoundingClientRect();
+      clearHoverPanelCloseTimer();
+      const nextHoverPanel = {
+        anchorKey,
+        anchorRect: {
+          height: anchorRect.height,
+          left: anchorRect.left - dockRect.left,
+          top: anchorRect.top - dockRect.top,
+          width: anchorRect.width
+        },
+        entryId
+      };
+      setDockHoverPanelOpen(true);
+      activeHoverPanelRef.current = nextHoverPanel;
+      setActiveHoverPanel(nextHoverPanel);
+    },
+    [
+      clearHoverPanelCloseTimer,
+      dockMeasureRef,
+      pauseDockMagnification,
+      setDockHoverPanelOpen
+    ]
+  );
+
+  const scheduleHoverPanelAfterRest = useCallback(
+    (entryId: string, anchorKey: string) => {
+      hoverPanelRestTargetRef.current = { anchorKey, entryId };
+      clearHoverPanelOpenTimer();
+      hoverPanelScheduledPointRef.current = null;
+      hoverPanelOpenTimerRef.current = setTimeout(() => {
+        hoverPanelOpenTimerRef.current = null;
+        hoverPanelScheduledPointRef.current = null;
+        const pending = hoverPanelRestTargetRef.current;
+        if (!pending || pending.entryId !== entryId) {
+          return;
+        }
+        const slotElement = slotRefs.current.get(anchorKey);
+        if (!slotElement) {
+          return;
+        }
+        showHoverPanel(entryId, anchorKey, slotElement);
+      }, dockHoverPanelOpenDelayMs);
+    },
+    [clearHoverPanelOpenTimer, showHoverPanel, slotRefs]
+  );
+
+  const showLabelTooltip = useCallback(
+    (
+      target: WorkbenchHostDockLabelTooltipTarget,
+      anchorKey: string,
+      anchorElement: HTMLElement
+    ): void => {
+      const dockElement = dockMeasureRef.current;
+      if (!dockElement) {
+        return;
+      }
+
+      const dockRect = dockElement.getBoundingClientRect();
+      const anchorRect = resolveDockLabelTooltipAnchorRect(anchorElement);
+      clearLabelTooltipOpenTimer();
+      const nextTooltip = {
+        anchorKey,
+        anchorRect: {
+          height: anchorRect.height,
+          left: anchorRect.left - dockRect.left,
+          top: anchorRect.top - dockRect.top,
+          width: anchorRect.width
+        },
+        key: target.key,
+        label: target.label
+      };
+      activeLabelTooltipRef.current = nextTooltip;
+      setActiveLabelTooltip(nextTooltip);
+    },
+    [clearLabelTooltipOpenTimer, dockMeasureRef]
+  );
+
+  const scheduleLabelTooltipAfterRest = useCallback(
+    (target: WorkbenchHostDockLabelTooltipTarget, anchorKey: string) => {
+      clearLabelTooltipOpenTimer();
+      labelTooltipScheduledPointRef.current = null;
+      labelTooltipOpenTimerRef.current = setTimeout(() => {
+        labelTooltipOpenTimerRef.current = null;
+        labelTooltipScheduledPointRef.current = null;
+        const slotElement = slotRefs.current.get(anchorKey);
+        if (!slotElement) {
+          return;
+        }
+        showLabelTooltip(target, anchorKey, slotElement);
+      }, dockHoverPanelOpenDelayMs);
+    },
+    [clearLabelTooltipOpenTimer, showLabelTooltip, slotRefs]
+  );
+
+  const resolveHoverPanelTargetAtPoint = useCallback(
+    (
+      clientX: number,
+      clientY: number
+    ): {
+      anchorKey: string;
+      entryId: string;
+      slotElement: HTMLElement;
+    } | null => {
+      for (const [anchorKey, slotElement] of slotRefs.current) {
+        const entryId = slotElement.dataset.dockHoverPanelEntryId;
+        if (!entryId) {
+          continue;
+        }
+
+        const rect = slotElement.getBoundingClientRect();
+        if (
+          clientX >= rect.left - dockHoverPanelHitSlopPx &&
+          clientX <= rect.right + dockHoverPanelHitSlopPx &&
+          clientY >= rect.top - dockHoverPanelHitSlopPx &&
+          clientY <= rect.bottom + dockHoverPanelHitSlopPx
+        ) {
+          return { anchorKey, entryId, slotElement };
+        }
+      }
+      return null;
+    },
+    [slotRefs]
+  );
+
+  const resolveLabelTooltipTargetAtPoint = useCallback(
+    (
+      clientX: number,
+      clientY: number
+    ): {
+      anchorKey: string;
+      slotElement: HTMLElement;
+      target: WorkbenchHostDockLabelTooltipTarget;
+    } | null => {
+      for (const [anchorKey, slotElement] of slotRefs.current) {
+        if (slotElement.dataset.dockHoverPanelEntryId) {
+          continue;
+        }
+        const key = slotElement.dataset.dockLabelTooltipKey;
+        const label = slotElement.dataset.dockLabelTooltipLabel?.trim() ?? "";
+        if (!key || !label) {
+          continue;
+        }
+
+        const rect = slotElement.getBoundingClientRect();
+        if (
+          clientX >= rect.left - dockHoverPanelHitSlopPx &&
+          clientX <= rect.right + dockHoverPanelHitSlopPx &&
+          clientY >= rect.top - dockHoverPanelHitSlopPx &&
+          clientY <= rect.bottom + dockHoverPanelHitSlopPx
+        ) {
+          return {
+            anchorKey,
+            slotElement,
+            target: { key, label }
+          };
+        }
+      }
+      return null;
+    },
+    [slotRefs]
+  );
+
+  const isPointerInsideActiveHoverPanelRegion = useCallback(
+    (clientX: number, clientY: number): boolean => {
+      const currentHoverPanel = activeHoverPanelRef.current;
+      if (!currentHoverPanel) {
+        return false;
+      }
+
+      const anchorSlot = slotRefs.current.get(currentHoverPanel.anchorKey);
+      const panel = hoverPanelRef.current;
+      if (
+        !anchorSlot ||
+        !panel ||
+        !anchorSlot.isConnected ||
+        !panel.isConnected
+      ) {
+        return false;
+      }
+
+      const anchorRect = anchorSlot.getBoundingClientRect();
+      const panelRect = panel.getBoundingClientRect();
+      return (
+        rectContainsPoint(
+          anchorRect,
+          clientX,
+          clientY,
+          dockHoverPanelHitSlopPx
+        ) ||
+        rectContainsPoint(
+          panelRect,
+          clientX,
+          clientY,
+          dockHoverPanelHitSlopPx
+        ) ||
+        rectContainsPoint(
+          createHoverPanelBridgeRect(anchorRect, panelRect),
+          clientX,
+          clientY,
+          dockHoverPanelBridgeSlopPx
+        )
+      );
+    },
+    [slotRefs]
+  );
+
+  const scheduleHoverPanelAtPointAfterRest = useCallback(
+    (clientX: number, clientY: number) => {
+      const scheduledPoint = hoverPanelScheduledPointRef.current;
+      if (
+        hoverPanelOpenTimerRef.current !== null &&
+        scheduledPoint &&
+        Math.abs(clientX - scheduledPoint.clientX) <=
+          dockHoverPanelPointerRestTolerancePx &&
+        Math.abs(clientY - scheduledPoint.clientY) <=
+          dockHoverPanelPointerRestTolerancePx
+      ) {
+        return;
+      }
+
+      clearHoverPanelOpenTimer();
+      hoverPanelScheduledPointRef.current = { clientX, clientY };
+      hoverPanelOpenTimerRef.current = setTimeout(() => {
+        hoverPanelOpenTimerRef.current = null;
+        hoverPanelScheduledPointRef.current = null;
+        if (activeHoverPanelRef.current !== null) {
+          return;
+        }
+        const target = resolveHoverPanelTargetAtPoint(clientX, clientY);
+        if (!target) {
+          hoverPanelRestTargetRef.current = null;
+          return;
+        }
+        hoverPanelRestTargetRef.current = {
+          anchorKey: target.anchorKey,
+          entryId: target.entryId
+        };
+        showHoverPanel(target.entryId, target.anchorKey, target.slotElement);
+      }, dockHoverPanelOpenDelayMs);
+    },
+    [clearHoverPanelOpenTimer, resolveHoverPanelTargetAtPoint, showHoverPanel]
+  );
+
+  const scheduleLabelTooltipAtPointAfterRest = useCallback(
+    (clientX: number, clientY: number) => {
+      if (activeLabelTooltipRef.current !== null) {
+        return;
+      }
+
+      const scheduledPoint = labelTooltipScheduledPointRef.current;
+      if (
+        labelTooltipOpenTimerRef.current !== null &&
+        scheduledPoint &&
+        Math.abs(clientX - scheduledPoint.clientX) <=
+          dockHoverPanelPointerRestTolerancePx &&
+        Math.abs(clientY - scheduledPoint.clientY) <=
+          dockHoverPanelPointerRestTolerancePx
+      ) {
+        return;
+      }
+
+      clearLabelTooltipOpenTimer();
+      labelTooltipScheduledPointRef.current = { clientX, clientY };
+      labelTooltipOpenTimerRef.current = setTimeout(() => {
+        labelTooltipOpenTimerRef.current = null;
+        labelTooltipScheduledPointRef.current = null;
+        if (activeHoverPanelRef.current !== null) {
+          return;
+        }
+        const target = resolveLabelTooltipTargetAtPoint(clientX, clientY);
+        if (!target) {
+          return;
+        }
+        showLabelTooltip(target.target, target.anchorKey, target.slotElement);
+      }, dockHoverPanelOpenDelayMs);
+    },
+    [
+      clearLabelTooltipOpenTimer,
+      resolveLabelTooltipTargetAtPoint,
+      showLabelTooltip
+    ]
+  );
+
+  const beginDockIconInteraction = useCallback(
+    (anchorKey: string) => {
+      hoverPanelRestTargetRef.current = null;
+      clearHoverPanelOpenTimer();
+      closeLabelTooltipImmediate();
+      closeHoverPanelImmediate();
+      triggerDockBounce(anchorKey);
+    },
+    [
+      clearHoverPanelOpenTimer,
+      closeHoverPanelImmediate,
+      closeLabelTooltipImmediate,
+      triggerDockBounce
+    ]
+  );
+
+  const handleDockPointerTravel = useCallback(
+    (clientX: number, clientY: number) => {
+      if (activeHoverPanelRef.current !== null) {
+        closeLabelTooltipImmediate();
+        if (isPointerInsideActiveHoverPanelRegion(clientX, clientY)) {
+          clearHoverPanelCloseTimer();
+          return;
+        }
+        scheduleHoverPanelClose(activeHoverPanelRef.current.entryId);
+        handleDockPointerLeave();
+        return;
+      }
+
+      const currentLabelTooltip = activeLabelTooltipRef.current;
+      if (currentLabelTooltip) {
+        const target = resolveLabelTooltipTargetAtPoint(clientX, clientY);
+        if (target?.target.key !== currentLabelTooltip.key) {
+          closeLabelTooltipImmediate(currentLabelTooltip.key);
+        }
+      }
+
+      handleDockPointerMove(clientX, clientY);
+      scheduleHoverPanelAtPointAfterRest(clientX, clientY);
+      scheduleLabelTooltipAtPointAfterRest(clientX, clientY);
+    },
+    [
+      clearHoverPanelCloseTimer,
+      closeLabelTooltipImmediate,
+      handleDockPointerMove,
+      handleDockPointerLeave,
+      isPointerInsideActiveHoverPanelRegion,
+      resolveLabelTooltipTargetAtPoint,
+      scheduleHoverPanelClose,
+      scheduleHoverPanelAtPointAfterRest,
+      scheduleLabelTooltipAtPointAfterRest
+    ]
+  );
+
+  const clearHoverPanelRestTarget = useCallback(() => {
+    hoverPanelRestTargetRef.current = null;
+  }, []);
+
+  const clearHoverPanelRestTargetForAnchor = useCallback(
+    (anchorKey: string) => {
+      if (hoverPanelRestTargetRef.current?.anchorKey === anchorKey) {
+        hoverPanelRestTargetRef.current = null;
+      }
+    },
+    []
+  );
+
+  const handleDockRootPointerLeave = useCallback(() => {
+    hoverPanelRestTargetRef.current = null;
+    clearHoverPanelOpenTimer();
+    clearLabelTooltipOpenTimer();
+    closeLabelTooltipImmediate();
+    closeHoverPanelImmediate();
+    handleDockPointerLeave();
+    flushPendingDockStateRefresh();
+  }, [
+    clearHoverPanelOpenTimer,
+    clearLabelTooltipOpenTimer,
+    closeHoverPanelImmediate,
+    closeLabelTooltipImmediate,
+    flushPendingDockStateRefresh,
+    handleDockPointerLeave
+  ]);
+
+  return {
+    activeHoverPanel,
+    activeLabelTooltip,
+    beginDockIconInteraction,
+    clearHoverPanelCloseTimer,
+    clearHoverPanelOpenTimer,
+    clearHoverPanelRestTarget,
+    clearHoverPanelRestTargetForAnchor,
+    clearLabelTooltipOpenTimer,
+    closeHoverPanelImmediate,
+    closeLabelTooltipImmediate,
+    dismissHoverPanelForPopup,
+    handleDockPointerTravel,
+    handleDockRootPointerLeave,
+    hoverPanelRef,
+    scheduleHoverPanelAfterRest,
+    scheduleHoverPanelAtPointAfterRest,
+    scheduleHoverPanelClose,
+    scheduleLabelTooltipAfterRest,
+    scheduleLabelTooltipAtPointAfterRest,
+    showHoverPanel,
+    showLabelTooltip
+  };
+}
+
+function rectContainsPoint(
+  rect: DOMRect,
+  clientX: number,
+  clientY: number,
+  slopPx = 0
+): boolean {
+  return (
+    clientX >= rect.left - slopPx &&
+    clientX <= rect.right + slopPx &&
+    clientY >= rect.top - slopPx &&
+    clientY <= rect.bottom + slopPx
+  );
+}
+
+function createHoverPanelBridgeRect(anchor: DOMRect, panel: DOMRect): DOMRect {
+  if (anchor.right <= panel.left || panel.right <= anchor.left) {
+    const left = Math.min(anchor.right, panel.right);
+    const right = Math.max(anchor.left, panel.left);
+    const top = Math.max(anchor.top, panel.top);
+    const bottom = Math.min(anchor.bottom, panel.bottom);
+    return new DOMRect(left, top, right - left, Math.max(0, bottom - top));
+  }
+
+  const left = Math.max(anchor.left, panel.left);
+  const right = Math.min(anchor.right, panel.right);
+  const top = Math.min(anchor.bottom, panel.bottom);
+  const bottom = Math.max(anchor.top, panel.top);
+  return new DOMRect(left, top, Math.max(0, right - left), bottom - top);
+}

--- a/packages/workbench/surface/src/host/useWorkbenchHostDockPresence.ts
+++ b/packages/workbench/surface/src/host/useWorkbenchHostDockPresence.ts
@@ -1,0 +1,73 @@
+import { useEffect, useRef, useState } from "react";
+import type { WorkbenchHostDockItem } from "./dockItems.ts";
+import {
+  resolveDockPresenceItems,
+  resolveDockPresenceSettleMs,
+  type WorkbenchHostPresentDockItem
+} from "./dockPresence.ts";
+
+export function useWorkbenchHostDockPresence(
+  items: readonly WorkbenchHostDockItem[],
+  shouldAnimateMinimizedDockEnter: (nodeId: string) => boolean
+): WorkbenchHostPresentDockItem[] {
+  const latestItemsByKey = useRef(new Map<string, WorkbenchHostDockItem>());
+  const shouldAnimateMinimizedDockEnterRef = useRef(
+    shouldAnimateMinimizedDockEnter
+  );
+  latestItemsByKey.current = new Map(items.map((item) => [item.key, item]));
+  shouldAnimateMinimizedDockEnterRef.current = shouldAnimateMinimizedDockEnter;
+  const itemKeys = items.map((item) => item.key).join("\u0000");
+  const [presentItems, setPresentItems] = useState<
+    WorkbenchHostPresentDockItem[]
+  >(() =>
+    items.map((item) => ({
+      item,
+      key: item.key,
+      presence: "present" as const
+    }))
+  );
+  const initialized = useRef(false);
+
+  useEffect(() => {
+    let nextSettleMs = 300;
+
+    setPresentItems((current) => {
+      const filteredItems = resolveDockPresenceItems({
+        current,
+        initialized: initialized.current,
+        nextSourceItems: [...latestItemsByKey.current.values()],
+        shouldAnimateMinimizedDockEnter:
+          shouldAnimateMinimizedDockEnterRef.current
+      });
+      nextSettleMs = resolveDockPresenceSettleMs(filteredItems);
+      return filteredItems;
+    });
+    initialized.current = true;
+
+    const timeout = globalThis.setTimeout(() => {
+      setPresentItems((current) =>
+        current
+          .filter((item) => item.presence !== "exiting")
+          .map((item) =>
+            item.presence === "entering"
+              ? { ...item, presence: "present" as const }
+              : item
+          )
+      );
+    }, nextSettleMs);
+
+    return () => globalThis.clearTimeout(timeout);
+  }, [itemKeys]);
+
+  const renderedPresentItems = resolveDockPresenceItems({
+    current: presentItems,
+    initialized: initialized.current,
+    nextSourceItems: [...latestItemsByKey.current.values()],
+    shouldAnimateMinimizedDockEnter
+  });
+
+  return renderedPresentItems.map((presentItem) => {
+    const latestItem = latestItemsByKey.current.get(presentItem.key);
+    return latestItem ? { ...presentItem, item: latestItem } : presentItem;
+  });
+}

--- a/packages/workbench/surface/src/host/useWorkbenchHostDockViewport.ts
+++ b/packages/workbench/surface/src/host/useWorkbenchHostDockViewport.ts
@@ -1,0 +1,286 @@
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
+import {
+  DOCK_ICON_PEAK_SIZE,
+  useDockMagnification
+} from "./dockMagnification.ts";
+import {
+  resolveWorkbenchHostDockScrollState,
+  type WorkbenchHostDockScrollState
+} from "./dockScrollState.ts";
+import type { WorkbenchHostProps } from "./types.ts";
+import { useWorkbenchHostDockBounce } from "./useWorkbenchHostDockBounce.ts";
+import { useWorkbenchHostDockWallpaperTones } from "./useWorkbenchHostDockWallpaperTones.ts";
+
+export type WorkbenchHostDockScrollDirection = "backward" | "forward";
+
+const desktopDockPlateChromeWidth = 15.3;
+
+export function useWorkbenchHostDockViewport({
+  dockItemsCount,
+  dockItemsKey,
+  dockPlacement,
+  dockWidth,
+  registerDockAnchor
+}: {
+  dockItemsCount: number;
+  dockItemsKey: string;
+  dockPlacement: NonNullable<WorkbenchHostProps["dockPlacement"]>;
+  dockWidth: number;
+  registerDockAnchor: (anchorKey: string, element: HTMLElement | null) => void;
+}) {
+  const dockPlateRef = useRef<HTMLDivElement | null>(null);
+  const dockMeasureRef = useRef<HTMLDivElement | null>(null);
+  const dockItemsRef = useRef<HTMLDivElement | null>(null);
+  const slotRefs = useRef(new Map<string, HTMLElement>());
+  const wallpaperToneElementRefs = useRef(new Map<string, HTMLElement>());
+  const dockSlotRefCallbacksRef = useRef(
+    new Map<string, (element: HTMLElement | null) => void>()
+  );
+  const clearSlotMagnificationRef = useRef<(anchorKey: string) => void>(() => {
+    return;
+  });
+  const registerDockAnchorRef = useRef(registerDockAnchor);
+  const [dockFrameSize, setDockFrameSize] = useState<number | null>(null);
+  const [dockScrollState, setDockScrollState] =
+    useState<WorkbenchHostDockScrollState>(() => ({
+      canScrollBackward: false,
+      canScrollForward: false,
+      hasOverflow: false
+    }));
+  const { triggerDockBounce } = useWorkbenchHostDockBounce(slotRefs);
+
+  useLayoutEffect(() => {
+    const element = dockMeasureRef.current;
+    if (!element || typeof window === "undefined") {
+      return undefined;
+    }
+
+    let frameId: number | null = null;
+    const updateDockFrameSize = () => {
+      frameId = null;
+      if (isDockVisualMutationActive(dockMeasureRef.current)) {
+        return;
+      }
+      const rect = element.getBoundingClientRect();
+      const nextSize = Math.ceil(
+        (dockPlacement === "left" ? rect.height : rect.width) +
+          desktopDockPlateChromeWidth
+      );
+      setDockFrameSize((current) =>
+        current === nextSize ? current : nextSize
+      );
+    };
+    const scheduleUpdate = () => {
+      if (frameId !== null) {
+        return;
+      }
+      frameId = window.requestAnimationFrame(updateDockFrameSize);
+    };
+
+    updateDockFrameSize();
+
+    const resizeObserver =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(scheduleUpdate);
+    resizeObserver?.observe(element);
+    window.addEventListener("resize", scheduleUpdate);
+
+    return () => {
+      if (frameId !== null) {
+        window.cancelAnimationFrame(frameId);
+      }
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", scheduleUpdate);
+    };
+  }, [dockPlacement]);
+
+  const wallpaperTones = useWorkbenchHostDockWallpaperTones({
+    dockItemsRef,
+    elementRefs: wallpaperToneElementRefs,
+    itemKeys: dockItemsKey
+  });
+  const magnification = useDockMagnification({
+    dockPlateRef,
+    dockPlacement,
+    dockRootRef: dockMeasureRef,
+    dockViewportRef: dockItemsRef,
+    slotRefs
+  });
+
+  clearSlotMagnificationRef.current = magnification.clearSlotMagnification;
+  registerDockAnchorRef.current = registerDockAnchor;
+
+  const updateDockScrollState = useCallback(() => {
+    const scrollElement = dockItemsRef.current;
+    const viewportElement = dockMeasureRef.current;
+    if (!scrollElement || !viewportElement) {
+      setDockScrollState((current) =>
+        current.hasOverflow ||
+        current.canScrollBackward ||
+        current.canScrollForward
+          ? {
+              canScrollBackward: false,
+              canScrollForward: false,
+              hasOverflow: false
+            }
+          : current
+      );
+      return;
+    }
+
+    const isVertical = dockPlacement === "left";
+    const viewportSize = isVertical
+      ? viewportElement.clientHeight
+      : viewportElement.clientWidth;
+    const scrollSize = isVertical
+      ? scrollElement.scrollHeight
+      : scrollElement.scrollWidth;
+    const scrollOffset = isVertical
+      ? scrollElement.scrollTop
+      : scrollElement.scrollLeft;
+    const nextState = resolveWorkbenchHostDockScrollState({
+      contentSize: dockWidth,
+      scrollOffset,
+      scrollSize,
+      viewportSize
+    });
+
+    setDockScrollState((current) =>
+      current.canScrollBackward === nextState.canScrollBackward &&
+      current.canScrollForward === nextState.canScrollForward &&
+      current.hasOverflow === nextState.hasOverflow
+        ? current
+        : nextState
+    );
+  }, [dockPlacement, dockWidth]);
+
+  useLayoutEffect(() => {
+    const element = dockItemsRef.current;
+    if (!element || typeof window === "undefined") {
+      return undefined;
+    }
+
+    let frameId: number | null = null;
+    const scheduleUpdate = () => {
+      if (isDockVisualMutationActive(dockMeasureRef.current)) {
+        return;
+      }
+      if (frameId !== null) {
+        return;
+      }
+      frameId = window.requestAnimationFrame(() => {
+        frameId = null;
+        updateDockScrollState();
+      });
+    };
+
+    updateDockScrollState();
+
+    const resizeObserver =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(scheduleUpdate);
+    resizeObserver?.observe(element);
+    window.addEventListener("resize", scheduleUpdate);
+    element.addEventListener("scroll", scheduleUpdate, { passive: true });
+
+    return () => {
+      if (frameId !== null) {
+        window.cancelAnimationFrame(frameId);
+      }
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", scheduleUpdate);
+      element.removeEventListener("scroll", scheduleUpdate);
+    };
+  }, [dockItemsCount, dockPlacement, updateDockScrollState]);
+
+  const registerWallpaperToneElement = useCallback(
+    (key: string) => (element: HTMLElement | null) => {
+      if (element) {
+        wallpaperToneElementRefs.current.set(key, element);
+        return;
+      }
+      wallpaperToneElementRefs.current.delete(key);
+    },
+    []
+  );
+
+  const registerDockSlot = useCallback((anchorKey: string) => {
+    const existing = dockSlotRefCallbacksRef.current.get(anchorKey);
+    if (existing) {
+      return existing;
+    }
+
+    const callback = (element: HTMLElement | null) => {
+      if (element) {
+        slotRefs.current.set(anchorKey, element);
+        wallpaperToneElementRefs.current.set(anchorKey, element);
+      } else {
+        slotRefs.current.delete(anchorKey);
+        wallpaperToneElementRefs.current.delete(anchorKey);
+        if (!dockMeasureRef.current?.hasAttribute("data-dock-pointer-active")) {
+          clearSlotMagnificationRef.current(anchorKey);
+        }
+      }
+      registerDockAnchorRef.current(anchorKey, element);
+    };
+    dockSlotRefCallbacksRef.current.set(anchorKey, callback);
+    return callback;
+  }, []);
+
+  const scrollDockItems = useCallback(
+    (direction: WorkbenchHostDockScrollDirection) => {
+      const element = dockItemsRef.current;
+      if (!element) {
+        return;
+      }
+
+      const isVertical = dockPlacement === "left";
+      const viewportSize = isVertical
+        ? element.clientHeight
+        : element.clientWidth;
+      const delta =
+        Math.max(DOCK_ICON_PEAK_SIZE * 2, viewportSize * 0.72) *
+        (direction === "forward" ? 1 : -1);
+
+      element.scrollBy({
+        behavior: "smooth",
+        left: isVertical ? 0 : delta,
+        top: isVertical ? delta : 0
+      });
+    },
+    [dockPlacement]
+  );
+
+  return {
+    ...magnification,
+    dockFrameSize,
+    dockItemsRef,
+    dockMeasureRef,
+    dockPlateRef,
+    dockScrollState,
+    registerDockSlot,
+    registerWallpaperToneElement,
+    scrollDockItems,
+    slotRefs,
+    triggerDockBounce,
+    wallpaperTones
+  };
+}
+
+export function isDockVisualMutationActive(
+  element: HTMLElement | null
+): boolean {
+  if (!element) {
+    return false;
+  }
+
+  return (
+    element.hasAttribute("data-dock-pointer-active") ||
+    element.hasAttribute("data-dock-hover-panel-open") ||
+    element.querySelector(
+      '[data-collapsing="true"], [data-presence="entering"], [data-presence="exiting"], [data-stack-dispatching="true"], [data-promoted-from-stack="true"]'
+    ) !== null
+  );
+}

--- a/packages/workbench/surface/src/host/useWorkbenchHostDockWallpaperTones.ts
+++ b/packages/workbench/surface/src/host/useWorkbenchHostDockWallpaperTones.ts
@@ -1,0 +1,180 @@
+import { useLayoutEffect, useState, type RefObject } from "react";
+import {
+  getDockWallpaperImageSample,
+  parseDockWallpaperCssUrl,
+  resolveDockWallpaperRenderedImageRect,
+  sampleDockWallpaperLuminanceAtElement
+} from "./dockWallpaperSampling.ts";
+
+export type WorkbenchDockWallpaperTone = "dark" | "light";
+
+const dockWallpaperDarkLuminanceThreshold = 132;
+const dockWallpaperImageCache = new Map<
+  string,
+  Promise<HTMLImageElement | null>
+>();
+
+export function useWorkbenchHostDockWallpaperTones({
+  dockItemsRef,
+  elementRefs,
+  itemKeys
+}: {
+  dockItemsRef: RefObject<HTMLElement | null>;
+  elementRefs: RefObject<Map<string, HTMLElement>>;
+  itemKeys: string;
+}): ReadonlyMap<string, WorkbenchDockWallpaperTone> {
+  const [tones, setTones] = useState<Map<string, WorkbenchDockWallpaperTone>>(
+    () => new Map()
+  );
+
+  useLayoutEffect(() => {
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+
+    let canceled = false;
+    let frameId: number | null = null;
+
+    const updateTones = () => {
+      frameId = null;
+      void resolveDockWallpaperTones({
+        dockItemsElement: dockItemsRef.current,
+        elements: elementRefs.current
+      }).then((nextTones) => {
+        if (canceled) {
+          return;
+        }
+        setTones((current) =>
+          dockWallpaperToneMapsEqual(current, nextTones) ? current : nextTones
+        );
+      });
+    };
+
+    const scheduleUpdate = () => {
+      if (frameId !== null) {
+        return;
+      }
+      frameId = window.requestAnimationFrame(updateTones);
+    };
+
+    scheduleUpdate();
+    window.addEventListener("resize", scheduleUpdate);
+
+    const resizeObserver =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(scheduleUpdate);
+    if (dockItemsRef.current) {
+      resizeObserver?.observe(dockItemsRef.current);
+    }
+    const wallpaperElement = dockItemsRef.current
+      ?.closest(".workbench-surface")
+      ?.querySelector(".workbench-surface__wallpaper");
+    if (wallpaperElement instanceof HTMLElement) {
+      resizeObserver?.observe(wallpaperElement);
+    }
+
+    return () => {
+      canceled = true;
+      if (frameId !== null) {
+        window.cancelAnimationFrame(frameId);
+      }
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", scheduleUpdate);
+    };
+  }, [dockItemsRef, elementRefs, itemKeys]);
+
+  return tones;
+}
+
+async function resolveDockWallpaperTones({
+  dockItemsElement,
+  elements
+}: {
+  dockItemsElement: HTMLElement | null;
+  elements: ReadonlyMap<string, HTMLElement>;
+}): Promise<Map<string, WorkbenchDockWallpaperTone>> {
+  const wallpaperElement = dockItemsElement
+    ?.closest(".workbench-surface")
+    ?.querySelector(".workbench-surface__wallpaper");
+  if (!(wallpaperElement instanceof HTMLElement)) {
+    return new Map();
+  }
+
+  const wallpaperStyle = window.getComputedStyle(wallpaperElement);
+  const wallpaperUrl = parseDockWallpaperCssUrl(wallpaperStyle.backgroundImage);
+  if (!wallpaperUrl) {
+    return new Map();
+  }
+
+  const wallpaperImage = await loadDockWallpaperImage(wallpaperUrl);
+  if (!wallpaperImage) {
+    return new Map();
+  }
+
+  const wallpaperSample = getDockWallpaperImageSample(wallpaperImage);
+  if (!wallpaperSample) {
+    return new Map();
+  }
+
+  const wallpaperRect = wallpaperElement.getBoundingClientRect();
+  const renderedImageRect = resolveDockWallpaperRenderedImageRect({
+    containerHeight: wallpaperRect.height,
+    containerWidth: wallpaperRect.width,
+    imageHeight: wallpaperImage.naturalHeight,
+    imageWidth: wallpaperImage.naturalWidth,
+    positionX: wallpaperStyle.backgroundPositionX,
+    positionY: wallpaperStyle.backgroundPositionY,
+    size: wallpaperStyle.backgroundSize
+  });
+  const nextTones = new Map<string, WorkbenchDockWallpaperTone>();
+
+  for (const [key, element] of elements) {
+    const luminance = sampleDockWallpaperLuminanceAtElement({
+      elementRect: element.getBoundingClientRect(),
+      renderedImageRect,
+      sample: wallpaperSample,
+      wallpaperRect
+    });
+    if (luminance === null) {
+      continue;
+    }
+    nextTones.set(
+      key,
+      luminance < dockWallpaperDarkLuminanceThreshold ? "dark" : "light"
+    );
+  }
+
+  return nextTones;
+}
+
+function loadDockWallpaperImage(url: string): Promise<HTMLImageElement | null> {
+  const cached = dockWallpaperImageCache.get(url);
+  if (cached) {
+    return cached;
+  }
+  const promise = new Promise<HTMLImageElement | null>((resolve) => {
+    const image = new Image();
+    image.decoding = "async";
+    image.onload = () => resolve(image);
+    image.onerror = () => resolve(null);
+    image.src = url;
+  });
+  dockWallpaperImageCache.set(url, promise);
+  return promise;
+}
+
+function dockWallpaperToneMapsEqual(
+  left: ReadonlyMap<string, WorkbenchDockWallpaperTone>,
+  right: ReadonlyMap<string, WorkbenchDockWallpaperTone>
+): boolean {
+  if (left.size !== right.size) {
+    return false;
+  }
+  for (const [key, value] of left) {
+    if (right.get(key) !== value) {
+      return false;
+    }
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary

- 将 WorkbenchHostDock 从 3563 行收敛到 728 行，根组件只保留数据归一化、hook 编排和呈现装配
- 按职责拆分条目模型、presence、wallpaper、viewport、activity、overlay、交互、普通/最小化槽位和 popup composition；所有新增业务文件均低于 800 行
- 保留既有公共 API、DOM/CSS、i18n、host 边界及点击、hover、popup、最小化恢复时序
- 新增纯模型和根级交互 characterization tests，覆盖五类激活路径、右键 payload、hover 去重、tooltip 以及独立/堆叠最小化恢复

Closes #1907

## Verification

- pnpm check:changed（9 个 lane 通过）
- pnpm check:changed -- --push-ready（10 个 lane 通过）
- pnpm --filter @tutti-os/workbench-surface test
- pnpm --filter @tutti-os/workbench-surface typecheck
- pnpm --filter @tutti-os/workbench-surface build
- make dev-gui：实际回归 Dock 启动与聚焦、右键新窗口、多窗口预览选择/关闭、单窗及双窗最小化恢复、键盘 tooltip；测试窗口已清理

## Fallback Three Questions

不适用。本 PR 未新增 timer、retry、cache 或 defensive branch 语义，仅将既有调度、节流和壁纸缓存逻辑迁移到独立 hook。

## Checklist

- [x] 本变更不涉及 agent lifecycle semantics
- [x] 变更聚焦于 Workbench Host Dock 内部重构
- [x] 已完成文档影响检查；公共行为、模块归属和使用方式未变化，无需更新持久化文档
- [x] 未修改 README 或 CONTRIBUTING
- [x] 已运行受影响范围内的最低有效检查及 GUI 回归
- [x] 提交包含 DCO sign-off