### PR TITLE
fix(agent): handle Codex MCP elicitation requests

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2730,6 +2730,15 @@ while waiting for user input. If the provider can emit follow-up frames during
 that wait, the adapter keeps reading and joins them before publishing the
 canonical Interaction. When the answer is delivered, local call resolution is
 serialized ahead of provider terminal messages caused by that answer.
+Codex app-server requests are classified explicitly against the generated
+server-request surface. A request being schema-known does not make it a
+background request that may be declined silently. Message-only MCP form
+elicitations reuse the canonical approval Interaction and preserve the exact
+`accept`, `decline`, `cancel`, and advertised persistence semantics in the
+app-server response. Field-bearing forms, URL elicitations, and other request
+shapes that AgentGUI cannot represent losslessly fail closed before publishing
+an Interaction; adapters must not coerce them into a partial approval or
+question surface.
 When a standard ACP provider bridges a structured question through
 one `session/request_permission` as the complete question transaction, one
 selected permission option is that bridge's entire response capacity. The

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -47,6 +47,7 @@ const (
 	appServerMethodFileChangeApproval  = "item/fileChange/requestApproval"
 	appServerMethodPermissionsApproval = "item/permissions/requestApproval"
 	appServerMethodRequestUserInput    = "item/tool/requestUserInput"
+	appServerMethodMCPElicitation      = "mcpServer/elicitation/request"
 	appServerMethodExecApprovalV1      = "execCommandApproval"
 	appServerMethodPatchApprovalV1     = "applyPatchApproval"
 

--- a/packages/agent/daemon/runtime/codex_appserver_elicitation.go
+++ b/packages/agent/daemon/runtime/codex_appserver_elicitation.go
@@ -1,0 +1,230 @@
+package agentruntime
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+)
+
+const (
+	appServerMCPElicitationApprovalKindKey  = "codex_approval_kind"
+	appServerMCPElicitationToolApprovalKind = "mcp_tool_call"
+	appServerMCPElicitationToolSuggestKind  = "tool_suggestion"
+	appServerMCPElicitationPersistKey       = "persist"
+	appServerMCPElicitationPersistSession   = "session"
+	appServerMCPElicitationPersistAlways    = "always"
+)
+
+func (a *CodexAppServerAdapter) appServerMCPElicitationRequested(
+	session Session,
+	turnID string,
+	requestID string,
+	params map[string]any,
+) ([]activityshared.Event, *pendingInteractiveRequest, error) {
+	if err := validateMessageOnlyMCPElicitation(params); err != nil {
+		return nil, nil, err
+	}
+
+	message, ok := params["message"].(string)
+	if !ok {
+		return nil, nil, errors.New("MCP elicitation message must be a string")
+	}
+	message = strings.TrimSpace(message)
+	if message == "" {
+		message = "MCP server requests permission."
+	}
+	serverName, ok := params["serverName"].(string)
+	if !ok {
+		return nil, nil, errors.New("MCP elicitation serverName must be a string")
+	}
+	serverName = strings.TrimSpace(serverName)
+	if serverName == "" {
+		return nil, nil, errors.New("MCP elicitation serverName is required")
+	}
+	meta := payloadObject(params["_meta"])
+	if asString(meta[appServerMCPElicitationApprovalKindKey]) == appServerMCPElicitationToolSuggestKind {
+		return nil, nil, errors.New("MCP tool-suggestion elicitation is not supported")
+	}
+	options := appServerMCPElicitationApprovalOptions(meta)
+	input := map[string]any{
+		"requestId":       requestID,
+		"reason":          message,
+		"serverName":      serverName,
+		"mode":            "form",
+		"requestedSchema": clonePayloadValue(params["requestedSchema"]),
+		"options":         cloneOptionMaps(options),
+	}
+	pending := &pendingInteractiveRequest{
+		agentSessionID: strings.TrimSpace(session.AgentSessionID),
+		turnID:         strings.TrimSpace(turnID),
+		requestID:      requestID,
+		eventID:        newID(),
+		callID:         requestID,
+		callType:       "approval",
+		input:          input,
+		kind:           "approval",
+		providerTurnID: strings.TrimSpace(
+			asString(params["turnId"]),
+		),
+		name:     message,
+		toolName: serverName,
+		options:  options,
+		response: make(chan pendingInteractiveResponse, 1),
+	}
+	a.storePendingRequest(pending)
+	return []activityshared.Event{
+		newTurnActivityEvent(session, EventTurnUpdated, turnID, SessionStatusWaiting, "", "", map[string]any{
+			"phase":     string(activityshared.TurnPhaseWaitingApproval),
+			"requestId": requestID,
+		}),
+		newTurnActivityEventWithID(
+			session,
+			pending.eventID,
+			EventCallStarted,
+			turnID,
+			SessionStatusWaiting,
+			"",
+			message,
+			map[string]any{
+				"callId":   pending.callID,
+				"callType": pending.callType,
+				"name":     pending.name,
+				"toolName": pending.toolName,
+				"status":   string(activityshared.TurnPhaseWaitingApproval),
+				"input":    clonePayload(input),
+				"metadata": map[string]any{
+					"callType":  pending.callType,
+					"mcpServer": serverName,
+				},
+			},
+		),
+		normalizedInteractionRequestedEvent(session, turnID, pending),
+	}, pending, nil
+}
+
+func validateMessageOnlyMCPElicitation(params map[string]any) error {
+	mode := strings.TrimSpace(asString(params["mode"]))
+	if mode != "form" {
+		return fmt.Errorf("MCP elicitation mode %q is not supported", mode)
+	}
+	schema, ok := params["requestedSchema"].(map[string]any)
+	if !ok {
+		return errors.New("MCP elicitation requestedSchema must be an object")
+	}
+	if strings.TrimSpace(asString(schema["type"])) != "object" {
+		return errors.New("MCP elicitation requestedSchema type must be object")
+	}
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		return errors.New("MCP elicitation requestedSchema properties must be an object")
+	}
+	if len(properties) > 0 {
+		return errors.New("MCP elicitation forms with fields are not supported")
+	}
+	if required, exists := schema["required"]; exists {
+		values, valid := appServerMCPStringArray(required)
+		if !valid {
+			return errors.New("MCP elicitation requestedSchema required must be a string array")
+		}
+		if len(values) > 0 {
+			return errors.New("MCP elicitation message-only schema cannot require fields")
+		}
+	}
+	for key := range schema {
+		switch key {
+		case "$schema", "type", "properties", "required":
+		default:
+			return fmt.Errorf("MCP elicitation requestedSchema field %q is not supported", key)
+		}
+	}
+	return nil
+}
+
+func appServerMCPElicitationApprovalOptions(meta map[string]any) []map[string]any {
+	options := []map[string]any{
+		{"optionId": "approve", "name": "Allow", "kind": "allow_once"},
+	}
+	if appServerMCPElicitationSupportsPersist(meta, appServerMCPElicitationPersistSession) {
+		options = append(options, map[string]any{
+			"optionId": "approve_for_session",
+			"name":     "Allow for this session",
+			"kind":     "allow_always",
+		})
+	}
+	if appServerMCPElicitationSupportsPersist(meta, appServerMCPElicitationPersistAlways) {
+		options = append(options, map[string]any{
+			"optionId": "approve_always",
+			"name":     "Always allow",
+			"kind":     "allow_always",
+		})
+	}
+	if asString(meta[appServerMCPElicitationApprovalKindKey]) == appServerMCPElicitationToolApprovalKind {
+		return append(options, map[string]any{
+			"optionId": "cancel",
+			"name":     "Cancel",
+			"kind":     "reject_once",
+		})
+	}
+	return append(options,
+		map[string]any{"optionId": "deny", "name": "Deny", "kind": "reject_once"},
+		map[string]any{"optionId": "cancel", "name": "Cancel", "kind": "reject_once"},
+	)
+}
+
+func appServerMCPElicitationSupportsPersist(meta map[string]any, expected string) bool {
+	persist := meta[appServerMCPElicitationPersistKey]
+	if asString(persist) == expected {
+		return true
+	}
+	values, _ := appServerMCPStringArray(persist)
+	for _, value := range values {
+		if value == expected {
+			return true
+		}
+	}
+	return false
+}
+
+func appServerMCPStringArray(value any) ([]string, bool) {
+	switch typed := value.(type) {
+	case nil:
+		return nil, true
+	case []string:
+		return append([]string(nil), typed...), true
+	case []any:
+		values := make([]string, 0, len(typed))
+		for _, entry := range typed {
+			text, ok := entry.(string)
+			if !ok {
+				return nil, false
+			}
+			values = append(values, text)
+		}
+		return values, true
+	default:
+		return nil, false
+	}
+}
+
+func appServerMCPElicitationResult(selection pendingInteractiveResponse) map[string]any {
+	result := map[string]any{}
+	switch strings.TrimSpace(selection.optionID) {
+	case "approve":
+		result["action"] = "accept"
+	case "approve_for_session":
+		result["action"] = "accept"
+		result["_meta"] = map[string]any{appServerMCPElicitationPersistKey: appServerMCPElicitationPersistSession}
+	case "approve_always":
+		result["action"] = "accept"
+		result["_meta"] = map[string]any{appServerMCPElicitationPersistKey: appServerMCPElicitationPersistAlways}
+	case "deny":
+		result["action"] = "decline"
+	case "cancel":
+		result["action"] = "cancel"
+	default:
+		result["action"] = "cancel"
+	}
+	return result
+}

