### PR TITLE
fix(ui-rich-text): align mention palette scroll arrows

### DIFF
--- a/.changeset/mention-palette-scroll-button-position.md
+++ b/.changeset/mention-palette-scroll-button-position.md
@@ -1,0 +1,6 @@
+---
+"@tutti-os/ui-rich-text": patch
+---
+
+Keep overflowing mention palette tab scroll buttons vertically aligned by
+delegating their translation and scaling to the shared UnderlineTabs component.

--- a/packages/ui/rich-text/src/at-panel/mentionPalette.css
+++ b/packages/ui/rich-text/src/at-panel/mentionPalette.css
@@ -473,7 +473,6 @@
   color: var(--rich-text-at-mention-text-secondary);
   opacity: 0;
   box-shadow: 0 4px 16px rgb(15 23 42 / 12%);
-  transform: translateY(-50%) scale(0.94);
   transition:
     opacity 160ms ease,
     transform 160ms ease,
@@ -499,7 +498,6 @@
   [data-slot="underline-tabs-scroll-right"][data-visible="true"] {
   pointer-events: auto;
   opacity: 1;
-  transform: translateY(-50%) scale(1);
 }
 
 .rich-text-at-mention-palette-header {

--- a/packages/ui/rich-text/src/at-panel/mentionPaletteStyles.test.ts
+++ b/packages/ui/rich-text/src/at-panel/mentionPaletteStyles.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const mentionPaletteStyles = readFileSync(
+  new URL("./mentionPalette.css", import.meta.url),
+  "utf8"
+);
+
+test("mention palette delegates scroll button transforms to UnderlineTabs", () => {
+  const scrollButtonRules = [
+    ...mentionPaletteStyles.matchAll(
+      /([^{}]*underline-tabs-scroll[^{}]*)\{([^{}]*)\}/g
+    )
+  ];
+
+  assert.ok(scrollButtonRules.length > 0, "expected scroll button style rules");
+
+  for (const match of scrollButtonRules) {
+    const selectors = match[1];
+    const declarations = match[2];
+    assert.ok(selectors);
+    assert.ok(declarations);
+
+    assert.doesNotMatch(
+      declarations,
+      /(^|\s)transform\s*:/,
+      `scroll button transform must be owned by UnderlineTabs: ${selectors.trim()}`
+    );
+  }
+});


### PR DESCRIPTION
## Summary

- 移除 mention palette 对 UnderlineTabs 翻页按钮 transform 的重复覆盖
- 让共享 UnderlineTabs 独立负责箭头的垂直居中与可见状态缩放
- 增加样式契约测试，防止 package-local CSS 再次覆盖按钮 transform

## Verification

- 纯 UI 展示修改，依据仓库 UI-only validation exception 不运行额外检查
- git diff --check origin/main...fix/q3nor4ctnev4qech5lmcqy9ynxd-mention-arrow-position

## Checklist

- [x] 本次修改聚焦单一问题
- [x] 已检查文档影响；没有公共 API、配置或贡献流程变化，无需更新文档
- [x] 未修改 README/CONTRIBUTING
- [x] 使用了变更范围对应的最低验证要求
- [x] 提交包含 DCO Signed-off-by