### PR TITLE
perf(ci): skip unnecessary Windows installer builds

### DIFF
--- a/.github/workflows/windows-desktop-alpha.yml
+++ b/.github/workflows/windows-desktop-alpha.yml
@@ -53,6 +53,19 @@ jobs:
             services/tuttid/go.mod
             services/tuttid/go.sum
 
+      - name: Classify changed files
+        if: github.event_name == 'pull_request'
+        id: changed-files
+        shell: pwsh
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: >-
+          node ./tools/scripts/change-classification.mjs
+          --base "${env:BASE_SHA}"
+          --head "${env:HEAD_SHA}"
+          --github-output "${env:GITHUB_OUTPUT}"
+
       - name: Install dependencies
         shell: pwsh
         run: pnpm install --frozen-lockfile
@@ -96,13 +109,20 @@ jobs:
         shell: pwsh
         run: pnpm --filter @tutti-os/desktop typecheck
 
+      - name: Build Windows Desktop bundles
+        if: github.event_name == 'pull_request' && steps.changed-files.outputs.build_windows_installer != 'true'
+        shell: pwsh
+        run: pnpm --filter @tutti-os/desktop build
+
       - name: Build unsigned Windows NSIS package
+        if: github.event_name == 'workflow_dispatch' || steps.changed-files.outputs.build_windows_installer == 'true'
         shell: pwsh
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: "false"
-        run: pnpm --filter @tutti-os/desktop build:win
+        run: pnpm --filter @tutti-os/desktop build:win:prepared
 
       - name: Smoke test packaged Workspace App shell and Onboarding
+        if: github.event_name == 'workflow_dispatch' || steps.changed-files.outputs.build_windows_installer == 'true'
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
@@ -161,6 +181,7 @@ jobs:
           }
 
       - name: Upload Windows installer
+        if: github.event_name == 'workflow_dispatch' || steps.changed-files.outputs.build_windows_installer == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: tutti-windows-amd64-alpha

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -133,6 +133,7 @@
     "build:unpack": "bash ../../tools/scripts/build-desktop-package.sh unpack",
     "build:win": "bash ../../tools/scripts/build-desktop-package.sh win",
     "predev": "node scripts/prepare-managed-posix-shell-dev.mjs",
+    "build:win:prepared": "bash ../../tools/scripts/build-desktop-package.sh win --prepared-builtin-apps",
     "build:win:store": "bash ../../tools/scripts/build-desktop-package.sh win-store",
     "dev": "electron-vite dev",
     "dev:web": "vite --config vite.web.config.mjs",

--- a/docs/architecture/windows-platform-support.md
+++ b/docs/architecture/windows-platform-support.md
@@ -300,8 +300,11 @@ The Alpha workflow is intentionally separate from the formal desktop release:
   `.github/workflows/windows-daemon-adapters.yml` provide focused pull-request
   coverage and maintain reusable caches on matching `main` pushes; they do not
   produce desktop packages;
-- `.github/workflows/windows-desktop-alpha.yml` builds and tests Windows x64;
-- the output is an unsigned NSIS installer uploaded as a workflow artifact;
+- `.github/workflows/windows-desktop-alpha.yml` always tests Windows x64 and
+  builds the Desktop bundles for pull requests;
+- pull requests build, smoke-test, and upload an unsigned NSIS installer only
+  when Desktop packaging inputs change; manual runs always produce the
+  installer;
 - the workflow does not publish a GitHub Release or mutate stable/prerelease
   update metadata;
 - `.github/workflows/desktop-release.yml` currently stages only macOS assets.

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -28,7 +28,12 @@ The current release flow intentionally excludes:
 - Microsoft Store RC/beta products and package flights
 
 Windows packaging remains available through
-`.github/workflows/windows-desktop-alpha.yml` for smoke validation. The formal
+`.github/workflows/windows-desktop-alpha.yml` for smoke validation. Pull
+requests always run Windows tests and build the Desktop bundles, while only
+packaging-input changes build and smoke-test the unsigned NSIS installer.
+Manual Alpha runs always build the installer. The workflow generates builtin
+apps once and then uses `build:win:prepared`; that command requires
+`pnpm generate:builtin-apps` to have completed first. The formal
 `.github/workflows/desktop-release.yml` workflow always builds Windows. It
 builds an unsigned Windows NSIS
 installer and stages its `.exe`, `.blockmap`, and updater `.yml` beside the

--- a/tools/scripts/build-desktop-package.sh
+++ b/tools/scripts/build-desktop-package.sh
@@ -4,11 +4,28 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 APP_DIR="${ROOT_DIR}/apps/desktop"
 VARIANT="${1:-unpack}"
