### PR TITLE
feat(connector): add declarative authorization interactions

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,6 +11,7 @@
       "@tutti-os/analytics",
       "@tutti-os/analytics-debug",
       "@tutti-os/event-stream-core",
+      "@tutti-os/connector-authorization-protocol",
       "@tutti-os/connector-market",
       "@tutti-os/workspace-file-manager",
       "@tutti-os/workspace-file-reference",

--- a/.changeset/connector-authorization-interaction.md
+++ b/.changeset/connector-authorization-interaction.md
@@ -1,0 +1,7 @@
+---
+"@tutti-os/connector-authorization-protocol": minor
+"@tutti-os/connector-market": minor
+"@tutti-os/desktop": patch
+---
+
+Add the versioned Connector authorization View/Event protocol, configuration-driven native-secret forms, replaceable authorization rendering, and localized Tencent Docs authorization presentation support.

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceConnectorMarketDialogHost.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceConnectorMarketDialogHost.tsx
@@ -9,7 +9,7 @@ import { useWorkspaceSettingsService } from "./useWorkspaceSettingsService";
 
 /** One canonical connector-market dialog host for each workbench window. */
 export function WorkspaceConnectorMarketDialogHost() {
-  const { i18n: appI18n } = useTranslation();
+  const { i18n: appI18n, locale } = useTranslation();
   const i18n = useMemo(
     () => createConnectorMarketI18nRuntime(appI18n),
     [appI18n]
@@ -25,6 +25,7 @@ export function WorkspaceConnectorMarketDialogHost() {
   return (
     <ConnectorMarketDialogHost
       i18n={i18n}
+      locale={locale}
       onError={handleError}
       onTryConnector={() => settingsService.closePanel()}
       root={connectorMarketModule.root}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
@@ -514,6 +514,7 @@ export function WorkspaceSettingsPanel({
                   connectorsVisible ? (
                   <ConnectorMarketPanel
                     i18n={connectorMarketI18n}
+                    locale={desktopPreferencesState.locale}
                     onError={handleConnectorMarketError}
                     onTryConnector={() => settingsService.closePanel()}
                     root={connectorMarketModule.root}

--- a/docs/conventions/npm-package-release.md
+++ b/docs/conventions/npm-package-release.md
@@ -19,6 +19,7 @@ The current fixed release group is:
 @tutti-os/analytics
 @tutti-os/analytics-debug
 @tutti-os/event-stream-core
+@tutti-os/connector-authorization-protocol
 @tutti-os/connector-market
 @tutti-os/workspace-file-manager
 @tutti-os/workspace-file-reference
@@ -178,6 +179,7 @@ pnpm add @tutti-os/workspace-file-preview@beta
 pnpm add @tutti-os/workspace-file-manager@beta
 pnpm add @tutti-os/workspace-issue-manager@beta
 pnpm add @tutti-os/connector-market@beta
+pnpm add @tutti-os/connector-authorization-protocol@beta
 pnpm add @tutti-os/workspace-app-center@beta
 pnpm add @tutti-os/workspace-terminal@beta
 pnpm add @tutti-os/workbench-electron@beta
@@ -358,7 +360,10 @@ The stable package entrypoints are:
 @tutti-os/ui-rich-text/types
 @tutti-os/ui-react-hooks
 @tutti-os/connector-market
+@tutti-os/connector-authorization-protocol
+@tutti-os/connector-authorization-protocol/v1
 @tutti-os/connector-market/contracts
+@tutti-os/connector-market/authorization
 @tutti-os/connector-market/core
 @tutti-os/connector-market/i18n
 @tutti-os/connector-market/openapi/connector-market.v1.yaml

--- a/docs/specs/2026-08-12-connector-authorization-interaction.md
+++ b/docs/specs/2026-08-12-connector-authorization-interaction.md
@@ -1,0 +1,1404 @@
+# Connector 授权 UI 协议与可替换渲染方案
+
+Status: Draft RFC
+
+Owner: Connector Platform
+
+Protocol:
+
+- `tutti.connector.authorization.view.v1`
+- `tutti.connector.authorization.event.v1`
+
+## 0. 决策摘要
+
+Connector 授权采用一套 Tutti 所有、版本化、与 React 无关的声明式 UI 协议。授权交互适配器
+只描述当前要展示的授权界面，Renderer 只展示界面并返回用户事件。常规单凭证、OAuth 等场景
+优先由平台的声明式适配器根据 Connector 配置完成，不要求每个 Connector 发布 JS 处理器；
+只有二维码、设备码、轮询或其他动态多步流程才实现自定义交互适配器。
+
+协议只存在于 Connector 和 Renderer 的边界，不是 tsh-server API、Connector Market API、
+持久化模型或通用低代码页面协议。tsh-server 不解析、不校验、也不生成该协议。
+
+协议实现放在独立 workspace 包：
+
+```text
+packages/connector/authorization-protocol
+```
+
+包名：
+
+```text
+@tutti-os/connector-authorization-protocol
+```
+
+该包使用 Valibot 定义 V1 Schema，并从 Schema 推导 TypeScript 类型。首期不引入 JSON
+Schema、AJV、JSON Forms、RJSF 或表单状态库。默认 Renderer 继续放在
+`@tutti-os/connector-market`，使用 `@tutti-os/ui-system`；宿主可以替换整个 Renderer，
+也可以替换某种 view 或 field 的 Renderer。
+
+UI 协议与声明式授权配置是两个边界：前者是 Adapter/Renderer 之间的 View/Event；后者是
+Connector package 提供给平台通用 Adapter 的可信配置。credential 最终注入哪个 header、
+endpoint 或进程环境仍由现有受信 binding 决定，不进入 UI 协议。
+
+## 1. 背景和第一处错误边界
+
+当前授权 Dialog 根据 `authorizationKind === "api_key"` 决定是否展示 secret 输入框，
+并直接理解 `secret`、`authorizationUrl` 等授权实现细节：
+
+```text
+authorizationKind
+  -> ConnectorAuthorizationDialog 分支
+  -> secret 或 authorizationUrl
+  -> beginAuthorization
+```
+
+`authorizationKind` 描述凭证类型，不等于当前应该渲染的用户交互。一个 API key Connector
+可能需要多个字段，一个 OAuth Connector 可能需要链接、device code 或二维码；Renderer
+不应该根据凭证类型猜测界面。
+
+目标数据流是：
+
+```text
+Connector
+  -> AuthorizationViewEnvelopeV1 (unknown JSON)
+  -> Valibot parse + 跨字段校验
+  -> Authorization UI Controller
+  -> injected AuthorizationRenderer
+  -> AuthorizationEventEnvelopeV1
+  -> Controller 校验事件与当前 view 是否匹配
+  -> Connector
+  -> 下一份 AuthorizationViewEnvelopeV1
+```
+
+第一个需要修正的状态是 Connector 没有显式输出 UI view，而不是 Dialog 缺少更多
+`authorizationKind` 分支。
+
+### 1.1 工作流程图
+
+```mermaid
+flowchart TD
+    U["用户打开授权页面"] --> C0["Controller 创建本地 flow<br/>open(locale, signal)"]
+    C0 --> S["Connector 打开有序 View Stream"]
+
+    subgraph ADAPTER["授权交互适配器：声明式优先，可自定义"]
+        S --> B["推进授权业务<br/>通用 profile adapter / 自定义动态流程"]
+        B --> O["输出 unknown AuthorizationView"]
+        E2["接收已校验 AuthorizationEvent"] --> B
+    end
+
+    O --> P{"Valibot + 跨字段校验"}
+    P -- "失败" --> PE["Tutti 安全协议错误页<br/>不渲染原始 payload"]
+    P -- "成功" --> CV["Controller 提交当前 viewId<br/>生成 renderKey"]
+    CV --> R["可替换 Renderer<br/>只展示 View"]
+
+    R --> A["用户输入或操作"]
+    A --> D["Renderer 生成 Event<br/>submit / activate / refresh / retry / cancel"]
+    D --> V{"Controller 按当前 View<br/>校验 viewId、字段和值"}
+    V -- "失败" --> LE["本地安全错误<br/>不发送给 Connector"]
+    LE --> R
+    V -- "成功" --> K{"事件类型"}
+
+    K -- "activate" --> N["宿主校验并打开外部 URL"]
+    N -- "允许并成功" --> E2
+    N -- "拒绝或失败" --> LE
+    K -- "submit / refresh / retry" --> E2
+    K -- "cancel" --> X["best-effort dispatch cancel"]
+
+    O -. "下一帧，继续循环" .-> P
+
+    U2["用户关闭 / 协议失败 / 卸载"] --> X
+    PE --> X
+    X --> CL["abort View Stream<br/>撤销 file handle / object URL<br/>清空 secret draft / port.close"]
+
+    B -. "Adapter 内部调用；不属于 UI 协议" .-> BACKEND["Provider / 本地 Runtime / tsh-server"]
+```
+
+图中的实线 `View` 和 `Event` 是本方案定义的授权适配器/Renderer UI 协议；适配器到
+Provider、本地 Runtime 或 tsh-server 的调用不共享这套 UI Schema。Renderer 永远不直接
+访问这些 backend。
+
+### 1.2 腾讯文档现状核对
+
+腾讯文档 `0.2.0` 没有 Connector 专属授权脚本，业务链路确实是配置驱动的：
+
+- `tutti.connector.json` 声明 `authorization.kind: "api_key"`、
+  `backend: "native_secret"`；
+- `implementation/mcp.json` 通过 `bindingRef: "tencent-docs.primary"` 关联服务端 binding；
+- `server/tsh-binding.json` 声明远端 MCP endpoint、`Authorization` header 注入、allowlist 和
+  `initialize` / `tools/list` 验证；
+- tsh-server 负责校验、加密保存和运行时 header 注入，Connector 不处理 token。
+
+但当前 UI 仍不是“显式表单配置”：桌面端根据 `authorizationKind === "api_key"` 硬编码生成
+单个 `secret` 输入框。也就是说，腾讯文档的授权业务和 binding 已配置化，表单展示仍靠 UI
+猜测。本方案要补齐的是最后这一段：由通用声明式适配器把显式 presentation 配置转换为
+View/Event，Renderer 不再根据 authorization kind 猜字段，同时不破坏腾讯文档现有的
+`native_secret` 和 tsh binding 链路。
+
+## 2. 范围
+
+### 2.1 目标
+
+- 用有限、版本化的 union 描述当前授权页面；
+- 覆盖邮箱加授权码、PAT、数值配置、OAuth 文件、外部链接、device code、二维码、等待和
+  结果页；
+- 所有 Connector 输出在进入 Renderer 前经过运行时校验；
+- Renderer 不理解具体 Connector、provider 或凭证类型；
+- Connector 不提供 React、HTML、CSS、组件路径或脚本；
+- 支持替换整体 Renderer、单个 view Renderer 和单个 field Renderer；
+- 对未知版本、未知 view、未知 field 和额外属性 fail closed；
+- secret、二维码内容和本地文件句柄不进入日志、持久化或 analytics；
+- 保持协议轻量，首期只增加 Valibot。
+
+### 2.2 非目标
+
+- 不定义 tsh-server、HTTP、gRPC、protobuf 或 Connector Market backend 接口；
+- 不定义 Connector 内部如何完成 OAuth、轮询或凭证交换；
+- 不提供任意页面布局、嵌套对象、数组表单、条件表达式或远程组件；
+- 不允许 Connector 下发 Markdown、HTML、CSS、className、图标 URL 或任意 handler；
+- 不允许 Connector 选择 Renderer；
+- 不让 Renderer 直接访问 Connector transport、Market backend 或 credential store；
+- 不为非 TypeScript 语言生成 JSON Schema；
+- 不在 V1 提供自定义 field/view type 扩展槽。
+
+## 3. 所有权与依赖方向
+
+### 3.1 包职责
+
+```text
+packages/connector/authorization-protocol/
+  package.json
+  src/
+    index.ts
+    limits.ts
+    parseAuthorizationEvent.ts
+    parseAuthorizationView.ts
+    validateEventForView.ts
+    v1/
+      eventSchemas.ts
+      types.ts
+      viewSchemas.ts
+    __fixtures__/
+      valid/
+      invalid/
+```
+
+协议包只拥有：
+
+- Valibot Schema；
+- 从 Schema 推导的 V1 DTO 类型；
+- 统一 parser 和稳定的 parse error；
+- 事件与当前 view 的语义校验；
+- 安全上限常量；
+- package-private contract fixtures。
+
+协议包禁止依赖：
+
+- React 和 DOM；
+- `@tutti-os/ui-system`；
+- `@tutti-os/connector-market`；
+- desktop bridge；
+- tsh-server client；
+- Connector runtime transport；
+- Valtio 或其他业务状态库。
+
+依赖方向：
+
+```text
+Authorization adapter ────┐
+                          ├──> connector-authorization-protocol
+Authorization controller ┤
+Default Renderer ─────────┘
+
+connector-authorization-protocol -X-> connector-market
+connector-authorization-protocol -X-> tsh-server
+```
+
+这满足 `packages/AGENTS.md` 的共享边界要求：协议包由授权 Adapter 输出侧、Controller 和
+Renderer 多方消费，职责可以精确命名，不是为了“看起来可复用”而抽取。
+
+### 3.2 默认 Renderer 位置
+
+首期默认实现放在：
+
+```text
+packages/connector/market/src/ui/authorization/
+  DefaultAuthorizationRenderer.tsx
+  AuthorizationRenderer.types.ts
+  viewRenderers/
+    AuthorizationFormView.tsx
+    AuthorizationExternalLinkView.tsx
+    AuthorizationQrCodeView.tsx
+    AuthorizationDeviceCodeView.tsx
+    AuthorizationProgressView.tsx
+    AuthorizationResultView.tsx
+  fieldRenderers/
+    AuthorizationTextField.tsx
+    AuthorizationSecretField.tsx
+    AuthorizationNumberField.tsx
+    AuthorizationSelectField.tsx
+    AuthorizationBooleanField.tsx
+    AuthorizationLocalFileField.tsx
+```
+
+只有出现第二个真实 UI 消费方后，才将默认实现拆为
+`packages/connector/authorization-ui`。协议包从一开始独立，避免 Connector 依赖 Market
+或 React。
+
+### 3.3 发布形态
+
+本方案不发布需要单独执行或通过 CDN 加载的 JS 脚本。发布物是普通 ESM npm library：
+
+```text
+@tutti-os/connector-authorization-protocol
+  dist/index.js
+  dist/index.d.ts
+  dist/v1/index.js
+  dist/v1/index.d.ts
+  README.md
+  package.json
+```
+
+推荐 exports：
+
+```json
+{
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./v1": {
+      "types": "./dist/v1/index.d.ts",
+      "import": "./dist/v1/index.js"
+    }
+  }
+}
+```
+
+- 声明式 Connector 直接在 manifest 中携带 JSON 配置，不需要 import 或执行 JS；
+- 自定义 JS/TS Adapter 可以从 `/v1` import typed builder；
+- Tutti Controller 和默认 Renderer 依赖同一 package；
+- `valibot` 是该 package 的普通 runtime dependency，不要求调用方配置 peer version；
+- package 输出编译后的 ESM JS 和 `.d.ts`，不公开 `src/*`；
+- npm package version 与 UI protocol version 独立：package 可以修 bug，Connector 通过
+  `/v1` subpath 明确选择协议版本；
+- Python 或其他语言 Connector 不需要执行这份 JS，仍可按协议生成 JSON，由 Tutti 的
+  Valibot parser 做最终边界校验；
+- 首期不发布 JSON Schema、CDN bundle、全局变量脚本、CLI executable 或远程可执行代码。
+
+本次实现将协议作为 public workspace package，并已加入
+`docs/conventions/npm-package-release.md` 的固定发布组。Connector manifest 只携带 JSON，
+不要求加载该 package 或执行远程 JS；仓库外 TypeScript Adapter 后续可从 `/v1` import 类型和
+builder。
+
+## 4. 协议设计原则
+
+1. **一帧一个 view**：Connector 每次只描述当前界面，不下发完整流程图。
+2. **Adapter 拥有状态转换**：Renderer 不推断下一步、不轮询、不交换凭证。Adapter 可以是
+   Tutti 提供的通用声明式实现，也可以是 Connector 的自定义动态实现。
+3. **纯数据**：协议是可结构化克隆的 JSON 数据，不包含函数或框架对象。
+4. **显式 union**：view 和 field 均使用封闭的 discriminated union。
+5. **严格 V1**：V1 Schema 使用 `strictObject`，未知字段拒绝；发布后冻结。
+6. **安全能力由宿主决定**：打开 URL、读取文件和复制内容必须经过可信宿主能力。
+7. **文案与视觉分离**：Connector 可以提供业务标题和说明；通用按钮、状态和错误文案由
+   Tutti i18n 提供。
+8. **协议与 Renderer API 分离**：协议包只定义数据；React component props 留在 UI 包。
+
+Adapter 输出的业务文案必须已经按 `open` 收到的 locale 解析；协议不承载 i18n message
+key。声明式配置由通用 Adapter 选择 locale，自定义 Adapter 自行选择；缺少目标语言时使用
+Connector 的默认语言，Tutti-owned 文案仍由宿主 i18n 生成。
+
+## 5. Authorization View V1
+
+### 5.1 Envelope
+
+```ts
+interface AuthorizationViewEnvelopeV1 {
+  protocol: "tutti.connector.authorization.view.v1";
+  viewId: string;
+  view: AuthorizationViewV1;
+}
+```
+
+`viewId` 是 Connector 为当前 UI 帧生成的不透明标识：
+
+- 在同一次授权流程内必须唯一；
+- view 的交互语义发生变化时必须生成新值；
+- Renderer 返回事件时原样回传；
+- Controller 只接受与当前 `viewId` 相同的事件；
+- 它不是服务端 session ID、Market revision 或幂等键；
+- 不得包含账号、token、路径或其他敏感信息。
+
+授权流程实例 ID 由 Controller 内部管理，不属于 Connector/Renderer 协议。
+
+### 5.2 View union
+
+```ts
+type AuthorizationViewV1 =
+  | AuthorizationFormViewV1
+  | AuthorizationExternalLinkViewV1
+  | AuthorizationDeviceCodeViewV1
+  | AuthorizationQrCodeViewV1
+  | AuthorizationProgressViewV1
+  | AuthorizationResultViewV1;
+
+interface AuthorizationViewBaseV1 {
+  type: string;
+  title?: string;
+  description?: string;
+}
+```
+
+所有文字按纯文本渲染。`description` 不支持 Markdown、HTML 或内嵌链接；链接必须使用
+结构化 `helpLinks`。
+
+### 5.3 Form view
+
+```ts
+interface AuthorizationFormViewV1 extends AuthorizationViewBaseV1 {
+  type: "form";
+  helpLinks?: AuthorizationHelpLinkV1[];
+  fields: AuthorizationFieldV1[];
+  fieldErrors?: Record<string, string>;
+  submitLabel?: string;
+}
+
+interface AuthorizationHelpLinkV1 {
+  label: string;
+  url: string;
+}
+```
+
+`submitLabel` 只允许覆盖业务动作，例如“保存并连接”。取消、返回、重试等通用文案由
+Renderer 的本地 i18n 提供。`fieldErrors` 只能引用当前 form 已声明的字段，内容按纯文本
+展示；它用于 Connector 完成业务校验后返回错误，不替代 Renderer 的本地基础校验。
+
+### 5.4 External link view
+
+```ts
+interface AuthorizationExternalLinkViewV1 extends AuthorizationViewBaseV1 {
+  type: "external_link";
+  url: string;
+  actionLabel?: string;
+  expiresAt?: string;
+}
+```
+
+Renderer 不直接使用 `window.open`。用户触发后发出 `activate` 事件，由可信宿主通过统一
+external navigation policy 校验并打开 URL。协议不支持 `autoOpen`；是否在特定受信场景
+自动打开由宿主策略决定，Connector 无权指定。
+
+### 5.5 Device code view
+
+```ts
+interface AuthorizationDeviceCodeViewV1 extends AuthorizationViewBaseV1 {
+  type: "device_code";
+  verificationUrl: string;
+  userCode: string;
+  actionLabel?: string;
+  expiresAt?: string;
+}
+```
+
+Renderer 展示和复制 `userCode`，并通过 `activate` 请求宿主打开 `verificationUrl`。复制是
+Renderer 本地操作，不向 Connector 发事件。
+
+### 5.6 QR code view
+
+```ts
+interface AuthorizationQrCodeViewV1 extends AuthorizationViewBaseV1 {
+  type: "qr_code";
+  source:
+    | {
+        type: "payload";
+        value: string;
+      }
+    | {
+        type: "png_base64";
+        value: string;
+      };
+  fallbackText?: string;
+  expiresAt?: string;
+  refreshable?: boolean;
+}
+```
+
+优先使用 `payload`，默认 Renderer 在本地编码二维码。只有 Connector 无法获得原始 payload
+时才允许 `png_base64`。V1 不允许远程图片 URL、data URL、SVG 或 HTML：
+
+- payload 最大 4,096 UTF-8 bytes；
+- PNG 解码后最大 512 KiB；
+- 协议 parser 检查 base64、decoded length、PNG signature 和 IHDR 尺寸；
+- 默认 Renderer 在展示前还必须使用受限 decoder 完成实际解码，解码失败安全终止；
+- 二维码尺寸、纠错等级、颜色、留白和 Logo 由 Renderer 决定；
+- `fallbackText` 可以复制，但不得记录；
+- `expiresAt` 仅用于显示倒计时和禁用过期操作，不让 Renderer 自动调用 Connector；
+- `refreshable: true` 时显示本地“刷新”按钮并发出 `refresh` 事件。
+
+Connector 负责扫码结果观察。扫码成功后 Connector 主动输出新的 result view，Renderer
+不轮询二维码状态。
+
+### 5.7 Progress view
+
+```ts
+interface AuthorizationProgressViewV1 extends AuthorizationViewBaseV1 {
+  type: "progress";
+  message?: string;
+}
+```
+
+`progress` 只描述展示状态。Connector 在后台工作完成后主动输出下一帧；Renderer 不依据
+该 view 启动 timer、poll 或网络请求。Dialog 是否允许关闭由宿主策略控制。
+
+### 5.8 Result view
+
+```ts
+interface AuthorizationResultViewV1 extends AuthorizationViewBaseV1 {
+  type: "result";
+  outcome: "success" | "failure";
+  message?: string;
+  retryable?: boolean;
+}
+```
+
+`retryable` 只对 failure 有效。为 true 时 Renderer 显示本地化重试按钮并发出 `retry`
+事件。Result 是 Connector 的业务结果，不用于表示协议解析失败或 Renderer 异常；后两者由
+Tutti 自己的错误 UI 处理。
+
+## 6. Form field V1
+
+### 6.1 Field union
+
+```ts
+type AuthorizationFieldV1 =
+  | TextAuthorizationFieldV1
+  | SecretAuthorizationFieldV1
+  | NumberAuthorizationFieldV1
+  | SelectAuthorizationFieldV1
+  | BooleanAuthorizationFieldV1
+  | LocalFileAuthorizationFieldV1;
+
+interface AuthorizationFieldBaseV1 {
+  name: string;
+  label: string;
+  description?: string;
+  helpLinks?: AuthorizationHelpLinkV1[];
+  required?: boolean;
+}
+```
+
+字段名必须匹配 `^[a-z][a-z0-9_]{0,63}$`，同一 form 内不能重复。Renderer 使用 `name`
+关联值和错误，不将它直接用作 DOM id。
+
+### 6.2 Text 和 secret
+
+```ts
+interface TextAuthorizationFieldV1 extends AuthorizationFieldBaseV1 {
+  type: "text";
+  format?: "plain" | "email";
+  placeholder?: string;
+  defaultValue?: string;
+  minLength?: number;
+  maxLength?: number;
+}
+
+interface SecretAuthorizationFieldV1 extends AuthorizationFieldBaseV1 {
+  type: "secret";
+  placeholder?: string;
+  minLength?: number;
+  maxLength?: number;
+}
+```
+
+V1 不允许 secret `defaultValue`。text 默认去除首尾空白；secret 永不自动 trim，避免改变
+真实凭证。`format: "email"` 提供基础格式反馈，但 Connector 仍负责业务校验。
+
+### 6.3 Number
+
+```ts
+interface NumberAuthorizationFieldV1 extends AuthorizationFieldBaseV1 {
+  type: "number";
+  placeholder?: string;
+  defaultValue?: number;
+  minimum?: number;
+  maximum?: number;
+  step?: number;
+  unit?: string;
+}
+```
+
+数值必须是有限安全数值，拒绝 `NaN`、`Infinity` 和超出 JavaScript safe integer 范围的
+整数。`step` 必须大于 0；step 校验以 `minimum ?? 0` 为基准，并允许有限浮点误差。
+
+### 6.4 Select 和 boolean
+
+```ts
+interface SelectAuthorizationFieldV1 extends AuthorizationFieldBaseV1 {
+  type: "select";
+  defaultValue?: string;
+  options: Array<{
+    value: string;
+    label: string;
+    description?: string;
+  }>;
+}
+
+interface BooleanAuthorizationFieldV1 extends AuthorizationFieldBaseV1 {
+  type: "boolean";
+  defaultValue?: boolean;
+}
+```
+
+Select option value 在字段内必须唯一；提交值必须来自 options。未勾选 boolean 的规范值是
+`false`，除非 required 语义明确要求用户确认 true。
+
+### 6.5 Local file
+
+```ts
+interface LocalFileAuthorizationFieldV1 extends AuthorizationFieldBaseV1 {
+  type: "local_file";
+  extensions?: string[];
+}
+
+interface AuthorizationLocalFileValueV1 {
+  type: "local_file";
+  handleId: string;
+}
+```
+
+V1 的 `local_file` 返回宿主创建的短期 opaque handle，不把原始路径或文件内容放进协议。
+Renderer 可以显示经过脱敏的文件名或路径，但事件只携带 `handleId`。Connector 通过宿主
+提供的受限文件能力读取 handle；该能力不属于本协议。
+
+约束：
+
+- handle 绑定当前授权流程，关闭 Dialog 或 view 切换时撤销；
+- Connector 只能读取用户明确选择的文件；
+- 不允许 Connector 自行解析任意宿主路径；
+- 不支持 `defaultValue`，避免静默读取历史路径；
+- extensions 最多 20 个，使用规范化的 `.json` 形式；
+- 宿主读取时重新检查 handle、文件类型、大小和权限，不能只信任选择时检查；
+- 实现应避免符号链接切换和选择后替换造成的 TOCTOU；优先使用已打开的只读句柄或安全
+  快照。
+
+如果某个受信本地 Connector 确实需要路径而不是文件内容，应通过宿主的 Connector
+capability 显式解决，不把 `path` 加回通用 UI 协议。
+
+### 6.6 字段与 Connector 参数绑定
+
+`field.name` 是授权交互内部的提交键，Renderer 不维护 credential 映射表。绑定分两层：
+
+```text
+声明式授权配置输出 field.name
+  -> Renderer 以 name 收集 draft
+  -> submit.values[name]
+  -> Controller 做结构和类型校验
+  -> 通用授权 Adapter 按 trusted submission 配置取值
+  -> 现有 authorization backend / credential binding
+```
+
+声明式配置不属于 Renderer 协议，也不会原样发送给 Renderer。建议在 Connector 的
+authorization method 中增加 `interaction`，由平台通用 Adapter 消费：
+
+```ts
+interface DeclarativeAuthorizationInteractionV1 {
+  protocol: "tutti.connector.authorization.declarative.v1";
+  initialView: AuthorizationViewV1;
+  submission: {
+    kind: "native_secret";
+    secretField: string;
+  };
+}
+```
+
+`secretField` 只能引用 `initialView` 中类型为 `secret` 的字段。通用 Adapter 收到 submit 后，
+从 values 中取出该字段，并调用现有 `native_secret` complete 流程；它无权指定 header、host、
+endpoint 或文件路径。这些安全敏感的运行时映射继续由 tsh binding 或其他受信 runtime
+binding 管理。
+
+以 Figma PAT 为例，Connector package 只需声明配置，不需要 `handleFigmaEvent`：
+
+```json
+{
+  "protocol": "tutti.connector.authorization.declarative.v1",
+  "initialView": {
+    "type": "form",
+    "title": "配置 Figma",
+    "submitLabel": "保存并启用",
+    "fields": [
+      {
+        "type": "secret",
+        "name": "personal_access_token",
+        "label": "个人访问令牌",
+        "required": true
+      }
+    ]
+  },
+  "submission": {
+    "kind": "native_secret",
+    "secretField": "personal_access_token"
+  }
+}
+```
+
+运行时通用 Adapter 执行：
+
+```text
+personal_access_token
+  -> submit.values.personal_access_token
+  -> submission.secretField
+  -> CompleteAuthorization({ secret })
+  -> encrypted native_secret
+  -> trusted runtime binding（例如 X-Figma-Token）
+```
+
+腾讯文档可以沿用同一路径：
+
+```json
+{
+  "protocol": "tutti.connector.authorization.declarative.v1",
+  "initialView": {
+    "type": "form",
+    "title": "连接 Tencent Docs",
+    "fields": [
+      {
+        "type": "secret",
+        "name": "personal_token",
+        "label": "Personal Token",
+        "required": true
+      }
+    ]
+  },
+  "submission": {
+    "kind": "native_secret",
+    "secretField": "personal_token"
+  }
+}
+```
+
+随后仍调用现有 `native_secret` backend；`Authorization` header 名称、空 prefix、
+`docs.qq.com` allowlist 和 MCP 验证全部保持在 `tsh-binding.json`，不重复写入 UI 配置。
+
+为了兼容现有 Tencent Docs manifest，迁移期通用 Adapter 可以把
+`kind: "api_key" + backend: "native_secret" + secret: {}` 转换为一个默认单 secret 表单。
+这是集中在 Adapter 内的 legacy 兼容，不允许 Renderer 继续包含
+`authorizationKind === "api_key"` 分支。Connector 想自定义标题、字段名和帮助链接时，应显式
+提供 `interaction`。
+
+V1 的声明式 submission 先只支持 `native_secret` 单敏感字段。邮箱账号加授权码、多 credential
+slot、非敏感 runtime settings 等场景，只有在对应 backend 已定义明确的存储与消费 contract
+后才增加新的封闭 union 分支；不能通过通用表达式或任意 `binding` 对象绕过安全边界。动态
+二维码、device code、轮询等流程使用自定义 InteractionPort，但仍输出相同 View/Event 协议。
+
+Connector manifest tooling 可以提供轻量 builder 校验 presentation 和 submission 引用一致；
+它不是 Renderer protocol package 的职责：
+
+```ts
+const figmaAuthorization = defineDeclarativeAuthorization({
+  protocol: "tutti.connector.authorization.declarative.v1",
+  initialView: {
+    type: "form",
+    title: "配置 Figma",
+    fields: [
+      {
+        type: "secret",
+        name: "personal_access_token",
+        label: "个人访问令牌",
+        required: true
+      }
+    ]
+  },
+  submission: {
+    kind: "native_secret",
+    secretField: "personal_access_token"
+  }
+} as const);
+```
+
+这段 TypeScript 只是可选的构建期辅助；发布物可以直接携带等价 JSON。不存在需要宿主下载并
+执行的 Connector JS 脚本。Renderer protocol package 仍只导出 View/Event Schema。
+
+Renderer 实际收到的 submit event 仍然只有 UI 数据：
+
+```json
+{
+  "protocol": "tutti.connector.authorization.event.v1",
+  "viewId": "figma-token-1",
+  "event": {
+    "type": "submit",
+    "values": {
+      "personal_access_token": "figd_..."
+    }
+  }
+}
+```
+
+V1 不增加 `envName`、`configPath`、`headerName` 或通用 `binding` 属性，原因是：
+
+- Renderer 不应该知道 credential 最终落在哪里；
+- 远端 Connector、本地 CLI 和 managed broker 的落地方式不同；
+- 允许 Connector 通过 UI Schema 指定环境变量、文件路径或 header 会扩大安全权限；
+- credential binding 可以独立演进，不迫使 UI 协议升级。
+
+`field.name` 不是用户可见文案，也不是最终运行时参数名。它只是一次授权交互内的稳定提交
+key。声明式配置的 contract test 必须证明 `submission` 引用的每个 key 都由 form 声明且类型
+匹配；自定义 Adapter 必须证明消费字段与 form 声明一致。未知 key 必须拒绝，不能静默丢弃。
+
+## 7. Authorization Event V1
+
+### 7.1 Envelope 和 event union
+
+```ts
+interface AuthorizationEventEnvelopeV1 {
+  protocol: "tutti.connector.authorization.event.v1";
+  viewId: string;
+  event: AuthorizationEventV1;
+}
+
+type AuthorizationEventV1 =
+  | {
+      type: "submit";
+      values: Record<string, AuthorizationValueV1>;
+    }
+  | { type: "activate" }
+  | { type: "refresh" }
+  | { type: "retry" }
+  | { type: "cancel" };
+
+type AuthorizationValueV1 =
+  | string
+  | number
+  | boolean
+  | AuthorizationLocalFileValueV1;
+```
+
+### 7.2 Event 与 view 的合法组合
+
+| 当前 view        | 允许事件                                |
+| ---------------- | --------------------------------------- |
+| `form`           | `submit`, `cancel`                      |
+| `external_link`  | `activate`, `cancel`                    |
+| `device_code`    | `activate`, `cancel`                    |
+| `qr_code`        | `refresh`（仅 `refreshable`）, `cancel` |
+| `progress`       | `cancel`                                |
+| `result/success` | `cancel`                                |
+| `result/failure` | `retry`（仅 `retryable`）, `cancel`     |
+
+`validateEventForView(currentView, event)` 必须执行以下语义校验：
+
+- `viewId` 必须等于 Controller 当前 view；
+- submit 只能用于 form；
+- values 不能包含未知字段；
+- required 字段必须存在；
+- optional 空值按第 7.3 节规范化；
+- value 类型必须与 field type 匹配；
+- select value 必须存在于 options；
+- 字符串、数值和本地文件必须满足字段限制；
+- refresh/retry 只有对应 flag 为 true 才能发送。
+
+### 7.3 Form 值规范化
+
+- optional text 为空时从 values 中省略；
+- required text trim 后为空时报字段错误；
+- secret 不 trim，空字符串只在 required 时拒绝；
+- optional number 输入为空时省略，不能转换成 0；
+- boolean 始终提交明确的 true/false；
+- local_file 只提交当前 flow 创建且仍有效的 handle；
+- defaultValue 只负责初始化 Renderer draft，用户提交前仍按同一规则校验；
+- Renderer 本地字段错误使用稳定内部 code，不使用 Connector 提供的 HTML 或富文本错误。
+
+## 8. Valibot 组织
+
+### 8.1 唯一协议实现
+
+Valibot Schema 是 V1 TypeScript 协议定义和运行时校验的单一来源：
+
+完整、可类型检查的参考 Schema 位于
+[`packages/connector/authorization-protocol/src/v1/schema.ts`](../../packages/connector/authorization-protocol/src/v1/schema.ts)。
+它包括全部 View、Field、Event、限制、跨字段检查、推导类型、typed form builder，以及依赖
+当前 View 的 `validateAuthorizationEventForViewV1`。以下代码只展示两个顶层 envelope：
+
+```ts
+import * as v from "valibot";
+
+export const authorizationViewEnvelopeV1Schema = v.strictObject({
+  protocol: v.literal("tutti.connector.authorization.view.v1"),
+  viewId: viewIdSchema,
+  view: authorizationViewV1Schema
+});
+
+export const authorizationEventEnvelopeV1Schema = v.strictObject({
+  protocol: v.literal("tutti.connector.authorization.event.v1"),
+  viewId: viewIdSchema,
+  event: authorizationEventV1Schema
+});
+
+export type AuthorizationViewEnvelopeV1 = v.InferOutput<
+  typeof authorizationViewEnvelopeV1Schema
+>;
+```
+
+禁止另外手写一份结构相同的 TypeScript interface 作为协议源。本文代码块用于表达规范，
+实现时以 Schema 和推导类型为准。
+
+首期不生成 JSON Schema，原因是该协议没有 tsh-server 或其他语言运行时消费者。未来只有
+出现明确的跨语言 Connector SDK 消费者时，才评估从同一来源生成发布 artifact；不能手写
+第二份 Schema。
+
+### 8.2 Parser
+
+```ts
+type AuthorizationProtocolParseResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: AuthorizationProtocolError };
+
+function parseAuthorizationView(
+  input: unknown
+): AuthorizationProtocolParseResult<AuthorizationViewEnvelopeV1>;
+
+function parseAuthorizationEvent(
+  input: unknown
+): AuthorizationProtocolParseResult<AuthorizationEventEnvelopeV1>;
+```
+
+Parser 负责：
+
+- 按完整 protocol literal 路由版本；
+- 执行 strict structural validation；
+- 执行数组长度、字符串长度、URL、时间、base64、PNG header 和尺寸上限；
+- 执行字段名、select option 和跨字段约束；
+- 将 Valibot issue 转为稳定错误 code；
+- diagnostics 只保留字段路径、code 和协议版本，不保留原始值。
+
+建议上限：
+
+| 项目                    | V1 限制                                                    |
+| ----------------------- | ---------------------------------------------------------- |
+| 单个 form 字段          | 16                                                         |
+| select options          | 每字段 100                                                 |
+| title/label/actionLabel | 128 Unicode 字符                                           |
+| description/message     | 1,024 Unicode 字符                                         |
+| placeholder/unit        | 128 Unicode 字符                                           |
+| 用户文本输入            | 每字段最大 8,192 字符                                      |
+| helpLinks               | view 最多 8 个、field 最多 4 个                            |
+| URL                     | 最大 2,048 字符，`https:`；开发策略可允许 loopback `http:` |
+| QR payload              | 4,096 UTF-8 bytes                                          |
+| QR PNG                  | 解码后 512 KiB，最大 2,048 × 2,048                         |
+| local_file extensions   | 20                                                         |
+
+## 9. Connector 集成与 Headless Controller
+
+协议不规定 Adapter 使用 stdio、进程 RPC、worker 还是内存调用。Market feature 定义一个
+transport-neutral port。这个 port 通常由 Tutti 的声明式 profile adapter 实现；只有动态流程
+才由 Connector 自定义实现。为避免 request/response 返回值和异步订阅产生新旧 view 竞态，
+输出统一为单一、有序的 AsyncIterable：
+
+```ts
+interface ConnectorAuthorizationInteractionPort {
+  open(options: {
+    connectorKey: string;
+    locale: string;
+    signal: AbortSignal;
+  }): AsyncIterable<unknown>;
+
+  dispatch(
+    event: AuthorizationEventEnvelopeV1,
+    options: { signal: AbortSignal }
+  ): Promise<void>;
+
+  close?(): Promise<void>;
+}
+```
+
+- `open` 返回当前授权 flow 唯一的 view stream，第一项必须是首帧；
+- stream 内所有 view 按 Adapter 状态提交顺序输出，不能在较新 view 后输出旧 view；
+- `dispatch` 只确认事件已被 Adapter 接收，不返回 view；
+- 简单声明式 adapter 也必须把响应放入同一 stream；
+- OAuth、扫码和等待等异步结果同样进入该 stream；
+- 返回值保持 unknown，必须经过 parser 后才能进入状态；
+- transport 的认证、超时和进程生命周期不属于 UI 协议。
+
+Controller 状态仅描述本地请求生命周期：
+
+```ts
+interface AuthorizationControllerState {
+  view: AuthorizationViewEnvelopeV1 | null;
+  status: "idle" | "starting" | "ready" | "dispatching" | "failed";
+  error?: AuthorizationUiError;
+}
+```
+
+`progress` 和 `result` 是 Connector 输出的业务 view，不重复编码成 controller status。
+
+Controller 独占：
+
+- parse Connector 输出；
+- 保存当前 viewId；
+- 串行 dispatch，拒绝重复点击和旧 view 事件；
+- 单线程消费 Connector view stream，保证 UI 不发生响应/订阅竞态；
+- 对 form event 做 view-aware validation；
+- 管理 Renderer draft 的 reset key；
+- 管理 AbortController 和 Connector view stream；
+- 通过宿主能力打开 URL、创建/撤销 local file handle；
+- close、view 变化、失败和卸载时清理 secret、object URL 和 file handle；
+- 将 transport/protocol 错误映射为 Tutti-owned 安全错误。
+
+`activate` 的处理顺序是：Controller 校验当前 view 和 URL，通过宿主 external navigation
+policy 打开成功后，再向 Connector dispatch `activate`；用户拒绝或宿主拦截时不通知
+Connector 已激活。`cancel` 在 Dialog 关闭时 best-effort dispatch，随后总是 abort stream、
+撤销本地资源并调用 port `close`，不能因为 Connector 无响应阻止窗口关闭。
+
+Authorization Adapter 独占：
+
+- 授权状态机；
+- 网络请求和凭证交换；
+- OAuth/device code/扫码结果观察；
+- 业务字段校验；
+- 决定下一份 view；
+- 生成用户安全、可展示的业务失败信息。
+
+默认采用平台通用声明式 Adapter：它读取 Connector 的 `interaction` 和既有 authorization
+profile，生成首帧、验证提交字段，并调用现有 backend。自定义 Adapter 只用于声明式能力无法
+表达的动态流程；两者对 Controller 暴露同一个 port，因此 Renderer 无感知。
+
+Renderer 独占：
+
+- 布局和视觉；
+- 临时表单 draft；
+- 本地基础校验和字段错误关联；
+- 倒计时、复制、密码显示/隐藏等展示行为；
+- 发出结构化 UI event。
+
+## 10. 可替换 Renderer
+
+React 接口属于 `connector-market/ui`，不导出自协议包：
+
+```ts
+interface AuthorizationRendererProps {
+  connector: Pick<Connector, "key" | "release">;
+  view: AuthorizationViewEnvelopeV1;
+  renderKey: string;
+  busy: boolean;
+  error?: AuthorizationUiError;
+  capabilities: AuthorizationRendererCapabilities;
+  onEvent(event: AuthorizationEventEnvelopeV1): void;
+}
+
+type AuthorizationRenderer = React.ComponentType<AuthorizationRendererProps>;
+
+interface AuthorizationRendererCapabilities {
+  selectLocalFile(options: { extensions?: string[] }): Promise<{
+    handleId: string;
+    displayName: string;
+  } | null>;
+}
+```
+
+`renderKey` 是 Controller 创建的 `flowInstanceId + viewId` 不透明组合，只用于强制清理
+Renderer subtree，不进入协议。`selectLocalFile` 是唯一需要暴露给 Renderer 的宿主能力：
+宿主负责弹出系统选择器、创建 flow-scoped handle，并只返回用于展示的脱敏文件名。
+Renderer 不能自行构造 handle。打开外部 URL 仍由 Controller 处理，不作为 Renderer
+capability 暴露。
+
+整体替换只能在可信宿主组合根注入：
+
+```tsx
+<ConnectorMarketDialogHost
+  authorizationRenderer={CustomAuthorizationRenderer}
+/>
+```
+
+Connector manifest 和 view 均不能指定 Renderer。
+
+默认 Renderer 内提供两级 registry：
+
+```ts
+interface AuthorizationViewRendererMap {
+  form: AuthorizationViewRenderer<AuthorizationFormViewV1>;
+  external_link: AuthorizationViewRenderer<AuthorizationExternalLinkViewV1>;
+  device_code: AuthorizationViewRenderer<AuthorizationDeviceCodeViewV1>;
+  qr_code: AuthorizationViewRenderer<AuthorizationQrCodeViewV1>;
+  progress: AuthorizationViewRenderer<AuthorizationProgressViewV1>;
+  result: AuthorizationViewRenderer<AuthorizationResultViewV1>;
+}
+
+interface AuthorizationFieldRendererMap {
+  text: AuthorizationFieldRenderer<TextAuthorizationFieldV1>;
+  secret: AuthorizationFieldRenderer<SecretAuthorizationFieldV1>;
+  number: AuthorizationFieldRenderer<NumberAuthorizationFieldV1>;
+  select: AuthorizationFieldRenderer<SelectAuthorizationFieldV1>;
+  boolean: AuthorizationFieldRenderer<BooleanAuthorizationFieldV1>;
+  local_file: AuthorizationFieldRenderer<LocalFileAuthorizationFieldV1>;
+}
+```
+
+宿主可以传入 `Partial<AuthorizationViewRendererMap>` 或
+`Partial<AuthorizationFieldRendererMap>` 覆盖局部实现。未知类型在 parser 阶段已经拒绝，
+不能静默跳过 required 字段。
+
+默认实现使用 `@tutti-os/ui-system` 的公开组件、图标和 token。字段 Renderer 只接收字段
+定义、当前值、字段错误和 `onChange`；不接收 Controller、Connector port 或 backend。
+
+Dialog 必须以 `renderKey` 作为 Renderer 的 React key。view 改变时强制销毁旧 subtree，
+确保 secret draft、倒计时、临时 object URL 和 field-local state 被清理。
+
+## 11. 典型场景
+
+### 11.1 邮箱和 IMAP/SMTP 授权码
+
+```json
+{
+  "protocol": "tutti.connector.authorization.view.v1",
+  "viewId": "mail-credentials-1",
+  "view": {
+    "type": "form",
+    "title": "邮箱授权",
+    "description": "输入邮箱地址和 IMAP/SMTP 授权码（非登录密码）",
+    "helpLinks": [
+      {
+        "label": "如何开启 IMAP/SMTP 并获取授权码",
+        "url": "https://example.com/mail-help"
+      }
+    ],
+    "submitLabel": "保存并连接",
+    "fields": [
+      {
+        "type": "text",
+        "format": "email",
+        "name": "email",
+        "label": "邮箱地址",
+        "required": true
+      },
+      {
+        "type": "secret",
+        "name": "authorization_code",
+        "label": "IMAP/SMTP 授权码",
+        "required": true
+      }
+    ]
+  }
+}
+```
+
+### 11.2 Figma PAT 完整流程
+
+Figma PAT 与腾讯文档 Personal Token 同属单 secret 场景，应完全走声明式配置，不发布
+Connector 专属授权 JS。Connector manifest 的 authorization method 在现有 profile 上增加
+presentation 和 submission 配置：
+
+```json
+{
+  "kind": "api_key",
+  "methods": [
+    {
+      "profileId": "figma-personal-token",
+      "profileVersion": "1",
+      "method": "api_key",
+      "displayName": "Connect Figma",
+      "backend": "native_secret",
+      "secret": {},
+      "interaction": {
+        "protocol": "tutti.connector.authorization.declarative.v1",
+        "initialView": {
+          "type": "form",
+          "title": "配置 Figma",
+          "description": "输入 Figma Personal Access Token",
+          "submitLabel": "保存并启用",
+          "fields": [
+            {
+              "type": "secret",
+              "name": "personal_access_token",
+              "label": "个人访问令牌",
+              "required": true
+            }
+          ]
+        },
+        "submission": {
+          "kind": "native_secret",
+          "secretField": "personal_access_token"
+        }
+      }
+    }
+  ]
+}
+```
+
+配置加载后，通用声明式 Adapter 为本次 flow 生成 `viewId`，输出 Renderer 协议帧：
+
+```json
+{
+  "protocol": "tutti.connector.authorization.view.v1",
+  "viewId": "figma-token-1",
+  "view": {
+    "type": "form",
+    "title": "配置 Figma",
+    "description": "输入 Figma Personal Access Token",
+    "submitLabel": "保存并启用",
+    "fields": [
+      {
+        "type": "secret",
+        "name": "personal_access_token",
+        "label": "个人访问令牌",
+        "required": true
+      }
+    ]
+  }
+}
+```
+
+Renderer 不理解 Figma，只按 `field.name` 生成 submit event：
+
+```json
+{
+  "protocol": "tutti.connector.authorization.event.v1",
+  "viewId": "figma-token-1",
+  "event": {
+    "type": "submit",
+    "values": {
+      "personal_access_token": "figd_..."
+    }
+  }
+}
+```
+
+通用 Adapter 校验事件后读取 `submission.secretField`，调用现有 `native_secret` 授权完成接口。
+验证、加密保存与运行时注入继续沿用已有 backend/binding：
+
+```text
+personal_access_token
+  -> submit.values.personal_access_token
+  -> declarative submission.native_secret
+  -> existing CompleteAuthorization secret proof
+  -> encrypted credential storage
+  -> trusted Figma binding
+  -> provider request header
+```
+
+这里不存在 Renderer 到具体 header 的直接映射，也没有 Figma 专属
+`handleFigmaAuthorization`。通用 Adapter 只把指定 secret 交给 backend，受信 binding 决定
+最终注入位置。验证失败时 Adapter 根据 backend 的结构化错误生成新的 form view 和
+`fieldErrors`；PAT 不能回传为 `defaultValue`。
+
+`timeout_seconds` 是 Connector 运行配置，不是授权凭证。首期不把它混入 `native_secret`
+submission；应由独立 settings 配置处理。如果未来要求在同一个 Dialog 提交，必须先定义
+一个明确的 `credential_and_settings` backend contract，再给声明式 submission union 增加对应
+分支，不能让 Renderer 直接写 runtime config。
+
+“让 Agent 帮我配置”是 Tutti 宿主能力，不由 Connector 协议下发按钮。宿主需要时在整体
+Renderer 外围根据可信 feature flag 添加。
+
+### 11.3 OAuth JSON 文件
+
+```json
+{
+  "protocol": "tutti.connector.authorization.view.v1",
+  "viewId": "google-oauth-file-1",
+  "view": {
+    "type": "form",
+    "title": "配置 Google 日历",
+    "fields": [
+      {
+        "type": "local_file",
+        "name": "oauth_credentials",
+        "label": "OAuth 凭据文件",
+        "required": true,
+        "extensions": [".json"]
+      }
+    ]
+  }
+}
+```
+
+Renderer 展示文件选择器，提交 opaque handle；协议不传 `~/...` 原始路径。
+
+### 11.4 二维码
+
+```json
+{
+  "protocol": "tutti.connector.authorization.view.v1",
+  "viewId": "scan-login-1",
+  "view": {
+    "type": "qr_code",
+    "title": "扫码授权",
+    "description": "请使用目标应用扫描二维码",
+    "source": {
+      "type": "payload",
+      "value": "https://example.com/device/authorize?challenge=opaque"
+    },
+    "fallbackText": "https://example.com/device/authorize?challenge=opaque",
+    "expiresAt": "2026-08-12T12:00:00Z",
+    "refreshable": true
+  }
+}
+```
+
+默认 Renderer 使用 Tutti 已有的 `qrcode-generator` 依赖本地编码。共享编码 helper 应放在
+适当的 UI 基础层或授权 UI 内部，不能让 Connector Market 反向依赖 Desktop feature。
+
+## 12. 错误模型
+
+协议边界错误由 Tutti 定义，不允许 Connector 模拟。`stale_view` 和
+`invalid_event_for_view` 由 Controller 的 view-aware validation 产生，其余错误来自 parser：
+
+```ts
+interface AuthorizationProtocolError {
+  code:
+    | "unsupported_protocol"
+    | "invalid_envelope"
+    | "invalid_view"
+    | "invalid_event"
+    | "invalid_event_for_view"
+    | "limit_exceeded"
+    | "stale_view";
+  path?: string;
+}
+```
+
+业务字段错误由 Connector 在收到 submit 后通过 form view 的 `fieldErrors` 返回。
+`fieldErrors` 只能引用当前 form 已声明字段，值是安全纯文本。返回错误时 Connector 必须生成
+新的 viewId，Controller 销毁旧 draft；如需保留非敏感输入，应由 Connector 在新 view 的
+对应字段 `defaultValue` 中显式返回。Connector 禁止回传 secret defaultValue，因此 secret
+失败后必须重新输入。
+
+Transport 错误、Connector 崩溃和 Renderer error boundary 使用 Tutti-owned
+`AuthorizationUiError`，不属于协议。
+
+## 13. 安全和隐私
+
+- Connector 字符串全部按纯文本展示；
+- URL 仅允许 HTTPS，开发策略可以显式允许 loopback HTTP；
+- 打开 URL 必须经过宿主 external navigation policy；
+- Renderer 不加载 Connector 提供的远程图片、SVG、HTML 或 data URL；
+- QR payload、fallbackText、PNG、secret、field values、file handle 和显示路径均不写入
+  日志、analytics、Valtio snapshot 或持久化；
+- secret 只存在于当前 Renderer subtree 的临时 draft；
+- view 切换、提交完成、失败、关闭和卸载都清空 secret；
+- protocol parse error 不记录原始 payload；
+- local file handle 绑定 flow、短期有效、只读、可撤销；
+- 自定义 Renderer 只能由可信宿主注入，Connector 无权选择；
+- Renderer event 在发送给 Connector 前必须再次进行 view-aware validation；
+- Connector 必须把 Renderer 输入视为不可信，并执行最终业务校验；
+- `viewId` 只防止本地旧 UI 事件错投，不替代 transport 层认证或 Connector 自身幂等性。
+
+## 14. 版本策略
+
+- V1 使用 `strictObject`，发布后属性集合和语义冻结；
+- 修正文档、收紧实现 bug 或增加 fixture 不改变版本；
+- 新增可见属性、view type、field type、value type 或事件语义必须发布 V2；
+- parser 通过完整 protocol literal 路由，未知版本 fail closed；
+- 同一个 UI Controller 可以注册多版本 parser，并归一化到内部 Renderer model；
+- V2 只有在需要兼容已发布 V1 Connector 时才引入 normalizer，不提前维护重复 domain type；
+- 首期不提供开放 `metadata` 或 `extensions` bag，避免形成无法校验的隐式协议；
+- Connector 和 Tutti 的版本协商属于 transport adapter，不属于 UI message 本身。
+
+## 15. 兼容迁移
+
+### 阶段 A：协议包
+
+- 新增 `@tutti-os/connector-authorization-protocol`；
+- 增加 Valibot dependency、V1 view/event Schema、parser、limits 和 fixtures；
+- 不修改 tsh-server；
+- 不生成 JSON Schema；
+- 暂不发布独立 npm SDK，直到存在明确的外部 Connector 消费需求。
+
+### 阶段 B：Controller 和默认 Renderer
+
+- 在 Connector Market 增加 interaction port 和 headless controller；
+- 增加默认 view/field renderer registry；
+- `ConnectorAuthorizationDialog` 只组合 Controller 和 Renderer；
+- 默认 UI 使用 `@tutti-os/ui-system`；
+- 整体 Renderer 注入点放在可信宿主 composition root。
+
+### 阶段 C：声明式 Adapter 与 Connector adoption
+
+- 在 Connector manifest contract 中增加可选 `interaction` 配置；该配置不属于 Renderer
+  protocol package，内部 `initialView` 复用同一份 View Schema；
+- 实现平台通用 declarative Adapter，负责生成 `viewId`、输出 view、消费 event，并调用现有
+  authorization backend；
+- Tencent Docs 和 Figma 单 token 场景只增加配置，不增加 Connector 专属 JS；
+- OAuth URL 只有在 provider 实际返回 URL 时映射为 `external_link`；
+- API key 只有在 Connector 明确声明表单字段时渲染 form；
+- 禁止继续用 `authorizationKind === "api_key"` 猜测 secret 表单；
+- 只在二维码、device code、轮询等声明式配置不能表达的流程实现自定义 Adapter；
+- legacy 与新协议使用独立 Controller，不能伪造 viewId 或假装旧路径支持异步 view。
+
+### 阶段 D：清理旧 UI 分支
+
+- 新 Connector 全部使用协议后，删除 Dialog 内的凭证类型分支；
+- 删除只为旧 Dialog 存在的 `secret?` 和 `authorizationUrl?` UI contract；
+- 兼容 adapter 的删除以实际 Connector 覆盖率为准，不与 tsh-server 升级绑定。
+
+## 16. 测试与验收
+
+### 16.1 Protocol tests
+
+- 每种 view 和 field 的最小/完整有效 fixture；
+- 未知协议、view、field、event 和额外属性失败；
+- 字符串、数组、URL、base64、PNG 和时间边界；
+- 重复 field name、重复 select value 和非法 defaultValue 失败；
+- submit 缺少 required、出现未知字段或类型不匹配失败；
+- stale viewId、非法 activate/refresh/retry 组合失败；
+- parser error 不包含输入值。
+- declarative contract fixture 证明 form 字段与 submission 引用完全一致；自定义 Adapter fixture
+  证明声明字段与消费字段完全一致。
+
+### 16.2 Controller tests
+
+- open stream 的首帧必须 parse 成功；
+- dispatch 串行且 busy 时重复点击不重复发送；
+- stream 中每一份 unknown view 都重新 parse，且消费顺序不倒退；
+- 旧 view 事件被本地拒绝；
+- view 切换和 close 撤销 stream、file handle 和 draft；
+- dispatch 不返回 view，Controller 保持当前 view，直到 stream 推送下一帧；
+- transport/protocol/Connector failure 映射为安全 UI error；
+- legacy 与 interaction controller 不共享假状态。
+
+### 16.3 Renderer tests
+
+- V1 所有 view 和 field 都有默认 Renderer；
+- 邮箱、PAT、OAuth JSON 文件和二维码 case 可完整渲染/提交；
+- QR payload 本地生成，PNG 校验失败时安全失败；
+- QR 过期后禁用并只在 refreshable 时显示刷新；
+- secret 不 trim、不持久化，view 改变时清空；
+- local_file 只提交 opaque handle；
+- whole/view/field 三层替换均有效；
+- 自定义 Renderer 不获得 Connector port 或 backend；
+- label、焦点、键盘提交、错误关联和 loading 状态满足可访问性要求。
+
+### 16.4 工程验证
+
+实施后至少运行：
+
+```bash
+pnpm --filter @tutti-os/connector-authorization-protocol test
+pnpm --filter @tutti-os/connector-authorization-protocol typecheck
+pnpm --filter @tutti-os/connector-authorization-protocol build
+pnpm --filter @tutti-os/connector-market test
+pnpm --filter @tutti-os/connector-market typecheck
+pnpm --filter @tutti-os/connector-market build
+pnpm check:changed
+```
+
+记录引入 Valibot 和默认 Renderer 前后的实际 bundle diff。Valibot 只能出现在协议解析边界，
+不得被表单状态或 UI component 直接依赖。
+
+## 17. PR 拆分和完成标准
+
+推荐三个可独立回滚的 PR：
+
+1. **protocol**：workspace package、Valibot Schema、parser、limits、fixtures；
+2. **renderer**：interaction port、Controller、默认 Renderer、注入点和 legacy Controller；
+3. **declarative adoption**：通用 Adapter、manifest interaction schema、Tencent Docs/Figma
+   配置迁移；动态流程再按需接入自定义 Adapter。
+
+方案完成标准：
+
+- tsh-server 没有新增协议代码或检测机制；
+- 协议包没有 React、UI System、Market 或 transport dependency；
+- ConnectorAuthorizationDialog 不再根据 Connector 类型决定字段；
+- Renderer 不调用 Connector API，只发结构化 event；
+- 声明式和自定义 Adapter 可以通过同一协议覆盖 form、URL、device code、QR、progress 和
+  result；
+- 更换整体 Renderer 不需要改 Connector；
+- 增加一个已有 V1 field/view 的 Connector 不需要修改 Dialog；
+- 所有 unknown Adapter 输出在渲染前 fail closed。

--- a/docs/specs/2026-08-12-connector-authorization-interaction.md
+++ b/docs/specs/2026-08-12-connector-authorization-interaction.md
@@ -603,7 +603,10 @@ authorization method 中增加 `interaction`，由平台通用 Adapter 消费：
 ```ts
 interface DeclarativeAuthorizationInteractionV1 {
   protocol: "tutti.connector.authorization.declarative.v1";
-  initialView: AuthorizationViewV1;
+  initialView: {
+    defaultLocale: string;
+    locales: Record<string, AuthorizationViewV1>;
+  };
   submission: {
     kind: "native_secret";
     secretField: string;
@@ -611,7 +614,9 @@ interface DeclarativeAuthorizationInteractionV1 {
 }
 ```
 
-`secretField` 只能引用 `initialView` 中类型为 `secret` 的字段。通用 Adapter 收到 submit 后，
+`initialView.defaultLocale` 必须引用 `initialView.locales` 中存在的语言项。locale 精确命中时选择
+对应 View，未命中时选择 `defaultLocale`；所有语言项必须保持相同字段 contract。
+`secretField` 只能引用每个语言 View 中类型为 `secret` 的字段。通用 Adapter 收到 submit 后，
 从 values 中取出该字段，并调用现有 `native_secret` complete 流程；它无权指定 header、host、
 endpoint 或文件路径。这些安全敏感的运行时映射继续由 tsh binding 或其他受信 runtime
 binding 管理。
@@ -622,17 +627,35 @@ binding 管理。
 {
   "protocol": "tutti.connector.authorization.declarative.v1",
   "initialView": {
-    "type": "form",
-    "title": "配置 Figma",
-    "submitLabel": "保存并启用",
-    "fields": [
-      {
-        "type": "secret",
-        "name": "personal_access_token",
-        "label": "个人访问令牌",
-        "required": true
+    "defaultLocale": "en-US",
+    "locales": {
+      "en-US": {
+        "type": "form",
+        "title": "Configure Figma",
+        "submitLabel": "Save and enable",
+        "fields": [
+          {
+            "type": "secret",
+            "name": "personal_access_token",
+            "label": "Personal access token",
+            "required": true
+          }
+        ]
+      },
+      "zh-CN": {
+        "type": "form",
+        "title": "配置 Figma",
+        "submitLabel": "保存并启用",
+        "fields": [
+          {
+            "type": "secret",
+            "name": "personal_access_token",
+            "label": "个人访问令牌",
+            "required": true
+          }
+        ]
       }
-    ]
+    }
   },
   "submission": {
     "kind": "native_secret",
@@ -658,16 +681,33 @@ personal_access_token
 {
   "protocol": "tutti.connector.authorization.declarative.v1",
   "initialView": {
-    "type": "form",
-    "title": "连接 Tencent Docs",
-    "fields": [
-      {
-        "type": "secret",
-        "name": "personal_token",
-        "label": "Personal Token",
-        "required": true
+    "defaultLocale": "en-US",
+    "locales": {
+      "en-US": {
+        "type": "form",
+        "title": "Connect Tencent Docs",
+        "fields": [
+          {
+            "type": "secret",
+            "name": "personal_token",
+            "label": "Personal Token",
+            "required": true
+          }
+        ]
+      },
+      "zh-CN": {
+        "type": "form",
+        "title": "连接腾讯文档",
+        "fields": [
+          {
+            "type": "secret",
+            "name": "personal_token",
+            "label": "Personal Token",
+            "required": true
+          }
+        ]
       }
-    ]
+    }
   },
   "submission": {
     "kind": "native_secret",
@@ -697,16 +737,21 @@ Connector manifest tooling 可以提供轻量 builder 校验 presentation 和 su
 const figmaAuthorization = defineDeclarativeAuthorization({
   protocol: "tutti.connector.authorization.declarative.v1",
   initialView: {
-    type: "form",
-    title: "配置 Figma",
-    fields: [
-      {
-        type: "secret",
-        name: "personal_access_token",
-        label: "个人访问令牌",
-        required: true
+    defaultLocale: "en-US",
+    locales: {
+      "en-US": {
+        type: "form",
+        title: "Configure Figma",
+        fields: [
+          {
+            type: "secret",
+            name: "personal_access_token",
+            label: "Personal access token",
+            required: true
+          }
+        ]
       }
-    ]
+    }
   },
   submission: {
     kind: "native_secret",
@@ -1100,18 +1145,37 @@ presentation 和 submission 配置：
       "interaction": {
         "protocol": "tutti.connector.authorization.declarative.v1",
         "initialView": {
-          "type": "form",
-          "title": "配置 Figma",
-          "description": "输入 Figma Personal Access Token",
-          "submitLabel": "保存并启用",
-          "fields": [
-            {
-              "type": "secret",
-              "name": "personal_access_token",
-              "label": "个人访问令牌",
-              "required": true
+          "defaultLocale": "en-US",
+          "locales": {
+            "en-US": {
+              "type": "form",
+              "title": "Configure Figma",
+              "description": "Enter a Figma Personal Access Token",
+              "submitLabel": "Save and enable",
+              "fields": [
+                {
+                  "type": "secret",
+                  "name": "personal_access_token",
+                  "label": "Personal access token",
+                  "required": true
+                }
+              ]
+            },
+            "zh-CN": {
+              "type": "form",
+              "title": "配置 Figma",
+              "description": "输入 Figma Personal Access Token",
+              "submitLabel": "保存并启用",
+              "fields": [
+                {
+                  "type": "secret",
+                  "name": "personal_access_token",
+                  "label": "个人访问令牌",
+                  "required": true
+                }
+              ]
             }
-          ]
+          }
         },
         "submission": {
           "kind": "native_secret",
@@ -1312,7 +1376,8 @@ Transport 错误、Connector 崩溃和 Renderer error boundary 使用 Tutti-owne
 ### 阶段 C：声明式 Adapter 与 Connector adoption
 
 - 在 Connector manifest contract 中增加可选 `interaction` 配置；该配置不属于 Renderer
-  protocol package，内部 `initialView` 复用同一份 View Schema；
+  protocol package，`initialView.locales` 的每个值复用同一份 View Schema，并由
+  `defaultLocale` 声明未命中时的回退项；
 - 实现平台通用 declarative Adapter，负责生成 `viewId`、输出 view、消费 event，并调用现有
   authorization backend；
 - Tencent Docs 和 Figma 单 token 场景只增加配置，不增加 Connector 专属 JS；

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -9,7 +9,7 @@ Specs are not the source of truth for behavior that has already landed. When a
 spec completes, update the current document that owns the result and delete the
 dated plan.
 
-There are currently nine active specs:
+There are currently ten active specs:
 
 - [Agent Provider Status Read/Detect Split](./2026-06-28-agent-status-read-detect-split-design.md): pending review.
 - [Agent Extension Package Design](./2026-07-14-agent-extension-package-design.md): pending architecture and implementation approval.
@@ -20,3 +20,4 @@ There are currently nine active specs:
 - [Tutti Agent `skills/list` Integration](./2026-07-30-tutti-agent-skills-list-integration.md): implemented; local Desktop end-to-end validation passed, pending cross-platform artifact validation.
 - [Connector Market Shared Domain](./2026-08-03-connector-market-shared-domain.md): signed shared core, Tutti daemon implementation host, and renderer service implemented; credential-backed connectors remain outside the initial compatibility boundary.
 - [Agent Conversation Activity View PRD](./2026-08-05-agent-conversation-activity-view-prd.md): implemented, pending code review.
+- [Connector Authorization UI Protocol](./2026-08-12-connector-authorization-interaction.md): accepted configuration-first protocol; protocol, declarative adapter, and replaceable renderer implementation in progress.

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -4837,6 +4837,12 @@ export type ConnectorMarketManifest = {
   permissions: Array<string>;
   implementation: ConnectorMarketImplementation;
   authorizationKind: string;
+  /**
+   * Opaque Connector-owned authorization interaction configuration. Hosts transport this value without interpreting its UI semantics; renderers must validate it against the versioned protocol.
+   */
+  authorizationInteraction?: {
+    [key: string]: unknown;
+  };
   compatibility?: ConnectorMarketCompatibilityRequirements;
 };
 

--- a/packages/connector/authorization-protocol/README.md
+++ b/packages/connector/authorization-protocol/README.md
@@ -1,0 +1,21 @@
+# Connector Authorization Protocol
+
+Host-neutral, versioned View/Event contracts for Connector authorization UI.
+
+- The protocol contains data only and has no React or transport dependency.
+- All untrusted payloads must pass the exported Valibot parsers before use.
+- Runtime credential routing remains outside this package.
+
+V1 includes:
+
+- strict `AuthorizationViewEnvelopeV1` and `AuthorizationEventEnvelopeV1`
+  contracts;
+- form, external-link, device-code, QR-code, progress, and result views;
+- text, secret, number, select, boolean, and opaque local-file fields;
+- view-aware event validation, including stale-view and unknown-field rejection;
+- a narrow declarative `native_secret` interaction whose submission field must
+  reference its only secret field.
+
+The declarative interaction is configuration, not executable Connector code.
+The host adapter owns runtime `viewId` generation and calls the existing trusted
+authorization backend after validation.

--- a/packages/connector/authorization-protocol/README.md
+++ b/packages/connector/authorization-protocol/README.md
@@ -14,7 +14,9 @@ V1 includes:
 - text, secret, number, select, boolean, and opaque local-file fields;
 - view-aware event validation, including stale-view and unknown-field rejection;
 - a narrow declarative `native_secret` interaction whose submission field must
-  reference its only secret field.
+  reference its only secret field;
+- symmetric localized initial views under `initialView.locales`, with an
+  explicit `initialView.defaultLocale` fallback.
 
 The declarative interaction is configuration, not executable Connector code.
 The host adapter owns runtime `viewId` generation and calls the existing trusted

--- a/packages/connector/authorization-protocol/package.json
+++ b/packages/connector/authorization-protocol/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@tutti-os/connector-authorization-protocol",
+  "version": "0.1.0",
+  "private": false,
+  "type": "module",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./v1": "./src/v1/index.ts"
+  },
+  "scripts": {
+    "build": "tsup --config tsup.config.ts",
+    "test": "tsx --test \"./src/**/*.test.ts\"",
+    "typecheck": "node ../../../tools/scripts/run-tsgo-typecheck.mjs"
+  },
+  "dependencies": {
+    "valibot": "^1.1.0"
+  },
+  "devDependencies": {
+    "@tutti-os/config-tsconfig": "workspace:*",
+    "@types/node": "^24.0.1",
+    "tsx": "^4.22.3",
+    "typescript": "^5.8.3"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tutti-os/tutti.git",
+    "directory": "packages/connector/authorization-protocol"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./v1": {
+        "types": "./dist/v1/index.d.ts",
+        "import": "./dist/v1/index.js"
+      }
+    },
+    "types": "./dist/index.d.ts"
+  }
+}

--- a/packages/connector/authorization-protocol/src/index.ts
+++ b/packages/connector/authorization-protocol/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./v1/index.ts";

--- a/packages/connector/authorization-protocol/src/v1/index.ts
+++ b/packages/connector/authorization-protocol/src/v1/index.ts
@@ -1,0 +1,2 @@
+export * from "./schema.ts";
+export * from "./validation.ts";

--- a/packages/connector/authorization-protocol/src/v1/schema.test.ts
+++ b/packages/connector/authorization-protocol/src/v1/schema.test.ts
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  AUTHORIZATION_DECLARATIVE_PROTOCOL_V1,
+  AUTHORIZATION_EVENT_PROTOCOL_V1,
+  AUTHORIZATION_VIEW_PROTOCOL_V1,
+  parseAuthorizationViewV1,
+  parseDeclarativeAuthorizationInteractionV1,
+  resolveDeclarativeAuthorizationInitialViewV1
+} from "./schema.ts";
+import { validateAuthorizationEventForViewV1 } from "./validation.ts";
+
+const figmaInteraction = {
+  protocol: AUTHORIZATION_DECLARATIVE_PROTOCOL_V1,
+  initialView: {
+    type: "form",
+    title: "Configure Figma",
+    fields: [
+      {
+        type: "secret",
+        name: "personal_access_token",
+        label: "Personal access token",
+        required: true
+      }
+    ]
+  },
+  submission: {
+    kind: "native_secret",
+    secretField: "personal_access_token"
+  }
+} as const;
+
+test("parses a declarative native-secret interaction", () => {
+  const result = parseDeclarativeAuthorizationInteractionV1(figmaInteraction);
+  assert.equal(result.ok, true);
+});
+
+test("rejects a native-secret mapping to an undeclared field", () => {
+  const result = parseDeclarativeAuthorizationInteractionV1({
+    ...figmaInteraction,
+    submission: {
+      kind: "native_secret",
+      secretField: "other_token"
+    }
+  });
+  assert.deepEqual(result, {
+    ok: false,
+    error: { code: "invalid_declarative_interaction" }
+  });
+});
+
+test("resolves an exact localized view and falls back to the default", () => {
+  const parsed = parseDeclarativeAuthorizationInteractionV1({
+    ...figmaInteraction,
+    localizedInitialViews: {
+      "zh-CN": {
+        ...figmaInteraction.initialView,
+        title: "配置 Figma"
+      }
+    }
+  });
+  assert.equal(parsed.ok, true);
+  if (!parsed.ok) return;
+  assert.equal(
+    resolveDeclarativeAuthorizationInitialViewV1(parsed.value, "zh-CN").title,
+    "配置 Figma"
+  );
+  assert.equal(
+    resolveDeclarativeAuthorizationInitialViewV1(parsed.value, "fr-FR").title,
+    "Configure Figma"
+  );
+});
+
+test("rejects unknown view properties", () => {
+  const result = parseAuthorizationViewV1({
+    protocol: AUTHORIZATION_VIEW_PROTOCOL_V1,
+    viewId: "figma-token-1",
+    view: {
+      ...figmaInteraction.initialView,
+      headerName: "X-Figma-Token"
+    }
+  });
+  assert.deepEqual(result, {
+    ok: false,
+    error: { code: "invalid_view" }
+  });
+});
+
+test("validates a submit event against the current form without trimming secrets", () => {
+  const view = {
+    protocol: AUTHORIZATION_VIEW_PROTOCOL_V1,
+    viewId: "figma-token-1",
+    view: figmaInteraction.initialView
+  };
+  const event = {
+    protocol: AUTHORIZATION_EVENT_PROTOCOL_V1,
+    viewId: "figma-token-1",
+    event: {
+      type: "submit",
+      values: { personal_access_token: "  figd_secret  " }
+    }
+  };
+  const result = validateAuthorizationEventForViewV1(view, event, {
+    isCurrentLocalFileHandle: () => false
+  });
+  assert.equal(result.ok, true);
+  if (result.ok && result.value.event.type === "submit") {
+    assert.equal(
+      result.value.event.values.personal_access_token,
+      "  figd_secret  "
+    );
+  }
+});
+
+test("rejects stale and unknown-field events", () => {
+  const view = {
+    protocol: AUTHORIZATION_VIEW_PROTOCOL_V1,
+    viewId: "figma-token-1",
+    view: figmaInteraction.initialView
+  };
+  const stale = validateAuthorizationEventForViewV1(
+    view,
+    {
+      protocol: AUTHORIZATION_EVENT_PROTOCOL_V1,
+      viewId: "figma-token-0",
+      event: {
+        type: "submit",
+        values: { personal_access_token: "figd_secret" }
+      }
+    },
+    { isCurrentLocalFileHandle: () => false }
+  );
+  assert.deepEqual(stale, { ok: false, error: { code: "stale_view" } });
+
+  const unknownField = validateAuthorizationEventForViewV1(
+    view,
+    {
+      protocol: AUTHORIZATION_EVENT_PROTOCOL_V1,
+      viewId: "figma-token-1",
+      event: {
+        type: "submit",
+        values: {
+          personal_access_token: "figd_secret",
+          header_name: "X-Figma-Token"
+        }
+      }
+    },
+    { isCurrentLocalFileHandle: () => false }
+  );
+  assert.deepEqual(unknownField, {
+    ok: false,
+    error: { code: "invalid_field", fieldName: "header_name" }
+  });
+});

--- a/packages/connector/authorization-protocol/src/v1/schema.test.ts
+++ b/packages/connector/authorization-protocol/src/v1/schema.test.ts
@@ -14,16 +14,21 @@ import { validateAuthorizationEventForViewV1 } from "./validation.ts";
 const figmaInteraction = {
   protocol: AUTHORIZATION_DECLARATIVE_PROTOCOL_V1,
   initialView: {
-    type: "form",
-    title: "Configure Figma",
-    fields: [
-      {
-        type: "secret",
-        name: "personal_access_token",
-        label: "Personal access token",
-        required: true
+    defaultLocale: "en-US",
+    locales: {
+      "en-US": {
+        type: "form",
+        title: "Configure Figma",
+        fields: [
+          {
+            type: "secret",
+            name: "personal_access_token",
+            label: "Personal access token",
+            required: true
+          }
+        ]
       }
-    ]
+    }
   },
   submission: {
     kind: "native_secret",
@@ -53,10 +58,14 @@ test("rejects a native-secret mapping to an undeclared field", () => {
 test("resolves an exact localized view and falls back to the default", () => {
   const parsed = parseDeclarativeAuthorizationInteractionV1({
     ...figmaInteraction,
-    localizedInitialViews: {
-      "zh-CN": {
-        ...figmaInteraction.initialView,
-        title: "配置 Figma"
+    initialView: {
+      ...figmaInteraction.initialView,
+      locales: {
+        ...figmaInteraction.initialView.locales,
+        "zh-CN": {
+          ...figmaInteraction.initialView.locales["en-US"],
+          title: "配置 Figma"
+        }
       }
     }
   });
@@ -72,12 +81,26 @@ test("resolves an exact localized view and falls back to the default", () => {
   );
 });
 
+test("rejects a missing default locale", () => {
+  const result = parseDeclarativeAuthorizationInteractionV1({
+    ...figmaInteraction,
+    initialView: {
+      ...figmaInteraction.initialView,
+      defaultLocale: "fr-FR"
+    }
+  });
+  assert.deepEqual(result, {
+    ok: false,
+    error: { code: "invalid_declarative_interaction" }
+  });
+});
+
 test("rejects unknown view properties", () => {
   const result = parseAuthorizationViewV1({
     protocol: AUTHORIZATION_VIEW_PROTOCOL_V1,
     viewId: "figma-token-1",
     view: {
-      ...figmaInteraction.initialView,
+      ...figmaInteraction.initialView.locales["en-US"],
       headerName: "X-Figma-Token"
     }
   });
@@ -91,7 +114,7 @@ test("validates a submit event against the current form without trimming secrets
   const view = {
     protocol: AUTHORIZATION_VIEW_PROTOCOL_V1,
     viewId: "figma-token-1",
-    view: figmaInteraction.initialView
+    view: figmaInteraction.initialView.locales["en-US"]
   };
   const event = {
     protocol: AUTHORIZATION_EVENT_PROTOCOL_V1,
@@ -117,7 +140,7 @@ test("rejects stale and unknown-field events", () => {
   const view = {
     protocol: AUTHORIZATION_VIEW_PROTOCOL_V1,
     viewId: "figma-token-1",
-    view: figmaInteraction.initialView
+    view: figmaInteraction.initialView.locales["en-US"]
   };
   const stale = validateAuthorizationEventForViewV1(
     view,

--- a/packages/connector/authorization-protocol/src/v1/schema.ts
+++ b/packages/connector/authorization-protocol/src/v1/schema.ts
@@ -1,0 +1,733 @@
+import * as v from "valibot";
+
+export const AUTHORIZATION_VIEW_PROTOCOL_V1 =
+  "tutti.connector.authorization.view.v1" as const;
+export const AUTHORIZATION_EVENT_PROTOCOL_V1 =
+  "tutti.connector.authorization.event.v1" as const;
+export const AUTHORIZATION_DECLARATIVE_PROTOCOL_V1 =
+  "tutti.connector.authorization.declarative.v1" as const;
+
+export const authorizationProtocolLimitsV1 = {
+  viewId: 128,
+  fieldName: 64,
+  title: 128,
+  label: 128,
+  description: 1_024,
+  message: 1_024,
+  placeholder: 128,
+  unit: 128,
+  actionLabel: 128,
+  url: 2_048,
+  helpLinksPerView: 8,
+  helpLinksPerField: 4,
+  fieldsPerForm: 16,
+  selectOptionsPerField: 100,
+  userText: 8_192,
+  qrPayloadBytes: 4_096,
+  qrPngBytes: 512 * 1_024,
+  qrPngDimension: 2_048,
+  localFileExtensions: 20
+} as const;
+
+const VIEW_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const FIELD_NAME_PATTERN = /^[a-z][a-z0-9_]{0,63}$/;
+const LOCALE_PATTERN = /^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$/;
+const HANDLE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const EXTENSION_PATTERN = /^\.[A-Za-z0-9][A-Za-z0-9._+-]{0,15}$/;
+const RFC3339_PATTERN =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:Z|[+-]\d{2}:\d{2})$/;
+const BASIC_EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function unicodeLength(value: string): number {
+  return Array.from(value).length;
+}
+
+function isBoundedUnicodeString(
+  value: string,
+  minimum: number,
+  maximum: number
+): boolean {
+  const length = unicodeLength(value);
+  return length >= minimum && length <= maximum;
+}
+
+function isFiniteSafeNumber(value: number): boolean {
+  return (
+    Number.isFinite(value) &&
+    (!Number.isInteger(value) || Number.isSafeInteger(value))
+  );
+}
+
+function isHttpsUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === "https:" &&
+      url.hostname.length > 0 &&
+      url.username === "" &&
+      url.password === ""
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isRfc3339Timestamp(value: string): boolean {
+  return RFC3339_PATTERN.test(value) && Number.isFinite(Date.parse(value));
+}
+
+function isStepAligned(value: number, base: number, step: number): boolean {
+  const quotient = (value - base) / step;
+  const nearest = Math.round(quotient);
+  const tolerance = Number.EPSILON * Math.max(1, Math.abs(quotient)) * 16;
+  return Math.abs(quotient - nearest) <= tolerance;
+}
+
+function decodeBase64(value: string): Uint8Array | null {
+  try {
+    const decoded = globalThis.atob(value);
+    return Uint8Array.from(decoded, (character) => character.charCodeAt(0));
+  } catch {
+    return null;
+  }
+}
+
+function isBoundedPng(value: string): boolean {
+  const bytes = decodeBase64(value);
+  if (
+    bytes === null ||
+    bytes.byteLength < 24 ||
+    bytes.byteLength > authorizationProtocolLimitsV1.qrPngBytes
+  ) {
+    return false;
+  }
+
+  const signature = [137, 80, 78, 71, 13, 10, 26, 10];
+  if (!signature.every((byte, index) => bytes[index] === byte)) {
+    return false;
+  }
+  if (
+    bytes[12] !== 73 ||
+    bytes[13] !== 72 ||
+    bytes[14] !== 68 ||
+    bytes[15] !== 82
+  ) {
+    return false;
+  }
+
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const width = view.getUint32(16);
+  const height = view.getUint32(20);
+  return (
+    width > 0 &&
+    height > 0 &&
+    width <= authorizationProtocolLimitsV1.qrPngDimension &&
+    height <= authorizationProtocolLimitsV1.qrPngDimension
+  );
+}
+
+function hasUniqueStrings(values: readonly string[]): boolean {
+  return new Set(values).size === values.length;
+}
+
+const boundedString = (minimum: number, maximum: number) =>
+  v.pipe(
+    v.string(),
+    v.check(
+      (value) => isBoundedUnicodeString(value, minimum, maximum),
+      "authorization.string_length"
+    )
+  );
+
+const nonEmptyTitleSchema = boundedString(
+  1,
+  authorizationProtocolLimitsV1.title
+);
+const nonEmptyLabelSchema = boundedString(
+  1,
+  authorizationProtocolLimitsV1.label
+);
+const descriptionSchema = boundedString(
+  1,
+  authorizationProtocolLimitsV1.description
+);
+const messageSchema = boundedString(1, authorizationProtocolLimitsV1.message);
+const placeholderSchema = boundedString(
+  1,
+  authorizationProtocolLimitsV1.placeholder
+);
+const unitSchema = boundedString(1, authorizationProtocolLimitsV1.unit);
+const actionLabelSchema = boundedString(
+  1,
+  authorizationProtocolLimitsV1.actionLabel
+);
+const httpsUrlSchema = v.pipe(
+  v.string(),
+  v.maxLength(authorizationProtocolLimitsV1.url, "authorization.url_too_long"),
+  v.check(isHttpsUrl, "authorization.invalid_https_url")
+);
+const userTextSchema = boundedString(0, authorizationProtocolLimitsV1.userText);
+
+export const authorizationViewIdV1Schema = v.pipe(
+  v.string(),
+  v.regex(VIEW_ID_PATTERN, "authorization.invalid_view_id")
+);
+
+export const authorizationFieldNameV1Schema = v.pipe(
+  v.string(),
+  v.regex(FIELD_NAME_PATTERN, "authorization.invalid_field_name")
+);
+
+export const authorizationHelpLinkV1Schema = v.strictObject({
+  label: nonEmptyLabelSchema,
+  url: httpsUrlSchema
+});
+
+const viewHelpLinksSchema = v.pipe(
+  v.array(authorizationHelpLinkV1Schema),
+  v.minLength(1, "authorization.empty_help_links"),
+  v.maxLength(
+    authorizationProtocolLimitsV1.helpLinksPerView,
+    "authorization.too_many_help_links"
+  )
+);
+
+const fieldHelpLinksSchema = v.pipe(
+  v.array(authorizationHelpLinkV1Schema),
+  v.minLength(1, "authorization.empty_help_links"),
+  v.maxLength(
+    authorizationProtocolLimitsV1.helpLinksPerField,
+    "authorization.too_many_help_links"
+  )
+);
+
+const optionalTimestampSchema = v.optional(
+  v.pipe(
+    v.string(),
+    v.maxLength(64, "authorization.timestamp_too_long"),
+    v.check(isRfc3339Timestamp, "authorization.invalid_timestamp")
+  )
+);
+
+const viewBaseEntries = {
+  title: v.optional(nonEmptyTitleSchema),
+  description: v.optional(descriptionSchema)
+};
+
+const fieldBaseEntries = {
+  name: authorizationFieldNameV1Schema,
+  label: nonEmptyLabelSchema,
+  description: v.optional(descriptionSchema),
+  helpLinks: v.optional(fieldHelpLinksSchema),
+  required: v.optional(v.boolean())
+};
+
+const lengthConstraintSchema = v.pipe(
+  v.number(),
+  v.integer("authorization.length_not_integer"),
+  v.minValue(0, "authorization.length_below_zero"),
+  v.maxValue(
+    authorizationProtocolLimitsV1.userText,
+    "authorization.length_too_large"
+  )
+);
+
+export const textAuthorizationFieldV1Schema = v.pipe(
+  v.strictObject({
+    type: v.literal("text"),
+    ...fieldBaseEntries,
+    format: v.optional(v.picklist(["plain", "email"])),
+    placeholder: v.optional(placeholderSchema),
+    defaultValue: v.optional(userTextSchema),
+    minLength: v.optional(lengthConstraintSchema),
+    maxLength: v.optional(lengthConstraintSchema)
+  }),
+  v.check((field) => {
+    const minimum = field.minLength ?? 0;
+    const maximum = field.maxLength ?? authorizationProtocolLimitsV1.userText;
+    if (minimum > maximum) {
+      return false;
+    }
+    if (field.defaultValue === undefined) {
+      return true;
+    }
+    const valueLength = unicodeLength(field.defaultValue);
+    return (
+      valueLength >= minimum &&
+      valueLength <= maximum &&
+      (field.format !== "email" ||
+        field.defaultValue === "" ||
+        BASIC_EMAIL_PATTERN.test(field.defaultValue.trim()))
+    );
+  }, "authorization.invalid_text_field_constraints")
+);
+
+export const secretAuthorizationFieldV1Schema = v.pipe(
+  v.strictObject({
+    type: v.literal("secret"),
+    ...fieldBaseEntries,
+    placeholder: v.optional(placeholderSchema),
+    minLength: v.optional(lengthConstraintSchema),
+    maxLength: v.optional(lengthConstraintSchema)
+  }),
+  v.check(
+    (field) =>
+      (field.minLength ?? 0) <=
+      (field.maxLength ?? authorizationProtocolLimitsV1.userText),
+    "authorization.invalid_secret_field_constraints"
+  )
+);
+
+const finiteSafeNumberSchema = v.pipe(
+  v.number(),
+  v.check(isFiniteSafeNumber, "authorization.invalid_number")
+);
+
+export const numberAuthorizationFieldV1Schema = v.pipe(
+  v.strictObject({
+    type: v.literal("number"),
+    ...fieldBaseEntries,
+    placeholder: v.optional(placeholderSchema),
+    defaultValue: v.optional(finiteSafeNumberSchema),
+    minimum: v.optional(finiteSafeNumberSchema),
+    maximum: v.optional(finiteSafeNumberSchema),
+    step: v.optional(
+      v.pipe(
+        finiteSafeNumberSchema,
+        v.minValue(Number.MIN_VALUE, "authorization.invalid_number_step")
+      )
+    ),
+    unit: v.optional(unitSchema)
+  }),
+  v.check((field) => {
+    if (
+      field.minimum !== undefined &&
+      field.maximum !== undefined &&
+      field.minimum > field.maximum
+    ) {
+      return false;
+    }
+    if (field.defaultValue === undefined) {
+      return true;
+    }
+    if (
+      (field.minimum !== undefined && field.defaultValue < field.minimum) ||
+      (field.maximum !== undefined && field.defaultValue > field.maximum)
+    ) {
+      return false;
+    }
+    return (
+      field.step === undefined ||
+      isStepAligned(field.defaultValue, field.minimum ?? 0, field.step)
+    );
+  }, "authorization.invalid_number_field_constraints")
+);
+
+export const selectAuthorizationOptionV1Schema = v.strictObject({
+  value: boundedString(1, 256),
+  label: nonEmptyLabelSchema,
+  description: v.optional(descriptionSchema)
+});
+
+export const selectAuthorizationFieldV1Schema = v.pipe(
+  v.strictObject({
+    type: v.literal("select"),
+    ...fieldBaseEntries,
+    defaultValue: v.optional(boundedString(1, 256)),
+    options: v.pipe(
+      v.array(selectAuthorizationOptionV1Schema),
+      v.minLength(1, "authorization.empty_select_options"),
+      v.maxLength(
+        authorizationProtocolLimitsV1.selectOptionsPerField,
+        "authorization.too_many_select_options"
+      )
+    )
+  }),
+  v.check((field) => {
+    const optionValues = field.options.map((option) => option.value);
+    return (
+      hasUniqueStrings(optionValues) &&
+      (field.defaultValue === undefined ||
+        optionValues.includes(field.defaultValue))
+    );
+  }, "authorization.invalid_select_field_constraints")
+);
+
+export const booleanAuthorizationFieldV1Schema = v.strictObject({
+  type: v.literal("boolean"),
+  ...fieldBaseEntries,
+  defaultValue: v.optional(v.boolean())
+});
+
+const localFileExtensionSchema = v.pipe(
+  v.string(),
+  v.regex(EXTENSION_PATTERN, "authorization.invalid_file_extension")
+);
+
+export const localFileAuthorizationFieldV1Schema = v.strictObject({
+  type: v.literal("local_file"),
+  ...fieldBaseEntries,
+  extensions: v.optional(
+    v.pipe(
+      v.array(localFileExtensionSchema),
+      v.minLength(1, "authorization.empty_file_extensions"),
+      v.maxLength(
+        authorizationProtocolLimitsV1.localFileExtensions,
+        "authorization.too_many_file_extensions"
+      ),
+      v.check(
+        (extensions) => hasUniqueStrings(extensions),
+        "authorization.duplicate_file_extensions"
+      )
+    )
+  )
+});
+
+export const authorizationFieldV1Schema = v.variant("type", [
+  textAuthorizationFieldV1Schema,
+  secretAuthorizationFieldV1Schema,
+  numberAuthorizationFieldV1Schema,
+  selectAuthorizationFieldV1Schema,
+  booleanAuthorizationFieldV1Schema,
+  localFileAuthorizationFieldV1Schema
+]);
+
+const fieldErrorsSchema = v.pipe(
+  v.record(authorizationFieldNameV1Schema, messageSchema),
+  v.check(
+    (errors) =>
+      Object.keys(errors).length <= authorizationProtocolLimitsV1.fieldsPerForm,
+    "authorization.too_many_field_errors"
+  )
+);
+
+export const authorizationFormViewV1Schema = v.pipe(
+  v.strictObject({
+    type: v.literal("form"),
+    ...viewBaseEntries,
+    helpLinks: v.optional(viewHelpLinksSchema),
+    fields: v.pipe(
+      v.array(authorizationFieldV1Schema),
+      v.minLength(1, "authorization.empty_form"),
+      v.maxLength(
+        authorizationProtocolLimitsV1.fieldsPerForm,
+        "authorization.too_many_fields"
+      )
+    ),
+    fieldErrors: v.optional(fieldErrorsSchema),
+    submitLabel: v.optional(actionLabelSchema)
+  }),
+  v.check((view) => {
+    const fieldNames = view.fields.map((field) => field.name);
+    return (
+      hasUniqueStrings(fieldNames) &&
+      (view.fieldErrors === undefined ||
+        Object.keys(view.fieldErrors).every((name) =>
+          fieldNames.includes(name)
+        ))
+    );
+  }, "authorization.invalid_form_constraints")
+);
+
+export const authorizationExternalLinkViewV1Schema = v.strictObject({
+  type: v.literal("external_link"),
+  ...viewBaseEntries,
+  url: httpsUrlSchema,
+  actionLabel: v.optional(actionLabelSchema),
+  expiresAt: optionalTimestampSchema
+});
+
+export const authorizationDeviceCodeViewV1Schema = v.strictObject({
+  type: v.literal("device_code"),
+  ...viewBaseEntries,
+  verificationUrl: httpsUrlSchema,
+  userCode: boundedString(1, 128),
+  actionLabel: v.optional(actionLabelSchema),
+  expiresAt: optionalTimestampSchema
+});
+
+export const authorizationQrCodeSourceV1Schema = v.variant("type", [
+  v.strictObject({
+    type: v.literal("payload"),
+    value: v.pipe(
+      v.string(),
+      v.check((value) => {
+        const length = new TextEncoder().encode(value).byteLength;
+        return (
+          length > 0 && length <= authorizationProtocolLimitsV1.qrPayloadBytes
+        );
+      }, "authorization.invalid_qr_payload")
+    )
+  }),
+  v.strictObject({
+    type: v.literal("png_base64"),
+    value: v.pipe(
+      v.string(),
+      v.maxLength(
+        Math.ceil(authorizationProtocolLimitsV1.qrPngBytes / 3) * 4,
+        "authorization.qr_png_base64_too_long"
+      ),
+      v.base64("authorization.invalid_base64"),
+      v.check(isBoundedPng, "authorization.invalid_qr_png")
+    )
+  })
+]);
+
+export const authorizationQrCodeViewV1Schema = v.strictObject({
+  type: v.literal("qr_code"),
+  ...viewBaseEntries,
+  source: authorizationQrCodeSourceV1Schema,
+  fallbackText: v.optional(userTextSchema),
+  expiresAt: optionalTimestampSchema,
+  refreshable: v.optional(v.boolean())
+});
+
+export const authorizationProgressViewV1Schema = v.strictObject({
+  type: v.literal("progress"),
+  ...viewBaseEntries,
+  message: v.optional(messageSchema)
+});
+
+export const authorizationResultViewV1Schema = v.pipe(
+  v.strictObject({
+    type: v.literal("result"),
+    ...viewBaseEntries,
+    outcome: v.picklist(["success", "failure"]),
+    message: v.optional(messageSchema),
+    retryable: v.optional(v.boolean())
+  }),
+  v.check(
+    (view) => view.outcome === "failure" || view.retryable === undefined,
+    "authorization.success_cannot_retry"
+  )
+);
+
+export const authorizationViewV1Schema = v.variant("type", [
+  authorizationFormViewV1Schema,
+  authorizationExternalLinkViewV1Schema,
+  authorizationDeviceCodeViewV1Schema,
+  authorizationQrCodeViewV1Schema,
+  authorizationProgressViewV1Schema,
+  authorizationResultViewV1Schema
+]);
+
+export const authorizationViewEnvelopeV1Schema = v.strictObject({
+  protocol: v.literal(AUTHORIZATION_VIEW_PROTOCOL_V1),
+  viewId: authorizationViewIdV1Schema,
+  view: authorizationViewV1Schema
+});
+
+export const nativeSecretAuthorizationSubmissionV1Schema = v.strictObject({
+  kind: v.literal("native_secret"),
+  secretField: authorizationFieldNameV1Schema
+});
+
+const authorizationLocaleV1Schema = v.pipe(
+  v.string(),
+  v.regex(LOCALE_PATTERN, "authorization.invalid_locale")
+);
+
+const localizedInitialViewsV1Schema = v.pipe(
+  v.record(authorizationLocaleV1Schema, authorizationViewV1Schema),
+  v.check(
+    (views) => Object.keys(views).length > 0 && Object.keys(views).length <= 8,
+    "authorization.invalid_localized_views"
+  )
+);
+
+function isNativeSecretForm(
+  view: AuthorizationViewV1,
+  secretField: string
+): boolean {
+  if (view.type !== "form") return false;
+  const secretFields = view.fields.filter((field) => field.type === "secret");
+  return (
+    view.fields.length === 1 &&
+    secretFields.length === 1 &&
+    secretFields[0]?.name === secretField
+  );
+}
+
+export const declarativeAuthorizationInteractionV1Schema = v.pipe(
+  v.strictObject({
+    protocol: v.literal(AUTHORIZATION_DECLARATIVE_PROTOCOL_V1),
+    initialView: authorizationViewV1Schema,
+    localizedInitialViews: v.optional(localizedInitialViewsV1Schema),
+    submission: nativeSecretAuthorizationSubmissionV1Schema
+  }),
+  v.check((interaction) => {
+    const views = [
+      interaction.initialView,
+      ...Object.values(interaction.localizedInitialViews ?? {})
+    ];
+    return views.every((view) =>
+      isNativeSecretForm(view, interaction.submission.secretField)
+    );
+  }, "authorization.invalid_native_secret_interaction")
+);
+
+export const authorizationLocalFileValueV1Schema = v.strictObject({
+  type: v.literal("local_file"),
+  handleId: v.pipe(
+    v.string(),
+    v.regex(HANDLE_ID_PATTERN, "authorization.invalid_file_handle")
+  )
+});
+
+export const authorizationValueV1Schema = v.union([
+  userTextSchema,
+  finiteSafeNumberSchema,
+  v.boolean(),
+  authorizationLocalFileValueV1Schema
+]);
+
+const submitValuesSchema = v.pipe(
+  v.record(authorizationFieldNameV1Schema, authorizationValueV1Schema),
+  v.check(
+    (values) =>
+      Object.keys(values).length <= authorizationProtocolLimitsV1.fieldsPerForm,
+    "authorization.too_many_submit_values"
+  )
+);
+
+export const authorizationSubmitEventV1Schema = v.strictObject({
+  type: v.literal("submit"),
+  values: submitValuesSchema
+});
+
+export const authorizationActivateEventV1Schema = v.strictObject({
+  type: v.literal("activate")
+});
+
+export const authorizationRefreshEventV1Schema = v.strictObject({
+  type: v.literal("refresh")
+});
+
+export const authorizationRetryEventV1Schema = v.strictObject({
+  type: v.literal("retry")
+});
+
+export const authorizationCancelEventV1Schema = v.strictObject({
+  type: v.literal("cancel")
+});
+
+export const authorizationEventV1Schema = v.variant("type", [
+  authorizationSubmitEventV1Schema,
+  authorizationActivateEventV1Schema,
+  authorizationRefreshEventV1Schema,
+  authorizationRetryEventV1Schema,
+  authorizationCancelEventV1Schema
+]);
+
+export const authorizationEventEnvelopeV1Schema = v.strictObject({
+  protocol: v.literal(AUTHORIZATION_EVENT_PROTOCOL_V1),
+  viewId: authorizationViewIdV1Schema,
+  event: authorizationEventV1Schema
+});
+
+export type AuthorizationHelpLinkV1 = v.InferOutput<
+  typeof authorizationHelpLinkV1Schema
+>;
+export type AuthorizationFieldV1 = v.InferOutput<
+  typeof authorizationFieldV1Schema
+>;
+export type AuthorizationFormViewV1 = v.InferOutput<
+  typeof authorizationFormViewV1Schema
+>;
+export type AuthorizationViewV1 = v.InferOutput<
+  typeof authorizationViewV1Schema
+>;
+export type AuthorizationViewEnvelopeV1 = v.InferOutput<
+  typeof authorizationViewEnvelopeV1Schema
+>;
+export type DeclarativeAuthorizationInteractionV1 = v.InferOutput<
+  typeof declarativeAuthorizationInteractionV1Schema
+>;
+export type AuthorizationLocalFileValueV1 = v.InferOutput<
+  typeof authorizationLocalFileValueV1Schema
+>;
+export type AuthorizationValueV1 = v.InferOutput<
+  typeof authorizationValueV1Schema
+>;
+export type AuthorizationEventV1 = v.InferOutput<
+  typeof authorizationEventV1Schema
+>;
+export type AuthorizationEventEnvelopeV1 = v.InferOutput<
+  typeof authorizationEventEnvelopeV1Schema
+>;
+
+export type AuthorizationProtocolParseErrorCode =
+  | "invalid_declarative_interaction"
+  | "invalid_event"
+  | "invalid_view";
+
+export interface AuthorizationProtocolParseError {
+  code: AuthorizationProtocolParseErrorCode;
+}
+
+export type AuthorizationProtocolParseResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: AuthorizationProtocolParseError };
+
+function parseProtocolValue<
+  TSchema extends v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>
+>(
+  schema: TSchema,
+  input: unknown,
+  code: AuthorizationProtocolParseErrorCode
+): AuthorizationProtocolParseResult<v.InferOutput<TSchema>> {
+  const result = v.safeParse(schema, input);
+  return result.success
+    ? { ok: true, value: result.output }
+    : { ok: false, error: { code } };
+}
+
+export function parseAuthorizationViewV1(
+  input: unknown
+): AuthorizationProtocolParseResult<AuthorizationViewEnvelopeV1> {
+  return parseProtocolValue(
+    authorizationViewEnvelopeV1Schema,
+    input,
+    "invalid_view"
+  );
+}
+
+export function parseAuthorizationEventV1(
+  input: unknown
+): AuthorizationProtocolParseResult<AuthorizationEventEnvelopeV1> {
+  return parseProtocolValue(
+    authorizationEventEnvelopeV1Schema,
+    input,
+    "invalid_event"
+  );
+}
+
+export function parseDeclarativeAuthorizationInteractionV1(
+  input: unknown
+): AuthorizationProtocolParseResult<DeclarativeAuthorizationInteractionV1> {
+  return parseProtocolValue(
+    declarativeAuthorizationInteractionV1Schema,
+    input,
+    "invalid_declarative_interaction"
+  );
+}
+
+export function resolveDeclarativeAuthorizationInitialViewV1(
+  interaction: DeclarativeAuthorizationInteractionV1,
+  locale: string
+): AuthorizationViewV1 {
+  const normalized = locale.trim();
+  const language = normalized.split("-")[0];
+  return (
+    interaction.localizedInitialViews?.[normalized] ??
+    (language ? interaction.localizedInitialViews?.[language] : undefined) ??
+    interaction.initialView
+  );
+}
+
+export function defineAuthorizationForm<
+  const TForm extends v.InferInput<typeof authorizationFormViewV1Schema>
+>(form: TForm): TForm {
+  v.parse(authorizationFormViewV1Schema, form);
+  return form;
+}

--- a/packages/connector/authorization-protocol/src/v1/schema.ts
+++ b/packages/connector/authorization-protocol/src/v1/schema.ts
@@ -527,11 +527,23 @@ const authorizationLocaleV1Schema = v.pipe(
   v.regex(LOCALE_PATTERN, "authorization.invalid_locale")
 );
 
-const localizedInitialViewsV1Schema = v.pipe(
+const authorizationLocalizedViewsV1Schema = v.pipe(
   v.record(authorizationLocaleV1Schema, authorizationViewV1Schema),
   v.check(
     (views) => Object.keys(views).length > 0 && Object.keys(views).length <= 8,
     "authorization.invalid_localized_views"
+  )
+);
+
+export const authorizationLocalizedViewV1Schema = v.pipe(
+  v.strictObject({
+    defaultLocale: authorizationLocaleV1Schema,
+    locales: authorizationLocalizedViewsV1Schema
+  }),
+  v.check(
+    (localizedView) =>
+      Object.hasOwn(localizedView.locales, localizedView.defaultLocale),
+    "authorization.missing_default_locale"
   )
 );
 
@@ -551,15 +563,11 @@ function isNativeSecretForm(
 export const declarativeAuthorizationInteractionV1Schema = v.pipe(
   v.strictObject({
     protocol: v.literal(AUTHORIZATION_DECLARATIVE_PROTOCOL_V1),
-    initialView: authorizationViewV1Schema,
-    localizedInitialViews: v.optional(localizedInitialViewsV1Schema),
+    initialView: authorizationLocalizedViewV1Schema,
     submission: nativeSecretAuthorizationSubmissionV1Schema
   }),
   v.check((interaction) => {
-    const views = [
-      interaction.initialView,
-      ...Object.values(interaction.localizedInitialViews ?? {})
-    ];
+    const views = Object.values(interaction.initialView.locales);
     return views.every((view) =>
       isNativeSecretForm(view, interaction.submission.secretField)
     );
@@ -717,11 +725,9 @@ export function resolveDeclarativeAuthorizationInitialViewV1(
   locale: string
 ): AuthorizationViewV1 {
   const normalized = locale.trim();
-  const language = normalized.split("-")[0];
   return (
-    interaction.localizedInitialViews?.[normalized] ??
-    (language ? interaction.localizedInitialViews?.[language] : undefined) ??
-    interaction.initialView
+    interaction.initialView.locales[normalized] ??
+    interaction.initialView.locales[interaction.initialView.defaultLocale]!
   );
 }
 

--- a/packages/connector/authorization-protocol/src/v1/validation.ts
+++ b/packages/connector/authorization-protocol/src/v1/validation.ts
@@ -1,0 +1,266 @@
+import * as v from "valibot";
+
+import {
+  authorizationEventEnvelopeV1Schema,
+  authorizationProtocolLimitsV1,
+  authorizationViewEnvelopeV1Schema,
+  type AuthorizationEventEnvelopeV1,
+  type AuthorizationFieldV1,
+  type AuthorizationFormViewV1,
+  type AuthorizationValueV1,
+  type AuthorizationViewEnvelopeV1
+} from "./schema.ts";
+
+const BASIC_EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+type TextField = Extract<AuthorizationFieldV1, { type: "text" }>;
+type SecretField = Extract<AuthorizationFieldV1, { type: "secret" }>;
+type NumberField = Extract<AuthorizationFieldV1, { type: "number" }>;
+type SubmitEventEnvelope = AuthorizationEventEnvelopeV1 & {
+  event: Extract<AuthorizationEventEnvelopeV1["event"], { type: "submit" }>;
+};
+
+export type AuthorizationEventForViewErrorCode =
+  | "invalid_event"
+  | "stale_view"
+  | "invalid_event_for_view"
+  | "invalid_field";
+
+export interface AuthorizationEventForViewError {
+  code: AuthorizationEventForViewErrorCode;
+  fieldName?: string;
+}
+
+export type AuthorizationEventForViewResult =
+  | { ok: true; value: AuthorizationEventEnvelopeV1 }
+  | { ok: false; error: AuthorizationEventForViewError };
+
+export interface AuthorizationEventValidationContext {
+  isCurrentLocalFileHandle(handleId: string): boolean;
+}
+
+function invalidEventForView(
+  code: AuthorizationEventForViewErrorCode,
+  fieldName?: string
+): AuthorizationEventForViewResult {
+  return {
+    ok: false,
+    error: { code, ...(fieldName === undefined ? {} : { fieldName }) }
+  };
+}
+
+function unicodeLength(value: string): number {
+  return Array.from(value).length;
+}
+
+function isFiniteSafeNumber(value: number): boolean {
+  return (
+    Number.isFinite(value) &&
+    (!Number.isInteger(value) || Number.isSafeInteger(value))
+  );
+}
+
+function isStepAligned(value: number, base: number, step: number): boolean {
+  const quotient = (value - base) / step;
+  const nearest = Math.round(quotient);
+  const tolerance = Number.EPSILON * Math.max(1, Math.abs(quotient)) * 16;
+  return Math.abs(quotient - nearest) <= tolerance;
+}
+
+function isTextValueValid(field: TextField, value: string): boolean {
+  const length = unicodeLength(value);
+  if (
+    length < (field.minLength ?? 0) ||
+    length > (field.maxLength ?? authorizationProtocolLimitsV1.userText)
+  ) {
+    return false;
+  }
+  return field.format !== "email" || BASIC_EMAIL_PATTERN.test(value);
+}
+
+function isSecretValueValid(field: SecretField, value: string): boolean {
+  const length = unicodeLength(value);
+  return (
+    length >= (field.minLength ?? 0) &&
+    length <= (field.maxLength ?? authorizationProtocolLimitsV1.userText)
+  );
+}
+
+function isNumberValueValid(field: NumberField, value: number): boolean {
+  if (
+    !isFiniteSafeNumber(value) ||
+    (field.minimum !== undefined && value < field.minimum) ||
+    (field.maximum !== undefined && value > field.maximum)
+  ) {
+    return false;
+  }
+  return (
+    field.step === undefined ||
+    isStepAligned(value, field.minimum ?? 0, field.step)
+  );
+}
+
+function validateFormSubmission(
+  viewEnvelope: AuthorizationViewEnvelopeV1 & {
+    view: AuthorizationFormViewV1;
+  },
+  eventEnvelope: SubmitEventEnvelope,
+  context: AuthorizationEventValidationContext
+): AuthorizationEventForViewResult {
+  const fieldsByName = new Map(
+    viewEnvelope.view.fields.map((field) => [field.name, field])
+  );
+
+  for (const name of Object.keys(eventEnvelope.event.values)) {
+    if (!fieldsByName.has(name)) {
+      return invalidEventForView("invalid_field", name);
+    }
+  }
+
+  const normalizedValues: Record<string, AuthorizationValueV1> = {};
+  for (const field of viewEnvelope.view.fields) {
+    const value = eventEnvelope.event.values[field.name];
+
+    if (field.type === "boolean" && value === undefined) {
+      return invalidEventForView("invalid_field", field.name);
+    }
+    if (value === undefined) {
+      if (field.required) {
+        return invalidEventForView("invalid_field", field.name);
+      }
+      continue;
+    }
+
+    switch (field.type) {
+      case "text": {
+        if (typeof value !== "string") {
+          return invalidEventForView("invalid_field", field.name);
+        }
+        const normalized = value.trim();
+        if (normalized === "" && !field.required) continue;
+        if (
+          (field.required && normalized === "") ||
+          !isTextValueValid(field, normalized)
+        ) {
+          return invalidEventForView("invalid_field", field.name);
+        }
+        normalizedValues[field.name] = normalized;
+        break;
+      }
+      case "secret":
+        if (
+          typeof value !== "string" ||
+          (field.required && value === "") ||
+          !isSecretValueValid(field, value)
+        ) {
+          return invalidEventForView("invalid_field", field.name);
+        }
+        normalizedValues[field.name] = value;
+        break;
+      case "number":
+        if (typeof value !== "number" || !isNumberValueValid(field, value)) {
+          return invalidEventForView("invalid_field", field.name);
+        }
+        normalizedValues[field.name] = value;
+        break;
+      case "select":
+        if (
+          typeof value !== "string" ||
+          !field.options.some((option) => option.value === value)
+        ) {
+          return invalidEventForView("invalid_field", field.name);
+        }
+        normalizedValues[field.name] = value;
+        break;
+      case "boolean":
+        if (
+          typeof value !== "boolean" ||
+          (field.required === true && value !== true)
+        ) {
+          return invalidEventForView("invalid_field", field.name);
+        }
+        normalizedValues[field.name] = value;
+        break;
+      case "local_file":
+        if (
+          typeof value !== "object" ||
+          value === null ||
+          !("type" in value) ||
+          value.type !== "local_file" ||
+          !("handleId" in value) ||
+          typeof value.handleId !== "string" ||
+          !context.isCurrentLocalFileHandle(value.handleId)
+        ) {
+          return invalidEventForView("invalid_field", field.name);
+        }
+        normalizedValues[field.name] = value;
+        break;
+    }
+  }
+
+  return {
+    ok: true,
+    value: {
+      ...eventEnvelope,
+      event: { type: "submit", values: normalizedValues }
+    }
+  };
+}
+
+export function validateAuthorizationEventForViewV1(
+  currentViewInput: unknown,
+  eventInput: unknown,
+  context: AuthorizationEventValidationContext
+): AuthorizationEventForViewResult {
+  const currentViewResult = v.safeParse(
+    authorizationViewEnvelopeV1Schema,
+    currentViewInput
+  );
+  const eventResult = v.safeParse(
+    authorizationEventEnvelopeV1Schema,
+    eventInput
+  );
+  if (!currentViewResult.success || !eventResult.success) {
+    return invalidEventForView("invalid_event");
+  }
+
+  const currentView = currentViewResult.output;
+  const eventEnvelope = eventResult.output;
+  if (currentView.viewId !== eventEnvelope.viewId) {
+    return invalidEventForView("stale_view");
+  }
+  if (eventEnvelope.event.type === "cancel") {
+    return { ok: true, value: eventEnvelope };
+  }
+
+  switch (currentView.view.type) {
+    case "form":
+      return eventEnvelope.event.type === "submit"
+        ? validateFormSubmission(
+            currentView as AuthorizationViewEnvelopeV1 & {
+              view: AuthorizationFormViewV1;
+            },
+            eventEnvelope as SubmitEventEnvelope,
+            context
+          )
+        : invalidEventForView("invalid_event_for_view");
+    case "external_link":
+    case "device_code":
+      return eventEnvelope.event.type === "activate"
+        ? { ok: true, value: eventEnvelope }
+        : invalidEventForView("invalid_event_for_view");
+    case "qr_code":
+      return eventEnvelope.event.type === "refresh" &&
+        currentView.view.refreshable === true
+        ? { ok: true, value: eventEnvelope }
+        : invalidEventForView("invalid_event_for_view");
+    case "result":
+      return eventEnvelope.event.type === "retry" &&
+        currentView.view.outcome === "failure" &&
+        currentView.view.retryable === true
+        ? { ok: true, value: eventEnvelope }
+        : invalidEventForView("invalid_event_for_view");
+    case "progress":
+      return invalidEventForView("invalid_event_for_view");
+  }
+}

--- a/packages/connector/authorization-protocol/tsconfig.json
+++ b/packages/connector/authorization-protocol/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../packages/configs/tsconfig/base.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*", "tsup.config.ts"]
+}

--- a/packages/connector/authorization-protocol/tsup.config.ts
+++ b/packages/connector/authorization-protocol/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  clean: true,
+  dts: true,
+  entry: {
+    index: "src/index.ts",
+    "v1/index": "src/v1/index.ts"
+  },
+  external: ["valibot"],
+  format: ["esm"],
+  sourcemap: true
+});

--- a/packages/connector/daemon/catalog_source.go
+++ b/packages/connector/daemon/catalog_source.go
@@ -253,6 +253,10 @@ func (source *CatalogSource) mapItem(item wireMarketItem) (market.Release, error
 	if err != nil {
 		return market.Release{}, err
 	}
+	authorizationInteraction, err := connectorManifest.Payload.Authorization.interaction()
+	if err != nil {
+		return market.Release{}, err
+	}
 	releaseDigest := sha256.Sum256([]byte(item.ItemKey + "\x00" + item.Version + "\x00" + item.Artifact.SHA256))
 	iconURL := connectorManifest.Display.IconURL
 	if strings.TrimSpace(iconURL) == "" {
@@ -266,7 +270,8 @@ func (source *CatalogSource) mapItem(item wireMarketItem) (market.Release, error
 		Permissions:          connectorManifest.Payload.Permissions,
 		RequiredCapabilities: connectorManifest.Payload.RequiredCapabilities,
 		Implementation:       implementation, AuthorizationKind: connectorManifest.Payload.Authorization.Kind,
-		Compatibility: connectorManifest.Payload.Compatibility}
+		AuthorizationInteraction: authorizationInteraction,
+		Compatibility:            connectorManifest.Payload.Compatibility}
 	release := market.Release{SchemaVersion: "1", ReleaseID: item.ItemKey + "@" + item.Version,
 		ConnectorKey: item.ItemKey, Version: item.Version,
 		ReleaseDigest: hex.EncodeToString(releaseDigest[:]), ManifestDigest: connectorManifest.Payload.PackageManifestSHA256,
@@ -377,7 +382,26 @@ type wireConnectorManifestPayload struct {
 }
 
 type wireConnectorAuthorization struct {
-	Kind string `json:"kind"`
+	Kind    string                             `json:"kind"`
+	Methods []wireConnectorAuthorizationMethod `json:"methods,omitempty"`
+}
+
+type wireConnectorAuthorizationMethod struct {
+	Interaction json.RawMessage `json:"interaction,omitempty"`
+}
+
+func (authorization wireConnectorAuthorization) interaction() (json.RawMessage, error) {
+	var selected json.RawMessage
+	for _, method := range authorization.Methods {
+		if len(method.Interaction) == 0 || string(method.Interaction) == "null" {
+			continue
+		}
+		if len(selected) != 0 {
+			return nil, errors.New("connector authorization must declare at most one interaction")
+		}
+		selected = append(json.RawMessage(nil), method.Interaction...)
+	}
+	return selected, nil
 }
 
 const legacyConnectorIconURL = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCI+PHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTQiIGZpbGw9IiM2YjcyODAiLz48cGF0aCBkPSJNMTggMjBoMjh2MjRIMTh6IiBmaWxsPSJub25lIiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjQiLz48L3N2Zz4="

--- a/packages/connector/daemon/catalog_source_test.go
+++ b/packages/connector/daemon/catalog_source_test.go
@@ -135,7 +135,24 @@ func TestCatalogSourcePreservesRemoteRequiredCapabilities(t *testing.T) {
     "permissions": [],
     "requiredCapabilities": ["tools"],
     "packageManifestSha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-    "authorization": {"kind": "api_key"},
+    "authorization": {
+      "kind": "api_key",
+      "methods": [{
+        "interaction": {
+          "protocol": "tutti.connector.authorization.declarative.v1",
+          "initialView": {
+            "type": "form",
+            "fields": [{
+              "type": "secret",
+              "name": "personal_token",
+              "label": "Personal token",
+              "required": true
+            }]
+          },
+          "submission": {"kind": "native_secret", "secretField": "personal_token"}
+        }
+      }]
+    },
     "compatibility": {},
     "implementation": {
       "kind": "remote_streamable_http",
@@ -162,6 +179,9 @@ func TestCatalogSourcePreservesRemoteRequiredCapabilities(t *testing.T) {
 	}
 	if len(release.Manifest.RequiredCapabilities) != 1 || release.Manifest.RequiredCapabilities[0] != "tools" {
 		t.Fatalf("requiredCapabilities = %#v, want [tools]", release.Manifest.RequiredCapabilities)
+	}
+	if !strings.Contains(string(release.Manifest.AuthorizationInteraction), `"secretField":"personal_token"`) {
+		t.Fatalf("authorizationInteraction = %s", release.Manifest.AuthorizationInteraction)
 	}
 }
 

--- a/packages/connector/host/manifest.go
+++ b/packages/connector/host/manifest.go
@@ -2,6 +2,7 @@ package host
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/url"
@@ -143,6 +144,10 @@ func validateManifestShape(manifest Manifest, validateIcon bool) error {
 	case "none", "oauth2", "api_key":
 	default:
 		return invalidManifest("authorizationKind must be none, oauth2, or api_key", nil)
+	}
+	if len(manifest.AuthorizationInteraction) > 64<<10 ||
+		(len(manifest.AuthorizationInteraction) > 0 && !json.Valid(manifest.AuthorizationInteraction)) {
+		return invalidManifest("authorizationInteraction must be valid bounded JSON", nil)
 	}
 	implementation := manifest.Implementation
 	branches := 0

--- a/packages/connector/host/manifest_test.go
+++ b/packages/connector/host/manifest_test.go
@@ -1,6 +1,7 @@
 package host
 
 import (
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -85,6 +86,28 @@ func TestValidateManifestShapeAcceptsBindingOnlyRemoteMCPContract(t *testing.T) 
 	manifest.Implementation.RemoteStreamableHTTP.BindingRef = "https://docs.qq.com/openapi/mcp"
 	if err := ValidateManifestShape(manifest); err == nil || !strings.Contains(err.Error(), "bindingRef") {
 		t.Fatalf("endpoint-shaped bindingRef error = %v", err)
+	}
+}
+
+func TestValidateManifestShapeRequiresBoundedAuthorizationInteractionJSON(t *testing.T) {
+	manifest := Manifest{
+		SchemaVersion: "1", DisplayName: "Tencent Docs", IconURL: testConnectorIconURL,
+		AuthorizationKind: "api_key", AuthorizationInteraction: json.RawMessage(`{"protocol":"example"}`),
+		Implementation: Implementation{Kind: ImplementationKindBuiltin,
+			Builtin: &BuiltinImplementation{ProviderID: "tencent-docs", MCP: true}},
+	}
+	if err := ValidateManifestShape(manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest.AuthorizationInteraction = json.RawMessage(`{"protocol":`)
+	if err := ValidateManifestShape(manifest); err == nil || !strings.Contains(err.Error(), "authorizationInteraction") {
+		t.Fatalf("invalid authorization interaction error = %v", err)
+	}
+
+	manifest.AuthorizationInteraction = json.RawMessage(`"` + strings.Repeat("a", 64<<10) + `"`)
+	if err := ValidateManifestShape(manifest); err == nil || !strings.Contains(err.Error(), "authorizationInteraction") {
+		t.Fatalf("oversized authorization interaction error = %v", err)
 	}
 }
 

--- a/packages/connector/host/types.go
+++ b/packages/connector/host/types.go
@@ -1,6 +1,9 @@
 package host
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 type InstallationState string
 
@@ -100,16 +103,17 @@ type Release struct {
 }
 
 type Manifest struct {
-	SchemaVersion        string                    `json:"schemaVersion"`
-	DisplayName          string                    `json:"displayName"`
-	IconURL              string                    `json:"iconUrl"`
-	Description          string                    `json:"description,omitempty"`
-	AgentRouting         *AgentRouting             `json:"agentRouting,omitempty"`
-	Permissions          []string                  `json:"permissions"`
-	RequiredCapabilities []string                  `json:"requiredCapabilities,omitempty"`
-	Implementation       Implementation            `json:"implementation"`
-	AuthorizationKind    string                    `json:"authorizationKind"`
-	Compatibility        CompatibilityRequirements `json:"compatibility,omitempty"`
+	SchemaVersion            string                    `json:"schemaVersion"`
+	DisplayName              string                    `json:"displayName"`
+	IconURL                  string                    `json:"iconUrl"`
+	Description              string                    `json:"description,omitempty"`
+	AgentRouting             *AgentRouting             `json:"agentRouting,omitempty"`
+	Permissions              []string                  `json:"permissions"`
+	RequiredCapabilities     []string                  `json:"requiredCapabilities,omitempty"`
+	Implementation           Implementation            `json:"implementation"`
+	AuthorizationKind        string                    `json:"authorizationKind"`
+	AuthorizationInteraction json.RawMessage           `json:"authorizationInteraction,omitempty"`
+	Compatibility            CompatibilityRequirements `json:"compatibility,omitempty"`
 }
 
 // AgentRouting carries connector-owned brand and product aliases used only to

--- a/packages/connector/market/README.md
+++ b/packages/connector/market/README.md
@@ -8,6 +8,8 @@ The package owns the TypeScript and renderer side of the shared boundary:
 - `openapi/connector-market.v1.yaml`: the HTTP fragment composed by each host
   daemon's aggregate OpenAPI document
 - `contracts`: host-neutral backend, event, domain, and error contracts
+- `authorization`: the declarative authorization adapter and replaceable
+  View/Event renderer boundary
 - `core`: the renderer module lifecycle and stable Root boundary
 - `services`: a module-scoped Root, Runtime, lifecycle, StartupJobs, Valtio
   domain services, and host adapter contracts
@@ -20,6 +22,22 @@ The package does not construct an HTTP client, read Electron globals, choose a
 catalog endpoint, persist credentials, select install directories, or own a
 host database. Those responsibilities remain in the consuming daemon and
 renderer adapters.
+
+## Declarative authorization UI
+
+Connector manifests may carry a versioned `authorizationInteraction` value.
+The daemon transports this value without interpreting its presentation
+semantics. `@tutti-os/connector-authorization-protocol` validates it at the
+renderer boundary, and Connector Market's declarative adapter maps the selected
+secret field to the existing authorization backend input. Runtime header,
+endpoint, environment, and credential-storage bindings never enter the UI
+protocol.
+
+Hosts may inject an `authorizationRenderer` into `ConnectorMarketPanel` or
+`ConnectorMarketDialogHost`. Without an override, Connector Market renders the
+same protocol with its UI System-based default renderer. A missing interaction
+on a legacy `api_key` Connector uses the centralized one-secret compatibility
+adapter; an explicitly invalid interaction fails closed.
 
 ## Renderer usage
 

--- a/packages/connector/market/openapi/connector-market.v1.yaml
+++ b/packages/connector/market/openapi/connector-market.v1.yaml
@@ -509,6 +509,13 @@ components:
           $ref: "#/components/schemas/ConnectorMarketImplementation"
         authorizationKind:
           type: string
+        authorizationInteraction:
+          type: object
+          description: >-
+            Opaque Connector-owned authorization interaction configuration.
+            Hosts transport this value without interpreting its UI semantics;
+            renderers must validate it against the versioned protocol.
+          additionalProperties: true
         compatibility:
           $ref: "#/components/schemas/ConnectorMarketCompatibilityRequirements"
     ConnectorMarketAgentRouting:

--- a/packages/connector/market/package.json
+++ b/packages/connector/market/package.json
@@ -6,6 +6,7 @@
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./authorization": "./src/authorization/index.ts",
     "./contracts": "./src/contracts/index.ts",
     "./core": "./src/services/core/index.ts",
     "./i18n": "./src/i18n/index.ts",
@@ -30,15 +31,18 @@
     "typecheck": "node ../../../tools/scripts/run-tsgo-typecheck.mjs"
   },
   "dependencies": {
+    "@tutti-os/connector-authorization-protocol": "workspace:*",
     "@tutti-os/infra": "0.1.0",
     "@tutti-os/ui-i18n-runtime": "workspace:*",
     "@tutti-os/ui-system": "workspace:*",
+    "qrcode-generator": "2.0.4",
     "valtio": "^2.3.2"
   },
   "devDependencies": {
     "@tutti-os/config-tsconfig": "workspace:*",
     "@types/node": "^24.0.1",
     "@types/react": "^19.1.6",
+    "@types/react-dom": "^19.1.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "tsx": "^4.22.3",
@@ -56,6 +60,10 @@
       ".": {
         "types": "./dist/index.d.ts",
         "import": "./dist/index.js"
+      },
+      "./authorization": {
+        "types": "./dist/authorization/index.d.ts",
+        "import": "./dist/authorization/index.js"
       },
       "./contracts": {
         "types": "./dist/contracts/index.d.ts",

--- a/packages/connector/market/src/authorization/AuthorizationViewRenderer.test.ts
+++ b/packages/connector/market/src/authorization/AuthorizationViewRenderer.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { DefaultAuthorizationViewRenderer } from "./AuthorizationViewRenderer.tsx";
+
+const labels = {
+  activate: "Continue",
+  cancel: "Cancel",
+  qrCodeAlt: "Authorization QR code",
+  refresh: "Refresh",
+  retry: "Retry",
+  submit: "Authorize",
+  unsupportedField: "Unsupported"
+};
+
+test("renders a QR payload locally without exposing it as text", () => {
+  const payload = "https://example.com/authorize?opaque=secret-value";
+  const markup = renderToStaticMarkup(
+    createElement(DefaultAuthorizationViewRenderer, {
+      busy: false,
+      labels,
+      view: {
+        protocol: "tutti.connector.authorization.view.v1",
+        viewId: "qr-1",
+        view: {
+          type: "qr_code",
+          source: { type: "payload", value: payload },
+          refreshable: true
+        }
+      },
+      onEvent: () => undefined
+    })
+  );
+
+  assert.match(markup, /data:image\/gif;base64,/);
+  assert.match(markup, /Authorization QR code/);
+  assert.match(markup, />Refresh</);
+  assert.doesNotMatch(markup, /secret-value/);
+});
+
+test("renders an activation action for external-link views", () => {
+  const markup = renderToStaticMarkup(
+    createElement(DefaultAuthorizationViewRenderer, {
+      busy: false,
+      labels,
+      view: {
+        protocol: "tutti.connector.authorization.view.v1",
+        viewId: "external-1",
+        view: {
+          type: "external_link",
+          title: "Continue in browser",
+          url: "https://example.com/authorize"
+        }
+      },
+      onEvent: () => undefined
+    })
+  );
+
+  assert.match(markup, /Continue in browser/);
+  assert.match(markup, />Continue</);
+  assert.doesNotMatch(markup, /https:\/\/example.com/);
+});

--- a/packages/connector/market/src/authorization/AuthorizationViewRenderer.tsx
+++ b/packages/connector/market/src/authorization/AuthorizationViewRenderer.tsx
@@ -1,0 +1,430 @@
+import type {
+  AuthorizationEventEnvelopeV1,
+  AuthorizationFieldV1,
+  AuthorizationValueV1,
+  AuthorizationViewEnvelopeV1
+} from "@tutti-os/connector-authorization-protocol/v1";
+import {
+  Button,
+  Checkbox,
+  DialogFooter,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Spinner
+} from "@tutti-os/ui-system/components";
+import qrcode from "qrcode-generator";
+import { useMemo, useState, type ComponentType, type FormEvent } from "react";
+
+import { createAuthorizationSubmitEvent } from "./declarativeAuthorizationAdapter.ts";
+
+export interface AuthorizationRendererLabels {
+  activate: string;
+  cancel: string;
+  refresh: string;
+  qrCodeAlt: string;
+  retry: string;
+  submit: string;
+  unsupportedField: string;
+}
+
+export interface AuthorizationViewRendererProps {
+  busy: boolean;
+  labels: AuthorizationRendererLabels;
+  view: AuthorizationViewEnvelopeV1;
+  onEvent(event: AuthorizationEventEnvelopeV1): void;
+}
+
+export type AuthorizationViewRenderer =
+  ComponentType<AuthorizationViewRendererProps>;
+
+type AuthorizationActionEventType = Exclude<
+  AuthorizationEventEnvelopeV1["event"]["type"],
+  "submit"
+>;
+
+function createAuthorizationActionEvent(
+  viewId: string,
+  type: AuthorizationActionEventType
+): AuthorizationEventEnvelopeV1 {
+  return {
+    protocol: "tutti.connector.authorization.event.v1",
+    viewId,
+    event: { type }
+  };
+}
+
+function initialFormValues(
+  fields: readonly AuthorizationFieldV1[]
+): Record<string, AuthorizationValueV1> {
+  const values: Record<string, AuthorizationValueV1> = {};
+  for (const field of fields) {
+    if (field.type === "boolean") {
+      values[field.name] = field.defaultValue ?? false;
+    } else if ("defaultValue" in field && field.defaultValue !== undefined) {
+      values[field.name] = field.defaultValue;
+    }
+  }
+  return values;
+}
+
+function requiredFormValuesPresent(
+  fields: readonly AuthorizationFieldV1[],
+  values: Readonly<Record<string, AuthorizationValueV1>>
+): boolean {
+  return fields.every((field) => {
+    if (field.type === "local_file") return false;
+    if (!field.required) return true;
+    const value = values[field.name];
+    return field.type === "boolean"
+      ? value === true
+      : typeof value === "string"
+        ? value.length > 0
+        : value !== undefined;
+  });
+}
+
+function AuthorizationFormField({
+  busy,
+  field,
+  unsupportedField,
+  value,
+  onChange
+}: {
+  busy: boolean;
+  field: AuthorizationFieldV1;
+  unsupportedField: string;
+  value: AuthorizationValueV1 | undefined;
+  onChange(value: AuthorizationValueV1): void;
+}) {
+  const description =
+    field.type === "local_file" ? unsupportedField : field.description;
+
+  return (
+    <label className="grid gap-2" htmlFor={`authorization-${field.name}`}>
+      <span className="text-sm font-medium text-[var(--text-primary)]">
+        {field.label}
+        {field.required ? " *" : null}
+      </span>
+      {field.type === "text" || field.type === "secret" ? (
+        <Input
+          autoComplete="off"
+          disabled={busy}
+          id={`authorization-${field.name}`}
+          placeholder={field.placeholder}
+          type={field.type === "secret" ? "password" : "text"}
+          value={typeof value === "string" ? value : ""}
+          onChange={(event) => onChange(event.currentTarget.value)}
+        />
+      ) : field.type === "number" ? (
+        <Input
+          disabled={busy}
+          id={`authorization-${field.name}`}
+          max={field.maximum}
+          min={field.minimum}
+          placeholder={field.placeholder}
+          step={field.step}
+          type="number"
+          value={typeof value === "number" ? value : ""}
+          onChange={(event) => {
+            if (event.currentTarget.value !== "") {
+              onChange(event.currentTarget.valueAsNumber);
+            }
+          }}
+        />
+      ) : field.type === "select" ? (
+        <Select
+          disabled={busy}
+          value={typeof value === "string" ? value : undefined}
+          onValueChange={onChange}
+        >
+          <SelectTrigger id={`authorization-${field.name}`}>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent style={{ zIndex: "var(--z-dialog-popover)" }}>
+            {field.options.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      ) : field.type === "boolean" ? (
+        <Checkbox
+          checked={value === true}
+          disabled={busy}
+          id={`authorization-${field.name}`}
+          onCheckedChange={(checked) => onChange(checked === true)}
+        />
+      ) : (
+        <Input disabled id={`authorization-${field.name}`} type="file" />
+      )}
+      {description ? (
+        <span className="text-xs text-[var(--text-tertiary)]">
+          {description}
+        </span>
+      ) : null}
+    </label>
+  );
+}
+
+function AuthorizationFormRenderer({
+  busy,
+  labels,
+  view,
+  onEvent
+}: AuthorizationViewRendererProps & {
+  view: AuthorizationViewEnvelopeV1 & { view: { type: "form" } };
+}) {
+  const [values, setValues] = useState<Record<string, AuthorizationValueV1>>(
+    () => initialFormValues(view.view.fields)
+  );
+  const canSubmit =
+    !busy && requiredFormValuesPresent(view.view.fields, values);
+
+  const submit = (event: FormEvent) => {
+    event.preventDefault();
+    if (canSubmit) {
+      const submitEvent = createAuthorizationSubmitEvent(view.viewId, values);
+      setValues(initialFormValues(view.view.fields));
+      onEvent(submitEvent);
+    }
+  };
+
+  return (
+    <form className="grid gap-4" onSubmit={submit}>
+      {view.view.title ? (
+        <h3 className="m-0 text-base font-semibold text-[var(--text-primary)]">
+          {view.view.title}
+        </h3>
+      ) : null}
+      {view.view.description ? (
+        <p className="m-0 text-sm text-[var(--text-secondary)]">
+          {view.view.description}
+        </p>
+      ) : null}
+      {view.view.fields.map((field) => (
+        <AuthorizationFormField
+          busy={busy}
+          field={field}
+          key={field.name}
+          unsupportedField={labels.unsupportedField}
+          value={values[field.name]}
+          onChange={(value) =>
+            setValues((current) => ({ ...current, [field.name]: value }))
+          }
+        />
+      ))}
+      <DialogFooter>
+        <Button
+          disabled={busy}
+          size="dialog"
+          type="button"
+          variant="secondary"
+          onClick={() =>
+            onEvent(createAuthorizationActionEvent(view.viewId, "cancel"))
+          }
+        >
+          {labels.cancel}
+        </Button>
+        <Button disabled={!canSubmit} size="dialog" type="submit">
+          {busy ? <Spinner size={14} /> : null}
+          {view.view.submitLabel ?? labels.submit}
+        </Button>
+      </DialogFooter>
+    </form>
+  );
+}
+
+function AuthorizationViewHeading({
+  description,
+  title
+}: {
+  description?: string;
+  title?: string;
+}) {
+  return (
+    <>
+      {title ? (
+        <h3 className="m-0 text-base font-semibold text-[var(--text-primary)]">
+          {title}
+        </h3>
+      ) : null}
+      {description ? (
+        <p className="m-0 text-sm text-[var(--text-secondary)]">
+          {description}
+        </p>
+      ) : null}
+    </>
+  );
+}
+
+function AuthorizationActionFooter({
+  actionLabel,
+  actionType,
+  busy,
+  cancelLabel,
+  viewId,
+  onEvent
+}: {
+  actionLabel?: string;
+  actionType?: AuthorizationActionEventType;
+  busy: boolean;
+  cancelLabel: string;
+  viewId: string;
+  onEvent(event: AuthorizationEventEnvelopeV1): void;
+}) {
+  return (
+    <DialogFooter>
+      <Button
+        disabled={busy}
+        size="dialog"
+        type="button"
+        variant="secondary"
+        onClick={() =>
+          onEvent(createAuthorizationActionEvent(viewId, "cancel"))
+        }
+      >
+        {cancelLabel}
+      </Button>
+      {actionType && actionLabel ? (
+        <Button
+          disabled={busy}
+          size="dialog"
+          type="button"
+          onClick={() =>
+            onEvent(createAuthorizationActionEvent(viewId, actionType))
+          }
+        >
+          {busy ? <Spinner size={14} /> : null}
+          {actionLabel}
+        </Button>
+      ) : null}
+    </DialogFooter>
+  );
+}
+
+function AuthorizationQrCodeRenderer({
+  busy,
+  labels,
+  view,
+  onEvent
+}: AuthorizationViewRendererProps & {
+  view: AuthorizationViewEnvelopeV1 & { view: { type: "qr_code" } };
+}) {
+  const imageSource = useMemo(() => {
+    if (view.view.source.type === "png_base64") {
+      return `data:image/png;base64,${view.view.source.value}`;
+    }
+    try {
+      const code = qrcode(0, "M");
+      code.addData(view.view.source.value);
+      code.make();
+      return code.createDataURL(6, 12);
+    } catch {
+      return null;
+    }
+  }, [view.view.source]);
+
+  return (
+    <div className="grid gap-4 text-center">
+      <AuthorizationViewHeading
+        description={view.view.description}
+        title={view.view.title}
+      />
+      {imageSource ? (
+        <img
+          alt={view.view.title ?? labels.qrCodeAlt}
+          className="mx-auto size-56 max-w-full rounded-lg bg-white p-3"
+          src={imageSource}
+        />
+      ) : null}
+      {view.view.fallbackText ? (
+        <p className="m-0 break-all text-xs text-[var(--text-tertiary)]">
+          {view.view.fallbackText}
+        </p>
+      ) : null}
+      <AuthorizationActionFooter
+        actionLabel={view.view.refreshable ? labels.refresh : undefined}
+        actionType={view.view.refreshable ? "refresh" : undefined}
+        busy={busy}
+        cancelLabel={labels.cancel}
+        viewId={view.viewId}
+        onEvent={onEvent}
+      />
+    </div>
+  );
+}
+
+export function DefaultAuthorizationViewRenderer(
+  props: AuthorizationViewRendererProps
+) {
+  if (props.view.view.type === "form") {
+    return (
+      <AuthorizationFormRenderer
+        {...props}
+        view={
+          props.view as AuthorizationViewEnvelopeV1 & {
+            view: { type: "form" };
+          }
+        }
+      />
+    );
+  }
+
+  if (props.view.view.type === "qr_code") {
+    return (
+      <AuthorizationQrCodeRenderer
+        {...props}
+        view={
+          props.view as AuthorizationViewEnvelopeV1 & {
+            view: { type: "qr_code" };
+          }
+        }
+      />
+    );
+  }
+
+  const { view } = props.view;
+  const action =
+    view.type === "external_link" || view.type === "device_code"
+      ? {
+          label: view.actionLabel ?? props.labels.activate,
+          type: "activate" as const
+        }
+      : view.type === "result" &&
+          view.outcome === "failure" &&
+          view.retryable === true
+        ? { label: props.labels.retry, type: "retry" as const }
+        : null;
+  return (
+    <div className="grid gap-4 text-center">
+      {view.type === "progress" ? <Spinner size={20} /> : null}
+      <AuthorizationViewHeading
+        description={view.description}
+        title={view.title}
+      />
+      {view.type === "device_code" ? (
+        <output className="rounded-lg border border-[var(--border-1)] bg-[var(--surface-2)] px-4 py-3 font-mono text-lg font-semibold tracking-widest text-[var(--text-primary)]">
+          {view.userCode}
+        </output>
+      ) : null}
+      {"message" in view && view.message ? (
+        <p className="m-0 text-sm text-[var(--text-secondary)]">
+          {view.message}
+        </p>
+      ) : null}
+      <AuthorizationActionFooter
+        actionLabel={action?.label}
+        actionType={action?.type}
+        busy={props.busy}
+        cancelLabel={props.labels.cancel}
+        viewId={props.view.viewId}
+        onEvent={props.onEvent}
+      />
+    </div>
+  );
+}

--- a/packages/connector/market/src/authorization/declarativeAuthorizationAdapter.test.ts
+++ b/packages/connector/market/src/authorization/declarativeAuthorizationAdapter.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createAuthorizationSubmitEvent,
+  resolveAuthorizationInteraction,
+  resolveDeclarativeAuthorizationSubmission
+} from "./declarativeAuthorizationAdapter.ts";
+
+const legacyLabels = {
+  description: "Stored securely",
+  fieldLabel: "Access token",
+  placeholder: "Paste token"
+};
+
+test("creates a legacy secret form only when interaction is absent", () => {
+  const resolved = resolveAuthorizationInteraction({
+    authorizationKind: "api_key",
+    interaction: undefined,
+    legacyLabels,
+    locale: "en-US"
+  });
+  assert.equal(resolved.kind, "form");
+  if (resolved.kind === "form") {
+    assert.equal(resolved.interaction.submission.secretField, "secret");
+  }
+});
+
+test("fails closed for an explicitly invalid interaction", () => {
+  const resolved = resolveAuthorizationInteraction({
+    authorizationKind: "api_key",
+    interaction: { protocol: "unknown" },
+    legacyLabels,
+    locale: "en-US"
+  });
+  assert.deepEqual(resolved, { kind: "invalid" });
+});
+
+test("maps a declared field to the existing native-secret input", () => {
+  const resolved = resolveAuthorizationInteraction({
+    authorizationKind: "api_key",
+    interaction: {
+      protocol: "tutti.connector.authorization.declarative.v1",
+      initialView: {
+        type: "form",
+        fields: [
+          {
+            type: "secret",
+            name: "personal_token",
+            label: "Personal token",
+            required: true
+          }
+        ]
+      },
+      submission: {
+        kind: "native_secret",
+        secretField: "personal_token"
+      }
+    },
+    legacyLabels,
+    locale: "en-US"
+  });
+  assert.equal(resolved.kind, "form");
+  if (resolved.kind !== "form") return;
+
+  const event = createAuthorizationSubmitEvent(resolved.view.viewId, {
+    personal_token: " token-with-spaces "
+  });
+  assert.deepEqual(resolveDeclarativeAuthorizationSubmission(resolved, event), {
+    ok: true,
+    secret: " token-with-spaces "
+  });
+});
+
+test("selects the localized presentation without changing submission binding", () => {
+  const resolved = resolveAuthorizationInteraction({
+    authorizationKind: "api_key",
+    interaction: {
+      protocol: "tutti.connector.authorization.declarative.v1",
+      initialView: {
+        type: "form",
+        title: "Connect",
+        fields: [
+          {
+            type: "secret",
+            name: "personal_token",
+            label: "Personal token",
+            required: true
+          }
+        ]
+      },
+      localizedInitialViews: {
+        "zh-CN": {
+          type: "form",
+          title: "连接",
+          fields: [
+            {
+              type: "secret",
+              name: "personal_token",
+              label: "个人令牌",
+              required: true
+            }
+          ]
+        }
+      },
+      submission: {
+        kind: "native_secret",
+        secretField: "personal_token"
+      }
+    },
+    legacyLabels,
+    locale: "zh-CN"
+  });
+  assert.equal(resolved.kind, "form");
+  if (resolved.kind === "form") {
+    assert.equal(resolved.view.view.title, "连接");
+    assert.equal(resolved.interaction.submission.secretField, "personal_token");
+  }
+});

--- a/packages/connector/market/src/authorization/declarativeAuthorizationAdapter.test.ts
+++ b/packages/connector/market/src/authorization/declarativeAuthorizationAdapter.test.ts
@@ -42,15 +42,20 @@ test("maps a declared field to the existing native-secret input", () => {
     interaction: {
       protocol: "tutti.connector.authorization.declarative.v1",
       initialView: {
-        type: "form",
-        fields: [
-          {
-            type: "secret",
-            name: "personal_token",
-            label: "Personal token",
-            required: true
+        defaultLocale: "en-US",
+        locales: {
+          "en-US": {
+            type: "form",
+            fields: [
+              {
+                type: "secret",
+                name: "personal_token",
+                label: "Personal token",
+                required: true
+              }
+            ]
           }
-        ]
+        }
       },
       submission: {
         kind: "native_secret",
@@ -78,29 +83,32 @@ test("selects the localized presentation without changing submission binding", (
     interaction: {
       protocol: "tutti.connector.authorization.declarative.v1",
       initialView: {
-        type: "form",
-        title: "Connect",
-        fields: [
-          {
-            type: "secret",
-            name: "personal_token",
-            label: "Personal token",
-            required: true
+        defaultLocale: "en-US",
+        locales: {
+          "en-US": {
+            type: "form",
+            title: "Connect",
+            fields: [
+              {
+                type: "secret",
+                name: "personal_token",
+                label: "Personal token",
+                required: true
+              }
+            ]
+          },
+          "zh-CN": {
+            type: "form",
+            title: "连接",
+            fields: [
+              {
+                type: "secret",
+                name: "personal_token",
+                label: "个人令牌",
+                required: true
+              }
+            ]
           }
-        ]
-      },
-      localizedInitialViews: {
-        "zh-CN": {
-          type: "form",
-          title: "连接",
-          fields: [
-            {
-              type: "secret",
-              name: "personal_token",
-              label: "个人令牌",
-              required: true
-            }
-          ]
         }
       },
       submission: {

--- a/packages/connector/market/src/authorization/declarativeAuthorizationAdapter.ts
+++ b/packages/connector/market/src/authorization/declarativeAuthorizationAdapter.ts
@@ -35,17 +35,22 @@ function createLegacySecretInteraction(
   return {
     protocol: "tutti.connector.authorization.declarative.v1",
     initialView: {
-      type: "form",
-      fields: [
-        {
-          type: "secret",
-          name: "secret",
-          label: labels.fieldLabel,
-          description: labels.description,
-          placeholder: labels.placeholder,
-          required: true
+      defaultLocale: "en-US",
+      locales: {
+        "en-US": {
+          type: "form",
+          fields: [
+            {
+              type: "secret",
+              name: "secret",
+              label: labels.fieldLabel,
+              description: labels.description,
+              placeholder: labels.placeholder,
+              required: true
+            }
+          ]
         }
-      ]
+      }
     },
     submission: {
       kind: "native_secret",

--- a/packages/connector/market/src/authorization/declarativeAuthorizationAdapter.ts
+++ b/packages/connector/market/src/authorization/declarativeAuthorizationAdapter.ts
@@ -1,0 +1,116 @@
+import {
+  AUTHORIZATION_EVENT_PROTOCOL_V1,
+  AUTHORIZATION_VIEW_PROTOCOL_V1,
+  parseDeclarativeAuthorizationInteractionV1,
+  resolveDeclarativeAuthorizationInitialViewV1,
+  validateAuthorizationEventForViewV1,
+  type AuthorizationEventEnvelopeV1,
+  type AuthorizationValueV1,
+  type AuthorizationViewEnvelopeV1,
+  type DeclarativeAuthorizationInteractionV1
+} from "@tutti-os/connector-authorization-protocol/v1";
+
+export interface LegacySecretInteractionLabels {
+  description: string;
+  fieldLabel: string;
+  placeholder: string;
+}
+
+export type ResolvedAuthorizationInteraction =
+  | {
+      kind: "form";
+      interaction: DeclarativeAuthorizationInteractionV1;
+      view: AuthorizationViewEnvelopeV1;
+    }
+  | { kind: "none" }
+  | { kind: "invalid" };
+
+export type DeclarativeAuthorizationSubmissionResult =
+  | { ok: true; secret: string }
+  | { ok: false; code: "invalid_event" | "invalid_secret" };
+
+function createLegacySecretInteraction(
+  labels: LegacySecretInteractionLabels
+): DeclarativeAuthorizationInteractionV1 {
+  return {
+    protocol: "tutti.connector.authorization.declarative.v1",
+    initialView: {
+      type: "form",
+      fields: [
+        {
+          type: "secret",
+          name: "secret",
+          label: labels.fieldLabel,
+          description: labels.description,
+          placeholder: labels.placeholder,
+          required: true
+        }
+      ]
+    },
+    submission: {
+      kind: "native_secret",
+      secretField: "secret"
+    }
+  };
+}
+
+export function resolveAuthorizationInteraction(input: {
+  authorizationKind: string;
+  interaction: unknown;
+  legacyLabels: LegacySecretInteractionLabels;
+  locale: string;
+}): ResolvedAuthorizationInteraction {
+  const parsed = parseDeclarativeAuthorizationInteractionV1(input.interaction);
+  const interaction = parsed.ok
+    ? parsed.value
+    : input.interaction === undefined && input.authorizationKind === "api_key"
+      ? createLegacySecretInteraction(input.legacyLabels)
+      : null;
+
+  if (!interaction) {
+    return input.interaction === undefined
+      ? { kind: "none" }
+      : { kind: "invalid" };
+  }
+
+  return {
+    kind: "form",
+    interaction,
+    view: {
+      protocol: AUTHORIZATION_VIEW_PROTOCOL_V1,
+      viewId: "authorization-form",
+      view: resolveDeclarativeAuthorizationInitialViewV1(
+        interaction,
+        input.locale
+      )
+    }
+  };
+}
+
+export function createAuthorizationSubmitEvent(
+  viewId: string,
+  values: Record<string, AuthorizationValueV1>
+): AuthorizationEventEnvelopeV1 {
+  return {
+    protocol: AUTHORIZATION_EVENT_PROTOCOL_V1,
+    viewId,
+    event: { type: "submit", values }
+  };
+}
+
+export function resolveDeclarativeAuthorizationSubmission(
+  resolved: Extract<ResolvedAuthorizationInteraction, { kind: "form" }>,
+  event: unknown
+): DeclarativeAuthorizationSubmissionResult {
+  const validation = validateAuthorizationEventForViewV1(resolved.view, event, {
+    isCurrentLocalFileHandle: () => false
+  });
+  if (!validation.ok || validation.value.event.type !== "submit") {
+    return { ok: false, code: "invalid_event" };
+  }
+  const secret =
+    validation.value.event.values[resolved.interaction.submission.secretField];
+  return typeof secret === "string" && secret.length > 0
+    ? { ok: true, secret }
+    : { ok: false, code: "invalid_secret" };
+}

--- a/packages/connector/market/src/authorization/index.ts
+++ b/packages/connector/market/src/authorization/index.ts
@@ -1,0 +1,2 @@
+export * from "./declarativeAuthorizationAdapter.ts";
+export * from "./AuthorizationViewRenderer.tsx";

--- a/packages/connector/market/src/contracts/domain.ts
+++ b/packages/connector/market/src/contracts/domain.ts
@@ -134,6 +134,7 @@ export interface ConnectorManifest {
   requiredCapabilities?: string[];
   implementation: ConnectorManifestImplementation;
   authorizationKind: string;
+  authorizationInteraction?: unknown;
   compatibility?: ConnectorCompatibilityRequirements;
 }
 

--- a/packages/connector/market/src/i18n/connectorMarketI18n.ts
+++ b/packages/connector/market/src/i18n/connectorMarketI18n.ts
@@ -36,6 +36,7 @@ const connectorMarketEn = {
   actionManage: "Manage",
   actionMore: "More actions",
   actionRefresh: "Refresh",
+  authorizationQrCodeAlt: "Authorization QR code",
   actionRetry: "Retry",
   actionTry: "Try it",
   actionUninstall: "Uninstall",
@@ -68,6 +69,8 @@ const connectorMarketEn = {
   connectedStatus: "Connected",
   connectorAuthorizationFailed:
     "Authorization could not be started. Try again.",
+  connectorAuthorizationConfigurationInvalid:
+    "This connector has an invalid authorization configuration",
   connectorDisconnectFailed:
     "Authorization could not be disconnected. Try again.",
   connectorInstallFailed: "Installation failed. Try again.",
@@ -130,6 +133,8 @@ const connectorMarketEn = {
     "The token is sent directly to Tutti for validation and encrypted storage. It is not saved by the desktop app",
   secretInputPlaceholder: "Paste token",
   secretInputTitle: "Access token",
+  unsupportedAuthorizationField:
+    "This field requires a host capability that is not available",
   statusAuthorizationRequired: "Authorization required",
   statusInstalled: "Installed",
   statusNotInstalled: "Not installed",
@@ -156,6 +161,7 @@ const connectorMarketZhCN = {
   actionManage: "管理",
   actionMore: "更多操作",
   actionRefresh: "刷新",
+  authorizationQrCodeAlt: "授权二维码",
   actionRetry: "重试",
   actionTry: "去试试",
   actionUninstall: "卸载",
@@ -184,6 +190,7 @@ const connectorMarketZhCN = {
   close: "关闭",
   connectedStatus: "已连接",
   connectorAuthorizationFailed: "无法启动授权，请重试",
+  connectorAuthorizationConfigurationInvalid: "连接器授权配置无效",
   connectorDisconnectFailed: "无法解除授权，请重试",
   connectorInstallFailed: "安装失败，请重试",
   connectorUninstallFailed: "卸载失败，请重试",
@@ -238,6 +245,7 @@ const connectorMarketZhCN = {
     "Token 会直接发送给 Tutti 完成校验和加密存储，桌面端不会保存明文",
   secretInputPlaceholder: "粘贴 Token",
   secretInputTitle: "访问令牌",
+  unsupportedAuthorizationField: "当前宿主不支持这个授权字段",
   statusAuthorizationRequired: "需要授权",
   statusInstalled: "已安装",
   statusNotInstalled: "未安装",

--- a/packages/connector/market/src/index.ts
+++ b/packages/connector/market/src/index.ts
@@ -1,4 +1,5 @@
 export type * from "./contracts/index.ts";
+export * from "./authorization/index.ts";
 export * from "./services/index.ts";
 export * from "./i18n/index.ts";
 export * from "./ui/index.ts";

--- a/packages/connector/market/src/services/view/connectorMarketViewBuilder.test.ts
+++ b/packages/connector/market/src/services/view/connectorMarketViewBuilder.test.ts
@@ -138,6 +138,47 @@ test("keeps connector details open through installation and advances to authoriz
   );
 });
 
+test("preserves the connector authorization interaction for the dialog", () => {
+  const market = createConnectorMarketStoreState();
+  const connector = connectorFixture();
+  const interaction = {
+    protocol: "tutti.connector.authorization.declarative.v1",
+    initialView: {
+      type: "form",
+      fields: [
+        {
+          type: "secret",
+          name: "personal_token",
+          label: "Personal token",
+          required: true
+        }
+      ]
+    },
+    submission: { kind: "native_secret", secretField: "personal_token" }
+  };
+  connector.installation = {
+    installedReleaseDigest: connector.release.releaseDigest,
+    state: "installed"
+  };
+  connector.release.manifest.authorizationKind = "api_key";
+  connector.release.manifest.authorizationInteraction = interaction;
+  market.connectorKeys = [connector.key];
+  market.connectorsByKey[connector.key] = connector;
+
+  const dialog = buildConnectorMarketView(market, {
+    ...uiState,
+    dialog: { connectorKey: connector.key, kind: "connector" }
+  }).dialog;
+
+  assert.equal(dialog?.kind, "authorization");
+  assert.deepEqual(
+    dialog?.kind === "authorization"
+      ? dialog.authorizationInteraction
+      : undefined,
+    interaction
+  );
+});
+
 test("keeps a physical repair in the available segment until installation completes", () => {
   const market = createConnectorMarketStoreState();
   const connector = connectorFixture();

--- a/packages/connector/market/src/services/view/connectorMarketViewBuilder.test.ts
+++ b/packages/connector/market/src/services/view/connectorMarketViewBuilder.test.ts
@@ -144,15 +144,20 @@ test("preserves the connector authorization interaction for the dialog", () => {
   const interaction = {
     protocol: "tutti.connector.authorization.declarative.v1",
     initialView: {
-      type: "form",
-      fields: [
-        {
-          type: "secret",
-          name: "personal_token",
-          label: "Personal token",
-          required: true
+      defaultLocale: "en-US",
+      locales: {
+        "en-US": {
+          type: "form",
+          fields: [
+            {
+              type: "secret",
+              name: "personal_token",
+              label: "Personal token",
+              required: true
+            }
+          ]
         }
-      ]
+      }
     },
     submission: { kind: "native_secret", secretField: "personal_token" }
   };

--- a/packages/connector/market/src/services/view/connectorMarketViewBuilder.ts
+++ b/packages/connector/market/src/services/view/connectorMarketViewBuilder.ts
@@ -256,6 +256,8 @@ function buildConnectorDialogView(
   if (!["connected", "not_required"].includes(connector.authorization.state)) {
     return {
       ...base,
+      authorizationInteraction:
+        connector.release.manifest.authorizationInteraction,
       authorizationKind: connector.release.manifest.authorizationKind,
       authorizing,
       kind: "authorization",

--- a/packages/connector/market/src/services/view/connectorMarketViewTypes.ts
+++ b/packages/connector/market/src/services/view/connectorMarketViewTypes.ts
@@ -78,6 +78,7 @@ interface ConnectorDialogBaseView {
 }
 
 export interface ConnectorAuthorizationDialogView extends ConnectorDialogBaseView {
+  authorizationInteraction?: unknown;
   authorizationKind: string;
   authorizing: boolean;
   kind: "authorization";

--- a/packages/connector/market/src/ui/ConnectorMarketDialogHost.tsx
+++ b/packages/connector/market/src/ui/ConnectorMarketDialogHost.tsx
@@ -1,10 +1,13 @@
 import type { ConnectorMarketI18nRuntime } from "../i18n/connectorMarketI18n.ts";
+import type { AuthorizationViewRenderer } from "../authorization/AuthorizationViewRenderer.tsx";
 import type { IConnectorMarketRoot } from "../services/core/connectorMarketRoot.interface.ts";
 import { ConnectorMarketRootProvider } from "./ConnectorMarketServicesContext.tsx";
 import { ConnectorMarketDialogs } from "./dialogs/ConnectorMarketDialogs.tsx";
 
 export interface ConnectorMarketDialogHostProps {
+  authorizationRenderer?: AuthorizationViewRenderer;
   i18n: ConnectorMarketI18nRuntime;
+  locale?: string;
   onError?: (message: string) => void;
   onTryConnector?: (connectorKey: string) => void;
   root: IConnectorMarketRoot;
@@ -15,14 +18,18 @@ export interface ConnectorMarketDialogHostProps {
  * authorization, management, and compatibility dialogs.
  */
 export function ConnectorMarketDialogHost({
+  authorizationRenderer,
   i18n,
+  locale,
   onError,
   onTryConnector,
   root
 }: ConnectorMarketDialogHostProps) {
   return (
     <ConnectorMarketRootProvider
+      authorizationRenderer={authorizationRenderer}
       i18n={i18n}
+      locale={locale}
       onError={onError}
       onTryConnector={onTryConnector}
       root={root}

--- a/packages/connector/market/src/ui/ConnectorMarketPanel.tsx
+++ b/packages/connector/market/src/ui/ConnectorMarketPanel.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@tutti-os/ui-system/utils";
 
+import type { AuthorizationViewRenderer } from "../authorization/AuthorizationViewRenderer.tsx";
 import type { ConnectorMarketI18nRuntime } from "../i18n/connectorMarketI18n.ts";
 import type { IConnectorMarketRoot } from "../services/core/connectorMarketRoot.interface.ts";
 import { ConnectorMarketRootProvider } from "./ConnectorMarketServicesContext.tsx";
@@ -7,23 +8,29 @@ import { ConnectorCatalog } from "./catalog/ConnectorCatalog.tsx";
 import { ConnectorMarketToolbar } from "./toolbar/ConnectorMarketToolbar.tsx";
 
 export interface ConnectorMarketPanelProps {
+  authorizationRenderer?: AuthorizationViewRenderer;
   className?: string;
   i18n: ConnectorMarketI18nRuntime;
+  locale?: string;
   onError?: (message: string) => void;
   onTryConnector?: (connectorKey: string) => void;
   root: IConnectorMarketRoot;
 }
 
 export function ConnectorMarketPanel({
+  authorizationRenderer,
   className,
   i18n,
+  locale,
   onError,
   onTryConnector,
   root
 }: ConnectorMarketPanelProps) {
   return (
     <ConnectorMarketRootProvider
+      authorizationRenderer={authorizationRenderer}
       i18n={i18n}
+      locale={locale}
       onError={onError}
       onTryConnector={onTryConnector}
       root={root}

--- a/packages/connector/market/src/ui/ConnectorMarketServicesContext.tsx
+++ b/packages/connector/market/src/ui/ConnectorMarketServicesContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useMemo, type ReactNode } from "react";
 
 import type { ConnectorMarketI18nRuntime } from "../i18n/connectorMarketI18n.ts";
+import type { AuthorizationViewRenderer } from "../authorization/AuthorizationViewRenderer.tsx";
 import type { IConnectorMarketRoot } from "../services/core/connectorMarketRoot.interface.ts";
 
 export interface ConnectorMarketServices extends Omit<
@@ -8,13 +9,17 @@ export interface ConnectorMarketServices extends Omit<
   "_serviceBrand"
 > {
   i18n: ConnectorMarketI18nRuntime;
+  locale: string;
+  authorizationRenderer?: AuthorizationViewRenderer;
   onError?: (message: string) => void;
   onTryConnector?: (connectorKey: string) => void;
 }
 
 export interface ConnectorMarketRootProviderProps {
   children: ReactNode;
+  authorizationRenderer?: AuthorizationViewRenderer;
   i18n: ConnectorMarketI18nRuntime;
+  locale?: string;
   onError?: (message: string) => void;
   onTryConnector?: (connectorKey: string) => void;
   root: IConnectorMarketRoot;
@@ -38,22 +43,26 @@ export function ConnectorMarketServicesProvider({
 }
 
 export function ConnectorMarketRootProvider({
+  authorizationRenderer,
   children,
   i18n,
+  locale = "en-US",
   onError,
   onTryConnector,
   root
 }: ConnectorMarketRootProviderProps) {
   const services = useMemo(
     () => ({
+      authorizationRenderer,
       i18n,
+      locale,
       market: root.market,
       onError,
       onTryConnector,
       uiState: root.uiState,
       view: root.view
     }),
-    [i18n, onError, onTryConnector, root]
+    [authorizationRenderer, i18n, locale, onError, onTryConnector, root]
   );
 
   return (

--- a/packages/connector/market/src/ui/dialogs/ConnectorAuthorizationDialog.tsx
+++ b/packages/connector/market/src/ui/dialogs/ConnectorAuthorizationDialog.tsx
@@ -5,49 +5,78 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  Input,
   Spinner
 } from "@tutti-os/ui-system/components";
-import {
-  LinkIcon,
-  LockGridHorizontalLinedIcon,
-  TuttiMark,
-  UserLinedIcon
-} from "@tutti-os/ui-system/icons";
-import { useState } from "react";
+import { LinkIcon, TuttiMark } from "@tutti-os/ui-system/icons";
 
+import type { AuthorizationEventEnvelopeV1 } from "@tutti-os/connector-authorization-protocol/v1";
+
+import {
+  DefaultAuthorizationViewRenderer,
+  type AuthorizationViewRenderer
+} from "../../authorization/AuthorizationViewRenderer.tsx";
+import {
+  resolveAuthorizationInteraction,
+  resolveDeclarativeAuthorizationSubmission
+} from "../../authorization/declarativeAuthorizationAdapter.ts";
 import type { ConnectorMarketI18nRuntime } from "../../i18n/connectorMarketI18n.ts";
-import type { ConnectorPermissionView } from "../../services/view/connectorMarketViewTypes.ts";
 import { ConnectorIcon } from "../catalog/ConnectorIcon.tsx";
 import { ConnectorDialogInfoRow } from "./ConnectorDialogInfoRow.tsx";
-import { ConnectorDialogSection } from "./ConnectorDialogSection.tsx";
-import { ConnectorPermissionList } from "./ConnectorPermissionList.tsx";
 
 export interface ConnectorAuthorizationDialogProps {
+  authorizationInteraction?: unknown;
   authorizationKind: string;
+  authorizationRenderer?: AuthorizationViewRenderer;
   authorizing: boolean;
   displayName: string;
   iconUrl: string;
   i18n: ConnectorMarketI18nRuntime;
+  locale: string;
   onAuthorize: (secret?: string) => Promise<void>;
   onClose: () => void;
   pending: boolean;
-  permissions: readonly ConnectorPermissionView[];
 }
 
 export function ConnectorAuthorizationDialog({
+  authorizationInteraction,
   authorizationKind,
+  authorizationRenderer:
+    AuthorizationRenderer = DefaultAuthorizationViewRenderer,
   authorizing,
   displayName,
   iconUrl,
   i18n,
+  locale,
   onAuthorize,
   onClose,
-  pending,
-  permissions
+  pending
 }: ConnectorAuthorizationDialogProps) {
-  const [secret, setSecret] = useState("");
-  const usesSecret = authorizationKind === "api_key";
+  const resolved = resolveAuthorizationInteraction({
+    authorizationKind,
+    interaction: authorizationInteraction,
+    legacyLabels: {
+      description: i18n.t("secretInputDescription"),
+      fieldLabel: i18n.t("secretInputTitle"),
+      placeholder: i18n.t("secretInputPlaceholder")
+    },
+    locale
+  });
+
+  const handleInteractionEvent = (event: AuthorizationEventEnvelopeV1) => {
+    if (event.event.type === "cancel") {
+      onClose();
+      return;
+    }
+    if (resolved.kind !== "form") return;
+    const submission = resolveDeclarativeAuthorizationSubmission(
+      resolved,
+      event
+    );
+    if (submission.ok) {
+      void onAuthorize(submission.secret);
+    }
+  };
+
   return (
     <DialogContent className="max-h-[min(720px,calc(100vh-32px))] overflow-y-auto sm:max-w-[520px]">
       <DialogHeader className="items-center px-5 pt-4 text-center">
@@ -80,73 +109,62 @@ export function ConnectorAuthorizationDialog({
         />
       </div>
 
-      <ConnectorDialogSection title={i18n.t("permissionsTitle")}>
-        <ConnectorPermissionList i18n={i18n} permissions={permissions} />
-      </ConnectorDialogSection>
-
-      {usesSecret ? (
-        <ConnectorDialogSection title={i18n.t("secretInputTitle")}>
-          <div className="space-y-2">
-            <Input
-              aria-label={i18n.t("secretInputTitle")}
-              autoComplete="off"
-              disabled={authorizing || pending}
-              placeholder={i18n.t("secretInputPlaceholder")}
-              type="password"
-              value={secret}
-              onChange={(event) => setSecret(event.currentTarget.value)}
-            />
-            <p className="m-0 text-[11px] leading-[1.45] text-[var(--text-tertiary)]">
-              {i18n.t("secretInputDescription")}
-            </p>
-          </div>
-        </ConnectorDialogSection>
-      ) : null}
-
-      <ConnectorDialogSection title={i18n.t("accessScopeTitle")}>
-        <div className="overflow-hidden rounded-lg border border-[var(--border-1)]">
-          <ConnectorDialogInfoRow
-            description={i18n.t("accountResourcesDescription", {
-              name: displayName
-            })}
-            icon={<UserLinedIcon className="size-4" />}
-            title={i18n.t("accountResourcesTitle")}
-          />
-          <ConnectorDialogInfoRow
-            description={i18n.t("organizationResourcesDescription")}
-            icon={<LockGridHorizontalLinedIcon className="size-4" />}
-            title={i18n.t("organizationResourcesTitle")}
-          />
-        </div>
-      </ConnectorDialogSection>
-
-      <DialogFooter>
-        <Button
-          size="dialog"
-          type="button"
-          variant="secondary"
-          onClick={onClose}
-        >
-          {i18n.t("cancel")}
-        </Button>
-        <Button
-          disabled={authorizing || (usesSecret && !secret.trim())}
-          size="dialog"
-          type="button"
-          onClick={() => {
-            const submittedSecret = usesSecret ? secret : undefined;
-            if (usesSecret) setSecret("");
-            void onAuthorize(submittedSecret);
+      {resolved.kind === "form" ? (
+        <AuthorizationRenderer
+          busy={authorizing || pending}
+          labels={{
+            activate: i18n.t("actionContinueAuthorization"),
+            cancel: i18n.t("cancel"),
+            refresh: i18n.t("actionRefresh"),
+            qrCodeAlt: i18n.t("authorizationQrCodeAlt"),
+            retry: i18n.t("actionRetry"),
+            submit: i18n.t("actionAuthorize"),
+            unsupportedField: i18n.t("unsupportedAuthorizationField")
           }}
-        >
-          {authorizing && !pending ? <Spinner size={14} /> : null}
-          {authorizing && pending
-            ? i18n.t("actionWaitingAuthorization")
-            : pending
-              ? i18n.t("actionContinueAuthorization")
-              : i18n.t("actionAuthorize")}
-        </Button>
-      </DialogFooter>
+          view={resolved.view}
+          onEvent={handleInteractionEvent}
+        />
+      ) : resolved.kind === "invalid" ? (
+        <>
+          <p className="m-0 text-sm text-[var(--text-secondary)]">
+            {i18n.t("connectorAuthorizationConfigurationInvalid")}
+          </p>
+          <DialogFooter>
+            <Button
+              size="dialog"
+              type="button"
+              variant="secondary"
+              onClick={onClose}
+            >
+              {i18n.t("close")}
+            </Button>
+          </DialogFooter>
+        </>
+      ) : (
+        <DialogFooter>
+          <Button
+            size="dialog"
+            type="button"
+            variant="secondary"
+            onClick={onClose}
+          >
+            {i18n.t("cancel")}
+          </Button>
+          <Button
+            disabled={authorizing}
+            size="dialog"
+            type="button"
+            onClick={() => void onAuthorize()}
+          >
+            {authorizing && !pending ? <Spinner size={14} /> : null}
+            {authorizing && pending
+              ? i18n.t("actionWaitingAuthorization")
+              : pending
+                ? i18n.t("actionContinueAuthorization")
+                : i18n.t("actionAuthorize")}
+          </Button>
+        </DialogFooter>
+      )}
       <p className="m-0 text-center text-[11px] text-[var(--text-tertiary)]">
         {i18n.t("exactAccessNotice")}
       </p>

--- a/packages/connector/market/src/ui/dialogs/ConnectorMarketDialogs.tsx
+++ b/packages/connector/market/src/ui/dialogs/ConnectorMarketDialogs.tsx
@@ -21,8 +21,16 @@ interface UninstallSuccessToast {
 }
 
 export function ConnectorMarketDialogs() {
-  const { i18n, market, onError, onTryConnector, uiState, view } =
-    useConnectorMarketServices();
+  const {
+    authorizationRenderer,
+    i18n,
+    locale,
+    market,
+    onError,
+    onTryConnector,
+    uiState,
+    view
+  } = useConnectorMarketServices();
   const dialog = useSnapshot(view.dataStore).dialog;
   const dialogRequest = useSnapshot(uiState.dataStore).dialog;
   const marketSnapshot = useSnapshot(market.dataStore);
@@ -149,13 +157,15 @@ export function ConnectorMarketDialogs() {
             />
           ) : dialog.kind === "authorization" ? (
             <ConnectorAuthorizationDialog
+              authorizationInteraction={dialog.authorizationInteraction}
               authorizationKind={dialog.authorizationKind}
+              authorizationRenderer={authorizationRenderer}
               authorizing={dialog.authorizing}
               displayName={dialog.displayName}
               iconUrl={dialog.iconUrl}
               i18n={i18n}
+              locale={locale}
               pending={dialog.pending}
-              permissions={dialog.permissions}
               onAuthorize={(secret) => {
                 setShowSuccessToast(null);
                 return market

--- a/packages/connector/market/tsup.config.ts
+++ b/packages/connector/market/tsup.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   dts: true,
   entry: {
     index: "src/index.ts",
+    "authorization/index": "src/authorization/index.ts",
     "contracts/index": "src/contracts/index.ts",
     "core/index": "src/services/core/index.ts",
     "i18n/index": "src/i18n/index.ts",
@@ -13,6 +14,8 @@ export default defineConfig({
     "ui/index": "src/ui/index.ts"
   },
   external: [
+    "@tutti-os/connector-authorization-protocol",
+    "@tutti-os/connector-authorization-protocol/v1",
     "@tutti-os/ui-i18n-runtime",
     "@tutti-os/ui-system",
     "@tutti-os/ui-system/components",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -817,8 +817,30 @@ importers:
 
   packages/configs/tsconfig: {}
 
+  packages/connector/authorization-protocol:
+    dependencies:
+      valibot:
+        specifier: ^1.1.0
+        version: 1.4.2(typescript@5.9.3)
+    devDependencies:
+      "@tutti-os/config-tsconfig":
+        specifier: workspace:*
+        version: link:../../configs/tsconfig
+      "@types/node":
+        specifier: ^24.0.1
+        version: 24.12.4
+      tsx:
+        specifier: ^4.22.3
+        version: 4.22.3
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+
   packages/connector/market:
     dependencies:
+      "@tutti-os/connector-authorization-protocol":
+        specifier: workspace:*
+        version: link:../authorization-protocol
       "@tutti-os/infra":
         specifier: 0.1.0
         version: 0.1.0(lodash-es@4.18.1)(react@19.2.6)
@@ -828,6 +850,9 @@ importers:
       "@tutti-os/ui-system":
         specifier: workspace:*
         version: link:../../ui/system
+      qrcode-generator:
+        specifier: 2.0.4
+        version: 2.0.4
       valtio:
         specifier: ^2.3.2
         version: 2.3.2(@types/react@19.2.15)(react@19.2.6)
@@ -841,6 +866,9 @@ importers:
       "@types/react":
         specifier: ^19.1.6
         version: 19.2.15
+      "@types/react-dom":
+        specifier: ^19.1.5
+        version: 19.2.3(@types/react@19.2.15)
       react:
         specifier: ^19.1.0
         version: 19.2.6
@@ -16225,6 +16253,17 @@ packages:
       }
     engines: { node: ^20.17.0 || >=22.9.0 }
 
+  valibot@1.4.2:
+    resolution:
+      {
+        integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==
+      }
+    peerDependencies:
+      typescript: ">=5"
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   valtio@2.3.2:
     resolution:
       {
@@ -27097,6 +27136,10 @@ snapshots:
       convert-source-map: 2.0.0
 
   validate-npm-package-name@7.0.2: {}
+
+  valibot@1.4.2(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
 
   valtio@2.3.2(@types/react@19.2.15)(react@19.2.6):
     dependencies:

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -6239,12 +6239,15 @@ type ConnectorMarketInstallationState string
 
 // ConnectorMarketManifest defines model for ConnectorMarketManifest.
 type ConnectorMarketManifest struct {
-	AgentRouting      *ConnectorMarketAgentRouting              `json:"agentRouting,omitempty"`
-	AuthorizationKind string                                    `json:"authorizationKind"`
-	Compatibility     *ConnectorMarketCompatibilityRequirements `json:"compatibility,omitempty"`
-	Description       *string                                   `json:"description,omitempty"`
-	DisplayName       string                                    `json:"displayName"`
-	IconUrl           string                                    `json:"iconUrl"`
+	AgentRouting *ConnectorMarketAgentRouting `json:"agentRouting,omitempty"`
+
+	// AuthorizationInteraction Opaque Connector-owned authorization interaction configuration. Hosts transport this value without interpreting its UI semantics; renderers must validate it against the versioned protocol.
+	AuthorizationInteraction *map[string]interface{}                   `json:"authorizationInteraction,omitempty"`
+	AuthorizationKind        string                                    `json:"authorizationKind"`
+	Compatibility            *ConnectorMarketCompatibilityRequirements `json:"compatibility,omitempty"`
+	Description              *string                                   `json:"description,omitempty"`
+	DisplayName              string                                    `json:"displayName"`
+	IconUrl                  string                                    `json:"iconUrl"`
 
 	// Implementation Public implementation discriminator; sensitive host configuration is never returned.
 	Implementation ConnectorMarketImplementation        `json:"implementation"`


### PR DESCRIPTION
## Summary

- add a public Valibot-backed Connector authorization View/Event V1 protocol
- preserve manifest authorization interaction metadata through the daemon and generated API
- replace the hard-coded API-key dialog with a unified, replaceable UI System renderer
- support localized declarative secret forms plus external-link, device-code, QR, progress, and result views
- keep the legacy API-key form as a compatibility fallback

## Validation

- `pnpm check:changed` (22 lanes)
- `pnpm --filter @tutti-os/desktop build`
- protocol tests/typecheck/build
- Connector Market tests/typecheck/build
- focused Go host/daemon/API tests

## Notes

- tsh-server does not parse or detect the UI protocol; the interaction remains opaque presentation metadata until the local client validates it.
- the Tencent Docs manifest adoption is submitted separately in tutti-lab/tutti-connectors.