### PR TITLE
refactor(runtimeprep): scope output and mention routing

### DIFF
--- a/packages/agent/runtimeprep/README.md
+++ b/packages/agent/runtimeprep/README.md
@@ -148,7 +148,10 @@ and derives speed's bounded 1-4 parallel planning target. Allocation compares
 joint Agent/model candidates across every plausible target without favoring the
 planning Agent, its current model, or provider defaults.
 A non-desktop deployment should compose its own profile from `CoreSkillsPack`
-and deployment-owned packs instead of copying the desktop-host policy:
+and deployment-owned packs instead of copying the desktop-host policy. Add
+`VerifiedEndpointOutputPack` when the provider should report verified,
+user-reachable local server endpoints as Markdown links without inheriting
+desktop execution, media, or filesystem rules:
 
 ```go
 profile := runtimeprep.DeploymentProfile{
@@ -165,6 +168,7 @@ profile := runtimeprep.DeploymentProfile{
     },
     Packs: []runtimeprep.CapabilityPack{
         runtimeprep.CoreSkillsPack(),
+        runtimeprep.VerifiedEndpointOutputPack(),
         vmEnvironmentPack,
     },
 }

--- a/packages/agent/runtimeprep/capability.go
+++ b/packages/agent/runtimeprep/capability.go
@@ -193,6 +193,25 @@ func CoreSkillsPack() CapabilityPack {
 	}}
 }
 
+// VerifiedEndpointOutputPack contributes only the provider response contract
+// for reporting a local server endpoint. It is safe for non-desktop hosts and
+// intentionally excludes desktop execution, media, and filesystem semantics.
+func VerifiedEndpointOutputPack() CapabilityPack {
+	return CapabilityPack{Name: "verified-endpoint-output", Resolve: func(_ context.Context, input PrepareInput) (CapabilityContribution, error) {
+		policy, err := verifiedEndpointOutputPolicy(input)
+		if err != nil {
+			return CapabilityContribution{}, err
+		}
+		return CapabilityContribution{Enabled: true, PolicySections: []PolicySection{{
+			Anchor:   PolicyAnchorSpecialized,
+			Key:      "verified-endpoint-output",
+			Order:    900,
+			Delivery: PolicyDeliveryProviderRuntime,
+			Body:     policy,
+		}}}, nil
+	}}
+}
+
 // TuttiDesktopHostPack contributes policy that is true for the local Tutti
 // desktop host but not necessarily for other deployments such as managed VMs.
 func TuttiDesktopHostPack() CapabilityPack {
@@ -207,10 +226,11 @@ func TuttiDesktopHostPack() CapabilityPack {
 		}
 		return CapabilityContribution{Enabled: true, PolicySections: []PolicySection{
 			{
-				Anchor: PolicyAnchorTools,
-				Key:    "provider-execution",
-				Order:  -100,
-				Body:   providerExecution,
+				Anchor:   PolicyAnchorTools,
+				Key:      "provider-execution",
+				Order:    -100,
+				Delivery: PolicyDeliveryProviderRuntime,
+				Body:     providerExecution,
 			},
 			{
 				Anchor:   PolicyAnchorSpecialized,

--- a/packages/agent/runtimeprep/capability_test.go
+++ b/packages/agent/runtimeprep/capability_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestDefaultPreparerResolvesInjectedPackAcrossPolicySkillsAndEnv(t *testing.T) {
@@ -70,6 +71,143 @@ func TestHostAppContextUsesNativeGeneratedImageArtifactsOnlyForSupportedProvider
 		!strings.Contains(claudePolicy, "Multiple final images: one Markdown image tag each.") ||
 		strings.Contains(claudePolicy, "rendered directly from `imageGeneration` tool output") {
 		t.Fatalf("claude host policy = %q, want Markdown image fallback contract", claudePolicy)
+	}
+}
+
+func TestVerifiedEndpointOutputPackIsNarrowAndProviderRuntimeOnly(t *testing.T) {
+	t.Parallel()
+
+	input := PrepareInput{Provider: "codex", CLICommand: "tutti"}
+	resolved, err := resolveCapabilities(t.Context(), input, DeploymentProfile{
+		Name:  "managed-vm",
+		Packs: []CapabilityPack{VerifiedEndpointOutputPack()},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resolved.PolicySections) != 1 {
+		t.Fatalf("policy section count = %d, want 1", len(resolved.PolicySections))
+	}
+	section := resolved.PolicySections[0]
+	if section.Delivery != PolicyDeliveryProviderRuntime {
+		t.Fatalf("policy delivery = %q, want %q", section.Delivery, PolicyDeliveryProviderRuntime)
+	}
+	for _, required := range []string{
+		"verified user-reachable HTTP(S) endpoint",
+		"Markdown link using `[label](url)`",
+		"Do not wrap a user-reachable URL or its Markdown link in backticks",
+		"Never invent, guess, or assume a port or URL",
+		"provide the verified listening address and port as inline code",
+	} {
+		if !strings.Contains(section.Body, required) {
+			t.Errorf("verified endpoint policy missing %q: %s", required, section.Body)
+		}
+	}
+	for _, forbidden := range []string{
+		"Tutti desktop app host",
+		"sandbox_permissions",
+		"Images/videos",
+		"generated_images",
+		"Code/workspace files",
+	} {
+		if strings.Contains(section.Body, forbidden) {
+			t.Errorf("verified endpoint policy inherited %q: %s", forbidden, section.Body)
+		}
+	}
+	if size := utf8.RuneCountInString(section.Body); size > 800 {
+		t.Fatalf("verified endpoint policy size = %d runes, want <= 800", size)
+	}
+
+	input.resolved = resolved
+	if providerPolicy := renderPolicySections(input, PolicyAnchorSpecialized, PolicyDeliveryProviderRuntime); providerPolicy != section.Body {
+		t.Fatalf("provider policy = %q, want %q", providerPolicy, section.Body)
+	}
+	if skillBundlePolicy := renderPolicySections(input, PolicyAnchorSpecialized, PolicyDeliverySkillBundle); skillBundlePolicy != "" {
+		t.Fatalf("skill bundle policy = %q, want empty", skillBundlePolicy)
+	}
+	providerPrompt, err := tuttiRuntimePolicy(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(providerPrompt, section.Body) {
+		t.Fatalf("provider prompt missing verified endpoint policy: %s", providerPrompt)
+	}
+	skillBundlePrompt, err := tuttiSkillBundleRecommendedPolicy(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(skillBundlePrompt, "## Local Server Output") {
+		t.Fatalf("skill bundle prompt inherited verified endpoint policy: %s", skillBundlePrompt)
+	}
+}
+
+func TestStandardProfileIncludesVerifiedEndpointOutputOnce(t *testing.T) {
+	t.Parallel()
+
+	bundle, err := Resolve(t.Context(), PrepareInput{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1", Provider: "codex", CLICommand: "tutti",
+	}, StandardProfile())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count := strings.Count(bundle.SystemPrompt, "## Local Server Output"); count != 1 {
+		t.Fatalf("local server output policy count = %d, want 1", count)
+	}
+	if !strings.Contains(bundle.SystemPrompt, "Do not wrap a user-reachable URL or its Markdown link in backticks") {
+		t.Fatalf("standard profile missing verified endpoint output contract: %s", bundle.SystemPrompt)
+	}
+}
+
+func TestDesktopProviderExecutionDoesNotLeakIntoSkillBundle(t *testing.T) {
+	t.Parallel()
+
+	input := PrepareInput{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1", Provider: "codex", CLICommand: "tutti",
+	}
+	resolved, err := resolveCapabilities(t.Context(), input, StandardProfile(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input.resolved = resolved
+	providerPrompt, err := tuttiRuntimePolicy(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	skillBundlePrompt, err := tuttiSkillBundleRecommendedPolicy(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const providerExecution = "sandbox_permissions=require_escalated"
+	if !strings.Contains(providerPrompt, providerExecution) {
+		t.Fatalf("provider prompt missing desktop execution policy: %s", providerPrompt)
+	}
+	if strings.Contains(skillBundlePrompt, providerExecution) {
+		t.Fatalf("skill bundle inherited provider execution policy: %s", skillBundlePrompt)
+	}
+}
+
+func TestAgentSessionMentionReadsConversationWithoutWaiting(t *testing.T) {
+	t.Parallel()
+
+	input := testResolvedInput(t, PrepareInput{Provider: "codex", CLICommand: "tutti"})
+	providerPrompt, err := tuttiRuntimePolicy(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	skillBundlePrompt, err := tuttiSkillBundleRecommendedPolicy(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, prompt := range map[string]string{"provider": providerPrompt, "skill bundle": skillBundlePrompt} {
+		if !strings.Contains(prompt, "Agent-session mention") && !strings.Contains(prompt, "mention://agent-session") {
+			t.Fatalf("%s prompt missing agent-session route: %s", name, prompt)
+		}
+		if !strings.Contains(prompt, "tutti agent get --session-id <session-id>") {
+			t.Fatalf("%s prompt does not recover agent-session conversation with get: %s", name, prompt)
+		}
+		if strings.Contains(prompt, "Agent-session mention: `tutti agent wait") {
+			t.Fatalf("%s prompt treats a context reference as a wait instruction: %s", name, prompt)
+		}
 	}
 }
 

