### PR TITLE
fix(browser-node): coalesce equivalent host synchronization

### DIFF
--- a/packages/browser/workbench-node/src/core/webviewController.test.ts
+++ b/packages/browser/workbench-node/src/core/webviewController.test.ts
@@ -3,7 +3,11 @@ import test from "node:test";
 import { createBrowserNodeFeature } from "./feature.ts";
 import { browserNodeGuestInteractionHostChannel } from "./guestInteraction.ts";
 import { acquireBrowserNodeWebviewController } from "./webviewController.ts";
-import type { BrowserNodeHostApi } from "./types.ts";
+import type {
+  BrowserNodeHostApi,
+  BrowserNodePrepareSessionInput,
+  BrowserNodeUpdateAutomationTargetInput
+} from "./types.ts";
 import type { BrowserNodeWebviewTag } from "../react/webviewTag.ts";
 
 test("Browser Node webview controller prepares sessions when active", async () => {
@@ -51,6 +55,68 @@ test("Browser Node webview controller prepares sessions when active", async () =
       workspaceId: "workspace-1"
     }
   ]);
+  controller.release();
+});
+
+test("Browser Node webview controller coalesces equivalent host synchronization", async () => {
+  const prepareCalls: BrowserNodePrepareSessionInput[] = [];
+  const automationTargetCalls: BrowserNodeUpdateAutomationTargetInput[] = [];
+  const feature = createBrowserNodeFeature({
+    hostApi: createBrowserNodeHostApi({
+      prepareSession(payload) {
+        prepareCalls.push(payload);
+        return Promise.resolve();
+      },
+      updateAutomationTarget(payload) {
+        automationTargetCalls.push(payload);
+        return Promise.resolve();
+      }
+    })
+  });
+  const createController = (lifecycle: "active" | "cold", selected: boolean) =>
+    acquireBrowserNodeWebviewController({
+      automationTarget: {
+        agentSessionId: "agent-1",
+        focused: false,
+        selected,
+        surfaceId: "surface-1",
+        surfaceRole: "agent",
+        tabId: "tab-1",
+        workspaceId: "workspace-1"
+      },
+      feature,
+      initialUrl: "https://example.com/",
+      lifecycle,
+      navigationPolicy: {
+        mode: "same-origin",
+        originUrl: "https://example.com/"
+      },
+      nodeId: "browser-host-sync",
+      profileId: null,
+      sessionMode: "shared"
+    });
+
+  const controller = createController("active", true);
+  controller.retain();
+  controller.sync();
+  createController("active", true).sync();
+  await Promise.resolve();
+
+  assert.equal(prepareCalls.length, 1);
+  assert.equal(automationTargetCalls.length, 1);
+
+  createController("active", false).sync();
+  await Promise.resolve();
+  assert.equal(prepareCalls.length, 2);
+  assert.equal(automationTargetCalls.length, 2);
+  assert.equal(prepareCalls.at(-1)?.automationTarget?.selected, false);
+  assert.equal(automationTargetCalls.at(-1)?.automationTarget.selected, false);
+
+  createController("cold", false).sync();
+  createController("active", false).sync();
+  await Promise.resolve();
+  assert.equal(prepareCalls.length, 3);
+  assert.equal(automationTargetCalls.length, 2);
   controller.release();
 });
 
@@ -426,6 +492,9 @@ function createBrowserNodeHostApi(
     ...(overrides.openDevTools ? { openDevTools: overrides.openDevTools } : {}),
     ...(overrides.showDevToolsContextMenu
       ? { showDevToolsContextMenu: overrides.showDevToolsContextMenu }
+      : {}),
+    ...(overrides.updateAutomationTarget
+      ? { updateAutomationTarget: overrides.updateAutomationTarget }
       : {})
   };
 }

--- a/packages/browser/workbench-node/src/core/webviewController.ts
+++ b/packages/browser/workbench-node/src/core/webviewController.ts
@@ -3,8 +3,10 @@ import { browserNodeGuestInteractionHostChannel } from "./guestInteraction.ts";
 import { resolveBrowserSessionPartition } from "./session.ts";
 import type {
   BrowserNodeAutomationTargetMetadata,
+  BrowserNodeHostApi,
   BrowserNodeLifecycle,
   BrowserNodeNavigationPolicy,
+  BrowserNodePrepareSessionInput,
   BrowserNodeSessionMode
 } from "./types.ts";
 import type { BrowserNodeWebviewTag } from "../react/webviewTag.ts";
