### PR TITLE
Revert pull request publishing convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,9 +94,6 @@ Before preparing commits or pull requests, read `CONTRIBUTING.md` and follow it
 for repository-wide contribution requirements, including Conventional Commits,
 DCO sign-off, PR workflow, review gates, and multilingual documentation updates.
 
-When creating pull requests for the user, create a regular ready-for-review PR
-(not a draft), write the PR title in English, and write the PR description in
-Chinese.
 After creating or updating a pull request, read it back from GitHub and verify
 its draft state, title, description encoding, head commit, and CI status.
 


### PR DESCRIPTION
## Summary

- 回滚提交 96b1bd03bdd56c0faa8f4d7506e83bc072c620b7 引入的 PR 发布约定
- 删除 ready-for-review、英文标题和中文描述的强制要求
- 保留后续独立加入的 GitHub 回读校验规则

## Verification

- `pnpm check:changed`
- 推送前钩子：`pnpm check:changed -- --push-ready`
- Windows 影响评估：仅修改贡献者指令文档，不涉及平台相关运行时行为

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.