### PR TITLE
feat(device-link): recover transports after network changes

### DIFF
--- a/packages/device-link/README.md
+++ b/packages/device-link/README.md
@@ -113,11 +113,14 @@ self-healing. It starts at generation `1`, publishes only later generations,
 and hashes interface status, addresses, and—where the platform exposes a
 reliable native table—default-route identity. Darwin uses a no-cgo route socket
 as a trigger with 500ms debounce and a 30s safety sample; its default-route
-summary comes from the native routing information base. Linux/Android sample `/proc/net/route` and
-`/proc/net/ipv6_route`; Windows samples IP Helper's `GetIpForwardTable2`.
-Unsupported mobile/other platforms retain the interface/address summary and
-explicitly do not claim default-route coverage. Windows and mobile fallback
-to 2s polling, while Darwin watcher failure also falls back to 2s polling.
+summary comes from the native routing information base. Linux samples
+`/proc/net/route` and `/proc/net/ipv6_route`; Windows samples IP Helper's
+`GetIpForwardTable2`. Android 10 and newer deny ordinary applications access
+to `/proc/net`, so Android retains only the interface/address summary until a
+native `ConnectivityManager` source is provided. Android, iOS, and other
+unsupported platforms explicitly do not claim default-route coverage. Windows
+and mobile fallback to 2s polling, while Darwin watcher failure also falls back
+to 2s polling.
 
 `Monitor.Status()` is a read-only diagnostic snapshot with `stopped`,
 `starting`, `watching`, or `polling` mode plus a sanitized polling reason and

--- a/packages/device-link/README.md
+++ b/packages/device-link/README.md
@@ -108,6 +108,32 @@ sanitized, typed `OwnerEvent` values into product logs or metrics. Retry events
 separate the backoff cap, chosen jitter, server `Retry-After`, and total delay;
 liveness events expose only ping/pong counts and timestamps, never payloads.
 
+`networkchange.Monitor` is the process-level transport signal for reconnect
+self-healing. It starts at generation `1`, publishes only later generations,
+and hashes interface status, addresses, and—where the platform exposes a
+reliable native table—default-route identity. Darwin uses a no-cgo route socket
+as a trigger with 500ms debounce and a 30s safety sample; its default-route
+summary comes from the native routing information base. Linux/Android sample `/proc/net/route` and
+`/proc/net/ipv6_route`; Windows samples IP Helper's `GetIpForwardTable2`.
+Unsupported mobile/other platforms retain the interface/address summary and
+explicitly do not claim default-route coverage. Windows and mobile fallback
+to 2s polling, while Darwin watcher failure also falls back to 2s polling.
+
+`Monitor.Status()` is a read-only diagnostic snapshot with `stopped`,
+`starting`, `watching`, or `polling` mode plus a sanitized polling reason and
+bounded sample-health counters.
+Consumers should derive watcher health from `ModeWatching`; they must not
+invent a separate `watcherHealthy` field. An
+`OwnerHost.AdvanceNetworkGeneration` call cancels only the current attempt or
+retry wait, closes the old Relay transport, and reuses the same owner lifecycle
+for an immediate retry. It does not clear credentials; `SessionEnded` remains
+the product-owned credential policy boundary.
+
+Default-route changes are included only after successful parsing of the
+platform snapshot. A route-table read or parse failure fails that sample and
+does not advance generation, preserving the monitor's fail-closed rule rather
+than silently pretending that default-route coverage is complete.
+
 Relay endpoints, headers, query values, credentials, leases, registrations,
 room or pairing state, application protocols, and token invalidation remain in
 consumer adapters. In particular, a shared transport error is evidence for the

--- a/packages/device-link/go.mod
+++ b/packages/device-link/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/pion/stun/v3 v3.1.4
 	github.com/pion/transport/v4 v4.0.2
 	github.com/quic-go/quic-go v0.59.0
+	golang.org/x/net v0.50.0
 	golang.org/x/sys v0.41.0
 )
 
