### PR TITLE
fix(workbench): restore background Dock previews

### DIFF
--- a/docs/architecture/workbench-dock-model.md
+++ b/docs/architecture/workbench-dock-model.md
@@ -268,17 +268,22 @@ snapshot.
 Native popup previews pass the clamped target rectangle to Electron capture;
 they must not capture the whole `webContents` and crop afterward. A native
 region capture is valid only for the foreground node represented by those
-composited pixels. Background and minimized nodes must not use a fresh DOM
-snapshot because their bodies may be unhydrated or their imperative resources
-may be inactive. They reuse the last successful memory or persistent image
-instead. A failed capture is terminal only for the mounted popup; it must not
-be retained across popup lifetimes because the node may be foreground the next
-time. Popup capture effects are keyed by preview identity and revision, not
-transient item arrays or callback references. Cleanup may fence stale UI
-writes, but it must retain the pending marker for a native capture that has
-already started until that capture settles, because Electron capture cannot be
-canceled. Skeletons represent in-flight capture only; a terminally unavailable
-preview uses a non-loading static placeholder.
+composited pixels. When native capture and the persistent cache both miss, a
+non-minimized background node may fall back to a DOM-cloned snapshot. DOM
+fallbacks run serially, are deduplicated by preview identity and revision, and
+yield the renderer task queue between clones so a large popup cannot turn the
+serialized work into one microtask-bound long task. They persist only successful
+images so repeated popup openings do not repeat the expensive clone. Minimized
+nodes must not request a fresh DOM snapshot because
+their bodies may be unhydrated or their imperative resources may be inactive.
+A failed capture is terminal only for the mounted popup; it must not be retained
+across popup lifetimes because the node may be foreground the next time. Popup
+capture effects are keyed by preview identity and revision, not transient item
+arrays or callback references. Cleanup may fence stale UI writes, but it must
+retain the pending marker for a native capture that has already started until
+that capture settles, because Electron capture cannot be canceled. Skeletons
+represent in-flight capture only; a terminally unavailable preview uses a
+non-loading static placeholder.
 
 Dock popup responsibilities stay split by lifecycle: `WorkbenchHostDockPopup`
 owns portal/layout and dismissal, `WorkbenchHostDockPopupPresentation` owns

--- a/docs/conventions/testing.md
+++ b/docs/conventions/testing.md
@@ -152,7 +152,8 @@ The capture runner ships `provider-switch`, `session-switch`,
 `concurrent-agent-streaming`,
 `virtualized-scroll-locator`, `virtualized-session-cycle`,
 `virtualized-oversized-active-turn`, `browser-behind-agent-gui-pixels`,
-`rail-scope-reveal`, `composer-input`, `composer-overflow-resize`, `workbench-window-lifecycle`,
+`rail-scope-reveal`, `composer-input`, `composer-overflow-resize`,
+`workbench-dock-popup-preview`, `workbench-window-lifecycle`,
 `workbench-window-drag`, `workbench-fifty-window-stress`,
 `desktop-window-state`, and
 `provider-status-focus-refresh`. List them with
@@ -160,6 +161,12 @@ The capture runner ships `provider-switch`, `session-switch`,
 `--scenario <id>`. Scenario modules own preparation, completion conditions,
 semantic assertions, milestones, and metadata; runtime startup, trace capture,
 renderer analysis, and report rendering stay scenario-neutral.
+
+`workbench-dock-popup-preview` starts with an empty isolated Desktop preview
+cache, restores fifty non-minimized AgentGUI windows in the established stress
+layout, waits for renderer mutations and idle work to settle, opens the unified
+Agent Dock popup, validates all foreground and background preview PNG pixels,
+saves a screenshot, and enforces a 50 ms renderer-task budget.
 
 `concurrent-agent-streaming` selects two settled root Sessions, restores them
 into two non-overlapping visible AgentGUI windows, and routes each through an

--- a/docs/conventions/troubleshooting/workbench-renderer.md
+++ b/docs/conventions/troubleshooting/workbench-renderer.md
@@ -719,15 +719,18 @@
   revision.
 - Fix:
   Keep native capture as the foreground high-fidelity path. Background and
-  minimized popup nodes reuse only a successful memory or persistent image;
-  they do not request a fresh DOM snapshot. Keep an unavailable result local to
-  the mounted popup so reopening can retry after the node becomes foreground.
-  Show a static terminal placeholder instead of a loading skeleton when no
-  successful image exists.
+  minimized popup nodes first reuse a successful memory or persistent image.
+  If those sources miss, serialize DOM-cloned snapshots for non-minimized
+  background nodes, yield the renderer task queue between clones, deduplicate
+  them by preview identity and revision, and persist successful images. Do not
+  DOM-capture minimized nodes because their content may be unhydrated. Keep an
+  unavailable result local to the mounted popup so reopening can retry after
+  the node becomes foreground. Show a static terminal placeholder instead of a
+  loading skeleton when no successful image exists.
 - Validation:
