### PR TITLE
fix(workbench): share Dock preview cache across popup states

### DIFF
--- a/docs/architecture/workbench-dock-model.md
+++ b/docs/architecture/workbench-dock-model.md
@@ -268,8 +268,16 @@ snapshot.
 Native popup previews pass the clamped target rectangle to Electron capture;
 they must not capture the whole `webContents` and crop afterward. A native
 region capture is valid only for the foreground node represented by those
-composited pixels. When native capture and the persistent cache both miss, a
-non-minimized background node may fall back to a DOM-cloned snapshot. DOM
+composited pixels. When native capture misses, a popup first reads the Node's
+shared latest Dock preview from memory. After a memory miss, it reads the
+unrevisioned persistent latest identity and the exact-revision identity in
+parallel. The shared latest entry wins; an exact-revision entry is a
+compatibility fallback for previously captured generations and is promoted to
+the shared identity when used. When every cache source misses, a non-minimized
+background node may fall back to a DOM-cloned snapshot. Successful native and
+DOM captures update the one shared latest entry, so popup and minimize capture
+reuse the same bounded Dock PNG without duplicating persistent writes or
+sharing the full-resolution Genie animation texture. DOM
 fallbacks run serially, are deduplicated by preview identity and revision, and
 yield the renderer task queue between clones so a large popup cannot turn the
 serialized work into one microtask-bound long task. They persist only successful

--- a/docs/conventions/troubleshooting/workbench-renderer.md
+++ b/docs/conventions/troubleshooting/workbench-renderer.md
@@ -720,17 +720,23 @@
 - Fix:
   Keep native capture as the foreground high-fidelity path. Background and
   minimized popup nodes first reuse a successful memory or persistent image.
-  If those sources miss, serialize DOM-cloned snapshots for non-minimized
-  background nodes, yield the renderer task queue between clones, deduplicate
-  them by preview identity and revision, and persist successful images. Do not
-  DOM-capture minimized nodes because their content may be unhydrated. Keep an
-  unavailable result local to the mounted popup so reopening can retry after
-  the node becomes foreground. Show a static terminal placeholder instead of a
-  loading skeleton when no successful image exists.
+  Treat the bounded Dock PNG as one Node-level latest artifact shared by popup
+  and minimize capture: read shared memory first, then read the unrevisioned
+  persistent latest identity and exact revision in parallel. Prefer the shared
+  latest entry and promote an exact-revision fallback when used. If those
+  sources miss, serialize DOM-cloned snapshots for non-minimized background
+  nodes, yield the renderer task queue between clones, deduplicate them by
+  preview identity and revision, and write successful images to the one
+  shared-latest identity. Keep the full-resolution Genie animation texture
+  separate. Do not DOM-capture minimized nodes because their content may be
+  unhydrated. Keep an unavailable result local to the mounted popup so reopening
+  can retry after the node becomes foreground. Show a static terminal
+  placeholder instead of a loading skeleton when no successful image exists.
 - Validation:
-  Cover native-null plus persisted-cache success before DOM capture, native-null
-  plus cache-miss DOM success, and reopen the popup to prove that a prior
-  unavailable result does not block a later successful capture.
+  Cover native-null plus exact-cache promotion, shared memory and unrevisioned
+  persisted-cache reuse before DOM capture, single shared-latest writes after
+  memory or DOM success, and reopen the popup to prove that a prior unavailable
+  result does not block a later successful capture.
 - References:
   [docs/architecture/workbench-dock-model.md](../../architecture/workbench-dock-model.md)
   [WorkbenchHostDockPopup.tsx](../../../packages/workbench/surface/src/host/WorkbenchHostDockPopup.tsx)

