### PR TITLE
fix(agent-gui): reorder resumed conversations

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1300,9 +1300,16 @@ worktree or another detached execution directory. Path matching is reserved
 for resolving the user's explicit project selection before a new activation;
 it is not an existing-Session compatibility fallback.
 Native Mobile applies the same rule to Activity labels and Rail placement.
-Section `sessionIds` remain query ordering and hydration data; if their section
-disagrees with a Session's canonical `railSectionKey`, Mobile rehomes the row by
-the Session key instead of accepting the stale membership.
+Section `sessionIds` remain query membership, page-boundary, initial-order, and
+hydration data. After joining those memberships to current Engine entities,
+hosts sort loaded ordinary sections by the canonical conversation sort key:
+the latest Turn start time, falling back to Session creation time. Streaming
+freshness, status, and completion updates do not change that key, so parallel
+running Turns do not churn Rail positions. Pinned sections preserve the query's
+pinned order. If a section disagrees with a Session's canonical
+`railSectionKey`, the host rehomes the row by the Session key instead of
+accepting the stale membership; presentation reordering must not mutate cached
+memberships or pagination cursors.
 
 Cross-platform hosts may also reuse the DOM-free canonical transcript
 projection from `@tutti-os/agent-gui/conversation-projection`. It accepts the

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.spec.ts
@@ -379,6 +379,87 @@ describe("projectConversationRailMemberships", () => {
 
     expect(projected[0]?.items.map((item) => item.id)).toEqual(["exact"]);
   });
+
+  it("reorders loaded ordinary rows from current turn sort times", () => {
+    const previouslyRecent = {
+      ...conversation("previously-recent"),
+      sortTimeUnixMs: 100
+    };
+    const continuedHistorical = {
+      ...conversation("continued-historical"),
+      sortTimeUnixMs: 200
+    };
+
+    const projected = projectConversationRailMemberships({
+      conversations: [previouslyRecent, continuedHistorical],
+      labels: railLabels,
+      sections: membership([previouslyRecent, continuedHistorical])
+    });
+
+    expect(projected[0]?.items.map((item) => item.id)).toEqual([
+      "continued-historical",
+      "previously-recent"
+    ]);
+  });
+
+  it("keeps ordinary row order stable when only streaming freshness changes", () => {
+    const first = {
+      ...conversation("first"),
+      sortTimeUnixMs: 200,
+      updatedAtUnixMs: 1
+    };
+    const second = {
+      ...conversation("second"),
+      sortTimeUnixMs: 100,
+      updatedAtUnixMs: 2
+    };
+    const sections = membership([first, second]);
+
+    const projected = projectConversationRailMemberships({
+      conversations: [
+        { ...first, updatedAtUnixMs: 3 },
+        { ...second, updatedAtUnixMs: 4 }
+      ],
+      labels: railLabels,
+      sections
+    });
+
+    expect(projected[0]?.items.map((item) => item.id)).toEqual([
+      "first",
+      "second"
+    ]);
+  });
+
+  it("preserves daemon-owned pinned membership order", () => {
+    const first = {
+      ...conversation("pinned-first", 10),
+      railSectionKey: "conversations",
+      sortTimeUnixMs: 100
+    };
+    const second = {
+      ...conversation("pinned-second", 20),
+      railSectionKey: "conversations",
+      sortTimeUnixMs: 200
+    };
+
+    const projected = projectConversationRailMemberships({
+      conversations: [first, second],
+      labels: railLabels,
+      sections: [
+        {
+          id: "pinned",
+          kind: "pinned",
+          project: null,
+          sessionIds: [first.id, second.id]
+        }
+      ]
+    });
+
+    expect(projected[0]?.items.map((item) => item.id)).toEqual([
+      "pinned-first",
+      "pinned-second"
+    ]);
+  });
 });
 
 describe("projectConversationRailSectionsWithTransientConversations", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.ts
@@ -470,17 +470,8 @@ export function projectConversationRailMemberships(input: {
       (conversation) => [conversation.id, conversation] as const
     )
   );
-  return input.sections.map((section) => ({
-    id: section.id,
-    kind: section.kind,
-    label:
-      section.kind === "pinned"
-        ? input.labels.sectionPinned
-        : section.kind === "project"
-          ? (section.project?.label ?? section.id)
-          : input.labels.sectionConversations,
-    project: section.project,
-    items: section.sessionIds.flatMap((id) => {
+  return input.sections.map((section) => {
+    const items = section.sessionIds.flatMap((id) => {
       const conversation = conversationsById.get(id);
       if (!conversation) return [];
       const exactSectionId = conversationRailSectionId(conversation);
@@ -490,8 +481,20 @@ export function projectConversationRailMemberships(input: {
           ? { ...conversation, project: section.project }
           : { ...conversation, project: null }
       ];
-    })
-  }));
+    });
+    return {
+      id: section.id,
+      kind: section.kind,
+      label:
+        section.kind === "pinned"
+          ? input.labels.sectionPinned
+          : section.kind === "project"
+            ? (section.project?.label ?? section.id)
+            : input.labels.sectionConversations,
+      project: section.project,
+      items: section.kind === "pinned" ? items : sortConversations(items)
+    };
+  });
 }
 
 export function projectConversationRailSearchSections(input: {


### PR DESCRIPTION
## Summary
- reorder loaded ordinary conversation Rail rows from current canonical Turn sort times
- keep streaming freshness updates position-stable and preserve daemon-owned pinned order
- document the Rail membership versus presentation-order contract

## Tests
- `pnpm check:changed -- --push-ready`

## Notes
- Windows impact: platform-neutral numeric sorting only; no path, filesystem, process, or shell behavior changes
- ordinary rows move when a new Turn starts, not on streaming status or completion updates
