### PR TITLE
fix(connectors): isolate unavailable runtimes during bootstrap

### DIFF
--- a/packages/connector/daemon/host.go
+++ b/packages/connector/daemon/host.go
@@ -50,6 +50,8 @@ type Host struct {
 	authorizationSyncWake      chan struct{}
 	authorizationEventsDone    chan struct{}
 	authorizationScopeWake     chan struct{}
+	runtimeRecoveryDone        chan struct{}
+	runtimeRecoveryWake        chan struct{}
 	closeOnce                  sync.Once
 	bootstrapMu                sync.Mutex
 	bootstrapped               bool
@@ -65,6 +67,7 @@ type Host struct {
 	authorizationEvents        market.AuthorizationEventSource
 	authorizationReadiness     *market.AuthorizationReadinessGate
 	authorizationDirty         map[string]map[string]struct{}
+	runtimeRecoveryPending     map[string]struct{}
 }
 
 type capabilityPublicationGate interface {
@@ -113,6 +116,8 @@ func NewHost(parent context.Context, config HostConfig) (*Host, error) {
 		authorizationSyncWake:   make(chan struct{}, 1),
 		authorizationEventsDone: make(chan struct{}),
 		authorizationScopeWake:  make(chan struct{}, 1),
+		runtimeRecoveryDone:     make(chan struct{}),
+		runtimeRecoveryWake:     make(chan struct{}, 1),
 		repository:              config.Repository,
 		implementationHost:      config.ImplementationHost,
 		activationGate:          activationGate,
@@ -121,6 +126,7 @@ func NewHost(parent context.Context, config HostConfig) (*Host, error) {
 		authorizationEvents:     config.AuthorizationEvents,
 		authorizationReadiness:  config.AuthorizationReadiness,
 		authorizationDirty:      make(map[string]map[string]struct{}),
+		runtimeRecoveryPending:  make(map[string]struct{}),
 	}
 	if snapshotStore, ok := config.AuthorizationProjections.(market.AuthorizationSnapshotStore); ok {
 		host.authorizationSnapshotStore = snapshotStore
@@ -149,6 +155,10 @@ func NewHost(parent context.Context, config HostConfig) (*Host, error) {
 	if _, ok := config.Authorization.(market.AuthorizationObserver); ok {
 		go host.runAuthorizationReconcileWorker(hostContext)
 	}
+	go func() {
+		defer close(host.runtimeRecoveryDone)
+		host.runRuntimeRecoveryWorker(hostContext)
+	}()
 	cleanupWorker := LifecycleCleanupWorker{Store: config.Lifecycle, Policy: config.LifecyclePolicy}
 	go func() {
 		defer close(host.lifecycleDone)
@@ -224,9 +234,10 @@ func (host *Host) BootstrapForScope(ctx context.Context, scope market.OperationS
 	defer host.bootstrapMu.Unlock()
 	sameScope := host.bootstrapScope == scope
 	if host.bootstrapped && sameScope && !host.activationGate.requiresRecovery() {
-		return nil
+		return host.reconcilePendingRuntimesLocked(ctx, scope)
 	}
 	host.bootstrapScope = scope
+	host.runtimeRecoveryPending = make(map[string]struct{})
 	if host.authorizationReadiness != nil && strings.TrimSpace(scope.AccountID) != "" {
 		host.authorizationReadiness.SetReady(scope.AccountID, false)
 	}
@@ -284,8 +295,16 @@ func (host *Host) BootstrapForScope(ctx context.Context, scope market.OperationS
 		}
 	}
 	host.activationGate.setOpen(scope, true)
-	if err := host.Application.ReconcileInstalledRuntimesForScope(ctx, scope); err != nil {
-		return err
+	reconcileErr := host.Application.ReconcileInstalledRuntimesForScope(ctx, scope)
+	var reconcileFailures *market.RuntimeReconcileFailures
+	if reconcileErr != nil && !errors.As(reconcileErr, &reconcileFailures) {
+		return reconcileErr
+	}
+	if reconcileFailures != nil {
+		for _, connectorKey := range reconcileFailures.ConnectorKeys() {
+			host.runtimeRecoveryPending[connectorKey] = struct{}{}
+		}
+		host.notifyRuntimeRecovery()
 	}
 	if err := host.applyCapabilityPublication(ctx, scope, true); err != nil {
 		return err
@@ -293,6 +312,9 @@ func (host *Host) BootstrapForScope(ctx context.Context, scope market.OperationS
 	host.activationGate.markRecovered()
 	host.bootstrapped = true
 	committed = true
+	if reconcileFailures != nil {
+		slog.Warn("connector market bootstrap completed with unavailable connectors", "error", reconcileFailures)
+	}
 	return nil
 }
 
@@ -503,6 +525,7 @@ func (host *Host) FenceForScope(ctx context.Context, scope market.OperationScope
 	}
 	host.bootstrapped = false
 	host.bootstrapScope = scope
+	host.runtimeRecoveryPending = make(map[string]struct{})
 	host.notifyAuthorizationScopeChanged()
 	publicationErr := host.applyCapabilityPublication(ctx, scope, false)
 	fenceErr := host.activationGate.FailClosed(ctx, time.Now().Add(10*time.Second))
@@ -751,6 +774,7 @@ func (host *Host) Close() {
 		<-host.lifecycleDone
 		<-host.authorizationSyncDone
 		<-host.authorizationEventsDone
+		<-host.runtimeRecoveryDone
 		host.scheduler.Wait()
 	})
 }

--- a/packages/connector/daemon/host_test.go
+++ b/packages/connector/daemon/host_test.go
@@ -251,11 +251,14 @@ func TestBootstrapRestoresInstalledRuntimeWithoutRefreshingCatalog(t *testing.T)
 	host.refreshWorkerStarted = true
 	t.Cleanup(host.Close)
 
-	if err := host.Bootstrap(ctx); err == nil {
-		t.Fatal("first bootstrap unexpectedly reconciled the runtime")
+	if err := host.Bootstrap(ctx); err != nil {
+		t.Fatalf("partial bootstrap failed: %v", err)
+	}
+	if len(host.runtimeRecoveryPending) != 1 || len(publication.values) == 0 || !publication.values[len(publication.values)-1] {
+		t.Fatalf("partial bootstrap pending=%#v publication=%#v", host.runtimeRecoveryPending, publication.values)
 	}
 	if err := host.Bootstrap(ctx); err != nil {
-		t.Fatalf("second bootstrap failed: %v", err)
+		t.Fatalf("degraded runtime recovery failed: %v", err)
 	}
 	if source.refreshes != 0 || runtime.reconciles != 2 {
 		t.Fatalf("bootstrap refreshes=%d reconciles=%d, want 0 and 2", source.refreshes, runtime.reconciles)
@@ -308,8 +311,8 @@ func TestBootstrapRestoresInstalledRuntimeWithoutRefreshingCatalog(t *testing.T)
 	if runtime.reconciles != 5 || !publication.values[len(publication.values)-1] {
 		t.Fatalf("same-account recovery reconciles=%d publication=%#v", runtime.reconciles, publication.values)
 	}
-	if runtime.installationInspections != 4 {
-		t.Fatalf("installation inspections = %d, want one per non-idempotent bootstrap", runtime.installationInspections)
+	if runtime.installationInspections != 3 {
+		t.Fatalf("installation inspections = %d, want one per full bootstrap", runtime.installationInspections)
 	}
 
 	if err := host.FenceForScope(ctx, accountScope); err != nil {

--- a/packages/connector/daemon/runtime_recovery.go
+++ b/packages/connector/daemon/runtime_recovery.go
@@ -1,0 +1,80 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sort"
+	"time"
+
+	market "github.com/tutti-os/tutti/packages/connector/host"
+)
+
+func (host *Host) reconcilePendingRuntimesLocked(ctx context.Context, scope market.OperationScope) error {
+	connectorKeys := make([]string, 0, len(host.runtimeRecoveryPending))
+	for connectorKey := range host.runtimeRecoveryPending {
+		connectorKeys = append(connectorKeys, connectorKey)
+	}
+	sort.Strings(connectorKeys)
+	var reconcileErr error
+	for _, connectorKey := range connectorKeys {
+		if err := host.reconcileRuntimeForScopeLocked(ctx, scope, connectorKey); err != nil {
+			reconcileErr = errors.Join(reconcileErr, fmt.Errorf("%s: %w", connectorKey, err))
+			continue
+		}
+		delete(host.runtimeRecoveryPending, connectorKey)
+	}
+	return reconcileErr
+}
+
+func (host *Host) notifyRuntimeRecovery() {
+	select {
+	case host.runtimeRecoveryWake <- struct{}{}:
+	default:
+	}
+}
+
+func (host *Host) runRuntimeRecoveryWorker(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-host.runtimeRecoveryWake:
+		}
+		retry := time.Second
+		for {
+			timer := time.NewTimer(retry)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			case <-host.runtimeRecoveryWake:
+				timer.Stop()
+				retry = time.Second
+				continue
+			case <-timer.C:
+			}
+			reconcileContext, cancel := context.WithTimeout(ctx, 45*time.Second)
+			host.bootstrapMu.Lock()
+			if !host.bootstrapped || len(host.runtimeRecoveryPending) == 0 {
+				host.bootstrapMu.Unlock()
+				cancel()
+				break
+			}
+			err := host.reconcilePendingRuntimesLocked(reconcileContext, host.bootstrapScope)
+			pending := len(host.runtimeRecoveryPending) > 0
+			host.bootstrapMu.Unlock()
+			cancel()
+			if err != nil && !errors.Is(err, context.Canceled) {
+				slog.Warn("connector runtime recovery retry failed", "error", err)
+			}
+			if !pending {
+				break
+			}
+			if retry < time.Minute {
+				retry *= 2
+			}
+		}
+	}
+}

--- a/packages/connector/host/application_execution.go
+++ b/packages/connector/host/application_execution.go
@@ -260,10 +260,18 @@ func (application *Application) completeUninstall(ctx context.Context, operation
 const defaultConnectorConnectionID = "default"
 
 func validateRuntimeReceipt(receipt RuntimeReceipt, operationID, connectionID, connectorKey,
-	releaseDigest string, generation HostGeneration) error {
+	releaseDigest string, generation HostGeneration, expectedEnabled bool) error {
 	if receipt.OperationID != operationID || receipt.ConnectionID != connectionID ||
 		receipt.ConnectorKey != connectorKey || receipt.ReleaseDigest != releaseDigest || receipt.Generation != generation {
 		return invalidOperationReceipt("implementation host returned a mismatched runtime receipt")
+	}
+	if !expectedEnabled {
+		if receipt.Readiness.State != RuntimeReadinessBlocked ||
+			receipt.Readiness.ReasonCode != RuntimeReadinessReasonRuntimeDisabled ||
+			len(receipt.Readiness.Interfaces) != 0 {
+			return invalidOperationReceipt("implementation host returned invalid disabled runtime readiness")
+		}
+		return nil
 	}
 	if receipt.Readiness.State != RuntimeReadinessReady {
 		return invalidOperationReceipt("implementation host did not return a ready runtime receipt")

--- a/packages/connector/host/application_runtime_execution.go
+++ b/packages/connector/host/application_runtime_execution.go
@@ -29,7 +29,7 @@ func (application *Application) executeRuntimeReconcile(ctx context.Context, ope
 		return NewDomainError(ErrorCodeInstallFailed, "connector runtime could not be reconciled", true, err)
 	}
 	if err := validateRuntimeReceipt(receipt, operation.OperationID, binding.ConnectionID, connector.Key,
-		release.ReleaseDigest, operation.HostGeneration); err != nil {
+		release.ReleaseDigest, operation.HostGeneration, binding.Enabled); err != nil {
 		return err
 	}
 	return application.completeConnectorOperation(ctx, operation.OperationID, func(current Connector) Connector { return current })

--- a/packages/connector/host/application_scoped_runtime.go
+++ b/packages/connector/host/application_scoped_runtime.go
@@ -187,6 +187,39 @@ func (application *Application) InstalledRemoteAuthorizedConnectorKeys(ctx conte
 	return keys, nil
 }
 
+// RuntimeReconcileFailures contains Connector-local recovery failures. The
+// caller may safely publish routes committed by other Connectors while retrying
+// these keys independently. Snapshot and generation-commit failures are not
+// included because they require the global runtime fence to remain closed.
+type RuntimeReconcileFailures struct {
+	failures []error
+	keys     []string
+}
+
+func (failures *RuntimeReconcileFailures) Error() string {
+	return errors.Join(failures.failures...).Error()
+}
+
+func (failures *RuntimeReconcileFailures) Unwrap() []error {
+	return append([]error(nil), failures.failures...)
+}
+
+func (failures *RuntimeReconcileFailures) ConnectorKeys() []string {
+	return append([]string(nil), failures.keys...)
+}
+
+func (failures *RuntimeReconcileFailures) add(connectorKey, stage string, err error) {
+	failures.keys = append(failures.keys, connectorKey)
+	failures.failures = append(failures.failures, fmt.Errorf("%s: %s: %w", connectorKey, stage, err))
+}
+
+func (failures *RuntimeReconcileFailures) errOrNil() error {
+	if len(failures.failures) == 0 {
+		return nil
+	}
+	return failures
+}
+
 func (application *Application) reconcileInstalledRuntimesForScope(ctx context.Context, scope OperationScope, remoteAuthorizedOnly bool) error {
 	if application == nil {
 		return NewDomainError(ErrorCodeUnavailable, "connector application is unavailable", false, nil)
@@ -195,29 +228,23 @@ func (application *Application) reconcileInstalledRuntimesForScope(ctx context.C
 	if err != nil {
 		return err
 	}
-	var reconcileErr error
+	reconcileFailures := &RuntimeReconcileFailures{}
 	for _, connector := range snapshot.Connectors {
 		if connector.Installation.State != InstallationStateInstalled {
 			continue
 		}
 		installedRelease, evidenceErr := application.installedReleaseEvidence(ctx, connector)
 		if evidenceErr != nil {
-			if remoteAuthorizedOnly {
-				reconcileErr = errors.Join(reconcileErr, fmt.Errorf("%s: load installed release: %w", connector.Key, evidenceErr))
-				continue
-			}
-			return NewDomainError(ErrorCodeUnavailable, "installed connector release evidence is unavailable", false, nil)
+			reconcileFailures.add(connector.Key, "load installed release", evidenceErr)
+			continue
 		}
 		if remoteAuthorizedOnly && (installedRelease.Manifest.Implementation.RemoteStreamableHTTP == nil ||
 			installedRelease.Manifest.AuthorizationKind == "none") {
 			continue
 		}
 		if validationErr := ValidateRuntimeReleaseShape(installedRelease); validationErr != nil {
-			if remoteAuthorizedOnly {
-				reconcileErr = errors.Join(reconcileErr, fmt.Errorf("%s: validate installed release: %w", connector.Key, validationErr))
-				continue
-			}
-			return NewDomainError(ErrorCodeUnavailable, "installed connector release evidence is invalid", false, validationErr)
+			reconcileFailures.add(connector.Key, "validate installed release", validationErr)
+			continue
 		}
 		installedConnector := connector
 		installedConnector.Release = installedRelease
@@ -229,11 +256,8 @@ func (application *Application) reconcileInstalledRuntimesForScope(ctx context.C
 		operation := Operation{OperationID: operationID, ConnectorKey: connector.Key, Scope: scope}
 		binding, err := application.resolveRuntimeBinding(ctx, operation, installedConnector, installedRelease, RuntimeBindingPurposeReconcile)
 		if err != nil {
-			if remoteAuthorizedOnly {
-				reconcileErr = errors.Join(reconcileErr, fmt.Errorf("%s: resolve runtime binding: %w", connector.Key, err))
-				continue
-			}
-			return NewDomainError(ErrorCodeUnavailable, "connector runtime binding could not be resolved", true, err)
+			reconcileFailures.add(connector.Key, "resolve runtime binding", err)
+			continue
 		}
 		installedConnector.Authorization.State = binding.AuthorizationState
 		receipt, err := application.reconcileRuntime(ctx, RuntimeReconcileRequest{
@@ -242,29 +266,24 @@ func (application *Application) reconcileInstalledRuntimesForScope(ctx context.C
 			Generation: HostGeneration{BootEpoch: application.config.BootEpoch, Generation: generation},
 		})
 		if err != nil {
-			if remoteAuthorizedOnly {
-				reconcileErr = errors.Join(reconcileErr, fmt.Errorf("%s: reconcile runtime: %w", connector.Key, err))
-				continue
-			}
-			return NewDomainError(ErrorCodeUnavailable, "connector runtime could not be reconciled", true, err)
+			reconcileFailures.add(connector.Key, "reconcile runtime", err)
+			continue
 		}
 		if err := validateRuntimeReceipt(receipt, operationID, binding.ConnectionID, connector.Key,
-			installedRelease.ReleaseDigest, HostGeneration{BootEpoch: application.config.BootEpoch, Generation: generation}); err != nil {
-			if remoteAuthorizedOnly {
-				reconcileErr = errors.Join(reconcileErr, fmt.Errorf("%s: validate runtime receipt: %w", connector.Key, err))
-				continue
-			}
-			return err
+			installedRelease.ReleaseDigest, HostGeneration{BootEpoch: application.config.BootEpoch, Generation: generation},
+			binding.Enabled); err != nil {
+			reconcileFailures.add(connector.Key, "validate runtime receipt", err)
+			continue
 		}
 		if err := application.recordDirectRuntimeGeneration(ctx, connector.Key, installedRelease.ReleaseDigest, operationID, generation); err != nil {
 			if remoteAuthorizedOnly {
-				reconcileErr = errors.Join(reconcileErr, fmt.Errorf("%s: record runtime generation: %w", connector.Key, err))
+				reconcileFailures.add(connector.Key, "record runtime generation", err)
 				continue
 			}
 			return err
 		}
 	}
-	return reconcileErr
+	return reconcileFailures.errOrNil()
 }
 
 // recordDirectRuntimeGeneration makes startup reconciliation participate in

--- a/packages/connector/host/application_test.go
+++ b/packages/connector/host/application_test.go
@@ -337,6 +337,102 @@ func TestApplicationReconcilesInstalledRuntimeAtStartup(t *testing.T) {
 	}
 }
 
+func TestApplicationStartupReconcileAcceptsDisabledRuntimeWithoutBlockingEnabledRuntime(t *testing.T) {
+	disabled := testConnector("dingtalk")
+	disabled.Installation = Installation{
+		State: InstallationStateInstalled, InstalledVersion: disabled.Release.Version,
+		InstalledReleaseID: disabled.Release.ReleaseID, InstalledReleaseDigest: disabled.Release.ReleaseDigest,
+	}
+	enabled := testConnector("lark")
+	enabled.Installation = Installation{
+		State: InstallationStateInstalled, InstalledVersion: enabled.Release.Version,
+		InstalledReleaseID: enabled.Release.ReleaseID, InstalledReleaseDigest: enabled.Release.ReleaseDigest,
+	}
+	repository := newMemoryRepository(disabled, enabled)
+	host := &memoryInstallRuntime{}
+	application := newTestApplication(t, repository, &memoryScheduler{}, host, CatalogSnapshot{})
+	application.config.RuntimeBindings = runtimeBindingResolverFunc(func(_ context.Context, request RuntimeBindingRequest) (RuntimeBinding, error) {
+		return RuntimeBinding{
+			ConnectionID: request.Connector.Key + "-connection",
+			Enabled:      request.Connector.Key == enabled.Key,
+		}, nil
+	})
+
+	if err := application.ReconcileInstalledRuntimes(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(host.reconcileRequests) != 2 {
+		t.Fatalf("runtime reconciles = %#v", host.reconcileRequests)
+	}
+	if host.reconcileRequests[0].Connector.Key != disabled.Key || host.reconcileRequests[0].Enabled ||
+		host.reconcileRequests[1].Connector.Key != enabled.Key || !host.reconcileRequests[1].Enabled {
+		t.Fatalf("runtime reconciles = %#v", host.reconcileRequests)
+	}
+}
+
+func TestApplicationStartupReconcileContinuesAfterConnectorFailure(t *testing.T) {
+	failing := testConnector("dingtalk")
+	failing.Installation = Installation{
+		State: InstallationStateInstalled, InstalledVersion: failing.Release.Version,
+		InstalledReleaseID: failing.Release.ReleaseID, InstalledReleaseDigest: failing.Release.ReleaseDigest,
+	}
+	healthy := testConnector("lark")
+	healthy.Installation = Installation{
+		State: InstallationStateInstalled, InstalledVersion: healthy.Release.Version,
+		InstalledReleaseID: healthy.Release.ReleaseID, InstalledReleaseDigest: healthy.Release.ReleaseDigest,
+	}
+	repository := newMemoryRepository(failing, healthy)
+	host := &memoryInstallRuntime{reconcileErrors: map[string]error{failing.Key: errors.New("runtime unavailable")}}
+	application := newTestApplication(t, repository, &memoryScheduler{}, host, CatalogSnapshot{})
+
+	err := application.ReconcileInstalledRuntimes(context.Background())
+	var failures *RuntimeReconcileFailures
+	if !errors.As(err, &failures) {
+		t.Fatalf("startup reconcile error = %v", err)
+	}
+	failedKeys := failures.ConnectorKeys()
+	if len(failedKeys) != 1 || failedKeys[0] != failing.Key {
+		t.Fatalf("failed connector keys = %#v", failedKeys)
+	}
+	if len(host.reconcileRequests) != 2 || host.reconcileRequests[1].Connector.Key != healthy.Key {
+		t.Fatalf("runtime reconciles = %#v", host.reconcileRequests)
+	}
+}
+
+func TestValidateRuntimeReceiptRequiresExactDisabledReadiness(t *testing.T) {
+	generation := HostGeneration{BootEpoch: "boot-1", Generation: 1}
+	base := RuntimeReceipt{
+		OperationID: "operation-1", ConnectionID: "connection-1", ConnectorKey: "dingtalk",
+		ReleaseDigest: strings.Repeat("a", 64), Generation: generation,
+	}
+	tests := []struct {
+		name      string
+		readiness RuntimeReadiness
+		wantError bool
+	}{
+		{name: "disabled", readiness: RuntimeReadiness{
+			State: RuntimeReadinessBlocked, ReasonCode: RuntimeReadinessReasonRuntimeDisabled}},
+		{name: "ready", readiness: RuntimeReadiness{State: RuntimeReadinessReady,
+			Interfaces: []InterfaceReadiness{{Kind: "mcp", State: RuntimeReadinessReady}}}, wantError: true},
+		{name: "unrelated block", readiness: RuntimeReadiness{
+			State: RuntimeReadinessBlocked, ReasonCode: "publication_gate_closed"}, wantError: true},
+		{name: "disabled with published interface", readiness: RuntimeReadiness{
+			State: RuntimeReadinessBlocked, ReasonCode: RuntimeReadinessReasonRuntimeDisabled,
+			Interfaces: []InterfaceReadiness{{Kind: "mcp", State: RuntimeReadinessReady}}}, wantError: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			receipt := base
+			receipt.Readiness = test.readiness
+			err := validateRuntimeReceipt(receipt, base.OperationID, base.ConnectionID, base.ConnectorKey,
+				base.ReleaseDigest, generation, false)
+			if (err != nil) != test.wantError {
+				t.Fatalf("validateRuntimeReceipt() error = %v, wantError = %t", err, test.wantError)
+			}
+		})
+	}
+}
+
 func TestApplicationInstallKeepsRuntimeReconcileSeparate(t *testing.T) {
 	repository := newMemoryRepository(testConnector("github"))
 	host := &memoryInstallRuntime{}
@@ -1385,6 +1481,7 @@ type memoryInstallRuntime struct {
 	deactivations           int
 	activeDigest            string
 	reconciles              int
+	reconcileRequests       []RuntimeReconcileRequest
 	lastReconcile           RuntimeReconcileRequest
 	lastDeactivation        RuntimeDeactivationRequest
 	lastPrepare             PrepareArtifactRequest
@@ -1397,16 +1494,25 @@ type memoryInstallRuntime struct {
 	installationResult      ReleaseInstallationObservation
 	installationInspectErr  error
 	installationCommitErr   error
+	reconcileErrors         map[string]error
 }
 
 func (host *memoryInstallRuntime) Reconcile(_ context.Context, request RuntimeReconcileRequest) (RuntimeReceipt, error) {
 	host.reconciles++
+	host.reconcileRequests = append(host.reconcileRequests, request)
 	host.lastReconcile = request
 	host.lastCredentialGrant = string(request.CredentialBrokerGrant)
+	if err := host.reconcileErrors[request.Connector.Key]; err != nil {
+		return RuntimeReceipt{}, err
+	}
+	readiness := RuntimeReadiness{State: RuntimeReadinessReady,
+		Interfaces: []InterfaceReadiness{{Kind: "mcp", State: RuntimeReadinessReady}}}
+	if !request.Enabled {
+		readiness = RuntimeReadiness{State: RuntimeReadinessBlocked, ReasonCode: RuntimeReadinessReasonRuntimeDisabled}
+	}
 	return RuntimeReceipt{OperationID: request.OperationID, ConnectionID: request.ConnectionID,
 		ConnectorKey: request.Connector.Key, ReleaseDigest: request.Connector.Release.ReleaseDigest, Generation: request.Generation,
-		Readiness: RuntimeReadiness{State: RuntimeReadinessReady,
-			Interfaces: []InterfaceReadiness{{Kind: "mcp", State: RuntimeReadinessReady}}}}, nil
+		Readiness: readiness}, nil
 }
 
 func (host *memoryInstallRuntime) InspectReleaseInstallation(_ context.Context, request InspectReleaseInstallationRequest) (ReleaseInstallationObservation, error) {
@@ -1498,6 +1604,8 @@ type runtimeBindingResolverStub struct {
 	binding RuntimeBinding
 }
 
+type runtimeBindingResolverFunc func(context.Context, RuntimeBindingRequest) (RuntimeBinding, error)
+
 type recordingAuthorizationProjectionStore struct {
 	projection AuthorizationProjection
 }
@@ -1516,6 +1624,10 @@ func (store *recordingAuthorizationProjectionStore) SaveAuthorizationProjection(
 
 func (resolver *runtimeBindingResolverStub) ResolveRuntimeBinding(context.Context, RuntimeBindingRequest) (RuntimeBinding, error) {
 	return resolver.binding, nil
+}
+
+func (resolver runtimeBindingResolverFunc) ResolveRuntimeBinding(ctx context.Context, request RuntimeBindingRequest) (RuntimeBinding, error) {
+	return resolver(ctx, request)
 }
 
 func (host *memoryInstallRuntime) Remove(context.Context, RemoveArtifactRequest) error {

--- a/packages/connector/host/types.go
+++ b/packages/connector/host/types.go
@@ -395,6 +395,10 @@ const (
 	RuntimeReadinessFailed  RuntimeReadinessState = "failed"
 )
 
+// RuntimeReadinessReasonRuntimeDisabled confirms that a disabled reconcile
+// removed capability publication instead of attempting to start a runtime.
+const RuntimeReadinessReasonRuntimeDisabled = "runtime_disabled"
+
 type InterfaceReadiness struct {
 	Kind       string                `json:"kind"`
 	State      RuntimeReadinessState `json:"state"`

--- a/packages/connector/runtime/implementationhost/host.go
+++ b/packages/connector/runtime/implementationhost/host.go
@@ -198,7 +198,8 @@ func (host *Host) Reconcile(ctx context.Context, request ReconcileRequest) (mark
 		return market.RuntimeReceipt{OperationID: runtimeRequest.OperationID, ConnectionID: runtimeRequest.ConnectionID,
 			ConnectorKey: runtimeRequest.Connector.Key, ReleaseDigest: runtimeRequest.Connector.Installation.InstalledReleaseDigest,
 			Generation: runtimeRequest.Generation,
-			Readiness:  market.RuntimeReadiness{State: market.RuntimeReadinessBlocked, ReasonCode: "runtime_disabled"}}, nil
+			Readiness: market.RuntimeReadiness{State: market.RuntimeReadinessBlocked,
+				ReasonCode: market.RuntimeReadinessReasonRuntimeDisabled}}, nil
 	}
 	if runtimeRequest.Connector.Installation.State != market.InstallationStateInstalled ||
 		runtimeRequest.Connector.Installation.InstalledReleaseDigest != runtimeRequest.Connector.Release.ReleaseDigest {


### PR DESCRIPTION
## Summary

- validate runtime receipts against the requested enabled intent, accepting only the exact `blocked/runtime_disabled` receipt for disabled connectors
- continue startup reconciliation after connector-local failures and publish the successfully restored connector subset
- retry degraded connector runtimes independently with bounded exponential backoff while preserving global fail-close for snapshot, generation, and publication failures
- align the test runtime with the real disabled-runtime receipt contract and add regression coverage for disabled and unavailable connectors

## Verification

- `go test ./packages/connector/host ./packages/connector/daemon ./packages/connector/runtime/implementationhost ./services/tuttid/service/connectormarket`
- `go test -race ./packages/connector/host ./packages/connector/daemon`
- `pnpm check:changed -- --push-ready`
- manual dev verification: `tutti-dev connector available --json` returns `lark-cli` as `cli/ready` while an unavailable `tencent-docs` MCP endpoint is excluded and retried

## Fallback Three Questions

- Source: an installed connector can be intentionally disabled or its independent runtime/remote endpoint can be temporarily unavailable during daemon bootstrap.
- Why can it not be fixed at that source? Connector processes and remote endpoints are independent failure domains; the daemon must prevent one connector from suppressing unrelated healthy capability publication.
- Removal condition: remove this retry worker when the implementation host owns durable per-connector convergence and exposes an equivalent event-driven recovery contract to the daemon.

## Checklist

- [x] Not applicable: this does not change agent lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] Documentation checked; existing connector architecture already defines active-only CLI publication and fail-closed account transitions.
- [x] Not applicable: no README/CONTRIBUTING language changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required.