### PR TITLE
fix: stabilize desktop update, close guard, and message center layout

### DIFF
--- a/apps/desktop/src/main/ipc/hostWindow.ts
+++ b/apps/desktop/src/main/ipc/hostWindow.ts
@@ -1,4 +1,4 @@
-import { screen } from "electron";
+import { ipcMain, screen } from "electron";
 import {
   captureWorkbenchDockPreview,
   captureWorkbenchPreviewImages,
@@ -6,6 +6,7 @@ import {
 } from "@tutti-os/workbench-electron";
 import {
   desktopIpcChannels,
+  type DesktopHostWindowCloseRequestResolutionPayload,
   type DesktopHostOpenAgentWindowInput,
   type DesktopHostWindowCapturePreviewInput
 } from "../../shared/contracts/ipc";
@@ -14,7 +15,11 @@ import type { WorkspaceLaunch } from "../host/workspaceLaunch";
 import { getDesktopLogger, type DesktopLogger } from "../logging";
 import { registerDesktopIpcHandler } from "./handle";
 import { resolveOwnerWindowFromEvent } from "./ownerWindow";
-import { getWorkspaceWindowKind } from "../windows/workspaceWindow";
+import {
+  getWorkspaceWindowKind,
+  resolveWorkspaceWindowCloseRequest,
+  setWorkspaceWindowCloseGuardEnabled
+} from "../windows/workspaceWindow";
 import {
   resolveStandaloneAgentWindowContentWidth,
   shouldAnimateStandaloneAgentWindowResize
@@ -32,9 +37,31 @@ export function registerHostWindowIpc(deps: HostWindowIpcDependencies): void {
   const windowAccess = createDesktopWindowAccess();
   const logger = getDesktopLogger();
 
+  ipcMain.on(
+    desktopIpcChannels.host.window.closeRequestResolved,
+    (event, payload: DesktopHostWindowCloseRequestResolutionPayload) => {
+      const ownerWindow = resolveOwnerWindowFromEvent(event);
+      if (!ownerWindow) {
+        return;
+      }
+      resolveWorkspaceWindowCloseRequest(ownerWindow, payload);
+    }
+  );
+
   registerDesktopIpcHandler(
     desktopIpcChannels.host.window.approveClose,
     (event) => windowAccess.approveClose(resolveOwnerWindowFromEvent(event))
+  );
+
+  registerDesktopIpcHandler(
+    desktopIpcChannels.host.window.setCloseGuardEnabled,
+    (event, input) => {
+      const ownerWindow = resolveOwnerWindowFromEvent(event);
+      if (!ownerWindow) {
+        return;
+      }
+      setWorkspaceWindowCloseGuardEnabled(ownerWindow, input.enabled);
+    }
   );
 
   registerDesktopIpcHandler(

--- a/apps/desktop/src/main/update/appUpdateService.test.ts
+++ b/apps/desktop/src/main/update/appUpdateService.test.ts
@@ -226,6 +226,64 @@ test("createAppUpdateService reports static feed resolution errors", async () =>
   }
 });
 
+test("createAppUpdateService records native check failures", async () => {
+  const driver = createFakeDriver({
+    checkForUpdates: async () => {
+      throw new Error("Update feed connection closed");
+    }
+  });
+  const service = createAppUpdateService(driver, {
+    supportsUpdates: true
+  });
+
+  try {
+    await service.configure({ channel: "stable", policy: "prompt" });
+    await waitFor(
+      () => service.getState().status === "error",
+      "native update check failure did not update service state"
+    );
+
+    assert.equal(service.getState().message, "Update feed connection closed");
+  } finally {
+    service.dispose();
+  }
+});
+
+test("createAppUpdateService records download promise failures", async () => {
+  const listeners: {
+    available?: (info: UpdateInfo) => void;
+  } = {};
+  const driver = createFakeDriver({
+    async downloadUpdate() {
+      throw new Error("Differential download connection closed");
+    },
+    onUpdateAvailable(listener) {
+      listeners.available = listener;
+      return noop;
+    }
+  });
+  const service = createAppUpdateService(driver, {
+    supportsUpdates: true
+  });
+
+  try {
+    await service.configure({ channel: "stable", policy: "prompt" });
+    listeners.available?.(createUpdateInfoFixture("1.1.0"));
+
+    await assert.rejects(
+      service.downloadUpdate(),
+      /Differential download connection closed/
+    );
+    assert.equal(service.getState().status, "error");
+    assert.equal(
+      service.getState().message,
+      "Differential download connection closed"
+    );
+  } finally {
+    service.dispose();
+  }
+});
+
 test("createAppUpdateService shares static feed resolution across concurrent checks", async () => {
   const driver = createFakeDriver();
   const deferredFeed = createDeferred<{

--- a/apps/desktop/src/main/update/appUpdateService.ts
+++ b/apps/desktop/src/main/update/appUpdateService.ts
@@ -71,7 +71,7 @@ interface AppUpdateDriver {
 }
 
 export interface AppUpdateService {
-  checkForUpdates(): Promise<AppUpdateState>;
+  checkForUpdates(reason?: string): Promise<AppUpdateState>;
   configure(input: ConfigureAppUpdatesInput): Promise<AppUpdateState>;
   dispose(): void;
   downloadUpdate(): Promise<AppUpdateState>;
@@ -425,6 +425,14 @@ export function createAppUpdateService(
     });
   };
 
+  const applyUpdaterErrorIfNeeded = (error: Error): void => {
+    const message = normalizeMessage(error);
+    if (state.status === "error" && state.message === message) {
+      return;
+    }
+    applyUpdaterError(error);
+  };
+
   const resetConfiguredState = (
     status: AppUpdateStatus,
     message: string | null = null
@@ -527,28 +535,37 @@ export function createAppUpdateService(
       });
     }),
     resolvedDriver.onError((error) => {
-      applyUpdaterError(error);
+      applyUpdaterErrorIfNeeded(error);
       quitAndInstallPending = false;
     })
   ];
 
   service = {
-    async checkForUpdates() {
+    async checkForUpdates(reason = "manual") {
       assertUpdaterAccess();
       if (
         !supportsUpdates ||
         state.policy === "off" ||
         state.status === "downloaded"
       ) {
+        getDesktopLogger().debug?.("application update check skipped", {
+          reason,
+          status: state.status,
+          supports_updates: supportsUpdates,
+          policy: state.policy
+        });
         return state;
       }
 
       if (activeCheckPromise) {
+        getDesktopLogger().debug?.("application update check joined", {
+          reason
+        });
         await activeCheckPromise;
         return state;
       }
 
-      activeCheckPromise = runStaticFeedUpdateCheck().finally(() => {
+      activeCheckPromise = runStaticFeedUpdateCheck(reason).finally(() => {
         activeCheckPromise = null;
       });
       await activeCheckPromise;
@@ -630,7 +647,7 @@ export function createAppUpdateService(
 
       preserveAvailableStateDuringCheck = true;
       try {
-        await service.checkForUpdates();
+        await service.checkForUpdates("download");
       } finally {
         preserveAvailableStateDuringCheck = false;
       }
@@ -638,9 +655,29 @@ export function createAppUpdateService(
         return state;
       }
 
-      activeDownloadPromise = resolvedDriver.downloadUpdate().finally(() => {
-        activeDownloadPromise = null;
+      getDesktopLogger().info("application update download started", {
+        channel: state.channel,
+        latest_version: state.latestVersion,
+        policy: state.policy
       });
+      activeDownloadPromise = resolvedDriver
+        .downloadUpdate()
+        .catch((error) => {
+          const updateError =
+            error instanceof Error
+              ? error
+              : new Error(formatErrorDetail(error));
+          applyUpdaterErrorIfNeeded(updateError);
+          throw updateError;
+        })
+        .finally(() => {
+          getDesktopLogger().info("application update download finished", {
+            channel: state.channel,
+            latest_version: state.latestVersion,
+            status: state.status
+          });
+          activeDownloadPromise = null;
+        });
       await activeDownloadPromise;
       return state;
     },
@@ -698,7 +735,7 @@ export function createAppUpdateService(
   };
 
   const runBackgroundCheck = (reason: string): void => {
-    void service.checkForUpdates().catch((error) => {
+    void service.checkForUpdates(reason).catch((error) => {
       getDesktopLogger().warn("background application update check failed", {
         error: formatErrorDetail(error),
         reason
@@ -706,7 +743,12 @@ export function createAppUpdateService(
     });
   };
 
-  const runStaticFeedUpdateCheck = async (): Promise<void> => {
+  const runStaticFeedUpdateCheck = async (reason: string): Promise<void> => {
+    getDesktopLogger().info("application update check started", {
+      channel: state.channel,
+      policy: state.policy,
+      reason
+    });
     try {
       if (releaseFeedResolver) {
         const feed = await releaseFeedResolver({ channel: state.channel });
@@ -718,14 +760,20 @@ export function createAppUpdateService(
           version: feed.version
         });
       }
+
+      await resolvedDriver.checkForUpdates();
+      getDesktopLogger().info("application update check finished", {
+        channel: state.channel,
+        latest_version: state.latestVersion,
+        reason,
+        status: state.status
+      });
     } catch (error) {
       const updateError =
         error instanceof Error ? error : new Error(formatErrorDetail(error));
-      applyUpdaterError(updateError);
+      applyUpdaterErrorIfNeeded(updateError);
       throw updateError;
     }
-
-    await resolvedDriver.checkForUpdates();
   };
 
   return service;

--- a/apps/desktop/src/main/windows/workspaceWindow.ts
+++ b/apps/desktop/src/main/windows/workspaceWindow.ts
@@ -25,6 +25,7 @@ import {
   desktopIpcChannels,
   type DesktopHostWindowCloseRequestPayload
 } from "../../shared/contracts/ipc";
+import { randomUUID } from "node:crypto";
 import { installWorkspaceWindowDevelopmentReloadShortcut } from "./workspaceWindowReload.ts";
 import { resolvePackagedWorkspaceRendererIndexPath } from "./workspaceWindowPaths.ts";
 import { createPrimaryWindowAnalyticsClaim } from "./primaryWindowAnalyticsClaim.ts";
@@ -54,6 +55,11 @@ export interface CreateWorkspaceWindowOptions {
 }
 
 const workspaceWindows = new WorkspaceWindowRegistry<BrowserWindow>();
+const workspaceWindowCloseGuardEnabled = new WeakSet<BrowserWindow>();
+const pendingWorkspaceWindowCloseRequests = new WeakMap<
+  BrowserWindow,
+  string
+>();
 // DAU/PV belongs to the first workspace renderer for the lifetime of this main
 // process. Do not derive this from current registry membership: closing the
 // owner must not let a later window report another process-level open/pageview.
@@ -239,7 +245,29 @@ export function createWorkspaceWindow(
     kind: windowKind,
     workspaceID: options.workspaceID
   });
+  workspaceWindow.on("close", (event) => {
+    if (
+      process.platform !== "win32" ||
+      !workspaceWindowCloseGuardEnabled.has(workspaceWindow)
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    if (pendingWorkspaceWindowCloseRequests.has(workspaceWindow)) {
+      return;
+    }
+
+    const requestId = randomUUID();
+    pendingWorkspaceWindowCloseRequests.set(workspaceWindow, requestId);
+    sendWorkspaceWindowCloseRequest(workspaceWindow, {
+      reason: "window-close",
+      requestId
+    });
+  });
   workspaceWindow.once("closed", () => {
+    workspaceWindowCloseGuardEnabled.delete(workspaceWindow);
+    pendingWorkspaceWindowCloseRequests.delete(workspaceWindow);
     workspaceWindows.unregister(workspaceWindow);
   });
 
@@ -307,6 +335,35 @@ export function createWorkspaceWindow(
   }
 
   return workspaceWindow;
+}
+
+export function setWorkspaceWindowCloseGuardEnabled(
+  workspaceWindow: BrowserWindow,
+  enabled: boolean
+): void {
+  if (enabled) {
+    workspaceWindowCloseGuardEnabled.add(workspaceWindow);
+    return;
+  }
+
+  workspaceWindowCloseGuardEnabled.delete(workspaceWindow);
+  pendingWorkspaceWindowCloseRequests.delete(workspaceWindow);
+}
+
+export function resolveWorkspaceWindowCloseRequest(
+  workspaceWindow: BrowserWindow,
+  input: { outcome: "approved" | "blocked"; requestId: string }
+): void {
+  if (
+    pendingWorkspaceWindowCloseRequests.get(workspaceWindow) !== input.requestId
+  ) {
+    return;
+  }
+
+  pendingWorkspaceWindowCloseRequests.delete(workspaceWindow);
+  if (input.outcome === "approved" && !workspaceWindow.isDestroyed()) {
+    workspaceWindow.destroy();
+  }
 }
 
 export function getWorkspaceWindowKind(

--- a/apps/desktop/src/main/windows/workspaceWindow.ts
+++ b/apps/desktop/src/main/windows/workspaceWindow.ts
@@ -36,6 +36,7 @@ import {
 } from "./standaloneAgentWindowBounds.ts";
 import { WorkspaceWindowRegistry } from "./workspaceWindowRegistry.ts";
 import { resolveWorkspaceWindowChromeOptions } from "./workspaceWindowChrome.ts";
+import { supportsWorkspaceWindowCloseGuard } from "./workspaceWindowCloseGuard.ts";
 
 export const workspaceAppBrowserPartitionPrefix = "persist:tutti-app:";
 
@@ -247,7 +248,7 @@ export function createWorkspaceWindow(
   });
   workspaceWindow.on("close", (event) => {
     if (
-      process.platform !== "win32" ||
+      !supportsWorkspaceWindowCloseGuard(process.platform) ||
       !workspaceWindowCloseGuardEnabled.has(workspaceWindow)
     ) {
       return;

--- a/apps/desktop/src/main/windows/workspaceWindowCloseGuard.test.ts
+++ b/apps/desktop/src/main/windows/workspaceWindowCloseGuard.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { supportsWorkspaceWindowCloseGuard } from "./workspaceWindowCloseGuard.ts";
+
+test("workspace window close guard supports native Windows and macOS closes", () => {
+  assert.equal(supportsWorkspaceWindowCloseGuard("win32"), true);
+  assert.equal(supportsWorkspaceWindowCloseGuard("darwin"), true);
+});
+
+test("workspace window close guard does not change Linux behavior", () => {
+  assert.equal(supportsWorkspaceWindowCloseGuard("linux"), false);
+});

--- a/apps/desktop/src/main/windows/workspaceWindowCloseGuard.ts
+++ b/apps/desktop/src/main/windows/workspaceWindowCloseGuard.ts
@@ -1,0 +1,5 @@
+export function supportsWorkspaceWindowCloseGuard(
+  platform: NodeJS.Platform
+): boolean {
+  return platform === "darwin" || platform === "win32";
+}

--- a/apps/desktop/src/preload/api/host.ts
+++ b/apps/desktop/src/preload/api/host.ts
@@ -187,6 +187,12 @@ export function createHostDesktopApi(): DesktopHostApi {
       approveClose(): Promise<void> {
         return invokeDesktopApi(desktopIpcChannels.host.window.approveClose);
       },
+      setCloseGuardEnabled(enabled: boolean): Promise<void> {
+        return invokeDesktopApi(
+          desktopIpcChannels.host.window.setCloseGuardEnabled,
+          { enabled }
+        );
+      },
       capturePreview(input): Promise<string | null> {
         return invokeDesktopApi(
           desktopIpcChannels.host.window.capturePreview,

--- a/apps/desktop/src/preload/types.ts
+++ b/apps/desktop/src/preload/types.ts
@@ -178,6 +178,7 @@ export interface DesktopHostNotificationsApi {
 
 export interface DesktopHostWindowApi {
   approveClose(): Promise<void>;
+  setCloseGuardEnabled(enabled: boolean): Promise<void>;
   capturePreview(
     input: DesktopHostWindowCapturePreviewInput
   ): Promise<string | null>;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
@@ -269,6 +269,10 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
     return this.dependencies.hostWindowApi.approveClose();
   }
 
+  setWindowCloseGuardEnabled(enabled: boolean): Promise<void> {
+    return this.dependencies.hostWindowApi.setCloseGuardEnabled(enabled);
+  }
+
   onWindowCloseRequest(
     listener: Parameters<
       IWorkspaceWorkbenchHostService["onWindowCloseRequest"]

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchHostService.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchHostService.interface.ts
@@ -169,6 +169,7 @@ export interface IWorkspaceWorkbenchHostService {
   readonly dockRetention: WorkspaceDockRetentionService;
 
   approveWindowClose(): Promise<void>;
+  setWindowCloseGuardEnabled(enabled: boolean): Promise<void>;
   openHostSession(workspaceId: string): WorkspaceWorkbenchHostSessionBinding;
   createWorkspaceAppExternalFileReferenceAdapter(
     workspaceId: string

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAgentMessageCenterAction.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAgentMessageCenterAction.tsx
@@ -55,11 +55,13 @@ const MESSAGE_CENTER_SUMMARY_MESSAGE_LIMIT = 20;
 const MESSAGE_CENTER_SUMMARY_PREFETCH_ITEM_LIMIT = 12;
 const MESSAGE_CENTER_VISIBLE_HISTORY_MS = 7 * 24 * 60 * 60 * 1000;
 export function WorkspaceAgentMessageCenterAction({
+  drawerTopInsetPx,
   launchNode,
   open,
   setOpen,
   workspace
 }: {
+  drawerTopInsetPx?: number;
   launchNode?: WorkbenchHostChromeRenderContext["launchNode"];
   open: boolean;
   setOpen: (nextOpen: boolean) => void;
@@ -435,6 +437,7 @@ export function WorkspaceAgentMessageCenterAction({
         open={open}
         model={model}
         highlightedItemId={highlightedMessageCenterItemId}
+        drawerTopInsetPx={drawerTopInsetPx}
         onClose={closeMessageCenter}
         onHighlightedItemSettled={handleHighlightedMessageCenterItemSettled}
         onLinkAction={handleLinkAction}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceChrome.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceChrome.tsx
@@ -37,6 +37,7 @@ const WORKSPACE_CHROME_MAC_TRAFFIC_LIGHT_GUTTER_PX = 64;
 const WORKSPACE_CHROME_MAC_TRAFFIC_LIGHT_RESERVED_WIDTH_PX =
   WORKSPACE_CHROME_MAC_TRAFFIC_LIGHT_INSET_PX +
   WORKSPACE_CHROME_MAC_TRAFFIC_LIGHT_GUTTER_PX;
+const WORKSPACE_CHROME_TITLEBAR_HEIGHT_PX = 52;
 
 export function WorkspaceChrome({
   appName,
@@ -171,6 +172,9 @@ export function WorkspaceChrome({
           {headerSlot ? <div className="min-w-0">{headerSlot}</div> : null}
           <WorkspaceFeedbackGroupPopover />
           <WorkspaceAgentMessageCenterAction
+            drawerTopInsetPx={
+              isWindows ? WORKSPACE_CHROME_TITLEBAR_HEIGHT_PX : undefined
+            }
             launchNode={launchNode}
             open={messageCenterOpen}
             setOpen={setMessageCenterOpen}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceWorkbenchShellRuntime.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceWorkbenchShellRuntime.tsx
@@ -440,20 +440,41 @@ export function useWorkspaceWorkbenchShellRuntime({
       return;
     }
 
-    return workbenchHostService.onWindowCloseRequest((payload) => {
-      void shellRuntimeController
-        .requestWindowClose({
-          reason: payload.reason
-        })
-        .then((outcome) => {
-          if (payload.requestId) {
-            workbenchHostService.resolveWindowCloseRequest({
-              outcome,
-              requestId: payload.requestId
-            });
-          }
-        });
+    const disposeCloseRequestListener =
+      workbenchHostService.onWindowCloseRequest((payload) => {
+        void shellRuntimeController
+          .requestWindowClose({
+            reason: payload.reason
+          })
+          .then((outcome) => {
+            if (payload.requestId) {
+              workbenchHostService.resolveWindowCloseRequest({
+                outcome,
+                requestId: payload.requestId
+              });
+            }
+          })
+          .catch(() => {
+            if (payload.requestId) {
+              workbenchHostService.resolveWindowCloseRequest({
+                outcome: "blocked",
+                requestId: payload.requestId
+              });
+            }
+          });
+      });
+
+    void workbenchHostService.setWindowCloseGuardEnabled(true).catch(() => {
+      // Older preload clients do not expose the native close interception
+      // handshake. The renderer-side guard remains usable in that case.
     });
+
+    return () => {
+      disposeCloseRequestListener();
+      void workbenchHostService
+        .setWindowCloseGuardEnabled(false)
+        .catch(() => undefined);
+    };
   }, [enableWindowCloseGuard, shellRuntimeController, workbenchHostService]);
 
   const handleWorkbenchHostReady = useCallback(

--- a/apps/desktop/src/renderer/src/platform/desktop/web/createWebDesktopApi.ts
+++ b/apps/desktop/src/renderer/src/platform/desktop/web/createWebDesktopApi.ts
@@ -354,6 +354,9 @@ function createWebHostApi(): DesktopHostApi {
         window.close();
         return Promise.resolve();
       },
+      setCloseGuardEnabled() {
+        return Promise.resolve();
+      },
       capturePreview() {
         return Promise.resolve(null);
       },

--- a/apps/desktop/src/shared/contracts/ipc.ts
+++ b/apps/desktop/src/shared/contracts/ipc.ts
@@ -292,6 +292,7 @@ export const desktopIpcChannels = {
     },
     window: {
       approveClose: "host:window:approveClose",
+      setCloseGuardEnabled: "host:window:setCloseGuardEnabled",
       capturePreview: "host:window:capturePreview",
       capturePreviewImages: "host:window:capturePreviewImages",
       closeRequest: "host:window:closeRequest",
@@ -353,6 +354,10 @@ export interface DesktopHostWindowResizeContentWidthResult {
 export interface DesktopHostWindowCloseRequestPayload {
   requestId?: string;
   reason: "quit" | "window-close";
+}
+
+export interface DesktopHostWindowCloseGuardInput {
+  enabled: boolean;
 }
 
 export interface DesktopHostOpenAgentWindowInput {
@@ -1286,6 +1291,8 @@ export interface DesktopInvokePayloadByChannel {
   [desktopIpcChannels.host.files.copyFilesToClipboard]: string[];
   [desktopIpcChannels.host.window.approveClose]: undefined;
   [desktopIpcChannels.host.window
+    .setCloseGuardEnabled]: DesktopHostWindowCloseGuardInput;
+  [desktopIpcChannels.host.window
     .capturePreview]: DesktopHostWindowCapturePreviewInput;
   [desktopIpcChannels.host.window
     .capturePreviewImages]: DesktopHostWindowCapturePreviewInput;
@@ -1486,6 +1493,7 @@ export interface DesktopInvokeResultByChannel {
   [desktopIpcChannels.host.files.copyImageToClipboard]: void;
   [desktopIpcChannels.host.files.copyFilesToClipboard]: void;
   [desktopIpcChannels.host.window.approveClose]: void;
+  [desktopIpcChannels.host.window.setCloseGuardEnabled]: void;
   [desktopIpcChannels.host.window.capturePreview]: string | null;
   [desktopIpcChannels.host.window
     .capturePreviewImages]: DesktopHostWindowPreviewImages | null;

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.spec.ts
@@ -1166,6 +1166,42 @@ describe("agentGuiConversationModel", () => {
     ]);
   });
 
+  it("keeps an optimistic prompt after a durable assistant tail during merge", () => {
+    const merged = mergeAgentGUITimelineItems(
+      [
+        timelineItem({
+          id: 8,
+          eventId: "assistant-tail",
+          itemType: "message.assistant",
+          role: "assistant",
+          content: "Assistant tail",
+          occurredAtUnixMs: 200,
+          seq: 8
+        })
+      ],
+      [
+        timelineItem({
+          id: -1,
+          eventId: "client-submit:user:submit-1",
+          itemType: "message.user",
+          role: "user",
+          content: "New ask",
+          payload: {
+            __agentGuiOptimisticPrompt: true
+          },
+          occurredAtUnixMs: 100,
+          createdAtUnixMs: 100,
+          seq: 0
+        })
+      ]
+    );
+
+    expect(merged.map((item) => item.eventId)).toEqual([
+      "assistant-tail",
+      "client-submit:user:submit-1"
+    ]);
+  });
+
   it("keeps distinct user prompts from different turns when event ids are missing but seq matches", () => {
     expect(
       mergeAgentGUITimelineItems(

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.tsx
@@ -81,6 +81,7 @@ export interface WorkspaceAgentMessageCenterPanelProps {
   model: WorkspaceAgentMessageCenterModel;
   highlightedItemId?: string | null;
   portalContainer?: HTMLElement | null;
+  drawerTopInsetPx?: number;
   presentation?: WorkspaceAgentMessageCenterPanelPresentation;
   onClose: () => void;
   onHighlightedItemSettled?: (itemId: string) => void;
@@ -112,6 +113,7 @@ export const WorkspaceAgentMessageCenterPanel = memo(
     model,
     highlightedItemId = null,
     portalContainer = null,
+    drawerTopInsetPx,
     presentation = "drawer",
     onClose,
     onHighlightedItemSettled,
@@ -132,6 +134,7 @@ export const WorkspaceAgentMessageCenterPanel = memo(
           model={model}
           highlightedItemId={highlightedItemId}
           portalContainer={portalContainer}
+          drawerTopInsetPx={drawerTopInsetPx}
           presentation={presentation}
           onClose={onClose}
           onHighlightedItemSettled={onHighlightedItemSettled}
@@ -151,6 +154,7 @@ function WorkspaceAgentMessageCenterPanelContent({
   model,
   highlightedItemId = null,
   portalContainer = null,
+  drawerTopInsetPx,
   presentation = "drawer",
   onClose,
   onHighlightedItemSettled,
@@ -674,6 +678,9 @@ function WorkspaceAgentMessageCenterPanelContent({
         data-presentation="drawer"
         data-testid="workspace-agent-message-center"
         portalContainer={portalContainer ?? undefined}
+        style={
+          drawerTopInsetPx === undefined ? undefined : { top: drawerTopInsetPx }
+        }
         showOverlay={false}
         aria-label={t("agentHost.workspaceAgentMessageCenterTitle")}
       >


### PR DESCRIPTION
## 变更概述

- 修正 AgentGUI 乐观用户消息的展示顺序，确保已发送的用户消息位于 durable assistant tail 之后，并补充 merge 回归测试。
- 补充桌面端更新检测和下载 Promise 的失败状态、原因日志与错误状态收敛。
- Windows 下让消息中心 Drawer 避开 52px 原生标题栏。
- 将 Windows 和 macOS 原生窗口 close 事件接入既有 renderer close guard，覆盖 preload、IPC contract、main 和 renderer 链路。

## 根因

- 乐观消息排序只按时间/序号，未把本地 optimistic prompt 作为尾部消息处理。
- 更新检查和下载存在异步失败未稳定进入状态机的问题。
- Drawer 使用全窗口顶定位，未考虑 Windows 原生标题栏。
- Windows/macOS 原生 close 事件未经过 renderer 的未保存变更确认链路。

## 验证

- AgentGUI targeted Vitest：73 tests passed。
- Desktop update tests：18 tests passed。
- Desktop close guard platform tests：2 tests passed。
- Renderer close coordinator/request controller tests：12 tests passed。
- pnpm --filter @tutti-os/agent-gui typecheck：passed。
- pnpm --filter @tutti-os/desktop typecheck：passed。
- pnpm exec oxfmt --check（本次改动文件）：passed。
- electron-vite build 在当前 Windows 环境超时；但 main/preload 产物已生成，并确认 out/main/index.js 包含 macOS close guard。
- 独立桌面开发实例启动成功，日志出现 desktop app ready。
- PR Checks：success。
- Windows Desktop Alpha：仍 in progress。
- Windows E2E：未通过，启动脚本未达到 desktop ready，且未生成 desktop log；判断为当前环境/launcher 阻塞，详见交付说明。
- macOS 真机红色关闭按钮验收：当前 Windows 环境无法执行，需在 macOS 实机或 macOS CI 验证。

## Review

已使用独立 Claude subagent 做只读静态 review，无 blocking findings。review 确认 macOS 红色关闭按钮进入现有 IPC/renderer 确认链路，Windows/Linux 无回归，Cmd+Q 未受影响。仅提出额外 main→renderer→main 集成测试建议，属于 non-blocking。

## 风险与回滚

- macOS 原生 close 现在会等待 renderer close guard；依赖 renderer 完成 enable handshake。
- Cmd+Q 应用退出逻辑未修改。
- Linux 和 web API 行为未修改。
- 如需回滚，可回滚本 MR 的新增 macOS close guard 提交；不涉及数据迁移。