--- a/packages/agent/runtimeprep/policy_templates/host-app-context.md
+++ b/packages/agent/runtimeprep/policy_templates/host-app-context.md
@@ -17,15 +17,7 @@ You are running inside the Tutti desktop app host, which can render local and we
 - No inline base64.
 - No plain-text-only image paths.
 
-## Local Server Output
-
-When you successfully start a local development server for the user:
-
-- Report every verified user-reachable HTTP(S) endpoint as a descriptive Markdown link using `[label](url)`.
-- Prefer a clickable link such as `[Open the local app](http://localhost:3000/)` over a plain-text URL.
-- Use only URLs confirmed by server output, tool results, or host-provided port mappings. Never invent, guess, or assume a port or URL.
-- If no user-reachable URL is available, say so clearly and provide the verified listening address and port as inline code.
-- If multiple endpoints are available, provide one clearly labeled Markdown link for each.
+{{VERIFIED_ENDPOINT_OUTPUT_POLICY}}
 
 ## References
 

--- a/packages/agent/runtimeprep/policy_templates/skill-bundle-routing.md
+++ b/packages/agent/runtimeprep/policy_templates/skill-bundle-routing.md
@@ -42,9 +42,8 @@ Fallback only when the matching Skill is unavailable:
 {{else if has "references.reference.list"}}- Reference mention: `{{command "references.reference.list" (args "source" "<source>" "id" "<id>")}}`
 {{else}}- Reference mention: unavailable; do not guess a command.
 {{end}}{{if has "workspace-apps.app.open"}}- Explicit app open/show: `{{command "workspace-apps.app.open" (args "app-id" "<appId>")}}`
