### PR TITLE
fix(ui-rich-text): align mention palette scroll arrows

### DIFF
--- a/.changeset/mention-palette-scroll-button-position.md
+++ b/.changeset/mention-palette-scroll-button-position.md
@@ -1,0 +1,6 @@
+---
+"@tutti-os/ui-rich-text": patch
+---
+
+Keep overflowing mention palette tab scroll buttons vertically aligned by
+delegating their translation and scaling to the shared UnderlineTabs component.

--- a/packages/ui/rich-text/src/at-panel/mentionPalette.css
+++ b/packages/ui/rich-text/src/at-panel/mentionPalette.css
@@ -473,7 +473,6 @@
   color: var(--rich-text-at-mention-text-secondary);
   opacity: 0;
   box-shadow: 0 4px 16px rgb(15 23 42 / 12%);
-  transform: translateY(-50%) scale(0.94);
   transition:
     opacity 160ms ease,
     transform 160ms ease,
@@ -499,7 +498,6 @@
   [data-slot="underline-tabs-scroll-right"][data-visible="true"] {
   pointer-events: auto;
   opacity: 1;
-  transform: translateY(-50%) scale(1);
 }
 
 .rich-text-at-mention-palette-header {

--- a/packages/ui/rich-text/src/at-panel/mentionPaletteStyles.test.ts
+++ b/packages/ui/rich-text/src/at-panel/mentionPaletteStyles.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const mentionPaletteStyles = readFileSync(
+  new URL("./mentionPalette.css", import.meta.url),
+  "utf8"
+);
+
+test("mention palette delegates scroll button transforms to UnderlineTabs", () => {
+  const scrollButtonRules = [
+    ...mentionPaletteStyles.matchAll(
+      /([^{}]*underline-tabs-scroll[^{}]*)\{([^{}]*)\}/g
+    )
+  ];
+
+  assert.ok(scrollButtonRules.length > 0, "expected scroll button style rules");
+
+  for (const match of scrollButtonRules) {
+    const selectors = match[1];
+    const declarations = match[2];
+    assert.ok(selectors);
+    assert.ok(declarations);
+
+    assert.doesNotMatch(
+      declarations,
+      /(^|\s)transform\s*:/,
+      `scroll button transform must be owned by UnderlineTabs: ${selectors.trim()}`
+    );
+  }
+});


### PR DESCRIPTION
## 问题

窄屏下 Mention Palette 的 Tab 发生溢出后，左右翻页箭头会向上偏移。

根因是 `UnderlineTabs` 已通过 Tailwind 独立 `translate`/`scale` 属性控制按钮几何位置，而 `ui-rich-text` 兼容样式又通过旧式 `transform` 重复施加 `translateY(-50%)` 和缩放，两套变换叠加后导致箭头重复上移。

## 修改

- 删除 Mention Palette 基础态的重复 `transform`
- 删除 hover/focus 态的重复 `transform`
- 由共享 `UnderlineTabs` 唯一负责翻页按钮的位移与缩放
- 增加样式所有权回归测试，禁止 `ui-rich-text` 再为该按钮声明 `transform`
- 增加 `@tutti-os/ui-rich-text` patch changeset

## 验证

- `pnpm --filter @tutti-os/ui-rich-text test`
- `pnpm --filter @tutti-os/ui-rich-text typecheck`
- `pnpm --filter @tutti-os/ui-rich-text build`
- `pnpm typecheck`
- `pnpm check:ui-boundaries`
- `pnpm check:changed -- --push-ready`
- 构建产物 CSS 检查：翻页按钮规则不再声明 `transform`

## 影响范围

仅影响 Mention Palette 窄屏溢出后的左右翻页按钮位置。Tab 文案、数据、显隐和点击行为不变；无平台相关逻辑。

Bug record: https://ccn53rwonxso.feishu.cn/record/Q3nor4CTneV4Qech5LmcqY9Ynxd
