### PR TITLE
fix(agent): normalize transport fallback notices

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1479,6 +1479,13 @@ not call back into selection or Rail state. There is no separate messages-only
 Engine reconcile helper.
 
 Timeline projection is pure, deterministic, and provider-neutral. React views render rows/cards and dispatch actions.
+Provider runtime adapters normalize known connection-recovery output into the
+existing `transport_retry` and `transport_fallback` system-notice semantics
+before persistence. The transcript presents retry progress as a concise status;
+a successful transport fallback keeps its raw diagnostic detail behind the
+details disclosure without adding a separate success title. A narrow
+presentation compatibility check may recognize legacy fallback rows that were
+persisted as `warning`, but canonical writes remain semantic.
 Transcript Turn membership and order come only from timeline items in the
 hydrated message window. Session-wide canonical Turn metadata may enrich an
 already projected Turn by exact `turnId`—for example, by adding a view-only

--- a/packages/agent/daemon/runtime/acp_update_events.go
+++ b/packages/agent/daemon/runtime/acp_update_events.go
@@ -464,8 +464,7 @@ func acpSystemNoticeFromAgentText(text string) (map[string]any, bool) {
 			"source":     "agent_text",
 		}, true
 	}
-	if strings.Contains(normalized, "falling back from websockets to https transport") ||
-		strings.Contains(normalized, "switched to https transport") {
+	if acpAgentTextLooksLikeTransportFallback(normalized) {
 		return map[string]any{
 			"kind":       "agent_system_notice",
 			"noticeKind": "transport_fallback",
@@ -476,6 +475,11 @@ func acpSystemNoticeFromAgentText(text string) (map[string]any, bool) {
 		}, true
 	}
 	return nil, false
+}
+
+func acpAgentTextLooksLikeTransportFallback(normalized string) bool {
+	return strings.Contains(normalized, "falling back from websockets to https transport") ||
+		strings.Contains(normalized, "switched to https transport")
 }
 
 func acpAgentTextLooksLikeTransportRetry(normalized string) bool {

--- a/packages/agent/daemon/runtime/codex_appserver_events_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_events_test.go
@@ -157,6 +157,39 @@ func TestCodexAppServerCompactionKeepsUnrelatedWarnings(t *testing.T) {
 	}
 }
 
+func TestCodexAppServerNormalizesTransportFallbackWarning(t *testing.T) {
+	t.Parallel()
+
+	session := reportTestSession()
+	session.ProviderSessionID = "thread-1"
+	detail := "Falling back from WebSockets to HTTPS transport. request timed out"
+	reduction := newCodexAppServerReducer(&CodexAppServerAdapter{}).ReduceNotification(
+		nil,
+		session,
+		"turn-1",
+		acpMessage{
+			Method: appServerNotifyWarning,
+			Params: mustJSONRawMessage(t, map[string]any{
+				"threadId": "thread-1",
+				"turnId":   "provider-turn-1",
+				"message":  detail,
+			}),
+		},
+		newACPTurnNormalizer(),
+		nil,
+	)
+	if len(reduction.Events) != 1 {
+		t.Fatalf("transport fallback events = %#v, want one system notice", reduction.Events)
+	}
+	metadata := reduction.Events[0].Payload.Metadata
+	if got := asString(metadata["noticeKind"]); got != "transport_fallback" {
+		t.Fatalf("noticeKind = %q, want transport_fallback", got)
+	}
+	if got := asString(metadata["detail"]); got != detail {
+		t.Fatalf("detail = %q, want %q", got, detail)
+	}
+}
+
 func TestCodexAppServerCommandOutputDeltaUsesToolOutputFastLane(t *testing.T) {
 	t.Parallel()
 	session := reportTestSession()

--- a/packages/agent/daemon/runtime/codex_appserver_reducer.go
+++ b/packages/agent/daemon/runtime/codex_appserver_reducer.go
@@ -270,7 +270,11 @@ func (r codexAppServerReducer) reduceNotification(
 		if normalizer.HasCompactionNotice() && message == appServerCompactionAdvisoryMessage {
 			return emit(nil)
 		}
-		return emit([]activityshared.Event{appServerSystemNoticeEvent(session, turnID, "warning", "", message)})
+		noticeKind := "warning"
+		if acpAgentTextLooksLikeTransportFallback(strings.ToLower(strings.TrimSpace(message))) {
+			noticeKind = "transport_fallback"
+		}
+		return emit([]activityshared.Event{appServerSystemNoticeEvent(session, turnID, noticeKind, "", message)})
 	case appServerNotifyDeprecation:
 		return emit([]activityshared.Event{appServerSystemNoticeEvent(session, turnID, "warning",
 			asString(params["summary"]), asString(params["details"]))})

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
@@ -534,11 +534,10 @@ function AgentSystemNoticeMessage({
   message
 }: {
   message: AgentMessageContentVM;
-}): JSX.Element {
+}): JSX.Element | null {
   "use memo";
   const notice = message.systemNotice;
   const detail = notice?.detail?.trim() ?? "";
-  const title = systemNoticeTitle(message);
   if (notice?.noticeKind === "transport_retry") {
     const retryText = transportRetryNoticeText(message);
     return (
@@ -549,6 +548,19 @@ function AgentSystemNoticeMessage({
         {retryText}
       </div>
     );
+  }
+  if (
+    notice?.noticeKind === "transport_fallback" ||
+    isTransportFallbackNotice(message)
+  ) {
+    const diagnosticDetail =
+      detail || notice?.title?.trim() || message.body.trim();
+    return diagnosticDetail ? (
+      <AgentMessageDetailsDisclosure
+        detail={diagnosticDetail}
+        className="[&>button]:!text-[var(--text-primary)] [&>button>svg]:!text-[var(--text-primary)]"
+      />
+    ) : null;
   }
   if (isContextCompactionProgressNotice(message)) {
     return (
@@ -572,6 +584,7 @@ function AgentSystemNoticeMessage({
       />
     );
   }
+  const title = systemNoticeTitle(message);
   const isStatusNotice = systemNoticeIsStatus(message);
   return (
     <section

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
@@ -1117,8 +1117,8 @@ describe("AgentTranscriptItemView render stability", () => {
     }
   );
 
-  it("renders transport fallback notices with the localized label", () => {
-    const { getByRole, getByText } = render(
+  it("renders transport fallback notices as details without a status title", () => {
+    const { getByRole, queryByText } = render(
       <AgentMessageBlock
         workspaceRoot="/workspace/demo"
         basePath="/workspace/demo"
@@ -1141,14 +1141,21 @@ describe("AgentTranscriptItemView render stability", () => {
       />
     );
 
-    expect(getByRole("status")).toBeTruthy();
     expect(
-      getByText("agentHost.agentGui.systemNoticeTransportFallback")
+      queryByText("agentHost.agentGui.systemNoticeTransportFallback")
+    ).toBeNull();
+    expect(
+      queryByText("Falling back from WebSockets to HTTPS transport.")
+    ).toBeNull();
+    expect(
+      getByRole("button", {
+        name: "agentHost.agentGui.visibleErrorDetails"
+      })
     ).toBeTruthy();
   });
 
-  it("renders fallback warning notices with their title", () => {
-    const { getByRole, getByText } = render(
+  it("keeps historical fallback warnings details-only", () => {
+    const { getByRole, queryByText } = render(
       <AgentMessageBlock
         workspaceRoot="/workspace/demo"
         basePath="/workspace/demo"
@@ -1171,9 +1178,13 @@ describe("AgentTranscriptItemView render stability", () => {
       />
     );
 
-    expect(getByRole("status")).toBeTruthy();
     expect(
-      getByText("Falling back from WebSockets to HTTPS transport.")
+      queryByText("Falling back from WebSockets to HTTPS transport.")
+    ).toBeNull();
+    expect(
+      getByRole("button", {
+        name: "agentHost.agentGui.visibleErrorDetails"
+      })
     ).toBeTruthy();
   });
 


### PR DESCRIPTION
## 摘要

- 在 Codex app-server runtime 边界将 WebSocket 降级 HTTPS 的 warning 归一化为现有 transport_fallback 语义
- 默认会话只保留可展开的‘查看详情’，不再展示‘Agent 已切换到 HTTPS 传输’状态标题；详情入口使用正常正文色
- 兼容历史上以 warning 持久化的同类记录，并补充 runtime、renderer 测试及架构说明

## 验证

- pnpm check:changed -- --base upstream/main：14/14 通过
- pre-push pnpm check:changed -- --push-ready：16/16 通过
- Agent GUI 完整相关测试、Go runtime 测试、lint、typecheck、边界与退化检查均通过

## Fallback 三问

- 来源：Codex app-server 在 WebSocket 重试耗尽并降级到 HTTPS 时发送未分类 warning；历史数据库中也已存在此类 warning 记录
- 为什么不能只在来源修复：runtime 修复能保证新事件正确，但已持久化的历史记录仍需 renderer 使用既有特征兼容展示
- 移除条件：当兼容窗口结束且不再需要读取旧版 warning 记录时，可移除 renderer 的文本特征兼容；transport_fallback 语义渲染仍保留

## 检查清单

- [x] 不改变 Session、Turn、Goal 或 runtime-operation 生命周期语义
- [x] 改动聚焦于一个问题
- [x] 已更新受影响的架构文档
- [x] 未修改 README 或 CONTRIBUTING，无多语言同步要求
- [x] 已运行变更范围内的完整检查
- [x] 提交已包含 DCO Signed-off-by