### PR TITLE
fix(agent): preserve terminal failure diagnostics

### DIFF
--- a/packages/agent/daemon/runtime/acp_update_events.go
+++ b/packages/agent/daemon/runtime/acp_update_events.go
@@ -340,6 +340,19 @@ func acpFailureMetadata(err error) map[string]any {
 	payload := map[string]any{
 		"error": err.Error(),
 	}
+	var transportFailure RuntimeTransportFailure
+	if errors.As(err, &transportFailure) {
+		if code := boundedRuntimeTransportFailureCode(transportFailure.RuntimeTransportFailureCode()); code != "" {
+			payload["errorCode"] = code
+			payload["transportReason"] = code
+		}
+		var grpcFailure RuntimeTransportGRPCFailure
+		if errors.As(err, &grpcFailure) {
+			if code := strings.TrimSpace(grpcFailure.RuntimeTransportGRPCCode()); code != "" && len(code) <= 32 {
+				payload["transportGrpcCode"] = code
+			}
+		}
+	}
 	var callErr *acpCallError
 	if !errors.As(err, &callErr) {
 		return payload
@@ -357,6 +370,20 @@ func acpFailureMetadata(err error) map[string]any {
 		payload["codexErrorInfo"] = codexErrorInfo
 	}
 	return payload
+}
+
+func boundedRuntimeTransportFailureCode(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" || len(value) > 80 {
+		return ""
+	}
+	for _, character := range value {
+		if (character < 'a' || character > 'z') &&
+			(character < '0' || character > '9') && character != '_' {
+			return ""
+		}
+	}
+	return value
 }
 
 func acpErrorDataPayload(raw json.RawMessage) map[string]any {

--- a/packages/agent/daemon/runtime/adapter.go
+++ b/packages/agent/daemon/runtime/adapter.go
@@ -77,6 +77,22 @@ type ProcessConnection interface {
 	Close() error
 }
 
+// RuntimeTransportFailure carries a bounded machine-readable failure code
+// from a host-owned process transport into canonical Agent failure events.
+// Implementations must not encode raw paths, request payloads, or credentials
+// in the code.
+type RuntimeTransportFailure interface {
+	error
+	RuntimeTransportFailureCode() string
+}
+
+// RuntimeTransportGRPCFailure optionally preserves the bounded gRPC status
+// code for transport diagnostics without exposing the raw status message.
+type RuntimeTransportGRPCFailure interface {
+	RuntimeTransportFailure
+	RuntimeTransportGRPCCode() string
+}
+
 // ProcessCassetteCheckpointConnection is implemented by replay connections so
 // provider adapters can distinguish a cold process tape from capture attached
 // to an already initialized live provider connection.

--- a/packages/agent/daemon/runtime/controller_turn_state_test.go
+++ b/packages/agent/daemon/runtime/controller_turn_state_test.go
@@ -57,6 +57,49 @@ func TestFailedTurnActivityEventProjectsStableErrorDetails(t *testing.T) {
 	}
 }
 
