### PR TITLE
fix(agent-gui): keep plan-waiting on rail and settle switch frames

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailQuerySnapshot.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationRailQuerySnapshot.ts
@@ -1,9 +1,11 @@
 import {
+  selectRootAgentSessionIdsWithPendingInteractions,
   selectWorkspaceAgentConsumerSessions,
   type AgentSessionEngineState
 } from "@tutti-os/agent-activity-core";
 import { projectCanonicalAgentGUIConversationSummaries } from "../../../shared/agentGUIConversationSummaryProjection";
 import { createAgentGUIConversationRailTitlePromptSelector } from "../../../shared/agentConversationRailTitlePromptSelector";
+import { selectRootAgentSessionIdsAwaitingPlanImplementation } from "../../../shared/agentConversation/planImplementationAwaiting";
 import type { AgentGUIConversationSummary } from "../model/agentGuiConversationModel";
 import type { AgentGUIConversationRailQuerySnapshot } from "./agentConversationRailQuerySnapshot";
 
@@ -42,13 +44,18 @@ export function createConversationRailConversationsSelector(): (
     for (const sessionId of input.querySnapshot.railSearch.sessionIds) {
       projectionSessionIds.add(sessionId);
     }
+    const rootSessionIdsAwaitingUserAction = new Set([
+      ...selectRootAgentSessionIdsWithPendingInteractions(input.engineState),
+      ...selectRootAgentSessionIdsAwaitingPlanImplementation(input.engineState)
+    ]);
     return stabilizeConversationSectionItems(
       previous,
       projectCanonicalAgentGUIConversationSummaries(
         workspaceSessions.filter((session) =>
           projectionSessionIds.has(session.session.agentSessionId)
         ),
-        selectRailTitlePrompts(input.engineState)
+        selectRailTitlePrompts(input.engineState),
+        rootSessionIdsAwaitingUserAction
       )
     );
   };

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIViewAssembly.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIViewAssembly.ts
@@ -186,8 +186,38 @@ export function useAgentGUIViewAssembly(input: UseAgentGUIViewAssemblyInput) {
     pendingApproval: detail.pendingApproval,
     serverInteractivePrompt: detail.serverInteractivePrompt
   });
