### PR TITLE
fix(connector): recover runtime status and update flow

### DIFF
--- a/docs/architecture/connector-remote-mcp.md
+++ b/docs/architecture/connector-remote-mcp.md
@@ -8,8 +8,8 @@ Tutti 侧已经采用独立的 MCP `2026-07-28` 无状态 HTTP Client，不复�
 Streamable HTTP Client。公共 `ImplementationHost` 通过
 `RemoteMCPClientFactory` 请求一个产品实现的远端 Client，不再持有 Gateway Base URL、
 HTTP Client 或账号授权回调。Tuttid 的 Direct Factory 使用默认
-`https://api.tutti.sh/api/desktop`（可通过 `TUTTI_CONNECTOR_MCP_BASE_URL` 覆盖），并把
-实际地址固定派生为 `POST {baseUrl}/mcp/connectors/{connectorId}`；Connector 无法覆盖
+`https://tutti.sh/api/desktop`（可通过 `TUTTI_CONNECTOR_MCP_BASE_URL` 覆盖），并把
+实际地址固定派生为 `POST {baseUrl}/v1/connectors/{connectorId}/mcp`；Connector 无法覆盖
 该地址。VM-backed 产品可以提供指向 typed desktop relay 的 Factory。
 
 Remote Connector 在建立 Route 时仍会解析本地安装发布物，并把其中合法的 `skills/`
@@ -33,7 +33,7 @@ flowchart LR
     R["Connector Release<br/>产品契约"] -->|"bindingRef + contractVersion"| B["tsh-server MCP Binding<br/>基础设施契约"]
     B --> D["已发布的 Binding 快照"]
     D --> G["Connector MCP Gateway"]
-    T["Tutti 远程 MCP Client"] -->|"POST /mcp/connectors/{connectorId}"| G
+    T["Tutti 远程 MCP Client"] -->|"POST /v1/connectors/{connectorId}/mcp"| G
     G --> U["业务 MCP Server"]
     T --> A["Agent 本地 connector MCP"]
 ```
@@ -92,7 +92,7 @@ Connector 发布方必须在激活 Release 前，根据其引用的已发布 Bin
 Tutti 根据当前环境和 Connector 标识生成 endpoint：
 
 ```text
