### PR TITLE
fix(workbench-surface): prefetch focused dock previews

### DIFF
--- a/.changeset/workbench-dock-focused-preview-prefetch.md
+++ b/.changeset/workbench-dock-focused-preview-prefetch.md
@@ -1,0 +1,7 @@
+---
+"@tutti-os/workbench-surface": patch
+---
+
+Render focused Workbench windows in isolation before the Dock popup obscures
+them, then reuse the revision-scoped image for multi-window previews without
+capturing overlapping windows or overlays.

--- a/docs/architecture/workbench-dock-model.md
+++ b/docs/architecture/workbench-dock-model.md
@@ -265,20 +265,23 @@ must not interleave per-frame `getBoundingClientRect()` reads with slot size
 writes. Resetting the interaction or changing slot membership invalidates the
 snapshot.
 
-Native popup previews pass the clamped target rectangle to Electron capture;
-they must not capture the whole `webContents` and crop afterward. A native
-region capture is valid only for the foreground node represented by those
-composited pixels. Background and minimized nodes must not use a fresh DOM
-snapshot because their bodies may be unhydrated or their imperative resources
-may be inactive. They reuse the last successful memory or persistent image
-instead. A failed capture is terminal only for the mounted popup; it must not
-be retained across popup lifetimes because the node may be foreground the next
-time. Popup capture effects are keyed by preview identity and revision, not
-transient item arrays or callback references. Cleanup may fence stale UI
-writes, but it must retain the pending marker for a native capture that has
-already started until that capture settles, because Electron capture cannot be
-canceled. Skeletons represent in-flight capture only; a terminally unavailable
-preview uses a non-loading static placeholder.
+Dock previews must isolate the target window from the rest of the composited
+Workbench. Capture the focused node before a Dock popup can obscure it by
+cloning only its capture element and rendering that clone to an image. Do not
+crop `webContents.capturePage()` for Dock previews: another Workbench window,
+an always-on-top surface, or an overlay can own pixels inside the same rectangle.
+Node-owned preview providers may replace the clone path for imperative surfaces
+that cannot be represented by cloned DOM. Retain each successful image by
+preview identity and revision. Background and minimized nodes must not request
+a fresh DOM snapshot because their bodies may be unhydrated or their imperative
+resources may be inactive. They reuse the last successful memory or persistent
+image instead. A failed capture is terminal only for the mounted popup; it must
+not be retained across popup lifetimes because the node may be foreground the
+next time. Popup capture effects are keyed by preview identity and revision,
+not transient item arrays or callback references. Cleanup may fence stale UI
+writes, but it must retain a pending capture marker until that capture settles.
+Skeletons represent in-flight capture only; a terminally unavailable preview
+uses a non-loading static placeholder.
 
 Dock popup responsibilities stay split by lifecycle: `WorkbenchHostDockPopup`
 owns portal/layout and dismissal, `WorkbenchHostDockPopupPresentation` owns

--- a/docs/conventions/troubleshooting/workbench-renderer.md
+++ b/docs/conventions/troubleshooting/workbench-renderer.md
@@ -718,16 +718,21 @@
   reusable cache entry also prevents a later foreground attempt for the same
   revision.
 - Fix:
-  Keep native capture as the foreground high-fidelity path. Background and
-  minimized popup nodes reuse only a successful memory or persistent image;
-  they do not request a fresh DOM snapshot. Keep an unavailable result local to
-  the mounted popup so reopening can retry after the node becomes foreground.
-  Show a static terminal placeholder instead of a loading skeleton when no
+  Prefetch the focused node before opening a Dock popup by rendering only the
+  node's cloned capture element. Do not use a cropped Electron `capturePage()`
+  image for Dock previews because overlapping Workbench windows and overlays
+  are part of those composited pixels. Retain the isolated image under the same
+  preview identity and revision used by the popup. Background and minimized
+  popup nodes reuse only that successful memory or persistent image; they do
+  not request a fresh DOM snapshot. Keep an unavailable result local to the
+  mounted popup so reopening can retry after the node becomes foreground. Show
+  a static terminal placeholder instead of a loading skeleton when no
   successful image exists.
 - Validation:
-  Cover native-null plus persisted-cache success, assert that background DOM
-  capture is not called, and reopen the popup to prove that a prior unavailable
-  result does not block a later successful capture.
+  Cover focused prefetch before the popup mounts, exclusion of an overlapping
+  sibling from the cloned capture document, persisted-cache success, and
+  reopening after an unavailable result. Assert that opening the popup reuses
+  the prefetched image without starting a composited native capture.
 - References:
   [docs/architecture/workbench-dock-model.md](../../architecture/workbench-dock-model.md)
   [WorkbenchHostDockPopup.tsx](../../../packages/workbench/surface/src/host/WorkbenchHostDockPopup.tsx)

--- a/packages/workbench/surface/src/host/WorkbenchHostDock.render.test.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDock.render.test.tsx
@@ -241,7 +241,7 @@ describe("WorkbenchHostDock", () => {
     }
   });
 
-  it("captures dock popup previews as images when no component preview exists", async () => {
+  it("reuses an isolated prefetched image when no component preview exists", async () => {
     vi.stubGlobal(
       "ResizeObserver",
       class {
@@ -250,10 +250,18 @@ describe("WorkbenchHostDock", () => {
         unobserve() {}
       }
     );
-    const node = createNode();
+    const node = {
+      ...createNode(),
+      id: "agent-gui:isolated-popup-preview"
+    };
     const props = createDockProps([node]);
+    props.context.focusedNodeId = node.id;
+    const previewImageUrl = "data:image/png;base64,AA==";
+    const captureIsolatedNodePreview = vi
+      .spyOn(genieAnimation, "captureWorkbenchNodePreviewImage")
+      .mockResolvedValue(previewImageUrl);
     const captureNodePreviewImage = vi.fn(
-      async () => "data:image/png;base64,AA=="
+      async () => "data:image/png;base64,Q09NUE9TSVRFRA=="
     );
     const dockEntry = {
       icon: null,
@@ -283,6 +291,9 @@ describe("WorkbenchHostDock", () => {
           />
         );
       });
+      await vi.waitFor(() => {
+        expect(captureIsolatedNodePreview).toHaveBeenCalledOnce();
+      });
       const button = container.querySelector<HTMLButtonElement>(
         'button[aria-haspopup="dialog"]'
       );
@@ -293,8 +304,13 @@ describe("WorkbenchHostDock", () => {
       });
 
       await vi.waitFor(() => {
-        expect(captureNodePreviewImage).toHaveBeenCalledWith(node);
+        expect(
+          document.body.querySelector<HTMLImageElement>(
+            `[data-preview-kind="image"] img`
+          )?.src
+        ).toBe(previewImageUrl);
       });
+      expect(captureNodePreviewImage).not.toHaveBeenCalled();
     } finally {
       await act(async () => {
         root.unmount();
@@ -303,6 +319,150 @@ describe("WorkbenchHostDock", () => {
       (
         globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
       ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+      captureIsolatedNodePreview.mockRestore();
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("prefetches an isolated focused dock window before the popup obscures it", async () => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        disconnect() {}
+        observe() {}
+        unobserve() {}
+      }
+    );
+    const baseNode = createNode();
+    const node = {
+      ...baseNode,
+      data: {
+        ...baseNode.data,
+        instanceId: "focused-prefetch-1"
+      },
+      id: "agent-gui:focused-prefetch-1"
+    };
+    const secondNode = {
+      ...baseNode,
+      data: {
+        ...baseNode.data,
+        instanceId: "focused-prefetch-2"
+      },
+      id: "agent-gui:focused-prefetch-2"
+    };
+    const props = createDockProps([node, secondNode]);
+    props.context.focusedNodeId = node.id;
+    const previewImageUrls = {
+      [node.id]: "data:image/png;base64,UFJFRkVUQ0gx",
+      [secondNode.id]: "data:image/png;base64,UFJFRkVUQ0gy"
+    };
+    const captureIsolatedNodePreview = vi
+      .spyOn(genieAnimation, "captureWorkbenchNodePreviewImage")
+      .mockImplementation(
+        async (nodeId) =>
+          previewImageUrls[nodeId as keyof typeof previewImageUrls] ?? null
+      );
+    const captureNodePreviewImage = vi.fn(
+      async () => "data:image/png;base64,Q09NUE9TSVRFRF9TVVJGQUNF"
+    );
+    const writePreview = vi.fn();
+    const dockEntry = {
+      icon: null,
+      id: "agent-gui",
+      instanceMode: "multi" as const,
+      label: "Agent",
+      resolvePopupItem: () => ({ revision: "session-1" }),
+      typeId: "agent-gui",
+      visibility: "always" as const
+    };
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const previousActEnvironment = (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT;
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+
+    try {
+      await act(async () => {
+        root.render(
+          <WorkbenchHostDock
+            {...props}
+            captureNodePreviewImage={captureNodePreviewImage}
+            dockEntries={[dockEntry]}
+            dockPreviewCache={{ read: async () => null, write: writePreview }}
+          />
+        );
+      });
+
+      await vi.waitFor(() => {
+        expect(captureIsolatedNodePreview).toHaveBeenCalledTimes(1);
+        expect(captureIsolatedNodePreview).toHaveBeenCalledWith(node.id, {
+          bypassCache: true
+        });
+        expect(captureNodePreviewImage).not.toHaveBeenCalled();
+        expect(writePreview).toHaveBeenCalledWith({
+          key: {
+            instanceId: "focused-prefetch-1",
+            instanceKey: null,
+            nodeId: node.id,
+            revision: "session-1",
+            typeId: "agent-gui",
+            workspaceId: "workspace-hook-order"
+          },
+          previewImageUrl: previewImageUrls[node.id]
+        });
+      });
+
+      props.context.focusedNodeId = secondNode.id;
+      await act(async () => {
+        root.render(
+          <WorkbenchHostDock
+            {...props}
+            captureNodePreviewImage={captureNodePreviewImage}
+            dockEntries={[dockEntry]}
+            dockPreviewCache={{ read: async () => null, write: writePreview }}
+          />
+        );
+      });
+      await vi.waitFor(() => {
+        expect(captureIsolatedNodePreview).toHaveBeenCalledTimes(2);
+        expect(captureIsolatedNodePreview).toHaveBeenLastCalledWith(
+          secondNode.id,
+          { bypassCache: true }
+        );
+        expect(captureNodePreviewImage).not.toHaveBeenCalled();
+      });
+
+      const button = container.querySelector<HTMLButtonElement>(
+        'button[aria-haspopup="dialog"]'
+      );
+      await act(async () => {
+        button?.click();
+      });
+      await vi.waitFor(() => {
+        expect(
+          Array.from(
+            document.body.querySelectorAll<HTMLImageElement>(
+              `[data-preview-kind="image"] img`
+            ),
+            (image) => image.src
+          )
+        ).toEqual([previewImageUrls[secondNode.id], previewImageUrls[node.id]]);
+      });
+      expect(captureIsolatedNodePreview).toHaveBeenCalledTimes(2);
+      expect(captureNodePreviewImage).not.toHaveBeenCalled();
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      (
+        globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+      ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+      captureIsolatedNodePreview.mockRestore();
       vi.unstubAllGlobals();
     }
   });
@@ -516,7 +676,7 @@ describe("WorkbenchHostDock", () => {
     }
   });
 
-  it("does not restart an in-flight popup capture after a semantic no-op render", async () => {
+  it("does not restart an in-flight isolated prefetch after a semantic no-op render", async () => {
     vi.stubGlobal(
       "ResizeObserver",
       class {
@@ -530,8 +690,14 @@ describe("WorkbenchHostDock", () => {
       id: "agent-gui:pending-preview"
     };
     const props = createDockProps([node]);
+    props.context.focusedNodeId = node.id;
     const pendingCapture = deferred<string>();
-    const captureNodePreviewImage = vi.fn(() => pendingCapture.promise);
+    const captureIsolatedNodePreview = vi
+      .spyOn(genieAnimation, "captureWorkbenchNodePreviewImage")
+      .mockImplementation(() => pendingCapture.promise);
+    const captureNodePreviewImage = vi.fn(
+      async () => "data:image/png;base64,Q09NUE9TSVRFRA=="
+    );
     const dockEntry = {
       icon: null,
       id: "agent-gui",
@@ -560,14 +726,8 @@ describe("WorkbenchHostDock", () => {
           />
         );
       });
-      const button = container.querySelector<HTMLButtonElement>(
-        'button[aria-haspopup="dialog"]'
-      );
-      await act(async () => {
-        button?.click();
-      });
       await vi.waitFor(() => {
-        expect(captureNodePreviewImage).toHaveBeenCalledTimes(1);
+        expect(captureIsolatedNodePreview).toHaveBeenCalledTimes(1);
       });
 
       await act(async () => {
@@ -581,7 +741,8 @@ describe("WorkbenchHostDock", () => {
       });
       await new Promise<void>((resolve) => setTimeout(resolve, 0));
 
-      expect(captureNodePreviewImage).toHaveBeenCalledTimes(1);
+      expect(captureIsolatedNodePreview).toHaveBeenCalledTimes(1);
+      expect(captureNodePreviewImage).not.toHaveBeenCalled();
       pendingCapture.resolve("data:image/png;base64,AA==");
     } finally {
       pendingCapture.resolve("data:image/png;base64,AA==");
@@ -592,6 +753,7 @@ describe("WorkbenchHostDock", () => {
       (
         globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
       ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+      captureIsolatedNodePreview.mockRestore();
       vi.unstubAllGlobals();
     }
   });

--- a/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
@@ -44,6 +44,7 @@ import { WorkbenchHostDockMinimizedSlot } from "./WorkbenchHostDockMinimizedSlot
 import { WorkbenchHostDockPopups } from "./WorkbenchHostDockPopups.tsx";
 import { useWorkbenchHostDockEntryActivation } from "./useWorkbenchHostDockEntryActivation.ts";
 import { useWorkbenchHostDockActivity } from "./useWorkbenchHostDockActivity.ts";
+import { useWorkbenchHostFocusedDockPreviewCapture } from "./useWorkbenchHostFocusedDockPreviewCapture.ts";
 import {
   type WorkbenchHostDockPopupAnchorRect,
   type WorkbenchHostDockPopupState
@@ -272,6 +273,17 @@ export function WorkbenchHostDock({
       renderedDockEntries,
       workspaceId
     });
+
+  useWorkbenchHostFocusedDockPreviewCapture({
+    context,
+    dockPreviewCache,
+    enabled: activePopup === null && activeMinimizedStackPopup === null,
+    externalStateRevision,
+    externalStateSource,
+    host,
+    resolvedEntries,
+    workspaceId
+  });
 
   const captureMinimizedNodePreview = useCallback(
     async (node: WorkbenchMinimizedDockNode) => {
@@ -698,7 +710,6 @@ export function WorkbenchHostDock({
         activeMinimizedStackPopup={activeMinimizedStackPopup}
         activePopup={activePopup}
         captureMinimizedNodePreview={captureMinimizedNodePreview}
-        captureNodePreviewImage={captureNodePreviewImage}
         closePopup={closePopup}
         context={context}
         debugDiagnostics={debugDiagnostics}

--- a/packages/workbench/surface/src/host/WorkbenchHostDockPopups.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDockPopups.tsx
@@ -53,7 +53,6 @@ export function WorkbenchHostDockPopups({
   activeMinimizedStackPopup,
   activePopup,
   captureMinimizedNodePreview,
-  captureNodePreviewImage,
   closePopup,
   context,
   debugDiagnostics,
@@ -79,7 +78,6 @@ export function WorkbenchHostDockPopups({
   captureMinimizedNodePreview: (
     node: WorkbenchMinimizedDockNode
   ) => Promise<string | null> | string | null;
-  captureNodePreviewImage?: WorkbenchHostProps["captureNodePreviewImage"];
   closePopup: () => void;
   context: WorkbenchDockContext<WorkbenchHostNodeData>;
   debugDiagnostics?: WorkbenchHostProps["debugDiagnostics"];
@@ -115,6 +113,8 @@ export function WorkbenchHostDockPopups({
       : (resolvedEntries.find(
           (entry) => entry.entry.id === activePopup.entryId
         ) ?? null);
+  const capturePopupItemPreview =
+    popupEntry?.entry.capturePopupItemPreview ?? null;
   const activeMinimizedStackSlot =
     activeMinimizedStackPopup === null
       ? null
@@ -190,12 +190,10 @@ export function WorkbenchHostDockPopups({
               : null
           }
           capturePreview={
-            popupEntry.entry.capturePopupItemPreview || captureNodePreviewImage
+            capturePopupItemPreview
               ? async (item) => {
                   const previewImageUrl = await Promise.resolve(
-                    popupEntry.entry.capturePopupItemPreview
-                      ? popupEntry.entry.capturePopupItemPreview(item)
-                      : (captureNodePreviewImage?.(item.node) ?? null)
+                    capturePopupItemPreview(item)
                   ).catch(() => null);
                   return previewImageUrl
                     ? {

--- a/packages/workbench/surface/src/host/useWorkbenchHostDockPopupPreviewCapture.ts
+++ b/packages/workbench/surface/src/host/useWorkbenchHostDockPopupPreviewCapture.ts
@@ -11,6 +11,10 @@ import type {
   WorkbenchHostProps
 } from "./types.ts";
 import type { WorkbenchHostDockPopupItem } from "./WorkbenchHostDockPopup.tsx";
+import {
+  workbenchDockPreviewIdentity,
+  workbenchNodePreviewRuntime
+} from "../preview/workbenchNodePreviewRuntime.ts";
 
 const dockPopupPreviewCacheMaxEntries = 64;
 const dockPopupPreviewByMemoryKey = new Map<
@@ -62,7 +66,9 @@ export function useWorkbenchHostDockPopupPreviewCapture(input: {
     items,
     resolveDockPreviewCacheKey
   } = input;
-  const hasCapturePreview = Boolean(capturePreview);
+  const canResolvePreview = Boolean(
+    capturePreview || resolveDockPreviewCacheKey
+  );
   const [capturedPreviewByMemoryKey, setCapturedPreviewByMemoryKey] = useState<
     Record<string, WorkbenchHostDockPopupCapturedPreview | undefined>
   >({});
@@ -105,7 +111,7 @@ export function useWorkbenchHostDockPopupPreviewCapture(input: {
   }, []);
 
   useEffect(() => {
-    if (!capturePreviewRef.current || isContextMenu) {
+    if (!canResolvePreview || isContextMenu) {
       return;
     }
     const captureItemStateIsCurrent = (itemStateKey: string): boolean =>
@@ -209,6 +215,31 @@ export function useWorkbenchHostDockPopupPreviewCapture(input: {
             resolvedCacheKey,
             revision
           );
+          const prefetchedPreview = cacheKey
+            ? await workbenchNodePreviewRuntime.ensure({
+                identity: workbenchDockPreviewIdentity(cacheKey),
+                nodeId: item.node.id
+              })
+            : null;
+          if (!captureItemStateIsCurrent(itemStateKey)) {
+            continue;
+          }
+          if (prefetchedPreview) {
+            const preview: WorkbenchDockPreviewContent = {
+              kind: "image",
+              src: prefetchedPreview
+            };
+            writeCachedWorkbenchNodePreviewImage(
+              item.node.id,
+              prefetchedPreview
+            );
+            writeDockPopupPreviewImage(previewMemoryKey, preview, revision);
+            setCapturedPreviewByMemoryKey((current) => ({
+              ...current,
+              [previewMemoryKey]: { preview, revision }
+            }));
+            continue;
+          }
           if (item.isMinimized && cacheKey) {
             const minimizedPersistedPreview = await readPersistedDockPreview(
               dockPreviewCacheRef.current,
@@ -268,6 +299,13 @@ export function useWorkbenchHostDockPopupPreviewCapture(input: {
           if (preview) {
             if (preview.kind === "image") {
               writeCachedWorkbenchNodePreviewImage(item.node.id, preview.src);
+              if (cacheKey) {
+                workbenchNodePreviewRuntime.write({
+                  identity: workbenchDockPreviewIdentity(cacheKey),
+                  nodeId: item.node.id,
+                  previewImageUrl: preview.src
+                });
+              }
             }
             writeDockPopupPreviewImage(previewMemoryKey, preview, revision);
             if (cacheKey && preview.kind === "image") {
@@ -298,6 +336,13 @@ export function useWorkbenchHostDockPopupPreviewCapture(input: {
               item.node.id,
               fallbackPersistedPreview
             );
+            if (cacheKey) {
+              workbenchNodePreviewRuntime.write({
+                identity: workbenchDockPreviewIdentity(cacheKey),
+                nodeId: item.node.id,
+                previewImageUrl: fallbackPersistedPreview
+              });
+            }
             const fallbackPreview: WorkbenchDockPreviewContent = {
               kind: "image",
               src: fallbackPersistedPreview
@@ -374,7 +419,7 @@ export function useWorkbenchHostDockPopupPreviewCapture(input: {
         }
       }
     };
-  }, [hasCapturePreview, isContextMenu, previewCaptureKey]);
+  }, [canResolvePreview, isContextMenu, previewCaptureKey]);
 
   return {
     previewStateFor(item) {
@@ -388,7 +433,7 @@ export function useWorkbenchHostDockPopupPreviewCapture(input: {
       return resolveDockPopupItemPreviewState(
         item,
         capturedPreview,
-        hasCapturePreview
+        canResolvePreview
       );
     }
   };

--- a/packages/workbench/surface/src/host/useWorkbenchHostFocusedDockPreviewCapture.ts
+++ b/packages/workbench/surface/src/host/useWorkbenchHostFocusedDockPreviewCapture.ts
@@ -1,0 +1,108 @@
+import { useEffect, useMemo } from "react";
+import type { WorkbenchDockContext } from "../react/types.ts";
+import type { WorkbenchDockPreviewCache } from "../react/dockPreviewCache.ts";
+import { captureWorkbenchNodePreviewImage } from "../react/useWorkbenchGenieAnimation.tsx";
+import {
+  workbenchDockPreviewIdentity,
+  workbenchNodePreviewRuntime
+} from "../preview/workbenchNodePreviewRuntime.ts";
+import { readWorkbenchHostExternalState } from "./externalState.ts";
+import type { ResolvedWorkbenchHostDockEntry } from "./dockEntries.ts";
+import { workbenchHostDockPopupPreviewViewport } from "./WorkbenchHostDockPopup.tsx";
+import type {
+  WorkbenchHostExternalStateSource,
+  WorkbenchHostHandle,
+  WorkbenchHostNodeData
+} from "./types.ts";
+
+export function useWorkbenchHostFocusedDockPreviewCapture(input: {
+  context: WorkbenchDockContext<WorkbenchHostNodeData>;
+  dockPreviewCache?: WorkbenchDockPreviewCache;
+  enabled: boolean;
+  externalStateRevision: number;
+  externalStateSource?: WorkbenchHostExternalStateSource;
+  host: WorkbenchHostHandle;
+  resolvedEntries: readonly ResolvedWorkbenchHostDockEntry[];
+  workspaceId: string;
+}): void {
+  const request = useMemo(() => {
+    if (!input.enabled || !input.context.focusedNodeId) {
+      return null;
+    }
+    const node = input.context.nodes.find(
+      (candidate) => candidate.id === input.context.focusedNodeId
+    );
+    if (!node || node.isMinimized) {
+      return null;
+    }
+    const resolvedEntry = input.resolvedEntries.find((entry) =>
+      entry.matchedNodes.some((candidate) => candidate.id === node.id)
+    );
+    if (!resolvedEntry) {
+      return null;
+    }
+
+    const externalState = readWorkbenchHostExternalState({
+      externalStateSource: input.externalStateSource,
+      node,
+      workspaceId: input.workspaceId
+    });
+    const popupItem = {
+      externalNodeState: externalState.externalNodeState,
+      externalWorkspaceState: externalState.externalWorkspaceState,
+      host: input.host,
+      isFocused: true,
+      isMinimized: false,
+      node,
+      previewViewport: workbenchHostDockPopupPreviewViewport
+    };
+    const descriptor = resolvedEntry.entry.resolvePopupItem?.(popupItem) ?? {};
+    const providedPreview =
+      descriptor.preview ??
+      resolvedEntry.entry.providePopupItemPreview?.(popupItem) ??
+      null;
+    if (providedPreview) {
+      return null;
+    }
+    const capture = resolvedEntry.entry.capturePopupItemPreview
+      ? () => resolvedEntry.entry.capturePopupItemPreview?.(popupItem) ?? null
+      : () => captureWorkbenchNodePreviewImage(node.id, { bypassCache: true });
+
+    const key = {
+      instanceId: node.data.instanceId,
+      instanceKey: node.data.instanceKey ?? null,
+      nodeId: node.id,
+      revision: descriptor.revision ?? null,
+      typeId: node.data.typeId,
+      workspaceId: input.workspaceId
+    };
+    return { capture, key, nodeId: node.id };
+  }, [
+    input.context.focusedNodeId,
+    input.context.nodes,
+    input.enabled,
+    input.externalStateRevision,
+    input.externalStateSource,
+    input.host,
+    input.resolvedEntries,
+    input.workspaceId
+  ]);
+
+  useEffect(() => {
+    if (!request) {
+      return;
+    }
+    void workbenchNodePreviewRuntime.ensure({
+      capture: request.capture,
+      identity: workbenchDockPreviewIdentity(request.key),
+      nodeId: request.nodeId,
+      writePersisted: input.dockPreviewCache
+        ? (previewImageUrl) =>
+            input.dockPreviewCache?.write({
+              key: request.key,
+              previewImageUrl
+            })
+        : undefined
+    });
+  }, [input.dockPreviewCache, request]);
+}

--- a/packages/workbench/surface/src/react/genieTextureCapture.test.tsx
+++ b/packages/workbench/surface/src/react/genieTextureCapture.test.tsx
@@ -14,6 +14,9 @@ describe("prepareGenieTextureCapture", () => {
       .preview-child { padding: 4px; }
     `;
     const source = document.createElement("section");
+    const overlappingWindow = document.createElement("section");
+    overlappingWindow.dataset.overlappingWindow = "true";
+    overlappingWindow.textContent = "Must not enter the isolated preview";
     source.className = "preview";
     source.style.setProperty("--preview-accent", "rgb(0, 128, 255)");
     source.innerHTML = `
@@ -23,7 +26,7 @@ describe("prepareGenieTextureCapture", () => {
     document.documentElement.dataset.theme = "dark";
     document.body.className = "app-shell";
     document.head.append(stylesheet);
-    document.body.append(source);
+    document.body.append(source, overlappingWindow);
     const child = source.querySelector<HTMLElement>(".preview-child");
     const image = source.querySelector<HTMLImageElement>("img");
     expect(child).not.toBeNull();
@@ -78,6 +81,9 @@ describe("prepareGenieTextureCapture", () => {
       expect(prepared?.clone.querySelector(".preview-child")?.textContent).toBe(
         "Agent preview"
       );
+      expect(
+        prepared?.clone.querySelector('[data-overlapping-window="true"]')
+      ).toBeNull();
       expect(childMeasurementCount).toBe(0);
       expect(imageMeasurementCount).toBe(1);
       expect(getComputedStyle).toHaveBeenCalledTimes(1);
@@ -105,6 +111,7 @@ describe("prepareGenieTextureCapture", () => {
     } finally {
       getComputedStyle.mockRestore();
       source.remove();
+      overlappingWindow.remove();
       stylesheet.remove();
       document.body.className = previousBodyClassName;
       if (previousTheme === undefined) {


### PR DESCRIPTION
## Summary
- prefetch focused Workbench node previews before the Dock popup can obscure them
- render only the target window capture element, so overlapping windows and overlays cannot leak into the thumbnail
- reuse revision-scoped memory and persistent images for background and minimized popup cards
- document the isolated-capture lifecycle and add multi-window plus overlapping-sibling regressions

## Tests
- `pnpm --filter @tutti-os/workbench-surface test`
- `pnpm check:changed -- --push-ready`
- linked `@tutti-os/workbench-surface` into TSH and ran its Dock preview unit tests plus Desktop type checks

## Notes
- Dock thumbnails no longer crop `webContents.capturePage()` output, because those pixels can belong to a different overlapping surface.
- Node-owned preview providers remain available for imperative content that cannot be represented by a cloned DOM capture element.
- Platform-neutral renderer/cache orchestration only; no path, process, shell, filesystem, or native API contract changes.