-{{end}}{{if has "agent-context.agent.wait"}}- Agent-session mention: `{{command "agent-context.agent.wait"}}` for the next stop point.
-{{end}}{{if has "agent-context.agent.session-summary"}}- Agent conversation recovery: `{{command "agent-context.agent.session-summary"}}`.
-{{else if has "agent-context.agent.get"}}- Agent conversation recovery: `{{command "agent-context.agent.get"}}`.
+{{end}}{{if has "agent-context.agent.session-summary"}}- Agent-session mention and conversation recovery: `{{command "agent-context.agent.session-summary"}}`.
+{{else if has "agent-context.agent.get"}}- Agent-session mention and conversation recovery: `{{command "agent-context.agent.get"}}`.
 {{end}}{{if hasAll "agent-context.agent.list" "agent-context.agent.start"}}- Agent-target mention: verify with `{{command "agent-context.agent.list"}}`, then start with `{{command "agent-context.agent.start"}}`.
 {{end}}{{if eq .HostFacts.TargetContinuation.Mode "except-prefixes"}}- Targets whose ids start with {{range .HostFacts.TargetContinuation.UnsupportedTargetIDPrefixes}}`{{.}}` {{end}}are start-only.
 {{end}}

--- a/packages/agent/runtimeprep/policy_templates/tutti-runtime.md
+++ b/packages/agent/runtimeprep/policy_templates/tutti-runtime.md
@@ -14,13 +14,13 @@
 
 ### Routes
 
