### PR TITLE
fix(agent): make Connector an optional capability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,9 +94,6 @@ Before preparing commits or pull requests, read `CONTRIBUTING.md` and follow it
 for repository-wide contribution requirements, including Conventional Commits,
 DCO sign-off, PR workflow, review gates, and multilingual documentation updates.
 
-After creating or updating a pull request, read it back from GitHub and verify
-its draft state, title, description encoding, head commit, and CI status.
-
 ## Hard Rules
 
 - Published workspace packages use `@tutti-os/*`; keep manifests, imports, docs, and release config aligned.

--- a/docs/architecture/connector-market.md
+++ b/docs/architecture/connector-market.md
@@ -511,6 +511,16 @@ are issued by `packages/connector/runtime/agentgateway`, whose listener and
 bearer authority can outlive replacement of the bundle-owned backend.
 `packages/connector/runtime/mcpserver` remains the replaceable MCP protocol
 backend; product daemons own both lifecycles.
+Before creating a Connector binding, the Agent runtime resolves the exact
+provider adapter. Standard ACP adapters enable Connector only when the
+`initialize` response explicitly declares
+`agentCapabilities.mcpCapabilities.http == true`; a missing or false field,
+capability-probe failure, or Connector binding/preparation failure falls back
+to the ordinary Connector-free session. Unknown future adapters are also
+Connector-free until they explicitly implement this capability contract.
+The fallback omits the session binding, MCP configuration, routing hints,
+Connector policy, Skill roots, and Connector CLI path together.
+
 Tool names are
 namespaced as `<connector-key>_<upstream-tool-name>`. Each Agent session receives
 a short-lived bearer binding through its provider-native MCP configuration;

