### PR TITLE
fix(connector): support provider-native MCP gateway

### DIFF
--- a/docs/specs/2026-08-07-connector-native-agent-integration.md
+++ b/docs/specs/2026-08-07-connector-native-agent-integration.md
@@ -176,12 +176,18 @@ Server 即使暂时没有工具也保持运行并注入 Agent。连接器发生�
 
 ### 5.2 首期协议范围
 
-本地 Server 使用 MCP `2026-07-28` 的无状态 HTTP 请求模型。每次调用都是一个
-独立的 `POST`，请求参数的 `_meta` 携带 protocol version、client info 和 client
-capabilities；HTTP header 同时携带 `MCP-Protocol-Version`、`Mcp-Method`，工具调用
-还校验 `Mcp-Name` 和 schema 声明的 `Mcp-Param-*`。
+本地 Server 同时提供两种 Agent-facing HTTP MCP 表面，并共享同一个
+`ConnectorMCPRegistry`：
 
-实现的方法为：
+- Tutti modern client 使用 MCP `2026-07-28` 的无状态请求模型。每次调用都是一个
+  独立的 `POST`，请求参数的 `_meta` 携带 protocol version、client info 和 client
+  capabilities；HTTP header 同时携带 `MCP-Protocol-Version`、`Mcp-Method`，工具调用
+  还校验 `Mcp-Name` 和 schema 声明的 `Mcp-Param-*`。
+- Codex、Claude 和其他 Provider 原生 client 使用 MCP `2025-06-18` 的标准
+  `initialize -> notifications/initialized -> tools/list -> tools/call` 链路。该表面还
+  返回空的 `resources/list` 和 `resources/templates/list`，因为首期只投影 tools。
+
+modern 表面实现：
 
 - `server/discover`；
 - `tools/list`；
@@ -190,9 +196,18 @@ capabilities；HTTP header 同时携带 `MCP-Protocol-Version`、`Mcp-Method`，
   `notifications/subscriptions/acknowledged` 和
   `notifications/tools/list_changed`。
 
-旧的 `initialize` / `notifications/initialized`、HTTP `GET` / `DELETE` 和
-`MCP-Session-Id` 不属于本地协议。Server 只接受 `POST`，不会在 daemon 内维护
-协议 Session；长连接只用于 `subscriptions/listen` 的通知流。
+Provider 原生表面实现：
+
+- `initialize`；
+- `notifications/initialized`、`notifications/cancelled`；
+- `ping`；
+- `tools/list`、`tools/call`；
+- `resources/list`、`resources/templates/list`，首期固定返回空列表。
+
+两种表面都只接受 `POST`，不会在 daemon 内维护协议 Session。HTTP `GET` / `DELETE`
+和 `MCP-Session-Id` 不属于首期范围；长连接只用于 modern
+`subscriptions/listen` 的通知流。Provider 原生表面声明 `tools.listChanged=false`，
+因此不会承诺尚未实现的原生 list-changed 通知。
 
 上游 tool 的 `name`、`description`、`inputSchema` 和调用结果保持 MCP 语义，
 只在本地聚合层增加连接器命名空间。
@@ -653,13 +668,15 @@ Provider 注入或动态刷新问题。
 ### 15.2 MCP Server 测试
 
 - `server/discover -> tools/list -> tools/call` 完整链路；
+- Provider 原生 `initialize -> tools/list -> tools/call` 完整链路；
+- Provider 原生 `resources/list`、`resources/templates/list` 返回空列表；
 - 每次请求的 `_meta` 和 MCP header 一致性校验；
 - 本地工具名正确映射回上游原始名称和 arguments；
 - 上游 content、structured result、`isError` 和 transport error 保持正确语义；
 - invalid token 被拒绝，相同 Session 重签、Session 清理和 `RevokeAll` 立即使旧 token
   失效；
 - 非 loopback Host、非法 Origin 被拒绝；
-- HTTP `GET` / `DELETE` 和旧协议方法被拒绝；
+- HTTP `GET` / `DELETE` 和未声明的方法被拒绝；
 - `subscriptions/listen` 先发送 acknowledged，Connector 更新后发送 list-changed，
   binding 撤销后结束订阅。
 

