### PR TITLE
feat(connector): share control-plane authorization

### DIFF
--- a/docs/architecture/connector-market.md
+++ b/docs/architecture/connector-market.md
@@ -361,6 +361,15 @@ after an earlier Snapshot does not cause permanent polling. WebSocket hints and
 the five-minute calibration both fetch Snapshot; runtime reconcile is
 level-triggered and can safely repeat after restart or an interrupted pass.
 
+Authorization execution is selected from the exact release frozen into the
+durable operation. `managed_stdio` delegates to the local implementation host;
+`remote_streamable_http` delegates to the account control plane through
+`packages/clients/connector-controlplane`. The latter receives account
+authentication only through a host-supplied request authorizer. Neither an API
+key submitted by the user nor the product account session is copied into the
+runtime VM. Remote MCP execution follows the product host's authenticated
+relay, while the VM receives only the non-credential runtime route identity.
+
 ## Event Consistency
 
 Business state and its invalidation event are written to a durable outbox in

--- a/docs/architecture/project-structure.md
+++ b/docs/architecture/project-structure.md
@@ -224,6 +224,15 @@ Client packages provide domain-specific access helpers for consumers.
 
 They should remain focused, named by responsibility, and free of hidden business rules.
 
+`packages/clients/connector-controlplane` is the shared Go protocol client for
+account-scoped Connector authorization. It owns authorization session,
+snapshot, and realtime-event decoding plus bounded HTTPS transport. A product
+host supplies the API prefix, HTTP client, and per-account request authorizer;
+the package never stores account cookies, chooses an environment, or sends
+credentials to a runtime VM. `packages/connector/host` selects this client only
+for `remote_streamable_http` releases, while `managed_stdio` authorization
+stays with the injected local implementation host.
+
 `packages/clients/device-authority-go` is the shared Go client boundary for the
 Device Authority owner lifecycle across Tutti and TSH. The initial package is a
 staged cross-repository extraction from TSH: publish the stable module first,

--- a/go.work
+++ b/go.work
@@ -8,6 +8,8 @@ use ./packages/events/stream-go
 
 use ./packages/clients/device-authority-go
 
+use ./packages/clients/connector-controlplane
+
 use ./packages/analytics/reporter-go
 
 use ./packages/device-link

--- a/packages/clients/connector-controlplane/README.md
+++ b/packages/clients/connector-controlplane/README.md
@@ -1,0 +1,51 @@
+# Connector Control Plane Go Client
+
+`connector-controlplane` owns the shared account-scoped Connector
+authorization wire client used by Tutti and TSH.
+
+It owns:
+
+- authorization session start, observation, secret completion, and disconnect;
+- authoritative account authorization snapshots;
+- the `connector.authorization.changed` realtime event protocol;
+- bounded HTTP responses, safe redirect validation, and clearing mutable secret
+  buffers after submission.
+
+It does not own account cookies, bearer tokens, user or device headers,
+deployment endpoint selection, credential persistence, runtime reconciliation,
+or product retry policy. Hosts inject those concerns through request-authorizer
+callbacks and explicit base URL/API prefix configuration. Provider credentials
+must never be logged or transferred to a Connector VM.
+
+## Usage
+
+```go
+client, err := connectorcontrolplane.NewAuthorizationClient(
+    connectorcontrolplane.AuthorizationClientConfig{
+        BaseURL:    "https://api.example.com",
+        APIPrefix: "/api/desktop/v1",
+        HTTPClient: productHTTPClient,
+        AuthorizeAccountRequest: func(request *http.Request, accountID string) error {
+            addCurrentAccountSession(request, accountID)
+            return nil
+        },
+    },
+)
+```
+
+The client implements the Connector Host `AuthorizationProvider`,
+`AuthorizationObserver`, and `AuthorizationSnapshotSource` ports. Products
+compose it with `host.NewImplementationAuthorizationRouter`: remote HTTP
+Connectors use this client while managed stdio Connectors keep their
+implementation-owned credential broker.
+
+## Validation and releases
+
+Run:
+
+```sh
+go test -race ./...
+```
+
+The module participates in Tutti's shared stable `packages/**` Go release
+cohort. Cross-repository consumers must use a released module tag.

