### PR TITLE
fix(agent): keep replaced goals current in UI and session reads

### DIFF
--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -405,6 +405,12 @@ state. An empty pause/resume observation therefore records divergence without
 erasing the visible Goal; only a durable tombstone returns `null`. The daemon
 overlays that Host-owned result onto `session.goal`, and the Engine applies the
 same invariant when a synced typed result reaches its canonical Session state.
+Daemon Session reads apply the same authority rule: unresolved durable state
+projects `desired`; synchronized state projects `observed` progress; a durable
+tombstone clears the Goal. The Goal-state timestamp advances the Session
+envelope. Single-Session reads, batch lists, refreshes, and realtime-driven
+reloads therefore cannot overwrite a newer Goal with an older provider snapshot
+or resurrect a completed Goal as active.
 Engine-originated requests always send their caller-stable identity through to
 the existing Agent Host Goal saga.
 Every admitted mutation reaches Host; frontend Goal equality is not a no-op

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -411,6 +411,10 @@ tombstone clears the Goal. The Goal-state timestamp advances the Session
 envelope. Single-Session reads, batch lists, refreshes, and realtime-driven
 reloads therefore cannot overwrite a newer Goal with an older provider snapshot
 or resurrect a completed Goal as active.
+After Session creation, any later Goal Control operation retires the initial
+activation Goal as a presentation source. The operation result and canonical
+Session projection then own the banner, so the creation-time objective cannot
+shadow a replacement Goal.
 Engine-originated requests always send their caller-stable identity through to
 the existing Agent Host Goal saga.
 Every admitted mutation reaches Host; frontend Goal equality is not a no-op

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -4133,6 +4133,36 @@ convergence deadline`.
   [goal_operation_worker.go](../../../packages/agent/host/goal_operation_worker.go)
   [goal_scenarios.go](../../../packages/agent/host/conformance/goal_scenarios.go)
 
+### Replaced Goal banner keeps the previous objective
+
+- Symptom:
+  A second `/goal <objective>` is accepted and runs, but AgentGUI continues to
+  show the first objective. The Goal state table contains the second objective
+  at a newer revision while `workspace_agent_sessions.session_metadata_json`
+  or a runtime Session snapshot still contains the first.
+- Quick checks:
+  Compare `workspace_agent_session_goals.desired_json`, `revision`, and
+  `updated_at_unix_ms` with the Session metadata Goal. Confirm that the second
+  Goal operation completed before attributing the mismatch to React rendering.
+- Root cause:
+  Durable Goal state and provider Session metadata update on different
+  schedules. Session reads previously exposed the provider metadata Goal and
+  attached only `goalSyncState`, so a later Session reload could overwrite the
+  correct Goal Control response with an older objective.
+- Fix:
+  Project Host-owned durable Goal state and its update timestamp onto every
+  single and batch Session read. Use `desired` while convergence is unresolved,
+  use `observed` after synchronization, and honor the durable tombstone.
+- Validation:
+  Read a Session whose metadata contains objective A beside durable Goal
+  revision N+1 containing objective B. Single and batch projections must return
+  B with a Session timestamp at least as new as the Goal state. A durable
+  tombstone must return no Session Goal; a synchronized terminal observation
+  must remain terminal instead of reverting to active `desired` state.
+- References:
+  [service_turns.go](../../../services/tuttid/service/agent/service_turns.go)
+  [goal_state.go](../../../packages/agent/store-sqlite/goal_state.go)
+
 ### Cleared Goal reappears as a newer provider-authored Goal
 
 - Symptom:

--- a/packages/agent/activity-core/src/engine/sessionGoalControl.selectors.ts
+++ b/packages/agent/activity-core/src/engine/sessionGoalControl.selectors.ts
@@ -193,6 +193,7 @@ function projectSessionGoalControlPresentation(
     };
   }
   if (
+    !operation &&
     activation?.mode === "new" &&
     activation.initialGoalControl &&
     isPendingActivationViable(activation)
@@ -214,7 +215,7 @@ function projectSessionGoalControlPresentation(
         agentSessionId: id || null,
         goal: canonicalGoal,
         optimistic: false,
-        status: operation?.status ?? "idle"
+        status: "idle"
       };
     }
     return {

--- a/packages/agent/activity-core/src/engine/sessionGoalControl.semantic.test.ts
+++ b/packages/agent/activity-core/src/engine/sessionGoalControl.semantic.test.ts
@@ -517,12 +517,38 @@ test("uncertain rejection stays retryable while pre-admission rejection fails", 
   );
 });
 
-test("new-session Goal projection stops being optimistic after canonical hydration", () => {
+test("new-session Goal projection yields to canonical hydration and later Goal control", async () => {
+  const replacementGoal = goal("replacement goal", "active");
   const engine = createAgentSessionEngine({
     clock: { nowUnixMs: () => 100 },
-    commandPort: createTestEngineCommandPort(
-      () => new Promise(() => undefined)
-    ),
+    commandPort: createTestEngineCommandPort((command) => {
+      if (command.type !== "goal/control") {
+        return new Promise(() => undefined);
+      }
+      return Promise.resolve({
+        goal: replacementGoal,
+        operationId: "replacement-operation",
+        session: {
+          ...session(replacementGoal, 3),
+          agentSessionId: "session-new",
+          goalSyncState: {
+            pendingOperationId: null,
+            revision: 2,
+            syncStatus: "synced"
+          }
+        },
+        state: {
+          desired: replacementGoal,
+          lastEvidence: { source: "test" },
+          observed: replacementGoal,
+          pendingOperationId: null,
+          revision: 2,
+          syncStatus: "synced",
+          tombstoned: false,
+          updatedAtUnixMs: 3
+        }
+      });
+    }),
     identity: { origin: "test", workspaceId: "workspace-1" },
     scheduler: { schedule: () => ({ cancel() {} }) }
   });
@@ -594,17 +620,25 @@ test("new-session Goal projection stops being optimistic after canonical hydrati
     }
   );
 
-  engine.dispatch({
-    session: {
-      ...session(goal("ship it", "active"), 2),
+  assert.deepEqual(
+    engine.controlGoal({
+      action: "set",
       agentSessionId: "session-new",
-      goalSyncState: null
-    },
-    type: "session/upserted"
-  });
-  assert.equal(
-    selectEngineSession(engine.getSnapshot(), "session-new")?.goalSyncState,
-    null
+      clientSubmitId: "replacement-submit",
+      objective: replacementGoal.objective
+    }),
+    { accepted: true, clientSubmitId: "replacement-submit" }
+  );
+  await flushMicrotasks();
+
+  assert.deepEqual(
+    selectSessionGoalControlPresentation(engine.getSnapshot(), "session-new"),
+    {
+      agentSessionId: "session-new",
+      goal: replacementGoal,
+      optimistic: false,
+      status: "succeeded"
+    }
   );
 });
 

--- a/services/tuttid/service/agent/service_turns.go
+++ b/services/tuttid/service/agent/service_turns.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"strings"
+	"time"
 
 	agenthost "github.com/tutti-os/tutti/packages/agent/host"
 	agentactivitybiz "github.com/tutti-os/tutti/packages/agent/store-sqlite"
@@ -256,7 +257,7 @@ func (s *Service) withProtocolV2TurnStateProjectionOptions(
 		if err != nil {
 			return Session{}, err
 		}
-		return s.withSessionGoalSyncState(ctx, workspaceID, session)
+		return s.withSessionGoalState(ctx, workspaceID, session)
 	}
 	latestTurn, ok, err := s.TurnStore.GetLatestTurn(ctx, workspaceID, session.ID)
 	if err != nil {
@@ -297,7 +298,7 @@ func (s *Service) withProtocolV2TurnStateProjectionOptions(
 	if err != nil {
 		return Session{}, err
 	}
-	return s.withSessionGoalSyncState(ctx, workspaceID, session)
+	return s.withSessionGoalState(ctx, workspaceID, session)
 }
 
 func (s *Service) withProtocolV2TurnStateProjection(ctx context.Context, workspaceID string, session Session, latestTurn *agentactivitybiz.Turn, latestTurnInteractions []agentactivitybiz.Interaction) (Session, error) {
@@ -341,7 +342,7 @@ func (s *Service) withProtocolV2TurnStates(ctx context.Context, workspaceID stri
 		if err != nil {
 			return nil, err
 		}
-		return s.withSessionGoalSyncStates(ctx, workspaceID, result)
+		return s.withSessionGoalStates(ctx, workspaceID, result)
 	}
 	ids := make([]string, 0, len(sessions))
 	activeTurnIDBySessionID := make(map[string]string)
@@ -391,10 +392,10 @@ func (s *Service) withProtocolV2TurnStates(ctx context.Context, workspaceID stri
 	if err != nil {
 		return nil, err
 	}
-	return s.withSessionGoalSyncStates(ctx, workspaceID, result)
+	return s.withSessionGoalStates(ctx, workspaceID, result)
 }
 
-func (s *Service) withSessionGoalSyncState(
+func (s *Service) withSessionGoalState(
 	ctx context.Context,
 	workspaceID string,
 	session Session,
@@ -412,12 +413,12 @@ func (s *Service) withSessionGoalSyncState(
 		return Session{}, err
 	}
 	if found {
-		session.GoalSyncState = projectedSessionGoalSyncState(state)
+		return projectSessionGoalState(session, state)
 	}
 	return session, nil
 }
 
-func (s *Service) withSessionGoalSyncStates(
+func (s *Service) withSessionGoalStates(
 	ctx context.Context,
 	workspaceID string,
 	sessions []Session,
@@ -465,11 +466,60 @@ func (s *Service) withSessionGoalSyncStates(
 	}
 	for i, session := range result {
 		if state, ok := states[strings.TrimSpace(session.ID)]; ok {
-			session.GoalSyncState = projectedSessionGoalSyncState(state)
+			projected, err := projectSessionGoalState(session, state)
+			if err != nil {
+				return nil, err
+			}
+			session = projected
 		}
 		result[i] = session
 	}
 	return result, nil
+}
+
+// projectSessionGoalState makes Host-owned durable Goal state the Session read
+// authority. Desired state remains visible while convergence is unresolved;
+// once synced (or definitively failed), observed state owns provider progress.
+func projectSessionGoalState(
+	session Session,
+	state agentactivitybiz.SessionGoalState,
+) (Session, error) {
+	var rawGoal any
+	if !state.Tombstoned && len(state.Desired) > 0 {
+		rawGoal = state.Desired
+	}
+	if !state.Tombstoned &&
+		(state.SyncStatus == agentactivitybiz.GoalSyncStatusSynced ||
+			state.SyncStatus == agentactivitybiz.GoalSyncStatusFailed) &&
+		len(state.Observed) > 0 {
+		rawGoal = state.Observed
+	}
+	goal, err := decodeProjectedSessionGoal(rawGoal)
+	if err != nil {
+		return Session{}, err
+	}
+	session.Metadata.Goal = goal
+	session.GoalSyncState = projectedSessionGoalSyncState(state)
+	if state.UpdatedAtUnixMS > 0 &&
+		(session.UpdatedAt == nil || state.UpdatedAtUnixMS > session.UpdatedAt.UnixMilli()) {
+		updatedAt := time.UnixMilli(state.UpdatedAtUnixMS)
+		session.UpdatedAt = &updatedAt
+	}
+	return session, nil
+}
+
+func decodeProjectedSessionGoal(rawGoal any) (*agentactivitybiz.SessionGoal, error) {
+	raw, ok := rawGoal.(map[string]any)
+	status, _ := raw["status"].(string)
+	if !ok || strings.TrimSpace(status) != "completed" {
+		return agentactivitybiz.DecodeSessionGoal(rawGoal)
+	}
+	normalized := make(map[string]any, len(raw))
+	for key, value := range raw {
+		normalized[key] = value
+	}
+	normalized["status"] = "complete"
+	return agentactivitybiz.DecodeSessionGoal(normalized)
 }
 
 func projectedSessionGoalSyncState(state agentactivitybiz.SessionGoalState) *SessionGoalSyncState {

--- a/services/tuttid/service/agent/service_turns_error_test.go
+++ b/services/tuttid/service/agent/service_turns_error_test.go
@@ -276,6 +276,126 @@ func TestProtocolV2ProjectionIncludesDurableGoalSyncState(t *testing.T) {
 	}
 }
 
+func TestProtocolV2ProjectionUsesDurableGoalOverStaleSessionMetadata(t *testing.T) {
+	t.Parallel()
+	store := &goalStateProjectionStore{states: map[string]agentactivitybiz.SessionGoalState{
+		"session-1": {
+			AgentSessionID: "session-1",
+			Desired: map[string]any{
+				"objective": "replacement goal",
+				"status":    "active",
+			},
+			Observed: map[string]any{
+				"objective": "replacement goal",
+				"status":    "active",
+			},
+			Revision:        2,
+			SyncStatus:      agentactivitybiz.GoalSyncStatusSynced,
+			UpdatedAtUnixMS: 2_000,
+			WorkspaceID:     "workspace-1",
+		},
+	}}
+	service := &Service{GoalStateStore: store}
+	staleUpdatedAt := time.UnixMilli(1_000)
+
+	projected, err := service.withProtocolV2TurnState(
+		context.Background(),
+		"workspace-1",
+		Session{
+			ID:        "session-1",
+			UpdatedAt: &staleUpdatedAt,
+			Metadata: agentactivitybiz.SessionMetadata{Goal: &agentactivitybiz.SessionGoal{
+				Objective: "original goal",
+				Status:    "complete",
+			}},
+		},
+	)
+	if err != nil {
+		t.Fatalf("withProtocolV2TurnState() error = %v", err)
+	}
+	if projected.Metadata.Goal == nil ||
+		projected.Metadata.Goal.Objective != "replacement goal" ||
+		projected.Metadata.Goal.Status != "active" {
+		t.Fatalf("Goal = %#v, want durable replacement", projected.Metadata.Goal)
+	}
+	if projected.UpdatedAt == nil || projected.UpdatedAt.UnixMilli() != 2_000 {
+		t.Fatalf("UpdatedAt = %v, want durable Goal timestamp", projected.UpdatedAt)
+	}
+}
+
+func TestProtocolV2ProjectionUsesSyncedGoalObservation(t *testing.T) {
+	t.Parallel()
+	store := &goalStateProjectionStore{states: map[string]agentactivitybiz.SessionGoalState{
+		"session-1": {
+			AgentSessionID: "session-1",
+			Desired: map[string]any{
+				"objective": "replacement goal",
+				"status":    "active",
+			},
+			Observed: map[string]any{
+				"durationMs": 4_000,
+				"objective":  "replacement goal",
+				"status":     "completed",
+				"tokens":     1_200,
+			},
+			Revision:    2,
+			SyncStatus:  agentactivitybiz.GoalSyncStatusSynced,
+			WorkspaceID: "workspace-1",
+		},
+	}}
+	service := &Service{GoalStateStore: store}
+
+	projected, err := service.withProtocolV2TurnState(
+		context.Background(),
+		"workspace-1",
+		Session{ID: "session-1"},
+	)
+	if err != nil {
+		t.Fatalf("withProtocolV2TurnState() error = %v", err)
+	}
+	if projected.Metadata.Goal == nil ||
+		projected.Metadata.Goal.Status != "complete" ||
+		projected.Metadata.Goal.DurationMS != 4_000 ||
+		projected.Metadata.Goal.Tokens != 1_200 {
+		t.Fatalf("Goal = %#v, want synced observation", projected.Metadata.Goal)
+	}
+	if store.states["session-1"].Observed["status"] != "completed" {
+		t.Fatalf("durable observation was mutated: %#v", store.states["session-1"].Observed)
+	}
+}
+
+func TestProtocolV2ProjectionUsesDurableGoalTombstone(t *testing.T) {
+	t.Parallel()
+	store := &goalStateProjectionStore{states: map[string]agentactivitybiz.SessionGoalState{
+		"session-1": {
+			AgentSessionID: "session-1",
+			Revision:       3,
+			SyncStatus:     agentactivitybiz.GoalSyncStatusSynced,
+			Tombstoned:     true,
+			WorkspaceID:    "workspace-1",
+		},
+	}}
+	service := &Service{GoalStateStore: store}
+
+	projected, err := service.withProtocolV2TurnState(
+		context.Background(),
+		"workspace-1",
+		Session{
+			ID: "session-1",
+			Metadata: agentactivitybiz.SessionMetadata{Goal: &agentactivitybiz.SessionGoal{
+				Objective: "stale goal",
+				Status:    "active",
+			}},
+		},
+	)
+	if err != nil {
+		t.Fatalf("withProtocolV2TurnState() error = %v", err)
+	}
+	if projected.Metadata.Goal != nil {
+		t.Fatalf("Goal = %#v, want durable tombstone", projected.Metadata.Goal)
+	}
+}
+
 func TestProtocolV2BatchProjectionReadsGoalSyncStatesOnce(t *testing.T) {
 	t.Parallel()
 	listCalls, getCalls := 0, 0
@@ -284,10 +404,19 @@ func TestProtocolV2BatchProjectionReadsGoalSyncStatesOnce(t *testing.T) {
 		listCalls: &listCalls,
 		states: map[string]agentactivitybiz.SessionGoalState{
 			"session-1": {
-				AgentSessionID:     "session-1",
+				AgentSessionID: "session-1",
+				Desired: map[string]any{
+					"objective": "replacement goal",
+					"status":    "active",
+				},
+				Observed: map[string]any{
+					"objective": "original goal",
+					"status":    "complete",
+				},
 				PendingOperationID: "goal-operation-1",
 				Revision:           2,
 				SyncStatus:         agentactivitybiz.GoalSyncStatusPending,
+				UpdatedAtUnixMS:    2_000,
 				WorkspaceID:        "workspace-1",
 			},
 		},
@@ -297,7 +426,16 @@ func TestProtocolV2BatchProjectionReadsGoalSyncStatesOnce(t *testing.T) {
 	projected, err := service.withProtocolV2TurnStates(
 		context.Background(),
 		"workspace-1",
-		[]Session{{ID: "session-1"}, {ID: "session-2"}},
+		[]Session{
+			{
+				ID: "session-1",
+				Metadata: agentactivitybiz.SessionMetadata{Goal: &agentactivitybiz.SessionGoal{
+					Objective: "original goal",
+					Status:    "complete",
+				}},
+			},
+			{ID: "session-2"},
+		},
 	)
 	if err != nil {
 		t.Fatalf("withProtocolV2TurnStates() error = %v", err)
@@ -307,6 +445,9 @@ func TestProtocolV2BatchProjectionReadsGoalSyncStatesOnce(t *testing.T) {
 	}
 	if projected[0].GoalSyncState == nil || projected[0].GoalSyncState.Revision != 2 {
 		t.Fatalf("first GoalSyncState = %#v", projected[0].GoalSyncState)
+	}
+	if projected[0].Metadata.Goal == nil || projected[0].Metadata.Goal.Objective != "replacement goal" {
+		t.Fatalf("first Goal = %#v, want durable replacement", projected[0].Metadata.Goal)
 	}
 	if projected[1].GoalSyncState != nil {
 		t.Fatalf("second GoalSyncState = %#v, want nil", projected[1].GoalSyncState)


### PR DESCRIPTION
## Summary
- make Host-owned durable Goal state authoritative in single and batch Session reads
- project desired state while unresolved, observed state after settlement, and durable tombstones on clear
- retire the new-session activation Goal after any later Goal Control operation so the UI banner cannot restore the first objective
- add daemon and activity-core regressions plus durable architecture guidance

## Tests
- `go test ./service/agent -count=1`
- `pnpm check:changed`
- `pnpm check:changed -- --push-ready`
- L05 real Codex Record, cassette audit, and fresh Replay: passed

## Notes
- Agent Host lifecycle semantics are unchanged; this fixes durable read and frontend presentation projection.
- No platform-sensitive path, process, filesystem, or shell behavior changed.
- Replay coverage: https://github.com/tutti-os/tutti-replay/pull/8