### PR TITLE
fix(connector): keep repairs pending until installed

### DIFF
--- a/.changeset/connector-repair-install-grouping.md
+++ b/.changeset/connector-repair-install-grouping.md
@@ -1,0 +1,7 @@
+---
+"@tutti-os/connector-market": patch
+---
+
+Keep physically missing or invalid Connectors in their catalog section while a
+repair installation is running, and only classify them as installed after the
+new installation receipt is committed.

--- a/packages/connector/host/application.go
+++ b/packages/connector/host/application.go
@@ -259,12 +259,28 @@ func (application *Application) Install(
 			if !CanTransitionInstallation(connector.Installation.State, target) {
 				return Connector{}, invalidTransition("installation", string(connector.Installation.State), string(target))
 			}
+			if installationRequiresPhysicalRepair(connector.Installation) {
+				// Calibration deliberately retains the last committed release while
+				// an installation is absent or invalid so a later observation can
+				// restore it without reinstalling. Once the user explicitly repairs
+				// the Connector, that evidence no longer describes a usable
+				// installation and must not survive the transition to installing.
+				connector.Installation = Installation{}
+			}
 			connector.Installation.State = target
 			connector.Installation.FailureCode = ""
 			return connector, nil
 		},
 	)
 	return result, err
+}
+
+func installationRequiresPhysicalRepair(installation Installation) bool {
+	if installation.State != InstallationStateFailed {
+		return false
+	}
+	return installation.FailureCode == InstallationFailureCodePhysicallyAbsent ||
+		installation.FailureCode == InstallationFailureCodePhysicallyInvalid
 }
 
 // Uninstall removes the Connector runtime and release from this device. It is

--- a/packages/connector/host/application_test.go
+++ b/packages/connector/host/application_test.go
@@ -46,6 +46,75 @@ func TestApplicationInstallIsDurableAndIdempotent(t *testing.T) {
 	}
 }
 