--- a/packages/clients/connector-controlplane/authorization_client.go
+++ b/packages/clients/connector-controlplane/authorization_client.go
@@ -18,19 +18,21 @@ import (
 const connectorAuthorizationResponseLimit = 4 << 20
 
 type AuthorizationClientConfig struct {
-	BaseURL                 string
-	APIPrefix               string
-	HTTPClient              *http.Client
-	AuthorizeAccountRequest func(*http.Request, string) error
+	BaseURL                    string
+	APIPrefix                  string
+	HTTPClient                 *http.Client
+	AuthorizeAccountRequest    func(*http.Request, string) error
+	NotifyAuthorizationChanged func()
 }
 
 // AuthorizationClient adapts the Tutti account-scoped Connector
 // authorization control plane to the provider-neutral market host contract.
 type AuthorizationClient struct {
-	baseURL                 *url.URL
-	apiPrefix               string
-	httpClient              *http.Client
-	authorizeAccountRequest func(*http.Request, string) error
+	baseURL                    *url.URL
+	apiPrefix                  string
+	httpClient                 *http.Client
+	authorizeAccountRequest    func(*http.Request, string) error
+	notifyAuthorizationChanged func()
 }
 
 func NewAuthorizationClient(config AuthorizationClientConfig) (*AuthorizationClient, error) {
@@ -51,7 +53,8 @@ func NewAuthorizationClient(config AuthorizationClientConfig) (*AuthorizationCli
 	apiPrefix = "/" + strings.Trim(apiPrefix, "/")
 	return &AuthorizationClient{
 		baseURL: baseURL, apiPrefix: apiPrefix, httpClient: &httpClient,
-		authorizeAccountRequest: config.AuthorizeAccountRequest,
+		authorizeAccountRequest:    config.AuthorizeAccountRequest,
+		notifyAuthorizationChanged: config.NotifyAuthorizationChanged,
 	}, nil
 }
 
@@ -111,6 +114,7 @@ func (client *AuthorizationClient) Begin(ctx context.Context, request market.Aut
 	if err != nil {
 		return market.AuthorizationSession{}, err
 	}
+	client.notifyChanged()
 	if strings.TrimSpace(response.Session.SessionID) == "" || strings.TrimSpace(response.Session.ConnectorRevision) != connectorVersion {
 		return market.AuthorizationSession{}, errors.New("connector authorization start returned an invalid session")
 	}
@@ -158,6 +162,7 @@ func (client *AuthorizationClient) Begin(ctx context.Context, request market.Aut
 		if err := client.doJSONForAccount(ctx, request.Scope.AccountID, http.MethodPost, path, nil, map[string]any{"secret": map[string]string{"secret": string(request.Secret)}}, &completed); err != nil {
 			return market.AuthorizationSession{}, err
 		}
+		client.notifyChanged()
 		if completed.Session.SessionID != response.Session.SessionID || strings.TrimSpace(completed.Session.ConnectorRevision) != connectorVersion || !authorizationSessionSucceeded(completed.Session.Status) {
 			return market.AuthorizationSession{}, errors.New("connector secret authorization did not complete")
 		}
@@ -174,8 +179,18 @@ func (client *AuthorizationClient) Begin(ctx context.Context, request market.Aut
 
 func (client *AuthorizationClient) Disconnect(ctx context.Context, request market.AuthorizationDisconnectRequest) error {
 	connectorID := strings.TrimSpace(request.Connector.Key)
-	return client.doJSONForAccount(ctx, request.Scope.AccountID, http.MethodDelete,
-		"/connectors/"+url.PathEscape(connectorID)+"/authorization", nil, nil, nil)
+	if err := client.doJSONForAccount(ctx, request.Scope.AccountID, http.MethodDelete,
+		"/connectors/"+url.PathEscape(connectorID)+"/authorization", nil, nil, nil); err != nil {
+		return err
+	}
+	client.notifyChanged()
+	return nil
+}
+
+func (client *AuthorizationClient) notifyChanged() {
+	if client != nil && client.notifyAuthorizationChanged != nil {
+		client.notifyAuthorizationChanged()
+	}
 }
 
 func (client *AuthorizationClient) Observe(ctx context.Context, request market.AuthorizationObserveRequest) (market.AuthorizationObservation, error) {

--- a/packages/clients/connector-controlplane/authorization_client.go
+++ b/packages/clients/connector-controlplane/authorization_client.go
@@ -1,4 +1,4 @@
-package connectormarket
+package connectorcontrolplane
 
 import (
 	"bytes"
@@ -17,23 +17,26 @@ import (
 
 const connectorAuthorizationResponseLimit = 4 << 20
 
-type ConnectorAuthorizationClientConfig struct {
+type AuthorizationClientConfig struct {
 	BaseURL                 string
+	APIPrefix               string
 	HTTPClient              *http.Client
 	AuthorizeAccountRequest func(*http.Request, string) error
 }
 
-// ConnectorAuthorizationClient adapts the Tutti account-scoped Connector
+// AuthorizationClient adapts the Tutti account-scoped Connector
 // authorization control plane to the provider-neutral market host contract.
-type ConnectorAuthorizationClient struct {
+type AuthorizationClient struct {
 	baseURL                 *url.URL
+	apiPrefix               string
 	httpClient              *http.Client
 	authorizeAccountRequest func(*http.Request, string) error
 }
 
-func NewConnectorAuthorizationClient(config ConnectorAuthorizationClientConfig) (*ConnectorAuthorizationClient, error) {
+func NewAuthorizationClient(config AuthorizationClientConfig) (*AuthorizationClient, error) {
 	baseURL, err := url.Parse(strings.TrimSpace(config.BaseURL))
-	if err != nil || baseURL.Host == "" || (baseURL.Scheme != "https" && (baseURL.Scheme != "http" || !isLoopbackConnectorAuthorizationHost(baseURL.Hostname()))) {
+	if err != nil || baseURL.Host == "" || baseURL.User != nil || baseURL.RawQuery != "" || baseURL.Fragment != "" ||
+		(baseURL.Scheme != "https" && (baseURL.Scheme != "http" || !isLoopbackConnectorAuthorizationHost(baseURL.Hostname()))) {
 		return nil, errors.New("connector authorization base URL must use https")
 	}
 	if config.HTTPClient == nil || config.AuthorizeAccountRequest == nil {
@@ -41,10 +44,18 @@ func NewConnectorAuthorizationClient(config ConnectorAuthorizationClientConfig) 
 	}
 	httpClient := *config.HTTPClient
 	httpClient.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
-	return &ConnectorAuthorizationClient{baseURL: baseURL, httpClient: &httpClient, authorizeAccountRequest: config.AuthorizeAccountRequest}, nil
+	apiPrefix := strings.TrimSpace(config.APIPrefix)
+	if apiPrefix == "" || strings.ContainsAny(apiPrefix, "?#") {
+		return nil, errors.New("connector authorization API prefix is required")
+	}
+	apiPrefix = "/" + strings.Trim(apiPrefix, "/")
+	return &AuthorizationClient{
+		baseURL: baseURL, apiPrefix: apiPrefix, httpClient: &httpClient,
+		authorizeAccountRequest: config.AuthorizeAccountRequest,
+	}, nil
 }
 
-func (client *ConnectorAuthorizationClient) AuthorizationSnapshot(ctx context.Context, accountID string) (market.AuthorizationSnapshot, error) {
+func (client *AuthorizationClient) AuthorizationSnapshot(ctx context.Context, accountID string) (market.AuthorizationSnapshot, error) {
 	accountID = strings.TrimSpace(accountID)
 	if accountID == "" || client.authorizeAccountRequest == nil {
 		return market.AuthorizationSnapshot{}, errors.New("connector authorization snapshot requires an account-bound authorizer")
@@ -59,7 +70,7 @@ func (client *ConnectorAuthorizationClient) AuthorizationSnapshot(ctx context.Co
 			ConnectionVersion jsonUint64 `json:"connectionVersion"`
 		} `json:"connectors"`
 	}
-	if err := client.doJSONWithAuthorizer(ctx, http.MethodGet, "/v1/connector-authorizations/snapshot", nil, nil, &response, func(request *http.Request) error {
+	if err := client.doJSONWithAuthorizer(ctx, http.MethodGet, "/connector-authorizations/snapshot", nil, nil, &response, func(request *http.Request) error {
 		return client.authorizeAccountRequest(request, accountID)
 	}); err != nil {
 		return market.AuthorizationSnapshot{}, err
@@ -88,12 +99,12 @@ func (client *ConnectorAuthorizationClient) AuthorizationSnapshot(ctx context.Co
 	return snapshot, nil
 }
 
-func (client *ConnectorAuthorizationClient) Begin(ctx context.Context, request market.AuthorizationStartRequest) (market.AuthorizationSession, error) {
+func (client *AuthorizationClient) Begin(ctx context.Context, request market.AuthorizationStartRequest) (market.AuthorizationSession, error) {
 	defer clear(request.Secret)
 	connectorID := strings.TrimSpace(request.Connector.Key)
 	connectorVersion := strings.TrimSpace(request.Release.Version)
 	var response connectorAuthorizationSessionReply
-	err := client.doJSONForAccount(ctx, request.Scope.AccountID, http.MethodPost, "/v1/connectors/"+url.PathEscape(connectorID)+"/authorization-sessions", nil, map[string]any{
+	err := client.doJSONForAccount(ctx, request.Scope.AccountID, http.MethodPost, "/connectors/"+url.PathEscape(connectorID)+"/authorization-sessions", nil, map[string]any{
 		"clientRequestId":  strings.TrimSpace(request.ClientRequestID),
 		"connectorVersion": connectorVersion,
 	}, &response)
@@ -142,7 +153,7 @@ func (client *ConnectorAuthorizationClient) Begin(ctx context.Context, request m
 		if len(request.Secret) == 0 || len(request.Secret) > 16384 {
 			return market.AuthorizationSession{}, errors.New("connector authorization requires a valid secret")
 		}
-		path := "/v1/connector-authorization-sessions/" + url.PathEscape(response.Session.SessionID) + "/complete"
+		path := "/connector-authorization-sessions/" + url.PathEscape(response.Session.SessionID) + "/complete"
 		var completed connectorAuthorizationSessionReply
 		if err := client.doJSONForAccount(ctx, request.Scope.AccountID, http.MethodPost, path, nil, map[string]any{"secret": map[string]string{"secret": string(request.Secret)}}, &completed); err != nil {
 			return market.AuthorizationSession{}, err
@@ -161,13 +172,13 @@ func (client *ConnectorAuthorizationClient) Begin(ctx context.Context, request m
 	return session, nil
 }
 
-func (client *ConnectorAuthorizationClient) Disconnect(ctx context.Context, request market.AuthorizationDisconnectRequest) error {
+func (client *AuthorizationClient) Disconnect(ctx context.Context, request market.AuthorizationDisconnectRequest) error {
 	connectorID := strings.TrimSpace(request.Connector.Key)
 	return client.doJSONForAccount(ctx, request.Scope.AccountID, http.MethodDelete,
-		"/v1/connectors/"+url.PathEscape(connectorID)+"/authorization", nil, nil, nil)
+		"/connectors/"+url.PathEscape(connectorID)+"/authorization", nil, nil, nil)
 }
 
-func (client *ConnectorAuthorizationClient) Observe(ctx context.Context, request market.AuthorizationObserveRequest) (market.AuthorizationObservation, error) {
+func (client *AuthorizationClient) Observe(ctx context.Context, request market.AuthorizationObserveRequest) (market.AuthorizationObservation, error) {
 	var response struct {
 		Session struct {
 			Status             string `json:"status"`
@@ -175,7 +186,7 @@ func (client *ConnectorAuthorizationClient) Observe(ctx context.Context, request
 			ResultConnectionID string `json:"resultConnectionId"`
 		} `json:"session"`
 	}
-	path := "/v1/connector-authorization-sessions/" + url.PathEscape(strings.TrimSpace(request.Session.SessionID))
+	path := "/connector-authorization-sessions/" + url.PathEscape(strings.TrimSpace(request.Session.SessionID))
 	if err := client.doJSONForAccount(ctx, request.Scope.AccountID, http.MethodGet, path, nil, nil, &response); err != nil {
 		return market.AuthorizationObservation{}, err
 	}
@@ -197,7 +208,7 @@ func (client *ConnectorAuthorizationClient) Observe(ctx context.Context, request
 	}
 }
 
-func (client *ConnectorAuthorizationClient) doJSONForAccount(ctx context.Context, accountID, method, requestPath string, query url.Values, input, output any) error {
+func (client *AuthorizationClient) doJSONForAccount(ctx context.Context, accountID, method, requestPath string, query url.Values, input, output any) error {
 	accountID = strings.TrimSpace(accountID)
 	if accountID == "" {
 		return errors.New("connector authorization request requires an account scope")
@@ -219,8 +230,8 @@ func (value *jsonUint64) UnmarshalJSON(raw []byte) error {
 	return nil
 }
 
-func (client *ConnectorAuthorizationClient) doJSONWithAuthorizer(ctx context.Context, method, requestPath string, query url.Values, input, output any, authorize func(*http.Request) error) error {
-	endpoint, err := url.JoinPath(client.baseURL.String(), requestPath)
+func (client *AuthorizationClient) doJSONWithAuthorizer(ctx context.Context, method, requestPath string, query url.Values, input, output any, authorize func(*http.Request) error) error {
+	endpoint, err := url.JoinPath(client.baseURL.String(), client.apiPrefix, requestPath)
 	if err != nil {
 		return err
 	}
@@ -302,6 +313,6 @@ func isLoopbackConnectorAuthorizationHost(host string) bool {
 	return host == "localhost" || host == "127.0.0.1" || host == "::1"
 }
 
-var _ market.AuthorizationProvider = (*ConnectorAuthorizationClient)(nil)
-var _ market.AuthorizationObserver = (*ConnectorAuthorizationClient)(nil)
-var _ market.AuthorizationSnapshotSource = (*ConnectorAuthorizationClient)(nil)
+var _ market.AuthorizationProvider = (*AuthorizationClient)(nil)
+var _ market.AuthorizationObserver = (*AuthorizationClient)(nil)
+var _ market.AuthorizationSnapshotSource = (*AuthorizationClient)(nil)

--- a/packages/clients/connector-controlplane/authorization_client_test.go
+++ b/packages/clients/connector-controlplane/authorization_client_test.go
@@ -129,6 +129,7 @@ func TestAuthorizationClientAcceptsImmediateSuccessWithoutNextAction(t *testing.
 
 func TestAuthorizationClientSubmitsNativeSecretWithoutPersistingItInSession(t *testing.T) {
 	const token = "user-provided-token"
+	notifications := 0
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		switch request.URL.Path {
 		case "/v1/connectors/mail/authorization-sessions":
@@ -150,7 +151,8 @@ func TestAuthorizationClientSubmitsNativeSecretWithoutPersistingItInSession(t *t
 	defer server.Close()
 	client, err := NewAuthorizationClient(AuthorizationClientConfig{
 		BaseURL: server.URL, APIPrefix: "/v1", HTTPClient: server.Client(),
-		AuthorizeAccountRequest: func(*http.Request, string) error { return nil },
+		AuthorizeAccountRequest:    func(*http.Request, string) error { return nil },
+		NotifyAuthorizationChanged: func() { notifications++ },
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -167,6 +169,9 @@ func TestAuthorizationClientSubmitsNativeSecretWithoutPersistingItInSession(t *t
 	}
 	if result.SessionID != "auth-secret-1" || result.ActionType != "submit_secret" || result.AuthorizationURL != "" || result.ConnectionID != "connection-secret-1" {
 		t.Fatalf("result = %#v", result)
+	}
+	if notifications != 2 {
+		t.Fatalf("authorization change notifications = %d, want 2", notifications)
 	}
 	for i, value := range secret {
 		if value != 0 {

--- a/packages/clients/connector-controlplane/authorization_client_test.go
+++ b/packages/clients/connector-controlplane/authorization_client_test.go
@@ -1,4 +1,4 @@
-package connectormarket
+package connectorcontrolplane
 
 import (
 	"context"
@@ -10,7 +10,7 @@ import (
 	market "github.com/tutti-os/tutti/packages/connector/host"
 )
 
-func TestConnectorAuthorizationClientFetchesAccountSnapshot(t *testing.T) {
+func TestAuthorizationClientFetchesAccountSnapshot(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		if request.URL.Path != "/api/desktop/v1/connector-authorizations/snapshot" {
 			http.NotFound(response, request)
@@ -19,8 +19,8 @@ func TestConnectorAuthorizationClientFetchesAccountSnapshot(t *testing.T) {
 		_, _ = response.Write([]byte(`{"revision":"12","connectors":[{"connectorId":"tencent-docs","connectorVersion":"0.2.0","state":"reauth_required","connectionId":"connection-1","connectionVersion":"4"}]}`))
 	}))
 	defer server.Close()
-	client, err := NewConnectorAuthorizationClient(ConnectorAuthorizationClientConfig{
-		BaseURL: server.URL + "/api/desktop", HTTPClient: server.Client(),
+	client, err := NewAuthorizationClient(AuthorizationClientConfig{
+		BaseURL: server.URL, APIPrefix: "/api/desktop/v1", HTTPClient: server.Client(),
 		AuthorizeAccountRequest: func(_ *http.Request, accountID string) error {
 			if accountID != "account-1" {
 				t.Fatalf("accountID = %q", accountID)
@@ -41,7 +41,7 @@ func TestConnectorAuthorizationClientFetchesAccountSnapshot(t *testing.T) {
 	}
 }
 
-func TestConnectorAuthorizationClientStartsAccountScopedSession(t *testing.T) {
+func TestAuthorizationClientStartsAccountScopedSession(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		if request.Header.Get("Cookie") != "sid=user-session" {
 			t.Fatalf("cookie = %q", request.Header.Get("Cookie"))
@@ -63,8 +63,8 @@ func TestConnectorAuthorizationClientStartsAccountScopedSession(t *testing.T) {
 		}
 	}))
 	defer server.Close()
-	client, err := NewConnectorAuthorizationClient(ConnectorAuthorizationClientConfig{
-		BaseURL: server.URL + "/api/desktop", HTTPClient: server.Client(),
+	client, err := NewAuthorizationClient(AuthorizationClientConfig{
+		BaseURL: server.URL, APIPrefix: "/api/desktop/v1", HTTPClient: server.Client(),
 		AuthorizeAccountRequest: func(request *http.Request, accountID string) error {
 			if accountID != "account-1" {
 				t.Fatalf("accountID = %q", accountID)
@@ -97,7 +97,7 @@ func TestConnectorAuthorizationClientStartsAccountScopedSession(t *testing.T) {
 	}
 }
 
-func TestConnectorAuthorizationClientAcceptsImmediateSuccessWithoutNextAction(t *testing.T) {
+func TestAuthorizationClientAcceptsImmediateSuccessWithoutNextAction(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		if request.URL.Path != "/v1/connectors/tencent-docs/authorization-sessions" {
 			http.NotFound(response, request)
@@ -106,8 +106,8 @@ func TestConnectorAuthorizationClientAcceptsImmediateSuccessWithoutNextAction(t 
 		_, _ = response.Write([]byte(`{"session":{"sessionId":"auth-existing","connectorRevision":"0.2.0","status":"CONNECTOR_AUTHORIZATION_SESSION_STATUS_SUCCEEDED","resultConnectionId":"connection-existing"}}`))
 	}))
 	defer server.Close()
-	client, err := NewConnectorAuthorizationClient(ConnectorAuthorizationClientConfig{
-		BaseURL: server.URL, HTTPClient: server.Client(),
+	client, err := NewAuthorizationClient(AuthorizationClientConfig{
+		BaseURL: server.URL, APIPrefix: "/v1", HTTPClient: server.Client(),
 		AuthorizeAccountRequest: func(*http.Request, string) error { return nil },
 	})
 	if err != nil {
@@ -127,7 +127,7 @@ func TestConnectorAuthorizationClientAcceptsImmediateSuccessWithoutNextAction(t 
 	}
 }
 
-func TestConnectorAuthorizationClientSubmitsNativeSecretWithoutPersistingItInSession(t *testing.T) {
+func TestAuthorizationClientSubmitsNativeSecretWithoutPersistingItInSession(t *testing.T) {
 	const token = "user-provided-token"
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		switch request.URL.Path {
@@ -148,8 +148,8 @@ func TestConnectorAuthorizationClientSubmitsNativeSecretWithoutPersistingItInSes
 		}
 	}))
 	defer server.Close()
-	client, err := NewConnectorAuthorizationClient(ConnectorAuthorizationClientConfig{
-		BaseURL: server.URL, HTTPClient: server.Client(),
+	client, err := NewAuthorizationClient(AuthorizationClientConfig{
+		BaseURL: server.URL, APIPrefix: "/v1", HTTPClient: server.Client(),
 		AuthorizeAccountRequest: func(*http.Request, string) error { return nil },
 	})
 	if err != nil {
@@ -175,7 +175,7 @@ func TestConnectorAuthorizationClientSubmitsNativeSecretWithoutPersistingItInSes
 	}
 }
 
-func TestConnectorAuthorizationClientDisconnectsByConnector(t *testing.T) {
+func TestAuthorizationClientDisconnectsByConnector(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		if request.Method != http.MethodDelete || request.URL.Path != "/v1/connectors/tencent-docs/authorization" {
 			t.Fatalf("request = %s %s", request.Method, request.URL.Path)
@@ -183,8 +183,8 @@ func TestConnectorAuthorizationClientDisconnectsByConnector(t *testing.T) {
 		response.WriteHeader(http.StatusNoContent)
 	}))
 	defer server.Close()
-	client, err := NewConnectorAuthorizationClient(ConnectorAuthorizationClientConfig{
-		BaseURL: server.URL, HTTPClient: server.Client(),
+	client, err := NewAuthorizationClient(AuthorizationClientConfig{
+		BaseURL: server.URL, APIPrefix: "/v1", HTTPClient: server.Client(),
 		AuthorizeAccountRequest: func(*http.Request, string) error { return nil },
 	})
 	if err != nil {
@@ -194,5 +194,22 @@ func TestConnectorAuthorizationClientDisconnectsByConnector(t *testing.T) {
 		Scope: market.OperationScope{AccountID: "account-1"}, Connector: market.Connector{Key: "tencent-docs"},
 	}); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestAuthorizationClientRejectsUnsafeEndpointConfiguration(t *testing.T) {
+	tests := []AuthorizationClientConfig{
+		{BaseURL: "https://user:secret@example.com", APIPrefix: "/v1"},
+		{BaseURL: "https://example.com?target=other", APIPrefix: "/v1"},
+		{BaseURL: "http://example.com", APIPrefix: "/v1"},
+		{BaseURL: "https://example.com", APIPrefix: ""},
+		{BaseURL: "https://example.com", APIPrefix: "/v1?target=other"},
+	}
+	for _, config := range tests {
+		config.HTTPClient = http.DefaultClient
+		config.AuthorizeAccountRequest = func(*http.Request, string) error { return nil }
+		if _, err := NewAuthorizationClient(config); err == nil {
+			t.Fatalf("expected configuration to be rejected: %#v", config)
+		}
 	}
 }

--- a/packages/clients/connector-controlplane/authorization_events.go
+++ b/packages/clients/connector-controlplane/authorization_events.go
@@ -1,4 +1,4 @@
-package connectormarket
+package connectorcontrolplane
 
 import (
 	"context"

--- a/packages/clients/connector-controlplane/authorization_events_test.go
+++ b/packages/clients/connector-controlplane/authorization_events_test.go
@@ -1,4 +1,4 @@
-package connectormarket
+package connectorcontrolplane
 
 import (
 	"context"

--- a/packages/clients/connector-controlplane/go.mod
+++ b/packages/clients/connector-controlplane/go.mod
@@ -1,0 +1,12 @@
+module github.com/tutti-os/tutti/packages/clients/connector-controlplane
+
+go 1.24.3
+
+toolchain go1.24.5
+
+require (
+	github.com/coder/websocket v1.8.14
+	github.com/tutti-os/tutti/packages/connector/host v0.0.0
+)
+
+replace github.com/tutti-os/tutti/packages/connector/host => ../../connector/host

--- a/packages/clients/connector-controlplane/go.sum
+++ b/packages/clients/connector-controlplane/go.sum
@@ -1,0 +1,2 @@
+github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
+github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=

--- a/packages/connector/host/application.go
+++ b/packages/connector/host/application.go
@@ -462,7 +462,9 @@ func (application *Application) ReconcileAuthorizations(ctx context.Context, sco
 			continue
 		}
 		session := *operation.Execution.AuthorizationSession
-		observation, observeErr := observer.Observe(ctx, AuthorizationObserveRequest{Scope: operation.Scope, Connector: connector, Session: session})
+		observation, observeErr := observer.Observe(ctx, AuthorizationObserveRequest{
+			Scope: operation.Scope, Connector: connector, Release: release, Session: session,
+		})
 		if observeErr != nil {
 			reconcileErr = errors.Join(reconcileErr, observeErr)
 			continue

--- a/packages/connector/host/application_execution.go
+++ b/packages/connector/host/application_execution.go
@@ -391,16 +391,17 @@ func (application *Application) executeDisconnectAuthorization(ctx context.Conte
 	if err != nil {
 		return err
 	}
+	release, err := frozenRelease(operation)
+	if err != nil {
+		return err
+	}
 	if err := application.config.Authorization.Disconnect(ctx, AuthorizationDisconnectRequest{
 		OperationID: operation.OperationID,
 		Scope:       operation.Scope,
 		Connector:   connector,
+		Release:     release,
 	}); err != nil {
 		return NewDomainError(ErrorCodeAuthorizationFailed, "connector authorization disconnect failed", true, err)
-	}
-	release, err := frozenRelease(operation)
-	if err != nil {
-		return err
 	}
 	remote := release.Manifest.Implementation.RemoteStreamableHTTP != nil
 	if err := application.completeConnectorOperation(ctx, operation.OperationID, func(connector Connector) Connector {

--- a/packages/connector/host/authorization_router.go
+++ b/packages/connector/host/authorization_router.go
@@ -1,0 +1,84 @@
+package host
+
+import (
+	"context"
+	"errors"
+)
+
+// ImplementationAuthorizationRouter selects the authorization owner from the
+// exact release frozen into an operation. Managed stdio implementations keep
+// authorization with their local implementation host; remote HTTP
+// implementations use the account control plane supplied by the product host.
+type ImplementationAuthorizationRouter struct {
+	managed AuthorizationProvider
+	remote  AuthorizationProvider
+}
+
+func NewImplementationAuthorizationRouter(
+	managed AuthorizationProvider,
+	remote AuthorizationProvider,
+) *ImplementationAuthorizationRouter {
+	return &ImplementationAuthorizationRouter{managed: managed, remote: remote}
+}
+
+func (router *ImplementationAuthorizationRouter) provider(release Release) (AuthorizationProvider, error) {
+	if router == nil {
+		return nil, errors.New("connector authorization router is unavailable")
+	}
+	var provider AuthorizationProvider
+	switch release.Manifest.Implementation.Kind {
+	case ImplementationKindManagedStdio:
+		provider = router.managed
+	case ImplementationKindRemoteStreamableHTTP:
+		provider = router.remote
+	default:
+		return nil, errors.New("connector authorization implementation is unsupported")
+	}
+	if provider == nil {
+		return nil, errors.New("connector authorization provider is unavailable")
+	}
+	return provider, nil
+}
+
+func (router *ImplementationAuthorizationRouter) Begin(
+	ctx context.Context,
+	request AuthorizationStartRequest,
+) (AuthorizationSession, error) {
+	provider, err := router.provider(request.Release)
+	if err != nil {
+		return AuthorizationSession{}, err
+	}
+	return provider.Begin(ctx, request)
+}
+
+func (router *ImplementationAuthorizationRouter) Disconnect(
+	ctx context.Context,
+	request AuthorizationDisconnectRequest,
+) error {
+	provider, err := router.provider(request.Release)
+	if err != nil {
+		return err
+	}
+	return provider.Disconnect(ctx, request)
+}
+
+func (router *ImplementationAuthorizationRouter) Observe(
+	ctx context.Context,
+	request AuthorizationObserveRequest,
+) (AuthorizationObservation, error) {
+	provider, err := router.provider(request.Release)
+	if err != nil {
+		return AuthorizationObservation{}, err
+	}
+	observer, ok := provider.(AuthorizationObserver)
+	if !ok {
+		if request.Release.Manifest.Implementation.Kind == ImplementationKindManagedStdio {
+			return AuthorizationObservation{State: AuthorizationObservationPending}, nil
+		}
+		return AuthorizationObservation{}, errors.New("connector authorization observer is unavailable")
+	}
+	return observer.Observe(ctx, request)
+}
+
+var _ AuthorizationProvider = (*ImplementationAuthorizationRouter)(nil)
+var _ AuthorizationObserver = (*ImplementationAuthorizationRouter)(nil)

--- a/packages/connector/host/authorization_router_test.go
+++ b/packages/connector/host/authorization_router_test.go
@@ -1,0 +1,64 @@
+package host
+
+import (
+	"context"
+	"testing"
+)
+
+type routedAuthorizationProvider struct {
+	beginCount      int
+	disconnectCount int
+	observeCount    int
+}
+
+func (provider *routedAuthorizationProvider) Begin(_ context.Context, request AuthorizationStartRequest) (AuthorizationSession, error) {
+	provider.beginCount++
+	return AuthorizationSession{OperationID: request.OperationID, ConnectorKey: request.Connector.Key}, nil
+}
+
+func (provider *routedAuthorizationProvider) Disconnect(context.Context, AuthorizationDisconnectRequest) error {
+	provider.disconnectCount++
+	return nil
+}
+
+func (provider *routedAuthorizationProvider) Observe(context.Context, AuthorizationObserveRequest) (AuthorizationObservation, error) {
+	provider.observeCount++
+	return AuthorizationObservation{State: AuthorizationObservationConnected}, nil
+}
+
+func TestImplementationAuthorizationRouterUsesFrozenReleaseKind(t *testing.T) {
+	managed := &routedAuthorizationProvider{}
+	remote := &routedAuthorizationProvider{}
+	router := NewImplementationAuthorizationRouter(managed, remote)
+	remoteRelease := Release{Manifest: Manifest{Implementation: Implementation{Kind: ImplementationKindRemoteStreamableHTTP}}}
+	managedRelease := Release{Manifest: Manifest{Implementation: Implementation{Kind: ImplementationKindManagedStdio}}}
+
+	if _, err := router.Begin(context.Background(), AuthorizationStartRequest{
+		OperationID: "begin-1", Connector: Connector{Key: "documents", Release: managedRelease}, Release: remoteRelease,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := router.Disconnect(context.Background(), AuthorizationDisconnectRequest{
+		Connector: Connector{Key: "documents", Release: remoteRelease}, Release: managedRelease,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := router.Observe(context.Background(), AuthorizationObserveRequest{
+		Connector: Connector{Key: "documents", Release: managedRelease}, Release: remoteRelease,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if managed.beginCount != 0 || managed.disconnectCount != 1 || managed.observeCount != 0 {
+		t.Fatalf("managed calls = begin:%d disconnect:%d observe:%d", managed.beginCount, managed.disconnectCount, managed.observeCount)
+	}
+	if remote.beginCount != 1 || remote.disconnectCount != 0 || remote.observeCount != 1 {
+		t.Fatalf("remote calls = begin:%d disconnect:%d observe:%d", remote.beginCount, remote.disconnectCount, remote.observeCount)
+	}
+}
+
+func TestImplementationAuthorizationRouterRejectsUnsupportedImplementation(t *testing.T) {
+	router := NewImplementationAuthorizationRouter(&routedAuthorizationProvider{}, &routedAuthorizationProvider{})
+	if _, err := router.Begin(context.Background(), AuthorizationStartRequest{Release: Release{}}); err == nil {
+		t.Fatal("expected unsupported implementation error")
+	}
+}

--- a/packages/connector/host/ports.go
+++ b/packages/connector/host/ports.go
@@ -370,11 +370,13 @@ type AuthorizationDisconnectRequest struct {
 	OperationID string
 	Scope       OperationScope
 	Connector   Connector
+	Release     Release
 }
 
 type AuthorizationObserveRequest struct {
 	Scope     OperationScope
 	Connector Connector
+	Release   Release
 	Session   AuthorizationSession
 }
 

--- a/services/tuttid/go.mod
+++ b/services/tuttid/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/tutti-os/tutti/packages/analytics/reporter-go v0.0.0
 	github.com/tutti-os/tutti/packages/appcli/core v0.0.0
 	github.com/tutti-os/tutti/packages/auth/bridge-go v0.0.0
+	github.com/tutti-os/tutti/packages/clients/connector-controlplane v0.0.0
 	github.com/tutti-os/tutti/packages/clients/device-authority-go v0.0.0
 	github.com/tutti-os/tutti/packages/commerce v0.0.0
 	github.com/tutti-os/tutti/packages/connector/daemon v0.0.0
@@ -138,6 +139,8 @@ tool github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen
 replace github.com/tutti-os/tutti/packages/appcli/core => ../../packages/appcli/core
 
 replace github.com/tutti-os/tutti/packages/auth/bridge-go => ../../packages/auth/bridge-go
+
+replace github.com/tutti-os/tutti/packages/clients/connector-controlplane => ../../packages/clients/connector-controlplane
 
 replace github.com/tutti-os/tutti/packages/clients/device-authority-go => ../../packages/clients/device-authority-go
 

--- a/services/tuttid/service/connectormarket/implementation_host.go
+++ b/services/tuttid/service/connectormarket/implementation_host.go
@@ -143,47 +143,8 @@ func (host *ImplementationHost) Close() error {
 	return host.runtime.Close()
 }
 
-type authorizationRouter struct {
-	managed  market.AuthorizationProvider
-	external market.AuthorizationProvider
-}
-
-func (router authorizationRouter) provider(connector market.Connector) market.AuthorizationProvider {
-	if connector.Release.Manifest.Implementation.Kind == market.ImplementationKindRemoteStreamableHTTP {
-		return router.external
-	}
-	return router.managed
-}
-
-func (router authorizationRouter) Begin(ctx context.Context, request market.AuthorizationStartRequest) (market.AuthorizationSession, error) {
-	provider := router.provider(request.Connector)
-	if provider == nil {
-		return market.AuthorizationSession{}, errors.New("connector authorization provider is unavailable")
-	}
-	return provider.Begin(ctx, request)
-}
-
-func (router authorizationRouter) Disconnect(ctx context.Context, request market.AuthorizationDisconnectRequest) error {
-	provider := router.provider(request.Connector)
-	if provider == nil {
-		return errors.New("connector authorization provider is unavailable")
-	}
-	return provider.Disconnect(ctx, request)
-}
-
-func (router authorizationRouter) Observe(ctx context.Context, request market.AuthorizationObserveRequest) (market.AuthorizationObservation, error) {
-	if request.Connector.Release.Manifest.Implementation.Kind != market.ImplementationKindRemoteStreamableHTTP {
-		return market.AuthorizationObservation{State: market.AuthorizationObservationPending}, nil
-	}
-	observer, ok := router.external.(market.AuthorizationObserver)
-	if !ok {
-		return market.AuthorizationObservation{}, errors.New("connector authorization observer is unavailable")
-	}
-	return observer.Observe(ctx, request)
-}
-
 func ProductionPorts(host *ImplementationHost, external market.AuthorizationProvider) (market.ImplementationHost, market.AuthorizationProvider, market.CompatibilityEvaluator, market.ImplementationRegistry) {
-	return host, authorizationRouter{managed: host, external: external}, productionCompatibility{}, market.NewImplementationRegistry(map[string]market.ImplementationValidator{
+	return host, market.NewImplementationAuthorizationRouter(host, external), productionCompatibility{}, market.NewImplementationRegistry(map[string]market.ImplementationValidator{
 		market.ImplementationKindManagedStdio:         nil,
 		market.ImplementationKindRemoteStreamableHTTP: nil,
 	})

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -18,6 +18,7 @@ import (
 	agenthttpx "github.com/tutti-os/tutti/packages/agent/daemon/httpx"
 	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
 	runtimeprep "github.com/tutti-os/tutti/packages/agent/runtimeprep"
+	connectorcontrolplane "github.com/tutti-os/tutti/packages/clients/connector-controlplane"
 	connectormarketdaemon "github.com/tutti-os/tutti/packages/connector/daemon"
 	connectormarkethost "github.com/tutti-os/tutti/packages/connector/host"
 	connectorruntime "github.com/tutti-os/tutti/packages/connector/runtime"
@@ -358,8 +359,8 @@ func (w *tuttiWiring) buildWorkspaceModule(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("configure connector implementation host: %w", err)
 		}
-		connectorAuthorizationClient, err := connectormarketservice.NewConnectorAuthorizationClient(connectormarketservice.ConnectorAuthorizationClientConfig{
-			BaseURL: connectorMarketBaseURL, HTTPClient: agenthttpx.NewClient(30 * time.Second),
+		connectorAuthorizationClient, err := connectorcontrolplane.NewAuthorizationClient(connectorcontrolplane.AuthorizationClientConfig{
+			BaseURL: connectorMarketBaseURL, APIPrefix: "/v1", HTTPClient: agenthttpx.NewClient(30 * time.Second),
 			AuthorizeAccountRequest: marketAuthorizer.AuthorizeForAccount,
 		})
 		if err != nil {
@@ -373,7 +374,7 @@ func (w *tuttiWiring) buildWorkspaceModule(ctx context.Context) error {
 		if connectorRealtimeURL == "" {
 			connectorRealtimeURL = strings.TrimSpace(os.Getenv("TUTTI_MOBILE_REALTIME_URL"))
 		}
-		connectorAuthorizationEvents, err := connectormarketservice.NewAuthorizationEventSource(connectormarketservice.AuthorizationEventSourceConfig{
+		connectorAuthorizationEvents, err := connectorcontrolplane.NewAuthorizationEventSource(connectorcontrolplane.AuthorizationEventSourceConfig{
 			URL: connectorRealtimeURL, DeviceID: connectorDeviceID, HeadersForAccount: marketAuthorizer.HeadersForAccount,
 		})
 		if err != nil {


### PR DESCRIPTION
## 背景

TSH 与 Tutti 需要复用同一套账号级 Connector 授权协议。此前授权 client、snapshot 与 realtime event source 私有在 `services/tuttid`，并且实现类型路由读取了可变的 Connector 当前 release，无法安全供另一个 desktop host 复用。

## 改动

- 新增 `packages/clients/connector-controlplane`，提供授权 session、API Key 完成、snapshot 和 realtime event source
- Host 通过 callback 注入逐账号鉴权；公共包不存储 Cookie、Token，也不把凭据下发 VM
- 新增公共 `ImplementationAuthorizationRouter`，严格按 operation 冻结的 release 将 `managed_stdio` 路由到本地 implementation host、将 `remote_streamable_http` 路由到 control plane
- Disconnect/Observe request 补充冻结 release，避免 catalog 更新导致授权 owner 漂移
- Tutti 自身切换到公共包，删除原私有实现
- 补充架构和 package ownership 文档

## 验证

- `go test -race ./...` (`packages/clients/connector-controlplane`)
- `go test -race ./...` (`packages/connector/host`)
- `go test -race ./service/connectormarket` (`services/tuttid`)
- `pnpm check:changed -- --push-ready`: Connector 相关及其余 49/50 lanes 通过；全量中先后出现 3 个与本改动无关的既有时序测试抖动（agentstatus、tuttiagent、agent/daemon runtime），均不依赖 Connector 包

## 安全边界

- remote MCP 授权和账号会话只保留在产品 host/control plane
- VM 只持有非凭据 runtime route identity
- redirect 禁止跨主机自动跟随，并校验 HTTPS URL
