### PR TITLE
fix(agent): verify Codex OAuth remotely

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -371,16 +371,17 @@ Desktop management surfaces and AgentGUI consume that same status. They may
 keep a `configured` provider launchable when availability is `ready`, but must
 not relabel it as connected or authenticated.
 
-For Claude Code subscription OAuth, the descriptor-owned remote check is
-`GET https://api.anthropic.com/api/oauth/usage`. It is attempted on ordinary
-status detection and becomes stale after 15 minutes. Visible, focused Desktop
-windows reconcile stale providers on focus/visibility activation and on the
-15-minute poll. API-key configuration skips this OAuth endpoint. `401` and
-`403` are authoritative login failures; rate limits, server errors, and network
-failures leave the weaker `configured` state intact. This check validates an
-access token but does not rotate refresh tokens; refresh ownership requires a
-separate serialized credential lifecycle that can gate on live Claude
-processes.
+For subscription OAuth, provider descriptors select the remote-auth strategy.
+Claude Code uses `GET https://api.anthropic.com/api/oauth/usage`; Codex uses the
+provider runtime's `account/rateLimits/read`. These checks are attempted on
+ordinary status detection and become stale after 15 minutes. Visible, focused
+Desktop windows reconcile stale providers on focus/visibility activation and
+on the 15-minute poll. API-key configuration skips subscription OAuth checks.
+Explicit authentication rejection is authoritative; rate limits, server
+errors, and network failures leave the weaker `configured` state intact.
+These checks validate current access but do not rotate refresh tokens; refresh
+ownership requires a separate serialized credential lifecycle that can gate on
+live provider processes.
 
 ### 2.6 Developer cassette replay
 

--- a/packages/agent/daemon/README.md
+++ b/packages/agent/daemon/README.md
@@ -167,16 +167,18 @@ External hosts consume the same reducer only when their runtime cannot use the
 host must wait for credential projection before probing; the host maps that
 semantic barrier to its own synchronization mechanism.
 
-`StatusDescriptor.RemoteAuthProbe` owns the provider request shape without
+`StatusDescriptor.RemoteAuthProbe` owns the provider-backed strategy without
 owning credential storage. Claude Code declares its OAuth usage request to
 `https://api.anthropic.com/api/oauth/usage`; hosts resolve the OAuth access
 token from their own credential authority and never send an API key or
-`ANTHROPIC_AUTH_TOKEN` to that endpoint. A `2xx` response authenticates the
-session, `401`/`403` requires login, and throttling, server, or transport
-failures preserve the local `configured` state. `tuttid` expires this remote
-evidence after 15 minutes; Desktop asks again only while its window is visible
-and focused. OAuth refresh-token rotation remains credential-owner policy and
-is not performed by this status probe.
+`ANTHROPIC_AUTH_TOKEN` to that endpoint. Codex declares the provider-usage
+strategy, which invokes `account/rateLimits/read` through the provider runtime
+without publishing credential bytes. A successful request authenticates the
+session, an explicit authentication rejection requires login, and throttling,
+server, or transport failures preserve the local `configured` state. `tuttid`
+expires this remote evidence after 15 minutes; Desktop asks again only while
+its window is visible and focused. OAuth refresh-token rotation remains
+credential-owner policy and is not performed by this status probe.
 
 ## Live Session Recycling
 

--- a/packages/agent/daemon/providerregistry/codex.go
+++ b/packages/agent/daemon/providerregistry/codex.go
@@ -44,7 +44,11 @@ func codexDescriptor() ProviderDescriptor {
 			MinVersion:             CodexMinVersion,
 			BinaryNames:            []string{"codex"},
 			AuthStatusCommand:      []string{"-c", `service_tier="fast"`, "app-server"},
-			AuthMarkerPaths:        []string{"~/.codex/auth.json"},
+			RemoteAuthProbe: RemoteAuthProbeDescriptor{
+				Kind:           RemoteAuthProbeKindProviderUsage,
+				TimeoutSeconds: 30,
+			},
+			AuthMarkerPaths: []string{"~/.codex/auth.json"},
 			APIEndpoints: []string{
 				"https://chatgpt.com/backend-api/codex",
 				"https://api.openai.com/v1",

--- a/packages/agent/daemon/providerregistry/registry_test.go
+++ b/packages/agent/daemon/providerregistry/registry_test.go
@@ -203,6 +203,13 @@ func TestValidateRejectsUnsafeRemoteAuthProbeDeclarations(t *testing.T) {
 			}
 		})
 	}