+BUILTIN_APPS_PREPARED=false
 DAEMON_BUNDLE_DIR="${APP_DIR}/build/tuttid"
 CLI_BUNDLE_DIR="${APP_DIR}/build/tutti"
 DESKTOP_BUILD_VERSION="${TUTTI_DESKTOP_BUILD_VERSION:-}"
 MAC_ARCH="${TUTTI_DESKTOP_MAC_ARCH:-all}"
 MAC_ARCH_ARGS=()
+
+if [[ "$#" -gt 0 ]]; then
+  shift
+fi
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --prepared-builtin-apps)
+      BUILTIN_APPS_PREPARED=true
+      ;;
+    *)
+      echo "Unsupported desktop package argument: $1" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
 
 release_timing_log() {
   echo "[release-timing] $*"
@@ -184,6 +201,15 @@ prepare_packaged_daemon() {
 }
 
 prepare_builtin_apps() {
+  if [[ "${BUILTIN_APPS_PREPARED}" == "true" ]]; then
+    local archives=("${ROOT_DIR}"/services/tuttid/builtin-apps/generated/tutti-onboarding/*.zip)
+    if [[ ! -f "${archives[0]}" ]]; then
+      echo "Prepared builtin apps are missing; run pnpm generate:builtin-apps first." >&2
+      return 1
+    fi
+    release_timing_log "builtin_apps=prepared"
+    return
+  fi
   (
     cd "${ROOT_DIR}"
     pnpm generate:builtin-apps

--- a/tools/scripts/change-classification.mjs
+++ b/tools/scripts/change-classification.mjs
@@ -34,6 +34,9 @@ export function classifyChangedFiles(
   const testShards = buildTypeScriptTestShards(testSelection.packageNames);
 
   return {
+    buildWindowsInstaller: normalizedFiles.some(
+      isWindowsDesktopInstallerRelevant
+    ),
     packAll: packSelection.packAll,
     packPackages: packSelection.packageNames,
     runAgentSessionReplay: normalizedFiles.some(isAgentSessionReplayRelevant),
@@ -126,6 +129,7 @@ export function discoverReleasePackages(root = workspaceRoot) {
 
 export function formatClassificationOutputs(classification) {
   return [
+    ["build_windows_installer", classification.buildWindowsInstaller],
     ["pack_all", classification.packAll],
     ["pack_packages", JSON.stringify(classification.packPackages)],
     ["run_agent_session_replay", classification.runAgentSessionReplay],
@@ -142,6 +146,16 @@ export function formatClassificationOutputs(classification) {
   ]
     .map(([key, value]) => `${key}=${value}`)
     .join("\n");
+}
+
+export function isWindowsDesktopInstallerRelevant(file) {
+  return (
+    ["package.json", "pnpm-lock.yaml"].includes(file) ||
+    file === "apps/desktop/package.json" ||
+    file.startsWith("apps/desktop/build/") ||
+    file.startsWith("apps/desktop/scripts/") ||
+    file.startsWith("services/tuttid/builtin-apps/")
+  );
 }
 
 export function buildTypeScriptTestShards(packageNames, maximum = 3) {

--- a/tools/scripts/change-classification.test.mjs
+++ b/tools/scripts/change-classification.test.mjs
@@ -127,6 +127,36 @@ test("unrelated UI changes do not select the Agent Session Replay closed loop", 
   assert.equal(classification.runAgentSessionReplay, false);
 });
 
+test("ordinary Desktop source changes skip the Windows installer", () => {
+  for (const file of [
+    "apps/desktop/src/main/index.ts",
+    "apps/desktop/src/preload/index.ts",
+    "apps/desktop/src/renderer/src/main.tsx",
+    "apps/desktop/test/register-asset-stub.mjs",
+    "apps/desktop/electron.vite.config.ts",
+    "apps/desktop/tsconfig.json"
+  ]) {
+    const classification = classifyChangedFiles([file], { releasePackages });
+
+    assert.equal(classification.buildWindowsInstaller, false, file);
+  }
+});
+
+test("Windows packaging inputs select the Windows installer", () => {
+  for (const file of [
+    "package.json",
+    "pnpm-lock.yaml",
+    "apps/desktop/package.json",
+    "apps/desktop/build/icon.png",
+    "apps/desktop/scripts/vendor-managed-posix-shell.mjs",
+    "services/tuttid/builtin-apps/tutti-onboarding/src/main.ts"
+  ]) {
+    const classification = classifyChangedFiles([file], { releasePackages });
+
+    assert.equal(classification.buildWindowsInstaller, true, file);
+  }
+});
+
 test("published CSS and assets select package packing and UI boundaries", () => {
   for (const file of [
     "packages/agent/gui/app/renderer/agentactivity.css",

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -1139,10 +1139,17 @@ test("desktop packaging provides an application icon resource", async () => {
 });
 
 test("desktop windows packaging anchors electron-builder workspace detection to the repo root", async () => {
+  const packageJson = JSON.parse(await readFile(desktopPackagePath, "utf8"));
   const buildScript = await readFile(buildScriptPath, "utf8");
 
   assert.match(buildScript, /npm_package_json="\$\{ROOT_DIR\}\/package\.json"/);
   assert.match(buildScript, /INIT_CWD="\$\{ROOT_DIR\}"/);
+  assert.equal(
+    packageJson.scripts["build:win:prepared"],
+    "bash ../../tools/scripts/build-desktop-package.sh win --prepared-builtin-apps"
+  );
+  assert.match(buildScript, /--prepared-builtin-apps/);
+  assert.match(buildScript, /BUILTIN_APPS_PREPARED/);
 });
 
 test("desktop Windows package and daemon agree on the managed POSIX shell resource", async () => {
@@ -1204,7 +1211,10 @@ test("desktop Windows package and daemon agree on the bundled Mutagen resource",
 test("desktop packages and daemon agree on the bundled uv archive root", async () => {
   const packageJson = JSON.parse(await readFile(desktopPackagePath, "utf8"));
   const defaults = JSON.parse(
-    await readFile(new URL("../../config/tutti.defaults.json", import.meta.url), "utf8")
+    await readFile(
+      new URL("../../config/tutti.defaults.json", import.meta.url),
+      "utf8"
+    )
   );
   const buildScript = await readFile(buildScriptPath, "utf8");
   const tuttidManager = await readFile(tuttidManagerPath, "utf8");

--- a/tools/scripts/pr-checks-workflow.test.mjs
+++ b/tools/scripts/pr-checks-workflow.test.mjs
@@ -133,6 +133,43 @@ test("Windows workflows route source changes without self-triggering", () => {
   }
 });
 
+test("Windows Desktop Alpha packages only packaging-relevant changes", () => {
+  const { workflow } = windowsWorkflows[0];
+  const [job] = Object.values(workflow.jobs);
+  const classification = job.steps.find(
+    (step) => step.name === "Classify changed files"
+  );
+  const bundleBuild = job.steps.find(
+    (step) => step.name === "Build Windows Desktop bundles"
+  );
+  const installerBuild = job.steps.find(
+    (step) => step.name === "Build unsigned Windows NSIS package"
+  );
+  const packagedSmoke = job.steps.find(
+    (step) =>
+      step.name === "Smoke test packaged Workspace App shell and Onboarding"
+  );
+  const installerUpload = job.steps.find(
+    (step) => step.name === "Upload Windows installer"
+  );
+  const packageCondition =
+    "github.event_name == 'workflow_dispatch' || steps.changed-files.outputs.build_windows_installer == 'true'";
+
+  assert.match(
+    classification.run,
+    /tools\/scripts\/change-classification\.mjs/u
+  );
+  assert.equal(
+    bundleBuild.if,
+    "github.event_name == 'pull_request' && steps.changed-files.outputs.build_windows_installer != 'true'"
+  );
+  assert.match(bundleBuild.run, /@tutti-os\/desktop build$/u);
+  assert.equal(installerBuild.if, packageCondition);
+  assert.match(installerBuild.run, /@tutti-os\/desktop build:win:prepared/u);
+  assert.equal(packagedSmoke.if, packageCondition);
+  assert.equal(installerUpload.if, packageCondition);
+});
+
 test("Windows adapter workflows warm default-branch caches", () => {
   for (const { expectedPaths, path, workflow } of windowsWorkflows.filter(
     ({ expectedSetupSteps }) => expectedSetupSteps


### PR DESCRIPTION
## Summary
- 普通 Desktop 源码 PR 只构建 Windows Desktop bundles，不再生成 NSIS 安装包
- 打包输入变更和手动运行继续生成、冒烟测试并上传 Windows 安装包
- 新增 `build:win:prepared`，复用工作流已生成的 Onboarding 包，避免二次生成
- 更新 Windows Alpha CI 和 Desktop release 文档

## Tests
- `node --test tools/scripts/change-classification.test.mjs tools/scripts/pr-checks-workflow.test.mjs tools/scripts/desktop-release-config.test.mjs`
- `pnpm check:changed -- --push-ready`（pre-push，26 lanes）

## Notes
- 正式 `.github/workflows/desktop-release.yml` 不变
- Windows Alpha 手动运行仍始终产出完整 NSIS 安装包