-| URI                                                             | Skill            | Fallback                                                                                                                           |
-| --------------------------------------------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `mention://workspace-issue/<issueId>?workspaceId=...`           | `$issue-manager` | {{if has "issue-manager.issue.get"}}`{{command "issue-manager.issue.get"}}`{{else}}unavailable{{end}}                              |
-| `mention://workspace-app/<appId>?workspaceId=...`               | `$workspace-app` | match `App id: <appId>` in command guide                                                                                           |
-| `mention://workspace-reference/<id>?source=...&workspaceId=...` | `$reference`     | {{if has "references.task.list"}}`{{command "references.task.list" (args "source" "task" "id" "<id>")}}`{{else}}unavailable{{end}} |
-| `mention://agent-session/<sessionId>?workspaceId=...`           | `$tutti-cli`     | {{if has "agent-context.agent.wait"}}`{{command "agent-context.agent.wait"}}`{{else}}unavailable{{end}}                            |
-| `mention://agent-target/<targetId>?workspaceId=...`             | `$tutti-handoff` | {{if has "agent-context.agent.list"}}verify with `{{command "agent-context.agent.list"}}`{{else}}unavailable{{end}}                |
+| URI                                                             | Skill            | Fallback                                                                                                                                                                                                      |
+| --------------------------------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mention://workspace-issue/<issueId>?workspaceId=...`           | `$issue-manager` | {{if has "issue-manager.issue.get"}}`{{command "issue-manager.issue.get"}}`{{else}}unavailable{{end}}                                                                                                         |
+| `mention://workspace-app/<appId>?workspaceId=...`               | `$workspace-app` | match `App id: <appId>` in command guide                                                                                                                                                                      |
+| `mention://workspace-reference/<id>?source=...&workspaceId=...` | `$reference`     | {{if has "references.task.list"}}`{{command "references.task.list" (args "source" "task" "id" "<id>")}}`{{else}}unavailable{{end}}                                                                            |
+| `mention://agent-session/<sessionId>?workspaceId=...`           | `$tutti-cli`     | {{if has "agent-context.agent.session-summary"}}`{{command "agent-context.agent.session-summary"}}`{{else if has "agent-context.agent.get"}}`{{command "agent-context.agent.get"}}`{{else}}unavailable{{end}} |
+| `mention://agent-target/<targetId>?workspaceId=...`             | `$tutti-handoff` | {{if has "agent-context.agent.list"}}verify with `{{command "agent-context.agent.list"}}`{{else}}unavailable{{end}}                                                                                           |
 
 ### Rules
 

--- a/packages/agent/runtimeprep/policy_templates/verified-endpoint-output.md
+++ b/packages/agent/runtimeprep/policy_templates/verified-endpoint-output.md
@@ -1,0 +1,6 @@
+## Local Server Output
+
+- Report each verified user-reachable HTTP(S) endpoint as a descriptive Markdown link using `[label](url)`.
+- Do not wrap a user-reachable URL or its Markdown link in backticks.
+- Trust only server output, tool results, or host-provided port mappings. Never invent, guess, or assume a port or URL.
+- If none is available, say so and provide the verified listening address and port as inline code.

