### PR TITLE
fix(browser-node): reuse matching workspace tabs

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserService.test.ts
@@ -170,6 +170,119 @@ test("workspace browser service opens Browser popups in tabs and launches app UR
   ]);
 });
 
+test("workspace browser service reuses matching pages and creates tabs for new URLs", () => {
+  const service = createWorkspaceBrowserService({
+    browserApi: createBrowserNodeHostApi()
+  });
+  const feature = createBrowserNodeFeature({
+    hostApi: service.createFeatureHostApi({
+      acceptsEvent: (event) => browserNodeOwnsEvent(event),
+      source: "browser",
+      workspaceId: "workspace-page-reuse"
+    })
+  });
+  const olderSurfaceId = "browser:older";
+  const recentSurfaceId = "browser:recent";
+  const pageA = feature.tabsStore.ensureSurface(
+    olderSurfaceId,
+    "https://example.com/a"
+  ).tabs[0]!;
+  const pageB = feature.tabsStore.addTab(
+    olderSurfaceId,
+    "https://example.com/b"
+  );
+  feature.tabsStore.ensureSurface(
+    recentSurfaceId,
+    "https://example.com/current"
+  );
+  service.ensureFeatureConnected(feature);
+
+  assert.deepEqual(
+    service.openPage({
+      surfaceNodeIds: [recentSurfaceId, olderSurfaceId],
+      url: "https://example.com/a",
+      workspaceId: "workspace-page-reuse"
+    }),
+    {
+      pageNodeId: pageA.nodeId,
+      surfaceNodeId: olderSurfaceId
+    }
+  );
+  assert.equal(
+    feature.tabsStore.getSurfaceState(olderSurfaceId)?.activeTabId,
+    pageA.id
+  );
+  assert.notEqual(pageA.id, pageB.id);
+
+  const opened = service.openPage({
+    surfaceNodeIds: [recentSurfaceId, olderSurfaceId],
+    url: "https://example.com/new",
+    workspaceId: "workspace-page-reuse"
+  });
+  assert.equal(opened?.surfaceNodeId, recentSurfaceId);
+  assert.equal(
+    feature.tabsStore
+      .getSurfaceState(recentSurfaceId)
+      ?.tabs.find((tab) => tab.nodeId === opened?.pageNodeId)?.defaultUrl,
+    "https://example.com/new"
+  );
+  assert.equal(
+    feature.tabsStore.getSurfaceState(olderSurfaceId)?.tabs.length,
+    2
+  );
+  assert.equal(
+    feature.tabsStore.getSurfaceState(recentSurfaceId)?.tabs.length,
+    2
+  );
+});
+
+test("workspace browser service reuses a redirected tab while another tab is selected", () => {
+  const service = createWorkspaceBrowserService({
+    browserApi: createBrowserNodeHostApi()
+  });
+  const feature = createBrowserNodeFeature({
+    hostApi: service.createFeatureHostApi({
+      acceptsEvent: (event) => browserNodeOwnsEvent(event),
+      source: "browser",
+      workspaceId: "workspace-redirected-page-reuse"
+    })
+  });
+  const surfaceNodeId = "browser:redirected-page-reuse";
+  feature.tabsStore.ensureSurface(surfaceNodeId, "https://example.com/");
+  const pageB = feature.tabsStore.addTab(
+    surfaceNodeId,
+    "https://www.openai.com/"
+  );
+  const pageC = feature.tabsStore.addTab(
+    surfaceNodeId,
+    "https://docs.python.org/3/"
+  );
+  feature.runtimeStore.applyEvent(
+    createBrowserStateEvent(pageB.nodeId, "https://openai.com/")
+  );
+  service.ensureFeatureConnected(feature);
+
+  const opened = service.openPage({
+    surfaceNodeIds: [surfaceNodeId],
+    url: "https://www.openai.com/",
+    workspaceId: "workspace-redirected-page-reuse"
+  });
+
+  assert.deepEqual(opened, {
+    pageNodeId: pageB.nodeId,
+    surfaceNodeId
+  });
+  assert.equal(
+    feature.tabsStore.getSurfaceState(surfaceNodeId)?.activeTabId,
+    pageB.id
+  );
+  assert.notEqual(pageB.id, pageC.id);
+  assert.equal(
+    feature.tabsStore.getSurfaceState(surfaceNodeId)?.tabs.length,
+    3
+  );
+});
+
 test("workspace browser service replaces stale feature routes before handling popups", () => {
   let emitDesktopBrowserEvent = (_event: BrowserNodeEvent): void => undefined;
   const service = createWorkspaceBrowserService({
@@ -505,6 +618,23 @@ function workspaceAppOwnsEvent(event: BrowserNodeEvent): boolean {
     nodeId.startsWith("workspace-app-webview:") ||
     nodeId.startsWith("workspace-app:")
   );
+}
+
+function createBrowserStateEvent(
+  nodeId: string,
+  url: string
+): BrowserNodeEvent {
+  return {
+    canGoBack: false,
+    canGoForward: false,
+    isLoading: false,
+    isOccluded: false,
+    lifecycle: "active",
+    nodeId,
+    title: null,
+    type: "state",
+    url
+  };
 }
 
 function createBrowserNodeHostApi(

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserService.ts
@@ -4,8 +4,15 @@ import type {
   BrowserNodeHostApi,
   BrowserNodeOpenUrlEvent
 } from "@tutti-os/browser-node";
-import { closeBrowserNodeTab } from "@tutti-os/browser-node";
+import {
+  activateBrowserNodePageByUrl,
+  closeBrowserNodeTab
+} from "@tutti-os/browser-node";
 import type { DesktopBrowserApi } from "@preload/types";
+import type {
+  WorkspaceBrowserPageOpenInput,
+  WorkspaceBrowserPageOpenResult
+} from "../workspaceWorkbenchHostService.interface.ts";
 import {
   requestWorkspaceBrowserLaunch,
   requestWorkspaceBrowserSurfaceFocus
@@ -26,6 +33,9 @@ export interface WorkspaceBrowserService {
   ): BrowserNodeHostApi;
   disposeWorkspace(workspaceId: string): void;
   ensureFeatureConnected(feature: BrowserNodeFeature): void;
+  openPage(
+    input: WorkspaceBrowserPageOpenInput
+  ): WorkspaceBrowserPageOpenResult | null;
   setUserAutomationSurface(input: {
     feature: BrowserNodeFeature;
     workspaceId: string;
@@ -214,6 +224,36 @@ export function createWorkspaceBrowserService(
       route.feature = feature;
       route.releaseFeature = releaseFeature;
       replaceActiveRoute(route);
+    },
+    openPage({ surfaceNodeIds, url, workspaceId }) {
+      const feature = activeRoutesByWorkspace
+        .get(workspaceId)
+        ?.get("browser")?.feature;
+      const normalizedUrl = url.trim();
+      if (!feature || !normalizedUrl) {
+        return null;
+      }
+
+      const eligibleSurfaceNodeIds = Array.from(
+        new Set(surfaceNodeIds.map((nodeId) => nodeId.trim()).filter(Boolean))
+      ).filter((nodeId) => feature.tabsStore.getSurfaceState(nodeId));
+      for (const surfaceNodeId of eligibleSurfaceNodeIds) {
+        const page = activateBrowserNodePageByUrl(
+          feature,
+          surfaceNodeId,
+          normalizedUrl
+        );
+        if (page) {
+          return { pageNodeId: page.nodeId, surfaceNodeId };
+        }
+      }
+
+      const surfaceNodeId = eligibleSurfaceNodeIds[0];
+      if (!surfaceNodeId) {
+        return null;
+      }
+      const page = feature.tabsStore.addTab(surfaceNodeId, normalizedUrl);
+      return { pageNodeId: page.nodeId, surfaceNodeId };
     },
     setUserAutomationSurface({ feature, workspaceId }) {
       disconnectUserAutomation?.();

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
@@ -4,6 +4,8 @@ import type {
 } from "@tutti-os/workbench-surface";
 import type {
   IWorkspaceWorkbenchHostService,
+  WorkspaceBrowserPageOpenInput,
+  WorkspaceBrowserPageOpenResult,
   WorkspaceOnboardingAutoOpenDiagnostic,
   WorkspaceCustomWallpaperSnapshot,
   WorkspaceCustomWallpaperStatus,
@@ -341,6 +343,12 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
 
   openExternal(url: string): Promise<void> {
     return this.dependencies.hostFilesApi.openExternal(url);
+  }
+
+  openBrowserPage(
+    input: WorkspaceBrowserPageOpenInput
+  ): WorkspaceBrowserPageOpenResult | null {
+    return this.dependencies.browserService.openPage(input);
   }
 
   async queryWorkspaceAppExternalAt(input: {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workbenchWorkspaceBrowserPresenter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workbenchWorkspaceBrowserPresenter.test.ts
@@ -6,6 +6,7 @@ import { createWorkbenchWorkspaceBrowserPresenter } from "./workbenchWorkspaceBr
 test("workbench Browser presenter focuses the exact requested surface", async () => {
   const focused: string[] = [];
   const presenter = createWorkbenchWorkspaceBrowserPresenter({
+    browserPages: createBrowserPages(),
     host: createHost({
       focused,
       nodes: [
@@ -31,7 +32,13 @@ test("workbench Browser presenter launches and activates a new page", async () =
   const activations: unknown[] = [];
   const launches: unknown[] = [];
   const presenter = createWorkbenchWorkspaceBrowserPresenter({
-    host: createHost({ activations, launches, nodes: [], nodeStack: [] })
+    browserPages: createBrowserPages(),
+    host: createHost({
+      activations,
+      launches,
+      nodes: [{ data: { typeId: "browser" }, id: "browser:existing" }],
+      nodeStack: ["browser:existing"]
+    })
   });
 
   assert.equal(
@@ -61,6 +68,134 @@ test("workbench Browser presenter launches and activates a new page", async () =
     ]
   ]);
 });
+
+test("workbench Browser presenter activates an existing page by URL", async () => {
+  const activations: unknown[] = [];
+  const focused: string[] = [];
+  const openRequests: unknown[] = [];
+  const presenter = createWorkbenchWorkspaceBrowserPresenter({
+    browserPages: createBrowserPages({
+      openPage(request) {
+        openRequests.push(request);
+        return {
+          pageNodeId: "browser:older:tab:1",
+          surfaceNodeId: "browser:older"
+        };
+      }
+    }),
+    host: createHost({
+      activations,
+      focused,
+      nodes: [
+        { data: { typeId: "browser" }, id: "browser:older" },
+        { data: { typeId: "browser" }, id: "browser:recent" }
+      ],
+      nodeStack: ["browser:older", "browser:recent"]
+    })
+  });
+
+  assert.equal(
+    await presenter({
+      kind: "open",
+      url: "https://example.com/a",
+      workspaceId: "workspace-1"
+    }),
+    "browser:older"
+  );
+  assert.deepEqual(openRequests, [
+    {
+      surfaceNodeIds: ["browser:recent", "browser:older"],
+      url: "https://example.com/a",
+      workspaceId: "workspace-1"
+    }
+  ]);
+  assert.deepEqual(focused, ["browser:older"]);
+  assert.deepEqual(activations, []);
+});
+
+test("workbench Browser presenter launches a new surface when existing tab state is unavailable", async () => {
+  const activations: unknown[] = [];
+  const launches: unknown[] = [];
+  const presenter = createWorkbenchWorkspaceBrowserPresenter({
+    browserPages: createBrowserPages(),
+    host: createHost({
+      activations,
+      launches,
+      nodes: [{ data: { typeId: "browser" }, id: "browser:unavailable" }],
+      nodeStack: ["browser:unavailable"]
+    })
+  });
+
+  assert.equal(
+    await presenter({
+      kind: "open",
+      url: "https://example.com/b",
+      workspaceId: "workspace-1"
+    }),
+    "browser:launched"
+  );
+  assert.deepEqual(launches, [
+    {
+      launchSource: undefined,
+      reason: "host",
+      typeId: "browser"
+    }
+  ]);
+  assert.deepEqual(activations, [
+    [
+      { nodeId: "browser:launched" },
+      {
+        payload: { url: "https://example.com/b" },
+        type: "open-url"
+      }
+    ]
+  ]);
+});
+
+test("workbench Browser presenter opens a missing URL as a tab in the current surface", async () => {
+  const activations: unknown[] = [];
+  const focused: string[] = [];
+  const presenter = createWorkbenchWorkspaceBrowserPresenter({
+    browserPages: createBrowserPages({
+      openPage() {
+        return {
+          pageNodeId: "browser:recent:tab:2",
+          surfaceNodeId: "browser:recent"
+        };
+      }
+    }),
+    host: createHost({
+      activations,
+      focused,
+      nodes: [{ data: { typeId: "browser" }, id: "browser:recent" }],
+      nodeStack: ["browser:recent"]
+    })
+  });
+
+  assert.equal(
+    await presenter({
+      kind: "open",
+      url: "https://example.com/b",
+      workspaceId: "workspace-1"
+    }),
+    "browser:recent"
+  );
+  assert.deepEqual(focused, ["browser:recent"]);
+  assert.deepEqual(activations, []);
+});
+
+function createBrowserPages(
+  overrides: {
+    openPage?: (request: unknown) => {
+      pageNodeId: string;
+      surfaceNodeId: string;
+    } | null;
+  } = {}
+) {
+  return {
+    openPage: overrides.openPage ?? (() => null)
+  };
+}
 
 function createHost(input: {
   activations?: unknown[];

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workbenchWorkspaceBrowserPresenter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workbenchWorkspaceBrowserPresenter.ts
@@ -3,26 +3,61 @@ import {
   type WorkspaceBrowserLaunchHandler,
   type WorkspaceBrowserLaunchRequest
 } from "./workspaceBrowserLaunchCoordinator.ts";
+import type {
+  WorkspaceBrowserPageOpenInput,
+  WorkspaceBrowserPageOpenResult
+} from "./workspaceWorkbenchHostService.interface.ts";
 import { workspaceBrowserNodeID } from "./workspaceWorkbenchNodeIds.ts";
 
 export function createWorkbenchWorkspaceBrowserPresenter(input: {
+  browserPages: {
+    openPage(
+      request: WorkspaceBrowserPageOpenInput
+    ): WorkspaceBrowserPageOpenResult | null;
+  };
   host: WorkbenchHostHandle;
 }): WorkspaceBrowserLaunchHandler {
-  return (request) => presentWorkspaceBrowser(input.host, request);
+  return (request) => presentWorkspaceBrowser(input, request);
 }
 
 async function presentWorkspaceBrowser(
-  host: WorkbenchHostHandle,
+  input: {
+    browserPages: {
+      openPage(
+        request: WorkspaceBrowserPageOpenInput
+      ): WorkspaceBrowserPageOpenResult | null;
+    };
+    host: WorkbenchHostHandle;
+  },
   request: WorkspaceBrowserLaunchRequest
 ): Promise<string | null> {
+  const { host } = input;
+  const browserNodeIds = resolveWorkspaceBrowserNodeIds(host);
   const preferredNodeId =
     request.kind === "focus"
       ? resolveWorkspaceBrowserNodeId(host, request.preferredNodeId)
       : null;
   const existingNodeId =
-    request.kind === "open" && request.reuseIfOpen === false
-      ? null
-      : (preferredNodeId ?? resolveCurrentWorkspaceBrowserNodeId(host));
+    request.kind === "focus"
+      ? (preferredNodeId ?? browserNodeIds[0] ?? null)
+      : null;
+
+  if (
+    request.kind === "open" &&
+    request.reuseIfOpen !== false &&
+    browserNodeIds.length > 0
+  ) {
+    const openedPage = input.browserPages.openPage({
+      surfaceNodeIds: browserNodeIds,
+      url: request.url,
+      workspaceId: request.workspaceId
+    });
+    if (openedPage) {
+      host.focusNode(openedPage.surfaceNodeId);
+      return openedPage.surfaceNodeId;
+    }
+  }
+
   const nodeId =
     existingNodeId ??
     (await host.launchNode({
@@ -65,20 +100,24 @@ function resolveWorkspaceBrowserNodeId(
   return node?.data.typeId === workspaceBrowserNodeID ? node.id : null;
 }
 
-function resolveCurrentWorkspaceBrowserNodeId(
-  host: WorkbenchHostHandle
-): string | null {
+function resolveWorkspaceBrowserNodeIds(host: WorkbenchHostHandle): string[] {
   const snapshot = host.getSnapshot();
   const nodesById = new Map(snapshot.nodes.map((node) => [node.id, node]));
+  const browserNodeIds: string[] = [];
   for (const nodeId of [...snapshot.nodeStack].reverse()) {
     const node = nodesById.get(nodeId);
     if (node?.data.typeId === workspaceBrowserNodeID) {
-      return node.id;
+      browserNodeIds.push(node.id);
     }
   }
 
-  return (
-    snapshot.nodes.find((node) => node.data.typeId === workspaceBrowserNodeID)
-      ?.id ?? null
-  );
+  for (const node of snapshot.nodes) {
+    if (
+      node.data.typeId === workspaceBrowserNodeID &&
+      !browserNodeIds.includes(node.id)
+    ) {
+      browserNodeIds.push(node.id);
+    }
+  }
+  return browserNodeIds;
 }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchHostService.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchHostService.interface.ts
@@ -100,6 +100,17 @@ export type WorkspaceWorkbenchCapabilitySettingsTarget =
       action?: "open";
     };
 
+export interface WorkspaceBrowserPageOpenInput {
+  surfaceNodeIds: readonly string[];
+  url: string;
+  workspaceId: string;
+}
+
+export interface WorkspaceBrowserPageOpenResult {
+  pageNodeId: string;
+  surfaceNodeId: string;
+}
+
 export interface WorkspaceWorkbenchHostInput {
   readonly captureNodePreviewImages?: WorkbenchHostProps["captureNodePreviewImages"];
   readonly contributions?: readonly WorkbenchContribution[];
@@ -210,6 +221,9 @@ export interface IWorkspaceWorkbenchHostService {
     diagnostic: WorkspaceOnboardingAutoOpenDiagnostic
   ): void;
   markWorkspaceOnboardingAutoOpened(workspaceId: string): Promise<void>;
+  openBrowserPage(
+    input: WorkspaceBrowserPageOpenInput
+  ): WorkspaceBrowserPageOpenResult | null;
   readWallpaperDisplayMode(workspaceId: string): WorkspaceWallpaperDisplayMode;
   readWallpaperId(workspaceId: string): WorkspaceWallpaperId;
   resolveWindowCloseRequest(input: {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
@@ -582,7 +582,13 @@ function ReadyWorkspaceWorkbenchWithSession({
       unregisterBrowserLaunchRef.current =
         registerWorkspaceBrowserLaunchHandler(
           state.workspace.id,
-          createWorkbenchWorkspaceBrowserPresenter({ host })
+          createWorkbenchWorkspaceBrowserPresenter({
+            browserPages: {
+              openPage: (request) =>
+                runtime.workbenchHostService.openBrowserPage(request)
+            },
+            host
+          })
         );
       unregisterWorkbenchNodeLaunchRef.current =
         registerWorkspaceWorkbenchNodeLaunchHandler(

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2229,6 +2229,9 @@ otherwise recover interactively.
 
 `AgentToolBrowserPanel` owns its BrowserNode feature, surface identity, and
 tab state. It also owns the single browser chrome instance for that surface.
+Its controller may activate an existing page by URL inside that one surface;
+the product Host remains responsible for choosing among Browser surfaces and
+focusing the owning top-level node or window.
 Hosts compose window controls into the tab strip through `defaultActions`,
 pass draggable-header semantics through `dragHandleProps`, and use
 `navigationActions` for address-row actions. A host must not wrap the panel in

--- a/docs/architecture/browser-node-package.md
+++ b/docs/architecture/browser-node-package.md
@@ -106,6 +106,14 @@ releases every Browser route for that workspace. A weak lookup does not replace
 this lifecycle: a route that still strongly owns its lookup key would also keep
 the obsolete feature and tab store alive.
 
+Host-level URL launches reuse Browser pages, not the active page's navigation
+slot. Tutti searches eligible Browser surfaces in recent-use order and selects
+an existing tab when its live URL matches, then uses its requested URL as an
+alias when the page redirected. If no page matches, it creates a tab in the most
+recent initialized Browser surface. If that surface's tab state is not
+available, it launches a new Browser surface instead of replacing the active
+page. Explicit non-reuse requests continue to launch a new surface.
+
 ## Package Entry Points
 
 The package uses multiple exports from one package rather than several small

--- a/packages/agent/gui/workbench/tool-sidebar/AgentToolBrowserPanel.render.test.tsx
+++ b/packages/agent/gui/workbench/tool-sidebar/AgentToolBrowserPanel.render.test.tsx
@@ -13,6 +13,7 @@ const browserNodeMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@tutti-os/browser-node/react", () => ({
+  BrowserNode: () => <div data-browser-node-body="true" />,
   BrowserNodeWorkbenchHeader: (props: BrowserNodeWorkbenchHeaderProps) => {
     browserNodeMocks.headerProps = props;
     return (
@@ -43,6 +44,7 @@ describe("AgentToolBrowserPanel header composition", () => {
       />
     );
 
+    await vi.dynamicImportSettled();
     expect(
       await screen.findByLabelText("Browser drag handle")
     ).toBeInTheDocument();
@@ -69,6 +71,7 @@ describe("AgentToolBrowserPanel header composition", () => {
       />
     );
 
+    await vi.dynamicImportSettled();
     await screen.findByLabelText("Browser drag handle");
     expect(controller).not.toBeNull();
     const secondPageNodeId = controller!.createPage("https://second.test");

--- a/packages/agent/gui/workbench/tool-sidebar/AgentToolBrowserPanel.render.test.tsx
+++ b/packages/agent/gui/workbench/tool-sidebar/AgentToolBrowserPanel.render.test.tsx
@@ -3,7 +3,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { BrowserNodeHostApi } from "@tutti-os/browser-node";
 import type { BrowserNodeWorkbenchHeaderProps } from "@tutti-os/browser-node/react";
 import type { I18nRuntime } from "@tutti-os/ui-i18n-runtime";
-import { AgentToolBrowserPanel } from "./AgentToolBrowserPanel.tsx";
+import {
+  AgentToolBrowserPanel,
+  type AgentToolBrowserController
+} from "./AgentToolBrowserPanel.tsx";
 
 const browserNodeMocks = vi.hoisted(() => ({
   headerProps: null as BrowserNodeWorkbenchHeaderProps | null
@@ -49,6 +52,35 @@ describe("AgentToolBrowserPanel header composition", () => {
     expect(
       document.querySelectorAll('[data-browser-node-header="true"]')
     ).toHaveLength(1);
+  });
+
+  it("activates an existing page by URL through the host controller", async () => {
+    let controller: AgentToolBrowserController | null = null;
+    render(
+      <AgentToolBrowserPanel
+        browserApi={createBrowserApi()}
+        defaultUrl="https://first.test"
+        dragHandleProps={{ "aria-label": "Browser drag handle" }}
+        hidden={false}
+        i18n={{ t: (key) => key } as I18nRuntime<string>}
+        onControllerReady={(value) => {
+          controller = value;
+        }}
+      />
+    );
+
+    await screen.findByLabelText("Browser drag handle");
+    expect(controller).not.toBeNull();
+    const secondPageNodeId = controller!.createPage("https://second.test");
+    expect(controller!.selectPage(secondPageNodeId)).toBe(true);
+
+    const firstPageNodeId = controller!.activatePageByUrl(
+      "https://first.test/"
+    );
+
+    expect(firstPageNodeId).not.toBeNull();
+    expect(firstPageNodeId).not.toBe(secondPageNodeId);
+    expect(controller!.ownsPage(firstPageNodeId!)).toBe(true);
   });
 });
 

--- a/packages/agent/gui/workbench/tool-sidebar/AgentToolBrowserPanel.tsx
+++ b/packages/agent/gui/workbench/tool-sidebar/AgentToolBrowserPanel.tsx
@@ -8,6 +8,7 @@ import {
   type ReactNode
 } from "react";
 import {
+  activateBrowserNodePageByUrl,
   closeBrowserNodeTab,
   createBrowserNodeFeature,
   isBrowserNodeSurfaceEvent,
@@ -58,6 +59,7 @@ export interface AgentToolBrowserPanelProps {
 }
 
 export interface AgentToolBrowserController {
+  activatePageByUrl(url: string): string | null;
   closePage(nodeId: string): "closed" | "last-page" | "not-found";
   createPage(url?: string | null): string;
   ownsPage(nodeId: string): boolean;
@@ -103,6 +105,11 @@ export function AgentToolBrowserPanel({
       return state && tab ? { state, tab } : null;
     };
     return {
+      activatePageByUrl(url) {
+        return (
+          activateBrowserNodePageByUrl(feature, nodeId, url)?.nodeId ?? null
+        );
+      },
       closePage(pageNodeId) {
         const page = getPage(pageNodeId);
         if (!page) return "not-found";

--- a/packages/browser/workbench-node/README.md
+++ b/packages/browser/workbench-node/README.md
@@ -104,9 +104,10 @@ forking the Browser surface.
 
 Hosts that coordinate multiple Browser surfaces can use
 `findBrowserNodePageByUrl(...)` and `activateBrowserNodePageByUrl(...)`. These
-helpers compare the live runtime URL when available and otherwise use a newly
-created tab's pending URL. Surface eligibility, top-level window focus, and
-whether a missing page opens in an existing or new Browser remain host policy.
+helpers prefer a live runtime URL match, then retain the tab's requested URL as
+an alias for redirects and newly created pages without runtime state. Surface
+eligibility, top-level window focus, and whether a missing page opens in an
+existing or new Browser remain host policy.
 
 Electron hosts may attach `automationTarget` metadata to User Browser and
 Agent Browser surfaces. The package registry then exposes the current

--- a/packages/browser/workbench-node/README.md
+++ b/packages/browser/workbench-node/README.md
@@ -102,6 +102,12 @@ function receives the tab node id and a `navigate(url)` callback, allowing a
 host to render live sandbox ports or other product-owned shortcuts without
 forking the Browser surface.
 
+Hosts that coordinate multiple Browser surfaces can use
+`findBrowserNodePageByUrl(...)` and `activateBrowserNodePageByUrl(...)`. These
+helpers compare the live runtime URL when available and otherwise use a newly
+created tab's pending URL. Surface eligibility, top-level window focus, and
+whether a missing page opens in an existing or new Browser remain host policy.
+
 Electron hosts may attach `automationTarget` metadata to User Browser and
 Agent Browser surfaces. The package registry then exposes the current
 workspace's User tabs and only the calling Agent session's Agent tabs, with

--- a/packages/browser/workbench-node/src/core/index.ts
+++ b/packages/browser/workbench-node/src/core/index.ts
@@ -18,6 +18,10 @@ export {
   type BrowserNodeTabsStore
 } from "./tabsStore.ts";
 export {
+  activateBrowserNodePageByUrl,
+  findBrowserNodePageByUrl
+} from "./pageActivation.ts";
+export {
   closeBrowserNodeTab,
   closeBrowserNodeTabSurface,
   retainBrowserNodeTabSurface

--- a/packages/browser/workbench-node/src/core/pageActivation.test.ts
+++ b/packages/browser/workbench-node/src/core/pageActivation.test.ts
@@ -9,7 +9,7 @@ import type { BrowserNodeHostApi } from "./types.ts";
 
 const surfaceNodeId = "browser-surface";
 
-test("finds a page by its live runtime URL instead of its launch URL", () => {
+test("prefers a live URL match while retaining redirected launch URLs as aliases", () => {
   const feature = createFeature();
   const first = feature.tabsStore.ensureSurface(
     surfaceNodeId,
@@ -18,7 +18,7 @@ test("finds a page by its live runtime URL instead of its launch URL", () => {
   assert.ok(first);
   const second = feature.tabsStore.addTab(
     surfaceNodeId,
-    "https://second.test/launch"
+    "https://first.test/current?view=live"
   );
 
   feature.runtimeStore.applyEvent(
@@ -41,8 +41,8 @@ test("finds a page by its live runtime URL instead of its launch URL", () => {
       feature,
       surfaceNodeId,
       "https://first.test/launch"
-    ),
-    null
+    )?.nodeId,
+    first.nodeId
   );
 });
 

--- a/packages/browser/workbench-node/src/core/pageActivation.test.ts
+++ b/packages/browser/workbench-node/src/core/pageActivation.test.ts
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createBrowserNodeFeature } from "./feature.ts";
+import {
+  activateBrowserNodePageByUrl,
+  findBrowserNodePageByUrl
+} from "./pageActivation.ts";
+import type { BrowserNodeHostApi } from "./types.ts";
+
+const surfaceNodeId = "browser-surface";
+
+test("finds a page by its live runtime URL instead of its launch URL", () => {
+  const feature = createFeature();
+  const first = feature.tabsStore.ensureSurface(
+    surfaceNodeId,
+    "https://first.test/launch"
+  ).tabs[0];
+  assert.ok(first);
+  const second = feature.tabsStore.addTab(
+    surfaceNodeId,
+    "https://second.test/launch"
+  );
+
+  feature.runtimeStore.applyEvent(
+    createStateEvent(first.nodeId, "https://first.test/current?view=live")
+  );
+  feature.runtimeStore.applyEvent(
+    createStateEvent(second.nodeId, "https://second.test/current")
+  );
+
+  assert.equal(
+    findBrowserNodePageByUrl(
+      feature,
+      surfaceNodeId,
+      "https://first.test/current?view=live"
+    )?.nodeId,
+    first.nodeId
+  );
+  assert.equal(
+    findBrowserNodePageByUrl(
+      feature,
+      surfaceNodeId,
+      "https://first.test/launch"
+    ),
+    null
+  );
+});
+
+test("finds a newly created page by its desired URL before runtime state arrives", () => {
+  const feature = createFeature();
+  feature.tabsStore.ensureSurface(surfaceNodeId, "about:blank");
+  const pending = feature.tabsStore.addTab(
+    surfaceNodeId,
+    "https://pending.test/path"
+  );
+
+  assert.equal(
+    findBrowserNodePageByUrl(
+      feature,
+      surfaceNodeId,
+      "https://pending.test/path"
+    )?.nodeId,
+    pending.nodeId
+  );
+});
+
+test("activates a matching page without creating another tab", () => {
+  const feature = createFeature();
+  const first = feature.tabsStore.ensureSurface(
+    surfaceNodeId,
+    "https://first.test"
+  ).tabs[0];
+  assert.ok(first);
+  const second = feature.tabsStore.addTab(surfaceNodeId, "https://second.test");
+  feature.tabsStore.selectTab(surfaceNodeId, second.id);
+
+  const activated = activateBrowserNodePageByUrl(
+    feature,
+    surfaceNodeId,
+    "https://first.test/"
+  );
+
+  assert.equal(activated?.nodeId, first.nodeId);
+  assert.equal(
+    feature.tabsStore.getSurfaceState(surfaceNodeId)?.activeTabId,
+    first.id
+  );
+  assert.equal(
+    feature.tabsStore.getSurfaceState(surfaceNodeId)?.tabs.length,
+    2
+  );
+});
+
+test("does not treat an empty home tab as a reusable URL page", () => {
+  const feature = createFeature();
+  feature.tabsStore.ensureSurface(surfaceNodeId, "about:blank");
+
+  assert.equal(
+    findBrowserNodePageByUrl(feature, surfaceNodeId, "about:blank"),
+    null
+  );
+});
+
+function createFeature() {
+  return createBrowserNodeFeature({ hostApi: createBrowserApi() });
+}
+
+function createBrowserApi(): BrowserNodeHostApi {
+  return {
+    activate: async () => undefined,
+    close: async () => undefined,
+    goBack: async () => undefined,
+    goForward: async () => undefined,
+    navigate: async () => undefined,
+    onEvent: () => () => undefined,
+    prepareSession: async () => undefined,
+    registerGuest: async () => undefined,
+    reload: async () => undefined,
+    unregisterGuest: async () => undefined
+  };
+}
+
+function createStateEvent(nodeId: string, url: string) {
+  return {
+    canGoBack: false,
+    canGoForward: false,
+    isLoading: false,
+    isOccluded: false,
+    lifecycle: "active" as const,
+    nodeId,
+    title: null,
+    type: "state" as const,
+    url
+  };
+}

--- a/packages/browser/workbench-node/src/core/pageActivation.ts
+++ b/packages/browser/workbench-node/src/core/pageActivation.ts
@@ -13,12 +13,20 @@ export function findBrowserNodePageByUrl(
   }
 
   const state = feature.tabsStore.getSurfaceState(surfaceNodeId);
+  if (!state) {
+    return null;
+  }
+
+  const livePage = state.tabs.find((tab) => {
+    const runtimeUrl = feature.runtimeStore.getNodeState(tab.nodeId).url;
+    return normalizeBrowserComparableUrl(runtimeUrl ?? "") === comparableUrl;
+  });
   return (
-    state?.tabs.find((tab) => {
-      const runtimeUrl = feature.runtimeStore.getNodeState(tab.nodeId).url;
-      const pageUrl = runtimeUrl?.trim() || tab.defaultUrl;
-      return normalizeBrowserComparableUrl(pageUrl) === comparableUrl;
-    }) ?? null
+    livePage ??
+    state.tabs.find(
+      (tab) => normalizeBrowserComparableUrl(tab.defaultUrl) === comparableUrl
+    ) ??
+    null
   );
 }
 

--- a/packages/browser/workbench-node/src/core/pageActivation.ts
+++ b/packages/browser/workbench-node/src/core/pageActivation.ts
@@ -1,0 +1,36 @@
+import type { BrowserNodeFeature } from "./feature.ts";
+import type { BrowserNodeTab } from "./tabsStore.ts";
+import { normalizeBrowserComparableUrl } from "./url.ts";
+
+export function findBrowserNodePageByUrl(
+  feature: BrowserNodeFeature,
+  surfaceNodeId: string,
+  url: string
+): BrowserNodeTab | null {
+  const comparableUrl = normalizeBrowserComparableUrl(url);
+  if (!comparableUrl) {
+    return null;
+  }
+
+  const state = feature.tabsStore.getSurfaceState(surfaceNodeId);
+  return (
+    state?.tabs.find((tab) => {
+      const runtimeUrl = feature.runtimeStore.getNodeState(tab.nodeId).url;
+      const pageUrl = runtimeUrl?.trim() || tab.defaultUrl;
+      return normalizeBrowserComparableUrl(pageUrl) === comparableUrl;
+    }) ?? null
+  );
+}
+
+export function activateBrowserNodePageByUrl(
+  feature: BrowserNodeFeature,
+  surfaceNodeId: string,
+  url: string
+): BrowserNodeTab | null {
+  const page = findBrowserNodePageByUrl(feature, surfaceNodeId, url);
+  if (!page) {
+    return null;
+  }
+  feature.tabsStore.selectTab(surfaceNodeId, page.id);
+  return page;
+}

--- a/packages/browser/workbench-node/src/index.ts
+++ b/packages/browser/workbench-node/src/index.ts
@@ -23,6 +23,10 @@ export {
   type BrowserNodeTabsStore
 } from "./core/tabsStore.ts";
 export {
+  activateBrowserNodePageByUrl,
+  findBrowserNodePageByUrl
+} from "./core/pageActivation.ts";
+export {
   closeBrowserNodeTab,
   closeBrowserNodeTabSurface,
   retainBrowserNodeTabSurface


### PR DESCRIPTION
## 变更内容

- 在 `@tutti-os/browser-node` 提供按 URL 查找和激活现有页面的公开能力
- Workspace 打开 URL 时，先跨现有 Browser surface 查找匹配 tab；命中后直接选中并聚焦所属 Browser
- 未命中时，在最近使用且已初始化的 Browser surface 新建 tab，不再覆盖当前 tab
- 实时 URL 优先匹配；页面发生 `www → non-www`、登录跳转等重定向时，再使用该 tab 的原始请求 URL 作为别名
- `reuseIfOpen: false` 保持新建 Browser surface；自动化 `new_page` 保持每次新建 tab
- 修复 Agent Tool Browser lazy-import 测试在并行门禁中的非确定性等待

## 原因

原来的 Workspace 复用只复用了 Browser surface，然后通过 `open-url` 更新当前 tab 的 URL。因此已有 A 时打开 B，会把 A 导航成 B。

第一次修复接入 URL 匹配后，真实日志又证明重定向场景仍会重复：请求 URL 是 `https://www.openai.com/`，实时 URL 是 `https://openai.com/`。因此匹配策略改为“实时 URL 优先、原始请求 URL 作为重定向别名”。

## 行为与风险

- 已存在相同页面：选中原 tab，不新增
- 不存在相同页面：在最近使用的 Browser 中新增 tab
- Browser tab state 暂不可用：新建 Browser surface，不回退为覆盖当前 tab
- 匹配仍使用 Browser Node 的 HTTP/HTTPS URL 规范化；`about:blank` 和无效 URL 不参与复用
- 查找只发生在显式打开 URL 操作中，线性扫描当前 tab；没有新增订阅、轮询或高频渲染路径
- Windows 无路径、进程、Shell、文件系统或平台适配影响

## 验证

- Browser Node URL 匹配测试：4 个通过
- Workspace Browser presenter/service 定向测试：14 个通过
- Agent Tool Browser React 测试：2 个通过
- 真实运行时：已有 Example/OpenAI/Python tabs 且 Python 选中时，再打开重定向前的 OpenAI URL，会选中原 OpenAI tab，不新增重复项
- `pnpm check:changed -- --push-ready`：17 个检查通道通过

## 文档

- 更新 Browser Node README：记录实时 URL 与重定向别名匹配顺序
- 更新 Browser Node 架构文档：记录 Workspace Host 的复用、新建与不可用 fallback 策略
