### PR TITLE
feat(connector): return exact reconcile discovery summary

### DIFF
--- a/docs/architecture/connector-market.md
+++ b/docs/architecture/connector-market.md
@@ -339,6 +339,14 @@ does the resolver request a one-shot credential-broker grant. `expired`,
 `disconnected`, and missing projections reconcile inactive. Daemon or guest
 restart uses `BootstrapForScope` to rebuild the same projection explicitly.
 
+An enabled Runtime Reconcile returns one identity-fenced receipt containing
+the bounded, non-secret `ConnectorSummary` for the exact route generation it
+committed. The receipt is available while capability publication is disabled,
+so a cross-machine host can project readiness without consulting an
+Agent-facing registry. A later key-only Route lookup is forbidden because an
+upgrade or concurrent connection reconcile could otherwise attach metadata
+from a different release or generation.
+
 Remote Connector authorization uses that account projection for Start,
 observation, presentation, and route publication; the device Connector's
 authorization field is not remote authorization truth. A completed Start

--- a/packages/connector/daemon/host_test.go
+++ b/packages/connector/daemon/host_test.go
@@ -55,7 +55,9 @@ func (delegate *activationGateDelegate) Reconcile(_ context.Context, request mar
 	return market.RuntimeReceipt{OperationID: request.OperationID, ConnectionID: request.ConnectionID,
 		ConnectorKey: request.Connector.Key, ReleaseDigest: request.Connector.Release.ReleaseDigest, Generation: request.Generation,
 		Readiness: market.RuntimeReadiness{State: market.RuntimeReadinessReady,
-			Interfaces: []market.InterfaceReadiness{{Kind: "mcp", State: market.RuntimeReadinessReady}}}}, nil
+			Interfaces: []market.InterfaceReadiness{{Kind: "mcp", State: market.RuntimeReadinessReady}}},
+		Summary: &market.ConnectorSummary{Key: request.Connector.Key, Name: request.Connector.Key,
+			Interfaces: []market.ConnectorInterfaceSummary{{Kind: "mcp", ServerName: "connector", Status: string(market.RuntimeReadinessReady)}}}}, nil
 }
 
 type runtimeBindingResolverFunc func(context.Context, market.RuntimeBindingRequest) (market.RuntimeBinding, error)

--- a/packages/connector/host/README.md
+++ b/packages/connector/host/README.md
@@ -23,4 +23,8 @@ machine, sync the verified candidate, and install it on the runtime machine.
 Receipts may use opaque references when execution is remote. Installation
 never implies runtime publication: authorization observation drives a separate
 reconcile. Runtime receipts carry structured per-interface readiness so a
-CLI-only Connector can be ready without an MCP route.
+CLI-only Connector can be ready without an MCP route. A successful enabled
+reconcile also carries the bounded `ConnectorSummary` committed by that exact
+route generation. Lifecycle observers consume this receipt projection even
+while Agent publication is fenced; they must not perform a later key-only
+lookup against the mutable published registry.