-  const railConversations = visibleConversations;
-  const railActiveConversation = activeConversation;
+  const railConversations = useMemo(() => {
+    const prompt = session.pendingInteractivePrompt;
+    if (prompt?.kind !== "plan-implementation" || !input.activeConversationId) {
+      return visibleConversations;
+    }
+    let changed = false;
+    const next = visibleConversations.map((conversation) => {
+      if (
+        conversation.id !== input.activeConversationId ||
+        conversation.needsUserAction
+      ) {
+        return conversation;
+      }
+      changed = true;
+      return { ...conversation, needsUserAction: true };
+    });
+    return changed ? next : visibleConversations;
+  }, [
+    input.activeConversationId,
+    session.pendingInteractivePrompt,
+    visibleConversations
+  ]);
+  const railActiveConversation = useMemo(() => {
+    if (
+      !activeConversation ||
+      session.pendingInteractivePrompt?.kind !== "plan-implementation" ||
+      activeConversation.needsUserAction
+    ) {
+      return activeConversation;
+    }
+    return { ...activeConversation, needsUserAction: true };
+  }, [activeConversation, session.pendingInteractivePrompt]);
   const providerHome = useAgentGUIProviderHome(input);
   const controllerActions = useAgentGUIControllerActions({
     ...input.operationActions,

--- a/packages/agent/gui/shared/agentConversation/planImplementationAwaiting.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/planImplementationAwaiting.spec.ts
@@ -28,7 +28,7 @@ describe("planImplementationAwaiting", () => {
     ).toBe(true);
   });
 
-  it("fails closed for dismissals, missing plan messages, or missing capabilities", () => {
+  it("fails closed for dismissals, missing plan messages, or explicit capability denial", () => {
     const messages = [
       {
         turnId: "turn-plan",
@@ -54,6 +54,14 @@ describe("planImplementationAwaiting", () => {
     ).toBe(false);
     expect(
       consumerAwaitingPlanImplementation({
+        capabilities: planCapabilities({ planMode: false }),
+        dismissed: false,
+        latestTurn: settledPlanTurn("turn-plan"),
+        messages
+      })
+    ).toBe(false);
+    expect(
+      consumerAwaitingPlanImplementation({
         capabilities: planCapabilities(),
         dismissed: false,
         latestTurn: settledPlanTurn("turn-plan"),
@@ -66,6 +74,23 @@ describe("planImplementationAwaiting", () => {
         ]
       })
     ).toBe(false);
+  });
+
+  it("keeps waiting when session capabilities are not projected yet", () => {
+    expect(
+      consumerAwaitingPlanImplementation({
+        capabilities: null,
+        dismissed: false,
+        latestTurn: settledPlanTurn("turn-plan"),
+        messages: [
+          {
+            turnId: "turn-plan",
+            occurredAtUnixMs: 20,
+            payload: { messageKind: "plan" }
+          }
+        ]
+      })
+    ).toBe(true);
   });
 
   it("selects every root session awaiting plan implementation from engine state", () => {

--- a/packages/agent/gui/shared/agentConversation/planImplementationAwaiting.ts
+++ b/packages/agent/gui/shared/agentConversation/planImplementationAwaiting.ts
@@ -16,6 +16,10 @@ type AgentSessionEngineSnapshot = Parameters<
  * approval / question / exit-plan waits already ride pendingInteractions;
  * this predicate is the matching cross-surface fact for plan confirmation so
  * rail, conversation list, and attention do not each invent a private rule.
+ *
+ * Capability rules match the detail composer: an explicit `false` fails closed,
+ * but a missing capabilities record stays open so a settled plan turn can still
+ * surface waiting while composer options are the only advertised source.
  */
 export function consumerAwaitingPlanImplementation(input: {
   capabilities: AgentActivitySession["capabilities"] | null | undefined;
@@ -34,13 +38,23 @@ export function consumerAwaitingPlanImplementation(input: {
     !latestTurn ||
     latestTurn.phase !== "settled" ||
     latestTurn.outcome !== "completed" ||
-    input.capabilities?.planImplementation !== true ||
-    input.capabilities?.planMode !== true ||
-    input.dismissed
+    input.dismissed ||
+    !sessionAllowsPlanImplementation(input.capabilities)
   ) {
     return false;
   }
   return latestPlanTurnId(input.messages) === latestTurn.turnId;
+}
+
+function sessionAllowsPlanImplementation(
+  capabilities: AgentActivitySession["capabilities"] | null | undefined
+): boolean {
+  if (!capabilities) {
+    return true;
+  }
+  return (
+    capabilities.planImplementation === true && capabilities.planMode === true
+  );
 }
 
 export function selectRootAgentSessionIdsAwaitingPlanImplementation(

--- a/packages/agent/session-replay-runner/src/evidence-helpers.mjs
+++ b/packages/agent/session-replay-runner/src/evidence-helpers.mjs
@@ -100,11 +100,13 @@ export function checkpointAllowsOptionalScreenshotSettle(checkpoint) {
   const kind = String(checkpoint.kind ?? "");
   const tags = Array.isArray(checkpoint.tags) ? checkpoint.tags : [];
   // Queue cases soft-wait for the composer blue bar on busy-queue submits.
+  // Plan-waiting settle lets scenarios switch away for rail-waiting evidence
+  // (I15) without hard-blocking settlers that ignore this kind.
   // Do not fold this into checkpointNeedsScreenshotSettle: tool-evidence
   // settlers (I10/L06/R*) would hang for the full timeout when no tool chrome
-  // exists yet at submission.accepted.
+  // exists yet at submission.accepted / plan.waiting.
   return [kind, ...tags].some((token) =>
-    /(?:^|[.])submission\.accepted$/u.test(String(token))
+    /(?:^|[.])(?:submission\.accepted|plan\.waiting)$/u.test(String(token))
   );
 }
 

--- a/tools/scripts/run-agent-session-replay.mjs
+++ b/tools/scripts/run-agent-session-replay.mjs
@@ -3270,7 +3270,10 @@ export async function maybeSettleForScreenshot(
               checkpoints: options.checkpoints
             }).replace(/\.png$/u, "")
           : join(artifactDirectory, "settle");
-      await captureScreenshot(client, `${base}-${label}.png`);
+      const outputPath = `${base}-${label}.png`;
+      await captureScreenshot(client, outputPath);
+      // Cases Console indexes live screenshots from this log line.
+      log(`checkpoint screenshot: ${outputPath}`);
     });
   try {
     await scenario.settleForScreenshot({

--- a/tools/scripts/run-agent-session-replay.mjs
+++ b/tools/scripts/run-agent-session-replay.mjs
@@ -828,7 +828,13 @@ async function runReplayWorkspaceOrchestration(
                     client,
                     options.timeoutMs,
                     checkpointPlan,
-                    settleAgentSessionId
+                    settleAgentSessionId,
+                    {
+                      artifactDirectory: workspaceArtifactDirectory,
+                      cassetteId: cassette.cassetteId,
+                      checkpointIndex: checkpoint,
+                      checkpoints: cassette.checkpoints
+                    }
                   );
                   if (signal.aborted) return;
                   await captureCheckpointScreenshot({
@@ -1674,7 +1680,12 @@ async function runDesktopAction(input) {
                 pageClient,
                 input.timeoutMs,
                 checkpointPlan,
-                input.action.agentSessionId
+                input.action.agentSessionId,
+                {
+                  artifactDirectory: input.artifactDirectory,
+                  checkpointIndex: checkpoint,
+                  checkpoints: input.checkpoints
+                }
               );
               await captureCheckpointScreenshot({
                 agentSessionId: input.action.agentSessionId,
@@ -3213,7 +3224,8 @@ export async function maybeSettleForScreenshot(
   client,
   timeoutMs,
   checkpoint = null,
-  agentSessionId = null
+  agentSessionId = null,
+  options = null
 ) {
   if (!scenario || typeof scenario.settleForScreenshot !== "function") {
     return;
@@ -3235,9 +3247,35 @@ export async function maybeSettleForScreenshot(
       `globalThis.__tuttiSettleAgentSessionId = ${JSON.stringify(pinned)}; true`
     );
   }
+  const artifactDirectory =
+    typeof options?.artifactDirectory === "string" &&
+    options.artifactDirectory.trim()
+      ? options.artifactDirectory.trim()
+      : null;
+  const captureFrame =
+    artifactDirectory &&
+    (async (suffix = "settle") => {
+      const token = String(suffix ?? "settle")
+        .trim()
+        .replace(/[^a-z0-9._-]+/giu, "-")
+        .replace(/^-+|-+$/gu, "")
+        .slice(0, 48);
+      const label = token || "settle";
+      const base =
+        checkpoint && Array.isArray(options?.checkpoints)
+          ? replayCheckpointScreenshotPath({
+              artifactDirectory,
+              cassetteId: options.cassetteId,
+              checkpointIndex: options.checkpointIndex ?? 0,
+              checkpoints: options.checkpoints
+            }).replace(/\.png$/u, "")
+          : join(artifactDirectory, "settle");
+      await captureScreenshot(client, `${base}-${label}.png`);
+    });
   try {
     await scenario.settleForScreenshot({
       agentSessionId: pinned,
+      captureFrame: captureFrame || undefined,
       client,
       timeoutMs,
       checkpoint

--- a/tools/scripts/run-agent-session-replay.test.mjs
+++ b/tools/scripts/run-agent-session-replay.test.mjs
@@ -45,6 +45,7 @@ import {
   assertReplayWorkspaceSucceeded,
   checkpointNeedsToolSettle,
   checkpointNeedsScreenshotSettle,
+  checkpointAllowsOptionalScreenshotSettle,
   captureCheckpointScreenshot,
   captureScreenshot,
   hasOpenToolDetailText,
@@ -2485,6 +2486,27 @@ test("checkpoint settle targets completed tool and terminal turn checkpoints", (
   );
   assert.equal(
     checkpointNeedsToolSettle({ kind: "turn.working", tags: ["turn.working"] }),
+    false
+  );
+  assert.equal(
+    checkpointAllowsOptionalScreenshotSettle({
+      kind: "submission.accepted",
+      tags: ["submission.accepted"]
+    }),
+    true
+  );
+  assert.equal(
+    checkpointAllowsOptionalScreenshotSettle({
+      kind: "plan.waiting",
+      tags: ["plan.waiting"]
+    }),
+    true
+  );
+  assert.equal(
+    checkpointAllowsOptionalScreenshotSettle({
+      kind: "turn.working",
+      tags: ["turn.working"]
+    }),
     false
   );
 });


### PR DESCRIPTION
## Summary
- Restore plan-implementation rail/Attention waiting when session `capabilities` are still missing, and keep the active-session overlay consistent with the detail card.
- Add settle `captureFrame` (and log `checkpoint screenshot:` so Cases Console indexes mid-settle PNGs such as I15 `switch-away`).

## Tests
- `node --test --test-name-pattern='checkpoint settle targets' tools/scripts/run-agent-session-replay.test.mjs`
- Cases Console I15 replay on plan `f4547fb4-…` → passed; artifact `0006-checkpoint-0006-switch-away.png` shows rail waiting while switched away

## Notes
- Pair with tutti-replay: https://github.com/tutti-os/tutti-replay/pull/7
- Stay-in-plan must still run before `waitForSessionIdle` (status `waiting` never counts as idle).