-POST {tshServerBaseUrl}/mcp/connectors/{connectorId}
+POST {tshServerBaseUrl}/v1/connectors/{connectorId}/mcp
 ```
 
 每个请求还必须通过 `Tutti-Connector-Version` 固定当前已安装的 Connector Release。客户端不会接收或发送 Binding Revision、业务 endpoint、Connection ID 或 Provider 凭据。

--- a/packages/connector/host/application_scoped_runtime.go
+++ b/packages/connector/host/application_scoped_runtime.go
@@ -275,7 +275,7 @@ func (application *Application) reconcileInstalledRuntimesForScope(ctx context.C
 			reconcileFailures.add(connector.Key, "validate runtime receipt", err)
 			continue
 		}
-		if err := application.recordDirectRuntimeGeneration(ctx, connector.Key, installedRelease.ReleaseDigest, operationID, generation); err != nil {
+		if err := application.recordDirectRuntimeGeneration(ctx, scope, connector.Key, installedRelease.ReleaseDigest, operationID, generation); err != nil {
 			if remoteAuthorizedOnly {
 				reconcileFailures.add(connector.Key, "record runtime generation", err)
 				continue
@@ -292,6 +292,7 @@ func (application *Application) reconcileInstalledRuntimesForScope(ctx context.C
 // same-boot fence is then rejected as stale even though desktopd is the owner.
 func (application *Application) recordDirectRuntimeGeneration(
 	ctx context.Context,
+	scope OperationScope,
 	connectorKey, releaseDigest, operationID string,
 	generation uint64,
 ) error {
@@ -313,6 +314,23 @@ func (application *Application) recordDirectRuntimeGeneration(
 		}
 		connector.Revision = revision
 		if err := tx.SaveConnector(connector); err != nil {
+			return err
+		}
+		now := application.config.Now().UTC()
+		if err := tx.SaveOperation(Operation{
+			OperationID:     operationID,
+			ClientRequestID: operationID,
+			ConnectorKey:    connector.Key,
+			Kind:            OperationKindReconcileRuntime,
+			Scope:           scope,
+			State:           OperationStateCompleted,
+			Stage:           OperationStageCompleted,
+			Target:          operationTarget(OperationKindReconcileRuntime, connector),
+			HostGeneration:  HostGeneration{BootEpoch: application.config.BootEpoch, Generation: generation},
+			Attempt:         1,
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		}); err != nil {
 			return err
 		}
 		return tx.EnqueueConnectorMarketChanged(ChangedEvent{

--- a/packages/connector/host/application_test.go
+++ b/packages/connector/host/application_test.go
@@ -335,6 +335,16 @@ func TestApplicationReconcilesInstalledRuntimeAtStartup(t *testing.T) {
 		host.lastReconcile.Generation.Generation != 8 || host.lastReconcile.Generation.BootEpoch == "" {
 		t.Fatalf("startup reconcile = %#v, count=%d", host.lastReconcile, host.reconciles)
 	}
+	operationID := "reconcile/" + application.config.BootEpoch + "/" + connector.Key
+	operation, err := repository.Operation(context.Background(), operationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if operation.Kind != OperationKindReconcileRuntime || operation.State != OperationStateCompleted ||
+		operation.Stage != OperationStageCompleted || operation.Scope != (OperationScope{}) ||
+		operation.HostGeneration != host.lastReconcile.Generation {
+		t.Fatalf("startup reconcile operation = %#v", operation)
+	}
 }
 
 func TestApplicationStartupReconcileAcceptsDisabledRuntimeWithoutBlockingEnabledRuntime(t *testing.T) {

--- a/packages/connector/market/src/services/view/connectorMarketViewBuilder.test.ts
+++ b/packages/connector/market/src/services/view/connectorMarketViewBuilder.test.ts
@@ -221,6 +221,17 @@ test("requires an installed connector to update before authorization when the ac
     view.dialog?.kind === "installation" && view.dialog.updating,
     true
   );
+
+  market.pendingInstallationsByConnectorKey[connector.key] = true;
+  const pendingUpdate = buildConnectorMarketView(market, dialogState);
+  assert.equal(pendingUpdate.cardsByKey[connector.key]?.action, "busy");
+  assert.equal(pendingUpdate.cardsByKey[connector.key]?.status, "updating");
+
+  delete market.pendingInstallationsByConnectorKey[connector.key];
+  connector.installation.state = "updating";
+  const updating = buildConnectorMarketView(market, dialogState);
+  assert.equal(updating.cardsByKey[connector.key]?.action, "busy");
+  assert.equal(updating.cardsByKey[connector.key]?.status, "updating");
 });
 
 test("exposes disconnect directly for an authorized connector", () => {

--- a/packages/connector/market/src/services/view/connectorMarketViewBuilder.ts
+++ b/packages/connector/market/src/services/view/connectorMarketViewBuilder.ts
@@ -155,6 +155,9 @@ function buildConnectorCardView(
   const installed = connectorHasInstalledArtifact(connector);
   const currentReleaseInstalled =
     connectorHasCurrentReleaseInstalled(connector);
+  const updating =
+    connector.installation.state === "updating" ||
+    (installed && !currentReleaseInstalled && pendingInstallation);
   const unavailable = connector.compatibility.state !== "supported";
   const connected = connector.authorization.state === "connected";
   const requiresAuthorization = !["connected", "not_required"].includes(
@@ -188,7 +191,9 @@ function buildConnectorCardView(
     status: unavailable
       ? "unavailable"
       : busy
-        ? "installing"
+        ? updating
+          ? "updating"
+          : "installing"
         : !installed
           ? "not_installed"
           : !currentReleaseInstalled

--- a/packages/connector/market/src/services/view/connectorMarketViewTypes.ts
+++ b/packages/connector/market/src/services/view/connectorMarketViewTypes.ts
@@ -39,6 +39,7 @@ export interface ConnectorCardView {
     | "installing"
     | "not_installed"
     | "unavailable"
+    | "updating"
     | "update_available";
 }
 

--- a/packages/connector/market/src/ui/catalog/ConnectorCard.test.ts
+++ b/packages/connector/market/src/ui/catalog/ConnectorCard.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  connectorCardActionStartsInstallation,
+  connectorCardBusyActionLabelKey
+} from "./connectorCardAction.ts";
+
+test("routes connector install and update actions directly to installation", () => {
+  assert.equal(connectorCardActionStartsInstallation("install"), true);
+  assert.equal(connectorCardActionStartsInstallation("update"), true);
+  assert.equal(connectorCardActionStartsInstallation("authorize"), false);
+  assert.equal(connectorCardActionStartsInstallation("manage"), false);
+});
+
+test("labels an active connector update as updating", () => {
+  assert.equal(
+    connectorCardBusyActionLabelKey({
+      authorizationState: "failed",
+      installationState: "installed",
+      operationStage: null,
+      status: "updating"
+    }),
+    "actionUpdating"
+  );
+});

--- a/packages/connector/market/src/ui/catalog/ConnectorCard.tsx
+++ b/packages/connector/market/src/ui/catalog/ConnectorCard.tsx
@@ -16,6 +16,10 @@ import { useSnapshot } from "valtio";
 import type { ConnectorMarketI18nRuntime } from "../../i18n/connectorMarketI18n.ts";
 import type { ConnectorCardView } from "../../services/view/connectorMarketViewTypes.ts";
 import { useConnectorMarketServices } from "../ConnectorMarketServicesContext.tsx";
+import {
+  connectorCardActionStartsInstallation,
+  connectorCardBusyActionLabelKey
+} from "./connectorCardAction.ts";
 import { ConnectorIcon } from "./ConnectorIcon.tsx";
 
 export function ConnectorCard({ connectorKey }: { connectorKey: string }) {
@@ -40,9 +44,15 @@ export function ConnectorCard({ connectorKey }: { connectorKey: string }) {
         .finally(() => setDisconnecting(false));
       return;
     }
-    if (card.action === "install") {
+    if (connectorCardActionStartsInstallation(card.action)) {
       void market.install(connectorKey).catch(() => {
-        onError?.(i18n.t("connectorInstallFailed"));
+        onError?.(
+          i18n.t(
+            card.action === "update"
+              ? "connectorUpdateFailed"
+              : "connectorInstallFailed"
+          )
+        );
       });
       return;
     }
@@ -109,7 +119,7 @@ export function ConnectorCard({ connectorKey }: { connectorKey: string }) {
       <div className="flex items-center justify-between gap-3">
         <div className="flex min-w-0 items-center gap-2 text-[12px] text-[var(--text-secondary)]">
           <StatusDot
-            pulse={card.status === "installing"}
+            pulse={["installing", "updating"].includes(card.status)}
             size="xs"
             tone={status.tone}
           />
@@ -144,7 +154,11 @@ function resolveActionLabel(
   card: Readonly<
     Pick<
       ConnectorCardView,
-      "action" | "authorizationState" | "installationState" | "operationStage"
+      | "action"
+      | "authorizationState"
+      | "installationState"
+      | "operationStage"
+      | "status"
     >
   >,
   t: ConnectorMarketI18nRuntime["t"]
@@ -162,19 +176,7 @@ function resolveActionLabel(
     case "unavailable":
       return t("actionManage");
     case "busy":
-      if (card.installationState === "uninstalling") {
-        return t("actionUninstalling");
-      }
-      if (
-        card.installationState === "installed" &&
-        card.authorizationState === "disconnected" &&
-        ["accepted", "deactivating", "disconnecting"].includes(
-          card.operationStage ?? ""
-        )
-      ) {
-        return t("actionDisconnecting");
-      }
-      return t("actionInstalling");
+      return t(connectorCardBusyActionLabelKey(card));
   }
 }
 
@@ -185,6 +187,7 @@ function resolveStatus(
     | "installing"
     | "not_installed"
     | "unavailable"
+    | "updating"
     | "update_available",
   t: ConnectorMarketI18nRuntime["t"]
 ): {
@@ -198,6 +201,8 @@ function resolveStatus(
       return { label: t("statusAuthorizationRequired"), tone: "amber" };
     case "installing":
       return { label: t("actionInstalling"), tone: "blue" };
+    case "updating":
+      return { label: t("actionUpdating"), tone: "blue" };
     case "unavailable":
       return { label: t("statusUnavailable"), tone: "red" };
     case "not_installed":

--- a/packages/connector/market/src/ui/catalog/connectorCardAction.ts
+++ b/packages/connector/market/src/ui/catalog/connectorCardAction.ts
@@ -1,0 +1,37 @@
+import type { ConnectorCardView } from "../../services/view/connectorMarketViewTypes.ts";
+
+export function connectorCardActionStartsInstallation(
+  action: ConnectorCardView["action"]
+): boolean {
+  return action === "install" || action === "update";
+}
+
+export function connectorCardBusyActionLabelKey(
+  card: Readonly<
+    Pick<
+      ConnectorCardView,
+      "authorizationState" | "installationState" | "operationStage" | "status"
+    >
+  >
+):
+  | "actionDisconnecting"
+  | "actionInstalling"
+  | "actionUninstalling"
+  | "actionUpdating" {
+  if (card.status === "updating") {
+    return "actionUpdating";
+  }
+  if (card.installationState === "uninstalling") {
+    return "actionUninstalling";
+  }
+  if (
+    card.installationState === "installed" &&
+    card.authorizationState === "disconnected" &&
+    ["accepted", "deactivating", "disconnecting"].includes(
+      card.operationStage ?? ""
+    )
+  ) {
+    return "actionDisconnecting";
+  }
+  return "actionInstalling";
+}

--- a/services/tuttid/service/connectormarket/remote_mcp_client_factory.go
+++ b/services/tuttid/service/connectormarket/remote_mcp_client_factory.go
@@ -63,7 +63,7 @@ func (factory *DirectRemoteMCPClientFactory) NewRemoteMCPClient(
 	if connectorKey == "" || accountID == "" {
 		return nil, errors.New("remote MCP route identity is invalid")
 	}
-	endpoint, err := url.JoinPath(factory.base.String(), "mcp", "connectors", connectorKey)
+	endpoint, err := url.JoinPath(factory.base.String(), "v1", "connectors", connectorKey, "mcp")
 	if err != nil {
 		return nil, errors.New("build remote MCP Gateway endpoint")
 	}

--- a/services/tuttid/service/connectormarket/remote_mcp_client_factory_test.go
+++ b/services/tuttid/service/connectormarket/remote_mcp_client_factory_test.go
@@ -15,7 +15,7 @@ import (
 func TestDirectRemoteMCPClientFactoryBuildsFixedGatewayRouteAndAuthorizesAccount(t *testing.T) {
 	var gotAccountID string
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
-		if request.URL.Path != "/api/desktop/mcp/connectors/documents" || request.Header.Get("Cookie") != "session_id=session-1" {
+		if request.URL.Path != "/api/desktop/v1/connectors/documents/mcp" || request.Header.Get("Cookie") != "session_id=session-1" {
 			t.Errorf("request path/cookie = %q / %q", request.URL.Path, request.Header.Get("Cookie"))
 		}
 		var message struct {


### PR DESCRIPTION
## Summary

- run connector updates directly from the card and show an explicit updating state without a second confirmation dialog
- align the Tutti remote MCP client with the server route `/v1/connectors/{connectorId}/mcp`
- persist successful startup runtime reconciliation so a recovered connector supersedes stale failed operation state

## Root causes

- update actions only opened the installation dialog and reused the installing presentation
- the local client still called the retired `/mcp/connectors/{connectorId}` route
- direct startup reconciliation emitted an event with an operation ID but never persisted that successful operation, leaving the renderer on the last historical failure

## Validation

- `pnpm --filter @tutti-os/connector-market test`
- `pnpm --filter @tutti-os/connector-market typecheck`
- `go test ./packages/connector/host/... ./packages/connector/runtime/... ./packages/connector/store-sqlite/... ./packages/connector/daemon/... ./services/tuttid/service/connectormarket/...`
- `pnpm check:changed`
- push-ready checks: 16 lanes passed
- restarted Tutti and verified Lark CLI latest `reconcile_runtime` operation is `completed`