--- a/packages/agent/daemon/runtime/codex_appserver_event_interactive.go
+++ b/packages/agent/daemon/runtime/codex_appserver_event_interactive.go
@@ -195,6 +195,9 @@ func (a *CodexAppServerAdapter) appServerApprovalRequested(
 	if method == appServerMethodRequestUserInput {
 		return a.appServerUserInputRequested(session, turnID, requestID, params)
 	}
+	if method == appServerMethodMCPElicitation {
+		return a.appServerMCPElicitationRequested(session, turnID, requestID, params)
+	}
 	toolCall := appServerApprovalToolCall(method, params)
 	options := appServerApprovalOptions(method)
 	title := firstNonEmpty(asString(toolCall["title"]), "Permission requested")
@@ -482,6 +485,8 @@ func appServerApprovalResult(method string, params map[string]any, selection pen
 		return map[string]any{
 			"answers": appServerUserInputAnswers(params, selection),
 		}, nil
+	case appServerMethodMCPElicitation:
+		return appServerMCPElicitationResult(selection), nil
 	default:
 		return map[string]any{}, nil
 	}

--- a/packages/agent/daemon/runtime/codex_appserver_events.go
+++ b/packages/agent/daemon/runtime/codex_appserver_events.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
-	"github.com/tutti-os/tutti/packages/agent/daemon/runtime/codexproto"
 )
 
 // handleAppServerMessage routes codex app-server server->client traffic.