--- a/packages/connector/runtime/agentgateway/gateway.go
+++ b/packages/connector/runtime/agentgateway/gateway.go
@@ -198,6 +198,11 @@ func (gateway *Gateway) ServeHTTP(writer http.ResponseWriter, request *http.Requ
 	originalDirector := proxy.Director
 	proxy.Director = func(outbound *http.Request) {
 		originalDirector(outbound)
+		// NewSingleHostReverseProxy joins target.Path with the inbound path.
+		// Both bindings deliberately expose the same fixed MCP path, so the
+		// default join would forward /mcp/connector/mcp/connector.
+		outbound.URL.Path = target.Path
+		outbound.URL.RawPath = target.RawPath
 		outbound.Host = target.Host
 		outbound.Header.Del("Authorization")
 		if authorization := strings.TrimSpace(binding.Headers["Authorization"]); authorization != "" {

--- a/packages/connector/runtime/agentgateway/gateway_test.go
+++ b/packages/connector/runtime/agentgateway/gateway_test.go
@@ -24,6 +24,10 @@ func newBackendStub(t *testing.T, token, response string) *backendStub {
 	t.Helper()
 	backend := &backendStub{token: token}
 	backend.server = httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != connectorMCPPath {
+			http.NotFound(writer, request)
+			return
+		}
 		if request.Header.Get("Authorization") != "Bearer "+token {
 			http.Error(writer, "invalid backend authorization", http.StatusUnauthorized)
 			return

--- a/packages/connector/runtime/mcpserver/server.go
+++ b/packages/connector/runtime/mcpserver/server.go
@@ -23,9 +23,10 @@ import (
 )
 
 const (
-	serverName      = "connector"
-	protocolVersion = "2026-07-28"
-	maxRequestBytes = 2 << 20
+	serverName              = "connector"
+	protocolVersion         = "2026-07-28"
+	providerProtocolVersion = "2025-06-18"
+	maxRequestBytes         = 2 << 20
 )
 
 type Config struct {
@@ -200,8 +201,16 @@ func (server *Server) handlePost(writer http.ResponseWriter, request *http.Reque
 	decoder.DisallowUnknownFields()
 	var rpc rpcRequest
 	if err := decoder.Decode(&rpc); err != nil || decoder.Decode(&struct{}{}) != io.EOF || rpc.JSONRPC != "2.0" ||
-		len(rpc.ID) == 0 || strings.TrimSpace(rpc.Method) == "" {
+		strings.TrimSpace(rpc.Method) == "" {
 		writeRPCError(writer, http.StatusBadRequest, nullID(rpc.ID), -32600, "Invalid MCP request", nil)
+		return
+	}
+	if isProviderNativeMethod(request, rpc.Method) {
+		server.handleProviderNativePost(writer, request, token, auth, rpc)
+		return
+	}
+	if len(rpc.ID) == 0 {
+		writeRPCError(writer, http.StatusBadRequest, nil, -32600, "Invalid MCP request", nil)
 		return
 	}
 	params, metadata, err := decodeRequestParams(rpc.Params)
@@ -235,7 +244,7 @@ func (server *Server) handlePost(writer http.ResponseWriter, request *http.Reque
 			"resultType": "complete", "tools": tools, "ttlMs": 0, "cacheScope": "private",
 		}})
 	case "tools/call":
-		server.handleToolCall(writer, request, rpc.ID, params)
+		server.handleToolCall(writer, request, rpc.ID, params, true)
 	case "subscriptions/listen":
 		server.handleSubscription(writer, request, token, auth, rpc.ID, params)
 	default:
@@ -243,7 +252,84 @@ func (server *Server) handlePost(writer http.ResponseWriter, request *http.Reque
 	}
 }
 
-func (server *Server) handleToolCall(writer http.ResponseWriter, request *http.Request, id json.RawMessage, params map[string]json.RawMessage) {
+func isProviderNativeMethod(request *http.Request, method string) bool {
+	switch method {
+	case "initialize", "notifications/initialized", "notifications/cancelled", "ping",
+		"resources/list", "resources/templates/list":
+		return true
+	case "tools/list", "tools/call":
+		// The modern protocol always carries the method in its integrity header.
+		// Provider-native MCP clients do not.
+		return strings.TrimSpace(request.Header.Get("Mcp-Method")) == ""
+	default:
+		return false
+	}
+}
+
+func (server *Server) handleProviderNativePost(
+	writer http.ResponseWriter,
+	request *http.Request,
+	token string,
+	auth authorization,
+	rpc rpcRequest,
+) {
+	_ = token
+	_ = auth
+	switch rpc.Method {
+	case "initialize":
+		if len(rpc.ID) == 0 {
+			writeRPCError(writer, http.StatusBadRequest, nil, -32600, "Initialize request ID is required", nil)
+			return
+		}
+		var params struct {
+			ProtocolVersion string         `json:"protocolVersion"`
+			Capabilities    map[string]any `json:"capabilities"`
+			ClientInfo      implementation `json:"clientInfo"`
+		}
+		if json.Unmarshal(rpc.Params, &params) != nil || strings.TrimSpace(params.ProtocolVersion) == "" ||
+			strings.TrimSpace(params.ClientInfo.Name) == "" || strings.TrimSpace(params.ClientInfo.Version) == "" {
+			writeRPCError(writer, http.StatusBadRequest, rpc.ID, -32602, "Invalid initialize parameters", nil)
+			return
+		}
+		writeRPC(writer, http.StatusOK, rpcResponse{JSONRPC: "2.0", ID: rpc.ID, Result: map[string]any{
+			"protocolVersion": providerProtocolVersion,
+			"capabilities":    map[string]any{"tools": map[string]any{"listChanged": false}},
+			"serverInfo":      map[string]any{"name": serverName, "version": "1"},
+		}})
+	case "notifications/initialized", "notifications/cancelled":
+		writer.WriteHeader(http.StatusAccepted)
+	case "ping":
+		writeRPC(writer, http.StatusOK, rpcResponse{JSONRPC: "2.0", ID: rpc.ID, Result: map[string]any{}})
+	case "resources/list":
+		writeRPC(writer, http.StatusOK, rpcResponse{JSONRPC: "2.0", ID: rpc.ID, Result: map[string]any{"resources": []any{}}})
+	case "resources/templates/list":
+		writeRPC(writer, http.StatusOK, rpcResponse{JSONRPC: "2.0", ID: rpc.ID, Result: map[string]any{"resourceTemplates": []any{}}})
+	case "tools/list":
+		tools, err := server.registry.Tools(request.Context())
+		if err != nil {
+			writeRegistryError(writer, rpc.ID, err)
+			return
+		}
+		writeRPC(writer, http.StatusOK, rpcResponse{JSONRPC: "2.0", ID: rpc.ID, Result: map[string]any{"tools": tools}})
+	case "tools/call":
+		var params map[string]json.RawMessage
+		if len(rpc.ID) == 0 || json.Unmarshal(rpc.Params, &params) != nil {
+			writeRPCError(writer, http.StatusBadRequest, nullID(rpc.ID), -32602, "Invalid tool arguments", nil)
+			return
+		}
+		server.handleToolCall(writer, request, rpc.ID, params, false)
+	default:
+		writeRPCError(writer, http.StatusOK, nullID(rpc.ID), -32601, "Method not found", nil)
+	}
+}
+
+func (server *Server) handleToolCall(
+	writer http.ResponseWriter,
+	request *http.Request,
+	id json.RawMessage,
+	params map[string]json.RawMessage,
+	modern bool,
+) {
 	var name string
 	var arguments map[string]any
 	if json.Unmarshal(params["name"], &name) != nil || strings.TrimSpace(name) == "" ||
@@ -255,10 +341,14 @@ func (server *Server) handleToolCall(writer http.ResponseWriter, request *http.R
 		arguments = map[string]any{}
 	}
 	var parameterValidation error
-	raw, err := server.registry.CallValidated(request.Context(), name, arguments, func(tool implementationhost.MCPTool) error {
-		parameterValidation = validateToolParameterHeaders(request.Header, []implementationhost.MCPTool{tool}, name, params["arguments"])
-		return parameterValidation
-	})
+	var validate func(implementationhost.MCPTool) error
+	if modern {
+		validate = func(tool implementationhost.MCPTool) error {
+			parameterValidation = validateToolParameterHeaders(request.Header, []implementationhost.MCPTool{tool}, name, params["arguments"])
+			return parameterValidation
+		}
+	}
+	raw, err := server.registry.CallValidated(request.Context(), name, arguments, validate)
 	if err != nil {
 		if parameterValidation != nil {
 			writeRPCError(writer, http.StatusBadRequest, id, -32020, parameterValidation.Error(), nil)
@@ -272,8 +362,14 @@ func (server *Server) handleToolCall(writer http.ResponseWriter, request *http.R
 		writeRPCError(writer, http.StatusInternalServerError, id, -32603, "Invalid upstream tool result", nil)
 		return
 	}
-	if _, exists := result["resultType"]; !exists {
-		result["resultType"] = "complete"
+	if modern {
+		if _, exists := result["resultType"]; !exists {
+			result["resultType"] = "complete"
+		}
+	} else {
+		delete(result, "resultType")
+		delete(result, "ttlMs")
+		delete(result, "cacheScope")
 	}
 	writeRPC(writer, http.StatusOK, rpcResponse{JSONRPC: "2.0", ID: id, Result: result})
 }

--- a/packages/connector/runtime/mcpserver/server_test.go
+++ b/packages/connector/runtime/mcpserver/server_test.go
@@ -16,6 +16,59 @@ import (
 
 const protocolVersion = "2026-07-28"
 
+func TestServerServesProviderNativeMCP(t *testing.T) {
+	server, err := connectormcpserver.Start(connectormcpserver.Config{Registry: implementationhost.NewMCPRegistry()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = server.Close(context.Background()) })
+	binding, err := server.Binding("workspace-1", "session-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	initialized := postProviderRPC(t, binding.URL, binding.Headers["Authorization"], 1, "initialize", map[string]any{
+		"protocolVersion": "2025-06-18",
+		"capabilities":    map[string]any{},
+		"clientInfo":      map[string]any{"name": "codex", "version": "1"},
+	})
+	defer initialized.Body.Close()
+	var initializePayload struct {
+		Result struct {
+			ProtocolVersion string `json:"protocolVersion"`
+			ServerInfo      struct {
+				Name string `json:"name"`
+			} `json:"serverInfo"`
+		} `json:"result"`
+	}
+	if initialized.StatusCode != http.StatusOK || json.NewDecoder(initialized.Body).Decode(&initializePayload) != nil ||
+		initializePayload.Result.ProtocolVersion != "2025-06-18" || initializePayload.Result.ServerInfo.Name != "connector" {
+		t.Fatalf("initialize status=%d payload=%#v", initialized.StatusCode, initializePayload)
+	}
+
+	listing := postProviderRPC(t, binding.URL, binding.Headers["Authorization"], 2, "tools/list", map[string]any{})
+	defer listing.Body.Close()
+	var listPayload struct {
+		Result struct {
+			Tools []implementationhost.MCPTool `json:"tools"`
+		} `json:"result"`
+	}
+	if listing.StatusCode != http.StatusOK || json.NewDecoder(listing.Body).Decode(&listPayload) != nil || listPayload.Result.Tools == nil {
+		t.Fatalf("tools/list status=%d payload=%#v", listing.StatusCode, listPayload)
+	}
+
+	resources := postProviderRPC(t, binding.URL, binding.Headers["Authorization"], 3, "resources/list", map[string]any{})
+	defer resources.Body.Close()
+	var resourcesPayload struct {
+		Result struct {
+			Resources []any `json:"resources"`
+		} `json:"result"`
+	}
+	if resources.StatusCode != http.StatusOK || json.NewDecoder(resources.Body).Decode(&resourcesPayload) != nil || resourcesPayload.Result.Resources == nil {
+		t.Fatalf("resources/list status=%d payload=%#v", resources.StatusCode, resourcesPayload)
+	}
+}
+
 func TestServerIssuesSessionScopedBindingAndServesModernMCP(t *testing.T) {
 	server, err := connectormcpserver.Start(connectormcpserver.Config{Registry: implementationhost.NewMCPRegistry()})
 	if err != nil {
@@ -199,6 +252,26 @@ func readSSEPayload(t *testing.T, reader *bufio.Reader) map[string]any {
 func postModernRPC(t *testing.T, endpoint, authorization string, id int, method string, params map[string]any) *http.Response {
 	t.Helper()
 	request := modernRPCRequest(t, endpoint, authorization, id, method, params)
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return response
+}
+
+func postProviderRPC(t *testing.T, endpoint, authorization string, id int, method string, params map[string]any) *http.Response {
+	t.Helper()
+	raw, err := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": id, "method": method, "params": params})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Authorization", authorization)
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json, text/event-stream")
 	response, err := http.DefaultClient.Do(request)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary
- preserve the fixed Connector MCP gateway path when proxying Agent requests
- add provider-native MCP 2025-06-18 initialize, tools, ping, and empty resources compatibility alongside the modern protocol
- document the dual Agent-facing MCP surface and add regression coverage

## Validation
- `go test ./... -count=1` in `packages/connector/runtime`
- `go test ./... -count=1` in connector host, daemon, and store-sqlite modules
- `pnpm check:changed -- --push-ready` via pre-push hook
- local TSH Computer Use E2E: Tencent Docs ready, native MCP tool discovery succeeded, read-only recent-files call returned 10 files