### PR TITLE
fix(agent-gui): normalize Windows undo patch paths

### DIFF
--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -2647,10 +2647,15 @@ inline data URL instead`. Claude or standard ACP may instead receive no
   Provider display diffs can contain syntax that a viewer tolerates but
   `git apply` rejects. Treating that display payload as executable patch data
   produces corrupt hunks. A separate failure occurs when the patch is valid
-  but later edits changed its context.
+  but later edits changed its context. On Windows, leaving an absolute drive
+  path in either a synthesized patch or an existing unified-diff header also
+  violates Git's cwd-relative patch contract and can report that an untracked
+  created file does not exist in the index.
 - Fix:
   Canonicalize provider file-change metadata at the runtime adapter boundary
   before persistence, and canonicalize historical no-newline markers on read.
+  AgentGUI must make synthesized paths and existing unified-diff headers
+  relative to the patch cwd, using case-insensitive path identity for Windows.
   The daemon must preflight with `git apply --check` using the same execution
   options, return `invalid-patch` for syntax failures and
   `patch-does-not-apply` for state mismatch, and avoid mutating the worktree on
@@ -2658,7 +2663,8 @@ inline data URL instead`. Claude or standard ACP may instead receive no
 - Validation:
   Cover leading-whitespace no-newline markers, historical activity projection,
   corrupt-patch preflight without mutation, worktree divergence, reverse
-  application, and the existing untracked-created-file behavior.
+  application, cwd-relative Windows drive paths for synthesized and complete
+  diffs, and the existing untracked-created-file behavior.
 - References:
   [claude_sdk_activity.go](../../../packages/agent/daemon/runtime/claude_sdk_activity.go)
   [agentPatchMetadata.ts](../../../packages/agent/gui/shared/agentConversation/rules/agentPatchMetadata.ts)

--- a/packages/agent/gui/shared/agentConversation/rules/agentTurnSummaryPatchDiff.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/rules/agentTurnSummaryPatchDiff.spec.ts
@@ -37,4 +37,50 @@ describe("buildAgentTurnSummaryPatchDiff", () => {
       "diff --git a/src/new.ts b/src/new.ts\nnew file mode 100644\n--- /dev/null\n+++ b/src/new.ts\n@@ -0,0 +1,1 @@\n+export const ready = true;\n"
     );
   });
+
+  it("makes Windows absolute paths relative to the patch cwd", () => {
+    const diff = buildAgentTurnSummaryPatchDiff({
+      cwd: "C:\\Users\\17940\\Documents\\tutti\\test_git",
+      toolCallId: "call-1",
+      changes: [
+        {
+          path: "C:/Users/17940/Documents/tutti/test_git/today.txt",
+          changeType: "created",
+          content: "2026-08-12\n"
+        }
+      ]
+    });
+
+    expect(diff).toBe(
+      "diff --git a/today.txt b/today.txt\nnew file mode 100644\n--- /dev/null\n+++ b/today.txt\n@@ -0,0 +1,1 @@\n+2026-08-12\n"
+    );
+  });
+
+  it("rebases Windows paths in complete unified diffs case-insensitively", () => {
+    const absolutePath = "C:/Users/17940/Documents/tutti/test_git/today.txt";
+    const diff = buildAgentTurnSummaryPatchDiff({
+      cwd: "c:/users/17940/documents/tutti/test_git",
+      toolCallId: "call-1",
+      changes: [
+        {
+          path: absolutePath,
+          changeType: "modified",
+          unifiedDiff: [
+            `diff --git a/${absolutePath} b/${absolutePath}`,
+            `--- a/${absolutePath}`,
+            `+++ b/${absolutePath}`,
+            "@@ -1,2 +1,2 @@",
+            "--- old option",
+            "+++ new option",
+            "-old",
+            "+new"
+          ].join("\n")
+        }
+      ]
+    });
+
+    expect(diff).toBe(
+      "diff --git a/today.txt b/today.txt\n--- a/today.txt\n+++ b/today.txt\n@@ -1,2 +1,2 @@\n--- old option\n+++ new option\n-old\n+new\n"
+    );
+  });
 });

--- a/packages/agent/gui/shared/agentConversation/rules/agentTurnSummaryPatchDiff.ts
+++ b/packages/agent/gui/shared/agentConversation/rules/agentTurnSummaryPatchDiff.ts
@@ -2,6 +2,10 @@ import type {
   AgentTurnSummaryPatchBatchVM,
   AgentTurnSummaryPatchChangeVM
 } from "../contracts/agentTurnSummaryRowVM";
+import {
+  isInsideOrEqualWorkspaceFilePath,
+  normalizeWorkspaceFilePath
+} from "../../../actions/workspaceFilePathCandidate";
 import { normalizeAgentPatchText } from "./agentPatchMetadata";
 import { isAgentUnifiedDiffText } from "./agentUnifiedDiffValidation";
 
