### PR TITLE
fix(agent): recover disconnected provider sessions

### DIFF
--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -1132,20 +1132,27 @@ catalog revision mismatch`, fully restart `dev:desktop`; renderer HMR cannot
 - Symptom:
   A submitted Codex turn stays working without assistant text, reasoning, or
   tool activity. Stop may return quickly, but the next prompt on the same
-  conversation can stall in the same way.
+  conversation can stall in the same way. This also occurs when a conversation
+  is left offline and its first later submit loses the app-server connection.
 - Quick checks:
   Correlate `agent.submit.trace` records by `client_submit_id`, `turn_id`, and
   `agent_session_id`. A `turn.start.requested` without
   `turn.start.succeeded` means the immediate app-server acknowledgement did
   not arrive. After the bounded failure, confirm
   `agent_session.app_server.turn_start.client_invalidated` appears and the next
-  submit starts a new local process with `thread/resume`.
+  submit starts a new local process with `thread/resume`. An immediate
+  `turn.start.failed` with `error=EOF` is an outcome-unknown transport loss and
+  must still project one visible failed assistant message.
 - Root cause:
   Codex `turn/start` should acknowledge immediately and stream the actual work
   through notifications, but the adapter previously called it with no client
   deadline. A graceful Stop could acknowledge `turn/interrupt` without proving
   that the unacknowledged `turn/start` connection was healthy, so the adapter
-  retained and reused the same bad process.
+  retained and reused the same bad process. The live-session probe also treated
+  a retained client pointer as live after its `Done` channel closed. Finally, a
+  pre-acceptance `turn/start` failure was buffered as provider output even
+  though it had no provider Turn identity, hiding the canonical terminal from
+  the controller and GUI.
 - Fix:
   Bound only the `turn/start` acknowledgement to 30 seconds; do not bound the
   subsequent running turn. Treat deadline, cancellation before acknowledgement,
@@ -1153,12 +1160,17 @@ catalog revision mismatch`, fully restart `dev:desktop`; renderer HMR cannot
   from the live-session registry, and close it. Do not automatically replay the
   prompt because delivery is unknown. The next explicit submit uses the
   existing session recovery path to start a process and resume the provider
-  thread. Bound `turn/steer` acknowledgement separately to 10 seconds.
+  thread. A live-session probe must also reject terminated clients. Publish the
+  exact canonical `turn.failed` directly when `turn/start` fails before provider
+  acceptance, while dropping unaccepted provider-dependent output; this reuses
+  the normal visible-error projection without inventing provider identity.
+  Bound `turn/steer` acknowledgement separately to 10 seconds.
 - Validation:
   Run
-  `go test ./packages/agent/daemon/runtime -run 'TestCodexAppServerAdapter(Turn(StartAckTimeoutInvalidatesClient|StartCancelBeforeAckInvalidatesClient|StartAckTimeoutDoesNotBoundRunningTurn|SteerTimesOut)|CanResumeAfterTurnStartAckTimeout)$'`.
-  Cover timeout, pre-ack cancellation, a long post-ack turn, bounded guidance,
-  and successful `thread/resume` followed by a completed turn.
+  `go test ./packages/agent/daemon/runtime -run 'Test(CodexAppServerAdapter(Turn(StartAckTimeoutInvalidatesClient|StartEOFProjectsVisibleFailureBeforeAcceptance|StartCancelBeforeAckInvalidatesClient|StartAckTimeoutDoesNotBoundRunningTurn|SteerTimesOut)|CanResumeAfterTurnStartAckTimeout|HasLiveSessionRejectsClosedClient)|StandardACPAdapterHasLiveSessionRejectsClosedClient)$'`.
+  Cover timeout, EOF before acceptance, terminated-client liveness, pre-ack
+  cancellation, a long post-ack turn, bounded guidance, and successful
+  `thread/resume` followed by a completed turn.
 - References:
   [codex_appserver_turn.go](../../../packages/agent/daemon/runtime/codex_appserver_turn.go)
   [codex_appserver_registry.go](../../../packages/agent/daemon/runtime/codex_appserver_registry.go)