+func TestApplicationRepairInstallClearsInvalidInstalledEvidence(t *testing.T) {
+	for _, failureCode := range []string{
+		InstallationFailureCodePhysicallyAbsent,
+		InstallationFailureCodePhysicallyInvalid,
+	} {
+		t.Run(failureCode, func(t *testing.T) {
+			connector := testConnector("github")
+			connector.Installation = Installation{
+				State:                  InstallationStateFailed,
+				InstalledVersion:       connector.Release.Version,
+				InstalledReleaseID:     connector.Release.ReleaseID,
+				InstalledReleaseDigest: connector.Release.ReleaseDigest,
+				FailureCode:            failureCode,
+			}
+			repository := newMemoryRepository(connector)
+			application := newTestApplication(t, repository, &memoryScheduler{}, &memoryInstallRuntime{}, CatalogSnapshot{})
+
+			accepted, err := application.Install(context.Background(), ConnectorMutation{
+				Mutation:     Mutation{ClientRequestID: "repair-" + failureCode, ExpectedRevision: 0},
+				ConnectorKey: connector.Key,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if accepted.Connector == nil {
+				t.Fatal("accepted repair omitted Connector projection")
+			}
+			installation := accepted.Connector.Installation
+			if installation.State != InstallationStateInstalling ||
+				installation.InstalledVersion != "" ||
+				installation.InstalledReleaseID != "" ||
+				installation.InstalledReleaseDigest != "" ||
+				installation.FailureCode != "" {
+				t.Fatalf("accepted repair installation = %#v", installation)
+			}
+		})
+	}
+}
+
+func TestApplicationUpdateInstallRetainsUsableInstalledEvidence(t *testing.T) {
+	connector := testConnector("github")
+	connector.Installation = Installation{
+		State:                  InstallationStateInstalled,
+		InstalledVersion:       "0.9.0",
+		InstalledReleaseID:     "github@0.9.0",
+		InstalledReleaseDigest: strings.Repeat("a", 64),
+	}
+	repository := newMemoryRepository(connector)
+	application := newTestApplication(t, repository, &memoryScheduler{}, &memoryInstallRuntime{}, CatalogSnapshot{})
+
+	accepted, err := application.Install(context.Background(), ConnectorMutation{
+		Mutation:     Mutation{ClientRequestID: "update-github", ExpectedRevision: 0},
+		ConnectorKey: connector.Key,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if accepted.Connector == nil {
+		t.Fatal("accepted update omitted Connector projection")
+	}
+	installation := accepted.Connector.Installation
+	if installation.State != InstallationStateUpdating ||
+		installation.InstalledVersion != connector.Installation.InstalledVersion ||
+		installation.InstalledReleaseID != connector.Installation.InstalledReleaseID ||
+		installation.InstalledReleaseDigest != connector.Installation.InstalledReleaseDigest {
+		t.Fatalf("accepted update installation = %#v", installation)
+	}
+}
+
 func TestApplicationClientRequestIDIsReusableOnlyAfterTerminalRetention(t *testing.T) {
 	repository := newMemoryRepository(testConnector("github"))
 	scheduler := &memoryScheduler{}

--- a/packages/connector/market/src/services/view/connectorMarketViewBuilder.test.ts
+++ b/packages/connector/market/src/services/view/connectorMarketViewBuilder.test.ts
@@ -138,6 +138,60 @@ test("keeps connector details open through installation and advances to authoriz
   );
 });
 
+test("keeps a physical repair in the available segment until installation completes", () => {
+  const market = createConnectorMarketStoreState();
+  const connector = connectorFixture();
+  connector.installation = {
+    installedReleaseDigest: connector.release.releaseDigest,
+    installedReleaseId: connector.release.releaseId,
+    installedVersion: connector.release.version,
+    state: "installing"
+  };
+  market.connectorKeys = [connector.key];
+  market.connectorsByKey[connector.key] = connector;
+  market.catalogSections = [
+    {
+      categoryId: "productivity",
+      connectorKeys: [connector.key],
+      itemCount: 1,
+      kind: "category",
+      loadState: "ready",
+      sortOrder: 10
+    }
+  ];
+  market.operationsByConnectorKey[connector.key] = {
+    attempt: 1,
+    clientRequestId: "repair-github",
+    connectorKey: connector.key,
+    createdAt: "2026-08-11T00:00:00Z",
+    kind: "install",
+    operationId: "repair-operation",
+    stage: "installing",
+    state: "running",
+    updatedAt: "2026-08-11T00:00:01Z"
+  };
+
+  const installingView = buildConnectorMarketView(market, uiState);
+  assert.equal(installingView.installedCount, 0);
+  assert.equal(installingView.availableCount, 1);
+  assert.deepEqual(installingView.sections[0]?.connectorKeys, [connector.key]);
+  assert.equal(installingView.cardsByKey[connector.key]?.status, "installing");
+
+  connector.installation.state = "installed";
+  market.operationsByConnectorKey[connector.key] = {
+    ...market.operationsByConnectorKey[connector.key]!,
+    stage: "completed",
+    state: "completed",
+    updatedAt: "2026-08-11T00:00:02Z"
+  };
+  const installedView = buildConnectorMarketView(market, {
+    ...uiState,
+    segment: "installed"
+  });
+  assert.equal(installedView.installedCount, 1);
+  assert.deepEqual(installedView.sections[0]?.connectorKeys, [connector.key]);
+});
+
 test("requires an installed connector to update before authorization when the active release changes", () => {
   const market = createConnectorMarketStoreState();
   const connector = connectorFixture();

--- a/packages/connector/market/src/services/view/connectorMarketViewBuilder.ts
+++ b/packages/connector/market/src/services/view/connectorMarketViewBuilder.ts
@@ -257,6 +257,12 @@ function buildConnectorDialogView(
 
 function connectorHasInstalledArtifact(connector: Connector): boolean {
   if (
+    connector.installation.state === "not_installed" ||
+    connector.installation.state === "installing"
+  ) {
+    return false;
+  }
+  if (
     connector.installation.state === "failed" &&
     [
       "connector_installation_absent",


### PR DESCRIPTION
## 背景

Connector 在物理安装缺失或损坏后发起修复安装时，Host 会保留上一次 installed release 字段。市场 UI 把这些旧字段当作当前安装证据，导致操作刚被接受就立即从「可安装」移动到「已安装」。

## 修改

- 修复安装从 `failed + physically_absent/physically_invalid` 进入 `installing` 时清理旧安装证据
- 普通 `installed -> updating` 仍保留当前可用安装证据
- 市场 View Builder 对 `installing/not_installed` 明确不按旧 release 字段归类为已安装
- 增加 Host 与市场 View 回归测试

## 验证

- `pnpm check:changed -- --push-ready`
- `pnpm release:pack:check`
- `pnpm --filter @tutti-os/connector-market test`
- `pnpm --filter @tutti-os/connector-market typecheck`
- `go test ./packages/connector/host/...`

## 影响评估

- Windows：无平台相关路径、进程或系统调用变更，逻辑跨平台一致
- 文档：不改变公开协议或所有权边界，changeset 已记录用户可见修复