### PR TITLE
fix(connector): allow multi-step authorization continuation

### DIFF
--- a/packages/connector/host/application.go
+++ b/packages/connector/host/application.go
@@ -335,7 +335,15 @@ func (application *Application) BeginAuthorization(
 	if remote && !accountScoped {
 		return AuthorizationResult{}, invalidRequest("accountId is required for remote connector authorization")
 	}
-	if accountScoped {
+	idempotentReplay, err := application.isIdempotentConnectorOperation(
+		ctx,
+		mutation,
+		OperationKindStartAuthorization,
+	)
+	if err != nil {
+		return AuthorizationResult{}, err
+	}
+	if accountScoped && !idempotentReplay {
 		projection, projectionErr := application.GetAuthorizationProjection(ctx, accountID, mutation.ConnectorKey)
 		if projectionErr != nil && !errors.Is(projectionErr, ErrNotFound) {
 			return AuthorizationResult{}, projectionErr
@@ -844,6 +852,35 @@ func (application *Application) acceptConnectorOperation(
 		}
 	}
 	return result, nil
+}
+
+// isIdempotentConnectorOperation distinguishes a continuation of an existing
+// command from a new state transition. Authorization providers may expose a
+// multi-step flow through repeated BeginAuthorization calls with one stable
+// clientRequestId, so account projection guards must not reject that replay as
+// a new pending-to-pending transition. acceptConnectorOperation repeats this
+// verification inside its mutation transaction before returning the operation.
+func (application *Application) isIdempotentConnectorOperation(
+	ctx context.Context,
+	mutation ConnectorMutation,
+	kind OperationKind,
+) (bool, error) {
+	var replay bool
+	err := application.config.Repository.Transaction(ctx, func(tx Transaction) error {
+		existing, err := tx.OperationByClientRequestID(mutation.ClientRequestID)
+		if err != nil {
+			return err
+		}
+		if existing == nil {
+			return nil
+		}
+		if err := verifyIdempotentOperation(*existing, kind, mutation.ConnectorKey, mutation.AccountID); err != nil {
+			return err
+		}
+		replay = true
+		return nil
+	})
+	return replay, err
 }
 
 func (application *Application) acceptOperation(

--- a/packages/connector/host/application_scoped_runtime.go
+++ b/packages/connector/host/application_scoped_runtime.go
@@ -40,8 +40,19 @@ func (application *Application) ObserveAuthorization(
 	mutation ConnectorMutation,
 	projection AuthorizationProjection,
 ) (MutationResult, error) {
+	if err := application.saveAuthorizationProjection(ctx, mutation, projection); err != nil {
+		return MutationResult{}, err
+	}
+	return application.ReconcileRuntime(ctx, mutation)
+}
+
+func (application *Application) saveAuthorizationProjection(
+	ctx context.Context,
+	mutation ConnectorMutation,
+	projection AuthorizationProjection,
+) error {
 	if application.config.AuthorizationProjections == nil {
-		return MutationResult{}, NewDomainError(ErrorCodeUnavailable, "account authorization projections are not registered", false, nil)
+		return NewDomainError(ErrorCodeUnavailable, "account authorization projections are not registered", false, nil)
 	}
 	projection.AccountID = strings.TrimSpace(projection.AccountID)
 	projection.ConnectorKey = strings.TrimSpace(projection.ConnectorKey)
@@ -49,24 +60,21 @@ func (application *Application) ObserveAuthorization(
 	if projection.AccountID == "" || projection.ConnectorKey == "" ||
 		projection.AccountID != strings.TrimSpace(mutation.AccountID) ||
 		projection.ConnectorKey != strings.TrimSpace(mutation.ConnectorKey) {
-		return MutationResult{}, invalidRequest("authorization projection does not match the mutation scope")
+		return invalidRequest("authorization projection does not match the mutation scope")
 	}
 	if projection.ConnectionID != "" && !runtimeConnectionIDPattern.MatchString(projection.ConnectionID) {
-		return MutationResult{}, invalidRequest("authorization projection connectionId is invalid")
+		return invalidRequest("authorization projection connectionId is invalid")
 	}
 	switch projection.State {
 	case AuthorizationStateNotRequired, AuthorizationStateDisconnected, AuthorizationStatePending,
 		AuthorizationStateConnected, AuthorizationStateExpired, AuthorizationStateFailed:
 	default:
-		return MutationResult{}, invalidRequest("authorization projection state is invalid")
+		return invalidRequest("authorization projection state is invalid")
 	}
 	if projection.UpdatedAt.IsZero() {
 		projection.UpdatedAt = application.config.Now().UTC()
 	}
-	if err := application.config.AuthorizationProjections.SaveAuthorizationProjection(ctx, projection); err != nil {
-		return MutationResult{}, err
-	}
-	return application.ReconcileRuntime(ctx, mutation)
+	return application.config.AuthorizationProjections.SaveAuthorizationProjection(ctx, projection)
 }
 
 func (application *Application) projectAuthorizationAndScheduleRuntime(
@@ -107,6 +115,20 @@ func (application *Application) projectAuthorizationAndScheduleRuntime(
 			application.config.AuthorizationReadiness.SetReady(scope.AccountID, true)
 		}
 	} else {
+		mutation := ConnectorMutation{
+			ConnectorKey: strings.TrimSpace(connectorKey),
+			AccountID:    strings.TrimSpace(scope.AccountID),
+		}
+		projection := AuthorizationProjection{
+			AccountID: strings.TrimSpace(scope.AccountID), ConnectorKey: strings.TrimSpace(connectorKey),
+			ConnectionID: connectionID, State: state, FailureCode: strings.TrimSpace(failureCode), UpdatedAt: application.config.Now().UTC(),
+		}
+		// Pending authorization has no runtime effect. Persisting the projection
+		// without scheduling a reconcile also leaves the accepted authorization
+		// operation available for the provider's next continuation step.
+		if state == AuthorizationStatePending {
+			return application.saveAuthorizationProjection(ctx, mutation, projection)
+		}
 		deviceSnapshot, snapshotErr := application.Snapshot(ctx)
 		if snapshotErr != nil {
 			return snapshotErr
@@ -115,13 +137,11 @@ func (application *Application) projectAuthorizationAndScheduleRuntime(
 		if idErr != nil {
 			return idErr
 		}
-		if _, err := application.ObserveAuthorization(ctx, ConnectorMutation{
-			Mutation:     Mutation{ClientRequestID: "authorization-projection/" + requestID, ExpectedRevision: deviceSnapshot.Revision},
-			ConnectorKey: strings.TrimSpace(connectorKey), AccountID: strings.TrimSpace(scope.AccountID),
-		}, AuthorizationProjection{
-			AccountID: strings.TrimSpace(scope.AccountID), ConnectorKey: strings.TrimSpace(connectorKey),
-			ConnectionID: connectionID, State: state, FailureCode: strings.TrimSpace(failureCode), UpdatedAt: application.config.Now().UTC(),
-		}); err != nil {
+		mutation.Mutation = Mutation{
+			ClientRequestID:  "authorization-projection/" + requestID,
+			ExpectedRevision: deviceSnapshot.Revision,
+		}
+		if _, err := application.ObserveAuthorization(ctx, mutation, projection); err != nil {
 			return err
 		}
 		return nil

--- a/packages/connector/host/application_test.go
+++ b/packages/connector/host/application_test.go
@@ -806,6 +806,57 @@ func TestApplicationManagedAuthorizationStartCanChallengeAnotherAccount(t *testi
 	}
 }
 
+func TestApplicationManagedAuthorizationContinuationReplaysBeforeProjectionTransitionValidation(t *testing.T) {
+	connector := testManagedAuthorizedConnector("lark-cli")
+	connector.Authorization = Authorization{State: AuthorizationStateDisconnected}
+	repository := newMemoryRepository(connector)
+	projections := &recordingAuthorizationProjectionStore{}
+	provider := &continuingAuthorizationProviderStub{}
+	scheduler := &memoryScheduler{}
+	application := newTestApplication(t, repository, scheduler, &memoryInstallRuntime{}, CatalogSnapshot{})
+	application.config.Authorization = provider
+	application.config.AuthorizationProjections = projections
+	mutation := ConnectorMutation{
+		Mutation:     Mutation{ClientRequestID: "one-authorization-request", ExpectedRevision: 0},
+		ConnectorKey: connector.Key,
+		AccountID:    "account-1",
+	}
+
+	first, err := application.BeginAuthorization(context.Background(), mutation, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.AuthorizationURL != "https://open.feishu.cn/page/cli" ||
+		projections.projection.State != AuthorizationStatePending {
+		t.Fatalf("first result=%#v projection=%#v", first, projections.projection)
+	}
+	continued, err := application.BeginAuthorization(context.Background(), mutation, nil)
+	if err != nil {
+		t.Fatalf("continue authorization: %v", err)
+	}
+	if continued.Operation.OperationID != first.Operation.OperationID ||
+		continued.AuthorizationURL != "https://accounts.feishu.cn/device" || provider.begins != 2 {
+		t.Fatalf("continued=%#v first=%#v provider begins=%d", continued, first, provider.begins)
+	}
+	if len(scheduler.operationIDs) != 0 {
+		t.Fatalf("pending authorization scheduled runtime operations: %v", scheduler.operationIDs)
+	}
+
+	snapshot, err := application.Snapshot(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = application.BeginAuthorization(context.Background(), ConnectorMutation{
+		Mutation:     Mutation{ClientRequestID: "different-authorization-request", ExpectedRevision: snapshot.Revision},
+		ConnectorKey: connector.Key,
+		AccountID:    "account-1",
+	}, nil)
+	var domainError *DomainError
+	if !errors.As(err, &domainError) || domainError.Code != ErrorCodeOperationInProgress {
+		t.Fatalf("different authorization error = %#v, want operation in progress", err)
+	}
+}
+
 func TestApplicationConnectedProjectionConvergesReceiptWithoutProviderPolling(t *testing.T) {
 	connector := testConnector("tencent-docs")
 	connector.Release.Manifest.AuthorizationKind = "oauth2"
@@ -1768,6 +1819,30 @@ func (connectedAuthorizationProviderStub) Begin(_ context.Context, request Autho
 		SessionID:    "session-connected",
 		ConnectionID: "existing-cli-login",
 		State:        AuthorizationStateConnected,
+	}, nil
+}
+
+type continuingAuthorizationProviderStub struct {
+	authorizationProviderStub
+	begins int
+}
+
+func (provider *continuingAuthorizationProviderStub) Begin(
+	_ context.Context,
+	request AuthorizationStartRequest,
+) (AuthorizationSession, error) {
+	provider.begins++
+	authorizationURL := "https://open.feishu.cn/page/cli"
+	if provider.begins > 1 {
+		authorizationURL = "https://accounts.feishu.cn/device"
+	}
+	return AuthorizationSession{
+		OperationID:      request.OperationID,
+		ConnectorKey:     request.Connector.Key,
+		SessionID:        request.OperationID + "/credential-broker",
+		ActionType:       "redirect",
+		AuthorizationURL: authorizationURL,
+		State:            AuthorizationStatePending,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

Fix multi-step managed connector authorization continuations that reuse one `clientRequestId`.

The authorization host previously validated the account projection transition before checking whether the command was an idempotent replay. After the first step persisted `pending`, the next step was rejected as an invalid `pending` to `pending` transition with HTTP 409. In addition, persisting a local `pending` projection scheduled a runtime reconcile even though pending authorization cannot change runtime state, creating a second `operation already in progress` race.

This change:

- recognizes an existing matching authorization operation before applying new-transition guards;
- continues to reject a different authorization request while the account is pending;
- persists local pending projections without scheduling runtime reconciliation;
- retains reconciliation for terminal authorization states;
- adds regression coverage for the complete continuation and conflict behavior.

## Verification

- Reproduced the failure with two `BeginAuthorization` calls using one stable `clientRequestId`: the second call previously returned `authorization cannot transition from pending to pending`.
- Added `TestApplicationManagedAuthorizationContinuationReplaysBeforeProjectionTransitionValidation`, which verifies the same operation advances to the next authorization URL, does not schedule a pending runtime reconcile, and still rejects a different request.
- `go test ./packages/connector/host -count=1`
- `pnpm check:changed`
- push-ready checks executed by the pre-push hook

## Checklist

- [x] If this PR changes agent lifecycle semantics (session/turn/goal/runtime-operation creation, sendability, terminal state, or recovery): the change lives in `packages/agent/host` and adds a `packages/agent/host/conformance` scenario, not in a `tuttid`/tsh adapter. (N/A: connector authorization lifecycle only.)
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed. (N/A: internal bug fix with no public workflow change.)
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. (N/A: no README/CONTRIBUTING changes.)
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