--- a/packages/connector/host/application_execution.go
+++ b/packages/connector/host/application_execution.go
@@ -277,12 +277,28 @@ func validateRuntimeReceipt(receipt RuntimeReceipt, operationID, connectionID, c
 	if receipt.Readiness.State != RuntimeReadinessReady {
 		return invalidOperationReceipt("implementation host did not return a ready runtime receipt")
 	}
+	if receipt.Summary == nil {
+		return invalidOperationReceipt("implementation host returned no matching connector summary")
+	}
+	if err := ValidateConnectorSummary(*receipt.Summary, connectorKey); err != nil {
+		return invalidOperationReceipt("implementation host returned an invalid connector summary")
+	}
 	if len(receipt.Readiness.Interfaces) == 0 {
 		return invalidOperationReceipt("implementation host returned no ready interfaces")
 	}
+	readyInterfaces := make(map[string]struct{}, len(receipt.Readiness.Interfaces))
 	for _, readiness := range receipt.Readiness.Interfaces {
 		if (readiness.Kind != "mcp" && readiness.Kind != "cli") || readiness.State != RuntimeReadinessReady {
 			return invalidOperationReceipt("implementation host returned invalid interface readiness")
+		}
+		readyInterfaces[readiness.Kind] = struct{}{}
+	}
+	if len(readyInterfaces) != len(receipt.Summary.Interfaces) {
+		return invalidOperationReceipt("implementation host returned inconsistent interface summary")
+	}
+	for _, summary := range receipt.Summary.Interfaces {
+		if _, ok := readyInterfaces[summary.Kind]; !ok {
+			return invalidOperationReceipt("implementation host returned inconsistent interface summary")
 		}
 	}
 	return nil

--- a/packages/connector/host/application_test.go
+++ b/packages/connector/host/application_test.go
@@ -1532,12 +1532,15 @@ func (host *memoryInstallRuntime) Reconcile(_ context.Context, request RuntimeRe
 	}
 	readiness := RuntimeReadiness{State: RuntimeReadinessReady,
 		Interfaces: []InterfaceReadiness{{Kind: "mcp", State: RuntimeReadinessReady}}}
+	summary := &ConnectorSummary{Key: request.Connector.Key, Name: request.Connector.Key,
+		Interfaces: []ConnectorInterfaceSummary{{Kind: "mcp", ServerName: "connector", Status: string(RuntimeReadinessReady)}}}
 	if !request.Enabled {
 		readiness = RuntimeReadiness{State: RuntimeReadinessBlocked, ReasonCode: RuntimeReadinessReasonRuntimeDisabled}
+		summary = nil
 	}
 	return RuntimeReceipt{OperationID: request.OperationID, ConnectionID: request.ConnectionID,
 		ConnectorKey: request.Connector.Key, ReleaseDigest: request.Connector.Release.ReleaseDigest, Generation: request.Generation,
-		Readiness: readiness}, nil
+		Readiness: readiness, Summary: summary}, nil
 }
 
 func (host *memoryInstallRuntime) InspectReleaseInstallation(_ context.Context, request InspectReleaseInstallationRequest) (ReleaseInstallationObservation, error) {

--- a/packages/connector/host/connector_summary.go
+++ b/packages/connector/host/connector_summary.go
@@ -1,0 +1,128 @@
+package host
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	ConnectorSummaryKeyMaxBytes         = 128
+	ConnectorSummaryNameMaxBytes        = 256
+	ConnectorSummaryDescriptionMaxBytes = 16 * 1024
+	ConnectorInterfaceMaxCount          = 8
+	ConnectorInterfaceFieldMaxBytes     = 512
+	ConnectorSkillMaxCount              = 128
+	ConnectorSkillNameMaxBytes          = 128
+	ConnectorSkillTitleMaxBytes         = 256
+	ConnectorSkillDescriptionMaxBytes   = 4 * 1024
+	ConnectorSkillProjectionMaxBytes    = 512 * 1024
+)
+
+// ValidateConnectorSummary validates the complete process-boundary discovery
+// projection produced by an exact runtime reconcile.
+func ValidateConnectorSummary(summary ConnectorSummary, expectedKey string) error {
+	if strings.TrimSpace(summary.Key) == "" || summary.Key != expectedKey {
+		return errors.New("connector summary key does not match the reconciled Connector")
+	}
+	if err := validateSummaryText("key", summary.Key, ConnectorSummaryKeyMaxBytes, true); err != nil {
+		return err
+	}
+	if err := validateSummaryText("name", summary.Name, ConnectorSummaryNameMaxBytes, true); err != nil {
+		return err
+	}
+	if err := validateSummaryText("description", summary.Description, ConnectorSummaryDescriptionMaxBytes, false); err != nil {
+		return err
+	}
+	if err := ValidateConnectorSkillSummaries(summary.Skills); err != nil {
+		return err
+	}
+	if len(summary.Interfaces) == 0 || len(summary.Interfaces) > ConnectorInterfaceMaxCount {
+		return fmt.Errorf("connector interface count must be between 1 and %d", ConnectorInterfaceMaxCount)
+	}
+	seen := make(map[string]struct{}, len(summary.Interfaces))
+	for _, item := range summary.Interfaces {
+		if item.Kind != "mcp" && item.Kind != "cli" {
+			return fmt.Errorf("unsupported connector interface kind %q", item.Kind)
+		}
+		if _, exists := seen[item.Kind]; exists {
+			return fmt.Errorf("duplicate connector interface kind %q", item.Kind)
+		}
+		seen[item.Kind] = struct{}{}
+		for name, value := range map[string]string{
+			"kind": item.Kind, "serverName": item.ServerName, "toolPrefix": item.ToolPrefix,
+			"command": item.Command, "status": item.Status,
+		} {
+			if err := validateSummaryText("interface "+name, value, ConnectorInterfaceFieldMaxBytes, name == "kind" || name == "status"); err != nil {
+				return err
+			}
+		}
+		if item.Status != string(RuntimeReadinessReady) {
+			return fmt.Errorf("connector interface %q is not ready", item.Kind)
+		}
+		if item.Kind == "mcp" && strings.TrimSpace(item.ServerName) == "" {
+			return errors.New("connector MCP interface serverName is required")
+		}
+		if item.Kind == "cli" && strings.TrimSpace(item.Command) == "" {
+			return errors.New("connector CLI interface command is required")
+		}
+	}
+	return nil
+}
+
+func validateSummaryText(name, value string, limit int, required bool) error {
+	if !utf8.ValidString(value) {
+		return fmt.Errorf("connector summary %s must be valid UTF-8", name)
+	}
+	if len(value) > limit {
+		return fmt.Errorf("connector summary %s exceeds %d bytes", name, limit)
+	}
+	if required && strings.TrimSpace(value) == "" {
+		return fmt.Errorf("connector summary %s is required", name)
+	}
+	return nil
+}
+
+// ValidateConnectorSkillSummaries enforces the process-boundary size contract
+// for Connector discovery metadata. Skill bodies are deliberately excluded.
+func ValidateConnectorSkillSummaries(summaries []ConnectorSkillSummary) error {
+	if len(summaries) > ConnectorSkillMaxCount {
+		return fmt.Errorf("connector Skill count exceeds %d", ConnectorSkillMaxCount)
+	}
+	total := 0
+	for _, summary := range summaries {
+		if err := ValidateConnectorSkillSummary(summary); err != nil {
+			return err
+		}
+		total += len(summary.Name) + len(summary.Title) + len(summary.Description)
+		if total > ConnectorSkillProjectionMaxBytes {
+			return fmt.Errorf("connector Skill summary projection exceeds %d bytes", ConnectorSkillProjectionMaxBytes)
+		}
+	}
+	return nil
+}
+
+func ValidateConnectorSkillSummary(summary ConnectorSkillSummary) error {
+	fields := []struct {
+		name  string
+		value string
+		limit int
+	}{
+		{name: "name", value: summary.Name, limit: ConnectorSkillNameMaxBytes},
+		{name: "title", value: summary.Title, limit: ConnectorSkillTitleMaxBytes},
+		{name: "description", value: summary.Description, limit: ConnectorSkillDescriptionMaxBytes},
+	}
+	for _, field := range fields {
+		if !utf8.ValidString(field.value) {
+			return fmt.Errorf("connector Skill %s must be valid UTF-8", field.name)
+		}
+		if len(field.value) > field.limit {
+			return fmt.Errorf("connector Skill %s exceeds %d bytes", field.name, field.limit)
+		}
+	}
+	if strings.TrimSpace(summary.Name) == "" || strings.TrimSpace(summary.Title) == "" || strings.TrimSpace(summary.Description) == "" {
+		return errors.New("connector Skill name, title, and description are required")
+	}
+	return nil
+}