+	t.Run("provider usage with HTTP settings", func(t *testing.T) {
+		descriptor := codexDescriptor()
+		descriptor.Status.RemoteAuthProbe.Endpoint = "https://chatgpt.com/backend-api/wham/usage"
+		if err := Validate(descriptor); err == nil {
+			t.Fatal("Validate() error = nil")
+		}
+	})
 }
 
 func TestMigratedCodexDescriptorIsComplete(t *testing.T) {
@@ -218,6 +225,9 @@ func TestMigratedCodexDescriptorIsComplete(t *testing.T) {
 	}
 	if descriptor.Runtime.Kind != RuntimeKindCodexAppServer {
 		t.Fatalf("Runtime.Kind = %q", descriptor.Runtime.Kind)
+	}
+	if descriptor.Status.RemoteAuthProbe.Kind != RemoteAuthProbeKindProviderUsage {
+		t.Fatalf("remote auth probe = %#v", descriptor.Status.RemoteAuthProbe)
 	}
 	if descriptor.Runtime.AppServerFork != (AppServerForkDescriptor{
 		UserAgentBrand:        "codex",

--- a/packages/agent/daemon/providerregistry/remote_auth.go
+++ b/packages/agent/daemon/providerregistry/remote_auth.go
@@ -16,6 +16,16 @@ func validateRemoteAuthProbe(descriptor RemoteAuthProbeDescriptor) error {
 		}
 		return nil
 	}
+	if descriptor.TimeoutSeconds <= 0 {
+		return fmt.Errorf("timeout seconds must be positive")
+	}
+	if descriptor.Kind == RemoteAuthProbeKindProviderUsage {
+		if descriptor.CredentialKind != "" || strings.TrimSpace(descriptor.Endpoint) != "" ||
+			strings.TrimSpace(descriptor.Method) != "" || len(descriptor.Headers) > 0 {
+			return fmt.Errorf("provider usage probe must not declare HTTP settings")
+		}
+		return nil
+	}
 	if descriptor.Kind != RemoteAuthProbeKindHTTPBearer {
 		return fmt.Errorf("kind %q is unsupported", descriptor.Kind)
 	}
@@ -30,9 +40,6 @@ func validateRemoteAuthProbe(descriptor RemoteAuthProbeDescriptor) error {
 	}
 	if method := strings.ToUpper(strings.TrimSpace(descriptor.Method)); method != http.MethodGet {
 		return fmt.Errorf("method %q is unsupported", descriptor.Method)
-	}
-	if descriptor.TimeoutSeconds <= 0 {
-		return fmt.Errorf("timeout seconds must be positive")
 	}
 	for key, value := range descriptor.Headers {
 		if strings.TrimSpace(key) == "" || strings.TrimSpace(value) == "" {

--- a/packages/agent/daemon/providerregistry/types.go
+++ b/packages/agent/daemon/providerregistry/types.go
@@ -161,7 +161,10 @@ const (
 // descriptor or a public status response.
 type RemoteAuthProbeKind string
 
-const RemoteAuthProbeKindHTTPBearer RemoteAuthProbeKind = "http_bearer"
+const (
+	RemoteAuthProbeKindHTTPBearer    RemoteAuthProbeKind = "http_bearer"
+	RemoteAuthProbeKindProviderUsage RemoteAuthProbeKind = "provider_usage"
+)
 
 // RemoteAuthCredentialKind identifies the provider credential grammar used by
 // a host or managed-runtime adapter before invoking RemoteAuthProbe.

--- a/packages/agent/daemon/providerstatus/codex_remote_auth.go
+++ b/packages/agent/daemon/providerstatus/codex_remote_auth.go
@@ -1,0 +1,31 @@
+package providerstatus
+
+import "strings"
+
+// CodexRemoteAuthEvidence converts the provider-backed result of
+// account/rateLimits/read into the shared authentication evidence vocabulary.
+// Only explicit authentication rejection invalidates the weaker local session.
+func CodexRemoteAuthEvidence(success bool, failure string) AuthEvidence {
+	if success {
+		return AuthEvidence{Kind: AuthEvidenceRemoteSuccess}
+	}
+	lower := strings.ToLower(strings.TrimSpace(failure))
+	switch {
+	case strings.Contains(lower, "session expired"),
+		strings.Contains(lower, "unauthorized"),
+		strings.Contains(lower, "401"),
+		strings.Contains(lower, "403"),
+		strings.Contains(lower, "access token expired"),
+		strings.Contains(lower, "refresh token"),
+		strings.Contains(lower, "token has been revoked"),
+		strings.Contains(lower, "token was revoked"),
+		strings.Contains(lower, "invalid bearer token"):
+		return AuthEvidence{Kind: AuthEvidenceRemoteAuthFailure, Reason: AuthReasonSessionExpired}
+	case strings.Contains(lower, "not logged in"),
+		strings.Contains(lower, "unauthenticated"),
+		strings.Contains(lower, "authentication required"):
+		return AuthEvidence{Kind: AuthEvidenceRemoteAuthFailure, Reason: AuthReasonAuthRequired}
+	default:
+		return AuthEvidence{Kind: AuthEvidenceProbeFailure, Reason: AuthReasonProbeFailed}
+	}
+}

--- a/packages/agent/daemon/providerstatus/codex_remote_auth_test.go
+++ b/packages/agent/daemon/providerstatus/codex_remote_auth_test.go
@@ -1,0 +1,26 @@
+package providerstatus
+
+import "testing"
+
+func TestCodexRemoteAuthEvidenceClassifiesProviderResult(t *testing.T) {
+	tests := []struct {
+		name       string
+		success    bool
+		failure    string
+		wantKind   AuthEvidenceKind
+		wantReason string
+	}{
+		{name: "accepted", success: true, wantKind: AuthEvidenceRemoteSuccess},
+		{name: "revoked", failure: "401 Unauthorized: refresh token was revoked", wantKind: AuthEvidenceRemoteAuthFailure, wantReason: AuthReasonSessionExpired},
+		{name: "signed out", failure: "authentication required", wantKind: AuthEvidenceRemoteAuthFailure, wantReason: AuthReasonAuthRequired},
+		{name: "transient", failure: "connection reset", wantKind: AuthEvidenceProbeFailure, wantReason: AuthReasonProbeFailed},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			evidence := CodexRemoteAuthEvidence(test.success, test.failure)
+			if evidence.Kind != test.wantKind || evidence.Reason != test.wantReason {
+				t.Fatalf("evidence = %#v", evidence)
+			}
+		})
+	}
+}

--- a/packages/agent/daemon/runtime/codex_appserver_probe.go
+++ b/packages/agent/daemon/runtime/codex_appserver_probe.go
@@ -19,6 +19,7 @@ type CodexAppServerProbeInput struct {
 	CWD              string
 	Host             HostMetadata
 	ReadAccount      bool
+	ReadRateLimits   bool
 	StartupTimeout   time.Duration
 	HandshakeTimeout time.Duration
 	ShutdownTimeout  time.Duration
@@ -40,15 +41,17 @@ const (
 // separate. Callers must use ProtocolReady, not CommandStarted, as runtime
 // capability evidence.
 type CodexAppServerProbeResult struct {
-	CommandStarted   bool
-	ProtocolReady    bool
-	AccountRead      bool
-	AccountState     CodexAppServerAccountState
-	AccountLabel     string
-	AuthMethod       string
-	CommandCategory  string
-	ProtocolCategory string
-	AccountCategory  string
+	CommandStarted     bool
+	ProtocolReady      bool
+	AccountRead        bool
+	AccountState       CodexAppServerAccountState
+	AccountLabel       string
+	AuthMethod         string
+	RateLimitsRead     bool
+	CommandCategory    string
+	ProtocolCategory   string
+	AccountCategory    string
+	RateLimitsCategory string
 	// Category is the compatibility projection of the failing stage.
 	Category   string
 	Message    string
@@ -68,8 +71,9 @@ const (
 )
 
 // ProbeCodexAppServer reuses the production ProcessTransport, JSON-RPC client,
-// typed initialize request and initialized notification. When ReadAccount is
-// set, it also calls the same account/read method used during session startup.
+// typed initialize request and initialized notification. ReadAccount calls the
+// same account/read method used during session startup. ReadRateLimits calls
+// account/rateLimits/read, which requires a provider-accepted OAuth session.
 // The connection is always closed before returning; no user-facing Codex state
 // is created.
 func ProbeCodexAppServer(ctx context.Context, input CodexAppServerProbeInput) (result CodexAppServerProbeResult) {
@@ -186,28 +190,40 @@ func ProbeCodexAppServer(ctx context.Context, input CodexAppServerProbeInput) (r
 	// final protocol fact.
 	result.CommandStarted = true
 	result.Category = ""
-	if !input.ReadAccount {
-		return result
+	if input.ReadAccount {
+		accountRaw, err := client.AccountRead(handshakeCtx, handshakeTimeout, map[string]any{},
+			func(context.Context, acpMessage) error { return nil })
+		if err != nil {
+			result.AccountCategory = codexProbeErrorCategory(handshakeCtx, err)
+			result.Category = result.AccountCategory
+			result.Message = err.Error()
+			return result
+		}
+		account, ok := parseCodexProbeAccount(accountRaw)
+		if !ok {
+			result.AccountCategory = CodexProbeInvalidResponse
+			result.Category = result.AccountCategory
+			result.Message = "account/read returned an invalid account response"
+			return result
+		}
+		result.AccountRead = true
+		result.AccountState = account.State
+		result.AccountLabel = account.Label
+		result.AuthMethod = account.AuthMethod
 	}
-	accountRaw, err := client.AccountRead(handshakeCtx, handshakeTimeout, map[string]any{},
-		func(context.Context, acpMessage) error { return nil })
-	if err != nil {
-		result.AccountCategory = codexProbeErrorCategory(handshakeCtx, err)
-		result.Category = result.AccountCategory
-		result.Message = err.Error()
-		return result
+	if input.ReadRateLimits {
+		if _, err := client.AccountRateLimitsRead(
+			handshakeCtx,
+			handshakeTimeout,
+			func(context.Context, acpMessage) error { return nil },
+		); err != nil {
+			result.RateLimitsCategory = codexProbeErrorCategory(handshakeCtx, err)
+			result.Category = result.RateLimitsCategory
+			result.Message = err.Error()
+			return result
+		}
+		result.RateLimitsRead = true
 	}
-	account, ok := parseCodexProbeAccount(accountRaw)
-	if !ok {
-		result.AccountCategory = CodexProbeInvalidResponse
-		result.Category = result.AccountCategory
-		result.Message = "account/read returned an invalid account response"
-		return result
-	}
-	result.AccountRead = true
-	result.AccountState = account.State
-	result.AccountLabel = account.Label
-	result.AuthMethod = account.AuthMethod
 	return result
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_probe_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_probe_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -103,6 +104,40 @@ func TestProbeCodexAppServerDoesNotAuthenticateAccountReadFailure(t *testing.T) 
 	}
 	if result.AccountCategory != CodexProbeProtocolFailure {
 		t.Fatalf("account category = %q, want %q", result.AccountCategory, CodexProbeProtocolFailure)
+	}
+	assertScriptedProbeConnectionClosed(t, transport.conn)
+}
+
+func TestProbeCodexAppServerReadsProviderRateLimits(t *testing.T) {
+	t.Parallel()
+	transport := newScriptedAppServerTransport()
+	result := ProbeCodexAppServer(context.Background(), CodexAppServerProbeInput{
+		Command: []string{"codex", "app-server"}, Transport: transport,
+		HandshakeTimeout: time.Second, ReadRateLimits: true,
+	})
+	if !result.ProtocolReady || !result.RateLimitsRead || result.Category != "" {
+		t.Fatalf("probe = %#v, want successful rate limits read", result)
+	}
+	if got := len(appServerRequestParamsList(t, transport.conn, appServerMethodRateLimitsRead)); got != 1 {
+		t.Fatalf("account/rateLimits/read calls = %d, want 1", got)
+	}
+	assertScriptedProbeConnectionClosed(t, transport.conn)
+}
+
+func TestProbeCodexAppServerReturnsRateLimitsAuthenticationFailure(t *testing.T) {
+	t.Parallel()
+	transport := newScriptedAppServerTransport()
+	transport.server.rateLimitsReadError = true
+	transport.server.rateLimitsReadErrorCode = -32001
+	transport.server.rateLimitsReadErrorMessage = "401 Unauthorized: refresh token was revoked"
+	result := ProbeCodexAppServer(context.Background(), CodexAppServerProbeInput{
+		Command: []string{"codex", "app-server"}, Transport: transport,
+		HandshakeTimeout: time.Second, ReadRateLimits: true,
+	})
+	if !result.ProtocolReady || result.RateLimitsRead ||
+		result.RateLimitsCategory != CodexProbeProtocolFailure ||
+		!strings.Contains(result.Message, "refresh token was revoked") {
+		t.Fatalf("probe = %#v, want rate limits authentication failure", result)
 	}
 	assertScriptedProbeConnectionClosed(t, transport.conn)
 }

--- a/packages/agent/daemon/runtime/codex_appserver_scripted_session_rpc_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_scripted_session_rpc_test.go
@@ -18,6 +18,9 @@ type scriptedSessionState struct {
 	accountReadError             bool
 	accountReadErrorCode         int
 	accountReadErrorMessage      string
+	rateLimitsReadError          bool
+	rateLimitsReadErrorCode      int
+	rateLimitsReadErrorMessage   string
 	childNicknames               map[string]string
 	historyTurns                 []any
 	rollbackHistoryTurns         []any
@@ -162,6 +165,21 @@ func (s *fakeCodexAppServer) handleSessionRPC(message scriptedAppServerMessage) 
 			},
 		})
 	case appServerMethodRateLimitsRead:
+		if s.rateLimitsReadError {
+			errorMessage := s.rateLimitsReadErrorMessage
+			if errorMessage == "" {
+				errorMessage = "rate limits backend unavailable"
+			}
+			errorCode := s.rateLimitsReadErrorCode
+			if errorCode == 0 {
+				errorCode = -32000
+			}
+			s.sendJSON(map[string]any{
+				"id":    message.ID,
+				"error": map[string]any{"code": errorCode, "message": errorMessage},
+			})
+			return true
+		}
 		s.sendJSON(map[string]any{
 			"id": message.ID,
 			"result": map[string]any{

--- a/services/tuttid/service/agentstatus/remote_auth.go
+++ b/services/tuttid/service/agentstatus/remote_auth.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerstatus"
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
 )
 
 const claudeKeychainReadTimeout = 3 * time.Second
@@ -20,9 +21,14 @@ const claudeKeychainReadTimeout = 3 * time.Second
 func (s Service) resolveRemoteAuthEvidence(
 	ctx context.Context,
 	spec ProviderSpec,
+	binaryPath string,
+	env []string,
 ) (providerstatus.AuthEvidence, bool) {
 	if s.RemoteAuthProbe != nil {
 		return s.RemoteAuthProbe(ctx, spec)
+	}
+	if spec.RemoteAuthProbe.Kind == providerregistry.RemoteAuthProbeKindProviderUsage {
+		return s.resolveProviderUsageRemoteAuthEvidence(ctx, spec, binaryPath, env)
 	}
 	token, found, err := s.resolveRemoteAuthCredential(ctx, spec.RemoteAuthProbe.CredentialKind)
 	if err != nil {
@@ -51,6 +57,55 @@ func (s Service) resolveRemoteAuthEvidence(
 		"success", result.Evidence.Kind == providerstatus.AuthEvidenceRemoteSuccess,
 	)
 	return result.Evidence, true
+}
+
+func (s Service) resolveProviderUsageRemoteAuthEvidence(
+	ctx context.Context,
+	spec ProviderSpec,
+	binaryPath string,
+	env []string,
+) (providerstatus.AuthEvidence, bool) {
+	if authCommandRunnerKind(spec) != providerregistry.AuthCommandRunnerKindCodexAppServerAccount ||
+		strings.TrimSpace(binaryPath) == "" {
+		return providerstatus.AuthEvidence{
+			Kind: providerstatus.AuthEvidenceProbeFailure, Reason: providerstatus.AuthReasonProbeFailed,
+		}, true
+	}
+	command := append([]string{binaryPath}, spec.AuthStatusCommand...)
+	if s.CodexRemoteAuthProbe != nil {
+		return s.CodexRemoteAuthProbe(ctx, command, append([]string(nil), env...)), true
+	}
+	release, acquired := s.DetectionCommands.acquire(ctx)
+	if !acquired {
+		return providerstatus.AuthEvidence{
+			Kind: providerstatus.AuthEvidenceProbeFailure, Reason: providerstatus.AuthReasonProbeFailed,
+		}, true
+	}
+	defer release()
+	timeout := time.Duration(spec.RemoteAuthProbe.TimeoutSeconds) * time.Second
+	result := agentruntime.ProbeCodexAppServer(ctx, agentruntime.CodexAppServerProbeInput{
+		Command: command,
+		Env:     append([]string(nil), env...),
+		Host: agentruntime.HostMetadata{ClientInfo: agentruntime.ClientInfo{
+			Name: "tutti-desktop", Title: "Tutti", Version: "0.1.0",
+		}},
+		ReadRateLimits:   true,
+		StartupTimeout:   timeout,
+		HandshakeTimeout: timeout,
+		ShutdownTimeout:  s.probeReadyAfter(),
+	})
+	evidence := providerstatus.CodexRemoteAuthEvidence(result.RateLimitsRead, result.Message)
+	level := slog.LevelDebug
+	if evidence.Kind == providerstatus.AuthEvidenceRemoteAuthFailure {
+		level = slog.LevelWarn
+	}
+	slog.Log(ctx, level, "agent provider remote auth probe completed",
+		"event", "tutti.agent_provider.remote_auth.completed",
+		"provider", spec.Provider,
+		"evidence", evidence.Kind,
+		"success", evidence.Kind == providerstatus.AuthEvidenceRemoteSuccess,
+	)
+	return evidence, true
 }
 
 func (s Service) resolveRemoteAuthCredential(

--- a/services/tuttid/service/agentstatus/remote_auth_test.go
+++ b/services/tuttid/service/agentstatus/remote_auth_test.go
@@ -6,10 +6,12 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
 	"github.com/tutti-os/tutti/packages/agent/daemon/providerstatus"
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
 )
 
 func TestResolveRemoteAuthEvidenceReadsClaudeOAuthCredential(t *testing.T) {
@@ -45,14 +47,51 @@ func TestResolveRemoteAuthEvidenceReadsClaudeOAuthCredential(t *testing.T) {
 			CredentialKind: providerregistry.RemoteAuthCredentialKindClaudeOAuth,
 			Endpoint:       server.URL, Method: http.MethodGet, TimeoutSeconds: 1,
 		},
-	})
+	}, "", nil)
 	if !attempted || evidence.Kind != providerstatus.AuthEvidenceRemoteAuthFailure ||
 		evidence.Reason != providerstatus.AuthReasonSessionExpired {
 		t.Fatalf("evidence = %#v, attempted = %v", evidence, attempted)
 	}
 }
 
-func TestReduceProviderAuthRemoteEvidenceOutranksLocalClaudeStatus(t *testing.T) {
+func TestResolveRemoteAuthEvidenceUsesCodexProviderUsageProbe(t *testing.T) {
+	var gotCommand []string
+	var gotEnv []string
+	service := Service{
+		CodexRemoteAuthProbe: func(
+			_ context.Context,
+			command []string,
+			env []string,
+		) providerstatus.AuthEvidence {
+			gotCommand = append([]string(nil), command...)
+			gotEnv = append([]string(nil), env...)
+			return providerstatus.AuthEvidence{Kind: providerstatus.AuthEvidenceRemoteSuccess}
+		},
+	}
+	evidence, attempted := service.resolveRemoteAuthEvidence(
+		context.Background(),
+		ProviderSpec{
+			Provider:          providerregistry.CodexProviderID,
+			AuthStatusCommand: []string{"-c", `service_tier="fast"`, "app-server"},
+			RemoteAuthProbe: providerregistry.RemoteAuthProbeDescriptor{
+				Kind: providerregistry.RemoteAuthProbeKindProviderUsage, TimeoutSeconds: 30,
+			},
+		},
+		"/usr/local/bin/codex",
+		[]string{"PATH=/usr/local/bin"},
+	)
+	if !attempted || evidence.Kind != providerstatus.AuthEvidenceRemoteSuccess {
+		t.Fatalf("evidence = %#v, attempted = %v", evidence, attempted)
+	}
+	if want := []string{"/usr/local/bin/codex", "-c", `service_tier="fast"`, "app-server"}; !reflect.DeepEqual(gotCommand, want) {
+		t.Fatalf("command = %#v, want %#v", gotCommand, want)
+	}
+	if want := []string{"PATH=/usr/local/bin"}; !reflect.DeepEqual(gotEnv, want) {
+		t.Fatalf("env = %#v, want %#v", gotEnv, want)
+	}
+}
+
+func TestReduceProviderAuthRemoteEvidenceOutranksLocalStatus(t *testing.T) {
 	service := Service{RunOutcomes: NewRunOutcomeStore()}
 	spec := ProviderSpec{Provider: "claude-code"}
 	local := AuthInfo{Status: AuthAuthenticated, AuthMethod: "oauth"}
@@ -93,5 +132,40 @@ func TestReduceProviderAuthRemoteEvidenceOutranksLocalClaudeStatus(t *testing.T)
 	)
 	if transient.Status != AuthConfigured {
 		t.Fatalf("transient status = %q", transient.Status)
+	}
+}
+
+func TestServiceListCodexRequiresProviderUsageEvidence(t *testing.T) {
+	tests := []struct {
+		name     string
+		evidence providerstatus.AuthEvidence
+		want     AuthStatus
+	}{
+		{name: "accepted", evidence: providerstatus.AuthEvidence{Kind: providerstatus.AuthEvidenceRemoteSuccess}, want: AuthAuthenticated},
+		{name: "revoked", evidence: providerstatus.AuthEvidence{Kind: providerstatus.AuthEvidenceRemoteAuthFailure, Reason: providerstatus.AuthReasonSessionExpired}, want: AuthRequired},
+		{name: "transient failure", evidence: providerstatus.AuthEvidence{Kind: providerstatus.AuthEvidenceProbeFailure, Reason: providerstatus.AuthReasonProbeFailed}, want: AuthConfigured},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			service := testService(func(name string) (string, error) {
+				return "/usr/local/bin/" + name, nil
+			}, map[string]bool{})
+			service.CodexAuthProbe = func(context.Context, []string, []string) CodexAuthProbeEvidence {
+				return CodexAuthProbeEvidence{
+					State: agentruntime.CodexAppServerAccountAuthenticated, AuthMethod: "chatgpt",
+				}
+			}
+			service.RemoteAuthProbe = func(context.Context, ProviderSpec) (providerstatus.AuthEvidence, bool) {
+				return test.evidence, true
+			}
+
+			snapshot, err := service.List(context.Background(), ListInput{Providers: []string{"codex"}})
+			if err != nil {
+				t.Fatalf("List() error = %v", err)
+			}
+			if got := onlyStatus(t, snapshot).Auth.Status; got != test.want {
+				t.Fatalf("Auth.Status = %q, want %q", got, test.want)
+			}
+		})
 	}
 }

--- a/services/tuttid/service/agentstatus/service.go
+++ b/services/tuttid/service/agentstatus/service.go
@@ -305,6 +305,9 @@ type Service struct {
 	// RemoteAuthProbe is the provider-neutral test seam for descriptor-owned
 	// provider requests. Nil resolves credentials locally and uses HTTPClient.
 	RemoteAuthProbe func(context.Context, ProviderSpec) (providerstatus.AuthEvidence, bool)
+	// CodexRemoteAuthProbe is the narrow test seam for the provider-usage
+	// strategy. Nil uses Codex app-server account/rateLimits/read.
+	CodexRemoteAuthProbe func(context.Context, []string, []string) providerstatus.AuthEvidence
 	// CodexRuntimeSelectionStore persists only an explicit Codex launcher
 	// choice. A missing selection permits only one uniquely ready candidate;
 	// multiple ready candidates require the user to choose one.

--- a/services/tuttid/service/agentstatus/service_helpers.go
+++ b/services/tuttid/service/agentstatus/service_helpers.go
@@ -243,10 +243,7 @@ func (s Service) resolveAuthAndCLIVersion(
 	return s.resolveAuthFromMarkers(spec), "", providerstatus.AuthEvidenceAuthorityLocal
 }
 
-func authCommandEvidenceAuthority(spec ProviderSpec) providerstatus.AuthEvidenceAuthority {
-	if authCommandRunnerKind(spec) == providerregistry.AuthCommandRunnerKindCodexAppServerAccount {
-		return providerstatus.AuthEvidenceAuthorityRemote
-	}
+func authCommandEvidenceAuthority(ProviderSpec) providerstatus.AuthEvidenceAuthority {
 	return providerstatus.AuthEvidenceAuthorityLocal
 }
 

--- a/services/tuttid/service/agentstatus/service_status.go
+++ b/services/tuttid/service/agentstatus/service_status.go
@@ -145,7 +145,12 @@ func (s Service) statusForSpec(
 		remoteAuthProbeRan = true
 		checks.Go(func() error {
 			remoteStartedAt := time.Now()
-			remoteAuthEvidence, remoteAuthEvidencePresent = s.resolveRemoteAuthEvidence(detectionCtx, spec)
+			remoteAuthEvidence, remoteAuthEvidencePresent = s.resolveRemoteAuthEvidence(
+				detectionCtx,
+				spec,
+				runtimeResolution.CLIPath,
+				runtimeResolution.Env,
+			)
 			remoteAuthDuration = time.Since(remoteStartedAt)
 			return nil
 		})

--- a/services/tuttid/service/agentstatus/service_status_test.go
+++ b/services/tuttid/service/agentstatus/service_status_test.go
@@ -8,6 +8,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/tutti-os/tutti/packages/agent/daemon/providerregistry"
+	"github.com/tutti-os/tutti/packages/agent/daemon/providerstatus"
 )
 
 // TestServiceListDetectsProvidersConcurrently proves provider detection fans
@@ -30,6 +33,12 @@ func TestServiceListDetectsProvidersConcurrently(t *testing.T) {
 		case <-ctx.Done():
 		}
 		return AuthInfo{Status: AuthAuthenticated}, true
+	}
+	service.RemoteAuthProbe = func(_ context.Context, spec ProviderSpec) (providerstatus.AuthEvidence, bool) {
+		if spec.Provider == providerregistry.CodexProviderID {
+			return providerstatus.AuthEvidence{Kind: providerstatus.AuthEvidenceRemoteSuccess}, true
+		}
+		return providerstatus.AuthEvidence{}, false
 	}
 
 	type listResult struct {

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -414,6 +414,9 @@ func TestServiceListReportsReadyWhenInstalledAndAuthenticated(t *testing.T) {
 			AuthMethod:   "chatgpt",
 		}
 	}
+	service.RemoteAuthProbe = func(context.Context, ProviderSpec) (providerstatus.AuthEvidence, bool) {
+		return providerstatus.AuthEvidence{Kind: providerstatus.AuthEvidenceRemoteSuccess}, true
+	}
 
 	snapshot, err := service.List(context.Background(), ListInput{Providers: []string{"codex"}})
 	if err != nil {
@@ -461,6 +464,9 @@ func TestServiceListUsesCodexAppServerAccountCommand(t *testing.T) {
 			t.Fatalf("binaryPath = %q, want /usr/local/bin/codex", binaryPath)
 		}
 		return AuthInfo{Status: AuthAuthenticated}, true
+	}
+	service.RemoteAuthProbe = func(context.Context, ProviderSpec) (providerstatus.AuthEvidence, bool) {
+		return providerstatus.AuthEvidence{Kind: providerstatus.AuthEvidenceRemoteSuccess}, true
 	}
 
 	snapshot, err := service.List(context.Background(), ListInput{Providers: []string{"codex"}})


### PR DESCRIPTION
## Summary

- 为通用 `RemoteAuthProbeDescriptor` 新增 `provider_usage` 策略；Codex 不再因为本地 `account/read` 显示账号就直接判定远端已认证
- Codex 通过现有 app-server 进程执行 `account/rateLimits/read`：成功归并为 `authenticated`，明确的过期、revoke、未登录归并为 `required`
- 网络、限流、服务端或协议暂时失败保留本地 `configured`；API Key 继续只表示已配置，不触发订阅 OAuth 探测
- Tutti provider-status、Desktop 和 AgentGUI 继续消费同一认证证据；外部 Host 可从同一描述符触发自己的 Provider usage adapter

## Root Cause

Codex 描述符没有声明远端认证策略。外部 Host 会把 Codex app-server 的本地账号识别结果归并为 `configured`，但不会继续调用已存在的 usage 探测，因此有效 OAuth、已 revoke OAuth 都停在同一个 UI 状态。

## Tests

- `pnpm check:changed -- --push-ready`
- TSH 使用临时 `go.work` 接入本分支后：`go test ./cmd/desktopd ./cmd/desktopd/bridge -count=1`

## Review

| Lane | Result | Evidence | Consumers |
| --- | --- | --- | --- |
| Architecture | pass | 按 `RemoteAuthProbe` + `AuthCommandRunnerKind` 策略分发；Provider ID 分支被仓库边界检查拒绝后已移除 | tuttid、Tutti Desktop、AgentGUI、TSH |
| Security | pass | OAuth 凭据只留在 Provider runtime；状态层只接收无凭据证据 | desktopd/renderer 不接触 token |
| Performance | pass | 沿用 15 分钟远端证据 TTL 和全局检测命令限流；不随普通渲染重复执行 | provider status 刷新链路 |
| Compatibility | pass | API Key 跳过订阅探测；Claude Code HTTP OAuth 探测不变 | Codex、Claude Code |

## Windows Impact

复用现有 argv、命令解析和 `ProcessTransport`。没有新增 POSIX 路径、shell 拼接或平台分支。Windows 实机验证仍由现有 Agent adapter CI lane 覆盖。

## Follow-up

合并并发布新的 Tutti cohort 后，TSH 需要整体升级 Tutti 依赖并提交对应 PR；本 PR 不在下游添加 `replace`、patch 或兼容分支。
