### PR TITLE
fix(agent-activity): bound structured tool payloads

### DIFF
--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -66,6 +66,21 @@ that classification. Replication and read contracts continue to accept a
 missing value from older stored messages, so compatibility stays at the read
 boundary instead of being inferred by presentation code.
 
+Canonical tool-call persistence also owns the replication-safe payload budget.
+Provider `content` is projected into the formal output fields before MCP
+`structuredContent` is normalized: exact string leaves that duplicate
+`output.text` keep their map key or array position with an explicit duplicate
+marker, while other structured string leaves are deterministically and
+UTF-8-safely shortened with the standard truncation marker. Inputs and
+non-string structured values are never shortened. The final encoded payload
+must fit the 768 KiB canonical budget; if required data alone cannot fit, the
+write returns an error and the transaction does not persist an unsynchronizable
+message. A versioned store migration applies the same projection to retained
+oversized tool calls, including MCP messages, and updates a row only after its
+encoded replacement satisfies the budget. Replication consumers derive a new
+fingerprint and mutation identity from that physical repair, which clears any
+retry schedule tied to the obsolete oversized representation.
+
 ## Responsibilities
 
 ### `packages/agent/host`

--- a/packages/agent/store-sqlite/activity_messages.go
+++ b/packages/agent/store-sqlite/activity_messages.go
@@ -59,7 +59,7 @@ func (*Store) upsertAgentMessageTx(
 	if err != nil {
 		return Message{}, false, false, fmt.Errorf("normalize workspace agent message payload: %w", err)
 	}
-	message, accepted := agentactivityprojection.ProjectMessageUpdate(
+	message, accepted, err := agentactivityprojection.ProjectMessageUpdateChecked(
 		messageProjectionSnapshot(existing),
 		ok,
 		agentactivityprojection.MessageUpdate{
@@ -77,6 +77,9 @@ func (*Store) upsertAgentMessageTx(
 		0,
 		now,
 	)
+	if err != nil {
+		return Message{}, false, false, fmt.Errorf("project workspace agent message: %w", err)
+	}
 	if !accepted {
 		return Message{}, false, false, nil
 	}

--- a/packages/agent/store-sqlite/canonical/projection.go
+++ b/packages/agent/store-sqlite/canonical/projection.go
@@ -324,9 +324,22 @@ func ProjectMessageUpdate(
 	version uint64,
 	nowUnixMS int64,
 ) (MessageSnapshot, bool) {
+	message, accepted, _ := ProjectMessageUpdateChecked(existing, hasExisting, update, version, nowUnixMS)
+	return message, accepted
+}
+
+// ProjectMessageUpdateChecked projects one update while surfacing canonical
+// tool payload budget failures to persistence callers.
+func ProjectMessageUpdateChecked(
+	existing MessageSnapshot,
+	hasExisting bool,
+	update MessageUpdate,
+	version uint64,
+	nowUnixMS int64,
+) (MessageSnapshot, bool, error) {
 	messageID := strings.TrimSpace(update.MessageID)
 	if messageID == "" {
-		return MessageSnapshot{}, false
+		return MessageSnapshot{}, false, nil
 	}
 	message := MessageSnapshot{
 		MessageID:         messageID,
@@ -349,7 +362,7 @@ func ProjectMessageUpdate(
 		if message.TurnID == "" {
 			message.TurnID = existing.TurnID
 		} else if existingTurnID := strings.TrimSpace(existing.TurnID); existingTurnID != "" && message.TurnID != existingTurnID {
-			return MessageSnapshot{}, false
+			return MessageSnapshot{}, false, nil
 		}
 		if message.Role == "" {
 			message.Role = existing.Role
@@ -386,12 +399,16 @@ func ProjectMessageUpdate(
 	}
 	message.Payload = clearStaleToolPayloadForStatus(message.Kind, message.Status, message.Payload)
 	if strings.TrimSpace(message.Kind) == "tool_call" {
-		message.Payload = CompactToolCallPayload(message.Status, message.Payload)
+		compacted, err := CompactToolCallPayloadChecked(message.Status, message.Payload)
+		if err != nil {
+			return MessageSnapshot{}, false, err
+		}
+		message.Payload = compacted
 	}
 	if message.Payload == nil {
 		message.Payload = map[string]any{}
 	}
-	return message, true
+	return message, true, nil
 }
 
 func clearStaleToolPayloadForStatus(kind string, status string, payload map[string]any) map[string]any {

--- a/packages/agent/store-sqlite/canonical/tool_output_truncation.go
+++ b/packages/agent/store-sqlite/canonical/tool_output_truncation.go
@@ -2,6 +2,7 @@ package canonical
 
 import (
 	"encoding/json"
+	"sort"
 	"strings"
 	"unicode/utf8"
 )
@@ -13,11 +14,86 @@ const (
 	// replication request limit for mutation identity, scope, and batch framing.
 	ToolCallPayloadMaxBytes = 768 << 10
 	// ToolOutputTruncationMarker identifies a tool output prefix with omitted bytes.
-	ToolOutputTruncationMarker    = "[Output truncated]"
-	toolOutputTruncationSeparator = "\n"
+	ToolOutputTruncationMarker = "[Output truncated]"
+	// ToolStructuredContentDuplicateTextMarker replaces a structured string
+	// leaf that can be reconstructed exactly from its containing output text.
+	ToolStructuredContentDuplicateTextMarker = "[Duplicate of output.text omitted]"
+	toolOutputTruncationSeparator            = "\n"
 )
 
 var truncatedToolOutputTextKeys = [...]string{"text", "stdout", "stderr"}
+
+// CompactToolStructuredContentAliases replaces exact string duplicates of a
+// containing output.text with an explicit canonical reference marker. Map
+// keys and array positions are retained so business-relevant structure stays
+// stable while reconstructible provider duplication is removed.
+func CompactToolStructuredContentAliases(payload map[string]any) bool {
+	changed := false
+	var compactBody func(any)
+	var compactSteps func(any)
+	var replaceDuplicates func(any, string)
+
+	replaceDuplicates = func(value any, duplicate string) {
+		switch typed := value.(type) {
+		case map[string]any:
+			keys := make([]string, 0, len(typed))
+			for key := range typed {
+				keys = append(keys, key)
+			}
+			sort.Strings(keys)
+			for _, key := range keys {
+				if text, ok := typed[key].(string); ok && text == duplicate {
+					typed[key] = ToolStructuredContentDuplicateTextMarker
+					changed = true
+					continue
+				}
+				replaceDuplicates(typed[key], duplicate)
+			}
+		case []any:
+			for index := range typed {
+				if text, ok := typed[index].(string); ok && text == duplicate {
+					typed[index] = ToolStructuredContentDuplicateTextMarker
+					changed = true
+					continue
+				}
+				replaceDuplicates(typed[index], duplicate)
+			}
+		}
+	}
+	compactBody = func(value any) {
+		body, _ := value.(map[string]any)
+		if len(body) == 0 {
+			return
+		}
+		if text, ok := body["text"].(string); ok && text != "" {
+			if structured, ok := body["structuredContent"].(string); ok && structured == text {
+				body["structuredContent"] = ToolStructuredContentDuplicateTextMarker
+				changed = true
+			} else {
+				replaceDuplicates(body["structuredContent"], text)
+			}
+		}
+		compactSteps(body["steps"])
+	}
+	compactSteps = func(value any) {
+		steps, _ := value.([]any)
+		for _, item := range steps {
+			step, _ := item.(map[string]any)
+			if len(step) == 0 {
+				continue
+			}
+			for _, key := range []string{"toolResult", "toolError", "output", "error"} {
+				compactBody(step[key])
+			}
+			compactSteps(step["steps"])
+		}
+	}
+
+	compactBody(payload["output"])
+	compactBody(payload["error"])
+	compactSteps(payload["steps"])
+	return changed
+}
 
 // TruncateToolOutputText bounds one canonical tool output field while
 // preserving a valid UTF-8 prefix and an explicit truncation marker.
@@ -61,16 +137,17 @@ func truncateToolOutputTextToBytes(value string, maxBytes int) string {
 }
 
 type toolOutputTextField struct {
-	body     map[string]any
-	key      string
 	original string
+	set      func(string)
+	current  func() string
 }
 
 // FitToolCallPayloadOutputBudget bounds the encoded canonical tool payload by
-// fairly reducing only formal output/error text streams. It preserves inputs
-// and structured fields, emits the standard truncation marker, and reports
-// both whether a field changed and whether the final encoded payload fits.
-// A false fits result means non-textual payload data alone exceeds the budget.
+// fairly reducing formal output/error text streams and string leaves inside
+// structuredContent. It preserves inputs and non-string structured values,
+// emits the standard truncation marker, and reports both whether a field
+// changed and whether the final encoded payload fits. A false fits result
+// means required input or non-string structured data alone exceeds the budget.
 func FitToolCallPayloadOutputBudget(
 	payload map[string]any,
 	maxBytes int,
@@ -82,17 +159,17 @@ func FitToolCallPayloadOutputBudget(
 	if err != nil {
 		return false, false
 	}
-	fields := collectToolOutputTextFields(payload)
+	fields := collectToolOutputBudgetStringFields(payload)
 	if len(fields) == 0 {
 		return false, len(encoded) <= maxBytes
 	}
 
 	applyCap := func(capBytes int) {
 		for _, field := range fields {
-			field.body[field.key] = truncateToolOutputTextToBytes(
+			field.set(truncateToolOutputTextToBytes(
 				field.original,
 				capBytes,
-			)
+			))
 		}
 	}
 	encodedSize := func() (int, bool) {
@@ -101,7 +178,7 @@ func FitToolCallPayloadOutputBudget(
 	}
 	changed := func() bool {
 		for _, field := range fields {
-			if field.body[field.key] != field.original {
+			if field.current() != field.original {
 				return true
 			}
 		}
@@ -117,10 +194,10 @@ func FitToolCallPayloadOutputBudget(
 	applyCap(minimumCap)
 	if size, ok := encodedSize(); !ok || size > maxBytes {
 		for _, field := range fields {
-			field.body[field.key] = truncateToolOutputTextToBytes(
+			field.set(truncateToolOutputTextToBytes(
 				field.original,
 				ToolOutputTextMaxBytes,
-			)
+			))
 		}
 		return changed(), false
 	}
@@ -142,10 +219,47 @@ func FitToolCallPayloadOutputBudget(
 	return changed(), true
 }
 
-func collectToolOutputTextFields(payload map[string]any) []toolOutputTextField {
+func collectToolOutputBudgetStringFields(payload map[string]any) []toolOutputTextField {
 	fields := make([]toolOutputTextField, 0, 4)
 	var collectBody func(any)
 	var collectSteps func(any)
+	var collectStructuredContent func(any)
+
+	collectStructuredContent = func(value any) {
+		switch typed := value.(type) {
+		case map[string]any:
+			keys := make([]string, 0, len(typed))
+			for key := range typed {
+				keys = append(keys, key)
+			}
+			sort.Strings(keys)
+			for _, key := range keys {
+				if text, ok := typed[key].(string); ok {
+					body, fieldKey := typed, key
+					fields = append(fields, toolOutputTextField{
+						original: text,
+						set:      func(value string) { body[fieldKey] = value },
+						current:  func() string { value, _ := body[fieldKey].(string); return value },
+					})
+					continue
+				}
+				collectStructuredContent(typed[key])
+			}
+		case []any:
+			for index := range typed {
+				if text, ok := typed[index].(string); ok {
+					values, fieldIndex := typed, index
+					fields = append(fields, toolOutputTextField{
+						original: text,
+						set:      func(value string) { values[fieldIndex] = value },
+						current:  func() string { value, _ := values[fieldIndex].(string); return value },
+					})
+					continue
+				}
+				collectStructuredContent(typed[index])
+			}
+		}
+	}
 
 	collectBody = func(value any) {
 		body, _ := value.(map[string]any)
@@ -154,11 +268,15 @@ func collectToolOutputTextFields(payload map[string]any) []toolOutputTextField {
 		}
 		for _, key := range truncatedToolOutputTextKeys {
 			if text, ok := body[key].(string); ok {
+				fieldBody, fieldKey := body, key
 				fields = append(fields, toolOutputTextField{
-					body: body, key: key, original: text,
+					original: text,
+					set:      func(value string) { fieldBody[fieldKey] = value },
+					current:  func() string { value, _ := fieldBody[fieldKey].(string); return value },
 				})
 			}
 		}
+		collectStructuredContent(body["structuredContent"])
 		collectSteps(body["steps"])
 		if metadata, _ := body["metadata"].(map[string]any); metadata != nil {
 			collectSteps(metadata["steps"])

--- a/packages/agent/store-sqlite/canonical/tool_output_truncation_test.go
+++ b/packages/agent/store-sqlite/canonical/tool_output_truncation_test.go
@@ -75,9 +75,10 @@ func TestCompactToolCallPayloadLimitsOutputErrorAndStepBodiesWithoutChangingInpu
 	t.Parallel()
 
 	large := strings.Repeat("x", ToolOutputTextMaxBytes+64)
+	inputText := "preserved input"
 	got := CompactToolCallPayload("failed", map[string]any{
 		"callId": "call-1",
-		"input":  map[string]any{"text": large},
+		"input":  map[string]any{"text": inputText},
 		"output": map[string]any{"text": large, "stdout": large},
 		"error":  map[string]any{"text": large, "stderr": large},
 		"steps": []any{
@@ -90,7 +91,7 @@ func TestCompactToolCallPayloadLimitsOutputErrorAndStepBodiesWithoutChangingInpu
 		},
 	})
 
-	if got["input"].(map[string]any)["text"] != large {
+	if got["input"].(map[string]any)["text"] != inputText {
 		t.Fatal("tool input was truncated")
 	}
 	assertTruncatedToolTextFields(t, got["output"].(map[string]any), "text", "stdout")

--- a/packages/agent/store-sqlite/canonical/tool_payload.go
+++ b/packages/agent/store-sqlite/canonical/tool_payload.go
@@ -1,9 +1,30 @@
 package canonical
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 )
+
+var ErrToolCallPayloadTooLarge = errors.New("canonical tool call payload exceeds byte budget")
+
+// ToolCallPayloadBudgetError reports a canonical payload that cannot fit even
+// after every truncatable output string has been reduced to its marker.
+type ToolCallPayloadBudgetError struct {
+	EncodedBytes int
+	MaxBytes     int
+}
+
+func (e *ToolCallPayloadBudgetError) Error() string {
+	return fmt.Sprintf("%v: encoded bytes=%d max bytes=%d", ErrToolCallPayloadTooLarge, e.EncodedBytes, e.MaxBytes)
+}
+
+func (*ToolCallPayloadBudgetError) Unwrap() error { return ErrToolCallPayloadTooLarge }
+
+func IsToolCallPayloadTooLarge(err error) bool {
+	return errors.Is(err, ErrToolCallPayloadTooLarge)
+}
 
 var canonicalToolPayloadKeys = map[string]struct{}{
 	"activityKind":    {},
@@ -121,10 +142,19 @@ var canonicalToolMetadataKeys = map[string]struct{}{
 }
 
 // CompactToolCallPayload turns provider-shaped tool data into the canonical
-// stored business projection; accepted provider envelopes are never retained.
+// stored business projection. Callers that persist its result must use
+// CompactToolCallPayloadChecked so an impossible budget is not ignored.
 func CompactToolCallPayload(status string, payload map[string]any) map[string]any {
+	result, _ := CompactToolCallPayloadChecked(status, payload)
+	return result
+}
+
+// CompactToolCallPayloadChecked returns an error instead of allowing a
+// replication-unsafe payload to be persisted when required non-truncatable
+// data alone exceeds the byte budget.
+func CompactToolCallPayloadChecked(status string, payload map[string]any) (map[string]any, error) {
 	if len(payload) == 0 {
-		return payload
+		return payload, nil
 	}
 
 	result := cloneToolMap(payload)
@@ -198,6 +228,11 @@ func CompactToolCallPayload(status string, payload map[string]any) map[string]an
 		compactTerminalCommandBodyAlias(output)
 		compactTerminalCommandBodyAlias(toolError)
 	}
+	CompactToolStructuredContentAliases(map[string]any{
+		"output": output,
+		"error":  toolError,
+		"steps":  steps,
+	})
 	if output != nil {
 		delete(output, "content")
 		output = TruncateToolOutputBody(selectToolKeys(output, canonicalToolBodyKeys))
@@ -231,8 +266,19 @@ func CompactToolCallPayload(status string, payload map[string]any) map[string]an
 
 	result = selectToolKeys(result, canonicalToolPayloadKeys)
 	CompactTerminalCommandOutputAliases(status, result)
-	FitToolCallPayloadOutputBudget(result, ToolCallPayloadMaxBytes)
-	return result
+	CompactToolStructuredContentAliases(result)
+	_, fits := FitToolCallPayloadOutputBudget(result, ToolCallPayloadMaxBytes)
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("encode canonical tool call payload: %w", err)
+	}
+	if !fits || len(encoded) > ToolCallPayloadMaxBytes {
+		return nil, &ToolCallPayloadBudgetError{
+			EncodedBytes: len(encoded),
+			MaxBytes:     ToolCallPayloadMaxBytes,
+		}
+	}
+	return result, nil
 }
 
 func compactToolSteps(value any) []any {

--- a/packages/agent/store-sqlite/canonical/tool_payload_test.go
+++ b/packages/agent/store-sqlite/canonical/tool_payload_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestCompactToolCallPayloadKeepsBusinessProjectionWithoutProviderEnvelopes(t *testing.T) {
@@ -601,7 +602,7 @@ func TestProjectMessageUpdateCompactsToolPayloadBeforePersistence(t *testing.T) 
 		},
 	}, 1, 100)
 	if !ok {
-		t.Fatal("ProjectMessageUpdate() rejected tool message")
+		t.Fatal("(ProjectMessageUpdate()) rejected tool message")
 	}
 	if _, exists := message.Payload["content"]; exists {
 		t.Fatalf("payload.content retained: %#v", message.Payload)
@@ -612,5 +613,95 @@ func TestProjectMessageUpdateCompactsToolPayloadBeforePersistence(t *testing.T) 
 	}
 	if _, exists := output["toolResponse"]; exists {
 		t.Fatalf("output.toolResponse retained: %#v", output)
+	}
+}
+
+func TestCompactToolCallPayloadDeduplicatesMCPStructuredContentAndFitsBudget(t *testing.T) {
+	large := strings.Repeat("node-repl-output-", 1<<16)
+	payload := map[string]any{
+		"toolName": "node_repl.js",
+		"input":    map[string]any{"code": "return value"},
+		"content":  []any{map[string]any{"type": "text", "text": large}},
+		"output": map[string]any{
+			"structuredContent": map[string]any{
+				"result": large,
+				"meta":   map[string]any{"count": json.Number("9007199254740993")},
+			},
+		},
+	}
+
+	got, err := CompactToolCallPayloadChecked("completed", payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(encoded) > ToolCallPayloadMaxBytes {
+		t.Fatalf("canonical payload has %d bytes, want at most %d", len(encoded), ToolCallPayloadMaxBytes)
+	}
+	output := got["output"].(map[string]any)
+	if output["structuredContent"].(map[string]any)["result"] != ToolStructuredContentDuplicateTextMarker {
+		t.Fatalf("structured content did not retain duplicate marker: %#v", output)
+	}
+	if !strings.HasSuffix(output["text"].(string), ToolOutputTruncationMarker) {
+		t.Fatalf("projected text did not retain truncation marker: %#v", output["text"])
+	}
+	if payload["output"].(map[string]any)["structuredContent"].(map[string]any)["result"] != large {
+		t.Fatal("input payload was mutated")
+	}
+}
+
+func TestCompactToolCallPayloadFairlyTruncatesNestedStructuredStringsUTF8(t *testing.T) {
+	large := strings.Repeat("界", ToolCallPayloadMaxBytes/2)
+	got, err := CompactToolCallPayloadChecked("completed", map[string]any{
+		"toolName": "node_repl.js",
+		"input":    map[string]any{"code": "preserve me"},
+		"output": map[string]any{
+			"structuredContent": map[string]any{
+				"first": large,
+				"nested": map[string]any{
+					"second": large,
+					"items":  []any{large, map[string]any{"third": large}},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !utf8.Valid(encoded) || len(encoded) > ToolCallPayloadMaxBytes {
+		t.Fatalf("encoded payload valid=%t bytes=%d", utf8.Valid(encoded), len(encoded))
+	}
+	structured := got["output"].(map[string]any)["structuredContent"].(map[string]any)
+	values := []string{
+		structured["first"].(string),
+		structured["nested"].(map[string]any)["second"].(string),
+		structured["nested"].(map[string]any)["items"].([]any)[0].(string),
+		structured["nested"].(map[string]any)["items"].([]any)[1].(map[string]any)["third"].(string),
+	}
+	for _, value := range values {
+		if !utf8.ValidString(value) || !strings.HasSuffix(value, ToolOutputTruncationMarker) {
+			t.Fatalf("structured string is not UTF-8 safe with marker: %q", value[len(value)-64:])
+		}
+	}
+	if got["input"].(map[string]any)["code"] != "preserve me" {
+		t.Fatal("tool input changed")
+	}
+}
+
+func TestCompactToolCallPayloadRejectsRequiredDataOverBudget(t *testing.T) {
+	_, err := CompactToolCallPayloadChecked("completed", map[string]any{
+		"toolName": "node_repl.js",
+		"input":    map[string]any{"code": strings.Repeat("x", ToolCallPayloadMaxBytes)},
+		"output":   map[string]any{"structuredContent": map[string]any{"count": 1}},
+	})
+	if !IsToolCallPayloadTooLarge(err) {
+		t.Fatalf("error = %v, want tool payload budget error", err)
 	}
 }

--- a/packages/agent/store-sqlite/migrations.go
+++ b/packages/agent/store-sqlite/migrations.go
@@ -88,6 +88,7 @@ const schemaMigrationWorkspaceAgentProviderTurnBindingJSONV1 = "workspace_agent_
 const schemaMigrationWorkspaceAgentRecoverableDeletionV1 = "workspace_agent_recoverable_deletion_v1"
 const schemaMigrationWorkspaceAgentTurnIdentityAnchorV1 = "workspace_agent_turn_identity_anchor_v1"
 const schemaMigrationWorkspaceAgentCommandOutputAliasesV1 = "workspace_agent_command_output_aliases_v1"
+const schemaMigrationWorkspaceAgentToolPayloadBudgetV1 = "workspace_agent_tool_payload_budget_v1"
 
 // claimableMigrationIDs are the migration IDs that may already be recorded
 // in the legacy tuttid ledger; the claim copies exactly these.
@@ -322,6 +323,9 @@ CREATE TABLE IF NOT EXISTS `+schemaMigrationsTable+` (
 		return err
 	}
 	if err := s.applyWorkspaceAgentCommandOutputAliasesV1(ctx); err != nil {
+		return err
+	}
+	if err := s.applyWorkspaceAgentToolPayloadBudgetV1(ctx); err != nil {
 		return err
 	}
 	return s.applyWorkspaceAgentActivityRailV2(ctx)

--- a/packages/agent/store-sqlite/migrations_tool_payload_budget.go
+++ b/packages/agent/store-sqlite/migrations_tool_payload_budget.go
@@ -1,0 +1,97 @@
+package storesqlite
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
+)
+
+// applyWorkspaceAgentToolPayloadBudgetV1 reprojects every oversized retained
+// tool call, including MCP results. Rows are updated only when the canonical
+// representation encodes within the replication-safe payload budget. Logical
+// message versions and timestamps remain unchanged; downstream replication
+// derives a new fingerprint and mutation identity from the repaired row.
+func (s *Store) applyWorkspaceAgentToolPayloadBudgetV1(ctx context.Context) error {
+	const migrationID = schemaMigrationWorkspaceAgentToolPayloadBudgetV1
+	applied, err := s.hasMigration(ctx, migrationID)
+	if err != nil || applied {
+		return err
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin workspace agent tool payload budget migration: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	rows, err := tx.QueryContext(ctx, `
+SELECT id, status, payload_json
+FROM workspace_agent_messages
+WHERE kind = 'tool_call'
+  AND length(CAST(payload_json AS BLOB)) > ?
+ORDER BY id
+`, canonical.ToolCallPayloadMaxBytes)
+	if err != nil {
+		return fmt.Errorf("select oversized workspace agent tool payloads: %w", err)
+	}
+	type candidate struct {
+		id          int64
+		status      string
+		payloadJSON string
+	}
+	candidates := make([]candidate, 0)
+	for rows.Next() {
+		var item candidate
+		if err := rows.Scan(&item.id, &item.status, &item.payloadJSON); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan oversized workspace agent tool payload: %w", err)
+		}
+		candidates = append(candidates, item)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("iterate oversized workspace agent tool payloads: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close oversized workspace agent tool payloads: %w", err)
+	}
+
+	for _, item := range candidates {
+		var payload map[string]any
+		decoder := json.NewDecoder(strings.NewReader(item.payloadJSON))
+		decoder.UseNumber()
+		if err := decoder.Decode(&payload); err != nil {
+			return fmt.Errorf("decode workspace agent tool payload row %d: %w", item.id, err)
+		}
+		compacted, err := canonical.CompactToolCallPayloadChecked(item.status, payload)
+		if err != nil {
+			if canonical.IsToolCallPayloadTooLarge(err) {
+				continue
+			}
+			return fmt.Errorf("compact workspace agent tool payload row %d: %w", item.id, err)
+		}
+		encoded, err := json.Marshal(compacted)
+		if err != nil {
+			return fmt.Errorf("encode workspace agent tool payload row %d: %w", item.id, err)
+		}
+		if len(encoded) > canonical.ToolCallPayloadMaxBytes || string(encoded) == item.payloadJSON {
+			continue
+		}
+		if _, err := tx.ExecContext(ctx, `
+UPDATE workspace_agent_messages SET payload_json = ? WHERE id = ? AND payload_json = ?
+`, string(encoded), item.id, item.payloadJSON); err != nil {
+			return fmt.Errorf("update workspace agent tool payload row %d: %w", item.id, err)
+		}
+	}
+
+	if err := recordMigrationTx(ctx, tx, migrationID); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit workspace agent tool payload budget migration: %w", err)
+	}
+	return nil
+}

--- a/packages/agent/store-sqlite/migrations_tool_payload_budget_test.go
+++ b/packages/agent/store-sqlite/migrations_tool_payload_budget_test.go
@@ -1,0 +1,102 @@
+package storesqlite
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/tutti-os/tutti/packages/agent/store-sqlite/canonical"
+)
+
+func TestToolPayloadBudgetMigrationCompactsOversizedMCPMessages(t *testing.T) {
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	ctx := context.Background()
+	if _, err := store.ReportSessionState(ctx, SessionStateReport{
+		WorkspaceID: "ws-mcp-budget", AgentSessionID: "session-mcp-budget",
+		Provider: "codex", OccurredAtUnixMS: 10,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	large := strings.Repeat("node-repl-output-", 1<<16)
+	fixtures := []struct {
+		messageID string
+		payload   map[string]any
+	}{
+		{
+			messageID: "mcp-duplicate",
+			payload: map[string]any{
+				"toolName": "node_repl.js",
+				"input":    map[string]any{"code": "return value"},
+				"output": map[string]any{
+					"text": large,
+					"structuredContent": map[string]any{
+						"result": large,
+						"meta":   map[string]any{"necessary": true},
+					},
+				},
+			},
+		},
+		{
+			messageID: "required-input-too-large",
+			payload: map[string]any{
+				"toolName": "node_repl.js",
+				"input":    map[string]any{"code": strings.Repeat("x", canonical.ToolCallPayloadMaxBytes)},
+				"output":   map[string]any{"structuredContent": map[string]any{"necessary": true}},
+			},
+		},
+	}
+	original := make(map[string]string, len(fixtures))
+	for index, fixture := range fixtures {
+		encoded, err := json.Marshal(fixture.payload)
+		if err != nil {
+			t.Fatal(err)
+		}
+		original[fixture.messageID] = string(encoded)
+		if _, err := store.db.ExecContext(ctx, `
+INSERT INTO workspace_agent_messages (
+  workspace_id, agent_session_id, message_id, version, role, kind, status,
+  payload_json, occurred_at_unix_ms, created_at_unix_ms, updated_at_unix_ms
+) VALUES ('ws-mcp-budget', 'session-mcp-budget', ?, ?, 'assistant', 'tool_call',
+          'completed', ?, 20, 20, 20)
+`, fixture.messageID, index+1, string(encoded)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := store.db.ExecContext(ctx, `DELETE FROM agent_store_schema_migrations WHERE id=?`, schemaMigrationWorkspaceAgentToolPayloadBudgetV1); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	var compacted string
+	if err := store.db.QueryRowContext(ctx, `SELECT payload_json FROM workspace_agent_messages WHERE message_id='mcp-duplicate'`).Scan(&compacted); err != nil {
+		t.Fatal(err)
+	}
+	if len(compacted) > canonical.ToolCallPayloadMaxBytes || compacted == original["mcp-duplicate"] {
+		t.Fatalf("compacted bytes=%d changed=%t", len(compacted), compacted != original["mcp-duplicate"])
+	}
+	if !strings.Contains(compacted, canonical.ToolStructuredContentDuplicateTextMarker) ||
+		!strings.Contains(compacted, canonical.ToolOutputTruncationMarker) {
+		t.Fatalf("compacted MCP payload lacks canonical markers: %s", compacted[:256])
+	}
+	var unchanged string
+	if err := store.db.QueryRowContext(ctx, `SELECT payload_json FROM workspace_agent_messages WHERE message_id='required-input-too-large'`).Scan(&unchanged); err != nil {
+		t.Fatal(err)
+	}
+	if unchanged != original["required-input-too-large"] {
+		t.Fatal("migration updated a row that could not satisfy the budget")
+	}
+	if err := store.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	var repeated string
+	if err := store.db.QueryRowContext(ctx, `SELECT payload_json FROM workspace_agent_messages WHERE message_id='mcp-duplicate'`).Scan(&repeated); err != nil {
+		t.Fatal(err)
+	}
+	if repeated != compacted {
+		t.Fatal("idempotent migration changed compacted payload")
+	}
+}


### PR DESCRIPTION
## What changed
- canonicalize MCP structuredContent by removing exact output.text duplicates while preserving structure
- apply deterministic UTF-8-safe truncation across nested structured strings and enforce the 768 KiB encoded payload budget
- reject new tool messages whose required data cannot fit instead of persisting unsynchronizable mutations
- migrate retained oversized MCP tool messages so replication rebuilds them with a new fingerprint and mutation identity

## Why
A node_repl.js result could retain the same roughly 1 MiB value in output.text and structuredContent, producing a roughly 2 MiB Agent Activity mutation that retried HTTP 413 indefinitely.

## Risk
The affected surface is canonical tool-call persistence and historical message migration. Inputs and non-string structured values are preserved; rows that still cannot satisfy the budget are not rewritten.

## Verification
- pnpm check:changed
- pnpm check:changed -- --push-ready
- go test ./... in packages/agent/store-sqlite
- pnpm check:full preparation and 21 preflight tasks passed; full Go lint is baseline-red on unrelated bare http.Client literals in services/tuttid/service/mobileremote/relay_control_plane.go and packages/agent/runtimeprep/mutagen_auth.go