### PR TITLE
feat: self-heal relay owner sessions on readiness loss

### DIFF
--- a/packages/clients/device-authority-go/README.md
+++ b/packages/clients/device-authority-go/README.md
@@ -17,6 +17,8 @@ The module owns:
   and lease-renewal HTTP wire contracts;
 - the canonical `tsh.gateway.owner-session.v1` Ed25519 signing payload;
 - response-to-request credential binding checks;
+- `ErrResponseBinding` for adapters to fail closed when a lease response is
+  bound to a different authority;
 - bounded response and HTTP error metadata handling;
 - a reusable process-local Ed25519 identity source compatible with TSH's
   current behavior.
@@ -60,7 +62,8 @@ product demand
   -> RegisterDeviceGatewayIdentity
   -> IssueDeviceGatewayOwnerTunnelToken
   -> product starts relaytransport.OwnerHost
-  -> RenewDeviceAuthorityLease on the product schedule
+  -> RenewDeviceAuthorityLease on the product schedule while its server
+     `ExpiresAt` remains fresh
   -> product releases Relay demand
 ```
 

--- a/packages/clients/device-authority-go/client.go
+++ b/packages/clients/device-authority-go/client.go
@@ -285,7 +285,7 @@ func (c *Client) RenewDeviceAuthorityLease(ctx context.Context, req RenewDeviceA
 	}
 	responseAuthorityID := strings.TrimSpace(raw.AuthorityID)
 	if responseAuthorityID != "" && responseAuthorityID != authorityID {
-		return RenewDeviceAuthorityLeaseResult{}, fmt.Errorf("renew device authority lease response authority id %q does not match request %q", responseAuthorityID, authorityID)
+		return RenewDeviceAuthorityLeaseResult{}, fmt.Errorf("%w: renew response authority id does not match request", ErrResponseBinding)
 	}
 	return RenewDeviceAuthorityLeaseResult{
 		AuthorityID: responseAuthorityID,

--- a/packages/clients/device-authority-go/types.go
+++ b/packages/clients/device-authority-go/types.go
@@ -1,6 +1,16 @@
 package deviceauthority
 
-import "time"
+import (
+	"errors"
+	"time"
+)
+
+// ErrResponseBinding identifies a control-plane response whose authority
+// binding does not match the request. The current lease-renewal wire response
+// exposes authority binding but not a runtime field; adapters must treat this
+// as a non-transient product-state failure rather than retrying the old
+// authority.
+var ErrResponseBinding = errors.New("device authority response binding mismatch")
 
 // EnsureDeviceAuthorityRequest identifies the product owner and local runtime
 // that should own the Device Authority.

--- a/packages/device-link/README.md
+++ b/packages/device-link/README.md
@@ -79,13 +79,19 @@ least one product driver holds a reference, accepts remote streams only after
 the product readiness barrier succeeds, and reconnects with bounded full-jitter
 backoff plus `Retry-After`.
 
+`OwnerLifecycle.Activate` returns an `OwnerActivation`: its `Readiness`
+context is a continuous product health condition for the complete connection
+generation. Cancelling it closes the generation, joins its stream handlers,
+reports its cancellation cause through `SessionEnded`, and starts a new
+generation while demand remains.
+
 The owner path has an explicit ownership split:
 
 ```text
 product demand (zero -> one)
   -> product OwnerLifecycle.Prepare
   -> relaytransport WebSocket dial + liveness
-  -> product OwnerLifecycle.Activate readiness barrier
+  -> product OwnerLifecycle.Activate continuous readiness
   -> relaytransport yamux stream acceptance
   -> product StreamHandler
   -> final product demand release
@@ -109,6 +115,10 @@ interpret HTTP status codes as product policy. `DialError` makes a bounded
 handshake response body available for adapter-owned wire-reason parsing, but
 does not include that body in its error string; adapters must not persist the
 raw value in ordinary logs or metrics.
+
+`OwnerHost.Wake` is a product-neutral demand-preserving interrupt for the
+current generation or retry wait. It coalesces repeated requests, does not
+release or acquire references, and does not reset reconnect backoff.
 
 ### Stream readiness probe
 

--- a/packages/device-link/relaytransport/doc.go
+++ b/packages/device-link/relaytransport/doc.go
@@ -2,9 +2,12 @@
 // WebSocket Relay.
 //
 // It owns WebSocket stream dialing and the reusable owner-tunnel mechanics:
-// reference-counted demand, reconnect backoff, WebSocket liveness, yamux stream
-// acceptance, and close ordering. Products inject authority credentials, lease
-// activation, final release, and stream handlers through narrow interfaces.
+// reference-counted demand, reconnect backoff, WebSocket liveness, continuous
+// owner readiness, yamux stream acceptance, and close ordering. Products inject
+// authority credentials, lease activation, final release, and stream handlers
+// through narrow interfaces. OwnerLifecycle.Activate returns an
+// OwnerActivation whose Readiness context must remain live for the complete
+// connection generation; it is not merely a one-time readiness barrier.
 // The package never interprets rooms, pairings, accounts, target tokens, or
 // application payloads.
 package relaytransport

--- a/packages/device-link/relaytransport/owner_host.go
+++ b/packages/device-link/relaytransport/owner_host.go
@@ -32,6 +32,8 @@ type ownerRun struct {
 
 	mu      sync.Mutex
 	session OwnerSession
+	wakeCh  chan struct{}
+	wake    bool
 }
 
 // NewOwnerHost validates config and creates an idle owner host.
@@ -94,7 +96,12 @@ func (h *OwnerHost) Acquire(ctx context.Context, driver string) error {
 		return errors.New("relay owner lifecycle factory returned nil")
 	}
 	runCtx, cancel := context.WithCancel(context.Background())
-	run := &ownerRun{cancel: cancel, done: make(chan struct{}), lifecycle: lifecycle}
+	run := &ownerRun{
+		cancel:    cancel,
+		done:      make(chan struct{}),
+		lifecycle: lifecycle,
+		wakeCh:    make(chan struct{}),
+	}
 	h.run = run
 	go h.runLoop(runCtx, run)
 	return nil
@@ -152,20 +159,71 @@ func (h *OwnerHost) RefCount() int {
 	return h.refCount
 }
 