+func TestFailedTurnActivityEventProjectsProviderStopReason(t *testing.T) {
+	t.Parallel()
+
+	session := Session{Provider: ProviderCodex, AgentSessionID: "agent-1", RoomID: "room-1"}
+	event := newTurnActivityEvent(
+		session,
+		EventTurnFailed,
+		"turn-1",
+		SessionStatusFailed,
+		"",
+		"",
+		map[string]any{"stopReason": "max_tokens"},
+	)
+	patch, ok := statePatchFromSessionEvent(
+		canonical.EventSource{Provider: ProviderCodex},
+		event,
+		"agent-1",
+		200,
+	)
+	if !ok || patch.Turn == nil {
+		t.Fatalf("failed turn patch = %#v ok=%v", patch, ok)
+	}
+	if patch.Turn.ErrorCode != "provider_max_tokens" || patch.Turn.ErrorMessage != "" {
+		t.Fatalf("failed turn error = %q/%q", patch.Turn.ErrorCode, patch.Turn.ErrorMessage)
+	}
+}
+
+func TestProviderStopFailureCodeUsesClosedVocabulary(t *testing.T) {
+	t.Parallel()
+
+	for reason, expected := range map[string]string{
+		"refusal":           "provider_refusal",
+		"max_tokens":        "provider_max_tokens",
+		"max_turn_requests": "provider_max_turn_requests",
+		"end_turn":          "",
+		"future_reason":     "",
+	} {
+		if actual := providerStopFailureCode(reason); actual != expected {
+			t.Fatalf("providerStopFailureCode(%q) = %q, want %q", reason, actual, expected)
+		}
+	}
+}
+
 func TestProviderRootTurnStartMakesSessionResumable(t *testing.T) {
 	t.Parallel()
 	controller := &Controller{}

--- a/packages/agent/daemon/runtime/reporter_state.go
+++ b/packages/agent/daemon/runtime/reporter_state.go
@@ -165,8 +165,11 @@ func statePatchFromSessionEvent(source canonical.EventSource, event activityshar
 		errorCode := activityshared.BestEffortErrorCode(event.Payload)
 		if completed &&
 			strings.TrimSpace(event.Payload.TurnOutcome) == string(activityshared.TurnOutcomeFailed) &&
-			strings.TrimSpace(errorCode) == "" && strings.TrimSpace(errorMessage) != "" {
-			errorCode = visibleFailureCode(errorMessage)
+			strings.TrimSpace(errorCode) == "" {
+			errorCode = providerStopFailureCode(payloadString(event.Payload.Metadata, "stopReason"))
+			if errorCode == "" && strings.TrimSpace(errorMessage) != "" {
+				errorCode = visibleFailureCode(errorMessage)
+			}
 		}
 		patch.RootProviderTurn = &canonical.WorkspaceAgentRootProviderTurnTransition{
 			RootTurnID:              strings.TrimSpace(event.Payload.TurnID),
@@ -190,10 +193,26 @@ func turnFailureDetails(event activityshared.Event) (string, string) {
 	}
 	message := activityshared.BestEffortErrorMessage(event.Payload)
 	code := activityshared.BestEffortErrorCode(event.Payload)
+	if code == "" {
+		code = providerStopFailureCode(payloadString(event.Payload.Metadata, "stopReason"))
+	}
 	if code == "" && message != "" {
 		code = visibleFailureCode(message)
 	}
 	return code, message
+}
+
+func providerStopFailureCode(stopReason string) string {
+	switch strings.ToLower(strings.TrimSpace(stopReason)) {
+	case "refusal":
+		return "provider_refusal"
+	case "max_tokens":
+		return "provider_max_tokens"
+	case "max_turn_requests":
+		return "provider_max_turn_requests"
+	default:
+		return ""
+	}
 }
 
 // applyProviderCreatedGoalTurnToPatch turns the provider's first authoritative

--- a/packages/agent/daemon/runtime/visible_error.go
+++ b/packages/agent/daemon/runtime/visible_error.go
@@ -231,7 +231,10 @@ func structuredProviderFailureCode(detail string) string {
 func visibleFailureCode(detail string) string {
 	normalized := strings.ToLower(detail)
 	structuredCode := structuredProviderFailureCode(normalized)
+	transportCode := structuredRuntimeTransportFailureCode(normalized)
 	switch {
+	case transportCode != "":
+		return transportCode
 	// Tutti billing failures are actionable account state, not a generic provider
 	// crash. Prefer the structured code emitted by llm-token-usage, while also
 	// recognizing the legacy 402 text already present in persisted conversations.
@@ -329,6 +332,29 @@ func containsFailureMarker(normalized string, markers []string) bool {
 		}
 	}
 	return false
+}
+
+func structuredRuntimeTransportFailureCode(normalized string) string {
+	const marker = "error_code="
+	index := strings.Index(normalized, marker)
+	if index < 0 {
+		return ""
+	}
+	remainder := normalized[index+len(marker):]
+	end := 0
+	for end < len(remainder) {
+		character := remainder[end]
+		if (character < 'a' || character > 'z') &&
+			(character < '0' || character > '9') && character != '_' {
+			break
+		}
+		end++
+	}
+	code := remainder[:end]
+	if strings.HasPrefix(code, "egress_") || strings.HasPrefix(code, "provider_process_exit_") {
+		return code
+	}
+	return ""
 }
 
 // ClassifyAccountFailure returns a stable account-state code without exposing
@@ -459,7 +485,8 @@ func codexErrorLooksLikeNetwork(lower string) bool {
 
 func visibleFailureRetryable(code string, detail string) bool {
 	if code == "runtime_unavailable" || code == "request_timed_out" || code == "network_error" ||
-		code == "session_interrupted" {
+		code == "session_interrupted" || strings.HasPrefix(code, "egress_") ||
+		strings.HasPrefix(code, "provider_process_exit_") {
 		return true
 	}
 	normalized := strings.ToLower(detail)

--- a/packages/agent/daemon/runtime/visible_error_test.go
+++ b/packages/agent/daemon/runtime/visible_error_test.go
@@ -7,6 +7,35 @@ import (
 	"github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
 )
 
+type testRuntimeTransportFailure struct {
+	code string
+}
+
+func (testRuntimeTransportFailure) Error() string { return "runtime transport failed" }
+
+func (e testRuntimeTransportFailure) RuntimeTransportFailureCode() string { return e.code }
+
+func TestACPFailureMetadataPreservesTrustedRuntimeTransportCode(t *testing.T) {
+	metadata := acpFailureMetadata(testRuntimeTransportFailure{code: "provider_process_exit_stream_eof"})
+	if metadata["errorCode"] != "provider_process_exit_stream_eof" {
+		t.Fatalf("errorCode = %#v, want provider_process_exit_stream_eof", metadata["errorCode"])
+	}
+}
+
+func TestVisibleFailureCodePreservesStructuredTransportReasons(t *testing.T) {
+	for detail, want := range map[string]string{
+		"egress request failed; error_code=egress_dns_failed":                                  "egress_dns_failed",
+		"provider process exit was not confirmed; error_code=provider_process_exit_stream_eof": "provider_process_exit_stream_eof",
+	} {
+		if got := visibleFailureCode(detail); got != want {
+			t.Fatalf("visibleFailureCode(%q) = %q, want %q", detail, got, want)
+		}
+		if !visibleFailureRetryable(want, detail) {
+			t.Fatalf("visibleFailureRetryable(%q) = false, want true", want)
+		}
+	}
+}
+
 func TestVisibleFailureCodeClassifiesDeadlineExceededAsRequestTimedOut(t *testing.T) {
 	if got := visibleFailureCode("context deadline exceeded"); got != "request_timed_out" {
 		t.Fatalf("visibleFailureCode() = %q, want request_timed_out", got)

--- a/packages/agent/host/README.md
+++ b/packages/agent/host/README.md
@@ -559,6 +559,13 @@ changes the command result. Work that must survive observer failure must first
 be represented by the transaction participant's durable marker; legacy
 workspace-only change notifiers are optional latency optimizations.
 
+`TerminalFailureObserver` is the aggregated failure-only seam. A failed command
+or a Turn whose canonical outcome is `failed` may produce one observation;
+`completed`, `canceled`, and startup-reconciled `interrupted` Turns do not.
+Consumers that need the exhaustive terminal population must read
+`CommittedDelta.RootTurnsSettled` from `CommitObserver` and classify the
+canonical outcome instead of inferring cancellation from a failure callback.
+
 Re-derivable adapter projections are deliberately outside the participant
 contract. Adapters repair those while consuming canonical state rather than
 coupling their schema to every Host transaction.

--- a/packages/agent/host/command_failure.go
+++ b/packages/agent/host/command_failure.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"sync"
+	"time"
 )
 
 // commandPreconditionStage names the boundary emission for a command that
@@ -22,9 +23,22 @@ type commandTerminalFailure struct {
 	mu             sync.Mutex
 	workspaceID    string
 	agentSessionID string
+	operationID    string
+	clientSubmitID string
+	turnID         string
 	provider       string
 	stage          string
+	startedAt      time.Time
 	emitted        bool
+}
+
+type commandTerminalFailureInput struct {
+	flow           string
+	workspaceID    string
+	agentSessionID string
+	operationID    string
+	clientSubmitID string
+	turnID         string
 }
 
 type commandTerminalFailureKey struct{}
@@ -33,12 +47,18 @@ type commandTerminalFailureKey struct{}
 // nested command scopes its own aggregation for its callees only.
 func (h *Host) beginCommand(
 	ctx context.Context,
-	flow, workspaceID, agentSessionID string,
+	input commandTerminalFailureInput,
 ) (context.Context, *commandTerminalFailure) {
 	command := &commandTerminalFailure{
-		flow:           flow,
-		workspaceID:    strings.TrimSpace(workspaceID),
-		agentSessionID: strings.TrimSpace(agentSessionID),
+		flow:           strings.TrimSpace(input.flow),
+		workspaceID:    strings.TrimSpace(input.workspaceID),
+		agentSessionID: strings.TrimSpace(input.agentSessionID),
+		operationID:    strings.TrimSpace(input.operationID),
+		clientSubmitID: strings.TrimSpace(input.clientSubmitID),
+		turnID:         strings.TrimSpace(input.turnID),
+	}
+	if h != nil {
+		command.startedAt = h.now()
 	}
 	if h == nil || h.terminalFailure == nil {
 		return ctx, command
@@ -97,8 +117,12 @@ func (c *commandTerminalFailure) finish(ctx context.Context, h *Host, err error)
 		Flow:           c.flow,
 		WorkspaceID:    c.workspaceID,
 		AgentSessionID: c.agentSessionID,
+		OperationID:    c.operationID,
+		ClientSubmitID: c.clientSubmitID,
+		TurnID:         c.turnID,
 		Provider:       c.provider,
 	}
+	startedAt := c.startedAt
 	c.mu.Unlock()
 	if emitted {
 		return
@@ -110,5 +134,8 @@ func (c *commandTerminalFailure) finish(ctx context.Context, h *Host, err error)
 	failure.ErrorCode = terminalFailureCode(err)
 	failure.ErrorMessage = err.Error()
 	failure.Retryable = isRetryableRuntimeOperationError(err)
+	if duration := h.now().Sub(startedAt).Milliseconds(); duration > 0 {
+		failure.DurationMS = duration
+	}
 	h.observeTerminalFailure(ctx, failure)
 }

--- a/packages/agent/host/committed_delta.go
+++ b/packages/agent/host/committed_delta.go
@@ -226,13 +226,17 @@ func StaleTurnSettlementDelta(settlements []storesqlite.StaleTurnSettlement) Com
 			WorkspaceID:    workspaceID,
 			AgentSessionID: agentSessionID,
 			Turn: storesqlite.Turn{
-				WorkspaceID:    workspaceID,
-				AgentSessionID: agentSessionID,
-				TurnID:         turnID,
-				Phase:          storesqlite.TurnPhaseSettled,
-				Outcome:        storesqlite.TurnOutcomeInterrupted,
-				ErrorMessage:   "stale turn settled on daemon startup",
+				WorkspaceID:     workspaceID,
+				AgentSessionID:  agentSessionID,
+				TurnID:          turnID,
+				Phase:           storesqlite.TurnPhaseSettled,
+				Outcome:         storesqlite.TurnOutcomeInterrupted,
+				ErrorMessage:    "stale turn settled on daemon startup",
+				StartedAtUnixMS: settlement.StartedAtUnixMS,
+				SettledAtUnixMS: settlement.SettledAtUnixMS,
 			},
+			Provider:          strings.TrimSpace(settlement.Provider),
+			IsChildSession:    settlement.IsChildSession,
 			StartupReconciled: true,
 		})
 	}

--- a/packages/agent/host/lifecycle.go
+++ b/packages/agent/host/lifecycle.go
@@ -15,7 +15,12 @@ import (
 // CreateSession reports at most one aggregated TerminalFailure for a failed
 // command. Cleanup after a primary failure stays diagnostic.
 func (h *Host) CreateSession(ctx context.Context, workspaceID string, input CreateSessionInput) (CreateSessionResult, error) {
-	ctx, command := h.beginCommand(ctx, "session_create", workspaceID, input.AgentSessionID)
+	clientSubmitID := firstNonEmptyTrimmed(input.ClientSubmitID, legacyClientSubmitID(input.Metadata))
+	operationID := firstNonEmptyTrimmed(clientSubmitID, input.AgentSessionID)
+	ctx, command := h.beginCommand(ctx, commandTerminalFailureInput{
+		flow: "session_create", workspaceID: workspaceID, agentSessionID: input.AgentSessionID,
+		operationID: operationID, clientSubmitID: clientSubmitID, turnID: input.TurnID,
+	})
 	result, err := h.createSession(ctx, workspaceID, input)
 	command.finish(ctx, h, err)
 	return result, err
@@ -461,7 +466,12 @@ func (h *Host) ensureRuntimeSessionLocked(ctx context.Context, ref SessionRef) (
 // SendInput reports at most one aggregated TerminalFailure for a failed
 // command. Guidance target binding and goal control own their own emissions.
 func (h *Host) SendInput(ctx context.Context, ref SessionRef, input SendInput) (SendInputResult, error) {
-	ctx, command := h.beginCommand(ctx, "message_send", ref.WorkspaceID, ref.AgentSessionID)
+	clientSubmitID := firstNonEmptyTrimmed(input.ClientSubmitID, legacyClientSubmitID(input.Metadata))
+	ctx, command := h.beginCommand(ctx, commandTerminalFailureInput{
+		flow: "message_send", workspaceID: ref.WorkspaceID, agentSessionID: ref.AgentSessionID,
+		operationID:    firstNonEmptyTrimmed(clientSubmitID, input.TurnID),
+		clientSubmitID: clientSubmitID, turnID: input.TurnID,
+	})
 	result, err := h.sendInput(ctx, ref, input)
 	command.finish(ctx, h, err)
 	return result, err

--- a/packages/agent/host/stale_turn_settlement_test.go
+++ b/packages/agent/host/stale_turn_settlement_test.go
@@ -15,7 +15,7 @@ func (o *recordingStaleTurnFailureObserver) ObserveTerminalFailure(_ context.Con
 	o.failures = append(o.failures, failure)
 }
 
-func TestObserveTerminalFailuresFromStaleTurnSettlementDelta(t *testing.T) {
+func TestStaleTurnSettlementDeltaDoesNotReportInterruptedAsFailure(t *testing.T) {
 	delta := StaleTurnSettlementDelta([]storesqlite.StaleTurnSettlement{
 		{WorkspaceID: "ws-1", AgentSessionID: "session-1", TurnID: "turn-stale"},
 		{WorkspaceID: "ws-1", AgentSessionID: "session-2", TurnID: ""},
@@ -33,36 +33,22 @@ func TestObserveTerminalFailuresFromStaleTurnSettlementDelta(t *testing.T) {
 
 	observer := &recordingStaleTurnFailureObserver{}
 	ObserveTerminalFailuresFromDelta(context.Background(), observer, delta)
-	if len(observer.failures) != 1 {
-		t.Fatalf("terminal failures = %#v, want 1", observer.failures)
-	}
-	got := observer.failures[0]
-	if got.Flow != "turn" || got.FailureStage != "settled" {
-		t.Fatalf("failure identity = %#v", got)
-	}
-	if got.WorkspaceID != "ws-1" || got.AgentSessionID != "session-1" || got.TurnID != "turn-stale" {
-		t.Fatalf("failure session identity = %#v", got)
-	}
-	if got.ErrorMessage != "stale turn settled on daemon startup" {
-		t.Fatalf("failure message = %q", got.ErrorMessage)
-	}
-	if got.TurnOutcome != storesqlite.TurnOutcomeInterrupted || !got.StartupReconciled {
-		t.Fatalf("failure settlement metadata = %#v", got)
+	if len(observer.failures) != 0 {
+		t.Fatalf("terminal failures = %#v, want interrupted settlement excluded", observer.failures)
 	}
 }
 
-func TestStaleTurnSettlementDeltaKeepsChildSessionIdentityFromCallSite(t *testing.T) {
+func TestStaleTurnSettlementDeltaKeepsChildSessionIdentityFromStore(t *testing.T) {
 	delta := StaleTurnSettlementDelta([]storesqlite.StaleTurnSettlement{
-		{WorkspaceID: "ws-1", AgentSessionID: "child-1", TurnID: "turn-stale"},
+		{WorkspaceID: "ws-1", AgentSessionID: "child-1", TurnID: "turn-stale", IsChildSession: true},
 	})
-	if len(delta.RootTurnsSettled) != 1 || delta.RootTurnsSettled[0].IsChildSession {
-		t.Fatalf("root turns settled = %#v, want child identity left to the call site", delta.RootTurnsSettled)
+	if len(delta.RootTurnsSettled) != 1 || !delta.RootTurnsSettled[0].IsChildSession {
+		t.Fatalf("root turns settled = %#v, want persisted child identity", delta.RootTurnsSettled)
 	}
-	delta.RootTurnsSettled[0].IsChildSession = true
 
 	observer := &recordingStaleTurnFailureObserver{}
 	ObserveTerminalFailuresFromDelta(context.Background(), observer, delta)
-	if len(observer.failures) != 1 || !observer.failures[0].IsChildSession {
-		t.Fatalf("terminal failures = %#v, want one child-session turn failure", observer.failures)
+	if len(observer.failures) != 0 {
+		t.Fatalf("terminal failures = %#v, want interrupted child settlement excluded", observer.failures)
 	}
 }

--- a/packages/agent/host/terminal_failure.go
+++ b/packages/agent/host/terminal_failure.go
@@ -154,7 +154,7 @@ func terminalFailureFromGoalOperation(committed GoalOperationCommitted) (Termina
 func terminalFailureFromRootTurn(settled RootTurnSettled) (TerminalFailure, bool) {
 	outcome := strings.TrimSpace(settled.Turn.Outcome)
 	switch outcome {
-	case storesqlite.TurnOutcomeFailed, storesqlite.TurnOutcomeInterrupted:
+	case storesqlite.TurnOutcomeFailed:
 	default:
 		return TerminalFailure{}, false
 	}

--- a/packages/agent/host/terminal_failure_test.go
+++ b/packages/agent/host/terminal_failure_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	storesqlite "github.com/tutti-os/tutti/packages/agent/store-sqlite"
 	"github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
@@ -17,12 +18,62 @@ func (o *recordingTerminalFailureObserver) ObserveTerminalFailure(_ context.Cont
 	o.failures = append(o.failures, failure)
 }
 
+type terminalFailureSequenceClock struct {
+	now time.Time
+}
+
+func (c *terminalFailureSequenceClock) Now() time.Time {
+	current := c.now
+	c.now = c.now.Add(250 * time.Millisecond)
+	return current
+}
+
+func TestCommandBoundaryCarriesStableIdentityAndDuration(t *testing.T) {
+	observer := &recordingTerminalFailureObserver{}
+	host := New(Config{
+		TerminalFailureObserver: observer,
+		Clock: &terminalFailureSequenceClock{
+			now: time.Unix(1_700_000_000, 0),
+		},
+	})
+
+	_, _ = host.CreateSession(context.Background(), "workspace-1", CreateSessionInput{
+		AgentSessionID: "session-1",
+		ClientSubmitID: "create-submit-1",
+		TurnID:         "turn-initial",
+	})
+	_, _ = host.SendInput(
+		context.Background(),
+		SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-1"},
+		SendInput{ClientSubmitID: "send-submit-1", TurnID: "turn-2"},
+	)
+
+	if len(observer.failures) != 2 {
+		t.Fatalf("terminal failures = %#v, want 2", observer.failures)
+	}
+	for index, want := range []struct {
+		flow, operationID, clientSubmitID, turnID string
+	}{
+		{flow: "session_create", operationID: "create-submit-1", clientSubmitID: "create-submit-1", turnID: "turn-initial"},
+		{flow: "message_send", operationID: "send-submit-1", clientSubmitID: "send-submit-1", turnID: "turn-2"},
+	} {
+		got := observer.failures[index]
+		if got.Flow != want.flow || got.OperationID != want.operationID ||
+			got.ClientSubmitID != want.clientSubmitID || got.TurnID != want.turnID ||
+			got.DurationMS != 250 {
+			t.Fatalf("terminal failure %d = %#v, want identity %#v and duration 250", index, got, want)
+		}
+	}
+}
+
 func TestCommandBoundaryEmitsOneFailureForTheFirstFailedStep(t *testing.T) {
 	observer := &recordingTerminalFailureObserver{}
 	host := New(Config{TerminalFailureObserver: observer})
 	cause := NewProviderError("provider_timeout", "provider timed out after 30s", "debug", errors.New("deadline"))
 
-	ctx, command := host.beginCommand(context.Background(), "message_send", "workspace-1", "session-1")
+	ctx, command := host.beginCommand(context.Background(), commandTerminalFailureInput{
+		flow: "message_send", workspaceID: "workspace-1", agentSessionID: "session-1",
+	})
 	host.observeStep(ctx, "message_send", "runtime_session_ready", "workspace-1", "session-1", "claude", host.now(), cause)
 	host.observeStep(ctx, "message_send", "runtime_exec", "workspace-1", "session-1", "claude", host.now(), errors.New("later stage"))
 	command.finish(ctx, host, cause)
@@ -43,7 +94,9 @@ func TestCommandBoundaryEmitsOneFailureForTheFirstFailedStep(t *testing.T) {
 func TestObserveStepDoesNotEmitTerminalFailure(t *testing.T) {
 	observer := &recordingTerminalFailureObserver{}
 	host := New(Config{TerminalFailureObserver: observer})
-	ctx, _ := host.beginCommand(context.Background(), "message_send", "workspace-1", "session-1")
+	ctx, _ := host.beginCommand(context.Background(), commandTerminalFailureInput{
+		flow: "message_send", workspaceID: "workspace-1", agentSessionID: "session-1",
+	})
 	host.observeStep(ctx, "message_send", "runtime_exec", "workspace-1", "session-1", "claude", host.now(), errors.New("boom"))
 	if len(observer.failures) != 0 {
 		t.Fatalf("terminal failures = %#v, want none until the command boundary", observer.failures)
@@ -53,7 +106,9 @@ func TestObserveStepDoesNotEmitTerminalFailure(t *testing.T) {
 func TestCommandBoundarySkipsTerminalFailureOnSuccess(t *testing.T) {
 	observer := &recordingTerminalFailureObserver{}
 	host := New(Config{TerminalFailureObserver: observer})
-	ctx, command := host.beginCommand(context.Background(), "message_send", "workspace-1", "session-1")
+	ctx, command := host.beginCommand(context.Background(), commandTerminalFailureInput{
+		flow: "message_send", workspaceID: "workspace-1", agentSessionID: "session-1",
+	})
 	host.observeStep(ctx, "message_send", "runtime_exec", "workspace-1", "session-1", "claude", host.now(), nil)
 	command.finish(ctx, host, nil)
 	if len(observer.failures) != 0 {
@@ -66,7 +121,9 @@ func TestCommandBoundaryIgnoresCleanupStepsAfterPrimaryFailure(t *testing.T) {
 	host := New(Config{TerminalFailureObserver: observer})
 	primary := errors.New("runtime start failed")
 
-	ctx, command := host.beginCommand(context.Background(), "session_create", "workspace-1", "session-1")
+	ctx, command := host.beginCommand(context.Background(), commandTerminalFailureInput{
+		flow: "session_create", workspaceID: "workspace-1", agentSessionID: "session-1",
+	})
 	host.observeStep(ctx, "session_create", "runtime_started", "workspace-1", "session-1", "codex", host.now(), primary)
 	host.observeStep(ctx, "session_create_cleanup", "runtime_closed", "workspace-1", "session-1", "codex", host.now(), errors.New("cleanup failed"))
 	command.finish(ctx, host, primary)
@@ -79,7 +136,9 @@ func TestCommandBoundaryIgnoresCleanupStepsAfterPrimaryFailure(t *testing.T) {
 func TestCommandBoundaryUsesPreconditionStageWithoutAFailedStep(t *testing.T) {
 	observer := &recordingTerminalFailureObserver{}
 	host := New(Config{TerminalFailureObserver: observer})
-	ctx, command := host.beginCommand(context.Background(), "session_create", "workspace-1", "session-1")
+	ctx, command := host.beginCommand(context.Background(), commandTerminalFailureInput{
+		flow: "session_create", workspaceID: "workspace-1", agentSessionID: "session-1",
+	})
 	command.finish(ctx, host, ErrInvalidArgument)
 	if len(observer.failures) != 1 || observer.failures[0].FailureStage != commandPreconditionStage {
 		t.Fatalf("terminal failures = %#v, want one precondition failure", observer.failures)
@@ -89,7 +148,9 @@ func TestCommandBoundaryUsesPreconditionStageWithoutAFailedStep(t *testing.T) {
 func TestCommandBoundaryDefersToASpecificEmission(t *testing.T) {
 	observer := &recordingTerminalFailureObserver{}
 	host := New(Config{TerminalFailureObserver: observer})
-	ctx, command := host.beginCommand(context.Background(), "message_send", "workspace-1", "session-1")
+	ctx, command := host.beginCommand(context.Background(), commandTerminalFailureInput{
+		flow: "message_send", workspaceID: "workspace-1", agentSessionID: "session-1",
+	})
 	host.observeGuidanceTargetFailure(
 		ctx, SessionRef{WorkspaceID: "workspace-1", AgentSessionID: "session-1"},
 		"codex", "turn-1", "guidance-1", host.now(), ErrActiveTurnTargetMismatch,
@@ -164,6 +225,19 @@ func TestTerminalFailuresFromDeltaCoversInteractivePlanToolAndTurn(t *testing.T)
 	if byFlow["tool_call"].ToolNameFamily != "bash" || byFlow["tool_call"].ErrorMessage != "command exited 1" ||
 		byFlow["tool_call"].Provider != "openclaw" {
 		t.Fatalf("tool failure = %#v", byFlow["tool_call"])
+	}
+}
+
+func TestTerminalFailuresFromDeltaDoesNotTreatInterruptedOrCanceledTurnsAsFailures(t *testing.T) {
+	observer := &recordingTerminalFailureObserver{}
+	ObserveTerminalFailuresFromDelta(context.Background(), observer, CommittedDelta{
+		RootTurnsSettled: []RootTurnSettled{
+			{Turn: storesqlite.Turn{TurnID: "turn-interrupted", Outcome: storesqlite.TurnOutcomeInterrupted, ErrorMessage: "daemon restarted"}},
+			{Turn: storesqlite.Turn{TurnID: "turn-canceled", Outcome: storesqlite.TurnOutcomeCanceled, ErrorMessage: "user canceled"}},
+		},
+	})
+	if len(observer.failures) != 0 {
+		t.Fatalf("terminal failures = %#v, want interrupted and canceled turns excluded", observer.failures)
 	}
 }
 

--- a/packages/agent/store-sqlite/activity_turn_settlement.go
+++ b/packages/agent/store-sqlite/activity_turn_settlement.go
@@ -69,11 +69,15 @@ LIMIT 1
 
 func encodeTurnErrorJSON(message string, code string) any {
 	message = strings.TrimSpace(message)
-	if message == "" {
+	code = strings.TrimSpace(code)
+	if message == "" && code == "" {
 		return nil
 	}
-	payload := map[string]any{"message": message}
-	if code = strings.TrimSpace(code); code != "" {
+	payload := map[string]any{}
+	if message != "" {
+		payload["message"] = message
+	}
+	if code != "" {
 		payload["code"] = code
 	}
 	encoded, err := marshalJSONMap(payload)

--- a/packages/agent/store-sqlite/activity_turns.go
+++ b/packages/agent/store-sqlite/activity_turns.go
@@ -312,7 +312,7 @@ func mergeTurnTransition(existing Turn, hasExisting bool, transition TurnTransit
 	))
 	merged.Backfilled = false
 	merged.UpdatedAtUnixMS = occurred
-	if transition.ErrorMessage != "" {
+	if transition.ErrorMessage != "" || transition.ErrorCode != "" {
 		merged.ErrorMessage = strings.TrimSpace(transition.ErrorMessage)
 		merged.ErrorCode = strings.TrimSpace(transition.ErrorCode)
 	}

--- a/packages/agent/store-sqlite/activity_turns.go
+++ b/packages/agent/store-sqlite/activity_turns.go
@@ -447,8 +447,13 @@ func (s *Store) SettleStaleTurns(ctx context.Context) ([]StaleTurnSettlement, er
 	}()
 
 	rows, err := tx.QueryContext(ctx, `
-SELECT t.workspace_id, t.agent_session_id, t.turn_id
+SELECT t.workspace_id, t.agent_session_id, t.turn_id,
+       COALESCE(s.provider, ''), s.session_kind, COALESCE(s.parent_tool_call_id, ''),
+       t.started_at_unix_ms
 FROM workspace_agent_turns AS t
+JOIN workspace_agent_sessions AS s
+  ON s.workspace_id = t.workspace_id
+ AND s.agent_session_id = t.agent_session_id
 WHERE t.phase != ?
   AND NOT EXISTS (
     SELECT 1 FROM workspace_agent_runtime_operations AS op
@@ -463,7 +468,7 @@ WHERE t.phase != ?
       )
       AND op.status IN (?, ?)
   )
-ORDER BY workspace_id ASC, agent_session_id ASC, turn_id ASC
+ORDER BY t.workspace_id ASC, t.agent_session_id ASC, t.turn_id ASC
 `, TurnPhaseSettled, RuntimeOperationKindEditRetry,
 		RuntimeOperationStatusPrepared, RuntimeOperationStatusLeased)
 	if err != nil {
@@ -472,10 +477,21 @@ ORDER BY workspace_id ASC, agent_session_id ASC, turn_id ASC
 	settlements := make([]StaleTurnSettlement, 0)
 	for rows.Next() {
 		var settlement StaleTurnSettlement
-		if err := rows.Scan(&settlement.WorkspaceID, &settlement.AgentSessionID, &settlement.TurnID); err != nil {
+		var sessionKind, parentToolCallID string
+		if err := rows.Scan(
+			&settlement.WorkspaceID,
+			&settlement.AgentSessionID,
+			&settlement.TurnID,
+			&settlement.Provider,
+			&sessionKind,
+			&parentToolCallID,
+			&settlement.StartedAtUnixMS,
+		); err != nil {
 			rows.Close()
 			return nil, fmt.Errorf("scan stale workspace agent turn: %w", err)
 		}
+		settlement.IsChildSession = strings.EqualFold(strings.TrimSpace(sessionKind), SessionKindChild) ||
+			strings.TrimSpace(parentToolCallID) != ""
 		settlements = append(settlements, settlement)
 	}
 	if err := rows.Err(); err != nil {
@@ -493,6 +509,9 @@ ORDER BY workspace_id ASC, agent_session_id ASC, turn_id ASC
 	}
 
 	now := unixMs(time.Now().UTC())
+	for index := range settlements {
+		settlements[index].SettledAtUnixMS = now
+	}
 	if _, err := tx.ExecContext(ctx, `
 UPDATE workspace_agent_turns AS t
 SET phase = ?, outcome = ?, settled_at_unix_ms = ?, updated_at_unix_ms = ?

--- a/packages/agent/store-sqlite/activity_turns_test.go
+++ b/packages/agent/store-sqlite/activity_turns_test.go
@@ -185,6 +185,10 @@ func TestSettleStaleTurnsClosesSplitRuntimeSuccessStateOnRestart(t *testing.T) {
 	if len(settlements) != 1 {
 		t.Fatalf("settlements = %#v, want one", settlements)
 	}
+	if settlement := settlements[0]; settlement.Provider != "codex" ||
+		settlement.StartedAtUnixMS != 100 || settlement.SettledAtUnixMS <= settlement.StartedAtUnixMS {
+		t.Fatalf("settlement identity and timing = %#v, want provider codex and a valid duration", settlement)
+	}
 	turn, ok, err := store.GetTurn(ctx, "ws-1", "session-1", "turn-1")
 	if err != nil || !ok || turn.Phase != TurnPhaseSettled || turn.Outcome != TurnOutcomeInterrupted {
 		t.Fatalf("turn after restart settlement ok=%v error=%v turn=%#v", ok, err, turn)
@@ -209,6 +213,36 @@ func TestSettleStaleTurnsClosesSplitRuntimeSuccessStateOnRestart(t *testing.T) {
 	if message.MessageID != "system-stale-turn-turn-1" || message.TurnID != "turn-1" || message.Payload["noticeKind"] != "stale_turn_reconciled" {
 		t.Fatalf("startup system message = %#v", message)
 	}
+}
+
+func TestSettleStaleTurnsCarriesChildSessionIdentity(t *testing.T) {
+	t.Parallel()
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	reportSessionWithTurn(t, store, SessionStateReport{
+		WorkspaceID: "ws-1", AgentSessionID: "root", Kind: SessionKindRoot,
+		Provider: "codex", OccurredAtUnixMS: 10,
+	}, "root-turn", 10)
+	reportSessionWithTurn(t, store, SessionStateReport{
+		WorkspaceID: "ws-1", AgentSessionID: "child", Kind: SessionKindChild,
+		RootAgentSessionID: "root", RootTurnID: "root-turn",
+		ParentAgentSessionID: "root", ParentTurnID: "root-turn", ParentToolCallID: "call-1",
+		Provider: "claude-code", OccurredAtUnixMS: 20,
+	}, "child-turn", 20)
+
+	settlements, err := store.SettleStaleTurns(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, settlement := range settlements {
+		if settlement.AgentSessionID == "child" {
+			if !settlement.IsChildSession || settlement.Provider != "claude-code" ||
+				settlement.StartedAtUnixMS != 20 || settlement.SettledAtUnixMS <= 20 {
+				t.Fatalf("child settlement = %#v", settlement)
+			}
+			return
+		}
+	}
+	t.Fatalf("child settlement missing from %#v", settlements)
 }
 
 func TestSettleStaleTurnsPreservesTurnProtectedByDeferredRuntimeOperation(t *testing.T) {

--- a/packages/agent/store-sqlite/activity_turns_test.go
+++ b/packages/agent/store-sqlite/activity_turns_test.go
@@ -62,6 +62,25 @@ func TestSettledTurnFreezesLastPersistedAssistantTextAsFinalMessageAnchor(t *tes
 	}
 }
 
+func TestSettledTurnPersistsStructuredErrorCodeWithoutMessage(t *testing.T) {
+	t.Parallel()
+
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	ctx := context.Background()
+	seedTurnTestSession(t, store, "ws-1", "session-error-code")
+	turn, accepted, err := store.RecordTurnTransition(ctx, TurnTransition{
+		WorkspaceID: "ws-1", AgentSessionID: "session-error-code", TurnID: "turn-1",
+		Phase: TurnPhaseSettled, Outcome: TurnOutcomeFailed,
+		ErrorCode: "provider_max_tokens", OccurredAtUnixMS: 10,
+	})
+	if err != nil || !accepted {
+		t.Fatalf("RecordTurnTransition() accepted=%v error=%v", accepted, err)
+	}
+	if turn.ErrorCode != "provider_max_tokens" || turn.ErrorMessage != "" {
+		t.Fatalf("stored turn error = %q/%q", turn.ErrorCode, turn.ErrorMessage)
+	}
+}
+
 func TestLatestTurnsUseCompositeSessionScopeAndDurableOrdering(t *testing.T) {
 	t.Parallel()
 	store := openTestStore(t, testOptions(&staticProjectPaths{}))

--- a/packages/agent/store-sqlite/repository.go
+++ b/packages/agent/store-sqlite/repository.go
@@ -679,11 +679,15 @@ type ListSessionInteractionsInput struct {
 // StaleTurnSettlement identifies one turn that startup reconciliation
 // force-settled with outcome interrupted.
 type StaleTurnSettlement struct {
-	TransactionID  string           `json:"-"`
-	CommitDelta    TransactionDelta `json:"-"`
-	WorkspaceID    string
-	AgentSessionID string
-	TurnID         string
+	TransactionID   string           `json:"-"`
+	CommitDelta     TransactionDelta `json:"-"`
+	WorkspaceID     string
+	AgentSessionID  string
+	TurnID          string
+	Provider        string
+	IsChildSession  bool
+	StartedAtUnixMS int64
+	SettledAtUnixMS int64
 }
 
 type SessionStateReport struct {


### PR DESCRIPTION
## Summary\n- preserve stable operation, submit, Turn, provider, child-session, and duration fields on Host terminal observations\n- treat canceled and startup-interrupted Turns as non-failures while keeping canonical settlement metadata\n- propagate bounded egress and provider-process transport reasons into Agent failure metadata\n- preserve code-only Provider failures and map refusal, max_tokens, and max_turn_requests to stable error codes\n\n## Why\nProvider stop reasons can settle a failed Turn without an error message. Previously those failures lost their machine-readable cause during SQLite persistence, so downstream telemetry could only report unknown.\n\n## Risks\n- changes the failure-observer contract so only canonical failed Turns enter TerminalFailureObserver\n- adds three stable Provider stop codes to failed Turn persistence\n- does not change successful or canceled Turn semantics\n\n## Tests\n- go test ./packages/agent/daemon/runtime ./packages/agent/store-sqlite ./packages/agent/host\n- pnpm check:changed -- --push-ready\n\n## Notes\n- no package was published\n- the TSH consumer change is submitted separately