--- a/packages/connector/host/types.go
+++ b/packages/connector/host/types.go
@@ -385,6 +385,35 @@ type RuntimeReceipt struct {
 	ReleaseDigest string           `json:"releaseDigest"`
 	Generation    HostGeneration   `json:"generation"`
 	Readiness     RuntimeReadiness `json:"readiness"`
+	// Summary is the immutable, verified discovery projection committed by this
+	// exact reconcile. It is independent of capability publication so lifecycle
+	// observers can establish ready state while Agent-facing routes are fenced.
+	Summary *ConnectorSummary `json:"summary,omitempty"`
+}
+
+// ConnectorSummary contains bounded, non-secret metadata for one committed
+// runtime route. RuntimeReceipt owns the route identity; this projection must
+// never contain credentials, filesystem paths, or Skill bodies.
+type ConnectorSummary struct {
+	Key         string                      `json:"key"`
+	Name        string                      `json:"name"`
+	Description string                      `json:"description"`
+	Skills      []ConnectorSkillSummary     `json:"skills"`
+	Interfaces  []ConnectorInterfaceSummary `json:"interfaces"`
+}
+
+type ConnectorSkillSummary struct {
+	Name        string `json:"name"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+}
+
+type ConnectorInterfaceSummary struct {
+	Kind       string `json:"kind"`
+	ServerName string `json:"serverName,omitempty"`
+	ToolPrefix string `json:"toolPrefix,omitempty"`
+	Command    string `json:"command,omitempty"`
+	Status     string `json:"status"`
 }
 
 type RuntimeReadinessState string

--- a/packages/connector/runtime/README.md
+++ b/packages/connector/runtime/README.md
@@ -16,6 +16,12 @@ rescan a mutable installation directory. MCP calls use `MCPRegistry`, while CLI
 calls use the stable per-Connector shim. There is no generic Connector broker
 or generic `connector.invoke` transport in the public runtime.
 
+Every successful enabled `Reconcile` returns the bounded discovery summary for
+the exact committed connection, release digest, and host generation. This
+receipt projection is independent of the Agent publication switch. Cross-
+machine hosts should serialize it directly into their observed-runtime
+protocol instead of querying `RouteRegistry` by Connector key after reconcile.
+
 Hosts supply the managed runtime resolver, implementation host, process
 transport, `RemoteMCPClientFactory`, state roots, and product-facing command
 transport. Runtime code must not import `services/tuttid` or expose host

--- a/packages/connector/runtime/artifact/skills.go
+++ b/packages/connector/runtime/artifact/skills.go
@@ -8,23 +8,24 @@ import (
 	"sort"
 	"strings"
 
+	market "github.com/tutti-os/tutti/packages/connector/host"
 	"gopkg.in/yaml.v3"
 )
 
 const (
-	connectorSkillEntryName    = "SKILL.md"
-	connectorSkillMaxDepth     = 8
-	connectorSkillMaxCount     = 128
-	connectorSkillMaxEntrySize = 512 * 1024
+	connectorSkillEntryName           = "SKILL.md"
+	connectorSkillMaxDepth            = 8
+	connectorSkillMaxCount            = market.ConnectorSkillMaxCount
+	connectorSkillMaxEntrySize        = 512 * 1024
+	ConnectorSkillNameMaxBytes        = market.ConnectorSkillNameMaxBytes
+	ConnectorSkillTitleMaxBytes       = market.ConnectorSkillTitleMaxBytes
+	ConnectorSkillDescriptionMaxBytes = market.ConnectorSkillDescriptionMaxBytes
+	ConnectorSkillProjectionMaxBytes  = market.ConnectorSkillProjectionMaxBytes
 )
 
 // SkillSummary is the immutable, non-secret metadata projected from one
 // verified Connector Skill.
-type SkillSummary struct {
-	Name        string `json:"name"`
-	Title       string `json:"title"`
-	Description string `json:"description"`
-}
+type SkillSummary = market.ConnectorSkillSummary
 
 // SkillProjection is produced once while a Connector route is activated.
 // Root is empty when the release has no optional skills directory.
@@ -56,6 +57,7 @@ func InspectSkills(installedRoot string) (SkillProjection, error) {
 	skills := make([]SkillSummary, 0)
 	seen := make(map[string]struct{})
 	skillCount := 0
+	projectionBytes := 0
 	err = filepath.WalkDir(skillRoot, func(path string, entry os.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
@@ -99,6 +101,13 @@ func InspectSkills(installedRoot string) (SkillProjection, error) {
 		if err != nil {
 			return fmt.Errorf("%s: %w", filepath.ToSlash(relative), err)
 		}
+		if err := ValidateSkillSummary(metadata); err != nil {
+			return fmt.Errorf("%s: %w", filepath.ToSlash(relative), err)
+		}
+		projectionBytes += skillSummaryBytes(metadata)
+		if projectionBytes > ConnectorSkillProjectionMaxBytes {
+			return fmt.Errorf("connector Skill summary projection exceeds %d bytes", ConnectorSkillProjectionMaxBytes)
+		}
 		if _, duplicate := seen[metadata.Name]; duplicate {
 			return fmt.Errorf("duplicate Connector Skill %q", metadata.Name)
 		}
@@ -111,6 +120,21 @@ func InspectSkills(installedRoot string) (SkillProjection, error) {
 	}
 	sort.Slice(skills, func(left, right int) bool { return skills[left].Name < skills[right].Name })
 	return SkillProjection{Root: skillRoot, Skills: skills}, nil
+}
+
+// ValidateSkillSummaries applies the public projection bounds to metadata
+// received across a process boundary. Artifact inspection calls the same
+// validation before a route can be committed.
+func ValidateSkillSummaries(summaries []SkillSummary) error {
+	return market.ValidateConnectorSkillSummaries(summaries)
+}
+
+func ValidateSkillSummary(summary SkillSummary) error {
+	return market.ValidateConnectorSkillSummary(summary)
+}
+
+func skillSummaryBytes(summary SkillSummary) int {
+	return len(summary.Name) + len(summary.Title) + len(summary.Description)
 }
 
 func parseSkill(content string) (SkillSummary, error) {

--- a/packages/connector/runtime/artifact/skills_test.go
+++ b/packages/connector/runtime/artifact/skills_test.go
@@ -83,6 +83,33 @@ func TestInspectSkillsBoundsSkillCount(t *testing.T) {
 	}
 }
 
+func TestValidateSkillSummariesBoundsFieldsAndTotalProjection(t *testing.T) {
+	valid := SkillSummary{Name: "calendar", Title: "Calendar", Description: "Manage calendar events"}
+	tests := []struct {
+		name      string
+		summaries []SkillSummary
+		want      string
+	}{
+		{name: "name", summaries: []SkillSummary{{Name: strings.Repeat("n", ConnectorSkillNameMaxBytes+1), Title: valid.Title, Description: valid.Description}}, want: "name exceeds"},
+		{name: "title", summaries: []SkillSummary{{Name: valid.Name, Title: strings.Repeat("t", ConnectorSkillTitleMaxBytes+1), Description: valid.Description}}, want: "title exceeds"},
+		{name: "description", summaries: []SkillSummary{{Name: valid.Name, Title: valid.Title, Description: strings.Repeat("d", ConnectorSkillDescriptionMaxBytes+1)}}, want: "description exceeds"},
+		{name: "total", summaries: func() []SkillSummary {
+			result := make([]SkillSummary, connectorSkillMaxCount)
+			for index := range result {
+				result[index] = SkillSummary{Name: fmt.Sprintf("skill-%03d", index), Title: strings.Repeat("t", ConnectorSkillTitleMaxBytes), Description: strings.Repeat("d", ConnectorSkillDescriptionMaxBytes)}
+			}
+			return result
+		}(), want: "projection exceeds"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := ValidateSkillSummaries(test.summaries); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("ValidateSkillSummaries() error = %v", err)
+			}
+		})
+	}
+}
+
 func writeSkillTestFile(t *testing.T, path, name, title string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {

--- a/packages/connector/runtime/implementationhost/host.go
+++ b/packages/connector/runtime/implementationhost/host.go
@@ -282,9 +282,10 @@ func (host *Host) Reconcile(ctx context.Context, request ReconcileRequest) (mark
 	if route.mcpClient != nil {
 		go host.monitorMCPRoute(route, route.mcpClient)
 	}
+	summary := connectorSummaryFromDescriptor(routeDescriptor(route))
 	return market.RuntimeReceipt{OperationID: runtimeRequest.OperationID, ConnectionID: runtimeRequest.ConnectionID,
 		ConnectorKey: runtimeRequest.Connector.Key, ReleaseDigest: route.releaseDigest,
-		Generation: runtimeRequest.Generation, Readiness: cloneRuntimeReadiness(route.readiness)}, nil
+		Generation: runtimeRequest.Generation, Readiness: cloneRuntimeReadiness(route.readiness), Summary: &summary}, nil
 }
 
 func (*Host) validateAuthorization(request market.RuntimeReconcileRequest) error {
@@ -824,14 +825,18 @@ func (registry *RouteRegistry) Routes() []RouteDescriptor {
 	routes := registry.activeRoutes()
 	result := make([]RouteDescriptor, 0, len(routes))
 	for _, route := range routes {
-		result = append(result, RouteDescriptor{ConnectorKey: route.connectorKey, DisplayName: route.displayName,
-			Description: route.description, RoutingAliases: append([]string(nil), route.routingAliases...),
-			SkillRoot: route.skillRoot, Skills: append([]connectorartifact.SkillSummary(nil), route.skills...),
-			HasMCP: len(route.mcpTools) > 0, CLICommand: route.cliCommand,
-			Readiness: cloneRuntimeReadiness(route.readiness)})
+		result = append(result, routeDescriptor(route))
 	}
 	sort.Slice(result, func(left, right int) bool { return result[left].ConnectorKey < result[right].ConnectorKey })
 	return result
+}
+
+func routeDescriptor(route *connectorRoute) RouteDescriptor {
+	return RouteDescriptor{ConnectorKey: route.connectorKey, DisplayName: route.displayName,
+		Description: route.description, RoutingAliases: append([]string(nil), route.routingAliases...),
+		SkillRoot: route.skillRoot, Skills: append([]connectorartifact.SkillSummary(nil), route.skills...),
+		HasMCP: len(route.mcpTools) > 0, CLICommand: route.cliCommand,
+		Readiness: cloneRuntimeReadiness(route.readiness)}
 }
 
 var _ connectorruntime.ManagedRoute = (*connectorRoute)(nil)

--- a/packages/connector/runtime/implementationhost/route_projection.go
+++ b/packages/connector/runtime/implementationhost/route_projection.go
@@ -1,24 +1,10 @@
 package implementationhost
 
-import connectorartifact "github.com/tutti-os/tutti/packages/connector/runtime/artifact"
+import market "github.com/tutti-os/tutti/packages/connector/host"
 
-type SkillSummary = connectorartifact.SkillSummary
-
-type ConnectorSummary struct {
-	Key         string                      `json:"key"`
-	Name        string                      `json:"name"`
-	Description string                      `json:"description"`
-	Skills      []SkillSummary              `json:"skills"`
-	Interfaces  []ConnectorInterfaceSummary `json:"interfaces"`
-}
-
-type ConnectorInterfaceSummary struct {
-	Kind       string `json:"kind"`
-	ServerName string `json:"serverName,omitempty"`
-	ToolPrefix string `json:"toolPrefix,omitempty"`
-	Command    string `json:"command,omitempty"`
-	Status     string `json:"status"`
-}
+type SkillSummary = market.ConnectorSkillSummary
+type ConnectorSummary = market.ConnectorSummary
+type ConnectorInterfaceSummary = market.ConnectorInterfaceSummary
 
 // ConnectorRoutingHint is a bounded, non-secret projection of one active
 // route for Agent runtime preparation.
@@ -35,21 +21,23 @@ func (registry *RouteRegistry) ConnectorSummaries() []ConnectorSummary {
 	routes := registry.Routes()
 	connectors := make([]ConnectorSummary, 0, len(routes))
 	for _, route := range routes {
-		interfaces := make([]ConnectorInterfaceSummary, 0, 2)
-		if route.HasMCP {
-			interfaces = append(interfaces, ConnectorInterfaceSummary{Kind: "mcp", ServerName: "connector",
-				ToolPrefix: route.ConnectorKey + "_", Status: string(route.InterfaceState("mcp"))})
-		}
-		if route.CLICommand != "" {
-			interfaces = append(interfaces, ConnectorInterfaceSummary{Kind: "cli", Command: route.CLICommand,
-				Status: string(route.InterfaceState("cli"))})
-		}
-		connectors = append(connectors, ConnectorSummary{
-			Key: route.ConnectorKey, Name: route.DisplayName, Description: route.Description,
-			Skills: append([]SkillSummary(nil), route.Skills...), Interfaces: interfaces,
-		})
+		connectors = append(connectors, connectorSummaryFromDescriptor(route))
 	}
 	return connectors
+}
+
+func connectorSummaryFromDescriptor(route RouteDescriptor) ConnectorSummary {
+	interfaces := make([]ConnectorInterfaceSummary, 0, 2)
+	if route.HasMCP {
+		interfaces = append(interfaces, ConnectorInterfaceSummary{Kind: "mcp", ServerName: "connector",
+			ToolPrefix: route.ConnectorKey + "_", Status: string(route.InterfaceState("mcp"))})
+	}
+	if route.CLICommand != "" {
+		interfaces = append(interfaces, ConnectorInterfaceSummary{Kind: "cli", Command: route.CLICommand,
+			Status: string(route.InterfaceState("cli"))})
+	}
+	return ConnectorSummary{Key: route.ConnectorKey, Name: route.DisplayName, Description: route.Description,
+		Skills: append([]SkillSummary(nil), route.Skills...), Interfaces: interfaces}
 }
 
 // RoutingHints returns a detached snapshot for Agent runtime preparation.

--- a/packages/connector/runtime/implementationhost/route_projection_test.go
+++ b/packages/connector/runtime/implementationhost/route_projection_test.go
@@ -41,3 +41,29 @@ func TestRouteRegistryProjectsDetachedConnectorMetadata(t *testing.T) {
 		t.Fatal("route projection leaked mutable state")
 	}
 }
+
+func TestCommittedRouteSummaryDoesNotDependOnCapabilityPublication(t *testing.T) {
+	route := &connectorRoute{
+		id: "account-1\x00calendar", releaseDigest: "digest",
+		generation:   market.HostGeneration{BootEpoch: "boot-1", Generation: 1},
+		connectorKey: "calendar", displayName: "Calendar", description: "Manage meetings",
+		skills:   []connectorartifact.SkillSummary{{Name: "standup", Title: "Standup", Description: "Prepare a standup"}},
+		mcpTools: map[string]registeredMCPTool{"calendar_list": {}}, processes: connectorruntime.NewProcessGroup(),
+		readiness: market.RuntimeReadiness{State: market.RuntimeReadinessReady,
+			Interfaces: []market.InterfaceReadiness{{Kind: "mcp", State: market.RuntimeReadinessReady}}},
+	}
+	table := connectorruntime.NewRouteTable()
+	if err := table.Commit(route); err != nil {
+		t.Fatal(err)
+	}
+	table.SetPublished(false)
+	registry := NewRouteRegistry()
+	registry.attach(table)
+	if summaries := registry.ConnectorSummaries(); len(summaries) != 0 {
+		t.Fatalf("published summaries = %#v", summaries)
+	}
+	summary := connectorSummaryFromDescriptor(routeDescriptor(route))
+	if summary.Key != "calendar" || len(summary.Skills) != 1 || len(summary.Interfaces) != 1 {
+		t.Fatalf("committed summary = %#v", summary)
+	}
+}


### PR DESCRIPTION
## Summary
- return a bounded Connector discovery summary from the exact successful Runtime Reconcile receipt
- validate summary identity, interface readiness, UTF-8, count, and byte limits at the host boundary
- make artifact Skill summaries share the public host contract and document the cross-machine consumption rule

## Why
VM-backed hosts must project ready Connector metadata while Agent publication is fenced. A later key-only RouteRegistry lookup can race an upgrade or another connection and attach metadata from the wrong generation.

## Validation
- `go test ./packages/connector/host ./packages/connector/daemon ./packages/connector/runtime/artifact ./packages/connector/runtime/implementationhost`
- `pnpm check:changed`