### PR TITLE
revert(agent): restore quick prompt feature flag

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentQuickPromptService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentQuickPromptService.test.ts
@@ -5,6 +5,9 @@ import type {
   TuttidClient,
   TuttidEventStreamClient
 } from "@tutti-os/client-tuttid-ts";
+import { proxy } from "valtio";
+import { AGENT_QUICK_PROMPT_LIBRARY_FLAG } from "../../../../../../shared/featureFlags/catalog.ts";
+import type { IDesktopPreferencesService } from "../../../desktop-preferences/services/desktopPreferencesService.interface.ts";
 import { DesktopAgentQuickPromptService } from "./desktopAgentQuickPromptService.ts";
 
 const firstPrompt: AgentHostQuickPrompt = {
@@ -16,12 +19,20 @@ const firstPrompt: AgentHostQuickPrompt = {
   version: 1
 };
 
-test("quick prompts are enabled without eager loading", async () => {
+test("quick prompts default disabled and enable without eager loading", async () => {
   const harness = createHarness();
 
-  assert.equal(harness.service.getSnapshot().enabled, true);
+  assert.equal(harness.service.getSnapshot().enabled, false);
+  await assert.rejects(
+    harness.service.ensureLoaded(),
+    /quick_prompts\.disabled/
+  );
   assert.equal(harness.calls.list, 0);
+
+  harness.enable();
+  await waitFor(() => harness.service.getSnapshot().enabled);
   assert.equal(harness.service.getSnapshot().status, "idle");
+  assert.equal(harness.calls.list, 0);
 
   await harness.service.ensureLoaded();
   assert.equal(harness.calls.list, 1);
@@ -31,7 +42,7 @@ test("quick prompts are enabled without eager loading", async () => {
 });
 
 test("quick prompts CRUD publishes immutable committed snapshots", async () => {
-  const harness = createHarness();
+  const harness = createHarness({ enabled: true });
   await harness.service.ensureLoaded();
 
   const created = await harness.service.create({
@@ -82,6 +93,7 @@ test("quick prompt move publishes optimistic order then authoritative order", as
   };
   const moveResponse = deferred<{ prompts: AgentHostQuickPrompt[] }>();
   const harness = createHarness({
+    enabled: true,
     list: async () => ({ prompts: [firstPrompt, secondPrompt] }),
     move: () => moveResponse.promise
   });
@@ -114,6 +126,7 @@ test("quick prompt move publishes optimistic order then authoritative order", as
 test("failed quick prompt move rolls back and requests authoritative refresh", async () => {
   const secondPrompt = { ...firstPrompt, id: "prompt-2", title: "Second" };
   const harness = createHarness({
+    enabled: true,
     list: async () => ({ prompts: [firstPrompt, secondPrompt] }),
     move: async () => {
       throw new Error("move failed");
@@ -137,8 +150,35 @@ test("failed quick prompt move rolls back and requests authoritative refresh", a
   harness.service.dispose();
 });
 
+test("disabling quick prompts during a failed move stays fail closed", async () => {
+  const secondPrompt = { ...firstPrompt, id: "prompt-2", title: "Second" };
+  const moveResponse = deferred<{ prompts: AgentHostQuickPrompt[] }>();
+  const harness = createHarness({
+    enabled: true,
+    list: async () => ({ prompts: [firstPrompt, secondPrompt] }),
+    move: () => moveResponse.promise
+  });
+  await harness.service.ensureLoaded();
+
+  const moving = harness.service.move({
+    promptId: firstPrompt.id,
+    beforePromptId: null,
+    expectedVersion: firstPrompt.version
+  });
+  harness.disable();
+  await waitFor(() => !harness.service.getSnapshot().enabled);
+  moveResponse.reject(new Error("move failed"));
+
+  await assert.rejects(moving, /move failed/);
+  assert.equal(harness.service.getSnapshot().enabled, false);
+  assert.equal(harness.service.getSnapshot().error, null);
+  assert.equal(harness.service.getSnapshot().orderMutationPending, false);
+  assert.equal(harness.calls.list, 1);
+  harness.service.dispose();
+});
+
 test("quick prompt global events coalesce refresh and skip an applied mutation", async () => {
-  const harness = createHarness();
+  const harness = createHarness({ enabled: true });
   await harness.service.ensureLoaded();
 
   harness.emit({
@@ -179,6 +219,7 @@ test("quick prompt events received during a list request trigger a fresh follow-
     updatedAtUnixMs: 50
   };
   const harness = createHarness({
+    enabled: true,
     list: (call) => {
       if (call === 2) return secondList.promise;
       return Promise.resolve({
@@ -207,13 +248,127 @@ test("quick prompt events received during a list request trigger a fresh follow-
   harness.service.dispose();
 });
 
+test("re-enabling quick prompts keeps loading lazy and invalidates the old list", async () => {
+  let remotePrompts: AgentHostQuickPrompt[] = [firstPrompt];
+  const harness = createHarness({
+    enabled: true,
+    list: async () => ({ prompts: remotePrompts })
+  });
+  await harness.service.ensureLoaded();
+
+  harness.disable();
+  await waitFor(() => !harness.service.getSnapshot().enabled);
+  remotePrompts = [
+    {
+      ...firstPrompt,
+      id: "created-while-disabled",
+      title: "Created elsewhere",
+      updatedAtUnixMs: 60
+    }
+  ];
+  harness.emit({
+    changeKind: "created",
+    promptId: remotePrompts[0]!.id,
+    version: remotePrompts[0]!.version
+  });
+  harness.enable();
+  await waitFor(() => harness.service.getSnapshot().enabled);
+
+  assert.equal(harness.service.getSnapshot().status, "idle");
+  assert.equal(harness.calls.list, 1);
+  await harness.service.ensureLoaded();
+  assert.equal(harness.calls.list, 2);
+  assert.deepEqual(harness.service.getSnapshot().prompts, remotePrompts);
+  harness.service.dispose();
+});
+
+test("reopening after a fast disable and enable reruns an in-flight stale list", async () => {
+  const staleList = deferred<{ prompts: AgentHostQuickPrompt[] }>();
+  const remotePrompt = {
+    ...firstPrompt,
+    id: "fresh-after-reenable",
+    title: "Fresh",
+    updatedAtUnixMs: 70
+  };
+  const harness = createHarness({
+    enabled: true,
+    list: (call) =>
+      call === 1
+        ? staleList.promise
+        : Promise.resolve({ prompts: [remotePrompt] })
+  });
+  const originalLoad = harness.service.ensureLoaded();
+  await waitFor(() => harness.calls.list === 1);
+
+  harness.disable();
+  await waitFor(() => !harness.service.getSnapshot().enabled);
+  harness.enable();
+  await waitFor(() => harness.service.getSnapshot().enabled);
+  const reopenedLoad = harness.service.ensureLoaded();
+  staleList.resolve({ prompts: [firstPrompt] });
+  await Promise.all([originalLoad, reopenedLoad]);
+
+  assert.equal(harness.calls.list, 2);
+  assert.equal(harness.service.getSnapshot().status, "ready");
+  assert.deepEqual(harness.service.getSnapshot().prompts, [remotePrompt]);
+  harness.service.dispose();
+});
+
+test("disabling quick prompts is immediate, fail closed, and dispose releases subscriptions", async () => {
+  const harness = createHarness({ enabled: true });
+  let notifications = 0;
+  harness.service.subscribe(() => notifications++);
+  await harness.service.ensureLoaded();
+
+  harness.disable();
+  await waitFor(() => !harness.service.getSnapshot().enabled);
+  const callsBeforeDisabledOperations = { ...harness.calls };
+  await assert.rejects(
+    harness.service.create({ content: "No", title: "Disabled" }),
+    /quick_prompts\.disabled/
+  );
+  await assert.rejects(
+    harness.service.update({
+      content: "No",
+      expectedVersion: 1,
+      id: firstPrompt.id,
+      title: "Disabled"
+    }),
+    /quick_prompts\.disabled/
+  );
+  await assert.rejects(
+    harness.service.remove({ expectedVersion: 1, id: firstPrompt.id }),
+    /quick_prompts\.disabled/
+  );
+  assert.deepEqual(harness.calls, callsBeforeDisabledOperations);
+
+  const notificationsBeforeDispose = notifications;
+  harness.service.dispose();
+  harness.enable();
+  harness.emit({
+    changeKind: "updated",
+    promptId: firstPrompt.id,
+    version: 3
+  });
+  await Promise.resolve();
+  assert.equal(notifications, notificationsBeforeDispose);
+  assert.equal(harness.calls.list, callsBeforeDisabledOperations.list);
+});
+
 function createHarness(
   input: {
+    enabled?: boolean;
     list?: (call: number) => Promise<{ prompts: AgentHostQuickPrompt[] }>;
     move?: () => Promise<{ prompts: AgentHostQuickPrompt[] }>;
   } = {}
 ) {
   const calls = { create: 0, list: 0, move: 0, remove: 0, update: 0 };
+  const preferencesStore = proxy({
+    changingFeatureFlags: null as Record<string, boolean> | null,
+    featureFlags: input.enabled
+      ? { [AGENT_QUICK_PROMPT_LIBRARY_FLAG]: true }
+      : {}
+  });
   let eventListener:
     | ((event: {
         payload: {
@@ -279,18 +434,33 @@ function createHarness(
       return { prompts: [firstPrompt] };
     }
   } as unknown as TuttidClient;
+  const desktopPreferencesService = {
+    _serviceBrand: undefined,
+    store: preferencesStore
+  } as unknown as IDesktopPreferencesService;
   const service = new DesktopAgentQuickPromptService({
+    desktopPreferencesService,
     eventStreamClient,
     tuttidClient
   });
   return {
     calls,
+    disable() {
+      preferencesStore.featureFlags = {
+        [AGENT_QUICK_PROMPT_LIBRARY_FLAG]: false
+      };
+    },
     emit(payload: {
       promptId: string;
       changeKind: "created" | "updated" | "deleted";
       version: number;
     }) {
       eventListener?.({ payload: { ...payload, occurredAtUnixMs: 100 } });
+    },
+    enable() {
+      preferencesStore.featureFlags = {
+        [AGENT_QUICK_PROMPT_LIBRARY_FLAG]: true
+      };
     },
     service
   };

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentQuickPromptService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentQuickPromptService.ts
@@ -6,7 +6,15 @@ import type {
   TuttidClient,
   TuttidEventStreamClient
 } from "@tutti-os/client-tuttid-ts";
+import { subscribe as subscribeValtio } from "valtio";
+import {
+  AGENT_QUICK_PROMPT_LIBRARY_FLAG,
+  isFeatureEnabled
+} from "../../../../../../shared/featureFlags/catalog.ts";
+import type { IDesktopPreferencesService } from "../../../desktop-preferences/services/desktopPreferencesService.interface.ts";
 import type { IAgentQuickPromptService } from "../agentQuickPromptService.interface.ts";
+
+const disabledErrorCode = "quick_prompts.disabled";
 
 export class DesktopAgentQuickPromptService implements IAgentQuickPromptService {
   readonly _serviceBrand = undefined;
@@ -16,6 +24,7 @@ export class DesktopAgentQuickPromptService implements IAgentQuickPromptService 
   >();
   private readonly pendingMutationCounts = new Map<string, number>();
   private readonly locallyAppliedEvents = new Set<string>();
+  private readonly disposePreferencesSubscription: () => void;
   private readonly disposeEventSubscription: (() => void) | null;
   private snapshot: AgentHostQuickPromptSnapshot;
   private loadPromise: Promise<void> | null = null;
@@ -25,17 +34,19 @@ export class DesktopAgentQuickPromptService implements IAgentQuickPromptService 
   private disposed = false;
   private mutationSequence = 0;
   private readonly input: {
+    desktopPreferencesService: IDesktopPreferencesService;
     eventStreamClient?: TuttidEventStreamClient;
     tuttidClient: TuttidClient;
   };
 
   constructor(input: {
+    desktopPreferencesService: IDesktopPreferencesService;
     eventStreamClient?: TuttidEventStreamClient;
     tuttidClient: TuttidClient;
   }) {
     this.input = input;
     this.snapshot = {
-      enabled: true,
+      enabled: this.readEnabled(),
       error: null,
       pendingMutationIds: [],
       orderMutationPending: false,
@@ -43,6 +54,10 @@ export class DesktopAgentQuickPromptService implements IAgentQuickPromptService 
       revision: 0,
       status: "idle"
     };
+    this.disposePreferencesSubscription = subscribeValtio(
+      input.desktopPreferencesService.store,
+      () => this.handlePreferencesChanged()
+    );
     this.disposeEventSubscription = input.eventStreamClient
       ? input.eventStreamClient.subscribe(
           "agent.quickprompt.updated",
@@ -68,7 +83,7 @@ export class DesktopAgentQuickPromptService implements IAgentQuickPromptService 
   };
 
   async ensureLoaded(input?: { force?: boolean }): Promise<void> {
-    this.assertAvailable();
+    this.assertEnabled();
     if (!input?.force && this.snapshot.status === "ready") return;
     if (this.loadPromise) {
       if (input?.force || this.snapshot.status === "idle") {
@@ -90,7 +105,7 @@ export class DesktopAgentQuickPromptService implements IAgentQuickPromptService 
     title: string;
     content: string;
   }): Promise<AgentHostQuickPrompt> {
-    this.assertAvailable();
+    this.assertEnabled();
     const mutationId = `create:${++this.mutationSequence}`;
     return this.runMutation(mutationId, "create", async () => {
       const response = await this.input.tuttidClient.createAgentQuickPrompt({
@@ -107,7 +122,7 @@ export class DesktopAgentQuickPromptService implements IAgentQuickPromptService 
     content: string;
     expectedVersion: number;
   }): Promise<AgentHostQuickPrompt> {
-    this.assertAvailable();
+    this.assertEnabled();
     return this.runMutation(input.id, "update", async () => {
       const response = await this.input.tuttidClient.updateAgentQuickPrompt(
         input.id,
@@ -122,7 +137,7 @@ export class DesktopAgentQuickPromptService implements IAgentQuickPromptService 
   }
 
   async remove(input: { id: string; expectedVersion: number }): Promise<void> {
-    this.assertAvailable();
+    this.assertEnabled();
     await this.runMutation(input.id, "delete", async () => {
       await this.input.tuttidClient.deleteAgentQuickPrompt(input.id, {
         expectedVersion: input.expectedVersion
@@ -135,7 +150,7 @@ export class DesktopAgentQuickPromptService implements IAgentQuickPromptService 
     beforePromptId: string | null;
     expectedVersion: number;
   }): Promise<readonly AgentHostQuickPrompt[]> {
-    this.assertAvailable();
+    this.assertEnabled();
     if (this.snapshot.orderMutationPending) {
       throw new Error("quick_prompts.move_pending");
     }
@@ -167,12 +182,12 @@ export class DesktopAgentQuickPromptService implements IAgentQuickPromptService 
           movedPrompt.version
         );
       }
-      if (!this.disposed) {
+      if (!this.disposed && this.readEnabled()) {
         this.publish({ error: null, prompts, status: "ready" });
       }
       return prompts;
     } catch (error) {
-      if (!this.disposed) {
+      if (!this.disposed && this.readEnabled()) {
         if (promptSnapshotsEqual(this.snapshot.prompts, optimisticPrompts)) {
           this.publish({
             error: "quick_prompts.move_failed",
@@ -196,18 +211,19 @@ export class DesktopAgentQuickPromptService implements IAgentQuickPromptService 
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
+    this.disposePreferencesSubscription();
     this.disposeEventSubscription?.();
     this.listeners.clear();
   }
 
   private async load(): Promise<void> {
     this.publish({ error: null, status: "loading" });
-    while (!this.disposed) {
+    while (!this.disposed && this.readEnabled()) {
       this.refreshRequestedDuringLoad = false;
       const generation = this.loadGeneration;
       try {
         const response = await this.input.tuttidClient.listAgentQuickPrompts();
-        if (this.disposed) return;
+        if (this.disposed || !this.readEnabled()) return;
         if (
           this.refreshRequestedDuringLoad ||
           generation !== this.loadGeneration
@@ -219,7 +235,7 @@ export class DesktopAgentQuickPromptService implements IAgentQuickPromptService 
         this.publish({ error: null, prompts, status: "ready" });
         return;
       } catch (error) {
-        if (!this.disposed) {
+        if (!this.disposed && this.readEnabled()) {
           this.publish({
             error: "quick_prompts.load_failed",
             status: "error"
@@ -240,7 +256,7 @@ export class DesktopAgentQuickPromptService implements IAgentQuickPromptService 
     try {
       const result = await operation();
       this.markDataChangedDuringLoad();
-      if (this.disposed) return result;
+      if (this.disposed || !this.readEnabled()) return result;
       if (kind === "delete") {
         this.rememberLocallyAppliedEvent(mutationId, kind, null);
         this.publish({
@@ -279,6 +295,7 @@ export class DesktopAgentQuickPromptService implements IAgentQuickPromptService 
   private scheduleEventRefresh(): void {
     if (
       this.disposed ||
+      !this.readEnabled() ||
       this.snapshot.status === "idle" ||
       this.eventRefreshQueued
     ) {
@@ -287,7 +304,7 @@ export class DesktopAgentQuickPromptService implements IAgentQuickPromptService 
     this.eventRefreshQueued = true;
     queueMicrotask(() => {
       this.eventRefreshQueued = false;
-      if (this.disposed) return;
+      if (this.disposed || !this.readEnabled()) return;
       void this.ensureLoaded({ force: true }).catch(() => {});
     });
   }
@@ -326,8 +343,36 @@ export class DesktopAgentQuickPromptService implements IAgentQuickPromptService 
     }
   }
 
-  private assertAvailable(): void {
-    if (this.disposed) throw new Error("quick_prompts.disposed");
+  private handlePreferencesChanged(): void {
+    const enabled = this.readEnabled();
+    if (enabled === this.snapshot.enabled) return;
+    if (!enabled) {
+      this.loadGeneration++;
+      this.refreshRequestedDuringLoad = false;
+      this.pendingMutationCounts.clear();
+      this.locallyAppliedEvents.clear();
+      this.publish({
+        enabled: false,
+        error: null,
+        pendingMutationIds: [],
+        orderMutationPending: false,
+        status: "idle"
+      });
+      return;
+    }
+    this.publish({ enabled: true, error: null, status: "idle" });
+  }
+
+  private readEnabled(): boolean {
+    const store = this.input.desktopPreferencesService.store;
+    const flags = store.changingFeatureFlags ?? store.featureFlags;
+    return isFeatureEnabled(flags, AGENT_QUICK_PROMPT_LIBRARY_FLAG);
+  }
+
+  private assertEnabled(): void {
+    if (this.disposed || !this.readEnabled()) {
+      throw new Error(disabledErrorCode);
+    }
   }
 
   private publishPendingMutations(): void {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/registerWorkspaceAgentServices.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/registerWorkspaceAgentServices.ts
@@ -140,6 +140,7 @@ export function registerWorkspaceAgentServices(
     preferencesStore
   });
   const agentQuickPromptService = new DesktopAgentQuickPromptService({
+    desktopPreferencesService: input.desktopPreferencesService,
     eventStreamClient: input.eventStreamClient,
     tuttidClient: input.tuttidClient
   });

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFeatureFlagSettings.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFeatureFlagSettings.ts
@@ -3,6 +3,7 @@ import type { DesktopFeatureFlags } from "@shared/preferences";
 import { desktopFeatureFlagsEqual } from "../../../../../../shared/preferences/index.ts";
 import {
   AGENT_EXTENSION_ACTIVATION_FLAGS,
+  AGENT_QUICK_PROMPT_LIBRARY_FLAG,
   isFeatureEnabled,
   MOBILE_REMOTE_ACCESS_SETTINGS_FLAG
 } from "../../../../../../shared/featureFlags/catalog.ts";
@@ -35,6 +36,9 @@ export function createWorkspaceFeatureFlagSettings(input: {
         return;
       }
 
+      const quickPromptLibraryChanged =
+        isFeatureEnabled(previousFlags, AGENT_QUICK_PROMPT_LIBRARY_FLAG) !==
+        isFeatureEnabled(nextFlags, AGENT_QUICK_PROMPT_LIBRARY_FLAG);
       const mobileRemoteAccessSettingsChanged =
         isFeatureEnabled(previousFlags, MOBILE_REMOTE_ACCESS_SETTINGS_FLAG) !==
         isFeatureEnabled(nextFlags, MOBILE_REMOTE_ACCESS_SETTINGS_FLAG);
@@ -51,9 +55,11 @@ export function createWorkspaceFeatureFlagSettings(input: {
       } catch {
         input.notifications.error({
           title: createTranslator(getActiveLocale()).t(
-            mobileRemoteAccessSettingsChanged
-              ? "workspace.settings.developer.mobileRemoteAccessSettingsSaveFailed"
-              : "workspace.settings.lab.preferencesSaveFailed"
+            quickPromptLibraryChanged
+              ? "workspace.settings.developer.quickPromptLibrarySaveFailed"
+              : mobileRemoteAccessSettingsChanged
+                ? "workspace.settings.developer.mobileRemoteAccessSettingsSaveFailed"
+                : "workspace.settings.lab.preferencesSaveFailed"
           )
         });
       }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceSettingsService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceSettingsService.test.ts
@@ -9,6 +9,7 @@ import type { ReporterEventInput } from "../../../analytics/services/reporterSer
 import {
   AGENT_EXTENSION_ACTIVATION_FLAGS,
   AGENT_EXTENSION_GEMINI_FLAG,
+  AGENT_QUICK_PROMPT_LIBRARY_FLAG,
   LAB_CONNECTORS_FLAG,
   LAB_ENABLED_FLAG,
   MOBILE_REMOTE_ACCESS_SETTINGS_FLAG
@@ -595,6 +596,31 @@ test("WorkspaceSettingsService does not refresh Agent Targets after changing an 
       next: { [LAB_ENABLED_FLAG]: true }
     }),
     ["save"]
+  );
+});
+
+test("WorkspaceSettingsService reports a quick prompt specific save failure", async () => {
+  const notifications = createNotificationRecorder();
+  const service = new WorkspaceSettingsService(
+    { client: createWorkspaceSettingsClient({}) },
+    createDesktopPreferencesService({
+      onSetFeatureFlags: async () => {
+        throw new Error("preferences unavailable");
+      },
+      state: createPreferencesState({ featureFlags: {} })
+    }),
+    notifications.service
+  );
+
+  await service.changeFeatureFlags({
+    [AGENT_QUICK_PROMPT_LIBRARY_FLAG]: true
+  });
+
+  assert.equal(notifications.items.length, 1);
+  assert.ok(
+    notifications.items[0] ===
+      "We couldn't update quick-prompt library availability." ||
+      notifications.items[0] === "暂时无法更新快捷提示词库可用状态"
   );
 });
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceDeveloperSettingsSection.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceDeveloperSettingsSection.tsx
@@ -34,6 +34,7 @@ import {
   type DesktopUpdateChannel
 } from "@shared/preferences";
 import {
+  AGENT_QUICK_PROMPT_LIBRARY_FLAG,
   AGENT_REFERENCE_PROVENANCE_FILTER_FLAG,
   AGENT_SESSION_RECORDING_FLAG,
   isFeatureEnabled,
@@ -88,6 +89,10 @@ export function WorkspaceDeveloperSettingsSection() {
   const referenceProvenanceFilterEnabled = isFeatureEnabled(
     pendingFeatureFlags,
     AGENT_REFERENCE_PROVENANCE_FILTER_FLAG
+  );
+  const quickPromptLibraryEnabled = isFeatureEnabled(
+    pendingFeatureFlags,
+    AGENT_QUICK_PROMPT_LIBRARY_FLAG
   );
   const agentSessionRecordingEnabled = isFeatureEnabled(
     pendingFeatureFlags,
@@ -163,6 +168,12 @@ export function WorkspaceDeveloperSettingsSection() {
     void settingsService.changeFeatureFlags({
       ...pendingFeatureFlags,
       [AGENT_REFERENCE_PROVENANCE_FILTER_FLAG]: enabled
+    });
+  };
+  const onQuickPromptLibraryEnabledChange = (enabled: boolean) => {
+    void settingsService.changeFeatureFlags({
+      ...pendingFeatureFlags,
+      [AGENT_QUICK_PROMPT_LIBRARY_FLAG]: enabled
     });
   };
   const onAgentSessionRecordingEnabledChange = (enabled: boolean) => {
@@ -353,6 +364,23 @@ export function WorkspaceDeveloperSettingsSection() {
           checked={agentSessionForkEnabled}
           disabled={featureFlagsUpdating}
           onCheckedChange={onAgentSessionForkEnabledChange}
+        />
+      </div>
+
+      <div className="flex w-full items-center justify-between gap-4 max-[560px]:flex-col max-[560px]:items-stretch">
+        <div className="flex min-w-0 flex-1 flex-col gap-1 max-[560px]:w-full">
+          <strong className="text-[13px] font-semibold text-[var(--text-primary)]">
+            {t("workspace.settings.developer.quickPromptLibraryLabel")}
+          </strong>
+          <p className="m-0 text-[13px] leading-[1.3] text-[var(--text-secondary)]">
+            {t("workspace.settings.developer.quickPromptLibraryDescription")}
+          </p>
+        </div>
+        <Switch
+          aria-label={t("workspace.settings.developer.quickPromptLibraryLabel")}
+          checked={quickPromptLibraryEnabled}
+          disabled={featureFlagsUpdating}
+          onCheckedChange={onQuickPromptLibraryEnabledChange}
         />
       </div>
 

--- a/apps/desktop/src/shared/featureFlags/catalog.test.ts
+++ b/apps/desktop/src/shared/featureFlags/catalog.test.ts
@@ -9,6 +9,7 @@ import {
   AGENT_EXTENSION_KILO_FLAG,
   AGENT_EXTENSION_QWEN_FLAG,
   AGENT_REFERENCE_PROVENANCE_FILTER_FLAG,
+  AGENT_QUICK_PROMPT_LIBRARY_FLAG,
   AGENT_SESSION_RECORDING_FLAG,
   isFeatureEnabled,
   labFeatureDefinitions,
@@ -61,8 +62,23 @@ test("isFeatureEnabled falls back to catalog default when key absent", () => {
     isFeatureEnabled({}, AGENT_REFERENCE_PROVENANCE_FILTER_FLAG),
     false
   );
+  assert.equal(isFeatureEnabled({}, AGENT_QUICK_PROMPT_LIBRARY_FLAG), false);
   assert.equal(isFeatureEnabled({}, AGENT_SESSION_RECORDING_FLAG), false);
   assert.equal(isFeatureEnabled({}, MOBILE_REMOTE_ACCESS_SETTINGS_FLAG), false);
+  assert.equal(
+    isFeatureEnabled(
+      { [AGENT_QUICK_PROMPT_LIBRARY_FLAG]: false },
+      AGENT_QUICK_PROMPT_LIBRARY_FLAG
+    ),
+    false
+  );
+  assert.equal(
+    isFeatureEnabled(
+      { [AGENT_QUICK_PROMPT_LIBRARY_FLAG]: true },
+      AGENT_QUICK_PROMPT_LIBRARY_FLAG
+    ),
+    true
+  );
   assert.equal(
     isFeatureEnabled(
       { [AGENT_SESSION_RECORDING_FLAG]: true },

--- a/apps/desktop/src/shared/featureFlags/catalog.ts
+++ b/apps/desktop/src/shared/featureFlags/catalog.ts
@@ -20,6 +20,7 @@ export const WORKSPACE_STANDALONE_AGENT_MODE_FLAG =
   "workspace.standaloneAgentMode";
 export const AGENT_REFERENCE_PROVENANCE_FILTER_FLAG =
   "agent.referenceProvenanceFilter";
+export const AGENT_QUICK_PROMPT_LIBRARY_FLAG = "agent.quickPromptLibrary";
 export const AGENT_SESSION_RECORDING_FLAG = "agent.sessionRecording";
 export const MOBILE_REMOTE_ACCESS_SETTINGS_FLAG = "mobile.remoteAccessSettings";
 export const AGENT_EXTENSION_GEMINI_FLAG = "agent.extension.gemini";
@@ -137,6 +138,11 @@ export const FEATURE_FLAG_DEFINITIONS: readonly FeatureFlagDefinition[] = [
   },
   {
     key: AGENT_REFERENCE_PROVENANCE_FILTER_FLAG,
+    default: false,
+    group: "developer"
+  },
+  {
+    key: AGENT_QUICK_PROMPT_LIBRARY_FLAG,
     default: false,
     group: "developer"
   },

--- a/apps/desktop/src/shared/i18n/locales/en.ts
+++ b/apps/desktop/src/shared/i18n/locales/en.ts
@@ -1342,6 +1342,11 @@ export const en = {
         referenceProvenanceFilterDescription:
           "Enable Agent source filtering in Agent conversation reference pickers.",
         referenceProvenanceFilterLabel: "Agent source filter",
+        quickPromptLibraryDescription:
+          "Show a personal quick-prompt library in the Agent composer.",
+        quickPromptLibraryLabel: "Quick-prompt library",
+        quickPromptLibrarySaveFailed:
+          "We couldn't update quick-prompt library availability.",
         releaseChannelOptions: {
           rc: "Preview",
           stable: "Stable"

--- a/apps/desktop/src/shared/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/shared/i18n/locales/zh-CN.ts
@@ -1257,6 +1257,10 @@ export const zhCN = {
         referenceProvenanceFilterDescription:
           "在 Agent 对话的引用选择器中启用智能体来源筛选",
         referenceProvenanceFilterLabel: "智能体来源筛选",
+        quickPromptLibraryDescription:
+          "在 Agent 输入框中显示个人快捷提示词库入口",
+        quickPromptLibraryLabel: "快捷提示词库",
+        quickPromptLibrarySaveFailed: "暂时无法更新快捷提示词库可用状态",
         releaseChannelOptions: {
           rc: "预览版",
           stable: "稳定版"

--- a/apps/mobile/src/services/mobileApplicationService.test.ts
+++ b/apps/mobile/src/services/mobileApplicationService.test.ts
@@ -532,7 +532,6 @@ function createHarness(
         getDesktopPreferences: async () => ({
           preferences: { featureFlags: {} }
         }),
-        listAgentQuickPrompts: async () => ({ prompts: [] }),
         listAgentTargets: async () => ({ targets: [] }),
         listUserProjects: async () => ({ projects: [] }),
         listWorkspaceAgentSessionSections: async () => ({

--- a/apps/mobile/src/services/mobileQuickPromptLibraryService.test.ts
+++ b/apps/mobile/src/services/mobileQuickPromptLibraryService.test.ts
@@ -1,5 +1,6 @@
 import type {
   AgentQuickPrompt,
+  DesktopPreferencesStateResponse,
   TuttidClient
 } from "@tutti-os/client-tuttid-ts";
 import { MobileQuickPromptLibraryService } from "./mobileQuickPromptLibraryService";
@@ -14,9 +15,30 @@ const prompt: AgentQuickPrompt = {
 };
 
 describe("MobileQuickPromptLibraryService", () => {
-  test("loads the canonical device prompt order without a feature flag", async () => {
+  test("keeps the library hidden without the desktop feature flag", async () => {
+    const listAgentQuickPrompts = jest.fn();
     const service = new MobileQuickPromptLibraryService(
       createClient({
+        featureFlags: {},
+        listAgentQuickPrompts
+      })
+    );
+
+    await service.refresh();
+
+    expect(listAgentQuickPrompts).not.toHaveBeenCalled();
+    expect(service.getSnapshot()).toEqual({
+      enabled: false,
+      errorCode: null,
+      prompts: [],
+      status: "ready"
+    });
+  });
+
+  test("loads the canonical device prompt order when enabled", async () => {
+    const service = new MobileQuickPromptLibraryService(
+      createClient({
+        featureFlags: { "agent.quickPromptLibrary": true },
         listAgentQuickPrompts: jest
           .fn()
           .mockResolvedValue({ prompts: [prompt] })
@@ -33,19 +55,18 @@ describe("MobileQuickPromptLibraryService", () => {
     });
   });
 
-  test("reports quick prompt request failures", async () => {
-    const service = new MobileQuickPromptLibraryService(
-      createClient({
-        listAgentQuickPrompts: jest
-          .fn()
-          .mockRejectedValue(new Error("unavailable"))
-      })
-    );
+  test("fails closed when desktop preferences cannot be read", async () => {
+    const service = new MobileQuickPromptLibraryService({
+      getDesktopPreferences: jest
+        .fn()
+        .mockRejectedValue(new Error("unavailable")),
+      listAgentQuickPrompts: jest.fn()
+    } as unknown as TuttidClient);
 
     await service.refresh();
 
     expect(service.getSnapshot()).toEqual({
-      enabled: true,
+      enabled: false,
       errorCode: "request_failed",
       prompts: [],
       status: "error"
@@ -59,6 +80,7 @@ describe("MobileQuickPromptLibraryService", () => {
       .mockRejectedValueOnce(new Error("unavailable"));
     const service = new MobileQuickPromptLibraryService(
       createClient({
+        featureFlags: { "agent.quickPromptLibrary": true },
         listAgentQuickPrompts
       })
     );
@@ -89,6 +111,7 @@ describe("MobileQuickPromptLibraryService", () => {
       .mockResolvedValueOnce({ prompts: [] });
     const service = new MobileQuickPromptLibraryService(
       createClient({
+        featureFlags: { "agent.quickPromptLibrary": true },
         listAgentQuickPrompts
       })
     );
@@ -110,9 +133,17 @@ describe("MobileQuickPromptLibraryService", () => {
 });
 
 function createClient(input: {
+  featureFlags: Record<string, boolean>;
   listAgentQuickPrompts: jest.Mock;
 }): TuttidClient {
   return {
+    getDesktopPreferences: async () =>
+      ({
+        initialized: true,
+        preferences: {
+          featureFlags: input.featureFlags
+        }
+      }) as DesktopPreferencesStateResponse,
     listAgentQuickPrompts: input.listAgentQuickPrompts
   } as unknown as TuttidClient;
 }

--- a/apps/mobile/src/services/mobileQuickPromptLibraryService.ts
+++ b/apps/mobile/src/services/mobileQuickPromptLibraryService.ts
@@ -4,6 +4,8 @@ import type {
 } from "@tutti-os/client-tuttid-ts";
 import { ObservableService } from "./observableService";
 
+const AGENT_QUICK_PROMPT_LIBRARY_FLAG = "agent.quickPromptLibrary";
+
 export interface MobileQuickPromptLibrarySnapshot {
   enabled: boolean;
   errorCode: "request_failed" | null;
@@ -12,7 +14,7 @@ export interface MobileQuickPromptLibrarySnapshot {
 }
 
 const initialSnapshot: MobileQuickPromptLibrarySnapshot = {
-  enabled: true,
+  enabled: false,
   errorCode: null,
   prompts: [],
   status: "idle"
@@ -36,14 +38,27 @@ export class MobileQuickPromptLibraryService extends ObservableService<MobileQui
     if (this.disposed) return Promise.resolve();
     this.publish({
       ...this.snapshot,
-      enabled: true,
       errorCode: null,
       status: "loading"
     });
     const generation = ++this.refreshGeneration;
+    let enabled = false;
     const refreshPromise = this.client
-      .listAgentQuickPrompts()
-      .then(({ prompts }) => {
+      .getDesktopPreferences()
+      .then(async ({ preferences }) => {
+        if (this.disposed || generation !== this.refreshGeneration) return;
+        enabled =
+          preferences.featureFlags[AGENT_QUICK_PROMPT_LIBRARY_FLAG] === true;
+        if (!enabled) {
+          this.publish({
+            enabled: false,
+            errorCode: null,
+            prompts: [],
+            status: "ready"
+          });
+          return;
+        }
+        const { prompts } = await this.client.listAgentQuickPrompts();
         if (this.disposed || generation !== this.refreshGeneration) return;
         this.publish({
           enabled: true,
@@ -55,9 +70,9 @@ export class MobileQuickPromptLibraryService extends ObservableService<MobileQui
       .catch(() => {
         if (this.disposed || generation !== this.refreshGeneration) return;
         this.publish({
-          enabled: true,
+          enabled,
           errorCode: "request_failed",
-          prompts: this.snapshot.prompts,
+          prompts: enabled ? this.snapshot.prompts : [],
           status: "error"
         });
       })

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -566,8 +566,8 @@ for a remote pasted-text asset carries only its safe preview mention; short-
 lived URLs and object-store locators remain in structured prompt content and
 must not enter caller-visible transcript projections.
 Device-global quick prompts are also an optional host capability rather than
-activity data. The desktop adapter combines the generated `tuttid` client and
-global invalidation events behind
+activity data. The desktop adapter combines the developer-gated preference,
+the generated `tuttid` client, and global invalidation events behind
 `AgentHostApi.quickPrompts`. AgentGUI may subscribe to that capability to render
 the composer picker and management dialogs, but quick-prompt entities must not
 be copied into `AgentGUIRuntime`, a workspace engine, a Session, or a Turn.
@@ -580,8 +580,8 @@ project the resulting order optimistically, but it must replace that projection
 with the daemon's authoritative list. AgentGUI only renders and requests moves;
 hosts that omit the optional move capability keep the library read/write-only.
 The v2 prompt-order schema is a forward-only daemon migration. After it is
-applied, rollback means reverting the renderer surface; do not run an older
-daemon writer against that database.
+applied, rollback means disabling the quick-prompt feature flag or reverting
+the renderer surface; do not run an older daemon writer against that database.
 Older writers do not maintain `sort_order`, so binary daemon downgrade followed
 by create/delete is not a supported recovery path.
 Conversation rail sections are also an `AgentGUIRuntime` contract:

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -40,14 +40,15 @@ partial or disabled library.
 
 The native Mobile composer consumes the same device-global list through its
 authenticated Desktop connection rather than creating Mobile-owned prompt
-state. Its authenticated-device service reads the canonical quick-prompt list
-through the generated tuttid client. The Mobile `+` menu
+state. Its authenticated-device service reads the stored
+`agent.quickPromptLibrary` desktop feature gate and the canonical quick-prompt
+list through the generated tuttid client. When enabled, the Mobile `+` menu
 offers a searchable, read-only selector; choosing a prompt adds its text at the
 current plain-text input position without replacing the existing draft,
 restores input focus, and never sends automatically. Create, edit, delete, and
 reorder remain Desktop management actions. DeviceLink permits only exact
-`GET /v1/agent-quick-prompts` reads for this flow; mutation and per-prompt
-routes remain blocked.
+`GET /v1/preferences/desktop` and `GET /v1/agent-quick-prompts` reads for this
+flow; mutation and per-prompt routes remain blocked.
 
 The native Mobile new-conversation Composer presents Agent Target and working
 directory as peer context selectors directly above the input. The Agent Target
@@ -2374,10 +2375,11 @@ The optional quick-prompt library follows that host-capability boundary. Tutti
 Desktop projects the device-global `tuttid` quick-prompt CRUD service through
 `AgentHostApi.quickPrompts`; AgentGUI owns only the picker/editor presentation
 and inserts a selected prompt into the current TipTap selection without
-submitting it. The library snapshot and cross-window invalidation are not
-Session or Turn state and must not enter `AgentGUIRuntime` or the workspace
-engine. Hosts that omit the capability render no quick-prompt composer entry.
-AgentGUI may also present a small, localized set
+submitting it. The library snapshot, developer feature gate, and cross-window
+invalidation are not Session or Turn state and must not enter
+`AgentGUIRuntime` or the workspace engine. Hosts that omit the capability,
+and hosts whose capability reports the developer gate disabled, render no
+quick-prompt composer entry. AgentGUI may also present a small, localized set
 of recommended templates; those only prefill the existing editor and remain
 client-local until the user explicitly saves them through the CRUD capability.
 

--- a/docs/conventions/troubleshooting/mobile.md
+++ b/docs/conventions/troubleshooting/mobile.md
@@ -188,21 +188,26 @@
 
 ## Mobile quick prompts are missing from the plus menu
 
-- **Symptom:** The connected Mobile composer does not show Quick prompts under
-  `+`, or the list is empty despite prompts saved on Desktop.
-- **Quick checks:** Inspect the DeviceLink `agent_http` response for
+- **Symptom:** The Desktop quick-prompt library is enabled and contains
+  prompts, but the connected Mobile composer does not show Quick prompts under
+  `+`.
+- **Quick checks:** Read the host's Desktop preferences and confirm
+  `agent.quickPromptLibrary` is `true`. Then inspect the DeviceLink
+  `agent_http` responses for `GET /v1/preferences/desktop` and
   `GET /v1/agent-quick-prompts`. A 403 response with `route_not_allowed`
   identifies an allowlist gap.
-- **Root cause:** Mobile loads prompt content only from the canonical device
-  list, so neither the UI nor workspace activity state invents a local
+- **Root cause:** Mobile deliberately fails closed when it cannot verify the
+  Desktop feature gate. It also loads prompt content only from the canonical
+  device list, so neither the UI nor workspace activity state invents a local
   fallback.
-- **Fix:** Keep the exact quick-prompt GET route in the DeviceLink allowlist
-  and keep all preference writes, quick-prompt mutations, and per-prompt
-  routes blocked. Refresh the authenticated-device quick-prompt service when
-  the `+` menu opens.
-- **Validation:** Confirm the canonical prompt order is visible, search
-  matches title and content, and selecting a prompt adds text at the current
-  input position without replacing the existing draft or sending it.
+- **Fix:** Keep the two exact GET routes in the DeviceLink allowlist and keep
+  all preference writes, quick-prompt mutations, and per-prompt routes blocked.
+  Refresh the authenticated-device quick-prompt service when the `+` menu
+  opens.
+- **Validation:** Confirm a disabled or missing feature flag hides the row,
+  enabling it exposes the canonical prompt order, search matches title and
+  content, and selecting a prompt adds text at the current input position
+  without replacing the existing draft or sending it.
 - **References:** `services/tuttid/service/mobileremote/remote_protocol.go`,
   `apps/mobile/src/services/mobileQuickPromptLibraryService.ts`,
   `apps/mobile/src/components/MobileComposerDock.tsx`

--- a/docs/specs/2026-07-23-mobile-agentgui-device-link-design.md
+++ b/docs/specs/2026-07-23-mobile-agentgui-device-link-design.md
@@ -166,10 +166,10 @@ Mobile 使用稳定 Bootstrap container。未登录 child 与登录后 child 互
 
 设备级快捷提示词由登录后的设备 scope 中的独立 service 读取，不进入 workspace
 `AgentSessionEngine`、Session 或移动端持久存储。该 service 通过生成客户端读取电脑端
-canonical 提示词顺序；Composer 的 `+` 菜单提供搜索与只读选择，点选后在当前输入位置
-添加文本，不替换已有草稿，恢复输入焦点且不自动发送。
-新增、编辑、删除和排序仍由电脑端负责。DeviceLink 只为此能力开放精确的快捷提示词
-列表 GET 路由，不开放 mutation 或单条记录路由。
+`agent.quickPromptLibrary` 开关和 canonical 提示词顺序；开关打开时，Composer 的 `+`
+菜单提供搜索与只读选择，点选后在当前输入位置添加文本，不替换已有草稿，恢复输入焦点且不自动发送。
+新增、编辑、删除和排序仍由电脑端负责。DeviceLink 只为此能力开放精确的桌面偏好和
+快捷提示词列表 GET 路由，不开放 mutation 或单条记录路由。
 
 ## 7. DeviceLink 边界
 


### PR DESCRIPTION
## 背景

回滚 PR #2269。快捷提示词恢复为受实验开关控制，不再默认无条件开启。

## 变更

- 恢复 Desktop 快捷提示词 feature flag、开发者设置入口及偏好订阅
- 恢复 Mobile 对 Desktop feature flag 的读取和关闭态行为
- 恢复相关测试、i18n 文案和架构/排障文档

## 验证

- Desktop TypeScript typecheck
- Mobile TypeScript typecheck
- Desktop 和 Mobile 完整 TypeScript 测试 lane
- i18n 检查
- push-ready changed checks：15 lanes

## 平台影响

本次为纯 TypeScript、React 与文档回滚，不涉及路径、进程、原生依赖或平台专属实现；Windows 行为由现有 Windows x64 PR CI 继续验证。