@@ -28,27 +27,24 @@ func (a *CodexAppServerAdapter) handleAppServerMessage(
 		return nil, nil
 	}
 	if len(message.ID) > 0 {
-		switch message.Method {
-		case appServerMethodCommandApproval,
-			appServerMethodFileChangeApproval,
-			appServerMethodPermissionsApproval,
-			appServerMethodRequestUserInput,
-			appServerMethodExecApprovalV1,
-			appServerMethodPatchApprovalV1:
+		switch appServerServerRequestDispositionForMethod(message.Method) {
+		case appServerServerRequestInteractive:
 			return a.appServerServerRequest(ctx, client, session, turnID, message, normalizer, emit)
-		default:
+		case appServerServerRequestUnsupportedBackground:
 			err := fmt.Errorf("server request method %q is not supported", message.Method)
-			if codexproto.IsKnownServerRequestMethod(message.Method) {
-				// Schema-known background requests the daemon deliberately
-				// declines (auth token refresh, attestation, sandbox setup)
-				// get a silent -32601; a transcript failure card would show
-				// users spurious red cards for background operations.
-				slog.Debug(
-					"agent session app-server declined known server request",
-					"agent_session_id", session.AgentSessionID,
-					"method", message.Method,
-				)
-			} else if emit != nil {
+			// These requests are explicit initialize-time capabilities that this
+			// client does not advertise. Decline them without manufacturing a
+			// foreground failure card.
+			slog.Debug(
+				"agent session app-server declined background server request",
+				"agent_session_id", session.AgentSessionID,
+				"method", message.Method,
+			)
+			_ = client.Respond(ctx, message.ID, nil, &acpError{Code: -32601, Message: err.Error()})
+			return nil, nil
+		case appServerServerRequestUnsupportedForeground, appServerServerRequestUnknown:
+			err := fmt.Errorf("server request method %q is not supported", message.Method)
+			if emit != nil {
 				emit(appServerUnsupportedServerRequestEvents(session, turnID, message, err))
 			}
 			_ = client.Respond(ctx, message.ID, nil, &acpError{Code: -32601, Message: err.Error()})
@@ -65,6 +61,34 @@ func (a *CodexAppServerAdapter) handleAppServerMessage(
 	}
 	reduction := newCodexAppServerReducer(a).ReduceNotification(client, session, turnID, message, normalizer, emitCommands)
 	return reduction.Events, nil
+}
+
+type appServerServerRequestDisposition uint8
+
+const (
+	appServerServerRequestUnknown appServerServerRequestDisposition = iota
+	appServerServerRequestInteractive
+	appServerServerRequestUnsupportedBackground
+	appServerServerRequestUnsupportedForeground
+)
+
+func appServerServerRequestDispositionForMethod(method string) appServerServerRequestDisposition {
+	switch method {
+	case appServerMethodCommandApproval,
+		appServerMethodFileChangeApproval,
+		appServerMethodPermissionsApproval,
+		appServerMethodRequestUserInput,
+		appServerMethodMCPElicitation,
+		appServerMethodExecApprovalV1,
+		appServerMethodPatchApprovalV1:
+		return appServerServerRequestInteractive
+	case "account/chatgptAuthTokens/refresh", "attestation/generate":
+		return appServerServerRequestUnsupportedBackground
+	case "item/tool/call":
+		return appServerServerRequestUnsupportedForeground
+	default:
+		return appServerServerRequestUnknown
+	}
 }
 
 func appServerNotificationUsesNormalizer(method string) bool {

--- a/packages/agent/daemon/runtime/codex_appserver_events_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_events_test.go
@@ -12,6 +12,7 @@ import (
 
 	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 	"github.com/tutti-os/tutti/packages/agent/daemon/liveprotocol"
+	"github.com/tutti-os/tutti/packages/agent/daemon/runtime/codexproto"
 )
 
 type appServerCaptureConn struct {
@@ -965,7 +966,7 @@ func TestCodexAppServerControlCardNeverClaimsChildOwnership(t *testing.T) {
 	}
 }
 
-func TestCodexAppServerUnhandledServerRequestCardOnlyForUnknownMethods(t *testing.T) {
+func TestCodexAppServerUnsupportedServerRequestCardsFollowDisposition(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -976,6 +977,8 @@ func TestCodexAppServerUnhandledServerRequestCardOnlyForUnknownMethods(t *testin
 		// Schema-known background request the daemon deliberately declines:
 		// respond -32601 silently, no transcript failure card.
 		{name: "known background request stays silent", method: "account/chatgptAuthTokens/refresh", wantCard: false},
+		{name: "known attestation request stays silent", method: "attestation/generate", wantCard: false},
+		{name: "known foreground request renders failure card", method: "item/tool/call", wantCard: true},
 		{name: "unknown request renders failure card", method: "definitely/notInSchema", wantCard: true},
 	}
 
@@ -1019,6 +1022,261 @@ func TestCodexAppServerUnhandledServerRequestCardOnlyForUnknownMethods(t *testin
 			}
 			if len(emitted) != 1 || emitted[0].Type != activityshared.EventCallFailed {
 				t.Fatalf("emitted = %#v, want one call.failed card", emitted)
+			}
+		})
+	}
+}
+
+func TestCodexAppServerClassifiesEveryGeneratedServerRequest(t *testing.T) {
+	t.Parallel()
+
+	for _, method := range codexproto.ServerRequestMethods() {
+		if disposition := appServerServerRequestDispositionForMethod(method); disposition == appServerServerRequestUnknown {
+			t.Errorf("generated server request %q has no explicit adapter disposition", method)
+		}
+	}
+}
+
+func TestCodexAppServerMessageOnlyMCPElicitationRoundTripsApproval(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		optionID     string
+		meta         map[string]any
+		wantAction   string
+		wantPersist  string
+		wantOptionID []string
+	}{
+		{
+			name:         "allow once",
+			optionID:     "approve",
+			meta:         map[string]any{"codex_approval_kind": "mcp_tool_call", "persist": []any{"session", "always"}},
+			wantAction:   "accept",
+			wantOptionID: []string{"approve", "approve_for_session", "approve_always", "cancel"},
+		},
+		{
+			name:         "allow for session",
+			optionID:     "approve_for_session",
+			meta:         map[string]any{"codex_approval_kind": "mcp_tool_call", "persist": []any{"session", "always"}},
+			wantAction:   "accept",
+			wantPersist:  "session",
+			wantOptionID: []string{"approve", "approve_for_session", "approve_always", "cancel"},
+		},
+		{
+			name:         "always allow",
+			optionID:     "approve_always",
+			meta:         map[string]any{"codex_approval_kind": "mcp_tool_call", "persist": []any{"session", "always"}},
+			wantAction:   "accept",
+			wantPersist:  "always",
+			wantOptionID: []string{"approve", "approve_for_session", "approve_always", "cancel"},
+		},
+		{
+			name:         "cancel tool call",
+			optionID:     "cancel",
+			meta:         map[string]any{"codex_approval_kind": "mcp_tool_call", "persist": []any{"session", "always"}},
+			wantAction:   "cancel",
+			wantOptionID: []string{"approve", "approve_for_session", "approve_always", "cancel"},
+		},
+		{
+			name:         "decline ordinary request",
+			optionID:     "deny",
+			wantAction:   "decline",
+			wantOptionID: []string{"approve", "deny", "cancel"},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			conn := newAppServerCaptureConn()
+			client := newCodexAppServerClient(conn)
+			defer func() { _ = client.Close() }()
+			adapter := NewCodexAppServerAdapter(nil)
+			session := Session{
+				AgentSessionID:    "agent-session-1",
+				Provider:          ProviderCodex,
+				ProviderSessionID: "thread-1",
+				CWD:               "/workspace",
+			}
+			adapter.storeSession(session.AgentSessionID, &codexAppServerSession{
+				threadID:        session.ProviderSessionID,
+				pendingRequests: make(map[string]*pendingInteractiveRequest),
+			})
+
+			var emitted []activityshared.Event
+			_, err := adapter.handleAppServerMessage(
+				context.Background(),
+				client,
+				session,
+				"turn-1",
+				acpMessage{
+					ID:     json.RawMessage(`"elicitation-1"`),
+					Method: "mcpServer/elicitation/request",
+					Params: mustJSONRawMessage(t, map[string]any{
+						"threadId":   "thread-1",
+						"turnId":     "provider-turn-1",
+						"serverName": "node_repl",
+						"mode":       "form",
+						"message":    "Allow node_repl to control the visible Browser?",
+						"requestedSchema": map[string]any{
+							"type":       "object",
+							"properties": map[string]any{},
+						},
+						"_meta": tc.meta,
+					}),
+				},
+				newACPTurnNormalizer(),
+				func(events []activityshared.Event) { emitted = append(emitted, events...) },
+				nil,
+			)
+			if err != nil {
+				t.Fatalf("handleAppServerMessage: %v", err)
+			}
+
+			pending := adapter.getPendingRequest(session.AgentSessionID, "turn-1", "elicitation-1")
+			if pending == nil || pending.kind != "approval" || asString(pending.input["reason"]) != "Allow node_repl to control the visible Browser?" {
+				t.Fatalf("pending elicitation = %#v, want visible approval", pending)
+			}
+			optionIDs := make([]string, 0, len(pending.options))
+			for _, option := range pending.options {
+				optionIDs = append(optionIDs, asString(option["optionId"]))
+			}
+			if !reflect.DeepEqual(optionIDs, tc.wantOptionID) {
+				t.Fatalf("option ids = %#v, want %#v", optionIDs, tc.wantOptionID)
+			}
+			for _, option := range pending.options {
+				if asString(option["optionId"]) == "cancel" &&
+					(asString(option["name"]) != "Cancel" || asString(option["kind"]) != "reject_once") {
+					t.Fatalf("cancel option = %#v, want neutral one-shot cancellation presentation", option)
+				}
+			}
+			if requested := eventsOfType(emitted, activityshared.EventInteractionRequested); len(requested) != 1 {
+				t.Fatalf("interaction.requested events = %#v, want one", requested)
+			}
+
+			result, err := adapter.SubmitInteractive(context.Background(), session, SubmitInteractiveInput{
+				TurnID:    "turn-1",
+				RequestID: "elicitation-1",
+				OptionID:  tc.optionID,
+			})
+			if err != nil || !result.Accepted || result.OptionID != tc.optionID {
+				t.Fatalf("SubmitInteractive = %#v, %v", result, err)
+			}
+
+			responses := conn.responses(t)
+			if len(responses) != 1 || responses[0].Error != nil {
+				t.Fatalf("responses = %#v, want one success", responses)
+			}
+			var response map[string]any
+			if err := json.Unmarshal(responses[0].Result, &response); err != nil {
+				t.Fatalf("unmarshal elicitation response: %v", err)
+			}
+			if asString(response["action"]) != tc.wantAction {
+				t.Fatalf("response = %#v, want action %q", response, tc.wantAction)
+			}
+			meta := payloadObject(response["_meta"])
+			if asString(meta["persist"]) != tc.wantPersist {
+				t.Fatalf("response meta = %#v, want persist %q", meta, tc.wantPersist)
+			}
+			if _, exists := response["content"]; exists {
+				t.Fatalf("message-only response = %#v, want no content", response)
+			}
+		})
+	}
+}
+
+func TestCodexAppServerRejectsMCPElicitationItCannotRepresent(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		params map[string]any
+	}{
+		{
+			name: "form fields",
+			params: map[string]any{
+				"mode":    "form",
+				"message": "Choose a value",
+				"requestedSchema": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"value": map[string]any{"type": "string"},
+					},
+				},
+			},
+		},
+		{
+			name: "URL mode",
+			params: map[string]any{
+				"mode":          "url",
+				"message":       "Open authorization page",
+				"url":           "https://example.com/authorize",
+				"elicitationId": "url-1",
+			},
+		},
+		{
+			name: "tool suggestion",
+			params: map[string]any{
+				"mode":    "form",
+				"message": "Install a suggested tool",
+				"requestedSchema": map[string]any{
+					"type":       "object",
+					"properties": map[string]any{},
+				},
+				"_meta": map[string]any{"codex_approval_kind": "tool_suggestion"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			conn := newAppServerCaptureConn()
+			client := newCodexAppServerClient(conn)
+			defer func() { _ = client.Close() }()
+			adapter := NewCodexAppServerAdapter(nil)
+			session := Session{
+				AgentSessionID:    "agent-session-1",
+				Provider:          ProviderCodex,
+				ProviderSessionID: "thread-1",
+			}
+			adapter.storeSession(session.AgentSessionID, &codexAppServerSession{
+				threadID:        session.ProviderSessionID,
+				pendingRequests: make(map[string]*pendingInteractiveRequest),
+			})
+			params := clonePayload(tc.params)
+			params["threadId"] = "thread-1"
+			params["turnId"] = "provider-turn-1"
+			params["serverName"] = "node_repl"
+
+			_, err := adapter.handleAppServerMessage(
+				context.Background(),
+				client,
+				session,
+				"turn-1",
+				acpMessage{
+					ID:     json.RawMessage(`"elicitation-unsupported"`),
+					Method: "mcpServer/elicitation/request",
+					Params: mustJSONRawMessage(t, params),
+				},
+				newACPTurnNormalizer(),
+				func([]activityshared.Event) {},
+				nil,
+			)
+			if err == nil {
+				t.Fatal("unrepresentable elicitation was accepted")
+			}
+			if pending := adapter.getPendingRequest(session.AgentSessionID, "turn-1", "elicitation-unsupported"); pending != nil {
+				t.Fatalf("unrepresentable elicitation registered pending state: %#v", pending)
+			}
+			responses := conn.responses(t)
+			if len(responses) != 1 || responses[0].Error == nil || responses[0].Error.Code != -32602 {
+				t.Fatalf("responses = %#v, want one -32602", responses)
 			}
 		})
 	}