+// Wake interrupts the current owner generation or retry wait when demand is
+// present. It does not change references, release product state, or reset
+// reconnect backoff. Repeated wakes before the current wait observes one are
+// coalesced.
+func (h *OwnerHost) Wake() {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	run := h.run
+	active := h.refCount > 0
+	h.mu.Unlock()
+	if !active || run == nil {
+		return
+	}
+	run.signalWake()
+}
+
 func (h *OwnerHost) runLoop(ctx context.Context, run *ownerRun) {
 	defer close(run.done)
 	backoff := newExponentialBackoff(h.cfg.Backoff)
 	for ctx.Err() == nil {
-		session, err := run.lifecycle.Prepare(ctx)
+		attemptCtx, attemptCancel := context.WithCancelCause(ctx)
+		wakeCh := run.wakeChannel()
+		attemptStop := make(chan struct{})
+		attemptDone := make(chan struct{})
+		go func() {
+			defer close(attemptDone)
+			select {
+			case <-wakeCh:
+				attemptCancel(ErrOwnerWake)
+			case <-ctx.Done():
+				attemptCancel(context.Cause(ctx))
+			case <-attemptStop:
+			}
+		}()
+
+		session, err := run.lifecycle.Prepare(attemptCtx)
 		if strings.TrimSpace(session.Key) != "" {
 			run.setSession(session)
 		}
 		h.observe(OwnerEvent{Phase: OwnerPhasePrepare, Outcome: outcome(err), SessionKey: session.Key, Error: err})
 		var readyFor time.Duration
 		if err == nil {
-			readyFor, err = h.runSession(ctx, run, session)
-			if readyFor >= h.cfg.StableSessionFor {
+			readyFor, err = h.runSession(attemptCtx, run, session)
+			if readyFor >= h.cfg.StableSessionFor && !errors.Is(context.Cause(attemptCtx), ErrOwnerWake) {
 				backoff.Reset()
+			}
+		}
+		attemptCause := context.Cause(attemptCtx)
+		wakeObserved := errors.Is(attemptCause, ErrOwnerWake)
+		close(attemptStop)
+		attemptCancel(nil)
+		<-attemptDone
+		// The monitor can lose the select race with attemptStop after Wake has
+		// closed wakeCh. Observe the pending signal after joining it so a wake
+		// cannot accidentally schedule a retry before its cancellation cause is
+		// recorded in attemptCtx.
+		if !wakeObserved {
+			wakeObserved = run.wakePending(wakeCh)
+		}
+		if wakeObserved {
+			run.acknowledgeWake(wakeCh)
+			if err == nil || errors.Is(err, context.Canceled) {
+				err = ErrOwnerWake
 			}
 		}
 		if ctx.Err() != nil {
@@ -173,6 +231,9 @@ func (h *OwnerHost) runLoop(ctx context.Context, run *ownerRun) {
 		}
 		run.lifecycle.SessionEnded(session, err)
 		h.observe(OwnerEvent{Phase: OwnerPhaseSession, Outcome: OwnerOutcomeEnded, SessionKey: session.Key, Error: err})
+		if wakeObserved {
+			continue
+		}
 		backoffDelay := backoff.Next()
 		retryAfter := retryDelay(err, h.cfg.Now())
 		delay := combineRetryDelay(backoffDelay, retryAfter)
@@ -183,7 +244,10 @@ func (h *OwnerHost) runLoop(ctx context.Context, run *ownerRun) {
 			},
 			Error: err,
 		})
-		if sleepErr := h.cfg.Sleep(ctx, delay); sleepErr != nil {
+		if sleepErr := h.sleepRetry(ctx, run, delay); sleepErr != nil {
+			if errors.Is(sleepErr, ErrOwnerWake) {
+				continue
+			}
 			return
 		}
 	}
@@ -209,14 +273,24 @@ func (h *OwnerHost) runSession(ctx context.Context, run *ownerRun, session Owner
 	defer stopLiveness()
 	h.observe(OwnerEvent{Phase: OwnerPhaseDial, Outcome: OwnerOutcomeConnected, SessionKey: session.Key})
 
-	deactivate, err := run.lifecycle.Activate(ctx, session)
+	activation, err := run.lifecycle.Activate(ctx, session)
 	if err != nil {
 		return 0, err
 	}
+	if activation.Readiness == nil {
+		if activation.Deactivate != nil {
+			activation.Deactivate()
+		}
+		return 0, ErrOwnerActivationReadiness
+	}
+	deactivate := activation.Deactivate
 	if deactivate == nil {
 		deactivate = func() {}
 	}
-	defer deactivate()
+	if cause := ownerReadinessCause(activation.Readiness); cause != nil {
+		deactivate()
+		return 0, cause
+	}
 
 	yamuxConfig := yamux.DefaultConfig()
 	yamuxConfig.EnableKeepAlive = false
@@ -225,40 +299,100 @@ func (h *OwnerHost) runSession(ctx context.Context, run *ownerRun, session Owner
 	yamuxConfig.LogOutput = io.Discard
 	mux, err := yamux.Server(conn, yamuxConfig)
 	if err != nil {
+		deactivate()
 		return 0, fmt.Errorf("start relay owner mux: %w", err)
 	}
-	defer func() { _ = mux.Close() }()
-	readyAt := h.cfg.Now()
-	h.observe(OwnerEvent{Phase: OwnerPhaseServe, Outcome: OwnerOutcomeReady, SessionKey: session.Key})
-
-	cancelDone := make(chan struct{})
-	defer close(cancelDone)
+	sessionCtx, sessionCancel := context.WithCancelCause(ctx)
+	monitorDone := make(chan struct{})
 	go func() {
+		defer close(monitorDone)
 		select {
-		case <-ctx.Done():
+		case <-activation.Readiness.Done():
+			cause := ownerReadinessCause(activation.Readiness)
+			if cause == nil {
+				cause = context.Canceled
+			}
+			sessionCancel(cause)
 			_ = mux.Close()
 			_ = conn.Close()
-		case <-cancelDone:
+		case <-sessionCtx.Done():
+			_ = mux.Close()
+			_ = conn.Close()
 		}
 	}()
+	defer func() {
+		sessionCancel(nil)
+		_ = mux.Close()
+		_ = conn.Close()
+		<-monitorDone
+		stopLiveness()
+		run.handlers.Wait()
+		deactivate()
+	}()
+	if cause := ownerSessionCause(sessionCtx, activation.Readiness); cause != nil {
+		return 0, cause
+	}
+	readyAt := h.cfg.Now()
+	h.observe(OwnerEvent{Phase: OwnerPhaseServe, Outcome: OwnerOutcomeReady, SessionKey: session.Key})
+	if cause := ownerSessionCause(sessionCtx, activation.Readiness); cause != nil {
+		return elapsed(readyAt, h.cfg.Now()), cause
+	}
 
 	for {
 		stream, acceptErr := mux.AcceptStream()
 		if acceptErr != nil {
 			readyFor := elapsed(readyAt, h.cfg.Now())
+			if cause := context.Cause(sessionCtx); cause != nil {
+				return readyFor, cause
+			}
 			if ctx.Err() != nil {
-				return readyFor, ctx.Err()
+				return readyFor, context.Cause(ctx)
 			}
 			return readyFor, fmt.Errorf("accept relay owner stream: %w", acceptErr)
 		}
+		if cause := ownerSessionCause(sessionCtx, activation.Readiness); cause != nil {
+			_ = stream.Close()
+			readyFor := elapsed(readyAt, h.cfg.Now())
+			return readyFor, cause
+		}
 		run.handlers.Add(1)
-		go h.handleStream(ctx, run, session.Key, stream)
+		go h.handleStream(sessionCtx, activation.Readiness, run, session.Key, stream)
 	}
 }
 
-func (h *OwnerHost) handleStream(ctx context.Context, run *ownerRun, sessionKey string, stream net.Conn) {
+func (h *OwnerHost) sleepRetry(ctx context.Context, run *ownerRun, delay time.Duration) error {
+	sleepCtx, cancel := context.WithCancelCause(ctx)
+	wakeCh := run.wakeChannel()
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		select {
+		case <-wakeCh:
+			run.acknowledgeWake(wakeCh)
+			cancel(ErrOwnerWake)
+		case <-ctx.Done():
+			cancel(context.Cause(ctx))
+		case <-stop:
+		}
+	}()
+	err := h.cfg.Sleep(sleepCtx, delay)
+	close(stop)
+	cancel(nil)
+	<-done
+	if cause := context.Cause(sleepCtx); errors.Is(cause, ErrOwnerWake) {
+		return cause
+	}
+	return err
+}
+
+func (h *OwnerHost) handleStream(ctx, readiness context.Context, run *ownerRun, sessionKey string, stream net.Conn) {
 	defer run.handlers.Done()
 	defer func() { _ = stream.Close() }()
+	if cause := ownerSessionCause(ctx, readiness); cause != nil {
+		h.observe(OwnerEvent{Phase: OwnerPhaseStream, Outcome: OwnerOutcomeFailed, SessionKey: sessionKey, Error: cause})
+		return
+	}
 	err := h.cfg.Handler.HandleRelayStream(ctx, stream)
 	h.observe(OwnerEvent{Phase: OwnerPhaseStream, Outcome: outcome(err), SessionKey: sessionKey, Error: err})
 }
@@ -279,6 +413,64 @@ func (r *ownerRun) currentSession() OwnerSession {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.session
+}
+
+func (r *ownerRun) signalWake() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.wake {
+		return
+	}
+	close(r.wakeCh)
+	r.wake = true
+}
+
+func (r *ownerRun) wakeChannel() <-chan struct{} {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.wakeCh
+}
+
+func (r *ownerRun) wakePending(ch <-chan struct{}) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.wakeCh == ch && r.wake
+}
+
+func (r *ownerRun) acknowledgeWake(ch <-chan struct{}) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.wakeCh != ch || !r.wake {
+		return
+	}
+	r.wakeCh = make(chan struct{})
+	r.wake = false
+}
+
+func ownerReadinessCause(readiness context.Context) error {
+	if readiness == nil {
+		return ErrOwnerActivationReadiness
+	}
+	select {
+	case <-readiness.Done():
+		cause := context.Cause(readiness)
+		if cause == nil {
+			cause = context.Canceled
+		}
+		if errors.Is(cause, ErrOwnerWake) || errors.Is(cause, context.Canceled) {
+			return cause
+		}
+		return &OwnerReadinessError{Cause: cause}
+	default:
+		return nil
+	}
+}
+
+func ownerSessionCause(session, readiness context.Context) error {
+	if cause := context.Cause(session); cause != nil {
+		return cause
+	}
+	return ownerReadinessCause(readiness)
 }
 
 func outcome(err error) OwnerOutcome {

--- a/packages/device-link/relaytransport/owner_host_test.go
+++ b/packages/device-link/relaytransport/owner_host_test.go
@@ -162,6 +162,182 @@ func TestOwnerHostReconnectsAfterActivationFailure(t *testing.T) {
 	}
 }
 