@@ -28,7 +29,6 @@ require (
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/mobile v0.0.0-20251209145715-2553ed8ce294 // indirect
 	golang.org/x/mod v0.33.0 // indirect
-	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	golang.org/x/tools v0.42.0 // indirect

--- a/packages/device-link/go.sum
+++ b/packages/device-link/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
@@ -25,6 +27,7 @@ github.com/pion/transport/v4 v4.0.2/go.mod h1:06hFI+jCFcok2X2MekVufNZ/uzNZXivGBP
 github.com/pion/turn/v5 v5.0.7 h1:cA4zPYZR/tS1qZqOi5myHSQ+cwPENCvY8T/wMloP8Tg=
 github.com/pion/turn/v5 v5.0.7/go.mod h1:1VwvxElZaOdJU0liJ/WUSm/Tsh+n2OxS5ISSDxgOWxU=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/quic-go/quic-go v0.59.0 h1:OLJkp1Mlm/aS7dpKgTc6cnpynnD2Xg7C1pwL6vy/SAw=
 github.com/quic-go/quic-go v0.59.0/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
@@ -38,6 +41,7 @@ golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVo
 golang.org/x/mobile v0.0.0-20251209145715-2553ed8ce294 h1:Cr6kbEvA6nqvdHynE4CtVKlqpZB9dS1Jva/6IsHA19g=
 golang.org/x/mobile v0.0.0-20251209145715-2553ed8ce294/go.mod h1:RdZ+3sb4CVgpCFnzv+I4haEpwqFfsfzlLHs3L7ok+e0=
 golang.org/x/mod v0.33.0 h1:tHFzIWbBifEmbwtGz65eaWyGiGZatSrT9prnU8DbVL8=
+golang.org/x/mod v0.33.0/go.mod h1:swjeQEj+6r7fODbD2cqrnje9PnziFuw4bmLbBZFrQ5w=
 golang.org/x/net v0.50.0 h1:ucWh9eiCGyDR3vtzso0WMQinm2Dnt8cFMuQa9K33J60=
 golang.org/x/net v0.50.0/go.mod h1:UgoSli3F/pBgdJBHCTc+tp3gmrU4XswgGRgtnwWTfyM=
 golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
@@ -47,6 +51,7 @@ golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/time v0.14.0 h1:MRx4UaLrDotUKUdCIqzPC48t1Y9hANFKIRpNx+Te8PI=
 golang.org/x/time v0.14.0/go.mod h1:eL/Oa2bBBK0TkX57Fyni+NgnyQQN4LitPmob2Hjnqw4=
 golang.org/x/tools v0.42.0 h1:uNgphsn75Tdz5Ji2q36v/nsFSfR/9BRFvqhGBaJGd5k=
+golang.org/x/tools v0.42.0/go.mod h1:Ma6lCIwGZvHK6XtgbswSoWroEkhugApmsXyrUmBhfr0=
 golang.org/x/tools/go/expect v0.1.1-deprecated h1:jpBZDwmgPhXsKZC6WhL20P4b/wmnpsEAGHaNy0n/rJM=
 golang.org/x/tools/go/expect v0.1.1-deprecated/go.mod h1:eihoPOH+FgIqa3FpoTwguz/bVUSGBlGQU67vpBeOrBY=
 golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated h1:1h2MnaIAIXISqTFKdENegdpAgUXz6NrPEsbIeWaBRvM=

--- a/packages/device-link/networkchange/doc.go
+++ b/packages/device-link/networkchange/doc.go
@@ -1,0 +1,7 @@
+// Package networkchange provides a process-local network environment monitor.
+//
+// The monitor publishes only monotonically increasing generations. It keeps
+// the sampled environment private by hashing interface state, addresses, and
+// supported-platform default-route identity; subscribers never receive an
+// address, gateway, route, or other raw network value.
+package networkchange

--- a/packages/device-link/networkchange/monitor_test.go
+++ b/packages/device-link/networkchange/monitor_test.go
@@ -1,0 +1,284 @@
+package networkchange
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestMonitorStartsAtOneAndAdvancesOnlyForDistinctSuccessfulSamples(t *testing.T) {
+	source := newTestSource(Fingerprint{1})
+	monitor, err := NewMonitorWithConfig(source, Config{
+		Debounce:      time.Millisecond,
+		PollInterval:  time.Hour,
+		SafetyRecheck: 100 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	changes, unsubscribe, err := monitor.Subscribe(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unsubscribe()
+	runDone := make(chan error, 1)
+	go func() { runDone <- monitor.Run(ctx) }()
+	source.WaitForSamples(t, 1)
+	if got := monitor.Generation(); got != 1 {
+		t.Fatalf("initial generation = %d, want 1", got)
+	}
+	waitForMode(t, monitor, ObservationWatching)
+	status := monitor.Status()
+	if status.Mode != ObservationWatching || status.PollReason != PollReasonNone || status.Generation != 1 ||
+		!status.SampleHealthy || status.ConsecutiveSampleFailures != 0 || status.LastSampleAt.IsZero() {
+		t.Fatalf("watching status = %#v, want active watcher at generation 1", status)
+	}
+
+	source.Trigger()
+	assertNoChange(t, changes)
+
+	source.SetFingerprint(Fingerprint{2})
+	source.Trigger()
+	change := waitForChange(t, changes)
+	if change.PreviousGeneration != 1 || change.Generation != 2 {
+		t.Fatalf("change = %#v, want 1 -> 2", change)
+	}
+	if got := monitor.Generation(); got != 2 {
+		t.Fatalf("generation after first change = %d, want 2", got)
+	}
+
+	source.SetError(errors.New("sample unavailable"))
+	source.SetFingerprint(Fingerprint{3})
+	source.Trigger()
+	assertNoChange(t, changes)
+	if got := monitor.Generation(); got != 2 {
+		t.Fatalf("generation after failed sample = %d, want 2", got)
+	}
+	status = monitor.Status()
+	if status.SampleHealthy || status.ConsecutiveSampleFailures != 1 {
+		t.Fatalf("failed sample status = %#v, want one consecutive failure", status)
+	}
+
+	source.SetError(nil)
+	source.Trigger()
+	change = waitForChange(t, changes)
+	if change.PreviousGeneration != 2 || change.Generation != 3 {
+		t.Fatalf("change after recovery = %#v, want 2 -> 3", change)
+	}
+	status = monitor.Status()
+	if !status.SampleHealthy || status.ConsecutiveSampleFailures != 0 {
+		t.Fatalf("recovered sample status = %#v, want healthy", status)
+	}
+	cancel()
+	if err := <-runDone; err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if status := monitor.Status(); status.Mode != ObservationStopped {
+		t.Fatalf("stopped status = %#v, want stopped", status)
+	}
+}
+
+func TestMonitorFallsBackToPollingAfterWatcherFailure(t *testing.T) {
+	source := newTestSource(Fingerprint{1})
+	source.watch = make(chan struct{})
+	close(source.watch)
+	monitor, err := NewMonitorWithConfig(source, Config{
+		Debounce:      time.Millisecond,
+		PollInterval:  2 * time.Millisecond,
+		SafetyRecheck: 10 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	changes, unsubscribe, err := monitor.Subscribe(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unsubscribe()
+	runDone := make(chan error, 1)
+	go func() { runDone <- monitor.Run(ctx) }()
+	source.WaitForSamples(t, 1)
+	waitForMode(t, monitor, ObservationPolling)
+	status := monitor.Status()
+	if status.Mode != ObservationPolling || status.PollReason != PollReasonWatcherClosed {
+		t.Fatalf("fallback status = %#v, want closed-watcher polling", status)
+	}
+	source.SetFingerprint(Fingerprint{2})
+	change := waitForChange(t, changes)
+	if change.Generation != 2 {
+		t.Fatalf("polling change generation = %d, want 2", change.Generation)
+	}
+	cancel()
+	if err := <-runDone; err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if status := monitor.Status(); status.Mode != ObservationStopped {
+		t.Fatalf("stopped fallback status = %#v, want stopped", status)
+	}
+}
+
+func TestMonitorCoalescesSlowSubscriberToNewestGeneration(t *testing.T) {
+	source := newTestSource(Fingerprint{1})
+	monitor, err := NewMonitorWithConfig(source, Config{
+		Debounce:      time.Millisecond,
+		PollInterval:  time.Hour,
+		SafetyRecheck: time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	changes, unsubscribe, err := monitor.Subscribe(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unsubscribe()
+	runDone := make(chan error, 1)
+	go func() { runDone <- monitor.Run(ctx) }()
+	source.WaitForSamples(t, 1)
+	for value := byte(2); value < 12; value++ {
+		source.SetFingerprint(Fingerprint{value})
+		source.Trigger()
+		// Each trigger is debounced and sampled synchronously by the monitor;
+		// waiting for the generation makes this test independent of scheduler
+		// ordering while intentionally leaving the subscription unread.
+		waitForGeneration(t, monitor, uint64(value))
+	}
+	change := waitForChange(t, changes)
+	if change.Generation < 2 || change.Generation > 11 {
+		t.Fatalf("first queued generation = %d, want a retained generation", change.Generation)
+	}
+	for {
+		select {
+		case change = <-changes:
+		default:
+			if change.Generation != 11 {
+				t.Fatalf("newest queued generation = %d, want 11", change.Generation)
+			}
+			cancel()
+			if err := <-runDone; err != nil {
+				t.Fatalf("Run() error = %v", err)
+			}
+			return
+		}
+	}
+}
+
+type testSource struct {
+	mu          sync.Mutex
+	fingerprint Fingerprint
+	err         error
+	watch       chan struct{}
+	samples     int
+	sampleSeen  chan struct{}
+}
+
+func newTestSource(fingerprint Fingerprint) *testSource {
+	return &testSource{
+		fingerprint: fingerprint,
+		watch:       make(chan struct{}, 32),
+		sampleSeen:  make(chan struct{}, 32),
+	}
+}
+
+func (s *testSource) Sample(context.Context) (Fingerprint, error) {
+	s.mu.Lock()
+	s.samples++
+	fingerprint, err := s.fingerprint, s.err
+	s.mu.Unlock()
+	select {
+	case s.sampleSeen <- struct{}{}:
+	default:
+	}
+	return fingerprint, err
+}
+
+func (s *testSource) Watch(context.Context) (<-chan struct{}, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.watch, nil
+}
+
+func (s *testSource) SetFingerprint(fingerprint Fingerprint) {
+	s.mu.Lock()
+	s.fingerprint = fingerprint
+	s.mu.Unlock()
+}
+
+func (s *testSource) SetError(err error) {
+	s.mu.Lock()
+	s.err = err
+	s.mu.Unlock()
+}
+
+func (s *testSource) Trigger() {
+	s.mu.Lock()
+	watch := s.watch
+	s.mu.Unlock()
+	select {
+	case watch <- struct{}{}:
+	default:
+	}
+}
+
+func (s *testSource) WaitForSamples(t *testing.T, count int) {
+	t.Helper()
+	for i := 0; i < count; i++ {
+		select {
+		case <-s.sampleSeen:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for network sample")
+		}
+	}
+}
+
+func waitForChange(t *testing.T, changes <-chan Change) Change {
+	t.Helper()
+	select {
+	case change := <-changes:
+		return change
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for network change")
+		return Change{}
+	}
+}
+
+func waitForGeneration(t *testing.T, monitor *Monitor, generation uint64) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if monitor.Generation() == generation {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("generation = %d, want %d", monitor.Generation(), generation)
+}
+
+func waitForMode(t *testing.T, monitor *Monitor, mode ObservationMode) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if monitor.Status().Mode == mode {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("monitor mode = %q, want %q", monitor.Status().Mode, mode)
+}
+
+func assertNoChange(t *testing.T, changes <-chan Change) {
+	t.Helper()
+	select {
+	case change := <-changes:
+		t.Fatalf("unexpected network change: %#v", change)
+	case <-time.After(15 * time.Millisecond):
+	}
+}

--- a/packages/device-link/networkchange/route_android.go
+++ b/packages/device-link/networkchange/route_android.go
@@ -1,0 +1,15 @@
+//go:build android
+
+package networkchange
+
+import "context"
+
+// Android 10 and newer deny ordinary applications access to /proc/net. Route
+// changes are therefore represented by the interface/address fingerprint
+// until an Android-owned ConnectivityManager source is provided.
+func sampleDefaultRoutes(ctx context.Context) (defaultRouteSample, error) {
+	if err := contextErr(ctx); err != nil {
+		return defaultRouteSample{}, err
+	}
+	return defaultRouteSample{}, nil
+}

--- a/packages/device-link/networkchange/route_darwin.go
+++ b/packages/device-link/networkchange/route_darwin.go
@@ -1,0 +1,82 @@
+//go:build darwin && !ios
+
+package networkchange
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"sort"
+	"strconv"
+
+	"golang.org/x/net/route"
+	"golang.org/x/sys/unix"
+)
+
+func sampleDefaultRoutes(ctx context.Context) (defaultRouteSample, error) {
+	if err := contextErr(ctx); err != nil {
+		return defaultRouteSample{}, err
+	}
+	raw, err := route.FetchRIB(unix.AF_UNSPEC, route.RIBTypeRoute, 0)
+	if err != nil {
+		return defaultRouteSample{}, errors.New("default route sample failed")
+	}
+	messages, err := route.ParseRIB(route.RIBTypeRoute, raw)
+	if err != nil {
+		return defaultRouteSample{}, errors.New("default route sample failed")
+	}
+	entries := darwinDefaultRouteEntries(messages)
+	sort.Strings(entries)
+	return defaultRouteSample{entries: entries, supported: true}, nil
+}
+
+func darwinDefaultRouteEntries(messages []route.Message) []string {
+	entries := make([]string, 0, 2)
+	for _, message := range messages {
+		routeMessage, ok := message.(*route.RouteMessage)
+		if !ok || routeMessage.Flags&unix.RTF_UP == 0 || len(routeMessage.Addrs) < 2 {
+			continue
+		}
+		family, destination, ok := darwinRouteAddress(routeMessage.Addrs[0])
+		if !ok || !isZeroBytes(destination) {
+			continue
+		}
+		if len(routeMessage.Addrs) > 2 && routeMessage.Addrs[2] != nil {
+			maskFamily, mask, maskOK := darwinRouteAddress(routeMessage.Addrs[2])
+			if !maskOK || maskFamily != family || !isZeroBytes(mask) {
+				continue
+			}
+		}
+		gatewayFamily, gateway, gatewayOK := darwinRouteAddress(routeMessage.Addrs[1])
+		if !gatewayOK {
+			continue
+		}
+		entries = append(entries, "default-route:"+family+"|"+
+			strconv.Itoa(routeMessage.Index)+"|"+gatewayFamily+"|"+
+			hex.EncodeToString(gateway)+"|"+strconv.Itoa(routeMessage.Flags))
+	}
+	return entries
+}
+
+func darwinRouteAddress(address route.Addr) (string, []byte, bool) {
+	switch value := address.(type) {
+	case *route.Inet4Addr:
+		if value == nil {
+			return "", nil, false
+		}
+		return "ipv4", value.IP[:], true
+	case *route.Inet6Addr:
+		if value == nil {
+			return "", nil, false
+		}
+		return "ipv6", value.IP[:], true
+	case *route.LinkAddr:
+		if value == nil {
+			return "", nil, false
+		}
+		encoded := append([]byte(strconv.Itoa(value.Index)+"\x00"+value.Name+"\x00"), value.Addr...)
+		return "link", encoded, true
+	default:
+		return "", nil, false
+	}
+}

--- a/packages/device-link/networkchange/route_darwin_test.go
+++ b/packages/device-link/networkchange/route_darwin_test.go
@@ -1,0 +1,59 @@
+//go:build darwin && !ios
+
+package networkchange
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/route"
+	"golang.org/x/sys/unix"
+)
+
+func TestDarwinDefaultRouteSampleReadsNativeRIB(t *testing.T) {
+	sample, err := sampleDefaultRoutes(context.Background())
+	if err != nil {
+		t.Fatalf("sampleDefaultRoutes() error = %v", err)
+	}
+	if !sample.supported {
+		t.Fatal("Darwin default route sample reported unsupported")
+	}
+}
+
+func TestDarwinDefaultRouteEntriesIncludeOnlyUsableDefaults(t *testing.T) {
+	messages := []route.Message{
+		&route.RouteMessage{
+			Flags: unix.RTF_UP, Index: 4,
+			Addrs: []route.Addr{
+				&route.Inet4Addr{},
+				&route.Inet4Addr{IP: [4]byte{192, 0, 2, 1}},
+				&route.Inet4Addr{},
+			},
+		},
+		&route.RouteMessage{
+			Flags: unix.RTF_UP, Index: 5,
+			Addrs: []route.Addr{
+				&route.Inet4Addr{IP: [4]byte{10, 0, 0, 0}},
+				&route.Inet4Addr{IP: [4]byte{192, 0, 2, 2}},
+				&route.Inet4Addr{IP: [4]byte{255, 0, 0, 0}},
+			},
+		},
+		&route.RouteMessage{
+			Flags: 0, Index: 6,
+			Addrs: []route.Addr{
+				&route.Inet6Addr{},
+				&route.Inet6Addr{IP: [16]byte{15: 1}},
+				&route.Inet6Addr{},
+			},
+		},
+	}
+
+	entries := darwinDefaultRouteEntries(messages)
+	if len(entries) != 1 || !strings.HasPrefix(entries[0], "default-route:ipv4|4|ipv4|") {
+		t.Fatalf("Darwin default routes = %q, want one interface 4 route", entries)
+	}
+	if strings.Contains(entries[0], "192.0.2.1") {
+		t.Fatalf("route entry exposed a raw gateway: %q", entries[0])
+	}
+}

--- a/packages/device-link/networkchange/route_linux.go
+++ b/packages/device-link/networkchange/route_linux.go
@@ -1,0 +1,58 @@
+//go:build linux || android
+
+package networkchange
+
+import (
+	"context"
+	"errors"
+	"os"
+	"sort"
+)
+
+func sampleDefaultRoutes(ctx context.Context) (defaultRouteSample, error) {
+	v4, v4Present, err := readRouteFile(ctx, "/proc/net/route")
+	if err != nil {
+		return defaultRouteSample{}, err
+	}
+	v6, v6Present, err := readRouteFile(ctx, "/proc/net/ipv6_route")
+	if err != nil {
+		return defaultRouteSample{}, err
+	}
+	if !v4Present && !v6Present {
+		return defaultRouteSample{}, nil
+	}
+	entries := make([]string, 0, 2)
+	if v4Present {
+		parsed, err := parseLinuxIPv4Routes(v4)
+		if err != nil {
+			return defaultRouteSample{}, err
+		}
+		entries = append(entries, parsed...)
+	}
+	if v6Present {
+		parsed, err := parseLinuxIPv6Routes(v6)
+		if err != nil {
+			return defaultRouteSample{}, err
+		}
+		entries = append(entries, parsed...)
+	}
+	sort.Strings(entries)
+	return defaultRouteSample{entries: entries, supported: true}, nil
+}
+
+func readRouteFile(ctx context.Context, path string) ([]byte, bool, error) {
+	if err := contextErr(ctx); err != nil {
+		return nil, false, err
+	}
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, errors.New("default route sample failed")
+	}
+	if err := contextErr(ctx); err != nil {
+		return nil, false, err
+	}
+	return data, true, nil
+}

--- a/packages/device-link/networkchange/route_linux.go
+++ b/packages/device-link/networkchange/route_linux.go
@@ -1,4 +1,4 @@
-//go:build linux || android
+//go:build linux && !android
 
 package networkchange
 

--- a/packages/device-link/networkchange/route_linux_parser.go
+++ b/packages/device-link/networkchange/route_linux_parser.go
@@ -1,4 +1,5 @@
-//nolint:unused // Platform-neutral so Linux route fixtures run on every development host.
+//go:build linux && !android
+
 package networkchange
 
 import (

--- a/packages/device-link/networkchange/route_linux_parser.go
+++ b/packages/device-link/networkchange/route_linux_parser.go
@@ -1,0 +1,93 @@
+//nolint:unused // Platform-neutral so Linux route fixtures run on every development host.
+package networkchange
+
+import (
+	"encoding/hex"
+	"errors"
+	"strconv"
+	"strings"
+)
+
+func parseLinuxIPv4Routes(data []byte) ([]string, error) {
+	entries := make([]string, 0, 1)
+	for lineNumber, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 || (lineNumber == 0 && fields[0] == "Iface") {
+			continue
+		}
+		if len(fields) < 8 {
+			return nil, errors.New("default route sample failed")
+		}
+		destination, gateway, flags, metric, mask := fields[1], fields[2], fields[3], fields[6], fields[7]
+		if !isHex(destination, 8) || !isHex(mask, 8) {
+			return nil, errors.New("default route sample failed")
+		}
+		if !isHexZero(destination, 8) || !isHexZero(mask, 8) {
+			continue
+		}
+		if !isHexUint32(flags) || !isHex(gateway, 8) || !isDecimal(metric) {
+			return nil, errors.New("default route sample failed")
+		}
+		if !hasHexFlag(flags, 1) {
+			continue
+		}
+		entries = append(entries, "default-route:ipv4|"+fields[0]+"|"+strings.ToUpper(gateway)+"|"+metric+"|"+strings.ToUpper(flags))
+	}
+	return entries, nil
+}
+
+func parseLinuxIPv6Routes(data []byte) ([]string, error) {
+	entries := make([]string, 0, 1)
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		if len(fields) < 10 {
+			return nil, errors.New("default route sample failed")
+		}
+		destination, prefix, nextHop := fields[0], fields[1], fields[4]
+		if !isHex(destination, 32) || !isHex(prefix, 2) {
+			return nil, errors.New("default route sample failed")
+		}
+		if !isHexZero(destination, 32) || !isHexZero(prefix, 2) {
+			continue
+		}
+		metric, flags := fields[5], fields[8]
+		if !isHex(nextHop, 32) || !isHex(metric, 8) || !isHex(flags, 8) {
+			return nil, errors.New("default route sample failed")
+		}
+		if !hasHexFlag(flags, 1) {
+			continue
+		}
+		entries = append(entries, "default-route:ipv6|"+fields[9]+"|"+strings.ToUpper(nextHop)+"|"+strings.ToUpper(metric)+"|"+strings.ToUpper(flags))
+	}
+	return entries, nil
+}
+
+func isHex(value string, length int) bool {
+	if len(value) != length {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil
+}
+
+func isHexZero(value string, length int) bool {
+	return isHex(value, length) && strings.Trim(value, "0") == ""
+}
+
+func hasHexFlag(value string, flag byte) bool {
+	parsed, err := strconv.ParseUint(value, 16, 32)
+	return err == nil && parsed&uint64(flag) != 0
+}
+
+func isHexUint32(value string) bool {
+	_, err := strconv.ParseUint(value, 16, 32)
+	return err == nil
+}
+
+func isDecimal(value string) bool {
+	_, err := strconv.ParseUint(value, 10, 32)
+	return err == nil
+}

--- a/packages/device-link/networkchange/route_linux_test.go
+++ b/packages/device-link/networkchange/route_linux_test.go
@@ -1,0 +1,34 @@
+package networkchange
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseLinuxDefaultRoutesDoesNotExposeGateway(t *testing.T) {
+	v4 := []byte("Iface Destination Gateway Flags RefCnt Use Metric Mask MTU Window IRTT\n" +
+		"eth0 00000000 0102A8C0 0003 0 0 100 00000000 0 0 0\n")
+	entries, err := parseLinuxIPv4Routes(v4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("IPv4 default routes = %d, want 1", len(entries))
+	}
+	if entries[0] == "" || strings.Contains(entries[0], "192.168.2.1") {
+		t.Fatalf("route entry exposed or omitted the opaque gateway summary: %q", entries[0])
+	}
+}
+
+func TestParseLinuxIPv6DefaultRouteUsesKernelPrefixWidth(t *testing.T) {
+	route := []byte("00000000000000000000000000000000 00 " +
+		"00000000000000000000000000000000 00 " +
+		"fe800000000000000000000000000001 00000064 00000000 00000000 00000003 eth0\n")
+	entries, err := parseLinuxIPv6Routes(route)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || !strings.HasPrefix(entries[0], "default-route:ipv6|eth0|") {
+		t.Fatalf("IPv6 default routes = %q, want one eth0 route", entries)
+	}
+}

--- a/packages/device-link/networkchange/route_linux_test.go
+++ b/packages/device-link/networkchange/route_linux_test.go
@@ -1,3 +1,5 @@
+//go:build linux && !android
+
 package networkchange
 
 import (

--- a/packages/device-link/networkchange/route_other.go
+++ b/packages/device-link/networkchange/route_other.go
@@ -1,0 +1,9 @@
+//go:build (!darwin || ios) && !linux && !android && !windows
+
+package networkchange
+
+import "context"
+
+func sampleDefaultRoutes(context.Context) (defaultRouteSample, error) {
+	return defaultRouteSample{}, nil
+}

--- a/packages/device-link/networkchange/route_windows.go
+++ b/packages/device-link/networkchange/route_windows.go
@@ -1,0 +1,64 @@
+//go:build windows
+
+package networkchange
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func sampleDefaultRoutes(ctx context.Context) (defaultRouteSample, error) {
+	if err := contextErr(ctx); err != nil {
+		return defaultRouteSample{}, err
+	}
+	var table *windows.MibIpForwardTable2
+	if err := windows.GetIpForwardTable2(windows.AF_UNSPEC, &table); err != nil {
+		return defaultRouteSample{}, errors.New("default route sample failed")
+	}
+	if table == nil {
+		return defaultRouteSample{}, errors.New("default route sample failed")
+	}
+	defer windows.FreeMibTable(unsafe.Pointer(table))
+	entries := make([]string, 0, 2)
+	for _, row := range table.Rows() {
+		if err := contextErr(ctx); err != nil {
+			return defaultRouteSample{}, err
+		}
+		if row.DestinationPrefix.PrefixLength != 0 {
+			continue
+		}
+		family, destination, err := windowsRouteAddress(row.DestinationPrefix.Prefix)
+		if err != nil || !isZeroBytes(destination) {
+			continue
+		}
+		_, nextHop, err := windowsRouteAddress(row.NextHop)
+		if err != nil {
+			return defaultRouteSample{}, errors.New("default route sample failed")
+		}
+		entries = append(entries, fmt.Sprintf(
+			"default-route:%s|%d|%s|%d|%d|%d",
+			family, row.InterfaceIndex, hex.EncodeToString(nextHop), row.Metric, row.Protocol, row.Origin,
+		))
+	}
+	sort.Strings(entries)
+	return defaultRouteSample{entries: entries, supported: true}, nil
+}
+
+func windowsRouteAddress(value windows.RawSockaddrInet) (string, []byte, error) {
+	switch value.Family {
+	case windows.AF_INET:
+		address := (*windows.RawSockaddrInet4)(unsafe.Pointer(&value))
+		return "ipv4", append([]byte(nil), address.Addr[:]...), nil
+	case windows.AF_INET6:
+		address := (*windows.RawSockaddrInet6)(unsafe.Pointer(&value))
+		return "ipv6", append([]byte(nil), address.Addr[:]...), nil
+	default:
+		return "", nil, errors.New("unsupported route address family")
+	}
+}

--- a/packages/device-link/networkchange/route_zero_bytes.go
+++ b/packages/device-link/networkchange/route_zero_bytes.go
@@ -1,0 +1,12 @@
+//go:build (darwin && !ios) || windows
+
+package networkchange
+
+func isZeroBytes(value []byte) bool {
+	for _, byteValue := range value {
+		if byteValue != 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/packages/device-link/networkchange/source.go
+++ b/packages/device-link/networkchange/source.go
@@ -92,15 +92,6 @@ func canonicalAddress(address net.Addr) (string, bool) {
 	return ip.String() + "/" + prefixLength, true
 }
 
-func isZeroBytes(value []byte) bool {
-	for _, byteValue := range value {
-		if byteValue != 0 {
-			return false
-		}
-	}
-	return true
-}
-
 func contextErr(ctx context.Context) error {
 	if ctx == nil {
 		return nil

--- a/packages/device-link/networkchange/source.go
+++ b/packages/device-link/networkchange/source.go
@@ -1,0 +1,109 @@
+package networkchange
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"net"
+	"net/netip"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type defaultRouteSample struct {
+	entries   []string
+	supported bool
+}
+
+func sampleLocalNetwork(ctx context.Context) (Fingerprint, error) {
+	if err := contextErr(ctx); err != nil {
+		return Fingerprint{}, err
+	}
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return Fingerprint{}, errors.New("network interface sample failed")
+	}
+	parts := make([]string, 0, len(interfaces)*3)
+	for _, iface := range interfaces {
+		if err := contextErr(ctx); err != nil {
+			return Fingerprint{}, err
+		}
+		// Interface names and addresses are input to the digest only. They
+		// never leave this function or appear in an error/event.
+		parts = append(parts, iface.Name+"\x00"+strconv.Itoa(iface.Index)+"\x00"+strconv.FormatUint(uint64(iface.Flags), 10))
+		addresses, err := iface.Addrs()
+		if err != nil {
+			return Fingerprint{}, errors.New("network address sample failed")
+		}
+		for _, address := range addresses {
+			canonical, ok := canonicalAddress(address)
+			if !ok {
+				return Fingerprint{}, errors.New("network address sample failed")
+			}
+			parts = append(parts, iface.Name+"\x00"+canonical)
+		}
+	}
+	routes, err := sampleDefaultRoutes(ctx)
+	if err != nil {
+		return Fingerprint{}, err
+	}
+	if routes.supported {
+		if len(routes.entries) == 0 {
+			parts = append(parts, "default-route:none")
+		} else {
+			parts = append(parts, routes.entries...)
+		}
+	} else {
+		parts = append(parts, "default-route:unsupported")
+	}
+	sort.Strings(parts)
+	return sha256.Sum256([]byte(strings.Join(parts, "\n"))), nil
+}
+
+func canonicalAddress(address net.Addr) (string, bool) {
+	if address == nil {
+		return "", false
+	}
+	raw := strings.TrimSpace(address.String())
+	if raw == "" {
+		return "", false
+	}
+	slash := strings.LastIndexByte(raw, '/')
+	addressPart := raw
+	prefixLength := ""
+	if slash >= 0 {
+		addressPart = raw[:slash]
+		prefixLength = raw[slash+1:]
+		if _, err := strconv.Atoi(prefixLength); err != nil {
+			return "", false
+		}
+	}
+	if zone := strings.LastIndexByte(addressPart, '%'); zone >= 0 {
+		addressPart = addressPart[:zone]
+	}
+	ip, err := netip.ParseAddr(addressPart)
+	if err != nil {
+		return "", false
+	}
+	if prefixLength == "" {
+		return ip.String(), true
+	}
+	return ip.String() + "/" + prefixLength, true
+}
+
+func isZeroBytes(value []byte) bool {
+	for _, byteValue := range value {
+		if byteValue != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func contextErr(ctx context.Context) error {
+	if ctx == nil {
+		return nil
+	}
+	return ctx.Err()
+}

--- a/packages/device-link/networkchange/source_darwin.go
+++ b/packages/device-link/networkchange/source_darwin.go
@@ -1,0 +1,55 @@
+//go:build darwin && !ios
+
+package networkchange
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+type systemSource struct{}
+
+func (systemSource) Sample(ctx context.Context) (Fingerprint, error) {
+	return sampleLocalNetwork(ctx)
+}
+
+// Watch uses macOS's native routing socket as a trigger. The monitor still
+// samples through net.Interfaces after debounce; route-socket payloads are
+// never parsed, persisted, or exposed.
+func (systemSource) Watch(ctx context.Context) (<-chan struct{}, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	fd, err := unix.Socket(unix.AF_ROUTE, unix.SOCK_RAW, unix.AF_UNSPEC)
+	if err != nil {
+		return nil, ErrWatcherUnavailable
+	}
+	events := make(chan struct{}, 1)
+	var closeOnce sync.Once
+	closeFD := func() { closeOnce.Do(func() { _ = unix.Close(fd) }) }
+	go func() {
+		defer close(events)
+		defer closeFD()
+		buffer := make([]byte, 16*1024)
+		for {
+			count, readErr := unix.Read(fd, buffer)
+			if readErr != nil || count == 0 {
+				return
+			}
+			select {
+			case events <- struct{}{}:
+			default:
+			}
+		}
+	}()
+	go func() {
+		<-ctx.Done()
+		closeFD()
+	}()
+	return events, nil
+}
+
+const defaultSafetyRecheck = 30 * time.Second

--- a/packages/device-link/networkchange/source_other.go
+++ b/packages/device-link/networkchange/source_other.go
@@ -1,0 +1,20 @@
+//go:build !darwin || ios
+
+package networkchange
+
+import (
+	"context"
+	"time"
+)
+
+type systemSource struct{}
+
+func (systemSource) Sample(ctx context.Context) (Fingerprint, error) {
+	return sampleLocalNetwork(ctx)
+}
+
+func (systemSource) Watch(context.Context) (<-chan struct{}, error) {
+	return nil, ErrWatcherUnavailable
+}
+
+const defaultSafetyRecheck time.Duration = 0

--- a/packages/device-link/networkchange/types.go
+++ b/packages/device-link/networkchange/types.go
@@ -1,0 +1,406 @@
+package networkchange
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// ErrWatcherUnavailable tells a Monitor to use polling because the platform
+// source cannot provide a kernel notification stream.
+var ErrWatcherUnavailable = errors.New("network change watcher unavailable")
+
+// Fingerprint is an opaque digest of one sampled local network environment.
+// Its bytes are never sent to subscribers and callers should not interpret
+// them as an address or route representation.
+type Fingerprint [32]byte
+
+// Source samples the local network environment and, when available, provides
+// a channel that is signalled after a kernel-level network event. Watch must
+// return ErrWatcherUnavailable when polling is the only supported mechanism.
+// A watcher channel that closes unexpectedly is treated as a watcher failure
+// and causes the Monitor to fall back to polling.
+type Source interface {
+	Sample(context.Context) (Fingerprint, error)
+	Watch(context.Context) (<-chan struct{}, error)
+}
+
+// Change is the only value delivered to subscribers. Generation is strictly
+// greater than the previous generation for a running Monitor. No network
+// address, gateway, interface name, or fingerprint is included.
+type Change struct {
+	Generation         uint64
+	PreviousGeneration uint64
+}
+
+// ObservationMode is the monitor's read-only source mode. Consumers should
+// use ObservationWatching to report an active kernel watcher and ObservationPolling to
+// report a deliberate fallback; there is intentionally no mutable or
+// caller-supplied watcherHealthy flag.
+type ObservationMode string
+
+const (
+	ObservationStopped  ObservationMode = "stopped"
+	ObservationStarting ObservationMode = "starting"
+	ObservationWatching ObservationMode = "watching"
+	ObservationPolling  ObservationMode = "polling"
+)
+
+// PollReason identifies why a monitor is polling. It contains no platform
+// error text or network material.
+type PollReason string
+
+const (
+	PollReasonNone               PollReason = ""
+	PollReasonWatcherUnavailable PollReason = "watcher_unavailable"
+	PollReasonWatcherClosed      PollReason = "watcher_closed"
+	PollReasonWatcherDisabled    PollReason = "watcher_disabled"
+)
+
+// Status is a read-only diagnostic snapshot. ObservationWatching means the
+// source returned a live watcher; ObservationPolling means samples are being
+// driven by the polling ticker. SampleHealthy and ConsecutiveSampleFailures
+// report bounded health without exposing source errors or network material.
+type Status struct {
+	Mode                      ObservationMode
+	PollReason                PollReason
+	Generation                uint64
+	SampleHealthy             bool
+	ConsecutiveSampleFailures uint64
+	LastSampleAt              time.Time
+}
+
+// Config controls Monitor timing. Zero values select the platform defaults:
+// 500ms debounce, 2s fallback polling, and a 30s Darwin watcher safety
+// recheck. SafetyRecheck is ignored while the source is in polling mode.
+type Config struct {
+	Debounce      time.Duration
+	PollInterval  time.Duration
+	SafetyRecheck time.Duration
+}
+
+// Monitor observes one Source and broadcasts environment changes to all
+// subscribers. A Monitor starts at generation 1. The first successful sample
+// establishes its baseline and does not advance that generation; later
+// distinct successful samples advance it once each.
+type Monitor struct {
+	source Source
+	cfg    Config
+
+	mu             sync.Mutex
+	generation     uint64
+	baseline       Fingerprint
+	hasBaseline    bool
+	running        bool
+	mode           ObservationMode
+	pollReason     PollReason
+	sampleHealthy  bool
+	sampleFailures uint64
+	lastSampleAt   time.Time
+	nextSubscriber uint64
+	subscribers    map[uint64]*subscription
+}
+
+type subscription struct {
+	channel chan Change
+	done    chan struct{}
+}
+
+// NewMonitor creates an idle monitor for source. Call Run to begin sampling.
+// It returns an error for a nil source.
+func NewMonitor(source Source) (*Monitor, error) {
+	return NewMonitorWithConfig(source, Config{})
+}
+
+// NewMonitorWithConfig creates an idle monitor with explicit timing. Values
+// below one millisecond are rejected to prevent busy loops in callers and
+// tests.
+func NewMonitorWithConfig(source Source, cfg Config) (*Monitor, error) {
+	if source == nil {
+		return nil, errors.New("network change source is required")
+	}
+	if cfg.Debounce <= 0 {
+		cfg.Debounce = 500 * time.Millisecond
+	}
+	if cfg.PollInterval <= 0 {
+		cfg.PollInterval = 2 * time.Second
+	}
+	if cfg.SafetyRecheck <= 0 {
+		cfg.SafetyRecheck = defaultSafetyRecheck
+	}
+	if cfg.Debounce < time.Millisecond || cfg.PollInterval < time.Millisecond ||
+		(cfg.SafetyRecheck > 0 && cfg.SafetyRecheck < time.Millisecond) {
+		return nil, errors.New("network change monitor intervals are too short")
+	}
+	return &Monitor{
+		source:      source,
+		cfg:         cfg,
+		generation:  1,
+		mode:        ObservationStopped,
+		subscribers: make(map[uint64]*subscription),
+	}, nil
+}
+
+// NewSystemMonitor creates a monitor backed by the current platform's local
+// network source.
+func NewSystemMonitor() (*Monitor, error) {
+	return NewMonitor(NewSystemSource())
+}
+
+// NewSystemSource returns the process-local platform source. Darwin uses a
+// native route socket as a change trigger; other platforms intentionally
+// return ErrWatcherUnavailable and use polling.
+func NewSystemSource() Source { return systemSource{} }
+
+// Generation returns the latest committed generation. It returns 1 before the
+// first successful sample and after a sample failure.
+func (m *Monitor) Generation() uint64 {
+	if m == nil {
+		return 0
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.generation
+}
+
+// Status returns a read-only diagnostic snapshot of the monitor source mode.
+// It never exposes source errors, interface names, addresses, gateways, or
+// route contents.
+func (m *Monitor) Status() Status {
+	if m == nil {
+		return Status{}
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return Status{
+		Mode:                      m.mode,
+		PollReason:                m.pollReason,
+		Generation:                m.generation,
+		SampleHealthy:             m.sampleHealthy,
+		ConsecutiveSampleFailures: m.sampleFailures,
+		LastSampleAt:              m.lastSampleAt,
+	}
+}
+
+// Subscribe registers a buffered change subscription. The returned cancel
+// function is idempotent. Changes are coalesced when a subscriber is slower
+// than the monitor; the newest generation replaces an older queued change.
+// The subscription is closed when ctx is canceled or Run exits.
+func (m *Monitor) Subscribe(ctx context.Context) (<-chan Change, func(), error) {
+	if m == nil {
+		return nil, func() {}, errors.New("network change monitor is nil")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, func() {}, err
+	}
+	subscriber := &subscription{channel: make(chan Change, 8), done: make(chan struct{})}
+	m.mu.Lock()
+	m.nextSubscriber++
+	id := m.nextSubscriber
+	m.subscribers[id] = subscriber
+	m.mu.Unlock()
+
+	var once sync.Once
+	cancel := func() {
+		once.Do(func() {
+			m.removeSubscriber(id)
+		})
+	}
+	if done := ctx.Done(); done != nil {
+		go func() {
+			select {
+			case <-done:
+				cancel()
+			case <-subscriber.done:
+			}
+		}()
+	}
+	return subscriber.channel, cancel, nil
+}
+
+// Run starts monitoring until ctx is canceled. A Monitor may be run again
+// after it stops; each run establishes no new baseline unless the source has
+// successfully sampled one during the previous run.
+func (m *Monitor) Run(ctx context.Context) error {
+	if m == nil {
+		return errors.New("network change monitor is nil")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	m.mu.Lock()
+	if m.running {
+		m.mu.Unlock()
+		return errors.New("network change monitor is already running")
+	}
+	m.running = true
+	m.mode = ObservationStarting
+	m.pollReason = PollReasonNone
+	m.mu.Unlock()
+	defer m.finishRun()
+
+	_ = m.sample(ctx)
+
+	watch, watchErr := m.source.Watch(ctx)
+	watching := watchErr == nil && watch != nil
+	if watching {
+		if m.cfg.SafetyRecheck <= 0 {
+			watching = false
+			m.setMode(ObservationPolling, PollReasonWatcherDisabled)
+		} else {
+			watch = nonNilWatch(watch)
+			m.setMode(ObservationWatching, PollReasonNone)
+		}
+	} else {
+		m.setMode(ObservationPolling, PollReasonWatcherUnavailable)
+	}
+	interval := m.cfg.PollInterval
+	if watching {
+		interval = m.cfg.SafetyRecheck
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	var debounce *time.Timer
+	var debounceC <-chan time.Time
+	resetDebounce := func() {
+		if debounce == nil {
+			debounce = time.NewTimer(m.cfg.Debounce)
+			debounceC = debounce.C
+			return
+		}
+		if !debounce.Stop() {
+			select {
+			case <-debounce.C:
+			default:
+			}
+		}
+		debounce.Reset(m.cfg.Debounce)
+		debounceC = debounce.C
+	}
+	defer func() {
+		if debounce != nil {
+			debounce.Stop()
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case _, ok := <-watch:
+			if !watching {
+				watch = nil
+				continue
+			}
+			if !ok {
+				watching = false
+				watch = nil
+				m.setMode(ObservationPolling, PollReasonWatcherClosed)
+				interval = m.cfg.PollInterval
+				ticker.Stop()
+				ticker = time.NewTicker(interval)
+				continue
+			}
+			resetDebounce()
+		case <-debounceC:
+			debounceC = nil
+			_ = m.sample(ctx)
+		case <-ticker.C:
+			_ = m.sample(ctx)
+		}
+	}
+}
+
+func (m *Monitor) sample(ctx context.Context) error {
+	fingerprint, err := m.source.Sample(ctx)
+	sampledAt := time.Now().UTC()
+	if err != nil {
+		m.mu.Lock()
+		m.lastSampleAt = sampledAt
+		m.sampleHealthy = false
+		if m.sampleFailures != ^uint64(0) {
+			m.sampleFailures++
+		}
+		m.mu.Unlock()
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.lastSampleAt = sampledAt
+	m.sampleHealthy = true
+	m.sampleFailures = 0
+	if !m.hasBaseline {
+		m.baseline = fingerprint
+		m.hasBaseline = true
+		return nil
+	}
+	if fingerprint == m.baseline {
+		return nil
+	}
+	previous := m.generation
+	if previous == ^uint64(0) {
+		return nil
+	}
+	m.baseline = fingerprint
+	m.generation++
+	change := Change{Generation: m.generation, PreviousGeneration: previous}
+	for _, subscriber := range m.subscribers {
+		select {
+		case subscriber.channel <- change:
+		default:
+			select {
+			case <-subscriber.channel:
+			default:
+			}
+			select {
+			case subscriber.channel <- change:
+			default:
+			}
+		}
+	}
+	return nil
+}
+
+func (m *Monitor) removeSubscriber(id uint64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if subscriber, ok := m.subscribers[id]; ok {
+		delete(m.subscribers, id)
+		close(subscriber.done)
+		close(subscriber.channel)
+	}
+}
+
+func (m *Monitor) setMode(mode ObservationMode, reason PollReason) {
+	m.mu.Lock()
+	m.mode = mode
+	m.pollReason = reason
+	m.mu.Unlock()
+}
+
+func (m *Monitor) finishRun() {
+	m.mu.Lock()
+	m.running = false
+	m.mode = ObservationStopped
+	m.pollReason = PollReasonNone
+	for id, subscriber := range m.subscribers {
+		delete(m.subscribers, id)
+		close(subscriber.done)
+		close(subscriber.channel)
+	}
+	m.mu.Unlock()
+}
+
+func nonNilWatch(watch <-chan struct{}) <-chan struct{} {
+	if watch != nil {
+		return watch
+	}
+	closed := make(chan struct{})
+	close(closed)
+	return closed
+}

--- a/packages/device-link/relaytransport/doc.go
+++ b/packages/device-link/relaytransport/doc.go
@@ -3,11 +3,14 @@
 //
 // It owns WebSocket stream dialing and the reusable owner-tunnel mechanics:
 // reference-counted demand, reconnect backoff, WebSocket liveness, continuous
-// owner readiness, yamux stream acceptance, and close ordering. Products inject
-// authority credentials, lease activation, final release, and stream handlers
-// through narrow interfaces. OwnerLifecycle.Activate returns an
-// OwnerActivation whose Readiness context must remain live for the complete
-// connection generation; it is not merely a one-time readiness barrier.
+// owner readiness, yamux stream acceptance, close ordering, and
+// generation-fenced reconnects. Products inject authority credentials, lease
+// activation, final release, and stream handlers through narrow interfaces.
+// OwnerLifecycle.Activate returns an OwnerActivation whose Readiness context
+// must remain live for the complete connection generation; it is not merely a
+// one-time readiness barrier. A product network monitor may call
+// OwnerHost.AdvanceNetworkGeneration without changing demand references or
+// credential state.
 // The package never interprets rooms, pairings, accounts, target tokens, or
 // application payloads.
 package relaytransport

--- a/packages/device-link/relaytransport/liveness.go
+++ b/packages/device-link/relaytransport/liveness.go
@@ -15,6 +15,7 @@ type livenessConfig struct {
 	pongTimeout  time.Duration
 	pingPayload  []byte
 	sessionKey   string
+	generation   uint64
 	observe      OwnerObserver
 }
 
@@ -103,6 +104,7 @@ func observeLiveness(cfg livenessConfig, event OwnerEvent) {
 		return
 	}
 	event.Phase = OwnerPhaseLiveness
+	event.Generation = cfg.generation
 	event.SessionKey = cfg.sessionKey
 	cfg.observe(event)
 }

--- a/packages/device-link/relaytransport/owner_host.go
+++ b/packages/device-link/relaytransport/owner_host.go
@@ -270,7 +270,7 @@ func (h *OwnerHost) runLoop(ctx context.Context, run *ownerRun) {
 			backoff.Reset()
 			continue
 		}
-		if readyFor >= h.cfg.StableSessionFor {
+		if readyFor >= h.cfg.StableSessionFor && !wakeObserved {
 			backoff.Reset()
 		}
 		run.lifecycle.SessionEnded(session, err)

--- a/packages/device-link/relaytransport/owner_host.go
+++ b/packages/device-link/relaytransport/owner_host.go
@@ -18,10 +18,11 @@ import (
 type OwnerHost struct {
 	cfg OwnerHostConfig
 
-	mu       sync.Mutex
-	refs     map[string]int
-	refCount int
-	run      *ownerRun
+	mu                sync.Mutex
+	refs              map[string]int
+	refCount          int
+	networkGeneration uint64
+	run               *ownerRun
 }
 
 type ownerRun struct {
@@ -30,10 +31,11 @@ type ownerRun struct {
 	lifecycle OwnerLifecycle
 	handlers  sync.WaitGroup
 
-	mu      sync.Mutex
-	session OwnerSession
-	wakeCh  chan struct{}
-	wake    bool
+	mu         sync.Mutex
+	session    OwnerSession
+	generation uint64
+	wakeCh     chan struct{}
+	wake       bool
 }
 
 // NewOwnerHost validates config and creates an idle owner host.
@@ -59,7 +61,7 @@ func NewOwnerHost(cfg OwnerHostConfig) (*OwnerHost, error) {
 	if cfg.Now == nil {
 		cfg.Now = time.Now
 	}
-	return &OwnerHost{cfg: cfg, refs: make(map[string]int)}, nil
+	return &OwnerHost{cfg: cfg, refs: make(map[string]int), networkGeneration: 1}, nil
 }
 
 // Acquire starts the owner tunnel on the first reference. driver is a
@@ -97,10 +99,11 @@ func (h *OwnerHost) Acquire(ctx context.Context, driver string) error {
 	}
 	runCtx, cancel := context.WithCancel(context.Background())
 	run := &ownerRun{
-		cancel:    cancel,
-		done:      make(chan struct{}),
-		lifecycle: lifecycle,
-		wakeCh:    make(chan struct{}),
+		cancel:     cancel,
+		done:       make(chan struct{}),
+		lifecycle:  lifecycle,
+		generation: h.networkGeneration,
+		wakeCh:     make(chan struct{}),
 	}
 	h.run = run
 	go h.runLoop(runCtx, run)
@@ -145,8 +148,34 @@ func (h *OwnerHost) Release(driver string) error {
 	run.handlers.Wait()
 	session := run.currentSession()
 	err := run.lifecycle.Release(context.Background(), session)
-	h.observe(OwnerEvent{Phase: OwnerPhaseRelease, Outcome: outcome(err), SessionKey: session.Key, Error: err})
+	h.observe(OwnerEvent{
+		Phase: OwnerPhaseRelease, Outcome: outcome(err), Generation: h.currentNetworkGeneration(),
+		SessionKey: session.Key, Error: err,
+	})
 	return err
+}
+
+// AdvanceNetworkGeneration fences the current owner attempt when generation
+// is newer than the host's last accepted generation. It does not alter
+// demand references, create a lifecycle, or clear product credentials. A
+// newer generation cancels Prepare, Dial, Activate, Serve, active handlers,
+// and any retry wait; the existing lifecycle is reused for the immediate
+// retry. Equal or older generations are ignored.
+func (h *OwnerHost) AdvanceNetworkGeneration(generation uint64) {
+	if h == nil || generation == 0 {
+		return
+	}
+	h.mu.Lock()
+	if generation <= h.networkGeneration {
+		h.mu.Unlock()
+		return
+	}
+	h.networkGeneration = generation
+	run := h.run
+	h.mu.Unlock()
+	if run != nil {
+		run.advanceGeneration(generation)
+	}
 }
 
 // RefCount returns the number of current product references.
@@ -181,8 +210,8 @@ func (h *OwnerHost) runLoop(ctx context.Context, run *ownerRun) {
 	defer close(run.done)
 	backoff := newExponentialBackoff(h.cfg.Backoff)
 	for ctx.Err() == nil {
+		generation, wakeCh := run.attemptState()
 		attemptCtx, attemptCancel := context.WithCancelCause(ctx)
-		wakeCh := run.wakeChannel()
 		attemptStop := make(chan struct{})
 		attemptDone := make(chan struct{})
 		go func() {
@@ -195,18 +224,17 @@ func (h *OwnerHost) runLoop(ctx context.Context, run *ownerRun) {
 			case <-attemptStop:
 			}
 		}()
-
 		session, err := run.lifecycle.Prepare(attemptCtx)
 		if strings.TrimSpace(session.Key) != "" {
 			run.setSession(session)
 		}
-		h.observe(OwnerEvent{Phase: OwnerPhasePrepare, Outcome: outcome(err), SessionKey: session.Key, Error: err})
+		h.observe(OwnerEvent{
+			Phase: OwnerPhasePrepare, Outcome: outcome(err), Generation: generation,
+			SessionKey: session.Key, Error: err,
+		})
 		var readyFor time.Duration
 		if err == nil {
-			readyFor, err = h.runSession(attemptCtx, run, session)
-			if readyFor >= h.cfg.StableSessionFor && !errors.Is(context.Cause(attemptCtx), ErrOwnerWake) {
-				backoff.Reset()
-			}
+			readyFor, err = h.runSession(attemptCtx, run, session, generation)
 		}
 		attemptCause := context.Cause(attemptCtx)
 		wakeObserved := errors.Is(attemptCause, ErrOwnerWake)
@@ -229,8 +257,27 @@ func (h *OwnerHost) runLoop(ctx context.Context, run *ownerRun) {
 		if ctx.Err() != nil {
 			return
 		}
+		if current, changed := run.generationChangedSince(generation); changed {
+			err = &NetworkGenerationChangedError{
+				PreviousGeneration: generation,
+				Generation:         current,
+			}
+			run.lifecycle.SessionEnded(session, err)
+			h.observe(OwnerEvent{
+				Phase: OwnerPhaseSession, Outcome: OwnerOutcomeEnded, Generation: current,
+				EndReason: OwnerEndReasonNetworkChanged, SessionKey: session.Key, Error: err,
+			})
+			backoff.Reset()
+			continue
+		}
+		if readyFor >= h.cfg.StableSessionFor {
+			backoff.Reset()
+		}
 		run.lifecycle.SessionEnded(session, err)
-		h.observe(OwnerEvent{Phase: OwnerPhaseSession, Outcome: OwnerOutcomeEnded, SessionKey: session.Key, Error: err})
+		h.observe(OwnerEvent{
+			Phase: OwnerPhaseSession, Outcome: OwnerOutcomeEnded, Generation: generation,
+			SessionKey: session.Key, Error: err,
+		})
 		if wakeObserved {
 			continue
 		}
@@ -238,22 +285,32 @@ func (h *OwnerHost) runLoop(ctx context.Context, run *ownerRun) {
 		retryAfter := retryDelay(err, h.cfg.Now())
 		delay := combineRetryDelay(backoffDelay, retryAfter)
 		h.observe(OwnerEvent{
-			Phase: OwnerPhaseRetry, Outcome: OwnerOutcomeScheduled, SessionKey: session.Key,
+			Phase: OwnerPhaseRetry, Outcome: OwnerOutcomeScheduled, Generation: generation,
+			SessionKey: session.Key,
 			Retry: &OwnerRetryObservation{
 				Delay: delay, BackoffCap: backoff.Cap(), BackoffDelay: backoffDelay, RetryAfter: retryAfter,
 			},
 			Error: err,
 		})
-		if sleepErr := h.sleepRetry(ctx, run, delay); sleepErr != nil {
-			if errors.Is(sleepErr, ErrOwnerWake) {
-				continue
-			}
+		sleepErr := h.sleepRetry(ctx, run, delay)
+		if ctx.Err() != nil {
+			return
+		}
+		if current, changed := run.generationChangedSince(generation); changed {
+			h.observeNetworkRetry(session, generation, current)
+			backoff.Reset()
+			continue
+		}
+		if errors.Is(sleepErr, ErrOwnerWake) {
+			continue
+		}
+		if sleepErr != nil {
 			return
 		}
 	}
 }
 
-func (h *OwnerHost) runSession(ctx context.Context, run *ownerRun, session OwnerSession) (time.Duration, error) {
+func (h *OwnerHost) runSession(ctx context.Context, run *ownerRun, session OwnerSession, generation uint64) (time.Duration, error) {
 	ws, err := dialWebSocket(ctx, session.Dial)
 	if err != nil {
 		return 0, err
@@ -265,13 +322,17 @@ func (h *OwnerHost) runSession(ctx context.Context, run *ownerRun, session Owner
 		pongTimeout:  h.cfg.PongTimeout,
 		pingPayload:  session.PingPayload,
 		sessionKey:   session.Key,
+		generation:   generation,
 		observe:      h.observe,
 	})
 	if err != nil {
 		return 0, err
 	}
 	defer stopLiveness()
-	h.observe(OwnerEvent{Phase: OwnerPhaseDial, Outcome: OwnerOutcomeConnected, SessionKey: session.Key})
+	h.observe(OwnerEvent{
+		Phase: OwnerPhaseDial, Outcome: OwnerOutcomeConnected, Generation: generation,
+		SessionKey: session.Key,
+	})
 
 	activation, err := run.lifecycle.Activate(ctx, session)
 	if err != nil {
@@ -333,7 +394,10 @@ func (h *OwnerHost) runSession(ctx context.Context, run *ownerRun, session Owner
 		return 0, cause
 	}
 	readyAt := h.cfg.Now()
-	h.observe(OwnerEvent{Phase: OwnerPhaseServe, Outcome: OwnerOutcomeReady, SessionKey: session.Key})
+	h.observe(OwnerEvent{
+		Phase: OwnerPhaseServe, Outcome: OwnerOutcomeReady, Generation: generation,
+		SessionKey: session.Key,
+	})
 	if cause := ownerSessionCause(sessionCtx, activation.Readiness); cause != nil {
 		return elapsed(readyAt, h.cfg.Now()), cause
 	}
@@ -356,7 +420,7 @@ func (h *OwnerHost) runSession(ctx context.Context, run *ownerRun, session Owner
 			return readyFor, cause
 		}
 		run.handlers.Add(1)
-		go h.handleStream(sessionCtx, activation.Readiness, run, session.Key, stream)
+		go h.handleStream(sessionCtx, activation.Readiness, run, session.Key, generation, stream)
 	}
 }
 
@@ -386,7 +450,13 @@ func (h *OwnerHost) sleepRetry(ctx context.Context, run *ownerRun, delay time.Du
 	return err
 }
 
-func (h *OwnerHost) handleStream(ctx, readiness context.Context, run *ownerRun, sessionKey string, stream net.Conn) {
+func (h *OwnerHost) handleStream(
+	ctx, readiness context.Context,
+	run *ownerRun,
+	sessionKey string,
+	generation uint64,
+	stream net.Conn,
+) {
 	defer run.handlers.Done()
 	defer func() { _ = stream.Close() }()
 	if cause := ownerSessionCause(ctx, readiness); cause != nil {
@@ -394,7 +464,10 @@ func (h *OwnerHost) handleStream(ctx, readiness context.Context, run *ownerRun, 
 		return
 	}
 	err := h.cfg.Handler.HandleRelayStream(ctx, stream)
-	h.observe(OwnerEvent{Phase: OwnerPhaseStream, Outcome: outcome(err), SessionKey: sessionKey, Error: err})
+	h.observe(OwnerEvent{
+		Phase: OwnerPhaseStream, Outcome: outcome(err), Generation: generation,
+		SessionKey: sessionKey, Error: err,
+	})
 }
 
 func (h *OwnerHost) observe(event OwnerEvent) {
@@ -407,6 +480,49 @@ func (r *ownerRun) setSession(session OwnerSession) {
 	r.mu.Lock()
 	r.session = session
 	r.mu.Unlock()
+}
+
+func (r *ownerRun) attemptState() (uint64, <-chan struct{}) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.generation, r.wakeCh
+}
+
+func (r *ownerRun) advanceGeneration(generation uint64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if generation <= r.generation {
+		return
+	}
+	r.generation = generation
+	if !r.wake {
+		close(r.wakeCh)
+		r.wake = true
+	}
+}
+
+func (r *ownerRun) generationChangedSince(generation uint64) (uint64, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.generation, r.generation > generation
+}
+
+func (h *OwnerHost) currentNetworkGeneration() uint64 {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.networkGeneration
+}
+
+func (h *OwnerHost) observeNetworkRetry(session OwnerSession, previous, generation uint64) {
+	err := &NetworkGenerationChangedError{
+		PreviousGeneration: previous,
+		Generation:         generation,
+	}
+	h.observe(OwnerEvent{
+		Phase: OwnerPhaseRetry, Outcome: OwnerOutcomeScheduled, Generation: generation,
+		EndReason: OwnerEndReasonNetworkChanged, SessionKey: session.Key,
+		Retry: &OwnerRetryObservation{Delay: 0}, Error: err,
+	})
 }
 
 func (r *ownerRun) currentSession() OwnerSession {

--- a/packages/device-link/relaytransport/owner_host_network_test.go
+++ b/packages/device-link/relaytransport/owner_host_network_test.go
@@ -1,0 +1,153 @@
+package relaytransport
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestOwnerHostNetworkAdvanceReusesLifecycleAndClosesOldTransport(t *testing.T) {
+	relay := newTestOwnerRelay(t)
+	defer relay.Close()
+	lifecycle := newTestOwnerLifecycle(testOwnerSession(relay.OwnerEndpoint(), "network-owner"))
+	events := make(chan OwnerEvent, 32)
+	host := newTestOwnerHost(t, lifecycle, StreamHandlerFunc(func(context.Context, net.Conn) error { return nil }), func(cfg *OwnerHostConfig) {
+		cfg.Observe = func(event OwnerEvent) { events <- event }
+	})
+	if err := host.Acquire(context.Background(), "owner"); err != nil {
+		t.Fatal(err)
+	}
+	first := relay.WaitSession(t)
+	host.AdvanceNetworkGeneration(2)
+	select {
+	case <-first.mux.CloseChan():
+	case <-time.After(2 * time.Second):
+		t.Fatal("old Relay mux was not closed after network generation advance")
+	}
+	second := relay.WaitSession(t)
+	if first == second {
+		t.Fatal("network generation advance reused the old Relay session")
+	}
+	if got := lifecycle.PrepareCount(); got < 2 {
+		t.Fatalf("Prepare() count = %d, want at least 2", got)
+	}
+	if got := lifecycle.ReleaseCount(); got != 0 {
+		t.Fatalf("lifecycle Release() count before demand end = %d, want 0", got)
+	}
+
+	var networkEnd OwnerEvent
+	deadline := time.After(2 * time.Second)
+	for networkEnd.EndReason == "" {
+		select {
+		case event := <-events:
+			if event.EndReason == OwnerEndReasonNetworkChanged {
+				networkEnd = event
+			}
+		case <-deadline:
+			t.Fatal("network generation end event was not observed")
+		}
+	}
+	if networkEnd.Generation != 2 || networkEnd.Outcome != OwnerOutcomeEnded {
+		t.Fatalf("network end event = %#v, want generation 2 ended", networkEnd)
+	}
+	var generationErr *NetworkGenerationChangedError
+	if !errors.As(networkEnd.Error, &generationErr) {
+		t.Fatalf("network end error = %T %v, want NetworkGenerationChangedError", networkEnd.Error, networkEnd.Error)
+	}
+	if generationErr.PreviousGeneration != 1 || generationErr.Generation != 2 {
+		t.Fatalf("network generation error = %#v, want 1 -> 2", generationErr)
+	}
+	if err := host.Release("owner"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestOwnerHostNetworkAdvanceInterruptsBackoffImmediately(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "retry", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+	endpoint := "ws" + server.URL[len("http"):]
+	lifecycle := newTestOwnerLifecycle(testOwnerSession(endpoint, "backoff-owner"))
+	sleepStarted := make(chan struct{})
+	var sleepOnce sync.Once
+	host := newTestOwnerHost(t, lifecycle, StreamHandlerFunc(func(context.Context, net.Conn) error { return nil }), func(cfg *OwnerHostConfig) {
+		cfg.Sleep = func(ctx context.Context, _ time.Duration) error {
+			sleepOnce.Do(func() { close(sleepStarted) })
+			<-ctx.Done()
+			return ctx.Err()
+		}
+	})
+	if err := host.Acquire(context.Background(), "owner"); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-sleepStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("owner host did not enter retry backoff")
+	}
+	started := time.Now()
+	host.AdvanceNetworkGeneration(2)
+	deadline := time.After(500 * time.Millisecond)
+	for lifecycle.PrepareCount() < 2 {
+		select {
+		case <-deadline:
+			t.Fatal("network generation advance did not interrupt retry backoff")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+	if elapsed := time.Since(started); elapsed >= 500*time.Millisecond {
+		t.Fatalf("retry after network generation took %s", elapsed)
+	}
+	if err := host.Release("owner"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestOwnerHostIgnoresConcurrentOlderNetworkGenerations(t *testing.T) {
+	lifecycle := newTestOwnerLifecycle(OwnerSession{Key: "generation-owner"})
+	prepared := make(chan OwnerEvent, 1)
+	host := newTestOwnerHost(t, lifecycle, StreamHandlerFunc(func(context.Context, net.Conn) error { return nil }), func(cfg *OwnerHostConfig) {
+		cfg.Observe = func(event OwnerEvent) {
+			if event.Phase == OwnerPhasePrepare {
+				prepared <- event
+			}
+		}
+		cfg.Sleep = func(ctx context.Context, _ time.Duration) error {
+			<-ctx.Done()
+			return ctx.Err()
+		}
+	})
+	var group sync.WaitGroup
+	for generation := uint64(2); generation <= 64; generation++ {
+		generation := generation
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			host.AdvanceNetworkGeneration(generation)
+		}()
+	}
+	group.Wait()
+	if err := host.Acquire(context.Background(), "owner"); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = host.Release("owner") }()
+	select {
+	case event := <-prepared:
+		if event.Generation != 64 {
+			t.Fatalf("prepare generation = %d, want 64", event.Generation)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("owner host did not prepare after concurrent generation updates")
+	}
+	host.AdvanceNetworkGeneration(63)
+	if lifecycle.PrepareCount() != 1 {
+		t.Fatalf("older generation caused another Prepare() call: %d", lifecycle.PrepareCount())
+	}
+}

--- a/packages/device-link/relaytransport/owner_host_stability_test.go
+++ b/packages/device-link/relaytransport/owner_host_stability_test.go
@@ -75,6 +75,72 @@ func TestOwnerHostResetsBackoffOnlyAfterStableReadySession(t *testing.T) {
 	}
 }
 
+func TestOwnerHostWakePreservesBackoffAfterStableReadySession(t *testing.T) {
+	relay := newTestOwnerRelay(t)
+	defer relay.Close()
+	lifecycle := newTestOwnerLifecycle(testOwnerSession(relay.OwnerEndpoint(), "owner-wake-stability"))
+	clock := newOwnerTestClock(time.Date(2026, time.August, 12, 12, 0, 0, 0, time.UTC))
+	ready := make(chan struct{}, 5)
+	retries := make(chan OwnerEvent, 4)
+	host := newTestOwnerHost(t, lifecycle, StreamHandlerFunc(func(context.Context, net.Conn) error { return nil }), func(cfg *OwnerHostConfig) {
+		cfg.StableSessionFor = 30 * time.Second
+		cfg.Now = clock.Now
+		cfg.Backoff = BackoffConfig{
+			Initial:    100 * time.Millisecond,
+			Max:        time.Second,
+			Multiplier: 2,
+		}
+		cfg.Sleep = func(ctx context.Context, _ time.Duration) error {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+				return nil
+			}
+		}
+		cfg.Observe = func(event OwnerEvent) {
+			if event.Phase == OwnerPhaseServe && event.Outcome == OwnerOutcomeReady {
+				ready <- struct{}{}
+			}
+			if event.Phase == OwnerPhaseRetry && event.Outcome == OwnerOutcomeScheduled {
+				retries <- event
+			}
+		}
+	})
+
+	if err := host.Acquire(context.Background(), "owner"); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = host.Release("owner") }()
+
+	first := relay.WaitSession(t)
+	waitOwnerReady(t, ready)
+	clock.Advance(29*time.Second + 999*time.Millisecond)
+	first.Close()
+	if got := waitOwnerRetryEvent(t, retries).Retry.BackoffCap; got != 100*time.Millisecond {
+		t.Fatalf("first retry cap = %s, want 100ms", got)
+	}
+
+	second := relay.WaitSession(t)
+	waitOwnerReady(t, ready)
+	clock.Advance(29*time.Second + 999*time.Millisecond)
+	second.Close()
+	if got := waitOwnerRetryEvent(t, retries).Retry.BackoffCap; got != 200*time.Millisecond {
+		t.Fatalf("second retry cap = %s, want 200ms", got)
+	}
+
+	relay.WaitSession(t)
+	waitOwnerReady(t, ready)
+	clock.Advance(30 * time.Second)
+	host.Wake()
+	fourth := relay.WaitSession(t)
+	waitOwnerReady(t, ready)
+	fourth.Close()
+	if got := waitOwnerRetryEvent(t, retries).Retry.BackoffCap; got != 400*time.Millisecond {
+		t.Fatalf("retry cap after stable Wake = %s, want preserved growth to 400ms", got)
+	}
+}
+
 func waitOwnerReady(t *testing.T, ready <-chan struct{}) {
 	t.Helper()
 	select {
@@ -92,6 +158,20 @@ func waitOwnerRetry(t *testing.T, delays <-chan time.Duration) time.Duration {
 	case <-time.After(2 * time.Second):
 		t.Fatal("owner session did not schedule a retry")
 		return 0
+	}
+}
+
+func waitOwnerRetryEvent(t *testing.T, retries <-chan OwnerEvent) OwnerEvent {
+	t.Helper()
+	select {
+	case event := <-retries:
+		if event.Retry == nil {
+			t.Fatal("owner retry event omitted retry observation")
+		}
+		return event
+	case <-time.After(2 * time.Second):
+		t.Fatal("owner session did not schedule a retry")
+		return OwnerEvent{}
 	}
 }
 

--- a/packages/device-link/relaytransport/types.go
+++ b/packages/device-link/relaytransport/types.go
@@ -124,6 +124,17 @@ const (
 	OwnerPhaseRelease  OwnerPhase = "release"
 )
 
+// OwnerEndReason identifies a diagnostic reason for ending an owner attempt.
+// Empty remains the normal value for legacy failure-driven endings.
+type OwnerEndReason string
+
+const (
+	// OwnerEndReasonNetworkChanged means the attempt was fenced by a newer
+	// network generation. Product lifecycles receive the same reason through
+	// NetworkGenerationChangedError and decide whether credentials remain valid.
+	OwnerEndReasonNetworkChanged OwnerEndReason = "network_changed"
+)
+
 // OwnerOutcome identifies the result of one owner-tunnel phase. New outcomes
 // may be added compatibly; observers must ignore outcomes they do not recognize.
 type OwnerOutcome string
@@ -145,11 +156,34 @@ const (
 type OwnerEvent struct {
 	Phase      OwnerPhase
 	Outcome    OwnerOutcome
+	Generation uint64
+	EndReason  OwnerEndReason
 	SessionKey string
 	Retry      *OwnerRetryObservation
 	Liveness   *OwnerLivenessObservation
 	Error      error
 }
+
+// ErrNetworkGenerationChanged is the sentinel wrapped by
+// NetworkGenerationChangedError. It is transport cancellation, not a
+// credential invalidation signal.
+var ErrNetworkGenerationChanged = errors.New("relay owner network generation changed")
+
+// NetworkGenerationChangedError identifies an attempt canceled by a newer
+// network generation without exposing any network material.
+type NetworkGenerationChangedError struct {
+	PreviousGeneration uint64
+	Generation         uint64
+}
+
+func (e *NetworkGenerationChangedError) Error() string {
+	if e == nil {
+		return ErrNetworkGenerationChanged.Error()
+	}
+	return "relay owner network generation changed"
+}
+
+func (*NetworkGenerationChangedError) Unwrap() error { return ErrNetworkGenerationChanged }
 
 // OwnerRetryObservation describes one scheduled reconnect without product
 // identifiers or credentials.


### PR DESCRIPTION
## Summary

- add a process-local, monotonically increasing network generation monitor for Darwin, Linux/Android, Windows, and fallback platforms
- fingerprint interface/address state plus default routes without exposing raw network identifiers
- debounce native notifications, retain polling as a correctness fallback, and report watcher/sample health
- let `relaytransport.OwnerHost` rebuild Prepare/Dial/Activate/Serve and retry waits on a newer generation while preserving demand references, lifecycle credentials, and product identity
- preserve the latest upstream owner-readiness `Wake` recovery semantics while fencing late work from older network generations

This addresses long-lived owner relay sockets that can remain bound to an obsolete path after Wi-Fi, VPN, or default-route changes. Network events are proactive hints; existing liveness and timeout behavior remains the correctness fallback.

Main risks are platform-specific route observation and false-positive transport resets. Generation changes are monotonic and debounced, and resets affect only physical transports rather than business authority or demand.

## Verification

- `go test ./... -count=1` in `packages/device-link`
- `go test -race ./relaytransport ./networkchange -count=1`
- `go vet ./...`
- `pnpm check:changed -- --failed-only`
- push hook: `pnpm check:changed -- --push-ready` (7 lanes)

## Fallback Three Questions

- Source: native network notification APIs can be missed, become unavailable, or close while interface/default-route state still changes.
- Why can it not be fixed at that source? The notification contract and failure modes are controlled by each operating system, and supported platforms expose different primitives.
- Removal condition: remove the polling fallback only when every supported platform provides a demonstrably lossless watcher with observable permanent-failure recovery.

## Checklist

- [x] This change does not alter Agent session/turn/goal/runtime-operation lifecycle semantics.
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] README/CONTRIBUTING language variants are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.