-  Cover native-null plus persisted-cache success, assert that background DOM
-  capture is not called, and reopen the popup to prove that a prior unavailable
-  result does not block a later successful capture.
+  Cover native-null plus persisted-cache success before DOM capture, native-null
+  plus cache-miss DOM success, and reopen the popup to prove that a prior
+  unavailable result does not block a later successful capture.
 - References:
   [docs/architecture/workbench-dock-model.md](../../architecture/workbench-dock-model.md)
   [WorkbenchHostDockPopup.tsx](../../../packages/workbench/surface/src/host/WorkbenchHostDockPopup.tsx)

--- a/packages/workbench/surface/src/host/WorkbenchHostDock.render.test.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDock.render.test.tsx
@@ -307,7 +307,73 @@ describe("WorkbenchHostDock", () => {
     }
   });
 
-  it("reuses a persisted preview without capturing background DOM", async () => {
+  it("shows the node title when a popup item has no resolved title", async () => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        disconnect() {}
+        observe() {}
+        unobserve() {}
+      }
+    );
+    const node = createNode();
+    const { host } = createDockProps([node]);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const previousActEnvironment = (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT;
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+
+    try {
+      await act(async () => {
+        root.render(
+          <WorkbenchHostDockPopup
+            anchorRect={{ height: 40, left: 20, top: 100, width: 40 }}
+            closeWindowLabel={() => "Close"}
+            items={[
+              {
+                host,
+                isFocused: false,
+                isMinimized: false,
+                node,
+                preview: null,
+                previewRevision: null,
+                subtitle: null,
+                title: null
+              }
+            ]}
+            label="Agent"
+            newWindowLabel="New"
+            onClose={() => undefined}
+            onCloseNode={() => undefined}
+            onCreateNew={() => undefined}
+            onSelectNode={() => undefined}
+            showCreateNew={false}
+          />
+        );
+      });
+
+      expect(
+        document.body.querySelector(".desktop-dock-popup__title-marquee")
+          ?.textContent
+      ).toBe("Agent");
+    } finally {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+      (
+        globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+      ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("uses persisted previews before serialized background DOM fallbacks", async () => {
     vi.stubGlobal(
       "ResizeObserver",
       class {
@@ -324,15 +390,35 @@ describe("WorkbenchHostDock", () => {
       ...createNode(),
       id: "agent-gui:unavailable-preview"
     };
-    const { host } = createDockProps([node, unavailableNode]);
-    const capturePreview = vi.fn(async () => null);
+    const secondUnavailableNode = {
+      ...createNode(),
+      id: "agent-gui:second-unavailable-preview"
+    };
+    const { host } = createDockProps([
+      node,
+      unavailableNode,
+      secondUnavailableNode
+    ]);
+    const capturePreview = vi.fn<
+      NonNullable<
+        React.ComponentProps<typeof WorkbenchHostDockPopup>["capturePreview"]
+      >
+    >(async () => null);
     const previewImageUrl = "data:image/png;base64,Q0FDSEU=";
+    const domPreviewImageUrl = "data:image/png;base64,RE9N";
+    const secondDomPreviewImageUrl = "data:image/png;base64,RE9NLTI=";
+    const pendingDomPreview = deferred<string>();
     const captureDomPreview = vi
       .spyOn(genieAnimation, "captureWorkbenchNodePreviewImage")
-      .mockResolvedValue("data:image/png;base64,RE9N");
+      .mockImplementation((nodeId) =>
+        nodeId === unavailableNode.id
+          ? pendingDomPreview.promise
+          : Promise.resolve(secondDomPreviewImageUrl)
+      );
     const readPersistedPreview = vi.fn(async (key: { nodeId: string }) =>
       key.nodeId === node.id ? previewImageUrl : null
     );
+    const writePersistedPreview = vi.fn();
     const container = document.createElement("div");
     document.body.append(container);
     const root = createRoot(container);
@@ -352,7 +438,7 @@ describe("WorkbenchHostDock", () => {
             closeWindowLabel={() => "Close"}
             dockPreviewCache={{
               read: readPersistedPreview,
-              write: vi.fn()
+              write: writePersistedPreview
             }}
             items={[
               {
@@ -374,6 +460,16 @@ describe("WorkbenchHostDock", () => {
                 previewRevision: "revision-1",
                 subtitle: null,
                 title: "Background Agent"
+              },
+              {
+                host,
+                isFocused: false,
+                isMinimized: false,
+                node: secondUnavailableNode,
+                preview: null,
+                previewRevision: "revision-1",
+                subtitle: null,
+                title: "Second Background Agent"
               }
             ]}
             label="Agent"
@@ -396,22 +492,47 @@ describe("WorkbenchHostDock", () => {
       await vi.waitFor(() => {
         expect(capturePreview).toHaveBeenCalledTimes(2);
         expect(readPersistedPreview).toHaveBeenCalledTimes(2);
-        expect(captureDomPreview).not.toHaveBeenCalled();
+        expect(captureDomPreview).toHaveBeenCalledOnce();
+        expect(captureDomPreview).toHaveBeenCalledWith(unavailableNode.id, {
+          bypassCache: true
+        });
+      });
+      expect(capturePreview.mock.calls.map(([item]) => item.node.id)).toEqual([
+        node.id,
+        unavailableNode.id
+      ]);
+
+      pendingDomPreview.resolve(domPreviewImageUrl);
+      await Promise.resolve();
+      expect(captureDomPreview).toHaveBeenCalledOnce();
+
+      await vi.waitFor(() => {
+        expect(capturePreview).toHaveBeenCalledTimes(3);
+        expect(readPersistedPreview).toHaveBeenCalledTimes(3);
+        expect(captureDomPreview).toHaveBeenCalledTimes(2);
+        expect(captureDomPreview).toHaveBeenLastCalledWith(
+          secondUnavailableNode.id,
+          { bypassCache: true }
+        );
+        expect(writePersistedPreview).toHaveBeenCalledTimes(2);
         expect(
-          document.body.querySelector<HTMLImageElement>(
-            `[data-preview-kind="image"] img`
-          )?.src
-        ).toBe(previewImageUrl);
-        expect(
-          document.body.querySelector<HTMLElement>(
-            `[data-preview-state="fallback"]`
-          )?.textContent
-        ).toBe("");
+          Array.from(
+            document.body.querySelectorAll<HTMLImageElement>(
+              `[data-preview-kind="image"] img`
+            ),
+            (image) => image.src
+          )
+        ).toEqual([
+          previewImageUrl,
+          domPreviewImageUrl,
+          secondDomPreviewImageUrl
+        ]);
         expect(
           document.body.querySelector(`[data-preview-state="loading"]`)
         ).toBeNull();
       });
     } finally {
+      pendingDomPreview.resolve(domPreviewImageUrl);
       captureDomPreview.mockRestore();
       await act(async () => {
         root.unmount();

--- a/packages/workbench/surface/src/host/WorkbenchHostDockPopupPresentation.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDockPopupPresentation.tsx
@@ -380,8 +380,8 @@ export const WorkbenchHostDockPopupCard = forwardRef<
         onKeyDown={handleSelectKeyDown}
       >
         <WorkbenchHostDockPopupCardPreview previewState={previewState} />
-        {labelMode === "hover-overlay" && item.title?.trim() ? (
-          <WorkbenchHostDockPopupCardLabel title={item.title} />
+        {labelMode === "hover-overlay" && title.trim() ? (
+          <WorkbenchHostDockPopupCardLabel title={title} />
         ) : null}
       </div>
       <Button

--- a/packages/workbench/surface/src/host/useWorkbenchHostDockPopupPreviewCapture.ts
+++ b/packages/workbench/surface/src/host/useWorkbenchHostDockPopupPreviewCapture.ts
@@ -1,5 +1,8 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
-import { writeCachedWorkbenchNodePreviewImage } from "../react/useWorkbenchGenieAnimation.tsx";
+import {
+  captureWorkbenchNodePreviewImage,
+  writeCachedWorkbenchNodePreviewImage
+} from "../react/useWorkbenchGenieAnimation.tsx";
 import type {
   WorkbenchDockPreviewCache,
   WorkbenchDockPreviewCacheKey,
@@ -293,24 +296,48 @@ export function useWorkbenchHostDockPopupPreviewCapture(input: {
           if (!captureItemStateIsCurrent(itemStateKey)) {
             continue;
           }
-          if (fallbackPersistedPreview) {
-            writeCachedWorkbenchNodePreviewImage(
+          let fallbackDomPreview: string | null = null;
+          if (!item.isMinimized && !fallbackPersistedPreview) {
+            await yieldDockPopupPreviewCaptureTask();
+            if (!captureItemStateIsCurrent(itemStateKey)) {
+              continue;
+            }
+            fallbackDomPreview = await captureWorkbenchNodePreviewImage(
               item.node.id,
-              fallbackPersistedPreview
-            );
+              { bypassCache: true }
+            ).catch(() => null);
+          }
+          if (!captureItemStateIsCurrent(itemStateKey)) {
+            continue;
+          }
+          const fallbackPreviewImageUrl =
+            fallbackPersistedPreview ?? fallbackDomPreview;
+          if (fallbackPreviewImageUrl) {
+            if (fallbackPersistedPreview) {
+              writeCachedWorkbenchNodePreviewImage(
+                item.node.id,
+                fallbackPersistedPreview
+              );
+            }
             const fallbackPreview: WorkbenchDockPreviewContent = {
               kind: "image",
-              src: fallbackPersistedPreview
+              src: fallbackPreviewImageUrl
             };
             writeDockPopupPreviewImage(
               previewMemoryKey,
               fallbackPreview,
               revision
             );
+            if (fallbackDomPreview && cacheKey) {
+              dockPreviewCacheRef.current?.write({
+                key: cacheKey,
+                previewImageUrl: fallbackDomPreview
+              });
+            }
           }
           const fallbackPreview: WorkbenchDockPreviewContent | null =
-            fallbackPersistedPreview
-              ? { kind: "image", src: fallbackPersistedPreview }
+            fallbackPreviewImageUrl
+              ? { kind: "image", src: fallbackPreviewImageUrl }
               : null;
           setCapturedPreviewByMemoryKey((current) => ({
             ...current,
@@ -444,6 +471,10 @@ function readPersistedDockPreview(
   return (
     dockPreviewCache?.read(cacheKey).catch(() => null) ?? Promise.resolve(null)
   );
+}
+
+function yieldDockPopupPreviewCaptureTask(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 function resolveDockPopupPreviewCacheKey(

--- a/tools/scripts/agent-gui-dock-preview-performance-scenario.mjs
+++ b/tools/scripts/agent-gui-dock-preview-performance-scenario.mjs
@@ -1,0 +1,384 @@
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  evaluate,
+  finishRendererScenario,
+  markRenderer,
+  startRendererScenario,
+  waitForEvaluation
+} from "./agent-gui-performance-helpers.mjs";
+import {
+  requiredScenarioData,
+  sqlString,
+  startupWorkspaceID
+} from "./agent-gui-performance-snapshot-helpers.mjs";
+import {
+  prepareAgentGUIWindowStressSnapshot,
+  waitForWorkbenchRendererIdle,
+  waitForWorkbenchRendererQuiet
+} from "./agent-gui-window-performance-scenarios.mjs";
+
+const dockPopupPreviewWindowCount = 50;
+const dockPopupPreviewScreenshot = "workbench-dock-popup-preview.png";
+const dockPopupPreviewMarkers = {
+  start: "tutti-perf:workbench-dock-popup-preview:start",
+  opened: "tutti-perf:workbench-dock-popup-preview:opened-observed",
+  ready: "tutti-perf:workbench-dock-popup-preview:ready-observed",
+  captured: "tutti-perf:workbench-dock-popup-preview:captured-observed",
+  end: "tutti-perf:workbench-dock-popup-preview:end"
+};
+
+export const workbenchDockPopupPreviewScenario = {
+  id: "workbench-dock-popup-preview",
+  markers: dockPopupPreviewMarkers,
+  milestones: [
+    {
+      key: "opened",
+      label: "Dock popup opened",
+      marker: dockPopupPreviewMarkers.opened
+    },
+    {
+      key: "ready",
+      label: "all preview images ready",
+      marker: dockPopupPreviewMarkers.ready
+    },
+    {
+      key: "captured",
+      label: "Dock popup pixels captured",
+      marker: dockPopupPreviewMarkers.captured
+    }
+  ],
+  prepareSnapshot: prepareWorkbenchDockPopupPreviewDatabaseSnapshot,
+  prepare: prepareWorkbenchDockPopupPreview,
+  execute: executeWorkbenchDockPopupPreview,
+  describe(prepared) {
+    return `${prepared.expectedNodeIDs.length} mounted AgentGUI windows; fresh Dock preview cache`;
+  },
+  summarize(prepared, result) {
+    return scenarioSummary(
+      [
+        {
+          name: `${dockPopupPreviewWindowCount} Dock popup cards rendered`,
+          passed: result.cardCount === dockPopupPreviewWindowCount
+        },
+        {
+          name: "foreground preview rendered",
+          passed: result.foregroundReadyCount === 1
+        },
+        {
+          name: "background previews rendered",
+          passed:
+            result.backgroundReadyCount === dockPopupPreviewWindowCount - 1
+        },
+        {
+          name: "preview PNGs contain visible pixels",
+          passed: result.pixelReadyCount === dockPopupPreviewWindowCount
+        },
+        {
+          name: "preview titles rendered",
+          passed: result.titledCardCount === dockPopupPreviewWindowCount
+        },
+        {
+          name: "no loading or terminal fallback remained",
+          passed: result.unreadyCount === 0
+        },
+        { name: "pixel screenshot written", passed: result.captured }
+      ],
+      [
+        { label: "Workspace", value: prepared.workspaceID },
+        { label: "Dock popup cards", value: result.cardCount },
+        {
+          label: "Foreground/background previews",
+          value: `${result.foregroundReadyCount}/${result.backgroundReadyCount}`
+        },
+        { label: "Pixel-ready previews", value: result.pixelReadyCount },
+        { label: "Titled cards", value: result.titledCardCount },
+        { label: "Screenshot", value: dockPopupPreviewScreenshot }
+      ],
+      "an isolated empty preview cache forces 49 background AgentGUI cards through the serialized DOM-clone fallback; every resulting PNG must decode with visible, non-uniform pixels"
+    );
+  },
+  assessTrace: assessWorkbenchDockPopupPreviewTrace
+};
+
+export function prepareWorkbenchDockPopupPreviewSnapshot(snapshot) {
+  if (
+    !snapshot ||
+    typeof snapshot !== "object" ||
+    !Array.isArray(snapshot.nodes)
+  ) {
+    throw new Error("invalid Workbench Dock popup preview snapshot input");
+  }
+  const stressedSnapshot = prepareAgentGUIWindowStressSnapshot(
+    snapshot,
+    dockPopupPreviewWindowCount
+  );
+  const agentGuiNodes = stressedSnapshot.nodes
+    .filter((node) => node?.data?.typeId === "agent-gui")
+    .map((node, index) => ({
+      ...node,
+      title: `Dock Preview ${index + 1}`
+    }));
+  const agentGuiNodeByID = new Map(
+    agentGuiNodes.map((node) => [node.id, node])
+  );
+  return {
+    snapshot: {
+      ...stressedSnapshot,
+      nodes: stressedSnapshot.nodes.map(
+        (node) => agentGuiNodeByID.get(node.id) ?? node
+      )
+    },
+    expectedNodeIDs: agentGuiNodes.map((node) => node.id),
+    expectedTitles: agentGuiNodes.map((node) => node.title)
+  };
+}
+
+export function assessWorkbenchDockPopupPreviewTrace(traceSummary) {
+  const maximumRendererTaskMs = 50;
+  const maximumObservedRendererTaskMs = traceSummary.timing.maxLongTaskMs;
+  return {
+    assertions: [
+      {
+        name: `renderer task <= ${maximumRendererTaskMs} ms`,
+        passed: maximumObservedRendererTaskMs <= maximumRendererTaskMs
+      }
+    ],
+    details: [
+      {
+        label: "Maximum renderer task",
+        value: `${maximumObservedRendererTaskMs} ms`
+      },
+      {
+        label: "Renderer task budget",
+        value: `${maximumRendererTaskMs} ms`
+      }
+    ]
+  };
+}
+
+async function prepareWorkbenchDockPopupPreviewDatabaseSnapshot(context) {
+  const workspaceID = await startupWorkspaceID(context);
+  const rows = await context.sqliteJSON(
+    context.databasePath,
+    `
+SELECT snapshot_json AS snapshotJSON
+FROM workspace_workbench_snapshots
+WHERE workspace_id = '${sqlString(workspaceID)}'
+LIMIT 1;
+`
+  );
+  const prepared = prepareWorkbenchDockPopupPreviewSnapshot(
+    JSON.parse(rows[0]?.snapshotJSON ?? "null")
+  );
+  await context.sqliteExec(
+    context.databasePath,
+    `
+UPDATE workspace_workbench_snapshots
+SET snapshot_json = '${sqlString(JSON.stringify(prepared.snapshot))}'
+WHERE workspace_id = '${sqlString(workspaceID)}';
+`
+  );
+  return {
+    data: {
+      expectedNodeIDs: prepared.expectedNodeIDs,
+      workspaceID
+    }
+  };
+}
+
+async function prepareWorkbenchDockPopupPreview(context, options) {
+  const scenarioData = requiredScenarioData(
+    context,
+    "workbench-dock-popup-preview"
+  );
+  const expectedNodeIDs = scenarioData.expectedNodeIDs;
+  await waitForEvaluation(
+    context.pageClient,
+    `(() => {
+      const expectedNodeIDs = ${JSON.stringify(expectedNodeIDs)};
+      const shells = expectedNodeIDs.map((nodeID) =>
+        document.querySelector('[data-workbench-window-id="' + CSS.escape(nodeID) + '"]')
+      );
+      const mountedShellCount = shells.filter((shell) =>
+        shell instanceof HTMLElement &&
+        shell.dataset.minimizedMount === 'visible' &&
+        shell.dataset.presentationVisibility === 'visible'
+      ).length;
+      const pendingHydrationCount = document.querySelectorAll(
+        '[data-agent-gui-workbench-hydration="pending"]'
+      ).length;
+      const slot = document.querySelector(
+        '[data-desktop-dock-anchor-key="agent-gui:unified"]'
+      );
+      const button = slot?.querySelector('button');
+      if (!(button instanceof HTMLButtonElement)) {
+        return { ready: false, mountedShellCount, pendingHydrationCount };
+      }
+      const rect = button.getBoundingClientRect();
+      return {
+        ready:
+          mountedShellCount === expectedNodeIDs.length &&
+          pendingHydrationCount === 0 &&
+          rect.width > 0 &&
+          rect.height > 0,
+        mountedShellCount,
+        pendingHydrationCount,
+        expectedWindowCount: expectedNodeIDs.length
+      };
+    })()`,
+    options.timeoutMs,
+    "50 mounted AgentGUI windows and the unified Agent Dock button"
+  );
+  await waitForWorkbenchRendererQuiet(context.pageClient);
+  await waitForWorkbenchRendererIdle(context.pageClient);
+  return {
+    expectedNodeIDs,
+    workspaceID: scenarioData.workspaceID
+  };
+}
+
+async function executeWorkbenchDockPopupPreview(context, prepared, options) {
+  const { pageClient } = context;
+  await startRendererScenario(pageClient, dockPopupPreviewMarkers.start);
+  await evaluate(
+    pageClient,
+    `(() => {
+      const slot = document.querySelector(
+        '[data-desktop-dock-anchor-key="agent-gui:unified"]'
+      );
+      const button = slot?.querySelector('button');
+      if (!(button instanceof HTMLButtonElement)) {
+        throw new Error('Agent Dock button is unavailable');
+      }
+      button.click();
+      return true;
+    })()`
+  );
+  await waitForEvaluation(
+    pageClient,
+    `(() => {
+      const popup = document.querySelector(
+        '[data-desktop-dock-popup-root][data-popup-variant="default"]'
+      );
+      const cards = popup?.querySelectorAll('[data-desktop-dock-popup-card]');
+      return { ready: cards?.length === ${dockPopupPreviewWindowCount} };
+    })()`,
+    options.timeoutMs,
+    "Agent Dock popup with 50 cards"
+  );
+  await markRenderer(pageClient, dockPopupPreviewMarkers.opened);
+  await waitForEvaluation(
+    pageClient,
+    `(() => {
+      const cards = [...document.querySelectorAll(
+        '[data-desktop-dock-popup-root][data-popup-variant="default"] [data-desktop-dock-popup-card]'
+      )];
+      const images = cards.map((card) =>
+        card.querySelector('[data-preview-state="ready"][data-preview-kind="image"] img')
+      );
+      return {
+        ready:
+          cards.length === ${dockPopupPreviewWindowCount} &&
+          images.every((image) =>
+            image instanceof HTMLImageElement &&
+            image.complete &&
+            image.naturalWidth > 0 &&
+            image.naturalHeight > 0
+          )
+      };
+    })()`,
+    options.timeoutMs,
+    "decoded foreground and background Dock preview images"
+  );
+  const previewState = await evaluate(
+    pageClient,
+    `Promise.all([...document.querySelectorAll(
+      '[data-desktop-dock-popup-root][data-popup-variant="default"] [data-desktop-dock-popup-card]'
+    )].map(async (card) => {
+      const image = card.querySelector(
+        '[data-preview-state="ready"][data-preview-kind="image"] img'
+      );
+      if (!(image instanceof HTMLImageElement)) {
+        return {
+          active: card.getAttribute('data-active') === 'true',
+          pixelReady: false,
+          ready: false,
+          title: card.querySelector('[role="button"]')?.getAttribute('aria-label') ?? ''
+        };
+      }
+      await image.decode().catch(() => undefined);
+      const canvas = document.createElement('canvas');
+      canvas.width = Math.min(64, image.naturalWidth);
+      canvas.height = Math.min(64, image.naturalHeight);
+      const context = canvas.getContext('2d', { willReadFrequently: true });
+      if (!context) throw new Error('Dock preview pixel canvas unavailable');
+      context.drawImage(image, 0, 0, canvas.width, canvas.height);
+      const pixels = context.getImageData(0, 0, canvas.width, canvas.height).data;
+      let visiblePixels = 0;
+      const colorBuckets = new Set();
+      for (let index = 0; index < pixels.length; index += 4) {
+        if (pixels[index + 3] <= 8) continue;
+        visiblePixels += 1;
+        colorBuckets.add(
+          (pixels[index] >> 5) + ':' +
+          (pixels[index + 1] >> 5) + ':' +
+          (pixels[index + 2] >> 5)
+        );
+      }
+      const totalPixels = canvas.width * canvas.height;
+      return {
+        active: card.getAttribute('data-active') === 'true',
+        pixelReady:
+          totalPixels > 0 &&
+          visiblePixels / totalPixels >= 0.05 &&
+          colorBuckets.size >= 2,
+        ready: true,
+        title: card.querySelector('[role="button"]')?.getAttribute('aria-label') ?? ''
+      };
+    }))`,
+    true
+  );
+  await markRenderer(pageClient, dockPopupPreviewMarkers.ready);
+  await capturePageScreenshot(
+    context,
+    join(context.outputDirectory, dockPopupPreviewScreenshot)
+  );
+  await markRenderer(pageClient, dockPopupPreviewMarkers.captured);
+  await finishRendererScenario(pageClient, dockPopupPreviewMarkers.end);
+  return {
+    backgroundReadyCount: previewState.filter(
+      (preview) => !preview.active && preview.ready
+    ).length,
+    captured: true,
+    cardCount: previewState.length,
+    foregroundReadyCount: previewState.filter(
+      (preview) => preview.active && preview.ready
+    ).length,
+    pixelReadyCount: previewState.filter((preview) => preview.pixelReady)
+      .length,
+    titledCardCount: previewState.filter((preview) => preview.title.trim())
+      .length,
+    unreadyCount: previewState.filter((preview) => !preview.ready).length
+  };
+}
+
+async function capturePageScreenshot(context, outputPath) {
+  const screenshot = await context.pageClient.send("Page.captureScreenshot", {
+    captureBeyondViewport: false,
+    format: "png",
+    fromSurface: true
+  });
+  await writeFile(outputPath, Buffer.from(screenshot.data, "base64"));
+}
+
+function scenarioSummary(assertions, details, stabilityCriterion) {
+  return {
+    outcome: assertions.every((assertion) => assertion.passed)
+      ? "passed"
+      : "failed",
+    assertions,
+    details,
+    stabilityCriterion
+  };
+}

--- a/tools/scripts/agent-gui-performance-scenarios.mjs
+++ b/tools/scripts/agent-gui-performance-scenarios.mjs
@@ -23,6 +23,7 @@ import {
 } from "./agent-gui-virtualization-performance-scenarios.mjs";
 import { providerStatusFocusRefreshScenario } from "./agent-provider-status-performance-scenario.mjs";
 import { concurrentAgentStreamingScenario } from "./agent-gui-concurrent-streaming-performance-scenario.mjs";
+import { workbenchDockPopupPreviewScenario } from "./agent-gui-dock-preview-performance-scenario.mjs";
 
 export const agentGuiPerformanceScenarios = [
   providerSwitchScenario,
@@ -37,6 +38,7 @@ export const agentGuiPerformanceScenarios = [
   railScopeRevealScenario,
   composerInputScenario,
   composerOverflowResizeScenario,
+  workbenchDockPopupPreviewScenario,
   workbenchFiftyWindowStressScenario,
   workbenchWindowDragScenario,
   workbenchWindowLifecycleScenario,

--- a/tools/scripts/agent-gui-window-performance-scenarios.mjs
+++ b/tools/scripts/agent-gui-window-performance-scenarios.mjs
@@ -577,7 +577,7 @@ async function prepareWorkbenchWindowDrag(
   );
 }
 
-async function waitForWorkbenchRendererQuiet(pageClient) {
+export async function waitForWorkbenchRendererQuiet(pageClient) {
   await evaluate(
     pageClient,
     `new Promise((resolve) => {
@@ -608,7 +608,7 @@ async function waitForWorkbenchRendererQuiet(pageClient) {
   );
 }
 
-async function waitForWorkbenchRendererIdle(pageClient) {
+export async function waitForWorkbenchRendererIdle(pageClient) {
   await evaluate(
     pageClient,
     `new Promise((resolve) => {

--- a/tools/scripts/run-agent-gui-performance.test.mjs
+++ b/tools/scripts/run-agent-gui-performance.test.mjs
@@ -18,6 +18,10 @@ import {
 import { summarizeProviderStatusFocusRefresh } from "./agent-provider-status-performance-scenario.mjs";
 import { buildAllProcessTimeProfileArgs } from "./all-process-time-profile.mjs";
 import { prepareConcurrentAgentStreamingWorkbenchSnapshot } from "./agent-gui-concurrent-streaming-performance-scenario.mjs";
+import {
+  assessWorkbenchDockPopupPreviewTrace,
+  prepareWorkbenchDockPopupPreviewSnapshot
+} from "./agent-gui-dock-preview-performance-scenario.mjs";
 import { isDesktopBundleFresh } from "./prepared-desktop-launch.mjs";
 import {
   applyScenarioAssessment,
@@ -239,6 +243,7 @@ test("performance scenario registry exposes renderer and window scenarios", () =
       "rail-scope-reveal",
       "composer-input",
       "composer-overflow-resize",
+      "workbench-dock-popup-preview",
       "workbench-fifty-window-stress",
       "workbench-window-drag",
       "workbench-window-lifecycle",
@@ -341,6 +346,64 @@ test("AgentGUI window stress snapshot creates exact unique mounted windows", () 
   assert.equal(
     snapshot.nodes.some((node) => node.id === "terminal:1"),
     true
+  );
+});
+
+test("Dock popup preview snapshot creates 50 stress-layout windows", () => {
+  const prepared = prepareWorkbenchDockPopupPreviewSnapshot({
+    activeNodeId: "agent-source",
+    nodeStack: ["terminal-1", "agent-source"],
+    nodes: [
+      {
+        id: "terminal-1",
+        data: { typeId: "terminal" },
+        frame: { x: 0, y: 0, width: 800, height: 600 }
+      },
+      {
+        id: "agent-source",
+        data: {
+          instanceId: "source",
+          typeId: "agent-gui"
+        },
+        frame: { x: 80, y: 40, width: 1000, height: 700 },
+        isMinimized: true,
+        title: "Agent"
+      }
+    ]
+  });
+  const agents = prepared.snapshot.nodes.filter(
+    (node) => node.data.typeId === "agent-gui"
+  );
+
+  assert.equal(agents.length, 50);
+  assert.deepEqual(
+    [agents[0].title, agents.at(-1).title],
+    ["Dock Preview 1", "Dock Preview 50"]
+  );
+  assert.equal(
+    agents.every((node) => node.isMinimized === false),
+    true
+  );
+  assert.equal(new Set(agents.map((node) => node.id)).size, 50);
+  assert.equal(prepared.snapshot.activeNodeId, agents.at(-1).id);
+  assert.deepEqual(
+    prepared.expectedNodeIDs,
+    agents.map((node) => node.id)
+  );
+});
+
+test("Dock popup preview trace rejects renderer tasks above 50 ms", () => {
+  assert.equal(
+    assessWorkbenchDockPopupPreviewTrace({
+      timing: { maxLongTaskMs: 50 }
+    }).assertions[0].passed,
+    true
+  );
+  assert.equal(
+    assessWorkbenchDockPopupPreviewTrace({
+      timing: { maxLongTaskMs: 51 }
+    }).assertions[0].passed,
+    false
   );
 });
 


### PR DESCRIPTION
## Summary
- restore Dock previews for non-minimized background windows by falling back to serialized DOM-clone capture after native capture and persistent cache miss
- yield between clones, deduplicate pending captures, persist successful fallback images, and retain node-title labels when popup descriptors omit a title
- add a stable 50-AgentGUI performance scenario that validates every preview's pixels and title under an empty cache with a 50 ms renderer-task budget

## Tests
- `pnpm --filter @tutti-os/workbench-surface exec vitest run ./src/host/WorkbenchHostDock.render.test.tsx --environment jsdom`
- `node --test tools/scripts/run-agent-gui-performance.test.mjs`
- `pnpm perf:agent-gui -- --scenario workbench-dock-popup-preview` (50/50 pixel-ready previews; max renderer task 44.59 ms)
- `pnpm check:changed`
- pre-push `pnpm check:changed -- --push-ready`

## Notes
- Windows impact assessed: the product change is renderer-only DOM capture; scenario paths use Node `path.join` and add no platform-specific filesystem or process assumptions
- unrelated local `pnpm-lock.yaml` changes are intentionally excluded