+func TestOwnerHostReconnectsWhenReadinessEndsAndPreservesCause(t *testing.T) {
+	relay := newTestOwnerRelay(t)
+	defer relay.Close()
+	lifecycle := newTestOwnerLifecycle(testOwnerSession(relay.OwnerEndpoint(), "owner-readiness"))
+	readiness, cancelReadiness := context.WithCancelCause(context.Background())
+	lifecycle.readiness = readiness
+	lifecycle.readinessCancel = cancelReadiness
+	handlerStarted := make(chan struct{}, 1)
+	host := newTestOwnerHost(t, lifecycle, StreamHandlerFunc(func(ctx context.Context, _ net.Conn) error {
+		handlerStarted <- struct{}{}
+		<-ctx.Done()
+		return ctx.Err()
+	}), nil)
+
+	if err := host.Acquire(context.Background(), "owner"); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = host.Release("owner") }()
+	first := relay.WaitSession(t)
+	readinessCause := errors.New("lease freshness ended")
+	lifecycle.CancelReadiness(readinessCause)
+	if stream, openErr := first.mux.OpenStream(); openErr == nil {
+		_ = stream.Close()
+	}
+	select {
+	case <-handlerStarted:
+		t.Fatal("stream handler started after readiness cancellation")
+	default:
+	}
+	second := relay.WaitSession(t)
+	if first == second {
+		t.Fatal("readiness cancellation did not establish a new Relay session")
+	}
+	select {
+	case <-handlerStarted:
+		t.Fatal("stream handler started for the canceled generation")
+	default:
+	}
+	if got := lifecycle.SessionErrors(); len(got) == 0 || !errors.Is(got[0], readinessCause) {
+		t.Fatalf("SessionEnded() errors = %v, want readiness cause", got)
+	}
+	if got := lifecycle.DeactivateCount(); got < 1 {
+		t.Fatalf("deactivate count = %d, want ended generation deactivation", got)
+	}
+}
+
+func TestOwnerHostDoesNotPublishReadyForAlreadyCanceledReadiness(t *testing.T) {
+	relay := newTestOwnerRelay(t)
+	defer relay.Close()
+	lifecycle := newTestOwnerLifecycle(testOwnerSession(relay.OwnerEndpoint(), "owner-canceled-readiness"))
+	readiness, cancelReadiness := context.WithCancelCause(context.Background())
+	readinessCause := errors.New("lease is stale")
+	cancelReadiness(readinessCause)
+	lifecycle.readiness = readiness
+	readyEvents := make(chan struct{}, 1)
+	endedEvents := make(chan struct{}, 1)
+	host := newTestOwnerHost(t, lifecycle, StreamHandlerFunc(func(context.Context, net.Conn) error {
+		return nil
+	}), func(cfg *OwnerHostConfig) {
+		cfg.Sleep = func(ctx context.Context, _ time.Duration) error {
+			<-ctx.Done()
+			return ctx.Err()
+		}
+		cfg.Observe = func(event OwnerEvent) {
+			if event.Phase == OwnerPhaseServe && event.Outcome == OwnerOutcomeReady {
+				readyEvents <- struct{}{}
+			}
+			if event.Phase == OwnerPhaseSession {
+				endedEvents <- struct{}{}
+			}
+		}
+	})
+
+	if err := host.Acquire(context.Background(), "owner"); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-endedEvents:
+	case <-time.After(2 * time.Second):
+		t.Fatal("already-canceled readiness did not end the generation")
+	}
+	select {
+	case <-readyEvents:
+		t.Fatal("OwnerOutcomeReady was published for canceled readiness")
+	default:
+	}
+	ended := lifecycle.SessionErrors()
+	if len(ended) == 0 || !errors.Is(ended[0], readinessCause) {
+		t.Fatalf("SessionEnded() errors = %v, want readiness cause", ended)
+	}
+	if err := host.Release("owner"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestOwnerHostWakeInterruptsReadySessionWithoutChangingDemand(t *testing.T) {
+	relay := newTestOwnerRelay(t)
+	defer relay.Close()
+	lifecycle := newTestOwnerLifecycle(testOwnerSession(relay.OwnerEndpoint(), "owner-wake"))
+	host := newTestOwnerHost(t, lifecycle, StreamHandlerFunc(func(ctx context.Context, _ net.Conn) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}), nil)
+
+	if err := host.Acquire(context.Background(), "owner"); err != nil {
+		t.Fatal(err)
+	}
+	first := relay.WaitSession(t)
+	if got := host.RefCount(); got != 1 {
+		t.Fatalf("RefCount() before Wake = %d, want 1", got)
+	}
+	host.Wake()
+	host.Wake()
+	second := relay.WaitSession(t)
+	if first == second {
+		t.Fatal("Wake did not establish a new Relay session")
+	}
+	if got := host.RefCount(); got != 1 {
+		t.Fatalf("RefCount() after Wake = %d, want 1", got)
+	}
+	if err := host.Release("owner"); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case unexpected := <-relay.sessions:
+		unexpected.Close()
+		t.Fatal("Wake or release established an unexpected third session")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestOwnerHostWakeSkipsBackoffForConcurrentNonContextError(t *testing.T) {
+	relay := newTestOwnerRelay(t)
+	defer relay.Close()
+	lifecycle := newTestOwnerLifecycle(testOwnerSession(relay.OwnerEndpoint(), "owner-wake-error"))
+	activateGate := make(chan struct{})
+	lifecycle.activateGate = activateGate
+	lifecycle.ignoreActivateCancellation = true
+	lifecycle.activateErrors = []error{errors.New("activation operation failed")}
+	retries := make(chan struct{}, 1)
+	host := newTestOwnerHost(t, lifecycle, StreamHandlerFunc(func(context.Context, net.Conn) error {
+		return nil
+	}), func(cfg *OwnerHostConfig) {
+		cfg.Sleep = func(ctx context.Context, _ time.Duration) error {
+			<-ctx.Done()
+			return ctx.Err()
+		}
+		cfg.Observe = func(event OwnerEvent) {
+			if event.Phase == OwnerPhaseRetry {
+				retries <- struct{}{}
+			}
+		}
+	})
+
+	if err := host.Acquire(context.Background(), "owner"); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = host.Release("owner") }()
+	first := relay.WaitSession(t)
+	host.Wake()
+	close(activateGate)
+	second := relay.WaitSession(t)
+	if first == second {
+		t.Fatal("Wake did not advance past the concurrent activation error")
+	}
+	select {
+	case <-retries:
+		t.Fatal("Wake scheduled a retry after it had already interrupted the generation")
+	default:
+	}
+	ended := lifecycle.SessionErrors()
+	if len(ended) == 0 || ended[0] == nil || ended[0].Error() != "activation operation failed" {
+		t.Fatalf("SessionEnded() errors = %v, want original activation error", ended)
+	}
+}
+
 func TestOwnerHostReferenceCountsDemand(t *testing.T) {
 	lifecycle := newTestOwnerLifecycle(OwnerSession{Key: "owner-ref"})
 	lifecycle.prepareGate = make(chan struct{})
@@ -290,7 +466,7 @@ func TestOwnerHostReportsRetryComponentsAndCancelsWaitOnRelease(t *testing.T) {
 	defer server.Close()
 	endpoint := "ws" + server.URL[len("http"):]
 	lifecycle := newTestOwnerLifecycle(testOwnerSession(endpoint, "owner-retry"))
-	retries := make(chan OwnerEvent, 1)
+	retries := make(chan OwnerEvent, 2)
 	const seed = int64(11)
 	host := newTestOwnerHost(t, lifecycle, StreamHandlerFunc(func(context.Context, net.Conn) error { return nil }), func(cfg *OwnerHostConfig) {
 		cfg.Backoff = BackoffConfig{
@@ -329,6 +505,13 @@ func TestOwnerHostReportsRetryComponentsAndCancelsWaitOnRelease(t *testing.T) {
 	}
 	if retry.Retry.Delay != 2*time.Second+wantBackoff {
 		t.Fatalf("retry delay = %s, want %s", retry.Retry.Delay, 2*time.Second+wantBackoff)
+	}
+	host.Wake()
+	host.Wake()
+	select {
+	case <-retries:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Wake did not interrupt the retry wait")
 	}
 	if err := host.Release("owner"); err != nil {
 		t.Fatalf("Release() error = %v", err)
@@ -454,23 +637,26 @@ func newTestOwnerHost(t *testing.T, lifecycle OwnerLifecycle, handler StreamHand
 type testOwnerLifecycle struct {
 	session OwnerSession
 
-	mu                sync.Mutex
-	prepareCalls      int
-	activateCalls     int
-	deactivateCalls   int
-	releaseCalls      int
-	prepareErrors     []error
-	activateErrors    []error
-	sessionErrors     []error
-	releasedKeys      []string
-	prepareGate       <-chan struct{}
-	activateGate      <-chan struct{}
-	releaseGate       <-chan struct{}
-	sleepAfterPrepare chan struct{}
-	prepareSeen       chan struct{}
-	releaseStarted    chan struct{}
-	prepareOnce       sync.Once
-	releaseOnce       sync.Once
+	mu                         sync.Mutex
+	prepareCalls               int
+	activateCalls              int
+	deactivateCalls            int
+	releaseCalls               int
+	prepareErrors              []error
+	activateErrors             []error
+	ignoreActivateCancellation bool
+	sessionErrors              []error
+	releasedKeys               []string
+	readiness                  context.Context
+	readinessCancel            context.CancelCauseFunc
+	prepareGate                <-chan struct{}
+	activateGate               <-chan struct{}
+	releaseGate                <-chan struct{}
+	sleepAfterPrepare          chan struct{}
+	prepareSeen                chan struct{}
+	releaseStarted             chan struct{}
+	prepareOnce                sync.Once
+	releaseOnce                sync.Once
 }
 
 func newTestOwnerLifecycle(session OwnerSession) *testOwnerLifecycle {
@@ -501,7 +687,7 @@ func (l *testOwnerLifecycle) Prepare(ctx context.Context) (OwnerSession, error) 
 	return l.session, err
 }
 
-func (l *testOwnerLifecycle) Activate(ctx context.Context, _ OwnerSession) (func(), error) {
+func (l *testOwnerLifecycle) Activate(ctx context.Context, _ OwnerSession) (OwnerActivation, error) {
 	l.mu.Lock()
 	l.activateCalls++
 	var err error
@@ -511,26 +697,48 @@ func (l *testOwnerLifecycle) Activate(ctx context.Context, _ OwnerSession) (func
 	}
 	l.mu.Unlock()
 	if l.activateGate != nil {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-l.activateGate:
+		if l.ignoreActivateCancellation {
+			<-l.activateGate
+		} else {
+			select {
+			case <-ctx.Done():
+				return OwnerActivation{}, ctx.Err()
+			case <-l.activateGate:
+			}
 		}
 	}
 	if err != nil {
-		return nil, err
+		return OwnerActivation{}, err
 	}
-	return func() {
-		l.mu.Lock()
-		l.deactivateCalls++
-		l.mu.Unlock()
-	}, nil
+	readiness := l.readiness
+	if readiness != nil {
+		l.readiness = nil
+	}
+	if readiness == nil {
+		readiness = ctx
+	}
+	return OwnerActivation{
+		Readiness: readiness,
+		Deactivate: func() {
+			l.mu.Lock()
+			l.deactivateCalls++
+			l.mu.Unlock()
+		}}, nil
 }
 
 func (l *testOwnerLifecycle) SessionEnded(_ OwnerSession, err error) {
 	l.mu.Lock()
 	l.sessionErrors = append(l.sessionErrors, err)
 	l.mu.Unlock()
+}
+
+func (l *testOwnerLifecycle) CancelReadiness(err error) {
+	l.mu.Lock()
+	cancel := l.readinessCancel
+	l.mu.Unlock()
+	if cancel != nil {
+		cancel(err)
+	}
 }
 
 func (l *testOwnerLifecycle) Release(ctx context.Context, session OwnerSession) error {

--- a/packages/device-link/relaytransport/types.go
+++ b/packages/device-link/relaytransport/types.go
@@ -2,6 +2,7 @@ package relaytransport
 
 import (
 	"context"
+	"errors"
 	"math/rand"
 	"net"
 	"net/http"
@@ -40,6 +41,41 @@ type OwnerSession struct {
 	PingPayload []byte
 }
 
+// OwnerActivation is the continuous product health contract for one connected
+// owner session. Readiness remains valid for the whole connection generation;
+// its cancellation cause is the product-neutral explanation for why the
+// generation must end. Deactivate stops and joins all product maintenance
+// started by Activate.
+type OwnerActivation struct {
+	Readiness  context.Context
+	Deactivate func()
+}
+
+// ErrOwnerWake identifies a host-directed wake request. A wake interrupts the
+// current generation or retry wait without changing demand or resetting
+// reconnect backoff.
+var ErrOwnerWake = errors.New("relay owner wake requested")
+
+// ErrOwnerActivationReadiness identifies an invalid lifecycle activation that
+// did not return the required continuous readiness context.
+var ErrOwnerActivationReadiness = errors.New("relay owner activation readiness is required")
+
+// OwnerReadinessError preserves a product readiness cause while keeping the
+// transport observer's error text free of product payloads. Callers can use
+// errors.Is or errors.As to inspect Cause.
+type OwnerReadinessError struct {
+	Cause error
+}
+
+func (*OwnerReadinessError) Error() string { return "relay owner readiness ended" }
+
+func (e *OwnerReadinessError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
 // OwnerLifecycle owns product state for exactly one zero-to-one Host demand
 // lifecycle. A Host never reuses a lifecycle after its final Release.
 type OwnerLifecycle interface {
@@ -47,10 +83,13 @@ type OwnerLifecycle interface {
 	// session together with an error so Release can clean up product state that
 	// was committed before preparation failed.
 	Prepare(ctx context.Context) (OwnerSession, error)
-	// Activate is a readiness barrier after the WebSocket connects and before
-	// relay streams are accepted. The returned function stops maintenance and
-	// joins any goroutines started by Activate.
-	Activate(ctx context.Context, session OwnerSession) (deactivate func(), err error)
+	// Activate establishes the product conditions for this connection
+	// generation after the WebSocket connects and before relay streams are
+	// accepted. Readiness is a continuous condition, not just a one-time
+	// barrier: cancelling it ends the generation and carries the product cause
+	// to SessionEnded. Deactivate stops maintenance and joins all goroutines
+	// started by Activate.
+	Activate(ctx context.Context, session OwnerSession) (OwnerActivation, error)
 	// SessionEnded lets the product invalidate credentials or projections based
 	// on a completed connection attempt. It must not block.
 	SessionEnded(session OwnerSession, err error)

--- a/services/tuttid/service/mobileremote/relay_owner.go
+++ b/services/tuttid/service/mobileremote/relay_owner.go
@@ -27,6 +27,14 @@ const (
 	defaultRelayLeaseRenew  = 30 * time.Second
 	defaultRelayLeaseWindow = 5 * time.Second
 	defaultRelayTokenTTL    = 10 * time.Minute
+	defaultLeaseRequest     = 5 * time.Second
+	defaultLeaseRetry       = 100 * time.Millisecond
+	maxLeaseRetry           = 2 * time.Second
+)
+
+var (
+	errRelayLeaseExpired  = errors.New("mobile remote Relay lease expired")
+	errRelayLeaseResponse = errors.New("mobile remote Relay lease response is invalid")
 )
 
 // NewRelayOwner creates the product adapter for the shared Relay owner host.
@@ -127,29 +135,40 @@ func (l *relayOwnerLifecycle) Prepare(ctx context.Context) (relaytransport.Owner
 	return session, nil
 }
 
-func (l *relayOwnerLifecycle) Activate(ctx context.Context, _ relaytransport.OwnerSession) (func(), error) {
+func (l *relayOwnerLifecycle) Activate(ctx context.Context, _ relaytransport.OwnerSession) (relaytransport.OwnerActivation, error) {
 	l.mu.Lock()
 	authority := l.authority
 	ownerUserID := l.ownerUserID
 	l.mu.Unlock()
 	if strings.TrimSpace(authority.AuthorityID) == "" {
-		return nil, errors.New("mobile remote Relay authority is unavailable")
+		return relaytransport.OwnerActivation{}, errors.New("mobile remote Relay authority is unavailable")
 	}
 	activationCtx, cancel := context.WithTimeout(ctx, defaultRelayLeaseWindow)
-	_, err := l.renewLease(activationCtx, authority, ownerUserID)
+	lease, err := l.renewLease(activationCtx, authority, ownerUserID)
 	cancel()
 	if err != nil {
-		return nil, fmt.Errorf("activate mobile remote Relay lease: %w", err)
+		l.handleLeaseFailure(err)
+		return relaytransport.OwnerActivation{}, fmt.Errorf("activate mobile remote Relay lease: %w", err)
 	}
-	renewCtx, renewCancel := context.WithCancel(ctx)
+	if _, err := parseLeaseExpiry(lease.ExpiresAt, l.service.now()); err != nil {
+		l.handleLeaseFailure(err)
+		return relaytransport.OwnerActivation{}, fmt.Errorf("activate mobile remote Relay lease: %w", err)
+	}
+	readiness, cancelReadiness := context.WithCancelCause(ctx)
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		l.maintainLease(renewCtx, authority, ownerUserID)
+		l.maintainLease(readiness, authority, ownerUserID, lease, cancelReadiness)
 	}()
-	return func() {
-		renewCancel()
-		<-done
+	var deactivateOnce sync.Once
+	return relaytransport.OwnerActivation{
+		Readiness: readiness,
+		Deactivate: func() {
+			deactivateOnce.Do(func() {
+				cancelReadiness(context.Canceled)
+				<-done
+			})
+		},
 	}, nil
 }
 
@@ -296,39 +315,157 @@ func (l *relayOwnerLifecycle) renewLease(
 		return deviceauthority.RenewDeviceAuthorityLeaseResult{}, err
 	}
 	if lease.AuthorityID != authority.AuthorityID || strings.TrimSpace(lease.State) != "online" {
-		return deviceauthority.RenewDeviceAuthorityLeaseResult{}, errors.New("mobile remote Relay lease is not online")
+		return deviceauthority.RenewDeviceAuthorityLeaseResult{}, fmt.Errorf("%w: authority or state mismatch", errRelayLeaseResponse)
 	}
 	return lease, nil
 }
 
-func (l *relayOwnerLifecycle) maintainLease(ctx context.Context, authority deviceauthority.DeviceAuthorityResult, ownerUserID string) {
-	intervalSeconds := authority.Lease.RenewIntervalSeconds
-	if intervalSeconds <= 0 && authority.Lease.TTLSeconds > 0 {
-		intervalSeconds = authority.Lease.TTLSeconds / 2
-		if intervalSeconds <= 0 {
-			intervalSeconds = 1
-		}
+func (l *relayOwnerLifecycle) maintainLease(
+	ctx context.Context,
+	authority deviceauthority.DeviceAuthorityResult,
+	ownerUserID string,
+	initialLease deviceauthority.RenewDeviceAuthorityLeaseResult,
+	cancelReadiness context.CancelCauseFunc,
+) {
+	expiresAt, err := parseLeaseExpiry(initialLease.ExpiresAt, l.service.now())
+	if err != nil {
+		cancelReadiness(err)
+		return
 	}
-	interval := time.Duration(intervalSeconds) * time.Second
+	retryDelay := time.Duration(0)
+	for {
+		now := l.service.now()
+		if !expiresAt.After(now) {
+			cancelReadiness(errRelayLeaseExpired)
+			return
+		}
+		wait := leaseRenewWait(now, expiresAt, authority.Lease)
+		if retryDelay > 0 && retryDelay < wait {
+			wait = retryDelay
+		}
+		if err := waitLease(ctx, wait); err != nil {
+			return
+		}
+		requestNow := l.service.now()
+		if !expiresAt.After(requestNow) {
+			cancelReadiness(errRelayLeaseExpired)
+			return
+		}
+		requestTimeout := defaultLeaseRequest
+		if remaining := expiresAt.Sub(requestNow); remaining < requestTimeout {
+			requestTimeout = remaining
+		}
+		requestCtx, cancel := context.WithTimeout(ctx, requestTimeout)
+		lease, renewErr := l.renewLease(requestCtx, authority, ownerUserID)
+		cancel()
+		if renewErr == nil {
+			newExpiresAt, parseErr := parseLeaseExpiry(lease.ExpiresAt, l.service.now())
+			if parseErr != nil {
+				if !expiresAt.After(l.service.now()) {
+					cancelReadiness(errRelayLeaseExpired)
+					return
+				}
+				l.handleLeaseFailure(parseErr)
+				cancelReadiness(parseErr)
+				return
+			}
+			expiresAt = newExpiresAt
+			retryDelay = 0
+			continue
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		if !expiresAt.After(l.service.now()) {
+			cancelReadiness(errRelayLeaseExpired)
+			return
+		}
+		l.handleLeaseFailure(renewErr)
+		if !isTransientLeaseError(renewErr) {
+			cancelReadiness(renewErr)
+			return
+		}
+		retryDelay = nextLeaseRetryDelay(retryDelay)
+	}
+}
+
+func parseLeaseExpiry(value string, now time.Time) (time.Time, error) {
+	expiresAt, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(value))
+	if err != nil || !expiresAt.After(now) {
+		return time.Time{}, fmt.Errorf("%w: expiresAt is missing or expired", errRelayLeaseResponse)
+	}
+	return expiresAt, nil
+}
+
+func leaseRenewWait(now, expiresAt time.Time, policy deviceauthority.LeasePolicy) time.Duration {
+	interval := time.Duration(policy.RenewIntervalSeconds) * time.Second
 	if interval <= 0 {
 		interval = defaultRelayLeaseRenew
-	}
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			if _, err := l.renewLease(ctx, authority, ownerUserID); err != nil && !errors.Is(err, context.Canceled) {
-				// The owner tunnel remains transport-owned. Clear the cached token so
-				// the next reconnect cannot reuse credentials issued before a failed
-				// lease renewal.
-				l.mu.Lock()
-				l.token = deviceauthority.Token{}
-				l.mu.Unlock()
-			}
+		if policy.TTLSeconds > 0 {
+			interval = time.Duration(policy.TTLSeconds/2) * time.Second
 		}
+	}
+	remaining := expiresAt.Sub(now)
+	if interval >= remaining {
+		interval = remaining / 2
+	}
+	if interval <= 0 {
+		return time.Nanosecond
+	}
+	return interval
+}
+
+func waitLease(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func nextLeaseRetryDelay(previous time.Duration) time.Duration {
+	if previous <= 0 {
+		return defaultLeaseRetry
+	}
+	next := previous * 2
+	if next > maxLeaseRetry || next <= previous {
+		return maxLeaseRetry
+	}
+	return next
+}
+
+func isTransientLeaseError(err error) bool {
+	if errors.Is(err, context.Canceled) ||
+		errors.Is(err, deviceauthority.ErrResponseBinding) ||
+		errors.Is(err, errRelayLeaseResponse) {
+		return false
+	}
+	var httpErr *deviceauthority.HTTPError
+	if !errors.As(err, &httpErr) {
+		return true
+	}
+	return httpErr.StatusCode == http.StatusRequestTimeout ||
+		httpErr.StatusCode == http.StatusTooEarly ||
+		httpErr.StatusCode == http.StatusTooManyRequests ||
+		httpErr.StatusCode >= http.StatusInternalServerError
+}
+
+func (l *relayOwnerLifecycle) handleLeaseFailure(err error) {
+	var httpErr *deviceauthority.HTTPError
+	if errors.As(err, &httpErr) && (httpErr.StatusCode == http.StatusUnauthorized || httpErr.StatusCode == http.StatusForbidden) {
+		l.mu.Lock()
+		l.token = deviceauthority.Token{}
+		l.mu.Unlock()
+	}
+	if errors.Is(err, errRelayLeaseResponse) || errors.Is(err, deviceauthority.ErrResponseBinding) {
+		l.mu.Lock()
+		l.authority = deviceauthority.DeviceAuthorityResult{}
+		l.identityEnrolled = false
+		l.token = deviceauthority.Token{}
+		l.mu.Unlock()
 	}
 }
 

--- a/services/tuttid/service/mobileremote/relay_owner.go
+++ b/services/tuttid/service/mobileremote/relay_owner.go
@@ -402,7 +402,7 @@ func leaseRenewWait(now, expiresAt time.Time, policy deviceauthority.LeasePolicy
 	if interval <= 0 {
 		interval = defaultRelayLeaseRenew
 		if policy.TTLSeconds > 0 {
-			interval = time.Duration(policy.TTLSeconds/2) * time.Second
+			interval = time.Duration(policy.TTLSeconds) * time.Second / 2
 		}
 	}
 	remaining := expiresAt.Sub(now)

--- a/services/tuttid/service/mobileremote/relay_owner_test.go
+++ b/services/tuttid/service/mobileremote/relay_owner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -15,6 +16,7 @@ import (
 	authbridge "github.com/tutti-os/tutti/packages/auth/bridge-go"
 	deviceauthority "github.com/tutti-os/tutti/packages/clients/device-authority-go"
 	devicelink "github.com/tutti-os/tutti/packages/device-link"
+	"github.com/tutti-os/tutti/packages/device-link/relaytransport"
 	mobileremotebiz "github.com/tutti-os/tutti/services/tuttid/biz/mobileremote"
 )
 
@@ -74,14 +76,17 @@ func TestRelayOwnerLifecyclePreparesAndActivatesBoundSession(t *testing.T) {
 	if controlPlane.ensureCalls != 1 || controlPlane.registerCalls != 1 || controlPlane.tokenCalls != 1 {
 		t.Fatalf("authority calls = ensure=%d register=%d token=%d, want one each", controlPlane.ensureCalls, controlPlane.registerCalls, controlPlane.tokenCalls)
 	}
-	deactivate, err := lifecycle.Activate(context.Background(), session)
+	activation, err := lifecycle.Activate(context.Background(), session)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if activation.Readiness == nil {
+		t.Fatal("Activate() returned nil readiness")
 	}
 	if controlPlane.renewCalls != 1 {
 		t.Fatalf("lease renew calls = %d, want activation renewal", controlPlane.renewCalls)
 	}
-	deactivate()
+	activation.Deactivate()
 }
 
 func TestRelayOwnerLifecycleReusesAuthorityAndTokenAcrossReconnects(t *testing.T) {
@@ -103,6 +108,130 @@ func TestRelayOwnerLifecycleReusesAuthorityAndTokenAcrossReconnects(t *testing.T
 	}
 	if controlPlane.ensureCalls != 1 || controlPlane.registerCalls != 1 || controlPlane.tokenCalls != 1 {
 		t.Fatalf("reconnect calls = ensure=%d register=%d token=%d, want one each", controlPlane.ensureCalls, controlPlane.registerCalls, controlPlane.tokenCalls)
+	}
+}
+
+func TestRelayOwnerLeaseTransientFailureKeepsReadinessAndConnectionGeneration(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	controlPlane := newRelayOwnerTestAuthority(now)
+	controlPlane.authority.Lease = deviceauthority.LeasePolicy{TTLSeconds: 1, RenewIntervalSeconds: 1}
+	controlPlane.lease.ExpiresAt = now.Add(250 * time.Millisecond).Format(time.RFC3339Nano)
+	controlPlane.renewErrors = map[int]error{2: errors.New("temporary control-plane network failure")}
+	controlPlane.renewResults = map[int]deviceauthority.RenewDeviceAuthorityLeaseResult{
+		3: {
+			AuthorityID: "authority-1", State: "online",
+			ExpiresAt: time.Now().UTC().Add(time.Second).Format(time.RFC3339Nano),
+		},
+	}
+	service := &Service{
+		Account:         &relayOwnerTestAccount{session: &authbridge.Session{UserID: "user-1", Cookie: "cookie"}},
+		ControlPlane:    &relayOwnerTestControlPlane{},
+		DeviceAuthority: controlPlane,
+		RuntimeID:       "runtime-1",
+	}
+	lifecycle := (&relayOwnerLifecycleFactory{service: service}).NewOwnerLifecycle()
+	if _, err := lifecycle.Prepare(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	activation, err := lifecycle.Activate(context.Background(), relaytransport.OwnerSession{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer activation.Deactivate()
+	select {
+	case <-activation.Readiness.Done():
+		t.Fatalf("readiness ended after transient renewal failure: %v", context.Cause(activation.Readiness))
+	case <-time.After(350 * time.Millisecond):
+	}
+	if got := controlPlane.renewCount(); got < 3 {
+		t.Fatalf("renew calls = %d, want transient retry and recovery", got)
+	}
+	select {
+	case <-activation.Readiness.Done():
+		t.Fatalf("readiness ended after recovery: %v", context.Cause(activation.Readiness))
+	default:
+	}
+}
+
+func TestRelayOwnerLeaseExpiryEndsReadiness(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	controlPlane := newRelayOwnerTestAuthority(now)
+	controlPlane.authority.Lease = deviceauthority.LeasePolicy{TTLSeconds: 1, RenewIntervalSeconds: 1}
+	controlPlane.lease.ExpiresAt = now.Add(180 * time.Millisecond).Format(time.RFC3339Nano)
+	controlPlane.renewErrors = map[int]error{
+		2: errors.New("temporary control-plane network failure"),
+		3: errors.New("temporary control-plane network failure"),
+	}
+	service := &Service{
+		Account:         &relayOwnerTestAccount{session: &authbridge.Session{UserID: "user-1", Cookie: "cookie"}},
+		ControlPlane:    &relayOwnerTestControlPlane{},
+		DeviceAuthority: controlPlane,
+		RuntimeID:       "runtime-1",
+	}
+	lifecycle := (&relayOwnerLifecycleFactory{service: service}).NewOwnerLifecycle()
+	if _, err := lifecycle.Prepare(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	activation, err := lifecycle.Activate(context.Background(), relaytransport.OwnerSession{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer activation.Deactivate()
+	select {
+	case <-activation.Readiness.Done():
+		if !errors.Is(context.Cause(activation.Readiness), errRelayLeaseExpired) {
+			t.Fatalf("readiness cause = %v, want lease expiry", context.Cause(activation.Readiness))
+		}
+	case <-time.After(time.Second):
+		t.Fatal("readiness did not end after lease expiry")
+	}
+}
+
+func TestRelayOwnerLeaseUnauthorizedEndsReadinessAndInvalidatesToken(t *testing.T) {
+	now := time.Now().UTC()
+	controlPlane := newRelayOwnerTestAuthority(now)
+	controlPlane.authority.Lease = deviceauthority.LeasePolicy{TTLSeconds: 1, RenewIntervalSeconds: 1}
+	controlPlane.lease.ExpiresAt = now.Add(200 * time.Millisecond).Format(time.RFC3339Nano)
+	controlPlane.renewErrors = map[int]error{
+		2: &deviceauthority.HTTPError{StatusCode: http.StatusUnauthorized},
+	}
+	service := &Service{
+		Account:         &relayOwnerTestAccount{session: &authbridge.Session{UserID: "user-1", Cookie: "cookie"}},
+		ControlPlane:    &relayOwnerTestControlPlane{},
+		DeviceAuthority: controlPlane,
+		RuntimeID:       "runtime-1",
+	}
+	lifecycle := (&relayOwnerLifecycleFactory{service: service}).NewOwnerLifecycle().(*relayOwnerLifecycle)
+	if _, err := lifecycle.Prepare(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	activation, err := lifecycle.Activate(context.Background(), relaytransport.OwnerSession{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer activation.Deactivate()
+	select {
+	case <-activation.Readiness.Done():
+		var httpErr *deviceauthority.HTTPError
+		if !errors.As(context.Cause(activation.Readiness), &httpErr) || httpErr.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("readiness cause = %v, want unauthorized", context.Cause(activation.Readiness))
+		}
+	case <-time.After(time.Second):
+		t.Fatal("readiness did not end after unauthorized renewal")
+	}
+	lifecycle.mu.Lock()
+	tokenBefore := lifecycle.token.Value
+	lifecycle.mu.Unlock()
+	if tokenBefore != "" {
+		t.Fatalf("cached token after unauthorized renewal = %q, want invalidated", tokenBefore)
+	}
+	if _, err := lifecycle.Prepare(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if controlPlane.tokenCalls != 2 {
+		t.Fatalf("token calls after unauthorized renewal = %d, want re-sign", controlPlane.tokenCalls)
 	}
 }
 
@@ -306,6 +435,8 @@ type relayOwnerTestAuthority struct {
 	registerCalls int
 	tokenCalls    int
 	renewCalls    int
+	renewErrors   map[int]error
+	renewResults  map[int]deviceauthority.RenewDeviceAuthorityLeaseResult
 }
 
 func (c *relayOwnerTestAuthority) EnsureDeviceAuthority(context.Context, deviceauthority.EnsureDeviceAuthorityRequest) (deviceauthority.DeviceAuthorityResult, error) {
@@ -333,7 +464,19 @@ func (c *relayOwnerTestAuthority) RenewDeviceAuthorityLease(context.Context, dev
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.renewCalls++
+	if err := c.renewErrors[c.renewCalls]; err != nil {
+		return deviceauthority.RenewDeviceAuthorityLeaseResult{}, err
+	}
+	if lease, ok := c.renewResults[c.renewCalls]; ok {
+		return lease, nil
+	}
 	return c.lease, nil
+}
+
+func (c *relayOwnerTestAuthority) renewCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.renewCalls
 }
 
 type relayOwnerTestControlPlane struct{}

--- a/services/tuttid/service/mobileremote/relay_owner_test.go
+++ b/services/tuttid/service/mobileremote/relay_owner_test.go
@@ -111,6 +111,14 @@ func TestRelayOwnerLifecycleReusesAuthorityAndTokenAcrossReconnects(t *testing.T
 	}
 }
 
+func TestLeaseRenewWaitDoesNotTruncateOneSecondTTL(t *testing.T) {
+	now := time.Unix(0, 0)
+	got := leaseRenewWait(now, now.Add(time.Second), deviceauthority.LeasePolicy{TTLSeconds: 1})
+	if got != 500*time.Millisecond {
+		t.Fatalf("leaseRenewWait() = %s, want 500ms", got)
+	}
+}
+
 func TestRelayOwnerLeaseTransientFailureKeepsReadinessAndConnectionGeneration(t *testing.T) {
 	t.Parallel()
 	now := time.Now().UTC()


### PR DESCRIPTION
按原始需求完成 Owner 会话健康状态机：新增持续 OwnerActivation.Readiness 契约；OwnerHost 支持 readiness 失效关闭连接、传递 cause、重连及 Wake；mobileremote 使用 ExpiresAt、有限续约重试、失效处理和 token 清理；补充 authority binding typed error、文档与测试。未修改 TSH、tsh-server、数据库或 wire schema。

验证通过：device-link、device-authority-go、mobileremote race tests；Wake 高重复回归；services/tuttid go build ./...；git diff --check。未运行 E2E。