### PR TITLE
fix(agent): preserve terminal failure diagnostics

### DIFF
--- a/packages/agent/daemon/activity/compat.go
+++ b/packages/agent/daemon/activity/compat.go
@@ -449,6 +449,8 @@ func sessionStateUpdateFromPatch(patch WorkspaceAgentStatePatch) WorkspaceAgentS
 			ActiveTurnID:            cloneStringPointer(patch.Turn.ActiveTurnID),
 			Phase:                   strings.TrimSpace(patch.Turn.Phase),
 			Outcome:                 strings.TrimSpace(patch.Turn.Outcome),
+			ErrorCode:               strings.TrimSpace(patch.Turn.ErrorCode),
+			ErrorMessage:            strings.TrimSpace(patch.Turn.ErrorMessage),
 			Settling:                patch.Turn.Settling,
 			CompletedCommand:        cloneCompletedCommand(patch.Turn.CompletedCommand),
 			SubmitAvailability:      cloneSubmitAvailability(patch.Turn.SubmitAvailability),

--- a/packages/agent/daemon/activity/events/activity_types.go
+++ b/packages/agent/daemon/activity/events/activity_types.go
@@ -579,6 +579,27 @@ func BestEffortErrorMessage(payload EventPayload) string {
 	return ""
 }
 
+// BestEffortErrorCode preserves a provider-owned structured error code when
+// the event carries one. It does not classify free-form text; runtime adapters
+// that own a stable classifier may apply that only after this exact value.
+func BestEffortErrorCode(payload EventPayload) string {
+	if payload.Metadata != nil {
+		if code := firstNonEmptyErrorString(
+			payload.Metadata["errorCode"],
+			payload.Metadata["error_code"],
+			payload.Metadata["code"],
+		); code != "" {
+			return code
+		}
+		if nested, ok := payload.Metadata["error"].(map[string]any); ok {
+			if code := errorCodeFromMap(nested); code != "" {
+				return code
+			}
+		}
+	}
+	return errorCodeFromMap(payload.Error)
+}
+
 func firstNonEmptyErrorString(values ...any) string {
 	for _, value := range values {
 		if text, ok := value.(string); ok {
@@ -612,4 +633,11 @@ func errorMessageFromMap(value map[string]any) string {
 		value["debugMessage"],
 		value["lastError"],
 	)
+}
+
+func errorCodeFromMap(value map[string]any) string {
+	if len(value) == 0 {
+		return ""
+	}
+	return firstNonEmptyErrorString(value["errorCode"], value["error_code"], value["code"])
 }

--- a/packages/agent/daemon/activity/events/activity_types_test.go
+++ b/packages/agent/daemon/activity/events/activity_types_test.go
@@ -162,6 +162,36 @@ func TestMessageEventRequiresStableEventIDAndRole(t *testing.T) {
 	}
 }
 
+func TestBestEffortErrorCodePrefersStructuredProviderCode(t *testing.T) {
+	t.Parallel()
+
+	payload := EventPayload{
+		Metadata: map[string]any{
+			"errorCode": " quota_or_rate_limit ",
+			"error":     map[string]any{"code": "nested_code"},
+		},
+		Error: map[string]any{"code": "fallback_code"},
+	}
+	if got := BestEffortErrorCode(payload); got != "quota_or_rate_limit" {
+		t.Fatalf("BestEffortErrorCode() = %q, want quota_or_rate_limit", got)
+	}
+}
+
+func TestBestEffortErrorCodeReadsNestedAndPayloadErrors(t *testing.T) {
+	t.Parallel()
+
+	for name, payload := range map[string]EventPayload{
+		"nested metadata": {Metadata: map[string]any{"error": map[string]any{"error_code": "auth_required"}}},
+		"payload error":   {Error: map[string]any{"code": "request_timed_out"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := BestEffortErrorCode(payload); got == "" {
+				t.Fatalf("BestEffortErrorCode(%s) is empty", name)
+			}
+		})
+	}
+}
+
 func TestContextEventBuildersCreateMessagesAndCompactCalls(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/activity/service_interrupt.go
+++ b/packages/agent/daemon/activity/service_interrupt.go
@@ -181,6 +181,7 @@ func statePatchFromActivityEvent(source EventSource, event activityshared.Event,
 		LastError:            statePatchLastError(event),
 		OccurredAtUnixMS:     timestamp,
 	}
+	turnErrorCode, turnErrorMessage := activityTurnFailureDetails(event)
 	if turnID := strings.TrimSpace(event.Payload.TurnID); turnID != "" &&
 		event.Type != activityshared.EventRootProviderTurnStarted &&
 		event.Type != activityshared.EventRootProviderTurnCheckpoint &&
@@ -193,6 +194,8 @@ func statePatchFromActivityEvent(source EventSource, event activityshared.Event,
 			SourceGoalRepairEpoch: int64ValueFromPayloadMap(event.Payload.Metadata, "sourceGoalRepairEpoch"),
 			Phase:                 strings.TrimSpace(event.Payload.TurnPhase),
 			Outcome:               strings.TrimSpace(event.Payload.TurnOutcome),
+			ErrorCode:             turnErrorCode,
+			ErrorMessage:          turnErrorMessage,
 		}
 	}
 	applyExplicitTurnLifecycleToPatch(&patch, event)
@@ -248,9 +251,17 @@ func statePatchFromActivityEvent(source EventSource, event activityshared.Event,
 			Phase:                   phase,
 			Outcome:                 strings.TrimSpace(event.Payload.TurnOutcome),
 			ErrorMessage:            activityshared.BestEffortErrorMessage(event.Payload),
+			ErrorCode:               activityshared.BestEffortErrorCode(event.Payload),
 		}
 	}
 	return patch, true