--- a/packages/agent/daemon/runtime/codexproto/internal/codegen/main.go
+++ b/packages/agent/daemon/runtime/codexproto/internal/codegen/main.go
@@ -678,6 +678,14 @@ func renderServerRequests(methods []rpcMethod, codexCommit string) []byte {
 	b.WriteString("func IsKnownServerRequestMethod(method string) bool {\n")
 	b.WriteString("\t_, ok := serverRequestParsers[method]\n\treturn ok\n}\n\n")
 
+	b.WriteString("// ServerRequestMethods returns the generated server request surface in stable order.\n")
+	b.WriteString("func ServerRequestMethods() []string {\n")
+	b.WriteString("\treturn []string{\n")
+	for _, method := range methods {
+		fmt.Fprintf(&b, "\t\t%q,\n", method.Method)
+	}
+	b.WriteString("\t}\n}\n\n")
+
 	b.WriteString("func dispatchServerRequest(ctx context.Context, handler ServerRequestHandler, req JSONRPCRequest) (any, error) {\n")
 	b.WriteString("\tswitch req.Method {\n")
 	for _, method := range methods {

--- a/packages/agent/daemon/runtime/codexproto/server_requests_gen.go
+++ b/packages/agent/daemon/runtime/codexproto/server_requests_gen.go
@@ -139,6 +139,22 @@ func IsKnownServerRequestMethod(method string) bool {
 	return ok
 }
 
+// ServerRequestMethods returns the generated server request surface in stable order.
+func ServerRequestMethods() []string {
+	return []string{
+		"account/chatgptAuthTokens/refresh",
+		"applyPatchApproval",
+		"attestation/generate",
+		"execCommandApproval",
+		"item/commandExecution/requestApproval",
+		"item/fileChange/requestApproval",
+		"item/permissions/requestApproval",
+		"item/tool/call",
+		"item/tool/requestUserInput",
+		"mcpServer/elicitation/request",
+	}
+}
+
 func dispatchServerRequest(ctx context.Context, handler ServerRequestHandler, req JSONRPCRequest) (any, error) {
 	switch req.Method {
 	case "account/chatgptAuthTokens/refresh":


### PR DESCRIPTION
## Summary
- Handle message-only `mcpServer/elicitation/request` calls as canonical AgentGUI approval interactions.
- Preserve Codex `accept`, `decline`, `cancel`, and advertised session/always persistence semantics while failing closed for elicitation shapes the UI cannot represent losslessly.
- Explicitly classify every generated Codex server request so unsupported foreground requests are visible and future protocol additions fail regression coverage.

## Tests
- `go test ./runtime -count=1`
- `go test ./runtime -shuffle=on -count=3`
- `go test -race ./runtime -run 'TestCodexAppServerMessageOnlyMCPElicitationRoundTripsApproval$' -count=1`
- `pnpm check:changed -- --push-ready` (9 lanes passed)

## Notes
- Field-bearing forms, URL mode, `openai/form`, and tool-suggestion elicitations remain explicitly unsupported until AgentGUI can represent their answers losslessly.
- Windows impact is platform-neutral JSON-RPC normalization only; this change adds no OS-specific paths, process handling, or filesystem behavior.
- A real TSH Browser E2E was not run; the Browser approval shape and response semantics are covered at the Codex adapter boundary.
