### PR TITLE
fix(windows): restore CLI discovery and stop controls

### DIFF
--- a/apps/desktop/src/main/cli/cliInstaller.test.ts
+++ b/apps/desktop/src/main/cli/cliInstaller.test.ts
@@ -93,11 +93,42 @@ test("ensureDesktopCliShim writes windows command shim", async () => {
   });
 
   assert.equal(state.installed, true);
-  assert.equal(state.pathShimPath, null);
+  const pathShimPath = join(localBinDir, "tutti.cmd");
+  assert.equal(state.pathShimPath, pathShimPath);
   assert.equal(state.shimPath, join(stateRootDir, "bin", "tutti.cmd"));
   const content = await readFile(state.shimPath, "utf8");
   assert.match(content, /tutti\.exe/);
   assert.match(content, new RegExp(escapeRegExp(stateRootDir)));
+  const pathShimContent = await readFile(pathShimPath, "utf8");
+  assert.match(pathShimContent, /Tutti CLI shim/);
+  assert.match(pathShimContent, new RegExp(escapeRegExp(state.shimPath)));
+});
+
+test("ensureDesktopCliShim repairs an existing Windows Tutti PATH shim", async () => {
+  const stateRootDir = await mkdtemp(join(tmpdir(), "tutti-cli-state-"));
+  const homeDir = await mkdtemp(join(tmpdir(), "tutti-cli-home-"));
+  const localBinDir = join(homeDir, ".local", "bin");
+  const existingCommandPath = join(localBinDir, "tutti.cmd");
+  await mkdir(localBinDir, { recursive: true });
+  await writeFile(
+    existingCommandPath,
+    '@echo off\r\nrem Tutti CLI shim\r\n"C:\\stale\\tutti.exe" %*\r\n',
+    "utf8"
+  );
+
+  const state = await ensureDesktopCliShim({
+    homeDir,
+    isPackaged: true,
+    pathEnv: localBinDir + ";C:\\Windows\\System32",
+    platform: "win32",
+    resourcesPath: "C:\\Program Files\\Tutti\\resources",
+    stateRootDir
+  });
+
+  assert.equal(state.pathShimPath, existingCommandPath);
+  const content = await readFile(existingCommandPath, "utf8");
+  assert.doesNotMatch(content, /stale/);
+  assert.match(content, new RegExp(escapeRegExp(state.shimPath)));
 });
 
 test("ensureDesktopCliShim keeps an existing non-Tutti PATH command", async () => {

--- a/apps/desktop/src/main/cli/cliInstaller.ts
+++ b/apps/desktop/src/main/cli/cliInstaller.ts
@@ -64,18 +64,16 @@ export async function ensureDesktopCliShim(
   }
 
   let pathShimPath: string | null = null;
-  if (platform !== "win32") {
-    const pathEnv = options.pathEnv ?? (await resolveCliInstallPathEnv()) ?? "";
-    pathShimPath = await installPathShimIfPossible({
-      canonicalShimPath: shimPath,
-      commandName: isPackaged ? "tutti" : "tutti-dev",
-      development: !isPackaged,
-      homeDir: options.homeDir ?? homedir(),
-      pathEnv,
-      platform,
-      stateRootDir
-    });
-  }
+  const pathEnv = options.pathEnv ?? (await resolveCliInstallPathEnv()) ?? "";
+  pathShimPath = await installPathShimIfPossible({
+    canonicalShimPath: shimPath,
+    commandName: isPackaged ? "tutti" : "tutti-dev",
+    development: !isPackaged,
+    homeDir: options.homeDir ?? homedir(),
+    pathEnv,
+    platform,
+    stateRootDir
+  });
 
   return {
     installed: true,
@@ -197,7 +195,8 @@ async function installPathShimIfPossible(input: {
 
   const existingCommand = await findExistingPathCommand(
     pathDirs,
-    input.commandName
+    input.commandName,
+    input.platform
   );
   if (existingCommand) {
     if (!(await isOwnedCliShim(existingCommand))) {
@@ -212,7 +211,10 @@ async function installPathShimIfPossible(input: {
     return null;
   }
 
-  const pathShimPath = join(targetDir, input.commandName);
+  const pathShimPath = join(
+    targetDir,
+    pathCommandFileName(input.commandName, input.platform)
+  );
   await writePathShim(pathShimPath, input);
   return pathShimPath;
 }
@@ -245,15 +247,23 @@ async function writePathShim(
 
 async function findExistingPathCommand(
   pathDirs: readonly string[],
-  commandName: string
+  commandName: string,
+  platform: NodeJS.Platform
 ): Promise<string | null> {
   for (const pathDir of pathDirs) {
-    const candidate = join(pathDir, commandName);
+    const candidate = join(pathDir, pathCommandFileName(commandName, platform));
     if (await pathExists(candidate)) {
       return candidate;
     }
   }
   return null;
+}
+
+function pathCommandFileName(
+  commandName: string,
+  platform: NodeJS.Platform
+): string {
+  return platform === "win32" ? `${commandName}.cmd` : commandName;
 }
 
 async function firstWritableUserPathDir(

--- a/docs/architecture/desktop-transport.md
+++ b/docs/architecture/desktop-transport.md
@@ -153,12 +153,13 @@ token in the HTTP `Authorization` header.
 
 The packaged desktop app repairs the canonical user-level CLI shim during
 startup. The canonical shim path derives from the same state root. To expose the
-command to external shells on macOS and Linux, desktop may also install or
-repair a Tutti-owned forwarding shim in `~/.local/bin` or `~/bin`, but only
-when that directory is already present in the user's login-shell `PATH` and
-writable. It must not overwrite a non-Tutti command, mutate shell profiles, or
-write to global locations such as `/usr/local/bin`. PATH exposure is a
-best-effort background startup task and must not delay desktop window creation.
+command to external shells on macOS, Linux, and Windows, desktop may also
+install or repair a Tutti-owned forwarding shim in `~/.local/bin`, `~/bin`, or
+the Windows equivalent user-owned PATH directory, but only when that directory
+is already present in the user's `PATH` and writable. Windows uses a `.cmd`
+shim. It must not overwrite a non-Tutti command, mutate shell profiles or the
+registry, or write to global locations. PATH exposure is a best-effort
+background startup task and must not delay desktop window creation.
 
 Local development scripts install a separate `tutti-dev` command so developer
 shells can target the development daemon without shadowing a packaged `tutti`

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.spec.ts
@@ -242,7 +242,7 @@ describe("Home status presentation", () => {
     ).toBe(inlineNoticeChrome);
   });
 
-  it("keeps Stop visible but disables it while active work is disconnected", () => {
+  it("keeps Stop actionable while submission commands are blocked", () => {
     expect(
       resolveAgentGUIStopControl({
         hasPendingApproval: false,
@@ -253,10 +253,9 @@ describe("Home status presentation", () => {
         isCreatingConversation: false,
         isInterrupting: false,
         isSubmitting: false,
-        isUnavailable: false,
-        runtimeCommandsBlocked: true
+        isUnavailable: false
       })
-    ).toEqual({ disabled: true, visible: true });
+    ).toEqual({ disabled: false, visible: true });
   });
 });
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIDetailModelHelpers.ts
@@ -292,10 +292,12 @@ export function resolveAgentGUIStopControl(input: {
   isInterrupting: boolean;
   isSubmitting: boolean;
   isUnavailable: boolean;
-  runtimeCommandsBlocked: boolean;
 }): { disabled: boolean; visible: boolean } {
   return {
-    disabled: input.runtimeCommandsBlocked,
+    // Stop is a daemon/session control, not a composer command. The runtime
+    // gate may block new submissions while the daemon can still cancel the
+    // active turn, so do not inherit the composer gate here.
+    disabled: false,
     visible: shouldShowAgentGUIStopButton(input)
   };
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailModel.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/useAgentGUIDetailModel.tsx
@@ -230,8 +230,6 @@ export function useAgentGUIDetailModel(input: Input) {
   const composerDisabledReason = isCollaboratorConversation
     ? labels.collaboratorSessionReadOnlyPlaceholder
     : null;
-  const runtimeCommandsBlocked =
-    viewModel.composer.gate.runtime.status === "blocked";
   const stopControl = resolveAgentGUIStopControl({
     hasPendingApproval: viewModel.interaction.pendingApproval !== null,
     hasPendingInteractivePrompt:
@@ -242,8 +240,7 @@ export function useAgentGUIDetailModel(input: Input) {
     isCreatingConversation: viewModel.composer.isCreatingConversation,
     isInterrupting: viewModel.composer.isInterrupting,
     isSubmitting: viewModel.composer.isSubmitting,
-    isUnavailable: viewModel.readiness.activeLiveState === "failed",
-    runtimeCommandsBlocked
+    isUnavailable: viewModel.readiness.activeLiveState === "failed"
   });
   const showStopButton = stopControl.visible;
   const stopDisabled = stopControl.disabled;


### PR DESCRIPTION
修复 Windows 上两个相关问题：1) Agent GUI 的 Stop 不再继承 composer runtime blocked 状态，保持 daemon/session cancel 可用；2) 桌面启动在 Windows 也安装或修复用户 PATH 中的 Tutti .cmd shim，并正确发现现有 .cmd 文件。证据：Windows local:tutti-agent 取消链路已实测 turn/cancel -> turn/interrupt -> canceled/settled；日志未出现 forced interrupt。验证：Windows CLI 定向测试 3/3，Agent GUI 回归 32/32，Agent GUI 与 desktop typecheck 通过。未修改证书问题。构建整包曾因 electron-vite/esbuild renderer warmup 超时，已用 direct main 启动和上述测试验证。