+}
+
+func activityTurnFailureDetails(event activityshared.Event) (string, string) {
+	if event.Type != activityshared.EventTurnFailed {
+		return "", ""
+	}
+	return activityshared.BestEffortErrorCode(event.Payload), activityshared.BestEffortErrorMessage(event.Payload)
 }
 
 func statePatchLastError(event activityshared.Event) string {

--- a/packages/agent/daemon/activity/types.go
+++ b/packages/agent/daemon/activity/types.go
@@ -344,6 +344,8 @@ type WorkspaceAgentTurnPatch struct {
 	ActiveTurnID            *string                             `json:"activeTurnId,omitempty"`
 	Phase                   string                              `json:"phase,omitempty"`
 	Outcome                 string                              `json:"outcome,omitempty"`
+	ErrorCode               string                              `json:"errorCode,omitempty"`
+	ErrorMessage            string                              `json:"errorMessage,omitempty"`
 	Settling                bool                                `json:"settling,omitempty"`
 	CompletedCommand        *WorkspaceAgentCompletedCommand     `json:"completedCommand,omitempty"`
 	SubmitAvailability      *WorkspaceAgentSubmitAvailability   `json:"submitAvailability,omitempty"`

--- a/packages/agent/daemon/runtime/controller_turn_state_test.go
+++ b/packages/agent/daemon/runtime/controller_turn_state_test.go
@@ -30,6 +30,33 @@ func TestSubmittedTurnActivityEventProjectsCapabilityReferences(t *testing.T) {
 	}
 }
 
+func TestFailedTurnActivityEventProjectsStableErrorDetails(t *testing.T) {
+	t.Parallel()
+
+	session := Session{Provider: ProviderCodex, AgentSessionID: "agent-1", RoomID: "room-1"}
+	event := newTurnActivityEvent(
+		session,
+		EventTurnFailed,
+		"turn-1",
+		SessionStatusFailed,
+		"",
+		"",
+		map[string]any{"error": "rate limit exceeded"},
+	)
+	patch, ok := statePatchFromSessionEvent(
+		canonical.EventSource{Provider: ProviderCodex},
+		event,
+		"agent-1",
+		200,
+	)
+	if !ok || patch.Turn == nil {
+		t.Fatalf("failed turn patch = %#v ok=%v", patch, ok)
+	}
+	if patch.Turn.ErrorCode != FailureCodeQuotaOrRateLimit || patch.Turn.ErrorMessage != "rate limit exceeded" {
+		t.Fatalf("failed turn error = %q/%q", patch.Turn.ErrorCode, patch.Turn.ErrorMessage)
+	}
+}
+
 func TestProviderRootTurnStartMakesSessionResumable(t *testing.T) {
 	t.Parallel()
 	controller := &Controller{}

--- a/packages/agent/daemon/runtime/reporter_state.go
+++ b/packages/agent/daemon/runtime/reporter_state.go
@@ -28,6 +28,7 @@ func statePatchFromSessionEvent(source canonical.EventSource, event activityshar
 	default:
 		return agentsessionstore.WorkspaceAgentStatePatch{}, false
 	}
+	turnErrorCode, turnErrorMessage := turnFailureDetails(event)
 	patch := agentsessionstore.WorkspaceAgentStatePatch{
 		AgentSessionID:       sessionID,
 		Kind:                 strings.TrimSpace(event.SessionKind),
@@ -78,6 +79,8 @@ func statePatchFromSessionEvent(source canonical.EventSource, event activityshar
 			SourceGoalRepairEpoch: payloadInt64(event.Payload.Metadata, "sourceGoalRepairEpoch"),
 			Phase:                 strings.TrimSpace(event.Payload.TurnPhase),
 			Outcome:               strings.TrimSpace(event.Payload.TurnOutcome),
+			ErrorCode:             turnErrorCode,
+			ErrorMessage:          turnErrorMessage,
 		}
 	}
 	applyProviderInitiatedInteractionTurnToPatch(&patch, event)
@@ -159,10 +162,10 @@ func statePatchFromSessionEvent(source canonical.EventSource, event activityshar
 			started = true
 		}
 		errorMessage := activityshared.BestEffortErrorMessage(event.Payload)
-		errorCode := ""
+		errorCode := activityshared.BestEffortErrorCode(event.Payload)
 		if completed &&
 			strings.TrimSpace(event.Payload.TurnOutcome) == string(activityshared.TurnOutcomeFailed) &&
-			strings.TrimSpace(errorMessage) != "" {
+			strings.TrimSpace(errorCode) == "" && strings.TrimSpace(errorMessage) != "" {
 			errorCode = visibleFailureCode(errorMessage)
 		}
 		patch.RootProviderTurn = &canonical.WorkspaceAgentRootProviderTurnTransition{
@@ -179,6 +182,18 @@ func statePatchFromSessionEvent(source canonical.EventSource, event activityshar
 		}
 	}
 	return patch, true
+}
+
+func turnFailureDetails(event activityshared.Event) (string, string) {
+	if event.Type != activityshared.EventTurnFailed {
+		return "", ""
+	}
+	message := activityshared.BestEffortErrorMessage(event.Payload)
+	code := activityshared.BestEffortErrorCode(event.Payload)
+	if code == "" && message != "" {
+		code = visibleFailureCode(message)
+	}
+	return code, message
 }
 
 // applyProviderCreatedGoalTurnToPatch turns the provider's first authoritative

--- a/packages/agent/host/committed_delta.go
+++ b/packages/agent/host/committed_delta.go
@@ -19,6 +19,10 @@ type SessionMessagesCommitted struct {
 	Input  canonical.ReportSessionMessagesInput
 	Reply  canonical.ReportSessionMessagesReply
 	Result storesqlite.MessageReportResult
+	// Provider is the canonical provider identity for the reporting session.
+	// Message rows do not repeat session identity, so terminal tool-call
+	// analytics carry it on the committed wrapper.
+	Provider string
 	// IsChildSession marks a provider-native subagent session. Message reports
 	// carry no session state, so the reporting adapter resolves it from the
 	// canonical session before publishing the delta.
@@ -29,6 +33,7 @@ type RootTurnSettled struct {
 	WorkspaceID    string
 	AgentSessionID string
 	Turn           storesqlite.Turn
+	Provider       string
 	IsChildSession bool
 	// StartupReconciled marks a turn force-settled by daemon-start
 	// reconciliation rather than by a live provider settlement. Failure
@@ -48,9 +53,11 @@ const (
 )
 
 type RuntimeOperationCommitted struct {
-	Stage     RuntimeOperationCommitStage
-	Operation storesqlite.RuntimeOperation
-	Event     *storesqlite.RuntimeOperationEvent
+	Stage          RuntimeOperationCommitStage
+	Operation      storesqlite.RuntimeOperation
+	Event          *storesqlite.RuntimeOperationEvent
+	Provider       string
+	IsChildSession bool
 }
 
 type GoalOperationCommitStage string
@@ -69,10 +76,12 @@ const (
 )
 
 type GoalOperationCommitted struct {
-	Stage     GoalOperationCommitStage
-	Operation storesqlite.GoalControlOperation
-	State     storesqlite.SessionGoalState
-	Audit     *storesqlite.Message
+	Stage          GoalOperationCommitStage
+	Operation      storesqlite.GoalControlOperation
+	State          storesqlite.SessionGoalState
+	Audit          *storesqlite.Message
+	Provider       string
+	IsChildSession bool
 }
 
 type CanonicalProjectionDirty struct {
@@ -112,6 +121,7 @@ func ActivityStateDelta(input canonical.ReportSessionStateInput, reply canonical
 	if result.RootTurnAccepted && result.RootTurn.Phase == storesqlite.TurnPhaseSettled {
 		delta.RootTurnsSettled = append(delta.RootTurnsSettled, RootTurnSettled{
 			WorkspaceID: result.RootTurn.WorkspaceID, AgentSessionID: result.RootTurn.AgentSessionID, Turn: result.RootTurn,
+			Provider:       firstNonEmptyTrimmed(result.State.Session.Provider, input.State.Provider, input.Source.Provider),
 			IsChildSession: sessionStateIsChild(input.State),
 		})
 	}
@@ -163,7 +173,9 @@ func goalOperationFromActivityState(
 		return nil
 	}
 	return &GoalOperationCommitted{
-		Stage: GoalOperationReconciled,
+		Stage:          GoalOperationReconciled,
+		Provider:       firstNonEmptyTrimmed(result.State.Session.Provider, input.State.Provider, input.Source.Provider),
+		IsChildSession: sessionStateIsChild(input.State),
 		State: storesqlite.SessionGoalState{
 			WorkspaceID:         workspaceID,
 			AgentSessionID:      sessionID,
@@ -186,7 +198,10 @@ func runtimeContextGoal(runtimeContext map[string]any) map[string]any {
 
 func SessionMessagesDelta(input canonical.ReportSessionMessagesInput, reply canonical.ReportSessionMessagesReply, result storesqlite.MessageReportResult) CommittedDelta {
 	delta := committedDeltaFromMutations(result.TransactionID, result.CommitDelta.Mutations)
-	delta.SessionMessages = &SessionMessagesCommitted{Input: input, Reply: reply, Result: result}
+	delta.SessionMessages = &SessionMessagesCommitted{
+		Input: input, Reply: reply, Result: result,
+		Provider: strings.TrimSpace(input.Source.Provider),
+	}
 	delta.addView(input.WorkspaceID, canonicalMessageSessionID(input.AgentSessionID, result.Messages))
 	return delta
 }
@@ -307,7 +322,70 @@ func NotifyCommitted(ctx context.Context, observer CommitObserver, delta Committ
 
 func (h *Host) notifyCommitted(ctx context.Context, delta CommittedDelta) {
 	if h != nil {
+		h.enrichCommittedDeltaTerminalIdentity(ctx, &delta)
 		ObserveTerminalFailuresFromDelta(ctx, h.terminalFailure, delta)
 		NotifyCommitted(ctx, h.commitObserver, delta)
 	}
+}
+
+type terminalFailureSessionIdentity struct {
+	provider       string
+	isChildSession bool
+}
+
+// enrichCommittedDeltaTerminalIdentity resolves session-owned facts from the
+// canonical store after commit. Runtime and Goal operation rows deliberately
+// do not duplicate provider identity, while product telemetry still needs the
+// exact canonical Provider and child-session classification.
+func (h *Host) enrichCommittedDeltaTerminalIdentity(ctx context.Context, delta *CommittedDelta) {
+	if h == nil || h.store == nil || delta == nil {
+		return
+	}
+	identities := map[string]terminalFailureSessionIdentity{}
+	resolve := func(workspaceID, agentSessionID string) terminalFailureSessionIdentity {
+		workspaceID = strings.TrimSpace(workspaceID)
+		agentSessionID = strings.TrimSpace(agentSessionID)
+		key := workspaceID + "\x00" + agentSessionID
+		if identity, ok := identities[key]; ok {
+			return identity
+		}
+		identity := terminalFailureSessionIdentity{}
+		if workspaceID != "" && agentSessionID != "" {
+			if session, found, err := h.store.GetSession(ctx, workspaceID, agentSessionID); err == nil && found {
+				identity.provider = strings.TrimSpace(session.Provider)
+				identity.isChildSession = canonicalSessionIsChild(session)
+			}
+		}
+		identities[key] = identity
+		return identity
+	}
+	apply := func(provider *string, isChildSession *bool, workspaceID, agentSessionID string) {
+		identity := resolve(workspaceID, agentSessionID)
+		if strings.TrimSpace(*provider) == "" {
+			*provider = identity.provider
+		}
+		*isChildSession = *isChildSession || identity.isChildSession
+	}
+	if committed := delta.RuntimeOperation; committed != nil {
+		apply(&committed.Provider, &committed.IsChildSession,
+			committed.Operation.WorkspaceID, committed.Operation.AgentSessionID)
+	}
+	if committed := delta.GoalOperation; committed != nil {
+		workspaceID := firstNonEmptyTrimmed(committed.Operation.WorkspaceID, committed.State.WorkspaceID)
+		agentSessionID := firstNonEmptyTrimmed(committed.Operation.AgentSessionID, committed.State.AgentSessionID)
+		apply(&committed.Provider, &committed.IsChildSession, workspaceID, agentSessionID)
+	}
+	for index := range delta.RootTurnsSettled {
+		settled := &delta.RootTurnsSettled[index]
+		apply(&settled.Provider, &settled.IsChildSession, settled.WorkspaceID, settled.AgentSessionID)
+	}
+	if committed := delta.SessionMessages; committed != nil {
+		agentSessionID := canonicalMessageSessionID(committed.Input.AgentSessionID, committed.Result.Messages)
+		apply(&committed.Provider, &committed.IsChildSession, committed.Input.WorkspaceID, agentSessionID)
+	}
+}
+
+func canonicalSessionIsChild(session storesqlite.Session) bool {
+	return strings.EqualFold(strings.TrimSpace(session.Kind), storesqlite.SessionKindChild) ||
+		strings.TrimSpace(session.ParentToolCallID) != ""
 }

--- a/packages/agent/host/committed_delta.go
+++ b/packages/agent/host/committed_delta.go
@@ -366,20 +366,26 @@ func (h *Host) enrichCommittedDeltaTerminalIdentity(ctx context.Context, delta *
 		}
 		*isChildSession = *isChildSession || identity.isChildSession
 	}
-	if committed := delta.RuntimeOperation; committed != nil {
+	if committed := delta.RuntimeOperation; committed != nil && committed.Stage == RuntimeOperationFailed {
 		apply(&committed.Provider, &committed.IsChildSession,
 			committed.Operation.WorkspaceID, committed.Operation.AgentSessionID)
 	}
-	if committed := delta.GoalOperation; committed != nil {
+	if committed := delta.GoalOperation; committed != nil &&
+		(committed.Stage == GoalOperationFailed || committed.Stage == GoalOperationTerminal) {
 		workspaceID := firstNonEmptyTrimmed(committed.Operation.WorkspaceID, committed.State.WorkspaceID)
 		agentSessionID := firstNonEmptyTrimmed(committed.Operation.AgentSessionID, committed.State.AgentSessionID)
 		apply(&committed.Provider, &committed.IsChildSession, workspaceID, agentSessionID)
 	}
 	for index := range delta.RootTurnsSettled {
 		settled := &delta.RootTurnsSettled[index]
+		if outcome := strings.TrimSpace(settled.Turn.Outcome); outcome != storesqlite.TurnOutcomeFailed &&
+			outcome != storesqlite.TurnOutcomeInterrupted && outcome != storesqlite.TurnOutcomeCanceled {
+			continue
+		}
 		apply(&settled.Provider, &settled.IsChildSession, settled.WorkspaceID, settled.AgentSessionID)
 	}
-	if committed := delta.SessionMessages; committed != nil {
+	if committed := delta.SessionMessages; committed != nil &&
+		len(terminalFailuresFromSessionMessages(*committed, nil)) > 0 {
 		agentSessionID := canonicalMessageSessionID(committed.Input.AgentSessionID, committed.Result.Messages)
 		apply(&committed.Provider, &committed.IsChildSession, committed.Input.WorkspaceID, agentSessionID)
 	}

--- a/packages/agent/host/committed_delta_goal_test.go
+++ b/packages/agent/host/committed_delta_goal_test.go
@@ -1,11 +1,26 @@
 package agenthost
 
 import (
+	"context"
 	"testing"
 
 	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 	"github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
 )
+
+type terminalIdentityReadCountingStore struct {
+	CanonicalStore
+	getSessionCalls int
+}
+
+func (s *terminalIdentityReadCountingStore) GetSession(
+	context.Context,
+	string,
+	string,
+) (storesqlite.Session, bool, error) {
+	s.getSessionCalls++
+	return storesqlite.Session{Provider: "codex"}, true, nil
+}
 
 func TestActivityStateDeltaAttachesGoalOperationForObservedComplete(t *testing.T) {
 	t.Parallel()
@@ -101,5 +116,44 @@ func TestActivityStateDeltaCarriesCanonicalProviderIntoRootSettlement(t *testing
 	)
 	if len(delta.RootTurnsSettled) != 1 || delta.RootTurnsSettled[0].Provider != "canonical-provider" {
 		t.Fatalf("root settlements = %#v, want canonical provider", delta.RootTurnsSettled)
+	}
+}
+
+func TestTerminalFailureIdentityEnrichmentSkipsSuccessfulCommits(t *testing.T) {
+	t.Parallel()
+
+	store := &terminalIdentityReadCountingStore{}
+	host := &Host{store: store}
+	delta := CommittedDelta{
+		RuntimeOperation: &RuntimeOperationCommitted{
+			Stage: RuntimeOperationCompleted,
+			Operation: storesqlite.RuntimeOperation{
+				WorkspaceID: "ws-1", AgentSessionID: "session-1",
+			},
+		},
+		GoalOperation: &GoalOperationCommitted{
+			Stage: GoalOperationCompleted,
+			Operation: storesqlite.GoalControlOperation{
+				WorkspaceID: "ws-1", AgentSessionID: "session-1",
+			},
+		},
+		RootTurnsSettled: []RootTurnSettled{{
+			WorkspaceID: "ws-1", AgentSessionID: "session-1",
+			Turn: storesqlite.Turn{Outcome: storesqlite.TurnOutcomeCompleted},
+		}},
+		SessionMessages: &SessionMessagesCommitted{
+			Input: canonical.ReportSessionMessagesInput{
+				WorkspaceID: "ws-1", AgentSessionID: "session-1",
+			},
+			Result: storesqlite.MessageReportResult{Messages: []storesqlite.Message{{
+				AgentSessionID: "session-1", MessageID: "message-1", Status: "completed",
+			}}},
+		},
+	}
+
+	host.enrichCommittedDeltaTerminalIdentity(context.Background(), &delta)
+
+	if store.getSessionCalls != 0 {
+		t.Fatalf("GetSession calls = %d, want none for successful commits", store.getSessionCalls)
 	}
 }

--- a/packages/agent/host/committed_delta_goal_test.go
+++ b/packages/agent/host/committed_delta_goal_test.go
@@ -79,3 +79,27 @@ func TestActivityStateDeltaSkipsGoalOperationWithoutGoalMutation(t *testing.T) {
 		t.Fatalf("unexpected GoalOperation=%#v", delta.GoalOperation)
 	}
 }
+
+func TestActivityStateDeltaCarriesCanonicalProviderIntoRootSettlement(t *testing.T) {
+	t.Parallel()
+
+	delta := ActivityStateDelta(
+		canonical.ReportSessionStateInput{
+			WorkspaceID: "ws-1", AgentSessionID: "session-1",
+			Source: canonical.EventSource{Provider: "source-provider"},
+			State:  canonical.WorkspaceAgentSessionStateUpdate{Provider: "reported-provider"},
+		},
+		canonical.ReportSessionStateReply{Accepted: true, StateApplied: true},
+		storesqlite.ActivityStateReportResult{
+			State:            storesqlite.StateReportResult{Session: storesqlite.Session{Provider: "canonical-provider"}},
+			RootTurnAccepted: true,
+			RootTurn: storesqlite.Turn{
+				WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-1",
+				Phase: storesqlite.TurnPhaseSettled, Outcome: storesqlite.TurnOutcomeFailed,
+			},
+		},
+	)
+	if len(delta.RootTurnsSettled) != 1 || delta.RootTurnsSettled[0].Provider != "canonical-provider" {
+		t.Fatalf("root settlements = %#v, want canonical provider", delta.RootTurnsSettled)
+	}
+}

--- a/packages/agent/host/host.go
+++ b/packages/agent/host/host.go
@@ -222,6 +222,14 @@ func (h *Host) observeTerminalFailure(ctx context.Context, failure TerminalFailu
 	if h == nil || h.terminalFailure == nil {
 		return
 	}
+	if h.store != nil && strings.TrimSpace(failure.WorkspaceID) != "" && strings.TrimSpace(failure.AgentSessionID) != "" {
+		if session, found, err := h.store.GetSession(ctx, failure.WorkspaceID, failure.AgentSessionID); err == nil && found {
+			if strings.TrimSpace(failure.Provider) == "" {
+				failure.Provider = strings.TrimSpace(session.Provider)
+			}
+			failure.IsChildSession = failure.IsChildSession || canonicalSessionIsChild(session)
+		}
+	}
 	if failure.ErrorMessage == "" && failure.ErrorCode == "" {
 		return
 	}

--- a/packages/agent/host/observed_stores_test.go
+++ b/packages/agent/host/observed_stores_test.go
@@ -37,11 +37,16 @@ func (s runtimeCompletionStore) CompleteCancelRuntimeOperation(context.Context, 
 
 type canonicalTurnReadStore struct {
 	CanonicalStore
-	turn storesqlite.Turn
+	turn    storesqlite.Turn
+	session storesqlite.Session
 }
 
 func (s canonicalTurnReadStore) GetTurn(context.Context, string, string, string) (storesqlite.Turn, bool, error) {
 	return s.turn, true, nil
+}
+
+func (s canonicalTurnReadStore) GetSession(context.Context, string, string) (storesqlite.Session, bool, error) {
+	return s.session, true, nil
 }
 
 func (r *committedDeltaRecorder) ObserveCommitted(_ context.Context, delta CommittedDelta) error {
@@ -95,7 +100,13 @@ func TestObservedCancelCompletionReportsRootSettlementOnce(t *testing.T) {
 		WorkspaceID: "ws-1", AgentSessionID: "root-session", TurnID: "root-turn",
 		Phase: storesqlite.TurnPhaseSettled, Outcome: storesqlite.TurnOutcomeCanceled,
 	}
-	host := &Host{commitObserver: recorder, store: canonicalTurnReadStore{turn: root}}
+	host := &Host{commitObserver: recorder, store: canonicalTurnReadStore{
+		turn: root,
+		session: storesqlite.Session{
+			ID: "root-session", WorkspaceID: "ws-1", Provider: "codex",
+			Kind: storesqlite.SessionKindChild, ParentToolCallID: "tool-1",
+		},
+	}}
 	completion := storesqlite.RuntimeOperationCompletion{
 		Operation: storesqlite.RuntimeOperation{
 			OperationID: "cancel-1", WorkspaceID: "ws-1", AgentSessionID: "root-session",
@@ -123,5 +134,9 @@ func TestObservedCancelCompletionReportsRootSettlementOnce(t *testing.T) {
 	}
 	if len(recorder.deltas) != 1 || len(recorder.deltas[0].RootTurnsSettled) != 1 || recorder.deltas[0].RootTurnsSettled[0].Turn.TurnID != "root-turn" {
 		t.Fatalf("committed deltas=%#v", recorder.deltas)
+	}
+	settled := recorder.deltas[0].RootTurnsSettled[0]
+	if settled.Provider != "codex" || !settled.IsChildSession {
+		t.Fatalf("root settlement identity=%#v, want canonical provider and child marker", settled)
 	}
 }

--- a/packages/agent/host/ports.go
+++ b/packages/agent/host/ports.go
@@ -541,6 +541,13 @@ type TerminalFailure struct {
 	ErrorMessage    string
 	ToolNameFamily  string
 	InteractionKind string
+	TurnOutcome     string
+	// DurationMS is populated only when the canonical terminal fact carries a
+	// valid start and settlement timestamp. Zero means unavailable.
+	DurationMS int64
+	// StartupReconciled distinguishes daemon-start interruption settlement from
+	// a live provider terminal observation.
+	StartupReconciled bool
 	// IsChildSession marks provider-native subagent sessions (parent tool call).
 	// Adapters may use it to distinguish child-session turn/tool failures from
 	// root-session ones without a separate event family.

--- a/packages/agent/host/stale_turn_settlement_test.go
+++ b/packages/agent/host/stale_turn_settlement_test.go
@@ -46,6 +46,9 @@ func TestObserveTerminalFailuresFromStaleTurnSettlementDelta(t *testing.T) {
 	if got.ErrorMessage != "stale turn settled on daemon startup" {
 		t.Fatalf("failure message = %q", got.ErrorMessage)
 	}
+	if got.TurnOutcome != storesqlite.TurnOutcomeInterrupted || !got.StartupReconciled {
+		t.Fatalf("failure settlement metadata = %#v", got)
+	}
 }
 
 func TestStaleTurnSettlementDeltaKeepsChildSessionIdentityFromCallSite(t *testing.T) {

--- a/packages/agent/host/terminal_failure.go
+++ b/packages/agent/host/terminal_failure.go
@@ -83,9 +83,11 @@ func terminalFailureFromRuntimeOperation(committed RuntimeOperationCommitted) (T
 		OperationID:     strings.TrimSpace(op.OperationID),
 		ClientSubmitID:  runtimeOperationPayloadText(op.Payload, "clientSubmitId"),
 		RequestID:       strings.TrimSpace(op.RequestID),
+		Provider:        strings.TrimSpace(committed.Provider),
 		ErrorCode:       strings.TrimSpace(op.Result),
 		ErrorMessage:    message,
 		InteractionKind: runtimeOperationInteractionKind(op),
+		IsChildSession:  committed.IsChildSession,
 		Retryable:       false,
 	}, true
 }
@@ -142,7 +144,9 @@ func terminalFailureFromGoalOperation(committed GoalOperationCommitted) (Termina
 		AgentSessionID: sessionID,
 		OperationID:    strings.TrimSpace(op.OperationID),
 		ClientSubmitID: strings.TrimSpace(op.ClientSubmitID),
+		Provider:       strings.TrimSpace(committed.Provider),
 		ErrorMessage:   message,
+		IsChildSession: committed.IsChildSession,
 		Retryable:      false,
 	}, true
 }
@@ -159,15 +163,20 @@ func terminalFailureFromRootTurn(settled RootTurnSettled) (TerminalFailure, bool
 		message = "turn " + outcome
 	}
 	return TerminalFailure{
-		Flow:           "turn",
-		FailureStage:   "settled",
-		WorkspaceID:    strings.TrimSpace(settled.WorkspaceID),
-		AgentSessionID: strings.TrimSpace(settled.AgentSessionID),
-		TurnID:         strings.TrimSpace(settled.Turn.TurnID),
-		ErrorCode:      strings.TrimSpace(settled.Turn.ErrorCode),
-		ErrorMessage:   message,
-		IsChildSession: settled.IsChildSession,
-		Retryable:      false,
+		Flow:              "turn",
+		FailureStage:      "settled",
+		WorkspaceID:       strings.TrimSpace(settled.WorkspaceID),
+		AgentSessionID:    strings.TrimSpace(settled.AgentSessionID),
+		TurnID:            strings.TrimSpace(settled.Turn.TurnID),
+		OperationID:       strings.TrimSpace(settled.Turn.SourceGoalOperationID),
+		Provider:          strings.TrimSpace(settled.Provider),
+		ErrorCode:         strings.TrimSpace(settled.Turn.ErrorCode),
+		ErrorMessage:      message,
+		TurnOutcome:       outcome,
+		DurationMS:        settledTurnDurationMS(settled.Turn),
+		StartupReconciled: settled.StartupReconciled,
+		IsChildSession:    settled.IsChildSession,
+		Retryable:         false,
 	}, true
 }
 
@@ -197,6 +206,7 @@ func terminalFailuresFromSessionMessages(committed SessionMessagesCommitted, chi
 			AgentSessionID: sessionID,
 			TurnID:         strings.TrimSpace(message.TurnID),
 			RequestID:      strings.TrimSpace(message.MessageID),
+			Provider:       strings.TrimSpace(committed.Provider),
 			ErrorCode:      strings.TrimSpace(message.Status),
 			ErrorMessage:   messageText,
 			ToolNameFamily: toolNameFamily(message.Payload),
@@ -205,6 +215,13 @@ func terminalFailuresFromSessionMessages(committed SessionMessagesCommitted, chi
 		})
 	}
 	return failures
+}
+
+func settledTurnDurationMS(turn storesqlite.Turn) int64 {
+	if turn.StartedAtUnixMS <= 0 || turn.SettledAtUnixMS < turn.StartedAtUnixMS {
+		return 0
+	}
+	return turn.SettledAtUnixMS - turn.StartedAtUnixMS
 }
 
 func isFailedToolCallMessage(message storesqlite.Message) bool {

--- a/packages/agent/host/terminal_failure_test.go
+++ b/packages/agent/host/terminal_failure_test.go
@@ -104,7 +104,7 @@ func TestTerminalFailuresFromDeltaCoversInteractivePlanToolAndTurn(t *testing.T)
 	observer := &recordingTerminalFailureObserver{}
 	delta := CommittedDelta{
 		RuntimeOperation: &RuntimeOperationCommitted{
-			Stage: RuntimeOperationFailed,
+			Stage: RuntimeOperationFailed, Provider: "codex", IsChildSession: true,
 			Operation: storesqlite.RuntimeOperation{
 				WorkspaceID: "ws-1", AgentSessionID: "session-1", OperationID: "op-interactive",
 				Kind: storesqlite.RuntimeOperationKindInteractiveResponse, RequestID: "request-1", TurnID: "turn-1",
@@ -112,21 +112,22 @@ func TestTerminalFailuresFromDeltaCoversInteractivePlanToolAndTurn(t *testing.T)
 			},
 		},
 		GoalOperation: &GoalOperationCommitted{
-			Stage: GoalOperationFailed,
+			Stage: GoalOperationFailed, Provider: "claude-code", IsChildSession: true,
 			Operation: storesqlite.GoalControlOperation{
 				WorkspaceID: "ws-1", AgentSessionID: "session-1", OperationID: "op-goal",
 				ClientSubmitID: "goal-1", LastError: "goal runtime unavailable",
 			},
 		},
 		RootTurnsSettled: []RootTurnSettled{{
-			WorkspaceID: "ws-1", AgentSessionID: "session-1",
+			WorkspaceID: "ws-1", AgentSessionID: "session-1", Provider: "cursor", StartupReconciled: true,
 			Turn: storesqlite.Turn{
-				TurnID: "turn-2", Outcome: storesqlite.TurnOutcomeFailed,
+				TurnID: "turn-2", Outcome: storesqlite.TurnOutcomeFailed, SourceGoalOperationID: "goal-op-2",
 				ErrorCode: "provider_timeout", ErrorMessage: "turn timed out",
+				StartedAtUnixMS: 100, SettledAtUnixMS: 350,
 			},
 		}},
 		SessionMessages: &SessionMessagesCommitted{
-			Input: canonical.ReportSessionMessagesInput{WorkspaceID: "ws-1", AgentSessionID: "session-1"},
+			Input: canonical.ReportSessionMessagesInput{WorkspaceID: "ws-1", AgentSessionID: "session-1"}, Provider: "openclaw",
 			Result: storesqlite.MessageReportResult{
 				Messages: []storesqlite.Message{{
 					MessageID: "toolcall:1", AgentSessionID: "session-1", TurnID: "turn-2",
@@ -146,16 +147,22 @@ func TestTerminalFailuresFromDeltaCoversInteractivePlanToolAndTurn(t *testing.T)
 	for _, failure := range observer.failures {
 		byFlow[failure.Flow] = failure
 	}
-	if byFlow["interactive_response"].InteractionKind != "plan" || byFlow["interactive_response"].ErrorMessage != "interactive submit rejected" {
+	if byFlow["interactive_response"].InteractionKind != "plan" || byFlow["interactive_response"].ErrorMessage != "interactive submit rejected" ||
+		byFlow["interactive_response"].Provider != "codex" || !byFlow["interactive_response"].IsChildSession {
 		t.Fatalf("interactive failure = %#v", byFlow["interactive_response"])
 	}
-	if byFlow["goal_control"].ClientSubmitID != "goal-1" || byFlow["goal_control"].ErrorMessage != "goal runtime unavailable" {
+	if byFlow["goal_control"].ClientSubmitID != "goal-1" || byFlow["goal_control"].ErrorMessage != "goal runtime unavailable" ||
+		byFlow["goal_control"].Provider != "claude-code" || !byFlow["goal_control"].IsChildSession {
 		t.Fatalf("goal failure = %#v", byFlow["goal_control"])
 	}
-	if byFlow["turn"].TurnID != "turn-2" || byFlow["turn"].ErrorCode != "provider_timeout" {
+	if byFlow["turn"].TurnID != "turn-2" || byFlow["turn"].ErrorCode != "provider_timeout" ||
+		byFlow["turn"].Provider != "cursor" || byFlow["turn"].OperationID != "goal-op-2" ||
+		byFlow["turn"].TurnOutcome != storesqlite.TurnOutcomeFailed || byFlow["turn"].DurationMS != 250 ||
+		!byFlow["turn"].StartupReconciled {
 		t.Fatalf("turn failure = %#v", byFlow["turn"])
 	}
-	if byFlow["tool_call"].ToolNameFamily != "bash" || byFlow["tool_call"].ErrorMessage != "command exited 1" {
+	if byFlow["tool_call"].ToolNameFamily != "bash" || byFlow["tool_call"].ErrorMessage != "command exited 1" ||
+		byFlow["tool_call"].Provider != "openclaw" {
 		t.Fatalf("tool failure = %#v", byFlow["tool_call"])
 	}
 }

--- a/packages/agent/store-sqlite/canonical/activity_reports.go
+++ b/packages/agent/store-sqlite/canonical/activity_reports.go
@@ -147,6 +147,8 @@ type WorkspaceAgentTurnStateUpdate struct {
 	ActiveTurnID            *string                             `json:"activeTurnId,omitempty"`
 	Phase                   string                              `json:"phase,omitempty"`
 	Outcome                 string                              `json:"outcome,omitempty"`
+	ErrorCode               string                              `json:"errorCode,omitempty"`
+	ErrorMessage            string                              `json:"errorMessage,omitempty"`
 	Settling                bool                                `json:"settling,omitempty"`
 	CompletedCommand        *WorkspaceAgentCompletedCommand     `json:"completedCommand,omitempty"`
 	SubmitAvailability      *WorkspaceAgentSubmitAvailability   `json:"submitAvailability,omitempty"`

--- a/services/tuttid/service/agent/activity_projection.go
+++ b/services/tuttid/service/agent/activity_projection.go
@@ -402,11 +402,13 @@ func (p *ActivityProjection) reportSessionMessages(
 	}
 	delta := agenthost.SessionMessagesDelta(input, reply, result)
 	if delta.SessionMessages != nil {
-		// A message report carries no session state, so child identity for
-		// failed tool calls has to come from the canonical session.
-		delta.SessionMessages.IsChildSession = p.sessionIsChild(
+		// A message report carries no session state, so terminal-failure identity
+		// for failed tool calls has to come from the canonical session.
+		provider, isChildSession := p.sessionTerminalFailureIdentity(
 			ctx, input.WorkspaceID, canonicalMessageUpdateSessionID(input.AgentSessionID, result.Messages),
 		)
+		delta.SessionMessages.Provider = strings.TrimSpace(firstNonEmptyString(provider, delta.SessionMessages.Provider))
+		delta.SessionMessages.IsChildSession = isChildSession
 	}
 	p.observeCommittedOutsideHost(ctx, delta)
 	p.notifyReplayCommitted(ctx, delta, replayContext)

--- a/services/tuttid/service/agent/activity_projection_reconcile.go
+++ b/services/tuttid/service/agent/activity_projection_reconcile.go
@@ -38,23 +38,24 @@ func (p *ActivityProjection) SettleStaleTurnsOnStartup(ctx context.Context) erro
 	)
 	delta := agenthost.StaleTurnSettlementDelta(settlements)
 	for index, settled := range delta.RootTurnsSettled {
-		delta.RootTurnsSettled[index].IsChildSession = p.sessionIsChild(ctx, settled.WorkspaceID, settled.AgentSessionID)
+		delta.RootTurnsSettled[index].Provider, delta.RootTurnsSettled[index].IsChildSession =
+			p.sessionTerminalFailureIdentity(ctx, settled.WorkspaceID, settled.AgentSessionID)
 	}
 	p.observeCommittedOutsideHost(ctx, delta)
 	return nil
 }
 
-// sessionIsChild reports whether a canonical session is a provider-native
-// subagent session.
-func (p *ActivityProjection) sessionIsChild(ctx context.Context, workspaceID, agentSessionID string) bool {
+// sessionTerminalFailureIdentity resolves fields that message and stale-turn
+// reports do not repeat but terminal failure analytics need.
+func (p *ActivityProjection) sessionTerminalFailureIdentity(ctx context.Context, workspaceID, agentSessionID string) (string, bool) {
 	workspaceID, agentSessionID = strings.TrimSpace(workspaceID), strings.TrimSpace(agentSessionID)
 	if p == nil || p.repo == nil || workspaceID == "" || agentSessionID == "" {
-		return false
+		return "", false
 	}
 	session, found, err := p.repo.GetSession(ctx, workspaceID, agentSessionID)
 	if err != nil || !found {
-		return false
+		return "", false
 	}
-	return strings.EqualFold(strings.TrimSpace(session.Kind), agentactivitybiz.SessionKindChild) ||
+	return strings.TrimSpace(session.Provider), strings.EqualFold(strings.TrimSpace(session.Kind), agentactivitybiz.SessionKindChild) ||
 		strings.TrimSpace(session.ParentToolCallID) != ""
 }

--- a/services/tuttid/service/agent/activity_projection_terminal_failure_test.go
+++ b/services/tuttid/service/agent/activity_projection_terminal_failure_test.go
@@ -99,7 +99,7 @@ func TestReportSessionMessagesMarksChildSessionToolFailures(t *testing.T) {
 				t.Fatalf("terminal failures = %#v, want 1", observer.failures)
 			}
 			got := observer.failures[0]
-			if got.Flow != "tool_call" || got.ErrorMessage != "Exit code 137" || got.ToolNameFamily != "bash" {
+			if got.Flow != "tool_call" || got.ErrorMessage != "Exit code 137" || got.ToolNameFamily != "bash" || got.Provider != "codex" {
 				t.Fatalf("tool failure = %#v", got)
 			}
 			if got.IsChildSession != tt.want {

--- a/services/tuttid/service/agent/activity_projection_turns.go
+++ b/services/tuttid/service/agent/activity_projection_turns.go
@@ -128,6 +128,8 @@ func turnTransitionFromStateInput(
 			CapabilityRefs:          capabilityRefs,
 			Phase:                   phase,
 			Outcome:                 normalizeTurnOutcomeV2(turn.Outcome),
+			ErrorCode:               strings.TrimSpace(turn.ErrorCode),
+			ErrorMessage:            strings.TrimSpace(turn.ErrorMessage),
 			FileChanges:             clonePayload(turn.FileChanges),
 			StartedAtUnixMS:         turn.StartedAtUnixMS,
 			SettledAtUnixMS:         turn.CompletedAtUnixMS,
@@ -143,7 +145,7 @@ func turnTransitionFromStateInput(
 			transition.CompletedCommandStatus = strings.TrimSpace(turn.CompletedCommand.Status)
 		}
 		if phase == agentactivitybiz.TurnPhaseSettled && transition.Outcome == agentactivitybiz.TurnOutcomeFailed {
-			transition.ErrorMessage = strings.TrimSpace(state.LastError)
+			transition.ErrorMessage = firstNonEmptyString(transition.ErrorMessage, state.LastError)
 		}
 		return transition, true
 	}

--- a/services/tuttid/service/agent/activity_projection_turns_test.go
+++ b/services/tuttid/service/agent/activity_projection_turns_test.go
@@ -88,6 +88,27 @@ func TestTurnTransitionFromStateInputRequiresExplicitTurnPatch(t *testing.T) {
 	}
 }
 
+func TestTurnTransitionFromStateInputPreservesStructuredFailure(t *testing.T) {
+	t.Parallel()
+
+	transition, ok := turnTransitionFromStateInput(canonical.ReportSessionStateInput{
+		WorkspaceID: "ws-1", AgentSessionID: "session-1",
+		State: canonical.WorkspaceAgentSessionStateUpdate{
+			LastError: "session fallback",
+			Turn: &canonical.WorkspaceAgentTurnStateUpdate{
+				TurnID: "turn-1", Phase: "settled", Outcome: "failed",
+				ErrorCode: "request_timed_out", ErrorMessage: "provider timed out",
+			},
+		},
+	})
+	if !ok {
+		t.Fatal("failed turn transition was rejected")
+	}
+	if transition.ErrorCode != "request_timed_out" || transition.ErrorMessage != "provider timed out" {
+		t.Fatalf("failure transition error = %q/%q", transition.ErrorCode, transition.ErrorMessage)
+	}
+}
+
 // Completeness-guard tests (agent-gui refactor plan rule six): the projection
 // from stored domain records to generated transport types must assign every
 // generated field explicitly. These tests project a fully populated stored


### PR DESCRIPTION
## Summary
- preserve canonical provider and child-session identity for Host terminal failures
- carry structured turn error codes/messages through provider events into canonical Turn state
- expose terminal outcome, duration, startup reconciliation, and operation correlation for failure analytics

## Why
- Host is the authoritative failure source, but Root Turn, Goal, Runtime, and Tool Call observations could lose provider or structured failure fields before analytics reporting
- missing fields split one failure across incomplete diagnostic rows and limited error clustering

## Tests
- `go test ./packages/agent/host -count=1`
- `go test ./services/tuttid/service/agent -run TestHostCreateWithSuccessfulTypedGoalPreservesSessionWhenResponseReadFails -count=1`
- `go test ./packages/agent/daemon/activity/events -run TestBestEffortErrorCode -count=1`
- `go test ./packages/agent/daemon/runtime -run 'TestFailedTurnActivityEventProjectsStableErrorDetails|TestRootProviderTurnFailurePersistsVisibleErrorCode' -count=1`
- `go test ./services/tuttid/service/agent -run 'TestTurnTransitionFromStateInputPreservesStructuredFailure|TestReportSessionMessagesMarksChildSessionToolFailures' -count=1`
- `pnpm check:changed -- --failed-only` — 15/15 lanes passed (6 run, 9 reused)

## Notes
- canonical session lookups are cached per committed delta
- DataFinder event/property schemas were registered separately
- publishing a Tutti release and upgrading TSH remain separate follow-up work