--- a/docs/specs/2026-08-07-connector-native-agent-integration.md
+++ b/docs/specs/2026-08-07-connector-native-agent-integration.md
@@ -359,9 +359,10 @@ MCP。`DefaultPreparer` 的最终输出以其 `PreparedRuntime.MCPServers` 为�
 }
 ```
 
-发送 `session/new` 或 `session/load` 前，必须先检查 initialize 响应中的
-`agentCapabilities.mcpCapabilities.http == true`。Provider 未声明标准 HTTP MCP
-能力时启动失败并返回明确错误，不能静默创建一个看不到 Connector 工具的 Session。
+创建 Connector Session Binding 前，必须先检查 initialize 响应中的
+`agentCapabilities.mcpCapabilities.http == true`。只有明确声明支持的 Provider 才注入
+Connector MCP、routing hints、Skill 和 Connector 提示；字段缺失、值为 false、能力探测
+失败或 Connector 自身失败时，整体降级为不含 Connector 的普通 Session，不得阻断启动。
 
 ### 7.3 Codex
 
@@ -666,7 +667,9 @@ Provider 注入或动态刷新问题。
 ### 15.3 Provider 测试
 
 - ACP `session/new` 和 `session/load` 收到非空 `mcpServers`；
-- ACP 未声明 HTTP MCP capability 时明确拒绝启动；
+- ACP 明确声明 HTTP MCP capability 时注入完整 Connector 上下文；
+- ACP 未声明、声明 false 或能力探测失败时不绑定 Connector，普通 Session 正常启动；
+- 未实现 Connector capability contract 的未来 Provider 默认按不支持降级；
 - Codex Session 配置包含 `[mcp_servers.connector]`；
 - Claude SDK Session options 包含 `connector` binding；
 - Tutti Agent Session 配置包含 `[mcp_servers.connector]`；

--- a/packages/agent/daemon/runtime/adapter.go
+++ b/packages/agent/daemon/runtime/adapter.go
@@ -166,6 +166,17 @@ type Adapter interface {
 	Cancel(context.Context, Session, string) ([]activityshared.Event, error)
 }
 
+// ConnectorCapabilityAdapter reports whether this exact provider runtime can
+// accept Tutti's session-scoped Connector binding. Implementations must return
+// false unless support is explicit; a missing implementation is unsupported.
+type ConnectorCapabilityAdapter interface {
+	ConnectorCapabilities(context.Context, Session) (ConnectorCapabilities, error)
+}
+
+type ConnectorCapabilities struct {
+	HTTPMCP bool
+}
+
 // SessionForkAdapter is an optional provider-native capability. Providers that
 // cannot prove an exact fork boundary do not implement it.
 type SessionForkAdapter interface {

--- a/packages/agent/daemon/runtime/claude_sdk_adapter.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter.go
@@ -1,6 +1,7 @@
 package agentruntime
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -222,6 +223,13 @@ func NewClaudeCodeSDKAdapter(transport ProcessTransport) *ClaudeCodeSDKAdapter {
 
 func (*ClaudeCodeSDKAdapter) Provider() string {
 	return ProviderClaudeCode
+}
+
+func (*ClaudeCodeSDKAdapter) ConnectorCapabilities(
+	context.Context,
+	Session,
+) (ConnectorCapabilities, error) {
+	return ConnectorCapabilities{HTTPMCP: true}, nil
 }
 
 func (*ClaudeCodeSDKAdapter) UsesRootProviderTurnLifecycle() bool {

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -533,6 +533,13 @@ func (a *CodexAppServerAdapter) Provider() string {
 	return a.config.provider
 }
 
+func (*CodexAppServerAdapter) ConnectorCapabilities(
+	context.Context,
+	Session,
+) (ConnectorCapabilities, error) {
+	return ConnectorCapabilities{HTTPMCP: true}, nil
+}
+
 func (*CodexAppServerAdapter) sessionCWD(session Session) string {
 	return projectCodexWorkspaceCWD(strings.TrimSpace(session.CWD), session.RoomID)
 }

--- a/packages/agent/daemon/runtime/controller_connector_capabilities.go
+++ b/packages/agent/daemon/runtime/controller_connector_capabilities.go
@@ -1,0 +1,53 @@
+package agentruntime
+
+import (
+	"context"
+	"strings"
+)
+
+type ConnectorCapabilityInput struct {
+	RoomID            string
+	AgentSessionID    string
+	AgentTargetID     string
+	Provider          string
+	CWD               string
+	Env               []string
+	ProviderTargetRef map[string]any
+	PermissionModeID  string
+	Settings          *SessionSettings
+}
+
+// ConnectorCapabilities resolves the exact adapter that will own the session
+// and asks it for explicit Connector transport support. Unknown and future
+// adapters fail closed to an ordinary, Connector-free session.
+func (c *Controller) ConnectorCapabilities(
+	ctx context.Context,
+	input ConnectorCapabilityInput,
+) (ConnectorCapabilities, error) {
+	provider := strings.TrimSpace(input.Provider)
+	adapter, err := c.resolveAdapter(ctx, AdapterResolveInput{
+		Provider:          provider,
+		AgentTargetID:     strings.TrimSpace(input.AgentTargetID),
+		CWD:               strings.TrimSpace(input.CWD),
+		ProviderTargetRef: clonePayload(input.ProviderTargetRef),
+	})
+	if err != nil {
+		return ConnectorCapabilities{}, err
+	}
+	capabilityAdapter, ok := adapter.(ConnectorCapabilityAdapter)
+	if !ok {
+		return ConnectorCapabilities{}, nil
+	}
+	return capabilityAdapter.ConnectorCapabilities(ctx, Session{
+		RoomID:             strings.TrimSpace(input.RoomID),
+		AgentSessionID:     strings.TrimSpace(input.AgentSessionID),
+		RootAgentSessionID: strings.TrimSpace(input.AgentSessionID),
+		AgentTargetID:      strings.TrimSpace(input.AgentTargetID),
+		Provider:           provider,
+		CWD:                strings.TrimSpace(input.CWD),
+		Env:                append([]string(nil), input.Env...),
+		ProviderTargetRef:  clonePayload(input.ProviderTargetRef),
+		PermissionModeID:   strings.TrimSpace(input.PermissionModeID),
+		Settings:           cloneOptionalSessionSettings(input.Settings),
+	})
+}

--- a/packages/agent/daemon/runtime/standard_acp_launch_settings_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_launch_settings_test.go
@@ -476,7 +476,7 @@ func TestStandardACPSessionNewAndLoadPassStandardClientMCPConfig(t *testing.T) {
 	}
 }
 
-func TestStandardACPSessionRejectsHTTPMCPWhenAgentDoesNotAdvertiseCapability(t *testing.T) {
+func TestStandardACPSessionFallsBackWithoutHTTPMCPWhenAgentDoesNotAdvertiseCapability(t *testing.T) {
 	t.Parallel()
 
 	newTransport := newStandardACPTransport("MCP Unsupported ACP", "mcp-unsupported-session")
@@ -489,11 +489,11 @@ func TestStandardACPSessionRejectsHTTPMCPWhenAgentDoesNotAdvertiseCapability(t *
 	}
 	session := standardTestSession("acp:mcp-unsupported")
 	session.MCPServers = []MCPServerBinding{{Name: "connector", Type: "http", URL: "http://127.0.0.1:1234/mcp/connector"}}
-	if _, err := newAdapter.Start(context.Background(), session); !errors.Is(err, ErrMCPHTTPUnsupported) {
-		t.Fatalf("Start error = %v, want ErrMCPHTTPUnsupported", err)
+	if _, err := newAdapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start error = %v", err)
 	}
-	if newTransport.conn.lastNewSessionParams != nil {
-		t.Fatalf("session/new params = %#v, want no session creation", newTransport.conn.lastNewSessionParams)
+	if servers, ok := newTransport.conn.lastNewSessionParams["mcpServers"].([]any); ok && len(servers) != 0 {
+		t.Fatalf("session/new mcpServers = %#v, want empty fallback", newTransport.conn.lastNewSessionParams["mcpServers"])
 	}
 
 	loadTransport := newStandardACPTransport("MCP Unsupported ACP", "mcp-unsupported-load-session")
@@ -508,11 +508,45 @@ func TestStandardACPSessionRejectsHTTPMCPWhenAgentDoesNotAdvertiseCapability(t *
 	loadSession := standardTestSession("acp:mcp-unsupported")
 	loadSession.ProviderSessionID = "mcp-unsupported-load-session"
 	loadSession.MCPServers = cloneMCPServerBindings(session.MCPServers)
-	if err := loadAdapter.Resume(context.Background(), loadSession); !errors.Is(err, ErrMCPHTTPUnsupported) {
-		t.Fatalf("Resume error = %v, want ErrMCPHTTPUnsupported", err)
+	if err := loadAdapter.Resume(context.Background(), loadSession); err != nil {
+		t.Fatalf("Resume error = %v", err)
 	}
-	if loadTransport.conn.lastLoadSessionParams != nil {
-		t.Fatalf("session/load params = %#v, want no session resume", loadTransport.conn.lastLoadSessionParams)
+	if servers, ok := loadTransport.conn.lastLoadSessionParams["mcpServers"].([]any); ok && len(servers) != 0 {
+		t.Fatalf("session/load mcpServers = %#v, want empty fallback", loadTransport.conn.lastLoadSessionParams["mcpServers"])
+	}
+}
+
+func TestStandardACPConnectorCapabilitiesRequireExplicitHTTPDeclaration(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name      string
+		supported bool
+	}{
+		{name: "declared", supported: true},
+		{name: "missing", supported: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			transport := newStandardACPTransport("Capability ACP", "capability-session")
+			transport.conn.supportsHTTPMCP = test.supported
+			adapter, err := NewStandardACPAdapter(StandardACPAdapterConfig{
+				Provider: "acp:capability", Name: "capability-acp", DisplayName: "Capability ACP", Command: []string{"capability-acp", "stdio"},
+			}, transport, LegacyHostMetadata())
+			if err != nil {
+				t.Fatalf("NewStandardACPAdapter: %v", err)
+			}
+			capabilities, err := adapter.(ConnectorCapabilityAdapter).ConnectorCapabilities(t.Context(), standardTestSession("acp:capability"))
+			if err != nil {
+				t.Fatalf("ConnectorCapabilities: %v", err)
+			}
+			if capabilities.HTTPMCP != test.supported {
+				t.Fatalf("HTTPMCP = %v, want %v", capabilities.HTTPMCP, test.supported)
+			}
+			if transport.conn.lastNewSessionParams != nil {
+				t.Fatalf("capability probe created session: %#v", transport.conn.lastNewSessionParams)
+			}
+		})
 	}
 }
 

--- a/packages/agent/daemon/runtime/standard_acp_session.go
+++ b/packages/agent/daemon/runtime/standard_acp_session.go
@@ -41,13 +41,12 @@ func (a *standardACPAdapter) Start(ctx context.Context, session Session) ([]acti
 	}
 	mcpServers := acpMCPServers(session.MCPServers)
 	if len(mcpServers) > 0 && !standardACPHTTPMCPSupported(initializeResult) {
-		a.logStandardACPStartupDiagnostics("mcp_http.unsupported", map[string]any{
+		a.logStandardACPStartupDiagnostics("mcp_http.unsupported_fallback", map[string]any{
 			"room_id":          session.RoomID,
 			"agent_session_id": session.AgentSessionID,
 			"binding_count":    len(mcpServers),
 		})
-		_ = client.Close()
-		return nil, ErrMCPHTTPUnsupported
+		mcpServers = nil
 	}
 	started := false
 	keepSession := false
@@ -187,19 +186,18 @@ func (a *standardACPAdapter) Resume(ctx context.Context, session Session) error 
 	}
 	unlockLifecycle := a.lockSessionLifecycle(session.AgentSessionID)
 	defer unlockLifecycle()
-	client, initializeResult, attachedCheckpoint, err := a.startClient(ctx, session, true)
+	client, initializeResult, attachedCheckpoint, err := a.startClient(ctx, session, true, true)
 	if err != nil {
 		return err
 	}
 	mcpServers := acpMCPServers(session.MCPServers)
 	if !attachedCheckpoint && len(mcpServers) > 0 && !standardACPHTTPMCPSupported(initializeResult) {
-		a.logStandardACPStartupDiagnostics("mcp_http.unsupported", map[string]any{
+		a.logStandardACPStartupDiagnostics("mcp_http.unsupported_fallback", map[string]any{
 			"room_id":          session.RoomID,
 			"agent_session_id": session.AgentSessionID,
 			"binding_count":    len(mcpServers),
 		})
-		_ = client.Close()
-		return ErrMCPHTTPUnsupported
+		mcpServers = nil
 	}
 	started := false
 	keepSession := false
@@ -442,14 +440,29 @@ func (a *standardACPAdapter) startInitializedClient(
 	ctx context.Context,
 	session Session,
 ) (*acpClient, json.RawMessage, error) {
-	client, initializeResult, _, err := a.startClient(ctx, session, false)
+	client, initializeResult, _, err := a.startClient(ctx, session, false, true)
 	return client, initializeResult, err
+}
+
+func (a *standardACPAdapter) ConnectorCapabilities(
+	ctx context.Context,
+	session Session,
+) (ConnectorCapabilities, error) {
+	client, initializeResult, _, err := a.startClient(ctx, session, false, false)
+	if err != nil {
+		return ConnectorCapabilities{}, err
+	}
+	if err := client.Close(); err != nil {
+		slog.WarnContext(ctx, "close ACP Connector capability probe", "provider", a.Provider(), "error", err)
+	}
+	return ConnectorCapabilities{HTTPMCP: standardACPHTTPMCPSupported(initializeResult)}, nil
 }
 
 func (a *standardACPAdapter) startClient(
 	ctx context.Context,
 	session Session,
 	allowAttachedCheckpoint bool,
+	runBeforeNewSession bool,
 ) (*acpClient, json.RawMessage, bool, error) {
 	if a == nil || a.transport == nil {
 		return nil, nil, false, errors.New("ACP process transport is unavailable")
@@ -589,7 +602,7 @@ func (a *standardACPAdapter) startClient(
 		"agent_info":       acpAgentInfo(initializeResult),
 	})
 
-	if a.config.beforeNewSession != nil {
+	if runBeforeNewSession && a.config.beforeNewSession != nil {
 		beforeNewSessionStartedAt := time.Now()
 		a.logStandardACPStartupDiagnostics("before_new_session.start", map[string]any{
 			"room_id":          session.RoomID,

--- a/packages/agent/runtimeprep/capability.go
+++ b/packages/agent/runtimeprep/capability.go
@@ -97,6 +97,7 @@ type ResolvedBundle struct {
 // Resolve composes a deployment profile without materializing provider files.
 // DefaultPreparer uses the same resolver before provider preparation.
 func Resolve(ctx context.Context, input PrepareInput, profile DeploymentProfile, sources ...SkillSource) (ResolvedBundle, error) {
+	input = expandConnectorAgentContext(input)
 	resolved, err := resolveCapabilities(ctx, input, profile, sources)
 	if err != nil {
 		return ResolvedBundle{}, err
@@ -125,12 +126,11 @@ func StandardProfile() DeploymentProfile {
 	}
 }
 
-// ConnectorDiscoveryPack teaches an Agent the stable two-level Broker flow.
-// Connector-owned Skills remain lazy and untrusted; they are never injected
-// into the initial provider context.
+// ConnectorDiscoveryPack teaches an explicitly Connector-enabled Agent the
+// stable two-level Broker flow. Connector-owned Skills remain untrusted.
 func ConnectorDiscoveryPack() CapabilityPack {
 	return CapabilityPack{Name: "connector-discovery", Resolve: func(_ context.Context, input PrepareInput) (CapabilityContribution, error) {
-		if input.commandCapabilities == nil || !input.commandCapabilities.HasAll(
+		if input.Connector == nil || input.commandCapabilities == nil || !input.commandCapabilities.HasAll(
 			"connector.available",
 		) {
 			return CapabilityContribution{Enabled: false}, nil

--- a/packages/agent/runtimeprep/preparer.go
+++ b/packages/agent/runtimeprep/preparer.go
@@ -191,6 +191,7 @@ func cloneMCPServerBindings(input []MCPServerBinding) []MCPServerBinding {
 }
 
 func (p *DefaultPreparer) RenderSkillBundle(ctx context.Context, input PrepareInput) (SkillBundle, error) {
+	input = expandConnectorAgentContext(input)
 	workspaceID := strings.TrimSpace(input.WorkspaceID)
 	agentTargetID := strings.TrimSpace(input.AgentTargetID)
 	providerID := strings.TrimSpace(input.Provider)

--- a/packages/agent/runtimeprep/preparer_test.go
+++ b/packages/agent/runtimeprep/preparer_test.go
@@ -64,8 +64,9 @@ func TestDefaultPreparerCodexWritesInstructionsSkillManifestAndEnv(t *testing.T)
 		AgentTargetID:  "local:codex",
 		Provider:       "codex",
 		Cwd:            cwd,
-		ConnectorRoutingHints: []ConnectorRoutingHint{{ConnectorKey: "lark-cli", DisplayName: "Lark CLI",
+		Connector: &ConnectorAgentContext{RoutingHints: []ConnectorRoutingHint{{ConnectorKey: "lark-cli", DisplayName: "Lark CLI",
 			Aliases: []string{"飞书", "Feishu", "Lark", "Lark Suite"}}},
+		},
 		ExtraSkills: []ProviderSkillBundle{
 			{
 				Name: "app-factory",

--- a/packages/agent/runtimeprep/provider_skill_test.go
+++ b/packages/agent/runtimeprep/provider_skill_test.go
@@ -105,8 +105,9 @@ func TestTuttiCLIPolicyUsesPreparedCLIAndProviderRules(t *testing.T) {
 		AgentSessionID: "session-1",
 		CLICommand:     "tutti-dev",
 		Provider:       "codex",
-		ConnectorRoutingHints: []ConnectorRoutingHint{{ConnectorKey: "lark-cli", DisplayName: "Lark CLI",
+		Connector: &ConnectorAgentContext{RoutingHints: []ConnectorRoutingHint{{ConnectorKey: "lark-cli", DisplayName: "Lark CLI",
 			Aliases: []string{"飞书", "Feishu", "Lark", "Lark Suite"}}},
+		},
 	}))
 	if err != nil {
 		t.Fatal(err)

--- a/packages/agent/runtimeprep/tutti_cli_policy.go
+++ b/packages/agent/runtimeprep/tutti_cli_policy.go
@@ -6,6 +6,7 @@ import (
 )
 
 func tuttiCLIPolicy(input PrepareInput) (string, error) {
+	input = expandConnectorAgentContext(input)
 	if input.resolved == nil {
 		if resolved, err := resolveCapabilities(context.Background(), input, StandardProfile(), nil); err == nil {
 			input.resolved = resolved

--- a/services/tuttid/agent_runtime_adapter.go
+++ b/services/tuttid/agent_runtime_adapter.go
@@ -30,6 +30,24 @@ func newAgentRuntimeAdapter(controller *agentruntime.Controller) agentRuntimeAda
 	return agentRuntimeAdapter{controller: controller}
 }
 
+func (a agentRuntimeAdapter) ConnectorHTTPMCPSupported(
+	ctx context.Context,
+	input agentservice.ConnectorCapabilityInput,
+) (bool, error) {
+	capabilities, err := a.controller.ConnectorCapabilities(ctx, agentruntime.ConnectorCapabilityInput{
+		RoomID:            input.WorkspaceID,
+		AgentSessionID:    input.AgentSessionID,
+		AgentTargetID:     input.AgentTargetID,
+		Provider:          input.Provider,
+		CWD:               input.Cwd,
+		Env:               append([]string(nil), input.Env...),
+		ProviderTargetRef: cloneRuntimeContext(input.ProviderTargetRef),
+		PermissionModeID:  input.PermissionModeID,
+		Settings:          agentRuntimeSessionSettings(input.Settings),
+	})
+	return capabilities.HTTPMCP, err
+}
+
 func (a agentRuntimeAdapter) Cancel(ctx context.Context, input agentservice.RuntimeCancelInput) (agentservice.RuntimeCancelResult, error) {
 	targets := make([]agentruntime.CancelTarget, 0, len(input.Targets))
 	for _, target := range input.Targets {

--- a/services/tuttid/service/agent/composer_defaults_validation.go
+++ b/services/tuttid/service/agent/composer_defaults_validation.go
@@ -189,11 +189,7 @@ func (s *Service) validateExtensionComposerSettingsForCreate(
 			input.ReasoningEffort = stringPointer(resolved)
 		}
 	}
-	if err := validateExtensionComposerOption(
-		preferencesbiz.AgentComposerDefaultsFieldModel,
-		settings.Model,
-		options.ModelConfig,
-	); err != nil {
+	if err := validateExtensionComposerModelForCreate(settings.Model, options); err != nil {
 		return err
 	}
 	if permissionModeExplicit && settings.PermissionModeID != "" &&
@@ -222,6 +218,31 @@ func (s *Service) validateExtensionComposerSettingsForCreate(
 		settings.Speed,
 		options.SpeedConfig,
 	)
+}
+
+func validateExtensionComposerModelForCreate(selected string, options ComposerOptions) error {
+	// A live extension model catalog can still be loading after the bounded
+	// Composer wait. In that case the target has not said model selection is
+	// unsupported; allow the already requested model through to the runtime.
+	// Once any authoritative options are available, keep the ordinary strict
+	// membership validation.
+	if options.liveModelDiscoveryPending && !composerConfigHasAdvertisedOptions(options.ModelConfig) {
+		return nil
+	}
+	return validateExtensionComposerOption(
+		preferencesbiz.AgentComposerDefaultsFieldModel,
+		selected,
+		options.ModelConfig,
+	)
+}
+
+func composerConfigHasAdvertisedOptions(config ComposerConfigOption) bool {
+	for _, option := range config.Options {
+		if !option.Requested && strings.TrimSpace(option.Value) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func composerReasoningConfigForSelectedModel(options ComposerOptions) ComposerConfigOption {

--- a/services/tuttid/service/agent/composer_live_model_coordinator.go
+++ b/services/tuttid/service/agent/composer_live_model_coordinator.go
@@ -73,7 +73,11 @@ func (s *Service) discoverLiveComposerModels(
 		s.setLiveComposerModelOptionsForScope(scope, time.Now().UTC(), discovered)
 		return discovered, nil
 	})
-	waitTimer := time.NewTimer(liveModelDiscoveryTimeout)
+	waitTimeout := liveModelDiscoveryTimeout
+	if s != nil && s.liveModelDiscoveryWaitTimeout > 0 {
+		waitTimeout = s.liveModelDiscoveryWaitTimeout
+	}
+	waitTimer := time.NewTimer(waitTimeout)
 	defer waitTimer.Stop()
 	select {
 	case <-ctx.Done():

--- a/services/tuttid/service/agent/composer_live_model_discovery.go
+++ b/services/tuttid/service/agent/composer_live_model_discovery.go
@@ -501,6 +501,7 @@ func (s *Service) mergeLiveComposerModelsForComposerOptions(
 	provider := agentprovider.NormalizeOpen(input.Provider)
 	scope := newComposerLiveModelScopeForInput(input, effectiveSettings)
 	var liveModels []ComposerConfigOptionValue
+	liveModelDiscoveryPending := false
 	modelSource := "claude-static"
 	if strings.TrimSpace(input.WorkspaceID) != "" {
 		now := time.Now().UTC()
@@ -564,6 +565,7 @@ func (s *Service) mergeLiveComposerModelsForComposerOptions(
 				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 					return ComposerOptions{}, err
 				}
+				liveModelDiscoveryPending = errors.Is(err, errLiveModelDiscoveryPending)
 				if err == nil && len(discovered) > 0 {
 					liveModels = discovered
 					modelSource = runtimeLiveModelCatalogSource
@@ -598,6 +600,10 @@ func (s *Service) mergeLiveComposerModelsForComposerOptions(
 	if !isClaudeSDKLiveModelProvider(provider) {
 		// Without a live list there is nothing trustworthy to offer beyond
 		// the currently selected model; keep the static single-entry select.
+		// Preserve a pending discovery as separate evidence so create validation
+		// does not mistake a slow extension startup for an explicit refusal to
+		// configure models.
+		options.liveModelDiscoveryPending = liveModelDiscoveryPending
 		return options, nil
 	}
 	staticModels := staticClaudeComposerModelOptions(effectiveSettings.Model)

--- a/services/tuttid/service/agent/composer_options.go
+++ b/services/tuttid/service/agent/composer_options.go
@@ -140,6 +140,10 @@ type ComposerOptions struct {
 	CapabilityCatalog       []ComposerCapabilityOption
 	Behavior                providerregistry.ComposerBehaviorDescriptor
 	SlashCommandPolicy      *providerregistry.SlashCommandPolicyDescriptor
+	// liveModelDiscoveryPending distinguishes a temporarily unavailable live
+	// catalog from an agent target that explicitly does not expose model
+	// selection. It is daemon-internal and must not be serialized.
+	liveModelDiscoveryPending bool
 }
 
 func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsInput) (ComposerOptions, error) {

--- a/services/tuttid/service/agent/extension_composer_create_validation_test.go
+++ b/services/tuttid/service/agent/extension_composer_create_validation_test.go
@@ -5,12 +5,94 @@ import (
 	"errors"
 	"slices"
 	"testing"
+	"time"
 
 	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
 )
 
 const extensionComposerValidationTargetID = "extension:gemini-validation"
+
+func TestExtensionComposerModelValidationDegradesWhileLiveCatalogDiscoveryIsPending(t *testing.T) {
+	runtime := newFakeRuntime()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	closed := make(chan struct{})
+	runtime.startHook = func(input RuntimeStartInput, session ProviderRuntimeSession) ProviderRuntimeSession {
+		if input.Visible != nil && !*input.Visible {
+			close(started)
+			<-release
+			session.RuntimeContext["configOptions"] = []any{map[string]any{
+				"id": "model", "options": []any{
+					map[string]any{"value": "gemini-pro", "name": "Gemini Pro"},
+				},
+			}}
+		}
+		return session
+	}
+	runtime.closeHook = func(RuntimeCloseInput) { close(closed) }
+	service := newIsolatedAgentService(runtime)
+	service.liveModelDiscoveryWaitTimeout = 10 * time.Millisecond
+	input := extensionComposerDiscoveryInput(t.TempDir())
+	input.Settings.Model = "gemini-pro"
+	input.extensionComposerProfile.ModelConfigOptionID = "model"
+	base := ComposerOptions{
+		Provider:          input.Provider,
+		EffectiveSettings: input.Settings,
+		ModelConfig: ComposerConfigOption{
+			CurrentValue: "gemini-pro",
+			DefaultValue: "gemini-pro",
+			Options:      composerSelectedModelOptions("gemini-pro"),
+		},
+		RuntimeContext: map[string]any{},
+	}
+
+	type mergeResult struct {
+		options ComposerOptions
+		err     error
+	}
+	result := make(chan mergeResult, 1)
+	go func() {
+		options, err := service.mergeLiveComposerModelsForComposerOptions(
+			context.Background(), input, input.Settings, base,
+		)
+		result <- mergeResult{options: options, err: err}
+	}()
+	<-started
+	merged := <-result
+	if merged.err != nil {
+		t.Fatalf("mergeLiveComposerModelsForComposerOptions() error = %v", merged.err)
+	}
+	if !merged.options.liveModelDiscoveryPending {
+		t.Fatal("live model discovery pending state was not preserved")
+	}
+	if err := validateExtensionComposerModelForCreate("gemini-pro", merged.options); err != nil {
+		t.Fatalf("pending live catalog rejected selected model: %v", err)
+	}
+
+	close(release)
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for hidden discovery cleanup")
+	}
+}
+
+func TestExtensionComposerModelValidationRemainsStrictWithAdvertisedCatalog(t *testing.T) {
+	options := ComposerOptions{
+		liveModelDiscoveryPending: true,
+		ModelConfig: ComposerConfigOption{
+			Configurable: true,
+			Options: []ComposerConfigOptionValue{
+				{Value: "gemini-pro"},
+				{Value: "gemini-fast"},
+			},
+		},
+	}
+	if err := validateExtensionComposerModelForCreate("unknown-model", options); !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("advertised catalog validation error = %v, want ErrInvalidArgument", err)
+	}
+}
 
 func TestServiceCreateValidatesExtensionDefaultsAndExplicitOverrides(t *testing.T) {
 	runtime, service := newExtensionComposerValidationService(t)

--- a/services/tuttid/service/agent/host_runtime_preparation.go
+++ b/services/tuttid/service/agent/host_runtime_preparation.go
@@ -35,6 +35,7 @@ type serviceHostRuntimePreparationSupport interface {
 type serviceRuntimePreparation struct {
 	runtimePreparer              runtimeprep.Preparer
 	connectorRuntime             ConnectorRuntime
+	connectorCapabilities        ConnectorCapabilityResolver
 	modelGateway                 ModelGatewayRegistry
 	modelCatalog                 AgentModelCatalog
 	agentTargetStore             AgentTargetStore
@@ -52,6 +53,7 @@ func newServiceRuntimePreparation(config ServiceConfig) *serviceRuntimePreparati
 	return &serviceRuntimePreparation{
 		runtimePreparer:           config.Runtime.Preparer,
 		connectorRuntime:          config.Runtime.Connector,
+		connectorCapabilities:     config.Runtime.ConnectorCapabilities,
 		modelGateway:              config.Runtime.ModelGateway,
 		modelCatalog:              config.Composer.ModelCatalog,
 		agentTargetStore:          config.Composer.AgentTargetStore,
@@ -76,6 +78,7 @@ func (p *serviceRuntimePreparation) facade() *Service {
 	return &Service{
 		RuntimePreparer:              p.runtimePreparer,
 		ConnectorRuntime:             p.connectorRuntime,
+		ConnectorCapabilities:        p.connectorCapabilities,
 		ModelGateway:                 p.modelGateway,
 		ModelCatalog:                 p.modelCatalog,
 		AgentTargetStore:             p.agentTargetStore,

--- a/services/tuttid/service/agent/service_config.go
+++ b/services/tuttid/service/agent/service_config.go
@@ -33,6 +33,7 @@ type ServiceHostConfig struct {
 type ServiceRuntimeConfig struct {
 	Preparer                      runtimeprep.Preparer
 	Connector                     ConnectorRuntime
+	ConnectorCapabilities         ConnectorCapabilityResolver
 	ModelGateway                  ModelGatewayRegistry
 	BrowserUseAvailable           func() bool
 	ComputerUseAvailable          func() bool
@@ -152,6 +153,7 @@ func (s *Service) applyConfig(config ServiceConfig) {
 	s.PromptAttachmentStore = config.Resources.PromptAttachmentStore
 	s.RuntimePreparer = config.Runtime.Preparer
 	s.ConnectorRuntime = config.Runtime.Connector
+	s.ConnectorCapabilities = config.Runtime.ConnectorCapabilities
 	s.ModelGateway = config.Runtime.ModelGateway
 	s.BrowserUseAvailable = config.Runtime.BrowserUseAvailable
 	s.ComputerUseAvailable = config.Runtime.ComputerUseAvailable

--- a/services/tuttid/service/agent/service_create.go
+++ b/services/tuttid/service/agent/service_create.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -604,21 +605,7 @@ func (s *Service) prepareRuntimeWithModelEndpoint(
 	}
 	effectiveBrowserUse := s.clampComposerBrowserUseForLaunch(ctx, provider, input.ProviderTargetRef, input.BrowserUse)
 	effectiveComputerUse := s.clampComposerComputerUseForLaunch(ctx, provider, input.ProviderTargetRef, input.ComputerUse)
-	var connectorContext *runtimeprep.ConnectorAgentContext
-	connectorBound := false
-	if s.ConnectorRuntime != nil {
-		contextBinding, bindingErr := s.ConnectorRuntime.BindSession(workspaceID, strings.TrimSpace(input.AgentSessionID))
-		if bindingErr != nil {
-			if gatewayRegistered {
-				s.ModelGateway.Unregister(context.WithoutCancel(ctx), workspaceID, input.AgentSessionID)
-			}
-			return preparedRuntime{}, bindingErr
-		}
-		contextBinding = cloneConnectorAgentContext(contextBinding)
-		connectorContext = &contextBinding
-		connectorBound = true
-	}
-	prepared, err := s.RuntimePreparer.Prepare(ctx, runtimeprep.PrepareInput{
+	prepareInput := runtimeprep.PrepareInput{
 		WorkspaceID:               workspaceID,
 		AgentSessionID:            strings.TrimSpace(input.AgentSessionID),
 		AgentTargetID:             strings.TrimSpace(input.AgentTargetID),
@@ -644,21 +631,66 @@ func (s *Service) prepareRuntimeWithModelEndpoint(
 		AgentSkills:               append([]string(nil), input.AgentSkills...),
 		AgentTools:                append([]string(nil), input.AgentTools...),
 		ExtraSkills:               sessionSkillBundlesToProviderSkillBundles(input.ExtraSkills),
-		Connector:                 connectorContext,
 		Metadata:                  input.Metadata,
 		CommandCapabilityProjection: cloneCommandCapabilityProjection(
 			input.CommandCapabilityProjection,
 		),
 		ExternalRolloutSourcePath: input.ExternalRolloutSourcePath,
-	})
+	}
+	prepared, err := s.RuntimePreparer.Prepare(ctx, prepareInput)
 	if err != nil {
-		if connectorBound {
-			s.ConnectorRuntime.RevokeSession(workspaceID, strings.TrimSpace(input.AgentSessionID))
-		}
 		if gatewayRegistered {
 			s.ModelGateway.Unregister(context.WithoutCancel(ctx), workspaceID, input.AgentSessionID)
 		}
 		return preparedRuntime{}, err
+	}
+	if strings.TrimSpace(prepared.Cwd) == "" {
+		prepared.Cwd = cwd
+	}
+	if s.ConnectorRuntime != nil && s.ConnectorCapabilities != nil {
+		httpMCP, capabilityErr := s.ConnectorCapabilities.ConnectorHTTPMCPSupported(ctx, ConnectorCapabilityInput{
+			WorkspaceID: workspaceID, AgentSessionID: strings.TrimSpace(input.AgentSessionID),
+			AgentTargetID: strings.TrimSpace(input.AgentTargetID), Provider: provider,
+			Cwd: prepared.Cwd, Env: append([]string(nil), prepared.Env...),
+			ProviderTargetRef: clonePayload(input.ProviderTargetRef), PermissionModeID: value(input.PermissionModeID),
+			Settings: ComposerSettings{
+				Model: value(input.Model), ReasoningEffort: value(input.ReasoningEffort),
+				PlanMode: valueBool(input.PlanMode), BrowserUse: effectiveCapabilitySetting(input.BrowserUse, effectiveBrowserUse),
+				ComputerUse:    effectiveCapabilitySetting(input.ComputerUse, effectiveComputerUse),
+				CodexSaverMode: valueBool(input.CodexSaverMode), ConversationDetailMode: input.ConversationDetailMode,
+			},
+		})
+		if capabilityErr != nil {
+			slog.WarnContext(ctx, "Connector capability probe failed; continuing without Connector",
+				"event", "agent.connector.capability_probe_failed", "provider", provider,
+				"agent_session_id", input.AgentSessionID, "error", capabilityErr)
+		} else if httpMCP {
+			contextBinding, bindingErr := s.ConnectorRuntime.BindSession(workspaceID, strings.TrimSpace(input.AgentSessionID))
+			if bindingErr != nil {
+				slog.WarnContext(ctx, "Connector session binding failed; continuing without Connector",
+					"event", "agent.connector.binding_failed", "provider", provider,
+					"agent_session_id", input.AgentSessionID, "error", bindingErr)
+			} else {
+				contextBinding = cloneConnectorAgentContext(contextBinding)
+				prepareInput.Connector = &contextBinding
+				enhanced, enhanceErr := s.RuntimePreparer.Prepare(ctx, prepareInput)
+				if enhanceErr != nil {
+					s.ConnectorRuntime.RevokeSession(workspaceID, strings.TrimSpace(input.AgentSessionID))
+					slog.WarnContext(ctx, "Connector runtime enhancement failed; continuing without Connector",
+						"event", "agent.connector.runtime_enhancement_failed", "provider", provider,
+						"agent_session_id", input.AgentSessionID, "error", enhanceErr)
+					if restored, restoreErr := s.RuntimePreparer.Prepare(ctx, prepareInputWithoutConnector(prepareInput)); restoreErr == nil {
+						prepared = restored
+					} else {
+						slog.WarnContext(ctx, "restore ordinary Agent runtime after Connector enhancement failure",
+							"event", "agent.connector.runtime_restore_failed", "provider", provider,
+							"agent_session_id", input.AgentSessionID, "error", restoreErr)
+					}
+				} else {
+					prepared = enhanced
+				}
+			}
+		}
 	}
 	if strings.TrimSpace(prepared.Cwd) == "" {
 		prepared.Cwd = cwd
@@ -670,6 +702,13 @@ func (s *Service) prepareRuntimeWithModelEndpoint(
 		BrowserUse:  effectiveCapabilitySetting(input.BrowserUse, effectiveBrowserUse),
 		ComputerUse: effectiveCapabilitySetting(input.ComputerUse, effectiveComputerUse),
 	}, nil
+}
+
+func prepareInputWithoutConnector(input runtimeprep.PrepareInput) runtimeprep.PrepareInput {
+	input.Connector = nil
+	input.ConnectorRoutingHints = nil
+	input.MCPServers = nil
+	return input
 }
 
 func cloneRuntimeMCPServerBindings(input []runtimeprep.MCPServerBinding) []runtimeprep.MCPServerBinding {

--- a/services/tuttid/service/agent/service_create_runtime_test.go
+++ b/services/tuttid/service/agent/service_create_runtime_test.go
@@ -18,6 +18,8 @@ type testConnectorRuntime struct {
 	hints      []runtimeprep.ConnectorRoutingHint
 	context    runtimeprep.ConnectorAgentContext
 	bind       func(string, string)
+	bindErr    error
+	bindCalls  int
 	revoked    []string
 	revokeAlls int
 }
@@ -27,6 +29,7 @@ func (runtime *testConnectorRuntime) RoutingHints() []runtimeprep.ConnectorRouti
 }
 
 func (runtime *testConnectorRuntime) BindSession(workspaceID, sessionID string) (runtimeprep.ConnectorAgentContext, error) {
+	runtime.bindCalls++
 	if runtime.bind != nil {
 		runtime.bind(workspaceID, sessionID)
 	}
@@ -34,7 +37,21 @@ func (runtime *testConnectorRuntime) BindSession(workspaceID, sessionID string) 
 	if len(context.RoutingHints) == 0 {
 		context.RoutingHints = runtime.hints
 	}
-	return context, nil
+	return context, runtime.bindErr
+}
+
+type testConnectorCapabilityResolver struct {
+	supported bool
+	err       error
+	calls     int
+}
+
+func (resolver *testConnectorCapabilityResolver) ConnectorHTTPMCPSupported(
+	_ context.Context,
+	_ ConnectorCapabilityInput,
+) (bool, error) {
+	resolver.calls++
+	return resolver.supported, resolver.err
 }
 
 func (runtime *testConnectorRuntime) RevokeSession(workspaceID, sessionID string) {
@@ -71,6 +88,7 @@ func TestServiceCreateUsesRuntimePreparerResult(t *testing.T) {
 			}
 		},
 	}
+	service.ConnectorCapabilities = &testConnectorCapabilityResolver{supported: true}
 	cwd := "/user/workdir"
 
 	session, err := service.Create(context.Background(), "ws-1", CreateSessionInput{
@@ -120,21 +138,98 @@ func TestServiceCreateUsesRuntimePreparerResult(t *testing.T) {
 func TestPrepareRuntimeRevokesConnectorBindingWhenProviderPreparationFails(t *testing.T) {
 	service := newTestService(newFakeRuntime())
 	prepareErr := errors.New("prepare failed")
-	service.RuntimePreparer = fakeRuntimePreparer{err: prepareErr}
+	preparer := &sequenceRuntimePreparer{results: []runtimeprep.PreparedRuntime{{Cwd: t.TempDir()}}, errors: []error{nil, prepareErr, nil}}
+	service.RuntimePreparer = preparer
 	connector := &testConnectorRuntime{context: runtimeprep.ConnectorAgentContext{MCPServers: []runtimeprep.MCPServerBinding{{
 		Name: "connector", Type: "http", URL: "http://127.0.0.1:1234/mcp/connector",
 	}}}}
 	service.ConnectorRuntime = connector
+	service.ConnectorCapabilities = &testConnectorCapabilityResolver{supported: true}
 
 	_, err := service.prepareRuntimeWithModelEndpoint(t.Context(), "ws-1", t.TempDir(), CreateSessionInput{
 		AgentSessionID: "11111111-1111-4111-8111-111111111111",
 		Provider:       "codex",
 	}, nil)
-	if !errors.Is(err, prepareErr) {
-		t.Fatalf("prepareRuntimeWithModelEndpoint() error = %v, want %v", err, prepareErr)
+	if err != nil {
+		t.Fatalf("prepareRuntimeWithModelEndpoint() error = %v, want ordinary runtime fallback", err)
 	}
 	if !slices.Equal(connector.revoked, []string{"ws-1/11111111-1111-4111-8111-111111111111"}) {
 		t.Fatalf("revoked bindings = %#v", connector.revoked)
+	}
+}
+
+type sequenceRuntimePreparer struct {
+	results []runtimeprep.PreparedRuntime
+	errors  []error
+	inputs  []runtimeprep.PrepareInput
+}
+
+func (preparer *sequenceRuntimePreparer) Prepare(_ context.Context, input runtimeprep.PrepareInput) (runtimeprep.PreparedRuntime, error) {
+	preparer.inputs = append(preparer.inputs, input)
+	index := len(preparer.inputs) - 1
+	var result runtimeprep.PreparedRuntime
+	if index < len(preparer.results) {
+		result = preparer.results[index]
+	}
+	if index < len(preparer.errors) {
+		return result, preparer.errors[index]
+	}
+	return result, nil
+}
+
+func (*sequenceRuntimePreparer) Cleanup(context.Context, runtimeprep.CleanupInput) error { return nil }
+
+func TestPrepareRuntimeSkipsConnectorWhenAgentDoesNotDeclareHTTPMCP(t *testing.T) {
+	service := newTestService(newFakeRuntime())
+	var prepareInput runtimeprep.PrepareInput
+	service.RuntimePreparer = fakeRuntimePreparer{result: runtimeprep.PreparedRuntime{Cwd: t.TempDir()}, input: &prepareInput}
+	connector := &testConnectorRuntime{}
+	service.ConnectorRuntime = connector
+	service.ConnectorCapabilities = &testConnectorCapabilityResolver{supported: false}
+
+	prepared, err := service.prepareRuntimeWithModelEndpoint(t.Context(), "ws-1", t.TempDir(), CreateSessionInput{
+		AgentSessionID: "11111111-1111-4111-8111-111111111111", Provider: "acp:future-agent",
+	}, nil)
+	if err != nil {
+		t.Fatalf("prepareRuntimeWithModelEndpoint() error = %v", err)
+	}
+	if connector.bindCalls != 0 || prepareInput.Connector != nil || len(prepared.MCPServers) != 0 {
+		t.Fatalf("unsupported Agent received Connector: binds=%d input=%#v MCP=%#v", connector.bindCalls, prepareInput.Connector, prepared.MCPServers)
+	}
+}
+
+func TestPrepareRuntimeContinuesWithoutConnectorWhenProbeFails(t *testing.T) {
+	service := newTestService(newFakeRuntime())
+	service.RuntimePreparer = fakeRuntimePreparer{result: runtimeprep.PreparedRuntime{Cwd: t.TempDir()}}
+	connector := &testConnectorRuntime{}
+	service.ConnectorRuntime = connector
+	service.ConnectorCapabilities = &testConnectorCapabilityResolver{err: errors.New("probe failed")}
+
+	if _, err := service.prepareRuntimeWithModelEndpoint(t.Context(), "ws-1", t.TempDir(), CreateSessionInput{
+		AgentSessionID: "11111111-1111-4111-8111-111111111111", Provider: "acp:future-agent",
+	}, nil); err != nil {
+		t.Fatalf("prepareRuntimeWithModelEndpoint() error = %v", err)
+	}
+	if connector.bindCalls != 0 {
+		t.Fatalf("Connector BindSession calls = %d, want 0", connector.bindCalls)
+	}
+}
+
+func TestPrepareRuntimeContinuesWithoutConnectorWhenBindingFails(t *testing.T) {
+	service := newTestService(newFakeRuntime())
+	service.RuntimePreparer = fakeRuntimePreparer{result: runtimeprep.PreparedRuntime{Cwd: t.TempDir()}}
+	connector := &testConnectorRuntime{bindErr: errors.New("binding failed")}
+	service.ConnectorRuntime = connector
+	service.ConnectorCapabilities = &testConnectorCapabilityResolver{supported: true}
+
+	prepared, err := service.prepareRuntimeWithModelEndpoint(t.Context(), "ws-1", t.TempDir(), CreateSessionInput{
+		AgentSessionID: "11111111-1111-4111-8111-111111111111", Provider: "acp:future-agent",
+	}, nil)
+	if err != nil {
+		t.Fatalf("prepareRuntimeWithModelEndpoint() error = %v", err)
+	}
+	if connector.bindCalls != 1 || len(prepared.MCPServers) != 0 {
+		t.Fatalf("binding fallback = calls %d MCP %#v", connector.bindCalls, prepared.MCPServers)
 	}
 }
 

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -80,6 +80,7 @@ type Service struct {
 	ProviderAvailabilityCacheTTL   time.Duration
 	CapabilityCatalogCacheTTL      time.Duration
 	LiveModelCacheTTL              time.Duration
+	liveModelDiscoveryWaitTimeout  time.Duration
 	GeneratedFilesClock            func() time.Time
 	LiveModelDiscoveryDeleteDelay  time.Duration
 	skillOptionsCache              *composerSkillOptionsCache

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -68,6 +68,7 @@ type Service struct {
 	PromptAttachmentStore          PromptAttachmentStore
 	RuntimePreparer                runtimeprep.Preparer
 	ConnectorRuntime               ConnectorRuntime
+	ConnectorCapabilities          ConnectorCapabilityResolver
 	ModelGateway                   ModelGatewayRegistry
 	BrowserUseAvailable            func() bool
 	ComputerUseAvailable           func() bool
@@ -119,6 +120,22 @@ type ConnectorRuntime interface {
 	BindSession(string, string) (runtimeprep.ConnectorAgentContext, error)
 	RevokeSession(string, string)
 	RevokeAll()
+}
+
+type ConnectorCapabilityInput struct {
+	WorkspaceID       string
+	AgentSessionID    string
+	AgentTargetID     string
+	Provider          string
+	Cwd               string
+	Env               []string
+	ProviderTargetRef map[string]any
+	PermissionModeID  string
+	Settings          ComposerSettings
+}
+
+type ConnectorCapabilityResolver interface {
+	ConnectorHTTPMCPSupported(context.Context, ConnectorCapabilityInput) (bool, error)
 }
 
 type TuttiModeSourceActivity struct {

--- a/services/tuttid/service/agent/skill_bundle.go
+++ b/services/tuttid/service/agent/skill_bundle.go
@@ -37,15 +37,30 @@ func (s *Service) GetSkillBundle(ctx context.Context, workspaceID string, input 
 		return SkillBundle{}, err
 	}
 	provider := launch.Provider
+	var connector *runtimeprep.ConnectorAgentContext
+	if sessionID := strings.TrimSpace(input.AgentSessionID); sessionID != "" {
+		if session, ok := s.controller().Session(workspaceID, sessionID); ok && sessionHasConnectorBinding(session) {
+			connector = &runtimeprep.ConnectorAgentContext{RoutingHints: s.activeConnectorRoutingHints()}
+		}
+	}
 	return renderer.RenderSkillBundle(ctx, runtimeprep.PrepareInput{
-		WorkspaceID:           workspaceID,
-		AgentSessionID:        strings.TrimSpace(input.AgentSessionID),
-		AgentTargetID:         agentTargetID,
-		Provider:              provider,
-		BrowserUse:            input.BrowserUse,
-		ComputerUse:           input.ComputerUse,
-		ConnectorRoutingHints: s.activeConnectorRoutingHints(),
+		WorkspaceID:    workspaceID,
+		AgentSessionID: strings.TrimSpace(input.AgentSessionID),
+		AgentTargetID:  agentTargetID,
+		Provider:       provider,
+		BrowserUse:     input.BrowserUse,
+		ComputerUse:    input.ComputerUse,
+		Connector:      connector,
 	})
+}
+
+func sessionHasConnectorBinding(session ProviderRuntimeSession) bool {
+	for _, binding := range session.MCPServers {
+		if strings.TrimSpace(binding.Name) == "connector" && strings.TrimSpace(binding.Type) == "http" {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Service) activeConnectorRoutingHints() []runtimeprep.ConnectorRoutingHint {

--- a/services/tuttid/wiring_daemon_api.go
+++ b/services/tuttid/wiring_daemon_api.go
@@ -361,6 +361,7 @@ func buildDaemonAPI(
 		Runtime: agentservice.ServiceRuntimeConfig{
 			Preparer:                 agentRuntimePreparation,
 			Connector:                connectorRuntime,
+			ConnectorCapabilities:    agentRuntimeController,
 			ModelGateway:             modelGateway,
 			BrowserUseAvailable:      browserUseAvailable,
 			ComputerUseAvailable:     computerUseAvailable,


### PR DESCRIPTION
﻿## 背景

Tutti 在创建 Agent 会话时会准备 Connector MCP、路由提示和技能。此前该流程把 HTTP MCP 能力视为启动前置条件：当标准 ACP Agent（例如 Hermes）没有在 `initialize` 中显式声明 `agentCapabilities.mcpCapabilities.http=true` 时，会返回 `ErrMCPHTTPUnsupported` 并终止整个 Agent 启动，导致普通聊天也显示 `Agent failed to start`。

## 修改

- 增加统一的 Connector 能力探测，仅在 Agent 明确声明支持 HTTP MCP 时启用 Connector
- 对未声明、不支持、探测失败、绑定失败或准备失败的 Agent 整体降级：不生成 Connector Session Binding，不注入 Connector MCP、routing hints、相关 skill 或 Connector 提示，普通会话继续启动
- Codex App Server 与 Claude SDK 适配器显式声明 HTTP MCP 支持，保持现有 Connector 能力
- 标准 ACP 正式启动阶段增加兼容兜底，避免能力声明变化再次阻断普通会话
- 补充标准 ACP 与会话创建测试，并更新 Connector 架构及规格文档
- 还原项目级 AGENTS.md 中误加入的个人 PR 规则

## 影响

- Hermes 等未声明 HTTP MCP 的 Agent 可以正常启动和回复，但不会获得 Connector 增强
- 已显式支持 HTTP MCP 的 Agent 继续注入 Connector 能力
- 后续接入且未声明该能力的 Agent 默认安全降级，不会因 Connector 影响普通会话

## 验证

- 相关 Go 定向测试通过
- `git diff --check origin/main...HEAD` 通过
- Windows 开发环境实测 Hermes `initialize` 未返回 HTTP MCP 声明时，`session/new`、`session/prompt` 和完整回复均成功，最终 turn 状态为 `completed`
- `pnpm check:changed` 中可在当前 Windows 环境运行的检查通过；依赖 WSL 的 Bash 检查因本机 WSL 不可用未完成，交由 CI 继续验证