--- a/packages/workbench/surface/src/host/WorkbenchHostDock.render.test.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDock.render.test.tsx
@@ -390,12 +390,22 @@ describe("WorkbenchHostDock", () => {
       ...createNode(),
       id: "agent-gui:unavailable-preview"
     };
+    const memoryPreviewNode = {
+      ...createNode(),
+      id: "agent-gui:memory-preview"
+    };
+    const sharedPersistedPreviewNode = {
+      ...createNode(),
+      id: "agent-gui:shared-persisted-preview"
+    };
     const secondUnavailableNode = {
       ...createNode(),
       id: "agent-gui:second-unavailable-preview"
     };
     const { host } = createDockProps([
       node,
+      memoryPreviewNode,
+      sharedPersistedPreviewNode,
       unavailableNode,
       secondUnavailableNode
     ]);
@@ -405,6 +415,8 @@ describe("WorkbenchHostDock", () => {
       >
     >(async () => null);
     const previewImageUrl = "data:image/png;base64,Q0FDSEU=";
+    const memoryPreviewImageUrl = "data:image/png;base64,TUVNT1JZ";
+    const sharedPersistedPreviewImageUrl = "data:image/png;base64,U0hBUkVE";
     const domPreviewImageUrl = "data:image/png;base64,RE9N";
     const secondDomPreviewImageUrl = "data:image/png;base64,RE9NLTI=";
     const pendingDomPreview = deferred<string>();
@@ -415,8 +427,26 @@ describe("WorkbenchHostDock", () => {
           ? pendingDomPreview.promise
           : Promise.resolve(secondDomPreviewImageUrl)
       );
-    const readPersistedPreview = vi.fn(async (key: { nodeId: string }) =>
-      key.nodeId === node.id ? previewImageUrl : null
+    genieAnimation.writeCachedWorkbenchNodePreviewImage(
+      memoryPreviewNode.id,
+      memoryPreviewImageUrl
+    );
+    const readPersistedPreview = vi.fn(
+      async (key: { nodeId: string; revision?: string | null }) => {
+        if (key.nodeId === node.id && key.revision === "revision-1") {
+          return previewImageUrl;
+        }
+        if (
+          key.nodeId === sharedPersistedPreviewNode.id &&
+          key.revision == null
+        ) {
+          return sharedPersistedPreviewImageUrl;
+        }
+        if (key.nodeId === sharedPersistedPreviewNode.id) {
+          return "data:image/png;base64,U1RBTEU=";
+        }
+        return null;
+      }
     );
     const writePersistedPreview = vi.fn();
     const container = document.createElement("div");
@@ -450,6 +480,26 @@ describe("WorkbenchHostDock", () => {
                 previewRevision: "revision-1",
                 subtitle: null,
                 title: "Agent"
+              },
+              {
+                host,
+                isFocused: false,
+                isMinimized: false,
+                node: memoryPreviewNode,
+                preview: null,
+                previewRevision: "revision-1",
+                subtitle: null,
+                title: "Memory Agent"
+              },
+              {
+                host,
+                isFocused: false,
+                isMinimized: false,
+                node: sharedPersistedPreviewNode,
+                preview: null,
+                previewRevision: "revision-1",
+                subtitle: null,
+                title: "Shared Persisted Agent"
               },
               {
                 host,
@@ -490,8 +540,8 @@ describe("WorkbenchHostDock", () => {
       });
 
       await vi.waitFor(() => {
-        expect(capturePreview).toHaveBeenCalledTimes(2);
-        expect(readPersistedPreview).toHaveBeenCalledTimes(2);
+        expect(capturePreview).toHaveBeenCalledTimes(4);
+        expect(readPersistedPreview).toHaveBeenCalledTimes(6);
         expect(captureDomPreview).toHaveBeenCalledOnce();
         expect(captureDomPreview).toHaveBeenCalledWith(unavailableNode.id, {
           bypassCache: true
@@ -499,6 +549,8 @@ describe("WorkbenchHostDock", () => {
       });
       expect(capturePreview.mock.calls.map(([item]) => item.node.id)).toEqual([
         node.id,
+        memoryPreviewNode.id,
+        sharedPersistedPreviewNode.id,
         unavailableNode.id
       ]);
 
@@ -507,14 +559,28 @@ describe("WorkbenchHostDock", () => {
       expect(captureDomPreview).toHaveBeenCalledOnce();
 
       await vi.waitFor(() => {
-        expect(capturePreview).toHaveBeenCalledTimes(3);
-        expect(readPersistedPreview).toHaveBeenCalledTimes(3);
+        expect(capturePreview).toHaveBeenCalledTimes(5);
+        expect(readPersistedPreview).toHaveBeenCalledTimes(8);
         expect(captureDomPreview).toHaveBeenCalledTimes(2);
         expect(captureDomPreview).toHaveBeenLastCalledWith(
           secondUnavailableNode.id,
           { bypassCache: true }
         );
-        expect(writePersistedPreview).toHaveBeenCalledTimes(2);
+        expect(writePersistedPreview).toHaveBeenCalledTimes(4);
+        for (const [candidate, expectedPreview] of [
+          [node, previewImageUrl],
+          [memoryPreviewNode, memoryPreviewImageUrl],
+          [unavailableNode, domPreviewImageUrl],
+          [secondUnavailableNode, secondDomPreviewImageUrl]
+        ] as const) {
+          expect(writePersistedPreview).toHaveBeenCalledWith({
+            key: expect.objectContaining({
+              nodeId: candidate.id,
+              revision: undefined
+            }),
+            previewImageUrl: expectedPreview
+          });
+        }
         expect(
           Array.from(
             document.body.querySelectorAll<HTMLImageElement>(
@@ -524,6 +590,8 @@ describe("WorkbenchHostDock", () => {
           )
         ).toEqual([
           previewImageUrl,
+          memoryPreviewImageUrl,
+          sharedPersistedPreviewImageUrl,
           domPreviewImageUrl,
           secondDomPreviewImageUrl
         ]);

--- a/packages/workbench/surface/src/host/useWorkbenchHostDockPopupPreviewCapture.ts
+++ b/packages/workbench/surface/src/host/useWorkbenchHostDockPopupPreviewCapture.ts
@@ -1,6 +1,7 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
   captureWorkbenchNodePreviewImage,
+  readCachedWorkbenchNodePreviewImage,
   writeCachedWorkbenchNodePreviewImage
 } from "../react/useWorkbenchGenieAnimation.tsx";
 import type {
@@ -273,11 +274,12 @@ export function useWorkbenchHostDockPopupPreviewCapture(input: {
               writeCachedWorkbenchNodePreviewImage(item.node.id, preview.src);
             }
             writeDockPopupPreviewImage(previewMemoryKey, preview, revision);
-            if (cacheKey && preview.kind === "image") {
-              dockPreviewCacheRef.current?.write({
-                key: cacheKey,
-                previewImageUrl: preview.src
-              });
+            if (cacheKey && preview.kind === "image" && !item.isMinimized) {
+              writeLatestPersistedDockPreview(
+                dockPreviewCacheRef.current,
+                cacheKey,
+                preview.src
+              );
             }
             setCapturedPreviewByMemoryKey((current) => ({
               ...current,
@@ -286,18 +288,35 @@ export function useWorkbenchHostDockPopupPreviewCapture(input: {
             continue;
           }
 
-          const fallbackPersistedPreview =
-            !item.isMinimized && cacheKey
-              ? await readPersistedDockPreview(
-                  dockPreviewCacheRef.current,
-                  cacheKey
-                )
-              : null;
+          const fallbackMemoryPreview = !item.isMinimized
+            ? readCachedWorkbenchNodePreviewImage(item.node.id)
+            : null;
+          const [
+            fallbackLatestPersistedPreview,
+            fallbackExactPersistedPreview
+          ] =
+            !item.isMinimized && !fallbackMemoryPreview && cacheKey
+              ? await Promise.all([
+                  readPersistedDockPreview(
+                    dockPreviewCacheRef.current,
+                    resolveLatestDockPreviewCacheKey(cacheKey)
+                  ),
+                  readPersistedDockPreview(
+                    dockPreviewCacheRef.current,
+                    cacheKey
+                  )
+                ])
+              : [null, null];
           if (!captureItemStateIsCurrent(itemStateKey)) {
             continue;
           }
           let fallbackDomPreview: string | null = null;
-          if (!item.isMinimized && !fallbackPersistedPreview) {
+          if (
+            !item.isMinimized &&
+            !fallbackMemoryPreview &&
+            !fallbackLatestPersistedPreview &&
+            !fallbackExactPersistedPreview
+          ) {
             await yieldDockPopupPreviewCaptureTask();
             if (!captureItemStateIsCurrent(itemStateKey)) {
               continue;
@@ -311,12 +330,19 @@ export function useWorkbenchHostDockPopupPreviewCapture(input: {
             continue;
           }
           const fallbackPreviewImageUrl =
-            fallbackPersistedPreview ?? fallbackDomPreview;
+            fallbackMemoryPreview ??
+            fallbackLatestPersistedPreview ??
+            fallbackExactPersistedPreview ??
+            fallbackDomPreview;
           if (fallbackPreviewImageUrl) {
-            if (fallbackPersistedPreview) {
+            if (
+              fallbackMemoryPreview ||
+              fallbackLatestPersistedPreview ||
+              fallbackExactPersistedPreview
+            ) {
               writeCachedWorkbenchNodePreviewImage(
                 item.node.id,
-                fallbackPersistedPreview
+                fallbackPreviewImageUrl
               );
             }
             const fallbackPreview: WorkbenchDockPreviewContent = {
@@ -328,11 +354,12 @@ export function useWorkbenchHostDockPopupPreviewCapture(input: {
               fallbackPreview,
               revision
             );
-            if (fallbackDomPreview && cacheKey) {
-              dockPreviewCacheRef.current?.write({
-                key: cacheKey,
-                previewImageUrl: fallbackDomPreview
-              });
+            if (cacheKey && !fallbackLatestPersistedPreview) {
+              writeLatestPersistedDockPreview(
+                dockPreviewCacheRef.current,
+                cacheKey,
+                fallbackPreviewImageUrl
+              );
             }
           }
           const fallbackPreview: WorkbenchDockPreviewContent | null =
@@ -471,6 +498,23 @@ function readPersistedDockPreview(
   return (
     dockPreviewCache?.read(cacheKey).catch(() => null) ?? Promise.resolve(null)
   );
+}
+
+function writeLatestPersistedDockPreview(
+  dockPreviewCache: WorkbenchDockPreviewCache | undefined,
+  cacheKey: WorkbenchDockPreviewCacheKey,
+  previewImageUrl: string
+): void {
+  dockPreviewCache?.write({
+    key: resolveLatestDockPreviewCacheKey(cacheKey),
+    previewImageUrl
+  });
+}
+
+function resolveLatestDockPreviewCacheKey(
+  cacheKey: WorkbenchDockPreviewCacheKey
+): WorkbenchDockPreviewCacheKey {
+  return { ...cacheKey, revision: undefined };
 }
 
 function yieldDockPopupPreviewCaptureTask(): Promise<void> {

--- a/packages/workbench/surface/src/host/useWorkbenchMinimizedDockPreview.test.tsx
+++ b/packages/workbench/surface/src/host/useWorkbenchMinimizedDockPreview.test.tsx
@@ -172,7 +172,7 @@ describe("useWorkbenchMinimizedDockPreview", () => {
     hook.unmount();
   });
 
-  it("falls back to the unrevisioned Genie cache identity", async () => {
+  it("falls back to the shared unrevisioned Dock preview identity", async () => {
     const node = createNode("genie-cache-node", 7);
     const capturePreview = vi.fn(async () => "data:image/png;base64,LIVE=");
     const dockPreviewCache = {


### PR DESCRIPTION
## Summary

- share one Node-level latest bounded Dock PNG between popup and minimize capture
- reuse memory first, then read persistent latest and exact-revision entries in parallel; prefer latest and promote exact hits
- keep the full-resolution Genie animation texture separate, and cover cache priority, promotion, persistence, and serialized DOM fallback

## Tests

- `pnpm --filter @tutti-os/workbench-surface exec vitest run ./src/host/WorkbenchHostDock.render.test.tsx ./src/host/useWorkbenchMinimizedDockPreview.test.tsx --environment jsdom` (14/14 passed)
- pre-push `pnpm check:changed -- --push-ready` (10 lanes passed)
- `pnpm perf:agent-gui -- --scenario workbench-dock-popup-preview` (two completed runs passed all 50/50 semantic preview assertions)

## Notes

- the local 50 ms performance gate was not qualified under the current concurrent Electron/GPU workload: completed traces measured 210/213 ms renderer wall time overlapping 205/207 ms GPU tasks; a final retry exited before scenario execution when the CDP websocket closed
- renderer-only cache coordination; no OS-specific path, process, filesystem, or native behavior changed, and the existing platform-neutral cache adapter remains the persistence boundary