@@ -22,7 +26,7 @@ function patchChangeToUnifiedDiff(
   const rawDiff = normalizeAgentPatchText(change.unifiedDiff ?? "").trim();
   if (rawDiff && isAgentUnifiedDiffText(rawDiff)) {
     return ensureTrailingNewline(
-      wrapUnifiedDiff(path, change.changeType, rawDiff)
+      wrapUnifiedDiff(path, change.changeType, rawDiff, cwd)
     );
   }
   if (change.changeType === "created") {
@@ -52,10 +56,11 @@ function patchChangeToUnifiedDiff(
 function wrapUnifiedDiff(
   path: string,
   changeType: AgentTurnSummaryPatchChangeVM["changeType"],
-  diff: string
+  diff: string,
+  cwd: string | null
 ): string {
   if (diff.startsWith("diff --git ")) {
-    return diff;
+    return rebaseUnifiedDiffPaths(diff, cwd);
   }
   const headers = [`diff --git a/${path} b/${path}`];
   if (changeType === "created") {
@@ -66,6 +71,43 @@ function wrapUnifiedDiff(
     headers.push(`--- a/${path}`, `+++ b/${path}`);
   }
   return [...headers, diff].join("\n");
+}
+
+function rebaseUnifiedDiffPaths(diff: string, cwd: string | null): string {
+  let inHunk = false;
+  return diff
+    .split("\n")
+    .map((line) => {
+      if (line.startsWith("diff --git ")) {
+        inHunk = false;
+      } else if (line.startsWith("@@ ")) {
+        inHunk = true;
+        return line;
+      } else if (inHunk) {
+        return line;
+      }
+
+      const gitHeader = line.match(/^diff --git a\/(.+?) b\/(.+)$/);
+      if (gitHeader?.[1] && gitHeader[2]) {
+        return `diff --git a/${patchPathRelativeToCwd(
+          gitHeader[1],
+          cwd
+        )} b/${patchPathRelativeToCwd(gitHeader[2], cwd)}`;
+      }
+
+      const fileHeader = line.match(/^(---|\+\+\+) ((?:a\/|b\/)?)(.+)$/);
+      const [, marker, prefix, filePath] = fileHeader ?? [];
+      if (
+        !marker ||
+        prefix === undefined ||
+        !filePath ||
+        filePath === "/dev/null"
+      ) {
+        return line;
+      }
+      return `${marker} ${prefix}${patchPathRelativeToCwd(filePath, cwd)}`;
+    })
+    .join("\n");
 }
 
 function fileContentPatch(
@@ -119,20 +161,25 @@ function modifiedFilePatch(
 }
 
 function patchPathRelativeToCwd(path: string, cwd: string | null): string {
-  const normalizedPath = normalizePathForPatch(path);
-  const normalizedCwd = normalizePathForPatch(cwd ?? "");
+  const normalizedPath = normalizeWorkspaceFilePath(path);
+  const normalizedCwd = normalizeWorkspaceFilePath(cwd ?? "");
   if (
-    normalizedPath.startsWith("/") &&
+    isAbsolutePatchPath(normalizedPath) &&
     normalizedCwd &&
-    normalizedPath.startsWith(`${normalizedCwd}/`)
+    isInsideOrEqualWorkspaceFilePath(normalizedPath, normalizedCwd)
   ) {
-    return normalizedPath.slice(normalizedCwd.length + 1);
+    const relativePath = normalizedPath
+      .slice(normalizedCwd.length)
+      .replace(/^\/+/, "");
+    if (relativePath) {
+      return relativePath;
+    }
   }
   return normalizedPath.replace(/^\/+/, "");
 }
 
-function normalizePathForPatch(path: string): string {
-  return path.trim().replaceAll("\\", "/").replace(/\/+$/, "");
+function isAbsolutePatchPath(path: string): boolean {
+  return path.startsWith("/") || /^[A-Za-z]:\//.test(path);
 }
 
 function splitPatchContentLines(content: string): string[] {


### PR DESCRIPTION
## Summary

- make Windows drive paths cwd-relative in generated AgentGUI undo patches
- rebase executable paths in complete unified-diff headers without changing hunk bodies
- add Windows regressions and document the recurring diagnostic

## Root cause

AgentGUI only treated POSIX `/...` paths as absolute when constructing executable patches. A Windows path such as `C:/Users/.../today.txt` therefore reached `git apply -R` as `a/C:/Users/.../today.txt`, so Git could not match the newly created untracked file under the patch cwd.

## Tests

- `pnpm --filter @tutti-os/agent-gui test -- shared/agentConversation/rules/agentTurnSummaryPatchDiff.spec.ts` (316 files, 2793 tests passed)
- `pnpm check:changed -- --failed-only` (12/12 lanes passed after fixing a TypeScript narrowing finding)
- `pnpm check:changed -- --push-ready` (12/12 lanes passed in the pre-push hook)

## Review

- Architecture: pass — the executable patch path remains owned by the existing AgentGUI rule; no Host lifecycle, DTO, or public API change
- Performance: pass — one linear header scan during existing per-turn patch construction; no render, subscription, layout, or logging fanout
- Consumers: pass — Desktop and standalone AgentGUI use the same rule; POSIX behavior remains covered

## Replay coverage

`tutti-replay` R27/R28 partially exercise Undo/Reapply for tracked modifications, but they do not cover the exact Windows new-untracked-file failure, assert the resulting filesystem state, or currently have qualified cassettes. No replay Case changes are included in this product fix.