--- a/packages/agent/daemon/runtime/codex_appserver_scripted_rpc_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_scripted_rpc_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 type scriptedAppServerResponder interface {
+	Close() error
 	sendJSON(map[string]any)
 	sendJSONBatch(...map[string]any)
 	notify(string, map[string]any)

--- a/packages/agent/daemon/runtime/codex_appserver_scripted_turn_rpc_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_scripted_turn_rpc_test.go
@@ -15,6 +15,7 @@ type scriptedTurnState struct {
 	turnStartEntered        chan struct{}
 	turnStartRelease        chan struct{}
 	hangTurnStart           bool
+	closeOnTurnStart        bool
 	turnStartError          bool
 	hangSteer               bool
 	commandApproval         bool
@@ -37,6 +38,7 @@ func (s *fakeCodexAppServer) handleTurnRPC(message scriptedAppServerMessage) boo
 		turnStartEntered := s.turnStartEntered
 		turnStartRelease := s.turnStartRelease
 		hangTurnStart := s.hangTurnStart
+		closeOnTurnStart := s.closeOnTurnStart
 		turnStartError := s.turnStartError
 		s.mu.Unlock()
 		if turnStartEntered != nil {
@@ -46,6 +48,10 @@ func (s *fakeCodexAppServer) handleTurnRPC(message scriptedAppServerMessage) boo
 			<-turnStartRelease
 		}
 		if hangTurnStart {
+			return true
+		}
+		if closeOnTurnStart {
+			_ = s.Close()
 			return true
 		}
 		if turnStartError {

--- a/packages/agent/daemon/runtime/codex_appserver_session.go
+++ b/packages/agent/daemon/runtime/codex_appserver_session.go
@@ -375,7 +375,15 @@ func (*CodexAppServerAdapter) CanResume(session Session) bool {
 
 func (a *CodexAppServerAdapter) HasLiveSession(session Session) bool {
 	appSession := a.getSession(session.AgentSessionID)
-	return appSession != nil && appSession.client != nil
+	if appSession == nil || appSession.client == nil {
+		return false
+	}
+	select {
+	case <-appSession.client.Done():
+		return false
+	default:
+		return true
+	}
 }
 
 func (a *CodexAppServerAdapter) Close(_ context.Context, session Session) error {

--- a/packages/agent/daemon/runtime/codex_appserver_turn.go
+++ b/packages/agent/daemon/runtime/codex_appserver_turn.go
@@ -410,6 +410,21 @@ func (a *CodexAppServerAdapter) execBlocking(
 			emitProviderLocked(next)
 		}
 	}
+	// A turn/start failure has no provider identity to accept. Publish its
+	// canonical terminal directly so the controller can settle the Turn, while
+	// dropping any provider events that arrived before the failed response.
+	emitProviderlessTerminal := func(next []activityshared.Event) {
+		eventsMu.Lock()
+		defer eventsMu.Unlock()
+		if turnClosed {
+			return
+		}
+		turnClosed = true
+		pendingProviderEvents = nil
+		if len(next) > 0 {
+			emitLocked(next)
+		}
+	}
 	releaseProviderEvents := func() {
 		eventsMu.Lock()
 		defer eventsMu.Unlock()
@@ -575,11 +590,11 @@ func (a *CodexAppServerAdapter) execBlocking(
 			terminalEvents = append(terminalEvents, newTurnActivityEvent(session, EventTurnCanceled, turnID, SessionStatusCanceled, "", "", map[string]any{
 				"error": err.Error(),
 			}))
-			emitTerminal(terminalEvents)
+			emitProviderlessTerminal(terminalEvents)
 		} else {
 			terminalEvents := normalizer.FinishFailed(session, turnID)
 			terminalEvents = append(terminalEvents, newTurnActivityEvent(session, EventTurnFailed, turnID, SessionStatusFailed, "", "", acpFailureMetadata(err)))
-			emitTerminal(terminalEvents)
+			emitProviderlessTerminal(terminalEvents)
 		}
 		if invalidateClient && a.invalidateSessionClient(session.AgentSessionID, appSession.client) {
 			slog.Warn(

--- a/packages/agent/daemon/runtime/codex_appserver_turn_timeout_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_turn_timeout_test.go
@@ -65,6 +65,77 @@ func TestCodexAppServerAdapterTurnStartAckTimeoutInvalidatesClient(t *testing.T)
 	}
 }
 
+func TestCodexAppServerAdapterTurnStartEOFProjectsVisibleFailureBeforeAcceptance(t *testing.T) {
+	adapter, transport, session := startedAppServerAdapter(t)
+	t.Cleanup(func() { _ = adapter.Close(context.Background(), session) })
+	transport.server.closeOnTurnStart = true
+
+	var dispatch ProviderDispatchResult
+	barrierCalled := false
+	events, err := adapter.ExecWithProviderAcceptance(
+		context.Background(),
+		session,
+		[]PromptContentBlock{{Type: "text", Text: "disconnect before acknowledgement"}},
+		"disconnect before acknowledgement",
+		"turn-eof",
+		nil,
+		nil,
+		func(result ProviderDispatchResult) { dispatch = result },
+		func(ProviderAcceptanceReceipt) error {
+			barrierCalled = true
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("ExecWithProviderAcceptance: %v", err)
+	}
+	if barrierCalled {
+		t.Fatal("provider acceptance barrier called without a turn/start response")
+	}
+	if dispatch.Disposition != DispatchDispositionOutcomeUnknown {
+		t.Fatalf("dispatch disposition = %q, want outcome_unknown", dispatch.Disposition)
+	}
+	failed := eventsOfType(events, activityshared.EventTurnFailed)
+	if len(failed) != 1 {
+		t.Fatalf("turn.failed events = %d, want 1; events = %#v", len(failed), events)
+	}
+	if got := failed[0].Payload.Metadata["error"]; got != "EOF" {
+		t.Fatalf("turn.failed error = %#v, want EOF", got)
+	}
+	report := reportActivityInput(session, events)
+	visibleFailures := 0
+	for _, update := range report.MessageUpdates {
+		if update.Status == messageStreamStateFailed && update.Payload["kind"] == visibleErrorKind {
+			visibleFailures++
+		}
+	}
+	if visibleFailures != 1 {
+		t.Fatalf("visible failure count = %d, want 1; updates = %#v", visibleFailures, report.MessageUpdates)
+	}
+}
+
+func TestCodexAppServerAdapterHasLiveSessionRejectsClosedClient(t *testing.T) {
+	adapter, transport, session := startedAppServerAdapter(t)
+	appSession := adapter.getSession(session.AgentSessionID)
+	if appSession == nil || appSession.client == nil {
+		t.Fatal("started session has no client")
+	}
+	if err := transport.conn.Close(); err != nil {
+		t.Fatal(err)
+	}
+	waitForCondition(t, func() bool {
+		select {
+		case <-appSession.client.Done():
+			return true
+		default:
+			return false
+		}
+	})
+	if adapter.HasLiveSession(session) {
+		t.Fatal("HasLiveSession = true after app-server client terminated")
+	}
+}
+
 func TestCodexAppServerAdapterTurnStartCancelBeforeAckInvalidatesClient(t *testing.T) {
 	adapter, transport, session := startedAppServerAdapter(t)
 	t.Cleanup(func() { _ = adapter.Close(context.Background(), session) })

--- a/packages/agent/daemon/runtime/standard_acp_session.go
+++ b/packages/agent/daemon/runtime/standard_acp_session.go
@@ -322,7 +322,15 @@ func (*standardACPAdapter) CanResume(session Session) bool {
 
 func (a *standardACPAdapter) HasLiveSession(session Session) bool {
 	acpSession := a.getSession(session.AgentSessionID)
-	return acpSession != nil && acpSession.client != nil
+	if acpSession == nil || acpSession.client == nil {
+		return false
+	}
+	select {
+	case <-acpSession.client.Done():
+		return false
+	default:
+		return true
+	}
 }
 
 func (a *standardACPAdapter) Close(ctx context.Context, session Session) error {

--- a/packages/agent/daemon/runtime/standard_acp_session_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_session_test.go
@@ -104,6 +104,35 @@ func TestStandardACPAdapterConcurrentStartsLeaveSingleLiveProcess(t *testing.T) 
 	}
 }
 
+func TestStandardACPAdapterHasLiveSessionRejectsClosedClient(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Hermes Agent", "hermes-session-1")
+	adapter := newHermesExtensionTestAdapter(transport)
+	session := standardTestSession(hermesExtensionTestProvider)
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	acpSession := adapter.getSession(session.AgentSessionID)
+	if acpSession == nil || acpSession.client == nil {
+		t.Fatal("started session has no client")
+	}
+	if err := transport.conn.Close(); err != nil {
+		t.Fatal(err)
+	}
+	waitForCondition(t, func() bool {
+		select {
+		case <-acpSession.client.Done():
+			return true
+		default:
+			return false
+		}
+	})
+	if adapter.HasLiveSession(session) {
+		t.Fatal("HasLiveSession = true after ACP client terminated")
+	}
+}
+
 func TestStandardACPAdapterCarriesExecutableIdentityToProcessStart(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Codex app-server 和标准 ACP 的 `HasLiveSession` 同时检查 client 是否已经终止，让离线后失效的会话在下一次显式操作前走现有恢复流程。
- Codex `turn/start` 在 provider acceptance 前因 EOF 等错误失败时，直接发布精确的 canonical terminal，并丢弃尚未接受的 provider-dependent 事件。
- 复用现有 visible-error 投影，用户会看到失败消息；继续保留 `outcome_unknown`，不会自动重发可能已送达的 prompt。
- 更新 Agent Session lifecycle troubleshooting，记录 EOF 诊断和恢复边界。

这不改变 Host 的 canonical lifecycle 语义；它修复 provider adapter 对既有“无 provider identity 的 terminal”与进程存活状态的执行。因此不新增 Host conformance 场景。

## Verification

- `go test ./packages/agent/daemon/runtime -count=1`
- `go test -race ./packages/agent/daemon/runtime -run 'Test(CodexAppServerAdapterTurnStartEOFProjectsVisibleFailureBeforeAcceptance|CodexAppServerAdapterHasLiveSessionRejectsClosedClient|StandardACPAdapterHasLiveSessionRejectsClosedClient)$' -count=1`
- pre-push: `pnpm check:changed -- --push-ready`（8 lanes passed）

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter.（不改变语义；修复 provider adapter 执行）
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.（未修改 README/CONTRIBUTING）
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