@@ -58,11 +60,18 @@ interface BrowserNodeWebviewControllerEntry {
   context: BrowserNodeWebviewControllerContext;
   controller: BrowserNodeWebviewController;
   listeners: Set<() => void>;
+  lastAutomationTargetSync: BrowserNodeHostEffectSnapshot<BrowserNodeAutomationTargetMetadata> | null;
+  lastSessionPreparation: BrowserNodeHostEffectSnapshot<BrowserNodePrepareSessionInput> | null;
   refCount: number;
   registeredGuestId: number | null;
   registeringGuestId: number | null;
   state: BrowserNodeWebviewControllerState;
   webview: BrowserNodeWebviewTag | null;
+}
+
+interface BrowserNodeHostEffectSnapshot<T> {
+  hostApi: BrowserNodeHostApi;
+  payload: T;
 }
 
 interface BrowserNodeGuestInteractionEvent extends Event {
@@ -137,6 +146,8 @@ function createBrowserNodeWebviewControllerEntry(
     context,
     controller: null as unknown as BrowserNodeWebviewController,
     listeners: new Set(),
+    lastAutomationTargetSync: null,
+    lastSessionPreparation: null,
     refCount: 0,
     registeredGuestId: null,
     registeringGuestId: null,
@@ -256,15 +267,9 @@ function reconcileBrowserNodeWebviewControllerState(
     entry.state.webviewSrc !== nextState.webviewSrc;
 
   if (options.allowHostEffects) {
-    if (entry.context.automationTarget) {
-      void entry.context.feature.hostApi
-        .updateAutomationTarget?.({
-          automationTarget: entry.context.automationTarget,
-          nodeId: entry.context.nodeId
-        })
-        .catch(() => undefined);
-    }
+    syncBrowserNodeAutomationTarget(entry);
     if (entry.context.lifecycle === "cold") {
+      entry.lastSessionPreparation = null;
       scheduleBrowserNodeGuestUnregister(entry);
     } else {
       const pendingGuestId = clearPendingBrowserNodeGuestUnregister(
@@ -273,17 +278,7 @@ function reconcileBrowserNodeWebviewControllerState(
       if (entry.registeredGuestId === null && pendingGuestId !== null) {
         entry.registeredGuestId = pendingGuestId;
       }
-      void entry.context.feature.hostApi
-        .prepareSession({
-          automationTarget: entry.context.automationTarget,
-          navigationPolicy: entry.context.navigationPolicy,
-          nodeId: entry.context.nodeId,
-          profileId: entry.context.profileId,
-          sessionMode: entry.context.sessionMode,
-          sessionPartition: entry.context.sessionPartition,
-          url: entry.context.initialUrl
-        })
-        .catch(() => undefined);
+      prepareBrowserNodeSession(entry);
     }
   }
 
@@ -304,6 +299,151 @@ function reconcileBrowserNodeWebviewControllerState(
   if (options.notifyListeners) {
     notifyBrowserNodeWebviewControllerListeners(entry);
   }
+}
+
+function syncBrowserNodeAutomationTarget(
+  entry: BrowserNodeWebviewControllerEntry
+): void {
+  const automationTarget = entry.context.automationTarget;
+  const hostApi = entry.context.feature.hostApi;
+  if (!automationTarget || !hostApi.updateAutomationTarget) {
+    entry.lastAutomationTargetSync = null;
+    return;
+  }
+  const previous = entry.lastAutomationTargetSync;
+  if (
+    previous?.hostApi === hostApi &&
+    areBrowserNodeAutomationTargetsEqual(previous.payload, automationTarget)
+  ) {
+    return;
+  }
+
+  const snapshot: BrowserNodeHostEffectSnapshot<BrowserNodeAutomationTargetMetadata> =
+    {
+      hostApi,
+      payload: { ...automationTarget }
+    };
+  entry.lastAutomationTargetSync = snapshot;
+  void hostApi
+    .updateAutomationTarget({
+      automationTarget: snapshot.payload,
+      nodeId: entry.context.nodeId
+    })
+    .catch(() => {
+      if (entry.lastAutomationTargetSync === snapshot) {
+        entry.lastAutomationTargetSync = null;
+      }
+    });
+}
+
+function prepareBrowserNodeSession(
+  entry: BrowserNodeWebviewControllerEntry
+): void {
+  const hostApi = entry.context.feature.hostApi;
+  const payload: BrowserNodePrepareSessionInput = {
+    automationTarget: cloneBrowserNodeAutomationTarget(
+      entry.context.automationTarget
+    ),
+    navigationPolicy: cloneBrowserNodeNavigationPolicy(
+      entry.context.navigationPolicy
+    ),
+    nodeId: entry.context.nodeId,
+    profileId: entry.context.profileId,
+    sessionMode: entry.context.sessionMode,
+    sessionPartition: entry.context.sessionPartition,
+    url: entry.context.initialUrl
+  };
+  const previous = entry.lastSessionPreparation;
+  if (
+    previous?.hostApi === hostApi &&
+    areBrowserNodeSessionPreparationsEqual(previous.payload, payload)
+  ) {
+    return;
+  }
+
+  const snapshot: BrowserNodeHostEffectSnapshot<BrowserNodePrepareSessionInput> =
+    {
+      hostApi,
+      payload
+    };
+  entry.lastSessionPreparation = snapshot;
+  void hostApi.prepareSession(payload).catch(() => {
+    if (entry.lastSessionPreparation === snapshot) {
+      entry.lastSessionPreparation = null;
+    }
+  });
+}
+
+function cloneBrowserNodeAutomationTarget(
+  value: BrowserNodeAutomationTargetMetadata | null | undefined
+): BrowserNodeAutomationTargetMetadata | null | undefined {
+  return value ? { ...value } : value;
+}
+
+function cloneBrowserNodeNavigationPolicy(
+  value: BrowserNodeNavigationPolicy | null | undefined
+): BrowserNodeNavigationPolicy | null | undefined {
+  return value ? { ...value } : value;
+}
+
+function areBrowserNodeSessionPreparationsEqual(
+  left: BrowserNodePrepareSessionInput,
+  right: BrowserNodePrepareSessionInput
+): boolean {
+  return (
+    left.nodeId === right.nodeId &&
+    left.profileId === right.profileId &&
+    left.sessionMode === right.sessionMode &&
+    left.sessionPartition === right.sessionPartition &&
+    left.url === right.url &&
+    areBrowserNodeNavigationPoliciesEqual(
+      left.navigationPolicy,
+      right.navigationPolicy
+    ) &&
+    areBrowserNodeAutomationTargetsEqual(
+      left.automationTarget,
+      right.automationTarget
+    )
+  );
+}
+
+function areBrowserNodeNavigationPoliciesEqual(
+  left: BrowserNodeNavigationPolicy | null | undefined,
+  right: BrowserNodeNavigationPolicy | null | undefined
+): boolean {
+  if (left === right) {
+    return true;
+  }
+  return (
+    left !== null &&
+    left !== undefined &&
+    right !== null &&
+    right !== undefined &&
+    left.mode === right.mode &&
+    left.originUrl === right.originUrl
+  );
+}
+
+function areBrowserNodeAutomationTargetsEqual(
+  left: BrowserNodeAutomationTargetMetadata | null | undefined,
+  right: BrowserNodeAutomationTargetMetadata | null | undefined
+): boolean {
+  if (left === right) {
+    return true;
+  }
+  return (
+    left !== null &&
+    left !== undefined &&
+    right !== null &&
+    right !== undefined &&
+    left.agentSessionId === right.agentSessionId &&
+    left.focused === right.focused &&
+    left.selected === right.selected &&
+    left.surfaceId === right.surfaceId &&
+    left.surfaceRole === right.surfaceRole &&
+    left.tabId === right.tabId &&
+    left.workspaceId === right.workspaceId
+  );
 }
 
 function setBrowserNodeDevToolsContextMenu(


### PR DESCRIPTION
## Summary

- coalesce equivalent BrowserNode session preparation and automation-target synchronization
- preserve synchronization for real metadata changes and cold-to-active recovery
- reset failed snapshots so a later controller sync can retry

## Verification

- `pnpm check:changed`
- `pnpm check:changed -- --push-ready`

## Fallback Three Questions

- Source: renderer contexts can recreate value-equivalent automation metadata, while controller synchronization previously invoked both host effects unconditionally.
- Why can it not be fixed at that source? This change is the shared BrowserNode source fix; caller-only memoization would leave other consumers exposed to the same churn.
- Removal condition: remove the snapshots only if the controller contract guarantees and tests that `sync()` is called exclusively for semantic context changes.

## Checklist

- [x] This PR does not change Agent lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] Documentation is unchanged because the public API and product behavior are unchanged.
- [x] README/CONTRIBUTING language updates are not applicable.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] The commit is signed off with DCO.