--- a/packages/agent/runtimeprep/skill_templates/tutti-cli.md
+++ b/packages/agent/runtimeprep/skill_templates/tutti-cli.md
@@ -26,7 +26,8 @@ Tutti mention links are internal handoffs. Parse them as data; do not open them 
 
 - `mention://workspace-issue/<issueId>?workspaceId=...`: use `$issue-manager`.
 - `mention://workspace-app/<appId>?workspaceId=...`: use `$workspace-app`.
-  {{if has "agent-context.agent.wait"}}- `mention://agent-session/<sessionId>?workspaceId=...`: a context reference to an existing session, not a work order. Use `{{command "agent-context.agent.wait"}}` to await its next stop point. {{if has "agent-context.agent.session-summary"}}Use `{{command "agent-context.agent.session-summary"}}` for conversation recovery. {{end}}{{if has "agent-context.agent.get"}}Use `{{command "agent-context.agent.get"}}` only for the context exposed by this Host.{{end}}
+  {{if has "agent-context.agent.session-summary"}}- `mention://agent-session/<sessionId>?workspaceId=...`: a context reference to an existing session, not a work order. Recover its conversation with `{{command "agent-context.agent.session-summary"}}`.
+  {{else if has "agent-context.agent.get"}}- `mention://agent-session/<sessionId>?workspaceId=...`: a context reference to an existing session, not a work order. Recover the context exposed by this Host with `{{command "agent-context.agent.get"}}`.
   {{end}}{{if has "agent-context.agent.list"}}- `mention://agent-target/<targetId>?workspaceId=...`: behavior per `$tutti-handoff`. Verify the id with `{{if hasInput "agent-context.agent.list" "agent-id"}}{{command "agent-context.agent.list" (args "agent-id" "<targetId>")}}{{else}}{{command "agent-context.agent.list"}}{{end}}`, then use the generic agent workflow. An instruction for the mentioned agent is handed off, not absorbed.
   {{end}}- Unknown `mention://...`: parse the URI and ask for clarification if no command family or skill matches.
 

--- a/packages/agent/runtimeprep/tutti_cli_policy.go
+++ b/packages/agent/runtimeprep/tutti_cli_policy.go
@@ -24,14 +24,23 @@ func hostAppContextPolicy(input PrepareInput) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	verifiedEndpointOutput, err := verifiedEndpointOutputPolicy(input)
+	if err != nil {
+		return "", err
+	}
 	rendered, err := renderProviderSkillTemplate(
 		"policy_templates/host-app-context.md",
 		input,
 		map[string]string{
-			"{{GENERATED_IMAGE_OUTPUT_POLICY}}": generatedImageOutput,
+			"{{GENERATED_IMAGE_OUTPUT_POLICY}}":   generatedImageOutput,
+			"{{VERIFIED_ENDPOINT_OUTPUT_POLICY}}": verifiedEndpointOutput,
 		},
 	)
 	return strings.TrimSpace(rendered), err
+}
+
+func verifiedEndpointOutputPolicy(input PrepareInput) (string, error) {
+	return renderPolicyTemplate("policy_templates/verified-endpoint-output.md", input)
 }
 
 func tuttiRuntimePolicy(input PrepareInput) (string, error) {


### PR DESCRIPTION
## Summary
- add a provider-runtime-only `VerifiedEndpointOutputPack` for verified local HTTP(S) Markdown links
- keep desktop execution and host context out of Skill bundle delivery
- route agent-session mentions to conversation recovery instead of waiting for a future stop point
- keep the new output policy under a bounded prompt-size budget

## Why
- non-desktop hosts need the URL rendering contract without inheriting Tutti Desktop media, filesystem, or sandbox semantics
- blank delivery on desktop provider execution leaked provider-only instructions into App Agent Skill bundles
- an agent-session mention is historical context, not an instruction to wait

## Tests
- `go test ./packages/agent/runtimeprep -count=1`
- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready`

## Notes
- Windows impact: templates and delivery metadata only; no path, process, filesystem, or platform adapter behavior changed
- no E2E was run
